### PR TITLE
sql: support arbitrary functions in FROM clauses

### DIFF
--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -1636,7 +1636,8 @@ distinct_on_clause ::=
 
 table_ref ::=
 	relation_expr opt_index_hints opt_ordinality opt_alias_clause
-	| qualified_name '(' opt_expr_list ')' opt_ordinality opt_alias_clause
+	| func_name '(' opt_expr_list ')' opt_ordinality opt_alias_clause
+	| special_function opt_ordinality opt_alias_clause
 	| select_with_parens opt_ordinality opt_alias_clause
 	| joined_table
 	| '(' joined_table ')' opt_ordinality alias_clause
@@ -1732,32 +1733,18 @@ over_clause ::=
 
 func_expr_common_subexpr ::=
 	'CURRENT_DATE'
-	| 'CURRENT_DATE' '(' ')'
 	| 'CURRENT_SCHEMA'
-	| 'CURRENT_SCHEMA' '(' ')'
 	| 'CURRENT_TIMESTAMP'
-	| 'CURRENT_TIMESTAMP' '(' ')'
 	| 'CURRENT_USER'
-	| 'CURRENT_USER' '(' ')'
 	| 'SESSION_USER'
 	| 'USER'
 	| 'CAST' '(' a_expr 'AS' cast_target ')'
 	| 'ANNOTATE_TYPE' '(' a_expr ',' typename ')'
-	| 'EXTRACT' '(' extract_list ')'
-	| 'EXTRACT_DURATION' '(' extract_list ')'
-	| 'OVERLAY' '(' overlay_list ')'
-	| 'POSITION' '(' position_list ')'
-	| 'SUBSTRING' '(' substr_list ')'
-	| 'TRIM' '(' 'BOTH' trim_list ')'
-	| 'TRIM' '(' 'LEADING' trim_list ')'
-	| 'TRIM' '(' 'TRAILING' trim_list ')'
-	| 'TRIM' '(' trim_list ')'
 	| 'IF' '(' a_expr ',' a_expr ',' a_expr ')'
 	| 'NULLIF' '(' a_expr ',' a_expr ')'
 	| 'IFNULL' '(' a_expr ',' a_expr ')'
 	| 'COALESCE' '(' expr_list ')'
-	| 'GREATEST' '(' expr_list ')'
-	| 'LEAST' '(' expr_list ')'
+	| special_function
 
 opt_expr_list ::=
 	expr_list
@@ -1816,6 +1803,27 @@ opt_ordinality ::=
 opt_alias_clause ::=
 	alias_clause
 	| 
+
+func_name ::=
+	type_function_name
+	| name qname_indirection
+
+special_function ::=
+	'CURRENT_DATE' '(' ')'
+	| 'CURRENT_SCHEMA' '(' ')'
+	| 'CURRENT_TIMESTAMP' '(' ')'
+	| 'CURRENT_USER' '(' ')'
+	| 'EXTRACT' '(' extract_list ')'
+	| 'EXTRACT_DURATION' '(' extract_list ')'
+	| 'OVERLAY' '(' overlay_list ')'
+	| 'POSITION' '(' position_list ')'
+	| 'SUBSTRING' '(' substr_list ')'
+	| 'TRIM' '(' 'BOTH' trim_list ')'
+	| 'TRIM' '(' 'LEADING' trim_list ')'
+	| 'TRIM' '(' 'TRAILING' trim_list ')'
+	| 'TRIM' '(' trim_list ')'
+	| 'GREATEST' '(' expr_list ')'
+	| 'LEAST' '(' expr_list ')'
 
 joined_table ::=
 	'(' joined_table ')'
@@ -1876,12 +1884,29 @@ reference_on_update ::=
 reference_on_delete ::=
 	'ON' 'DELETE' reference_action
 
-func_name ::=
-	type_function_name
-	| name qname_indirection
-
 window_specification ::=
 	'(' opt_existing_window_name opt_partition_clause opt_sort_clause ')'
+
+opt_varying ::=
+	'VARYING'
+	| 
+
+character_base ::=
+	'CHARACTER' opt_varying
+	| 'CHAR' opt_varying
+	| 'VARCHAR'
+	| 'STRING'
+
+window_definition ::=
+	name 'AS' window_specification
+
+index_hints_param_list ::=
+	( index_hints_param ) ( ( ',' index_hints_param ) )*
+
+type_function_name ::=
+	'identifier'
+	| unreserved_keyword
+	| type_func_name_keyword
 
 extract_list ::=
 	extract_arg 'FROM' a_expr
@@ -1908,22 +1933,6 @@ trim_list ::=
 	| 'FROM' expr_list
 	| expr_list
 
-opt_varying ::=
-	'VARYING'
-	| 
-
-character_base ::=
-	'CHARACTER' opt_varying
-	| 'CHAR' opt_varying
-	| 'VARCHAR'
-	| 'STRING'
-
-window_definition ::=
-	name 'AS' window_specification
-
-index_hints_param_list ::=
-	( index_hints_param ) ( ( ',' index_hints_param ) )*
-
 join_type ::=
 	'FULL' join_outer
 	| 'LEFT' join_outer
@@ -1948,11 +1957,6 @@ reference_action ::=
 	| 'SET' 'NULL'
 	| 'SET' 'DEFAULT'
 
-type_function_name ::=
-	'identifier'
-	| unreserved_keyword
-	| type_func_name_keyword
-
 opt_existing_window_name ::=
 	name
 	| 
@@ -1960,6 +1964,10 @@ opt_existing_window_name ::=
 opt_partition_clause ::=
 	'PARTITION' 'BY' expr_list
 	| 
+
+index_hints_param ::=
+	'FORCE_INDEX' '=' unrestricted_name
+	| 'NO_INDEX_JOIN'
 
 extract_arg ::=
 	'identifier'
@@ -1978,10 +1986,6 @@ substr_from ::=
 
 substr_for ::=
 	'FOR' a_expr
-
-index_hints_param ::=
-	'FORCE_INDEX' '=' unrestricted_name
-	| 'NO_INDEX_JOIN'
 
 join_outer ::=
 	'OUTER'

--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -379,8 +379,8 @@ func (dsp *DistSQLPlanner) checkSupportForNode(node planNode) (distRecommendatio
 		return 0, newQueryNotSupportedErrorf("unsupported node %T", node)
 
 	case *valuesNode:
-		if n.n == nil {
-			return 0, newQueryNotSupportedErrorf("unsupported node %T without SQL VALUES clause", node)
+		if !n.specifiedInQuery {
+			return 0, newQueryNotSupportedErrorf("unsupported node %T", node)
 		}
 
 		for _, tuple := range n.tuples {

--- a/pkg/sql/logictest/testdata/logic_test/generators
+++ b/pkg/sql/logictest/testdata/logic_test/generators
@@ -307,3 +307,9 @@ SELECT * FROM upper('abc')
 ----
 upper
 ABC
+
+query TI colnames
+SELECT * FROM current_schema() WITH ORDINALITY AS a(b)
+----
+b    ordinality
+test 1

--- a/pkg/sql/logictest/testdata/logic_test/generators
+++ b/pkg/sql/logictest/testdata/logic_test/generators
@@ -300,3 +300,10 @@ SELECT 'a', crdb_internal.unary_table() b, 'c' LIMIT 1
 ----
 'a'  b   'c'
 a    ()  c
+
+# Regular scalar functions can be used as functions too. #22312
+query T colnames
+SELECT * FROM upper('abc')
+----
+upper
+ABC


### PR DESCRIPTION
Fixes #22312.

The following is valid in pg's SQL dialect:

```
> SELECT * FROM cos(123)
```

i.e. any scalar function is a valid data source.

This patch implements this in CockroachDB for compatibility.
This is needed e.g. by TypeORM.

Release note (sql change): scalar functions can now be used
in FROM clauses.