### PR TITLE
ui: show aggregated stats for localities w/ gauge

### DIFF
--- a/pkg/storage/metrics.go
+++ b/pkg/storage/metrics.go
@@ -141,6 +141,16 @@ var (
 	metaLastUpdateNanos = metric.Metadata{
 		Name: "lastupdatenanos",
 		Help: "Time at which ages were last updated"}
+
+	// Disk usage diagram (CR=Cockroach):
+	//                            ---------------------------------
+	// Entire hard drive:         | non-CR data | CR data | empty |
+	//                            ---------------------------------
+	// Metrics:
+	//                "capacity": |===============================|
+	//                    "used":               |=========|
+	//               "available":                         |=======|
+	// "usable" (computed in UI):               |=================|
 	metaCapacity = metric.Metadata{
 		Name: "capacity",
 		Help: "Total storage capacity"}
@@ -150,6 +160,7 @@ var (
 	metaUsed = metric.Metadata{
 		Name: "capacity.used",
 		Help: "Used storage capacity"}
+
 	metaReserved = metric.Metadata{
 		Name: "capacity.reserved",
 		Help: "Capacity reserved for snapshots"}

--- a/pkg/ui/ccl/src/views/clusterviz/containers/map/nodeView.tsx
+++ b/pkg/ui/ccl/src/views/clusterviz/containers/map/nodeView.tsx
@@ -8,132 +8,33 @@
 
 import React from "react";
 
-import { MetricConstants } from "src/util/proto";
-import { Bytes } from "src/util/format";
+import { NodeStatus$Properties } from "src/util/proto";
+import { StatsView } from "ccl/src/views/clusterviz/containers/map/statsView";
+import { sumNodeStats } from "src/redux/nodes";
+import { cockroach } from "src/js/protos";
+import { SimulatedNodeStatus } from "ccl/src/views/clusterviz/containers/map/nodeSimulator";
 
-import { SimulatedNodeStatus } from "./nodeSimulator";
-import * as PathMath from "./pathmath";
+type NodeLivenessStatus = cockroach.storage.NodeLivenessStatus;
 
 interface NodeViewProps {
-  nodeHistory: SimulatedNodeStatus;
+  node: NodeStatus$Properties;
+  liveness: { [id: string]: NodeLivenessStatus };
+
+  nodeHistory?: SimulatedNodeStatus;
   maxClientActivityRate: number;
 }
 
 export class NodeView extends React.Component<NodeViewProps, any> {
-  static radius = 42;
-  static arcWidth = NodeView.radius * 0.11111;
-  static outerRadius = NodeView.radius + NodeView.arcWidth;
-  static maxRadius = NodeView.outerRadius + NodeView.arcWidth;
-
-  renderBackground() {
-    return (
-      <path
-        className="capacity-background"
-        d={PathMath.createArcPath(
-          NodeView.radius, NodeView.outerRadius, PathMath.arcAngleFromPct(0), PathMath.arcAngleFromPct(1),
-        )}
-      />
-    );
-  }
-
-  renderCapacityArc() {
-    // Compute used percentage.
-    const { metrics } = this.props.nodeHistory.latest();
-    const used = metrics[MetricConstants.usedCapacity];
-    const capacity = metrics[MetricConstants.capacity];
-    const capacityUsedPct = (capacity) ? used / capacity : 0;
-
-    const usedX = Math.cos(PathMath.angleFromPct(capacityUsedPct));
-    const usedY = Math.sin(PathMath.angleFromPct(capacityUsedPct));
-
-    return (
-      <g>
-        <text
-          className="capacity-label"
-          x={(NodeView.outerRadius + NodeView.arcWidth) * Math.cos(0)}
-        >
-          {Bytes(capacity)}
-        </text>
-        <path
-          className="capacity-used"
-          d={PathMath.createArcPath(
-            NodeView.radius,
-            NodeView.outerRadius,
-            PathMath.arcAngleFromPct(0),
-            PathMath.arcAngleFromPct(capacityUsedPct),
-          )}
-        />
-        <text
-          className="capacity-used-label"
-          transform={`translate(${usedX * NodeView.maxRadius}, ${usedY * NodeView.maxRadius})`}
-          textAnchor={capacityUsedPct < 0.75 ? "end" : "start"}
-        >
-          {Bytes(used)}
-        </text>
-
-        <g transform={`translate(${-NodeView.outerRadius}, ${-NodeView.outerRadius})`}>
-          <svg width={NodeView.outerRadius * 2} height={NodeView.outerRadius * 2}>
-            <text className="capacity-used-pct-label" x="50%" y="40%">
-              {Math.round(100 * capacityUsedPct) + "%"}
-            </text>
-            <text className="capacity-used-text" x="50%" y="60%">
-              CAPACITY USED
-              </text>
-          </svg>
-        </g>
-      </g>
-    );
-  }
-
-  renderNetworkActivity() {
-    const barsX = NodeView.radius * Math.cos(PathMath.angleFromPct(0));
-    const barsWidth = NodeView.outerRadius - barsX - 4;
-    const labelH = 8;
-
-    const { nodeHistory, maxClientActivityRate } = this.props;
-
-    return (
-      <g transform={`translate(0,${NodeView.radius * Math.sin(PathMath.angleFromPct(0))})`} >
-        <line
-          className="client-activity"
-          x1={NodeView.outerRadius - 2}
-          y1={-labelH}
-          x2={Math.round(NodeView.outerRadius - barsWidth * nodeHistory.clientActivityRate / maxClientActivityRate)}
-          y2={-labelH}
-        />
-        <text className="client-activity-label" x={NodeView.outerRadius + NodeView.arcWidth} y={-labelH}>
-          {Math.round(nodeHistory.clientActivityRate)} qps
-          </text>
-      </g>
-    );
-  }
-
-  renderLabel() {
-    return (
-      <g transform={`translate(${-NodeView.outerRadius}, ${NodeView.outerRadius * 0.9})`}>
-        <path
-          className="locality-label-background"
-          d={PathMath.drawBox(NodeView.outerRadius * 2, 20, 0.05)}
-        />
-        <svg width={NodeView.outerRadius * 2} height="20">
-          <text className="locality-label" x="50%" y="55%">
-            {this.props.nodeHistory.latest().desc.address.address_field}
-          </text>
-        </svg>
-      </g>
-    );
-  }
-
   render() {
+    const { node, liveness } = this.props;
+    const { capacityUsable, capacityUsed } = sumNodeStats([node], liveness);
+
     return (
-      <g className="locality">
-        <g className="capacity-centric">
-          {this.renderBackground()}
-          {this.renderCapacityArc()}
-          {this.renderNetworkActivity()}
-          {this.renderLabel()}
-        </g>
-      </g>
+      <StatsView
+        usableCapacity={capacityUsable}
+        usedCapacity={capacityUsed}
+        label={node.desc.address.address_field}
+      />
     );
   }
 }

--- a/pkg/ui/ccl/src/views/clusterviz/containers/map/statsView.tsx
+++ b/pkg/ui/ccl/src/views/clusterviz/containers/map/statsView.tsx
@@ -1,0 +1,141 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Cockroach Community Licence (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+import React from "react";
+
+import { Bytes } from "src/util/format";
+
+import { SimulatedNodeStatus } from "./nodeSimulator";
+import * as PathMath from "./pathmath";
+
+interface StatsViewProps {
+  usableCapacity: number;
+  usedCapacity: number;
+  label: string;
+
+  nodeHistory?: SimulatedNodeStatus;
+  maxClientActivityRate?: number;
+}
+
+export class StatsView extends React.Component<StatsViewProps, any> {
+  static radius = 42;
+  static arcWidth = StatsView.radius * 0.11111;
+  static outerRadius = StatsView.radius + StatsView.arcWidth;
+  static maxRadius = StatsView.outerRadius + StatsView.arcWidth;
+
+  renderBackground() {
+    return (
+      <path
+        className="capacity-background"
+        d={PathMath.createArcPath(
+          StatsView.radius, StatsView.outerRadius, PathMath.arcAngleFromPct(0), PathMath.arcAngleFromPct(1),
+        )}
+      />
+    );
+  }
+
+  renderCapacityArc() {
+    // Compute used percentage.
+    const usedCapacity = this.props.usedCapacity;
+    const capacity = this.props.usableCapacity;
+    const capacityUsedPct = (capacity) ? usedCapacity / capacity : 0;
+
+    const usedX = Math.cos(PathMath.angleFromPct(capacityUsedPct));
+    const usedY = Math.sin(PathMath.angleFromPct(capacityUsedPct));
+
+    return (
+      <g>
+        <text
+          className="capacity-label"
+          x={(StatsView.outerRadius + StatsView.arcWidth) * Math.cos(0)}
+        >
+          {Bytes(capacity)}
+        </text>
+        <path
+          className="capacity-used"
+          d={PathMath.createArcPath(
+            StatsView.radius,
+            StatsView.outerRadius,
+            PathMath.arcAngleFromPct(0),
+            PathMath.arcAngleFromPct(capacityUsedPct),
+          )}
+        />
+        <text
+          className="capacity-used-label"
+          transform={`translate(${usedX * StatsView.maxRadius}, ${usedY * StatsView.maxRadius})`}
+          textAnchor={capacityUsedPct < 0.75 ? "end" : "start"}
+        >
+          {Bytes(usedCapacity)}
+        </text>
+
+        <g transform={`translate(${-StatsView.outerRadius}, ${-StatsView.outerRadius})`}>
+          <svg width={StatsView.outerRadius * 2} height={StatsView.outerRadius * 2}>
+            <text className="capacity-used-pct-label" x="50%" y="40%">
+              {Math.round(100 * capacityUsedPct) + "%"}
+            </text>
+            <text className="capacity-used-text" x="50%" y="60%">
+              CAPACITY USED
+            </text>
+          </svg>
+        </g>
+      </g>
+    );
+  }
+
+  renderNetworkActivity() {
+    const barsX = StatsView.radius * Math.cos(PathMath.angleFromPct(0));
+    const barsWidth = StatsView.outerRadius - barsX - 4;
+    const labelH = 8;
+
+    const { nodeHistory, maxClientActivityRate } = this.props;
+
+    return (
+      <g transform={`translate(0,${StatsView.radius * Math.sin(PathMath.angleFromPct(0))})`} >
+        <line
+          className="client-activity"
+          x1={StatsView.outerRadius - 2}
+          y1={-labelH}
+          x2={Math.round(StatsView.outerRadius - barsWidth * nodeHistory.clientActivityRate / maxClientActivityRate)}
+          y2={-labelH}
+        />
+        <text className="client-activity-label" x={StatsView.outerRadius + StatsView.arcWidth} y={-labelH}>
+          {Math.round(nodeHistory.clientActivityRate)} qps
+        </text>
+      </g>
+    );
+  }
+
+  renderLabel() {
+    return (
+      <g transform={`translate(${-StatsView.outerRadius}, ${StatsView.outerRadius * 0.9})`}>
+        <path
+          className="locality-label-background"
+          d={PathMath.drawBox(StatsView.outerRadius * 2, 20, 0.05)}
+        />
+        <svg width={StatsView.outerRadius * 2} height="20">
+          <text className="locality-label" x="50%" y="55%">
+            {this.props.label}
+          </text>
+        </svg>
+      </g>
+    );
+  }
+
+  render() {
+    return (
+      <g className="locality">
+        <g className="capacity-centric">
+          {this.renderBackground()}
+          {this.renderCapacityArc()}
+          {this.props.nodeHistory ? this.renderNetworkActivity() : null}
+          {this.renderLabel()}
+        </g>
+      </g>
+    );
+  }
+}

--- a/pkg/ui/src/redux/nodes.ts
+++ b/pkg/ui/src/redux/nodes.ts
@@ -116,7 +116,7 @@ const nodeSumsSelector = createSelector(
 
 export function sumNodeStats(
   nodeStatuses: NodeStatus$Properties[],
-  livenessStatusByNodeID: Dictionary<LivenessStatus>,
+  livenessStatusByNodeID: { [id: string]: LivenessStatus },
 ) {
   const result = {
     nodeCounts: {

--- a/pkg/ui/src/redux/nodes.ts
+++ b/pkg/ui/src/redux/nodes.ts
@@ -64,11 +64,18 @@ export const livenessByNodeIDSelector = createSelector(
   },
 );
 
+/*
+ * selectLivenessRequestStatus returns the current status of the liveness request.
+ */
+export function selectLivenessRequestStatus(state: AdminUIState) {
+  return state.cachedData.liveness;
+}
+
 /**
  * livenessStatusByNodeIDSelector returns a map from NodeID to the
  * LivenessStatus of that node.
  */
-const livenessStatusByNodeIDSelector = createSelector(
+export const livenessStatusByNodeIDSelector = createSelector(
   livenessesSelector,
   (livenesses) => livenesses ? (livenesses.statuses || {}) : {},
 );
@@ -104,63 +111,70 @@ const nodeStatusByIDSelector = createSelector(
 const nodeSumsSelector = createSelector(
   nodeStatusesSelector,
   livenessStatusByNodeIDSelector,
-  (nodeStatuses, livenessStatusByNodeID) => {
-    const result = {
-      nodeCounts: {
-        total: 0,
-        healthy: 0,
-        suspect: 0,
-        dead: 0,
-        decommissioned: 0,
-      },
-      capacityUsed: 0,
-      capacityAvailable: 0,
-      capacityTotal: 0,
-      usedBytes: 0,
-      usedMem: 0,
-      totalRanges: 0,
-      underReplicatedRanges: 0,
-      unavailableRanges: 0,
-      replicas: 0,
-    };
-    if (_.isArray(nodeStatuses) && _.isObject(livenessStatusByNodeID)) {
-      nodeStatuses.forEach((n) => {
-        const status = livenessStatusByNodeID[n.desc.node_id];
-        if (status !== LivenessStatus.DECOMMISSIONING) {
-          result.nodeCounts.total += 1;
-        }
-        switch (status) {
-          case LivenessStatus.LIVE:
-            result.nodeCounts.healthy++;
-            break;
-          case LivenessStatus.UNAVAILABLE:
-          case LivenessStatus.DECOMMISSIONING:
-            result.nodeCounts.suspect++;
-            break;
-          case LivenessStatus.DECOMMISSIONED:
-            result.nodeCounts.decommissioned++;
-            break;
-          case LivenessStatus.DEAD:
-          default:
-            result.nodeCounts.dead++;
-            break;
-        }
-        if (status !== LivenessStatus.DEAD) {
-          result.capacityUsed += n.metrics[MetricConstants.usedCapacity];
-          result.capacityAvailable += n.metrics[MetricConstants.availableCapacity];
-          result.capacityTotal += n.metrics[MetricConstants.capacity];
-          result.usedBytes += BytesUsed(n);
-          result.usedMem += n.metrics[MetricConstants.rss];
-          result.totalRanges += n.metrics[MetricConstants.ranges];
-          result.underReplicatedRanges += n.metrics[MetricConstants.underReplicatedRanges];
-          result.unavailableRanges += n.metrics[MetricConstants.unavailableRanges];
-          result.replicas += n.metrics[MetricConstants.replicas];
-        }
-      });
-    }
-    return result;
-  },
+  sumNodeStats,
 );
+
+export function sumNodeStats(
+  nodeStatuses: NodeStatus$Properties[],
+  livenessStatusByNodeID: Dictionary<LivenessStatus>,
+) {
+  const result = {
+    nodeCounts: {
+      total: 0,
+      healthy: 0,
+      suspect: 0,
+      dead: 0,
+      decommissioned: 0,
+    },
+    capacityUsed: 0,
+    capacityAvailable: 0,
+    capacityTotal: 0,
+    capacityUsable: 0,
+    usedBytes: 0,
+    usedMem: 0,
+    totalRanges: 0,
+    underReplicatedRanges: 0,
+    unavailableRanges: 0,
+    replicas: 0,
+  };
+  if (_.isArray(nodeStatuses) && _.isObject(livenessStatusByNodeID)) {
+    nodeStatuses.forEach((n) => {
+      const status = livenessStatusByNodeID[n.desc.node_id];
+      if (status !== LivenessStatus.DECOMMISSIONING) {
+        result.nodeCounts.total += 1;
+      }
+      switch (status) {
+        case LivenessStatus.LIVE:
+          result.nodeCounts.healthy++;
+          break;
+        case LivenessStatus.UNAVAILABLE:
+        case LivenessStatus.DECOMMISSIONING:
+          result.nodeCounts.suspect++;
+          break;
+        case LivenessStatus.DECOMMISSIONED:
+          result.nodeCounts.decommissioned++;
+          break;
+        case LivenessStatus.DEAD:
+        default:
+          result.nodeCounts.dead++;
+          break;
+      }
+      if (status !== LivenessStatus.DEAD) {
+        result.capacityUsed += n.metrics[MetricConstants.usedCapacity];
+        result.capacityAvailable += n.metrics[MetricConstants.availableCapacity];
+        result.capacityTotal += n.metrics[MetricConstants.capacity];
+        result.capacityUsable = result.capacityUsed + result.capacityAvailable;
+        result.usedBytes += BytesUsed(n);
+        result.usedMem += n.metrics[MetricConstants.rss];
+        result.totalRanges += n.metrics[MetricConstants.ranges];
+        result.underReplicatedRanges += n.metrics[MetricConstants.underReplicatedRanges];
+        result.unavailableRanges += n.metrics[MetricConstants.unavailableRanges];
+        result.replicas += n.metrics[MetricConstants.replicas];
+      }
+    });
+  }
+  return result;
+}
 
 /**
  * nodesSummarySelector returns a directory object containing a variety of

--- a/pkg/ui/src/util/localities.spec.ts
+++ b/pkg/ui/src/util/localities.spec.ts
@@ -7,6 +7,7 @@ import {
   parseLocalityRoute,
   getNodeLocalityTiers,
   getChildLocalities,
+  getLeaves,
   getLocality,
 } from "./localities";
 
@@ -293,5 +294,65 @@ describe("getLocality", function() {
 
       assert.equal(tree, null);
     });
+  });
+});
+
+describe("getLeaves", function() {
+  it("returns the leaves of a locality tree", function() {
+    const node1 = {
+      desc: {
+        node_id: 1,
+        locality: {
+          tiers: [
+            { key: "region", value: "us-east" },
+            { key: "zone", value: "us-east-1" },
+          ],
+        },
+      },
+    };
+    const node2 = {
+      desc: {
+        node_id: 1,
+        locality: {
+          tiers: [
+            { key: "region", value: "us-east" },
+          ],
+        },
+      },
+    };
+    // Uneven tree depth is intentional.
+    const localityTree: LocalityTree = {
+      tiers: [],
+      localities: {
+        region: {
+          "us-east": {
+            tiers: [{ key: "region", value: "us-east" }],
+            localities: {
+              zone: {
+                "us-east-1": {
+                  tiers: [
+                    { key: "region", value: "us-east" },
+                    { key: "zone", value: "us-east-1" },
+                  ],
+                  localities: {},
+                  nodes: [node1],
+                },
+              },
+            },
+            nodes: [],
+          },
+          "us-west": {
+            tiers: [{ key: "region", value: "us-west" }],
+            localities: {},
+            nodes: [node2],
+          },
+        },
+      },
+      nodes: [],
+    };
+
+    const leaves = getLeaves(localityTree);
+
+    assert.deepEqual(leaves, [node1, node2]);
   });
 });

--- a/pkg/ui/src/util/localities.ts
+++ b/pkg/ui/src/util/localities.ts
@@ -71,3 +71,18 @@ export function getLocality(localityTree: LocalityTree, tiers: LocalityTier[]): 
 
   return result;
 }
+
+/* getLeaves returns the leaves under the given locality tree. Confusingly,
+ * in this tree the "leaves" of the tree are nodes, i.e. servers.
+ */
+export function getLeaves(tree: LocalityTree): NodeStatus$Properties[] {
+  const output: NodeStatus$Properties[] = [];
+  function recur(curTree: LocalityTree) {
+    output.push(...curTree.nodes);
+    _.forEach(curTree.localities, (localityValues) => {
+      _.forEach(localityValues, recur);
+    });
+  }
+  recur(tree);
+  return output;
+}

--- a/pkg/ui/src/views/cluster/containers/clusterOverview/index.tsx
+++ b/pkg/ui/src/views/cluster/containers/clusterOverview/index.tsx
@@ -43,11 +43,10 @@ function renderCapacityUsage(props: CapacityUsageProps) {
 const mapStateToCapacityUsageProps = createSelector(
   nodesSummarySelector,
   function (nodesSummary: NodesSummary) {
-    const { capacityAvailable, capacityUsed } = nodesSummary.nodeSums;
-    const usableCapacity = capacityAvailable + capacityUsed;
+    const { capacityUsed, capacityUsable } = nodesSummary.nodeSums;
     return {
       usedCapacity: capacityUsed,
-      usableCapacity: usableCapacity,
+      usableCapacity: capacityUsable,
     };
   },
 );

--- a/pkg/ui/src/views/cluster/containers/nodeGraphs/summaryBar.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodeGraphs/summaryBar.tsx
@@ -59,9 +59,8 @@ function formatNanosAsMillis (n: number) {
  */
 export default function(props: ClusterSummaryProps) {
   // Capacity math used in the summary status section.
-  const { capacityAvailable, capacityUsed } = props.nodesSummary.nodeSums;
-  const usableCapacity = capacityAvailable + capacityUsed;
-  const capacityPercent = usableCapacity !== 0 ? (capacityUsed / usableCapacity) : null;
+  const { capacityUsed, capacityUsable } = props.nodesSummary.nodeSums;
+  const capacityPercent = capacityUsable !== 0 ? (capacityUsed / capacityUsable) : null;
 
   return (
     <div>
@@ -69,7 +68,7 @@ export default function(props: ClusterSummaryProps) {
         <SummaryLabel>Summary</SummaryLabel>
         <ClusterNodeTotals {...props}/>
         <SummaryStat title="Capacity Used" value={capacityPercent} format={formatPercentage}>
-          <SummaryStatMessage message={`You are using ${Bytes(capacityUsed)} of ${Bytes(usableCapacity)}
+          <SummaryStatMessage message={`You are using ${Bytes(capacityUsed)} of ${Bytes(capacityUsable)}
                                         usable storage capacity across all nodes.`} />
         </SummaryStat>
         <SummaryStat title="Unavailable ranges" value={props.nodesSummary.nodeSums.unavailableRanges} />


### PR DESCRIPTION
When the cluster viz shows a locality, sum up its disk usage metrics and show them with the gauge.

![screen shot 2018-02-01 at 5 53 38 pm](https://user-images.githubusercontent.com/7341/35707710-df1604a6-0778-11e8-8b03-e01a0a462119.png)

Release note: None