### PR TITLE
sql/parser: allow collated strings in COPY and IMPORT

### DIFF
--- a/pkg/ccl/sqlccl/csv.go
+++ b/pkg/ccl/sqlccl/csv.go
@@ -542,6 +542,7 @@ func convertRecord(
 	const kvBatchSize = 1000
 	padding := 2 * (len(tableDesc.Indexes) + len(tableDesc.Families))
 	visibleCols := tableDesc.VisibleColumns()
+	cenv := &tree.CollationEnvironment{}
 
 	ri, err := sqlbase.MakeRowInserter(nil /* txn */, tableDesc, nil, /* fkTables */
 		tableDesc.Columns, false /* checkFKs */, &sqlbase.DatumAlloc{})
@@ -570,7 +571,7 @@ func convertRecord(
 				if nullif != nil && v == *nullif {
 					datums[i] = tree.DNull
 				} else {
-					datums[i], err = parser.ParseStringAs(col.Type.ToDatumType(), v, &evalCtx)
+					datums[i], err = parser.ParseStringAs(col.Type.ToDatumType(), v, &evalCtx, cenv)
 					if err != nil {
 						return errors.Wrapf(err, "%s: row %d: parse %q as %s", batch.file, rowNum, col.Name, col.Type.SQLString())
 					}

--- a/pkg/sql/copy.go
+++ b/pkg/sql/copy.go
@@ -72,6 +72,9 @@ type copyMachine struct {
 	// parsing. Is it not correcly initialized with timestamps, transactions and
 	// other things that statements more generally need.
 	parsingEvalCtx *tree.EvalContext
+	// collationEnv is needed only when creating collated strings. Using a common
+	// environment allows for some expensive work to only be done once.
+	collationEnv *tree.CollationEnvironment
 }
 
 // newCopyMachine creates a new copyMachine.
@@ -88,6 +91,7 @@ func newCopyMachine(
 		// The planner will be prepared before use.
 		p:              planner{},
 		parsingEvalCtx: &evalCtx.EvalContext,
+		collationEnv:   &tree.CollationEnvironment{},
 	}
 
 	cleanup := c.preparePlanner(ctx)
@@ -351,7 +355,7 @@ func (c *copyMachine) addRow(ctx context.Context, line []byte) error {
 				return err
 			}
 		}
-		d, err := parser.ParseStringAs(c.resultColumns[i].Typ, s, c.parsingEvalCtx)
+		d, err := parser.ParseStringAs(c.resultColumns[i].Typ, s, c.parsingEvalCtx, c.collationEnv)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Release note (sql change): allow collated strings in COPY
Release note (enterprise change): allow collated strings in IMPORT

Fixes #21858