### PR TITLE
gceworker: learn to sync files

### DIFF
--- a/build/bootstrap/autoshutdown.cron.sh
+++ b/build/bootstrap/autoshutdown.cron.sh
@@ -27,7 +27,7 @@ FILE=/dev/shm/autoshutdown-count
 COUNT=0
 
 
-if [ -f /.active ] || w -hs | grep pts | grep -vq "pts/[0-9]* *tmux"; then
+if [ -f /.active ] || w -hs | grep pts | grep -vq "pts/[0-9]* *tmux" || pgrep unison; then
   # Auto-shutdown is disabled (via /.active) or there is a remote session.
   echo 0 > $FILE
   exit 0

--- a/build/bootstrap/bootstrap-debian.sh
+++ b/build/bootstrap/bootstrap-debian.sh
@@ -35,3 +35,4 @@ mkdir -p "$GOPATH/src/github.com/cockroachdb"
 git clone https://github.com/cockroachdb/cockroach.git "$GOPATH/src/github.com/cockroachdb/cockroach"
 
 . bootstrap/bootstrap-go.sh
+. bootstrap/bootstrap-unison.sh

--- a/build/bootstrap/bootstrap-unison.sh
+++ b/build/bootstrap/bootstrap-unison.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+#
+# On a Debian/Ubuntu system, bootstraps the Unison file-syncer.
+
+set -euxo pipefail
+
+sudo apt-get install -y --no-install-recommends ocaml-nox
+
+# Ubuntu's "unison" package does not ship unison-fsmonitor, which is needed for
+# the "-repeat watch" option to function properly.
+git clone --branch=unison-2.48 https://github.com/bcpierce00/unison
+(cd unison && git cherry-pick -n c64b007ca0c20e1cea94a79b82d7c415aa3729eb && make)
+for bin in unison unison-fsmonitor; do
+  sudo install -m 755 "unison/src/$bin" "/usr/local/bin/$bin"
+done
+
+echo fs.inotify.max_user_watches=524288 | sudo tee /etc/sysctl.d/60-max-user-watches.conf
+sudo service procps restart
+
+echo "UNISONLOCALHOSTNAME=$(hostname)-$(date +%Y%m%d-%H%M%S)" | sudo tee -a /etc/environment

--- a/scripts/gceworker.sh
+++ b/scripts/gceworker.sh
@@ -6,7 +6,14 @@ export CLOUDSDK_CORE_PROJECT=${CLOUDSDK_CORE_PROJECT-${GCEWORKER_PROJECT-cockroa
 export CLOUDSDK_COMPUTE_ZONE=${GCEWORKER_ZONE-${CLOUDSDK_COMPUTE_ZONE-us-east1-b}}
 NAME=${GCEWORKER_NAME-gceworker-$(id -un)}
 
-case ${1-} in
+cd "$(dirname "$0")/.."
+
+cmd=${1-}
+if [[ "${cmd}" ]]; then
+  shift
+fi
+
+case "${cmd}" in
     create)
     gcloud compute instances \
            create "${NAME}" \
@@ -23,7 +30,7 @@ case ${1-} in
     # Retry while vm and sshd to start up.
     "$(dirname "${0}")/travis_retry.sh" gcloud compute ssh "${NAME}" --command=true
 
-    gcloud compute copy-files "$(dirname "${0}")/../build/bootstrap" "${NAME}:bootstrap"
+    gcloud compute copy-files "build/bootstrap" "${NAME}:bootstrap"
     gcloud compute ssh "${NAME}" --ssh-flag="-A" --command="./bootstrap/bootstrap-debian.sh"
 
     # Install automatic shutdown after ten minutes of operation without a
@@ -41,11 +48,43 @@ case ${1-} in
     gcloud compute instances delete "${NAME}"
     ;;
     ssh)
-    shift
     gcloud compute ssh "${NAME}" --ssh-flag="-A" "$@"
     ;;
+    sync)
+    if ! hash unison 2>/dev/null; then
+      echo 'unison not found (on macOS, run `brew install unison`)' >&2
+      exit 1
+    fi
+    if ! hash unison-fsmonitor 2>/dev/null; then
+      echo 'unison-fsmonitor not installed (on macOS, run `brew install eugenmayer/dockersync/unox`)'
+      exit 1
+    fi
+    if (( $# == 0 )); then
+      host=.  # Sync the Cockroach repo by default.
+      worker=go/src/github.com/cockroachdb/cockroach
+    elif (( $# == 2 )); then
+      host=$1
+      worker=$2
+    else
+      echo "usage: $0 mount [HOST-PATH WORKER-PATH]" >&2
+      exit 1
+    fi
+    read -p "Warning: sync will overwrite files on the GCE worker with your local copy. Continue? (Y/n) "
+    if [[ "$REPLY" && "$REPLY" != [Yy] ]]; then
+      exit 1
+    fi
+    tmpfile=$(mktemp)
+    trap 'rm -f ${tmpfile}' EXIT
+    gcloud compute config-ssh --ssh-config-file "$tmpfile" > /dev/null
+    unison "$host" "ssh://${NAME}.${CLOUDSDK_COMPUTE_ZONE}.${CLOUDSDK_CORE_PROJECT}/$worker" \
+      -sshargs "-F ${tmpfile}" -auto -prefer "$host" -repeat watch \
+      -ignore 'Path bin*' \
+      -ignore 'Path build/builder_home' \
+      -ignore 'Path pkg/sql/parser/gen' \
+      -ignore 'Name zcgo_flags*.go'
+    ;;
     *)
-    echo "$0: unknown command: ${1-}, use one of create, start, stop, delete, or ssh"
+    echo "$0: unknown command: ${cmd}, use one of create, start, stop, delete, ssh, or sync"
     exit 1
     ;;
 esac


### PR DESCRIPTION
Teach the GCE worker a sync command, which uses Unison to perform
bidirectional syncing of the CockroachDB repo. This makes the GCE
development workflow quite pleasant.

This is an extension of #8981, which used SSHFS to similar effect.
Unison is far more performant than SSHFS, if a bit more complicated to
set up. SSHFS has to hit the network to service every filesystem
request, making builds excruciatingly slow, whereas Unison maintains a
full "replica" of the synced folder on each machine and syncs the
replicas when notified of changes by either filesystem.

Release note: None