### PR TITLE
sql: don't ignore job status update errors

### DIFF
--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -577,8 +577,7 @@ func (sc *SchemaChanger) backfillIndexes(
 		if details.ReadAsOf == (hlc.Timestamp{}) {
 			details.ReadAsOf = txn.OrigTimestamp()
 			if err := sc.job.WithTxn(txn).SetDetails(ctx, details); err != nil {
-				log.Warningf(ctx, "failed to store readAsOf on job %v after completing state machine: %v",
-					sc.job.ID(), err)
+				return errors.Wrapf(err, "failed to store readAsOf on job %d", *sc.job.ID())
 			}
 		}
 		sc.readAsOf = details.ReadAsOf

--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -626,8 +626,7 @@ func (sc *SchemaChanger) done(ctx context.Context, isRollback bool) (*sqlbase.De
 		return nil
 	}, func(txn *client.Txn) error {
 		if err := sc.job.WithTxn(txn).Succeeded(ctx, jobs.NoopFn); err != nil {
-			log.Warningf(ctx, "schema change ignoring error while marking job %d as successful: %+v",
-				*sc.job.ID(), err)
+			return errors.Wrapf(err, "failed to mark job %d as as successful", *sc.job.ID())
 		}
 
 		schemaChangeEventType := EventLogFinishSchemaChange

--- a/pkg/sql/table.go
+++ b/pkg/sql/table.go
@@ -713,7 +713,7 @@ func (p *planner) createSchemaChangeJob(
 	}
 	job := p.ExecCfg().JobRegistry.NewJob(jobRecord)
 	if err := job.WithTxn(p.txn).Created(ctx); err != nil {
-		return sqlbase.InvalidMutationID, nil
+		return sqlbase.InvalidMutationID, err
 	}
 	tableDesc.MutationJobs = append(tableDesc.MutationJobs, sqlbase.TableDescriptor_MutationJob{
 		MutationID: mutationID, JobID: *job.ID()})


### PR DESCRIPTION
Fixes #21828.
Fixes #21846.
Fixes #21844.
Fixes #21808.

See discussion in #21802.

We were previously ignoring the errors returned by job operations in
a few places. This meant that we would fail to propagate retryable txn
errors when using the jobs API and we could think a txn succeeded when
it didn't. This change fixes that.

In doing so, it makes schema changes fail when they see errors due to
job status updates. I don't see a compelling reason why the old behavior
was better and I suspect it was allowing subtle inconsistencies.

Release note: None