### PR TITLE
cli/interactive_tests: skip flaky quit tests

### DIFF
--- a/pkg/cli/interactive_tests/test_missing_log_output.tcl
+++ b/pkg/cli/interactive_tests/test_missing_log_output.tcl
@@ -90,7 +90,10 @@ eexpect ":/# "
 
 end_test
 
-
+# Quit is broken, so skip the rest of the tests.
+#
+# TODO: Remove this once #22536 is fixed.
+exit
 
 start_server $argv
 


### PR DESCRIPTION
These are broken because quit is broken (#22536).

Release note: None