### PR TITLE
distsql: fix node selection for desc limit scans

### DIFF
--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -813,11 +813,11 @@ func (dsp *DistSQLPlanner) getNodeIDForScan(
 
 	// Determine the node ID for the first range to be scanned.
 	it := planCtx.spanIter
-	scanDirection := kv.Ascending
 	if reverse {
-		scanDirection = kv.Descending
+		it.Seek(planCtx.ctx, spans[len(spans)-1], kv.Descending)
+	} else {
+		it.Seek(planCtx.ctx, spans[0], kv.Ascending)
 	}
-	it.Seek(planCtx.ctx, spans[0], scanDirection)
 	if !it.Valid() {
 		return 0, it.Error()
 	}

--- a/pkg/sql/logictest/testdata/logic_test/distsql_numtables
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_numtables
@@ -227,8 +227,9 @@ SELECT "URL" FROM [EXPLAIN (DISTSQL) SELECT y FROM NumToStr ORDER BY y LIMIT 5]
 ----
 https://cockroachdb.github.io/distsqlplan/decode.html?eJyMjzFrAzEMhff-ivBmD7mhi6esgdKU0K14cM8iGO6sQ5KhJfi_l7OH0qGQ8b0nfU-6o3Ci17iSwn9gQnDYhGdSZdmtMXBOX_BHh1y2arsdHGYWgr_Dsi0Ej_f4udCVYiKBQyKLeenQTfIa5ftU6mqstqeXav5wmuDwktdsh2eE5sDVfvFq8UbwU3OPn3Al3bgo_en_j3xswYHSjcabylVmehOee82Ql77XjURqI52GOJcRtdCefgIAAP__lz9sqw==
 
+# Test that the correct node is chosen in a reverse scan with multiple spans.
 query T
-SELECT "URL" FROM [EXPLAIN (DISTSQL) SELECT y FROM NumToStr ORDER BY y DESC LIMIT 5]
+SELECT "URL" FROM [EXPLAIN (DISTSQL) SELECT y FROM NumToStr WHERE y < 1000 OR y > 9000 ORDER BY y DESC LIMIT 5]
 ----
 https://cockroachdb.github.io/distsqlplan/decode.html?eJyMkLFqMzEQhPv_KczU-uHO4EaVW0Owg0kXrlBOixHcaYV2BQnm3j3oVMQOxEm5O_uNZnRFZE9HN5PAvqKHwQ6DQco8kgjnum5HB_8O2xmEmIrW9WAwcibYKzToRLA48n9OMPCkLkzr0WLARb8QUXch2O1ibmz7x7Yv7m2iMzlP-c4cKYfZ5Y99LLOyaFVPRe1mX4s8hTnoZoefIvR3EX5pdiZJHIX-VK5bBgPyF2q_J1zySM-Zx_WZNp5Wbl14Em3qtg2H2KQa8BbuH8LdN3hY_n0GAAD__0cMnlY=
 
@@ -242,7 +243,7 @@ SELECT y FROM NumToStr ORDER BY y LIMIT 5
 5
 
 query I
-SELECT y FROM NumToStr ORDER BY y DESC LIMIT 5
+SELECT y FROM NumToStr WHERE y < 1000 OR y > 9000 ORDER BY y DESC LIMIT 5
 ----
 10000
 9999


### PR DESCRIPTION
getNodeIDForScan was not properly handling reverse scans with multiple
spans. In this case we should look at the last span, not the first.

Release note: None