### PR TITLE
logictest: add missing rowsort to cascade test

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/cascade
+++ b/pkg/sql/logictest/testdata/logic_test/cascade
@@ -1778,7 +1778,7 @@ INSERT INTO b VALUES (1, 1), (2, NULL), (3, 2), (4, 1), (5, NULL);
 statement ok
 UPDATE a SET id = id + 10;
 
-query II
+query II rowsort
 SELECT id, a_id FROM b;
 ----
 1  11


### PR DESCRIPTION
Deflakes TestLogic/distsql/cascade/UpdateCascade_Multi.

Fix #22255.
Fix #22254.
Fix #22250.

Release note: None