### PR TITLE
sql, sqlbase: Have the TablesNeededForFK function also add a CheckHelper.

### DIFF
--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -521,7 +521,12 @@ func (sc *SchemaChanger) distBackfill(
 			var otherTableDescs []sqlbase.TableDescriptor
 			if backfillType == columnBackfill {
 				fkTables, _ := sqlbase.TablesNeededForFKs(
-					ctx, *tableDesc, sqlbase.CheckUpdates, sqlbase.NoLookup, sqlbase.NoCheckPrivilege,
+					ctx,
+					*tableDesc,
+					sqlbase.CheckUpdates,
+					sqlbase.NoLookup,
+					sqlbase.NoCheckPrivilege,
+					nil, /* AnalyzeExprFunction */
 				)
 				for k := range fkTables {
 					table, err := tc.getTableVersionByID(ctx, txn, k)

--- a/pkg/sql/delete.go
+++ b/pkg/sql/delete.go
@@ -82,7 +82,12 @@ func (p *planner) Delete(
 	}
 
 	fkTables, err := sqlbase.TablesNeededForFKs(
-		ctx, *en.tableDesc, sqlbase.CheckDeletes, p.lookupFKTable, p.CheckPrivilege,
+		ctx,
+		*en.tableDesc,
+		sqlbase.CheckDeletes,
+		p.lookupFKTable,
+		p.CheckPrivilege,
+		p.analyzeExpr,
 	)
 	if err != nil {
 		return nil, err

--- a/pkg/sql/distsqlrun/columnbackfiller.go
+++ b/pkg/sql/distsqlrun/columnbackfiller.go
@@ -153,7 +153,12 @@ func (cb *columnBackfiller) runChunk(
 		}
 
 		fkTables, _ := sqlbase.TablesNeededForFKs(
-			ctx, tableDesc, sqlbase.CheckUpdates, sqlbase.NoLookup, sqlbase.NoCheckPrivilege,
+			ctx,
+			tableDesc,
+			sqlbase.CheckUpdates,
+			sqlbase.NoLookup,
+			sqlbase.NoCheckPrivilege,
+			nil, /* AnalyzeExprFunction */
 		)
 		for _, fkTableDesc := range cb.spec.OtherTables {
 			found, ok := fkTables[fkTableDesc.ID]

--- a/pkg/sql/insert.go
+++ b/pkg/sql/insert.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
@@ -52,7 +51,7 @@ type insertNode struct {
 	defaultExprs []tree.TypedExpr
 	computeExprs []tree.TypedExpr
 	n            *tree.Insert
-	checkHelper  sqlbase.CheckHelper
+	checkHelper  *sqlbase.CheckHelper
 
 	insertCols   []sqlbase.ColumnDescriptor
 	computedCols []sqlbase.ColumnDescriptor
@@ -198,8 +197,19 @@ func (p *planner) Insert(
 		}
 	}
 
+	var fkCheckType sqlbase.FKCheck
+	if n.OnConflict == nil || n.OnConflict.DoNothing {
+		fkCheckType = sqlbase.CheckInserts
+	} else {
+		fkCheckType = sqlbase.CheckUpdates
+	}
 	fkTables, err := sqlbase.TablesNeededForFKs(
-		ctx, *en.tableDesc, sqlbase.CheckInserts, p.lookupFKTable, p.CheckPrivilege,
+		ctx,
+		*en.tableDesc,
+		fkCheckType,
+		p.lookupFKTable,
+		p.CheckPrivilege,
+		p.analyzeExpr,
 	)
 	if err != nil {
 		return nil, err
@@ -266,13 +276,6 @@ func (p *planner) Insert(
 				return nil, err
 			}
 
-			fkTables, err := sqlbase.TablesNeededForFKs(
-				ctx, *en.tableDesc, sqlbase.CheckUpdates, p.lookupFKTable, p.CheckPrivilege,
-			)
-			if err != nil {
-				return nil, err
-			}
-
 			tu := tableUpserterPool.Get().(*tableUpserter)
 			*tu = tableUpserter{
 				ri:            ri,
@@ -302,12 +305,7 @@ func (p *planner) Insert(
 			insertColIDtoRowIndex: ri.InsertColIDtoRowIndex,
 			isUpsertReturning:     isUpsertReturning,
 		},
-	}
-
-	if err := in.checkHelper.Init(
-		ctx, p.analyzeExpr, parser.ParseExprs, tn, en.tableDesc,
-	); err != nil {
-		return nil, err
+		checkHelper: fkTables[en.tableDesc.ID].CheckHelper,
 	}
 
 	if err := in.run.initEditNode(

--- a/pkg/sql/sqlbase/check.go
+++ b/pkg/sql/sqlbase/check.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/pkg/errors"
 
+	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
@@ -46,16 +47,10 @@ type AnalyzeExprFunction func(
 	typingContext string,
 ) (tree.TypedExpr, error)
 
-// ParseExprsFunction is used by the check helper during initialization to parse
-// the check expressions. See planner/parse.go for more details on this
-// function.
-type ParseExprsFunction func(sql []string) (tree.Exprs, error)
-
 // Init initializes the CheckHelper. This step should be done during planning.
 func (c *CheckHelper) Init(
 	ctx context.Context,
 	analyzeExpr AnalyzeExprFunction,
-	parserExprs ParseExprsFunction,
 	tn *tree.TableName,
 	tableDesc *TableDescriptor,
 ) error {
@@ -73,7 +68,7 @@ func (c *CheckHelper) Init(
 	for i, check := range tableDesc.Checks {
 		exprStrings[i] = check.Expr
 	}
-	exprs, err := parserExprs(exprStrings)
+	exprs, err := parser.ParseExprs(exprStrings)
 	if err != nil {
 		return err
 	}

--- a/pkg/sql/sqlbase/fk.go
+++ b/pkg/sql/sqlbase/fk.go
@@ -35,9 +35,11 @@ type TableLookupsByID map[ID]TableLookup
 // TableLookup is the value type of TableLookupsByID: An optional table
 // descriptor, populated when the table is public/leasable, and an IsAdding
 // flag.
+// This also includes an optional CheckHelper for the table.
 type TableLookup struct {
-	Table    *TableDescriptor
-	IsAdding bool
+	Table       *TableDescriptor
+	IsAdding    bool
+	CheckHelper *CheckHelper
 }
 
 // TableLookupFunction is the function type used by TablesNeededForFKs that will
@@ -83,6 +85,16 @@ type tableLookupQueue struct {
 	tableLookups   TableLookupsByID
 	lookup         TableLookupFunction
 	checkPrivilege CheckPrivilegeFunction
+	analyzeExpr    AnalyzeExprFunction
+}
+
+func (tl *TableLookup) addCheckHelper(ctx context.Context, analyzeExpr AnalyzeExprFunction) error {
+	if analyzeExpr == nil {
+		return nil
+	}
+	tableName := tree.MakeUnqualifiedTableName(tree.Name(tl.Table.Name))
+	tl.CheckHelper = &CheckHelper{}
+	return tl.CheckHelper.Init(ctx, analyzeExpr, &tableName, tl.Table)
 }
 
 func (q *tableLookupQueue) getTable(ctx context.Context, tableID ID) (TableLookup, error) {
@@ -95,6 +107,9 @@ func (q *tableLookupQueue) getTable(ctx context.Context, tableID ID) (TableLooku
 	}
 	if !tableLookup.IsAdding && tableLookup.Table != nil {
 		if err := q.checkPrivilege(ctx, tableLookup.Table, privilege.SELECT); err != nil {
+			return TableLookup{}, err
+		}
+		if err := tableLookup.addCheckHelper(ctx, q.analyzeExpr); err != nil {
 			return TableLookup{}, err
 		}
 	}
@@ -153,22 +168,32 @@ func (q *tableLookupQueue) dequeue() (TableLookup, FKCheck, bool) {
 // TablesNeededForFKs populates a map of TableLookupsByID for all the
 // TableDescriptors that might be needed when performing FK checking for delete
 // and/or insert operations. It uses the passed in lookup function to perform
-// the actual lookup.
+// the actual lookup. The AnalyzeExpr function, if provided, is used to
+// initialize the CheckHelper, and this requires that the TableLookupFunction
+// and CheckPrivilegeFunction are provided and not just placeholder functions
+// as well. If an operation may include a cascading operation then the
+// CheckHelpers are required.
 func TablesNeededForFKs(
 	ctx context.Context,
 	table TableDescriptor,
 	usage FKCheck,
 	lookup TableLookupFunction,
 	checkPrivilege CheckPrivilegeFunction,
+	analyzeExpr AnalyzeExprFunction,
 ) (TableLookupsByID, error) {
 	queue := tableLookupQueue{
 		tableLookups:   make(TableLookupsByID),
 		alreadyChecked: make(map[ID]map[FKCheck]struct{}),
 		lookup:         lookup,
 		checkPrivilege: checkPrivilege,
+		analyzeExpr:    analyzeExpr,
 	}
 	// Add the passed in table descriptor to the table lookup.
-	queue.tableLookups[table.ID] = TableLookup{Table: &table}
+	baseTableLookup := TableLookup{Table: &table}
+	if err := baseTableLookup.addCheckHelper(ctx, analyzeExpr); err != nil {
+		return nil, err
+	}
+	queue.tableLookups[table.ID] = baseTableLookup
 	if err := queue.enqueue(ctx, table.ID, usage); err != nil {
 		return nil, err
 	}

--- a/pkg/sql/sqlbase/fk_test.go
+++ b/pkg/sql/sqlbase/fk_test.go
@@ -179,7 +179,14 @@ func TestTablesNeededForFKs(t *testing.T) {
 	}
 
 	test := func(t *testing.T, usage FKCheck, expectedIDs []ID) {
-		tableLookups, err := TablesNeededForFKs(context.TODO(), *xDesc, usage, lookup, NoCheckPrivilege)
+		tableLookups, err := TablesNeededForFKs(
+			context.TODO(),
+			*xDesc,
+			usage,
+			lookup,
+			NoCheckPrivilege,
+			nil, /* AnalyzeExprFunction */
+		)
 		if err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
This is the third of a set of 4 commits that will enable the combination of
foreign key cascading actions and check constraints. Unlike the previous 2
commits, this one does include some code changes.

- Move DataSourceInfo from sql to sqlbase. (#22414)
- Move CheckHelper from sql to sqlbase. (#22481)
- Add CheckHelpers to TablesNeededForFK. (this commit)
- Enable Check Constraints on cascading actions

These changes should also enable the ability to mix computed columns and
foreign key cascading actions.

Every Insert and Update (and Deletes with cascading) requires one or more
CheckHelpers. Instead of using a new struct that needs to be plumbed around
the idea here is to leverage the already existing fkTables to now also
optionally include a CheckHelper.

While updating Insert.go, it became apparent that we were sometimes calling
`TablesNeededForFK()` twice. If there are FK constraints this is an expensive
function call so this double call was eliminated.

Release note: None