### PR TITLE
workload: maybe fix flaky TestSetup

### DIFF
--- a/pkg/sql/drop_test.go
+++ b/pkg/sql/drop_test.go
@@ -827,6 +827,23 @@ func TestDropAndCreateTable(t *testing.T) {
 	}
 }
 
+func TestDropAndCreateDatabase(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	t.Skip(`#22256`)
+
+	ctx := context.Background()
+	s, db, _ := serverutils.StartServer(t, base.TestServerArgs{UseDatabase: `test`})
+	defer s.Stopper().Stop(ctx)
+	sqlDB := sqlutils.MakeSQLRunner(db)
+
+	for i := 0; i < 20; i++ {
+		sqlDB.Exec(t, `DROP DATABASE IF EXISTS test`)
+		sqlDB.Exec(t, `CREATE DATABASE test`)
+		sqlDB.Exec(t, `CREATE TABLE foo (a INT PRIMARY KEY)`)
+		sqlDB.Exec(t, `INSERT INTO foo VALUES (1), (2), (3)`)
+	}
+}
+
 // Test commands while a table is being dropped.
 func TestCommandsWhileTableBeingDropped(t *testing.T) {
 	defer leaktest.AfterTest(t)()


### PR DESCRIPTION
It appears that something is occasionally wrong in the database
descriptor caching, when they are dropped and recreated. Pull this
suspect behavior into a skipped test, so it doesn't get lost if it is
indeed the problem. Stressing it locally seems to reproduce.

Closes #21618
Closes #21736
Closes #21848
Closes #21196

Release note: None