### PR TITLE
roachtest: add -c/--cluster for running a test on an existing cluster

### DIFF
--- a/pkg/cmd/roachtest/import.go
+++ b/pkg/cmd/roachtest/import.go
@@ -26,8 +26,8 @@ func init() {
 		c := newCluster(ctx, t, nodes)
 		defer c.Destroy(ctx)
 
-		c.Put(ctx, cockroach, "./cockroach")
-		c.Put(ctx, workload, "./workload")
+		c.Put(ctx, cockroach, "./cockroach", c.Range(1, nodes))
+		c.Put(ctx, workload, "./workload", c.Node(1))
 		t.Status("starting csv servers")
 		for node := 1; node <= nodes; node++ {
 			c.Run(ctx, node, `./workload csv-server --port=8081 &> /dev/null < /dev/null &`)

--- a/pkg/cmd/roachtest/kv.go
+++ b/pkg/cmd/roachtest/kv.go
@@ -27,8 +27,8 @@ func init() {
 		c := newCluster(ctx, t, nodes+1)
 		defer c.Destroy(ctx)
 
-		c.Put(ctx, cockroach, "./cockroach")
-		c.Put(ctx, workload, "./workload")
+		c.Put(ctx, cockroach, "./cockroach", c.Range(1, nodes))
+		c.Put(ctx, workload, "./workload", c.Node(nodes+1))
 		c.Start(ctx, c.Range(1, nodes))
 
 		t.Status("running workload")
@@ -65,8 +65,8 @@ func init() {
 		c := newCluster(ctx, t, nodes+1)
 		defer c.Destroy(ctx)
 
-		c.Put(ctx, cockroach, "./cockroach")
-		c.Put(ctx, workload, "./workload")
+		c.Put(ctx, cockroach, "./cockroach", c.Range(1, nodes))
+		c.Put(ctx, workload, "./workload", c.Node(nodes+1))
 		c.Start(ctx, c.Range(1, nodes))
 
 		t.Status("running workload")
@@ -96,7 +96,7 @@ func init() {
 		c := newCluster(ctx, t, nodes+1, "--local-ssd", "--machine-type", "n1-highcpu-8")
 		defer c.Destroy(ctx)
 
-		if !local {
+		if !c.isLocal() {
 			var wg sync.WaitGroup
 			wg.Add(nodes)
 			for i := 1; i <= 6; i++ {
@@ -111,8 +111,8 @@ func init() {
 			wg.Wait()
 		}
 
-		c.Put(ctx, cockroach, "./cockroach")
-		c.Put(ctx, workload, "./workload")
+		c.Put(ctx, cockroach, "./cockroach", c.Range(1, nodes))
+		c.Put(ctx, workload, "./workload", c.Node(nodes+1))
 
 		const maxPerNodeConcurrency = 64
 		for i := nodes; i <= nodes*maxPerNodeConcurrency; i += nodes {

--- a/pkg/cmd/roachtest/main.go
+++ b/pkg/cmd/roachtest/main.go
@@ -16,6 +16,7 @@
 package main
 
 import (
+	"fmt"
 	"os"
 	"strings"
 
@@ -40,6 +41,10 @@ func main() {
 	` + strings.Join(allTests(), "\n\t") + `
 `,
 		RunE: func(_ *cobra.Command, args []string) error {
+			if clusterName != "" && local {
+				return fmt.Errorf("cannot specify both an existing cluster (%s) and --local", clusterName)
+			}
+
 			initBinaries()
 			os.Exit(tests.Run(args))
 			return nil
@@ -56,6 +61,8 @@ func main() {
 		&parallelism, "parallelism", "p", parallelism, "number of tests to run in parallel")
 	runCmd.Flags().StringVar(
 		&artifacts, "artifacts", "artifacts", "path to artifacts directory")
+	runCmd.Flags().StringVarP(
+		&clusterName, "cluster", "c", "", "name of an existing cluster to use for running tests")
 	runCmd.Flags().StringVar(
 		&clusterID, "cluster-id", "", "an identifier to use in the test cluster's name")
 	runCmd.Flags().StringVar(

--- a/pkg/cmd/roachtest/test.go
+++ b/pkg/cmd/roachtest/test.go
@@ -94,8 +94,14 @@ func (r *registry) Run(filter []string) int {
 	wg := &sync.WaitGroup{}
 	wg.Add(len(tests))
 
-	// We can't run local tests in parallel as there is only 1 "local" cluster.
-	if local {
+	// If we're running against an existing "local" cluster, force the local flag
+	// to true in order to get the "local" test configurations.
+	if clusterName == "local" {
+		local = true
+	}
+	// We can't run tests in parallel on local clusters or on an existing
+	// cluster.
+	if local || clusterName != "" {
 		parallelism = 1
 	}
 	// Limit the parallelism to the number of tests. The primary effect this has

--- a/pkg/cmd/roachtest/tpcc.go
+++ b/pkg/cmd/roachtest/tpcc.go
@@ -26,8 +26,8 @@ func init() {
 		c := newCluster(ctx, t, nodes+1)
 		defer c.Destroy(ctx)
 
-		c.Put(ctx, cockroach, "./cockroach")
-		c.Put(ctx, workload, "./workload")
+		c.Put(ctx, cockroach, "./cockroach", c.Range(1, nodes))
+		c.Put(ctx, workload, "./workload", c.Node(nodes+1))
 		c.Start(ctx, c.Range(1, nodes))
 
 		t.Status("running workload")


### PR DESCRIPTION
Add `-c/--cluster` flag for running a test or tests on an existing
cluster. When running on an existing cluster, the cluster is wiped
before and after the test, but no attempt is made to create or destroy
it. Like running a test locally, running on an existing cluster forces
parallelism to 1.

Fixes #22644

Release note: None