### PR TITLE
sql: be safer about swapping out IVarHelpers

### DIFF
--- a/pkg/sql/check.go
+++ b/pkg/sql/check.go
@@ -119,8 +119,8 @@ func (c *checkHelper) IndexedVarNodeFormatter(idx int) tree.NodeFormatter {
 }
 
 func (c *checkHelper) check(ctx *tree.EvalContext) error {
-	ctx.IVarHelper = c.ivarHelper
-	defer func() { ctx.IVarHelper = nil }()
+	ctx.PushIVarHelper(c.ivarHelper)
+	defer func() { ctx.PopIVarHelper() }()
 	for _, expr := range c.exprs {
 		if d, err := expr.Eval(ctx); err != nil {
 			return err

--- a/pkg/sql/distsqlrun/expr.go
+++ b/pkg/sql/distsqlrun/expr.go
@@ -150,9 +150,9 @@ func (eh *exprHelper) init(
 // returns whether the filter passes.
 func (eh *exprHelper) evalFilter(row sqlbase.EncDatumRow) (bool, error) {
 	eh.row = row
-	eh.evalCtx.IVarHelper = &eh.vars
+	eh.evalCtx.PushIVarHelper(&eh.vars)
 	pass, err := sqlbase.RunFilter(eh.expr, eh.evalCtx)
-	eh.evalCtx.IVarHelper = nil
+	eh.evalCtx.PopIVarHelper()
 	return pass, err
 }
 
@@ -165,8 +165,8 @@ func (eh *exprHelper) evalFilter(row sqlbase.EncDatumRow) (bool, error) {
 func (eh *exprHelper) eval(row sqlbase.EncDatumRow) (tree.Datum, error) {
 	eh.row = row
 
-	eh.evalCtx.IVarHelper = &eh.vars
+	eh.evalCtx.PushIVarHelper(&eh.vars)
 	d, err := eh.expr.Eval(eh.evalCtx)
-	eh.evalCtx.IVarHelper = nil
+	eh.evalCtx.PopIVarHelper()
 	return d, err
 }

--- a/pkg/sql/filter.go
+++ b/pkg/sql/filter.go
@@ -57,9 +57,9 @@ func (f *filterNode) Next(params runParams) (bool, error) {
 			return false, err
 		}
 
-		params.extendedEvalCtx.IVarHelper = &f.ivarHelper
+		params.extendedEvalCtx.PushIVarHelper(&f.ivarHelper)
 		passesFilter, err := sqlbase.RunFilter(f.filter, params.EvalContext())
-		params.extendedEvalCtx.IVarHelper = nil
+		params.extendedEvalCtx.PopIVarHelper()
 		if err != nil {
 			return false, err
 		}

--- a/pkg/sql/join_predicate.go
+++ b/pkg/sql/join_predicate.go
@@ -318,9 +318,9 @@ func (p *joinPredicate) eval(
 		p.curRow = result
 		copy(p.curRow[:len(leftRow)], leftRow)
 		copy(p.curRow[len(leftRow):], rightRow)
-		ctx.IVarHelper = &p.iVarHelper
+		ctx.PushIVarHelper(&p.iVarHelper)
 		pred, err := sqlbase.RunFilter(p.onCond, ctx)
-		ctx.IVarHelper = nil
+		ctx.PopIVarHelper()
 		return pred, err
 	}
 	return true, nil

--- a/pkg/sql/logictest/testdata/logic_test/regclass22249
+++ b/pkg/sql/logictest/testdata/logic_test/regclass22249
@@ -1,0 +1,18 @@
+# LogicTest: default parallel-stmts
+
+# This still fails in DistSQL, #22264.
+
+statement ok
+CREATE TABLE d (id INT PRIMARY KEY, str STRING);
+
+statement ok
+CREATE TABLE e (id INT PRIMARY KEY, did INT REFERENCES d (id), str STRING);
+
+statement ok
+INSERT INTO d VALUES (4, 'd');
+
+statement ok
+INSERT INTO e VALUES (5, 4, 'd');
+
+statement ok
+SELECT e.str FROM e INNER JOIN d on (e.str::REGCLASS = d.str::REGCLASS);

--- a/pkg/sql/upsert.go
+++ b/pkg/sql/upsert.go
@@ -177,8 +177,8 @@ func (uh *upsertHelper) eval(insertRow tree.Datums, existingRow tree.Datums) (tr
 
 	var err error
 	ret := make([]tree.Datum, len(uh.evalExprs))
-	uh.p.extendedEvalCtx.IVarHelper = uh.ivarHelper
-	defer func() { uh.p.extendedEvalCtx.IVarHelper = nil }()
+	uh.p.extendedEvalCtx.PushIVarHelper(uh.ivarHelper)
+	defer func() { uh.p.extendedEvalCtx.PopIVarHelper() }()
 	for i, evalExpr := range uh.evalExprs {
 		ret[i], err = evalExpr.Eval(uh.p.EvalContext())
 		if err != nil {
@@ -194,8 +194,8 @@ func (uh *upsertHelper) shouldUpdate(insertRow tree.Datums, existingRow tree.Dat
 	uh.curSourceRow = existingRow
 	uh.curExcludedRow = insertRow
 
-	uh.p.extendedEvalCtx.IVarHelper = uh.ivarHelper
-	defer func() { uh.p.extendedEvalCtx.IVarHelper = nil }()
+	uh.p.extendedEvalCtx.PushIVarHelper(uh.ivarHelper)
+	defer func() { uh.p.extendedEvalCtx.PopIVarHelper() }()
 	return sqlbase.RunFilter(uh.whereExpr, uh.p.EvalContext())
 }
 

--- a/pkg/sql/window.go
+++ b/pkg/sql/window.go
@@ -783,9 +783,9 @@ func (n *windowNode) populateValues(ctx context.Context, evalCtx *tree.EvalConte
 				}
 				// Instead, we evaluate the current window render, which depends on at least
 				// one window function, at the given row.
-				evalCtx.IVarHelper = n.ivarHelper
+				evalCtx.PushIVarHelper(n.ivarHelper)
 				res, err := curWindowRender.Eval(evalCtx)
-				evalCtx.IVarHelper = nil
+				evalCtx.PopIVarHelper()
 				if err != nil {
 					return err
 				}


### PR DESCRIPTION
Fixes #22249.

This fix is admittedly somewhat ad-hoc, though I argue that it is
strictly less ad-hoc than the system we had before! The provided logic
test would panic because there was a place in the code where we were not
appropriately resetting an IVarHelper after swapping it out, leaving an
EvalContext with a nil IVarHelper.

I think this swapping out of IVarHelpers is something that has evolved
organically and has never been a particularly principled thing for us to
do. We should at some point figure out what it means for us to evaluate
a new expression with different indexed var bindings with the same
"context".

Release note (bug fix): Fix a panic with certain queries involving
REGCLASS