### PR TITLE
sql: replace IVarHelper in SemaContext/EvalContext with IVarContainer

### DIFF
--- a/pkg/sql/analyze_expr.go
+++ b/pkg/sql/analyze_expr.go
@@ -64,14 +64,14 @@ func (p *planner) analyzeExpr(
 
 	// Type check.
 	var typedExpr tree.TypedExpr
-	p.semaCtx.IVarHelper = &iVarHelper
+	p.semaCtx.IVarContainer = iVarHelper.Container()
 	if requireType {
 		typedExpr, err = tree.TypeCheckAndRequire(resolved, &p.semaCtx,
 			expectedType, typingContext)
 	} else {
 		typedExpr, err = tree.TypeCheck(resolved, &p.semaCtx, expectedType)
 	}
-	p.semaCtx.IVarHelper = nil
+	p.semaCtx.IVarContainer = nil
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/computed_exprs.go
+++ b/pkg/sql/computed_exprs.go
@@ -114,7 +114,7 @@ func ProcessComputedColumns(
 	)
 
 	semaCtx := tree.MakeSemaContext(false)
-	semaCtx.IVarHelper = &ivarHelper
+	semaCtx.IVarContainer = iv
 
 	computedExprs := make([]tree.TypedExpr, 0, len(cols))
 	for i, col := range computedCols {

--- a/pkg/sql/distsqlplan/aggregator_funcs.go
+++ b/pkg/sql/distsqlplan/aggregator_funcs.go
@@ -222,7 +222,7 @@ var DistAggregationTable = map[distsqlrun.AggregatorSpec_Func]DistAggregationInf
 					Type: coltypes.NewFloat(0 /* prec */, false /* precSpecified */),
 				}
 			}
-			ctx := &tree.SemaContext{IVarHelper: h}
+			ctx := &tree.SemaContext{IVarContainer: h.Container()}
 			return expr.TypeCheck(ctx, types.Any)
 		},
 	},

--- a/pkg/sql/distsqlrun/expr.go
+++ b/pkg/sql/distsqlrun/expr.go
@@ -69,7 +69,7 @@ func processExpression(exprSpec Expression, h *tree.IndexedVarHelper) (tree.Type
 	}
 
 	// Convert to a fully typed expression.
-	typedExpr, err := tree.TypeCheck(expr, &tree.SemaContext{IVarHelper: h}, types.Any)
+	typedExpr, err := tree.TypeCheck(expr, &tree.SemaContext{IVarContainer: h.Container()}, types.Any)
 	if err != nil {
 		return nil, errors.Wrap(err, expr.String())
 	}

--- a/pkg/sql/distsqlrun/expr.go
+++ b/pkg/sql/distsqlrun/expr.go
@@ -149,9 +149,9 @@ func (eh *exprHelper) init(
 // returns whether the filter passes.
 func (eh *exprHelper) evalFilter(row sqlbase.EncDatumRow) (bool, error) {
 	eh.row = row
-	eh.evalCtx.PushIVarHelper(&eh.vars)
+	eh.evalCtx.PushIVarContainer(eh)
 	pass, err := sqlbase.RunFilter(eh.expr, eh.evalCtx)
-	eh.evalCtx.PopIVarHelper()
+	eh.evalCtx.PopIVarContainer()
 	return pass, err
 }
 
@@ -164,8 +164,8 @@ func (eh *exprHelper) evalFilter(row sqlbase.EncDatumRow) (bool, error) {
 func (eh *exprHelper) eval(row sqlbase.EncDatumRow) (tree.Datum, error) {
 	eh.row = row
 
-	eh.evalCtx.PushIVarHelper(&eh.vars)
+	eh.evalCtx.PushIVarContainer(eh)
 	d, err := eh.expr.Eval(eh.evalCtx)
-	eh.evalCtx.PopIVarHelper()
+	eh.evalCtx.PopIVarContainer()
 	return d, err
 }

--- a/pkg/sql/filter.go
+++ b/pkg/sql/filter.go
@@ -57,9 +57,9 @@ func (f *filterNode) Next(params runParams) (bool, error) {
 			return false, err
 		}
 
-		params.extendedEvalCtx.PushIVarHelper(&f.ivarHelper)
+		params.extendedEvalCtx.PushIVarContainer(f)
 		passesFilter, err := sqlbase.RunFilter(f.filter, params.EvalContext())
-		params.extendedEvalCtx.PopIVarHelper()
+		params.extendedEvalCtx.PopIVarContainer()
 		if err != nil {
 			return false, err
 		}

--- a/pkg/sql/insert.go
+++ b/pkg/sql/insert.go
@@ -555,10 +555,9 @@ func GenerateInsertRow(
 
 	if len(computeExprs) > 0 {
 		// Evaluate any computed columns. Since these obviously can reference other
-		// columns, we need an IVarHelper to be able to resolve column references.
+		// columns, we need an IVarContainer to be able to resolve column references.
 		iv := &rowIndexedVarContainer{rowVals, tableDesc.Columns, insertColIDtoRowIndex}
-		ivarHelper := tree.MakeIndexedVarHelper(iv, len(rowVals))
-		evalCtx.PushIVarHelper(&ivarHelper)
+		evalCtx.PushIVarContainer(iv)
 
 		for i := range computedCols {
 			// Note that even though the row is not fully constructed at this point,
@@ -572,7 +571,7 @@ func GenerateInsertRow(
 			rowVals[insertColIDtoRowIndex[computedCols[i].ID]] = d
 		}
 
-		evalCtx.PopIVarHelper()
+		evalCtx.PopIVarContainer()
 	}
 
 	// Check to see if NULL is being inserted into any non-nullable column.

--- a/pkg/sql/join.go
+++ b/pkg/sql/join.go
@@ -285,9 +285,9 @@ func (p *planner) makeJoin(
 				},
 			}
 			var err error
-			p.semaCtx.IVarHelper = &r.ivarHelper
+			p.semaCtx.IVarContainer = r.ivarHelper.Container()
 			expr, err = c.TypeCheck(&p.semaCtx, types.Any)
-			p.semaCtx.IVarHelper = nil
+			p.semaCtx.IVarContainer = nil
 			if err != nil {
 				return planDataSource{}, err
 			}

--- a/pkg/sql/join_predicate.go
+++ b/pkg/sql/join_predicate.go
@@ -248,9 +248,9 @@ func (p *joinPredicate) eval(
 		p.curRow = result
 		copy(p.curRow[:len(leftRow)], leftRow)
 		copy(p.curRow[len(leftRow):], rightRow)
-		ctx.PushIVarHelper(&p.iVarHelper)
+		ctx.PushIVarContainer(p.iVarHelper.Container())
 		pred, err := sqlbase.RunFilter(p.onCond, ctx)
-		ctx.PopIVarHelper()
+		ctx.PopIVarContainer()
 		return pred, err
 	}
 	return true, nil

--- a/pkg/sql/opt/index_constraints_test.go
+++ b/pkg/sql/opt/index_constraints_test.go
@@ -72,7 +72,7 @@ func BenchmarkIndexConstraints(b *testing.B) {
 
 			iVarHelper := tree.MakeTypesOnlyIndexedVarHelper(varTypes)
 
-			typedExpr, err := testutils.ParseScalarExpr(tc.expr, &iVarHelper)
+			typedExpr, err := testutils.ParseScalarExpr(tc.expr, iVarHelper.Container())
 			if err != nil {
 				b.Fatal(err)
 			}

--- a/pkg/sql/opt/opt_test.go
+++ b/pkg/sql/opt/opt_test.go
@@ -187,7 +187,7 @@ func TestOpt(t *testing.T) {
 				getTypedExpr := func() tree.TypedExpr {
 					if typedExpr == nil {
 						var err error
-						typedExpr, err = testutils.ParseScalarExpr(d.Input, &iVarHelper)
+						typedExpr, err = testutils.ParseScalarExpr(d.Input, iVarHelper.Container())
 						if err != nil {
 							d.Fatalf(t, "%v", err)
 						}

--- a/pkg/sql/opt/optbuilder/builder.go
+++ b/pkg/sql/opt/optbuilder/builder.go
@@ -128,8 +128,7 @@ type Builder struct {
 func New(ctx context.Context, factory opt.Factory, stmt tree.Statement) *Builder {
 	b := &Builder{factory: factory, stmt: stmt, colMap: make([]columnProps, 1), ctx: ctx}
 
-	ivarHelper := tree.MakeIndexedVarHelper(b, 0)
-	b.semaCtx.IVarHelper = &ivarHelper
+	b.semaCtx.IVarContainer = b
 	b.semaCtx.Placeholders = tree.MakePlaceholderInfo()
 
 	return b
@@ -1146,9 +1145,8 @@ func (b *Builder) buildDistinct(
 	return b.factory.ConstructGroupBy(in, groupingList, aggList)
 }
 
-// Builder implements the IndexedVarContainer interface so it can be
-// used as the container inside an IndexedVarHelper (specifically
-// Builder.semaCtx.IVarHelper). This allows tree.TypeCheck to determine the
+// Builder implements the IndexedVarContainer interface so it can be used as the
+// IVarContainer in Builder.semaCtx. This allows tree.TypeCheck to determine the
 // correct type for any IndexedVars in Builder.stmt. These types are maintained
 // inside the Builder.colMap.
 var _ tree.IndexedVarContainer = &Builder{}

--- a/pkg/sql/opt/optbuilder/builder_test.go
+++ b/pkg/sql/opt/optbuilder/builder_test.go
@@ -127,7 +127,7 @@ func TestBuilder(t *testing.T) {
 					return exprView.String()
 
 				case "build-scalar":
-					typedExpr, err := testutils.ParseScalarExpr(d.Input, &iVarHelper)
+					typedExpr, err := testutils.ParseScalarExpr(d.Input, iVarHelper.Container())
 					if err != nil {
 						d.Fatalf(t, "%v", err)
 					}

--- a/pkg/sql/opt/testutils/utils.go
+++ b/pkg/sql/opt/testutils/utils.go
@@ -45,14 +45,14 @@ func ParseTypes(colStrs []string) ([]types.T, error) {
 
 // ParseScalarExpr parses a scalar expression and converts it to a
 // tree.TypedExpr.
-func ParseScalarExpr(sql string, ivh *tree.IndexedVarHelper) (tree.TypedExpr, error) {
+func ParseScalarExpr(sql string, ivc tree.IndexedVarContainer) (tree.TypedExpr, error) {
 	expr, err := parser.ParseExpr(sql)
 	if err != nil {
 		return nil, err
 	}
 
 	sema := tree.MakeSemaContext(false /* privileged */)
-	sema.IVarHelper = ivh
+	sema.IVarContainer = ivc
 
 	return expr.TypeCheck(&sema, types.Any)
 }

--- a/pkg/sql/opt_decompose_test.go
+++ b/pkg/sql/opt_decompose_test.go
@@ -84,7 +84,7 @@ func parseAndNormalizeExpr(t *testing.T, p *planner, sql string, sel *renderNode
 	if expr, _, _, err = p.resolveNamesForRender(expr, sel); err != nil {
 		t.Fatalf("%s: %v", sql, err)
 	}
-	p.semaCtx.IVarHelper = p.extendedEvalCtx.IVarHelper
+	p.semaCtx.IVarContainer = p.extendedEvalCtx.IVarHelper.Container()
 	typedExpr, err := tree.TypeCheck(expr, &p.semaCtx, types.Any)
 	if err != nil {
 		t.Fatalf("%s: %v", sql, err)

--- a/pkg/sql/render.go
+++ b/pkg/sql/render.go
@@ -693,7 +693,7 @@ func (r *renderNode) renderRow(evalCtx *tree.EvalContext) error {
 	}
 	for i, e := range r.render {
 		var err error
-		evalCtx.IVarHelper = &r.ivarHelper
+		evalCtx.IVarContainer = r
 		r.run.row[i], err = e.Eval(evalCtx)
 		if err != nil {
 			return err

--- a/pkg/sql/returning.go
+++ b/pkg/sql/returning.go
@@ -105,7 +105,7 @@ func (rh *returningHelper) cookResultRow(rowVals tree.Datums) (tree.Datums, erro
 	rh.curSourceRow = rowVals
 	resRow := make(tree.Datums, len(rh.exprs))
 	for i, e := range rh.exprs {
-		rh.p.extendedEvalCtx.IVarHelper = &rh.ivarHelper
+		rh.p.extendedEvalCtx.IVarContainer = rh
 		d, err := e.Eval(rh.p.EvalContext())
 		if err != nil {
 			return nil, err

--- a/pkg/sql/scan.go
+++ b/pkg/sql/scan.go
@@ -191,7 +191,7 @@ func (n *scanNode) Next(params runParams) (bool, error) {
 		if err != nil || n.run.row == nil {
 			return false, err
 		}
-		params.extendedEvalCtx.IVarHelper = &n.filterVars
+		params.extendedEvalCtx.IVarContainer = n
 		passesFilter, err := sqlbase.RunFilter(n.filter, params.EvalContext())
 		if err != nil {
 			return false, err

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -2287,11 +2287,12 @@ type EvalContext struct {
 	// underlying datum, if available.
 	Placeholders *PlaceholderInfo
 
-	IVarHelper *IndexedVarHelper
-	// iVarHelperStack is used when we swap out IVarHelpers in order to evaluate
-	// an intermediate expression. This keeps track of those which we need to
-	// restore once we finish evaluating it.
-	iVarHelperStack []*IndexedVarHelper
+	// IVarContainer is used to evaluate IndexedVars.
+	IVarContainer IndexedVarContainer
+	// iVarContainerStack is used when we swap out IVarContainers in order to
+	// evaluate an intermediate expression. This keeps track of those which we
+	// need to restore once we finish evaluating it.
+	iVarContainerStack []IndexedVarContainer
 
 	// CtxProvider holds the context in which the expression is evaluated. This
 	// will point to the session, which is itself a provider of contexts.
@@ -2360,19 +2361,19 @@ func MakeTestingEvalContext(st *cluster.Settings) EvalContext {
 	return ctx
 }
 
-// PushIVarHelper replaces the current IVarHelper with a different one -
-// pushing the current one onto a stack to be replaced later once PopIVarHelper
-// is called.
-func (ctx *EvalContext) PushIVarHelper(i *IndexedVarHelper) {
-	ctx.iVarHelperStack = append(ctx.iVarHelperStack, ctx.IVarHelper)
-	ctx.IVarHelper = i
+// PushIVarContainer replaces the current IVarContainer with a different one -
+// pushing the current one onto a stack to be replaced later once
+// PopIVarContainer is called.
+func (ctx *EvalContext) PushIVarContainer(c IndexedVarContainer) {
+	ctx.iVarContainerStack = append(ctx.iVarContainerStack, ctx.IVarContainer)
+	ctx.IVarContainer = c
 }
 
-// PopIVarHelper discards the current IVarHelper on the EvalContext, replacing
-// it with an older one.
-func (ctx *EvalContext) PopIVarHelper() {
-	ctx.IVarHelper = ctx.iVarHelperStack[len(ctx.iVarHelperStack)-1]
-	ctx.iVarHelperStack = ctx.iVarHelperStack[:len(ctx.iVarHelperStack)-1]
+// PopIVarContainer discards the current IVarContainer on the EvalContext,
+// replacing it with an older one.
+func (ctx *EvalContext) PopIVarContainer() {
+	ctx.IVarContainer = ctx.iVarContainerStack[len(ctx.iVarContainerStack)-1]
+	ctx.iVarContainerStack = ctx.iVarContainerStack[:len(ctx.iVarContainerStack)-1]
 }
 
 // NewTestingEvalContext is a convenience version of MakeTestingEvalContext

--- a/pkg/sql/sem/tree/indexed_vars.go
+++ b/pkg/sql/sem/tree/indexed_vars.go
@@ -59,10 +59,7 @@ func (v *IndexedVar) Walk(_ Visitor) Expr {
 
 // TypeCheck is part of the Expr interface.
 func (v *IndexedVar) TypeCheck(ctx *SemaContext, desired types.T) (TypedExpr, error) {
-	if ctx.IVarHelper == nil {
-		panic("indexed var had no SemaContext.IVarHelper during type checking")
-	}
-	if ctx.IVarHelper.container == nil || ctx.IVarHelper.container == unboundContainer {
+	if ctx.IVarContainer == nil || ctx.IVarContainer == unboundContainer {
 		// A more technically correct message would be to say that the
 		// reference is unbound and thus cannot be typed. However this is
 		// a tad bit too technical for the average SQL use case and
@@ -72,7 +69,7 @@ func (v *IndexedVar) TypeCheck(ctx *SemaContext, desired types.T) (TypedExpr, er
 		return nil, pgerror.NewErrorf(
 			pgerror.CodeUndefinedColumnError, "column reference @%d not allowed in this context", v.Idx+1)
 	}
-	v.typ = ctx.IVarHelper.container.IndexedVarResolvedType(v.Idx)
+	v.typ = ctx.IVarContainer.IndexedVarResolvedType(v.Idx)
 	return v, nil
 }
 
@@ -137,6 +134,11 @@ func NewIndexedVar(r int) *IndexedVar {
 type IndexedVarHelper struct {
 	vars      []IndexedVar
 	container IndexedVarContainer
+}
+
+// Container returns the container associated with the helper.
+func (h *IndexedVarHelper) Container() IndexedVarContainer {
+	return h.container
 }
 
 // BindIfUnbound ensures the IndexedVar is attached to this helper's container.

--- a/pkg/sql/sem/tree/indexed_vars.go
+++ b/pkg/sql/sem/tree/indexed_vars.go
@@ -75,10 +75,10 @@ func (v *IndexedVar) TypeCheck(ctx *SemaContext, desired types.T) (TypedExpr, er
 
 // Eval is part of the TypedExpr interface.
 func (v *IndexedVar) Eval(ctx *EvalContext) (Datum, error) {
-	if ctx.IVarHelper.container == nil || ctx.IVarHelper.container == unboundContainer {
+	if ctx.IVarContainer == nil || ctx.IVarContainer == unboundContainer {
 		panic("indexed var must be bound to a container before evaluation")
 	}
-	return ctx.IVarHelper.container.IndexedVarEval(v.Idx, ctx)
+	return ctx.IVarContainer.IndexedVarEval(v.Idx, ctx)
 }
 
 // ResolvedType is part of the TypedExpr interface.

--- a/pkg/sql/sem/tree/indexed_vars_test.go
+++ b/pkg/sql/sem/tree/indexed_vars_test.go
@@ -96,7 +96,7 @@ func TestIndexedVars(t *testing.T) {
 	}
 	evalCtx := NewTestingEvalContext(cluster.MakeTestingClusterSettings())
 	defer evalCtx.Stop(context.Background())
-	evalCtx.IVarHelper = &IndexedVarHelper{container: c}
+	evalCtx.IVarContainer = c
 	d, err := typedExpr.Eval(evalCtx)
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/sql/sem/tree/indexed_vars_test.go
+++ b/pkg/sql/sem/tree/indexed_vars_test.go
@@ -63,7 +63,7 @@ func TestIndexedVars(t *testing.T) {
 	expr := binary(Plus, v0, binary(Mult, v1, v2))
 
 	// Verify the expression evaluates correctly.
-	semaContext := &SemaContext{IVarHelper: &IndexedVarHelper{container: c}}
+	semaContext := &SemaContext{IVarContainer: c}
 	typedExpr, err := expr.TypeCheck(semaContext, types.Any)
 	if err != nil {
 		t.Fatal(err)
@@ -96,7 +96,7 @@ func TestIndexedVars(t *testing.T) {
 	}
 	evalCtx := NewTestingEvalContext(cluster.MakeTestingClusterSettings())
 	defer evalCtx.Stop(context.Background())
-	evalCtx.IVarHelper = semaContext.IVarHelper
+	evalCtx.IVarHelper = &IndexedVarHelper{container: c}
 	d, err := typedExpr.Eval(evalCtx)
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/sql/sem/tree/type_check.go
+++ b/pkg/sql/sem/tree/type_check.go
@@ -34,7 +34,8 @@ type SemaContext struct {
 	// Placeholders relates placeholder names to their type and, later, value.
 	Placeholders PlaceholderInfo
 
-	IVarHelper *IndexedVarHelper
+	// IVarContainer is used to resolve the types of IndexedVars.
+	IVarContainer IndexedVarContainer
 
 	// Location references the *Location on the current Session.
 	Location **time.Location

--- a/pkg/sql/sqlbase/check.go
+++ b/pkg/sql/sqlbase/check.go
@@ -140,8 +140,8 @@ func (c *CheckHelper) IndexedVarNodeFormatter(idx int) tree.NodeFormatter {
 // Check performs the actual checks based on the values stored in the
 // CheckHelper.
 func (c *CheckHelper) Check(ctx *tree.EvalContext) error {
-	ctx.PushIVarHelper(c.ivarHelper)
-	defer func() { ctx.PopIVarHelper() }()
+	ctx.PushIVarContainer(c)
+	defer func() { ctx.PopIVarContainer() }()
 	for _, expr := range c.Exprs {
 		if d, err := expr.Eval(ctx); err != nil {
 			return err

--- a/pkg/sql/update.go
+++ b/pkg/sql/update.go
@@ -340,8 +340,7 @@ func (u *updateNode) Next(params runParams) (bool, error) {
 		}
 
 		iv := &rowIndexedVarContainer{newVals, u.tableDesc.Columns, u.tw.ru.FetchColIDtoRowIndex}
-		ivarHelper := tree.MakeIndexedVarHelper(iv, len(newVals))
-		params.EvalContext().IVarHelper = &ivarHelper
+		params.EvalContext().IVarContainer = iv
 
 		for i := range u.computedCols {
 			d, err := u.computeExprs[i].Eval(params.EvalContext())
@@ -352,7 +351,7 @@ func (u *updateNode) Next(params runParams) (bool, error) {
 		}
 	}
 
-	params.EvalContext().IVarHelper = nil
+	params.EvalContext().IVarContainer = nil
 
 	// TODO(justin): we have actually constructed the whole row at this point and
 	// thus should be able to avoid loading it separately like this now.

--- a/pkg/sql/upsert.go
+++ b/pkg/sql/upsert.go
@@ -194,8 +194,8 @@ func (uh *upsertHelper) eval(insertRow tree.Datums, existingRow tree.Datums) (tr
 
 	var err error
 	ret := make([]tree.Datum, len(uh.evalExprs))
-	uh.p.extendedEvalCtx.PushIVarHelper(uh.ivarHelper)
-	defer func() { uh.p.extendedEvalCtx.PopIVarHelper() }()
+	uh.p.extendedEvalCtx.PushIVarContainer(uh.ivarHelper.Container())
+	defer func() { uh.p.extendedEvalCtx.PopIVarContainer() }()
 	for i, evalExpr := range uh.evalExprs {
 		ret[i], err = evalExpr.Eval(uh.p.EvalContext())
 		if err != nil {
@@ -213,8 +213,8 @@ func (uh *upsertHelper) evalComputedCols(
 	updatedRow tree.Datums, appendTo tree.Datums,
 ) (tree.Datums, error) {
 	uh.ccIvarContainer.curSourceRow = updatedRow
-	uh.p.EvalContext().IVarHelper = uh.ccIvarHelper
-	defer func() { uh.p.EvalContext().IVarHelper = nil }()
+	uh.p.EvalContext().IVarContainer = uh.ccIvarContainer
+	defer func() { uh.p.EvalContext().IVarContainer = nil }()
 	for i := range uh.computeExprs {
 		res, err := uh.computeExprs[i].Eval(uh.p.EvalContext())
 		if err != nil {
@@ -231,8 +231,8 @@ func (uh *upsertHelper) shouldUpdate(insertRow tree.Datums, existingRow tree.Dat
 	uh.curSourceRow = existingRow
 	uh.curExcludedRow = insertRow
 
-	uh.p.extendedEvalCtx.PushIVarHelper(uh.ivarHelper)
-	defer func() { uh.p.extendedEvalCtx.PopIVarHelper() }()
+	uh.p.extendedEvalCtx.PushIVarContainer(uh.ivarHelper.Container())
+	defer func() { uh.p.extendedEvalCtx.PopIVarContainer() }()
 	return sqlbase.RunFilter(uh.whereExpr, uh.p.EvalContext())
 }
 

--- a/pkg/sql/window.go
+++ b/pkg/sql/window.go
@@ -783,9 +783,9 @@ func (n *windowNode) populateValues(ctx context.Context, evalCtx *tree.EvalConte
 				}
 				// Instead, we evaluate the current window render, which depends on at least
 				// one window function, at the given row.
-				evalCtx.PushIVarHelper(n.ivarHelper)
+				evalCtx.PushIVarContainer(&n.colContainer)
 				res, err := curWindowRender.Eval(evalCtx)
-				evalCtx.PopIVarHelper()
+				evalCtx.PopIVarContainer()
 				if err != nil {
 					return err
 				}


### PR DESCRIPTION
#### sql: replace IndexedVarHelper in SemaContext with IndexedVarContainer

The `SemaContext.IVarHelper` felt strange to me (why would we want a
helper in a semantic context?) so I looked at how it is used. Turns
out we only use it for its container (which makes sense). This leads
to situations where we create `IndexedVarHelper`s just to populate
this field.

We change the field to be an `IndexedVarContainer`.

Release note: None

#### sql: replace IndexedVarHelper in EvalContext with IndexedVarContainer

`EvalContext.IndexedVarHelper` is only used for its container. In many
contexts we create a helper just to populate this field.

Changing the field to `IndexedVarContainer`.

Release note: None
