### PR TITLE
sql: don't panic on leftover bytes in production

### DIFF
--- a/pkg/base/config.go
+++ b/pkg/base/config.go
@@ -25,6 +25,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/cockroachdb/cockroach/pkg/security"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
@@ -440,7 +441,11 @@ type TempStorageConfig struct {
 // If parentDir is not specified and the specified store is in-memory,
 // then the temp storage will also be in-memory.
 func TempStorageConfigFromEnv(
-	ctx context.Context, firstStore StoreSpec, parentDir string, maxSizeBytes int64,
+	ctx context.Context,
+	st *cluster.Settings,
+	firstStore StoreSpec,
+	parentDir string,
+	maxSizeBytes int64,
 ) TempStorageConfig {
 	inMem := parentDir == "" && firstStore.InMemory
 	var monitor mon.BytesMonitor
@@ -452,6 +457,7 @@ func TempStorageConfigFromEnv(
 			nil,             /* maxHist */
 			1024*1024,       /* increment */
 			maxSizeBytes/10, /* noteworthy */
+			st,
 		)
 		monitor.Start(ctx, nil /* pool */, mon.MakeStandaloneBudget(maxSizeBytes))
 	} else {
@@ -462,6 +468,7 @@ func TempStorageConfigFromEnv(
 			nil,             /* maxHist */
 			64*1024*1024,    /* increment */
 			maxSizeBytes/10, /* noteworthy */
+			st,
 		)
 		monitor.Start(ctx, nil /* pool */, mon.MakeStandaloneBudget(maxSizeBytes))
 	}

--- a/pkg/base/test_server_args.go
+++ b/pkg/base/test_server_args.go
@@ -135,7 +135,7 @@ var (
 // DefaultTestTempStorageConfig is the associated temp storage for
 // DefaultTestStoreSpec that is in-memory.
 // It has a maximum size of 100MiB.
-func DefaultTestTempStorageConfig() TempStorageConfig {
+func DefaultTestTempStorageConfig(st *cluster.Settings) TempStorageConfig {
 	var maxSizeBytes int64 = DefaultInMemTempStorageMaxSizeBytes
 	monitor := mon.MakeMonitor(
 		"in-mem temp storage",
@@ -144,6 +144,7 @@ func DefaultTestTempStorageConfig() TempStorageConfig {
 		nil,             /* maxHist */
 		1024*1024,       /* increment */
 		maxSizeBytes/10, /* noteworthy */
+		st,
 	)
 	monitor.Start(context.Background(), nil /* pool */, mon.MakeStandaloneBudget(maxSizeBytes))
 	return TempStorageConfig{

--- a/pkg/cli/dump.go
+++ b/pkg/cli/dump.go
@@ -24,13 +24,13 @@ import (
 	"strings"
 	"time"
 
-	"github.com/cockroachdb/cockroach/pkg/sql/lex"
-	"golang.org/x/sync/errgroup"
-
-	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
-	"github.com/cockroachdb/cockroach/pkg/util/timeofday"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+	"golang.org/x/sync/errgroup"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/lex"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/util/timeofday"
 )
 
 // dumpCmd dumps SQL tables.
@@ -519,7 +519,8 @@ func dumpTableData(w io.Writer, conn *sqlConn, clusterTS string, bmd basicMetada
 							if err != nil {
 								return err
 							}
-							d, err = tree.ParseDArrayFromString(tree.NewTestingEvalContext(), string(t), elemType)
+							d, err = tree.ParseDArrayFromString(
+								tree.NewTestingEvalContext(serverCfg.Settings), string(t), elemType)
 							if err != nil {
 								return err
 							}

--- a/pkg/cli/start.go
+++ b/pkg/cli/start.go
@@ -45,6 +45,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/server"
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/cockroach/pkg/util/grpcutil"
@@ -278,7 +279,7 @@ func initExternalIODir(ctx context.Context, firstStore base.StoreSpec) (string, 
 }
 
 func initTempStorageConfig(
-	ctx context.Context, stopper *stop.Stopper, firstStore base.StoreSpec,
+	ctx context.Context, st *cluster.Settings, stopper *stop.Stopper, firstStore base.StoreSpec,
 ) (base.TempStorageConfig, error) {
 	var recordPath string
 	if !firstStore.InMemory {
@@ -333,6 +334,7 @@ func initTempStorageConfig(
 	// cli flags.
 	tempStorageConfig := base.TempStorageConfigFromEnv(
 		ctx,
+		st,
 		firstStore,
 		startCtx.tempDir,
 		tempStorageMaxSizeBytes,
@@ -437,7 +439,7 @@ func runStart(cmd *cobra.Command, args []string) error {
 	if serverCfg.Settings.ExternalIODir, err = initExternalIODir(ctx, serverCfg.Stores.Specs[0]); err != nil {
 		return err
 	}
-	if serverCfg.TempStorageConfig, err = initTempStorageConfig(ctx, stopper, serverCfg.Stores.Specs[0]); err != nil {
+	if serverCfg.TempStorageConfig, err = initTempStorageConfig(ctx, serverCfg.Settings, stopper, serverCfg.Stores.Specs[0]); err != nil {
 		return err
 	}
 

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -370,7 +370,7 @@ func MakeConfig(ctx context.Context, st *cluster.Settings) Config {
 			Specs: []base.StoreSpec{storeSpec},
 		},
 		TempStorageConfig: base.TempStorageConfigFromEnv(
-			ctx, storeSpec, "" /* parentDir */, base.DefaultTempStorageMaxSizeBytes),
+			ctx, st, storeSpec, "" /* parentDir */, base.DefaultTempStorageMaxSizeBytes),
 	}
 	cfg.AmbientCtx.Tracer = st.Tracer
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -302,6 +302,7 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 		nil,           /* maxHist */
 		-1,            /* increment: use default increment */
 		math.MaxInt64, /* noteworthy */
+		st,
 	)
 	rootSQLMemoryMonitor.Start(context.Background(), nil, mon.MakeStandaloneBudget(s.cfg.SQLMemoryPoolSize))
 
@@ -525,6 +526,7 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 	s.pgServer = pgwire.MakeServer(
 		s.cfg.AmbientCtx,
 		s.cfg.Config,
+		s.ClusterSettings(),
 		s.sqlExecutor,
 		&s.internalMemMetrics,
 		&rootSQLMemoryMonitor,

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -72,7 +72,7 @@ func makeTestConfig(st *cluster.Settings) Config {
 
 	// Configure the default in-memory temp storage for all tests unless
 	// otherwise configured.
-	cfg.TempStorageConfig = base.DefaultTestTempStorageConfig()
+	cfg.TempStorageConfig = base.DefaultTestTempStorageConfig(st)
 
 	// Load test certs. In addition, the tests requiring certs
 	// need to call security.SetAssetLoader(securitytest.EmbeddedAssets)

--- a/pkg/sql/builtin_mem_usage_test.go
+++ b/pkg/sql/builtin_mem_usage_test.go
@@ -20,13 +20,15 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/lib/pq"
+
 	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/builtins"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
-	"github.com/lib/pq"
 )
 
 // lowMemoryBudget is the memory budget used to test builtins are recording
@@ -131,7 +133,7 @@ func TestBuiltinsAccountForMemory(t *testing.T) {
 
 	for _, test := range testData {
 		t.Run("", func(t *testing.T) {
-			evalCtx := tree.NewTestingEvalContext()
+			evalCtx := tree.NewTestingEvalContext(cluster.MakeTestingClusterSettings())
 			defer evalCtx.Stop(context.Background())
 			defer evalCtx.ActiveMemAcc.Close(context.Background())
 			previouslyAllocated := evalCtx.ActiveMemAcc.Used()

--- a/pkg/sql/distsqlplan/physical_plan.go
+++ b/pkg/sql/distsqlplan/physical_plan.go
@@ -22,12 +22,13 @@ import (
 	"fmt"
 	"math"
 
+	"github.com/pkg/errors"
+
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/distsqlrun"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
-	"github.com/pkg/errors"
 )
 
 // Processor contains the information associated with a processor in a plan.

--- a/pkg/sql/distsqlrun/aggregator_test.go
+++ b/pkg/sql/distsqlrun/aggregator_test.go
@@ -350,11 +350,12 @@ func TestAggregator(t *testing.T) {
 
 			in := NewRowBuffer(c.inputTypes, c.input, RowBufferArgs{})
 			out := NewRowBuffer(c.outputTypes, nil /* rows */, RowBufferArgs{})
-			evalCtx := tree.MakeTestingEvalContext()
+			st := cluster.MakeTestingClusterSettings()
+			evalCtx := tree.MakeTestingEvalContext(st)
 			defer evalCtx.Stop(context.Background())
 			flowCtx := FlowCtx{
 				Ctx:      context.Background(),
-				Settings: cluster.MakeTestingClusterSettings(),
+				Settings: st,
 				EvalCtx:  evalCtx,
 			}
 
@@ -409,12 +410,13 @@ func BenchmarkAggregation(b *testing.B) {
 	}
 
 	ctx := context.Background()
-	evalCtx := tree.MakeTestingEvalContext()
+	st := cluster.MakeTestingClusterSettings()
+	evalCtx := tree.MakeTestingEvalContext(st)
 	defer evalCtx.Stop(ctx)
 
 	flowCtx := &FlowCtx{
 		Ctx:      ctx,
-		Settings: cluster.MakeTestingClusterSettings(),
+		Settings: st,
 		EvalCtx:  evalCtx,
 	}
 
@@ -452,12 +454,13 @@ func BenchmarkGrouping(b *testing.B) {
 	const numRows = 1000
 
 	ctx := context.Background()
-	evalCtx := tree.MakeTestingEvalContext()
+	st := cluster.MakeTestingClusterSettings()
+	evalCtx := tree.MakeTestingEvalContext(st)
 	defer evalCtx.Stop(ctx)
 
 	flowCtx := &FlowCtx{
 		Ctx:      ctx,
-		Settings: cluster.MakeTestingClusterSettings(),
+		Settings: st,
 		EvalCtx:  evalCtx,
 	}
 	spec := &AggregatorSpec{

--- a/pkg/sql/distsqlrun/algebraic_set_op_test.go
+++ b/pkg/sql/distsqlrun/algebraic_set_op_test.go
@@ -85,10 +85,11 @@ func runProcessors(tc testCase) (sqlbase.EncDatumRows, error) {
 	inR := NewRowBuffer(types, tc.inputRight, RowBufferArgs{})
 	out := NewRowBuffer(types, nil /* rows */, RowBufferArgs{})
 
+	st := cluster.MakeTestingClusterSettings()
 	flowCtx := FlowCtx{
 		Ctx:      context.Background(),
-		Settings: cluster.MakeTestingClusterSettings(),
-		EvalCtx:  tree.MakeTestingEvalContext(),
+		Settings: st,
+		EvalCtx:  tree.MakeTestingEvalContext(st),
 	}
 
 	s, err := newAlgebraicSetOp(&flowCtx, &tc.spec, inL, inR, &PostProcessSpec{}, out)
@@ -225,12 +226,13 @@ func BenchmarkExceptAll(b *testing.B) {
 	const numRows = 1000
 
 	ctx := context.Background()
-	evalCtx := tree.MakeTestingEvalContext()
+	st := cluster.MakeTestingClusterSettings()
+	evalCtx := tree.MakeTestingEvalContext(st)
 	defer evalCtx.Stop(ctx)
 
 	flowCtx := &FlowCtx{
 		Ctx:      ctx,
-		Settings: cluster.MakeTestingClusterSettings(),
+		Settings: st,
 		EvalCtx:  evalCtx,
 	}
 	spec := &AlgebraicSetOpSpec{

--- a/pkg/sql/distsqlrun/disk_row_container_test.go
+++ b/pkg/sql/distsqlrun/disk_row_container_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
@@ -62,7 +63,8 @@ func TestDiskRowContainer(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	ctx := context.Background()
-	tempEngine, err := engine.NewTempEngine(base.DefaultTestTempStorageConfig())
+	st := cluster.MakeTestingClusterSettings()
+	tempEngine, err := engine.NewTempEngine(base.DefaultTestTempStorageConfig(st))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -101,7 +103,7 @@ func TestDiskRowContainer(t *testing.T) {
 
 	rng := rand.New(rand.NewSource(timeutil.Now().UnixNano()))
 
-	evalCtx := tree.MakeTestingEvalContext()
+	evalCtx := tree.MakeTestingEvalContext(st)
 	diskMonitor := mon.MakeMonitor(
 		"test-disk",
 		mon.DiskResource,
@@ -109,6 +111,7 @@ func TestDiskRowContainer(t *testing.T) {
 		nil, /* maxHist */
 		-1,  /* increment: use default block size */
 		math.MaxInt64,
+		st,
 	)
 	diskMonitor.Start(ctx, nil /* pool */, mon.MakeStandaloneBudget(math.MaxInt64))
 	defer diskMonitor.Stop(ctx)
@@ -242,7 +245,8 @@ func TestDiskRowContainerDiskFull(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	ctx := context.Background()
-	tempEngine, err := engine.NewTempEngine(base.DefaultTestTempStorageConfig())
+	st := cluster.MakeTestingClusterSettings()
+	tempEngine, err := engine.NewTempEngine(base.DefaultTestTempStorageConfig(st))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -256,6 +260,7 @@ func TestDiskRowContainerDiskFull(t *testing.T) {
 		nil, /* maxHist */
 		-1,  /* increment: use default block size */
 		math.MaxInt64,
+		st,
 	)
 	monitor.Start(ctx, nil, mon.MakeStandaloneBudget(0 /* capacity */))
 

--- a/pkg/sql/distsqlrun/distinct_test.go
+++ b/pkg/sql/distsqlrun/distinct_test.go
@@ -137,11 +137,12 @@ func TestDistinct(t *testing.T) {
 			in := NewRowBuffer(twoIntCols, c.input, RowBufferArgs{})
 			out := &RowBuffer{}
 
-			evalCtx := tree.MakeTestingEvalContext()
+			st := cluster.MakeTestingClusterSettings()
+			evalCtx := tree.MakeTestingEvalContext(st)
 			defer evalCtx.Stop(context.Background())
 			flowCtx := FlowCtx{
 				Ctx:      context.Background(),
-				Settings: cluster.MakeTestingClusterSettings(),
+				Settings: st,
 				EvalCtx:  evalCtx,
 			}
 
@@ -175,12 +176,13 @@ func BenchmarkDistinct(b *testing.B) {
 	const numRows = 1000
 
 	ctx := context.Background()
-	evalCtx := tree.MakeTestingEvalContext()
+	st := cluster.MakeTestingClusterSettings()
+	evalCtx := tree.MakeTestingEvalContext(st)
 	defer evalCtx.Stop(ctx)
 
 	flowCtx := &FlowCtx{
 		Ctx:      ctx,
-		Settings: cluster.MakeTestingClusterSettings(),
+		Settings: st,
 		EvalCtx:  evalCtx,
 	}
 	spec := &DistinctSpec{

--- a/pkg/sql/distsqlrun/input_sync_test.go
+++ b/pkg/sql/distsqlrun/input_sync_test.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
@@ -112,7 +113,7 @@ func TestOrderedSync(t *testing.T) {
 			rowBuf := NewRowBuffer(threeIntCols, srcRows, RowBufferArgs{})
 			sources = append(sources, rowBuf)
 		}
-		evalCtx := tree.NewTestingEvalContext()
+		evalCtx := tree.NewTestingEvalContext(cluster.MakeTestingClusterSettings())
 		defer evalCtx.Stop(context.Background())
 		src, err := makeOrderedSync(c.ordering, evalCtx, sources)
 		if err != nil {

--- a/pkg/sql/distsqlrun/interleaved_reader_joiner_test.go
+++ b/pkg/sql/distsqlrun/interleaved_reader_joiner_test.go
@@ -393,7 +393,7 @@ func TestInterleavedReaderJoiner(t *testing.T) {
 
 	for i, tc := range testCases {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
-			evalCtx := tree.MakeTestingEvalContext()
+			evalCtx := tree.MakeTestingEvalContext(s.ClusterSettings())
 			defer evalCtx.Stop(context.Background())
 			flowCtx := FlowCtx{
 				Ctx:      context.Background(),
@@ -522,7 +522,7 @@ func TestInterleavedReaderJoinerErrors(t *testing.T) {
 
 	for i, tc := range testCases {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
-			evalCtx := tree.MakeTestingEvalContext()
+			evalCtx := tree.MakeTestingEvalContext(s.ClusterSettings())
 			defer evalCtx.Stop(context.Background())
 			flowCtx := FlowCtx{
 				EvalCtx:  evalCtx,

--- a/pkg/sql/distsqlrun/joinreader_test.go
+++ b/pkg/sql/distsqlrun/joinreader_test.go
@@ -157,12 +157,13 @@ func TestJoinReader(t *testing.T) {
 	}
 	for _, c := range testCases {
 		t.Run(c.description, func(t *testing.T) {
-			evalCtx := tree.MakeTestingEvalContext()
+			st := cluster.MakeTestingClusterSettings()
+			evalCtx := tree.MakeTestingEvalContext(st)
 			defer evalCtx.Stop(context.Background())
 			flowCtx := FlowCtx{
 				Ctx:      context.Background(),
 				EvalCtx:  evalCtx,
-				Settings: cluster.MakeTestingClusterSettings(),
+				Settings: st,
 				txn:      client.NewTxn(s.DB(), s.NodeID(), client.RootTxn),
 			}
 
@@ -231,7 +232,7 @@ func TestJoinReaderDrain(t *testing.T) {
 	)
 	td := sqlbase.GetTableDescriptor(kvDB, "test", "t")
 
-	evalCtx := tree.MakeTestingEvalContext()
+	evalCtx := tree.MakeTestingEvalContext(s.ClusterSettings())
 	defer evalCtx.Stop(context.Background())
 	flowCtx := FlowCtx{
 		Ctx:      context.Background(),

--- a/pkg/sql/distsqlrun/mergejoiner_test.go
+++ b/pkg/sql/distsqlrun/mergejoiner_test.go
@@ -698,11 +698,12 @@ func TestMergeJoiner(t *testing.T) {
 			leftInput := NewRowBuffer(c.leftTypes, c.leftInput, RowBufferArgs{})
 			rightInput := NewRowBuffer(c.rightTypes, c.rightInput, RowBufferArgs{})
 			out := &RowBuffer{}
-			evalCtx := tree.MakeTestingEvalContext()
+			st := cluster.MakeTestingClusterSettings()
+			evalCtx := tree.MakeTestingEvalContext(st)
 			defer evalCtx.Stop(context.Background())
 			flowCtx := FlowCtx{
 				Ctx:      context.Background(),
-				Settings: cluster.MakeTestingClusterSettings(),
+				Settings: st,
 				EvalCtx:  evalCtx,
 			}
 
@@ -805,11 +806,12 @@ func TestConsumerClosed(t *testing.T) {
 			out := &RowBuffer{}
 			out.ConsumerDone()
 
-			evalCtx := tree.MakeTestingEvalContext()
+			st := cluster.MakeTestingClusterSettings()
+			evalCtx := tree.MakeTestingEvalContext(st)
 			defer evalCtx.Stop(context.Background())
 			flowCtx := FlowCtx{
 				Ctx:      context.Background(),
-				Settings: cluster.MakeTestingClusterSettings(),
+				Settings: st,
 				EvalCtx:  evalCtx,
 			}
 			post := PostProcessSpec{Projection: true, OutputColumns: outCols}
@@ -829,11 +831,12 @@ func TestConsumerClosed(t *testing.T) {
 
 func BenchmarkMergeJoiner(b *testing.B) {
 	ctx := context.Background()
-	evalCtx := tree.MakeTestingEvalContext()
+	st := cluster.MakeTestingClusterSettings()
+	evalCtx := tree.MakeTestingEvalContext(st)
 	defer evalCtx.Stop(ctx)
 	flowCtx := &FlowCtx{
 		Ctx:      ctx,
-		Settings: cluster.MakeTestingClusterSettings(),
+		Settings: st,
 		EvalCtx:  evalCtx,
 	}
 

--- a/pkg/sql/distsqlrun/outbox_test.go
+++ b/pkg/sql/distsqlrun/outbox_test.go
@@ -42,10 +42,11 @@ func TestOutbox(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	evalCtx := tree.MakeTestingEvalContext()
+	st := cluster.MakeTestingClusterSettings()
+	evalCtx := tree.MakeTestingEvalContext(st)
 	defer evalCtx.Stop(context.Background())
 	flowCtx := FlowCtx{
-		Settings: cluster.MakeTestingClusterSettings(),
+		Settings: st,
 		stopper:  stopper,
 		EvalCtx:  evalCtx,
 		rpcCtx:   newInsecureRPCContext(stopper),
@@ -192,10 +193,11 @@ func TestOutboxInitializesStreamBeforeRecevingAnyRows(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	evalCtx := tree.MakeTestingEvalContext()
+	st := cluster.MakeTestingClusterSettings()
+	evalCtx := tree.MakeTestingEvalContext(st)
 	defer evalCtx.Stop(context.Background())
 	flowCtx := FlowCtx{
-		Settings: cluster.MakeTestingClusterSettings(),
+		Settings: st,
 		stopper:  stopper,
 		EvalCtx:  evalCtx,
 		rpcCtx:   newInsecureRPCContext(stopper),
@@ -260,10 +262,11 @@ func TestOutboxClosesWhenConsumerCloses(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			evalCtx := tree.MakeTestingEvalContext()
+			st := cluster.MakeTestingClusterSettings()
+			evalCtx := tree.MakeTestingEvalContext(st)
 			defer evalCtx.Stop(context.Background())
 			flowCtx := FlowCtx{
-				Settings: cluster.MakeTestingClusterSettings(),
+				Settings: st,
 				stopper:  stopper,
 				EvalCtx:  evalCtx,
 				rpcCtx:   newInsecureRPCContext(stopper),
@@ -385,10 +388,11 @@ func TestOutboxCancelsFlowOnError(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	evalCtx := tree.MakeTestingEvalContext()
+	st := cluster.MakeTestingClusterSettings()
+	evalCtx := tree.MakeTestingEvalContext(st)
 	defer evalCtx.Stop(context.Background())
 	flowCtx := FlowCtx{
-		Settings: cluster.MakeTestingClusterSettings(),
+		Settings: st,
 		stopper:  stopper,
 		EvalCtx:  evalCtx,
 		rpcCtx:   newInsecureRPCContext(stopper),

--- a/pkg/sql/distsqlrun/processors_test.go
+++ b/pkg/sql/distsqlrun/processors_test.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -254,7 +255,7 @@ func TestPostProcess(t *testing.T) {
 			outBuf := &RowBuffer{}
 
 			var out ProcOutputHelper
-			evalCtx := tree.NewTestingEvalContext()
+			evalCtx := tree.NewTestingEvalContext(cluster.MakeTestingClusterSettings())
 			defer evalCtx.Stop(context.Background())
 			if err := out.Init(&tc.post, inBuf.OutputTypes(), evalCtx, outBuf); err != nil {
 				t.Fatal(err)

--- a/pkg/sql/distsqlrun/routers_test.go
+++ b/pkg/sql/distsqlrun/routers_test.go
@@ -65,7 +65,7 @@ func TestRouters(t *testing.T) {
 
 	rng, _ := randutil.NewPseudoRand()
 	alloc := &sqlbase.DatumAlloc{}
-	evalCtx := tree.NewTestingEvalContext()
+	evalCtx := tree.NewTestingEvalContext(cluster.MakeTestingClusterSettings())
 	defer evalCtx.Stop(context.Background())
 
 	// Generate tables of possible values for each column; we have fewer possible
@@ -272,7 +272,7 @@ var (
 func TestConsumerStatus(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	evalCtx := tree.NewTestingEvalContext()
+	evalCtx := tree.NewTestingEvalContext(cluster.MakeTestingClusterSettings())
 	defer evalCtx.Stop(context.Background())
 
 	testCases := []struct {
@@ -422,7 +422,7 @@ func preimageAttack(
 func TestMetadataIsForwarded(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	evalCtx := tree.NewTestingEvalContext()
+	evalCtx := tree.NewTestingEvalContext(cluster.MakeTestingClusterSettings())
 	defer evalCtx.Stop(context.Background())
 
 	testCases := []struct {
@@ -572,7 +572,8 @@ func TestRouterBlocks(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			flowCtx := FlowCtx{Settings: cluster.MakeTestingClusterSettings(), EvalCtx: tree.MakeTestingEvalContext()}
+			st := cluster.MakeTestingClusterSettings()
+			flowCtx := FlowCtx{Settings: st, EvalCtx: tree.MakeTestingEvalContext(st)}
 			router.init(&flowCtx, colTypes)
 			var wg sync.WaitGroup
 			router.start(context.TODO(), &wg, nil /* ctxCancel */)

--- a/pkg/sql/distsqlrun/row_container_test.go
+++ b/pkg/sql/distsqlrun/row_container_test.go
@@ -19,6 +19,7 @@ import (
 	"math"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
@@ -35,7 +36,7 @@ func TestRowContainerReplaceMax(t *testing.T) {
 	ctx := context.Background()
 	rng, _ := randutil.NewPseudoRand()
 
-	evalCtx := tree.NewTestingEvalContext()
+	evalCtx := tree.NewTestingEvalContext(cluster.MakeTestingClusterSettings())
 	defer evalCtx.Stop(ctx)
 
 	typeInt := sqlbase.ColumnType{SemanticType: sqlbase.ColumnType_INT}

--- a/pkg/sql/distsqlrun/sample_aggregator_test.go
+++ b/pkg/sql/distsqlrun/sample_aggregator_test.go
@@ -39,11 +39,12 @@ func TestSampleAggregator(t *testing.T) {
 	server, sqlDB, kvDB := serverutils.StartServer(t, base.TestServerArgs{})
 	defer server.Stopper().Stop(context.TODO())
 
-	evalCtx := tree.MakeTestingEvalContext()
+	st := cluster.MakeTestingClusterSettings()
+	evalCtx := tree.MakeTestingEvalContext(st)
 	defer evalCtx.Stop(context.Background())
 	flowCtx := FlowCtx{
 		Ctx:      context.Background(),
-		Settings: cluster.MakeTestingClusterSettings(),
+		Settings: st,
 		EvalCtx:  evalCtx,
 		clientDB: kvDB,
 		executor: server.InternalExecutor().(sqlutil.InternalExecutor),

--- a/pkg/sql/distsqlrun/sampler_test.go
+++ b/pkg/sql/distsqlrun/sampler_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/axiomhq/hyperloglog"
+
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
@@ -43,11 +44,12 @@ func runSampler(t *testing.T, numRows, numSamples int) []int {
 
 	out := NewRowBuffer(outTypes, nil /* rows */, RowBufferArgs{})
 
-	evalCtx := tree.MakeTestingEvalContext()
+	st := cluster.MakeTestingClusterSettings()
+	evalCtx := tree.MakeTestingEvalContext(st)
 	defer evalCtx.Stop(context.Background())
 	flowCtx := FlowCtx{
 		Ctx:      context.Background(),
-		Settings: cluster.MakeTestingClusterSettings(),
+		Settings: st,
 		EvalCtx:  evalCtx,
 	}
 
@@ -148,11 +150,12 @@ func TestSamplerSketch(t *testing.T) {
 
 	out := NewRowBuffer(outTypes, nil /* rows */, RowBufferArgs{})
 
-	evalCtx := tree.MakeTestingEvalContext()
+	st := cluster.MakeTestingClusterSettings()
+	evalCtx := tree.MakeTestingEvalContext(st)
 	defer evalCtx.Stop(context.Background())
 	flowCtx := FlowCtx{
 		Ctx:      context.Background(),
-		Settings: cluster.MakeTestingClusterSettings(),
+		Settings: st,
 		EvalCtx:  evalCtx,
 	}
 

--- a/pkg/sql/distsqlrun/server.go
+++ b/pkg/sql/distsqlrun/server.go
@@ -175,6 +175,7 @@ func NewServer(ctx context.Context, cfg ServerConfig) *ServerImpl {
 			cfg.Metrics.MaxBytesHist,
 			-1, /* increment: use default block size */
 			noteworthyMemoryUsageBytes,
+			cfg.Settings,
 		),
 	}
 	ds.memMonitor.Start(ctx, cfg.ParentMemoryMonitor, mon.BoundAccount{})
@@ -298,6 +299,7 @@ func (ds *ServerImpl) setupFlow(
 		ds.Metrics.MaxBytesHist,
 		-1, /* use default block size */
 		noteworthyMemoryUsageBytes,
+		ds.Settings,
 	)
 	monitor.Start(ctx, &ds.memMonitor, mon.BoundAccount{})
 	acc := monitor.MakeBoundAccount()

--- a/pkg/sql/distsqlrun/sorter_test.go
+++ b/pkg/sql/distsqlrun/sorter_test.go
@@ -270,13 +270,14 @@ func TestSorter(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	tempEngine, err := engine.NewTempEngine(base.DefaultTestTempStorageConfig())
+	st := cluster.MakeTestingClusterSettings()
+	tempEngine, err := engine.NewTempEngine(base.DefaultTestTempStorageConfig(st))
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer tempEngine.Close()
 
-	evalCtx := tree.MakeTestingEvalContext()
+	evalCtx := tree.MakeTestingEvalContext(st)
 	defer evalCtx.Stop(ctx)
 	diskMonitor := mon.MakeMonitor(
 		"test-disk",
@@ -285,6 +286,7 @@ func TestSorter(t *testing.T) {
 		nil, /* maxHist */
 		-1,  /* increment: use default block size */
 		math.MaxInt64,
+		st,
 	)
 	diskMonitor.Start(ctx, nil /* pool */, mon.MakeStandaloneBudget(math.MaxInt64))
 	defer diskMonitor.Stop(ctx)
@@ -360,11 +362,12 @@ func TestSorter(t *testing.T) {
 // BenchmarkSortAll times how long it takes to sort an input of varying length.
 func BenchmarkSortAll(b *testing.B) {
 	ctx := context.Background()
-	evalCtx := tree.MakeTestingEvalContext()
+	st := cluster.MakeTestingClusterSettings()
+	evalCtx := tree.MakeTestingEvalContext(st)
 	defer evalCtx.Stop(ctx)
 	flowCtx := FlowCtx{
 		Ctx:      ctx,
-		Settings: cluster.MakeTestingClusterSettings(),
+		Settings: st,
 		EvalCtx:  evalCtx,
 	}
 
@@ -404,11 +407,12 @@ func BenchmarkSortAll(b *testing.B) {
 // varying limits.
 func BenchmarkSortLimit(b *testing.B) {
 	ctx := context.Background()
-	evalCtx := tree.MakeTestingEvalContext()
+	st := cluster.MakeTestingClusterSettings()
+	evalCtx := tree.MakeTestingEvalContext(st)
 	defer evalCtx.Stop(ctx)
 	flowCtx := FlowCtx{
 		Ctx:      ctx,
-		Settings: cluster.MakeTestingClusterSettings(),
+		Settings: st,
 		EvalCtx:  evalCtx,
 	}
 

--- a/pkg/sql/distsqlrun/tablereader_test.go
+++ b/pkg/sql/distsqlrun/tablereader_test.go
@@ -120,7 +120,7 @@ func TestTableReader(t *testing.T) {
 					ts := c.spec
 					ts.Table = *td
 
-					evalCtx := tree.MakeTestingEvalContext()
+					evalCtx := tree.MakeTestingEvalContext(s.ClusterSettings())
 					defer evalCtx.Stop(context.Background())
 					flowCtx := FlowCtx{
 						Ctx:      context.Background(),
@@ -199,13 +199,14 @@ ALTER TABLE t TESTING_RELOCATE VALUES (ARRAY[2], 1), (ARRAY[1], 2), (ARRAY[3], 3
 	kvDB := tc.Server(0).DB()
 	td := sqlbase.GetTableDescriptor(kvDB, "test", "t")
 
-	evalCtx := tree.MakeTestingEvalContext()
+	st := tc.Server(0).ClusterSettings()
+	evalCtx := tree.MakeTestingEvalContext(st)
 	defer evalCtx.Stop(context.Background())
 	nodeID := tc.Server(0).NodeID()
 	flowCtx := FlowCtx{
 		Ctx:      context.Background(),
 		EvalCtx:  evalCtx,
-		Settings: tc.Server(0).ClusterSettings(),
+		Settings: st,
 		txn:      client.NewTxn(tc.Server(0).DB(), nodeID, client.RootTxn),
 		nodeID:   nodeID,
 	}
@@ -292,7 +293,7 @@ func BenchmarkTableReader(b *testing.B) {
 
 	tableDesc := sqlbase.GetTableDescriptor(kvDB, "test", "t")
 
-	evalCtx := tree.MakeTestingEvalContext()
+	evalCtx := tree.MakeTestingEvalContext(s.ClusterSettings())
 	defer evalCtx.Stop(context.Background())
 	flowCtx := FlowCtx{
 		Ctx:      context.Background(),

--- a/pkg/sql/distsqlrun/values_test.go
+++ b/pkg/sql/distsqlrun/values_test.go
@@ -70,9 +70,10 @@ func TestValues(t *testing.T) {
 					}
 
 					out := &RowBuffer{}
+					st := cluster.MakeTestingClusterSettings()
 					flowCtx := FlowCtx{
 						Ctx:      context.Background(),
-						Settings: cluster.MakeTestingClusterSettings(),
+						Settings: st,
 					}
 
 					v, err := newValuesProcessor(&flowCtx, &spec, &PostProcessSpec{}, out)
@@ -97,7 +98,7 @@ func TestValues(t *testing.T) {
 						t.Fatalf("incorrect number of rows %d, expected %d", len(res), numRows)
 					}
 
-					evalCtx := tree.NewTestingEvalContext()
+					evalCtx := tree.NewTestingEvalContext(st)
 					defer evalCtx.Stop(context.Background())
 					var a sqlbase.DatumAlloc
 					for i := 0; i < numRows; i++ {

--- a/pkg/sql/expr_filter_test.go
+++ b/pkg/sql/expr_filter_test.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -183,7 +184,7 @@ func TestSplitFilter(t *testing.T) {
 	p := makeTestPlanner()
 	for _, d := range testData {
 		t.Run(fmt.Sprintf("%s~(%s, %s)", d.expr, d.expectedRes, d.expectedRem), func(t *testing.T) {
-			p.extendedEvalCtx = makeTestingExtendedEvalContext()
+			p.extendedEvalCtx = makeTestingExtendedEvalContext(cluster.MakeTestingClusterSettings())
 			defer p.extendedEvalCtx.Stop(context.Background())
 			sel := makeSelectNode(t, p)
 			// A function that "converts" only vars in the list.
@@ -266,7 +267,7 @@ func TestExtractNotNullConstraints(t *testing.T) {
 	p := makeTestPlanner()
 	for _, tc := range testCases {
 		t.Run(tc.expr, func(t *testing.T) {
-			p.extendedEvalCtx = makeTestingExtendedEvalContext()
+			p.extendedEvalCtx = makeTestingExtendedEvalContext(cluster.MakeTestingClusterSettings())
 			defer p.extendedEvalCtx.Stop(context.Background())
 
 			sel := makeSelectNode(t, p)

--- a/pkg/sql/group_test.go
+++ b/pkg/sql/group_test.go
@@ -19,6 +19,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
@@ -48,7 +49,7 @@ func TestDesiredAggregateOrder(t *testing.T) {
 	p := makeTestPlanner()
 	for _, d := range testData {
 		t.Run(d.expr, func(t *testing.T) {
-			p.extendedEvalCtx = makeTestingExtendedEvalContext()
+			p.extendedEvalCtx = makeTestingExtendedEvalContext(cluster.MakeTestingClusterSettings())
 			defer p.extendedEvalCtx.Stop(context.Background())
 			sel := makeSelectNode(t, p)
 			expr := parseAndNormalizeExpr(t, p, d.expr, sel)

--- a/pkg/sql/opt/index_constraints_spans_test.go
+++ b/pkg/sql/opt/index_constraints_spans_test.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -162,7 +163,8 @@ func TestIntersectSpan(t *testing.T) {
 		},
 	}
 
-	evalCtx := tree.MakeTestingEvalContext()
+	st := cluster.MakeTestingClusterSettings()
+	evalCtx := tree.MakeTestingEvalContext(st)
 
 	for i, tc := range testData {
 		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
@@ -313,7 +315,8 @@ func TestMergeSpanSets(t *testing.T) {
 		},
 	}
 
-	evalCtx := tree.MakeTestingEvalContext()
+	st := cluster.MakeTestingClusterSettings()
+	evalCtx := tree.MakeTestingEvalContext(st)
 
 	for i, tc := range testData {
 		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
@@ -376,7 +379,8 @@ expected: %v
 func TestIsSpanSubset(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	evalCtx := tree.MakeTestingEvalContext()
+	st := cluster.MakeTestingClusterSettings()
+	evalCtx := tree.MakeTestingEvalContext(st)
 
 	rng, _ := randutil.NewPseudoRand()
 	for n := 0; n < 500; n++ {

--- a/pkg/sql/opt/index_constraints_test.go
+++ b/pkg/sql/opt/index_constraints_test.go
@@ -18,6 +18,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/testutils"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 )
@@ -76,7 +77,8 @@ func BenchmarkIndexConstraints(b *testing.B) {
 				b.Fatal(err)
 			}
 
-			evalCtx := tree.MakeTestingEvalContext()
+			st := cluster.MakeTestingClusterSettings()
+			evalCtx := tree.MakeTestingEvalContext(st)
 			e, err := BuildScalarExpr(typedExpr, &evalCtx)
 			if err != nil {
 				b.Fatal(err)

--- a/pkg/sql/opt/opt_test.go
+++ b/pkg/sql/opt/opt_test.go
@@ -81,6 +81,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
@@ -134,7 +135,8 @@ func TestOpt(t *testing.T) {
 				var colInfos []IndexColumnInfo
 				var invertedIndex bool
 				var typedExpr tree.TypedExpr
-				evalCtx := tree.MakeTestingEvalContext()
+				st := cluster.MakeTestingClusterSettings()
+				evalCtx := tree.MakeTestingEvalContext(st)
 
 				for _, arg := range d.CmdArgs {
 					key := arg

--- a/pkg/sql/opt_decompose_test.go
+++ b/pkg/sql/opt_decompose_test.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
@@ -141,7 +142,7 @@ func TestSplitOrExpr(t *testing.T) {
 	p := makeTestPlanner()
 	for _, d := range testData {
 		t.Run(d.expr+"~"+d.expected, func(t *testing.T) {
-			p.extendedEvalCtx = makeTestingExtendedEvalContext()
+			p.extendedEvalCtx = makeTestingExtendedEvalContext(cluster.MakeTestingClusterSettings())
 			defer p.extendedEvalCtx.Stop(context.Background())
 			sel := makeSelectNode(t, p)
 			expr := parseAndNormalizeExpr(t, p, d.expr, sel)
@@ -168,7 +169,7 @@ func TestSplitAndExpr(t *testing.T) {
 	p := makeTestPlanner()
 	for _, d := range testData {
 		t.Run(d.expr+"~"+d.expected, func(t *testing.T) {
-			p.extendedEvalCtx = makeTestingExtendedEvalContext()
+			p.extendedEvalCtx = makeTestingExtendedEvalContext(cluster.MakeTestingClusterSettings())
 			defer p.extendedEvalCtx.Stop(context.Background())
 			sel := makeSelectNode(t, p)
 			expr := parseAndNormalizeExpr(t, p, d.expr, sel)
@@ -292,7 +293,7 @@ func TestSimplifyExpr(t *testing.T) {
 	p := makeTestPlanner()
 	for _, d := range testData {
 		t.Run(d.expr+"~"+d.expected, func(t *testing.T) {
-			p.extendedEvalCtx = makeTestingExtendedEvalContext()
+			p.extendedEvalCtx = makeTestingExtendedEvalContext(cluster.MakeTestingClusterSettings())
 			defer p.extendedEvalCtx.Stop(context.Background())
 			sel := makeSelectNode(t, p)
 			// We need to manually close this memory account because we're doing the
@@ -348,7 +349,7 @@ func TestSimplifyNotExpr(t *testing.T) {
 	p := makeTestPlanner()
 	for _, d := range testData {
 		t.Run(d.expr+"~"+d.expected, func(t *testing.T) {
-			p.extendedEvalCtx = makeTestingExtendedEvalContext()
+			p.extendedEvalCtx = makeTestingExtendedEvalContext(cluster.MakeTestingClusterSettings())
 			defer p.extendedEvalCtx.Stop(context.Background())
 			sel := makeSelectNode(t, p)
 			expr1 := parseAndNormalizeExpr(t, p, d.expr, sel)
@@ -386,7 +387,7 @@ func TestSimplifyAndExpr(t *testing.T) {
 	p := makeTestPlanner()
 	for _, d := range testData {
 		t.Run(d.expr+"~"+d.expected, func(t *testing.T) {
-			p.extendedEvalCtx = makeTestingExtendedEvalContext()
+			p.extendedEvalCtx = makeTestingExtendedEvalContext(cluster.MakeTestingClusterSettings())
 			defer p.extendedEvalCtx.Stop(context.Background())
 			sel := makeSelectNode(t, p)
 			expr1 := parseAndNormalizeExpr(t, p, d.expr, sel)
@@ -592,7 +593,7 @@ func TestSimplifyAndExprCheck(t *testing.T) {
 	p := makeTestPlanner()
 	for _, d := range testData {
 		t.Run(d.expr+"~"+d.expected, func(t *testing.T) {
-			p.extendedEvalCtx = makeTestingExtendedEvalContext()
+			p.extendedEvalCtx = makeTestingExtendedEvalContext(cluster.MakeTestingClusterSettings())
 			defer p.extendedEvalCtx.Stop(context.Background())
 			sel := makeSelectNode(t, p)
 			expr1 := parseAndNormalizeExpr(t, p, d.expr, sel)
@@ -645,7 +646,7 @@ func TestSimplifyOrExpr(t *testing.T) {
 	p := makeTestPlanner()
 	for _, d := range testData {
 		t.Run(d.expr+"~"+d.expected, func(t *testing.T) {
-			p.extendedEvalCtx = makeTestingExtendedEvalContext()
+			p.extendedEvalCtx = makeTestingExtendedEvalContext(cluster.MakeTestingClusterSettings())
 			defer p.extendedEvalCtx.Stop(context.Background())
 			sel := makeSelectNode(t, p)
 			expr1 := parseAndNormalizeExpr(t, p, d.expr, sel)
@@ -821,7 +822,7 @@ func TestSimplifyOrExprCheck(t *testing.T) {
 	p := makeTestPlanner()
 	for _, d := range testData {
 		t.Run(d.expr+"~"+d.expected, func(t *testing.T) {
-			p.extendedEvalCtx = makeTestingExtendedEvalContext()
+			p.extendedEvalCtx = makeTestingExtendedEvalContext(cluster.MakeTestingClusterSettings())
 			defer p.extendedEvalCtx.Stop(context.Background())
 			sel := makeSelectNode(t, p)
 			expr1 := parseAndNormalizeExpr(t, p, d.expr, sel)

--- a/pkg/sql/opt_index_selection_test.go
+++ b/pkg/sql/opt_index_selection_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
@@ -181,7 +182,7 @@ func TestMakeSpans(t *testing.T) {
 				} else {
 					expected = d.expectedDesc
 				}
-				p.extendedEvalCtx = makeTestingExtendedEvalContext()
+				p.extendedEvalCtx = makeTestingExtendedEvalContext(cluster.MakeTestingClusterSettings())
 				defer p.extendedEvalCtx.Stop(context.Background())
 				sel := makeSelectNode(t, p)
 				columns := strings.Split(d.columns, ",")
@@ -229,7 +230,7 @@ func TestMakeSpans(t *testing.T) {
 
 	for _, d := range testData2 {
 		t.Run(d.expr+"~"+d.expected, func(t *testing.T) {
-			p.extendedEvalCtx = makeTestingExtendedEvalContext()
+			p.extendedEvalCtx = makeTestingExtendedEvalContext(cluster.MakeTestingClusterSettings())
 			defer p.extendedEvalCtx.Stop(context.Background())
 			sel := makeSelectNode(t, p)
 			desc, index := makeTestIndexFromStr(t, d.columns)
@@ -322,7 +323,7 @@ func TestExactPrefix(t *testing.T) {
 	p := makeTestPlanner()
 	for _, d := range testData {
 		t.Run(fmt.Sprintf("%s~%d", d.expr, d.expected), func(t *testing.T) {
-			p.extendedEvalCtx = makeTestingExtendedEvalContext()
+			p.extendedEvalCtx = makeTestingExtendedEvalContext(cluster.MakeTestingClusterSettings())
 			defer p.extendedEvalCtx.Stop(context.Background())
 			sel := makeSelectNode(t, p)
 			desc, index := makeTestIndexFromStr(t, d.columns)

--- a/pkg/sql/pgwire/binary_test.go
+++ b/pkg/sql/pgwire/binary_test.go
@@ -28,6 +28,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgwirebase"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
@@ -71,7 +72,7 @@ func testBinaryDatumType(t *testing.T, typ string, datumConstructor func(val str
 			if buf.err != nil {
 				t.Fatal(buf.err)
 			}
-			evalCtx := tree.NewTestingEvalContext()
+			evalCtx := tree.NewTestingEvalContext(cluster.MakeTestingClusterSettings())
 			defer evalCtx.Stop(context.Background())
 			if got := buf.wrapped.Bytes(); !bytes.Equal(got, test.Expect) {
 				t.Errorf("%q:\n\t%v found,\n\t%v expected", test.In, got, test.Expect)
@@ -180,7 +181,7 @@ func TestBinaryIntArray(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	evalCtx := tree.NewTestingEvalContext()
+	evalCtx := tree.NewTestingEvalContext(cluster.MakeTestingClusterSettings())
 	defer evalCtx.Stop(context.Background())
 	if got.Compare(evalCtx, d) != 0 {
 		t.Fatalf("expected %s, got %s", d, got)
@@ -244,7 +245,7 @@ func TestRandomBinaryDecimal(t *testing.T) {
 		if buf.err != nil {
 			t.Fatal(buf.err)
 		}
-		evalCtx := tree.NewTestingEvalContext()
+		evalCtx := tree.NewTestingEvalContext(cluster.MakeTestingClusterSettings())
 		if got := buf.wrapped.Bytes(); !bytes.Equal(got, test.Expect) {
 			t.Errorf("%q:\n\t%v found,\n\t%v expected", test.In, got, test.Expect)
 		} else if datum, err := pgwirebase.DecodeOidDatum(

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -222,14 +222,14 @@ func newInternalPlanner(
 		mon.MemoryResource,
 		memMetrics.SessionCurBytesCount,
 		memMetrics.SessionMaxBytesHist,
-		-1, noteworthyInternalMemoryUsageBytes/5)
+		-1, noteworthyInternalMemoryUsageBytes/5, execCfg.Settings)
 	s.sessionMon.Start(ctx, &s.mon, mon.BoundAccount{})
 
 	s.TxnState.mon = mon.MakeMonitor("internal-txn",
 		mon.MemoryResource,
 		memMetrics.TxnCurBytesCount,
 		memMetrics.TxnMaxBytesHist,
-		-1, noteworthyInternalMemoryUsageBytes/5)
+		-1, noteworthyInternalMemoryUsageBytes/5, execCfg.Settings)
 	s.TxnState.mon.Start(ctx, &s.mon, mon.BoundAccount{})
 
 	var ts time.Time

--- a/pkg/sql/results_writer_test.go
+++ b/pkg/sql/results_writer_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/security"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
@@ -45,7 +46,7 @@ func withExecutor(test func(e *Executor, s *Session, evalCtx *tree.EvalContext),
 	ctx, span := ac.AnnotateCtxWithSpan(context.Background(), "test")
 	defer span.Finish()
 
-	evalCtx := tree.NewTestingEvalContext()
+	evalCtx := tree.NewTestingEvalContext(cluster.MakeTestingClusterSettings())
 	defer evalCtx.Stop(context.Background())
 
 	e := s.Executor().(*Executor)
@@ -184,6 +185,7 @@ func TestBufferedWriterReset(t *testing.T) {
 		nil,           /* maxHist */
 		-1,            /* increment: use default block size */
 		math.MaxInt64, /* noteworthy */
+		cluster.MakeTestingClusterSettings(),
 	)
 	memMon.Start(ctx, nil /* pool */, mon.MakeStandaloneBudget(math.MaxInt64))
 	defer memMon.Stop(ctx)

--- a/pkg/sql/sem/builtins/aggregate_builtins_test.go
+++ b/pkg/sql/sem/builtins/aggregate_builtins_test.go
@@ -20,6 +20,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
@@ -36,7 +37,7 @@ import (
 func testAggregateResultDeepCopy(
 	t *testing.T, aggFunc func([]types.T, *tree.EvalContext) tree.AggregateFunc, vals []tree.Datum,
 ) {
-	evalCtx := tree.NewTestingEvalContext()
+	evalCtx := tree.NewTestingEvalContext(cluster.MakeTestingClusterSettings())
 	defer evalCtx.Stop(context.Background())
 	aggImpl := aggFunc([]types.T{vals[0].ResolvedType()}, evalCtx)
 	runningDatums := make([]tree.Datum, len(vals))
@@ -276,7 +277,7 @@ func testArrayAggAliasedTypeOverload(t *testing.T, expected types.T) {
 func runBenchmarkAggregate(
 	b *testing.B, aggFunc func([]types.T, *tree.EvalContext) tree.AggregateFunc, vals []tree.Datum,
 ) {
-	evalCtx := tree.NewTestingEvalContext()
+	evalCtx := tree.NewTestingEvalContext(cluster.MakeTestingClusterSettings())
 	defer evalCtx.Stop(context.Background())
 	params := []types.T{vals[0].ResolvedType()}
 	b.ResetTimer()

--- a/pkg/sql/sem/builtins/builtins_test.go
+++ b/pkg/sql/sem/builtins/builtins_test.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
 )
@@ -103,7 +104,8 @@ func TestStringToArray(t *testing.T) {
 				}
 			}
 
-			if result.Compare(tree.NewTestingEvalContext(), expectedArray) != 0 {
+			evalContext := tree.NewTestingEvalContext(cluster.MakeTestingClusterSettings())
+			if result.Compare(evalContext, expectedArray) != 0 {
 				t.Fatalf("expected %v, got %v", tc.expected, result)
 			}
 		})

--- a/pkg/sql/sem/tree/collatedstring_test.go
+++ b/pkg/sql/sem/tree/collatedstring_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/coltypes"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
 )
@@ -40,7 +41,7 @@ func TestCastToCollatedString(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			evalCtx := NewTestingEvalContext()
+			evalCtx := NewTestingEvalContext(cluster.MakeTestingClusterSettings())
 			defer evalCtx.Stop(context.Background())
 			val, err := typedexpr.Eval(evalCtx)
 			if err != nil {

--- a/pkg/sql/sem/tree/compare_test.go
+++ b/pkg/sql/sem/tree/compare_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
 )
 
@@ -51,7 +52,7 @@ func TestEvalComparisonExprCaching(t *testing.T) {
 			Left:     NewDString(d.left),
 			Right:    NewDString(d.right),
 		}
-		ctx := NewTestingEvalContext()
+		ctx := NewTestingEvalContext(cluster.MakeTestingClusterSettings())
 		defer ctx.Mon.Stop(context.Background())
 		ctx.ReCache = NewRegexpCache(8)
 		typedExpr, err := TypeCheck(expr, nil, types.Any)

--- a/pkg/sql/sem/tree/constant_test.go
+++ b/pkg/sql/sem/tree/constant_test.go
@@ -25,7 +25,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/apd"
-
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
@@ -333,7 +333,7 @@ func TestStringConstantResolveAvailableTypes(t *testing.T) {
 					i, availType, test.c, res)
 			} else {
 				expectedDatum := parseFuncs[availType](t, test.c.RawString())
-				evalCtx := tree.NewTestingEvalContext()
+				evalCtx := tree.NewTestingEvalContext(cluster.MakeTestingClusterSettings())
 				defer evalCtx.Stop(context.Background())
 				if res.Compare(evalCtx, expectedDatum) != 0 {
 					t.Errorf("%d: type %s expected to be resolved from the tree.StrVal %v to tree.Datum %v"+

--- a/pkg/sql/sem/tree/datum_test.go
+++ b/pkg/sql/sem/tree/datum_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
@@ -40,7 +41,7 @@ func prepareExpr(t *testing.T, datumExpr string) tree.TypedExpr {
 		t.Fatalf("%s: %v", datumExpr, err)
 	}
 	// Normalization ensures that casts are processed.
-	evalCtx := tree.NewTestingEvalContext()
+	evalCtx := tree.NewTestingEvalContext(cluster.MakeTestingClusterSettings())
 	defer evalCtx.Stop(context.Background())
 	typedExpr, err = evalCtx.NormalizeExpr(typedExpr)
 	if err != nil {
@@ -221,7 +222,7 @@ func TestDatumOrdering(t *testing.T) {
 		{`row(row(false), ARRAY[true])`, noPrev, `((false), ARRAY[true,NULL])`,
 			`((false), ARRAY[])`, noMax},
 	}
-	ctx := tree.NewTestingEvalContext()
+	ctx := tree.NewTestingEvalContext(cluster.MakeTestingClusterSettings())
 	for _, td := range testData {
 		expr := prepareExpr(t, td.datumExpr)
 
@@ -314,7 +315,7 @@ func TestDFloatCompare(t *testing.T) {
 			} else if i > j {
 				expected = 1
 			}
-			evalCtx := tree.NewTestingEvalContext()
+			evalCtx := tree.NewTestingEvalContext(cluster.MakeTestingClusterSettings())
 			defer evalCtx.Stop(context.Background())
 			got := x.Compare(evalCtx, y)
 			if got != expected {
@@ -364,7 +365,7 @@ func TestParseDIntervalWithField(t *testing.T) {
 			t.Errorf("unexpected error while parsing expected value INTERVAL %s: %s", td.expected, err)
 			continue
 		}
-		evalCtx := tree.NewTestingEvalContext()
+		evalCtx := tree.NewTestingEvalContext(cluster.MakeTestingClusterSettings())
 		defer evalCtx.Stop(context.Background())
 		if expected.Compare(evalCtx, actual) != 0 {
 			t.Errorf("INTERVAL %s %v: got %s, expected %s", td.str, td.field, actual, expected)
@@ -405,7 +406,7 @@ func TestParseDDate(t *testing.T) {
 			t.Errorf("unexpected error while parsing expected value DATE %s: %s", td.expected, err)
 			continue
 		}
-		evalCtx := tree.NewTestingEvalContext()
+		evalCtx := tree.NewTestingEvalContext(cluster.MakeTestingClusterSettings())
 		defer evalCtx.Stop(context.Background())
 		if expected.Compare(evalCtx, actual) != 0 {
 			t.Errorf("DATE %s: got %s, expected %s", td.str, actual, expected)
@@ -574,7 +575,7 @@ func TestMakeDJSON(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if j1.Compare(tree.NewTestingEvalContext(), j2) != -1 {
+	if j1.Compare(tree.NewTestingEvalContext(cluster.MakeTestingClusterSettings()), j2) != -1 {
 		t.Fatal("expected JSON 1 < 2")
 	}
 }

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -2334,9 +2334,10 @@ type EvalContext struct {
 }
 
 // MakeTestingEvalContext returns an EvalContext that includes a MemoryMonitor.
-func MakeTestingEvalContext() EvalContext {
+func MakeTestingEvalContext(st *cluster.Settings) EvalContext {
 	ctx := EvalContext{
 		SessionData: &sessiondata.SessionData{},
+		Settings:    st,
 	}
 	monitor := mon.MakeMonitor(
 		"test-monitor",
@@ -2345,6 +2346,7 @@ func MakeTestingEvalContext() EvalContext {
 		nil,           /* maxHist */
 		-1,            /* increment */
 		math.MaxInt64, /* noteworthy */
+		st,
 	)
 	monitor.Start(context.Background(), nil /* pool */, mon.MakeStandaloneBudget(math.MaxInt64))
 	ctx.Mon = &monitor
@@ -2375,8 +2377,8 @@ func (ctx *EvalContext) PopIVarHelper() {
 
 // NewTestingEvalContext is a convenience version of MakeTestingEvalContext
 // that returns a pointer.
-func NewTestingEvalContext() *EvalContext {
-	ctx := MakeTestingEvalContext()
+func NewTestingEvalContext(st *cluster.Settings) *EvalContext {
+	ctx := MakeTestingEvalContext(st)
 	return &ctx
 }
 

--- a/pkg/sql/sem/tree/eval_test.go
+++ b/pkg/sql/sem/tree/eval_test.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	_ "github.com/cockroachdb/cockroach/pkg/sql/sem/builtins"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -1089,7 +1090,7 @@ func TestEval(t *testing.T) {
 		{`'192.168.2.1'::inet <<= '192.168.2.1'::inet`, `true`},
 		{`'192.168.200.95'::inet && '192.168.2.1/8'::inet`, `true`},
 	}
-	ctx := tree.NewTestingEvalContext()
+	ctx := tree.NewTestingEvalContext(cluster.MakeTestingClusterSettings())
 	// We have to manually close this account because we're doing the evaluations
 	// ourselves.
 	defer ctx.Mon.Stop(context.Background())
@@ -1198,7 +1199,7 @@ func TestTimeConversion(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		ctx := tree.NewTestingEvalContext()
+		ctx := tree.NewTestingEvalContext(cluster.MakeTestingClusterSettings())
 		defer ctx.Mon.Stop(context.Background())
 		exprStr := fmt.Sprintf("experimental_strptime('%s', '%s')", test.start, test.format)
 		expr, err := parser.ParseExpr(exprStr)
@@ -1340,7 +1341,7 @@ func TestEvalError(t *testing.T) {
 		}
 		typedExpr, err := tree.TypeCheck(expr, nil, types.Any)
 		if err == nil {
-			evalCtx := tree.NewTestingEvalContext()
+			evalCtx := tree.NewTestingEvalContext(cluster.MakeTestingClusterSettings())
 			defer evalCtx.Stop(context.Background())
 			_, err = typedExpr.Eval(evalCtx)
 		}

--- a/pkg/sql/sem/tree/expr_test.go
+++ b/pkg/sql/sem/tree/expr_test.go
@@ -19,6 +19,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	_ "github.com/cockroachdb/cockroach/pkg/sql/sem/builtins"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -178,7 +179,7 @@ func TestExprString(t *testing.T) {
 			t.Errorf("Print/parse/print cycle changes the string: `%s` vs `%s`", str, str2)
 		}
 		// Compare the normalized expressions.
-		ctx := tree.NewTestingEvalContext()
+		ctx := tree.NewTestingEvalContext(cluster.MakeTestingClusterSettings())
 		defer ctx.Mon.Stop(context.Background())
 		normalized, err := ctx.NormalizeExpr(typedExpr)
 		if err != nil {

--- a/pkg/sql/sem/tree/indexed_vars_test.go
+++ b/pkg/sql/sem/tree/indexed_vars_test.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
 )
 
@@ -93,7 +94,7 @@ func TestIndexedVars(t *testing.T) {
 	if !typ.Equivalent(types.Int) {
 		t.Errorf("invalid expression type %s", typ)
 	}
-	evalCtx := NewTestingEvalContext()
+	evalCtx := NewTestingEvalContext(cluster.MakeTestingClusterSettings())
 	defer evalCtx.Stop(context.Background())
 	evalCtx.IVarHelper = semaContext.IVarHelper
 	d, err := typedExpr.Eval(evalCtx)

--- a/pkg/sql/sem/tree/like_test.go
+++ b/pkg/sql/sem/tree/like_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
 )
 
@@ -77,7 +78,7 @@ func benchmarkLike(b *testing.B, ctx *EvalContext, caseInsensitive bool) {
 }
 
 func BenchmarkLikeWithCache(b *testing.B) {
-	ctx := NewTestingEvalContext()
+	ctx := NewTestingEvalContext(cluster.MakeTestingClusterSettings())
 	ctx.ReCache = NewRegexpCache(len(benchmarkLikePatterns))
 	defer ctx.Mon.Stop(context.Background())
 
@@ -85,14 +86,14 @@ func BenchmarkLikeWithCache(b *testing.B) {
 }
 
 func BenchmarkLikeWithoutCache(b *testing.B) {
-	evalCtx := NewTestingEvalContext()
+	evalCtx := NewTestingEvalContext(cluster.MakeTestingClusterSettings())
 	defer evalCtx.Stop(context.Background())
 
 	benchmarkLike(b, evalCtx, false)
 }
 
 func BenchmarkILikeWithCache(b *testing.B) {
-	ctx := NewTestingEvalContext()
+	ctx := NewTestingEvalContext(cluster.MakeTestingClusterSettings())
 	ctx.ReCache = NewRegexpCache(len(benchmarkLikePatterns))
 	defer ctx.Mon.Stop(context.Background())
 
@@ -100,7 +101,7 @@ func BenchmarkILikeWithCache(b *testing.B) {
 }
 
 func BenchmarkILikeWithoutCache(b *testing.B) {
-	evalCtx := NewTestingEvalContext()
+	evalCtx := NewTestingEvalContext(cluster.MakeTestingClusterSettings())
 	defer evalCtx.Stop(context.Background())
 
 	benchmarkLike(b, evalCtx, true)

--- a/pkg/sql/sem/tree/normalize_test.go
+++ b/pkg/sql/sem/tree/normalize_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	_ "github.com/cockroachdb/cockroach/pkg/sql/sem/builtins"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -227,7 +228,7 @@ func TestNormalizeExpr(t *testing.T) {
 				t.Fatalf("%s: %v", d.expr, err)
 			}
 			rOrig := typedExpr.String()
-			ctx := tree.NewTestingEvalContext()
+			ctx := tree.NewTestingEvalContext(cluster.MakeTestingClusterSettings())
 			defer ctx.Mon.Stop(context.Background())
 			defer ctx.ActiveMemAcc.Close(context.Background())
 			r, err := ctx.NormalizeExpr(typedExpr)

--- a/pkg/sql/sem/tree/parse_array_test.go
+++ b/pkg/sql/sem/tree/parse_array_test.go
@@ -19,6 +19,7 @@ import (
 	"math/rand"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/coltypes"
 )
 
@@ -88,11 +89,12 @@ lo}`, coltypes.String, Datums{NewDString(`hel`), NewDString(`lo`)}},
 					t.Fatal(err)
 				}
 			}
-			actual, err := ParseDArrayFromString(NewTestingEvalContext(), td.str, td.typ)
+			evalContext := NewTestingEvalContext(cluster.MakeTestingClusterSettings())
+			actual, err := ParseDArrayFromString(evalContext, td.str, td.typ)
 			if err != nil {
 				t.Fatalf("ARRAY %s: got error %s, expected %s", td.str, err.Error(), expected)
 			}
-			if actual.Compare(NewTestingEvalContext(), expected) != 0 {
+			if actual.Compare(evalContext, expected) != 0 {
 				t.Fatalf("ARRAY %s: got %s, expected %s", td.str, actual, expected)
 			}
 		})
@@ -137,7 +139,8 @@ func TestParseArrayRandomParseArray(t *testing.T) {
 		}
 		buf.WriteByte('}')
 
-		parsed, err := ParseDArrayFromString(NewTestingEvalContext(), buf.String(), coltypes.String)
+		parsed, err := ParseDArrayFromString(
+			NewTestingEvalContext(cluster.MakeTestingClusterSettings()), buf.String(), coltypes.String)
 		if err != nil {
 			t.Fatalf(`got error: "%s" for elem "%s"`, err, buf.String())
 		}
@@ -177,7 +180,8 @@ func TestParseArrayError(t *testing.T) {
 	}
 	for _, td := range testData {
 		t.Run(td.str, func(t *testing.T) {
-			_, err := ParseDArrayFromString(NewTestingEvalContext(), td.str, td.typ)
+			_, err := ParseDArrayFromString(
+				NewTestingEvalContext(cluster.MakeTestingClusterSettings()), td.str, td.typ)
 			if err == nil {
 				t.Fatalf("expected %#v to error with message %#v", td.str, td.expectedError)
 			}

--- a/pkg/sql/sem/tree/timeconv_test.go
+++ b/pkg/sql/sem/tree/timeconv_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	_ "github.com/cockroachdb/cockroach/pkg/sql/sem/builtins"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
@@ -37,7 +38,7 @@ func TestClusterTimestampConversion(t *testing.T) {
 		{9223372036854775807, 2147483647, "9223372036854775807.2147483647"},
 	}
 
-	ctx := tree.NewTestingEvalContext()
+	ctx := tree.NewTestingEvalContext(cluster.MakeTestingClusterSettings())
 	defer ctx.Mon.Stop(context.Background())
 	ctx.PrepareOnly = true
 	for _, d := range testData {

--- a/pkg/sql/sem/tree/type_check_internal_test.go
+++ b/pkg/sql/sem/tree/type_check_internal_test.go
@@ -21,6 +21,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/coltypes"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -65,7 +66,7 @@ func TestTypeCheckNormalize(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			evalCtx := tree.NewTestingEvalContext()
+			evalCtx := tree.NewTestingEvalContext(cluster.MakeTestingClusterSettings())
 			defer evalCtx.Stop(context.Background())
 			typedExpr, err := evalCtx.NormalizeExpr(typeChecked)
 			if err != nil {

--- a/pkg/sql/session_mem_usage.go
+++ b/pkg/sql/session_mem_usage.go
@@ -38,7 +38,7 @@ func (s *Session) StartMonitor(pool *mon.BytesMonitor, reserved mon.BoundAccount
 		mon.MemoryResource,
 		s.memMetrics.CurBytesCount,
 		s.memMetrics.MaxBytesHist,
-		-1, math.MaxInt64)
+		-1, math.MaxInt64, s.execCfg.Settings)
 	s.mon.Start(s.context, pool, reserved)
 	s.deriveAndStartMonitors()
 }
@@ -60,7 +60,7 @@ func (s *Session) deriveAndStartMonitors() {
 		mon.MemoryResource,
 		s.memMetrics.SessionCurBytesCount,
 		s.memMetrics.SessionMaxBytesHist,
-		-1, noteworthyMemoryUsageBytes)
+		-1, noteworthyMemoryUsageBytes, s.execCfg.Settings)
 	s.sessionMon.Start(s.context, &s.mon, mon.BoundAccount{})
 
 	// We merely prepare the txn monitor here. It is fully started in
@@ -69,7 +69,7 @@ func (s *Session) deriveAndStartMonitors() {
 		mon.MemoryResource,
 		s.memMetrics.TxnCurBytesCount,
 		s.memMetrics.TxnMaxBytesHist,
-		-1, noteworthyMemoryUsageBytes)
+		-1, noteworthyMemoryUsageBytes, s.execCfg.Settings)
 }
 
 func (s *Session) makeBoundAccount() mon.BoundAccount {

--- a/pkg/sql/sqlbase/encoded_datum_test.go
+++ b/pkg/sql/sqlbase/encoded_datum_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -28,7 +29,7 @@ func TestEncDatum(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	a := &DatumAlloc{}
-	evalCtx := tree.NewTestingEvalContext()
+	evalCtx := tree.NewTestingEvalContext(cluster.MakeTestingClusterSettings())
 	defer evalCtx.Stop(context.Background())
 	v := EncDatum{}
 	if !v.IsUnset() {
@@ -173,7 +174,7 @@ func checkEncDatumCmp(
 
 	dec2 := EncDatumFromEncoded(enc2, buf2)
 
-	evalCtx := tree.NewTestingEvalContext()
+	evalCtx := tree.NewTestingEvalContext(cluster.MakeTestingClusterSettings())
 	defer evalCtx.Stop(context.Background())
 	if val, err := dec1.Compare(&typ, a, evalCtx, &dec2); err != nil {
 		t.Fatal(err)
@@ -204,7 +205,7 @@ func TestEncDatumCompare(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	a := &DatumAlloc{}
-	evalCtx := tree.NewTestingEvalContext()
+	evalCtx := tree.NewTestingEvalContext(cluster.MakeTestingClusterSettings())
 	defer evalCtx.Stop(context.Background())
 	rng, _ := randutil.NewPseudoRand()
 
@@ -265,7 +266,7 @@ func TestEncDatumFromBuffer(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	var alloc DatumAlloc
-	evalCtx := tree.NewTestingEvalContext()
+	evalCtx := tree.NewTestingEvalContext(cluster.MakeTestingClusterSettings())
 	defer evalCtx.Stop(context.Background())
 	rng, _ := randutil.NewPseudoRand()
 	for test := 0; test < 20; test++ {
@@ -418,7 +419,7 @@ func TestEncDatumRowCompare(t *testing.T) {
 	}
 
 	a := &DatumAlloc{}
-	evalCtx := tree.NewTestingEvalContext()
+	evalCtx := tree.NewTestingEvalContext(cluster.MakeTestingClusterSettings())
 	defer evalCtx.Stop(context.Background())
 	for _, c := range testCases {
 		types := make([]ColumnType, len(c.row1))
@@ -440,7 +441,7 @@ func TestEncDatumRowCompare(t *testing.T) {
 func TestEncDatumRowAlloc(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	evalCtx := tree.NewTestingEvalContext()
+	evalCtx := tree.NewTestingEvalContext(cluster.MakeTestingClusterSettings())
 	defer evalCtx.Stop(context.Background())
 	rng, _ := randutil.NewPseudoRand()
 	for _, cols := range []int{1, 2, 4, 10, 40, 100} {

--- a/pkg/sql/sqlbase/table_test.go
+++ b/pkg/sql/sqlbase/table_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
@@ -197,7 +198,7 @@ func TestIndexKey(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		evalCtx := tree.NewTestingEvalContext()
+		evalCtx := tree.NewTestingEvalContext(cluster.MakeTestingClusterSettings())
 		defer evalCtx.Stop(context.Background())
 		tableDesc, colMap := makeTableDescForTest(test)
 		testValues := append(test.primaryValues, test.secondaryValues...)
@@ -363,7 +364,8 @@ func TestArrayEncoding(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			if d.Compare(tree.NewTestingEvalContext(), &test.datum) != 0 {
+			evalContext := tree.NewTestingEvalContext(cluster.MakeTestingClusterSettings())
+			if d.Compare(evalContext, &test.datum) != 0 {
 				t.Fatalf("expected %v to decode to %s, got %s", enc, test.datum.String(), d.String())
 			}
 		})
@@ -1482,7 +1484,7 @@ func TestDecodeTableValue(t *testing.T) {
 			} else if err != nil {
 				return
 			}
-			if tc.in.Compare(tree.NewTestingEvalContext(), d) != 0 {
+			if tc.in.Compare(tree.NewTestingEvalContext(cluster.MakeTestingClusterSettings()), d) != 0 {
 				t.Fatalf("decoded datum %[1]v (%[1]T) does not match encoded datum %[2]v (%[2]T)", d, tc.in)
 			}
 		})

--- a/pkg/sql/stats/histogram_test.go
+++ b/pkg/sql/stats/histogram_test.go
@@ -22,6 +22,7 @@ import (
 	"math/rand"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 )
@@ -141,7 +142,7 @@ func TestEquiDepthHistogram(t *testing.T) {
 		},
 	}
 
-	evalCtx := tree.NewTestingEvalContext()
+	evalCtx := tree.NewTestingEvalContext(cluster.MakeTestingClusterSettings())
 
 	for i, tc := range testCases {
 		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {

--- a/pkg/sql/testutils.go
+++ b/pkg/sql/testutils.go
@@ -33,17 +33,18 @@ func CreateTestTableDescriptor(
 	schema string,
 	privileges *sqlbase.PrivilegeDescriptor,
 ) (sqlbase.TableDescriptor, error) {
+	st := cluster.MakeTestingClusterSettings()
 	stmt, err := parser.ParseOne(schema)
 	if err != nil {
 		return sqlbase.TableDescriptor{}, err
 	}
 	semaCtx := tree.MakeSemaContext(false /* privileged */)
-	evalCtx := tree.MakeTestingEvalContext()
+	evalCtx := tree.MakeTestingEvalContext(st)
 	return MakeTableDesc(
 		ctx,
 		nil, /* txn */
 		nil, /* vt */
-		cluster.MakeTestingClusterSettings(),
+		st,
 		stmt.(*tree.CreateTable),
 		parentID, id,
 		hlc.Timestamp{}, /* creationTime */
@@ -55,9 +56,9 @@ func CreateTestTableDescriptor(
 	)
 }
 
-func makeTestingExtendedEvalContext() extendedEvalContext {
+func makeTestingExtendedEvalContext(st *cluster.Settings) extendedEvalContext {
 	return extendedEvalContext{
-		EvalContext: tree.MakeTestingEvalContext(),
+		EvalContext: tree.MakeTestingEvalContext(st),
 	}
 }
 

--- a/pkg/sql/txn_state_test.go
+++ b/pkg/sql/txn_state_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
@@ -71,6 +72,7 @@ func makeTestContext() testContext {
 			nil,  /* maxHist */
 			-1,   /* increment */
 			1000, /* noteworthy */
+			cluster.MakeTestingClusterSettings(),
 		),
 		tracer: tracing.NewTracer(),
 		ctx:    context.TODO(),
@@ -103,6 +105,7 @@ func (tc *testContext) createOpenState(
 		nil,  /* maxHist */
 		-1,   /* increment */
 		1000, /* noteworthy */
+		cluster.MakeTestingClusterSettings(),
 	)
 	txnStateMon.Start(tc.ctx, &tc.mon, mon.BoundAccount{})
 
@@ -159,6 +162,7 @@ func (tc *testContext) createNoTxnState() (State, *txnState2) {
 		nil,  /* maxHist */
 		-1,   /* increment */
 		1000, /* noteworthy */
+		cluster.MakeTestingClusterSettings(),
 	)
 	ts := txnState2{mon: &txnStateMon}
 	return stateNoTxn{}, &ts

--- a/pkg/storage/engine/disk_map_test.go
+++ b/pkg/storage/engine/disk_map_test.go
@@ -25,6 +25,7 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 )
@@ -32,7 +33,8 @@ import (
 func TestRocksDBMap(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	ctx := context.Background()
-	tempEngine, err := NewTempEngine(base.DefaultTestTempStorageConfig())
+	st := cluster.MakeTestingClusterSettings()
+	tempEngine, err := NewTempEngine(base.DefaultTestTempStorageConfig(st))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -133,7 +135,8 @@ func TestRocksDBMap(t *testing.T) {
 func TestRocksDBMapSandbox(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	ctx := context.Background()
-	tempEngine, err := NewTempEngine(base.DefaultTestTempStorageConfig())
+	st := cluster.MakeTestingClusterSettings()
+	tempEngine, err := NewTempEngine(base.DefaultTestTempStorageConfig(st))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -224,7 +227,8 @@ func TestRocksDBMapSandbox(t *testing.T) {
 func TestRocksDBStore(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	ctx := context.Background()
-	tempEngine, err := NewTempEngine(base.DefaultTestTempStorageConfig())
+	st := cluster.MakeTestingClusterSettings()
+	tempEngine, err := NewTempEngine(base.DefaultTestTempStorageConfig(st))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/storage/ts_maintenance_queue_test.go
+++ b/pkg/storage/ts_maintenance_queue_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/server"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
@@ -282,6 +283,7 @@ func TestTimeSeriesMaintenanceQueueServer(t *testing.T) {
 		nil,           /* maxHist */
 		-1,            /* increment: use default block size */
 		math.MaxInt64, /* noteworthy */
+		cluster.MakeTestingClusterSettings(),
 	)
 	memMon.Start(context.TODO(), nil /* pool */, mon.MakeStandaloneBudget(math.MaxInt64))
 	defer memMon.Stop(context.TODO())

--- a/pkg/ts/query_test.go
+++ b/pkg/ts/query_test.go
@@ -23,13 +23,15 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gogo/protobuf/proto"
+	"github.com/pkg/errors"
+
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/ts/tspb"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
-	"github.com/gogo/protobuf/proto"
-	"github.com/pkg/errors"
 )
 
 // dataSample is a basic data type that represents a single time series sample:
@@ -1313,6 +1315,7 @@ func TestQueryWorkerMemoryConstraint(t *testing.T) {
 		nil,
 		1,
 		math.MaxInt64,
+		cluster.MakeTestingClusterSettings(),
 	)
 	tm.workerMemMonitor = &adjustedMon
 	tm.workerMemMonitor.Start(context.TODO(), unlimitedMon, mon.BoundAccount{})
@@ -1422,6 +1425,7 @@ func TestQueryWorkerMemoryMonitor(t *testing.T) {
 		nil,
 		100,
 		100,
+		cluster.MakeTestingClusterSettings(),
 	)
 	tm.workerMemMonitor = &limitedMon
 	tm.workerMemMonitor.Start(context.TODO(), unlimitedMon, mon.BoundAccount{})

--- a/pkg/util/mon/bytes_usage.go
+++ b/pkg/util/mon/bytes_usage.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/pkg/errors"
 
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/cockroach/pkg/util/humanizeutil"
@@ -221,6 +222,8 @@ type BytesMonitor struct {
 
 	curBytesCount *metric.Gauge
 	maxBytesHist  *metric.Histogram
+
+	settings *cluster.Settings
 }
 
 // maxAllocatedButUnusedBlocks determines the maximum difference between the
@@ -261,8 +264,10 @@ func MakeMonitor(
 	maxHist *metric.Histogram,
 	increment int64,
 	noteworthy int64,
+	settings *cluster.Settings,
 ) BytesMonitor {
-	return MakeMonitorWithLimit(name, res, math.MaxInt64, curCount, maxHist, increment, noteworthy)
+	return MakeMonitorWithLimit(
+		name, res, math.MaxInt64, curCount, maxHist, increment, noteworthy, settings)
 }
 
 // MakeMonitorWithLimit creates a new monitor with a limit local to this
@@ -275,6 +280,7 @@ func MakeMonitorWithLimit(
 	maxHist *metric.Histogram,
 	increment int64,
 	noteworthy int64,
+	settings *cluster.Settings,
 ) BytesMonitor {
 	if increment <= 0 {
 		increment = DefaultPoolAllocationSize
@@ -290,6 +296,7 @@ func MakeMonitorWithLimit(
 		curBytesCount:        curCount,
 		maxBytesHist:         maxHist,
 		poolAllocationSize:   increment,
+		settings:             settings,
 	}
 }
 
@@ -304,6 +311,7 @@ func MakeMonitorInheritWithLimit(name string, limit int64, m *BytesMonitor) Byte
 		m.maxBytesHist,
 		m.poolAllocationSize,
 		m.noteworthyUsageBytes,
+		m.settings,
 	)
 }
 
@@ -384,9 +392,11 @@ func (mm *BytesMonitor) doStop(ctx context.Context, check bool) {
 	}
 
 	if check && mm.mu.curAllocated != 0 {
-		panic(fmt.Sprintf("%s: unexpected %d leftover bytes",
-			mm.name,
-			mm.mu.curAllocated))
+		var reportables []interface{}
+		log.ReportOrPanic(
+			ctx, &mm.settings.SV,
+			fmt.Sprintf("%s: unexpected %d leftover bytes", mm.name, mm.mu.curAllocated),
+			reportables)
 	}
 
 	mm.releaseBudget(ctx)


### PR DESCRIPTION
During cleanup, our BytesMonitor currently checks for unreleased
allocations and panics if so. This is something we want to be aware of
but panicking the server is overkill, since this is not a fatal issue
and does not affect the correctness of query results.

Now for release builds, we report the error to Sentry without panicking.
We still panic if this assertion fails during tests.

One deficiency of this change is that the query which triggered the
allocation issue is no longer included in the Sentry report. This will
be addressed in a future commit.

Release note: None