### PR TITLE
sql: make SERIALIZABLE isolation the default upgrade

### DIFF
--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -2475,11 +2475,11 @@ var_list:
 iso_level:
   READ UNCOMMITTED
   {
-    $$.val = tree.SnapshotIsolation
+    $$.val = tree.SerializableIsolation
   }
 | READ COMMITTED
   {
-    $$.val = tree.SnapshotIsolation
+    $$.val = tree.SerializableIsolation
   }
 | SNAPSHOT
   {


### PR DESCRIPTION
No longer upgrade `READ UNCOMMITTED` and `READ COMMITTED` to `SNAPSHOT`,
and instead upgrade them to `SERIALIZABLE`.

Release note (sql change): In light of recent improvements to the
serializable isolation level to prevent client-side retries, deprecate
automatic usage of SNAPSHOT through upgrade from READ UNCOMMITTED/COMMITTED.