### PR TITLE
ui: clusterviz: fix unwanted redirect when viewing child locality

### DIFF
--- a/pkg/ui/ccl/src/views/clusterviz/containers/map/nodeCanvas.tsx
+++ b/pkg/ui/ccl/src/views/clusterviz/containers/map/nodeCanvas.tsx
@@ -98,7 +98,7 @@ export class NodeCanvas extends React.Component<NodeCanvasProps, NodeCanvasState
       return null;
     }
 
-    const parentLocality = tiers.splice(0, tiers.length - 1);
+    const parentLocality = tiers.slice(0, tiers.length - 1);
 
     return (
       <div style={{ position: "absolute", left: BACK_BUTTON_OFFSET, bottom: BACK_BUTTON_OFFSET }}>


### PR DESCRIPTION
The NodeCanvas component was mutating its `tiers` prop, e.g. from `["country=US", "coast=east"]` to just `["coast=east"]`, which on the next render (caused by a data refresh) would then not find anything in the locality tree, and redirect to the root.

This is because it was using `array.splice`, which mutates the array, instead of `array.slice`, which doesn't — it returns the same thing, but as a copy. Thanks, JavaScript! Ugh.

Not sure at the moment how to write a good unit test for this.

Release note: None