### PR TITLE
opt: replace projections column set with a list

### DIFF
--- a/pkg/sql/opt/build/builder.go
+++ b/pkg/sql/opt/build/builder.go
@@ -1065,7 +1065,13 @@ func (b *Builder) synthesizeColumn(scope *scope, label string, typ types.T) *col
 }
 
 func (b *Builder) constructProjectionList(items []opt.GroupID, cols []columnProps) opt.GroupID {
-	return b.factory.ConstructProjections(b.factory.InternList(items), b.factory.InternPrivate(makeColSet(cols)))
+	var colList opt.ColList
+	for i := range cols {
+		colList.Set(i, int(cols[i].index))
+	}
+	return b.factory.ConstructProjections(
+		b.factory.InternList(items), b.factory.InternPrivate(&colList),
+	)
 }
 
 // Builder implements the IndexedVarContainer interface so it can be
@@ -1093,15 +1099,6 @@ func (b *Builder) IndexedVarNodeFormatter(idx int) tree.NodeFormatter {
 func isAggregate(def *tree.FunctionDefinition) bool {
 	_, ok := builtins.Aggregates[strings.ToLower(def.Name)]
 	return ok
-}
-
-func makeColSet(cols []columnProps) *opt.ColSet {
-	// Create column index list parameter to the ProjectionList op.
-	var colSet opt.ColSet
-	for i := range cols {
-		colSet.Add(int(cols[i].index))
-	}
-	return &colSet
 }
 
 func groupingError(colName string) error {

--- a/pkg/sql/opt/build/testdata/aggregate
+++ b/pkg/sql/opt/build/testdata/aggregate
@@ -112,7 +112,7 @@ build
 SELECT COUNT(*), k FROM t.kv GROUP BY k
 ----
 project
- ├── columns: kv.k:int:null:1 column5:int:null:5
+ ├── columns: column5:int:null:5 kv.k:int:null:1
  ├── group-by
  │    ├── columns: kv.k:int:null:1 column5:int:null:5
  │    ├── scan
@@ -130,7 +130,7 @@ build
 SELECT COUNT(*), k FROM t.kv GROUP BY 2
 ----
 project
- ├── columns: kv.k:int:null:1 column5:int:null:5
+ ├── columns: column5:int:null:5 kv.k:int:null:1
  ├── group-by
  │    ├── columns: kv.k:int:null:1 column5:int:null:5
  │    ├── scan
@@ -163,7 +163,7 @@ build
 SELECT COUNT(*), kv.s FROM t.kv GROUP BY s
 ----
 project
- ├── columns: kv.s:string:null:4 column5:int:null:5
+ ├── columns: column5:int:null:5 kv.s:string:null:4
  ├── group-by
  │    ├── columns: kv.s:string:null:4 column5:int:null:5
  │    ├── scan
@@ -180,7 +180,7 @@ build
 SELECT COUNT(*), s FROM t.kv GROUP BY kv.s
 ----
 project
- ├── columns: kv.s:string:null:4 column5:int:null:5
+ ├── columns: column5:int:null:5 kv.s:string:null:4
  ├── group-by
  │    ├── columns: kv.s:string:null:4 column5:int:null:5
  │    ├── scan
@@ -197,7 +197,7 @@ build
 SELECT COUNT(*), kv.s FROM t.kv GROUP BY kv.s
 ----
 project
- ├── columns: kv.s:string:null:4 column5:int:null:5
+ ├── columns: column5:int:null:5 kv.s:string:null:4
  ├── group-by
  │    ├── columns: kv.s:string:null:4 column5:int:null:5
  │    ├── scan
@@ -214,7 +214,7 @@ build
 SELECT COUNT(*), s FROM t.kv GROUP BY s
 ----
 project
- ├── columns: kv.s:string:null:4 column5:int:null:5
+ ├── columns: column5:int:null:5 kv.s:string:null:4
  ├── group-by
  │    ├── columns: kv.s:string:null:4 column5:int:null:5
  │    ├── scan
@@ -232,7 +232,7 @@ build
 SELECT v, COUNT(*), w FROM t.kv GROUP BY v, w
 ----
 project
- ├── columns: kv.v:int:null:2 kv.w:int:null:3 column5:int:null:5
+ ├── columns: kv.v:int:null:2 column5:int:null:5 kv.w:int:null:3
  ├── group-by
  │    ├── columns: kv.v:int:null:2 kv.w:int:null:3 column5:int:null:5
  │    ├── scan
@@ -252,7 +252,7 @@ build
 SELECT v, COUNT(*), w FROM t.kv GROUP BY 1, 3
 ----
 project
- ├── columns: kv.v:int:null:2 kv.w:int:null:3 column5:int:null:5
+ ├── columns: kv.v:int:null:2 column5:int:null:5 kv.w:int:null:3
  ├── group-by
  │    ├── columns: kv.v:int:null:2 kv.w:int:null:3 column5:int:null:5
  │    ├── scan
@@ -272,7 +272,7 @@ build
 SELECT COUNT(*), UPPER(s) FROM t.kv GROUP BY UPPER(s)
 ----
 project
- ├── columns: column5:string:null:5 column6:int:null:6
+ ├── columns: column6:int:null:6 column5:string:null:5
  ├── group-by
  │    ├── columns: column5:string:null:5 column6:int:null:6
  │    ├── scan
@@ -350,7 +350,7 @@ build
 SELECT COUNT(*), k+v FROM t.kv GROUP BY k+v
 ----
 project
- ├── columns: column5:int:null:5 column6:int:null:6
+ ├── columns: column6:int:null:6 column5:int:null:5
  ├── group-by
  │    ├── columns: column5:int:null:5 column6:int:null:6
  │    ├── scan
@@ -417,7 +417,7 @@ build
 SELECT count(kv.k) AS count_1, kv.v + kv.w AS lx FROM t.kv GROUP BY kv.v + kv.w
 ----
 project
- ├── columns: column5:int:null:5 count_1:int:null:6
+ ├── columns: count_1:int:null:6 column5:int:null:5
  ├── group-by
  │    ├── columns: column5:int:null:5 count_1:int:null:6
  │    ├── scan

--- a/pkg/sql/opt/build/testdata/aggregate
+++ b/pkg/sql/opt/build/testdata/aggregate
@@ -21,8 +21,8 @@ group-by
  ├── columns: column5:int:null:5 column6:int:null:6 column7:int:null:7 column8:int:null:8 column9:decimal:null:9 column10:decimal:null:10 column11:decimal:null:11 column12:decimal:null:12 column13:bool:null:13 column14:bool:null:14 column15:bytes:null:15
  ├── scan
  │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
- ├── projections [type=tuple{}]
- └── projections [type=tuple{NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL}]
+ ├── projections
+ └── projections
       ├── function: min [type=NULL]
       │    └── const: 1 [type=int]
       ├── function: max [type=NULL]
@@ -53,8 +53,8 @@ group-by
  ├── columns: column5:int[]:null:5
  ├── scan
  │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
- ├── projections [type=tuple{}]
- └── projections [type=tuple{NULL}]
+ ├── projections
+ └── projections
       └── function: array_agg [type=NULL]
            └── const: 1 [type=int]
 
@@ -65,8 +65,8 @@ group-by
  ├── columns: column5:jsonb:null:5
  ├── scan
  │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
- ├── projections [type=tuple{}]
- └── projections [type=tuple{NULL}]
+ ├── projections
+ └── projections
       └── function: json_agg [type=NULL]
            └── variable: kv.v [type=int]
 
@@ -77,8 +77,8 @@ group-by
  ├── columns: column1:jsonb:null:1
  ├── values
  │    └── tuple [type=tuple{}]
- ├── projections [type=tuple{}]
- └── projections [type=tuple{NULL}]
+ ├── projections
+ └── projections
       └── function: jsonb_agg [type=NULL]
            └── const: 1 [type=int]
 
@@ -92,10 +92,10 @@ project
  │    ├── columns: kv.v:int:null:2
  │    ├── scan
  │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
- │    ├── projections [type=tuple{int}]
+ │    ├── projections
  │    │    └── variable: kv.v [type=int]
- │    └── projections [type=tuple{}]
- └── projections [type=tuple{int}]
+ │    └── projections
+ └── projections
       └── const: 1 [type=int]
 
 build
@@ -117,11 +117,11 @@ project
  │    ├── columns: kv.k:int:null:1 column5:int:null:5
  │    ├── scan
  │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
- │    ├── projections [type=tuple{int}]
+ │    ├── projections
  │    │    └── variable: kv.k [type=int]
- │    └── projections [type=tuple{NULL}]
+ │    └── projections
  │         └── function: count_rows [type=NULL]
- └── projections [type=tuple{int, int}]
+ └── projections
       ├── variable: column5 [type=int]
       └── variable: kv.k [type=int]
 
@@ -135,11 +135,11 @@ project
  │    ├── columns: kv.k:int:null:1 column5:int:null:5
  │    ├── scan
  │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
- │    ├── projections [type=tuple{int}]
+ │    ├── projections
  │    │    └── variable: kv.k [type=int]
- │    └── projections [type=tuple{NULL}]
+ │    └── projections
  │         └── function: count_rows [type=NULL]
- └── projections [type=tuple{int, int}]
+ └── projections
       ├── variable: column5 [type=int]
       └── variable: kv.k [type=int]
 
@@ -168,11 +168,11 @@ project
  │    ├── columns: kv.s:string:null:4 column5:int:null:5
  │    ├── scan
  │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
- │    ├── projections [type=tuple{string}]
+ │    ├── projections
  │    │    └── variable: kv.s [type=string]
- │    └── projections [type=tuple{NULL}]
+ │    └── projections
  │         └── function: count_rows [type=NULL]
- └── projections [type=tuple{int, string}]
+ └── projections
       ├── variable: column5 [type=int]
       └── variable: kv.s [type=string]
 
@@ -185,11 +185,11 @@ project
  │    ├── columns: kv.s:string:null:4 column5:int:null:5
  │    ├── scan
  │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
- │    ├── projections [type=tuple{string}]
+ │    ├── projections
  │    │    └── variable: kv.s [type=string]
- │    └── projections [type=tuple{NULL}]
+ │    └── projections
  │         └── function: count_rows [type=NULL]
- └── projections [type=tuple{int, string}]
+ └── projections
       ├── variable: column5 [type=int]
       └── variable: kv.s [type=string]
 
@@ -202,11 +202,11 @@ project
  │    ├── columns: kv.s:string:null:4 column5:int:null:5
  │    ├── scan
  │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
- │    ├── projections [type=tuple{string}]
+ │    ├── projections
  │    │    └── variable: kv.s [type=string]
- │    └── projections [type=tuple{NULL}]
+ │    └── projections
  │         └── function: count_rows [type=NULL]
- └── projections [type=tuple{int, string}]
+ └── projections
       ├── variable: column5 [type=int]
       └── variable: kv.s [type=string]
 
@@ -219,11 +219,11 @@ project
  │    ├── columns: kv.s:string:null:4 column5:int:null:5
  │    ├── scan
  │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
- │    ├── projections [type=tuple{string}]
+ │    ├── projections
  │    │    └── variable: kv.s [type=string]
- │    └── projections [type=tuple{NULL}]
+ │    └── projections
  │         └── function: count_rows [type=NULL]
- └── projections [type=tuple{int, string}]
+ └── projections
       ├── variable: column5 [type=int]
       └── variable: kv.s [type=string]
 
@@ -237,12 +237,12 @@ project
  │    ├── columns: kv.v:int:null:2 kv.w:int:null:3 column5:int:null:5
  │    ├── scan
  │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
- │    ├── projections [type=tuple{int, int}]
+ │    ├── projections
  │    │    ├── variable: kv.v [type=int]
  │    │    └── variable: kv.w [type=int]
- │    └── projections [type=tuple{NULL}]
+ │    └── projections
  │         └── function: count_rows [type=NULL]
- └── projections [type=tuple{int, int, int}]
+ └── projections
       ├── variable: kv.v [type=int]
       ├── variable: column5 [type=int]
       └── variable: kv.w [type=int]
@@ -257,12 +257,12 @@ project
  │    ├── columns: kv.v:int:null:2 kv.w:int:null:3 column5:int:null:5
  │    ├── scan
  │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
- │    ├── projections [type=tuple{int, int}]
+ │    ├── projections
  │    │    ├── variable: kv.v [type=int]
  │    │    └── variable: kv.w [type=int]
- │    └── projections [type=tuple{NULL}]
+ │    └── projections
  │         └── function: count_rows [type=NULL]
- └── projections [type=tuple{int, int, int}]
+ └── projections
       ├── variable: kv.v [type=int]
       ├── variable: column5 [type=int]
       └── variable: kv.w [type=int]
@@ -277,12 +277,12 @@ project
  │    ├── columns: column5:string:null:5 column6:int:null:6
  │    ├── scan
  │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
- │    ├── projections [type=tuple{NULL}]
+ │    ├── projections
  │    │    └── function: upper [type=NULL]
  │    │         └── variable: kv.s [type=string]
- │    └── projections [type=tuple{NULL}]
+ │    └── projections
  │         └── function: count_rows [type=NULL]
- └── projections [type=tuple{int, string}]
+ └── projections
       ├── variable: column6 [type=int]
       └── variable: column5 [type=string]
 
@@ -296,11 +296,11 @@ project
  │    ├── columns: column5:int:null:5 column6:int:null:6
  │    ├── scan
  │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
- │    ├── projections [type=tuple{int}]
+ │    ├── projections
  │    │    └── const: 3 [type=int]
- │    └── projections [type=tuple{NULL}]
+ │    └── projections
  │         └── function: count_rows [type=NULL]
- └── projections [type=tuple{int}]
+ └── projections
       └── variable: column6 [type=int]
 
 build
@@ -312,12 +312,12 @@ project
  │    ├── columns: column5:int:null:5 column6:int:null:6
  │    ├── scan
  │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
- │    ├── projections [type=tuple{NULL}]
+ │    ├── projections
  │    │    └── function: length [type=NULL]
  │    │         └── const: 'abc' [type=string]
- │    └── projections [type=tuple{NULL}]
+ │    └── projections
  │         └── function: count_rows [type=NULL]
- └── projections [type=tuple{int}]
+ └── projections
       └── variable: column6 [type=int]
 
 # Selecting a function of something which is grouped works.
@@ -330,11 +330,11 @@ project
  │    ├── columns: kv.s:string:null:4 column5:int:null:5
  │    ├── scan
  │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
- │    ├── projections [type=tuple{string}]
+ │    ├── projections
  │    │    └── variable: kv.s [type=string]
- │    └── projections [type=tuple{NULL}]
+ │    └── projections
  │         └── function: count_rows [type=NULL]
- └── projections [type=tuple{int, NULL}]
+ └── projections
       ├── variable: column5 [type=int]
       └── function: upper [type=NULL]
            └── variable: kv.s [type=string]
@@ -355,13 +355,13 @@ project
  │    ├── columns: column5:int:null:5 column6:int:null:6
  │    ├── scan
  │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
- │    ├── projections [type=tuple{int}]
+ │    ├── projections
  │    │    └── plus [type=int]
  │    │         ├── variable: kv.k [type=int]
  │    │         └── variable: kv.v [type=int]
- │    └── projections [type=tuple{NULL}]
+ │    └── projections
  │         └── function: count_rows [type=NULL]
- └── projections [type=tuple{int, int}]
+ └── projections
       ├── variable: column6 [type=int]
       └── variable: column5 [type=int]
 
@@ -376,12 +376,12 @@ project
  │    ├── columns: kv.k:int:null:1 kv.v:int:null:2 column5:int:null:5
  │    ├── scan
  │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
- │    ├── projections [type=tuple{int, int}]
+ │    ├── projections
  │    │    ├── variable: kv.k [type=int]
  │    │    └── variable: kv.v [type=int]
- │    └── projections [type=tuple{NULL}]
+ │    └── projections
  │         └── function: count_rows [type=NULL]
- └── projections [type=tuple{int, int}]
+ └── projections
       ├── variable: column5 [type=int]
       └── plus [type=int]
            ├── variable: kv.k [type=int]
@@ -422,14 +422,14 @@ project
  │    ├── columns: column5:int:null:5 count_1:int:null:6
  │    ├── scan
  │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
- │    ├── projections [type=tuple{int}]
+ │    ├── projections
  │    │    └── plus [type=int]
  │    │         ├── variable: kv.v [type=int]
  │    │         └── variable: kv.w [type=int]
- │    └── projections [type=tuple{NULL}]
+ │    └── projections
  │         └── function: count [type=NULL]
  │              └── variable: kv.k [type=int]
- └── projections [type=tuple{int, int}]
+ └── projections
       ├── variable: count_1 [type=int]
       └── variable: column5 [type=int]
 
@@ -440,8 +440,8 @@ group-by
  ├── columns: column1:int:null:1
  ├── values
  │    └── tuple [type=tuple{}]
- ├── projections [type=tuple{}]
- └── projections [type=tuple{NULL}]
+ ├── projections
+ └── projections
       └── function: count_rows [type=NULL]
 
 build
@@ -451,8 +451,8 @@ group-by
  ├── columns: column5:int:null:5
  ├── scan
  │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
- ├── projections [type=tuple{}]
- └── projections [type=tuple{NULL}]
+ ├── projections
+ └── projections
       └── function: count [type=NULL]
            └── variable: kv.k [type=int]
 
@@ -463,8 +463,8 @@ group-by
  ├── columns: column1:int:null:1
  ├── values
  │    └── tuple [type=tuple{}]
- ├── projections [type=tuple{}]
- └── projections [type=tuple{NULL}]
+ ├── projections
+ └── projections
       └── function: count [type=NULL]
            └── const: 1 [type=int]
 
@@ -475,8 +475,8 @@ group-by
  ├── columns: column5:int:null:5
  ├── scan
  │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
- ├── projections [type=tuple{}]
- └── projections [type=tuple{NULL}]
+ ├── projections
+ └── projections
       └── function: count [type=NULL]
            └── const: 1 [type=int]
 
@@ -492,8 +492,8 @@ group-by
  ├── columns: column5:int:null:5 column6:int:null:6 column7:int:null:7
  ├── scan
  │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
- ├── projections [type=tuple{}]
- └── projections [type=tuple{NULL, NULL, NULL}]
+ ├── projections
+ └── projections
       ├── function: count_rows [type=NULL]
       ├── function: count [type=NULL]
       │    └── variable: kv.k [type=int]
@@ -513,8 +513,8 @@ group-by
  ├── columns: column5:int:null:5
  ├── scan
  │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
- ├── projections [type=tuple{}]
- └── projections [type=tuple{NULL}]
+ ├── projections
+ └── projections
       └── function: count [type=NULL]
            └── tuple [type=tuple{int, int}]
                 ├── variable: kv.k [type=int]
@@ -529,13 +529,13 @@ project
  │    ├── columns: column5:int:null:5 column6:int:null:6
  │    ├── scan
  │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
- │    ├── projections [type=tuple{}]
- │    └── projections [type=tuple{NULL, NULL}]
+ │    ├── projections
+ │    └── projections
  │         ├── function: count [type=NULL]
  │         │    └── variable: kv.k [type=int]
  │         └── function: count [type=NULL]
  │              └── variable: kv.v [type=int]
- └── projections [type=tuple{int}]
+ └── projections
       └── plus [type=int]
            ├── variable: column5 [type=int]
            └── variable: column6 [type=int]
@@ -547,8 +547,8 @@ group-by
  ├── columns: column5:int:null:5 column6:int:null:6 column7:int:null:7 column8:int:null:8
  ├── scan
  │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
- ├── projections [type=tuple{}]
- └── projections [type=tuple{NULL, NULL, NULL, NULL}]
+ ├── projections
+ └── projections
       ├── function: min [type=NULL]
       │    └── variable: kv.k [type=int]
       ├── function: max [type=NULL]
@@ -570,8 +570,8 @@ group-by
  │    └── gt [type=bool]
  │         ├── variable: kv.k [type=int]
  │         └── const: 8 [type=int]
- ├── projections [type=tuple{}]
- └── projections [type=tuple{NULL, NULL, NULL, NULL}]
+ ├── projections
+ └── projections
       ├── function: min [type=NULL]
       │    └── variable: kv.k [type=int]
       ├── function: max [type=NULL]
@@ -593,8 +593,8 @@ group-by
  │    └── is [type=bool]
  │         ├── variable: kv.s [type=string]
  │         └── const: NULL [type=NULL]
- ├── projections [type=tuple{}]
- └── projections [type=tuple{NULL}]
+ ├── projections
+ └── projections
       └── function: array_agg [type=NULL]
            └── variable: kv.s [type=string]
 
@@ -605,8 +605,8 @@ group-by
  ├── columns: column5:decimal:null:5 column6:decimal:null:6 column7:decimal:null:7 column8:decimal:null:8
  ├── scan
  │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
- ├── projections [type=tuple{}]
- └── projections [type=tuple{NULL, NULL, NULL, NULL}]
+ ├── projections
+ └── projections
       ├── function: avg [type=NULL]
       │    └── variable: kv.k [type=int]
       ├── function: avg [type=NULL]
@@ -632,8 +632,8 @@ group-by
  ├── columns: column5:string:null:5 column6:float:null:6 column7:bool:null:7 column8:decimal:null:8
  ├── scan
  │    └── columns: abc.a:string:1 abc.b:float:null:2 abc.c:bool:null:3 abc.d:decimal:null:4
- ├── projections [type=tuple{}]
- └── projections [type=tuple{NULL, NULL, NULL, NULL}]
+ ├── projections
+ └── projections
       ├── function: min [type=NULL]
       │    └── variable: abc.a [type=string]
       ├── function: min [type=NULL]
@@ -650,8 +650,8 @@ group-by
  ├── columns: column5:string:null:5 column6:float:null:6 column7:bool:null:7 column8:decimal:null:8
  ├── scan
  │    └── columns: abc.a:string:1 abc.b:float:null:2 abc.c:bool:null:3 abc.d:decimal:null:4
- ├── projections [type=tuple{}]
- └── projections [type=tuple{NULL, NULL, NULL, NULL}]
+ ├── projections
+ └── projections
       ├── function: max [type=NULL]
       │    └── variable: abc.a [type=string]
       ├── function: max [type=NULL]
@@ -668,8 +668,8 @@ group-by
  ├── columns: column5:float:null:5 column6:float:null:6 column7:decimal:null:7 column8:decimal:null:8
  ├── scan
  │    └── columns: abc.a:string:1 abc.b:float:null:2 abc.c:bool:null:3 abc.d:decimal:null:4
- ├── projections [type=tuple{}]
- └── projections [type=tuple{NULL, NULL, NULL, NULL}]
+ ├── projections
+ └── projections
       ├── function: avg [type=NULL]
       │    └── variable: abc.b [type=float]
       ├── function: sum [type=NULL]
@@ -693,8 +693,8 @@ group-by
  ├── columns: column2:interval:null:2
  ├── scan
  │    └── columns: intervals.a:interval:1
- ├── projections [type=tuple{}]
- └── projections [type=tuple{NULL}]
+ ├── projections
+ └── projections
       └── function: sum [type=NULL]
            └── variable: intervals.a [type=interval]
 
@@ -748,8 +748,8 @@ group-by
  ├── columns: column4:int:null:4
  ├── scan
  │    └── columns: xyz.x:int:1 xyz.y:int:null:2 xyz.z:float:null:3
- ├── projections [type=tuple{}]
- └── projections [type=tuple{NULL}]
+ ├── projections
+ └── projections
       └── function: min [type=NULL]
            └── variable: xyz.x [type=int]
 
@@ -768,8 +768,8 @@ group-by
  │              ├── const: 0 [type=int]
  │              ├── const: 4 [type=int]
  │              └── const: 7 [type=int]
- ├── projections [type=tuple{}]
- └── projections [type=tuple{NULL}]
+ ├── projections
+ └── projections
       └── function: min [type=NULL]
            └── variable: xyz.x [type=int]
 
@@ -780,8 +780,8 @@ group-by
  ├── columns: column4:int:null:4
  ├── scan
  │    └── columns: xyz.x:int:1 xyz.y:int:null:2 xyz.z:float:null:3
- ├── projections [type=tuple{}]
- └── projections [type=tuple{NULL}]
+ ├── projections
+ └── projections
       └── function: max [type=NULL]
            └── variable: xyz.x [type=int]
 
@@ -797,8 +797,8 @@ group-by
  │    └── eq [type=bool]
  │         ├── variable: xyz.x [type=int]
  │         └── const: 1 [type=int]
- ├── projections [type=tuple{}]
- └── projections [type=tuple{NULL}]
+ ├── projections
+ └── projections
       └── function: max [type=NULL]
            └── variable: xyz.y [type=int]
 
@@ -814,8 +814,8 @@ group-by
  │    └── eq [type=bool]
  │         ├── variable: xyz.x [type=int]
  │         └── const: 7 [type=int]
- ├── projections [type=tuple{}]
- └── projections [type=tuple{NULL}]
+ ├── projections
+ └── projections
       └── function: min [type=NULL]
            └── variable: xyz.y [type=int]
 
@@ -835,8 +835,8 @@ group-by
  │         └── tuple [type=tuple{int, float}]
  │              ├── const: 2 [type=int]
  │              └── const: 3.0 [type=float]
- ├── projections [type=tuple{}]
- └── projections [type=tuple{NULL}]
+ ├── projections
+ └── projections
       └── function: min [type=NULL]
            └── variable: xyz.x [type=int]
 
@@ -856,8 +856,8 @@ group-by
  │         └── tuple [type=tuple{float, int}]
  │              ├── const: 3.0 [type=float]
  │              └── const: 2 [type=int]
- ├── projections [type=tuple{}]
- └── projections [type=tuple{NULL}]
+ ├── projections
+ └── projections
       └── function: max [type=NULL]
            └── variable: xyz.x [type=int]
 
@@ -876,8 +876,8 @@ group-by
  │    └── eq [type=bool]
  │         ├── variable: xyz.x [type=int]
  │         └── const: 10 [type=int]
- ├── projections [type=tuple{}]
- └── projections [type=tuple{NULL}]
+ ├── projections
+ └── projections
       └── function: variance [type=NULL]
            └── variable: xyz.x [type=int]
 
@@ -893,8 +893,8 @@ group-by
  │    └── eq [type=bool]
  │         ├── variable: xyz.x [type=int]
  │         └── const: 1 [type=int]
- ├── projections [type=tuple{}]
- └── projections [type=tuple{NULL}]
+ ├── projections
+ └── projections
       └── function: stddev [type=NULL]
            └── variable: xyz.x [type=int]
 
@@ -909,8 +909,8 @@ group-by
  ├── columns: column3:bool:null:3 column4:bool:null:4
  ├── scan
  │    └── columns: bools.b:bool:null:1 bools.rowid:int:2
- ├── projections [type=tuple{}]
- └── projections [type=tuple{NULL, NULL}]
+ ├── projections
+ └── projections
       ├── function: bool_and [type=NULL]
       │    └── variable: bools.b [type=bool]
       └── function: bool_or [type=NULL]
@@ -927,13 +927,13 @@ project
  │    ├── columns: kv.k:int:null:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
  │    ├── scan
  │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
- │    ├── projections [type=tuple{int, int, int, string}]
+ │    ├── projections
  │    │    ├── variable: kv.k [type=int]
  │    │    ├── variable: kv.v [type=int]
  │    │    ├── variable: kv.w [type=int]
  │    │    └── variable: kv.s [type=string]
- │    └── projections [type=tuple{}]
- └── projections [type=tuple{int}]
+ │    └── projections
+ └── projections
       └── const: 1 [type=int]
 
 exec-raw
@@ -949,13 +949,13 @@ project
  │    ├── columns: column5:bytes:null:5 column7:int:null:7
  │    ├── scan
  │    │    └── columns: xor_bytes.a:bytes:null:1 xor_bytes.b:int:null:2 xor_bytes.c:int:null:3 xor_bytes.rowid:int:4
- │    ├── projections [type=tuple{}]
- │    └── projections [type=tuple{NULL, NULL}]
+ │    ├── projections
+ │    └── projections
  │         ├── function: xor_agg [type=NULL]
  │         │    └── variable: xor_bytes.a [type=bytes]
  │         └── function: xor_agg [type=NULL]
  │              └── variable: xor_bytes.c [type=int]
- └── projections [type=tuple{NULL, int}]
+ └── projections
       ├── function: to_hex [type=NULL]
       │    └── variable: column5 [type=bytes]
       └── variable: column7 [type=int]
@@ -967,8 +967,8 @@ group-by
  ├── columns: column1:bool:null:1 column2:bool:null:2
  ├── values
  │    └── tuple [type=tuple{}]
- ├── projections [type=tuple{}]
- └── projections [type=tuple{NULL, NULL}]
+ ├── projections
+ └── projections
       ├── function: max [type=NULL]
       │    └── const: true [type=bool]
       └── function: min [type=NULL]
@@ -997,11 +997,11 @@ project
  │    ├── columns: ab.a:int:null:1 ab.b:int:null:2
  │    ├── scan
  │    │    └── columns: ab.a:int:1 ab.b:int:null:2
- │    ├── projections [type=tuple{int, int}]
+ │    ├── projections
  │    │    ├── variable: ab.b [type=int]
  │    │    └── variable: ab.a [type=int]
- │    └── projections [type=tuple{}]
- └── projections [type=tuple{tuple{int, int}}]
+ │    └── projections
+ └── projections
       └── tuple [type=tuple{int, int}]
            ├── variable: ab.b [type=int]
            └── variable: ab.a [type=int]
@@ -1021,14 +1021,14 @@ project
  │    │    ├── scan
  │    │    │    └── columns: xy.x:string:null:3 xy.y:string:null:4 xy.rowid:int:5
  │    │    └── true [type=bool]
- │    ├── projections [type=tuple{string, int, int}]
+ │    ├── projections
  │    │    ├── variable: xy.x [type=string]
  │    │    ├── variable: ab.a [type=int]
  │    │    └── variable: ab.b [type=int]
- │    └── projections [type=tuple{NULL}]
+ │    └── projections
  │         └── function: min [type=NULL]
  │              └── variable: xy.y [type=string]
- └── projections [type=tuple{string, tuple{int, int}}]
+ └── projections
       ├── variable: column6 [type=string]
       └── tuple [type=tuple{int, int}]
            ├── variable: ab.b [type=int]
@@ -1043,15 +1043,15 @@ project
  │    ├── columns: column5:int:null:5 column6:int:null:6
  │    ├── scan
  │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
- │    ├── projections [type=tuple{int, int}]
+ │    ├── projections
  │    │    ├── plus [type=int]
  │    │    │    ├── variable: kv.k [type=int]
  │    │    │    └── variable: kv.v [type=int]
  │    │    └── plus [type=int]
  │    │         ├── variable: kv.v [type=int]
  │    │         └── variable: kv.w [type=int]
- │    └── projections [type=tuple{}]
- └── projections [type=tuple{decimal}]
+ │    └── projections
+ └── projections
       └── div [type=decimal]
            ├── plus [type=int]
            │    ├── variable: kv.k [type=int]

--- a/pkg/sql/opt/build/testdata/inner-join
+++ b/pkg/sql/opt/build/testdata/inner-join
@@ -26,7 +26,7 @@ project
  │    ├── scan
  │    │    └── columns: b.x:int:null:3 b.y:float:null:4 b.rowid:int:5
  │    └── true [type=bool]
- └── projections [type=tuple{int, float, int, float}]
+ └── projections
       ├── variable: a.x [type=int]
       ├── variable: a.y [type=float]
       ├── variable: b.x [type=int]
@@ -49,7 +49,7 @@ project
  │    └── eq [type=bool]
  │         ├── variable: a.x [type=int]
  │         └── variable: b.x [type=int]
- └── projections [type=tuple{int, float}]
+ └── projections
       ├── variable: a.x [type=int]
       └── variable: b.y [type=float]
 
@@ -79,7 +79,7 @@ project
  │         └── eq [type=bool]
  │              ├── variable: b.x [type=int]
  │              └── variable: a.x [type=int]
- └── projections [type=tuple{int, float, string, int, float, int, float}]
+ └── projections
       ├── variable: c.x [type=int]
       ├── variable: c.y [type=float]
       ├── variable: c.z [type=string]

--- a/pkg/sql/opt/build/testdata/project
+++ b/pkg/sql/opt/build/testdata/project
@@ -40,7 +40,7 @@ build
 SELECT a.y, a.x FROM t.a
 ----
 project
- ├── columns: a.x:int:1 a.y:float:null:2
+ ├── columns: a.y:float:null:2 a.x:int:1
  ├── scan
  │    └── columns: a.x:int:1 a.y:float:null:2
  └── projections [type=tuple{float, int}]

--- a/pkg/sql/opt/build/testdata/project
+++ b/pkg/sql/opt/build/testdata/project
@@ -17,7 +17,7 @@ project
  ├── columns: column1:int:null:1
  ├── values
  │    └── tuple [type=tuple{}]
- └── projections [type=tuple{int}]
+ └── projections
       └── const: 5 [type=int]
 
 build
@@ -27,7 +27,7 @@ project
  ├── columns: a.x:int:1
  ├── scan
  │    └── columns: a.x:int:1 a.y:float:null:2
- └── projections [type=tuple{int}]
+ └── projections
       └── variable: a.x [type=int]
 
 build
@@ -43,7 +43,7 @@ project
  ├── columns: a.y:float:null:2 a.x:int:1
  ├── scan
  │    └── columns: a.x:int:1 a.y:float:null:2
- └── projections [type=tuple{float, int}]
+ └── projections
       ├── variable: a.y [type=float]
       └── variable: a.x [type=int]
 
@@ -62,7 +62,7 @@ project
  ├── columns: b.x:int:null:1 b.y:float:null:2
  ├── scan
  │    └── columns: b.x:int:null:1 b.y:float:null:2 b.rowid:int:3
- └── projections [type=tuple{int, float}]
+ └── projections
       ├── variable: b.x [type=int]
       └── variable: b.y [type=float]
 
@@ -73,7 +73,7 @@ project
  ├── columns: X:int:null:3 Y:bool:null:4
  ├── scan
  │    └── columns: a.x:int:1 a.y:float:null:2
- └── projections [type=tuple{int, bool}]
+ └── projections
       ├── plus [type=int]
       │    ├── variable: a.x [type=int]
       │    └── const: 3 [type=int]
@@ -86,7 +86,7 @@ project
  ├── columns: a.x:int:1 a.y:float:null:2 column3:bool:null:3
  ├── scan
  │    └── columns: a.x:int:1 a.y:float:null:2
- └── projections [type=tuple{int, float, bool}]
+ └── projections
       ├── variable: a.x [type=int]
       ├── variable: a.y [type=float]
       └── or [type=bool]
@@ -104,7 +104,7 @@ project
  ├── columns: a.x:int:1 a.y:float:null:2 column3:bool:null:3
  ├── scan
  │    └── columns: a.x:int:1 a.y:float:null:2
- └── projections [type=tuple{int, float, bool}]
+ └── projections
       ├── variable: a.x [type=int]
       ├── variable: a.y [type=float]
       └── const: true [type=bool]

--- a/pkg/sql/opt/ops/scalar.opt
+++ b/pkg/sql/opt/ops/scalar.opt
@@ -54,11 +54,11 @@ define Tuple {
 # Projections is a set of typed scalar expressions that will become output
 # columns for a containing relational expression, such as Project or GroupBy.
 # The private Cols field contains the set of column indexes returned by the
-# expression, as a *ColSet.
+# expression, as a *ColList.
 [Scalar]
 define Projections {
     Elems ExprList
-    Cols  ColSet
+    Cols  ColList
 }
 
 [Scalar]

--- a/pkg/sql/opt/opt/metadata.go
+++ b/pkg/sql/opt/opt/metadata.go
@@ -34,6 +34,12 @@ type TableIndex int32
 // ColSet efficiently stores an unordered set of column indexes.
 type ColSet = util.FastIntSet
 
+// ColList is a list of column indexes.
+// It is represented as a map from 0,1,2,.. to column indexes.
+// TODO(radu): perhaps implement a FastIntList with the same "small"
+// representation as FastIntMap but with a slice for large cases.
+type ColList = util.FastIntMap
+
 // ColMap provides a 1:1 mapping from one column index to another. It is used
 // by operators that need to match columns from its inputs.
 type ColMap = util.FastIntMap
@@ -169,4 +175,17 @@ func (md *Metadata) Table(index TableIndex) optbase.Table {
 // position in the table.
 func (md *Metadata) TableColumn(tblIndex TableIndex, ord int) ColumnIndex {
 	return ColumnIndex(int(tblIndex) + ord)
+}
+
+// ColListToSet converts a column index list to a column index set.
+func ColListToSet(colList ColList) ColSet {
+	var r ColSet
+	for i, n := 0, colList.Len(); i < n; i++ {
+		col, ok := colList.Get(i)
+		if !ok {
+			panic("corrupt column set")
+		}
+		r.Add(col)
+	}
+	return r
 }

--- a/pkg/sql/opt/xform/expr.go
+++ b/pkg/sql/opt/xform/expr.go
@@ -168,15 +168,19 @@ func (ev *ExprView) formatScalar(tp treeprinter.Node) {
 	fmt.Fprintf(&buf, "%v", ev.op)
 	ev.formatPrivate(&buf, ev.Private())
 
-	scalar := ev.Logical().Scalar
-	if scalar != nil {
-		buf.WriteString(" [")
-		fmt.Fprintf(&buf, "type=%s", scalar.Type)
-		buf.WriteString("]")
-	} else {
-		// Don't panic if scalar properties don't yet exist when printing
-		// expression.
-		buf.WriteString(" [type=undefined]")
+	// Don't show the type of the projections op, the types of each expression are
+	// already listed in the children.
+	if ev.Operator() != opt.ProjectionsOp {
+		scalar := ev.Logical().Scalar
+		if scalar != nil {
+			buf.WriteString(" [")
+			fmt.Fprintf(&buf, "type=%s", scalar.Type)
+			buf.WriteString("]")
+		} else {
+			// Don't panic if scalar properties don't yet exist when printing
+			// expression.
+			buf.WriteString(" [type=undefined]")
+		}
 	}
 
 	tp = tp.Child(buf.String())

--- a/pkg/sql/opt/xform/logical_props.go
+++ b/pkg/sql/opt/xform/logical_props.go
@@ -73,19 +73,22 @@ func (p *LogicalProps) formatOutputCols(mem *memo, tp treeprinter.Node) {
 		var buf bytes.Buffer
 		buf.WriteString("columns:")
 		p.Relational.OutputCols.ForEach(func(i int) {
-			colIndex := opt.ColumnIndex(i)
-			label := mem.metadata.ColumnLabel(colIndex)
-			typ := mem.metadata.ColumnType(colIndex)
-			buf.WriteByte(' ')
-			buf.WriteString(label)
-			buf.WriteByte(':')
-			buf.WriteString(typ.String())
-			buf.WriteByte(':')
-			if !p.Relational.NotNullCols.Contains(int(colIndex)) {
-				buf.WriteString("null:")
-			}
-			fmt.Fprintf(&buf, "%d", colIndex)
+			p.formatCol(mem, &buf, opt.ColumnIndex(i))
 		})
 		tp.Child(buf.String())
 	}
+}
+
+func (p *LogicalProps) formatCol(mem *memo, buf *bytes.Buffer, colIndex opt.ColumnIndex) {
+	label := mem.metadata.ColumnLabel(colIndex)
+	typ := mem.metadata.ColumnType(colIndex)
+	buf.WriteByte(' ')
+	buf.WriteString(label)
+	buf.WriteByte(':')
+	buf.WriteString(typ.String())
+	buf.WriteByte(':')
+	if !p.Relational.NotNullCols.Contains(int(colIndex)) {
+		buf.WriteString("null:")
+	}
+	fmt.Fprintf(buf, "%d", colIndex)
 }

--- a/pkg/sql/opt/xform/logical_props_factory.go
+++ b/pkg/sql/opt/xform/logical_props_factory.go
@@ -115,7 +115,7 @@ func (f *logicalPropsFactory) constructProjectProps(ev *ExprView) LogicalProps {
 
 	// Use output columns from projection list.
 	projections := ev.Child(1)
-	props.Relational.OutputCols = *projections.Private().(*opt.ColSet)
+	props.Relational.OutputCols = opt.ColListToSet(*projections.Private().(*opt.ColList))
 
 	// Inherit not null columns from input.
 	props.Relational.NotNullCols = inputProps.Relational.NotNullCols
@@ -165,12 +165,12 @@ func (f *logicalPropsFactory) constructJoinProps(ev *ExprView) LogicalProps {
 func (f *logicalPropsFactory) constructGroupByProps(ev *ExprView) LogicalProps {
 	props := LogicalProps{Relational: &RelationalProps{}}
 
-	// Output columns are union of columns from grouping and aggregate
+	// Output columns are the union of columns from grouping and aggregate
 	// projection lists.
 	groupings := ev.Child(1)
-	props.Relational.OutputCols = groupings.Private().(*opt.ColSet).Copy()
+	props.Relational.OutputCols = opt.ColListToSet(*groupings.Private().(*opt.ColList))
 	agg := ev.Child(2)
-	props.Relational.OutputCols.UnionWith(*agg.Private().(*opt.ColSet))
+	props.Relational.OutputCols.UnionWith(opt.ColListToSet(*agg.Private().(*opt.ColList)))
 
 	return props
 }

--- a/pkg/sql/opt/xform/logical_props_test.go
+++ b/pkg/sql/opt/xform/logical_props_test.go
@@ -97,12 +97,14 @@ func TestLogicalGroupByProps(t *testing.T) {
 	col1 := f.Metadata().TableColumn(a, 1)
 	varGroup := f.ConstructVariable(f.InternPrivate(col1))
 	items1 := f.InternList([]opt.GroupID{varGroup})
-	cols1 := util.MakeFastIntSet(int(col1))
+	var cols1 util.FastIntMap
+	cols1.Set(0, int(col1))
 	groupingsGroup := f.ConstructProjections(items1, f.InternPrivate(&cols1))
 
 	col2 := f.Metadata().AddColumn("false", types.Bool)
 	items2 := f.InternList([]opt.GroupID{f.ConstructFalse()})
-	cols2 := util.MakeFastIntSet(int(col2))
+	var cols2 util.FastIntMap
+	cols2.Set(0, int(col2))
 	aggsGroup := f.ConstructProjections(items2, f.InternPrivate(&cols2))
 
 	groupByGroup := f.ConstructGroupBy(scanGroup, groupingsGroup, aggsGroup)

--- a/pkg/sql/opt/xform/testdata/typing
+++ b/pkg/sql/opt/xform/testdata/typing
@@ -6,7 +6,7 @@ project
  ├── columns: a.x:int:1
  ├── scan
  │    └── columns: a.x:int:1 a.y:int:null:2
- └── projections [type=tuple{int}]
+ └── projections
       └── variable: a.x [type=int]
 
 # Const
@@ -17,7 +17,7 @@ project
  ├── columns: column1:int:null:1 column2:bool:null:2 column3:bool:null:3
  ├── values
  │    └── tuple [type=tuple{}]
- └── projections [type=tuple{int, bool, bool}]
+ └── projections
       ├── const: 1 [type=int]
       ├── const: true [type=bool]
       └── const: false [type=bool]
@@ -39,10 +39,10 @@ build
 SELECT (a.x, 1.5), a.y FROM a
 ----
 project
- ├── columns: a.y:int:null:2 column3:tuple{int, decimal}:null:3
+ ├── columns: column3:tuple{int, decimal}:null:3 a.y:int:null:2
  ├── scan
  │    └── columns: a.x:int:1 a.y:int:null:2
- └── projections [type=tuple{tuple{int, decimal}, int}]
+ └── projections
       ├── tuple [type=tuple{int, decimal}]
       │    ├── variable: a.x [type=int]
       │    └── const: 1.5 [type=decimal]
@@ -209,7 +209,7 @@ project
  ├── columns: column3:int:null:3 column4:int:null:4 column5:int:null:5
  ├── scan
  │    └── columns: a.x:int:1 a.y:int:null:2
- └── projections [type=tuple{int, int, int}]
+ └── projections
       ├── bitand [type=int]
       │    ├── variable: a.x [type=int]
       │    └── variable: a.y [type=int]
@@ -228,7 +228,7 @@ project
  ├── columns: column3:decimal:null:3 column4:date:null:4 column5:decimal:null:5 column6:decimal:null:6 column7:decimal:null:7
  ├── scan
  │    └── columns: a.x:int:1 a.y:int:null:2
- └── projections [type=tuple{decimal, date, decimal, decimal, decimal}]
+ └── projections
       ├── plus [type=decimal]
       │    ├── variable: a.x [type=int]
       │    └── const: 1.5 [type=decimal]
@@ -253,7 +253,7 @@ project
  ├── columns: column3:decimal:null:3 column4:decimal:null:4 column5:int:null:5 column6:int:null:6
  ├── scan
  │    └── columns: a.x:int:1 a.y:int:null:2
- └── projections [type=tuple{decimal, decimal, int, int}]
+ └── projections
       ├── mod [type=decimal]
       │    ├── const: 100.1 [type=decimal]
       │    └── variable: a.x [type=int]
@@ -275,7 +275,7 @@ project
  ├── columns: column3:string:null:3
  ├── scan
  │    └── columns: b.x:string:1 b.z:decimal:2
- └── projections [type=tuple{string}]
+ └── projections
       └── concat [type=string]
            ├── variable: b.x [type=string]
            └── const: 'more' [type=string]
@@ -288,7 +288,7 @@ project
  ├── columns: column3:int:null:3 column4:int:null:4 column5:int:null:5
  ├── scan
  │    └── columns: a.x:int:1 a.y:int:null:2
- └── projections [type=tuple{int, int, int}]
+ └── projections
       ├── unary-plus [type=int]
       │    └── variable: a.x [type=int]
       ├── unary-minus [type=int]

--- a/pkg/util/fast_int_map.go
+++ b/pkg/util/fast_int_map.go
@@ -15,7 +15,10 @@
 package util
 
 import (
+	"bytes"
+	"fmt"
 	"math/bits"
+	"sort"
 
 	"golang.org/x/tools/container/intsets"
 )
@@ -185,6 +188,42 @@ func (m FastIntMap) ForEach(fn func(key, val int)) {
 			fn(k, v)
 		}
 	}
+}
+
+// String prints out the contents of the map in the following format:
+//   map[key1:val1 key2:val2 ...]
+// The keys are in ascending order.
+func (m FastIntMap) String() string {
+	var buf bytes.Buffer
+	buf.WriteString("map[")
+	first := true
+
+	if m.large != nil {
+		keys := make([]int, 0, len(m.large))
+		for k := range m.large {
+			keys = append(keys, k)
+		}
+		sort.Ints(keys)
+		for _, k := range keys {
+			if !first {
+				buf.WriteByte(' ')
+			}
+			first = false
+			fmt.Fprintf(&buf, "%d:%d", k, m.large[k])
+		}
+	} else {
+		for i := 0; i < numVals; i++ {
+			if val := m.getSmallVal(uint32(i)); val != -1 {
+				if !first {
+					buf.WriteByte(' ')
+				}
+				first = false
+				fmt.Fprintf(&buf, "%d:%d", i, val)
+			}
+		}
+	}
+	buf.WriteByte(']')
+	return buf.String()
 }
 
 // These constants determine the "small" representation: we pack <numVals>


### PR DESCRIPTION
The way we store projections in the memo does not allow us to list an
expression to a column index. This change replaces the ColSet with a
map and shows the map in the expression printouts.

Release note: None