### PR TITLE
ts: Use Live Node Count in Estimates

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -354,7 +354,10 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 	s.registry.AddMetricStruct(s.adminMemMetrics)
 
 	s.tsDB = ts.NewDB(s.db, s.cfg.Settings)
-	s.tsServer = ts.MakeServer(s.cfg.AmbientCtx, s.tsDB, s.cfg.TimeSeriesServerConfig, s.stopper)
+	nodeCountFn := func() int64 {
+		return s.nodeLiveness.Metrics().LiveNodes.Value()
+	}
+	s.tsServer = ts.MakeServer(s.cfg.AmbientCtx, s.tsDB, nodeCountFn, s.cfg.TimeSeriesServerConfig, s.stopper)
 
 	// The InternalExecutor will be further initialized later, as we create more
 	// of the server's components. There's a circular dependency - many things

--- a/pkg/ts/server.go
+++ b/pkg/ts/server.go
@@ -44,6 +44,10 @@ const (
 	queryMemoryMax = int64(64 * 1024 * 1024) // 64MiB
 )
 
+// ClusterNodeCountFn is a function that returns the number of nodes active on
+// the cluster.
+type ClusterNodeCountFn func() int64
+
 // ServerConfig provides a means for tests to override settings in the time
 // series server.
 type ServerConfig struct {
@@ -83,6 +87,7 @@ type Server struct {
 	log.AmbientContext
 	db               *DB
 	stopper          *stop.Stopper
+	nodeCountFn      ClusterNodeCountFn
 	queryMemoryMax   int64
 	queryWorkerMax   int
 	workerMemMonitor mon.BytesMonitor
@@ -93,7 +98,11 @@ type Server struct {
 // MakeServer instantiates a new Server which services requests with data from
 // the supplied DB.
 func MakeServer(
-	ambient log.AmbientContext, db *DB, cfg ServerConfig, stopper *stop.Stopper,
+	ambient log.AmbientContext,
+	db *DB,
+	nodeCountFn ClusterNodeCountFn,
+	cfg ServerConfig,
+	stopper *stop.Stopper,
 ) Server {
 	ambient.AddLogTag("ts-srv", nil)
 
@@ -111,6 +120,7 @@ func MakeServer(
 		AmbientContext: ambient,
 		db:             db,
 		stopper:        stopper,
+		nodeCountFn:    nodeCountFn,
 		workerMemMonitor: mon.MakeUnlimitedMonitor(
 			context.Background(),
 			"timeseries-workers",
@@ -170,9 +180,13 @@ func (s *Server) Query(
 	// be interpolated).
 	interpolationLimit := storage.TimeUntilStoreDead.Get(&s.db.st.SV).Nanoseconds()
 
-	// TODO(mrtracy): This number should be computed from node livenesses, which
-	// will yield more accurate estimates.
-	estimatedClusterNodeCount := int64(6)
+	// Get the estimated number of nodes on the cluster, used to compute more
+	// accurate memory usage estimates. Set a minimum of 1 in order to avoid
+	// divide-by-zero panics.
+	estimatedClusterNodeCount := s.nodeCountFn()
+	if estimatedClusterNodeCount == 0 {
+		estimatedClusterNodeCount = 1
+	}
 
 	response := tspb.TimeSeriesQueryResponse{
 		Results: make([]tspb.TimeSeriesQueryResponse_Result, len(request.Queries)),


### PR DESCRIPTION
Time series server now uses a real estimate of the number of live nodes
when computing memory budgets for queries; previously, a constant value
was used.

The estimate is taken directly from the node livenesses LiveNodes
metric.

Release note: None