### PR TITLE
sql: dequalify column references

### DIFF
--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -181,8 +181,12 @@ func (n *alterTableNode) startExec(params runParams) error {
 				}
 
 			case *tree.CheckConstraintTableDef:
+				tableName, err := n.n.Table.Normalize()
+				if err != nil {
+					return err
+				}
 				ck, err := makeCheckConstraint(
-					*n.tableDesc, d, inuseNames, &params.p.semaCtx, params.EvalContext())
+					*n.tableDesc, d, inuseNames, &params.p.semaCtx, params.EvalContext(), *tableName)
 				if err != nil {
 					return err
 				}

--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/coltypes"
+	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/transform"
@@ -832,12 +833,14 @@ func makeTableDescIfAs(
 		if len(p.AsColumnNames) > i {
 			columnTableDef.Name = p.AsColumnNames[i]
 		}
+
 		col, _, _, err := sqlbase.MakeColumnDefDescs(&columnTableDef, semaCtx, evalCtx)
 		if err != nil {
 			return desc, err
 		}
 		desc.AddColumn(*col)
 	}
+
 	// AllocateIDs mutates its receiver. `return desc, desc.AllocateIDs()`
 	// happens to work in gc, but does not work in gccgo.
 	//
@@ -859,6 +862,29 @@ func validateComputedColumnHasNoImpureFunctions(e tree.TypedExpr, colName tree.N
 		return pgerror.NewError(pgerror.CodeInvalidTableDefinitionError, errMsg.String())
 	}
 	return nil
+}
+
+func dequalifyColumnRefs(sources sqlbase.MultiSourceInfo, expr tree.Expr) (tree.Expr, error) {
+	return tree.SimpleVisit(
+		expr,
+		func(expr tree.Expr) (err error, recurse bool, newExpr tree.Expr) {
+			if vBase, ok := expr.(tree.VarName); ok {
+				v, err := vBase.NormalizeVarName()
+				if err != nil {
+					return err, false, nil
+				}
+				if c, ok := v.(*tree.ColumnItem); ok {
+					srcIdx, colIdx, err := findColumn(sources, c)
+					if err != nil {
+						return err, false, nil
+					}
+					col := sources[srcIdx].SourceColumns[colIdx]
+					return nil, false, &tree.ColumnItem{ColumnName: tree.Name(col.Name)}
+				}
+			}
+			return nil, true, expr
+		},
+	)
 }
 
 // MakeTableDesc creates a table descriptor from a CreateTable statement.
@@ -935,6 +961,29 @@ func MakeTableDesc(
 		}
 	}
 
+	// Now that we've constructed our columns, we pop into any of our computed
+	// columns so that we can dequalify any column references.
+	sourceInfo := sqlbase.NewSourceInfoForSingleTable(
+		*tableName, sqlbase.ResultColumnsFromColDescs(desc.Columns),
+	)
+	sources := sqlbase.MultiSourceInfo{sourceInfo}
+
+	for i, col := range desc.Columns {
+		if col.IsComputed() {
+			expr, err := parser.ParseExpr(*col.ComputeExpr)
+			if err != nil {
+				return desc, err
+			}
+
+			expr, err = dequalifyColumnRefs(sources, expr)
+			if err != nil {
+				return desc, err
+			}
+			serialized := tree.Serialize(expr)
+			desc.Columns[i].ComputeExpr = &serialized
+		}
+	}
+
 	var primaryIndexColumnSet map[string]struct{}
 	for _, def := range n.Defs {
 		switch d := def.(type) {
@@ -993,7 +1042,6 @@ func MakeTableDesc(
 			if d.Interleave != nil {
 				return desc, pgerror.UnimplementedWithIssueError(9148, "use CREATE INDEX to make interleaved indexes")
 			}
-
 		case *tree.CheckConstraintTableDef, *tree.ForeignKeyConstraintTableDef, *tree.FamilyTableDef:
 			// pass, handled below.
 
@@ -1060,11 +1108,12 @@ func MakeTableDesc(
 					return desc, err
 				}
 			}
+
 		case *tree.IndexTableDef, *tree.UniqueConstraintTableDef, *tree.FamilyTableDef:
 			// Pass, handled above.
 
 		case *tree.CheckConstraintTableDef:
-			ck, err := makeCheckConstraint(desc, d, generatedNames, semaCtx, evalCtx)
+			ck, err := makeCheckConstraint(desc, d, generatedNames, semaCtx, evalCtx, *tableName)
 			if err != nil {
 				return desc, err
 			}
@@ -1369,6 +1418,7 @@ func makeCheckConstraint(
 	inuseNames map[string]struct{},
 	semaCtx *tree.SemaContext,
 	evalCtx *tree.EvalContext,
+	tableName tree.TableName,
 ) (*sqlbase.TableDescriptor_CheckConstraint, error) {
 	name := string(d.Name)
 
@@ -1402,8 +1452,18 @@ func makeCheckConstraint(
 	}
 	sort.Sort(sqlbase.ColumnIDs(colIDs))
 
+	sourceInfo := sqlbase.NewSourceInfoForSingleTable(
+		tableName, sqlbase.ResultColumnsFromColDescs(desc.Columns),
+	)
+	sources := sqlbase.MultiSourceInfo{sourceInfo}
+
+	expr, err = dequalifyColumnRefs(sources, d.Expr)
+	if err != nil {
+		return nil, err
+	}
+
 	return &sqlbase.TableDescriptor_CheckConstraint{
-		Expr:      tree.Serialize(d.Expr),
+		Expr:      tree.Serialize(expr),
 		Name:      name,
 		ColumnIDs: colIDs,
 	}, nil

--- a/pkg/sql/logictest/testdata/logic_test/check_constraints
+++ b/pkg/sql/logictest/testdata/logic_test/check_constraints
@@ -229,3 +229,47 @@ t7  CREATE TABLE t7 (
       CONSTRAINT check_y_z1 CHECK ((y + z) = 0),
       CONSTRAINT named_constraint CHECK (z = 1)
     )
+
+# Check that table references are dequalified in their stored representation.
+
+statement error source name "different_table" not found in FROM clause
+CREATE TABLE t8 (
+  a INT,
+  CHECK (different_table.a > 0)
+)
+
+statement error source name "different_database.t8" not found in FROM clause
+CREATE TABLE t8 (
+  a INT,
+  CHECK (different_database.t8.a > 0)
+)
+
+statement ok
+CREATE TABLE t8 (
+  a INT,
+  CHECK (a > 0),
+  CHECK (t8.a > 0),
+  CHECK (test.t8.a > 0)
+)
+
+query TT
+SHOW CREATE TABLE t8
+----
+t8  CREATE TABLE t8 (
+      a INT NULL,
+      FAMILY "primary" (a, rowid),
+      CONSTRAINT check_a CHECK (a > 0),
+      CONSTRAINT check_a1 CHECK (a > 0),
+      CONSTRAINT check_a2 CHECK (a > 0)
+    )
+
+statement ok
+CREATE DATABASE test2
+
+statement ok
+CREATE TABLE test2.t (
+  a INT,
+  CHECK (a > 0),
+  CHECK (t.a > 0),
+  CHECK (test2.t.a > 0)
+)

--- a/pkg/sql/logictest/testdata/logic_test/computed
+++ b/pkg/sql/logictest/testdata/logic_test/computed
@@ -272,7 +272,7 @@ CREATE TABLE y (
   b INT AS (a) STORED
 )
 
-statement error column "a" not found, referenced in "a"
+statement error column name "a" not found
 CREATE TABLE y (
   b INT AS (a) STORED
 )
@@ -362,9 +362,17 @@ CREATE TABLE y (
   r INT AS ((SELECT 1)) STORED
 )
 
-statement error column "a" not found, referenced in "x.a"
+# TODO(justin): better error message needed here.
+statement error source name "x" not found in FROM clause
 CREATE TABLE y (
   r INT AS (x.a) STORED
+)
+
+# TODO(justin): better error message needed here.
+statement error source name "x" not found in FROM clause
+CREATE TABLE y (
+  q INT,
+  r INT AS (x.q) STORED
 )
 
 statement ok
@@ -554,6 +562,24 @@ query T
 SELECT d FROM x
 ----
 {2,3,1}
+
+statement ok
+DROP TABLE x
+
+statement ok
+CREATE TABLE x (
+  a INT,
+  b INT as (x.a) STORED
+)
+
+query TT
+SHOW CREATE TABLE x
+----
+x CREATE TABLE x (
+    a INT NULL,
+    b INT NULL AS (a) STORED,
+    FAMILY "primary" (a, b, rowid)
+  )
 
 statement ok
 DROP TABLE x


### PR DESCRIPTION
Fixes #22415.

Applies to check constraints and computed columns.

I'm vaguely concerned I'm re-implementing some fundamental
name-resolution logic here, please point me towards the code I should be
using if that's the case.

Release note (bug fix): Expressions stored in check constraints and
computed columns are now stored dequalified so that they no longer
refer to a specific database or table.