### PR TITLE
opt: switch to using value receivers for ExprView

### DIFF
--- a/pkg/sql/opt/optgen/cmd/optgen/exprs_gen.go
+++ b/pkg/sql/opt/optgen/cmd/optgen/exprs_gen.go
@@ -59,11 +59,11 @@ func (g *exprsGen) generate(compiled *lang.CompiledExpr, w io.Writer) {
 // genChildCountLookup generates a lookup table used to implement the ExprView
 // ChildCount method for each different kind of memo expression.
 func (g *exprsGen) genChildCountLookup() {
-	fmt.Fprintf(g.w, "type childCountLookupFunc func(ev *ExprView) int\n")
+	fmt.Fprintf(g.w, "type childCountLookupFunc func(ev ExprView) int\n")
 
 	fmt.Fprintf(g.w, "var childCountLookup = [...]childCountLookupFunc{\n")
 	fmt.Fprintf(g.w, "  // UnknownOp\n")
-	fmt.Fprintf(g.w, "  func(ev *ExprView) int {\n")
+	fmt.Fprintf(g.w, "  func(ev ExprView) int {\n")
 	fmt.Fprintf(g.w, "    panic(\"op type not initialized\")\n")
 	fmt.Fprintf(g.w, "  },\n\n")
 
@@ -72,7 +72,7 @@ func (g *exprsGen) genChildCountLookup() {
 		varName := exprType
 
 		fmt.Fprintf(g.w, "  // %sOp\n", define.Name)
-		fmt.Fprintf(g.w, "  func(ev *ExprView) int {\n")
+		fmt.Fprintf(g.w, "  func(ev ExprView) int {\n")
 
 		count := len(define.Fields)
 		if privateField(define) != nil {
@@ -97,11 +97,11 @@ func (g *exprsGen) genChildCountLookup() {
 // genChildGroupLookup generates a lookup table used to implement the ExprView
 // ChildGroup method for each different kind of memo expression.
 func (g *exprsGen) genChildGroupLookup() {
-	fmt.Fprintf(g.w, "type childGroupLookupFunc func(ev *ExprView, n int) opt.GroupID\n")
+	fmt.Fprintf(g.w, "type childGroupLookupFunc func(ev ExprView, n int) opt.GroupID\n")
 
 	fmt.Fprintf(g.w, "var childGroupLookup = [...]childGroupLookupFunc{\n")
 	fmt.Fprintf(g.w, "  // UnknownOp\n")
-	fmt.Fprintf(g.w, "  func(ev *ExprView, n int) opt.GroupID {\n")
+	fmt.Fprintf(g.w, "  func(ev ExprView, n int) opt.GroupID {\n")
 	fmt.Fprintf(g.w, "    panic(\"op type not initialized\")\n")
 	fmt.Fprintf(g.w, "  },\n\n")
 
@@ -110,7 +110,7 @@ func (g *exprsGen) genChildGroupLookup() {
 		varName := exprType
 
 		fmt.Fprintf(g.w, "  // %sOp\n", define.Name)
-		fmt.Fprintf(g.w, "  func(ev *ExprView, n int) opt.GroupID {\n")
+		fmt.Fprintf(g.w, "  func(ev ExprView, n int) opt.GroupID {\n")
 
 		count := len(define.Fields)
 		if privateField(define) != nil {
@@ -173,11 +173,11 @@ func (g *exprsGen) genChildGroupLookup() {
 // genPrivateFieldLookup generates a lookup table used to implement the
 // ExprView Private method for each different kind of memo expression.
 func (g *exprsGen) genPrivateFieldLookup() {
-	fmt.Fprintf(g.w, "type privateLookupFunc func(ev *ExprView) opt.PrivateID\n")
+	fmt.Fprintf(g.w, "type privateLookupFunc func(ev ExprView) opt.PrivateID\n")
 
 	fmt.Fprintf(g.w, "var privateLookup = [...]privateLookupFunc{\n")
 	fmt.Fprintf(g.w, "  // UnknownOp\n")
-	fmt.Fprintf(g.w, "  func(ev *ExprView) opt.PrivateID {\n")
+	fmt.Fprintf(g.w, "  func(ev ExprView) opt.PrivateID {\n")
 	fmt.Fprintf(g.w, "    panic(\"op type not initialized\")\n")
 	fmt.Fprintf(g.w, "  },\n\n")
 
@@ -186,7 +186,7 @@ func (g *exprsGen) genPrivateFieldLookup() {
 		varName := unTitle(exprType)
 
 		fmt.Fprintf(g.w, "  // %sOp\n", define.Name)
-		fmt.Fprintf(g.w, "  func(ev *ExprView) opt.PrivateID {\n")
+		fmt.Fprintf(g.w, "  func(ev ExprView) opt.PrivateID {\n")
 
 		private := privateField(define)
 		if private != nil {
@@ -226,7 +226,7 @@ func (g *exprsGen) genTagLookup() {
 // genIsTag generates IsXXX tag methods on ExprView for every unique tag.
 func (g *exprsGen) genIsTag() {
 	for _, tag := range g.compiled.DefineTags {
-		fmt.Fprintf(g.w, "func (ev *ExprView) Is%s() bool {\n", tag)
+		fmt.Fprintf(g.w, "func (ev ExprView) Is%s() bool {\n", tag)
 		fmt.Fprintf(g.w, "  return is%sLookup[ev.op]\n", tag)
 		fmt.Fprintf(g.w, "}\n\n")
 	}

--- a/pkg/sql/opt/optgen/cmd/optgen/testdata/exprs
+++ b/pkg/sql/opt/optgen/cmd/optgen/testdata/exprs
@@ -17,31 +17,31 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/opt"
 )
 
-type childCountLookupFunc func(ev *ExprView) int
+type childCountLookupFunc func(ev ExprView) int
 
 var childCountLookup = [...]childCountLookupFunc{
 	// UnknownOp
-	func(ev *ExprView) int {
+	func(ev ExprView) int {
 		panic("op type not initialized")
 	},
 
 	// FuncCallOp
-	func(ev *ExprView) int {
+	func(ev ExprView) int {
 		funcCallExpr := (*funcCallExpr)(ev.mem.lookupExpr(ev.loc))
 		return 1 + int(funcCallExpr.args().Length)
 	},
 }
 
-type childGroupLookupFunc func(ev *ExprView, n int) opt.GroupID
+type childGroupLookupFunc func(ev ExprView, n int) opt.GroupID
 
 var childGroupLookup = [...]childGroupLookupFunc{
 	// UnknownOp
-	func(ev *ExprView, n int) opt.GroupID {
+	func(ev ExprView, n int) opt.GroupID {
 		panic("op type not initialized")
 	},
 
 	// FuncCallOp
-	func(ev *ExprView, n int) opt.GroupID {
+	func(ev ExprView, n int) opt.GroupID {
 		funcCallExpr := (*funcCallExpr)(ev.mem.lookupExpr(ev.loc))
 
 		switch n {
@@ -54,16 +54,16 @@ var childGroupLookup = [...]childGroupLookupFunc{
 	},
 }
 
-type privateLookupFunc func(ev *ExprView) opt.PrivateID
+type privateLookupFunc func(ev ExprView) opt.PrivateID
 
 var privateLookup = [...]privateLookupFunc{
 	// UnknownOp
-	func(ev *ExprView) opt.PrivateID {
+	func(ev ExprView) opt.PrivateID {
 		panic("op type not initialized")
 	},
 
 	// FuncCallOp
-	func(ev *ExprView) opt.PrivateID {
+	func(ev ExprView) opt.PrivateID {
 		funcCallExpr := (*funcCallExpr)(ev.mem.lookupExpr(ev.loc))
 		return funcCallExpr.def()
 	},
@@ -118,30 +118,30 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/opt"
 )
 
-type childCountLookupFunc func(ev *ExprView) int
+type childCountLookupFunc func(ev ExprView) int
 
 var childCountLookup = [...]childCountLookupFunc{
 	// UnknownOp
-	func(ev *ExprView) int {
+	func(ev ExprView) int {
 		panic("op type not initialized")
 	},
 
 	// SortOp
-	func(ev *ExprView) int {
+	func(ev ExprView) int {
 		return 1
 	},
 }
 
-type childGroupLookupFunc func(ev *ExprView, n int) opt.GroupID
+type childGroupLookupFunc func(ev ExprView, n int) opt.GroupID
 
 var childGroupLookup = [...]childGroupLookupFunc{
 	// UnknownOp
-	func(ev *ExprView, n int) opt.GroupID {
+	func(ev ExprView, n int) opt.GroupID {
 		panic("op type not initialized")
 	},
 
 	// SortOp
-	func(ev *ExprView, n int) opt.GroupID {
+	func(ev ExprView, n int) opt.GroupID {
 		if n == 0 {
 			return ev.loc.group
 		}
@@ -150,16 +150,16 @@ var childGroupLookup = [...]childGroupLookupFunc{
 	},
 }
 
-type privateLookupFunc func(ev *ExprView) opt.PrivateID
+type privateLookupFunc func(ev ExprView) opt.PrivateID
 
 var privateLookup = [...]privateLookupFunc{
 	// UnknownOp
-	func(ev *ExprView) opt.PrivateID {
+	func(ev ExprView) opt.PrivateID {
 		panic("op type not initialized")
 	},
 
 	// SortOp
-	func(ev *ExprView) opt.PrivateID {
+	func(ev ExprView) opt.PrivateID {
 		return 0
 	},
 }
@@ -170,7 +170,7 @@ var isEnforcerLookup = [...]bool{
 	true, // SortOp
 }
 
-func (ev *ExprView) IsEnforcer() bool {
+func (ev ExprView) IsEnforcer() bool {
 	return isEnforcerLookup[ev.op]
 }
 ----

--- a/pkg/sql/opt/xform/expr.go
+++ b/pkg/sql/opt/xform/expr.go
@@ -97,24 +97,24 @@ func makeExprView(mem *memo, group opt.GroupID, required opt.PhysicalPropsID) Ex
 }
 
 // Operator returns the type of the expression.
-func (ev *ExprView) Operator() opt.Operator {
+func (ev ExprView) Operator() opt.Operator {
 	return ev.op
 }
 
 // Logical returns the set of logical properties that this expression provides.
-func (ev *ExprView) Logical() *LogicalProps {
+func (ev ExprView) Logical() *LogicalProps {
 	return &ev.mem.lookupGroup(ev.loc.group).logical
 }
 
 // ChildCount returns the number of expressions that are inputs to this
 // parent expression.
-func (ev *ExprView) ChildCount() int {
+func (ev ExprView) ChildCount() int {
 	return childCountLookup[ev.op](ev)
 }
 
 // Child returns the nth expression that is an input to this parent expression.
 // It panics if the requested child does not exist.
-func (ev *ExprView) Child(nth int) ExprView {
+func (ev ExprView) Child(nth int) ExprView {
 	group := ev.ChildGroup(nth)
 	if ev.required == opt.MinPhysPropsID {
 		return makeExprView(ev.mem, group, opt.MinPhysPropsID)
@@ -125,36 +125,36 @@ func (ev *ExprView) Child(nth int) ExprView {
 
 // ChildGroup returns the memo group containing the nth child of this parent
 // expression.
-func (ev *ExprView) ChildGroup(nth int) opt.GroupID {
+func (ev ExprView) ChildGroup(nth int) opt.GroupID {
 	return childGroupLookup[ev.op](ev, nth)
 }
 
 // Private returns any private data associated with this expression, or nil if
 // there is none.
-func (ev *ExprView) Private() interface{} {
+func (ev ExprView) Private() interface{} {
 	return ev.mem.lookupPrivate(ev.privateID())
 }
 
 // Metadata returns the metadata that's specific to this expression tree. Some
 // operator types refer to the metadata in their private fields. For example,
 // the Scan operator holds a metadata table index.
-func (ev *ExprView) Metadata() *opt.Metadata {
+func (ev ExprView) Metadata() *opt.Metadata {
 	return ev.mem.metadata
 }
 
 // String returns a string representation of this expression for testing and
 // debugging.
-func (ev *ExprView) String() string {
+func (ev ExprView) String() string {
 	tp := treeprinter.New()
 	ev.format(tp)
 	return tp.String()
 }
 
-func (ev *ExprView) privateID() opt.PrivateID {
+func (ev ExprView) privateID() opt.PrivateID {
 	return privateLookup[ev.op](ev)
 }
 
-func (ev *ExprView) format(tp treeprinter.Node) {
+func (ev ExprView) format(tp treeprinter.Node) {
 	if ev.IsScalar() {
 		ev.formatScalar(tp)
 	} else {
@@ -162,7 +162,7 @@ func (ev *ExprView) format(tp treeprinter.Node) {
 	}
 }
 
-func (ev *ExprView) formatScalar(tp treeprinter.Node) {
+func (ev ExprView) formatScalar(tp treeprinter.Node) {
 	var buf bytes.Buffer
 
 	fmt.Fprintf(&buf, "%v", ev.op)
@@ -194,7 +194,7 @@ func (ev *ExprView) formatScalar(tp treeprinter.Node) {
 	}
 }
 
-func (ev *ExprView) formatPrivate(buf *bytes.Buffer, private interface{}) {
+func (ev ExprView) formatPrivate(buf *bytes.Buffer, private interface{}) {
 	switch ev.op {
 	case opt.VariableOp:
 		colIndex := private.(opt.ColumnIndex)
@@ -212,7 +212,7 @@ func (ev *ExprView) formatPrivate(buf *bytes.Buffer, private interface{}) {
 	}
 }
 
-func (ev *ExprView) formatRelational(tp treeprinter.Node) {
+func (ev ExprView) formatRelational(tp treeprinter.Node) {
 	var buf bytes.Buffer
 
 	fmt.Fprintf(&buf, "%v", ev.op)

--- a/pkg/sql/opt/xform/expr.og.go
+++ b/pkg/sql/opt/xform/expr.og.go
@@ -6,423 +6,423 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/opt"
 )
 
-type childCountLookupFunc func(ev *ExprView) int
+type childCountLookupFunc func(ev ExprView) int
 
 var childCountLookup = [...]childCountLookupFunc{
 	// UnknownOp
-	func(ev *ExprView) int {
+	func(ev ExprView) int {
 		panic("op type not initialized")
 	},
 
 	// SubqueryOp
-	func(ev *ExprView) int {
+	func(ev ExprView) int {
 		return 2
 	},
 
 	// VariableOp
-	func(ev *ExprView) int {
+	func(ev ExprView) int {
 		return 0
 	},
 
 	// ConstOp
-	func(ev *ExprView) int {
+	func(ev ExprView) int {
 		return 0
 	},
 
 	// TrueOp
-	func(ev *ExprView) int {
+	func(ev ExprView) int {
 		return 0
 	},
 
 	// FalseOp
-	func(ev *ExprView) int {
+	func(ev ExprView) int {
 		return 0
 	},
 
 	// PlaceholderOp
-	func(ev *ExprView) int {
+	func(ev ExprView) int {
 		return 0
 	},
 
 	// TupleOp
-	func(ev *ExprView) int {
+	func(ev ExprView) int {
 		tupleExpr := (*tupleExpr)(ev.mem.lookupExpr(ev.loc))
 		return 0 + int(tupleExpr.elems().Length)
 	},
 
 	// ProjectionsOp
-	func(ev *ExprView) int {
+	func(ev ExprView) int {
 		projectionsExpr := (*projectionsExpr)(ev.mem.lookupExpr(ev.loc))
 		return 0 + int(projectionsExpr.elems().Length)
 	},
 
 	// AggregationsOp
-	func(ev *ExprView) int {
+	func(ev ExprView) int {
 		aggregationsExpr := (*aggregationsExpr)(ev.mem.lookupExpr(ev.loc))
 		return 0 + int(aggregationsExpr.aggs().Length)
 	},
 
 	// GroupingsOp
-	func(ev *ExprView) int {
+	func(ev ExprView) int {
 		groupingsExpr := (*groupingsExpr)(ev.mem.lookupExpr(ev.loc))
 		return 0 + int(groupingsExpr.elems().Length)
 	},
 
 	// ExistsOp
-	func(ev *ExprView) int {
+	func(ev ExprView) int {
 		return 1
 	},
 
 	// AndOp
-	func(ev *ExprView) int {
+	func(ev ExprView) int {
 		andExpr := (*andExpr)(ev.mem.lookupExpr(ev.loc))
 		return 0 + int(andExpr.conditions().Length)
 	},
 
 	// OrOp
-	func(ev *ExprView) int {
+	func(ev ExprView) int {
 		orExpr := (*orExpr)(ev.mem.lookupExpr(ev.loc))
 		return 0 + int(orExpr.conditions().Length)
 	},
 
 	// NotOp
-	func(ev *ExprView) int {
+	func(ev ExprView) int {
 		return 1
 	},
 
 	// EqOp
-	func(ev *ExprView) int {
+	func(ev ExprView) int {
 		return 2
 	},
 
 	// LtOp
-	func(ev *ExprView) int {
+	func(ev ExprView) int {
 		return 2
 	},
 
 	// GtOp
-	func(ev *ExprView) int {
+	func(ev ExprView) int {
 		return 2
 	},
 
 	// LeOp
-	func(ev *ExprView) int {
+	func(ev ExprView) int {
 		return 2
 	},
 
 	// GeOp
-	func(ev *ExprView) int {
+	func(ev ExprView) int {
 		return 2
 	},
 
 	// NeOp
-	func(ev *ExprView) int {
+	func(ev ExprView) int {
 		return 2
 	},
 
 	// InOp
-	func(ev *ExprView) int {
+	func(ev ExprView) int {
 		return 2
 	},
 
 	// NotInOp
-	func(ev *ExprView) int {
+	func(ev ExprView) int {
 		return 2
 	},
 
 	// LikeOp
-	func(ev *ExprView) int {
+	func(ev ExprView) int {
 		return 2
 	},
 
 	// NotLikeOp
-	func(ev *ExprView) int {
+	func(ev ExprView) int {
 		return 2
 	},
 
 	// ILikeOp
-	func(ev *ExprView) int {
+	func(ev ExprView) int {
 		return 2
 	},
 
 	// NotILikeOp
-	func(ev *ExprView) int {
+	func(ev ExprView) int {
 		return 2
 	},
 
 	// SimilarToOp
-	func(ev *ExprView) int {
+	func(ev ExprView) int {
 		return 2
 	},
 
 	// NotSimilarToOp
-	func(ev *ExprView) int {
+	func(ev ExprView) int {
 		return 2
 	},
 
 	// RegMatchOp
-	func(ev *ExprView) int {
+	func(ev ExprView) int {
 		return 2
 	},
 
 	// NotRegMatchOp
-	func(ev *ExprView) int {
+	func(ev ExprView) int {
 		return 2
 	},
 
 	// RegIMatchOp
-	func(ev *ExprView) int {
+	func(ev ExprView) int {
 		return 2
 	},
 
 	// NotRegIMatchOp
-	func(ev *ExprView) int {
+	func(ev ExprView) int {
 		return 2
 	},
 
 	// IsOp
-	func(ev *ExprView) int {
+	func(ev ExprView) int {
 		return 2
 	},
 
 	// IsNotOp
-	func(ev *ExprView) int {
+	func(ev ExprView) int {
 		return 2
 	},
 
 	// ContainsOp
-	func(ev *ExprView) int {
+	func(ev ExprView) int {
 		return 2
 	},
 
 	// BitandOp
-	func(ev *ExprView) int {
+	func(ev ExprView) int {
 		return 2
 	},
 
 	// BitorOp
-	func(ev *ExprView) int {
+	func(ev ExprView) int {
 		return 2
 	},
 
 	// BitxorOp
-	func(ev *ExprView) int {
+	func(ev ExprView) int {
 		return 2
 	},
 
 	// PlusOp
-	func(ev *ExprView) int {
+	func(ev ExprView) int {
 		return 2
 	},
 
 	// MinusOp
-	func(ev *ExprView) int {
+	func(ev ExprView) int {
 		return 2
 	},
 
 	// MultOp
-	func(ev *ExprView) int {
+	func(ev ExprView) int {
 		return 2
 	},
 
 	// DivOp
-	func(ev *ExprView) int {
+	func(ev ExprView) int {
 		return 2
 	},
 
 	// FloorDivOp
-	func(ev *ExprView) int {
+	func(ev ExprView) int {
 		return 2
 	},
 
 	// ModOp
-	func(ev *ExprView) int {
+	func(ev ExprView) int {
 		return 2
 	},
 
 	// PowOp
-	func(ev *ExprView) int {
+	func(ev ExprView) int {
 		return 2
 	},
 
 	// ConcatOp
-	func(ev *ExprView) int {
+	func(ev ExprView) int {
 		return 2
 	},
 
 	// LShiftOp
-	func(ev *ExprView) int {
+	func(ev ExprView) int {
 		return 2
 	},
 
 	// RShiftOp
-	func(ev *ExprView) int {
+	func(ev ExprView) int {
 		return 2
 	},
 
 	// FetchValOp
-	func(ev *ExprView) int {
+	func(ev ExprView) int {
 		return 2
 	},
 
 	// FetchTextOp
-	func(ev *ExprView) int {
+	func(ev ExprView) int {
 		return 2
 	},
 
 	// FetchValPathOp
-	func(ev *ExprView) int {
+	func(ev ExprView) int {
 		return 2
 	},
 
 	// FetchTextPathOp
-	func(ev *ExprView) int {
+	func(ev ExprView) int {
 		return 2
 	},
 
 	// UnaryPlusOp
-	func(ev *ExprView) int {
+	func(ev ExprView) int {
 		return 1
 	},
 
 	// UnaryMinusOp
-	func(ev *ExprView) int {
+	func(ev ExprView) int {
 		return 1
 	},
 
 	// UnaryComplementOp
-	func(ev *ExprView) int {
+	func(ev ExprView) int {
 		return 1
 	},
 
 	// FunctionOp
-	func(ev *ExprView) int {
+	func(ev ExprView) int {
 		functionExpr := (*functionExpr)(ev.mem.lookupExpr(ev.loc))
 		return 0 + int(functionExpr.args().Length)
 	},
 
 	// ScanOp
-	func(ev *ExprView) int {
+	func(ev ExprView) int {
 		return 0
 	},
 
 	// ValuesOp
-	func(ev *ExprView) int {
+	func(ev ExprView) int {
 		valuesExpr := (*valuesExpr)(ev.mem.lookupExpr(ev.loc))
 		return 0 + int(valuesExpr.rows().Length)
 	},
 
 	// SelectOp
-	func(ev *ExprView) int {
+	func(ev ExprView) int {
 		return 2
 	},
 
 	// ProjectOp
-	func(ev *ExprView) int {
+	func(ev ExprView) int {
 		return 2
 	},
 
 	// InnerJoinOp
-	func(ev *ExprView) int {
+	func(ev ExprView) int {
 		return 3
 	},
 
 	// LeftJoinOp
-	func(ev *ExprView) int {
+	func(ev ExprView) int {
 		return 3
 	},
 
 	// RightJoinOp
-	func(ev *ExprView) int {
+	func(ev ExprView) int {
 		return 3
 	},
 
 	// FullJoinOp
-	func(ev *ExprView) int {
+	func(ev ExprView) int {
 		return 3
 	},
 
 	// SemiJoinOp
-	func(ev *ExprView) int {
+	func(ev ExprView) int {
 		return 3
 	},
 
 	// AntiJoinOp
-	func(ev *ExprView) int {
+	func(ev ExprView) int {
 		return 3
 	},
 
 	// InnerJoinApplyOp
-	func(ev *ExprView) int {
+	func(ev ExprView) int {
 		return 3
 	},
 
 	// LeftJoinApplyOp
-	func(ev *ExprView) int {
+	func(ev ExprView) int {
 		return 3
 	},
 
 	// RightJoinApplyOp
-	func(ev *ExprView) int {
+	func(ev ExprView) int {
 		return 3
 	},
 
 	// FullJoinApplyOp
-	func(ev *ExprView) int {
+	func(ev ExprView) int {
 		return 3
 	},
 
 	// SemiJoinApplyOp
-	func(ev *ExprView) int {
+	func(ev ExprView) int {
 		return 3
 	},
 
 	// AntiJoinApplyOp
-	func(ev *ExprView) int {
+	func(ev ExprView) int {
 		return 3
 	},
 
 	// GroupByOp
-	func(ev *ExprView) int {
+	func(ev ExprView) int {
 		return 3
 	},
 
 	// UnionOp
-	func(ev *ExprView) int {
+	func(ev ExprView) int {
 		return 2
 	},
 
 	// IntersectOp
-	func(ev *ExprView) int {
+	func(ev ExprView) int {
 		return 2
 	},
 
 	// ExceptOp
-	func(ev *ExprView) int {
+	func(ev ExprView) int {
 		return 2
 	},
 
 	// SortOp
-	func(ev *ExprView) int {
+	func(ev ExprView) int {
 		return 1
 	},
 
 	// PresentOp
-	func(ev *ExprView) int {
+	func(ev ExprView) int {
 		return 1
 	},
 }
 
-type childGroupLookupFunc func(ev *ExprView, n int) opt.GroupID
+type childGroupLookupFunc func(ev ExprView, n int) opt.GroupID
 
 var childGroupLookup = [...]childGroupLookupFunc{
 	// UnknownOp
-	func(ev *ExprView, n int) opt.GroupID {
+	func(ev ExprView, n int) opt.GroupID {
 		panic("op type not initialized")
 	},
 
 	// SubqueryOp
-	func(ev *ExprView, n int) opt.GroupID {
+	func(ev ExprView, n int) opt.GroupID {
 		subqueryExpr := (*subqueryExpr)(ev.mem.lookupExpr(ev.loc))
 
 		switch n {
@@ -436,32 +436,32 @@ var childGroupLookup = [...]childGroupLookupFunc{
 	},
 
 	// VariableOp
-	func(ev *ExprView, n int) opt.GroupID {
+	func(ev ExprView, n int) opt.GroupID {
 		panic("child index out of range")
 	},
 
 	// ConstOp
-	func(ev *ExprView, n int) opt.GroupID {
+	func(ev ExprView, n int) opt.GroupID {
 		panic("child index out of range")
 	},
 
 	// TrueOp
-	func(ev *ExprView, n int) opt.GroupID {
+	func(ev ExprView, n int) opt.GroupID {
 		panic("child index out of range")
 	},
 
 	// FalseOp
-	func(ev *ExprView, n int) opt.GroupID {
+	func(ev ExprView, n int) opt.GroupID {
 		panic("child index out of range")
 	},
 
 	// PlaceholderOp
-	func(ev *ExprView, n int) opt.GroupID {
+	func(ev ExprView, n int) opt.GroupID {
 		panic("child index out of range")
 	},
 
 	// TupleOp
-	func(ev *ExprView, n int) opt.GroupID {
+	func(ev ExprView, n int) opt.GroupID {
 		tupleExpr := (*tupleExpr)(ev.mem.lookupExpr(ev.loc))
 
 		switch n {
@@ -472,7 +472,7 @@ var childGroupLookup = [...]childGroupLookupFunc{
 	},
 
 	// ProjectionsOp
-	func(ev *ExprView, n int) opt.GroupID {
+	func(ev ExprView, n int) opt.GroupID {
 		projectionsExpr := (*projectionsExpr)(ev.mem.lookupExpr(ev.loc))
 
 		switch n {
@@ -483,7 +483,7 @@ var childGroupLookup = [...]childGroupLookupFunc{
 	},
 
 	// AggregationsOp
-	func(ev *ExprView, n int) opt.GroupID {
+	func(ev ExprView, n int) opt.GroupID {
 		aggregationsExpr := (*aggregationsExpr)(ev.mem.lookupExpr(ev.loc))
 
 		switch n {
@@ -494,7 +494,7 @@ var childGroupLookup = [...]childGroupLookupFunc{
 	},
 
 	// GroupingsOp
-	func(ev *ExprView, n int) opt.GroupID {
+	func(ev ExprView, n int) opt.GroupID {
 		groupingsExpr := (*groupingsExpr)(ev.mem.lookupExpr(ev.loc))
 
 		switch n {
@@ -505,7 +505,7 @@ var childGroupLookup = [...]childGroupLookupFunc{
 	},
 
 	// ExistsOp
-	func(ev *ExprView, n int) opt.GroupID {
+	func(ev ExprView, n int) opt.GroupID {
 		existsExpr := (*existsExpr)(ev.mem.lookupExpr(ev.loc))
 
 		switch n {
@@ -517,7 +517,7 @@ var childGroupLookup = [...]childGroupLookupFunc{
 	},
 
 	// AndOp
-	func(ev *ExprView, n int) opt.GroupID {
+	func(ev ExprView, n int) opt.GroupID {
 		andExpr := (*andExpr)(ev.mem.lookupExpr(ev.loc))
 
 		switch n {
@@ -528,7 +528,7 @@ var childGroupLookup = [...]childGroupLookupFunc{
 	},
 
 	// OrOp
-	func(ev *ExprView, n int) opt.GroupID {
+	func(ev ExprView, n int) opt.GroupID {
 		orExpr := (*orExpr)(ev.mem.lookupExpr(ev.loc))
 
 		switch n {
@@ -539,7 +539,7 @@ var childGroupLookup = [...]childGroupLookupFunc{
 	},
 
 	// NotOp
-	func(ev *ExprView, n int) opt.GroupID {
+	func(ev ExprView, n int) opt.GroupID {
 		notExpr := (*notExpr)(ev.mem.lookupExpr(ev.loc))
 
 		switch n {
@@ -551,7 +551,7 @@ var childGroupLookup = [...]childGroupLookupFunc{
 	},
 
 	// EqOp
-	func(ev *ExprView, n int) opt.GroupID {
+	func(ev ExprView, n int) opt.GroupID {
 		eqExpr := (*eqExpr)(ev.mem.lookupExpr(ev.loc))
 
 		switch n {
@@ -565,7 +565,7 @@ var childGroupLookup = [...]childGroupLookupFunc{
 	},
 
 	// LtOp
-	func(ev *ExprView, n int) opt.GroupID {
+	func(ev ExprView, n int) opt.GroupID {
 		ltExpr := (*ltExpr)(ev.mem.lookupExpr(ev.loc))
 
 		switch n {
@@ -579,7 +579,7 @@ var childGroupLookup = [...]childGroupLookupFunc{
 	},
 
 	// GtOp
-	func(ev *ExprView, n int) opt.GroupID {
+	func(ev ExprView, n int) opt.GroupID {
 		gtExpr := (*gtExpr)(ev.mem.lookupExpr(ev.loc))
 
 		switch n {
@@ -593,7 +593,7 @@ var childGroupLookup = [...]childGroupLookupFunc{
 	},
 
 	// LeOp
-	func(ev *ExprView, n int) opt.GroupID {
+	func(ev ExprView, n int) opt.GroupID {
 		leExpr := (*leExpr)(ev.mem.lookupExpr(ev.loc))
 
 		switch n {
@@ -607,7 +607,7 @@ var childGroupLookup = [...]childGroupLookupFunc{
 	},
 
 	// GeOp
-	func(ev *ExprView, n int) opt.GroupID {
+	func(ev ExprView, n int) opt.GroupID {
 		geExpr := (*geExpr)(ev.mem.lookupExpr(ev.loc))
 
 		switch n {
@@ -621,7 +621,7 @@ var childGroupLookup = [...]childGroupLookupFunc{
 	},
 
 	// NeOp
-	func(ev *ExprView, n int) opt.GroupID {
+	func(ev ExprView, n int) opt.GroupID {
 		neExpr := (*neExpr)(ev.mem.lookupExpr(ev.loc))
 
 		switch n {
@@ -635,7 +635,7 @@ var childGroupLookup = [...]childGroupLookupFunc{
 	},
 
 	// InOp
-	func(ev *ExprView, n int) opt.GroupID {
+	func(ev ExprView, n int) opt.GroupID {
 		inExpr := (*inExpr)(ev.mem.lookupExpr(ev.loc))
 
 		switch n {
@@ -649,7 +649,7 @@ var childGroupLookup = [...]childGroupLookupFunc{
 	},
 
 	// NotInOp
-	func(ev *ExprView, n int) opt.GroupID {
+	func(ev ExprView, n int) opt.GroupID {
 		notInExpr := (*notInExpr)(ev.mem.lookupExpr(ev.loc))
 
 		switch n {
@@ -663,7 +663,7 @@ var childGroupLookup = [...]childGroupLookupFunc{
 	},
 
 	// LikeOp
-	func(ev *ExprView, n int) opt.GroupID {
+	func(ev ExprView, n int) opt.GroupID {
 		likeExpr := (*likeExpr)(ev.mem.lookupExpr(ev.loc))
 
 		switch n {
@@ -677,7 +677,7 @@ var childGroupLookup = [...]childGroupLookupFunc{
 	},
 
 	// NotLikeOp
-	func(ev *ExprView, n int) opt.GroupID {
+	func(ev ExprView, n int) opt.GroupID {
 		notLikeExpr := (*notLikeExpr)(ev.mem.lookupExpr(ev.loc))
 
 		switch n {
@@ -691,7 +691,7 @@ var childGroupLookup = [...]childGroupLookupFunc{
 	},
 
 	// ILikeOp
-	func(ev *ExprView, n int) opt.GroupID {
+	func(ev ExprView, n int) opt.GroupID {
 		iLikeExpr := (*iLikeExpr)(ev.mem.lookupExpr(ev.loc))
 
 		switch n {
@@ -705,7 +705,7 @@ var childGroupLookup = [...]childGroupLookupFunc{
 	},
 
 	// NotILikeOp
-	func(ev *ExprView, n int) opt.GroupID {
+	func(ev ExprView, n int) opt.GroupID {
 		notILikeExpr := (*notILikeExpr)(ev.mem.lookupExpr(ev.loc))
 
 		switch n {
@@ -719,7 +719,7 @@ var childGroupLookup = [...]childGroupLookupFunc{
 	},
 
 	// SimilarToOp
-	func(ev *ExprView, n int) opt.GroupID {
+	func(ev ExprView, n int) opt.GroupID {
 		similarToExpr := (*similarToExpr)(ev.mem.lookupExpr(ev.loc))
 
 		switch n {
@@ -733,7 +733,7 @@ var childGroupLookup = [...]childGroupLookupFunc{
 	},
 
 	// NotSimilarToOp
-	func(ev *ExprView, n int) opt.GroupID {
+	func(ev ExprView, n int) opt.GroupID {
 		notSimilarToExpr := (*notSimilarToExpr)(ev.mem.lookupExpr(ev.loc))
 
 		switch n {
@@ -747,7 +747,7 @@ var childGroupLookup = [...]childGroupLookupFunc{
 	},
 
 	// RegMatchOp
-	func(ev *ExprView, n int) opt.GroupID {
+	func(ev ExprView, n int) opt.GroupID {
 		regMatchExpr := (*regMatchExpr)(ev.mem.lookupExpr(ev.loc))
 
 		switch n {
@@ -761,7 +761,7 @@ var childGroupLookup = [...]childGroupLookupFunc{
 	},
 
 	// NotRegMatchOp
-	func(ev *ExprView, n int) opt.GroupID {
+	func(ev ExprView, n int) opt.GroupID {
 		notRegMatchExpr := (*notRegMatchExpr)(ev.mem.lookupExpr(ev.loc))
 
 		switch n {
@@ -775,7 +775,7 @@ var childGroupLookup = [...]childGroupLookupFunc{
 	},
 
 	// RegIMatchOp
-	func(ev *ExprView, n int) opt.GroupID {
+	func(ev ExprView, n int) opt.GroupID {
 		regIMatchExpr := (*regIMatchExpr)(ev.mem.lookupExpr(ev.loc))
 
 		switch n {
@@ -789,7 +789,7 @@ var childGroupLookup = [...]childGroupLookupFunc{
 	},
 
 	// NotRegIMatchOp
-	func(ev *ExprView, n int) opt.GroupID {
+	func(ev ExprView, n int) opt.GroupID {
 		notRegIMatchExpr := (*notRegIMatchExpr)(ev.mem.lookupExpr(ev.loc))
 
 		switch n {
@@ -803,7 +803,7 @@ var childGroupLookup = [...]childGroupLookupFunc{
 	},
 
 	// IsOp
-	func(ev *ExprView, n int) opt.GroupID {
+	func(ev ExprView, n int) opt.GroupID {
 		isExpr := (*isExpr)(ev.mem.lookupExpr(ev.loc))
 
 		switch n {
@@ -817,7 +817,7 @@ var childGroupLookup = [...]childGroupLookupFunc{
 	},
 
 	// IsNotOp
-	func(ev *ExprView, n int) opt.GroupID {
+	func(ev ExprView, n int) opt.GroupID {
 		isNotExpr := (*isNotExpr)(ev.mem.lookupExpr(ev.loc))
 
 		switch n {
@@ -831,7 +831,7 @@ var childGroupLookup = [...]childGroupLookupFunc{
 	},
 
 	// ContainsOp
-	func(ev *ExprView, n int) opt.GroupID {
+	func(ev ExprView, n int) opt.GroupID {
 		containsExpr := (*containsExpr)(ev.mem.lookupExpr(ev.loc))
 
 		switch n {
@@ -845,7 +845,7 @@ var childGroupLookup = [...]childGroupLookupFunc{
 	},
 
 	// BitandOp
-	func(ev *ExprView, n int) opt.GroupID {
+	func(ev ExprView, n int) opt.GroupID {
 		bitandExpr := (*bitandExpr)(ev.mem.lookupExpr(ev.loc))
 
 		switch n {
@@ -859,7 +859,7 @@ var childGroupLookup = [...]childGroupLookupFunc{
 	},
 
 	// BitorOp
-	func(ev *ExprView, n int) opt.GroupID {
+	func(ev ExprView, n int) opt.GroupID {
 		bitorExpr := (*bitorExpr)(ev.mem.lookupExpr(ev.loc))
 
 		switch n {
@@ -873,7 +873,7 @@ var childGroupLookup = [...]childGroupLookupFunc{
 	},
 
 	// BitxorOp
-	func(ev *ExprView, n int) opt.GroupID {
+	func(ev ExprView, n int) opt.GroupID {
 		bitxorExpr := (*bitxorExpr)(ev.mem.lookupExpr(ev.loc))
 
 		switch n {
@@ -887,7 +887,7 @@ var childGroupLookup = [...]childGroupLookupFunc{
 	},
 
 	// PlusOp
-	func(ev *ExprView, n int) opt.GroupID {
+	func(ev ExprView, n int) opt.GroupID {
 		plusExpr := (*plusExpr)(ev.mem.lookupExpr(ev.loc))
 
 		switch n {
@@ -901,7 +901,7 @@ var childGroupLookup = [...]childGroupLookupFunc{
 	},
 
 	// MinusOp
-	func(ev *ExprView, n int) opt.GroupID {
+	func(ev ExprView, n int) opt.GroupID {
 		minusExpr := (*minusExpr)(ev.mem.lookupExpr(ev.loc))
 
 		switch n {
@@ -915,7 +915,7 @@ var childGroupLookup = [...]childGroupLookupFunc{
 	},
 
 	// MultOp
-	func(ev *ExprView, n int) opt.GroupID {
+	func(ev ExprView, n int) opt.GroupID {
 		multExpr := (*multExpr)(ev.mem.lookupExpr(ev.loc))
 
 		switch n {
@@ -929,7 +929,7 @@ var childGroupLookup = [...]childGroupLookupFunc{
 	},
 
 	// DivOp
-	func(ev *ExprView, n int) opt.GroupID {
+	func(ev ExprView, n int) opt.GroupID {
 		divExpr := (*divExpr)(ev.mem.lookupExpr(ev.loc))
 
 		switch n {
@@ -943,7 +943,7 @@ var childGroupLookup = [...]childGroupLookupFunc{
 	},
 
 	// FloorDivOp
-	func(ev *ExprView, n int) opt.GroupID {
+	func(ev ExprView, n int) opt.GroupID {
 		floorDivExpr := (*floorDivExpr)(ev.mem.lookupExpr(ev.loc))
 
 		switch n {
@@ -957,7 +957,7 @@ var childGroupLookup = [...]childGroupLookupFunc{
 	},
 
 	// ModOp
-	func(ev *ExprView, n int) opt.GroupID {
+	func(ev ExprView, n int) opt.GroupID {
 		modExpr := (*modExpr)(ev.mem.lookupExpr(ev.loc))
 
 		switch n {
@@ -971,7 +971,7 @@ var childGroupLookup = [...]childGroupLookupFunc{
 	},
 
 	// PowOp
-	func(ev *ExprView, n int) opt.GroupID {
+	func(ev ExprView, n int) opt.GroupID {
 		powExpr := (*powExpr)(ev.mem.lookupExpr(ev.loc))
 
 		switch n {
@@ -985,7 +985,7 @@ var childGroupLookup = [...]childGroupLookupFunc{
 	},
 
 	// ConcatOp
-	func(ev *ExprView, n int) opt.GroupID {
+	func(ev ExprView, n int) opt.GroupID {
 		concatExpr := (*concatExpr)(ev.mem.lookupExpr(ev.loc))
 
 		switch n {
@@ -999,7 +999,7 @@ var childGroupLookup = [...]childGroupLookupFunc{
 	},
 
 	// LShiftOp
-	func(ev *ExprView, n int) opt.GroupID {
+	func(ev ExprView, n int) opt.GroupID {
 		lShiftExpr := (*lShiftExpr)(ev.mem.lookupExpr(ev.loc))
 
 		switch n {
@@ -1013,7 +1013,7 @@ var childGroupLookup = [...]childGroupLookupFunc{
 	},
 
 	// RShiftOp
-	func(ev *ExprView, n int) opt.GroupID {
+	func(ev ExprView, n int) opt.GroupID {
 		rShiftExpr := (*rShiftExpr)(ev.mem.lookupExpr(ev.loc))
 
 		switch n {
@@ -1027,7 +1027,7 @@ var childGroupLookup = [...]childGroupLookupFunc{
 	},
 
 	// FetchValOp
-	func(ev *ExprView, n int) opt.GroupID {
+	func(ev ExprView, n int) opt.GroupID {
 		fetchValExpr := (*fetchValExpr)(ev.mem.lookupExpr(ev.loc))
 
 		switch n {
@@ -1041,7 +1041,7 @@ var childGroupLookup = [...]childGroupLookupFunc{
 	},
 
 	// FetchTextOp
-	func(ev *ExprView, n int) opt.GroupID {
+	func(ev ExprView, n int) opt.GroupID {
 		fetchTextExpr := (*fetchTextExpr)(ev.mem.lookupExpr(ev.loc))
 
 		switch n {
@@ -1055,7 +1055,7 @@ var childGroupLookup = [...]childGroupLookupFunc{
 	},
 
 	// FetchValPathOp
-	func(ev *ExprView, n int) opt.GroupID {
+	func(ev ExprView, n int) opt.GroupID {
 		fetchValPathExpr := (*fetchValPathExpr)(ev.mem.lookupExpr(ev.loc))
 
 		switch n {
@@ -1069,7 +1069,7 @@ var childGroupLookup = [...]childGroupLookupFunc{
 	},
 
 	// FetchTextPathOp
-	func(ev *ExprView, n int) opt.GroupID {
+	func(ev ExprView, n int) opt.GroupID {
 		fetchTextPathExpr := (*fetchTextPathExpr)(ev.mem.lookupExpr(ev.loc))
 
 		switch n {
@@ -1083,7 +1083,7 @@ var childGroupLookup = [...]childGroupLookupFunc{
 	},
 
 	// UnaryPlusOp
-	func(ev *ExprView, n int) opt.GroupID {
+	func(ev ExprView, n int) opt.GroupID {
 		unaryPlusExpr := (*unaryPlusExpr)(ev.mem.lookupExpr(ev.loc))
 
 		switch n {
@@ -1095,7 +1095,7 @@ var childGroupLookup = [...]childGroupLookupFunc{
 	},
 
 	// UnaryMinusOp
-	func(ev *ExprView, n int) opt.GroupID {
+	func(ev ExprView, n int) opt.GroupID {
 		unaryMinusExpr := (*unaryMinusExpr)(ev.mem.lookupExpr(ev.loc))
 
 		switch n {
@@ -1107,7 +1107,7 @@ var childGroupLookup = [...]childGroupLookupFunc{
 	},
 
 	// UnaryComplementOp
-	func(ev *ExprView, n int) opt.GroupID {
+	func(ev ExprView, n int) opt.GroupID {
 		unaryComplementExpr := (*unaryComplementExpr)(ev.mem.lookupExpr(ev.loc))
 
 		switch n {
@@ -1119,7 +1119,7 @@ var childGroupLookup = [...]childGroupLookupFunc{
 	},
 
 	// FunctionOp
-	func(ev *ExprView, n int) opt.GroupID {
+	func(ev ExprView, n int) opt.GroupID {
 		functionExpr := (*functionExpr)(ev.mem.lookupExpr(ev.loc))
 
 		switch n {
@@ -1130,12 +1130,12 @@ var childGroupLookup = [...]childGroupLookupFunc{
 	},
 
 	// ScanOp
-	func(ev *ExprView, n int) opt.GroupID {
+	func(ev ExprView, n int) opt.GroupID {
 		panic("child index out of range")
 	},
 
 	// ValuesOp
-	func(ev *ExprView, n int) opt.GroupID {
+	func(ev ExprView, n int) opt.GroupID {
 		valuesExpr := (*valuesExpr)(ev.mem.lookupExpr(ev.loc))
 
 		switch n {
@@ -1146,7 +1146,7 @@ var childGroupLookup = [...]childGroupLookupFunc{
 	},
 
 	// SelectOp
-	func(ev *ExprView, n int) opt.GroupID {
+	func(ev ExprView, n int) opt.GroupID {
 		selectExpr := (*selectExpr)(ev.mem.lookupExpr(ev.loc))
 
 		switch n {
@@ -1160,7 +1160,7 @@ var childGroupLookup = [...]childGroupLookupFunc{
 	},
 
 	// ProjectOp
-	func(ev *ExprView, n int) opt.GroupID {
+	func(ev ExprView, n int) opt.GroupID {
 		projectExpr := (*projectExpr)(ev.mem.lookupExpr(ev.loc))
 
 		switch n {
@@ -1174,7 +1174,7 @@ var childGroupLookup = [...]childGroupLookupFunc{
 	},
 
 	// InnerJoinOp
-	func(ev *ExprView, n int) opt.GroupID {
+	func(ev ExprView, n int) opt.GroupID {
 		innerJoinExpr := (*innerJoinExpr)(ev.mem.lookupExpr(ev.loc))
 
 		switch n {
@@ -1190,7 +1190,7 @@ var childGroupLookup = [...]childGroupLookupFunc{
 	},
 
 	// LeftJoinOp
-	func(ev *ExprView, n int) opt.GroupID {
+	func(ev ExprView, n int) opt.GroupID {
 		leftJoinExpr := (*leftJoinExpr)(ev.mem.lookupExpr(ev.loc))
 
 		switch n {
@@ -1206,7 +1206,7 @@ var childGroupLookup = [...]childGroupLookupFunc{
 	},
 
 	// RightJoinOp
-	func(ev *ExprView, n int) opt.GroupID {
+	func(ev ExprView, n int) opt.GroupID {
 		rightJoinExpr := (*rightJoinExpr)(ev.mem.lookupExpr(ev.loc))
 
 		switch n {
@@ -1222,7 +1222,7 @@ var childGroupLookup = [...]childGroupLookupFunc{
 	},
 
 	// FullJoinOp
-	func(ev *ExprView, n int) opt.GroupID {
+	func(ev ExprView, n int) opt.GroupID {
 		fullJoinExpr := (*fullJoinExpr)(ev.mem.lookupExpr(ev.loc))
 
 		switch n {
@@ -1238,7 +1238,7 @@ var childGroupLookup = [...]childGroupLookupFunc{
 	},
 
 	// SemiJoinOp
-	func(ev *ExprView, n int) opt.GroupID {
+	func(ev ExprView, n int) opt.GroupID {
 		semiJoinExpr := (*semiJoinExpr)(ev.mem.lookupExpr(ev.loc))
 
 		switch n {
@@ -1254,7 +1254,7 @@ var childGroupLookup = [...]childGroupLookupFunc{
 	},
 
 	// AntiJoinOp
-	func(ev *ExprView, n int) opt.GroupID {
+	func(ev ExprView, n int) opt.GroupID {
 		antiJoinExpr := (*antiJoinExpr)(ev.mem.lookupExpr(ev.loc))
 
 		switch n {
@@ -1270,7 +1270,7 @@ var childGroupLookup = [...]childGroupLookupFunc{
 	},
 
 	// InnerJoinApplyOp
-	func(ev *ExprView, n int) opt.GroupID {
+	func(ev ExprView, n int) opt.GroupID {
 		innerJoinApplyExpr := (*innerJoinApplyExpr)(ev.mem.lookupExpr(ev.loc))
 
 		switch n {
@@ -1286,7 +1286,7 @@ var childGroupLookup = [...]childGroupLookupFunc{
 	},
 
 	// LeftJoinApplyOp
-	func(ev *ExprView, n int) opt.GroupID {
+	func(ev ExprView, n int) opt.GroupID {
 		leftJoinApplyExpr := (*leftJoinApplyExpr)(ev.mem.lookupExpr(ev.loc))
 
 		switch n {
@@ -1302,7 +1302,7 @@ var childGroupLookup = [...]childGroupLookupFunc{
 	},
 
 	// RightJoinApplyOp
-	func(ev *ExprView, n int) opt.GroupID {
+	func(ev ExprView, n int) opt.GroupID {
 		rightJoinApplyExpr := (*rightJoinApplyExpr)(ev.mem.lookupExpr(ev.loc))
 
 		switch n {
@@ -1318,7 +1318,7 @@ var childGroupLookup = [...]childGroupLookupFunc{
 	},
 
 	// FullJoinApplyOp
-	func(ev *ExprView, n int) opt.GroupID {
+	func(ev ExprView, n int) opt.GroupID {
 		fullJoinApplyExpr := (*fullJoinApplyExpr)(ev.mem.lookupExpr(ev.loc))
 
 		switch n {
@@ -1334,7 +1334,7 @@ var childGroupLookup = [...]childGroupLookupFunc{
 	},
 
 	// SemiJoinApplyOp
-	func(ev *ExprView, n int) opt.GroupID {
+	func(ev ExprView, n int) opt.GroupID {
 		semiJoinApplyExpr := (*semiJoinApplyExpr)(ev.mem.lookupExpr(ev.loc))
 
 		switch n {
@@ -1350,7 +1350,7 @@ var childGroupLookup = [...]childGroupLookupFunc{
 	},
 
 	// AntiJoinApplyOp
-	func(ev *ExprView, n int) opt.GroupID {
+	func(ev ExprView, n int) opt.GroupID {
 		antiJoinApplyExpr := (*antiJoinApplyExpr)(ev.mem.lookupExpr(ev.loc))
 
 		switch n {
@@ -1366,7 +1366,7 @@ var childGroupLookup = [...]childGroupLookupFunc{
 	},
 
 	// GroupByOp
-	func(ev *ExprView, n int) opt.GroupID {
+	func(ev ExprView, n int) opt.GroupID {
 		groupByExpr := (*groupByExpr)(ev.mem.lookupExpr(ev.loc))
 
 		switch n {
@@ -1382,7 +1382,7 @@ var childGroupLookup = [...]childGroupLookupFunc{
 	},
 
 	// UnionOp
-	func(ev *ExprView, n int) opt.GroupID {
+	func(ev ExprView, n int) opt.GroupID {
 		unionExpr := (*unionExpr)(ev.mem.lookupExpr(ev.loc))
 
 		switch n {
@@ -1396,7 +1396,7 @@ var childGroupLookup = [...]childGroupLookupFunc{
 	},
 
 	// IntersectOp
-	func(ev *ExprView, n int) opt.GroupID {
+	func(ev ExprView, n int) opt.GroupID {
 		intersectExpr := (*intersectExpr)(ev.mem.lookupExpr(ev.loc))
 
 		switch n {
@@ -1410,7 +1410,7 @@ var childGroupLookup = [...]childGroupLookupFunc{
 	},
 
 	// ExceptOp
-	func(ev *ExprView, n int) opt.GroupID {
+	func(ev ExprView, n int) opt.GroupID {
 		exceptExpr := (*exceptExpr)(ev.mem.lookupExpr(ev.loc))
 
 		switch n {
@@ -1424,7 +1424,7 @@ var childGroupLookup = [...]childGroupLookupFunc{
 	},
 
 	// SortOp
-	func(ev *ExprView, n int) opt.GroupID {
+	func(ev ExprView, n int) opt.GroupID {
 		if n == 0 {
 			return ev.loc.group
 		}
@@ -1433,7 +1433,7 @@ var childGroupLookup = [...]childGroupLookupFunc{
 	},
 
 	// PresentOp
-	func(ev *ExprView, n int) opt.GroupID {
+	func(ev ExprView, n int) opt.GroupID {
 		if n == 0 {
 			return ev.loc.group
 		}
@@ -1442,411 +1442,411 @@ var childGroupLookup = [...]childGroupLookupFunc{
 	},
 }
 
-type privateLookupFunc func(ev *ExprView) opt.PrivateID
+type privateLookupFunc func(ev ExprView) opt.PrivateID
 
 var privateLookup = [...]privateLookupFunc{
 	// UnknownOp
-	func(ev *ExprView) opt.PrivateID {
+	func(ev ExprView) opt.PrivateID {
 		panic("op type not initialized")
 	},
 
 	// SubqueryOp
-	func(ev *ExprView) opt.PrivateID {
+	func(ev ExprView) opt.PrivateID {
 		return 0
 	},
 
 	// VariableOp
-	func(ev *ExprView) opt.PrivateID {
+	func(ev ExprView) opt.PrivateID {
 		variableExpr := (*variableExpr)(ev.mem.lookupExpr(ev.loc))
 		return variableExpr.col()
 	},
 
 	// ConstOp
-	func(ev *ExprView) opt.PrivateID {
+	func(ev ExprView) opt.PrivateID {
 		constExpr := (*constExpr)(ev.mem.lookupExpr(ev.loc))
 		return constExpr.value()
 	},
 
 	// TrueOp
-	func(ev *ExprView) opt.PrivateID {
+	func(ev ExprView) opt.PrivateID {
 		return 0
 	},
 
 	// FalseOp
-	func(ev *ExprView) opt.PrivateID {
+	func(ev ExprView) opt.PrivateID {
 		return 0
 	},
 
 	// PlaceholderOp
-	func(ev *ExprView) opt.PrivateID {
+	func(ev ExprView) opt.PrivateID {
 		placeholderExpr := (*placeholderExpr)(ev.mem.lookupExpr(ev.loc))
 		return placeholderExpr.value()
 	},
 
 	// TupleOp
-	func(ev *ExprView) opt.PrivateID {
+	func(ev ExprView) opt.PrivateID {
 		return 0
 	},
 
 	// ProjectionsOp
-	func(ev *ExprView) opt.PrivateID {
+	func(ev ExprView) opt.PrivateID {
 		projectionsExpr := (*projectionsExpr)(ev.mem.lookupExpr(ev.loc))
 		return projectionsExpr.cols()
 	},
 
 	// AggregationsOp
-	func(ev *ExprView) opt.PrivateID {
+	func(ev ExprView) opt.PrivateID {
 		aggregationsExpr := (*aggregationsExpr)(ev.mem.lookupExpr(ev.loc))
 		return aggregationsExpr.cols()
 	},
 
 	// GroupingsOp
-	func(ev *ExprView) opt.PrivateID {
+	func(ev ExprView) opt.PrivateID {
 		groupingsExpr := (*groupingsExpr)(ev.mem.lookupExpr(ev.loc))
 		return groupingsExpr.cols()
 	},
 
 	// ExistsOp
-	func(ev *ExprView) opt.PrivateID {
+	func(ev ExprView) opt.PrivateID {
 		return 0
 	},
 
 	// AndOp
-	func(ev *ExprView) opt.PrivateID {
+	func(ev ExprView) opt.PrivateID {
 		return 0
 	},
 
 	// OrOp
-	func(ev *ExprView) opt.PrivateID {
+	func(ev ExprView) opt.PrivateID {
 		return 0
 	},
 
 	// NotOp
-	func(ev *ExprView) opt.PrivateID {
+	func(ev ExprView) opt.PrivateID {
 		return 0
 	},
 
 	// EqOp
-	func(ev *ExprView) opt.PrivateID {
+	func(ev ExprView) opt.PrivateID {
 		return 0
 	},
 
 	// LtOp
-	func(ev *ExprView) opt.PrivateID {
+	func(ev ExprView) opt.PrivateID {
 		return 0
 	},
 
 	// GtOp
-	func(ev *ExprView) opt.PrivateID {
+	func(ev ExprView) opt.PrivateID {
 		return 0
 	},
 
 	// LeOp
-	func(ev *ExprView) opt.PrivateID {
+	func(ev ExprView) opt.PrivateID {
 		return 0
 	},
 
 	// GeOp
-	func(ev *ExprView) opt.PrivateID {
+	func(ev ExprView) opt.PrivateID {
 		return 0
 	},
 
 	// NeOp
-	func(ev *ExprView) opt.PrivateID {
+	func(ev ExprView) opt.PrivateID {
 		return 0
 	},
 
 	// InOp
-	func(ev *ExprView) opt.PrivateID {
+	func(ev ExprView) opt.PrivateID {
 		return 0
 	},
 
 	// NotInOp
-	func(ev *ExprView) opt.PrivateID {
+	func(ev ExprView) opt.PrivateID {
 		return 0
 	},
 
 	// LikeOp
-	func(ev *ExprView) opt.PrivateID {
+	func(ev ExprView) opt.PrivateID {
 		return 0
 	},
 
 	// NotLikeOp
-	func(ev *ExprView) opt.PrivateID {
+	func(ev ExprView) opt.PrivateID {
 		return 0
 	},
 
 	// ILikeOp
-	func(ev *ExprView) opt.PrivateID {
+	func(ev ExprView) opt.PrivateID {
 		return 0
 	},
 
 	// NotILikeOp
-	func(ev *ExprView) opt.PrivateID {
+	func(ev ExprView) opt.PrivateID {
 		return 0
 	},
 
 	// SimilarToOp
-	func(ev *ExprView) opt.PrivateID {
+	func(ev ExprView) opt.PrivateID {
 		return 0
 	},
 
 	// NotSimilarToOp
-	func(ev *ExprView) opt.PrivateID {
+	func(ev ExprView) opt.PrivateID {
 		return 0
 	},
 
 	// RegMatchOp
-	func(ev *ExprView) opt.PrivateID {
+	func(ev ExprView) opt.PrivateID {
 		return 0
 	},
 
 	// NotRegMatchOp
-	func(ev *ExprView) opt.PrivateID {
+	func(ev ExprView) opt.PrivateID {
 		return 0
 	},
 
 	// RegIMatchOp
-	func(ev *ExprView) opt.PrivateID {
+	func(ev ExprView) opt.PrivateID {
 		return 0
 	},
 
 	// NotRegIMatchOp
-	func(ev *ExprView) opt.PrivateID {
+	func(ev ExprView) opt.PrivateID {
 		return 0
 	},
 
 	// IsOp
-	func(ev *ExprView) opt.PrivateID {
+	func(ev ExprView) opt.PrivateID {
 		return 0
 	},
 
 	// IsNotOp
-	func(ev *ExprView) opt.PrivateID {
+	func(ev ExprView) opt.PrivateID {
 		return 0
 	},
 
 	// ContainsOp
-	func(ev *ExprView) opt.PrivateID {
+	func(ev ExprView) opt.PrivateID {
 		return 0
 	},
 
 	// BitandOp
-	func(ev *ExprView) opt.PrivateID {
+	func(ev ExprView) opt.PrivateID {
 		return 0
 	},
 
 	// BitorOp
-	func(ev *ExprView) opt.PrivateID {
+	func(ev ExprView) opt.PrivateID {
 		return 0
 	},
 
 	// BitxorOp
-	func(ev *ExprView) opt.PrivateID {
+	func(ev ExprView) opt.PrivateID {
 		return 0
 	},
 
 	// PlusOp
-	func(ev *ExprView) opt.PrivateID {
+	func(ev ExprView) opt.PrivateID {
 		return 0
 	},
 
 	// MinusOp
-	func(ev *ExprView) opt.PrivateID {
+	func(ev ExprView) opt.PrivateID {
 		return 0
 	},
 
 	// MultOp
-	func(ev *ExprView) opt.PrivateID {
+	func(ev ExprView) opt.PrivateID {
 		return 0
 	},
 
 	// DivOp
-	func(ev *ExprView) opt.PrivateID {
+	func(ev ExprView) opt.PrivateID {
 		return 0
 	},
 
 	// FloorDivOp
-	func(ev *ExprView) opt.PrivateID {
+	func(ev ExprView) opt.PrivateID {
 		return 0
 	},
 
 	// ModOp
-	func(ev *ExprView) opt.PrivateID {
+	func(ev ExprView) opt.PrivateID {
 		return 0
 	},
 
 	// PowOp
-	func(ev *ExprView) opt.PrivateID {
+	func(ev ExprView) opt.PrivateID {
 		return 0
 	},
 
 	// ConcatOp
-	func(ev *ExprView) opt.PrivateID {
+	func(ev ExprView) opt.PrivateID {
 		return 0
 	},
 
 	// LShiftOp
-	func(ev *ExprView) opt.PrivateID {
+	func(ev ExprView) opt.PrivateID {
 		return 0
 	},
 
 	// RShiftOp
-	func(ev *ExprView) opt.PrivateID {
+	func(ev ExprView) opt.PrivateID {
 		return 0
 	},
 
 	// FetchValOp
-	func(ev *ExprView) opt.PrivateID {
+	func(ev ExprView) opt.PrivateID {
 		return 0
 	},
 
 	// FetchTextOp
-	func(ev *ExprView) opt.PrivateID {
+	func(ev ExprView) opt.PrivateID {
 		return 0
 	},
 
 	// FetchValPathOp
-	func(ev *ExprView) opt.PrivateID {
+	func(ev ExprView) opt.PrivateID {
 		return 0
 	},
 
 	// FetchTextPathOp
-	func(ev *ExprView) opt.PrivateID {
+	func(ev ExprView) opt.PrivateID {
 		return 0
 	},
 
 	// UnaryPlusOp
-	func(ev *ExprView) opt.PrivateID {
+	func(ev ExprView) opt.PrivateID {
 		return 0
 	},
 
 	// UnaryMinusOp
-	func(ev *ExprView) opt.PrivateID {
+	func(ev ExprView) opt.PrivateID {
 		return 0
 	},
 
 	// UnaryComplementOp
-	func(ev *ExprView) opt.PrivateID {
+	func(ev ExprView) opt.PrivateID {
 		return 0
 	},
 
 	// FunctionOp
-	func(ev *ExprView) opt.PrivateID {
+	func(ev ExprView) opt.PrivateID {
 		functionExpr := (*functionExpr)(ev.mem.lookupExpr(ev.loc))
 		return functionExpr.def()
 	},
 
 	// ScanOp
-	func(ev *ExprView) opt.PrivateID {
+	func(ev ExprView) opt.PrivateID {
 		scanExpr := (*scanExpr)(ev.mem.lookupExpr(ev.loc))
 		return scanExpr.table()
 	},
 
 	// ValuesOp
-	func(ev *ExprView) opt.PrivateID {
+	func(ev ExprView) opt.PrivateID {
 		valuesExpr := (*valuesExpr)(ev.mem.lookupExpr(ev.loc))
 		return valuesExpr.cols()
 	},
 
 	// SelectOp
-	func(ev *ExprView) opt.PrivateID {
+	func(ev ExprView) opt.PrivateID {
 		return 0
 	},
 
 	// ProjectOp
-	func(ev *ExprView) opt.PrivateID {
+	func(ev ExprView) opt.PrivateID {
 		return 0
 	},
 
 	// InnerJoinOp
-	func(ev *ExprView) opt.PrivateID {
+	func(ev ExprView) opt.PrivateID {
 		return 0
 	},
 
 	// LeftJoinOp
-	func(ev *ExprView) opt.PrivateID {
+	func(ev ExprView) opt.PrivateID {
 		return 0
 	},
 
 	// RightJoinOp
-	func(ev *ExprView) opt.PrivateID {
+	func(ev ExprView) opt.PrivateID {
 		return 0
 	},
 
 	// FullJoinOp
-	func(ev *ExprView) opt.PrivateID {
+	func(ev ExprView) opt.PrivateID {
 		return 0
 	},
 
 	// SemiJoinOp
-	func(ev *ExprView) opt.PrivateID {
+	func(ev ExprView) opt.PrivateID {
 		return 0
 	},
 
 	// AntiJoinOp
-	func(ev *ExprView) opt.PrivateID {
+	func(ev ExprView) opt.PrivateID {
 		return 0
 	},
 
 	// InnerJoinApplyOp
-	func(ev *ExprView) opt.PrivateID {
+	func(ev ExprView) opt.PrivateID {
 		return 0
 	},
 
 	// LeftJoinApplyOp
-	func(ev *ExprView) opt.PrivateID {
+	func(ev ExprView) opt.PrivateID {
 		return 0
 	},
 
 	// RightJoinApplyOp
-	func(ev *ExprView) opt.PrivateID {
+	func(ev ExprView) opt.PrivateID {
 		return 0
 	},
 
 	// FullJoinApplyOp
-	func(ev *ExprView) opt.PrivateID {
+	func(ev ExprView) opt.PrivateID {
 		return 0
 	},
 
 	// SemiJoinApplyOp
-	func(ev *ExprView) opt.PrivateID {
+	func(ev ExprView) opt.PrivateID {
 		return 0
 	},
 
 	// AntiJoinApplyOp
-	func(ev *ExprView) opt.PrivateID {
+	func(ev ExprView) opt.PrivateID {
 		return 0
 	},
 
 	// GroupByOp
-	func(ev *ExprView) opt.PrivateID {
+	func(ev ExprView) opt.PrivateID {
 		return 0
 	},
 
 	// UnionOp
-	func(ev *ExprView) opt.PrivateID {
+	func(ev ExprView) opt.PrivateID {
 		unionExpr := (*unionExpr)(ev.mem.lookupExpr(ev.loc))
 		return unionExpr.colMap()
 	},
 
 	// IntersectOp
-	func(ev *ExprView) opt.PrivateID {
+	func(ev ExprView) opt.PrivateID {
 		return 0
 	},
 
 	// ExceptOp
-	func(ev *ExprView) opt.PrivateID {
+	func(ev ExprView) opt.PrivateID {
 		return 0
 	},
 
 	// SortOp
-	func(ev *ExprView) opt.PrivateID {
+	func(ev ExprView) opt.PrivateID {
 		return 0
 	},
 
 	// PresentOp
-	func(ev *ExprView) opt.PrivateID {
+	func(ev ExprView) opt.PrivateID {
 		return 0
 	},
 }
@@ -2598,39 +2598,39 @@ var isEnforcerLookup = [...]bool{
 	true,  // PresentOp
 }
 
-func (ev *ExprView) IsScalar() bool {
+func (ev ExprView) IsScalar() bool {
 	return isScalarLookup[ev.op]
 }
 
-func (ev *ExprView) IsBoolean() bool {
+func (ev ExprView) IsBoolean() bool {
 	return isBooleanLookup[ev.op]
 }
 
-func (ev *ExprView) IsComparison() bool {
+func (ev ExprView) IsComparison() bool {
 	return isComparisonLookup[ev.op]
 }
 
-func (ev *ExprView) IsBinary() bool {
+func (ev ExprView) IsBinary() bool {
 	return isBinaryLookup[ev.op]
 }
 
-func (ev *ExprView) IsUnary() bool {
+func (ev ExprView) IsUnary() bool {
 	return isUnaryLookup[ev.op]
 }
 
-func (ev *ExprView) IsRelational() bool {
+func (ev ExprView) IsRelational() bool {
 	return isRelationalLookup[ev.op]
 }
 
-func (ev *ExprView) IsJoin() bool {
+func (ev ExprView) IsJoin() bool {
 	return isJoinLookup[ev.op]
 }
 
-func (ev *ExprView) IsJoinApply() bool {
+func (ev ExprView) IsJoinApply() bool {
 	return isJoinApplyLookup[ev.op]
 }
 
-func (ev *ExprView) IsEnforcer() bool {
+func (ev ExprView) IsEnforcer() bool {
 	return isEnforcerLookup[ev.op]
 }
 

--- a/pkg/sql/opt/xform/logical_props_factory.go
+++ b/pkg/sql/opt/xform/logical_props_factory.go
@@ -38,7 +38,7 @@ func (f *logicalPropsFactory) init(mem *memo) {
 // NOTE: The parent expression is passed as an ExprView for convenient access
 //       to children, but certain properties on it are not yet defined (like
 //       its logical properties!).
-func (f *logicalPropsFactory) constructProps(ev *ExprView) LogicalProps {
+func (f *logicalPropsFactory) constructProps(ev ExprView) LogicalProps {
 	if ev.IsRelational() {
 		return f.constructRelationalProps(ev)
 	}
@@ -46,7 +46,7 @@ func (f *logicalPropsFactory) constructProps(ev *ExprView) LogicalProps {
 	return f.constructScalarProps(ev)
 }
 
-func (f *logicalPropsFactory) constructRelationalProps(ev *ExprView) LogicalProps {
+func (f *logicalPropsFactory) constructRelationalProps(ev ExprView) LogicalProps {
 	switch ev.Operator() {
 	case opt.ScanOp:
 		return f.constructScanProps(ev)
@@ -75,7 +75,7 @@ func (f *logicalPropsFactory) constructRelationalProps(ev *ExprView) LogicalProp
 	panic(fmt.Sprintf("unrecognized relational expression type: %v", ev.op))
 }
 
-func (f *logicalPropsFactory) constructScanProps(ev *ExprView) LogicalProps {
+func (f *logicalPropsFactory) constructScanProps(ev ExprView) LogicalProps {
 	props := LogicalProps{Relational: &RelationalProps{}}
 
 	tblIndex := ev.Private().(opt.TableIndex)
@@ -94,7 +94,7 @@ func (f *logicalPropsFactory) constructScanProps(ev *ExprView) LogicalProps {
 	return props
 }
 
-func (f *logicalPropsFactory) constructSelectProps(ev *ExprView) LogicalProps {
+func (f *logicalPropsFactory) constructSelectProps(ev ExprView) LogicalProps {
 	props := LogicalProps{Relational: &RelationalProps{}}
 
 	inputProps := f.mem.lookupGroup(ev.ChildGroup(0)).logical
@@ -108,7 +108,7 @@ func (f *logicalPropsFactory) constructSelectProps(ev *ExprView) LogicalProps {
 	return props
 }
 
-func (f *logicalPropsFactory) constructProjectProps(ev *ExprView) LogicalProps {
+func (f *logicalPropsFactory) constructProjectProps(ev ExprView) LogicalProps {
 	props := LogicalProps{Relational: &RelationalProps{}}
 
 	inputProps := f.mem.lookupGroup(ev.ChildGroup(0)).logical
@@ -124,7 +124,7 @@ func (f *logicalPropsFactory) constructProjectProps(ev *ExprView) LogicalProps {
 	return props
 }
 
-func (f *logicalPropsFactory) constructJoinProps(ev *ExprView) LogicalProps {
+func (f *logicalPropsFactory) constructJoinProps(ev ExprView) LogicalProps {
 	props := LogicalProps{Relational: &RelationalProps{}}
 
 	leftProps := f.mem.lookupGroup(ev.ChildGroup(0)).logical
@@ -162,7 +162,7 @@ func (f *logicalPropsFactory) constructJoinProps(ev *ExprView) LogicalProps {
 	return props
 }
 
-func (f *logicalPropsFactory) constructGroupByProps(ev *ExprView) LogicalProps {
+func (f *logicalPropsFactory) constructGroupByProps(ev ExprView) LogicalProps {
 	props := LogicalProps{Relational: &RelationalProps{}}
 
 	// Output columns are the union of columns from grouping and aggregate
@@ -175,7 +175,7 @@ func (f *logicalPropsFactory) constructGroupByProps(ev *ExprView) LogicalProps {
 	return props
 }
 
-func (f *logicalPropsFactory) constructSetProps(ev *ExprView) LogicalProps {
+func (f *logicalPropsFactory) constructSetProps(ev ExprView) LogicalProps {
 	props := LogicalProps{Relational: &RelationalProps{}}
 
 	leftProps := f.mem.lookupGroup(ev.ChildGroup(0)).logical
@@ -202,7 +202,7 @@ func (f *logicalPropsFactory) constructSetProps(ev *ExprView) LogicalProps {
 	return props
 }
 
-func (f *logicalPropsFactory) constructValuesProps(ev *ExprView) LogicalProps {
+func (f *logicalPropsFactory) constructValuesProps(ev ExprView) LogicalProps {
 	props := LogicalProps{Relational: &RelationalProps{}}
 
 	// Use output columns that are attached to the values op.
@@ -210,7 +210,7 @@ func (f *logicalPropsFactory) constructValuesProps(ev *ExprView) LogicalProps {
 	return props
 }
 
-func (f *logicalPropsFactory) constructScalarProps(ev *ExprView) LogicalProps {
+func (f *logicalPropsFactory) constructScalarProps(ev ExprView) LogicalProps {
 	return LogicalProps{Scalar: &ScalarProps{Type: inferType(ev)}}
 }
 

--- a/pkg/sql/opt/xform/memo.go
+++ b/pkg/sql/opt/xform/memo.go
@@ -175,7 +175,7 @@ func (m *memo) memoizeNormExpr(norm *memoExpr) opt.GroupID {
 
 	mgrp := m.newGroup(norm)
 	e := makeExprView(m, mgrp.id, opt.MinPhysPropsID)
-	mgrp.logical = m.logPropsFactory.constructProps(&e)
+	mgrp.logical = m.logPropsFactory.constructProps(e)
 
 	m.exprMap[norm.fingerprint()] = mgrp.id
 	return mgrp.id

--- a/pkg/sql/opt/xform/typing.go
+++ b/pkg/sql/opt/xform/typing.go
@@ -26,7 +26,7 @@ import (
 // the operator, the type may be fixed, or it may be dependent upon the
 // operands. inferType is called during initial construction of the expression,
 // so its logical properties are not yet available.
-func inferType(ev *ExprView) types.T {
+func inferType(ev ExprView) types.T {
 	fn := typingFuncMap[ev.Operator()]
 	if fn == nil {
 		// TODO(rytaft): This should cause a panic, but for now just return NULL
@@ -36,7 +36,7 @@ func inferType(ev *ExprView) types.T {
 	return fn(ev)
 }
 
-type typingFunc func(ev *ExprView) types.T
+type typingFunc func(ev ExprView) types.T
 
 // typingFuncMap is a lookup table from scalar operator type to a function
 // which returns the data type of an instance of that operator.
@@ -71,7 +71,7 @@ func init() {
 
 // typeVariable returns the type of a variable expression, which is stored in
 // the query metadata and acessed by column index.
-func typeVariable(ev *ExprView) types.T {
+func typeVariable(ev ExprView) types.T {
 	colIndex := ev.Private().(opt.ColumnIndex)
 	typ := ev.Metadata().ColumnType(colIndex)
 	if typ == nil {
@@ -81,13 +81,13 @@ func typeVariable(ev *ExprView) types.T {
 }
 
 // typeAsBool returns the fixed boolean type.
-func typeAsBool(_ *ExprView) types.T {
+func typeAsBool(_ ExprView) types.T {
 	return types.Bool
 }
 
 // typeAsTuple constructs a tuple type that is composed of the types of all the
 // expression's children.
-func typeAsTuple(ev *ExprView) types.T {
+func typeAsTuple(ev ExprView) types.T {
 	types := make(types.TTuple, ev.ChildCount())
 	for i := 0; i < ev.ChildCount(); i++ {
 		child := ev.Child(i)
@@ -98,13 +98,13 @@ func typeAsTuple(ev *ExprView) types.T {
 
 // typeAsTypedExpr returns the resolved type of the private field, with the
 // assumption that it is a tree.TypedExpr.
-func typeAsTypedExpr(ev *ExprView) types.T {
+func typeAsTypedExpr(ev ExprView) types.T {
 	return ev.Private().(tree.TypedExpr).ResolvedType()
 }
 
 // typeAsUnary returns the type of a unary expression by hooking into the sql
 // semantics code that searches for unary operator overloads.
-func typeAsUnary(ev *ExprView) types.T {
+func typeAsUnary(ev ExprView) types.T {
 	unaryOp := opt.UnaryOpReverseMap[ev.Operator()]
 
 	input := ev.Child(0)
@@ -123,7 +123,7 @@ func typeAsUnary(ev *ExprView) types.T {
 
 // typeAsBinary returns the type of a binary expression by hooking into the sql
 // semantics code that searches for binary operator overloads.
-func typeAsBinary(ev *ExprView) types.T {
+func typeAsBinary(ev ExprView) types.T {
 	binOp := opt.BinaryOpReverseMap[ev.Operator()]
 
 	left := ev.Child(0)


### PR DESCRIPTION
The ExprView pointer receivers make some things more annoying, e.g.
you can't do `ev.Child(0).Private())`. Switching to value receivers;
this should be fine because the type is small and immutable.

Release note: None