### PR TITLE
sql: cache role memberships.

### DIFF
--- a/pkg/sql/authorization.go
+++ b/pkg/sql/authorization.go
@@ -22,7 +22,20 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 )
+
+type membershipCache struct {
+	syncutil.Mutex
+	tableVersion sqlbase.DescriptorVersion
+	// userCache is a mapping from username to userRoleMembership.
+	userCache map[string]userRoleMembership
+}
+
+var roleMembersCache membershipCache
+
+// userRoleMembership is a mapping of "rolename" -> "with admin option".
+type userRoleMembership map[string]bool
 
 // AuthorizationAccessor for checking authorization (e.g. desc privileges).
 type AuthorizationAccessor interface {
@@ -143,8 +156,65 @@ func (p *planner) RequireSuperUser(ctx context.Context, action string) error {
 // MemberOfWithAdminOption looks up all the roles 'member' belongs to (direct and indirect) and
 // returns a map of "role" -> "isAdmin".
 // The "isAdmin" flag applies to both direct and indirect members.
-// TODO(mberhault): this is too expensive: we need some type of caching with change notification.
 func (p *planner) MemberOfWithAdminOption(
+	ctx context.Context, member string,
+) (map[string]bool, error) {
+	// Lookup table version.
+	tableName := tree.MakeTableName("system", "role_members")
+	tableDesc, err := p.getTableDesc(ctx, &tableName)
+	if err != nil {
+		return nil, err
+	}
+	tableVersion := tableDesc.Version
+
+	// We loop in case the table version changes while we're looking up memberships.
+	for {
+		// Check version and maybe clear cache while holding the mutex.
+		// We release the lock here instead of using defer as we need to keep
+		// going and re-lock if adding the looked-up entry.
+		roleMembersCache.Lock()
+		if roleMembersCache.tableVersion != tableVersion {
+			// Update version and drop the map.
+			roleMembersCache.tableVersion = tableDesc.Version
+			roleMembersCache.userCache = make(map[string]userRoleMembership)
+		}
+
+		userMapping, ok := roleMembersCache.userCache[member]
+		roleMembersCache.Unlock()
+
+		if ok {
+			// Found: return.
+			return userMapping, nil
+		}
+
+		// Lookup memberships outside the lock.
+		memberships, err := p.resolveMemberOfWithAdminOption(ctx, member)
+		if err != nil {
+			return nil, err
+		}
+
+		// Update membership.
+		roleMembersCache.Lock()
+		if roleMembersCache.tableVersion != tableVersion {
+			// Table version has changed while we were looking, unlock and start over.
+			tableVersion = roleMembersCache.tableVersion
+			roleMembersCache.Unlock()
+			continue
+		}
+
+		// Table version remains the same: update map, unlock, return.
+		roleMembersCache.userCache[member] = memberships
+		roleMembersCache.Unlock()
+
+		return memberships, nil
+	}
+}
+
+// resolveMemberOfWithAdminOption performs the actual recursive role membership lookup.
+// TODO(mberhault): this is the naive way and performs a full lookup for each user,
+// we could save detailed memberships (as opposed to fully expanded) and reuser them
+// across users. We may then want to lookup more than just this user.
+func (p *planner) resolveMemberOfWithAdminOption(
 	ctx context.Context, member string,
 ) (map[string]bool, error) {
 	ret := map[string]bool{}

--- a/pkg/sql/data_source.go
+++ b/pkg/sql/data_source.go
@@ -398,6 +398,17 @@ func (p *planner) getTableDesc(
 	return p.Tables().getTableVersion(ctx, p.txn, p.getVirtualTabler(), tn)
 }
 
+// bumpTableVersion loads the table descriptor for 'table', calls UpVersion and persists it.
+func (p *planner) bumpTableVersion(ctx context.Context, tn *tree.TableName) error {
+	tableDesc, err := MustGetTableOrViewDesc(
+		ctx, p.txn, p.getVirtualTabler(), tn, false /*allowAdding*/)
+	if err != nil {
+		return err
+	}
+
+	return p.saveNonmutationAndNotify(ctx, tableDesc)
+}
+
 func (p *planner) getPlanForDesc(
 	ctx context.Context,
 	desc *sqlbase.TableDescriptor,

--- a/pkg/sql/planhook.go
+++ b/pkg/sql/planhook.go
@@ -86,6 +86,7 @@ type PlanHookState interface {
 		ctx context.Context, namesE tree.Exprs, ifExists bool, isRole bool, opName string,
 	) (*DropUserNode, error)
 	GetAllUsersAndRoles(ctx context.Context) (map[string]bool, error)
+	BumpRoleMembershipTableVersion(ctx context.Context) error
 }
 
 // AddPlanHook adds a hook used to short-circuit creating a planNode from a

--- a/pkg/sql/user.go
+++ b/pkg/sql/user.go
@@ -99,3 +99,9 @@ func existingUserIsRole(
 	isRole := bool(*(values[0]).(*tree.DBool))
 	return isRole, nil
 }
+
+// BumpRoleMembershipTableVersion increases the table version for the role membership table.
+func (p *planner) BumpRoleMembershipTableVersion(ctx context.Context) error {
+	tableName := tree.MakeTableName("system", "role_members")
+	return p.bumpTableVersion(ctx, &tableName)
+}


### PR DESCRIPTION
Role memberships are now cached per user and refreshed when the
system.role_members table version changes.

We bump the version if rows were modified on:
* role membership deletion on user/role drop
* grant role membership
* revoke role membership

Release note: None