### PR TITLE
roachtest: misc changes

### DIFF
--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -46,6 +46,7 @@ var (
 	cockroach string
 	workload  string
 	clusterID string
+	username  = os.Getenv("ROACHPROD_USER")
 )
 
 func ifLocal(trueVal, falseVal string) string {
@@ -60,7 +61,8 @@ func findBinary(binary, defValue string) (string, error) {
 		binary = defValue
 	}
 
-	if _, err := os.Stat(binary); err == nil {
+	// Check to see if binary exists and is a regular file and executable.
+	if fi, err := os.Stat(binary); err == nil && fi.Mode().IsRegular() && (fi.Mode()&0111) != 0 {
 		return filepath.Abs(binary)
 	}
 
@@ -166,7 +168,6 @@ func makeClusterName(t testI) string {
 
 	// TODO(peter): Add an option to use an existing cluster.
 
-	username := os.Getenv("ROACHPROD_USER")
 	if username == "" {
 		usr, err := user.Current()
 		if err != nil {

--- a/pkg/cmd/roachtest/log.go
+++ b/pkg/cmd/roachtest/log.go
@@ -39,7 +39,12 @@ type logger struct {
 // test.
 func newLogger(name, filename string, stdout, stderr io.Writer) (*logger, error) {
 	filename = fmt.Sprintf("%s.log", fileutil.EscapeFilename(filename))
-	f, err := os.Create(filepath.Join(artifacts, filename))
+	path := filepath.Join(artifacts, filename)
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		return nil, err
+	}
+
+	f, err := os.Create(path)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cmd/roachtest/main.go
+++ b/pkg/cmd/roachtest/main.go
@@ -57,13 +57,15 @@ func main() {
 	runCmd.Flags().IntVarP(
 		&parallelism, "parallelism", "p", parallelism, "number of tests to run in parallel")
 	runCmd.Flags().StringVar(
-		&artifacts, "artifacts", "", "path to artifacts directory")
-	runCmd.Flags().StringVar(
-		&cockroach, "cockroach", "", "path to cockroach binary to use")
-	runCmd.Flags().StringVar(
-		&workload, "workload", "", "path to workload binary to use")
+		&artifacts, "artifacts", "artifacts", "path to artifacts directory")
 	runCmd.Flags().StringVar(
 		&clusterID, "cluster-id", "", "an identifier to use in the test cluster's name")
+	runCmd.Flags().StringVar(
+		&cockroach, "cockroach", "", "path to cockroach binary to use")
+	runCmd.Flags().StringVarP(
+		&username, "user", "u", username, "username to run under, detect if blank")
+	runCmd.Flags().StringVar(
+		&workload, "workload", "", "path to workload binary to use")
 
 	if err := rootCmd.Execute(); err != nil {
 		// Cobra has already printed the error message.


### PR DESCRIPTION
Add detection of whether a binary is a file and executable so as not to
select a directory (e.g. "workload").

Set the default `artifacts` directory to "artifacts" and create the
directory if it doesn't exist. This prevents spamming the current
directory with files if you forget to set this flag.

Add a `--user/-u` flag to specify the username to use for
`roachprod`. Defaults to the `ROACHPROD_USER` env variable. Useful if
your gcloud username differs from the username on your laptop (as mine does).

Release note: None