### PR TITLE
build: add ui-clean task

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1084,10 +1084,15 @@ ui-watch: PORT := 3000
 ui-watch: $(UI_DLLS) $(UI_ROOT)/yarn.opt.installed
 	cd $(UI_ROOT) && $(WEBPACK_DASHBOARD) -- $(WEBPACK_DEV_SERVER) --config webpack.ccl.js --port $(PORT)
 
-.PHONY: ui-maintainer-clean
-ui-maintainer-clean: ## Like clean, but also remove some auto-generated source code.
+.PHONY: ui-clean
+ui-clean: ## Remove build artifacts.
 	find $(UI_ROOT)/dist* -mindepth 1 -not -name dist*.go -delete
-	rm -rf $(UI_ROOT)/node_modules $(UI_DLLS) $(YARN_INSTALLED_TARGET)
+	rm -f $(UI_DLLS)
+
+.PHONY: ui-maintainer-clean
+ui-maintainer-clean: ## Like clean, but also remove installed dependencies
+ui-maintainer-clean: ui-clean
+	rm -rf $(UI_ROOT)/node_modules $(YARN_INSTALLED_TARGET)
 
 .SECONDARY: $(SQLPARSER_ROOT)/gen/sql.go.tmp
 $(SQLPARSER_ROOT)/gen/sql.go.tmp: $(SQLPARSER_ROOT)/gen/sql.y $(BOOTSTRAP_TARGET)


### PR DESCRIPTION
This adds a task to clean the UI build without removing installed
dependencies, a useful level of clean between manual and
ui-maintainer-clean.

Release note (build change): Add a ui-clean task.