### PR TITLE
roachtest: return exit code 1 on failure

### DIFF
--- a/pkg/cmd/roachtest/main.go
+++ b/pkg/cmd/roachtest/main.go
@@ -43,7 +43,7 @@ func main() {
 			if local {
 				parallelism = 1
 			}
-			tests.Run(args)
+			os.Exit(tests.Run(args))
 			return nil
 		},
 	}


### PR DESCRIPTION
Also print a final status message of `PASS` or `FAIL` for the overall
result of running all of the tests.

Release note: None