### PR TITLE
opt: index constraints for LIKE and SIMILAR TO

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/select_index
+++ b/pkg/sql/logictest/testdata/logic_test/select_index
@@ -907,3 +907,52 @@ render     0  render  ·         ·            (a, b)              a!=NULL; b!=N
  └── scan  1  scan    ·         ·            (a, b, c[omitted])  a!=NULL; b!=NULL; key(a,b)
 ·          1  ·       table     abc@primary  ·                   ·
 ·          1  ·       spans     /1/2-/3/4/#  ·                   ·
+
+# Regression test for #21831.
+statement ok
+CREATE TABLE str (k INT PRIMARY KEY, v STRING, INDEX(v))
+
+statement ok
+INSERT INTO str VALUES (1, 'A'), (4, 'AB'), (2, 'ABC'), (5, 'ABCD'), (3, 'ABCDEZ'), (9, 'ABD')
+
+query TITTTTT
+EXPLAIN (VERBOSE) SELECT k, v FROM str WHERE v LIKE 'ABC%'
+----
+scan  0  scan  ·      ·              (k, v)  k!=NULL; v!=NULL; key(k,v)
+·     0  ·     table  str@str_v_idx  ·       ·
+·     0  ·     spans  /"ABC"-/"ABD"  ·       ·
+
+query IT rowsort
+SELECT k, v FROM str WHERE v LIKE 'ABC%'
+----
+2  ABC
+5  ABCD
+3  ABCDEZ
+
+query TITTTTT
+EXPLAIN (VERBOSE) SELECT k, v FROM str WHERE v LIKE 'ABC%Z'
+----
+scan  0  scan  ·       ·               (k, v)  k!=NULL; v!=NULL; key(k,v)
+·     0  ·     table   str@str_v_idx   ·       ·
+·     0  ·     spans   /"ABC"-/"ABD"   ·       ·
+·     0  ·     filter  v LIKE 'ABC%Z'  ·       ·
+
+query IT rowsort
+SELECT k, v FROM str WHERE v LIKE 'ABC%Z'
+----
+3  ABCDEZ
+
+query TITTTTT
+EXPLAIN (VERBOSE) SELECT k, v FROM str WHERE v SIMILAR TO 'ABC_*'
+----
+scan  0  scan  ·       ·                     (k, v)  k!=NULL; v!=NULL; key(k,v)
+·     0  ·     table   str@str_v_idx         ·       ·
+·     0  ·     spans   /"ABC"-/"ABD"         ·       ·
+·     0  ·     filter  v SIMILAR TO 'ABC_*'  ·       ·
+
+query IT rowsort
+SELECT k, v FROM str WHERE v SIMILAR TO 'ABC_*'
+----
+2  ABC
+5  ABCD
+3  ABCDEZ

--- a/pkg/sql/logictest/testdata/logic_test/select_index
+++ b/pkg/sql/logictest/testdata/logic_test/select_index
@@ -428,7 +428,7 @@ EXPLAIN SELECT a FROM t WHERE (b, c) = (5.1, 1)
 render     ·      ·
  └── scan  ·      ·
 ·          table  t@bc
-·          spans  ALL
+·          spans  /!NULL-
 
 # Note the span is reversed because of #20203.
 query TTT

--- a/pkg/sql/logictest/testdata/logic_test/select_non_covering_index_filtering
+++ b/pkg/sql/logictest/testdata/logic_test/select_non_covering_index_filtering
@@ -60,7 +60,7 @@ EXPLAIN (EXPRS) SELECT * FROM t WHERE b = 2 AND c != b
 index-join  ·       ·
  ├── scan   ·       ·
  │          table   t@bc
- │          spans   /2-/3
+ │          spans   /2/!NULL-/3
  │          filter  c != b
  └── scan   ·       ·
 ·           table   t@primary

--- a/pkg/sql/opt/index_constraints.go
+++ b/pkg/sql/opt/index_constraints.go
@@ -16,6 +16,8 @@ package opt
 
 import (
 	"fmt"
+	"regexp"
+	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
@@ -46,6 +48,42 @@ func (c *indexConstraintCtx) makeNotNullSpan(offset int) LogicalSpan {
 	}
 
 	return sp
+}
+
+// makeStringPrefixSpan returns a span that constraints string column <offset>
+// to strings having the given prefix.
+func (c *indexConstraintCtx) makeStringPrefixSpan(offset int, prefix string) LogicalSpan {
+	span := c.makeNotNullSpan(offset)
+	startKey := LogicalKey{Vals: tree.Datums{tree.NewDString(prefix)}, Inclusive: true}
+	if c.colInfos[offset].Direction == encoding.Ascending {
+		span.Start = startKey
+	} else {
+		span.End = startKey
+	}
+
+	i := len(prefix) - 1
+	for ; i >= 0 && prefix[i] == 0xFF; i-- {
+	}
+	if i < 0 {
+		// We have a prefix like "\xff\xff\xff"; there is no ending value.
+		return span
+	}
+	// A few examples:
+	//   prefix      -> endValue
+	//   ABC         -> ABD
+	//   ABC\xff     -> ABD
+	//   ABC\xff\xff -> ABD
+	endVal := []byte(prefix[:i+1])
+	endVal[i]++
+	endDatum := tree.NewDString(string(endVal))
+	endKey := LogicalKey{Vals: tree.Datums{endDatum}, Inclusive: false}
+	if c.colInfos[offset].Direction == encoding.Ascending {
+		span.End = endKey
+	} else {
+		span.Start = endKey
+	}
+
+	return span
 }
 
 // verifyType checks that the type of the index column <offset> matches the
@@ -136,9 +174,39 @@ func (c *indexConstraintCtx) makeSpansForSingleColumn(
 		c.preferInclusive(offset, &spans[1])
 		return spans, true, true
 
-	default:
-		return nil, false, false
+	case likeOp:
+		if s, ok := tree.AsDString(datum); ok {
+			if i := strings.IndexAny(string(s), "_%"); i >= 0 {
+				if i == 0 {
+					// Mask starts with _ or %.
+					return nil, false, false
+				}
+				span := c.makeStringPrefixSpan(offset, string(s[:i]))
+				// A mask like ABC% is equivalent to restricting the prefix to ABC.
+				// A mask like ABC%Z requires restricting the prefix, but is a stronger
+				// condition.
+				tight := (i == len(s)-1) && s[i] == '%'
+				return LogicalSpans{span}, true, tight
+			}
+			// No wildcard characters, this is an equality.
+			return LogicalSpans{c.makeEqSpan(offset, &s)}, true, true
+		}
+
+	case similarToOp:
+		// a SIMILAR TO 'foo_*' -> prefix "foo"
+		if s, ok := tree.AsDString(datum); ok {
+			pattern := tree.SimilarEscape(string(s))
+			if re, err := regexp.Compile(pattern); err == nil {
+				prefix, complete := re.LiteralPrefix()
+				if complete {
+					return LogicalSpans{c.makeEqSpan(offset, tree.NewDString(prefix))}, true, true
+				}
+				span := c.makeStringPrefixSpan(offset, prefix)
+				return LogicalSpans{span}, true, false
+			}
+		}
 	}
+	return nil, false, false
 }
 
 // makeSpansForTupleInequality creates spans for index columns starting at

--- a/pkg/sql/opt/testdata/index-constraints
+++ b/pkg/sql/opt/testdata/index-constraints
@@ -1055,7 +1055,7 @@ Remaining filter: (@2 = 2) OR (@2 = 3)
 build-scalar,index-constraints vars=(int, int, int) index=(@1, @2, @3)
 @1 = 1 AND @2 = CASE WHEN @3 = 2 THEN 1 ELSE 2 END
 ----
-[/1 - /1]
+(/1/NULL - /1]
 Remaining filter: @2 = CASE WHEN @3 = 2 THEN 1 ELSE 2 END
 
 # This testcase exposed an issue around extending spans. We don't normalize the
@@ -1078,19 +1078,19 @@ build-scalar,normalize,index-constraints vars=(int, int) index=(@1, @2)
 build-scalar,normalize,index-constraints vars=(int) index=(@1)
 @1 = 1.5
 ----
-[ - ]
+(/NULL - ]
 Remaining filter: @1 = 1.5
 
 build-scalar,normalize,index-constraints vars=(int) index=(@1)
 @1 > 1.5
 ----
-[ - ]
+(/NULL - ]
 Remaining filter: @1 > 1.5
 
 build-scalar,normalize,index-constraints vars=(int, int) index=(@1, @2)
 (@1, @2) = (1, 2.5)
 ----
-[/1 - /1]
+(/1/NULL - /1]
 Remaining filter: @2 = 2.5
 
 build-scalar,normalize,index-constraints vars=(int, int) index=(@1, @2)
@@ -1170,13 +1170,13 @@ build-scalar,normalize,index-constraints vars=(string) index=@1
 build-scalar,normalize,index-constraints vars=(string) index=@1
 @1 LIKE '%'
 ----
-[ - ]
+(/NULL - ]
 Remaining filter: @1 LIKE '%'
 
 build-scalar,normalize,index-constraints vars=(string) index=@1
 @1 LIKE '%XY'
 ----
-[ - ]
+(/NULL - ]
 Remaining filter: @1 LIKE '%XY'
 
 build-scalar,normalize,index-constraints vars=(string) index=(@1 desc)

--- a/pkg/sql/opt/testdata/index-constraints
+++ b/pkg/sql/opt/testdata/index-constraints
@@ -1144,3 +1144,76 @@ build-scalar,normalize,index-constraints vars=(jsonb, int) inverted-index=@1
 ----
 [/'{"a":1}' - /'{"a":1}']
 Remaining filter: (@2 = 1) AND (@1 @> '{"b":1}')
+
+build-scalar,normalize,index-constraints vars=(string) index=@1
+@1 LIKE 'ABC%'
+----
+[/'ABC' - /'ABD')
+
+build-scalar,normalize,index-constraints vars=(string) index=@1
+@1 LIKE 'ABC_'
+----
+[/'ABC' - /'ABD')
+Remaining filter: @1 LIKE 'ABC_'
+
+build-scalar,normalize,index-constraints vars=(string) index=@1
+@1 LIKE 'ABC%Z'
+----
+[/'ABC' - /'ABD')
+Remaining filter: @1 LIKE 'ABC%Z'
+
+build-scalar,normalize,index-constraints vars=(string) index=@1
+@1 LIKE 'ABC'
+----
+[/'ABC' - /'ABC']
+
+build-scalar,normalize,index-constraints vars=(string) index=@1
+@1 LIKE '%'
+----
+[ - ]
+Remaining filter: @1 LIKE '%'
+
+build-scalar,normalize,index-constraints vars=(string) index=@1
+@1 LIKE '%XY'
+----
+[ - ]
+Remaining filter: @1 LIKE '%XY'
+
+build-scalar,normalize,index-constraints vars=(string) index=(@1 desc)
+@1 LIKE 'ABC%'
+----
+(/'ABD' - /'ABC']
+
+build-scalar,normalize,index-constraints vars=(int,string) index=(@1, @2 desc)
+@1 = 1 AND @2 LIKE 'ABC%'
+----
+(/1/'ABD' - /1/'ABC']
+
+build-scalar,normalize,index-constraints vars=(int,string) index=(@1, @2 desc)
+@1 >= 1 AND @1 <= 4 AND @2 LIKE 'ABC%'
+----
+(/1/'ABD' - /4/'ABC']
+Remaining filter: @2 LIKE 'ABC%'
+
+build-scalar,normalize,index-constraints vars=(string) index=(@1)
+@1 SIMILAR TO 'ABC.*'
+----
+[/'ABC' - /'ABD')
+Remaining filter: @1 SIMILAR TO 'ABC.*'
+
+build-scalar,normalize,index-constraints vars=(string) index=(@1)
+@1 SIMILAR TO 'ABC.*Z'
+----
+[/'ABC' - /'ABD')
+Remaining filter: @1 SIMILAR TO 'ABC.*Z'
+
+build-scalar,normalize,index-constraints vars=(string) index=(@1)
+@1 SIMILAR TO 'ABC'
+----
+[/'ABC' - /'ABC']
+
+build-scalar,normalize,index-constraints vars=(string) index=(@1)
+@1 SIMILAR TO '(ABC|ABCDEF)%'
+----
+[/'ABC' - /'ABD')
+Remaining filter: @1 SIMILAR TO '(ABC|ABCDEF)%'


### PR DESCRIPTION
#### opt: index constraints for LIKE and SIMILAR TO

The old index constraints code supported these; implementing them was
an omission.

Fixes #21831.

Release note: None

#### opt: fall back to not-NULL constraints

Improving the index selection code to at least generate a not-NULL
constraint when we can't create any other constraints on a column.

Release note: None