### PR TITLE
workload: use []interface{} instead of []string

### DIFF
--- a/pkg/ccl/sqlccl/bench_test.go
+++ b/pkg/ccl/sqlccl/bench_test.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/ccl/sqlccl"
 	"github.com/cockroachdb/cockroach/pkg/ccl/utilccl/sampledataccl"
+	"github.com/cockroachdb/cockroach/pkg/testutils/workload"
 	"github.com/cockroachdb/cockroach/pkg/testutils/workload/bank"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 )
@@ -27,7 +28,7 @@ func bankBuf(numAccounts int) *bytes.Buffer {
 	var buf bytes.Buffer
 	fmt.Fprintf(&buf, "CREATE TABLE %s %s;\n", bankData.Name, bankData.Schema)
 	for rowIdx := 0; rowIdx < bankData.InitialRowCount; rowIdx++ {
-		row := bankData.InitialRowFn(rowIdx)
+		row := workload.StringTuple(bankData.InitialRowFn(rowIdx))
 		fmt.Fprintf(&buf, "INSERT INTO %s VALUES (%s);\n", bankData.Name, strings.Join(row, `,`))
 	}
 	return &buf

--- a/pkg/ccl/sqlccl/load_test.go
+++ b/pkg/ccl/sqlccl/load_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/ccl/sqlccl"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/workload"
 	"github.com/cockroachdb/cockroach/pkg/testutils/workload/bank"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -48,8 +49,8 @@ func TestImportOutOfOrder(t *testing.T) {
 	defer cleanupFn()
 
 	bankData := bank.FromRows(2).Tables()[0]
-	row1 := bankData.InitialRowFn(0)
-	row2 := bankData.InitialRowFn(1)
+	row1 := workload.StringTuple(bankData.InitialRowFn(0))
+	row2 := workload.StringTuple(bankData.InitialRowFn(1))
 
 	var buf bytes.Buffer
 	fmt.Fprintf(&buf, "CREATE TABLE %s %s;\n", bankData.Name, bankData.Schema)

--- a/pkg/ccl/testutilsccl/workloadccl/fixture.go
+++ b/pkg/ccl/testutilsccl/workloadccl/fixture.go
@@ -136,7 +136,12 @@ func writeCSVs(
 				return ctx.Err()
 			default:
 			}
-			if err := csvW.Write(table.InitialRowFn(rowIdx)); err != nil {
+			row := table.InitialRowFn(rowIdx)
+			rowStrings := make([]string, len(row))
+			for i, datum := range row {
+				rowStrings[i] = fmt.Sprintf(`%v`, datum)
+			}
+			if err := csvW.Write(rowStrings); err != nil {
 				return err
 			}
 		}

--- a/pkg/ccl/testutilsccl/workloadccl/fixture_test.go
+++ b/pkg/ccl/testutilsccl/workloadccl/fixture_test.go
@@ -54,7 +54,9 @@ func (g fixtureTestGen) Tables() []workload.Table {
 		Name:            `fx`,
 		Schema:          `(key INT PRIMARY KEY, value INT)`,
 		InitialRowCount: fixtureTestGenRows,
-		InitialRowFn:    func(rowIdx int) []string { return []string{strconv.Itoa(rowIdx), g.val} },
+		InitialRowFn: func(rowIdx int) []interface{} {
+			return []interface{}{rowIdx, g.val}
+		},
 	}}
 }
 

--- a/pkg/ccl/utilccl/sampledataccl/bankdata.go
+++ b/pkg/ccl/utilccl/sampledataccl/bankdata.go
@@ -54,7 +54,7 @@ func toBackup(t testing.TB, data workload.Table, dir string, chunkBytes int64) (
 	var stmts bytes.Buffer
 	fmt.Fprintf(&stmts, "CREATE TABLE %s %s;\n", data.Name, data.Schema)
 	for rowIdx := 0; rowIdx < data.InitialRowCount; rowIdx++ {
-		row := data.InitialRowFn(rowIdx)
+		row := workload.StringTuple(data.InitialRowFn(rowIdx))
 		fmt.Fprintf(&stmts, "INSERT INTO %s VALUES (%s);\n", data.Name, strings.Join(row, `,`))
 	}
 

--- a/pkg/testutils/workload/bank/bank.go
+++ b/pkg/testutils/workload/bank/bank.go
@@ -21,7 +21,6 @@ import (
 	"encoding/hex"
 	"fmt"
 	"math/rand"
-	"strconv"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/pflag"
@@ -111,21 +110,21 @@ func (b *bank) Tables() []workload.Table {
 		Name:            `bank`,
 		Schema:          bankSchema,
 		InitialRowCount: b.rows,
-		InitialRowFn: func(rowIdx int) []string {
+		InitialRowFn: func(rowIdx int) []interface{} {
 			const initialPrefix = `initial-`
 			bytes := hex.EncodeToString(randutil.RandBytes(rng, b.payloadBytes/2))
 			// Minus 2 for the single quotes
 			bytes = bytes[:b.payloadBytes-len(initialPrefix)-2]
-			return []string{
-				strconv.Itoa(rowIdx), // id
-				`0`,                  // balance
-				`'` + initialPrefix + bytes + `'`, // payload
+			return []interface{}{
+				rowIdx, // id
+				0,      // balance
+				initialPrefix + bytes, // payload
 			}
 		},
 		SplitCount: b.ranges - 1,
-		SplitFn: func(splitIdx int) []string {
-			return []string{
-				strconv.Itoa((splitIdx + 1) * (b.rows / b.ranges)),
+		SplitFn: func(splitIdx int) []interface{} {
+			return []interface{}{
+				(splitIdx + 1) * (b.rows / b.ranges),
 			}
 		},
 	}

--- a/pkg/testutils/workload/kv/kv.go
+++ b/pkg/testutils/workload/kv/kv.go
@@ -105,11 +105,11 @@ func (w *kv) Tables() []workload.Table {
 		// TODO(dan): Support initializing kv with data.
 		InitialRowCount: 0,
 		SplitCount:      w.splits,
-		SplitFn: func(splitIdx int) []string {
+		SplitFn: func(splitIdx int) []interface{} {
 			rng := rand.New(rand.NewSource(w.seed + int64(splitIdx)))
 			g := newHashGenerator(&sequence{config: w, val: w.writeSeq})
-			return []string{
-				fmt.Sprintf("%d", g.hash(rng.Int63())),
+			return []interface{}{
+				int(g.hash(rng.Int63())),
 			}
 		},
 	}

--- a/pkg/testutils/workload/sliceslice_test.go
+++ b/pkg/testutils/workload/sliceslice_test.go
@@ -23,24 +23,26 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 )
 
-func TestStringStringSort(t *testing.T) {
+func TestSliceSliceInterfaceSort(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	sorted := [][]string{
+	sorted := [][]interface{}{
 		{},
 		{``},
 		{`a`},
-		{`a`, `b`},
-		{`a`, `c`},
+		{`a`, -9223372036854775808},
+		{`a`, 2},
+		{`a`, 12},
+		{`b`},
 	}
 
 	// Create a shuffled version of sorted.
-	actual := make([][]string, len(sorted))
+	actual := make([][]interface{}, len(sorted))
 	for i, v := range rand.Perm(len(actual)) {
 		actual[v] = sorted[i]
 	}
 
-	sort.Sort(stringStringSlice(actual))
+	sort.Sort(sliceSliceInterface(actual))
 	if !reflect.DeepEqual(actual, sorted) {
 		t.Fatalf(`got %v expected %v`, actual, sorted)
 	}

--- a/pkg/testutils/workload/workload.go
+++ b/pkg/testutils/workload/workload.go
@@ -22,10 +22,13 @@ import (
 	"context"
 	gosql "database/sql"
 	"fmt"
+	"math"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 
+	"github.com/cockroachdb/cockroach/pkg/sql/lex"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/pkg/errors"
 	"github.com/spf13/pflag"
@@ -96,16 +99,14 @@ type Table struct {
 	// table after setup is completed.
 	InitialRowCount int
 	// InitialRowFn is a function to deterministically compute the datums in a
-	// row of the table's initial data given its index. They are returned as
-	// strings and must be pre-escaped for use directly in SQL/CSVs.
-	InitialRowFn func(int) []string
+	// row of the table's initial data given its index.
+	InitialRowFn func(int) []interface{}
 	// SplitCount is the initial number of splits that will be present in the
 	// table after setup is completed.
 	SplitCount int
 	// SplitFn is a function to deterministically compute the datums in a tuple
-	// of the table's initial splits given its index. They are returned as
-	// strings and must be pre-escaped for use directly in SQL/CSVs.
-	SplitFn func(int) []string
+	// of the table's initial splits given its index.
+	SplitFn func(int) []interface{}
 }
 
 // Operation represents some SQL query workload performable on a database
@@ -151,17 +152,28 @@ func Registered() []Meta {
 	return gens
 }
 
+// DatumSize returns the canonical size of a datum as returned from a call to
+// `Table.InitialRowFn`.
+func DatumSize(x interface{}) int64 {
+	switch t := x.(type) {
+	case int:
+		return int64(math.Log10(float64(t)))
+	case float64:
+		return int64(math.Log10(t))
+	case string:
+		return int64(len(t))
+	default:
+		panic(fmt.Sprintf("unsupported type %T: %v", x, x))
+	}
+}
+
 // Setup creates the given tables and fills them with initial data via batched
 // INSERTs. batchSize will only be used when positive (but INSERTs are batched
 // either way).
 //
 // The size of the loaded data is returned in bytes, suitable for use with
-// SetBytes of benchmarks. This size is defined as the sum of lengths of the
-// string representations of the sql (e.g. `1` the int is 1 and `'x'` the string
-// is three).
-//
-// TODO(dan): Is there something better we could be doing here for the size of
-// the loaded data?
+// SetBytes of benchmarks. The exact definition of this is deferred to the
+// DatumSize implementation.
 func Setup(db *gosql.DB, gen Generator, batchSize int) (int64, error) {
 	if batchSize <= 0 {
 		batchSize = 1000
@@ -190,25 +202,27 @@ func Setup(db *gosql.DB, gen Generator, batchSize int) (int64, error) {
 			insertStmtBuf.Reset()
 			fmt.Fprintf(&insertStmtBuf, `INSERT INTO %s VALUES `, table.Name)
 
-			batchIdx := 0
-			for ; batchIdx < batchSize && rowIdx < table.InitialRowCount; batchIdx++ {
+			var params []interface{}
+			for batchIdx := 0; batchIdx < batchSize && rowIdx < table.InitialRowCount; batchIdx++ {
 				if batchIdx != 0 {
 					insertStmtBuf.WriteString(`,`)
 				}
 				insertStmtBuf.WriteString(`(`)
-				for i, datum := range table.InitialRowFn(rowIdx) {
-					size += int64(len(datum))
+				row := table.InitialRowFn(rowIdx)
+				for i, datum := range row {
+					size += DatumSize(datum)
 					if i != 0 {
 						insertStmtBuf.WriteString(`,`)
 					}
-					insertStmtBuf.WriteString(datum)
+					fmt.Fprintf(&insertStmtBuf, `$%d`, len(params)+i+1)
 				}
+				params = append(params, row...)
 				insertStmtBuf.WriteString(`)`)
 				rowIdx++
 			}
-			if batchIdx > 0 {
+			if len(params) > 0 {
 				insertStmt := insertStmtBuf.String()
-				if _, err := db.Exec(insertStmt); err != nil {
+				if _, err := db.Exec(insertStmt, params...); err != nil {
 					return 0, err
 				}
 			}
@@ -222,11 +236,11 @@ func Split(ctx context.Context, db *gosql.DB, table Table, concurrency int) erro
 	if table.SplitCount <= 0 {
 		return nil
 	}
-	splitPoints := make([][]string, table.SplitCount)
+	splitPoints := make([][]interface{}, table.SplitCount)
 	for splitIdx := 0; splitIdx < table.SplitCount; splitIdx++ {
 		splitPoints[splitIdx] = table.SplitFn(splitIdx)
 	}
-	sort.Sort(stringStringSlice(splitPoints))
+	sort.Sort(sliceSliceInterface(splitPoints))
 
 	type pair struct {
 		lo, hi int
@@ -249,7 +263,7 @@ func Split(ctx context.Context, db *gosql.DB, table Table, concurrency int) erro
 					break
 				}
 				m := (p.lo + p.hi) / 2
-				split := strings.Join(splitPoints[m], `,`)
+				split := strings.Join(StringTuple(splitPoints[m]), `,`)
 
 				buf.Reset()
 				fmt.Fprintf(&buf, `ALTER TABLE %s SPLIT AT VALUES (%s)`, table.Name, split)
@@ -296,17 +310,50 @@ func Split(ctx context.Context, db *gosql.DB, table Table, concurrency int) erro
 	return nil
 }
 
-type stringStringSlice [][]string
+// StringTuple returns the given datums as strings suitable for use in directly
+// in SQL.
+//
+// TODO(dan): Remove this once SCATTER supports placeholders.
+func StringTuple(datums []interface{}) []string {
+	s := make([]string, len(datums))
+	for i, datum := range datums {
+		switch x := datum.(type) {
+		case int:
+			s[i] = strconv.Itoa(x)
+		case string:
+			s[i] = lex.EscapeSQLString(x)
+		default:
+			panic(fmt.Sprintf("unsupported type %T: %v", x, x))
+		}
+	}
+	return s
+}
 
-func (s stringStringSlice) Len() int      { return len(s) }
-func (s stringStringSlice) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
-func (s stringStringSlice) Less(i, j int) bool {
+type sliceSliceInterface [][]interface{}
+
+func (s sliceSliceInterface) Len() int      { return len(s) }
+func (s sliceSliceInterface) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
+func (s sliceSliceInterface) Less(i, j int) bool {
 	for offset := 0; ; offset++ {
 		iLen, jLen := len(s[i]), len(s[j])
 		if iLen <= offset || jLen <= offset {
 			return iLen < jLen
 		}
-		if cmp := strings.Compare(s[i][offset], s[j][offset]); cmp < 0 {
+		var cmp int
+		switch x := s[i][offset].(type) {
+		case int:
+			if x < s[j][offset].(int) {
+				return true
+			} else if x > s[j][offset].(int) {
+				return false
+			}
+			continue
+		case string:
+			cmp = strings.Compare(x, s[j][offset].(string))
+		default:
+			panic(fmt.Sprintf("unsupported type %T: %v", x, x))
+		}
+		if cmp < 0 {
 			return true
 		} else if cmp > 0 {
 			return false


### PR DESCRIPTION
The workloads all had to do their own escaping plus there were some
datums where no escaping would be correct in all contexts. Now each use
of the row/split needs to do it's own interpretation. This should also
save some allocations.

This also caused a real bug in roachmart impl, where we had too many
levels of quoting.