### PR TITLE
storage: don't let Rocks delete sideload's SST

### DIFF
--- a/pkg/storage/engine/engine.go
+++ b/pkg/storage/engine/engine.go
@@ -249,8 +249,11 @@ type Engine interface {
 	// by invoking Close(). Note that snapshots must not be used after the
 	// original engine has been stopped.
 	NewSnapshot() Reader
-	// IngestExternalFile links a file into the RocksDB log-structured
-	// merge-tree.
+	// IngestExternalFile links a file into the RocksDB log-structured merge-tree.
+	// Removes the passed path on success if `move` is true. May modify the file
+	// (including the underlying file in the case of hard-links) if
+	// allowFileModification is passed as well. See additional comments in db.cc's
+	// IngestExternalFile explaining modification behavior.
 	IngestExternalFile(ctx context.Context, path string, move, allowFileModification bool) error
 	// ApproximateDiskBytes returns an approximation of the on-disk size for the given key span.
 	ApproximateDiskBytes(from, to roachpb.Key) (uint64, error)

--- a/pkg/storage/replica_proposal.go
+++ b/pkg/storage/replica_proposal.go
@@ -346,28 +346,39 @@ func addSSTablePreApply(
 			panic(err)
 		}
 	} else {
+		ingestPath := path + ".ingested"
+
 		// The SST may already be on disk, thanks to the sideloading mechanism.  If
-		// so we can try to add that file directly, rather than writing another copy
-		// of it, so long as doing so does not modify the file, which would be bad
-		// since it is still part of an immutable raft log message. We *can* tell
-		// Rocks that it is not allowed to modify the file though, in which case it
-		// will return and error if it would have tried to do so (see note on
-		// DBIngestExternalFile in db.cc about what causes that), at which point we
-		// can fall back to writing a copy for Rocks.
+		// so we can try to add that file directly, via a new hardlink if the file-
+		// system support it, rather than writing a new copy of it. However, this is
+		// only safe if we can do so without modifying the file since it is still
+		// part of an immutable raft log message, but in some cases, described in
+		// DBIngestExternalFile, RocksDB would modify the file. Fortunately we can
+		// tell Rocks that it is not allowed to modify the file, in which case it
+		// will return and error if it would have tried to do so, at which point we
+		// can fall back to writing a new copy for Rocks to ingest.
 		if _, err := os.Stat(path); err == nil {
-			err = eng.IngestExternalFile(ctx, path, move, noModify)
-			if err == nil {
-				// Adding without modification succeeded, no copy necessary.
-				log.Eventf(ctx, "ingested SSTable at index %d, term %d: %s", index, term, path)
-				return false
-			}
-			const seqNoMsg = "Global seqno is required, but disabled"
-			if err, ok := err.(*engine.RocksDBError); ok && !strings.Contains(err.Error(), seqNoMsg) {
-				log.Fatalf(ctx, "while ingesting %s: %s", path, err)
+			// If the fs supports it, make a hard-link for rocks to ingest. We cannot
+			// pass it the path in the sideload store as it deletes the passed path on
+			// success.
+			if linkErr := os.Link(path, ingestPath); linkErr == nil {
+				ingestErr := eng.IngestExternalFile(ctx, ingestPath, move, noModify)
+				if ingestErr == nil {
+					// Adding without modification succeeded, no copy necessary.
+					log.Eventf(ctx, "ingested SSTable at index %d, term %d: %s", index, term, ingestPath)
+					return false
+				}
+				if rmErr := os.Remove(ingestPath); rmErr != nil {
+					log.Fatalf(ctx, "failed to move ingest sst: %v", rmErr)
+				}
+				const seqNoMsg = "Global seqno is required, but disabled"
+				if err, ok := err.(*engine.RocksDBError); ok && !strings.Contains(err.Error(), seqNoMsg) {
+					log.Fatalf(ctx, "while ingesting %s: %s", ingestPath, err)
+				}
 			}
 		}
 
-		path += ".ingested"
+		path = ingestPath
 
 		limitBulkIOWrite(ctx, st, len(sst.Data))
 		log.Eventf(ctx, "copying SSTable for ingestion at index %d, term %d: %s", index, term, path)


### PR DESCRIPTION
On successful ingestion, a move_files IngestExternalFile call deletes the passed path, so we need to give rocksdb its own link to the SST so it does not delete the sideload's copy.

Release note (bug fix): Fix AddSSTable accidentially destorying files in the log on success.