### PR TITLE
log: miscellaneous improvements

### DIFF
--- a/pkg/util/log/clog_test.go
+++ b/pkg/util/log/clog_test.go
@@ -454,7 +454,7 @@ func TestGetLogReader(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	dir, err := logDir.get()
+	dir, err := logging.logDir.get()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -596,7 +596,7 @@ func TestGC(t *testing.T) {
 	if e, a := 1, len(allFilesOriginal); e != a {
 		t.Fatalf("expected %d files, but found %d", e, a)
 	}
-	dir, err := logDir.get()
+	dir, err := logging.logDir.get()
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/util/log/clog_test.go
+++ b/pkg/util/log/clog_test.go
@@ -757,6 +757,7 @@ func TestFileSeverityFilter(t *testing.T) {
 	defer s.Close(t)
 
 	setFlags()
+	defer func(save Severity) { logging.fileThreshold = save }(logging.fileThreshold)
 	logging.fileThreshold = Severity_ERROR
 
 	Infof(context.Background(), "test1")

--- a/pkg/util/log/file_test.go
+++ b/pkg/util/log/file_test.go
@@ -34,7 +34,7 @@ func TestLogFilenameParsing(t *testing.T) {
 	}
 
 	for i, testCase := range testCases {
-		filename, _ := logName(testCase)
+		filename, _ := logName(program, testCase)
 		details, err := parseLogFilename(filename)
 		if err != nil {
 			t.Fatal(err)
@@ -54,7 +54,7 @@ func TestSelectFiles(t *testing.T) {
 	year2200 := time.Date(2200, time.January, 1, 1, 0, 0, 0, time.UTC)
 	for i := 0; i < 100; i++ {
 		fileTime := year2000.AddDate(i, 0, 0)
-		name, _ := logName(fileTime)
+		name, _ := logName(program, fileTime)
 		testfile := FileInfo{
 			Name: name,
 			Details: FileDetails{

--- a/pkg/util/log/flags.go
+++ b/pkg/util/log/flags.go
@@ -23,7 +23,7 @@ import (
 func init() {
 	logflags.InitFlags(
 		&logging.noStderrRedirect,
-		&logDir, &showLogs, &noColor, &logging.verbosity,
+		&logging.logDir, &showLogs, &noColor, &logging.verbosity,
 		&logging.vmodule, &logging.traceLocation,
 		&LogFileMaxSize, &LogFilesCombinedMaxSize,
 	)

--- a/pkg/util/log/secondary_log.go
+++ b/pkg/util/log/secondary_log.go
@@ -1,0 +1,94 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package log
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"sync/atomic"
+
+	"github.com/cockroachdb/cockroach/pkg/util/caller"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+)
+
+// SecondaryLogger represents a secondary / auxiliary logging channel
+// whose logging events go to a different file than the main logging
+// facility.
+type SecondaryLogger struct {
+	logger          loggingT
+	msgCount        uint64
+	enableGc        bool
+	forceSyncWrites bool
+}
+
+var secondaryLogRegistry struct {
+	mu struct {
+		syncutil.Mutex
+		loggers []*SecondaryLogger
+	}
+}
+
+// NewSecondaryLogger creates a secondary logger.
+//
+// The given directory name can be either nil or empty, in which case
+// the global logger's own dirName is used; or non-nil and non-empty,
+// in which case it specifies the directory for that new logger.
+func NewSecondaryLogger(dirName *DirName, fileNamePrefix string, enableGc, forceSyncWrites bool) *SecondaryLogger {
+	logging.mu.Lock()
+	defer logging.mu.Unlock()
+	var dir string
+	if dirName != nil {
+		dir = dirName.String()
+	}
+	if dir == "" {
+		dir = logging.logDir.String()
+	}
+	l := &SecondaryLogger{
+		logger: loggingT{
+			logDir:           DirName{name: dir},
+			noStderrRedirect: true,
+			prefix:           program + "-" + fileNamePrefix,
+			stderrThreshold:  logging.stderrThreshold,
+			fileThreshold:    Severity_INFO,
+			syncWrites:       forceSyncWrites || logging.syncWrites,
+			gcNotify:         make(chan struct{}, 1),
+			disableDaemons:   logging.disableDaemons,
+			exitFunc:         os.Exit,
+		},
+		forceSyncWrites: forceSyncWrites,
+		enableGc:        enableGc,
+	}
+
+	// Ensure the registry knows about this logger.
+	secondaryLogRegistry.mu.Lock()
+	defer secondaryLogRegistry.mu.Unlock()
+	secondaryLogRegistry.mu.loggers = append(secondaryLogRegistry.mu.loggers, l)
+	return l
+}
+
+// Logf logs an event on a secondary logger.
+func (l *SecondaryLogger) Logf(ctx context.Context, format string, args ...interface{}) {
+	file, line, _ := caller.Lookup(1)
+	var buf msgBuf
+	formatTags(ctx, &buf)
+
+	// Add a counter. This is important for auditing.
+	counter := atomic.AddUint64(&l.msgCount, 1)
+	fmt.Fprintf(&buf, "%d ", counter)
+
+	fmt.Fprintf(&buf, format, args...)
+	l.logger.outputLogEntry(Severity_INFO, file, line, buf.String())
+}

--- a/pkg/util/log/secondary_log_test.go
+++ b/pkg/util/log/secondary_log_test.go
@@ -1,0 +1,67 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package log
+
+import (
+	"context"
+	"io/ioutil"
+	"strings"
+	"testing"
+)
+
+func TestSecondaryLog(t *testing.T) {
+	s := ScopeWithoutShowLogs(t)
+	defer s.Close(t)
+	setFlags()
+
+	// Make a new logger, in the same directory.
+	l := NewSecondaryLogger(&logging.logDir, "woo", false, false)
+
+	// Interleave some messages.
+	Infof(context.Background(), "test1")
+	ctx := WithLogTagStr(context.Background(), "hello", "world")
+	l.Logf(ctx, "story time")
+	Infof(context.Background(), "test2")
+
+	// Make sure the content made it to disk.
+	Flush()
+
+	// Check that the messages indeed made it to different files.
+
+	contents, err := ioutil.ReadFile(logging.file.(*syncBuffer).file.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(contents), "test1") || !strings.Contains(string(contents), "test2") {
+		t.Errorf("log does not contain error text\n%s", contents)
+	}
+	if strings.Contains(string(contents), "world") {
+		t.Errorf("secondary log spilled into primary\n%s", contents)
+	}
+
+	contents, err = ioutil.ReadFile(l.logger.file.(*syncBuffer).file.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(contents), "hello") ||
+		!strings.Contains(string(contents), "world") ||
+		!strings.Contains(string(contents), "story time") {
+		t.Errorf("secondary log does not contain text\n%s", contents)
+	}
+	if strings.Contains(string(contents), "test1") {
+		t.Errorf("primary log spilled into secondary\n%s", contents)
+	}
+
+}

--- a/pkg/util/log/test_log_scope.go
+++ b/pkg/util/log/test_log_scope.go
@@ -98,7 +98,7 @@ func enableLogFileOutput(dir string, stderrSeverity Severity) (func(), error) {
 	}
 	logging.stderrThreshold = stderrSeverity
 	logging.noStderrRedirect = true
-	return undo, logDir.Set(dir)
+	return undo, logging.logDir.Set(dir)
 }
 
 // Close cleans up a TestLogScope. The directory and its contents are
@@ -166,16 +166,16 @@ func dirTestOverride(expected, newDir string) error {
 	logging.mu.Lock()
 	defer logging.mu.Unlock()
 
-	logDir.Lock()
+	logging.logDir.Lock()
 	// The following check is intended to catch concurrent uses of
 	// Scope() or TestLogScope.Close(), which would be invalid.
-	if logDir.name != expected {
-		logDir.Unlock()
+	if logging.logDir.name != expected {
+		logging.logDir.Unlock()
 		return errors.Errorf("unexpected logDir setting: set to %q, expected %q",
-			logDir.name, expected)
+			logging.logDir.name, expected)
 	}
-	logDir.name = newDir
-	logDir.Unlock()
+	logging.logDir.name = newDir
+	logging.logDir.Unlock()
 
 	// When we change the directory we close the current logging
 	// output, so that a rotation to the new directory is forced on


### PR DESCRIPTION
This is the PR prefix of #22534.

The secondary logger and exported LogDir are meant for use by the auditing / logging facility introduced in #22534.

