### PR TITLE
server: make maximum max offset explicit on error

### DIFF
--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -102,7 +102,7 @@ func (mo *MaxOffsetType) Set(v string) error {
 		return err
 	}
 	if nanos > maximumMaxClockOffset {
-		return errors.Errorf("%s is not a valid MaxOffset", v)
+		return errors.Errorf("%s is not a valid max offset, must be less than %v.", v, maximumMaxClockOffset)
 	}
 	*mo = MaxOffsetType(nanos)
 	return nil


### PR DESCRIPTION
Release note: None

This tripped up a user on gitter, who wasn't sure what the maximum was, and had to binary search for it.