### PR TITLE
distsqlrun: add sorter test cases

### DIFF
--- a/pkg/sql/distsqlrun/sorter.go
+++ b/pkg/sql/distsqlrun/sorter.go
@@ -170,13 +170,13 @@ func (s *sortAllProcessor) Next() (sqlbase.EncDatumRow, *ProducerMetadata) {
 		}
 	}
 
-	if ok, err := s.i.Valid(); err != nil {
-		return nil, s.producerMeta(err)
-	} else if !ok {
-		return s.trailingMetadata()
-	}
-
 	for {
+		if ok, err := s.i.Valid(); err != nil {
+			return nil, s.producerMeta(err)
+		} else if !ok {
+			return s.trailingMetadata()
+		}
+
 		row, err := s.i.Row()
 		if err != nil {
 			return nil, s.producerMeta(err)

--- a/pkg/sql/distsqlrun/sorter_test.go
+++ b/pkg/sql/distsqlrun/sorter_test.go
@@ -111,6 +111,60 @@ func TestSorter(t *testing.T) {
 				{v[3], v[3], v[0]},
 			},
 		}, {
+			name: "SortOffset",
+			// No specified input ordering but specified offset and limit.
+			spec: SorterSpec{
+				OutputOrdering: convertToSpecOrdering(
+					sqlbase.ColumnOrdering{
+						{ColIdx: 0, Direction: asc},
+						{ColIdx: 1, Direction: asc},
+						{ColIdx: 2, Direction: asc},
+					}),
+			},
+			post:  PostProcessSpec{Offset: 2, Limit: 2},
+			types: threeIntCols,
+			input: sqlbase.EncDatumRows{
+				{v[3], v[3], v[0]},
+				{v[3], v[4], v[1]},
+				{v[1], v[0], v[4]},
+				{v[0], v[0], v[0]},
+				{v[4], v[4], v[4]},
+				{v[4], v[4], v[5]},
+				{v[3], v[2], v[0]},
+			},
+			expected: sqlbase.EncDatumRows{
+				{v[3], v[2], v[0]},
+				{v[3], v[3], v[0]},
+			},
+		}, {
+			name: "SortFilterExpr",
+			// No specified input ordering but specified postprocess filter expression.
+			spec: SorterSpec{
+				OutputOrdering: convertToSpecOrdering(
+					sqlbase.ColumnOrdering{
+						{ColIdx: 0, Direction: asc},
+						{ColIdx: 1, Direction: asc},
+						{ColIdx: 2, Direction: asc},
+					}),
+			},
+			post:  PostProcessSpec{Filter: Expression{Expr: "@1 + @2 < 7"}},
+			types: threeIntCols,
+			input: sqlbase.EncDatumRows{
+				{v[3], v[3], v[0]},
+				{v[3], v[4], v[1]},
+				{v[1], v[0], v[4]},
+				{v[0], v[0], v[0]},
+				{v[4], v[4], v[4]},
+				{v[4], v[4], v[5]},
+				{v[3], v[2], v[0]},
+			},
+			expected: sqlbase.EncDatumRows{
+				{v[0], v[0], v[0]},
+				{v[1], v[0], v[4]},
+				{v[3], v[2], v[0]},
+				{v[3], v[3], v[0]},
+			},
+		}, {
 			name: "SortMatchOrderingNoLimit",
 			// Specified match ordering length but no specified limit.
 			spec: SorterSpec{


### PR DESCRIPTION
Also fix a panic uncovered by the testcase when a postprocess filter
expression is specified on a sorter.
