### PR TITLE
storage/engine: hack around small C.GoBytes performance problem

### DIFF
--- a/pkg/storage/engine/bench_rocksdb_test.go
+++ b/pkg/storage/engine/bench_rocksdb_test.go
@@ -48,7 +48,7 @@ func setupMVCCInMemRocksDB(_ testing.TB, loc string) Engine {
 // Read benchmarks. All of them run with on-disk data.
 
 func BenchmarkMVCCScan_RocksDB(b *testing.B) {
-	for _, numRows := range []int{1, 10, 100, 1000} {
+	for _, numRows := range []int{1, 10, 100, 1000, 10000} {
 		b.Run(fmt.Sprintf("rows=%d", numRows), func(b *testing.B) {
 			for _, numVersions := range []int{1, 2, 10, 100} {
 				b.Run(fmt.Sprintf("versions=%d", numVersions), func(b *testing.B) {

--- a/pkg/storage/engine/rocksdb.go
+++ b/pkg/storage/engine/rocksdb.go
@@ -77,7 +77,7 @@ func rocksDBLog(s *C.char, n C.int) {
 //export prettyPrintKey
 func prettyPrintKey(cKey C.DBKey) *C.char {
 	mvccKey := MVCCKey{
-		Key: C.GoBytes(unsafe.Pointer(cKey.key.data), cKey.key.len),
+		Key: gobytes(unsafe.Pointer(cKey.key.data), int(cKey.key.len)),
 		Timestamp: hlc.Timestamp{
 			WallTime: int64(cKey.wall_time),
 			Logical:  int32(cKey.logical),
@@ -2179,7 +2179,7 @@ func cStringToGoBytes(s C.DBString) []byte {
 	if s.data == nil {
 		return nil
 	}
-	result := C.GoBytes(unsafe.Pointer(s.data), s.len)
+	result := gobytes(unsafe.Pointer(s.data), int(s.len))
 	C.free(unsafe.Pointer(s.data))
 	return result
 }
@@ -2188,7 +2188,7 @@ func cSliceToGoBytes(s C.DBSlice) []byte {
 	if s.data == nil {
 		return nil
 	}
-	return C.GoBytes(unsafe.Pointer(s.data), s.len)
+	return gobytes(unsafe.Pointer(s.data), int(s.len))
 }
 
 func cSliceToUnsafeGoBytes(s C.DBSlice) []byte {

--- a/pkg/storage/engine/slice.go
+++ b/pkg/storage/engine/slice.go
@@ -1,0 +1,24 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+// +build !go1.9
+
+package engine
+
+import "C"
+import "unsafe"
+
+func gobytes(ptr unsafe.Pointer, len int) []byte {
+	return C.GoBytes(ptr, len)
+}

--- a/pkg/storage/engine/slice.s
+++ b/pkg/storage/engine/slice.s
@@ -1,0 +1,1 @@
+// Empty assembly file to allow go:linkname to work.

--- a/pkg/storage/engine/slice_go1.9.go
+++ b/pkg/storage/engine/slice_go1.9.go
@@ -1,0 +1,36 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+// +build go1.9
+
+package engine
+
+import "unsafe" // for go:linkname
+
+// The go:linkname directives provides backdoor access to private functions in
+// the runtime. Below we're accessing the rawbyteslice function. Note that this
+// access is necessarily tied to a specific Go release which is why this file
+// is protected by a build tag.
+
+//go:linkname rawbyteslice runtime.rawbyteslice
+func rawbyteslice(size int) (b []byte)
+
+// Replacement for C.GoBytes which does not zero initialize the returned slice
+// before overwriting it. See https://github.com/golang/go/issues/23634.
+func gobytes(ptr unsafe.Pointer, len int) []byte {
+	x := rawbyteslice(len)
+	src := (*[maxArrayLen]byte)(ptr)[:len:len]
+	copy(x, src)
+	return x
+}


### PR DESCRIPTION
`C.GoBytes` zero initializes the slice it will return before copying
over it. The zero initialization is a small but measurable performance
hit. Hack around this problem by providing our own `gobytes` routine
which allocates an uninitialized slice using `runtime.rawbyteslice`.

```
name                                                    old time/op    new time/op    delta
MVCCScan_RocksDB/rows=100/versions=1/valueSize=64-8       35.0µs ± 3%    33.8µs ± 1%  -3.30%  (p=0.000 n=10+10)
MVCCScan_RocksDB/rows=100/versions=1/valueSize=512-8      51.3µs ± 1%    49.5µs ± 0%  -3.43%  (p=0.000 n=10+9)
MVCCScan_RocksDB/rows=1000/versions=1/valueSize=64-8       272µs ± 0%     266µs ± 1%  -2.39%  (p=0.000 n=8+10)
MVCCScan_RocksDB/rows=1000/versions=1/valueSize=512-8      439µs ± 1%     422µs ± 1%  -3.91%  (p=0.000 n=10+10)
MVCCScan_RocksDB/rows=10000/versions=1/valueSize=64-8     2.71ms ± 5%    2.63ms ± 1%  -2.77%  (p=0.000 n=9+10)
MVCCScan_RocksDB/rows=10000/versions=1/valueSize=512-8    6.29ms ± 1%    5.87ms ± 3%  -6.76%  (p=0.000 n=8+10)
```

Release note (performance improvement): Small performance improvement to
low-level scan operations.