### PR TITLE
cmd/workload: return a non-zero exit code on error

### DIFF
--- a/pkg/cmd/workload/main.go
+++ b/pkg/cmd/workload/main.go
@@ -16,6 +16,8 @@
 package main
 
 import (
+	"os"
+
 	"github.com/spf13/cobra"
 
 	_ "github.com/cockroachdb/cockroach/pkg/ccl/workloadccl/allccl"
@@ -26,5 +28,8 @@ var rootCmd = &cobra.Command{
 }
 
 func main() {
-	_ = rootCmd.Execute()
+	if err := rootCmd.Execute(); err != nil {
+		// Cobra has already printed the error message.
+		os.Exit(1)
+	}
 }

--- a/pkg/cmd/workload/run.go
+++ b/pkg/cmd/workload/run.go
@@ -386,7 +386,8 @@ func runRun(gen workload.Generator, args []string) error {
 				log.Error(ctx, err)
 				continue
 			}
-			return err
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
 
 		case <-tick:
 			var h *hdrhistogram.Histogram


### PR DESCRIPTION
Previously, `workload run ...` was returning a zero exit code even if
the command had encountered an error. This made scripting difficult.

Release note: None