### PR TITLE
sql: Add information_schema.constraint_column_usage table

### DIFF
--- a/pkg/sql/information_schema.go
+++ b/pkg/sql/information_schema.go
@@ -40,6 +40,7 @@ var informationSchema = virtualSchema{
 		informationSchemaApplicableRoles,
 		informationSchemaColumnPrivileges,
 		informationSchemaColumnsTable,
+		informationSchemaConstraintColumnUsageTable,
 		informationSchemaEnabledRoles,
 		informationSchemaKeyColumnUsageTable,
 		informationSchemaReferentialConstraintsTable,
@@ -338,6 +339,59 @@ func numericScale(colType sqlbase.ColumnType) tree.Datum {
 func datetimePrecision(colType sqlbase.ColumnType) tree.Datum {
 	// We currently do not support a datetime precision.
 	return tree.DNull
+}
+
+// Postgres: https://www.postgresql.org/docs/9.6/static/infoschema-constraint-column-usage.html
+// MySQL:    missing
+var informationSchemaConstraintColumnUsageTable = virtualSchemaTable{
+	schema: `
+CREATE TABLE information_schema.constraint_column_usage (
+	TABLE_CATALOG STRING NOT NULL,
+	TABLE_SCHEMA STRING NOT NULL,
+	TABLE_NAME STRING NOT NULL,
+	COLUMN_NAME STRING NOT NULL,
+	CONSTRAINT_CATALOG STRING NOT NULL,
+	CONSTRAINT_SCHEMA STRING NOT NULL,
+	CONSTRAINT_NAME STRING NOT NULL
+);`,
+	populate: func(ctx context.Context, p *planner, prefix string, addRow func(...tree.Datum) error) error {
+		return forEachTableDescWithTableLookup(ctx, p, prefix, func(
+			db *sqlbase.DatabaseDescriptor,
+			table *sqlbase.TableDescriptor,
+			tableLookup tableLookupFn,
+		) error {
+			conInfo, err := table.GetConstraintInfoWithLookup(tableLookup.tableOrErr)
+			if err != nil {
+				return err
+			}
+
+			for conName, con := range conInfo {
+				conTable := table
+				conCols := con.Columns
+				if con.Kind == sqlbase.ConstraintTypeFK {
+					// For foreign key constraint, constraint_column_usage
+					// identifies the table/columns that the foreign key
+					// references.
+					conTable = con.ReferencedTable
+					conCols = con.ReferencedIndex.ColumnNames
+				}
+				for _, col := range conCols {
+					if err := addRow(
+						defString,                      // table_catalog
+						tree.NewDString(db.Name),       // table_schema
+						tree.NewDString(conTable.Name), // table_name
+						tree.NewDString(col),           // column_name
+						defString,                      // constraint_catalog
+						tree.NewDString(db.Name),       // constraint_schema
+						tree.NewDString(conName),       // constraint_name
+					); err != nil {
+						return err
+					}
+				}
+			}
+			return nil
+		})
+	},
 }
 
 // Postgres: https://www.postgresql.org/docs/9.6/static/infoschema-key-column-usage.html

--- a/pkg/sql/logictest/testdata/logic_test/explain
+++ b/pkg/sql/logictest/testdata/logic_test/explain
@@ -161,11 +161,11 @@ query TTT
 EXPLAIN SHOW TABLES
 ----
 sort                   ·      ·
- │                     order  +"Table"
- └── render            ·      ·
+│                     order  +"Table"
+└── render            ·      ·
       └── filter       ·      ·
-           └── values  ·      ·
-·                      size   5 columns, 93 rows
+            └── values  ·      ·
+·                      size   5 columns, 94 rows
 
 query TTT
 EXPLAIN SHOW DATABASE
@@ -211,21 +211,21 @@ query TTT
 EXPLAIN SHOW COLUMNS FROM foo
 ----
 sort                                       ·         ·
- │                                         order     +ordinal_position
- └── render                                ·         ·
+│                                         order     +ordinal_position
+└── render                                ·         ·
       └── group                            ·         ·
-           │                               group by  @1-@5
-           └── render                      ·         ·
-                └── join                   ·         ·
-                     │                     type      left outer
-                     │                     equality  (column_name) = (column_name)
-                     ├── render            ·         ·
-                     │    └── filter       ·         ·
-                     │         └── values  ·         ·
-                     │                     size      17 columns, 783 rows
-                     └── render            ·         ·
-                          └── filter       ·         ·
-                               └── values  ·         ·
+            │                               group by  @1-@5
+            └── render                      ·         ·
+                  └── join                   ·         ·
+                        │                     type      left outer
+                        │                     equality  (column_name) = (column_name)
+                        ├── render            ·         ·
+                        │    └── filter       ·         ·
+                        │         └── values  ·         ·
+                        │                     size      17 columns, 790 rows
+                        └── render            ·         ·
+                        └── filter       ·         ·
+                              └── values  ·         ·
 ·                                          size      13 columns, 37 rows
 
 query TTT

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -111,6 +111,7 @@ administrable_role_authorizations
 applicable_roles
 column_privileges
 columns
+constraint_column_usage
 enabled_roles
 key_column_usage
 referential_constraints
@@ -243,6 +244,7 @@ information_schema  administrable_role_authorizations
 information_schema  applicable_roles
 information_schema  column_privileges
 information_schema  columns
+information_schema  constraint_column_usage
 information_schema  enabled_roles
 information_schema  key_column_usage
 information_schema  referential_constraints
@@ -424,6 +426,7 @@ def            information_schema  administrable_role_authorizations  SYSTEM VIE
 def            information_schema  applicable_roles                   SYSTEM VIEW  1
 def            information_schema  column_privileges                  SYSTEM VIEW  1
 def            information_schema  columns                            SYSTEM VIEW  1
+def            information_schema  constraint_column_usage            SYSTEM VIEW  1
 def            information_schema  enabled_roles                      SYSTEM VIEW  1
 def            information_schema  key_column_usage                   SYSTEM VIEW  1
 def            information_schema  referential_constraints            SYSTEM VIEW  1
@@ -532,6 +535,7 @@ statement ok
 SET DATABASE = test
 
 ## information_schema.table_constraints
+## information_schema.constraint_column_usage
 
 query TTTTTTTTT colnames
 SELECT *
@@ -553,6 +557,36 @@ def                 system             primary          def            system   
 def                 system             primary          def            system        users             PRIMARY KEY      NO             NO
 def                 system             primary          def            system        web_sessions      PRIMARY KEY      NO             NO
 def                 system             primary          def            system        zones             PRIMARY KEY      NO             NO
+
+query TTTTTTT colnames
+SELECT *
+FROM information_schema.constraint_column_usage
+ORDER BY TABLE_NAME, COLUMN_NAME, CONSTRAINT_NAME
+----
+table_catalog  table_schema  table_name        column_name    constraint_catalog  constraint_schema  constraint_name
+def            system        descriptor        id             def                 system             primary
+def            system        eventlog          timestamp      def                 system             primary
+def            system        eventlog          uniqueID       def                 system             primary
+def            system        jobs              id             def                 system             primary
+def            system        lease             descID         def                 system             primary
+def            system        lease             expiration     def                 system             primary
+def            system        lease             nodeID         def                 system             primary
+def            system        lease             version        def                 system             primary
+def            system        locations         localityKey    def                 system             primary
+def            system        locations         localityValue  def                 system             primary
+def            system        namespace         name           def                 system             primary
+def            system        namespace         parentID       def                 system             primary
+def            system        rangelog          timestamp      def                 system             primary
+def            system        rangelog          uniqueID       def                 system             primary
+def            system        role_members      member         def                 system             primary
+def            system        role_members      role           def                 system             primary
+def            system        settings          name           def                 system             primary
+def            system        table_statistics  statisticID    def                 system             primary
+def            system        table_statistics  tableID        def                 system             primary
+def            system        ui                key            def                 system             primary
+def            system        users             username       def                 system             primary
+def            system        web_sessions      id             def                 system             primary
+def            system        zones             id             def                 system             primary
 
 statement ok
 CREATE DATABASE constraint_db
@@ -586,6 +620,19 @@ def                 constraint_db      check_a          def            constrain
 def                 constraint_db      primary          def            constraint_db  t1          PRIMARY KEY      NO             NO
 def                 constraint_db      t1_a_key         def            constraint_db  t1          UNIQUE           NO             NO
 def                 constraint_db      fk               def            constraint_db  t2          FOREIGN KEY      NO             NO
+
+query TTTTTTT colnames
+SELECT *
+FROM information_schema.constraint_column_usage
+WHERE constraint_schema = 'constraint_db'
+ORDER BY TABLE_NAME, COLUMN_NAME, CONSTRAINT_NAME
+----
+table_catalog  table_schema   table_name  column_name  constraint_catalog  constraint_schema  constraint_name
+def            constraint_db  t1          a            def                 constraint_db      c2
+def            constraint_db  t1          a            def                 constraint_db      check_a
+def            constraint_db  t1          a            def                 constraint_db      fk
+def            constraint_db  t1          a            def                 constraint_db      t1_a_key
+def            constraint_db  t1          p            def                 constraint_db      primary
 
 statement ok
 DROP DATABASE constraint_db CASCADE

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -632,7 +632,7 @@ ORDER BY con.oid
 conname    conislocal  coninhcount  connoinherit  conkey
 t1_a_key   true        0            true          {2}
 index_key  true        0            true          {3,4}
-check_b    true        0            true          NULL
+check_b    true        0            true          {2}
 primary    true        0            true          {1}
 fk         true        0            true          {1,2}
 fk         true        0            true          {1}

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -564,9 +564,9 @@ CREATE TABLE pg_catalog.pg_constraint (
 				case sqlbase.ConstraintTypeCheck:
 					oid = h.CheckConstraintOid(db, table, con.CheckConstraint)
 					contype = conTypeCheck
-					// TODO(nvanbenschoten): We currently do not store the referenced columns for a check
-					// constraint. We should add an array of column indexes to
-					// sqlbase.TableDescriptor_CheckConstraint and use that here.
+					if conkey, err = colIDArrayToDatum(con.CheckConstraint.ColumnIDs); err != nil {
+						return err
+					}
 					consrc = tree.NewDString(con.Details)
 					conbin = consrc
 					condef = tree.NewDString(fmt.Sprintf("CHECK (%s)", con.Details))


### PR DESCRIPTION
Related to #8675.
Related to #22298.

The `constraint_column_usage` table identifies all columns in the current
database that are used by some constraint.

Release note (sql change): Added constraint_column_usage table to the
information_schema.