### PR TITLE
ts: Budget memory for time series queries

### DIFF
--- a/pkg/base/test_server_args.go
+++ b/pkg/base/test_server_args.go
@@ -73,15 +73,16 @@ type TestServerArgs struct {
 	ExternalIODir string
 
 	// Fields copied to the server.Config.
-	Insecure                 bool
-	RetryOptions             retry.Options
-	SocketFile               string
-	ScanInterval             time.Duration
-	ScanMaxIdleTime          time.Duration
-	SSLCertsDir              string
-	TimeSeriesQueryWorkerMax int
-	SQLMemoryPoolSize        int64
-	ListeningURLFile         string
+	Insecure                    bool
+	RetryOptions                retry.Options
+	SocketFile                  string
+	ScanInterval                time.Duration
+	ScanMaxIdleTime             time.Duration
+	SSLCertsDir                 string
+	TimeSeriesQueryWorkerMax    int
+	TimeSeriesQueryMemoryBudget int64
+	SQLMemoryPoolSize           int64
+	ListeningURLFile            string
 
 	// If set, this will be appended to the Postgres URL by functions that
 	// automatically open a connection to the server. That's equivalent to running

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -137,6 +137,9 @@ func makeTestConfigFromParams(params base.TestServerArgs) Config {
 	if params.TimeSeriesQueryWorkerMax != 0 {
 		cfg.TimeSeriesServerConfig.QueryWorkerMax = params.TimeSeriesQueryWorkerMax
 	}
+	if params.TimeSeriesQueryMemoryBudget != 0 {
+		cfg.TimeSeriesServerConfig.QueryMemoryMax = params.TimeSeriesQueryMemoryBudget
+	}
 	if params.DisableEventLog {
 		cfg.EventLogEnabled = false
 	}

--- a/pkg/storage/ts_maintenance_queue_test.go
+++ b/pkg/storage/ts_maintenance_queue_test.go
@@ -300,6 +300,7 @@ func TestTimeSeriesMaintenanceQueueServer(t *testing.T) {
 			now+ts.Resolution10s.SlabDuration(),
 			0,
 			&acc,
+			&memMon,
 		)
 		return dps, err
 	}


### PR DESCRIPTION
Allow the time series query system to budget the amount of memory used
for all queries currently in progress.

As described in comments:

> The server attempts to constrain the total amount of memory it uses for
> processing incoming queries. This is accomplished with a multi-pronged
> strategy:
> + The server has a worker memory limit, which is a quota for the amount of
>   memory that can be used across all currently executing queries.
> + The server also has a pre-set limit on the number of parallel workers that
>   can be executing at one time. Each worker is given an even share of the
>   server's total memory limit, which it should not exceed.
> + Each worker breaks its task into chunks which it will process sequentially;
>   the size of each chunk is calculated to avoid exceeding the memory limit.
>
> In addition to this strategy, the server uses a memory monitor to track the
> amount of memory being used in reality by worker tasks. This is intended to
> verify the calculations of the individual workers are correct.

Memory usage is not currently enforced by the memory monitor; instead,
the memory monitor will log messages if maximum usage exceeds twice the
allotted budget.

This commit breaks memory monitoring for the time series server into two
pools: one for workers to use while processing intermediate structures,
and another to hold the results of the query until they are returned.
This division will be necessary if we decide to budget result memory (in
order to avoid deadlocks when making reservations).

Note that, as of this commit, all queries estimate that there are six
nodes on the cluster for the purposes of estimating the amount of time
series data. This will be replaced in a future commit with a count
of nodes from the cluster; however, while that will provide more
accurate estimates and thus more efficient usage, it is not necessary
for the memory budget to provide value.

Resolves #20014