### PR TITLE
 sql: support SQL Null in JSONB inverted index 

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/inverted_index
+++ b/pkg/sql/logictest/testdata/logic_test/inverted_index
@@ -144,6 +144,9 @@ INSERT INTO d VALUES(17, '{}')
 statement ok
 INSERT INTO d VALUES(18, '[]')
 
+statement ok
+INSERT INTO d VALUES (29,  NULL)
+
 query TITTTTT
 EXPLAIN (VERBOSE) SELECT * from d where b @>'{"a": "b"}'
 ----
@@ -395,3 +398,33 @@ query IT
 SELECT * from d where b @> '[[]]' ORDER BY a;
 ----
 26  [[], {}]
+
+query IT
+SELECT * from d where b IS NULL;
+----
+29  NULL
+
+query IT
+SELECT * from d where b = NULL;
+----
+
+query TITTTTT
+EXPLAIN (VERBOSE) SELECT * from d where b IS NULL
+----
+index-join  0  index-join  ·       ·          (a, b)           a!=NULL; weak-key(a,b)
+ ├── scan   1  scan        ·       ·          (a, b[omitted])  a!=NULL; weak-key(a,b)
+ │          1  ·           table   d@foo_inv  ·                ·
+ │          1  ·           spans   ALL        ·                ·
+ └── scan   1  scan        ·       ·          (a, b)           ·
+·           1  ·           table   d@primary  ·                ·
+·           1  ·           filter  b IS NULL  ·                ·
+
+
+query IT
+SELECT * from d where b @> NULL;
+----
+
+query IT
+SELECT * from d where b @> 'null' ORDER BY a;
+----
+11  null

--- a/pkg/sql/sqlbase/table.go
+++ b/pkg/sql/sqlbase/table.go
@@ -1591,6 +1591,9 @@ func EncodeInvertedIndexKeys(
 // a list of buffers per path. The encoded values is guaranteed to be lexicographically sortable, but not
 // guaranteed to be round-trippable during decoding.
 func EncodeInvertedIndexTableKeys(val tree.Datum, inKey []byte) (key [][]byte, err error) {
+	if val == tree.DNull {
+		return [][]byte{encoding.EncodeNullAscending(inKey)}, nil
+	}
 	switch t := tree.UnwrapDatum(nil, val).(type) {
 	case *tree.DJSON:
 		return json.EncodeInvertedIndexKeys(inKey, (t.JSON))


### PR DESCRIPTION
Before we would force indexed JSONB columns to be non null.

Now we will encode SQL NULL in the inverted index and support index
operations.

Closes: #21789

Release note: None