### PR TITLE
roachtest: use a per-test directory for test artifacts

### DIFF
--- a/build/roachtest-nightly.sh
+++ b/build/roachtest-nightly.sh
@@ -17,7 +17,7 @@ set -x
 
 # If TC_BUILD_ID is unset, as it likely is locally, we simply write artifacts
 # directly into the artifacts directory.
-artifacts=$PWD/artifacts/${TC_BUILD_ID}
+artifacts=$PWD/artifacts/$(date +"%Y%m%d")-${TC_BUILD_ID}
 mkdir -p "$artifacts"
 
 go get -u -v github.com/cockroachdb/roachprod

--- a/pkg/cmd/roachtest/cluster_test.go
+++ b/pkg/cmd/roachtest/cluster_test.go
@@ -18,6 +18,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/testutils"
@@ -54,8 +55,9 @@ func TestClusterNodes(t *testing.T) {
 }
 
 func TestClusterMonitor(t *testing.T) {
+	logger := &logger{stdout: os.Stdout, stderr: os.Stderr}
 	t.Run(`success`, func(t *testing.T) {
-		c := &cluster{t: t, l: stdLogger(t.Name())}
+		c := &cluster{t: t, l: logger}
 		m := newMonitor(context.Background(), c)
 		m.Go(func(context.Context) error { return nil })
 		if err := m.wait(`sleep`, `100`); err != nil {
@@ -64,7 +66,7 @@ func TestClusterMonitor(t *testing.T) {
 	})
 
 	t.Run(`dead`, func(t *testing.T) {
-		c := &cluster{t: t, l: stdLogger(t.Name())}
+		c := &cluster{t: t, l: logger}
 		m := newMonitor(context.Background(), c)
 		m.Go(func(ctx context.Context) error {
 			<-ctx.Done()
@@ -80,7 +82,7 @@ func TestClusterMonitor(t *testing.T) {
 	})
 
 	t.Run(`worker-fail`, func(t *testing.T) {
-		c := &cluster{t: t, l: stdLogger(t.Name())}
+		c := &cluster{t: t, l: logger}
 		m := newMonitor(context.Background(), c)
 		m.Go(func(context.Context) error {
 			return errors.New(`worker-fail`)

--- a/pkg/cmd/roachtest/main.go
+++ b/pkg/cmd/roachtest/main.go
@@ -40,9 +40,6 @@ func main() {
 	` + strings.Join(allTests(), "\n\t") + `
 `,
 		RunE: func(_ *cobra.Command, args []string) error {
-			if local {
-				parallelism = 1
-			}
 			os.Exit(tests.Run(args))
 			return nil
 		},


### PR DESCRIPTION
Use a per-test directory for test artifacts rather than putting all test
artifacts in the same directory. Changing the logging behavior to only
output detailed test logs to a file if an artifacts directory is specified.

Log output from a test is now only mirrored to stdout/stderr when running
with `--parallelism=1`. This is true for local tests, but usually not true
for remote tests. Mirroring log output to stdout/stderr for remote tests
run in parallel was causing stdout/stderr to become a jumbled mess. TODO in
a future PR is to provide some progress indication on stdout when running
with tests in parallel.

See #22645

Release note: None