### PR TITLE
sql: fix unlimited bytes monitor constructor

### DIFF
--- a/pkg/server/admin.go
+++ b/pkg/server/admin.go
@@ -94,6 +94,7 @@ func newAdminServer(s *Server, ie *sql.InternalExecutor) *adminServer {
 		nil,
 		nil,
 		noteworthyAdminMemoryUsageBytes,
+		s.ClusterSettings(),
 	)
 	return server
 }

--- a/pkg/sql/distsqlrun/row_container_test.go
+++ b/pkg/sql/distsqlrun/row_container_test.go
@@ -36,7 +36,8 @@ func TestRowContainerReplaceMax(t *testing.T) {
 	ctx := context.Background()
 	rng, _ := randutil.NewPseudoRand()
 
-	evalCtx := tree.NewTestingEvalContext(cluster.MakeTestingClusterSettings())
+	st := cluster.MakeTestingClusterSettings()
+	evalCtx := tree.NewTestingEvalContext(st)
 	defer evalCtx.Stop(ctx)
 
 	typeInt := sqlbase.ColumnType{SemanticType: sqlbase.ColumnType_INT}
@@ -54,7 +55,7 @@ func TestRowContainerReplaceMax(t *testing.T) {
 	}
 
 	m := mon.MakeUnlimitedMonitor(
-		context.Background(), "test", mon.MemoryResource, nil, nil, math.MaxInt64,
+		context.Background(), "test", mon.MemoryResource, nil, nil, math.MaxInt64, st,
 	)
 	defer m.Stop(ctx)
 

--- a/pkg/sql/pgwire/v3_test.go
+++ b/pkg/sql/pgwire/v3_test.go
@@ -35,10 +35,10 @@ import (
 
 func makeTestV3Conn(c net.Conn) v3Conn {
 	metrics := makeServerMetrics(nil, metric.TestSampleInterval)
-	mon := mon.MakeUnlimitedMonitor(
-		context.Background(), "test", mon.MemoryResource, nil, nil, 1000,
-	)
 	st := cluster.MakeTestingClusterSettings()
+	mon := mon.MakeUnlimitedMonitor(
+		context.Background(), "test", mon.MemoryResource, nil, nil, 1000, st,
+	)
 	exec := sql.NewExecutor(
 		sql.ExecutorConfig{
 			AmbientCtx:              log.AmbientContext{Tracer: st.Tracer},

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -216,7 +216,7 @@ func newInternalPlanner(
 		"internal-root",
 		mon.MemoryResource,
 		memMetrics.CurBytesCount, memMetrics.MaxBytesHist,
-		noteworthyInternalMemoryUsageBytes)
+		noteworthyInternalMemoryUsageBytes, execCfg.Settings)
 
 	s.sessionMon = mon.MakeMonitor("internal-session",
 		mon.MemoryResource,

--- a/pkg/sql/session_mem_usage.go
+++ b/pkg/sql/session_mem_usage.go
@@ -51,6 +51,7 @@ func (s *Session) StartUnlimitedMonitor() {
 		s.memMetrics.CurBytesCount,
 		s.memMetrics.MaxBytesHist,
 		math.MaxInt64,
+		s.execCfg.Settings,
 	)
 	s.deriveAndStartMonitors()
 }

--- a/pkg/sql/sqlbase/row_container_test.go
+++ b/pkg/sql/sqlbase/row_container_test.go
@@ -19,6 +19,7 @@ import (
 	"math"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -35,8 +36,9 @@ func TestRowContainer(t *testing.T) {
 				for i := range resCol {
 					resCol[i] = ResultColumn{Typ: types.Int}
 				}
+				st := cluster.MakeTestingClusterSettings()
 				m := mon.MakeUnlimitedMonitor(
-					context.Background(), "test", mon.MemoryResource, nil, nil, math.MaxInt64,
+					context.Background(), "test", mon.MemoryResource, nil, nil, math.MaxInt64, st,
 				)
 				rc := NewRowContainer(m.MakeBoundAccount(), ColTypeInfoFromResCols(resCol), 0)
 				row := make(tree.Datums, numCols)
@@ -80,7 +82,8 @@ func TestRowContainerAtOutOfRange(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	ctx := context.Background()
-	m := mon.MakeUnlimitedMonitor(ctx, "test", mon.MemoryResource, nil, nil, math.MaxInt64)
+	st := cluster.MakeTestingClusterSettings()
+	m := mon.MakeUnlimitedMonitor(ctx, "test", mon.MemoryResource, nil, nil, math.MaxInt64, st)
 	defer m.Stop(ctx)
 
 	resCols := ResultColumns{ResultColumn{Typ: types.Int}}
@@ -106,7 +109,8 @@ func TestRowContainerZeroCols(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	ctx := context.Background()
-	m := mon.MakeUnlimitedMonitor(ctx, "test", mon.MemoryResource, nil, nil, math.MaxInt64)
+	st := cluster.MakeTestingClusterSettings()
+	m := mon.MakeUnlimitedMonitor(ctx, "test", mon.MemoryResource, nil, nil, math.MaxInt64, st)
 	defer m.Stop(ctx)
 
 	rc := NewRowContainer(m.MakeBoundAccount(), ColTypeInfoFromResCols(nil), 0)
@@ -134,8 +138,9 @@ func BenchmarkRowContainerAt(b *testing.B) {
 	const numCols = 3
 	const numRows = 1024
 
+	st := cluster.MakeTestingClusterSettings()
 	m := mon.MakeUnlimitedMonitor(
-		context.Background(), "test", mon.MemoryResource, nil, nil, math.MaxInt64,
+		context.Background(), "test", mon.MemoryResource, nil, nil, math.MaxInt64, st,
 	)
 	defer m.Stop(context.Background())
 

--- a/pkg/ts/db_test.go
+++ b/pkg/ts/db_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/localtestcluster"
@@ -67,6 +68,7 @@ type testModel struct {
 // newTestModel creates a new testModel instance. The Start() method must
 // be called before using it.
 func newTestModel(t *testing.T) testModel {
+	st := cluster.MakeTestingClusterSettings()
 	workerMonitor := mon.MakeUnlimitedMonitor(
 		context.Background(),
 		"timeseries-test-worker",
@@ -74,6 +76,7 @@ func newTestModel(t *testing.T) testModel {
 		nil,
 		nil,
 		math.MaxInt64,
+		st,
 	)
 	resultMonitor := mon.MakeUnlimitedMonitor(
 		context.Background(),
@@ -82,6 +85,7 @@ func newTestModel(t *testing.T) testModel {
 		nil,
 		nil,
 		math.MaxInt64,
+		st,
 	)
 	return testModel{
 		t:                 t,

--- a/pkg/ts/server.go
+++ b/pkg/ts/server.go
@@ -130,6 +130,7 @@ func MakeServer(
 			// Begin logging messages if we exceed our planned memory usage by
 			// more than double.
 			queryMemoryMax*2,
+			db.st,
 		),
 		resultMemMonitor: mon.MakeUnlimitedMonitor(
 			context.Background(),
@@ -138,6 +139,7 @@ func MakeServer(
 			nil,
 			nil,
 			math.MaxInt64,
+			db.st,
 		),
 		queryMemoryMax: queryMemoryMax,
 		queryWorkerMax: queryWorkerMax,

--- a/pkg/util/mon/bytes_usage.go
+++ b/pkg/util/mon/bytes_usage.go
@@ -354,6 +354,7 @@ func MakeUnlimitedMonitor(
 	curCount *metric.Gauge,
 	maxHist *metric.Histogram,
 	noteworthy int64,
+	settings *cluster.Settings,
 ) BytesMonitor {
 	if log.V(2) {
 		log.InfofDepth(ctx, 1, "%s: starting unlimited monitor", name)
@@ -368,6 +369,7 @@ func MakeUnlimitedMonitor(
 		maxBytesHist:         maxHist,
 		poolAllocationSize:   DefaultPoolAllocationSize,
 		reserved:             MakeStandaloneBudget(math.MaxInt64),
+		settings:             settings,
 	}
 }
 


### PR DESCRIPTION
MakeUnlimitedMonitor was not setting the `settings` field, which could
lead to nil pointer errors.

Release note: None