### PR TITLE
cherry-pick 1.1: sql: report schema change error with txn commit

### DIFF
--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -355,6 +355,9 @@ func (sc *SchemaChanger) maybeAddDropRename(
 // Execute the entire schema change in steps.
 // inSession is set to false when this is called from the asynchronous
 // schema change execution path.
+//
+// If the txn that queued the schema changer did not commit, this will be a
+// no-op, as we'll fail to find the job for our mutation in the jobs registry.
 func (sc *SchemaChanger) exec(
 	ctx context.Context, inSession bool, evalCtx parser.EvalContext,
 ) error {

--- a/pkg/sql/schema_changer_test.go
+++ b/pkg/sql/schema_changer_test.go
@@ -2684,3 +2684,37 @@ CREATE TABLE t.test (k INT PRIMARY KEY, v INT);
 		t.Fatalf("columns %q, %q in descriptor", k, x)
 	}
 }
+
+// Test that, when DDL statements are run in a transaction, their errors are
+// received as the results of the commit statement.
+func TestSchemaChangeErrorOnCommit(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	params, _ := createTestServerParams()
+	s, sqlDB, _ := serverutils.StartServer(t, params)
+	defer s.Stopper().Stop(context.TODO())
+
+	if _, err := sqlDB.Exec(`
+CREATE DATABASE t;
+CREATE TABLE t.test (k INT PRIMARY KEY, v INT);
+INSERT INTO t.test (k, v) VALUES (1, 99), (2, 99);
+`); err != nil {
+		t.Fatal(err)
+	}
+
+	tx, err := sqlDB.Begin()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// This schema change is invalid because of the duplicate v, but its error is
+	// only reported later.
+	if _, err := tx.Exec("ALTER TABLE t.test ADD CONSTRAINT v_unique UNIQUE (v)"); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := tx.Commit(); !testutils.IsError(
+		err, `pq: duplicate key value`,
+	) {
+		t.Fatal(err)
+	}
+}

--- a/pkg/sql/session.go
+++ b/pkg/sql/session.go
@@ -689,7 +689,6 @@ func (s *Session) resetForBatch(e *Executor) {
 	// Update the database cache to a more recent copy, so that we can use tables
 	// that we created in previous batches of the same transaction.
 	s.tables.databaseCache = e.getDatabaseCache()
-	s.TxnState.schemaChangers.curGroupNum++
 }
 
 // setTestingVerifyMetadata sets a callback to be called after the Session
@@ -1284,27 +1283,11 @@ func (ts *txnState) isSerializableRestart() bool {
 }
 
 type schemaChangerCollection struct {
-	// A schemaChangerCollection accumulates schemaChangers from potentially
-	// multiple user requests, part of the same SQL transaction. We need to
-	// remember what group and index within the group each schemaChanger came
-	// from, so we can map failures back to the statement that produced them.
-	curGroupNum int
-
-	// schema change callbacks together with the index of the statement
-	// that enqueued it (within its group of statements).
-	schemaChangers []struct {
-		epoch int
-		sc    SchemaChanger
-	}
+	schemaChangers []SchemaChanger
 }
 
 func (scc *schemaChangerCollection) queueSchemaChanger(schemaChanger SchemaChanger) {
-	scc.schemaChangers = append(
-		scc.schemaChangers,
-		struct {
-			epoch int
-			sc    SchemaChanger
-		}{scc.curGroupNum, schemaChanger})
+	scc.schemaChangers = append(scc.schemaChangers, schemaChanger)
 }
 
 // execSchemaChanges releases schema leases and runs the queued
@@ -1321,8 +1304,7 @@ func (scc *schemaChangerCollection) execSchemaChanges(
 	// Execute any schema changes that were scheduled, in the order of the
 	// statements that scheduled them.
 	var firstError error
-	for _, scEntry := range scc.schemaChangers {
-		sc := &scEntry.sc
+	for _, sc := range scc.schemaChangers {
 		sc.db = *e.cfg.DB
 		sc.testingKnobs = e.cfg.SchemaChangerTestingKnobs
 		sc.distSQLPlanner = e.distSQLPlanner
@@ -1339,10 +1321,7 @@ func (scc *schemaChangerCollection) execSchemaChanges(
 					// There's some sketchiness here: we assume there's a single result
 					// per statement and we clobber the result/error of the corresponding
 					// statement.
-					// There's also another subtlety: we can only report results for
-					// statements in the current batch; we can't modify the results of older
-					// statements.
-					if scEntry.epoch == scc.curGroupNum && firstError == nil {
+					if firstError == nil {
 						firstError = err
 					}
 				} else {

--- a/pkg/sql/table.go
+++ b/pkg/sql/table.go
@@ -562,6 +562,9 @@ func (p *planner) getAliasedTableName(n parser.TableExpr) (*parser.TableName, er
 // descriptor and creates a schema change job in the system.jobs table.
 // The identifiers of the mutations and newly-created job are written to a new
 // MutationJob in the table descriptor.
+//
+// The job creation is done within the planner's txn. This is important - if the
+// txn ends up rolling back, the job needs to go away.
 func (p *planner) createSchemaChangeJob(
 	ctx context.Context, tableDesc *sqlbase.TableDescriptor, stmt string,
 ) (sqlbase.MutationID, error) {


### PR DESCRIPTION
Before this change, an error encountered by a schema change queued up by
a statement in an explicit transaction would not be reported to the
client unless the statement was part of the same query string as the
COMMIT statement. So, generally speaking, schema change errors queued up
in transactions would not be reported :).
This occurs because of remnants of code of code that tried to associate
errors with statements.
At some point I think we used to have code that either associated the error
with the statement that queued the change (if it still had access to its
result) or associated it with the commit otherwise. That broke when we
introduced results streaming. Or maybe it was always broken.

Besides this bug, there's an outstanding issue that the way in which
these errors are reported is not conformant to the pgwire protocol, and
also that these errors confusingly suggest to someone that the
transaction has not been committed. This commit does nothing to address
either of these. These issues are discussed in this Cockroach Labs
internal thread: https://groups.google.com/a/cockroachlabs.com/forum/#!topic/eng/Jc61hd6Pv2US

Fixes #21822

Release note(sql): Fix reporting of errors from transactional schema
changes: errors from DDL statements sent by a client as part of a
transaction, but in a different query string than the final commit used
to be silently swallowed.

cc @cockroachdb/release 