### PR TITLE
ui: remove settings change details from event log

### DIFF
--- a/pkg/server/admin.go
+++ b/pkg/server/admin.go
@@ -744,10 +744,10 @@ func (s *adminServer) Events(
 			return nil, err
 		}
 		if event.EventType == string(sql.EventLogSetClusterSetting) {
-			if s.getUser(req) != security.RootUser {
-				// TODO(dt): unpack and selectively redact the setting value.
-				event.Info = ""
-			}
+
+			// TODO: `if s.getUser(req) != security.RootUser` when we have auth.
+
+			event.Info = redactSettingsChange(event.Info)
 		}
 		if err := scanner.ScanIndex(row, 5, &event.UniqueID); err != nil {
 			return nil, err
@@ -756,6 +756,20 @@ func (s *adminServer) Events(
 		resp.Events = append(resp.Events, event)
 	}
 	return &resp, nil
+}
+
+// make a best-effort attempt at redacting the setting value.
+func redactSettingsChange(info string) string {
+	var s sql.EventLogSetClusterSettingDetail
+	if err := json.Unmarshal([]byte(info), &s); err != nil {
+		return ""
+	}
+	s.Value = "<hidden>"
+	ret, err := json.Marshal(s)
+	if err != nil {
+		return ""
+	}
+	return string(ret)
 }
 
 // RangeLog is an endpoint that returns the latest range log entries.

--- a/pkg/sql/event_log.go
+++ b/pkg/sql/event_log.go
@@ -88,6 +88,13 @@ const (
 	EventLogSetClusterSetting EventLogType = "set_cluster_setting"
 )
 
+// EventLogSetClusterSettingDetail is the json details for a settings change.
+type EventLogSetClusterSettingDetail struct {
+	SettingName string
+	Value       string
+	User        string
+}
+
 // An EventLogger exposes methods used to record events to the event table.
 type EventLogger struct {
 	InternalExecutor

--- a/pkg/sql/set_cluster_setting.go
+++ b/pkg/sql/set_cluster_setting.go
@@ -130,11 +130,7 @@ func (n *setClusterSettingNode) startExec(params runParams) error {
 		EventLogSetClusterSetting,
 		0, /* no target */
 		int32(params.extendedEvalCtx.NodeID),
-		struct {
-			SettingName string
-			Value       string
-			User        string
-		}{n.name, reportedValue, params.SessionData().User},
+		EventLogSetClusterSettingDetail{n.name, reportedValue, params.SessionData().User},
 	)
 }
 

--- a/pkg/ui/src/util/events.ts
+++ b/pkg/ui/src/util/events.ts
@@ -72,7 +72,10 @@ export function getEventDescription(e: Event$Properties): string {
     case eventTypes.NODE_RESTART:
       return `Node Rejoined: Node ${targetId} rejoined the cluster`;
     case eventTypes.SET_CLUSTER_SETTING:
-      return `Cluster Setting Changed: User ${info.User} set ${info.SettingName} to ${info.Value}`;
+      if (info.Value && info.Value.length > 0) {
+        return `Cluster Setting Changed: User ${info.User} set ${info.SettingName} to ${info.Value}`;
+      }
+      return `Cluster Setting Changed: User ${info.User} changed ${info.SettingName}`;
     default:
       return `Unknown Event Type: ${e.event_type}, content: ${JSON.stringify(info, null, 2)}`;
   }


### PR DESCRIPTION
We originally thought we'd radact these based on root-vs-not-root user, but we don't actually have auth yet, so we need to just unconditionally redact them for now.

Release note: none (never appeared in a released version).