### PR TITLE
sql: show column names in computed column errors

### DIFF
--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -1159,6 +1159,8 @@ func (p *planner) makeTableDesc(
 // that can be both type-checked and examined for variable expressions.
 type dummyColumnItem struct {
 	typ types.T
+	// name is only used for error-reporting.
+	name tree.Name
 }
 
 // String implements the Stringer interface.
@@ -1168,9 +1170,7 @@ func (d *dummyColumnItem) String() string {
 
 // Format implements the NodeFormatter interface.
 func (d *dummyColumnItem) Format(ctx *tree.FmtCtx) {
-	ctx.WriteByte('<')
-	ctx.WriteString(d.typ.String())
-	ctx.WriteByte('>')
+	d.name.Format(ctx)
 }
 
 // Walk implements the Expr interface.
@@ -1372,7 +1372,7 @@ func replaceVars(
 		}
 		colIDs[col.ID] = struct{}{}
 		// Convert to a dummy node of the correct type.
-		return nil, false, &dummyColumnItem{col.Type.ToDatumType()}
+		return nil, false, &dummyColumnItem{typ: col.Type.ToDatumType(), name: c.ColumnName}
 	})
 	return newExpr, colIDs, err
 }

--- a/pkg/sql/logictest/testdata/logic_test/check_constraints
+++ b/pkg/sql/logictest/testdata/logic_test/check_constraints
@@ -79,6 +79,9 @@ CREATE TABLE t4 (a INT, b INT CHECK (EXISTS (SELECT * FROM t2)))
 statement error pq: expected CHECK expression to have type bool, but '1' has type int
 CREATE TABLE t4 (a INT CHECK(1))
 
+statement error pq: expected CHECK expression to have type bool, but 'a' has type int
+CREATE TABLE t4 (a INT CHECK(a))
+
 # Function calls in CHECK are okay.
 statement ok
 CREATE TABLE calls_func (a INT CHECK(abs(a) < 2))

--- a/pkg/sql/logictest/testdata/logic_test/computed
+++ b/pkg/sql/logictest/testdata/logic_test/computed
@@ -212,7 +212,7 @@ CREATE TABLE y (
 
 # We utilize the types from other columns.
 
-statement error expected computed column expression to have type int, but .* has type string
+statement error expected computed column expression to have type int, but 'a' has type string
 CREATE TABLE y (
   a STRING,
   b INT AS (a) STORED


### PR DESCRIPTION
Also affects CHECK constraints.

Release note (sql change): Computed columns and CHECK constraints now correctly
report column names in the case of a type error.