### PR TITLE
nightly: add two TPCC tests

### DIFF
--- a/pkg/nightly/nightly_test.go
+++ b/pkg/nightly/nightly_test.go
@@ -106,9 +106,11 @@ func TestSingleDC(t *testing.T) {
 	// clusters (# of machines in each locality) are going to generalize. For now,
 	// just hardcode what we had before.
 	for testName, testCmd := range map[string]string{
-		"kv0":    "./workload run kv --init --read-percent=0 --splits=1000 --concurrency=384 --duration=10m",
-		"kv95":   "./workload run kv --init --read-percent=95 --splits=1000 --concurrency=384 --duration=10m",
-		"splits": "./workload run kv --init --read-percent=0 --splits=100000 --concurrency=384 --max-ops=1 --duration=10m",
+		"kv0":     "./workload run kv --init --read-percent=0 --splits=1000 --concurrency=384 --duration=10m",
+		"kv95":    "./workload run kv --init --read-percent=95 --splits=1000 --concurrency=384 --duration=10m",
+		"splits":  "./workload run kv --init --read-percent=0 --splits=100000 --concurrency=384 --max-ops=1 --duration=10m",
+		"tpcc_w1": "./workload run tpcc --init --warehouses=1 --wait=false --concurrency=384 --duration=10m",
+		"tpmc_w1": "./workload run tpcc --init --warehouses=1 --concurrency=10 --duration=10m",
 	} {
 		testName, testCmd := testName, testCmd
 		t.Run(testName, func(t *testing.T) {

--- a/pkg/workload/tpcc/worker.go
+++ b/pkg/workload/tpcc/worker.go
@@ -111,6 +111,11 @@ func initializeMix(config *tpcc) error {
 }
 
 func (w *worker) run() error {
+	// TODO(dan): Remove this when the real check in Hooks.Validate is added.
+	if w.config.doWaits && w.warehouse >= w.config.warehouses {
+		return errors.New(`--wait=true expects 10 workers per warehouse`)
+	}
+
 	transactionType := rand.Intn(w.config.totalWeight)
 	weightSum := 0
 	var t tx


### PR DESCRIPTION
There's still some work to be done on the tpmC version of the test and
it's only one warehouse for now, but I figured it'd be good to get these
running.

Release note: None