### PR TITLE
cli: inject some last-minute version checks

### DIFF
--- a/pkg/build/info.go
+++ b/pkg/build/info.go
@@ -103,3 +103,10 @@ func GetInfo() Info {
 		Type:         typ,
 	}
 }
+
+// TestingOverrideTag allows tests to override the build tag.
+func TestingOverrideTag(t string) func() {
+	prev := tag
+	tag = t
+	return func() { tag = prev }
+}

--- a/pkg/ccl/cliccl/main_test.go
+++ b/pkg/ccl/cliccl/main_test.go
@@ -12,12 +12,17 @@ import (
 	"os"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/build"
 	"github.com/cockroachdb/cockroach/pkg/ccl/utilccl"
 	"github.com/cockroachdb/cockroach/pkg/server"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 )
 
 func TestMain(m *testing.M) {
+	// CLI tests are sensitive to the server version, but test binaries don't have
+	// a version injected. Pretend to be a very up-to-date version.
+	defer build.TestingOverrideTag("v999")()
+
 	defer utilccl.TestingEnableEnterprise()()
 	serverutils.InitTestServerFactory(server.TestServerFactory)
 	os.Exit(m.Run())

--- a/pkg/cli/dump.go
+++ b/pkg/cli/dump.go
@@ -55,6 +55,13 @@ func runDump(cmd *cobra.Command, args []string) error {
 	}
 	defer conn.Close()
 
+	// NOTE: We too aggressively broke backwards compatibility in this command.
+	// Future changes should maintain compatibility with the last two released
+	// versions of CockroachDB.
+	if err := conn.requireServerVersion(">v2.0-alpha.20180212"); err != nil {
+		return err
+	}
+
 	dbName := args[0]
 	var tableNames []string
 	if len(args) > 1 {

--- a/pkg/cli/main_test.go
+++ b/pkg/cli/main_test.go
@@ -18,6 +18,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/build"
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/security/securitytest"
 	"github.com/cockroachdb/cockroach/pkg/server"
@@ -29,6 +30,10 @@ func init() {
 }
 
 func TestMain(m *testing.M) {
+	// CLI tests are sensitive to the server version, but test binaries don't have
+	// a version injected. Pretend to be a very up-to-date version.
+	defer build.TestingOverrideTag("v999")()
+
 	serverutils.InitTestServerFactory(server.TestServerFactory)
 	os.Exit(m.Run())
 }

--- a/pkg/cli/user.go
+++ b/pkg/cli/user.go
@@ -43,6 +43,12 @@ func runGetUser(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	defer conn.Close()
+	// NOTE: We too aggressively broke backwards compatibility in this command.
+	// Future changes should maintain compatibility with the last two released
+	// versions of CockroachDB.
+	if err := conn.requireServerVersion(">=v2.0-alpha.20180116"); err != nil {
+		return err
+	}
 	return runQueryAndFormatResults(conn, os.Stdout,
 		makeQuery(`SELECT * FROM system.users WHERE username=$1 AND "isRole" = false`, args[0]))
 }
@@ -89,6 +95,12 @@ func runRmUser(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	defer conn.Close()
+	// NOTE: We too aggressively broke backwards compatibility in this command.
+	// Future changes should maintain compatibility with the last two released
+	// versions of CockroachDB.
+	if err := conn.requireServerVersion(">=v1.1-alpha.20170622"); err != nil {
+		return err
+	}
 	return runQueryAndFormatResults(conn, os.Stdout,
 		makeQuery(`DROP USER $1`, args[0]))
 }
@@ -130,6 +142,13 @@ func runSetUser(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	defer conn.Close()
+
+	// NOTE: We too aggressively broke backwards compatibility in this command.
+	// Future changes should maintain compatibility with the last two released
+	// versions of CockroachDB.
+	if err := conn.requireServerVersion(">=v1.2-alpha.20171113"); err != nil {
+		return err
+	}
 
 	if err := runQueryAndFormatResults(conn, os.Stdout,
 		makeQuery(`CREATE USER IF NOT EXISTS $1`, args[0])); err != nil {

--- a/pkg/cli/zone.go
+++ b/pkg/cli/zone.go
@@ -85,6 +85,13 @@ func runGetZone(cmd *cobra.Command, args []string) error {
 	}
 	defer conn.Close()
 
+	// NOTE: We too aggressively broke backwards compatibility in this command.
+	// Future changes should maintain compatibility with the last two released
+	// versions of CockroachDB.
+	if err := conn.requireServerVersion(">=v1.2-alpha.20171026"); err != nil {
+		return err
+	}
+
 	vals, err := conn.QueryRow(fmt.Sprintf(
 		`SELECT cli_specifier, config_yaml FROM [EXPERIMENTAL SHOW ZONE CONFIGURATION FOR %s]`, &zs), nil)
 	if err != nil {
@@ -126,6 +133,13 @@ func runLsZones(cmd *cobra.Command, args []string) error {
 	}
 	defer conn.Close()
 
+	// NOTE: We too aggressively broke backwards compatibility in this command.
+	// Future changes should maintain compatibility with the last two released
+	// versions of CockroachDB.
+	if err := conn.requireServerVersion(">=v1.2-alpha.20171026"); err != nil {
+		return err
+	}
+
 	specifiers, err := queryZoneSpecifiers(conn)
 	if err != nil {
 		return err
@@ -155,16 +169,23 @@ func runRmZone(cmd *cobra.Command, args []string) error {
 		return usageAndError(cmd)
 	}
 
-	zs, err := config.ParseCLIZoneSpecifier(args[0])
-	if err != nil {
-		return err
-	}
-
 	conn, err := getPasswordAndMakeSQLClient()
 	if err != nil {
 		return err
 	}
 	defer conn.Close()
+
+	// NOTE: We too aggressively broke backwards compatibility in this command.
+	// Future changes should maintain compatibility with the last two released
+	// versions of CockroachDB.
+	if err := conn.requireServerVersion(">=v1.2-alpha.20171026"); err != nil {
+		return err
+	}
+
+	zs, err := config.ParseCLIZoneSpecifier(args[0])
+	if err != nil {
+		return err
+	}
 
 	return runQueryAndFormatResults(conn, os.Stdout,
 		makeQuery(fmt.Sprintf(`ALTER %s EXPERIMENTAL CONFIGURE ZONE NULL`, &zs)))
@@ -230,6 +251,13 @@ func runSetZone(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	defer conn.Close()
+
+	// NOTE: We too aggressively broke backwards compatibility in this command.
+	// Future changes should maintain compatibility with the last two released
+	// versions of CockroachDB.
+	if err := conn.requireServerVersion(">=v1.2-alpha.20171026"); err != nil {
+		return err
+	}
 
 	zs, err := config.ParseCLIZoneSpecifier(args[0])
 	if err != nil {


### PR DESCRIPTION
2.0 CLI commands are variously incompatible with 1.0 and 1.1 CockroachDB
clusters. Apply some emergency stopgaps to print out nice error
messages. For example, running `cockroach init` against a 1.0 cluster
now prints out

    incompatible client and server versions (likely server version: v1.0, required: >=v1.1)

instead of:

    Error: rpc error: code = Unimplemented desc = unknown service cockroach.server.serverpb.Init

The `cockroach node` commands, which are also incompatible with 1.0
clusters, get a similar treatment.

The `cockroach dump`, `cockroach user`, and `cockroach zone` print out
similar version errors based on their particular required version:

    Error: incompatible client and server versions (detected server version: 1.1.5, required: >=v1.2-alpha.20171026)

The `dump`, `user`, and `zone` command use the SQL interface where
precise version information is available; `init`, `node`, and `quit` use
the GRPC interface where the server version must be inferred from the
error messages returned.

Future CLI work should try harder to maintain compatibility with old
Cockroach servers; for 2.0, though, we're both out of time and don't
have the infrastructure in place to test the CLI against old servers.

Fix #21323.

Release note (cli change): The CLI produces better error messages when
connecting to a server with an incompatible version.