### PR TITLE
cli: make computed columns work with dump

### DIFF
--- a/pkg/cli/dump.go
+++ b/pkg/cli/dump.go
@@ -316,6 +316,7 @@ func getMetadataForTable(conn *sqlConn, md basicMetadata, ts string) (tableMetad
 		AS OF SYSTEM TIME %s
 		WHERE TABLE_SCHEMA = $1
 			AND TABLE_NAME = $2
+			AND GENERATION_EXPRESSION = ''
 		`, lex.EscapeSQLString(ts)), []driver.Value{md.name.Schema(), md.name.Table()})
 	if err != nil {
 		return tableMetadata{}, err
@@ -399,7 +400,8 @@ func dumpTableData(w io.Writer, conn *sqlConn, clusterTS string, bmd basicMetada
 		return err
 	}
 
-	bs := fmt.Sprintf("SELECT * FROM %s AS OF SYSTEM TIME %s ORDER BY PRIMARY KEY %[1]s",
+	bs := fmt.Sprintf("SELECT %s FROM %s AS OF SYSTEM TIME %s ORDER BY PRIMARY KEY %[2]s",
+		md.columnNames,
 		md.name,
 		lex.EscapeSQLString(clusterTS),
 	)

--- a/pkg/cli/dump_test.go
+++ b/pkg/cli/dump_test.go
@@ -1098,3 +1098,43 @@ INSERT INTO t (a, b) VALUES
 		t.Fatalf("expected: %s\ngot: %s", expect, out)
 	}
 }
+
+func TestDumpWithComputedColumn(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	c := newCLITest(cliTestParams{t: t})
+	defer c.cleanup()
+
+	const create = `
+	CREATE DATABASE d;
+	CREATE TABLE d.t (
+		a INT PRIMARY KEY,
+		b INT AS (a + 1) STORED
+	);
+
+	INSERT INTO d.t VALUES (1);
+`
+
+	c.RunWithArgs([]string{"sql", "-e", create})
+
+	out, err := c.RunWithCapture("dump d t")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	const expect = `dump d t
+CREATE TABLE t (
+	a INT NOT NULL,
+	b INT NULL AS (a + 1) STORED,
+	CONSTRAINT "primary" PRIMARY KEY (a ASC),
+	FAMILY "primary" (a, b)
+);
+
+INSERT INTO t (a) VALUES
+	(1);
+`
+
+	if out != expect {
+		t.Fatalf("expected: %s\ngot: %s", expect, out)
+	}
+}


### PR DESCRIPTION
Please only review the last commit!

We shouldn't dump computed columns during dump - explicit inserts into
them will fail.

Release note (bug fix): Tables with computed columns will produce a
meaningful dump.