### PR TITLE
sql: disallow adding computed columns via ALTER

### DIFF
--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -80,6 +80,10 @@ func (n *alterTableNode) startExec(params runParams) error {
 				return pgerror.Unimplemented(
 					"alter add fk", "adding a REFERENCES constraint via ALTER not supported")
 			}
+			if d.Computed.Computed {
+				return pgerror.Unimplemented(
+					"alter add computed", "adding a computed column via ALTER not supported")
+			}
 			col, idx, expr, err := sqlbase.MakeColumnDefDescs(d, &params.p.semaCtx, params.EvalContext())
 			if err != nil {
 				return err

--- a/pkg/sql/logictest/testdata/logic_test/computed
+++ b/pkg/sql/logictest/testdata/logic_test/computed
@@ -495,4 +495,6 @@ WHERE table_name = 'x' and generation_expression = ''
 ----
 1
 
-# TODO(justin): adding computed columns.
+# TODO(justin): #22652
+statement error adding a computed column via ALTER not supported
+ALTER TABLE x ADD COLUMN c INT AS (4) STORED


### PR DESCRIPTION
See #22652.

Release note (sql change): Computed columns can no longer be added to a
table after table creation.