### PR TITLE
acceptance: skip flaky VersionUpgradeTest

### DIFF
--- a/pkg/acceptance/version_upgrade_test.go
+++ b/pkg/acceptance/version_upgrade_test.go
@@ -40,6 +40,7 @@ func TestVersionUpgrade(t *testing.T) {
 }
 
 func testVersionUpgrade(ctx context.Context, t *testing.T, cfg cluster.TestConfig) {
+	t.Skip("#22581")
 
 	// Version 1.0.5 does not contain
 	// https://github.com/cockroachdb/cockroach/pull/19493 and the test will be


### PR DESCRIPTION
Investigation is tracked in #22581.

Release note: None