### PR TITLE
cmd/workload: support IMPORT from csv-server in fixture creation

### DIFF
--- a/pkg/ccl/workloadccl/fixture.go
+++ b/pkg/ccl/workloadccl/fixture.go
@@ -17,6 +17,7 @@ import (
 	"path"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"sync/atomic"
 	"time"
 
@@ -45,6 +46,12 @@ type FixtureStore struct {
 	// GCSPrefix is a prefix to prepend to each Google Cloud Storage object
 	// path.
 	GCSPrefix string
+
+	// CSVServerURL is a url to a `./workload csv-server` to use as a source of
+	// CSV data. The url is anything accepted by our backup/restore. Notably, if
+	// you run a csv-server next to each CockroachDB node,
+	// `http://localhost:<port>` will work.
+	CSVServerURL string
 }
 
 func (s FixtureStore) objectPathToURI(folder string) string {
@@ -176,7 +183,7 @@ func (c *groupCSVWriter) groupWriteCSVs(
 				return err
 			}
 
-			pathsCh <- path
+			pathsCh <- c.store.objectPathToURI(path)
 			newBytesWritten := atomic.AddInt64(&c.csvBytesWritten, w.Attrs().Size)
 			d := timeutil.Since(c.start)
 			throughput := float64(newBytesWritten) / (d.Seconds() * float64(1<<20) /* 1MiB */)
@@ -227,6 +234,54 @@ func (c *groupCSVWriter) groupWriteCSVs(
 	return g.Wait()
 }
 
+func csvServerPaths(
+	csvServerURL string, gen workload.Generator, table workload.Table, chunkSizeBytes int64,
+) []string {
+	if table.InitialRowCount == 0 {
+		return nil
+	}
+
+	// TODO(dan): Do some better sampling to figure out these row splits.
+	var rowStep int
+	{
+		var approxRowSize int64
+		for _, datum := range table.InitialRowFn(0) {
+			approxRowSize += workload.DatumSize(datum)
+		}
+		if approxRowSize <= 0 {
+			approxRowSize = 1
+		}
+		rowStep = int(chunkSizeBytes / approxRowSize)
+		if rowStep <= 0 {
+			rowStep = 1
+		}
+	}
+
+	var paths []string
+	for rowIdx := 0; rowIdx < table.InitialRowCount; {
+		chunkRowStart, chunkRowEnd := rowIdx, rowIdx+rowStep
+		if chunkRowEnd > table.InitialRowCount {
+			chunkRowEnd = table.InitialRowCount
+		}
+
+		params := url.Values{
+			`row-start`: []string{strconv.Itoa(chunkRowStart)},
+			`row-end`:   []string{strconv.Itoa(chunkRowEnd)},
+		}
+		if f, ok := gen.(workload.Flagser); ok {
+			f.Flags().VisitAll(func(f *pflag.Flag) {
+				params[f.Name] = append(params[f.Name], f.Value.String())
+			})
+		}
+		path := fmt.Sprintf(`%s/csv/%s/%s?%s`,
+			csvServerURL, gen.Meta().Name, table.Name, params.Encode())
+		paths = append(paths, path)
+
+		rowIdx = chunkRowEnd
+	}
+	return paths
+}
+
 // MakeFixture regenerates a fixture, storing it to GCS. It is expected that the
 // generator will have had Configure called on it.
 //
@@ -269,8 +324,15 @@ func MakeFixture(
 
 		g.Go(func() error {
 			defer close(tableCSVPathsCh)
-			startRow, endRow := 0, table.InitialRowCount
-			return c.groupWriteCSVs(gCtx, tableCSVPathsCh, table, startRow, endRow)
+			if len(store.CSVServerURL) == 0 {
+				startRow, endRow := 0, table.InitialRowCount
+				return c.groupWriteCSVs(gCtx, tableCSVPathsCh, table, startRow, endRow)
+			}
+			paths := csvServerPaths(store.CSVServerURL, gen, table, writeCSVChunkSize)
+			for _, path := range paths {
+				tableCSVPathsCh <- path
+			}
+			return nil
 		})
 		g.Go(func() error {
 			params := []interface{}{
@@ -280,7 +342,7 @@ func MakeFixture(
 			// ctx.Done because a context cancel will cause the above goroutine
 			// to finish and close tableCSVPathsCh.
 			for tableCSVPath := range tableCSVPathsCh {
-				params = append(params, store.objectPathToURI(tableCSVPath))
+				params = append(params, tableCSVPath)
 			}
 			select {
 			case <-gCtx.Done():

--- a/pkg/cmd/workload/fixtures.go
+++ b/pkg/cmd/workload/fixtures.go
@@ -54,8 +54,12 @@ var fixturesLoadCmd = &cobra.Command{
 		`An enterprise license is required.`,
 }
 
+var fixturesStoreCSVServerURL = fixturesStoreCmd.PersistentFlags().String(
+	`csv-server`, ``,
+	`Skip saving CSVs to cloud storage, instead get them from a 'csv-server' running at this url`)
+
 var fixturesLoadDB = fixturesLoadCmd.PersistentFlags().String(
-	`into_db`, `workload`, `SQL database to load fixture into`)
+	`into-db`, `workload`, `SQL database to load fixture into`)
 
 const storageError = `failed to create google cloud client ` +
 	`(You may need to setup the GCS application default credentials: ` +
@@ -142,8 +146,9 @@ func fixturesStore(cmd *cobra.Command, gen workload.Generator, crdbURI string) e
 	if err != nil {
 		return err
 	}
-
-	fixture, err := workloadccl.MakeFixture(ctx, sqlDB, gcs, useast1bFixtures, gen)
+	store := useast1bFixtures
+	store.CSVServerURL = *fixturesStoreCSVServerURL
+	fixture, err := workloadccl.MakeFixture(ctx, sqlDB, gcs, store, gen)
 	if err != nil {
 		return err
 	}

--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -23,6 +23,7 @@ import (
 	gosql "database/sql"
 	"fmt"
 	"math"
+	"math/bits"
 	"sort"
 	"strconv"
 	"strings"
@@ -165,9 +166,12 @@ func DatumSize(x interface{}) int64 {
 	}
 	switch t := x.(type) {
 	case int:
-		return int64(math.Log10(float64(t)))
+		if t < 0 {
+			t = -t
+		}
+		return int64(bits.Len(uint(t))+8) / 8
 	case float64:
-		return int64(math.Log10(t))
+		return int64(bits.Len64(math.Float64bits(t))+8) / 8
 	case string:
 		return int64(len(t))
 	default:

--- a/pkg/workload/workload_test.go
+++ b/pkg/workload/workload_test.go
@@ -111,3 +111,37 @@ func TestSplits(t *testing.T) {
 		})
 	}
 }
+
+func TestDatumSize(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	tests := []struct {
+		datum interface{}
+		size  int64
+	}{
+		{nil, 0},
+		{int(-1000000), 3},
+		{int(-1000), 2},
+		{int(-1), 1},
+		{int(0), 1},
+		{int(1), 1},
+		{int(1000), 2},
+		{int(1000000), 3},
+		{float64(0), 1},
+		{float64(3), 8},
+		{float64(3.1), 8},
+		{float64(3.14), 8},
+		{float64(3.141), 8},
+		{float64(3.1415), 8},
+		{float64(3.14159), 8},
+		{float64(3.141592), 8},
+		{"", 0},
+		{"a", 1},
+		{"aa", 2},
+	}
+	for _, test := range tests {
+		if size := workload.DatumSize(test.datum); size != test.size {
+			t.Errorf(`%T: %v got %d expected %d`, test.datum, test.datum, size, test.size)
+		}
+	}
+}


### PR DESCRIPTION
Instead of first writing all the CSVs to cloud storage, get them from an
instance of `./workload csv-server`. The expected deployment of this is
localhost next to each node.

This was able to create a tpcc-1000 backup in 2h20m on a 4 node cluster.
For comparison, the current parallel batched insert method takes 28h (I
don't know what size cluster that was).

Release note: None