### PR TITLE
roachtest: remove special-case logic for local binaries

### DIFF
--- a/pkg/cmd/roachtest/import.go
+++ b/pkg/cmd/roachtest/import.go
@@ -26,11 +26,11 @@ func init() {
 		c := newCluster(ctx, t, nodes)
 		defer c.Destroy(ctx)
 
-		c.Put(ctx, cockroach, "<cockroach>")
-		c.Put(ctx, workload, "<workload>")
+		c.Put(ctx, cockroach, "./cockroach")
+		c.Put(ctx, workload, "./workload")
 		t.Status("starting csv servers")
 		for node := 1; node <= nodes; node++ {
-			c.Run(ctx, node, `<workload> csv-server --port=8081 &> /dev/null < /dev/null &`)
+			c.Run(ctx, node, `./workload csv-server --port=8081 &> /dev/null < /dev/null &`)
 		}
 		c.Start(ctx, c.Range(1, nodes))
 
@@ -38,7 +38,7 @@ func init() {
 		m := newMonitor(ctx, c, c.Range(1, nodes))
 		m.Go(func(ctx context.Context) error {
 			cmd := fmt.Sprintf(
-				`<workload> fixtures store tpcc --warehouses=%d --csv-server='http://localhost:8081' `+
+				`./workload fixtures store tpcc --warehouses=%d --csv-server='http://localhost:8081' `+
 					`--gcs-bucket-override=cockroachdb-backup-testing --gcs-prefix-override=%s`,
 				warehouses, c.name)
 			c.Run(ctx, 1, cmd)

--- a/pkg/cmd/roachtest/kv.go
+++ b/pkg/cmd/roachtest/kv.go
@@ -27,8 +27,8 @@ func init() {
 		c := newCluster(ctx, t, nodes+1)
 		defer c.Destroy(ctx)
 
-		c.Put(ctx, cockroach, "<cockroach>")
-		c.Put(ctx, workload, "<workload>")
+		c.Put(ctx, cockroach, "./cockroach")
+		c.Put(ctx, workload, "./workload")
 		c.Start(ctx, c.Range(1, nodes))
 
 		t.Status("running workload")
@@ -37,7 +37,7 @@ func init() {
 			concurrency := ifLocal("", " --concurrency=384")
 			duration := " --duration=" + ifLocal("10s", "10m")
 			cmd := fmt.Sprintf(
-				"<workload> run kv --init --read-percent=%d --splits=1000"+
+				"./workload run kv --init --read-percent=%d --splits=1000"+
 					concurrency+duration+
 					" {pgurl:1-%d}",
 				percent, nodes)
@@ -65,8 +65,8 @@ func init() {
 		c := newCluster(ctx, t, nodes+1)
 		defer c.Destroy(ctx)
 
-		c.Put(ctx, cockroach, "<cockroach>")
-		c.Put(ctx, workload, "<workload>")
+		c.Put(ctx, cockroach, "./cockroach")
+		c.Put(ctx, workload, "./workload")
 		c.Start(ctx, c.Range(1, nodes))
 
 		t.Status("running workload")
@@ -75,7 +75,7 @@ func init() {
 			concurrency := ifLocal("", " --concurrency=384")
 			splits := " --splits=" + ifLocal("2000", "500000")
 			cmd := fmt.Sprintf(
-				"<workload> run kv --init --max-ops=1"+
+				"./workload run kv --init --max-ops=1"+
 					concurrency+splits+
 					" {pgurl:1-%d}",
 				nodes)
@@ -111,8 +111,8 @@ func init() {
 			wg.Wait()
 		}
 
-		c.Put(ctx, cockroach, "<cockroach>")
-		c.Put(ctx, workload, "<workload>")
+		c.Put(ctx, cockroach, "./cockroach")
+		c.Put(ctx, workload, "./workload")
 
 		const maxPerNodeConcurrency = 64
 		for i := nodes; i <= nodes*maxPerNodeConcurrency; i += nodes {
@@ -122,7 +122,7 @@ func init() {
 			t.Status("running workload")
 			m := newMonitor(ctx, c, c.Range(1, nodes))
 			m.Go(func(ctx context.Context) error {
-				cmd := fmt.Sprintf("<workload> run kv --init --read-percent=%d "+
+				cmd := fmt.Sprintf("./workload run kv --init --read-percent=%d "+
 					"--splits=1000 --duration=1m "+fmt.Sprintf("--concurrency=%d", i)+
 					" {pgurl:1-%d}",
 					percent, nodes)

--- a/pkg/cmd/roachtest/roachmart.go
+++ b/pkg/cmd/roachtest/roachmart.go
@@ -26,8 +26,8 @@ func init() {
 		c := newCluster(ctx, t, 9, "--geo")
 		defer c.Destroy(ctx)
 
-		c.Put(ctx, cockroach, "<cockroach>")
-		c.Put(ctx, workload, "<workload>")
+		c.Put(ctx, cockroach, "./cockroach")
+		c.Put(ctx, workload, "./workload")
 		c.Start(ctx)
 
 		// TODO(benesch): avoid hardcoding this list.
@@ -56,7 +56,7 @@ func init() {
 			c.RunL(ctx, l, nodes[i].i, args...)
 		}
 		t.Status("initializing workload")
-		roachmartRun(ctx, 0, "<workload>", "init", "roachmart")
+		roachmartRun(ctx, 0, "./workload", "init", "roachmart")
 
 		duration := " --duration=" + ifLocal("10s", "10m")
 
@@ -65,7 +65,7 @@ func init() {
 		for i := range nodes {
 			i := i
 			m.Go(func(ctx context.Context) error {
-				roachmartRun(ctx, i, "<workload>", "run", "roachmart", duration)
+				roachmartRun(ctx, i, "./workload", "run", "roachmart", duration)
 				return nil
 			})
 		}

--- a/pkg/cmd/roachtest/tpcc.go
+++ b/pkg/cmd/roachtest/tpcc.go
@@ -26,8 +26,8 @@ func init() {
 		c := newCluster(ctx, t, nodes+1)
 		defer c.Destroy(ctx)
 
-		c.Put(ctx, cockroach, "<cockroach>")
-		c.Put(ctx, workload, "<workload>")
+		c.Put(ctx, cockroach, "./cockroach")
+		c.Put(ctx, workload, "./workload")
 		c.Start(ctx, c.Range(1, nodes))
 
 		t.Status("running workload")
@@ -35,7 +35,7 @@ func init() {
 		m.Go(func(ctx context.Context) error {
 			duration := " --duration=" + ifLocal("10s", "10m")
 			cmd := fmt.Sprintf(
-				"<workload> run tpcc --init --warehouses=%d"+
+				"./workload run tpcc --init --warehouses=%d"+
 					extra+duration+" {pgurl:1-%d}",
 				warehouses, nodes)
 			c.Run(ctx, nodes+1, cmd)


### PR DESCRIPTION
Now that local clusters have per-node directories that are cd'd into
before running binaries, we no longer need to special case the handling
of binaries for local clusters.

Depends on https://github.com/cockroachdb/roachprod/pull/65.

Fixes #22640

Release note: None