### PR TITLE
sql: stop obfuscating client params in prepared statements

### DIFF
--- a/pkg/sql/conn_io.go
+++ b/pkg/sql/conn_io.go
@@ -180,7 +180,8 @@ var _ Command = DeletePreparedStmt{}
 type BindStmt struct {
 	PreparedStatementName string
 	PortalName            string
-	ProtocolMeta          interface{}
+	// OutFormats contains the requested formats for the output columns.
+	OutFormats []pgwirebase.FormatCode
 	// Args are the arguments for the prepared statement.
 	// They are passed in without decoding because decoding requires type
 	// inference to have been performed.

--- a/pkg/sql/pgwire/conn.go
+++ b/pkg/sql/pgwire/conn.go
@@ -509,7 +509,7 @@ func (c *conn) handleBind(ctx context.Context, buf *pgwirebase.ReadBuffer) error
 			PortalName:            portalName,
 			Args:                  qargs,
 			ArgFormatCodes:        qArgFormatCodes,
-			ProtocolMeta:          preparedPortalMeta{outFormats: columnFormatCodes},
+			OutFormats:            columnFormatCodes,
 		})
 }
 

--- a/pkg/sql/prepared_stmt.go
+++ b/pkg/sql/prepared_stmt.go
@@ -20,9 +20,11 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgwirebase"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
+	"github.com/lib/pq/oid"
 )
 
 // PreparedStatement is a SQL statement that has been parsed and the types
@@ -50,7 +52,9 @@ type PreparedStatement struct {
 	Columns     sqlbase.ResultColumns
 	portalNames map[string]struct{}
 
-	ProtocolMeta interface{} // a field for protocol implementations to hang metadata off of.
+	// InTypes represents the inferred types for placeholder, using protocol
+	// identifiers.
+	InTypes []oid.Oid
 
 	memAcc mon.BoundAccount
 }
@@ -209,7 +213,8 @@ type PreparedPortal struct {
 	Stmt  *PreparedStatement
 	Qargs tree.QueryArguments
 
-	ProtocolMeta interface{} // a field for protocol implementations to hang metadata off of.
+	// OutFormats contains the requested formats for the output columns.
+	OutFormats []pgwirebase.FormatCode
 
 	memAcc mon.BoundAccount
 }


### PR DESCRIPTION
Before this patch, some protocol params associated with prepared stmts
and portals were obfuscated from the sql package behind an interface{},
only to be cast back later by pgwire. This was probably done initially
because some of the types in question were not accessible to the sql
package, but now that has changed, so obfuscation is no longer
necessary. More importantly, the SQL package itself needs to deal with
these params in the upcoming world where it takes a bigger role in
preparing statements.

Release note: None