### PR TITLE
sql: remove crdb_internal.force_retry(duration, txn_id)

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -799,8 +799,6 @@ Compatible elements: hour, minute, second, millisecond, microsecond.</p>
 </span></td></tr>
 <tr><td><code>crdb_internal.force_retry(val: <a href="interval.html">interval</a>) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>This function is used only by CockroachDB’s developers for testing purposes.</p>
 </span></td></tr>
-<tr><td><code>crdb_internal.force_retry(val: <a href="interval.html">interval</a>, txnID: <a href="string.html">string</a>) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>This function is used only by CockroachDB’s developers for testing purposes.</p>
-</span></td></tr>
 <tr><td><code>crdb_internal.no_constant_folding(input: anyelement) &rarr; anyelement</code></td><td><span class="funcdesc"><p>This function is used only by CockroachDB’s developers for testing purposes.</p>
 </span></td></tr>
 <tr><td><code>crdb_internal.node_executable_version() &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Returns the version of CockroachDB this node is running.</p>

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -2377,32 +2377,6 @@ CockroachDB supports the following flags:
 			Category: categorySystemInfo,
 			Info:     "This function is used only by CockroachDB's developers for testing purposes.",
 		},
-		tree.Builtin{
-			Types: tree.ArgTypes{
-				{"val", types.Interval},
-				{"txnID", types.String}},
-			ReturnType: tree.FixedReturnType(types.Int),
-			Impure:     true,
-			Fn: func(ctx *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
-				minDuration := args[0].(*tree.DInterval).Duration
-				txnID := args[1].(*tree.DString)
-				elapsed := duration.Duration{
-					Nanos: int64(ctx.StmtTimestamp.Sub(ctx.TxnTimestamp)),
-				}
-				if elapsed.Compare(minDuration) < 0 {
-					uuid, err := uuid.FromString(string(*txnID))
-					if err != nil {
-						return nil, err
-					}
-					err = ctx.Txn.GenerateForcedRetryableError("forced by crdb_internal.force_retry()")
-					err.(*roachpb.HandledRetryableTxnError).TxnID = uuid
-					return nil, err
-				}
-				return tree.DZero, nil
-			},
-			Category: categorySystemInfo,
-			Info:     "This function is used only by CockroachDB's developers for testing purposes.",
-		},
 	},
 
 	// Identity function which is marked as impure to avoid constant folding.


### PR DESCRIPTION
This patch removes the flavor of force_retry that explicitly takes in a
transaction id. This function was used to test that SQL has protection
for not retrying on a retriable error that was intended for a different
txn. It has outlived its usefulness: lower layers now have protection
against returning a retriable error for the wrong txn to SQL. I don't
want to keep the SQL-level protection in the connExecutor code.

Release note: None