### PR TITLE
sql: normalize -> expression to use @> when valid

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/inverted_index
+++ b/pkg/sql/logictest/testdata/logic_test/inverted_index
@@ -327,3 +327,28 @@ query IT
 SELECT * from d where b @> '[[[["a"]]]]' ORDER BY a;
 ----
 22  [[[["a"]]],[[["a"]]]]
+
+query IT
+SELECT * from d where b->'a' = '"b"'
+----
+7  {"a":"b","c":"d"}
+
+query TITTTTT
+EXPLAIN (VERBOSE) SELECT * from d where b->'a' = '"b"'
+----
+index-join  0  index-join  ·      ·                                        (a, b)           b=CONST; a!=NULL; key(a)
+ ├── scan   1  scan        ·      ·                                        (a, b[omitted])  b=CONST; a!=NULL; key(a)
+ │          1  ·           table  d@foo_inv                                ·                ·
+ │          1  ·           spans  /!NULL/"a"/"b"-/!NULL/"a"/"b"/PrefixEnd  ·                ·
+ └── scan   1  scan        ·      ·                                        (a, b)           ·
+·           1  ·           table  d@primary                                ·                ·
+
+query TITTTTT
+EXPLAIN (VERBOSE) SELECT * from d where '"b"' = b->'a'
+----
+index-join  0  index-join  ·      ·                                        (a, b)           b=CONST; a!=NULL; key(a)
+ ├── scan   1  scan        ·      ·                                        (a, b[omitted])  b=CONST; a!=NULL; key(a)
+ │          1  ·           table  d@foo_inv                                ·                ·
+ │          1  ·           spans  /!NULL/"a"/"b"-/!NULL/"a"/"b"/PrefixEnd  ·                ·
+ └── scan   1  scan        ·      ·                                        (a, b)           ·
+·           1  ·           table  d@primary                                ·                ·

--- a/pkg/sql/sem/tree/normalize.go
+++ b/pkg/sql/sem/tree/normalize.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/coltypes"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
+	"github.com/cockroachdb/cockroach/pkg/util/json"
 )
 
 type normalizableExpr interface {
@@ -288,7 +289,6 @@ func (expr *ComparisonExpr) normalize(v *NormalizeVisitor) TypedExpr {
 			if !ok {
 				return expr
 			}
-
 			// The right is const and the left side is a binary expression. Rotate the
 			// comparison combining portions that are const.
 
@@ -418,6 +418,36 @@ func (expr *ComparisonExpr) normalize(v *NormalizeVisitor) TypedExpr {
 					// variable.
 					continue
 				}
+
+			case expr.Operator == EQ && left.Operator == FetchVal && v.isConst(left.Right) &&
+				v.isConst(expr.Right):
+				// This is a JSONB inverted index normalization, changing things of the form
+				// x->y=z to x @> {y:z} which can be used to build spans for inverted index
+				// lookups.
+
+				if left.TypedRight().ResolvedType() != types.String {
+					break
+				}
+
+				str, err := left.TypedRight().Eval(v.ctx)
+				if err != nil {
+					break
+				}
+
+				j := json.NewObjectBuilder(1)
+				j.Add(string(*str.(*DString)), expr.Right.(*DJSON).JSON)
+
+				dj, err := MakeDJSON(j.Build())
+				if err != nil {
+					break
+				}
+
+				typedJ, err := dj.TypeCheck(nil, types.JSON)
+				if err != nil {
+					break
+				}
+
+				return NewTypedComparisonExpr(Contains, left.TypedLeft(), typedJ)
 			}
 
 			// We've run out of work to do.

--- a/pkg/sql/sem/tree/normalize_test.go
+++ b/pkg/sql/sem/tree/normalize_test.go
@@ -26,11 +26,13 @@ import (
 
 func TestNormalizeExpr(t *testing.T) {
 	defer tree.MockNameTypes(map[string]types.T{
-		"a": types.Int,
-		"b": types.Int,
-		"c": types.Int,
-		"d": types.Bool,
-		"s": types.String,
+		"a":  types.Int,
+		"b":  types.Int,
+		"c":  types.Int,
+		"d":  types.Bool,
+		"s":  types.String,
+		"j":  types.JSON,
+		"jv": types.JSON,
 	})()
 	testData := []struct {
 		expr     string
@@ -216,6 +218,11 @@ func TestNormalizeExpr(t *testing.T) {
 		{`a - 1 < 9223372036854775806`, `a < 9223372036854775807`},
 		{`-1 + a < 9223372036854775807`, `(-1 + a) < 9223372036854775807`},
 		{`-1 + a < 9223372036854775806`, `a < 9223372036854775807`},
+		{`j->'s' = '"jv"'::JSONB`, `j @> '{"s":"jv"}'`},
+		{`'"jv"'::JSONB = j->'s'`, `j @> '{"s":"jv"}'`},
+		{`j->'s' = jv`, `(j->'s') = jv`},
+		{`j->s = jv`, `(j->s) = jv`},
+		{`j->2 = '"jv"'::JSONB`, `(j->2) = '"jv"'`},
 	}
 	for _, d := range testData {
 		expr, err := parser.ParseExpr(d.expr)


### PR DESCRIPTION
Before for expressions of the form x->y=z in a where clause we would do
a full index scan.

Now we will convert expression above to x @> {y:z} for which we can just
do a regular inverted index lookup.

Closes: #21784

Release note: None