### PR TITLE
importccl: correctly set read progress contribution in IMPORT

### DIFF
--- a/pkg/sql/jobs/jobs.go
+++ b/pkg/sql/jobs/jobs.go
@@ -657,7 +657,7 @@ func (d ImportDetails_Table) Completed() float32 {
 	}
 	sampling := sum(d.SamplingProgress) * samplingPhaseContribution
 	if len(d.SamplingProgress) == 0 {
-		// SamplingProgress in empty iff we are in the second phase. If so, the
+		// SamplingProgress is empty iff we are in the second phase. If so, the
 		// first phase is implied as fully complete.
 		sampling = samplingPhaseContribution
 	}


### PR DESCRIPTION
The read contribution percentages were only being set in the sampling
stage. Correctly set them for use in both stages.

Also remove duplicate .Progressed call that should only happen during
sampling.

Release note: None