### PR TITLE
ui: prefix node with "n" in node list

### DIFF
--- a/pkg/ui/src/views/cluster/containers/nodesOverview/index.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodesOverview/index.tsx
@@ -73,7 +73,7 @@ class LiveNodeList extends React.Component<NodeCategoryListProps, {}> {
             // Node ID column.
             {
               title: "ID",
-              cell: (ns) => ns.desc.node_id,
+              cell: (ns) => `n${ns.desc.node_id}`,
               sort: (ns) => ns.desc.node_id,
             },
             // Node address column - displays the node address, links to the
@@ -187,7 +187,7 @@ class NotLiveNodeList extends React.Component<NotLiveNodeListProps, {}> {
             // Node ID column.
             {
               title: "ID",
-              cell: (ns) => ns.desc.node_id,
+              cell: (ns) => `n${ns.desc.node_id}`,
               sort: (ns) => ns.desc.node_id,
             },
             // Node address column - displays the node address, links to the


### PR DESCRIPTION
To make the node list consistent with the decision made on #22614,
always prefix node ids with the letter n.

Release note: None

<img width="484" alt="screen shot 2018-02-14 at 5 19 12 pm" src="https://user-images.githubusercontent.com/793969/36231214-41d8b070-11ab-11e8-8f29-d53123ae054f.png">
