### PR TITLE
partitionccl: skip flaky TestRepartitioning

### DIFF
--- a/pkg/ccl/partitionccl/partition_test.go
+++ b/pkg/ccl/partitionccl/partition_test.go
@@ -1223,6 +1223,8 @@ func TestSelectPartitionExprs(t *testing.T) {
 
 func TestRepartitioning(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	t.Skip("#22360")
+
 	rng, _ := randutil.NewPseudoRand()
 	testCases, err := allRepartitioningTests(allPartitioningTests(rng))
 	if err != nil {


### PR DESCRIPTION
This is already tracked in #22360.

Release note: None