### PR TITLE
opt: Fall back on existing planner for unsupported statements.

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/optimizer
+++ b/pkg/sql/logictest/testdata/logic_test/optimizer
@@ -9,9 +9,36 @@ INSERT INTO t VALUES (1, 10), (2, 20), (3, 30)
 statement ok
 SET EXPERIMENTAL_OPT = ON
 
+# ParenSelect
+query II
+(SELECT * FROM test.t)
+----
+1  10
+2  20
+3  30
+
+# Select
+query error pq: ORDER BY not yet supported: SELECT \* FROM test.t ORDER BY t.k
+SELECT * FROM test.t ORDER BY t.k
+
+# SelectClause
 query II
 SELECT * FROM test.t
 ----
 1 10
 2 20
 3 30
+
+# UnionClause
+query error pq: not yet implemented: select statement: \*tree.UnionClause
+SELECT * FROM test.t UNION SELECT * FROM test.t
+
+# Insert
+statement ok
+INSERT INTO t VALUES (4, 40)
+
+statement ok
+SET EXPERIMENTAL_OPT = ALWAYS
+
+query error pq: unexpected statement: \*tree.Insert
+INSERT INTO test (k, v) VALUES (5, 50)

--- a/pkg/sql/sessiondata/session_data.go
+++ b/pkg/sql/sessiondata/session_data.go
@@ -135,9 +135,12 @@ type OptimizerMode int64
 const (
 	// OptimizerOff means that we don't use the optimizer.
 	OptimizerOff = iota
-	// OptimizerOn means that we use the optimizer for all statements.
+	// OptimizerOn means that we use the optimizer for all supported statements.
 	OptimizerOn
-	// TODO(radu): we will want an Auto mode to decide on a case-by-case basis.
+	// OptimizerAlways means that we attempt to use the optimizer always, even
+	// for unsupported statements which result in errors. This mode is useful
+	// for testing.
+	OptimizerAlways
 )
 
 func (m OptimizerMode) String() string {
@@ -146,6 +149,8 @@ func (m OptimizerMode) String() string {
 		return "off"
 	case OptimizerOn:
 		return "on"
+	case OptimizerAlways:
+		return "always"
 	default:
 		return fmt.Sprintf("invalid (%d)", m)
 	}
@@ -158,6 +163,8 @@ func OptimizerModeFromString(val string) (_ OptimizerMode, ok bool) {
 		return OptimizerOff, true
 	case "ON":
 		return OptimizerOn, true
+	case "ALWAYS":
+		return OptimizerAlways, true
 	default:
 		return 0, false
 	}


### PR DESCRIPTION
The new optimizer supports only read-only query statements. For other
statements, fall back on the existing planner.

Release note: None