### PR TITLE
opt: Stop catching all panics in opt/build.go

### DIFF
--- a/pkg/sql/opt/opt_test.go
+++ b/pkg/sql/opt/opt_test.go
@@ -99,12 +99,12 @@ var (
 	testDataGlob = flag.String("d", "testdata/[^.]*", "test data glob")
 )
 
-// testCatalog implements the sqlbase.Catalog interface.
+// testCatalog implements the optbase.Catalog interface.
 type testCatalog struct {
 	kvDB *client.DB
 }
 
-// FindTable implements the sqlbase.Catalog interface.
+// FindTable implements the optbase.Catalog interface.
 func (c testCatalog) FindTable(ctx context.Context, name *tree.TableName) (optbase.Table, error) {
 	return sqlbase.GetTableDescriptor(c.kvDB, string(name.SchemaName), string(name.TableName)), nil
 }

--- a/pkg/sql/opt/optbuilder/builder_test.go
+++ b/pkg/sql/opt/optbuilder/builder_test.go
@@ -187,8 +187,8 @@ func newScalarBuilder(factory opt.Factory, ivh *tree.IndexedVarHelper) *Builder 
 func buildScalar(b *Builder, typedExpr tree.TypedExpr) (group opt.GroupID, err error) {
 	defer func() {
 		if r := recover(); r != nil {
-			if _, ok := r.(builderError); ok {
-				err = r.(builderError)
+			if bldErr, ok := r.(builderError); ok {
+				err = bldErr
 			} else {
 				panic(r)
 			}

--- a/pkg/sql/opt/scope.go
+++ b/pkg/sql/opt/scope.go
@@ -43,7 +43,7 @@ func (s *scope) resolve(expr tree.Expr, desired types.T) tree.TypedExpr {
 	expr, _ = tree.WalkExpr(s, expr)
 	texpr, err := tree.TypeCheck(expr, &s.state.semaCtx, desired)
 	if err != nil {
-		panic(err)
+		panic(builderError{err})
 	}
 
 	return texpr
@@ -57,7 +57,7 @@ func (s *scope) VisitPre(expr tree.Expr) (recurse bool, newExpr tree.Expr) {
 	case *tree.UnresolvedName:
 		vn, err := t.NormalizeVarName()
 		if err != nil {
-			panic(err)
+			panic(builderError{err})
 		}
 		return s.VisitPre(vn)
 
@@ -78,7 +78,7 @@ func (s *scope) VisitPre(expr tree.Expr) (recurse bool, newExpr tree.Expr) {
 				}
 			}
 		}
-		panic(fmt.Sprintf("unknown column %s", t))
+		panic(errorf("unknown column %s", t))
 
 		// TODO(rytaft): Implement function expressions and subquery replacement.
 	}

--- a/pkg/sql/opt/testdata/build
+++ b/pkg/sql/opt/testdata/build
@@ -13,21 +13,6 @@ scan [out=(0,1)]
  └── columns: a.x:int:0 a.y:float,null:1
 
 build
-SELECT * FROM t.b
-----
-error: table missing
-
-build
-SELECT * FROM b
-----
-error: database missing
-
-build
-SELECT * FROM u.a
-----
-error: database missing
-
-build
 SELECT * FROM t.a WHERE x > 10
 ----
 select [out=(0,1)]


### PR DESCRIPTION
This change fixes `opt/build.go` to behave like the newer
build code in `opt/optbuilder/builder.go` when handling errors.
Instead of simply panicking in case of an error, it wraps
the error in a `builderError` before panicking. Then the
top-level `build()` and `buildScalar()` functions catch panics,
convert those containing `builderError`s back to errors, and
re-panic the rest.

Fixes #22578.

Release note: None