### PR TITLE
sql: fix implementation of encode and decode

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -595,7 +595,7 @@ Compatible elements: hour, minute, second, millisecond, microsecond.</p>
 <tr><td><code>concat_ws(<a href="string.html">string</a>...) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Uses the first argument as a separator between the concatenation of the subsequent arguments.</p>
 <p>For example <code>concat_ws('!','wow','great')</code> returns <code>wow!great</code>.</p>
 </span></td></tr>
-<tr><td><code>decode(text: <a href="string.html">string</a>, format: <a href="string.html">string</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Decodes <code>data</code> as the format specified by <code>format</code> (only “hex” is supported).</p>
+<tr><td><code>decode(text: <a href="string.html">string</a>, format: <a href="string.html">string</a>) &rarr; <a href="bytes.html">bytes</a></code></td><td><span class="funcdesc"><p>Decodes <code>data</code> as the format specified by <code>format</code> (only “hex” is supported).</p>
 </span></td></tr>
 <tr><td><code>encode(data: <a href="bytes.html">bytes</a>, format: <a href="string.html">string</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Encodes <code>data</code> in the text format specified by <code>format</code> (only “hex” is supported).</p>
 </span></td></tr>

--- a/pkg/sql/logictest/testdata/logic_test/builtin_function
+++ b/pkg/sql/logictest/testdata/logic_test/builtin_function
@@ -1349,9 +1349,9 @@ query error invalid UTF-8
 SELECT ENCODE('\xa7', 'hex')
 
 query TT
-SELECT ENCODE('\x616263', 'hex'), DECODE('abc', 'hex')
+SELECT ENCODE('abc', 'hex'), DECODE('616263', 'hex')
 ----
-abc 616263
+616263 abc
 
 query T
 SELECT FROM_IP(b'\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xff\xff\x01\x02\x03\x04')


### PR DESCRIPTION
Fixes #20814.

I think I confused myself when I initially implemented these - got
tripped up by the different ways psql and cockroach --sql display BYTES
values. I only used psql for this so I think I've got it now!

Release note (bug fix): Fix behaviour and types of ENCODE and DECODE.