### PR TITLE
opt: tag constant values

### DIFF
--- a/pkg/sql/opt/ops/scalar.opt
+++ b/pkg/sql/opt/ops/scalar.opt
@@ -22,7 +22,7 @@ define Variable {
 
 # Const is a typed scalar constant value. The private field is a tree.Datum
 # value having any datum type that's legal in the expression's context.
-[Scalar]
+[Scalar, ConstValue]
 define Const {
     Value Datum
 }
@@ -30,14 +30,14 @@ define Const {
 # True is the boolean true value that is equivalent to the tree.DBoolTrue datum
 # value. It is a separate operator to make matching and replacement simpler and
 # more efficient, as patterns can contain (True) expressions.
-[Scalar, Boolean]
+[Scalar, Boolean, ConstValue]
 define True {
 }
 
 # False is the boolean false value that is equivalent to the tree.DBoolFalse
 # datum value. It is a separate operator to make matching and replacement
 # simpler and more efficient, as patterns can contain (False) expressions.
-[Scalar, Boolean]
+[Scalar, Boolean, ConstValue]
 define False {
 }
 

--- a/pkg/sql/opt/opt/operator.og.go
+++ b/pkg/sql/opt/opt/operator.og.go
@@ -306,6 +306,12 @@ var ScalarOperators = [...]Operator{
 	FunctionOp,
 }
 
+var ConstValueOperators = [...]Operator{
+	ConstOp,
+	TrueOp,
+	FalseOp,
+}
+
 var BooleanOperators = [...]Operator{
 	TrueOp,
 	FalseOp,

--- a/pkg/sql/opt/xform/expr.og.go
+++ b/pkg/sql/opt/xform/expr.og.go
@@ -1934,6 +1934,89 @@ var isScalarLookup = [...]bool{
 	false, // PresentOp
 }
 
+var isConstValueLookup = [...]bool{
+	false, // UnknownOp
+
+	false, // SubqueryOp
+	false, // VariableOp
+	true,  // ConstOp
+	true,  // TrueOp
+	true,  // FalseOp
+	false, // PlaceholderOp
+	false, // TupleOp
+	false, // ProjectionsOp
+	false, // AggregationsOp
+	false, // GroupingsOp
+	false, // ExistsOp
+	false, // AndOp
+	false, // OrOp
+	false, // NotOp
+	false, // EqOp
+	false, // LtOp
+	false, // GtOp
+	false, // LeOp
+	false, // GeOp
+	false, // NeOp
+	false, // InOp
+	false, // NotInOp
+	false, // LikeOp
+	false, // NotLikeOp
+	false, // ILikeOp
+	false, // NotILikeOp
+	false, // SimilarToOp
+	false, // NotSimilarToOp
+	false, // RegMatchOp
+	false, // NotRegMatchOp
+	false, // RegIMatchOp
+	false, // NotRegIMatchOp
+	false, // IsOp
+	false, // IsNotOp
+	false, // ContainsOp
+	false, // BitandOp
+	false, // BitorOp
+	false, // BitxorOp
+	false, // PlusOp
+	false, // MinusOp
+	false, // MultOp
+	false, // DivOp
+	false, // FloorDivOp
+	false, // ModOp
+	false, // PowOp
+	false, // ConcatOp
+	false, // LShiftOp
+	false, // RShiftOp
+	false, // FetchValOp
+	false, // FetchTextOp
+	false, // FetchValPathOp
+	false, // FetchTextPathOp
+	false, // UnaryPlusOp
+	false, // UnaryMinusOp
+	false, // UnaryComplementOp
+	false, // FunctionOp
+	false, // ScanOp
+	false, // ValuesOp
+	false, // SelectOp
+	false, // ProjectOp
+	false, // InnerJoinOp
+	false, // LeftJoinOp
+	false, // RightJoinOp
+	false, // FullJoinOp
+	false, // SemiJoinOp
+	false, // AntiJoinOp
+	false, // InnerJoinApplyOp
+	false, // LeftJoinApplyOp
+	false, // RightJoinApplyOp
+	false, // FullJoinApplyOp
+	false, // SemiJoinApplyOp
+	false, // AntiJoinApplyOp
+	false, // GroupByOp
+	false, // UnionOp
+	false, // IntersectOp
+	false, // ExceptOp
+	false, // SortOp
+	false, // PresentOp
+}
+
 var isBooleanLookup = [...]bool{
 	false, // UnknownOp
 
@@ -2600,6 +2683,10 @@ var isEnforcerLookup = [...]bool{
 
 func (ev ExprView) IsScalar() bool {
 	return isScalarLookup[ev.op]
+}
+
+func (ev ExprView) IsConstValue() bool {
+	return isConstValueLookup[ev.op]
 }
 
 func (ev ExprView) IsBoolean() bool {


### PR DESCRIPTION
We have to handle TrueOp and FalseOp separately wherever we handle a
ConstOp. Adding a `ConstValue` tag to make the code less tedious.

Release note: None