### PR TITLE
sql: return correct pg error codes in multiple places and improve tests

### DIFF
--- a/pkg/sql/distinct.go
+++ b/pkg/sql/distinct.go
@@ -18,7 +18,6 @@ import (
 	"bytes"
 	"context"
 
-	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
@@ -158,10 +157,7 @@ func (p *planner) distinct(
 		}
 
 		if index == -1 {
-			return nil, nil, pgerror.NewErrorf(
-				pgerror.CodeUndefinedColumnError,
-				"column %s does not exist", expr,
-			)
+			return nil, nil, sqlbase.NewUndefinedColumnError(expr.String())
 		}
 
 		d.distinctOnColIdxs.Add(index)

--- a/pkg/sql/logictest/testdata/logic_test/alter_table
+++ b/pkg/sql/logictest/testdata/logic_test/alter_table
@@ -171,7 +171,7 @@ t  primary         PRIMARY KEY          a  NULL
 statement ok
 ALTER TABLE t DROP CONSTRAINT check_a, DROP CONSTRAINT check_a1
 
-statement error column "d" does not exist
+statement error pgcode 42703 column "d" does not exist
 ALTER TABLE t DROP d
 
 statement ok
@@ -628,10 +628,10 @@ a     INT  false NULL    {"primary","foo"}
 b     INT  true  NULL    {"foo"}
 c     INT  true  NULL    {}
 
-statement error relation "nonexistent" does not exist
+statement error pgcode 42P01 relation "nonexistent" does not exist
 ALTER TABLE nonexistent SPLIT AT VALUES (42)
 
-statement error relation "nonexistent" does not exist
+statement error pgcode 42P01 relation "nonexistent" does not exist
 ALTER INDEX nonexistent@noindex SPLIT AT VALUES (42)
 
 user root

--- a/pkg/sql/logictest/testdata/logic_test/case_sensitive_names
+++ b/pkg/sql/logictest/testdata/logic_test/case_sensitive_names
@@ -26,40 +26,40 @@ SHOW TABLES FROM "E"
 statement ok
 CREATE TABLE A(x INT)
 
-statement error relation "A" does not exist
+statement error pgcode 42P01 relation "A" does not exist
 SHOW COLUMNS FROM "A"
 
-statement error relation "A" does not exist
+statement error pgcode 42P01 relation "A" does not exist
 SHOW INDEXES FROM "A"
 
-statement error relation "A" does not exist
+statement error pgcode 42P01 relation "A" does not exist
 SHOW CREATE TABLE "A"
 
-statement error relation "A" does not exist
+statement error pgcode 42P01 relation "A" does not exist
 SHOW GRANTS ON TABLE "A"
 
-statement error relation "test.A" does not exist
+statement error pgcode 42P01 relation "test.A" does not exist
 SHOW GRANTS ON TABLE test."A"
 
-statement error relation "A" does not exist
+statement error pgcode 42P01 relation "A" does not exist
 SHOW CONSTRAINTS FROM "A"
 
-statement error relation "A" does not exist
+statement error pgcode 42P01 relation "A" does not exist
 SELECT * FROM "A"
 
-statement error relation "A" does not exist
+statement error pgcode 42P01 relation "A" does not exist
 INSERT INTO "A"(x) VALUES(1)
 
-statement error relation "A" does not exist
+statement error pgcode 42P01 relation "A" does not exist
 UPDATE "A" SET x = 42
 
-statement error relation "A" does not exist
+statement error pgcode 42P01 relation "A" does not exist
 DELETE FROM "A"
 
-statement error relation "A" does not exist
+statement error pgcode 42P01 relation "A" does not exist
 TRUNCATE "A"
 
-statement error relation "A" does not exist
+statement error pgcode 42P01 relation "A" does not exist
 DROP TABLE "A"
 
 statement ok
@@ -98,40 +98,40 @@ DROP TABLE a
 statement ok
 CREATE TABLE "B"(x INT)
 
-statement error relation "b" does not exist
+statement error pgcode 42P01 relation "b" does not exist
 SHOW COLUMNS FROM B
 
-statement error relation "b" does not exist
+statement error pgcode 42P01 relation "b" does not exist
 SHOW INDEXES FROM B
 
-statement error relation "b" does not exist
+statement error pgcode 42P01 relation "b" does not exist
 SHOW CREATE TABLE B
 
-statement error relation "b" does not exist
+statement error pgcode 42P01 relation "b" does not exist
 SHOW GRANTS ON TABLE B
 
-statement error relation "test.b" does not exist
+statement error pgcode 42P01 relation "test.b" does not exist
 SHOW GRANTS ON TABLE test.B
 
-statement error relation "b" does not exist
+statement error pgcode 42P01 relation "b" does not exist
 SHOW CONSTRAINTS FROM B
 
-statement error relation "b" does not exist
+statement error pgcode 42P01 relation "b" does not exist
 SELECT * FROM B
 
-statement error relation "b" does not exist
+statement error pgcode 42P01 relation "b" does not exist
 INSERT INTO B(x) VALUES(1)
 
-statement error relation "b" does not exist
+statement error pgcode 42P01 relation "b" does not exist
 UPDATE B SET x = 42
 
-statement error relation "b" does not exist
+statement error pgcode 42P01 relation "b" does not exist
 DELETE FROM B
 
-statement error relation "b" does not exist
+statement error pgcode 42P01 relation "b" does not exist
 TRUNCATE B
 
-statement error relation "b" does not exist
+statement error pgcode 42P01 relation "b" does not exist
 DROP TABLE B
 
 statement ok
@@ -202,7 +202,7 @@ SHOW CREATE VIEW xv
 ----
 xv  CREATE VIEW xv (x, "Y") AS SELECT x, "Y" FROM test.public.foo
 
-query error relation "XV" does not exist
+query error pgcode 42P01 relation "XV" does not exist
 SHOW CREATE VIEW "XV"
 
 statement ok
@@ -213,7 +213,7 @@ SHOW CREATE VIEW "YV"
 ----
 "YV"  CREATE VIEW "YV" (x, "Y") AS SELECT x, "Y" FROM test.public.foo
 
-query error relation "yv" does not exist
+query error pgcode 42P01 relation "yv" does not exist
 SHOW CREATE VIEW YV
 
 # Case sensitivity of index names.

--- a/pkg/sql/logictest/testdata/logic_test/create_as
+++ b/pkg/sql/logictest/testdata/logic_test/create_as
@@ -73,7 +73,7 @@ SELECT * FROM smtng.something ORDER BY 1 LIMIT 1
 ----
 cups 10
 
-statement error pq: relation "something" does not exist
+statement error pgcode 42P01 relation "something" does not exist
 SELECT * FROM something LIMIT 1
 
 # Check for memory leak (#10466)

--- a/pkg/sql/logictest/testdata/logic_test/database
+++ b/pkg/sql/logictest/testdata/logic_test/database
@@ -98,7 +98,7 @@ DROP DATABASE b RESTRICT
 statement ok
 DROP DATABASE b CASCADE
 
-statement error relation "b.a" does not exist
+statement error pgcode 42P01 relation "b.a" does not exist
 SELECT * FROM b.a
 
 statement error database "b" does not exist
@@ -129,7 +129,7 @@ test
 statement ok
 CREATE DATABASE b
 
-statement error relation "b.a" does not exist
+statement error pgcode 42P01 relation "b.a" does not exist
 SELECT * FROM b.a
 
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/drop_database
+++ b/pkg/sql/logictest/testdata/logic_test/drop_database
@@ -143,16 +143,16 @@ d2
 system
 test
 
-query error relation "d1.v2" does not exist
+query error pgcode 42P01 relation "d1.v2" does not exist
 SELECT * FROM d1.v2
 
-query error relation "d2.v2" does not exist
+query error pgcode 42P01 relation "d2.v2" does not exist
 SELECT * FROM d2.v2
 
-query error relation "d2.v3" does not exist
+query error pgcode 42P01 relation "d2.v3" does not exist
 SELECT * FROM d2.v3
 
-query error relation "d2.v4" does not exist
+query error pgcode 42P01 relation "d2.v4" does not exist
 SELECT * FROM d2.v4
 
 query TT
@@ -168,7 +168,7 @@ SHOW DATABASES
 system
 test
 
-query error relation "d2.v1" does not exist
+query error pgcode 42P01 relation "d2.v1" does not exist
 SELECT * FROM d2.v1
 
 ## drop a database containing tables with foreign key constraints, e.g. #8497
@@ -199,7 +199,7 @@ SHOW DATABASES
 system
 test
 
-query error relation "constraint_db.t1" does not exist
+query error pgcode 42P01 relation "constraint_db.t1" does not exist
 SELECT * FROM constraint_db.t1
 
 # Check that the default option is CASCADE, but that safe_updates blocks it

--- a/pkg/sql/logictest/testdata/logic_test/drop_table
+++ b/pkg/sql/logictest/testdata/logic_test/drop_table
@@ -32,10 +32,10 @@ SHOW TABLES FROM test
 Table
 b
 
-statement error relation "a" does not exist
+statement error pgcode 42P01 relation "a" does not exist
 SELECT * FROM a
 
-statement error relation "a" does not exist
+statement error pgcode 42P01 relation "a" does not exist
 DROP TABLE a
 
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/fk
+++ b/pkg/sql/logictest/testdata/logic_test/fk
@@ -12,13 +12,13 @@ CREATE TABLE products (sku STRING PRIMARY KEY, upc STRING UNIQUE, vendor STRING)
 statement ok
 INSERT INTO products VALUES ('VP-W9QH-W44L', '867072000006', 'Dave'), ('780', '885155001450', 'iRobot')
 
-statement error relation "productz" does not exist
+statement error pgcode 42P01 relation "productz" does not exist
 CREATE TABLE missing (product STRING REFERENCES productz)
 
-statement error relation "customerz" does not exist
+statement error pgcode 42P01 relation "customerz" does not exist
 CREATE TABLE missing_with_col (customer INT REFERENCES customerz (id))
 
-statement error column "idz" does not exist
+statement error pgcode 42703 column "idz" does not exist
 CREATE TABLE missing_col (customer INT REFERENCES customers (idz))
 
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/grant_table
+++ b/pkg/sql/logictest/testdata/logic_test/grant_table
@@ -307,19 +307,19 @@ test      information_schema  NULL              root  ALL
 test      pg_catalog          NULL              root  ALL
 test      public              NULL              root  ALL
 
-statement error relation "a.t" does not exist
+statement error pgcode 42P01 relation "a.t" does not exist
 SHOW GRANTS ON a.t
 
-statement error relation "t" does not exist
+statement error pgcode 42P01 relation "t" does not exist
 SHOW GRANTS ON t
 
 statement ok
 SET DATABASE = a
 
-statement error relation "t" does not exist
+statement error pgcode 42P01 relation "t" does not exist
 SHOW GRANTS ON t
 
-statement error relation "a.t" does not exist
+statement error pgcode 42P01 relation "a.t" does not exist
 GRANT ALL ON a.t TO readwrite
 
 statement ok
@@ -607,7 +607,7 @@ GRANT ALL ON a.t@xyz TO readwrite
 statement error pq: pattern "\*" did not match any valid database or schema
 GRANT ALL ON * TO readwrite
 
-statement error relation "a.tt" does not exist
+statement error pgcode 42P01 relation "a.tt" does not exist
 GRANT ALL ON a.t, a.tt TO readwrite
 
 # '*' doesn't work for databases.

--- a/pkg/sql/logictest/testdata/logic_test/insert
+++ b/pkg/sql/logictest/testdata/logic_test/insert
@@ -1,6 +1,6 @@
 # LogicTest: default parallel-stmts
 
-statement error relation "kv" does not exist
+statement error pgcode 42P01 relation "kv" does not exist
 INSERT INTO kv VALUES ('a', 'b')
 
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/interleaved
+++ b/pkg/sql/logictest/testdata/logic_test/interleaved
@@ -185,7 +185,7 @@ SELECT * FROM p1_0
 statement ok
 DROP TABLE p2 CASCADE
 
-statement error relation "p0" does not exist
+statement error pgcode 42P01 relation "p0" does not exist
 SELECT * FROM p0
 
 # Validation and descriptor bookkeeping
@@ -221,7 +221,7 @@ all_interleaves   CREATE TABLE all_interleaves (
                     FAMILY "primary" (b, c, d)
                   ) INTERLEAVE IN PARENT p1_1 (b)
 
-statement error relation "missing" does not exist
+statement error pgcode 42P01 relation "missing" does not exist
 CREATE TABLE err (f FLOAT PRIMARY KEY) INTERLEAVE IN PARENT missing (f)
 
 # Check that interleaved columns match in length to parent's primary columns.

--- a/pkg/sql/logictest/testdata/logic_test/join
+++ b/pkg/sql/logictest/testdata/logic_test/join
@@ -558,16 +558,16 @@ SELECT a.x AS s, b.x, c.x, a.y, b.y, c.y FROM (twocolumn AS a JOIN twocolumn AS 
  44  44  44  51  51  51
  45  45  45  45  45  45
 
-query error column "y" specified in USING clause does not exist
+query error pgcode 42703 column "y" specified in USING clause does not exist
 SELECT * FROM (onecolumn AS a JOIN onecolumn AS b USING(y))
 
-query error column "x" appears more than once in USING clause
+query error pgcode 42701 column "x" appears more than once in USING clause
 SELECT * FROM (onecolumn AS a JOIN onecolumn AS b USING(x, x))
 
 statement ok
 CREATE TABLE othertype (x TEXT)
 
-query error JOIN/USING types.*cannot be matched
+query error pgcode 42804 JOIN/USING types.*cannot be matched
 SELECT * FROM (onecolumn AS a JOIN othertype AS b USING(x))
 
 query error cannot join columns from the same source name "onecolumn"

--- a/pkg/sql/logictest/testdata/logic_test/multi_statement
+++ b/pkg/sql/logictest/testdata/logic_test/multi_statement
@@ -61,5 +61,5 @@ SELECT * from kv; ROLLBACK
 statement ok
 ROLLBACK
 
-statement error pq: relation "system.t" does not exist
+statement error pgcode 42P01 relation "system.t" does not exist
 BEGIN TRANSACTION; SELECT * FROM system.t; INSERT INTO t(a) VALUES (1)

--- a/pkg/sql/logictest/testdata/logic_test/parallel_stmts
+++ b/pkg/sql/logictest/testdata/logic_test/parallel_stmts
@@ -338,7 +338,7 @@ SELECT k, v FROM kv ORDER BY k
 statement ok
 BEGIN
 
-statement error column "z" does not exist
+statement error pgcode 42703 column "z" does not exist
 UPDATE kv SET z = 10 WHERE k = 3 RETURNING NOTHING
 
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/pgoidtype
+++ b/pkg/sql/logictest/testdata/logic_test/pgoidtype
@@ -45,7 +45,7 @@ SELECT 'pg_constraint'::REGCLASS, 'pg_catalog.pg_constraint'::REGCLASS
 ----
 pg_constraint  pg_constraint
 
-query error relation "foo.pg_constraint" does not exist
+query error pgcode 42P01 relation "foo.pg_constraint" does not exist
 SELECT 'foo.pg_constraint'::REGCLASS
 
 query TITTTTT
@@ -141,7 +141,7 @@ numeric  numeric
 query error type 'foo.' does not exist
 SELECT 'foo.'::REGTYPE
 
-query error relation "blah" does not exist
+query error pgcode 42P01 relation "blah" does not exist
 SELECT 'blah'::REGCLASS
 
 query error unknown function: blah\(\)
@@ -192,7 +192,7 @@ hascase
 statement ok
 CREATE TABLE "quotedCase" (id INT PRIMARY KEY)
 
-query error relation "quotedcase" does not exist
+query error pgcode 42P01 relation "quotedcase" does not exist
 SELECT relname from pg_class where oid='quotedCase'::regclass
 
 query T
@@ -228,7 +228,7 @@ SET DATABASE = otherdb
 
 user testuser
 
-query error relation "a" does not exist
+query error pgcode 42P01 relation "a" does not exist
 SELECT 'a'::regclass
 
 user root
@@ -266,7 +266,7 @@ SET DATABASE = thirddb
 # still exists in another database, the query does fail (regclass
 # does not automatically search in other dbs, even for the root user).
 
-query error relation "a" does not exist
+query error pgcode 42P01 relation "a" does not exist
 SELECT relname, relnatts FROM pg_class WHERE oid='a'::regclass
 
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/planning_errors
+++ b/pkg/sql/logictest/testdata/logic_test/planning_errors
@@ -8,5 +8,5 @@ CREATE TABLE kv(k INT, v INT);
  CREATE INDEX aa ON kv(v);
  SELECT k FROM [SHOW JOBS], kv@{FORCE_INDEX=aa,NO_INDEX_JOIN};
 
-statement error relation "nonexistent" does not exist
+statement error pgcode 42P01 relation "nonexistent" does not exist
 SELECT * FROM [SHOW JOBS], [SHOW CREATE TABLE nonexistent];

--- a/pkg/sql/logictest/testdata/logic_test/rename_column
+++ b/pkg/sql/logictest/testdata/logic_test/rename_column
@@ -25,10 +25,10 @@ ALTER TABLE users RENAME COLUMN title TO name
 statement error empty column name
 ALTER TABLE users RENAME COLUMN title TO ""
 
-statement error column "ttle" does not exist
+statement error pgcode 42703 column "ttle" does not exist
 ALTER TABLE users RENAME COLUMN ttle TO species
 
-statement error relation "uses" does not exist
+statement error pgcode 42P01 relation "uses" does not exist
 ALTER TABLE uses RENAME COLUMN title TO species
 
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/rename_database
+++ b/pkg/sql/logictest/testdata/logic_test/rename_database
@@ -38,7 +38,7 @@ SELECT * FROM kv
 statement ok
 ALTER DATABASE test RENAME TO u
 
-statement error relation "kv" does not exist
+statement error pgcode 42P01 relation "kv" does not exist
 SELECT * FROM kv
 
 statement error database "test" does not exist

--- a/pkg/sql/logictest/testdata/logic_test/rename_table
+++ b/pkg/sql/logictest/testdata/logic_test/rename_table
@@ -189,7 +189,7 @@ ALTER TABLE d.kv RENAME TO d.kv2
 statement ok
 INSERT INTO d.kv2 (k,v) VALUES ('e', 'f')
 
-statement error relation \"d.kv\" does not exist
+statement error pgcode 42P01 relation \"d.kv\" does not exist
 INSERT INTO d.kv (k,v) VALUES ('g', 'h')
 
 statement ok
@@ -205,7 +205,7 @@ ALTER DATABASE d RENAME TO dnew
 statement ok
 INSERT INTO dnew.kv (k,v) VALUES ('e', 'f')
 
-statement error relation \"d.kv\" does not exist
+statement error pgcode 42P01 relation \"d.kv\" does not exist
 INSERT INTO d.kv (k,v) VALUES ('g', 'h')
 
 statement ok
@@ -243,7 +243,7 @@ INSERT INTO dd.kv (k,v) VALUES ('a', 'b')
 statement ok
 ROLLBACK
 
-statement error relation "dd\.kv" does not exist
+statement error pgcode 42P01 relation "dd\.kv" does not exist
 INSERT INTO dd.kv (k,v) VALUES ('c', 'd')
 
 # Check that on a rollback a table name cannot be used.
@@ -259,5 +259,5 @@ INSERT INTO d.kv2 (k,v) VALUES ('a', 'b')
 statement ok
 ROLLBACK
 
-statement error relation \"d.kv2\" does not exist
+statement error pgcode 42P01 relation \"d.kv2\" does not exist
 INSERT INTO d.kv2 (k,v) VALUES ('c', 'd')

--- a/pkg/sql/logictest/testdata/logic_test/scrub
+++ b/pkg/sql/logictest/testdata/logic_test/scrub
@@ -1,6 +1,6 @@
 # LogicTest: default parallel-stmts distsql
 
-statement error relation "t" does not exist
+statement error pgcode 42P01 relation "t" does not exist
 EXPERIMENTAL SCRUB TABLE t
 -----
 
@@ -111,13 +111,13 @@ EXPERIMENTAL SCRUB TABLE test.fk_parent WITH OPTIONS CONSTRAINT (fkey)
 
 # Test AS OF SYSTEM TIME
 
-statement error relation "xz" does not exist
+statement error pgcode 42P01 relation "xz" does not exist
 EXPERIMENTAL SCRUB TABLE xz AS OF SYSTEM TIME '2017' WITH OPTIONS PHYSICAL
 
-statement error relation "xz" does not exist
+statement error pgcode 42P01 relation "xz" does not exist
 EXPERIMENTAL SCRUB TABLE xz AS OF SYSTEM TIME '2017' WITH OPTIONS INDEX ALL
 
-statement error relation "xz" does not exist
+statement error pgcode 42P01 relation "xz" does not exist
 EXPERIMENTAL SCRUB TABLE xz AS OF SYSTEM TIME '2017' WITH OPTIONS CONSTRAINT ALL
 
 # Test scrubbing sequences.

--- a/pkg/sql/logictest/testdata/logic_test/select
+++ b/pkg/sql/logictest/testdata/logic_test/select
@@ -286,7 +286,7 @@ SELECT xyzw.y FROM test.xyzw@foo WHERE z = 3
 ----
 2
 
-query error relation "test.unknown" does not exist
+query error pgcode 42P01 relation "test.unknown" does not exist
 SELECT z FROM test.unknown@foo WHERE y = 5
 
 query error index "unknown" not found

--- a/pkg/sql/logictest/testdata/logic_test/table
+++ b/pkg/sql/logictest/testdata/logic_test/table
@@ -127,16 +127,16 @@ f
 statement ok
 SET DATABASE = ""
 
-query error relation "users" does not exist
+query error pgcode 42P01 relation "users" does not exist
 SHOW COLUMNS FROM users
 
-query error relation "test.users" does not exist
+query error pgcode 42P01 relation "test.users" does not exist
 SHOW COLUMNS FROM test.users
 
-query error relation "users" does not exist
+query error pgcode 42P01 relation "users" does not exist
 SHOW INDEXES FROM users
 
-query error relation "test.users" does not exist
+query error pgcode 42P01 relation "test.users" does not exist
 SHOW INDEXES FROM test.users
 
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/union
+++ b/pkg/sql/logictest/testdata/logic_test/union
@@ -221,7 +221,7 @@ SELECT 1 INTERSECT SELECT '3'
 query error EXCEPT types int and string cannot be matched
 SELECT 1 EXCEPT SELECT '3'
 
-query error column z does not exist
+query error pgcode 42703 column \"z\" does not exist
 SELECT 1 UNION SELECT 3 ORDER BY z
 
 query error UNION types int\[] and string\[] cannot be matched

--- a/pkg/sql/logictest/testdata/logic_test/update
+++ b/pkg/sql/logictest/testdata/logic_test/update
@@ -43,7 +43,7 @@ SELECT * FROM kv
 5 11
 7 15
 
-statement error column "m" does not exist
+statement error pgcode 42703 column "m" does not exist
 UPDATE kv SET m = 9 WHERE k IN (1, 3)
 
 statement error unimplemented at or near "k"

--- a/pkg/sql/logictest/testdata/logic_test/values
+++ b/pkg/sql/logictest/testdata/logic_test/values
@@ -17,7 +17,7 @@ VALUES (1), (1), (2), (3) ORDER BY 1 DESC LIMIT 3
 2
 1
 
-query error column z does not exist
+query error pgcode 42703 column \"z\" does not exist
 VALUES (1), (1), (2), (3) ORDER BY z
 
 # subqueries can be evaluated in VALUES

--- a/pkg/sql/logictest/testdata/logic_test/with
+++ b/pkg/sql/logictest/testdata/logic_test/with
@@ -60,7 +60,7 @@ WITH t(x) AS (WITH t(x) AS (SELECT 1) SELECT x * 10 FROM t) SELECT x + 2 FROM t
 
 # CTEs with DMLs
 
-query error relation "t" does not exist
+query error pgcode 42P01 relation "t" does not exist
 WITH t AS (SELECT * FROM x) INSERT INTO t VALUES (1)
 
 query I rowsort

--- a/pkg/sql/sort.go
+++ b/pkg/sql/sort.go
@@ -190,10 +190,7 @@ func (p *planner) orderBy(
 		}
 
 		if index == -1 {
-			return nil, pgerror.NewErrorf(
-				pgerror.CodeUndefinedColumnError,
-				"column %s does not exist", expr,
-			)
+			return nil, sqlbase.NewUndefinedColumnError(expr.String())
 		}
 		ordering = append(ordering,
 			sqlbase.ColumnOrderInfo{ColIdx: index, Direction: direction})

--- a/pkg/sql/sqlbase/errors.go
+++ b/pkg/sql/sqlbase/errors.go
@@ -155,6 +155,11 @@ func NewUndefinedRelationError(name tree.NodeFormatter) error {
 		"relation %q does not exist", tree.ErrString(name))
 }
 
+// NewUndefinedColumnError creates an error that represents a missing database column.
+func NewUndefinedColumnError(name string) error {
+	return pgerror.NewErrorf(pgerror.CodeUndefinedColumnError, "column %q does not exist", name)
+}
+
 // NewDatabaseAlreadyExistsError creates an error for a preexisting database.
 func NewDatabaseAlreadyExistsError(name string) error {
 	return pgerror.NewErrorf(pgerror.CodeDuplicateDatabaseError, "database %q already exists", name)

--- a/pkg/sql/sqlbase/structured.go
+++ b/pkg/sql/sqlbase/structured.go
@@ -1767,7 +1767,7 @@ func (desc *TableDescriptor) FindColumnByName(name tree.Name) (ColumnDescriptor,
 			}
 		}
 	}
-	return ColumnDescriptor{}, false, fmt.Errorf("column %q does not exist", name)
+	return ColumnDescriptor{}, false, NewUndefinedColumnError(string(name))
 }
 
 // UpdateColumnDescriptor updates an existing column descriptor.
@@ -1785,7 +1785,7 @@ func (desc *TableDescriptor) UpdateColumnDescriptor(column ColumnDescriptor) {
 		}
 	}
 
-	panic(fmt.Sprintf("column %q does not exist", column.Name))
+	panic(NewUndefinedColumnError(column.Name))
 }
 
 // FindActiveColumnByName finds an active column with the specified name.
@@ -1795,7 +1795,7 @@ func (desc *TableDescriptor) FindActiveColumnByName(name string) (ColumnDescript
 			return c, nil
 		}
 	}
-	return ColumnDescriptor{}, fmt.Errorf("column %q does not exist", name)
+	return ColumnDescriptor{}, NewUndefinedColumnError(name)
 }
 
 // FindColumnByID finds the column with specified ID.


### PR DESCRIPTION
Found when writing #22714.

This change:
- returns the correct error code for unknown tables in RENAME COLUMN 
- returns the correct error code for missing JOIN columns
- tests all error code for all non-existent table and column errors 