### PR TITLE
sql: Fix improper normalization of some aggregates to NULL

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/aggregate
+++ b/pkg/sql/logictest/testdata/logic_test/aggregate
@@ -72,6 +72,34 @@ SELECT JSONB_AGG(1)
 ----
 [1]
 
+# Some aggregate functions are not normalized to NULL when given a NULL
+# argument.
+query I
+SELECT COUNT(NULL)
+----
+0
+
+query T
+SELECT JSON_AGG(NULL)
+----
+[null]
+
+query T
+SELECT JSONB_AGG(NULL)
+----
+[null]
+
+# This should ideally return {NULL}, but this is a pathological case, and
+# Postgres has the same behavior, so it's sufficient for now.
+statement error ambiguous call
+SELECT ARRAY_AGG(NULL)
+
+# With an explicit cast, this works as expected.
+query T
+SELECT ARRAY_AGG(NULL::TEXT)
+----
+{NULL}
+
 # Check that COALESCE using aggregate results over an empty table
 # work properly.
 query I

--- a/pkg/sql/sem/builtins/aggregate_builtins.go
+++ b/pkg/sql/sem/builtins/aggregate_builtins.go
@@ -71,6 +71,13 @@ func initAggregateBuiltins() {
 // functions must return NULL when they are no rows in the source
 // table, so their evaluation must always be delayed until query
 // execution.
+// Some aggregate functions must handle nullable arguments, since normalizing
+// an aggregate function call to NULL in the presence of a NULL argument may
+// not be correct. There are two cases where an aggregate function must handle
+// nullable arguments:
+// 1) the aggregate function does not skip NULLs (e.g., ARRAY_AGG); and
+// 2) the aggregate function does not return NULL when it aggregates no rows
+//		(e.g., COUNT).
 // Exported for use in documentation.
 var Aggregates = map[string][]tree.Builtin{
 	"array_agg": arrayBuiltin(func(t types.T) tree.Builtin {
@@ -85,7 +92,8 @@ var Aggregates = map[string][]tree.Builtin{
 				return types.TArray{Typ: args[0].ResolvedType()}
 			},
 			newArrayAggregate,
-			"Aggregates the selected values into an array.")
+			"Aggregates the selected values into an array.",
+			true /* nullableArgs */)
 	}),
 
 	"avg": {
@@ -120,7 +128,7 @@ var Aggregates = map[string][]tree.Builtin{
 	},
 
 	"count": {
-		makeAggBuiltin([]types.T{types.Any}, types.Int, newCountAggregate,
+		makeAggBuiltinWithNullableArgs([]types.T{types.Any}, types.Int, newCountAggregate,
 			"Calculates the number of selected elements."),
 	},
 
@@ -218,12 +226,12 @@ var Aggregates = map[string][]tree.Builtin{
 	},
 
 	"json_agg": {
-		makeAggBuiltin([]types.T{types.Any}, types.JSON, newJSONAggregate,
+		makeAggBuiltinWithNullableArgs([]types.T{types.Any}, types.JSON, newJSONAggregate,
 			"aggregates values as a JSON or JSONB array"),
 	},
 
 	"jsonb_agg": {
-		makeAggBuiltin([]types.T{types.Any}, types.JSON, newJSONAggregate,
+		makeAggBuiltinWithNullableArgs([]types.T{types.Any}, types.JSON, newJSONAggregate,
 			"aggregates values as a JSON or JSONB array"),
 	},
 }
@@ -231,7 +239,15 @@ var Aggregates = map[string][]tree.Builtin{
 func makeAggBuiltin(
 	in []types.T, ret types.T, f func([]types.T, *tree.EvalContext) tree.AggregateFunc, info string,
 ) tree.Builtin {
-	return makeAggBuiltinWithReturnType(in, tree.FixedReturnType(ret), f, info)
+	return makeAggBuiltinWithReturnType(
+		in, tree.FixedReturnType(ret), f, info, false /* nullableArgs */)
+}
+
+func makeAggBuiltinWithNullableArgs(
+	in []types.T, ret types.T, f func([]types.T, *tree.EvalContext) tree.AggregateFunc, info string,
+) tree.Builtin {
+	return makeAggBuiltinWithReturnType(
+		in, tree.FixedReturnType(ret), f, info, true /* nullableArgs */)
 }
 
 func makeAggBuiltinWithReturnType(
@@ -239,6 +255,7 @@ func makeAggBuiltinWithReturnType(
 	retType tree.ReturnTyper,
 	f func([]types.T, *tree.EvalContext) tree.AggregateFunc,
 	info string,
+	nullableArgs bool,
 ) tree.Builtin {
 	argTypes := make(tree.ArgTypes, len(in))
 	for i, typ := range in {
@@ -257,7 +274,8 @@ func makeAggBuiltinWithReturnType(
 		WindowFunc: func(params []types.T, evalCtx *tree.EvalContext) tree.WindowFunc {
 			return newAggregateWindow(f(params, evalCtx))
 		},
-		Info: info,
+		Info:         info,
+		NullableArgs: nullableArgs,
 	}
 }
 


### PR DESCRIPTION
Previously, some queries like `SELECT count(NULL)` erroneously returned
NULL instead of the expected value (0 in the example). This was caused
by NullableArgs being set to false for all aggregates. Now, the flag is
set to true for aggregates that can either accept NULLs, or skip NULLs
but return a non-NULL value when no rows are selected for aggregation.

Note that this introduces ambiguity for some array_agg queries, like
`SELECT array_agg(NULL)`. This is preferable to returning the unexpected
result of NULL as we did before, because it is a clearer indication that
the types are not well-specified enough. Furthermore, Postgres behaves
in the same way for this particular query.

Fixes #21589.

Release note (bug fix): Return the correct results for aggregates that
take null arguments.