### PR TITLE
sql, sql/parser, sql/sem/tree: sanitize/simplify the handling of names

### DIFF
--- a/pkg/config/zone.go
+++ b/pkg/config/zone.go
@@ -105,18 +105,18 @@ func ParseCLIZoneSpecifier(s string) (tree.ZoneSpecifier, error) {
 	}
 	parsed.SearchTable = false
 	var partition tree.Name
-	if un := parsed.Table.TableNameReference.(*tree.UnresolvedName); len(*un) == 1 {
+	if un := parsed.Table.TableNameReference.(*tree.UnresolvedName); un.NumParts == 1 {
 		// Unlike in SQL, where a name with one part indicates a table in the
 		// current database, if a CLI specifier has just one name part, it indicates
 		// a database.
-		return tree.ZoneSpecifier{Database: *(*un)[0].(*tree.Name)}, nil
-	} else if len(*un) == 3 {
+		return tree.ZoneSpecifier{Database: tree.Name(un.Parts[0])}, nil
+	} else if un.NumParts == 3 {
 		// If a CLI specifier has three name parts, the last name is a partition.
 		// Pop it off so TableNameReference.Normalize sees only the table name
 		// below.
-		partition = *(*un)[2].(*tree.Name)
-		tPref := (*un)[:2]
-		parsed.Table.TableNameReference = &tPref
+		partition = tree.Name(un.Parts[0])
+		un.Parts[0], un.Parts[1], un.Parts[2] = un.Parts[1], un.Parts[2], un.Parts[3]
+		un.NumParts--
 	}
 	// We've handled the special cases for named zones, databases and partitions;
 	// have TableNameReference.Normalize tell us whether what remains is a valid
@@ -147,7 +147,10 @@ func CLIZoneSpecifier(zs *tree.ZoneSpecifier) string {
 	if zs.Partition != "" {
 		tn := ti.Table.TableName()
 		ti.Table = tree.NormalizableTableName{
-			TableNameReference: &tree.UnresolvedName{&tn.SchemaName, &tn.TableName, &zs.Partition},
+			TableNameReference: &tree.UnresolvedName{
+				NumParts: 3,
+				Parts:    tree.NameParts{string(zs.Partition), string(tn.TableName), string(tn.SchemaName)},
+			},
 		}
 		// The index is redundant when the partition is specified, so omit it.
 		ti.Index = ""

--- a/pkg/sql/data_source.go
+++ b/pkg/sql/data_source.go
@@ -939,10 +939,6 @@ func findColHelper(
 // source. Returns invalid indices and an error if the source is not
 // found or the name is ambiguous.
 func (sources multiSourceInfo) findColumn(c *tree.ColumnItem) (srcIdx int, colIdx int, err error) {
-	if len(c.Selector) > 0 {
-		return invalidSrcIdx, invalidColIdx, pgerror.UnimplementedWithIssueErrorf(8318, "compound types not supported yet: %q", c)
-	}
-
 	colName := string(c.ColumnName)
 	var tableName tree.TableName
 	if c.TableName.Table() != "" {

--- a/pkg/sql/expr_filter_test.go
+++ b/pkg/sql/expr_filter_test.go
@@ -194,8 +194,7 @@ func TestSplitFilter(t *testing.T) {
 					if colName == col {
 						// Convert to a VarName (to check that conversion happens correctly). It
 						// will print the same.
-						cn := tree.Name(colName)
-						return true, &tree.UnresolvedName{&cn}
+						return true, &tree.UnresolvedName{NumParts: 1, Parts: tree.NameParts{colName}}
 					}
 				}
 				return false, nil

--- a/pkg/sql/logictest/testdata/logic_test/pgoidtype
+++ b/pkg/sql/logictest/testdata/logic_test/pgoidtype
@@ -82,10 +82,13 @@ WHERE relname = 'pg_constraint'
 ----
 402060402  pg_constraint  402060402  pg_constraint  pg_constraint
 
-query OOO
-SELECT 'upper'::REGPROC, 'upper'::REGPROCEDURE, 'upper'::REGPROC::OID
+query OOOO
+SELECT 'upper'::REGPROC, 'upper'::REGPROCEDURE, 'pg_catalog.upper'::REGPROCEDURE, 'upper'::REGPROC::OID
 ----
-upper  upper  1736923753
+upper  upper  upper  1736923753
+
+query error invalid function name
+SELECT 'invalid.more.pg_catalog.upper'::REGPROCEDURE
 
 query OOO
 SELECT 'upper(int)'::REGPROC, 'upper(int)'::REGPROCEDURE, 'upper(int)'::REGPROC::OID
@@ -104,7 +107,7 @@ SELECT 'blah ()'::REGPROC
 query error unknown function: blah\(\)
 SELECT 'blah( )'::REGPROC
 
-query error unknown function: "blah\(, \)"\(\)
+query error unknown function: blah\(, \)\(\)
 SELECT 'blah(, )'::REGPROC
 
 query error more than one function named 'sqrt'

--- a/pkg/sql/logictest/testdata/logic_test/set
+++ b/pkg/sql/logictest/testdata/logic_test/set
@@ -62,7 +62,7 @@ SHOW TABLES from foo
 Table
 bar
 
-statement error invalid statement
+statement error invalid variable name: ""
 SET ROW (1, TRUE, NULL)
 
 statement ok

--- a/pkg/sql/parser/help.go
+++ b/pkg/sql/parser/help.go
@@ -135,9 +135,8 @@ func helpWithFunction(sqllex sqlLexer, f tree.ResolvableFunctionReference) int {
 }
 
 func helpWithFunctionByName(sqllex sqlLexer, s string) int {
-	n := tree.Name(s)
-	un := tree.UnresolvedName{&n}
-	return helpWithFunction(sqllex, tree.ResolvableFunctionReference{FunctionReference: &un})
+	un := &tree.UnresolvedName{NumParts: 1, Parts: tree.NameParts{s}}
+	return helpWithFunction(sqllex, tree.ResolvableFunctionReference{FunctionReference: un})
 }
 
 const (

--- a/pkg/sql/render.go
+++ b/pkg/sql/render.go
@@ -645,12 +645,7 @@ func getRenderColName(
 
 	switch t := target.Expr.(type) {
 	case *tree.ColumnItem:
-		// We only shorten the name of the result column to become the
-		// unqualified column part of this expr name if there is
-		// no additional subscript on the column.
-		if len(t.Selector) == 0 {
-			return t.Column(), nil
-		}
+		return t.Column(), nil
 
 	case *tree.FuncExpr:
 		// Special case for rendering builtin functions: the column name for an

--- a/pkg/sql/select_name_resolution.go
+++ b/pkg/sql/select_name_resolution.go
@@ -164,10 +164,11 @@ func (v *nameResolutionVisitor) VisitPre(expr tree.Expr) (recurse bool, newNode 
 				// columns. A * is invalid elsewhere (and will be caught by TypeCheck()).
 				// Replace the function with COUNT_ROWS (which doesn't take any
 				// arguments).
-				cr := tree.Name("COUNT_ROWS")
 				e := &tree.FuncExpr{
 					Func: tree.ResolvableFunctionReference{
-						FunctionReference: &tree.UnresolvedName{&cr},
+						FunctionReference: &tree.UnresolvedName{
+							NumParts: 1, Parts: tree.NameParts{"count_rows"},
+						},
 					},
 				}
 				// We call TypeCheck to fill in FuncExpr internals. This is a fixed

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -2874,9 +2874,17 @@ func performCast(ctx *EvalContext, d Datum, t coltypes.CastTargetType) (Datum, e
 				s = pgSignatureRegexp.ReplaceAllString(s, "$1")
 				// Resolve function name.
 				substrs := strings.Split(s, ".")
-				name := UnresolvedName{}
-				for i := range substrs {
-					name = append(name, (*Name)(&substrs[i]))
+				if len(substrs) > 3 {
+					// A fully qualified function name in pg's dialect can contain
+					// at most 3 parts: db.schema.funname.
+					// For example mydb.pg_catalog.max().
+					// Anything longer is always invalid.
+					return nil, pgerror.NewErrorf(pgerror.CodeSyntaxError,
+						"invalid function name: %s", s)
+				}
+				name := UnresolvedName{NumParts: len(substrs)}
+				for i := 0; i < len(substrs); i++ {
+					name.Parts[i] = substrs[len(substrs)-1-i]
 				}
 				funcDef, err := name.ResolveFunction(ctx.SessionData.SearchPath)
 				if err != nil {

--- a/pkg/sql/sem/tree/expr_test.go
+++ b/pkg/sql/sem/tree/expr_test.go
@@ -49,8 +49,7 @@ func TestUnresolvedNameString(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		n := tree.Name(tc.in)
-		q := tree.UnresolvedName{&n}
+		q := tree.UnresolvedName{NumParts: 1, Parts: tree.NameParts{tc.in}}
 		if q.String() != tc.out {
 			t.Errorf("expected q.String() == %q, got %q", tc.out, q.String())
 		}

--- a/pkg/sql/sem/tree/function_name.go
+++ b/pkg/sql/sem/tree/function_name.go
@@ -17,7 +17,6 @@ package tree
 import (
 	"fmt"
 
-	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 )
 
@@ -84,63 +83,3 @@ type FunctionReference interface {
 
 func (*UnresolvedName) functionReference()     {}
 func (*FunctionDefinition) functionReference() {}
-
-// functionName implements a structured function name. It is an
-// intermediate step between an UnresolvedName and a
-// FunctionDefinition.
-type functionName struct {
-	prefixName   Name
-	functionName Name
-	selector     NameParts
-}
-
-// normalizeFunctionName transforms an UnresolvedName to a functionName.
-func (n *UnresolvedName) normalizeFunctionName() (functionName, error) {
-	if len(*n) == 0 {
-		return functionName{}, pgerror.NewErrorf(
-			pgerror.CodeInvalidNameError, "invalid function name: %s", n)
-	}
-
-	// Find the first array subscript, if any.
-	i := len(*n)
-	for j, p := range *n {
-		if _, ok := p.(*ArraySubscript); ok {
-			i = j
-			break
-		}
-	}
-
-	// There must be something before the array subscript.
-	if i == 0 {
-		return functionName{}, pgerror.NewErrorf(
-			pgerror.CodeInvalidNameError, "invalid function name: %s", n)
-	}
-
-	// The function name, together with its prefix, must /look/ like a
-	// table name. (We don't support record types yet.)  Reuse the
-	// existing normalization code.
-	fPref := (*n)[:i]
-	tn, err := fPref.normalizeTableNameAsValue()
-	if err != nil {
-		// Override the error, so as to not confuse the user.
-		return functionName{}, pgerror.NewErrorf(
-			pgerror.CodeInvalidNameError, "invalid function name: %s", n)
-	}
-
-	// Everything afterwards is the selector.
-	return functionName{
-		prefixName:   tn.SchemaName,
-		functionName: tn.TableName,
-		selector:     NameParts((*n)[i:]),
-	}, nil
-}
-
-// Function retrieves the unqualified function name.
-func (fn *functionName) function() string {
-	return string(fn.functionName)
-}
-
-// Prefix retrieves the unqualified prefix.
-func (fn *functionName) prefix() string {
-	return string(fn.prefixName)
-}

--- a/pkg/sql/sem/tree/name_part.go
+++ b/pkg/sql/sem/tree/name_part.go
@@ -148,60 +148,69 @@ func (a *ArraySubscript) Format(ctx *FmtCtx) {
 	ctx.WriteByte(']')
 }
 
-// NamePart is the interface for the sub-parts of an UnresolvedName or
-// the Selector/Context members of ColumnItem and FunctionName.
-type NamePart interface {
-	NodeFormatter
-	namePart()
+// UnresolvedName corresponds to an unresolved qualified name.
+type UnresolvedName struct {
+	// NumParts indicates the number of name parts specified, including
+	// the star. Always 1 or greater.
+	NumParts int
+
+	// Star indicates the name ends with a star.
+	// In that case, Parts below is empty in the first position.
+	Star bool
+
+	// Parts are the name components, in reverse order.
+	// There are at most 4: column, table, schema, catalog/db.
+	//
+	// Note: NameParts has a fixed size so that we avoid a heap
+	// allocation for the slice every time we construct an
+	// UnresolvedName. It does imply however that Parts does not have
+	// a meaningful "length"; its actually length (the number of parts
+	// specified) is populated in NumParts above.
+	Parts NameParts
 }
 
-var _ NamePart = func() *Name { n := Name(""); return &n }()
-var _ NamePart = func() *UnrestrictedName { n := UnrestrictedName(""); return &n }()
-var _ NamePart = &ArraySubscript{}
-var _ NamePart = UnqualifiedStar{}
-
-func (Name) namePart()              {}
-func (UnrestrictedName) namePart()  {}
-func (a *ArraySubscript) namePart() {}
-func (UnqualifiedStar) namePart()   {}
-
-// NameParts represents a combination of names with array and
-// sub-field subscripts.
-type NameParts []NamePart
-
-// Format implements the NodeFormatter interface.
-func (l *NameParts) Format(ctx *FmtCtx) {
-	for i, p := range *l {
-		_, isArraySubscript := p.(*ArraySubscript)
-		if !isArraySubscript && i > 0 {
-			ctx.WriteByte('.')
-		}
-		ctx.FormatNode(p)
-	}
-}
-
-// UnresolvedName holds the initial syntax of a name as
-// determined during parsing.
-type UnresolvedName NameParts
+// NameParts is the array of strings that composes the path in an
+// UnresolvedName.
+type NameParts = [4]string
 
 // Format implements the NodeFormatter interface.
 func (u *UnresolvedName) Format(ctx *FmtCtx) {
-	ctx.FormatNode((*NameParts)(u))
+	stopAt := 1
+	if u.Star {
+		stopAt = 2
+	}
+	// Every part after that is necessarily an unrestricted name.
+	for i := u.NumParts; i >= stopAt; i-- {
+		// The first part to print is the last item in u.Parts.  It is also
+		// a potentially restricted name to disambiguate from keywords in
+		// the grammar, so print it out as a "Name".
+		if i == u.NumParts {
+			ctx.FormatNode((*Name)(&u.Parts[i-1]))
+		} else {
+			ctx.FormatNode((*UnrestrictedName)(&u.Parts[i-1]))
+		}
+		if i > 1 {
+			ctx.WriteByte('.')
+		}
+	}
+	if u.Star {
+		ctx.WriteByte('*')
+	}
 }
 func (u *UnresolvedName) String() string { return AsString(u) }
 
-// UnresolvedNames corresponds to a comma-separate list of unresolved
-// names.  Note: this should be treated as immutable when embedded in
-// an Expr context, otherwise the Walk code must be updated to
-// duplicate the array an Expr node is duplicated.
-type UnresolvedNames []UnresolvedName
+// UnresolvedNames corresponds to a comma-separated list of
+// unresolved names. Note: this should be treated as immutable when
+// embedded in an Expr context, otherwise the Walk code must be
+// updated to duplicate the array an Expr node is duplicated.
+type UnresolvedNames []*UnresolvedName
 
 // Format implements the NodeFormatter interface.
 func (u *UnresolvedNames) Format(ctx *FmtCtx) {
-	for i := range *u {
+	for i, un := range *u {
 		if i > 0 {
 			ctx.WriteString(", ")
 		}
-		ctx.FormatNode(&(*u)[i])
+		ctx.FormatNode(un)
 	}
 }

--- a/pkg/sql/sem/tree/set.go
+++ b/pkg/sql/sem/tree/set.go
@@ -25,19 +25,19 @@ package tree
 
 // SetVar represents a SET or RESET statement.
 type SetVar struct {
-	Name   VarName
+	Name   string
 	Values Exprs
 }
 
 // Format implements the NodeFormatter interface.
 func (node *SetVar) Format(ctx *FmtCtx) {
 	ctx.WriteString("SET ")
-	if node.Name == nil {
+	if node.Name == "" {
 		ctx.WriteString("ROW (")
 		ctx.FormatNode(&node.Values)
 		ctx.WriteString(")")
 	} else {
-		ctx.FormatNode(node.Name)
+		ctx.FormatNameP(&node.Name)
 		ctx.WriteString(" = ")
 		ctx.FormatNode(&node.Values)
 	}
@@ -45,14 +45,14 @@ func (node *SetVar) Format(ctx *FmtCtx) {
 
 // SetClusterSetting represents a SET CLUSTER SETTING statement.
 type SetClusterSetting struct {
-	Name  VarName
+	Name  string
 	Value Expr
 }
 
 // Format implements the NodeFormatter interface.
 func (node *SetClusterSetting) Format(ctx *FmtCtx) {
 	ctx.WriteString("SET CLUSTER SETTING ")
-	ctx.FormatNode(node.Name)
+	ctx.FormatNameP(&node.Name)
 	ctx.WriteString(" = ")
 	ctx.FormatNode(node.Value)
 }

--- a/pkg/sql/sem/tree/var_name.go
+++ b/pkg/sql/sem/tree/var_name.go
@@ -21,32 +21,17 @@ import (
 
 // Variable names are used in multiples places in SQL:
 //
-// - if the context is the LHS of an UPDATE, then the name is for an
-//   unqualified column.
-//
-//   Syntax: <column-name>
-//
-//   Represented by: ColumnItem
-//
 // - if the context is a direct select target, then the name may end
 //   with '*' for a column group, with optional database and table prefix.
 //
-//   Syntax: [ [ <database-name> '.' ] <table-name> '.' ] '*'
+//   Syntax: [ [ [ <database-name> '.' ] <schema-name> '.' ] <table-name> '.' ] '*'
 //
 //   Represented by: UnqualifiedStar, *AllColumnsSelector (VarName)
 //   Found by: NormalizeVarName()
 //
-// - elsewhere, the name is for a optionally-qualified column name
-//   with optional array subscript followed by additional optional
-//   subfield or array subscripts.
+// - elsewhere, the name is for a optionally-qualified column name.
 //
-//   Syntax: [ [ <database-name> '.' ] <table-name> '.' ]
-//              <column-name>
-//           [ '[' <index> ']' [ '[' <index> ']' | '.' <subfield> ] * ]
-//   (either there is no array subscript and the qualified name *ends*
-//   with a column name; or there is an array subscript and the
-//   supporting column's name is the last unqualified name before the first
-//   array subscript).
+//   Syntax: [ [ [ <database-name> '.' ] <schema-name> '.' ] <table-name> '.' ]  <column-name>
 //
 //   Represented by: ColumnItem (VarName)
 //   Found by: NormalizeVarName()
@@ -58,10 +43,6 @@ import (
 // checking or render target expansion (render node) this is
 // normalized and replaced by either *ColumnItem, UnqualifiedStar or
 // AllColumnsSelector using the NormalizeVarName() method.
-//
-// In the context of UpdateExprs, UnresolvedNames are translated to
-// ColumnItem directly by NormalizeUnqualifiedColumnItem() without
-// going through the VarName interface at all.
 
 // VarName is the common interface to UnresolvedName,
 // ColumnItem and AllColumnsSelector for use in expression contexts.
@@ -140,9 +121,6 @@ type ColumnItem struct {
 	TableName TableName
 	// ColumnName names the designated column.
 	ColumnName Name
-	// Selector defines which sub-part of the variable is being
-	// accessed.
-	Selector NameParts
 
 	// This column is a selector column expression used in a SELECT
 	// for an UPDATE/DELETE.
@@ -162,12 +140,6 @@ func (c *ColumnItem) Format(ctx *FmtCtx) {
 		ctx.WriteByte('.')
 	}
 	ctx.FormatNode(&c.ColumnName)
-	if len(c.Selector) > 0 {
-		if _, ok := c.Selector[0].(*ArraySubscript); !ok {
-			ctx.WriteByte('.')
-		}
-		ctx.FormatNode(&c.Selector)
-	}
 }
 func (c *ColumnItem) String() string { return AsString(c) }
 
@@ -199,68 +171,22 @@ func newInvColRef(fmt string, args ...interface{}) error {
 // NormalizeVarName normalizes a UnresolvedName for all the forms it can have
 // inside an expression context.
 func (n *UnresolvedName) NormalizeVarName() (VarName, error) {
-	if len(*n) == 0 {
-		return nil, pgerror.NewErrorf(pgerror.CodeInvalidNameError, "invalid name: %q", *n)
-	}
-
-	ln := len(*n)
-	if s, isStar := (*n)[ln-1].(UnqualifiedStar); isStar {
-		// Either a single '*' or a name of the form [db.]table.*
-
-		if ln == 1 {
-			return s, nil
+	var tn TableName
+	if n.NumParts > 1 {
+		tnPart := UnresolvedName{
+			NumParts: n.NumParts - 1,
+			Parts:    NameParts{n.Parts[1], n.Parts[2], n.Parts[3]},
 		}
-
-		// The prefix before the star must be a valid table name.  Use the
-		// existing normalize code to enforce that, since we can reuse the
-		// resulting TableName.
-		tPref := (*n)[:ln-1]
-		t, err := tPref.normalizeTableNameAsValue()
-		if err != nil {
+		var err error
+		if tn, err = tnPart.normalizeTableNameAsValue(); err != nil {
 			return nil, err
 		}
-
-		return &AllColumnsSelector{t}, nil
 	}
-
-	// In the remaining case, we have an optional table name prefix,
-	// followed by a column name, followed by some additional selector.
-
-	// Find the first array subscript, if any.
-	i := ln
-	for j, p := range *n {
-		if _, ok := p.(*ArraySubscript); ok {
-			i = j
-			break
-		}
+	if n.Star {
+		return &AllColumnsSelector{tn}, nil
 	}
-	// The element at position i - 1 must be the column name.
-	// (We don't support record types yet.)
-	if i == 0 {
-		return nil, newInvColRef("invalid column name: %q", *n)
+	if len(n.Parts[0]) == 0 {
+		return nil, newInvColRef("empty column name: %q", ErrString(n))
 	}
-	colName, ok := (*n)[i-1].(*Name)
-	if !ok {
-		return nil, newInvColRef("invalid column name: %q", (*n)[:i])
-	}
-	if len(*colName) == 0 {
-		return nil, newInvColRef("empty column name: %q", *n)
-	}
-
-	// Everything afterwards is the selector.
-	res := &ColumnItem{ColumnName: *colName, Selector: NameParts((*n)[i:])}
-
-	if i-1 > 0 {
-		// What's before must be a valid table name.  Use the existing
-		// normalize code to enforce that, since we can reuse the
-		// resulting TableName.
-		tPref := (*n)[:i-1]
-		t, err := tPref.normalizeTableNameAsValue()
-		if err != nil {
-			return nil, err
-		}
-		res.TableName = t
-	}
-
-	return res, nil
+	return &ColumnItem{TableName: tn, ColumnName: Name(n.Parts[0])}, nil
 }

--- a/pkg/sql/set_cluster_setting.go
+++ b/pkg/sql/set_cluster_setting.go
@@ -46,7 +46,7 @@ func (p *planner) SetClusterSetting(
 		return nil, err
 	}
 
-	name := strings.ToLower(tree.AsStringWithFlags(n.Name, tree.FmtBareIdentifiers))
+	name := strings.ToLower(n.Name)
 	st := p.EvalContext().Settings
 	setting, ok := settings.Lookup(name)
 	if !ok {


### PR DESCRIPTION
Forked off #21753 for easier review.

Prior to this patch, the type `UnresolvedName` was an array of things
called "name parts", and could include stars, array indirections or
subscripts. The corresponding logic to normalize unresolved names into
table names, column names or other things was complicated.

In the light of a desired upcoming change to support both catalog and
schema specifiations in names, this code was welcoming a
simplification.

The simplification came from the realization that the syntactic
structure for a table or column path is unambiguous and the "item of
interest" is always in the last position. My previous (mistaken)
understanding was that a column name could be followed by other name
parts in the grammar; however, this is not valid SQL.

- to access an array column, the grammar rules to parse `a.b.c[d]`
  parse first `a.b.c` as a column item, then `<expr> [d]` as an array
  subscript expression. The `[d]` part is not part of the grammar for
  names, never has.

- to access a field in a column of a compound type (these are not
  supported by CockroachDB yet, but the grammar mirrors pg's which
  does support them), pg's SQL dialect has it that one *must* write
  `(a.b.c).field` with grouping parentheses; a direct path of
  `a.b.c.field` is not valid. (More precisely, `a.b.c.field`
  *always* refers to the column `field` of table `c` in schema `b` in
  catalog `a`, and the query would error out if there is no such
  table/column.)

  In short, an unresolved column name again always has a period-separated
  path with the column name in last position.

The predecessor to this patch already had simplified the grammar rules
to account for the known maximum length of a qualified name. This
patch now simplifies the AST and all uses to further capitalize on the
new understanding and simplify the normalization and pretty-printing
rules.

Release note: None