### PR TITLE
sql: support inverted indexes in create table

### DIFF
--- a/docs/generated/sql/bnf/index_def.bnf
+++ b/docs/generated/sql/bnf/index_def.bnf
@@ -11,3 +11,5 @@ index_def ::=
 	| 'UNIQUE' 'INDEX'  '(' index_elem ( ( ',' index_elem ) )* ')' 'COVERING' '(' name_list ')' opt_interleave opt_partition_by
 	| 'UNIQUE' 'INDEX'  '(' index_elem ( ( ',' index_elem ) )* ')' 'STORING' '(' name_list ')' opt_interleave opt_partition_by
 	| 'UNIQUE' 'INDEX'  '(' index_elem ( ( ',' index_elem ) )* ')'  opt_interleave opt_partition_by
+	| 'INVERTED' 'INDEX' name '(' index_elem ( ( ',' index_elem ) )* ')'
+	| 'INVERTED' 'INDEX'  '(' index_elem ( ( ',' index_elem ) )* ')'

--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -1196,6 +1196,7 @@ column_def ::=
 index_def ::=
 	'INDEX' opt_name '(' index_params ')' opt_storing opt_interleave opt_partition_by
 	| 'UNIQUE' 'INDEX' opt_name '(' index_params ')' opt_storing opt_interleave opt_partition_by
+	| 'INVERTED' 'INDEX' opt_name '(' index_params ')'
 
 family_def ::=
 	'FAMILY' opt_name '(' name_list ')'

--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -967,6 +967,9 @@ func MakeTableDesc(
 				Name:             string(d.Name),
 				StoreColumnNames: d.Storing.ToStrings(),
 			}
+			if d.Inverted {
+				idx.Type = sqlbase.IndexDescriptor_INVERTED
+			}
 			if err := idx.FillColumns(d.Columns); err != nil {
 				return desc, err
 			}

--- a/pkg/sql/logictest/testdata/logic_test/inverted_index
+++ b/pkg/sql/logictest/testdata/logic_test/inverted_index
@@ -24,11 +24,40 @@ CREATE INDEX foo_inv2 ON t(b) USING GIN
 statement error pq: syntax error at or near "inverted"
 CREATE UNIQUE INVERTED INDEX foo_inv ON t(b)
 
-statement error pq: syntax error at or near "index"
+statement ok
 CREATE TABLE c (
   id INT PRIMARY KEY,
+  foo JSON,
+  bar JSON,
+  INVERTED INDEX (foo),
+  INVERTED INDEX (bar)
+)
+
+query TT
+SHOW CREATE TABLE c
+----
+c  CREATE TABLE c (
+     id INT NOT NULL,
+     foo JSON NULL,
+     bar JSON NULL,
+     CONSTRAINT "primary" PRIMARY KEY (id ASC),
+     INVERTED INDEX c_foo_idx (foo),
+     INVERTED INDEX c_bar_idx (bar),
+     FAMILY "primary" (id, foo, bar)
+   )
+
+statement error indexing more than one column with an inverted index is not supported
+CREATE TABLE d (
+  id INT PRIMARY KEY,
+  foo JSONB,
+  bar JSONB,
+  INVERTED INDEX (foo, bar)
+)
+
+statement error column foo is of type INT and thus is not indexable with an inverted index
+CREATE TABLE d (
+  id INT PRIMARY KEY,
   foo INT,
-  bar INT,
   INVERTED INDEX (foo)
 )
 
@@ -261,10 +290,10 @@ SELECT * from d where b @> '1.23' ORDER BY a;
 ----
 15  1.23
 
-statement error pq: constraints = , table ID = 53, index ID = 2: can't look up empty JSON
+statement error pq: constraints = , .*: can't look up empty JSON
 SELECT * from d where b @> '{}' ORDER BY a;
 
-statement error pq: constraints = , table ID = 53, index ID = 2: can't look up empty JSON
+statement error pq: constraints = , .*: can't look up empty JSON
 SELECT * from d where b @> '[]' ORDER BY a;
 
 statement ok

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -3387,6 +3387,14 @@ index_def:
       },
     }
   }
+| INVERTED INDEX opt_name '(' index_params ')'
+  {
+    $$.val = &tree.IndexTableDef{
+      Name:    tree.Name($3),
+      Columns: $5.idxElems(),
+      Inverted: true,
+    }
+  }
 
 family_def:
   FAMILY opt_name '(' name_list ')'

--- a/pkg/sql/sqlbase/structured.go
+++ b/pkg/sql/sqlbase/structured.go
@@ -283,8 +283,10 @@ func (desc *IndexDescriptor) ColNamesFormat(ctx *tree.FmtCtxWithBuf) {
 			ctx.WriteString(", ")
 		}
 		ctx.FormatNameP(&desc.ColumnNames[i])
-		ctx.WriteByte(' ')
-		ctx.WriteString(desc.ColumnDirections[i].String())
+		if desc.Type != IndexDescriptor_INVERTED {
+			ctx.WriteByte(' ')
+			ctx.WriteString(desc.ColumnDirections[i].String())
+		}
 	}
 }
 
@@ -302,6 +304,9 @@ func (desc *IndexDescriptor) SQLString(tableName string) string {
 	f := tree.NewFmtCtxWithBuf(tree.FmtSimple)
 	if desc.Unique {
 		f.WriteString("UNIQUE ")
+	}
+	if desc.Type == IndexDescriptor_INVERTED {
+		f.WriteString("INVERTED ")
 	}
 	f.WriteString("INDEX ")
 	if tableName != "" {


### PR DESCRIPTION
Fixes #21790.

This was required in order to be able to correctly support SHOW CREATE
TABLE and other related functionality, like DUMP.

Release note (sql change): JSON inverted indexes may now be specified in
a CREATE TABLE statement.