### PR TITLE
sql: disallow computed cols from being fk refs

### DIFF
--- a/pkg/ccl/importccl/load.go
+++ b/pkg/ccl/importccl/load.go
@@ -174,7 +174,7 @@ func Load(
 			})
 
 			for _, col := range tableDesc.Columns {
-				if col.ComputeExpr != nil {
+				if col.IsComputed() {
 					return backupccl.BackupDescriptor{}, errors.Errorf("computed columns are not allowed")
 				}
 			}

--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -192,6 +192,15 @@ func (n *alterTableNode) startExec(params runParams) error {
 				); err != nil {
 					return err
 				}
+				for _, colName := range d.FromCols {
+					col, _, err := n.tableDesc.FindColumnByName(colName)
+					if err != nil {
+						return err
+					}
+					if err := col.CheckCanBeFKRef(); err != nil {
+						return err
+					}
+				}
 				affected := make(map[sqlbase.ID]*sqlbase.TableDescriptor)
 				err := params.p.resolveFK(params.ctx, n.tableDesc, d, affected, sqlbase.ConstraintValidity_Unvalidated)
 				if err != nil {

--- a/pkg/sql/computed_exprs.go
+++ b/pkg/sql/computed_exprs.go
@@ -52,7 +52,7 @@ func cannotWriteToComputedColError(col sqlbase.ColumnDescriptor) error {
 
 func checkHasNoComputedCols(cols []sqlbase.ColumnDescriptor) error {
 	for i := range cols {
-		if cols[i].ComputeExpr != nil {
+		if cols[i].IsComputed() {
 			return cannotWriteToComputedColError(cols[i])
 		}
 	}
@@ -78,7 +78,7 @@ func ProcessComputedColumns(
 	haveComputed := false
 	endOfNonComputed := len(cols)
 	for _, col := range tableDesc.Columns {
-		if col.ComputeExpr != nil {
+		if col.IsComputed() {
 			cols = append(cols, col)
 			haveComputed = true
 		}

--- a/pkg/sql/insert.go
+++ b/pkg/sql/insert.go
@@ -118,7 +118,7 @@ func (p *planner) Insert(
 	// go by.
 	maxInsertIdx := len(cols)
 	for i, col := range cols {
-		if col.ComputeExpr != nil {
+		if col.IsComputed() {
 			maxInsertIdx = i
 			break
 		}

--- a/pkg/sql/logictest/testdata/logic_test/computed
+++ b/pkg/sql/logictest/testdata/logic_test/computed
@@ -265,6 +265,60 @@ CREATE TABLE y (
   r INT AS (q) STORED
 )
 
+statement error computed column "r" cannot be a foreign key reference
+CREATE TABLE y (
+  r INT AS (1) STORED REFERENCES x (a)
+)
+
+statement error computed column "r" cannot be a foreign key reference
+CREATE TABLE y (
+  r INT AS (1) STORED REFERENCES x
+)
+
+statement error computed column "r" cannot be a foreign key reference
+CREATE TABLE y (
+  a INT,
+  r INT AS (1) STORED REFERENCES x
+)
+
+# Composite FK.
+
+statement ok
+CREATE TABLE xx (
+  a INT,
+  b INT,
+  UNIQUE (a, b)
+)
+
+statement error computed column "y" cannot be a foreign key reference
+CREATE TABLE yy (
+  x INT,
+  y INT AS (3) STORED,
+  FOREIGN KEY (x, y) REFERENCES xx (a, b)
+)
+
+statement error computed column "y" cannot be a foreign key reference
+CREATE TABLE yy (
+  x INT,
+  y INT AS (3) STORED,
+  FOREIGN KEY (y, x) REFERENCES xx (a, b)
+)
+
+statement ok
+DROP TABLE xx
+
+statement ok
+CREATE TABLE y (
+  r INT AS (1) STORED,
+  INDEX (r)
+)
+
+statement error computed column "r" cannot be a foreign key reference
+ALTER TABLE y ADD FOREIGN KEY (r) REFERENCES x (a)
+
+statement ok
+DROP TABLE y
+
 statement error computed column expression '\(SELECT 1\)' may not contain variable sub-expressions
 CREATE TABLE y (
   r INT AS ((SELECT 1)) STORED
@@ -369,8 +423,20 @@ SELECT data->>'name' FROM x WHERE k = 5
 ----
 ernie
 
+# Referencing a computed column.
 statement ok
-DROP TABLE x
+create table y (
+  a INT REFERENCES x (k)
+)
+
+statement ok
+INSERT INTO y VALUES (5)
+
+statement error foreign key violation
+INSERT INTO y VALUES (100)
+
+statement ok
+DROP TABLE x CASCADE
 
 statement ok
 CREATE TABLE x (

--- a/pkg/sql/rename_column.go
+++ b/pkg/sql/rename_column.go
@@ -127,7 +127,7 @@ func (p *planner) RenameColumn(ctx context.Context, n *tree.RenameColumn) (planN
 
 	// Rename the column in computed columns.
 	for i := range tableDesc.Columns {
-		if tableDesc.Columns[i].ComputeExpr != nil {
+		if tableDesc.Columns[i].IsComputed() {
 			newExpr, err := renameIn(*tableDesc.Columns[i].ComputeExpr)
 			if err != nil {
 				return nil, err

--- a/pkg/sql/sqlbase/structured.go
+++ b/pkg/sql/sqlbase/structured.go
@@ -2484,7 +2484,7 @@ func (desc *ColumnDescriptor) SQLString() string {
 		f.WriteString(" DEFAULT ")
 		f.WriteString(*desc.DefaultExpr)
 	}
-	if desc.ComputeExpr != nil {
+	if desc.IsComputed() {
 		f.WriteString(" AS (")
 		f.WriteString(*desc.ComputeExpr)
 		f.WriteString(") STORED")
@@ -2585,6 +2585,23 @@ func (desc *ColumnDescriptor) DatumType() types.T {
 // IsHidden is part of the optbase.Column interface.
 func (desc *ColumnDescriptor) IsHidden() bool {
 	return desc.Hidden
+}
+
+// IsComputed returns whether the given column is computed.
+func (desc *ColumnDescriptor) IsComputed() bool {
+	return desc.ComputeExpr != nil
+}
+
+// CheckCanBeFKRef returns whether the given column is computed.
+func (desc *ColumnDescriptor) CheckCanBeFKRef() error {
+	if desc.IsComputed() {
+		return pgerror.NewErrorf(
+			pgerror.CodeInvalidTableDefinitionError,
+			"computed column %q cannot be a foreign key reference",
+			desc.Name,
+		)
+	}
+	return nil
 }
 
 var _ optbase.Table = &TableDescriptor{}


### PR DESCRIPTION
Fixes #22428.

Release note (bug fix): Computed columns are now correctly disallowed
from being foreign-key references.