### PR TITLE
workloadccl: chunk and concurrency write CSVs in fixture store

### DIFF
--- a/pkg/cmd/workload/fixtures.go
+++ b/pkg/cmd/workload/fixtures.go
@@ -148,7 +148,7 @@ func fixturesStore(cmd *cobra.Command, gen workload.Generator, crdbURI string) e
 		return err
 	}
 	for _, table := range fixture.Tables {
-		log.Infof(ctx, `stored %s`, table.BackupURI)
+		log.Infof(ctx, `stored backup %s`, table.BackupURI)
 	}
 	return nil
 }

--- a/pkg/testutils/lint/lint_test.go
+++ b/pkg/testutils/lint/lint_test.go
@@ -831,6 +831,7 @@ func TestLint(t *testing.T) {
 			stream.GrepNot(`cockroach/pkg/(server/serverpb|ts/tspb): github\.com/golang/protobuf/proto$`),
 			stream.GrepNot(`cockroach/pkg/util/caller: path$`),
 			stream.GrepNot(`cockroach/pkg/ccl/storageccl: path$`),
+			stream.GrepNot(`cockroach/pkg/ccl/workloadccl: path$`),
 			stream.GrepNot(`cockroach/pkg/util/uuid: github\.com/satori/go\.uuid$`),
 		), func(s string) {
 			pkgStr := strings.Split(s, ": ")

--- a/pkg/workload/bank/bank.go
+++ b/pkg/workload/bank/bank.go
@@ -100,12 +100,12 @@ func (b *bank) Flags() *pflag.FlagSet {
 
 // Tables implements the Generator interface.
 func (b *bank) Tables() []workload.Table {
-	rng := rand.New(rand.NewSource(b.seed))
 	table := workload.Table{
 		Name:            `bank`,
 		Schema:          bankSchema,
 		InitialRowCount: b.rows,
 		InitialRowFn: func(rowIdx int) []interface{} {
+			rng := rand.New(rand.NewSource(b.seed + int64(rowIdx)))
 			const initialPrefix = `initial-`
 			bytes := hex.EncodeToString(randutil.RandBytes(rng, b.payloadBytes/2))
 			// Minus 2 for the single quotes

--- a/pkg/workload/tpcc/tpcc.go
+++ b/pkg/workload/tpcc/tpcc.go
@@ -48,6 +48,7 @@ var tpccMeta = workload.Meta{
 	Name: `tpcc`,
 	Description: `TPC-C simulates a transaction processing workload` +
 		` using a rich schema of multiple tables`,
+	Version: `1.0.0`,
 	New: func() workload.Generator {
 		g := &tpcc{flags: pflag.NewFlagSet(`tpcc`, pflag.ContinueOnError)}
 		g.flags.Int64Var(&g.seed, `seed`, 1, `Random number generator seed`)


### PR DESCRIPTION
For each table, first write out a chunk of the given size. If the table
fits in one chunk, we're done, otherwise this gives an estimate for how
many rows are needed. Based on this, figure out how many chunks are
needed to finish the table. Then break up the remaining rows into that
many chunks, running this whole process recursively in case the
distribution of row size is not uniform.

Do this concurrently for all tables, but with the total limit on the
concurrency of csv chunk writers (to prevent thrashing of the network).

On a gceworker, this writes 10GB of CSVs in 73s (~136MB/s):

    ./workload run bank --rows=10000000 --payload-bytes=1024

Release note: None