### PR TITLE
roachtest: test creating a fixture for tpcc-1000

### DIFF
--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -91,12 +91,12 @@ func initBinaries() {
 	var err error
 	cockroach, err = findBinary(cockroach, "cockroach")
 	if err != nil {
-		fmt.Fprint(os.Stderr, err)
+		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
 	workload, err = findBinary(workload, "workload")
 	if err != nil {
-		fmt.Fprint(os.Stderr, err)
+		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
 }
@@ -393,7 +393,7 @@ func (c *cluster) Stop(ctx context.Context, opts ...option) {
 	}
 }
 
-// wipe a subset of the nodes in a cluster. See cluster.Start() for a
+// Wipe a subset of the nodes in a cluster. See cluster.Start() for a
 // description of the nodes parameter.
 func (c *cluster) Wipe(ctx context.Context, opts ...option) {
 	if c.t.Failed() {

--- a/pkg/cmd/roachtest/import.go
+++ b/pkg/cmd/roachtest/import.go
@@ -1,0 +1,52 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+
+package main
+
+import (
+	"context"
+	"fmt"
+)
+
+func init() {
+	runImportTPCC := func(t *test, warehouses, nodes int) {
+		ctx := context.Background()
+		c := newCluster(ctx, t, nodes)
+		defer c.Destroy(ctx)
+
+		c.Put(ctx, cockroach, "<cockroach>")
+		c.Put(ctx, workload, "<workload>")
+		for node := 1; node <= nodes; node++ {
+			c.Run(ctx, node, `<workload> csv-server --port=8081 &> /dev/null < /dev/null &`)
+		}
+		c.Start(ctx, c.Range(1, nodes))
+
+		m := newMonitor(ctx, c, c.Range(1, nodes))
+		m.Go(func(ctx context.Context) error {
+			cmd := fmt.Sprintf(
+				`<workload> fixtures store tpcc --warehouses=%d --csv-server='http://localhost:8081' `+
+					`--gcs-bucket-override=cockroachdb-backup-testing --gcs-prefix-override=%s`,
+				warehouses, c.name)
+			c.Run(ctx, 1, cmd)
+			return nil
+		})
+		m.Wait()
+	}
+
+	const warehouses, nodes = 100, 4
+	tests.Add(fmt.Sprintf("import/tpcc/warehouses=%d/nodes=%d", warehouses, nodes), func(t *test) {
+		runImportTPCC(t, warehouses, nodes)
+	})
+}

--- a/pkg/cmd/workload/fixtures.go
+++ b/pkg/cmd/workload/fixtures.go
@@ -58,6 +58,16 @@ var fixturesStoreCSVServerURL = fixturesStoreCmd.PersistentFlags().String(
 	`csv-server`, ``,
 	`Skip saving CSVs to cloud storage, instead get them from a 'csv-server' running at this url`)
 
+// gcs-bucket-override and gcs-prefix-override are exposed for testing.
+var gcsBucketOverride, gcsPrefixOverride *string
+
+func init() {
+	gcsBucketOverride = fixturesStoreCmd.PersistentFlags().String(`gcs-bucket-override`, ``, ``)
+	gcsPrefixOverride = fixturesStoreCmd.PersistentFlags().String(`gcs-prefix-override`, ``, ``)
+	_ = fixturesStoreCmd.PersistentFlags().MarkHidden(`gcs-bucket-override`)
+	_ = fixturesStoreCmd.PersistentFlags().MarkHidden(`gcs-prefix-override`)
+}
+
 var fixturesLoadDB = fixturesLoadCmd.PersistentFlags().String(
 	`into-db`, `workload`, `SQL database to load fixture into`)
 
@@ -147,6 +157,12 @@ func fixturesStore(cmd *cobra.Command, gen workload.Generator, crdbURI string) e
 		return err
 	}
 	store := useast1bFixtures
+	if len(*gcsBucketOverride) > 0 {
+		store.GCSBucket = *gcsBucketOverride
+	}
+	if len(*gcsPrefixOverride) > 0 {
+		store.GCSPrefix = *gcsPrefixOverride
+	}
 	store.CSVServerURL = *fixturesStoreCSVServerURL
 	fixture, err := workloadccl.MakeFixture(ctx, sqlDB, gcs, store, gen)
 	if err != nil {


### PR DESCRIPTION
This test uses the new roachtest infrastructure to verify that
`./workload fixtures store` works for a 1000 warehouse TPCC backup.

Release note: None

cc @mjibson 