### PR TITLE
ui: add breadcrumbs to clusterviz

### DIFF
--- a/pkg/ui/ccl/src/views/clusterviz/containers/map/breadcrumbs.tsx
+++ b/pkg/ui/ccl/src/views/clusterviz/containers/map/breadcrumbs.tsx
@@ -1,0 +1,51 @@
+import React from "react";
+import _ from "lodash";
+import { Link } from "react-router";
+
+import { generateLocalityRoute } from "src/util/localities";
+import { LocalityTier } from "src/redux/localities";
+import { intersperse } from "src/util/intersperse";
+
+interface BreadcrumbsProps {
+  tiers: LocalityTier[];
+}
+
+export class Breadcrumbs extends React.Component<BreadcrumbsProps, {}> {
+  getLabel(path: LocalityTier[]): string {
+    if (path.length === 0) {
+      return "Cluster";
+    }
+
+    const thisTier = path[path.length - 1];
+    return `${thisTier.key}=${thisTier.value}`;
+  }
+
+  render() {
+    const paths = breadcrumbPaths(this.props.tiers);
+
+    return (
+      <div className="breadcrumbs">
+        {intersperse(
+          paths.map((path) => (
+            <span className="breadcrumb">
+              <Link to={"/clusterviz/" + generateLocalityRoute(path)}>
+                {this.getLabel(path)}
+              </Link>
+            </span>
+          )),
+          <span className="breadcrumb-sep"> &gt; </span>,
+        )}
+      </div>
+    );
+  }
+}
+
+function breadcrumbPaths(path: LocalityTier[]): LocalityTier[][] {
+  const pathSoFar: LocalityTier[] = [];
+  const output: LocalityTier[][] = [[]];
+  path.forEach((tier) => {
+    pathSoFar.push(tier);
+    output.push(_.clone(pathSoFar));
+  });
+  return output;
+}

--- a/pkg/ui/ccl/src/views/clusterviz/containers/map/index.tsx
+++ b/pkg/ui/ccl/src/views/clusterviz/containers/map/index.tsx
@@ -19,6 +19,8 @@ import "./sim.css";
 import NodeSimulator from "./nodeSimulator";
 import { WorldMap } from "./worldmap";
 import { Box, ZoomTransformer } from "./zoom";
+import { LocalityTier } from "src/redux/localities";
+import { Breadcrumbs } from "ccl/src/views/clusterviz/containers/map/breadcrumbs";
 
 interface ClusterVisualizationState {
   zoomTransform: ZoomTransformer;
@@ -92,7 +94,7 @@ export default class ClusterVisualization extends React.Component<RouterState, C
     window.removeEventListener("resize", this.debouncedOnResize);
   }
 
-  renderContent() {
+  renderContent(tiers: LocalityTier[]) {
     if (!this.state) {
       return null;
     }
@@ -107,8 +109,6 @@ export default class ClusterVisualization extends React.Component<RouterState, C
     projection.scale(projection.scale() * scale);
     projection.translate(vector.add(vector.mult(projection.translate(), scale), translate));
 
-    const tiers = parseLocalityRoute(this.props.params.splat);
-
     return (
       <g>
         <WorldMap projection={projection} />
@@ -118,17 +118,22 @@ export default class ClusterVisualization extends React.Component<RouterState, C
   }
 
   render() {
+    const tiers = parseLocalityRoute(this.props.params.splat);
+
     // We must render the SVG even before initializing the state, because we
     // need to read its dimensions from the DOM in order to initialize the
     // state.
     return (
-      <svg
-        style={{ width: "100%", height: "100%" }}
-        className="cluster-viz"
-        ref={svg => this.graphEl = svg}
-      >
-        { this.renderContent() }
-      </svg>
+      <div style={{ height: "100%" }}>
+        <Breadcrumbs tiers={tiers} />
+        <svg
+          style={{ width: "100%", height: "100%" }}
+          className="cluster-viz"
+          ref={svg => this.graphEl = svg}
+        >
+          { this.renderContent(tiers) }
+        </svg>
+      </div>
     );
   }
 }

--- a/pkg/ui/src/util/intersperse.spec.ts
+++ b/pkg/ui/src/util/intersperse.spec.ts
@@ -1,0 +1,22 @@
+import { assert } from "chai";
+
+import { intersperse } from "oss/src/util/intersperse";
+
+describe("intersperse", () => {
+
+  it("puts separator in between array items", () => {
+    const result = intersperse(["foo", "bar", "baz"], "-");
+    assert.deepEqual(result, ["foo", "-", "bar", "-", "baz"]);
+  });
+
+  it("puts separator in between array items when given a one-item array", () => {
+    const result = intersperse(["baz"], "-");
+    assert.deepEqual(result, ["baz"]);
+  });
+
+  it("puts separator in between array items when given an empty array", () => {
+    const result = intersperse([], "-");
+    assert.deepEqual(result, []);
+  });
+
+});

--- a/pkg/ui/src/util/intersperse.ts
+++ b/pkg/ui/src/util/intersperse.ts
@@ -1,0 +1,11 @@
+// e.g. intersperse(["foo", "bar", "baz"], "-") => ["foo", "-", "bar", "-", "baz"]
+export function intersperse<T>(array: T[], sep: T): T[] {
+  const output = [];
+  for (let i = 0; i < array.length; i++) {
+    if (i > 0) {
+      output.push(sep);
+    }
+    output.push(array[i]);
+  }
+  return output;
+}


### PR DESCRIPTION
They show you where you are in the locality tree, and allow you to go back up.

Completely unstyled for now, but nice to have this working.

![screen shot 2018-02-01 at 6 36 38 pm](https://user-images.githubusercontent.com/7341/35709131-3594d1da-077f-11e8-9aa8-b178d9b140dd.png)

Release note: None