### PR TITLE
opt: Add some scalar normalization rules

### DIFF
--- a/pkg/sql/opt/build/builder.go
+++ b/pkg/sql/opt/build/builder.go
@@ -54,10 +54,10 @@ var comparisonOpMap = [...]binaryFactoryFunc{
 	tree.NotRegIMatch:      (opt.Factory).ConstructNotRegIMatch,
 	tree.IsDistinctFrom:    (opt.Factory).ConstructIsNot,
 	tree.IsNotDistinctFrom: (opt.Factory).ConstructIs,
+	tree.Contains:          (opt.Factory).ConstructContains,
 
 	// TODO(rytaft): NYI, but these need to be nil to avoid an index out of
 	// range exception if any of these functions are used.
-	tree.Contains:       nil,
 	tree.ContainedBy:    nil,
 	tree.JSONExists:     nil,
 	tree.JSONSomeExists: nil,
@@ -309,10 +309,10 @@ func (b *Builder) buildScalar(scalar tree.TypedExpr, inScope *scope) (out opt.Gr
 		return b.factory.ConstructVariable(b.factory.InternPrivate(t.index))
 
 	case *tree.AndExpr:
-		out = b.factory.ConstructAnd(
-			b.buildScalar(t.TypedLeft(), inScope),
-			b.buildScalar(t.TypedRight(), inScope),
-		)
+		left := b.buildScalar(t.TypedLeft(), inScope)
+		right := b.buildScalar(t.TypedRight(), inScope)
+		conditions := b.factory.InternList([]opt.GroupID{left, right})
+		out = b.factory.ConstructAnd(conditions)
 
 	case *tree.BinaryExpr:
 		out = binaryOpMap[t.Operator](b.factory,
@@ -321,18 +321,27 @@ func (b *Builder) buildScalar(scalar tree.TypedExpr, inScope *scope) (out opt.Gr
 		)
 
 	case *tree.ComparisonExpr:
-		// TODO(rytaft): remove this check when we are confident that all operators
-		// are included in comparisonOpMap.
-		if comparisonOpMap[t.Operator] == nil {
-			panic(errorf("not yet implemented: operator %s", t.Operator.String()))
-		}
+		left := b.buildScalar(t.TypedLeft(), inScope)
+		right := b.buildScalar(t.TypedRight(), inScope)
+		fn := comparisonOpMap[t.Operator]
+		if fn != nil {
+			// Most comparison ops map directly to a factory method.
+			out = fn(b.factory, left, right)
+		} else {
+			// Several comparison ops need special handling.
+			// TODO(andyk): handle t.SubOperator. Do this by mapping Any, Some,
+			// and All to various formulations of the opt Exists operator.
+			switch t.Operator {
+			case tree.ContainedBy:
+				// This is just syntatic sugar that reverses the operands.
+				out = b.factory.ConstructContains(right, left)
 
-		// TODO(andyk): handle t.SubOperator. Do this by mapping Any, Some, and
-		// All to various formulations of the opt Exists operator.
-		out = comparisonOpMap[t.Operator](b.factory,
-			b.buildScalar(t.TypedLeft(), inScope),
-			b.buildScalar(t.TypedRight(), inScope),
-		)
+			default:
+				// TODO(rytaft): remove this check when we are confident that
+				// all operators are included in comparisonOpMap.
+				panic(errorf("not yet implemented: operator %s", t.Operator.String()))
+			}
+		}
 
 	case *tree.DTuple:
 		list := make([]opt.GroupID, len(t.D))
@@ -353,10 +362,10 @@ func (b *Builder) buildScalar(scalar tree.TypedExpr, inScope *scope) (out opt.Gr
 		out = b.factory.ConstructNot(b.buildScalar(t.TypedInnerExpr(), inScope))
 
 	case *tree.OrExpr:
-		out = b.factory.ConstructOr(
-			b.buildScalar(t.TypedLeft(), inScope),
-			b.buildScalar(t.TypedRight(), inScope),
-		)
+		left := b.buildScalar(t.TypedLeft(), inScope)
+		right := b.buildScalar(t.TypedRight(), inScope)
+		conditions := b.factory.InternList([]opt.GroupID{left, right})
+		out = b.factory.ConstructOr(conditions)
 
 	case *tree.ParenExpr:
 		out = b.buildScalar(t.TypedInnerExpr(), inScope)
@@ -379,7 +388,14 @@ func (b *Builder) buildScalar(scalar tree.TypedExpr, inScope *scope) (out opt.Gr
 	// tree.Datum case needs to occur after *tree.Placeholder which implements
 	// Datum.
 	case tree.Datum:
-		out = b.factory.ConstructConst(b.factory.InternPrivate(t))
+		// Map True/False datums to True/False operator.
+		if t == tree.DBoolTrue {
+			out = b.factory.ConstructTrue()
+		} else if t == tree.DBoolFalse {
+			out = b.factory.ConstructFalse()
+		} else {
+			out = b.factory.ConstructConst(b.factory.InternPrivate(t))
+		}
 
 	default:
 		panic(errorf("not yet implemented: scalar expr: %T", scalar))

--- a/pkg/sql/opt/build/builder_test.go
+++ b/pkg/sql/opt/build/builder_test.go
@@ -117,7 +117,7 @@ func TestBuilder(t *testing.T) {
 						d.Fatalf(t, "%v", err)
 					}
 
-					o := xform.NewOptimizer(catalog, 0 /* maxSteps */)
+					o := xform.NewOptimizer(catalog, xform.OptimizeNone)
 					b := NewBuilder(ctx, o.Factory(), stmt)
 					root, props, err := b.Build()
 					if err != nil {
@@ -132,7 +132,7 @@ func TestBuilder(t *testing.T) {
 						d.Fatalf(t, "%v", err)
 					}
 
-					o := xform.NewOptimizer(catalog, 0 /* maxSteps */)
+					o := xform.NewOptimizer(catalog, xform.OptimizeNone)
 					b := newScalarBuilder(o.Factory(), &iVarHelper)
 
 					group, err := buildScalar(b, typedExpr)

--- a/pkg/sql/opt/build/testdata/aggregate
+++ b/pkg/sql/opt/build/testdata/aggregate
@@ -41,9 +41,9 @@ group-by
       ├── function: variance [type=NULL]
       │    └── const: 1 [type=int]
       ├── function: bool_and [type=NULL]
-      │    └── const: true [type=bool]
+      │    └── true [type=bool]
       ├── function: bool_and [type=NULL]
-      │    └── const: false [type=bool]
+      │    └── false [type=bool]
       └── function: xor_agg [type=NULL]
            └── const: '\x01' [type=bytes]
 
@@ -990,9 +990,9 @@ group-by
  ├── groupings
  └── aggregations
       ├── function: max [type=NULL]
-      │    └── const: true [type=bool]
+      │    └── true [type=bool]
       └── function: min [type=NULL]
-           └── const: true [type=bool]
+           └── true [type=bool]
 
 exec-ddl
 CREATE TABLE t.ab (

--- a/pkg/sql/opt/build/testdata/having
+++ b/pkg/sql/opt/build/testdata/having
@@ -26,7 +26,7 @@ project
  │    │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
  │    │    ├── groupings
  │    │    └── aggregations
- │    └── const: true [type=bool]
+ │    └── true [type=bool]
  └── projections
       └── const: 3 [type=int]
 

--- a/pkg/sql/opt/build/testdata/project
+++ b/pkg/sql/opt/build/testdata/project
@@ -80,7 +80,7 @@ project
       ├── plus [type=int]
       │    ├── variable: a.x [type=int]
       │    └── const: 3 [type=int]
-      └── const: false [type=bool]
+      └── false [type=bool]
 
 build
 SELECT *, ((x < y) OR x > 1000) FROM t.a
@@ -110,4 +110,4 @@ project
  └── projections
       ├── variable: a.x [type=int]
       ├── variable: a.y [type=float]
-      └── const: true [type=bool]
+      └── true [type=bool]

--- a/pkg/sql/opt/build/testdata/scalar
+++ b/pkg/sql/opt/build/testdata/scalar
@@ -208,10 +208,26 @@ eq [type=bool]
 build-scalar vars=(jsonb)
 @1 @> '{"a":1}'
 ----
-error: not yet implemented: operator @>
+contains [type=bool]
+ ├── variable: @1 [type=jsonb]
+ └── const: '{"a": 1}' [type=jsonb]
 
 
 build-scalar vars=(jsonb)
 '{"a":1}' <@ @1
 ----
-error: not yet implemented: operator <@
+contains [type=bool]
+ ├── variable: @1 [type=jsonb]
+ └── const: '{"a": 1}' [type=jsonb]
+
+
+build-scalar
+TRUE
+----
+true [type=bool]
+
+
+build-scalar
+FALSE
+----
+false [type=bool]

--- a/pkg/sql/opt/exec/build/builder_test.go
+++ b/pkg/sql/opt/exec/build/builder_test.go
@@ -66,7 +66,7 @@ func TestBuild(t *testing.T) {
 			}
 
 			// Build and optimize the opt expression tree.
-			o := xform.NewOptimizer(catalog, 0 /* maxSteps */)
+			o := xform.NewOptimizer(catalog, xform.OptimizeNone)
 			root, props, err := optbuild.NewBuilder(ctx, o.Factory(), stmt).Build()
 			if err != nil {
 				d.Fatalf(t, "BuildOpt: %v", err)

--- a/pkg/sql/opt/ops/scalar.opt
+++ b/pkg/sql/opt/ops/scalar.opt
@@ -81,27 +81,28 @@ define Groupings {
 }
 
 [Scalar]
-define Filters {
-    Conditions ExprList
-}
-
-[Scalar]
 define Exists {
     Input Expr
 }
 
+# And is the boolean conjunction operator that evalutes to true if all of its
+# conditions evaluate to true. If the conditions list is empty, it evalutes to
+# true.
 [Scalar, Boolean]
 define And {
-    Left  Expr
-    Right Expr
+    Conditions ExprList
 }
 
+# Or is the boolean disjunction operator that evalutes to true if any of its
+# conditions evaluate to true. If the conditions list is empty, it evaluates to
+# false.
 [Scalar, Boolean]
 define Or {
-    Left  Expr
-    Right Expr
+    Conditions ExprList
 }
 
+# Not is the boolean negation operator that evaluates to true if its input
+# evalutes to false.
 [Scalar, Boolean]
 define Not {
     Input Expr
@@ -229,12 +230,6 @@ define IsNot {
 
 [Scalar, Comparison]
 define Contains {
-   Left  Expr
-   Right Expr
-}
-
-[Scalar, Comparison]
-define ContainedBy {
    Left  Expr
    Right Expr
 }

--- a/pkg/sql/opt/opt/factory.og.go
+++ b/pkg/sql/opt/opt/factory.og.go
@@ -78,19 +78,24 @@ type Factory interface {
 	// expression, as a *ColList.
 	ConstructGroupings(elems ListID, cols PrivateID) GroupID
 
-	// ConstructFilters constructs an expression for the Filters operator.
-	ConstructFilters(conditions ListID) GroupID
-
 	// ConstructExists constructs an expression for the Exists operator.
 	ConstructExists(input GroupID) GroupID
 
 	// ConstructAnd constructs an expression for the And operator.
-	ConstructAnd(left GroupID, right GroupID) GroupID
+	// And is the boolean conjunction operator that evalutes to true if all of its
+	// conditions evaluate to true. If the conditions list is empty, it evalutes to
+	// true.
+	ConstructAnd(conditions ListID) GroupID
 
 	// ConstructOr constructs an expression for the Or operator.
-	ConstructOr(left GroupID, right GroupID) GroupID
+	// Or is the boolean disjunction operator that evalutes to true if any of its
+	// conditions evaluate to true. If the conditions list is empty, it evaluates to
+	// false.
+	ConstructOr(conditions ListID) GroupID
 
 	// ConstructNot constructs an expression for the Not operator.
+	// Not is the boolean negation operator that evaluates to true if its input
+	// evalutes to false.
 	ConstructNot(input GroupID) GroupID
 
 	// ConstructEq constructs an expression for the Eq operator.
@@ -155,9 +160,6 @@ type Factory interface {
 
 	// ConstructContains constructs an expression for the Contains operator.
 	ConstructContains(left GroupID, right GroupID) GroupID
-
-	// ConstructContainedBy constructs an expression for the ContainedBy operator.
-	ConstructContainedBy(left GroupID, right GroupID) GroupID
 
 	// ConstructBitand constructs an expression for the Bitand operator.
 	ConstructBitand(left GroupID, right GroupID) GroupID

--- a/pkg/sql/opt/opt/operator.go
+++ b/pkg/sql/opt/opt/operator.go
@@ -60,7 +60,6 @@ var ComparisonOpReverseMap = [...]tree.ComparisonOperator{
 	IsOp:           tree.IsNotDistinctFrom,
 	IsNotOp:        tree.IsDistinctFrom,
 	ContainsOp:     tree.Contains,
-	ContainedByOp:  tree.ContainedBy,
 }
 
 // BinaryOpReverseMap maps from an optimizer operator type to a semantic tree

--- a/pkg/sql/opt/opt/operator.og.go
+++ b/pkg/sql/opt/opt/operator.og.go
@@ -50,14 +50,20 @@ const (
 	// expression, as a *ColList.
 	GroupingsOp
 
-	FiltersOp
-
 	ExistsOp
 
+	// AndOp is the boolean conjunction operator that evalutes to true if all of its
+	// conditions evaluate to true. If the conditions list is empty, it evalutes to
+	// true.
 	AndOp
 
+	// OrOp is the boolean disjunction operator that evalutes to true if any of its
+	// conditions evaluate to true. If the conditions list is empty, it evaluates to
+	// false.
 	OrOp
 
+	// NotOp is the boolean negation operator that evaluates to true if its input
+	// evalutes to false.
 	NotOp
 
 	EqOp
@@ -101,8 +107,6 @@ const (
 	IsNotOp
 
 	ContainsOp
-
-	ContainedByOp
 
 	BitandOp
 
@@ -234,9 +238,9 @@ const (
 	NumOperators
 )
 
-const opNames = "unknownsubqueryvariableconsttruefalseplaceholdertupleprojectionsaggregationsgroupingsfiltersexistsandornoteqltgtlegeneinnot-inlikenot-likei-likenot-i-likesimilar-tonot-similar-toreg-matchnot-reg-matchreg-i-matchnot-reg-i-matchisis-notcontainscontained-bybitandbitorbitxorplusminusmultdivfloor-divmodpowconcatl-shiftr-shiftfetch-valfetch-textfetch-val-pathfetch-text-pathunary-plusunary-minusunary-complementfunctionscanvaluesselectprojectinner-joinleft-joinright-joinfull-joinsemi-joinanti-joininner-join-applyleft-join-applyright-join-applyfull-join-applysemi-join-applyanti-join-applygroup-byunionintersectexceptsortpresent"
+const opNames = "unknownsubqueryvariableconsttruefalseplaceholdertupleprojectionsaggregationsgroupingsexistsandornoteqltgtlegeneinnot-inlikenot-likei-likenot-i-likesimilar-tonot-similar-toreg-matchnot-reg-matchreg-i-matchnot-reg-i-matchisis-notcontainsbitandbitorbitxorplusminusmultdivfloor-divmodpowconcatl-shiftr-shiftfetch-valfetch-textfetch-val-pathfetch-text-pathunary-plusunary-minusunary-complementfunctionscanvaluesselectprojectinner-joinleft-joinright-joinfull-joinsemi-joinanti-joininner-join-applyleft-join-applyright-join-applyfull-join-applysemi-join-applyanti-join-applygroup-byunionintersectexceptsortpresent"
 
-var opIndexes = [...]uint32{0, 7, 15, 23, 28, 32, 37, 48, 53, 64, 76, 85, 92, 98, 101, 103, 106, 108, 110, 112, 114, 116, 118, 120, 126, 130, 138, 144, 154, 164, 178, 187, 200, 211, 226, 228, 234, 242, 254, 260, 265, 271, 275, 280, 284, 287, 296, 299, 302, 308, 315, 322, 331, 341, 355, 370, 380, 391, 407, 415, 419, 425, 431, 438, 448, 457, 467, 476, 485, 494, 510, 525, 541, 556, 571, 586, 594, 599, 608, 614, 618, 625}
+var opIndexes = [...]uint32{0, 7, 15, 23, 28, 32, 37, 48, 53, 64, 76, 85, 91, 94, 96, 99, 101, 103, 105, 107, 109, 111, 113, 119, 123, 131, 137, 147, 157, 171, 180, 193, 204, 219, 221, 227, 235, 241, 246, 252, 256, 261, 265, 268, 277, 280, 283, 289, 296, 303, 312, 322, 336, 351, 361, 372, 388, 396, 400, 406, 412, 419, 429, 438, 448, 457, 466, 475, 491, 506, 522, 537, 552, 567, 575, 580, 589, 595, 599, 606}
 
 var ScalarOperators = [...]Operator{
 	SubqueryOp,
@@ -249,7 +253,6 @@ var ScalarOperators = [...]Operator{
 	ProjectionsOp,
 	AggregationsOp,
 	GroupingsOp,
-	FiltersOp,
 	ExistsOp,
 	AndOp,
 	OrOp,
@@ -275,7 +278,6 @@ var ScalarOperators = [...]Operator{
 	IsOp,
 	IsNotOp,
 	ContainsOp,
-	ContainedByOp,
 	BitandOp,
 	BitorOp,
 	BitxorOp,
@@ -329,7 +331,6 @@ var ComparisonOperators = [...]Operator{
 	IsOp,
 	IsNotOp,
 	ContainsOp,
-	ContainedByOp,
 }
 
 var BinaryOperators = [...]Operator{

--- a/pkg/sql/opt/optgen/cmd/optgen/factory_gen.go
+++ b/pkg/sql/opt/optgen/cmd/optgen/factory_gen.go
@@ -319,7 +319,7 @@ func (g *factoryGen) genConstantMatch(
 	// operator. If there are fewer arguments than there are children, then
 	// only the first N children need to be matched.
 	for index, matchArg := range match.Args {
-		fieldName := string(g.compiled.LookupDefine(opName).Fields[index].Name)
+		fieldName := unTitle(string(g.compiled.LookupDefine(opName).Fields[index].Name))
 		g.genMatch(matchArg, fmt.Sprintf("%s.%s()", varName, fieldName), false /* noMatch */)
 	}
 }

--- a/pkg/sql/opt/optgen/cmd/optgen/testdata/factory
+++ b/pkg/sql/opt/optgen/cmd/optgen/testdata/factory
@@ -659,16 +659,16 @@ func (_f *factory) ConstructEq(
 	{
 		_eq := _f.mem.lookupNormExpr(left).asEq()
 		if _eq != nil {
-			_eq2 := _f.mem.lookupNormExpr(_eq.Left()).asEq()
+			_eq2 := _f.mem.lookupNormExpr(_eq.left()).asEq()
 			if _eq2 != nil {
-				_eq3 := _f.mem.lookupNormExpr(_eq.Right()).asEq()
+				_eq3 := _f.mem.lookupNormExpr(_eq.right()).asEq()
 				if _eq3 == nil {
 					_match := false
 					_eq4 := _f.mem.lookupNormExpr(right).asEq()
 					if _eq4 != nil {
-						_eq5 := _f.mem.lookupNormExpr(_eq4.Left()).asEq()
+						_eq5 := _f.mem.lookupNormExpr(_eq4.left()).asEq()
 						if _eq5 != nil {
-							_eq6 := _f.mem.lookupNormExpr(_eq4.Right()).asEq()
+							_eq6 := _f.mem.lookupNormExpr(_eq4.right()).asEq()
 							if _eq6 == nil {
 								_match = true
 							}

--- a/pkg/sql/opt/xform/expr.og.go
+++ b/pkg/sql/opt/xform/expr.og.go
@@ -68,12 +68,6 @@ var childCountLookup = [...]childCountLookupFunc{
 		return 0 + int(groupingsExpr.elems().Length)
 	},
 
-	// FiltersOp
-	func(ev *ExprView) int {
-		filtersExpr := (*filtersExpr)(ev.mem.lookupExpr(ev.loc))
-		return 0 + int(filtersExpr.conditions().Length)
-	},
-
 	// ExistsOp
 	func(ev *ExprView) int {
 		return 1
@@ -81,12 +75,14 @@ var childCountLookup = [...]childCountLookupFunc{
 
 	// AndOp
 	func(ev *ExprView) int {
-		return 2
+		andExpr := (*andExpr)(ev.mem.lookupExpr(ev.loc))
+		return 0 + int(andExpr.conditions().Length)
 	},
 
 	// OrOp
 	func(ev *ExprView) int {
-		return 2
+		orExpr := (*orExpr)(ev.mem.lookupExpr(ev.loc))
+		return 0 + int(orExpr.conditions().Length)
 	},
 
 	// NotOp
@@ -195,11 +191,6 @@ var childCountLookup = [...]childCountLookupFunc{
 	},
 
 	// ContainsOp
-	func(ev *ExprView) int {
-		return 2
-	},
-
-	// ContainedByOp
 	func(ev *ExprView) int {
 		return 2
 	},
@@ -513,17 +504,6 @@ var childGroupLookup = [...]childGroupLookupFunc{
 		}
 	},
 
-	// FiltersOp
-	func(ev *ExprView, n int) opt.GroupID {
-		filtersExpr := (*filtersExpr)(ev.mem.lookupExpr(ev.loc))
-
-		switch n {
-		default:
-			list := ev.mem.lookupList(filtersExpr.conditions())
-			return list[n-0]
-		}
-	},
-
 	// ExistsOp
 	func(ev *ExprView, n int) opt.GroupID {
 		existsExpr := (*existsExpr)(ev.mem.lookupExpr(ev.loc))
@@ -541,12 +521,9 @@ var childGroupLookup = [...]childGroupLookupFunc{
 		andExpr := (*andExpr)(ev.mem.lookupExpr(ev.loc))
 
 		switch n {
-		case 0:
-			return andExpr.left()
-		case 1:
-			return andExpr.right()
 		default:
-			panic("child index out of range")
+			list := ev.mem.lookupList(andExpr.conditions())
+			return list[n-0]
 		}
 	},
 
@@ -555,12 +532,9 @@ var childGroupLookup = [...]childGroupLookupFunc{
 		orExpr := (*orExpr)(ev.mem.lookupExpr(ev.loc))
 
 		switch n {
-		case 0:
-			return orExpr.left()
-		case 1:
-			return orExpr.right()
 		default:
-			panic("child index out of range")
+			list := ev.mem.lookupList(orExpr.conditions())
+			return list[n-0]
 		}
 	},
 
@@ -865,20 +839,6 @@ var childGroupLookup = [...]childGroupLookupFunc{
 			return containsExpr.left()
 		case 1:
 			return containsExpr.right()
-		default:
-			panic("child index out of range")
-		}
-	},
-
-	// ContainedByOp
-	func(ev *ExprView, n int) opt.GroupID {
-		containedByExpr := (*containedByExpr)(ev.mem.lookupExpr(ev.loc))
-
-		switch n {
-		case 0:
-			return containedByExpr.left()
-		case 1:
-			return containedByExpr.right()
 		default:
 			panic("child index out of range")
 		}
@@ -1546,11 +1506,6 @@ var privateLookup = [...]privateLookupFunc{
 		return groupingsExpr.cols()
 	},
 
-	// FiltersOp
-	func(ev *ExprView) opt.PrivateID {
-		return 0
-	},
-
 	// ExistsOp
 	func(ev *ExprView) opt.PrivateID {
 		return 0
@@ -1672,11 +1627,6 @@ var privateLookup = [...]privateLookupFunc{
 	},
 
 	// ContainsOp
-	func(ev *ExprView) opt.PrivateID {
-		return 0
-	},
-
-	// ContainedByOp
 	func(ev *ExprView) opt.PrivateID {
 		return 0
 	},
@@ -1914,7 +1864,6 @@ var isScalarLookup = [...]bool{
 	true,  // ProjectionsOp
 	true,  // AggregationsOp
 	true,  // GroupingsOp
-	true,  // FiltersOp
 	true,  // ExistsOp
 	true,  // AndOp
 	true,  // OrOp
@@ -1940,7 +1889,6 @@ var isScalarLookup = [...]bool{
 	true,  // IsOp
 	true,  // IsNotOp
 	true,  // ContainsOp
-	true,  // ContainedByOp
 	true,  // BitandOp
 	true,  // BitorOp
 	true,  // BitxorOp
@@ -1999,7 +1947,6 @@ var isBooleanLookup = [...]bool{
 	false, // ProjectionsOp
 	false, // AggregationsOp
 	false, // GroupingsOp
-	false, // FiltersOp
 	false, // ExistsOp
 	true,  // AndOp
 	true,  // OrOp
@@ -2025,7 +1972,6 @@ var isBooleanLookup = [...]bool{
 	false, // IsOp
 	false, // IsNotOp
 	false, // ContainsOp
-	false, // ContainedByOp
 	false, // BitandOp
 	false, // BitorOp
 	false, // BitxorOp
@@ -2084,7 +2030,6 @@ var isComparisonLookup = [...]bool{
 	false, // ProjectionsOp
 	false, // AggregationsOp
 	false, // GroupingsOp
-	false, // FiltersOp
 	false, // ExistsOp
 	false, // AndOp
 	false, // OrOp
@@ -2110,7 +2055,6 @@ var isComparisonLookup = [...]bool{
 	true,  // IsOp
 	true,  // IsNotOp
 	true,  // ContainsOp
-	true,  // ContainedByOp
 	false, // BitandOp
 	false, // BitorOp
 	false, // BitxorOp
@@ -2169,7 +2113,6 @@ var isBinaryLookup = [...]bool{
 	false, // ProjectionsOp
 	false, // AggregationsOp
 	false, // GroupingsOp
-	false, // FiltersOp
 	false, // ExistsOp
 	false, // AndOp
 	false, // OrOp
@@ -2195,7 +2138,6 @@ var isBinaryLookup = [...]bool{
 	false, // IsOp
 	false, // IsNotOp
 	false, // ContainsOp
-	false, // ContainedByOp
 	true,  // BitandOp
 	true,  // BitorOp
 	true,  // BitxorOp
@@ -2254,7 +2196,6 @@ var isUnaryLookup = [...]bool{
 	false, // ProjectionsOp
 	false, // AggregationsOp
 	false, // GroupingsOp
-	false, // FiltersOp
 	false, // ExistsOp
 	false, // AndOp
 	false, // OrOp
@@ -2280,7 +2221,6 @@ var isUnaryLookup = [...]bool{
 	false, // IsOp
 	false, // IsNotOp
 	false, // ContainsOp
-	false, // ContainedByOp
 	false, // BitandOp
 	false, // BitorOp
 	false, // BitxorOp
@@ -2339,7 +2279,6 @@ var isRelationalLookup = [...]bool{
 	false, // ProjectionsOp
 	false, // AggregationsOp
 	false, // GroupingsOp
-	false, // FiltersOp
 	false, // ExistsOp
 	false, // AndOp
 	false, // OrOp
@@ -2365,7 +2304,6 @@ var isRelationalLookup = [...]bool{
 	false, // IsOp
 	false, // IsNotOp
 	false, // ContainsOp
-	false, // ContainedByOp
 	false, // BitandOp
 	false, // BitorOp
 	false, // BitxorOp
@@ -2424,7 +2362,6 @@ var isJoinLookup = [...]bool{
 	false, // ProjectionsOp
 	false, // AggregationsOp
 	false, // GroupingsOp
-	false, // FiltersOp
 	false, // ExistsOp
 	false, // AndOp
 	false, // OrOp
@@ -2450,7 +2387,6 @@ var isJoinLookup = [...]bool{
 	false, // IsOp
 	false, // IsNotOp
 	false, // ContainsOp
-	false, // ContainedByOp
 	false, // BitandOp
 	false, // BitorOp
 	false, // BitxorOp
@@ -2509,7 +2445,6 @@ var isJoinApplyLookup = [...]bool{
 	false, // ProjectionsOp
 	false, // AggregationsOp
 	false, // GroupingsOp
-	false, // FiltersOp
 	false, // ExistsOp
 	false, // AndOp
 	false, // OrOp
@@ -2535,7 +2470,6 @@ var isJoinApplyLookup = [...]bool{
 	false, // IsOp
 	false, // IsNotOp
 	false, // ContainsOp
-	false, // ContainedByOp
 	false, // BitandOp
 	false, // BitorOp
 	false, // BitxorOp
@@ -2594,7 +2528,6 @@ var isEnforcerLookup = [...]bool{
 	false, // ProjectionsOp
 	false, // AggregationsOp
 	false, // GroupingsOp
-	false, // FiltersOp
 	false, // ExistsOp
 	false, // AndOp
 	false, // OrOp
@@ -2620,7 +2553,6 @@ var isEnforcerLookup = [...]bool{
 	false, // IsOp
 	false, // IsNotOp
 	false, // ContainsOp
-	false, // ContainedByOp
 	false, // BitandOp
 	false, // BitorOp
 	false, // BitxorOp
@@ -2941,27 +2873,6 @@ func (m *memoExpr) asGroupings() *groupingsExpr {
 	return (*groupingsExpr)(m)
 }
 
-type filtersExpr memoExpr
-
-func makeFiltersExpr(conditions opt.ListID) filtersExpr {
-	return filtersExpr{op: opt.FiltersOp, state: exprState{conditions.Offset, conditions.Length}}
-}
-
-func (e *filtersExpr) conditions() opt.ListID {
-	return opt.ListID{Offset: e.state[0], Length: e.state[1]}
-}
-
-func (e *filtersExpr) fingerprint() fingerprint {
-	return fingerprint(*e)
-}
-
-func (m *memoExpr) asFilters() *filtersExpr {
-	if m.op != opt.FiltersOp {
-		return nil
-	}
-	return (*filtersExpr)(m)
-}
-
 type existsExpr memoExpr
 
 func makeExistsExpr(input opt.GroupID) existsExpr {
@@ -2983,18 +2894,17 @@ func (m *memoExpr) asExists() *existsExpr {
 	return (*existsExpr)(m)
 }
 
+// andExpr is the boolean conjunction operator that evalutes to true if all of its
+// conditions evaluate to true. If the conditions list is empty, it evalutes to
+// true.
 type andExpr memoExpr
 
-func makeAndExpr(left opt.GroupID, right opt.GroupID) andExpr {
-	return andExpr{op: opt.AndOp, state: exprState{uint32(left), uint32(right)}}
+func makeAndExpr(conditions opt.ListID) andExpr {
+	return andExpr{op: opt.AndOp, state: exprState{conditions.Offset, conditions.Length}}
 }
 
-func (e *andExpr) left() opt.GroupID {
-	return opt.GroupID(e.state[0])
-}
-
-func (e *andExpr) right() opt.GroupID {
-	return opt.GroupID(e.state[1])
+func (e *andExpr) conditions() opt.ListID {
+	return opt.ListID{Offset: e.state[0], Length: e.state[1]}
 }
 
 func (e *andExpr) fingerprint() fingerprint {
@@ -3008,18 +2918,17 @@ func (m *memoExpr) asAnd() *andExpr {
 	return (*andExpr)(m)
 }
 
+// orExpr is the boolean disjunction operator that evalutes to true if any of its
+// conditions evaluate to true. If the conditions list is empty, it evaluates to
+// false.
 type orExpr memoExpr
 
-func makeOrExpr(left opt.GroupID, right opt.GroupID) orExpr {
-	return orExpr{op: opt.OrOp, state: exprState{uint32(left), uint32(right)}}
+func makeOrExpr(conditions opt.ListID) orExpr {
+	return orExpr{op: opt.OrOp, state: exprState{conditions.Offset, conditions.Length}}
 }
 
-func (e *orExpr) left() opt.GroupID {
-	return opt.GroupID(e.state[0])
-}
-
-func (e *orExpr) right() opt.GroupID {
-	return opt.GroupID(e.state[1])
+func (e *orExpr) conditions() opt.ListID {
+	return opt.ListID{Offset: e.state[0], Length: e.state[1]}
 }
 
 func (e *orExpr) fingerprint() fingerprint {
@@ -3033,6 +2942,8 @@ func (m *memoExpr) asOr() *orExpr {
 	return (*orExpr)(m)
 }
 
+// notExpr is the boolean negation operator that evaluates to true if its input
+// evalutes to false.
 type notExpr memoExpr
 
 func makeNotExpr(input opt.GroupID) notExpr {
@@ -3577,31 +3488,6 @@ func (m *memoExpr) asContains() *containsExpr {
 		return nil
 	}
 	return (*containsExpr)(m)
-}
-
-type containedByExpr memoExpr
-
-func makeContainedByExpr(left opt.GroupID, right opt.GroupID) containedByExpr {
-	return containedByExpr{op: opt.ContainedByOp, state: exprState{uint32(left), uint32(right)}}
-}
-
-func (e *containedByExpr) left() opt.GroupID {
-	return opt.GroupID(e.state[0])
-}
-
-func (e *containedByExpr) right() opt.GroupID {
-	return opt.GroupID(e.state[1])
-}
-
-func (e *containedByExpr) fingerprint() fingerprint {
-	return fingerprint(*e)
-}
-
-func (m *memoExpr) asContainedBy() *containedByExpr {
-	if m.op != opt.ContainedByOp {
-		return nil
-	}
-	return (*containedByExpr)(m)
 }
 
 type bitandExpr memoExpr

--- a/pkg/sql/opt/xform/factory.og.go
+++ b/pkg/sql/opt/xform/factory.og.go
@@ -197,23 +197,6 @@ func (_f *factory) ConstructGroupings(
 	return _f.onConstruct(_f.mem.memoizeNormExpr((*memoExpr)(&_groupingsExpr)))
 }
 
-// ConstructFilters constructs an expression for the Filters operator.
-func (_f *factory) ConstructFilters(
-	conditions opt.ListID,
-) opt.GroupID {
-	_filtersExpr := makeFiltersExpr(conditions)
-	_group := _f.mem.lookupGroupByFingerprint(_filtersExpr.fingerprint())
-	if _group != 0 {
-		return _group
-	}
-
-	if !_f.allowOptimizations() {
-		return _f.mem.memoizeNormExpr((*memoExpr)(&_filtersExpr))
-	}
-
-	return _f.onConstruct(_f.mem.memoizeNormExpr((*memoExpr)(&_filtersExpr)))
-}
-
 // ConstructExists constructs an expression for the Exists operator.
 func (_f *factory) ConstructExists(
 	input opt.GroupID,
@@ -232,11 +215,13 @@ func (_f *factory) ConstructExists(
 }
 
 // ConstructAnd constructs an expression for the And operator.
+// And is the boolean conjunction operator that evalutes to true if all of its
+// conditions evaluate to true. If the conditions list is empty, it evalutes to
+// true.
 func (_f *factory) ConstructAnd(
-	left opt.GroupID,
-	right opt.GroupID,
+	conditions opt.ListID,
 ) opt.GroupID {
-	_andExpr := makeAndExpr(left, right)
+	_andExpr := makeAndExpr(conditions)
 	_group := _f.mem.lookupGroupByFingerprint(_andExpr.fingerprint())
 	if _group != 0 {
 		return _group
@@ -246,15 +231,43 @@ func (_f *factory) ConstructAnd(
 		return _f.mem.memoizeNormExpr((*memoExpr)(&_andExpr))
 	}
 
+	// [EliminateAnd]
+	{
+		for _, _item := range _f.mem.lookupList(conditions) {
+			_false := _f.mem.lookupNormExpr(_item).asFalse()
+			if _false != nil {
+				_f.reportOptimization()
+				_group = _f.ConstructFalse()
+				_f.mem.addAltFingerprint(_andExpr.fingerprint(), _group)
+				return _group
+			}
+		}
+	}
+
+	// [FlattenAnd]
+	{
+		for _, _item := range _f.mem.lookupList(conditions) {
+			_and := _f.mem.lookupNormExpr(_item).asAnd()
+			if _and != nil {
+				_f.reportOptimization()
+				_group = _f.flattenAnd(conditions)
+				_f.mem.addAltFingerprint(_andExpr.fingerprint(), _group)
+				return _group
+			}
+		}
+	}
+
 	return _f.onConstruct(_f.mem.memoizeNormExpr((*memoExpr)(&_andExpr)))
 }
 
 // ConstructOr constructs an expression for the Or operator.
+// Or is the boolean disjunction operator that evalutes to true if any of its
+// conditions evaluate to true. If the conditions list is empty, it evaluates to
+// false.
 func (_f *factory) ConstructOr(
-	left opt.GroupID,
-	right opt.GroupID,
+	conditions opt.ListID,
 ) opt.GroupID {
-	_orExpr := makeOrExpr(left, right)
+	_orExpr := makeOrExpr(conditions)
 	_group := _f.mem.lookupGroupByFingerprint(_orExpr.fingerprint())
 	if _group != 0 {
 		return _group
@@ -264,10 +277,38 @@ func (_f *factory) ConstructOr(
 		return _f.mem.memoizeNormExpr((*memoExpr)(&_orExpr))
 	}
 
+	// [EliminateOr]
+	{
+		for _, _item := range _f.mem.lookupList(conditions) {
+			_true := _f.mem.lookupNormExpr(_item).asTrue()
+			if _true != nil {
+				_f.reportOptimization()
+				_group = _f.ConstructTrue()
+				_f.mem.addAltFingerprint(_orExpr.fingerprint(), _group)
+				return _group
+			}
+		}
+	}
+
+	// [FlattenOr]
+	{
+		for _, _item := range _f.mem.lookupList(conditions) {
+			_or := _f.mem.lookupNormExpr(_item).asOr()
+			if _or != nil {
+				_f.reportOptimization()
+				_group = _f.flattenOr(conditions)
+				_f.mem.addAltFingerprint(_orExpr.fingerprint(), _group)
+				return _group
+			}
+		}
+	}
+
 	return _f.onConstruct(_f.mem.memoizeNormExpr((*memoExpr)(&_orExpr)))
 }
 
 // ConstructNot constructs an expression for the Not operator.
+// Not is the boolean negation operator that evaluates to true if its input
+// evalutes to false.
 func (_f *factory) ConstructNot(
 	input opt.GroupID,
 ) opt.GroupID {
@@ -279,6 +320,31 @@ func (_f *factory) ConstructNot(
 
 	if !_f.allowOptimizations() {
 		return _f.mem.memoizeNormExpr((*memoExpr)(&_notExpr))
+	}
+
+	// [NegateComparison]
+	{
+		_norm := _f.mem.lookupNormExpr(input)
+		if isComparisonLookup[_norm.op] {
+			if _f.canInvertComparison(input) {
+				_f.reportOptimization()
+				_group = _f.invertComparison(input)
+				_f.mem.addAltFingerprint(_notExpr.fingerprint(), _group)
+				return _group
+			}
+		}
+	}
+
+	// [EliminateNot]
+	{
+		_not := _f.mem.lookupNormExpr(input).asNot()
+		if _not != nil {
+			input := _not.input()
+			_f.reportOptimization()
+			_group = input
+			_f.mem.addAltFingerprint(_notExpr.fingerprint(), _group)
+			return _group
+		}
 	}
 
 	return _f.onConstruct(_f.mem.memoizeNormExpr((*memoExpr)(&_notExpr)))
@@ -297,6 +363,36 @@ func (_f *factory) ConstructEq(
 
 	if !_f.allowOptimizations() {
 		return _f.mem.memoizeNormExpr((*memoExpr)(&_eqExpr))
+	}
+
+	// [NormalizeVar]
+	{
+		_variable := _f.mem.lookupNormExpr(left).asVariable()
+		if _variable == nil {
+			_variable2 := _f.mem.lookupNormExpr(right).asVariable()
+			if _variable2 != nil {
+				_f.reportOptimization()
+				_group = _f.ConstructEq(right, left)
+				_f.mem.addAltFingerprint(_eqExpr.fingerprint(), _group)
+				return _group
+			}
+		}
+	}
+
+	// [NormalizeTupleEquality]
+	{
+		_tuple := _f.mem.lookupNormExpr(left).asTuple()
+		if _tuple != nil {
+			left := _tuple.elems()
+			_tuple2 := _f.mem.lookupNormExpr(right).asTuple()
+			if _tuple2 != nil {
+				right := _tuple2.elems()
+				_f.reportOptimization()
+				_group = _f.normalizeTupleEquality(left, right)
+				_f.mem.addAltFingerprint(_eqExpr.fingerprint(), _group)
+				return _group
+			}
+		}
 	}
 
 	return _f.onConstruct(_f.mem.memoizeNormExpr((*memoExpr)(&_eqExpr)))
@@ -387,6 +483,20 @@ func (_f *factory) ConstructNe(
 
 	if !_f.allowOptimizations() {
 		return _f.mem.memoizeNormExpr((*memoExpr)(&_neExpr))
+	}
+
+	// [NormalizeVar]
+	{
+		_variable := _f.mem.lookupNormExpr(left).asVariable()
+		if _variable == nil {
+			_variable2 := _f.mem.lookupNormExpr(right).asVariable()
+			if _variable2 != nil {
+				_f.reportOptimization()
+				_group = _f.ConstructNe(right, left)
+				_f.mem.addAltFingerprint(_neExpr.fingerprint(), _group)
+				return _group
+			}
+		}
 	}
 
 	return _f.onConstruct(_f.mem.memoizeNormExpr((*memoExpr)(&_neExpr)))
@@ -660,24 +770,6 @@ func (_f *factory) ConstructContains(
 	}
 
 	return _f.onConstruct(_f.mem.memoizeNormExpr((*memoExpr)(&_containsExpr)))
-}
-
-// ConstructContainedBy constructs an expression for the ContainedBy operator.
-func (_f *factory) ConstructContainedBy(
-	left opt.GroupID,
-	right opt.GroupID,
-) opt.GroupID {
-	_containedByExpr := makeContainedByExpr(left, right)
-	_group := _f.mem.lookupGroupByFingerprint(_containedByExpr.fingerprint())
-	if _group != 0 {
-		return _group
-	}
-
-	if !_f.allowOptimizations() {
-		return _f.mem.memoizeNormExpr((*memoExpr)(&_containedByExpr))
-	}
-
-	return _f.onConstruct(_f.mem.memoizeNormExpr((*memoExpr)(&_containedByExpr)))
 }
 
 // ConstructBitand constructs an expression for the Bitand operator.
@@ -1448,7 +1540,7 @@ func (_f *factory) ConstructExcept(
 
 type dynConstructLookupFunc func(f *factory, children []opt.GroupID, private opt.PrivateID) opt.GroupID
 
-var dynConstructLookup [79]dynConstructLookupFunc
+var dynConstructLookup [77]dynConstructLookupFunc
 
 func init() {
 	// UnknownOp
@@ -1506,11 +1598,6 @@ func init() {
 		return f.ConstructGroupings(f.InternList(children), private)
 	}
 
-	// FiltersOp
-	dynConstructLookup[opt.FiltersOp] = func(f *factory, children []opt.GroupID, private opt.PrivateID) opt.GroupID {
-		return f.ConstructFilters(f.InternList(children))
-	}
-
 	// ExistsOp
 	dynConstructLookup[opt.ExistsOp] = func(f *factory, children []opt.GroupID, private opt.PrivateID) opt.GroupID {
 		return f.ConstructExists(children[0])
@@ -1518,12 +1605,12 @@ func init() {
 
 	// AndOp
 	dynConstructLookup[opt.AndOp] = func(f *factory, children []opt.GroupID, private opt.PrivateID) opt.GroupID {
-		return f.ConstructAnd(children[0], children[1])
+		return f.ConstructAnd(f.InternList(children))
 	}
 
 	// OrOp
 	dynConstructLookup[opt.OrOp] = func(f *factory, children []opt.GroupID, private opt.PrivateID) opt.GroupID {
-		return f.ConstructOr(children[0], children[1])
+		return f.ConstructOr(f.InternList(children))
 	}
 
 	// NotOp
@@ -1634,11 +1721,6 @@ func init() {
 	// ContainsOp
 	dynConstructLookup[opt.ContainsOp] = func(f *factory, children []opt.GroupID, private opt.PrivateID) opt.GroupID {
 		return f.ConstructContains(children[0], children[1])
-	}
-
-	// ContainedByOp
-	dynConstructLookup[opt.ContainedByOp] = func(f *factory, children []opt.GroupID, private opt.PrivateID) opt.GroupID {
-		return f.ConstructContainedBy(children[0], children[1])
 	}
 
 	// BitandOp

--- a/pkg/sql/opt/xform/optimizer.go
+++ b/pkg/sql/opt/xform/optimizer.go
@@ -17,6 +17,26 @@ package xform
 import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/optbase"
+	"golang.org/x/tools/container/intsets"
+)
+
+// OptimizeSteps is passed to NewOptimizer, and specifies the maximum number
+// of normalization and exploration transformations that will be applied by the
+// optimizer. This can be used to effectively disable the optimizer (if set to
+// zero), to debug the optimizer (by disabling optimizations past a certain
+// point), or to limit the running time of the optimizer.
+type OptimizeSteps int
+
+const (
+	// OptimizeNone instructs the optimizer to suppress all transformations.
+	// The unaltered input expression tree will become the output expression
+	// tree. This effectively disables the optimizer.
+	OptimizeNone = OptimizeSteps(0)
+
+	// OptimizeAll instructs the optimizer to continue applying transformations
+	// until the best plan has been found. There is no limit to the number of
+	// steps that the optimizer will take to get there.
+	OptimizeAll = OptimizeSteps(intsets.MaxInt)
 )
 
 // Optimizer transforms an input expression tree into the logically equivalent
@@ -40,7 +60,7 @@ type Optimizer struct {
 // by the optimizer. If maxSteps is zero, then the unaltered input expression
 // tree becomes the output expression tree (because no transformations are
 // applied).
-func NewOptimizer(cat optbase.Catalog, maxSteps int) *Optimizer {
+func NewOptimizer(cat optbase.Catalog, maxSteps OptimizeSteps) *Optimizer {
 	f := newFactory(cat, maxSteps)
 	return &Optimizer{f: f, mem: f.mem}
 }

--- a/pkg/sql/opt/xform/rules/bool.opt
+++ b/pkg/sql/opt/xform/rules/bool.opt
@@ -1,0 +1,53 @@
+# =============================================================================
+# bool.opt contains normalization rules for boolean And, Or, Not operators.
+# =============================================================================
+
+
+# EliminateAnd discards the And operator if any of its operands is false.
+[EliminateAnd, Normalize]
+(And
+    $conditions:[ ... (False) ... ]
+)
+=>
+(False)
+
+# EliminateOr discards the Or operator if any of its operands is true.
+[EliminateOr, Normalize]
+(Or
+    $conditions:[ ... (True) ... ]
+)
+=>
+(True)
+
+# FlattenAnd ensures that And operators are never nested within one another. If
+# an And operator has another And as a child, then the child And is "flattened"
+# by merging its conditions into the parent And. Flattened And conditions are
+# easier to match and enumerate.
+[FlattenAnd, Normalize]
+(And
+    $conditions:[ ... (And) ... ]
+)
+=>
+(FlattenAnd $conditions)
+
+# FlattenOr ensures that Or operators are never nested within one another. If
+# an Or operator has another Or as a child, then the child Or is "flattened" by
+# merging its conditions into the parent Or. Flattened Or conditions are easier
+# to match and enumerate.
+[FlattenOr, Normalize]
+(Or
+    $conditions:[ ... (Or) ... ]
+)
+=>
+(FlattenOr $conditions)
+
+# NegateComparison inverts eligible comparison operators when they are negated
+# by the Not operator. For example, Eq maps to Ne, and Gt maps to Le.
+[NegateComparison, Normalize]
+(Not $input:(Comparison) & (CanInvertComparison $input))
+=>
+(InvertComparison $input)
+
+# EliminateNot discards a doubled Not operator.
+[EliminateNot, Normalize]
+(Not (Not $input:*)) => $input

--- a/pkg/sql/opt/xform/rules/comp.opt
+++ b/pkg/sql/opt/xform/rules/comp.opt
@@ -1,0 +1,26 @@
+# =============================================================================
+# comp.opt contains normalization rules for comparison operators.
+# =============================================================================
+
+
+# NormalizeVar ensures that variable references are on the left side of
+# equality and inequality operators.
+[NormalizeVar, Normalize]
+(Eq | Ne
+    $left:^(Variable)
+    $right:(Variable)
+)
+=>
+((OpName) $right $left)
+
+# NormalizeTupleEquality breaks up expressions like:
+#   (a, b, c) = (x, y, z)
+# into
+#   (a = x) AND (b = y) AND (c = z)
+#
+# This rule makes it easier to extract constraints from boolean expressions,
+# since recognition code doesn't have to handle the tuple case separately.
+[NormalizeTupleEquality]
+(Eq (Tuple $left:*) (Tuple $right:*))
+=>
+(NormalizeTupleEquality $left $right)

--- a/pkg/sql/opt/xform/rules_test.go
+++ b/pkg/sql/opt/xform/rules_test.go
@@ -1,0 +1,82 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package xform
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/build"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/testutils"
+	"github.com/cockroachdb/cockroach/pkg/sql/parser"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/testutils/datadriven"
+)
+
+// Rules files can be run separately like this:
+//   make test PKG=./pkg/sql/opt/xform TESTS="TestRules/bool"
+//   make test PKG=./pkg/sql/opt/xform TESTS="TestRules/comp"
+//   ...
+func TestRules(t *testing.T) {
+	paths, err := filepath.Glob("testdata/rules/*")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, path := range paths {
+		t.Run(filepath.Base(path), func(t *testing.T) {
+			catalog := testutils.NewTestCatalog()
+
+			datadriven.RunTest(t, path, func(d *datadriven.TestData) string {
+				stmt, err := parser.ParseOne(d.Input)
+				if err != nil {
+					d.Fatalf(t, "%v", err)
+				}
+
+				switch d.Cmd {
+				case "exec-ddl":
+					if stmt.StatementType() != tree.DDL {
+						d.Fatalf(t, "statement type is not DDL: %v", stmt.StatementType())
+					}
+
+					switch stmt := stmt.(type) {
+					case *tree.CreateTable:
+						tbl := catalog.CreateTable(stmt)
+						return tbl.String()
+
+					default:
+						d.Fatalf(t, "expected CREATE TABLE statement but found: %v", stmt)
+						return ""
+					}
+
+				case "opt":
+					o := NewOptimizer(catalog, OptimizeAll)
+					b := build.NewBuilder(context.Background(), o.Factory(), stmt)
+					root, props, err := b.Build()
+					if err != nil {
+						d.Fatalf(t, "%v", err)
+					}
+					exprView := o.Optimize(root, props)
+					return exprView.String()
+
+				default:
+					d.Fatalf(t, "unsupported command: %s", d.Cmd)
+					return ""
+				}
+			})
+		})
+	}
+}

--- a/pkg/sql/opt/xform/testdata/rules/bool
+++ b/pkg/sql/opt/xform/testdata/rules/bool
@@ -1,0 +1,297 @@
+exec-ddl
+CREATE TABLE a (k INT PRIMARY KEY, i INT, f FLOAT, s STRING, j JSON)
+----
+table a
+  k int NOT NULL
+  i int NULL
+  f float NULL
+  s string NULL
+  j jsonb NULL
+
+#
+# EliminateAnd
+#
+opt
+SELECT * FROM a WHERE k=1 AND False AND f=3.5
+----
+select
+ ├── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5
+ ├── scan
+ │    └── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5
+ └── false [type=bool]
+
+#
+# EliminateAnd
+#
+opt
+SELECT * FROM a WHERE False AND s='foo'
+----
+select
+ ├── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5
+ ├── scan
+ │    └── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5
+ └── false [type=bool]
+
+#
+# EliminateOr
+#
+opt
+SELECT * FROM a WHERE k=1 OR (i=2 OR True)
+----
+select
+ ├── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5
+ ├── scan
+ │    └── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5
+ └── true [type=bool]
+
+#
+# EliminateOr
+#
+opt
+SELECT * FROM a WHERE k=1 OR True OR f=3.5
+----
+select
+ ├── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5
+ ├── scan
+ │    └── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5
+ └── true [type=bool]
+
+#
+# FlattenAnd
+#
+opt
+SELECT * FROM a WHERE k=1 AND i=2 AND f=3.5
+----
+select
+ ├── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5
+ ├── scan
+ │    └── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5
+ └── and [type=bool]
+      ├── eq [type=bool]
+      │    ├── variable: a.k [type=int]
+      │    └── const: 1 [type=int]
+      ├── eq [type=bool]
+      │    ├── variable: a.i [type=int]
+      │    └── const: 2 [type=int]
+      └── eq [type=bool]
+           ├── variable: a.f [type=float]
+           └── const: 3.5 [type=float]
+
+#
+# FlattenOr
+#
+opt
+SELECT * FROM a WHERE k=1 OR i=2 OR f=3.5
+----
+select
+ ├── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5
+ ├── scan
+ │    └── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5
+ └── or [type=bool]
+      ├── eq [type=bool]
+      │    ├── variable: a.k [type=int]
+      │    └── const: 1 [type=int]
+      ├── eq [type=bool]
+      │    ├── variable: a.i [type=int]
+      │    └── const: 2 [type=int]
+      └── eq [type=bool]
+           ├── variable: a.f [type=float]
+           └── const: 3.5 [type=float]
+
+#
+# FlattenAnd + FlattenOr
+#   Combine and/or ops.
+#   Use parentheses to make and/or tree right-heavy instead of left-heavy.
+#
+opt
+SELECT * FROM a WHERE (k=1 OR (i=2 OR f=3.5)) AND (s='foo' AND s<>'bar')
+----
+select
+ ├── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5
+ ├── scan
+ │    └── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5
+ └── and [type=bool]
+      ├── or [type=bool]
+      │    ├── eq [type=bool]
+      │    │    ├── variable: a.k [type=int]
+      │    │    └── const: 1 [type=int]
+      │    ├── eq [type=bool]
+      │    │    ├── variable: a.i [type=int]
+      │    │    └── const: 2 [type=int]
+      │    └── eq [type=bool]
+      │         ├── variable: a.f [type=float]
+      │         └── const: 3.5 [type=float]
+      ├── eq [type=bool]
+      │    ├── variable: a.s [type=string]
+      │    └── const: 'foo' [type=string]
+      └── ne [type=bool]
+           ├── variable: a.s [type=string]
+           └── const: 'bar' [type=string]
+
+#
+# NegateComparison
+#   Equality and inequality comparisons.
+#
+opt
+SELECT * FROM a WHERE NOT(i=1) AND NOT(i<>1) AND NOT(i>1) AND NOT(i>=1) AND NOT(i<1) AND NOT(i<=1)
+----
+select
+ ├── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5
+ ├── scan
+ │    └── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5
+ └── and [type=bool]
+      ├── ne [type=bool]
+      │    ├── variable: a.i [type=int]
+      │    └── const: 1 [type=int]
+      ├── eq [type=bool]
+      │    ├── variable: a.i [type=int]
+      │    └── const: 1 [type=int]
+      ├── le [type=bool]
+      │    ├── variable: a.i [type=int]
+      │    └── const: 1 [type=int]
+      ├── lt [type=bool]
+      │    ├── variable: a.i [type=int]
+      │    └── const: 1 [type=int]
+      ├── ge [type=bool]
+      │    ├── variable: a.i [type=int]
+      │    └── const: 1 [type=int]
+      └── gt [type=bool]
+           ├── variable: a.i [type=int]
+           └── const: 1 [type=int]
+
+#
+# NegateComparison
+#   IN and IS comparisons.
+#
+opt
+SELECT *
+FROM a
+WHERE NOT(i IN (1,2)) AND NOT(i NOT IN (3,4)) AND NOT(i IS NULL) AND NOT(i IS NOT NULL)
+----
+select
+ ├── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5
+ ├── scan
+ │    └── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5
+ └── and [type=bool]
+      ├── not-in [type=bool]
+      │    ├── variable: a.i [type=int]
+      │    └── tuple [type=tuple{int, int}]
+      │         ├── const: 1 [type=int]
+      │         └── const: 2 [type=int]
+      ├── in [type=bool]
+      │    ├── variable: a.i [type=int]
+      │    └── tuple [type=tuple{int, int}]
+      │         ├── const: 3 [type=int]
+      │         └── const: 4 [type=int]
+      ├── is-not [type=bool]
+      │    ├── variable: a.i [type=int]
+      │    └── const: NULL [type=NULL]
+      └── is [type=bool]
+           ├── variable: a.i [type=int]
+           └── const: NULL [type=NULL]
+
+#
+# NegateComparison
+#   Like comparisons.
+#
+opt
+SELECT *
+FROM a
+WHERE NOT(s LIKE 'foo') AND NOT(s NOT LIKE 'foo') AND NOT(s ILIKE 'foo') AND NOT(s NOT ILIKE 'foo')
+----
+select
+ ├── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5
+ ├── scan
+ │    └── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5
+ └── and [type=bool]
+      ├── not-like [type=bool]
+      │    ├── variable: a.s [type=string]
+      │    └── const: 'foo' [type=string]
+      ├── like [type=bool]
+      │    ├── variable: a.s [type=string]
+      │    └── const: 'foo' [type=string]
+      ├── not-i-like [type=bool]
+      │    ├── variable: a.s [type=string]
+      │    └── const: 'foo' [type=string]
+      └── i-like [type=bool]
+           ├── variable: a.s [type=string]
+           └── const: 'foo' [type=string]
+
+#
+# NegateComparison
+#   SimilarTo comparisons.
+#
+opt
+SELECT * FROM a WHERE NOT(s SIMILAR TO 'foo') AND NOT(s NOT SIMILAR TO 'foo')
+----
+select
+ ├── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5
+ ├── scan
+ │    └── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5
+ └── and [type=bool]
+      ├── not-similar-to [type=bool]
+      │    ├── variable: a.s [type=string]
+      │    └── const: 'foo' [type=string]
+      └── similar-to [type=bool]
+           ├── variable: a.s [type=string]
+           └── const: 'foo' [type=string]
+
+#
+# NegateComparison
+#   RegMatch comparisons.
+#
+opt
+SELECT * FROM a WHERE NOT(s ~ 'foo') AND NOT(s !~ 'foo') AND NOT(s ~* 'foo') AND NOT (s !~* 'foo')
+----
+select
+ ├── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5
+ ├── scan
+ │    └── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5
+ └── and [type=bool]
+      ├── not-reg-match [type=bool]
+      │    ├── variable: a.s [type=string]
+      │    └── const: 'foo' [type=string]
+      ├── reg-match [type=bool]
+      │    ├── variable: a.s [type=string]
+      │    └── const: 'foo' [type=string]
+      ├── not-reg-i-match [type=bool]
+      │    ├── variable: a.s [type=string]
+      │    └── const: 'foo' [type=string]
+      └── reg-i-match [type=bool]
+           ├── variable: a.s [type=string]
+           └── const: 'foo' [type=string]
+
+#
+# NegateComparison
+#   Contains comparison (should not be negated).
+#
+opt
+SELECT * FROM a WHERE NOT('[1, 2]' @> j) AND NOT(j <@ '[3, 4]')
+----
+select
+ ├── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5
+ ├── scan
+ │    └── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5
+ └── and [type=bool]
+      ├── not [type=bool]
+      │    └── contains [type=bool]
+      │         ├── const: '[1, 2]' [type=jsonb]
+      │         └── variable: a.j [type=jsonb]
+      └── not [type=bool]
+           └── contains [type=bool]
+                ├── const: '[3, 4]' [type=jsonb]
+                └── variable: a.j [type=jsonb]
+
+#
+# EliminateNot
+#
+opt
+SELECT * FROM a WHERE NOT(NOT('[1, 2]' @> j))
+----
+select
+ ├── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5
+ ├── scan
+ │    └── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5
+ └── contains [type=bool]
+      ├── const: '[1, 2]' [type=jsonb]
+      └── variable: a.j [type=jsonb]

--- a/pkg/sql/opt/xform/testdata/rules/comp
+++ b/pkg/sql/opt/xform/testdata/rules/comp
@@ -1,0 +1,70 @@
+exec-ddl
+CREATE TABLE a (k INT PRIMARY KEY, i INT, f FLOAT, s STRING, j JSON)
+----
+table a
+  k int NOT NULL
+  i int NULL
+  f float NULL
+  s string NULL
+  j jsonb NULL
+
+#
+# NormalizeVar
+#
+opt
+SELECT * FROM a WHERE 1=k AND 2<>i
+----
+select
+ ├── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5
+ ├── scan
+ │    └── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5
+ └── and [type=bool]
+      ├── eq [type=bool]
+      │    ├── variable: a.k [type=int]
+      │    └── const: 1 [type=int]
+      └── ne [type=bool]
+           ├── variable: a.i [type=int]
+           └── const: 2 [type=int]
+
+#
+# NormalizeTupleEquality
+#
+opt
+SELECT * FROM a WHERE (i, f, s) = (1, 3.5, 'foo')
+----
+select
+ ├── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5
+ ├── scan
+ │    └── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5
+ └── and [type=bool]
+      ├── eq [type=bool]
+      │    ├── variable: a.i [type=int]
+      │    └── const: 1 [type=int]
+      ├── eq [type=bool]
+      │    ├── variable: a.f [type=float]
+      │    └── const: 3.5 [type=float]
+      └── eq [type=bool]
+           ├── variable: a.s [type=string]
+           └── const: 'foo' [type=string]
+
+#
+# NormalizeTupleEquality, FlattenAnd
+#   Nested tuples.
+#
+opt
+SELECT * FROM a WHERE (1, (2, 'foo')) = (k, (i, s))
+----
+select
+ ├── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5
+ ├── scan
+ │    └── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5
+ └── and [type=bool]
+      ├── eq [type=bool]
+      │    ├── variable: a.k [type=int]
+      │    └── const: 1 [type=int]
+      ├── eq [type=bool]
+      │    ├── variable: a.i [type=int]
+      │    └── const: 2 [type=int]
+      └── eq [type=bool]
+           ├── variable: a.s [type=string]
+           └── const: 'foo' [type=string]

--- a/pkg/sql/opt/xform/testdata/typing
+++ b/pkg/sql/opt/xform/testdata/typing
@@ -19,8 +19,8 @@ project
  │    └── tuple [type=tuple{}]
  └── projections
       ├── const: 1 [type=int]
-      ├── const: true [type=bool]
-      └── const: false [type=bool]
+      ├── true [type=bool]
+      └── false [type=bool]
 
 # Placeholder
 build

--- a/pkg/sql/opt/xform/typing.go
+++ b/pkg/sql/opt/xform/typing.go
@@ -49,7 +49,6 @@ func init() {
 		opt.PlaceholderOp: typeAsTypedExpr,
 		opt.TupleOp:       typeAsTuple,
 		opt.ProjectionsOp: typeAsTuple,
-		opt.FiltersOp:     typeAsBool,
 		opt.ExistsOp:      typeAsBool,
 	}
 

--- a/pkg/sql/opt/xform/typing_test.go
+++ b/pkg/sql/opt/xform/typing_test.go
@@ -39,7 +39,7 @@ func TestTyping(t *testing.T) {
 			d.Fatalf(t, "%v", err)
 		}
 
-		o := NewOptimizer(createTypingCatalog(), 0 /* maxSteps */)
+		o := NewOptimizer(createTypingCatalog(), OptimizeNone)
 		b := build.NewBuilder(context.Background(), o.Factory(), stmt)
 		root, props, err := b.Build()
 		if err != nil {
@@ -52,7 +52,7 @@ func TestTyping(t *testing.T) {
 }
 
 func TestTypingTrueFalse(t *testing.T) {
-	o := NewOptimizer(createTypingCatalog(), 0 /* maxSteps */)
+	o := NewOptimizer(createTypingCatalog(), OptimizeNone)
 	f := o.Factory()
 
 	// (True)
@@ -65,7 +65,7 @@ func TestTypingTrueFalse(t *testing.T) {
 }
 
 func TestTypingJson(t *testing.T) {
-	o := NewOptimizer(createTypingCatalog(), 0 /* maxSteps */)
+	o := NewOptimizer(createTypingCatalog(), OptimizeNone)
 	f := o.Factory()
 
 	// (Const <json>)


### PR DESCRIPTION
Add the set of scalar normalization rules that are currently
performed by opt/scalar.go (plus a couple):
  EliminateAnd: eliminate And if it has a False condition
  EliminateOr: eliminate Or if it has a True condition
  FlattenAnd: flatten nested And ops into one list
  FlattenOr: flatten nested Or ops into one list
  NegateComparison: flip cases like Not(x=1) to x<>1
  EliminateNot: eliminate double Not(Not(..))
  NormalizeVar: ensure vars are on left side of Eq/Ne
  NormalizeTupleEquality: break (a, b) = (x, y) into (a=x) AND (b=y)

This prepares for the next step, which is to convert the index
constraints code to use the new exprs. It also generates rules for
the first time, which surfaced a small bug in Optgen where it was
incorrectly capitalizing an expression field name.

Other changes triggered by adding these rules:
  - Remove ContainedBy op, since it's trivial inverse of the Contains
    op, which builder now builds instead.
  - Convert And and Or ops to use a list for their conditions rather
    than being binary ops. This makes matching easier, and also means
    we don't need the Filters op.
  - Map boolean datums to True/False ops, making them easier to
    recognize and construct in rules.
  - Use an enum rather than an int as maxSteps parameter to the
    NewOptimizer function, for better clarity.

Release note: None