### PR TITLE
sql: add privilege checks on sequences

### DIFF
--- a/pkg/sql/data_source.go
+++ b/pkg/sql/data_source.go
@@ -727,6 +727,10 @@ func (p *planner) getGeneratorPlan(ctx context.Context, t *tree.FuncExpr) (planD
 func (p *planner) getSequenceSource(
 	ctx context.Context, tn tree.TableName, desc *sqlbase.TableDescriptor,
 ) (planDataSource, error) {
+	if err := p.CheckPrivilege(ctx, desc, privilege.SELECT); err != nil {
+		return planDataSource{}, err
+	}
+
 	node, err := p.SequenceSelectNode(desc)
 	if err != nil {
 		return planDataSource{}, err

--- a/pkg/sql/logictest/testdata/logic_test/sequences
+++ b/pkg/sql/logictest/testdata/logic_test/sequences
@@ -782,3 +782,48 @@ DROP TABLE drop_test_tbl
 
 statement ok
 DROP SEQUENCE drop_test
+
+# Test that sequences can only be modified with the UPDATE permission
+# and read with the SELECT permission.
+
+statement ok
+CREATE SEQUENCE priv_test
+
+user testuser
+
+statement error pq: user testuser does not have SELECT privilege on relation priv_test
+SELECT * FROM priv_test
+
+statement error pq: nextval\(\): user testuser does not have UPDATE privilege on relation priv_test
+SELECT nextval('priv_test')
+
+statement error pq: setval\(\): user testuser does not have UPDATE privilege on relation priv_test
+SELECT setval('priv_test', 5)
+
+user root
+
+# Verify that the value hasn't been changed.
+query I
+SELECT last_value FROM priv_test
+----
+0
+
+statement ok
+GRANT UPDATE, SELECT ON priv_test TO testuser
+
+user testuser
+
+# After the grant, testuser can select, increment, and set.
+
+statement ok
+SELECT nextval('priv_test')
+
+statement ok
+SELECT setval('priv_test', 5)
+
+query I
+SELECT last_value FROM priv_test
+----
+5
+
+user root


### PR DESCRIPTION
Before, they weren't checked -- nextval() and setval() just went right through to the KV layer. Selecting from sequences wasn't checked either.

Fixes #20955

Release note (sql change): add privilege checks on sequences