### PR TITLE
 workload/tpcc: port loadgen/tpcc to implement workload Ops

### DIFF
--- a/pkg/testutils/workload/tpcc/ddls.go
+++ b/pkg/testutils/workload/tpcc/ddls.go
@@ -63,7 +63,8 @@ const (
 		c_payment_cnt  integer,
 		c_delivery_cnt integer,
 		c_data         varchar(500),
-		primary key (c_w_id, c_d_id, c_id)
+		primary key (c_w_id, c_d_id, c_id),
+		index customer_idx (c_w_id, c_d_id, c_last, c_first)
 	)`
 	tpccCustomerSchemaInterleave = ` interleave in parent district (c_w_id, c_d_id)`
 	// No PK necessary for this table.
@@ -75,7 +76,9 @@ const (
 		h_w_id   integer,
 		h_date   timestamp,
 		h_amount decimal(6,2),
-		h_data   varchar(24)
+		h_data   varchar(24),
+		index (h_w_id, h_d_id),
+		index (h_c_w_id, h_c_d_id, h_c_id)
 	)`
 	tpccOrderSchema = `(
 		o_id         integer      not null,
@@ -86,7 +89,9 @@ const (
 		o_carrier_id integer,
 		o_ol_cnt     integer,
 		o_all_local  integer,
-		primary key (o_w_id, o_d_id, o_id DESC)
+		primary key (o_w_id, o_d_id, o_id DESC),
+		unique index order_idx (o_w_id, o_d_id, o_carrier_id, o_id),
+		index (o_w_id, o_d_id, o_c_id)
 	)`
 	tpccOrderSchemaInterleave = ` interleave in parent district (o_w_id, o_d_id)`
 	tpccNewOrderSchema        = `(
@@ -122,7 +127,8 @@ const (
 		s_order_cnt  integer,
 		s_remote_cnt integer,
 		s_data       varchar(50),
-		primary key (s_w_id, s_i_id)
+		primary key (s_w_id, s_i_id),
+		index (s_i_id)
 	)`
 	tpccStockSchemaInterleave = ` interleave in parent warehouse (s_w_id)`
 	tpccOrderLineSchema       = `(
@@ -136,7 +142,8 @@ const (
 		ol_quantity     integer,
 		ol_amount       decimal(6,2),
 		ol_dist_info    char(24),
-		primary key (ol_w_id, ol_d_id, ol_o_id DESC, ol_number)
+		primary key (ol_w_id, ol_d_id, ol_o_id DESC, ol_number),
+		index order_line_fk (ol_supply_w_id, ol_d_id)
 	)`
 	tpccOrderLineSchemaInterleave = ` interleave in parent "order" (ol_w_id, ol_d_id, ol_o_id)`
 )

--- a/pkg/testutils/workload/tpcc/delivery.go
+++ b/pkg/testutils/workload/tpcc/delivery.go
@@ -1,0 +1,134 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+
+package main
+
+import (
+	"database/sql"
+	"math/rand"
+	"time"
+
+	"context"
+
+	"github.com/cockroachdb/cockroach-go/crdb"
+)
+
+// 2.7 The Delivery Transaction
+
+// The Delivery business transaction consists of processing a batch of 10 new
+// (not yet delivered) orders. Each order is processed (delivered) in full
+// within the scope of a read-write database transaction. The number of orders
+// delivered as a group (or batched) within the same database transaction is
+// implementation specific. The business transaction, comprised of one or more
+// (up to 10) database transactions, has a low frequency of execution and must
+// complete within a relaxed response time requirement.
+
+// The Delivery transaction is intended to be executed in deferred mode through
+// a queuing mechanism, rather than interactively, with terminal response
+// indicating transaction completion. The result of the deferred execution is
+// recorded into a result file.
+
+type delivery struct{}
+
+var _ tpccTx = newOrder{}
+
+func (del delivery) run(db *sql.DB, wID int) (interface{}, error) {
+	oCarrierID := rand.Intn(10) + 1
+	olDeliveryD := time.Now()
+
+	if err := crdb.ExecuteTx(
+		context.Background(),
+		db,
+		&sql.TxOptions{Isolation: sql.LevelSerializable},
+		func(tx *sql.Tx) error {
+			getNewOrder, err := tx.Prepare(`
+			SELECT no_o_id
+			FROM new_order
+			WHERE no_w_id = $1 AND no_d_id = $2
+			ORDER BY no_o_id ASC
+			LIMIT 1`)
+			if err != nil {
+				return err
+			}
+			delNewOrder, err := tx.Prepare(`
+			DELETE FROM new_order
+			WHERE no_w_id = $1 AND no_d_id = $2 AND no_o_id = $3`)
+			if err != nil {
+				return err
+			}
+			updateOrder, err := tx.Prepare(`
+			UPDATE "order"
+			SET o_carrier_id = $1
+			WHERE o_w_id = $2 AND o_d_id = $3 AND o_id = $4
+			RETURNING o_c_id`)
+			if err != nil {
+				return err
+			}
+			updateOrderLine, err := tx.Prepare(`
+			UPDATE order_line
+			SET ol_delivery_d = $1
+			WHERE ol_w_id = $2 AND ol_d_id = $3 AND ol_o_id = $4`)
+			if err != nil {
+				return err
+			}
+			sumOrderLine, err := tx.Prepare(`
+			SELECT SUM(ol_amount) FROM order_line
+			WHERE ol_w_id = $1 AND ol_d_id = $2 AND ol_o_id = $3`)
+			if err != nil {
+				return err
+			}
+			updateCustomer, err := tx.Prepare(`
+			UPDATE customer
+			SET (c_balance, c_delivery_cnt) =
+				(c_Balance + $1, c_delivery_cnt + 1)
+			WHERE c_w_id = $2 AND c_d_id = $3 AND c_id = $4`)
+			if err != nil {
+				return err
+			}
+
+			// 2.7.4.2. For each district:
+			for dID := 1; dID <= 10; dID++ {
+				var oID int
+				if err := getNewOrder.QueryRow(wID, dID).Scan(&oID); err != nil {
+					// If no matching order is found, the delivery of this order is skipped.
+					if err != sql.ErrNoRows {
+						return err
+					}
+					continue
+				}
+				if _, err := delNewOrder.Exec(wID, dID, oID); err != nil {
+					return err
+				}
+				var oCID int
+				if err := updateOrder.QueryRow(oCarrierID, wID, dID, oID).Scan(&oCID); err != nil {
+					return err
+				}
+				if _, err := updateOrderLine.Exec(olDeliveryD, wID, dID, oID); err != nil {
+					return err
+				}
+				var olTotal float64
+				if err := sumOrderLine.QueryRow(wID, dID, oID).Scan(&olTotal); err != nil {
+					return err
+				}
+				if _, err := updateCustomer.Exec(olTotal, wID, dID, oID); err != nil {
+					return err
+				}
+			}
+			return nil
+		}); err != nil {
+		return nil, err
+	}
+	return nil, nil
+}

--- a/pkg/testutils/workload/tpcc/generate.go
+++ b/pkg/testutils/workload/tpcc/generate.go
@@ -41,7 +41,8 @@ const (
 	hackOrderLinesPerWarehouse = hackOrderLinesPerDistrict * numDistrictsPerWarehouse
 
 	originalString = "ORIGINAL"
-	ytd            = 30000.00 // also used by warehouse
+	wYtd           = 300000.00
+	ytd            = 30000.00
 	nextOrderID    = 3001
 	creditLimit    = 50000.00
 	balance        = -10.00
@@ -81,7 +82,7 @@ func (w *tpcc) tpccWarehouseInitialRow(rowIdx int) []interface{} {
 		randState(rng),
 		randZip(rng),
 		randTax(rng),
-		ytd,
+		wYtd,
 	}
 }
 
@@ -89,7 +90,7 @@ func (w *tpcc) tpccStockInitialRow(rowIdx int) []interface{} {
 	rng := rand.New(rand.NewSource(w.seed + int64(rowIdx)))
 
 	sID := (rowIdx % numStockPerWarehouse) + 1
-	wID := (rowIdx / numStockPerWarehouse) + 1
+	wID := (rowIdx / numStockPerWarehouse)
 
 	return []interface{}{
 		sID, wID,
@@ -115,7 +116,7 @@ func (w *tpcc) tpccDistrictInitialRow(rowIdx int) []interface{} {
 	rng := rand.New(rand.NewSource(w.seed + int64(rowIdx)))
 
 	dID := (rowIdx % numDistrictsPerWarehouse) + 1
-	wID := (rowIdx / numDistrictsPerWarehouse) + 1
+	wID := (rowIdx / numDistrictsPerWarehouse)
 
 	return []interface{}{
 		dID,
@@ -136,8 +137,8 @@ func (w *tpcc) tpccCustomerInitialRow(rowIdx int) []interface{} {
 	rng := rand.New(rand.NewSource(w.seed + int64(rowIdx)))
 
 	cID := (rowIdx % numCustomersPerDistrict) + 1
-	dID := (rowIdx / numCustomersPerDistrict) + 1
-	wID := (rowIdx / numCustomersPerWarehouse) + 1
+	dID := ((rowIdx / numCustomersPerDistrict) % numDistrictsPerWarehouse) + 1
+	wID := (rowIdx / numCustomersPerWarehouse)
 
 	// 10% of the customer rows have bad credit.
 	// See section 4.3, under the CUSTOMER table population section.
@@ -182,8 +183,8 @@ func (w *tpcc) tpccHistoryInitialRow(rowIdx int) []interface{} {
 	rng := rand.New(rand.NewSource(w.seed + int64(rowIdx)))
 
 	cID := (rowIdx % numCustomersPerDistrict) + 1
-	dID := (rowIdx / numCustomersPerDistrict) + 1
-	wID := (rowIdx / numCustomersPerWarehouse) + 1
+	dID := ((rowIdx / numCustomersPerDistrict) % numDistrictsPerWarehouse) + 1
+	wID := (rowIdx / numCustomersPerWarehouse)
 
 	return []interface{}{
 		cID, dID, wID, dID, wID, w.nowString, 10.00, randAString(rng, 12, 24),
@@ -194,8 +195,8 @@ func (w *tpcc) tpccOrderInitialRow(rowIdx int) []interface{} {
 	rng := rand.New(rand.NewSource(w.seed + int64(rowIdx)))
 
 	oID := (rowIdx % numOrdersPerDistrict) + 1
-	dID := (rowIdx / numOrdersPerDistrict) + 1
-	wID := (rowIdx / numOrdersPerWarehouse) + 1
+	dID := ((rowIdx / numOrdersPerDistrict) % numDistrictsPerWarehouse) + 1
+	wID := (rowIdx / numOrdersPerWarehouse)
 
 	// We need a random permutation of customers that stable for all orders in a
 	// district, so use the district ID to seed the random permuation.
@@ -223,8 +224,8 @@ func (w *tpcc) tpccNewOrderInitialRow(rowIdx int) []interface{} {
 	// The last numNewOrdersPerDistrict orders have entries in new orders.
 	const firstNewOrderOffset = numOrdersPerDistrict - numNewOrdersPerDistrict
 	oID := (rowIdx % numNewOrdersPerDistrict) + firstNewOrderOffset + 1
-	dID := (rowIdx / numNewOrdersPerDistrict) + 1
-	wID := (rowIdx / numNewOrdersPerWarehouse) + 1
+	dID := ((rowIdx / numNewOrdersPerDistrict) % numDistrictsPerWarehouse) + 1
+	wID := (rowIdx / numNewOrdersPerWarehouse)
 
 	return []interface{}{
 		oID, dID, wID,
@@ -235,9 +236,9 @@ func (w *tpcc) tpccOrderLineInitialRow(rowIdx int) []interface{} {
 	rng := rand.New(rand.NewSource(w.seed + int64(rowIdx)))
 
 	olNumber := (rowIdx % hackOrderLinesPerOrder) + 1
-	oID := (rowIdx / hackOrderLinesPerOrder) + 1
-	dID := (rowIdx / hackOrderLinesPerDistrict) + 1
-	wID := (rowIdx / hackOrderLinesPerWarehouse) + 1
+	oID := ((rowIdx / hackOrderLinesPerOrder) % numOrdersPerDistrict) + 1
+	dID := ((rowIdx / hackOrderLinesPerDistrict) % numDistrictsPerWarehouse) + 1
+	wID := (rowIdx / hackOrderLinesPerWarehouse)
 
 	var amount float64
 	var deliveryD interface{}

--- a/pkg/testutils/workload/tpcc/new_order.go
+++ b/pkg/testutils/workload/tpcc/new_order.go
@@ -1,0 +1,249 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+
+package main
+
+import (
+	"database/sql"
+	"fmt"
+	"math/rand"
+	"strings"
+	"time"
+
+	"context"
+
+	"github.com/cockroachdb/cockroach-go/crdb"
+	"github.com/lib/pq"
+	"github.com/pkg/errors"
+)
+
+// From the TPCC spec, section 2.4:
+//
+// The New-Order business transaction consists of entering a complete order
+// through a single database transaction. It represents a mid-weight, read-write
+// transaction with a high frequency of execution and stringent response time
+// requirements to satisfy on-line users. This transaction is the backbone of
+// the workload. It is designed to place a variable load on the system to
+// reflect on-line database activity as typically found in production
+// environments.
+
+type orderItem struct {
+	olSupplyWID  int    // supplying warehouse id
+	olIID        int    // item id
+	iName        string // item name
+	olQuantity   int    // order quantity
+	sQuantity    int    // stock quantity
+	brandGeneric string
+	iPrice       float64 // item price
+	olAmount     float64 // order amount
+	olDeliveryD  pq.NullTime
+
+	remoteWarehouse bool // internal use - item from a local or remote warehouse?
+}
+
+type newOrderData struct {
+	// This data must all be returned by the transaction. See 2.4.3.3.
+	wID         int // home warehouse ID
+	dID         int // district id
+	cID         int // customer id
+	oID         int // order id
+	oOlCnt      int // order line count
+	cLast       string
+	cCredit     string
+	cDiscount   float64
+	wTax        float64
+	dTax        float64
+	oEntryD     time.Time
+	totalAmount float64
+
+	items []orderItem
+}
+
+var errSimulated = errors.New("simulated user error")
+
+type newOrder struct{}
+
+var _ tpccTx = newOrder{}
+
+func (n newOrder) run(db *sql.DB, wID int) (interface{}, error) {
+	d := newOrderData{
+		wID:    wID,
+		dID:    randInt(1, 10),
+		cID:    randCustomerID(),
+		oOlCnt: randInt(5, 15),
+	}
+	d.items = make([]orderItem, d.oOlCnt)
+
+	// 2.4.1.4: A fixed 1% of the New-Order transactions are chosen at random to
+	// simulate user data entry errors and exercise the performance of rolling
+	// back update transactions.
+	rollback := rand.Intn(100) == 0
+
+	// allLocal tracks whether any of the items were from a remote warehouse.
+	allLocal := 1
+	for i := 0; i < d.oOlCnt; i++ {
+		item := orderItem{
+			// 2.4.1.5.3: order has a quantity [1..10]
+			olQuantity: rand.Intn(10) + 1,
+		}
+		// 2.4.1.5.1 an order item has a random item number, unless rollback is true
+		// and it's the last item in the items list.
+		if rollback && i == d.oOlCnt-1 {
+			item.olIID = -1
+		} else {
+			item.olIID = randItemID()
+		}
+		// 2.4.1.5.2: 1% of the time, an item is supplied from a remote warehouse.
+		item.remoteWarehouse = rand.Intn(100) == 0
+		if item.remoteWarehouse {
+			allLocal = 0
+			item.olSupplyWID = rand.Intn(*warehouses)
+		} else {
+			item.olSupplyWID = wID
+		}
+		d.items[i] = item
+	}
+
+	d.oEntryD = time.Now()
+
+	err := crdb.ExecuteTx(
+		context.Background(),
+		db,
+		&sql.TxOptions{Isolation: sql.LevelSerializable},
+		func(tx *sql.Tx) error {
+			// Select the warehouse tax rate.
+			if err := tx.QueryRow(
+				`SELECT w_tax FROM warehouse WHERE w_id = $1`,
+				wID,
+			).Scan(&d.wTax); err != nil {
+				return err
+			}
+
+			// Select the district tax rate and next available order number, bumping it.
+			var dNextOID int
+			if err := tx.QueryRow(`
+				UPDATE district
+				SET d_next_o_id = d_next_o_id + 1
+				WHERE d_w_id = $1 AND d_id = $2
+				RETURNING d_tax, d_next_o_id`,
+				d.wID, d.dID,
+			).Scan(&d.dTax, &dNextOID); err != nil {
+				return err
+			}
+
+			d.oID = dNextOID - 1
+
+			// Select the customer's discount, last name and credit.
+			if err := tx.QueryRow(`
+				SELECT c_discount, c_last, c_credit
+				FROM customer
+				WHERE c_w_id = $1 AND c_d_id = $2 AND c_id = $3`,
+				d.wID, d.dID, d.cID,
+			).Scan(&d.cDiscount, &d.cLast, &d.cCredit); err != nil {
+				return err
+			}
+
+			// Insert row into the orders and new orders table.
+			if _, err := tx.Exec(`
+				INSERT INTO "order" (o_id, o_d_id, o_w_id, o_c_id, o_entry_d, o_ol_cnt, o_all_local)
+				VALUES ($1, $2, $3, $4, $5, $6, $7)`,
+				d.oID, d.dID, d.wID, d.cID, d.oEntryD, d.oOlCnt, allLocal); err != nil {
+				return err
+			}
+			if _, err := tx.Exec(`
+				INSERT INTO new_order (no_o_id, no_d_id, no_w_id) 
+				VALUES ($1, $2, $3)`,
+				d.oID, d.dID, d.wID); err != nil {
+				return err
+			}
+
+			selectItem, err := tx.Prepare(`SELECT i_price, i_name, i_data FROM item WHERE i_id=$1`)
+			if err != nil {
+				return err
+			}
+			updateStock, err := tx.Prepare(fmt.Sprintf(`
+			UPDATE stock
+			SET (s_quantity, s_ytd, s_order_cnt, s_remote_cnt) =
+				(CASE s_quantity >= $1 + 10 WHEN true THEN s_quantity-$1 ELSE (s_quantity-$1)+91 END,
+				 s_ytd + $1,
+				 s_order_cnt + 1,
+				 s_remote_cnt + (CASE $2::bool WHEN true THEN 1 ELSE 0 END))
+			WHERE s_i_id=$3 AND s_w_id=$4
+			RETURNING s_dist_%02d, s_data`, d.dID))
+			if err != nil {
+				return err
+			}
+			insertOrderLine, err := tx.Prepare(`
+			INSERT INTO order_line(ol_o_id, ol_d_id, ol_w_id, ol_number, ol_i_id, ol_supply_w_id, ol_quantity, ol_amount, ol_dist_info)
+			VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)`)
+			if err != nil {
+				return err
+			}
+
+			var iData string
+			// 2.4.2.2: For each o_ol_cnt item in the order, query the relevant item
+			// row, update the stock row to account for the order, and insert a new
+			// line into the order_line table to reflect the item on the order.
+			for i, item := range d.items {
+				if err := selectItem.QueryRow(item.olIID).Scan(&item.iPrice, &item.iName, &iData); err != nil {
+					if rollback && item.olIID < 0 {
+						// 2.4.2.3: roll back when we're expecting a rollback due to
+						// simulated user error (invalid item id) and we actually
+						// can't find the item. The spec requires us to actually go
+						// to the database for this, even though we know earlier
+						// that the item has an invalid number.
+						return errSimulated
+					}
+					return err
+				}
+
+				var distInfo, sData string
+				if err := updateStock.QueryRow(
+					item.olQuantity, item.remoteWarehouse, item.olIID, item.olSupplyWID,
+				).Scan(&distInfo, &sData); err != nil {
+					return err
+				}
+				if strings.Contains(sData, originalString) && strings.Contains(iData, originalString) {
+					item.brandGeneric = "B"
+				} else {
+					item.brandGeneric = "G"
+				}
+
+				item.olAmount = float64(item.olQuantity) * item.iPrice
+				d.totalAmount += item.olAmount
+				if _, err := insertOrderLine.Exec(
+					d.oID, // ol_o_id
+					d.dID,
+					d.wID,
+					i+1, // ol_number is a counter over the items in the order.
+					item.olIID,
+					item.olSupplyWID,
+					item.olQuantity,
+					item.olAmount,
+					distInfo, // ol_dist_info is set to the contents of s_dist_xx
+				); err != nil {
+					return err
+				}
+			}
+			// 2.4.2.2: total_amount = sum(OL_AMOUNT) * (1 - C_DISCOUNT) * (1 + W_TAX + D_TAX)
+			d.totalAmount *= (1 - d.cDiscount) * (1 + d.wTax + d.dTax)
+
+			return nil
+		})
+	if err == errSimulated {
+		return d, nil
+	}
+	return d, err
+}

--- a/pkg/testutils/workload/tpcc/order_status.go
+++ b/pkg/testutils/workload/tpcc/order_status.go
@@ -1,0 +1,166 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+
+package main
+
+import (
+	"database/sql"
+	"math/rand"
+	"time"
+
+	"github.com/pkg/errors"
+
+	"context"
+
+	"github.com/cockroachdb/cockroach-go/crdb"
+)
+
+// From the TPCC spec, section 2.6:
+//
+// The Order-Status business transaction queries the status of a customer's last
+// order. It represents a mid-weight read-only database transaction with a low
+// frequency of execution and response time requirement to satisfy on-line
+// users. In addition, this table includes non-primary key access to the
+// CUSTOMER table.
+
+type orderStatusData struct {
+	// Return data specified by 2.6.3.3
+	dID        int
+	cID        int
+	cFirst     string
+	cMiddle    string
+	cLast      string
+	cBalance   float64
+	oID        int
+	oEntryD    time.Time
+	oCarrierID sql.NullInt64
+
+	items []orderItem
+}
+
+type customerData struct {
+	cID      int
+	cBalance float64
+	cFirst   string
+	cMiddle  string
+}
+
+type orderStatus struct{}
+
+var _ tpccTx = orderStatus{}
+
+func (o orderStatus) run(db *sql.DB, wID int) (interface{}, error) {
+	d := orderStatusData{
+		dID: rand.Intn(9) + 1,
+	}
+
+	// 2.6.1.2: The customer is randomly selected 60% of the time by last name
+	// and 40% by number.
+	if rand.Intn(9) < 6 {
+		d.cLast = randCLast()
+	} else {
+		d.cID = randCustomerID()
+	}
+
+	if err := crdb.ExecuteTx(
+		context.Background(),
+		db,
+		&sql.TxOptions{Isolation: sql.LevelSerializable},
+		func(tx *sql.Tx) error {
+			// 2.6.2.2 explains this entire transaction.
+
+			// Select the customer
+			if d.cID != 0 {
+				// Case 1: select by customer id
+				if err := tx.QueryRow(`
+					SELECT c_balance, c_first, c_middle, c_last
+					FROM customer
+					WHERE c_w_id = $1 AND c_d_id = $2 AND c_id = $3`,
+					wID, d.dID, d.cID,
+				).Scan(&d.cBalance, &d.cFirst, &d.cMiddle, &d.cLast); err != nil {
+					return errors.Wrap(err, "select by customer idfail")
+				}
+			} else {
+				// Case 2: Pick the middle row, rounded up, from the selection by last name.
+				rows, err := tx.Query(`
+					SELECT c_id, c_balance, c_first, c_middle
+					FROM customer@customer_idx
+					WHERE c_w_id = $1 AND c_d_id = $2 AND c_last = $3
+					ORDER BY c_first ASC`,
+					wID, d.dID, d.cLast)
+				if err != nil {
+					return errors.Wrap(err, "select by last name fail")
+				}
+				customers := make([]customerData, 0, 1)
+				for rows.Next() {
+					c := customerData{}
+					err = rows.Scan(&c.cID, &c.cBalance, &c.cFirst, &c.cMiddle)
+					if err != nil {
+						rows.Close()
+						return err
+					}
+					customers = append(customers, c)
+				}
+				rows.Close()
+				cIdx := len(customers) / 2
+				if len(customers)%2 == 0 {
+					cIdx--
+				}
+
+				c := customers[cIdx]
+				d.cID = c.cID
+				d.cBalance = c.cBalance
+				d.cFirst = c.cFirst
+				d.cMiddle = c.cMiddle
+			}
+
+			// Select the customer's order.
+			if err := tx.QueryRow(`
+				SELECT o_id, o_entry_d, o_carrier_id
+				FROM "order"
+				WHERE o_w_id = $1 AND o_d_id = $2 AND o_c_id = $3
+				ORDER BY o_id DESC
+				LIMIT 1`,
+				wID, d.dID, d.cID,
+			).Scan(&d.oID, &d.oEntryD, &d.oCarrierID); err != nil {
+				return errors.Wrap(err, "select order fail")
+			}
+
+			// Select the items from the customer's order.
+			rows, err := tx.Query(`
+				SELECT ol_i_id, ol_supply_w_id, ol_quantity, ol_amount, ol_delivery_d
+				FROM order_line
+				WHERE ol_w_id = $1 AND ol_d_id = $2 AND ol_o_id = $3`,
+				wID, d.dID, d.oID)
+			if err != nil {
+				return errors.Wrap(err, "select items fail")
+			}
+			defer rows.Close()
+
+			// On average there's 10 items per order - 2.4.1.3
+			d.items = make([]orderItem, 0, 10)
+			for rows.Next() {
+				item := orderItem{}
+				if err := rows.Scan(&item.olIID, &item.olSupplyWID, &item.olQuantity, &item.olAmount, &item.olDeliveryD); err != nil {
+					return err
+				}
+				d.items = append(d.items, item)
+			}
+			return nil
+		}); err != nil {
+		return nil, err
+	}
+	return d, nil
+}

--- a/pkg/testutils/workload/tpcc/payment.go
+++ b/pkg/testutils/workload/tpcc/payment.go
@@ -1,0 +1,209 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+
+package main
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"math/rand"
+	"time"
+
+	"github.com/cockroachdb/cockroach-go/crdb"
+	"github.com/pkg/errors"
+)
+
+// Section 2.5:
+//
+// The Payment business transaction updates the customer's balance and reflects
+// the payment on the district and warehouse sales statistics. It represents a
+// light-weight, read-write transaction with a high frequency of execution and
+// stringent response time requirements to satisfy on-line users. In addition,
+// this transaction includes non-primary key access to the CUSTOMER table.
+
+type paymentData struct {
+	// This data must all be returned by the transaction. See 2.5.3.4.
+	dID  int
+	cID  int
+	cDID int
+	cWID int
+
+	wStreet1 string
+	wStreet2 string
+	wCity    string
+	wState   string
+	wZip     string
+
+	dStreet1 string
+	dStreet2 string
+	dCity    string
+	dState   string
+	dZip     string
+
+	cFirst     string
+	cMiddle    string
+	cLast      string
+	cStreet1   string
+	cStreet2   string
+	cCity      string
+	cState     string
+	cZip       string
+	cPhone     string
+	cSince     time.Time
+	cCredit    string
+	cCreditLim float64
+	cDiscount  float64
+	cBalance   float64
+	cData      string
+
+	hAmount float64
+	hDate   time.Time
+}
+
+type payment struct{}
+
+var _ tpccTx = payment{}
+
+func (p payment) run(db *sql.DB, wID int) (interface{}, error) {
+	d := paymentData{
+		dID: rand.Intn(10) + 1,
+		// hAmount is randomly selected within [1.00..5000.00]
+		hAmount: float64(randInt(100, 500000)) / float64(100.0),
+		hDate:   time.Now(),
+	}
+
+	// 2.5.1.2: 85% chance of paying through home warehouse, otherwise
+	// remote.
+	if rand.Intn(100) < 85 {
+		d.cWID = wID
+		d.cDID = d.dID
+	} else {
+		d.cWID = rand.Intn(*warehouses)
+		// Find a cWID != w_id if there's more than 1 configured warehouse.
+		for d.cWID == wID && *warehouses > 1 {
+			d.cWID = rand.Intn(*warehouses)
+		}
+		d.cDID = rand.Intn(10) + 1
+	}
+
+	// 2.5.1.2: The customer is randomly selected 60% of the time by last name
+	// and 40% by number.
+	if rand.Intn(9) < 6 {
+		d.cLast = randCLast()
+	} else {
+		d.cID = randCustomerID()
+	}
+
+	if err := crdb.ExecuteTx(
+		context.Background(),
+		db,
+		&sql.TxOptions{Isolation: sql.LevelSerializable},
+		func(tx *sql.Tx) error {
+			var wName, dName string
+			// Update warehouse with payment
+			if err := tx.QueryRow(`
+				UPDATE warehouse
+				SET w_ytd = w_ytd + $1
+				WHERE w_id = $2
+				RETURNING w_name, w_street_1, w_street_2, w_city, w_state, w_zip`,
+				d.hAmount, wID,
+			).Scan(&wName, &d.wStreet1, &d.wStreet2, &d.wCity, &d.wState, &d.wZip); err != nil {
+				return err
+			}
+
+			// Update district with payment
+			if err := tx.QueryRow(`
+				UPDATE district
+				SET d_ytd = d_ytd + $1
+				WHERE d_w_id = $2 AND d_id = $3
+				RETURNING d_name, d_street_1, d_street_2, d_city, d_state, d_zip`,
+				d.hAmount, wID, d.dID,
+			).Scan(&dName, &d.dStreet1, &d.dStreet2, &d.dCity, &d.dState, &d.dZip); err != nil {
+				return err
+			}
+
+			// If we are selecting by last name, first find the relevant customer id and
+			// then proceed.
+			if d.cID == 0 {
+				// 2.5.2.2 Case 2: Pick the middle row, rounded up, from the selection by last name.
+				rows, err := tx.Query(`
+					SELECT c_id
+					FROM customer@customer_idx
+					WHERE c_w_id = $1 AND c_d_id = $2 AND c_last = $3
+					ORDER BY c_first ASC`,
+					wID, d.dID, d.cLast)
+				if err != nil {
+					return errors.Wrap(err, "select by last name fail")
+				}
+				customers := make([]int, 0, 1)
+				for rows.Next() {
+					var cID int
+					err = rows.Scan(&cID)
+					if err != nil {
+						rows.Close()
+						return err
+					}
+					customers = append(customers, cID)
+				}
+				rows.Close()
+				cIdx := len(customers) / 2
+				if len(customers)%2 == 0 {
+					cIdx--
+				}
+
+				d.cID = customers[cIdx]
+			}
+
+			// Update customer with payment.
+			if err := tx.QueryRow(`
+				UPDATE customer
+				SET (c_balance, c_ytd_payment, c_payment_cnt) =
+					(c_balance - $1, c_ytd_payment + $1, c_payment_cnt + 1)
+				WHERE c_w_id = $2 AND c_d_id = $3 AND c_id = $4
+				RETURNING c_first, c_middle, c_last, c_street_1, c_street_2,
+						  c_city, c_state, c_zip, c_phone, c_since, c_credit,
+						  c_credit_lim, c_discount, c_balance`,
+				d.hAmount, d.cWID, d.cDID, d.cID,
+			).Scan(&d.cFirst, &d.cMiddle, &d.cLast, &d.cStreet1, &d.cStreet2,
+				&d.cCity, &d.cState, &d.cZip, &d.cPhone, &d.cSince, &d.cCredit,
+				&d.cCreditLim, &d.cDiscount, &d.cBalance,
+			); err != nil {
+				return errors.Wrap(err, "select by customer idfail")
+			}
+
+			if d.cCredit == "BC" {
+				// If the customer has bad credit, update the customer's C_DATA.
+				d.cData = fmt.Sprintf("%d %d %d %d %d %f | %s", d.cID, d.cDID, d.cWID, d.dID, wID, d.hAmount, d.cData)
+				if len(d.cData) > 500 {
+					d.cData = d.cData[0:500]
+				}
+			}
+			hData := fmt.Sprintf("%s    %s", wName, dName)
+
+			// Insert history line.
+			if _, err := tx.Exec(`
+				INSERT INTO history (h_c_id, h_c_d_id, h_c_w_id, h_d_id, h_w_id, h_data)
+				VALUES ($1, $2, $3, $4, $5, $6)`,
+				d.cID, d.cDID, d.cWID, d.dID, wID, hData,
+			); err != nil {
+				return err
+			}
+			return nil
+		}); err != nil {
+		return nil, err
+	}
+	return d, nil
+}

--- a/pkg/testutils/workload/tpcc/random.go
+++ b/pkg/testutils/workload/tpcc/random.go
@@ -123,3 +123,13 @@ func randCLastSyllables(n int) string {
 func randCLast(rng *rand.Rand) string {
 	return randCLastSyllables(((rng.Intn(256) | rng.Intn(1000)) + cLoad) % 1000)
 }
+
+// Return a non-uniform random customer ID. See 2.1.6.
+func randCustomerID(rng *rand.Rand) int {
+	return ((rng.Intn(1024) | (rng.Intn(3000) + 1) + cCustomerID) % 3000) + 1
+}
+
+// Return a non-uniform random item ID. See 2.1.6.
+func randItemID(rng *rand.Rand) int {
+	return ((rng.Intn(8190) | (rng.Intn(100000) + 1) + cItemID) % 100000) + 1
+}

--- a/pkg/testutils/workload/tpcc/stock_level.go
+++ b/pkg/testutils/workload/tpcc/stock_level.go
@@ -1,0 +1,96 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+
+package main
+
+import (
+	"database/sql"
+	"math/rand"
+
+	"context"
+
+	"github.com/cockroachdb/cockroach-go/crdb"
+)
+
+// 2.8 The Stock-Level Transaction
+//
+// The Stock-Level business transaction determines the number of recently sold
+// items that have a stock level below a specified threshold. It represents a
+// heavy read-only database transaction with a low frequency of execution, a
+// relaxed response time requirement, and relaxed consistency requirements.
+
+// 2.8.2.3 states:
+// Full serializability and repeatable reads are not required for the
+// Stock-Level business transaction. All data read must be committed and no
+// older than the most recently committed data prior to the time this business
+// transaction was initiated. All other ACID properties must be maintained.
+// TODO(jordan): can we take advantage of this?
+
+type stockLevelData struct {
+	// This data must all be returned by the transaction. See 2.8.3.4.
+	dID       int
+	threshold int
+	lowStock  int
+}
+
+type stockLevel struct{}
+
+var _ tpccTx = stockLevel{}
+
+func (s stockLevel) run(db *sql.DB, wID int) (interface{}, error) {
+	// 2.8.1.2: The threshold of minimum quantity in stock is selected at random
+	// within [10..20].
+	d := stockLevelData{
+		threshold: randInt(10, 20),
+		dID:       rand.Intn(9) + 1,
+	}
+
+	if err := crdb.ExecuteTx(
+		context.Background(),
+		db,
+		&sql.TxOptions{Isolation: sql.LevelSerializable},
+		func(tx *sql.Tx) error {
+			var dNextOID int
+			if err := tx.QueryRow(`
+				SELECT d_next_o_id
+				FROM district
+				WHERE d_w_id = $1 AND d_id = $2`,
+				wID, d.dID,
+			).Scan(&dNextOID); err != nil {
+				return err
+			}
+
+			// Count the number of recently sold items that have a stock level below
+			// the threshold.
+			if err := tx.QueryRow(`
+				SELECT COUNT(DISTINCT(s_i_id))
+				FROM order_line
+				JOIN stock
+				ON s_i_id=ol_i_id
+				WHERE ol_w_id = $1
+				  AND ol_d_id = $2
+				  AND ol_o_id BETWEEN $3 - 20 AND $3 - 1
+				  AND s_w_id = $1
+				  AND s_quantity < $4`,
+				wID, d.dID, dNextOID, d.threshold,
+			).Scan(&d.lowStock); err != nil {
+				return err
+			}
+			return nil
+		}); err != nil {
+		return nil, err
+	}
+	return d, nil
+}

--- a/pkg/testutils/workload/tpcc/worker.go
+++ b/pkg/testutils/workload/tpcc/worker.go
@@ -13,201 +13,134 @@
 // permissions and limitations under the License. See the AUTHORS file
 // for names of contributors.
 
-package main
+package tpcc
 
 import (
-	"database/sql"
-	"fmt"
-	"log"
+	gosql "database/sql"
 	"math"
 	"math/rand"
 	"strconv"
 	"strings"
-	"sync"
-	"sync/atomic"
 	"time"
 
-	"github.com/codahale/hdrhistogram"
 	"github.com/pkg/errors"
 )
 
-type worker struct {
-	idx       int
-	db        *sql.DB
-	warehouse int
-	latency   struct {
-		sync.Mutex
-		*hdrhistogram.WindowedHistogram
-		byOp []*hdrhistogram.WindowedHistogram
-	}
-}
-
-func clampLatency(d, min, max time.Duration) time.Duration {
-	if d < min {
-		return min
-	}
-	if d > max {
-		return max
-	}
-	return d
-}
-
-type txType int
-
 const (
-	newOrderType txType = iota
-	paymentType
-	orderStatusType
-	deliveryType
-	stockLevelType
+	numWorkersPerWarehouse = 10
 )
-const nTxTypes = 5
+
+type worker struct {
+	config    *tpcc
+	idx       int
+	db        *gosql.DB
+	warehouse int
+}
 
 type tpccTx interface {
-	run(db *sql.DB, wID int) (interface{}, error)
+	run(config *tpcc, db *gosql.DB, wID int) (interface{}, error)
 }
 
 type tx struct {
 	tpccTx
-	weight     int    // percent likelihood that each transaction type is run
-	name       string // display name
-	numOps     uint64
+	weight     int     // percent likelihood that each transaction type is run
+	name       string  // display name
 	keyingTime int     // keying time in seconds, see 5.2.5.7
 	thinkTime  float64 // minimum mean of think time distribution, 5.2.5.7
 }
 
-// Keep this in the same order as the const type enum above, since it's used as a map from tx type
-// to struct.
-var txs = [...]tx{
-	newOrderType: {
+var allTxs = [...]tx{
+	{
 		tpccTx: newOrder{}, name: "newOrder",
 		keyingTime: 18,
 		thinkTime:  12,
 	},
-	paymentType: {
+	{
 		tpccTx: payment{}, name: "payment",
 		keyingTime: 3,
 		thinkTime:  12,
 	},
-	orderStatusType: {
+	{
 		tpccTx: orderStatus{}, name: "orderStatus",
 		keyingTime: 2,
 		thinkTime:  10,
 	},
-	deliveryType: {
+	{
 		tpccTx: delivery{}, name: "delivery",
 		keyingTime: 2,
 		thinkTime:  5,
 	},
-	stockLevelType: {
+	{
 		tpccTx: stockLevel{}, name: "stockLevel",
 		keyingTime: 2,
 		thinkTime:  5,
 	},
 }
 
-var totalWeight int
-
-func initializeMix() {
-	nameToTx := make(map[string]txType)
-	for i, tx := range txs {
-		nameToTx[tx.name] = txType(i)
+func initializeMix(config *tpcc) error {
+	config.txs = append([]tx(nil), allTxs[0:]...)
+	nameToTx := make(map[string]int)
+	for i, tx := range config.txs {
+		nameToTx[tx.name] = i
 	}
 
-	items := strings.Split(*mix, ",")
+	items := strings.Split(config.mix, `,`)
 	for _, item := range items {
-		kv := strings.Split(item, "=")
+		kv := strings.Split(item, `=`)
 		if len(kv) != 2 {
-			log.Fatalf("Invalid mix %s: %s is not a k=v pair", *mix, item)
+			return errors.Errorf(`Invalid mix %s: %s is not a k=v pair`, config.mix, item)
 		}
 		txName, weightStr := kv[0], kv[1]
 
 		weight, err := strconv.Atoi(weightStr)
 		if err != nil {
-			log.Fatalf("Invalid percentage mix %s: %s is not an integer", *mix, weightStr)
+			return errors.Errorf(
+				`Invalid percentage mix %s: %s is not an integer`, config.mix, weightStr)
 		}
 
-		txIdx, ok := nameToTx[txName]
+		i, ok := nameToTx[txName]
 		if !ok {
-			log.Fatalf("Invalid percentage mix %s: no such transaction %s", *mix, txName)
+			return errors.Errorf(
+				`Invalid percentage mix %s: no such transaction %s`, config.mix, txName)
 		}
 
-		txs[txIdx].weight = weight
-		totalWeight += weight
+		config.txs[i].weight = weight
+		config.totalWeight += weight
 	}
-	if *verbose {
-		scaleFactor := 100.0 / float64(totalWeight)
-
-		fmt.Printf("Running with mix ")
-		for _, tx := range txs {
-			fmt.Printf("%s=%.0f%% ", tx.name, float64(tx.weight)*scaleFactor)
-		}
-		fmt.Printf("\n")
-	}
+	return nil
 }
 
-func newWorker(i int, db *sql.DB, wg *sync.WaitGroup) *worker {
-	wg.Add(1)
-	w := &worker{idx: i, db: db}
-	w.latency.WindowedHistogram = hdrhistogram.NewWindowed(1,
-		minLatency.Nanoseconds(), maxLatency.Nanoseconds(), 1)
-
-	w.latency.byOp = make([]*hdrhistogram.WindowedHistogram, nTxTypes)
-	for i := 0; i < nTxTypes; i++ {
-		w.latency.byOp[i] = hdrhistogram.NewWindowed(1,
-			minLatency.Nanoseconds(), maxLatency.Nanoseconds(), 1)
-	}
-	return w
-}
-
-func (w *worker) run(errCh chan<- error, warehouseID int) {
-	for {
-		transactionType := rand.Intn(totalWeight)
-		weightSum := 0
-		var i int
-		var t tx
-		for i, t = range txs {
-			weightSum += t.weight
-			if transactionType < weightSum {
-				break
-			}
-		}
-		if *noWait {
-			warehouseID = rand.Intn(*warehouses)
-		} else {
-			time.Sleep(time.Duration(t.keyingTime) * time.Second)
-		}
-
-		start := time.Now()
-		if _, err := t.run(w.db, warehouseID); err != nil {
-			errCh <- errors.Wrapf(err, "error in %s", t.name)
-			continue
-		}
-		elapsed := clampLatency(time.Since(start), minLatency, maxLatency).Nanoseconds()
-		w.latency.Lock()
-		if err := w.latency.Current.RecordValue(elapsed); err != nil {
-			log.Fatal(err)
-		}
-		if err := w.latency.byOp[i].Current.RecordValue(elapsed); err != nil {
-			log.Fatal(err)
-		}
-		w.latency.Unlock()
-		atomic.AddUint64(&txs[i].numOps, 1)
-		v := atomic.AddUint64(&numOps, 1)
-		if *maxOps > 0 && v >= *maxOps {
-			return
-		}
-
-		if !*noWait {
-			// 5.2.5.4: Think time is taken independently from a negative exponential
-			// distribution. Think time = -log(r) * u, where r is a uniform random number
-			// between 0 and 1 and u is the mean think time per operation.
-			// Each distribution is truncated at 10 times its mean value.
-			thinkTime := -math.Log(rand.Float64()) * float64(t.thinkTime)
-			if thinkTime > (t.thinkTime * 10) {
-				thinkTime = t.thinkTime * 10
-			}
-			time.Sleep(time.Duration(thinkTime) * time.Second)
+func (w *worker) run() error {
+	transactionType := rand.Intn(w.config.totalWeight)
+	weightSum := 0
+	var t tx
+	for _, t = range w.config.txs {
+		weightSum += t.weight
+		if transactionType < weightSum {
+			break
 		}
 	}
+	warehouseID := w.warehouse
+	if !w.config.doWaits {
+		warehouseID = rand.Intn(w.config.warehouses)
+	} else {
+		time.Sleep(time.Duration(t.keyingTime) * time.Second)
+	}
+
+	if _, err := t.run(w.config, w.db, warehouseID); err != nil {
+		return errors.Wrapf(err, "error in %s", t.name)
+	}
+
+	if w.config.doWaits {
+		// 5.2.5.4: Think time is taken independently from a negative exponential
+		// distribution. Think time = -log(r) * u, where r is a uniform random number
+		// between 0 and 1 and u is the mean think time per operation.
+		// Each distribution is truncated at 10 times its mean value.
+		thinkTime := -math.Log(rand.Float64()) * t.thinkTime
+		if thinkTime > (t.thinkTime * 10) {
+			thinkTime = t.thinkTime * 10
+		}
+		time.Sleep(time.Duration(thinkTime) * time.Second)
+	}
+	return nil
 }

--- a/pkg/testutils/workload/tpcc/worker.go
+++ b/pkg/testutils/workload/tpcc/worker.go
@@ -1,0 +1,213 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+
+package main
+
+import (
+	"database/sql"
+	"fmt"
+	"log"
+	"math"
+	"math/rand"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/codahale/hdrhistogram"
+	"github.com/pkg/errors"
+)
+
+type worker struct {
+	idx       int
+	db        *sql.DB
+	warehouse int
+	latency   struct {
+		sync.Mutex
+		*hdrhistogram.WindowedHistogram
+		byOp []*hdrhistogram.WindowedHistogram
+	}
+}
+
+func clampLatency(d, min, max time.Duration) time.Duration {
+	if d < min {
+		return min
+	}
+	if d > max {
+		return max
+	}
+	return d
+}
+
+type txType int
+
+const (
+	newOrderType txType = iota
+	paymentType
+	orderStatusType
+	deliveryType
+	stockLevelType
+)
+const nTxTypes = 5
+
+type tpccTx interface {
+	run(db *sql.DB, wID int) (interface{}, error)
+}
+
+type tx struct {
+	tpccTx
+	weight     int    // percent likelihood that each transaction type is run
+	name       string // display name
+	numOps     uint64
+	keyingTime int     // keying time in seconds, see 5.2.5.7
+	thinkTime  float64 // minimum mean of think time distribution, 5.2.5.7
+}
+
+// Keep this in the same order as the const type enum above, since it's used as a map from tx type
+// to struct.
+var txs = [...]tx{
+	newOrderType: {
+		tpccTx: newOrder{}, name: "newOrder",
+		keyingTime: 18,
+		thinkTime:  12,
+	},
+	paymentType: {
+		tpccTx: payment{}, name: "payment",
+		keyingTime: 3,
+		thinkTime:  12,
+	},
+	orderStatusType: {
+		tpccTx: orderStatus{}, name: "orderStatus",
+		keyingTime: 2,
+		thinkTime:  10,
+	},
+	deliveryType: {
+		tpccTx: delivery{}, name: "delivery",
+		keyingTime: 2,
+		thinkTime:  5,
+	},
+	stockLevelType: {
+		tpccTx: stockLevel{}, name: "stockLevel",
+		keyingTime: 2,
+		thinkTime:  5,
+	},
+}
+
+var totalWeight int
+
+func initializeMix() {
+	nameToTx := make(map[string]txType)
+	for i, tx := range txs {
+		nameToTx[tx.name] = txType(i)
+	}
+
+	items := strings.Split(*mix, ",")
+	for _, item := range items {
+		kv := strings.Split(item, "=")
+		if len(kv) != 2 {
+			log.Fatalf("Invalid mix %s: %s is not a k=v pair", *mix, item)
+		}
+		txName, weightStr := kv[0], kv[1]
+
+		weight, err := strconv.Atoi(weightStr)
+		if err != nil {
+			log.Fatalf("Invalid percentage mix %s: %s is not an integer", *mix, weightStr)
+		}
+
+		txIdx, ok := nameToTx[txName]
+		if !ok {
+			log.Fatalf("Invalid percentage mix %s: no such transaction %s", *mix, txName)
+		}
+
+		txs[txIdx].weight = weight
+		totalWeight += weight
+	}
+	if *verbose {
+		scaleFactor := 100.0 / float64(totalWeight)
+
+		fmt.Printf("Running with mix ")
+		for _, tx := range txs {
+			fmt.Printf("%s=%.0f%% ", tx.name, float64(tx.weight)*scaleFactor)
+		}
+		fmt.Printf("\n")
+	}
+}
+
+func newWorker(i int, db *sql.DB, wg *sync.WaitGroup) *worker {
+	wg.Add(1)
+	w := &worker{idx: i, db: db}
+	w.latency.WindowedHistogram = hdrhistogram.NewWindowed(1,
+		minLatency.Nanoseconds(), maxLatency.Nanoseconds(), 1)
+
+	w.latency.byOp = make([]*hdrhistogram.WindowedHistogram, nTxTypes)
+	for i := 0; i < nTxTypes; i++ {
+		w.latency.byOp[i] = hdrhistogram.NewWindowed(1,
+			minLatency.Nanoseconds(), maxLatency.Nanoseconds(), 1)
+	}
+	return w
+}
+
+func (w *worker) run(errCh chan<- error, warehouseID int) {
+	for {
+		transactionType := rand.Intn(totalWeight)
+		weightSum := 0
+		var i int
+		var t tx
+		for i, t = range txs {
+			weightSum += t.weight
+			if transactionType < weightSum {
+				break
+			}
+		}
+		if *noWait {
+			warehouseID = rand.Intn(*warehouses)
+		} else {
+			time.Sleep(time.Duration(t.keyingTime) * time.Second)
+		}
+
+		start := time.Now()
+		if _, err := t.run(w.db, warehouseID); err != nil {
+			errCh <- errors.Wrapf(err, "error in %s", t.name)
+			continue
+		}
+		elapsed := clampLatency(time.Since(start), minLatency, maxLatency).Nanoseconds()
+		w.latency.Lock()
+		if err := w.latency.Current.RecordValue(elapsed); err != nil {
+			log.Fatal(err)
+		}
+		if err := w.latency.byOp[i].Current.RecordValue(elapsed); err != nil {
+			log.Fatal(err)
+		}
+		w.latency.Unlock()
+		atomic.AddUint64(&txs[i].numOps, 1)
+		v := atomic.AddUint64(&numOps, 1)
+		if *maxOps > 0 && v >= *maxOps {
+			return
+		}
+
+		if !*noWait {
+			// 5.2.5.4: Think time is taken independently from a negative exponential
+			// distribution. Think time = -log(r) * u, where r is a uniform random number
+			// between 0 and 1 and u is the mean think time per operation.
+			// Each distribution is truncated at 10 times its mean value.
+			thinkTime := -math.Log(rand.Float64()) * float64(t.thinkTime)
+			if thinkTime > (t.thinkTime * 10) {
+				thinkTime = t.thinkTime * 10
+			}
+			time.Sleep(time.Duration(thinkTime) * time.Second)
+		}
+	}
+}

--- a/pkg/testutils/workload/workload.go
+++ b/pkg/testutils/workload/workload.go
@@ -155,6 +155,9 @@ func Registered() []Meta {
 // DatumSize returns the canonical size of a datum as returned from a call to
 // `Table.InitialRowFn`.
 func DatumSize(x interface{}) int64 {
+	if x == nil {
+		return 0
+	}
 	switch t := x.(type) {
 	case int:
 		return int64(math.Log10(float64(t)))
@@ -185,7 +188,7 @@ func Setup(db *gosql.DB, gen Generator, batchSize int) (int64, error) {
 
 	var size int64
 	for _, table := range tables {
-		createStmt := fmt.Sprintf(`CREATE TABLE %s %s`, table.Name, table.Schema)
+		createStmt := fmt.Sprintf(`CREATE TABLE "%s" %s`, table.Name, table.Schema)
 		if _, err := db.Exec(createStmt); err != nil {
 			return 0, err
 		}
@@ -200,7 +203,7 @@ func Setup(db *gosql.DB, gen Generator, batchSize int) (int64, error) {
 	for _, table := range tables {
 		for rowIdx := 0; rowIdx < table.InitialRowCount; {
 			insertStmtBuf.Reset()
-			fmt.Fprintf(&insertStmtBuf, `INSERT INTO %s VALUES `, table.Name)
+			fmt.Fprintf(&insertStmtBuf, `INSERT INTO "%s" VALUES `, table.Name)
 
 			var params []interface{}
 			for batchIdx := 0; batchIdx < batchSize && rowIdx < table.InitialRowCount; batchIdx++ {


### PR DESCRIPTION
Line items are still not to spec, I haven't figured out what to do about FKs, and there's a refactor coming that will fix up the timings. Everything else from loadgen/tpcc should be here, though. I even figured out a workaround to make wait mode work and to pin workers to warehouses.

As a sanity check, both this and loadgen/tpcc are getting ~90-93 ops/sec for "all" on my laptop (with warehouses=1 and concurrency=16). Calculating actual tpmC will have to wait on the timings refactor.