### PR TITLE
sql/sem/tree: make function names properly case-sensitive

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/function_lookup
+++ b/pkg/sql/logictest/testdata/logic_test/function_lookup
@@ -33,3 +33,8 @@ query T
 INSERT INTO foo(x) VALUES (42) RETURNING PG_TYPEOF(x)
 ----
 int
+
+# CockroachDB is case-preserving for quoted identifiers like pg, and
+# function names only exist in lowercase.
+query error unknown function: PG_TYPEOF()
+SELECT "PG_TYPEOF"(123)

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -5871,7 +5871,7 @@ a_expr:
   }
 | a_expr REMOVE_PATH a_expr
   {
-    $$.val = &tree.FuncExpr{Func: tree.WrapFunction("JSON_REMOVE_PATH"), Exprs: tree.Exprs{$1.expr(), $3.expr()}}
+    $$.val = &tree.FuncExpr{Func: tree.WrapFunction("json_remove_path"), Exprs: tree.Exprs{$1.expr(), $3.expr()}}
   }
 | a_expr LESS_EQUALS a_expr
   {
@@ -6420,7 +6420,7 @@ special_function:
 | OVERLAY '(' error { return helpWithFunctionByName(sqllex, $1) }
 | POSITION '(' position_list ')'
   {
-    $$.val = &tree.FuncExpr{Func: tree.WrapFunction("STRPOS"), Exprs: $3.exprs()}
+    $$.val = &tree.FuncExpr{Func: tree.WrapFunction("strpos"), Exprs: $3.exprs()}
   }
 | SUBSTRING '(' substr_list ')'
   {
@@ -6430,19 +6430,19 @@ special_function:
 | TREAT '(' a_expr AS typename ')' { return unimplemented(sqllex, "treat") }
 | TRIM '(' BOTH trim_list ')'
   {
-    $$.val = &tree.FuncExpr{Func: tree.WrapFunction("BTRIM"), Exprs: $4.exprs()}
+    $$.val = &tree.FuncExpr{Func: tree.WrapFunction("btrim"), Exprs: $4.exprs()}
   }
 | TRIM '(' LEADING trim_list ')'
   {
-    $$.val = &tree.FuncExpr{Func: tree.WrapFunction("LTRIM"), Exprs: $4.exprs()}
+    $$.val = &tree.FuncExpr{Func: tree.WrapFunction("ltrim"), Exprs: $4.exprs()}
   }
 | TRIM '(' TRAILING trim_list ')'
   {
-    $$.val = &tree.FuncExpr{Func: tree.WrapFunction("RTRIM"), Exprs: $4.exprs()}
+    $$.val = &tree.FuncExpr{Func: tree.WrapFunction("rtrim"), Exprs: $4.exprs()}
   }
 | TRIM '(' trim_list ')'
   {
-    $$.val = &tree.FuncExpr{Func: tree.WrapFunction("BTRIM"), Exprs: $3.exprs()}
+    $$.val = &tree.FuncExpr{Func: tree.WrapFunction("btrim"), Exprs: $3.exprs()}
   }
 | GREATEST '(' expr_list ')'
   {

--- a/pkg/sql/sem/builtins/all_builtins.go
+++ b/pkg/sql/sem/builtins/all_builtins.go
@@ -16,7 +16,6 @@ package builtins
 
 import (
 	"sort"
-	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
@@ -40,18 +39,14 @@ func init() {
 		AllBuiltinNames = append(AllBuiltinNames, name)
 	}
 
-	// We alias the builtins to uppercase to hasten the lookup in the
-	// common case. Also generate missing categories.
+	// Generate missing categories.
 	for _, name := range AllBuiltinNames {
-		uname := strings.ToUpper(name)
 		def := Builtins[name]
 		for i, b := range def {
 			if b.Category == "" {
 				def[i].Category = getCategory(def[i])
 			}
 		}
-		Builtins[uname] = def
-		tree.FunDefs[uname] = tree.FunDefs[name]
 	}
 
 	sort.Strings(AllBuiltinNames)


### PR DESCRIPTION
There was a time in the past where CockroachDB was (or attempted to
be) case-insensitive about identifiers, and this was a source of
incompatibility with PostgreSQL.

This incompatibility was corrected for object
(table/view/database/index) names and column names in #16884, but
somehow I forgot about function names in that patch. As a result,
CockroachDB continued to consider `upper()` and `"UPPER"()` the same
thing, whereas most definitely only the former is valid.

This patch corrects the issue and simplifies the code accordingly.

Release note (sql change): CockroachDB now properly rejects
incorrectly cased SQL function names with an error.