### PR TITLE
ui: cpu sparkline should not be a derivative

### DIFF
--- a/pkg/ui/ccl/src/views/clusterviz/containers/map/cpuSparkline.tsx
+++ b/pkg/ui/ccl/src/views/clusterviz/containers/map/cpuSparkline.tsx
@@ -15,8 +15,8 @@ export function CpuSparkline(props: CpuSparklineProps) {
   return (
     <MetricsDataProvider id={key}>
       <SparklineMetricsDataComponent formatCurrentValue={d3.format(".1%")}>
-        <Metric name="cr.node.sys.cpu.sys.percent" sources={props.nodes} nonNegativeRate />
-        <Metric name="cr.node.sys.cpu.user.percent" sources={props.nodes} nonNegativeRate />
+        <Metric name="cr.node.sys.cpu.sys.percent" sources={props.nodes} />
+        <Metric name="cr.node.sys.cpu.user.percent" sources={props.nodes} />
       </SparklineMetricsDataComponent>
     </MetricsDataProvider>
   );


### PR DESCRIPTION
In #22618 the CPU sparkline was made a derivative through the time-honored
copy-pasta tradition.  We should show the raw value, not the derivative.

Release note: None