### PR TITLE
kubernetes: Fix secure deployment with RBAC to work on Kubernetes v1.7

### DIFF
--- a/cloud/kubernetes/cockroachdb-statefulset-secure.yaml
+++ b/cloud/kubernetes/cockroachdb-statefulset-secure.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app: cockroachdb
 ---
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: Role
 metadata:
   name: cockroachdb
@@ -20,7 +20,7 @@ rules:
   - create
   - get
 ---
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
   name: cockroachdb
@@ -36,7 +36,7 @@ rules:
   - get
   - watch
 ---
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: RoleBinding
 metadata:
   name: cockroachdb
@@ -51,7 +51,7 @@ subjects:
   name: cockroachdb
   namespace: default
 ---
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
   name: cockroachdb


### PR DESCRIPTION
Tested on v1.7 and v1.8. I'd also test on v1.9 but GKE doesn't have that
yet.

Fixes #22213 

Release note: None