### PR TITLE
sql: introduce SHOW GRANTS ON ROLE statement.

### DIFF
--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -438,7 +438,8 @@ show_databases_stmt ::=
 	'SHOW' 'DATABASES'
 
 show_grants_stmt ::=
-	'SHOW' 'GRANTS' on_privilege_target_clause for_grantee_clause
+	'SHOW' 'GRANTS' 'ON' 'ROLE' opt_name_list for_grantee_clause
+	| 'SHOW' 'GRANTS' on_privilege_target_clause for_grantee_clause
 
 show_histogram_stmt ::=
 	'SHOW' 'HISTOGRAM' 'ICONST'
@@ -992,12 +993,16 @@ var_value ::=
 	a_expr
 	| 'ON'
 
-on_privilege_target_clause ::=
-	'ON' targets
+opt_name_list ::=
+	name_list
 	| 
 
 for_grantee_clause ::=
 	'FOR' name_list
+	| 
+
+on_privilege_target_clause ::=
+	'ON' targets
 	| 
 
 opt_compact ::=

--- a/pkg/ccl/sqlccl/logictestccl/testdata/logic_test/role
+++ b/pkg/ccl/sqlccl/logictestccl/testdata/logic_test/role
@@ -113,6 +113,12 @@ CREATE USER testuser2
 statement ok
 CREATE ROLE testrole
 
+query TTB colnames
+SHOW GRANTS ON ROLE
+----
+role   member  isAdmin
+admin  root    true
+
 # Test that only roles are grantable.
 statement error pq: role testuser does not exist
 GRANT testuser TO testrole
@@ -136,6 +142,13 @@ GRANT testrole TO testuser
 
 query TTB colnames
 SELECT * FROM system.role_members
+----
+role      member    isAdmin
+admin     root      true
+testrole  testuser  false
+
+query TTB colnames
+SHOW GRANTS ON ROLE
 ----
 role      member    isAdmin
 admin     root      true
@@ -176,6 +189,57 @@ role      member     isAdmin
 admin     root       true
 admin     testuser   false
 testrole  testuser   true
+testrole  testuser2  true
+
+query TTB colnames
+SHOW GRANTS ON ROLE
+----
+role      member     isAdmin
+admin     root       true
+admin     testuser   false
+testrole  testuser   true
+testrole  testuser2  true
+
+query TTB colnames
+SHOW GRANTS ON ROLE admin
+----
+role      member     isAdmin
+admin     root       true
+admin     testuser   false
+
+query TTB colnames
+SHOW GRANTS ON ROLE FOR testuser
+----
+role      member     isAdmin
+admin     testuser   false
+testrole  testuser   true
+
+query TTB colnames
+SHOW GRANTS ON ROLE testrole FOR testuser2
+----
+role      member     isAdmin
+testrole  testuser2  true
+
+query TTB colnames
+SHOW GRANTS ON ROLE foo,testrole
+----
+role      member     isAdmin
+testrole  testuser   true
+testrole  testuser2  true
+
+query TTB colnames
+SHOW GRANTS ON ROLE FOR testuser, testuser2
+----
+role      member     isAdmin
+admin     testuser   false
+testrole  testuser   true
+testrole  testuser2  true
+
+query TTB colnames
+SHOW GRANTS ON ROLE admin, testrole FOR root, testuser2
+----
+role      member     isAdmin
+admin     root       true
 testrole  testuser2  true
 
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/role
+++ b/pkg/sql/logictest/testdata/logic_test/role
@@ -5,3 +5,37 @@ SHOW ROLES
 ----
 username
 admin
+
+query TTB colnames
+SHOW GRANTS ON ROLE
+----
+role   member  isAdmin
+admin  root    true
+
+query TTB colnames
+SHOW GRANTS ON ROLE admin
+----
+role   member  isAdmin
+admin  root    true
+
+query TTB colnames
+SHOW GRANTS ON ROLE FOR root
+----
+role   member  isAdmin
+admin  root    true
+
+query TTB colnames
+SHOW GRANTS ON ROLE admin FOR root
+----
+role   member  isAdmin
+admin  root    true
+
+query TTB colnames
+SHOW GRANTS ON ROLE FOR testuser
+----
+role  member  isAdmin
+
+query TTB colnames
+SHOW GRANTS ON ROLE testuser,admin FOR testuser,admin
+----
+role  member  isAdmin

--- a/pkg/sql/parser/help_test.go
+++ b/pkg/sql/parser/help_test.go
@@ -255,6 +255,10 @@ func TestContextualHelp(t *testing.T) {
 		{`SHOW GRANTS ON foo FOR ??`, `SHOW GRANTS`},
 		{`SHOW GRANTS ON foo FOR bar ??`, `SHOW GRANTS`},
 
+		{`SHOW GRANTS ON ROLE ??`, `SHOW GRANTS`},
+		{`SHOW GRANTS ON ROLE foo FOR ??`, `SHOW GRANTS`},
+		{`SHOW GRANTS ON ROLE foo FOR bar ??`, `SHOW GRANTS`},
+
 		{`SHOW KEYS ??`, `SHOW INDEXES`},
 		{`SHOW INDEX ??`, `SHOW INDEXES`},
 		{`SHOW INDEXES FROM ??`, `SHOW INDEXES`},

--- a/pkg/sql/parser/parse_test.go
+++ b/pkg/sql/parser/parse_test.go
@@ -377,6 +377,12 @@ func TestParse(t *testing.T) {
 		{`SHOW GRANTS ON DATABASE foo FOR bar`},
 		{`SHOW GRANTS FOR bar, baz`},
 
+		{`SHOW GRANTS ON ROLE`},
+		{`SHOW GRANTS ON ROLE foo`},
+		{`SHOW GRANTS ON ROLE foo, bar`},
+		{`SHOW GRANTS ON ROLE foo FOR bar`},
+		{`SHOW GRANTS ON ROLE FOR bar, baz`},
+
 		{`SHOW TRANSACTION STATUS`},
 
 		{`SHOW SYNTAX 'select 1'`},

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -775,7 +775,7 @@ func newNameFromStr(s string) *tree.Name {
 %type <tree.OrderBy> sort_clause opt_sort_clause
 %type <[]*tree.Order> sortby_list
 %type <tree.IndexElemList> index_params
-%type <tree.NameList> name_list privilege_list
+%type <tree.NameList> name_list opt_name_list privilege_list
 %type <[]int32> opt_array_bounds
 %type <*tree.From> from_clause update_from_clause
 %type <tree.TableExprs> from_list
@@ -2721,9 +2721,19 @@ show_databases_stmt:
 
 // %Help: SHOW GRANTS - list grants
 // %Category: Priv
-// %Text: SHOW GRANTS [ON <targets...>] [FOR <users...>]
+// %Text:
+// Show privilege grants:
+//   SHOW GRANTS [ON <targets...>] [FOR <users...>]
+// Show role grants:
+//   SHOW GRANTS ON ROLE [<roles...>] [FOR <grantees...>]
+//
 // %SeeAlso: WEBDOCS/show-grants.html
 show_grants_stmt:
+  SHOW GRANTS ON ROLE opt_name_list for_grantee_clause
+  {
+    $$.val = &tree.ShowRoleGrants{Roles: $5.nameList(), Grantees: $6.nameList()}
+  }
+|
   SHOW GRANTS on_privilege_target_clause for_grantee_clause
   {
     $$.val = &tree.ShowGrants{Targets: $3.targetListPtr(), Grantees: $4.nameList()}
@@ -7039,6 +7049,16 @@ name_list:
 | name_list ',' name
   {
     $$.val = append($1.nameList(), tree.Name($3))
+  }
+
+opt_name_list:
+  name_list
+  {
+    $$.val = $1.nameList()
+  }
+| /* EMPTY */
+  {
+    $$.val = tree.NameList(nil)
   }
 
 // The production for a qualified func_name has to exactly match the production

--- a/pkg/sql/plan.go
+++ b/pkg/sql/plan.go
@@ -652,6 +652,8 @@ func (p *planner) newPlan(
 		return p.ShowQueries(ctx, n)
 	case *tree.ShowJobs:
 		return p.ShowJobs(ctx, n)
+	case *tree.ShowRoleGrants:
+		return p.ShowRoleGrants(ctx, n)
 	case *tree.ShowRoles:
 		return p.ShowRoles(ctx, n)
 	case *tree.ShowSessions:
@@ -773,6 +775,8 @@ func (p *planner) doPrepare(ctx context.Context, stmt tree.Statement) (planNode,
 		return p.ShowQueries(ctx, n)
 	case *tree.ShowJobs:
 		return p.ShowJobs(ctx, n)
+	case *tree.ShowRoleGrants:
+		return p.ShowRoleGrants(ctx, n)
 	case *tree.ShowRoles:
 		return p.ShowRoles(ctx, n)
 	case *tree.ShowSessions:

--- a/pkg/sql/sem/tree/show.go
+++ b/pkg/sql/sem/tree/show.go
@@ -210,6 +210,25 @@ func (node *ShowGrants) Format(ctx *FmtCtx) {
 	}
 }
 
+// ShowRoleGrants represents a SHOW GRANTS ON ROLE statement.
+type ShowRoleGrants struct {
+	Roles    NameList
+	Grantees NameList
+}
+
+// Format implements the NodeFormatter interface.
+func (node *ShowRoleGrants) Format(ctx *FmtCtx) {
+	ctx.WriteString("SHOW GRANTS ON ROLE")
+	if node.Roles != nil {
+		ctx.WriteString(" ")
+		ctx.FormatNode(&node.Roles)
+	}
+	if node.Grantees != nil {
+		ctx.WriteString(" FOR ")
+		ctx.FormatNode(&node.Grantees)
+	}
+}
+
 // ShowCreateTable represents a SHOW CREATE TABLE statement.
 type ShowCreateTable struct {
 	Table NormalizableTableName

--- a/pkg/sql/sem/tree/stmt.go
+++ b/pkg/sql/sem/tree/stmt.go
@@ -700,6 +700,15 @@ func (*ShowJobs) hiddenFromStats()                   {}
 func (*ShowJobs) independentFromParallelizedPriors() {}
 
 // StatementType implements the Statement interface.
+func (*ShowRoleGrants) StatementType() StatementType { return Rows }
+
+// StatementTag returns a short string identifying the type of statement.
+func (*ShowRoleGrants) StatementTag() string { return "SHOW GRANTS ON ROLE" }
+
+func (*ShowRoleGrants) hiddenFromStats()                   {}
+func (*ShowRoleGrants) independentFromParallelizedPriors() {}
+
+// StatementType implements the Statement interface.
 func (*ShowSessions) StatementType() StatementType { return Rows }
 
 // StatementTag returns a short string identifying the type of statement.
@@ -913,6 +922,7 @@ func (n *ShowIndex) String() string                 { return AsString(n) }
 func (n *ShowJobs) String() string                  { return AsString(n) }
 func (n *ShowQueries) String() string               { return AsString(n) }
 func (n *ShowRanges) String() string                { return AsString(n) }
+func (n *ShowRoleGrants) String() string            { return AsString(n) }
 func (n *ShowRoles) String() string                 { return AsString(n) }
 func (n *ShowSessions) String() string              { return AsString(n) }
 func (n *ShowSyntax) String() string                { return AsString(n) }

--- a/pkg/sql/show_role_grants.go
+++ b/pkg/sql/show_role_grants.go
@@ -1,0 +1,62 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package sql
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/lex"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+)
+
+// ShowRoleGrants returns role membership details for the specified roles and grantees.
+// Privileges: SELECT on system.role_members.
+//   Notes: postgres does not have a SHOW GRANTS ON ROLES statement.
+func (p *planner) ShowRoleGrants(ctx context.Context, n *tree.ShowRoleGrants) (planNode, error) {
+	const selectQuery = `SELECT "role", "member", "isAdmin" FROM system.role_members`
+
+	var query bytes.Buffer
+	query.WriteString(selectQuery)
+
+	if n.Roles != nil {
+		var roles []string
+		for _, r := range n.Roles.ToStrings() {
+			roles = append(roles, lex.EscapeSQLString(r))
+		}
+		fmt.Fprintf(&query, ` WHERE "role" IN (%s)`, strings.Join(roles, ","))
+	}
+
+	if n.Grantees != nil {
+		if n.Roles == nil {
+			// No roles specified: we need a WHERE clause.
+			query.WriteString(" WHERE ")
+		} else {
+			// We have a WHERE clause for roles.
+			query.WriteString(" AND ")
+		}
+
+		var grantees []string
+		for _, g := range n.Grantees.ToStrings() {
+			grantees = append(grantees, lex.EscapeSQLString(g))
+		}
+		fmt.Fprintf(&query, ` "member" IN (%s)`, strings.Join(grantees, ","))
+
+	}
+
+	return p.delegateQuery(ctx, "SHOW GRANTS ON ROLES", query.String(), nil, nil)
+}


### PR DESCRIPTION
Part of role-based access control, `SHOW GRANTS ON ROLE` shows the
memberships for the requested roles and members (both optional lists).

Does not require an enterprise license.

Release note (sql change): introduce SHOW GRANTS ON ROLE to list role
memberships