### PR TITLE
storage/engine: avoid memory unsafe operations

### DIFF
--- a/pkg/storage/engine/slice.go
+++ b/pkg/storage/engine/slice.go
@@ -15,18 +15,12 @@
 package engine
 
 import (
-	"reflect"
 	"unsafe"
 )
 
 func nonZeroingMakeByteSlice(len int) []byte {
-	var b []byte
-	*(*reflect.SliceHeader)(unsafe.Pointer(&b)) = reflect.SliceHeader{
-		Data: uintptr(mallocgc(uintptr(len), nil, false)),
-		Len:  len,
-		Cap:  len,
-	}
-	return b
+	ptr := mallocgc(uintptr(len), nil, false)
+	return (*[maxArrayLen]byte)(ptr)[:len:len]
 }
 
 // Replacement for C.GoBytes which does not zero initialize the returned slice


### PR DESCRIPTION
A uintptr does not act as a reference to memory as far as the GC is
concerned; reflect.SliceHeader is usually a bug because of that.

Avoiding transit through a uintptr guarantees that the memory won't be
collected unsafely.

via @petermattis

Release note: None