### PR TITLE
sql, sqlbase: Move DataSourceInfo from sql into sqlbase.

### DIFF
--- a/pkg/sql/analyze_expr.go
+++ b/pkg/sql/analyze_expr.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 )
 
 // analyzeExpr performs semantic analysis of an expression, including:
@@ -32,7 +33,7 @@ import (
 func (p *planner) analyzeExpr(
 	ctx context.Context,
 	raw tree.Expr,
-	sources multiSourceInfo,
+	sources sqlbase.MultiSourceInfo,
 	iVarHelper tree.IndexedVarHelper,
 	expectedType types.T,
 	requireType bool,

--- a/pkg/sql/check.go
+++ b/pkg/sql/check.go
@@ -34,7 +34,7 @@ import (
 type checkHelper struct {
 	exprs        []tree.TypedExpr
 	cols         []sqlbase.ColumnDescriptor
-	sourceInfo   *dataSourceInfo
+	sourceInfo   *sqlbase.DataSourceInfo
 	ivarHelper   *tree.IndexedVarHelper
 	curSourceRow tree.Datums
 }
@@ -47,7 +47,7 @@ func (c *checkHelper) init(
 	}
 
 	c.cols = tableDesc.Columns
-	c.sourceInfo = newSourceInfoForSingleTable(
+	c.sourceInfo = sqlbase.NewSourceInfoForSingleTable(
 		*tn, sqlbase.ResultColumnsFromColDescs(tableDesc.Columns),
 	)
 
@@ -63,7 +63,7 @@ func (c *checkHelper) init(
 
 	ivarHelper := tree.MakeIndexedVarHelper(c, len(c.cols))
 	for i, raw := range exprs {
-		typedExpr, err := p.analyzeExpr(ctx, raw, multiSourceInfo{c.sourceInfo}, ivarHelper,
+		typedExpr, err := p.analyzeExpr(ctx, raw, sqlbase.MultiSourceInfo{c.sourceInfo}, ivarHelper,
 			types.Bool, false, "")
 		if err != nil {
 			return err
@@ -110,7 +110,7 @@ func (c *checkHelper) IndexedVarEval(idx int, ctx *tree.EvalContext) (tree.Datum
 
 // IndexedVarResolvedType implements the tree.IndexedVarContainer interface.
 func (c *checkHelper) IndexedVarResolvedType(idx int) types.T {
-	return c.sourceInfo.sourceColumns[idx].Typ
+	return c.sourceInfo.SourceColumns[idx].Typ
 }
 
 // IndexedVarNodeFormatter implements the parser.IndexedVarContainer interface.

--- a/pkg/sql/computed_exprs.go
+++ b/pkg/sql/computed_exprs.go
@@ -92,7 +92,7 @@ func ProcessComputedColumns(
 	iv := &descContainer{tableDesc.Columns}
 	ivarHelper := tree.MakeIndexedVarHelper(iv, len(tableDesc.Columns))
 
-	sourceInfo := newSourceInfoForSingleTable(
+	sourceInfo := sqlbase.NewSourceInfoForSingleTable(
 		*tn, sqlbase.ResultColumnsFromColDescs(tableDesc.Columns),
 	)
 
@@ -101,7 +101,7 @@ func ProcessComputedColumns(
 
 	computedExprs := make([]tree.TypedExpr, 0, len(cols))
 	for i, col := range computedCols {
-		expr, _, _, err := resolveNames(exprs[i], multiSourceInfo{sourceInfo}, ivarHelper, evalCtx.SessionData.SearchPath)
+		expr, _, _, err := resolveNames(exprs[i], sqlbase.MultiSourceInfo{sourceInfo}, ivarHelper, evalCtx.SessionData.SearchPath)
 		if err != nil {
 			return nil, nil, nil, err
 		}

--- a/pkg/sql/distinct.go
+++ b/pkg/sql/distinct.go
@@ -71,7 +71,7 @@ func (p *planner) distinct(
 
 	for _, expr := range n.DistinctOn {
 		// The expressions in DISTINCT ON follow similar rules as
-		// the expressionss in ORDER BY (see sort.go:sortBy).
+		// the expressions in ORDER BY (see sort.go:sortBy).
 
 		// The logical data source for DISTINCT ON is the list of render
 		// expressions for a SELECT, as specified in the input SQL text
@@ -170,13 +170,20 @@ func (p *planner) distinct(
 	// We add a post renderNode if DISTINCT ON introduced additional render
 	// expressions.
 	if len(origRender) < len(r.render) {
-		src := planDataSource{info: newSourceInfoForSingleTable(anonymousTable, origColumns), plan: d}
+		src := planDataSource{
+			info: sqlbase.NewSourceInfoForSingleTable(sqlbase.AnonymousTable, origColumns),
+			plan: d,
+		}
 		postRender := &renderNode{
 			source:     src,
-			sourceInfo: multiSourceInfo{src.info},
+			sourceInfo: sqlbase.MultiSourceInfo{src.info},
 		}
-		postRender.ivarHelper = tree.MakeIndexedVarHelper(postRender, len(src.info.sourceColumns))
-		if err := p.initTargets(ctx, postRender, tree.SelectExprs{tree.SelectExpr{Expr: &tree.AllColumnsSelector{}}}, nil /* desiredTypes */); err != nil {
+		postRender.ivarHelper = tree.MakeIndexedVarHelper(postRender, len(src.info.SourceColumns))
+		if err := p.initTargets(ctx, postRender, tree.SelectExprs{
+			tree.SelectExpr{
+				Expr: &tree.AllColumnsSelector{},
+			},
+		}, nil /* desiredTypes */); err != nil {
 			return nil, nil, err
 		}
 		plan = postRender

--- a/pkg/sql/executor_opt_interface.go
+++ b/pkg/sql/executor_opt_interface.go
@@ -77,13 +77,13 @@ func (ee *execEngine) ConstructScan(table optbase.Table) (exec.Node, error) {
 func (ee *execEngine) ConstructFilter(n exec.Node, filter tree.TypedExpr) (exec.Node, error) {
 	plan := n.(planNode)
 	src := planDataSource{
-		info: &dataSourceInfo{sourceColumns: planColumns(plan)},
+		info: &sqlbase.DataSourceInfo{SourceColumns: planColumns(plan)},
 		plan: plan,
 	}
 	f := &filterNode{
 		source: src,
 	}
-	f.ivarHelper = tree.MakeIndexedVarHelper(f, len(src.info.sourceColumns))
+	f.ivarHelper = tree.MakeIndexedVarHelper(f, len(src.info.SourceColumns))
 	f.filter = filter
 	f.ivarHelper.Rebind(filter, true /* alsoReset */, false /* normalizeToNonNil */)
 	return f, nil

--- a/pkg/sql/filter.go
+++ b/pkg/sql/filter.go
@@ -42,7 +42,7 @@ func (f *filterNode) IndexedVarEval(idx int, ctx *tree.EvalContext) (tree.Datum,
 
 // IndexedVarResolvedType implements the tree.IndexedVarContainer interface.
 func (f *filterNode) IndexedVarResolvedType(idx int) types.T {
-	return f.source.info.sourceColumns[idx].Typ
+	return f.source.info.SourceColumns[idx].Typ
 }
 
 // IndexedVarNodeFormatter implements the tree.IndexedVarContainer interface.

--- a/pkg/sql/join_predicate.go
+++ b/pkg/sql/join_predicate.go
@@ -54,10 +54,10 @@ type joinPredicate struct {
 	rightColNames tree.NameList
 
 	// For ON predicates or joins with an added filter expression,
-	// we need an IndexedVarHelper, the dataSourceInfo, a row buffer
+	// we need an IndexedVarHelper, the DataSourceInfo, a row buffer
 	// and the expression itself.
 	iVarHelper tree.IndexedVarHelper
-	info       *dataSourceInfo
+	info       *sqlbase.DataSourceInfo
 	curRow     tree.Datums
 	onCond     tree.TypedExpr
 
@@ -71,14 +71,16 @@ type joinPredicate struct {
 
 // makeCrossPredicate constructs a joinPredicate object for joins with a ON clause.
 func makeCrossPredicate(
-	typ joinType, left, right *dataSourceInfo,
-) (*joinPredicate, *dataSourceInfo, error) {
+	typ joinType, left, right *sqlbase.DataSourceInfo,
+) (*joinPredicate, *sqlbase.DataSourceInfo, error) {
 	return makeEqualityPredicate(typ, left, right, nil /*leftColNames*/, nil /*rightColNames */)
 }
 
 // tryAddEqualityFilter attempts to turn the given filter expression into
 // an equality predicate. It returns true iff the transformation succeeds.
-func (p *joinPredicate) tryAddEqualityFilter(filter tree.Expr, left, right *dataSourceInfo) bool {
+func (p *joinPredicate) tryAddEqualityFilter(
+	filter tree.Expr, left, right *sqlbase.DataSourceInfo,
+) bool {
 	c, ok := filter.(*tree.ComparisonExpr)
 	if !ok || c.Operator != tree.EQ {
 		return false
@@ -92,7 +94,7 @@ func (p *joinPredicate) tryAddEqualityFilter(filter tree.Expr, left, right *data
 		return false
 	}
 
-	sourceBoundary := len(left.sourceColumns)
+	sourceBoundary := len(left.SourceColumns)
 	if (lhs.Idx >= sourceBoundary && rhs.Idx >= sourceBoundary) ||
 		(lhs.Idx < sourceBoundary && rhs.Idx < sourceBoundary) {
 		// Both variables are on the same side of the join (e.g. `a JOIN b ON a.x = a.y`).
@@ -111,7 +113,7 @@ func (p *joinPredicate) tryAddEqualityFilter(filter tree.Expr, left, right *data
 	// the full column set of the joinPredicate, including the
 	// merged columns.
 	leftColIdx := lhs.Idx
-	rightColIdx := rhs.Idx - len(left.sourceColumns)
+	rightColIdx := rhs.Idx - len(left.SourceColumns)
 
 	// Also, we will want to avoid redundant equality checks.
 	for i := range p.leftEqualityIndices {
@@ -140,23 +142,31 @@ func (p *joinPredicate) tryAddEqualityFilter(filter tree.Expr, left, right *data
 
 	p.leftEqualityIndices = append(p.leftEqualityIndices, leftColIdx)
 	p.rightEqualityIndices = append(p.rightEqualityIndices, rightColIdx)
-	p.leftColNames = append(p.leftColNames, tree.Name(left.sourceColumns[leftColIdx].Name))
-	p.rightColNames = append(p.rightColNames, tree.Name(right.sourceColumns[rightColIdx].Name))
+	p.leftColNames = append(p.leftColNames, tree.Name(left.SourceColumns[leftColIdx].Name))
+	p.rightColNames = append(p.rightColNames, tree.Name(right.SourceColumns[rightColIdx].Name))
 
 	return true
 }
 
 // makeOnPredicate constructs a joinPredicate object for joins with a ON clause.
 func (p *planner) makeOnPredicate(
-	ctx context.Context, typ joinType, left, right *dataSourceInfo, expr tree.Expr,
-) (*joinPredicate, *dataSourceInfo, error) {
+	ctx context.Context, typ joinType, left, right *sqlbase.DataSourceInfo, expr tree.Expr,
+) (*joinPredicate, *sqlbase.DataSourceInfo, error) {
 	pred, info, err := makeEqualityPredicate(typ, left, right, nil /*leftColNames*/, nil /*rightColNames*/)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	// Determine the on condition expression.
-	onCond, err := p.analyzeExpr(ctx, expr, multiSourceInfo{info}, pred.iVarHelper, types.Bool, true, "ON")
+	onCond, err := p.analyzeExpr(
+		ctx,
+		expr,
+		sqlbase.MultiSourceInfo{info},
+		pred.iVarHelper,
+		types.Bool,
+		true, /* requireType */
+		"ON",
+	)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -167,8 +177,8 @@ func (p *planner) makeOnPredicate(
 // makeUsingPredicate constructs a joinPredicate object for joins with
 // a USING clause.
 func makeUsingPredicate(
-	typ joinType, left, right *dataSourceInfo, usingCols tree.NameList,
-) (*joinPredicate, *dataSourceInfo, error) {
+	typ joinType, left, right *sqlbase.DataSourceInfo, usingCols tree.NameList,
+) (*joinPredicate, *sqlbase.DataSourceInfo, error) {
 	seenNames := make(map[string]struct{})
 
 	for _, syntaxColName := range usingCols {
@@ -187,8 +197,8 @@ func makeUsingPredicate(
 // condition includes equality between the columns specified by leftColNames and
 // rightColNames.
 func makeEqualityPredicate(
-	typ joinType, left, right *dataSourceInfo, leftColNames, rightColNames tree.NameList,
-) (resPred *joinPredicate, info *dataSourceInfo, err error) {
+	typ joinType, left, right *sqlbase.DataSourceInfo, leftColNames, rightColNames tree.NameList,
+) (resPred *joinPredicate, info *sqlbase.DataSourceInfo, err error) {
 	if len(leftColNames) != len(rightColNames) {
 		panic(fmt.Errorf("left columns' length %q doesn't match right columns' length %q in EqualityPredicate",
 			len(leftColNames), len(rightColNames)))
@@ -205,13 +215,13 @@ func makeEqualityPredicate(
 		rightColName := string(rightColNames[i])
 
 		// Find the column name on the left.
-		leftIdx, leftType, err := pickUsingColumn(left.sourceColumns, leftColName, "left")
+		leftIdx, leftType, err := pickUsingColumn(left.SourceColumns, leftColName, "left")
 		if err != nil {
 			return nil, nil, err
 		}
 
 		// Find the column name on the right.
-		rightIdx, rightType, err := pickUsingColumn(right.sourceColumns, rightColName, "right")
+		rightIdx, rightType, err := pickUsingColumn(right.SourceColumns, rightColName, "right")
 		if err != nil {
 			return nil, nil, err
 		}
@@ -238,43 +248,46 @@ func makeEqualityPredicate(
 	// are hidden so that they are invisible to star expansion, but
 	// not omitted so that they can still be selected separately.
 
-	columns := make(sqlbase.ResultColumns, 0, len(left.sourceColumns)+len(right.sourceColumns))
-	columns = append(columns, left.sourceColumns...)
-	columns = append(columns, right.sourceColumns...)
+	columns := make(sqlbase.ResultColumns, 0, len(left.SourceColumns)+len(right.SourceColumns))
+	columns = append(columns, left.SourceColumns...)
+	columns = append(columns, right.SourceColumns...)
 
 	// Compute the mappings from table aliases to column sets from
 	// both sides into a new alias-columnset mapping for the result
 	// rows. We need to be extra careful about the aliases
 	// for the anonymous table, which needs to be merged.
-	aliases := make(sourceAliases, 0, len(left.sourceAliases)+len(right.sourceAliases))
+	aliases := make(sqlbase.SourceAliases, 0, len(left.SourceAliases)+len(right.SourceAliases))
 
 	var anonymousCols util.FastIntSet
 
-	collectAliases := func(sourceAliases sourceAliases, offset int) {
+	collectAliases := func(sourceAliases sqlbase.SourceAliases, offset int) {
 		for _, alias := range sourceAliases {
-			newSet := alias.columnSet.Shift(offset)
-			if alias.name == anonymousTable {
+			newSet := alias.ColumnSet.Shift(offset)
+			if alias.Name == sqlbase.AnonymousTable {
 				anonymousCols.UnionWith(newSet)
 			} else {
-				aliases = append(aliases, sourceAlias{name: alias.name, columnSet: newSet})
+				aliases = append(aliases, sqlbase.SourceAlias{Name: alias.Name, ColumnSet: newSet})
 			}
 		}
 	}
-	collectAliases(left.sourceAliases, 0)
-	collectAliases(right.sourceAliases, len(left.sourceColumns))
+	collectAliases(left.SourceAliases, 0)
+	collectAliases(right.SourceAliases, len(left.SourceColumns))
 	if !anonymousCols.Empty() {
-		aliases = append(aliases, sourceAlias{name: anonymousTable, columnSet: anonymousCols})
+		aliases = append(aliases, sqlbase.SourceAlias{
+			Name:      sqlbase.AnonymousTable,
+			ColumnSet: anonymousCols,
+		})
 	}
 
-	info = &dataSourceInfo{
-		sourceColumns: columns,
-		sourceAliases: aliases,
+	info = &sqlbase.DataSourceInfo{
+		SourceColumns: columns,
+		SourceAliases: aliases,
 	}
 
 	pred := &joinPredicate{
 		joinType:             typ,
-		numLeftCols:          len(left.sourceColumns),
-		numRightCols:         len(right.sourceColumns),
+		numLeftCols:          len(left.SourceColumns),
+		numRightCols:         len(right.SourceColumns),
 		leftColNames:         leftColNames,
 		rightColNames:        rightColNames,
 		cmpFunctions:         cmpOps,
@@ -296,7 +309,7 @@ func (p *joinPredicate) IndexedVarEval(idx int, ctx *tree.EvalContext) (tree.Dat
 
 // IndexedVarResolvedType implements the tree.IndexedVarContainer interface.
 func (p *joinPredicate) IndexedVarResolvedType(idx int) types.T {
-	return p.info.sourceColumns[idx].Typ
+	return p.info.SourceColumns[idx].Typ
 }
 
 // IndexedVarNodeFormatter implements the tree.IndexedVarContainer interface.

--- a/pkg/sql/opt_decompose_test.go
+++ b/pkg/sql/opt_decompose_test.go
@@ -65,7 +65,7 @@ func makeSelectNode(t *testing.T, p *planner) *renderNode {
 	if err := desc.AllocateIDs(); err != nil {
 		t.Fatal(err)
 	}
-	numColumns := len(sel.sourceInfo[0].sourceColumns)
+	numColumns := len(sel.sourceInfo[0].SourceColumns)
 	sel.ivarHelper = tree.MakeIndexedVarHelper(sel, numColumns)
 	p.extendedEvalCtx.IVarHelper = &sel.ivarHelper
 	sel.run.curSourceRow = make(tree.Datums, numColumns)

--- a/pkg/sql/opt_needed.go
+++ b/pkg/sql/opt_needed.go
@@ -110,7 +110,7 @@ func setNeededColumns(plan planNode, needed []bool) {
 	case *filterNode:
 		// Detect which columns from the source are needed in addition to
 		// those needed by the context.
-		sourceNeeded := make([]bool, len(n.source.info.sourceColumns))
+		sourceNeeded := make([]bool, len(n.source.info.SourceColumns))
 		copy(sourceNeeded, needed)
 		for i := range sourceNeeded {
 			sourceNeeded[i] = sourceNeeded[i] || n.ivarHelper.IndexedVarUsed(i)
@@ -134,7 +134,7 @@ func setNeededColumns(plan planNode, needed []bool) {
 		}
 
 		// Now detect which columns from the source are still needed.
-		sourceNeeded := make([]bool, len(n.source.info.sourceColumns))
+		sourceNeeded := make([]bool, len(n.source.info.SourceColumns))
 		for i := range sourceNeeded {
 			sourceNeeded[i] = n.ivarHelper.IndexedVarUsed(i)
 		}

--- a/pkg/sql/ordinality.go
+++ b/pkg/sql/ordinality.go
@@ -71,15 +71,15 @@ func (p *planner) wrapOrdinality(ds planDataSource) planDataSource {
 
 	// Extend the dataSourceInfo with information about the
 	// new column.
-	ds.info.sourceColumns = res.columns
-	if srcIdx, ok := ds.info.sourceAliases.srcIdx(anonymousTable); !ok {
-		ds.info.sourceAliases = append(ds.info.sourceAliases, sourceAlias{
-			name:      anonymousTable,
-			columnSet: util.MakeFastIntSet(newColIdx),
+	ds.info.SourceColumns = res.columns
+	if srcIdx, ok := ds.info.SourceAliases.SrcIdx(sqlbase.AnonymousTable); !ok {
+		ds.info.SourceAliases = append(ds.info.SourceAliases, sqlbase.SourceAlias{
+			Name:      sqlbase.AnonymousTable,
+			ColumnSet: util.MakeFastIntSet(newColIdx),
 		})
 	} else {
-		srcAlias := &ds.info.sourceAliases[srcIdx]
-		srcAlias.columnSet.Add(newColIdx)
+		srcAlias := &ds.info.SourceAliases[srcIdx]
+		srcAlias.ColumnSet.Add(newColIdx)
 	}
 
 	ds.plan = res

--- a/pkg/sql/returning.go
+++ b/pkg/sql/returning.go
@@ -34,7 +34,7 @@ type returningHelper struct {
 	// Processed copies of expressions from ReturningExprs.
 	exprs        []tree.TypedExpr
 	rowCount     int
-	source       *dataSourceInfo
+	source       *sqlbase.DataSourceInfo
 	curSourceRow tree.Datums
 
 	// This struct must be allocated on the heap and its location stay
@@ -76,14 +76,14 @@ func (p *planner) newReturningHelper(
 	}
 
 	rh.columns = make(sqlbase.ResultColumns, 0, len(rExprs))
-	rh.source = newSourceInfoForSingleTable(
+	rh.source = sqlbase.NewSourceInfoForSingleTable(
 		*tn, sqlbase.ResultColumnsFromColDescs(tablecols),
 	)
 	rh.exprs = make([]tree.TypedExpr, 0, len(rExprs))
 	ivarHelper := tree.MakeIndexedVarHelper(rh, len(tablecols))
 	for _, target := range rExprs {
 		cols, typedExprs, _, err := p.computeRenderAllowingStars(
-			ctx, target, types.Any, multiSourceInfo{rh.source}, ivarHelper,
+			ctx, target, types.Any, sqlbase.MultiSourceInfo{rh.source}, ivarHelper,
 			autoGenerateRenderOutputName)
 		if err != nil {
 			return nil, err
@@ -122,7 +122,7 @@ func (rh *returningHelper) IndexedVarEval(idx int, ctx *tree.EvalContext) (tree.
 
 // IndexedVarResolvedType implements the tree.IndexedVarContainer interface.
 func (rh *returningHelper) IndexedVarResolvedType(idx int) types.T {
-	return rh.source.sourceColumns[idx].Typ
+	return rh.source.SourceColumns[idx].Typ
 }
 
 // IndexedVarNodeFormatter implements the tree.IndexedVarContainer interface.

--- a/pkg/sql/select_name_resolution.go
+++ b/pkg/sql/select_name_resolution.go
@@ -23,19 +23,14 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 )
-
-// invalidSrcIdx is the srcIdx value returned by findColumn() when there is no match.
-const invalidSrcIdx = -1
-
-// invalidColIdx is the colIdx value returned by findColumn() when there is no match.
-const invalidColIdx = -1
 
 // nameResolutionVisitor is a tree.Visitor implementation used to
 // resolve the column names in an expression.
 type nameResolutionVisitor struct {
 	err        error
-	sources    multiSourceInfo
+	sources    sqlbase.MultiSourceInfo
 	iVarHelper tree.IndexedVarHelper
 	searchPath sessiondata.SearchPath
 
@@ -81,7 +76,7 @@ func (v *nameResolutionVisitor) VisitPre(expr tree.Expr) (recurse bool, newNode 
 		//    SELECT (kv.*) FROM kv               -> SELECT (k, v) FROM kv
 		//    SELECT COUNT(DISTINCT kv.*) FROM kv -> SELECT COUNT(DISTINCT (k, v)) FROM kv
 		//
-		_, exprs, err := v.sources[0].expandStar(t, v.iVarHelper)
+		_, exprs, err := expandStar(v.sources[0], t, v.iVarHelper)
 		if err != nil {
 			v.err = err
 			return false, expr
@@ -116,12 +111,12 @@ func (v *nameResolutionVisitor) VisitPre(expr tree.Expr) (recurse bool, newNode 
 		return v.VisitPre(vn)
 
 	case *tree.ColumnItem:
-		srcIdx, colIdx, err := v.sources.findColumn(t)
+		srcIdx, colIdx, err := findColumn(v.sources, t)
 		if err != nil {
 			v.err = err
 			return false, expr
 		}
-		ivar := v.iVarHelper.IndexedVar(v.sources[srcIdx].colOffset + colIdx)
+		ivar := v.iVarHelper.IndexedVar(v.sources[srcIdx].ColOffset + colIdx)
 		v.foundDependentVars = true
 		return true, ivar
 
@@ -216,7 +211,7 @@ func (p *planner) resolveNamesForRender(
 // row in a table, the 2nd return value is true.
 // If any star is expanded, the 3rd return value is true.
 func (p *planner) resolveNames(
-	expr tree.Expr, sources multiSourceInfo, ivarHelper tree.IndexedVarHelper,
+	expr tree.Expr, sources sqlbase.MultiSourceInfo, ivarHelper tree.IndexedVarHelper,
 ) (tree.Expr, bool, bool, error) {
 	if expr == nil {
 		return nil, false, false, nil
@@ -234,7 +229,7 @@ func (p *planner) resolveNames(
 
 func resolveNames(
 	expr tree.Expr,
-	sources multiSourceInfo,
+	sources sqlbase.MultiSourceInfo,
 	ivarHelper tree.IndexedVarHelper,
 	searchPath sessiondata.SearchPath,
 ) (tree.Expr, bool, bool, error) {
@@ -253,8 +248,8 @@ func resolveNamesUsingVisitor(
 ) (tree.Expr, bool, bool, error) {
 	colOffset := 0
 	for _, s := range v.sources {
-		s.colOffset = colOffset
-		colOffset += len(s.sourceColumns)
+		s.ColOffset = colOffset
+		colOffset += len(s.SourceColumns)
 	}
 
 	expr, _ = tree.WalkExpr(v, expr)

--- a/pkg/sql/select_name_resolution_test.go
+++ b/pkg/sql/select_name_resolution_test.go
@@ -33,8 +33,8 @@ func testInitDummySelectNode(p *planner, desc *sqlbase.TableDescriptor) *renderN
 	sel.source.plan = scan
 	testName := tree.MakeTableName("test", tree.Name(desc.Name))
 	cols := planColumns(scan)
-	sel.source.info = newSourceInfoForSingleTable(testName, cols)
-	sel.sourceInfo = multiSourceInfo{sel.source.info}
+	sel.source.info = sqlbase.NewSourceInfoForSingleTable(testName, cols)
+	sel.sourceInfo = sqlbase.MultiSourceInfo{sel.source.info}
 	sel.ivarHelper = tree.MakeIndexedVarHelper(sel, len(cols))
 
 	return sel
@@ -63,7 +63,7 @@ func TestRetryResolveNames(t *testing.T) {
 			t.Fatal(err)
 		}
 		count := 0
-		for iv := 0; iv < len(s.sourceInfo[0].sourceColumns); iv++ {
+		for iv := 0; iv < len(s.sourceInfo[0].SourceColumns); iv++ {
 			if s.ivarHelper.IndexedVarUsed(iv) {
 				count++
 			}

--- a/pkg/sql/sqlbase/data_source.go
+++ b/pkg/sql/sqlbase/data_source.go
@@ -1,0 +1,271 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package sqlbase
+
+import (
+	"bytes"
+	"fmt"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/util"
+)
+
+// To understand DataSourceInfo below it is crucial to understand the
+// meaning of a "data source" and its relationship to names/IndexedVars.
+//
+// A data source is an object that can deliver rows of column data,
+// where each row is implemented in CockroachDB as an array of values.
+// The defining property of a data source is that the columns in its
+// result row arrays are always 0-indexed.
+//
+// From the language perspective, data sources are defined indirectly by:
+// - the FROM clause in a SELECT statement;
+// - JOIN clauses within the FROM clause;
+// - the clause that follows INSERT INTO colName(Cols...);
+// - the clause that follows UPSERT ....;
+// - the invisible data source defined by the original table row during
+//   UPSERT, if it exists.
+//
+// Most expressions (tree.Expr trees) in CockroachDB refer to a
+// single data source. A notable exception is UPSERT, where expressions
+// can refer to two sources: one for the values being inserted, one for
+// the original row data in the table for the conflicting (already
+// existing) rows.
+//
+// Meanwhile, IndexedVars in CockroachDB provide the interface between
+// symbolic names in expressions (e.g. "f.x", called VarNames,
+// or names) and data sources. During evaluation, an IndexedVar must
+// resolve to a column value. For a given name there are thus two
+// subsequent questions that must be answered:
+//
+// - which data source is the name referring to? (when there is more than 1 source)
+// - which 0-indexed column in that data source is the name referring to?
+//
+// The IndexedVar must distinguish data sources because the same column index
+// may refer to different columns in different data sources. For
+// example in an UPSERT statement the IndexedVar for "excluded.x" could refer
+// to column 0 in the (already existing) table row, whereas "src.x" could
+// refer to column 0 in the valueNode that provides values to insert.
+//
+// Within this context, the infrastructure for data sources and IndexedVars
+// is implemented as follows:
+//
+// - DataSourceInfo provides column metadata for exactly one data source;
+// - MultiSourceInfo is an array of one or more DataSourceInfo
+// - the index in IndexedVars points to one of the columns in the
+//   logical concatenation of all items in the MultiSourceInfo;
+// - IndexedVarResolver (select_name_resolution.go) is tasked with
+//   linking back IndexedVars with their data source and column index.
+//
+// This being said, there is a misunderstanding one should be careful
+// to avoid: *there is no direct relationship between data sources and
+// table names* in SQL. In other words:
+//
+// - the same table name can be present in two or more data sources; for example
+//   with:
+//        INSERT INTO excluded VALUES (42) ON CONFLICT (x) DO UPDATE ...
+//   the name "excluded" can refer either to the data source for VALUES(42)
+//   or the implicit data source corresponding to the rows in the original table
+//   that conflict with the new values.
+//
+//   When this happens, a name of the form "excluded.x" must be
+//   resolved by considering all the data sources; if there is more
+//   than one data source providing the table name "excluded" (as in
+//   this case), the query is rejected with an ambiguity error.
+//
+// - a single data source may provide values for multiple table names; for
+//   example with:
+//         SELECT * FROM (f CROSS JOIN g) WHERE f.x = g.x
+//   there is a single data source corresponding to the results of the
+//   CROSS JOIN, providing a single 0-indexed array of values on each
+//   result row.
+//
+//   (multiple table names for a single data source happen in JOINed sources
+//   and JOINed sources only. Note that a FROM clause with a comma-separated
+//   list of sources is a CROSS JOIN in disguise.)
+//
+//   When this happens, names of the form "f.x" in either WHERE,
+//   SELECT renders, or other expressions which can refer to the data
+//   source do not refer to the "internal" data sources of the JOIN;
+//   they always refer to the final result rows of the JOIN source as
+//   a whole.
+//
+//   This implies that a single DataSourceInfo that provides metadata
+//   for a complex JOIN clause must "know" which table name is
+//   associated with each column in its result set.
+//
+
+// DataSourceInfo provides column metadata for exactly one data source.
+type DataSourceInfo struct {
+	// SourceColumns match the plan.Columns() 1-to-1. However the column
+	// names might be different if the statement renames them using AS.
+	SourceColumns ResultColumns
+
+	// SourceAliases indicates to which table alias column ranges
+	// belong.
+	// These often correspond to the original table names for each
+	// column but might be different if the statement renames
+	// them using AS.
+	SourceAliases SourceAliases
+
+	// ColOffset is the offset of the first column in this DataSourceInfo in the
+	// MultiSourceInfo array it is part of.
+	// The value is populated and used during name resolution, and shouldn't get
+	// touched by anything but the nameResolutionVisitor without care.
+	ColOffset int
+
+	// The number of backfill source columns. The backfill columns are
+	// always the last columns from SourceColumns.
+	NumBackfillColumns int
+}
+
+// SourceAlias associates a table name (alias) to a set of columns in the result
+// row of a data source.
+type SourceAlias struct {
+	Name tree.TableName
+	// ColumnSet identifies a non-empty set of columns in a
+	// selection. This is used by DataSourceInfo.SourceAliases to map
+	// table names to column ranges.
+	ColumnSet util.FastIntSet
+}
+
+func (src *DataSourceInfo) String() string {
+	var buf bytes.Buffer
+	for i := range src.SourceColumns {
+		if i > 0 {
+			buf.WriteByte('\t')
+		}
+		fmt.Fprintf(&buf, "%d", i)
+	}
+	buf.WriteString("\toutput column positions\n")
+	for i, c := range src.SourceColumns {
+		if i > 0 {
+			buf.WriteByte('\t')
+		}
+		if c.Hidden {
+			buf.WriteByte('*')
+		}
+		buf.WriteString(c.Name)
+	}
+	buf.WriteString("\toutput column names\n")
+	for _, a := range src.SourceAliases {
+		for i := range src.SourceColumns {
+			if i > 0 {
+				buf.WriteByte('\t')
+			}
+			if a.ColumnSet.Contains(i) {
+				buf.WriteString("x")
+			}
+		}
+		if a.Name == AnonymousTable {
+			buf.WriteString("\t<anonymous table>")
+		} else {
+			fmt.Fprintf(&buf, "\t'%s'", a.Name.String())
+		}
+		fmt.Fprintf(&buf, " - %s\n", a.ColumnSet)
+	}
+	return buf.String()
+}
+
+// SourceAliases is an array of one or more SourceAlias.
+type SourceAliases []SourceAlias
+
+// SrcIdx looks up a source by qualified name and returns the index of the
+// source (and whether we found one).
+func (s SourceAliases) SrcIdx(name tree.TableName) (srcIdx int, found bool) {
+	for i := range s {
+		if s[i].Name.SchemaName == name.SchemaName && s[i].Name.TableName == name.TableName {
+			return i, true
+		}
+	}
+	return -1, false
+}
+
+// ColumnSet looks up a source by name and returns the column set (and
+// whether we found the name).
+func (s SourceAliases) ColumnSet(name tree.TableName) (_ util.FastIntSet, found bool) {
+	idx, ok := s.SrcIdx(name)
+	if !ok {
+		return util.FastIntSet{}, false
+	}
+	return s[idx].ColumnSet, true
+}
+
+// AnonymousTable is the empty table name, used when a data source
+// has no own name, e.g. VALUES, subqueries or the empty source.
+var AnonymousTable = tree.TableName{}
+
+// FillColumnRange creates a single range that refers to all the
+// columns between firstIdx and lastIdx, inclusive.
+func FillColumnRange(firstIdx, lastIdx int) util.FastIntSet {
+	var res util.FastIntSet
+	for i := firstIdx; i <= lastIdx; i++ {
+		res.Add(i)
+	}
+	return res
+}
+
+// NewSourceInfoForSingleTable creates a simple DataSourceInfo
+// which maps the same tableAlias to all columns.
+func NewSourceInfoForSingleTable(tn tree.TableName, columns ResultColumns) *DataSourceInfo {
+	return &DataSourceInfo{
+		SourceColumns: columns,
+		SourceAliases: SourceAliases{{Name: tn, ColumnSet: FillColumnRange(0, len(columns)-1)}},
+	}
+}
+
+// MultiSourceInfo is an array of one or more DataSourceInfo.
+type MultiSourceInfo []*DataSourceInfo
+
+// findTableAlias returns the first table alias providing the column
+// index given as argument. The index must be valid.
+func (src *DataSourceInfo) findTableAlias(colIdx int) (tree.TableName, bool) {
+	for _, alias := range src.SourceAliases {
+		if alias.ColumnSet.Contains(colIdx) {
+			return alias.Name, true
+		}
+	}
+	return AnonymousTable, false
+}
+
+type varFormatter struct {
+	TableName  tree.TableName
+	ColumnName tree.Name
+}
+
+// Format implements the NodeFormatter interface.
+func (c *varFormatter) Format(ctx *tree.FmtCtx) {
+	if ctx.HasFlags(tree.FmtShowTableAliases) && c.TableName.TableName != "" {
+		if c.TableName.SchemaName != "" {
+			ctx.FormatNode(&c.TableName.SchemaName)
+			ctx.WriteByte('.')
+		}
+
+		ctx.FormatNode(&c.TableName.TableName)
+		ctx.WriteByte('.')
+	}
+	ctx.FormatNode(&c.ColumnName)
+}
+
+// NodeFormatter returns a tree.NodeFormatter that, when formatted,
+// represents the object at the input column index.
+func (src *DataSourceInfo) NodeFormatter(colIdx int) tree.NodeFormatter {
+	var ret varFormatter
+	ret.ColumnName = tree.Name(src.SourceColumns[colIdx].Name)
+	if tableAlias, found := src.findTableAlias(colIdx); found {
+		ret.TableName = tableAlias
+	}
+	return &ret
+}

--- a/pkg/sql/targets.go
+++ b/pkg/sql/targets.go
@@ -30,7 +30,7 @@ func (p *planner) computeRender(
 	ctx context.Context,
 	target tree.SelectExpr,
 	desiredType types.T,
-	info multiSourceInfo,
+	info sqlbase.MultiSourceInfo,
 	ivarHelper tree.IndexedVarHelper,
 	outputName string,
 ) (column sqlbase.ResultColumn, expr tree.TypedExpr, err error) {
@@ -59,7 +59,7 @@ func (p *planner) computeRenderAllowingStars(
 	ctx context.Context,
 	target tree.SelectExpr,
 	desiredType types.T,
-	info multiSourceInfo,
+	info sqlbase.MultiSourceInfo,
 	ivarHelper tree.IndexedVarHelper,
 	outputName string,
 ) (columns sqlbase.ResultColumns, exprs []tree.TypedExpr, hasStar bool, err error) {
@@ -153,7 +153,7 @@ func symbolicExprStr(expr tree.Expr) string {
 // name to one of the tables in the query and then expand the "*" into a list
 // of columns. A sqlbase.ResultColumns and Expr pair is returned for each column.
 func checkRenderStar(
-	target tree.SelectExpr, info multiSourceInfo, ivarHelper tree.IndexedVarHelper,
+	target tree.SelectExpr, info sqlbase.MultiSourceInfo, ivarHelper tree.IndexedVarHelper,
 ) (isStar bool, columns sqlbase.ResultColumns, exprs []tree.TypedExpr, err error) {
 	v, ok := target.Expr.(tree.VarName)
 	if !ok {
@@ -166,7 +166,7 @@ func checkRenderStar(
 			return false, nil, nil, errors.Errorf("\"%s\" cannot be aliased", v)
 		}
 
-		columns, exprs, err = info[0].expandStar(v, ivarHelper)
+		columns, exprs, err = expandStar(info[0], v, ivarHelper)
 		return true, columns, exprs, err
 	default:
 		return false, nil, nil, nil

--- a/pkg/sql/value_generator.go
+++ b/pkg/sql/value_generator.go
@@ -49,7 +49,7 @@ func (p *planner) makeGenerator(ctx context.Context, t *tree.FuncExpr) (planNode
 
 	lastKnownSubqueryIndex := len(p.curPlan.subqueryPlans)
 	normalized, err := p.analyzeExpr(
-		ctx, t, multiSourceInfo{}, tree.IndexedVarHelper{}, types.Any, false, "FROM",
+		ctx, t, sqlbase.MultiSourceInfo{}, tree.IndexedVarHelper{}, types.Any, false, "FROM",
 	)
 	if err != nil {
 		return nil, err

--- a/pkg/sql/window.go
+++ b/pkg/sql/window.go
@@ -979,12 +979,12 @@ type windowNodeColContainer struct {
 
 	// sourceInfo contains information on the for the IndexedVars from the
 	// source plan where they were originally created.
-	sourceInfo *dataSourceInfo
+	sourceInfo *sqlbase.DataSourceInfo
 }
 
 // IndexedVarResolvedType implements the tree.IndexedVarContainer interface.
 func (cc *windowNodeColContainer) IndexedVarResolvedType(idx int) types.T {
-	return cc.sourceInfo.sourceColumns[idx].Typ
+	return cc.sourceInfo.SourceColumns[idx].Typ
 }
 
 // IndexedVarNodeFormatter implements the tree.IndexedVarContainer interface.

--- a/pkg/sql/with.go
+++ b/pkg/sql/with.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 )
 
 // This file contains the implementation of common table expressions. See
@@ -122,7 +123,7 @@ func (p *planner) getCTEDataSource(t *tree.NormalizableTableName) (planDataSourc
 				frame[tn.TableName] = cteSource
 				plan := cteSource.plan
 				dataSource := planDataSource{
-					info: newSourceInfoForSingleTable(*tn, planColumns(plan)),
+					info: sqlbase.NewSourceInfoForSingleTable(*tn, planColumns(plan)),
 					plan: plan,
 				}
 				dataSource, err = renameSource(dataSource, cteSource.alias, false)


### PR DESCRIPTION
This is the first of a set of 4 commits that will enable the combination of
foreign key cascading actions and check constraints. This commit is entirely\
code movement.

1) Move DataSourceInfo from sql to sqlbase. (this commit)
2) Move CheckHelper from sql to sqlbase.
3) Add CheckHelpers to TablesNeededForFK.
4) Enable Check Constraints on cascading actions

These changes should also enable the ability to mix computed columns and
foreign key cascading actions.

Release note: None