### PR TITLE
roachpb: disable roachpb.Value checksum computation

### DIFF
--- a/pkg/ccl/storageccl/add_sstable.go
+++ b/pkg/ccl/storageccl/add_sstable.go
@@ -88,7 +88,7 @@ func verifySSTable(
 	// we a) pass a verify flag on the iterator so that as ComputeStatsGo calls
 	// Next, we're also verifying each KV pair. We explicitly check the first key
 	// is >= start and then that we do not find a key after end.
-	dataIter, err := engineccl.NewMemSSTIterator(data, true)
+	dataIter, err := engineccl.NewMemSSTIterator(data)
 	if err != nil {
 		return enginepb.MVCCStats{}, err
 	}

--- a/pkg/ccl/storageccl/add_sstable_test.go
+++ b/pkg/ccl/storageccl/add_sstable_test.go
@@ -169,21 +169,6 @@ func runTestDBAddSSTable(ctx context.Context, t *testing.T, db *client.DB) {
 			}
 		}
 	}
-
-	// Invalid key/value entry checksum.
-	{
-		key := engine.MVCCKey{Key: []byte("bb"), Timestamp: hlc.Timestamp{WallTime: 1}}
-		value := roachpb.MakeValueFromString("1")
-		value.MustInitChecksum([]byte("foo"))
-		data, err := singleKVSSTable(key, value.RawBytes)
-		if err != nil {
-			t.Fatalf("%+v", err)
-		}
-
-		if err := db.AddSSTable(ctx, "b", "c", data); !testutils.IsError(err, "invalid checksum") {
-			t.Fatalf("expected 'invalid checksum' error got: %+v", err)
-		}
-	}
 }
 
 func randomMVCCKeyValues(rng *rand.Rand, numKVs int) []engine.MVCCKeyValue {

--- a/pkg/ccl/storageccl/add_sstable_test.go
+++ b/pkg/ccl/storageccl/add_sstable_test.go
@@ -174,7 +174,7 @@ func runTestDBAddSSTable(ctx context.Context, t *testing.T, db *client.DB) {
 	{
 		key := engine.MVCCKey{Key: []byte("bb"), Timestamp: hlc.Timestamp{WallTime: 1}}
 		value := roachpb.MakeValueFromString("1")
-		value.InitChecksum([]byte("foo"))
+		value.MustInitChecksum([]byte("foo"))
 		data, err := singleKVSSTable(key, value.RawBytes)
 		if err != nil {
 			t.Fatalf("%+v", err)

--- a/pkg/ccl/storageccl/engineccl/rocksdb.go
+++ b/pkg/ccl/storageccl/engineccl/rocksdb.go
@@ -11,7 +11,6 @@ package engineccl
 import (
 	"unsafe"
 
-	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
 	"github.com/pkg/errors"
@@ -38,39 +37,6 @@ import "C"
 func VerifyBatchRepr(
 	repr []byte, start, end engine.MVCCKey, nowNanos int64,
 ) (enginepb.MVCCStats, error) {
-	// We store a 4 byte checksum of each key/value entry in the value. Make
-	// sure the all ones in this BatchRepr validate.
-	//
-	// TODO(dan): After a number of hours of trying, I was unable to get a
-	// performant c++ implementation of crc32 ieee, so this verifies the
-	// checksums in go and constructs the MVCCStats in c++. It'd be nice to move
-	// one or the other.
-	{
-		r, err := engine.NewRocksDBBatchReader(repr)
-		if err != nil {
-			return enginepb.MVCCStats{}, errors.Wrapf(err, "verifying key/value checksums")
-		}
-		for r.Next() {
-			switch r.BatchType() {
-			case engine.BatchTypeValue:
-				mvccKey, err := r.MVCCKey()
-				if err != nil {
-					return enginepb.MVCCStats{}, errors.Wrapf(err, "verifying key/value checksums")
-				}
-				v := roachpb.Value{RawBytes: r.Value()}
-				if err := v.Verify(mvccKey.Key); err != nil {
-					return enginepb.MVCCStats{}, err
-				}
-			default:
-				return enginepb.MVCCStats{}, errors.Errorf(
-					"unexpected entry type in batch: %d", r.BatchType())
-			}
-		}
-		if err := r.Error(); err != nil {
-			return enginepb.MVCCStats{}, errors.Wrapf(err, "verifying key/value checksums")
-		}
-	}
-
 	var stats C.MVCCStatsResult
 	if err := statusToError(C.DBBatchReprVerify(
 		goToCSlice(repr), goToCKey(start), goToCKey(end), C.int64_t(nowNanos), &stats,

--- a/pkg/ccl/storageccl/engineccl/rocksdb_test.go
+++ b/pkg/ccl/storageccl/engineccl/rocksdb_test.go
@@ -48,18 +48,4 @@ func TestVerifyBatchRepr(t *testing.T) {
 	if _, err := VerifyBatchRepr(data, keyA, keyB, 0); !testutils.IsError(err, "request range") {
 		t.Fatalf("expected request range error got: %+v", err)
 	}
-
-	// Invalid key/value entry checksum.
-	{
-		var batch engine.RocksDBBatchBuilder
-		key := engine.MVCCKey{Key: []byte("bb"), Timestamp: hlc.Timestamp{WallTime: 1}}
-		value := roachpb.MakeValueFromString("1")
-		value.MustInitChecksum([]byte("foo"))
-		batch.Put(key, value.RawBytes)
-		data := batch.Finish()
-
-		if _, err := VerifyBatchRepr(data, keyB, keyC, 0); !testutils.IsError(err, "invalid checksum") {
-			t.Fatalf("expected 'invalid checksum' error got: %+v", err)
-		}
-	}
 }

--- a/pkg/ccl/storageccl/engineccl/rocksdb_test.go
+++ b/pkg/ccl/storageccl/engineccl/rocksdb_test.go
@@ -54,7 +54,7 @@ func TestVerifyBatchRepr(t *testing.T) {
 		var batch engine.RocksDBBatchBuilder
 		key := engine.MVCCKey{Key: []byte("bb"), Timestamp: hlc.Timestamp{WallTime: 1}}
 		value := roachpb.MakeValueFromString("1")
-		value.InitChecksum([]byte("foo"))
+		value.MustInitChecksum([]byte("foo"))
 		batch.Put(key, value.RawBytes)
 		data := batch.Finish()
 

--- a/pkg/ccl/storageccl/engineccl/sst_iterator.go
+++ b/pkg/ccl/storageccl/engineccl/sst_iterator.go
@@ -17,7 +17,6 @@ import (
 	"github.com/golang/leveldb/table"
 	"github.com/pkg/errors"
 
-	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
 )
 
@@ -40,9 +39,6 @@ type sstIterator struct {
 	// don't think there's a concrete reason that we need to hold a pointer to
 	// it, but may as well.
 	fs db.FileSystem
-
-	// roachpb.Verify k/v pairs on each call to Next()
-	verify bool
 }
 
 var _ engine.SimpleIterator = &sstIterator{}
@@ -63,7 +59,7 @@ func NewSSTIterator(path string) (engine.SimpleIterator, error) {
 // memory. It's compatible with sstables output by engine.RocksDBSstFileWriter,
 // which means the keys are CockroachDB mvcc keys and they each have the RocksDB
 // trailer (of seqno & value type).
-func NewMemSSTIterator(data []byte, verify bool) (engine.SimpleIterator, error) {
+func NewMemSSTIterator(data []byte) (engine.SimpleIterator, error) {
 	fs := memfs.New()
 	const filename = "data.sst"
 	f, err := fs.Create(filename)
@@ -81,7 +77,7 @@ func NewMemSSTIterator(data []byte, verify bool) (engine.SimpleIterator, error) 
 	if err != nil {
 		return nil, err
 	}
-	return &sstIterator{fs: fs, sst: table.NewReader(file, readerOpts), verify: verify}, nil
+	return &sstIterator{fs: fs, sst: table.NewReader(file, readerOpts)}, nil
 }
 
 // Close implements the engine.SimpleIterator interface.
@@ -134,10 +130,6 @@ func (r *sstIterator) Next() {
 	if r.mvccKey, r.err = engine.DecodeKey(key); r.err != nil {
 		r.err = errors.Wrapf(r.err, "decoding key: %s", key)
 		return
-	}
-
-	if r.verify {
-		r.err = roachpb.Value{RawBytes: r.iter.Value()}.Verify(r.mvccKey.Key)
 	}
 }
 

--- a/pkg/ccl/storageccl/engineccl/sst_iterator_test.go
+++ b/pkg/ccl/storageccl/engineccl/sst_iterator_test.go
@@ -100,7 +100,7 @@ func TestSSTIterator(t *testing.T) {
 		runTestSSTIterator(t, iter, allKVs)
 	})
 	t.Run("Mem", func(t *testing.T) {
-		iter, err := NewMemSSTIterator(data, false)
+		iter, err := NewMemSSTIterator(data)
 		if err != nil {
 			t.Fatalf("%+v", err)
 		}

--- a/pkg/ccl/storageccl/import.go
+++ b/pkg/ccl/storageccl/import.go
@@ -195,7 +195,7 @@ func evalImport(ctx context.Context, cArgs batcheval.CommandArgs) (*roachpb.Impo
 			}
 		}
 
-		iter, err := engineccl.NewMemSSTIterator(fileContents, false)
+		iter, err := engineccl.NewMemSSTIterator(fileContents)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/ccl/storageccl/writebatch_test.go
+++ b/pkg/ccl/storageccl/writebatch_test.go
@@ -91,20 +91,6 @@ func TestDBWriteBatch(t *testing.T) {
 			t.Errorf("expected nil, got \"%s\"", result)
 		}
 	}
-
-	// Invalid key/value entry checksum.
-	{
-		var batch engine.RocksDBBatchBuilder
-		key := engine.MVCCKey{Key: []byte("bb"), Timestamp: hlc.Timestamp{WallTime: 1}}
-		value := roachpb.MakeValueFromString("1")
-		value.MustInitChecksum([]byte("foo"))
-		batch.Put(key, value.RawBytes)
-		data := batch.Finish()
-
-		if err := db.WriteBatch(ctx, "b", "c", data); !testutils.IsError(err, "invalid checksum") {
-			t.Fatalf("expected 'invalid checksum' error got: %+v", err)
-		}
-	}
 }
 
 func TestWriteBatchMVCCStats(t *testing.T) {

--- a/pkg/ccl/storageccl/writebatch_test.go
+++ b/pkg/ccl/storageccl/writebatch_test.go
@@ -97,7 +97,7 @@ func TestDBWriteBatch(t *testing.T) {
 		var batch engine.RocksDBBatchBuilder
 		key := engine.MVCCKey{Key: []byte("bb"), Timestamp: hlc.Timestamp{WallTime: 1}}
 		value := roachpb.MakeValueFromString("1")
-		value.InitChecksum([]byte("foo"))
+		value.MustInitChecksum([]byte("foo"))
 		batch.Put(key, value.RawBytes)
 		data := batch.Finish()
 

--- a/pkg/gossip/gossip.go
+++ b/pkg/gossip/gossip.go
@@ -800,9 +800,6 @@ func (g *Gossip) getNodeDescriptorLocked(nodeID roachpb.NodeID) (*roachpb.NodeDe
 
 	// We can't use GetInfoProto here because that method grabs the lock.
 	if i := g.mu.is.getInfo(nodeIDKey); i != nil {
-		if err := i.Value.Verify([]byte(nodeIDKey)); err != nil {
-			return nil, err
-		}
 		nodeDescriptor := &roachpb.NodeDescriptor{}
 		if err := i.Value.GetProto(nodeDescriptor); err != nil {
 			return nil, err
@@ -865,9 +862,6 @@ func (g *Gossip) GetInfo(key string) ([]byte, error) {
 	g.mu.Unlock()
 
 	if i != nil {
-		if err := i.Value.Verify([]byte(key)); err != nil {
-			return nil, err
-		}
 		return i.Value.GetBytes()
 	}
 	return nil, NewKeyNotPresentError(key)

--- a/pkg/kv/transport.go
+++ b/pkg/kv/transport.go
@@ -253,11 +253,6 @@ func (gt *grpcTransport) send(
 		}
 		reply, err := roachpb.NewInternalClient(conn).Batch(ctx, &client.args)
 		if reply != nil {
-			for i := range reply.Responses {
-				if err := reply.Responses[i].GetInner().Verify(client.args.Requests[i].GetInner()); err != nil {
-					log.Error(ctx, err)
-				}
-			}
 			// Import the remotely collected spans, if any.
 			if len(reply.CollectedSpans) != 0 {
 				span := opentracing.SpanFromContext(ctx)

--- a/pkg/roachpb/api.go
+++ b/pkg/roachpb/api.go
@@ -180,8 +180,6 @@ type Response interface {
 	Header() ResponseHeader
 	// SetHeader sets the response header.
 	SetHeader(ResponseHeader)
-	// Verify verifies response integrity, as applicable.
-	Verify(req Request) error
 }
 
 // combinable is implemented by response types whose corresponding
@@ -352,46 +350,6 @@ func (*NoopResponse) Header() ResponseHeader { return ResponseHeader{} }
 
 // SetHeader implements the Response interface.
 func (*NoopResponse) SetHeader(_ ResponseHeader) {}
-
-// Verify implements the Response interface for ResopnseHeader with a
-// default noop. Individual response types should override this method
-// if they contain checksummed data which can be verified.
-func (rh *ResponseHeader) Verify(req Request) error {
-	return nil
-}
-
-// Verify verifies the integrity of the get response value.
-func (gr *GetResponse) Verify(req Request) error {
-	if gr.Value != nil {
-		return gr.Value.Verify(req.Header().Key)
-	}
-	return nil
-}
-
-// Verify verifies the integrity of every value returned in the scan.
-func (sr *ScanResponse) Verify(req Request) error {
-	for _, kv := range sr.Rows {
-		if err := kv.Value.Verify(kv.Key); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-// Verify verifies the integrity of every value returned in the reverse scan.
-func (sr *ReverseScanResponse) Verify(req Request) error {
-	for _, kv := range sr.Rows {
-		if err := kv.Value.Verify(kv.Key); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-// Verify implements the Response interface.
-func (*NoopResponse) Verify(_ Request) error {
-	return nil
-}
 
 // GetInner returns the Request contained in the union.
 func (ru RequestUnion) GetInner() Request {

--- a/pkg/roachpb/data.go
+++ b/pkg/roachpb/data.go
@@ -283,22 +283,6 @@ func (v *Value) ClearChecksum() {
 	v.setChecksum(0)
 }
 
-// Verify verifies the value's Checksum matches a newly-computed
-// checksum of the value's contents. If the value's Checksum is not
-// set the verification is a noop.
-func (v Value) Verify(key []byte) error {
-	if n := len(v.RawBytes); n > 0 && n < headerSize {
-		return fmt.Errorf("%s: invalid header size: %d", Key(key), n)
-	}
-	if sum := v.checksum(); sum != 0 {
-		if computedSum := v.computeChecksum(key); computedSum != sum {
-			return fmt.Errorf("%s: invalid checksum (%x) value [% x]",
-				Key(key), computedSum, v.RawBytes)
-		}
-	}
-	return nil
-}
-
 // ShallowClone returns a shallow clone of the receiver.
 func (v *Value) ShallowClone() *Value {
 	if v == nil {

--- a/pkg/roachpb/data_test.go
+++ b/pkg/roachpb/data_test.go
@@ -229,7 +229,7 @@ func TestValueChecksumEmpty(t *testing.T) {
 func TestValueChecksumWithBytes(t *testing.T) {
 	k := []byte("key")
 	v := MakeValueFromString("abc")
-	v.InitChecksum(k)
+	v.MustInitChecksum(k)
 	if err := v.Verify(k); err != nil {
 		t.Error(err)
 	}
@@ -245,7 +245,7 @@ func TestValueChecksumWithBytes(t *testing.T) {
 	}
 	// Test ClearChecksum and reinitialization of checksum.
 	v.ClearChecksum()
-	v.InitChecksum(k)
+	v.MustInitChecksum(k)
 	if err := v.Verify(k); err != nil {
 		t.Error(err)
 	}

--- a/pkg/roachpb/data_test.go
+++ b/pkg/roachpb/data_test.go
@@ -16,6 +16,7 @@ package roachpb
 
 import (
 	"bytes"
+	"fmt"
 	"math"
 	"math/rand"
 	"reflect"
@@ -210,18 +211,38 @@ func TestIsPrev(t *testing.T) {
 	}
 }
 
+// TestingVerify verifies the value's Checksum matches a newly-computed
+// checksum of the value's contents. If the value's Checksum is not
+// set the verification is a noop.
+//
+// This method is used only to test Value.MustInitChecksum. The Value type
+// no longer exposes a method to verify its checksum because Value checksums
+// are almost never written anymore and Value.InitChecksum is now a no-op.
+func (v Value) TestingVerify(key []byte) error {
+	if n := len(v.RawBytes); n > 0 && n < headerSize {
+		return fmt.Errorf("%s: invalid header size: %d", Key(key), n)
+	}
+	if sum := v.checksum(); sum != 0 {
+		if computedSum := v.computeChecksum(key); computedSum != sum {
+			return fmt.Errorf("%s: invalid checksum (%x) value [% x]",
+				Key(key), computedSum, v.RawBytes)
+		}
+	}
+	return nil
+}
+
 func TestValueChecksumEmpty(t *testing.T) {
 	k := []byte("key")
 	v := Value{}
 	// Before initializing checksum, always works.
-	if err := v.Verify(k); err != nil {
+	if err := v.TestingVerify(k); err != nil {
 		t.Error(err)
 	}
-	if err := v.Verify([]byte("key2")); err != nil {
+	if err := v.TestingVerify([]byte("key2")); err != nil {
 		t.Error(err)
 	}
-	v.InitChecksum(k)
-	if err := v.Verify(k); err != nil {
+	v.MustInitChecksum(k)
+	if err := v.TestingVerify(k); err != nil {
 		t.Error(err)
 	}
 }
@@ -230,23 +251,23 @@ func TestValueChecksumWithBytes(t *testing.T) {
 	k := []byte("key")
 	v := MakeValueFromString("abc")
 	v.MustInitChecksum(k)
-	if err := v.Verify(k); err != nil {
+	if err := v.TestingVerify(k); err != nil {
 		t.Error(err)
 	}
 	// Try a different key; should fail.
-	if err := v.Verify([]byte("key2")); err == nil {
+	if err := v.TestingVerify([]byte("key2")); err == nil {
 		t.Error("expected checksum verification failure on different key")
 	}
 	// Mess with the value. In order to corrupt the data for testing purposes we
 	// have to ensure we overwrite the data without touching the checksum.
 	copy(v.RawBytes[headerSize:], "cba")
-	if err := v.Verify(k); err == nil {
+	if err := v.TestingVerify(k); err == nil {
 		t.Error("expected checksum verification failure on different value")
 	}
 	// Test ClearChecksum and reinitialization of checksum.
 	v.ClearChecksum()
 	v.MustInitChecksum(k)
-	if err := v.Verify(k); err != nil {
+	if err := v.TestingVerify(k); err != nil {
 		t.Error(err)
 	}
 }

--- a/pkg/storage/engine/mvcc.go
+++ b/pkg/storage/engine/mvcc.go
@@ -817,9 +817,6 @@ func mvccGetInternal(
 	if meta.IsInline() {
 		value := &buf.value
 		*value = roachpb.Value{RawBytes: meta.RawBytes}
-		if err := value.Verify(metaKey.Key); err != nil {
-			return nil, nil, safeValue, err
-		}
 		return value, nil, safeValue, nil
 	}
 	var ignoredIntents []roachpb.Intent
@@ -933,9 +930,6 @@ func mvccGetInternal(
 		value.RawBytes = iter.Value()
 	}
 	value.Timestamp = unsafeKey.Timestamp
-	if err := value.Verify(metaKey.Key); err != nil {
-		return nil, nil, safeValue, err
-	}
 	return value, ignoredIntents, allowedSafety, nil
 }
 

--- a/pkg/storage/stateloader/stateloader.go
+++ b/pkg/storage/stateloader/stateloader.go
@@ -350,7 +350,15 @@ func (rsl StateLoader) LoadMVCCStats(
 func (rsl StateLoader) SetMVCCStats(
 	ctx context.Context, eng engine.ReadWriter, newMS *enginepb.MVCCStats,
 ) error {
-	return engine.MVCCPutProto(ctx, eng, nil, rsl.RangeStatsKey(), hlc.Timestamp{}, nil, newMS)
+	key := rsl.RangeStatsKey()
+	value := roachpb.Value{}
+	if err := value.SetProto(newMS); err != nil {
+		return err
+	}
+	// We're beneath Raft and need to maintain strict consistency on this key
+	// because it is replicated, so we must always initialize the checksum.
+	value.MustInitChecksum(key)
+	return engine.MVCCPut(ctx, eng, nil /* ms */, key, hlc.Timestamp{}, value, nil /* txn */)
 }
 
 // The rest is not technically part of ReplicaState.

--- a/pkg/storage/track_raft_protos.go
+++ b/pkg/storage/track_raft_protos.go
@@ -32,6 +32,20 @@ func funcName(f interface{}) string {
 	return runtime.FuncForPC(reflect.ValueOf(f).Pointer()).Name()
 }
 
+func forCallers(fn func(runtime.Frame) bool) {
+	var pcs [256]uintptr
+	if numCallers := runtime.Callers(1, pcs[:]); numCallers == len(pcs) {
+		panic(fmt.Sprintf("number of callers %d might have exceeded slice size %d", numCallers, len(pcs)))
+	}
+	frames := runtime.CallersFrames(pcs[:])
+	for {
+		f, more := frames.Next()
+		if !fn(f) || !more {
+			return
+		}
+	}
+}
+
 // TrackRaftProtos instruments proto marshaling to track protos which are
 // marshaled downstream of raft. It returns a function that removes the
 // instrumentation and returns the list of downstream-of-raft protos.
@@ -40,13 +54,26 @@ func TrackRaftProtos() func() []reflect.Type {
 	processRaftFunc := funcName((*Replica).processRaftCommand)
 	// We only need to track protos that could cause replica divergence
 	// by being written to disk downstream of raft.
-	whitelist := []string{
+	marshalWhitelist := []string{
 		// Some raft operations trigger gossip, but we don't require
 		// strict consistency there.
 		funcName((*gossip.Gossip).AddInfoProto),
 		// Replica destroyed errors are written to disk, but they are
 		// deliberately per-replica values.
 		funcName((stateloader.StateLoader).SetReplicaDestroyedError),
+	}
+	// We only need to track checksum computations for values that could
+	// cause replica divergence by being written to disk downstream of raft.
+	checksumWhitelist := []string{
+		// Some raft operations trigger gossip, but we don't require
+		// strict consistency there.
+		funcName((*gossip.Gossip).AddInfo),
+		// Replica destroyed errors are written to disk, but they are
+		// deliberately per-replica values.
+		funcName((stateloader.StateLoader).SetReplicaDestroyedError),
+		// HardState is unreplicated, so we don't require strict
+		// consistency on its value.
+		funcName((stateloader.StateLoader).SetHardState),
 	}
 
 	belowRaftProtos := struct {
@@ -81,39 +108,41 @@ func TrackRaftProtos() func() []reflect.Type {
 			return
 		}
 
-		var pcs [256]uintptr
-		if numCallers := runtime.Callers(0, pcs[:]); numCallers == len(pcs) {
-			panic(fmt.Sprintf("number of callers %d might have exceeded slice size %d", numCallers, len(pcs)))
-		}
-		frames := runtime.CallersFrames(pcs[:])
-		for {
-			f, more := frames.Next()
-
-			whitelisted := false
-			for _, s := range whitelist {
+		forCallers(func(f runtime.Frame) bool {
+			for _, s := range marshalWhitelist {
 				if strings.Contains(f.Function, s) {
-					whitelisted = true
-					break
+					return false
 				}
-			}
-			if whitelisted {
-				break
 			}
 
 			if strings.Contains(f.Function, processRaftFunc) {
 				belowRaftProtos.Lock()
 				belowRaftProtos.inner[t] = struct{}{}
 				belowRaftProtos.Unlock()
-				break
+				return false
 			}
-			if !more {
-				break
+			return true
+		})
+	}
+
+	roachpb.ChecksumInterceptor = func(v *roachpb.Value) {
+		forCallers(func(f runtime.Frame) bool {
+			for _, s := range checksumWhitelist {
+				if strings.Contains(f.Function, s) {
+					return false
+				}
 			}
-		}
+
+			if strings.Contains(f.Function, processRaftFunc) {
+				panic(fmt.Sprintf("unexpected below raft checksum computation on value %v", v))
+			}
+			return true
+		})
 	}
 
 	return func() []reflect.Type {
 		protoutil.Interceptor = func(_ protoutil.Message) {}
+		roachpb.ChecksumInterceptor = func(_ *roachpb.Value) {}
 
 		belowRaftProtos.Lock()
 		types := make([]reflect.Type, 0, len(belowRaftProtos.inner))


### PR DESCRIPTION
Fixes #21435.

This change disables roachpb.Value checksum computation, leaving
the checksum field blank on roachpb.Values.

See https://github.com/cockroachdb/cockroach/issues/21435#issuecomment-358389164
for details on the measured performance improvement from this change.

Release note (performance improvement): Unnecessary value
checksums are no longer computed, speeding up database writes.