### PR TITLE
storage: move io limiter to store

### DIFF
--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -927,7 +927,11 @@ func (r *Replica) setReplicaIDRaftMuLockedMuLocked(replicaID roachpb.ReplicaID) 
 	}
 	var err error
 	if r.raftMu.sideloaded, err = newDiskSideloadStorage(
-		r.store.cfg.Settings, r.mu.state.Desc.RangeID, replicaID, r.store.Engine().GetAuxiliaryDir(),
+		r.store.cfg.Settings,
+		r.mu.state.Desc.RangeID,
+		replicaID,
+		r.store.Engine().GetAuxiliaryDir(),
+		r.store.bulkIOWriteLimiter,
 	); err != nil {
 		return errors.Wrap(err, "while initializing sideloaded storage")
 	}
@@ -4676,6 +4680,7 @@ func (r *Replica) processRaftCommand(
 				term,
 				raftIndex,
 				*raftCmd.ReplicatedEvalResult.AddSSTable,
+				r.store.bulkIOWriteLimiter,
 			)
 			r.store.metrics.AddSSTableApplications.Inc(1)
 			if copied {

--- a/pkg/storage/replica_proposal.go
+++ b/pkg/storage/replica_proposal.go
@@ -25,6 +25,7 @@ import (
 	"github.com/coreos/etcd/raft"
 	"github.com/kr/pretty"
 	"github.com/pkg/errors"
+	"golang.org/x/time/rate"
 
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -319,6 +320,7 @@ func addSSTablePreApply(
 	sideloaded sideloadStorage,
 	term, index uint64,
 	sst storagebase.ReplicatedEvalResult_AddSSTable,
+	limiter *rate.Limiter,
 ) bool {
 	checksum := util.CRC32(sst.Data)
 
@@ -396,7 +398,7 @@ func addSSTablePreApply(
 			}
 		}
 
-		if err := writeFileSyncing(ctx, path, sst.Data, 0600, st); err != nil {
+		if err := writeFileSyncing(ctx, path, sst.Data, 0600, st, limiter); err != nil {
 			log.Fatalf(ctx, "while ingesting %s: %s", path, err)
 		}
 		copied = true

--- a/pkg/storage/replica_sideload_test.go
+++ b/pkg/storage/replica_sideload_test.go
@@ -44,6 +44,7 @@ import (
 	"github.com/coreos/etcd/raft/raftpb"
 	"github.com/kr/pretty"
 	"github.com/pkg/errors"
+	"golang.org/x/time/rate"
 )
 
 func entryEq(l, r raftpb.Entry) error {
@@ -87,7 +88,12 @@ func TestSideloadingSideloadedStorage(t *testing.T) {
 		testSideloadingSideloadedStorage(t, newInMemSideloadStorage)
 	})
 	t.Run("Disk", func(t *testing.T) {
-		testSideloadingSideloadedStorage(t, newDiskSideloadStorage)
+		maker := func(
+			s *cluster.Settings, rangeID roachpb.RangeID, rep roachpb.ReplicaID, name string,
+		) (sideloadStorage, error) {
+			return newDiskSideloadStorage(s, rangeID, rep, name, rate.NewLimiter(rate.Inf, math.MaxInt64))
+		}
+		testSideloadingSideloadedStorage(t, maker)
 	})
 }
 

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -120,6 +120,13 @@ var enablePreVote = envutil.EnvOrDefaultBool(
 var enableTickQuiesced = envutil.EnvOrDefaultBool(
 	"COCKROACH_ENABLE_TICK_QUIESCED", true)
 
+// bulkIOWriteLimit is defined here because it is used by BulkIOWriteLimiter.
+var bulkIOWriteLimit = settings.RegisterByteSizeSetting(
+	"kv.bulk_io_write.max_rate",
+	"the rate limit (bytes/sec) to use for writes to disk on behalf of bulk io ops",
+	math.MaxInt64,
+)
+
 // TestStoreConfig has some fields initialized with values relevant in tests.
 func TestStoreConfig(clock *hlc.Clock) StoreConfig {
 	if clock == nil {
@@ -365,6 +372,7 @@ type Store struct {
 	metrics            *StoreMetrics
 	intentResolver     *intentResolver
 	raftEntryCache     *raftEntryCache
+	bulkIOWriteLimiter *rate.Limiter
 
 	// gossipRangeCountdown and leaseRangeCountdown are countdowns of
 	// changes to range and leaseholder counts, after which the store
@@ -863,6 +871,11 @@ func NewStore(cfg StoreConfig, eng engine.Engine, nodeDesc *roachpb.NodeDescript
 	s.metrics.registry.AddMetricStruct(s.compactor.Metrics)
 
 	s.snapshotApplySem = make(chan struct{}, cfg.concurrentSnapshotApplyLimit)
+
+	s.bulkIOWriteLimiter = rate.NewLimiter(rate.Limit(bulkIOWriteLimit.Get(&cfg.Settings.SV)), bulkIOWriteBurst)
+	bulkIOWriteLimit.SetOnChange(&cfg.Settings.SV, func() {
+		s.bulkIOWriteLimiter.SetLimit(rate.Limit(bulkIOWriteLimit.Get(&cfg.Settings.SV)))
+	})
 
 	if s.cfg.Gossip != nil {
 		// Add range scanner and configure with queues.

--- a/pkg/testutils/lint/lint_test.go
+++ b/pkg/testutils/lint/lint_test.go
@@ -848,6 +848,7 @@ func TestLint(t *testing.T) {
 				case strings.HasSuffix(s, "humanizeutil"):
 				case strings.HasSuffix(s, "protoutil"):
 				case strings.HasSuffix(s, "testutils"):
+				case strings.HasSuffix(s, "syncutil"):
 				case strings.HasSuffix(s, settingsPkgPrefix):
 				default:
 					t.Errorf("%s <- please don't add CRDB dependencies to settings pkg", s)


### PR DESCRIPTION
Move the bulk io limiter from the global cluster settings object to individual stores.
This is both cleaner (not having some package-specific object in a shared, base package) and
has the runtime benefit of limiting stores separately, which matches the intention that they
are separate devices with, presumably, separate IO budgets.

Release note (enterprise change): Bulk IO rate limiting is done per-store rather than per-node.

cc @RaduBerinde for the first commit (the settings `SetOnChange` hook registration).