### PR TITLE
roachtest: periodically output progress when not logging to stdout

### DIFF
--- a/pkg/cmd/roachtest/import.go
+++ b/pkg/cmd/roachtest/import.go
@@ -28,11 +28,13 @@ func init() {
 
 		c.Put(ctx, cockroach, "<cockroach>")
 		c.Put(ctx, workload, "<workload>")
+		t.Status("starting csv servers")
 		for node := 1; node <= nodes; node++ {
 			c.Run(ctx, node, `<workload> csv-server --port=8081 &> /dev/null < /dev/null &`)
 		}
 		c.Start(ctx, c.Range(1, nodes))
 
+		t.Status("running workload")
 		m := newMonitor(ctx, c, c.Range(1, nodes))
 		m.Go(func(ctx context.Context) error {
 			cmd := fmt.Sprintf(

--- a/pkg/cmd/roachtest/kv.go
+++ b/pkg/cmd/roachtest/kv.go
@@ -31,6 +31,7 @@ func init() {
 		c.Put(ctx, workload, "<workload>")
 		c.Start(ctx, c.Range(1, nodes))
 
+		t.Status("running workload")
 		m := newMonitor(ctx, c, c.Range(1, nodes))
 		m.Go(func(ctx context.Context) error {
 			concurrency := ifLocal("", " --concurrency=384")
@@ -68,6 +69,7 @@ func init() {
 		c.Put(ctx, workload, "<workload>")
 		c.Start(ctx, c.Range(1, nodes))
 
+		t.Status("running workload")
 		m := newMonitor(ctx, c, c.Range(1, nodes))
 		m.Go(func(ctx context.Context) error {
 			concurrency := ifLocal("", " --concurrency=384")
@@ -117,6 +119,7 @@ func init() {
 			c.Wipe(ctx, c.Range(1, nodes))
 			c.Start(ctx, c.Range(1, nodes))
 
+			t.Status("running workload")
 			m := newMonitor(ctx, c, c.Range(1, nodes))
 			m.Go(func(ctx context.Context) error {
 				cmd := fmt.Sprintf("<workload> run kv --init --read-percent=%d "+

--- a/pkg/cmd/roachtest/main.go
+++ b/pkg/cmd/roachtest/main.go
@@ -40,6 +40,7 @@ func main() {
 	` + strings.Join(allTests(), "\n\t") + `
 `,
 		RunE: func(_ *cobra.Command, args []string) error {
+			initBinaries()
 			os.Exit(tests.Run(args))
 			return nil
 		},

--- a/pkg/cmd/roachtest/roachmart.go
+++ b/pkg/cmd/roachtest/roachmart.go
@@ -55,10 +55,12 @@ func init() {
 			defer l.close()
 			c.RunL(ctx, l, nodes[i].i, args...)
 		}
+		t.Status("initializing workload")
 		roachmartRun(ctx, 0, "<workload>", "init", "roachmart")
 
 		duration := " --duration=" + ifLocal("10s", "10m")
 
+		t.Status("running workload")
 		m := newMonitor(ctx, c)
 		for i := range nodes {
 			i := i

--- a/pkg/cmd/roachtest/test_test.go
+++ b/pkg/cmd/roachtest/test_test.go
@@ -1,0 +1,49 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+
+package main
+
+import (
+	"io/ioutil"
+	"testing"
+)
+
+func TestRegistryRun(t *testing.T) {
+	r := &registry{m: make(map[string]*test), out: ioutil.Discard}
+	r.Add("pass", func(t *test) {
+	})
+	r.Add("fail", func(t *test) {
+		t.Fatal("failed")
+	})
+
+	testCases := []struct {
+		filters  []string
+		expected int
+	}{
+		{nil, 1},
+		{[]string{"pass"}, 0},
+		{[]string{"fail"}, 1},
+		{[]string{"pass|fail"}, 1},
+		{[]string{"pass", "fail"}, 1},
+	}
+	for _, c := range testCases {
+		t.Run("", func(t *testing.T) {
+			code := r.Run(c.filters)
+			if c.expected != code {
+				t.Fatalf("expected %d, but found %d", c.expected, code)
+			}
+		})
+	}
+}

--- a/pkg/cmd/roachtest/tpcc.go
+++ b/pkg/cmd/roachtest/tpcc.go
@@ -30,6 +30,7 @@ func init() {
 		c.Put(ctx, workload, "<workload>")
 		c.Start(ctx, c.Range(1, nodes))
 
+		t.Status("running workload")
 		m := newMonitor(ctx, c, c.Range(1, nodes))
 		m.Go(func(ctx context.Context) error {
 			duration := " --duration=" + ifLocal("10s", "10m")


### PR DESCRIPTION
Periodically (once per minute) output test progress when not logging to
stdout (i.e. when `parallelism > 1`). Example output:

```
=== RUN   kv0/nodes=1
=== RUN   kv0/nodes=3
=== RUN   kv95/nodes=1
=== RUN   kv95/nodes=3
[   1] kv0/nodes=1: uploading binary (1m0s)
[   1] kv0/nodes=3: creating cluster (1m0s)
[   1] kv95/nodes=1: creating cluster (1m0s)
[   1] kv95/nodes=3: uploading binary (1m0s)
[   2] kv0/nodes=1: uploading binary (2m0s)
[   2] kv0/nodes=3: uploading binary (2m0s)
[   2] kv95/nodes=1: uploading binary (2m0s)
[   2] kv95/nodes=3: uploading binary (2m0s)
```

Fixes #22645

Release note: None