### PR TITLE
cli: add framework for writing dump tests

### DIFF
--- a/pkg/cli/testdata/dump_test
+++ b/pkg/cli/testdata/dump_test
@@ -1,0 +1,455 @@
+% name simple_dump
+% database d
+% command dump d t
+CREATE TABLE t (
+  a INT
+);
+INSERT INTO t VALUES
+  (1);
+----
+CREATE TABLE t (
+	a INT NULL,
+	FAMILY "primary" (a, rowid)
+);
+
+INSERT INTO t (a) VALUES
+	(1);
+
+% name dump_row
+% database d
+% command dump d t
+CREATE TABLE t (
+  i int,
+  f float,
+  s string,
+  b bytes,
+  d date,
+  t time,
+  ts timestamp,
+  n interval,
+  o bool,
+  e decimal,
+  u uuid,
+  ip inet,
+  j JSON,
+  ary string[],
+  tz timestamptz,
+  e1 decimal(2),
+  e2 decimal(2, 1),
+  s1 string(1),
+  FAMILY "primary" (i, f, d, t, ts, n, o, u, ip, j, ary, tz, e1, e2, s1, rowid),
+  FAMILY fam_1_s (s),
+  FAMILY fam_2_b (b),
+  FAMILY fam_3_e (e)
+);
+INSERT INTO t VALUES (
+  1,
+  2.3,
+  'striiing',
+  '\x613162326333',
+  '2016-03-26',
+  '01:02:03.456',
+  '2016-01-25 10:10:10',
+  '2h30m30s',
+  true,
+  1.2345,
+  'e9716c74-2638-443d-90ed-ffde7bea7d1d',
+  '192.168.0.1',
+  '{"a":"b"}',
+  ARRAY['hello','world'],
+  '2016-01-25 10:10:10',
+  3.4,
+  4.5,
+  's'
+);
+INSERT INTO t VALUES (DEFAULT);
+INSERT INTO t (f, e) VALUES (
+  CAST('+Inf' AS FLOAT), CAST('+Inf' AS DECIMAL)
+), (
+  CAST('-Inf' AS FLOAT), CAST('-Inf' AS DECIMAL)
+), (
+  CAST('NaN' AS FLOAT), CAST('NaN' AS DECIMAL)
+);
+----
+CREATE TABLE t (
+	i INT NULL,
+	f FLOAT NULL,
+	s STRING NULL,
+	b BYTES NULL,
+	d DATE NULL,
+	t TIME NULL,
+	ts TIMESTAMP NULL,
+	n INTERVAL NULL,
+	o BOOL NULL,
+	e DECIMAL NULL,
+	u UUID NULL,
+	ip INET NULL,
+	j JSON NULL,
+	ary STRING[] NULL,
+	tz TIMESTAMP WITH TIME ZONE NULL,
+	e1 DECIMAL(2) NULL,
+	e2 DECIMAL(2,1) NULL,
+	s1 STRING(1) NULL,
+	FAMILY "primary" (i, f, d, t, ts, n, o, u, ip, j, ary, tz, e1, e2, s1, rowid),
+	FAMILY fam_1_s (s),
+	FAMILY fam_2_b (b),
+	FAMILY fam_3_e (e)
+);
+
+INSERT INTO t (i, f, s, b, d, t, ts, n, o, e, u, ip, j, ary, tz, e1, e2, s1) VALUES
+	(1, 2.3, 'striiing', '\x613162326333', '2016-03-26', '01:02:03.456', '2016-01-25 10:10:10+00:00', '2h30m30s', true, 1.2345, 'e9716c74-2638-443d-90ed-ffde7bea7d1d', '192.168.0.1', '{"a": "b"}', ARRAY['hello':::STRING,'world':::STRING], '2016-01-25 10:10:10+00:00', 3, 4.5, 's'),
+	(NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL),
+	(NULL, '+Inf', NULL, NULL, NULL, NULL, NULL, NULL, NULL, 'Infinity', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL),
+	(NULL, '-Inf', NULL, NULL, NULL, NULL, NULL, NULL, NULL, '-Infinity', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL),
+	(NULL, 'NaN', NULL, NULL, NULL, NULL, NULL, NULL, NULL, 'NaN', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+% name inverted_index
+% database d
+% command dump d t
+CREATE TABLE t (
+	a JSON,
+	b JSON,
+	INVERTED INDEX idx (a)
+);
+
+CREATE INVERTED INDEX idx2 ON t (b);
+
+INSERT INTO t VALUES ('{"a": "b"}', '{"c": "d"}');
+----
+CREATE TABLE t (
+	a JSON NULL,
+	b JSON NULL,
+	INVERTED INDEX idx (a),
+	INVERTED INDEX idx2 (b),
+	FAMILY "primary" (a, b, rowid)
+);
+
+INSERT INTO t (a, b) VALUES
+	('{"a": "b"}', '{"c": "d"}');
+
+% name flag_both
+% database d
+% command dump d t --dump-mode=both
+CREATE TABLE t (x INT, y INT);
+INSERT INTO t VALUES (42, 69);
+----
+CREATE TABLE t (
+	x INT NULL,
+	y INT NULL,
+	FAMILY "primary" (x, y, rowid)
+);
+
+INSERT INTO t (x, y) VALUES
+	(42, 69);
+
+% name flag_schema
+% database d
+% command dump d t --dump-mode=schema
+CREATE TABLE t (x INT, y INT);
+INSERT INTO t VALUES (42, 69);
+----
+CREATE TABLE t (
+	x INT NULL,
+	y INT NULL,
+	FAMILY "primary" (x, y, rowid)
+);
+
+% name flag_data
+% database d
+% command dump d t --dump-mode=data
+% no-run-expected true
+CREATE TABLE t (x INT, y INT);
+INSERT INTO t VALUES (42, 69);
+----
+INSERT INTO t (x, y) VALUES
+	(42, 69);
+
+% name reference_cycle
+% database d
+% command dump d t
+# This tests dumping in the presence of cycles.  This used to crash before
+# with stack overflow due to an infinite loop before:
+# https://github.com/cockroachdb/cockroach/pull/20255
+CREATE TABLE t (
+  PRIMARY KEY (id),
+  FOREIGN KEY (next_id) REFERENCES t(id),
+  id INT,
+  next_id INT
+);
+INSERT INTO t VALUES (
+  1,
+  NULL
+);
+----
+CREATE TABLE t (
+	id INT NOT NULL,
+	next_id INT NULL,
+	CONSTRAINT "primary" PRIMARY KEY (id ASC),
+	CONSTRAINT fk_next_id_ref_t FOREIGN KEY (next_id) REFERENCES t (id),
+	INDEX t_auto_index_fk_next_id_ref_t (next_id ASC),
+	FAMILY "primary" (id, next_id)
+);
+
+INSERT INTO t (id, next_id) VALUES
+	(1, NULL);
+
+% name primary_key_constraint
+% database d
+% command dump d t
+# This tests that a primary key with a non-default name works.
+CREATE TABLE t (
+  i int,
+  CONSTRAINT pk_name PRIMARY KEY (i)
+);
+INSERT INTO t VALUES (1);
+----
+CREATE TABLE t (
+	i INT NOT NULL,
+	CONSTRAINT pk_name PRIMARY KEY (i ASC),
+	FAMILY "primary" (i)
+);
+
+INSERT INTO t (i) VALUES
+	(1);
+
+% name multiple_tables
+% database d
+% command dump d f g
+CREATE TABLE f (x INT, y INT);
+INSERT INTO f VALUES (42, 69);
+
+CREATE TABLE g (x INT, y INT);
+INSERT INTO g VALUES (3, 4);
+----
+CREATE TABLE f (
+	x INT NULL,
+	y INT NULL,
+	FAMILY "primary" (x, y, rowid)
+);
+
+CREATE TABLE g (
+	x INT NULL,
+	y INT NULL,
+	FAMILY "primary" (x, y, rowid)
+);
+
+INSERT INTO f (x, y) VALUES
+	(42, 69);
+
+INSERT INTO g (x, y) VALUES
+	(3, 4);
+
+% name identifiers
+% database d
+% command dump d
+# Tests dumping a table with a semicolon in the table,
+# index, and column names properly escapes.
+CREATE TABLE ";" (";" int, index (";"));
+INSERT INTO ";" VALUES (1);
+----
+CREATE TABLE ";" (
+	";" INT NULL,
+	INDEX ";_;_idx" (";" ASC),
+	FAMILY "primary" (";", rowid)
+);
+
+INSERT INTO ";" (";") VALUES
+	(1);
+
+% name reference_order
+% database d
+% command dump d
+# B -> A
+CREATE TABLE b (i int PRIMARY KEY);
+CREATE TABLE a (i int REFERENCES b);
+INSERT INTO b VALUES (1);
+INSERT INTO a VALUES (1);
+
+# Test multiple tables to make sure transitive deps are sorted correctly.
+# E -> D -> C
+# G -> F -> D -> C
+CREATE TABLE g (i int PRIMARY KEY);
+CREATE TABLE f (i int PRIMARY KEY, g int REFERENCES g);
+CREATE TABLE e (i int PRIMARY KEY);
+CREATE TABLE d (i int PRIMARY KEY, e int REFERENCES e, f int REFERENCES f);
+CREATE TABLE c (i int REFERENCES d);
+INSERT INTO g VALUES (1);
+INSERT INTO f VALUES (1, 1);
+INSERT INTO e VALUES (1);
+INSERT INTO d VALUES (1, 1, 1);
+INSERT INTO c VALUES (1);
+
+# Test a table that uses a sequence to make sure the sequence is dumped first.
+CREATE SEQUENCE s;
+CREATE TABLE s_tbl (id INT PRIMARY KEY DEFAULT nextval('s'), v INT);
+INSERT INTO s_tbl (v) VALUES (10), (11);
+----
+CREATE TABLE b (
+	i INT NOT NULL,
+	CONSTRAINT "primary" PRIMARY KEY (i ASC),
+	FAMILY "primary" (i)
+);
+
+CREATE TABLE a (
+	i INT NULL,
+	CONSTRAINT fk_i_ref_b FOREIGN KEY (i) REFERENCES b (i),
+	INDEX a_auto_index_fk_i_ref_b (i ASC),
+	FAMILY "primary" (i, rowid)
+);
+
+CREATE TABLE e (
+	i INT NOT NULL,
+	CONSTRAINT "primary" PRIMARY KEY (i ASC),
+	FAMILY "primary" (i)
+);
+
+CREATE TABLE g (
+	i INT NOT NULL,
+	CONSTRAINT "primary" PRIMARY KEY (i ASC),
+	FAMILY "primary" (i)
+);
+
+CREATE TABLE f (
+	i INT NOT NULL,
+	g INT NULL,
+	CONSTRAINT "primary" PRIMARY KEY (i ASC),
+	CONSTRAINT fk_g_ref_g FOREIGN KEY (g) REFERENCES g (i),
+	INDEX f_auto_index_fk_g_ref_g (g ASC),
+	FAMILY "primary" (i, g)
+);
+
+CREATE TABLE d (
+	i INT NOT NULL,
+	e INT NULL,
+	f INT NULL,
+	CONSTRAINT "primary" PRIMARY KEY (i ASC),
+	CONSTRAINT fk_e_ref_e FOREIGN KEY (e) REFERENCES e (i),
+	INDEX d_auto_index_fk_e_ref_e (e ASC),
+	CONSTRAINT fk_f_ref_f FOREIGN KEY (f) REFERENCES f (i),
+	INDEX d_auto_index_fk_f_ref_f (f ASC),
+	FAMILY "primary" (i, e, f)
+);
+
+CREATE TABLE c (
+	i INT NULL,
+	CONSTRAINT fk_i_ref_d FOREIGN KEY (i) REFERENCES d (i),
+	INDEX c_auto_index_fk_i_ref_d (i ASC),
+	FAMILY "primary" (i, rowid)
+);
+
+CREATE SEQUENCE s MINVALUE 1 MAXVALUE 9223372036854775807 INCREMENT 1 START 1;
+
+CREATE TABLE s_tbl (
+	id INT NOT NULL DEFAULT nextval('s':::STRING),
+	v INT NULL,
+	CONSTRAINT "primary" PRIMARY KEY (id ASC),
+	FAMILY "primary" (id, v)
+);
+
+INSERT INTO b (i) VALUES
+	(1);
+
+INSERT INTO a (i) VALUES
+	(1);
+
+INSERT INTO e (i) VALUES
+	(1);
+
+INSERT INTO g (i) VALUES
+	(1);
+
+INSERT INTO f (i, g) VALUES
+	(1, 1);
+
+INSERT INTO d (i, e, f) VALUES
+	(1, 1, 1);
+
+INSERT INTO c (i) VALUES
+	(1);
+
+SELECT setval('s', 2);
+
+INSERT INTO s_tbl (id, v) VALUES
+	(1, 10),
+	(2, 11);
+
+% name reference_order_only_some
+% database d
+% command dump d d e
+% no-run-expected true
+# Ensure dump specifying only some tables works if those tables reference
+# tables not in the dump. We need no-run-expected because of this.
+# B -> A
+CREATE TABLE b (i int PRIMARY KEY);
+CREATE TABLE a (i int REFERENCES b);
+INSERT INTO b VALUES (1);
+INSERT INTO a VALUES (1);
+
+# Test multiple tables to make sure transitive deps are sorted correctly.
+# E -> D -> C
+# G -> F -> D -> C
+CREATE TABLE g (i int PRIMARY KEY);
+CREATE TABLE f (i int PRIMARY KEY, g int REFERENCES g);
+CREATE TABLE e (i int PRIMARY KEY);
+CREATE TABLE d (i int PRIMARY KEY, e int REFERENCES e, f int REFERENCES f);
+CREATE TABLE c (i int REFERENCES d);
+INSERT INTO g VALUES (1);
+INSERT INTO f VALUES (1, 1);
+INSERT INTO e VALUES (1);
+INSERT INTO d VALUES (1, 1, 1);
+INSERT INTO c VALUES (1);
+
+# Test a table that uses a sequence to make sure the sequence is dumped first.
+CREATE SEQUENCE s;
+CREATE TABLE s_tbl (id INT PRIMARY KEY DEFAULT nextval('s'), v INT);
+INSERT INTO s_tbl (v) VALUES (10), (11);
+----
+CREATE TABLE e (
+	i INT NOT NULL,
+	CONSTRAINT "primary" PRIMARY KEY (i ASC),
+	FAMILY "primary" (i)
+);
+
+CREATE TABLE d (
+	i INT NOT NULL,
+	e INT NULL,
+	f INT NULL,
+	CONSTRAINT "primary" PRIMARY KEY (i ASC),
+	CONSTRAINT fk_e_ref_e FOREIGN KEY (e) REFERENCES e (i),
+	INDEX d_auto_index_fk_e_ref_e (e ASC),
+	CONSTRAINT fk_f_ref_f FOREIGN KEY (f) REFERENCES f (i),
+	INDEX d_auto_index_fk_f_ref_f (f ASC),
+	FAMILY "primary" (i, e, f)
+);
+
+INSERT INTO e (i) VALUES
+	(1);
+
+INSERT INTO d (i, e, f) VALUES
+	(1, 1, 1);
+
+% name view
+% database d
+% command dump d
+# Verifies dump doesn't attempt to dump data of views.
+CREATE VIEW d.bar AS SELECT 1;
+----
+CREATE VIEW bar ("1") AS SELECT 1;
+
+% name sequence
+% database d
+% command dump d
+CREATE SEQUENCE d.bar;
+----
+CREATE SEQUENCE bar MINVALUE 1 MAXVALUE 9223372036854775807 INCREMENT 1 START 1;
+
+SELECT setval('bar', 0);
+
+% name sequence_escaping
+% database "'"
+% command dump '
+CREATE SEQUENCE "'";
+----
+CREATE SEQUENCE "'" MINVALUE 1 MAXVALUE 9223372036854775807 INCREMENT 1 START 1;
+
+SELECT setval(e'"\'"', 0);


### PR DESCRIPTION
I quite frequently find myself having to add new tests and functionality
to dump. While the existing setup for writing tests was quite good, and
easy to add new tests, I often found myself wanting to be able to
`rewrite-results-in-testfiles` it (especially due to whitespace issues),
and not write my tests in a string literal, so my attempt at changing
this is a somewhat radical one - a logic test-esque file format that's
composed of a schema and an expected dump output.

Feel free to reject this PR for any of the following reasons, my
feelings won't be hurt:
* not worth the review or engineering effort this close to code freeze
* not worth the review or engineering effort period
* not a fan of the approach in general

This PR is still missing a number of things, however:
* I haven't ported over all of the existing dump tests
* error handling when writing a faulty test file could be better
* bikeshedding about the syntax
* code could be cleaned up a bit, not too interested in discussion on
  that at this point, more interested in thoughts on the general approach.

I think this general format of

* parameters incl. test name
* input
* output

could be quite useful in general and we might be able to extract some
kind of general framework for it in the future if we decide to go that
route.