### PR TITLE
storage/engine: use an append-only write batch

### DIFF
--- a/c-deps/libroach/CMakeLists.txt
+++ b/c-deps/libroach/CMakeLists.txt
@@ -24,6 +24,7 @@ project(roachlib)
 add_library(roach
   batch.cc
   cache.cc
+  chunked_buffer.cc
   comparator.cc
   db.cc
   encoding.cc

--- a/c-deps/libroach/chunked_buffer.cc
+++ b/c-deps/libroach/chunked_buffer.cc
@@ -1,0 +1,83 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied.  See the License for the specific language governing
+// permissions and limitations under the License.
+
+#include "chunked_buffer.h"
+#include <rocksdb/db.h>
+#include "encoding.h"
+
+namespace cockroach {
+
+// Write a key/value pair to this chunkedBuffer.
+void chunkedBuffer::Put(const rocksdb::Slice& key, const rocksdb::Slice& value) {
+  putLengthPrefixedSlice(key);
+  putLengthPrefixedSlice(value);
+  count_++;
+}
+
+void chunkedBuffer::Clear() {
+  for (int i = 0; i < bufs_.size(); i++) {
+    delete[] bufs_[i].data;
+  }
+  count_ = 0;
+  buf_ptr_ = nullptr;
+  bufs_.clear();
+}
+
+// put writes len bytes of the input data to this vector of buffers,
+// allocating new buffers if necessary. next_size_hint can be passed to
+// indicate that the required size of this buffer will soon be
+// len+next_size_hint, to prevent excessive resize operations.
+void chunkedBuffer::put(const char* data, int len, int next_size_hint) {
+  const int avail = bufs_.empty() ? 0 :
+      (bufs_.back().len - (buf_ptr_ - bufs_.back().data));
+  if (len > avail) {
+    // If it's bigger than the last buf's capacity, we fill the last buf,
+    // allocate a new one, and write the remainder to the new one.  Our new
+    // buf's size will be the next power of two past the size of the last buf
+    // that can accomodate the new data, plus a size hint if available.
+    memcpy(buf_ptr_, data, avail);
+    data += avail;
+    len -= avail;
+
+    int new_size = bufs_.empty() ? 16 : bufs_.back().len * 2;
+    for (; new_size < len + next_size_hint; new_size *= 2) {
+    }
+
+    DBSlice new_buf;
+    new_buf.data = new char[new_size];
+    new_buf.len = new_size;
+    bufs_.push_back(new_buf);
+
+    // Now reset so that we'll write the remainder below.
+    buf_ptr_ = new_buf.data;
+  }
+
+  memcpy(buf_ptr_, data, len);
+  buf_ptr_ += len;
+}
+
+// putLengthPrefixedSlice writes the input value to the iterator's output
+// slice, prefixed by the value's length encoded as a Varint32. This matches
+// the RocksDB WriteBatch format *without* the leading 1-byte value tag.
+void chunkedBuffer::putLengthPrefixedSlice(const rocksdb::Slice& value) {
+  // Encode the value length into a buffer to determine the size of the length
+  // encoding.
+  char buf[5];
+  char* ptr = EncodeVarint32(buf, value.size());
+  const int put_size = ptr - buf;
+  put(buf, put_size, value.size());
+  put(value.data(), value.size(), 0);
+}
+
+}  // namespace cockroach

--- a/c-deps/libroach/chunked_buffer.h
+++ b/c-deps/libroach/chunked_buffer.h
@@ -1,0 +1,60 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied.  See the License for the specific language governing
+// permissions and limitations under the License.
+
+#pragma once
+
+#include <rocksdb/db.h>
+#include "libroach.h"
+
+namespace cockroach {
+
+class chunkedBuffer {
+ public:
+  chunkedBuffer() {
+    Clear();
+  }
+  ~chunkedBuffer() {
+    Clear();
+  }
+
+  // Write a key/value pair to this chunkedBuffer.
+  void Put(const rocksdb::Slice& key, const rocksdb::Slice& value);
+
+  // Clear this chunkedBuffer.
+  void Clear();
+
+  void GetChunks(DBSlice **bufs, int32_t *len) {
+    // Cap the last buffer's size to the amount that's been written to it.
+    DBSlice &last = bufs_.back();
+    last.len = buf_ptr_ - last.data;
+    *bufs = &bufs_.front();
+    *len = bufs_.size();
+  }
+
+  // Get the number of key/value pairs written to this chunkedBuffer.
+  int Count() const {
+    return count_;
+  }
+
+ private:
+  void put(const char* data, int len, int next_size_hint);
+  void putLengthPrefixedSlice(const rocksdb::Slice& value);
+
+ private:
+  std::vector<DBSlice> bufs_;
+  int64_t count_;
+  char* buf_ptr_;
+};
+
+}  // namespace cockroach

--- a/c-deps/libroach/encoding.cc
+++ b/c-deps/libroach/encoding.cc
@@ -18,6 +18,35 @@
 
 namespace cockroach {
 
+char* EncodeVarint32(char* dst, uint32_t v) {
+  // Copied from RocksDB's coding.cc.
+  // Operate on characters as unsigneds
+  unsigned char* ptr = reinterpret_cast<unsigned char*>(dst);
+  static const int B = 128;
+  if (v < (1 << 7)) {
+    *(ptr++) = v;
+  } else if (v < (1 << 14)) {
+    *(ptr++) = v | B;
+    *(ptr++) = v >> 7;
+  } else if (v < (1 << 21)) {
+    *(ptr++) = v | B;
+    *(ptr++) = (v >> 7) | B;
+    *(ptr++) = v >> 14;
+  } else if (v < (1 << 28)) {
+    *(ptr++) = v | B;
+    *(ptr++) = (v >> 7) | B;
+    *(ptr++) = (v >> 14) | B;
+    *(ptr++) = v >> 21;
+  } else {
+    *(ptr++) = v | B;
+    *(ptr++) = (v >> 7) | B;
+    *(ptr++) = (v >> 14) | B;
+    *(ptr++) = (v >> 21) | B;
+    *(ptr++) = v >> 28;
+  }
+  return reinterpret_cast<char*>(ptr);
+}
+
 void EncodeUint32(std::string* buf, uint32_t v) {
   const uint8_t tmp[sizeof(v)] = {
       uint8_t(v >> 24),

--- a/c-deps/libroach/encoding.h
+++ b/c-deps/libroach/encoding.h
@@ -22,6 +22,10 @@
 
 namespace cockroach {
 
+// EncodeVarint32 encodes the uint32 value using RocksDB's varint
+// representation.
+char* EncodeVarint32(char* dst, uint32_t value);
+
 // EncodeUint32 encodes the uint32 value using a big-endian 4 byte
 // representation. The bytes are appended to the supplied buffer.
 void EncodeUint32(std::string* buf, uint32_t v);

--- a/c-deps/libroach/include/libroach.h
+++ b/c-deps/libroach/include/libroach.h
@@ -250,11 +250,19 @@ typedef struct {
   DBTimestamp max_timestamp;
 } DBTxn;
 
+typedef struct {
+  DBSlice *bufs;
+  // len is the number of DBSlices in bufs.
+  int32_t len;
+  // count is the number of key/value pairs in bufs.
+  int32_t count;
+} DBChunkedBuffer;
+
 // DBScanResults contains the key/value pairs and intents encoded
 // using the RocksDB batch repr format.
 typedef struct {
   DBStatus status;
-  DBSlice data;
+  DBChunkedBuffer data;
   DBSlice intents;
   DBTimestamp uncertainty_timestamp;
 } DBScanResults;

--- a/c-deps/libroach/iterator.h
+++ b/c-deps/libroach/iterator.h
@@ -14,13 +14,14 @@
 
 #pragma once
 
-#include <libroach.h>
 #include <memory>
+#include "chunked_buffer.h"
+#include "encoding.h"
 #include <rocksdb/iterator.h>
 #include <rocksdb/write_batch.h>
 
 struct DBIterator {
   std::unique_ptr<rocksdb::Iterator> rep;
-  std::unique_ptr<rocksdb::WriteBatch> kvs;
+  std::unique_ptr<cockroach::chunkedBuffer> kvs;
   std::unique_ptr<rocksdb::WriteBatch> intents;
 };

--- a/pkg/storage/engine/batch.go
+++ b/pkg/storage/engine/batch.go
@@ -384,16 +384,12 @@ func rocksDBBatchVarString(repr []byte) (s []byte, orepr []byte, err error) {
 	return repr[:v], repr[v:], nil
 }
 
-// Decode a RocksDB batch repr key/value pair, returning both the key/value and
-// the suffix of data remaining in the batch.
-func rocksDBBatchDecodeValue(repr []byte) (key MVCCKey, value []byte, orepr []byte, err error) {
+// Decode an MVCC scan batch repr key/value pair, returning both the key/value
+// and the suffix of data remaining in the batch.
+func mvccScanBatchDecodeValue(repr []byte) (key MVCCKey, value []byte, orepr []byte, err error) {
 	if len(repr) == 0 {
 		return key, nil, repr, errors.Errorf("unexpected batch EOF")
 	}
-	if BatchType(repr[0]) != BatchTypeValue {
-		return key, nil, repr, errors.Errorf("unexpected batch entry type: %d", BatchType(repr[0]))
-	}
-	repr = repr[1:]
 	rawKey, repr, err := rocksDBBatchVarString(repr)
 	if err != nil {
 		return key, nil, repr, err

--- a/pkg/storage/engine/engine.go
+++ b/pkg/storage/engine/engine.go
@@ -107,11 +107,11 @@ type Iterator interface {
 	) (*roachpb.Value, []roachpb.Intent, error)
 	// MVCCScan scans the underlying engine from start to end keys and returns
 	// key/value pairs which have a timestamp less than or equal to the supplied
-	// timestamp, up to a max rows. The key/value pairs are returned in the batch
-	// repr format and can be iterated over using RocksDBBatchReader.
+	// timestamp, up to a max rows. The key/value pairs are returned as a buffer
+	// of varint-prefixed slices, alternating from key to value, numKvs pairs.
 	MVCCScan(start, end roachpb.Key, max int64, timestamp hlc.Timestamp,
 		txn *roachpb.Transaction, consistent, reverse bool,
-	) (kvs []byte, intents []byte, err error)
+	) (kvs []byte, numKvs int64, intents []byte, err error)
 }
 
 // Reader is the read interface to an engine's data.

--- a/pkg/storage/engine/mvcc.go
+++ b/pkg/storage/engine/mvcc.go
@@ -1639,7 +1639,7 @@ func mvccScanInternal(
 		iter = engine.NewIterator(false)
 		ownIter = true
 	}
-	kvData, intentData, err := iter.MVCCScan(
+	kvData, numKvs, intentData, err := iter.MVCCScan(
 		key, endKey, max, timestamp, txn, consistent, reverse)
 	if ownIter {
 		iter.Close()
@@ -1649,7 +1649,7 @@ func mvccScanInternal(
 		return nil, nil, nil, err
 	}
 
-	kvs, resumeKey, intents, err := buildScanResults(kvData, intentData, max, consistent)
+	kvs, resumeKey, intents, err := buildScanResults(kvData, numKvs, intentData, max, consistent)
 	var resumeSpan *roachpb.Span
 	if resumeKey != nil {
 		if reverse {
@@ -1694,24 +1694,21 @@ func buildScanIntents(data []byte) ([]roachpb.Intent, error) {
 	return intents, nil
 }
 
-func buildScanResumeKey(kvData []byte, max int) ([]byte, error) {
+func buildScanResumeKey(kvData []byte, numKvs int64, max int64) ([]byte, error) {
 	if len(kvData) == 0 {
 		return nil, nil
 	}
-	count, kvData, err := rocksDBBatchDecodeHeader(kvData)
-	if err != nil {
-		return nil, err
-	}
-	if count <= max {
+	if numKvs <= max {
 		return nil, nil
 	}
-	for i := 0; i < max; i++ {
-		_, _, kvData, err = rocksDBBatchDecodeValue(kvData)
+	var err error
+	for i := int64(0); i < max; i++ {
+		_, _, kvData, err = mvccScanBatchDecodeValue(kvData)
 		if err != nil {
 			return nil, err
 		}
 	}
-	key, _, _, err := rocksDBBatchDecodeValue(kvData)
+	key, _, _, err := mvccScanBatchDecodeValue(kvData)
 	if err != nil {
 		return nil, err
 	}
@@ -1719,7 +1716,7 @@ func buildScanResumeKey(kvData []byte, max int) ([]byte, error) {
 }
 
 func buildScanResults(
-	kvData, intentData []byte, max int64, consistent bool,
+	kvData []byte, numKvs int64, intentData []byte, max int64, consistent bool,
 ) ([]roachpb.KeyValue, roachpb.Key, []roachpb.Intent, error) {
 	intents, err := buildScanIntents(intentData)
 	if err != nil {
@@ -1728,7 +1725,7 @@ func buildScanResults(
 	if consistent && len(intents) > 0 {
 		// When encountering intents during a consistent scan we still need to
 		// return the resume key.
-		resumeKey, err := buildScanResumeKey(kvData, int(max))
+		resumeKey, err := buildScanResumeKey(kvData, numKvs, max)
 		if err != nil {
 			return nil, nil, nil, err
 		}
@@ -1738,15 +1735,7 @@ func buildScanResults(
 		return nil, nil, intents, nil
 	}
 
-	// Loop over the kvData (which is in RocksDB batch repr format), creating a
-	// slice of roachpb.KeyValue. This code would be slightly more compact using
-	// RocksDBBatchReader, but there is a measurable performance benefit to
-	// avoiding the associated allocation for small (1 row) scans.
-	count, kvData, err := rocksDBBatchDecodeHeader(kvData)
-	if err != nil {
-		return nil, nil, nil, err
-	}
-	if count == 0 {
+	if numKvs == 0 {
 		return nil, nil, intents, nil
 	}
 
@@ -1756,16 +1745,16 @@ func buildScanResults(
 	//
 	// TODO(peter): We should change the resumeKey to be Key.Next() of the last
 	// key returned.
-	n := count
-	if n > int(max) {
-		n = int(max)
+	n := numKvs
+	if n > max {
+		n = max
 	}
 	kvs := make([]roachpb.KeyValue, n)
 
 	var key MVCCKey
 	var rawBytes []byte
 	for i := range kvs {
-		key, rawBytes, kvData, err = rocksDBBatchDecodeValue(kvData)
+		key, rawBytes, kvData, err = mvccScanBatchDecodeValue(kvData)
 		if err != nil {
 			return nil, nil, nil, err
 		}
@@ -1775,8 +1764,8 @@ func buildScanResults(
 	}
 
 	var resumeKey roachpb.Key
-	if count > int(max) {
-		key, _, _, err = rocksDBBatchDecodeValue(kvData)
+	if numKvs > max {
+		key, _, _, err = mvccScanBatchDecodeValue(kvData)
 		if err != nil {
 			return nil, nil, nil, err
 		}

--- a/pkg/storage/spanset/batch.go
+++ b/pkg/storage/spanset/batch.go
@@ -181,9 +181,9 @@ func (s *Iterator) MVCCScan(
 	timestamp hlc.Timestamp,
 	txn *roachpb.Transaction,
 	consistent, reverse bool,
-) (kvs []byte, intents []byte, err error) {
+) (kvs []byte, numKvs int64, intents []byte, err error) {
 	if err := s.spans.CheckAllowed(SpanReadOnly, roachpb.Span{Key: start, EndKey: end}); err != nil {
-		return nil, nil, err
+		return nil, 0, nil, err
 	}
 	return s.i.MVCCScan(start, end, max, timestamp, txn, consistent, reverse)
 }


### PR DESCRIPTION
Previously, the C++ MVCCScan code wrote the data it found on disk into a
std::string, which copies and reallocates when it runs out of capacity.
This was inefficient, since we eventually just copy it into Go memory
anyway.

Now, MVCCScan writes to a new data structure called chunkedBuffer, which
maintains a vector of buffers that increase exponentially in size
starting at 16 bytes. When one of the buffers runs out of capacity, a
new one is created and appended to the vector.

Then, Go copies data out of this sequence of buffers into Go memory.

```
name                                                    old time/op    new time/op    delta
MVCCScan_RocksDB/rows=1/versions=1/valueSize=8-8          5.45µs ± 2%    5.33µs ± 2%   -2.23%  (p=0.000 n=10+9)
MVCCScan_RocksDB/rows=1/versions=1/valueSize=64-8         5.60µs ± 2%    5.64µs ± 2%     ~     (p=0.280 n=10+10)
MVCCScan_RocksDB/rows=1/versions=1/valueSize=512-8        6.48µs ± 2%    6.41µs ± 3%     ~     (p=0.271 n=10+10)
MVCCScan_RocksDB/rows=10/versions=1/valueSize=8-8         8.38µs ± 1%    8.27µs ± 2%   -1.34%  (p=0.003 n=10+10)
MVCCScan_RocksDB/rows=10/versions=1/valueSize=64-8        9.12µs ± 3%    8.94µs ± 1%   -2.01%  (p=0.001 n=9+10)
MVCCScan_RocksDB/rows=10/versions=1/valueSize=512-8       12.0µs ± 1%    11.7µs ± 1%   -2.21%  (p=0.000 n=10+9)
MVCCScan_RocksDB/rows=100/versions=1/valueSize=8-8        31.8µs ± 3%    28.9µs ± 1%   -9.14%  (p=0.000 n=9+10)
MVCCScan_RocksDB/rows=100/versions=1/valueSize=64-8       34.5µs ± 2%    31.8µs ± 1%   -7.66%  (p=0.000 n=10+10)
MVCCScan_RocksDB/rows=100/versions=1/valueSize=512-8      50.6µs ± 3%    45.8µs ± 1%   -9.54%  (p=0.000 n=10+10)
MVCCScan_RocksDB/rows=1000/versions=1/valueSize=8-8        251µs ± 1%     221µs ± 0%  -12.25%  (p=0.000 n=10+9)
MVCCScan_RocksDB/rows=1000/versions=1/valueSize=64-8       269µs ± 0%     237µs ± 1%  -11.95%  (p=0.000 n=9+10)
MVCCScan_RocksDB/rows=1000/versions=1/valueSize=512-8      425µs ± 1%     371µs ± 1%  -12.53%  (p=0.000 n=10+9)
MVCCScan_RocksDB/rows=10000/versions=1/valueSize=8-8      2.48ms ± 2%    2.12ms ± 1%  -14.49%  (p=0.000 n=10+9)
MVCCScan_RocksDB/rows=10000/versions=1/valueSize=64-8     2.66ms ± 2%    2.24ms ± 1%  -15.70%  (p=0.000 n=10+10)
MVCCScan_RocksDB/rows=10000/versions=1/valueSize=512-8    5.68ms ± 4%    3.69ms ± 1%  -35.00%  (p=0.000 n=10+9)
MVCCGet_RocksDB/versions=1/valueSize=8-8                  5.41µs ± 3%    5.44µs ± 2%     ~     (p=0.497 n=10+9)
MVCCGet_RocksDB/versions=10/valueSize=8-8                 6.21µs ± 2%    6.25µs ± 2%     ~     (p=0.252 n=9+10)
MVCCGet_RocksDB/versions=100/valueSize=8-8                17.4µs ±17%    18.5µs ±19%     ~     (p=0.218 n=10+10)
```