### PR TITLE
build: improve roachtest nightly interop with TeamCity

### DIFF
--- a/build/roachtest-nightly.sh
+++ b/build/roachtest-nightly.sh
@@ -2,6 +2,8 @@
 
 set -eo pipefail
 
+source "$(dirname "$0")/teamcity-support.sh"
+
 if [[ "$GOOGLE_EPHEMERAL_CREDENTIALS" ]]; then
   echo "$GOOGLE_EPHEMERAL_CREDENTIALS" > creds.json
   gcloud auth activate-service-account --key-file=creds.json
@@ -11,34 +13,37 @@ else
   echo "Assuming that you've run \`gcloud auth login\` from inside the builder." >&2
 fi
 
-# IMPORTANT: To avoid leaking credentials, we don't set -x until after
-# processing credentials.
-set -x
-
 # If TC_BUILD_ID is unset, as it likely is locally, we simply write artifacts
 # directly into the artifacts directory.
 artifacts=$PWD/artifacts/$(date +"%Y%m%d")-${TC_BUILD_ID}
 mkdir -p "$artifacts"
 
-go get -u -v github.com/cockroachdb/roachprod
-git -C "$(go env GOPATH)/src/github.com/cockroachdb/roachprod" rev-parse HEAD
+if_tc tc_start_block "Compile roachprod"
+run go get -u -v github.com/cockroachdb/roachprod
+run git -C "$(go env GOPATH)/src/github.com/cockroachdb/roachprod" rev-parse HEAD
+if_tc tc_end_block "Install roachprod"
 
-make build TYPE=release-linux-gnu
-
+if_tc tc_start_block "Compile CockroachDB"
+run make build TYPE=release-linux-gnu
 # Use this instead of the `make build` above for faster debugging iteration.
-# curl -L https://edge-binaries.cockroachdb.com/cockroach/cockroach.linux-gnu-amd64.LATEST -o cockroach-linux-2.6.32-gnu-amd64
-# chmod +x cockroach-linux-2.6.32-gnu-amd64
+# run curl -L https://edge-binaries.cockroachdb.com/cockroach/cockroach.linux-gnu-amd64.LATEST -o cockroach-linux-2.6.32-gnu-amd64
+# run chmod +x cockroach-linux-2.6.32-gnu-amd64
+if_tc tc_end_block "Compile CockroachDB"
 
-make bin/roachtest bin/workload
+if_tc tc_start_block "Compile Workload"
+run make bin/roachtest bin/workload
+if_tc tc_end_block "Compile Workload"
 
-bin/roachtest run \
+if_tc tc_start_block "Run roachtest"
+run bin/roachtest run \
   --cluster-id "${TC_BUILD_ID}" \
   --cockroach "$PWD/cockroach-linux-2.6.32-gnu-amd64" \
   --workload "$PWD/bin/workload" \
   --artifacts "$artifacts"
+if_tc tc_end_block "Run roachtest"
 
-# Don't upload test results if not running in TeamCity.
-if [[ "$TC_BUILD_ID" ]]; then
-  gsutil -m -h "Content-Type: text/plain" cp -r \
+if_tc tc_start_block "Upload artifacts"
+# Only upload artifacts if in TeamCity.
+if_tc run gsutil -m -h "Content-Type: text/plain" cp -r \
     "$artifacts" "gs://cockroach-acceptance-results/teamcity-nightly/$TC_BUILD_ID"
-fi
+if_tc tc_end_block "Upload artifacts"

--- a/build/teamcity-support.sh
+++ b/build/teamcity-support.sh
@@ -37,6 +37,12 @@ tc_start_block() {
   echo "##teamcity[blockOpened name='$1']"
 }
 
+if_tc() {
+  if [[ "${TC_BUILD_ID-}" ]]; then
+    "$@"
+  fi
+}
+
 tc_end_block() {
   echo "##teamcity[blockClosed name='$1']"
 }


### PR DESCRIPTION
Teach the roachtest nightly scripts to declare TeamCity build log
blocks, like a440a0af8 did for our PR build scripts.

Release note: None