### PR TITLE
[DNM] storage: avoid double copy of RocksDB data

### DIFF
--- a/c-deps/libroach/encoding.cc
+++ b/c-deps/libroach/encoding.cc
@@ -18,6 +18,35 @@
 
 namespace cockroach {
 
+char* EncodeVarint32(char* dst, uint32_t v) {
+  // Copied from RocksDB's coding.cc.
+  // Operate on characters as unsigneds
+  unsigned char* ptr = reinterpret_cast<unsigned char*>(dst);
+  static const int B = 128;
+  if (v < (1 << 7)) {
+    *(ptr++) = v;
+  } else if (v < (1 << 14)) {
+    *(ptr++) = v | B;
+    *(ptr++) = v >> 7;
+  } else if (v < (1 << 21)) {
+    *(ptr++) = v | B;
+    *(ptr++) = (v >> 7) | B;
+    *(ptr++) = v >> 14;
+  } else if (v < (1 << 28)) {
+    *(ptr++) = v | B;
+    *(ptr++) = (v >> 7) | B;
+    *(ptr++) = (v >> 14) | B;
+    *(ptr++) = v >> 21;
+  } else {
+    *(ptr++) = v | B;
+    *(ptr++) = (v >> 7) | B;
+    *(ptr++) = (v >> 14) | B;
+    *(ptr++) = (v >> 21) | B;
+    *(ptr++) = v >> 28;
+  }
+  return reinterpret_cast<char*>(ptr);
+}
+
 void EncodeUint32(std::string* buf, uint32_t v) {
   const uint8_t tmp[sizeof(v)] = {
       uint8_t(v >> 24),

--- a/c-deps/libroach/encoding.h
+++ b/c-deps/libroach/encoding.h
@@ -22,6 +22,10 @@
 
 namespace cockroach {
 
+// EncodeVarint32 encodes the uint32 value using RocksDB's varint
+// representation.
+char* EncodeVarint32(char* dst, uint32_t value);
+
 // EncodeUint32 encodes the uint32 value using a big-endian 4 byte
 // representation. The bytes are appended to the supplied buffer.
 void EncodeUint32(std::string* buf, uint32_t v);

--- a/c-deps/libroach/include/libroach.h
+++ b/c-deps/libroach/include/libroach.h
@@ -260,9 +260,10 @@ typedef struct {
 } DBScanResults;
 
 DBScanResults MVCCGet(DBIterator* iter, DBSlice key, DBTimestamp timestamp, DBTxn txn,
-                      bool consistent, DBSlice results);
+                      bool consistent, DBSlice results, uintptr_t data_ref);
 DBScanResults MVCCScan(DBIterator* iter, DBSlice start, DBSlice end, DBTimestamp timestamp,
-                       int64_t max_keys, DBTxn txn, bool consistent, bool reverse, DBSlice results);
+                       int64_t max_keys, DBTxn txn, bool consistent, bool reverse, DBSlice results,
+                       uintptr_t data_ref);
 
 // DBStatsResult contains various runtime stats for RocksDB.
 typedef struct {

--- a/c-deps/libroach/include/libroach.h
+++ b/c-deps/libroach/include/libroach.h
@@ -260,9 +260,9 @@ typedef struct {
 } DBScanResults;
 
 DBScanResults MVCCGet(DBIterator* iter, DBSlice key, DBTimestamp timestamp, DBTxn txn,
-                      bool consistent);
+                      bool consistent, DBSlice results);
 DBScanResults MVCCScan(DBIterator* iter, DBSlice start, DBSlice end, DBTimestamp timestamp,
-                       int64_t max_keys, DBTxn txn, bool consistent, bool reverse);
+                       int64_t max_keys, DBTxn txn, bool consistent, bool reverse, DBSlice results);
 
 // DBStatsResult contains various runtime stats for RocksDB.
 typedef struct {

--- a/c-deps/libroach/mvcc.cc
+++ b/c-deps/libroach/mvcc.cc
@@ -260,7 +260,7 @@ DBStatus MVCCFindSplitKey(DBIterator* iter, DBKey start, DBKey end, DBKey min_sp
 }
 
 DBScanResults MVCCGet(DBIterator* iter, DBSlice key, DBTimestamp timestamp, DBTxn txn,
-                      bool consistent, DBSlice results) {
+                      bool consistent, DBSlice results, uintptr_t data_ref) {
   // Get is implemented as a scan where we retrieve a single key. Note
   // that the semantics of max_keys is that we retrieve one more key
   // than is specified in order to maintain the existing semantics of
@@ -270,18 +270,18 @@ DBScanResults MVCCGet(DBIterator* iter, DBSlice key, DBTimestamp timestamp, DBTx
   // don't retrieve a key different than the start key. This is a bit
   // of a hack.
   const DBSlice end = {0, 0};
-  mvccForwardScanner scanner(iter, key, end, timestamp, 0 /* max_keys */, txn, consistent, results);
+  mvccForwardScanner scanner(iter, key, end, timestamp, 0 /* max_keys */, txn, consistent, results, data_ref);
   return scanner.get();
 }
 
 DBScanResults MVCCScan(DBIterator* iter, DBSlice start, DBSlice end, DBTimestamp timestamp,
                        int64_t max_keys, DBTxn txn, bool consistent, bool reverse,
-                       DBSlice results) {
+                       DBSlice results, uintptr_t data_ref) {
   if (reverse) {
-    mvccReverseScanner scanner(iter, end, start, timestamp, max_keys, txn, consistent, results);
+    mvccReverseScanner scanner(iter, end, start, timestamp, max_keys, txn, consistent, results, data_ref);
     return scanner.scan();
   } else {
-    mvccForwardScanner scanner(iter, start, end, timestamp, max_keys, txn, consistent, results);
+    mvccForwardScanner scanner(iter, start, end, timestamp, max_keys, txn, consistent, results, data_ref);
     return scanner.scan();
   }
 }

--- a/c-deps/libroach/mvcc.cc
+++ b/c-deps/libroach/mvcc.cc
@@ -260,7 +260,7 @@ DBStatus MVCCFindSplitKey(DBIterator* iter, DBKey start, DBKey end, DBKey min_sp
 }
 
 DBScanResults MVCCGet(DBIterator* iter, DBSlice key, DBTimestamp timestamp, DBTxn txn,
-                      bool consistent) {
+                      bool consistent, DBSlice results) {
   // Get is implemented as a scan where we retrieve a single key. Note
   // that the semantics of max_keys is that we retrieve one more key
   // than is specified in order to maintain the existing semantics of
@@ -270,17 +270,18 @@ DBScanResults MVCCGet(DBIterator* iter, DBSlice key, DBTimestamp timestamp, DBTx
   // don't retrieve a key different than the start key. This is a bit
   // of a hack.
   const DBSlice end = {0, 0};
-  mvccForwardScanner scanner(iter, key, end, timestamp, 0 /* max_keys */, txn, consistent);
+  mvccForwardScanner scanner(iter, key, end, timestamp, 0 /* max_keys */, txn, consistent, results);
   return scanner.get();
 }
 
 DBScanResults MVCCScan(DBIterator* iter, DBSlice start, DBSlice end, DBTimestamp timestamp,
-                       int64_t max_keys, DBTxn txn, bool consistent, bool reverse) {
+                       int64_t max_keys, DBTxn txn, bool consistent, bool reverse,
+                       DBSlice results) {
   if (reverse) {
-    mvccReverseScanner scanner(iter, end, start, timestamp, max_keys, txn, consistent);
+    mvccReverseScanner scanner(iter, end, start, timestamp, max_keys, txn, consistent, results);
     return scanner.scan();
   } else {
-    mvccForwardScanner scanner(iter, start, end, timestamp, max_keys, txn, consistent);
+    mvccForwardScanner scanner(iter, start, end, timestamp, max_keys, txn, consistent, results);
     return scanner.scan();
   }
 }

--- a/c-deps/libroach/mvcc.h
+++ b/c-deps/libroach/mvcc.h
@@ -28,7 +28,7 @@ static void __attribute__((noreturn)) die_missing_symbol(const char* name) {
   fprintf(stderr, "%s symbol missing; expected to be supplied by Go\n", name);
   abort();
 }
-void __attribute__((weak)) growSlice(void*, DBSlice*, int) { die_missing_symbol(__func__); }
+void __attribute__((weak)) growSlice(void*, DBSlice*, int, int, int) { die_missing_symbol(__func__); }
 }  // extern "C"
 
 // kMaxItersBeforeSeek is the number of calls to iter->{Next,Prev}()
@@ -446,7 +446,7 @@ template <bool reverse> class mvccScanner {
       // If it's bigger than the output batch's capacity, we grow the output
       // batch big enough to fit the slice.
       int oldLen = batchPtr_ - results_.data.data;
-      growSlice(data_ref_, &results_.data, expectedLen - results_.data.len);
+      growSlice(data_ref_, &results_.data, expectedLen - results_.data.len, keys_, max_keys_);
       batchPtr_ = results_.data.data + oldLen;
     }
     memcpy(batchPtr_, buf, putSize);

--- a/pkg/storage/engine/mvcc.go
+++ b/pkg/storage/engine/mvcc.go
@@ -1709,7 +1709,7 @@ func buildScanResumeKey(kvData []byte, max int) ([]byte, error) {
 	if len(kvData) == 0 {
 		return nil, nil
 	}
-	count, kvData, err := rocksDBBatchDecodeHeader(kvData)
+	count, kvData, err := mvccScanBatchDecodeHeader(kvData)
 	if err != nil {
 		return nil, err
 	}
@@ -1717,12 +1717,12 @@ func buildScanResumeKey(kvData []byte, max int) ([]byte, error) {
 		return nil, nil
 	}
 	for i := 0; i < max; i++ {
-		_, _, kvData, err = rocksDBBatchDecodeValue(kvData)
+		_, _, kvData, err = mvccScanBatchDecodeValue(kvData)
 		if err != nil {
 			return nil, err
 		}
 	}
-	key, _, _, err := rocksDBBatchDecodeValue(kvData)
+	key, _, _, err := mvccScanBatchDecodeValue(kvData)
 	if err != nil {
 		return nil, err
 	}
@@ -1753,7 +1753,7 @@ func buildScanResults(
 	// slice of roachpb.KeyValue. This code would be slightly more compact using
 	// RocksDBBatchReader, but there is a measurable performance benefit to
 	// avoiding the associated allocation for small (1 row) scans.
-	count, kvData, err := rocksDBBatchDecodeHeader(kvData)
+	count, kvData, err := mvccScanBatchDecodeHeader(kvData)
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -1776,7 +1776,7 @@ func buildScanResults(
 	var key MVCCKey
 	var rawBytes []byte
 	for i := range kvs {
-		key, rawBytes, kvData, err = rocksDBBatchDecodeValue(kvData)
+		key, rawBytes, kvData, err = mvccScanBatchDecodeValue(kvData)
 		if err != nil {
 			return nil, nil, nil, err
 		}
@@ -1787,7 +1787,7 @@ func buildScanResults(
 
 	var resumeKey roachpb.Key
 	if count > int(max) {
-		key, _, _, err = rocksDBBatchDecodeValue(kvData)
+		key, _, _, err = mvccScanBatchDecodeValue(kvData)
 		if err != nil {
 			return nil, nil, nil, err
 		}

--- a/pkg/storage/engine/rocksdb.go
+++ b/pkg/storage/engine/rocksdb.go
@@ -103,14 +103,12 @@ type dataRef struct {
 // and its size.
 //
 //export growSlice
-func growSlice(ref unsafe.Pointer, cSlice *C.DBSlice, needed int) {
+func growSlice(ref unsafe.Pointer, cSlice *C.DBSlice, needed int, keys int, maxKeys int) {
 	data := cSliceToUnsafeGoBytes(*cSlice)
-	newData := data
-	newCap := (cap(data) + needed) * 2
-	for cap(newData) < newCap {
-		newData = append(newData, data...)
-	}
-	newData = newData[:cap(newData)]
+	minimum := cap(data) + needed
+	guess := float32(maxKeys) / float32(keys) * float32(minimum)
+	newData := make([]byte, int32(guess))
+	copy(newData, data)
 	*cSlice = goToCSlice(newData)
 	dref := (*dataRef)(ref)
 	dref.data = newData


### PR DESCRIPTION
Previously, all data returned from RocksDB was allocated for and copied
twice:

1. In C++, from RocksDB's key/value slices to a newly-allocated WriteBatch
2. In Go, from the C++-allocated WriteBatch to a Go-allocated byte slice

This is clearly undesirable, as it's expensive to allocate and copy all
of that data twice.

Now, Go allocates a byte slice based on a rough estimate of the size of
the data and passes that slice into C++, which uses that Go memory
instead of allocating on its own.

If the size of the actual data exceeds the size of the Go byte slice, C++
calls back into Go to request more memory. n.b. this dynamic resizing
happened before this patch as well, localized to C++.

See #21840.

Release note (performance improvement): perform fewer in-memory copies
of result data.