### PR TITLE
builder: fix pull command

### DIFF
--- a/build/builder.sh
+++ b/build/builder.sh
@@ -10,7 +10,7 @@ function init() {
 }
 
 if [ "${1-}" = "pull" ]; then
-  docker pull "${image}"
+  docker pull "${image}:${version}"
   exit 0
 fi
 


### PR DESCRIPTION
`build/builder.sh pull` previously attempted to pull the "latest" tag of
the builder image, but we don't push latest tags. Teach it to instead
pull whatever tag builder.sh is currently using.

Release note: None