### PR TITLE
ui: clusterviz: fix flicker as data reloads

### DIFF
--- a/pkg/ui/ccl/src/views/clusterviz/containers/map/historyAccumulator.tsx
+++ b/pkg/ui/ccl/src/views/clusterviz/containers/map/historyAccumulator.tsx
@@ -38,6 +38,7 @@ interface HistoryAccumulatorProps {
   localityTree: LocalityTree;
   locationTree: LocationTree;
   liveness: { [id: string]: LivenessStatus };
+  dataExists: boolean;
   dataIsValid: boolean;
   refreshNodes: typeof refreshNodes;
   refreshLiveness: typeof refreshLiveness;
@@ -90,7 +91,7 @@ class HistoryAccumulator extends React.Component<HistoryAccumulatorProps & Histo
 
     return (
       <Loading
-        loading={!this.props.dataIsValid}
+        loading={!this.props.dataExists}
         className="loading-image loading-image__spinner-left"
         image={spinner}
       >
@@ -106,6 +107,13 @@ class HistoryAccumulator extends React.Component<HistoryAccumulatorProps & Histo
   }
 }
 
+const selectDataExists = createSelector(
+  selectNodeRequestStatus,
+  selectLocationsRequestStatus,
+  selectLivenessRequestStatus,
+  (nodes, locations, liveness) => !!nodes.data && !!locations.data && !!liveness.data,
+);
+
 const selectDataIsValid = createSelector(
   selectNodeRequestStatus,
   selectLocationsRequestStatus,
@@ -120,6 +128,7 @@ export default connect(
     locationTree: selectLocationTree(state),
     liveness: livenessStatusByNodeIDSelector(state),
     dataIsValid: selectDataIsValid(state),
+    dataExists: selectDataExists(state),
   }),
   {
     refreshNodes,


### PR DESCRIPTION
The data used to render the cluster viz is invalidated after a timeout (currently every 10s), leading to a call to refresh the data.

previously:
- data doesn't exist => spinner instead of map
- data invalid (e.g. when refreshing) => spinner instead of map, wiping out map state (such as zoom) every 10s. flicker effect is quite bad.

now:
- data doesn't exist => spinner
- data invalid => still render content. in the future, could put a loading spinner somewhere.

Release note: None