### PR TITLE
ui: Do not graph series which have no data points

### DIFF
--- a/pkg/ui/src/views/cluster/util/graphs.ts
+++ b/pkg/ui/src/views/cluster/util/graphs.ts
@@ -261,7 +261,7 @@ function formatMetricData(
 
   _.each(metrics, (s, idx) => {
     const result = data.results[idx];
-    if (result) {
+    if (result && !_.isEmpty(result.datapoints)) {
       formattedData.push({
         values: result.datapoints,
         key: s.props.title || s.props.name,


### PR DESCRIPTION
Graph lines which have no data points in the queried time span will no
longer be displayed *at all*; they will not appear in the legend or the
interactive tooltip. This situation has proved a consistent source of
confusion, especially on graphs which display (empty) values for
decommissioned nodes which are no longer producing data.

Fixes #19541

Release note: Fixed an issue where graph tooltips would continue to
display zero values for nodes which had long been decommissioned.