### PR TITLE
ui: Unique display address for all nodes

### DIFF
--- a/pkg/ui/src/redux/nodes.spec.ts
+++ b/pkg/ui/src/redux/nodes.spec.ts
@@ -1,0 +1,69 @@
+import { assert } from "chai";
+
+import { nodeDisplayNameByIDSelector } from "./nodes";
+import { nodesReducerObj  } from "./apiReducers";
+import { createAdminUIStore } from "./state";
+
+function makeNodesState(...addresses: { id: number, address: string }[]) {
+  const data = addresses.map(addr => {
+    return {
+      desc : {
+        node_id: addr.id,
+        address: {
+          address_field: addr.address,
+        },
+      },
+    };
+  });
+  const store = createAdminUIStore();
+  store.dispatch(nodesReducerObj.receiveData(data));
+  return store.getState();
+}
+
+describe("node data selectors", function() {
+  describe("display name by ID", function() {
+    it("display name is node id appended to address", function() {
+      const state: any = makeNodesState(
+        { id: 1, address: "addressA" },
+        { id: 2, address: "addressB" },
+        { id: 3, address: "addressC" },
+        { id: 4, address: "addressD" },
+      );
+
+      const addressesByID = nodeDisplayNameByIDSelector(state);
+      assert.deepEqual(addressesByID, {
+        1: "addressA (n1)",
+        2: "addressB (n2)",
+        3: "addressC (n3)",
+        4: "addressD (n4)",
+      });
+    });
+
+    it("generates unique names for re-used addresses", function() {
+      const state: any = makeNodesState(
+        { id: 1, address: "addressA" },
+        { id: 2, address: "addressB" },
+        { id: 3, address: "addressC" },
+        { id: 4, address: "addressD" },
+        { id: 5, address: "addressA" },
+        { id: 6, address: "addressC" },
+        { id: 7, address: "addressA" },
+      );
+
+      const addressesByID = nodeDisplayNameByIDSelector(state);
+      assert.deepEqual(addressesByID, {
+        1: "addressA (n1)",
+        2: "addressB (n2)",
+        3: "addressC (n3)",
+        4: "addressD (n4)",
+        5: "addressA (n5)",
+        6: "addressC (n6)",
+        7: "addressA (n7)",
+      });
+    });
+
+    it("returns empty collection for empty state", function() {
+      assert.deepEqual(nodeDisplayNameByIDSelector(makeNodesState()), {});
+    });
+  });
+});

--- a/pkg/ui/src/redux/nodes.ts
+++ b/pkg/ui/src/redux/nodes.ts
@@ -176,6 +176,19 @@ export function sumNodeStats(
   return result;
 }
 
+// nodeDisplayNameByIDSelector provides a unique, human-readable display name
+// for each node.
+export const nodeDisplayNameByIDSelector = createSelector(
+  nodeStatusesSelector,
+  (nodeStatuses) => {
+    const result: {[key: string]: string} = {};
+    nodeStatuses.forEach(ns => {
+      result[ns.desc.node_id] = `${ns.desc.address.address_field} (n${ns.desc.node_id})`;
+    });
+    return result;
+  },
+);
+
 /**
  * nodesSummarySelector returns a directory object containing a variety of
  * computed information based on the current nodes. This object is easy to
@@ -186,14 +199,16 @@ export const nodesSummarySelector = createSelector(
   nodeIDsSelector,
   nodeStatusByIDSelector,
   nodeSumsSelector,
+  nodeDisplayNameByIDSelector,
   livenessStatusByNodeIDSelector,
   livenessByNodeIDSelector,
-  (nodeStatuses, nodeIDs, nodeStatusByID, nodeSums, livenessStatusByNodeID, livenessByNodeID) => {
+  (nodeStatuses, nodeIDs, nodeStatusByID, nodeSums, nodeDisplayNameByID, livenessStatusByNodeID, livenessByNodeID) => {
     return {
       nodeStatuses,
       nodeIDs,
       nodeStatusByID,
       nodeSums,
+      nodeDisplayNameByID,
       livenessStatusByNodeID,
       livenessByNodeID,
     };

--- a/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/dashboardUtils.ts
+++ b/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/dashboardUtils.ts
@@ -34,14 +34,14 @@ export interface GraphDashboardProps {
   tooltipSelection: string;
 }
 
-export function nodeAddress(nodesSummary: NodesSummary, nid: string) {
+export function nodeDisplayName(nodesSummary: NodesSummary, nid: string) {
   const ns = nodesSummary.nodeStatusByID[nid];
   if (!ns) {
     // This should only happen immediately after loading a page, and
     // associated graphs should display no data.
-    return "unknown address";
+    return "unknown node";
   }
-  return ns.desc.address.address_field;
+  return nodesSummary.nodeDisplayNameByID[ns.desc.node_id];
 }
 
 export function storeIDsForNode(nodesSummary: NodesSummary, nid: string): string[] {

--- a/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/distributed.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/distributed.tsx
@@ -4,7 +4,7 @@ import _ from "lodash";
 import { LineGraph } from "src/views/cluster/components/linegraph";
 import { Metric, Axis, AxisUnits } from "src/views/shared/components/metricQuery";
 
-import { GraphDashboardProps, nodeAddress } from "./dashboardUtils";
+import { GraphDashboardProps, nodeDisplayName } from "./dashboardUtils";
 
 export default function (props: GraphDashboardProps) {
   const { nodeIDs, nodesSummary, nodeSources } = props;
@@ -59,7 +59,7 @@ export default function (props: GraphDashboardProps) {
             <Metric
               key={node}
               name="cr.node.txn.durations-p99"
-              title={nodeAddress(nodesSummary, node)}
+              title={nodeDisplayName(nodesSummary, node)}
               sources={[node]}
               downsampleMax
             />
@@ -77,7 +77,7 @@ export default function (props: GraphDashboardProps) {
             <Metric
               key={node}
               name="cr.node.txn.durations-p90"
-              title={nodeAddress(nodesSummary, node)}
+              title={nodeDisplayName(nodesSummary, node)}
               sources={[node]}
               downsampleMax
             />
@@ -95,7 +95,7 @@ export default function (props: GraphDashboardProps) {
             <Metric
               key={node}
               name="cr.node.liveness.heartbeatlatency-p99"
-              title={nodeAddress(nodesSummary, node)}
+              title={nodeDisplayName(nodesSummary, node)}
               sources={[node]}
               downsampleMax
             />
@@ -113,7 +113,7 @@ export default function (props: GraphDashboardProps) {
             <Metric
               key={node}
               name="cr.node.liveness.heartbeatlatency-p90"
-              title={nodeAddress(nodesSummary, node)}
+              title={nodeDisplayName(nodesSummary, node)}
               sources={[node]}
               downsampleMax
             />

--- a/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/overview.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/overview.tsx
@@ -5,7 +5,7 @@ import docsURL from "src/util/docs";
 import { LineGraph } from "src/views/cluster/components/linegraph";
 import { Metric, Axis, AxisUnits } from "src/views/shared/components/metricQuery";
 
-import { GraphDashboardProps, nodeAddress, storeIDsForNode } from "./dashboardUtils";
+import { GraphDashboardProps, nodeDisplayName, storeIDsForNode } from "./dashboardUtils";
 
 export default function (props: GraphDashboardProps) {
   const { nodeIDs, nodesSummary, nodeSources, storeSources, tooltipSelection } = props;
@@ -43,7 +43,7 @@ export default function (props: GraphDashboardProps) {
             <Metric
               key={node}
               name="cr.node.sql.service.latency-p99"
-              title={nodeAddress(nodesSummary, node)}
+              title={nodeDisplayName(nodesSummary, node)}
               sources={[node]}
               downsampleMax
             />
@@ -68,7 +68,7 @@ export default function (props: GraphDashboardProps) {
             <Metric
               key={nid}
               name="cr.store.replicas"
-              title={nodeAddress(nodesSummary, nid)}
+              title={nodeDisplayName(nodesSummary, nid)}
               sources={storeIDsForNode(nodesSummary, nid)}
             />
           ))

--- a/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/replication.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/replication.tsx
@@ -4,7 +4,7 @@ import _ from "lodash";
 import { LineGraph } from "src/views/cluster/components/linegraph";
 import { Metric, Axis, AxisUnits } from "src/views/shared/components/metricQuery";
 
-import { GraphDashboardProps, nodeAddress, storeIDsForNode } from "./dashboardUtils";
+import { GraphDashboardProps, nodeDisplayName, storeIDsForNode } from "./dashboardUtils";
 
 export default function (props: GraphDashboardProps) {
   const { nodeIDs, nodesSummary, storeSources } = props;
@@ -28,7 +28,7 @@ export default function (props: GraphDashboardProps) {
             <Metric
               key={nid}
               name="cr.store.replicas"
-              title={nodeAddress(nodesSummary, nid)}
+              title={nodeDisplayName(nodesSummary, nid)}
               sources={storeIDsForNode(nodesSummary, nid)}
             />
           ))
@@ -49,7 +49,7 @@ export default function (props: GraphDashboardProps) {
             <Metric
               key={nid}
               name="cr.store.replicas.leaseholders"
-              title={nodeAddress(nodesSummary, nid)}
+              title={nodeDisplayName(nodesSummary, nid)}
               sources={storeIDsForNode(nodesSummary, nid)}
             />
           ))
@@ -64,7 +64,7 @@ export default function (props: GraphDashboardProps) {
             <Metric
               key={nid}
               name="cr.store.totalbytes"
-              title={nodeAddress(nodesSummary, nid)}
+              title={nodeDisplayName(nodesSummary, nid)}
               sources={storeIDsForNode(nodesSummary, nid)}
             />
           ))
@@ -79,7 +79,7 @@ export default function (props: GraphDashboardProps) {
             <Metric
               key={nid}
               name="cr.store.rebalancing.writespersecond"
-              title={nodeAddress(nodesSummary, nid)}
+              title={nodeDisplayName(nodesSummary, nid)}
               sources={storeIDsForNode(nodesSummary, nid)}
             />
           ))

--- a/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/sql.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/sql.tsx
@@ -4,7 +4,7 @@ import _ from "lodash";
 import { LineGraph } from "src/views/cluster/components/linegraph";
 import { Metric, Axis, AxisUnits } from "src/views/shared/components/metricQuery";
 
-import { GraphDashboardProps, nodeAddress } from "./dashboardUtils";
+import { GraphDashboardProps, nodeDisplayName } from "./dashboardUtils";
 
 export default function (props: GraphDashboardProps) {
   const { nodeIDs, nodesSummary, nodeSources, tooltipSelection } = props;
@@ -70,7 +70,7 @@ export default function (props: GraphDashboardProps) {
             <Metric
               key={node}
               name="cr.node.sql.distsql.flows.active"
-              title={nodeAddress(nodesSummary, node)}
+              title={nodeDisplayName(nodesSummary, node)}
               sources={[node]}
             />
           ))
@@ -94,7 +94,7 @@ export default function (props: GraphDashboardProps) {
             <Metric
               key={node}
               name="cr.node.sql.service.latency-p99"
-              title={nodeAddress(nodesSummary, node)}
+              title={nodeDisplayName(nodesSummary, node)}
               sources={[node]}
               downsampleMax
             />
@@ -119,7 +119,7 @@ export default function (props: GraphDashboardProps) {
             <Metric
               key={node}
               name="cr.node.sql.service.latency-p90"
-              title={nodeAddress(nodesSummary, node)}
+              title={nodeDisplayName(nodesSummary, node)}
               sources={[node]}
               downsampleMax
             />
@@ -141,7 +141,7 @@ export default function (props: GraphDashboardProps) {
             <Metric
               key={node}
               name="cr.node.sql.distsql.service.latency-p99"
-              title={nodeAddress(nodesSummary, node)}
+              title={nodeDisplayName(nodesSummary, node)}
               sources={[node]}
               downsampleMax
             />
@@ -163,7 +163,7 @@ export default function (props: GraphDashboardProps) {
             <Metric
               key={node}
               name="cr.node.sql.distsql.service.latency-p90"
-              title={nodeAddress(nodesSummary, node)}
+              title={nodeDisplayName(nodesSummary, node)}
               sources={[node]}
               downsampleMax
             />
@@ -185,7 +185,7 @@ export default function (props: GraphDashboardProps) {
             <Metric
               key={node}
               name="cr.node.exec.latency-p99"
-              title={nodeAddress(nodesSummary, node)}
+              title={nodeDisplayName(nodesSummary, node)}
               sources={[node]}
               downsampleMax
             />
@@ -207,7 +207,7 @@ export default function (props: GraphDashboardProps) {
             <Metric
               key={node}
               name="cr.node.exec.latency-p90"
-              title={nodeAddress(nodesSummary, node)}
+              title={nodeDisplayName(nodesSummary, node)}
               sources={[node]}
               downsampleMax
             />

--- a/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/storage.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/storage.tsx
@@ -4,7 +4,7 @@ import _ from "lodash";
 import { LineGraph } from "src/views/cluster/components/linegraph";
 import { Metric, Axis, AxisUnits } from "src/views/shared/components/metricQuery";
 
-import { GraphDashboardProps, nodeAddress, storeIDsForNode } from "./dashboardUtils";
+import { GraphDashboardProps, nodeDisplayName, storeIDsForNode } from "./dashboardUtils";
 
 export default function (props: GraphDashboardProps) {
   const { nodeIDs, nodesSummary, nodeSources, storeSources, tooltipSelection } = props;
@@ -47,7 +47,7 @@ export default function (props: GraphDashboardProps) {
             <Metric
               key={nid}
               name="cr.store.raft.process.logcommit.latency-p99"
-              title={nodeAddress(nodesSummary, nid)}
+              title={nodeDisplayName(nodesSummary, nid)}
               sources={storeIDsForNode(nodesSummary, nid)}
             />
           ))
@@ -66,7 +66,7 @@ export default function (props: GraphDashboardProps) {
             <Metric
               key={nid}
               name="cr.store.raft.process.commandcommit.latency-p99"
-              title={nodeAddress(nodesSummary, nid)}
+              title={nodeDisplayName(nodesSummary, nid)}
               sources={storeIDsForNode(nodesSummary, nid)}
             />
           ))

--- a/pkg/ui/src/views/cluster/containers/nodeGraphs/index.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodeGraphs/index.tsx
@@ -92,12 +92,13 @@ class NodeGraphs extends React.Component<NodeGraphsProps, {}> {
    */
   private nodeDropdownOptions = createSelector(
     (summary: NodesSummary) => summary.nodeStatuses,
-    (nodeStatuses): DropdownOption[] => {
+    (summary: NodesSummary) => summary.nodeDisplayNameByID,
+    (nodeStatuses, nodeDisplayNameByID): DropdownOption[] => {
       const base = [{value: "", label: "Cluster"}];
       return base.concat(_.map(nodeStatuses, (ns) => {
         return {
           value: ns.desc.node_id.toString(),
-          label: ns.desc.address.address_field,
+          label: nodeDisplayNameByID[ns.desc.node_id],
         };
       }));
     },

--- a/pkg/ui/src/views/devtools/containers/raftMessages/index.tsx
+++ b/pkg/ui/src/views/devtools/containers/raftMessages/index.tsx
@@ -53,12 +53,13 @@ class NodeGraphs extends React.Component<NodeGraphsProps, {}> {
    */
   private nodeDropdownOptions = createSelector(
     (summary: NodesSummary) => summary.nodeStatuses,
-    (nodeStatuses): DropdownOption[] => {
+    (summary: NodesSummary) => summary.nodeDisplayNameByID,
+    (nodeStatuses, nodeDisplayNameByID): DropdownOption[] => {
       const base = [{value: "", label: "Cluster"}];
       return base.concat(_.map(nodeStatuses, (ns) => {
         return {
           value: ns.desc.node_id.toString(),
-          label: ns.desc.address.address_field,
+          label: nodeDisplayNameByID[ns.desc.node_id],
         };
       }));
     },


### PR DESCRIPTION
Guarantee that each node gets a unique display address, even in the case
where a physical address is re-used between two nodes. Address re-use
can happen if a node is decommissioned, and a new node is later
restarted with the same address (but a different node ID). This presents
a problem in the UI, where we often use the node address as a
human-readable identifier for the nodes.

This commit now generates a unique address for each node; if a node's
network address has been re-used, the Node ID is appended to the visible
address for each duplicate.

Fixes #15541

Release note: Fixed a bug where re-using addresses of decommissioned
nodes could cause issues with graphs.

<img width="354" alt="screen shot 2018-02-12 at 4 49 25 pm" src="https://user-images.githubusercontent.com/6969858/36122994-509a8f72-1019-11e8-931e-1899be5b3f57.png">
<img width="302" alt="screen shot 2018-02-12 at 4 49 30 pm" src="https://user-images.githubusercontent.com/6969858/36122995-50d5a8c8-1019-11e8-98f8-6177c6912849.png">
