### PR TITLE
sql: abstract the planner's use of PreparedStatements

### DIFF
--- a/pkg/sql/execute.go
+++ b/pkg/sql/execute.go
@@ -55,7 +55,7 @@ func (p *planner) Execute(ctx context.Context, n *tree.Execute) (planNode, error
 // placeholder info.
 // See https://www.postgresql.org/docs/current/static/sql-execute.html for details.
 func getPreparedStatementForExecute(
-	preparedStmts *PreparedStatements, searchPath sessiondata.SearchPath, s *tree.Execute,
+	preparedStmts preparedStatementsAccessor, searchPath sessiondata.SearchPath, s *tree.Execute,
 ) (ps *PreparedStatement, pInfo *tree.PlaceholderInfo, err error) {
 	name := s.Name.String()
 	prepared, ok := preparedStmts.Get(name)

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -90,10 +90,6 @@ type testingVerifyMetadata interface {
 type planner struct {
 	txn *client.Txn
 
-	// preparedStatements points to the Session's collection of prepared
-	// statements.
-	preparedStatements *PreparedStatements
-
 	// Reference to the corresponding sql Statement for this query.
 	stmt *Statement
 
@@ -104,6 +100,8 @@ type planner struct {
 	// sessionDataMutator is used to mutate the session variables. Read
 	// access to them is provided through evalCtx.
 	sessionDataMutator sessionDataMutator
+
+	preparedStatements preparedStatementsAccessor
 
 	// statsCollector is used to collect statistics about SQL statement execution.
 	statsCollector sqlStatsCollector


### PR DESCRIPTION
PreparedStatements encapsulates a collection of prepared statements. The
current structure is logically a part of a Session, and as such it's
quite intermingled with the Session type. The planner has a reference to
this type, but only needs a limited subset of it. As Session is going
away, this patch makes the planner only hold a reference to a new
interface.

Release note: None