### PR TITLE
sql: make copyMachine stop depending on a Session

### DIFF
--- a/pkg/sql/copy.go
+++ b/pkg/sql/copy.go
@@ -61,8 +61,12 @@ type copyMachine struct {
 	// conn is the pgwire connection from which data is to be read.
 	conn pgwirebase.Conn
 
-	session *Session
-	txnOpt  copyTxnOpt
+	execCfg *ExecutorConfig
+	// resetPlanner is a function to be used to prepare the planner for inserting
+	// data.
+	resetPlanner func(p *planner, txn *client.Txn, txnTS time.Time, stmtTS time.Time)
+
+	txnOpt copyTxnOpt
 
 	// p is the planner used to plan inserts. preparePlanner() needs to be called
 	// before preparing each new statement.
@@ -79,19 +83,25 @@ type copyMachine struct {
 
 // newCopyMachine creates a new copyMachine.
 func newCopyMachine(
-	ctx context.Context, conn pgwirebase.Conn, s *Session, n *tree.CopyFrom, txnOpt copyTxnOpt,
+	ctx context.Context,
+	conn pgwirebase.Conn,
+	n *tree.CopyFrom,
+	txnOpt copyTxnOpt,
+	execCfg *ExecutorConfig,
+	resetPlanner func(p *planner, txn *client.Txn, txnTS time.Time, stmtTS time.Time),
 ) (_ *copyMachine, retErr error) {
-	evalCtx := s.extendedEvalCtx(nil /* txn */, time.Time{} /* txnTimestamp */, time.Time{} /* stmtTimestamp */)
 	c := &copyMachine{
 		conn:    conn,
 		table:   &n.Table,
 		columns: n.Columns,
-		session: s,
 		txnOpt:  txnOpt,
 		// The planner will be prepared before use.
-		p:              planner{},
-		parsingEvalCtx: &evalCtx.EvalContext,
+		p:            planner{},
+		execCfg:      execCfg,
+		resetPlanner: resetPlanner,
 	}
+	c.resetPlanner(&c.p, nil /* txn */, time.Time{} /* txnTS */, time.Time{} /* stmtTS */)
+	c.parsingEvalCtx = c.p.EvalContext()
 
 	cleanup := c.preparePlanner(ctx)
 	defer func() {
@@ -253,15 +263,12 @@ func (c *copyMachine) preparePlanner(ctx context.Context) func(context.Context, 
 	stmtTs := c.txnOpt.stmtTimestamp
 	autoCommit := false
 	if txn == nil {
-		txn = client.NewTxn(c.session.execCfg.DB, c.session.execCfg.NodeID.Get(), client.RootTxn)
-		txnTs = c.session.execCfg.Clock.PhysicalTime()
+		txn = client.NewTxn(c.execCfg.DB, c.execCfg.NodeID.Get(), client.RootTxn)
+		txnTs = c.execCfg.Clock.PhysicalTime()
 		stmtTs = txnTs
 		autoCommit = true
 	}
-	c.session.resetPlanner(
-		&c.p, txn, txnTs, stmtTs,
-		nil /* reCache */, c.session.statsCollector(),
-	)
+	c.resetPlanner(&c.p, txn, txnTs, stmtTs)
 	c.p.autoCommit = autoCommit
 
 	return func(ctx context.Context, err error) error {

--- a/pkg/sql/executor.go
+++ b/pkg/sql/executor.go
@@ -1691,7 +1691,18 @@ func (e *Executor) execStmtInOpenTxn(
 				stmtTimestamp: e.cfg.Clock.PhysicalTime(),
 			}
 		}
-		cm, err := newCopyMachine(session.Ctx(), session.conn, session, s, txnOpt)
+		cm, err := newCopyMachine(
+			session.Ctx(), session.conn,
+			s,
+			txnOpt,
+			&e.cfg,
+			// resetPlanner
+			func(p *planner, txn *client.Txn, txnTS time.Time, stmtTS time.Time) {
+				session.resetPlanner(
+					p, txn, txnTS, stmtTS,
+					nil /* reCache */, session.statsCollector())
+			},
+		)
 		if err != nil {
 			return err
 		}

--- a/pkg/sql/pgwire/conn.go
+++ b/pkg/sql/pgwire/conn.go
@@ -544,12 +544,6 @@ func (c *conn) BeginCopyIn(ctx context.Context, columns []sqlbase.ResultColumn) 
 	return nil
 }
 
-// SendError is part of te pgwirebase.Conn interface.
-func (c *conn) SendError(err error) error {
-	// TODO(andrei)
-	return nil
-}
-
 // SendCommandComplete is part of the pgwirebase.Conn interface.
 func (c *conn) SendCommandComplete(tag []byte) error {
 	// TODO(andrei)

--- a/pkg/sql/pgwire/pgwirebase/conn.go
+++ b/pkg/sql/pgwire/pgwirebase/conn.go
@@ -30,9 +30,6 @@ type Conn interface {
 	// updating connection metrics.
 	Rd() BufferedReader
 
-	// SendError send an error message on the connection.
-	SendError(err error) error
-
 	// BeginCopyIn sends the message server message initiating the Copy-in
 	// subprotocol (COPY ... FROM STDIN). This message informs the client about
 	// the columns that are expected for the rows to be inserted.

--- a/pkg/sql/pgwire/v3.go
+++ b/pkg/sql/pgwire/v3.go
@@ -1293,11 +1293,6 @@ func (c *v3Conn) Rd() pgwirebase.BufferedReader {
 	return &pgwireReader{conn: c}
 }
 
-// SendError is part of te pgwirebase.Conn interface.
-func (c *v3Conn) SendError(err error) error {
-	return c.sendError(err)
-}
-
 // SendCommandComplete is part of the pgwirebase.Conn interface.
 func (c *v3Conn) SendCommandComplete(tag []byte) error {
 	return c.sendCommandComplete(tag, &c.streamingState.buf)


### PR DESCRIPTION
The copyMachine needed a Session because it asked it to set up a
planner. Since I'm trying to replace the Session with something else,
I've made the copyMachine take in just a callback for resetting the
planner.
The callback's signature is more narrow than before - it doesn't take a
txnTimestamp and a stmtTimestamp  (to be used as the result of the NOW()
function, and such). This is inconsequential - the INSERTs constructed
by the copy machine don't admit expressions.

Release note: None