### PR TITLE
status: force linkage via call to je_zone_register

### DIFF
--- a/pkg/server/status/runtime_jemalloc.go
+++ b/pkg/server/status/runtime_jemalloc.go
@@ -18,12 +18,6 @@ package status
 
 // #cgo CPPFLAGS: -DJEMALLOC_NO_DEMANGLE
 // #cgo LDFLAGS: -ljemalloc
-// // On macOS, je_zone_register is run at init time to register
-// // jemalloc with the system allocator. Unfortunately, all the
-// // machinery for this is in a single file, and is not referenced
-// // elsewhere, causing the linker to omit the file's symbols.
-// // Manually force the presence of these symbols on macOS.
-// #cgo darwin LDFLAGS: -u_je_zone_register
 // #cgo dragonfly freebsd LDFLAGS: -lm
 // #cgo linux LDFLAGS: -lrt -lm -lpthread
 //

--- a/pkg/server/status/runtime_jemalloc_darwin.go
+++ b/pkg/server/status/runtime_jemalloc_darwin.go
@@ -1,0 +1,36 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+// +build !stdmalloc,darwin
+
+package status
+
+// extern void je_zone_register();
+import "C"
+
+func init() {
+	// On macOS, je_zone_register is run at init time to register jemalloc with
+	// the system allocator. Unfortunately, all the machinery for this is in a
+	// single file, and is not referenced elsewhere, causing the linker to omit
+	// the file's symbols. Manually force the presence of these symbols on macOS
+	// by explicitly calling this method.
+	//
+	// Note that the same could be achieved via linker flags, but go >= 1.9.4
+	// requires explicit opt-in for the required flag, which we want to avoid
+	// having to put up with.
+	//
+	// See https://github.com/jemalloc/jemalloc/issues/708 and the references
+	// within.
+	C.je_zone_register()
+}


### PR DESCRIPTION
go 1.9.4 and up require the env variable CGO_LDFLAGS_ALLOW to be set to
allow passing most linker flags. Instead of putting up with this, use
the alternative method of calling the hook directly to force inclusion.

Release note (build change): CockroachDB now builds with go 1.9.4 and
higher.