### PR TITLE
cmd/roachtest: improve node selection

### DIFF
--- a/pkg/cmd/roachtest/roachmart.go
+++ b/pkg/cmd/roachtest/roachmart.go
@@ -23,12 +23,12 @@ import (
 func init() {
 	runRoachmart := func(t *test, partition bool) {
 		ctx := context.Background()
-		c := newCluster(ctx, t, "--geo", "--nodes", "9")
+		c := newCluster(ctx, t, 9, "--geo")
 		defer c.Destroy(ctx)
 
 		c.Put(ctx, cockroach, "<cockroach>")
 		c.Put(ctx, workload, "<workload>")
-		c.Start(ctx, 1, 9)
+		c.Start(ctx)
 
 		// TODO(benesch): avoid hardcoding this list.
 		nodes := []struct {

--- a/pkg/cmd/roachtest/tpcc.go
+++ b/pkg/cmd/roachtest/tpcc.go
@@ -23,14 +23,14 @@ import (
 func init() {
 	runTPCC := func(t *test, warehouses, nodes int, extra string) {
 		ctx := context.Background()
-		c := newCluster(ctx, t, "-n", nodes+1)
+		c := newCluster(ctx, t, nodes+1)
 		defer c.Destroy(ctx)
 
 		c.Put(ctx, cockroach, "<cockroach>")
 		c.Put(ctx, workload, "<workload>")
-		c.Start(ctx, 1, nodes)
+		c.Start(ctx, c.Range(1, nodes))
 
-		m := newMonitor(ctx, c)
+		m := newMonitor(ctx, c, c.Range(1, nodes))
 		m.Go(func(ctx context.Context) error {
 			duration := " --duration=" + ifLocal("10s", "10m")
 			cmd := fmt.Sprintf(
@@ -40,7 +40,7 @@ func init() {
 			c.Run(ctx, nodes+1, cmd)
 			return nil
 		})
-		m.Wait(1, nodes)
+		m.Wait()
 	}
 
 	tests.Add("tpcc/w=1/nodes=3", func(t *test) {


### PR DESCRIPTION
Improve node selection by adding `cluster.{All,Range,Node}()`
methods. The various `cluster` methods that take a nodes specification
now accept a list of options of which these node selectors are the only
existing type of option. To enable the above, changed `newCluster` so
that the number of nodes is an explicit parameter and clusters remember
the number of nodes they contain.

Release note: None