### PR TITLE
sqlccl: require IMPORT CSV tables to specify a primary key

### DIFF
--- a/pkg/ccl/sqlccl/backup_test.go
+++ b/pkg/ccl/sqlccl/backup_test.go
@@ -955,17 +955,17 @@ func TestBackupRestoreControlJob(t *testing.T) {
 		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			if r.Method == "GET" {
 				<-allowResponse
-				_, _ = w.Write([]byte("1"))
+				_, _ = w.Write([]byte(r.URL.Path[1:]))
 			}
 		}))
 		defer srv.Close()
 
 		var urls []string
 		for i := 0; i < 10; i++ {
-			urls = append(urls, fmt.Sprintf("'%s/%d.csv'", srv.URL, i))
+			urls = append(urls, fmt.Sprintf("'%s/%d'", srv.URL, i))
 		}
 		csvURLs := strings.Join(urls, ", ")
-		query := fmt.Sprintf(`IMPORT TABLE t (i INT) CSV DATA (%s) WITH into_db = 'cancelimport'`, csvURLs)
+		query := fmt.Sprintf(`IMPORT TABLE t (i INT PRIMARY KEY) CSV DATA (%s) WITH into_db = 'cancelimport'`, csvURLs)
 
 		if _, err := run(t, "cancel", query); !testutils.IsError(err, "job canceled") {
 			t.Fatalf("expected 'job canceled' error, but got %+v", err)

--- a/pkg/ccl/sqlccl/csv.go
+++ b/pkg/ccl/sqlccl/csv.go
@@ -360,6 +360,14 @@ func makeSimpleTableDescriptor(
 	if err != nil {
 		return nil, err
 	}
+	// A hidden column is set if there was no primary key specified in the create
+	// statement. We require primary keys to be specified so that the sampling
+	// phase and read phase of distributed import produce the same data.
+	for _, col := range tableDesc.Columns {
+		if col.Hidden {
+			return nil, errors.New("must specify primary key")
+		}
+	}
 
 	return &tableDesc, nil
 }

--- a/pkg/ccl/sqlccl/csv_internal_test.go
+++ b/pkg/ccl/sqlccl/csv_internal_test.go
@@ -47,6 +47,10 @@ func TestMakeSimpleTableDescriptorErrors(t *testing.T) {
 			error: `foreign keys not supported: CONSTRAINT a FOREIGN KEY \(i\) REFERENCES c \(id\)`,
 		},
 		{
+			stmt:  "create table a (i int)",
+			error: "must specify primary key",
+		},
+		{
 			stmt: `create table a (
 				i int check (i > 0),
 				b int default 1,

--- a/pkg/ccl/sqlccl/csv_test.go
+++ b/pkg/ccl/sqlccl/csv_test.go
@@ -140,15 +140,16 @@ func TestLoadCSVUniqueDuplicate(t *testing.T) {
 		csvName     = tableName + ".dat"
 		tableCreate = `
 			CREATE TABLE ` + tableName + ` (
+				a int primary key,
 				i int,
 				unique index idx_f (i)
 			)
 		`
-		tableCSV = `1
-2
-3
-3
-4
+		tableCSV = `1,1
+2,2
+3,3
+4,3
+5,4
 `
 	)
 
@@ -301,28 +302,29 @@ func TestLoadCSVOptions(t *testing.T) {
 		csvName     = tableName + ".dat"
 		tableCreate = `
 			CREATE TABLE ` + tableName + ` (
+				a int primary key,
 				i int,
 				s string,
 				index (s)
 			)
 		`
-		tableCSV = `1|2
+		tableCSV = `1|1|2
 # second value should be null
-2|N
+2|2|N
 # delimiter at EOL is allowed
-3|blah|
-4|"quoted "" line"
-5|"quoted "" line
+3|3|blah|
+4|4|"quoted "" line"
+5|5|"quoted "" line
 "
-6|"quoted "" line
+6|6|"quoted "" line
 "|
-7|"quoted "" line
+7|7|"quoted "" line
 # with comment
 "
-8|lazy " quotes|
-9|"lazy "quotes"|
-N|N
-10|"|"|
+8|8|lazy " quotes|
+9|9|"lazy "quotes"|
+10|N|N
+11|10|"|"|
 `
 	)
 
@@ -336,7 +338,7 @@ N|N
 		t.Fatal(err)
 	}
 	null := "N"
-	csv, kv, sst, err := LoadCSV(ctx, tablePath, []string{dataPath}, tmp, '|' /* comma */, '#' /* comment */, &null /* nullif */, 500, tmp)
+	csv, kv, sst, err := LoadCSV(ctx, tablePath, []string{dataPath}, tmp, '|' /* comma */, '#' /* comment */, &null /* nullif */, 400, tmp)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -792,7 +794,7 @@ func TestImportStmt(t *testing.T) {
 	t.Run("checkpoint-leftover", func(t *testing.T) {
 		nodetmp := "nodelocal:///tmp"
 		// Specify wrong number of columns.
-		_, err := conn.Exec(fmt.Sprintf(`IMPORT TABLE t (a INT) CSV DATA (%s) WITH transform = $1`, files[0]), nodetmp)
+		_, err := conn.Exec(fmt.Sprintf(`IMPORT TABLE t (a INT PRIMARY KEY) CSV DATA (%s) WITH transform = $1`, files[0]), nodetmp)
 		if !testutils.IsError(err, "expected 1 fields, got 2") {
 			t.Fatalf("unexpected: %v", err)
 		}
@@ -804,7 +806,7 @@ func TestImportStmt(t *testing.T) {
 		}
 
 		// Expect it to succeed with correct columns.
-		sqlDB.Exec(t, fmt.Sprintf(`IMPORT TABLE t (a INT, b STRING) CSV DATA (%s) WITH transform = $1`, files[0]), nodetmp)
+		sqlDB.Exec(t, fmt.Sprintf(`IMPORT TABLE t (a INT PRIMARY KEY, b STRING) CSV DATA (%s) WITH transform = $1`, files[0]), nodetmp)
 	})
 
 	// Verify DEFAULT columns and SERIAL are allowed but not evaluated.


### PR DESCRIPTION
This is needed because the sampling phase of distributed import must
produce identical keys as the read phase. The unique_rowid function
isn't idempotent, so the sampling is incorrect and results in a single
range with all of the data.

Release note (sql change): Require IMPORT CSV tables to specify a
primary key.