### PR TITLE
sqlbase: pass batches of kv pairs from kvfetcher to rowfetcher

### DIFF
--- a/pkg/sql/sqlbase/fk.go
+++ b/pkg/sql/sqlbase/fk.go
@@ -246,14 +246,14 @@ type spanKVFetcher struct {
 	kvs []roachpb.KeyValue
 }
 
-// nextKV implements the kvFetcher interface.
-func (f *spanKVFetcher) nextKV(ctx context.Context) (bool, roachpb.KeyValue, error) {
+// nextBatch implements the kvFetcher interface.
+func (f *spanKVFetcher) nextBatch(_ context.Context) (bool, []roachpb.KeyValue, error) {
 	if len(f.kvs) == 0 {
-		return false, roachpb.KeyValue{}, nil
+		return false, nil, nil
 	}
-	kv := f.kvs[0]
-	f.kvs = f.kvs[1:]
-	return true, kv, nil
+	res := f.kvs
+	f.kvs = nil
+	return true, res, nil
 }
 
 // getRangesInfo implements the kvFetcher interface.

--- a/pkg/sql/sqlbase/rowfetcher.go
+++ b/pkg/sql/sqlbase/rowfetcher.go
@@ -37,7 +37,7 @@ import (
 const debugRowFetch = false
 
 type kvFetcher interface {
-	nextKV(ctx context.Context) (bool, roachpb.KeyValue, error)
+	nextBatch(ctx context.Context) (bool, []roachpb.KeyValue, error)
 	getRangesInfo() []roachpb.RangeInfo
 }
 
@@ -196,6 +196,8 @@ type RowFetcher struct {
 	kv                roachpb.KeyValue
 	keyRemainingBytes []byte
 	kvEnd             bool
+
+	kvs []roachpb.KeyValue
 
 	// isCheck indicates whether or not we are running checks for k/v
 	// correctness. It is set only during SCRUB commands.
@@ -402,9 +404,26 @@ func (rf *RowFetcher) StartScan(
 func (rf *RowFetcher) StartScanFrom(ctx context.Context, f kvFetcher) error {
 	rf.indexKey = nil
 	rf.kvFetcher = f
+	rf.kvs = nil
 	// Retrieve the first key.
 	_, err := rf.NextKey(ctx)
 	return err
+}
+
+func (rf *RowFetcher) nextKV(ctx context.Context) (ok bool, kv roachpb.KeyValue, err error) {
+	if len(rf.kvs) != 0 {
+		kv = rf.kvs[0]
+		rf.kvs = rf.kvs[1:]
+		return true, kv, nil
+	}
+	ok, rf.kvs, err = rf.kvFetcher.nextBatch(ctx)
+	if err != nil {
+		return ok, kv, err
+	}
+	if !ok {
+		return false, kv, nil
+	}
+	return rf.nextKV(ctx)
 }
 
 // NextKey retrieves the next key/value and sets kv/kvEnd. Returns whether a row
@@ -413,7 +432,7 @@ func (rf *RowFetcher) NextKey(ctx context.Context) (rowDone bool, err error) {
 	var ok bool
 
 	for {
-		ok, rf.kv, err = rf.kvFetcher.nextKV(ctx)
+		ok, rf.kv, err = rf.nextKV(ctx)
 		if err != nil {
 			return false, err
 		}


### PR DESCRIPTION
This change is in preparation for passing batches of rows from the
rowfetcher to callers.

Release note: None