### PR TITLE
sql: fix ResultColumns for unionNode with NULL sub-plan columns

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/union
+++ b/pkg/sql/logictest/testdata/logic_test/union
@@ -71,7 +71,7 @@ VALUES (1) UNION ALL VALUES (NULL) ORDER BY 1
 NULL
 1
 
-query T
+query I
 VALUES (NULL) UNION ALL VALUES (1) ORDER BY 1
 ----
 NULL
@@ -82,6 +82,18 @@ VALUES (NULL) UNION ALL VALUES (NULL)
 ----
 NULL
 NULL
+
+query IT
+SELECT x, pg_typeof(y) FROM (SELECT 1, NULL UNION ALL SELECT 2, 4) AS t(x, y)
+----
+1  NULL
+2  int
+
+query IT
+SELECT x, pg_typeof(y) FROM (SELECT 1, 3 UNION ALL SELECT 2, NULL) AS t(x, y)
+----
+1  int
+2  NULL
 
 statement ok
 CREATE TABLE uniontest (

--- a/pkg/sql/opt_needed.go
+++ b/pkg/sql/opt_needed.go
@@ -67,6 +67,7 @@ func setNeededColumns(plan planNode, needed []bool) {
 		}
 		setNeededColumns(n.left, needed)
 		setNeededColumns(n.right, needed)
+		markOmitted(n.columns, needed)
 
 	case *joinNode:
 		// Note: getNeededColumns takes into account both the columns

--- a/pkg/sql/plan_columns.go
+++ b/pkg/sql/plan_columns.go
@@ -65,6 +65,8 @@ func getPlanColumns(plan planNode, mut bool) sqlbase.ResultColumns {
 		return n.resultColumns
 	case *sortNode:
 		return n.columns
+	case *unionNode:
+		return n.columns
 	case *valueGenerator:
 		return n.columns
 	case *valuesNode:
@@ -76,7 +78,7 @@ func getPlanColumns(plan planNode, mut bool) sqlbase.ResultColumns {
 	case *showTraceNode:
 		return n.columns
 
-		// Nodes with a fixed schema.
+	// Nodes with a fixed schema.
 	case *scrubNode:
 		return n.getColumns(mut, scrubColumns)
 	case *explainDistSQLNode:
@@ -114,11 +116,6 @@ func getPlanColumns(plan planNode, mut bool) sqlbase.ResultColumns {
 		return getPlanColumns(n.table, mut)
 	case *limitNode:
 		return getPlanColumns(n.plan, mut)
-	case *unionNode:
-		if n.inverted {
-			return getPlanColumns(n.right, mut)
-		}
-		return getPlanColumns(n.left, mut)
 	}
 
 	// Every other node has no columns in their results.


### PR DESCRIPTION
Fixes #22431.

We now maintain a combined ResultColumns field in unionNode and
ensure that this field does not contain NULL types when it shouldn't.

Release note (bug fix): pg_typeof now returns the correct type for the
output of UNION ALL even when the left sub-select has a NULL column.