### PR TITLE
sqlbase: convert batch errors when cascading

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/cascade
+++ b/pkg/sql/logictest/testdata/logic_test/cascade
@@ -72,6 +72,10 @@ SELECT * FROM b;
 ----
 1  2  3  4  5  1006  7  8  9  10
 
+# Also ensure that normal errors are still correctly wrapped even if cascading.
+statement error pq: duplicate key value \(id\)=\(1\) violates unique constraint "primary"
+UPDATE a SET id = 1 WHERE id = 1006;
+
 # 7. ON DELETE SET NULL
 statement ok
 DELETE FROM a WHERE id = 7;

--- a/pkg/sql/sqlbase/rowwriter.go
+++ b/pkg/sql/sqlbase/rowwriter.go
@@ -707,7 +707,7 @@ func (ru *RowUpdater) UpdateRow(
 
 		if ru.cascader != nil {
 			if err := ru.cascader.txn.Run(ctx, batch); err != nil {
-				return nil, err
+				return nil, ConvertBatchError(ctx, ru.Helper.TableDesc, batch)
 			}
 			if err := ru.cascader.cascadeAll(
 				ctx,
@@ -853,7 +853,7 @@ func (ru *RowUpdater) UpdateRow(
 
 	if ru.cascader != nil {
 		if err := ru.cascader.txn.Run(ctx, batch); err != nil {
-			return nil, err
+			return nil, ConvertBatchError(ctx, ru.Helper.TableDesc, batch)
 		}
 		if err := ru.cascader.cascadeAll(
 			ctx,


### PR DESCRIPTION
There are two cases in which a batch error was not wrapper correctly. This
fixes that.

Release note: None