### PR TITLE
sql: add a new supported event to the conn state machine

### DIFF
--- a/pkg/sql/conn_fsm.go
+++ b/pkg/sql/conn_fsm.go
@@ -31,6 +31,7 @@ import (
 	// implementations using that library are weird beasts intimately inter-twined
 	// with that package; therefor this file should stay as small as possible.
 	. "github.com/cockroachdb/cockroach/pkg/util/fsm"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 )
 
 /// States.
@@ -327,6 +328,23 @@ var TxnStateTransitions = Compile(Pattern{
 			Next:        stateCommitWait{},
 			Action: func(args Args) error {
 				args.Extended.(*txnState2).setAdvanceInfo(advanceOne, flush, noRewind, txnCommit)
+				return nil
+			},
+		},
+		// ROLLBACK TO SAVEPOINT
+		eventTxnRestart{}: {
+			Description: "ROLLBACK TO SAVEPOINT cockroach_restart",
+			Next:        stateOpen{ImplicitTxn: False, RetryIntent: True},
+			Action: func(args Args) error {
+				state := args.Extended.(*txnState2)
+				// NOTE: We don't bump the txn timestamp on this restart. Should we?
+				// Well, if we generally supported savepoints and one would issue a
+				// rollback to a regular savepoint, clearly we couldn't bump the
+				// timestamp in that case. In the special case of the cockroach_restart
+				// savepoint, it's not clear to me what a user's expectation might be.
+				state.mu.txn.Proto().Restart(
+					0 /* userPriority */, 0 /* upgradePriority */, hlc.Timestamp{})
+				args.Extended.(*txnState2).setAdvanceInfo(advanceOne, flush, noRewind, txnRestart)
 				return nil
 			},
 		},

--- a/pkg/sql/txn_state_test.go
+++ b/pkg/sql/txn_state_test.go
@@ -639,6 +639,25 @@ func TestTransitions(t *testing.T) {
 				isFinalized: &varTrue,
 			},
 		},
+		{
+			// Restarting from Open via ROLLBACK TO SAVEPOINT.
+			name: "Open + restart",
+			init: func() (State, *txnState2, error) {
+				s, ts := testCon.createOpenState(explicitTxn, retryIntentSet)
+				return s, ts, nil
+			},
+			ev:       eventTxnRestart{},
+			expState: stateOpen{ImplicitTxn: False, RetryIntent: True},
+			expAdv: expAdvance{
+				expCode:  advanceOne,
+				expFlush: flush,
+				expEv:    txnRestart,
+			},
+			expTxn: &expKVTxn{
+			// We would like to test that the transaction's epoch bumped if the txn
+			// performed any operations, but it's not easy to do the test.
+			},
+		},
 		//
 		// Tests starting from the Aborted state.
 		//

--- a/pkg/sql/txnstatetransitions_diagram.gv
+++ b/pkg/sql/txnstatetransitions_diagram.gv
@@ -36,6 +36,7 @@ digraph finite_state_machine {
 	"Open{ImplicitTxn:false, RetryIntent:true}" -> "Open{ImplicitTxn:false, RetryIntent:true}" [label = <RetriableErr{CanAutoRetry:true, IsCommit:true}<BR/><I>Retriable err; will auto-retry</I>>]
 	"Open{ImplicitTxn:false, RetryIntent:true}" -> "NoTxn{}" [label = <TxnFinish{}<BR/><I>COMMIT/ROLLBACK, or after a statement running as an implicit txn</I>>]
 	"Open{ImplicitTxn:false, RetryIntent:true}" -> "CommitWait{}" [label = <TxnReleased{}<BR/><I>RELEASE SAVEPOINT cockroach_restart</I>>]
+	"Open{ImplicitTxn:false, RetryIntent:true}" -> "Open{ImplicitTxn:false, RetryIntent:true}" [label = <TxnRestart{}<BR/><I>ROLLBACK TO SAVEPOINT cockroach_restart</I>>]
 	"Open{ImplicitTxn:true, RetryIntent:false}" -> "NoTxn{}" [label = "NonRetriableErr{IsCommit:false}"]
 	"Open{ImplicitTxn:true, RetryIntent:false}" -> "NoTxn{}" [label = "NonRetriableErr{IsCommit:true}"]
 	"Open{ImplicitTxn:true, RetryIntent:false}" -> "NoTxn{}" [label = "RetriableErr{CanAutoRetry:false, IsCommit:false}"]

--- a/pkg/sql/txnstatetransitions_report.txt
+++ b/pkg/sql/txnstatetransitions_report.txt
@@ -85,9 +85,9 @@ Open{ImplicitTxn:false, RetryIntent:true}
 		RetriableErr{CanAutoRetry:true, IsCommit:true}
 		TxnFinish{}
 		TxnReleased{}
+		TxnRestart{}
 	missing events:
 		RetryIntentSet{}
-		TxnRestart{}
 		TxnStart{ImplicitTxn:false}
 		TxnStart{ImplicitTxn:true}
 Open{ImplicitTxn:true, RetryIntent:false}


### PR DESCRIPTION
This patch adds support for the event generated when running a `rollback
to savepoint cockroach_restart` when in state Open (so, when no error
has occured). We support running this with the current Executor code;
this adds feature parity to the conn_fsm.

Release note: None