### PR TITLE
sql: improve syntax around computed columns

### DIFF
--- a/docs/generated/sql/bnf/col_qualification.bnf
+++ b/docs/generated/sql/bnf/col_qualification.bnf
@@ -6,7 +6,7 @@ col_qualification ::=
 	| 'CONSTRAINT' constraint_name 'CHECK' '(' a_expr ')'
 	| 'CONSTRAINT' constraint_name 'DEFAULT' b_expr
 	| 'CONSTRAINT' constraint_name 'REFERENCES' table_name opt_name_parens reference_actions
-	| 'CONSTRAINT' constraint_name 'AS' b_expr 'STORED'
+	| 'CONSTRAINT' constraint_name 'AS' '(' a_expr ')' 'STORED'
 	| 'NOT' 'NULL'
 	| 'NULL'
 	| 'UNIQUE'
@@ -14,7 +14,7 @@ col_qualification ::=
 	| 'CHECK' '(' a_expr ')'
 	| 'DEFAULT' b_expr
 	| 'REFERENCES' table_name opt_name_parens reference_actions
-	| 'AS' b_expr 'STORED'
+	| 'AS' '(' a_expr ')' 'STORED'
 	| 'COLLATE' collation_name
 	| 'FAMILY' family_name
 	| 'CREATE' 'FAMILY' family_name

--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -1468,6 +1468,7 @@ reserved_keyword ::=
 	| 'USING'
 	| 'VARIADIC'
 	| 'VIEW'
+	| 'VIRTUAL'
 	| 'WHEN'
 	| 'WHERE'
 	| 'WINDOW'
@@ -1909,7 +1910,7 @@ col_qualification_elem ::=
 	| 'CHECK' '(' a_expr ')'
 	| 'DEFAULT' b_expr
 	| 'REFERENCES' table_name opt_name_parens reference_actions
-	| 'AS' b_expr 'STORED'
+	| 'AS' '(' a_expr ')' 'STORED'
 
 family_name ::=
 	name

--- a/pkg/ccl/sqlccl/csv_test.go
+++ b/pkg/ccl/sqlccl/csv_test.go
@@ -652,7 +652,7 @@ func TestImportStmt(t *testing.T) {
 		},
 		{
 			"bad-computed-column",
-			`IMPORT TABLE t (a INT PRIMARY KEY, b STRING AS 'hello' STORED, INDEX (b), INDEX (a, b)) CSV DATA (%s) WITH transform = $1`,
+			`IMPORT TABLE t (a INT PRIMARY KEY, b STRING AS ('hello') STORED, INDEX (b), INDEX (a, b)) CSV DATA (%s) WITH transform = $1`,
 			nil,
 			filesWithOpts,
 			``,

--- a/pkg/sql/logictest/testdata/logic_test/computed
+++ b/pkg/sql/logictest/testdata/logic_test/computed
@@ -4,7 +4,7 @@ statement ok
 CREATE TABLE with_no_column_refs (
   a INT,
   b INT,
-  c INT AS 3 STORED
+  c INT AS (3) STORED
 )
 
 query TT
@@ -13,9 +13,27 @@ SHOW CREATE TABLE with_no_column_refs
 with_no_column_refs CREATE TABLE with_no_column_refs (
                       a INT NULL,
                       b INT NULL,
-                      c INT NULL AS 3 STORED,
+                      c INT NULL AS (3) STORED,
                       FAMILY "primary" (a, b, c, rowid)
                     )
+
+statement ok
+CREATE TABLE extra_parens (
+  a INT,
+  b INT,
+  c INT AS ((3)) STORED
+)
+
+query TT
+SHOW CREATE TABLE extra_parens
+----
+extra_parens CREATE TABLE extra_parens (
+                a INT NULL,
+                b INT NULL,
+                c INT NULL AS ((3)) STORED,
+                FAMILY "primary" (a, b, c, rowid)
+              )
+
 
 statement error cannot write directly to computed column "c"
 INSERT INTO with_no_column_refs (c) VALUES (1)
@@ -32,8 +50,8 @@ statement ok
 CREATE TABLE x (
   a INT DEFAULT 3,
   b INT DEFAULT 7,
-  c INT AS a STORED,
-  d INT AS a + b STORED
+  c INT AS (a) STORED,
+  d INT AS (a + b) STORED
 )
 
 query TT
@@ -42,8 +60,8 @@ SHOW CREATE TABLE x
 x CREATE TABLE x (
     a INT NULL DEFAULT 3:::INT,
     b INT NULL DEFAULT 7:::INT,
-    c INT NULL AS a STORED,
-    d INT NULL AS a + b STORED,
+    c INT NULL AS (a) STORED,
+    d INT NULL AS (a + b) STORED,
     FAMILY "primary" (a, b, c, d, rowid)
   )
 
@@ -95,8 +113,8 @@ statement ok
 CREATE TABLE x (
   a INT PRIMARY KEY,
   b INT,
-  c INT AS b + 1 STORED,
-  d INT AS b - 1 STORED
+  c INT AS (b + 1) STORED,
+  d INT AS (b - 1) STORED
 )
 
 statement ok
@@ -153,7 +171,7 @@ DROP TABLE x
 
 statement ok
 CREATE TABLE x (
-  b INT AS a STORED,
+  b INT AS (a) STORED,
   a INT
 )
 
@@ -172,9 +190,24 @@ SELECT b FROM x ORDER BY b
 statement ok
 DROP TABLE x
 
+statement error use AS \( <expr> \) STORED
+CREATE TABLE y (
+  a INT AS 3 STORED
+)
+
+statement error use AS \( <expr> \) STORED
+CREATE TABLE y (
+  a INT AS (3)
+)
+
+statement error unimplemented at or near "virtual"
+CREATE TABLE y (
+  a INT AS (3) VIRTUAL
+)
+
 statement error expected computed column expression to have type int, but .* has type string
 CREATE TABLE y (
-  a INT AS 'not an integer!'::STRING STORED
+  a INT AS ('not an integer!'::STRING) STORED
 )
 
 # We utilize the types from other columns.
@@ -182,38 +215,38 @@ CREATE TABLE y (
 statement error expected computed column expression to have type int, but .* has type string
 CREATE TABLE y (
   a STRING,
-  b INT AS a STORED
+  b INT AS (a) STORED
 )
 
 statement error computed column a contains impure functions: now\(\)
 CREATE TABLE y (
-  a TIMESTAMP AS now() STORED
+  a TIMESTAMP AS (now()) STORED
 )
 
 statement error computed column a contains impure functions: now\(\), uuid_v4\(\)
 CREATE TABLE y (
-  a STRING AS CONCAT(now()::STRING, uuid_v4()::STRING) STORED
+  a STRING AS (CONCAT(now()::STRING, uuid_v4()::STRING)) STORED
 )
 
 statement error computed columns cannot reference other computed columns
 CREATE TABLE y (
-  a INT AS 3 STORED,
-  b INT AS a STORED
+  a INT AS (3) STORED,
+  b INT AS (a) STORED
 )
 
 statement error column "a" not found, referenced in "a"
 CREATE TABLE y (
-  b INT AS a STORED
+  b INT AS (a) STORED
 )
 
 statement error aggregate functions are not allowed in computed column expressions
 CREATE TABLE y (
-  b INT AS COUNT(1) STORED
+  b INT AS (COUNT(1)) STORED
 )
 
 statement error computed columns cannot have default values
 CREATE TABLE y (
-  a INT AS 3 STORED DEFAULT 4
+  a INT AS (3) STORED DEFAULT 4
 )
 
 # TODO(justin,bram): this should be allowed.
@@ -223,29 +256,29 @@ CREATE TABLE x (a INT PRIMARY KEY)
 statement error computed columns cannot reference non-restricted FK columns
 CREATE TABLE y (
   q INT REFERENCES x (a) ON UPDATE CASCADE,
-  r INT AS q STORED
+  r INT AS (q) STORED
 )
 
 statement error computed columns cannot reference non-restricted FK columns
 CREATE TABLE y (
   q INT REFERENCES x (a) ON DELETE CASCADE,
-  r INT AS q STORED
+  r INT AS (q) STORED
 )
 
 statement error computed column expression '\(SELECT 1\)' may not contain variable sub-expressions
 CREATE TABLE y (
-  r INT AS (SELECT 1) STORED
+  r INT AS ((SELECT 1)) STORED
 )
 
 statement error column "a" not found, referenced in "x.a"
 CREATE TABLE y (
-  r INT AS x.a STORED
+  r INT AS (x.a) STORED
 )
 
 statement ok
 CREATE TABLE y (
   q INT,
-  r INT AS y.q STORED
+  r INT AS (y.q) STORED
 )
 
 statement ok
@@ -255,7 +288,7 @@ DROP TABLE y
 statement ok
 CREATE TABLE y (
   q INT REFERENCES x (a) ON UPDATE CASCADE,
-  r INT AS 3 STORED
+  r INT AS (3) STORED
 )
 
 statement ok

--- a/pkg/sql/sem/tree/create.go
+++ b/pkg/sql/sem/tree/create.go
@@ -408,9 +408,9 @@ func (node *ColumnTableDef) Format(ctx *FmtCtx) {
 		ctx.FormatNode(&node.References.Actions)
 	}
 	if node.IsComputed() {
-		ctx.WriteString(" AS ")
+		ctx.WriteString(" AS (")
 		ctx.FormatNode(node.Computed.Expr)
-		ctx.WriteString(" STORED")
+		ctx.WriteString(") STORED")
 	}
 	if node.HasColumnFamily() {
 		if node.Family.Create {

--- a/pkg/sql/sqlbase/structured.go
+++ b/pkg/sql/sqlbase/structured.go
@@ -2476,9 +2476,9 @@ func (desc *ColumnDescriptor) SQLString() string {
 		f.WriteString(*desc.DefaultExpr)
 	}
 	if desc.ComputeExpr != nil {
-		f.WriteString(" AS ")
+		f.WriteString(" AS (")
 		f.WriteString(*desc.ComputeExpr)
-		f.WriteString(" STORED")
+		f.WriteString(") STORED")
 	}
 	return f.CloseAndGetString()
 }


### PR DESCRIPTION
This commit makes two distinct but related changes:

* Generation expression for computed columns must be wrapped in
  parentheses.
* Parsing now provides more helpful error messages for computed columns.

Release note (sql change): Change computed column syntax and improved
error messages.