### PR TITLE
ui: clusterviz: make whole locality clickable

### DIFF
--- a/pkg/ui/ccl/src/views/clusterviz/containers/map/localityView.tsx
+++ b/pkg/ui/ccl/src/views/clusterviz/containers/map/localityView.tsx
@@ -101,6 +101,7 @@ class LocalityView extends React.Component<LocalityViewProps & WithRouterProps> 
         style={{ cursor: "pointer" }}
         transform="translate(-90 -100)"
       >
+        <rect width={180} height={210} opacity={0} />
         <Labels
           label={getLocalityLabel(tiers)}
           subLabel={`${leavesUnderMe.length} ${pluralize(leavesUnderMe.length, "Node", "Nodes")}`}


### PR DESCRIPTION
…instead of just the precise area of the interior components, by adding an invisible `<rect>`:

![screen shot 2018-02-14 at 6 19 21 pm](https://user-images.githubusercontent.com/7341/36233381-cb7d3726-11b3-11e8-8510-96f110a28b86.png)

…is there a smarter way to do this? It seems to work pretty well. Also the amount of magic numbers in this file is bad but I'm not sure how much I care.

Release note: None