### PR TITLE
ui: update routes for admin UI

### DIFF
--- a/pkg/ui/src/redux/analytics.ts
+++ b/pkg/ui/src/redux/analytics.ts
@@ -21,6 +21,11 @@ const defaultRedactions = [
         match: new RegExp("/databases/database/.*/table/.*"),
         replace: "/databases/database/[db]/table/[tbl]",
     },
+    // The new URL for a database page.
+    {
+        match: new RegExp("/database/.*/table/.*"),
+        replace: "/database/[db]/table/[tbl]",
+    },
 ];
 
 /**

--- a/pkg/ui/src/views/app/components/layoutSidebar/index.tsx
+++ b/pkg/ui/src/views/app/components/layoutSidebar/index.tsx
@@ -50,7 +50,7 @@ export default class extends React.Component<{}, {}> {
     return <nav className="navigation-bar">
       <ul className="navigation-bar__list">
         <IconLink to="/overview" icon={homeIcon} title="Overview" />
-        <IconLink to="/cluster" icon={metricsIcon} title="Cluster" />
+        <IconLink to="/metrics" icon={metricsIcon} title="Metrics" />
         <IconLink to="/databases" icon={databasesIcon} title="Databases"/>
         <IconLink to="/jobs" icon={jobsIcon} title="Jobs"/>
       </ul>

--- a/pkg/ui/src/views/cluster/containers/events/index.tsx
+++ b/pkg/ui/src/views/cluster/containers/events/index.tsx
@@ -95,7 +95,7 @@ export class EventBoxUnconnected extends React.Component<EventBoxProps, {}> {
             return <EventRow event={e} key={i} />;
           })}
           <tr>
-            <td className="events__more-link" colSpan={2}><Link to="/cluster/events">View all events</Link></td>
+            <td className="events__more-link" colSpan={2}><Link to="/events">View all events</Link></td>
           </tr>
         </tbody>
       </table>
@@ -135,7 +135,7 @@ export class EventPageUnconnected extends React.Component<EventPageProps, {}> {
         // page, when it should link back to the dashboard previously visible.
       }
       <section className="section parent-link">
-        <Link to="/cluster">&lt; Back to Cluster</Link>
+        <Link to="/">&lt; Back to Cluster</Link>
       </section>
       <section className="section section--heading">
         <h2>Events</h2>

--- a/pkg/ui/src/views/cluster/containers/nodeGraphs/index.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodeGraphs/index.tsx
@@ -119,9 +119,9 @@ class NodeGraphs extends React.Component<NodeGraphsProps, {}> {
 
   setClusterPath(nodeID: string, dashboardName: string) {
     if (!_.isString(nodeID) || nodeID === "") {
-      this.context.router.push(`/cluster/all/${dashboardName}`);
+      this.context.router.push(`/metrics/${dashboardName}/cluster`);
     } else {
-      this.context.router.push(`/cluster/node/${nodeID}/${dashboardName}`);
+      this.context.router.push(`/metrics/${dashboardName}/node/${nodeID}`);
     }
   }
 

--- a/pkg/ui/src/views/cluster/containers/nodeGraphs/index.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodeGraphs/index.tsx
@@ -104,8 +104,14 @@ class NodeGraphs extends React.Component<NodeGraphsProps, {}> {
     },
   );
 
-  static title() {
-    return "Cluster Overview";
+  static title({ params }: { params: { [name: string]: any } }) {
+    const dashboard = params[dashboardNameAttr];
+
+    if (dashboard in dashboards) {
+      return dashboards[dashboard].label + " Dashboard";
+    }
+
+    return "Cluster Metrics";
   }
 
   refresh(props = this.props) {

--- a/pkg/ui/src/views/cluster/containers/nodeGraphs/summaryBar.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodeGraphs/summaryBar.tsx
@@ -39,7 +39,7 @@ function ClusterNodeTotals (props: ClusterSummaryProps) {
   return (
     <SummaryStat
       title={
-        <span>Total Nodes <Link to="/cluster/nodes">View nodes list</Link></span>
+        <span>Total Nodes <Link to="/nodes">View nodes list</Link></span>
       }
       value={nodeCounts.total}
     >

--- a/pkg/ui/src/views/cluster/containers/nodeLogs/index.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodeLogs/index.tsx
@@ -65,7 +65,7 @@ class Logs extends React.Component<LogProps & RouterState, {}> {
     return (
       <div>
         <section className="section parent-link">
-          <Link to="/cluster/nodes">&lt; Back to Node List</Link>
+          <Link to="/nodes">&lt; Back to Node List</Link>
         </section>
         <div className="section section--heading">
           <h2>Logs Node { this.props.params[nodeIDAttr] } / { nodeAddress }</h2>

--- a/pkg/ui/src/views/cluster/containers/nodeOverview/index.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodeOverview/index.tsx
@@ -56,7 +56,7 @@ class NodeOverview extends React.Component<NodeOverviewProps, {}> {
     return (
       <div>
         <section className="section parent-link">
-          <Link to="/cluster/nodes">&lt; Back to Node List</Link>
+          <Link to="/nodes">&lt; Back to Node List</Link>
         </section>
         <div className="section section--heading">
           <h2>{`Node ${node.desc.node_id} / ${node.desc.address.address_field}`}</h2>
@@ -135,7 +135,7 @@ class NodeOverview extends React.Component<NodeOverviewProps, {}> {
               <SummaryValue title="Build" value={node.build_info.tag} />
               <SummaryValue
                 title="Logs"
-                value={<Link to={`/cluster/nodes/${node.desc.node_id}/logs`}>View Logs</Link>}
+                value={<Link to={`/node/${node.desc.node_id}/logs`}>View Logs</Link>}
                 classModifier="link"
               />
             </SummaryBar>

--- a/pkg/ui/src/views/cluster/containers/nodesOverview/index.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodesOverview/index.tsx
@@ -98,7 +98,7 @@ class LiveNodeList extends React.Component<NodeCategoryListProps, {}> {
                 return (
                   <div className="sort-table__unbounded-column">
                     <div className={"icon-circle-filled node-status-icon node-status-icon--" + s} title={tooltip} />
-                    <Link to={`/cluster/nodes/${ns.desc.node_id}`}>{ns.desc.address.address_field}</Link>
+                    <Link to={`/node/${ns.desc.node_id}`}>{ns.desc.address.address_field}</Link>
                   </div>
                 );
               },
@@ -145,7 +145,7 @@ class LiveNodeList extends React.Component<NodeCategoryListProps, {}> {
             // Logs - a link to the logs data for this node.
             {
               title: "Logs",
-              cell: (ns) => <Link to={`/cluster/nodes/${ns.desc.node_id}/logs`}>Logs</Link>,
+              cell: (ns) => <Link to={`/node/${ns.desc.node_id}/logs`}>Logs</Link>,
               className: "expand-link",
             },
           ]} />
@@ -205,7 +205,7 @@ class NotLiveNodeList extends React.Component<NotLiveNodeListProps, {}> {
                         "'server.time_until_store_dead'"
                       }
                     />
-                    <Link to={`/cluster/nodes/${ns.desc.node_id}`}>{ns.desc.address.address_field}</Link>
+                    <Link to={`/node/${ns.desc.node_id}`}>{ns.desc.address.address_field}</Link>
                   </div>
                 );
               },
@@ -390,7 +390,7 @@ function NodesPage() {
   return (
     <div>
       <section className="section parent-link">
-        <Link to="/cluster">&lt; Back to Cluster</Link>
+        <Link to="/">&lt; Back to Cluster</Link>
       </section>
       <NodesMainConnected />
     </div>

--- a/pkg/ui/src/views/databases/containers/databaseTables/index.tsx
+++ b/pkg/ui/src/views/databases/containers/databaseTables/index.tsx
@@ -72,7 +72,7 @@ class DatabaseSummaryTables extends DatabaseSummaryBase {
                         cell: (tableInfo) => {
                           return (
                             <div className="sort-table__unbounded-column">
-                              <Link to={`/databases/database/${dbID}/table/${tableInfo.name}`}>{tableInfo.name}</Link>
+                              <Link to={`/database/${dbID}/table/${tableInfo.name}`}>{tableInfo.name}</Link>
                             </div>
                           );
                         },

--- a/pkg/ui/src/views/devtools/containers/raftRanges/index.tsx
+++ b/pkg/ui/src/views/devtools/containers/raftRanges/index.tsx
@@ -148,7 +148,7 @@ class RangesMain extends React.Component<RangesMainProps, RangesMainState> {
         nodeIDIndex[id] = i + 1;
         columns.push((
           <th key={i}>
-            <Link className="debug-link" to={"/cluster/nodes/" + id}>Node {id}</Link>
+            <Link className="debug-link" to={"/nodes/" + id}>Node {id}</Link>
           </th>
         ));
       });


### PR DESCRIPTION
This updates the routing for the admin UI to follow the new structure discussed in #19643.  Redirects should maintain existing links.  Please do point out if I missed any redirects, it's a pretty big change, and though I testing things pretty thoroughly I could certainly have missed something.

The second commit is only moderately related, an update to show the current dashboard as the title, rather than the generic "Cluster Overview".  This is the title displayed within the page, no attempt was made to update the title shown in the browser window (that is discussed on #18408).