### PR TITLE
sql: fix NULL handling in index constraints for tuple IN tuple

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/select_index
+++ b/pkg/sql/logictest/testdata/logic_test/select_index
@@ -1012,3 +1012,41 @@ render           0  render      ·         ·              (x, y)               
       │          2  ·           spans     /!NULL-/4 /5-  ·                                        ·
       └── scan   2  scan        ·         ·              (x, y, rowid[hidden,omitted])            ·
 ·                2  ·           table     xy@primary     ·                                        ·
+
+# Regression tests for #22670.
+statement ok
+CREATE INDEX xy_idx ON xy (x, y)
+
+statement ok
+INSERT INTO xy VALUES (NULL, NULL), (1, NULL), (NULL, 1), (1, 1)
+
+query TITTTTT
+EXPLAIN (VERBOSE) SELECT * FROM xy WHERE x IN (NULL, 1, 2)
+----
+render     0  render  ·         ·            (x, y)                         x!=NULL
+ │         0  ·       render 0  test.xy.x    ·                              ·
+ │         0  ·       render 1  test.xy.y    ·                              ·
+ └── scan  1  scan    ·         ·            (x, y, rowid[hidden,omitted])  x!=NULL; rowid!=NULL; weak-key(x,y,rowid)
+·          1  ·       table     xy@xy_idx    ·                              ·
+·          1  ·       spans     /1-/2 /2-/3  ·                              ·
+
+query II
+SELECT * FROM xy WHERE x IN (NULL, 1, 2)
+----
+1  NULL
+1  1
+
+query TITTTTT
+EXPLAIN (VERBOSE) SELECT * FROM xy WHERE (x, y) IN ((NULL, NULL), (1, NULL), (NULL, 1), (1, 1), (1, 2))
+----
+render     0  render  ·         ·                    (x, y)                         x=CONST; y!=NULL
+ │         0  ·       render 0  test.xy.x            ·                              ·
+ │         0  ·       render 1  test.xy.y            ·                              ·
+ └── scan  1  scan    ·         ·                    (x, y, rowid[hidden,omitted])  x=CONST; y!=NULL; rowid!=NULL; key(y,rowid)
+·          1  ·       table     xy@xy_idx            ·                              ·
+·          1  ·       spans     /1/1-/1/2 /1/2-/1/3  ·                              ·
+
+query II
+SELECT * FROM xy WHERE (x, y) IN ((NULL, NULL), (1, NULL), (NULL, 1), (1, 1), (1, 2))
+----
+1  1

--- a/pkg/sql/opt/testdata/index-constraints
+++ b/pkg/sql/opt/testdata/index-constraints
@@ -352,6 +352,13 @@ semtree-normalize,build-scalar,index-constraints vars=(int) index=(@1 desc)
 [/4 - /4]
 [/1 - /1]
 
+build-scalar,normalize,index-constraints vars=(int) index=(@1)
+@1 IN (1, 2, 3, NULL)
+----
+[/1 - /1]
+[/2 - /2]
+[/3 - /3]
+
 build-scalar,normalize,index-constraints vars=(int, int) index=(@1, @2)
 @1 = 1 AND @2 IN (1, 2, 3)
 ----
@@ -779,6 +786,27 @@ build-scalar,normalize,index-constraints vars=(int, int, int) index=(@1, @2, @3)
 [/7/8 - /7/8]
 [/9/10 - /9/10]
 Remaining filter: (@1 + 5, @1, @1 + @2, @2) IN ((1, 5, 1, 6), (2, 7, 2, 8), (3, 9, 3, 10))
+
+# Test that we properly handle NULLs inside IN tuples.
+build-scalar,normalize,index-constraints vars=(int, int) index=(@1, @2)
+(@1, @2) IN ((1, 2), (3, NULL))
+----
+[/1/2 - /1/2]
+
+build-scalar,normalize,index-constraints vars=(int, int) index=(@1, @2)
+(@1, @2) IN ((3, NULL))
+----
+
+build-scalar,normalize,index-constraints vars=(int, int) index=(@1, @2)
+(@1, @2) IN ((1, 2), (NULL, 4))
+----
+[/1/2 - /1/2]
+
+build-scalar,normalize,index-constraints vars=(int, int, int) index=(@1, @2, @3)
+(@1, @2, @3) IN ((1, 2, 3), (4, 5, 6), (NULL, 8, 9))
+----
+[/1/2/3 - /1/2/3]
+[/4/5/6 - /4/5/6]
 
 # Verify that we sort and de-duplicate if we "project" the tuples;
 # in this case the expression becomes:


### PR DESCRIPTION
This is the second (much easier) part of #22670.

#### sql: fix NULL handling in index constraints for tuple IN tuple

We were incorrectly generating spans that contain NULL values. Since
NULL is not equal to NULL, these tuples can be discarded.

Fixes #22670.

Release note (bug fix): Fixed incorrect query results when the WHERE
condition contains IN expressions where the right-hand side tuple
contains NULLs.
