### PR TITLE
opt: support joins in the optbuilder

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/scalar
+++ b/pkg/sql/opt/exec/execbuilder/testdata/scalar
@@ -240,11 +240,11 @@ render     0  render  ·         ·            (column8)                        
 exec-explain
 SELECT CASE WHEN a = 2 THEN 1 ELSE 2 END FROM t.t
 ----
-render     0  render  ·         ·                                    (column8)                          ·
- │         0  ·       render 0  CASE WHEN t.a = 2 THEN 1 ELSE 2 END  ·                                  ·
- └── scan  1  scan    ·         ·                                    (a, b, c, d, j, s, rowid[hidden])  ·
-·          1  ·       table     t@primary                            ·                                  ·
-·          1  ·       spans     ALL                                  ·                                  ·
+render     0  render  ·         ·                                             (column8)                          ·
+ │         0  ·       render 0  CASE WHEN t.public.t.a = 2 THEN 1 ELSE 2 END  ·                                  ·
+ └── scan  1  scan    ·         ·                                             (a, b, c, d, j, s, rowid[hidden])  ·
+·          1  ·       table     t@primary                                     ·                                  ·
+·          1  ·       spans     ALL                                           ·                                  ·
 
 ## Functions not supported yet.
 #exec-explain

--- a/pkg/sql/opt/ops/scalar.opt
+++ b/pkg/sql/opt/ops/scalar.opt
@@ -360,6 +360,11 @@ define Function {
     Def  FuncDef
 }
 
+[Scalar]
+define Coalesce {
+    Args ExprList
+}
+
 # UnsupportedExpr is used for interfacing with the old planner code. It can
 # encapsulate a TypedExpr that is otherwise not supported by the optimizer.
 [Scalar]

--- a/pkg/sql/opt/opt/factory.og.go
+++ b/pkg/sql/opt/opt/factory.og.go
@@ -227,6 +227,9 @@ type Factory interface {
 	// of the function as well as a pointer to the builtin overload definition.
 	ConstructFunction(args ListID, def PrivateID) GroupID
 
+	// ConstructCoalesce constructs an expression for the Coalesce operator.
+	ConstructCoalesce(args ListID) GroupID
+
 	// ConstructUnsupportedExpr constructs an expression for the UnsupportedExpr operator.
 	// UnsupportedExpr is used for interfacing with the old planner code. It can
 	// encapsulate a TypedExpr that is otherwise not supported by the optimizer.

--- a/pkg/sql/opt/opt/operator.og.go
+++ b/pkg/sql/opt/opt/operator.og.go
@@ -153,6 +153,8 @@ const (
 	// of the function as well as a pointer to the builtin overload definition.
 	FunctionOp
 
+	CoalesceOp
+
 	// UnsupportedExprOp is used for interfacing with the old planner code. It can
 	// encapsulate a TypedExpr that is otherwise not supported by the optimizer.
 	UnsupportedExprOp
@@ -250,9 +252,9 @@ const (
 	NumOperators
 )
 
-const opNames = "unknownsubqueryvariableconsttruefalseplaceholdertupleprojectionsaggregationsgroupingsexistsandornoteqltgtlegeneinnot-inlikenot-likei-likenot-i-likesimilar-tonot-similar-toreg-matchnot-reg-matchreg-i-matchnot-reg-i-matchisis-notcontainsbitandbitorbitxorplusminusmultdivfloor-divmodpowconcatl-shiftr-shiftfetch-valfetch-textfetch-val-pathfetch-text-pathunary-plusunary-minusunary-complementfunctionunsupported-exprscanvaluesselectprojectinner-joinleft-joinright-joinfull-joinsemi-joinanti-joininner-join-applyleft-join-applyright-join-applyfull-join-applysemi-join-applyanti-join-applygroup-byunionintersectexceptsortpresent"
+const opNames = "unknownsubqueryvariableconsttruefalseplaceholdertupleprojectionsaggregationsgroupingsexistsandornoteqltgtlegeneinnot-inlikenot-likei-likenot-i-likesimilar-tonot-similar-toreg-matchnot-reg-matchreg-i-matchnot-reg-i-matchisis-notcontainsbitandbitorbitxorplusminusmultdivfloor-divmodpowconcatl-shiftr-shiftfetch-valfetch-textfetch-val-pathfetch-text-pathunary-plusunary-minusunary-complementfunctioncoalesceunsupported-exprscanvaluesselectprojectinner-joinleft-joinright-joinfull-joinsemi-joinanti-joininner-join-applyleft-join-applyright-join-applyfull-join-applysemi-join-applyanti-join-applygroup-byunionintersectexceptsortpresent"
 
-var opIndexes = [...]uint32{0, 7, 15, 23, 28, 32, 37, 48, 53, 64, 76, 85, 91, 94, 96, 99, 101, 103, 105, 107, 109, 111, 113, 119, 123, 131, 137, 147, 157, 171, 180, 193, 204, 219, 221, 227, 235, 241, 246, 252, 256, 261, 265, 268, 277, 280, 283, 289, 296, 303, 312, 322, 336, 351, 361, 372, 388, 396, 412, 416, 422, 428, 435, 445, 454, 464, 473, 482, 491, 507, 522, 538, 553, 568, 583, 591, 596, 605, 611, 615, 622}
+var opIndexes = [...]uint32{0, 7, 15, 23, 28, 32, 37, 48, 53, 64, 76, 85, 91, 94, 96, 99, 101, 103, 105, 107, 109, 111, 113, 119, 123, 131, 137, 147, 157, 171, 180, 193, 204, 219, 221, 227, 235, 241, 246, 252, 256, 261, 265, 268, 277, 280, 283, 289, 296, 303, 312, 322, 336, 351, 361, 372, 388, 396, 404, 420, 424, 430, 436, 443, 453, 462, 472, 481, 490, 499, 515, 530, 546, 561, 576, 591, 599, 604, 613, 619, 623, 630}
 
 var ScalarOperators = [...]Operator{
 	SubqueryOp,
@@ -311,6 +313,7 @@ var ScalarOperators = [...]Operator{
 	UnaryMinusOp,
 	UnaryComplementOp,
 	FunctionOp,
+	CoalesceOp,
 	UnsupportedExprOp,
 }
 

--- a/pkg/sql/opt/optbuilder/builder.go
+++ b/pkg/sql/opt/optbuilder/builder.go
@@ -964,7 +964,7 @@ func (b *Builder) buildJoin(
 		}
 	}
 
-	joinType := getJoinType(join.Join)
+	joinType := sqlbase.JoinTypeFromAstString(join.Join)
 
 	switch cond := join.Cond.(type) {
 	case tree.NaturalJoinCond, *tree.UsingJoinCond:
@@ -1035,7 +1035,7 @@ func commonColumns(leftScope, rightScope *scope) (common tree.NameList) {
 // See Builder.buildStmt above for a description of the remaining input and
 // return values.
 func (b *Builder) buildUsingJoin(
-	joinType joinType,
+	joinType sqlbase.JoinType,
 	names tree.NameList,
 	left, right opt.GroupID,
 	leftScope, rightScope, inScope *scope,
@@ -1134,7 +1134,7 @@ func (b *Builder) buildUsingJoin(
 // See Builder.buildStmt above for a description of the remaining input and
 // return values.
 func (b *Builder) buildUsingJoinPredicate(
-	joinType joinType,
+	joinType sqlbase.JoinType,
 	leftCols []columnProps,
 	rightCols []columnProps,
 	names tree.NameList,
@@ -1171,11 +1171,11 @@ func (b *Builder) buildUsingJoinPredicate(
 		conditions = append(conditions, eq)
 
 		// Add the merged column to the scope, constructing a new column if needed.
-		if joinType == joinTypeInner || joinType == joinTypeLeftOuter {
+		if joinType == sqlbase.InnerJoin || joinType == sqlbase.LeftOuterJoin {
 			// The merged column is the same as the corresponding column from the
 			// left side.
 			outScope.cols = append(outScope.cols, *leftCol)
-		} else if joinType == joinTypeRightOuter &&
+		} else if joinType == sqlbase.RightOuterJoin &&
 			!sqlbase.DatumTypeHasCompositeKeyEncoding(leftCol.typ) {
 			// The merged column is the same as the corresponding column from the
 			// right side.
@@ -1231,39 +1231,17 @@ func (b *Builder) constructFilter(conditions []opt.GroupID) opt.GroupID {
 	}
 }
 
-type joinType int
-
-const (
-	joinTypeInner joinType = iota
-	joinTypeLeftOuter
-	joinTypeRightOuter
-	joinTypeFullOuter
-)
-
-func getJoinType(astJoinType string) joinType {
-	switch astJoinType {
-	case "JOIN", "INNER JOIN", "CROSS JOIN":
-		return joinTypeInner
-	case "LEFT JOIN":
-		return joinTypeLeftOuter
-	case "RIGHT JOIN":
-		return joinTypeRightOuter
-	case "FULL JOIN":
-		return joinTypeFullOuter
-	default:
-		panic(errorf("unsupported JOIN type %T", astJoinType))
-	}
-}
-
-func (b *Builder) constructJoin(joinType joinType, left, right, filter opt.GroupID) opt.GroupID {
+func (b *Builder) constructJoin(
+	joinType sqlbase.JoinType, left, right, filter opt.GroupID,
+) opt.GroupID {
 	switch joinType {
-	case joinTypeInner:
+	case sqlbase.InnerJoin:
 		return b.factory.ConstructInnerJoin(left, right, filter)
-	case joinTypeLeftOuter:
+	case sqlbase.LeftOuterJoin:
 		return b.factory.ConstructLeftJoin(left, right, filter)
-	case joinTypeRightOuter:
+	case sqlbase.RightOuterJoin:
 		return b.factory.ConstructRightJoin(left, right, filter)
-	case joinTypeFullOuter:
+	case sqlbase.FullOuterJoin:
 		return b.factory.ConstructFullJoin(left, right, filter)
 	default:
 		panic(fmt.Errorf("unsupported JOIN type %d", joinType))

--- a/pkg/sql/opt/optbuilder/builder.go
+++ b/pkg/sql/opt/optbuilder/builder.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/opt"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/optbase"
@@ -258,7 +259,7 @@ func (b *Builder) buildTable(
 			panic(builderError{err})
 		}
 
-		return b.buildScan(tbl, inScope)
+		return b.buildScan(tbl, tn, inScope)
 
 	case *tree.ParenTableExpr:
 		return b.buildTable(source.Expr, inScope)
@@ -283,7 +284,7 @@ func (b *Builder) renameSource(as tree.AliasClause, scope *scope) {
 		// If an alias was specified, use that.
 		tableAlias = as.Alias
 		for i := range scope.cols {
-			scope.cols[i].table = optbase.TableName(tableAlias)
+			scope.cols[i].table.TableName = tableAlias
 		}
 	}
 
@@ -298,17 +299,20 @@ func (b *Builder) renameSource(as tree.AliasClause, scope *scope) {
 			if scope.cols[colIdx].hidden {
 				continue
 			}
-			scope.cols[colIdx].name = optbase.ColumnName(colAlias[aliasIdx])
+			scope.cols[colIdx].name = colAlias[aliasIdx]
 			aliasIdx++
 		}
 	}
 }
 
-// buildScan builds a memo group for a scanOp expression on the given table.
+// buildScan builds a memo group for a scanOp expression on the given table
+// with the given table name.
 //
 // See Builder.buildStmt above for a description of the remaining input and
 // return values.
-func (b *Builder) buildScan(tbl optbase.Table, inScope *scope) (out opt.GroupID, outScope *scope) {
+func (b *Builder) buildScan(
+	tbl optbase.Table, tn *tree.TableName, inScope *scope,
+) (out opt.GroupID, outScope *scope) {
 	tblIndex := b.factory.Metadata().AddTable(tbl)
 
 	outScope = inScope.push()
@@ -317,8 +321,8 @@ func (b *Builder) buildScan(tbl optbase.Table, inScope *scope) (out opt.GroupID,
 		colIndex := b.factory.Metadata().TableColumn(tblIndex, i)
 		colProps := columnProps{
 			index:  colIndex,
-			name:   col.ColName(),
-			table:  tbl.TabName(),
+			name:   tree.Name(col.ColName()),
+			table:  *tn,
 			typ:    col.DatumType(),
 			hidden: col.IsHidden(),
 		}
@@ -814,16 +818,25 @@ func (b *Builder) expandStarAndResolveType(
 	// NB: The case statements are sorted lexicographically.
 	switch t := expr.(type) {
 	case *tree.AllColumnsSelector:
-		// TODO(whomever): this improperly omits the catalog/schema prefix.
-		tableName := optbase.TableName(t.TableName.Parts[0])
+		tn, err := tree.NormalizeTableName(&t.TableName)
+		if err != nil {
+			panic(builderError{err})
+		}
+
+		numRes, src, _, err := inScope.FindSourceMatchingName(b.ctx, tn)
+		if err != nil {
+			panic(builderError{err})
+		}
+		if numRes == tree.NoResults {
+			panic(builderError{pgerror.NewErrorf(pgerror.CodeUndefinedColumnError,
+				"no data source named %q", tree.ErrString(&tn))})
+		}
+
 		for i := range inScope.cols {
 			col := inScope.cols[i]
-			if col.table == tableName && !col.hidden {
+			if col.table == *src && !col.hidden {
 				exprs = append(exprs, &col)
 			}
-		}
-		if len(exprs) == 0 {
-			panic(errorf("unknown table %s", t))
 		}
 
 	case tree.UnqualifiedStar:
@@ -932,22 +945,22 @@ func (b *Builder) buildJoin(
 	right, rightScope := b.buildTable(join.Right, inScope)
 
 	// Check that the same table name is not used on both sides.
-	leftTables := make(map[string]struct{})
+	leftTables := make(map[tree.TableName]struct{})
 	for _, leftCol := range leftScope.cols {
-		leftTables[string(leftCol.table)] = exists
+		leftTables[leftCol.table] = exists
 	}
 
 	for _, rightCol := range rightScope.cols {
 		t := rightCol.table
-		if t == "" {
+		if t.TableName == "" {
 			// Allow joins of sources that define columns with no
 			// associated table name. At worst, the USING/NATURAL
 			// detection code or expression analysis for ON will detect an
 			// ambiguity later.
 			continue
 		}
-		if _, ok := leftTables[string(t)]; ok {
-			panic(errorf("cannot join columns from the same source name %q (missing AS clause)", t))
+		if _, ok := leftTables[t]; ok {
+			panic(errorf("cannot join columns from the same source name %q (missing AS clause)", t.TableName))
 		}
 	}
 
@@ -999,7 +1012,7 @@ func commonColumns(leftScope, rightScope *scope) (common tree.NameList) {
 			}
 
 			if leftCol.name == rightCol.name {
-				common = append(common, tree.Name(leftCol.name))
+				common = append(common, leftCol.name)
 				break
 			}
 		}
@@ -1127,13 +1140,12 @@ func (b *Builder) buildUsingJoinPredicate(
 	names tree.NameList,
 	inScope *scope,
 ) (mergedCols map[opt.ColumnIndex]opt.GroupID, out opt.GroupID, outScope *scope) {
-	joined := make(map[optbase.ColumnName]*columnProps, len(names))
+	joined := make(map[tree.Name]*columnProps, len(names))
 	conditions := make([]opt.GroupID, 0, len(names))
 	mergedCols = make(map[opt.ColumnIndex]opt.GroupID)
 	outScope = inScope.push()
 
-	for _, n := range names {
-		name := optbase.ColumnName(n)
+	for _, name := range names {
 		if _, ok := joined[name]; ok {
 			panic(errorf("column %q appears more than once in USING clause", name))
 		}
@@ -1192,9 +1204,7 @@ func (b *Builder) buildUsingJoinPredicate(
 // (2) If the column has the same name as one of the columns in `joined` but is
 //     not equal, it is marked as hidden and added to the scope.
 // (3) All other columns are added to the scope without modification.
-func hideMatchingColumns(
-	cols []columnProps, joined map[optbase.ColumnName]*columnProps, scope *scope,
-) {
+func hideMatchingColumns(cols []columnProps, joined map[tree.Name]*columnProps, scope *scope) {
 	for _, col := range cols {
 		if foundCol, ok := joined[col.name]; ok {
 			// Hide other columns with the same name.
@@ -1265,7 +1275,7 @@ func (b *Builder) constructJoin(joinType joinType, left, right, filter opt.Group
 //
 // context is a string ("left" or "right") used to indicate in the error
 // message whether the name is missing from the left or right side of the join.
-func findUsingColumn(cols []columnProps, name optbase.ColumnName, context string) *columnProps {
+func findUsingColumn(cols []columnProps, name tree.Name, context string) *columnProps {
 	for i := range cols {
 		col := &cols[i]
 		if !col.hidden && col.name == name {
@@ -1397,9 +1407,9 @@ func (b *Builder) buildVariableProjection(
 	// as a visible member of an anonymous table.
 	col = &outScope.cols[len(outScope.cols)-1]
 	if label != "" {
-		col.name = optbase.ColumnName(label)
+		col.name = tree.Name(label)
 	}
-	col.table = ""
+	col.table.TableName = ""
 	col.hidden = false
 	return out
 }
@@ -1444,7 +1454,7 @@ func (b *Builder) buildDefaultScalarProjection(
 			// The column already exists, so use that instead.
 			col = &b.colMap[col.index]
 			if label != "" {
-				col.name = optbase.ColumnName(label)
+				col.name = tree.Name(label)
 			}
 			outScope.cols = append(outScope.cols, *col)
 
@@ -1475,7 +1485,7 @@ func (b *Builder) synthesizeColumn(scope *scope, label string, typ types.T) *col
 	}
 
 	colIndex := b.factory.Metadata().AddColumn(label, typ)
-	col := columnProps{name: optbase.ColumnName(label), typ: typ, index: colIndex}
+	col := columnProps{name: tree.Name(label), typ: typ, index: colIndex}
 	b.colMap = append(b.colMap, col)
 	scope.cols = append(scope.cols, col)
 	return &scope.cols[len(scope.cols)-1]

--- a/pkg/sql/opt/optbuilder/builder.go
+++ b/pkg/sql/opt/optbuilder/builder.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/opt"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/optbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/builtins"
@@ -241,20 +242,11 @@ func (b *Builder) buildTable(
 		out, outScope = b.buildTable(source.Expr, inScope)
 
 		// Overwrite output properties with any alias information.
-		if source.As.Alias != "" {
-			if n := len(source.As.Cols); n > 0 && n != len(outScope.cols) {
-				panic(errorf("rename specified %d columns, but table contains %d", n, len(outScope.cols)))
-			}
-
-			for i := range outScope.cols {
-				outScope.cols[i].table = optbase.TableName(source.As.Alias)
-				if i < len(source.As.Cols) {
-					outScope.cols[i].name = optbase.ColumnName(source.As.Cols[i])
-				}
-			}
-		}
-
+		b.renameSource(source.As, outScope)
 		return out, outScope
+
+	case *tree.JoinTableExpr:
+		return b.buildJoin(source, inScope)
 
 	case *tree.NormalizableTableName:
 		tn, err := source.Normalize()
@@ -276,6 +268,39 @@ func (b *Builder) buildTable(
 
 	default:
 		panic(errorf("not yet implemented: table expr: %T", texpr))
+	}
+}
+
+// renameSource applies an AS clause to the columns in scope.
+func (b *Builder) renameSource(as tree.AliasClause, scope *scope) {
+	var tableAlias tree.Name
+	colAlias := as.Cols
+
+	if as.Alias != "" {
+		// TODO(rytaft): Handle anonymous tables such as set-generating
+		// functions with just one column.
+
+		// If an alias was specified, use that.
+		tableAlias = as.Alias
+		for i := range scope.cols {
+			scope.cols[i].table = optbase.TableName(tableAlias)
+		}
+	}
+
+	if len(colAlias) > 0 {
+		// The column aliases can only refer to explicit columns.
+		for colIdx, aliasIdx := 0, 0; aliasIdx < len(colAlias); colIdx++ {
+			if colIdx >= len(scope.cols) {
+				panic(errorf(
+					"source %q has %d columns available but %d columns specified",
+					tableAlias, aliasIdx, len(colAlias)))
+			}
+			if scope.cols[colIdx].hidden {
+				continue
+			}
+			scope.cols[colIdx].name = optbase.ColumnName(colAlias[aliasIdx])
+			aliasIdx++
+		}
 	}
 }
 
@@ -879,6 +904,12 @@ func (b *Builder) hasAggregates(selects tree.SelectExprs) bool {
 	return false
 }
 
+// buildHaving builds a set of memo groups that represent the given HAVING
+// clause. inScope contains the name bindings that are visible for this HAVING
+// clause (e.g., passed in from an enclosing statement).
+//
+// The return value corresponds to the top-level memo group ID for this
+// HAVING clause.
 func (b *Builder) buildHaving(having tree.Expr, inScope *scope) opt.GroupID {
 	out := b.buildScalar(inScope.resolveType(having, types.Bool), inScope)
 	if len(inScope.groupby.varsUsed) > 0 {
@@ -887,6 +918,362 @@ func (b *Builder) buildHaving(having tree.Expr, inScope *scope) opt.GroupID {
 		panic(groupingError(col.String()))
 	}
 	return out
+}
+
+// buildJoin builds a set of memo groups that represent the given join table
+// expression.
+//
+// See Builder.buildStmt above for a description of the remaining input and
+// return values.
+func (b *Builder) buildJoin(
+	join *tree.JoinTableExpr, inScope *scope,
+) (out opt.GroupID, outScope *scope) {
+	left, leftScope := b.buildTable(join.Left, inScope)
+	right, rightScope := b.buildTable(join.Right, inScope)
+
+	// Check that the same table name is not used on both sides.
+	leftTables := make(map[string]struct{})
+	for _, leftCol := range leftScope.cols {
+		leftTables[string(leftCol.table)] = exists
+	}
+
+	for _, rightCol := range rightScope.cols {
+		t := rightCol.table
+		if t == "" {
+			// Allow joins of sources that define columns with no
+			// associated table name. At worst, the USING/NATURAL
+			// detection code or expression analysis for ON will detect an
+			// ambiguity later.
+			continue
+		}
+		if _, ok := leftTables[string(t)]; ok {
+			panic(errorf("cannot join columns from the same source name %q (missing AS clause)", t))
+		}
+	}
+
+	joinType := getJoinType(join.Join)
+
+	switch cond := join.Cond.(type) {
+	case tree.NaturalJoinCond, *tree.UsingJoinCond:
+		var usingColNames tree.NameList
+
+		switch t := cond.(type) {
+		case tree.NaturalJoinCond:
+			usingColNames = commonColumns(leftScope, rightScope)
+		case *tree.UsingJoinCond:
+			usingColNames = t.Cols
+		}
+
+		return b.buildUsingJoin(joinType, usingColNames, left, right, leftScope, rightScope, inScope)
+
+	case *tree.OnJoinCond, nil:
+		// Append columns added by the children, as they are visible to the filter.
+		outScope = inScope.push()
+		outScope.appendColumns(leftScope)
+		outScope.appendColumns(rightScope)
+
+		var filter opt.GroupID
+		if on, ok := cond.(*tree.OnJoinCond); ok {
+			filter = b.buildScalar(outScope.resolveType(on.Expr, types.Bool), outScope)
+		} else {
+			filter = b.factory.ConstructTrue()
+		}
+
+		return b.constructJoin(joinType, left, right, filter), outScope
+
+	default:
+		panic(fmt.Sprintf("unsupported join condition %#v", cond))
+	}
+}
+
+// commonColumns returns the names of columns common on the
+// left and right sides, for use by NATURAL JOIN.
+func commonColumns(leftScope, rightScope *scope) (common tree.NameList) {
+	for _, leftCol := range leftScope.cols {
+		if leftCol.hidden {
+			continue
+		}
+		for _, rightCol := range rightScope.cols {
+			if rightCol.hidden {
+				continue
+			}
+
+			if leftCol.name == rightCol.name {
+				common = append(common, tree.Name(leftCol.name))
+				break
+			}
+		}
+	}
+
+	return common
+}
+
+// buildUsingJoin builds a set of memo groups that represent the given join
+// table expression with the given `USING` column names. It is used for both
+// USING and NATURAL joins.
+//
+// joinType    The join type (inner, left, right or outer)
+// names       The list of `USING` column names
+// left        The memo group ID of the left table
+// right       The memo group ID of the right table
+// leftScope   The outScope from the left table
+// rightScope  The outScope from the right table
+//
+// See Builder.buildStmt above for a description of the remaining input and
+// return values.
+func (b *Builder) buildUsingJoin(
+	joinType joinType,
+	names tree.NameList,
+	left, right opt.GroupID,
+	leftScope, rightScope, inScope *scope,
+) (out opt.GroupID, outScope *scope) {
+	// Build the join predicate.
+	mergedCols, filter, outScope := b.buildUsingJoinPredicate(
+		joinType, leftScope.cols, rightScope.cols, names, inScope,
+	)
+
+	out = b.constructJoin(joinType, left, right, filter)
+
+	if len(mergedCols) > 0 {
+		// Wrap in a projection to include the merged columns.
+		projections := make([]opt.GroupID, 0, len(outScope.cols))
+		for _, col := range outScope.cols {
+			if mergedCol, ok := mergedCols[col.index]; ok {
+				projections = append(projections, mergedCol)
+			} else {
+				v := b.factory.ConstructVariable(b.factory.InternPrivate(col.index))
+				projections = append(projections, v)
+			}
+		}
+
+		p := b.constructList(opt.ProjectionsOp, projections, outScope.cols)
+		out = b.factory.ConstructProject(out, p)
+	}
+
+	return out, outScope
+}
+
+// buildUsingJoinPredicate builds a set of memo groups that represent the join
+// conditions for a USING join or natural join. It finds the columns in the
+// left and right relations that match the columns provided in the names
+// parameter, and creates equality predicate(s) with those columns. It also
+// ensures that there is a single output column for each name in `names`
+// (other columns with the same name are hidden).
+//
+// -- Merged columns --
+//
+// With NATURAL JOIN or JOIN USING (a,b,c,...), SQL allows us to refer to the
+// columns a,b,c directly; these columns have the following semantics:
+//   a = IFNULL(left.a, right.a)
+//   b = IFNULL(left.b, right.b)
+//   c = IFNULL(left.c, right.c)
+//   ...
+//
+// Furthermore, a star has to resolve the columns in the following order:
+// merged columns, non-equality columns from the left table, non-equality
+// columns from the right table. To perform this rearrangement, we use a
+// projection on top of the join. Note that the original columns must
+// still be accessible via left.a, right.a (they will just be hidden).
+//
+// For inner or left outer joins, a is always the same as left.a.
+//
+// For right outer joins, a is always equal to right.a; but for some types
+// (like collated strings), this doesn't mean it is the same as right.a. In
+// this case we must still use the IFNULL construct.
+//
+// Example:
+//
+//  left has columns (a,b,x)
+//  right has columns (a,b,y)
+//
+//  - SELECT * FROM left JOIN right USING(a,b)
+//
+//  join has columns:
+//    1: left.a
+//    2: left.b
+//    3: left.x
+//    4: right.a
+//    5: right.b
+//    6: right.y
+//
+//  projection has columns and corresponding variable expressions:
+//    1: a aka left.a        @1
+//    2: b aka left.b        @2
+//    3: left.x              @3
+//    4: right.a (hidden)    @4
+//    5: right.b (hidden)    @5
+//    6: right.y             @6
+//
+// If the join was a FULL OUTER JOIN, the columns would be:
+//    1: a                   IFNULL(@1,@4)
+//    2: b                   IFNULL(@2,@5)
+//    3: left.a (hidden)     @1
+//    4: left.b (hidden)     @2
+//    5: left.x              @3
+//    6: right.a (hidden)    @4
+//    7: right.b (hidden)    @5
+//    8: right.y             @6
+//
+// If new merged columns are created (as in the FULL OUTER JOIN example above),
+// the return value mergedCols contains a mapping from the column index to the
+// memo group ID of the IFNULL expression.
+//
+// See Builder.buildStmt above for a description of the remaining input and
+// return values.
+func (b *Builder) buildUsingJoinPredicate(
+	joinType joinType,
+	leftCols []columnProps,
+	rightCols []columnProps,
+	names tree.NameList,
+	inScope *scope,
+) (mergedCols map[opt.ColumnIndex]opt.GroupID, out opt.GroupID, outScope *scope) {
+	joined := make(map[optbase.ColumnName]*columnProps, len(names))
+	conditions := make([]opt.GroupID, 0, len(names))
+	mergedCols = make(map[opt.ColumnIndex]opt.GroupID)
+	outScope = inScope.push()
+
+	for _, n := range names {
+		name := optbase.ColumnName(n)
+		if _, ok := joined[name]; ok {
+			panic(errorf("column %q appears more than once in USING clause", name))
+		}
+
+		// For every adjacent pair of tables, add an equality predicate.
+		leftCol := findUsingColumn(leftCols, name, "left")
+		rightCol := findUsingColumn(rightCols, name, "right")
+
+		if !leftCol.typ.Equivalent(rightCol.typ) {
+			// First, check if the comparison would even be valid.
+			if _, found := tree.FindEqualComparisonFunction(leftCol.typ, rightCol.typ); !found {
+				panic(errorf(
+					"JOIN/USING types %s for left and %s for right cannot be matched for column %s",
+					leftCol.typ, rightCol.typ, leftCol.name,
+				))
+			}
+		}
+
+		// Construct the predicate.
+		leftVar := b.factory.ConstructVariable(b.factory.InternPrivate(leftCol.index))
+		rightVar := b.factory.ConstructVariable(b.factory.InternPrivate(rightCol.index))
+		eq := b.factory.ConstructEq(leftVar, rightVar)
+		conditions = append(conditions, eq)
+
+		// Add the merged column to the scope, constructing a new column if needed.
+		if joinType == joinTypeInner || joinType == joinTypeLeftOuter {
+			// The merged column is the same as the corresponding column from the
+			// left side.
+			outScope.cols = append(outScope.cols, *leftCol)
+		} else if joinType == joinTypeRightOuter &&
+			!sqlbase.DatumTypeHasCompositeKeyEncoding(leftCol.typ) {
+			// The merged column is the same as the corresponding column from the
+			// right side.
+			outScope.cols = append(outScope.cols, *rightCol)
+		} else {
+			// Construct a new merged column to represent IFNULL(left, right).
+			col := b.synthesizeColumn(outScope, string(leftCol.name), leftCol.typ)
+			merged := b.factory.ConstructCoalesce(b.factory.InternList([]opt.GroupID{leftVar, rightVar}))
+			mergedCols[col.index] = merged
+		}
+
+		joined[name] = &outScope.cols[len(outScope.cols)-1]
+	}
+
+	// Hide other columns that have the same name as the merged columns.
+	hideMatchingColumns(leftCols, joined, outScope)
+	hideMatchingColumns(rightCols, joined, outScope)
+
+	return mergedCols, b.constructFilter(conditions), outScope
+}
+
+// hideMatchingColumns iterates through each of the columns in cols and
+// performs one of the following actions:
+// (1) If the column is equal to one of the columns in `joined`, it is skipped
+//     since it was one of the merged columns already added to the scope.
+// (2) If the column has the same name as one of the columns in `joined` but is
+//     not equal, it is marked as hidden and added to the scope.
+// (3) All other columns are added to the scope without modification.
+func hideMatchingColumns(
+	cols []columnProps, joined map[optbase.ColumnName]*columnProps, scope *scope,
+) {
+	for _, col := range cols {
+		if foundCol, ok := joined[col.name]; ok {
+			// Hide other columns with the same name.
+			if col == *foundCol {
+				continue
+			}
+			col.hidden = true
+		}
+		scope.cols = append(scope.cols, col)
+	}
+}
+
+// constructFilter builds a set of memo groups that represent the given
+// list of filter conditions. It returns the top-level memo group ID for the
+// filter.
+func (b *Builder) constructFilter(conditions []opt.GroupID) opt.GroupID {
+	switch len(conditions) {
+	case 0:
+		return b.factory.ConstructTrue()
+	case 1:
+		return conditions[0]
+	default:
+		return b.factory.ConstructAnd(b.factory.InternList(conditions))
+	}
+}
+
+type joinType int
+
+const (
+	joinTypeInner joinType = iota
+	joinTypeLeftOuter
+	joinTypeRightOuter
+	joinTypeFullOuter
+)
+
+func getJoinType(astJoinType string) joinType {
+	switch astJoinType {
+	case "JOIN", "INNER JOIN", "CROSS JOIN":
+		return joinTypeInner
+	case "LEFT JOIN":
+		return joinTypeLeftOuter
+	case "RIGHT JOIN":
+		return joinTypeRightOuter
+	case "FULL JOIN":
+		return joinTypeFullOuter
+	default:
+		panic(errorf("unsupported JOIN type %T", astJoinType))
+	}
+}
+
+func (b *Builder) constructJoin(joinType joinType, left, right, filter opt.GroupID) opt.GroupID {
+	switch joinType {
+	case joinTypeInner:
+		return b.factory.ConstructInnerJoin(left, right, filter)
+	case joinTypeLeftOuter:
+		return b.factory.ConstructLeftJoin(left, right, filter)
+	case joinTypeRightOuter:
+		return b.factory.ConstructRightJoin(left, right, filter)
+	case joinTypeFullOuter:
+		return b.factory.ConstructFullJoin(left, right, filter)
+	default:
+		panic(fmt.Errorf("unsupported JOIN type %d", joinType))
+	}
+}
+
+// findUsingColumn finds the column in cols that has the given name. If the
+// column exists it is returned. Otherwise, an error is thrown.
+//
+// context is a string ("left" or "right") used to indicate in the error
+// message whether the name is missing from the left or right side of the join.
+func findUsingColumn(cols []columnProps, name optbase.ColumnName, context string) *columnProps {
+	for i := range cols {
+		col := &cols[i]
+		if !col.hidden && col.name == name {
+			return col
+		}
+	}
+
+	panic(errorf("column \"%s\" specified in USING clause does not exist in %s table", name, context))
 }
 
 // buildProjectionList builds a set of memo groups that represent the given
@@ -903,16 +1290,8 @@ func (b *Builder) buildProjectionList(
 ) (projections []opt.GroupID) {
 	projections = make([]opt.GroupID, 0, len(selects))
 	for _, e := range selects {
-		end := len(outScope.cols)
 		subset := b.buildProjection(e.Expr, string(e.As), inScope, outScope)
 		projections = append(projections, subset...)
-
-		// Update the name of the column if there is an alias defined.
-		if e.As != "" {
-			for i := range outScope.cols[end:] {
-				outScope.cols[i].name = optbase.ColumnName(e.As)
-			}
-		}
 	}
 
 	return projections
@@ -971,14 +1350,14 @@ func (b *Builder) buildScalarProjection(
 	// NB: The case statements are sorted lexicographically.
 	switch t := texpr.(type) {
 	case *columnProps:
-		return b.buildVariableProjection(b.colMap[t.index], inScope, outScope)
+		return b.buildVariableProjection(t, label, inScope, outScope)
 
 	case *tree.FuncExpr:
 		out, col := b.buildFunction(t, label, inScope)
 		if col != nil {
 			// Function was mapped to a column reference, such as in the case
 			// of an aggregate.
-			outScope.cols = append(outScope.cols, b.colMap[col.index])
+			outScope.cols = append(outScope.cols, *col)
 		} else {
 			out = b.buildDefaultScalarProjection(texpr, out, label, inScope, outScope)
 		}
@@ -995,7 +1374,8 @@ func (b *Builder) buildScalarProjection(
 }
 
 // buildVariableProjection builds a memo group that represents the given
-// column.
+// column. label contains an optional alias for the column (e.g., if specified
+// with the AS keyword).
 //
 // The return value corresponds to the top-level memo group ID for this scalar
 // expression.
@@ -1004,12 +1384,23 @@ func (b *Builder) buildScalarProjection(
 // (outScope is passed as a parameter here rather than a return value because
 // the newly bound variables are appended to a growing list to be returned by
 // buildProjectionList).
-func (b *Builder) buildVariableProjection(col columnProps, inScope, outScope *scope) opt.GroupID {
+func (b *Builder) buildVariableProjection(
+	col *columnProps, label string, inScope, outScope *scope,
+) opt.GroupID {
 	if inScope.inGroupingContext() && !inScope.groupby.groupingsScope.hasColumn(col.index) {
 		panic(groupingError(col.String()))
 	}
 	out := b.factory.ConstructVariable(b.factory.InternPrivate(col.index))
-	outScope.cols = append(outScope.cols, col)
+	outScope.cols = append(outScope.cols, *col)
+
+	// Update the column name with the alias if it exists, and mark the column
+	// as a visible member of an anonymous table.
+	col = &outScope.cols[len(outScope.cols)-1]
+	if label != "" {
+		col.name = optbase.ColumnName(label)
+	}
+	col.table = ""
+	col.hidden = false
 	return out
 }
 
@@ -1084,7 +1475,7 @@ func (b *Builder) synthesizeColumn(scope *scope, label string, typ types.T) *col
 	}
 
 	colIndex := b.factory.Metadata().AddColumn(label, typ)
-	col := columnProps{typ: typ, index: colIndex}
+	col := columnProps{name: optbase.ColumnName(label), typ: typ, index: colIndex}
 	b.colMap = append(b.colMap, col)
 	scope.cols = append(scope.cols, col)
 	return &scope.cols[len(scope.cols)-1]
@@ -1115,6 +1506,20 @@ func (b *Builder) constructList(
 	panic(fmt.Sprintf("unexpected operator: %s", op))
 }
 
+// buildDistinct builds a set of memo groups that represent a DISTINCT
+// expression.
+//
+// in        contains the memo group ID of the input expression.
+// distinct  is true if this is a DISTINCT expression. If distinct is false,
+//           we just return `in`.
+// byCols    is the set of columns in the DISTINCT expression. Since
+//           DISTINCT is equivalent to GROUP BY without any aggregations,
+//           byCols are essentially the grouping columns.
+// inScope   contains the name bindings that are visible for this DISTINCT
+//           expression (e.g., passed in from an enclosing statement).
+//
+// The return value corresponds to the top-level memo group ID for this
+// DISTINCT expression.
 func (b *Builder) buildDistinct(
 	in opt.GroupID, distinct bool, byCols []columnProps, inScope *scope,
 ) opt.GroupID {

--- a/pkg/sql/opt/optbuilder/scope.go
+++ b/pkg/sql/opt/optbuilder/scope.go
@@ -16,11 +16,14 @@ package optbuilder
 
 import (
 	"context"
-	"fmt"
 	"strings"
+
+	"bytes"
+	"fmt"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/optbase"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
 )
@@ -271,6 +274,98 @@ func (s *scope) endAggFunc() (refScope *scope) {
 	return refScope
 }
 
+// findColumn finds the given column in the scope, and returns
+// a columnProps representing the column.
+//
+// If multiple columns match c in the same scope, findColumn throws an error
+// due to ambiguity. If no columns match in the current scope, findColumn
+// searches the parent scope. If the column is not found in any of the
+// ancestor scopes, findColumn throws an error.
+func (s *scope) findColumn(c *tree.ColumnItem) *columnProps {
+	//tblName := optbase.TableName(c.TableName.Table())
+	tblName := optbase.TableName("")
+	colName := optbase.ColumnName(c.ColumnName)
+
+	if tblName != "" {
+		// TODO(rytaft): This needs to be updated to include schema.
+		found := false
+		for _, col := range s.cols {
+			if col.table == tblName {
+				found = true
+				break
+			}
+		}
+
+		if !found {
+			panic(builderError{pgerror.NewErrorf(pgerror.CodeUndefinedTableError,
+				"source name %q not found in FROM clause", tblName)})
+		}
+	}
+
+	var candidates []*columnProps
+
+	// We only allow hidden columns in the current scope. Hidden columns
+	// in parent scopes are not accessible.
+	allowHidden := true
+
+	for curr := s; curr != nil; curr, allowHidden = curr.parent, false {
+		for i := range curr.cols {
+			col := &curr.cols[i]
+			// TODO(rytaft): Do not return a match if this column is being
+			// backfilled, or the column expression being resolved is not from
+			// a selector column expression from an UPDATE/DELETE.
+
+			if col.matches(tblName, colName) && (allowHidden || !col.hidden) {
+				candidates = append(candidates, col)
+			}
+		}
+
+		if len(candidates) == 1 {
+			col := candidates[0]
+			return col
+		} else if len(candidates) > 1 {
+			if tblName == "" {
+				// The table name was unqualified, so if a single anonymous, non-hidden
+				// source exists with a matching column, use that.
+				var anon *columnProps
+				for i := range candidates {
+					if candidates[i].table == "" && !candidates[i].hidden {
+						if anon != nil {
+							panic(ambiguousError(c, candidates))
+						}
+						anon = candidates[i]
+					}
+				}
+
+				if anon != nil {
+					return anon
+				}
+
+				// One last option: if a single non-hidden source exists with a
+				// matching column, use that.
+				var visible *columnProps
+				for i := range candidates {
+					if !candidates[i].hidden {
+						if visible != nil {
+							panic(ambiguousError(c, candidates))
+						}
+						visible = candidates[i]
+					}
+				}
+
+				if visible != nil {
+					return visible
+				}
+			}
+
+			panic(ambiguousError(c, candidates))
+		}
+	}
+
+	panic(builderError{pgerror.NewErrorf(pgerror.CodeUndefinedColumnError,
+		"column name %q not found", tree.ErrString(c))})
+}
+
 // scope implements the tree.Visitor interface so that it can walk through
 // a tree.Expr tree, perform name resolution, and replace unresolved column
 // names with a columnProps. The info stored in columnProps is necessary for
@@ -370,7 +465,7 @@ func (s *scope) VisitPre(expr tree.Expr) (recurse bool, newExpr tree.Expr) {
 	case *tree.ColumnItem:
 		colI, err := t.Resolve(context.TODO(), s)
 		if err != nil {
-			panic(err)
+			panic(builderError{err})
 		}
 		return false, colI.(*columnProps)
 
@@ -449,4 +544,27 @@ func (s *scope) IndexedVarResolvedType(idx int) types.T {
 // IndexedVarNodeFormatter is part of the IndexedVarContainer interface.
 func (s *scope) IndexedVarNodeFormatter(idx int) tree.NodeFormatter {
 	panic("unimplemented: scope.IndexedVarNodeFormatter")
+}
+
+// ambiguousError returns an error with a helpful error message to be used in
+// case of an ambiguous column reference.
+func ambiguousError(c *tree.ColumnItem, candidates []*columnProps) error {
+	colString := tree.ErrString(c)
+	var msgBuf bytes.Buffer
+	sep := ""
+	fmtCandidate := func(tn tree.TableName) {
+		name := tree.ErrString(&tn)
+		if len(name) == 0 {
+			name = "<anonymous>"
+		}
+		fmt.Fprintf(&msgBuf, "%s%s.%s", sep, name, colString)
+	}
+	for i := range candidates {
+		candidate := tree.MakeUnqualifiedTableName(tree.Name(candidates[i].table))
+		fmtCandidate(candidate)
+		sep = ", "
+	}
+	return builderError{pgerror.NewErrorf(pgerror.CodeAmbiguousColumnError,
+		"column reference %q is ambiguous (candidates: %s)", colString, msgBuf.String(),
+	)}
 }

--- a/pkg/sql/opt/optbuilder/scope.go
+++ b/pkg/sql/opt/optbuilder/scope.go
@@ -336,7 +336,12 @@ func (s *scope) FindSourceProvidingColumn(
 
 		// The table name was unqualified, so if a single anonymous source exists
 		// with a matching non-hidden column, use that.
-		if candidateFromAnonSource != nil && !moreThanOneCandidateFromAnonSource {
+		if moreThanOneCandidateFromAnonSource {
+			return nil, nil, -1, s.newAmbiguousColumnError(
+				&colName, allowHidden, moreThanOneCandidateFromAnonSource, moreThanOneCandidateWithPrefix, moreThanOneHiddenCandidate,
+			)
+		}
+		if candidateFromAnonSource != nil {
 			return &candidateFromAnonSource.table, candidateFromAnonSource, int(candidateFromAnonSource.index), nil
 		}
 
@@ -345,8 +350,7 @@ func (s *scope) FindSourceProvidingColumn(
 		if candidateWithPrefix != nil && !moreThanOneCandidateWithPrefix {
 			return &candidateWithPrefix.table, candidateWithPrefix, int(candidateWithPrefix.index), nil
 		}
-
-		if moreThanOneCandidateFromAnonSource || moreThanOneCandidateWithPrefix || moreThanOneHiddenCandidate {
+		if moreThanOneCandidateWithPrefix || moreThanOneHiddenCandidate {
 			return nil, nil, -1, s.newAmbiguousColumnError(
 				&colName, allowHidden, moreThanOneCandidateFromAnonSource, moreThanOneCandidateWithPrefix, moreThanOneHiddenCandidate,
 			)
@@ -545,7 +549,8 @@ func (s *scope) IndexedVarNodeFormatter(idx int) tree.NodeFormatter {
 // newAmbiguousColumnError returns an error with a helpful error message to be
 // used in case of an ambiguous column reference.
 func (s *scope) newAmbiguousColumnError(
-	n *tree.Name, allowHidden, moreThanOneCandidateFromAnonSource, moreThanOneCandidateWithPrefix, moreThanOneHiddenCandidate bool,
+	n *tree.Name,
+	allowHidden, moreThanOneCandidateFromAnonSource, moreThanOneCandidateWithPrefix, moreThanOneHiddenCandidate bool,
 ) error {
 	colString := tree.ErrString(n)
 	var msgBuf bytes.Buffer

--- a/pkg/sql/opt/optbuilder/testdata/aggregate
+++ b/pkg/sql/opt/optbuilder/testdata/aggregate
@@ -102,7 +102,7 @@ project
 build
 SELECT COUNT(*), k FROM t.kv
 ----
-error: column "kv.k" must appear in the GROUP BY clause or be used in an aggregate function
+error: column "t.kv.k" must appear in the GROUP BY clause or be used in an aggregate function
 
 build
 SELECT COUNT(*) FROM t.kv GROUP BY s < 5
@@ -344,7 +344,7 @@ project
 build
 SELECT COUNT(*), s FROM t.kv GROUP BY UPPER(s)
 ----
-error: column "kv.s" must appear in the GROUP BY clause or be used in an aggregate function
+error: column "t.kv.s" must appear in the GROUP BY clause or be used in an aggregate function
 
 # Selecting and grouping on a more complex expression works.
 build
@@ -391,17 +391,17 @@ project
 build
 SELECT COUNT(*), k+v FROM t.kv GROUP BY k
 ----
-error: column "kv.v" must appear in the GROUP BY clause or be used in an aggregate function
+error: column "t.kv.v" must appear in the GROUP BY clause or be used in an aggregate function
 
 build
 SELECT COUNT(*), k+v FROM t.kv GROUP BY v
 ----
-error: column "kv.k" must appear in the GROUP BY clause or be used in an aggregate function
+error: column "t.kv.k" must appear in the GROUP BY clause or be used in an aggregate function
 
 build
 SELECT COUNT(*), v/(k+v) FROM t.kv GROUP BY k+v
 ----
-error: column "kv.v" must appear in the GROUP BY clause or be used in an aggregate function
+error: column "t.kv.v" must appear in the GROUP BY clause or be used in an aggregate function
 
 build
 SELECT k FROM t.kv WHERE AVG(k) > 1

--- a/pkg/sql/opt/optbuilder/testdata/having
+++ b/pkg/sql/opt/optbuilder/testdata/having
@@ -105,25 +105,25 @@ error: aggregate function cannot be nested within another aggregate function
 build
 SELECT MAX(k), MIN(v) FROM t.kv HAVING k
 ----
-error: column "kv.k" must appear in the GROUP BY clause or be used in an aggregate function
+error: column "t.kv.k" must appear in the GROUP BY clause or be used in an aggregate function
 
 # Expressions listed in the HAVING clause must conform to same validation as the SELECT clause (grouped or aggregated).
 build
 SELECT 3 FROM t.kv GROUP BY v HAVING k > 5
 ----
-error: column "kv.k" must appear in the GROUP BY clause or be used in an aggregate function
+error: column "t.kv.k" must appear in the GROUP BY clause or be used in an aggregate function
 
 # pg has a special case for grouping on primary key, which would allow this, but we do not.
 # See http://www.postgresql.org/docs/current/static/sql-select.html#SQL-GROUPBY
 build
 SELECT 3 FROM t.kv GROUP BY k HAVING v > 2
 ----
-error: column "kv.v" must appear in the GROUP BY clause or be used in an aggregate function
+error: column "t.kv.v" must appear in the GROUP BY clause or be used in an aggregate function
 
 build
 SELECT k FROM t.kv HAVING k > 7
 ----
-error: column "kv.k" must appear in the GROUP BY clause or be used in an aggregate function
+error: column "t.kv.k" must appear in the GROUP BY clause or be used in an aggregate function
 
 build
 SELECT count(*), k+w FROM t.kv GROUP BY k+w HAVING (k+w) > 5
@@ -154,7 +154,7 @@ project
 build
 SELECT count(*), k+w FROM t.kv GROUP BY k+w HAVING (k+v) > 5
 ----
-error: column "kv.k" must appear in the GROUP BY clause or be used in an aggregate function
+error: column "t.kv.k" must appear in the GROUP BY clause or be used in an aggregate function
 
 # Check that everything still works with differently qualified names
 build
@@ -257,4 +257,4 @@ project
 build
 SELECT t.kv.v FROM t.kv GROUP BY v, kv.k * w HAVING w > 5
 ----
-error: column "kv.w" must appear in the GROUP BY clause or be used in an aggregate function
+error: column "t.kv.w" must appear in the GROUP BY clause or be used in an aggregate function

--- a/pkg/sql/opt/optbuilder/testdata/join
+++ b/pkg/sql/opt/optbuilder/testdata/join
@@ -1,0 +1,3244 @@
+# LogicTest: default parallel-stmts distsql distsql-disk
+
+# The join condition logic is tricky to get right with NULL
+# values. Simple implementations can deal well with NULLs on the first
+# or last row but fail to handle them in the middle. So the test table
+# must contain at least 3 rows with a null in the middle. This test
+# table also contains the pair 44/42 so that a test with a non-trivial
+# ON condition can be written.
+exec-ddl
+CREATE TABLE onecolumn (x INT)
+----
+table onecolumn
+  x int NULL
+  rowid int NOT NULL (hidden)
+
+build
+SELECT * FROM onecolumn AS a(x) CROSS JOIN onecolumn AS b(y)
+----
+project
+ ├── columns: onecolumn.x:int:null:1 onecolumn.x:int:null:3
+ ├── inner-join
+ │    ├── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2 onecolumn.x:int:null:3 onecolumn.rowid:int:4
+ │    ├── scan
+ │    │    └── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2
+ │    ├── scan
+ │    │    └── columns: onecolumn.x:int:null:3 onecolumn.rowid:int:4
+ │    └── true [type=bool]
+ └── projections
+      ├── variable: onecolumn.x [type=int]
+      └── variable: onecolumn.x [type=int]
+
+# Check that name resolution chokes on ambiguity when it needs to.
+build
+SELECT x FROM onecolumn AS a, onecolumn AS b
+----
+error: column reference "x" is ambiguous (candidates: a.x, b.x)
+
+# Check that name resolution does not choke on ambiguity if an
+# unqualified column name is requested and there is an anonymous
+# source providing this name in addition to two or more named sources
+# that also provide it.
+build
+SELECT x FROM (SELECT 1 AS x), onecolumn AS a, onecolumn AS b
+----
+project
+ ├── columns: x:int:null:1
+ ├── inner-join
+ │    ├── columns: x:int:null:1 onecolumn.x:int:null:2 onecolumn.rowid:int:3 onecolumn.x:int:null:4 onecolumn.rowid:int:5
+ │    ├── inner-join
+ │    │    ├── columns: x:int:null:1 onecolumn.x:int:null:2 onecolumn.rowid:int:3
+ │    │    ├── project
+ │    │    │    ├── columns: x:int:null:1
+ │    │    │    ├── values
+ │    │    │    │    └── tuple [type=tuple{}]
+ │    │    │    └── projections
+ │    │    │         └── const: 1 [type=int]
+ │    │    ├── scan
+ │    │    │    └── columns: onecolumn.x:int:null:2 onecolumn.rowid:int:3
+ │    │    └── true [type=bool]
+ │    ├── scan
+ │    │    └── columns: onecolumn.x:int:null:4 onecolumn.rowid:int:5
+ │    └── true [type=bool]
+ └── projections
+      └── variable: x [type=int]
+
+build
+SELECT * FROM onecolumn AS a(x) JOIN onecolumn AS b(y) ON a.x = b.y
+----
+project
+ ├── columns: onecolumn.x:int:null:1 onecolumn.x:int:null:3
+ ├── inner-join
+ │    ├── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2 onecolumn.x:int:null:3 onecolumn.rowid:int:4
+ │    ├── scan
+ │    │    └── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2
+ │    ├── scan
+ │    │    └── columns: onecolumn.x:int:null:3 onecolumn.rowid:int:4
+ │    └── eq [type=bool]
+ │         ├── variable: onecolumn.x [type=int]
+ │         └── variable: onecolumn.x [type=int]
+ └── projections
+      ├── variable: onecolumn.x [type=int]
+      └── variable: onecolumn.x [type=int]
+
+build
+SELECT * FROM onecolumn AS a JOIN onecolumn as b USING(x)
+----
+project
+ ├── columns: onecolumn.x:int:null:1
+ ├── inner-join
+ │    ├── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2 onecolumn.x:int:null:3 onecolumn.rowid:int:4
+ │    ├── scan
+ │    │    └── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2
+ │    ├── scan
+ │    │    └── columns: onecolumn.x:int:null:3 onecolumn.rowid:int:4
+ │    └── eq [type=bool]
+ │         ├── variable: onecolumn.x [type=int]
+ │         └── variable: onecolumn.x [type=int]
+ └── projections
+      └── variable: onecolumn.x [type=int]
+
+build
+SELECT * FROM onecolumn AS a NATURAL JOIN onecolumn as b
+----
+project
+ ├── columns: onecolumn.x:int:null:1
+ ├── inner-join
+ │    ├── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2 onecolumn.x:int:null:3 onecolumn.rowid:int:4
+ │    ├── scan
+ │    │    └── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2
+ │    ├── scan
+ │    │    └── columns: onecolumn.x:int:null:3 onecolumn.rowid:int:4
+ │    └── eq [type=bool]
+ │         ├── variable: onecolumn.x [type=int]
+ │         └── variable: onecolumn.x [type=int]
+ └── projections
+      └── variable: onecolumn.x [type=int]
+
+build
+SELECT * FROM onecolumn AS a(x) LEFT OUTER JOIN onecolumn AS b(y) ON a.x = b.y
+----
+project
+ ├── columns: onecolumn.x:int:null:1 onecolumn.x:int:null:3
+ ├── left-join
+ │    ├── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2 onecolumn.x:int:null:3 onecolumn.rowid:int:null:4
+ │    ├── scan
+ │    │    └── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2
+ │    ├── scan
+ │    │    └── columns: onecolumn.x:int:null:3 onecolumn.rowid:int:4
+ │    └── eq [type=bool]
+ │         ├── variable: onecolumn.x [type=int]
+ │         └── variable: onecolumn.x [type=int]
+ └── projections
+      ├── variable: onecolumn.x [type=int]
+      └── variable: onecolumn.x [type=int]
+
+build
+SELECT * FROM onecolumn AS a LEFT OUTER JOIN onecolumn AS b USING(x)
+----
+project
+ ├── columns: onecolumn.x:int:null:1
+ ├── left-join
+ │    ├── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2 onecolumn.x:int:null:3 onecolumn.rowid:int:null:4
+ │    ├── scan
+ │    │    └── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2
+ │    ├── scan
+ │    │    └── columns: onecolumn.x:int:null:3 onecolumn.rowid:int:4
+ │    └── eq [type=bool]
+ │         ├── variable: onecolumn.x [type=int]
+ │         └── variable: onecolumn.x [type=int]
+ └── projections
+      └── variable: onecolumn.x [type=int]
+
+build
+SELECT * FROM onecolumn AS a NATURAL LEFT OUTER JOIN onecolumn AS b
+----
+project
+ ├── columns: onecolumn.x:int:null:1
+ ├── left-join
+ │    ├── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2 onecolumn.x:int:null:3 onecolumn.rowid:int:null:4
+ │    ├── scan
+ │    │    └── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2
+ │    ├── scan
+ │    │    └── columns: onecolumn.x:int:null:3 onecolumn.rowid:int:4
+ │    └── eq [type=bool]
+ │         ├── variable: onecolumn.x [type=int]
+ │         └── variable: onecolumn.x [type=int]
+ └── projections
+      └── variable: onecolumn.x [type=int]
+
+build
+SELECT * FROM onecolumn AS a(x) RIGHT OUTER JOIN onecolumn AS b(y) ON a.x = b.y
+----
+project
+ ├── columns: onecolumn.x:int:null:1 onecolumn.x:int:null:3
+ ├── right-join
+ │    ├── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:null:2 onecolumn.x:int:null:3 onecolumn.rowid:int:4
+ │    ├── scan
+ │    │    └── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2
+ │    ├── scan
+ │    │    └── columns: onecolumn.x:int:null:3 onecolumn.rowid:int:4
+ │    └── eq [type=bool]
+ │         ├── variable: onecolumn.x [type=int]
+ │         └── variable: onecolumn.x [type=int]
+ └── projections
+      ├── variable: onecolumn.x [type=int]
+      └── variable: onecolumn.x [type=int]
+
+build
+SELECT * FROM onecolumn AS a RIGHT OUTER JOIN onecolumn AS b USING(x)
+----
+project
+ ├── columns: onecolumn.x:int:null:3
+ ├── right-join
+ │    ├── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:null:2 onecolumn.x:int:null:3 onecolumn.rowid:int:4
+ │    ├── scan
+ │    │    └── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2
+ │    ├── scan
+ │    │    └── columns: onecolumn.x:int:null:3 onecolumn.rowid:int:4
+ │    └── eq [type=bool]
+ │         ├── variable: onecolumn.x [type=int]
+ │         └── variable: onecolumn.x [type=int]
+ └── projections
+      └── variable: onecolumn.x [type=int]
+
+build
+SELECT * FROM onecolumn AS a NATURAL RIGHT OUTER JOIN onecolumn AS b
+----
+project
+ ├── columns: onecolumn.x:int:null:3
+ ├── right-join
+ │    ├── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:null:2 onecolumn.x:int:null:3 onecolumn.rowid:int:4
+ │    ├── scan
+ │    │    └── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2
+ │    ├── scan
+ │    │    └── columns: onecolumn.x:int:null:3 onecolumn.rowid:int:4
+ │    └── eq [type=bool]
+ │         ├── variable: onecolumn.x [type=int]
+ │         └── variable: onecolumn.x [type=int]
+ └── projections
+      └── variable: onecolumn.x [type=int]
+
+exec-ddl
+CREATE TABLE onecolumn_w(w INT)
+----
+table onecolumn_w
+  w int NULL
+  rowid int NOT NULL (hidden)
+
+build
+SELECT * FROM onecolumn AS a NATURAL JOIN onecolumn_w as b
+----
+project
+ ├── columns: onecolumn.x:int:null:1 onecolumn_w.w:int:null:3
+ ├── inner-join
+ │    ├── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2 onecolumn_w.w:int:null:3 onecolumn_w.rowid:int:4
+ │    ├── scan
+ │    │    └── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2
+ │    ├── scan
+ │    │    └── columns: onecolumn_w.w:int:null:3 onecolumn_w.rowid:int:4
+ │    └── true [type=bool]
+ └── projections
+      ├── variable: onecolumn.x [type=int]
+      └── variable: onecolumn_w.w [type=int]
+
+exec-ddl
+CREATE TABLE othercolumn (x INT)
+----
+table othercolumn
+  x int NULL
+  rowid int NOT NULL (hidden)
+
+build
+SELECT * FROM onecolumn AS a FULL OUTER JOIN othercolumn AS b ON a.x = b.x
+----
+project
+ ├── columns: onecolumn.x:int:null:1 othercolumn.x:int:null:3
+ ├── full-join
+ │    ├── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:null:2 othercolumn.x:int:null:3 othercolumn.rowid:int:null:4
+ │    ├── scan
+ │    │    └── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2
+ │    ├── scan
+ │    │    └── columns: othercolumn.x:int:null:3 othercolumn.rowid:int:4
+ │    └── eq [type=bool]
+ │         ├── variable: onecolumn.x [type=int]
+ │         └── variable: othercolumn.x [type=int]
+ └── projections
+      ├── variable: onecolumn.x [type=int]
+      └── variable: othercolumn.x [type=int]
+
+build
+SELECT * FROM onecolumn AS a FULL OUTER JOIN othercolumn AS b USING(x)
+----
+project
+ ├── columns: x:int:null:5
+ ├── project
+ │    ├── columns: x:int:null:5 onecolumn.x:int:null:1 onecolumn.rowid:int:null:2 othercolumn.x:int:null:3 othercolumn.rowid:int:null:4
+ │    ├── full-join
+ │    │    ├── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:null:2 othercolumn.x:int:null:3 othercolumn.rowid:int:null:4
+ │    │    ├── scan
+ │    │    │    └── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2
+ │    │    ├── scan
+ │    │    │    └── columns: othercolumn.x:int:null:3 othercolumn.rowid:int:4
+ │    │    └── eq [type=bool]
+ │    │         ├── variable: onecolumn.x [type=int]
+ │    │         └── variable: othercolumn.x [type=int]
+ │    └── projections
+ │         ├── coalesce [type=NULL]
+ │         │    ├── variable: onecolumn.x [type=int]
+ │         │    └── variable: othercolumn.x [type=int]
+ │         ├── variable: onecolumn.x [type=int]
+ │         ├── variable: onecolumn.rowid [type=int]
+ │         ├── variable: othercolumn.x [type=int]
+ │         └── variable: othercolumn.rowid [type=int]
+ └── projections
+      └── variable: x [type=int]
+
+# Check that the source columns can be selected separately from the
+# USING column (#12033).
+build
+SELECT x AS s, a.x, b.x FROM onecolumn AS a FULL OUTER JOIN othercolumn AS b USING(x)
+----
+project
+ ├── columns: x:int:null:5 onecolumn.x:int:null:1 othercolumn.x:int:null:3
+ ├── project
+ │    ├── columns: x:int:null:5 onecolumn.x:int:null:1 onecolumn.rowid:int:null:2 othercolumn.x:int:null:3 othercolumn.rowid:int:null:4
+ │    ├── full-join
+ │    │    ├── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:null:2 othercolumn.x:int:null:3 othercolumn.rowid:int:null:4
+ │    │    ├── scan
+ │    │    │    └── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2
+ │    │    ├── scan
+ │    │    │    └── columns: othercolumn.x:int:null:3 othercolumn.rowid:int:4
+ │    │    └── eq [type=bool]
+ │    │         ├── variable: onecolumn.x [type=int]
+ │    │         └── variable: othercolumn.x [type=int]
+ │    └── projections
+ │         ├── coalesce [type=NULL]
+ │         │    ├── variable: onecolumn.x [type=int]
+ │         │    └── variable: othercolumn.x [type=int]
+ │         ├── variable: onecolumn.x [type=int]
+ │         ├── variable: onecolumn.rowid [type=int]
+ │         ├── variable: othercolumn.x [type=int]
+ │         └── variable: othercolumn.rowid [type=int]
+ └── projections
+      ├── variable: x [type=int]
+      ├── variable: onecolumn.x [type=int]
+      └── variable: othercolumn.x [type=int]
+
+build
+SELECT * FROM onecolumn AS a NATURAL FULL OUTER JOIN othercolumn AS b
+----
+project
+ ├── columns: x:int:null:5
+ ├── project
+ │    ├── columns: x:int:null:5 onecolumn.x:int:null:1 onecolumn.rowid:int:null:2 othercolumn.x:int:null:3 othercolumn.rowid:int:null:4
+ │    ├── full-join
+ │    │    ├── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:null:2 othercolumn.x:int:null:3 othercolumn.rowid:int:null:4
+ │    │    ├── scan
+ │    │    │    └── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2
+ │    │    ├── scan
+ │    │    │    └── columns: othercolumn.x:int:null:3 othercolumn.rowid:int:4
+ │    │    └── eq [type=bool]
+ │    │         ├── variable: onecolumn.x [type=int]
+ │    │         └── variable: othercolumn.x [type=int]
+ │    └── projections
+ │         ├── coalesce [type=NULL]
+ │         │    ├── variable: onecolumn.x [type=int]
+ │         │    └── variable: othercolumn.x [type=int]
+ │         ├── variable: onecolumn.x [type=int]
+ │         ├── variable: onecolumn.rowid [type=int]
+ │         ├── variable: othercolumn.x [type=int]
+ │         └── variable: othercolumn.rowid [type=int]
+ └── projections
+      └── variable: x [type=int]
+
+exec-ddl
+CREATE TABLE empty (x INT)
+----
+table empty
+  x int NULL
+  rowid int NOT NULL (hidden)
+
+build
+SELECT * FROM onecolumn AS a(x) CROSS JOIN empty AS b(y)
+----
+project
+ ├── columns: onecolumn.x:int:null:1 empty.x:int:null:3
+ ├── inner-join
+ │    ├── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2 empty.x:int:null:3 empty.rowid:int:4
+ │    ├── scan
+ │    │    └── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2
+ │    ├── scan
+ │    │    └── columns: empty.x:int:null:3 empty.rowid:int:4
+ │    └── true [type=bool]
+ └── projections
+      ├── variable: onecolumn.x [type=int]
+      └── variable: empty.x [type=int]
+
+build
+SELECT * FROM empty AS a CROSS JOIN onecolumn AS b
+----
+project
+ ├── columns: empty.x:int:null:1 onecolumn.x:int:null:3
+ ├── inner-join
+ │    ├── columns: empty.x:int:null:1 empty.rowid:int:2 onecolumn.x:int:null:3 onecolumn.rowid:int:4
+ │    ├── scan
+ │    │    └── columns: empty.x:int:null:1 empty.rowid:int:2
+ │    ├── scan
+ │    │    └── columns: onecolumn.x:int:null:3 onecolumn.rowid:int:4
+ │    └── true [type=bool]
+ └── projections
+      ├── variable: empty.x [type=int]
+      └── variable: onecolumn.x [type=int]
+
+build
+SELECT * FROM onecolumn AS a(x) JOIN empty AS b(y) ON a.x = b.y
+----
+project
+ ├── columns: onecolumn.x:int:null:1 empty.x:int:null:3
+ ├── inner-join
+ │    ├── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2 empty.x:int:null:3 empty.rowid:int:4
+ │    ├── scan
+ │    │    └── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2
+ │    ├── scan
+ │    │    └── columns: empty.x:int:null:3 empty.rowid:int:4
+ │    └── eq [type=bool]
+ │         ├── variable: onecolumn.x [type=int]
+ │         └── variable: empty.x [type=int]
+ └── projections
+      ├── variable: onecolumn.x [type=int]
+      └── variable: empty.x [type=int]
+
+build
+SELECT * FROM onecolumn AS a JOIN empty AS b USING(x)
+----
+project
+ ├── columns: onecolumn.x:int:null:1
+ ├── inner-join
+ │    ├── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2 empty.x:int:null:3 empty.rowid:int:4
+ │    ├── scan
+ │    │    └── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2
+ │    ├── scan
+ │    │    └── columns: empty.x:int:null:3 empty.rowid:int:4
+ │    └── eq [type=bool]
+ │         ├── variable: onecolumn.x [type=int]
+ │         └── variable: empty.x [type=int]
+ └── projections
+      └── variable: onecolumn.x [type=int]
+
+build
+SELECT * FROM empty AS a(x) JOIN onecolumn AS b(y) ON a.x = b.y
+----
+project
+ ├── columns: empty.x:int:null:1 onecolumn.x:int:null:3
+ ├── inner-join
+ │    ├── columns: empty.x:int:null:1 empty.rowid:int:2 onecolumn.x:int:null:3 onecolumn.rowid:int:4
+ │    ├── scan
+ │    │    └── columns: empty.x:int:null:1 empty.rowid:int:2
+ │    ├── scan
+ │    │    └── columns: onecolumn.x:int:null:3 onecolumn.rowid:int:4
+ │    └── eq [type=bool]
+ │         ├── variable: empty.x [type=int]
+ │         └── variable: onecolumn.x [type=int]
+ └── projections
+      ├── variable: empty.x [type=int]
+      └── variable: onecolumn.x [type=int]
+
+build
+SELECT * FROM empty AS a JOIN onecolumn AS b USING(x)
+----
+project
+ ├── columns: empty.x:int:null:1
+ ├── inner-join
+ │    ├── columns: empty.x:int:null:1 empty.rowid:int:2 onecolumn.x:int:null:3 onecolumn.rowid:int:4
+ │    ├── scan
+ │    │    └── columns: empty.x:int:null:1 empty.rowid:int:2
+ │    ├── scan
+ │    │    └── columns: onecolumn.x:int:null:3 onecolumn.rowid:int:4
+ │    └── eq [type=bool]
+ │         ├── variable: empty.x [type=int]
+ │         └── variable: onecolumn.x [type=int]
+ └── projections
+      └── variable: empty.x [type=int]
+
+build
+SELECT * FROM onecolumn AS a(x) LEFT OUTER JOIN empty AS b(y) ON a.x = b.y
+----
+project
+ ├── columns: onecolumn.x:int:null:1 empty.x:int:null:3
+ ├── left-join
+ │    ├── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2 empty.x:int:null:3 empty.rowid:int:null:4
+ │    ├── scan
+ │    │    └── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2
+ │    ├── scan
+ │    │    └── columns: empty.x:int:null:3 empty.rowid:int:4
+ │    └── eq [type=bool]
+ │         ├── variable: onecolumn.x [type=int]
+ │         └── variable: empty.x [type=int]
+ └── projections
+      ├── variable: onecolumn.x [type=int]
+      └── variable: empty.x [type=int]
+
+build
+SELECT * FROM onecolumn AS a LEFT OUTER JOIN empty AS b USING(x)
+----
+project
+ ├── columns: onecolumn.x:int:null:1
+ ├── left-join
+ │    ├── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2 empty.x:int:null:3 empty.rowid:int:null:4
+ │    ├── scan
+ │    │    └── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2
+ │    ├── scan
+ │    │    └── columns: empty.x:int:null:3 empty.rowid:int:4
+ │    └── eq [type=bool]
+ │         ├── variable: onecolumn.x [type=int]
+ │         └── variable: empty.x [type=int]
+ └── projections
+      └── variable: onecolumn.x [type=int]
+
+build
+SELECT * FROM empty AS a(x) LEFT OUTER JOIN onecolumn AS b(y) ON a.x = b.y
+----
+project
+ ├── columns: empty.x:int:null:1 onecolumn.x:int:null:3
+ ├── left-join
+ │    ├── columns: empty.x:int:null:1 empty.rowid:int:2 onecolumn.x:int:null:3 onecolumn.rowid:int:null:4
+ │    ├── scan
+ │    │    └── columns: empty.x:int:null:1 empty.rowid:int:2
+ │    ├── scan
+ │    │    └── columns: onecolumn.x:int:null:3 onecolumn.rowid:int:4
+ │    └── eq [type=bool]
+ │         ├── variable: empty.x [type=int]
+ │         └── variable: onecolumn.x [type=int]
+ └── projections
+      ├── variable: empty.x [type=int]
+      └── variable: onecolumn.x [type=int]
+
+build
+SELECT * FROM empty AS a LEFT OUTER JOIN onecolumn AS b USING(x)
+----
+project
+ ├── columns: empty.x:int:null:1
+ ├── left-join
+ │    ├── columns: empty.x:int:null:1 empty.rowid:int:2 onecolumn.x:int:null:3 onecolumn.rowid:int:null:4
+ │    ├── scan
+ │    │    └── columns: empty.x:int:null:1 empty.rowid:int:2
+ │    ├── scan
+ │    │    └── columns: onecolumn.x:int:null:3 onecolumn.rowid:int:4
+ │    └── eq [type=bool]
+ │         ├── variable: empty.x [type=int]
+ │         └── variable: onecolumn.x [type=int]
+ └── projections
+      └── variable: empty.x [type=int]
+
+build
+SELECT * FROM onecolumn AS a(x) RIGHT OUTER JOIN empty AS b(y) ON a.x = b.y
+----
+project
+ ├── columns: onecolumn.x:int:null:1 empty.x:int:null:3
+ ├── right-join
+ │    ├── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:null:2 empty.x:int:null:3 empty.rowid:int:4
+ │    ├── scan
+ │    │    └── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2
+ │    ├── scan
+ │    │    └── columns: empty.x:int:null:3 empty.rowid:int:4
+ │    └── eq [type=bool]
+ │         ├── variable: onecolumn.x [type=int]
+ │         └── variable: empty.x [type=int]
+ └── projections
+      ├── variable: onecolumn.x [type=int]
+      └── variable: empty.x [type=int]
+
+build
+SELECT * FROM onecolumn AS a RIGHT OUTER JOIN empty AS b USING(x)
+----
+project
+ ├── columns: empty.x:int:null:3
+ ├── right-join
+ │    ├── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:null:2 empty.x:int:null:3 empty.rowid:int:4
+ │    ├── scan
+ │    │    └── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2
+ │    ├── scan
+ │    │    └── columns: empty.x:int:null:3 empty.rowid:int:4
+ │    └── eq [type=bool]
+ │         ├── variable: onecolumn.x [type=int]
+ │         └── variable: empty.x [type=int]
+ └── projections
+      └── variable: empty.x [type=int]
+
+build
+SELECT * FROM empty AS a(x) FULL OUTER JOIN onecolumn AS b(y) ON a.x = b.y
+----
+project
+ ├── columns: empty.x:int:null:1 onecolumn.x:int:null:3
+ ├── full-join
+ │    ├── columns: empty.x:int:null:1 empty.rowid:int:null:2 onecolumn.x:int:null:3 onecolumn.rowid:int:null:4
+ │    ├── scan
+ │    │    └── columns: empty.x:int:null:1 empty.rowid:int:2
+ │    ├── scan
+ │    │    └── columns: onecolumn.x:int:null:3 onecolumn.rowid:int:4
+ │    └── eq [type=bool]
+ │         ├── variable: empty.x [type=int]
+ │         └── variable: onecolumn.x [type=int]
+ └── projections
+      ├── variable: empty.x [type=int]
+      └── variable: onecolumn.x [type=int]
+
+build
+SELECT * FROM empty AS a FULL OUTER JOIN onecolumn AS b USING(x)
+----
+project
+ ├── columns: x:int:null:5
+ ├── project
+ │    ├── columns: x:int:null:5 empty.x:int:null:1 empty.rowid:int:null:2 onecolumn.x:int:null:3 onecolumn.rowid:int:null:4
+ │    ├── full-join
+ │    │    ├── columns: empty.x:int:null:1 empty.rowid:int:null:2 onecolumn.x:int:null:3 onecolumn.rowid:int:null:4
+ │    │    ├── scan
+ │    │    │    └── columns: empty.x:int:null:1 empty.rowid:int:2
+ │    │    ├── scan
+ │    │    │    └── columns: onecolumn.x:int:null:3 onecolumn.rowid:int:4
+ │    │    └── eq [type=bool]
+ │    │         ├── variable: empty.x [type=int]
+ │    │         └── variable: onecolumn.x [type=int]
+ │    └── projections
+ │         ├── coalesce [type=NULL]
+ │         │    ├── variable: empty.x [type=int]
+ │         │    └── variable: onecolumn.x [type=int]
+ │         ├── variable: empty.x [type=int]
+ │         ├── variable: empty.rowid [type=int]
+ │         ├── variable: onecolumn.x [type=int]
+ │         └── variable: onecolumn.rowid [type=int]
+ └── projections
+      └── variable: x [type=int]
+
+build
+SELECT * FROM onecolumn AS a(x) FULL OUTER JOIN empty AS b(y) ON a.x = b.y
+----
+project
+ ├── columns: onecolumn.x:int:null:1 empty.x:int:null:3
+ ├── full-join
+ │    ├── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:null:2 empty.x:int:null:3 empty.rowid:int:null:4
+ │    ├── scan
+ │    │    └── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2
+ │    ├── scan
+ │    │    └── columns: empty.x:int:null:3 empty.rowid:int:4
+ │    └── eq [type=bool]
+ │         ├── variable: onecolumn.x [type=int]
+ │         └── variable: empty.x [type=int]
+ └── projections
+      ├── variable: onecolumn.x [type=int]
+      └── variable: empty.x [type=int]
+
+build
+SELECT * FROM onecolumn AS a FULL OUTER JOIN empty AS b USING(x)
+----
+project
+ ├── columns: x:int:null:5
+ ├── project
+ │    ├── columns: x:int:null:5 onecolumn.x:int:null:1 onecolumn.rowid:int:null:2 empty.x:int:null:3 empty.rowid:int:null:4
+ │    ├── full-join
+ │    │    ├── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:null:2 empty.x:int:null:3 empty.rowid:int:null:4
+ │    │    ├── scan
+ │    │    │    └── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2
+ │    │    ├── scan
+ │    │    │    └── columns: empty.x:int:null:3 empty.rowid:int:4
+ │    │    └── eq [type=bool]
+ │    │         ├── variable: onecolumn.x [type=int]
+ │    │         └── variable: empty.x [type=int]
+ │    └── projections
+ │         ├── coalesce [type=NULL]
+ │         │    ├── variable: onecolumn.x [type=int]
+ │         │    └── variable: empty.x [type=int]
+ │         ├── variable: onecolumn.x [type=int]
+ │         ├── variable: onecolumn.rowid [type=int]
+ │         ├── variable: empty.x [type=int]
+ │         └── variable: empty.rowid [type=int]
+ └── projections
+      └── variable: x [type=int]
+
+exec-ddl
+CREATE TABLE twocolumn (x INT, y INT)
+----
+table twocolumn
+  x int NULL
+  y int NULL
+  rowid int NOT NULL (hidden)
+
+# Natural joins with partial match
+build
+SELECT * FROM onecolumn NATURAL JOIN twocolumn
+----
+project
+ ├── columns: onecolumn.x:int:null:1 twocolumn.y:int:null:4
+ ├── inner-join
+ │    ├── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2 twocolumn.x:int:null:3 twocolumn.y:int:null:4 twocolumn.rowid:int:5
+ │    ├── scan
+ │    │    └── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2
+ │    ├── scan
+ │    │    └── columns: twocolumn.x:int:null:3 twocolumn.y:int:null:4 twocolumn.rowid:int:5
+ │    └── eq [type=bool]
+ │         ├── variable: onecolumn.x [type=int]
+ │         └── variable: twocolumn.x [type=int]
+ └── projections
+      ├── variable: onecolumn.x [type=int]
+      └── variable: twocolumn.y [type=int]
+
+build
+SELECT * FROM onecolumn JOIN twocolumn USING(x)
+----
+project
+ ├── columns: onecolumn.x:int:null:1 twocolumn.y:int:null:4
+ ├── inner-join
+ │    ├── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2 twocolumn.x:int:null:3 twocolumn.y:int:null:4 twocolumn.rowid:int:5
+ │    ├── scan
+ │    │    └── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2
+ │    ├── scan
+ │    │    └── columns: twocolumn.x:int:null:3 twocolumn.y:int:null:4 twocolumn.rowid:int:5
+ │    └── eq [type=bool]
+ │         ├── variable: onecolumn.x [type=int]
+ │         └── variable: twocolumn.x [type=int]
+ └── projections
+      ├── variable: onecolumn.x [type=int]
+      └── variable: twocolumn.y [type=int]
+
+build
+SELECT * FROM twocolumn AS a JOIN twocolumn AS b ON a.x = b.y
+----
+project
+ ├── columns: twocolumn.x:int:null:1 twocolumn.y:int:null:2 twocolumn.x:int:null:4 twocolumn.y:int:null:5
+ ├── inner-join
+ │    ├── columns: twocolumn.x:int:null:1 twocolumn.y:int:null:2 twocolumn.rowid:int:3 twocolumn.x:int:null:4 twocolumn.y:int:null:5 twocolumn.rowid:int:6
+ │    ├── scan
+ │    │    └── columns: twocolumn.x:int:null:1 twocolumn.y:int:null:2 twocolumn.rowid:int:3
+ │    ├── scan
+ │    │    └── columns: twocolumn.x:int:null:4 twocolumn.y:int:null:5 twocolumn.rowid:int:6
+ │    └── eq [type=bool]
+ │         ├── variable: twocolumn.x [type=int]
+ │         └── variable: twocolumn.y [type=int]
+ └── projections
+      ├── variable: twocolumn.x [type=int]
+      ├── variable: twocolumn.y [type=int]
+      ├── variable: twocolumn.x [type=int]
+      └── variable: twocolumn.y [type=int]
+
+build
+SELECT * FROM twocolumn AS a JOIN twocolumn AS b ON a.x = a.y
+----
+project
+ ├── columns: twocolumn.x:int:null:1 twocolumn.y:int:null:2 twocolumn.x:int:null:4 twocolumn.y:int:null:5
+ ├── inner-join
+ │    ├── columns: twocolumn.x:int:null:1 twocolumn.y:int:null:2 twocolumn.rowid:int:3 twocolumn.x:int:null:4 twocolumn.y:int:null:5 twocolumn.rowid:int:6
+ │    ├── scan
+ │    │    └── columns: twocolumn.x:int:null:1 twocolumn.y:int:null:2 twocolumn.rowid:int:3
+ │    ├── scan
+ │    │    └── columns: twocolumn.x:int:null:4 twocolumn.y:int:null:5 twocolumn.rowid:int:6
+ │    └── eq [type=bool]
+ │         ├── variable: twocolumn.x [type=int]
+ │         └── variable: twocolumn.y [type=int]
+ └── projections
+      ├── variable: twocolumn.x [type=int]
+      ├── variable: twocolumn.y [type=int]
+      ├── variable: twocolumn.x [type=int]
+      └── variable: twocolumn.y [type=int]
+
+build
+SELECT * FROM onecolumn AS a JOIN twocolumn AS b ON ((a.x)) = ((b.y))
+----
+project
+ ├── columns: onecolumn.x:int:null:1 twocolumn.x:int:null:3 twocolumn.y:int:null:4
+ ├── inner-join
+ │    ├── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2 twocolumn.x:int:null:3 twocolumn.y:int:null:4 twocolumn.rowid:int:5
+ │    ├── scan
+ │    │    └── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2
+ │    ├── scan
+ │    │    └── columns: twocolumn.x:int:null:3 twocolumn.y:int:null:4 twocolumn.rowid:int:5
+ │    └── eq [type=bool]
+ │         ├── variable: onecolumn.x [type=int]
+ │         └── variable: twocolumn.y [type=int]
+ └── projections
+      ├── variable: onecolumn.x [type=int]
+      ├── variable: twocolumn.x [type=int]
+      └── variable: twocolumn.y [type=int]
+
+build
+SELECT * FROM onecolumn JOIN twocolumn ON onecolumn.x = twocolumn.y
+----
+project
+ ├── columns: onecolumn.x:int:null:1 twocolumn.x:int:null:3 twocolumn.y:int:null:4
+ ├── inner-join
+ │    ├── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2 twocolumn.x:int:null:3 twocolumn.y:int:null:4 twocolumn.rowid:int:5
+ │    ├── scan
+ │    │    └── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2
+ │    ├── scan
+ │    │    └── columns: twocolumn.x:int:null:3 twocolumn.y:int:null:4 twocolumn.rowid:int:5
+ │    └── eq [type=bool]
+ │         ├── variable: onecolumn.x [type=int]
+ │         └── variable: twocolumn.y [type=int]
+ └── projections
+      ├── variable: onecolumn.x [type=int]
+      ├── variable: twocolumn.x [type=int]
+      └── variable: twocolumn.y [type=int]
+
+# Inner join with filter predicate
+build
+SELECT * FROM twocolumn AS a JOIN twocolumn AS b ON a.x = 44
+----
+project
+ ├── columns: twocolumn.x:int:null:1 twocolumn.y:int:null:2 twocolumn.x:int:null:4 twocolumn.y:int:null:5
+ ├── inner-join
+ │    ├── columns: twocolumn.x:int:null:1 twocolumn.y:int:null:2 twocolumn.rowid:int:3 twocolumn.x:int:null:4 twocolumn.y:int:null:5 twocolumn.rowid:int:6
+ │    ├── scan
+ │    │    └── columns: twocolumn.x:int:null:1 twocolumn.y:int:null:2 twocolumn.rowid:int:3
+ │    ├── scan
+ │    │    └── columns: twocolumn.x:int:null:4 twocolumn.y:int:null:5 twocolumn.rowid:int:6
+ │    └── eq [type=bool]
+ │         ├── variable: twocolumn.x [type=int]
+ │         └── const: 44 [type=int]
+ └── projections
+      ├── variable: twocolumn.x [type=int]
+      ├── variable: twocolumn.y [type=int]
+      ├── variable: twocolumn.x [type=int]
+      └── variable: twocolumn.y [type=int]
+
+build
+SELECT o.x, t.y FROM onecolumn o INNER JOIN twocolumn t ON (o.x=t.x AND t.y=53)
+----
+project
+ ├── columns: onecolumn.x:int:null:1 twocolumn.y:int:null:4
+ ├── inner-join
+ │    ├── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2 twocolumn.x:int:null:3 twocolumn.y:int:null:4 twocolumn.rowid:int:5
+ │    ├── scan
+ │    │    └── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2
+ │    ├── scan
+ │    │    └── columns: twocolumn.x:int:null:3 twocolumn.y:int:null:4 twocolumn.rowid:int:5
+ │    └── and [type=bool]
+ │         ├── eq [type=bool]
+ │         │    ├── variable: onecolumn.x [type=int]
+ │         │    └── variable: twocolumn.x [type=int]
+ │         └── eq [type=bool]
+ │              ├── variable: twocolumn.y [type=int]
+ │              └── const: 53 [type=int]
+ └── projections
+      ├── variable: onecolumn.x [type=int]
+      └── variable: twocolumn.y [type=int]
+
+# Outer joins with filter predicate
+build
+SELECT o.x, t.y FROM onecolumn o LEFT OUTER JOIN twocolumn t ON (o.x=t.x AND t.y=53)
+----
+project
+ ├── columns: onecolumn.x:int:null:1 twocolumn.y:int:null:4
+ ├── left-join
+ │    ├── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2 twocolumn.x:int:null:3 twocolumn.y:int:null:4 twocolumn.rowid:int:null:5
+ │    ├── scan
+ │    │    └── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2
+ │    ├── scan
+ │    │    └── columns: twocolumn.x:int:null:3 twocolumn.y:int:null:4 twocolumn.rowid:int:5
+ │    └── and [type=bool]
+ │         ├── eq [type=bool]
+ │         │    ├── variable: onecolumn.x [type=int]
+ │         │    └── variable: twocolumn.x [type=int]
+ │         └── eq [type=bool]
+ │              ├── variable: twocolumn.y [type=int]
+ │              └── const: 53 [type=int]
+ └── projections
+      ├── variable: onecolumn.x [type=int]
+      └── variable: twocolumn.y [type=int]
+
+build
+SELECT o.x, t.y FROM onecolumn o LEFT OUTER JOIN twocolumn t ON (o.x=t.x AND o.x=44)
+----
+project
+ ├── columns: onecolumn.x:int:null:1 twocolumn.y:int:null:4
+ ├── left-join
+ │    ├── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2 twocolumn.x:int:null:3 twocolumn.y:int:null:4 twocolumn.rowid:int:null:5
+ │    ├── scan
+ │    │    └── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2
+ │    ├── scan
+ │    │    └── columns: twocolumn.x:int:null:3 twocolumn.y:int:null:4 twocolumn.rowid:int:5
+ │    └── and [type=bool]
+ │         ├── eq [type=bool]
+ │         │    ├── variable: onecolumn.x [type=int]
+ │         │    └── variable: twocolumn.x [type=int]
+ │         └── eq [type=bool]
+ │              ├── variable: onecolumn.x [type=int]
+ │              └── const: 44 [type=int]
+ └── projections
+      ├── variable: onecolumn.x [type=int]
+      └── variable: twocolumn.y [type=int]
+
+build
+SELECT o.x, t.y FROM onecolumn o LEFT OUTER JOIN twocolumn t ON (o.x=t.x AND t.x=44)
+----
+project
+ ├── columns: onecolumn.x:int:null:1 twocolumn.y:int:null:4
+ ├── left-join
+ │    ├── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2 twocolumn.x:int:null:3 twocolumn.y:int:null:4 twocolumn.rowid:int:null:5
+ │    ├── scan
+ │    │    └── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2
+ │    ├── scan
+ │    │    └── columns: twocolumn.x:int:null:3 twocolumn.y:int:null:4 twocolumn.rowid:int:5
+ │    └── and [type=bool]
+ │         ├── eq [type=bool]
+ │         │    ├── variable: onecolumn.x [type=int]
+ │         │    └── variable: twocolumn.x [type=int]
+ │         └── eq [type=bool]
+ │              ├── variable: twocolumn.x [type=int]
+ │              └── const: 44 [type=int]
+ └── projections
+      ├── variable: onecolumn.x [type=int]
+      └── variable: twocolumn.y [type=int]
+
+build
+SELECT x, a.x, b.y FROM (SELECT * FROM onecolumn AS a NATURAL JOIN twocolumn AS b) AS q
+----
+error: source name "a" not found in FROM clause
+
+build
+SELECT x, a.x, b.y FROM (SELECT * FROM onecolumn AS a NATURAL JOIN twocolumn AS b)
+----
+error: source name "a" not found in FROM clause
+
+
+## Simple test cases for inner, left, right, and outer joins
+
+exec-ddl
+CREATE TABLE a (i int)
+----
+table a
+  i int NULL
+  rowid int NOT NULL (hidden)
+
+exec-ddl
+CREATE TABLE b (i int, b bool)
+----
+table b
+  i int NULL
+  b bool NULL
+  rowid int NOT NULL (hidden)
+
+build
+SELECT * FROM a INNER JOIN b ON a.i = b.i
+----
+project
+ ├── columns: a.i:int:null:1 b.i:int:null:3 b.b:bool:null:4
+ ├── inner-join
+ │    ├── columns: a.i:int:null:1 a.rowid:int:2 b.i:int:null:3 b.b:bool:null:4 b.rowid:int:5
+ │    ├── scan
+ │    │    └── columns: a.i:int:null:1 a.rowid:int:2
+ │    ├── scan
+ │    │    └── columns: b.i:int:null:3 b.b:bool:null:4 b.rowid:int:5
+ │    └── eq [type=bool]
+ │         ├── variable: a.i [type=int]
+ │         └── variable: b.i [type=int]
+ └── projections
+      ├── variable: a.i [type=int]
+      ├── variable: b.i [type=int]
+      └── variable: b.b [type=bool]
+
+build
+SELECT * FROM a LEFT OUTER JOIN b ON a.i = b.i
+----
+project
+ ├── columns: a.i:int:null:1 b.i:int:null:3 b.b:bool:null:4
+ ├── left-join
+ │    ├── columns: a.i:int:null:1 a.rowid:int:2 b.i:int:null:3 b.b:bool:null:4 b.rowid:int:null:5
+ │    ├── scan
+ │    │    └── columns: a.i:int:null:1 a.rowid:int:2
+ │    ├── scan
+ │    │    └── columns: b.i:int:null:3 b.b:bool:null:4 b.rowid:int:5
+ │    └── eq [type=bool]
+ │         ├── variable: a.i [type=int]
+ │         └── variable: b.i [type=int]
+ └── projections
+      ├── variable: a.i [type=int]
+      ├── variable: b.i [type=int]
+      └── variable: b.b [type=bool]
+
+build
+SELECT * FROM a RIGHT OUTER JOIN b ON a.i = b.i
+----
+project
+ ├── columns: a.i:int:null:1 b.i:int:null:3 b.b:bool:null:4
+ ├── right-join
+ │    ├── columns: a.i:int:null:1 a.rowid:int:null:2 b.i:int:null:3 b.b:bool:null:4 b.rowid:int:5
+ │    ├── scan
+ │    │    └── columns: a.i:int:null:1 a.rowid:int:2
+ │    ├── scan
+ │    │    └── columns: b.i:int:null:3 b.b:bool:null:4 b.rowid:int:5
+ │    └── eq [type=bool]
+ │         ├── variable: a.i [type=int]
+ │         └── variable: b.i [type=int]
+ └── projections
+      ├── variable: a.i [type=int]
+      ├── variable: b.i [type=int]
+      └── variable: b.b [type=bool]
+
+build
+SELECT * FROM a FULL OUTER JOIN b ON a.i = b.i
+----
+project
+ ├── columns: a.i:int:null:1 b.i:int:null:3 b.b:bool:null:4
+ ├── full-join
+ │    ├── columns: a.i:int:null:1 a.rowid:int:null:2 b.i:int:null:3 b.b:bool:null:4 b.rowid:int:null:5
+ │    ├── scan
+ │    │    └── columns: a.i:int:null:1 a.rowid:int:2
+ │    ├── scan
+ │    │    └── columns: b.i:int:null:3 b.b:bool:null:4 b.rowid:int:5
+ │    └── eq [type=bool]
+ │         ├── variable: a.i [type=int]
+ │         └── variable: b.i [type=int]
+ └── projections
+      ├── variable: a.i [type=int]
+      ├── variable: b.i [type=int]
+      └── variable: b.b [type=bool]
+
+# Full outer join with filter predicate
+build
+SELECT * FROM a FULL OUTER JOIN b ON (a.i = b.i and a.i>2)
+----
+project
+ ├── columns: a.i:int:null:1 b.i:int:null:3 b.b:bool:null:4
+ ├── full-join
+ │    ├── columns: a.i:int:null:1 a.rowid:int:null:2 b.i:int:null:3 b.b:bool:null:4 b.rowid:int:null:5
+ │    ├── scan
+ │    │    └── columns: a.i:int:null:1 a.rowid:int:2
+ │    ├── scan
+ │    │    └── columns: b.i:int:null:3 b.b:bool:null:4 b.rowid:int:5
+ │    └── and [type=bool]
+ │         ├── eq [type=bool]
+ │         │    ├── variable: a.i [type=int]
+ │         │    └── variable: b.i [type=int]
+ │         └── gt [type=bool]
+ │              ├── variable: a.i [type=int]
+ │              └── const: 2 [type=int]
+ └── projections
+      ├── variable: a.i [type=int]
+      ├── variable: b.i [type=int]
+      └── variable: b.b [type=bool]
+
+# Check column orders and names.
+build
+SELECT * FROM (onecolumn CROSS JOIN twocolumn JOIN onecolumn AS a(b) ON a.b=twocolumn.x JOIN twocolumn AS c(d,e) ON a.b=c.d AND c.d=onecolumn.x)
+----
+project
+ ├── columns: onecolumn.x:int:null:1 twocolumn.x:int:null:3 twocolumn.y:int:null:4 onecolumn.x:int:null:6 twocolumn.x:int:null:8 twocolumn.y:int:null:9
+ ├── inner-join
+ │    ├── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2 twocolumn.x:int:null:3 twocolumn.y:int:null:4 twocolumn.rowid:int:5 onecolumn.x:int:null:6 onecolumn.rowid:int:7 twocolumn.x:int:null:8 twocolumn.y:int:null:9 twocolumn.rowid:int:10
+ │    ├── inner-join
+ │    │    ├── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2 twocolumn.x:int:null:3 twocolumn.y:int:null:4 twocolumn.rowid:int:5 onecolumn.x:int:null:6 onecolumn.rowid:int:7
+ │    │    ├── inner-join
+ │    │    │    ├── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2 twocolumn.x:int:null:3 twocolumn.y:int:null:4 twocolumn.rowid:int:5
+ │    │    │    ├── scan
+ │    │    │    │    └── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2
+ │    │    │    ├── scan
+ │    │    │    │    └── columns: twocolumn.x:int:null:3 twocolumn.y:int:null:4 twocolumn.rowid:int:5
+ │    │    │    └── true [type=bool]
+ │    │    ├── scan
+ │    │    │    └── columns: onecolumn.x:int:null:6 onecolumn.rowid:int:7
+ │    │    └── eq [type=bool]
+ │    │         ├── variable: onecolumn.x [type=int]
+ │    │         └── variable: twocolumn.x [type=int]
+ │    ├── scan
+ │    │    └── columns: twocolumn.x:int:null:8 twocolumn.y:int:null:9 twocolumn.rowid:int:10
+ │    └── and [type=bool]
+ │         ├── eq [type=bool]
+ │         │    ├── variable: onecolumn.x [type=int]
+ │         │    └── variable: twocolumn.x [type=int]
+ │         └── eq [type=bool]
+ │              ├── variable: twocolumn.x [type=int]
+ │              └── variable: onecolumn.x [type=int]
+ └── projections
+      ├── variable: onecolumn.x [type=int]
+      ├── variable: twocolumn.x [type=int]
+      ├── variable: twocolumn.y [type=int]
+      ├── variable: onecolumn.x [type=int]
+      ├── variable: twocolumn.x [type=int]
+      └── variable: twocolumn.y [type=int]
+
+build
+SELECT * FROM onecolumn JOIN (SELECT x + 2 AS x FROM onecolumn) USING(x)
+----
+project
+ ├── columns: onecolumn.x:int:null:1
+ ├── inner-join
+ │    ├── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2 x:int:null:5
+ │    ├── scan
+ │    │    └── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2
+ │    ├── project
+ │    │    ├── columns: x:int:null:5
+ │    │    ├── scan
+ │    │    │    └── columns: onecolumn.x:int:null:3 onecolumn.rowid:int:4
+ │    │    └── projections
+ │    │         └── plus [type=int]
+ │    │              ├── variable: onecolumn.x [type=int]
+ │    │              └── const: 2 [type=int]
+ │    └── eq [type=bool]
+ │         ├── variable: onecolumn.x [type=int]
+ │         └── variable: x [type=int]
+ └── projections
+      └── variable: onecolumn.x [type=int]
+
+# Check that a single column can have multiple table aliases.
+build
+SELECT * FROM (twocolumn AS a JOIN twocolumn AS b USING(x) JOIN twocolumn AS c USING(x))
+----
+project
+ ├── columns: twocolumn.x:int:null:1 twocolumn.y:int:null:2 twocolumn.y:int:null:5 twocolumn.y:int:null:8
+ ├── inner-join
+ │    ├── columns: twocolumn.x:int:null:1 twocolumn.y:int:null:2 twocolumn.rowid:int:3 twocolumn.x:int:null:4 twocolumn.y:int:null:5 twocolumn.rowid:int:6 twocolumn.x:int:null:7 twocolumn.y:int:null:8 twocolumn.rowid:int:9
+ │    ├── inner-join
+ │    │    ├── columns: twocolumn.x:int:null:1 twocolumn.y:int:null:2 twocolumn.rowid:int:3 twocolumn.x:int:null:4 twocolumn.y:int:null:5 twocolumn.rowid:int:6
+ │    │    ├── scan
+ │    │    │    └── columns: twocolumn.x:int:null:1 twocolumn.y:int:null:2 twocolumn.rowid:int:3
+ │    │    ├── scan
+ │    │    │    └── columns: twocolumn.x:int:null:4 twocolumn.y:int:null:5 twocolumn.rowid:int:6
+ │    │    └── eq [type=bool]
+ │    │         ├── variable: twocolumn.x [type=int]
+ │    │         └── variable: twocolumn.x [type=int]
+ │    ├── scan
+ │    │    └── columns: twocolumn.x:int:null:7 twocolumn.y:int:null:8 twocolumn.rowid:int:9
+ │    └── eq [type=bool]
+ │         ├── variable: twocolumn.x [type=int]
+ │         └── variable: twocolumn.x [type=int]
+ └── projections
+      ├── variable: twocolumn.x [type=int]
+      ├── variable: twocolumn.y [type=int]
+      ├── variable: twocolumn.y [type=int]
+      └── variable: twocolumn.y [type=int]
+
+build
+SELECT a.x AS s, b.x, c.x, a.y, b.y, c.y FROM (twocolumn AS a JOIN twocolumn AS b USING(x) JOIN twocolumn AS c USING(x))
+----
+project
+ ├── columns: twocolumn.x:int:null:1 twocolumn.x:int:null:4 twocolumn.x:int:null:7 twocolumn.y:int:null:2 twocolumn.y:int:null:5 twocolumn.y:int:null:8
+ ├── inner-join
+ │    ├── columns: twocolumn.x:int:null:1 twocolumn.y:int:null:2 twocolumn.rowid:int:3 twocolumn.x:int:null:4 twocolumn.y:int:null:5 twocolumn.rowid:int:6 twocolumn.x:int:null:7 twocolumn.y:int:null:8 twocolumn.rowid:int:9
+ │    ├── inner-join
+ │    │    ├── columns: twocolumn.x:int:null:1 twocolumn.y:int:null:2 twocolumn.rowid:int:3 twocolumn.x:int:null:4 twocolumn.y:int:null:5 twocolumn.rowid:int:6
+ │    │    ├── scan
+ │    │    │    └── columns: twocolumn.x:int:null:1 twocolumn.y:int:null:2 twocolumn.rowid:int:3
+ │    │    ├── scan
+ │    │    │    └── columns: twocolumn.x:int:null:4 twocolumn.y:int:null:5 twocolumn.rowid:int:6
+ │    │    └── eq [type=bool]
+ │    │         ├── variable: twocolumn.x [type=int]
+ │    │         └── variable: twocolumn.x [type=int]
+ │    ├── scan
+ │    │    └── columns: twocolumn.x:int:null:7 twocolumn.y:int:null:8 twocolumn.rowid:int:9
+ │    └── eq [type=bool]
+ │         ├── variable: twocolumn.x [type=int]
+ │         └── variable: twocolumn.x [type=int]
+ └── projections
+      ├── variable: twocolumn.x [type=int]
+      ├── variable: twocolumn.x [type=int]
+      ├── variable: twocolumn.x [type=int]
+      ├── variable: twocolumn.y [type=int]
+      ├── variable: twocolumn.y [type=int]
+      └── variable: twocolumn.y [type=int]
+
+build
+SELECT * FROM (onecolumn AS a JOIN onecolumn AS b USING(y))
+----
+error: column "y" specified in USING clause does not exist in left table
+
+build
+SELECT * FROM (onecolumn AS a JOIN onecolumn AS b USING(x, x))
+----
+error: column "x" appears more than once in USING clause
+
+exec-ddl
+CREATE TABLE othertype (x TEXT)
+----
+table othertype
+  x string NULL
+  rowid int NOT NULL (hidden)
+
+build
+SELECT * FROM (onecolumn AS a JOIN othertype AS b USING(x))
+----
+error: JOIN/USING types int for left and string for right cannot be matched for column x
+
+build
+SELECT * FROM (onecolumn JOIN onecolumn USING(x))
+----
+error: cannot join columns from the same source name "onecolumn" (missing AS clause)
+
+build
+SELECT * FROM (onecolumn JOIN twocolumn USING(x) JOIN onecolumn USING(x))
+----
+error: cannot join columns from the same source name "onecolumn" (missing AS clause)
+
+# Check that star expansion works across anonymous sources.
+build
+SELECT * FROM (SELECT * FROM onecolumn), (SELECT * FROM onecolumn)
+----
+inner-join
+ ├── columns: onecolumn.x:int:null:1 onecolumn.x:int:null:3
+ ├── project
+ │    ├── columns: onecolumn.x:int:null:1
+ │    ├── scan
+ │    │    └── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2
+ │    └── projections
+ │         └── variable: onecolumn.x [type=int]
+ ├── project
+ │    ├── columns: onecolumn.x:int:null:3
+ │    ├── scan
+ │    │    └── columns: onecolumn.x:int:null:3 onecolumn.rowid:int:4
+ │    └── projections
+ │         └── variable: onecolumn.x [type=int]
+ └── true [type=bool]
+
+# Check that anonymous sources are properly looked up without ambiguity.
+build
+SELECT x FROM (onecolumn JOIN othercolumn USING (x)) JOIN (onecolumn AS a JOIN othercolumn AS b USING(x)) USING(x)
+----
+project
+ ├── columns: onecolumn.x:int:null:1
+ ├── inner-join
+ │    ├── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2 othercolumn.x:int:null:3 othercolumn.rowid:int:4 onecolumn.x:int:null:5 onecolumn.rowid:int:6 othercolumn.x:int:null:7 othercolumn.rowid:int:8
+ │    ├── inner-join
+ │    │    ├── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2 othercolumn.x:int:null:3 othercolumn.rowid:int:4
+ │    │    ├── scan
+ │    │    │    └── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2
+ │    │    ├── scan
+ │    │    │    └── columns: othercolumn.x:int:null:3 othercolumn.rowid:int:4
+ │    │    └── eq [type=bool]
+ │    │         ├── variable: onecolumn.x [type=int]
+ │    │         └── variable: othercolumn.x [type=int]
+ │    ├── inner-join
+ │    │    ├── columns: onecolumn.x:int:null:5 onecolumn.rowid:int:6 othercolumn.x:int:null:7 othercolumn.rowid:int:8
+ │    │    ├── scan
+ │    │    │    └── columns: onecolumn.x:int:null:5 onecolumn.rowid:int:6
+ │    │    ├── scan
+ │    │    │    └── columns: othercolumn.x:int:null:7 othercolumn.rowid:int:8
+ │    │    └── eq [type=bool]
+ │    │         ├── variable: onecolumn.x [type=int]
+ │    │         └── variable: othercolumn.x [type=int]
+ │    └── eq [type=bool]
+ │         ├── variable: onecolumn.x [type=int]
+ │         └── variable: onecolumn.x [type=int]
+ └── projections
+      └── variable: onecolumn.x [type=int]
+
+# Check that multiple anonymous sources cause proper ambiguity errors.
+build
+SELECT x FROM (SELECT * FROM onecolumn), (SELECT * FROM onecolumn)
+----
+error: column reference "x" is ambiguous (candidates: <anonymous>.x, <anonymous>.x)
+
+build
+SELECT * FROM (onecolumn AS a JOIN onecolumn AS b ON x > 32)
+----
+error: column reference "x" is ambiguous (candidates: a.x, b.x)
+
+build
+SELECT * FROM (onecolumn AS a JOIN onecolumn AS b ON a.y > y)
+----
+error: column name "a.y" not found
+
+# THe following queries verify that only the necessary columns are scanned.
+build
+SELECT a.x, b.y FROM twocolumn AS a, twocolumn AS b
+----
+project
+ ├── columns: twocolumn.x:int:null:1 twocolumn.y:int:null:5
+ ├── inner-join
+ │    ├── columns: twocolumn.x:int:null:1 twocolumn.y:int:null:2 twocolumn.rowid:int:3 twocolumn.x:int:null:4 twocolumn.y:int:null:5 twocolumn.rowid:int:6
+ │    ├── scan
+ │    │    └── columns: twocolumn.x:int:null:1 twocolumn.y:int:null:2 twocolumn.rowid:int:3
+ │    ├── scan
+ │    │    └── columns: twocolumn.x:int:null:4 twocolumn.y:int:null:5 twocolumn.rowid:int:6
+ │    └── true [type=bool]
+ └── projections
+      ├── variable: twocolumn.x [type=int]
+      └── variable: twocolumn.y [type=int]
+
+build
+SELECT b.y FROM (twocolumn AS a JOIN twocolumn AS b USING(x))
+----
+project
+ ├── columns: twocolumn.y:int:null:5
+ ├── inner-join
+ │    ├── columns: twocolumn.x:int:null:1 twocolumn.y:int:null:2 twocolumn.rowid:int:3 twocolumn.x:int:null:4 twocolumn.y:int:null:5 twocolumn.rowid:int:6
+ │    ├── scan
+ │    │    └── columns: twocolumn.x:int:null:1 twocolumn.y:int:null:2 twocolumn.rowid:int:3
+ │    ├── scan
+ │    │    └── columns: twocolumn.x:int:null:4 twocolumn.y:int:null:5 twocolumn.rowid:int:6
+ │    └── eq [type=bool]
+ │         ├── variable: twocolumn.x [type=int]
+ │         └── variable: twocolumn.x [type=int]
+ └── projections
+      └── variable: twocolumn.y [type=int]
+
+build
+SELECT b.y FROM (twocolumn AS a JOIN twocolumn AS b ON a.x = b.x)
+----
+project
+ ├── columns: twocolumn.y:int:null:5
+ ├── inner-join
+ │    ├── columns: twocolumn.x:int:null:1 twocolumn.y:int:null:2 twocolumn.rowid:int:3 twocolumn.x:int:null:4 twocolumn.y:int:null:5 twocolumn.rowid:int:6
+ │    ├── scan
+ │    │    └── columns: twocolumn.x:int:null:1 twocolumn.y:int:null:2 twocolumn.rowid:int:3
+ │    ├── scan
+ │    │    └── columns: twocolumn.x:int:null:4 twocolumn.y:int:null:5 twocolumn.rowid:int:6
+ │    └── eq [type=bool]
+ │         ├── variable: twocolumn.x [type=int]
+ │         └── variable: twocolumn.x [type=int]
+ └── projections
+      └── variable: twocolumn.y [type=int]
+
+build
+SELECT a.x FROM (twocolumn AS a JOIN twocolumn AS b ON a.x < b.y)
+----
+project
+ ├── columns: twocolumn.x:int:null:1
+ ├── inner-join
+ │    ├── columns: twocolumn.x:int:null:1 twocolumn.y:int:null:2 twocolumn.rowid:int:3 twocolumn.x:int:null:4 twocolumn.y:int:null:5 twocolumn.rowid:int:6
+ │    ├── scan
+ │    │    └── columns: twocolumn.x:int:null:1 twocolumn.y:int:null:2 twocolumn.rowid:int:3
+ │    ├── scan
+ │    │    └── columns: twocolumn.x:int:null:4 twocolumn.y:int:null:5 twocolumn.rowid:int:6
+ │    └── lt [type=bool]
+ │         ├── variable: twocolumn.x [type=int]
+ │         └── variable: twocolumn.y [type=int]
+ └── projections
+      └── variable: twocolumn.x [type=int]
+
+# Tests for filter propagation through joins.
+
+exec-ddl
+CREATE TABLE square (n INT PRIMARY KEY, sq INT)
+----
+table square
+  n int NOT NULL
+  sq int NULL
+
+exec-ddl
+CREATE TABLE pairs (a INT, b INT)
+----
+table pairs
+  a int NULL
+  b int NULL
+  rowid int NOT NULL (hidden)
+
+# The filter expression becomes an equality constraint.
+build
+SELECT * FROM pairs, square WHERE pairs.b = square.n
+----
+project
+ ├── columns: pairs.a:int:null:1 pairs.b:int:null:2 square.n:int:4 square.sq:int:null:5
+ ├── select
+ │    ├── columns: pairs.a:int:null:1 pairs.b:int:null:2 pairs.rowid:int:3 square.n:int:4 square.sq:int:null:5
+ │    ├── inner-join
+ │    │    ├── columns: pairs.a:int:null:1 pairs.b:int:null:2 pairs.rowid:int:3 square.n:int:4 square.sq:int:null:5
+ │    │    ├── scan
+ │    │    │    └── columns: pairs.a:int:null:1 pairs.b:int:null:2 pairs.rowid:int:3
+ │    │    ├── scan
+ │    │    │    └── columns: square.n:int:4 square.sq:int:null:5
+ │    │    └── true [type=bool]
+ │    └── eq [type=bool]
+ │         ├── variable: pairs.b [type=int]
+ │         └── variable: square.n [type=int]
+ └── projections
+      ├── variable: pairs.a [type=int]
+      ├── variable: pairs.b [type=int]
+      ├── variable: square.n [type=int]
+      └── variable: square.sq [type=int]
+
+# The filter expression becomes an ON predicate.
+build
+SELECT * FROM pairs, square WHERE pairs.a + pairs.b = square.sq
+----
+project
+ ├── columns: pairs.a:int:null:1 pairs.b:int:null:2 square.n:int:4 square.sq:int:null:5
+ ├── select
+ │    ├── columns: pairs.a:int:null:1 pairs.b:int:null:2 pairs.rowid:int:3 square.n:int:4 square.sq:int:null:5
+ │    ├── inner-join
+ │    │    ├── columns: pairs.a:int:null:1 pairs.b:int:null:2 pairs.rowid:int:3 square.n:int:4 square.sq:int:null:5
+ │    │    ├── scan
+ │    │    │    └── columns: pairs.a:int:null:1 pairs.b:int:null:2 pairs.rowid:int:3
+ │    │    ├── scan
+ │    │    │    └── columns: square.n:int:4 square.sq:int:null:5
+ │    │    └── true [type=bool]
+ │    └── eq [type=bool]
+ │         ├── plus [type=int]
+ │         │    ├── variable: pairs.a [type=int]
+ │         │    └── variable: pairs.b [type=int]
+ │         └── variable: square.sq [type=int]
+ └── projections
+      ├── variable: pairs.a [type=int]
+      ├── variable: pairs.b [type=int]
+      ├── variable: square.n [type=int]
+      └── variable: square.sq [type=int]
+
+# Query similar to the one above, but the filter refers to a rendered
+# expression and can't "break through". See the comment for propagateFilters
+# in fitler_opt.go for all the details.
+build
+SELECT a, b, n, sq FROM (SELECT a, b, a + b AS sum, n, sq FROM pairs, square) WHERE sum = sq
+----
+project
+ ├── columns: pairs.a:int:null:1 pairs.b:int:null:2 square.n:int:4 square.sq:int:null:5
+ ├── select
+ │    ├── columns: pairs.a:int:null:1 pairs.b:int:null:2 square.n:int:4 square.sq:int:null:5 sum:int:null:6
+ │    ├── project
+ │    │    ├── columns: pairs.a:int:null:1 pairs.b:int:null:2 sum:int:null:6 square.n:int:4 square.sq:int:null:5
+ │    │    ├── inner-join
+ │    │    │    ├── columns: pairs.a:int:null:1 pairs.b:int:null:2 pairs.rowid:int:3 square.n:int:4 square.sq:int:null:5
+ │    │    │    ├── scan
+ │    │    │    │    └── columns: pairs.a:int:null:1 pairs.b:int:null:2 pairs.rowid:int:3
+ │    │    │    ├── scan
+ │    │    │    │    └── columns: square.n:int:4 square.sq:int:null:5
+ │    │    │    └── true [type=bool]
+ │    │    └── projections
+ │    │         ├── variable: pairs.a [type=int]
+ │    │         ├── variable: pairs.b [type=int]
+ │    │         ├── plus [type=int]
+ │    │         │    ├── variable: pairs.a [type=int]
+ │    │         │    └── variable: pairs.b [type=int]
+ │    │         ├── variable: square.n [type=int]
+ │    │         └── variable: square.sq [type=int]
+ │    └── eq [type=bool]
+ │         ├── variable: sum [type=int]
+ │         └── variable: square.sq [type=int]
+ └── projections
+      ├── variable: pairs.a [type=int]
+      ├── variable: pairs.b [type=int]
+      ├── variable: square.n [type=int]
+      └── variable: square.sq [type=int]
+
+# The filter expression must stay on top of the outer join.
+build
+SELECT * FROM pairs FULL OUTER JOIN square ON pairs.a + pairs.b = square.sq
+----
+project
+ ├── columns: pairs.a:int:null:1 pairs.b:int:null:2 square.n:int:null:4 square.sq:int:null:5
+ ├── full-join
+ │    ├── columns: pairs.a:int:null:1 pairs.b:int:null:2 pairs.rowid:int:null:3 square.n:int:null:4 square.sq:int:null:5
+ │    ├── scan
+ │    │    └── columns: pairs.a:int:null:1 pairs.b:int:null:2 pairs.rowid:int:3
+ │    ├── scan
+ │    │    └── columns: square.n:int:4 square.sq:int:null:5
+ │    └── eq [type=bool]
+ │         ├── plus [type=int]
+ │         │    ├── variable: pairs.a [type=int]
+ │         │    └── variable: pairs.b [type=int]
+ │         └── variable: square.sq [type=int]
+ └── projections
+      ├── variable: pairs.a [type=int]
+      ├── variable: pairs.b [type=int]
+      ├── variable: square.n [type=int]
+      └── variable: square.sq [type=int]
+
+build
+SELECT * FROM pairs FULL OUTER JOIN square ON pairs.a + pairs.b = square.sq WHERE pairs.b%2 <> square.sq%2
+----
+project
+ ├── columns: pairs.a:int:null:1 pairs.b:int:null:2 square.n:int:null:4 square.sq:int:null:5
+ ├── select
+ │    ├── columns: pairs.a:int:null:1 pairs.b:int:null:2 pairs.rowid:int:null:3 square.n:int:null:4 square.sq:int:null:5
+ │    ├── full-join
+ │    │    ├── columns: pairs.a:int:null:1 pairs.b:int:null:2 pairs.rowid:int:null:3 square.n:int:null:4 square.sq:int:null:5
+ │    │    ├── scan
+ │    │    │    └── columns: pairs.a:int:null:1 pairs.b:int:null:2 pairs.rowid:int:3
+ │    │    ├── scan
+ │    │    │    └── columns: square.n:int:4 square.sq:int:null:5
+ │    │    └── eq [type=bool]
+ │    │         ├── plus [type=int]
+ │    │         │    ├── variable: pairs.a [type=int]
+ │    │         │    └── variable: pairs.b [type=int]
+ │    │         └── variable: square.sq [type=int]
+ │    └── ne [type=bool]
+ │         ├── mod [type=int]
+ │         │    ├── variable: pairs.b [type=int]
+ │         │    └── const: 2 [type=int]
+ │         └── mod [type=int]
+ │              ├── variable: square.sq [type=int]
+ │              └── const: 2 [type=int]
+ └── projections
+      ├── variable: pairs.a [type=int]
+      ├── variable: pairs.b [type=int]
+      ├── variable: square.n [type=int]
+      └── variable: square.sq [type=int]
+
+# Filter propagation through outer joins.
+
+build
+SELECT *
+  FROM (SELECT * FROM pairs LEFT JOIN square ON b = sq AND a > 1 AND n < 6)
+ WHERE b > 1 AND (n IS NULL OR n > 1) AND (n IS NULL OR a  < sq)
+----
+select
+ ├── columns: pairs.a:int:null:1 pairs.b:int:null:2 square.n:int:null:4 square.sq:int:null:5
+ ├── project
+ │    ├── columns: pairs.a:int:null:1 pairs.b:int:null:2 square.n:int:null:4 square.sq:int:null:5
+ │    ├── left-join
+ │    │    ├── columns: pairs.a:int:null:1 pairs.b:int:null:2 pairs.rowid:int:3 square.n:int:null:4 square.sq:int:null:5
+ │    │    ├── scan
+ │    │    │    └── columns: pairs.a:int:null:1 pairs.b:int:null:2 pairs.rowid:int:3
+ │    │    ├── scan
+ │    │    │    └── columns: square.n:int:4 square.sq:int:null:5
+ │    │    └── and [type=bool]
+ │    │         ├── and [type=bool]
+ │    │         │    ├── eq [type=bool]
+ │    │         │    │    ├── variable: pairs.b [type=int]
+ │    │         │    │    └── variable: square.sq [type=int]
+ │    │         │    └── gt [type=bool]
+ │    │         │         ├── variable: pairs.a [type=int]
+ │    │         │         └── const: 1 [type=int]
+ │    │         └── lt [type=bool]
+ │    │              ├── variable: square.n [type=int]
+ │    │              └── const: 6 [type=int]
+ │    └── projections
+ │         ├── variable: pairs.a [type=int]
+ │         ├── variable: pairs.b [type=int]
+ │         ├── variable: square.n [type=int]
+ │         └── variable: square.sq [type=int]
+ └── and [type=bool]
+      ├── and [type=bool]
+      │    ├── gt [type=bool]
+      │    │    ├── variable: pairs.b [type=int]
+      │    │    └── const: 1 [type=int]
+      │    └── or [type=bool]
+      │         ├── is [type=bool]
+      │         │    ├── variable: square.n [type=int]
+      │         │    └── const: NULL [type=NULL]
+      │         └── gt [type=bool]
+      │              ├── variable: square.n [type=int]
+      │              └── const: 1 [type=int]
+      └── or [type=bool]
+           ├── is [type=bool]
+           │    ├── variable: square.n [type=int]
+           │    └── const: NULL [type=NULL]
+           └── lt [type=bool]
+                ├── variable: pairs.a [type=int]
+                └── variable: square.sq [type=int]
+
+build
+SELECT *
+  FROM (SELECT * FROM pairs RIGHT JOIN square ON b = sq AND a > 1 AND n < 6)
+ WHERE (a IS NULL OR a > 2) AND n > 1 AND (a IS NULL OR a < sq)
+----
+select
+ ├── columns: pairs.a:int:null:1 pairs.b:int:null:2 square.n:int:4 square.sq:int:null:5
+ ├── project
+ │    ├── columns: pairs.a:int:null:1 pairs.b:int:null:2 square.n:int:4 square.sq:int:null:5
+ │    ├── right-join
+ │    │    ├── columns: pairs.a:int:null:1 pairs.b:int:null:2 pairs.rowid:int:null:3 square.n:int:4 square.sq:int:null:5
+ │    │    ├── scan
+ │    │    │    └── columns: pairs.a:int:null:1 pairs.b:int:null:2 pairs.rowid:int:3
+ │    │    ├── scan
+ │    │    │    └── columns: square.n:int:4 square.sq:int:null:5
+ │    │    └── and [type=bool]
+ │    │         ├── and [type=bool]
+ │    │         │    ├── eq [type=bool]
+ │    │         │    │    ├── variable: pairs.b [type=int]
+ │    │         │    │    └── variable: square.sq [type=int]
+ │    │         │    └── gt [type=bool]
+ │    │         │         ├── variable: pairs.a [type=int]
+ │    │         │         └── const: 1 [type=int]
+ │    │         └── lt [type=bool]
+ │    │              ├── variable: square.n [type=int]
+ │    │              └── const: 6 [type=int]
+ │    └── projections
+ │         ├── variable: pairs.a [type=int]
+ │         ├── variable: pairs.b [type=int]
+ │         ├── variable: square.n [type=int]
+ │         └── variable: square.sq [type=int]
+ └── and [type=bool]
+      ├── and [type=bool]
+      │    ├── or [type=bool]
+      │    │    ├── is [type=bool]
+      │    │    │    ├── variable: pairs.a [type=int]
+      │    │    │    └── const: NULL [type=NULL]
+      │    │    └── gt [type=bool]
+      │    │         ├── variable: pairs.a [type=int]
+      │    │         └── const: 2 [type=int]
+      │    └── gt [type=bool]
+      │         ├── variable: square.n [type=int]
+      │         └── const: 1 [type=int]
+      └── or [type=bool]
+           ├── is [type=bool]
+           │    ├── variable: pairs.a [type=int]
+           │    └── const: NULL [type=NULL]
+           └── lt [type=bool]
+                ├── variable: pairs.a [type=int]
+                └── variable: square.sq [type=int]
+
+# The simpler plan for an inner join, to compare.
+build
+SELECT *
+  FROM (SELECT * FROM pairs JOIN square ON b = sq AND a > 1 AND n < 6)
+ WHERE (a IS NULL OR a > 2) AND n > 1 AND (a IS NULL OR a < sq)
+----
+select
+ ├── columns: pairs.a:int:null:1 pairs.b:int:null:2 square.n:int:4 square.sq:int:null:5
+ ├── project
+ │    ├── columns: pairs.a:int:null:1 pairs.b:int:null:2 square.n:int:4 square.sq:int:null:5
+ │    ├── inner-join
+ │    │    ├── columns: pairs.a:int:null:1 pairs.b:int:null:2 pairs.rowid:int:3 square.n:int:4 square.sq:int:null:5
+ │    │    ├── scan
+ │    │    │    └── columns: pairs.a:int:null:1 pairs.b:int:null:2 pairs.rowid:int:3
+ │    │    ├── scan
+ │    │    │    └── columns: square.n:int:4 square.sq:int:null:5
+ │    │    └── and [type=bool]
+ │    │         ├── and [type=bool]
+ │    │         │    ├── eq [type=bool]
+ │    │         │    │    ├── variable: pairs.b [type=int]
+ │    │         │    │    └── variable: square.sq [type=int]
+ │    │         │    └── gt [type=bool]
+ │    │         │         ├── variable: pairs.a [type=int]
+ │    │         │         └── const: 1 [type=int]
+ │    │         └── lt [type=bool]
+ │    │              ├── variable: square.n [type=int]
+ │    │              └── const: 6 [type=int]
+ │    └── projections
+ │         ├── variable: pairs.a [type=int]
+ │         ├── variable: pairs.b [type=int]
+ │         ├── variable: square.n [type=int]
+ │         └── variable: square.sq [type=int]
+ └── and [type=bool]
+      ├── and [type=bool]
+      │    ├── or [type=bool]
+      │    │    ├── is [type=bool]
+      │    │    │    ├── variable: pairs.a [type=int]
+      │    │    │    └── const: NULL [type=NULL]
+      │    │    └── gt [type=bool]
+      │    │         ├── variable: pairs.a [type=int]
+      │    │         └── const: 2 [type=int]
+      │    └── gt [type=bool]
+      │         ├── variable: square.n [type=int]
+      │         └── const: 1 [type=int]
+      └── or [type=bool]
+           ├── is [type=bool]
+           │    ├── variable: pairs.a [type=int]
+           │    └── const: NULL [type=NULL]
+           └── lt [type=bool]
+                ├── variable: pairs.a [type=int]
+                └── variable: square.sq [type=int]
+
+
+exec-ddl
+CREATE TABLE t1 (col1 INT, x INT, col2 INT, y INT)
+----
+table t1
+  col1 int NULL
+  x int NULL
+  col2 int NULL
+  y int NULL
+  rowid int NOT NULL (hidden)
+
+exec-ddl
+CREATE TABLE t2 (col3 INT, y INT, x INT, col4 INT)
+----
+table t2
+  col3 int NULL
+  y int NULL
+  x int NULL
+  col4 int NULL
+  rowid int NOT NULL (hidden)
+
+build
+SELECT * FROM t1 JOIN t2 USING(x)
+----
+project
+ ├── columns: t1.x:int:null:2 t1.col1:int:null:1 t1.col2:int:null:3 t1.y:int:null:4 t2.col3:int:null:6 t2.y:int:null:7 t2.col4:int:null:9
+ ├── inner-join
+ │    ├── columns: t1.col1:int:null:1 t1.x:int:null:2 t1.col2:int:null:3 t1.y:int:null:4 t1.rowid:int:5 t2.col3:int:null:6 t2.y:int:null:7 t2.x:int:null:8 t2.col4:int:null:9 t2.rowid:int:10
+ │    ├── scan
+ │    │    └── columns: t1.col1:int:null:1 t1.x:int:null:2 t1.col2:int:null:3 t1.y:int:null:4 t1.rowid:int:5
+ │    ├── scan
+ │    │    └── columns: t2.col3:int:null:6 t2.y:int:null:7 t2.x:int:null:8 t2.col4:int:null:9 t2.rowid:int:10
+ │    └── eq [type=bool]
+ │         ├── variable: t1.x [type=int]
+ │         └── variable: t2.x [type=int]
+ └── projections
+      ├── variable: t1.x [type=int]
+      ├── variable: t1.col1 [type=int]
+      ├── variable: t1.col2 [type=int]
+      ├── variable: t1.y [type=int]
+      ├── variable: t2.col3 [type=int]
+      ├── variable: t2.y [type=int]
+      └── variable: t2.col4 [type=int]
+
+build
+SELECT * FROM t1 NATURAL JOIN t2
+----
+project
+ ├── columns: t1.x:int:null:2 t1.y:int:null:4 t1.col1:int:null:1 t1.col2:int:null:3 t2.col3:int:null:6 t2.col4:int:null:9
+ ├── inner-join
+ │    ├── columns: t1.col1:int:null:1 t1.x:int:null:2 t1.col2:int:null:3 t1.y:int:null:4 t1.rowid:int:5 t2.col3:int:null:6 t2.y:int:null:7 t2.x:int:null:8 t2.col4:int:null:9 t2.rowid:int:10
+ │    ├── scan
+ │    │    └── columns: t1.col1:int:null:1 t1.x:int:null:2 t1.col2:int:null:3 t1.y:int:null:4 t1.rowid:int:5
+ │    ├── scan
+ │    │    └── columns: t2.col3:int:null:6 t2.y:int:null:7 t2.x:int:null:8 t2.col4:int:null:9 t2.rowid:int:10
+ │    └── and [type=bool]
+ │         ├── eq [type=bool]
+ │         │    ├── variable: t1.x [type=int]
+ │         │    └── variable: t2.x [type=int]
+ │         └── eq [type=bool]
+ │              ├── variable: t1.y [type=int]
+ │              └── variable: t2.y [type=int]
+ └── projections
+      ├── variable: t1.x [type=int]
+      ├── variable: t1.y [type=int]
+      ├── variable: t1.col1 [type=int]
+      ├── variable: t1.col2 [type=int]
+      ├── variable: t2.col3 [type=int]
+      └── variable: t2.col4 [type=int]
+
+build
+SELECT * FROM t1 JOIN t2 ON t2.x=t1.x
+----
+project
+ ├── columns: t1.col1:int:null:1 t1.x:int:null:2 t1.col2:int:null:3 t1.y:int:null:4 t2.col3:int:null:6 t2.y:int:null:7 t2.x:int:null:8 t2.col4:int:null:9
+ ├── inner-join
+ │    ├── columns: t1.col1:int:null:1 t1.x:int:null:2 t1.col2:int:null:3 t1.y:int:null:4 t1.rowid:int:5 t2.col3:int:null:6 t2.y:int:null:7 t2.x:int:null:8 t2.col4:int:null:9 t2.rowid:int:10
+ │    ├── scan
+ │    │    └── columns: t1.col1:int:null:1 t1.x:int:null:2 t1.col2:int:null:3 t1.y:int:null:4 t1.rowid:int:5
+ │    ├── scan
+ │    │    └── columns: t2.col3:int:null:6 t2.y:int:null:7 t2.x:int:null:8 t2.col4:int:null:9 t2.rowid:int:10
+ │    └── eq [type=bool]
+ │         ├── variable: t2.x [type=int]
+ │         └── variable: t1.x [type=int]
+ └── projections
+      ├── variable: t1.col1 [type=int]
+      ├── variable: t1.x [type=int]
+      ├── variable: t1.col2 [type=int]
+      ├── variable: t1.y [type=int]
+      ├── variable: t2.col3 [type=int]
+      ├── variable: t2.y [type=int]
+      ├── variable: t2.x [type=int]
+      └── variable: t2.col4 [type=int]
+
+build
+SELECT * FROM t1 FULL OUTER JOIN t2 USING(x)
+----
+project
+ ├── columns: x:int:null:11 t1.col1:int:null:1 t1.col2:int:null:3 t1.y:int:null:4 t2.col3:int:null:6 t2.y:int:null:7 t2.col4:int:null:9
+ ├── project
+ │    ├── columns: x:int:null:11 t1.col1:int:null:1 t1.x:int:null:2 t1.col2:int:null:3 t1.y:int:null:4 t1.rowid:int:null:5 t2.col3:int:null:6 t2.y:int:null:7 t2.x:int:null:8 t2.col4:int:null:9 t2.rowid:int:null:10
+ │    ├── full-join
+ │    │    ├── columns: t1.col1:int:null:1 t1.x:int:null:2 t1.col2:int:null:3 t1.y:int:null:4 t1.rowid:int:null:5 t2.col3:int:null:6 t2.y:int:null:7 t2.x:int:null:8 t2.col4:int:null:9 t2.rowid:int:null:10
+ │    │    ├── scan
+ │    │    │    └── columns: t1.col1:int:null:1 t1.x:int:null:2 t1.col2:int:null:3 t1.y:int:null:4 t1.rowid:int:5
+ │    │    ├── scan
+ │    │    │    └── columns: t2.col3:int:null:6 t2.y:int:null:7 t2.x:int:null:8 t2.col4:int:null:9 t2.rowid:int:10
+ │    │    └── eq [type=bool]
+ │    │         ├── variable: t1.x [type=int]
+ │    │         └── variable: t2.x [type=int]
+ │    └── projections
+ │         ├── coalesce [type=NULL]
+ │         │    ├── variable: t1.x [type=int]
+ │         │    └── variable: t2.x [type=int]
+ │         ├── variable: t1.col1 [type=int]
+ │         ├── variable: t1.x [type=int]
+ │         ├── variable: t1.col2 [type=int]
+ │         ├── variable: t1.y [type=int]
+ │         ├── variable: t1.rowid [type=int]
+ │         ├── variable: t2.col3 [type=int]
+ │         ├── variable: t2.y [type=int]
+ │         ├── variable: t2.x [type=int]
+ │         ├── variable: t2.col4 [type=int]
+ │         └── variable: t2.rowid [type=int]
+ └── projections
+      ├── variable: x [type=int]
+      ├── variable: t1.col1 [type=int]
+      ├── variable: t1.col2 [type=int]
+      ├── variable: t1.y [type=int]
+      ├── variable: t2.col3 [type=int]
+      ├── variable: t2.y [type=int]
+      └── variable: t2.col4 [type=int]
+
+build
+SELECT * FROM t1 NATURAL FULL OUTER JOIN t2
+----
+project
+ ├── columns: x:int:null:11 y:int:null:12 t1.col1:int:null:1 t1.col2:int:null:3 t2.col3:int:null:6 t2.col4:int:null:9
+ ├── project
+ │    ├── columns: x:int:null:11 y:int:null:12 t1.col1:int:null:1 t1.x:int:null:2 t1.col2:int:null:3 t1.y:int:null:4 t1.rowid:int:null:5 t2.col3:int:null:6 t2.y:int:null:7 t2.x:int:null:8 t2.col4:int:null:9 t2.rowid:int:null:10
+ │    ├── full-join
+ │    │    ├── columns: t1.col1:int:null:1 t1.x:int:null:2 t1.col2:int:null:3 t1.y:int:null:4 t1.rowid:int:null:5 t2.col3:int:null:6 t2.y:int:null:7 t2.x:int:null:8 t2.col4:int:null:9 t2.rowid:int:null:10
+ │    │    ├── scan
+ │    │    │    └── columns: t1.col1:int:null:1 t1.x:int:null:2 t1.col2:int:null:3 t1.y:int:null:4 t1.rowid:int:5
+ │    │    ├── scan
+ │    │    │    └── columns: t2.col3:int:null:6 t2.y:int:null:7 t2.x:int:null:8 t2.col4:int:null:9 t2.rowid:int:10
+ │    │    └── and [type=bool]
+ │    │         ├── eq [type=bool]
+ │    │         │    ├── variable: t1.x [type=int]
+ │    │         │    └── variable: t2.x [type=int]
+ │    │         └── eq [type=bool]
+ │    │              ├── variable: t1.y [type=int]
+ │    │              └── variable: t2.y [type=int]
+ │    └── projections
+ │         ├── coalesce [type=NULL]
+ │         │    ├── variable: t1.x [type=int]
+ │         │    └── variable: t2.x [type=int]
+ │         ├── coalesce [type=NULL]
+ │         │    ├── variable: t1.y [type=int]
+ │         │    └── variable: t2.y [type=int]
+ │         ├── variable: t1.col1 [type=int]
+ │         ├── variable: t1.x [type=int]
+ │         ├── variable: t1.col2 [type=int]
+ │         ├── variable: t1.y [type=int]
+ │         ├── variable: t1.rowid [type=int]
+ │         ├── variable: t2.col3 [type=int]
+ │         ├── variable: t2.y [type=int]
+ │         ├── variable: t2.x [type=int]
+ │         ├── variable: t2.col4 [type=int]
+ │         └── variable: t2.rowid [type=int]
+ └── projections
+      ├── variable: x [type=int]
+      ├── variable: y [type=int]
+      ├── variable: t1.col1 [type=int]
+      ├── variable: t1.col2 [type=int]
+      ├── variable: t2.col3 [type=int]
+      └── variable: t2.col4 [type=int]
+
+build
+SELECT * FROM t1 FULL OUTER JOIN t2 ON t1.x=t2.x
+----
+project
+ ├── columns: t1.col1:int:null:1 t1.x:int:null:2 t1.col2:int:null:3 t1.y:int:null:4 t2.col3:int:null:6 t2.y:int:null:7 t2.x:int:null:8 t2.col4:int:null:9
+ ├── full-join
+ │    ├── columns: t1.col1:int:null:1 t1.x:int:null:2 t1.col2:int:null:3 t1.y:int:null:4 t1.rowid:int:null:5 t2.col3:int:null:6 t2.y:int:null:7 t2.x:int:null:8 t2.col4:int:null:9 t2.rowid:int:null:10
+ │    ├── scan
+ │    │    └── columns: t1.col1:int:null:1 t1.x:int:null:2 t1.col2:int:null:3 t1.y:int:null:4 t1.rowid:int:5
+ │    ├── scan
+ │    │    └── columns: t2.col3:int:null:6 t2.y:int:null:7 t2.x:int:null:8 t2.col4:int:null:9 t2.rowid:int:10
+ │    └── eq [type=bool]
+ │         ├── variable: t1.x [type=int]
+ │         └── variable: t2.x [type=int]
+ └── projections
+      ├── variable: t1.col1 [type=int]
+      ├── variable: t1.x [type=int]
+      ├── variable: t1.col2 [type=int]
+      ├── variable: t1.y [type=int]
+      ├── variable: t2.col3 [type=int]
+      ├── variable: t2.y [type=int]
+      ├── variable: t2.x [type=int]
+      └── variable: t2.col4 [type=int]
+
+build
+SELECT t2.x, t1.x, x FROM t1 JOIN t2 USING(x)
+----
+project
+ ├── columns: t2.x:int:null:8 t1.x:int:null:2 t1.x:int:null:2
+ ├── inner-join
+ │    ├── columns: t1.col1:int:null:1 t1.x:int:null:2 t1.col2:int:null:3 t1.y:int:null:4 t1.rowid:int:5 t2.col3:int:null:6 t2.y:int:null:7 t2.x:int:null:8 t2.col4:int:null:9 t2.rowid:int:10
+ │    ├── scan
+ │    │    └── columns: t1.col1:int:null:1 t1.x:int:null:2 t1.col2:int:null:3 t1.y:int:null:4 t1.rowid:int:5
+ │    ├── scan
+ │    │    └── columns: t2.col3:int:null:6 t2.y:int:null:7 t2.x:int:null:8 t2.col4:int:null:9 t2.rowid:int:10
+ │    └── eq [type=bool]
+ │         ├── variable: t1.x [type=int]
+ │         └── variable: t2.x [type=int]
+ └── projections
+      ├── variable: t2.x [type=int]
+      ├── variable: t1.x [type=int]
+      └── variable: t1.x [type=int]
+
+build
+SELECT t2.x, t1.x, x FROM t1 FULL OUTER JOIN t2 USING(x)
+----
+project
+ ├── columns: t2.x:int:null:8 t1.x:int:null:2 x:int:null:11
+ ├── project
+ │    ├── columns: x:int:null:11 t1.col1:int:null:1 t1.x:int:null:2 t1.col2:int:null:3 t1.y:int:null:4 t1.rowid:int:null:5 t2.col3:int:null:6 t2.y:int:null:7 t2.x:int:null:8 t2.col4:int:null:9 t2.rowid:int:null:10
+ │    ├── full-join
+ │    │    ├── columns: t1.col1:int:null:1 t1.x:int:null:2 t1.col2:int:null:3 t1.y:int:null:4 t1.rowid:int:null:5 t2.col3:int:null:6 t2.y:int:null:7 t2.x:int:null:8 t2.col4:int:null:9 t2.rowid:int:null:10
+ │    │    ├── scan
+ │    │    │    └── columns: t1.col1:int:null:1 t1.x:int:null:2 t1.col2:int:null:3 t1.y:int:null:4 t1.rowid:int:5
+ │    │    ├── scan
+ │    │    │    └── columns: t2.col3:int:null:6 t2.y:int:null:7 t2.x:int:null:8 t2.col4:int:null:9 t2.rowid:int:10
+ │    │    └── eq [type=bool]
+ │    │         ├── variable: t1.x [type=int]
+ │    │         └── variable: t2.x [type=int]
+ │    └── projections
+ │         ├── coalesce [type=NULL]
+ │         │    ├── variable: t1.x [type=int]
+ │         │    └── variable: t2.x [type=int]
+ │         ├── variable: t1.col1 [type=int]
+ │         ├── variable: t1.x [type=int]
+ │         ├── variable: t1.col2 [type=int]
+ │         ├── variable: t1.y [type=int]
+ │         ├── variable: t1.rowid [type=int]
+ │         ├── variable: t2.col3 [type=int]
+ │         ├── variable: t2.y [type=int]
+ │         ├── variable: t2.x [type=int]
+ │         ├── variable: t2.col4 [type=int]
+ │         └── variable: t2.rowid [type=int]
+ └── projections
+      ├── variable: t2.x [type=int]
+      ├── variable: t1.x [type=int]
+      └── variable: x [type=int]
+
+# Test for #19536.
+build
+SELECT x FROM t1 NATURAL JOIN (SELECT * FROM t2)
+----
+project
+ ├── columns: t1.x:int:null:2
+ ├── inner-join
+ │    ├── columns: t1.col1:int:null:1 t1.x:int:null:2 t1.col2:int:null:3 t1.y:int:null:4 t1.rowid:int:5 t2.col3:int:null:6 t2.y:int:null:7 t2.x:int:null:8 t2.col4:int:null:9
+ │    ├── scan
+ │    │    └── columns: t1.col1:int:null:1 t1.x:int:null:2 t1.col2:int:null:3 t1.y:int:null:4 t1.rowid:int:5
+ │    ├── project
+ │    │    ├── columns: t2.col3:int:null:6 t2.y:int:null:7 t2.x:int:null:8 t2.col4:int:null:9
+ │    │    ├── scan
+ │    │    │    └── columns: t2.col3:int:null:6 t2.y:int:null:7 t2.x:int:null:8 t2.col4:int:null:9 t2.rowid:int:10
+ │    │    └── projections
+ │    │         ├── variable: t2.col3 [type=int]
+ │    │         ├── variable: t2.y [type=int]
+ │    │         ├── variable: t2.x [type=int]
+ │    │         └── variable: t2.col4 [type=int]
+ │    └── and [type=bool]
+ │         ├── eq [type=bool]
+ │         │    ├── variable: t1.x [type=int]
+ │         │    └── variable: t2.x [type=int]
+ │         └── eq [type=bool]
+ │              ├── variable: t1.y [type=int]
+ │              └── variable: t2.y [type=int]
+ └── projections
+      └── variable: t1.x [type=int]
+
+# Tests for merge join ordering information.
+exec-ddl
+CREATE TABLE pkBA (a INT, b INT, c INT, d INT, PRIMARY KEY(b,a))
+----
+table pkba
+  a int NULL
+  b int NULL
+  c int NULL
+  d int NULL
+  rowid int NOT NULL (hidden)
+
+exec-ddl
+CREATE TABLE pkBC (a INT, b INT, c INT, d INT, PRIMARY KEY(b,c))
+----
+table pkbc
+  a int NULL
+  b int NULL
+  c int NULL
+  d int NULL
+  rowid int NOT NULL (hidden)
+
+exec-ddl
+CREATE TABLE pkBAC (a INT, b INT, c INT, d INT, PRIMARY KEY(b,a,c))
+----
+table pkbac
+  a int NULL
+  b int NULL
+  c int NULL
+  d int NULL
+  rowid int NOT NULL (hidden)
+
+exec-ddl
+CREATE TABLE pkBAD (a INT, b INT, c INT, d INT, PRIMARY KEY(b,a,d))
+----
+table pkbad
+  a int NULL
+  b int NULL
+  c int NULL
+  d int NULL
+  rowid int NOT NULL (hidden)
+
+build
+SELECT * FROM pkBA AS l JOIN pkBC AS r ON l.a = r.a AND l.b = r.b AND l.c = r.c
+----
+project
+ ├── columns: pkba.a:int:null:1 pkba.b:int:null:2 pkba.c:int:null:3 pkba.d:int:null:4 pkbc.a:int:null:6 pkbc.b:int:null:7 pkbc.c:int:null:8 pkbc.d:int:null:9
+ ├── inner-join
+ │    ├── columns: pkba.a:int:null:1 pkba.b:int:null:2 pkba.c:int:null:3 pkba.d:int:null:4 pkba.rowid:int:5 pkbc.a:int:null:6 pkbc.b:int:null:7 pkbc.c:int:null:8 pkbc.d:int:null:9 pkbc.rowid:int:10
+ │    ├── scan
+ │    │    └── columns: pkba.a:int:null:1 pkba.b:int:null:2 pkba.c:int:null:3 pkba.d:int:null:4 pkba.rowid:int:5
+ │    ├── scan
+ │    │    └── columns: pkbc.a:int:null:6 pkbc.b:int:null:7 pkbc.c:int:null:8 pkbc.d:int:null:9 pkbc.rowid:int:10
+ │    └── and [type=bool]
+ │         ├── and [type=bool]
+ │         │    ├── eq [type=bool]
+ │         │    │    ├── variable: pkba.a [type=int]
+ │         │    │    └── variable: pkbc.a [type=int]
+ │         │    └── eq [type=bool]
+ │         │         ├── variable: pkba.b [type=int]
+ │         │         └── variable: pkbc.b [type=int]
+ │         └── eq [type=bool]
+ │              ├── variable: pkba.c [type=int]
+ │              └── variable: pkbc.c [type=int]
+ └── projections
+      ├── variable: pkba.a [type=int]
+      ├── variable: pkba.b [type=int]
+      ├── variable: pkba.c [type=int]
+      ├── variable: pkba.d [type=int]
+      ├── variable: pkbc.a [type=int]
+      ├── variable: pkbc.b [type=int]
+      ├── variable: pkbc.c [type=int]
+      └── variable: pkbc.d [type=int]
+
+build
+SELECT * FROM pkBA NATURAL JOIN pkBAD
+----
+project
+ ├── columns: pkba.a:int:null:1 pkba.b:int:null:2 pkba.c:int:null:3 pkba.d:int:null:4
+ ├── inner-join
+ │    ├── columns: pkba.a:int:null:1 pkba.b:int:null:2 pkba.c:int:null:3 pkba.d:int:null:4 pkba.rowid:int:5 pkbad.a:int:null:6 pkbad.b:int:null:7 pkbad.c:int:null:8 pkbad.d:int:null:9 pkbad.rowid:int:10
+ │    ├── scan
+ │    │    └── columns: pkba.a:int:null:1 pkba.b:int:null:2 pkba.c:int:null:3 pkba.d:int:null:4 pkba.rowid:int:5
+ │    ├── scan
+ │    │    └── columns: pkbad.a:int:null:6 pkbad.b:int:null:7 pkbad.c:int:null:8 pkbad.d:int:null:9 pkbad.rowid:int:10
+ │    └── and [type=bool]
+ │         ├── eq [type=bool]
+ │         │    ├── variable: pkba.a [type=int]
+ │         │    └── variable: pkbad.a [type=int]
+ │         ├── eq [type=bool]
+ │         │    ├── variable: pkba.b [type=int]
+ │         │    └── variable: pkbad.b [type=int]
+ │         ├── eq [type=bool]
+ │         │    ├── variable: pkba.c [type=int]
+ │         │    └── variable: pkbad.c [type=int]
+ │         └── eq [type=bool]
+ │              ├── variable: pkba.d [type=int]
+ │              └── variable: pkbad.d [type=int]
+ └── projections
+      ├── variable: pkba.a [type=int]
+      ├── variable: pkba.b [type=int]
+      ├── variable: pkba.c [type=int]
+      └── variable: pkba.d [type=int]
+
+build
+SELECT * FROM pkBAC AS l JOIN pkBAC AS r USING(a, b, c)
+----
+project
+ ├── columns: pkbac.a:int:null:1 pkbac.b:int:null:2 pkbac.c:int:null:3 pkbac.d:int:null:4 pkbac.d:int:null:9
+ ├── inner-join
+ │    ├── columns: pkbac.a:int:null:1 pkbac.b:int:null:2 pkbac.c:int:null:3 pkbac.d:int:null:4 pkbac.rowid:int:5 pkbac.a:int:null:6 pkbac.b:int:null:7 pkbac.c:int:null:8 pkbac.d:int:null:9 pkbac.rowid:int:10
+ │    ├── scan
+ │    │    └── columns: pkbac.a:int:null:1 pkbac.b:int:null:2 pkbac.c:int:null:3 pkbac.d:int:null:4 pkbac.rowid:int:5
+ │    ├── scan
+ │    │    └── columns: pkbac.a:int:null:6 pkbac.b:int:null:7 pkbac.c:int:null:8 pkbac.d:int:null:9 pkbac.rowid:int:10
+ │    └── and [type=bool]
+ │         ├── eq [type=bool]
+ │         │    ├── variable: pkbac.a [type=int]
+ │         │    └── variable: pkbac.a [type=int]
+ │         ├── eq [type=bool]
+ │         │    ├── variable: pkbac.b [type=int]
+ │         │    └── variable: pkbac.b [type=int]
+ │         └── eq [type=bool]
+ │              ├── variable: pkbac.c [type=int]
+ │              └── variable: pkbac.c [type=int]
+ └── projections
+      ├── variable: pkbac.a [type=int]
+      ├── variable: pkbac.b [type=int]
+      ├── variable: pkbac.c [type=int]
+      ├── variable: pkbac.d [type=int]
+      └── variable: pkbac.d [type=int]
+
+build
+SELECT * FROM pkBAC AS l JOIN pkBAD AS r ON l.c = r.d AND l.a = r.a AND l.b = r.b
+----
+project
+ ├── columns: pkbac.a:int:null:1 pkbac.b:int:null:2 pkbac.c:int:null:3 pkbac.d:int:null:4 pkbad.a:int:null:6 pkbad.b:int:null:7 pkbad.c:int:null:8 pkbad.d:int:null:9
+ ├── inner-join
+ │    ├── columns: pkbac.a:int:null:1 pkbac.b:int:null:2 pkbac.c:int:null:3 pkbac.d:int:null:4 pkbac.rowid:int:5 pkbad.a:int:null:6 pkbad.b:int:null:7 pkbad.c:int:null:8 pkbad.d:int:null:9 pkbad.rowid:int:10
+ │    ├── scan
+ │    │    └── columns: pkbac.a:int:null:1 pkbac.b:int:null:2 pkbac.c:int:null:3 pkbac.d:int:null:4 pkbac.rowid:int:5
+ │    ├── scan
+ │    │    └── columns: pkbad.a:int:null:6 pkbad.b:int:null:7 pkbad.c:int:null:8 pkbad.d:int:null:9 pkbad.rowid:int:10
+ │    └── and [type=bool]
+ │         ├── and [type=bool]
+ │         │    ├── eq [type=bool]
+ │         │    │    ├── variable: pkbac.c [type=int]
+ │         │    │    └── variable: pkbad.d [type=int]
+ │         │    └── eq [type=bool]
+ │         │         ├── variable: pkbac.a [type=int]
+ │         │         └── variable: pkbad.a [type=int]
+ │         └── eq [type=bool]
+ │              ├── variable: pkbac.b [type=int]
+ │              └── variable: pkbad.b [type=int]
+ └── projections
+      ├── variable: pkbac.a [type=int]
+      ├── variable: pkbac.b [type=int]
+      ├── variable: pkbac.c [type=int]
+      ├── variable: pkbac.d [type=int]
+      ├── variable: pkbad.a [type=int]
+      ├── variable: pkbad.b [type=int]
+      ├── variable: pkbad.c [type=int]
+      └── variable: pkbad.d [type=int]
+
+# Tests with joins with merged columns of collated string type.
+exec-ddl
+CREATE TABLE str1 (a INT PRIMARY KEY, s STRING COLLATE en_u_ks_level1)
+----
+table str1
+  a int NOT NULL
+  s collatedstring{en_u_ks_level1} NULL
+
+exec-ddl
+CREATE TABLE str2 (a INT PRIMARY KEY, s STRING COLLATE en_u_ks_level1)
+----
+table str2
+  a int NOT NULL
+  s collatedstring{en_u_ks_level1} NULL
+
+build
+SELECT s, str1.s, str2.s FROM str1 INNER JOIN str2 USING(s)
+----
+project
+ ├── columns: str1.s:collatedstring{en_u_ks_level1}:null:2 str1.s:collatedstring{en_u_ks_level1}:null:2 str2.s:collatedstring{en_u_ks_level1}:null:4
+ ├── inner-join
+ │    ├── columns: str1.a:int:1 str1.s:collatedstring{en_u_ks_level1}:null:2 str2.a:int:3 str2.s:collatedstring{en_u_ks_level1}:null:4
+ │    ├── scan
+ │    │    └── columns: str1.a:int:1 str1.s:collatedstring{en_u_ks_level1}:null:2
+ │    ├── scan
+ │    │    └── columns: str2.a:int:3 str2.s:collatedstring{en_u_ks_level1}:null:4
+ │    └── eq [type=bool]
+ │         ├── variable: str1.s [type=collatedstring{en_u_ks_level1}]
+ │         └── variable: str2.s [type=collatedstring{en_u_ks_level1}]
+ └── projections
+      ├── variable: str1.s [type=collatedstring{en_u_ks_level1}]
+      ├── variable: str1.s [type=collatedstring{en_u_ks_level1}]
+      └── variable: str2.s [type=collatedstring{en_u_ks_level1}]
+
+build
+SELECT s, str1.s, str2.s FROM str1 LEFT OUTER JOIN str2 USING(s)
+----
+project
+ ├── columns: str1.s:collatedstring{en_u_ks_level1}:null:2 str1.s:collatedstring{en_u_ks_level1}:null:2 str2.s:collatedstring{en_u_ks_level1}:null:4
+ ├── left-join
+ │    ├── columns: str1.a:int:1 str1.s:collatedstring{en_u_ks_level1}:null:2 str2.a:int:null:3 str2.s:collatedstring{en_u_ks_level1}:null:4
+ │    ├── scan
+ │    │    └── columns: str1.a:int:1 str1.s:collatedstring{en_u_ks_level1}:null:2
+ │    ├── scan
+ │    │    └── columns: str2.a:int:3 str2.s:collatedstring{en_u_ks_level1}:null:4
+ │    └── eq [type=bool]
+ │         ├── variable: str1.s [type=collatedstring{en_u_ks_level1}]
+ │         └── variable: str2.s [type=collatedstring{en_u_ks_level1}]
+ └── projections
+      ├── variable: str1.s [type=collatedstring{en_u_ks_level1}]
+      ├── variable: str1.s [type=collatedstring{en_u_ks_level1}]
+      └── variable: str2.s [type=collatedstring{en_u_ks_level1}]
+
+build
+SELECT s, str1.s, str2.s FROM str1 RIGHT OUTER JOIN str2 USING(s)
+----
+project
+ ├── columns: s:collatedstring{en_u_ks_level1}:null:5 str1.s:collatedstring{en_u_ks_level1}:null:2 str2.s:collatedstring{en_u_ks_level1}:null:4
+ ├── project
+ │    ├── columns: s:collatedstring{en_u_ks_level1}:null:5 str1.a:int:null:1 str1.s:collatedstring{en_u_ks_level1}:null:2 str2.a:int:3 str2.s:collatedstring{en_u_ks_level1}:null:4
+ │    ├── right-join
+ │    │    ├── columns: str1.a:int:null:1 str1.s:collatedstring{en_u_ks_level1}:null:2 str2.a:int:3 str2.s:collatedstring{en_u_ks_level1}:null:4
+ │    │    ├── scan
+ │    │    │    └── columns: str1.a:int:1 str1.s:collatedstring{en_u_ks_level1}:null:2
+ │    │    ├── scan
+ │    │    │    └── columns: str2.a:int:3 str2.s:collatedstring{en_u_ks_level1}:null:4
+ │    │    └── eq [type=bool]
+ │    │         ├── variable: str1.s [type=collatedstring{en_u_ks_level1}]
+ │    │         └── variable: str2.s [type=collatedstring{en_u_ks_level1}]
+ │    └── projections
+ │         ├── coalesce [type=NULL]
+ │         │    ├── variable: str1.s [type=collatedstring{en_u_ks_level1}]
+ │         │    └── variable: str2.s [type=collatedstring{en_u_ks_level1}]
+ │         ├── variable: str1.a [type=int]
+ │         ├── variable: str1.s [type=collatedstring{en_u_ks_level1}]
+ │         ├── variable: str2.a [type=int]
+ │         └── variable: str2.s [type=collatedstring{en_u_ks_level1}]
+ └── projections
+      ├── variable: s [type=collatedstring{en_u_ks_level1}]
+      ├── variable: str1.s [type=collatedstring{en_u_ks_level1}]
+      └── variable: str2.s [type=collatedstring{en_u_ks_level1}]
+
+build
+SELECT s, str1.s, str2.s FROM str1 FULL OUTER JOIN str2 USING(s)
+----
+project
+ ├── columns: s:collatedstring{en_u_ks_level1}:null:5 str1.s:collatedstring{en_u_ks_level1}:null:2 str2.s:collatedstring{en_u_ks_level1}:null:4
+ ├── project
+ │    ├── columns: s:collatedstring{en_u_ks_level1}:null:5 str1.a:int:null:1 str1.s:collatedstring{en_u_ks_level1}:null:2 str2.a:int:null:3 str2.s:collatedstring{en_u_ks_level1}:null:4
+ │    ├── full-join
+ │    │    ├── columns: str1.a:int:null:1 str1.s:collatedstring{en_u_ks_level1}:null:2 str2.a:int:null:3 str2.s:collatedstring{en_u_ks_level1}:null:4
+ │    │    ├── scan
+ │    │    │    └── columns: str1.a:int:1 str1.s:collatedstring{en_u_ks_level1}:null:2
+ │    │    ├── scan
+ │    │    │    └── columns: str2.a:int:3 str2.s:collatedstring{en_u_ks_level1}:null:4
+ │    │    └── eq [type=bool]
+ │    │         ├── variable: str1.s [type=collatedstring{en_u_ks_level1}]
+ │    │         └── variable: str2.s [type=collatedstring{en_u_ks_level1}]
+ │    └── projections
+ │         ├── coalesce [type=NULL]
+ │         │    ├── variable: str1.s [type=collatedstring{en_u_ks_level1}]
+ │         │    └── variable: str2.s [type=collatedstring{en_u_ks_level1}]
+ │         ├── variable: str1.a [type=int]
+ │         ├── variable: str1.s [type=collatedstring{en_u_ks_level1}]
+ │         ├── variable: str2.a [type=int]
+ │         └── variable: str2.s [type=collatedstring{en_u_ks_level1}]
+ └── projections
+      ├── variable: s [type=collatedstring{en_u_ks_level1}]
+      ├── variable: str1.s [type=collatedstring{en_u_ks_level1}]
+      └── variable: str2.s [type=collatedstring{en_u_ks_level1}]
+
+# Verify that we resolve the merged column a to str2.a but use IFNULL for
+# column s which is a collated string.
+build
+SELECT * FROM str1 RIGHT OUTER JOIN str2 USING(a, s)
+----
+project
+ ├── columns: str2.a:int:3 s:collatedstring{en_u_ks_level1}:null:5
+ ├── project
+ │    ├── columns: str2.a:int:3 s:collatedstring{en_u_ks_level1}:null:5 str1.a:int:null:1 str1.s:collatedstring{en_u_ks_level1}:null:2 str2.s:collatedstring{en_u_ks_level1}:null:4
+ │    ├── right-join
+ │    │    ├── columns: str1.a:int:null:1 str1.s:collatedstring{en_u_ks_level1}:null:2 str2.a:int:3 str2.s:collatedstring{en_u_ks_level1}:null:4
+ │    │    ├── scan
+ │    │    │    └── columns: str1.a:int:1 str1.s:collatedstring{en_u_ks_level1}:null:2
+ │    │    ├── scan
+ │    │    │    └── columns: str2.a:int:3 str2.s:collatedstring{en_u_ks_level1}:null:4
+ │    │    └── and [type=bool]
+ │    │         ├── eq [type=bool]
+ │    │         │    ├── variable: str1.a [type=int]
+ │    │         │    └── variable: str2.a [type=int]
+ │    │         └── eq [type=bool]
+ │    │              ├── variable: str1.s [type=collatedstring{en_u_ks_level1}]
+ │    │              └── variable: str2.s [type=collatedstring{en_u_ks_level1}]
+ │    └── projections
+ │         ├── variable: str2.a [type=int]
+ │         ├── coalesce [type=NULL]
+ │         │    ├── variable: str1.s [type=collatedstring{en_u_ks_level1}]
+ │         │    └── variable: str2.s [type=collatedstring{en_u_ks_level1}]
+ │         ├── variable: str1.a [type=int]
+ │         ├── variable: str1.s [type=collatedstring{en_u_ks_level1}]
+ │         └── variable: str2.s [type=collatedstring{en_u_ks_level1}]
+ └── projections
+      ├── variable: str2.a [type=int]
+      └── variable: s [type=collatedstring{en_u_ks_level1}]
+
+
+exec-ddl
+CREATE TABLE xyu (x INT, y INT, u INT, PRIMARY KEY(x,y,u))
+----
+table xyu
+  x int NULL
+  y int NULL
+  u int NULL
+  rowid int NOT NULL (hidden)
+
+exec-ddl
+CREATE TABLE xyv (x INT, y INT, v INT, PRIMARY KEY(x,y,v))
+----
+table xyv
+  x int NULL
+  y int NULL
+  v int NULL
+  rowid int NOT NULL (hidden)
+
+build
+SELECT * FROM xyu INNER JOIN xyv USING(x, y) WHERE x > 2
+----
+project
+ ├── columns: xyu.x:int:null:1 xyu.y:int:null:2 xyu.u:int:null:3 xyv.v:int:null:7
+ ├── select
+ │    ├── columns: xyu.x:int:null:1 xyu.y:int:null:2 xyu.u:int:null:3 xyu.rowid:int:4 xyv.x:int:null:5 xyv.y:int:null:6 xyv.v:int:null:7 xyv.rowid:int:8
+ │    ├── inner-join
+ │    │    ├── columns: xyu.x:int:null:1 xyu.y:int:null:2 xyu.u:int:null:3 xyu.rowid:int:4 xyv.x:int:null:5 xyv.y:int:null:6 xyv.v:int:null:7 xyv.rowid:int:8
+ │    │    ├── scan
+ │    │    │    └── columns: xyu.x:int:null:1 xyu.y:int:null:2 xyu.u:int:null:3 xyu.rowid:int:4
+ │    │    ├── scan
+ │    │    │    └── columns: xyv.x:int:null:5 xyv.y:int:null:6 xyv.v:int:null:7 xyv.rowid:int:8
+ │    │    └── and [type=bool]
+ │    │         ├── eq [type=bool]
+ │    │         │    ├── variable: xyu.x [type=int]
+ │    │         │    └── variable: xyv.x [type=int]
+ │    │         └── eq [type=bool]
+ │    │              ├── variable: xyu.y [type=int]
+ │    │              └── variable: xyv.y [type=int]
+ │    └── gt [type=bool]
+ │         ├── variable: xyu.x [type=int]
+ │         └── const: 2 [type=int]
+ └── projections
+      ├── variable: xyu.x [type=int]
+      ├── variable: xyu.y [type=int]
+      ├── variable: xyu.u [type=int]
+      └── variable: xyv.v [type=int]
+
+build
+SELECT * FROM xyu LEFT OUTER JOIN xyv USING(x, y) WHERE x > 2
+----
+project
+ ├── columns: xyu.x:int:null:1 xyu.y:int:null:2 xyu.u:int:null:3 xyv.v:int:null:7
+ ├── select
+ │    ├── columns: xyu.x:int:null:1 xyu.y:int:null:2 xyu.u:int:null:3 xyu.rowid:int:4 xyv.x:int:null:5 xyv.y:int:null:6 xyv.v:int:null:7 xyv.rowid:int:null:8
+ │    ├── left-join
+ │    │    ├── columns: xyu.x:int:null:1 xyu.y:int:null:2 xyu.u:int:null:3 xyu.rowid:int:4 xyv.x:int:null:5 xyv.y:int:null:6 xyv.v:int:null:7 xyv.rowid:int:null:8
+ │    │    ├── scan
+ │    │    │    └── columns: xyu.x:int:null:1 xyu.y:int:null:2 xyu.u:int:null:3 xyu.rowid:int:4
+ │    │    ├── scan
+ │    │    │    └── columns: xyv.x:int:null:5 xyv.y:int:null:6 xyv.v:int:null:7 xyv.rowid:int:8
+ │    │    └── and [type=bool]
+ │    │         ├── eq [type=bool]
+ │    │         │    ├── variable: xyu.x [type=int]
+ │    │         │    └── variable: xyv.x [type=int]
+ │    │         └── eq [type=bool]
+ │    │              ├── variable: xyu.y [type=int]
+ │    │              └── variable: xyv.y [type=int]
+ │    └── gt [type=bool]
+ │         ├── variable: xyu.x [type=int]
+ │         └── const: 2 [type=int]
+ └── projections
+      ├── variable: xyu.x [type=int]
+      ├── variable: xyu.y [type=int]
+      ├── variable: xyu.u [type=int]
+      └── variable: xyv.v [type=int]
+
+build
+SELECT * FROM xyu RIGHT OUTER JOIN xyv USING(x, y) WHERE x > 2
+----
+project
+ ├── columns: xyv.x:int:null:5 xyv.y:int:null:6 xyu.u:int:null:3 xyv.v:int:null:7
+ ├── select
+ │    ├── columns: xyu.x:int:null:1 xyu.y:int:null:2 xyu.u:int:null:3 xyu.rowid:int:null:4 xyv.x:int:null:5 xyv.y:int:null:6 xyv.v:int:null:7 xyv.rowid:int:8
+ │    ├── right-join
+ │    │    ├── columns: xyu.x:int:null:1 xyu.y:int:null:2 xyu.u:int:null:3 xyu.rowid:int:null:4 xyv.x:int:null:5 xyv.y:int:null:6 xyv.v:int:null:7 xyv.rowid:int:8
+ │    │    ├── scan
+ │    │    │    └── columns: xyu.x:int:null:1 xyu.y:int:null:2 xyu.u:int:null:3 xyu.rowid:int:4
+ │    │    ├── scan
+ │    │    │    └── columns: xyv.x:int:null:5 xyv.y:int:null:6 xyv.v:int:null:7 xyv.rowid:int:8
+ │    │    └── and [type=bool]
+ │    │         ├── eq [type=bool]
+ │    │         │    ├── variable: xyu.x [type=int]
+ │    │         │    └── variable: xyv.x [type=int]
+ │    │         └── eq [type=bool]
+ │    │              ├── variable: xyu.y [type=int]
+ │    │              └── variable: xyv.y [type=int]
+ │    └── gt [type=bool]
+ │         ├── variable: xyv.x [type=int]
+ │         └── const: 2 [type=int]
+ └── projections
+      ├── variable: xyv.x [type=int]
+      ├── variable: xyv.y [type=int]
+      ├── variable: xyu.u [type=int]
+      └── variable: xyv.v [type=int]
+
+build
+SELECT * FROM xyu FULL OUTER JOIN xyv USING(x, y) WHERE x > 2
+----
+project
+ ├── columns: x:int:null:9 y:int:null:10 xyu.u:int:null:3 xyv.v:int:null:7
+ ├── select
+ │    ├── columns: xyu.x:int:null:1 xyu.y:int:null:2 xyu.u:int:null:3 xyu.rowid:int:null:4 xyv.x:int:null:5 xyv.y:int:null:6 xyv.v:int:null:7 xyv.rowid:int:null:8 x:int:null:9 y:int:null:10
+ │    ├── project
+ │    │    ├── columns: x:int:null:9 y:int:null:10 xyu.x:int:null:1 xyu.y:int:null:2 xyu.u:int:null:3 xyu.rowid:int:null:4 xyv.x:int:null:5 xyv.y:int:null:6 xyv.v:int:null:7 xyv.rowid:int:null:8
+ │    │    ├── full-join
+ │    │    │    ├── columns: xyu.x:int:null:1 xyu.y:int:null:2 xyu.u:int:null:3 xyu.rowid:int:null:4 xyv.x:int:null:5 xyv.y:int:null:6 xyv.v:int:null:7 xyv.rowid:int:null:8
+ │    │    │    ├── scan
+ │    │    │    │    └── columns: xyu.x:int:null:1 xyu.y:int:null:2 xyu.u:int:null:3 xyu.rowid:int:4
+ │    │    │    ├── scan
+ │    │    │    │    └── columns: xyv.x:int:null:5 xyv.y:int:null:6 xyv.v:int:null:7 xyv.rowid:int:8
+ │    │    │    └── and [type=bool]
+ │    │    │         ├── eq [type=bool]
+ │    │    │         │    ├── variable: xyu.x [type=int]
+ │    │    │         │    └── variable: xyv.x [type=int]
+ │    │    │         └── eq [type=bool]
+ │    │    │              ├── variable: xyu.y [type=int]
+ │    │    │              └── variable: xyv.y [type=int]
+ │    │    └── projections
+ │    │         ├── coalesce [type=NULL]
+ │    │         │    ├── variable: xyu.x [type=int]
+ │    │         │    └── variable: xyv.x [type=int]
+ │    │         ├── coalesce [type=NULL]
+ │    │         │    ├── variable: xyu.y [type=int]
+ │    │         │    └── variable: xyv.y [type=int]
+ │    │         ├── variable: xyu.x [type=int]
+ │    │         ├── variable: xyu.y [type=int]
+ │    │         ├── variable: xyu.u [type=int]
+ │    │         ├── variable: xyu.rowid [type=int]
+ │    │         ├── variable: xyv.x [type=int]
+ │    │         ├── variable: xyv.y [type=int]
+ │    │         ├── variable: xyv.v [type=int]
+ │    │         └── variable: xyv.rowid [type=int]
+ │    └── gt [type=bool]
+ │         ├── variable: x [type=int]
+ │         └── const: 2 [type=int]
+ └── projections
+      ├── variable: x [type=int]
+      ├── variable: y [type=int]
+      ├── variable: xyu.u [type=int]
+      └── variable: xyv.v [type=int]
+
+# Verify that we transfer constraints between the two sides.
+build
+SELECT * FROM xyu INNER JOIN xyv ON xyu.x = xyv.x AND xyu.y = xyv.y WHERE xyu.x = 1 AND xyu.y < 10
+----
+project
+ ├── columns: xyu.x:int:null:1 xyu.y:int:null:2 xyu.u:int:null:3 xyv.x:int:null:5 xyv.y:int:null:6 xyv.v:int:null:7
+ ├── select
+ │    ├── columns: xyu.x:int:null:1 xyu.y:int:null:2 xyu.u:int:null:3 xyu.rowid:int:4 xyv.x:int:null:5 xyv.y:int:null:6 xyv.v:int:null:7 xyv.rowid:int:8
+ │    ├── inner-join
+ │    │    ├── columns: xyu.x:int:null:1 xyu.y:int:null:2 xyu.u:int:null:3 xyu.rowid:int:4 xyv.x:int:null:5 xyv.y:int:null:6 xyv.v:int:null:7 xyv.rowid:int:8
+ │    │    ├── scan
+ │    │    │    └── columns: xyu.x:int:null:1 xyu.y:int:null:2 xyu.u:int:null:3 xyu.rowid:int:4
+ │    │    ├── scan
+ │    │    │    └── columns: xyv.x:int:null:5 xyv.y:int:null:6 xyv.v:int:null:7 xyv.rowid:int:8
+ │    │    └── and [type=bool]
+ │    │         ├── eq [type=bool]
+ │    │         │    ├── variable: xyu.x [type=int]
+ │    │         │    └── variable: xyv.x [type=int]
+ │    │         └── eq [type=bool]
+ │    │              ├── variable: xyu.y [type=int]
+ │    │              └── variable: xyv.y [type=int]
+ │    └── and [type=bool]
+ │         ├── eq [type=bool]
+ │         │    ├── variable: xyu.x [type=int]
+ │         │    └── const: 1 [type=int]
+ │         └── lt [type=bool]
+ │              ├── variable: xyu.y [type=int]
+ │              └── const: 10 [type=int]
+ └── projections
+      ├── variable: xyu.x [type=int]
+      ├── variable: xyu.y [type=int]
+      ├── variable: xyu.u [type=int]
+      ├── variable: xyv.x [type=int]
+      ├── variable: xyv.y [type=int]
+      └── variable: xyv.v [type=int]
+
+build
+SELECT * FROM xyu INNER JOIN xyv ON xyu.x = xyv.x AND xyu.y = xyv.y AND xyu.x = 1 AND xyu.y < 10
+----
+project
+ ├── columns: xyu.x:int:null:1 xyu.y:int:null:2 xyu.u:int:null:3 xyv.x:int:null:5 xyv.y:int:null:6 xyv.v:int:null:7
+ ├── inner-join
+ │    ├── columns: xyu.x:int:null:1 xyu.y:int:null:2 xyu.u:int:null:3 xyu.rowid:int:4 xyv.x:int:null:5 xyv.y:int:null:6 xyv.v:int:null:7 xyv.rowid:int:8
+ │    ├── scan
+ │    │    └── columns: xyu.x:int:null:1 xyu.y:int:null:2 xyu.u:int:null:3 xyu.rowid:int:4
+ │    ├── scan
+ │    │    └── columns: xyv.x:int:null:5 xyv.y:int:null:6 xyv.v:int:null:7 xyv.rowid:int:8
+ │    └── and [type=bool]
+ │         ├── and [type=bool]
+ │         │    ├── and [type=bool]
+ │         │    │    ├── eq [type=bool]
+ │         │    │    │    ├── variable: xyu.x [type=int]
+ │         │    │    │    └── variable: xyv.x [type=int]
+ │         │    │    └── eq [type=bool]
+ │         │    │         ├── variable: xyu.y [type=int]
+ │         │    │         └── variable: xyv.y [type=int]
+ │         │    └── eq [type=bool]
+ │         │         ├── variable: xyu.x [type=int]
+ │         │         └── const: 1 [type=int]
+ │         └── lt [type=bool]
+ │              ├── variable: xyu.y [type=int]
+ │              └── const: 10 [type=int]
+ └── projections
+      ├── variable: xyu.x [type=int]
+      ├── variable: xyu.y [type=int]
+      ├── variable: xyu.u [type=int]
+      ├── variable: xyv.x [type=int]
+      ├── variable: xyv.y [type=int]
+      └── variable: xyv.v [type=int]
+
+build
+SELECT * FROM xyu LEFT OUTER JOIN xyv ON xyu.x = xyv.x AND xyu.y = xyv.y AND xyu.x = 1 AND xyu.y < 10
+----
+project
+ ├── columns: xyu.x:int:null:1 xyu.y:int:null:2 xyu.u:int:null:3 xyv.x:int:null:5 xyv.y:int:null:6 xyv.v:int:null:7
+ ├── left-join
+ │    ├── columns: xyu.x:int:null:1 xyu.y:int:null:2 xyu.u:int:null:3 xyu.rowid:int:4 xyv.x:int:null:5 xyv.y:int:null:6 xyv.v:int:null:7 xyv.rowid:int:null:8
+ │    ├── scan
+ │    │    └── columns: xyu.x:int:null:1 xyu.y:int:null:2 xyu.u:int:null:3 xyu.rowid:int:4
+ │    ├── scan
+ │    │    └── columns: xyv.x:int:null:5 xyv.y:int:null:6 xyv.v:int:null:7 xyv.rowid:int:8
+ │    └── and [type=bool]
+ │         ├── and [type=bool]
+ │         │    ├── and [type=bool]
+ │         │    │    ├── eq [type=bool]
+ │         │    │    │    ├── variable: xyu.x [type=int]
+ │         │    │    │    └── variable: xyv.x [type=int]
+ │         │    │    └── eq [type=bool]
+ │         │    │         ├── variable: xyu.y [type=int]
+ │         │    │         └── variable: xyv.y [type=int]
+ │         │    └── eq [type=bool]
+ │         │         ├── variable: xyu.x [type=int]
+ │         │         └── const: 1 [type=int]
+ │         └── lt [type=bool]
+ │              ├── variable: xyu.y [type=int]
+ │              └── const: 10 [type=int]
+ └── projections
+      ├── variable: xyu.x [type=int]
+      ├── variable: xyu.y [type=int]
+      ├── variable: xyu.u [type=int]
+      ├── variable: xyv.x [type=int]
+      ├── variable: xyv.y [type=int]
+      └── variable: xyv.v [type=int]
+
+build
+SELECT * FROM xyu RIGHT OUTER JOIN xyv ON xyu.x = xyv.x AND xyu.y = xyv.y AND xyu.x = 1 AND xyu.y < 10
+----
+project
+ ├── columns: xyu.x:int:null:1 xyu.y:int:null:2 xyu.u:int:null:3 xyv.x:int:null:5 xyv.y:int:null:6 xyv.v:int:null:7
+ ├── right-join
+ │    ├── columns: xyu.x:int:null:1 xyu.y:int:null:2 xyu.u:int:null:3 xyu.rowid:int:null:4 xyv.x:int:null:5 xyv.y:int:null:6 xyv.v:int:null:7 xyv.rowid:int:8
+ │    ├── scan
+ │    │    └── columns: xyu.x:int:null:1 xyu.y:int:null:2 xyu.u:int:null:3 xyu.rowid:int:4
+ │    ├── scan
+ │    │    └── columns: xyv.x:int:null:5 xyv.y:int:null:6 xyv.v:int:null:7 xyv.rowid:int:8
+ │    └── and [type=bool]
+ │         ├── and [type=bool]
+ │         │    ├── and [type=bool]
+ │         │    │    ├── eq [type=bool]
+ │         │    │    │    ├── variable: xyu.x [type=int]
+ │         │    │    │    └── variable: xyv.x [type=int]
+ │         │    │    └── eq [type=bool]
+ │         │    │         ├── variable: xyu.y [type=int]
+ │         │    │         └── variable: xyv.y [type=int]
+ │         │    └── eq [type=bool]
+ │         │         ├── variable: xyu.x [type=int]
+ │         │         └── const: 1 [type=int]
+ │         └── lt [type=bool]
+ │              ├── variable: xyu.y [type=int]
+ │              └── const: 10 [type=int]
+ └── projections
+      ├── variable: xyu.x [type=int]
+      ├── variable: xyu.y [type=int]
+      ├── variable: xyu.u [type=int]
+      ├── variable: xyv.x [type=int]
+      ├── variable: xyv.y [type=int]
+      └── variable: xyv.v [type=int]
+
+
+# Test OUTER joins that are run in the distSQL merge joiner
+
+build
+SELECT * FROM (SELECT * FROM xyu) AS xyu LEFT OUTER JOIN (SELECT * FROM xyv) AS xyv USING(x, y) WHERE x > 2
+----
+project
+ ├── columns: xyu.x:int:null:1 xyu.y:int:null:2 xyu.u:int:null:3 xyv.v:int:null:7
+ ├── select
+ │    ├── columns: xyu.x:int:null:1 xyu.y:int:null:2 xyu.u:int:null:3 xyv.x:int:null:5 xyv.y:int:null:6 xyv.v:int:null:7
+ │    ├── left-join
+ │    │    ├── columns: xyu.x:int:null:1 xyu.y:int:null:2 xyu.u:int:null:3 xyv.x:int:null:5 xyv.y:int:null:6 xyv.v:int:null:7
+ │    │    ├── project
+ │    │    │    ├── columns: xyu.x:int:null:1 xyu.y:int:null:2 xyu.u:int:null:3
+ │    │    │    ├── scan
+ │    │    │    │    └── columns: xyu.x:int:null:1 xyu.y:int:null:2 xyu.u:int:null:3 xyu.rowid:int:4
+ │    │    │    └── projections
+ │    │    │         ├── variable: xyu.x [type=int]
+ │    │    │         ├── variable: xyu.y [type=int]
+ │    │    │         └── variable: xyu.u [type=int]
+ │    │    ├── project
+ │    │    │    ├── columns: xyv.x:int:null:5 xyv.y:int:null:6 xyv.v:int:null:7
+ │    │    │    ├── scan
+ │    │    │    │    └── columns: xyv.x:int:null:5 xyv.y:int:null:6 xyv.v:int:null:7 xyv.rowid:int:8
+ │    │    │    └── projections
+ │    │    │         ├── variable: xyv.x [type=int]
+ │    │    │         ├── variable: xyv.y [type=int]
+ │    │    │         └── variable: xyv.v [type=int]
+ │    │    └── and [type=bool]
+ │    │         ├── eq [type=bool]
+ │    │         │    ├── variable: xyu.x [type=int]
+ │    │         │    └── variable: xyv.x [type=int]
+ │    │         └── eq [type=bool]
+ │    │              ├── variable: xyu.y [type=int]
+ │    │              └── variable: xyv.y [type=int]
+ │    └── gt [type=bool]
+ │         ├── variable: xyu.x [type=int]
+ │         └── const: 2 [type=int]
+ └── projections
+      ├── variable: xyu.x [type=int]
+      ├── variable: xyu.y [type=int]
+      ├── variable: xyu.u [type=int]
+      └── variable: xyv.v [type=int]
+
+build
+SELECT * FROM (SELECT * FROM xyu) AS xyu RIGHT OUTER JOIN (SELECT * FROM xyv) AS xyv USING(x, y) WHERE x > 2
+----
+project
+ ├── columns: xyv.x:int:null:5 xyv.y:int:null:6 xyu.u:int:null:3 xyv.v:int:null:7
+ ├── select
+ │    ├── columns: xyu.x:int:null:1 xyu.y:int:null:2 xyu.u:int:null:3 xyv.x:int:null:5 xyv.y:int:null:6 xyv.v:int:null:7
+ │    ├── right-join
+ │    │    ├── columns: xyu.x:int:null:1 xyu.y:int:null:2 xyu.u:int:null:3 xyv.x:int:null:5 xyv.y:int:null:6 xyv.v:int:null:7
+ │    │    ├── project
+ │    │    │    ├── columns: xyu.x:int:null:1 xyu.y:int:null:2 xyu.u:int:null:3
+ │    │    │    ├── scan
+ │    │    │    │    └── columns: xyu.x:int:null:1 xyu.y:int:null:2 xyu.u:int:null:3 xyu.rowid:int:4
+ │    │    │    └── projections
+ │    │    │         ├── variable: xyu.x [type=int]
+ │    │    │         ├── variable: xyu.y [type=int]
+ │    │    │         └── variable: xyu.u [type=int]
+ │    │    ├── project
+ │    │    │    ├── columns: xyv.x:int:null:5 xyv.y:int:null:6 xyv.v:int:null:7
+ │    │    │    ├── scan
+ │    │    │    │    └── columns: xyv.x:int:null:5 xyv.y:int:null:6 xyv.v:int:null:7 xyv.rowid:int:8
+ │    │    │    └── projections
+ │    │    │         ├── variable: xyv.x [type=int]
+ │    │    │         ├── variable: xyv.y [type=int]
+ │    │    │         └── variable: xyv.v [type=int]
+ │    │    └── and [type=bool]
+ │    │         ├── eq [type=bool]
+ │    │         │    ├── variable: xyu.x [type=int]
+ │    │         │    └── variable: xyv.x [type=int]
+ │    │         └── eq [type=bool]
+ │    │              ├── variable: xyu.y [type=int]
+ │    │              └── variable: xyv.y [type=int]
+ │    └── gt [type=bool]
+ │         ├── variable: xyv.x [type=int]
+ │         └── const: 2 [type=int]
+ └── projections
+      ├── variable: xyv.x [type=int]
+      ├── variable: xyv.y [type=int]
+      ├── variable: xyu.u [type=int]
+      └── variable: xyv.v [type=int]
+
+build
+SELECT * FROM (SELECT * FROM xyu) AS xyu FULL OUTER JOIN (SELECT * FROM xyv) AS xyv USING(x, y) WHERE x > 2
+----
+project
+ ├── columns: x:int:null:9 y:int:null:10 xyu.u:int:null:3 xyv.v:int:null:7
+ ├── select
+ │    ├── columns: xyu.x:int:null:1 xyu.y:int:null:2 xyu.u:int:null:3 xyv.x:int:null:5 xyv.y:int:null:6 xyv.v:int:null:7 x:int:null:9 y:int:null:10
+ │    ├── project
+ │    │    ├── columns: x:int:null:9 y:int:null:10 xyu.x:int:null:1 xyu.y:int:null:2 xyu.u:int:null:3 xyv.x:int:null:5 xyv.y:int:null:6 xyv.v:int:null:7
+ │    │    ├── full-join
+ │    │    │    ├── columns: xyu.x:int:null:1 xyu.y:int:null:2 xyu.u:int:null:3 xyv.x:int:null:5 xyv.y:int:null:6 xyv.v:int:null:7
+ │    │    │    ├── project
+ │    │    │    │    ├── columns: xyu.x:int:null:1 xyu.y:int:null:2 xyu.u:int:null:3
+ │    │    │    │    ├── scan
+ │    │    │    │    │    └── columns: xyu.x:int:null:1 xyu.y:int:null:2 xyu.u:int:null:3 xyu.rowid:int:4
+ │    │    │    │    └── projections
+ │    │    │    │         ├── variable: xyu.x [type=int]
+ │    │    │    │         ├── variable: xyu.y [type=int]
+ │    │    │    │         └── variable: xyu.u [type=int]
+ │    │    │    ├── project
+ │    │    │    │    ├── columns: xyv.x:int:null:5 xyv.y:int:null:6 xyv.v:int:null:7
+ │    │    │    │    ├── scan
+ │    │    │    │    │    └── columns: xyv.x:int:null:5 xyv.y:int:null:6 xyv.v:int:null:7 xyv.rowid:int:8
+ │    │    │    │    └── projections
+ │    │    │    │         ├── variable: xyv.x [type=int]
+ │    │    │    │         ├── variable: xyv.y [type=int]
+ │    │    │    │         └── variable: xyv.v [type=int]
+ │    │    │    └── and [type=bool]
+ │    │    │         ├── eq [type=bool]
+ │    │    │         │    ├── variable: xyu.x [type=int]
+ │    │    │         │    └── variable: xyv.x [type=int]
+ │    │    │         └── eq [type=bool]
+ │    │    │              ├── variable: xyu.y [type=int]
+ │    │    │              └── variable: xyv.y [type=int]
+ │    │    └── projections
+ │    │         ├── coalesce [type=NULL]
+ │    │         │    ├── variable: xyu.x [type=int]
+ │    │         │    └── variable: xyv.x [type=int]
+ │    │         ├── coalesce [type=NULL]
+ │    │         │    ├── variable: xyu.y [type=int]
+ │    │         │    └── variable: xyv.y [type=int]
+ │    │         ├── variable: xyu.x [type=int]
+ │    │         ├── variable: xyu.y [type=int]
+ │    │         ├── variable: xyu.u [type=int]
+ │    │         ├── variable: xyv.x [type=int]
+ │    │         ├── variable: xyv.y [type=int]
+ │    │         └── variable: xyv.v [type=int]
+ │    └── gt [type=bool]
+ │         ├── variable: x [type=int]
+ │         └── const: 2 [type=int]
+ └── projections
+      ├── variable: x [type=int]
+      ├── variable: y [type=int]
+      ├── variable: xyu.u [type=int]
+      └── variable: xyv.v [type=int]
+
+build
+SELECT * FROM (SELECT * FROM xyu) AS xyu LEFT OUTER JOIN (SELECT * FROM xyv) AS xyv ON xyu.x = xyv.x AND xyu.y = xyv.y AND xyu.x = 1 AND xyu.y < 10
+----
+left-join
+ ├── columns: xyu.x:int:null:1 xyu.y:int:null:2 xyu.u:int:null:3 xyv.x:int:null:5 xyv.y:int:null:6 xyv.v:int:null:7
+ ├── project
+ │    ├── columns: xyu.x:int:null:1 xyu.y:int:null:2 xyu.u:int:null:3
+ │    ├── scan
+ │    │    └── columns: xyu.x:int:null:1 xyu.y:int:null:2 xyu.u:int:null:3 xyu.rowid:int:4
+ │    └── projections
+ │         ├── variable: xyu.x [type=int]
+ │         ├── variable: xyu.y [type=int]
+ │         └── variable: xyu.u [type=int]
+ ├── project
+ │    ├── columns: xyv.x:int:null:5 xyv.y:int:null:6 xyv.v:int:null:7
+ │    ├── scan
+ │    │    └── columns: xyv.x:int:null:5 xyv.y:int:null:6 xyv.v:int:null:7 xyv.rowid:int:8
+ │    └── projections
+ │         ├── variable: xyv.x [type=int]
+ │         ├── variable: xyv.y [type=int]
+ │         └── variable: xyv.v [type=int]
+ └── and [type=bool]
+      ├── and [type=bool]
+      │    ├── and [type=bool]
+      │    │    ├── eq [type=bool]
+      │    │    │    ├── variable: xyu.x [type=int]
+      │    │    │    └── variable: xyv.x [type=int]
+      │    │    └── eq [type=bool]
+      │    │         ├── variable: xyu.y [type=int]
+      │    │         └── variable: xyv.y [type=int]
+      │    └── eq [type=bool]
+      │         ├── variable: xyu.x [type=int]
+      │         └── const: 1 [type=int]
+      └── lt [type=bool]
+           ├── variable: xyu.y [type=int]
+           └── const: 10 [type=int]
+
+build
+SELECT * FROM xyu RIGHT OUTER JOIN (SELECT * FROM xyv) AS xyv ON xyu.x = xyv.x AND xyu.y = xyv.y AND xyu.x = 1 AND xyu.y < 10
+----
+project
+ ├── columns: xyu.x:int:null:1 xyu.y:int:null:2 xyu.u:int:null:3 xyv.x:int:null:5 xyv.y:int:null:6 xyv.v:int:null:7
+ ├── right-join
+ │    ├── columns: xyu.x:int:null:1 xyu.y:int:null:2 xyu.u:int:null:3 xyu.rowid:int:null:4 xyv.x:int:null:5 xyv.y:int:null:6 xyv.v:int:null:7
+ │    ├── scan
+ │    │    └── columns: xyu.x:int:null:1 xyu.y:int:null:2 xyu.u:int:null:3 xyu.rowid:int:4
+ │    ├── project
+ │    │    ├── columns: xyv.x:int:null:5 xyv.y:int:null:6 xyv.v:int:null:7
+ │    │    ├── scan
+ │    │    │    └── columns: xyv.x:int:null:5 xyv.y:int:null:6 xyv.v:int:null:7 xyv.rowid:int:8
+ │    │    └── projections
+ │    │         ├── variable: xyv.x [type=int]
+ │    │         ├── variable: xyv.y [type=int]
+ │    │         └── variable: xyv.v [type=int]
+ │    └── and [type=bool]
+ │         ├── and [type=bool]
+ │         │    ├── and [type=bool]
+ │         │    │    ├── eq [type=bool]
+ │         │    │    │    ├── variable: xyu.x [type=int]
+ │         │    │    │    └── variable: xyv.x [type=int]
+ │         │    │    └── eq [type=bool]
+ │         │    │         ├── variable: xyu.y [type=int]
+ │         │    │         └── variable: xyv.y [type=int]
+ │         │    └── eq [type=bool]
+ │         │         ├── variable: xyu.x [type=int]
+ │         │         └── const: 1 [type=int]
+ │         └── lt [type=bool]
+ │              ├── variable: xyu.y [type=int]
+ │              └── const: 10 [type=int]
+ └── projections
+      ├── variable: xyu.x [type=int]
+      ├── variable: xyu.y [type=int]
+      ├── variable: xyu.u [type=int]
+      ├── variable: xyv.x [type=int]
+      ├── variable: xyv.y [type=int]
+      └── variable: xyv.v [type=int]
+
+# Regression test for #20472: break up tuple inequalities.
+build
+SELECT * FROM xyu JOIN xyv USING(x, y) WHERE (x, y, u) > (1, 2, 3)
+----
+project
+ ├── columns: xyu.x:int:null:1 xyu.y:int:null:2 xyu.u:int:null:3 xyv.v:int:null:7
+ ├── select
+ │    ├── columns: xyu.x:int:null:1 xyu.y:int:null:2 xyu.u:int:null:3 xyu.rowid:int:4 xyv.x:int:null:5 xyv.y:int:null:6 xyv.v:int:null:7 xyv.rowid:int:8
+ │    ├── inner-join
+ │    │    ├── columns: xyu.x:int:null:1 xyu.y:int:null:2 xyu.u:int:null:3 xyu.rowid:int:4 xyv.x:int:null:5 xyv.y:int:null:6 xyv.v:int:null:7 xyv.rowid:int:8
+ │    │    ├── scan
+ │    │    │    └── columns: xyu.x:int:null:1 xyu.y:int:null:2 xyu.u:int:null:3 xyu.rowid:int:4
+ │    │    ├── scan
+ │    │    │    └── columns: xyv.x:int:null:5 xyv.y:int:null:6 xyv.v:int:null:7 xyv.rowid:int:8
+ │    │    └── and [type=bool]
+ │    │         ├── eq [type=bool]
+ │    │         │    ├── variable: xyu.x [type=int]
+ │    │         │    └── variable: xyv.x [type=int]
+ │    │         └── eq [type=bool]
+ │    │              ├── variable: xyu.y [type=int]
+ │    │              └── variable: xyv.y [type=int]
+ │    └── gt [type=bool]
+ │         ├── tuple [type=tuple{int, int, int}]
+ │         │    ├── variable: xyu.x [type=int]
+ │         │    ├── variable: xyu.y [type=int]
+ │         │    └── variable: xyu.u [type=int]
+ │         └── tuple [type=tuple{int, int, int}]
+ │              ├── const: 1 [type=int]
+ │              ├── const: 2 [type=int]
+ │              └── const: 3 [type=int]
+ └── projections
+      ├── variable: xyu.x [type=int]
+      ├── variable: xyu.y [type=int]
+      ├── variable: xyu.u [type=int]
+      └── variable: xyv.v [type=int]
+
+
+# Regression test for #20858.
+
+exec-ddl
+CREATE TABLE l (a INT PRIMARY KEY)
+----
+table l
+  a int NOT NULL
+
+exec-ddl
+CREATE TABLE r (a INT PRIMARY KEY)
+----
+table r
+  a int NOT NULL
+
+build
+SELECT * FROM l LEFT OUTER JOIN r ON l.a = r.a WHERE l.a = 3;
+----
+select
+ ├── columns: l.a:int:1 r.a:int:null:2
+ ├── left-join
+ │    ├── columns: l.a:int:1 r.a:int:null:2
+ │    ├── scan
+ │    │    └── columns: l.a:int:1
+ │    ├── scan
+ │    │    └── columns: r.a:int:2
+ │    └── eq [type=bool]
+ │         ├── variable: l.a [type=int]
+ │         └── variable: r.a [type=int]
+ └── eq [type=bool]
+      ├── variable: l.a [type=int]
+      └── const: 3 [type=int]
+
+build
+SELECT * FROM l RIGHT OUTER JOIN r ON l.a = r.a WHERE r.a = 3;
+----
+select
+ ├── columns: l.a:int:null:1 r.a:int:2
+ ├── right-join
+ │    ├── columns: l.a:int:null:1 r.a:int:2
+ │    ├── scan
+ │    │    └── columns: l.a:int:1
+ │    ├── scan
+ │    │    └── columns: r.a:int:2
+ │    └── eq [type=bool]
+ │         ├── variable: l.a [type=int]
+ │         └── variable: r.a [type=int]
+ └── eq [type=bool]
+      ├── variable: r.a [type=int]
+      └── const: 3 [type=int]
+
+build
+SELECT * FROM l LEFT OUTER JOIN r USING(a) WHERE a = 1
+----
+project
+ ├── columns: l.a:int:1
+ ├── select
+ │    ├── columns: l.a:int:1 r.a:int:null:2
+ │    ├── left-join
+ │    │    ├── columns: l.a:int:1 r.a:int:null:2
+ │    │    ├── scan
+ │    │    │    └── columns: l.a:int:1
+ │    │    ├── scan
+ │    │    │    └── columns: r.a:int:2
+ │    │    └── eq [type=bool]
+ │    │         ├── variable: l.a [type=int]
+ │    │         └── variable: r.a [type=int]
+ │    └── eq [type=bool]
+ │         ├── variable: l.a [type=int]
+ │         └── const: 1 [type=int]
+ └── projections
+      └── variable: l.a [type=int]
+
+build
+SELECT * FROM l RIGHT OUTER JOIN r USING(a) WHERE a = 3
+----
+project
+ ├── columns: r.a:int:2
+ ├── select
+ │    ├── columns: l.a:int:null:1 r.a:int:2
+ │    ├── right-join
+ │    │    ├── columns: l.a:int:null:1 r.a:int:2
+ │    │    ├── scan
+ │    │    │    └── columns: l.a:int:1
+ │    │    ├── scan
+ │    │    │    └── columns: r.a:int:2
+ │    │    └── eq [type=bool]
+ │    │         ├── variable: l.a [type=int]
+ │    │         └── variable: r.a [type=int]
+ │    └── eq [type=bool]
+ │         ├── variable: r.a [type=int]
+ │         └── const: 3 [type=int]
+ └── projections
+      └── variable: r.a [type=int]
+
+# Regression tests for #21243
+exec-ddl
+CREATE TABLE abcdef (
+  a INT NOT NULL,
+  b INT NOT NULL,
+  c INT NOT NULL,
+  d INT NOT NULL,
+  e INT NULL,
+  f INT NULL,
+  PRIMARY KEY (a ASC, b ASC, c DESC, d ASC)
+)
+----
+table abcdef
+  a int NOT NULL
+  b int NOT NULL
+  c int NOT NULL
+  d int NOT NULL
+  e int NULL
+  f int NULL
+  rowid int NOT NULL (hidden)
+
+exec-ddl
+CREATE TABLE abg (
+  a INT NOT NULL,
+  b INT NOT NULL,
+  g INT NULL,
+  PRIMARY KEY (a ASC, b ASC)
+);
+----
+table abg
+  a int NOT NULL
+  b int NOT NULL
+  g int NULL
+  rowid int NOT NULL (hidden)
+
+build
+SELECT * FROM abcdef join (select * from abg) USING (a,b) WHERE ((a,b)>(1,2) OR ((a,b)=(1,2) AND c < 6) OR ((a,b,c)=(1,2,6) AND d > 8))
+----
+project
+ ├── columns: abcdef.a:int:1 abcdef.b:int:2 abcdef.c:int:3 abcdef.d:int:4 abcdef.e:int:null:5 abcdef.f:int:null:6 abg.g:int:null:10
+ ├── select
+ │    ├── columns: abcdef.a:int:1 abcdef.b:int:2 abcdef.c:int:3 abcdef.d:int:4 abcdef.e:int:null:5 abcdef.f:int:null:6 abcdef.rowid:int:7 abg.a:int:8 abg.b:int:9 abg.g:int:null:10
+ │    ├── inner-join
+ │    │    ├── columns: abcdef.a:int:1 abcdef.b:int:2 abcdef.c:int:3 abcdef.d:int:4 abcdef.e:int:null:5 abcdef.f:int:null:6 abcdef.rowid:int:7 abg.a:int:8 abg.b:int:9 abg.g:int:null:10
+ │    │    ├── scan
+ │    │    │    └── columns: abcdef.a:int:1 abcdef.b:int:2 abcdef.c:int:3 abcdef.d:int:4 abcdef.e:int:null:5 abcdef.f:int:null:6 abcdef.rowid:int:7
+ │    │    ├── project
+ │    │    │    ├── columns: abg.a:int:8 abg.b:int:9 abg.g:int:null:10
+ │    │    │    ├── scan
+ │    │    │    │    └── columns: abg.a:int:8 abg.b:int:9 abg.g:int:null:10 abg.rowid:int:11
+ │    │    │    └── projections
+ │    │    │         ├── variable: abg.a [type=int]
+ │    │    │         ├── variable: abg.b [type=int]
+ │    │    │         └── variable: abg.g [type=int]
+ │    │    └── and [type=bool]
+ │    │         ├── eq [type=bool]
+ │    │         │    ├── variable: abcdef.a [type=int]
+ │    │         │    └── variable: abg.a [type=int]
+ │    │         └── eq [type=bool]
+ │    │              ├── variable: abcdef.b [type=int]
+ │    │              └── variable: abg.b [type=int]
+ │    └── or [type=bool]
+ │         ├── or [type=bool]
+ │         │    ├── gt [type=bool]
+ │         │    │    ├── tuple [type=tuple{int, int}]
+ │         │    │    │    ├── variable: abcdef.a [type=int]
+ │         │    │    │    └── variable: abcdef.b [type=int]
+ │         │    │    └── tuple [type=tuple{int, int}]
+ │         │    │         ├── const: 1 [type=int]
+ │         │    │         └── const: 2 [type=int]
+ │         │    └── and [type=bool]
+ │         │         ├── eq [type=bool]
+ │         │         │    ├── tuple [type=tuple{int, int}]
+ │         │         │    │    ├── variable: abcdef.a [type=int]
+ │         │         │    │    └── variable: abcdef.b [type=int]
+ │         │         │    └── tuple [type=tuple{int, int}]
+ │         │         │         ├── const: 1 [type=int]
+ │         │         │         └── const: 2 [type=int]
+ │         │         └── lt [type=bool]
+ │         │              ├── variable: abcdef.c [type=int]
+ │         │              └── const: 6 [type=int]
+ │         └── and [type=bool]
+ │              ├── eq [type=bool]
+ │              │    ├── tuple [type=tuple{int, int, int}]
+ │              │    │    ├── variable: abcdef.a [type=int]
+ │              │    │    ├── variable: abcdef.b [type=int]
+ │              │    │    └── variable: abcdef.c [type=int]
+ │              │    └── tuple [type=tuple{int, int, int}]
+ │              │         ├── const: 1 [type=int]
+ │              │         ├── const: 2 [type=int]
+ │              │         └── const: 6 [type=int]
+ │              └── gt [type=bool]
+ │                   ├── variable: abcdef.d [type=int]
+ │                   └── const: 8 [type=int]
+ └── projections
+      ├── variable: abcdef.a [type=int]
+      ├── variable: abcdef.b [type=int]
+      ├── variable: abcdef.c [type=int]
+      ├── variable: abcdef.d [type=int]
+      ├── variable: abcdef.e [type=int]
+      ├── variable: abcdef.f [type=int]
+      └── variable: abg.g [type=int]
+
+# Regression tests for mixed-type equality columns (#22514).
+exec-ddl
+CREATE TABLE foo (
+  a INT,
+  b INT,
+  c FLOAT,
+  d FLOAT
+)
+----
+table foo
+  a int NULL
+  b int NULL
+  c float NULL
+  d float NULL
+  rowid int NOT NULL (hidden)
+
+exec-ddl
+CREATE TABLE bar (
+  a INT,
+  b FLOAT,
+  c FLOAT,
+  d INT
+)
+----
+table bar
+  a int NULL
+  b float NULL
+  c float NULL
+  d int NULL
+  rowid int NOT NULL (hidden)
+
+# Only a and c can be equality columns.
+build
+SELECT * FROM foo NATURAL JOIN bar
+----
+project
+ ├── columns: foo.a:int:null:1 foo.b:int:null:2 foo.c:float:null:3 foo.d:float:null:4
+ ├── inner-join
+ │    ├── columns: foo.a:int:null:1 foo.b:int:null:2 foo.c:float:null:3 foo.d:float:null:4 foo.rowid:int:5 bar.a:int:null:6 bar.b:float:null:7 bar.c:float:null:8 bar.d:int:null:9 bar.rowid:int:10
+ │    ├── scan
+ │    │    └── columns: foo.a:int:null:1 foo.b:int:null:2 foo.c:float:null:3 foo.d:float:null:4 foo.rowid:int:5
+ │    ├── scan
+ │    │    └── columns: bar.a:int:null:6 bar.b:float:null:7 bar.c:float:null:8 bar.d:int:null:9 bar.rowid:int:10
+ │    └── and [type=bool]
+ │         ├── eq [type=bool]
+ │         │    ├── variable: foo.a [type=int]
+ │         │    └── variable: bar.a [type=int]
+ │         ├── eq [type=bool]
+ │         │    ├── variable: foo.b [type=int]
+ │         │    └── variable: bar.b [type=float]
+ │         ├── eq [type=bool]
+ │         │    ├── variable: foo.c [type=float]
+ │         │    └── variable: bar.c [type=float]
+ │         └── eq [type=bool]
+ │              ├── variable: foo.d [type=float]
+ │              └── variable: bar.d [type=int]
+ └── projections
+      ├── variable: foo.a [type=int]
+      ├── variable: foo.b [type=int]
+      ├── variable: foo.c [type=float]
+      └── variable: foo.d [type=float]
+
+# b can't be an equality column.
+build
+SELECT * FROM foo JOIN bar USING (b)
+----
+project
+ ├── columns: foo.b:int:null:2 foo.a:int:null:1 foo.c:float:null:3 foo.d:float:null:4 bar.a:int:null:6 bar.c:float:null:8 bar.d:int:null:9
+ ├── inner-join
+ │    ├── columns: foo.a:int:null:1 foo.b:int:null:2 foo.c:float:null:3 foo.d:float:null:4 foo.rowid:int:5 bar.a:int:null:6 bar.b:float:null:7 bar.c:float:null:8 bar.d:int:null:9 bar.rowid:int:10
+ │    ├── scan
+ │    │    └── columns: foo.a:int:null:1 foo.b:int:null:2 foo.c:float:null:3 foo.d:float:null:4 foo.rowid:int:5
+ │    ├── scan
+ │    │    └── columns: bar.a:int:null:6 bar.b:float:null:7 bar.c:float:null:8 bar.d:int:null:9 bar.rowid:int:10
+ │    └── eq [type=bool]
+ │         ├── variable: foo.b [type=int]
+ │         └── variable: bar.b [type=float]
+ └── projections
+      ├── variable: foo.b [type=int]
+      ├── variable: foo.a [type=int]
+      ├── variable: foo.c [type=float]
+      ├── variable: foo.d [type=float]
+      ├── variable: bar.a [type=int]
+      ├── variable: bar.c [type=float]
+      └── variable: bar.d [type=int]
+
+# Only a can be an equality column.
+build
+SELECT * FROM foo JOIN bar USING (a, b)
+----
+project
+ ├── columns: foo.a:int:null:1 foo.b:int:null:2 foo.c:float:null:3 foo.d:float:null:4 bar.c:float:null:8 bar.d:int:null:9
+ ├── inner-join
+ │    ├── columns: foo.a:int:null:1 foo.b:int:null:2 foo.c:float:null:3 foo.d:float:null:4 foo.rowid:int:5 bar.a:int:null:6 bar.b:float:null:7 bar.c:float:null:8 bar.d:int:null:9 bar.rowid:int:10
+ │    ├── scan
+ │    │    └── columns: foo.a:int:null:1 foo.b:int:null:2 foo.c:float:null:3 foo.d:float:null:4 foo.rowid:int:5
+ │    ├── scan
+ │    │    └── columns: bar.a:int:null:6 bar.b:float:null:7 bar.c:float:null:8 bar.d:int:null:9 bar.rowid:int:10
+ │    └── and [type=bool]
+ │         ├── eq [type=bool]
+ │         │    ├── variable: foo.a [type=int]
+ │         │    └── variable: bar.a [type=int]
+ │         └── eq [type=bool]
+ │              ├── variable: foo.b [type=int]
+ │              └── variable: bar.b [type=float]
+ └── projections
+      ├── variable: foo.a [type=int]
+      ├── variable: foo.b [type=int]
+      ├── variable: foo.c [type=float]
+      ├── variable: foo.d [type=float]
+      ├── variable: bar.c [type=float]
+      └── variable: bar.d [type=int]
+
+# Only a and c can be equality columns.
+build
+SELECT * FROM foo JOIN bar USING (a, b, c)
+----
+project
+ ├── columns: foo.a:int:null:1 foo.b:int:null:2 foo.c:float:null:3 foo.d:float:null:4 bar.d:int:null:9
+ ├── inner-join
+ │    ├── columns: foo.a:int:null:1 foo.b:int:null:2 foo.c:float:null:3 foo.d:float:null:4 foo.rowid:int:5 bar.a:int:null:6 bar.b:float:null:7 bar.c:float:null:8 bar.d:int:null:9 bar.rowid:int:10
+ │    ├── scan
+ │    │    └── columns: foo.a:int:null:1 foo.b:int:null:2 foo.c:float:null:3 foo.d:float:null:4 foo.rowid:int:5
+ │    ├── scan
+ │    │    └── columns: bar.a:int:null:6 bar.b:float:null:7 bar.c:float:null:8 bar.d:int:null:9 bar.rowid:int:10
+ │    └── and [type=bool]
+ │         ├── eq [type=bool]
+ │         │    ├── variable: foo.a [type=int]
+ │         │    └── variable: bar.a [type=int]
+ │         ├── eq [type=bool]
+ │         │    ├── variable: foo.b [type=int]
+ │         │    └── variable: bar.b [type=float]
+ │         └── eq [type=bool]
+ │              ├── variable: foo.c [type=float]
+ │              └── variable: bar.c [type=float]
+ └── projections
+      ├── variable: foo.a [type=int]
+      ├── variable: foo.b [type=int]
+      ├── variable: foo.c [type=float]
+      ├── variable: foo.d [type=float]
+      └── variable: bar.d [type=int]
+
+# b can't be an equality column.
+build
+SELECT * FROM foo JOIN bar ON foo.b = bar.b
+----
+project
+ ├── columns: foo.a:int:null:1 foo.b:int:null:2 foo.c:float:null:3 foo.d:float:null:4 bar.a:int:null:6 bar.b:float:null:7 bar.c:float:null:8 bar.d:int:null:9
+ ├── inner-join
+ │    ├── columns: foo.a:int:null:1 foo.b:int:null:2 foo.c:float:null:3 foo.d:float:null:4 foo.rowid:int:5 bar.a:int:null:6 bar.b:float:null:7 bar.c:float:null:8 bar.d:int:null:9 bar.rowid:int:10
+ │    ├── scan
+ │    │    └── columns: foo.a:int:null:1 foo.b:int:null:2 foo.c:float:null:3 foo.d:float:null:4 foo.rowid:int:5
+ │    ├── scan
+ │    │    └── columns: bar.a:int:null:6 bar.b:float:null:7 bar.c:float:null:8 bar.d:int:null:9 bar.rowid:int:10
+ │    └── eq [type=bool]
+ │         ├── variable: foo.b [type=int]
+ │         └── variable: bar.b [type=float]
+ └── projections
+      ├── variable: foo.a [type=int]
+      ├── variable: foo.b [type=int]
+      ├── variable: foo.c [type=float]
+      ├── variable: foo.d [type=float]
+      ├── variable: bar.a [type=int]
+      ├── variable: bar.b [type=float]
+      ├── variable: bar.c [type=float]
+      └── variable: bar.d [type=int]
+
+# Only a can be an equality column.
+build
+SELECT * FROM foo JOIN bar ON foo.a = bar.a AND foo.b = bar.b
+----
+project
+ ├── columns: foo.a:int:null:1 foo.b:int:null:2 foo.c:float:null:3 foo.d:float:null:4 bar.a:int:null:6 bar.b:float:null:7 bar.c:float:null:8 bar.d:int:null:9
+ ├── inner-join
+ │    ├── columns: foo.a:int:null:1 foo.b:int:null:2 foo.c:float:null:3 foo.d:float:null:4 foo.rowid:int:5 bar.a:int:null:6 bar.b:float:null:7 bar.c:float:null:8 bar.d:int:null:9 bar.rowid:int:10
+ │    ├── scan
+ │    │    └── columns: foo.a:int:null:1 foo.b:int:null:2 foo.c:float:null:3 foo.d:float:null:4 foo.rowid:int:5
+ │    ├── scan
+ │    │    └── columns: bar.a:int:null:6 bar.b:float:null:7 bar.c:float:null:8 bar.d:int:null:9 bar.rowid:int:10
+ │    └── and [type=bool]
+ │         ├── eq [type=bool]
+ │         │    ├── variable: foo.a [type=int]
+ │         │    └── variable: bar.a [type=int]
+ │         └── eq [type=bool]
+ │              ├── variable: foo.b [type=int]
+ │              └── variable: bar.b [type=float]
+ └── projections
+      ├── variable: foo.a [type=int]
+      ├── variable: foo.b [type=int]
+      ├── variable: foo.c [type=float]
+      ├── variable: foo.d [type=float]
+      ├── variable: bar.a [type=int]
+      ├── variable: bar.b [type=float]
+      ├── variable: bar.c [type=float]
+      └── variable: bar.d [type=int]
+
+build
+SELECT * FROM foo, bar WHERE foo.b = bar.b
+----
+project
+ ├── columns: foo.a:int:null:1 foo.b:int:null:2 foo.c:float:null:3 foo.d:float:null:4 bar.a:int:null:6 bar.b:float:null:7 bar.c:float:null:8 bar.d:int:null:9
+ ├── select
+ │    ├── columns: foo.a:int:null:1 foo.b:int:null:2 foo.c:float:null:3 foo.d:float:null:4 foo.rowid:int:5 bar.a:int:null:6 bar.b:float:null:7 bar.c:float:null:8 bar.d:int:null:9 bar.rowid:int:10
+ │    ├── inner-join
+ │    │    ├── columns: foo.a:int:null:1 foo.b:int:null:2 foo.c:float:null:3 foo.d:float:null:4 foo.rowid:int:5 bar.a:int:null:6 bar.b:float:null:7 bar.c:float:null:8 bar.d:int:null:9 bar.rowid:int:10
+ │    │    ├── scan
+ │    │    │    └── columns: foo.a:int:null:1 foo.b:int:null:2 foo.c:float:null:3 foo.d:float:null:4 foo.rowid:int:5
+ │    │    ├── scan
+ │    │    │    └── columns: bar.a:int:null:6 bar.b:float:null:7 bar.c:float:null:8 bar.d:int:null:9 bar.rowid:int:10
+ │    │    └── true [type=bool]
+ │    └── eq [type=bool]
+ │         ├── variable: foo.b [type=int]
+ │         └── variable: bar.b [type=float]
+ └── projections
+      ├── variable: foo.a [type=int]
+      ├── variable: foo.b [type=int]
+      ├── variable: foo.c [type=float]
+      ├── variable: foo.d [type=float]
+      ├── variable: bar.a [type=int]
+      ├── variable: bar.b [type=float]
+      ├── variable: bar.c [type=float]
+      └── variable: bar.d [type=int]
+
+# Only a can be an equality column.
+build
+SELECT * FROM foo, bar WHERE foo.a = bar.a AND foo.b = bar.b
+----
+project
+ ├── columns: foo.a:int:null:1 foo.b:int:null:2 foo.c:float:null:3 foo.d:float:null:4 bar.a:int:null:6 bar.b:float:null:7 bar.c:float:null:8 bar.d:int:null:9
+ ├── select
+ │    ├── columns: foo.a:int:null:1 foo.b:int:null:2 foo.c:float:null:3 foo.d:float:null:4 foo.rowid:int:5 bar.a:int:null:6 bar.b:float:null:7 bar.c:float:null:8 bar.d:int:null:9 bar.rowid:int:10
+ │    ├── inner-join
+ │    │    ├── columns: foo.a:int:null:1 foo.b:int:null:2 foo.c:float:null:3 foo.d:float:null:4 foo.rowid:int:5 bar.a:int:null:6 bar.b:float:null:7 bar.c:float:null:8 bar.d:int:null:9 bar.rowid:int:10
+ │    │    ├── scan
+ │    │    │    └── columns: foo.a:int:null:1 foo.b:int:null:2 foo.c:float:null:3 foo.d:float:null:4 foo.rowid:int:5
+ │    │    ├── scan
+ │    │    │    └── columns: bar.a:int:null:6 bar.b:float:null:7 bar.c:float:null:8 bar.d:int:null:9 bar.rowid:int:10
+ │    │    └── true [type=bool]
+ │    └── and [type=bool]
+ │         ├── eq [type=bool]
+ │         │    ├── variable: foo.a [type=int]
+ │         │    └── variable: bar.a [type=int]
+ │         └── eq [type=bool]
+ │              ├── variable: foo.b [type=int]
+ │              └── variable: bar.b [type=float]
+ └── projections
+      ├── variable: foo.a [type=int]
+      ├── variable: foo.b [type=int]
+      ├── variable: foo.c [type=float]
+      ├── variable: foo.d [type=float]
+      ├── variable: bar.a [type=int]
+      ├── variable: bar.b [type=float]
+      ├── variable: bar.c [type=float]
+      └── variable: bar.d [type=int]
+
+# Only a and c can be equality columns.
+build
+SELECT * FROM foo JOIN bar USING (a, b) WHERE foo.c = bar.c AND foo.d = bar.d
+----
+project
+ ├── columns: foo.a:int:null:1 foo.b:int:null:2 foo.c:float:null:3 foo.d:float:null:4 bar.c:float:null:8 bar.d:int:null:9
+ ├── select
+ │    ├── columns: foo.a:int:null:1 foo.b:int:null:2 foo.c:float:null:3 foo.d:float:null:4 foo.rowid:int:5 bar.a:int:null:6 bar.b:float:null:7 bar.c:float:null:8 bar.d:int:null:9 bar.rowid:int:10
+ │    ├── inner-join
+ │    │    ├── columns: foo.a:int:null:1 foo.b:int:null:2 foo.c:float:null:3 foo.d:float:null:4 foo.rowid:int:5 bar.a:int:null:6 bar.b:float:null:7 bar.c:float:null:8 bar.d:int:null:9 bar.rowid:int:10
+ │    │    ├── scan
+ │    │    │    └── columns: foo.a:int:null:1 foo.b:int:null:2 foo.c:float:null:3 foo.d:float:null:4 foo.rowid:int:5
+ │    │    ├── scan
+ │    │    │    └── columns: bar.a:int:null:6 bar.b:float:null:7 bar.c:float:null:8 bar.d:int:null:9 bar.rowid:int:10
+ │    │    └── and [type=bool]
+ │    │         ├── eq [type=bool]
+ │    │         │    ├── variable: foo.a [type=int]
+ │    │         │    └── variable: bar.a [type=int]
+ │    │         └── eq [type=bool]
+ │    │              ├── variable: foo.b [type=int]
+ │    │              └── variable: bar.b [type=float]
+ │    └── and [type=bool]
+ │         ├── eq [type=bool]
+ │         │    ├── variable: foo.c [type=float]
+ │         │    └── variable: bar.c [type=float]
+ │         └── eq [type=bool]
+ │              ├── variable: foo.d [type=float]
+ │              └── variable: bar.d [type=int]
+ └── projections
+      ├── variable: foo.a [type=int]
+      ├── variable: foo.b [type=int]
+      ├── variable: foo.c [type=float]
+      ├── variable: foo.d [type=float]
+      ├── variable: bar.c [type=float]
+      └── variable: bar.d [type=int]

--- a/pkg/sql/opt/optbuilder/testdata/join
+++ b/pkg/sql/opt/optbuilder/testdata/join
@@ -892,12 +892,12 @@ project
 build
 SELECT x, a.x, b.y FROM (SELECT * FROM onecolumn AS a NATURAL JOIN twocolumn AS b) AS q
 ----
-error: source name "a" not found in FROM clause
+error: no data source matches prefix: a
 
 build
 SELECT x, a.x, b.y FROM (SELECT * FROM onecolumn AS a NATURAL JOIN twocolumn AS b)
 ----
-error: source name "a" not found in FROM clause
+error: no data source matches prefix: a
 
 
 ## Simple test cases for inner, left, right, and outer joins

--- a/pkg/sql/opt/optbuilder/testdata/join
+++ b/pkg/sql/opt/optbuilder/testdata/join
@@ -284,7 +284,7 @@ project
  │    │         ├── variable: onecolumn.x [type=int]
  │    │         └── variable: othercolumn.x [type=int]
  │    └── projections
- │         ├── coalesce [type=NULL]
+ │         ├── coalesce [type=int]
  │         │    ├── variable: onecolumn.x [type=int]
  │         │    └── variable: othercolumn.x [type=int]
  │         ├── variable: onecolumn.x [type=int]
@@ -313,7 +313,7 @@ project
  │    │         ├── variable: onecolumn.x [type=int]
  │    │         └── variable: othercolumn.x [type=int]
  │    └── projections
- │         ├── coalesce [type=NULL]
+ │         ├── coalesce [type=int]
  │         │    ├── variable: onecolumn.x [type=int]
  │         │    └── variable: othercolumn.x [type=int]
  │         ├── variable: onecolumn.x [type=int]
@@ -342,7 +342,7 @@ project
  │    │         ├── variable: onecolumn.x [type=int]
  │    │         └── variable: othercolumn.x [type=int]
  │    └── projections
- │         ├── coalesce [type=NULL]
+ │         ├── coalesce [type=int]
  │         │    ├── variable: onecolumn.x [type=int]
  │         │    └── variable: othercolumn.x [type=int]
  │         ├── variable: onecolumn.x [type=int]
@@ -601,7 +601,7 @@ project
  │    │         ├── variable: empty.x [type=int]
  │    │         └── variable: onecolumn.x [type=int]
  │    └── projections
- │         ├── coalesce [type=NULL]
+ │         ├── coalesce [type=int]
  │         │    ├── variable: empty.x [type=int]
  │         │    └── variable: onecolumn.x [type=int]
  │         ├── variable: empty.x [type=int]
@@ -646,7 +646,7 @@ project
  │    │         ├── variable: onecolumn.x [type=int]
  │    │         └── variable: empty.x [type=int]
  │    └── projections
- │         ├── coalesce [type=NULL]
+ │         ├── coalesce [type=int]
  │         │    ├── variable: onecolumn.x [type=int]
  │         │    └── variable: empty.x [type=int]
  │         ├── variable: onecolumn.x [type=int]
@@ -1728,7 +1728,7 @@ project
  │    │         ├── variable: t1.x [type=int]
  │    │         └── variable: t2.x [type=int]
  │    └── projections
- │         ├── coalesce [type=NULL]
+ │         ├── coalesce [type=int]
  │         │    ├── variable: t1.x [type=int]
  │         │    └── variable: t2.x [type=int]
  │         ├── variable: t1.col1 [type=int]
@@ -1771,10 +1771,10 @@ project
  │    │              ├── variable: t1.y [type=int]
  │    │              └── variable: t2.y [type=int]
  │    └── projections
- │         ├── coalesce [type=NULL]
+ │         ├── coalesce [type=int]
  │         │    ├── variable: t1.x [type=int]
  │         │    └── variable: t2.x [type=int]
- │         ├── coalesce [type=NULL]
+ │         ├── coalesce [type=int]
  │         │    ├── variable: t1.y [type=int]
  │         │    └── variable: t2.y [type=int]
  │         ├── variable: t1.col1 [type=int]
@@ -1855,7 +1855,7 @@ project
  │    │         ├── variable: t1.x [type=int]
  │    │         └── variable: t2.x [type=int]
  │    └── projections
- │         ├── coalesce [type=NULL]
+ │         ├── coalesce [type=int]
  │         │    ├── variable: t1.x [type=int]
  │         │    └── variable: t2.x [type=int]
  │         ├── variable: t1.col1 [type=int]
@@ -2135,7 +2135,7 @@ project
  │    │         ├── variable: str1.s [type=collatedstring{en_u_ks_level1}]
  │    │         └── variable: str2.s [type=collatedstring{en_u_ks_level1}]
  │    └── projections
- │         ├── coalesce [type=NULL]
+ │         ├── coalesce [type=collatedstring{en_u_ks_level1}]
  │         │    ├── variable: str1.s [type=collatedstring{en_u_ks_level1}]
  │         │    └── variable: str2.s [type=collatedstring{en_u_ks_level1}]
  │         ├── variable: str1.a [type=int]
@@ -2164,7 +2164,7 @@ project
  │    │         ├── variable: str1.s [type=collatedstring{en_u_ks_level1}]
  │    │         └── variable: str2.s [type=collatedstring{en_u_ks_level1}]
  │    └── projections
- │         ├── coalesce [type=NULL]
+ │         ├── coalesce [type=collatedstring{en_u_ks_level1}]
  │         │    ├── variable: str1.s [type=collatedstring{en_u_ks_level1}]
  │         │    └── variable: str2.s [type=collatedstring{en_u_ks_level1}]
  │         ├── variable: str1.a [type=int]
@@ -2200,7 +2200,7 @@ project
  │    │              └── variable: str2.s [type=collatedstring{en_u_ks_level1}]
  │    └── projections
  │         ├── variable: str2.a [type=int]
- │         ├── coalesce [type=NULL]
+ │         ├── coalesce [type=collatedstring{en_u_ks_level1}]
  │         │    ├── variable: str1.s [type=collatedstring{en_u_ks_level1}]
  │         │    └── variable: str2.s [type=collatedstring{en_u_ks_level1}]
  │         ├── variable: str1.a [type=int]
@@ -2339,10 +2339,10 @@ project
  │    │    │              ├── variable: xyu.y [type=int]
  │    │    │              └── variable: xyv.y [type=int]
  │    │    └── projections
- │    │         ├── coalesce [type=NULL]
+ │    │         ├── coalesce [type=int]
  │    │         │    ├── variable: xyu.x [type=int]
  │    │         │    └── variable: xyv.x [type=int]
- │    │         ├── coalesce [type=NULL]
+ │    │         ├── coalesce [type=int]
  │    │         │    ├── variable: xyu.y [type=int]
  │    │         │    └── variable: xyv.y [type=int]
  │    │         ├── variable: xyu.x [type=int]
@@ -2620,10 +2620,10 @@ project
  │    │    │              ├── variable: xyu.y [type=int]
  │    │    │              └── variable: xyv.y [type=int]
  │    │    └── projections
- │    │         ├── coalesce [type=NULL]
+ │    │         ├── coalesce [type=int]
  │    │         │    ├── variable: xyu.x [type=int]
  │    │         │    └── variable: xyv.x [type=int]
- │    │         ├── coalesce [type=NULL]
+ │    │         ├── coalesce [type=int]
  │    │         │    ├── variable: xyu.y [type=int]
  │    │         │    └── variable: xyv.y [type=int]
  │    │         ├── variable: xyu.x [type=int]
@@ -3275,3 +3275,36 @@ project
  │    └── true [type=bool]
  └── projections
       └── variable: k [type=int]
+
+# TODO(rytaft): This test case will fail until we implement subquery
+# replacement.
+# build
+# select * from (select 1 as k), (select 2 as k) where 1 in (select k from kv)
+# ----
+# select
+#  ├── columns: k:int:null:1 k:int:null:2
+#  ├── inner-join
+#  │    ├── columns: k:int:null:1 k:int:null:2
+#  │    ├── project
+#  │    │    ├── columns: k:int:null:1
+#  │    │    ├── values
+#  │    │    │    └── tuple [type=tuple{}]
+#  │    │    └── projections
+#  │    │         └── const: 1 [type=int]
+#  │    ├── project
+#  │    │    ├── columns: k:int:null:2
+#  │    │    ├── values
+#  │    │    │    └── tuple [type=tuple{}]
+#  │    │    └── projections
+#  │    │         └── const: 2 [type=int]
+#  │    └── true [type=bool]
+#  └── in [type=bool]
+#       ├── const: 1 [type=int]
+#       └── subquery [type=NULL]
+#            ├── project
+#            │    ├── columns: kv.k:int:3
+#            │    ├── scan
+#            │    │    └── columns: kv.k:int:3 kv.v:int:null:4 kv.w:int:null:5 kv.s:string:null:6
+#            │    └── projections
+#            │         └── variable: kv.k [type=int]
+#            └── variable: kv.k [type=int]

--- a/pkg/sql/opt/optbuilder/testdata/join
+++ b/pkg/sql/opt/optbuilder/testdata/join
@@ -3242,3 +3242,36 @@ project
       ├── variable: foo.d [type=float]
       ├── variable: bar.c [type=float]
       └── variable: bar.d [type=int]
+
+exec-ddl
+CREATE TABLE t.kv (
+  k INT PRIMARY KEY,
+  v INT,
+  w INT,
+  s STRING
+)
+----
+table kv
+  k int NOT NULL
+  v int NULL
+  w int NULL
+  s string NULL
+
+build
+SELECT k FROM kv, (SELECT 1 AS k)
+----
+project
+ ├── columns: k:int:null:5
+ ├── inner-join
+ │    ├── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4 k:int:null:5
+ │    ├── scan
+ │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
+ │    ├── project
+ │    │    ├── columns: k:int:null:5
+ │    │    ├── values
+ │    │    │    └── tuple [type=tuple{}]
+ │    │    └── projections
+ │    │         └── const: 1 [type=int]
+ │    └── true [type=bool]
+ └── projections
+      └── variable: k [type=int]

--- a/pkg/sql/opt/optbuilder/testdata/project
+++ b/pkg/sql/opt/optbuilder/testdata/project
@@ -180,3 +180,16 @@ project
  │    └── columns: b.x:int:null:1 b.y:float:null:2 b.rowid:int:3
  └── projections
       └── variable: b.rowid [type=int]
+
+exec-ddl
+CREATE TABLE c (x INT, y FLOAT)
+----
+table c
+  x int NULL
+  y float NULL
+  rowid int NOT NULL (hidden)
+
+build
+SELECT rowid FROM b, c
+----
+error: column reference "rowid" is ambiguous (candidates: b.rowid, c.rowid)

--- a/pkg/sql/opt/optbuilder/testdata/project
+++ b/pkg/sql/opt/optbuilder/testdata/project
@@ -135,3 +135,48 @@ project
       └── plus [type=float]
            ├── variable: column4 [type=float]
            └── const: 1.0 [type=float]
+
+build
+SELECT rowid FROM b;
+----
+project
+ ├── columns: b.rowid:int:3
+ ├── scan
+ │    └── columns: b.x:int:null:1 b.y:float:null:2 b.rowid:int:3
+ └── projections
+      └── variable: b.rowid [type=int]
+
+build
+SELECT rowid FROM (SELECT * FROM b)
+----
+error: column name "rowid" not found
+
+build
+SELECT rowid FROM (SELECT rowid FROM b)
+----
+project
+ ├── columns: b.rowid:int:3
+ ├── scan
+ │    └── columns: b.x:int:null:1 b.y:float:null:2 b.rowid:int:3
+ └── projections
+      └── variable: b.rowid [type=int]
+
+build
+SELECT q.r FROM (SELECT rowid FROM b) AS q(r)
+----
+project
+ ├── columns: b.rowid:int:3
+ ├── scan
+ │    └── columns: b.x:int:null:1 b.y:float:null:2 b.rowid:int:3
+ └── projections
+      └── variable: b.rowid [type=int]
+
+build
+SELECT r FROM (SELECT rowid FROM b) AS q(r)
+----
+project
+ ├── columns: b.rowid:int:3
+ ├── scan
+ │    └── columns: b.x:int:null:1 b.y:float:null:2 b.rowid:int:3
+ └── projections
+      └── variable: b.rowid [type=int]

--- a/pkg/sql/opt/testutils/test_catalog.go
+++ b/pkg/sql/opt/testutils/test_catalog.go
@@ -136,7 +136,10 @@ func NewTestCatalog() *TestCatalog {
 
 // FindTable is part of the optbase.Catalog interface.
 func (c *TestCatalog) FindTable(ctx context.Context, name *tree.TableName) (optbase.Table, error) {
-	return c.tables[name.Table()], nil
+	if table, ok := c.tables[name.Table()]; ok {
+		return table, nil
+	}
+	return nil, fmt.Errorf("table %q not found", name.String())
 }
 
 // Table returns the test table that was previously added with the given name.

--- a/pkg/sql/opt/xform/expr.og.go
+++ b/pkg/sql/opt/xform/expr.og.go
@@ -301,6 +301,12 @@ var childCountLookup = [...]childCountLookupFunc{
 		return 0 + int(functionExpr.args().Length)
 	},
 
+	// CoalesceOp
+	func(ev ExprView) int {
+		coalesceExpr := (*coalesceExpr)(ev.mem.lookupExpr(ev.loc))
+		return 0 + int(coalesceExpr.args().Length)
+	},
+
 	// UnsupportedExprOp
 	func(ev ExprView) int {
 		return 0
@@ -1134,6 +1140,17 @@ var childGroupLookup = [...]childGroupLookupFunc{
 		}
 	},
 
+	// CoalesceOp
+	func(ev ExprView, n int) opt.GroupID {
+		coalesceExpr := (*coalesceExpr)(ev.mem.lookupExpr(ev.loc))
+
+		switch n {
+		default:
+			list := ev.mem.lookupList(coalesceExpr.args())
+			return list[n-0]
+		}
+	},
+
 	// UnsupportedExprOp
 	func(ev ExprView, n int) opt.GroupID {
 		panic("child index out of range")
@@ -1747,6 +1764,11 @@ var privateLookup = [...]privateLookupFunc{
 		return functionExpr.def()
 	},
 
+	// CoalesceOp
+	func(ev ExprView) opt.PrivateID {
+		return 0
+	},
+
 	// UnsupportedExprOp
 	func(ev ExprView) opt.PrivateID {
 		unsupportedExprExpr := (*unsupportedExprExpr)(ev.mem.lookupExpr(ev.loc))
@@ -1926,6 +1948,7 @@ var isScalarLookup = [...]bool{
 	true,  // UnaryMinusOp
 	true,  // UnaryComplementOp
 	true,  // FunctionOp
+	true,  // CoalesceOp
 	true,  // UnsupportedExprOp
 	false, // ScanOp
 	false, // ValuesOp
@@ -2010,6 +2033,7 @@ var isConstValueLookup = [...]bool{
 	false, // UnaryMinusOp
 	false, // UnaryComplementOp
 	false, // FunctionOp
+	false, // CoalesceOp
 	false, // UnsupportedExprOp
 	false, // ScanOp
 	false, // ValuesOp
@@ -2094,6 +2118,7 @@ var isBooleanLookup = [...]bool{
 	false, // UnaryMinusOp
 	false, // UnaryComplementOp
 	false, // FunctionOp
+	false, // CoalesceOp
 	false, // UnsupportedExprOp
 	false, // ScanOp
 	false, // ValuesOp
@@ -2178,6 +2203,7 @@ var isComparisonLookup = [...]bool{
 	false, // UnaryMinusOp
 	false, // UnaryComplementOp
 	false, // FunctionOp
+	false, // CoalesceOp
 	false, // UnsupportedExprOp
 	false, // ScanOp
 	false, // ValuesOp
@@ -2262,6 +2288,7 @@ var isBinaryLookup = [...]bool{
 	false, // UnaryMinusOp
 	false, // UnaryComplementOp
 	false, // FunctionOp
+	false, // CoalesceOp
 	false, // UnsupportedExprOp
 	false, // ScanOp
 	false, // ValuesOp
@@ -2346,6 +2373,7 @@ var isUnaryLookup = [...]bool{
 	true,  // UnaryMinusOp
 	true,  // UnaryComplementOp
 	false, // FunctionOp
+	false, // CoalesceOp
 	false, // UnsupportedExprOp
 	false, // ScanOp
 	false, // ValuesOp
@@ -2430,6 +2458,7 @@ var isRelationalLookup = [...]bool{
 	false, // UnaryMinusOp
 	false, // UnaryComplementOp
 	false, // FunctionOp
+	false, // CoalesceOp
 	false, // UnsupportedExprOp
 	true,  // ScanOp
 	true,  // ValuesOp
@@ -2514,6 +2543,7 @@ var isJoinLookup = [...]bool{
 	false, // UnaryMinusOp
 	false, // UnaryComplementOp
 	false, // FunctionOp
+	false, // CoalesceOp
 	false, // UnsupportedExprOp
 	false, // ScanOp
 	false, // ValuesOp
@@ -2598,6 +2628,7 @@ var isJoinApplyLookup = [...]bool{
 	false, // UnaryMinusOp
 	false, // UnaryComplementOp
 	false, // FunctionOp
+	false, // CoalesceOp
 	false, // UnsupportedExprOp
 	false, // ScanOp
 	false, // ValuesOp
@@ -2682,6 +2713,7 @@ var isEnforcerLookup = [...]bool{
 	false, // UnaryMinusOp
 	false, // UnaryComplementOp
 	false, // FunctionOp
+	false, // CoalesceOp
 	false, // UnsupportedExprOp
 	false, // ScanOp
 	false, // ValuesOp
@@ -4117,6 +4149,27 @@ func (m *memoExpr) asFunction() *functionExpr {
 		return nil
 	}
 	return (*functionExpr)(m)
+}
+
+type coalesceExpr memoExpr
+
+func makeCoalesceExpr(args opt.ListID) coalesceExpr {
+	return coalesceExpr{op: opt.CoalesceOp, state: exprState{args.Offset, args.Length}}
+}
+
+func (e *coalesceExpr) args() opt.ListID {
+	return opt.ListID{Offset: e.state[0], Length: e.state[1]}
+}
+
+func (e *coalesceExpr) fingerprint() fingerprint {
+	return fingerprint(*e)
+}
+
+func (m *memoExpr) asCoalesce() *coalesceExpr {
+	if m.op != opt.CoalesceOp {
+		return nil
+	}
+	return (*coalesceExpr)(m)
 }
 
 // unsupportedExprExpr is used for interfacing with the old planner code. It can


### PR DESCRIPTION
This commit is one of several needed to build a "memo"
structure from a parsed SQL query. The memo is the primary data
structure in the query optimizer, used for maintaining the forest of
query plan trees that the optimizer considers as part of its search
for the optimal plan.

This commit includes support for building a memo for queries
which include all types of joins (inner, left, right and outer) with
all types of join syntax (`CROSS JOIN`, `ON`, `NATURAL JOIN`, `USING`, etc.).
The test cases have been adapted from the join tests in logictests.

This code is based on code originally written as part of the
opttoy project.

Release note: None