### PR TITLE
sql: change JSON inverted index key encoding

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/inverted_index
+++ b/pkg/sql/logictest/testdata/logic_test/inverted_index
@@ -94,28 +94,28 @@ statement ok
 INSERT INTO d VALUES(1, '{"a": "b"}')
 
 statement ok
-INSERT INTO d VALUES(2, '[1,2,3,4,"foo"]')
+INSERT INTO d VALUES(2, '[1,2,3,4, "foo"]')
 
 statement ok
-INSERT INTO d VALUES(3, '{"a": {"b":"c"}}')
+INSERT INTO d VALUES(3, '{"a": {"b": "c"}}')
 
 statement ok
-INSERT INTO d VALUES(4, '{"a":{"b":[1]}}')
+INSERT INTO d VALUES(4, '{"a": {"b": [1]}}')
 
 statement ok
-INSERT INTO d VALUES(5, '{"a":{"b":[1,[2]]}}')
+INSERT INTO d VALUES(5, '{"a": {"b": [1, [2]]}}')
 
 statement ok
-INSERT INTO d VALUES(6, '{"a":{"b":[[2]]}}')
+INSERT INTO d VALUES(6, '{"a": {"b": [[2]]}}')
 
 statement ok
-INSERT INTO d VALUES(7, '{"a":"b", "c":"d"}')
+INSERT INTO d VALUES(7, '{"a": "b", "c": "d"}')
 
 statement ok
-INSERT INTO d VALUES(8, '{"a":{"b":true}}')
+INSERT INTO d VALUES(8, '{"a": {"b":true}}')
 
 statement ok
-INSERT INTO d VALUES(9, '{"a":{"b":false}}')
+INSERT INTO d VALUES(9, '{"a": {"b":false}}')
 
 statement ok
 INSERT INTO d VALUES(10, '"a"')
@@ -136,23 +136,23 @@ statement ok
 INSERT INTO d VALUES(15, '1.23')
 
 statement ok
-INSERT INTO d VALUES(17, '[{"a":{"b":[1,[2]]}}, "d"]')
+INSERT INTO d VALUES(16, '[{"a": {"b": [1, [2]]}}, "d"]')
 
-statement error pq: attempted access to empty key
-INSERT INTO d VALUES(16, '{}')
+statement ok
+INSERT INTO d VALUES(17, '{}')
 
-statement error pq: attempted access to empty key
-INSERT INTO d VALUES(16, '[]')
+statement ok
+INSERT INTO d VALUES(18, '[]')
 
 query TITTTTT
-EXPLAIN (VERBOSE) SELECT * from d where b @>'{"a":"b"}'
+EXPLAIN (VERBOSE) SELECT * from d where b @>'{"a": "b"}'
 ----
-index-join  0  index-join  ·      ·                                        (a, b)           b=CONST; a!=NULL; key(a)
- ├── scan   1  scan        ·      ·                                        (a, b[omitted])  b=CONST; a!=NULL; key(a)
- │          1  ·           table  d@foo_inv                                ·                ·
- │          1  ·           spans  /!NULL/"a"/"b"-/!NULL/"a"/"b"/PrefixEnd  ·                ·
- └── scan   1  scan        ·      ·                                        (a, b)           ·
-·           1  ·           table  d@primary                                ·                ·
+index-join  0  index-join  ·      ·                                            (a, b)           b=CONST; a!=NULL; key(a)
+ ├── scan   1  scan        ·      ·                                            (a, b[omitted])  b=CONST; a!=NULL; key(a)
+ │          1  ·           table  d@foo_inv                                    ·                ·
+ │          1  ·           spans  /"a"/"b"-/"a"/"b"/PrefixEnd  ·                ·
+ └── scan   1  scan        ·      ·                                            (a, b)           ·
+·           1  ·           table  d@primary                                    ·                ·
 
 query IT
 SELECT * from d where b @>'{"a": "b"}' ORDER BY a;
@@ -162,54 +162,54 @@ SELECT * from d where b @>'{"a": "b"}' ORDER BY a;
 
 
 query TITTTTT
-EXPLAIN (VERBOSE) SELECT * from d where b @>'{"a":{"b":[1]}}'
+EXPLAIN (VERBOSE) SELECT * from d where b @>'{"a": {"b": [1]}}'
 ----
-index-join  0  index-join  ·      ·                                                                (a, b)           b=CONST; a!=NULL; key(a)
- ├── scan   1  scan        ·      ·                                                                (a, b[omitted])  b=CONST; a!=NULL; key(a)
- │          1  ·           table  d@foo_inv                                                        ·                ·
- │          1  ·           spans  /!NULL/"a"/!NULL/"b"/Arr/1-/!NULL/"a"/!NULL/"b"/Arr/1/PrefixEnd  ·                ·
- └── scan   1  scan        ·      ·                                                                (a, b)           ·
-·           1  ·           table  d@primary                                                        ·                ·
+index-join  0  index-join  ·      ·                                                                        (a, b)           b=CONST; a!=NULL; key(a)
+ ├── scan   1  scan        ·      ·                                                                        (a, b[omitted])  b=CONST; a!=NULL; key(a)
+ │          1  ·           table  d@foo_inv                                                                ·                ·
+ │          1  ·           spans  /"a"/"b"/Arr/1-/"a"/"b"/Arr/1/PrefixEnd  ·                ·
+ └── scan   1  scan        ·      ·                                                                        (a, b)           ·
+·           1  ·           table  d@primary                                                                ·                ·
 
 query IT
-SELECT * from d where b @> '{"a":{"b":[1]}}' ORDER BY a;
+SELECT * from d where b @> '{"a": {"b": [1]}}' ORDER BY a;
 ----
 4  {"a": {"b": [1]}}
 5  {"a": {"b": [1, [2]]}}
 
 query TITTTTT
-EXPLAIN (VERBOSE) SELECT * from d where b @> '{"a":{"b":[[2]]}}';
+EXPLAIN (VERBOSE) SELECT * from d where b @> '{"a": {"b": [[2]]}}';
 ----
-index-join  0  index-join  ·      ·                                                                        (a, b)           b=CONST; a!=NULL; key(a)
- ├── scan   1  scan        ·      ·                                                                        (a, b[omitted])  b=CONST; a!=NULL; key(a)
- │          1  ·           table  d@foo_inv                                                                ·                ·
- │          1  ·           spans  /!NULL/"a"/!NULL/"b"/Arr/Arr/2-/!NULL/"a"/!NULL/"b"/Arr/Arr/2/PrefixEnd  ·                ·
- └── scan   1  scan        ·      ·                                                                        (a, b)           ·
-·           1  ·           table  d@primary                                                                ·                ·
+index-join  0  index-join  ·      ·                                                                                (a, b)           b=CONST; a!=NULL; key(a)
+ ├── scan   1  scan        ·      ·                                                                                (a, b[omitted])  b=CONST; a!=NULL; key(a)
+ │          1  ·           table  d@foo_inv                                                                        ·                ·
+ │          1  ·           spans  /"a"/"b"/Arr/Arr/2-/"a"/"b"/Arr/Arr/2/PrefixEnd  ·                ·
+ └── scan   1  scan        ·      ·                                                                                (a, b)           ·
+·           1  ·           table  d@primary                                                                        ·                ·
 
 query IT
-SELECT * from d where b @> '{"a":{"b":[[2]]}}' ORDER BY a;
+SELECT * from d where b @> '{"a": {"b": [[2]]}}' ORDER BY a;
 ----
 5  {"a": {"b": [1, [2]]}}
 6  {"a": {"b": [[2]]}}
 
 query TITTTTT
-EXPLAIN (VERBOSE) SELECT * from d where b @> '{"a":{"b":true}}';
+EXPLAIN (VERBOSE) SELECT * from d where b @> '{"a": {"b":true}}';
 ----
-index-join  0  index-join  ·      ·                                                     (a, b)           b=CONST; a!=NULL; key(a)
- ├── scan   1  scan        ·      ·                                                     (a, b[omitted])  b=CONST; a!=NULL; key(a)
- │          1  ·           table  d@foo_inv                                             ·                ·
- │          1  ·           spans  /!NULL/"a"/!NULL/"b"/True-/!NULL/"a"/!NULL/"b"/False  ·                ·
- └── scan   1  scan        ·      ·                                                     (a, b)           ·
-·           1  ·           table  d@primary                                             ·                ·
+index-join  0  index-join  ·      ·                                                             (a, b)           b=CONST; a!=NULL; key(a)
+ ├── scan   1  scan        ·      ·                                                             (a, b[omitted])  b=CONST; a!=NULL; key(a)
+ │          1  ·           table  d@foo_inv                                                     ·                ·
+ │          1  ·           spans  /"a"/"b"/True-/"a"/"b"/False  ·                ·
+ └── scan   1  scan        ·      ·                                                             (a, b)           ·
+·           1  ·           table  d@primary                                                     ·                ·
 
 query IT
-SELECT * from d where b @> '{"a":{"b":true}}' ORDER BY a;
+SELECT * from d where b @> '{"a": {"b": true}}' ORDER BY a;
 ----
 8  {"a": {"b": true}}
 
 query IT
-SELECT * from d where b @> '{"a":{"b":[[2]]}}' ORDER BY a;
+SELECT * from d where b @> '{"a": {"b": [[2]]}}' ORDER BY a;
 ----
 5  {"a": {"b": [1, [2]]}}
 6  {"a": {"b": [[2]]}}
@@ -230,19 +230,19 @@ SELECT * from d where b @>'[1]' ORDER BY a;
 2  [1, 2, 3, 4, "foo"]
 
 query TITTTTT
-EXPLAIN (VERBOSE) SELECT * from d where b @>'[{"a":{"b":[1]}}]'
+EXPLAIN (VERBOSE) SELECT * from d where b @>'[{"a": {"b": [1]}}]'
 ----
-index-join  0  index-join  ·      ·                                                                        (a, b)           b=CONST; a!=NULL; key(a)
- ├── scan   1  scan        ·      ·                                                                        (a, b[omitted])  b=CONST; a!=NULL; key(a)
- │          1  ·           table  d@foo_inv                                                                ·                ·
- │          1  ·           spans  /Arr/!NULL/"a"/!NULL/"b"/Arr/1-/Arr/!NULL/"a"/!NULL/"b"/Arr/1/PrefixEnd  ·                ·
- └── scan   1  scan        ·      ·                                                                        (a, b)           ·
-·           1  ·           table  d@primary                                                                ·                ·
+index-join  0  index-join  ·      ·                                                                                (a, b)           b=CONST; a!=NULL; key(a)
+ ├── scan   1  scan        ·      ·                                                                                (a, b[omitted])  b=CONST; a!=NULL; key(a)
+ │          1  ·           table  d@foo_inv                                                                        ·                ·
+ │          1  ·           spans  /Arr/"a"/"b"/Arr/1-/Arr/"a"/"b"/Arr/1/PrefixEnd  ·                ·
+ └── scan   1  scan        ·      ·                                                                                (a, b)           ·
+·           1  ·           table  d@primary                                                                        ·                ·
 
 query IT
-SELECT * from d where b @>'[{"a":{"b":[1]}}]' ORDER BY a;
+SELECT * from d where b @>'[{"a": {"b": [1]}}]' ORDER BY a;
 ----
-17  [{"a": {"b": [1, [2]]}}, "d"]
+16  [{"a": {"b": [1, [2]]}}, "d"]
 
 statement ok
 DELETE from d WHERE a=1;
@@ -256,7 +256,7 @@ statement ok
 DELETE from d WHERE a=6;
 
 query IT
-SELECT * from d where b @> '{"a":{"b":[[2]]}}' ORDER BY a;
+SELECT * from d where b @> '{"a": {"b": [[2]]}}' ORDER BY a;
 ----
 5  {"a": {"b": [1, [2]]}}
 
@@ -290,43 +290,47 @@ SELECT * from d where b @> '1.23' ORDER BY a;
 ----
 15  1.23
 
-statement error pq: .*: can't look up empty JSON
+query IT
 SELECT * from d where b @> '{}' ORDER BY a;
+----
+17  {}
 
-statement error pq: .*: can't look up empty JSON
+query IT
 SELECT * from d where b @> '[]' ORDER BY a;
+----
+18  []
 
 statement ok
-INSERT INTO d VALUES (20, '["a", "a"]')
+INSERT INTO d VALUES (19, '["a", "a"]')
 
 query IT
 SELECT * from d where b @> '["a"]' ORDER BY a;
 ----
-20  ["a", "a"]
+19  ["a", "a"]
 
 statement ok
-INSERT INTO d VALUES (21, '[{"a":"a"}, {"a":"a"}]')
+INSERT INTO d VALUES (20, '[{"a": "a"}, {"a": "a"}]')
 
 query IT
-SELECT * from d where b @> '[{"a":"a"}]' ORDER BY a;
+SELECT * from d where b @> '[{"a": "a"}]' ORDER BY a;
 ----
-21  [{"a": "a"}, {"a": "a"}]
+20  [{"a": "a"}, {"a": "a"}]
 
 statement ok
-INSERT INTO d VALUES (22,  '[[[["a"]]],[[["a"]]]]')
-
-query IT
-SELECT * from d where b @> '[[[["a"]]]]' ORDER BY a;
-----
-22  [[[["a"]]], [[["a"]]]]
-
-statement ok
-INSERT INTO d VALUES (23,  '[1,2,3,1]')
+INSERT INTO d VALUES (21,  '[[[["a"]]], [[["a"]]]]')
 
 query IT
 SELECT * from d where b @> '[[[["a"]]]]' ORDER BY a;
 ----
-22  [[[["a"]]], [[["a"]]]]
+21  [[[["a"]]], [[["a"]]]]
+
+statement ok
+INSERT INTO d VALUES (22,  '[1,2,3,1]')
+
+query IT
+SELECT * from d where b @> '[[[["a"]]]]' ORDER BY a;
+----
+21  [[[["a"]]], [[["a"]]]]
 
 query IT
 SELECT * from d where b->'a' = '"b"'
@@ -339,7 +343,7 @@ EXPLAIN (VERBOSE) SELECT * from d where b->'a' = '"b"'
 index-join  0  index-join  ·      ·                                        (a, b)           b=CONST; a!=NULL; key(a)
  ├── scan   1  scan        ·      ·                                        (a, b[omitted])  b=CONST; a!=NULL; key(a)
  │          1  ·           table  d@foo_inv                                ·                ·
- │          1  ·           spans  /!NULL/"a"/"b"-/!NULL/"a"/"b"/PrefixEnd  ·                ·
+ │          1  ·           spans  /"a"/"b"-/"a"/"b"/PrefixEnd  ·                ·
  └── scan   1  scan        ·      ·                                        (a, b)           ·
 ·           1  ·           table  d@primary                                ·                ·
 
@@ -349,6 +353,45 @@ EXPLAIN (VERBOSE) SELECT * from d where '"b"' = b->'a'
 index-join  0  index-join  ·      ·                                        (a, b)           b=CONST; a!=NULL; key(a)
  ├── scan   1  scan        ·      ·                                        (a, b[omitted])  b=CONST; a!=NULL; key(a)
  │          1  ·           table  d@foo_inv                                ·                ·
- │          1  ·           spans  /!NULL/"a"/"b"-/!NULL/"a"/"b"/PrefixEnd  ·                ·
+ │          1  ·           spans  /"a"/"b"-/"a"/"b"/PrefixEnd  ·                ·
  └── scan   1  scan        ·      ·                                        (a, b)           ·
 ·           1  ·           table  d@primary                                ·                ·
+
+statement ok
+INSERT INTO d VALUES (23,  '{"a": 123.123}')
+
+statement ok
+INSERT INTO d VALUES (24,  '{"a": 123.123000}')
+
+query IT
+SELECT * from d where b @> '{"a": 123.123}' ORDER BY a;
+----
+23  {"a": 123.123}
+24  {"a": 123.123000}
+
+query IT
+SELECT * from d where b @> '{"a": 123.123000}' ORDER BY a;
+----
+23  {"a": 123.123}
+24  {"a": 123.123000}
+
+statement ok
+INSERT INTO d VALUES (25,  '{"a": [{}]}')
+
+statement ok
+INSERT INTO d VALUES (26,  '[[], {}]')
+
+query IT
+SELECT * from d where b @> '{"a": [{}]}' ORDER BY a;
+----
+25  {"a": [{}]}
+
+query IT
+SELECT * from d where b @> '[{}]' ORDER BY a;
+----
+26  [[], {}]
+
+query IT
+SELECT * from d where b @> '[[]]' ORDER BY a;
+----
+26  [[], {}]

--- a/pkg/sql/sqlbase/encoded_datum.go
+++ b/pkg/sql/sqlbase/encoded_datum.go
@@ -97,17 +97,9 @@ func EncDatumFromBuffer(typ *ColumnType, enc DatumEncoding, buf []byte) (EncDatu
 	case DatumEncoding_ASCENDING_KEY, DatumEncoding_DESCENDING_KEY:
 		var encLen int
 		var err error
-		if typ.SemanticType == ColumnType_JSON {
-			encLen, err = encoding.GetJSONInvertedIndexKeyLength(buf)
-			if err != nil {
-				return EncDatum{}, nil, err
-			}
-		} else {
-			var err error
-			encLen, err = encoding.PeekLength(buf)
-			if err != nil {
-				return EncDatum{}, nil, err
-			}
+		encLen, err = encoding.PeekLength(buf)
+		if err != nil {
+			return EncDatum{}, nil, err
 		}
 		ed := EncDatumFromEncoded(enc, buf[:encLen])
 		return ed, buf[encLen:], nil

--- a/pkg/sql/sqlbase/table.go
+++ b/pkg/sql/sqlbase/table.go
@@ -1593,7 +1593,7 @@ func EncodeInvertedIndexKeys(
 func EncodeInvertedIndexTableKeys(val tree.Datum, inKey []byte) (key [][]byte, err error) {
 	switch t := tree.UnwrapDatum(nil, val).(type) {
 	case *tree.DJSON:
-		return (t.JSON).EncodeInvertedIndexKeys(inKey)
+		return json.EncodeInvertedIndexKeys(inKey, (t.JSON))
 	}
 	return nil, pgerror.NewError(pgerror.CodeInternalError, "trying to apply inverted index to non JSON type")
 }

--- a/pkg/util/encoding/encoding.go
+++ b/pkg/util/encoding/encoding.go
@@ -70,6 +70,10 @@ const (
 	decimalNaNDesc          = decimalInfinity + 1 // NaN encoded descendingly
 	decimalTerminator       = 0x00
 
+	jsonInvertedIndex = decimalNaNDesc + 1
+	jsonEmptyArray    = jsonInvertedIndex + 1
+	jsonEmptyObject   = jsonEmptyArray + 1
+
 	// IntMin is chosen such that the range of int tags does not overlap the
 	// ascii character set that is frequently used in testing.
 	IntMin      = 0x80 // 128
@@ -112,6 +116,8 @@ const (
 	Ascending
 	Descending
 )
+
+const escapeLength = 2
 
 // Reverse returns the opposite direction.
 func (d Direction) Reverse() Direction {
@@ -465,10 +471,12 @@ func DecodeUvarintDescending(b []byte) ([]byte, uint64, error) {
 const (
 	// <term>     -> \x00\x01
 	// \x00       -> \x00\xff
-	escape      byte = 0x00
-	escapedTerm byte = 0x01
-	escaped00   byte = 0xff
-	escapedFF   byte = 0x00
+	escape                   byte = 0x00
+	escapedTerm              byte = 0x01
+	escapedJSONObjectKeyTerm byte = 0x02
+	escapedJSONArray         byte = 0x03
+	escaped00                byte = 0xff
+	escapedFF                byte = 0x00
 )
 
 type escapes struct {
@@ -490,7 +498,34 @@ var (
 // encoded value. The encoded bytes are append to the supplied buffer
 // and the resulting buffer is returned.
 func EncodeBytesAscending(b []byte, data []byte) []byte {
-	b = append(b, bytesMarker)
+	return encodeBytesAscendingWithTerminatorAndPrefix(b, data, ascendingEscapes.escapedTerm, bytesMarker)
+}
+
+// encodeBytesAscendingWithTerminatorAndPrefix encodes the []byte value using an escape-based
+// encoding. The encoded value is terminated with the sequence
+// "\x00\terminator". The encoded bytes are append to the supplied buffer
+// and the resulting buffer is returned. The terminator allows us to pass
+// different terminators for things such as JSON key encoding.
+func encodeBytesAscendingWithTerminatorAndPrefix(
+	b []byte, data []byte, terminator byte, prefix byte,
+) []byte {
+	b = append(b, prefix)
+	return encodeBytesAscendingWithTerminator(b, data, terminator)
+}
+
+// encodeBytesAscendingWithTerminator encodes the []byte value using an escape-based
+// encoding. The encoded value is terminated with the sequence
+// "\x00\terminator". The encoded bytes are append to the supplied buffer
+// and the resulting buffer is returned. The terminator allows us to pass
+// different terminators for things such as JSON key encoding.
+func encodeBytesAscendingWithTerminator(b []byte, data []byte, terminator byte) []byte {
+	bs := encodeBytesAscendingWithoutTerminatorOrPrefix(b, data)
+	return append(bs, escape, terminator)
+}
+
+// encodeBytesAscendingWithoutTerminatorOrPrefix encodes the []byte value using an escape-based
+// encoding.
+func encodeBytesAscendingWithoutTerminatorOrPrefix(b []byte, data []byte) []byte {
 	for {
 		// IndexByte is implemented by the go runtime in assembly and is
 		// much faster than looping over the bytes in the slice.
@@ -502,8 +537,7 @@ func EncodeBytesAscending(b []byte, data []byte) []byte {
 		b = append(b, escape, escaped00)
 		data = data[i+1:]
 	}
-	b = append(b, data...)
-	return append(b, escape, escapedTerm)
+	return append(b, data...)
 }
 
 // EncodeBytesDescending encodes the []byte value using an
@@ -589,19 +623,57 @@ func getBytesLength(b []byte, e escapes) (int, error) {
 		if i+1 >= len(b) {
 			return 0, errors.Errorf("malformed escape in buffer %#x", b)
 		}
-		skipped += i + 2
+		skipped += i + escapeLength
 		if b[skipped-1] == e.escapedTerm {
 			return skipped, nil
 		}
 	}
 }
 
-// EncodeStringAscending encodes the string value using an escape-based encoding. See
-// EncodeBytes for details. The encoded bytes are append to the supplied buffer
-// and the resulting buffer is returned.
-func EncodeStringAscending(b []byte, s string) []byte {
+// prettyPrintInvertedIndexKey returns a string representation of the path part of a JSON inverted
+// index.
+func prettyPrintInvertedIndexKey(b []byte) (string, []byte, error) {
+	outBytes := ""
+	// We're skipping the first byte because it's the JSON tag.
+	tempB := b[1:]
+	for {
+		i := bytes.IndexByte(tempB, escape)
+
+		if i == -1 {
+			return "", nil, errors.Errorf("did not find terminator %#x in buffer %#x", escape, b)
+		}
+		if i+1 >= len(tempB) {
+			return "", nil, errors.Errorf("malformed escape in buffer %#x", b)
+		}
+
+		switch tempB[i+1] {
+		case escapedTerm:
+			if len(tempB[:i]) > 0 {
+				outBytes = outBytes + strconv.Quote(unsafeString(tempB[:i]))
+			} else {
+				lenOut := len(outBytes)
+				if lenOut > 1 && outBytes[lenOut-1] == '/' {
+					outBytes = outBytes[:lenOut-1]
+				}
+			}
+			return outBytes, tempB[i+escapeLength:], nil
+		case escapedJSONObjectKeyTerm:
+			outBytes = outBytes + strconv.Quote(unsafeString(tempB[:i])) + "/"
+		case escapedJSONArray:
+			outBytes = outBytes + "Arr/"
+		default:
+			return "", nil, errors.Errorf("malformed escape in buffer %#x", b)
+
+		}
+
+		tempB = tempB[i+escapeLength:]
+	}
+}
+
+// unsafeConvertStringToBytes converts a string to a byte array to be used with string encoding functions.
+func unsafeConvertStringToBytes(s string) []byte {
 	if len(s) == 0 {
-		return EncodeBytesAscending(b, nil)
+		return nil
 	}
 	// We unsafely convert the string to a []byte to avoid the
 	// usual allocation when converting to a []byte. This is
@@ -611,8 +683,53 @@ func EncodeStringAscending(b []byte, s string) []byte {
 	hdr := (*reflect.StringHeader)(unsafe.Pointer(&s))
 	// Next we treat the string data as a maximally sized array which we
 	// slice. This usage is safe because the pointer value remains in the string.
-	arg := (*[0x7fffffff]byte)(unsafe.Pointer(hdr.Data))[:len(s):len(s)]
-	return EncodeBytesAscending(b, arg)
+	return (*[0x7fffffff]byte)(unsafe.Pointer(hdr.Data))[:len(s):len(s)]
+}
+
+// EncodeStringAscending encodes the string value using an escape-based encoding. See
+// EncodeBytes for details. The encoded bytes are append to the supplied buffer
+// and the resulting buffer is returned.
+func EncodeStringAscending(b []byte, s string) []byte {
+	return encodeStringAscendingWithTerminatorAndPrefix(b, s, ascendingEscapes.escapedTerm, bytesMarker)
+}
+
+// encodeStringAscendingWithTerminatorAndPrefix encodes the string value using an escape-based encoding. See
+// EncodeBytes for details. The encoded bytes are append to the supplied buffer
+// and the resulting buffer is returned. We can also pass a terminator byte to be used with
+// JSON key encoding.
+func encodeStringAscendingWithTerminatorAndPrefix(
+	b []byte, s string, terminator byte, prefix byte,
+) []byte {
+	unsafeString := unsafeConvertStringToBytes(s)
+	return encodeBytesAscendingWithTerminatorAndPrefix(b, unsafeString, terminator, prefix)
+}
+
+// EncodeJSONKeyStringAscending encodes the JSON key string value with a JSON specific escaped
+// terminator. This allows us to encode keys in the same number of bytes as a string,
+// while at the same time giving us a sentinel to identify JSON keys. The end parameter is used
+// to determine if this is the last key in a a JSON path. If it is we don't add a separator after it.
+func EncodeJSONKeyStringAscending(b []byte, s string, end bool) []byte {
+	str := unsafeConvertStringToBytes(s)
+
+	if end {
+		return encodeBytesAscendingWithoutTerminatorOrPrefix(b, str)
+	}
+	return encodeBytesAscendingWithTerminator(b, str, escapedJSONObjectKeyTerm)
+}
+
+// EncodeJSONEmptyArray returns a byte array b with a byte to signify an empty JSON array.
+func EncodeJSONEmptyArray(b []byte) []byte {
+	return append(b, escape, escapedTerm, jsonEmptyArray)
+}
+
+// AddJSONPathTerminator adds a json path terminator to a byte array.
+func AddJSONPathTerminator(b []byte) []byte {
+	return append(b, escape, escapedTerm)
+}
+
+// EncodeJSONEmptyObject returns a byte array b with a byte to signify an empty JSON object.
+func EncodeJSONEmptyObject(b []byte) []byte {
+	return append(b, escape, escapedTerm, jsonEmptyObject)
 }
 
 // EncodeStringDescending is the descending version of EncodeStringAscending.
@@ -669,6 +786,12 @@ func EncodeNullAscending(b []byte) []byte {
 	return append(b, encodedNull)
 }
 
+// EncodeJSONAscending encodes a JSON Type. The encoded bytes are appended to the
+// supplied buffer and the final buffer is returned.
+func EncodeJSONAscending(b []byte) []byte {
+	return append(b, jsonInvertedIndex)
+}
+
 // EncodeNullDescending is the descending equivalent of EncodeNullAscending.
 func EncodeNullDescending(b []byte) []byte {
 	return append(b, encodedNullDesc)
@@ -683,7 +806,7 @@ func EncodeNotNullAscending(b []byte) []byte {
 
 // EncodeArrayAscending encodes a value used to signify membership of an array for JSON objects.
 func EncodeArrayAscending(b []byte) []byte {
-	return append(b, byte(Array))
+	return append(b, escape, escapedJSONArray)
 }
 
 // EncodeTrueAscending encodes the boolean value true for use with JSON inverted indexes.
@@ -1015,6 +1138,8 @@ func PeekLength(b []byte) (int, error) {
 		return 1, nil
 	case bytesMarker:
 		return getBytesLength(b, ascendingEscapes)
+	case jsonInvertedIndex:
+		return getJSONInvertedIndexKeyLength(b)
 	case bytesDescMarker:
 		return getBytesLength(b, descendingEscapes)
 	case timeMarker:
@@ -1177,7 +1302,6 @@ func prettyPrintFirstValue(dir Direction, b []byte) ([]byte, string, error) {
 		if dir == Descending {
 			return b, "", errors.Errorf("descending bytes column dir but ascending bytes encoding")
 		}
-
 		var s string
 		b, s, err = DecodeUnsafeStringAscending(b, nil)
 		if err != nil {
@@ -1218,6 +1342,24 @@ func prettyPrintFirstValue(dir Direction, b []byte) ([]byte, string, error) {
 		}
 		return b, d.String(), nil
 	default:
+		if len(b) >= 1 {
+			switch b[0] {
+			case jsonInvertedIndex:
+				var str string
+				str, b, err = prettyPrintInvertedIndexKey(b)
+				if err != nil {
+					return b, "", err
+				}
+				if str == "" {
+					return prettyPrintFirstValue(dir, b)
+				}
+				return b, str, nil
+			case jsonEmptyArray:
+				return b[1:], "[]", nil
+			case jsonEmptyObject:
+				return b[1:], "{}", nil
+			}
+		}
 		// This shouldn't ever happen, but if it does, return an empty slice.
 		return nil, strconv.Quote(string(b)), nil
 	}
@@ -1992,29 +2134,41 @@ func DecomposeKeyTokens(b []byte) (tokens [][]byte, containsNull bool, err error
 	return out, containsNull, nil
 }
 
-// GetJSONInvertedIndexKeyLength returns the length of encoded JSON inverted index
-// key at the start of b.
-func GetJSONInvertedIndexKeyLength(buf []byte) (int, error) {
-	offset := 0
+// getInvertedIndexKeyLength finds the length of an inverted index key
+// encoded as a byte array.
+func getInvertedIndexKeyLength(b []byte) (int, error) {
+	skipped := 0
 	for {
-		typ := PeekType(buf)
-		switch typ {
-		case Array:
-			offset++
-			buf = buf[1:]
-		case NotNull:
-			len, err := PeekLength(buf[1:])
-			if err != nil {
-				return 0, err
-			}
-			offset += len + 1
-			buf = buf[len+1:]
-		default:
-			len, err := PeekLength(buf)
-			if err != nil {
-				return 0, err
-			}
-			return offset + len, nil
+		i := bytes.IndexByte(b[skipped:], escape)
+		if i == -1 {
+			return 0, errors.Errorf("malformed inverted index key in buffer %#x", b)
 		}
+		skipped += i + escapeLength
+		switch b[skipped-1] {
+		case escapedTerm, jsonEmptyObject, jsonEmptyArray:
+			return skipped, nil
+		}
+	}
+}
+
+// getJSONInvertedIndexKeyLength returns the length of encoded JSON inverted index
+// key at the start of b.
+func getJSONInvertedIndexKeyLength(buf []byte) (int, error) {
+	len, err := getInvertedIndexKeyLength(buf)
+	if err != nil {
+		return 0, err
+	}
+
+	switch buf[len] {
+	case jsonEmptyArray, jsonEmptyObject:
+		return len + 1, nil
+
+	default:
+		valLen, err := PeekLength(buf[len:])
+		if err != nil {
+			return 0, err
+		}
+
+		return len + valLen, nil
 	}
 }

--- a/pkg/util/json/encoded.go
+++ b/pkg/util/json/encoded.go
@@ -693,13 +693,13 @@ func (j *jsonEncoded) Len() int {
 }
 
 // EncodeInvertedIndexKeys implements the JSON interface.
-func (j *jsonEncoded) EncodeInvertedIndexKeys(b []byte) ([][]byte, error) {
+func (j *jsonEncoded) encodeInvertedIndexKeys(b []byte) ([][]byte, error) {
 	// TODO(justin): this could possibly be optimized.
 	decoded, err := j.decode()
 	if err != nil {
 		return nil, err
 	}
-	return decoded.EncodeInvertedIndexKeys(b)
+	return decoded.encodeInvertedIndexKeys(b)
 }
 
 // preprocessForContains implements the JSON interface.


### PR DESCRIPTION
Before we used a sentinel not null as a prefix for JSON key strings.
This introduced an extra byte.

Now we're encoding the terminator differently for JSON object so we
can distinguish JSON object keys by looking at terminators instead of a
prefix.

We've also added support for explicitly encoding empty JSON objects and
arrays.

Closes #21485

Release note: None