### PR TITLE
ui: Make Overview latencies match Graph

### DIFF
--- a/pkg/ui/src/views/cluster/containers/nodeGraphs/summaryBar.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodeGraphs/summaryBar.tsx
@@ -77,10 +77,10 @@ export default function(props: ClusterSummaryProps) {
           <Metric sources={props.nodeSources} name="cr.node.sql.query.count" title="Queries/Sec" nonNegativeRate />
         </SummaryMetricStat>
         <SummaryMetricStat id="p50" title="P50 latency" format={formatNanosAsMillis} >
-          <Metric sources={props.nodeSources} name="cr.node.exec.latency-p50" aggregateMax downsampleMax />
+          <Metric sources={props.nodeSources} name="cr.node.sql.service.latency-p50" aggregateMax downsampleMax />
         </SummaryMetricStat>
         <SummaryMetricStat id="p99" title="P99 latency" format={formatNanosAsMillis} >
-          <Metric sources={props.nodeSources} name="cr.node.exec.latency-p99" aggregateMax downsampleMax />
+          <Metric sources={props.nodeSources} name="cr.node.sql.service.latency-p99" aggregateMax downsampleMax />
         </SummaryMetricStat>
       </SummaryBar>
       <SummaryBar>


### PR DESCRIPTION
The "P99 Latency" and "P50 Latency" on the cluster overview summary did
not agree with the "Service Latency: SQL" graph on the overview
dashboard.  because they were displaying a different metric;
specifically, they were displaying KV execution latency, not SQL
latency.  This caused confusiong for at least one user.

The "P99 Latency" and "P50 Latency" now display SQL latency and agree
with the graph on the overview dashboard.

Fixes #20221

Release note: None