### PR TITLE
sql: experimental execution path through the optimizer

### DIFF
--- a/pkg/sql/logictest/logic.go
+++ b/pkg/sql/logictest/logic.go
@@ -909,7 +909,10 @@ func (t *logicTest) setup(cfg testClusterConfig) {
 		); err != nil {
 			t.Fatal(err)
 		}
-		wantedMode := sessiondata.DistSQLExecModeFromString(cfg.overrideDistSQLMode) // off => 0, etc
+		wantedMode, ok := sessiondata.DistSQLExecModeFromString(cfg.overrideDistSQLMode)
+		if !ok {
+			t.Fatalf("invalid distsql mode override: %s", cfg.overrideDistSQLMode)
+		}
 		// Wait until all servers are aware of the setting.
 		testutils.SucceedsSoon(t.t, func() error {
 			for i := 0; i < t.cluster.NumServers(); i++ {

--- a/pkg/sql/logictest/testdata/logic_test/explain
+++ b/pkg/sql/logictest/testdata/logic_test/explain
@@ -173,7 +173,7 @@ EXPLAIN SHOW DATABASE
 render            ·     ·
  └── filter       ·     ·
       └── values  ·     ·
-·                 size  2 columns, 24 rows
+·                 size  2 columns, 25 rows
 
 query TTT
 EXPLAIN SHOW TIME ZONE
@@ -181,7 +181,7 @@ EXPLAIN SHOW TIME ZONE
 render            ·     ·
  └── filter       ·     ·
       └── values  ·     ·
-·                 size  2 columns, 24 rows
+·                 size  2 columns, 25 rows
 
 query TTT
 EXPLAIN SHOW DEFAULT_TRANSACTION_ISOLATION
@@ -189,7 +189,7 @@ EXPLAIN SHOW DEFAULT_TRANSACTION_ISOLATION
 render            ·     ·
  └── filter       ·     ·
       └── values  ·     ·
-·                 size  2 columns, 24 rows
+·                 size  2 columns, 25 rows
 
 query TTT
 EXPLAIN SHOW TRANSACTION ISOLATION LEVEL
@@ -197,7 +197,7 @@ EXPLAIN SHOW TRANSACTION ISOLATION LEVEL
 render            ·     ·
  └── filter       ·     ·
       └── values  ·     ·
-·                 size  2 columns, 24 rows
+·                 size  2 columns, 25 rows
 
 query TTT
 EXPLAIN SHOW TRANSACTION PRIORITY
@@ -205,7 +205,7 @@ EXPLAIN SHOW TRANSACTION PRIORITY
 render            ·     ·
  └── filter       ·     ·
       └── values  ·     ·
-·                 size  2 columns, 24 rows
+·                 size  2 columns, 25 rows
 
 query TTT
 EXPLAIN SHOW COLUMNS FROM foo

--- a/pkg/sql/logictest/testdata/logic_test/optimizer
+++ b/pkg/sql/logictest/testdata/logic_test/optimizer
@@ -1,0 +1,17 @@
+# LogicTest: default
+
+statement ok
+CREATE TABLE t (k INT PRIMARY KEY, v INT)
+
+statement ok
+INSERT INTO t VALUES (1, 10), (2, 20), (3, 30)
+
+statement ok
+SET EXPERIMENTAL_OPT = ON
+
+query II
+SELECT * FROM test.t
+----
+1 10
+2 20
+3 30

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -1139,6 +1139,7 @@ datestyle                      ISO           NULL      NULL        NULL        s
 default_transaction_isolation  serializable  NULL      NULL        NULL        string
 default_transaction_read_only  off           NULL      NULL        NULL        string
 distsql                        off           NULL      NULL        NULL        string
+experimental_opt               off           NULL      NULL        NULL        string
 extra_float_digits             ·             NULL      NULL        NULL        string
 intervalstyle                  postgres      NULL      NULL        NULL        string
 max_index_keys                 32            NULL      NULL        NULL        string
@@ -1168,6 +1169,7 @@ datestyle                      ISO           NULL  user     NULL      ISO       
 default_transaction_isolation  serializable  NULL  user     NULL      serializable  serializable
 default_transaction_read_only  off           NULL  user     NULL      off           off
 distsql                        off           NULL  user     NULL      off           off
+experimental_opt               off           NULL  user     NULL      off           off
 extra_float_digits             ·             NULL  user     NULL      ·             ·
 intervalstyle                  postgres      NULL  user     NULL      postgres      postgres
 max_index_keys                 32            NULL  user     NULL      32            32
@@ -1197,6 +1199,7 @@ datestyle                      NULL    NULL     NULL     NULL        NULL
 default_transaction_isolation  NULL    NULL     NULL     NULL        NULL
 default_transaction_read_only  NULL    NULL     NULL     NULL        NULL
 distsql                        NULL    NULL     NULL     NULL        NULL
+experimental_opt               NULL    NULL     NULL     NULL        NULL
 extra_float_digits             NULL    NULL     NULL     NULL        NULL
 intervalstyle                  NULL    NULL     NULL     NULL        NULL
 max_index_keys                 NULL    NULL     NULL     NULL        NULL

--- a/pkg/sql/logictest/testdata/logic_test/set
+++ b/pkg/sql/logictest/testdata/logic_test/set
@@ -85,6 +85,7 @@ datestyle                      ISO
 default_transaction_isolation  serializable
 default_transaction_read_only  off
 distsql                        off
+experimental_opt               off
 extra_float_digits             ·
 intervalstyle                  postgres
 max_index_keys                 32
@@ -180,6 +181,15 @@ SET DISTSQL = OFF
 
 statement error not supported
 SET DISTSQL = bogus
+
+statement ok
+SET EXPERIMENTAL_OPT = ON
+
+statement ok
+SET EXPERIMENTAL_OPT = OFF
+
+statement error not supported
+SET EXPERIMENTAL_OPT = bogus
 
 query T colnames
 SHOW SERVER_VERSION

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -30,6 +30,7 @@ datestyle                      ISO
 default_transaction_isolation  serializable
 default_transaction_read_only  off
 distsql                        off
+experimental_opt               off
 extra_float_digits             ·
 intervalstyle                  postgres
 max_index_keys                 32

--- a/pkg/sql/opt/exec/execbuilder/main_test.go
+++ b/pkg/sql/opt/exec/execbuilder/main_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/exec"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/exec/execbuilder"
+	"github.com/cockroachdb/cockroach/pkg/sql/optbase"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 )
@@ -35,7 +36,7 @@ func TestMain(m *testing.M) {
 	randutil.SeedForTests()
 	serverutils.InitTestServerFactory(server.TestServerFactory)
 
-	execbuilder.NewExecEngine = func(s serverutils.TestServerInterface) exec.Engine {
+	execbuilder.NewExecEngine = func(s serverutils.TestServerInterface) (exec.Engine, optbase.Catalog) {
 		return s.Executor().(*sql.Executor).NewExecEngine()
 	}
 

--- a/pkg/sql/opt/optbuilder/scope.go
+++ b/pkg/sql/opt/optbuilder/scope.go
@@ -151,7 +151,7 @@ func (s *scope) resolveType(expr tree.Expr, desired types.T) tree.TypedExpr {
 	expr, _ = tree.WalkExpr(s, expr)
 	texpr, err := tree.TypeCheck(expr, &s.builder.semaCtx, desired)
 	if err != nil {
-		panic(builderError(err))
+		panic(builderError{err})
 	}
 
 	return texpr
@@ -269,7 +269,7 @@ func (s *scope) VisitPre(expr tree.Expr) (recurse bool, newExpr tree.Expr) {
 	case *tree.UnresolvedName:
 		vn, err := t.NormalizeVarName()
 		if err != nil {
-			panic(builderError(err))
+			panic(builderError{err})
 		}
 		return s.VisitPre(vn)
 
@@ -296,7 +296,7 @@ func (s *scope) VisitPre(expr tree.Expr) (recurse bool, newExpr tree.Expr) {
 	case *tree.FuncExpr:
 		def, err := t.Func.Resolve(s.builder.semaCtx.SearchPath)
 		if err != nil {
-			panic(builderError(err))
+			panic(builderError{err})
 		}
 		if len(t.Exprs) != 1 {
 			break
@@ -307,7 +307,7 @@ func (s *scope) VisitPre(expr tree.Expr) (recurse bool, newExpr tree.Expr) {
 		}
 		vn, err = vn.NormalizeVarName()
 		if err != nil {
-			panic(builderError(err))
+			panic(builderError{err})
 		}
 		t.Exprs[0] = vn
 
@@ -328,7 +328,7 @@ func (s *scope) VisitPre(expr tree.Expr) (recurse bool, newExpr tree.Expr) {
 				// We call TypeCheck to fill in FuncExpr internals. This is a fixed
 				// expression; we should not hit an error here.
 				if _, err := e.TypeCheck(&tree.SemaContext{}, types.Any); err != nil {
-					panic(builderError(err))
+					panic(builderError{err})
 				}
 				e.Filter = t.Filter
 				e.WindowDef = t.WindowDef

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -192,9 +192,12 @@ func newInternalPlanner(
 			Location: time.UTC,
 			User:     user,
 		},
-		TxnState:       txnState{Ctx: ctx, implicitTxn: true},
-		context:        ctx,
-		tables:         TableCollection{databaseCache: newDatabaseCache(config.SystemConfig{})},
+		TxnState: txnState{Ctx: ctx, implicitTxn: true},
+		context:  ctx,
+		tables: TableCollection{
+			leaseMgr:      execCfg.LeaseManager,
+			databaseCache: newDatabaseCache(config.SystemConfig{}),
+		},
 		execCfg:        execCfg,
 		distSQLPlanner: execCfg.DistSQLPlanner,
 	}

--- a/pkg/sql/session.go
+++ b/pkg/sql/session.go
@@ -1893,6 +1893,10 @@ func (m *sessionDataMutator) SetDistSQLMode(val sessiondata.DistSQLExecMode) {
 	m.data.DistSQLMode = val
 }
 
+func (m *sessionDataMutator) SetOptimizerMode(val sessiondata.OptimizerMode) {
+	m.data.OptimizerMode = val
+}
+
 func (m *sessionDataMutator) SetSafeUpdates(val bool) {
 	m.data.SafeUpdates = val
 }

--- a/pkg/sql/sessiondata/session_data.go
+++ b/pkg/sql/sessiondata/session_data.go
@@ -40,6 +40,9 @@ type SessionData struct {
 	DistSQLMode DistSQLExecMode
 	// Location indicates the current time zone.
 	Location *time.Location
+	// OptimizerMode indicates whether to use the experimental optimizer for
+	// query planning.
+	OptimizerMode OptimizerMode
 	// SearchPath is a list of databases that will be searched for a table name
 	// before the database. Currently, this is used only for SELECTs.
 	// Names in the search path must have been normalized already.
@@ -111,17 +114,51 @@ func (m DistSQLExecMode) String() string {
 }
 
 // DistSQLExecModeFromString converts a string into a DistSQLExecMode
-func DistSQLExecModeFromString(val string) DistSQLExecMode {
+func DistSQLExecModeFromString(val string) (_ DistSQLExecMode, ok bool) {
 	switch strings.ToUpper(val) {
 	case "OFF":
-		return DistSQLOff
+		return DistSQLOff, true
 	case "AUTO":
-		return DistSQLAuto
+		return DistSQLAuto, true
 	case "ON":
-		return DistSQLOn
+		return DistSQLOn, true
 	case "ALWAYS":
-		return DistSQLAlways
+		return DistSQLAlways, true
 	default:
-		panic(fmt.Sprintf("unknown DistSQL mode %s", val))
+		return 0, false
+	}
+}
+
+// OptimizerMode controls if and when the Executor uses the optimizer.
+type OptimizerMode int64
+
+const (
+	// OptimizerOff means that we don't use the optimizer.
+	OptimizerOff = iota
+	// OptimizerOn means that we use the optimizer for all statements.
+	OptimizerOn
+	// TODO(radu): we will want an Auto mode to decide on a case-by-case basis.
+)
+
+func (m OptimizerMode) String() string {
+	switch m {
+	case OptimizerOff:
+		return "off"
+	case OptimizerOn:
+		return "on"
+	default:
+		return fmt.Sprintf("invalid (%d)", m)
+	}
+}
+
+// OptimizerModeFromString converts a string into a OptimizerMode
+func OptimizerModeFromString(val string) (_ OptimizerMode, ok bool) {
+	switch strings.ToUpper(val) {
+	case "OFF":
+		return OptimizerOff, true
+	case "ON":
+		return OptimizerOn, true
+	default:
+		return 0, false
 	}
 }


### PR DESCRIPTION
#### sql: experimental execution path through the optimizer

In order to be test the optimizer end-to-end, we wire the executor to
use the optimizer instead of the normal path (controlled by a session
variable).

As part of the implementation, we make `execEngine` implement
`Catalog` using the regular code path to look up a table. The
association between ExecEngine and Catalog is a bit unexpected - but
they share the context of the planner (most importantly the txn). We
will probably have to improve the interface (perhaps make a "parent"
interface which creates the planner and has accessors for the
`Catalog` and the `ExecEngine`).

Finally, we fix a problem in the optbuilder panic handling: the
intention was to only catch `builderError` but we catch all `error`s
because `error` is an interface (so `type builderError error` is the same
interface); we change `builderError` to a type.

Release note: None.
