### PR TITLE
cli/sql: print execution times any time output goes to a terminal

### DIFF
--- a/pkg/cli/interactive_tests/test_local_cmds.tcl
+++ b/pkg/cli/interactive_tests/test_local_cmds.tcl
@@ -95,7 +95,10 @@ eexpect root@
 end_test
 
 start_test "Check that \\set can change the display of query times"
-# by default, times are not displayed because we started with --display=tsv.
+# check the override
+send "\\unset show_times\r\\set\r"
+eexpect "show_times\tfalse"
+eexpect root@
 send "select 1;\r"
 eexpect "1 row"
 expect {
@@ -105,16 +108,9 @@ expect {
     }
     root@ {}
 }
-# check the override
-send "\\set show_times\r\\set\r"
-eexpect "show_times\ttrue"
-eexpect root@
-send "select 1;\r"
-eexpect "1 row"
-eexpect "Time:"
-eexpect root@
+eexpect "/> "
 # restore
-send "\\unset show_times\r"
+send "\\set show_times\r"
 end_test
 
 start_test "Check that \\h with invalid commands print a reminder."

--- a/pkg/cli/interactive_tests/test_pretty.tcl
+++ b/pkg/cli/interactive_tests/test_pretty.tcl
@@ -50,7 +50,8 @@ eexpect ":/# "
 send "$argv sql --format=tsv\r"
 eexpect root@
 send "select 42; select 1;\r"
-eexpect "42\r\n# 1 row\r\n1\r\n1\r\n# 1 row\r\n"
+eexpect "42\r\n# 1 row\r\n"
+eexpect "1\r\n1\r\n# 1 row\r\n"
 eexpect root@
 send "\\q\r"
 end_test

--- a/pkg/cli/sql.go
+++ b/pkg/cli/sql.go
@@ -1041,9 +1041,9 @@ func runInteractive(conn *sqlConn) (exitErr error) {
 		}
 		switch state {
 		case cliStart:
-			// If results are shown on a terminal and the table display
-			// format is "pretty", also enable printing of times.
-			if cliCtx.terminalOutput && cliCtx.tableDisplayFormat == tableDisplayPretty {
+			if cliCtx.terminalOutput {
+				// If results are shown on a terminal also enable printing of
+				// times by default.
 				cliCtx.showTimes = true
 			}
 


### PR DESCRIPTION
... not only when `display_format = pretty`.

Commit split away from #20835 to simplify review.

Release note (cli change): the client-side option `show_times` is now
always enabled when output goes to a terminal, not just when
`display_format` is set to `pretty`.