### PR TITLE
ui: update docs link to 2.0

### DIFF
--- a/pkg/ui/src/util/docs.ts
+++ b/pkg/ui/src/util/docs.ts
@@ -1,7 +1,7 @@
 // TODO(benesch): Derive this URL from build.VersionPrefix() rather than
-// hardcoding v1.1. This is harder than it sounds, since we don't want to encode
+// hardcoding it. This is harder than it sounds, since we don't want to encode
 // the branch name in embedded.go.
-const docsURLBase = "https://www.cockroachlabs.com/docs/v1.1";
+const docsURLBase = "https://www.cockroachlabs.com/docs/v2.0";
 
 export default function docsURL(pageName: string): string {
   return `${docsURLBase}/${pageName}`;


### PR DESCRIPTION
Fixes: #21892
Release note (admin ui change): Links to documentation in the Admin UI are
updated to point to the docs for version 2.0.