### PR TITLE
sql: support set transaction_isolation statement

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/txn
+++ b/pkg/sql/logictest/testdata/logic_test/txn
@@ -222,7 +222,7 @@ statement ok
 UPDATE kv SET v = 'b' WHERE k in ('a')
 
 statement error cannot change the isolation level of a running transaction
-SET TRANSACTION ISOLATION LEVEL SNAPSHOT
+SET transaction_isolation = 'snapshot'
 
 statement ok
 ROLLBACK
@@ -237,6 +237,11 @@ SHOW TRANSACTION ISOLATION LEVEL
 ----
 serializable
 
+query T
+SHOW transaction_isolation
+----
+serializable
+
 statement ok
 SET TRANSACTION ISOLATION LEVEL SNAPSHOT
 
@@ -245,8 +250,18 @@ SHOW TRANSACTION ISOLATION LEVEL
 ----
 snapshot
 
+query T
+SHOW transaction_isolation
+----
+snapshot
+
 statement ok
 COMMIT
+
+# We can't set isolation level to an unsupported one.
+
+statement error unsupported isolation level "read committed"
+SET transaction_isolation = 'read committed'
 
 # We can explicitly start a transaction in snapshot isolation.
 

--- a/pkg/sql/sem/tree/txn.go
+++ b/pkg/sql/sem/tree/txn.go
@@ -37,6 +37,13 @@ var isolationLevelNames = [...]string{
 	SerializableIsolation: "SERIALIZABLE",
 }
 
+// IsolationLevelMap is a map from string isolation level name to isolation
+// level, in the lowercase format that set isolation_level supports.
+var IsolationLevelMap = map[string]IsolationLevel{
+	"serializable": SnapshotIsolation,
+	"snapshot":     SnapshotIsolation,
+}
+
 func (i IsolationLevel) String() string {
 	if i < 0 || i > IsolationLevel(len(isolationLevelNames)-1) {
 		return fmt.Sprintf("IsolationLevel(%d)", i)


### PR DESCRIPTION
Release note (sql change): support the set transaction_isolation
statement for Postgres compatibility.

Fixes #19611.