### PR TITLE
ui: use display name for nodes in clusterviz

### DIFF
--- a/pkg/ui/ccl/src/views/clusterviz/containers/map/nodeView.tsx
+++ b/pkg/ui/ccl/src/views/clusterviz/containers/map/nodeView.tsx
@@ -10,7 +10,7 @@ import React from "react";
 import moment from "moment";
 
 import { NodeStatus$Properties } from "src/util/proto";
-import { sumNodeStats } from "src/redux/nodes";
+import { getDisplayName, sumNodeStats } from "src/redux/nodes";
 import { cockroach } from "src/js/protos";
 import { trustIcon } from "src/util/trust";
 import liveIcon from "!!raw-loader!assets/livenessIcons/live.svg";
@@ -45,7 +45,7 @@ export class NodeView extends React.Component<NodeViewProps> {
     return (
       <g transform="translate(-90 -100)">
         <Labels
-          label={node.desc.address.address_field}
+          label={getDisplayName(node)}
           subLabel={uptimeText}
         />
         <g dangerouslySetInnerHTML={trustIcon(nodeIcon)} transform="translate(14 14)" />

--- a/pkg/ui/src/redux/nodes.ts
+++ b/pkg/ui/src/redux/nodes.ts
@@ -176,6 +176,10 @@ export function sumNodeStats(
   return result;
 }
 
+export function getDisplayName(node: NodeStatus$Properties) {
+  return `${node.desc.address.address_field} (n${node.desc.node_id})`;
+}
+
 // nodeDisplayNameByIDSelector provides a unique, human-readable display name
 // for each node.
 export const nodeDisplayNameByIDSelector = createSelector(
@@ -184,7 +188,7 @@ export const nodeDisplayNameByIDSelector = createSelector(
     const result: {[key: string]: string} = {};
     if (!_.isEmpty(nodeStatuses)) {
       nodeStatuses.forEach(ns => {
-        result[ns.desc.node_id] = `${ns.desc.address.address_field} (n${ns.desc.node_id})`;
+        result[ns.desc.node_id] = getDisplayName(ns);
       });
     }
     return result;


### PR DESCRIPTION
Follows from #22614, and applies the display name to the nodes in the
clusterviz so they appear consistent with nodes elsewhere.

Release note: None