### PR TITLE
ui: exclude decommissioned nodes from cluster stats

### DIFF
--- a/pkg/ui/src/redux/nodes.ts
+++ b/pkg/ui/src/redux/nodes.ts
@@ -159,7 +159,7 @@ export function sumNodeStats(
           result.nodeCounts.dead++;
           break;
       }
-      if (status !== LivenessStatus.DEAD) {
+      if (status !== LivenessStatus.DEAD && status !== LivenessStatus.DECOMMISSIONED) {
         result.capacityUsed += n.metrics[MetricConstants.usedCapacity];
         result.capacityAvailable += n.metrics[MetricConstants.availableCapacity];
         result.capacityTotal += n.metrics[MetricConstants.capacity];


### PR DESCRIPTION
Fixes #22710
Release note (admin ui change): Fixes an issue where decommissioned nodes are
included in cluster stats aggregates.