### PR TITLE
ui: show dead node list first

### DIFF
--- a/pkg/ui/src/views/cluster/containers/nodesOverview/index.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodesOverview/index.tsx
@@ -346,8 +346,8 @@ class NodesMain extends React.Component<NodesMainProps, {}> {
 
   render() {
     return <div>
-      <LiveNodesConnected />
       <DeadNodesConnected />
+      <LiveNodesConnected />
       <DecommissionedNodesConnected />
     </div>;
   }


### PR DESCRIPTION
Release note (admin ui change): When there are dead nodes, show them first on
the node list page, above the live nodes.

<img width="852" alt="screen shot 2018-01-30 at 3 35 53 pm" src="https://user-images.githubusercontent.com/793969/35589915-4a6fc950-05d3-11e8-950a-72e7fdca747d.png">
