### PR TITLE
libroach,storage/engine: allow specification of arbitrary RocksDB options

### DIFF
--- a/c-deps/libroach/include/libroach.h
+++ b/c-deps/libroach/include/libroach.h
@@ -73,6 +73,7 @@ typedef struct {
   bool use_switching_env;
   bool must_exist;
   bool read_only;
+  DBSlice rocksdb_options;
   DBSlice extra_options;
 } DBOptions;
 

--- a/pkg/base/store_spec.go
+++ b/pkg/base/store_spec.go
@@ -70,6 +70,9 @@ type StoreSpec struct {
 	// UseSwitchingEnv is true if the "switching env" store version is desired.
 	// This is set by CCL code when encryption-at-rest is in use.
 	UseSwitchingEnv bool
+	// RocksDBOptions contains RocksDB specific options using a semicolon
+	// separated key-value syntax ("key1=value1; key2=value2").
+	RocksDBOptions string
 	// ExtraOptions is a serialized protobuf set by Go CCL code and passed through
 	// to C CCL code.
 	ExtraOptions []byte
@@ -225,6 +228,8 @@ func NewStoreSpec(value string) (StoreSpec, error) {
 			} else {
 				return StoreSpec{}, fmt.Errorf("%s is not a valid store type", value)
 			}
+		case "rocksdb":
+			ss.RocksDBOptions = value
 		default:
 			return StoreSpec{}, fmt.Errorf("%s is not a valid store field", field)
 		}

--- a/pkg/base/store_spec_test.go
+++ b/pkg/base/store_spec_test.go
@@ -34,49 +34,64 @@ func TestNewStoreSpec(t *testing.T) {
 		expected    StoreSpec
 	}{
 		// path
-		{"path=/mnt/hda1", "", StoreSpec{"/mnt/hda1", 0, 0, false, roachpb.Attributes{}, false, nil}},
-		{",path=/mnt/hda1", "", StoreSpec{"/mnt/hda1", 0, 0, false, roachpb.Attributes{}, false, nil}},
-		{"path=/mnt/hda1,", "", StoreSpec{"/mnt/hda1", 0, 0, false, roachpb.Attributes{}, false, nil}},
-		{",,,path=/mnt/hda1,,,", "", StoreSpec{"/mnt/hda1", 0, 0, false, roachpb.Attributes{}, false, nil}},
-		{"/mnt/hda1", "", StoreSpec{"/mnt/hda1", 0, 0, false, roachpb.Attributes{}, false, nil}},
+		{"path=/mnt/hda1", "", StoreSpec{Path: "/mnt/hda1"}},
+		{",path=/mnt/hda1", "", StoreSpec{Path: "/mnt/hda1"}},
+		{"path=/mnt/hda1,", "", StoreSpec{Path: "/mnt/hda1"}},
+		{",,,path=/mnt/hda1,,,", "", StoreSpec{Path: "/mnt/hda1"}},
+		{"/mnt/hda1", "", StoreSpec{Path: "/mnt/hda1"}},
 		{"path=", "no value specified for path", StoreSpec{}},
 		{"path=/mnt/hda1,path=/mnt/hda2", "path field was used twice in store definition", StoreSpec{}},
 		{"/mnt/hda1,path=/mnt/hda2", "path field was used twice in store definition", StoreSpec{}},
 
 		// attributes
-		{"path=/mnt/hda1,attrs=ssd", "", StoreSpec{"/mnt/hda1", 0, 0, false, roachpb.Attributes{Attrs: []string{"ssd"}}, false, nil}},
-		{"path=/mnt/hda1,attrs=ssd:hdd", "", StoreSpec{"/mnt/hda1", 0, 0, false, roachpb.Attributes{Attrs: []string{"hdd", "ssd"}}, false, nil}},
-		{"path=/mnt/hda1,attrs=hdd:ssd", "", StoreSpec{"/mnt/hda1", 0, 0, false, roachpb.Attributes{Attrs: []string{"hdd", "ssd"}}, false, nil}},
-		{"attrs=ssd:hdd,path=/mnt/hda1", "", StoreSpec{"/mnt/hda1", 0, 0, false, roachpb.Attributes{Attrs: []string{"hdd", "ssd"}}, false, nil}},
-		{"attrs=hdd:ssd,path=/mnt/hda1,", "", StoreSpec{"/mnt/hda1", 0, 0, false, roachpb.Attributes{Attrs: []string{"hdd", "ssd"}}, false, nil}},
+		{"path=/mnt/hda1,attrs=ssd", "", StoreSpec{
+			Path:       "/mnt/hda1",
+			Attributes: roachpb.Attributes{Attrs: []string{"ssd"}},
+		}},
+		{"path=/mnt/hda1,attrs=ssd:hdd", "", StoreSpec{
+			Path:       "/mnt/hda1",
+			Attributes: roachpb.Attributes{Attrs: []string{"hdd", "ssd"}},
+		}},
+		{"path=/mnt/hda1,attrs=hdd:ssd", "", StoreSpec{
+			Path:       "/mnt/hda1",
+			Attributes: roachpb.Attributes{Attrs: []string{"hdd", "ssd"}},
+		}},
+		{"attrs=ssd:hdd,path=/mnt/hda1", "", StoreSpec{
+			Path:       "/mnt/hda1",
+			Attributes: roachpb.Attributes{Attrs: []string{"hdd", "ssd"}},
+		}},
+		{"attrs=hdd:ssd,path=/mnt/hda1,", "", StoreSpec{
+			Path:       "/mnt/hda1",
+			Attributes: roachpb.Attributes{Attrs: []string{"hdd", "ssd"}},
+		}},
 		{"attrs=hdd:ssd", "no path specified", StoreSpec{}},
 		{"path=/mnt/hda1,attrs=", "no value specified for attrs", StoreSpec{}},
 		{"path=/mnt/hda1,attrs=hdd:hdd", "duplicate attribute given for store: hdd", StoreSpec{}},
 		{"path=/mnt/hda1,attrs=hdd,attrs=ssd", "attrs field was used twice in store definition", StoreSpec{}},
 
 		// size
-		{"path=/mnt/hda1,size=671088640", "", StoreSpec{"/mnt/hda1", 671088640, 0, false, roachpb.Attributes{}, false, nil}},
-		{"path=/mnt/hda1,size=20GB", "", StoreSpec{"/mnt/hda1", 20000000000, 0, false, roachpb.Attributes{}, false, nil}},
-		{"size=20GiB,path=/mnt/hda1", "", StoreSpec{"/mnt/hda1", 21474836480, 0, false, roachpb.Attributes{}, false, nil}},
-		{"size=0.1TiB,path=/mnt/hda1", "", StoreSpec{"/mnt/hda1", 109951162777, 0, false, roachpb.Attributes{}, false, nil}},
-		{"path=/mnt/hda1,size=.1TiB", "", StoreSpec{"/mnt/hda1", 109951162777, 0, false, roachpb.Attributes{}, false, nil}},
-		{"path=/mnt/hda1,size=123TB", "", StoreSpec{"/mnt/hda1", 123000000000000, 0, false, roachpb.Attributes{}, false, nil}},
-		{"path=/mnt/hda1,size=123TiB", "", StoreSpec{"/mnt/hda1", 135239930216448, 0, false, roachpb.Attributes{}, false, nil}},
+		{"path=/mnt/hda1,size=671088640", "", StoreSpec{Path: "/mnt/hda1", SizeInBytes: 671088640}},
+		{"path=/mnt/hda1,size=20GB", "", StoreSpec{Path: "/mnt/hda1", SizeInBytes: 20000000000}},
+		{"size=20GiB,path=/mnt/hda1", "", StoreSpec{Path: "/mnt/hda1", SizeInBytes: 21474836480}},
+		{"size=0.1TiB,path=/mnt/hda1", "", StoreSpec{Path: "/mnt/hda1", SizeInBytes: 109951162777}},
+		{"path=/mnt/hda1,size=.1TiB", "", StoreSpec{Path: "/mnt/hda1", SizeInBytes: 109951162777}},
+		{"path=/mnt/hda1,size=123TB", "", StoreSpec{Path: "/mnt/hda1", SizeInBytes: 123000000000000}},
+		{"path=/mnt/hda1,size=123TiB", "", StoreSpec{Path: "/mnt/hda1", SizeInBytes: 135239930216448}},
 		// %
-		{"path=/mnt/hda1,size=50.5%", "", StoreSpec{"/mnt/hda1", 0, 50.5, false, roachpb.Attributes{}, false, nil}},
-		{"path=/mnt/hda1,size=100%", "", StoreSpec{"/mnt/hda1", 0, 100, false, roachpb.Attributes{}, false, nil}},
-		{"path=/mnt/hda1,size=1%", "", StoreSpec{"/mnt/hda1", 0, 1, false, roachpb.Attributes{}, false, nil}},
+		{"path=/mnt/hda1,size=50.5%", "", StoreSpec{Path: "/mnt/hda1", SizePercent: 50.5}},
+		{"path=/mnt/hda1,size=100%", "", StoreSpec{Path: "/mnt/hda1", SizePercent: 100}},
+		{"path=/mnt/hda1,size=1%", "", StoreSpec{Path: "/mnt/hda1", SizePercent: 1}},
 		{"path=/mnt/hda1,size=0.999999%", "store size (0.999999%) must be between 1% and 100%", StoreSpec{}},
 		{"path=/mnt/hda1,size=100.0001%", "store size (100.0001%) must be between 1% and 100%", StoreSpec{}},
 		// 0.xxx
-		{"path=/mnt/hda1,size=0.99", "", StoreSpec{"/mnt/hda1", 0, 99, false, roachpb.Attributes{}, false, nil}},
-		{"path=/mnt/hda1,size=0.5000000", "", StoreSpec{"/mnt/hda1", 0, 50, false, roachpb.Attributes{}, false, nil}},
-		{"path=/mnt/hda1,size=0.01", "", StoreSpec{"/mnt/hda1", 0, 1, false, roachpb.Attributes{}, false, nil}},
+		{"path=/mnt/hda1,size=0.99", "", StoreSpec{Path: "/mnt/hda1", SizePercent: 99}},
+		{"path=/mnt/hda1,size=0.5000000", "", StoreSpec{Path: "/mnt/hda1", SizePercent: 50}},
+		{"path=/mnt/hda1,size=0.01", "", StoreSpec{Path: "/mnt/hda1", SizePercent: 1}},
 		{"path=/mnt/hda1,size=0.009999", "store size (0.009999) must be between 1% and 100%", StoreSpec{}},
 		// .xxx
-		{"path=/mnt/hda1,size=.999", "", StoreSpec{"/mnt/hda1", 0, 99.9, false, roachpb.Attributes{}, false, nil}},
-		{"path=/mnt/hda1,size=.5000000", "", StoreSpec{"/mnt/hda1", 0, 50, false, roachpb.Attributes{}, false, nil}},
-		{"path=/mnt/hda1,size=.01", "", StoreSpec{"/mnt/hda1", 0, 1, false, roachpb.Attributes{}, false, nil}},
+		{"path=/mnt/hda1,size=.999", "", StoreSpec{Path: "/mnt/hda1", SizePercent: 99.9}},
+		{"path=/mnt/hda1,size=.5000000", "", StoreSpec{Path: "/mnt/hda1", SizePercent: 50}},
+		{"path=/mnt/hda1,size=.01", "", StoreSpec{Path: "/mnt/hda1", SizePercent: 1}},
 		{"path=/mnt/hda1,size=.009999", "store size (.009999) must be between 1% and 100%", StoreSpec{}},
 		// errors
 		{"path=/mnt/hda1,size=0", "store size (0) must be larger than 640 MiB", StoreSpec{}},
@@ -86,10 +101,14 @@ func TestNewStoreSpec(t *testing.T) {
 		{"size=123TB", "no path specified", StoreSpec{}},
 
 		// type
-		{"type=mem,size=20GiB", "", StoreSpec{"", 21474836480, 0, true, roachpb.Attributes{}, false, nil}},
-		{"size=20GiB,type=mem", "", StoreSpec{"", 21474836480, 0, true, roachpb.Attributes{}, false, nil}},
-		{"size=20.5GiB,type=mem", "", StoreSpec{"", 22011707392, 0, true, roachpb.Attributes{}, false, nil}},
-		{"size=20GiB,type=mem,attrs=mem", "", StoreSpec{"", 21474836480, 0, true, roachpb.Attributes{Attrs: []string{"mem"}}, false, nil}},
+		{"type=mem,size=20GiB", "", StoreSpec{SizeInBytes: 21474836480, InMemory: true}},
+		{"size=20GiB,type=mem", "", StoreSpec{SizeInBytes: 21474836480, InMemory: true}},
+		{"size=20.5GiB,type=mem", "", StoreSpec{SizeInBytes: 22011707392, InMemory: true}},
+		{"size=20GiB,type=mem,attrs=mem", "", StoreSpec{
+			SizeInBytes: 21474836480,
+			InMemory:    true,
+			Attributes:  roachpb.Attributes{Attrs: []string{"mem"}},
+		}},
 		{"type=mem,size=20", "store size (20) must be larger than 640 MiB", StoreSpec{}},
 		{"type=mem,size=", "no value specified for size", StoreSpec{}},
 		{"type=mem,attrs=ssd", "size must be specified for an in memory store", StoreSpec{}},
@@ -97,9 +116,20 @@ func TestNewStoreSpec(t *testing.T) {
 		{"path=/mnt/hda1,type=other", "other is not a valid store type", StoreSpec{}},
 		{"path=/mnt/hda1,type=mem,size=20GiB", "path specified for in memory store", StoreSpec{}},
 
+		// RocksDB
+		{"path=/,rocksdb=key1=val1;key2=val2", "", StoreSpec{Path: "/", RocksDBOptions: "key1=val1;key2=val2"}},
+
 		// all together
-		{"path=/mnt/hda1,attrs=hdd:ssd,size=20GiB", "", StoreSpec{"/mnt/hda1", 21474836480, 0, false, roachpb.Attributes{Attrs: []string{"hdd", "ssd"}}, false, nil}},
-		{"type=mem,attrs=hdd:ssd,size=20GiB", "", StoreSpec{"", 21474836480, 0, true, roachpb.Attributes{Attrs: []string{"hdd", "ssd"}}, false, nil}},
+		{"path=/mnt/hda1,attrs=hdd:ssd,size=20GiB", "", StoreSpec{
+			Path:        "/mnt/hda1",
+			SizeInBytes: 21474836480,
+			Attributes:  roachpb.Attributes{Attrs: []string{"hdd", "ssd"}},
+		}},
+		{"type=mem,attrs=hdd:ssd,size=20GiB", "", StoreSpec{
+			SizeInBytes: 21474836480,
+			InMemory:    true,
+			Attributes:  roachpb.Attributes{Attrs: []string{"hdd", "ssd"}},
+		}},
 
 		// other error cases
 		{"", "no value specified", StoreSpec{}},

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -504,6 +504,7 @@ func (cfg *Config) CreateEngines(ctx context.Context) (Engines, error) {
 				WarnLargeBatchThreshold: 500 * time.Millisecond,
 				Settings:                cfg.Settings,
 				UseSwitchingEnv:         spec.UseSwitchingEnv,
+				RocksDBOptions:          spec.RocksDBOptions,
 				ExtraOptions:            spec.ExtraOptions,
 			}
 

--- a/pkg/storage/engine/rocksdb.go
+++ b/pkg/storage/engine/rocksdb.go
@@ -442,6 +442,9 @@ type RocksDBConfig struct {
 	// UseSwitchingEnv is true if the switching env is needed (eg: encryption-at-rest).
 	// This may force the store version to versionSwitchingEnv if currently lower.
 	UseSwitchingEnv bool
+	// RocksDBOptions contains RocksDB specific options using a semicolon
+	// separated key-value syntax ("key1=value1; key2=value2").
+	RocksDBOptions string
 	// ExtraOptions is a serialized protobuf set by Go CCL code and passed through
 	// to C CCL code.
 	ExtraOptions []byte
@@ -595,6 +598,7 @@ func (r *RocksDB) open() error {
 			use_switching_env: C.bool(newVersion == versionCurrent),
 			must_exist:        C.bool(r.cfg.MustExist),
 			read_only:         C.bool(r.cfg.ReadOnly),
+			rocksdb_options:   goToCSlice([]byte(r.cfg.RocksDBOptions)),
 			extra_options:     goToCSlice(r.cfg.ExtraOptions),
 		})
 	if err := statusToError(status); err != nil {

--- a/pkg/storage/engine/rocksdb_test.go
+++ b/pkg/storage/engine/rocksdb_test.go
@@ -15,12 +15,14 @@
 package engine
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"math/rand"
 	"os"
+	"path/filepath"
 	"sort"
 	"strconv"
 	"testing"
@@ -973,5 +975,56 @@ func TestSSTableInfosByLevel(t *testing.T) {
 				t.Errorf("expected max level %d; got %d", test.expMaxLevel, maxLevel)
 			}
 		})
+	}
+}
+
+func TestRocksDBOptions(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	dir, err := ioutil.TempDir("", "testing")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := os.RemoveAll(dir); err != nil {
+			t.Fatal(err)
+		}
+	}()
+	rocksdb, err := NewRocksDB(
+		RocksDBConfig{
+			Settings: cluster.MakeTestingClusterSettings(),
+			Dir:      dir,
+			RocksDBOptions: "use_fsync=true;" +
+				"min_write_buffer_number_to_merge=2;" +
+				"block_based_table_factory={block_size=4k}",
+		},
+		RocksDBCache{},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rocksdb.Close()
+
+	paths, err := filepath.Glob(dir + "/OPTIONS-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, p := range paths {
+		data, err := ioutil.ReadFile(p)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		options := []string{
+			"use_fsync=true",
+			"min_write_buffer_number_to_merge=2",
+			"block_size=4096",
+		}
+		for _, o := range options {
+			fullOption := fmt.Sprintf("  %s\n", o)
+			if !bytes.Contains(data, []byte(fullOption)) {
+				t.Errorf("unable to find %s in %s", o, p)
+			}
+		}
 	}
 }


### PR DESCRIPTION
Allow specification of arbitrary RocksDB options by extending the
store-spec syntax to to include a `rocksdb=<options>` field. The RocksDB
options are a semicolon separated list of `key=value` pairs. The easiest
way to see the various RocksDB options is to look in
`<store-dir>/OPTIONS-xyz`.

Options in the `DBOptions` and `CFOptions` sections can be specified using
the base `key=value` syntax. For example, to change the
`DBOptions.WAL_ttl_seconds` option, specifying
`rocksdb=WAL_ttl_seconds=60`.

Options in the `TableOptions/BlockBasedTable` section are specified using a
"nested options" syntax. For example,
`rocksdb=block_based_table_factory={block_size=4k}` will set the
`block_size` to 4 KB. Note that the syntax described here is provided from
RocksDB.

Fixes #21434

Release note (cli change): Allow specification of arbitrary RocksDB
options.