### PR TITLE
allocator: Include alive store count in error messages

### DIFF
--- a/pkg/storage/allocator.go
+++ b/pkg/storage/allocator.go
@@ -335,7 +335,7 @@ func (a *Allocator) AllocateTarget(
 	rangeInfo RangeInfo,
 	disableStatsBasedRebalancing bool,
 ) (*roachpb.StoreDescriptor, string, error) {
-	sl, _, throttledStoreCount := a.storePool.getStoreList(rangeInfo.Desc.RangeID, storeFilterThrottled)
+	sl, aliveStoreCount, throttledStoreCount := a.storePool.getStoreList(rangeInfo.Desc.RangeID, storeFilterThrottled)
 
 	options := a.scorerOptions(disableStatsBasedRebalancing)
 	candidates := allocateCandidates(
@@ -362,7 +362,8 @@ func (a *Allocator) AllocateTarget(
 		return nil, "", errors.Errorf("%d matching stores are currently throttled", throttledStoreCount)
 	}
 	return nil, "", &allocatorError{
-		required: constraints.Constraints,
+		required:        constraints.Constraints,
+		aliveStoreCount: aliveStoreCount,
 	}
 }
 


### PR DESCRIPTION
allocatorError messages have been misleading for a very long time --
they always say that 0 out of 0 stores match the constraints, even if
there are more than 0 live stores in the cluster. The last time a
correct count of the live stores was used was January 2017, before
f4f3ab6b1db33aa0168655e4406a4dbe2a1dd8b8, and even then a count was only
used on one of two code paths.

Release note: None

@BramGruneir is there some reason I'm missing for why we haven't been doing this?

This may make sense to include as a cherry pick if we ever do another 1.1 release -- not because it's critical, but because it's totally safe while improving the correctness of our logs.