### PR TITLE
opt: make ColList a slice

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/relational_builder.go
+++ b/pkg/sql/opt/exec/execbuilder/relational_builder.go
@@ -46,7 +46,11 @@ type execPlan struct {
 	// example the output columns in increasing index order. However, this would
 	// require a lot of otherwise unnecessary projections.
 	//
-	// TODO(radu): Maybe this should be just a ColList.
+	// The number of entries set in the map is always the same with the number of
+	// columns emitted by Node.
+	//
+	// Note: conceptually, this could be a ColList; however, the map is more
+	// convenient when converting VariableOps to IndexedVars.
 	outputCols opt.ColMap
 }
 
@@ -123,22 +127,20 @@ func (b *Builder) buildProject(ev xform.ExprView) (execPlan, error) {
 	}
 	projections := ev.Child(1)
 	colList := *projections.Private().(*opt.ColList)
-	exprs := make(tree.TypedExprs, colList.Len())
+	exprs := make(tree.TypedExprs, len(colList))
 	colNames := make([]string, len(exprs))
 	ctx := input.makeBuildScalarCtx()
-	for i := range exprs {
+	for i, col := range colList {
 		exprs[i] = b.buildScalar(&ctx, projections.Child(i))
-		v, _ := colList.Get(i)
-		colNames[i] = ev.Metadata().ColumnLabel(opt.ColumnIndex(v))
+		colNames[i] = ev.Metadata().ColumnLabel(col)
 	}
 	node, err := b.factory.ConstructProject(input.root, exprs, colNames)
 	if err != nil {
 		return execPlan{}, err
 	}
 	ep := execPlan{root: node}
-	for i := range exprs {
-		v, _ := colList.Get(i)
-		ep.outputCols.Set(v, i)
+	for i, col := range colList {
+		ep.outputCols.Set(int(col), i)
 	}
 	return ep, nil
 }

--- a/pkg/sql/opt/opt/metadata.go
+++ b/pkg/sql/opt/opt/metadata.go
@@ -35,10 +35,10 @@ type TableIndex int32
 type ColSet = util.FastIntSet
 
 // ColList is a list of column indexes.
-// It is represented as a map from 0,1,2,.. to column indexes.
+//
 // TODO(radu): perhaps implement a FastIntList with the same "small"
 // representation as FastIntMap but with a slice for large cases.
-type ColList = util.FastIntMap
+type ColList = []ColumnIndex
 
 // ColMap provides a 1:1 mapping from one column index to another. It is used
 // by operators that need to match columns from its inputs.
@@ -180,12 +180,8 @@ func (md *Metadata) TableColumn(tblIndex TableIndex, ord int) ColumnIndex {
 // ColListToSet converts a column index list to a column index set.
 func ColListToSet(colList ColList) ColSet {
 	var r ColSet
-	for i, n := 0, colList.Len(); i < n; i++ {
-		col, ok := colList.Get(i)
-		if !ok {
-			panic("corrupt column set")
-		}
-		r.Add(col)
+	for _, col := range colList {
+		r.Add(int(col))
 	}
 	return r
 }

--- a/pkg/sql/opt/optbuilder/builder.go
+++ b/pkg/sql/opt/optbuilder/builder.go
@@ -1100,9 +1100,9 @@ func (b *Builder) synthesizeColumn(scope *scope, label string, typ types.T) *col
 func (b *Builder) constructList(
 	op opt.Operator, items []opt.GroupID, cols []columnProps,
 ) opt.GroupID {
-	var colList opt.ColList
+	colList := make(opt.ColList, len(cols))
 	for i := range cols {
-		colList.Set(i, int(cols[i].index))
+		colList[i] = cols[i].index
 	}
 
 	list := b.factory.InternList(items)

--- a/pkg/sql/opt/xform/expr.go
+++ b/pkg/sql/opt/xform/expr.go
@@ -229,12 +229,11 @@ func (ev *ExprView) formatRelational(tp treeprinter.Node) {
 		// Get the list of columns from the ProjectionsOp, which has the correct
 		// order.
 		projections := ev.Child(1)
-		cols := projections.Private().(*opt.ColList)
+		cols := *projections.Private().(*opt.ColList)
 		var buf bytes.Buffer
 		buf.WriteString("columns:")
-		for i, n := 0, cols.Len(); i < n; i++ {
-			val, _ := cols.Get(i)
-			logicalProps.formatCol(ev.mem, &buf, opt.ColumnIndex(val))
+		for _, col := range cols {
+			logicalProps.formatCol(ev.mem, &buf, col)
 		}
 		tp.Child(buf.String())
 

--- a/pkg/sql/opt/xform/logical_props_test.go
+++ b/pkg/sql/opt/xform/logical_props_test.go
@@ -97,14 +97,12 @@ func TestLogicalGroupByProps(t *testing.T) {
 	col1 := f.Metadata().TableColumn(a, 1)
 	varGroup := f.ConstructVariable(f.InternPrivate(col1))
 	items1 := f.InternList([]opt.GroupID{varGroup})
-	var cols1 util.FastIntMap
-	cols1.Set(0, int(col1))
+	cols1 := opt.ColList{col1}
 	groupingsGroup := f.ConstructProjections(items1, f.InternPrivate(&cols1))
 
 	col2 := f.Metadata().AddColumn("false", types.Bool)
 	items2 := f.InternList([]opt.GroupID{f.ConstructFalse()})
-	var cols2 util.FastIntMap
-	cols2.Set(0, int(col2))
+	cols2 := opt.ColList{col2}
 	aggsGroup := f.ConstructProjections(items2, f.InternPrivate(&cols2))
 
 	groupByGroup := f.ConstructGroupBy(scanGroup, groupingsGroup, aggsGroup)


### PR DESCRIPTION
The FastIntMap is annoying to use for column lists (especially the
`ok` result from `Get`). Switching to a simple slice for now. If
necessary, we can implement a `FastIntList`.

Release note: None