### PR TITLE
opt: Intern lists of opt expression groups.

### DIFF
--- a/pkg/sql/opt/build/builder.go
+++ b/pkg/sql/opt/build/builder.go
@@ -322,7 +322,7 @@ func (b *Builder) buildScalar(scalar tree.TypedExpr, inScope *scope) opt.GroupID
 		for i := range t.D {
 			list[i] = b.buildScalar(t.D[i], inScope)
 		}
-		return b.factory.ConstructTuple(b.factory.StoreList(list))
+		return b.factory.ConstructTuple(b.factory.InternList(list))
 
 	case *tree.IndexedVar:
 		colProps := b.synthesizeColumn(inScope, fmt.Sprintf("@%d", t.Idx+1), t.ResolvedType())
@@ -348,7 +348,7 @@ func (b *Builder) buildScalar(scalar tree.TypedExpr, inScope *scope) opt.GroupID
 		for i := range t.Exprs {
 			list[i] = b.buildScalar(t.Exprs[i].(tree.TypedExpr), inScope)
 		}
-		return b.factory.ConstructTuple(b.factory.StoreList(list))
+		return b.factory.ConstructTuple(b.factory.InternList(list))
 
 	case *tree.UnaryExpr:
 		return unaryOpMap[t.Operator](b.factory, b.buildScalar(t.TypedInnerExpr(), inScope))
@@ -450,8 +450,8 @@ func (b *Builder) buildFrom(
 	if left == 0 {
 		// TODO(peter): This should be a table with 1 row and 0 columns to match
 		// current cockroach behavior.
-		rows := []opt.GroupID{b.factory.ConstructTuple(b.factory.StoreList(nil))}
-		out = b.factory.ConstructValues(b.factory.StoreList(rows), b.factory.InternPrivate(&opt.ColSet{}))
+		rows := []opt.GroupID{b.factory.ConstructTuple(b.factory.InternList(nil))}
+		out = b.factory.ConstructValues(b.factory.InternList(rows), b.factory.InternPrivate(&opt.ColSet{}))
 		outScope = inScope
 	} else {
 		out = left
@@ -627,7 +627,7 @@ func (b *Builder) synthesizeColumn(scope *scope, label string, typ types.T) *col
 }
 
 func (b *Builder) constructProjectionList(items []opt.GroupID, cols []columnProps) opt.GroupID {
-	return b.factory.ConstructProjections(b.factory.StoreList(items), b.factory.InternPrivate(makeColSet(cols)))
+	return b.factory.ConstructProjections(b.factory.InternList(items), b.factory.InternPrivate(makeColSet(cols)))
 }
 
 // Builder implements the IndexedVarContainer interface so it can be

--- a/pkg/sql/opt/opt/factory.go
+++ b/pkg/sql/opt/opt/factory.go
@@ -34,3 +34,7 @@ type ListID struct {
 	Offset uint32
 	Length uint32
 }
+
+// EmptyList is a list with zero elements. It begins at offset 1 because offset
+// 0 is reserved to indicate an invalid, uninitialized list.
+var EmptyList = ListID{Offset: 1, Length: 0}

--- a/pkg/sql/opt/opt/factory.og.go
+++ b/pkg/sql/opt/opt/factory.og.go
@@ -7,9 +7,11 @@ type Factory interface {
 	// about the columns and tables used in this particular query.
 	Metadata() *Metadata
 
-	// StoreList allocates storage for a list of group IDs in the memo and
-	// returns an ID that can be used for later lookup.
-	StoreList(items []GroupID) ListID
+	// InternList adds the given list of group IDs to memo storage and returns
+	// an ID that can be used for later lookup. If the same list was added
+	// previously, this method is a no-op and returns the ID of the previous
+	// value.
+	InternList(items []GroupID) ListID
 
 	// InternPrivate adds the given private value to the memo and returns an ID
 	// that can be used for later lookup. If the same value was added before,

--- a/pkg/sql/opt/optgen/cmd/optgen/factory_gen.go
+++ b/pkg/sql/opt/optgen/cmd/optgen/factory_gen.go
@@ -106,9 +106,9 @@ func (g *factoryGen) genDynamicConstructLookup() {
 
 			if isListType(string(field.Type)) {
 				if i == 0 {
-					g.w.write("f.StoreList(children)")
+					g.w.write("f.InternList(children)")
 				} else {
-					g.w.write("f.StoreList(children[%d:])", i)
+					g.w.write("f.InternList(children[%d:])", i)
 				}
 			} else if isPrivateType(string(field.Type)) {
 				g.w.write("private")

--- a/pkg/sql/opt/optgen/cmd/optgen/ifactory_gen.go
+++ b/pkg/sql/opt/optgen/cmd/optgen/ifactory_gen.go
@@ -44,9 +44,11 @@ func (g *ifactoryGen) generate(compiled *lang.CompiledExpr, w io.Writer) {
 	fmt.Fprintf(g.w, "  // about the columns and tables used in this particular query.\n")
 	fmt.Fprintf(g.w, "  Metadata() *Metadata\n\n")
 
-	fmt.Fprintf(g.w, "  // StoreList allocates storage for a list of group IDs in the memo and\n")
-	fmt.Fprintf(g.w, "  // returns an ID that can be used for later lookup.\n")
-	fmt.Fprintf(g.w, "  StoreList(items []GroupID) ListID\n\n")
+	fmt.Fprintf(g.w, "  // InternList adds the given list of group IDs to memo storage and returns\n")
+	fmt.Fprintf(g.w, "  // an ID that can be used for later lookup. If the same list was added\n")
+	fmt.Fprintf(g.w, "  // previously, this method is a no-op and returns the ID of the previous\n")
+	fmt.Fprintf(g.w, "  // value.\n")
+	fmt.Fprintf(g.w, "  InternList(items []GroupID) ListID\n\n")
 
 	fmt.Fprintf(g.w, "  // InternPrivate adds the given private value to the memo and returns an ID\n")
 	fmt.Fprintf(g.w, "  // that can be used for later lookup. If the same value was added before,\n")

--- a/pkg/sql/opt/optgen/cmd/optgen/testdata/factory
+++ b/pkg/sql/opt/optgen/cmd/optgen/testdata/factory
@@ -71,7 +71,7 @@ func init() {
 
 	// FuncCallOp
 	dynConstructLookup[opt.FuncCallOp] = func(f *factory, children []opt.GroupID, private opt.PrivateID) opt.GroupID {
-		return f.ConstructFuncCall(children[0], f.StoreList(children[1:]), private)
+		return f.ConstructFuncCall(children[0], f.InternList(children[1:]), private)
 	}
 
 }

--- a/pkg/sql/opt/optgen/cmd/optgen/testdata/ifactory
+++ b/pkg/sql/opt/optgen/cmd/optgen/testdata/ifactory
@@ -33,9 +33,11 @@ type Factory interface {
 	// about the columns and tables used in this particular query.
 	Metadata() *Metadata
 
-	// StoreList allocates storage for a list of group IDs in the memo and
-	// returns an ID that can be used for later lookup.
-	StoreList(items []GroupID) ListID
+	// InternList adds the given list of group IDs to memo storage and returns
+	// an ID that can be used for later lookup. If the same list was added
+	// previously, this method is a no-op and returns the ID of the previous
+	// value.
+	InternList(items []GroupID) ListID
 
 	// InternPrivate adds the given private value to the memo and returns an ID
 	// that can be used for later lookup. If the same value was added before,

--- a/pkg/sql/opt/xform/factory.go
+++ b/pkg/sql/opt/xform/factory.go
@@ -59,10 +59,11 @@ func (f *factory) Metadata() *opt.Metadata {
 	return f.mem.metadata
 }
 
-// StoreList allocates storage for a list of group IDs in the memo and returns
-// an ID that can be used for later lookup.
-func (f *factory) StoreList(items []opt.GroupID) opt.ListID {
-	return f.mem.storeList(items)
+// InternList adds the given list of group IDs to memo storage and returns an
+// ID that can be used for later lookup. If the same list was added previously,
+// this method is a no-op and returns the ID of the previous value.
+func (f *factory) InternList(items []opt.GroupID) opt.ListID {
+	return f.mem.internList(items)
 }
 
 // InternPrivate adds the given private value to the memo and returns an ID

--- a/pkg/sql/opt/xform/factory.og.go
+++ b/pkg/sql/opt/xform/factory.og.go
@@ -1072,17 +1072,17 @@ func init() {
 
 	// TupleOp
 	dynConstructLookup[opt.TupleOp] = func(f *factory, children []opt.GroupID, private opt.PrivateID) opt.GroupID {
-		return f.ConstructTuple(f.StoreList(children))
+		return f.ConstructTuple(f.InternList(children))
 	}
 
 	// ProjectionsOp
 	dynConstructLookup[opt.ProjectionsOp] = func(f *factory, children []opt.GroupID, private opt.PrivateID) opt.GroupID {
-		return f.ConstructProjections(f.StoreList(children), private)
+		return f.ConstructProjections(f.InternList(children), private)
 	}
 
 	// FiltersOp
 	dynConstructLookup[opt.FiltersOp] = func(f *factory, children []opt.GroupID, private opt.PrivateID) opt.GroupID {
-		return f.ConstructFilters(f.StoreList(children))
+		return f.ConstructFilters(f.InternList(children))
 	}
 
 	// ExistsOp
@@ -1332,7 +1332,7 @@ func init() {
 
 	// FunctionOp
 	dynConstructLookup[opt.FunctionOp] = func(f *factory, children []opt.GroupID, private opt.PrivateID) opt.GroupID {
-		return f.ConstructFunction(f.StoreList(children), private)
+		return f.ConstructFunction(f.InternList(children), private)
 	}
 
 	// ScanOp
@@ -1342,7 +1342,7 @@ func init() {
 
 	// ValuesOp
 	dynConstructLookup[opt.ValuesOp] = func(f *factory, children []opt.GroupID, private opt.PrivateID) opt.GroupID {
-		return f.ConstructValues(f.StoreList(children), private)
+		return f.ConstructValues(f.InternList(children), private)
 	}
 
 	// SelectOp

--- a/pkg/sql/opt/xform/list_storage.go
+++ b/pkg/sql/opt/xform/list_storage.go
@@ -1,0 +1,143 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package xform
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/opt"
+)
+
+// listStorage stores lists of memo group ids. Each list is interned, which
+// means that each unique list is stored at most once. If the same list is
+// added twice to storage, the same storage is used, and the same list id is
+// returned by the intern method.
+//
+// To use listStorage, first call the init method to initialize storage. Call
+// the intern method to add lists to storage and get back a unique list id.
+// Call the lookup method with an id to retrieve previously added lists.
+//
+// listStorage uses a prefix tree index to perform efficient interning. Each
+// unique list prefix is added to the index, and maps to the offset in the
+// lists slice that stores that sequence of group ids. If a list is interned,
+// then future interns of that same list, or any prefix of that list, will
+// find the existing list (or a prefix of it) in the index. For example,
+// consider the following lists interned in this order:
+//   [1 2]
+//   [1]
+//   [2 3]
+//   [2 3 4]
+//   [2 4]
+//   [2 3]
+//
+// The resulting lists slice looks like this (0th item is always unused):
+//   [0 1 2 2 3 4 2 4]
+//
+// The resulting prefix tree is equivalent to this:
+//   []: EmptyList
+//    ├── [1]: ListID{Offset: 1, Length: 1}
+//    │    └── [2]: ListID{Offset: 1, Length: 2]
+//    │
+//    └── [2]: ListID{Offset: 3, Length: 1}
+//         ├── [3]: ListID{Offset: 3, Length: 2}
+//         │    └── [4]: ListID{Offset: 3, Length: 3}
+//         │
+//         └── [4]: ListID{Offset: 6, Length: 2}
+//
+// Future calls to intern would return these list ids:
+//   [1]    : ListID{Offset: 1, Length: 1}
+//   [1 2]  : ListID{Offset: 1, Length: 2}
+//   [2]    : ListID{Offset: 3, Length: 1}
+//   [2 3]  : ListID{Offset: 3, Length: 2}
+//   [2 3 4]: ListID{Offset: 3, Length: 3}
+//   [2 4]  : ListID{Offset: 6, Length: 2}
+//
+type listStorage struct {
+	// index maps the path of each node in the prefix tree to the index of the
+	// list in the lists slice. See listStorageKey comment for more details
+	// about node path format.
+	index map[listStorageKey]uint32
+	lists []opt.GroupID
+}
+
+// listStorageKey is the path to a node in the prefix tree. The path is a
+// (prefix, item) pair, where prefix is the list of edges from root to parent
+// node, and item is the last edge from parent to child. This representation is
+// a legal and efficient map key type, and it allows the entire prefix tree to
+// be stored in a map, which are highly optimized in Go.
+type listStorageKey struct {
+	prefix opt.ListID
+	item   opt.GroupID
+}
+
+// init must be called before using other methods on listStorage.
+func (ls *listStorage) init() {
+	ls.index = make(map[listStorageKey]uint32)
+	ls.lists = make([]opt.GroupID, 1)
+}
+
+// intern adds the given list to storage and returns an id that can later be
+// used to retrieve the list by calling the lookup method. If the list has been
+// previously added to storage, then intern always returns the same list id
+// that was returned from the previous call. intern is an O(N) operation, where
+// N is the length of the list.
+func (ls *listStorage) intern(list []opt.GroupID) opt.ListID {
+	// Start with empty prefix.
+	prefix := opt.EmptyList
+
+	for i, item := range list {
+		// Is there an existing list for the prefix + next item?
+		key := listStorageKey{prefix: prefix, item: item}
+		existing := ls.index[key]
+		if existing == 0 {
+			// No, so append the list now.
+			return ls.appendList(prefix, list)
+		}
+
+		// Yes, so set the new prefix and keep looping.
+		prefix = opt.ListID{Offset: existing, Length: uint32(i + 1)}
+	}
+
+	// Found an existing list, so return it.
+	return prefix
+}
+
+// lookup returns a list that was previously interned by listStorage. Do not
+// change the elements of the returned list or append to it. lookup is an O(1)
+// operation.
+func (ls *listStorage) lookup(id opt.ListID) []opt.GroupID {
+	return ls.lists[id.Offset : id.Offset+id.Length]
+}
+
+func (ls *listStorage) appendList(prefix opt.ListID, list []opt.GroupID) opt.ListID {
+	var offset uint32
+
+	// If prefix is the last list in the slice, then optimize by appending only
+	// the suffix.
+	if prefix.Offset+prefix.Length == uint32(len(ls.lists)) {
+		offset = prefix.Offset
+		ls.lists = append(ls.lists, list[prefix.Length:]...)
+	} else {
+		offset = uint32(len(ls.lists))
+		ls.lists = append(ls.lists, list...)
+	}
+
+	// Add rest of list to the index (prefix is already in the index).
+	for i := prefix.Length; i < uint32(len(list)); i++ {
+		key := listStorageKey{prefix: prefix, item: list[i]}
+		ls.index[key] = offset
+		prefix = opt.ListID{Offset: offset, Length: i + 1}
+	}
+
+	return opt.ListID{Offset: offset, Length: uint32(len(list))}
+}

--- a/pkg/sql/opt/xform/list_storage_test.go
+++ b/pkg/sql/opt/xform/list_storage_test.go
@@ -1,0 +1,90 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package xform
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/opt"
+)
+
+func TestListStorage(t *testing.T) {
+	var ls listStorage
+	ls.init()
+
+	catID := ls.intern(stringToGroups("cat"))
+	if catID != (opt.ListID{Offset: 1, Length: 3}) {
+		t.Fatalf("unexpected id: %v", catID)
+	}
+
+	// Should return sublist since "c" is prefix of "cat".
+	cID := ls.intern(stringToGroups("c"))
+	if cID != (opt.ListID{Offset: 1, Length: 1}) {
+		t.Fatalf("unexpected id: %v", cID)
+	}
+
+	// Should append to existing "cat" list, since it's last in the slice.
+	catalogID := ls.intern(stringToGroups("catalog"))
+	if catalogID != (opt.ListID{Offset: 1, Length: 7}) {
+		t.Fatalf("unexpected id: %v", catalogID)
+	}
+
+	// Should create new list.
+	dogID := ls.intern(stringToGroups("dog"))
+	if dogID != (opt.ListID{Offset: 8, Length: 3}) {
+		t.Fatalf("unexpected id: %v", dogID)
+	}
+
+	// Should create new list, since "catalog" is no longer last in the slice.
+	catalogingID := ls.intern(stringToGroups("cataloging"))
+	if catalogingID != (opt.ListID{Offset: 11, Length: 10}) {
+		t.Fatalf("unexpected id: %v", catalogingID)
+	}
+
+	// Should create new list even though it's a substring of existing list.
+	logID := ls.intern(stringToGroups("log"))
+	if logID != (opt.ListID{Offset: 21, Length: 3}) {
+		t.Fatalf("unexpected id: %v", logID)
+	}
+
+	if s := groupsToString(ls.lookup(catID)); s != "cat" {
+		t.Fatalf("unexpected lookup: %v", s)
+	}
+
+	if s := groupsToString(ls.lookup(dogID)); s != "dog" {
+		t.Fatalf("unexpected lookup: %v", s)
+	}
+
+	if s := groupsToString(ls.lookup(catalogID)); s != "catalog" {
+		t.Fatalf("unexpected lookup: %v", s)
+	}
+}
+
+func stringToGroups(s string) []opt.GroupID {
+	groups := make([]opt.GroupID, len(s))
+	for i, rune := range s {
+		groups[i] = opt.GroupID(rune)
+	}
+	return groups
+}
+
+func groupsToString(groups []opt.GroupID) string {
+	var buf bytes.Buffer
+	for _, group := range groups {
+		buf.WriteRune(rune(group))
+	}
+	return buf.String()
+}

--- a/pkg/sql/opt/xform/logical_props_test.go
+++ b/pkg/sql/opt/xform/logical_props_test.go
@@ -96,12 +96,12 @@ func TestLogicalGroupByProps(t *testing.T) {
 
 	col1 := f.Metadata().TableColumn(a, 1)
 	varGroup := f.ConstructVariable(f.InternPrivate(col1))
-	items1 := f.StoreList([]opt.GroupID{varGroup})
+	items1 := f.InternList([]opt.GroupID{varGroup})
 	cols1 := util.MakeFastIntSet(int(col1))
 	groupingsGroup := f.ConstructProjections(items1, f.InternPrivate(&cols1))
 
 	col2 := f.Metadata().AddColumn("false", types.Bool)
-	items2 := f.StoreList([]opt.GroupID{f.ConstructFalse()})
+	items2 := f.InternList([]opt.GroupID{f.ConstructFalse()})
 	cols2 := util.MakeFastIntSet(int(col2))
 	aggsGroup := f.ConstructProjections(items2, f.InternPrivate(&cols2))
 
@@ -141,7 +141,7 @@ func TestLogicalValuesProps(t *testing.T) {
 	a := f.Metadata().AddTable(cat.Table("a"))
 
 	// (Values)
-	rows := f.StoreList(nil)
+	rows := f.InternList(nil)
 	a0 := f.Metadata().TableColumn(a, 0)
 	a1 := f.Metadata().TableColumn(a, 1)
 	cols := util.MakeFastIntSet(int(a0), int(a1))


### PR DESCRIPTION
Previously, each time a memo group list was created, its contents
were separately stored. This is not ideal, since it's better to
recognize equivalent expressions so that they can be optimized just
once. This PR adds interning support for lists, so that if the same
list is interned twice, the same list ID is returned each time. The
implementation uses a prefix tree to accomplish this efficiently.
Interning is O(N), where N is the number of items in the list. The
prefix tree adds additional storage requirements - on the order of
16 bytes + map overhead per item in unique lists.

Release note: None