### PR TITLE
sql/sem/tree: make IMPORT use normalizable table references

### DIFF
--- a/pkg/ccl/sqlccl/csv.go
+++ b/pkg/ccl/sqlccl/csv.go
@@ -1001,8 +1001,7 @@ func importPlanHook(
 
 		var create *tree.CreateTable
 		if importStmt.CreateDefs != nil {
-			normName := tree.NormalizableTableName{TableNameReference: &importStmt.Table}
-			create = &tree.CreateTable{Table: normName, Defs: importStmt.CreateDefs}
+			create = &tree.CreateTable{Table: importStmt.Table, Defs: importStmt.CreateDefs}
 		} else {
 			filename, err := createFileFn()
 			if err != nil {

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -1569,11 +1569,11 @@ import_data_format:
 import_stmt:
   IMPORT TABLE table_name CREATE USING string_or_placeholder import_data_format DATA '(' string_or_placeholder_list ')' opt_with_options
   {
-    $$.val = &tree.Import{Table: $3.unresolvedName(), CreateFile: $6.expr(), FileFormat: $7, Files: $10.exprs(), Options: $12.kvOptions()}
+    $$.val = &tree.Import{Table: $3.normalizableTableNameFromUnresolvedName(), CreateFile: $6.expr(), FileFormat: $7, Files: $10.exprs(), Options: $12.kvOptions()}
   }
 | IMPORT TABLE table_name '(' table_elem_list ')' import_data_format DATA '(' string_or_placeholder_list ')' opt_with_options
   {
-    $$.val = &tree.Import{Table: $3.unresolvedName(), CreateDefs: $5.tblDefs(), FileFormat: $7, Files: $10.exprs(), Options: $12.kvOptions()}
+    $$.val = &tree.Import{Table: $3.normalizableTableNameFromUnresolvedName(), CreateDefs: $5.tblDefs(), FileFormat: $7, Files: $10.exprs(), Options: $12.kvOptions()}
   }
 | IMPORT error // SHOW HELP: IMPORT
 

--- a/pkg/sql/sem/tree/import.go
+++ b/pkg/sql/sem/tree/import.go
@@ -16,7 +16,7 @@ package tree
 
 // Import represents a IMPORT statement.
 type Import struct {
-	Table      UnresolvedName
+	Table      NormalizableTableName
 	CreateFile Expr
 	CreateDefs TableDefs
 	FileFormat string


### PR DESCRIPTION
... for consistency with every other use of `table_name`.

Forked off #21753 for easier review.

Release note: None