### PR TITLE
sql, sem/tree: rename the 'Database' field to 'Schema'

### DIFF
--- a/pkg/ccl/sqlccl/targets.go
+++ b/pkg/ccl/sqlccl/targets.go
@@ -92,7 +92,7 @@ func descriptorsMatchingTargets(
 					return ret, err
 				}
 			}
-			db := string(p.DatabaseName)
+			db := string(p.SchemaName)
 			tablesByDatabase[db] = append(tablesByDatabase[db], table{
 				name:     string(p.TableName),
 				validity: maybeValid,
@@ -103,7 +103,7 @@ func descriptorsMatchingTargets(
 					return ret, err
 				}
 			}
-			starByDatabase[string(p.Database)] = maybeValid
+			starByDatabase[string(p.Schema)] = maybeValid
 		default:
 			return ret, errors.Errorf("unknown pattern %T: %+v", pattern, pattern)
 		}

--- a/pkg/cli/dump.go
+++ b/pkg/cli/dump.go
@@ -234,7 +234,9 @@ func getTableNames(conn *sqlConn, dbName string, ts string) (tableNames []string
 }
 
 func getBasicMetadata(conn *sqlConn, dbName, tableName string, ts string) (basicMetadata, error) {
-	// Get id, create statement, and kind.
+	name := &tree.TableName{SchemaName: tree.Name(dbName), TableName: tree.Name(tableName)}
+
+	// Fetch table ID.
 	dbNameEscaped := tree.NameString(dbName)
 	vals, err := conn.QueryRow(fmt.Sprintf(`
 		SELECT
@@ -248,9 +250,8 @@ func getBasicMetadata(conn *sqlConn, dbName, tableName string, ts string) (basic
 	`, dbNameEscaped, lex.EscapeSQLString(ts)), []driver.Value{dbName, tableName})
 	if err != nil {
 		if err == io.EOF {
-			tn := tree.TableName{DatabaseName: tree.Name(dbName), TableName: tree.Name(tableName)}
 			return basicMetadata{}, errors.Wrap(
-				errors.Errorf("relation %s does not exist", tree.ErrString(&tn)),
+				errors.Errorf("relation %s does not exist", tree.ErrString(name)),
 				"getBasicMetadata",
 			)
 		}
@@ -300,7 +301,7 @@ func getBasicMetadata(conn *sqlConn, dbName, tableName string, ts string) (basic
 
 	return basicMetadata{
 		ID:         id,
-		name:       &tree.TableName{DatabaseName: tree.Name(dbName), TableName: tree.Name(tableName)},
+		name:       &tree.TableName{SchemaName: tree.Name(dbName), TableName: tree.Name(tableName)},
 		createStmt: createStatement,
 		dependsOn:  refs,
 		kind:       kind,
@@ -315,7 +316,7 @@ func getMetadataForTable(conn *sqlConn, md basicMetadata, ts string) (tableMetad
 		AS OF SYSTEM TIME %s
 		WHERE TABLE_SCHEMA = $1
 			AND TABLE_NAME = $2
-		`, lex.EscapeSQLString(ts)), []driver.Value{md.name.Database(), md.name.Table()})
+		`, lex.EscapeSQLString(ts)), []driver.Value{md.name.Schema(), md.name.Table()})
 	if err != nil {
 		return tableMetadata{}, err
 	}

--- a/pkg/config/zone.go
+++ b/pkg/config/zone.go
@@ -76,7 +76,7 @@ func ZoneSpecifierFromID(
 	if err != nil {
 		return tree.ZoneSpecifier{}, err
 	}
-	tn := &tree.TableName{DatabaseName: tree.Name(db), TableName: tree.Name(name)}
+	tn := &tree.TableName{SchemaName: tree.Name(db), TableName: tree.Name(name)}
 	return tree.ZoneSpecifier{
 		TableOrIndex: tree.TableNameWithIndex{
 			Table: tree.NormalizableTableName{TableNameReference: tn},
@@ -147,7 +147,7 @@ func CLIZoneSpecifier(zs *tree.ZoneSpecifier) string {
 	if zs.Partition != "" {
 		tn := ti.Table.TableName()
 		ti.Table = tree.NormalizableTableName{
-			TableNameReference: &tree.UnresolvedName{&tn.DatabaseName, &tn.TableName, &zs.Partition},
+			TableNameReference: &tree.UnresolvedName{&tn.SchemaName, &tn.TableName, &zs.Partition},
 		}
 		// The index is redundant when the partition is specified, so omit it.
 		ti.Index = ""
@@ -180,7 +180,7 @@ func ResolveZoneSpecifier(
 	if err != nil {
 		return 0, err
 	}
-	databaseID, err := resolveName(keys.RootNamespaceID, tn.Database())
+	databaseID, err := resolveName(keys.RootNamespaceID, tn.Schema())
 	if err != nil {
 		return 0, err
 	}

--- a/pkg/sql/alter_user.go
+++ b/pkg/sql/alter_user.go
@@ -36,7 +36,7 @@ type alterUserSetPasswordNode struct {
 func (p *planner) AlterUserSetPassword(
 	ctx context.Context, n *tree.AlterUserSetPassword,
 ) (planNode, error) {
-	tDesc, err := getTableDesc(ctx, p.txn, p.getVirtualTabler(), &tree.TableName{DatabaseName: "system", TableName: "users"})
+	tDesc, err := getTableDesc(ctx, p.txn, p.getVirtualTabler(), &tree.TableName{SchemaName: "system", TableName: "users"})
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/create_sequence.go
+++ b/pkg/sql/create_sequence.go
@@ -35,7 +35,7 @@ func (p *planner) CreateSequence(ctx context.Context, n *tree.CreateSequence) (p
 		return nil, err
 	}
 
-	dbDesc, err := MustGetDatabaseDesc(ctx, p.txn, p.getVirtualTabler(), name.Database())
+	dbDesc, err := MustGetDatabaseDesc(ctx, p.txn, p.getVirtualTabler(), name.Schema())
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -53,7 +53,7 @@ func (p *planner) CreateTable(ctx context.Context, n *tree.CreateTable) (planNod
 		return nil, err
 	}
 
-	dbDesc, err := MustGetDatabaseDesc(ctx, p.txn, p.getVirtualTabler(), tn.Database())
+	dbDesc, err := MustGetDatabaseDesc(ctx, p.txn, p.getVirtualTabler(), tn.Schema())
 	if err != nil {
 		return nil, err
 	}
@@ -518,8 +518,8 @@ func resolveFK(
 					"cannot add a SET NULL cascading action on column %q which has a NOT NULL constraint",
 					tree.ErrString(&tree.ColumnItem{
 						TableName: tree.TableName{
-							DatabaseName: tree.Name(database.Name),
-							TableName:    tree.Name(tbl.Name),
+							SchemaName: tree.Name(database.Name),
+							TableName:  tree.Name(tbl.Name),
 						},
 						ColumnName: tree.Name(sourceColumn.Name),
 					}),
@@ -541,8 +541,8 @@ func resolveFK(
 					"cannot add a SET DEFAULT cascading action on column %q which has no DEFAULT expression",
 					tree.ErrString(&tree.ColumnItem{
 						TableName: tree.TableName{
-							DatabaseName: tree.Name(database.Name),
-							TableName:    tree.Name(tbl.Name),
+							SchemaName: tree.Name(database.Name),
+							TableName:  tree.Name(tbl.Name),
 						},
 						ColumnName: tree.Name(sourceColumn.Name),
 					}),

--- a/pkg/sql/create_user.go
+++ b/pkg/sql/create_user.go
@@ -47,7 +47,7 @@ func (p *planner) CreateUser(ctx context.Context, n *tree.CreateUser) (planNode,
 func (p *planner) CreateUserNode(
 	ctx context.Context, nameE, passwordE tree.Expr, ifNotExists bool, isRole bool, opName string,
 ) (*CreateUserNode, error) {
-	tDesc, err := getTableDesc(ctx, p.txn, p.getVirtualTabler(), &tree.TableName{DatabaseName: "system", TableName: "users"})
+	tDesc, err := getTableDesc(ctx, p.txn, p.getVirtualTabler(), &tree.TableName{SchemaName: "system", TableName: "users"})
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/create_view.go
+++ b/pkg/sql/create_view.go
@@ -48,7 +48,7 @@ func (p *planner) CreateView(ctx context.Context, n *tree.CreateView) (planNode,
 		return nil, err
 	}
 
-	dbDesc, err := MustGetDatabaseDesc(ctx, p.txn, p.getVirtualTabler(), name.Database())
+	dbDesc, err := MustGetDatabaseDesc(ctx, p.txn, p.getVirtualTabler(), name.Schema())
 	if err != nil {
 		return nil, err
 	}
@@ -75,7 +75,7 @@ func (p *planner) CreateView(ctx context.Context, n *tree.CreateView) (planNode,
 					return
 				}
 				// Persist the database prefix expansion.
-				tn.OmitDBNameDuringFormatting = false
+				tn.OmitSchemaNameDuringFormatting = false
 			},
 		)
 		f.FormatNode(n.AsSource)

--- a/pkg/sql/drop_user.go
+++ b/pkg/sql/drop_user.go
@@ -47,7 +47,7 @@ func (p *planner) DropUser(ctx context.Context, n *tree.DropUser) (planNode, err
 func (p *planner) DropUserNode(
 	ctx context.Context, namesE tree.Exprs, ifExists bool, isRole bool, opName string,
 ) (*DropUserNode, error) {
-	tDesc, err := getTableDesc(ctx, p.txn, p.getVirtualTabler(), &tree.TableName{DatabaseName: "system", TableName: "users"})
+	tDesc, err := getTableDesc(ctx, p.txn, p.getVirtualTabler(), &tree.TableName{SchemaName: "system", TableName: "users"})
 	if err != nil {
 		return nil, err
 	}
@@ -118,8 +118,8 @@ func (n *DropUserNode) startExec(params runParams) error {
 			for _, u := range table.GetPrivileges().Users {
 				if _, ok := userNames[u.User]; ok {
 					tn := tree.TableName{
-						DatabaseName: tree.Name(db.Name),
-						TableName:    tree.Name(table.Name),
+						SchemaName: tree.Name(db.Name),
+						TableName:  tree.Name(table.Name),
 					}
 					if f.Len() > 0 {
 						f.WriteString(", ")

--- a/pkg/sql/internal.go
+++ b/pkg/sql/internal.go
@@ -106,7 +106,7 @@ func (ie *InternalExecutor) GetTableSpan(
 	defer cleanup()
 	ie.initSession(p)
 
-	tn := tree.TableName{DatabaseName: tree.Name(dbName), TableName: tree.Name(tableName)}
+	tn := tree.TableName{SchemaName: tree.Name(dbName), TableName: tree.Name(tableName)}
 	tableID, err := getTableID(ctx, p, &tn)
 	if err != nil {
 		return roachpb.Span{}, err
@@ -142,7 +142,7 @@ func getTableID(ctx context.Context, p *planner, tn *tree.TableName) (sqlbase.ID
 		return retryable(ctx, p.txn)
 	}
 
-	dbID, err := p.Tables().databaseCache.getDatabaseID(ctx, txnRunner, p.getVirtualTabler(), tn.Database())
+	dbID, err := p.Tables().databaseCache.getDatabaseID(ctx, txnRunner, p.getVirtualTabler(), tn.Schema())
 	if err != nil {
 		return 0, err
 	}

--- a/pkg/sql/opt/build/builder_test.go
+++ b/pkg/sql/opt/build/builder_test.go
@@ -72,7 +72,7 @@ type testCatalog struct {
 
 // FindTable implements the sqlbase.Catalog interface.
 func (c testCatalog) FindTable(ctx context.Context, name *tree.TableName) (optbase.Table, error) {
-	return sqlbase.GetTableDescriptor(c.kvDB, string(name.DatabaseName), string(name.TableName)), nil
+	return sqlbase.GetTableDescriptor(c.kvDB, string(name.SchemaName), string(name.TableName)), nil
 }
 
 func TestBuilder(t *testing.T) {

--- a/pkg/sql/opt/build/scope.go
+++ b/pkg/sql/opt/build/scope.go
@@ -85,7 +85,7 @@ func (s *scope) VisitPre(expr tree.Expr) (recurse bool, newExpr tree.Expr) {
 					if tblName == "" && col.table != "" {
 						// TODO(andy): why is this necessary??
 						t.TableName.TableName = tree.Name(col.table)
-						t.TableName.OmitDBNameDuringFormatting = true
+						t.TableName.OmitSchemaNameDuringFormatting = true
 					}
 					return false, col
 				}

--- a/pkg/sql/opt/opt_test.go
+++ b/pkg/sql/opt/opt_test.go
@@ -113,7 +113,7 @@ type testCatalog struct {
 
 // FindTable implements the sqlbase.Catalog interface.
 func (c testCatalog) FindTable(ctx context.Context, name *tree.TableName) (optbase.Table, error) {
-	return sqlbase.GetTableDescriptor(c.kvDB, string(name.DatabaseName), string(name.TableName)), nil
+	return sqlbase.GetTableDescriptor(c.kvDB, string(name.SchemaName), string(name.TableName)), nil
 }
 
 func TestOpt(t *testing.T) {

--- a/pkg/sql/opt/scope.go
+++ b/pkg/sql/opt/scope.go
@@ -72,7 +72,7 @@ func (s *scope) VisitPre(expr tree.Expr) (recurse bool, newExpr tree.Expr) {
 					// TODO(peter): what is this doing?
 					if tblName == "" && col.table != "" {
 						t.TableName.TableName = tree.Name(col.table)
-						t.TableName.OmitDBNameDuringFormatting = true
+						t.TableName.OmitSchemaNameDuringFormatting = true
 					}
 					return false, col
 				}

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -727,8 +727,8 @@ CREATE TABLE pg_catalog.pg_depend (
 			p.txn,
 			p.getVirtualTabler(),
 			&tree.TableName{
-				DatabaseName: pgCatalogName,
-				TableName:    "pg_constraint"},
+				SchemaName: pgCatalogName,
+				TableName:  "pg_constraint"},
 		)
 		if err != nil {
 			return errors.New("could not find pg_catalog.pg_constraint")
@@ -740,8 +740,8 @@ CREATE TABLE pg_catalog.pg_depend (
 			p.txn,
 			p.getVirtualTabler(),
 			&tree.TableName{
-				DatabaseName: pgCatalogName,
-				TableName:    "pg_class"},
+				SchemaName: pgCatalogName,
+				TableName:  "pg_class"},
 		)
 		if err != nil {
 			return errors.New("could not find pg_catalog.pg_class")
@@ -1004,8 +1004,8 @@ func indexDefFromDescriptor(
 		Name: tree.Name(index.Name),
 		Table: tree.NormalizableTableName{
 			TableNameReference: &tree.TableName{
-				DatabaseName: tree.Name(db.Name),
-				TableName:    tree.Name(table.Name),
+				SchemaName: tree.Name(db.Name),
+				TableName:  tree.Name(table.Name),
 			},
 		},
 		Unique:  index.Unique,
@@ -1043,8 +1043,8 @@ func indexDefFromDescriptor(
 		intlDef := &tree.InterleaveDef{
 			Parent: &tree.NormalizableTableName{
 				TableNameReference: &tree.TableName{
-					DatabaseName: tree.Name(parentDb.Name),
-					TableName:    tree.Name(parentTable.Name),
+					SchemaName: tree.Name(parentDb.Name),
+					TableName:  tree.Name(parentTable.Name),
 				},
 			},
 			Fields: make(tree.NameList, len(fields)),

--- a/pkg/sql/rename_table.go
+++ b/pkg/sql/rename_table.go
@@ -42,7 +42,7 @@ func (p *planner) RenameTable(ctx context.Context, n *tree.RenameTable) (planNod
 		return nil, err
 	}
 
-	dbDesc, err := MustGetDatabaseDesc(ctx, p.txn, p.getVirtualTabler(), oldTn.Database())
+	dbDesc, err := MustGetDatabaseDesc(ctx, p.txn, p.getVirtualTabler(), oldTn.Schema())
 	if err != nil {
 		return nil, err
 	}
@@ -96,7 +96,7 @@ func (p *planner) RenameTable(ctx context.Context, n *tree.RenameTable) (planNod
 	}
 
 	// Check if target database exists.
-	targetDbDesc, err := MustGetDatabaseDesc(ctx, p.txn, p.getVirtualTabler(), newTn.Database())
+	targetDbDesc, err := MustGetDatabaseDesc(ctx, p.txn, p.getVirtualTabler(), newTn.Schema())
 	if err != nil {
 		return nil, err
 	}
@@ -106,7 +106,7 @@ func (p *planner) RenameTable(ctx context.Context, n *tree.RenameTable) (planNod
 	}
 
 	// oldTn and newTn are already normalized, so we can compare directly here.
-	if oldTn.Database() == newTn.Database() && oldTn.Table() == newTn.Table() {
+	if oldTn.Schema() == newTn.Schema() && oldTn.Table() == newTn.Table() {
 		// Noop.
 		return &zeroNode{}, nil
 	}

--- a/pkg/sql/scrub_constraint.go
+++ b/pkg/sql/scrub_constraint.go
@@ -156,7 +156,7 @@ func (o *sqlCheckConstraintCheckOperation) Next(params runParams) (tree.Datums, 
 		// TODO(joey): Add the job UUID once the SCRUB command uses jobs.
 		tree.DNull, /* job_uuid */
 		tree.NewDString(scrub.CheckConstraintViolation),
-		tree.NewDString(o.tableName.Database()),
+		tree.NewDString(o.tableName.Schema()),
 		tree.NewDString(o.tableName.Table()),
 		tree.NewDString(primaryKeyDatums.String()),
 		timestamp,

--- a/pkg/sql/scrub_fk.go
+++ b/pkg/sql/scrub_fk.go
@@ -66,7 +66,7 @@ func newSQLForeignKeyCheckOperation(
 // runs in the distSQL execution engine.
 func (o *sqlForeignKeyCheckOperation) Start(params runParams) error {
 	ctx := params.ctx
-	checkQuery, err := createFKCheckQuery(o.tableName.Database(), o.tableDesc, o.constraint, o.asOf)
+	checkQuery, err := createFKCheckQuery(o.tableName.Schema(), o.tableDesc, o.constraint, o.asOf)
 	if err != nil {
 		return err
 	}
@@ -185,7 +185,7 @@ func (o *sqlForeignKeyCheckOperation) Next(params runParams) (tree.Datums, error
 		// TODO(joey): Add the job UUID once the SCRUB command uses jobs.
 		tree.DNull, /* job_uuid */
 		tree.NewDString(scrub.ForeignKeyConstraintViolation),
-		tree.NewDString(o.tableName.Database()),
+		tree.NewDString(o.tableName.Schema()),
 		tree.NewDString(o.tableName.Table()),
 		tree.NewDString(primaryKeyDatums.String()),
 		tree.MakeDTimestamp(params.extendedEvalCtx.GetStmtTimestamp(), time.Nanosecond),

--- a/pkg/sql/scrub_index.go
+++ b/pkg/sql/scrub_index.go
@@ -218,7 +218,7 @@ func (o *indexCheckOperation) Next(params runParams) (tree.Datums, error) {
 		// TODO(joey): Add the job UUID once the SCRUB command uses jobs.
 		tree.DNull, /* job_uuid */
 		errorType,
-		tree.NewDString(o.tableName.Database()),
+		tree.NewDString(o.tableName.Schema()),
 		tree.NewDString(o.tableName.Table()),
 		primaryKey,
 		timestamp,

--- a/pkg/sql/scrub_physical.go
+++ b/pkg/sql/scrub_physical.go
@@ -171,7 +171,7 @@ func (o *physicalCheckOperation) Next(params runParams) (tree.Datums, error) {
 		// TODO(joey): Add the job UUID once the SCRUB command uses jobs.
 		tree.DNull, /* job_uuid */
 		row[0],     /* errorType */
-		tree.NewDString(o.tableName.Database()),
+		tree.NewDString(o.tableName.Schema()),
 		tree.NewDString(o.tableName.Table()),
 		row[1], /* primaryKey */
 		timestamp,

--- a/pkg/sql/select_name_resolution_test.go
+++ b/pkg/sql/select_name_resolution_test.go
@@ -31,7 +31,7 @@ func testInitDummySelectNode(p *planner, desc *sqlbase.TableDescriptor) *renderN
 
 	sel := &renderNode{}
 	sel.source.plan = scan
-	testName := tree.TableName{TableName: tree.Name(desc.Name), DatabaseName: tree.Name("test")}
+	testName := tree.TableName{TableName: tree.Name(desc.Name), SchemaName: tree.Name("test")}
 	cols := planColumns(scan)
 	sel.source.info = newSourceInfoForSingleTable(testName, cols)
 	sel.sourceInfo = multiSourceInfo{sel.source.info}

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -2906,7 +2906,7 @@ func performCast(ctx *EvalContext, d Datum, t coltypes.CastTargetType) (Datum, e
 				// queryOid like everyone else.
 				return queryOidWithJoin(ctx, typ, NewDString(tn.Table()),
 					"JOIN pg_catalog.pg_namespace ON relnamespace = pg_namespace.oid",
-					fmt.Sprintf("AND nspname = '%s'", tn.Database()))
+					fmt.Sprintf("AND nspname = '%s'", tn.Schema()))
 			default:
 				return queryOid(ctx, typ, NewDString(s))
 			}

--- a/pkg/sql/sem/tree/function_name.go
+++ b/pkg/sql/sem/tree/function_name.go
@@ -129,7 +129,7 @@ func (n *UnresolvedName) normalizeFunctionName() (functionName, error) {
 
 	// Everything afterwards is the selector.
 	return functionName{
-		prefixName:   tn.DatabaseName,
+		prefixName:   tn.SchemaName,
 		functionName: tn.TableName,
 		selector:     NameParts((*n)[i:]),
 	}, nil

--- a/pkg/sql/sem/tree/table_name_test.go
+++ b/pkg/sql/sem/tree/table_name_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 func resetRepr(tn *tree.TableName) {
-	tn.OmitDBNameDuringFormatting = false
+	tn.OmitSchemaNameDuringFormatting = false
 }
 
 func TestNormalizeTableName(t *testing.T) {
@@ -42,7 +42,7 @@ func TestNormalizeTableName(t *testing.T) {
 		{`foo`, ``, ``, `no database specified`},
 		{`foo@bar`, ``, ``, `syntax error`},
 		{`test.*`, ``, ``, `invalid table name: "test\.\*"`},
-		{`p."".bar`, ``, ``, `empty database name: "p\.\.bar"`},
+		{`p."".bar`, ``, ``, `empty schema name: "p\.\.bar"`},
 	}
 
 	for _, tc := range testCases {

--- a/pkg/sql/sem/tree/var_name.go
+++ b/pkg/sql/sem/tree/var_name.go
@@ -113,8 +113,8 @@ type AllColumnsSelector struct {
 
 // Format implements the NodeFormatter interface.
 func (a *AllColumnsSelector) Format(ctx *FmtCtx) {
-	if !a.TableName.OmitDBNameDuringFormatting {
-		ctx.FormatNode(&a.TableName.DatabaseName)
+	if !a.TableName.OmitSchemaNameDuringFormatting {
+		ctx.FormatNode(&a.TableName.SchemaName)
 		ctx.WriteByte('.')
 	}
 	ctx.FormatNode(&a.TableName.TableName)
@@ -156,8 +156,8 @@ type ColumnItem struct {
 // Format implements the NodeFormatter interface.
 func (c *ColumnItem) Format(ctx *FmtCtx) {
 	if c.TableName.TableName != "" {
-		if !c.TableName.OmitDBNameDuringFormatting {
-			ctx.FormatNode(&c.TableName.DatabaseName)
+		if !c.TableName.OmitSchemaNameDuringFormatting {
+			ctx.FormatNode(&c.TableName.SchemaName)
 			ctx.WriteByte('.')
 		}
 		ctx.FormatNode(&c.TableName.TableName)

--- a/pkg/sql/show_create.go
+++ b/pkg/sql/show_create.go
@@ -126,9 +126,9 @@ func (p *planner) printForeignKeyConstraint(
 		return err
 	}
 	fkTableName := tree.TableName{
-		DatabaseName:               tree.Name(fkDb.Name),
-		TableName:                  tree.Name(fkTable.Name),
-		OmitDBNameDuringFormatting: fkDb.Name == dbPrefix,
+		SchemaName:                     tree.Name(fkDb.Name),
+		TableName:                      tree.Name(fkTable.Name),
+		OmitSchemaNameDuringFormatting: fkDb.Name == dbPrefix,
 	}
 	fmtCtx := tree.MakeFmtCtx(buf, tree.FmtSimple)
 	buf.WriteString("FOREIGN KEY (")
@@ -303,9 +303,9 @@ func (p *planner) showCreateInterleave(
 		return err
 	}
 	parentName := tree.TableName{
-		DatabaseName:               tree.Name(parentDbDesc.Name),
-		TableName:                  tree.Name(parentTable.Name),
-		OmitDBNameDuringFormatting: parentDbDesc.Name == dbPrefix,
+		SchemaName:                     tree.Name(parentDbDesc.Name),
+		TableName:                      tree.Name(parentTable.Name),
+		OmitSchemaNameDuringFormatting: parentDbDesc.Name == dbPrefix,
 	}
 	var sharedPrefixLen int
 	for _, ancestor := range intl.Ancestors {

--- a/pkg/sql/show_grants.go
+++ b/pkg/sql/show_grants.go
@@ -110,7 +110,7 @@ func (p *planner) ShowGrants(ctx context.Context, n *tree.ShowGrants) (planNode,
 
 			for i := range allTables {
 				params = append(params, fmt.Sprintf("(%s,%s)",
-					lex.EscapeSQLString(allTables[i].Database()),
+					lex.EscapeSQLString(allTables[i].Schema()),
 					lex.EscapeSQLString(allTables[i].Table())))
 			}
 

--- a/pkg/sql/show_table.go
+++ b/pkg/sql/show_table.go
@@ -37,7 +37,7 @@ func (p *planner) showTableDetails(
 	if err != nil {
 		return nil, err
 	}
-	db := tn.Database()
+	db := tn.Schema()
 
 	initialCheck := func(ctx context.Context) error {
 		if err := checkDBExists(ctx, p, db); err != nil {
@@ -55,7 +55,7 @@ func (p *planner) showTableDetails(
 			lex.EscapeSQLString(db),
 			lex.EscapeSQLString(tn.Table()),
 			lex.EscapeSQLString(tn.String()),
-			tn.DatabaseName.String()),
+			tn.SchemaName.String()),
 		initialCheck, nil)
 }
 

--- a/pkg/sql/show_trace.go
+++ b/pkg/sql/show_trace.go
@@ -297,8 +297,8 @@ func (n *showTraceNode) Close(ctx context.Context) {
 }
 
 var sessionTraceTableName = tree.TableName{
-	DatabaseName: tree.Name("crdb_internal"),
-	TableName:    tree.Name("session_trace"),
+	SchemaName: tree.Name("crdb_internal"),
+	TableName:  tree.Name("session_trace"),
 }
 
 var errTracingAlreadyEnabled = errors.New(

--- a/pkg/sql/show_zone_config.go
+++ b/pkg/sql/show_zone_config.go
@@ -163,7 +163,7 @@ func ascendZoneSpecifier(
 	} else if resolvedID != actualID {
 		// We traversed at least one level up, and we're not at the top of the
 		// hierarchy, so we're showing the database zone config.
-		zs.Database = zs.TableOrIndex.Table.TableName().DatabaseName
+		zs.Database = zs.TableOrIndex.Table.TableName().SchemaName
 	} else if actualSubzone == nil {
 		// We didn't find a subzone, so no index or partition zone config exists.
 		zs.TableOrIndex.Index = ""

--- a/pkg/sql/sqlbase/cascader.go
+++ b/pkg/sql/sqlbase/cascader.go
@@ -800,8 +800,8 @@ func (c *cascader) updateRows(
 										"cannot cascade a null value into %q as it violates a NOT NULL constraint",
 										tree.ErrString(&tree.ColumnItem{
 											TableName: tree.TableName{
-												DatabaseName: tree.Name(database.Name),
-												TableName:    tree.Name(referencingTable.Name),
+												SchemaName: tree.Name(database.Name),
+												TableName:  tree.Name(referencingTable.Name),
 											},
 											ColumnName: tree.Name(column.Name),
 										}),

--- a/pkg/sql/table.go
+++ b/pkg/sql/table.go
@@ -112,7 +112,7 @@ func getTableOrViewDesc(
 		return virtual, err
 	}
 
-	dbDesc, err := MustGetDatabaseDesc(ctx, txn, vt, tn.Database())
+	dbDesc, err := MustGetDatabaseDesc(ctx, txn, vt, tn.Schema())
 	if err != nil {
 		return nil, err
 	}
@@ -315,8 +315,8 @@ func (tc *TableCollection) getTableVersion(
 		log.Infof(ctx, "planner acquiring lease on table '%s'", tn)
 	}
 
-	isSystemDB := tn.Database() == sqlbase.SystemDB.Name
-	isVirtualDB := vt.getVirtualDatabaseDesc(tn.Database()) != nil
+	isSystemDB := tn.Schema() == sqlbase.SystemDB.Name
+	isVirtualDB := vt.getVirtualDatabaseDesc(tn.Schema()) != nil
 	if isSystemDB || isVirtualDB || testDisableTableLeases {
 		// We don't go through the normal lease mechanism for:
 		// - system tables. The system.lease and system.descriptor table, in
@@ -341,7 +341,7 @@ func (tc *TableCollection) getTableVersion(
 	if dbID == 0 {
 		// Resolve the database from the database cache when the transaction
 		// hasn't modified the database.
-		dbID, err = tc.databaseCache.getDatabaseID(ctx, tc.leaseMgr.execCfg.DB.Txn, vt, tn.Database())
+		dbID, err = tc.databaseCache.getDatabaseID(ctx, tc.leaseMgr.execCfg.DB.Txn, vt, tn.Schema())
 		if err != nil {
 			return nil, err
 		}
@@ -492,7 +492,7 @@ func (tc *TableCollection) getUncommittedDatabaseID(tn *tree.TableName) (sqlbase
 	// Walk latest to earliest.
 	for i := len(tc.uncommittedDatabases) - 1; i >= 0; i-- {
 		db := tc.uncommittedDatabases[i]
-		if tn.Database() == db.name {
+		if tn.Schema() == db.name {
 			if db.dropped {
 				return 0, sqlbase.NewUndefinedRelationError(tn)
 			}
@@ -585,9 +585,9 @@ func getTableNames(
 			return nil, err
 		}
 		tn := tree.TableName{
-			DatabaseName:               tree.Name(dbDesc.Name),
-			TableName:                  tree.Name(tableName),
-			OmitDBNameDuringFormatting: dbNameOriginallyOmitted,
+			SchemaName:                     tree.Name(dbDesc.Name),
+			TableName:                      tree.Name(tableName),
+			OmitSchemaNameDuringFormatting: dbNameOriginallyOmitted,
 		}
 		tableNames = append(tableNames, tn)
 	}
@@ -724,12 +724,12 @@ func expandTableGlob(
 		return nil, err
 	}
 
-	dbDesc, err := MustGetDatabaseDesc(ctx, txn, vt, string(glob.Database))
+	dbDesc, err := MustGetDatabaseDesc(ctx, txn, vt, string(glob.Schema))
 	if err != nil {
 		return nil, err
 	}
 
-	tableNames, err := getTableNames(ctx, txn, vt, dbDesc, glob.OmitDBNameDuringFormatting)
+	tableNames, err := getTableNames(ctx, txn, vt, dbDesc, glob.OmitSchemaNameDuringFormatting)
 	if err != nil {
 		return nil, err
 	}
@@ -751,7 +751,7 @@ func (p *planner) searchAndQualifyDatabase(ctx context.Context, tn *tree.TableNa
 	}
 
 	if p.SessionData().Database != "" {
-		t.DatabaseName = tree.Name(p.SessionData().Database)
+		t.SchemaName = tree.Name(p.SessionData().Database)
 		desc, err := descFunc(ctx, p.txn, p.getVirtualTabler(), &t)
 		if err != nil && !sqlbase.IsUndefinedRelationError(err) && !sqlbase.IsUndefinedDatabaseError(err) {
 			return err
@@ -767,7 +767,7 @@ func (p *planner) searchAndQualifyDatabase(ctx context.Context, tn *tree.TableNa
 	// the search path instead.
 	iter := p.SessionData().SearchPath.Iter()
 	for database, ok := iter(); ok; database, ok = iter() {
-		t.DatabaseName = tree.Name(database)
+		t.SchemaName = tree.Name(database)
 		desc, err := descFunc(ctx, p.txn, p.getVirtualTabler(), &t)
 		if err != nil && !sqlbase.IsUndefinedRelationError(err) && !sqlbase.IsUndefinedDatabaseError(err) {
 			return err
@@ -792,8 +792,8 @@ func (p *planner) getQualifiedTableName(
 		return "", err
 	}
 	tbName := tree.TableName{
-		DatabaseName: tree.Name(dbDesc.Name),
-		TableName:    tree.Name(desc.Name),
+		SchemaName: tree.Name(dbDesc.Name),
+		TableName:  tree.Name(desc.Name),
 	}
 	return tbName.String(), nil
 }
@@ -875,7 +875,7 @@ func (p *planner) expandIndexName(
 		realTableName, err := p.findTableContainingIndex(
 			ctx,
 			p.txn, p.getVirtualTabler(),
-			tn.DatabaseName,
+			tn.SchemaName,
 			index.Index,
 			requireTable,
 		)
@@ -954,9 +954,9 @@ func resolveTableNameFromID(
 	table := tables[tableID]
 	tn := tree.TableName{TableName: tree.Name(table.Name)}
 	if parentDB, ok := databases[table.ParentID]; ok {
-		tn.DatabaseName = tree.Name(parentDB.Name)
+		tn.SchemaName = tree.Name(parentDB.Name)
 	} else {
-		tn.DatabaseName = tree.Name(fmt.Sprintf("[%d]", table.ParentID))
+		tn.SchemaName = tree.Name(fmt.Sprintf("[%d]", table.ParentID))
 		log.Errorf(ctx, "relation [%d] (%q) has no parent database (corrupted schema?)",
 			tableID, tree.ErrString(&tn))
 	}

--- a/pkg/sql/virtual_schema.go
+++ b/pkg/sql/virtual_schema.go
@@ -87,9 +87,9 @@ func (e virtualSchemaEntry) tableNames(dbNameOriginallyOmitted bool) tree.TableN
 	var res tree.TableNames
 	for _, tableName := range e.orderedTableNames {
 		tn := tree.TableName{
-			DatabaseName:               tree.Name(e.desc.Name),
-			TableName:                  tree.Name(tableName),
-			OmitDBNameDuringFormatting: dbNameOriginallyOmitted,
+			SchemaName:                     tree.Name(e.desc.Name),
+			TableName:                      tree.Name(tableName),
+			OmitSchemaNameDuringFormatting: dbNameOriginallyOmitted,
 		}
 		res = append(res, tn)
 	}
@@ -276,7 +276,7 @@ func (e *Executor) IsVirtualDatabase(name string) bool {
 // but the table is non-existent.
 // getVirtualTableEntry is part of the VirtualTabler interface.
 func (vs *VirtualSchemaHolder) getVirtualTableEntry(tn *tree.TableName) (virtualTableEntry, error) {
-	if db, ok := vs.getVirtualSchemaEntry(string(tn.DatabaseName)); ok {
+	if db, ok := vs.getVirtualSchemaEntry(string(tn.SchemaName)); ok {
 		if t, ok := db.tables[string(tn.TableName)]; ok {
 			return t, nil
 		}

--- a/pkg/sql/with.go
+++ b/pkg/sql/with.go
@@ -109,7 +109,7 @@ func (p *planner) getCTEDataSource(t *tree.NormalizableTableName) (planDataSourc
 	// Iterate backward through the environment, most recent frame first.
 	for i := range p.curPlan.cteNameEnvironment {
 		frame := p.curPlan.cteNameEnvironment[len(p.curPlan.cteNameEnvironment)-1-i]
-		if tn.DatabaseName == "" && tn.PrefixName == "" {
+		if tn.SchemaName == "" && tn.PrefixName == "" {
 			if cteSource, ok := frame[tn.TableName]; ok {
 				if cteSource.used {
 					// TODO(jordan): figure out how to lift this restriction.


### PR DESCRIPTION
Forked off #21753 for easier review.

We're going to address the fact that the current syntactic field used
to determine the database corresponds to the schema in PostgreSQL.

The first step to enlightenment is to realize the extent of the
damage.  This commit does just this: it renames that syntactic
position in the AST types "TableName" and "AllTablesSelector" to
"Schema" and propagates the change.

Every where else where a "database name" is being assigned to /
compared with a field called "Schema" should then be considered wrong
and in want of correction. As far as I can see there is only one
location (extracting the virtual table descriptor inside a virtual
schema) which is doing the right thing.

Subsequent commits will improve the situation incrementally.

Release note: None