### PR TITLE
libroach: use FlushWAL instead of SyncWAL

### DIFF
--- a/c-deps/libroach/db.cc
+++ b/c-deps/libroach/db.cc
@@ -273,7 +273,7 @@ DBStatus DBSyncWAL(DBEngine* db) {
   options.sync = true;
   return ToDBStatus(db->rep->Write(options, &batch));
 #else
-  return ToDBStatus(db->rep->SyncWAL());
+  return ToDBStatus(db->rep->FlushWAL(true /* sync */));
 #endif
 }
 

--- a/c-deps/libroach/options.cc
+++ b/c-deps/libroach/options.cc
@@ -252,6 +252,7 @@ rocksdb::Options DBMakeOptions(DBOptions db_opts) {
   // of sstables.
   options.target_file_size_base = 4 << 20;  // 4 MB
   options.target_file_size_multiplier = 2;
+  options.manual_wal_flush = true;
 
   // Because we open a long running rocksdb instance, we do not want the
   // manifest file to grow unbounded. Assuming each manifest entry is about 1


### PR DESCRIPTION
Tell RocksDB that we will manually flush the wal via the
`manual_wal_flush` option. Replace `SyncWAL()` with `FlushWAL(true)`. We
"sync" approximately half of writes. The effect of this change is to
avoid calling `write(2)` on the writes which we are not syncing.

Fixes #22443

Release note: None