### PR TITLE
acceptance: break TestVersionUpgrade into series of upgrade steps; re-enable

### DIFF
--- a/pkg/acceptance/localcluster/localcluster.go
+++ b/pkg/acceptance/localcluster/localcluster.go
@@ -119,8 +119,7 @@ func (b *LocalCluster) RestartAsync(ctx context.Context, i int) <-chan error {
 		// this file. That's why we let *every* node do this (you could try to make
 		// only the first one wait, but if that one is 1.0, bad luck).
 		// Short-circuiting the wait in the case that the listening URL file is
-		// written (i.e. isServing closes) makes restarts work with 1.0 servers for
-		// the most part.
+		// written makes restarts work with 1.0 servers for the most part.
 		for {
 			if gossipAddr := b.Nodes[i].AdvertiseAddr(); gossipAddr != "" {
 				return ch

--- a/pkg/acceptance/version_upgrade_test.go
+++ b/pkg/acceptance/version_upgrade_test.go
@@ -17,15 +17,17 @@ package acceptance
 import (
 	"context"
 	"fmt"
+	"math/rand"
 	"testing"
+	"time"
 
-	gosql "database/sql"
+	"github.com/pkg/errors"
 
 	"github.com/cockroachdb/cockroach/pkg/acceptance/cluster"
 	"github.com/cockroachdb/cockroach/pkg/acceptance/localcluster"
+	clusterversion "github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
-	"github.com/pkg/errors"
 )
 
 func TestVersionUpgrade(t *testing.T) {
@@ -39,124 +41,91 @@ func TestVersionUpgrade(t *testing.T) {
 	})
 }
 
-func testVersionUpgrade(ctx context.Context, t *testing.T, cfg cluster.TestConfig) {
-	t.Skip("#22581")
+// versionStep is an isolated version migration on a running cluster.
+type versionStep interface {
+	name() string
+	run(ctx context.Context, t *testing.T, c cluster.Cluster)
+}
 
-	// Version 1.0.5 does not contain
-	// https://github.com/cockroachdb/cockroach/pull/19493 and the test will be
-	// flaky.
-	//
-	// TODO(tschottdorf): The first version containing that PR will (likely) be
-	// included in 1.1.2. Check and remove once that's passed and this test has
-	// v1.0.5 bumped to a higher version that includes #19493.
-	if len(cfg.Nodes) > 3 {
-		cfg.Nodes = cfg.Nodes[:3]
+// binaryVersionUpgrade performs a rolling upgrade of all nodes in the cluster
+// up to its binary version.
+type binaryVersionUpgrade string
+
+// sourceVersion corresponds to the source binary version.
+const sourceVersion = "source"
+
+func (bv binaryVersionUpgrade) name() string { return fmt.Sprintf("binary=%s", bv) }
+
+func (bv binaryVersionUpgrade) run(ctx context.Context, t *testing.T, c cluster.Cluster) {
+	t.Helper()
+
+	var newBin string
+	if string(bv) == sourceVersion {
+		newBin = localcluster.SourceBinary()
+	} else {
+		newBin = GetBinary(ctx, t, string(bv))
 	}
-
-	for i := range cfg.Nodes {
-		// Leave the field blank for all but the first node so that they use the
-		// version we're testing in this run.
-		if i == 0 {
-			cfg.Nodes[i].Version = "v1.0.5"
-		}
-	}
-
-	c := StartCluster(ctx, t, cfg)
-	defer c.AssertAndStop(ctx, t)
-
-	// Verify that the nodes are *really* at the versions configured. This
-	// tests the CI harness.
-	log.Info(ctx, "verifying that configured versions are actual versions")
-	for i := 0; i < c.NumNodes(); i++ {
-		db, err := gosql.Open("postgres", c.PGUrl(ctx, i))
-		if err != nil {
-			t.Fatal(err)
-		}
-		defer db.Close()
-
-		expVersion := cfg.Nodes[i].Version
-		var version string
-		// 'Version' for 1.1, 'Tag' in 1.0.x.
-		if err := db.QueryRow(
-			`SELECT value FROM crdb_internal.node_build_info where field IN ('Version' , 'Tag')`,
-		).Scan(&version); err != nil {
-			t.Fatal(err)
-		}
-		// Strip leading `v` and compare (if expVersion = "", we'll accept anything).
-		if version != expVersion && expVersion != "" {
-			t.Fatalf("created node at v%s, but it is %s", expVersion, version)
-		}
-
-		// Similarly, should see the bootstrap version (the version of the
-		// first node) from the settings. The first node itself is skipped;
-		// it doesn't know about this setting.
-
-		if i == 0 {
-			continue
-		}
-
-		if err := db.QueryRow("SHOW CLUSTER SETTING version").Scan(&version); err != nil {
-			t.Fatal(err)
-		}
-		const exp = "1.0" // no leading `v` here
-		if version != exp {
-			t.Fatalf("%d: node running at %s, not %s", i, version, exp)
-		}
-	}
-
-	for i := 0; i < c.NumNodes(); i++ {
-		if err := c.Kill(ctx, i); err != nil {
-			t.Fatal(err)
-		}
-	}
-
 	lc := c.(*localcluster.LocalCluster)
-	log.Info(ctx, "upgrading the first node's binary to match the other nodes (i.e. the testing binary)")
-	lc.Nodes[0].Cfg.ExtraArgs[0] = lc.Nodes[1].Cfg.ExtraArgs[0]
-
-	var chs []<-chan error
-	log.Info(ctx, "restarting the nodes asynchronously")
 	for i := 0; i < c.NumNodes(); i++ {
-		chs = append(chs, lc.RestartAsync(ctx, i))
-	}
-
-	for _, ch := range chs {
-		if err := <-ch; err != nil {
+		log.Infof(ctx, "upgrading node %d's binary to %s", i, string(bv))
+		lc.ReplaceBinary(i, newBin)
+		if err := lc.Restart(ctx, i); err != nil {
 			t.Fatal(err)
 		}
+
+		bv.checkNode(ctx, t, c, i)
+
+		// TODO(nvanbenschoten): add upgrade qualification step. What should we
+		// test? We could run logictests. We could add custom logic here. Maybe
+		// this should all be pushed to nightly migration tests instead.
+		time.Sleep(1 * time.Second)
 	}
+}
+
+func (bv binaryVersionUpgrade) checkAll(ctx context.Context, t *testing.T, c cluster.Cluster) {
+	t.Helper()
+	for i := 0; i < c.NumNodes(); i++ {
+		bv.checkNode(ctx, t, c, i)
+	}
+}
+
+func (bv binaryVersionUpgrade) checkNode(
+	ctx context.Context, t *testing.T, c cluster.Cluster, nodeIdx int,
+) {
+	t.Helper()
+	db := makePGClient(t, c.PGUrl(ctx, nodeIdx))
+	defer db.Close()
+
+	// 'Version' for 1.1, 'Tag' in 1.0.x.
+	var version string
+	if err := db.QueryRow(
+		`SELECT value FROM crdb_internal.node_build_info where field IN ('Version' , 'Tag')`,
+	).Scan(&version); err != nil {
+		t.Fatal(err)
+	}
+	if version != string(bv) && string(bv) != sourceVersion {
+		t.Fatalf("created node at v%s, but it is %s", string(bv), version)
+	}
+}
+
+// clusterVersionUpgrade performs a cluster version upgrade to its version.
+// It waits until all nodes have seen the upgraded cluster version.
+type clusterVersionUpgrade string
+
+func (cv clusterVersionUpgrade) name() string { return fmt.Sprintf("cluster=%s", cv) }
+
+func (cv clusterVersionUpgrade) run(ctx context.Context, t *testing.T, c cluster.Cluster) {
+	t.Helper()
 
 	func() {
-		db := makePGClient(t, c.PGUrl(ctx, 0))
+		db := makePGClient(t, c.PGUrl(ctx, rand.Intn(c.NumNodes())))
 		defer db.Close()
 
-		var count int
-		if err := db.QueryRow("SELECT COUNT(*) FROM system.settings WHERE name = 'version';").Scan(&count); err != nil {
+		log.Infof(ctx, "upgrading cluster version to %s", string(cv))
+		if _, err := db.Exec(fmt.Sprintf(`SET CLUSTER SETTING version = '%s'`, string(cv))); err != nil {
 			t.Fatal(err)
 		}
-
-		// Since there are nodes at >1.0 in the cluster, a migration that populates
-		// the version setting should have run.
-		//
-		// NB: we could do this check before the restart as well. The new nodes
-		// won't declare startup complete until migrations have run. But putting
-		// it here also checks that the cluster still "works" after the restart.
-		if count < 1 {
-			t.Fatal("initial cluster version was not migrated in")
-		}
 	}()
-
-	bumps := []string{"1.0", "1.1", "1.1-2"}
-
-	for i, bump := range bumps {
-		func() {
-			db := makePGClient(t, c.PGUrl(ctx, i%c.NumNodes()))
-			defer db.Close()
-			if _, err := db.Exec(fmt.Sprintf(`SET CLUSTER SETTING version = '%s'`, bump)); err != nil {
-				t.Fatal(err)
-			}
-		}()
-	}
 
 	for i := 0; i < c.NumNodes(); i++ {
 		testutils.SucceedsSoon(t, func() error {
@@ -167,10 +136,47 @@ func testVersionUpgrade(ctx context.Context, t *testing.T, cfg cluster.TestConfi
 			if err := db.QueryRow("SHOW CLUSTER SETTING version").Scan(&version); err != nil {
 				t.Fatalf("%d: %s", i, err)
 			}
-			if exp := bumps[len(bumps)-1]; version != exp {
-				return errors.Errorf("%d: expected version %s, got %s", i, exp, version)
+			if version != string(cv) {
+				return errors.Errorf("%d: expected version %s, got %s", i, string(cv), version)
 			}
 			return nil
 		})
+	}
+
+	// TODO(nvanbenschoten): add upgrade qualification step.
+	time.Sleep(1 * time.Second)
+}
+
+func testVersionUpgrade(ctx context.Context, t *testing.T, cfg cluster.TestConfig) {
+	steps := []versionStep{
+		binaryVersionUpgrade("v1.0.6"),
+		// v1.1.0 is the first binary version that knows about cluster versions,
+		// but thinks it can only support up to 1.0-3.
+		binaryVersionUpgrade("v1.1.0"),
+		clusterVersionUpgrade("1.0"),
+		clusterVersionUpgrade("1.0-3"),
+		binaryVersionUpgrade("v1.1.1"),
+		clusterVersionUpgrade("1.1"),
+		binaryVersionUpgrade(sourceVersion),
+		clusterVersionUpgrade("1.1-6"),
+		clusterVersionUpgrade(clusterversion.BinaryServerVersion.String()),
+	}
+
+	if len(cfg.Nodes) > 3 {
+		cfg.Nodes = cfg.Nodes[:3]
+	}
+	startingBinVersion := steps[0].(binaryVersionUpgrade)
+	steps = steps[1:]
+	for i := range cfg.Nodes {
+		cfg.Nodes[i].Version = string(startingBinVersion)
+	}
+
+	c := StartCluster(ctx, t, cfg)
+	defer c.AssertAndStop(ctx, t)
+
+	startingBinVersion.checkAll(ctx, t, c)
+	for _, step := range steps {
+		t.Log(step.name())
+		step.run(ctx, t, c)
 	}
 }


### PR DESCRIPTION
See #15851.

This change re-enables `TestVersionUpgrade`, which has been broken for at-least
the past few weeks. It also verifies that the test would have caught the regression
in #22636.

In doing so, it improves `TestVersionUpgrade` by splitting the version upgrades
into a series of incremental steps.

Release note: None