### PR TITLE
Makefile: ensure optgen is up-to-date

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -360,9 +360,7 @@ $(BOOTSTRAP_TARGET): $(GITHOOKS) Gopkg.lock bin/returncheck | $(SUBMODULES_TARGE
 		./vendor/golang.org/x/perf/cmd/benchstat \
 		./vendor/golang.org/x/tools/cmd/goimports \
 		./vendor/golang.org/x/tools/cmd/goyacc \
-		./vendor/golang.org/x/tools/cmd/stringer \
-		./pkg/sql/opt/optgen/cmd/langgen \
-		./pkg/sql/opt/optgen/cmd/optgen
+		./vendor/golang.org/x/tools/cmd/stringer
 	touch $@
 
 $(SUBMODULES_TARGET):
@@ -839,6 +837,9 @@ dupl: $(BOOTSTRAP_TARGET)
 .PHONY: generate
 generate: ## Regenerate generated code.
 generate: protobuf $(DOCGEN_TARGETS)
+	@$(GO_INSTALL) -v \
+		./pkg/sql/opt/optgen/cmd/langgen \
+		./pkg/sql/opt/optgen/cmd/optgen
 	$(GO) generate $(GOFLAGS) -tags '$(TAGS)' -ldflags '$(LINKFLAGS)' $(PKG)
 
 .PHONY: lint


### PR DESCRIPTION
Previously we would only produce optgen and langen binaries once, when
"bootstrapping" a CockroachDB clone during the first build. A later `git
pull` could pull down updates to the optgen and langgen sources, but
Make would continue to use the stale optgen and langgen binaries in
`make generate`.

Instead, teach `make generate` to `go install` optgen and langgen, so
that the binaries are always up-to-date.

Release note: None