### PR TITLE
cli/sql: ensure client-side checking doesn't bark at empty inputs

### DIFF
--- a/pkg/cli/interactive_tests/test_client_side_checking.tcl
+++ b/pkg/cli/interactive_tests/test_client_side_checking.tcl
@@ -25,6 +25,13 @@ eexpect COMMIT
 eexpect root@
 end_test
 
+start_test "Check that the syntax checker does not get confused by empty inputs."
+# (issue #22441.)
+send ";\r"
+eexpect "0 rows"
+eexpect root@
+end_test
+
 start_test "Check that the user can force server-side handling."
 send "\\unset check_syntax\r"
 eexpect root@

--- a/pkg/cli/sql.go
+++ b/pkg/cli/sql.go
@@ -1232,13 +1232,13 @@ func (c *cliState) serverSideParse(sql string) (stmts []string, pgErr *pgerror.E
 		return nil, pgerror.NewErrorf(pgerror.CodeInternalError, "%v", err)
 	}
 
-	if len(rows) == 0 || len(cols) < 2 {
+	if len(cols) < 2 {
 		return nil, pgerror.NewErrorf(pgerror.CodeInternalError,
 			"invalid results for SHOW SYNTAX: %q %q", cols, rows)
 	}
 
 	// If SHOW SYNTAX reports an error, then it does so on the first row.
-	if rows[0][0] == "error" {
+	if len(rows) >= 1 && rows[0][0] == "error" {
 		var message, code, detail, hint string
 		for _, row := range rows {
 			switch row[0] {


### PR DESCRIPTION
Fixes #22441.

Release note (bug fix): `cockroach sql` does not produce an error
any more when the empty statement is entered at the interactive
prompt.