### PR TITLE
sql: add generation_expression column

### DIFF
--- a/pkg/sql/information_schema.go
+++ b/pkg/sql/information_schema.go
@@ -93,6 +93,13 @@ func dNameOrNull(s string) tree.Datum {
 	return tree.NewDName(s)
 }
 
+func dStringPtrOrEmpty(s *string) tree.Datum {
+	if s == nil {
+		return emptyString
+	}
+	return tree.NewDString(*s)
+}
+
 func dStringPtrOrNull(s *string) tree.Datum {
 	if s == nil {
 		return tree.DNull
@@ -251,7 +258,8 @@ CREATE TABLE information_schema.columns (
 	DATETIME_PRECISION INT,
 	CHARACTER_SET_CATALOG STRING,
 	CHARACTER_SET_SCHEMA STRING,
-	CHARACTER_SET_NAME STRING
+	CHARACTER_SET_NAME STRING,
+	GENERATION_EXPRESSION STRING
 );
 `,
 	populate: func(ctx context.Context, p *planner, prefix string, addRow func(...tree.Datum) error) error {
@@ -277,6 +285,7 @@ CREATE TABLE information_schema.columns (
 					tree.DNull,                               // character_set_catalog
 					tree.DNull,                               // character_set_schema
 					tree.DNull,                               // character_set_name
+					dStringPtrOrEmpty(column.ComputeExpr),    // generation_expression
 				)
 			})
 		})

--- a/pkg/sql/logictest/testdata/logic_test/computed
+++ b/pkg/sql/logictest/testdata/logic_test/computed
@@ -443,4 +443,23 @@ x CREATE TABLE x (
 statement ok
 DROP TABLE x
 
+statement ok
+CREATE TABLE x (
+  a INT,
+  b INT AS a * 2 STORED
+)
+
+query T colnames
+SELECT generation_expression FROM information_schema.columns
+WHERE table_name = 'x' and column_name = 'b'
+----
+generation_expression
+a * 2
+
+query I
+SELECT COUNT(*) FROM information_schema.columns
+WHERE table_name = 'x' and generation_expression = ''
+----
+1
+
 # TODO(justin): adding computed columns.

--- a/pkg/sql/logictest/testdata/logic_test/explain
+++ b/pkg/sql/logictest/testdata/logic_test/explain
@@ -222,7 +222,7 @@ sort                                       ·         ·
                      ├── render            ·         ·
                      │    └── filter       ·         ·
                      │         └── values  ·         ·
-                     │                     size      16 columns, 782 rows
+                     │                     size      17 columns, 783 rows
                      └── render            ·         ·
                           └── filter       ·         ·
                                └── values  ·         ·


### PR DESCRIPTION
This commit updates information_schema.columns to include the expression
to generate a computed column.

Release note: None