### PR TITLE
build: Update cockroachdb/cockroach-go dependency

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -214,7 +214,7 @@
   branch = "master"
   name = "github.com/cockroachdb/cockroach-go"
   packages = ["crdb"]
-  revision = "0d8b4682f140f0fe486ef7e3d2f70665f3066906"
+  revision = "59c0560478b705bf9bd12f9252224a0fad7c87df"
 
 [[projects]]
   branch = "master"


### PR DESCRIPTION
To pick up the fix for using errors.Wrap with crdb.ExecuteTx.

Release note: None