### PR TITLE
rpc: Perform initial-heartbeat validation on GRPC reconnections (take 2)

### DIFF
--- a/pkg/acceptance/localcluster/cluster.go
+++ b/pkg/acceptance/localcluster/cluster.go
@@ -479,7 +479,7 @@ func (n *Node) StatusClient() serverpb.StatusClient {
 		return existingClient
 	}
 
-	conn, err := n.rpcCtx.GRPCDialRaw(n.RPCAddr())
+	conn, _, err := n.rpcCtx.GRPCDialRaw(n.RPCAddr())
 	if err != nil {
 		log.Fatalf(context.Background(), "failed to initialize status client: %s", err)
 	}

--- a/pkg/cli/interactive_tests/common.tcl
+++ b/pkg/cli/interactive_tests/common.tcl
@@ -102,11 +102,7 @@ proc stop_server {argv} {
     # Trigger a normal shutdown.
     system "$argv quit"
     # If after 5 seconds the server hasn't shut down, trigger an error.
-
-    ## Re-enable this once issue #22536 is fixed.
-    # system "for i in `seq 1 5`; do kill -CONT `cat server_pid` 2>/dev/null || exit 0; echo still waiting; sleep 1; done; echo 'server still running?'; exit 0"
-    # Until #22536 is fixed use a violent kill.
-    system "for i in `seq 1 5`; do kill -CONT `cat server_pid` 2>/dev/null || exit 0; echo still waiting; sleep 1; done; echo 'server still running?'; kill -9 `cat server_pid`; exit 0"
+    system "for i in `seq 1 5`; do kill -CONT `cat server_pid` 2>/dev/null || exit 0; echo still waiting; sleep 1; done; echo 'server still running?'; exit 0"
 
     report "END STOP SERVER"
 }

--- a/pkg/rpc/context_test.go
+++ b/pkg/rpc/context_test.go
@@ -377,6 +377,14 @@ func TestHeartbeatHealthTransport(t *testing.T) {
 	}
 
 	isUnhealthy := func(err error) bool {
+		// Most of the time, an unhealthy connection will get
+		// ErrNotConnected, but there are brief periods during which we
+		// could get ErrNotHeartbeated (while we're trying to start a new
+		// connection) or one of the grpc errors below (while the old
+		// connection is in the middle of closing).
+		if err == ErrNotConnected || err == ErrNotHeartbeated {
+			return true
+		}
 		// The expected code here is Unavailable, but at least on OSX you can also get
 		//
 		// rpc error: code = Internal desc = connection error: desc = "transport: authentication
@@ -417,12 +425,16 @@ func TestHeartbeatHealthTransport(t *testing.T) {
 		if timeutil.Since(then) > 45*time.Second {
 			t.Fatal(err)
 		}
+		time.Sleep(10 * time.Millisecond)
 	}
 
 	close(done)
 
-	// Should become healthy again after GRPC reconnects.
+	// We can reconnect and the connection becomes healthy again.
 	testutils.SucceedsSoon(t, func() error {
+		if _, err := clientCtx.GRPCDial(remoteAddr).Connect(context.Background()); err != nil {
+			return err
+		}
 		return clientCtx.ConnHealth(remoteAddr)
 	})
 

--- a/pkg/util/grpcutil/grpc_util.go
+++ b/pkg/util/grpcutil/grpc_util.go
@@ -30,6 +30,11 @@ import (
 	"google.golang.org/grpc/transport"
 )
 
+// ErrCannotReuseClientConn is returned when a failed connection is
+// being reused. We require that new connections be created with
+// pkg/rpc.GRPCDial instead.
+var ErrCannotReuseClientConn = errors.New("cannot reuse client connection")
+
 type localRequestKey struct{}
 
 // NewLocalRequestContext returns a Context that can be used for local (in-process) requests.
@@ -46,6 +51,9 @@ func IsLocalRequestContext(ctx context.Context) bool {
 // on closed connections.
 func IsClosedConnection(err error) bool {
 	err = errors.Cause(err)
+	if err == ErrCannotReuseClientConn {
+		return true
+	}
 	if s, ok := status.FromError(err); ok {
 		if s.Code() == codes.Canceled ||
 			s.Code() == codes.Unavailable ||


### PR DESCRIPTION
The only difference from the previous version of this change is that
the new error has been moved from pkg/rpc to pkg/util/grpcutil,
and is included in IsClosedConnection. This suppresses the log message
that was causing intermittent failures in test_missing_log_output.tcl

Fixes #22536

This reverts commit 9b20d8aa15356b047ab9364b01de24363b063a17.