### PR TITLE
sql: fix go1.9 vs 1.10 comment format

### DIFF
--- a/pkg/sql/txn_state_test.go
+++ b/pkg/sql/txn_state_test.go
@@ -653,10 +653,9 @@ func TestTransitions(t *testing.T) {
 				expFlush: flush,
 				expEv:    txnRestart,
 			},
-			expTxn: &expKVTxn{
 			// We would like to test that the transaction's epoch bumped if the txn
 			// performed any operations, but it's not easy to do the test.
-			},
+			expTxn: &expKVTxn{},
 		},
 		//
 		// Tests starting from the Aborted state.


### PR DESCRIPTION
go1.10 thinks it should be indented, 1.9 does not. moving it up avoids the issue.

Release note: none.