### PR TITLE
storage: move clearing of ContainsEstimates to applyRaftCommand

### DIFF
--- a/pkg/storage/replica_proposal.go
+++ b/pkg/storage/replica_proposal.go
@@ -453,23 +453,6 @@ func (r *Replica) handleReplicatedEvalResult(
 	// of the ContainsEstimates hack.
 
 	if rResult.Split != nil {
-		// TODO(tschottdorf): We want to let the usual MVCCStats-delta
-		// machinery update our stats for the left-hand side. But there is no
-		// way to pass up an MVCCStats object that will clear out the
-		// ContainsEstimates flag. We should introduce one, but the migration
-		// makes this worth a separate effort (ContainsEstimates would need to
-		// have three possible values, 'UNCHANGED', 'NO', and 'YES').
-		// Until then, we're left with this rather crude hack.
-		{
-			r.mu.Lock()
-			r.mu.state.Stats.ContainsEstimates = false
-			stats := *r.mu.state.Stats
-			r.mu.Unlock()
-			if err := r.raftMu.stateLoader.SetMVCCStats(ctx, r.store.Engine(), &stats); err != nil {
-				log.Fatal(ctx, errors.Wrap(err, "unable to write MVCC stats"))
-			}
-		}
-
 		splitPostApply(
 			r.AnnotateCtx(ctx),
 			rResult.Split.RHSDelta,


### PR DESCRIPTION
Cleanup leading up to the fix for #13392.

We clear MVCCStats.ContainsEstimates whenever a range is split because
the splitting forces us to recompute the stats, thereby eliminating
any uncertainty in our stats values. Previously, we persisted the
MVCCStats in applyRaftCommand and then updated them to clear the
ContainsEstimates flag in handleReplicatedEvalResult if the rResult
indicated that the range was being split. We now clear this flag
before setting the stats for the first time. This releases us from
needing to set them twice and centralizes the logic for setting
the stats beneath Raft.

There shouldn't be any migration concern here, because the resulting
MVCCStats will always be the same regardless of whether we set it
once or twice.