### PR TITLE
opt: Add comments to generated code

### DIFF
--- a/pkg/sql/opt/build/builder.go
+++ b/pkg/sql/opt/build/builder.go
@@ -1118,8 +1118,8 @@ func (b *Builder) buildDistinct(
 		groupings = append(groupings, v)
 	}
 
-	groupingList := b.constructProjectionList(groupings, byCols)
-	aggList := b.constructProjectionList(nil, nil)
+	groupingList := b.constructList(opt.GroupingsOp, groupings, byCols)
+	aggList := b.constructList(opt.AggregationsOp, nil, nil)
 	return b.factory.ConstructGroupBy(in, groupingList, aggList)
 }
 

--- a/pkg/sql/opt/build/testdata/aggregate
+++ b/pkg/sql/opt/build/testdata/aggregate
@@ -1097,12 +1097,12 @@ project
  │    ├── columns: kv.v:int:null:2 column5:int:null:5 column6:decimal:null:6
  │    ├── scan
  │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
- │    ├── projections
+ │    ├── groupings
  │    │    ├── variable: kv.v [type=int]
  │    │    └── mult [type=int]
  │    │         ├── variable: kv.k [type=int]
  │    │         └── variable: kv.w [type=int]
- │    └── projections
+ │    └── aggregations
  │         └── function: sum [type=NULL]
  │              └── variable: kv.w [type=int]
  └── projections
@@ -1118,14 +1118,14 @@ project
  │    ├── columns: kv.v:int:null:2 column5:string:null:5 column6:int:null:6 column7:decimal:null:7
  │    ├── scan
  │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
- │    ├── projections
+ │    ├── groupings
  │    │    ├── variable: kv.v [type=int]
  │    │    ├── function: lower [type=NULL]
  │    │    │    └── variable: kv.s [type=string]
  │    │    └── mult [type=int]
  │    │         ├── variable: kv.k [type=int]
  │    │         └── variable: kv.w [type=int]
- │    └── projections
+ │    └── aggregations
  │         └── function: sum [type=NULL]
  │              └── variable: kv.w [type=int]
  └── projections

--- a/pkg/sql/opt/build/testdata/distinct
+++ b/pkg/sql/opt/build/testdata/distinct
@@ -40,10 +40,10 @@ group-by
  │    └── projections
  │         ├── variable: xyz.y [type=int]
  │         └── variable: xyz.z [type=float]
- ├── projections
+ ├── groupings
  │    ├── variable: xyz.y [type=int]
  │    └── variable: xyz.z [type=float]
- └── projections
+ └── aggregations
 
 build
 SELECT y FROM (SELECT DISTINCT y, z FROM t.xyz)
@@ -59,10 +59,10 @@ project
  │    │    └── projections
  │    │         ├── variable: xyz.y [type=int]
  │    │         └── variable: xyz.z [type=float]
- │    ├── projections
+ │    ├── groupings
  │    │    ├── variable: xyz.y [type=int]
  │    │    └── variable: xyz.z [type=float]
- │    └── projections
+ │    └── aggregations
  └── projections
       └── variable: xyz.y [type=int]
 
@@ -79,9 +79,9 @@ group-by
  │         └── tuple [type=tuple{int, float}]
  │              ├── variable: xyz.y [type=int]
  │              └── variable: xyz.z [type=float]
- ├── projections
+ ├── groupings
  │    └── variable: column4 [type=tuple{int, float}]
- └── projections
+ └── aggregations
 
 build
 SELECT COUNT(*) FROM (SELECT DISTINCT y FROM t.xyz)
@@ -96,11 +96,11 @@ group-by
  │    │    │    └── columns: xyz.x:int:1 xyz.y:int:null:2 xyz.z:float:null:3
  │    │    └── projections
  │    │         └── variable: xyz.y [type=int]
- │    ├── projections
+ │    ├── groupings
  │    │    └── variable: xyz.y [type=int]
- │    └── projections
- ├── projections
- └── projections
+ │    └── aggregations
+ ├── groupings
+ └── aggregations
       └── function: count_rows [type=NULL]
 
 build
@@ -119,9 +119,9 @@ group-by
  │    │         └── const: 0 [type=int]
  │    └── projections
  │         └── variable: xyz.x [type=int]
- ├── projections
+ ├── groupings
  │    └── variable: xyz.x [type=int]
- └── projections
+ └── aggregations
 
 build
 SELECT DISTINCT z FROM t.xyz WHERE x > 0
@@ -139,9 +139,9 @@ group-by
  │    │         └── const: 0 [type=int]
  │    └── projections
  │         └── variable: xyz.z [type=float]
- ├── projections
+ ├── groupings
  │    └── variable: xyz.z [type=float]
- └── projections
+ └── aggregations
 
 build
 SELECT DISTINCT MAX(x) FROM xyz GROUP BY x
@@ -154,16 +154,16 @@ group-by
  │    │    ├── columns: xyz.x:int:null:1 column4:int:null:4
  │    │    ├── scan
  │    │    │    └── columns: xyz.x:int:1 xyz.y:int:null:2 xyz.z:float:null:3
- │    │    ├── projections
+ │    │    ├── groupings
  │    │    │    └── variable: xyz.x [type=int]
- │    │    └── projections
+ │    │    └── aggregations
  │    │         └── function: max [type=NULL]
  │    │              └── variable: xyz.x [type=int]
  │    └── projections
  │         └── variable: column4 [type=int]
- ├── projections
+ ├── groupings
  │    └── variable: column4 [type=int]
- └── projections
+ └── aggregations
 
 build
 SELECT DISTINCT x+y FROM xyz
@@ -178,9 +178,9 @@ group-by
  │         └── plus [type=int]
  │              ├── variable: xyz.x [type=int]
  │              └── variable: xyz.y [type=int]
- ├── projections
+ ├── groupings
  │    └── variable: column4 [type=int]
- └── projections
+ └── aggregations
 
 build
 SELECT DISTINCT 3 FROM xyz
@@ -193,9 +193,9 @@ group-by
  │    │    └── columns: xyz.x:int:1 xyz.y:int:null:2 xyz.z:float:null:3
  │    └── projections
  │         └── const: 3 [type=int]
- ├── projections
+ ├── groupings
  │    └── variable: column4 [type=int]
- └── projections
+ └── aggregations
 
 build
 SELECT DISTINCT 3
@@ -208,9 +208,9 @@ group-by
  │    │    └── tuple [type=tuple{}]
  │    └── projections
  │         └── const: 3 [type=int]
- ├── projections
+ ├── groupings
  │    └── variable: column1 [type=int]
- └── projections
+ └── aggregations
 
 build
 SELECT DISTINCT MAX(z), x+y, 3 FROM xyz GROUP BY x, y HAVING y > 4
@@ -225,10 +225,10 @@ group-by
  │    │    │    ├── columns: xyz.x:int:null:1 xyz.y:int:null:2 column4:float:null:4
  │    │    │    ├── scan
  │    │    │    │    └── columns: xyz.x:int:1 xyz.y:int:null:2 xyz.z:float:null:3
- │    │    │    ├── projections
+ │    │    │    ├── groupings
  │    │    │    │    ├── variable: xyz.x [type=int]
  │    │    │    │    └── variable: xyz.y [type=int]
- │    │    │    └── projections
+ │    │    │    └── aggregations
  │    │    │         └── function: max [type=NULL]
  │    │    │              └── variable: xyz.z [type=float]
  │    │    └── gt [type=bool]
@@ -240,8 +240,8 @@ group-by
  │         │    ├── variable: xyz.x [type=int]
  │         │    └── variable: xyz.y [type=int]
  │         └── const: 3 [type=int]
- ├── projections
+ ├── groupings
  │    ├── variable: column4 [type=float]
  │    ├── variable: column5 [type=int]
  │    └── variable: column6 [type=int]
- └── projections
+ └── aggregations

--- a/pkg/sql/opt/build/testdata/having
+++ b/pkg/sql/opt/build/testdata/having
@@ -24,8 +24,8 @@ project
  │    ├── group-by
  │    │    ├── scan
  │    │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
- │    │    ├── projections
- │    │    └── projections
+ │    │    ├── groupings
+ │    │    └── aggregations
  │    └── const: true [type=bool]
  └── projections
       └── const: 3 [type=int]
@@ -39,9 +39,9 @@ select
  │    ├── columns: kv.s:string:null:4 column5:int:null:5
  │    ├── scan
  │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
- │    ├── projections
+ │    ├── groupings
  │    │    └── variable: kv.s [type=string]
- │    └── projections
+ │    └── aggregations
  │         └── function: count_rows [type=NULL]
  └── gt [type=bool]
       ├── variable: column5 [type=int]
@@ -58,8 +58,8 @@ project
  │    │    ├── columns: column5:int:null:5 column6:int:null:6
  │    │    ├── scan
  │    │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
- │    │    ├── projections
- │    │    └── projections
+ │    │    ├── groupings
+ │    │    └── aggregations
  │    │         ├── function: min [type=NULL]
  │    │         │    └── variable: kv.v [type=int]
  │    │         └── function: max [type=NULL]
@@ -82,8 +82,8 @@ project
  │    │    ├── columns: column5:int:null:5 column6:int:null:6 column7:int:null:7
  │    │    ├── scan
  │    │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
- │    │    ├── projections
- │    │    └── projections
+ │    │    ├── groupings
+ │    │    └── aggregations
  │    │         ├── function: max [type=NULL]
  │    │         │    └── variable: kv.v [type=int]
  │    │         ├── function: max [type=NULL]
@@ -136,11 +136,11 @@ project
  │    │    ├── columns: column5:int:null:5 column6:int:null:6
  │    │    ├── scan
  │    │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
- │    │    ├── projections
+ │    │    ├── groupings
  │    │    │    └── plus [type=int]
  │    │    │         ├── variable: kv.k [type=int]
  │    │    │         └── variable: kv.w [type=int]
- │    │    └── projections
+ │    │    └── aggregations
  │    │         └── function: count_rows [type=NULL]
  │    └── gt [type=bool]
  │         ├── plus [type=int]
@@ -168,9 +168,9 @@ project
  │    │    ├── columns: kv.v:int:null:2 column5:int:null:5
  │    │    ├── scan
  │    │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
- │    │    ├── projections
+ │    │    ├── groupings
  │    │    │    └── variable: kv.v [type=int]
- │    │    └── projections
+ │    │    └── aggregations
  │    │         └── function: max [type=NULL]
  │    │              └── variable: kv.v [type=int]
  │    └── gt [type=bool]
@@ -190,10 +190,10 @@ project
  │    │    ├── columns: column5:string:null:5 column6:decimal:null:6
  │    │    ├── scan
  │    │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
- │    │    ├── projections
+ │    │    ├── groupings
  │    │    │    └── function: lower [type=NULL]
  │    │    │         └── variable: kv.s [type=string]
- │    │    └── projections
+ │    │    └── aggregations
  │    │         └── function: sum [type=NULL]
  │    │              └── variable: kv.w [type=int]
  │    └── like [type=bool]
@@ -214,10 +214,10 @@ project
  │    │    ├── columns: column5:string:null:5 column6:decimal:null:6
  │    │    ├── scan
  │    │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
- │    │    ├── projections
+ │    │    ├── groupings
  │    │    │    └── function: lower [type=NULL]
  │    │    │         └── variable: kv.s [type=string]
- │    │    └── projections
+ │    │    └── aggregations
  │    │         └── function: sum [type=NULL]
  │    │              └── variable: kv.w [type=int]
  │    └── in [type=bool]
@@ -240,12 +240,12 @@ project
  │    │    ├── columns: kv.v:int:null:2 column5:int:null:5
  │    │    ├── scan
  │    │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
- │    │    ├── projections
+ │    │    ├── groupings
  │    │    │    ├── variable: kv.v [type=int]
  │    │    │    └── mult [type=int]
  │    │    │         ├── variable: kv.k [type=int]
  │    │    │         └── variable: kv.w [type=int]
- │    │    └── projections
+ │    │    └── aggregations
  │    └── gt [type=bool]
  │         ├── mult [type=int]
  │         │    ├── variable: kv.k [type=int]

--- a/pkg/sql/opt/ops/relational.opt
+++ b/pkg/sql/opt/ops/relational.opt
@@ -54,9 +54,9 @@ define Project {
     Projections Expr
 }
 
-# InnerJoin represents creates a result set that combines columns from its left
-# and right inputs, based upon its "on" join predicate. Rows which do not match
-# the predicate are filtered. While expressions in the predicate can refer to
+# InnerJoin creates a result set that combines columns from its left and right
+# inputs, based upon its "on" join predicate. Rows which do not match the
+# predicate are filtered. While expressions in the predicate can refer to
 # columns projected by either the left or right inputs, the inputs are not
 # allowed to refer to the other's projected columns.
 [Relational, Join]

--- a/pkg/sql/opt/ops/scalar.opt
+++ b/pkg/sql/opt/ops/scalar.opt
@@ -13,15 +13,15 @@ define Subquery {
     Projection Expr
 }
 
-# Variable returns the typed scalar value of the specified column in the query.
-# The private Col field is a Metadata.ColumnIndex.
+# Variable is the typed scalar value of a column in the query. The private
+# field is a Metadata.ColumnIndex that references the column by index.
 [Scalar]
 define Variable {
     Col ColumnIndex
 }
 
-# Const returns a typed scalar constant value. The private Value field is a
-# tree.Datum value.
+# Const is a typed scalar constant value. The private field is a tree.Datum
+# value having any datum type that's legal in the expression's context.
 [Scalar]
 define Const {
     Value Datum

--- a/pkg/sql/opt/opt/factory.og.go
+++ b/pkg/sql/opt/opt/factory.og.go
@@ -23,85 +23,284 @@ type Factory interface {
 	// ConstructXXX method that corresponds to the given operator.
 	DynamicConstruct(op Operator, children []GroupID, private PrivateID) GroupID
 
-	// Scalar operator constructors.
+	// ------------------------------------------------------------
+	// Scalar Operators
+	// ------------------------------------------------------------
+
+	// ConstructSubquery constructs an expression for the Subquery operator.
 	ConstructSubquery(input GroupID, projection GroupID) GroupID
+
+	// ConstructVariable constructs an expression for the Variable operator.
+	// Variable is the typed scalar value of a column in the query. The private
+	// field is a Metadata.ColumnIndex that references the column by index.
 	ConstructVariable(col PrivateID) GroupID
+
+	// ConstructConst constructs an expression for the Const operator.
+	// Const is a typed scalar constant value. The private field is a tree.Datum
+	// value having any datum type that's legal in the expression's context.
 	ConstructConst(value PrivateID) GroupID
+
+	// ConstructTrue constructs an expression for the True operator.
+	// True is the boolean true value that is equivalent to the tree.DBoolTrue datum
+	// value. It is a separate operator to make matching and replacement simpler and
+	// more efficient, as patterns can contain (True) expressions.
 	ConstructTrue() GroupID
+
+	// ConstructFalse constructs an expression for the False operator.
+	// False is the boolean false value that is equivalent to the tree.DBoolFalse
+	// datum value. It is a separate operator to make matching and replacement
+	// simpler and more efficient, as patterns can contain (False) expressions.
 	ConstructFalse() GroupID
+
+	// ConstructPlaceholder constructs an expression for the Placeholder operator.
 	ConstructPlaceholder(value PrivateID) GroupID
+
+	// ConstructTuple constructs an expression for the Tuple operator.
 	ConstructTuple(elems ListID) GroupID
+
+	// ConstructProjections constructs an expression for the Projections operator.
+	// Projections is a set of typed scalar expressions that will become output
+	// columns for a containing Project operator. The private Cols field contains
+	// the set of column indexes returned by the expression, as a *ColList.
 	ConstructProjections(elems ListID, cols PrivateID) GroupID
+
+	// ConstructAggregations constructs an expression for the Aggregations operator.
+	// Aggregations is a set of aggregate expressions that will become output
+	// columns for a containing GroupBy operator. The private Cols field contains
+	// the set of column indexes returned by the expression, as a *ColList.
 	ConstructAggregations(aggs ListID, cols PrivateID) GroupID
+
+	// ConstructGroupings constructs an expression for the Groupings operator.
+	// Groupings is a set of grouping expressions that will become output columns
+	// for a containing GroupBy operator. The GroupBy operator groups its input by
+	// the value of these expressions, and may compute aggregates over the groups.
+	// The private Cols field contains the set of column indexes returned by the
+	// expression, as a *ColList.
 	ConstructGroupings(elems ListID, cols PrivateID) GroupID
+
+	// ConstructFilters constructs an expression for the Filters operator.
 	ConstructFilters(conditions ListID) GroupID
+
+	// ConstructExists constructs an expression for the Exists operator.
 	ConstructExists(input GroupID) GroupID
+
+	// ConstructAnd constructs an expression for the And operator.
 	ConstructAnd(left GroupID, right GroupID) GroupID
+
+	// ConstructOr constructs an expression for the Or operator.
 	ConstructOr(left GroupID, right GroupID) GroupID
+
+	// ConstructNot constructs an expression for the Not operator.
 	ConstructNot(input GroupID) GroupID
+
+	// ConstructEq constructs an expression for the Eq operator.
 	ConstructEq(left GroupID, right GroupID) GroupID
+
+	// ConstructLt constructs an expression for the Lt operator.
 	ConstructLt(left GroupID, right GroupID) GroupID
+
+	// ConstructGt constructs an expression for the Gt operator.
 	ConstructGt(left GroupID, right GroupID) GroupID
+
+	// ConstructLe constructs an expression for the Le operator.
 	ConstructLe(left GroupID, right GroupID) GroupID
+
+	// ConstructGe constructs an expression for the Ge operator.
 	ConstructGe(left GroupID, right GroupID) GroupID
+
+	// ConstructNe constructs an expression for the Ne operator.
 	ConstructNe(left GroupID, right GroupID) GroupID
+
+	// ConstructIn constructs an expression for the In operator.
 	ConstructIn(left GroupID, right GroupID) GroupID
+
+	// ConstructNotIn constructs an expression for the NotIn operator.
 	ConstructNotIn(left GroupID, right GroupID) GroupID
+
+	// ConstructLike constructs an expression for the Like operator.
 	ConstructLike(left GroupID, right GroupID) GroupID
+
+	// ConstructNotLike constructs an expression for the NotLike operator.
 	ConstructNotLike(left GroupID, right GroupID) GroupID
+
+	// ConstructILike constructs an expression for the ILike operator.
 	ConstructILike(left GroupID, right GroupID) GroupID
+
+	// ConstructNotILike constructs an expression for the NotILike operator.
 	ConstructNotILike(left GroupID, right GroupID) GroupID
+
+	// ConstructSimilarTo constructs an expression for the SimilarTo operator.
 	ConstructSimilarTo(left GroupID, right GroupID) GroupID
+
+	// ConstructNotSimilarTo constructs an expression for the NotSimilarTo operator.
 	ConstructNotSimilarTo(left GroupID, right GroupID) GroupID
+
+	// ConstructRegMatch constructs an expression for the RegMatch operator.
 	ConstructRegMatch(left GroupID, right GroupID) GroupID
+
+	// ConstructNotRegMatch constructs an expression for the NotRegMatch operator.
 	ConstructNotRegMatch(left GroupID, right GroupID) GroupID
+
+	// ConstructRegIMatch constructs an expression for the RegIMatch operator.
 	ConstructRegIMatch(left GroupID, right GroupID) GroupID
+
+	// ConstructNotRegIMatch constructs an expression for the NotRegIMatch operator.
 	ConstructNotRegIMatch(left GroupID, right GroupID) GroupID
+
+	// ConstructIs constructs an expression for the Is operator.
 	ConstructIs(left GroupID, right GroupID) GroupID
+
+	// ConstructIsNot constructs an expression for the IsNot operator.
 	ConstructIsNot(left GroupID, right GroupID) GroupID
+
+	// ConstructContains constructs an expression for the Contains operator.
 	ConstructContains(left GroupID, right GroupID) GroupID
+
+	// ConstructContainedBy constructs an expression for the ContainedBy operator.
 	ConstructContainedBy(left GroupID, right GroupID) GroupID
+
+	// ConstructBitand constructs an expression for the Bitand operator.
 	ConstructBitand(left GroupID, right GroupID) GroupID
+
+	// ConstructBitor constructs an expression for the Bitor operator.
 	ConstructBitor(left GroupID, right GroupID) GroupID
+
+	// ConstructBitxor constructs an expression for the Bitxor operator.
 	ConstructBitxor(left GroupID, right GroupID) GroupID
+
+	// ConstructPlus constructs an expression for the Plus operator.
 	ConstructPlus(left GroupID, right GroupID) GroupID
+
+	// ConstructMinus constructs an expression for the Minus operator.
 	ConstructMinus(left GroupID, right GroupID) GroupID
+
+	// ConstructMult constructs an expression for the Mult operator.
 	ConstructMult(left GroupID, right GroupID) GroupID
+
+	// ConstructDiv constructs an expression for the Div operator.
 	ConstructDiv(left GroupID, right GroupID) GroupID
+
+	// ConstructFloorDiv constructs an expression for the FloorDiv operator.
 	ConstructFloorDiv(left GroupID, right GroupID) GroupID
+
+	// ConstructMod constructs an expression for the Mod operator.
 	ConstructMod(left GroupID, right GroupID) GroupID
+
+	// ConstructPow constructs an expression for the Pow operator.
 	ConstructPow(left GroupID, right GroupID) GroupID
+
+	// ConstructConcat constructs an expression for the Concat operator.
 	ConstructConcat(left GroupID, right GroupID) GroupID
+
+	// ConstructLShift constructs an expression for the LShift operator.
 	ConstructLShift(left GroupID, right GroupID) GroupID
+
+	// ConstructRShift constructs an expression for the RShift operator.
 	ConstructRShift(left GroupID, right GroupID) GroupID
+
+	// ConstructFetchVal constructs an expression for the FetchVal operator.
 	ConstructFetchVal(json GroupID, index GroupID) GroupID
+
+	// ConstructFetchText constructs an expression for the FetchText operator.
 	ConstructFetchText(json GroupID, index GroupID) GroupID
+
+	// ConstructFetchValPath constructs an expression for the FetchValPath operator.
 	ConstructFetchValPath(json GroupID, path GroupID) GroupID
+
+	// ConstructFetchTextPath constructs an expression for the FetchTextPath operator.
 	ConstructFetchTextPath(json GroupID, path GroupID) GroupID
+
+	// ConstructUnaryPlus constructs an expression for the UnaryPlus operator.
 	ConstructUnaryPlus(input GroupID) GroupID
+
+	// ConstructUnaryMinus constructs an expression for the UnaryMinus operator.
 	ConstructUnaryMinus(input GroupID) GroupID
+
+	// ConstructUnaryComplement constructs an expression for the UnaryComplement operator.
 	ConstructUnaryComplement(input GroupID) GroupID
+
+	// ConstructFunction constructs an expression for the Function operator.
 	ConstructFunction(args ListID, def PrivateID) GroupID
 
-	// Relational operator constructors.
+	// ------------------------------------------------------------
+	// Relational Operators
+	// ------------------------------------------------------------
+
+	// ConstructScan constructs an expression for the Scan operator.
+	// Scan returns a result set containing every row in the specified table. Rows
+	// and columns are not expected to have any particular ordering. The private
+	// Table field is a Metadata.TableIndex that references an optbase.Table
+	// definition in the query's metadata.
 	ConstructScan(table PrivateID) GroupID
+
+	// ConstructValues constructs an expression for the Values operator.
+	// Values returns a manufactured result set containing a constant number of rows
+	// specified by the Rows list field. Each row must contain the same set of
+	// columns in the same order. The Cols field contains the set of column indexes
+	// returned by each row, as a *ColSet.
 	ConstructValues(rows ListID, cols PrivateID) GroupID
+
+	// ConstructSelect constructs an expression for the Select operator.
+	// Select filters rows from its input result set, based on the boolean filter
+	// predicate expression. Rows which do not match the filter are discarded.
 	ConstructSelect(input GroupID, filter GroupID) GroupID
+
+	// ConstructProject constructs an expression for the Project operator.
 	ConstructProject(input GroupID, projections GroupID) GroupID
+
+	// ConstructInnerJoin constructs an expression for the InnerJoin operator.
+	// InnerJoin creates a result set that combines columns from its left and right
+	// inputs, based upon its "on" join predicate. Rows which do not match the
+	// predicate are filtered. While expressions in the predicate can refer to
+	// columns projected by either the left or right inputs, the inputs are not
+	// allowed to refer to the other's projected columns.
 	ConstructInnerJoin(left GroupID, right GroupID, on GroupID) GroupID
+
+	// ConstructLeftJoin constructs an expression for the LeftJoin operator.
 	ConstructLeftJoin(left GroupID, right GroupID, on GroupID) GroupID
+
+	// ConstructRightJoin constructs an expression for the RightJoin operator.
 	ConstructRightJoin(left GroupID, right GroupID, on GroupID) GroupID
+
+	// ConstructFullJoin constructs an expression for the FullJoin operator.
 	ConstructFullJoin(left GroupID, right GroupID, on GroupID) GroupID
+
+	// ConstructSemiJoin constructs an expression for the SemiJoin operator.
 	ConstructSemiJoin(left GroupID, right GroupID, on GroupID) GroupID
+
+	// ConstructAntiJoin constructs an expression for the AntiJoin operator.
 	ConstructAntiJoin(left GroupID, right GroupID, on GroupID) GroupID
+
+	// ConstructInnerJoinApply constructs an expression for the InnerJoinApply operator.
+	// InnerJoinApply has the same join semantics as InnerJoin. However, unlike
+	// InnerJoin, it allows the right input to refer to columns projected by the
+	// left input.
 	ConstructInnerJoinApply(left GroupID, right GroupID, on GroupID) GroupID
+
+	// ConstructLeftJoinApply constructs an expression for the LeftJoinApply operator.
 	ConstructLeftJoinApply(left GroupID, right GroupID, on GroupID) GroupID
+
+	// ConstructRightJoinApply constructs an expression for the RightJoinApply operator.
 	ConstructRightJoinApply(left GroupID, right GroupID, on GroupID) GroupID
+
+	// ConstructFullJoinApply constructs an expression for the FullJoinApply operator.
 	ConstructFullJoinApply(left GroupID, right GroupID, on GroupID) GroupID
+
+	// ConstructSemiJoinApply constructs an expression for the SemiJoinApply operator.
 	ConstructSemiJoinApply(left GroupID, right GroupID, on GroupID) GroupID
+
+	// ConstructAntiJoinApply constructs an expression for the AntiJoinApply operator.
 	ConstructAntiJoinApply(left GroupID, right GroupID, on GroupID) GroupID
+
+	// ConstructGroupBy constructs an expression for the GroupBy operator.
 	ConstructGroupBy(input GroupID, groupings GroupID, aggregations GroupID) GroupID
+
+	// ConstructUnion constructs an expression for the Union operator.
 	ConstructUnion(left GroupID, right GroupID, colMap PrivateID) GroupID
+
+	// ConstructIntersect constructs an expression for the Intersect operator.
 	ConstructIntersect(left GroupID, right GroupID) GroupID
+
+	// ConstructExcept constructs an expression for the Except operator.
 	ConstructExcept(left GroupID, right GroupID) GroupID
 }

--- a/pkg/sql/opt/opt/operator.go
+++ b/pkg/sql/opt/opt/operator.go
@@ -16,6 +16,7 @@ package opt
 
 import (
 	"fmt"
+
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 )
 

--- a/pkg/sql/opt/opt/operator.og.go
+++ b/pkg/sql/opt/opt/operator.og.go
@@ -5,90 +5,229 @@ package opt
 const (
 	UnknownOp Operator = iota
 
+	// ------------------------------------------------------------
 	// Scalar Operators
+	// ------------------------------------------------------------
+
 	SubqueryOp
+
+	// VariableOp is the typed scalar value of a column in the query. The private
+	// field is a Metadata.ColumnIndex that references the column by index.
 	VariableOp
+
+	// ConstOp is a typed scalar constant value. The private field is a tree.Datum
+	// value having any datum type that's legal in the expression's context.
 	ConstOp
+
+	// TrueOp is the boolean true value that is equivalent to the tree.DBoolTrue datum
+	// value. It is a separate operator to make matching and replacement simpler and
+	// more efficient, as patterns can contain (True) expressions.
 	TrueOp
+
+	// FalseOp is the boolean false value that is equivalent to the tree.DBoolFalse
+	// datum value. It is a separate operator to make matching and replacement
+	// simpler and more efficient, as patterns can contain (False) expressions.
 	FalseOp
+
 	PlaceholderOp
+
 	TupleOp
+
+	// ProjectionsOp is a set of typed scalar expressions that will become output
+	// columns for a containing Project operator. The private Cols field contains
+	// the set of column indexes returned by the expression, as a *ColList.
 	ProjectionsOp
+
+	// AggregationsOp is a set of aggregate expressions that will become output
+	// columns for a containing GroupBy operator. The private Cols field contains
+	// the set of column indexes returned by the expression, as a *ColList.
 	AggregationsOp
+
+	// GroupingsOp is a set of grouping expressions that will become output columns
+	// for a containing GroupBy operator. The GroupBy operator groups its input by
+	// the value of these expressions, and may compute aggregates over the groups.
+	// The private Cols field contains the set of column indexes returned by the
+	// expression, as a *ColList.
 	GroupingsOp
+
 	FiltersOp
+
 	ExistsOp
+
 	AndOp
+
 	OrOp
+
 	NotOp
+
 	EqOp
+
 	LtOp
+
 	GtOp
+
 	LeOp
+
 	GeOp
+
 	NeOp
+
 	InOp
+
 	NotInOp
+
 	LikeOp
+
 	NotLikeOp
+
 	ILikeOp
+
 	NotILikeOp
+
 	SimilarToOp
+
 	NotSimilarToOp
+
 	RegMatchOp
+
 	NotRegMatchOp
+
 	RegIMatchOp
+
 	NotRegIMatchOp
+
 	IsOp
+
 	IsNotOp
+
 	ContainsOp
+
 	ContainedByOp
+
 	BitandOp
+
 	BitorOp
+
 	BitxorOp
+
 	PlusOp
+
 	MinusOp
+
 	MultOp
+
 	DivOp
+
 	FloorDivOp
+
 	ModOp
+
 	PowOp
+
 	ConcatOp
+
 	LShiftOp
+
 	RShiftOp
+
 	FetchValOp
+
 	FetchTextOp
+
 	FetchValPathOp
+
 	FetchTextPathOp
+
 	UnaryPlusOp
+
 	UnaryMinusOp
+
 	UnaryComplementOp
+
 	FunctionOp
 
+	// ------------------------------------------------------------
 	// Relational Operators
+	// ------------------------------------------------------------
+
+	// ScanOp returns a result set containing every row in the specified table. Rows
+	// and columns are not expected to have any particular ordering. The private
+	// Table field is a Metadata.TableIndex that references an optbase.Table
+	// definition in the query's metadata.
 	ScanOp
+
+	// ValuesOp returns a manufactured result set containing a constant number of rows
+	// specified by the Rows list field. Each row must contain the same set of
+	// columns in the same order. The Cols field contains the set of column indexes
+	// returned by each row, as a *ColSet.
 	ValuesOp
+
+	// SelectOp filters rows from its input result set, based on the boolean filter
+	// predicate expression. Rows which do not match the filter are discarded.
 	SelectOp
+
 	ProjectOp
+
+	// InnerJoinOp creates a result set that combines columns from its left and right
+	// inputs, based upon its "on" join predicate. Rows which do not match the
+	// predicate are filtered. While expressions in the predicate can refer to
+	// columns projected by either the left or right inputs, the inputs are not
+	// allowed to refer to the other's projected columns.
 	InnerJoinOp
+
 	LeftJoinOp
+
 	RightJoinOp
+
 	FullJoinOp
+
 	SemiJoinOp
+
 	AntiJoinOp
+
+	// InnerJoinApplyOp has the same join semantics as InnerJoin. However, unlike
+	// InnerJoin, it allows the right input to refer to columns projected by the
+	// left input.
 	InnerJoinApplyOp
+
 	LeftJoinApplyOp
+
 	RightJoinApplyOp
+
 	FullJoinApplyOp
+
 	SemiJoinApplyOp
+
 	AntiJoinApplyOp
+
 	GroupByOp
+
 	UnionOp
+
 	IntersectOp
+
 	ExceptOp
 
+	// ------------------------------------------------------------
 	// Enforcer Operators
+	// ------------------------------------------------------------
+
+	// SortOp enforces the ordering of rows returned by its input expression. Rows can
+	// be sorted by one or more of the input columns, each of which can be sorted in
+	// either ascending or descending order. See the Ordering field in the
+	// PhysicalProps struct.
+	// TODO(andyk): Add the Ordering field.
 	SortOp
+
+	// PresentOp enforces physical properties related to column presentation, which
+	// includes column ordering, column naming, and duplicate columns. While the
+	// input expression must project the columns used by Present, it can project
+	// a superset of columns in any order and using any names. Whereas the Project
+	// operator modifies logical properties (i.e. the set of columns returned), the
+	// Present operator enforces physical properties (i.e. the presentation of the
+	// set of columns returned). See the Presentation field in the PhysicalProps
+	// struct.
+	// TODO(andyk): Add the Presentation field.
 	PresentOp
 
 	// NumOperators tracks the total count of operators.

--- a/pkg/sql/opt/optgen/cmd/optgen/exprs_gen.go
+++ b/pkg/sql/opt/optgen/cmd/optgen/exprs_gen.go
@@ -238,6 +238,9 @@ func (g *exprsGen) genExprType(define *lang.DefineExpr) {
 	opType := fmt.Sprintf("%sOp", define.Name)
 	exprType := fmt.Sprintf("%sExpr", unTitle(string(define.Name)))
 
+	// Generate comment for the expression type.
+	generateDefineComments(g.w, define, exprType)
+
 	// Generate the expression type.
 	fmt.Fprintf(g.w, "type %s memoExpr\n\n", exprType)
 

--- a/pkg/sql/opt/optgen/cmd/optgen/factory_gen.go
+++ b/pkg/sql/opt/optgen/cmd/optgen/factory_gen.go
@@ -50,6 +50,9 @@ func (g *factoryGen) genConstructFuncs() {
 	for _, define := range filterEnforcerDefines(g.compiled.Defines) {
 		varName := fmt.Sprintf("_%sExpr", unTitle(string(define.Name)))
 
+		format := "// Construct%s constructs an expression for the %s operator.\n"
+		g.w.writeIndent(format, define.Name, define.Name)
+		generateDefineComments(g.w.writer, define, string(define.Name))
 		g.w.writeIndent("func (_f *factory) Construct%s(\n", define.Name)
 
 		for _, field := range define.Fields {

--- a/pkg/sql/opt/optgen/cmd/optgen/ifactory_gen.go
+++ b/pkg/sql/opt/optgen/cmd/optgen/ifactory_gen.go
@@ -66,12 +66,18 @@ func (g *ifactoryGen) generate(compiled *lang.CompiledExpr, w io.Writer) {
 }
 
 func (g *ifactoryGen) genMethodsByTag(tag string) {
-	fmt.Fprintf(g.w, "  // %s operator constructors.\n", tag)
+	fmt.Fprintf(g.w, "  // ------------------------------------------------------------ \n")
+	fmt.Fprintf(g.w, "  // %s Operators\n", tag)
+	fmt.Fprintf(g.w, "  // ------------------------------------------------------------ \n\n")
 
 	for _, define := range g.compiled.Defines {
 		if !define.Tags.Contains(tag) {
 			continue
 		}
+
+		format := "  // Construct%s constructs an expression for the %s operator.\n"
+		fmt.Fprintf(g.w, format, define.Name, define.Name)
+		generateDefineComments(g.w, define, string(define.Name))
 
 		fmt.Fprintf(g.w, "  Construct%s(", define.Name)
 		for i, field := range define.Fields {
@@ -80,7 +86,7 @@ func (g *ifactoryGen) genMethodsByTag(tag string) {
 			}
 			fmt.Fprintf(g.w, "%s %s", unTitle(string(field.Name)), mapType(string(field.Type)))
 		}
-		fmt.Fprintf(g.w, ") GroupID\n")
+		fmt.Fprintf(g.w, ") GroupID\n\n")
 	}
 
 	fmt.Fprintf(g.w, "\n")

--- a/pkg/sql/opt/optgen/cmd/optgen/ops_gen.go
+++ b/pkg/sql/opt/optgen/cmd/optgen/ops_gen.go
@@ -73,12 +73,16 @@ func (g *opsGen) genOperatorNames() {
 }
 
 func (g *opsGen) genOperatorEnumByTag(tag string) {
+	fmt.Fprintf(g.w, "  // ------------------------------------------------------------ \n")
 	fmt.Fprintf(g.w, "  // %s Operators\n", tag)
+	fmt.Fprintf(g.w, "  // ------------------------------------------------------------ \n")
 	for _, define := range g.compiled.Defines {
 		if !define.Tags.Contains(tag) {
 			continue
 		}
 
+		fmt.Fprintf(g.w, "\n")
+		generateDefineComments(g.w, define, string(define.Name)+"Op")
 		fmt.Fprintf(g.w, "  %sOp\n", define.Name)
 	}
 	fmt.Fprintf(g.w, "\n")

--- a/pkg/sql/opt/optgen/cmd/optgen/testdata/compile
+++ b/pkg/sql/opt/optgen/cmd/optgen/testdata/compile
@@ -2,6 +2,7 @@
 # Print out compiled tree.
 #
 optgen compile test.opt
+# Not comment.
 define Not {
     Input Expr
 }
@@ -12,16 +13,18 @@ define Not {
 (Compiled
 	(Defines
 		(Define
+			Comments=(Comments # Not comment.)
 			Tags=(Tags)
 			Name="Not"
 			Fields=(DefineFields
-				(DefineField Name="Input" Type="Expr" Src=<test.opt:2:5>)
+				(DefineField Name="Input" Type="Expr" Src=<test.opt:3:5>)
 			)
-			Src=<test.opt:1:1>
+			Src=<test.opt:2:1>
 		)
 	)
 	(Rules
 		(Rule
+			Comments=(Comments)
 			Name="EliminateNot"
 			Tags=(Tags)
 			Match=(Match
@@ -30,15 +33,15 @@ define Not {
 					(Match
 						Names=(OpNames NotOp)
 						Args=(List
-							(Bind Label="input" Target=(MatchAny) Src=<test.opt:6:11>)
+							(Bind Label="input" Target=(MatchAny) Src=<test.opt:7:11>)
 						)
-						Src=<test.opt:6:6>
+						Src=<test.opt:7:6>
 					)
 				)
-				Src=<test.opt:6:1>
+				Src=<test.opt:7:1>
 			)
-			Replace=(Ref Label="input" Src=<test.opt:6:25>)
-			Src=<test.opt:5:1>
+			Replace=(Ref Label="input" Src=<test.opt:7:25>)
+			Src=<test.opt:6:1>
 		)
 	)
 )

--- a/pkg/sql/opt/optgen/cmd/optgen/testdata/factory
+++ b/pkg/sql/opt/optgen/cmd/optgen/testdata/factory
@@ -3,6 +3,7 @@
 # PrivateID args.
 #
 optgen factory test.opt
+# Not is a negate operator.
 define Not {
     Input Expr
 }
@@ -28,6 +29,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/opt"
 )
 
+// ConstructNot constructs an expression for the Not operator.
+// Not is a negate operator.
 func (_f *factory) ConstructNot(
 	input opt.GroupID,
 ) opt.GroupID {
@@ -44,6 +47,7 @@ func (_f *factory) ConstructNot(
 	return _f.onConstruct(_f.mem.memoizeNormExpr((*memoExpr)(&_notExpr)))
 }
 
+// ConstructFuncCall constructs an expression for the FuncCall operator.
 func (_f *factory) ConstructFuncCall(
 	name opt.GroupID,
 	args opt.ListID,
@@ -111,6 +115,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/opt"
 )
 
+// ConstructInnerJoin constructs an expression for the InnerJoin operator.
 func (_f *factory) ConstructInnerJoin(
 	left opt.GroupID,
 	right opt.GroupID,
@@ -190,6 +195,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/opt"
 )
 
+// ConstructEq constructs an expression for the Eq operator.
 func (_f *factory) ConstructEq(
 	left opt.GroupID,
 	right opt.GroupID,
@@ -217,6 +223,7 @@ func (_f *factory) ConstructEq(
 	return _f.onConstruct(_f.mem.memoizeNormExpr((*memoExpr)(&_eqExpr)))
 }
 
+// ConstructNe constructs an expression for the Ne operator.
 func (_f *factory) ConstructNe(
 	left opt.GroupID,
 	right opt.GroupID,
@@ -300,6 +307,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/opt"
 )
 
+// ConstructFunc constructs an expression for the Func operator.
 func (_f *factory) ConstructFunc(
 	name opt.GroupID,
 	args opt.ListID,
@@ -335,6 +343,7 @@ func (_f *factory) ConstructFunc(
 	return _f.onConstruct(_f.mem.memoizeNormExpr((*memoExpr)(&_funcExpr)))
 }
 
+// ConstructVariable constructs an expression for the Variable operator.
 func (_f *factory) ConstructVariable(
 	col opt.PrivateID,
 ) opt.GroupID {
@@ -429,6 +438,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/opt"
 )
 
+// ConstructSelect constructs an expression for the Select operator.
 func (_f *factory) ConstructSelect(
 	input opt.GroupID,
 	filter opt.GroupID,
@@ -475,6 +485,7 @@ func (_f *factory) ConstructSelect(
 	return _f.onConstruct(_f.mem.memoizeNormExpr((*memoExpr)(&_selectExpr)))
 }
 
+// ConstructInnerJoin constructs an expression for the InnerJoin operator.
 func (_f *factory) ConstructInnerJoin(
 	left opt.GroupID,
 	right opt.GroupID,
@@ -492,6 +503,7 @@ func (_f *factory) ConstructInnerJoin(
 	return _f.onConstruct(_f.mem.memoizeNormExpr((*memoExpr)(&_innerJoinExpr)))
 }
 
+// ConstructFullJoin constructs an expression for the FullJoin operator.
 func (_f *factory) ConstructFullJoin(
 	left opt.GroupID,
 	right opt.GroupID,
@@ -509,6 +521,7 @@ func (_f *factory) ConstructFullJoin(
 	return _f.onConstruct(_f.mem.memoizeNormExpr((*memoExpr)(&_fullJoinExpr)))
 }
 
+// ConstructUnion constructs an expression for the Union operator.
 func (_f *factory) ConstructUnion(
 	left opt.GroupID,
 	right opt.GroupID,
@@ -526,6 +539,7 @@ func (_f *factory) ConstructUnion(
 	return _f.onConstruct(_f.mem.memoizeNormExpr((*memoExpr)(&_unionExpr)))
 }
 
+// ConstructAnd constructs an expression for the And operator.
 func (_f *factory) ConstructAnd(
 	left opt.GroupID,
 	right opt.GroupID,
@@ -626,6 +640,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/opt"
 )
 
+// ConstructEq constructs an expression for the Eq operator.
 func (_f *factory) ConstructEq(
 	left opt.GroupID,
 	right opt.GroupID,
@@ -674,6 +689,7 @@ func (_f *factory) ConstructEq(
 	return _f.onConstruct(_f.mem.memoizeNormExpr((*memoExpr)(&_eqExpr)))
 }
 
+// ConstructNe constructs an expression for the Ne operator.
 func (_f *factory) ConstructNe(
 	left opt.GroupID,
 	right opt.GroupID,

--- a/pkg/sql/opt/optgen/cmd/optgen/testdata/ifactory
+++ b/pkg/sql/opt/optgen/cmd/optgen/testdata/ifactory
@@ -10,6 +10,7 @@ define FuncCall {
     Def  FuncDef
 }
 
+# Union is a union operator.
 [Relational]
 define Union {
     Left   Expr
@@ -49,10 +50,19 @@ type Factory interface {
 	// ConstructXXX method that corresponds to the given operator.
 	DynamicConstruct(op Operator, children []GroupID, private PrivateID) GroupID
 
-	// Scalar operator constructors.
+	// ------------------------------------------------------------
+	// Scalar Operators
+	// ------------------------------------------------------------
+
+	// ConstructFuncCall constructs an expression for the FuncCall operator.
 	ConstructFuncCall(name GroupID, args ListID, def PrivateID) GroupID
 
-	// Relational operator constructors.
+	// ------------------------------------------------------------
+	// Relational Operators
+	// ------------------------------------------------------------
+
+	// ConstructUnion constructs an expression for the Union operator.
+	// Union is a union operator.
 	ConstructUnion(left GroupID, right GroupID, colMap PrivateID) GroupID
 }
 ----

--- a/pkg/sql/opt/optgen/cmd/optgen/testdata/ops
+++ b/pkg/sql/opt/optgen/cmd/optgen/testdata/ops
@@ -1,10 +1,13 @@
 optgen ops test.opt
+# Lt is a comparison op. Don't replace Lt again.
+# Lt shouldn't be replaced on the second line either.
 [Scalar]
 define Lt {}
 
 [Relational]
 define InnerJoinApply {}
 
+# Sort is an enforcer.
 [Enforcer]
 define Sort {}
 ----
@@ -16,13 +19,25 @@ package opt
 const (
 	UnknownOp Operator = iota
 
+	// ------------------------------------------------------------
 	// Scalar Operators
+	// ------------------------------------------------------------
+
+	// LtOp is a comparison op. Don't replace Lt again.
+	// Lt shouldn't be replaced on the second line either.
 	LtOp
 
+	// ------------------------------------------------------------
 	// Relational Operators
+	// ------------------------------------------------------------
+
 	InnerJoinApplyOp
 
+	// ------------------------------------------------------------
 	// Enforcer Operators
+	// ------------------------------------------------------------
+
+	// SortOp is an enforcer.
 	SortOp
 
 	// NumOperators tracks the total count of operators.

--- a/pkg/sql/opt/optgen/lang/compiler.go
+++ b/pkg/sql/opt/optgen/lang/compiler.go
@@ -234,11 +234,12 @@ func (c *ruleCompiler) expandRule(opName OpNameExpr) {
 	replace := c.rule.Replace.Visit(c.acceptRuleReplaceExpr)
 
 	newRule := &RuleExpr{
-		Src:     c.rule.Src,
-		Name:    c.rule.Name,
-		Tags:    c.rule.Tags,
-		Match:   match,
-		Replace: replace,
+		Src:      c.rule.Src,
+		Name:     c.rule.Name,
+		Comments: c.rule.Comments,
+		Tags:     c.rule.Tags,
+		Match:    match,
+		Replace:  replace,
 	}
 	c.compiled.Rules = append(c.compiled.Rules, newRule)
 }

--- a/pkg/sql/opt/optgen/lang/lang.opt
+++ b/pkg/sql/opt/optgen/lang/lang.opt
@@ -43,9 +43,22 @@ define RuleSet {
 }
 
 define Define {
-    Tags   Tags
-    Name   String
-    Fields DefineFields
+    Comments Comments
+    Tags     Tags
+    Name     String
+    Fields   DefineFields
+}
+
+# type CommentsExpr []CommentExpr
+[Slice]
+define Comments {
+    Element Comment
+}
+
+# type CommentExpr string
+[Value]
+define Comment {
+    Value string
 }
 
 # type TagsExpr []TagExpr
@@ -72,10 +85,11 @@ define DefineField {
 }
 
 define Rule {
-    Name    String
-    Tags    Tags
-    Match   Match
-    Replace Expr
+    Comments Comments
+    Name     String
+    Tags     Tags
+    Match    Match
+    Replace  Expr
 }
 
 define Bind {

--- a/pkg/sql/opt/optgen/lang/operator.og.go
+++ b/pkg/sql/opt/optgen/lang/operator.og.go
@@ -11,6 +11,8 @@ const (
 	DefineSetOp
 	RuleSetOp
 	DefineOp
+	CommentsOp
+	CommentOp
 	TagsOp
 	TagOp
 	DefineFieldsOp

--- a/pkg/sql/opt/optgen/lang/operator_string.go
+++ b/pkg/sql/opt/optgen/lang/operator_string.go
@@ -4,9 +4,9 @@ package lang
 
 import "fmt"
 
-const _Operator_name = "UnknownOpRootOpDefineSetOpRuleSetOpDefineOpTagsOpTagOpDefineFieldsOpDefineFieldOpRuleOpBindOpRefOpMatchOpOpNamesOpOpNameOpMatchAndOpMatchInvokeOpMatchNotOpMatchAnyOpMatchListOpConstructOpConstructListOpListOpStringOp"
+const _Operator_name = "UnknownOpRootOpDefineSetOpRuleSetOpDefineOpCommentsOpCommentOpTagsOpTagOpDefineFieldsOpDefineFieldOpRuleOpBindOpRefOpMatchOpOpNamesOpOpNameOpMatchAndOpMatchInvokeOpMatchNotOpMatchAnyOpMatchListOpConstructOpConstructListOpListOpStringOp"
 
-var _Operator_index = [...]uint8{0, 9, 15, 26, 35, 43, 49, 54, 68, 81, 87, 93, 98, 105, 114, 122, 132, 145, 155, 165, 176, 187, 202, 208, 216}
+var _Operator_index = [...]uint8{0, 9, 15, 26, 35, 43, 53, 62, 68, 73, 87, 100, 106, 112, 117, 124, 133, 141, 151, 164, 174, 184, 195, 206, 221, 227, 235}
 
 func (i Operator) String() string {
 	if i < 0 || i >= Operator(len(_Operator_index)-1) {

--- a/pkg/sql/opt/optgen/lang/testdata/compiler
+++ b/pkg/sql/opt/optgen/lang/testdata/compiler
@@ -2,47 +2,51 @@
 # Simple case.
 #
 compile
+# Join comment.
 define Join {
     Left  Expr
     Right Expr
 }
 
+# CommuteJoin comment.
 [CommuteJoin]
 (Join $left:* $right:*) => (Join $right $left)
 ----
 (Compiled
 	(Defines
 		(Define
+			Comments=(Comments # Join comment.)
 			Tags=(Tags)
 			Name="Join"
 			Fields=(DefineFields
-				(DefineField Name="Left" Type="Expr" Src=<test.opt:2:5>)
-				(DefineField Name="Right" Type="Expr" Src=<test.opt:3:5>)
+				(DefineField Name="Left" Type="Expr" Src=<test.opt:3:5>)
+				(DefineField Name="Right" Type="Expr" Src=<test.opt:4:5>)
 			)
-			Src=<test.opt:1:1>
+			Src=<test.opt:2:1>
 		)
 	)
 	(Rules
 		(Rule
+			Comments=(Comments # CommuteJoin comment.)
 			Name="CommuteJoin"
 			Tags=(Tags)
 			Match=(Match
 				Names=(OpNames JoinOp)
 				Args=(List
-					(Bind Label="left" Target=(MatchAny) Src=<test.opt:7:7>)
-					(Bind Label="right" Target=(MatchAny) Src=<test.opt:7:15>)
+					(Bind Label="left" Target=(MatchAny) Src=<test.opt:9:7>)
+					(Bind Label="right" Target=(MatchAny) Src=<test.opt:9:15>)
 				)
-				Src=<test.opt:7:1>
+				Src=<test.opt:9:1>
 			)
 			Replace=(Construct
 				Name="Join"
 				Args=(List
-					(Ref Label="right" Src=<test.opt:7:34>)
-					(Ref Label="left" Src=<test.opt:7:41>)
+					(Ref Label="right" Src=<test.opt:9:34>)
+					(Ref Label="left" Src=<test.opt:9:41>)
 				)
-				Src=<test.opt:7:28>
+				Src=<test.opt:9:28>
 			)
-			Src=<test.opt:6:1>
+			Src=<test.opt:8:1>
 		)
 	)
 )
@@ -66,12 +70,14 @@ define Project {
     Input Expr
 }
 
+# Name rule comment.
 [Name]
 (Join | Project) => ((OpName))
 ----
 (Compiled
 	(Defines
 		(Define
+			Comments=(Comments)
 			Tags=(Tags Join)
 			Name="InnerJoin"
 			Fields=(DefineFields
@@ -81,6 +87,7 @@ define Project {
 			Src=<test.opt:1:1>
 		)
 		(Define
+			Comments=(Comments)
 			Tags=(Tags Join)
 			Name="LeftJoin"
 			Fields=(DefineFields
@@ -90,6 +97,7 @@ define Project {
 			Src=<test.opt:6:1>
 		)
 		(Define
+			Comments=(Comments)
 			Tags=(Tags)
 			Name="Project"
 			Fields=(DefineFields
@@ -100,37 +108,40 @@ define Project {
 	)
 	(Rules
 		(Rule
+			Comments=(Comments # Name rule comment.)
 			Name="Name"
 			Tags=(Tags)
 			Match=(Match
 				Names=(OpNames InnerJoinOp)
 				Args=(List)
-				Src=<test.opt:16:1>
+				Src=<test.opt:17:1>
 			)
-			Replace=(Construct Name=InnerJoinOp Args=(List) Src=<test.opt:16:21>)
-			Src=<test.opt:15:1>
+			Replace=(Construct Name=InnerJoinOp Args=(List) Src=<test.opt:17:21>)
+			Src=<test.opt:16:1>
 		)
 		(Rule
+			Comments=(Comments # Name rule comment.)
 			Name="Name"
 			Tags=(Tags)
 			Match=(Match
 				Names=(OpNames LeftJoinOp)
 				Args=(List)
-				Src=<test.opt:16:1>
+				Src=<test.opt:17:1>
 			)
-			Replace=(Construct Name=LeftJoinOp Args=(List) Src=<test.opt:16:21>)
-			Src=<test.opt:15:1>
+			Replace=(Construct Name=LeftJoinOp Args=(List) Src=<test.opt:17:21>)
+			Src=<test.opt:16:1>
 		)
 		(Rule
+			Comments=(Comments # Name rule comment.)
 			Name="Name"
 			Tags=(Tags)
 			Match=(Match
 				Names=(OpNames ProjectOp)
 				Args=(List)
-				Src=<test.opt:16:1>
+				Src=<test.opt:17:1>
 			)
-			Replace=(Construct Name=ProjectOp Args=(List) Src=<test.opt:16:21>)
-			Src=<test.opt:15:1>
+			Replace=(Construct Name=ProjectOp Args=(List) Src=<test.opt:17:21>)
+			Src=<test.opt:16:1>
 		)
 	)
 )
@@ -154,6 +165,7 @@ define SubOp2 {}
 (Compiled
 	(Defines
 		(Define
+			Comments=(Comments)
 			Tags=(Tags)
 			Name="Op"
 			Fields=(DefineFields
@@ -161,11 +173,12 @@ define SubOp2 {}
 			)
 			Src=<test.opt:1:1>
 		)
-		(Define Tags=(Tags) Name="SubOp1" Fields=(DefineFields) Src=<test.opt:4:1>)
-		(Define Tags=(Tags) Name="SubOp2" Fields=(DefineFields) Src=<test.opt:5:1>)
+		(Define Comments=(Comments) Tags=(Tags) Name="SubOp1" Fields=(DefineFields) Src=<test.opt:4:1>)
+		(Define Comments=(Comments) Tags=(Tags) Name="SubOp2" Fields=(DefineFields) Src=<test.opt:5:1>)
 	)
 	(Rules
 		(Rule
+			Comments=(Comments)
 			Name="SingleName"
 			Tags=(Tags)
 			Match=(Match
@@ -187,6 +200,7 @@ define SubOp2 {}
 			Src=<test.opt:7:1>
 		)
 		(Rule
+			Comments=(Comments)
 			Name="MultipleNames"
 			Tags=(Tags)
 			Match=(Match

--- a/pkg/sql/opt/optgen/lang/testdata/parser
+++ b/pkg/sql/opt/optgen/lang/testdata/parser
@@ -2,6 +2,11 @@
 # Define without tags.
 #
 parse
+# This is a file header, and shouldn't be part of Lt's comment.
+
+# This is a comment about Lt.
+# And another information-packed line about it as well.
+#
 define Lt {
     Left  Expr
     Right Expr
@@ -10,13 +15,14 @@ define Lt {
 (Root
 	Defines=(DefineSet
 		(Define
+			Comments=(Comments # This is a comment about Lt. # And another information-packed line about it as well. #)
 			Tags=(Tags)
 			Name="Lt"
 			Fields=(DefineFields
-				(DefineField Name="Left" Type="Expr" Src=<test.opt:2:5>)
-				(DefineField Name="Right" Type="Expr" Src=<test.opt:3:5>)
+				(DefineField Name="Left" Type="Expr" Src=<test.opt:7:5>)
+				(DefineField Name="Right" Type="Expr" Src=<test.opt:8:5>)
 			)
-			Src=<test.opt:1:1>
+			Src=<test.opt:6:1>
 		)
 	)
 	Rules=(RuleSet)
@@ -26,6 +32,7 @@ define Lt {
 # Define with tags.
 #
 parse
+# Comment on definition with a tag. 
 [Tag1, Tag2]
 define Not {
     Input Expr
@@ -34,12 +41,13 @@ define Not {
 (Root
 	Defines=(DefineSet
 		(Define
+			Comments=(Comments # Comment on definition with a tag. )
 			Tags=(Tags Tag1 Tag2)
 			Name="Not"
 			Fields=(DefineFields
-				(DefineField Name="Input" Type="Expr" Src=<test.opt:3:5>)
+				(DefineField Name="Input" Type="Expr" Src=<test.opt:4:5>)
 			)
-			Src=<test.opt:1:1>
+			Src=<test.opt:2:1>
 		)
 	)
 	Rules=(RuleSet)
@@ -87,6 +95,50 @@ test.opt:22:5: expected define field name, found '('
 test.opt:27:11: expected define field type, found '1'
 
 #
+# Multiple rules with comments.
+#
+parse
+# This is the One rule.
+[One]
+(One) => (One)
+
+# This is an intermediate comment that shouldn't be included.
+
+# This is the Two rule.
+[Two]
+(Two) => (Two)
+----
+(Root
+	Defines=(DefineSet)
+	Rules=(RuleSet
+		(Rule
+			Comments=(Comments # This is the One rule.)
+			Name="One"
+			Tags=(Tags)
+			Match=(Match
+				Names=(OpNames OneOp)
+				Args=(List)
+				Src=<test.opt:3:1>
+			)
+			Replace=(Construct Name="One" Args=(List) Src=<test.opt:3:10>)
+			Src=<test.opt:2:1>
+		)
+		(Rule
+			Comments=(Comments # This is the Two rule.)
+			Name="Two"
+			Tags=(Tags)
+			Match=(Match
+				Names=(OpNames TwoOp)
+				Args=(List)
+				Src=<test.opt:9:1>
+			)
+			Replace=(Construct Name="Two" Args=(List) Src=<test.opt:9:10>)
+			Src=<test.opt:8:1>
+		)
+	)
+)
+
+#
 # Match multiple op names.
 #
 parse
@@ -97,6 +149,7 @@ parse
 	Defines=(DefineSet)
 	Rules=(RuleSet
 		(Rule
+			Comments=(Comments)
 			Name="Tag"
 			Tags=(Tags)
 			Match=(Match
@@ -129,6 +182,7 @@ parse
 	Defines=(DefineSet)
 	Rules=(RuleSet
 		(Rule
+			Comments=(Comments)
 			Name="Tag"
 			Tags=(Tags)
 			Match=(Match
@@ -178,6 +232,7 @@ parse
 	Defines=(DefineSet)
 	Rules=(RuleSet
 		(Rule
+			Comments=(Comments)
 			Name="Bind"
 			Tags=(Tags)
 			Match=(Match
@@ -231,6 +286,7 @@ parse
 	Defines=(DefineSet)
 	Rules=(RuleSet
 		(Rule
+			Comments=(Comments)
 			Name="boolean"
 			Tags=(Tags)
 			Match=(Match
@@ -271,6 +327,7 @@ parse
 	Defines=(DefineSet)
 	Rules=(RuleSet
 		(Rule
+			Comments=(Comments)
 			Name="Invoke"
 			Tags=(Tags)
 			Match=(Match
@@ -309,6 +366,7 @@ parse
 	Defines=(DefineSet)
 	Rules=(RuleSet
 		(Rule
+			Comments=(Comments)
 			Name="List"
 			Tags=(Tags)
 			Match=(Match
@@ -363,6 +421,7 @@ parse
 	Defines=(DefineSet)
 	Rules=(RuleSet
 		(Rule
+			Comments=(Comments)
 			Name="ConstructString"
 			Tags=(Tags)
 			Match=(Match
@@ -387,6 +446,7 @@ parse
 	Defines=(DefineSet)
 	Rules=(RuleSet
 		(Rule
+			Comments=(Comments)
 			Name="ConstructBound"
 			Tags=(Tags)
 			Match=(Match
@@ -413,6 +473,7 @@ parse
 	Defines=(DefineSet)
 	Rules=(RuleSet
 		(Rule
+			Comments=(Comments)
 			Name="Construct"
 			Tags=(Tags)
 			Match=(Match
@@ -450,6 +511,7 @@ parse
 	Defines=(DefineSet)
 	Rules=(RuleSet
 		(Rule
+			Comments=(Comments)
 			Name="Construct"
 			Tags=(Tags)
 			Match=(Match

--- a/pkg/sql/opt/xform/expr.og.go
+++ b/pkg/sql/opt/xform/expr.og.go
@@ -2727,6 +2727,8 @@ func (m *memoExpr) asSubquery() *subqueryExpr {
 	return (*subqueryExpr)(m)
 }
 
+// variableExpr is the typed scalar value of a column in the query. The private
+// field is a Metadata.ColumnIndex that references the column by index.
 type variableExpr memoExpr
 
 func makeVariableExpr(col opt.PrivateID) variableExpr {
@@ -2748,6 +2750,8 @@ func (m *memoExpr) asVariable() *variableExpr {
 	return (*variableExpr)(m)
 }
 
+// constExpr is a typed scalar constant value. The private field is a tree.Datum
+// value having any datum type that's legal in the expression's context.
 type constExpr memoExpr
 
 func makeConstExpr(value opt.PrivateID) constExpr {
@@ -2769,6 +2773,9 @@ func (m *memoExpr) asConst() *constExpr {
 	return (*constExpr)(m)
 }
 
+// trueExpr is the boolean true value that is equivalent to the tree.DBoolTrue datum
+// value. It is a separate operator to make matching and replacement simpler and
+// more efficient, as patterns can contain (True) expressions.
 type trueExpr memoExpr
 
 func makeTrueExpr() trueExpr {
@@ -2786,6 +2793,9 @@ func (m *memoExpr) asTrue() *trueExpr {
 	return (*trueExpr)(m)
 }
 
+// falseExpr is the boolean false value that is equivalent to the tree.DBoolFalse
+// datum value. It is a separate operator to make matching and replacement
+// simpler and more efficient, as patterns can contain (False) expressions.
 type falseExpr memoExpr
 
 func makeFalseExpr() falseExpr {
@@ -2845,6 +2855,9 @@ func (m *memoExpr) asTuple() *tupleExpr {
 	return (*tupleExpr)(m)
 }
 
+// projectionsExpr is a set of typed scalar expressions that will become output
+// columns for a containing Project operator. The private Cols field contains
+// the set of column indexes returned by the expression, as a *ColList.
 type projectionsExpr memoExpr
 
 func makeProjectionsExpr(elems opt.ListID, cols opt.PrivateID) projectionsExpr {
@@ -2870,6 +2883,9 @@ func (m *memoExpr) asProjections() *projectionsExpr {
 	return (*projectionsExpr)(m)
 }
 
+// aggregationsExpr is a set of aggregate expressions that will become output
+// columns for a containing GroupBy operator. The private Cols field contains
+// the set of column indexes returned by the expression, as a *ColList.
 type aggregationsExpr memoExpr
 
 func makeAggregationsExpr(aggs opt.ListID, cols opt.PrivateID) aggregationsExpr {
@@ -2895,6 +2911,11 @@ func (m *memoExpr) asAggregations() *aggregationsExpr {
 	return (*aggregationsExpr)(m)
 }
 
+// groupingsExpr is a set of grouping expressions that will become output columns
+// for a containing GroupBy operator. The GroupBy operator groups its input by
+// the value of these expressions, and may compute aggregates over the groups.
+// The private Cols field contains the set of column indexes returned by the
+// expression, as a *ColList.
 type groupingsExpr memoExpr
 
 func makeGroupingsExpr(elems opt.ListID, cols opt.PrivateID) groupingsExpr {
@@ -4096,6 +4117,10 @@ func (m *memoExpr) asFunction() *functionExpr {
 	return (*functionExpr)(m)
 }
 
+// scanExpr returns a result set containing every row in the specified table. Rows
+// and columns are not expected to have any particular ordering. The private
+// Table field is a Metadata.TableIndex that references an optbase.Table
+// definition in the query's metadata.
 type scanExpr memoExpr
 
 func makeScanExpr(table opt.PrivateID) scanExpr {
@@ -4117,6 +4142,10 @@ func (m *memoExpr) asScan() *scanExpr {
 	return (*scanExpr)(m)
 }
 
+// valuesExpr returns a manufactured result set containing a constant number of rows
+// specified by the Rows list field. Each row must contain the same set of
+// columns in the same order. The Cols field contains the set of column indexes
+// returned by each row, as a *ColSet.
 type valuesExpr memoExpr
 
 func makeValuesExpr(rows opt.ListID, cols opt.PrivateID) valuesExpr {
@@ -4142,6 +4171,8 @@ func (m *memoExpr) asValues() *valuesExpr {
 	return (*valuesExpr)(m)
 }
 
+// selectExpr filters rows from its input result set, based on the boolean filter
+// predicate expression. Rows which do not match the filter are discarded.
 type selectExpr memoExpr
 
 func makeSelectExpr(input opt.GroupID, filter opt.GroupID) selectExpr {
@@ -4192,6 +4223,11 @@ func (m *memoExpr) asProject() *projectExpr {
 	return (*projectExpr)(m)
 }
 
+// innerJoinExpr creates a result set that combines columns from its left and right
+// inputs, based upon its "on" join predicate. Rows which do not match the
+// predicate are filtered. While expressions in the predicate can refer to
+// columns projected by either the left or right inputs, the inputs are not
+// allowed to refer to the other's projected columns.
 type innerJoinExpr memoExpr
 
 func makeInnerJoinExpr(left opt.GroupID, right opt.GroupID, on opt.GroupID) innerJoinExpr {
@@ -4366,6 +4402,9 @@ func (m *memoExpr) asAntiJoin() *antiJoinExpr {
 	return (*antiJoinExpr)(m)
 }
 
+// innerJoinApplyExpr has the same join semantics as InnerJoin. However, unlike
+// InnerJoin, it allows the right input to refer to columns projected by the
+// left input.
 type innerJoinApplyExpr memoExpr
 
 func makeInnerJoinApplyExpr(left opt.GroupID, right opt.GroupID, on opt.GroupID) innerJoinApplyExpr {

--- a/pkg/sql/opt/xform/factory.og.go
+++ b/pkg/sql/opt/xform/factory.og.go
@@ -6,6 +6,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/opt"
 )
 
+// ConstructSubquery constructs an expression for the Subquery operator.
 func (_f *factory) ConstructSubquery(
 	input opt.GroupID,
 	projection opt.GroupID,
@@ -23,6 +24,9 @@ func (_f *factory) ConstructSubquery(
 	return _f.onConstruct(_f.mem.memoizeNormExpr((*memoExpr)(&_subqueryExpr)))
 }
 
+// ConstructVariable constructs an expression for the Variable operator.
+// Variable is the typed scalar value of a column in the query. The private
+// field is a Metadata.ColumnIndex that references the column by index.
 func (_f *factory) ConstructVariable(
 	col opt.PrivateID,
 ) opt.GroupID {
@@ -39,6 +43,9 @@ func (_f *factory) ConstructVariable(
 	return _f.onConstruct(_f.mem.memoizeNormExpr((*memoExpr)(&_variableExpr)))
 }
 
+// ConstructConst constructs an expression for the Const operator.
+// Const is a typed scalar constant value. The private field is a tree.Datum
+// value having any datum type that's legal in the expression's context.
 func (_f *factory) ConstructConst(
 	value opt.PrivateID,
 ) opt.GroupID {
@@ -55,6 +62,10 @@ func (_f *factory) ConstructConst(
 	return _f.onConstruct(_f.mem.memoizeNormExpr((*memoExpr)(&_constExpr)))
 }
 
+// ConstructTrue constructs an expression for the True operator.
+// True is the boolean true value that is equivalent to the tree.DBoolTrue datum
+// value. It is a separate operator to make matching and replacement simpler and
+// more efficient, as patterns can contain (True) expressions.
 func (_f *factory) ConstructTrue() opt.GroupID {
 	_trueExpr := makeTrueExpr()
 	_group := _f.mem.lookupGroupByFingerprint(_trueExpr.fingerprint())
@@ -69,6 +80,10 @@ func (_f *factory) ConstructTrue() opt.GroupID {
 	return _f.onConstruct(_f.mem.memoizeNormExpr((*memoExpr)(&_trueExpr)))
 }
 
+// ConstructFalse constructs an expression for the False operator.
+// False is the boolean false value that is equivalent to the tree.DBoolFalse
+// datum value. It is a separate operator to make matching and replacement
+// simpler and more efficient, as patterns can contain (False) expressions.
 func (_f *factory) ConstructFalse() opt.GroupID {
 	_falseExpr := makeFalseExpr()
 	_group := _f.mem.lookupGroupByFingerprint(_falseExpr.fingerprint())
@@ -83,6 +98,7 @@ func (_f *factory) ConstructFalse() opt.GroupID {
 	return _f.onConstruct(_f.mem.memoizeNormExpr((*memoExpr)(&_falseExpr)))
 }
 
+// ConstructPlaceholder constructs an expression for the Placeholder operator.
 func (_f *factory) ConstructPlaceholder(
 	value opt.PrivateID,
 ) opt.GroupID {
@@ -99,6 +115,7 @@ func (_f *factory) ConstructPlaceholder(
 	return _f.onConstruct(_f.mem.memoizeNormExpr((*memoExpr)(&_placeholderExpr)))
 }
 
+// ConstructTuple constructs an expression for the Tuple operator.
 func (_f *factory) ConstructTuple(
 	elems opt.ListID,
 ) opt.GroupID {
@@ -115,6 +132,10 @@ func (_f *factory) ConstructTuple(
 	return _f.onConstruct(_f.mem.memoizeNormExpr((*memoExpr)(&_tupleExpr)))
 }
 
+// ConstructProjections constructs an expression for the Projections operator.
+// Projections is a set of typed scalar expressions that will become output
+// columns for a containing Project operator. The private Cols field contains
+// the set of column indexes returned by the expression, as a *ColList.
 func (_f *factory) ConstructProjections(
 	elems opt.ListID,
 	cols opt.PrivateID,
@@ -132,6 +153,10 @@ func (_f *factory) ConstructProjections(
 	return _f.onConstruct(_f.mem.memoizeNormExpr((*memoExpr)(&_projectionsExpr)))
 }
 
+// ConstructAggregations constructs an expression for the Aggregations operator.
+// Aggregations is a set of aggregate expressions that will become output
+// columns for a containing GroupBy operator. The private Cols field contains
+// the set of column indexes returned by the expression, as a *ColList.
 func (_f *factory) ConstructAggregations(
 	aggs opt.ListID,
 	cols opt.PrivateID,
@@ -149,6 +174,12 @@ func (_f *factory) ConstructAggregations(
 	return _f.onConstruct(_f.mem.memoizeNormExpr((*memoExpr)(&_aggregationsExpr)))
 }
 
+// ConstructGroupings constructs an expression for the Groupings operator.
+// Groupings is a set of grouping expressions that will become output columns
+// for a containing GroupBy operator. The GroupBy operator groups its input by
+// the value of these expressions, and may compute aggregates over the groups.
+// The private Cols field contains the set of column indexes returned by the
+// expression, as a *ColList.
 func (_f *factory) ConstructGroupings(
 	elems opt.ListID,
 	cols opt.PrivateID,
@@ -166,6 +197,7 @@ func (_f *factory) ConstructGroupings(
 	return _f.onConstruct(_f.mem.memoizeNormExpr((*memoExpr)(&_groupingsExpr)))
 }
 
+// ConstructFilters constructs an expression for the Filters operator.
 func (_f *factory) ConstructFilters(
 	conditions opt.ListID,
 ) opt.GroupID {
@@ -182,6 +214,7 @@ func (_f *factory) ConstructFilters(
 	return _f.onConstruct(_f.mem.memoizeNormExpr((*memoExpr)(&_filtersExpr)))
 }
 
+// ConstructExists constructs an expression for the Exists operator.
 func (_f *factory) ConstructExists(
 	input opt.GroupID,
 ) opt.GroupID {
@@ -198,6 +231,7 @@ func (_f *factory) ConstructExists(
 	return _f.onConstruct(_f.mem.memoizeNormExpr((*memoExpr)(&_existsExpr)))
 }
 
+// ConstructAnd constructs an expression for the And operator.
 func (_f *factory) ConstructAnd(
 	left opt.GroupID,
 	right opt.GroupID,
@@ -215,6 +249,7 @@ func (_f *factory) ConstructAnd(
 	return _f.onConstruct(_f.mem.memoizeNormExpr((*memoExpr)(&_andExpr)))
 }
 
+// ConstructOr constructs an expression for the Or operator.
 func (_f *factory) ConstructOr(
 	left opt.GroupID,
 	right opt.GroupID,
@@ -232,6 +267,7 @@ func (_f *factory) ConstructOr(
 	return _f.onConstruct(_f.mem.memoizeNormExpr((*memoExpr)(&_orExpr)))
 }
 
+// ConstructNot constructs an expression for the Not operator.
 func (_f *factory) ConstructNot(
 	input opt.GroupID,
 ) opt.GroupID {
@@ -248,6 +284,7 @@ func (_f *factory) ConstructNot(
 	return _f.onConstruct(_f.mem.memoizeNormExpr((*memoExpr)(&_notExpr)))
 }
 
+// ConstructEq constructs an expression for the Eq operator.
 func (_f *factory) ConstructEq(
 	left opt.GroupID,
 	right opt.GroupID,
@@ -265,6 +302,7 @@ func (_f *factory) ConstructEq(
 	return _f.onConstruct(_f.mem.memoizeNormExpr((*memoExpr)(&_eqExpr)))
 }
 
+// ConstructLt constructs an expression for the Lt operator.
 func (_f *factory) ConstructLt(
 	left opt.GroupID,
 	right opt.GroupID,
@@ -282,6 +320,7 @@ func (_f *factory) ConstructLt(
 	return _f.onConstruct(_f.mem.memoizeNormExpr((*memoExpr)(&_ltExpr)))
 }
 
+// ConstructGt constructs an expression for the Gt operator.
 func (_f *factory) ConstructGt(
 	left opt.GroupID,
 	right opt.GroupID,
@@ -299,6 +338,7 @@ func (_f *factory) ConstructGt(
 	return _f.onConstruct(_f.mem.memoizeNormExpr((*memoExpr)(&_gtExpr)))
 }
 
+// ConstructLe constructs an expression for the Le operator.
 func (_f *factory) ConstructLe(
 	left opt.GroupID,
 	right opt.GroupID,
@@ -316,6 +356,7 @@ func (_f *factory) ConstructLe(
 	return _f.onConstruct(_f.mem.memoizeNormExpr((*memoExpr)(&_leExpr)))
 }
 
+// ConstructGe constructs an expression for the Ge operator.
 func (_f *factory) ConstructGe(
 	left opt.GroupID,
 	right opt.GroupID,
@@ -333,6 +374,7 @@ func (_f *factory) ConstructGe(
 	return _f.onConstruct(_f.mem.memoizeNormExpr((*memoExpr)(&_geExpr)))
 }
 
+// ConstructNe constructs an expression for the Ne operator.
 func (_f *factory) ConstructNe(
 	left opt.GroupID,
 	right opt.GroupID,
@@ -350,6 +392,7 @@ func (_f *factory) ConstructNe(
 	return _f.onConstruct(_f.mem.memoizeNormExpr((*memoExpr)(&_neExpr)))
 }
 
+// ConstructIn constructs an expression for the In operator.
 func (_f *factory) ConstructIn(
 	left opt.GroupID,
 	right opt.GroupID,
@@ -367,6 +410,7 @@ func (_f *factory) ConstructIn(
 	return _f.onConstruct(_f.mem.memoizeNormExpr((*memoExpr)(&_inExpr)))
 }
 
+// ConstructNotIn constructs an expression for the NotIn operator.
 func (_f *factory) ConstructNotIn(
 	left opt.GroupID,
 	right opt.GroupID,
@@ -384,6 +428,7 @@ func (_f *factory) ConstructNotIn(
 	return _f.onConstruct(_f.mem.memoizeNormExpr((*memoExpr)(&_notInExpr)))
 }
 
+// ConstructLike constructs an expression for the Like operator.
 func (_f *factory) ConstructLike(
 	left opt.GroupID,
 	right opt.GroupID,
@@ -401,6 +446,7 @@ func (_f *factory) ConstructLike(
 	return _f.onConstruct(_f.mem.memoizeNormExpr((*memoExpr)(&_likeExpr)))
 }
 
+// ConstructNotLike constructs an expression for the NotLike operator.
 func (_f *factory) ConstructNotLike(
 	left opt.GroupID,
 	right opt.GroupID,
@@ -418,6 +464,7 @@ func (_f *factory) ConstructNotLike(
 	return _f.onConstruct(_f.mem.memoizeNormExpr((*memoExpr)(&_notLikeExpr)))
 }
 
+// ConstructILike constructs an expression for the ILike operator.
 func (_f *factory) ConstructILike(
 	left opt.GroupID,
 	right opt.GroupID,
@@ -435,6 +482,7 @@ func (_f *factory) ConstructILike(
 	return _f.onConstruct(_f.mem.memoizeNormExpr((*memoExpr)(&_iLikeExpr)))
 }
 
+// ConstructNotILike constructs an expression for the NotILike operator.
 func (_f *factory) ConstructNotILike(
 	left opt.GroupID,
 	right opt.GroupID,
@@ -452,6 +500,7 @@ func (_f *factory) ConstructNotILike(
 	return _f.onConstruct(_f.mem.memoizeNormExpr((*memoExpr)(&_notILikeExpr)))
 }
 
+// ConstructSimilarTo constructs an expression for the SimilarTo operator.
 func (_f *factory) ConstructSimilarTo(
 	left opt.GroupID,
 	right opt.GroupID,
@@ -469,6 +518,7 @@ func (_f *factory) ConstructSimilarTo(
 	return _f.onConstruct(_f.mem.memoizeNormExpr((*memoExpr)(&_similarToExpr)))
 }
 
+// ConstructNotSimilarTo constructs an expression for the NotSimilarTo operator.
 func (_f *factory) ConstructNotSimilarTo(
 	left opt.GroupID,
 	right opt.GroupID,
@@ -486,6 +536,7 @@ func (_f *factory) ConstructNotSimilarTo(
 	return _f.onConstruct(_f.mem.memoizeNormExpr((*memoExpr)(&_notSimilarToExpr)))
 }
 
+// ConstructRegMatch constructs an expression for the RegMatch operator.
 func (_f *factory) ConstructRegMatch(
 	left opt.GroupID,
 	right opt.GroupID,
@@ -503,6 +554,7 @@ func (_f *factory) ConstructRegMatch(
 	return _f.onConstruct(_f.mem.memoizeNormExpr((*memoExpr)(&_regMatchExpr)))
 }
 
+// ConstructNotRegMatch constructs an expression for the NotRegMatch operator.
 func (_f *factory) ConstructNotRegMatch(
 	left opt.GroupID,
 	right opt.GroupID,
@@ -520,6 +572,7 @@ func (_f *factory) ConstructNotRegMatch(
 	return _f.onConstruct(_f.mem.memoizeNormExpr((*memoExpr)(&_notRegMatchExpr)))
 }
 
+// ConstructRegIMatch constructs an expression for the RegIMatch operator.
 func (_f *factory) ConstructRegIMatch(
 	left opt.GroupID,
 	right opt.GroupID,
@@ -537,6 +590,7 @@ func (_f *factory) ConstructRegIMatch(
 	return _f.onConstruct(_f.mem.memoizeNormExpr((*memoExpr)(&_regIMatchExpr)))
 }
 
+// ConstructNotRegIMatch constructs an expression for the NotRegIMatch operator.
 func (_f *factory) ConstructNotRegIMatch(
 	left opt.GroupID,
 	right opt.GroupID,
@@ -554,6 +608,7 @@ func (_f *factory) ConstructNotRegIMatch(
 	return _f.onConstruct(_f.mem.memoizeNormExpr((*memoExpr)(&_notRegIMatchExpr)))
 }
 
+// ConstructIs constructs an expression for the Is operator.
 func (_f *factory) ConstructIs(
 	left opt.GroupID,
 	right opt.GroupID,
@@ -571,6 +626,7 @@ func (_f *factory) ConstructIs(
 	return _f.onConstruct(_f.mem.memoizeNormExpr((*memoExpr)(&_isExpr)))
 }
 
+// ConstructIsNot constructs an expression for the IsNot operator.
 func (_f *factory) ConstructIsNot(
 	left opt.GroupID,
 	right opt.GroupID,
@@ -588,6 +644,7 @@ func (_f *factory) ConstructIsNot(
 	return _f.onConstruct(_f.mem.memoizeNormExpr((*memoExpr)(&_isNotExpr)))
 }
 
+// ConstructContains constructs an expression for the Contains operator.
 func (_f *factory) ConstructContains(
 	left opt.GroupID,
 	right opt.GroupID,
@@ -605,6 +662,7 @@ func (_f *factory) ConstructContains(
 	return _f.onConstruct(_f.mem.memoizeNormExpr((*memoExpr)(&_containsExpr)))
 }
 
+// ConstructContainedBy constructs an expression for the ContainedBy operator.
 func (_f *factory) ConstructContainedBy(
 	left opt.GroupID,
 	right opt.GroupID,
@@ -622,6 +680,7 @@ func (_f *factory) ConstructContainedBy(
 	return _f.onConstruct(_f.mem.memoizeNormExpr((*memoExpr)(&_containedByExpr)))
 }
 
+// ConstructBitand constructs an expression for the Bitand operator.
 func (_f *factory) ConstructBitand(
 	left opt.GroupID,
 	right opt.GroupID,
@@ -639,6 +698,7 @@ func (_f *factory) ConstructBitand(
 	return _f.onConstruct(_f.mem.memoizeNormExpr((*memoExpr)(&_bitandExpr)))
 }
 
+// ConstructBitor constructs an expression for the Bitor operator.
 func (_f *factory) ConstructBitor(
 	left opt.GroupID,
 	right opt.GroupID,
@@ -656,6 +716,7 @@ func (_f *factory) ConstructBitor(
 	return _f.onConstruct(_f.mem.memoizeNormExpr((*memoExpr)(&_bitorExpr)))
 }
 
+// ConstructBitxor constructs an expression for the Bitxor operator.
 func (_f *factory) ConstructBitxor(
 	left opt.GroupID,
 	right opt.GroupID,
@@ -673,6 +734,7 @@ func (_f *factory) ConstructBitxor(
 	return _f.onConstruct(_f.mem.memoizeNormExpr((*memoExpr)(&_bitxorExpr)))
 }
 
+// ConstructPlus constructs an expression for the Plus operator.
 func (_f *factory) ConstructPlus(
 	left opt.GroupID,
 	right opt.GroupID,
@@ -690,6 +752,7 @@ func (_f *factory) ConstructPlus(
 	return _f.onConstruct(_f.mem.memoizeNormExpr((*memoExpr)(&_plusExpr)))
 }
 
+// ConstructMinus constructs an expression for the Minus operator.
 func (_f *factory) ConstructMinus(
 	left opt.GroupID,
 	right opt.GroupID,
@@ -707,6 +770,7 @@ func (_f *factory) ConstructMinus(
 	return _f.onConstruct(_f.mem.memoizeNormExpr((*memoExpr)(&_minusExpr)))
 }
 
+// ConstructMult constructs an expression for the Mult operator.
 func (_f *factory) ConstructMult(
 	left opt.GroupID,
 	right opt.GroupID,
@@ -724,6 +788,7 @@ func (_f *factory) ConstructMult(
 	return _f.onConstruct(_f.mem.memoizeNormExpr((*memoExpr)(&_multExpr)))
 }
 
+// ConstructDiv constructs an expression for the Div operator.
 func (_f *factory) ConstructDiv(
 	left opt.GroupID,
 	right opt.GroupID,
@@ -741,6 +806,7 @@ func (_f *factory) ConstructDiv(
 	return _f.onConstruct(_f.mem.memoizeNormExpr((*memoExpr)(&_divExpr)))
 }
 
+// ConstructFloorDiv constructs an expression for the FloorDiv operator.
 func (_f *factory) ConstructFloorDiv(
 	left opt.GroupID,
 	right opt.GroupID,
@@ -758,6 +824,7 @@ func (_f *factory) ConstructFloorDiv(
 	return _f.onConstruct(_f.mem.memoizeNormExpr((*memoExpr)(&_floorDivExpr)))
 }
 
+// ConstructMod constructs an expression for the Mod operator.
 func (_f *factory) ConstructMod(
 	left opt.GroupID,
 	right opt.GroupID,
@@ -775,6 +842,7 @@ func (_f *factory) ConstructMod(
 	return _f.onConstruct(_f.mem.memoizeNormExpr((*memoExpr)(&_modExpr)))
 }
 
+// ConstructPow constructs an expression for the Pow operator.
 func (_f *factory) ConstructPow(
 	left opt.GroupID,
 	right opt.GroupID,
@@ -792,6 +860,7 @@ func (_f *factory) ConstructPow(
 	return _f.onConstruct(_f.mem.memoizeNormExpr((*memoExpr)(&_powExpr)))
 }
 
+// ConstructConcat constructs an expression for the Concat operator.
 func (_f *factory) ConstructConcat(
 	left opt.GroupID,
 	right opt.GroupID,
@@ -809,6 +878,7 @@ func (_f *factory) ConstructConcat(
 	return _f.onConstruct(_f.mem.memoizeNormExpr((*memoExpr)(&_concatExpr)))
 }
 
+// ConstructLShift constructs an expression for the LShift operator.
 func (_f *factory) ConstructLShift(
 	left opt.GroupID,
 	right opt.GroupID,
@@ -826,6 +896,7 @@ func (_f *factory) ConstructLShift(
 	return _f.onConstruct(_f.mem.memoizeNormExpr((*memoExpr)(&_lShiftExpr)))
 }
 
+// ConstructRShift constructs an expression for the RShift operator.
 func (_f *factory) ConstructRShift(
 	left opt.GroupID,
 	right opt.GroupID,
@@ -843,6 +914,7 @@ func (_f *factory) ConstructRShift(
 	return _f.onConstruct(_f.mem.memoizeNormExpr((*memoExpr)(&_rShiftExpr)))
 }
 
+// ConstructFetchVal constructs an expression for the FetchVal operator.
 func (_f *factory) ConstructFetchVal(
 	json opt.GroupID,
 	index opt.GroupID,
@@ -860,6 +932,7 @@ func (_f *factory) ConstructFetchVal(
 	return _f.onConstruct(_f.mem.memoizeNormExpr((*memoExpr)(&_fetchValExpr)))
 }
 
+// ConstructFetchText constructs an expression for the FetchText operator.
 func (_f *factory) ConstructFetchText(
 	json opt.GroupID,
 	index opt.GroupID,
@@ -877,6 +950,7 @@ func (_f *factory) ConstructFetchText(
 	return _f.onConstruct(_f.mem.memoizeNormExpr((*memoExpr)(&_fetchTextExpr)))
 }
 
+// ConstructFetchValPath constructs an expression for the FetchValPath operator.
 func (_f *factory) ConstructFetchValPath(
 	json opt.GroupID,
 	path opt.GroupID,
@@ -894,6 +968,7 @@ func (_f *factory) ConstructFetchValPath(
 	return _f.onConstruct(_f.mem.memoizeNormExpr((*memoExpr)(&_fetchValPathExpr)))
 }
 
+// ConstructFetchTextPath constructs an expression for the FetchTextPath operator.
 func (_f *factory) ConstructFetchTextPath(
 	json opt.GroupID,
 	path opt.GroupID,
@@ -911,6 +986,7 @@ func (_f *factory) ConstructFetchTextPath(
 	return _f.onConstruct(_f.mem.memoizeNormExpr((*memoExpr)(&_fetchTextPathExpr)))
 }
 
+// ConstructUnaryPlus constructs an expression for the UnaryPlus operator.
 func (_f *factory) ConstructUnaryPlus(
 	input opt.GroupID,
 ) opt.GroupID {
@@ -927,6 +1003,7 @@ func (_f *factory) ConstructUnaryPlus(
 	return _f.onConstruct(_f.mem.memoizeNormExpr((*memoExpr)(&_unaryPlusExpr)))
 }
 
+// ConstructUnaryMinus constructs an expression for the UnaryMinus operator.
 func (_f *factory) ConstructUnaryMinus(
 	input opt.GroupID,
 ) opt.GroupID {
@@ -943,6 +1020,7 @@ func (_f *factory) ConstructUnaryMinus(
 	return _f.onConstruct(_f.mem.memoizeNormExpr((*memoExpr)(&_unaryMinusExpr)))
 }
 
+// ConstructUnaryComplement constructs an expression for the UnaryComplement operator.
 func (_f *factory) ConstructUnaryComplement(
 	input opt.GroupID,
 ) opt.GroupID {
@@ -959,6 +1037,7 @@ func (_f *factory) ConstructUnaryComplement(
 	return _f.onConstruct(_f.mem.memoizeNormExpr((*memoExpr)(&_unaryComplementExpr)))
 }
 
+// ConstructFunction constructs an expression for the Function operator.
 func (_f *factory) ConstructFunction(
 	args opt.ListID,
 	def opt.PrivateID,
@@ -976,6 +1055,11 @@ func (_f *factory) ConstructFunction(
 	return _f.onConstruct(_f.mem.memoizeNormExpr((*memoExpr)(&_functionExpr)))
 }
 
+// ConstructScan constructs an expression for the Scan operator.
+// Scan returns a result set containing every row in the specified table. Rows
+// and columns are not expected to have any particular ordering. The private
+// Table field is a Metadata.TableIndex that references an optbase.Table
+// definition in the query's metadata.
 func (_f *factory) ConstructScan(
 	table opt.PrivateID,
 ) opt.GroupID {
@@ -992,6 +1076,11 @@ func (_f *factory) ConstructScan(
 	return _f.onConstruct(_f.mem.memoizeNormExpr((*memoExpr)(&_scanExpr)))
 }
 
+// ConstructValues constructs an expression for the Values operator.
+// Values returns a manufactured result set containing a constant number of rows
+// specified by the Rows list field. Each row must contain the same set of
+// columns in the same order. The Cols field contains the set of column indexes
+// returned by each row, as a *ColSet.
 func (_f *factory) ConstructValues(
 	rows opt.ListID,
 	cols opt.PrivateID,
@@ -1009,6 +1098,9 @@ func (_f *factory) ConstructValues(
 	return _f.onConstruct(_f.mem.memoizeNormExpr((*memoExpr)(&_valuesExpr)))
 }
 
+// ConstructSelect constructs an expression for the Select operator.
+// Select filters rows from its input result set, based on the boolean filter
+// predicate expression. Rows which do not match the filter are discarded.
 func (_f *factory) ConstructSelect(
 	input opt.GroupID,
 	filter opt.GroupID,
@@ -1026,6 +1118,7 @@ func (_f *factory) ConstructSelect(
 	return _f.onConstruct(_f.mem.memoizeNormExpr((*memoExpr)(&_selectExpr)))
 }
 
+// ConstructProject constructs an expression for the Project operator.
 func (_f *factory) ConstructProject(
 	input opt.GroupID,
 	projections opt.GroupID,
@@ -1043,6 +1136,12 @@ func (_f *factory) ConstructProject(
 	return _f.onConstruct(_f.mem.memoizeNormExpr((*memoExpr)(&_projectExpr)))
 }
 
+// ConstructInnerJoin constructs an expression for the InnerJoin operator.
+// InnerJoin creates a result set that combines columns from its left and right
+// inputs, based upon its "on" join predicate. Rows which do not match the
+// predicate are filtered. While expressions in the predicate can refer to
+// columns projected by either the left or right inputs, the inputs are not
+// allowed to refer to the other's projected columns.
 func (_f *factory) ConstructInnerJoin(
 	left opt.GroupID,
 	right opt.GroupID,
@@ -1061,6 +1160,7 @@ func (_f *factory) ConstructInnerJoin(
 	return _f.onConstruct(_f.mem.memoizeNormExpr((*memoExpr)(&_innerJoinExpr)))
 }
 
+// ConstructLeftJoin constructs an expression for the LeftJoin operator.
 func (_f *factory) ConstructLeftJoin(
 	left opt.GroupID,
 	right opt.GroupID,
@@ -1079,6 +1179,7 @@ func (_f *factory) ConstructLeftJoin(
 	return _f.onConstruct(_f.mem.memoizeNormExpr((*memoExpr)(&_leftJoinExpr)))
 }
 
+// ConstructRightJoin constructs an expression for the RightJoin operator.
 func (_f *factory) ConstructRightJoin(
 	left opt.GroupID,
 	right opt.GroupID,
@@ -1097,6 +1198,7 @@ func (_f *factory) ConstructRightJoin(
 	return _f.onConstruct(_f.mem.memoizeNormExpr((*memoExpr)(&_rightJoinExpr)))
 }
 
+// ConstructFullJoin constructs an expression for the FullJoin operator.
 func (_f *factory) ConstructFullJoin(
 	left opt.GroupID,
 	right opt.GroupID,
@@ -1115,6 +1217,7 @@ func (_f *factory) ConstructFullJoin(
 	return _f.onConstruct(_f.mem.memoizeNormExpr((*memoExpr)(&_fullJoinExpr)))
 }
 
+// ConstructSemiJoin constructs an expression for the SemiJoin operator.
 func (_f *factory) ConstructSemiJoin(
 	left opt.GroupID,
 	right opt.GroupID,
@@ -1133,6 +1236,7 @@ func (_f *factory) ConstructSemiJoin(
 	return _f.onConstruct(_f.mem.memoizeNormExpr((*memoExpr)(&_semiJoinExpr)))
 }
 
+// ConstructAntiJoin constructs an expression for the AntiJoin operator.
 func (_f *factory) ConstructAntiJoin(
 	left opt.GroupID,
 	right opt.GroupID,
@@ -1151,6 +1255,10 @@ func (_f *factory) ConstructAntiJoin(
 	return _f.onConstruct(_f.mem.memoizeNormExpr((*memoExpr)(&_antiJoinExpr)))
 }
 
+// ConstructInnerJoinApply constructs an expression for the InnerJoinApply operator.
+// InnerJoinApply has the same join semantics as InnerJoin. However, unlike
+// InnerJoin, it allows the right input to refer to columns projected by the
+// left input.
 func (_f *factory) ConstructInnerJoinApply(
 	left opt.GroupID,
 	right opt.GroupID,
@@ -1169,6 +1277,7 @@ func (_f *factory) ConstructInnerJoinApply(
 	return _f.onConstruct(_f.mem.memoizeNormExpr((*memoExpr)(&_innerJoinApplyExpr)))
 }
 
+// ConstructLeftJoinApply constructs an expression for the LeftJoinApply operator.
 func (_f *factory) ConstructLeftJoinApply(
 	left opt.GroupID,
 	right opt.GroupID,
@@ -1187,6 +1296,7 @@ func (_f *factory) ConstructLeftJoinApply(
 	return _f.onConstruct(_f.mem.memoizeNormExpr((*memoExpr)(&_leftJoinApplyExpr)))
 }
 
+// ConstructRightJoinApply constructs an expression for the RightJoinApply operator.
 func (_f *factory) ConstructRightJoinApply(
 	left opt.GroupID,
 	right opt.GroupID,
@@ -1205,6 +1315,7 @@ func (_f *factory) ConstructRightJoinApply(
 	return _f.onConstruct(_f.mem.memoizeNormExpr((*memoExpr)(&_rightJoinApplyExpr)))
 }
 
+// ConstructFullJoinApply constructs an expression for the FullJoinApply operator.
 func (_f *factory) ConstructFullJoinApply(
 	left opt.GroupID,
 	right opt.GroupID,
@@ -1223,6 +1334,7 @@ func (_f *factory) ConstructFullJoinApply(
 	return _f.onConstruct(_f.mem.memoizeNormExpr((*memoExpr)(&_fullJoinApplyExpr)))
 }
 
+// ConstructSemiJoinApply constructs an expression for the SemiJoinApply operator.
 func (_f *factory) ConstructSemiJoinApply(
 	left opt.GroupID,
 	right opt.GroupID,
@@ -1241,6 +1353,7 @@ func (_f *factory) ConstructSemiJoinApply(
 	return _f.onConstruct(_f.mem.memoizeNormExpr((*memoExpr)(&_semiJoinApplyExpr)))
 }
 
+// ConstructAntiJoinApply constructs an expression for the AntiJoinApply operator.
 func (_f *factory) ConstructAntiJoinApply(
 	left opt.GroupID,
 	right opt.GroupID,
@@ -1259,6 +1372,7 @@ func (_f *factory) ConstructAntiJoinApply(
 	return _f.onConstruct(_f.mem.memoizeNormExpr((*memoExpr)(&_antiJoinApplyExpr)))
 }
 
+// ConstructGroupBy constructs an expression for the GroupBy operator.
 func (_f *factory) ConstructGroupBy(
 	input opt.GroupID,
 	groupings opt.GroupID,
@@ -1277,6 +1391,7 @@ func (_f *factory) ConstructGroupBy(
 	return _f.onConstruct(_f.mem.memoizeNormExpr((*memoExpr)(&_groupByExpr)))
 }
 
+// ConstructUnion constructs an expression for the Union operator.
 func (_f *factory) ConstructUnion(
 	left opt.GroupID,
 	right opt.GroupID,
@@ -1295,6 +1410,7 @@ func (_f *factory) ConstructUnion(
 	return _f.onConstruct(_f.mem.memoizeNormExpr((*memoExpr)(&_unionExpr)))
 }
 
+// ConstructIntersect constructs an expression for the Intersect operator.
 func (_f *factory) ConstructIntersect(
 	left opt.GroupID,
 	right opt.GroupID,
@@ -1312,6 +1428,7 @@ func (_f *factory) ConstructIntersect(
 	return _f.onConstruct(_f.mem.memoizeNormExpr((*memoExpr)(&_intersectExpr)))
 }
 
+// ConstructExcept constructs an expression for the Except operator.
 func (_f *factory) ConstructExcept(
 	left opt.GroupID,
 	right opt.GroupID,


### PR DESCRIPTION
We've commented several of our operators in the Optgen language files.
Now the code generator will grab those comments and insert them into
the generated code as Go comments, which makes the generated enums and
structs easier to use. The generator will take the comments from op
definitions and use them with the Operator enum, the factory, and the
memo structs.

Release note: None