### PR TITLE
nightly: add cluster object

### DIFF
--- a/pkg/nightly/cluster_test.go
+++ b/pkg/nightly/cluster_test.go
@@ -1,0 +1,359 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+
+package nightly
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/util/fileutil"
+	"github.com/pkg/errors"
+	"golang.org/x/sync/errgroup"
+)
+
+// cluster provides an interface for interacting with a set of machines,
+// starting and stopping a cockroach cluster on a subset of those machines, and
+// running load generators and other operations on the machines.
+//
+// A cluster is intended to be used only by a single test. Sharing of a cluster
+// between a test and a subtest is current disallowed (see cluster.assertT). A
+// cluster is safe for concurrent use by multiple goroutines.
+type cluster struct {
+	name     string
+	testName string
+	l        *logger
+}
+
+func newCluster(ctx context.Context, t *testing.T, args ...string) *cluster {
+	var l *logger
+	if *local {
+		l = stdLogger(t.Name())
+	} else {
+		var err error
+		if l, err = rootLogger(t.Name()); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	c := &cluster{
+		name:     makeClusterName(t),
+		testName: t.Name(),
+		l:        l,
+	}
+
+	args = append([]string{"roachprod", "create", c.name}, args...)
+	if err := runCmd(ctx, l, args...); err != nil {
+		t.Fatal(err)
+		return nil
+	}
+	return c
+}
+
+func (c *cluster) assertT(t *testing.T) {
+	if c.testName != t.Name() {
+		panic(fmt.Sprintf("cluster created by %s, but used by %s", c.testName, t.Name()))
+	}
+}
+
+func (c *cluster) Destroy(ctx context.Context, t *testing.T) {
+	c.assertT(t)
+	if !c.isLocal() {
+		// TODO(peter): Figure out how to retrieve local logs. One option would be
+		// to stop the cluster and mv ~/local to wherever we want it.
+		_ = runCmd(ctx, c.l, "roachprod", "get", c.name, "logs",
+			filepath.Join(*artifacts, fileutil.EscapeFilename(c.testName)))
+	}
+	if err := runCmd(ctx, c.l, "roachprod", "destroy", c.name); err != nil {
+		c.l.errorf("%s", err)
+	}
+	unregisterCluster(c.name)
+}
+
+// Put a local file to all of the machines in a cluster.
+func (c *cluster) Put(ctx context.Context, t *testing.T, src, dest string) {
+	c.assertT(t)
+	if t.Failed() {
+		// If the test has failed, don't try to limp along.
+		return
+	}
+	t.Helper()
+	if c.isLocal() {
+		switch dest {
+		case "<cockroach>", "<workload>":
+			// We don't have to put binaries for local clusters.
+			return
+		}
+	}
+	err := runCmd(ctx, c.l, "roachprod", "put", c.name, src, c.expand(dest))
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+// Start cockroach nodes on a subset of the cluster. The nodes parameter can
+// either be a specific node, empty (to indicate all nodes), or a pair of nodes
+// indicating a range.
+func (c *cluster) Start(ctx context.Context, t *testing.T, nodes ...int) {
+	c.assertT(t)
+	if t.Failed() {
+		// If the test has failed, don't try to limp along.
+		return
+	}
+	t.Helper()
+	binary := "./cockroach"
+	if c.isLocal() {
+		binary = *cockroach
+	}
+	err := runCmd(ctx, c.l, "roachprod", "start", "-b", binary, c.selector(t, nodes...))
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+// Stop cockroach nodes running on a subset of the cluster. See cluster.Start()
+// for a description of the nodes parameter.
+func (c *cluster) Stop(ctx context.Context, t *testing.T, nodes ...int) {
+	c.assertT(t)
+	if t.Failed() {
+		// If the test has failed, don't try to limp along.
+		return
+	}
+	t.Helper()
+	err := runCmd(ctx, c.l, "roachprod", "stop", c.selector(t, nodes...))
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+// wipe a subset of the nodes in a cluster. See cluster.Start() for a
+// description of the nodes parameter.
+func (c *cluster) Wipe(ctx context.Context, t *testing.T, nodes ...int) {
+	c.assertT(t)
+	if t.Failed() {
+		// If the test has failed, don't try to limp along.
+		return
+	}
+	t.Helper()
+	err := runCmd(ctx, c.l, "roachprod", "wipe", c.selector(t, nodes...))
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TODO(pmattis): cluster.Stop and cluster.Wipe are neither used or
+// tested. Silence unused warning.
+var _ = (*cluster).Stop
+var _ = (*cluster).Wipe
+
+// Run a command on the specified node.
+func (c *cluster) Run(ctx context.Context, t *testing.T, node int, cmd string) {
+	c.assertT(t)
+	if t.Failed() {
+		// If the test has failed, don't try to limp along.
+		return
+	}
+	t.Helper()
+	err := runCmd(ctx, c.l,
+		"roachprod", "ssh", fmt.Sprintf("%s:%d", c.name, node), "--", c.expand(cmd))
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+// Monitor monitors a cockroach cluster, watching for unexpected node
+// failures. A failure occurs if either the errgroup returns an error or if a
+// cockroach node dies.
+func (c *cluster) Monitor(ctx context.Context, t *testing.T, g *errgroup.Group) {
+	c.assertT(t)
+	if t.Failed() {
+		// If the test has failed, don't try to limp along.
+		return
+	}
+	t.Helper()
+
+	err := c.monitor(ctx, t, g, "roachprod", "monitor", c.name)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func (c *cluster) monitor(
+	ctx context.Context, t *testing.T, g *errgroup.Group, args ...string,
+) error {
+	t.Helper()
+
+	done := make(chan error)
+	go func() {
+		done <- g.Wait()
+	}()
+
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	pipeR, pipeW := io.Pipe()
+	go func() {
+		defer func() { _ = pipeW.Close() }()
+
+		// TODO(peter): Dan's version of this code created a child logger here via
+		// l.childLogger(`MONITOR`). This doesn't work well with `stdLogger`
+		// because it creates a file named `std_MONITOR`. Figure out what to do
+		// here.
+
+		cmd := exec.CommandContext(ctx, args[0], args[1:]...)
+		cmd.Stdout = pipeW
+		cmd.Stderr = c.l.stderr
+		if err := cmd.Run(); err != nil {
+			if err != context.Canceled && !strings.Contains(err.Error(), "killed") {
+				// The expected reason for an error is that the monitor was killed due
+				// to the context being canceled. Any other error is an actual error.
+				t.Fatal(err)
+			}
+			// Returning will cause the pipe to be closed which will cause the reader
+			// goroutine to exit and close the monitoring channel.
+			return
+		}
+	}()
+
+	monitorCh := make(chan string)
+	go func() {
+		defer func() { _ = pipeR.Close() }()
+		defer close(monitorCh)
+
+		scanner := bufio.NewScanner(pipeR)
+		for scanner.Scan() {
+			monitorCh <- scanner.Text()
+		}
+	}()
+
+	for {
+		select {
+		case err := <-done:
+			return err
+		case msg, ok := <-monitorCh:
+			if !ok {
+				return fmt.Errorf("monitor died unexpectedly")
+			}
+			if strings.Contains(msg, "dead") {
+				return fmt.Errorf("unexpected node event: %s", msg)
+			}
+		}
+	}
+}
+
+func (c *cluster) selector(t *testing.T, nodes ...int) string {
+	t.Helper()
+	switch len(nodes) {
+	case 0:
+		return c.name
+	case 1:
+		return fmt.Sprintf("%s:%d", c.name, nodes[0])
+	case 2:
+		return fmt.Sprintf("%s:%d-%d", c.name, nodes[0], nodes[1])
+	default:
+		t.Fatalf("bad nodes specification: %d", nodes)
+		return ""
+	}
+}
+
+func (c *cluster) expand(s string) string {
+	if c.isLocal() {
+		s = strings.Replace(s, "<cockroach>", *cockroach, -1)
+		s = strings.Replace(s, "<workload>", *workload, -1)
+	} else {
+		s = strings.Replace(s, "<cockroach>", "./cockroach", -1)
+		s = strings.Replace(s, "<workload>", "./workload", -1)
+	}
+	return s
+}
+
+func (c *cluster) isLocal() bool {
+	return c.name == "local"
+}
+
+func TestInvalidClusterUsage(t *testing.T) {
+	// Verify that it is invalid to share a cluster between a parent test and
+	// child tests. This is necessary because we arrange to run nightly tests in
+	// parallel and such sharing of a cluster would lead to all sorts of
+	// weirdness in the test.
+	c := &cluster{testName: t.Name()}
+
+	t.Run("child", func(t *testing.T) {
+		defer func() {
+			err := recover()
+			if !strings.Contains(fmt.Sprint(err), "but used by") {
+				t.Fatalf("expected a invalid usage panic, but found %v", err)
+			}
+		}()
+		c.Put(context.Background(), t, "foo", "bar")
+	})
+}
+
+func TestClusterMonitor(t *testing.T) {
+	t.Run(`success`, func(t *testing.T) {
+		c := &cluster{testName: t.Name(), l: stdLogger(t.Name())}
+		g := &errgroup.Group{}
+		g.Go(func() error { return nil })
+		if err := c.monitor(context.Background(), t, g, `sleep`, `100`); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	t.Run(`dead`, func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		c := &cluster{testName: t.Name(), l: stdLogger(t.Name())}
+		g := &errgroup.Group{}
+		g.Go(func() error {
+			<-ctx.Done()
+			return ctx.Err()
+		})
+
+		err := c.monitor(ctx, t, g, `echo`, "1: 100\n1: dead")
+		expectedErr := `dead`
+		if !testutils.IsError(err, expectedErr) {
+			t.Errorf(`expected %s err got: %+v`, expectedErr, err)
+		}
+	})
+
+	t.Run(`worker-fail`, func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		c := &cluster{testName: t.Name(), l: stdLogger(t.Name())}
+		g, ctx := errgroup.WithContext(ctx)
+		g.Go(func() error {
+			return errors.New(`worker-fail`)
+		})
+		g.Go(func() error {
+			<-ctx.Done()
+			return ctx.Err()
+		})
+
+		err := c.monitor(ctx, t, g, `sleep`, `100`)
+		expectedErr := `worker-fail`
+		if !testutils.IsError(err, expectedErr) {
+			t.Errorf(`expected %s err got: %+v`, expectedErr, err)
+		}
+	})
+}

--- a/pkg/nightly/cluster_test.go
+++ b/pkg/nightly/cluster_test.go
@@ -18,6 +18,7 @@ package nightly
 import (
 	"bufio"
 	"context"
+	"flag"
 	"fmt"
 	"io"
 	"os"
@@ -34,6 +35,8 @@ import (
 	"github.com/pkg/errors"
 	"golang.org/x/sync/errgroup"
 )
+
+var clusterID = flag.String("clusterid", "", "An identifier to use in the test cluster's name")
 
 func runCmd(ctx context.Context, l *logger, args ...string) error {
 	l.printf("> %s\n", strings.Join(args, " "))
@@ -85,6 +88,9 @@ type cluster struct {
 	l        *logger
 }
 
+// TODO(peter): Should set the lifetime of clusters to 2x the expected test
+// duration. The default lifetime of 12h is too long for some tests and will be
+// too short for others.
 func newCluster(ctx context.Context, t *testing.T, args ...string) *cluster {
 	var l *logger
 	if *local {

--- a/pkg/nightly/log_test.go
+++ b/pkg/nightly/log_test.go
@@ -41,12 +41,13 @@ func newLogger(name, filename string, stdout, stderr io.Writer) (*logger, error)
 	if err != nil {
 		return nil, err
 	}
-	p := name + ": "
+	p := []byte(name + ": ")
+
 	return &logger{
 		name:   name,
 		file:   f,
-		stdout: &dualLogger{prefix: p, shared: stdout, dedicated: f},
-		stderr: &dualLogger{prefix: p, shared: stderr, dedicated: f},
+		stdout: io.MultiWriter(f, &prefixWriter{out: stdout, prefix: p}),
+		stderr: io.MultiWriter(f, &prefixWriter{out: stderr, prefix: p}),
 	}, nil
 }
 
@@ -56,13 +57,27 @@ func rootLogger(name string) (*logger, error) {
 
 func stdLogger(name string) *logger {
 	return &logger{
-		name:   "std",
 		stdout: os.Stdout,
 		stderr: os.Stderr,
 	}
 }
 
+func (l *logger) close() {
+	if l.file != nil {
+		l.file.Close()
+	}
+}
+
 func (l *logger) childLogger(name string) (*logger, error) {
+	if l.file == nil {
+		p := []byte(name + ": ")
+		return &logger{
+			name:   name,
+			stdout: &prefixWriter{out: l.stdout, prefix: p},
+			stderr: &prefixWriter{out: l.stderr, prefix: p},
+		}, nil
+	}
+
 	filename := l.name + "_" + name
 	return newLogger(name, filename, l.stdout, l.stderr)
 }
@@ -75,20 +90,39 @@ func (l *logger) errorf(f string, args ...interface{}) {
 	fmt.Fprintf(l.stderr, f, args...)
 }
 
-type dualLogger struct {
-	prefix    string
-	shared    io.Writer
-	dedicated io.Writer
+type prefixWriter struct {
+	out    io.Writer
+	prefix []byte
+	buf    []byte
 }
 
-func (d *dualLogger) Write(data []byte) (int, error) {
-	// Transform data like "a\nb" into "PREFIX: a\nPREFIX b\n" before writing it
-	// to the shared channel. We always
-	prefixed := []byte(d.prefix)
-	prefixed = append(prefixed, data...)
-	prefixed = bytes.TrimSuffix(prefixed, []byte{'\n'})
-	prefixed = bytes.Replace(prefixed, []byte{'\n'}, []byte("\n"+d.prefix), -1)
-	prefixed = append(prefixed, '\n')
-	_, _ = d.shared.Write(prefixed)
-	return d.dedicated.Write(data)
+func (w *prefixWriter) Write(data []byte) (int, error) {
+	// Note that we only output data to the underlying writer when we see a
+	// newline. No newline and the data is buffered. We don't have a signal for
+	// when the end of data is reached, which means we won't output any trailing
+	// data if it isn't terminated with a newline.
+	var count int
+	for len(data) > 0 {
+		if len(w.buf) == 0 {
+			w.buf = append(w.buf, w.prefix...)
+		}
+
+		i := bytes.IndexByte(data, '\n')
+		if i == -1 {
+			// No newline, buffer the partial line.
+			w.buf = append(w.buf, data...)
+			count += len(data)
+			break
+		}
+
+		// Output the buffered line including prefix.
+		w.buf = append(w.buf, data[:i+1]...)
+		if _, err := w.out.Write(w.buf); err != nil {
+			return 0, err
+		}
+		w.buf = w.buf[:0]
+		data = data[i+1:]
+		count += i + 1
+	}
+	return count, nil
 }

--- a/pkg/nightly/main_test.go
+++ b/pkg/nightly/main_test.go
@@ -39,7 +39,12 @@ var workload = flag.String("workload", "", "Path to workload binary to use")
 func checkTestTimeout(t testing.TB) {
 	f := flag.Lookup("test.timeout")
 	d := f.Value.(flag.Getter).Get().(time.Duration)
-	if d > 0 && d < time.Hour {
+	if d == 0 {
+		// The default timeout is 10m, despite the flag setting due to special code
+		// in the go tool.
+		d = 10 * time.Minute
+	}
+	if d < time.Hour {
 		t.Fatalf("-timeout is too short: %s", d)
 	}
 }
@@ -53,8 +58,8 @@ func findBinary(binary, defValue string) (string, error) {
 		return filepath.Abs(binary)
 	}
 
-	// For "local" clusters we have to find the binary to run and translate it to
-	// an absolute path. First, look for the binary in PATH.
+	// Find the binary to run and translate it to an absolute path. First, look
+	// for the binary in PATH.
 	path, err := exec.LookPath(binary)
 	if err != nil {
 		if strings.HasPrefix(binary, "/") {

--- a/pkg/nightly/nightly_test.go
+++ b/pkg/nightly/nightly_test.go
@@ -17,95 +17,12 @@ package nightly
 
 import (
 	"context"
-	"flag"
 	"fmt"
-	"os"
-	"os/exec"
-	"path/filepath"
-	"strings"
-	"sync"
 	"testing"
-	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"golang.org/x/sync/errgroup"
 )
-
-var slow = flag.Bool("slow", false, "Run slow tests")
-var local = flag.Bool("local", false, "Run tests locally")
-var artifacts = flag.String("artifacts", "", "Path to artifacts directory")
-var cockroach = flag.String("cockroach", "", "Path to cockroach binary to use")
-var workload = flag.String("workload", "", "Path to workload binary to use")
-var clusterID = flag.String("clusterid", "", "An identifier to use in the test cluster's name")
-var initOnce sync.Once
-
-func checkTestTimeout(t testing.TB) {
-	f := flag.Lookup("test.timeout")
-	d := f.Value.(flag.Getter).Get().(time.Duration)
-	if d > 0 && d < time.Hour {
-		t.Fatalf("-timeout is too short: %s", d)
-	}
-}
-
-func findBinary(binary, defValue string) (string, error) {
-	if binary == "" {
-		binary = defValue
-	}
-
-	if _, err := os.Stat(binary); err == nil {
-		return filepath.Abs(binary)
-	}
-
-	// For "local" clusters we have to find the binary to run and translate it to
-	// an absolute path. First, look for the binary in PATH.
-	path, err := exec.LookPath(binary)
-	if err != nil {
-		if strings.HasPrefix(binary, "/") {
-			return "", err
-		}
-		// We're unable to find the binary in PATH and "binary" is a relative path:
-		// look in the cockroach repo.
-		gopath := os.Getenv("GOPATH")
-		if gopath == "" {
-			return "", err
-		}
-		path = filepath.Join(gopath, "/src/github.com/cockroachdb/cockroach/", binary)
-		var err2 error
-		path, err2 = exec.LookPath(path)
-		if err2 != nil {
-			return "", err
-		}
-	}
-	return filepath.Abs(path)
-}
-
-func initBinaries(t *testing.T) {
-	var err error
-	*cockroach, err = findBinary(*cockroach, "cockroach")
-	if err != nil {
-		t.Fatal(err)
-	}
-	*workload, err = findBinary(*workload, "workload")
-	if err != nil {
-		t.Fatal(err)
-	}
-}
-
-func maybeSkip(t *testing.T) {
-	if !*slow {
-		t.Skipf("-slow not specified")
-	}
-
-	initOnce.Do(func() {
-		checkTestTimeout(t)
-		initBinaries(t)
-	})
-
-	// If we're not running locally, we can run tests in parallel.
-	if !*local {
-		t.Parallel()
-	}
-}
 
 func TestLocal(t *testing.T) {
 	if !*local {

--- a/pkg/nightly/nightly_test.go
+++ b/pkg/nightly/nightly_test.go
@@ -27,6 +27,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -39,10 +40,12 @@ import (
 )
 
 var slow = flag.Bool("slow", false, "Run slow tests")
+var local = flag.Bool("local", false, "Run tests locally")
 var artifacts = flag.String("artifacts", "", "Path to artifacts directory")
 var cockroach = flag.String("cockroach", "", "Path to cockroach binary to use")
 var workload = flag.String("workload", "", "Path to workload binary to use")
 var clusterID = flag.String("clusterid", "", "An identifier to use in the test cluster's name")
+var initOnce sync.Once
 
 func checkTestTimeout(t testing.TB) {
 	f := flag.Lookup("test.timeout")
@@ -52,28 +55,71 @@ func checkTestTimeout(t testing.TB) {
 	}
 }
 
-func maybeSkip(t testing.TB) {
-	if !*slow {
-		if testing.Verbose() {
-			fmt.Fprintf(os.Stderr, "skipping %s because -slow flag was not provided\n", t.Name())
-		}
-		t.Skip()
+func findBinary(binary, defValue string) (string, error) {
+	if binary == "" {
+		binary = defValue
 	}
 
-	checkTestTimeout(t)
-	if _, err := os.Stat(*cockroach); err != nil {
-		t.Fatal(errors.Wrap(err, `missing cockroach binary`))
+	if _, err := os.Stat(binary); err == nil {
+		return filepath.Abs(binary)
 	}
-	if _, err := os.Stat(*workload); err != nil {
-		t.Fatal(errors.Wrap(err, `missing workload binary`))
+
+	// For "local" clusters we have to find the binary to run and translate it to
+	// an absolute path. First, look for the binary in PATH.
+	path, err := exec.LookPath(binary)
+	if err != nil {
+		if strings.HasPrefix(binary, "/") {
+			return "", err
+		}
+		// We're unable to find the binary in PATH and "binary" is a relative path:
+		// look in the cockroach repo.
+		gopath := os.Getenv("GOPATH")
+		if gopath == "" {
+			return "", err
+		}
+		path = filepath.Join(gopath, "/src/github.com/cockroachdb/cockroach/", binary)
+		var err2 error
+		path, err2 = exec.LookPath(path)
+		if err2 != nil {
+			return "", err
+		}
+	}
+	return filepath.Abs(path)
+}
+
+func initBinaries(t *testing.T) {
+	var err error
+	*cockroach, err = findBinary(*cockroach, "cockroach")
+	if err != nil {
+		t.Fatal(err)
+	}
+	*workload, err = findBinary(*workload, "workload")
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func maybeSkip(t *testing.T) {
+	if !*slow {
+		t.Skipf("-slow not specified")
+	}
+
+	initOnce.Do(func() {
+		checkTestTimeout(t)
+		initBinaries(t)
+	})
+
+	// If we're not running locally, we can run tests in parallel.
+	if !*local {
+		t.Parallel()
 	}
 }
 
 func runCmd(ctx context.Context, l *logger, args ...string) error {
 	l.printf("> %s\n", strings.Join(args, " "))
 	cmd := exec.CommandContext(ctx, args[0], args[1:]...)
-	cmd.Stdout = &l.stdout
-	cmd.Stderr = &l.stderr
+	cmd.Stdout = l.stdout
+	cmd.Stderr = l.stderr
 	if err := cmd.Run(); err != nil {
 		return errors.Wrapf(err, `runCmd: %s`, strings.Join(args, ` `))
 	}
@@ -101,7 +147,12 @@ func destroyCluster(t testing.TB, l *logger, clusterName string) {
 	unregisterCluster(clusterName)
 }
 
-func makeClusterName(t testing.TB) string {
+func makeClusterName(t *testing.T) string {
+	if *local {
+		return "local"
+	}
+
+	t.Parallel()
 	username := os.Getenv("ROACHPROD_USER")
 	if username == "" {
 		usr, err := user.Current()
@@ -122,59 +173,65 @@ func makeClusterName(t testing.TB) string {
 	return name
 }
 
+func TestLocal(t *testing.T) {
+	if !*local {
+		t.Skipf("-local not specified")
+	}
+	maybeSkip(t)
+
+	ctx := context.Background()
+	c := newCluster(ctx, t, "-n", "1")
+	defer c.Destroy(ctx, t)
+
+	c.Put(ctx, t, *cockroach, "<cockroach>")
+	c.Put(ctx, t, *workload, "<workload>")
+	c.Start(ctx, t, 1)
+
+	g, ctx := errgroup.WithContext(ctx)
+	g.Go(func() error {
+		c.Run(ctx, t, 1, "<workload> run kv --init --read-percent=95 --splits=100 --duration=10s")
+		return nil
+	})
+	c.Monitor(ctx, t, g)
+}
+
 func TestSingleDC(t *testing.T) {
 	maybeSkip(t)
-	t.Parallel()
 
 	// TODO(dan): It's not clear to me yet how all the various configurations of
 	// clusters (# of machines in each locality) are going to generalize. For now,
 	// just hardcode what we had before.
 	for testName, testCmd := range map[string]string{
-		"kv0":     "./workload run kv --init --read-percent=0 --splits=1000 --concurrency=384 --duration=10m",
-		"kv95":    "./workload run kv --init --read-percent=95 --splits=1000 --concurrency=384 --duration=10m",
-		"splits":  "./workload run kv --init --read-percent=0 --splits=100000 --concurrency=384 --max-ops=1 --duration=10m",
-		"tpcc_w1": "./workload run tpcc --init --warehouses=1 --wait=false --concurrency=384 --duration=10m",
-		"tpmc_w1": "./workload run tpcc --init --warehouses=1 --concurrency=10 --duration=10m",
+		"kv0":     "<workload> run kv --init --read-percent=0 --splits=1000 --concurrency=384 --duration=1m",
+		"kv95":    "<workload> run kv --init --read-percent=95 --splits=1000 --concurrency=384 --duration=1m",
+		"splits":  "<workload> run kv --init --read-percent=0 --splits=100000 --concurrency=384 --max-ops=1 --duration=10m",
+		"tpcc_w1": "<workload> run tpcc --init --warehouses=1 --wait=false --concurrency=384 --duration=10m",
+		"tpmc_w1": "<workload> run tpcc --init --warehouses=1 --concurrency=10 --duration=10m",
 	} {
 		testName, testCmd := testName, testCmd
 		t.Run(testName, func(t *testing.T) {
-			t.Parallel()
 			ctx := context.Background()
+			c := newCluster(ctx, t, "-n", "4")
+			defer c.Destroy(ctx, t)
 
-			l, err := rootLogger(t.Name())
-			if err != nil {
-				t.Fatal(err)
-			}
+			c.Put(ctx, t, *cockroach, "<cockroach>")
+			c.Put(ctx, t, *workload, "<workload>")
+			c.Start(ctx, t, 1, 3)
 
-			clusterName := makeClusterName(t)
-			defer destroyCluster(t, l, clusterName)
-
-			if err := runCmds(ctx, l, [][]string{
-				{"roachprod", "create", clusterName},
-				{"roachprod", "put", clusterName, *cockroach, "./cockroach"},
-				{"roachprod", "put", clusterName, *workload, "./workload"},
-				{"roachprod", "start", clusterName},
-			}); err != nil {
-				t.Fatal(err)
-			}
-
-			m := monitorWithContext(ctx)
-			m.Worker(func(ctx context.Context) error {
-				return runCmd(ctx, l, "roachprod", "ssh", clusterName+":1", "--", testCmd)
+			g, ctx := errgroup.WithContext(ctx)
+			g.Go(func() error {
+				c.Run(ctx, t, 4, testCmd)
+				return nil
 			})
-			if err := m.Monitor(l, "roachprod", "monitor", clusterName); err != nil {
-				t.Fatalf(`%+v`, err)
-			}
+			c.Monitor(ctx, t, g)
 		})
 	}
 }
 
 func TestRoachmart(t *testing.T) {
 	maybeSkip(t)
-	t.Parallel()
 
 	testutils.RunTrueAndFalse(t, "partition", func(t *testing.T, partition bool) {
-		t.Parallel()
 		ctx := context.Background()
 
 		l, err := rootLogger(t.Name())
@@ -279,8 +336,8 @@ func (m monitor) Monitor(l *logger, args ...string) error {
 		}
 
 		cmd := exec.CommandContext(m.ctx, args[0], args[1:]...)
-		cmd.Stdout = io.MultiWriter(&monL.stdout, pipeW)
-		cmd.Stderr = &monL.stderr
+		cmd.Stdout = io.MultiWriter(monL.stdout, pipeW)
+		cmd.Stderr = monL.stderr
 		if err := cmd.Start(); err != nil {
 			if c := errors.Cause(err); c == context.Canceled {
 				return nil


### PR DESCRIPTION
Add `cluster` object which makes creating and running commands on a
cluster somewhat more concise.

Add support for running "local" clusters via a `--local` flag.

Release note: None