### PR TITLE
sqlccl: remove experimental setting gate from IMPORT

### DIFF
--- a/pkg/ccl/sqlccl/backup_test.go
+++ b/pkg/ccl/sqlccl/backup_test.go
@@ -851,7 +851,6 @@ func TestBackupRestoreControlJob(t *testing.T) {
 	defer cleanup()
 
 	sqlDB := sqlutils.MakeSQLRunner(outerDB.DB)
-	sqlDB.Exec(t, `SET CLUSTER SETTING experimental.importcsv.enabled = true`)
 
 	run := func(t *testing.T, op, query string, args ...interface{}) (int64, error) {
 		allowResponse = make(chan struct{})
@@ -2645,15 +2644,6 @@ func TestBackupRestoreNotInTxn(t *testing.T) {
 	const numAccounts = 1
 	_, _, sqlDB, _, cleanupFn := backupRestoreTestSetup(t, singleNode, numAccounts, initNone)
 	defer cleanupFn()
-
-	// Our override above might be lost on gossip update unless we write it.
-	sqlDB.Exec(t, `SET CLUSTER SETTING experimental.importcsv.enabled = true`)
-	testutils.SucceedsSoon(t, func() error {
-		if res := sqlDB.QueryStr(t, "SHOW CLUSTER SETTING experimental.importcsv.enabled")[0][0]; res != "true" {
-			return errors.Errorf("%q != true", res)
-		}
-		return nil
-	})
 
 	tx, err := sqlDB.DB.Begin()
 	if err != nil {

--- a/pkg/ccl/sqlccl/csv_test.go
+++ b/pkg/ccl/sqlccl/csv_test.go
@@ -485,7 +485,6 @@ func TestImportStmt(t *testing.T) {
 	conn := tc.Conns[0]
 	sqlDB := sqlutils.MakeSQLRunner(conn)
 
-	sqlDB.Exec(t, `SET CLUSTER SETTING experimental.importcsv.enabled = true`)
 	sqlDB.Exec(t, `SET CLUSTER SETTING kv.import.batch_size = '10KB'`)
 
 	tablePath := filepath.Join(dir, "table")
@@ -878,8 +877,6 @@ func BenchmarkImport(b *testing.B) {
 	tc := testcluster.StartTestCluster(b, nodes, base.TestClusterArgs{ServerArgs: base.TestServerArgs{ExternalIODir: dir}})
 	defer tc.Stopper().Stop(ctx)
 	sqlDB := sqlutils.MakeSQLRunner(tc.Conns[0])
-
-	sqlDB.Exec(b, `SET CLUSTER SETTING experimental.importcsv.enabled = true`)
 
 	files, _, _ := makeCSVData(b, dir, numFiles, b.N*100)
 	tmp := fmt.Sprintf("nodelocal://%s", filepath.Join(dir, b.Name()))

--- a/pkg/ccl/workloadccl/fixture.go
+++ b/pkg/ccl/workloadccl/fixture.go
@@ -246,11 +246,6 @@ func MakeFixture(
 	const writeCSVChunkSize = 64 * 1 << 20 // 64 MB
 
 	fixtureFolder := generatorToGCSFolder(store, gen)
-	if _, err := sqlDB.Exec(
-		`SET CLUSTER SETTING experimental.importcsv.enabled = true`,
-	); err != nil {
-		return Fixture{}, err
-	}
 
 	writeCSVConcurrency := runtime.NumCPU()
 	c := &groupCSVWriter{


### PR DESCRIPTION
Release note (sql change): IMPORT no longer requires experimental setting