### PR TITLE
build,cmd/workload: stop using danhhz/roachperf

### DIFF
--- a/build/builder.sh
+++ b/build/builder.sh
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 image=cockroachdb/builder
-version=20180129-142711
+version=20180130-134402
 
 function init() {
   docker build --tag="${image}" "$(dirname "${0}")/builder"

--- a/build/builder/Dockerfile
+++ b/build/builder/Dockerfile
@@ -164,6 +164,7 @@ RUN apt-get install -y --no-install-recommends \
     google-cloud-sdk \
     nodejs \
     openjdk-8-jre \
+    openssh-client \
     yarn
 
 # Without CCACHE_CPP2=1, ccache can generate spurious warnings. See the manpage

--- a/build/nightly-workload.sh
+++ b/build/nightly-workload.sh
@@ -2,25 +2,13 @@
 
 set -ex
 
-go get -u github.com/cockroachlabs/roachprod
-
-# TODO(dan): Using my fork for rapid prototyping while I figure out what the
-# roachperf changes should even look like. Switch this to the official fork.
-go get -u github.com/danhhz/roachperf
+go get -u github.com/cockroachdb/roachprod
 
 make bin/workload
-
-curl -O https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-182.0.0-linux-x86_64.tar.gz
-tar -zxf google-cloud-sdk-182.0.0-linux-x86_64.tar.gz
-yes "" | ./google-cloud-sdk/install.sh
-source google-cloud-sdk/path.bash.inc
 
 # This `set +x`/paren magic turns off the `set -x` so we don't leak secrets.
 (set +x; echo $GOOGLE_CREDENTIALS > creds.json)
 gcloud auth activate-service-account --key-file=creds.json
-eval $(ssh-agent)
-ssh-keygen -f ~/.ssh/google_compute_engine -N ''
-ssh-add ~/.ssh/google_compute_engine
 
 # teamcity-nightlies assumes cockroach and workload are the cwd.
 cp cockroach-linux-2.6.32-gnu-amd64 cockroach
@@ -28,9 +16,10 @@ cp bin/workload .
 
 # teamcity-nightlies puts the arg we give into the name of every cluster it
 # creates, so this should let us match up clusters to invocations of this build.
-./workload teamcity-nightlies ${TC_BUILD_ID}
+mkdir -p ~/.roachprod/hosts
+./workload teamcity-nightlies teamcity-nightly-workload-${TC_BUILD_ID}
 cp -R workload-test* artifacts/
 
 # Currently broken because of s3 auth. Copied from the "Roachperf Nightly"
 # build, where it is also currently broken.
-roachperf upload workload-test* || true
+roachprod upload workload-test* || true

--- a/build/teamcity-nightly-workload.sh
+++ b/build/teamcity-nightly-workload.sh
@@ -8,12 +8,13 @@ mkdir -p artifacts
 # the nightly-workload.sh script.
 pkg/acceptance/prepare.sh
 
-docker run \
-    --workdir=/go/src/github.com/cockroachdb/cockroach \
-    --volume="${GOPATH%%:*}/src":/go/src \
-    --env="AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}" \
-    --env="AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}" \
-    --env="GOOGLE_CREDENTIALS=${GOOGLE_CREDENTIALS}" \
-    --env="TC_BUILD_ID=${TC_BUILD_ID}" \
-    --rm \
-    cockroachdb/builder:20171004-085709 ./build/nightly-workload.sh
+# Use this instead of prepare.sh for faster debugging iteration.
+# curl -L https://edge-binaries.cockroachdb.com/cockroach/cockroach.linux-gnu-amd64.LATEST -o cockroach-linux-2.6.32-gnu-amd64
+# chmod +x cockroach-linux-2.6.32-gnu-amd64
+
+./build/builder.sh env \
+    AWS_ACCESS_KEY_ID="$AWS_ACCESS_KEY_ID" \
+    AWS_SECRET_ACCESS_KEY="$AWS_SECRET_ACCESS_KEY" \
+    GOOGLE_CREDENTIALS="$GOOGLE_CREDENTIALS" \
+    TC_BUILD_ID="$TC_BUILD_ID" \
+    ./build/nightly-workload.sh

--- a/pkg/cmd/workload/teamcity-nightlies.go
+++ b/pkg/cmd/workload/teamcity-nightlies.go
@@ -25,7 +25,7 @@ import (
 )
 
 var teamcityNightliesCmd = &cobra.Command{
-	Use:   `teamcity-nightlies <unique-run-id>`,
+	Use:   `teamcity-nightlies <cluster-prefix>`,
 	Short: `Run the nightly performance tests`,
 	Args:  cobra.ExactArgs(1),
 	RunE:  runTeamcityNightlies,
@@ -39,15 +39,15 @@ func init() {
 // clusters (# of machines in each locality) are going to generalize. For now,
 // just hardcode what we had before.
 var singleDCTests = map[string]string{
-	`kv0`:    `./workload run kv --read-percent=0 --splits=1000 --concurrency=384 --duration=10m`,
-	`kv95`:   `./workload run kv --read-percent=95 --splits=1000 --concurrency=384 --duration=10m`,
-	`splits`: `./workload run kv --read-percent=0 --splits=100000 --concurrency=384 --max-ops=1`,
+	`kv0`:    `./workload run kv --init --read-percent=0 --splits=1000 --concurrency=384 --duration=10m`,
+	`kv95`:   `./workload run kv --init --read-percent=95 --splits=1000 --concurrency=384 --duration=10m`,
+	`splits`: `./workload run kv --init --read-percent=0 --splits=100000 --concurrency=384 --max-ops=1`,
 }
 
 func runTeamcityNightlies(_ *cobra.Command, args []string) error {
-	uniqueRunID := args[0]
+	clusterPrefix := args[0]
 	for testName, testCmd := range singleDCTests {
-		clusterName := fmt.Sprintf(`teamcity-nightly-workload-%s-%s`, uniqueRunID, testName)
+		clusterName := fmt.Sprintf(`%s-%s`, clusterPrefix, testName)
 		defer func(clusterName string) {
 			cmd := exec.Command(`roachprod`, `-u`, `teamcity`, `destroy`, clusterName)
 			fmt.Printf("> %s\n", strings.Join(cmd.Args, ` `))
@@ -59,15 +59,18 @@ func runTeamcityNightlies(_ *cobra.Command, args []string) error {
 		cmds := []*exec.Cmd{
 			exec.Command(`roachprod`, `-u`, `teamcity`, `create`, clusterName),
 			exec.Command(`roachprod`, `sync`),
-			exec.Command(`roachperf`, clusterName, `put`, `./cockroach`, `./cockroach`),
-			exec.Command(`roachperf`, clusterName, `put`, `./workload`, `./workload`),
-			exec.Command(`roachperf`, clusterName, `workload-test`, testName, testCmd),
+			exec.Command(`sleep`, `30`),
+			exec.Command(`roachprod`, `put`, clusterName, `./cockroach`, `./cockroach`),
+			exec.Command(`roachprod`, `put`, clusterName, `./workload`, `./workload`),
+			exec.Command(`roachprod`, `workload-test`, clusterName, testName, testCmd),
 		}
 		for _, cmd := range cmds {
 			fmt.Printf("> %s\n", strings.Join(cmd.Args, ` `))
 			output, err := cmd.CombinedOutput()
 			if err != nil {
-				return errors.Errorf("%s\n\n%s\n\n%s", strings.Join(cmd.Args, ` `), err, string(output))
+				err := errors.Errorf("%s\n\n%s\n\n%s", strings.Join(cmd.Args, ` `), err, string(output))
+				fmt.Println(err)
+				return err
 			}
 		}
 	}


### PR DESCRIPTION
roachperf has been merged into roachprod and the danhhz fork's patches
have been merged upstream.

Release note: None