### PR TITLE
sql: make ParseQualifiedTableName do what it's meant to do

### DIFF
--- a/pkg/sql/parser/parse.go
+++ b/pkg/sql/parser/parse.go
@@ -100,6 +100,20 @@ func ParseTableNameWithIndex(sql string) (tree.TableNameWithIndex, error) {
 	return *rename.Index, nil
 }
 
+// ParseTableName parses a table name.
+func ParseTableName(sql string) (*tree.NormalizableTableName, error) {
+	stmt, err := ParseOne(fmt.Sprintf("ALTER TABLE %s RENAME TO x", sql))
+	if err != nil {
+		return nil, err
+	}
+	rename, ok := stmt.(*tree.RenameTable)
+	if !ok {
+		return nil, pgerror.NewErrorf(
+			pgerror.CodeInternalError, "expected an ALTER TABLE statement, but found %T", stmt)
+	}
+	return &rename.Name, nil
+}
+
 // parseExprs parses one or more sql expressions.
 func parseExprs(exprs []string) (tree.Exprs, error) {
 	stmt, err := ParseOne(fmt.Sprintf("SET ROW (%s)", strings.Join(exprs, ",")))

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -315,10 +315,15 @@ func (p *planner) ParseType(sql string) (coltypes.CastTargetType, error) {
 	return parser.ParseType(sql)
 }
 
-// ParseTableNameWithIndex implements the parser.EvalPlanner interface.
-// We define this here to break the dependency from builtins.go to the parser.
-func (p *planner) ParseTableNameWithIndex(sql string) (tree.TableNameWithIndex, error) {
-	return parser.ParseTableNameWithIndex(sql)
+// ParseQualifiedTableName implements the tree.EvalDatabase interface.
+func (p *planner) ParseQualifiedTableName(
+	ctx context.Context, sql string,
+) (*tree.TableName, error) {
+	tn, err := parser.ParseTableName(sql)
+	if err != nil {
+		return nil, err
+	}
+	return p.QualifyWithDatabase(ctx, tn)
 }
 
 // QueryRow implements the parser.EvalPlanner interface.

--- a/pkg/sql/table.go
+++ b/pkg/sql/table.go
@@ -1013,15 +1013,3 @@ func resolveTableNameFromID(
 	}
 	return tree.ErrString(tn)
 }
-
-// ParseQualifiedTableName implements the tree.EvalDatabase interface.
-func (p *planner) ParseQualifiedTableName(
-	ctx context.Context, sql string,
-) (*tree.TableName, error) {
-	parsedNameWithIndex, err := p.ParseTableNameWithIndex(sql)
-	if err != nil {
-		return nil, err
-	}
-	parsedName := parsedNameWithIndex.Table
-	return p.QualifyWithDatabase(ctx, &parsedName)
-}


### PR DESCRIPTION
Prior to this patch, ParseQualifiedTableName() was using
ParseTableNameWithIndex and thus was overly generous in the syntax it
accepted. Worse than that, it would even silently drop the index part,
so one could e.g. compute `nextval('someseq@invalidindex')` without
error.

This patch corrects this oversight by ensuring the method only parses
table names.

Release note (bug fix): various primitives that expect table names as
argument now properly reject invalid table names.