### PR TITLE
sql: fix SHOW GRANTS with grantee but no targets.

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/grant_table
+++ b/pkg/sql/logictest/testdata/logic_test/grant_table
@@ -159,6 +159,79 @@ system    zones             root       UPDATE
 test      NULL              admin      ALL
 test      NULL              root       ALL
 
+query TTTT colnames
+SHOW GRANTS FOR root
+----
+Database  Table             User       Privileges
+a         NULL              root       ALL
+system    NULL              root       GRANT
+system    NULL              root       SELECT
+system    descriptor        root       GRANT
+system    descriptor        root       SELECT
+system    eventlog          root       DELETE
+system    eventlog          root       GRANT
+system    eventlog          root       INSERT
+system    eventlog          root       SELECT
+system    eventlog          root       UPDATE
+system    jobs              root       DELETE
+system    jobs              root       GRANT
+system    jobs              root       INSERT
+system    jobs              root       SELECT
+system    jobs              root       UPDATE
+system    lease             root       DELETE
+system    lease             root       GRANT
+system    lease             root       INSERT
+system    lease             root       SELECT
+system    lease             root       UPDATE
+system    locations         root       DELETE
+system    locations         root       GRANT
+system    locations         root       INSERT
+system    locations         root       SELECT
+system    locations         root       UPDATE
+system    namespace         root       GRANT
+system    namespace         root       SELECT
+system    rangelog          root       DELETE
+system    rangelog          root       GRANT
+system    rangelog          root       INSERT
+system    rangelog          root       SELECT
+system    rangelog          root       UPDATE
+system    role_members      root       DELETE
+system    role_members      root       GRANT
+system    role_members      root       INSERT
+system    role_members      root       SELECT
+system    role_members      root       UPDATE
+system    settings          root       DELETE
+system    settings          root       GRANT
+system    settings          root       INSERT
+system    settings          root       SELECT
+system    settings          root       UPDATE
+system    table_statistics  root       DELETE
+system    table_statistics  root       GRANT
+system    table_statistics  root       INSERT
+system    table_statistics  root       SELECT
+system    table_statistics  root       UPDATE
+system    ui                root       DELETE
+system    ui                root       GRANT
+system    ui                root       INSERT
+system    ui                root       SELECT
+system    ui                root       UPDATE
+system    users             root       DELETE
+system    users             root       GRANT
+system    users             root       INSERT
+system    users             root       SELECT
+system    users             root       UPDATE
+system    web_sessions      root       DELETE
+system    web_sessions      root       GRANT
+system    web_sessions      root       INSERT
+system    web_sessions      root       SELECT
+system    web_sessions      root       UPDATE
+system    zones             root       DELETE
+system    zones             root       GRANT
+system    zones             root       INSERT
+system    zones             root       SELECT
+system    zones             root       UPDATE
+test      NULL              root       ALL
+
 statement error relation "a.t" does not exist
 SHOW GRANTS ON a.t
 
@@ -392,6 +465,20 @@ a  v  test-user  DROP
 a  v  test-user  GRANT
 a  v  test-user  UPDATE
 
+query TTTT
+SHOW GRANTS FOR readwrite, "test-user"
+----
+a  NULL  readwrite  ALL
+a  v     readwrite  CREATE
+a  v     readwrite  DROP
+a  v     readwrite  GRANT
+a  v     readwrite  SELECT
+a  v     readwrite  UPDATE
+a  v     test-user  CREATE
+a  v     test-user  DROP
+a  v     test-user  GRANT
+a  v     test-user  UPDATE
+
 statement ok
 REVOKE ALL ON v FROM readwrite,"test-user"
 
@@ -404,6 +491,11 @@ a  v  root   ALL
 query TTTT
 SHOW GRANTS ON v FOR readwrite, "test-user"
 ----
+
+query TTTT
+SHOW GRANTS FOR readwrite, "test-user"
+----
+a  NULL  readwrite  ALL
 
 # Verify that the DB privileges have not changed.
 query TTT colnames

--- a/pkg/sql/show_grants.go
+++ b/pkg/sql/show_grants.go
@@ -128,6 +128,8 @@ func (p *planner) ShowGrants(ctx context.Context, n *tree.ShowGrants) (planNode,
 				`SELECT "Database", NULL::STRING AS "Table", "User", "Privileges" FROM (`)
 			source.WriteString(dbPrivQuery)
 			source.WriteByte(')')
+			// Specify the WHERE clause for grantees.
+			cond.WriteString(`WHERE true`)
 		}
 	}
 


### PR DESCRIPTION
The generated statement when a grantee is specified but no target was
something along the lines of:
```
SELECT * FROM (SELECT TABLE_SCHEMA AS "Database", TABLE_NAME AS "Table",
GRANTEE AS "User", PRIVILEGE_TYPE AS "Privileges" FROM
"".information_schema.table_privileges UNION ALL SELECT "Database",
NULL::STRING AS "Table", "User", "Privileges" FROM (SELECT TABLE_SCHEMA
AS "Database", GRANTEE AS "User", PRIVILEGE_TYPE AS "Privileges" FROM
"".information_schema.schema_privileges)) AND "User" IN ('root') ORDER
BY 1,2,3,4;
```

This fails on the `AND "User" .....` because it's missing a `WHERE`
clause.

Added some logic tests, I'm not sure this ever worked.

Release note (sql change): fix SHOW GRANTS with grantee but no targets.