### PR TITLE
sql/sem/tree, sql: clarify TableName.SchemaName and TableName.CatalogName

### DIFF
--- a/pkg/cli/dump.go
+++ b/pkg/cli/dump.go
@@ -234,7 +234,7 @@ func getTableNames(conn *sqlConn, dbName string, ts string) (tableNames []string
 }
 
 func getBasicMetadata(conn *sqlConn, dbName, tableName string, ts string) (basicMetadata, error) {
-	name := &tree.TableName{SchemaName: tree.Name(dbName), TableName: tree.Name(tableName)}
+	name := tree.NewTableName(tree.Name(dbName), tree.Name(tableName))
 
 	// Fetch table ID.
 	dbNameEscaped := tree.NameString(dbName)
@@ -301,7 +301,7 @@ func getBasicMetadata(conn *sqlConn, dbName, tableName string, ts string) (basic
 
 	return basicMetadata{
 		ID:         id,
-		name:       &tree.TableName{SchemaName: tree.Name(dbName), TableName: tree.Name(tableName)},
+		name:       tree.NewTableName(tree.Name(dbName), tree.Name(tableName)),
 		createStmt: createStatement,
 		dependsOn:  refs,
 		kind:       kind,

--- a/pkg/config/zone.go
+++ b/pkg/config/zone.go
@@ -76,7 +76,7 @@ func ZoneSpecifierFromID(
 	if err != nil {
 		return tree.ZoneSpecifier{}, err
 	}
-	tn := &tree.TableName{SchemaName: tree.Name(db), TableName: tree.Name(name)}
+	tn := tree.NewTableName(tree.Name(db), tree.Name(name))
 	return tree.ZoneSpecifier{
 		TableOrIndex: tree.TableNameWithIndex{
 			Table: tree.NormalizableTableName{TableNameReference: tn},

--- a/pkg/sql/alter_user.go
+++ b/pkg/sql/alter_user.go
@@ -36,7 +36,7 @@ type alterUserSetPasswordNode struct {
 func (p *planner) AlterUserSetPassword(
 	ctx context.Context, n *tree.AlterUserSetPassword,
 ) (planNode, error) {
-	tDesc, err := getTableDesc(ctx, p.txn, p.getVirtualTabler(), &tree.TableName{SchemaName: "system", TableName: "users"})
+	tDesc, err := getTableDesc(ctx, p.txn, p.getVirtualTabler(), userTableName)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/create_user.go
+++ b/pkg/sql/create_user.go
@@ -35,6 +35,8 @@ type CreateUserNode struct {
 	run createUserRun
 }
 
+var userTableName = tree.NewTableName("system", "users")
+
 // CreateUser creates a user.
 // Privileges: INSERT on system.users.
 //   notes: postgres allows the creation of users with an empty password. We do
@@ -47,7 +49,7 @@ func (p *planner) CreateUser(ctx context.Context, n *tree.CreateUser) (planNode,
 func (p *planner) CreateUserNode(
 	ctx context.Context, nameE, passwordE tree.Expr, ifNotExists bool, isRole bool, opName string,
 ) (*CreateUserNode, error) {
-	tDesc, err := getTableDesc(ctx, p.txn, p.getVirtualTabler(), &tree.TableName{SchemaName: "system", TableName: "users"})
+	tDesc, err := getTableDesc(ctx, p.txn, p.getVirtualTabler(), userTableName)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/create_view.go
+++ b/pkg/sql/create_view.go
@@ -75,7 +75,7 @@ func (p *planner) CreateView(ctx context.Context, n *tree.CreateView) (planNode,
 					return
 				}
 				// Persist the database prefix expansion.
-				tn.OmitSchemaNameDuringFormatting = false
+				tn.ExplicitSchema = true
 			},
 		)
 		f.FormatNode(n.AsSource)

--- a/pkg/sql/data_source.go
+++ b/pkg/sql/data_source.go
@@ -299,20 +299,17 @@ func (p *planner) getVirtualDataSource(
 		//
 		// Meanwhile the root user probably would be inconvenienced by
 		// this.
-		prefix := string(tn.PrefixName)
-		if !tn.PrefixOriginallySpecified {
-			prefix = p.SessionData().Database
-			if prefix == "" && p.RequireSuperUser(ctx, "access virtual tables across all databases") != nil {
-				prefix = sqlbase.SystemDB.Name
+		catalog := string(tn.CatalogName)
+		if !tn.ExplicitCatalog {
+			catalog = p.SessionData().Database
+			if catalog == "" && p.RequireSuperUser(ctx, "access virtual tables across all databases") != nil {
+				catalog = sqlbase.SystemDB.Name
 			}
 		}
 
 		// Define the name of the source visible in EXPLAIN(NOEXPAND).
-		sourceName := tree.TableName{
-			PrefixName: tree.Name(prefix),
-			TableName:  tree.Name(virtual.desc.Name),
-			SchemaName: tn.SchemaName,
-		}
+		sourceName := tree.MakeTableNameWithCatalog(
+			tree.Name(catalog), tn.SchemaName, tree.Name(virtual.desc.Name))
 
 		// The resulting node.
 		return planDataSource{
@@ -321,7 +318,7 @@ func (p *planner) getVirtualDataSource(
 				name:    sourceName.String(),
 				columns: columns,
 				constructor: func(ctx context.Context, p *planner) (planNode, error) {
-					return constructor(ctx, p, prefix)
+					return constructor(ctx, p, catalog)
 				},
 			},
 		}, true, nil
@@ -358,7 +355,7 @@ func (p *planner) getDataSourceAsOneColumn(
 		return planDataSource{}, err
 	}
 
-	tn := tree.TableName{TableName: tree.Name(fd.Name)}
+	tn := tree.MakeUnqualifiedTableName(tree.Name(fd.Name))
 	return planDataSource{
 		info: newSourceInfoForSingleTable(tn, planColumns(newPlan)),
 		plan: newPlan,
@@ -495,18 +492,15 @@ func (p *planner) getTableScanByRef(
 		return planDataSource{}, errors.Errorf("%s: %v", tree.ErrString(tref), err)
 	}
 
-	tn := tree.TableName{
-		TableName: tree.Name(desc.Name),
-		// Ideally, we'd like to populate DatabaseName here, however that
-		// would require a reverse-lookup from DB ID to database name, and
-		// we do not provide an API to do this without a KV lookup. The
-		// cost of a KV lookup to populate a field only used in (uncommon)
-		// error messages is unwarranted.
-		// So instead, we mark the "database name as originally omitted"
-		// so as to prevent pretty-printing a potentially confusing empty
-		// database name in error messages (we want `foo` not `"".foo`).
-		OmitSchemaNameDuringFormatting: true,
-	}
+	// Ideally, we'd like to populate DatabaseName here, however that
+	// would require a reverse-lookup from DB ID to database name, and
+	// we do not provide an API to do this without a KV lookup. The
+	// cost of a KV lookup to populate a field only used in (uncommon)
+	// error messages is unwarranted.
+	// So instead, we hide the schema part so as to prevent
+	// pretty-printing a potentially confusing empty database name in
+	// error messages (we want `foo` not `"".foo`).
+	tn := tree.MakeUnqualifiedTableName(tree.Name(desc.Name))
 
 	src, err := p.getPlanForDesc(ctx, desc, &tn, hints, scanVisibility, tref.Columns)
 	if err != nil {
@@ -580,7 +574,7 @@ func renameSource(
 func (p *planner) getTableScanOrSequenceOrViewPlan(
 	ctx context.Context, tn *tree.TableName, hints *tree.IndexHints, scanVisibility scanVisibility,
 ) (planDataSource, error) {
-	if tn.PrefixOriginallySpecified {
+	if tn.ExplicitCatalog {
 		// Prefixes are currently only supported for virtual tables.
 		return planDataSource{}, tree.NewInvalidNameErrorf(
 			"invalid table name: %q", tree.ErrString(tn))
@@ -769,7 +763,7 @@ func (src *dataSourceInfo) expandStar(
 		}
 	}
 
-	tableName := tree.TableName{OmitSchemaNameDuringFormatting: true}
+	tableName := anonymousTable
 	if a, ok := v.(*tree.AllColumnsSelector); ok {
 		tableName = a.TableName
 	}

--- a/pkg/sql/drop_database.go
+++ b/pkg/sql/drop_database.go
@@ -65,7 +65,7 @@ func (p *planner) DropDatabase(ctx context.Context, n *tree.DropDatabase) (planN
 		return nil, err
 	}
 
-	tbNames, err := getTableNames(ctx, p.txn, p.getVirtualTabler(), dbDesc, false)
+	tbNames, err := getTableNames(ctx, p.txn, p.getVirtualTabler(), dbDesc, true /*explicitSchema*/)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/drop_user.go
+++ b/pkg/sql/drop_user.go
@@ -47,7 +47,7 @@ func (p *planner) DropUser(ctx context.Context, n *tree.DropUser) (planNode, err
 func (p *planner) DropUserNode(
 	ctx context.Context, namesE tree.Exprs, ifExists bool, isRole bool, opName string,
 ) (*DropUserNode, error) {
-	tDesc, err := getTableDesc(ctx, p.txn, p.getVirtualTabler(), &tree.TableName{SchemaName: "system", TableName: "users"})
+	tDesc, err := getTableDesc(ctx, p.txn, p.getVirtualTabler(), userTableName)
 	if err != nil {
 		return nil, err
 	}
@@ -117,13 +117,10 @@ func (n *DropUserNode) startExec(params runParams) error {
 		func(db *sqlbase.DatabaseDescriptor, table *sqlbase.TableDescriptor) error {
 			for _, u := range table.GetPrivileges().Users {
 				if _, ok := userNames[u.User]; ok {
-					tn := tree.TableName{
-						SchemaName: tree.Name(db.Name),
-						TableName:  tree.Name(table.Name),
-					}
 					if f.Len() > 0 {
 						f.WriteString(", ")
 					}
+					tn := tree.MakeTableName(tree.Name(db.Name), tree.Name(table.Name))
 					f.FormatNode(&tn)
 				}
 			}

--- a/pkg/sql/internal.go
+++ b/pkg/sql/internal.go
@@ -106,7 +106,7 @@ func (ie *InternalExecutor) GetTableSpan(
 	defer cleanup()
 	ie.initSession(p)
 
-	tn := tree.TableName{SchemaName: tree.Name(dbName), TableName: tree.Name(tableName)}
+	tn := tree.MakeTableName(tree.Name(dbName), tree.Name(tableName))
 	tableID, err := getTableID(ctx, p, &tn)
 	if err != nil {
 		return roachpb.Span{}, err

--- a/pkg/sql/opt/build/scope.go
+++ b/pkg/sql/opt/build/scope.go
@@ -85,7 +85,7 @@ func (s *scope) VisitPre(expr tree.Expr) (recurse bool, newExpr tree.Expr) {
 					if tblName == "" && col.table != "" {
 						// TODO(andy): why is this necessary??
 						t.TableName.TableName = tree.Name(col.table)
-						t.TableName.OmitSchemaNameDuringFormatting = true
+						t.TableName.ExplicitSchema = false
 					}
 					return false, col
 				}

--- a/pkg/sql/opt/scope.go
+++ b/pkg/sql/opt/scope.go
@@ -72,7 +72,7 @@ func (s *scope) VisitPre(expr tree.Expr) (recurse bool, newExpr tree.Expr) {
 					// TODO(peter): what is this doing?
 					if tblName == "" && col.table != "" {
 						t.TableName.TableName = tree.Name(col.table)
-						t.TableName.OmitSchemaNameDuringFormatting = true
+						t.TableName.ExplicitSchema = false
 					}
 					return false, col
 				}

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -733,9 +733,7 @@ CREATE TABLE pg_catalog.pg_depend (
 			ctx,
 			p.txn,
 			p.getVirtualTabler(),
-			&tree.TableName{
-				SchemaName: pgCatalogName,
-				TableName:  "pg_constraint"},
+			tree.NewTableName(pgCatalogName, tree.Name("pg_constraint")),
 		)
 		if err != nil {
 			return errors.New("could not find pg_catalog.pg_constraint")
@@ -746,9 +744,7 @@ CREATE TABLE pg_catalog.pg_depend (
 			ctx,
 			p.txn,
 			p.getVirtualTabler(),
-			&tree.TableName{
-				SchemaName: pgCatalogName,
-				TableName:  "pg_class"},
+			tree.NewTableName(pgCatalogName, tree.Name("pg_class")),
 		)
 		if err != nil {
 			return errors.New("could not find pg_catalog.pg_class")
@@ -1010,10 +1006,7 @@ func indexDefFromDescriptor(
 	indexDef := tree.CreateIndex{
 		Name: tree.Name(index.Name),
 		Table: tree.NormalizableTableName{
-			TableNameReference: &tree.TableName{
-				SchemaName: tree.Name(db.Name),
-				TableName:  tree.Name(table.Name),
-			},
+			TableNameReference: tree.NewTableName(tree.Name(db.Name), tree.Name(table.Name)),
 		},
 		Unique:  index.Unique,
 		Columns: make(tree.IndexElemList, len(index.ColumnNames)),
@@ -1049,10 +1042,8 @@ func indexDefFromDescriptor(
 		fields := index.ColumnNames[:sharedPrefixLen]
 		intlDef := &tree.InterleaveDef{
 			Parent: &tree.NormalizableTableName{
-				TableNameReference: &tree.TableName{
-					SchemaName: tree.Name(parentDb.Name),
-					TableName:  tree.Name(parentTable.Name),
-				},
+				TableNameReference: tree.NewTableName(
+					tree.Name(parentDb.Name), tree.Name(parentTable.Name)),
 			},
 			Fields: make(tree.NameList, len(fields)),
 		}

--- a/pkg/sql/rename_database.go
+++ b/pkg/sql/rename_database.go
@@ -55,7 +55,7 @@ func (p *planner) RenameDatabase(ctx context.Context, n *tree.RenameDatabase) (p
 	// are currently just stored as strings, they explicitly specify the database
 	// name. Rather than trying to rewrite them with the changed DB name, we
 	// simply disallow such renames for now.
-	tbNames, err := getTableNames(ctx, p.txn, p.getVirtualTabler(), dbDesc, false)
+	tbNames, err := getTableNames(ctx, p.txn, p.getVirtualTabler(), dbDesc, true /*explicitSchema*/)
 	if err != nil {
 		return nil, err
 	}
@@ -77,7 +77,7 @@ func (p *planner) RenameDatabase(ctx context.Context, n *tree.RenameDatabase) (p
 				var err error
 				viewName, err = p.getQualifiedTableName(ctx, viewDesc)
 				if err != nil {
-					log.Warningf(ctx, "Unable to retrieve fully-qualified name of view %d: %v",
+					log.Warningf(ctx, "unable to retrieve fully-qualified name of view %d: %v",
 						viewDesc.ID, err)
 					msg := fmt.Sprintf("cannot rename database because a view depends on table %q", tbDesc.Name)
 					return nil, sqlbase.NewDependentObjectError(msg)

--- a/pkg/sql/scrub.go
+++ b/pkg/sql/scrub.go
@@ -178,7 +178,7 @@ func (n *scrubNode) startScrubDatabase(ctx context.Context, p *planner, name *tr
 	if err != nil {
 		return err
 	}
-	tbNames, err := getTableNames(ctx, p.txn, p.getVirtualTabler(), dbDesc, false)
+	tbNames, err := getTableNames(ctx, p.txn, p.getVirtualTabler(), dbDesc, true /*explicitSchema*/)
 	if err != nil {
 		return err
 	}

--- a/pkg/sql/select_name_resolution_test.go
+++ b/pkg/sql/select_name_resolution_test.go
@@ -31,7 +31,7 @@ func testInitDummySelectNode(p *planner, desc *sqlbase.TableDescriptor) *renderN
 
 	sel := &renderNode{}
 	sel.source.plan = scan
-	testName := tree.TableName{TableName: tree.Name(desc.Name), SchemaName: tree.Name("test")}
+	testName := tree.MakeTableName("test", tree.Name(desc.Name))
 	cols := planColumns(scan)
 	sel.source.info = newSourceInfoForSingleTable(testName, cols)
 	sel.sourceInfo = multiSourceInfo{sel.source.info}

--- a/pkg/sql/sem/tree/table_name_test.go
+++ b/pkg/sql/sem/tree/table_name_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 func resetRepr(tn *tree.TableName) {
-	tn.OmitSchemaNameDuringFormatting = false
+	tn.ExplicitSchema = true
 }
 
 func TestNormalizeTableName(t *testing.T) {

--- a/pkg/sql/sem/tree/var_name.go
+++ b/pkg/sql/sem/tree/var_name.go
@@ -92,11 +92,7 @@ type AllColumnsSelector struct {
 
 // Format implements the NodeFormatter interface.
 func (a *AllColumnsSelector) Format(ctx *FmtCtx) {
-	if !a.TableName.OmitSchemaNameDuringFormatting {
-		ctx.FormatNode(&a.TableName.SchemaName)
-		ctx.WriteByte('.')
-	}
-	ctx.FormatNode(&a.TableName.TableName)
+	ctx.FormatNode(&a.TableName)
 	ctx.WriteString(".*")
 }
 func (a *AllColumnsSelector) String() string { return AsString(a) }
@@ -132,11 +128,7 @@ type ColumnItem struct {
 // Format implements the NodeFormatter interface.
 func (c *ColumnItem) Format(ctx *FmtCtx) {
 	if c.TableName.TableName != "" {
-		if !c.TableName.OmitSchemaNameDuringFormatting {
-			ctx.FormatNode(&c.TableName.SchemaName)
-			ctx.WriteByte('.')
-		}
-		ctx.FormatNode(&c.TableName.TableName)
+		ctx.FormatNode(&c.TableName)
 		ctx.WriteByte('.')
 	}
 	ctx.FormatNode(&c.ColumnName)

--- a/pkg/sql/show_create.go
+++ b/pkg/sql/show_create.go
@@ -125,11 +125,8 @@ func (p *planner) printForeignKeyConstraint(
 	if err != nil {
 		return err
 	}
-	fkTableName := tree.TableName{
-		SchemaName:                     tree.Name(fkDb.Name),
-		TableName:                      tree.Name(fkTable.Name),
-		OmitSchemaNameDuringFormatting: fkDb.Name == dbPrefix,
-	}
+	fkTableName := tree.MakeTableName(tree.Name(fkDb.Name), tree.Name(fkTable.Name))
+	fkTableName.ExplicitSchema = fkDb.Name != dbPrefix
 	fmtCtx := tree.MakeFmtCtx(buf, tree.FmtSimple)
 	buf.WriteString("FOREIGN KEY (")
 	formatQuoteNames(buf, idx.ColumnNames[0:idx.ForeignKey.SharedPrefixLen]...)
@@ -302,11 +299,8 @@ func (p *planner) showCreateInterleave(
 	if err != nil {
 		return err
 	}
-	parentName := tree.TableName{
-		SchemaName:                     tree.Name(parentDbDesc.Name),
-		TableName:                      tree.Name(parentTable.Name),
-		OmitSchemaNameDuringFormatting: parentDbDesc.Name == dbPrefix,
-	}
+	parentName := tree.MakeTableName(tree.Name(parentDbDesc.Name), tree.Name(parentTable.Name))
+	parentName.ExplicitSchema = parentDbDesc.Name != dbPrefix
 	var sharedPrefixLen int
 	for _, ancestor := range intl.Ancestors {
 		sharedPrefixLen += int(ancestor.SharedPrefixLen)

--- a/pkg/sql/show_trace.go
+++ b/pkg/sql/show_trace.go
@@ -296,10 +296,7 @@ func (n *showTraceNode) Close(ctx context.Context) {
 	}
 }
 
-var sessionTraceTableName = tree.TableName{
-	SchemaName: tree.Name("crdb_internal"),
-	TableName:  tree.Name("session_trace"),
-}
+var sessionTraceTableName = tree.MakeTableName("crdb_internal", "session_trace")
 
 var errTracingAlreadyEnabled = errors.New(
 	"cannot run SHOW TRACE FOR on statement while session tracing is enabled" +

--- a/pkg/sql/sqlbase/cascader.go
+++ b/pkg/sql/sqlbase/cascader.go
@@ -799,10 +799,7 @@ func (c *cascader) updateRows(
 									return nil, nil, nil, 0, pgerror.NewErrorf(pgerror.CodeNullValueNotAllowedError,
 										"cannot cascade a null value into %q as it violates a NOT NULL constraint",
 										tree.ErrString(&tree.ColumnItem{
-											TableName: tree.TableName{
-												SchemaName: tree.Name(database.Name),
-												TableName:  tree.Name(referencingTable.Name),
-											},
+											TableName:  tree.MakeTableName(tree.Name(database.Name), tree.Name(referencingTable.Name)),
 											ColumnName: tree.Name(column.Name),
 										}),
 									)

--- a/pkg/sql/upsert.go
+++ b/pkg/sql/upsert.go
@@ -28,7 +28,7 @@ import (
 // expressions to refer to the values that would be inserted for a row if it
 // didn't conflict.
 // Example: `INSERT INTO kv VALUES (1, 2) ON CONFLICT (k) DO UPDATE SET v = excluded.v`
-var upsertExcludedTable = tree.TableName{TableName: "excluded"}
+var upsertExcludedTable = tree.MakeUnqualifiedTableName("excluded")
 
 type upsertHelper struct {
 	p                  *planner

--- a/pkg/sql/virtual_schema.go
+++ b/pkg/sql/virtual_schema.go
@@ -83,15 +83,10 @@ type virtualSchemaEntry struct {
 	orderedTableNames []string
 }
 
-func (e virtualSchemaEntry) tableNames(dbNameOriginallyOmitted bool) tree.TableNames {
+func (e virtualSchemaEntry) tableNames(explicitSchema bool) tree.TableNames {
 	var res tree.TableNames
 	for _, tableName := range e.orderedTableNames {
-		tn := tree.TableName{
-			SchemaName:                     tree.Name(e.desc.Name),
-			TableName:                      tree.Name(tableName),
-			OmitSchemaNameDuringFormatting: dbNameOriginallyOmitted,
-		}
-		res = append(res, tn)
+		res = append(res, tree.MakeTableName(tree.Name(e.desc.Name), tree.Name(tableName)))
 	}
 	return res
 }

--- a/pkg/sql/with.go
+++ b/pkg/sql/with.go
@@ -109,7 +109,7 @@ func (p *planner) getCTEDataSource(t *tree.NormalizableTableName) (planDataSourc
 	// Iterate backward through the environment, most recent frame first.
 	for i := range p.curPlan.cteNameEnvironment {
 		frame := p.curPlan.cteNameEnvironment[len(p.curPlan.cteNameEnvironment)-1-i]
-		if tn.SchemaName == "" && tn.PrefixName == "" {
+		if tn.SchemaName == "" && tn.CatalogName == "" {
 			if cteSource, ok := frame[tn.TableName]; ok {
 				if cteSource.used {
 					// TODO(jordan): figure out how to lift this restriction.


### PR DESCRIPTION
Forked off #21753 for easier review.

Working slowly towards a better use of the catalog prefix in `TableName`,
this patch clarifies the struct:

- the "Prefix" field is renamed to "Catalog".
- the fields "OmitSchemaDuringFormatting" and
  "PrefixOriginallySpecified" are renamed to "ExplicitSchema" (meaning
  inverted) and "ExplicitCatalog", to clarify what they are really
  about.
- new helper methods are provided to construct instances of
  `TableName`. This sensibly shortens most points of use, and
  clarifies intent.

Release note: None