### PR TITLE
sql: teach the distSQLReceiver to discriminate between error types

### DIFF
--- a/pkg/ccl/sqlccl/csv.go
+++ b/pkg/ccl/sqlccl/csv.go
@@ -1165,7 +1165,7 @@ func doDistributedCSVTransform(
 		evalCtx,
 		p.ExecCfg().NodeID.Get(),
 		nodes,
-		sql.NewRowResultWriter(tree.Rows, rows),
+		sql.NewRowResultWriter(rows),
 		tableDesc,
 		files,
 		temp,

--- a/pkg/sql/distsql_physical_planner_test.go
+++ b/pkg/sql/distsql_physical_planner_test.go
@@ -218,7 +218,8 @@ func TestDistSQLReceiverUpdatesCaches(t *testing.T) {
 	rangeCache := kv.NewRangeDescriptorCache(st, nil /* db */, size)
 	leaseCache := kv.NewLeaseHolderCache(size)
 	r := makeDistSQLReceiver(
-		context.TODO(), nil /* sink */, rangeCache, leaseCache, nil /* txn */, nil /* updateClock */)
+		context.TODO(), nil /* resultWriter */, tree.Rows,
+		rangeCache, leaseCache, nil /* txn */, nil /* updateClock */)
 
 	descs := []roachpb.RangeDescriptor{
 		{RangeID: 1, StartKey: roachpb.RKey("a"), EndKey: roachpb.RKey("c")},

--- a/pkg/sql/distsql_plan_csv.go
+++ b/pkg/sql/distsql_plan_csv.go
@@ -41,21 +41,16 @@ type DistLoader struct {
 
 // RowResultWriter is a thin wrapper around a RowContainer.
 type RowResultWriter struct {
-	statementType tree.StatementType
-	rowContainer  *sqlbase.RowContainer
-	rowsAffected  int
+	rowContainer *sqlbase.RowContainer
+	rowsAffected int
+	err          error
 }
+
+var _ rowResultWriter = &RowResultWriter{}
 
 // NewRowResultWriter creates a new RowResultWriter.
-func NewRowResultWriter(
-	statementType tree.StatementType, rowContainer *sqlbase.RowContainer,
-) *RowResultWriter {
-	return &RowResultWriter{statementType: statementType, rowContainer: rowContainer}
-}
-
-// StatementType implements the rowResultWriter interface.
-func (b *RowResultWriter) StatementType() tree.StatementType {
-	return b.statementType
+func NewRowResultWriter(rowContainer *sqlbase.RowContainer) *RowResultWriter {
+	return &RowResultWriter{rowContainer: rowContainer}
 }
 
 // IncrementRowsAffected implements the rowResultWriter interface.
@@ -69,28 +64,46 @@ func (b *RowResultWriter) AddRow(ctx context.Context, row tree.Datums) error {
 	return err
 }
 
+// SetError is part of the rowResultWriter interface.
+func (b *RowResultWriter) SetError(err error) {
+	b.err = err
+}
+
+// Err is part of the rowResultWriter interface.
+func (b *RowResultWriter) Err() error {
+	return b.err
+}
+
 // callbackResultWriter is a rowResultWriter that runs a callback function
 // on AddRow.
-type callbackResultWriter func(ctx context.Context, row tree.Datums) error
+type callbackResultWriter struct {
+	fn  func(ctx context.Context, row tree.Datums) error
+	err error
+}
 
-// newCallbackResultWriter creates a new callbackResultWriter.
+var _ rowResultWriter = &callbackResultWriter{}
+
+// makeCallbackResultWriter creates a new callbackResultWriter.
 func newCallbackResultWriter(
 	fn func(ctx context.Context, row tree.Datums) error,
 ) callbackResultWriter {
-	return callbackResultWriter(fn)
+	return callbackResultWriter{fn: fn}
 }
 
-// StatementType implements the rowResultWriter interface.
-func (callbackResultWriter) StatementType() tree.StatementType {
-	return tree.Rows
+func (*callbackResultWriter) IncrementRowsAffected(n int) {
+	panic("IncrementRowsAffected not supported by callbackResultWriter")
 }
 
-// IncrementRowsAffected implements the rowResultWriter interface.
-func (callbackResultWriter) IncrementRowsAffected(n int) {}
+func (c *callbackResultWriter) AddRow(ctx context.Context, row tree.Datums) error {
+	return c.fn(ctx, row)
+}
 
-// AddRow implements the rowResultWriter interface.
-func (c callbackResultWriter) AddRow(ctx context.Context, row tree.Datums) error {
-	return c(ctx, row)
+func (c *callbackResultWriter) SetError(err error) {
+	c.err = err
+}
+
+func (c *callbackResultWriter) Err() error {
+	return c.err
 }
 
 // LoadCSV performs a distributed transformation of the CSV files at from
@@ -253,7 +266,8 @@ func (l *DistLoader) LoadCSV(
 
 	recv := makeDistSQLReceiver(
 		ctx,
-		rowResultWriter,
+		&rowResultWriter,
+		tree.Rows,
 		nil, /* rangeCache */
 		nil, /* leaseCache */
 		nil, /* txn - the flow does not read or write the database */
@@ -273,12 +287,10 @@ func (l *DistLoader) LoadCSV(
 			}
 		}
 
-		return l.distSQLPlanner.Run(&planCtx, txn, &p, recv, evalCtx)
+		l.distSQLPlanner.Run(&planCtx, txn, &p, recv, evalCtx)
+		return rowResultWriter.Err()
 	}); err != nil {
 		return err
-	}
-	if recv.err != nil {
-		return recv.err
 	}
 
 	// Add the closing span.
@@ -389,6 +401,7 @@ func (l *DistLoader) LoadCSV(
 	recv = makeDistSQLReceiver(
 		ctx,
 		resultRows,
+		tree.Rows,
 		nil, /* rangeCache */
 		nil, /* leaseCache */
 		nil, /* txn - the flow does not read or write the database */
@@ -398,14 +411,8 @@ func (l *DistLoader) LoadCSV(
 	defer log.VEventf(ctx, 1, "finished job %s", job.Record.Description)
 	// TODO(dan): We really don't need the txn for this flow, so remove it once
 	// Run works without one.
-	if err := db.Txn(ctx, func(ctx context.Context, txn *client.Txn) error {
-		return l.distSQLPlanner.Run(&planCtx, txn, &p, recv, evalCtx)
-	}); err != nil {
-		return err
-	}
-	if recv.err != nil {
-		return recv.err
-	}
-
-	return nil
+	return db.Txn(ctx, func(ctx context.Context, txn *client.Txn) error {
+		l.distSQLPlanner.Run(&planCtx, txn, &p, recv, evalCtx)
+		return resultRows.Err()
+	})
 }

--- a/pkg/sql/executor.go
+++ b/pkg/sql/executor.go
@@ -2000,26 +2000,19 @@ func commitSQLTransaction(
 // exectDistSQL converts the current logical plan to a distributed SQL
 // physical plan and runs it.
 func (e *Executor) execDistSQL(
-	planner *planner, plan planNode, rowResultWriter StatementResult,
+	planner *planner, plan planNode, rowResultWriter StatementResult, stmtType tree.StatementType,
 ) error {
 	ctx := planner.EvalContext().Ctx()
 	recv := makeDistSQLReceiver(
-		ctx, rowResultWriter,
+		ctx, rowResultWriter, stmtType,
 		e.cfg.RangeDescriptorCache, e.cfg.LeaseHolderCache,
 		planner.txn,
 		func(ts hlc.Timestamp) {
 			_ = e.cfg.Clock.Update(ts)
 		},
 	)
-	if err := e.distSQLPlanner.PlanAndRun(
-		ctx, planner.txn, plan, recv, &planner.extendedEvalCtx,
-	); err != nil {
-		return err
-	}
-	if recv.err != nil {
-		return recv.err
-	}
-	return nil
+	e.distSQLPlanner.PlanAndRun(ctx, planner.txn, plan, recv, &planner.extendedEvalCtx)
+	return rowResultWriter.Err()
 }
 
 // execLocal runs the given logical plan using the local
@@ -2199,7 +2192,7 @@ func (e *Executor) execStmt(
 	planner.statsCollector.PhaseTimes()[plannerStartExecStmt] = timeutil.Now()
 	session.setQueryExecutionMode(stmt.queryID, useDistSQL, false /* isParallel */)
 	if useDistSQL {
-		err = e.execDistSQL(planner, planner.curPlan.plan, res)
+		err = e.execDistSQL(planner, planner.curPlan.plan, res, stmt.AST.StatementType())
 	} else {
 		err = e.execLocal(planner, planner.curPlan.plan, res)
 	}

--- a/pkg/sql/results_writer.go
+++ b/pkg/sql/results_writer.go
@@ -169,6 +169,11 @@ type StatementResult interface {
 	// CloseResult cannot be called unless there's a corresponding BeginResult
 	// prior.
 	CloseResult() error
+
+	// SetError allows an error to be  stored on the StatementResult.
+	SetError(err error)
+	// Err returns the error previously set with SetError(), if any.
+	Err() error
 }
 
 type bufferedWriter struct {
@@ -183,10 +188,22 @@ type bufferedWriter struct {
 	// currentResult and resultInProgress spans a statement.
 	currentResult    Result
 	resultInProgress bool
+
+	err error
 }
 
 func newBufferedWriter(acc mon.BoundAccount) *bufferedWriter {
 	return &bufferedWriter{acc: acc}
+}
+
+// SetError is part of the ResultsWriter interface.
+func (b *bufferedWriter) SetError(err error) {
+	b.err = err
+}
+
+// Err is part of the ResultsWriter interface.
+func (b *bufferedWriter) Err() error {
+	return b.err
 }
 
 func (b *bufferedWriter) results() StatementResults {


### PR DESCRIPTION
Today our sql execution code doesn't discriminated between query
execution errors and errors in communication with the client (e.g. when
a query produces a result row and tries to send it to the client, at
which point it finds out that the client network connection is toast).
Communication errors are important because they mean that the sql
session is also toast - we should clean it up and stop processing
queries. So, communication errors, which originate in pgwire, then flow
all the way through sql execution back into pgwire, which recognizes
them and dismantles the session.
This scheme is already pretty funky today, and doesn't fit at all in the
future connExecutor code -> there a session is not directly driven by a
pgwire connection; the session runs its own goroutine communicating
async with pgwire. The connExecutor will be aware of the two different
types of errors and handle them differently.

In preparation for that, this patch makes code around the
distSQLReceiver able to discriminate between the two types of error - it
keeps track of communication errors versus all other errors.
The capability is not used yet in earnest, as both types of errors flow
to pgwire just like they did before, but the refactoring already
simplifies some code.

Release note: none