### PR TITLE
cli: make the 'records' formatter more compatible with psql

### DIFF
--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -1343,7 +1343,7 @@ func Example_sql_table() {
 	// s | \foo
 	// d | printable ASCII with backslash
 	// -[ RECORD 4 ]
-	// s | foo
+	// s | foo+
 	//   | bar
 	// d | non-printable ASCII
 	// -[ RECORD 5 ]
@@ -1359,7 +1359,7 @@ func Example_sql_table() {
 	// s | ܈85
 	// d | UTF8 string with RTL char
 	// -[ RECORD 9 ]
-	// s | a	b	c
+	// s | a	b	c+
 	//   | 12	123123213	12313
 	// d | tabs
 	// sql --format=sql -e select * from t.t

--- a/pkg/cli/format_table.go
+++ b/pkg/cli/format_table.go
@@ -389,6 +389,10 @@ func (p *recordReporter) iter(w io.Writer, rowIdx int, row []string) error {
 			if l > 0 {
 				colLabel = ""
 			}
+			lineCont := "+"
+			if l == len(lines)-1 {
+				lineCont = ""
+			}
 			// Note: special characters, including a vertical bar, in
 			// the colLabel are not escaped here. This is in accordance
 			// with the same behavior in PostgreSQL. However there is
@@ -397,7 +401,7 @@ func (p *recordReporter) iter(w io.Writer, rowIdx int, row []string) error {
 			if len(p.colRest[j]) > 0 {
 				contChar = "+"
 			}
-			fmt.Fprintf(w, "%-*s%s| %s\n", p.maxColWidth, colLabel, contChar, line)
+			fmt.Fprintf(w, "%-*s%s| %s%s\n", p.maxColWidth, colLabel, contChar, line, lineCont)
 			for k, cont := range p.colRest[j] {
 				if k == len(p.colRest[j])-1 {
 					contChar = " "


### PR DESCRIPTION
Found while working on #22324.

CockroachDB's 'record' formatter reproduces the extended format from
`psql` (use `\x` in `psql` to enable).

This format ought to mark newline characters in both the column label
and the cell value with a `+` at the end of every line but the last.

This was already implemented in CockroachDB for the column label, but
incorrectly not for the cell value. This patch fixes that.

Release note (cli change): the table formatter `records` now properly
indicates line continuations in multi-line rows for better
compatibility with `psql`'s extended format.