### PR TITLE
cli/flags: recognize fractional values for --cache and --max-sql-memory

### DIFF
--- a/pkg/cli/cliflags/flags.go
+++ b/pkg/cli/cliflags/flags.go
@@ -160,7 +160,7 @@ accept requests.`,
 Maximum memory capacity available to store temporary data for SQL clients,
 including prepared queries and intermediate data rows during query execution.
 Accepts numbers interpreted as bytes, size suffixes (e.g. 1GB and 1GiB) or a
-percentage of physical memory (e.g. 25%).
+percentage of physical memory (e.g. .25).
 If left unspecified, defaults to 128MiB.
 `,
 	}
@@ -195,7 +195,7 @@ when the first store is in-memory.
 Total size in bytes for caches, shared evenly if there are multiple
 storage devices. Size suffixes are supported (e.g. 1GB and 1GiB).
 If left unspecified, defaults to 128MiB. A percentage of physical memory
-can also be specified (e.g. 25%).`,
+can also be specified (e.g. .25).`,
 	}
 
 	ClientHost = FlagInfo{

--- a/pkg/cli/flags_test.go
+++ b/pkg/cli/flags_test.go
@@ -15,6 +15,7 @@
 package cli
 
 import (
+	"context"
 	"flag"
 	"strings"
 	"testing"
@@ -22,6 +23,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/cli/cliflags"
+	"github.com/cockroachdb/cockroach/pkg/server"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/buildutil"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -79,6 +81,7 @@ func TestSQLMemoryPoolFlagValue(t *testing.T) {
 	// Avoid leaking configuration changes after the test ends.
 	defer initCLIDefaults()
 
+	// Check absolute values.
 	f := StartCmd.Flags()
 	args := []string{"--max-sql-memory", "100MB"}
 	if err := f.Parse(args); err != nil {
@@ -88,6 +91,23 @@ func TestSQLMemoryPoolFlagValue(t *testing.T) {
 	const expectedSQLMemSize = 100 * 1000 * 1000
 	if expectedSQLMemSize != serverCfg.SQLMemoryPoolSize {
 		t.Errorf("expected %d, but got %d", expectedSQLMemSize, serverCfg.SQLMemoryPoolSize)
+	}
+
+	args = []string{"--max-sql-memory", ".30"}
+	if err := f.Parse(args); err != nil {
+		t.Fatal(err)
+	}
+
+	// Check fractional values.
+	maxMem, err := server.GetTotalMemory(context.TODO())
+	if err != nil {
+		t.Logf("total memory unknown: %v", err)
+		return
+	}
+	expectedLow := (maxMem * 28) / 100
+	expectedHigh := (maxMem * 32) / 100
+	if serverCfg.SQLMemoryPoolSize < expectedLow || serverCfg.SQLMemoryPoolSize > expectedHigh {
+		t.Errorf("expected %d-%d, but got %d", expectedLow, expectedHigh, serverCfg.SQLMemoryPoolSize)
 	}
 }
 

--- a/pkg/cli/flags_util.go
+++ b/pkg/cli/flags_util.go
@@ -372,13 +372,21 @@ func newBytesOrPercentageValue(
 // Set implements the pflags.Flag interface.
 func (b *bytesOrPercentageValue) Set(s string) error {
 	b.origVal = s
-	if strings.HasSuffix(s, "%") {
-		percent, err := strconv.Atoi(s[:len(s)-1])
+	if strings.HasSuffix(s, "%") || strings.Contains(s, ".") {
+		multiplier := 100.0
+		if s[len(s)-1] == '%' {
+			// We have a percentage.
+			multiplier = 1.0
+			s = s[:len(s)-1]
+		}
+		// The user can express .123 or 0.123. Parse as float.
+		frac, err := strconv.ParseFloat(s, 32)
 		if err != nil {
 			return err
 		}
-		if percent < 0 || percent > 99 {
-			return fmt.Errorf("percentage %s out of range 0%% - 99%%", s)
+		percent := int(frac * multiplier)
+		if percent < 1 || percent > 99 {
+			return fmt.Errorf("percentage %d%% out of range 1%% - 99%%", percent)
 		}
 
 		if b.percentResolver == nil {

--- a/pkg/cli/start.go
+++ b/pkg/cli/start.go
@@ -780,7 +780,7 @@ func maybeWarnMemorySizes(ctx context.Context) {
 		fmt.Fprintf(&buf, "Using the default setting for --cache (%s).\n", cacheSizeValue)
 		fmt.Fprintf(&buf, "  A significantly larger value is usually needed for good performance.\n")
 		if size, err := server.GetTotalMemory(context.Background()); err == nil {
-			fmt.Fprintf(&buf, "  If you have a dedicated server a reasonable setting is --cache=25%% (%s).",
+			fmt.Fprintf(&buf, "  If you have a dedicated server a reasonable setting is --cache=.25 (%s).",
 				humanizeutil.IBytes(size/4))
 		} else {
 			fmt.Fprintf(&buf, "  If you have a dedicated server a reasonable setting is 25%% of physical memory.")
@@ -793,7 +793,7 @@ func maybeWarnMemorySizes(ctx context.Context) {
 		fmt.Fprintf(&buf, "Using the default setting for --max-sql-memory (%s).\n", sqlSizeValue)
 		fmt.Fprintf(&buf, "  A significantly larger value is usually needed in production.\n")
 		if size, err := server.GetTotalMemory(context.Background()); err == nil {
-			fmt.Fprintf(&buf, "  If you have a dedicated server a reasonable setting is --max-sql-memory=25%% (%s).",
+			fmt.Fprintf(&buf, "  If you have a dedicated server a reasonable setting is --max-sql-memory=.25 (%s).",
 				humanizeutil.IBytes(size/4))
 		} else {
 			fmt.Fprintf(&buf, "  If you have a dedicated server a reasonable setting is 25%% of physical memory.")


### PR DESCRIPTION
Fixes #19393.
 
CockroachDB enables users to specify a fraction of total memory with
`--cache` and `--max-sql-memory`. Prior to this patch, only the
notation `NN%` was recognized.

Unfortunately, many system administration tools (incl. systemd,
supervisord) also support string interpolation in configuration
strings, and users get confused about why they need to write `NN%%`
with these tools.

In order to simplify the configuration story, this patch extends the
configuration syntax to also support fractional values, so that users
can use e.g. `--cache=.25` as an alias for `--cache=25%`.

Release note (cli change): the `--cache` and `--max-sql-memory` now
also support decimal notation to support a fraction of total available
RAM size, e.g. `--cache=.25` is equivalent to `--cache=25%`. This
simplifies integration with system management tools.