### PR TITLE
sql: make JSON.FetchValKey and JSON.RemovePath more efficient

### DIFF
--- a/pkg/util/json/json_test.go
+++ b/pkg/util/json/json_test.go
@@ -1767,7 +1767,9 @@ func TestJSONRemovePath(t *testing.T) {
 		errMsg   string
 	}{
 		`{"foo": 1}`: {
+			{path: []string{"foa"}, expected: `{"foo": 1}`},
 			{path: []string{"foo"}, expected: `{}`},
+			{path: []string{"foz"}, expected: `{"foo": 1}`},
 			{path: []string{}, expected: `{"foo": 1}`},
 			{path: []string{"bar"}, expected: `{"foo": 1}`},
 		},


### PR DESCRIPTION
I think there are two things we could improve for performance:
1. reducing number of if conditions in for loop for both function
2. reducing number of string comparison from O(n) to O(logn) for
jsonObject.RemovePath