### PR TITLE
storage/engine: use a fixed-length encoding for key/value lengths

### DIFF
--- a/c-deps/libroach/chunked_buffer.h
+++ b/c-deps/libroach/chunked_buffer.h
@@ -49,7 +49,6 @@ class chunkedBuffer {
 
  private:
   void put(const char* data, int len, int next_size_hint);
-  void putLengthPrefixedSlice(const rocksdb::Slice& value);
 
  private:
   std::vector<DBSlice> bufs_;

--- a/c-deps/libroach/encoding.cc
+++ b/c-deps/libroach/encoding.cc
@@ -18,35 +18,6 @@
 
 namespace cockroach {
 
-char* EncodeVarint32(char* dst, uint32_t v) {
-  // Copied from RocksDB's coding.cc.
-  // Operate on characters as unsigneds
-  unsigned char* ptr = reinterpret_cast<unsigned char*>(dst);
-  static const int B = 128;
-  if (v < (1 << 7)) {
-    *(ptr++) = v;
-  } else if (v < (1 << 14)) {
-    *(ptr++) = v | B;
-    *(ptr++) = v >> 7;
-  } else if (v < (1 << 21)) {
-    *(ptr++) = v | B;
-    *(ptr++) = (v >> 7) | B;
-    *(ptr++) = v >> 14;
-  } else if (v < (1 << 28)) {
-    *(ptr++) = v | B;
-    *(ptr++) = (v >> 7) | B;
-    *(ptr++) = (v >> 14) | B;
-    *(ptr++) = v >> 21;
-  } else {
-    *(ptr++) = v | B;
-    *(ptr++) = (v >> 7) | B;
-    *(ptr++) = (v >> 14) | B;
-    *(ptr++) = (v >> 21) | B;
-    *(ptr++) = v >> 28;
-  }
-  return reinterpret_cast<char*>(ptr);
-}
-
 void EncodeUint32(std::string* buf, uint32_t v) {
   const uint8_t tmp[sizeof(v)] = {
       uint8_t(v >> 24),

--- a/c-deps/libroach/encoding.h
+++ b/c-deps/libroach/encoding.h
@@ -22,10 +22,6 @@
 
 namespace cockroach {
 
-// EncodeVarint32 encodes the uint32 value using RocksDB's varint
-// representation.
-char* EncodeVarint32(char* dst, uint32_t value);
-
 // EncodeUint32 encodes the uint32 value using a big-endian 4 byte
 // representation. The bytes are appended to the supplied buffer.
 void EncodeUint32(std::string* buf, uint32_t v);

--- a/pkg/storage/engine/batch.go
+++ b/pkg/storage/engine/batch.go
@@ -384,24 +384,6 @@ func rocksDBBatchVarString(repr []byte) (s []byte, orepr []byte, err error) {
 	return repr[:v], repr[v:], nil
 }
 
-// Decode an MVCC scan batch repr key/value pair, returning both the key/value
-// and the suffix of data remaining in the batch.
-func mvccScanBatchDecodeValue(repr []byte) (key MVCCKey, value []byte, orepr []byte, err error) {
-	if len(repr) == 0 {
-		return key, nil, repr, errors.Errorf("unexpected batch EOF")
-	}
-	rawKey, repr, err := rocksDBBatchVarString(repr)
-	if err != nil {
-		return key, nil, repr, err
-	}
-	value, repr, err = rocksDBBatchVarString(repr)
-	if err != nil {
-		return key, nil, repr, err
-	}
-	key, err = DecodeKey(rawKey)
-	return key, value, repr, err
-}
-
 // RocksDBBatchReader is used to iterate the entries in a RocksDB batch
 // representation.
 //

--- a/pkg/storage/engine/mvcc.go
+++ b/pkg/storage/engine/mvcc.go
@@ -1703,12 +1703,12 @@ func buildScanResumeKey(kvData []byte, numKvs int64, max int64) ([]byte, error) 
 	}
 	var err error
 	for i := int64(0); i < max; i++ {
-		_, _, kvData, err = mvccScanBatchDecodeValue(kvData)
+		_, _, kvData, err = mvccScanDecodeKeyValue(kvData)
 		if err != nil {
 			return nil, err
 		}
 	}
-	key, _, _, err := mvccScanBatchDecodeValue(kvData)
+	key, _, _, err := mvccScanDecodeKeyValue(kvData)
 	if err != nil {
 		return nil, err
 	}
@@ -1754,7 +1754,7 @@ func buildScanResults(
 	var key MVCCKey
 	var rawBytes []byte
 	for i := range kvs {
-		key, rawBytes, kvData, err = mvccScanBatchDecodeValue(kvData)
+		key, rawBytes, kvData, err = mvccScanDecodeKeyValue(kvData)
 		if err != nil {
 			return nil, nil, nil, err
 		}
@@ -1765,7 +1765,7 @@ func buildScanResults(
 
 	var resumeKey roachpb.Key
 	if numKvs > max {
-		key, _, _, err = mvccScanBatchDecodeValue(kvData)
+		key, _, _, err = mvccScanDecodeKeyValue(kvData)
 		if err != nil {
 			return nil, nil, nil, err
 		}


### PR DESCRIPTION
Use a fixed-length encoding for key/value lengths returned for the
`MVCCScan` "batch" (note that this was already not the RocksDB batch
repr format).

```
name                                                    old time/op    new time/op    delta
MVCCScan_RocksDB/rows=100/versions=1/valueSize=8-8        28.9µs ± 1%    28.7µs ± 3%     ~     (p=0.353 n=10+10)
MVCCScan_RocksDB/rows=100/versions=1/valueSize=64-8       31.8µs ± 1%    30.9µs ± 2%   -2.93%  (p=0.000 n=10+10)
MVCCScan_RocksDB/rows=100/versions=1/valueSize=512-8      45.8µs ± 1%    44.2µs ± 1%   -3.41%  (p=0.000 n=10+10)
MVCCScan_RocksDB/rows=1000/versions=1/valueSize=8-8        221µs ± 0%     216µs ± 1%   -1.95%  (p=0.000 n=9+10)
MVCCScan_RocksDB/rows=1000/versions=1/valueSize=64-8       237µs ± 1%     230µs ± 1%   -2.98%  (p=0.000 n=10+10)
MVCCScan_RocksDB/rows=1000/versions=1/valueSize=512-8      371µs ± 1%     354µs ± 1%   -4.59%  (p=0.000 n=9+10)
MVCCScan_RocksDB/rows=10000/versions=1/valueSize=8-8      2.12ms ± 1%    2.07ms ± 1%   -2.42%  (p=0.000 n=9+10)
MVCCScan_RocksDB/rows=10000/versions=1/valueSize=64-8     2.24ms ± 1%    2.18ms ± 1%   -2.65%  (p=0.000 n=10+10)
MVCCScan_RocksDB/rows=10000/versions=1/valueSize=512-8    3.69ms ± 1%    3.35ms ± 2%   -9.35%  (p=0.000 n=9+10)
```

Release note: None