### PR TITLE
sql: fix empty plan columns of sequenceSelectNode

### DIFF
--- a/pkg/sql/data_source.go
+++ b/pkg/sql/data_source.go
@@ -530,20 +530,7 @@ func (p *planner) getSequenceSource(
 	}
 	return planDataSource{
 		plan: node,
-		info: sqlbase.NewSourceInfoForSingleTable(tn, []sqlbase.ResultColumn{
-			{
-				Name: "last_value",
-				Typ:  types.Int,
-			},
-			{
-				Name: "log_cnt",
-				Typ:  types.Int,
-			},
-			{
-				Name: "is_called",
-				Typ:  types.Bool,
-			},
-		}),
+		info: sqlbase.NewSourceInfoForSingleTable(tn, sequenceSelectColumns),
 	}, nil
 }
 

--- a/pkg/sql/logictest/testdata/logic_test/sequences
+++ b/pkg/sql/logictest/testdata/logic_test/sequences
@@ -165,12 +165,11 @@ SELECT last_value FROM select_test
 statement error pq: column name "foo" not found
 SELECT foo from select_test
 
-query TTT colnames
-EXPLAIN SELECT * FROM select_test
+query TITTTTT colnames
+EXPLAIN (PLAN, METADATA) SELECT * FROM select_test
 ----
-Tree                  Field  Description
-render                ·      ·
- └── sequence select  ·      ·
+Tree             Level  Type             Field  Description  Columns                           Ordering
+sequence select  0      sequence select  ·      ·            (last_value, log_cnt, is_called)  ·
 
 # USING THE `nextval` AND `currval` FUNCTIONS
 

--- a/pkg/sql/plan_columns.go
+++ b/pkg/sql/plan_columns.go
@@ -97,6 +97,8 @@ func getPlanColumns(plan planNode, mut bool) sqlbase.ResultColumns {
 		return n.getColumns(mut, splitNodeColumns)
 	case *showTraceReplicaNode:
 		return n.getColumns(mut, showTraceReplicaColumns)
+	case *sequenceSelectNode:
+		return n.getColumns(mut, sequenceSelectColumns)
 
 	// Nodes using the RETURNING helper.
 	case *deleteNode:

--- a/pkg/sql/sequence_select.go
+++ b/pkg/sql/sequence_select.go
@@ -18,11 +18,14 @@ import (
 	"context"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/pkg/errors"
 )
 
 type sequenceSelectNode struct {
+	optColumnsSlot
+
 	desc *sqlbase.TableDescriptor
 
 	val  int64
@@ -65,3 +68,18 @@ func (ss *sequenceSelectNode) Values() tree.Datums {
 }
 
 func (ss *sequenceSelectNode) Close(ctx context.Context) {}
+
+var sequenceSelectColumns = sqlbase.ResultColumns{
+	{
+		Name: `last_value`,
+		Typ:  types.Int,
+	},
+	{
+		Name: `log_cnt`,
+		Typ:  types.Int,
+	},
+	{
+		Name: `is_called`,
+		Typ:  types.Bool,
+	},
+}


### PR DESCRIPTION
Related to #22494

Release note (bug fix): fixed empty plan columns of sequenceSelectNode