### PR TITLE
workload: support arbitrary histograms in queryload operations

### DIFF
--- a/pkg/workload/bank/bank.go
+++ b/pkg/workload/bank/bank.go
@@ -126,11 +126,11 @@ func (b *bank) Tables() []workload.Table {
 }
 
 // Ops implements the Opser interface.
-func (b *bank) Ops() []workload.Operation {
+func (b *bank) Ops() workload.Operations {
 	// TODO(dan): Move the various queries in the backup/restore tests here.
-	op := workload.Operation{
+	return workload.Operations{
 		Name: `balance transfers`,
-		Fn: func(sqlDB *gosql.DB) (func(context.Context) error, error) {
+		Fn: func(sqlDB *gosql.DB, reg *workload.HistogramRegistry) (func(context.Context) error, error) {
 			rng := rand.New(rand.NewSource(b.seed))
 			updateStmt, err := sqlDB.Prepare(`
 				UPDATE bank
@@ -140,6 +140,7 @@ func (b *bank) Ops() []workload.Operation {
 			if err != nil {
 				return nil, err
 			}
+			hists := reg.GetHandle()
 
 			return func(ctx context.Context) error {
 				from := rng.Intn(b.rows)
@@ -148,12 +149,13 @@ func (b *bank) Ops() []workload.Operation {
 					to = rng.Intn(b.rows - 1)
 				}
 				amount := rand.Intn(maxTransfer)
+				start := timeutil.Now()
 				_, err := updateStmt.ExecContext(ctx, from, to, amount)
+				hists.Get(`transfer`).Record(timeutil.Since(start))
 				return err
 			}, nil
 		},
 	}
-	return []workload.Operation{op}
 }
 
 // Split creates the configured number of ranges in an already created version

--- a/pkg/workload/histogram.go
+++ b/pkg/workload/histogram.go
@@ -1,0 +1,218 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package workload
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/codahale/hdrhistogram"
+)
+
+const (
+	numUnderlyingHistograms = 1
+	sigFigs                 = 1
+	// TODO(dan): It seems these constants could due with some tuning. In
+	// #22605, it was suggested to make them 100 microseconds minimum, 60
+	// seconds maximum, and 3 sigfigs. I'm intentionally waiting on this until
+	// after we're quite sure that the workload versions of `kv` and `tpcc` are
+	// producing the same results as the old tools.
+	minLatency = 100 * time.Microsecond
+	maxLatency = 10 * time.Second
+)
+
+// NamedHistogram is a named histogram for use in Operations. It is threadsafe
+// but intended to be thread-local.
+type NamedHistogram struct {
+	name string
+	mu   struct {
+		syncutil.Mutex
+		numOps int64
+		hist   *hdrhistogram.WindowedHistogram
+	}
+}
+
+func newNamedHistogram(name string) *NamedHistogram {
+	w := &NamedHistogram{name: name}
+	// TODO(dan): Does this really need to be a windowed histogram, given that
+	// we're using a window size of 1? I'm intentionally waiting on this until
+	// after we're quite sure that the workload versions of `kv` and `tpcc` are
+	// producing the same results as the old tools.
+	w.mu.hist = hdrhistogram.NewWindowed(
+		numUnderlyingHistograms, minLatency.Nanoseconds(), maxLatency.Nanoseconds(), sigFigs)
+	return w
+}
+
+// Record saves a new datapoint and should be called once per logical operation.
+func (w *NamedHistogram) Record(elapsed time.Duration) {
+	if elapsed < minLatency {
+		elapsed = minLatency
+	} else if elapsed > maxLatency {
+		elapsed = maxLatency
+	}
+
+	w.mu.Lock()
+	err := w.mu.hist.Current.RecordValue(elapsed.Nanoseconds())
+	w.mu.numOps++
+	w.mu.Unlock()
+
+	if err != nil {
+		panic(fmt.Sprintf(`%s: recording value: %s`, w.name, err))
+	}
+}
+
+// tick resets the current histogram to a new "period". The old one's data
+// should be saved via the closure argument.
+func (w *NamedHistogram) tick(fn func(numOps int64, h *hdrhistogram.Histogram)) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	m := w.mu.hist.Merge()
+	w.mu.hist.Rotate()
+	fn(w.mu.numOps, m)
+}
+
+// HistogramRegistry is a thread-safe enclosure for a (possibly large) number of
+// named histograms. It allows for "tick"ing them periodically to reset the
+// counts and also supports aggregations.
+type HistogramRegistry struct {
+	mu struct {
+		syncutil.Mutex
+		registered []*NamedHistogram
+	}
+
+	start      time.Time
+	cumulative map[string]*hdrhistogram.Histogram
+	prevTick   map[string]HistogramTick
+}
+
+// NewHistogramRegistry returns an initialized HistogramRegistry.
+func NewHistogramRegistry() *HistogramRegistry {
+	return &HistogramRegistry{
+		start:      timeutil.Now(),
+		cumulative: make(map[string]*hdrhistogram.Histogram),
+		prevTick:   make(map[string]HistogramTick),
+	}
+}
+
+// GetHandle returns a thread-local handle for creating and registering
+// NamedHistograms.
+func (w *HistogramRegistry) GetHandle() *Histograms {
+	hists := &Histograms{reg: w}
+	hists.mu.hists = make(map[string]*NamedHistogram)
+	return hists
+}
+
+// Tick aggregates all registered histograms, grouped by name. It is expected to
+// be called periodially from one goroutine.
+func (w *HistogramRegistry) Tick(fn func(HistogramTick)) {
+	w.mu.Lock()
+	registered := append([]*NamedHistogram(nil), w.mu.registered...)
+	w.mu.Unlock()
+
+	merged := make(map[string]*hdrhistogram.Histogram)
+	totalOps := make(map[string]int64)
+	for _, hist := range registered {
+		hist.tick(func(numOps int64, h *hdrhistogram.Histogram) {
+			// TODO(dan): It really seems like we should be able to use
+			// `h.TotalCount()` for the number of operations but for some reason
+			// that doesn't line up in practice. Investigate. Merge returns the
+			// number of samples that had to be dropped during the merge - we
+			// ignore that value. Perhaps that is the discrepancy.
+			totalOps[hist.name] += numOps
+			if m, ok := merged[hist.name]; ok {
+				m.Merge(h)
+			} else {
+				merged[hist.name] = h
+			}
+		})
+	}
+
+	// TODO(dan): Do this in a stable order (probably alphabetical).
+	for name, mergedHist := range merged {
+		if _, ok := w.cumulative[name]; !ok {
+			w.cumulative[name] = hdrhistogram.New(
+				minLatency.Nanoseconds(), maxLatency.Nanoseconds(), sigFigs)
+		}
+		w.cumulative[name].Merge(mergedHist)
+
+		prevTick, ok := w.prevTick[name]
+		if !ok {
+			prevTick.start = w.start
+		}
+		now := timeutil.Now()
+		w.prevTick[name] = HistogramTick{
+			Name:       name,
+			Hist:       merged[name],
+			Cumulative: w.cumulative[name],
+			Ops:        totalOps[name],
+			LastOps:    prevTick.Ops,
+			Elapsed:    now.Sub(prevTick.start),
+			start:      now,
+		}
+		fn(w.prevTick[name])
+	}
+}
+
+// Histograms is a thread-local handle for creating and registering
+// NamedHistograms.
+type Histograms struct {
+	reg *HistogramRegistry
+	mu  struct {
+		syncutil.Mutex
+		hists map[string]*NamedHistogram
+	}
+}
+
+// Get returns a NamedHistogram with the given name, creating and registering it
+// if necessary. The result is cached, so no need to cache it in the workload.
+func (w *Histograms) Get(name string) *NamedHistogram {
+	w.mu.Lock()
+	hist, ok := w.mu.hists[name]
+	if !ok {
+		hist = newNamedHistogram(name)
+		w.mu.hists[name] = hist
+	}
+	w.mu.Unlock()
+
+	if !ok {
+		w.reg.mu.Lock()
+		w.reg.mu.registered = append(w.reg.mu.registered, hist)
+		w.reg.mu.Unlock()
+	}
+
+	return hist
+}
+
+// HistogramTick is an aggregation of ticking all histograms in a
+// HistogramRegistry with a given name.
+type HistogramTick struct {
+	// Name is the name given to the histograms represented by this tick.
+	Name string
+	// Hist is the merged result of the represented histgrams for this tick.
+	Hist *hdrhistogram.Histogram
+	// Cumulative is the merged result of the represented histgrams for all
+	// time.
+	Cumulative *hdrhistogram.Histogram
+	// Ops is the total number of `Record` calls for all represented histgrams.
+	Ops int64
+	// LastOps is the value of Ops for the last tick.
+	LastOps int64
+	// Elapsed is the amount of time since the last tick.
+	Elapsed time.Duration
+
+	start time.Time
+}

--- a/pkg/workload/kv/kv.go
+++ b/pkg/workload/kv/kv.go
@@ -30,6 +30,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/pflag"
 
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/workload"
 )
 
@@ -119,8 +120,8 @@ func (w *kv) Tables() []workload.Table {
 }
 
 // Ops implements the Opser interface.
-func (w *kv) Ops() []workload.Operation {
-	opFn := func(db *gosql.DB) (func(context.Context) error, error) {
+func (w *kv) Ops() workload.Operations {
+	opFn := func(db *gosql.DB, reg *workload.HistogramRegistry) (func(context.Context) error, error) {
 		var buf bytes.Buffer
 		buf.WriteString(`SELECT k, v FROM test.kv WHERE k IN (`)
 		for i := 0; i < w.batchSize; i++ {
@@ -153,6 +154,7 @@ func (w *kv) Ops() []workload.Operation {
 
 		op := kvOp{
 			config:    w,
+			hists:     reg.GetHandle(),
 			db:        db,
 			readStmt:  readStmt,
 			writeStmt: writeStmt,
@@ -166,14 +168,15 @@ func (w *kv) Ops() []workload.Operation {
 		return op.run, nil
 	}
 
-	return []workload.Operation{{
+	return workload.Operations{
 		Name: fmt.Sprintf(`r%02dw%02d`, w.readPercent, 100-w.readPercent),
 		Fn:   opFn,
-	}}
+	}
 }
 
 type kvOp struct {
 	config    *kv
+	hists     *workload.Histograms
 	db        *gosql.DB
 	readStmt  *gosql.Stmt
 	writeStmt *gosql.Stmt
@@ -186,12 +189,14 @@ func (o *kvOp) run(ctx context.Context) error {
 		for i := 0; i < o.config.batchSize; i++ {
 			args[i] = o.g.readKey()
 		}
+		start := timeutil.Now()
 		rows, err := o.readStmt.Query(args...)
 		if err != nil {
 			return err
 		}
 		for rows.Next() {
 		}
+		o.hists.Get(`read`).Record(timeutil.Since(start))
 		return rows.Err()
 	}
 	const argCount = 2
@@ -201,7 +206,9 @@ func (o *kvOp) run(ctx context.Context) error {
 		args[j+0] = o.g.writeKey()
 		args[j+1] = randomBlock(o.config, o.g.rand())
 	}
+	start := timeutil.Now()
 	_, err := o.writeStmt.Exec(args...)
+	o.hists.Get(`write`).Record(timeutil.Since(start))
 	return err
 }
 

--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -73,7 +73,7 @@ type Flagser interface {
 // to have been created and initialized before running these.
 type Opser interface {
 	Generator
-	Ops() []Operation
+	Ops() Operations
 }
 
 // Hookser returns any hooks associated with the generator.
@@ -129,17 +129,24 @@ type Table struct {
 	SplitFn func(int) []interface{}
 }
 
-// Operation represents some SQL query workload performable on a database
+// Operations represents some SQL query workload performable on a database
 // initialized with the requisite tables.
 //
-// TODO(dan): Finish nailing down the invariants of Operation as more workloads
+// TODO(dan): Finish nailing down the invariants of Operations as more workloads
 // are ported to this framework. TPCC in particular should be informative.
-type Operation struct {
-	// Name is a name for the work performed by this Operation.
+type Operations struct {
+	// Name is a name for the work performed.
 	Name string
 	// Fn returns a function to be called once per unit of work to be done.
 	// Various generator tools use this to track progress.
-	Fn func(*gosql.DB) (func(context.Context) error, error)
+	Fn func(*gosql.DB, *HistogramRegistry) (func(context.Context) error, error)
+
+	// ResultHist is the name of the NamedHistogram to use for the benchmark
+	// formatted results output at the end of `./workload run`. The empty string
+	// will use the sum of all histograms.
+	//
+	// TODO(dan): This will go away once more of run.go moves inside Operations.
+	ResultHist string
 }
 
 var registered = make(map[string]Meta)


### PR DESCRIPTION
The motivating example here is TPCC, which wants to count newOrder
transactions for calculating tmpC. It's also generally quite useful to
be able to histogram queries by arbitrary criteria (e.g. different
transaction types in TPCC or by local/remote in roachmart).

This is accomplished by moving the histogram logic from run.go into a
new `Watch` abstraction. There's definitely still something wonky here,
but I've played with it for probably too long already and want to get
some feedback on the approach.

Release note: None