### PR TITLE
opt: Factor constraint code into generalized library

### DIFF
--- a/pkg/sql/opt/constraint/constraint.go
+++ b/pkg/sql/opt/constraint/constraint.go
@@ -1,0 +1,296 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package constraint
+
+import (
+	"bytes"
+	"fmt"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/opt"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+)
+
+// Constraint specifies the possible set of values that one or more columns
+// will have in the result set. If this is a single column constraint, then
+// that column's value will always be part of one of the spans in this
+// constraint. If this is a multi-column constraint, then the combination of
+// column values will always be part of one of the spans.
+//
+// Constrained columns are specified as an ordered list, and span key values
+// correspond to those columns by position. Constraints are inferred from
+// scalar filter conditions, since these restrict the set of possible results.
+// Constraints over different combinations of columns can be combined together
+// in a constraint set, which is a conjunction of constraints. See the
+// Set struct comment for more details.
+//
+// A few examples:
+//  - a constraint on @1 > 1: a single span             /@1: (/1 - ]
+//  - a constraint on @1 = 1 AND @2 >= 1: a single span /@1/@2: [/1/1 - /1]
+//  - a constraint on @1 < 5 OR @1 > 10: multiple spans /@1: [ - /5) (10 - ]
+type Constraint struct {
+	// firstCol holds the first column index and otherCols hold any indexes
+	// beyond the first. These are separated in order to optimize for the common
+	// case of a single-column constraint.
+	firstCol  opt.ColumnIndex
+	otherCols []opt.ColumnIndex
+
+	// firstSpan holds the first span and otherSpans hold any spans beyond the
+	// first. These are separated in order to optimize for the common case of a
+	// single-span constraint. The spans are always maintained in sorted order.
+	firstSpan  Span
+	otherSpans []Span
+}
+
+// init is for package use only. External callers should call NewConstraintSet.
+func (c *Constraint) init(col opt.ColumnIndex, sp *Span) {
+	if sp.IsUnconstrained() {
+		// Don't allow unconstrained span in a constraint. Instead just discard
+		// the constraint, as its absence already means it's unconstrained.
+		panic("unconstrained span cannot be part of a constraint")
+	}
+	c.firstCol = col
+	c.firstSpan = *sp
+}
+
+// initComposite is for package use only. External callers should call
+// NewForColumn or NewForColumns.
+func (c *Constraint) initComposite(cols []opt.ColumnIndex, sp *Span) {
+	c.init(cols[0], sp)
+	if len(cols) > 1 {
+		c.otherCols = cols[1:]
+	}
+}
+
+// ColumnCount returns the number of constrained columns (always at least one).
+func (c *Constraint) ColumnCount() int {
+	// There's always at least one column.
+	return 1 + len(c.otherCols)
+}
+
+// Column returns the index of the nth constrained column. Together with the
+// ColumnCount method, Column allows iteration over the list of constrained
+// columns (since there is no method to return a slice of columns).
+func (c *Constraint) Column(nth int) opt.ColumnIndex {
+	// There's always at least one column.
+	if nth == 0 {
+		return c.firstCol
+	}
+	return c.otherCols[nth-1]
+}
+
+// SpanCount returns the total number of spans in the constraint (always at
+// least one).
+func (c *Constraint) SpanCount() int {
+	return 1 + len(c.otherSpans)
+}
+
+// Span returns the nth span. Together with the SpanCount method, Span allows
+// iteration over the list of spans (since there is no method to return a slice
+// of spans).
+func (c *Constraint) Span(nth int) *Span {
+	// There's always at least one span.
+	if nth == 0 {
+		return &c.firstSpan
+	}
+	return &c.otherSpans[nth-1]
+}
+
+// tryUnionWith merges the spans of the given constraint into this constraint.
+// The columns of both constraints must be the same. Constrained columns in the
+// merged constraint can have values that are part of either of the input
+// constraints. If the merge results in an unconstrained span, then
+// tryUnionWith returns false. An unconstrained span should never be part of a
+// constraint, as then the constraint would not constrain anything, and should
+// not be added to the constraint set.
+func (c *Constraint) tryUnionWith(evalCtx *tree.EvalContext, other *Constraint) bool {
+	// Use variation on merge sort, because both sets of spans are ordered and
+	// non-overlapping.
+	var firstSpan Span
+	var otherSpans []Span
+
+	foundSpan := false
+	left := c
+	leftIndex := 0
+	right := other
+	rightIndex := 0
+
+	for leftIndex < left.SpanCount() || rightIndex < right.SpanCount() {
+		if rightIndex < right.SpanCount() {
+			if leftIndex >= left.SpanCount() ||
+				left.Span(leftIndex).Compare(evalCtx, right.Span(rightIndex)) > 0 {
+				// Swap the two sets, so that going forward the current left
+				// span starts before the current right span.
+				left, right = right, left
+				leftIndex, rightIndex = rightIndex, leftIndex
+			}
+		}
+
+		// Merge this span with any overlapping spans in left or right. Initially,
+		// it can only overlap with spans in right, but after the merge we can
+		// have new overlaps; hence why this is a loop and we check against both
+		// left and right. For example:
+		//   left : [/1 - /10] [/20 - /30] [/40 - /50]
+		//   right: [/5 - /25] [/30 - /40]
+		//                             span
+		//   initial:                [/1 - /10]
+		//   merge with [/5 - /25]:  [/1 - /25]
+		//   merge with [/20 - /30]: [/1 - /30]
+		//   merge with [/30 - /40]: [/1 - /40]
+		//   merge with [/40 - /50]: [/1 - /50]
+		//
+		mergeSpan := *left.Span(leftIndex)
+		leftIndex++
+		for {
+			// Note that Span.TryUnionWith returns false for a different reason
+			// than Constraint.tryUnionWith. Span.TryUnionWith returns false
+			// when the spans are not contiguous, and therefore the union cannot
+			// be represented as a valid Span. Constraint.tryUnionWith returns
+			// false when the merged spans are unconstrained (cover entire key
+			// range), and therefore the union cannot be represented as a valid
+			// Constraint.
+			var ok bool
+			if leftIndex < left.SpanCount() {
+				if mergeSpan.TryUnionWith(evalCtx, left.Span(leftIndex)) {
+					leftIndex++
+					ok = true
+				}
+			}
+			if rightIndex < right.SpanCount() {
+				if mergeSpan.TryUnionWith(evalCtx, right.Span(rightIndex)) {
+					rightIndex++
+					ok = true
+				}
+			}
+
+			// If union has resulted in an unconstrained Span, then return false,
+			// as that is not valid in a Constraint.
+			if mergeSpan.IsUnconstrained() {
+				return false
+			}
+
+			// If neither union succeeded, then it means either:
+			//   1. The spans don't merge into a single contiguous span, and will
+			//      need to be represented separately in this constraint.
+			//   2. There are no more spans to merge.
+			if !ok {
+				break
+			}
+		}
+
+		if otherSpans == nil {
+			if !foundSpan {
+				firstSpan = mergeSpan
+				foundSpan = true
+			} else {
+				maxRemaining := left.SpanCount() - leftIndex + right.SpanCount() - rightIndex
+				otherSpans = make([]Span, 1, 1+maxRemaining)
+				otherSpans[0] = mergeSpan
+			}
+		} else {
+			otherSpans = append(otherSpans, mergeSpan)
+		}
+	}
+
+	if firstSpan.IsUnconstrained() {
+		panic("unconstrained span should have been handled in the merge loop above")
+	}
+
+	// We've got a valid constraint.
+	c.firstSpan = firstSpan
+	c.otherSpans = otherSpans
+	return true
+}
+
+// tryIntersectWith intersects the spans of this constraint with those in the
+// given constraint and updates this constraint with any overlapping spans. The
+// columns of both constraints must be the same. If there are no overlapping
+// spans, then the intersection is empty, and tryIntersectWith returns false.
+// If a constraint set has even one empty constraint, then the entire set
+// should be marked as empty and all constraints removed.
+func (c *Constraint) tryIntersectWith(evalCtx *tree.EvalContext, other *Constraint) bool {
+	// Use variation on merge sort, because both sets of spans are ordered and
+	// non-overlapping.
+	var firstSpan Span
+	var otherSpans []Span
+
+	empty := true
+	index := 0
+	otherIndex := 0
+
+	for index < c.SpanCount() && otherIndex < other.SpanCount() {
+		if c.Span(index).StartsAfter(evalCtx, other.Span(otherIndex)) {
+			otherIndex++
+			continue
+		}
+
+		mergeSpan := *c.Span(index)
+		if !mergeSpan.TryIntersectWith(evalCtx, other.Span(otherIndex)) {
+			index++
+			continue
+		}
+
+		if otherSpans == nil {
+			if empty {
+				firstSpan = mergeSpan
+				empty = false
+			} else {
+				maxRemaining := c.SpanCount() - index
+				otherSpans = make([]Span, 1, maxRemaining)
+				otherSpans[0] = mergeSpan
+			}
+		} else {
+			otherSpans = append(otherSpans, mergeSpan)
+		}
+
+		// Skip past whichever span ends first, or skip past both if they have
+		// the same endpoint.
+		cmp := c.Span(index).CompareEnds(evalCtx, other.Span(otherIndex))
+		if cmp <= 0 {
+			index++
+		}
+		if cmp >= 0 {
+			otherIndex++
+		}
+	}
+
+	// If empty was never set to false, then the intersection must be empty.
+	if empty {
+		return false
+	}
+
+	c.firstSpan = firstSpan
+	c.otherSpans = otherSpans
+	return true
+}
+
+func (c *Constraint) String() string {
+	var buf bytes.Buffer
+
+	for i := 0; i < c.ColumnCount(); i++ {
+		buf.WriteRune('/')
+		buf.WriteString(fmt.Sprintf("%d", c.Column(i)))
+	}
+
+	buf.WriteString(": ")
+
+	for i := 0; i < c.SpanCount(); i++ {
+		if i > 0 {
+			buf.WriteRune(' ')
+		}
+		buf.WriteString(c.Span(i).String())
+	}
+
+	return buf.String()
+}

--- a/pkg/sql/opt/constraint/constraint_set.go
+++ b/pkg/sql/opt/constraint/constraint_set.go
@@ -1,0 +1,306 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package constraint
+
+import (
+	"bytes"
+	"fmt"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/opt"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+)
+
+// Unconstrained is an empty constraint set which does not impose any
+// constraints on any columns.
+var Unconstrained = &Set{}
+
+// Contradiction is a special constraint set which indicates there are no
+// possible values for the expression; it will always yield the empty result
+// set.
+var Contradiction = &Set{contradiction: true}
+
+// Set is a conjunction of constraints that are inferred from scalar filter
+// conditions. The constrained expression will always evaluate to a result set
+// having values that conform to all of the constraints in the constraint set.
+// Each constraint within the set is a disjunction of spans that together
+// specify the domain of possible values which that constraint's column(s) can
+// have. See the Constraint struct comment for more details.
+//
+// Constraint sets are useful for selecting indexes, pruning ranges, inferring
+// non-null columns, and more. They serve as a "summary" of arbitrarily complex
+// expressions, so that fast decisions can be made without analyzing the entire
+// expression tree each time.
+//
+// A few examples:
+//  - @1 > 10
+//      /@1: (/10 - ]
+//
+//  - @1 > 10 AND @2 = 5
+//      /@1: (/10 - ]
+//      /@2: [/5 - /5]
+//
+//  - (@1 = 10 AND @2 > 5) OR (@1 = 20 AND @2 > 0)
+//      /@1: [/10 - /10] [/20 - /20]
+//      /@2: [/0 - ]
+//
+type Set struct {
+	// firstConstraint holds the first constraint in the set and otherConstraints
+	// hold any constraints beyond the first. These are separated in order to
+	// optimize for the common case of a set with a single constraint.
+	firstConstraint  Constraint
+	otherConstraints []Constraint
+
+	// length is the number of constraints in the set.
+	length int32
+
+	// contradiction is true if this is the special Contradiction constraint set.
+	contradiction bool
+}
+
+// NewForColumn creates a new constraint set containing a single constraint.
+// The constraint has a single column and a single span.
+func NewForColumn(col opt.ColumnIndex, sp *Span) *Set {
+	cs := &Set{length: 1}
+	cs.firstConstraint.init(col, sp)
+	return cs
+}
+
+// NewForColumns creates a new constraint set containing a single constraint.
+// The constraint has one or more columns and a single span.
+func NewForColumns(cols []opt.ColumnIndex, sp *Span) *Set {
+	cs := &Set{length: 1}
+	cs.firstConstraint.initComposite(cols, sp)
+	return cs
+}
+
+// Length returns the number of constraints in the set.
+func (s *Set) Length() int {
+	return int(s.length)
+}
+
+// Constraint returns the nth constraint in the set. Together with the Length
+// method, Constraint allows iteration over the list of constraints (since
+// there is no method to return a slice of constraints).
+func (s *Set) Constraint(nth int) *Constraint {
+	if nth == 0 && s.length != 0 {
+		return &s.firstConstraint
+	}
+	return &s.otherConstraints[nth-1]
+}
+
+// IsUnconstrained returns true if the constraint set contains no constraints,
+// which means column values can have any possible values.
+func (s *Set) IsUnconstrained() bool {
+	return s.length == 0 && !s.contradiction
+}
+
+// Intersect finds the overlap between this constraint set and the given set.
+// Constraints that exist in either of the input sets will get merged into the
+// combined set. Compatible constraints (that share same column list) are
+// intersected with one another. Intersect returns the merged set.
+func (s *Set) Intersect(evalCtx *tree.EvalContext, other *Set) *Set {
+	// Intersection with the contradiction set is always the contradiction set.
+	if s == Contradiction || other == Contradiction {
+		return Contradiction
+	}
+
+	// Intersection with the unconstrained set is the identity op.
+	if s.IsUnconstrained() {
+		return other
+	}
+	if other.IsUnconstrained() {
+		return s
+	}
+
+	// Create a new set to hold the merged sets.
+	mergeSet := &Set{}
+
+	index := 0
+	length := s.Length()
+	otherIndex := 0
+	otherLength := other.Length()
+
+	// Constraints are ordered in the set by column indexes, with no duplicates,
+	// so intersection can be done as a variation on merge sort.
+	for index < length || otherIndex < otherLength {
+		// Allocate the next constraint slot in the new set.
+		merge := mergeSet.allocConstraint(length - index + otherLength - otherIndex)
+
+		var cmp int
+		if index >= length {
+			cmp = 1
+		} else if otherIndex >= otherLength {
+			cmp = -1
+		} else {
+			cmp = compareConstraintsByCols(s.Constraint(index), other.Constraint(otherIndex))
+		}
+
+		if cmp == 0 {
+			// Constraints have same columns, so they're compatible and need to
+			// be merged.
+			*merge = *s.Constraint(index)
+			if !merge.tryIntersectWith(evalCtx, other.Constraint(otherIndex)) {
+				// Constraints contradict one another.
+				return Contradiction
+			}
+
+			// Skip past both inputs.
+			index++
+			otherIndex++
+		} else if cmp < 0 {
+			// This constraint has no corresponding constraint in other set, so
+			// add it to the set (absence of other constraint = unconstrained).
+			*merge = *s.Constraint(index)
+			index++
+		} else {
+			*merge = *other.Constraint(otherIndex)
+			otherIndex++
+		}
+	}
+	return mergeSet
+}
+
+// Union creates a new set with constraints that allow any value that either of
+// the input sets allowed. Compatible constraints (that share same column list)
+// that exist in both sets are merged with one another. Note that the results
+// may not be "tight", meaning that the new constraint set might allow
+// additional values that neither of the input sets allowed. Union returns the
+// merged set.
+func (s *Set) Union(evalCtx *tree.EvalContext, other *Set) *Set {
+	// Union with the contradiction set is an identity operation.
+	if s == Contradiction {
+		return other
+	} else if other == Contradiction {
+		return s
+	}
+
+	// Union with the unconstrained set yields an unconstrained set.
+	if s.IsUnconstrained() {
+		return Unconstrained
+	} else if other.IsUnconstrained() {
+		return Unconstrained
+	}
+
+	// Create a new set to hold the merged sets.
+	mergeSet := &Set{}
+
+	index := 0
+	length := s.Length()
+	otherIndex := 0
+	otherLength := other.Length()
+
+	// Constraints are ordered in the set by column indexes, with no duplicates,
+	// so union can be done as a variation on merge sort. The constraints are
+	// matched up against one another. All constraints that have a "compatible"
+	// constraint in the other set can be merged into the new set. Currently,
+	// a compatible constraint is one in which columns exactly match.
+	for index < length && otherIndex < otherLength {
+		// Skip past any constraint that does not have a corresponding
+		// constraint in the other set. A missing constraint is equivalent to
+		// a constraint that allows all values. Union of that unconstrained
+		// range with any other range is also unconstrained, and the constraint
+		// set never includes unconstrained ranges. Therefore, skipping
+		// unmatched constraints is equivalent to doing a union operation and
+		// then not adding the result to the set.
+		cmp := compareConstraintsByCols(s.Constraint(index), other.Constraint(otherIndex))
+		if cmp < 0 {
+			index++
+			continue
+		} else if cmp > 0 {
+			otherIndex++
+			continue
+		}
+
+		// Constraints have same columns, so they're compatible and need to
+		// be merged. Allocate the next constraint slot in the new set.
+		merge := mergeSet.allocConstraint(length - index + otherLength - otherIndex)
+
+		*merge = *s.Constraint(index)
+		if !merge.tryUnionWith(evalCtx, other.Constraint(otherIndex)) {
+			// Together, constraints allow any possible value (unconstrained
+			// case), and so there's nothing to add to the set.
+			mergeSet.undoAllocConstraint()
+		}
+
+		// Skip past both inputs.
+		index++
+		otherIndex++
+	}
+	return mergeSet
+}
+
+// allocConstraint allocates space for a new constraint in the set and returns
+// a pointer to it. The first constraint is stored inline, and subsequent
+// constraints are stored in the otherConstraints slice.
+func (s *Set) allocConstraint(capacity int) *Constraint {
+	s.length++
+
+	// First constraint does not require heap allocation.
+	if s.length == 1 {
+		return &s.firstConstraint
+	}
+
+	// Second constraint allocates slice.
+	if s.otherConstraints == nil {
+		s.otherConstraints = make([]Constraint, 1, capacity)
+		return &s.otherConstraints[0]
+	}
+
+	// Subsequent constraints extend slice.
+	if cap(s.otherConstraints) < capacity {
+		panic("correct capacity should have been set when otherConstraints was allocated")
+	}
+
+	// Remember that otherConstraints' length is one less than the set length.
+	s.otherConstraints = s.otherConstraints[:s.length-1]
+	return &s.otherConstraints[s.length-2]
+}
+
+// undoAllocConstraint rolls back the previous allocation performed by
+// allocConstraint. The next call to allocConstraint will allocate the same
+// slot as before.
+func (s *Set) undoAllocConstraint() {
+	s.length--
+}
+
+func (s *Set) String() string {
+	if s.IsUnconstrained() {
+		return "unconstrained\n"
+	}
+	if s == Contradiction {
+		return "contradiction\n"
+	}
+
+	var buf bytes.Buffer
+	for i := 0; i < s.Length(); i++ {
+		fmt.Fprintf(&buf, "%s\n", s.Constraint(i))
+	}
+	return buf.String()
+}
+
+// compareConstraintsByCols orders constraints by the indexes of their columns,
+// with column position determining significance in the sort key (most
+// significant first).
+func compareConstraintsByCols(left, right *Constraint) int {
+	leftCount := left.ColumnCount()
+	rightCount := right.ColumnCount()
+	for i := 0; i < leftCount && i < rightCount; i++ {
+		diff := int(left.Column(i) - right.Column(i))
+		if diff != 0 {
+			return diff
+		}
+	}
+	return leftCount - rightCount
+}

--- a/pkg/sql/opt/constraint/constraint_set_test.go
+++ b/pkg/sql/opt/constraint/constraint_set_test.go
@@ -1,0 +1,261 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package constraint
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/opt"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+)
+
+func TestConstraintSetIntersect(t *testing.T) {
+	test := func(t *testing.T, evalCtx *tree.EvalContext, cs *Set, expected string) {
+		t.Helper()
+		if cs.String() != expected {
+			t.Errorf("\nexpected:\n%vactual:\n%v", expected, cs.String())
+		}
+	}
+
+	st := cluster.MakeTestingClusterSettings()
+	evalCtx := tree.MakeTestingEvalContext(st)
+	data := newSpanTestData(&evalCtx)
+
+	// Simple AND case.
+	// @1 > 20
+	gt20 := NewForColumn(1, &data.spGt20)
+	test(t, &evalCtx, gt20, "/1: (/20 - ]\n")
+
+	// @1 <= 40
+	le40 := NewForColumn(1, &data.spLe40)
+	test(t, &evalCtx, le40, "/1: [ - /40]\n")
+
+	// @1 > 20 AND @1 <= 40
+	range2040 := gt20.Intersect(&evalCtx, le40)
+	test(t, &evalCtx, range2040, "/1: (/20 - /40]\n")
+	range2040 = le40.Intersect(&evalCtx, gt20)
+	test(t, &evalCtx, range2040, "/1: (/20 - /40]\n")
+
+	// Include constraint on multiple columns.
+	// (@1, @2) >= (10, 15)
+	gt1015 := NewForColumns([]opt.ColumnIndex{1, 2}, &data.spGe1015)
+	test(t, &evalCtx, gt1015, "/1/2: [/10/15 - ]\n")
+
+	// (@1, @2) >= (10, 15) AND @1 <= 40
+	multi2 := le40.Intersect(&evalCtx, gt1015)
+	test(t, &evalCtx, multi2, ""+
+		"/1: [ - /40]\n"+
+		"/1/2: [/10/15 - ]\n")
+
+	multi2 = gt1015.Intersect(&evalCtx, le40)
+	test(t, &evalCtx, multi2, ""+
+		"/1: [ - /40]\n"+
+		"/1/2: [/10/15 - ]\n")
+
+	// (@1, @2) >= (10, 15) AND @1 <= 40 AND @2 < 80
+	lt80 := NewForColumn(2, &data.spLt80)
+	multi3 := lt80.Intersect(&evalCtx, multi2)
+	test(t, &evalCtx, multi3, ""+
+		"/1: [ - /40]\n"+
+		"/1/2: [/10/15 - ]\n"+
+		"/2: [ - /80)\n")
+
+	multi3 = multi2.Intersect(&evalCtx, lt80)
+	test(t, &evalCtx, multi3, ""+
+		"/1: [ - /40]\n"+
+		"/1/2: [/10/15 - ]\n"+
+		"/2: [ - /80)\n")
+
+	// Mismatched number of constraints in each set.
+	eq10 := NewForColumn(1, &data.spEq10)
+	mismatched := eq10.Intersect(&evalCtx, multi3)
+	test(t, &evalCtx, mismatched, ""+
+		"/1: [/10 - /10]\n"+
+		"/1/2: [/10/15 - ]\n"+
+		"/2: [ - /80)\n")
+
+	mismatched = multi3.Intersect(&evalCtx, eq10)
+	test(t, &evalCtx, mismatched, ""+
+		"/1: [/10 - /10]\n"+
+		"/1/2: [/10/15 - ]\n"+
+		"/2: [ - /80)\n")
+
+	// Multiple intersecting constraints on different columns.
+	diffCols := eq10.Intersect(&evalCtx, NewForColumn(2, &data.spGt20))
+	res := diffCols.Intersect(&evalCtx, multi3)
+	test(t, &evalCtx, res, ""+
+		"/1: [/10 - /10]\n"+
+		"/1/2: [/10/15 - ]\n"+
+		"/2: (/20 - /80)\n")
+
+	res = multi3.Intersect(&evalCtx, diffCols)
+	test(t, &evalCtx, res, ""+
+		"/1: [/10 - /10]\n"+
+		"/1/2: [/10/15 - ]\n"+
+		"/2: (/20 - /80)\n")
+
+	// Intersection results in Contradiction.
+	res = eq10.Intersect(&evalCtx, gt20)
+	test(t, &evalCtx, res, "contradiction\n")
+	res = gt20.Intersect(&evalCtx, eq10)
+	test(t, &evalCtx, res, "contradiction\n")
+
+	// Intersect with Unconstrained (identity op).
+	res = range2040.Intersect(&evalCtx, Unconstrained)
+	test(t, &evalCtx, res, "/1: (/20 - /40]\n")
+	res = Unconstrained.Intersect(&evalCtx, range2040)
+	test(t, &evalCtx, res, "/1: (/20 - /40]\n")
+
+	// Intersect with Contradiction (always contradiction).
+	res = eq10.Intersect(&evalCtx, Contradiction)
+	test(t, &evalCtx, res, "contradiction\n")
+	res = Contradiction.Intersect(&evalCtx, eq10)
+	test(t, &evalCtx, res, "contradiction\n")
+}
+
+func TestConstraintSetUnion(t *testing.T) {
+	test := func(t *testing.T, evalCtx *tree.EvalContext, cs *Set, expected string) {
+		t.Helper()
+		if cs.String() != expected {
+			t.Errorf("\nexpected:\n%vactual:\n%v", expected, cs.String())
+		}
+	}
+
+	st := cluster.MakeTestingClusterSettings()
+	evalCtx := tree.MakeTestingEvalContext(st)
+	data := newSpanTestData(&evalCtx)
+
+	// Simple OR case.
+	// @1 > 20
+	gt20 := NewForColumn(1, &data.spGt20)
+	test(t, &evalCtx, gt20, "/1: (/20 - ]\n")
+
+	// @1 = 10
+	eq10 := NewForColumn(1, &data.spEq10)
+	test(t, &evalCtx, eq10, "/1: [/10 - /10]\n")
+
+	// @1 > 20 OR @1 = 10
+	gt20eq10 := gt20.Union(&evalCtx, eq10)
+	test(t, &evalCtx, gt20eq10, "/1: [/10 - /10] (/20 - ]\n")
+	gt20eq10 = eq10.Union(&evalCtx, gt20)
+	test(t, &evalCtx, gt20eq10, "/1: [/10 - /10] (/20 - ]\n")
+
+	// Combine constraints that result in full span and unconstrained result.
+	// @1 > 20 OR @1 = 10 OR @1 <= 40
+	le40 := NewForColumn(1, &data.spLe40)
+	res := gt20eq10.Union(&evalCtx, le40)
+	test(t, &evalCtx, res, "unconstrained\n")
+	res = le40.Union(&evalCtx, gt20eq10)
+	test(t, &evalCtx, res, "unconstrained\n")
+
+	// Include constraint on multiple columns and union with itself.
+	// (@1, @2) >= (10, 15)
+	gt1015 := NewForColumns([]opt.ColumnIndex{1, 2}, &data.spGe1015)
+	res = gt1015.Union(&evalCtx, gt1015)
+	test(t, &evalCtx, res, "/1/2: [/10/15 - ]\n")
+
+	// Union incompatible constraints (both are discarded).
+	// (@1, @2) >= (10, 15) OR @2 < 80
+	lt80 := NewForColumn(2, &data.spLt80)
+	res = gt1015.Union(&evalCtx, lt80)
+	test(t, &evalCtx, res, "unconstrained\n")
+	res = lt80.Union(&evalCtx, gt1015)
+	test(t, &evalCtx, res, "unconstrained\n")
+
+	// Union two sets with multiple and differing numbers of constraints.
+	// ((@1, @2) >= (10, 15) AND @2 < 80 AND @1 > 20) OR (@1 = 10 AND @2 = 80)
+	multi3 := gt1015.Intersect(&evalCtx, lt80)
+	multi3 = multi3.Intersect(&evalCtx, gt20)
+
+	eq80 := NewForColumn(2, &data.spEq80)
+	multi2 := eq10.Intersect(&evalCtx, eq80)
+
+	res = multi3.Union(&evalCtx, multi2)
+	test(t, &evalCtx, res, ""+
+		"/1: [/10 - /10] (/20 - ]\n"+
+		"/2: [ - /80]\n")
+	res = multi2.Union(&evalCtx, multi3)
+	test(t, &evalCtx, res, ""+
+		"/1: [/10 - /10] (/20 - ]\n"+
+		"/2: [ - /80]\n")
+
+	// Do same as previous, but in different order so that discarded constraint
+	// is at end of list rather than beginning.
+	// (@1 > 20 AND @2 < 80 AND (@1, @2) >= (10, 15)) OR (@1 = 10 AND @2 = 80)
+	multi3 = gt20.Intersect(&evalCtx, lt80)
+	multi3 = multi3.Intersect(&evalCtx, gt1015)
+
+	res = multi3.Union(&evalCtx, multi2)
+	test(t, &evalCtx, res, ""+
+		"/1: [/10 - /10] (/20 - ]\n"+
+		"/2: [ - /80]\n")
+	res = multi2.Union(&evalCtx, multi3)
+	test(t, &evalCtx, res, ""+
+		"/1: [/10 - /10] (/20 - ]\n"+
+		"/2: [ - /80]\n")
+
+	// Union with Unconstrained (always unconstrained).
+	res = gt20.Union(&evalCtx, Unconstrained)
+	test(t, &evalCtx, res, "unconstrained\n")
+	res = Unconstrained.Union(&evalCtx, gt20)
+	test(t, &evalCtx, res, "unconstrained\n")
+
+	// Union with Contradiction (identity op).
+	res = eq10.Union(&evalCtx, Contradiction)
+	test(t, &evalCtx, res, "/1: [/10 - /10]\n")
+	res = Contradiction.Union(&evalCtx, eq10)
+	test(t, &evalCtx, res, "/1: [/10 - /10]\n")
+}
+
+type spanTestData struct {
+	spEq10   Span // [/10 - /10]
+	spGt20   Span // (/20 - ]
+	spLe40   Span // [ - /40]
+	spLt80   Span // [ - /80)
+	spEq80   Span // [/80 - /80]
+	spGe1015 Span // [/10/15 - ]
+}
+
+func newSpanTestData(evalCtx *tree.EvalContext) *spanTestData {
+	data := &spanTestData{}
+
+	key10 := MakeKey(tree.NewDInt(10))
+	key15 := MakeKey(tree.NewDInt(15))
+	key20 := MakeKey(tree.NewDInt(20))
+	key40 := MakeKey(tree.NewDInt(40))
+	key80 := MakeKey(tree.NewDInt(80))
+
+	// [/10 - /10]
+	data.spEq10.Set(evalCtx, key10, IncludeBoundary, key10, IncludeBoundary)
+
+	// (/20 - ]
+	data.spGt20.Set(evalCtx, key20, ExcludeBoundary, EmptyKey, IncludeBoundary)
+
+	// [ - /40]
+	data.spLe40.Set(evalCtx, EmptyKey, IncludeBoundary, key40, IncludeBoundary)
+
+	// [ - /80)
+	data.spLt80.Set(evalCtx, EmptyKey, IncludeBoundary, key80, ExcludeBoundary)
+
+	// [/80 - /80]
+	data.spEq80.Set(evalCtx, key80, IncludeBoundary, key80, IncludeBoundary)
+
+	// [/10/15 - ]
+	key1015 := key10.Concat(key15)
+	data.spGe1015.Set(evalCtx, key1015, IncludeBoundary, EmptyKey, IncludeBoundary)
+
+	return data
+}

--- a/pkg/sql/opt/constraint/constraint_test.go
+++ b/pkg/sql/opt/constraint/constraint_test.go
@@ -1,0 +1,248 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package constraint
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/opt"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+)
+
+func TestConstraintUnion(t *testing.T) {
+	test := func(t *testing.T, evalCtx *tree.EvalContext, left, right *Constraint, expected string) {
+		t.Helper()
+		clone := *left
+		ok := clone.tryUnionWith(evalCtx, right)
+
+		var actual string
+		if ok {
+			actual = clone.String()
+		}
+
+		if actual != expected {
+			format := "left: %s, right: %s, expected: %v, actual: %v"
+			t.Errorf(format, left.String(), right.String(), expected, actual)
+		}
+	}
+
+	st := cluster.MakeTestingClusterSettings()
+	evalCtx := tree.MakeTestingEvalContext(st)
+	data := newConstraintTestData(&evalCtx)
+
+	// Union constraint with itself.
+	test(t, &evalCtx, &data.c1to10, &data.c1to10, "/1: [/1 - /10]")
+
+	// Merge first spans in each constraint.
+	test(t, &evalCtx, &data.c1to10, &data.c5to25, "/1: [/1 - /25)")
+	test(t, &evalCtx, &data.c5to25, &data.c1to10, "/1: [/1 - /25)")
+
+	// Disjoint spans in each constraint.
+	test(t, &evalCtx, &data.c1to10, &data.c40to50, "/1: [/1 - /10] [/40 - /50]")
+	test(t, &evalCtx, &data.c40to50, &data.c1to10, "/1: [/1 - /10] [/40 - /50]")
+
+	// Adjacent disjoint spans in each constraint.
+	test(t, &evalCtx, &data.c20to30, &data.c30to40, "/1: [/20 - /40]")
+	test(t, &evalCtx, &data.c30to40, &data.c20to30, "/1: [/20 - /40]")
+
+	// Merge multiple spans down to single span.
+	var left, right Constraint
+	left = data.c1to10
+	_ = left.tryUnionWith(&evalCtx, &data.c20to30)
+	_ = left.tryUnionWith(&evalCtx, &data.c40to50)
+
+	right = data.c5to25
+	_ = right.tryUnionWith(&evalCtx, &data.c30to40)
+
+	test(t, &evalCtx, &left, &right, "/1: [/1 - /50]")
+	test(t, &evalCtx, &right, &left, "/1: [/1 - /50]")
+
+	// Multiple disjoint spans on each side.
+	left = data.c1to10
+	_ = left.tryUnionWith(&evalCtx, &data.c20to30)
+
+	right = data.c40to50
+	_ = right.tryUnionWith(&evalCtx, &data.c60to70)
+
+	test(t, &evalCtx, &left, &right, "/1: [/1 - /10] [/20 - /30) [/40 - /50] (/60 - /70)")
+	test(t, &evalCtx, &right, &left, "/1: [/1 - /10] [/20 - /30) [/40 - /50] (/60 - /70)")
+
+	// Multiple spans that yield the unconstrained span (should return ok=false
+	// and not modify either span).
+	left = data.cLt10
+	right = data.c5to25
+	_ = right.tryUnionWith(&evalCtx, &data.cGt20)
+
+	test(t, &evalCtx, &left, &right, "")
+	test(t, &evalCtx, &right, &left, "")
+
+	if left.String() != "/1: [ - /10)" {
+		t.Errorf("tryUnionWith failed, but still modified one of the spans: %v", left.String())
+	}
+	if right.String() != "/1: (/5 - ]" {
+		t.Errorf("tryUnionWith failed, but still modified one of the spans: %v", right.String())
+	}
+
+	// Multiple columns.
+	expected := "/1/2: [/'cherry'/true - /'strawberry']"
+	test(t, &evalCtx, &data.cherryRaspberry, &data.mangoStrawberry, expected)
+	test(t, &evalCtx, &data.mangoStrawberry, &data.cherryRaspberry, expected)
+}
+
+func TestConstraintIntersect(t *testing.T) {
+	test := func(t *testing.T, evalCtx *tree.EvalContext, left, right *Constraint, expected string) {
+		t.Helper()
+		clone := *left
+		ok := clone.tryIntersectWith(evalCtx, right)
+
+		var actual string
+		if ok {
+			actual = clone.String()
+		}
+
+		if actual != expected {
+			format := "left: %s, right: %s, expected: %v, actual: %v"
+			t.Errorf(format, left.String(), right.String(), expected, actual)
+		}
+	}
+
+	st := cluster.MakeTestingClusterSettings()
+	evalCtx := tree.MakeTestingEvalContext(st)
+	data := newConstraintTestData(&evalCtx)
+
+	// Intersect constraint with itself.
+	test(t, &evalCtx, &data.c1to10, &data.c1to10, "/1: [/1 - /10]")
+
+	// Intersect first spans in each constraint.
+	test(t, &evalCtx, &data.c1to10, &data.c5to25, "/1: (/5 - /10]")
+	test(t, &evalCtx, &data.c5to25, &data.c1to10, "/1: (/5 - /10]")
+
+	// Disjoint spans in each constraint.
+	test(t, &evalCtx, &data.c1to10, &data.c40to50, "")
+	test(t, &evalCtx, &data.c40to50, &data.c1to10, "")
+
+	// Intersect multiple spans.
+	var left, right Constraint
+	left = data.c1to10
+	_ = left.tryUnionWith(&evalCtx, &data.c20to30)
+	_ = left.tryUnionWith(&evalCtx, &data.c40to50)
+
+	right = data.c5to25
+	_ = right.tryUnionWith(&evalCtx, &data.c30to40)
+
+	test(t, &evalCtx, &right, &left, "/1: (/5 - /10] [/20 - /25) [/40 - /40]")
+	test(t, &evalCtx, &left, &right, "/1: (/5 - /10] [/20 - /25) [/40 - /40]")
+
+	// Intersect multiple disjoint spans (should return ok=false and not
+	// modify either span).
+	left = data.c1to10
+	_ = left.tryUnionWith(&evalCtx, &data.c20to30)
+
+	right = data.c40to50
+	_ = right.tryUnionWith(&evalCtx, &data.c60to70)
+
+	test(t, &evalCtx, &left, &right, "")
+	test(t, &evalCtx, &right, &left, "")
+
+	if left.String() != "/1: [/1 - /10] [/20 - /30)" {
+		t.Errorf("tryIntersectWith failed, but still modified one of the spans: %v", left.String())
+	}
+	if right.String() != "/1: [/40 - /50] (/60 - /70)" {
+		t.Errorf("tryIntersectWith failed, but still modified one of the spans: %v", right.String())
+	}
+
+	// Multiple columns.
+	expected := "/1/2: [/'mango'/false - /'raspberry'/false)"
+	test(t, &evalCtx, &data.cherryRaspberry, &data.mangoStrawberry, expected)
+	test(t, &evalCtx, &data.mangoStrawberry, &data.cherryRaspberry, expected)
+}
+
+type constraintTestData struct {
+	cLt10           Constraint // [ - /10)
+	cGt20           Constraint // (/20 - ]
+	c1to10          Constraint // [/1 - /10]
+	c5to25          Constraint // (/5 - /25)
+	c20to30         Constraint // [/20 - /30)
+	c30to40         Constraint // [/30 - /40]
+	c40to50         Constraint // [/40 - /50]
+	c60to70         Constraint // (/60 - /70)
+	cherryRaspberry Constraint // [/'cherry'/true - /'raspberry'/false)
+	mangoStrawberry Constraint // [/'mango'/false - /'strawberry']
+}
+
+func newConstraintTestData(evalCtx *tree.EvalContext) *constraintTestData {
+	data := &constraintTestData{}
+
+	key1 := MakeKey(tree.NewDInt(1))
+	key5 := MakeKey(tree.NewDInt(5))
+	key10 := MakeKey(tree.NewDInt(10))
+	key20 := MakeKey(tree.NewDInt(20))
+	key25 := MakeKey(tree.NewDInt(25))
+	key30 := MakeKey(tree.NewDInt(30))
+	key40 := MakeKey(tree.NewDInt(40))
+	key50 := MakeKey(tree.NewDInt(50))
+	key60 := MakeKey(tree.NewDInt(60))
+	key70 := MakeKey(tree.NewDInt(70))
+
+	cherry := MakeCompositeKey(tree.NewDString("cherry"), tree.DBoolTrue)
+	mango := MakeCompositeKey(tree.NewDString("mango"), tree.DBoolFalse)
+	raspberry := MakeCompositeKey(tree.NewDString("raspberry"), tree.DBoolFalse)
+	strawberry := MakeKey(tree.NewDString("strawberry"))
+
+	var span Span
+
+	// [ - /10)
+	span.Set(evalCtx, EmptyKey, IncludeBoundary, key10, ExcludeBoundary)
+	data.cLt10.init(1, &span)
+
+	// (/20 - ]
+	span.Set(evalCtx, key20, ExcludeBoundary, EmptyKey, IncludeBoundary)
+	data.cGt20.init(1, &span)
+
+	// [/1 - /10]
+	span.Set(evalCtx, key1, IncludeBoundary, key10, IncludeBoundary)
+	data.c1to10.init(1, &span)
+
+	// (/5 - /25)
+	span.Set(evalCtx, key5, ExcludeBoundary, key25, ExcludeBoundary)
+	data.c5to25.init(1, &span)
+
+	// [/20 - /30)
+	span.Set(evalCtx, key20, IncludeBoundary, key30, ExcludeBoundary)
+	data.c20to30.init(1, &span)
+
+	// [/30 - /40]
+	span.Set(evalCtx, key30, IncludeBoundary, key40, IncludeBoundary)
+	data.c30to40.init(1, &span)
+
+	// [/40 - /50]
+	span.Set(evalCtx, key40, IncludeBoundary, key50, IncludeBoundary)
+	data.c40to50.init(1, &span)
+
+	// (/60 - /70)
+	span.Set(evalCtx, key60, ExcludeBoundary, key70, ExcludeBoundary)
+	data.c60to70.init(1, &span)
+
+	// [/'cherry'/true - /'raspberry'/false)
+	span.Set(evalCtx, cherry, IncludeBoundary, raspberry, ExcludeBoundary)
+	data.cherryRaspberry.initComposite([]opt.ColumnIndex{1, 2}, &span)
+
+	// [/'mango'/false - /'strawberry']
+	span.Set(evalCtx, mango, IncludeBoundary, strawberry, IncludeBoundary)
+	data.mangoStrawberry.initComposite([]opt.ColumnIndex{1, 2}, &span)
+
+	return data
+}

--- a/pkg/sql/opt/constraint/key.go
+++ b/pkg/sql/opt/constraint/key.go
@@ -1,0 +1,171 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package constraint
+
+import (
+	"bytes"
+	"fmt"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+)
+
+// EmptyKey has zero values. If it's a start key, then it sorts before all
+// other keys. If it's an end key, then it sorts after all other keys.
+var EmptyKey = Key{}
+
+// Key is a composite of N typed datum values that are ordered from most
+// significant to least significant for purposes of sorting. The datum values
+// correspond to a set of columns; it is the responsibility of the calling code
+// to keep track of them.
+type Key struct {
+	// firstVal stores the first value in the key. Subsequent values are stored
+	// in otherVals. Inlining the first value avoids an extra allocation in the
+	// common case of a single value in the key.
+	firstVal tree.Datum
+
+	// otherVals is an ordered list of typed datum values. It only stores values
+	// after the first, and is nil if there is <= 1 value.
+	otherVals tree.Datums
+}
+
+// MakeKey constructs a simple one dimensional key having the given value. If
+// val is nil, then MakeKey returns an empty key.
+func MakeKey(val tree.Datum) Key {
+	return Key{firstVal: val}
+}
+
+// MakeCompositeKey constructs an N-dimensional key from the given slice of
+// values.
+func MakeCompositeKey(vals ...tree.Datum) Key {
+	switch len(vals) {
+	case 0:
+		return Key{}
+	case 1:
+		return Key{firstVal: vals[0]}
+	}
+	return Key{firstVal: vals[0], otherVals: vals[1:]}
+}
+
+// IsEmpty is true if this key has zero values.
+func (k Key) IsEmpty() bool {
+	return k.firstVal == nil
+}
+
+// Length returns the number of values in the key. If the count is zero, then
+// this is an empty key.
+func (k Key) Length() int {
+	if k.IsEmpty() {
+		return 0
+	}
+	return 1 + len(k.otherVals)
+}
+
+// Value returns the nth value of the key. If the index is out-of-range, then
+// Value will panic.
+func (k Key) Value(nth int) tree.Datum {
+	if k.firstVal != nil && nth == 0 {
+		return k.firstVal
+	}
+	return k.otherVals[nth-1]
+}
+
+// Compare returns an integer indicating the ordering of the two keys. The
+// result will be 0 if the keys are equal, -1 if this key is less than the
+// given key, or 1 if this key is greater.
+//
+// Comparisons between keys where one key is a prefix of the other have special
+// handling which can be controlled via the key extension parameters. Key
+// extensions specify whether each key is conceptually suffixed with negative
+// or positive infinity for purposes of comparison. For example, if k is /1/2,
+// then:
+//   k (kExt = ExtendLow) : /1/2/Low
+//   k (kExt = ExtendHigh): /1/2/High
+//
+// These extensions have no effect if one key is not a prefix of the other,
+// since the comparison would already have concluded in previous values. But
+// if comparison proceeds all the way to the end of one of the keys, then the
+// extension determines which key is greater. This enables correct comparison
+// of start and end keys in spans which may be either inclusive or exclusive.
+// Here is the mapping:
+//   [/1/2 - ...] (inclusive start key): ExtendLow : /1/2/Low
+//   (/1/2 - ...] (exclusive start key): ExtendHigh: /1/2/High
+//   [... - /1/2] (inclusive end key)  : ExtendHigh: /1/2/High
+//   [... - /1/2) (exclusive end key)  : ExtendLow : /1/2/Low
+func (k Key) Compare(evalCtx *tree.EvalContext, l Key, kext, lext KeyExtension) int {
+	klen := k.Length()
+	llen := l.Length()
+	for i := 0; i < klen && i < llen; i++ {
+		if cmp := k.Value(i).Compare(evalCtx, l.Value(i)); cmp != 0 {
+			return cmp
+		}
+	}
+
+	if klen < llen {
+		// k matches a prefix of l:
+		//   k = /1
+		//   l = /1/2
+		// Which of these is "smaller" depends on whether k is extended with
+		// -inf or with +inf:
+		//   k (ExtendLow)  = /1/Low  < /1/2  ->  k is smaller (-1)
+		//   k (ExtendHigh) = /1/High > /1/2  ->  k is bigger  (1)
+		return kext.ToCmp()
+	} else if klen > llen {
+		// Inverse case of above.
+		return -lext.ToCmp()
+	}
+
+	// Equal keys:
+	//   k (ExtendLow)  vs. l (ExtendLow)   ->  equal   (0)
+	//   k (ExtendLow)  vs. l (ExtendHigh)  ->  smaller (-1)
+	//   k (ExtendHigh) vs. l (ExtendLow)   ->  bigger  (1)
+	//   k (ExtendHigh) vs. l (ExtendHigh)  ->  equal   (0)
+	if kext == lext {
+		return 0
+	}
+	return kext.ToCmp()
+}
+
+// Concat creates a new composite key by extending this key's values with the
+// values of the given key. The new key's length is len(k) + len(l).
+func (k Key) Concat(l Key) Key {
+	klen := k.Length()
+	llen := l.Length()
+
+	if klen == 0 {
+		return l
+	}
+	if llen == 0 {
+		return k
+	}
+
+	vals := make(tree.Datums, klen+llen-1)
+	copy(vals, k.otherVals)
+	vals[klen-1] = l.firstVal
+	copy(vals[klen:], l.otherVals)
+	return Key{firstVal: k.firstVal, otherVals: vals}
+}
+
+// String formats a key like this:
+//  EmptyKey         : empty string
+//  Key with 1 value : /2
+//  Key with 2 values: /5/1
+//  Key with 3 values: /3/6/4
+func (k Key) String() string {
+	var buf bytes.Buffer
+	for i := 0; i < k.Length(); i++ {
+		fmt.Fprintf(&buf, "/%s", k.Value(i))
+	}
+	return buf.String()
+}

--- a/pkg/sql/opt/constraint/key_extension.go
+++ b/pkg/sql/opt/constraint/key_extension.go
@@ -1,0 +1,43 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package constraint
+
+// KeyExtension is an enumeration used when comparing keys. Key extensions
+// specify whether each key is conceptually suffixed with a value that sorts
+// before all values (ExtendLow) or with a value that sorts after all values
+// (ExtendHigh). This allows span boundaries to be compared with one another.
+// See the comment for the Key.Compare method for more details.
+type KeyExtension bool
+
+const (
+	// ExtendLow specifies that the key is conceptually suffixed with a value
+	// that sorts before all values for purposes of comparison.
+	ExtendLow KeyExtension = false
+
+	// ExtendHigh specifies that the key is conceptually suffixed with a value
+	// that sorts after all values for purposes of comparison.
+	ExtendHigh KeyExtension = true
+)
+
+// ToCmp converts from a key extension value to a comparison value. ExtendLow
+// maps to -1 because it sorts before all other values. ExtendHigh maps to 1
+// because it sorts after all other values.
+func (e KeyExtension) ToCmp() int {
+	// Map ExtendLow into -1 and ExtendHigh into +1.
+	if e == ExtendLow {
+		return -1
+	}
+	return 1
+}

--- a/pkg/sql/opt/constraint/key_test.go
+++ b/pkg/sql/opt/constraint/key_test.go
@@ -1,0 +1,127 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// This file implements data structures used by index constraints generation.
+
+package constraint
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+)
+
+func TestKey(t *testing.T) {
+	testKey(t, EmptyKey, "")
+
+	k := MakeKey(tree.NewDInt(1))
+	testKey(t, k, "/1")
+
+	k = MakeCompositeKey(tree.NewDInt(2))
+	testKey(t, k, "/2")
+
+	k = MakeCompositeKey(tree.NewDString("foo"), tree.NewDInt(3))
+	testKey(t, k, "/'foo'/3")
+}
+
+func TestKeyCompare(t *testing.T) {
+	test := func(
+		t *testing.T, evalCtx *tree.EvalContext, k, l Key, kExt, lExt KeyExtension, expected int,
+	) {
+		t.Helper()
+		if actual := k.Compare(evalCtx, l, kExt, lExt); actual != expected {
+			t.Errorf("k: %s, l %s, expected: %d, actual: %d", k, l, expected, actual)
+		}
+	}
+
+	st := cluster.MakeTestingClusterSettings()
+	evalCtx := tree.MakeTestingEvalContext(st)
+
+	key0 := MakeKey(tree.NewDInt(0))
+	key1 := MakeKey(tree.NewDInt(1))
+	key01 := MakeCompositeKey(tree.NewDInt(0), tree.NewDInt(1))
+	keyNull := MakeKey(tree.DNull)
+
+	test(t, &evalCtx, EmptyKey, keyNull, ExtendLow, ExtendLow, -1)
+	test(t, &evalCtx, EmptyKey, keyNull, ExtendLow, ExtendHigh, -1)
+	test(t, &evalCtx, EmptyKey, keyNull, ExtendHigh, ExtendLow, 1)
+	test(t, &evalCtx, EmptyKey, keyNull, ExtendHigh, ExtendHigh, 1)
+
+	test(t, &evalCtx, key0, key0, ExtendLow, ExtendLow, 0)
+	test(t, &evalCtx, key0, key0, ExtendLow, ExtendHigh, -1)
+	test(t, &evalCtx, key0, key0, ExtendHigh, ExtendLow, 1)
+	test(t, &evalCtx, key0, key0, ExtendHigh, ExtendHigh, 0)
+
+	test(t, &evalCtx, key0, key1, ExtendLow, ExtendLow, -1)
+	test(t, &evalCtx, key0, key1, ExtendLow, ExtendHigh, -1)
+	test(t, &evalCtx, key0, key1, ExtendHigh, ExtendLow, -1)
+	test(t, &evalCtx, key0, key1, ExtendHigh, ExtendHigh, -1)
+
+	test(t, &evalCtx, key1, key0, ExtendLow, ExtendLow, 1)
+	test(t, &evalCtx, key1, key0, ExtendLow, ExtendHigh, 1)
+	test(t, &evalCtx, key1, key0, ExtendHigh, ExtendLow, 1)
+	test(t, &evalCtx, key1, key0, ExtendHigh, ExtendHigh, 1)
+
+	test(t, &evalCtx, key01, key0, ExtendLow, ExtendLow, 1)
+	test(t, &evalCtx, key01, key0, ExtendLow, ExtendHigh, -1)
+	test(t, &evalCtx, key01, key0, ExtendHigh, ExtendLow, 1)
+	test(t, &evalCtx, key01, key0, ExtendHigh, ExtendHigh, -1)
+
+	test(t, &evalCtx, key0, key01, ExtendLow, ExtendLow, -1)
+	test(t, &evalCtx, key0, key01, ExtendLow, ExtendHigh, -1)
+	test(t, &evalCtx, key0, key01, ExtendHigh, ExtendLow, 1)
+	test(t, &evalCtx, key0, key01, ExtendHigh, ExtendHigh, 1)
+
+	test(t, &evalCtx, keyNull, key0, ExtendHigh, ExtendLow, -1)
+}
+
+func TestKeyConcat(t *testing.T) {
+	k := EmptyKey
+
+	// Empty + empty.
+	k = k.Concat(EmptyKey)
+	testKey(t, k, "")
+
+	// Empty + single value.
+	k = k.Concat(MakeKey(tree.NewDInt(1)))
+	testKey(t, k, "/1")
+
+	// Single value + empty.
+	k = k.Concat(EmptyKey)
+	testKey(t, k, "/1")
+
+	// Single value + single value.
+	k = k.Concat(MakeKey(tree.NewDInt(2)))
+	testKey(t, k, "/1/2")
+
+	// Multiple values + empty.
+	k = k.Concat(EmptyKey)
+	testKey(t, k, "/1/2")
+
+	// Multiple values + single value.
+	k = k.Concat(MakeKey(tree.NewDInt(3)))
+	testKey(t, k, "/1/2/3")
+
+	// Multiple values + multiple values.
+	k = k.Concat(MakeCompositeKey(tree.NewDString("bar"), tree.DBoolTrue))
+	testKey(t, k, "/1/2/3/'bar'/true")
+}
+
+func testKey(t *testing.T, k Key, expected string) {
+	t.Helper()
+	if k.String() != expected {
+		t.Errorf("expected: %s, actual: %s", expected, k.String())
+	}
+}

--- a/pkg/sql/opt/constraint/span.go
+++ b/pkg/sql/opt/constraint/span.go
@@ -1,0 +1,294 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package constraint
+
+import (
+	"bytes"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+)
+
+// SpanBoundary specifies whether a span endpoint is inclusive or exclusive of
+// its start or end key. An inclusive boundary is represented as '[' and an
+// exclusive boundary is represented as ')'. Examples:
+//   [/0 - /1]  (inclusive, inclusive)
+//   [/1 - /10) (inclusive, exclusive)
+type SpanBoundary bool
+
+const (
+	// IncludeBoundary indicates that the boundary does include the respective
+	// key.
+	IncludeBoundary SpanBoundary = false
+
+	// ExcludeBoundary indicates that the boundary does not include the
+	// respective key.
+	ExcludeBoundary SpanBoundary = true
+)
+
+// Span represents the range between two composite keys. The end keys of the
+// range can be inclusive or exclusive. Each key value within the range is
+// an N-tuple of datum values, one for each constrained column. Here are some
+// examples:
+//   @1 < 100                                          : [ - /100)
+//   @1 >= 100                                         : [/100 - ]
+//   @1 >= 1 AND @1 <= 10                              : [/1 - /10]
+//   (@1 = 100 AND @2 > 10) OR (@1 > 100 AND @1 <= 101): (/100/10 - /101]
+type Span struct {
+	// Start is the starting boundary for the span.
+	start Key
+
+	// End is the ending boundary for the span.
+	end Key
+
+	// startBoundary indicates whether the span contains the start key value.
+	startBoundary SpanBoundary
+
+	// endBoundary indicates whether the span contains the the end key value.
+	endBoundary SpanBoundary
+}
+
+// IsUnconstrained is true if the span does not constrain the key range. Both
+// the start and end boundaries are empty. This is the default state of a Span
+// before Set is called. Unconstrained spans cannot be used in constraints,
+// since the absence of a constraint is equivalent to an unconstrained span.
+func (sp *Span) IsUnconstrained() bool {
+	return sp.start.IsEmpty() && sp.end.IsEmpty()
+}
+
+// Set sets the boundaries of this span to the given values. The following
+// spans are not allowed (causes panic):
+//  1. Empty span (should never be used in a constraint)
+//  2. Unconstrained span (should never be used in a constraint)
+//  3. Exclusive empty key boundary (use inclusive instead)
+func (sp *Span) Set(
+	evalCtx *tree.EvalContext,
+	start Key,
+	startBoundary SpanBoundary,
+	end Key,
+	endBoundary SpanBoundary,
+) {
+	if start.IsEmpty() {
+		if end.IsEmpty() {
+			// Constraint should be discarded rather than using unconstrained
+			// span, because absence of constraint implies unconstrained span.
+			panic("unconstrained span should never be used")
+		}
+		if startBoundary == ExcludeBoundary {
+			// Enforce one representation for empty boundary.
+			panic("an empty start boundary must be inclusive")
+		}
+	} else if end.IsEmpty() {
+		if endBoundary == ExcludeBoundary {
+			// Enforce one representation for empty boundary.
+			panic("an empty end boundary must be inclusive")
+		}
+	}
+
+	sp.start = start
+	sp.startBoundary = startBoundary
+	sp.end = end
+	sp.endBoundary = endBoundary
+
+	// Ensure that start boundary is less than end boundary.
+	if sp.start.Compare(evalCtx, sp.end, sp.startExt(), sp.endExt()) >= 0 {
+		panic("span cannot be empty")
+	}
+}
+
+// Compare returns an integer indicating the ordering of the two spans. The
+// result will be 0 if the spans are equal, -1 if this span is less than the
+// given span, or 1 if this span is greater. Spans are first compared based on
+// their start boundaries. If those are equal, then their end boundaries are
+// compared. An inclusive start boundary is less than an exclusive start
+// boundary, and an exclusive end boundary is less than an inclusive end
+// boundary. Here are examples of how various spans are ordered, with
+// equivalent extended keys shown as well (see Key.Compare comment):
+//   [     - /2  )  =  /Low      - /2/Low
+//   [     - /2/1)  =  /Low      - /2/1/Low
+//   [     - /2/1]  =  /Low      - /2/1/High
+//   [     - /2  ]  =  /Low      - /2/High
+//   [     -     ]  =  /Low      - /High
+//   [/1   - /2/1)  =  /1/Low    - /2/1/Low
+//   [/1   - /2/1]  =  /1/Low    - /2/1/High
+//   [/1   -     ]  =  /1/Low    - /High
+//   [/1/1 - /2  )  =  /1/1/Low  - /2/Low
+//   [/1/1 - /2  ]  =  /1/1/Low  - /2/High
+//   [/1/1 -     ]  =  /1/1/Low  - /High
+//   (/1/1 - /2  )  =  /1/1/High - /2/Low
+//   (/1/1 - /2  ]  =  /1/1/High - /2/High
+//   (/1/1 -     ]  =  /1/1/High - /High
+//   (/1   - /2/1)  =  /1/High   - /2/1/Low
+//   (/1   - /2/1]  =  /1/High   - /2/1/High
+//   (/1   -     ]  =  /1/High   - /High
+func (sp *Span) Compare(evalCtx *tree.EvalContext, other *Span) int {
+	// Span with lowest start boundary is less than the other.
+	if cmp := sp.CompareStarts(evalCtx, other); cmp != 0 {
+		return cmp
+	}
+
+	// Start boundary is same, so span with lowest end boundary is less than
+	// the other.
+	if cmp := sp.CompareEnds(evalCtx, other); cmp != 0 {
+		return cmp
+	}
+
+	// End boundary is same as well, so spans are the same.
+	return 0
+}
+
+// CompareStarts returns an integer indicating the ordering of the start
+// boundaries of the two spans. The result will be 0 if the spans have the same
+// start boundary, -1 if this span has a smaller start boundary than the given
+// span, or 1 if this span has a bigger start boundary than the given span.
+func (sp *Span) CompareStarts(evalCtx *tree.EvalContext, other *Span) int {
+	return sp.start.Compare(evalCtx, other.start, sp.startExt(), other.startExt())
+}
+
+// CompareEnds returns an integer indicating the ordering of the end boundaries
+// of the two spans. The result will be 0 if the spans have the same end
+// boundary, -1 if this span has a smaller end boundary than the given span, or
+// 1 if this span has a bigger end boundary than the given span.
+func (sp *Span) CompareEnds(evalCtx *tree.EvalContext, other *Span) int {
+	return sp.end.Compare(evalCtx, other.end, sp.endExt(), other.endExt())
+}
+
+// StartsAfter returns true if this span is greater than the given span and
+// does not overlap it. In other words, this span's start boundary is greater
+// or equal to the given span's end boundary.
+func (sp *Span) StartsAfter(evalCtx *tree.EvalContext, other *Span) bool {
+	return sp.start.Compare(evalCtx, other.end, sp.startExt(), other.endExt()) >= 0
+}
+
+// TryIntersectWith finds the overlap between this span and the given span.
+// This span is updated to only cover the range that is common to both spans.
+// If there is no overlap, then this span will not be updated, and
+// TryIntersectWith will return false.
+func (sp *Span) TryIntersectWith(evalCtx *tree.EvalContext, other *Span) bool {
+	cmpStarts := sp.CompareStarts(evalCtx, other)
+	if cmpStarts > 0 {
+		// If this span's start boundary is >= the other span's end boundary,
+		// then intersection is empty.
+		if sp.start.Compare(evalCtx, other.end, sp.startExt(), other.endExt()) >= 0 {
+			return false
+		}
+	}
+
+	cmpEnds := sp.CompareEnds(evalCtx, other)
+	if cmpEnds < 0 {
+		// If this span's end boundary is <= the other span's start boundary,
+		// then intersection is empty.
+		if sp.end.Compare(evalCtx, other.start, sp.endExt(), other.startExt()) <= 0 {
+			return false
+		}
+	}
+
+	// Only update now that it's known that intersection is not empty.
+	if cmpStarts < 0 {
+		sp.start = other.start
+		sp.startBoundary = other.startBoundary
+	}
+	if cmpEnds > 0 {
+		sp.end = other.end
+		sp.endBoundary = other.endBoundary
+	}
+	return true
+}
+
+// TryUnionWith attempts to merge this span with the given span. If the merged
+// spans cannot be expressed as a single span, then TryUnionWith will not
+// update the span and TryUnionWith returns false. This could occur if the
+// spans are disjoint, for example:
+//   [/1 - /5] UNION [/10 - /15]
+//
+// Otherwise, this span is updated to the merged span range and TryUnionWith
+// returns true. If the resulting span does not constrain the range [ - ], then
+// its IsUnconstrained method returns true, and it cannot be used as part of a
+// constraint.
+func (sp *Span) TryUnionWith(evalCtx *tree.EvalContext, other *Span) bool {
+	// Determine the minimum start boundary.
+	cmpStartKeys := sp.CompareStarts(evalCtx, other)
+
+	var cmp int
+	if cmpStartKeys < 0 {
+		// This span is less, so see if there's any "space" after it and before
+		// the start of the other span.
+		cmp = sp.end.Compare(evalCtx, other.start, sp.endExt(), other.startExt())
+	} else if cmpStartKeys > 0 {
+		// This span is greater, so see if there's any "space" before it and
+		// after the end of the other span.
+		cmp = other.end.Compare(evalCtx, sp.start, other.endExt(), sp.startExt())
+	}
+	if cmp < 0 {
+		// There's "space" between spans, so union of these spans can't be
+		// expressed as a single span.
+		return false
+	}
+
+	// Determine the maximum end boundary.
+	cmpEndKeys := sp.CompareEnds(evalCtx, other)
+
+	// Create the merged span.
+	if cmpStartKeys > 0 {
+		sp.start = other.start
+		sp.startBoundary = other.startBoundary
+	}
+	if cmpEndKeys < 0 {
+		sp.end = other.end
+		sp.endBoundary = other.endBoundary
+	}
+	return true
+}
+
+func (sp *Span) startExt() KeyExtension {
+	// Trivial cast of start boundary value:
+	//   IncludeBoundary (false) = ExtendLow (false)
+	//   ExcludeBoundary (true)  = ExtendHigh (true)
+	return KeyExtension(sp.startBoundary)
+}
+
+func (sp *Span) endExt() KeyExtension {
+	// Invert end boundary value:
+	//   IncludeBoundary (false) = ExtendHigh (true)
+	//   ExcludeBoundary (true)  = ExtendLow (false)
+	return KeyExtension(!sp.endBoundary)
+}
+
+// String formats a Span. Inclusivity/exclusivity is shown using
+// brackets/parens. Some examples:
+//   [1 - 2]
+//   (1/1 - 2)
+//   [ - 5/6)
+//   [1 - ]
+//   [ - ]
+func (sp Span) String() string {
+	var buf bytes.Buffer
+	if sp.startBoundary == IncludeBoundary {
+		buf.WriteRune('[')
+	} else {
+		buf.WriteRune('(')
+	}
+
+	buf.WriteString(sp.start.String())
+	buf.WriteString(" - ")
+	buf.WriteString(sp.end.String())
+
+	if sp.endBoundary == IncludeBoundary {
+		buf.WriteRune(']')
+	} else {
+		buf.WriteRune(')')
+	}
+
+	return buf.String()
+}

--- a/pkg/sql/opt/constraint/span_test.go
+++ b/pkg/sql/opt/constraint/span_test.go
@@ -1,0 +1,513 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// This file implements data structures used by index constraints generation.
+
+package constraint
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+)
+
+func TestSpanSet(t *testing.T) {
+	test := func(t *testing.T, sp Span, expected string) {
+		t.Helper()
+		if sp.String() != expected {
+			t.Errorf("expected: %s, actual: %s", expected, sp.String())
+		}
+	}
+
+	testPanic := func(t *testing.T, fn func(), expected string) {
+		t.Helper()
+		defer func() {
+			msg := recover()
+			if msg == nil {
+				t.Errorf("panic expected with message: %s", expected)
+			} else if msg != expected {
+				t.Errorf("expected: %s, actual: %s", expected, msg)
+			}
+		}()
+		fn()
+	}
+
+	st := cluster.MakeTestingClusterSettings()
+	evalCtx := tree.MakeTestingEvalContext(st)
+
+	var sp Span
+	sp.Set(
+		&evalCtx,
+		MakeKey(tree.NewDInt(1)), IncludeBoundary,
+		MakeKey(tree.NewDInt(5)), IncludeBoundary,
+	)
+	test(t, sp, "[/1 - /5]")
+
+	sp.Set(
+		&evalCtx,
+		MakeCompositeKey(tree.NewDString("cherry"), tree.NewDInt(5)), IncludeBoundary,
+		MakeCompositeKey(tree.NewDString("mango"), tree.NewDInt(1)), ExcludeBoundary,
+	)
+	test(t, sp, "[/'cherry'/5 - /'mango'/1)")
+
+	sp.Set(
+		&evalCtx,
+		MakeCompositeKey(tree.NewDInt(5), tree.NewDInt(1)), ExcludeBoundary,
+		MakeKey(tree.NewDInt(5)), IncludeBoundary,
+	)
+	test(t, sp, "(/5/1 - /5]")
+
+	sp.Set(
+		&evalCtx,
+		MakeKey(tree.NewDInt(5)), IncludeBoundary,
+		MakeCompositeKey(tree.NewDInt(5), tree.NewDInt(1)), ExcludeBoundary,
+	)
+	test(t, sp, "[/5 - /5/1)")
+
+	// Try to create unconstrained span.
+	testPanic(t, func() {
+		sp.Set(&evalCtx, EmptyKey, IncludeBoundary, EmptyKey, IncludeBoundary)
+	}, "unconstrained span should never be used")
+
+	// Create exclusive empty start boundary.
+	testPanic(t, func() {
+		sp.Set(&evalCtx, EmptyKey, ExcludeBoundary, MakeKey(tree.DNull), IncludeBoundary)
+	}, "an empty start boundary must be inclusive")
+
+	// Create exclusive empty end boundary.
+	testPanic(t, func() {
+		sp.Set(&evalCtx, MakeKey(tree.DNull), IncludeBoundary, EmptyKey, ExcludeBoundary)
+	}, "an empty end boundary must be inclusive")
+
+	// Try to create zero-length spans.
+	testPanic(t, func() {
+		sp.Set(
+			&evalCtx,
+			MakeKey(tree.NewDInt(1)), IncludeBoundary,
+			MakeKey(tree.NewDInt(1)), ExcludeBoundary,
+		)
+	}, "span cannot be empty")
+
+	testPanic(t, func() {
+		sp.Set(
+			&evalCtx,
+			MakeCompositeKey(tree.NewDString("cherry"), tree.NewDInt(5)), ExcludeBoundary,
+			MakeCompositeKey(tree.NewDString("cherry"), tree.NewDInt(5)), IncludeBoundary,
+		)
+	}, "span cannot be empty")
+
+	// Try to create spans where start boundary > end boundary.
+	testPanic(t, func() {
+		sp.Set(&evalCtx, MakeKey(tree.NewDInt(0)), IncludeBoundary, MakeKey(tree.DNull), ExcludeBoundary)
+	}, "span cannot be empty")
+
+	testPanic(t, func() {
+		sp.Set(
+			&evalCtx,
+			MakeCompositeKey(tree.NewDString("mango"), tree.NewDInt(1)), IncludeBoundary,
+			MakeCompositeKey(tree.NewDString("cherry"), tree.NewDInt(5)), IncludeBoundary,
+		)
+	}, "span cannot be empty")
+}
+
+func TestSpanUnconstrained(t *testing.T) {
+	st := cluster.MakeTestingClusterSettings()
+	evalCtx := tree.MakeTestingEvalContext(st)
+
+	// Test unconstrained span.
+	unconstrained := Span{}
+	if !unconstrained.IsUnconstrained() {
+		t.Errorf("default span is not unconstrained")
+	}
+
+	if unconstrained.String() != "[ - ]" {
+		t.Errorf("unexpected string value for unconstrained span: %s", unconstrained.String())
+	}
+
+	// Test constrained span's IsUnconstrained method.
+	var sp Span
+	sp.Set(
+		&evalCtx,
+		MakeKey(tree.NewDInt(5)), IncludeBoundary,
+		MakeKey(tree.NewDInt(5)), IncludeBoundary,
+	)
+	if sp.IsUnconstrained() {
+		t.Errorf("IsUnconstrained should have returned false")
+	}
+}
+
+func TestSpanCompare(t *testing.T) {
+	testComp := func(t *testing.T, evalCtx *tree.EvalContext, left, right Span, expected int) {
+		t.Helper()
+		if actual := left.Compare(evalCtx, &right); actual != expected {
+			format := "left: %s, right: %s, expected: %v, actual: %v"
+			t.Errorf(format, left.String(), right.String(), expected, actual)
+		}
+	}
+
+	st := cluster.MakeTestingClusterSettings()
+	evalCtx := tree.MakeTestingEvalContext(st)
+
+	one := MakeKey(tree.NewDInt(1))
+	two := MakeKey(tree.NewDInt(2))
+	oneone := MakeCompositeKey(tree.NewDInt(1), tree.NewDInt(1))
+	twoone := MakeCompositeKey(tree.NewDInt(2), tree.NewDInt(1))
+
+	var spans [17]Span
+
+	// [ - /2)
+	spans[0].Set(&evalCtx, EmptyKey, IncludeBoundary, two, ExcludeBoundary)
+
+	// [ - /2/1)
+	spans[1].Set(&evalCtx, EmptyKey, IncludeBoundary, twoone, ExcludeBoundary)
+
+	// [ - /2/1]
+	spans[2].Set(&evalCtx, EmptyKey, IncludeBoundary, twoone, IncludeBoundary)
+
+	// [ - /2]
+	spans[3].Set(&evalCtx, EmptyKey, IncludeBoundary, two, IncludeBoundary)
+
+	// [ - ]
+	spans[4] = Span{}
+
+	// [/1 - /2/1)
+	spans[5].Set(&evalCtx, one, IncludeBoundary, twoone, ExcludeBoundary)
+
+	// [/1 - /2/1]
+	spans[6].Set(&evalCtx, one, IncludeBoundary, twoone, IncludeBoundary)
+
+	// [/1 - ]
+	spans[7].Set(&evalCtx, one, IncludeBoundary, EmptyKey, IncludeBoundary)
+
+	// [/1/1 - /2)
+	spans[8].Set(&evalCtx, oneone, IncludeBoundary, two, ExcludeBoundary)
+
+	// [/1/1 - /2]
+	spans[9].Set(&evalCtx, oneone, IncludeBoundary, two, IncludeBoundary)
+
+	// [/1/1 - ]
+	spans[10].Set(&evalCtx, oneone, IncludeBoundary, EmptyKey, IncludeBoundary)
+
+	// (/1/1 - /2)
+	spans[11].Set(&evalCtx, oneone, ExcludeBoundary, two, ExcludeBoundary)
+
+	// (/1/1 - /2]
+	spans[12].Set(&evalCtx, oneone, ExcludeBoundary, two, IncludeBoundary)
+
+	// (/1/1 - ]
+	spans[13].Set(&evalCtx, oneone, ExcludeBoundary, EmptyKey, IncludeBoundary)
+
+	// (/1 - /2/1)
+	spans[14].Set(&evalCtx, one, ExcludeBoundary, twoone, ExcludeBoundary)
+
+	// (/1 - /2/1]
+	spans[15].Set(&evalCtx, one, ExcludeBoundary, twoone, IncludeBoundary)
+
+	// (/1 - ]
+	spans[16].Set(&evalCtx, one, ExcludeBoundary, EmptyKey, IncludeBoundary)
+
+	for i := 0; i < len(spans)-1; i++ {
+		testComp(t, &evalCtx, spans[i], spans[i+1], -1)
+		testComp(t, &evalCtx, spans[i+1], spans[i], 1)
+		testComp(t, &evalCtx, spans[i], spans[i], 0)
+		testComp(t, &evalCtx, spans[i+1], spans[i+1], 0)
+	}
+}
+
+func TestSpanCompareStarts(t *testing.T) {
+	test := func(t *testing.T, evalCtx *tree.EvalContext, left, right Span, expected int) {
+		t.Helper()
+		if actual := left.CompareStarts(evalCtx, &right); actual != expected {
+			format := "left: %s, right: %s, expected: %v, actual: %v"
+			t.Errorf(format, left.String(), right.String(), expected, actual)
+		}
+	}
+
+	st := cluster.MakeTestingClusterSettings()
+	evalCtx := tree.MakeTestingEvalContext(st)
+
+	one := MakeKey(tree.NewDInt(1))
+	two := MakeKey(tree.NewDInt(2))
+	five := MakeKey(tree.NewDInt(5))
+	nine := MakeKey(tree.NewDInt(9))
+
+	var onefive Span
+	onefive.Set(&evalCtx, one, IncludeBoundary, five, IncludeBoundary)
+	var twonine Span
+	twonine.Set(&evalCtx, two, ExcludeBoundary, nine, ExcludeBoundary)
+
+	// Same span.
+	test(t, &evalCtx, onefive, onefive, 0)
+
+	// Different spans.
+	test(t, &evalCtx, onefive, twonine, -1)
+	test(t, &evalCtx, twonine, onefive, 1)
+}
+
+func TestSpanCompareEnds(t *testing.T) {
+	test := func(t *testing.T, evalCtx *tree.EvalContext, left, right Span, expected int) {
+		t.Helper()
+		if actual := left.CompareEnds(evalCtx, &right); actual != expected {
+			format := "left: %s, right: %s, expected: %v, actual: %v"
+			t.Errorf(format, left.String(), right.String(), expected, actual)
+		}
+	}
+
+	st := cluster.MakeTestingClusterSettings()
+	evalCtx := tree.MakeTestingEvalContext(st)
+
+	one := MakeKey(tree.NewDInt(1))
+	two := MakeKey(tree.NewDInt(2))
+	five := MakeKey(tree.NewDInt(5))
+	nine := MakeKey(tree.NewDInt(9))
+
+	var onefive Span
+	onefive.Set(&evalCtx, one, IncludeBoundary, five, IncludeBoundary)
+	var twonine Span
+	twonine.Set(&evalCtx, two, ExcludeBoundary, nine, ExcludeBoundary)
+
+	// Same span.
+	test(t, &evalCtx, onefive, onefive, 0)
+
+	// Different spans.
+	test(t, &evalCtx, onefive, twonine, -1)
+	test(t, &evalCtx, twonine, onefive, 1)
+}
+
+func TestSpanStartsAfter(t *testing.T) {
+	test := func(t *testing.T, evalCtx *tree.EvalContext, left, right Span, expected bool) {
+		t.Helper()
+		if actual := left.StartsAfter(evalCtx, &right); actual != expected {
+			format := "left: %s, right: %s, expected: %v, actual: %v"
+			t.Errorf(format, left.String(), right.String(), expected, actual)
+		}
+	}
+
+	st := cluster.MakeTestingClusterSettings()
+	evalCtx := tree.MakeTestingEvalContext(st)
+
+	// Same span.
+	var banana Span
+	banana.Set(
+		&evalCtx,
+		MakeCompositeKey(tree.DNull, tree.NewDInt(100)), IncludeBoundary,
+		MakeCompositeKey(tree.NewDString("banana"), tree.NewDInt(50)), IncludeBoundary,
+	)
+	test(t, &evalCtx, banana, banana, false)
+
+	// Right span's start equal to left span's end.
+	var cherry Span
+	cherry.Set(
+		&evalCtx,
+		MakeCompositeKey(tree.NewDString("banana"), tree.NewDInt(50)), ExcludeBoundary,
+		MakeKey(tree.NewDString("cherry")), ExcludeBoundary,
+	)
+	test(t, &evalCtx, banana, cherry, false)
+	test(t, &evalCtx, cherry, banana, true)
+
+	// Right span's start greater than left span's end, and inverse.
+	var cherry2 Span
+	cherry2.Set(
+		&evalCtx,
+		MakeCompositeKey(tree.NewDString("cherry"), tree.NewDInt(0)), IncludeBoundary,
+		MakeKey(tree.NewDString("mango")), ExcludeBoundary,
+	)
+	test(t, &evalCtx, cherry, cherry2, false)
+	test(t, &evalCtx, cherry2, cherry, true)
+}
+
+func TestSpanIntersect(t *testing.T) {
+	testInt := func(t *testing.T, evalCtx *tree.EvalContext, left, right Span, expected string) {
+		t.Helper()
+		sp := left
+		ok := sp.TryIntersectWith(evalCtx, &right)
+
+		var actual string
+		if ok {
+			actual = sp.String()
+		}
+
+		if actual != expected {
+			format := "left: %s, right: %s, expected: %v, actual: %v"
+			t.Errorf(format, left.String(), right.String(), expected, actual)
+		}
+	}
+
+	st := cluster.MakeTestingClusterSettings()
+	evalCtx := tree.MakeTestingEvalContext(st)
+
+	// Same span.
+	var banana Span
+	banana.Set(
+		&evalCtx,
+		MakeCompositeKey(tree.DNull, tree.NewDInt(100)), IncludeBoundary,
+		MakeCompositeKey(tree.NewDString("banana"), tree.NewDInt(50)), IncludeBoundary,
+	)
+	testInt(t, &evalCtx, banana, banana, "[/NULL/100 - /'banana'/50]")
+
+	// One span immediately after the other.
+	var grape Span
+	grape.Set(
+		&evalCtx,
+		MakeCompositeKey(tree.NewDString("banana"), tree.NewDInt(50)), ExcludeBoundary,
+		MakeCompositeKey(tree.NewDString("grape")), ExcludeBoundary,
+	)
+	testInt(t, &evalCtx, banana, grape, "")
+	testInt(t, &evalCtx, grape, banana, "")
+
+	// Partial overlap.
+	var apple Span
+	apple.Set(
+		&evalCtx,
+		MakeCompositeKey(tree.NewDString("apple"), tree.NewDInt(200)), ExcludeBoundary,
+		MakeCompositeKey(tree.NewDString("cherry"), tree.NewDInt(300)), ExcludeBoundary,
+	)
+	testInt(t, &evalCtx, banana, apple, "(/'apple'/200 - /'banana'/50]")
+	testInt(t, &evalCtx, apple, banana, "(/'apple'/200 - /'banana'/50]")
+
+	// One span is subset of other.
+	var mango Span
+	mango.Set(
+		&evalCtx,
+		MakeCompositeKey(tree.NewDString("apple"), tree.NewDInt(200)), ExcludeBoundary,
+		MakeCompositeKey(tree.NewDString("mango")), ExcludeBoundary,
+	)
+	testInt(t, &evalCtx, apple, mango, "(/'apple'/200 - /'cherry'/300)")
+	testInt(t, &evalCtx, mango, apple, "(/'apple'/200 - /'cherry'/300)")
+	testInt(t, &evalCtx, Span{}, mango, "(/'apple'/200 - /'mango')")
+	testInt(t, &evalCtx, mango, Span{}, "(/'apple'/200 - /'mango')")
+
+	// Spans are disjoint.
+	var pear Span
+	pear.Set(
+		&evalCtx,
+		MakeCompositeKey(tree.NewDString("mango"), tree.NewDInt(0)), IncludeBoundary,
+		MakeCompositeKey(tree.NewDString("pear"), tree.NewDInt(10)), IncludeBoundary,
+	)
+	testInt(t, &evalCtx, mango, pear, "")
+	testInt(t, &evalCtx, pear, mango, "")
+
+	// Ensure that if TryIntersectWith results in empty set, that it does not
+	// update either span.
+	mango2 := mango
+	pear2 := pear
+	mango2.TryIntersectWith(&evalCtx, &pear2)
+	if mango2.Compare(&evalCtx, &mango) != 0 {
+		t.Errorf("mango2 was incorrectly updated during TryIntersectWith")
+	}
+	if pear2.Compare(&evalCtx, &pear) != 0 {
+		t.Errorf("pear2 was incorrectly updated during TryIntersectWith")
+	}
+
+	// Partial overlap on second key.
+	pear2.Set(
+		&evalCtx,
+		MakeCompositeKey(tree.NewDString("pear"), tree.NewDInt(5), tree.DNull), ExcludeBoundary,
+		MakeCompositeKey(tree.NewDString("raspberry"), tree.NewDInt(100)), IncludeBoundary,
+	)
+	testInt(t, &evalCtx, pear, pear2, "(/'pear'/5/NULL - /'pear'/10]")
+	testInt(t, &evalCtx, pear2, pear, "(/'pear'/5/NULL - /'pear'/10]")
+
+	// Unconstrained (uninitialized) span.
+	testInt(t, &evalCtx, banana, Span{}, "[/NULL/100 - /'banana'/50]")
+	testInt(t, &evalCtx, Span{}, banana, "[/NULL/100 - /'banana'/50]")
+}
+
+func TestSpanUnion(t *testing.T) {
+	testUnion := func(t *testing.T, evalCtx *tree.EvalContext, left, right Span, expected string) {
+		t.Helper()
+		sp := left
+		ok := sp.TryUnionWith(evalCtx, &right)
+
+		var actual string
+		if ok {
+			actual = sp.String()
+		}
+
+		if actual != expected {
+			format := "left: %s, right: %s, expected: %v, actual: %v"
+			t.Errorf(format, left.String(), right.String(), expected, actual)
+		}
+	}
+
+	st := cluster.MakeTestingClusterSettings()
+	evalCtx := tree.MakeTestingEvalContext(st)
+
+	// Same span.
+	var banana Span
+	banana.Set(
+		&evalCtx,
+		MakeCompositeKey(tree.DNull, tree.NewDInt(100)), IncludeBoundary,
+		MakeCompositeKey(tree.NewDString("banana"), tree.NewDInt(50)), IncludeBoundary,
+	)
+	testUnion(t, &evalCtx, banana, banana, "[/NULL/100 - /'banana'/50]")
+
+	// Partial overlap.
+	var apple Span
+	apple.Set(
+		&evalCtx,
+		MakeCompositeKey(tree.NewDString("apple"), tree.NewDInt(200)), ExcludeBoundary,
+		MakeCompositeKey(tree.NewDString("cherry"), tree.NewDInt(300)), ExcludeBoundary,
+	)
+	testUnion(t, &evalCtx, banana, apple, "[/NULL/100 - /'cherry'/300)")
+	testUnion(t, &evalCtx, apple, banana, "[/NULL/100 - /'cherry'/300)")
+
+	// One span is subset of other.
+	var mango Span
+	mango.Set(
+		&evalCtx,
+		MakeCompositeKey(tree.NewDString("apple"), tree.NewDInt(200)), ExcludeBoundary,
+		MakeCompositeKey(tree.NewDString("mango")), ExcludeBoundary,
+	)
+	testUnion(t, &evalCtx, apple, mango, "(/'apple'/200 - /'mango')")
+	testUnion(t, &evalCtx, mango, apple, "(/'apple'/200 - /'mango')")
+	testUnion(t, &evalCtx, Span{}, mango, "[ - ]")
+	testUnion(t, &evalCtx, mango, Span{}, "[ - ]")
+
+	// Spans are disjoint.
+	var pear Span
+	pear.Set(
+		&evalCtx,
+		MakeCompositeKey(tree.NewDString("mango"), tree.NewDInt(0)), IncludeBoundary,
+		MakeCompositeKey(tree.NewDString("pear"), tree.NewDInt(10)), IncludeBoundary,
+	)
+	testUnion(t, &evalCtx, mango, pear, "")
+	testUnion(t, &evalCtx, pear, mango, "")
+
+	// Ensure that if TryUnionWith fails to merge, that it does not update
+	// either span.
+	mango2 := mango
+	pear2 := pear
+	mango2.TryUnionWith(&evalCtx, &pear2)
+	if mango2.Compare(&evalCtx, &mango) != 0 {
+		t.Errorf("mango2 was incorrectly updated during TryUnionWith")
+	}
+	if pear2.Compare(&evalCtx, &pear) != 0 {
+		t.Errorf("pear2 was incorrectly updated during TryUnionWith")
+	}
+
+	// Partial overlap on second key.
+	pear2.Set(
+		&evalCtx,
+		MakeCompositeKey(tree.NewDString("pear"), tree.NewDInt(5), tree.DNull), ExcludeBoundary,
+		MakeCompositeKey(tree.NewDString("raspberry"), tree.NewDInt(100)), IncludeBoundary,
+	)
+	testUnion(t, &evalCtx, pear, pear2, "[/'mango'/0 - /'raspberry'/100]")
+	testUnion(t, &evalCtx, pear, pear2, "[/'mango'/0 - /'raspberry'/100]")
+
+	// Unconstrained (uninitialized) span.
+	testUnion(t, &evalCtx, banana, Span{}, "[ - ]")
+	testUnion(t, &evalCtx, Span{}, banana, "[ - ]")
+}

--- a/pkg/sql/opt/opt/metadata.go
+++ b/pkg/sql/opt/opt/metadata.go
@@ -23,7 +23,8 @@ import (
 )
 
 // ColumnIndex uniquely identifies the usage of a column within the scope of a
-// query. See the comment for Metadata for more details.
+// query. ColumnIndex 0 is reserved to mean "unknown column". See the comment
+// for Metadata for more details.
 type ColumnIndex int32
 
 // TableIndex uniquely identifies the usage of a table within the scope of a

--- a/pkg/sql/opt/xform/rules/comp.opt
+++ b/pkg/sql/opt/xform/rules/comp.opt
@@ -19,7 +19,7 @@
 #   (a = x) AND (b = y) AND (c = z)
 #
 # This rule makes it easier to extract constraints from boolean expressions,
-# since recognition code doesn't have to handle the tuple case separately.
+# so that recognition code doesn't have to handle the tuple case separately.
 [NormalizeTupleEquality]
 (Eq (Tuple $left:*) (Tuple $right:*))
 =>


### PR DESCRIPTION
The current constraints code is special-cased to locate applicable
indexes. This PR factors out some of the core functionality of that
code into a standalone package. In the future, we may use this
library to:
  - infer non-null columns from filter expressions
  - prune ranges
  - select indexes
  - push down filter conditions with equivalent columns into joins

The library itself defines key, span, constraint, and constraint
set. A key has one or more datum values. A span has a start and end
key, and can have inclusive or exclusive boundaries. A constraint
is a disjunction of spans that describe the domain of a list of
columns. And constraint set is a conjunction of constraints, with
each constraint constraining a different list of columns.

Constraint sets will be inferred from filter expression trees. They
can be combined together with Intersect or Union operators to infer
new constraint sets from component sets. A constraint is carefully
coded to only allocate a single object in the common case of one
constraint, one column, and one span (i.e. the constraint set for
@1 = 5 is a single allocation).

Together, these abstractions and operators will allow us to
efficiently compute and store a useful "summary" of the ranges of
data that the expression may access.

Release note: None