### PR TITLE
workloadccl: two small cleanups

### DIFF
--- a/pkg/ccl/workloadccl/fixture.go
+++ b/pkg/ccl/workloadccl/fixture.go
@@ -304,6 +304,10 @@ func MakeFixture(
 	const writeCSVChunkSize = 64 * 1 << 20 // 64 MB
 
 	fixtureFolder := generatorToGCSFolder(store, gen)
+	if _, err := GetFixture(ctx, gcs, store, gen); err == nil {
+		return Fixture{}, errors.Errorf(
+			`fixture %s already exists`, store.objectPathToURI(fixtureFolder))
+	}
 
 	writeCSVConcurrency := runtime.NumCPU()
 	c := &groupCSVWriter{

--- a/pkg/ccl/workloadccl/fixture.go
+++ b/pkg/ccl/workloadccl/fixture.go
@@ -86,7 +86,11 @@ func serializeOptions(gen workload.Generator) string {
 	}
 	// NB: VisitAll visits in a deterministic (alphabetical) order.
 	var buf bytes.Buffer
-	f.Flags().VisitAll(func(f *pflag.Flag) {
+	flags := f.Flags()
+	flags.VisitAll(func(f *pflag.Flag) {
+		if flags.Meta != nil && flags.Meta[f.Name].RuntimeOnly {
+			return
+		}
 		if buf.Len() > 0 {
 			buf.WriteString(`,`)
 		}

--- a/pkg/ccl/workloadccl/fixture.go
+++ b/pkg/ccl/workloadccl/fixture.go
@@ -253,7 +253,7 @@ func csvServerPaths(
 	{
 		var approxRowSize int64
 		for _, datum := range table.InitialRowFn(0) {
-			approxRowSize += workload.DatumSize(datum)
+			approxRowSize += workload.ApproxDatumSize(datum)
 		}
 		if approxRowSize <= 0 {
 			approxRowSize = 1

--- a/pkg/ccl/workloadccl/fixture_test.go
+++ b/pkg/ccl/workloadccl/fixture_test.go
@@ -115,6 +115,11 @@ func TestFixture(t *testing.T) {
 		t.Fatalf(`%+v`, err)
 	}
 
+	_, err = MakeFixture(ctx, sqlDB.DB, gcs, store, gen)
+	if !testutils.IsError(err, `already exists`) {
+		t.Fatalf(`expected 'already exists' error got: %+v`, err)
+	}
+
 	fixtures, err = ListFixtures(ctx, gcs, store)
 	if err != nil {
 		t.Fatalf(`%+v`, err)

--- a/pkg/ccl/workloadccl/fixture_test.go
+++ b/pkg/ccl/workloadccl/fixture_test.go
@@ -35,18 +35,19 @@ import (
 const fixtureTestGenRows = 10
 
 type fixtureTestGen struct {
-	flags *pflag.FlagSet
+	flags workload.Flags
 	val   string
 }
 
 func makeTestWorkload() workload.Flagser {
-	g := &fixtureTestGen{flags: pflag.NewFlagSet(`fx`, pflag.ContinueOnError)}
+	g := &fixtureTestGen{}
+	g.flags.FlagSet = pflag.NewFlagSet(`fx`, pflag.ContinueOnError)
 	g.flags.StringVar(&g.val, `val`, `default`, `The value for each row`)
 	return g
 }
 
 func (fixtureTestGen) Meta() workload.Meta     { return workload.Meta{Name: `fixture`} }
-func (g fixtureTestGen) Flags() *pflag.FlagSet { return g.flags }
+func (g fixtureTestGen) Flags() workload.Flags { return g.flags }
 func (g fixtureTestGen) Tables() []workload.Table {
 	return []workload.Table{{
 		Name:            `fx`,

--- a/pkg/cli/examples.go
+++ b/pkg/cli/examples.go
@@ -50,7 +50,7 @@ func init() {
 			},
 		}
 		if f, ok := gen.(workload.Flagser); ok {
-			genExampleCmd.Flags().AddFlagSet(f.Flags())
+			genExampleCmd.Flags().AddFlagSet(f.Flags().FlagSet)
 		}
 		genExamplesCmd.AddCommand(genExampleCmd)
 	}

--- a/pkg/cmd/workload/fixtures.go
+++ b/pkg/cmd/workload/fixtures.go
@@ -80,7 +80,7 @@ func init() {
 		gen := meta.New()
 		var genFlags *pflag.FlagSet
 		if f, ok := gen.(workload.Flagser); ok {
-			genFlags = f.Flags()
+			genFlags = f.Flags().FlagSet
 		}
 
 		genStoreCmd := &cobra.Command{

--- a/pkg/cmd/workload/run.go
+++ b/pkg/cmd/workload/run.go
@@ -80,7 +80,7 @@ func init() {
 		gen := meta.New()
 		var genFlags *pflag.FlagSet
 		if f, ok := gen.(workload.Flagser); ok {
-			genFlags = f.Flags()
+			genFlags = f.Flags().FlagSet
 		}
 		var genHooks workload.Hooks
 		if h, ok := gen.(workload.Hookser); ok {

--- a/pkg/workload/bank/bank.go
+++ b/pkg/workload/bank/bank.go
@@ -45,7 +45,7 @@ const (
 )
 
 type bank struct {
-	flags *pflag.FlagSet
+	flags workload.Flags
 
 	seed                       int64
 	rows, payloadBytes, ranges int
@@ -60,7 +60,8 @@ var bankMeta = workload.Meta{
 	Description: `Bank models a set of accounts with currency balances`,
 	Version:     `1.0.0`,
 	New: func() workload.Generator {
-		g := &bank{flags: pflag.NewFlagSet(`bank`, pflag.ContinueOnError)}
+		g := &bank{}
+		g.flags.FlagSet = pflag.NewFlagSet(`bank`, pflag.ContinueOnError)
 		g.flags.Int64Var(&g.seed, `seed`, 1, `Key hash seed.`)
 		g.flags.IntVar(&g.rows, `rows`, defaultRows, `Initial number of accounts in bank table.`)
 		g.flags.IntVar(&g.payloadBytes, `payload-bytes`, defaultPayloadBytes, `Size of the payload field in each initial row.`)
@@ -93,10 +94,8 @@ func FromConfig(rows int, payloadBytes int, ranges int) workload.Generator {
 // Meta implements the Generator interface.
 func (*bank) Meta() workload.Meta { return bankMeta }
 
-// Flags implements the Generator interface.
-func (b *bank) Flags() *pflag.FlagSet {
-	return b.flags
-}
+// Flags implements the Flagser interface.
+func (b *bank) Flags() workload.Flags { return b.flags }
 
 // Tables implements the Generator interface.
 func (b *bank) Tables() []workload.Table {
@@ -126,7 +125,7 @@ func (b *bank) Tables() []workload.Table {
 	return []workload.Table{table}
 }
 
-// Ops implements the Generator interface.
+// Ops implements the Opser interface.
 func (b *bank) Ops() []workload.Operation {
 	// TODO(dan): Move the various queries in the backup/restore tests here.
 	op := workload.Operation{

--- a/pkg/workload/tpcc/tpcc.go
+++ b/pkg/workload/tpcc/tpcc.go
@@ -25,7 +25,7 @@ import (
 )
 
 type tpcc struct {
-	flags *pflag.FlagSet
+	flags workload.Flags
 
 	seed        int64
 	warehouses  int
@@ -50,7 +50,13 @@ var tpccMeta = workload.Meta{
 		` using a rich schema of multiple tables`,
 	Version: `1.0.0`,
 	New: func() workload.Generator {
-		g := &tpcc{flags: pflag.NewFlagSet(`tpcc`, pflag.ContinueOnError)}
+		g := &tpcc{}
+		g.flags.FlagSet = pflag.NewFlagSet(`tpcc`, pflag.ContinueOnError)
+		g.flags.Meta = map[string]workload.FlagMeta{
+			`mix`:  {RuntimeOnly: true},
+			`wait`: {RuntimeOnly: true},
+		}
+
 		g.flags.Int64Var(&g.seed, `seed`, 1, `Random number generator seed`)
 		g.flags.IntVar(&g.warehouses, `warehouses`, 1, `Number of warehouses for loading`)
 		g.flags.BoolVar(&g.interleaved, `interleaved`, false, `Use interleaved tables`)
@@ -69,12 +75,10 @@ var tpccMeta = workload.Meta{
 // Meta implements the Generator interface.
 func (*tpcc) Meta() workload.Meta { return tpccMeta }
 
-// Flags implements the Generator interface.
-func (w *tpcc) Flags() *pflag.FlagSet {
-	return w.flags
-}
+// Flags implements the Flagser interface.
+func (w *tpcc) Flags() workload.Flags { return w.flags }
 
-// Hooks implements the Generator interface.
+// Hooks implements the Hookser interface.
 func (w *tpcc) Hooks() workload.Hooks {
 	return workload.Hooks{
 		Validate: func() error {
@@ -158,7 +162,7 @@ func (w *tpcc) Tables() []workload.Table {
 	}
 }
 
-// Ops implements the Generator interface.
+// Ops implements the Opser interface.
 func (w *tpcc) Ops() []workload.Operation {
 	return []workload.Operation{{
 		Name: `tpmC`,

--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -46,13 +46,27 @@ type Generator interface {
 	Tables() []Table
 }
 
+// FlagMeta is metadata about a workload flag.
+type FlagMeta struct {
+	// RuntimeOnly may be set to true only if the corresponding flag has no
+	// impact on the behavior of any Tables in this workload.
+	RuntimeOnly bool
+}
+
+// Flags is a container for flags and associated metadata.
+type Flags struct {
+	*pflag.FlagSet
+	// Meta is keyed by flag name and may be nil if no metadata is needed.
+	Meta map[string]FlagMeta
+}
+
 // Flagser returns the flags this Generator is configured with. Any randomness
 // in the Generator must be deterministic from these options so that table data
 // initialization, query work, etc can be distributed by sending only these
 // flags.
 type Flagser interface {
 	Generator
-	Flags() *pflag.FlagSet
+	Flags() Flags
 }
 
 // Opser returns the work functions for this generator. The tables are required

--- a/pkg/workload/workload_test.go
+++ b/pkg/workload/workload_test.go
@@ -112,7 +112,7 @@ func TestSplits(t *testing.T) {
 	}
 }
 
-func TestDatumSize(t *testing.T) {
+func TestApproxDatumSize(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	tests := []struct {
@@ -140,7 +140,7 @@ func TestDatumSize(t *testing.T) {
 		{"aa", 2},
 	}
 	for _, test := range tests {
-		if size := workload.DatumSize(test.datum); size != test.size {
+		if size := workload.ApproxDatumSize(test.datum); size != test.size {
 			t.Errorf(`%T: %v got %d expected %d`, test.datum, test.datum, size, test.size)
 		}
 	}


### PR DESCRIPTION
workloadccl: don't overwrite existing fixtures
Before this commit, this trying to store a fixture a second time
resulted in a `... already contains a BACKUP file` error. We probably
want an overwrite flag at some point, but I'll leave that for later.

workloadccl: omit runtime-only flags from fixture paths
We now don't need a new fixture when changing the TPCC mix, for example.
The metadata for which flags are runtime only is plumbed through the
workload.Flagser interface.