### PR TITLE
distsql: optimize scans with hard limits

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/distsql_numtables
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_numtables
@@ -220,12 +220,17 @@ SELECT COUNT(*) FROM NumToStr WHERE str LIKE '%five%'
 query T
 SELECT "URL" FROM [EXPLAIN (DISTSQL) SELECT y FROM NumToStr LIMIT 5]
 ----
-https://cockroachdb.github.io/distsqlplan/decode.html?eJzEk7tq60AQhvvzFOav94B1S7GVW0Owg0kXVGy0g1mQdsReIMHo3YNWhSPjxAQVKmdG3_wfYvYCy5oOqiMP-YYMAjkECgiUEKhQC_SOG_Ke3fjJBOz1B-RWwNg-hrFdCzTsCPKCYEJLkHhV7y2dSGlyENAUlGlTSO9Mp9znzsYusA_j9BiD3OzG9GfTmbCpUA8CHMN1vQ_qTJDZIH5QuCZHy06TIz3LrYc7kgf-z_1c75FBPjPI1v8J-foKxfoK5foKDx7EiXzP1tPNVd7fvB2vlfSZptP2HF1DL46bFDOVx8SlhiYfpmk2FXubRknwO5z9Cj_N4O0tnC9JLpbA5RK4-hNcD_--AgAA__9hcK3z
+https://cockroachdb.github.io/distsqlplan/decode.html?eJyMjzFrAzEMhff-ivBmD7mhi6esgdKU0K14cM8iGO6sQ5KhJfi_l7OH0qGQ8b0nfU-6o3Ci17iSwn9gQnDYhGdSZdmtMXBOX_BHh1y2arsdHGYWgr_Dsi0Ej_f4udCVYiKBQyKLeenQTfIa5ftU6mqstqeXav5wmuDwktdsh2eE5sDVfvFq8UbwU3OPn3Al3bgo_en_j3xswYHSjcabylVmehOee82Ql77XjURqI52GOJcRtdCefgIAAP__lz9sqw==
 
 query T
 SELECT "URL" FROM [EXPLAIN (DISTSQL) SELECT y FROM NumToStr ORDER BY y LIMIT 5]
 ----
-https://cockroachdb.github.io/distsqlplan/decode.html?eJzEkz9r8zAQxvf3U4RnfVWw_KeDJq-BkpTQrXhQrSMIbJ-RZGgJ_u7F8pC6NA3Fg0fd3e-eH-Z8QceGDrolD_UKCYEUAhkEcggUqAR6xzV5z24amYG9eYdKBGzXD2EqVwI1O4K6INjQEBRe9FtDJ9KGHAQMBW2bGNI722r3UXZDG9iHqXscgtqVU_qTbW3YFahGAR7Cdb0P-kxQchQ3FK7J7Aw5MsvUUv5HNf7geeAH7pez9yTShYTc_juk2ytk2yvk2yvc-SdO5HvuPC3yb21Opmslc6b5uj0PrqZnx3WMmZ_HyMWCIR_mrpwf-y62ouBXWP4KPy7g5DucrknO1sD5Grj4E1yN_z4DAAD__zIVrfA=
+https://cockroachdb.github.io/distsqlplan/decode.html?eJyMjzFrAzEMhff-ivBmD7mhi6esgdKU0K14cM8iGO6sQ5KhJfi_l7OH0qGQ8b0nfU-6o3Ci17iSwn9gQnDYhGdSZdmtMXBOX_BHh1y2arsdHGYWgr_Dsi0Ej_f4udCVYiKBQyKLeenQTfIa5ftU6mqstqeXav5wmuDwktdsh2eE5sDVfvFq8UbwU3OPn3Al3bgo_en_j3xswYHSjcabylVmehOee82Ql77XjURqI52GOJcRtdCefgIAAP__lz9sqw==
+
+query T
+SELECT "URL" FROM [EXPLAIN (DISTSQL) SELECT y FROM NumToStr ORDER BY y DESC LIMIT 5]
+----
+https://cockroachdb.github.io/distsqlplan/decode.html?eJyMkLFqMzEQhPv_KczU-uHO4EaVW0Owg0kXrlBOixHcaYV2BQnm3j3oVMQOxEm5O_uNZnRFZE9HN5PAvqKHwQ6DQco8kgjnum5HB_8O2xmEmIrW9WAwcibYKzToRLA48n9OMPCkLkzr0WLARb8QUXch2O1ibmz7x7Yv7m2iMzlP-c4cKYfZ5Y99LLOyaFVPRe1mX4s8hTnoZoefIvR3EX5pdiZJHIX-VK5bBgPyF2q_J1zySM-Zx_WZNp5Wbl14Em3qtg2H2KQa8BbuH8LdN3hY_n0GAAD__0cMnlY=
 
 query I
 SELECT y FROM NumToStr ORDER BY y LIMIT 5
@@ -235,6 +240,15 @@ SELECT y FROM NumToStr ORDER BY y LIMIT 5
 3
 4
 5
+
+query I
+SELECT y FROM NumToStr ORDER BY y DESC LIMIT 5
+----
+10000
+9999
+9998
+9997
+9996
 
 query I
 SELECT y FROM NumToStr ORDER BY y OFFSET 5 LIMIT 2

--- a/pkg/sql/logictest/testdata/logic_test/explain_distsql
+++ b/pkg/sql/logictest/testdata/logic_test/explain_distsql
@@ -57,15 +57,15 @@ SELECT "Automatic" FROM [EXPLAIN (DISTSQL) SELECT k, SUM(v) FROM kv WHERE k>1 GR
 ----
 true
 
-# Hard limit in scan - don't distribute.
+# Hard limit in scan - distribute.
 query B
 SELECT "Automatic" FROM [EXPLAIN (DISTSQL) SELECT * FROM kv LIMIT 1]
 ----
-false
+true
 
 # Soft limit in scan - don't distribute.
 query B
-SELECT "Automatic" FROM [EXPLAIN (DISTSQL) SELECT * FROM kv WHERE v=1 LIMIT 1]
+SELECT "Automatic" FROM [EXPLAIN (DISTSQL) SELECT * FROM kv UNION SELECT * FROM kv LIMIT 1]
 ----
 false
 


### PR DESCRIPTION
This commit implements the short-term proposal from the
20170602_distsql_limit RFC for hard limits only.

Previously, a scan with a limit of X would create a table reader on each
node with relevant ranges, each with its own limit of X. This
potentially caused many more rows to be read than necessary and put
undue load on the cluster.

To avoid this, limit scans now use a single table reader on the node
with the first range to be scanned. This may result in remote reads, but
it will only read as many rows as necessary.

I've enabled distsql for hard limit scans since their performance should
now be as good or better than local execution in most cases. However,
note that the RFC calls out two potential problems:
- If the single table reader is in a faraway zone, routing all the
  scanned data through that node may not be performant.
- The node may become a hotspot if many similar queries are run
  concurrently.

distsql remains disabled for soft limit scans because they require an
additional control flow mechanism to avoid scanning rows too eagerly.

Release note: None