### PR TITLE
sqlccl: allow DEFAULT expressions in IMPORT

### DIFF
--- a/pkg/ccl/sqlccl/csv_internal_test.go
+++ b/pkg/ccl/sqlccl/csv_internal_test.go
@@ -47,12 +47,10 @@ func TestMakeSimpleTableDescriptorErrors(t *testing.T) {
 			error: `foreign keys not supported: CONSTRAINT a FOREIGN KEY \(i\) REFERENCES c \(id\)`,
 		},
 		{
-			stmt:  "create table a (i int default 0)",
-			error: "DEFAULT expressions not supported: i INT DEFAULT 0",
-		},
-		{
 			stmt: `create table a (
 				i int check (i > 0),
+				b int default 1,
+				c serial,
 				constraint a check (i < 0),
 				primary key (i),
 				unique index (i),


### PR DESCRIPTION
Release note (sql change): allow DEFAULT expressions in the CREATE
TABLE of IMPORT. The expressions are not evaluated (data in the CSV
is still required to be present). This change only allows them to be
part of the table definition.

Fixes #22207