### PR TITLE
cmd/docgen: dedup operator entries

### DIFF
--- a/docs/generated/sql/operators.md
+++ b/docs/generated/sql/operators.md
@@ -236,8 +236,6 @@
 <tr><td><a href="interval.html">interval</a> <code>=</code> <a href="interval.html">interval</a></td><td><a href="bool.html">bool</a></td></tr>
 <tr><td><a href="interval.html">interval[]</a> <code>=</code> <a href="interval.html">interval[]</a></td><td><a href="bool.html">bool</a></td></tr>
 <tr><td>jsonb <code>=</code> jsonb</td><td><a href="bool.html">bool</a></td></tr>
-<tr><td>jsonb <code>=</code> jsonb</td><td><a href="bool.html">bool</a></td></tr>
-<tr><td>oid <code>=</code> oid</td><td><a href="bool.html">bool</a></td></tr>
 <tr><td>oid <code>=</code> oid</td><td><a href="bool.html">bool</a></td></tr>
 <tr><td><a href="string.html">string</a> <code>=</code> <a href="string.html">string</a></td><td><a href="bool.html">bool</a></td></tr>
 <tr><td><a href="string.html">string[]</a> <code>=</code> <a href="string.html">string[]</a></td><td><a href="bool.html">bool</a></td></tr>
@@ -361,11 +359,6 @@
 <tr><td><a href="interval.html">interval[]</a> <code>||</code> <a href="interval.html">interval</a></td><td><a href="interval.html">interval[]</a></td></tr>
 <tr><td><a href="interval.html">interval[]</a> <code>||</code> <a href="interval.html">interval[]</a></td><td><a href="interval.html">interval[]</a></td></tr>
 <tr><td>jsonb <code>||</code> jsonb</td><td>jsonb</td></tr>
-<tr><td>jsonb <code>||</code> jsonb</td><td>jsonb</td></tr>
-<tr><td>jsonb <code>||</code> jsonb</td><td>jsonb</td></tr>
-<tr><td>jsonb <code>||</code> jsonb</td><td>jsonb</td></tr>
-<tr><td>oid <code>||</code> oid</td><td>oid</td></tr>
-<tr><td>oid <code>||</code> oid</td><td>oid</td></tr>
 <tr><td>oid <code>||</code> oid</td><td>oid</td></tr>
 <tr><td><a href="string.html">string</a> <code>||</code> <a href="string.html">string</a></td><td><a href="string.html">string</a></td></tr>
 <tr><td><a href="string.html">string</a> <code>||</code> <a href="string.html">string[]</a></td><td><a href="string.html">string[]</a></td></tr>

--- a/pkg/cmd/docgen/funcs.go
+++ b/pkg/cmd/docgen/funcs.go
@@ -147,12 +147,18 @@ func generateOperators() []byte {
 	}
 	sort.Strings(opstrs)
 	b := new(bytes.Buffer)
+	seen := map[string]bool{}
 	for _, op := range opstrs {
 		fmt.Fprintf(b, "<table><thead>\n")
 		fmt.Fprintf(b, "<tr><td><code>%s</code></td><td>Return</td></tr>\n", op)
 		fmt.Fprintf(b, "</thead><tbody>\n")
 		for _, v := range ops[op] {
-			fmt.Fprintf(b, "<tr><td>%s</td><td>%s</td></tr>\n", v.String(), linkTypeName(v.ret))
+			s := fmt.Sprintf("<tr><td>%s</td><td>%s</td></tr>\n", v.String(), linkTypeName(v.ret))
+			if seen[s] {
+				continue
+			}
+			seen[s] = true
+			b.WriteString(s)
 		}
 		fmt.Fprintf(b, "</tbody></table>")
 		fmt.Fprintln(b)


### PR DESCRIPTION
Due to stripping `[]` from the end of types in linkTypeName(), some
entries were being duplicated.

Release note: None