### PR TITLE
sql: add benchmarks for sequence increment and unique_rowid

### DIFF
--- a/pkg/sql/sequence_test.go
+++ b/pkg/sql/sequence_test.go
@@ -1,0 +1,76 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package sql
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+)
+
+func BenchmarkSequenceIncrement(b *testing.B) {
+	cluster := serverutils.StartTestCluster(b, 3, base.TestClusterArgs{})
+	defer cluster.Stopper().Stop(context.Background())
+
+	sqlDB := cluster.ServerConn(0)
+
+	if _, err := sqlDB.Exec(`
+		CREATE DATABASE test;
+		USE test;
+		CREATE SEQUENCE seq;
+		CREATE TABLE tbl (
+			id INT PRIMARY KEY DEFAULT nextval('seq'),
+			foo text
+		);
+	`); err != nil {
+		b.Fatal(err)
+	}
+
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		if _, err := sqlDB.Exec("INSERT INTO tbl (foo) VALUES ('foo')"); err != nil {
+			b.Fatal(err)
+		}
+	}
+	b.StopTimer()
+}
+
+func BenchmarkUniqueRowID(b *testing.B) {
+	cluster := serverutils.StartTestCluster(b, 3, base.TestClusterArgs{})
+	defer cluster.Stopper().Stop(context.Background())
+
+	sqlDB := cluster.ServerConn(0)
+
+	if _, err := sqlDB.Exec(`
+		CREATE DATABASE test;
+		USE test;
+		CREATE TABLE tbl (
+			id INT PRIMARY KEY DEFAULT unique_rowid(),
+			foo text
+		);
+	`); err != nil {
+		b.Fatal(err)
+	}
+
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		if _, err := sqlDB.Exec("INSERT INTO tbl (foo) VALUES ('foo')"); err != nil {
+			b.Fatal(err)
+		}
+	}
+	b.StopTimer()
+}


### PR DESCRIPTION
On my laptop:

Sequence: `BenchmarkSequenceIncrement-8   	    2000	    720976 ns/op`
unqiue_rowid: `BenchmarkUniqueRowID-8   	    5000	    310506 ns/op`

Open to suggestions on how to make this a better benchmark (start up multiple nodes in the test cluster?); don't have much experience writing them.

Release note: None