### PR TITLE
ui: show current CPU and QPS values on clusterviz

### DIFF
--- a/pkg/ui/ccl/src/views/clusterviz/components/nodeOrLocality/sparklines.tsx
+++ b/pkg/ui/ccl/src/views/clusterviz/components/nodeOrLocality/sparklines.tsx
@@ -10,7 +10,7 @@ import React from "react";
 
 import { CpuSparkline } from "src/views/clusterviz/containers/map/cpuSparkline";
 import { QpsSparkline } from "src/views/clusterviz/containers/map/qpsSparkline";
-import { DARK_BLUE, MAIN_BLUE } from "src/views/shared/colors";
+import { DARK_BLUE } from "src/views/shared/colors";
 
 const SPARKLINE_OFFSET_PX = 36;
 
@@ -31,15 +31,6 @@ export class Sparklines extends React.Component<SparklinesProps> {
         >
           CPU
         </text>
-        <text
-          fill={MAIN_BLUE}
-          fontFamily="Lato-Bold, Lato"
-          fontSize="12"
-          fontWeight="700"
-          x="124"
-        >
-          XX%
-        </text>
         {this.renderCPUSparkline()}
       </g>
     );
@@ -55,15 +46,6 @@ export class Sparklines extends React.Component<SparklinesProps> {
           fontWeight="bold"
         >
           QPS
-        </text>
-        <text
-          fill={MAIN_BLUE}
-          fontFamily="Lato-Bold, Lato"
-          fontSize="12"
-          fontWeight="700"
-          x="118"
-        >
-          XXXX
         </text>
         {this.renderQPSSparkline()}
       </g>

--- a/pkg/ui/ccl/src/views/clusterviz/containers/map/cpuSparkline.tsx
+++ b/pkg/ui/ccl/src/views/clusterviz/containers/map/cpuSparkline.tsx
@@ -1,3 +1,4 @@
+import d3 from "d3";
 import React from "react";
 
 import { SparklineMetricsDataComponent } from "src/views/clusterviz/containers/map/sparkline";
@@ -13,7 +14,7 @@ export function CpuSparkline(props: CpuSparklineProps) {
 
   return (
     <MetricsDataProvider id={key}>
-      <SparklineMetricsDataComponent>
+      <SparklineMetricsDataComponent formatCurrentValue={d3.format(".1%")}>
         <Metric name="cr.node.sys.cpu.sys.percent" sources={props.nodes} nonNegativeRate />
         <Metric name="cr.node.sys.cpu.user.percent" sources={props.nodes} nonNegativeRate />
       </SparklineMetricsDataComponent>

--- a/pkg/ui/ccl/src/views/clusterviz/containers/map/qpsSparkline.tsx
+++ b/pkg/ui/ccl/src/views/clusterviz/containers/map/qpsSparkline.tsx
@@ -1,3 +1,4 @@
+import d3 from "d3";
 import React from "react";
 
 import { SparklineMetricsDataComponent } from "src/views/clusterviz/containers/map/sparkline";
@@ -13,7 +14,7 @@ export function QpsSparkline(props: QpsSparklineProps) {
 
   return (
     <MetricsDataProvider id={key}>
-      <SparklineMetricsDataComponent>
+      <SparklineMetricsDataComponent formatCurrentValue={d3.format(".1f")}>
         <Metric name="cr.node.sql.select.count" sources={props.nodes} nonNegativeRate />
         <Metric name="cr.node.sql.insert.count" sources={props.nodes} nonNegativeRate />
         <Metric name="cr.node.sql.update.count" sources={props.nodes} nonNegativeRate />

--- a/pkg/ui/ccl/src/views/clusterviz/containers/map/sparkline.tsx
+++ b/pkg/ui/ccl/src/views/clusterviz/containers/map/sparkline.tsx
@@ -10,7 +10,8 @@ interface SparklineConfig {
   width: number;
   height: number;
   backgroundColor: string;
-  lineColor: string;
+  foregroundColor: string;
+  formatCurrentValue: (value: number) => string;
 }
 
 interface Datapoint {
@@ -23,7 +24,7 @@ interface SparklineChartProps {
 }
 
 function sparklineChart(config: SparklineConfig) {
-  const { width, height, backgroundColor, lineColor } = config;
+  const { width, height, backgroundColor, foregroundColor, formatCurrentValue } = config;
   const margin = {
     left: 1,
     top: 1,
@@ -66,17 +67,39 @@ function sparklineChart(config: SparklineConfig) {
       .enter()
       .append("path")
       .attr("fill", "none")
-      .attr("stroke", lineColor);
+      .attr("stroke", foregroundColor);
 
     line
       .attr("d", drawPath);
+
+    const lastDatapoint = results && results.length ? results[results.length - 1].value : 0;
+
+    const text = sel.selectAll("text")
+      .data([lastDatapoint]);
+
+    text.enter()
+      .append("text")
+      .attr("x", width + 13)
+      .attr("y", height - margin.bottom)
+      .attr("text-anchor", "left")
+      .attr("fill", foregroundColor)
+      .attr("font-family", "Lato-Bold, Lato")
+      .attr("font-size", 12)
+      .attr("font-weight", 700);
+
+    text
+      .text(formatCurrentValue);
   };
 }
 
-export class SparklineMetricsDataComponent extends React.Component<MetricsDataComponentProps> {
+interface SparklineMetricsDataComponentProps {
+  formatCurrentValue: (value: number) => string;
+}
+
+export class SparklineMetricsDataComponent extends React.Component<MetricsDataComponentProps & SparklineMetricsDataComponentProps> {
   chart: React.ComponentClass<SparklineChartProps>;
 
-  constructor(props: MetricsDataComponentProps) {
+  constructor(props: MetricsDataComponentProps & SparklineMetricsDataComponentProps) {
     super(props);
 
     this.chart = createChartComponent(
@@ -86,6 +109,7 @@ export class SparklineMetricsDataComponent extends React.Component<MetricsDataCo
         height: 10,
         backgroundColor: BACKGROUND_BLUE,
         foregroundColor: MAIN_BLUE,
+        formatCurrentValue: this.props.formatCurrentValue,
       }),
     );
   }

--- a/pkg/ui/ccl/src/views/clusterviz/containers/map/sparkline.tsx
+++ b/pkg/ui/ccl/src/views/clusterviz/containers/map/sparkline.tsx
@@ -4,6 +4,7 @@ import React from "react";
 import { NanoToMilli } from "src/util/convert";
 import { MetricsDataComponentProps } from "src/views/shared/components/metricQuery";
 import createChartComponent from "src/views/shared/util/d3-react";
+import { BACKGROUND_BLUE, MAIN_BLUE } from "src/views/shared/colors";
 
 interface SparklineConfig {
   width: number;
@@ -80,12 +81,11 @@ export class SparklineMetricsDataComponent extends React.Component<MetricsDataCo
 
     this.chart = createChartComponent(
       "g",
-      // TODO(couchand): dedupe this with the constants in statsView
       sparklineChart({
         width: 69,
         height: 10,
-        backgroundColor: "#B8CCEC",
-        lineColor: "#3A7DE1",
+        backgroundColor: BACKGROUND_BLUE,
+        foregroundColor: MAIN_BLUE,
       }),
     );
   }


### PR DESCRIPTION
Replaces the XXX with actual latest values.

<img width="633" alt="screen shot 2018-02-15 at 12 23 47 pm" src="https://user-images.githubusercontent.com/793969/36270963-24233456-124b-11e8-8d71-3fff77f5ac6d.png">
