### PR TITLE
sql: split out EvalSequence from EvalPlanner

### DIFF
--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -1036,7 +1036,7 @@ CockroachDB supports the following flags:
 				if err != nil {
 					return nil, err
 				}
-				res, err := evalCtx.Planner.IncrementSequence(evalCtx.Ctx(), qualifiedName)
+				res, err := evalCtx.Sequence.IncrementSequence(evalCtx.Ctx(), qualifiedName)
 				if err != nil {
 					return nil, err
 				}
@@ -1058,7 +1058,7 @@ CockroachDB supports the following flags:
 				if err != nil {
 					return nil, err
 				}
-				res, err := evalCtx.Planner.GetLatestValueInSessionForSequence(evalCtx.Ctx(), qualifiedName)
+				res, err := evalCtx.Sequence.GetLatestValueInSessionForSequence(evalCtx.Ctx(), qualifiedName)
 				if err != nil {
 					return nil, err
 				}
@@ -1101,7 +1101,7 @@ CockroachDB supports the following flags:
 				}
 
 				newVal := tree.MustBeDInt(args[1])
-				if err := evalCtx.Planner.SetSequenceValue(
+				if err := evalCtx.Sequence.SetSequenceValue(
 					evalCtx.Ctx(), qualifiedName, int64(newVal), true); err != nil {
 					return nil, err
 				}
@@ -1127,7 +1127,7 @@ CockroachDB supports the following flags:
 				isCalled := bool(tree.MustBeDBool(args[2]))
 
 				newVal := tree.MustBeDInt(args[1])
-				if err := evalCtx.Planner.SetSequenceValue(
+				if err := evalCtx.Sequence.SetSequenceValue(
 					evalCtx.Ctx(), qualifiedName, int64(newVal), isCalled); err != nil {
 					return nil, err
 				}

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -2078,6 +2078,13 @@ type EvalPlanner interface {
 	// ParseType parses a column type.
 	ParseType(sql string) (coltypes.CastTargetType, error)
 
+	// EvalSubquery returns the Datum for the given subquery node.
+	EvalSubquery(expr *Subquery) (Datum, error)
+}
+
+// SequenceOperators is used for various sql related functions that can
+// be used from EvalContext.
+type SequenceOperators interface {
 	// IncrementSequence increments the given sequence and returns the result.
 	// It returns an error if the given name is not a sequence.
 	// The caller must ensure that seqName is fully qualified already.
@@ -2092,9 +2099,6 @@ type EvalPlanner interface {
 	// `newVal` is returned. Otherwise, the next call to nextval will return
 	// `newVal + seqOpts.Increment`.
 	SetSequenceValue(ctx context.Context, seqName *TableName, newVal int64, isCalled bool) error
-
-	// EvalSubquery returns the Datum for the given subquery node.
-	EvalSubquery(expr *Subquery) (Datum, error)
 }
 
 // CtxProvider is anything that can return a Context.
@@ -2199,6 +2203,8 @@ type EvalContext struct {
 	CtxProvider CtxProvider
 
 	Planner EvalPlanner
+
+	Sequence SequenceOperators
 
 	// Ths transaction in which the statement is executing.
 	Txn *client.Txn

--- a/pkg/sql/sequence.go
+++ b/pkg/sql/sequence.go
@@ -29,7 +29,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-// IncrementSequence implements the tree.EvalPlanner interface.
+// IncrementSequence implements the tree.SequenceOperators interface.
 func (p *planner) IncrementSequence(ctx context.Context, seqName *tree.TableName) (int64, error) {
 	if p.EvalContext().TxnReadOnly {
 		return 0, readOnlyError("nextval()")
@@ -83,7 +83,7 @@ func boundsExceededError(descriptor *sqlbase.TableDescriptor) error {
 		`reached %s value of sequence "%s" (%d)`, word, descriptor.Name, value)
 }
 
-// GetLatestValueInSessionForSequence implements the tree.EvalPlanner interface.
+// GetLatestValueInSessionForSequence implements the tree.SequenceOperators interface.
 func (p *planner) GetLatestValueInSessionForSequence(
 	ctx context.Context, seqName *tree.TableName,
 ) (int64, error) {
@@ -102,7 +102,7 @@ func (p *planner) GetLatestValueInSessionForSequence(
 	return val, nil
 }
 
-// SetSequenceValue implements the tree.EvalPlanner interface.
+// SetSequenceValue implements the tree.SequenceOperators interface.
 func (p *planner) SetSequenceValue(
 	ctx context.Context, seqName *tree.TableName, newVal int64, isCalled bool,
 ) error {

--- a/pkg/sql/session.go
+++ b/pkg/sql/session.go
@@ -573,6 +573,7 @@ func (s *Session) resetPlanner(
 
 	p.extendedEvalCtx = s.extendedEvalCtx(txn, txnTimestamp, stmtTimestamp)
 	p.extendedEvalCtx.Planner = p
+	p.extendedEvalCtx.Sequence = p
 	p.extendedEvalCtx.ClusterID = s.execCfg.ClusterID()
 	p.extendedEvalCtx.NodeID = s.execCfg.NodeID.Get()
 	p.extendedEvalCtx.ReCache = reCache


### PR DESCRIPTION
Release note: None

I think someone can just rubber stamp this