### PR TITLE
workload: add an http server that returns Table data as CSVs

### DIFF
--- a/pkg/cmd/workload/csv_server.go
+++ b/pkg/cmd/workload/csv_server.go
@@ -1,0 +1,58 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+
+package main
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/spf13/cobra"
+
+	"github.com/cockroachdb/cockroach/pkg/workload"
+)
+
+var csvServerCmd = &cobra.Command{
+	Use:   `csv-server`,
+	Short: `Serves csv table data through an HTTP interface`,
+	Args:  cobra.NoArgs,
+	RunE:  runCSVServer,
+}
+
+var port *int
+
+func init() {
+	port = csvServerCmd.Flags().Int(`port`, 8081, `The port to bind to`)
+	rootCmd.AddCommand(csvServerCmd)
+}
+
+func runCSVServer(_ *cobra.Command, _ []string) error {
+	mux := http.NewServeMux()
+	for _, meta := range workload.Registered() {
+		meta := meta
+		prefix := fmt.Sprintf(`/csv/%s/`, meta.Name)
+		mux.HandleFunc(prefix, func(w http.ResponseWriter, req *http.Request) {
+			if err := workload.HandleCSV(w, req, prefix, meta); err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+			}
+		})
+	}
+	s := &http.Server{
+		Addr:    fmt.Sprintf(`:%d`, *port),
+		Handler: mux,
+	}
+	fmt.Printf("Listening on %s\n", s.Addr)
+	return s.ListenAndServe()
+}

--- a/pkg/workload/csv.go
+++ b/pkg/workload/csv.go
@@ -1,0 +1,137 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package workload
+
+import (
+	"context"
+	"encoding/csv"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/pflag"
+)
+
+const (
+	rowStartParam = `row-start`
+	rowEndParam   = `row-end`
+)
+
+// WriteCSVRows writes the specified table rows as a csv. If sizeBytesLimit is >
+// 0, it will be used as an approximate upper bound for how much to write. The
+// next rowStart is returned (so last row written + 1).
+func WriteCSVRows(
+	ctx context.Context, w io.Writer, table Table, rowStart, rowEnd int, sizeBytesLimit int64,
+) (rowIdx int, err error) {
+	bytesWrittenW := &bytesWrittenWriter{w: w}
+	csvW := csv.NewWriter(bytesWrittenW)
+	for rowIdx = rowStart; rowIdx < rowEnd; rowIdx++ {
+		if sizeBytesLimit > 0 && bytesWrittenW.written > sizeBytesLimit {
+			break
+		}
+
+		select {
+		case <-ctx.Done():
+			return 0, ctx.Err()
+		default:
+		}
+		row := table.InitialRowFn(rowIdx)
+		rowStrings := make([]string, len(row))
+		for i, datum := range row {
+			if datum == nil {
+				rowStrings[i] = `NULL`
+			} else {
+				rowStrings[i] = fmt.Sprintf(`%v`, datum)
+			}
+		}
+		if err := csvW.Write(rowStrings); err != nil {
+			return 0, err
+		}
+	}
+	csvW.Flush()
+	return rowIdx, csvW.Error()
+}
+
+// HandleCSV configures a Generator with url params and outputs the data for a
+// single Table as a CSV (optionally limiting the rows via `row-start` and
+// `row-end` params). It is intended for use in implementing a
+// `net/http.Handler`.
+func HandleCSV(w http.ResponseWriter, req *http.Request, prefix string, meta Meta) error {
+	ctx := context.Background()
+	if err := req.ParseForm(); err != nil {
+		return err
+	}
+
+	gen := meta.New()
+	if f, ok := gen.(Flagser); ok {
+		var flags []string
+		f.Flags().VisitAll(func(f *pflag.Flag) {
+			if vals, ok := req.Form[f.Name]; ok {
+				for _, val := range vals {
+					flags = append(flags, fmt.Sprintf(`--%s=%s`, f.Name, val))
+				}
+			}
+		})
+		if err := f.Flags().Parse(flags); err != nil {
+			return errors.Wrapf(err, `parsing parameters %s`, strings.Join(flags, ` `))
+		}
+	}
+
+	tableName := strings.TrimPrefix(req.URL.Path, prefix)
+	var table *Table
+	for _, t := range gen.Tables() {
+		if t.Name == tableName {
+			table = &t
+			break
+		}
+	}
+	if table == nil {
+		return errors.Errorf(`could not find table %s in generator %s`, tableName, meta.Name)
+	}
+
+	rowStart, rowEnd := 0, table.InitialRowCount
+	if vals, ok := req.Form[rowStartParam]; ok && len(vals) > 0 {
+		var err error
+		rowStart, err = strconv.Atoi(vals[len(vals)-1])
+		if err != nil {
+			return errors.Wrapf(err, `parsing %s`, rowStartParam)
+		}
+	}
+	if vals, ok := req.Form[rowEndParam]; ok && len(vals) > 0 {
+		var err error
+		rowEnd, err = strconv.Atoi(vals[len(vals)-1])
+		if err != nil {
+			return errors.Wrapf(err, `parsing %s`, rowEndParam)
+		}
+	}
+
+	w.Header().Set(`Content-Type`, `text/csv`)
+	_, err := WriteCSVRows(ctx, w, *table, rowStart, rowEnd, -1 /* sizeBytesLimit */)
+	return err
+}
+
+type bytesWrittenWriter struct {
+	w       io.Writer
+	written int64
+}
+
+func (w *bytesWrittenWriter) Write(p []byte) (int, error) {
+	n, err := w.w.Write(p)
+	w.written += int64(n)
+	return n, err
+}

--- a/pkg/workload/csv_test.go
+++ b/pkg/workload/csv_test.go
@@ -1,0 +1,102 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package workload_test
+
+import (
+	"bytes"
+	"context"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/workload"
+	"github.com/cockroachdb/cockroach/pkg/workload/bank"
+	_ "github.com/cockroachdb/cockroach/pkg/workload/tpcc"
+)
+
+func TestHandleCSV(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	tests := []struct {
+		params, expected string
+	}{
+		{
+			`?rows=1`, `
+0,0,initial-58566c427a67626169434d52416a577768544863746375417868784b5146446146704c536a466263586f454666`,
+		},
+		{
+			`?rows=5&row-start=1&row-end=3`, `
+1,0,initial-494d6d4f61674d5378656f4e6a714b5270576a624155624d494e524a4373567743466c65446a6a717257536766
+2,0,initial-6d54756f50526576475a4d6b485a6376496f415972646e4d587a464153574168555379576248515062696e754c`,
+		},
+	}
+
+	meta := bank.FromRows(0).Meta()
+	for _, test := range tests {
+		t.Run(test.params, func(t *testing.T) {
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if err := workload.HandleCSV(w, r, `/bank/`, meta); err != nil {
+					panic(err)
+				}
+			}))
+			defer ts.Close()
+
+			res, err := http.Get(ts.URL + `/bank/bank` + test.params)
+			if err != nil {
+				t.Fatal(err)
+			}
+			data, err := ioutil.ReadAll(res.Body)
+			res.Body.Close()
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if d, e := strings.TrimSpace(string(data)), strings.TrimSpace(test.expected); d != e {
+				t.Errorf("got [\n%s\n] expected [\n%s\n]", d, e)
+			}
+		})
+	}
+}
+
+func BenchmarkWriteCSVRows(b *testing.B) {
+	ctx := context.Background()
+	gen := bank.FromRows(1000)
+	const limit = -1
+
+	var buf bytes.Buffer
+	fn := func() {
+		for _, table := range gen.Tables() {
+			if _, err := workload.WriteCSVRows(
+				ctx, &buf, table, 0, table.InitialRowCount, limit,
+			); err != nil {
+				b.Fatalf(`%+v`, err)
+			}
+		}
+	}
+
+	// Run fn once to pre-size buf.
+	fn()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		buf.Reset()
+		fn()
+	}
+	b.StopTimer()
+	b.SetBytes(int64(buf.Len()))
+}


### PR DESCRIPTION
Release note: None

Still TODO is hooking this into the fixtures stuff and generating the IMPORT command that references each node's localhost copy of this server.