### PR TITLE
sql: error when evaluating column backfill needing planner

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/alter_table
+++ b/pkg/sql/logictest/testdata/logic_test/alter_table
@@ -549,6 +549,20 @@ SELECT a,b,f FROM add_default
 statement error duplicate key value .* violates unique constraint \"add_default_g_key\"
 ALTER TABLE add_default ADD g INT UNIQUE DEFAULT 1
 
+# various default evaluation errors
+
+statement ok
+CREATE SEQUENCE initial_seq
+
+statement error cannot backfill such sequence operation
+ALTER TABLE add_default ADD g INT DEFAULT nextval('initial_seq')
+
+statement error cannot backfill such evaluated expression
+ALTER TABLE add_default ADD g OID DEFAULT 'foo'::regclass::oid
+
+statement error cannot backfill such evaluated expression
+ALTER TABLE add_default ADD g INT DEFAULT 'foo'::regtype::INT
+
 # Multiple columns can be added at once with heterogeneous DEFAULT usage
 statement ok
 CREATE TABLE d (a INT PRIMARY KEY)

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -1032,7 +1032,7 @@ CockroachDB supports the following flags:
 			Impure:     true,
 			Fn: func(evalCtx *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
 				name := tree.MustBeDString(args[0])
-				qualifiedName, err := evalCtx.Planner.ParseQualifiedTableName(evalCtx.Ctx(), string(name))
+				qualifiedName, err := evalCtx.Sequence.ParseQualifiedTableName(evalCtx.Ctx(), string(name))
 				if err != nil {
 					return nil, err
 				}
@@ -1054,7 +1054,7 @@ CockroachDB supports the following flags:
 			Impure:     true,
 			Fn: func(evalCtx *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
 				name := tree.MustBeDString(args[0])
-				qualifiedName, err := evalCtx.Planner.ParseQualifiedTableName(evalCtx.Ctx(), string(name))
+				qualifiedName, err := evalCtx.Sequence.ParseQualifiedTableName(evalCtx.Ctx(), string(name))
 				if err != nil {
 					return nil, err
 				}
@@ -1095,7 +1095,7 @@ CockroachDB supports the following flags:
 			Impure:     true,
 			Fn: func(evalCtx *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
 				name := tree.MustBeDString(args[0])
-				qualifiedName, err := evalCtx.Planner.ParseQualifiedTableName(evalCtx.Ctx(), string(name))
+				qualifiedName, err := evalCtx.Sequence.ParseQualifiedTableName(evalCtx.Ctx(), string(name))
 				if err != nil {
 					return nil, err
 				}
@@ -1119,7 +1119,7 @@ CockroachDB supports the following flags:
 			Impure:     true,
 			Fn: func(evalCtx *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
 				name := tree.MustBeDString(args[0])
-				qualifiedName, err := evalCtx.Planner.ParseQualifiedTableName(evalCtx.Ctx(), string(name))
+				qualifiedName, err := evalCtx.Sequence.ParseQualifiedTableName(evalCtx.Ctx(), string(name))
 				if err != nil {
 					return nil, err
 				}

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -2058,18 +2058,23 @@ func (e *MultipleResultsError) Error() string {
 	return fmt.Sprintf("%s: unexpected multiple results", e.SQL)
 }
 
-// EvalPlanner is a limited planner that can be used from EvalContext.
-type EvalPlanner interface {
-	// QueryRow executes a SQL query string where exactly 1 result row is
-	// expected and returns that row.
-	QueryRow(ctx context.Context, sql string, args ...interface{}) (Datums, error)
-
+// EvalDatabase consists of functions that reference the session database
+// and is to be used from EvalContext.
+type EvalDatabase interface {
 	// ParseQualifiedTableName parses a SQL string of the form
 	// `[ database_name . ] table_name [ @ index_name ]`.
 	// If the database name is not given, it uses the search path to find it, and
 	// sets it on the returned TableName.
 	// It returns an error if the table doesn't exist.
 	ParseQualifiedTableName(ctx context.Context, sql string) (*TableName, error)
+}
+
+// EvalPlanner is a limited planner that can be used from EvalContext.
+type EvalPlanner interface {
+	EvalDatabase
+	// QueryRow executes a SQL query string where exactly 1 result row is
+	// expected and returns that row.
+	QueryRow(ctx context.Context, sql string, args ...interface{}) (Datums, error)
 
 	// ParseType parses a column type.
 	ParseType(sql string) (coltypes.CastTargetType, error)
@@ -2081,6 +2086,7 @@ type EvalPlanner interface {
 // SequenceOperators is used for various sql related functions that can
 // be used from EvalContext.
 type SequenceOperators interface {
+	EvalDatabase
 	// IncrementSequence increments the given sequence and returns the result.
 	// It returns an error if the given name is not a sequence.
 	// The caller must ensure that seqName is fully qualified already.

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -2064,10 +2064,6 @@ type EvalPlanner interface {
 	// expected and returns that row.
 	QueryRow(ctx context.Context, sql string, args ...interface{}) (Datums, error)
 
-	// QualifyWithDatabase resolves a possibly unqualified table name into a
-	// normalized table name that is qualified by database.
-	QualifyWithDatabase(ctx context.Context, t *NormalizableTableName) (*TableName, error)
-
 	// ParseQualifiedTableName parses a SQL string of the form
 	// `[ database_name . ] table_name [ @ index_name ]`.
 	// If the database name is not given, it uses the search path to find it, and

--- a/pkg/sql/sequence.go
+++ b/pkg/sql/sequence.go
@@ -256,7 +256,7 @@ func maybeAddSequenceDependencies(
 	}
 	var seqDescs []*sqlbase.TableDescriptor
 	for _, seqName := range seqNames {
-		parsedSeqName, err := evalCtx.Planner.ParseQualifiedTableName(ctx, seqName)
+		parsedSeqName, err := evalCtx.Sequence.ParseQualifiedTableName(ctx, seqName)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/sql/table.go
+++ b/pkg/sql/table.go
@@ -1014,7 +1014,7 @@ func resolveTableNameFromID(
 	return tree.ErrString(tn)
 }
 
-// ParseQualifiedTableName implements the tree.EvalPlanner interface.
+// ParseQualifiedTableName implements the tree.EvalDatabase interface.
 func (p *planner) ParseQualifiedTableName(
 	ctx context.Context, sql string,
 ) (*tree.TableName, error) {


### PR DESCRIPTION
One could argue that we should implement these methods rather than return errors. But that can't be done in the 2.0 timeframe.