### PR TITLE
opt: rework how IndexedVars get built

### DIFF
--- a/pkg/sql/opt/optbuilder/builder_test.go
+++ b/pkg/sql/opt/optbuilder/builder_test.go
@@ -132,8 +132,12 @@ func TestBuilder(t *testing.T) {
 						d.Fatalf(t, "%v", err)
 					}
 
+					varNames := make([]string, len(varTypes))
+					for i := range varNames {
+						varNames[i] = fmt.Sprintf("@%d", i+1)
+					}
 					o := xform.NewOptimizer(catalog, xform.OptimizeNone)
-					b := NewScalar(ctx, o.Factory())
+					b := NewScalar(ctx, o.Factory(), varNames, varTypes)
 					group, err := b.Build(typedExpr)
 					if err != nil {
 						return fmt.Sprintf("error: %v\n", err)

--- a/pkg/sql/opt/optbuilder/scope.go
+++ b/pkg/sql/opt/optbuilder/scope.go
@@ -151,6 +151,7 @@ func (s *scope) appendColumns(src *scope) {
 // with columnProps.
 func (s *scope) resolveType(expr tree.Expr, desired types.T) tree.TypedExpr {
 	expr, _ = tree.WalkExpr(s, expr)
+	s.builder.semaCtx.IVarContainer = s
 	texpr, err := tree.TypeCheck(expr, &s.builder.semaCtx, desired)
 	if err != nil {
 		panic(builderError{err})
@@ -414,4 +415,24 @@ func (s *scope) VisitPre(expr tree.Expr) (recurse bool, newExpr tree.Expr) {
 // VisitPost is part of the Visitor interface.
 func (*scope) VisitPost(expr tree.Expr) tree.Expr {
 	return expr
+}
+
+// scope implements the IndexedVarContainer interface so it can be used as
+// semaCtx.IVarContainer. This allows tree.TypeCheck to determine the correct
+// type for any IndexedVars.
+var _ tree.IndexedVarContainer = &scope{}
+
+// IndexedVarEval is part of the IndexedVarContainer interface.
+func (s *scope) IndexedVarEval(idx int, ctx *tree.EvalContext) (tree.Datum, error) {
+	panic("unimplemented: scope.IndexedVarEval")
+}
+
+// IndexedVarResolvedType is part of the IndexedVarContainer interface.
+func (s *scope) IndexedVarResolvedType(idx int) types.T {
+	return s.cols[idx].typ
+}
+
+// IndexedVarNodeFormatter is part of the IndexedVarContainer interface.
+func (s *scope) IndexedVarNodeFormatter(idx int) tree.NodeFormatter {
+	panic("unimplemented: scope.IndexedVarNodeFormatter")
 }

--- a/pkg/sql/opt/optbuilder/testdata/select
+++ b/pkg/sql/opt/optbuilder/testdata/select
@@ -60,3 +60,14 @@ SELECT * FROM t.a AS A(X, Y)
 ----
 scan
  └── columns: a.x:int:1 a.y:float:null:2
+
+build
+SELECT @1, @2 FROM t.a
+----
+project
+ ├── columns: column3:int:null:3 column4:float:null:4
+ ├── scan
+ │    └── columns: a.x:int:1 a.y:float:null:2
+ └── projections
+      ├── variable: a.x [type=int]
+      └── variable: a.y [type=float]


### PR DESCRIPTION
An IndexedVar refers to a column in the current scope. For example
`SELECT @1, @2 FROM ` would select the first two columns. This change
reworks the way we handle IndexedVars during build:
 - scope implements the IndexedVarContainer now (instead of Builder)
 - to build a scalar, we now provide the columns that are in
   scope.
 - the build code looks up the column in the scope, instead of
   synthesizing a new column every time it sees an IndexedVar.

Release note: None