### PR TITLE
storage: avoid copying sst files on ingestion

### DIFF
--- a/c-deps/libroach/db.cc
+++ b/c-deps/libroach/db.cc
@@ -495,7 +495,8 @@ DBSSTable* DBGetSSTables(DBEngine* db, int* n) { return db->GetSSTables(n); }
 
 DBString DBGetUserProperties(DBEngine* db) { return db->GetUserProperties(); }
 
-DBStatus DBIngestExternalFile(DBEngine* db, DBSlice path, bool move_file) {
+DBStatus DBIngestExternalFile(DBEngine* db, DBSlice path, bool move_file,
+                              bool allow_file_modification) {
   const std::vector<std::string> paths = {ToString(path)};
   rocksdb::IngestExternalFileOptions ingest_options;
   // If move_files is true and the env supports it, RocksDB will hard link.
@@ -510,7 +511,7 @@ DBStatus DBIngestExternalFile(DBEngine* db, DBSlice path, bool move_file) {
   // ingest runs, then after moving/copying the file, RocksDB will edit it
   // (overwrite some of the bytes) to have a global sequence number. If this is
   // false, it will error in these cases instead.
-  ingest_options.allow_global_seqno = true;
+  ingest_options.allow_global_seqno = allow_file_modification;
   // If there are mutations in the memtable for the keyrange covered by the file
   // being ingested, this option is checked. If true, the memtable is flushed
   // and the ingest run. If false, an error is returned.

--- a/c-deps/libroach/include/libroach.h
+++ b/c-deps/libroach/include/libroach.h
@@ -302,7 +302,11 @@ DBString DBGetUserProperties(DBEngine* db);
 // Bulk adds the file at the given path to a database. See the RocksDB
 // documentation on `IngestExternalFile` for the various restrictions on what
 // can be added. If move_file is true, the file will be moved instead of copied.
-DBStatus DBIngestExternalFile(DBEngine* db, DBSlice path, bool move_file);
+// If allow_file_modification is false, RocksDB will return an error if it would
+// have tried to modify the file's sequence number rather than editing the file
+// in place.
+DBStatus DBIngestExternalFile(DBEngine* db, DBSlice path, bool move_file,
+                              bool allow_file_modification);
 
 typedef struct DBSstFileWriter DBSstFileWriter;
 

--- a/pkg/ccl/storageccl/add_sstable_test.go
+++ b/pkg/ccl/storageccl/add_sstable_test.go
@@ -322,7 +322,7 @@ func TestAddSSTableMVCCStats(t *testing.T) {
 		if err := e.WriteFile(filename, sstBytes); err != nil {
 			t.Fatalf("%+v", err)
 		}
-		if err := e.IngestExternalFile(ctx, filename, false /* move */); err != nil {
+		if err := e.IngestExternalFile(ctx, filename, false /* move */, true /* modify the sst */); err != nil {
 			t.Fatalf("%+v", err)
 		}
 

--- a/pkg/storage/engine/engine.go
+++ b/pkg/storage/engine/engine.go
@@ -251,7 +251,7 @@ type Engine interface {
 	NewSnapshot() Reader
 	// IngestExternalFile links a file into the RocksDB log-structured
 	// merge-tree.
-	IngestExternalFile(ctx context.Context, path string, move bool) error
+	IngestExternalFile(ctx context.Context, path string, move, allowFileModification bool) error
 	// ApproximateDiskBytes returns an approximation of the on-disk size for the given key span.
 	ApproximateDiskBytes(from, to roachpb.Key) (uint64, error)
 	// CompactRange ensures that the specified range of key value pairs is

--- a/pkg/storage/engine/rocksdb.go
+++ b/pkg/storage/engine/rocksdb.go
@@ -2392,7 +2392,10 @@ func (fr *RocksDBSstFileReader) IngestExternalFile(data []byte) error {
 	if err := fr.rocksDB.WriteFile(filename, data); err != nil {
 		return err
 	}
-	return statusToError(C.DBIngestExternalFile(fr.rocksDB.rdb, goToCSlice([]byte(filename)), false))
+	const noMove, modify = false, true
+	return statusToError(C.DBIngestExternalFile(
+		fr.rocksDB.rdb, goToCSlice([]byte(filename)), noMove, modify,
+	))
 }
 
 // Iterate iterates over the keys between start inclusive and end
@@ -2501,8 +2504,12 @@ func (r *RocksDB) setAuxiliaryDir(d string) error {
 }
 
 // IngestExternalFile links a file into the RocksDB log-structured merge-tree.
-func (r *RocksDB) IngestExternalFile(ctx context.Context, path string, move bool) error {
-	return statusToError(C.DBIngestExternalFile(r.rdb, goToCSlice([]byte(path)), C._Bool(move)))
+func (r *RocksDB) IngestExternalFile(
+	ctx context.Context, path string, move, allowFileModification bool,
+) error {
+	return statusToError(C.DBIngestExternalFile(
+		r.rdb, goToCSlice([]byte(path)), C._Bool(move), C._Bool(allowFileModification),
+	))
 }
 
 // WriteFile writes data to a file in this RocksDB's env.

--- a/pkg/storage/metrics.go
+++ b/pkg/storage/metrics.go
@@ -466,6 +466,10 @@ var (
 	metaAddSSTableApplications = metric.Metadata{
 		Name: "addsstable.applications",
 		Help: "Number of SSTable ingestions applied (i.e. applied by Replicas)"}
+	metaAddSSTableApplicationCopies = metric.Metadata{
+		Name: "addsstable.copies",
+		Help: "number of SSTable ingestions that required copying files during application",
+	}
 )
 
 // StoreMetrics is the set of metrics for a given store.
@@ -651,9 +655,10 @@ type StoreMetrics struct {
 	BackpressuredOnSplitRequests *metric.Gauge
 
 	// AddSSTable stats: how many AddSSTable commands were proposed and how many
-	// were applied?
-	AddSSTableProposals    *metric.Counter
-	AddSSTableApplications *metric.Counter
+	// were applied? How many applications required writing a copy?
+	AddSSTableProposals         *metric.Counter
+	AddSSTableApplications      *metric.Counter
+	AddSSTableApplicationCopies *metric.Counter
 
 	// Stats for efficient merges.
 	mu struct {
@@ -837,8 +842,9 @@ func newStoreMetrics(histogramWindow time.Duration) *StoreMetrics {
 		BackpressuredOnSplitRequests: metric.NewGauge(metaBackpressuredOnSplitRequests),
 
 		// AddSSTable proposal + applications counters.
-		AddSSTableProposals:    metric.NewCounter(metaAddSSTableProposals),
-		AddSSTableApplications: metric.NewCounter(metaAddSSTableApplications),
+		AddSSTableProposals:         metric.NewCounter(metaAddSSTableProposals),
+		AddSSTableApplications:      metric.NewCounter(metaAddSSTableApplications),
+		AddSSTableApplicationCopies: metric.NewCounter(metaAddSSTableApplicationCopies),
 	}
 
 	sm.raftRcvdMessages[raftpb.MsgProp] = sm.RaftRcvdMsgProp

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -4655,7 +4655,7 @@ func (r *Replica) processRaftCommand(
 		// values) here. If the key range we are ingesting into isn't empty,
 		// we're not using AddSSTable but a plain WriteBatch.
 		if raftCmd.ReplicatedEvalResult.AddSSTable != nil {
-			addSSTablePreApply(
+			copied := addSSTablePreApply(
 				ctx,
 				r.store.cfg.Settings,
 				r.store.engine,
@@ -4665,6 +4665,9 @@ func (r *Replica) processRaftCommand(
 				*raftCmd.ReplicatedEvalResult.AddSSTable,
 			)
 			r.store.metrics.AddSSTableApplications.Inc(1)
+			if copied {
+				r.store.metrics.AddSSTableApplicationCopies.Inc(1)
+			}
 			raftCmd.ReplicatedEvalResult.AddSSTable = nil
 		}
 

--- a/pkg/storage/replica_proposal.go
+++ b/pkg/storage/replica_proposal.go
@@ -320,7 +320,7 @@ func addSSTablePreApply(
 	sideloaded sideloadStorage,
 	term, index uint64,
 	sst storagebase.ReplicatedEvalResult_AddSSTable,
-) {
+) bool {
 	checksum := util.CRC32(sst.Data)
 
 	if checksum != sst.CRC32 {
@@ -339,29 +339,31 @@ func addSSTablePreApply(
 		log.Fatalf(ctx, "sideloaded SSTable at term %d, index %d is missing", term, index)
 	}
 
+	copied := false
 	if inmem, ok := eng.(engine.InMem); ok {
 		path = fmt.Sprintf("%x", checksum)
 		if err := inmem.WriteFile(path, sst.Data); err != nil {
 			panic(err)
 		}
 	} else {
-		// The SST may already be on disk, thanks to the sideloading mechanism.  If so
-		// we can try to add that file directly, rather than writing another copy of
-		// it, so long as doing so does not modify the file, which would be bad since
-		// it is still part of an immutable raft log message. We *can* tell Rocks that
-		// it is not allowed to modify the file though, in which case it will return
-		// and error if it would have tried to do so (see note in db.cc about what
-		// causes that), at which point we can fall back to writing a copy for Rocks.
+		// The SST may already be on disk, thanks to the sideloading mechanism.  If
+		// so we can try to add that file directly, rather than writing another copy
+		// of it, so long as doing so does not modify the file, which would be bad
+		// since it is still part of an immutable raft log message. We *can* tell
+		// Rocks that it is not allowed to modify the file though, in which case it
+		// will return and error if it would have tried to do so (see note on
+		// DBIngestExternalFile in db.cc about what causes that), at which point we
+		// can fall back to writing a copy for Rocks.
 		if _, err := os.Stat(path); err == nil {
-			if err := eng.IngestExternalFile(ctx, path, move, noModify); err == nil {
+			err = eng.IngestExternalFile(ctx, path, move, noModify)
+			if err == nil {
 				// Adding without modification succeeded, no copy necessary.
 				log.Eventf(ctx, "ingested SSTable at index %d, term %d: %s", index, term, path)
-				return
-			} else {
-				const seqNoMsg = "Global seqno is required, but disabled"
-				if err, ok := err.(*engine.RocksDBError); ok && !strings.Contains(err.Error(), seqNoMsg) {
-					log.Fatalf(ctx, "while ingesting %s: %s", path, err)
-				}
+				return false
+			}
+			const seqNoMsg = "Global seqno is required, but disabled"
+			if err, ok := err.(*engine.RocksDBError); ok && !strings.Contains(err.Error(), seqNoMsg) {
+				log.Fatalf(ctx, "while ingesting %s: %s", path, err)
 			}
 		}
 
@@ -388,12 +390,14 @@ func addSSTablePreApply(
 		if err := fileutil.WriteFileSyncing(path, sst.Data, 0600, sstWriteSyncRate.Get(&st.SV)); err != nil {
 			log.Fatalf(ctx, "while ingesting %s: %s", path, err)
 		}
+		copied = true
 	}
 
 	if err := eng.IngestExternalFile(ctx, path, move, modify); err != nil {
 		log.Fatalf(ctx, "while ingesting %s: %s", path, err)
 	}
 	log.Eventf(ctx, "ingested SSTable at index %d, term %d: %s", index, term, path)
+	return copied
 }
 
 // maybeTransferRaftLeadership attempts to transfer the leadership

--- a/pkg/storage/replica_proposal.go
+++ b/pkg/storage/replica_proposal.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/coreos/etcd/raft"
@@ -330,17 +331,13 @@ func addSSTablePreApply(
 		)
 	}
 
-	// TODO(danhhz,tschottdorf): we can hardlink directly to the sideloaded
-	// SSTable and ingest that if we also put a "sanitizer" in the
-	// implementation of sideloadedStorage that undoes the serial number that
-	// RocksDB may add to the SSTable. This avoids copying the file entirely.
+	const move = true
+	const modify, noModify = true, false
+
 	path, err := sideloaded.Filename(ctx, index, term)
 	if err != nil {
 		log.Fatalf(ctx, "sideloaded SSTable at term %d, index %d is missing", term, index)
 	}
-	path += ".ingested"
-
-	limitBulkIOWrite(ctx, st, len(sst.Data))
 
 	if inmem, ok := eng.(engine.InMem); ok {
 		path = fmt.Sprintf("%x", checksum)
@@ -348,6 +345,31 @@ func addSSTablePreApply(
 			panic(err)
 		}
 	} else {
+		// The SST may already be on disk, thanks to the sideloading mechanism.  If so
+		// we can try to add that file directly, rather than writing another copy of
+		// it, so long as doing so does not modify the file, which would be bad since
+		// it is still part of an immutable raft log message. We *can* tell Rocks that
+		// it is not allowed to modify the file though, in which case it will return
+		// and error if it would have tried to do so (see note in db.cc about what
+		// causes that), at which point we can fall back to writing a copy for Rocks.
+		if _, err := os.Stat(path); err == nil {
+			if err := eng.IngestExternalFile(ctx, path, move, noModify); err == nil {
+				// Adding without modification succeeded, no copy necessary.
+				log.Eventf(ctx, "ingested SSTable at index %d, term %d: %s", index, term, path)
+				return
+			} else {
+				const seqNoMsg = "Global seqno is required, but disabled"
+				if err, ok := err.(*engine.RocksDBError); ok && !strings.Contains(err.Error(), seqNoMsg) {
+					log.Fatalf(ctx, "while ingesting %s: %s", path, err)
+				}
+			}
+		}
+
+		path += ".ingested"
+
+		limitBulkIOWrite(ctx, st, len(sst.Data))
+		log.Eventf(ctx, "copying SSTable for ingestion at index %d, term %d: %s", index, term, path)
+
 		// TODO(tschottdorf): remove this once sideloaded storage guarantees its
 		// existence.
 		if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
@@ -368,9 +390,8 @@ func addSSTablePreApply(
 		}
 	}
 
-	const move = true
-	if err := eng.IngestExternalFile(ctx, path, move); err != nil {
-		panic(err)
+	if err := eng.IngestExternalFile(ctx, path, move, modify); err != nil {
+		log.Fatalf(ctx, "while ingesting %s: %s", path, err)
 	}
 	log.Eventf(ctx, "ingested SSTable at index %d, term %d: %s", index, term, path)
 }

--- a/pkg/storage/replica_sideload_test.go
+++ b/pkg/storage/replica_sideload_test.go
@@ -669,6 +669,10 @@ func TestRaftSSTableSideloadingProposal(t *testing.T) {
 	if n := tc.store.metrics.AddSSTableApplications.Count(); n == 0 {
 		t.Fatalf("expected metric to show at least one AddSSTable application, but got %d", n)
 	}
+	// We don't count in-memory env SST writes as copies.
+	if n := tc.store.metrics.AddSSTableApplicationCopies.Count(); n != 0 {
+		t.Fatalf("expected metric to show 0 AddSSTable copy, but got %d", n)
+	}
 }
 
 type mockSender struct {


### PR DESCRIPTION
Previously we always copied the payload of an AddSSTable request into a new file for passing to RocksDB to ingest. However in most cases, our sideloading has that content in an on-disk file which we can just pass
directly to RocksDB as-is — on the condition that RocksDB does not
modify it. Rocks modifies added SSTs in some cases, but can be
instructed to return an error in those cases instead. By doing that, we
can avoid making a copy in cases where rocks can add it without modification, and then, if rocks complains, make a copy as needed. This 
hopefully results in less expected write amplification.