### PR TITLE
internal/client: Move resetting of txn deadlines from SQL to KV 

### DIFF
--- a/pkg/sql/session.go
+++ b/pkg/sql/session.go
@@ -1225,7 +1225,6 @@ func (ts *txnState) updateStateAndCleanupOnErr(err error, e *Executor) error {
 		// Note that TransactionAborted is also a retriable error, handled here;
 		// in this case cleanup for the txn has been done for us under the hood.
 		ts.SetState(RestartWait)
-		ts.mu.txn.ResetDeadline()
 	}
 	return err
 }


### PR DESCRIPTION
Before doing txn retries, SQL is in charge of resetting the txn
deadline. It's unfortunate that this is SQL's resposibility, but I
failed to immediately figure out how to get client.Txn/TxnCoordSender to
do it.

Release note: None