### PR TITLE
cherry-pick-1.1: sql: only check tables for indexes during DROP INDEX

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/drop_index
+++ b/pkg/sql/logictest/testdata/logic_test/drop_index
@@ -169,3 +169,25 @@ query T
 SHOW TABLES
 ----
 users
+
+# Test error message on nonexistent index.
+
+statement error index "nonexistent" not in any of the tables test.users
+DROP INDEX nonexistent
+
+# Test that presence of a view or sequence doesn't break DROP INDEX (#21834)
+
+statement ok
+CREATE DATABASE view_test
+
+statement ok
+SET DATABASE = view_test
+
+statement ok
+CREATE TABLE t (id INT)
+
+statement ok
+CREATE VIEW v AS SELECT id FROM t
+
+statement error pgcode 42704 pq: index "nonexistent_index" not in any of the tables view_test.t, view_test.v
+DROP INDEX nonexistent_index


### PR DESCRIPTION
Cherry pick of #21838

Previously, DROP INDEX was returning a nonsensical error message when a
view or sequence was present in the database, because it was
iterating over all TableDescriptors in the database, and asserting that
each one was a table before moving on to search it for indexes.

Instead, skip TableDescriptors that are not tables (views or sequences).

(This cherry pick didn't apply too cleanly; made some edits)

Release note: None