### PR TITLE
sql: release leftover bytes if not panicking

### DIFF
--- a/pkg/util/mon/bytes_usage.go
+++ b/pkg/util/mon/bytes_usage.go
@@ -397,6 +397,7 @@ func (mm *BytesMonitor) doStop(ctx context.Context, check bool) {
 			ctx, &mm.settings.SV,
 			fmt.Sprintf("%s: unexpected %d leftover bytes", mm.name, mm.mu.curAllocated),
 			reportables)
+		mm.releaseBytes(ctx, mm.mu.curAllocated)
 	}
 
 	mm.releaseBudget(ctx)


### PR DESCRIPTION
As of 91ed508, the bytes monitor now does not necessarily panic when
stopping if it encounters leftover bytes. However, we still need to
release these bytes to avoid a "started with %d bytes left over" panic
if the monitor is started again.

Release note: None