### PR TITLE
importccl: fail fast if table already exists

### DIFF
--- a/pkg/ccl/importccl/csv.go
+++ b/pkg/ccl/importccl/csv.go
@@ -1073,6 +1073,10 @@ func importPlanHook(
 				return err
 			}
 		} else {
+			if err := backupccl.CheckTableExists(ctx, p.Txn(), parentID, tableDesc.Name); err != nil {
+				return err
+			}
+
 			// Verification steps have passed, generate a new table ID if we're
 			// restoring. We do this last because we want to avoid calling
 			// GenerateUniqueDescID if there's any kind of error above.


### PR DESCRIPTION
Release note (bug fix): refuse to start an IMPORT job if the target
table already exsits.

Fixes #22554