### PR TITLE
storage: limit bulk IO writes to 250MB/s by default

### DIFF
--- a/pkg/settings/cluster/settings.go
+++ b/pkg/settings/cluster/settings.go
@@ -16,7 +16,6 @@ package cluster
 
 import (
 	"context"
-	"math"
 	"sync/atomic"
 
 	"golang.org/x/time/rate"
@@ -92,7 +91,11 @@ var version = settings.RegisterStateMachineSetting(KeyVersionSetting,
 var BulkIOWriteLimit = settings.RegisterByteSizeSetting(
 	"kv.bulk_io_write.max_rate",
 	"the rate limit (bytes/sec) to use for writes to disk on behalf of bulk io ops",
-	math.MaxInt64,
+	// Recommended hardware is local SSDs, i.e. >300MB/s IO capacity. Limiting
+	// to some number less than that ensures we don't starve more critical
+	// traffic. See #22733 and cockroachdb/docs#2533.
+	//TODO(dt, mjibson): Tune this, as high as possible on recommended hardware.
+	250<<20,
 )
 
 // BulkIOWriteLimiterBurst is the burst for the BulkIOWriteLimiter cluster setting.


### PR DESCRIPTION
Pulling a number out of a hat pending further experimental tuning.
Picked based on observed IO performance on a GCP, AWS and local MBP SSDs all being >300MB/s,
meaning that defaulting to 250MB/s should be a conservative-ish default, at least until we
can experimentally verify/tune it further.

Release note (performance improvement): limit writes by bulk IO operations to 250MB/s by default.