### PR TITLE
opt: Use specific operators for GroupBy grouping and aggregation

### DIFF
--- a/pkg/sql/opt/build/testdata/aggregate
+++ b/pkg/sql/opt/build/testdata/aggregate
@@ -21,8 +21,8 @@ group-by
  ├── columns: column5:int:null:5 column6:int:null:6 column7:int:null:7 column8:int:null:8 column9:decimal:null:9 column10:decimal:null:10 column11:decimal:null:11 column12:decimal:null:12 column13:bool:null:13 column14:bool:null:14 column15:bytes:null:15
  ├── scan
  │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
- ├── projections
- └── projections
+ ├── groupings
+ └── aggregations
       ├── function: min [type=NULL]
       │    └── const: 1 [type=int]
       ├── function: max [type=NULL]
@@ -53,8 +53,8 @@ group-by
  ├── columns: column5:int[]:null:5
  ├── scan
  │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
- ├── projections
- └── projections
+ ├── groupings
+ └── aggregations
       └── function: array_agg [type=NULL]
            └── const: 1 [type=int]
 
@@ -65,8 +65,8 @@ group-by
  ├── columns: column5:jsonb:null:5
  ├── scan
  │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
- ├── projections
- └── projections
+ ├── groupings
+ └── aggregations
       └── function: json_agg [type=NULL]
            └── variable: kv.v [type=int]
 
@@ -77,8 +77,8 @@ group-by
  ├── columns: column1:jsonb:null:1
  ├── values
  │    └── tuple [type=tuple{}]
- ├── projections
- └── projections
+ ├── groupings
+ └── aggregations
       └── function: jsonb_agg [type=NULL]
            └── const: 1 [type=int]
 
@@ -92,9 +92,9 @@ project
  │    ├── columns: kv.v:int:null:2
  │    ├── scan
  │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
- │    ├── projections
+ │    ├── groupings
  │    │    └── variable: kv.v [type=int]
- │    └── projections
+ │    └── aggregations
  └── projections
       └── const: 1 [type=int]
 
@@ -117,9 +117,9 @@ project
  │    ├── columns: kv.k:int:null:1 column5:int:null:5
  │    ├── scan
  │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
- │    ├── projections
+ │    ├── groupings
  │    │    └── variable: kv.k [type=int]
- │    └── projections
+ │    └── aggregations
  │         └── function: count_rows [type=NULL]
  └── projections
       ├── variable: column5 [type=int]
@@ -135,9 +135,9 @@ project
  │    ├── columns: kv.k:int:null:1 column5:int:null:5
  │    ├── scan
  │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
- │    ├── projections
+ │    ├── groupings
  │    │    └── variable: kv.k [type=int]
- │    └── projections
+ │    └── aggregations
  │         └── function: count_rows [type=NULL]
  └── projections
       ├── variable: column5 [type=int]
@@ -168,9 +168,9 @@ project
  │    ├── columns: kv.s:string:null:4 column5:int:null:5
  │    ├── scan
  │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
- │    ├── projections
+ │    ├── groupings
  │    │    └── variable: kv.s [type=string]
- │    └── projections
+ │    └── aggregations
  │         └── function: count_rows [type=NULL]
  └── projections
       ├── variable: column5 [type=int]
@@ -185,9 +185,9 @@ project
  │    ├── columns: kv.s:string:null:4 column5:int:null:5
  │    ├── scan
  │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
- │    ├── projections
+ │    ├── groupings
  │    │    └── variable: kv.s [type=string]
- │    └── projections
+ │    └── aggregations
  │         └── function: count_rows [type=NULL]
  └── projections
       ├── variable: column5 [type=int]
@@ -202,9 +202,9 @@ project
  │    ├── columns: kv.s:string:null:4 column5:int:null:5
  │    ├── scan
  │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
- │    ├── projections
+ │    ├── groupings
  │    │    └── variable: kv.s [type=string]
- │    └── projections
+ │    └── aggregations
  │         └── function: count_rows [type=NULL]
  └── projections
       ├── variable: column5 [type=int]
@@ -219,9 +219,9 @@ project
  │    ├── columns: kv.s:string:null:4 column5:int:null:5
  │    ├── scan
  │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
- │    ├── projections
+ │    ├── groupings
  │    │    └── variable: kv.s [type=string]
- │    └── projections
+ │    └── aggregations
  │         └── function: count_rows [type=NULL]
  └── projections
       ├── variable: column5 [type=int]
@@ -237,10 +237,10 @@ project
  │    ├── columns: kv.v:int:null:2 kv.w:int:null:3 column5:int:null:5
  │    ├── scan
  │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
- │    ├── projections
+ │    ├── groupings
  │    │    ├── variable: kv.v [type=int]
  │    │    └── variable: kv.w [type=int]
- │    └── projections
+ │    └── aggregations
  │         └── function: count_rows [type=NULL]
  └── projections
       ├── variable: kv.v [type=int]
@@ -257,10 +257,10 @@ project
  │    ├── columns: kv.v:int:null:2 kv.w:int:null:3 column5:int:null:5
  │    ├── scan
  │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
- │    ├── projections
+ │    ├── groupings
  │    │    ├── variable: kv.v [type=int]
  │    │    └── variable: kv.w [type=int]
- │    └── projections
+ │    └── aggregations
  │         └── function: count_rows [type=NULL]
  └── projections
       ├── variable: kv.v [type=int]
@@ -277,10 +277,10 @@ project
  │    ├── columns: column5:string:null:5 column6:int:null:6
  │    ├── scan
  │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
- │    ├── projections
+ │    ├── groupings
  │    │    └── function: upper [type=NULL]
  │    │         └── variable: kv.s [type=string]
- │    └── projections
+ │    └── aggregations
  │         └── function: count_rows [type=NULL]
  └── projections
       ├── variable: column6 [type=int]
@@ -296,9 +296,9 @@ project
  │    ├── columns: column5:int:null:5 column6:int:null:6
  │    ├── scan
  │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
- │    ├── projections
+ │    ├── groupings
  │    │    └── const: 3 [type=int]
- │    └── projections
+ │    └── aggregations
  │         └── function: count_rows [type=NULL]
  └── projections
       └── variable: column6 [type=int]
@@ -312,10 +312,10 @@ project
  │    ├── columns: column5:int:null:5 column6:int:null:6
  │    ├── scan
  │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
- │    ├── projections
+ │    ├── groupings
  │    │    └── function: length [type=NULL]
  │    │         └── const: 'abc' [type=string]
- │    └── projections
+ │    └── aggregations
  │         └── function: count_rows [type=NULL]
  └── projections
       └── variable: column6 [type=int]
@@ -330,9 +330,9 @@ project
  │    ├── columns: kv.s:string:null:4 column5:int:null:5
  │    ├── scan
  │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
- │    ├── projections
+ │    ├── groupings
  │    │    └── variable: kv.s [type=string]
- │    └── projections
+ │    └── aggregations
  │         └── function: count_rows [type=NULL]
  └── projections
       ├── variable: column5 [type=int]
@@ -355,11 +355,11 @@ project
  │    ├── columns: column5:int:null:5 column6:int:null:6
  │    ├── scan
  │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
- │    ├── projections
+ │    ├── groupings
  │    │    └── plus [type=int]
  │    │         ├── variable: kv.k [type=int]
  │    │         └── variable: kv.v [type=int]
- │    └── projections
+ │    └── aggregations
  │         └── function: count_rows [type=NULL]
  └── projections
       ├── variable: column6 [type=int]
@@ -376,10 +376,10 @@ project
  │    ├── columns: kv.k:int:null:1 kv.v:int:null:2 column5:int:null:5
  │    ├── scan
  │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
- │    ├── projections
+ │    ├── groupings
  │    │    ├── variable: kv.k [type=int]
  │    │    └── variable: kv.v [type=int]
- │    └── projections
+ │    └── aggregations
  │         └── function: count_rows [type=NULL]
  └── projections
       ├── variable: column5 [type=int]
@@ -422,11 +422,11 @@ project
  │    ├── columns: column5:int:null:5 count_1:int:null:6
  │    ├── scan
  │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
- │    ├── projections
+ │    ├── groupings
  │    │    └── plus [type=int]
  │    │         ├── variable: kv.v [type=int]
  │    │         └── variable: kv.w [type=int]
- │    └── projections
+ │    └── aggregations
  │         └── function: count [type=NULL]
  │              └── variable: kv.k [type=int]
  └── projections
@@ -440,8 +440,8 @@ group-by
  ├── columns: column1:int:null:1
  ├── values
  │    └── tuple [type=tuple{}]
- ├── projections
- └── projections
+ ├── groupings
+ └── aggregations
       └── function: count_rows [type=NULL]
 
 build
@@ -451,8 +451,8 @@ group-by
  ├── columns: column5:int:null:5
  ├── scan
  │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
- ├── projections
- └── projections
+ ├── groupings
+ └── aggregations
       └── function: count [type=NULL]
            └── variable: kv.k [type=int]
 
@@ -463,8 +463,8 @@ group-by
  ├── columns: column1:int:null:1
  ├── values
  │    └── tuple [type=tuple{}]
- ├── projections
- └── projections
+ ├── groupings
+ └── aggregations
       └── function: count [type=NULL]
            └── const: 1 [type=int]
 
@@ -475,8 +475,8 @@ group-by
  ├── columns: column5:int:null:5
  ├── scan
  │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
- ├── projections
- └── projections
+ ├── groupings
+ └── aggregations
       └── function: count [type=NULL]
            └── const: 1 [type=int]
 
@@ -492,8 +492,8 @@ group-by
  ├── columns: column5:int:null:5 column6:int:null:6 column7:int:null:7
  ├── scan
  │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
- ├── projections
- └── projections
+ ├── groupings
+ └── aggregations
       ├── function: count_rows [type=NULL]
       ├── function: count [type=NULL]
       │    └── variable: kv.k [type=int]
@@ -513,8 +513,8 @@ group-by
  ├── columns: column5:int:null:5
  ├── scan
  │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
- ├── projections
- └── projections
+ ├── groupings
+ └── aggregations
       └── function: count [type=NULL]
            └── tuple [type=tuple{int, int}]
                 ├── variable: kv.k [type=int]
@@ -529,8 +529,8 @@ project
  │    ├── columns: column5:int:null:5 column6:int:null:6
  │    ├── scan
  │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
- │    ├── projections
- │    └── projections
+ │    ├── groupings
+ │    └── aggregations
  │         ├── function: count [type=NULL]
  │         │    └── variable: kv.k [type=int]
  │         └── function: count [type=NULL]
@@ -547,8 +547,8 @@ group-by
  ├── columns: column5:int:null:5 column6:int:null:6 column7:int:null:7 column8:int:null:8
  ├── scan
  │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
- ├── projections
- └── projections
+ ├── groupings
+ └── aggregations
       ├── function: min [type=NULL]
       │    └── variable: kv.k [type=int]
       ├── function: max [type=NULL]
@@ -570,8 +570,8 @@ group-by
  │    └── gt [type=bool]
  │         ├── variable: kv.k [type=int]
  │         └── const: 8 [type=int]
- ├── projections
- └── projections
+ ├── groupings
+ └── aggregations
       ├── function: min [type=NULL]
       │    └── variable: kv.k [type=int]
       ├── function: max [type=NULL]
@@ -593,8 +593,8 @@ group-by
  │    └── is [type=bool]
  │         ├── variable: kv.s [type=string]
  │         └── const: NULL [type=NULL]
- ├── projections
- └── projections
+ ├── groupings
+ └── aggregations
       └── function: array_agg [type=NULL]
            └── variable: kv.s [type=string]
 
@@ -605,8 +605,8 @@ group-by
  ├── columns: column5:decimal:null:5 column6:decimal:null:6 column7:decimal:null:7 column8:decimal:null:8
  ├── scan
  │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
- ├── projections
- └── projections
+ ├── groupings
+ └── aggregations
       ├── function: avg [type=NULL]
       │    └── variable: kv.k [type=int]
       ├── function: avg [type=NULL]
@@ -632,8 +632,8 @@ group-by
  ├── columns: column5:string:null:5 column6:float:null:6 column7:bool:null:7 column8:decimal:null:8
  ├── scan
  │    └── columns: abc.a:string:1 abc.b:float:null:2 abc.c:bool:null:3 abc.d:decimal:null:4
- ├── projections
- └── projections
+ ├── groupings
+ └── aggregations
       ├── function: min [type=NULL]
       │    └── variable: abc.a [type=string]
       ├── function: min [type=NULL]
@@ -650,8 +650,8 @@ group-by
  ├── columns: column5:string:null:5 column6:float:null:6 column7:bool:null:7 column8:decimal:null:8
  ├── scan
  │    └── columns: abc.a:string:1 abc.b:float:null:2 abc.c:bool:null:3 abc.d:decimal:null:4
- ├── projections
- └── projections
+ ├── groupings
+ └── aggregations
       ├── function: max [type=NULL]
       │    └── variable: abc.a [type=string]
       ├── function: max [type=NULL]
@@ -668,8 +668,8 @@ group-by
  ├── columns: column5:float:null:5 column6:float:null:6 column7:decimal:null:7 column8:decimal:null:8
  ├── scan
  │    └── columns: abc.a:string:1 abc.b:float:null:2 abc.c:bool:null:3 abc.d:decimal:null:4
- ├── projections
- └── projections
+ ├── groupings
+ └── aggregations
       ├── function: avg [type=NULL]
       │    └── variable: abc.b [type=float]
       ├── function: sum [type=NULL]
@@ -693,8 +693,8 @@ group-by
  ├── columns: column2:interval:null:2
  ├── scan
  │    └── columns: intervals.a:interval:1
- ├── projections
- └── projections
+ ├── groupings
+ └── aggregations
       └── function: sum [type=NULL]
            └── variable: intervals.a [type=interval]
 
@@ -748,8 +748,8 @@ group-by
  ├── columns: column4:int:null:4
  ├── scan
  │    └── columns: xyz.x:int:1 xyz.y:int:null:2 xyz.z:float:null:3
- ├── projections
- └── projections
+ ├── groupings
+ └── aggregations
       └── function: min [type=NULL]
            └── variable: xyz.x [type=int]
 
@@ -768,8 +768,8 @@ group-by
  │              ├── const: 0 [type=int]
  │              ├── const: 4 [type=int]
  │              └── const: 7 [type=int]
- ├── projections
- └── projections
+ ├── groupings
+ └── aggregations
       └── function: min [type=NULL]
            └── variable: xyz.x [type=int]
 
@@ -780,8 +780,8 @@ group-by
  ├── columns: column4:int:null:4
  ├── scan
  │    └── columns: xyz.x:int:1 xyz.y:int:null:2 xyz.z:float:null:3
- ├── projections
- └── projections
+ ├── groupings
+ └── aggregations
       └── function: max [type=NULL]
            └── variable: xyz.x [type=int]
 
@@ -797,8 +797,8 @@ group-by
  │    └── eq [type=bool]
  │         ├── variable: xyz.x [type=int]
  │         └── const: 1 [type=int]
- ├── projections
- └── projections
+ ├── groupings
+ └── aggregations
       └── function: max [type=NULL]
            └── variable: xyz.y [type=int]
 
@@ -814,8 +814,8 @@ group-by
  │    └── eq [type=bool]
  │         ├── variable: xyz.x [type=int]
  │         └── const: 7 [type=int]
- ├── projections
- └── projections
+ ├── groupings
+ └── aggregations
       └── function: min [type=NULL]
            └── variable: xyz.y [type=int]
 
@@ -835,8 +835,8 @@ group-by
  │         └── tuple [type=tuple{int, float}]
  │              ├── const: 2 [type=int]
  │              └── const: 3.0 [type=float]
- ├── projections
- └── projections
+ ├── groupings
+ └── aggregations
       └── function: min [type=NULL]
            └── variable: xyz.x [type=int]
 
@@ -856,8 +856,8 @@ group-by
  │         └── tuple [type=tuple{float, int}]
  │              ├── const: 3.0 [type=float]
  │              └── const: 2 [type=int]
- ├── projections
- └── projections
+ ├── groupings
+ └── aggregations
       └── function: max [type=NULL]
            └── variable: xyz.x [type=int]
 
@@ -876,8 +876,8 @@ group-by
  │    └── eq [type=bool]
  │         ├── variable: xyz.x [type=int]
  │         └── const: 10 [type=int]
- ├── projections
- └── projections
+ ├── groupings
+ └── aggregations
       └── function: variance [type=NULL]
            └── variable: xyz.x [type=int]
 
@@ -893,8 +893,8 @@ group-by
  │    └── eq [type=bool]
  │         ├── variable: xyz.x [type=int]
  │         └── const: 1 [type=int]
- ├── projections
- └── projections
+ ├── groupings
+ └── aggregations
       └── function: stddev [type=NULL]
            └── variable: xyz.x [type=int]
 
@@ -909,8 +909,8 @@ group-by
  ├── columns: column3:bool:null:3 column4:bool:null:4
  ├── scan
  │    └── columns: bools.b:bool:null:1 bools.rowid:int:2
- ├── projections
- └── projections
+ ├── groupings
+ └── aggregations
       ├── function: bool_and [type=NULL]
       │    └── variable: bools.b [type=bool]
       └── function: bool_or [type=NULL]
@@ -927,12 +927,12 @@ project
  │    ├── columns: kv.k:int:null:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
  │    ├── scan
  │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
- │    ├── projections
+ │    ├── groupings
  │    │    ├── variable: kv.k [type=int]
  │    │    ├── variable: kv.v [type=int]
  │    │    ├── variable: kv.w [type=int]
  │    │    └── variable: kv.s [type=string]
- │    └── projections
+ │    └── aggregations
  └── projections
       └── const: 1 [type=int]
 
@@ -949,8 +949,8 @@ project
  │    ├── columns: column5:bytes:null:5 column7:int:null:7
  │    ├── scan
  │    │    └── columns: xor_bytes.a:bytes:null:1 xor_bytes.b:int:null:2 xor_bytes.c:int:null:3 xor_bytes.rowid:int:4
- │    ├── projections
- │    └── projections
+ │    ├── groupings
+ │    └── aggregations
  │         ├── function: xor_agg [type=NULL]
  │         │    └── variable: xor_bytes.a [type=bytes]
  │         └── function: xor_agg [type=NULL]
@@ -967,8 +967,8 @@ group-by
  ├── columns: column1:bool:null:1 column2:bool:null:2
  ├── values
  │    └── tuple [type=tuple{}]
- ├── projections
- └── projections
+ ├── groupings
+ └── aggregations
       ├── function: max [type=NULL]
       │    └── const: true [type=bool]
       └── function: min [type=NULL]
@@ -997,10 +997,10 @@ project
  │    ├── columns: ab.a:int:null:1 ab.b:int:null:2
  │    ├── scan
  │    │    └── columns: ab.a:int:1 ab.b:int:null:2
- │    ├── projections
+ │    ├── groupings
  │    │    ├── variable: ab.b [type=int]
  │    │    └── variable: ab.a [type=int]
- │    └── projections
+ │    └── aggregations
  └── projections
       └── tuple [type=tuple{int, int}]
            ├── variable: ab.b [type=int]
@@ -1021,11 +1021,11 @@ project
  │    │    ├── scan
  │    │    │    └── columns: xy.x:string:null:3 xy.y:string:null:4 xy.rowid:int:5
  │    │    └── true [type=bool]
- │    ├── projections
+ │    ├── groupings
  │    │    ├── variable: xy.x [type=string]
  │    │    ├── variable: ab.a [type=int]
  │    │    └── variable: ab.b [type=int]
- │    └── projections
+ │    └── aggregations
  │         └── function: min [type=NULL]
  │              └── variable: xy.y [type=string]
  └── projections
@@ -1043,14 +1043,14 @@ project
  │    ├── columns: column5:int:null:5 column6:int:null:6
  │    ├── scan
  │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
- │    ├── projections
+ │    ├── groupings
  │    │    ├── plus [type=int]
  │    │    │    ├── variable: kv.k [type=int]
  │    │    │    └── variable: kv.v [type=int]
  │    │    └── plus [type=int]
  │    │         ├── variable: kv.v [type=int]
  │    │         └── variable: kv.w [type=int]
- │    └── projections
+ │    └── aggregations
  └── projections
       └── div [type=decimal]
            ├── plus [type=int]

--- a/pkg/sql/opt/ops/scalar.opt
+++ b/pkg/sql/opt/ops/scalar.opt
@@ -52,11 +52,30 @@ define Tuple {
 }
 
 # Projections is a set of typed scalar expressions that will become output
-# columns for a containing relational expression, such as Project or GroupBy.
+# columns for a containing Project operator. The private Cols field contains
+# the set of column indexes returned by the expression, as a *ColList.
+[Scalar]
+define Projections {
+    Elems ExprList
+    Cols  ColList
+}
+
+# Aggregations is a set of aggregate expressions that will become output
+# columns for a containing GroupBy operator. The private Cols field contains
+# the set of column indexes returned by the expression, as a *ColList.
+[Scalar]
+define Aggregations {
+    Aggs ExprList
+    Cols ColList
+}
+
+# Groupings is a set of grouping expressions that will become output columns
+# for a containing GroupBy operator. The GroupBy operator groups its input by
+# the value of these expressions, and may compute aggregates over the groups.
 # The private Cols field contains the set of column indexes returned by the
 # expression, as a *ColList.
 [Scalar]
-define Projections {
+define Groupings {
     Elems ExprList
     Cols  ColList
 }

--- a/pkg/sql/opt/opt/factory.og.go
+++ b/pkg/sql/opt/opt/factory.og.go
@@ -32,6 +32,8 @@ type Factory interface {
 	ConstructPlaceholder(value PrivateID) GroupID
 	ConstructTuple(elems ListID) GroupID
 	ConstructProjections(elems ListID, cols PrivateID) GroupID
+	ConstructAggregations(aggs ListID, cols PrivateID) GroupID
+	ConstructGroupings(elems ListID, cols PrivateID) GroupID
 	ConstructFilters(conditions ListID) GroupID
 	ConstructExists(input GroupID) GroupID
 	ConstructAnd(left GroupID, right GroupID) GroupID

--- a/pkg/sql/opt/opt/operator.og.go
+++ b/pkg/sql/opt/opt/operator.og.go
@@ -14,6 +14,8 @@ const (
 	PlaceholderOp
 	TupleOp
 	ProjectionsOp
+	AggregationsOp
+	GroupingsOp
 	FiltersOp
 	ExistsOp
 	AndOp
@@ -93,9 +95,9 @@ const (
 	NumOperators
 )
 
-const opNames = "unknownsubqueryvariableconsttruefalseplaceholdertupleprojectionsfiltersexistsandornoteqltgtlegeneinnot-inlikenot-likei-likenot-i-likesimilar-tonot-similar-toreg-matchnot-reg-matchreg-i-matchnot-reg-i-matchisis-notcontainscontained-bybitandbitorbitxorplusminusmultdivfloor-divmodpowconcatl-shiftr-shiftfetch-valfetch-textfetch-val-pathfetch-text-pathunary-plusunary-minusunary-complementfunctionscanvaluesselectprojectinner-joinleft-joinright-joinfull-joinsemi-joinanti-joininner-join-applyleft-join-applyright-join-applyfull-join-applysemi-join-applyanti-join-applygroup-byunionintersectexceptsortpresent"
+const opNames = "unknownsubqueryvariableconsttruefalseplaceholdertupleprojectionsaggregationsgroupingsfiltersexistsandornoteqltgtlegeneinnot-inlikenot-likei-likenot-i-likesimilar-tonot-similar-toreg-matchnot-reg-matchreg-i-matchnot-reg-i-matchisis-notcontainscontained-bybitandbitorbitxorplusminusmultdivfloor-divmodpowconcatl-shiftr-shiftfetch-valfetch-textfetch-val-pathfetch-text-pathunary-plusunary-minusunary-complementfunctionscanvaluesselectprojectinner-joinleft-joinright-joinfull-joinsemi-joinanti-joininner-join-applyleft-join-applyright-join-applyfull-join-applysemi-join-applyanti-join-applygroup-byunionintersectexceptsortpresent"
 
-var opIndexes = [...]uint32{0, 7, 15, 23, 28, 32, 37, 48, 53, 64, 71, 77, 80, 82, 85, 87, 89, 91, 93, 95, 97, 99, 105, 109, 117, 123, 133, 143, 157, 166, 179, 190, 205, 207, 213, 221, 233, 239, 244, 250, 254, 259, 263, 266, 275, 278, 281, 287, 294, 301, 310, 320, 334, 349, 359, 370, 386, 394, 398, 404, 410, 417, 427, 436, 446, 455, 464, 473, 489, 504, 520, 535, 550, 565, 573, 578, 587, 593, 597, 604}
+var opIndexes = [...]uint32{0, 7, 15, 23, 28, 32, 37, 48, 53, 64, 76, 85, 92, 98, 101, 103, 106, 108, 110, 112, 114, 116, 118, 120, 126, 130, 138, 144, 154, 164, 178, 187, 200, 211, 226, 228, 234, 242, 254, 260, 265, 271, 275, 280, 284, 287, 296, 299, 302, 308, 315, 322, 331, 341, 355, 370, 380, 391, 407, 415, 419, 425, 431, 438, 448, 457, 467, 476, 485, 494, 510, 525, 541, 556, 571, 586, 594, 599, 608, 614, 618, 625}
 
 var ScalarOperators = [...]Operator{
 	SubqueryOp,
@@ -106,6 +108,8 @@ var ScalarOperators = [...]Operator{
 	PlaceholderOp,
 	TupleOp,
 	ProjectionsOp,
+	AggregationsOp,
+	GroupingsOp,
 	FiltersOp,
 	ExistsOp,
 	AndOp,


### PR DESCRIPTION
GroupBy previously reused the Projections operator for its Groupings
and Aggregations fields. However, it makes rules and tree printing
easier to understand if we use separate ops. This PR adds two new
ops: Groupings and Aggregations that behave similarly to Projections.

Release note: None