### PR TITLE
ui: fix clusterviz in Safari and FF

### DIFF
--- a/pkg/ui/ccl/src/views/clusterviz/containers/map/nodeCanvas.tsx
+++ b/pkg/ui/ccl/src/views/clusterviz/containers/map/nodeCanvas.tsx
@@ -47,8 +47,9 @@ export class NodeCanvas extends React.Component<NodeCanvasProps, NodeCanvasState
   }
 
   updateViewport = () => {
+    const rect = this.graphEl.getBoundingClientRect();
     this.setState({
-      viewportSize: [this.graphEl.clientWidth, this.graphEl.clientHeight],
+      viewportSize: [rect.width, rect.height],
     });
   }
 

--- a/pkg/ui/ccl/src/views/clusterviz/containers/map/nodeCanvas.tsx
+++ b/pkg/ui/ccl/src/views/clusterviz/containers/map/nodeCanvas.tsx
@@ -139,6 +139,7 @@ export class NodeCanvas extends React.Component<NodeCanvasProps, NodeCanvasState
               width: "100%",
               height: "100%",
               marginBottom: -3, // WHYYYYYYYYY?!?!?!?!?
+              position: "absolute",
             }}
             className="cluster-viz"
             ref={svg => this.graphEl = svg}


### PR DESCRIPTION
<img width="1680" alt="screen shot 2018-02-16 at 5 38 56 pm" src="https://user-images.githubusercontent.com/7341/36332504-6ebc44d0-1340-11e8-9f84-e6d78c66e456.png">

Don't exactly understand why these things fix the problems, but they do.

Fixes #22781
Fixes #22594