### PR TITLE
ui: correct heading for decommissioned nodes list

### DIFF
--- a/pkg/ui/src/views/cluster/containers/nodesOverview/index.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodesOverview/index.tsx
@@ -315,7 +315,7 @@ const DecommissionedNodesConnected = connect(
     const statuses = partitionedStatuses(state);
     return {
       sortSetting: decommissionedNodesSortSetting.selector(state),
-      status: LivenessStatus.DECOMMISSIONING,
+      status: LivenessStatus.DECOMMISSIONED,
       statuses: statuses.decommissioned,
       nodesSummary: nodesSummarySelector(state),
     };


### PR DESCRIPTION
Fixes #22698
Release note (admin ui change): Corrects the title of the decommissioned node
list, which was mistakenly updated to say "Decommissioning".