### PR TITLE
ui: Add graphs for compactor queued bytes and processing time

### DIFF
--- a/pkg/storage/compactor/compactor.go
+++ b/pkg/storage/compactor/compactor.go
@@ -307,10 +307,11 @@ func (c *Compactor) processCompaction(
 		startTime := timeutil.Now()
 		log.Eventf(ctx, "processing compaction %s", aggr)
 		if err := c.eng.CompactRange(aggr.StartKey, aggr.EndKey, false /* forceBottommost */); err != nil {
+			c.Metrics.CompactionFailures.Inc(1)
 			return 0, errors.Wrapf(err, "unable to compact range %+v", aggr)
 		}
 		c.Metrics.BytesCompacted.Inc(aggr.Bytes)
-		c.Metrics.Compactions.Inc(1)
+		c.Metrics.CompactionSuccesses.Inc(1)
 		duration := timeutil.Since(startTime)
 		c.Metrics.CompactingNanos.Inc(int64(duration))
 		log.Eventf(ctx, "processed compaction %s in %s", aggr, duration)

--- a/pkg/storage/compactor/compactor_test.go
+++ b/pkg/storage/compactor/compactor_test.go
@@ -453,7 +453,7 @@ func TestCompactorThresholds(t *testing.T) {
 				if a, e := compactor.Metrics.BytesCompacted.Count(), test.expBytesCompacted; a != e {
 					return fmt.Errorf("expected bytes compacted %d; got %d", e, a)
 				}
-				if a, e := compactor.Metrics.Compactions.Count(), int64(len(test.expCompactions)); a != e {
+				if a, e := compactor.Metrics.CompactionSuccesses.Count(), int64(len(test.expCompactions)); a != e {
 					return fmt.Errorf("expected compactions %d; got %d", e, a)
 				}
 				if len(test.expCompactions) == 0 {

--- a/pkg/storage/compactor/metrics.go
+++ b/pkg/storage/compactor/metrics.go
@@ -18,11 +18,12 @@ import "github.com/cockroachdb/cockroach/pkg/util/metric"
 
 // Metrics holds all metrics relating to a Compactor.
 type Metrics struct {
-	BytesQueued     *metric.Gauge
-	BytesSkipped    *metric.Counter
-	BytesCompacted  *metric.Counter
-	Compactions     *metric.Counter
-	CompactingNanos *metric.Counter
+	BytesQueued         *metric.Gauge
+	BytesSkipped        *metric.Counter
+	BytesCompacted      *metric.Counter
+	CompactionSuccesses *metric.Counter
+	CompactionFailures  *metric.Counter
+	CompactingNanos     *metric.Counter
 }
 
 // MetricStruct implements the metrics.Struct interface.
@@ -40,9 +41,12 @@ var (
 	metaBytesCompacted = metric.Metadata{
 		Name: "compactor.suggestionbytes.compacted",
 		Help: "Number of logical bytes compacted from suggested compactions"}
-	metaCompactions = metric.Metadata{
-		Name: "compactor.compactions",
-		Help: "Number of compaction requests sent to the storage engine"}
+	metaCompactionSuccesses = metric.Metadata{
+		Name: "compactor.compactions.success",
+		Help: "Number of successful compaction requests sent to the storage engine"}
+	metaCompactionFailures = metric.Metadata{
+		Name: "compactor.compactions.failure",
+		Help: "Number of failed compaction requests sent to the storage engine"}
 	metaCompactingNanos = metric.Metadata{
 		Name: "compactor.compactingnanos",
 		Help: "Number of nanoseconds spent compacting ranges"}
@@ -51,10 +55,11 @@ var (
 // makeMetrics returns a Metrics struct.
 func makeMetrics() Metrics {
 	return Metrics{
-		BytesQueued:     metric.NewGauge(metaBytesQueued),
-		BytesSkipped:    metric.NewCounter(metaBytesSkipped),
-		BytesCompacted:  metric.NewCounter(metaBytesCompacted),
-		Compactions:     metric.NewCounter(metaCompactions),
-		CompactingNanos: metric.NewCounter(metaCompactingNanos),
+		BytesQueued:         metric.NewGauge(metaBytesQueued),
+		BytesSkipped:        metric.NewCounter(metaBytesSkipped),
+		BytesCompacted:      metric.NewCounter(metaBytesCompacted),
+		CompactionSuccesses: metric.NewCounter(metaCompactionSuccesses),
+		CompactionFailures:  metric.NewCounter(metaCompactionFailures),
+		CompactingNanos:     metric.NewCounter(metaCompactingNanos),
 	}
 }

--- a/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/queues.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/queues.tsx
@@ -19,6 +19,7 @@ export default function (props: GraphDashboardProps) {
         <Metric name="cr.store.queue.raftlog.process.failure" title="Raft Log" nonNegativeRate />
         <Metric name="cr.store.queue.raftsnapshot.process.failure" title="Raft Snapshot" nonNegativeRate />
         <Metric name="cr.store.queue.tsmaintenance.process.failure" title="Time Series Maintenance" nonNegativeRate />
+        <Metric name="cr.store.compactor.compactions.failure" title="Compaction" nonNegativeRate />
       </Axis>
     </LineGraph>,
 
@@ -32,6 +33,7 @@ export default function (props: GraphDashboardProps) {
         <Metric name="cr.store.queue.raftlog.processingnanos" title="Raft Log" nonNegativeRate />
         <Metric name="cr.store.queue.raftsnapshot.processingnanos" title="Raft Snapshot" nonNegativeRate />
         <Metric name="cr.store.queue.tsmaintenance.processingnanos" title="Time Series Maintenance" nonNegativeRate />
+        <Metric name="cr.store.compactor.compactingnanos" title="Compaction" nonNegativeRate />
       </Axis>
     </LineGraph>,
 
@@ -98,6 +100,17 @@ export default function (props: GraphDashboardProps) {
       <Axis units={AxisUnits.Count} label="actions">
         <Metric name="cr.store.queue.tsmaintenance.process.success" title="Successful Actions / sec" nonNegativeRate />
         <Metric name="cr.store.queue.tsmaintenance.pending" title="Pending Actions" downsampleMax />
+      </Axis>
+    </LineGraph>,
+
+    <LineGraph
+      title="Compaction Queue"
+      sources={storeSources}
+      tooltip={`The completed (or estimated) bytes of storage that were (or could be) reclaimed by forcing RocksDB compactions.`}
+    >
+      <Axis units={AxisUnits.Bytes} label="bytes">
+        <Metric name="cr.store.compactor.suggestionbytes.compacted" title="Bytes compacted / sec" nonNegativeRate />
+        <Metric name="cr.store.compactor.suggestionbytes.queued" title="Queued bytes" downsampleMax />
       </Axis>
     </LineGraph>,
   ];


### PR DESCRIPTION
These seem to be the most important metrics - queued bytes give an
indication of how much disk could be saved by running manual
compactions, and processing nanos give an indication of when manual
compactions have run and how long they took.

It'd be nice if we could just work this stuff into the queue graphs more
directly, but processing time is the only thing that's directly shared,
since the compactor operates on bytes while all the existing queues
operate on replicas.

Release note (admin ui change): Add graphs for compactor queued bytes
and processing time.