### PR TITLE
sql: move ApplicationName to SessionData

### DIFF
--- a/pkg/ccl/sqlccl/csv.go
+++ b/pkg/ccl/sqlccl/csv.go
@@ -550,7 +550,7 @@ func convertRecord(
 	}
 
 	var txCtx transform.ExprTransformContext
-	evalCtx := tree.EvalContext{SessionData: sessiondata.SessionData{Location: time.UTC}}
+	evalCtx := tree.EvalContext{SessionData: &sessiondata.SessionData{Location: time.UTC}}
 	// Although we don't yet support DEFAULT expressions on visible columns,
 	// we do on hidden columns (which is only the default _rowid one). This
 	// allows those expressions to run.

--- a/pkg/sql/distsqlrun/server.go
+++ b/pkg/sql/distsqlrun/server.go
@@ -259,7 +259,7 @@ func (ds *ServerImpl) setupFlow(
 	}
 	evalCtx := tree.EvalContext{
 		Settings: ds.ServerConfig.Settings,
-		SessionData: sessiondata.SessionData{
+		SessionData: &sessiondata.SessionData{
 			Location:   location,
 			Database:   req.EvalContext.Database,
 			User:       req.EvalContext.User,

--- a/pkg/sql/plan.go
+++ b/pkg/sql/plan.go
@@ -90,7 +90,7 @@ func (r *runParams) EvalContext() *tree.EvalContext {
 
 // SessionData gives convenient access to the runParam's SessionData.
 func (r *runParams) SessionData() *sessiondata.SessionData {
-	return &r.extendedEvalCtx.SessionData
+	return r.extendedEvalCtx.SessionData
 }
 
 // planNode defines the interface for executing a query or portion of a query.

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -192,13 +192,11 @@ func newInternalPlanner(
 	// looks in the session for the current database.
 	ctx := log.WithLogTagStr(context.Background(), opName, "")
 
-	data := sessiondata.SessionData{
-		Location: time.UTC,
-		User:     user,
-	}
-
 	s := &Session{
-		data:           data,
+		data: sessiondata.SessionData{
+			Location: time.UTC,
+			User:     user,
+		},
 		TxnState:       txnState{Ctx: ctx, implicitTxn: true},
 		context:        ctx,
 		tables:         TableCollection{databaseCache: newDatabaseCache(config.SystemConfig{})},
@@ -207,7 +205,6 @@ func newInternalPlanner(
 	}
 	s.dataMutator = sessionDataMutator{
 		data: &s.data,
-		s:    s,
 		defaults: sessionDefaults{
 			applicationName: "crdb-internal",
 			database:        "",
@@ -546,7 +543,7 @@ func (p *planner) TypeAsStringArray(exprs tree.Exprs, op string) (func() ([]stri
 
 // SessionData is part of the PlanHookState interface.
 func (p *planner) SessionData() *sessiondata.SessionData {
-	return &p.EvalContext().SessionData
+	return p.EvalContext().SessionData
 }
 
 func (p *planner) testingVerifyMetadata() testingVerifyMetadata {

--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -1142,7 +1142,7 @@ func createSchemaChangeEvalCtx(ts hlc.Timestamp) extendedEvalContext {
 	dummyLocation := time.UTC
 	evalCtx := extendedEvalContext{
 		EvalContext: tree.EvalContext{
-			SessionData: sessiondata.SessionData{
+			SessionData: &sessiondata.SessionData{
 				SearchPath: sqlbase.DefaultSearchPath,
 				Location:   dummyLocation,
 				// The database is not supposed to be needed in schema changes, as there

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -2056,7 +2056,7 @@ func (*EvalContextTestingKnobs) ModuleTestingKnobs() {}
 type EvalContext struct {
 	// Session variables. This is a read-only copy of the values owned by the
 	// Session.
-	SessionData sessiondata.SessionData
+	SessionData *sessiondata.SessionData
 	// ApplicationName is a session variable, but it is not part of SessionData.
 	// See its definition in Session for details.
 	ApplicationName string
@@ -2129,7 +2129,9 @@ type EvalContext struct {
 
 // MakeTestingEvalContext returns an EvalContext that includes a MemoryMonitor.
 func MakeTestingEvalContext() EvalContext {
-	ctx := EvalContext{}
+	ctx := EvalContext{
+		SessionData: &sessiondata.SessionData{},
+	}
 	monitor := mon.MakeMonitor(
 		"test-monitor",
 		mon.MemoryResource,


### PR DESCRIPTION
ApplicationName is a session variable so it belongs in SessionData but,
before this patch, it was living on the Session because updating it
needs to update some other session state too. Reworked how updating that
state works.
Now SessionDataMutator no longer needs a Session.

Release note: None