### PR TITLE
metric: disallow calls to Counter.Dec, use Gauge instead

### DIFF
--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -523,8 +523,14 @@ func (ts *TestServer) MustGetSQLNetworkCounter(name string) int64 {
 	reg.AddMetricStruct(ts.pgServer.Metrics())
 	reg.Each(func(n string, v interface{}) {
 		if name == n {
-			c = v.(*metric.Counter).Count()
-			found = true
+			switch t := v.(type) {
+			case *metric.Counter:
+				c = t.Count()
+				found = true
+			case *metric.Gauge:
+				c = t.Value()
+				found = true
+			}
 		}
 	})
 	if !found {

--- a/pkg/sql/distsqlrun/metrics.go
+++ b/pkg/sql/distsqlrun/metrics.go
@@ -28,7 +28,7 @@ type DistSQLMetrics struct {
 	FlowsActive   *metric.Gauge
 	FlowsTotal    *metric.Counter
 	MaxBytesHist  *metric.Histogram
-	CurBytesCount *metric.Counter
+	CurBytesCount *metric.Gauge
 }
 
 // MetricStruct implements the metrics.Struct interface.
@@ -69,7 +69,7 @@ func MakeDistSQLMetrics(histogramWindow time.Duration) DistSQLMetrics {
 		FlowsActive:   metric.NewGauge(metaFlowsActive),
 		FlowsTotal:    metric.NewCounter(metaFlowsTotal),
 		MaxBytesHist:  metric.NewHistogram(metaMemMaxBytes, histogramWindow, log10int64times1000, 3),
-		CurBytesCount: metric.NewCounter(metaMemCurBytes),
+		CurBytesCount: metric.NewGauge(metaMemCurBytes),
 	}
 }
 

--- a/pkg/sql/mem_metrics.go
+++ b/pkg/sql/mem_metrics.go
@@ -27,11 +27,11 @@ import (
 // - "internal" for activities related to leases, schema changes, etc.
 type MemoryMetrics struct {
 	MaxBytesHist         *metric.Histogram
-	CurBytesCount        *metric.Counter
+	CurBytesCount        *metric.Gauge
 	TxnMaxBytesHist      *metric.Histogram
-	TxnCurBytesCount     *metric.Counter
+	TxnCurBytesCount     *metric.Gauge
 	SessionMaxBytesHist  *metric.Histogram
-	SessionCurBytesCount *metric.Counter
+	SessionCurBytesCount *metric.Gauge
 }
 
 // MetricStruct implements the metrics.Struct interface.
@@ -78,10 +78,10 @@ func MakeMemMetrics(endpoint string, histogramWindow time.Duration) MemoryMetric
 		Help: "Current sql session memory usage for " + endpoint}
 	return MemoryMetrics{
 		MaxBytesHist:         metric.NewHistogram(MetaMemMaxBytes, histogramWindow, log10int64times1000, 3),
-		CurBytesCount:        metric.NewCounter(MetaMemCurBytes),
+		CurBytesCount:        metric.NewGauge(MetaMemCurBytes),
 		TxnMaxBytesHist:      metric.NewHistogram(MetaMemMaxTxnBytes, histogramWindow, log10int64times1000, 3),
-		TxnCurBytesCount:     metric.NewCounter(MetaMemTxnCurBytes),
+		TxnCurBytesCount:     metric.NewGauge(MetaMemTxnCurBytes),
 		SessionMaxBytesHist:  metric.NewHistogram(MetaMemMaxSessionBytes, histogramWindow, log10int64times1000, 3),
-		SessionCurBytesCount: metric.NewCounter(MetaMemSessionCurBytes),
+		SessionCurBytesCount: metric.NewGauge(MetaMemSessionCurBytes),
 	}
 }

--- a/pkg/sql/pgwire/server.go
+++ b/pkg/sql/pgwire/server.go
@@ -115,7 +115,7 @@ type Server struct {
 type ServerMetrics struct {
 	BytesInCount   *metric.Counter
 	BytesOutCount  *metric.Counter
-	Conns          *metric.Counter
+	Conns          *metric.Gauge
 	ConnMemMetrics sql.MemoryMetrics
 	SQLMemMetrics  sql.MemoryMetrics
 
@@ -126,9 +126,9 @@ func makeServerMetrics(
 	internalMemMetrics *sql.MemoryMetrics, histogramWindow time.Duration,
 ) ServerMetrics {
 	return ServerMetrics{
-		Conns:              metric.NewCounter(MetaConns),
 		BytesInCount:       metric.NewCounter(MetaBytesIn),
 		BytesOutCount:      metric.NewCounter(MetaBytesOut),
+		Conns:              metric.NewGauge(MetaConns),
 		ConnMemMetrics:     sql.MakeMemMetrics("conns", histogramWindow),
 		SQLMemMetrics:      sql.MakeMemMetrics("client", histogramWindow),
 		internalMemMetrics: internalMemMetrics,

--- a/pkg/storage/client_metrics_test.go
+++ b/pkg/storage/client_metrics_test.go
@@ -36,12 +36,6 @@ func checkGauge(t *testing.T, g *metric.Gauge, e int64) {
 	}
 }
 
-func checkCounter(t *testing.T, c *metric.Counter, e int64) {
-	if a := c.Count(); a != e {
-		t.Error(errors.Errorf("%s for store: actual %d != expected %d", c.GetName(), a, e))
-	}
-}
-
 func verifyStats(t *testing.T, mtc *multiTestContext, storeIdxSlice ...int) {
 	var stores []*storage.Store
 	var wg sync.WaitGroup
@@ -190,7 +184,7 @@ func TestStoreMetrics(t *testing.T) {
 	}
 
 	// Verify range count is as expected
-	checkCounter(t, mtc.stores[0].Metrics().ReplicaCount, 2)
+	checkGauge(t, mtc.stores[0].Metrics().ReplicaCount, 2)
 
 	// Verify all stats on store0 after split.
 	verifyStats(t, mtc, 0)
@@ -224,7 +218,7 @@ func TestStoreMetrics(t *testing.T) {
 
 	// Verify stats after sequence cache addition.
 	verifyStats(t, mtc, 0)
-	checkCounter(t, mtc.stores[0].Metrics().ReplicaCount, 2)
+	checkGauge(t, mtc.stores[0].Metrics().ReplicaCount, 2)
 
 	// Unreplicate range from the first store.
 	mtc.unreplicateRange(replica.RangeID, 0)
@@ -234,8 +228,8 @@ func TestStoreMetrics(t *testing.T) {
 	mtc.waitForValues(roachpb.Key("z"), []int64{0, 5, 5})
 
 	// Verify range count is as expected.
-	checkCounter(t, mtc.stores[0].Metrics().ReplicaCount, 1)
-	checkCounter(t, mtc.stores[1].Metrics().ReplicaCount, 1)
+	checkGauge(t, mtc.stores[0].Metrics().ReplicaCount, 1)
+	checkGauge(t, mtc.stores[1].Metrics().ReplicaCount, 1)
 
 	// Verify all stats on store0 and store1 after range is removed.
 	verifyStats(t, mtc, 0, 1)

--- a/pkg/storage/metrics.go
+++ b/pkg/storage/metrics.go
@@ -468,8 +468,8 @@ type StoreMetrics struct {
 	registry *metric.Registry
 
 	// Replica metrics.
-	ReplicaCount                  *metric.Counter // Does not include reserved replicas.
-	ReservedReplicaCount          *metric.Counter
+	ReplicaCount                  *metric.Gauge // Does not include reserved replicas.
+	ReservedReplicaCount          *metric.Gauge
 	RaftLeaderCount               *metric.Gauge
 	RaftLeaderNotLeaseHolderCount *metric.Gauge
 	LeaseHolderCount              *metric.Gauge
@@ -516,7 +516,7 @@ type StoreMetrics struct {
 	Capacity        *metric.Gauge
 	Available       *metric.Gauge
 	Used            *metric.Gauge
-	Reserved        *metric.Counter
+	Reserved        *metric.Gauge
 	SysBytes        *metric.Gauge
 	SysCount        *metric.Gauge
 
@@ -660,8 +660,8 @@ func newStoreMetrics(histogramWindow time.Duration) *StoreMetrics {
 		registry: storeRegistry,
 
 		// Replica metrics.
-		ReplicaCount:                  metric.NewCounter(metaReplicaCount),
-		ReservedReplicaCount:          metric.NewCounter(metaReservedReplicaCount),
+		ReplicaCount:                  metric.NewGauge(metaReplicaCount),
+		ReservedReplicaCount:          metric.NewGauge(metaReservedReplicaCount),
 		RaftLeaderCount:               metric.NewGauge(metaRaftLeaderCount),
 		RaftLeaderNotLeaseHolderCount: metric.NewGauge(metaRaftLeaderNotLeaseHolderCount),
 		LeaseHolderCount:              metric.NewGauge(metaLeaseHolderCount),
@@ -706,7 +706,7 @@ func newStoreMetrics(histogramWindow time.Duration) *StoreMetrics {
 		Capacity:        metric.NewGauge(metaCapacity),
 		Available:       metric.NewGauge(metaAvailable),
 		Used:            metric.NewGauge(metaUsed),
-		Reserved:        metric.NewCounter(metaReserved),
+		Reserved:        metric.NewGauge(metaReserved),
 		SysBytes:        metric.NewGauge(metaSysBytes),
 		SysCount:        metric.NewGauge(metaSysCount),
 

--- a/pkg/util/metric/metric.go
+++ b/pkg/util/metric/metric.go
@@ -297,6 +297,16 @@ func NewCounter(metadata Metadata) *Counter {
 	return &Counter{metadata, metrics.NewCounter()}
 }
 
+// Dec overrides the metric.Counter method. This method should NOT be
+// used and serves only to prevent misuse of the metric type.
+func (c *Counter) Dec(int64) {
+	// From https://prometheus.io/docs/concepts/metric_types/#counter
+	// > Counters should not be used to expose current counts of items
+	// > whose number can also go down, e.g. the number of currently
+	// > running goroutines. Use gauges for this use case.
+	panic("Counter should not be decremented, use a Gauge instead")
+}
+
 // GetType returns the prometheus type enum for this metric.
 func (c *Counter) GetType() *prometheusgo.MetricType {
 	return prometheusgo.MetricType_COUNTER.Enum()

--- a/pkg/util/metric/metric_test.go
+++ b/pkg/util/metric/metric_test.go
@@ -77,8 +77,7 @@ func TestGaugeFloat64(t *testing.T) {
 
 func TestCounter(t *testing.T) {
 	c := NewCounter(emptyMetadata)
-	c.Inc(100)
-	c.Dec(10)
+	c.Inc(90)
 	if v := c.Count(); v != 90 {
 		t.Fatalf("unexpected value: %d", v)
 	}

--- a/pkg/util/mon/bytes_usage.go
+++ b/pkg/util/mon/bytes_usage.go
@@ -219,7 +219,7 @@ type BytesMonitor struct {
 	// become reported in the logs.
 	noteworthyUsageBytes int64
 
-	curBytesCount *metric.Counter
+	curBytesCount *metric.Gauge
 	maxBytesHist  *metric.Histogram
 }
 
@@ -257,7 +257,7 @@ var DefaultPoolAllocationSize = envutil.EnvOrDefaultInt64("COCKROACH_ALLOCATION_
 func MakeMonitor(
 	name string,
 	res Resource,
-	curCount *metric.Counter,
+	curCount *metric.Gauge,
 	maxHist *metric.Histogram,
 	increment int64,
 	noteworthy int64,
@@ -271,7 +271,7 @@ func MakeMonitorWithLimit(
 	name string,
 	res Resource,
 	limit int64,
-	curCount *metric.Counter,
+	curCount *metric.Gauge,
 	maxHist *metric.Histogram,
 	increment int64,
 	noteworthy int64,
@@ -343,7 +343,7 @@ func MakeUnlimitedMonitor(
 	ctx context.Context,
 	name string,
 	res Resource,
-	curCount *metric.Counter,
+	curCount *metric.Gauge,
 	maxHist *metric.Histogram,
 	noteworthy int64,
 ) BytesMonitor {


### PR DESCRIPTION
https://prometheus.io/docs/concepts/metric_types/#counter says that:
> Counters should not be used to expose current counts of items
> whose number can also go down, e.g. the number of currently
> running goroutines. Use gauges for this use case.

We were ignoring this in a few places. This change prevents the
use of `Counter.Dec` and turns all previous users into Gauges.

The change prevents use of `Counter.Dec` by overriding the method and
making it panic with a message to "use a Gauge instead". An alternate
approach would be to unembedded `metrics.Counter` and no longer expose
a `Dec` method. That approach would also be ok, but I think this way
does a better job documenting the issue, preventing regressions, and
avoiding boilerplate required if `metrics.Counter` was unexported.

Release note: None