### PR TITLE
distsql: Check for cancellation while waiting for inbound streams

### DIFF
--- a/pkg/sql/distsqlrun/inbound.go
+++ b/pkg/sql/distsqlrun/inbound.go
@@ -41,14 +41,11 @@ func ProcessInboundStream(
 	// as the last record that the producer gets.
 	if err != nil {
 		log.VEventf(ctx, 1, "inbound stream error: %s", err)
-		dst.Push(nil, &ProducerMetadata{Err: err})
-		dst.ProducerDone()
 		return err
 	}
 	log.VEventf(ctx, 1, "inbound stream done")
-	dst.ProducerDone()
-	// The consumer is now done. The producer, if it's still around, will
-	// receive an EOF error over its side of the stream.
+	// We are now done. The producer, if it's still around, will receive an EOF
+	// error over its side of the stream.
 	return nil
 }
 
@@ -59,90 +56,74 @@ func processInboundStreamHelper(
 	dst RowReceiver,
 	f *Flow,
 ) error {
-	var finalErr error
 	draining := false
 	var sd StreamDecoder
-	for {
-		var msg *ProducerMessage
-		if firstMsg != nil {
-			msg = firstMsg
-			firstMsg = nil
-		} else {
-			// Check for context cancellation before recv()ing the next message.
-			select {
-			case <-f.Ctx.Done():
-				// This will error out the FlowStream(), and also cancel
-				// the flow context on the producer.
-				return sqlbase.NewQueryCanceledError()
-			default:
-			}
-			var err error
-			msg, err = stream.Recv()
+
+	sendErrToConsumer := func(err error) {
+		if err != nil {
+			dst.Push(nil, &ProducerMetadata{Err: err})
+		}
+		dst.ProducerDone()
+	}
+
+	if firstMsg != nil {
+		if res := processProducerMessage(
+			ctx, stream, dst, &sd, &draining, firstMsg,
+		); res.err != nil || res.consumerClosed {
+			sendErrToConsumer(res.err)
+			return res.err
+		}
+	}
+
+	// There's two goroutines involved in handling the RPC - the current one (the
+	// "parent"), which is watching for context cancellation, and a "reader" one
+	// that receives messages from the stream. This is all because a stream.Recv()
+	// call doesn't react to context cancellation. The idea is that, if the parent
+	// detects a canceled context, it will return from this RPC handler, which
+	// will cause the stream to be closed. Because the parent cannot wait for the
+	// reader to finish (that being the whole point of the different goroutines),
+	// the reader sending an error to the parent might race with the parent
+	// finishing. In that case, nobody cares about the reader anymore and so its
+	// result channel is buffered.
+	errChan := make(chan error, 1)
+
+	f.waitGroup.Add(1)
+	go func() {
+		defer f.waitGroup.Done()
+		for {
+			msg, err := stream.Recv()
 			if err != nil {
 				if err != io.EOF {
 					// Communication error.
-					return errors.Wrap(
+					err = errors.Wrap(
 						err, log.MakeMessage(ctx, "communication error", nil /* args */))
+					sendErrToConsumer(err)
+					errChan <- err
+					return
 				}
 				// End of the stream.
-				return finalErr
-			}
-		}
-
-		err := sd.AddMessage(msg)
-		if err != nil {
-			return errors.Wrap(err, log.MakeMessage(ctx, "decoding error", nil /* args */))
-		}
-		var types []sqlbase.ColumnType
-		for {
-			row, meta, err := sd.GetRow(nil /* rowBuf */)
-			if err != nil {
-				return err
-			}
-			if row == nil && meta == nil {
-				// No more rows in the last message.
-				break
+				sendErrToConsumer(nil)
+				errChan <- nil
+				return
 			}
 
-			if log.V(3) {
-				if types == nil {
-					types = sd.Types()
-				}
-				log.Infof(ctx, "inbound stream pushing row %s", row.String(types))
-			}
-			if draining && meta == nil {
-				// Don't forward data rows when we're draining.
-				continue
-			}
-			switch dst.Push(row, meta) {
-			case NeedMoreRows:
-				continue
-			case DrainRequested:
-				// The rest of rows are not needed by the consumer. We'll send a drain
-				// signal to the producer and expect it to quickly send trailing
-				// metadata and close its side of the stream, at which point we also
-				// close the consuming side of the stream and call dst.ProducerDone().
-				if !draining {
-					draining = true
-					if err := sendDrainSignalToStreamProducer(ctx, stream); err != nil {
-						// We remember to forward this error to the consumer, but we
-						// continue forwarding the rows we've already buffered.
-						// NOTE(andrei): I'm not sure what to do with this error. If we
-						// failed to send the drain signal to the producer, we're probably
-						// (guaranteed?) also going to fail the next stream.Recv() call with
-						// something other than io.EOF, in which case that error will override
-						// finalErr. Assuming io.EOF were to be returned by the following
-						// stream.Recv(), we also don't care about this error; the draining
-						// would be completed successfully regardless of the failure to send
-						// this signal. This suggests that maybe we want to swallow this
-						// error...
-						finalErr = err
-					}
-				}
-			case ConsumerClosed:
-				return finalErr
+			if res := processProducerMessage(
+				ctx, stream, dst, &sd, &draining, msg,
+			); res.err != nil || res.consumerClosed {
+				sendErrToConsumer(res.err)
+				errChan <- res.err
+				return
 			}
 		}
+	}()
+
+	// Check for context cancellation while reading from the stream on another
+	// goroutine.
+	select {
+	case <-f.Ctx.Done():
+		return sqlbase.NewQueryCanceledError()
+	case err := <-errChan:
+		return err
 	}
 }
 
@@ -153,4 +134,69 @@ func sendDrainSignalToStreamProducer(ctx context.Context, stream DistSQL_FlowStr
 	log.VEvent(ctx, 1, "sending drain signal to producer")
 	sig := ConsumerSignal{DrainRequest: &DrainRequest{}}
 	return stream.Send(&sig)
+}
+
+// processProducerMessage is a helper function to process data from the producer
+// and send it along to the consumer. It keeps track of whether or not it's
+// draining between calls. If err in the result is set (or if the consumer is
+// closed), the caller must return the error to the producer.
+func processProducerMessage(
+	ctx context.Context,
+	stream DistSQL_FlowStreamServer,
+	dst RowReceiver,
+	sd *StreamDecoder,
+	draining *bool,
+	msg *ProducerMessage,
+) processMessageResult {
+	err := sd.AddMessage(msg)
+	if err != nil {
+		return processMessageResult{
+			err:            errors.Wrap(err, log.MakeMessage(ctx, "decoding error", nil /* args */)),
+			consumerClosed: false,
+		}
+	}
+	var types []sqlbase.ColumnType
+	for {
+		row, meta, err := sd.GetRow(nil /* rowBuf */)
+		if err != nil {
+			return processMessageResult{err: err, consumerClosed: false}
+		}
+		if row == nil && meta == nil {
+			// No more rows in the last message.
+			return processMessageResult{err: nil, consumerClosed: false}
+		}
+
+		if log.V(3) {
+			if types == nil {
+				types = sd.Types()
+			}
+			log.Infof(ctx, "inbound stream pushing row %s", row.String(types))
+		}
+		if *draining && meta == nil {
+			// Don't forward data rows when we're draining.
+			continue
+		}
+		switch dst.Push(row, meta) {
+		case NeedMoreRows:
+			continue
+		case DrainRequested:
+			// The rest of rows are not needed by the consumer. We'll send a drain
+			// signal to the producer and expect it to quickly send trailing
+			// metadata and close its side of the stream, at which point we also
+			// close the consuming side of the stream and call dst.ProducerDone().
+			if *draining {
+				*draining = true
+				if err := sendDrainSignalToStreamProducer(ctx, stream); err != nil {
+					log.Errorf(ctx, "draining error: %s", err)
+				}
+			}
+		case ConsumerClosed:
+			return processMessageResult{err: nil, consumerClosed: true}
+		}
+	}
+}
+
+type processMessageResult struct {
+	err            error
+	consumerClosed bool
 }


### PR DESCRIPTION
Previously, the flow context was checked for cancellation just before
the server sent an RPC to producers. However, if the context was
canceled while blocked on the RPC, the cancellation wouldn't be picked
up until the next producer RPC was sent.

To avoid this problem, the RPC is now sent in its own goroutine, and the
server waits for either context cancellation or the RPC to return,
whichever comes first.

Release note (performance improvement): Actively push cancellations up
DistSQL flows, without waiting for the first row.