### PR TITLE
logictest: add missing rowsort to cascade test

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/cascade
+++ b/pkg/sql/logictest/testdata/logic_test/cascade
@@ -886,7 +886,7 @@ INSERT INTO b VALUES (1, 1), (2, NULL), (3, 2), (4, 1), (5, NULL);
 statement ok
 DELETE FROM a;
 
-query II
+query II rowsort
 SELECT id, a_id FROM b;
 ----
 2  NULL


### PR DESCRIPTION
Looks like #22258 missed (at least) one more `rowsort`. It's flaking for me locally. 

There's a misconception that just because one reads from the primary key one should get it in order, but that's not true. If you want an ordering, you need to specify an `ORDER BY`.

```
E180131 21:39:22.709903 243854 sql/logictest/logic.go:2067  
testdata/logic_test/cascade:890: SELECT id, a_id FROM b;
expected:
    2  NULL
    5  NULL
    
but found (query options: "") :
    5  NULL  
    2  NULL  
```
