### PR TITLE
sql: support 'base64' and 'escape' args for encode/decode

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -595,9 +595,9 @@ Compatible elements: hour, minute, second, millisecond, microsecond.</p>
 <tr><td><code>concat_ws(<a href="string.html">string</a>...) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Uses the first argument as a separator between the concatenation of the subsequent arguments.</p>
 <p>For example <code>concat_ws('!','wow','great')</code> returns <code>wow!great</code>.</p>
 </span></td></tr>
-<tr><td><code>decode(text: <a href="string.html">string</a>, format: <a href="string.html">string</a>) &rarr; <a href="bytes.html">bytes</a></code></td><td><span class="funcdesc"><p>Decodes <code>data</code> as the format specified by <code>format</code> (only “hex” is supported).</p>
+<tr><td><code>decode(text: <a href="string.html">string</a>, format: <a href="string.html">string</a>) &rarr; <a href="bytes.html">bytes</a></code></td><td><span class="funcdesc"><p>Decodes <code>data</code> as the format specified by <code>format</code> (“hex”, “base64”, and “escape” are supported).</p>
 </span></td></tr>
-<tr><td><code>encode(data: <a href="bytes.html">bytes</a>, format: <a href="string.html">string</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Encodes <code>data</code> in the text format specified by <code>format</code> (only “hex” is supported).</p>
+<tr><td><code>encode(data: <a href="bytes.html">bytes</a>, format: <a href="string.html">string</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Encodes <code>data</code> in the text format specified by <code>format</code> (“hex”, “base64”, and “escape” are supported).</p>
 </span></td></tr>
 <tr><td><code>from_ip(val: <a href="bytes.html">bytes</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Converts the byte string representation of an IP to its character string representation.</p>
 </span></td></tr>

--- a/pkg/sql/logictest/testdata/logic_test/builtin_function
+++ b/pkg/sql/logictest/testdata/logic_test/builtin_function
@@ -1339,11 +1339,10 @@ SELECT array_upper(ARRAY[ARRAY[1, 2]], 2)
 ----
 2
 
-query error only 'hex' format is supported for ENCODE
-SELECT ENCODE('abc', 'escape')
-
-query error only 'hex' format is supported for DECODE
-SELECT DECODE('abc', 'escape')
+query TT
+SELECT ENCODE('abc', 'escape'), DECODE('abc', 'escape')
+----
+abc 616263
 
 query error invalid UTF-8
 SELECT ENCODE('\xa7', 'hex')
@@ -1352,6 +1351,17 @@ query TT
 SELECT ENCODE('abc', 'hex'), DECODE('616263', 'hex')
 ----
 616263 abc
+
+query TT
+SELECT ENCODE('abc', 'base64'), DECODE('YWJj', 'base64')
+----
+YWJj abc
+
+query error only 'hex', 'escape', and 'base64' formats are supported for ENCODE
+SELECT ENCODE('abc', 'fake')
+
+query error only 'hex', 'escape', and 'base64' formats are supported for DECODE
+SELECT DECODE('abc', 'fake')
 
 query T
 SELECT FROM_IP(b'\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xff\xff\x01\x02\x03\x04')

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -20,6 +20,7 @@ import (
 	"crypto/sha1"
 	"crypto/sha256"
 	"crypto/sha512"
+	"encoding/base64"
 	"encoding/hex"
 	"fmt"
 	"hash"
@@ -522,17 +523,24 @@ var Builtins = map[string][]tree.Builtin{
 			ReturnType: tree.FixedReturnType(types.String),
 			Fn: func(evalCtx *tree.EvalContext, args tree.Datums) (_ tree.Datum, err error) {
 				data, format := string(*args[0].(*tree.DBytes)), string(tree.MustBeDString(args[1]))
-				if format != "hex" {
-					return nil, pgerror.NewError(pgerror.CodeInvalidParameterValueError, "only 'hex' format is supported for ENCODE")
-				}
 				if !utf8.ValidString(data) {
 					return nil, pgerror.NewError(pgerror.CodeCharacterNotInRepertoireError, "invalid UTF-8 sequence")
 				}
-				var buf bytes.Buffer
-				lex.HexEncodeString(&buf, data)
-				return tree.NewDString(buf.String()), nil
+				switch format {
+				case "hex":
+					var buf bytes.Buffer
+					lex.HexEncodeString(&buf, data)
+					return tree.NewDString(buf.String()), nil
+				case "escape":
+					return tree.NewDString(data), nil
+				case "base64":
+					enc := base64.StdEncoding.EncodeToString([]byte(data))
+					return tree.NewDString(enc), nil
+				default:
+					return nil, pgerror.NewError(pgerror.CodeInvalidParameterValueError, "only 'hex', 'escape', and 'base64' formats are supported for ENCODE")
+				}
 			},
-			Info: "Encodes `data` in the text format specified by `format` (only \"hex\" is supported).",
+			Info: "Encodes `data` in the text format specified by `format` (\"hex\", \"base64\", and \"escape\" are supported).",
 		},
 	},
 
@@ -542,16 +550,28 @@ var Builtins = map[string][]tree.Builtin{
 			ReturnType: tree.FixedReturnType(types.Bytes),
 			Fn: func(evalCtx *tree.EvalContext, args tree.Datums) (_ tree.Datum, err error) {
 				data, format := string(tree.MustBeDString(args[0])), string(tree.MustBeDString(args[1]))
-				if format != "hex" {
-					return nil, pgerror.NewError(pgerror.CodeInvalidParameterValueError, "only 'hex' format is supported for DECODE")
+				switch format {
+				case "hex":
+					decoded, err := hex.DecodeString(data)
+					if err != nil {
+						return nil, err
+					}
+					return tree.NewDBytes(tree.DBytes(decoded)), nil
+				case "escape":
+					var buf bytes.Buffer
+					lex.HexEncodeString(&buf, data)
+					return tree.NewDBytes(tree.DBytes(buf.Bytes())), nil
+				case "base64":
+					dec, err := base64.StdEncoding.DecodeString(data)
+					if err != nil {
+						return nil, err
+					}
+					return tree.NewDBytes(tree.DBytes(dec)), nil
+				default:
+					return nil, pgerror.NewError(pgerror.CodeInvalidParameterValueError, "only 'hex', 'escape', and 'base64' formats are supported for DECODE")
 				}
-				decoded, err := hex.DecodeString(data)
-				if err != nil {
-					return nil, err
-				}
-				return tree.NewDBytes(tree.DBytes(decoded)), nil
 			},
-			Info: "Decodes `data` as the format specified by `format` (only \"hex\" is supported).",
+			Info: "Decodes `data` as the format specified by `format` (\"hex\", \"base64\", and \"escape\" are supported).",
 		},
 	},
 


### PR DESCRIPTION
Release note sql change: support 'base64' and 'escape' arugments for
encode/decode