### PR TITLE
sql: block inserts/updates into computed columns

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/computed
+++ b/pkg/sql/logictest/testdata/logic_test/computed
@@ -36,14 +36,36 @@ extra_parens CREATE TABLE extra_parens (
 
 
 statement error cannot write directly to computed column "c"
+INSERT INTO with_no_column_refs VALUES (1, 2, 3)
+
+statement error cannot write directly to computed column "c"
+INSERT INTO with_no_column_refs (SELECT 1, 2, 3)
+
+statement error cannot write directly to computed column "c"
+INSERT INTO with_no_column_refs (a, c) (SELECT 1, 3)
+
+statement error cannot write directly to computed column "c"
 INSERT INTO with_no_column_refs (c) VALUES (1)
 
 statement ok
 INSERT INTO with_no_column_refs (a, b) VALUES (1, 2)
 
+statement ok
+INSERT INTO with_no_column_refs VALUES (1, 2)
+
+statement error cannot write directly to computed column "c"
+UPDATE with_no_column_refs SET c = 1
+
+statement error cannot write directly to computed column "c"
+UPDATE with_no_column_refs SET (a, b, c) = (1, 2, 3)
+
+statement error cannot write directly to computed column "c"
+UPDATE with_no_column_refs SET (a, b, c) = (SELECT 1, 2, 3)
+
 query I
 SELECT c FROM with_no_column_refs
 ----
+3
 3
 
 statement ok
@@ -79,31 +101,8 @@ SELECT c, d FROM x
 statement ok
 DELETE FROM x
 
-# Ensure that defaults are handled properly.
-statement ok
-INSERT INTO x VALUES (DEFAULT)
-
-query I
-SELECT c FROM x
-----
-3
-
-query I
-SELECT d FROM x
-----
-10
-
 statement ok
 DELETE FROM x
-
-# We can use DEFAULT as a placeholder for computed columns
-statement ok
-INSERT INTO x VALUES (1, 2, DEFAULT, DEFAULT)
-
-query II
-SELECT c, d FROM x
-----
-1 3
 
 statement ok
 DROP TABLE x
@@ -169,26 +168,27 @@ UPDATE x SET (b, c) = (1, DEFAULT)
 statement ok
 DROP TABLE x
 
-statement ok
-CREATE TABLE x (
-  b INT AS (a) STORED,
-  a INT
-)
-
-statement ok
-INSERT INTO x VALUES (DEFAULT, 1)
-
-statement ok
-INSERT INTO x VALUES (DEFAULT, '2')
-
-query I
-SELECT b FROM x ORDER BY b
-----
-1
-2
-
-statement ok
-DROP TABLE x
+# TODO(justin): #22434
+# statement ok
+# CREATE TABLE x (
+#   b INT AS a STORED,
+#   a INT
+# )
+#
+# statement ok
+# INSERT INTO x VALUES (DEFAULT, 1)
+#
+# statement ok
+# INSERT INTO x VALUES (DEFAULT, '2')
+#
+# query I
+# SELECT b FROM x ORDER BY b
+# ----
+# 1
+# 2
+#
+# statement ok
+# DROP TABLE x
 
 statement error use AS \( <expr> \) STORED
 CREATE TABLE y (

--- a/pkg/sql/update.go
+++ b/pkg/sql/update.go
@@ -111,6 +111,13 @@ func (p *planner) Update(
 		return nil, err
 	}
 
+	// TODO(justin): this is incorrect: we should allow this, but then it should
+	// error unless we both have a VALUES clause and every value being "inserted"
+	// into a computed column is DEFAULT. See #22434.
+	if err := checkHasNoComputedCols(updateCols); err != nil {
+		return nil, err
+	}
+
 	// We update the set of columns being updated into with any computed columns.
 	updateCols, computedCols, computeExprs, err :=
 		ProcessComputedColumns(ctx, updateCols, tn, en.tableDesc, &p.txCtx, p.EvalContext())


### PR DESCRIPTION
Fixes #22410.

The previous implementation I had of this was incorrect - I think the
correct implementation is a bit involved so I'm putting out a fix for
the immediate issue and I've opened #22434 to track the correct fix.

Release note (bug fix): Disallowed any inserts into computed columns.