### PR TITLE
sql: attempt txn auto-commit before flushing txnResults

### DIFF
--- a/pkg/sql/executor.go
+++ b/pkg/sql/executor.go
@@ -873,9 +873,9 @@ func (e *Executor) execParsed(
 //
 // Args:
 // stmtsToExec: A prefix of these will be executed. The remaining ones will be
-// returned as remainingStmts.
+//   returned as remainingStmts.
 // txnPrefix: Set if stmtsToExec corresponds to the start of the current
-// transaction. Used to trap nested BEGINs.
+//   transaction. Used to trap nested BEGINs.
 // autoCommit: If set, the transaction will be committed after running the
 //   statement. If set, stmtsToExec can only contain a single statement.
 //   If set, the transaction state will always be NoTxn when this function
@@ -883,13 +883,13 @@ func (e *Executor) execParsed(
 //   Errors encountered when committing are reported to the caller and are
 //   indistinguishable from errors encountered while running the query.
 // protoTS: If not nil, the transaction proto sets its Orig and Max timestamps
-// to it each retry.
+//   to it each retry.
 //
 // Returns:
 // remainingStmts: all the statements that were not executed.
 // transitionToOpen: specifies if the caller should move from state AutoRetry to
-// state Open. This will be false if the state is not AutoRetry when this
-// returns.
+//   state Open. This will be false if the state is not AutoRetry when this
+//   returns.
 // err: An error that occurred while executing the queries.
 func runWithAutoRetry(
 	e *Executor,
@@ -943,8 +943,8 @@ func runWithAutoRetry(
 
 		// Run some statements.
 		remainingStmts, transitionToOpen, err = runTxnAttempt(
-			e, session, stmtsToExec, pinfo, origState,
-			txnPrefix, asOfSystemTime, avoidCachedDescriptors, automaticRetryCount, txnState.txnResults)
+			e, session, stmtsToExec, pinfo, origState, txnPrefix, autoCommit,
+			asOfSystemTime, avoidCachedDescriptors, automaticRetryCount, txnState.txnResults)
 
 		// Sanity checks.
 		if err != nil && txnState.TxnIsOpen() {
@@ -967,48 +967,7 @@ func runWithAutoRetry(
 			}
 		}
 
-		// Check if we need to auto-commit. If so, we end the transaction now; the
-		// transaction was only supposed to exist for the statement that we just
-		// ran.
 		if autoCommit {
-			if err == nil {
-				txn := txnState.mu.txn
-				if txn == nil {
-					log.Fatalf(session.Ctx(), "implicit txn returned with no error and yet "+
-						"the kv txn is gone. No state transition should have done that. State: %s",
-						txnState.State())
-				}
-
-				// We were told to autoCommit. The KV txn might already be committed
-				// (planNodes are free to do that when running an implicit transaction,
-				// and some try to do it to take advantage of 1-PC txns). If it is, then
-				// there's nothing to do. If it isn't, then we commit it here.
-				//
-				// NOTE(andrei): It bothers me some that we're peeking at txn to figure
-				// out whether we committed or not, where SQL could already know that -
-				// individual statements could report this back.
-				if txn.IsAborted() {
-					log.Fatalf(session.Ctx(), "#7881: the statement we just ran didn't generate an error "+
-						"but the txn proto is aborted. This should never happen. txn: %+v",
-						txn)
-				}
-
-				if !txn.IsCommitted() {
-					var skipCommit bool
-					if e.cfg.TestingKnobs.BeforeAutoCommit != nil {
-						err = e.cfg.TestingKnobs.BeforeAutoCommit(session.Ctx(), stmtsToExec[0].String())
-						skipCommit = err != nil
-					}
-					if !skipCommit {
-						err = txn.Commit(session.Ctx())
-					}
-					log.Eventf(session.Ctx(), "AutoCommit. err: %v\ntxn: %+v", err, txn.Proto())
-					if err != nil {
-						err = txnState.updateStateAndCleanupOnErr(err, e)
-					}
-				}
-			}
-
 			// After autoCommit, unless we're in RestartWait, we leave the transaction
 			// in NoTxn, regardless of whether we executed the query successfully or
 			// we encountered an error.
@@ -1065,14 +1024,16 @@ func runWithAutoRetry(
 //
 // Args:
 // txnPrefix: set if the start of the batch corresponds to the start of the
-// current transaction. Used to trap nested BEGINs.
+//   current transaction. Used to trap nested BEGINs.
+// autoCommit: If set, the transaction will be committed after running the
+//   statement.
 // txnResults: used to push query results.
 //
 // It returns:
 // remainingStmts: all the statements that were not executed.
 // transitionToOpen: specifies if the caller should move from state AutoRetry to
-// state Open. This will be false if the state is not AutoRetry when this
-// returns.
+//   state Open. This will be false if the state is not AutoRetry when this
+//   returns.
 func runTxnAttempt(
 	e *Executor,
 	session *Session,
@@ -1080,6 +1041,7 @@ func runTxnAttempt(
 	pinfo *tree.PlaceholderInfo,
 	origState TxnStateEnum,
 	txnPrefix bool,
+	autoCommit bool,
 	asOfSystemTime bool,
 	avoidCachedDescriptors bool,
 	automaticRetryCount int,
@@ -1128,6 +1090,47 @@ func runTxnAttempt(
 		// If the transaction is done, stop executing more statements.
 		if !txnState.TxnIsOpen() {
 			break
+		}
+	}
+
+	// Check if we need to auto-commit. If so, we end the transaction now; the
+	// transaction was only supposed to exist for the statement that we just
+	// ran. This needs to happen before the txnResults Flush below.
+	if autoCommit {
+		txn := txnState.mu.txn
+		if txn == nil {
+			log.Fatalf(session.Ctx(), "implicit txn returned with no error and yet "+
+				"the kv txn is gone. No state transition should have done that. State: %s",
+				txnState.State())
+		}
+
+		// We were told to autoCommit. The KV txn might already be committed
+		// (planNodes are free to do that when running an implicit transaction,
+		// and some try to do it to take advantage of 1-PC txns). If it is, then
+		// there's nothing to do. If it isn't, then we commit it here.
+		//
+		// NOTE(andrei): It bothers me some that we're peeking at txn to figure
+		// out whether we committed or not, where SQL could already know that -
+		// individual statements could report this back.
+		if txn.IsAborted() {
+			log.Fatalf(session.Ctx(), "#7881: the statement we just ran didn't generate an error "+
+				"but the txn proto is aborted. This should never happen. txn: %+v",
+				txn)
+		}
+
+		if !txn.IsCommitted() {
+			if filter := e.cfg.TestingKnobs.BeforeAutoCommit; filter != nil {
+				if err := filter(session.Ctx(), stmts[0].String()); err != nil {
+					err = txnState.updateStateAndCleanupOnErr(err, e)
+					return nil, false, err
+				}
+			}
+			err := txn.Commit(session.Ctx())
+			log.Eventf(session.Ctx(), "AutoCommit. err: %v\ntxn: %+v", err, txn.Proto())
+			if err != nil {
+				err = txnState.updateStateAndCleanupOnErr(err, e)
+				return nil, false, err
+			}
 		}
 	}
 

--- a/pkg/sql/txn_restart_test.go
+++ b/pkg/sql/txn_restart_test.go
@@ -499,22 +499,22 @@ CREATE TABLE t.test (k INT PRIMARY KEY, v TEXT, t DECIMAL);
 		}, false)
 
 	if err := aborter.QueueStmtForAbortion(
-		"INSERT INTO t.test(k, v, t) VALUES (1, 'boulanger', cluster_logical_timestamp())", 2 /* abortCount */, true, /* willBeRetriedIbid */
+		"INSERT INTO t.test(k, v, t) VALUES (1, 'boulanger', cluster_logical_timestamp()) RETURNING 1", 2 /* abortCount */, true, /* willBeRetriedIbid */
 	); err != nil {
 		t.Fatal(err)
 	}
 	if err := aborter.QueueStmtForAbortion(
-		"INSERT INTO t.test(k, v, t) VALUES (2, 'dromedary', cluster_logical_timestamp())", 2 /* abortCount */, true, /* willBeRetriedIbid */
+		"INSERT INTO t.test(k, v, t) VALUES (2, 'dromedary', cluster_logical_timestamp()) RETURNING 1", 2 /* abortCount */, true, /* willBeRetriedIbid */
 	); err != nil {
 		t.Fatal(err)
 	}
 	if err := aborter.QueueStmtForAbortion(
-		"INSERT INTO t.test(k, v, t) VALUES (3, 'fajita', cluster_logical_timestamp())", 2 /* abortCount */, true, /* willBeRetriedIbid */
+		"INSERT INTO t.test(k, v, t) VALUES (3, 'fajita', cluster_logical_timestamp()) RETURNING 1", 2 /* abortCount */, true, /* willBeRetriedIbid */
 	); err != nil {
 		t.Fatal(err)
 	}
 	if err := aborter.QueueStmtForAbortion(
-		"INSERT INTO t.test(k, v, t) VALUES (4, 'hooly', cluster_logical_timestamp())", 2 /* abortCount */, true, /* willBeRetriedIbid */
+		"INSERT INTO t.test(k, v, t) VALUES (4, 'hooly', cluster_logical_timestamp()) RETURNING 1", 2 /* abortCount */, true, /* willBeRetriedIbid */
 	); err != nil {
 		t.Fatal(err)
 	}
@@ -534,20 +534,38 @@ CREATE TABLE t.test (k INT PRIMARY KEY, v TEXT, t DECIMAL);
 	// TODO(knz): This test can be made more robust by exposing the
 	// current allocation count in monitor and checking that it has the
 	// same value at the beginning of each retry.
-	if _, err := sqlDB.Exec(`
-INSERT INTO t.test(k, v, t) VALUES (1, 'boulanger', cluster_logical_timestamp());
+	rows, err := sqlDB.Query(`
+INSERT INTO t.test(k, v, t) VALUES (1, 'boulanger', cluster_logical_timestamp()) RETURNING 1;
 BEGIN;
-SELECT * FROM t.test;
-INSERT INTO t.test(k, v, t) VALUES (2, 'dromedary', cluster_logical_timestamp());
-INSERT INTO t.test(k, v, t) VALUES (3, 'fajita', cluster_logical_timestamp());
+INSERT INTO t.test(k, v, t) VALUES (2, 'dromedary', cluster_logical_timestamp()) RETURNING 1;
+INSERT INTO t.test(k, v, t) VALUES (3, 'fajita', cluster_logical_timestamp()) RETURNING 1;
 END;
-INSERT INTO t.test(k, v, t) VALUES (4, 'hooly', cluster_logical_timestamp());
+INSERT INTO t.test(k, v, t) VALUES (4, 'hooly', cluster_logical_timestamp()) RETURNING 1;
 BEGIN;
-INSERT INTO t.test(k, v, t) VALUES (5, 'josephine', cluster_logical_timestamp());
-INSERT INTO t.test(k, v, t) VALUES (6, 'laureal', cluster_logical_timestamp());
-`); err != nil {
+INSERT INTO t.test(k, v, t) VALUES (5, 'josephine', cluster_logical_timestamp()) RETURNING 1;
+INSERT INTO t.test(k, v, t) VALUES (6, 'laureal', cluster_logical_timestamp()) RETURNING 1;
+`)
+	if err != nil {
 		t.Fatal(err)
 	}
+	defer rows.Close()
+
+	resSets := 0
+	for {
+		for rows.Next() {
+			resSets++
+		}
+		if !rows.NextResultSet() {
+			break
+		}
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatal(err)
+	}
+	if resSets != 6 {
+		t.Fatalf("Expected 6 result sets, got %d", resSets)
+	}
+
 	cleanupFilter()
 
 	checkRestarts(t, magicVals)
@@ -596,7 +614,7 @@ BEGIN;
 	}
 
 	// Continue the txn in a new request, which is not retriable.
-	_, err := sqlDB.Exec("INSERT INTO t.test(k, v, t) VALUES (4, 'hooly', cluster_logical_timestamp())")
+	_, err = sqlDB.Exec("INSERT INTO t.test(k, v, t) VALUES (4, 'hooly', cluster_logical_timestamp())")
 	if !testutils.IsError(
 		err, "RETRY_POSSIBLE_REPLAY") {
 		t.Errorf("didn't get expected injected error. Got: %v", err)


### PR DESCRIPTION
Fixes #19269.
Unflakes #22714.

From https://github.com/cockroachdb/cockroach/issues/19269#issuecomment-365765947:
> The problem is that we [`Flush` the statement results for an `AutoRetry` transaction attempt](https://github.com/cockroachdb/cockroach/blob/814a7ee11e5b32c494579265bdf449897b2a1bc8/pkg/sql/executor.go#L1134) before attempting to [perform an auto-commit](https://github.com/cockroachdb/cockroach/blob/814a7ee11e5b32c494579265bdf449897b2a1bc8/pkg/sql/executor.go#L970). The auto-commit can then throw a retryable error, forcing us to retry the entire transaction. At this point, we [check](https://github.com/cockroachdb/cockroach/blob/a91d155c45cf1b340e56ade1af825938b7b0b5c9/pkg/sql/executor.go#L1026) `ResultsSentToClient` to decide whether it's safe to retry automatically on the gateway instead of sending the error up to the client. The issue is that `ResultsGroup.Flush` was meant to be scoped to an entire transaction and because of this, it [resets](https://github.com/cockroachdb/cockroach/blob/a91d155c45cf1b340e56ade1af825938b7b0b5c9/pkg/sql/pgwire/v3.go#L1068) the `hasSentResults` flag. This in turn makes `ResultsSentToClient` return false, which allows us to perform an auto-retry on the gateway after we've sent results to the client, resulting in duplicate results.

Release note: None