### PR TITLE
ui: include decommissioning nodes in node count, not decommissioned

### DIFF
--- a/pkg/ui/src/redux/nodes.ts
+++ b/pkg/ui/src/redux/nodes.ts
@@ -140,7 +140,7 @@ export function sumNodeStats(
   if (_.isArray(nodeStatuses) && _.isObject(livenessStatusByNodeID)) {
     nodeStatuses.forEach((n) => {
       const status = livenessStatusByNodeID[n.desc.node_id];
-      if (status !== LivenessStatus.DECOMMISSIONING) {
+      if (status !== LivenessStatus.DECOMMISSIONED) {
         result.nodeCounts.total += 1;
       }
       switch (status) {


### PR DESCRIPTION
One bug that slipped through on #22237 was that decommissionING nodes were
excluded from the total node count, rather than decommissionED.  Nodes that
are live should always be included, and dead nodes should be excluded only
if they were intentionally decommissioned.

Fixes: #22689
Release note (admin ui change): Fixed a bug where decommissioned nodes were
included in the total node count, and decommissioning nodes were not.