### PR TITLE
ui: fix styling for the expandable rows in the jobs table

### DIFF
--- a/pkg/ui/assets/collapse.svg
+++ b/pkg/ui/assets/collapse.svg
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="16px" height="16px" viewBox="0 0 16 16" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 48.2 (47327) - http://www.bohemiancoding.com/sketch -->
+    <title>jobs_collapse_normal</title>
+    <desc>Created with Sketch.</desc>
+    <defs></defs>
+    <g id="Symbols" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="jobs_collapse_normal">
+            <g id="Expand-icon">
+                <rect id="Rectangle-14" fill="#C8CBD4" x="0" y="0" width="16" height="16" rx="8"></rect>
+                <g id="select-83" transform="translate(5.714286, 3.428571)" fill="#FFFFFF" fill-rule="nonzero">
+                    <polygon id="Shape" transform="translate(2.285714, 2.250729) scale(1, -1) translate(-2.285714, -2.250729) " points="0 3.93002915 4.57142857 3.93002915 2.28571429 0.571428571"></polygon>
+                    <polygon id="Shape" transform="translate(2.285714, 7.250729) scale(1, -1) translate(-2.285714, -7.250729) " points="2.28571429 8.93002915 4.57142857 5.57142857 0 5.57142857"></polygon>
+                </g>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/pkg/ui/assets/expand.svg
+++ b/pkg/ui/assets/expand.svg
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="16px" height="16px" viewBox="0 0 16 16" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 48.2 (47327) - http://www.bohemiancoding.com/sketch -->
+    <title>Expand icon</title>
+    <desc>Created with Sketch.</desc>
+    <defs></defs>
+    <g id="Expand-job-B" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" transform="translate(-725.000000, -207.000000)">
+        <g id="Expand-icon" transform="translate(725.000000, 207.000000)">
+            <rect id="Rectangle-14" fill="#C8CBD4" x="0" y="0" width="16" height="16" rx="8"></rect>
+            <g id="select-83" transform="translate(5.714286, 3.428571)" fill="#FFFFFF" fill-rule="nonzero">
+                <polygon id="Shape" points="0 3.35860058 4.57142857 3.35860058 2.28571429 0"></polygon>
+                <polygon id="Shape" points="2.28571429 9.14285714 4.57142857 5.78425656 0 5.78425656"></polygon>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/pkg/ui/src/views/shared/components/expandableString/expandable.styl
+++ b/pkg/ui/src/views/shared/components/expandableString/expandable.styl
@@ -1,0 +1,17 @@
+@require "~styl/base/palette.styl"
+
+.expandable
+  cursor pointer
+  width 100%
+  height 100%
+  display flex
+  justify-content space-between
+  align-items center
+
+  .expandable__icon
+    flex 0 0 auto
+    padding-left 10px
+    line-height 0
+
+  &:hover .expandable__icon rect
+    fill $link-color

--- a/pkg/ui/src/views/shared/components/expandableString/index.tsx
+++ b/pkg/ui/src/views/shared/components/expandableString/index.tsx
@@ -1,10 +1,14 @@
+import _ from "lodash";
 import React from "react";
 
 import { trustIcon } from "src/util/trust";
 
+import collapseIcon from "!!raw-loader!assets/collapse.svg";
 import expandIcon from "!!raw-loader!assets/expand.svg";
 
 import "./expandable.styl";
+
+const truncateLength = 50;
 
 interface ExpandableStringProps {
   short?: string;
@@ -25,22 +29,36 @@ export class ExpandableString extends React.Component<ExpandableStringProps, Exp
 
   onClick = (ev: any) => {
     ev.preventDefault();
-    this.setState({ expanded: true });
+    this.setState({ expanded: !this.state.expanded });
   }
 
-  render() {
-    const truncateLength = 50;
-
-    if (this.state.expanded || this.props.long.length <= truncateLength + 2) {
-      return <span>{ this.props.long }</span>;
+  renderText(expanded: boolean) {
+    if (expanded) {
+      return (
+        <span className="expandable__text expandable__text--expanded">{ this.props.long }</span>
+      );
     }
 
     const short = this.props.short || this.props.long.substr(0, truncateLength).trim();
+    return (
+      <span className="expandable__text">{ short }&nbsp;&hellip;</span>
+    );
+  }
 
+  render() {
+    const { short, long } = this.props;
+
+    const neverCollapse = _.isNil(short) && long.length <= truncateLength + 2;
+    if (neverCollapse) {
+      return <span>this.props.long</span>;
+    }
+
+    const { expanded } = this.state;
+    const icon = expanded ? collapseIcon : expandIcon;
     return (
       <div className="expandable" onClick={ this.onClick }>
-        <span className="expandable__text">{ short }&nbsp;&hellip;</span>
-        <span className="expandable__icon" dangerouslySetInnerHTML={ trustIcon(expandIcon) } />
+        { this.renderText(expanded) }
+        <span className="expandable__icon" dangerouslySetInnerHTML={ trustIcon(icon) } />
       </div>
     );
   }

--- a/pkg/ui/src/views/shared/components/expandableString/index.tsx
+++ b/pkg/ui/src/views/shared/components/expandableString/index.tsx
@@ -22,18 +22,23 @@ export class ExpandableString extends React.Component<ExpandableStringProps, Exp
   state: ExpandableStringState = {
     expanded: false,
   };
+
   onClick = (ev: any) => {
     ev.preventDefault();
     this.setState({ expanded: true });
   }
+
   render() {
     const truncateLength = 50;
+
     if (this.state.expanded || this.props.long.length <= truncateLength + 2) {
-      return <span>{this.props.long}</span>;
+      return <span>{ this.props.long }</span>;
     }
+
     const short = this.props.short || this.props.long.substr(0, truncateLength).trim();
+
     return (
-      <div className="expandable" onClick={this.onClick}>
+      <div className="expandable" onClick={ this.onClick }>
         <span className="expandable__text">{ short }&nbsp;&hellip;</span>
         <span className="expandable__icon" dangerouslySetInnerHTML={ trustIcon(expandIcon) } />
       </div>

--- a/pkg/ui/src/views/shared/components/expandableString/index.tsx
+++ b/pkg/ui/src/views/shared/components/expandableString/index.tsx
@@ -1,5 +1,11 @@
 import React from "react";
 
+import { trustIcon } from "src/util/trust";
+
+import expandIcon from "!!raw-loader!assets/expand.svg";
+
+import "./expandable.styl";
+
 interface ExpandableStringProps {
   short?: string;
   long: string;
@@ -27,12 +33,10 @@ export class ExpandableString extends React.Component<ExpandableStringProps, Exp
     }
     const short = this.props.short || this.props.long.substr(0, truncateLength).trim();
     return (
-      <span>
-        {short}
-        <a href="#" onClick={this.onClick}>
-          &hellip;
-        </a>
-      </span>
+      <div className="expandable" onClick={this.onClick}>
+        <span className="expandable__text">{ short }&nbsp;&hellip;</span>
+        <span className="expandable__icon" dangerouslySetInnerHTML={ trustIcon(expandIcon) } />
+      </div>
     );
   }
 }


### PR DESCRIPTION
expandable
<img width="699" alt="screen shot 2018-01-30 at 3 00 59 pm" src="https://user-images.githubusercontent.com/793969/35588398-8e12aa9c-05ce-11e8-9345-6e47bb04b180.png">
expandable, hover
<img width="745" alt="screen shot 2018-01-30 at 3 01 02 pm" src="https://user-images.githubusercontent.com/793969/35588399-8e2943f6-05ce-11e8-8673-245e561db77d.png">
collapsable
<img width="739" alt="screen shot 2018-01-30 at 3 01 07 pm" src="https://user-images.githubusercontent.com/793969/35588400-8e35bf8c-05ce-11e8-8785-ef4aa228e601.png">
collapsable, hover
<img width="837" alt="screen shot 2018-01-30 at 3 01 10 pm" src="https://user-images.githubusercontent.com/793969/35588401-8e449d90-05ce-11e8-84cc-69b11882d872.png">
