### PR TITLE
opt: Infer types for opt scalar expressions.

### DIFF
--- a/pkg/sql/opt/build/builder.go
+++ b/pkg/sql/opt/build/builder.go
@@ -47,8 +47,8 @@ var comparisonOpMap = [...]binaryFactoryFunc{
 	tree.NotRegMatch:       (opt.Factory).ConstructNotRegMatch,
 	tree.RegIMatch:         (opt.Factory).ConstructRegIMatch,
 	tree.NotRegIMatch:      (opt.Factory).ConstructNotRegIMatch,
-	tree.IsDistinctFrom:    (opt.Factory).ConstructIsDistinctFrom,
-	tree.IsNotDistinctFrom: (opt.Factory).ConstructIsNotDistinctFrom,
+	tree.IsDistinctFrom:    (opt.Factory).ConstructIsNot,
+	tree.IsNotDistinctFrom: (opt.Factory).ConstructIs,
 	tree.Any:               (opt.Factory).ConstructAny,
 	tree.Some:              (opt.Factory).ConstructSome,
 	tree.All:               (opt.Factory).ConstructAll,
@@ -619,7 +619,7 @@ func (b *Builder) synthesizeColumn(scope *scope, label string, typ types.T) *col
 		label = fmt.Sprintf("column%d", len(scope.cols)+1)
 	}
 
-	colIndex := b.factory.Metadata().AddColumn(label)
+	colIndex := b.factory.Metadata().AddColumn(label, typ)
 	col := columnProps{typ: typ, index: colIndex}
 	b.colMap = append(b.colMap, col)
 	scope.cols = append(scope.cols, col)

--- a/pkg/sql/opt/build/testdata/build-inner-join
+++ b/pkg/sql/opt/build/testdata/build-inner-join
@@ -18,72 +18,72 @@ build
 SELECT * FROM t.a, t.b
 ----
 project
- ├── columns: a.x:1 a.y:null:2 b.x:null:3 b.y:null:4
+ ├── columns: a.x:int:1 a.y:float:null:2 b.x:int:null:3 b.y:float:null:4
  ├── inner-join
- │    ├── columns: a.x:1 a.y:null:2 b.x:null:3 b.y:null:4 b.rowid:5
+ │    ├── columns: a.x:int:1 a.y:float:null:2 b.x:int:null:3 b.y:float:null:4 b.rowid:int:5
  │    ├── scan
- │    │    └── columns: a.x:1 a.y:null:2
+ │    │    └── columns: a.x:int:1 a.y:float:null:2
  │    ├── scan
- │    │    └── columns: b.x:null:3 b.y:null:4 b.rowid:5
- │    └── true
- └── projections
-      ├── variable: a.x
-      ├── variable: a.y
-      ├── variable: b.x
-      └── variable: b.y
+ │    │    └── columns: b.x:int:null:3 b.y:float:null:4 b.rowid:int:5
+ │    └── true [type=bool]
+ └── projections [type=tuple{int, float, int, float}]
+      ├── variable: a.x [type=int]
+      ├── variable: a.y [type=float]
+      ├── variable: b.x [type=int]
+      └── variable: b.y [type=float]
 
 build
 SELECT a.x, b.y FROM t.a, t.b WHERE a.x = b.x
 ----
 project
- ├── columns: a.x:1 b.y:null:4
+ ├── columns: a.x:int:1 b.y:float:null:4
  ├── select
- │    ├── columns: a.x:1 a.y:null:2 b.x:null:3 b.y:null:4 b.rowid:5
+ │    ├── columns: a.x:int:1 a.y:float:null:2 b.x:int:null:3 b.y:float:null:4 b.rowid:int:5
  │    ├── inner-join
- │    │    ├── columns: a.x:1 a.y:null:2 b.x:null:3 b.y:null:4 b.rowid:5
+ │    │    ├── columns: a.x:int:1 a.y:float:null:2 b.x:int:null:3 b.y:float:null:4 b.rowid:int:5
  │    │    ├── scan
- │    │    │    └── columns: a.x:1 a.y:null:2
+ │    │    │    └── columns: a.x:int:1 a.y:float:null:2
  │    │    ├── scan
- │    │    │    └── columns: b.x:null:3 b.y:null:4 b.rowid:5
- │    │    └── true
- │    └── eq
- │         ├── variable: a.x
- │         └── variable: b.x
- └── projections
-      ├── variable: a.x
-      └── variable: b.y
+ │    │    │    └── columns: b.x:int:null:3 b.y:float:null:4 b.rowid:int:5
+ │    │    └── true [type=bool]
+ │    └── eq [type=bool]
+ │         ├── variable: a.x [type=int]
+ │         └── variable: b.x [type=int]
+ └── projections [type=tuple{int, float}]
+      ├── variable: a.x [type=int]
+      └── variable: b.y [type=float]
 
 build
 SELECT * FROM t.c, t.b, t.a WHERE c.x = a.x AND b.x = a.x
 ----
 project
- ├── columns: c.x:null:1 c.y:null:2 c.z:null:3 b.x:null:5 b.y:null:6 a.x:8 a.y:null:9
+ ├── columns: c.x:int:null:1 c.y:float:null:2 c.z:string:null:3 b.x:int:null:5 b.y:float:null:6 a.x:int:8 a.y:float:null:9
  ├── select
- │    ├── columns: c.x:null:1 c.y:null:2 c.z:null:3 c.rowid:4 b.x:null:5 b.y:null:6 b.rowid:7 a.x:8 a.y:null:9
+ │    ├── columns: c.x:int:null:1 c.y:float:null:2 c.z:string:null:3 c.rowid:int:4 b.x:int:null:5 b.y:float:null:6 b.rowid:int:7 a.x:int:8 a.y:float:null:9
  │    ├── inner-join
- │    │    ├── columns: c.x:null:1 c.y:null:2 c.z:null:3 c.rowid:4 b.x:null:5 b.y:null:6 b.rowid:7 a.x:8 a.y:null:9
+ │    │    ├── columns: c.x:int:null:1 c.y:float:null:2 c.z:string:null:3 c.rowid:int:4 b.x:int:null:5 b.y:float:null:6 b.rowid:int:7 a.x:int:8 a.y:float:null:9
  │    │    ├── inner-join
- │    │    │    ├── columns: c.x:null:1 c.y:null:2 c.z:null:3 c.rowid:4 b.x:null:5 b.y:null:6 b.rowid:7
+ │    │    │    ├── columns: c.x:int:null:1 c.y:float:null:2 c.z:string:null:3 c.rowid:int:4 b.x:int:null:5 b.y:float:null:6 b.rowid:int:7
  │    │    │    ├── scan
- │    │    │    │    └── columns: c.x:null:1 c.y:null:2 c.z:null:3 c.rowid:4
+ │    │    │    │    └── columns: c.x:int:null:1 c.y:float:null:2 c.z:string:null:3 c.rowid:int:4
  │    │    │    ├── scan
- │    │    │    │    └── columns: b.x:null:5 b.y:null:6 b.rowid:7
- │    │    │    └── true
+ │    │    │    │    └── columns: b.x:int:null:5 b.y:float:null:6 b.rowid:int:7
+ │    │    │    └── true [type=bool]
  │    │    ├── scan
- │    │    │    └── columns: a.x:8 a.y:null:9
- │    │    └── true
- │    └── and
- │         ├── eq
- │         │    ├── variable: c.x
- │         │    └── variable: a.x
- │         └── eq
- │              ├── variable: b.x
- │              └── variable: a.x
- └── projections
-      ├── variable: c.x
-      ├── variable: c.y
-      ├── variable: c.z
-      ├── variable: b.x
-      ├── variable: b.y
-      ├── variable: a.x
-      └── variable: a.y
+ │    │    │    └── columns: a.x:int:8 a.y:float:null:9
+ │    │    └── true [type=bool]
+ │    └── and [type=bool]
+ │         ├── eq [type=bool]
+ │         │    ├── variable: c.x [type=int]
+ │         │    └── variable: a.x [type=int]
+ │         └── eq [type=bool]
+ │              ├── variable: b.x [type=int]
+ │              └── variable: a.x [type=int]
+ └── projections [type=tuple{int, float, string, int, float, int, float}]
+      ├── variable: c.x [type=int]
+      ├── variable: c.y [type=float]
+      ├── variable: c.z [type=string]
+      ├── variable: b.x [type=int]
+      ├── variable: b.y [type=float]
+      ├── variable: a.x [type=int]
+      └── variable: a.y [type=float]

--- a/pkg/sql/opt/build/testdata/build-project
+++ b/pkg/sql/opt/build/testdata/build-project
@@ -14,44 +14,44 @@ build
 SELECT 5
 ----
 project
- ├── columns: column1:null:1
+ ├── columns: column1:int:null:1
  ├── values
- │    └── tuple
- └── projections
-      └── const: 5
+ │    └── tuple [type=tuple{}]
+ └── projections [type=tuple{int}]
+      └── const: 5 [type=int]
 
 build
 SELECT a.x FROM t.a
 ----
 project
- ├── columns: a.x:1
+ ├── columns: a.x:int:1
  ├── scan
- │    └── columns: a.x:1 a.y:null:2
- └── projections
-      └── variable: a.x
+ │    └── columns: a.x:int:1 a.y:float:null:2
+ └── projections [type=tuple{int}]
+      └── variable: a.x [type=int]
 
 build
 SELECT a.x, a.y FROM t.a
 ----
 scan
- └── columns: a.x:1 a.y:null:2
+ └── columns: a.x:int:1 a.y:float:null:2
 
 build
 SELECT a.y, a.x FROM t.a
 ----
 project
- ├── columns: a.x:1 a.y:null:2
+ ├── columns: a.x:int:1 a.y:float:null:2
  ├── scan
- │    └── columns: a.x:1 a.y:null:2
- └── projections
-      ├── variable: a.y
-      └── variable: a.x
+ │    └── columns: a.x:int:1 a.y:float:null:2
+ └── projections [type=tuple{float, int}]
+      ├── variable: a.y [type=float]
+      └── variable: a.x [type=int]
 
 build
 SELECT * FROM t.a
 ----
 scan
- └── columns: a.x:1 a.y:null:2
+ └── columns: a.x:int:1 a.y:float:null:2
 
 # Note that an explicit projection operator is added for table b (unlike for
 # table a) to avoid projecting the hidden rowid column.
@@ -59,52 +59,52 @@ build
 SELECT * FROM t.b
 ----
 project
- ├── columns: b.x:null:1 b.y:null:2
+ ├── columns: b.x:int:null:1 b.y:float:null:2
  ├── scan
- │    └── columns: b.x:null:1 b.y:null:2 b.rowid:3
- └── projections
-      ├── variable: b.x
-      └── variable: b.y
+ │    └── columns: b.x:int:null:1 b.y:float:null:2 b.rowid:int:3
+ └── projections [type=tuple{int, float}]
+      ├── variable: b.x [type=int]
+      └── variable: b.y [type=float]
 
 build
 SELECT (a.x + 3) AS "X", false AS "Y" FROM t.a
 ----
 project
- ├── columns: X:null:3 Y:null:4
+ ├── columns: X:int:null:3 Y:bool:null:4
  ├── scan
- │    └── columns: a.x:1 a.y:null:2
- └── projections
-      ├── plus
-      │    ├── variable: a.x
-      │    └── const: 3
-      └── const: false
+ │    └── columns: a.x:int:1 a.y:float:null:2
+ └── projections [type=tuple{int, bool}]
+      ├── plus [type=int]
+      │    ├── variable: a.x [type=int]
+      │    └── const: 3 [type=int]
+      └── const: false [type=bool]
 
 build
 SELECT *, ((x < y) OR x > 1000) FROM t.a
 ----
 project
- ├── columns: a.x:1 a.y:null:2 column3:null:3
+ ├── columns: a.x:int:1 a.y:float:null:2 column3:bool:null:3
  ├── scan
- │    └── columns: a.x:1 a.y:null:2
- └── projections
-      ├── variable: a.x
-      ├── variable: a.y
-      └── or
-           ├── lt
-           │    ├── variable: a.x
-           │    └── variable: a.y
-           └── gt
-                ├── variable: a.x
-                └── const: 1000
+ │    └── columns: a.x:int:1 a.y:float:null:2
+ └── projections [type=tuple{int, float, bool}]
+      ├── variable: a.x [type=int]
+      ├── variable: a.y [type=float]
+      └── or [type=bool]
+           ├── lt [type=bool]
+           │    ├── variable: a.x [type=int]
+           │    └── variable: a.y [type=float]
+           └── gt [type=bool]
+                ├── variable: a.x [type=int]
+                └── const: 1000 [type=int]
 
 build
 SELECT a.*, true FROM t.a
 ----
 project
- ├── columns: a.x:1 a.y:null:2 column3:null:3
+ ├── columns: a.x:int:1 a.y:float:null:2 column3:bool:null:3
  ├── scan
- │    └── columns: a.x:1 a.y:null:2
- └── projections
-      ├── variable: a.x
-      ├── variable: a.y
-      └── const: true
+ │    └── columns: a.x:int:1 a.y:float:null:2
+ └── projections [type=tuple{int, float, bool}]
+      ├── variable: a.x [type=int]
+      ├── variable: a.y [type=float]
+      └── const: true [type=bool]

--- a/pkg/sql/opt/build/testdata/build-scalar
+++ b/pkg/sql/opt/build/testdata/build-scalar
@@ -1,194 +1,194 @@
 build-scalar
 1
 ----
-const: 1
+const: 1 [type=int]
 
 build-scalar
 1 + 2
 ----
-plus
- ├── const: 1
- └── const: 2
+plus [type=int]
+ ├── const: 1 [type=int]
+ └── const: 2 [type=int]
 
 build-scalar vars=(string)
 @1
 ----
-variable: @1
+variable: @1 [type=string]
 
 build-scalar vars=(int)
 @1 + 2
 ----
-plus
- ├── variable: @1
- └── const: 2
+plus [type=int]
+ ├── variable: @1 [type=int]
+ └── const: 2 [type=int]
 
 build-scalar vars=(int, int)
 @1 >= 5 AND @1 <= 10 AND @2 < 4
 ----
-and
- ├── and
- │    ├── ge
- │    │    ├── variable: @1
- │    │    └── const: 5
- │    └── le
- │         ├── variable: @1
- │         └── const: 10
- └── lt
-      ├── variable: @2
-      └── const: 4
+and [type=bool]
+ ├── and [type=bool]
+ │    ├── ge [type=bool]
+ │    │    ├── variable: @1 [type=int]
+ │    │    └── const: 5 [type=int]
+ │    └── le [type=bool]
+ │         ├── variable: @1 [type=int]
+ │         └── const: 10 [type=int]
+ └── lt [type=bool]
+      ├── variable: @2 [type=int]
+      └── const: 4 [type=int]
 
 build-scalar vars=(int, int)
 (@1, @2) = (1, 2)
 ----
-eq
- ├── tuple
- │    ├── variable: @1
- │    └── variable: @2
- └── tuple
-      ├── const: 1
-      └── const: 2
+eq [type=bool]
+ ├── tuple [type=tuple{int, int}]
+ │    ├── variable: @1 [type=int]
+ │    └── variable: @2 [type=int]
+ └── tuple [type=tuple{int, int}]
+      ├── const: 1 [type=int]
+      └── const: 2 [type=int]
 
 build-scalar vars=(int)
 @1 IN (1, 2)
 ----
-in
- ├── variable: @1
- └── tuple
-      ├── const: 1
-      └── const: 2
+in [type=bool]
+ ├── variable: @1 [type=int]
+ └── tuple [type=tuple{int, int}]
+      ├── const: 1 [type=int]
+      └── const: 2 [type=int]
 
 build-scalar vars=(int, int)
 (@1, @2) IN ((1, 2), (3, 4))
 ----
-in
- ├── tuple
- │    ├── variable: @1
- │    └── variable: @2
- └── tuple
-      ├── tuple
-      │    ├── const: 1
-      │    └── const: 2
-      └── tuple
-           ├── const: 3
-           └── const: 4
+in [type=bool]
+ ├── tuple [type=tuple{int, int}]
+ │    ├── variable: @1 [type=int]
+ │    └── variable: @2 [type=int]
+ └── tuple [type=tuple{tuple{int, int}, tuple{int, int}}]
+      ├── tuple [type=tuple{int, int}]
+      │    ├── const: 1 [type=int]
+      │    └── const: 2 [type=int]
+      └── tuple [type=tuple{int, int}]
+           ├── const: 3 [type=int]
+           └── const: 4 [type=int]
 
 build-scalar vars=(int, int, int, int)
 (@1, @2 + @3, 5 + @4 * 2) = (@2 + @3, 8, @1 - @4)
 ----
-eq
- ├── tuple
- │    ├── variable: @1
- │    ├── plus
- │    │    ├── variable: @2
- │    │    └── variable: @3
- │    └── plus
- │         ├── const: 5
- │         └── mult
- │              ├── variable: @4
- │              └── const: 2
- └── tuple
-      ├── plus
-      │    ├── variable: @2
-      │    └── variable: @3
-      ├── const: 8
-      └── minus
-           ├── variable: @1
-           └── variable: @4
+eq [type=bool]
+ ├── tuple [type=tuple{int, int, int}]
+ │    ├── variable: @1 [type=int]
+ │    ├── plus [type=int]
+ │    │    ├── variable: @2 [type=int]
+ │    │    └── variable: @3 [type=int]
+ │    └── plus [type=int]
+ │         ├── const: 5 [type=int]
+ │         └── mult [type=int]
+ │              ├── variable: @4 [type=int]
+ │              └── const: 2 [type=int]
+ └── tuple [type=tuple{int, int, int}]
+      ├── plus [type=int]
+      │    ├── variable: @2 [type=int]
+      │    └── variable: @3 [type=int]
+      ├── const: 8 [type=int]
+      └── minus [type=int]
+           ├── variable: @1 [type=int]
+           └── variable: @4 [type=int]
 
 build-scalar vars=(int, int, int, int)
 ((@1, @2), (@3, @4)) = ((1, 2), (3, 4))
 ----
-eq
- ├── tuple
- │    ├── tuple
- │    │    ├── variable: @1
- │    │    └── variable: @2
- │    └── tuple
- │         ├── variable: @3
- │         └── variable: @4
- └── tuple
-      ├── tuple
-      │    ├── const: 1
-      │    └── const: 2
-      └── tuple
-           ├── const: 3
-           └── const: 4
+eq [type=bool]
+ ├── tuple [type=tuple{tuple{int, int}, tuple{int, int}}]
+ │    ├── tuple [type=tuple{int, int}]
+ │    │    ├── variable: @1 [type=int]
+ │    │    └── variable: @2 [type=int]
+ │    └── tuple [type=tuple{int, int}]
+ │         ├── variable: @3 [type=int]
+ │         └── variable: @4 [type=int]
+ └── tuple [type=tuple{tuple{int, int}, tuple{int, int}}]
+      ├── tuple [type=tuple{int, int}]
+      │    ├── const: 1 [type=int]
+      │    └── const: 2 [type=int]
+      └── tuple [type=tuple{int, int}]
+           ├── const: 3 [type=int]
+           └── const: 4 [type=int]
 
 build-scalar vars=(int, int, int, string)
 (@1, (@2, 'a'), (@3, 'b', 5)) = (9, (@1 + @3, @4), (5, @4, @1))
 ----
-eq
- ├── tuple
- │    ├── variable: @1
- │    ├── tuple
- │    │    ├── variable: @2
- │    │    └── const: 'a'
- │    └── tuple
- │         ├── variable: @3
- │         ├── const: 'b'
- │         └── const: 5
- └── tuple
-      ├── const: 9
-      ├── tuple
-      │    ├── plus
-      │    │    ├── variable: @1
-      │    │    └── variable: @3
-      │    └── variable: @4
-      └── tuple
-           ├── const: 5
-           ├── variable: @4
-           └── variable: @1
+eq [type=bool]
+ ├── tuple [type=tuple{int, tuple{int, string}, tuple{int, string, int}}]
+ │    ├── variable: @1 [type=int]
+ │    ├── tuple [type=tuple{int, string}]
+ │    │    ├── variable: @2 [type=int]
+ │    │    └── const: 'a' [type=string]
+ │    └── tuple [type=tuple{int, string, int}]
+ │         ├── variable: @3 [type=int]
+ │         ├── const: 'b' [type=string]
+ │         └── const: 5 [type=int]
+ └── tuple [type=tuple{int, tuple{int, string}, tuple{int, string, int}}]
+      ├── const: 9 [type=int]
+      ├── tuple [type=tuple{int, string}]
+      │    ├── plus [type=int]
+      │    │    ├── variable: @1 [type=int]
+      │    │    └── variable: @3 [type=int]
+      │    └── variable: @4 [type=string]
+      └── tuple [type=tuple{int, string, int}]
+           ├── const: 5 [type=int]
+           ├── variable: @4 [type=string]
+           └── variable: @1 [type=int]
 
 build-scalar vars=(int, int)
 @1 IS NULL
 ----
-is-not-distinct-from
- ├── variable: @1
- └── const: NULL
+is [type=bool]
+ ├── variable: @1 [type=int]
+ └── const: NULL [type=NULL]
 
 build-scalar vars=(int, int)
 @1 IS NOT DISTINCT FROM NULL
 ----
-is-not-distinct-from
- ├── variable: @1
- └── const: NULL
+is [type=bool]
+ ├── variable: @1 [type=int]
+ └── const: NULL [type=NULL]
 
 build-scalar vars=(int, int)
 @1 IS NOT DISTINCT FROM @2
 ----
-is-not-distinct-from
- ├── variable: @1
- └── variable: @2
+is [type=bool]
+ ├── variable: @1 [type=int]
+ └── variable: @2 [type=int]
 
 build-scalar vars=(int, int)
 @1 IS NOT NULL
 ----
-is-distinct-from
- ├── variable: @1
- └── const: NULL
+is-not [type=bool]
+ ├── variable: @1 [type=int]
+ └── const: NULL [type=NULL]
 
 build-scalar vars=(int, int)
 @1 IS DISTINCT FROM NULL
 ----
-is-distinct-from
- ├── variable: @1
- └── const: NULL
+is-not [type=bool]
+ ├── variable: @1 [type=int]
+ └── const: NULL [type=NULL]
 
 build-scalar vars=(int, int)
 @1 IS DISTINCT FROM @2
 ----
-is-distinct-from
- ├── variable: @1
- └── variable: @2
+is-not [type=bool]
+ ├── variable: @1 [type=int]
+ └── variable: @2 [type=int]
 
 build-scalar vars=(int, int)
 + @1 + (- @2)
 ----
-plus
- ├── unary-plus
- │    └── variable: @1
- └── unary-minus
-      └── variable: @2
+plus [type=int]
+ ├── unary-plus [type=int]
+ │    └── variable: @1 [type=int]
+ └── unary-minus [type=int]
+      └── variable: @2 [type=int]
 
 build-scalar vars=(int, int)
 CASE WHEN @1 = 2 THEN 1 ELSE 2 END

--- a/pkg/sql/opt/build/testdata/build-select
+++ b/pkg/sql/opt/build/testdata/build-select
@@ -10,7 +10,7 @@ build
 SELECT * FROM t.a
 ----
 scan
- └── columns: a.x:1 a.y:null:2
+ └── columns: a.x:int:1 a.y:float:null:2
 
 build
 SELECT * FROM t.b
@@ -34,48 +34,48 @@ build
 SELECT * FROM t.a WHERE x > 10
 ----
 select
- ├── columns: a.x:1 a.y:null:2
+ ├── columns: a.x:int:1 a.y:float:null:2
  ├── scan
- │    └── columns: a.x:1 a.y:null:2
- └── gt
-      ├── variable: a.x
-      └── const: 10
+ │    └── columns: a.x:int:1 a.y:float:null:2
+ └── gt [type=bool]
+      ├── variable: a.x [type=int]
+      └── const: 10 [type=int]
 
 build
 SELECT * FROM t.a WHERE (x > 10 AND (x < 20 AND x != 13))
 ----
 select
- ├── columns: a.x:1 a.y:null:2
+ ├── columns: a.x:int:1 a.y:float:null:2
  ├── scan
- │    └── columns: a.x:1 a.y:null:2
- └── and
-      ├── gt
-      │    ├── variable: a.x
-      │    └── const: 10
-      └── and
-           ├── lt
-           │    ├── variable: a.x
-           │    └── const: 20
-           └── ne
-                ├── variable: a.x
-                └── const: 13
+ │    └── columns: a.x:int:1 a.y:float:null:2
+ └── and [type=bool]
+      ├── gt [type=bool]
+      │    ├── variable: a.x [type=int]
+      │    └── const: 10 [type=int]
+      └── and [type=bool]
+           ├── lt [type=bool]
+           │    ├── variable: a.x [type=int]
+           │    └── const: 20 [type=int]
+           └── ne [type=bool]
+                ├── variable: a.x [type=int]
+                └── const: 13 [type=int]
 
 build
 SELECT * FROM t.a WHERE x IN (1, 2, 3)
 ----
 select
- ├── columns: a.x:1 a.y:null:2
+ ├── columns: a.x:int:1 a.y:float:null:2
  ├── scan
- │    └── columns: a.x:1 a.y:null:2
- └── in
-      ├── variable: a.x
-      └── tuple
-           ├── const: 1
-           ├── const: 2
-           └── const: 3
+ │    └── columns: a.x:int:1 a.y:float:null:2
+ └── in [type=bool]
+      ├── variable: a.x [type=int]
+      └── tuple [type=tuple{int, int, int}]
+           ├── const: 1 [type=int]
+           ├── const: 2 [type=int]
+           └── const: 3 [type=int]
 
 build
 SELECT * FROM t.a AS A(X, Y)
 ----
 scan
- └── columns: a.x:1 a.y:null:2
+ └── columns: a.x:int:1 a.y:float:null:2

--- a/pkg/sql/opt/ops/scalar.opt
+++ b/pkg/sql/opt/ops/scalar.opt
@@ -51,19 +51,19 @@ define Tuple {
     Elems ExprList
 }
 
-[Scalar]
-define Filters {
-    Conditions ExprList
-}
-
 # Projections is a set of typed scalar expressions that will become output
 # columns for a containing relational expression, such as Project or GroupBy.
 # The private Cols field contains the set of column indexes returned by the
 # expression, as a *ColSet.
 [Scalar]
 define Projections {
-    Items ExprList
+    Elems ExprList
     Cols  ColSet
+}
+
+[Scalar]
+define Filters {
+    Conditions ExprList
 }
 
 [Scalar]
@@ -197,18 +197,6 @@ define NotRegIMatch {
 }
 
 [Scalar]
-define IsDistinctFrom {
-   Left  Expr
-   Right Expr
-}
-
-[Scalar]
-define IsNotDistinctFrom {
-   Left  Expr
-   Right Expr
-}
-
-[Scalar]
 define Is {
    Left  Expr
    Right Expr
@@ -216,6 +204,18 @@ define Is {
 
 [Scalar]
 define IsNot {
+   Left  Expr
+   Right Expr
+}
+
+[Scalar]
+define Contains {
+   Left  Expr
+   Right Expr
+}
+
+[Scalar]
+define ContainedBy {
    Left  Expr
    Right Expr
 }
@@ -314,6 +314,30 @@ define LShift {
 define RShift {
    Left  Expr
    Right Expr
+}
+
+[Scalar]
+define FetchVal {
+   Json  Expr
+   Index Expr
+}
+
+[Scalar]
+define FetchText {
+   Json  Expr
+   Index Expr
+}
+
+[Scalar]
+define FetchValPath {
+   Json Expr
+   Path Expr
+}
+
+[Scalar]
+define FetchTextPath {
+   Json Expr
+   Path Expr
 }
 
 [Scalar]

--- a/pkg/sql/opt/opt/factory.og.go
+++ b/pkg/sql/opt/opt/factory.og.go
@@ -29,8 +29,8 @@ type Factory interface {
 	ConstructFalse() GroupID
 	ConstructPlaceholder(value PrivateID) GroupID
 	ConstructTuple(elems ListID) GroupID
+	ConstructProjections(elems ListID, cols PrivateID) GroupID
 	ConstructFilters(conditions ListID) GroupID
-	ConstructProjections(items ListID, cols PrivateID) GroupID
 	ConstructExists(input GroupID) GroupID
 	ConstructAnd(left GroupID, right GroupID) GroupID
 	ConstructOr(left GroupID, right GroupID) GroupID
@@ -53,10 +53,10 @@ type Factory interface {
 	ConstructNotRegMatch(left GroupID, right GroupID) GroupID
 	ConstructRegIMatch(left GroupID, right GroupID) GroupID
 	ConstructNotRegIMatch(left GroupID, right GroupID) GroupID
-	ConstructIsDistinctFrom(left GroupID, right GroupID) GroupID
-	ConstructIsNotDistinctFrom(left GroupID, right GroupID) GroupID
 	ConstructIs(left GroupID, right GroupID) GroupID
 	ConstructIsNot(left GroupID, right GroupID) GroupID
+	ConstructContains(left GroupID, right GroupID) GroupID
+	ConstructContainedBy(left GroupID, right GroupID) GroupID
 	ConstructAny(left GroupID, right GroupID) GroupID
 	ConstructSome(left GroupID, right GroupID) GroupID
 	ConstructAll(left GroupID, right GroupID) GroupID
@@ -73,6 +73,10 @@ type Factory interface {
 	ConstructConcat(left GroupID, right GroupID) GroupID
 	ConstructLShift(left GroupID, right GroupID) GroupID
 	ConstructRShift(left GroupID, right GroupID) GroupID
+	ConstructFetchVal(json GroupID, index GroupID) GroupID
+	ConstructFetchText(json GroupID, index GroupID) GroupID
+	ConstructFetchValPath(json GroupID, path GroupID) GroupID
+	ConstructFetchTextPath(json GroupID, path GroupID) GroupID
 	ConstructUnaryPlus(input GroupID) GroupID
 	ConstructUnaryMinus(input GroupID) GroupID
 	ConstructUnaryComplement(input GroupID) GroupID

--- a/pkg/sql/opt/opt/metadata_test.go
+++ b/pkg/sql/opt/opt/metadata_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/testutils"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
 )
 
 func TestMetadataColumns(t *testing.T) {
@@ -28,7 +29,7 @@ func TestMetadataColumns(t *testing.T) {
 	}
 
 	// Add standalone column.
-	colIndex := md.AddColumn("alias")
+	colIndex := md.AddColumn("alias", types.Int)
 	if colIndex != 1 {
 		t.Fatalf("unexpected column index: %d", colIndex)
 	}
@@ -38,8 +39,13 @@ func TestMetadataColumns(t *testing.T) {
 		t.Fatalf("unexpected column label: %s", label)
 	}
 
+	typ := md.ColumnType(colIndex)
+	if typ != types.Int {
+		t.Fatalf("unexpected column type: %s", typ)
+	}
+
 	// Add another column.
-	colIndex = md.AddColumn("alias2")
+	colIndex = md.AddColumn("alias2", types.String)
 	if colIndex != 2 {
 		t.Fatalf("unexpected column index: %d", colIndex)
 	}
@@ -47,6 +53,11 @@ func TestMetadataColumns(t *testing.T) {
 	label = md.ColumnLabel(colIndex)
 	if label != "alias2" {
 		t.Fatalf("unexpected column label: %s", label)
+	}
+
+	typ = md.ColumnType(colIndex)
+	if typ != types.String {
+		t.Fatalf("unexpected column type: %s", typ)
 	}
 }
 

--- a/pkg/sql/opt/opt/operator.go
+++ b/pkg/sql/opt/opt/operator.go
@@ -16,6 +16,7 @@ package opt
 
 import (
 	"fmt"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 )
 
 //go:generate optgen -out operator.og.go ops ../ops/scalar.opt ../ops/relational.opt ../ops/enforcer.opt
@@ -32,4 +33,34 @@ func (i Operator) String() string {
 	}
 
 	return opNames[opIndexes[i]:opIndexes[i+1]]
+}
+
+// BinaryOpReverseMap maps from an optimizer operator type to a semantic tree
+// binary operator type.
+var BinaryOpReverseMap = [...]tree.BinaryOperator{
+	BitandOp:        tree.Bitand,
+	BitorOp:         tree.Bitor,
+	BitxorOp:        tree.Bitxor,
+	PlusOp:          tree.Plus,
+	MinusOp:         tree.Minus,
+	MultOp:          tree.Mult,
+	DivOp:           tree.Div,
+	FloorDivOp:      tree.FloorDiv,
+	ModOp:           tree.Mod,
+	PowOp:           tree.Pow,
+	ConcatOp:        tree.Concat,
+	LShiftOp:        tree.LShift,
+	RShiftOp:        tree.RShift,
+	FetchValOp:      tree.FetchVal,
+	FetchTextOp:     tree.FetchText,
+	FetchValPathOp:  tree.FetchValPath,
+	FetchTextPathOp: tree.FetchTextPath,
+}
+
+// UnaryOpReverseMap maps from an optimizer operator type to a semantic tree
+// unary operator type.
+var UnaryOpReverseMap = [...]tree.UnaryOperator{
+	UnaryPlusOp:       tree.UnaryPlus,
+	UnaryMinusOp:      tree.UnaryMinus,
+	UnaryComplementOp: tree.UnaryComplement,
 }

--- a/pkg/sql/opt/opt/operator.og.go
+++ b/pkg/sql/opt/opt/operator.og.go
@@ -13,8 +13,8 @@ const (
 	FalseOp
 	PlaceholderOp
 	TupleOp
-	FiltersOp
 	ProjectionsOp
+	FiltersOp
 	ExistsOp
 	AndOp
 	OrOp
@@ -37,10 +37,10 @@ const (
 	NotRegMatchOp
 	RegIMatchOp
 	NotRegIMatchOp
-	IsDistinctFromOp
-	IsNotDistinctFromOp
 	IsOp
 	IsNotOp
+	ContainsOp
+	ContainedByOp
 	AnyOp
 	SomeOp
 	AllOp
@@ -57,6 +57,10 @@ const (
 	ConcatOp
 	LShiftOp
 	RShiftOp
+	FetchValOp
+	FetchTextOp
+	FetchValPathOp
+	FetchTextPathOp
 	UnaryPlusOp
 	UnaryMinusOp
 	UnaryComplementOp
@@ -92,6 +96,6 @@ const (
 	NumOperators
 )
 
-const opNames = "unknownsubqueryvariableconsttruefalseplaceholdertuplefiltersprojectionsexistsandornoteqltgtlegeneinnot-inlikenot-likei-likenot-i-likesimilar-tonot-similar-toreg-matchnot-reg-matchreg-i-matchnot-reg-i-matchis-distinct-fromis-not-distinct-fromisis-notanysomeallbitandbitorbitxorplusminusmultdivfloor-divmodpowconcatl-shiftr-shiftunary-plusunary-minusunary-complementfunctionscanvaluesselectprojectinner-joinleft-joinright-joinfull-joinsemi-joinanti-joininner-join-applyleft-join-applyright-join-applyfull-join-applysemi-join-applyanti-join-applygroup-byunionintersectexceptsortpresent"
+const opNames = "unknownsubqueryvariableconsttruefalseplaceholdertupleprojectionsfiltersexistsandornoteqltgtlegeneinnot-inlikenot-likei-likenot-i-likesimilar-tonot-similar-toreg-matchnot-reg-matchreg-i-matchnot-reg-i-matchisis-notcontainscontained-byanysomeallbitandbitorbitxorplusminusmultdivfloor-divmodpowconcatl-shiftr-shiftfetch-valfetch-textfetch-val-pathfetch-text-pathunary-plusunary-minusunary-complementfunctionscanvaluesselectprojectinner-joinleft-joinright-joinfull-joinsemi-joinanti-joininner-join-applyleft-join-applyright-join-applyfull-join-applysemi-join-applyanti-join-applygroup-byunionintersectexceptsortpresent"
 
-var opIndexes = [...]uint32{0, 7, 15, 23, 28, 32, 37, 48, 53, 60, 71, 77, 80, 82, 85, 87, 89, 91, 93, 95, 97, 99, 105, 109, 117, 123, 133, 143, 157, 166, 179, 190, 205, 221, 241, 243, 249, 252, 256, 259, 265, 270, 276, 280, 285, 289, 292, 301, 304, 307, 313, 320, 327, 337, 348, 364, 372, 376, 382, 388, 395, 405, 414, 424, 433, 442, 451, 467, 482, 498, 513, 528, 543, 551, 556, 565, 571, 575, 582}
+var opIndexes = [...]uint32{0, 7, 15, 23, 28, 32, 37, 48, 53, 64, 71, 77, 80, 82, 85, 87, 89, 91, 93, 95, 97, 99, 105, 109, 117, 123, 133, 143, 157, 166, 179, 190, 205, 207, 213, 221, 233, 236, 240, 243, 249, 254, 260, 264, 269, 273, 276, 285, 288, 291, 297, 304, 311, 320, 330, 344, 359, 369, 380, 396, 404, 408, 414, 420, 427, 437, 446, 456, 465, 474, 483, 499, 514, 530, 545, 560, 575, 583, 588, 597, 603, 607, 614}

--- a/pkg/sql/opt/xform/expr.go
+++ b/pkg/sql/opt/xform/expr.go
@@ -135,6 +135,13 @@ func (ev *ExprView) Private() interface{} {
 	return ev.mem.lookupPrivate(ev.privateID())
 }
 
+// Metadata returns the metadata that's specific to this expression tree. Some
+// operator types refer to the metadata in their private fields. For example,
+// the Scan operator holds a metadata table index.
+func (ev *ExprView) Metadata() *opt.Metadata {
+	return ev.mem.metadata
+}
+
 // String returns a string representation of this expression for testing and
 // debugging.
 func (ev *ExprView) String() string {
@@ -160,6 +167,17 @@ func (ev *ExprView) formatScalar(tp treeprinter.Node) {
 
 	fmt.Fprintf(&buf, "%v", ev.op)
 	ev.formatPrivate(&buf, ev.Private())
+
+	scalar := ev.Logical().Scalar
+	if scalar != nil {
+		buf.WriteString(" [")
+		fmt.Fprintf(&buf, "type=%s", scalar.Type)
+		buf.WriteString("]")
+	} else {
+		// Don't panic if scalar properties don't yet exist when printing
+		// expression.
+		buf.WriteString(" [type=undefined]")
+	}
 
 	tp = tp.Child(buf.String())
 	for i := 0; i < ev.ChildCount(); i++ {

--- a/pkg/sql/opt/xform/expr.og.go
+++ b/pkg/sql/opt/xform/expr.og.go
@@ -50,16 +50,16 @@ var childCountLookup = [...]childCountLookupFunc{
 		return 0 + int(tupleExpr.elems().Length)
 	},
 
+	// ProjectionsOp
+	func(ev *ExprView) int {
+		projectionsExpr := (*projectionsExpr)(ev.mem.lookupExpr(ev.loc))
+		return 0 + int(projectionsExpr.elems().Length)
+	},
+
 	// FiltersOp
 	func(ev *ExprView) int {
 		filtersExpr := (*filtersExpr)(ev.mem.lookupExpr(ev.loc))
 		return 0 + int(filtersExpr.conditions().Length)
-	},
-
-	// ProjectionsOp
-	func(ev *ExprView) int {
-		projectionsExpr := (*projectionsExpr)(ev.mem.lookupExpr(ev.loc))
-		return 0 + int(projectionsExpr.items().Length)
 	},
 
 	// ExistsOp
@@ -172,22 +172,22 @@ var childCountLookup = [...]childCountLookupFunc{
 		return 2
 	},
 
-	// IsDistinctFromOp
-	func(ev *ExprView) int {
-		return 2
-	},
-
-	// IsNotDistinctFromOp
-	func(ev *ExprView) int {
-		return 2
-	},
-
 	// IsOp
 	func(ev *ExprView) int {
 		return 2
 	},
 
 	// IsNotOp
+	func(ev *ExprView) int {
+		return 2
+	},
+
+	// ContainsOp
+	func(ev *ExprView) int {
+		return 2
+	},
+
+	// ContainedByOp
 	func(ev *ExprView) int {
 		return 2
 	},
@@ -268,6 +268,26 @@ var childCountLookup = [...]childCountLookupFunc{
 	},
 
 	// RShiftOp
+	func(ev *ExprView) int {
+		return 2
+	},
+
+	// FetchValOp
+	func(ev *ExprView) int {
+		return 2
+	},
+
+	// FetchTextOp
+	func(ev *ExprView) int {
+		return 2
+	},
+
+	// FetchValPathOp
+	func(ev *ExprView) int {
+		return 2
+	},
+
+	// FetchTextPathOp
 	func(ev *ExprView) int {
 		return 2
 	},
@@ -463,6 +483,17 @@ var childGroupLookup = [...]childGroupLookupFunc{
 		}
 	},
 
+	// ProjectionsOp
+	func(ev *ExprView, n int) opt.GroupID {
+		projectionsExpr := (*projectionsExpr)(ev.mem.lookupExpr(ev.loc))
+
+		switch n {
+		default:
+			list := ev.mem.lookupList(projectionsExpr.elems())
+			return list[n-0]
+		}
+	},
+
 	// FiltersOp
 	func(ev *ExprView, n int) opt.GroupID {
 		filtersExpr := (*filtersExpr)(ev.mem.lookupExpr(ev.loc))
@@ -470,17 +501,6 @@ var childGroupLookup = [...]childGroupLookupFunc{
 		switch n {
 		default:
 			list := ev.mem.lookupList(filtersExpr.conditions())
-			return list[n-0]
-		}
-	},
-
-	// ProjectionsOp
-	func(ev *ExprView, n int) opt.GroupID {
-		projectionsExpr := (*projectionsExpr)(ev.mem.lookupExpr(ev.loc))
-
-		switch n {
-		default:
-			list := ev.mem.lookupList(projectionsExpr.items())
 			return list[n-0]
 		}
 	},
@@ -789,34 +809,6 @@ var childGroupLookup = [...]childGroupLookupFunc{
 		}
 	},
 
-	// IsDistinctFromOp
-	func(ev *ExprView, n int) opt.GroupID {
-		isDistinctFromExpr := (*isDistinctFromExpr)(ev.mem.lookupExpr(ev.loc))
-
-		switch n {
-		case 0:
-			return isDistinctFromExpr.left()
-		case 1:
-			return isDistinctFromExpr.right()
-		default:
-			panic("child index out of range")
-		}
-	},
-
-	// IsNotDistinctFromOp
-	func(ev *ExprView, n int) opt.GroupID {
-		isNotDistinctFromExpr := (*isNotDistinctFromExpr)(ev.mem.lookupExpr(ev.loc))
-
-		switch n {
-		case 0:
-			return isNotDistinctFromExpr.left()
-		case 1:
-			return isNotDistinctFromExpr.right()
-		default:
-			panic("child index out of range")
-		}
-	},
-
 	// IsOp
 	func(ev *ExprView, n int) opt.GroupID {
 		isExpr := (*isExpr)(ev.mem.lookupExpr(ev.loc))
@@ -840,6 +832,34 @@ var childGroupLookup = [...]childGroupLookupFunc{
 			return isNotExpr.left()
 		case 1:
 			return isNotExpr.right()
+		default:
+			panic("child index out of range")
+		}
+	},
+
+	// ContainsOp
+	func(ev *ExprView, n int) opt.GroupID {
+		containsExpr := (*containsExpr)(ev.mem.lookupExpr(ev.loc))
+
+		switch n {
+		case 0:
+			return containsExpr.left()
+		case 1:
+			return containsExpr.right()
+		default:
+			panic("child index out of range")
+		}
+	},
+
+	// ContainedByOp
+	func(ev *ExprView, n int) opt.GroupID {
+		containedByExpr := (*containedByExpr)(ev.mem.lookupExpr(ev.loc))
+
+		switch n {
+		case 0:
+			return containedByExpr.left()
+		case 1:
+			return containedByExpr.right()
 		default:
 			panic("child index out of range")
 		}
@@ -1064,6 +1084,62 @@ var childGroupLookup = [...]childGroupLookupFunc{
 			return rShiftExpr.left()
 		case 1:
 			return rShiftExpr.right()
+		default:
+			panic("child index out of range")
+		}
+	},
+
+	// FetchValOp
+	func(ev *ExprView, n int) opt.GroupID {
+		fetchValExpr := (*fetchValExpr)(ev.mem.lookupExpr(ev.loc))
+
+		switch n {
+		case 0:
+			return fetchValExpr.json()
+		case 1:
+			return fetchValExpr.index()
+		default:
+			panic("child index out of range")
+		}
+	},
+
+	// FetchTextOp
+	func(ev *ExprView, n int) opt.GroupID {
+		fetchTextExpr := (*fetchTextExpr)(ev.mem.lookupExpr(ev.loc))
+
+		switch n {
+		case 0:
+			return fetchTextExpr.json()
+		case 1:
+			return fetchTextExpr.index()
+		default:
+			panic("child index out of range")
+		}
+	},
+
+	// FetchValPathOp
+	func(ev *ExprView, n int) opt.GroupID {
+		fetchValPathExpr := (*fetchValPathExpr)(ev.mem.lookupExpr(ev.loc))
+
+		switch n {
+		case 0:
+			return fetchValPathExpr.json()
+		case 1:
+			return fetchValPathExpr.path()
+		default:
+			panic("child index out of range")
+		}
+	},
+
+	// FetchTextPathOp
+	func(ev *ExprView, n int) opt.GroupID {
+		fetchTextPathExpr := (*fetchTextPathExpr)(ev.mem.lookupExpr(ev.loc))
+
+		switch n {
+		case 0:
+			return fetchTextPathExpr.json()
+		case 1:
+			return fetchTextPathExpr.path()
 		default:
 			panic("child index out of range")
 		}
@@ -1475,15 +1551,15 @@ var privateLookup = [...]privateLookupFunc{
 		return 0
 	},
 
-	// FiltersOp
-	func(ev *ExprView) opt.PrivateID {
-		return 0
-	},
-
 	// ProjectionsOp
 	func(ev *ExprView) opt.PrivateID {
 		projectionsExpr := (*projectionsExpr)(ev.mem.lookupExpr(ev.loc))
 		return projectionsExpr.cols()
+	},
+
+	// FiltersOp
+	func(ev *ExprView) opt.PrivateID {
+		return 0
 	},
 
 	// ExistsOp
@@ -1596,22 +1672,22 @@ var privateLookup = [...]privateLookupFunc{
 		return 0
 	},
 
-	// IsDistinctFromOp
-	func(ev *ExprView) opt.PrivateID {
-		return 0
-	},
-
-	// IsNotDistinctFromOp
-	func(ev *ExprView) opt.PrivateID {
-		return 0
-	},
-
 	// IsOp
 	func(ev *ExprView) opt.PrivateID {
 		return 0
 	},
 
 	// IsNotOp
+	func(ev *ExprView) opt.PrivateID {
+		return 0
+	},
+
+	// ContainsOp
+	func(ev *ExprView) opt.PrivateID {
+		return 0
+	},
+
+	// ContainedByOp
 	func(ev *ExprView) opt.PrivateID {
 		return 0
 	},
@@ -1692,6 +1768,26 @@ var privateLookup = [...]privateLookupFunc{
 	},
 
 	// RShiftOp
+	func(ev *ExprView) opt.PrivateID {
+		return 0
+	},
+
+	// FetchValOp
+	func(ev *ExprView) opt.PrivateID {
+		return 0
+	},
+
+	// FetchTextOp
+	func(ev *ExprView) opt.PrivateID {
+		return 0
+	},
+
+	// FetchValPathOp
+	func(ev *ExprView) opt.PrivateID {
+		return 0
+	},
+
+	// FetchTextPathOp
 	func(ev *ExprView) opt.PrivateID {
 		return 0
 	},
@@ -1841,8 +1937,8 @@ var isScalarLookup = [...]bool{
 	true,  // FalseOp
 	true,  // PlaceholderOp
 	true,  // TupleOp
-	true,  // FiltersOp
 	true,  // ProjectionsOp
+	true,  // FiltersOp
 	true,  // ExistsOp
 	true,  // AndOp
 	true,  // OrOp
@@ -1865,10 +1961,10 @@ var isScalarLookup = [...]bool{
 	true,  // NotRegMatchOp
 	true,  // RegIMatchOp
 	true,  // NotRegIMatchOp
-	true,  // IsDistinctFromOp
-	true,  // IsNotDistinctFromOp
 	true,  // IsOp
 	true,  // IsNotOp
+	true,  // ContainsOp
+	true,  // ContainedByOp
 	true,  // AnyOp
 	true,  // SomeOp
 	true,  // AllOp
@@ -1885,6 +1981,10 @@ var isScalarLookup = [...]bool{
 	true,  // ConcatOp
 	true,  // LShiftOp
 	true,  // RShiftOp
+	true,  // FetchValOp
+	true,  // FetchTextOp
+	true,  // FetchValPathOp
+	true,  // FetchTextPathOp
 	true,  // UnaryPlusOp
 	true,  // UnaryMinusOp
 	true,  // UnaryComplementOp
@@ -1923,8 +2023,8 @@ var isRelationalLookup = [...]bool{
 	false, // FalseOp
 	false, // PlaceholderOp
 	false, // TupleOp
-	false, // FiltersOp
 	false, // ProjectionsOp
+	false, // FiltersOp
 	false, // ExistsOp
 	false, // AndOp
 	false, // OrOp
@@ -1947,10 +2047,10 @@ var isRelationalLookup = [...]bool{
 	false, // NotRegMatchOp
 	false, // RegIMatchOp
 	false, // NotRegIMatchOp
-	false, // IsDistinctFromOp
-	false, // IsNotDistinctFromOp
 	false, // IsOp
 	false, // IsNotOp
+	false, // ContainsOp
+	false, // ContainedByOp
 	false, // AnyOp
 	false, // SomeOp
 	false, // AllOp
@@ -1967,6 +2067,10 @@ var isRelationalLookup = [...]bool{
 	false, // ConcatOp
 	false, // LShiftOp
 	false, // RShiftOp
+	false, // FetchValOp
+	false, // FetchTextOp
+	false, // FetchValPathOp
+	false, // FetchTextPathOp
 	false, // UnaryPlusOp
 	false, // UnaryMinusOp
 	false, // UnaryComplementOp
@@ -2005,8 +2109,8 @@ var isJoinLookup = [...]bool{
 	false, // FalseOp
 	false, // PlaceholderOp
 	false, // TupleOp
-	false, // FiltersOp
 	false, // ProjectionsOp
+	false, // FiltersOp
 	false, // ExistsOp
 	false, // AndOp
 	false, // OrOp
@@ -2029,10 +2133,10 @@ var isJoinLookup = [...]bool{
 	false, // NotRegMatchOp
 	false, // RegIMatchOp
 	false, // NotRegIMatchOp
-	false, // IsDistinctFromOp
-	false, // IsNotDistinctFromOp
 	false, // IsOp
 	false, // IsNotOp
+	false, // ContainsOp
+	false, // ContainedByOp
 	false, // AnyOp
 	false, // SomeOp
 	false, // AllOp
@@ -2049,6 +2153,10 @@ var isJoinLookup = [...]bool{
 	false, // ConcatOp
 	false, // LShiftOp
 	false, // RShiftOp
+	false, // FetchValOp
+	false, // FetchTextOp
+	false, // FetchValPathOp
+	false, // FetchTextPathOp
 	false, // UnaryPlusOp
 	false, // UnaryMinusOp
 	false, // UnaryComplementOp
@@ -2087,8 +2195,8 @@ var isJoinApplyLookup = [...]bool{
 	false, // FalseOp
 	false, // PlaceholderOp
 	false, // TupleOp
-	false, // FiltersOp
 	false, // ProjectionsOp
+	false, // FiltersOp
 	false, // ExistsOp
 	false, // AndOp
 	false, // OrOp
@@ -2111,10 +2219,10 @@ var isJoinApplyLookup = [...]bool{
 	false, // NotRegMatchOp
 	false, // RegIMatchOp
 	false, // NotRegIMatchOp
-	false, // IsDistinctFromOp
-	false, // IsNotDistinctFromOp
 	false, // IsOp
 	false, // IsNotOp
+	false, // ContainsOp
+	false, // ContainedByOp
 	false, // AnyOp
 	false, // SomeOp
 	false, // AllOp
@@ -2131,6 +2239,10 @@ var isJoinApplyLookup = [...]bool{
 	false, // ConcatOp
 	false, // LShiftOp
 	false, // RShiftOp
+	false, // FetchValOp
+	false, // FetchTextOp
+	false, // FetchValPathOp
+	false, // FetchTextPathOp
 	false, // UnaryPlusOp
 	false, // UnaryMinusOp
 	false, // UnaryComplementOp
@@ -2169,8 +2281,8 @@ var isEnforcerLookup = [...]bool{
 	false, // FalseOp
 	false, // PlaceholderOp
 	false, // TupleOp
-	false, // FiltersOp
 	false, // ProjectionsOp
+	false, // FiltersOp
 	false, // ExistsOp
 	false, // AndOp
 	false, // OrOp
@@ -2193,10 +2305,10 @@ var isEnforcerLookup = [...]bool{
 	false, // NotRegMatchOp
 	false, // RegIMatchOp
 	false, // NotRegIMatchOp
-	false, // IsDistinctFromOp
-	false, // IsNotDistinctFromOp
 	false, // IsOp
 	false, // IsNotOp
+	false, // ContainsOp
+	false, // ContainedByOp
 	false, // AnyOp
 	false, // SomeOp
 	false, // AllOp
@@ -2213,6 +2325,10 @@ var isEnforcerLookup = [...]bool{
 	false, // ConcatOp
 	false, // LShiftOp
 	false, // RShiftOp
+	false, // FetchValOp
+	false, // FetchTextOp
+	false, // FetchValPathOp
+	false, // FetchTextPathOp
 	false, // UnaryPlusOp
 	false, // UnaryMinusOp
 	false, // UnaryComplementOp
@@ -2404,6 +2520,31 @@ func (m *memoExpr) asTuple() *tupleExpr {
 	return (*tupleExpr)(m)
 }
 
+type projectionsExpr memoExpr
+
+func makeProjectionsExpr(elems opt.ListID, cols opt.PrivateID) projectionsExpr {
+	return projectionsExpr{op: opt.ProjectionsOp, state: exprState{elems.Offset, elems.Length, uint32(cols)}}
+}
+
+func (e *projectionsExpr) elems() opt.ListID {
+	return opt.ListID{Offset: e.state[0], Length: e.state[1]}
+}
+
+func (e *projectionsExpr) cols() opt.PrivateID {
+	return opt.PrivateID(e.state[2])
+}
+
+func (e *projectionsExpr) fingerprint() fingerprint {
+	return fingerprint(*e)
+}
+
+func (m *memoExpr) asProjections() *projectionsExpr {
+	if m.op != opt.ProjectionsOp {
+		return nil
+	}
+	return (*projectionsExpr)(m)
+}
+
 type filtersExpr memoExpr
 
 func makeFiltersExpr(conditions opt.ListID) filtersExpr {
@@ -2423,31 +2564,6 @@ func (m *memoExpr) asFilters() *filtersExpr {
 		return nil
 	}
 	return (*filtersExpr)(m)
-}
-
-type projectionsExpr memoExpr
-
-func makeProjectionsExpr(items opt.ListID, cols opt.PrivateID) projectionsExpr {
-	return projectionsExpr{op: opt.ProjectionsOp, state: exprState{items.Offset, items.Length, uint32(cols)}}
-}
-
-func (e *projectionsExpr) items() opt.ListID {
-	return opt.ListID{Offset: e.state[0], Length: e.state[1]}
-}
-
-func (e *projectionsExpr) cols() opt.PrivateID {
-	return opt.PrivateID(e.state[2])
-}
-
-func (e *projectionsExpr) fingerprint() fingerprint {
-	return fingerprint(*e)
-}
-
-func (m *memoExpr) asProjections() *projectionsExpr {
-	if m.op != opt.ProjectionsOp {
-		return nil
-	}
-	return (*projectionsExpr)(m)
 }
 
 type existsExpr memoExpr
@@ -2992,56 +3108,6 @@ func (m *memoExpr) asNotRegIMatch() *notRegIMatchExpr {
 	return (*notRegIMatchExpr)(m)
 }
 
-type isDistinctFromExpr memoExpr
-
-func makeIsDistinctFromExpr(left opt.GroupID, right opt.GroupID) isDistinctFromExpr {
-	return isDistinctFromExpr{op: opt.IsDistinctFromOp, state: exprState{uint32(left), uint32(right)}}
-}
-
-func (e *isDistinctFromExpr) left() opt.GroupID {
-	return opt.GroupID(e.state[0])
-}
-
-func (e *isDistinctFromExpr) right() opt.GroupID {
-	return opt.GroupID(e.state[1])
-}
-
-func (e *isDistinctFromExpr) fingerprint() fingerprint {
-	return fingerprint(*e)
-}
-
-func (m *memoExpr) asIsDistinctFrom() *isDistinctFromExpr {
-	if m.op != opt.IsDistinctFromOp {
-		return nil
-	}
-	return (*isDistinctFromExpr)(m)
-}
-
-type isNotDistinctFromExpr memoExpr
-
-func makeIsNotDistinctFromExpr(left opt.GroupID, right opt.GroupID) isNotDistinctFromExpr {
-	return isNotDistinctFromExpr{op: opt.IsNotDistinctFromOp, state: exprState{uint32(left), uint32(right)}}
-}
-
-func (e *isNotDistinctFromExpr) left() opt.GroupID {
-	return opt.GroupID(e.state[0])
-}
-
-func (e *isNotDistinctFromExpr) right() opt.GroupID {
-	return opt.GroupID(e.state[1])
-}
-
-func (e *isNotDistinctFromExpr) fingerprint() fingerprint {
-	return fingerprint(*e)
-}
-
-func (m *memoExpr) asIsNotDistinctFrom() *isNotDistinctFromExpr {
-	if m.op != opt.IsNotDistinctFromOp {
-		return nil
-	}
-	return (*isNotDistinctFromExpr)(m)
-}
-
 type isExpr memoExpr
 
 func makeIsExpr(left opt.GroupID, right opt.GroupID) isExpr {
@@ -3090,6 +3156,56 @@ func (m *memoExpr) asIsNot() *isNotExpr {
 		return nil
 	}
 	return (*isNotExpr)(m)
+}
+
+type containsExpr memoExpr
+
+func makeContainsExpr(left opt.GroupID, right opt.GroupID) containsExpr {
+	return containsExpr{op: opt.ContainsOp, state: exprState{uint32(left), uint32(right)}}
+}
+
+func (e *containsExpr) left() opt.GroupID {
+	return opt.GroupID(e.state[0])
+}
+
+func (e *containsExpr) right() opt.GroupID {
+	return opt.GroupID(e.state[1])
+}
+
+func (e *containsExpr) fingerprint() fingerprint {
+	return fingerprint(*e)
+}
+
+func (m *memoExpr) asContains() *containsExpr {
+	if m.op != opt.ContainsOp {
+		return nil
+	}
+	return (*containsExpr)(m)
+}
+
+type containedByExpr memoExpr
+
+func makeContainedByExpr(left opt.GroupID, right opt.GroupID) containedByExpr {
+	return containedByExpr{op: opt.ContainedByOp, state: exprState{uint32(left), uint32(right)}}
+}
+
+func (e *containedByExpr) left() opt.GroupID {
+	return opt.GroupID(e.state[0])
+}
+
+func (e *containedByExpr) right() opt.GroupID {
+	return opt.GroupID(e.state[1])
+}
+
+func (e *containedByExpr) fingerprint() fingerprint {
+	return fingerprint(*e)
+}
+
+func (m *memoExpr) asContainedBy() *containedByExpr {
+	if m.op != opt.ContainedByOp {
+		return nil
+	}
+	return (*containedByExpr)(m)
 }
 
 type anyExpr memoExpr
@@ -3490,6 +3606,106 @@ func (m *memoExpr) asRShift() *rShiftExpr {
 		return nil
 	}
 	return (*rShiftExpr)(m)
+}
+
+type fetchValExpr memoExpr
+
+func makeFetchValExpr(json opt.GroupID, index opt.GroupID) fetchValExpr {
+	return fetchValExpr{op: opt.FetchValOp, state: exprState{uint32(json), uint32(index)}}
+}
+
+func (e *fetchValExpr) json() opt.GroupID {
+	return opt.GroupID(e.state[0])
+}
+
+func (e *fetchValExpr) index() opt.GroupID {
+	return opt.GroupID(e.state[1])
+}
+
+func (e *fetchValExpr) fingerprint() fingerprint {
+	return fingerprint(*e)
+}
+
+func (m *memoExpr) asFetchVal() *fetchValExpr {
+	if m.op != opt.FetchValOp {
+		return nil
+	}
+	return (*fetchValExpr)(m)
+}
+
+type fetchTextExpr memoExpr
+
+func makeFetchTextExpr(json opt.GroupID, index opt.GroupID) fetchTextExpr {
+	return fetchTextExpr{op: opt.FetchTextOp, state: exprState{uint32(json), uint32(index)}}
+}
+
+func (e *fetchTextExpr) json() opt.GroupID {
+	return opt.GroupID(e.state[0])
+}
+
+func (e *fetchTextExpr) index() opt.GroupID {
+	return opt.GroupID(e.state[1])
+}
+
+func (e *fetchTextExpr) fingerprint() fingerprint {
+	return fingerprint(*e)
+}
+
+func (m *memoExpr) asFetchText() *fetchTextExpr {
+	if m.op != opt.FetchTextOp {
+		return nil
+	}
+	return (*fetchTextExpr)(m)
+}
+
+type fetchValPathExpr memoExpr
+
+func makeFetchValPathExpr(json opt.GroupID, path opt.GroupID) fetchValPathExpr {
+	return fetchValPathExpr{op: opt.FetchValPathOp, state: exprState{uint32(json), uint32(path)}}
+}
+
+func (e *fetchValPathExpr) json() opt.GroupID {
+	return opt.GroupID(e.state[0])
+}
+
+func (e *fetchValPathExpr) path() opt.GroupID {
+	return opt.GroupID(e.state[1])
+}
+
+func (e *fetchValPathExpr) fingerprint() fingerprint {
+	return fingerprint(*e)
+}
+
+func (m *memoExpr) asFetchValPath() *fetchValPathExpr {
+	if m.op != opt.FetchValPathOp {
+		return nil
+	}
+	return (*fetchValPathExpr)(m)
+}
+
+type fetchTextPathExpr memoExpr
+
+func makeFetchTextPathExpr(json opt.GroupID, path opt.GroupID) fetchTextPathExpr {
+	return fetchTextPathExpr{op: opt.FetchTextPathOp, state: exprState{uint32(json), uint32(path)}}
+}
+
+func (e *fetchTextPathExpr) json() opt.GroupID {
+	return opt.GroupID(e.state[0])
+}
+
+func (e *fetchTextPathExpr) path() opt.GroupID {
+	return opt.GroupID(e.state[1])
+}
+
+func (e *fetchTextPathExpr) fingerprint() fingerprint {
+	return fingerprint(*e)
+}
+
+func (m *memoExpr) asFetchTextPath() *fetchTextPathExpr {
+	if m.op != opt.FetchTextPathOp {
+		return nil
+	}
+	return (*fetchTextPathExpr)(m)
 }
 
 type unaryPlusExpr memoExpr

--- a/pkg/sql/opt/xform/factory.og.go
+++ b/pkg/sql/opt/xform/factory.og.go
@@ -87,6 +87,19 @@ func (_f *factory) ConstructTuple(
 	return _f.onConstruct(_f.mem.memoizeNormExpr((*memoExpr)(&_tupleExpr)))
 }
 
+func (_f *factory) ConstructProjections(
+	elems opt.ListID,
+	cols opt.PrivateID,
+) opt.GroupID {
+	_projectionsExpr := makeProjectionsExpr(elems, cols)
+	_group := _f.mem.lookupGroupByFingerprint(_projectionsExpr.fingerprint())
+	if _group != 0 {
+		return _group
+	}
+
+	return _f.onConstruct(_f.mem.memoizeNormExpr((*memoExpr)(&_projectionsExpr)))
+}
+
 func (_f *factory) ConstructFilters(
 	conditions opt.ListID,
 ) opt.GroupID {
@@ -97,19 +110,6 @@ func (_f *factory) ConstructFilters(
 	}
 
 	return _f.onConstruct(_f.mem.memoizeNormExpr((*memoExpr)(&_filtersExpr)))
-}
-
-func (_f *factory) ConstructProjections(
-	items opt.ListID,
-	cols opt.PrivateID,
-) opt.GroupID {
-	_projectionsExpr := makeProjectionsExpr(items, cols)
-	_group := _f.mem.lookupGroupByFingerprint(_projectionsExpr.fingerprint())
-	if _group != 0 {
-		return _group
-	}
-
-	return _f.onConstruct(_f.mem.memoizeNormExpr((*memoExpr)(&_projectionsExpr)))
 }
 
 func (_f *factory) ConstructExists(
@@ -396,32 +396,6 @@ func (_f *factory) ConstructNotRegIMatch(
 	return _f.onConstruct(_f.mem.memoizeNormExpr((*memoExpr)(&_notRegIMatchExpr)))
 }
 
-func (_f *factory) ConstructIsDistinctFrom(
-	left opt.GroupID,
-	right opt.GroupID,
-) opt.GroupID {
-	_isDistinctFromExpr := makeIsDistinctFromExpr(left, right)
-	_group := _f.mem.lookupGroupByFingerprint(_isDistinctFromExpr.fingerprint())
-	if _group != 0 {
-		return _group
-	}
-
-	return _f.onConstruct(_f.mem.memoizeNormExpr((*memoExpr)(&_isDistinctFromExpr)))
-}
-
-func (_f *factory) ConstructIsNotDistinctFrom(
-	left opt.GroupID,
-	right opt.GroupID,
-) opt.GroupID {
-	_isNotDistinctFromExpr := makeIsNotDistinctFromExpr(left, right)
-	_group := _f.mem.lookupGroupByFingerprint(_isNotDistinctFromExpr.fingerprint())
-	if _group != 0 {
-		return _group
-	}
-
-	return _f.onConstruct(_f.mem.memoizeNormExpr((*memoExpr)(&_isNotDistinctFromExpr)))
-}
-
 func (_f *factory) ConstructIs(
 	left opt.GroupID,
 	right opt.GroupID,
@@ -446,6 +420,32 @@ func (_f *factory) ConstructIsNot(
 	}
 
 	return _f.onConstruct(_f.mem.memoizeNormExpr((*memoExpr)(&_isNotExpr)))
+}
+
+func (_f *factory) ConstructContains(
+	left opt.GroupID,
+	right opt.GroupID,
+) opt.GroupID {
+	_containsExpr := makeContainsExpr(left, right)
+	_group := _f.mem.lookupGroupByFingerprint(_containsExpr.fingerprint())
+	if _group != 0 {
+		return _group
+	}
+
+	return _f.onConstruct(_f.mem.memoizeNormExpr((*memoExpr)(&_containsExpr)))
+}
+
+func (_f *factory) ConstructContainedBy(
+	left opt.GroupID,
+	right opt.GroupID,
+) opt.GroupID {
+	_containedByExpr := makeContainedByExpr(left, right)
+	_group := _f.mem.lookupGroupByFingerprint(_containedByExpr.fingerprint())
+	if _group != 0 {
+		return _group
+	}
+
+	return _f.onConstruct(_f.mem.memoizeNormExpr((*memoExpr)(&_containedByExpr)))
 }
 
 func (_f *factory) ConstructAny(
@@ -654,6 +654,58 @@ func (_f *factory) ConstructRShift(
 	}
 
 	return _f.onConstruct(_f.mem.memoizeNormExpr((*memoExpr)(&_rShiftExpr)))
+}
+
+func (_f *factory) ConstructFetchVal(
+	json opt.GroupID,
+	index opt.GroupID,
+) opt.GroupID {
+	_fetchValExpr := makeFetchValExpr(json, index)
+	_group := _f.mem.lookupGroupByFingerprint(_fetchValExpr.fingerprint())
+	if _group != 0 {
+		return _group
+	}
+
+	return _f.onConstruct(_f.mem.memoizeNormExpr((*memoExpr)(&_fetchValExpr)))
+}
+
+func (_f *factory) ConstructFetchText(
+	json opt.GroupID,
+	index opt.GroupID,
+) opt.GroupID {
+	_fetchTextExpr := makeFetchTextExpr(json, index)
+	_group := _f.mem.lookupGroupByFingerprint(_fetchTextExpr.fingerprint())
+	if _group != 0 {
+		return _group
+	}
+
+	return _f.onConstruct(_f.mem.memoizeNormExpr((*memoExpr)(&_fetchTextExpr)))
+}
+
+func (_f *factory) ConstructFetchValPath(
+	json opt.GroupID,
+	path opt.GroupID,
+) opt.GroupID {
+	_fetchValPathExpr := makeFetchValPathExpr(json, path)
+	_group := _f.mem.lookupGroupByFingerprint(_fetchValPathExpr.fingerprint())
+	if _group != 0 {
+		return _group
+	}
+
+	return _f.onConstruct(_f.mem.memoizeNormExpr((*memoExpr)(&_fetchValPathExpr)))
+}
+
+func (_f *factory) ConstructFetchTextPath(
+	json opt.GroupID,
+	path opt.GroupID,
+) opt.GroupID {
+	_fetchTextPathExpr := makeFetchTextPathExpr(json, path)
+	_group := _f.mem.lookupGroupByFingerprint(_fetchTextPathExpr.fingerprint())
+	if _group != 0 {
+		return _group
+	}
+
+	return _f.onConstruct(_f.mem.memoizeNormExpr((*memoExpr)(&_fetchTextPathExpr)))
 }
 
 func (_f *factory) ConstructUnaryPlus(
@@ -980,7 +1032,7 @@ func (_f *factory) ConstructExcept(
 
 type dynConstructLookupFunc func(f *factory, children []opt.GroupID, private opt.PrivateID) opt.GroupID
 
-var dynConstructLookup [76]dynConstructLookupFunc
+var dynConstructLookup [80]dynConstructLookupFunc
 
 func init() {
 	// UnknownOp
@@ -1023,14 +1075,14 @@ func init() {
 		return f.ConstructTuple(f.StoreList(children))
 	}
 
-	// FiltersOp
-	dynConstructLookup[opt.FiltersOp] = func(f *factory, children []opt.GroupID, private opt.PrivateID) opt.GroupID {
-		return f.ConstructFilters(f.StoreList(children))
-	}
-
 	// ProjectionsOp
 	dynConstructLookup[opt.ProjectionsOp] = func(f *factory, children []opt.GroupID, private opt.PrivateID) opt.GroupID {
 		return f.ConstructProjections(f.StoreList(children), private)
+	}
+
+	// FiltersOp
+	dynConstructLookup[opt.FiltersOp] = func(f *factory, children []opt.GroupID, private opt.PrivateID) opt.GroupID {
+		return f.ConstructFilters(f.StoreList(children))
 	}
 
 	// ExistsOp
@@ -1143,16 +1195,6 @@ func init() {
 		return f.ConstructNotRegIMatch(children[0], children[1])
 	}
 
-	// IsDistinctFromOp
-	dynConstructLookup[opt.IsDistinctFromOp] = func(f *factory, children []opt.GroupID, private opt.PrivateID) opt.GroupID {
-		return f.ConstructIsDistinctFrom(children[0], children[1])
-	}
-
-	// IsNotDistinctFromOp
-	dynConstructLookup[opt.IsNotDistinctFromOp] = func(f *factory, children []opt.GroupID, private opt.PrivateID) opt.GroupID {
-		return f.ConstructIsNotDistinctFrom(children[0], children[1])
-	}
-
 	// IsOp
 	dynConstructLookup[opt.IsOp] = func(f *factory, children []opt.GroupID, private opt.PrivateID) opt.GroupID {
 		return f.ConstructIs(children[0], children[1])
@@ -1161,6 +1203,16 @@ func init() {
 	// IsNotOp
 	dynConstructLookup[opt.IsNotOp] = func(f *factory, children []opt.GroupID, private opt.PrivateID) opt.GroupID {
 		return f.ConstructIsNot(children[0], children[1])
+	}
+
+	// ContainsOp
+	dynConstructLookup[opt.ContainsOp] = func(f *factory, children []opt.GroupID, private opt.PrivateID) opt.GroupID {
+		return f.ConstructContains(children[0], children[1])
+	}
+
+	// ContainedByOp
+	dynConstructLookup[opt.ContainedByOp] = func(f *factory, children []opt.GroupID, private opt.PrivateID) opt.GroupID {
+		return f.ConstructContainedBy(children[0], children[1])
 	}
 
 	// AnyOp
@@ -1241,6 +1293,26 @@ func init() {
 	// RShiftOp
 	dynConstructLookup[opt.RShiftOp] = func(f *factory, children []opt.GroupID, private opt.PrivateID) opt.GroupID {
 		return f.ConstructRShift(children[0], children[1])
+	}
+
+	// FetchValOp
+	dynConstructLookup[opt.FetchValOp] = func(f *factory, children []opt.GroupID, private opt.PrivateID) opt.GroupID {
+		return f.ConstructFetchVal(children[0], children[1])
+	}
+
+	// FetchTextOp
+	dynConstructLookup[opt.FetchTextOp] = func(f *factory, children []opt.GroupID, private opt.PrivateID) opt.GroupID {
+		return f.ConstructFetchText(children[0], children[1])
+	}
+
+	// FetchValPathOp
+	dynConstructLookup[opt.FetchValPathOp] = func(f *factory, children []opt.GroupID, private opt.PrivateID) opt.GroupID {
+		return f.ConstructFetchValPath(children[0], children[1])
+	}
+
+	// FetchTextPathOp
+	dynConstructLookup[opt.FetchTextPathOp] = func(f *factory, children []opt.GroupID, private opt.PrivateID) opt.GroupID {
+		return f.ConstructFetchTextPath(children[0], children[1])
 	}
 
 	// UnaryPlusOp

--- a/pkg/sql/opt/xform/logical_props_factory.go
+++ b/pkg/sql/opt/xform/logical_props_factory.go
@@ -75,8 +75,8 @@ func (f *logicalPropsFactory) constructRelationalProps(ev *ExprView) LogicalProp
 	panic(fmt.Sprintf("unrecognized relational expression type: %v", ev.op))
 }
 
-func (f *logicalPropsFactory) constructScanProps(ev *ExprView) (props LogicalProps) {
-	props.Relational = &RelationalProps{}
+func (f *logicalPropsFactory) constructScanProps(ev *ExprView) LogicalProps {
+	props := LogicalProps{Relational: &RelationalProps{}}
 
 	tblIndex := ev.Private().(opt.TableIndex)
 	tbl := f.mem.metadata.Table(tblIndex)
@@ -91,11 +91,11 @@ func (f *logicalPropsFactory) constructScanProps(ev *ExprView) (props LogicalPro
 		}
 	}
 
-	return
+	return props
 }
 
-func (f *logicalPropsFactory) constructSelectProps(ev *ExprView) (props LogicalProps) {
-	props.Relational = &RelationalProps{}
+func (f *logicalPropsFactory) constructSelectProps(ev *ExprView) LogicalProps {
+	props := LogicalProps{Relational: &RelationalProps{}}
 
 	inputProps := f.mem.lookupGroup(ev.ChildGroup(0)).logical
 
@@ -105,11 +105,11 @@ func (f *logicalPropsFactory) constructSelectProps(ev *ExprView) (props LogicalP
 	// Inherit not null columns from input.
 	props.Relational.NotNullCols = inputProps.Relational.NotNullCols
 
-	return
+	return props
 }
 
-func (f *logicalPropsFactory) constructProjectProps(ev *ExprView) (props LogicalProps) {
-	props.Relational = &RelationalProps{}
+func (f *logicalPropsFactory) constructProjectProps(ev *ExprView) LogicalProps {
+	props := LogicalProps{Relational: &RelationalProps{}}
 
 	inputProps := f.mem.lookupGroup(ev.ChildGroup(0)).logical
 
@@ -121,11 +121,11 @@ func (f *logicalPropsFactory) constructProjectProps(ev *ExprView) (props Logical
 	props.Relational.NotNullCols = inputProps.Relational.NotNullCols
 	filterNullCols(props.Relational)
 
-	return
+	return props
 }
 
-func (f *logicalPropsFactory) constructJoinProps(ev *ExprView) (props LogicalProps) {
-	props.Relational = &RelationalProps{}
+func (f *logicalPropsFactory) constructJoinProps(ev *ExprView) LogicalProps {
+	props := LogicalProps{Relational: &RelationalProps{}}
 
 	leftProps := f.mem.lookupGroup(ev.ChildGroup(0)).logical
 	rightProps := f.mem.lookupGroup(ev.ChildGroup(1)).logical
@@ -159,11 +159,11 @@ func (f *logicalPropsFactory) constructJoinProps(ev *ExprView) (props LogicalPro
 		props.Relational.NotNullCols.UnionWith(leftProps.Relational.NotNullCols)
 	}
 
-	return
+	return props
 }
 
-func (f *logicalPropsFactory) constructGroupByProps(ev *ExprView) (props LogicalProps) {
-	props.Relational = &RelationalProps{}
+func (f *logicalPropsFactory) constructGroupByProps(ev *ExprView) LogicalProps {
+	props := LogicalProps{Relational: &RelationalProps{}}
 
 	// Output columns are union of columns from grouping and aggregate
 	// projection lists.
@@ -172,11 +172,11 @@ func (f *logicalPropsFactory) constructGroupByProps(ev *ExprView) (props Logical
 	agg := ev.Child(2)
 	props.Relational.OutputCols.UnionWith(*agg.Private().(*opt.ColSet))
 
-	return
+	return props
 }
 
-func (f *logicalPropsFactory) constructSetProps(ev *ExprView) (props LogicalProps) {
-	props.Relational = &RelationalProps{}
+func (f *logicalPropsFactory) constructSetProps(ev *ExprView) LogicalProps {
+	props := LogicalProps{Relational: &RelationalProps{}}
 
 	leftProps := f.mem.lookupGroup(ev.ChildGroup(0)).logical
 	rightProps := f.mem.lookupGroup(ev.ChildGroup(1)).logical
@@ -199,19 +199,19 @@ func (f *logicalPropsFactory) constructSetProps(ev *ExprView) (props LogicalProp
 		props.Relational.NotNullCols.Add(key)
 	})
 
-	return
+	return props
 }
 
-func (f *logicalPropsFactory) constructValuesProps(ev *ExprView) (props LogicalProps) {
-	props.Relational = &RelationalProps{}
+func (f *logicalPropsFactory) constructValuesProps(ev *ExprView) LogicalProps {
+	props := LogicalProps{Relational: &RelationalProps{}}
 
 	// Use output columns that are attached to the values op.
 	props.Relational.OutputCols = *ev.Private().(*opt.ColSet)
-	return
+	return props
 }
 
 func (f *logicalPropsFactory) constructScalarProps(ev *ExprView) LogicalProps {
-	return LogicalProps{}
+	return LogicalProps{Scalar: &ScalarProps{Type: inferType(ev)}}
 }
 
 // filterNullCols will ensure that the set of null columns is a subset of the

--- a/pkg/sql/opt/xform/testdata/typing
+++ b/pkg/sql/opt/xform/testdata/typing
@@ -1,0 +1,322 @@
+# Variable
+build
+SELECT a.x FROM a
+----
+project
+ ├── columns: a.x:int:1
+ ├── scan
+ │    └── columns: a.x:int:1 a.y:int:null:2
+ └── projections [type=tuple{int}]
+      └── variable: a.x [type=int]
+
+# Const
+build
+SELECT 1, TRUE, FALSE
+----
+project
+ ├── columns: column1:int:null:1 column2:bool:null:2 column3:bool:null:3
+ ├── values
+ │    └── tuple [type=tuple{}]
+ └── projections [type=tuple{int, bool, bool}]
+      ├── const: 1 [type=int]
+      ├── const: true [type=bool]
+      └── const: false [type=bool]
+
+# Placeholder
+build
+SELECT * FROM a WHERE x = $1
+----
+select
+ ├── columns: a.x:int:1 a.y:int:null:2
+ ├── scan
+ │    └── columns: a.x:int:1 a.y:int:null:2
+ └── eq [type=bool]
+      ├── variable: a.x [type=int]
+      └── placeholder: $1 [type=int]
+
+# Tuple, Projections
+build
+SELECT (a.x, 1.5), a.y FROM a
+----
+project
+ ├── columns: a.y:int:null:2 column1:tuple{int, decimal}:null:3
+ ├── scan
+ │    └── columns: a.x:int:1 a.y:int:null:2
+ └── projections [type=tuple{tuple{int, decimal}, int}]
+      ├── tuple [type=tuple{int, decimal}]
+      │    ├── variable: a.x [type=int]
+      │    └── const: 1.5 [type=decimal]
+      └── variable: a.y [type=int]
+
+# And, Or, Not
+build
+SELECT * FROM a WHERE a.x = 1 AND NOT (a.y = 2 OR a.y = 3.5)
+----
+select
+ ├── columns: a.x:int:1 a.y:int:null:2
+ ├── scan
+ │    └── columns: a.x:int:1 a.y:int:null:2
+ └── and [type=bool]
+      ├── eq [type=bool]
+      │    ├── variable: a.x [type=int]
+      │    └── const: 1 [type=int]
+      └── not [type=bool]
+           └── or [type=bool]
+                ├── eq [type=bool]
+                │    ├── variable: a.y [type=int]
+                │    └── const: 2 [type=int]
+                └── eq [type=bool]
+                     ├── variable: a.y [type=int]
+                     └── const: 3.5 [type=decimal]
+
+# Eq, Ne
+build
+SELECT * FROM a WHERE a.x = 1 AND a.x <> 2
+----
+select
+ ├── columns: a.x:int:1 a.y:int:null:2
+ ├── scan
+ │    └── columns: a.x:int:1 a.y:int:null:2
+ └── and [type=bool]
+      ├── eq [type=bool]
+      │    ├── variable: a.x [type=int]
+      │    └── const: 1 [type=int]
+      └── ne [type=bool]
+           ├── variable: a.x [type=int]
+           └── const: 2 [type=int]
+
+# Le, Ge, Lt, Gt
+build
+SELECT * FROM a WHERE a.x >= 1 AND a.x <= 10 AND a.y > 1 AND a.y < 10
+----
+select
+ ├── columns: a.x:int:1 a.y:int:null:2
+ ├── scan
+ │    └── columns: a.x:int:1 a.y:int:null:2
+ └── and [type=bool]
+      ├── and [type=bool]
+      │    ├── and [type=bool]
+      │    │    ├── ge [type=bool]
+      │    │    │    ├── variable: a.x [type=int]
+      │    │    │    └── const: 1 [type=int]
+      │    │    └── le [type=bool]
+      │    │         ├── variable: a.x [type=int]
+      │    │         └── const: 10 [type=int]
+      │    └── gt [type=bool]
+      │         ├── variable: a.y [type=int]
+      │         └── const: 1 [type=int]
+      └── lt [type=bool]
+           ├── variable: a.y [type=int]
+           └── const: 10 [type=int]
+
+# In, NotIn
+build
+SELECT * FROM a WHERE a.x IN (1, 2) AND a.y NOT IN (3, 4)
+----
+select
+ ├── columns: a.x:int:1 a.y:int:null:2
+ ├── scan
+ │    └── columns: a.x:int:1 a.y:int:null:2
+ └── and [type=bool]
+      ├── in [type=bool]
+      │    ├── variable: a.x [type=int]
+      │    └── tuple [type=tuple{int, int}]
+      │         ├── const: 1 [type=int]
+      │         └── const: 2 [type=int]
+      └── not-in [type=bool]
+           ├── variable: a.y [type=int]
+           └── tuple [type=tuple{int, int}]
+                ├── const: 3 [type=int]
+                └── const: 4 [type=int]
+
+# Like, NotLike
+build
+SELECT * FROM b WHERE b.x LIKE '%foo%' AND b.x NOT LIKE '%bar%'
+----
+select
+ ├── columns: b.x:string:1 b.z:decimal:2
+ ├── scan
+ │    └── columns: b.x:string:1 b.z:decimal:2
+ └── and [type=bool]
+      ├── like [type=bool]
+      │    ├── variable: b.x [type=string]
+      │    └── const: '%foo%' [type=string]
+      └── not-like [type=bool]
+           ├── variable: b.x [type=string]
+           └── const: '%bar%' [type=string]
+
+# ILike, INotLike
+build
+SELECT * FROM b WHERE b.x ILIKE '%foo%' AND b.x NOT ILIKE '%bar%'
+----
+select
+ ├── columns: b.x:string:1 b.z:decimal:2
+ ├── scan
+ │    └── columns: b.x:string:1 b.z:decimal:2
+ └── and [type=bool]
+      ├── i-like [type=bool]
+      │    ├── variable: b.x [type=string]
+      │    └── const: '%foo%' [type=string]
+      └── not-i-like [type=bool]
+           ├── variable: b.x [type=string]
+           └── const: '%bar%' [type=string]
+
+# RegMatch, NotRegMatch, RegIMatch, NotRegIMatch
+build
+SELECT * FROM b WHERE b.x ~ 'foo' AND b.x !~ 'bar' AND b.x ~* 'foo' AND b.x !~* 'bar'
+----
+select
+ ├── columns: b.x:string:1 b.z:decimal:2
+ ├── scan
+ │    └── columns: b.x:string:1 b.z:decimal:2
+ └── and [type=bool]
+      ├── and [type=bool]
+      │    ├── and [type=bool]
+      │    │    ├── reg-match [type=bool]
+      │    │    │    ├── variable: b.x [type=string]
+      │    │    │    └── const: 'foo' [type=string]
+      │    │    └── not-reg-match [type=bool]
+      │    │         ├── variable: b.x [type=string]
+      │    │         └── const: 'bar' [type=string]
+      │    └── reg-i-match [type=bool]
+      │         ├── variable: b.x [type=string]
+      │         └── const: 'foo' [type=string]
+      └── not-reg-i-match [type=bool]
+           ├── variable: b.x [type=string]
+           └── const: 'bar' [type=string]
+
+# Is, IsNot
+build
+SELECT * FROM a WHERE a.x IS DISTINCT FROM a.y AND a.x IS NULL
+----
+select
+ ├── columns: a.x:int:1 a.y:int:null:2
+ ├── scan
+ │    └── columns: a.x:int:1 a.y:int:null:2
+ └── and [type=bool]
+      ├── is-not [type=bool]
+      │    ├── variable: a.x [type=int]
+      │    └── variable: a.y [type=int]
+      └── is [type=bool]
+           ├── variable: a.x [type=int]
+           └── const: NULL [type=NULL]
+
+# Any, Some, All
+build
+SELECT a.x = ANY (1, 2), a.y = SOME (3, 4), a.x = ALL (5, 6) FROM a
+----
+project
+ ├── columns: column1:bool:null:3 column2:bool:null:4 column3:bool:null:5
+ ├── scan
+ │    └── columns: a.x:int:1 a.y:int:null:2
+ └── projections [type=tuple{bool, bool, bool}]
+      ├── any [type=bool]
+      │    ├── variable: a.x [type=int]
+      │    └── tuple [type=tuple{int, int}]
+      │         ├── const: 1 [type=int]
+      │         └── const: 2 [type=int]
+      ├── some [type=bool]
+      │    ├── variable: a.y [type=int]
+      │    └── tuple [type=tuple{int, int}]
+      │         ├── const: 3 [type=int]
+      │         └── const: 4 [type=int]
+      └── all [type=bool]
+           ├── variable: a.x [type=int]
+           └── tuple [type=tuple{int, int}]
+                ├── const: 5 [type=int]
+                └── const: 6 [type=int]
+
+# Bitand, Bitor, Bitxor
+build
+SELECT a.x & a.y, a.x | a.y, a.x # a.y FROM a
+----
+project
+ ├── columns: column1:int:null:3 column2:int:null:4 column3:int:null:5
+ ├── scan
+ │    └── columns: a.x:int:1 a.y:int:null:2
+ └── projections [type=tuple{int, int, int}]
+      ├── bitand [type=int]
+      │    ├── variable: a.x [type=int]
+      │    └── variable: a.y [type=int]
+      ├── bitor [type=int]
+      │    ├── variable: a.x [type=int]
+      │    └── variable: a.y [type=int]
+      └── bitxor [type=int]
+           ├── variable: a.x [type=int]
+           └── variable: a.y [type=int]
+
+# Plus, Minus, Mult, Div, FloorDiv
+build
+SELECT a.x + 1.5, DATE '2000-01-01' - 15, 10.10 * a.x, 1 / a.y, a.x // 1.5 FROM a
+----
+project
+ ├── columns: column1:decimal:null:3 column2:date:null:4 column3:decimal:null:5 column4:decimal:null:6 column5:decimal:null:7
+ ├── scan
+ │    └── columns: a.x:int:1 a.y:int:null:2
+ └── projections [type=tuple{decimal, date, decimal, decimal, decimal}]
+      ├── plus [type=decimal]
+      │    ├── variable: a.x [type=int]
+      │    └── const: 1.5 [type=decimal]
+      ├── minus [type=date]
+      │    ├── const: '2000-01-01' [type=date]
+      │    └── const: 15 [type=int]
+      ├── mult [type=decimal]
+      │    ├── const: 10.10 [type=decimal]
+      │    └── variable: a.x [type=int]
+      ├── div [type=decimal]
+      │    ├── const: 1 [type=int]
+      │    └── variable: a.y [type=int]
+      └── floor-div [type=decimal]
+           ├── variable: a.x [type=int]
+           └── const: 1.5 [type=decimal]
+
+# Mod, Pow, LShift, RShift
+build
+SELECT 100.1 % a.x, a.x ^ 2.5, a.x << 3, a.y >> 2 FROM a
+----
+project
+ ├── columns: column1:decimal:null:3 column2:decimal:null:4 column3:int:null:5 column4:int:null:6
+ ├── scan
+ │    └── columns: a.x:int:1 a.y:int:null:2
+ └── projections [type=tuple{decimal, decimal, int, int}]
+      ├── mod [type=decimal]
+      │    ├── const: 100.1 [type=decimal]
+      │    └── variable: a.x [type=int]
+      ├── pow [type=decimal]
+      │    ├── variable: a.x [type=int]
+      │    └── const: 2.5 [type=decimal]
+      ├── l-shift [type=int]
+      │    ├── variable: a.x [type=int]
+      │    └── const: 3 [type=int]
+      └── r-shift [type=int]
+           ├── variable: a.y [type=int]
+           └── const: 2 [type=int]
+
+# Concat
+build
+SELECT b.x || 'more' FROM b
+----
+project
+ ├── columns: column1:string:null:3
+ ├── scan
+ │    └── columns: b.x:string:1 b.z:decimal:2
+ └── projections [type=tuple{string}]
+      └── concat [type=string]
+           ├── variable: b.x [type=string]
+           └── const: 'more' [type=string]
+
+# UnaryPlus, UnaryMinus, UnaryComplement
+build
+SELECT +a.x, -a.y, ~a.x FROM a
+----
+project
+ ├── columns: column1:int:null:3 column2:int:null:4 column3:int:null:5
+ ├── scan
+ │    └── columns: a.x:int:1 a.y:int:null:2
+ └── projections [type=tuple{int, int, int}]
+      ├── unary-plus [type=int]
+      │    └── variable: a.x [type=int]
+      ├── unary-minus [type=int]
+      │    └── variable: a.y [type=int]
+      └── unary-complement [type=int]
+           └── variable: a.x [type=int]

--- a/pkg/sql/opt/xform/typing.go
+++ b/pkg/sql/opt/xform/typing.go
@@ -1,0 +1,176 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package xform
+
+import (
+	"fmt"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/opt"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
+)
+
+// inferType derives the type of the given scalar expression. Depending upon
+// the operator, the type may be fixed, or it may be dependent upon the
+// operands. inferType is called during initial construction of the expression,
+// so its logical properties are not yet available.
+func inferType(ev *ExprView) types.T {
+	fn := typingFuncMap[ev.Operator()]
+	if fn == nil {
+		panic(fmt.Sprintf("type inference for %v is not yet implemented", ev.Operator()))
+	}
+	return fn(ev)
+}
+
+type typingFunc func(ev *ExprView) types.T
+
+// typingFuncMap is a lookup table from scalar operator type to a function
+// which returns the data type of an instance of that operator.
+var typingFuncMap [opt.NumOperators]typingFunc
+
+func init() {
+	typingFuncMap = [opt.NumOperators]typingFunc{
+		opt.VariableOp:        typeVariable,
+		opt.ConstOp:           typeAsTypedExpr,
+		opt.TrueOp:            typeAsBool,
+		opt.FalseOp:           typeAsBool,
+		opt.PlaceholderOp:     typeAsTypedExpr,
+		opt.TupleOp:           typeAsTuple,
+		opt.ProjectionsOp:     typeAsTuple,
+		opt.FiltersOp:         typeAsBool,
+		opt.ExistsOp:          typeAsBool,
+		opt.AndOp:             typeAsBool,
+		opt.OrOp:              typeAsBool,
+		opt.NotOp:             typeAsBool,
+		opt.EqOp:              typeAsBool,
+		opt.LtOp:              typeAsBool,
+		opt.GtOp:              typeAsBool,
+		opt.LeOp:              typeAsBool,
+		opt.GeOp:              typeAsBool,
+		opt.NeOp:              typeAsBool,
+		opt.InOp:              typeAsBool,
+		opt.NotInOp:           typeAsBool,
+		opt.LikeOp:            typeAsBool,
+		opt.NotLikeOp:         typeAsBool,
+		opt.ILikeOp:           typeAsBool,
+		opt.NotILikeOp:        typeAsBool,
+		opt.SimilarToOp:       typeAsBool,
+		opt.NotSimilarToOp:    typeAsBool,
+		opt.RegMatchOp:        typeAsBool,
+		opt.NotRegMatchOp:     typeAsBool,
+		opt.RegIMatchOp:       typeAsBool,
+		opt.NotRegIMatchOp:    typeAsBool,
+		opt.IsOp:              typeAsBool,
+		opt.IsNotOp:           typeAsBool,
+		opt.AnyOp:             typeAsBool,
+		opt.SomeOp:            typeAsBool,
+		opt.AllOp:             typeAsBool,
+		opt.BitandOp:          typeAsBinary,
+		opt.BitorOp:           typeAsBinary,
+		opt.BitxorOp:          typeAsBinary,
+		opt.PlusOp:            typeAsBinary,
+		opt.MinusOp:           typeAsBinary,
+		opt.MultOp:            typeAsBinary,
+		opt.DivOp:             typeAsBinary,
+		opt.FloorDivOp:        typeAsBinary,
+		opt.ModOp:             typeAsBinary,
+		opt.PowOp:             typeAsBinary,
+		opt.ConcatOp:          typeAsBinary,
+		opt.LShiftOp:          typeAsBinary,
+		opt.RShiftOp:          typeAsBinary,
+		opt.FetchValOp:        typeAsBinary,
+		opt.FetchTextOp:       typeAsBinary,
+		opt.FetchValPathOp:    typeAsBinary,
+		opt.FetchTextPathOp:   typeAsBinary,
+		opt.UnaryPlusOp:       typeAsUnary,
+		opt.UnaryMinusOp:      typeAsUnary,
+		opt.UnaryComplementOp: typeAsUnary,
+	}
+}
+
+// typeVariable returns the type of a variable expression, which is stored in
+// the query metadata and acessed by column index.
+func typeVariable(ev *ExprView) types.T {
+	colIndex := ev.Private().(opt.ColumnIndex)
+	typ := ev.Metadata().ColumnType(colIndex)
+	if typ == nil {
+		panic(fmt.Sprintf("column %d does not have type", colIndex))
+	}
+	return typ
+}
+
+// typeAsBool returns the fixed boolean type.
+func typeAsBool(_ *ExprView) types.T {
+	return types.Bool
+}
+
+// typeAsTuple constructs a tuple type that is composed of the types of all the
+// expression's children.
+func typeAsTuple(ev *ExprView) types.T {
+	types := make(types.TTuple, ev.ChildCount())
+	for i := 0; i < ev.ChildCount(); i++ {
+		child := ev.Child(i)
+		types[i] = child.Logical().Scalar.Type
+	}
+	return types
+}
+
+// typeAsTypedExpr returns the resolved type of the private field, with the
+// assumption that it is a tree.TypedExpr.
+func typeAsTypedExpr(ev *ExprView) types.T {
+	return ev.Private().(tree.TypedExpr).ResolvedType()
+}
+
+// typeAsUnary returns the type of a unary expression by hooking into the sql
+// semantics code that searches for unary operator overloads.
+func typeAsUnary(ev *ExprView) types.T {
+	unaryOp := opt.UnaryOpReverseMap[ev.Operator()]
+
+	input := ev.Child(0)
+	inputType := input.Logical().Scalar.Type
+
+	// Find the unary op that matches the type of the expression's child.
+	for _, op := range tree.UnaryOps[unaryOp] {
+		o := op.(tree.UnaryOp)
+		if inputType.Equivalent(o.Typ) {
+			return o.ReturnType
+		}
+	}
+
+	panic(fmt.Sprintf("could not find type for unary expression: %v", ev))
+}
+
+// typeAsBinary returns the type of a binary expression by hooking into the sql
+// semantics code that searches for binary operator overloads.
+func typeAsBinary(ev *ExprView) types.T {
+	binOp := opt.BinaryOpReverseMap[ev.Operator()]
+
+	left := ev.Child(0)
+	leftType := left.Logical().Scalar.Type
+
+	right := ev.Child(1)
+	rightType := right.Logical().Scalar.Type
+
+	// Find the binary op that matches the type of the expression's left and
+	// right children.
+	for _, op := range tree.BinOps[binOp] {
+		o := op.(tree.BinOp)
+		if leftType.Equivalent(o.LeftType) && rightType.Equivalent(o.RightType) {
+			return o.ReturnType
+		}
+	}
+
+	panic(fmt.Sprintf("could not find type for binary expression: %v", ev))
+}

--- a/pkg/sql/opt/xform/typing_test.go
+++ b/pkg/sql/opt/xform/typing_test.go
@@ -1,0 +1,130 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package xform
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/build"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/opt"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/testutils"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/testutils/datadriven"
+	"github.com/cockroachdb/cockroach/pkg/sql/parser"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
+)
+
+func TestTyping(t *testing.T) {
+	datadriven.RunTest(t, "testdata/typing", func(d *datadriven.TestData) string {
+		// Only compile command supported.
+		if d.Cmd != "build" {
+			t.FailNow()
+		}
+
+		stmt, err := parser.ParseOne(d.Input)
+		if err != nil {
+			d.Fatalf(t, "%v", err)
+		}
+
+		o := NewOptimizer(createTypingCatalog(), 0 /* maxSteps */)
+		b := build.NewBuilder(context.Background(), o.Factory(), stmt)
+		root, props, err := b.Build()
+		if err != nil {
+			d.Fatalf(t, "%v", err)
+		}
+
+		ev := o.Optimize(root, props)
+		return ev.String()
+	})
+}
+
+func TestTypingTrueFalse(t *testing.T) {
+	o := NewOptimizer(createTypingCatalog(), 0 /* maxSteps */)
+	f := o.Factory()
+
+	// (True)
+	ev := o.Optimize(f.ConstructTrue(), &opt.PhysicalProps{})
+	testTyping(t, ev, types.Bool)
+
+	// (False)
+	ev = o.Optimize(f.ConstructFalse(), &opt.PhysicalProps{})
+	testTyping(t, ev, types.Bool)
+}
+
+func TestTypingJson(t *testing.T) {
+	o := NewOptimizer(createTypingCatalog(), 0 /* maxSteps */)
+	f := o.Factory()
+
+	// (Const <json>)
+	json, _ := tree.ParseDJSON("[1, 2]")
+	jsonGroup := f.ConstructConst(f.InternPrivate(json))
+
+	// (Const <int>)
+	intGroup := f.ConstructConst(f.InternPrivate(tree.NewDInt(1)))
+
+	// (Const <string-array>)
+	arrGroup := f.ConstructConst(f.InternPrivate(tree.NewDArray(types.String)))
+
+	// (FetchVal (Const <json>) (Const <int>))
+	fetchValGroup := f.ConstructFetchVal(jsonGroup, intGroup)
+	ev := o.Optimize(fetchValGroup, &opt.PhysicalProps{})
+	testTyping(t, ev, types.JSON)
+
+	// (FetchValPath (Const <json>) (Const <string-array>))
+	fetchValPathGroup := f.ConstructFetchValPath(jsonGroup, arrGroup)
+	ev = o.Optimize(fetchValPathGroup, &opt.PhysicalProps{})
+	testTyping(t, ev, types.JSON)
+
+	// (FetchText (Const <json>) (Const <int>))
+	fetchTextGroup := f.ConstructFetchText(jsonGroup, intGroup)
+	ev = o.Optimize(fetchTextGroup, &opt.PhysicalProps{})
+	testTyping(t, ev, types.String)
+
+	// (FetchTextPath (Const <json>) (Const <string-array>))
+	fetchTextPathGroup := f.ConstructFetchTextPath(jsonGroup, arrGroup)
+	ev = o.Optimize(fetchTextPathGroup, &opt.PhysicalProps{})
+	testTyping(t, ev, types.String)
+}
+
+func createTypingCatalog() *testutils.TestCatalog {
+	cat := testutils.NewTestCatalog()
+
+	// CREATE TABLE a (x INT PRIMARY KEY, y INT)
+	a := &testutils.TestTable{Name: "a"}
+	x := &testutils.TestColumn{Name: "x", Type: types.Int}
+	y := &testutils.TestColumn{Name: "y", Type: types.Int, Nullable: true}
+	a.Columns = append(a.Columns, x, y)
+	cat.AddTable(a)
+
+	// CREATE TABLE b (x NVARCHAR PRIMARY KEY, z DECIMAL NOT NULL)
+	b := &testutils.TestTable{Name: "b"}
+	x = &testutils.TestColumn{Name: "x", Type: types.String}
+	y = &testutils.TestColumn{Name: "z", Type: types.Decimal}
+	b.Columns = append(b.Columns, x, y)
+	cat.AddTable(b)
+
+	return cat
+}
+
+func testTyping(t *testing.T, ev ExprView, expected types.T) {
+	t.Helper()
+
+	actual := ev.Logical().Scalar.Type
+
+	if !actual.Equivalent(expected) {
+		t.Fatalf("\nexpected: %s\nactual  : %s", expected, actual)
+	}
+}


### PR DESCRIPTION
Add a Scalar field to the LogicalProps struct, containing a Type
field. Populate the type field when the logical properties are
constructed. A leaf expression gets its type from its private field.
A non-leaf expression infers its type from its children. These types
will be used to build the planner tree.