### PR TITLE
storage: only access RangeStatsKey through StateLoader

### DIFF
--- a/pkg/cli/debug.go
+++ b/pkg/cli/debug.go
@@ -668,14 +668,14 @@ func runDebugCheckStoreDescriptors(ctx context.Context, db *engine.RocksDB) erro
 				return false, err
 			}
 
-			if !ms.Equal(*claimedMS) {
+			if !ms.Equal(claimedMS) {
 				var prefix string
 				if !claimedMS.ContainsEstimates {
 					failed = true
 				} else {
 					prefix = "(ignored) "
 				}
-				fmt.Printf("\n%s%+v: diff(actual, claimed): %s\n", prefix, desc, strings.Join(pretty.Diff(ms, *claimedMS), "\n"))
+				fmt.Printf("\n%s%+v: diff(actual, claimed): %s\n", prefix, desc, strings.Join(pretty.Diff(ms, claimedMS), "\n"))
 			} else {
 				fmt.Print(".")
 			}

--- a/pkg/storage/batcheval/cmd_recompute_stats.go
+++ b/pkg/storage/batcheval/cmd_recompute_stats.go
@@ -17,7 +17,6 @@ package batcheval
 import (
 	"context"
 
-	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/pkg/errors"
 
 	"github.com/cockroachdb/cockroach/pkg/keys"
@@ -90,14 +89,9 @@ func RecomputeStats(
 		return result.Result{}, err
 	}
 
-	var currentStats enginepb.MVCCStats
-	if ok, err := engine.MVCCGetProto(
-		ctx, snap, keys.RangeStatsKey(cArgs.Header.RangeID), hlc.Timestamp{}, true /* consistent */, nil /* txn */, &currentStats,
-	); err != nil {
+	currentStats, err := MakeStateLoader(cArgs.EvalCtx).LoadMVCCStats(ctx, snap)
+	if err != nil {
 		return result.Result{}, err
-	} else if !ok {
-		// This should never happen.
-		return result.Result{}, errors.New("range stats not found")
 	}
 
 	delta := actualMS

--- a/pkg/storage/client_test.go
+++ b/pkg/storage/client_test.go
@@ -54,6 +54,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/storage/rditer"
+	"github.com/cockroachdb/cockroach/pkg/storage/stateloader"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
@@ -1344,7 +1345,7 @@ func TestSortRangeDescByAge(t *testing.T) {
 }
 
 func verifyRangeStats(eng engine.Reader, rangeID roachpb.RangeID, expMS enginepb.MVCCStats) error {
-	ms, err := engine.MVCCGetRangeStats(context.Background(), eng, rangeID)
+	ms, err := stateloader.Make(nil /* st */, rangeID).LoadMVCCStats(context.Background(), eng)
 	if err != nil {
 		return err
 	}

--- a/pkg/storage/engine/mvcc.go
+++ b/pkg/storage/engine/mvcc.go
@@ -597,23 +597,6 @@ func updateStatsOnGC(
 	return ms
 }
 
-// MVCCGetRangeStats reads stat counters for the specified range and
-// sets the values in the enginepb.MVCCStats struct.
-func MVCCGetRangeStats(
-	ctx context.Context, engine Reader, rangeID roachpb.RangeID,
-) (enginepb.MVCCStats, error) {
-	var ms enginepb.MVCCStats
-	_, err := MVCCGetProto(ctx, engine, keys.RangeStatsKey(rangeID), hlc.Timestamp{}, true, nil, &ms)
-	return ms, err
-}
-
-// MVCCSetRangeStats sets stat counters for specified range.
-func MVCCSetRangeStats(
-	ctx context.Context, engine ReadWriter, rangeID roachpb.RangeID, ms *enginepb.MVCCStats,
-) error {
-	return MVCCPutProto(ctx, engine, nil, keys.RangeStatsKey(rangeID), hlc.Timestamp{}, nil, ms)
-}
-
 // MVCCGetProto fetches the value at the specified key and unmarshals it into
 // msg if msg is non-nil. Returns true on success or false if the key was not
 // found. The semantics of consistent are the same as in MVCCGet.

--- a/pkg/storage/engine/mvcc_stats_test.go
+++ b/pkg/storage/engine/mvcc_stats_test.go
@@ -20,7 +20,6 @@ import (
 	"math/rand"
 	"sort"
 	"testing"
-	"unsafe"
 
 	"github.com/kr/pretty"
 	"github.com/stretchr/testify/require"
@@ -1469,36 +1468,4 @@ func TestMVCCComputeStatsError(t *testing.T) {
 			}
 		})
 	}
-}
-
-// BenchmarkMVCCStats set MVCCStats values.
-func BenchmarkMVCCStats(b *testing.B) {
-	rocksdb := NewInMem(roachpb.Attributes{Attrs: []string{"ssd"}}, testCacheSize)
-	defer rocksdb.Close()
-
-	ms := enginepb.MVCCStats{
-		LiveBytes:       1,
-		KeyBytes:        1,
-		ValBytes:        1,
-		IntentBytes:     1,
-		LiveCount:       1,
-		KeyCount:        1,
-		ValCount:        1,
-		IntentCount:     1,
-		IntentAge:       1,
-		GCBytesAge:      1,
-		SysBytes:        1,
-		SysCount:        1,
-		LastUpdateNanos: 1,
-	}
-	b.SetBytes(int64(unsafe.Sizeof(ms)))
-	b.ResetTimer()
-
-	for i := 0; i < b.N; i++ {
-		if err := MVCCSetRangeStats(context.Background(), rocksdb, 1, &ms); err != nil {
-			b.Fatal(err)
-		}
-	}
-
-	b.StopTimer()
 }

--- a/pkg/storage/engine/mvcc_test.go
+++ b/pkg/storage/engine/mvcc_test.go
@@ -3291,7 +3291,6 @@ func TestValidSplitKeys(t *testing.T) {
 
 func TestFindSplitKey(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	rangeID := roachpb.RangeID(1)
 	engine := createTestEngine()
 	defer engine.Close()
 
@@ -3310,10 +3309,6 @@ func TestFindSplitKey(t *testing.T) {
 		if err := MVCCPut(context.Background(), engine, ms, []byte(k), hlc.Timestamp{Logical: 1}, val, nil); err != nil {
 			t.Fatal(err)
 		}
-	}
-	// write stats
-	if err := MVCCSetRangeStats(context.Background(), engine, rangeID, ms); err != nil {
-		t.Fatal(err)
 	}
 
 	testData := []struct {
@@ -3363,7 +3358,6 @@ func TestFindValidSplitKeys(t *testing.T) {
 		return splitKey
 	}
 
-	rangeID := roachpb.RangeID(1)
 	testCases := []struct {
 		keys       []roachpb.Key
 		rangeStart roachpb.Key // optional
@@ -3508,10 +3502,6 @@ func TestFindValidSplitKeys(t *testing.T) {
 					t.Fatal(err)
 				}
 			}
-			// write stats
-			if err := MVCCSetRangeStats(context.Background(), engine, rangeID, ms); err != nil {
-				t.Fatal(err)
-			}
 			rangeStart := test.keys[0]
 			if len(test.rangeStart) > 0 {
 				rangeStart = test.rangeStart
@@ -3548,7 +3538,6 @@ func TestFindValidSplitKeys(t *testing.T) {
 // the left and right halves are equally balanced.
 func TestFindBalancedSplitKeys(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	rangeID := roachpb.RangeID(1)
 	testCases := []struct {
 		keySizes []int
 		valSizes []int
@@ -3608,10 +3597,6 @@ func TestFindBalancedSplitKeys(t *testing.T) {
 				if err := MVCCPut(context.Background(), engine, ms, key, hlc.Timestamp{Logical: 1}, val, nil); err != nil {
 					t.Fatal(err)
 				}
-			}
-			// write stats
-			if err := MVCCSetRangeStats(context.Background(), engine, rangeID, ms); err != nil {
-				t.Fatal(err)
 			}
 			targetSize := (ms.KeyBytes + ms.ValBytes) / 2
 			splitKey, err := MVCCFindSplitKey(context.Background(), engine,

--- a/pkg/storage/replica_command.go
+++ b/pkg/storage/replica_command.go
@@ -1455,7 +1455,7 @@ func mergeTrigger(
 
 	// Add in stats for right hand side of merge, excluding system-local
 	// stats, which will need to be recomputed.
-	rightMS, err := engine.MVCCGetRangeStats(ctx, batch, rightRangeID)
+	rightMS, err := stateloader.Make(rec.ClusterSettings(), rightRangeID).LoadMVCCStats(ctx, batch)
 	if err != nil {
 		return result.Result{}, err
 	}

--- a/pkg/storage/replica_test.go
+++ b/pkg/storage/replica_test.go
@@ -47,6 +47,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/storage/rditer"
 	"github.com/cockroachdb/cockroach/pkg/storage/spanset"
+	"github.com/cockroachdb/cockroach/pkg/storage/stateloader"
 	"github.com/cockroachdb/cockroach/pkg/storage/storagebase"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
@@ -5743,7 +5744,7 @@ func TestReplicaResolveIntentRange(t *testing.T) {
 }
 
 func verifyRangeStats(eng engine.Reader, rangeID roachpb.RangeID, expMS enginepb.MVCCStats) error {
-	ms, err := engine.MVCCGetRangeStats(context.Background(), eng, rangeID)
+	ms, err := stateloader.Make(nil /* st */, rangeID).LoadMVCCStats(context.Background(), eng)
 	if err != nil {
 		return err
 	}

--- a/pkg/storage/stateloader/stateloader.go
+++ b/pkg/storage/stateloader/stateloader.go
@@ -90,9 +90,11 @@ func (rsl StateLoader) Load(
 		return storagebase.ReplicaState{}, err
 	}
 
-	if s.Stats, err = rsl.LoadMVCCStats(ctx, reader); err != nil {
+	ms, err := rsl.LoadMVCCStats(ctx, reader)
+	if err != nil {
 		return storagebase.ReplicaState{}, err
 	}
+	s.Stats = &ms
 
 	// The truncated state should not be optional (i.e. the pointer is
 	// pointless), but it is and the migration is not worth it.
@@ -338,10 +340,10 @@ func (rsl StateLoader) SetTxnSpanGCThreshold(
 // LoadMVCCStats loads the MVCC stats.
 func (rsl StateLoader) LoadMVCCStats(
 	ctx context.Context, reader engine.Reader,
-) (*enginepb.MVCCStats, error) {
+) (enginepb.MVCCStats, error) {
 	var ms enginepb.MVCCStats
 	_, err := engine.MVCCGetProto(ctx, reader, rsl.RangeStatsKey(), hlc.Timestamp{}, true, nil, &ms)
-	return &ms, err
+	return ms, err
 }
 
 // SetMVCCStats overwrites the MVCC stats.

--- a/pkg/storage/stats_test.go
+++ b/pkg/storage/stats_test.go
@@ -19,8 +19,8 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/cockroachdb/cockroach/pkg/storage/engine"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
+	"github.com/cockroachdb/cockroach/pkg/storage/stateloader"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/kr/pretty"
@@ -69,10 +69,11 @@ func TestRangeStatsInit(t *testing.T) {
 		GCBytesAge:      10,
 		LastUpdateNanos: 11,
 	}
-	if err := engine.MVCCSetRangeStats(context.Background(), tc.engine, 1, &ms); err != nil {
+	rsl := stateloader.Make(nil /* st */, tc.repl.RangeID)
+	if err := rsl.SetMVCCStats(context.Background(), tc.engine, &ms); err != nil {
 		t.Fatal(err)
 	}
-	loadMS, err := engine.MVCCGetRangeStats(context.Background(), tc.engine, tc.repl.RangeID)
+	loadMS, err := rsl.LoadMVCCStats(context.Background(), tc.engine)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Cleanup leading up to the fix for #13392.

Before this change, there were a number of places where we loaded and
stored MVCCStats directly from an engine. We now access them through
a StateLoader in all cases. This abstraction will allow us to minimize
the amount of logic needed when we migrate away from the use of this
key.