### PR TITLE
build: make TeamCity build logs more readable

### DIFF
--- a/build/teamcity-acceptance.sh
+++ b/build/teamcity-acceptance.sh
@@ -1,30 +1,33 @@
 #!/usr/bin/env bash
 
-set -euxo pipefail
-
-export BUILDER_HIDE_GOPATH_SRC=1
+set -euo pipefail
 
 source "$(dirname "${0}")/teamcity-support.sh"
-maybe_ccache
 
-"$(dirname "${0}")"/../pkg/acceptance/prepare.sh
+tc_prepare
 
+tc_start_block "Prepare environment for acceptance tests"
 # The log files that should be created by -l below can only
 # be created if the parent directory already exists. Ensure
 # that it exists before running the test.
-mkdir -p artifacts/acceptance
 export TMPDIR=$PWD/artifacts/acceptance
+mkdir -p "$TMPDIR"
+type=release-$(go env GOOS)
+if [[ "$type" = *-linux ]]; then
+  type+=-gnu
+fi
+tc_end_block "Prepare environment for acceptance tests"
 
-TYPE=release-$(go env GOOS)
-case $TYPE in
-  *-linux)
-    TYPE+=-gnu
-    ;;
-esac
+tc_start_block "Compile CockroachDB"
+run pkg/acceptance/prepare.sh
+run ln -s cockroach-linux-2.6.32-gnu-amd64 cockroach  # For the tests that run without Docker.
+tc_end_block "Compile CockroachDB"
 
-# For the acceptance tests that run without Docker.
-ln -s cockroach-linux-2.6.32-gnu-amd64 cockroach
+tc_start_block "Compile acceptance tests"
+run build/builder.sh make -Otarget TYPE="$type" testbuild TAGS=acceptance PKG=./pkg/acceptance
+tc_end_block "Compile acceptance tests"
 
-build/builder.sh make TYPE=$TYPE testbuild TAGS=acceptance PKG=./pkg/acceptance
-cd pkg/acceptance
-./acceptance.test -nodes 4 -l "$TMPDIR" -test.v -test.timeout 20m 2>&1 | tee "$TMPDIR/acceptance.log" | go-test-teamcity
+tc_start_block "Run acceptance tests"
+run cd pkg/acceptance
+run ./acceptance.test -nodes 4 -l "$TMPDIR" -test.v -test.timeout 20m 2>&1 | tee "$TMPDIR/acceptance.log" | go-test-teamcity
+tc_end_block "Run acceptance tests"

--- a/build/teamcity-assert-clean.sh
+++ b/build/teamcity-assert-clean.sh
@@ -1,13 +1,15 @@
 #!/usr/bin/env bash
-set -exuo pipefail
 
-export BUILDER_HIDE_GOPATH_SRC=1
+set -euo pipefail
+
+source "$(dirname "${0}")/teamcity-support.sh"
 
 # The workspace is clean iff `git status --porcelain` produces no output. Any
 # output is either an error message or a listing of an untracked/dirty file.
 if [[ "$(git status --porcelain 2>&1)" != "" ]]; then
   git status >&2 || true
   git diff -a >&2 || true
-  docker run --volume="$(cd "$(dirname "$0")/.." && pwd):/nuke" --workdir="/nuke" golang:stretch git clean -fdx >&2
+  echo "Nuking build cruft. Please teach this build to clean up after itself." >&2
+  run docker run --volume="$root:/nuke" --workdir="/nuke" golang:stretch git clean -fdx >&2
   exit 1
 fi

--- a/build/teamcity-build-test-binary.sh
+++ b/build/teamcity-build-test-binary.sh
@@ -3,13 +3,15 @@
 # This file builds a cockroach binary that's used by integration tests external
 # to this repository.
 
-set -euxo pipefail
+set -euo pipefail
 
 source "$(dirname "${0}")/teamcity-support.sh"
-maybe_ccache
 
+tc_prepare
+
+tc_start_block "Build test binary"
 # We don't want to build a proper release binary here, because we don't want
 # this binary to operate in release mode and e.g. report errors.
-build/builder.sh make build TYPE=portable
-mkdir -p artifacts
-mv cockroach artifacts/
+run build/builder.sh make build -Otarget TYPE=portable
+run mv cockroach artifacts/
+tc_end_block "Build test binary"

--- a/build/teamcity-check.sh
+++ b/build/teamcity-check.sh
@@ -1,28 +1,18 @@
 #!/usr/bin/env bash
-set -exuo pipefail
 
-export BUILDER_HIDE_GOPATH_SRC=1
+set -euo pipefail
 
 source "$(dirname "${0}")/teamcity-support.sh"
-maybe_ccache
 
-mkdir -p artifacts
+tc_prepare
 
-build/builder.sh go install ./vendor/github.com/golang/dep/cmd/dep ./pkg/cmd/github-pull-request-make
+tc_start_block "Ensure dependencies are up-to-date"
+run build/builder.sh go install ./vendor/github.com/golang/dep/cmd/dep ./pkg/cmd/github-pull-request-make
+run build/builder.sh env BUILD_VCS_NUMBER="$BUILD_VCS_NUMBER" TARGET=checkdeps github-pull-request-make
+tc_end_block "Ensure dependencies are up-to-date"
 
-# Run checkdeps.
-build/builder.sh env \
-	BUILD_VCS_NUMBER="$BUILD_VCS_NUMBER" \
-	TARGET=checkdeps \
-	github-pull-request-make
-
-build/builder.sh make lint 2>&1 | tee artifacts/lint.log | go-test-teamcity
-
-# Generation of docs requires Railroad.jar to avoid excessive API requests.
-curl https://edge-binaries.cockroachdb.com/tools/Railroad.jar.enc | openssl aes-256-cbc -d -out build/Railroad.jar -k "$RAILROAD_JAR_KEY"
-
-build/builder.sh make generate
-
+tc_start_block "Ensure generated code is up-to-date"
+run build/builder.sh make generate
 # The workspace is clean iff `git status --porcelain` produces no output. Any
 # output is either an error message or a listing of an untracked/dirty file.
 if [[ "$(git status --porcelain 2>&1)" != "" ]]; then
@@ -30,8 +20,15 @@ if [[ "$(git status --porcelain 2>&1)" != "" ]]; then
   git diff -a >&2 || true
   exit 1
 fi
+tc_end_block "Ensure generated code is up-to-date"
 
+tc_start_block "Lint"
+run build/builder.sh make lint 2>&1 | tee artifacts/lint.log | go-test-teamcity
+tc_end_block "Lint"
+
+tc_start_block "Test web UI"
 # Run the UI tests. This logically belongs in teamcity-test.sh, but we do it
-# here to minimize total build time since the rest of this script completes
-# faster than the non-UI tests.
-build/builder.sh make -C pkg/ui
+# here to minimize total build time since this build has already generated the
+# UI.
+run build/builder.sh make -C pkg/ui
+tc_end_block "Test web UI"

--- a/build/teamcity-support.sh
+++ b/build/teamcity-support.sh
@@ -1,10 +1,50 @@
 # Common helpers for teamcity-*.sh scripts.
 
-# maybe_ccache turns on ccache to speed up compilation, but only for PR builds
-# (i.e., not builds on master or release branches). This speeds up the CI cycle
-# for developers while preventing ccache from corrupting a release build.
+# root is the absolute path to the root directory of the repository.
+root=$(cd "$(dirname "$0")/.." && pwd)
+
+# maybe_ccache turns on ccache to speed up compilation, but only for PR builds.
+# This speeds up the CI cycle for developers while preventing ccache from
+# corrupting a release build.
 maybe_ccache() {
-  if [[ "$TC_BUILD_BRANCH" != master && "$TC_BUILD_BRANCH" != release-* ]]; then
-    export COCKROACH_BUILDER_CCACHE=1
+  if tc_release_branch; then
+    echo "On release branch ($TC_BUILD_BRANCH), so not enabling ccache."
+  else
+    echo "Building PR (#$TC_BUILD_BRANCH), so enabling ccache."
+    run export COCKROACH_BUILDER_CCACHE=1
   fi
+}
+
+run() {
+  echo "$@"
+  "$@"
+}
+
+changed_go_pkgs() {
+  git fetch --quiet origin master
+  # Find changed packages, minus those that have been removed entirely.
+  git diff --name-only origin/master... -- "pkg/**/*.go" \
+    | xargs -rn1 dirname \
+    | sort -u \
+    | { while read path; do ls "$path"/*.go &>/dev/null && echo -n "./$path "; done; }
+}
+
+tc_release_branch() {
+  [[ "$TC_BUILD_BRANCH" == master || "$TC_BUILD_BRANCH" == release-* ]]
+}
+
+tc_start_block() {
+  echo "##teamcity[blockOpened name='$1']"
+}
+
+tc_end_block() {
+  echo "##teamcity[blockClosed name='$1']"
+}
+
+tc_prepare() {
+  tc_start_block "Prepare environment"
+  run export BUILDER_HIDE_GOPATH_SRC=1
+  run mkdir -p artifacts
+  maybe_ccache
+  tc_end_block "Prepare environment"
 }

--- a/build/teamcity-test.sh
+++ b/build/teamcity-test.sh
@@ -1,26 +1,26 @@
 #!/usr/bin/env bash
-set -euxo pipefail
 
-export BUILDER_HIDE_GOPATH_SRC=1
+set -euo pipefail
 
 source "$(dirname "${0}")/teamcity-support.sh"
-maybe_ccache
 
-mkdir -p artifacts
+tc_prepare
 
-build/builder.sh go install ./pkg/cmd/github-pull-request-make
+tc_start_block "Maybe stress pull request"
+run build/builder.sh go install ./pkg/cmd/github-pull-request-make
+run build/builder.sh env BUILD_VCS_NUMBER="$BUILD_VCS_NUMBER" TARGET=stress github-pull-request-make
+tc_end_block "Maybe stress pull request"
 
-build/builder.sh env \
-	BUILD_VCS_NUMBER="$BUILD_VCS_NUMBER" \
-	TARGET=stress \
-	github-pull-request-make
+tc_start_block "Compile"
+run build/builder.sh make -Otarget gotestdashi
+tc_end_block "Compile"
 
-build/builder.sh env \
-	TZ=America/New_York \
-	make test \
-	TESTFLAGS='-v' \
-	2>&1 \
+tc_start_block "Run Go tests"
+run build/builder.sh env TZ=America/New_York make test TESTFLAGS='-v' 2>&1 \
 	| tee artifacts/test.log \
 	| go-test-teamcity
+tc_end_block "Run Go tests"
 
-build/builder.sh make check-libroach
+tc_start_block "Run C++ tests"
+run build/builder.sh make check-libroach
+tc_end_block "Run C++ tests"

--- a/build/teamcity-testrace.sh
+++ b/build/teamcity-testrace.sh
@@ -1,39 +1,36 @@
 #!/usr/bin/env bash
-set -euxo pipefail
 
-export BUILDER_HIDE_GOPATH_SRC=1
+set -euo pipefail
 
 source "$(dirname "${0}")/teamcity-support.sh"
-maybe_ccache
 
-mkdir -p artifacts
+tc_prepare
 
+tc_start_block "Maybe stressrace pull request"
 build/builder.sh go install ./pkg/cmd/github-pull-request-make
+build/builder.sh env BUILD_VCS_NUMBER="$BUILD_VCS_NUMBER" TARGET=stressrace github-pull-request-make
+tc_end_block "Maybe stressrace pull request"
 
-build/builder.sh env \
-	BUILD_VCS_NUMBER="$BUILD_VCS_NUMBER" \
-	TARGET=stressrace \
-	github-pull-request-make
-
-if [[ "${TC_BUILD_BRANCH}" == master ]] || [[ "${TC_BUILD_BRANCH}" == release* ]] ; then
-	PKGSPEC="./pkg/..."
+tc_start_block "Determine changed packages"
+if tc_release_branch; then
+	pkgspec=./pkg/...
+  echo "On release branch ($TC_BUILD_BRANCH), so running testrace on all packages ($pkgspec)"
 else
-	git fetch origin master
-	PKGSPEC=$(git diff --name-only origin/master... | grep "^pkg.*\.go$" || true)
-	if [ -z "${PKGSPEC}" ]; then
-		echo "No changed packages; skipping race detector tests"
+  pkgspec=$(changed_go_pkgs)
+	if [[ -z "$pkgspec" ]]; then
+		echo "PR #$TC_BUILD_BRANCH has no changed packages; skipping race detector tests"
 		exit 0
 	fi
-	# Only keep the pathspecs for which there are go files remaining.
-	PKGSPEC=$(echo "${PKGSPEC}" | xargs -n1 dirname | sort | uniq | sed 's/^/.\//' | { while read path; do if ls "$path"/*.go >/dev/null 2>&1; then echo "$path"; fi; done; } | paste -sd " " -)
-	echo "Running testrace on packages ${PKGSPEC}"
+	echo "PR #$TC_BUILD_BRANCH has changed packages; running race detector tests on $pkgspec"
 fi
+tc_end_block "Determine changed packages"
 
-build/builder.sh env \
-	COCKROACH_LOGIC_TESTS_SKIP=true \
-	make testrace \
-	PKG="${PKGSPEC}" \
-	TESTFLAGS='-v' \
-	2>&1 \
+tc_start_block "Compile"
+run build/builder.sh make -Otarget gotestdashi GOFLAGS=-race
+tc_end_block "Compile"
+
+tc_start_block "Run Go tests under race detector"
+run build/builder.sh env COCKROACH_LOGIC_TESTS_SKIP=true make testrace PKG="$pkgspec" TESTFLAGS='-v' 2>&1 \
 	| tee artifacts/testrace.log \
 	| go-test-teamcity
+tc_end_block "Run Go tests under race detector"

--- a/build/teamcity-verify-archive.sh
+++ b/build/teamcity-verify-archive.sh
@@ -2,28 +2,38 @@
 
 set -euo pipefail
 
+source "$(dirname "${0}")/teamcity-support.sh"
+
+tc_start_block "Check build tag"
 # Regression test for #14284, where builds were erroneously marked as dirty when
 # build/variables.mk was out of date due to a race condition in Git.
-touch -m -t 197001010000 build/variables.mk
-build/builder.sh make .buildinfo/tag
+run touch -m -t 197001010000 build/variables.mk
+run build/builder.sh make .buildinfo/tag
 if grep -F --quiet -- dirty .buildinfo/tag; then
   echo "error: build tag recorded as dirty: $(<.buildinfo/tag)" >&2
   exit 1
 fi
+tc_end_block "Check build tag"
 
-build/builder.sh make archive ARCHIVE=build/cockroach.src.tgz
+tc_start_block "Build archive"
+run build/builder.sh make archive -Otarget ARCHIVE=build/cockroach.src.tgz
+tc_end_block "Build archive"
 
+tc_start_block "Test archive"
 # We use test the source archive in a minimal image; the builder image bundles
 # too much developer configuration to simulate a build on a fresh user machine.
 #
 # NB: This docker container runs as root. Be sure to mount any bind volumes as
 # read-only to avoid creating root-owned directories and files on the host
 # machine.
-docker run \
+run docker run \
   --rm \
   --volume="$(cd "$(dirname "$0")" && pwd):/work:ro" \
   --workdir="/work" \
   golang:stretch ./verify-archive.sh
+tc_end_block "Test archive"
 
+tc_start_block "Clean up"
 # Clean up the archive we produced.
-build/builder.sh rm build/cockroach.src.tgz
+run build/builder.sh rm build/cockroach.src.tgz
+tc_end_block "Clean up"


### PR DESCRIPTION
Tap into TeamCity's support for declaring collapsible build log blocks.

Release note: None