### PR TITLE
opt: execute Values (no columns), add execbuilder testcases for scalars

### DIFF
--- a/pkg/sql/executor_opt_interface.go
+++ b/pkg/sql/executor_opt_interface.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/exec"
 	"github.com/cockroachdb/cockroach/pkg/sql/optbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 )
 
@@ -51,6 +52,19 @@ func (ee *execEngine) Factory() exec.Factory {
 // Close is part of the exec.Engine interface.
 func (ee *execEngine) Close() {
 	ee.cleanup()
+}
+
+func (ee *execEngine) ConstructValues(
+	rows [][]tree.TypedExpr, colTypes []types.T, colNames []string,
+) (exec.Node, error) {
+	if len(colTypes) != 0 {
+		panic("values with columns not implemented")
+	}
+	values := ee.planner.newContainerValuesNode(sqlbase.ResultColumns{}, len(rows))
+	for range rows {
+		values.rows.AddRow(context.TODO(), tree.Datums{})
+	}
+	return values, nil
 }
 
 // ConstructScan is part of the exec.Factory interface.

--- a/pkg/sql/opt/exec/execbuilder/builder_test.go
+++ b/pkg/sql/opt/exec/execbuilder/builder_test.go
@@ -83,7 +83,7 @@ func TestBuild(t *testing.T) {
 
 					// Build and optimize the opt expression tree.
 					// We know that the ExecEngine also implements Catalog.
-					o := xform.NewOptimizer(catalog, xform.OptimizeNone)
+					o := xform.NewOptimizer(catalog, xform.OptimizeAll)
 					root, props, err := optbuilder.New(ctx, o.Factory(), stmt).Build()
 					if err != nil {
 						d.Fatalf(t, "BuildOpt: %v", err)

--- a/pkg/sql/opt/exec/execbuilder/testdata/join
+++ b/pkg/sql/opt/exec/execbuilder/testdata/join
@@ -39,7 +39,7 @@ exec-explain
 SELECT * FROM t.a, t.b WHERE a.x = b.x
 ----
 filter          0  filter  ·       ·          (x, y, x, z)  ·
- │              0  ·       filter  @1 = @3    ·             ·
+ │              0  ·       filter  x = x      ·             ·
  └── join       1  join    ·       ·          (x, y, x, z)  ·
       │         1  ·       type    cross      ·             ·
       ├── scan  2  scan    ·       ·          (x, y)        ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/project
+++ b/pkg/sql/opt/exec/execbuilder/testdata/project
@@ -14,7 +14,7 @@ exec-explain
 SELECT * FROM t.a WHERE x > 1
 ----
 filter     0  filter  ·       ·          (x, y)  ·
- │         0  ·       filter  @1 > 1     ·       ·
+ │         0  ·       filter  x > 1      ·       ·
  └── scan  1  scan    ·       ·          (x, y)  ·
 ·          1  ·       table   a@primary  ·       ·
 ·          1  ·       spans   ALL        ·       ·
@@ -29,7 +29,7 @@ exec-explain
 SELECT * FROM t.a WHERE y > 1
 ----
 filter     0  filter  ·       ·          (x, y)  ·
- │         0  ·       filter  @2 > 1     ·       ·
+ │         0  ·       filter  y > 1      ·       ·
  └── scan  1  scan    ·       ·          (x, y)  ·
 ·          1  ·       table   a@primary  ·       ·
 ·          1  ·       spans   ALL        ·       ·
@@ -44,11 +44,11 @@ SELECT * FROM t.a WHERE y > 1
 exec-explain
 SELECT * FROM t.a WHERE x > 1 AND x < 3
 ----
-filter     0  filter  ·       ·                      (x, y)  ·
- │         0  ·       filter  (@1 > 1) AND (@1 < 3)  ·       ·
- └── scan  1  scan    ·       ·                      (x, y)  ·
-·          1  ·       table   a@primary              ·       ·
-·          1  ·       spans   ALL                    ·       ·
+filter     0  filter  ·       ·                    (x, y)  ·
+ │         0  ·       filter  (x > 1) AND (x < 3)  ·       ·
+ └── scan  1  scan    ·       ·                    (x, y)  ·
+·          1  ·       table   a@primary            ·       ·
+·          1  ·       spans   ALL                  ·       ·
 
 exec
 SELECT * FROM t.a WHERE x > 1 AND x < 3
@@ -132,14 +132,14 @@ SELECT x, x, y, x FROM t.a
 exec-explain
 SELECT x + 1, x + y FROM t.a WHERE x + y > 20
 ----
-render          0  render  ·         ·               (column3, column4)  ·
- │              0  ·       render 0  x + 1           ·                   ·
- │              0  ·       render 1  x + y           ·                   ·
- └── filter     1  filter  ·         ·               (x, y)              ·
-      │         1  ·       filter    (@1 + @2) > 20  ·                   ·
-      └── scan  2  scan    ·         ·               (x, y)              ·
-·               2  ·       table     a@primary       ·                   ·
-·               2  ·       spans     ALL             ·                   ·
+render          0  render  ·         ·             (column3, column4)  ·
+ │              0  ·       render 0  x + 1         ·                   ·
+ │              0  ·       render 1  x + y         ·                   ·
+ └── filter     1  filter  ·         ·             (x, y)              ·
+      │         1  ·       filter    (x + y) > 20  ·                   ·
+      └── scan  2  scan    ·         ·             (x, y)              ·
+·               2  ·       table     a@primary     ·                   ·
+·               2  ·       spans     ALL           ·                   ·
 
 exec
 SELECT x + 1, x + y FROM t.a WHERE x + y > 20
@@ -176,7 +176,7 @@ SELECT x FROM t.b WHERE rowid > 0
 render          0  render  ·         ·          ("b.x")                ·
  │              0  ·       render 0  x          ·                      ·
  └── filter     1  filter  ·         ·          (x, y, rowid[hidden])  ·
-      │         1  ·       filter    @3 > 0     ·                      ·
+      │         1  ·       filter    rowid > 0  ·                      ·
       └── scan  2  scan    ·         ·          (x, y, rowid[hidden])  ·
 ·               2  ·       table     b@primary  ·                      ·
 ·               2  ·       spans     ALL        ·                      ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/scalar
+++ b/pkg/sql/opt/exec/execbuilder/testdata/scalar
@@ -1,0 +1,250 @@
+# This file tests that we build scalar expressions correctly. We do this by
+# putting expressions inside projections and checking that they roundtrip
+# correctly.
+
+exec-raw
+CREATE DATABASE t;
+CREATE TABLE t.t (a INT, b INT, c INT, d INT, j JSONB, s STRING)
+----
+
+exec-explain
+SELECT 1 + 2
+----
+render       0  render  ·         ·                 (column1)  ·
+ │           0  ·       render 0  3                 ·          ·
+ └── values  1  values  ·         ·                 ()         ·
+·            1  ·       size      0 columns, 1 row  ·          ·
+
+exec-explain
+SELECT true
+----
+render       0  render  ·         ·                 (column1)  ·
+ │           0  ·       render 0  true              ·          ·
+ └── values  1  values  ·         ·                 ()         ·
+·            1  ·       size      0 columns, 1 row  ·          ·
+
+exec-explain
+SELECT false
+----
+render       0  render  ·         ·                 (column1)  ·
+ │           0  ·       render 0  false             ·          ·
+ └── values  1  values  ·         ·                 ()         ·
+·            1  ·       size      0 columns, 1 row  ·          ·
+
+exec-explain
+SELECT 1 + 2 FROM t.t
+----
+render     0  render  ·         ·          (column8)                          ·
+ │         0  ·       render 0  3          ·                                  ·
+ └── scan  1  scan    ·         ·          (a, b, c, d, j, s, rowid[hidden])  ·
+·          1  ·       table     t@primary  ·                                  ·
+·          1  ·       spans     ALL        ·                                  ·
+
+exec-explain
+SELECT a + 2 FROM t.t
+----
+render     0  render  ·         ·          (column8)                          ·
+ │         0  ·       render 0  a + 2      ·                                  ·
+ └── scan  1  scan    ·         ·          (a, b, c, d, j, s, rowid[hidden])  ·
+·          1  ·       table     t@primary  ·                                  ·
+·          1  ·       spans     ALL        ·                                  ·
+
+exec-explain
+SELECT a >= 5 AND b <= 10 AND c < 4 FROM t.t
+----
+render     0  render  ·         ·                                     (column8)                          ·
+ │         0  ·       render 0  ((a >= 5) AND (b <= 10)) AND (c < 4)  ·                                  ·
+ └── scan  1  scan    ·         ·                                     (a, b, c, d, j, s, rowid[hidden])  ·
+·          1  ·       table     t@primary                             ·                                  ·
+·          1  ·       spans     ALL                                   ·                                  ·
+
+exec-explain
+SELECT a >= 5 OR b <= 10 OR c < 4  FROM t.t
+----
+render     0  render  ·         ·                                   (column8)                          ·
+ │         0  ·       render 0  ((a >= 5) OR (b <= 10)) OR (c < 4)  ·                                  ·
+ └── scan  1  scan    ·         ·                                   (a, b, c, d, j, s, rowid[hidden])  ·
+·          1  ·       table     t@primary                           ·                                  ·
+·          1  ·       spans     ALL                                 ·                                  ·
+
+exec-explain
+SELECT NOT (a = 5) FROM t.t
+----
+render     0  render  ·         ·          (column8)                          ·
+ │         0  ·       render 0  a != 5     ·                                  ·
+ └── scan  1  scan    ·         ·          (a, b, c, d, j, s, rowid[hidden])  ·
+·          1  ·       table     t@primary  ·                                  ·
+·          1  ·       spans     ALL        ·                                  ·
+
+exec-explain
+SELECT NOT (a > 5 AND b >= 10) FROM t.t
+----
+render     0  render  ·         ·                            (column8)                          ·
+ │         0  ·       render 0  NOT ((a > 5) AND (b >= 10))  ·                                  ·
+ └── scan  1  scan    ·         ·                            (a, b, c, d, j, s, rowid[hidden])  ·
+·          1  ·       table     t@primary                    ·                                  ·
+·          1  ·       spans     ALL                          ·                                  ·
+
+exec-explain
+SELECT (a >= 5 AND b <= 10) OR (a <= 10 AND c > 5) FROM t.t
+----
+render     0  render  ·         ·                                                    (column8)                          ·
+ │         0  ·       render 0  ((a >= 5) AND (b <= 10)) OR ((a <= 10) AND (c > 5))  ·                                  ·
+ └── scan  1  scan    ·         ·                                                    (a, b, c, d, j, s, rowid[hidden])  ·
+·          1  ·       table     t@primary                                            ·                                  ·
+·          1  ·       spans     ALL                                                  ·                                  ·
+
+exec-explain
+SELECT NOT (a >= 5 OR b <= 10) AND NOT (c >= 10) FROM t.t
+----
+render     0  render  ·         ·                                           (column8)                          ·
+ │         0  ·       render 0  (NOT ((a >= 5) OR (b <= 10))) AND (c < 10)  ·                                  ·
+ └── scan  1  scan    ·         ·                                           (a, b, c, d, j, s, rowid[hidden])  ·
+·          1  ·       table     t@primary                                   ·                                  ·
+·          1  ·       spans     ALL                                         ·                                  ·
+
+
+exec-explain
+SELECT (a, b) = (1, 2)  FROM t.t
+----
+render     0  render  ·         ·                    (column8)                          ·
+ │         0  ·       render 0  (a = 1) AND (b = 2)  ·                                  ·
+ └── scan  1  scan    ·         ·                    (a, b, c, d, j, s, rowid[hidden])  ·
+·          1  ·       table     t@primary            ·                                  ·
+·          1  ·       spans     ALL                  ·                                  ·
+
+exec-explain
+SELECT a IN (1, 2) FROM t.t
+----
+render     0  render  ·         ·            (column8)                          ·
+ │         0  ·       render 0  a IN (1, 2)  ·                                  ·
+ └── scan  1  scan    ·         ·            (a, b, c, d, j, s, rowid[hidden])  ·
+·          1  ·       table     t@primary    ·                                  ·
+·          1  ·       spans     ALL          ·                                  ·
+
+exec-explain
+SELECT (a, b) IN ((1, 2), (3, 4)) FROM t.t
+----
+render     0  render  ·         ·                           (column8)                          ·
+ │         0  ·       render 0  (a, b) IN ((1, 2), (3, 4))  ·                                  ·
+ └── scan  1  scan    ·         ·                           (a, b, c, d, j, s, rowid[hidden])  ·
+·          1  ·       table     t@primary                   ·                                  ·
+·          1  ·       spans     ALL                         ·                                  ·
+
+exec-explain
+SELECT (a, b + c, 5 + d * 2) = (b+c, 8, a - c)  FROM t.t
+----
+render     0  render  ·         ·                                                                (column8)                          ·
+ │         0  ·       render 0  ((a = (b + c)) AND ((b + c) = 8)) AND ((5 + (d * 2)) = (a - c))  ·                                  ·
+ └── scan  1  scan    ·         ·                                                                (a, b, c, d, j, s, rowid[hidden])  ·
+·          1  ·       table     t@primary                                                        ·                                  ·
+·          1  ·       spans     ALL                                                              ·                                  ·
+
+exec-explain
+SELECT ((a, b), (c, d)) = ((1, 2), (3, 4))  FROM t.t
+----
+render     0  render  ·         ·                                                (column8)                          ·
+ │         0  ·       render 0  (((a = 1) AND (b = 2)) AND (c = 3)) AND (d = 4)  ·                                  ·
+ └── scan  1  scan    ·         ·                                                (a, b, c, d, j, s, rowid[hidden])  ·
+·          1  ·       table     t@primary                                        ·                                  ·
+·          1  ·       spans     ALL                                              ·                                  ·
+
+exec-explain
+SELECT (a, (b, 'a'), (c, 'b', 5)) = (9, (a+c, s), (5, s, a)) FROM t.t
+----
+render     0  render  ·         ·                                                                                      (column8)                          ·
+ │         0  ·       render 0  (((((a = 9) AND (b = (a + c))) AND (s = 'a')) AND (c = 5)) AND (s = 'b')) AND (a = 5)  ·                                  ·
+ └── scan  1  scan    ·         ·                                                                                      (a, b, c, d, j, s, rowid[hidden])  ·
+·          1  ·       table     t@primary                                                                              ·                                  ·
+·          1  ·       spans     ALL                                                                                    ·                                  ·
+
+exec-explain
+SELECT a IS NULL FROM t.t
+----
+render     0  render  ·         ·          (column8)                          ·
+ │         0  ·       render 0  a IS NULL  ·                                  ·
+ └── scan  1  scan    ·         ·          (a, b, c, d, j, s, rowid[hidden])  ·
+·          1  ·       table     t@primary  ·                                  ·
+·          1  ·       spans     ALL        ·                                  ·
+
+exec-explain
+SELECT a IS NOT DISTINCT FROM NULL FROM t.t
+----
+render     0  render  ·         ·          (column8)                          ·
+ │         0  ·       render 0  a IS NULL  ·                                  ·
+ └── scan  1  scan    ·         ·          (a, b, c, d, j, s, rowid[hidden])  ·
+·          1  ·       table     t@primary  ·                                  ·
+·          1  ·       spans     ALL        ·                                  ·
+
+exec-explain
+SELECT a IS NOT DISTINCT FROM b FROM t.t
+----
+render     0  render  ·         ·                         (column8)                          ·
+ │         0  ·       render 0  a IS NOT DISTINCT FROM b  ·                                  ·
+ └── scan  1  scan    ·         ·                         (a, b, c, d, j, s, rowid[hidden])  ·
+·          1  ·       table     t@primary                 ·                                  ·
+·          1  ·       spans     ALL                       ·                                  ·
+
+exec-explain
+SELECT a IS NOT NULL FROM t.t
+----
+render     0  render  ·         ·              (column8)                          ·
+ │         0  ·       render 0  a IS NOT NULL  ·                                  ·
+ └── scan  1  scan    ·         ·              (a, b, c, d, j, s, rowid[hidden])  ·
+·          1  ·       table     t@primary      ·                                  ·
+·          1  ·       spans     ALL            ·                                  ·
+
+exec-explain
+SELECT a IS DISTINCT FROM NULL FROM t.t
+----
+render     0  render  ·         ·              (column8)                          ·
+ │         0  ·       render 0  a IS NOT NULL  ·                                  ·
+ └── scan  1  scan    ·         ·              (a, b, c, d, j, s, rowid[hidden])  ·
+·          1  ·       table     t@primary      ·                                  ·
+·          1  ·       spans     ALL            ·                                  ·
+
+exec-explain
+SELECT a IS DISTINCT FROM b FROM t.t
+----
+render     0  render  ·         ·                     (column8)                          ·
+ │         0  ·       render 0  a IS DISTINCT FROM b  ·                                  ·
+ └── scan  1  scan    ·         ·                     (a, b, c, d, j, s, rowid[hidden])  ·
+·          1  ·       table     t@primary             ·                                  ·
+·          1  ·       spans     ALL                   ·                                  ·
+
+exec-explain
+SELECT +a + (-b) FROM t.t
+----
+render     0  render  ·         ·            (column8)                          ·
+ │         0  ·       render 0  (+a) + (-b)  ·                                  ·
+ └── scan  1  scan    ·         ·            (a, b, c, d, j, s, rowid[hidden])  ·
+·          1  ·       table     t@primary    ·                                  ·
+·          1  ·       spans     ALL          ·                                  ·
+
+# CASE not supported yet.
+#exec-explain
+#SELECT CASE WHEN a = 2 THEN 1 ELSE 2 END FROM t.t
+#----
+
+# Functions not supported yet.
+#exec-explain
+#SELECT LENGTH(s) = 2 FROM t.t
+#----
+
+exec-explain
+SELECT j @> '{"a": 1}' FROM t.t
+----
+render     0  render  ·         ·                (column8)                          ·
+ │         0  ·       render 0  j @> '{"a": 1}'  ·                                  ·
+ └── scan  1  scan    ·         ·                (a, b, c, d, j, s, rowid[hidden])  ·
+·          1  ·       table     t@primary        ·                                  ·
+·          1  ·       spans     ALL              ·                                  ·
+
+exec-explain
+SELECT '{"a": 1}' <@ j FROM t.t
+----
+render     0  render  ·         ·                (column8)                          ·
+ │         0  ·       render 0  j @> '{"a": 1}'  ·                                  ·
+ └── scan  1  scan    ·         ·                (a, b, c, d, j, s, rowid[hidden])  ·
+·          1  ·       table     t@primary        ·                                  ·
+·          1  ·       spans     ALL              ·                                  ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/select
+++ b/pkg/sql/opt/exec/execbuilder/testdata/select
@@ -11,7 +11,7 @@ exec-explain
 SELECT * FROM t.a WHERE x > 1
 ----
 filter     0  filter  ·       ·          (x, y)  ·
- │         0  ·       filter  @1 > 1     ·       ·
+ │         0  ·       filter  x > 1      ·       ·
  └── scan  1  scan    ·       ·          (x, y)  ·
 ·          1  ·       table   a@primary  ·       ·
 ·          1  ·       spans   ALL        ·       ·
@@ -26,7 +26,7 @@ exec-explain
 SELECT * FROM t.a WHERE y > 10
 ----
 filter     0  filter  ·       ·          (x, y)  ·
- │         0  ·       filter  @2 > 10    ·       ·
+ │         0  ·       filter  y > 10     ·       ·
  └── scan  1  scan    ·       ·          (x, y)  ·
 ·          1  ·       table   a@primary  ·       ·
 ·          1  ·       spans   ALL        ·       ·
@@ -40,11 +40,11 @@ SELECT * FROM t.a WHERE y > 10
 exec-explain
 SELECT * FROM t.a WHERE x > 1 AND x < 3
 ----
-filter     0  filter  ·       ·                      (x, y)  ·
- │         0  ·       filter  (@1 > 1) AND (@1 < 3)  ·       ·
- └── scan  1  scan    ·       ·                      (x, y)  ·
-·          1  ·       table   a@primary              ·       ·
-·          1  ·       spans   ALL                    ·       ·
+filter     0  filter  ·       ·                    (x, y)  ·
+ │         0  ·       filter  (x > 1) AND (x < 3)  ·       ·
+ └── scan  1  scan    ·       ·                    (x, y)  ·
+·          1  ·       table   a@primary            ·       ·
+·          1  ·       spans   ALL                  ·       ·
 
 exec
 SELECT * FROM t.a WHERE x > 1 AND x < 3
@@ -54,11 +54,11 @@ SELECT * FROM t.a WHERE x > 1 AND x < 3
 exec-explain
 SELECT * FROM t.a WHERE x > 1 AND y < 30
 ----
-filter     0  filter  ·       ·                       (x, y)  ·
- │         0  ·       filter  (@1 > 1) AND (@2 < 30)  ·       ·
- └── scan  1  scan    ·       ·                       (x, y)  ·
-·          1  ·       table   a@primary               ·       ·
-·          1  ·       spans   ALL                     ·       ·
+filter     0  filter  ·       ·                     (x, y)  ·
+ │         0  ·       filter  (x > 1) AND (y < 30)  ·       ·
+ └── scan  1  scan    ·       ·                     (x, y)  ·
+·          1  ·       table   a@primary             ·       ·
+·          1  ·       spans   ALL                   ·       ·
 
 exec
 SELECT * FROM t.a WHERE x > 1 AND y < 30
@@ -74,7 +74,7 @@ exec-explain
 SELECT x, y, rowid FROM t.b WHERE rowid > 0
 ----
 filter     0  filter  ·       ·          (x, y, rowid[hidden])  ·
- │         0  ·       filter  @3 > 0     ·                      ·
+ │         0  ·       filter  rowid > 0  ·                      ·
  └── scan  1  scan    ·       ·          (x, y, rowid[hidden])  ·
 ·          1  ·       table   b@primary  ·                      ·
 ·          1  ·       spans   ALL        ·                      ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/values
+++ b/pkg/sql/opt/exec/execbuilder/testdata/values
@@ -1,0 +1,25 @@
+exec-explain
+SELECT 1
+----
+render       0  render  ·         ·                 (column1)  ·
+ │           0  ·       render 0  1                 ·          ·
+ └── values  1  values  ·         ·                 ()         ·
+·            1  ·       size      0 columns, 1 row  ·          ·
+
+exec
+SELECT 1
+----
+1
+
+exec-explain
+SELECT 1 + 2
+----
+render       0  render  ·         ·                 (column1)  ·
+ │           0  ·       render 0  3                 ·          ·
+ └── values  1  values  ·         ·                 ()         ·
+·            1  ·       size      0 columns, 1 row  ·          ·
+
+exec
+SELECT 1 + 2
+----
+3

--- a/pkg/sql/opt/exec/factory.go
+++ b/pkg/sql/opt/exec/factory.go
@@ -17,6 +17,7 @@ package exec
 import (
 	"github.com/cockroachdb/cockroach/pkg/sql/optbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
 )
 
 // Factory defines the interface for building an execution plan, which consists
@@ -25,6 +26,9 @@ import (
 // The TypedExprs passed to these functions refer to columns of the input node
 // via IndexedVars.
 type Factory interface {
+	// ConstructValues returns a node that outputs the given rows as results.
+	ConstructValues(rows [][]tree.TypedExpr, colTypes []types.T, colNames []string) (Node, error)
+
 	// ConstructScan returns a node that represents a scan of the given table.
 	// TODO(radu): support list of columns, index, index constraints
 	ConstructScan(table optbase.Table) (Node, error)

--- a/pkg/sql/opt/ops/relational.opt
+++ b/pkg/sql/opt/ops/relational.opt
@@ -30,14 +30,19 @@ define Scan {
     Table TableIndex
 }
 
-# Values returns a manufactured result set containing a constant number of rows
+# Values returns a manufactured result set containing a constant number of rows.
 # specified by the Rows list field. Each row must contain the same set of
-# columns in the same order. The Cols field contains the set of column indexes
-# returned by each row, as a *ColSet.
+# columns in the same order.
+#
+# The Rows field contains a list of Tuples, one for each row. Each tuple has
+# the same length (same with that of Cols).
+#
+# The Cols field contains the set of column indices returned by each row
+# as a *ColList. It is legal for Cols to be empty.
 [Relational]
 define Values {
     Rows ExprList
-    Cols ColSet
+    Cols ColList
 }
 
 # Select filters rows from its input result set, based on the boolean filter

--- a/pkg/sql/opt/opt/factory.og.go
+++ b/pkg/sql/opt/opt/factory.og.go
@@ -236,10 +236,15 @@ type Factory interface {
 	ConstructScan(table PrivateID) GroupID
 
 	// ConstructValues constructs an expression for the Values operator.
-	// Values returns a manufactured result set containing a constant number of rows
+	// Values returns a manufactured result set containing a constant number of rows.
 	// specified by the Rows list field. Each row must contain the same set of
-	// columns in the same order. The Cols field contains the set of column indexes
-	// returned by each row, as a *ColSet.
+	// columns in the same order.
+	//
+	// The Rows field contains a list of Tuples, one for each row. Each tuple has
+	// the same length (same with that of Cols).
+	//
+	// The Cols field contains the set of column indices returned by each row
+	// as a *ColList. It is legal for Cols to be empty.
 	ConstructValues(rows ListID, cols PrivateID) GroupID
 
 	// ConstructSelect constructs an expression for the Select operator.

--- a/pkg/sql/opt/opt/operator.og.go
+++ b/pkg/sql/opt/opt/operator.og.go
@@ -160,10 +160,15 @@ const (
 	// definition in the query's metadata.
 	ScanOp
 
-	// ValuesOp returns a manufactured result set containing a constant number of rows
+	// ValuesOp returns a manufactured result set containing a constant number of rows.
 	// specified by the Rows list field. Each row must contain the same set of
-	// columns in the same order. The Cols field contains the set of column indexes
-	// returned by each row, as a *ColSet.
+	// columns in the same order.
+	//
+	// The Rows field contains a list of Tuples, one for each row. Each tuple has
+	// the same length (same with that of Cols).
+	//
+	// The Cols field contains the set of column indices returned by each row
+	// as a *ColList. It is legal for Cols to be empty.
 	ValuesOp
 
 	// SelectOp filters rows from its input result set, based on the boolean filter

--- a/pkg/sql/opt/optbuilder/builder.go
+++ b/pkg/sql/opt/optbuilder/builder.go
@@ -630,7 +630,10 @@ func (b *Builder) buildFrom(
 		// TODO(peter): This should be a table with 1 row and 0 columns to match
 		// current cockroach behavior.
 		rows := []opt.GroupID{b.factory.ConstructTuple(b.factory.InternList(nil))}
-		out = b.factory.ConstructValues(b.factory.InternList(rows), b.factory.InternPrivate(&opt.ColSet{}))
+		out = b.factory.ConstructValues(
+			b.factory.InternList(rows),
+			b.factory.InternPrivate(&opt.ColList{}),
+		)
 		outScope = inScope
 	} else {
 		out = left

--- a/pkg/sql/opt/xform/expr.go
+++ b/pkg/sql/opt/xform/expr.go
@@ -229,13 +229,10 @@ func (ev *ExprView) formatRelational(tp treeprinter.Node) {
 		// Get the list of columns from the ProjectionsOp, which has the correct
 		// order.
 		projections := ev.Child(1)
-		cols := *projections.Private().(*opt.ColList)
-		var buf bytes.Buffer
-		buf.WriteString("columns:")
-		for _, col := range cols {
-			logicalProps.formatCol(ev.mem, &buf, col)
-		}
-		tp.Child(buf.String())
+		formatColList(ev.mem, logicalProps, *projections.Private().(*opt.ColList), tp)
+
+	case opt.ValuesOp:
+		formatColList(ev.mem, logicalProps, *ev.Private().(*opt.ColList), tp)
 
 	default:
 		// Write the output columns. Fall back to writing output columns in column
@@ -246,5 +243,16 @@ func (ev *ExprView) formatRelational(tp treeprinter.Node) {
 	for i := 0; i < ev.ChildCount(); i++ {
 		child := ev.Child(i)
 		child.format(tp)
+	}
+}
+
+func formatColList(mem *memo, logicalProps *LogicalProps, cols opt.ColList, tp treeprinter.Node) {
+	if len(cols) > 0 {
+		var buf bytes.Buffer
+		buf.WriteString("columns:")
+		for _, col := range cols {
+			logicalProps.formatCol(mem, &buf, col)
+		}
+		tp.Child(buf.String())
 	}
 }

--- a/pkg/sql/opt/xform/expr.og.go
+++ b/pkg/sql/opt/xform/expr.og.go
@@ -4028,10 +4028,15 @@ func (m *memoExpr) asScan() *scanExpr {
 	return (*scanExpr)(m)
 }
 
-// valuesExpr returns a manufactured result set containing a constant number of rows
+// valuesExpr returns a manufactured result set containing a constant number of rows.
 // specified by the Rows list field. Each row must contain the same set of
-// columns in the same order. The Cols field contains the set of column indexes
-// returned by each row, as a *ColSet.
+// columns in the same order.
+//
+// The Rows field contains a list of Tuples, one for each row. Each tuple has
+// the same length (same with that of Cols).
+//
+// The Cols field contains the set of column indices returned by each row
+// as a *ColList. It is legal for Cols to be empty.
 type valuesExpr memoExpr
 
 func makeValuesExpr(rows opt.ListID, cols opt.PrivateID) valuesExpr {

--- a/pkg/sql/opt/xform/factory.og.go
+++ b/pkg/sql/opt/xform/factory.og.go
@@ -1169,10 +1169,15 @@ func (_f *factory) ConstructScan(
 }
 
 // ConstructValues constructs an expression for the Values operator.
-// Values returns a manufactured result set containing a constant number of rows
+// Values returns a manufactured result set containing a constant number of rows.
 // specified by the Rows list field. Each row must contain the same set of
-// columns in the same order. The Cols field contains the set of column indexes
-// returned by each row, as a *ColSet.
+// columns in the same order.
+//
+// The Rows field contains a list of Tuples, one for each row. Each tuple has
+// the same length (same with that of Cols).
+//
+// The Cols field contains the set of column indices returned by each row
+// as a *ColList. It is legal for Cols to be empty.
 func (_f *factory) ConstructValues(
 	rows opt.ListID,
 	cols opt.PrivateID,

--- a/pkg/sql/opt/xform/logical_props_factory.go
+++ b/pkg/sql/opt/xform/logical_props_factory.go
@@ -206,7 +206,7 @@ func (f *logicalPropsFactory) constructValuesProps(ev *ExprView) LogicalProps {
 	props := LogicalProps{Relational: &RelationalProps{}}
 
 	// Use output columns that are attached to the values op.
-	props.Relational.OutputCols = *ev.Private().(*opt.ColSet)
+	props.Relational.OutputCols = opt.ColListToSet(*ev.Private().(*opt.ColList))
 	return props
 }
 

--- a/pkg/sql/opt/xform/logical_props_test.go
+++ b/pkg/sql/opt/xform/logical_props_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
 	"github.com/cockroachdb/cockroach/pkg/testutils/datadriven"
-	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/treeprinter"
 )
 
@@ -144,7 +143,7 @@ func TestLogicalValuesProps(t *testing.T) {
 	rows := f.InternList(nil)
 	a0 := f.Metadata().TableColumn(a, 0)
 	a1 := f.Metadata().TableColumn(a, 1)
-	cols := util.MakeFastIntSet(int(a0), int(a1))
+	cols := opt.ColList{a0, a1}
 	valuesGroup := f.ConstructValues(rows, f.InternPrivate(&cols))
 
 	expected := "columns: a.x:int:null:1 a.y:int:null:2\n"


### PR DESCRIPTION
#### opt: change Values.ColSet to ColList

Change the column set in Values to a column list.

#### opt: execution for Values with no columns

Build execution for Values when there are no columns. This is useful
for expressions like `SELECT 1`.

Release notes: None

#### opt: add execbuilder testcases for scalars

Adding scalar test cases from the old opt tests.

Release note: None
