### PR TITLE
server, sql: Correctly Hash AppNames for Reporting

### DIFF
--- a/pkg/server/admin_test.go
+++ b/pkg/server/admin_test.go
@@ -771,7 +771,7 @@ func TestAdminAPIEvents(t *testing.T) {
 		{sql.EventLogCreateDatabase, false, 0, 1},
 		{sql.EventLogDropTable, false, 0, 2},
 		{sql.EventLogCreateTable, false, 0, 3},
-		{sql.EventLogSetClusterSetting, false, 0, 4},
+		{sql.EventLogSetClusterSetting, false, 0, 5},
 		{sql.EventLogCreateTable, true, 0, 3},
 		{sql.EventLogCreateTable, true, -1, 3},
 		{sql.EventLogCreateTable, true, 2, 2},

--- a/pkg/server/updates.go
+++ b/pkg/server/updates.go
@@ -249,7 +249,7 @@ func (s *Server) maybeReportDiagnostics(
 }
 
 // safeToReportSettings are the names of settings which we want reported with
-// their values, regardless of their type -- usually only numeric/duraion/bool
+// their values, regardless of their type -- usually only numeric/duration/bool
 // settings are reported to avoid including potentially sensitive info that may
 // appear in strings or byte/proto/statemachine settings.
 var safeToReportSettings = map[string]struct{}{

--- a/pkg/sql/app_stats.go
+++ b/pkg/sql/app_stats.go
@@ -17,10 +17,10 @@ package sql
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"hash/fnv"
-	"strconv"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings"
@@ -281,12 +281,13 @@ func (e *Executor) GetScrubbedStmtStats() []roachpb.CollectedStatementStatistics
 	var ret []roachpb.CollectedStatementStatistics
 	vt := e.cfg.VirtualSchemas
 	e.sqlStats.Lock()
+	salt := ClusterSecret.Get(&e.cfg.Settings.SV)
 	for appName, a := range e.sqlStats.apps {
 		if cap(ret) == 0 {
-			// guesitmate that we'll need apps*(queries-per-app).
+			// guesstimate that we'll need apps*(queries-per-app).
 			ret = make([]roachpb.CollectedStatementStatistics, 0, len(a.stmts)*len(e.sqlStats.apps))
 		}
-		hashedApp := HashAppName(appName)
+		hashedAppName := HashForReporting(salt, appName)
 		a.Lock()
 		for q, stats := range a.stmts {
 			scrubbed, ok := scrubStmtStatKey(vt, q.stmt)
@@ -295,7 +296,7 @@ func (e *Executor) GetScrubbedStmtStats() []roachpb.CollectedStatementStatistics
 					Query:   scrubbed,
 					DistSQL: q.distSQLUsed,
 					Failed:  q.failed,
-					App:     hashedApp,
+					App:     hashedAppName,
 				}
 				stats.Lock()
 				data := stats.data
@@ -315,14 +316,23 @@ func (e *Executor) GetScrubbedStmtStats() []roachpb.CollectedStatementStatistics
 	return ret
 }
 
-// HashAppName 1-way hashes an application names for use in stat reporting.
-func HashAppName(appName string) string {
-	hash := fnv.New64a()
+// HashForReporting 1-way hashes values for use in stat reporting. The salt
+// should be the cluster.secret setting.
+func HashForReporting(salt, appName string) string {
+	// If no salt is provided, we cannot irreversibly hash the value, so return
+	// a default value.
+	if len(salt) == 0 {
+		return "unknown"
+	}
+	hash := sha256.New()
 
+	if _, err := hash.Write([]byte(salt)); err != nil {
+		panic(errors.Wrap(err, `"It never returns an error." -- https://golang.org/pkg/hash`))
+	}
 	if _, err := hash.Write([]byte(appName)); err != nil {
 		panic(errors.Wrap(err, `"It never returns an error." -- https://golang.org/pkg/hash`))
 	}
-	return strconv.Itoa(int(hash.Sum64()))
+	return hex.EncodeToString(hash.Sum(nil)[:4])
 }
 
 // ResetStatementStats resets the executor's collected statement statistics.

--- a/pkg/sql/executor.go
+++ b/pkg/sql/executor.go
@@ -64,6 +64,17 @@ var ClusterOrganization = settings.RegisterStringSetting(
 	"",
 )
 
+// ClusterSecret is a cluster specific secret. This setting is hidden.
+var ClusterSecret = func() *settings.StringSetting {
+	s := settings.RegisterStringSetting(
+		"cluster.secret",
+		"cluster specific secret",
+		"",
+	)
+	s.Hide()
+	return s
+}()
+
 var errNoTransactionInProgress = errors.New("there is no transaction in progress")
 var errTransactionInProgress = errors.New("there is already a transaction in progress")
 

--- a/pkg/sql/logictest/testdata/logic_test/event_log
+++ b/pkg/sql/logictest/testdata/logic_test/event_log
@@ -337,7 +337,8 @@ FROM system.eventlog
 WHERE "eventType" = 'set_cluster_setting' AND info NOT LIKE '%version%' AND info NOT LIKE '%sql.defaults.distsql%'
 ORDER BY "timestamp"
 ----
-0 1 {"SettingName":"diagnostics.reporting.enabled","Value":"true","User":"node"}
-0 1 {"SettingName":"trace.debug.enable","Value":"false","User":"node"}
-0 1 {"SettingName":"kv.allocator.load_based_lease_rebalancing.enabled","Value":"false","User":"root"}
-0 1 {"SettingName":"kv.allocator.load_based_lease_rebalancing.enabled","Value":"DEFAULT","User":"root"}
+0  1  {"SettingName":"diagnostics.reporting.enabled","Value":"true","User":"node"}
+0  1  {"SettingName":"trace.debug.enable","Value":"false","User":"node"}
+0  1  {"SettingName":"cluster.secret","Value":"gen_random_uuid()::STRING","User":"node"}
+0  1  {"SettingName":"kv.allocator.load_based_lease_rebalancing.enabled","Value":"false","User":"root"}
+0  1  {"SettingName":"kv.allocator.load_based_lease_rebalancing.enabled","Value":"DEFAULT","User":"root"}

--- a/pkg/sql/logictest/testdata/logic_test/select_index
+++ b/pkg/sql/logictest/testdata/logic_test/select_index
@@ -878,7 +878,7 @@ render     0  render  ·         ·                     (a, b, c, d)            
 ·          1  ·       table     abcd@abcd             ·                                    ·
 ·          1  ·       spans     /1/NULL/1-/1/NULL/10  ·                                    ·
 
-query IIII 
+query IIII
 SELECT * FROM abcd@abcd WHERE a = 1 AND b IS NULL AND c > 0 AND c < 10 ORDER BY c
 ----
 1  NULL  1  NULL
@@ -957,7 +957,7 @@ SELECT k, v FROM str WHERE v SIMILAR TO 'ABC_*'
 5  ABCD
 3  ABCDEZ
 
-# Test that we generate spans for IS (NOT) DISTICT FROM.
+# Test that we generate spans for IS (NOT) DISTINCT FROM.
 statement ok
 CREATE TABLE xy (x INT, y INT, INDEX (y))
 
@@ -1030,7 +1030,7 @@ render     0  render  ·         ·            (x, y)                         x!
 ·          1  ·       table     xy@xy_idx    ·                              ·
 ·          1  ·       spans     /1-/2 /2-/3  ·                              ·
 
-query II
+query II rowsort
 SELECT * FROM xy WHERE x IN (NULL, 1, 2)
 ----
 1  NULL

--- a/pkg/sql/logictest/testdata/logic_test/system
+++ b/pkg/sql/logictest/testdata/logic_test/system
@@ -409,8 +409,12 @@ GRANT ALL ON system.lease TO testuser
 # NB: the "order by" is necessary or this test is flaky under DistSQL.
 # This is somewhat surprising.
 query T
-select name from system.settings where name != 'sql.defaults.distsql' order by name
+SELECT name
+FROM system.settings
+WHERE name != 'sql.defaults.distsql'
+ORDER BY name
 ----
+cluster.secret
 diagnostics.reporting.enabled
 trace.debug.enable
 version
@@ -419,7 +423,10 @@ statement ok
 INSERT INTO system.settings (name, value) VALUES ('somesetting', 'somevalue')
 
 query TT
-select name, value from system.settings where name != 'version' AND name != 'sql.defaults.distsql' order by name
+SELECT name, value
+FROM system.settings
+WHERE name NOT IN ('version', 'sql.defaults.distsql', 'cluster.secret')
+ORDER BY name
 ----
 diagnostics.reporting.enabled  true
 somesetting                    somevalue

--- a/pkg/sqlmigrations/migrations.go
+++ b/pkg/sqlmigrations/migrations.go
@@ -184,6 +184,11 @@ var backwardCompatibleMigrations = []migrationDescriptor{
 		name:   "add default system.jobs zone config",
 		workFn: addDefaultSystemJobsZoneConfig,
 	},
+	{
+		// Introduced in v2.0.
+		name:   "initialize cluster.secret",
+		workFn: initializeClusterSecret,
+	},
 }
 
 // migrationDescriptor describes a single migration hook that's used to modify
@@ -531,6 +536,10 @@ func optInToDiagnosticsStatReporting(ctx context.Context, r runner) error {
 
 func disableNetTrace(ctx context.Context, r runner) error {
 	return runStmtAsRootWithRetry(ctx, r, `SET CLUSTER SETTING trace.debug.enable = false`)
+}
+
+func initializeClusterSecret(ctx context.Context, r runner) error {
+	return runStmtAsRootWithRetry(ctx, r, `SET CLUSTER SETTING cluster.secret = gen_random_uuid()::STRING`)
 }
 
 func populateVersionSetting(ctx context.Context, r runner) error {


### PR DESCRIPTION
This now ensures that appNames are correctly hashed irreversibly.

To accomplish this, a new cluster setting 'cluster.secret' was added. This
allows us to create a hash based on this value.

While in there, instead of using go's hashing algorithm, it now uses a proper
crypto hash.

Release note: None