### PR TITLE
distsql: fix TestFlowRegistryDrain flake

### DIFF
--- a/pkg/sql/distsqlrun/flow_registry_test.go
+++ b/pkg/sql/distsqlrun/flow_registry_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/pkg/errors"
 )
@@ -373,7 +374,7 @@ func TestFlowRegistryDrain(t *testing.T) {
 	flow := &Flow{}
 	flow.Ctx = ctx
 	id := FlowID{uuid.MakeV4()}
-	registerFlow := func(id FlowID) {
+	registerFlow := func(t *testing.T, id FlowID) {
 		t.Helper()
 		if err := reg.RegisterFlow(
 			ctx, id, flow, nil /* inboundStreams */, 0, /* timeout */
@@ -385,7 +386,7 @@ func TestFlowRegistryDrain(t *testing.T) {
 	// WaitForFlow verifies that Drain waits for a flow to finish within the
 	// timeout.
 	t.Run("WaitForFlow", func(t *testing.T) {
-		registerFlow(id)
+		registerFlow(t, id)
 		drainDone := make(chan struct{})
 		go func() {
 			reg.Drain(math.MaxInt64 /* flowDrainWait */, 0 /* minFlowDrainWait */)
@@ -400,7 +401,7 @@ func TestFlowRegistryDrain(t *testing.T) {
 
 	// DrainTimeout verifies that Drain returns once the timeout expires.
 	t.Run("DrainTimeout", func(t *testing.T) {
-		registerFlow(id)
+		registerFlow(t, id)
 		reg.Drain(0 /* flowDrainWait */, 0 /* minFlowDrainWait */)
 		reg.UnregisterFlow(id)
 		reg.Undrain()
@@ -409,7 +410,7 @@ func TestFlowRegistryDrain(t *testing.T) {
 	// AcceptNewFlow verifies that a flowRegistry continues accepting flows
 	// while draining.
 	t.Run("AcceptNewFlow", func(t *testing.T) {
-		registerFlow(id)
+		registerFlow(t, id)
 		drainDone := make(chan struct{})
 		go func() {
 			reg.Drain(math.MaxInt64 /* flowDrainWait */, 0 /* minFlowDrainWait */)
@@ -418,7 +419,7 @@ func TestFlowRegistryDrain(t *testing.T) {
 		// Be relatively sure that the flowRegistry is draining.
 		time.Sleep(time.Microsecond)
 		newFlowID := FlowID{uuid.MakeV4()}
-		registerFlow(newFlowID)
+		registerFlow(t, newFlowID)
 		reg.UnregisterFlow(id)
 		select {
 		case <-drainDone:
@@ -439,22 +440,49 @@ func TestFlowRegistryDrain(t *testing.T) {
 	// MinFlowWait verifies that the flowRegistry waits a minimum amount of time
 	// for incoming flows to be registered.
 	t.Run("MinFlowWait", func(t *testing.T) {
-		minFlowDrainWait := 10 * time.Millisecond
 		// Case in which draining is initiated with zero running flows.
 		drainDone := make(chan struct{})
+		// Register a flow right before the flowRegistry waits for
+		// minFlowDrainWait. Use an errChan because draining is performed from
+		// another goroutine and cannot call t.Fatal.
+		errChan := make(chan error)
+		reg.testingRunBeforeDrainSleep = func() {
+			if err := reg.RegisterFlow(
+				ctx, id, flow, nil /* inboundStreams */, 0, /* timeout */
+			); err != nil {
+				errChan <- err
+			}
+			errChan <- nil
+		}
+		defer func() { reg.testingRunBeforeDrainSleep = nil }()
 		go func() {
-			reg.Drain(math.MaxInt64 /* flowDrainWait */, minFlowDrainWait)
+			reg.Drain(math.MaxInt64 /* flowDrainWait */, 0 /* minFlowDrainWait */)
 			drainDone <- struct{}{}
 		}()
-		// Be relatively sure that the flowRegistry is draining.
-		time.Sleep(time.Microsecond)
-		registerFlow(id)
+		if err := <-errChan; err != nil {
+			t.Fatal(err)
+		}
 		reg.UnregisterFlow(id)
 		<-drainDone
 		reg.Undrain()
 
-		// Case in which a running flow finishes before the minimum wait time.
-		registerFlow(id)
+		// Case in which a running flow finishes before the minimum wait time. We
+		// attempt to register another flow after the completion of the first flow
+		// to simulate an incoming flow that is registered during the minimum wait
+		// time. However, it is possible to unregister the first flow after the
+		// minimum wait time has passed, in which case we simply verify that the
+		// flowRegistry drain process has lasted at least the required wait time.
+		registerFlow(t, id)
+		reg.testingRunBeforeDrainSleep = func() {
+			if err := reg.RegisterFlow(
+				ctx, id, flow, nil /* inboundStreams */, 0, /* timeout */
+			); err != nil {
+				errChan <- err
+			}
+			errChan <- nil
+		}
+		minFlowDrainWait := 10 * time.Millisecond
+		start := timeutil.Now()
 		go func() {
 			reg.Drain(math.MaxInt64 /* flowDrainWait */, minFlowDrainWait)
 			drainDone <- struct{}{}
@@ -462,9 +490,20 @@ func TestFlowRegistryDrain(t *testing.T) {
 		// Be relatively sure that the flowRegistry is draining.
 		time.Sleep(time.Microsecond)
 		reg.UnregisterFlow(id)
-		registerFlow(id)
+		select {
+		case <-drainDone:
+			if timeutil.Since(start) < minFlowDrainWait {
+				t.Fatal("flow registry did not wait at least minFlowDrainWait")
+			}
+			return
+		case err := <-errChan:
+			if err != nil {
+				t.Fatal(err)
+			}
+		}
 		reg.UnregisterFlow(id)
 		<-drainDone
+
 		reg.Undrain()
 	})
 }


### PR DESCRIPTION
The flake was due to the flowRegistry returning from the drain process
before we had a chance to register an incoming flow. Added a hook that
is executed before the wait for any incoming flows and allowed this case
with a check for a minimum wait time.

Fixes #22240
Fixes #22239

Release note: None