### PR TITLE
cherrypick-1.1: allocator: Include alive store count in error messages

### DIFF
--- a/pkg/storage/allocator.go
+++ b/pkg/storage/allocator.go
@@ -341,7 +341,7 @@ func (a *Allocator) AllocateTarget(
 	rangeInfo RangeInfo,
 	relaxConstraints bool,
 ) (*roachpb.StoreDescriptor, string, error) {
-	sl, _, throttledStoreCount := a.storePool.getStoreList(rangeInfo.Desc.RangeID, storeFilterThrottled)
+	sl, aliveStoreCount, throttledStoreCount := a.storePool.getStoreList(rangeInfo.Desc.RangeID, storeFilterThrottled)
 
 	candidates := allocateCandidates(
 		a.storePool.st,
@@ -372,7 +372,8 @@ func (a *Allocator) AllocateTarget(
 		return nil, "", errors.Errorf("%d matching stores are currently throttled", throttledStoreCount)
 	}
 	return nil, "", &allocatorError{
-		required: constraints.Constraints,
+		required:        constraints.Constraints,
+		aliveStoreCount: aliveStoreCount,
 	}
 }
 


### PR DESCRIPTION
allocatorError messages have been misleading for a very long time --
they always say that 0 out of 0 stores match the constraints, even if
there are more than 0 live stores in the cluster. The last time a
correct count of the live stores was used was January 2017, before
f4f3ab6b1db33aa0168655e4406a4dbe2a1dd8b8, and even then a count was only
used on one of two code paths.

Release note: None

Cherrypicks #22565 onto release-1.1. Feel free to reject this @cockroachdb/release , since it's not necessary for fixing any major bugs; it's just totally safe while improving the correctness of our logs. Proposing since nobody commented on the cherry-pick aspect of #22565.