### PR TITLE
sql: fix computed columns with UPSERT shorthand

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/computed
+++ b/pkg/sql/logictest/testdata/logic_test/computed
@@ -165,6 +165,44 @@ SELECT a, b, c FROM x
 statement error cannot write directly to computed column "c"
 UPDATE x SET (b, c) = (1, DEFAULT)
 
+# Upsert using the UPSERT shorthand.
+
+statement ok
+UPSERT INTO x (a, b) VALUES (1, 2)
+
+query IIII
+SELECT a, b, c, d FROM x
+----
+1 2 3 1
+
+statement ok
+TRUNCATE x
+
+# statement ok
+# INSERT INTO x VALUES (2, 3) ON CONFLICT (a) DO UPDATE SET a = 2, b = 3
+
+statement ok
+UPSERT INTO x VALUES (2, 3)
+
+query IIII
+SELECT a, b, c, d FROM x
+----
+2 3 4 2
+
+statement ok
+TRUNCATE x
+
+statement error cannot write directly to computed column "c"
+UPSERT INTO x VALUES (2, 3, 12)
+
+statement ok
+UPSERT INTO x (a, b) VALUES (2, 3)
+
+query IIII
+SELECT a, b, c, d FROM x
+----
+2 3 4 2
+
 statement ok
 DROP TABLE x
 

--- a/pkg/sql/upsert.go
+++ b/pkg/sql/upsert.go
@@ -256,14 +256,18 @@ func upsertExprsAndIndex(
 		}
 		updateExprs := make(tree.UpdateExprs, 0, len(insertCols))
 		for _, c := range insertCols {
-			if _, ok := indexColSet[c.ID]; !ok {
-				n := tree.Name(c.Name)
-				expr := &tree.ColumnItem{
-					TableName:  upsertExcludedTable,
-					ColumnName: n,
-				}
-				updateExprs = append(updateExprs, &tree.UpdateExpr{Names: tree.NameList{n}, Expr: expr})
+			if c.ComputeExpr != nil {
+				continue
 			}
+			if _, ok := indexColSet[c.ID]; ok {
+				continue
+			}
+			n := tree.Name(c.Name)
+			expr := &tree.ColumnItem{
+				TableName:  upsertExcludedTable,
+				ColumnName: n,
+			}
+			updateExprs = append(updateExprs, &tree.UpdateExpr{Names: tree.NameList{n}, Expr: expr})
 		}
 		return updateExprs, conflictIndex, nil
 	}


### PR DESCRIPTION
Release note (bug fix): Allow UPSERTing into a table with computed
columns.