### PR TITLE
release-1.0: Backports and updates for table lease leak

### DIFF
--- a/build/teamcity-testrace.sh
+++ b/build/teamcity-testrace.sh
@@ -12,7 +12,11 @@ build/builder.sh env \
 	TARGET=stressrace \
 	github-pull-request-make
 
+# Due to a limit on the number of running goroutines in the race
+# detector, testrace fails when run on 16-CPU machines. Set GOMAXPROCS
+# to work around this.
 build/builder.sh env \
+        GOMAXPROCS=8 \
 	make testrace \
 	TESTFLAGS='-v' \
 	2>&1 \

--- a/glide.lock
+++ b/glide.lock
@@ -89,7 +89,8 @@ imports:
 - name: github.com/codegangsta/cli
   version: 0bdeddeeb0f650497d603c4ad7b20cfe685682f6
 - name: github.com/coreos/etcd
-  version: 6dd807481cebac062e82c5ecaecdb2c3d0f605ad
+  version: 32f2a3d4ffbc585f1b467ac0da142f8c75191ecf
+  repo: https://github.com/cockroachdb/etcd
   subpackages:
   - raft
   - raft/raftpb

--- a/glide.yaml
+++ b/glide.yaml
@@ -48,7 +48,8 @@ import:
 - package: github.com/cockroachdb/cockroach-go
   version: 6fd53f6d2eea06acb0c7f7aa88e0547acb32441b
 - package: github.com/coreos/etcd
-  version: 6dd807481cebac062e82c5ecaecdb2c3d0f605ad
+  version: 32f2a3d4ffbc585f1b467ac0da142f8c75191ecf
+  repo: https://github.com/cockroachdb/etcd
 - package: github.com/gogo/protobuf
   version: 100ba4e885062801d56799d78530b73b178a78f3
 - package: github.com/golang/protobuf

--- a/pkg/cli/interactive_tests/test_missing_log_output.tcl
+++ b/pkg/cli/interactive_tests/test_missing_log_output.tcl
@@ -18,6 +18,21 @@ eexpect "255"
 eexpect ":/# "
 end_test
 
+start_test "Check that a broken stderr prints a message to the log files."
+send "$argv start -s=path=logs/db --insecure --logtostderr --verbosity=1 2>&1 | cat\r"
+eexpect "CockroachDB node starting"
+system "killall cat"
+eexpect ":/# "
+system "grep -F 'log: exiting because of error: write /dev/stderr: broken pipe' logs/db/logs/cockroach.log"
+end_test
+
+start_test "Check that a broken log file prints a message to stderr."
+send "$argv start -s=path=/dev/null --insecure --logtostderr\r"
+eexpect "log: exiting because of error: log: cannot create log: open"
+eexpect "not a directory"
+eexpect ":/# "
+end_test
+
 start_test "Check that a server started with only in-memory stores and no --log-dir automatically logs to stderr."
 send "$argv start --insecure --store=type=mem,size=1GiB\r"
 eexpect "CockroachDB node starting"

--- a/pkg/sql/lease.go
+++ b/pkg/sql/lease.go
@@ -778,6 +778,8 @@ func (t *tableState) release(lease *LeaseState, m *LeaseManager) error {
 	return nil
 }
 
+var removeLeaseSem = make(chan struct{}, 10)
+
 // t.mu needs to be locked.
 func (t *tableState) removeLease(lease *LeaseState, m *LeaseManager) {
 	t.active.remove(lease)
@@ -792,6 +794,10 @@ func (t *tableState) removeLease(lease *LeaseState, m *LeaseManager) {
 
 	// Release to the store asynchronously, without the tableState lock.
 	if err := t.stopper.RunAsyncTask(ctx, func(ctx context.Context) {
+		removeLeaseSem <- struct{}{}
+		defer func() {
+			<-removeLeaseSem
+		}()
 		m.LeaseStore.Release(ctx, t.stopper, lease)
 	}); err != nil {
 		log.Warningf(ctx, "error: %s, not releasing lease: %q", err, lease)

--- a/pkg/sql/lease.go
+++ b/pkg/sql/lease.go
@@ -561,11 +561,13 @@ func (t *tableState) acquire(
 	defer t.mu.Unlock()
 
 	for {
-		s := t.active.findNewest(version)
-		if s != nil {
-			if checkedLease := t.checkLease(s, version, m.clock); checkedLease != nil {
+		existingLeaseFailedCheck := false
+		existingLease := t.active.findNewest(version)
+		if existingLease != nil {
+			if checkedLease := t.checkLease(existingLease, version, m.clock); checkedLease != nil {
 				return checkedLease, nil
 			}
+			existingLeaseFailedCheck = true
 		} else if version != 0 {
 			n := t.active.findNewest(0)
 			if n != nil && version < n.Version {
@@ -577,6 +579,28 @@ func (t *tableState) acquire(
 		if err := t.acquireFromStoreLocked(ctx, txn, version, m); err != nil {
 			return nil, err
 		}
+
+		// We found an active lease that we couldn't use (because it's too
+		// close to expiration), and then we created a new one. Leases are
+		// deleted from the table when they have a refcount of zero and
+		// they are no longer the newest. It's possible that this lease
+		// had its refcount drop to zero while it was the newest version,
+		// in which case it's our responsibility to delete it when we make
+		// it no longer the newest.
+		if existingLeaseFailedCheck {
+			// It may have been removed already.
+			for _, s := range t.active.data {
+				if s == existingLease {
+					existingLease.mu.Lock()
+					if existingLease.refcount == 0 {
+						t.removeLease(existingLease, m)
+					}
+					existingLease.mu.Unlock()
+					break
+				}
+			}
+		}
+
 		// A new lease was added, so loop and perform the lookup again.
 	}
 }

--- a/pkg/util/log/clog.go
+++ b/pkg/util/log/clog.go
@@ -742,8 +742,8 @@ func (l *loggingT) outputLogEntry(s Severity, file string, line int, msg string)
 			if err := l.createFile(); err != nil {
 				// Make sure the message appears somewhere.
 				l.outputToStderr(entry, stacks)
+				l.exitLocked(err)
 				l.mu.Unlock()
-				l.exit(err)
 				return
 			}
 		}
@@ -752,7 +752,9 @@ func (l *loggingT) outputLogEntry(s Severity, file string, line int, msg string)
 		data := buf.Bytes()
 
 		if _, err := l.file.Write(data); err != nil {
-			panic(err)
+			l.exitLocked(err)
+			l.mu.Unlock()
+			return
 		}
 		if l.syncWrites {
 			_ = l.file.Flush()
@@ -778,7 +780,7 @@ func (l *loggingT) outputLogEntry(s Severity, file string, line int, msg string)
 func (l *loggingT) outputToStderr(entry Entry, stacks []byte) {
 	buf := l.processForStderr(entry, stacks)
 	if _, err := OrigStderr.Write(buf.Bytes()); err != nil {
-		panic(err)
+		l.exitLocked(err)
 	}
 	l.putBuffer(buf)
 }
@@ -872,21 +874,27 @@ func getStacks(all bool) []byte {
 // would make its use clumsier.
 var logExitFunc func(error)
 
-// exit is called if there is trouble creating or writing log files.
-// It flushes the logs and exits the program; there's no point in hanging around.
-// l.mu is held.
-func (l *loggingT) exit(err error) {
-	fmt.Fprintf(OrigStderr, "log: exiting because of error: %s\n", err)
+// exitLocked is called if there is trouble creating or writing log files, or
+// writing to stderr. It flushes the logs and exits the program; there's no
+// point in hanging around. l.mu is held.
+func (l *loggingT) exitLocked(err error) {
+	l.mu.AssertHeld()
+	// Either stderr or our log file is broken. Try writing the error to both
+	// streams in the hope that one still works or else the user will have no idea
+	// why we crashed.
+	for _, w := range []io.Writer{OrigStderr, l.file} {
+		if w == nil {
+			continue
+		}
+		fmt.Fprintf(w, "log: exiting because of error: %s\n", err)
+	}
 	// If logExitFunc is set, we do that instead of exiting.
 	if logExitFunc != nil {
 		logExitFunc(err)
 		return
 	}
 	l.flushAll()
-	l.mu.Lock()
-	exitFunc := l.exitFunc
-	l.mu.Unlock()
-	exitFunc(2)
+	l.exitFunc(2)
 }
 
 // syncBuffer joins a bufio.Writer to its underlying file, providing access to the
@@ -908,13 +916,13 @@ func (sb *syncBuffer) Sync() error {
 func (sb *syncBuffer) Write(p []byte) (n int, err error) {
 	if sb.nbytes+int64(len(p)) >= atomic.LoadInt64(&LogFileMaxSize) {
 		if err := sb.rotateFile(time.Now()); err != nil {
-			sb.logger.exit(err)
+			sb.logger.exitLocked(err)
 		}
 	}
 	n, err = sb.Writer.Write(p)
 	sb.nbytes += int64(n)
 	if err != nil {
-		sb.logger.exit(err)
+		sb.logger.exitLocked(err)
 	}
 	return
 }


### PR DESCRIPTION
Four commits:

1. Backport #17871 to fix a hang when the log disk fills up (unrelated, but requested by a customer)
2. Backport fix for #18601, which fixes the endless election loop for ranges that have been affected by this bug
3. Address #20451. This is new work in this branch, although this change should be propagated to the other branches
4. A new 1.0-specific fix for the table lease leak #20422.

