### PR TITLE
 sql: use full index scan for [] and {} with @> queries 

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/inverted_index
+++ b/pkg/sql/logictest/testdata/logic_test/inverted_index
@@ -294,14 +294,40 @@ SELECT * from d where b @> '1.23' ORDER BY a;
 ----
 15  1.23
 
+query TITTTTT
+EXPLAIN (VERBOSE) SELECT * from d where b @> '[]';
+----
+scan  0  scan  ·       ·          (a, b)  a!=NULL; b!=NULL; key(a)
+·     0  ·     table   d@primary  ·       ·
+·     0  ·     spans   ALL        ·       ·
+·     0  ·     filter  b @> '[]'  ·       ·
+
+
+query TITTTTT
+EXPLAIN (VERBOSE) SELECT * from d where b @> '{}';
+----
+scan  0  scan  ·       ·          (a, b)  a!=NULL; b!=NULL; key(a)
+·     0  ·     table   d@primary  ·       ·
+·     0  ·     spans   ALL        ·       ·
+·     0  ·     filter  b @> '{}'  ·       ·
+
+
 query IT
 SELECT * from d where b @> '{}' ORDER BY a;
 ----
+3   {"a": {"b": "c"}}
+4   {"a": {"b": [1]}}
+5   {"a": {"b": [1, [2]]}}
+7   {"a": "b", "c": "d"}
+8   {"a": {"b": true}}
+9   {"a": {"b": false}}
 17  {}
 
 query IT
 SELECT * from d where b @> '[]' ORDER BY a;
 ----
+2   [1, 2, 3, 4, "foo"]
+16  [{"a": {"b": [1, [2]]}}, "d"]
 18  []
 
 statement ok
@@ -440,14 +466,10 @@ SELECT * from d where b = NULL;
 query TITTTTT
 EXPLAIN (VERBOSE) SELECT * from d where b IS NULL
 ----
-index-join  0  index-join  ·       ·          (a, b)           a!=NULL; weak-key(a,b)
- ├── scan   1  scan        ·       ·          (a, b[omitted])  a!=NULL; weak-key(a,b)
- │          1  ·           table   d@foo_inv  ·                ·
- │          1  ·           spans   ALL        ·                ·
- └── scan   1  scan        ·       ·          (a, b)           ·
-·           1  ·           table   d@primary  ·                ·
-·           1  ·           filter  b IS NULL  ·                ·
-
+scan  0  scan  ·       ·          (a, b)  a!=NULL; key(a)
+·     0  ·     table   d@primary  ·       ·
+·     0  ·     spans   ALL        ·       ·
+·     0  ·     filter  b IS NULL  ·       ·
 
 query IT
 SELECT * from d where b @> NULL;

--- a/pkg/sql/opt/idxconstraint/index_constraints.go
+++ b/pkg/sql/opt/idxconstraint/index_constraints.go
@@ -860,6 +860,11 @@ func (c *indexConstraintCtx) makeInvertedIndexSpansForExpr(
 
 		switch rd.Type() {
 		case json.ArrayJSONType, json.ObjectJSONType:
+			// We want to have a full index scan for an empty json array or object on the RHS of @>.
+			if rd.Len() < 1 {
+				return nil, false, false
+			}
+
 			return LogicalSpans{c.makeEqSpan(xform.ExtractConstDatum(rhs))}, true, true
 		default:
 			// If we find a scalar on the right side of the @> operator it means that we need to find

--- a/pkg/sql/opt_index_selection.go
+++ b/pkg/sql/opt_index_selection.go
@@ -165,9 +165,12 @@ func (p *planner) selectIndex(
 
 	if s.noIndexJoin {
 		// Eliminate non-covering indexes. We do this after the check above for
-		// constant false filter.
+		// constant false filter. We're also removing inverted indexes that don't
+		// generate spans.
 		for i := 0; i < len(candidates); {
-			if !candidates[i].covering {
+			spans, ok := candidates[i].ic.Spans()
+			if !candidates[i].covering ||
+				(candidates[i].index.Type == sqlbase.IndexDescriptor_INVERTED && (!ok || len(spans) == 0)) {
 				candidates[i] = candidates[len(candidates)-1]
 				candidates = candidates[:len(candidates)-1]
 			} else {
@@ -243,7 +246,7 @@ func (p *planner) selectIndex(
 	s.reverse = c.reverse
 
 	var plan planNode
-	if c.covering && c.index.Type != sqlbase.IndexDescriptor_INVERTED {
+	if c.covering {
 		s.initOrdering(c.exactPrefix, p.EvalContext())
 		plan = s
 	} else {
@@ -347,6 +350,9 @@ func (v *indexInfo) analyzeOrdering(
 // the index. This allows a scan of only the index to be performed without requiring subsequent
 // lookup of the full row.
 func (v *indexInfo) isCoveringIndex(scan *scanNode) bool {
+	if v.index.Type == sqlbase.IndexDescriptor_INVERTED {
+		return false
+	}
 	if v.index == &v.desc.PrimaryIndex {
 		// The primary key index always covers all of the columns.
 		return true


### PR DESCRIPTION
sql: use full index scan for [] and {} with @> queries

Before we used an inverted index encoding to look up all rows with json arrays or
json objects. That only yielded rows with an explicit empty object or
empty array.

Now we are using a full index scan so we get every array for column @> '[]'
and all object for queries that are c @> '{}'.

Closes #22591

Release note: None