### PR TITLE
[WIP] libroach: allocate chunk memory directly from the Go heap

### DIFF
--- a/c-deps/libroach/chunked_buffer.h
+++ b/c-deps/libroach/chunked_buffer.h
@@ -21,7 +21,8 @@ namespace cockroach {
 
 class chunkedBuffer {
  public:
-  chunkedBuffer() {
+  chunkedBuffer(uintptr_t chunks_ref)
+      : chunks_ref_((void*)chunks_ref) {
     Clear();
   }
   ~chunkedBuffer() {
@@ -51,6 +52,7 @@ class chunkedBuffer {
   void put(const char* data, int len, int next_size_hint);
 
  private:
+  void* chunks_ref_;
   std::vector<DBSlice> bufs_;
   int64_t count_;
   char* buf_ptr_;

--- a/c-deps/libroach/godefs.cc
+++ b/c-deps/libroach/godefs.cc
@@ -30,4 +30,5 @@ static void __attribute__((noreturn)) die_missing_symbol(const char* name) {
 // storage/engine when the final cockroach binary is linked.
 void __attribute__((weak)) rocksDBLog(char*, int) { die_missing_symbol(__func__); }
 char* __attribute__((weak)) prettyPrintKey(DBKey) { die_missing_symbol(__func__); }
+void __attribute__((weak)) iterNewChunk(void*, int, DBSlice* result) { die_missing_symbol(__func__); }
 }  // extern "C"

--- a/c-deps/libroach/godefs.h
+++ b/c-deps/libroach/godefs.h
@@ -19,4 +19,5 @@
 extern "C" {
 void __attribute__((weak)) rocksDBLog(char*, int);
 char* __attribute__((weak)) prettyPrintKey(DBKey);
+void __attribute__((weak)) iterNewChunk(void*, int, DBSlice* result);
 }  // extern "C"

--- a/c-deps/libroach/include/libroach.h
+++ b/c-deps/libroach/include/libroach.h
@@ -268,9 +268,10 @@ typedef struct {
 } DBScanResults;
 
 DBScanResults MVCCGet(DBIterator* iter, DBSlice key, DBTimestamp timestamp, DBTxn txn,
-                      bool consistent);
+                      bool consistent, uintptr_t chunks_ref);
 DBScanResults MVCCScan(DBIterator* iter, DBSlice start, DBSlice end, DBTimestamp timestamp,
-                       int64_t max_keys, DBTxn txn, bool consistent, bool reverse);
+                       int64_t max_keys, DBTxn txn, bool consistent, bool reverse,
+                       uintptr_t chunks_ref);
 
 // DBStatsResult contains various runtime stats for RocksDB.
 typedef struct {

--- a/c-deps/libroach/mvcc.cc
+++ b/c-deps/libroach/mvcc.cc
@@ -260,7 +260,7 @@ DBStatus MVCCFindSplitKey(DBIterator* iter, DBKey start, DBKey end, DBKey min_sp
 }
 
 DBScanResults MVCCGet(DBIterator* iter, DBSlice key, DBTimestamp timestamp, DBTxn txn,
-                      bool consistent) {
+                      bool consistent, uintptr_t chunks_ref) {
   // Get is implemented as a scan where we retrieve a single key. Note
   // that the semantics of max_keys is that we retrieve one more key
   // than is specified in order to maintain the existing semantics of
@@ -270,17 +270,17 @@ DBScanResults MVCCGet(DBIterator* iter, DBSlice key, DBTimestamp timestamp, DBTx
   // don't retrieve a key different than the start key. This is a bit
   // of a hack.
   const DBSlice end = {0, 0};
-  mvccForwardScanner scanner(iter, key, end, timestamp, 0 /* max_keys */, txn, consistent);
+  mvccForwardScanner scanner(iter, key, end, timestamp, 0 /* max_keys */, txn, consistent, chunks_ref);
   return scanner.get();
 }
 
 DBScanResults MVCCScan(DBIterator* iter, DBSlice start, DBSlice end, DBTimestamp timestamp,
-                       int64_t max_keys, DBTxn txn, bool consistent, bool reverse) {
+                       int64_t max_keys, DBTxn txn, bool consistent, bool reverse, uintptr_t chunks_ref) {
   if (reverse) {
-    mvccReverseScanner scanner(iter, end, start, timestamp, max_keys, txn, consistent);
+    mvccReverseScanner scanner(iter, end, start, timestamp, max_keys, txn, consistent, chunks_ref);
     return scanner.scan();
   } else {
-    mvccForwardScanner scanner(iter, start, end, timestamp, max_keys, txn, consistent);
+    mvccForwardScanner scanner(iter, start, end, timestamp, max_keys, txn, consistent, chunks_ref);
     return scanner.scan();
   }
 }

--- a/c-deps/libroach/mvcc.h
+++ b/c-deps/libroach/mvcc.h
@@ -50,7 +50,7 @@ static const int kMaxItersBeforeSeek = 10;
 template <bool reverse> class mvccScanner {
  public:
   mvccScanner(DBIterator* iter, DBSlice start, DBSlice end, DBTimestamp timestamp, int64_t max_keys,
-              DBTxn txn, bool consistent)
+              DBTxn txn, bool consistent, uintptr_t chunks_ref)
       : iter_(iter),
         iter_rep_(iter->rep.get()),
         start_key_(ToSlice(start)),
@@ -62,7 +62,7 @@ template <bool reverse> class mvccScanner {
         txn_max_timestamp_(txn.max_timestamp),
         consistent_(consistent),
         check_uncertainty_(timestamp < txn.max_timestamp),
-        kvs_(new chunkedBuffer),
+        kvs_(new chunkedBuffer(chunks_ref)),
         intents_(new rocksdb::WriteBatch),
         peeked_(false),
         is_get_(false),

--- a/pkg/storage/engine/engine.go
+++ b/pkg/storage/engine/engine.go
@@ -111,7 +111,7 @@ type Iterator interface {
 	// of varint-prefixed slices, alternating from key to value, numKvs pairs.
 	MVCCScan(start, end roachpb.Key, max int64, timestamp hlc.Timestamp,
 		txn *roachpb.Transaction, consistent, reverse bool,
-	) (kvs []byte, numKvs int64, intents []byte, err error)
+	) (kvs [][]byte, numKvs int64, intents []byte, err error)
 }
 
 // Reader is the read interface to an engine's data.

--- a/pkg/storage/engine/mvcc.go
+++ b/pkg/storage/engine/mvcc.go
@@ -1694,7 +1694,7 @@ func buildScanIntents(data []byte) ([]roachpb.Intent, error) {
 	return intents, nil
 }
 
-func buildScanResumeKey(kvData []byte, numKvs int64, max int64) ([]byte, error) {
+func buildScanResumeKey(kvData [][]byte, numKvs int64, max int64) ([]byte, error) {
 	if len(kvData) == 0 {
 		return nil, nil
 	}
@@ -1716,7 +1716,7 @@ func buildScanResumeKey(kvData []byte, numKvs int64, max int64) ([]byte, error) 
 }
 
 func buildScanResults(
-	kvData []byte, numKvs int64, intentData []byte, max int64, consistent bool,
+	kvData [][]byte, numKvs int64, intentData []byte, max int64, consistent bool,
 ) ([]roachpb.KeyValue, roachpb.Key, []roachpb.Intent, error) {
 	intents, err := buildScanIntents(intentData)
 	if err != nil {

--- a/pkg/storage/engine/rocksdb.go
+++ b/pkg/storage/engine/rocksdb.go
@@ -17,6 +17,7 @@ package engine
 import (
 	"bytes"
 	"context"
+	"encoding/binary"
 	"fmt"
 	"io/ioutil"
 	"math"
@@ -38,7 +39,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/util"
-	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/humanizeutil"
@@ -85,6 +85,14 @@ func prettyPrintKey(cKey C.DBKey) *C.char {
 		},
 	}
 	return C.CString(mvccKey.String())
+}
+
+//export iterNewChunk
+func iterNewChunk(ref unsafe.Pointer, size int, result *C.DBSlice) {
+	chunk := rawbyteslice(size)
+	iter := (*rocksDBIterator)(ref)
+	iter.chunks = append(iter.chunks, chunk)
+	*result = goToCSlice(chunk)
 }
 
 const (
@@ -1353,7 +1361,7 @@ func (r *batchIterator) MVCCScan(
 	timestamp hlc.Timestamp,
 	txn *roachpb.Transaction,
 	consistent, reverse bool,
-) (kvs []byte, numKvs int64, intents []byte, err error) {
+) (kvs [][]byte, numKvs int64, intents []byte, err error) {
 	r.batch.flushMutations()
 	return r.iter.MVCCScan(start, end, max, timestamp, txn, consistent, reverse)
 }
@@ -1799,6 +1807,7 @@ type rocksDBIterator struct {
 	err    error
 	key    C.DBKey
 	value  C.DBSlice
+	chunks [][]byte
 }
 
 // TODO(peter): Is this pool useful now that rocksDBBatch.NewIterator doesn't
@@ -2006,7 +2015,10 @@ func (r *rocksDBIterator) MVCCGet(
 
 	state := C.MVCCGet(
 		r.iter, goToCSlice(key), goToCTimestamp(timestamp),
-		goToCTxn(txn), C.bool(consistent))
+		goToCTxn(txn), C.bool(consistent),
+		C.uintptr_t(uintptr(unsafe.Pointer(r))))
+	chunks := r.chunks
+	r.chunks = nil
 
 	if err := statusToError(state.status); err != nil {
 		return nil, nil, err
@@ -2035,8 +2047,8 @@ func (r *rocksDBIterator) MVCCGet(
 	}
 
 	// Extract the value from the batch data.
-	repr := copyFromSliceVector(state.data.bufs, state.data.len)
-	mvccKey, rawValue, _, err := mvccScanDecodeKeyValue(repr)
+	copyFromChunkedBuffer(chunks, state.data.bufs, state.data.len)
+	mvccKey, rawValue, _, err := mvccScanDecodeKeyValue(chunks)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -2053,7 +2065,7 @@ func (r *rocksDBIterator) MVCCScan(
 	timestamp hlc.Timestamp,
 	txn *roachpb.Transaction,
 	consistent, reverse bool,
-) (kvs []byte, numKvs int64, intents []byte, err error) {
+) (kvs [][]byte, numKvs int64, intents []byte, err error) {
 	if !consistent && txn != nil {
 		return nil, 0, nil, errors.Errorf("cannot allow inconsistent reads within a transaction")
 	}
@@ -2065,7 +2077,10 @@ func (r *rocksDBIterator) MVCCScan(
 		r.iter, goToCSlice(start), goToCSlice(end),
 		goToCTimestamp(timestamp), C.int64_t(max),
 		goToCTxn(txn), C.bool(consistent), C.bool(reverse),
+		C.uintptr_t(uintptr(unsafe.Pointer(r))),
 	)
+	chunks := r.chunks
+	r.chunks = nil
 
 	if err := statusToError(state.status); err != nil {
 		return nil, 0, nil, err
@@ -2073,26 +2088,15 @@ func (r *rocksDBIterator) MVCCScan(
 	if err := uncertaintyToError(timestamp, state.uncertainty_timestamp, txn); err != nil {
 		return nil, 0, nil, err
 	}
-	kvs = copyFromSliceVector(state.data.bufs, state.data.len)
-	return kvs, int64(state.data.count), cSliceToGoBytes(state.intents), nil
+	copyFromChunkedBuffer(chunks, state.data.bufs, state.data.len)
+	return chunks, int64(state.data.count), cSliceToGoBytes(state.intents), nil
 }
 
-func copyFromSliceVector(bufs *C.DBSlice, len C.int32_t) []byte {
-	if bufs == nil {
-		return nil
+func copyFromChunkedBuffer(chunks [][]byte, bufs *C.DBSlice, len C.int32_t) {
+	for i := uintptr(0); i < uintptr(len); i++ {
+		slice := (*C.DBSlice)(unsafe.Pointer(uintptr(unsafe.Pointer(bufs)) + i*unsafe.Sizeof(C.DBSlice{})))
+		chunks[i] = cSliceToUnsafeGoBytes(*slice)
 	}
-
-	// Interpret the C pointer as a pointer to a Go array, then slice.
-	slices := (*[1 << 20]C.DBSlice)(unsafe.Pointer(bufs))[:len:len]
-	neededBytes := 0
-	for i := range slices {
-		neededBytes += int(slices[i].len)
-	}
-	data := rawbyteslice(neededBytes)[:0]
-	for i := range slices {
-		data = append(data, cSliceToUnsafeGoBytes(slices[i])...)
-	}
-	return data
 }
 
 func cStatsToGoStats(stats C.MVCCStatsResult, nowNanos int64) (enginepb.MVCCStats, error) {
@@ -2546,23 +2550,38 @@ func unlockFile(lock C.DBFileLock) error {
 // Decode a key/value pair returned in an MVCCScan "batch" (this is not the
 // RocksDB batch repr format), returning both the key/value and the suffix of
 // data remaining in the batch.
-func mvccScanDecodeKeyValue(repr []byte) (key MVCCKey, value []byte, orepr []byte, err error) {
-	if len(repr) == 0 {
+func mvccScanDecodeKeyValue(repr [][]byte) (key MVCCKey, value []byte, orepr [][]byte, err error) {
+	if len(repr) == 0 || len(repr[0]) < 8 {
 		return key, nil, repr, errors.Errorf("unexpected batch EOF")
 	}
-	repr, v, err := encoding.DecodeUint64Ascending(repr)
-	if err != nil {
-		return key, nil, nil, err
-	}
+	v := binary.BigEndian.Uint64(repr[0])
+	repr[0] = repr[0][8:]
+
 	keySize := v >> 32
-	valSize := v & ((1 << 32) - 1)
-	if (keySize + valSize) > uint64(len(repr)) {
-		return key, nil, nil, fmt.Errorf("expected %d bytes, but only %d remaining",
-			keySize+valSize, len(repr))
+	if len(repr[0]) == 0 {
+		repr = repr[1:]
 	}
-	rawKey := repr[:keySize]
-	value = repr[keySize : keySize+valSize]
-	repr = repr[keySize+valSize:]
+	if keySize > uint64(len(repr[0])) {
+		return key, nil, nil, fmt.Errorf("expected %d bytes, but only %d remaining",
+			keySize, len(repr[0]))
+	}
+	rawKey := repr[0][:keySize]
+	repr[0] = repr[0][keySize:]
+	if len(repr[0]) == 0 {
+		repr = repr[1:]
+	}
+
+	valSize := v & ((1 << 32) - 1)
+	if valSize > uint64(len(repr[0])) {
+		return key, nil, nil, fmt.Errorf("expected %d bytes, but only %d remaining",
+			valSize, len(repr[0]))
+	}
+	value = repr[0][:valSize]
+	repr[0] = repr[0][valSize:]
+	if len(repr[0]) == 0 {
+		repr = repr[1:]
+	}
+
 	key, err = DecodeKey(rawKey)
 	return key, value, repr, err
 }

--- a/pkg/storage/spanset/batch.go
+++ b/pkg/storage/spanset/batch.go
@@ -181,7 +181,7 @@ func (s *Iterator) MVCCScan(
 	timestamp hlc.Timestamp,
 	txn *roachpb.Transaction,
 	consistent, reverse bool,
-) (kvs []byte, numKvs int64, intents []byte, err error) {
+) (kvs [][]byte, numKvs int64, intents []byte, err error) {
 	if err := s.spans.CheckAllowed(SpanReadOnly, roachpb.Span{Key: start, EndKey: end}); err != nil {
 		return nil, 0, nil, err
 	}


### PR DESCRIPTION
This avoids the need to copy the scan result chunk memory from C++ to
Go. The benchmark results are mixed: a win for larger scans and a loss
for smaller scans. More work needs to be done to address the small scan
performance. For example, we could allocate an initial chunk that we
pass in, or perhaps the first few scan chunks should be allocated in C++
and only when we reach a certain size do we allocate from the Go heap.

```
name                                                    old time/op    new time/op    delta
MVCCScan_RocksDB/rows=100/versions=1/valueSize=8-8        28.6µs ± 2%    30.2µs ± 0%   +5.30%  (p=0.000 n=10+9)
MVCCScan_RocksDB/rows=100/versions=1/valueSize=64-8       30.7µs ± 4%    32.6µs ± 4%   +6.14%  (p=0.000 n=9+10)
MVCCScan_RocksDB/rows=100/versions=1/valueSize=512-8      45.3µs ± 1%    53.8µs ± 1%  +18.86%  (p=0.000 n=9+10)
MVCCScan_RocksDB/rows=1000/versions=1/valueSize=8-8        216µs ± 1%     212µs ± 1%   -1.74%  (p=0.000 n=8+9)
MVCCScan_RocksDB/rows=1000/versions=1/valueSize=64-8       231µs ± 1%     222µs ± 1%   -3.86%  (p=0.000 n=10+9)
MVCCScan_RocksDB/rows=1000/versions=1/valueSize=512-8      368µs ± 0%     340µs ± 1%   -7.42%  (p=0.000 n=8+10)
MVCCScan_RocksDB/rows=10000/versions=1/valueSize=8-8      2.11ms ± 1%    1.94ms ± 1%   -8.15%  (p=0.000 n=10+10)
MVCCScan_RocksDB/rows=10000/versions=1/valueSize=64-8     2.25ms ± 1%    2.11ms ± 1%   -6.07%  (p=0.000 n=8+10)
MVCCScan_RocksDB/rows=10000/versions=1/valueSize=512-8    3.62ms ± 1%    2.88ms ± 2%  -20.33%  (p=0.000 n=10+10)
```

Unfortunately, there is no movement on the end-to-end benchmark of
`select count(*) from tpcc.stock`.