### PR TITLE
storage: avoid client-side retries on CPut/Inc write-too-old errors

### DIFF
--- a/pkg/kv/dist_sender_server_test.go
+++ b/pkg/kv/dist_sender_server_test.go
@@ -1833,7 +1833,7 @@ func TestTxnCoordSenderRetries(t *testing.T) {
 					return nil
 				}
 				pErr := roachpb.NewReadWithinUncertaintyIntervalError(
-					fArgs.Hdr.Timestamp, fArgs.Hdr.Timestamp.Add(1, 0), fArgs.Hdr.Txn)
+					fArgs.Hdr.Timestamp, s.Clock().Now(), fArgs.Hdr.Txn)
 				return roachpb.NewErrorWithTxn(pErr, fArgs.Hdr.Txn)
 			}
 			return nil
@@ -1853,6 +1853,7 @@ func TestTxnCoordSenderRetries(t *testing.T) {
 		retryable      func(context.Context, *client.Txn) error // called during the txn; may be retried
 		filter         func(storagebase.FilterArgs) *roachpb.Error
 		txnCoordRetry  bool
+		expFailure     string // regexp pattern to match on error if not empty
 	}{
 		{
 			name: "forwarded timestamp with get and put",
@@ -1863,7 +1864,6 @@ func TestTxnCoordSenderRetries(t *testing.T) {
 			retryable: func(ctx context.Context, txn *client.Txn) error {
 				return txn.Put(ctx, "a", "put") // put to advance txn ts
 			},
-			filter:        nil,
 			txnCoordRetry: true,
 		},
 		{
@@ -1875,7 +1875,6 @@ func TestTxnCoordSenderRetries(t *testing.T) {
 			retryable: func(ctx context.Context, txn *client.Txn) error {
 				return txn.InitPut(ctx, "a", "put", false) // put to advance txn ts
 			},
-			filter:        nil,
 			txnCoordRetry: true,
 		},
 		{
@@ -1898,7 +1897,6 @@ func TestTxnCoordSenderRetries(t *testing.T) {
 				}
 				return nil
 			},
-			filter:        nil,
 			txnCoordRetry: false,
 		},
 		{
@@ -1910,7 +1908,6 @@ func TestTxnCoordSenderRetries(t *testing.T) {
 			retryable: func(ctx context.Context, txn *client.Txn) error {
 				return txn.CPut(ctx, "a", "cput", "put") // cput to advance txn ts, set update span
 			},
-			filter:        nil,
 			txnCoordRetry: true,
 		},
 		{
@@ -1922,7 +1919,6 @@ func TestTxnCoordSenderRetries(t *testing.T) {
 			retryable: func(ctx context.Context, txn *client.Txn) error {
 				return txn.CPut(ctx, "ab", "cput", nil) // cput advances, sets update span
 			},
-			filter:        nil,
 			txnCoordRetry: true,
 		},
 		{
@@ -1936,7 +1932,6 @@ func TestTxnCoordSenderRetries(t *testing.T) {
 				b.Put("a", "put")
 				return txn.CommitInBatch(ctx, b) // will be a 1PC, but will get an auto retry
 			},
-			filter:        nil,
 			txnCoordRetry: true,
 		},
 		{
@@ -1947,11 +1942,24 @@ func TestTxnCoordSenderRetries(t *testing.T) {
 			retryable: func(ctx context.Context, txn *client.Txn) error {
 				return txn.Put(ctx, "a", "put")
 			},
-			filter:        nil,
 			txnCoordRetry: false,
 		},
 		{
-			name: "write too old with cput",
+			name: "write too old with cput matching newer value",
+			beforeTxnStart: func(ctx context.Context, db *client.DB) error {
+				return db.Put(ctx, "a", "value")
+			},
+			afterTxnStart: func(ctx context.Context, db *client.DB) error {
+				return db.Put(ctx, "a", "put")
+			},
+			retryable: func(ctx context.Context, txn *client.Txn) error {
+				return txn.CPut(ctx, "a", "cput", "put")
+			},
+			txnCoordRetry: false,              // fails on first attempt at cput
+			expFailure:    "unexpected value", // the failure we get is a condition failed error
+		},
+		{
+			name: "write too old with cput matching older value",
 			beforeTxnStart: func(ctx context.Context, db *client.DB) error {
 				return db.Put(ctx, "a", "value")
 			},
@@ -1961,8 +1969,43 @@ func TestTxnCoordSenderRetries(t *testing.T) {
 			retryable: func(ctx context.Context, txn *client.Txn) error {
 				return txn.CPut(ctx, "a", "cput", "value")
 			},
-			filter:        nil,
-			txnCoordRetry: false, // A write-too-old error on cput will result in a client-side retry
+			txnCoordRetry: false,              // non-matching value means we fail txn coord retry
+			expFailure:    "unexpected value", // the failure we get is a condition failed error
+		},
+		{
+			name: "write too old with cput matching older and newer values",
+			beforeTxnStart: func(ctx context.Context, db *client.DB) error {
+				return db.Put(ctx, "a", "value")
+			},
+			afterTxnStart: func(ctx context.Context, db *client.DB) error {
+				return db.Put(ctx, "a", "value")
+			},
+			retryable: func(ctx context.Context, txn *client.Txn) error {
+				return txn.CPut(ctx, "a", "cput", "value")
+			},
+			txnCoordRetry: true,
+		},
+		{
+			name: "write too old with increment",
+			beforeTxnStart: func(ctx context.Context, db *client.DB) error {
+				_, err := db.Inc(ctx, "inc", 1)
+				return err
+			},
+			afterTxnStart: func(ctx context.Context, db *client.DB) error {
+				_, err := db.Inc(ctx, "inc", 1)
+				return err
+			},
+			retryable: func(ctx context.Context, txn *client.Txn) error {
+				val, err := txn.Inc(ctx, "inc", 1)
+				if err != nil {
+					return err
+				}
+				if vInt := val.ValueInt(); vInt != 3 {
+					return errors.Errorf("expected val=3; got %d", vInt)
+				}
+				return nil
+			},
+			txnCoordRetry: true,
 		},
 		{
 			name: "multi-range batch with forwarded timestamp",
@@ -1976,7 +2019,6 @@ func TestTxnCoordSenderRetries(t *testing.T) {
 				b.Put("c", "put")
 				return txn.CommitInBatch(ctx, b) // both puts will succeed, et will retry
 			},
-			filter:        nil,
 			txnCoordRetry: true,
 		},
 		{
@@ -1994,7 +2036,6 @@ func TestTxnCoordSenderRetries(t *testing.T) {
 				b.Put("c", "put")
 				return txn.CommitInBatch(ctx, b) // both puts will succeed, et will retry
 			},
-			filter:        nil,
 			txnCoordRetry: true,
 		},
 		{
@@ -2008,7 +2049,6 @@ func TestTxnCoordSenderRetries(t *testing.T) {
 				b.Put("c", "put")
 				return txn.CommitInBatch(ctx, b) // both puts will succeed, et will retry
 			},
-			filter:        nil,
 			txnCoordRetry: true,
 		},
 		{
@@ -2025,7 +2065,6 @@ func TestTxnCoordSenderRetries(t *testing.T) {
 				b.Put("c", "put")
 				return txn.CommitInBatch(ctx, b)
 			},
-			filter:        nil,
 			txnCoordRetry: false, // cput with write too old requires restart
 		},
 		{
@@ -2187,7 +2226,9 @@ func TestTxnCoordSenderRetries(t *testing.T) {
 
 				return tc.retryable(ctx, txn)
 			}); err != nil {
-				t.Fatal(err)
+				if len(tc.expFailure) == 0 || !testutils.IsError(err, tc.expFailure) {
+					t.Fatal(err)
+				}
 			}
 			// Verify auto retry metric. Because there's a chance that splits
 			// from the cluster setup are still ongoing and can experience

--- a/pkg/sql/txn_restart_test.go
+++ b/pkg/sql/txn_restart_test.go
@@ -880,27 +880,6 @@ func runTestTxn(
 func TestTxnUserRestart(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	aborter := NewTxnAborter()
-	defer aborter.Close(t)
-	params, cmdFilters := tests.CreateTestServerParams()
-	params.Knobs.SQLExecutor = aborter.executorKnobs()
-	s, sqlDB, _ := serverutils.StartServer(t, params)
-	defer s.Stopper().Stop(context.TODO())
-	{
-		pgURL, cleanup := sqlutils.PGUrl(t, s.ServingAddr(), "TestTxnUserRestart", url.User(security.RootUser))
-		defer cleanup()
-		if err := aborter.Init(pgURL); err != nil {
-			t.Fatal(err)
-		}
-	}
-
-	if _, err := sqlDB.Exec(`
-CREATE DATABASE t;
-CREATE TABLE t.test (k INT PRIMARY KEY, v TEXT);
-`); err != nil {
-		t.Fatal(err)
-	}
-
 	// Set up error injection that causes retries.
 	testCases := []struct {
 		magicVals   *filterVals
@@ -923,61 +902,83 @@ CREATE TABLE t.test (k INT PRIMARY KEY, v TEXT);
 	for _, tc := range testCases {
 		for _, rs := range []rollbackStrategy{rollbackToSavepoint, declareSavepoint} {
 			for _, parallel := range []bool{false, true} {
-				cleanupFilter := cmdFilters.AppendFilter(
-					func(args storagebase.FilterArgs) *roachpb.Error {
-						if err := injectErrors(args.Req, args.Hdr, tc.magicVals, true /* verifyTxn */); err != nil {
-							return roachpb.NewErrorWithTxn(err, args.Hdr.Txn)
+				t.Run(fmt.Sprintf("err=%s,stgy=%d,parallel=%t", tc.expectedErr, rs, parallel), func(t *testing.T) {
+					aborter := NewTxnAborter()
+					defer aborter.Close(t)
+					params, cmdFilters := tests.CreateTestServerParams()
+					params.Knobs.SQLExecutor = aborter.executorKnobs()
+					s, sqlDB, _ := serverutils.StartServer(t, params)
+					defer s.Stopper().Stop(context.TODO())
+					{
+						pgURL, cleanup := sqlutils.PGUrl(t, s.ServingAddr(), "TestTxnUserRestart", url.User(security.RootUser))
+						defer cleanup()
+						if err := aborter.Init(pgURL); err != nil {
+							t.Fatal(err)
 						}
-						return nil
-					}, false)
+					}
 
-				// Also inject an error at RELEASE time, besides the error injected by magicVals.
-				sentinelInsert := "INSERT INTO t.test(k, v) VALUES (0, 'sentinel')"
-				if parallel {
-					sentinelInsert += " RETURNING NOTHING"
-				}
-				if err := aborter.QueueStmtForAbortion(
-					sentinelInsert, 1 /* abortCount */, true, /* willBeRetriedIbid */
-				); err != nil {
-					t.Fatal(err)
-				}
+					if _, err := sqlDB.Exec(`
+CREATE DATABASE t;
+CREATE TABLE t.test (k INT PRIMARY KEY, v TEXT);
+`); err != nil {
+						t.Fatal(err)
+					}
+					cleanupFilter := cmdFilters.AppendFilter(
+						func(args storagebase.FilterArgs) *roachpb.Error {
+							if err := injectErrors(args.Req, args.Hdr, tc.magicVals, true /* verifyTxn */); err != nil {
+								return roachpb.NewErrorWithTxn(err, args.Hdr.Txn)
+							}
+							return nil
+						}, false)
 
-				commitCount := s.MustGetSQLCounter(sql.MetaTxnCommit.Name)
-				// This is the magic. Run the txn closure until all the retries are exhausted.
-				retryExec(t, sqlDB, rs, func(tx *gosql.Tx) bool {
-					return runTestTxn(t, tc.magicVals, tc.expectedErr, sqlDB, tx, sentinelInsert)
-				})
-				checkRestarts(t, tc.magicVals)
+					// Also inject an error at RELEASE time, besides the error injected by magicVals.
+					sentinelInsert := "INSERT INTO t.test(k, v) VALUES (0, 'sentinel')"
+					if parallel {
+						sentinelInsert += " RETURNING NOTHING"
+					}
+					if err := aborter.QueueStmtForAbortion(
+						sentinelInsert, 1 /* abortCount */, true, /* willBeRetriedIbid */
+					); err != nil {
+						t.Fatal(err)
+					}
 
-				// Check that we only wrote the sentinel row.
-				rows, err := sqlDB.Query("SELECT * FROM t.test")
-				if err != nil {
-					t.Fatal(err)
-				}
-				defer rows.Close()
-				for rows.Next() {
-					var k int
-					var v string
-					err = rows.Scan(&k, &v)
+					commitCount := s.MustGetSQLCounter(sql.MetaTxnCommit.Name)
+					// This is the magic. Run the txn closure until all the retries are exhausted.
+					retryExec(t, sqlDB, rs, func(tx *gosql.Tx) bool {
+						return runTestTxn(t, tc.magicVals, tc.expectedErr, sqlDB, tx, sentinelInsert)
+					})
+					checkRestarts(t, tc.magicVals)
+
+					// Check that we only wrote the sentinel row.
+					rows, err := sqlDB.Query("SELECT * FROM t.test")
 					if err != nil {
 						t.Fatal(err)
 					}
-					if k != 0 || v != "sentinel" {
-						t.Fatalf("didn't find expected row: %d %s", k, v)
+					defer rows.Close()
+					for rows.Next() {
+						var k int
+						var v string
+						err = rows.Scan(&k, &v)
+						if err != nil {
+							t.Fatal(err)
+						}
+						if k != 0 || v != "sentinel" {
+							t.Fatalf("didn't find expected row: %d %s", k, v)
+						}
 					}
-				}
-				// Check that the commit counter was incremented. It could have been
-				// incremented by more than 1 because of the transactions we use to force
-				// aborts, plus who knows what else the server is doing in the background.
-				if err := checkCounterGE(s, sql.MetaTxnCommit, commitCount+1); err != nil {
-					t.Error(err)
-				}
-				// Clean up the table for the next test iteration.
-				_, err = sqlDB.Exec("DELETE FROM t.test WHERE true")
-				if err != nil {
-					t.Fatal(err)
-				}
-				cleanupFilter()
+					// Check that the commit counter was incremented. It could have been
+					// incremented by more than 1 because of the transactions we use to force
+					// aborts, plus who knows what else the server is doing in the background.
+					if err := checkCounterGE(s, sql.MetaTxnCommit, commitCount+1); err != nil {
+						t.Error(err)
+					}
+					// Clean up the table for the next test iteration.
+					_, err = sqlDB.Exec("DELETE FROM t.test WHERE true")
+					if err != nil {
+						t.Fatal(err)
+					}
+					cleanupFilter()
+				})
 			}
 		}
 	}

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -5409,6 +5409,9 @@ func evaluateBatch(
 		}
 
 		if pErr != nil {
+			// Initialize the error index.
+			pErr.SetErrorIndex(int32(index))
+
 			switch tErr := pErr.GetDetail().(type) {
 			case *roachpb.WriteTooOldError:
 				// We got a WriteTooOldError. In case this is a transactional request,
@@ -5416,9 +5419,28 @@ func evaluateBatch(
 				// intents so that other concurrent overlapping transactions are forced
 				// through intent resolution and the chances of this batch succeeding
 				// when it will be retried are increased.
-
 				if ba.Txn == nil {
 					return nil, result, pErr
+				}
+				// Return error early on some requests for serializable isolation.
+				if ba.Txn != nil && ba.Txn.Isolation == enginepb.SERIALIZABLE {
+					switch args.(type) {
+					case *roachpb.ConditionalPutRequest:
+						// Conditional puts are an exception. Here, it makes less sense to
+						// continue because it's likely that the cput will fail on retry (a
+						// newer value is less likely to match the expected value). It's
+						// better to return the WriteTooOldError directly, allowing the txn
+						// coord sender to retry if it can refresh all other spans encountered
+						// already during the transaction, and then, if the cput results in a
+						// condition failed error, report that back to the client instead of a
+						// retryable error.
+						return nil, result, pErr
+					case *roachpb.IncrementRequest:
+						// Increments are an exception for similar reasons. If we wait until
+						// commit, we'll need a client-side retry, so we return immediately
+						// to see if we can do a txn coord sender retry instead.
+						return nil, result, pErr
+					}
 				}
 				// On WriteTooOldError, we've written a new value or an intent
 				// at a too-high timestamp and we must forward the batch txn or
@@ -5431,8 +5453,6 @@ func evaluateBatch(
 				// pushed timestamp and return a TransactionRetryError.
 				pErr = nil
 			default:
-				// Initialize the error index.
-				pErr.SetErrorIndex(int32(index))
 				return nil, result, pErr
 			}
 		}


### PR DESCRIPTION
Previously, a conditional put or increment ops that experienced a write-too-old error
would not immediately return an error. Instead, it would proceed to lay
down the intent, set the `WriteTooOld` bool on the `Transaction`, and
continue so that intents might be laid down to assure succes on the
eventual retry. The `EndTransaction` request triggers restart at commit
time in the event that `WriteTooOld` is set.
    
The problem with this is that refreshing the conditional put key is
guaranteed to fail because there is a known, newer version of the key
written. This implies a client-side retry.
    
This change makes conditional puts immediately return a `WriteTooOldError`
instead of just swallowing the error and setting the `WriteTooOld`
flag. The returned error allows the `TxnCoordSender` to refresh all
spans mid-transaction, and hopefully retry the conditional put at the
advanced timestamp, to either succeed or fail on the conditional put.
This allows the transaction to continue on success, or return a
`ConditionFailedError` on failure.
