### PR TITLE
nightly-workload: print roachprod version

### DIFF
--- a/build/nightly-workload.sh
+++ b/build/nightly-workload.sh
@@ -21,6 +21,7 @@ artifacts=$PWD/artifacts/${TC_BUILD_ID}
 mkdir -p "$artifacts"
 
 go get -u -v github.com/cockroachdb/roachprod
+git -C "$(go env GOPATH)/src/github.com/cockroachdb/roachprod" rev-parse HEAD
 
 make build TYPE=release-linux-gnu
 


### PR DESCRIPTION
Print out roachprod version to assist in debugging.

Release note: None