### PR TITLE
build: use gsutil to upload the artfacts from nightly tests

### DIFF
--- a/build/nightly-workload.sh
+++ b/build/nightly-workload.sh
@@ -2,24 +2,29 @@
 
 set -ex
 
+# Below assumes TC_BUILD_ID, so if it's unset, fill it in with something.
+TC_BUILD_ID="${TC_BUILD_ID:-nobuild-`date +%Y-%m-%d-%H%M%S`}"
+
 go get -u github.com/cockroachdb/roachprod
 
+# teamcity-nightlies assumes cockroach and workload are the cwd.
+make build TYPE=release-linux-gnu
+# Use this instead of make build for faster debugging iteration.
+# curl -L https://edge-binaries.cockroachdb.com/cockroach/cockroach.linux-gnu-amd64.LATEST -o cockroach-linux-2.6.32-gnu-amd64
+# chmod +x cockroach-linux-2.6.32-gnu-amd64
+cp cockroach-linux-2.6.32-gnu-amd64 cockroach
 make bin/workload
+cp bin/workload .
 
 # This `set +x`/paren magic turns off the `set -x` so we don't leak secrets.
-(set +x; echo $GOOGLE_CREDENTIALS > creds.json)
-gcloud auth activate-service-account --key-file=creds.json
-
-# teamcity-nightlies assumes cockroach and workload are the cwd.
-cp cockroach-linux-2.6.32-gnu-amd64 cockroach
-cp bin/workload .
+(set +x; echo $GOOGLE_EPHEMERAL_CREDENTIALS > creds_ephemeral.json)
+gcloud auth activate-service-account --key-file=creds_ephemeral.json
 
 # teamcity-nightlies puts the arg we give into the name of every cluster it
 # creates, so this should let us match up clusters to invocations of this build.
 mkdir -p ~/.roachprod/hosts
 ./workload teamcity-nightlies teamcity-nightly-workload-${TC_BUILD_ID}
-cp -R workload-test* artifacts/
-
-# Currently broken because of s3 auth. Copied from the "Roachperf Nightly"
-# build, where it is also currently broken.
-roachprod upload workload-test* || true
+mkdir -p artifacts
+cp -R workload-test*/* artifacts/
+gsutil -h "Content-Type:text/plain" cp \
+    -R workload-test*/* gs://cockroach-acceptance-results/teamcity-nightly/${TC_BUILD_ID}/

--- a/build/teamcity-nightly-workload.sh
+++ b/build/teamcity-nightly-workload.sh
@@ -2,19 +2,7 @@
 
 set -ex
 
-mkdir -p artifacts
-
-# Build the cockroach binary (which uses docker) before hopping into docker for
-# the nightly-workload.sh script.
-pkg/acceptance/prepare.sh
-
-# Use this instead of prepare.sh for faster debugging iteration.
-# curl -L https://edge-binaries.cockroachdb.com/cockroach/cockroach.linux-gnu-amd64.LATEST -o cockroach-linux-2.6.32-gnu-amd64
-# chmod +x cockroach-linux-2.6.32-gnu-amd64
-
 ./build/builder.sh env \
-    AWS_ACCESS_KEY_ID="$AWS_ACCESS_KEY_ID" \
-    AWS_SECRET_ACCESS_KEY="$AWS_SECRET_ACCESS_KEY" \
-    GOOGLE_CREDENTIALS="$GOOGLE_CREDENTIALS" \
+    GOOGLE_EPHEMERAL_CREDENTIALS="$GOOGLE_EPHEMERAL_CREDENTIALS" \
     TC_BUILD_ID="$TC_BUILD_ID" \
     ./build/nightly-workload.sh


### PR DESCRIPTION
While I'm in here, clean up the scripts a bit.

Release note: None