### PR TITLE
roachpb: Remove unused Attributes methods

### DIFF
--- a/pkg/roachpb/metadata.go
+++ b/pkg/roachpb/metadata.go
@@ -59,43 +59,9 @@ func (r ReplicaID) String() string {
 	return strconv.FormatInt(int64(r), 10)
 }
 
-// IsSubset returns whether attributes list a is a subset of
-// attributes list b.
-func (a Attributes) IsSubset(b Attributes) bool {
-	m := map[string]struct{}{}
-	for _, s := range b.Attrs {
-		m[s] = struct{}{}
-	}
-	for _, s := range a.Attrs {
-		if _, ok := m[s]; !ok {
-			return false
-		}
-	}
-	return true
-}
-
-func (a Attributes) uniqueAttrs() []string {
-	var attrs []string
-	m := map[string]struct{}{}
-	for _, s := range a.Attrs {
-		if _, ok := m[s]; !ok {
-			m[s] = struct{}{}
-			attrs = append(attrs, s)
-		}
-	}
-	return attrs
-}
-
+// String implements the fmt.Stringer interface.
 func (a Attributes) String() string {
-	return strings.Join(a.uniqueAttrs(), ",")
-}
-
-// SortedString returns a sorted, de-duplicated, comma-separated list
-// of the attributes.
-func (a Attributes) SortedString() string {
-	attrs := a.uniqueAttrs()
-	sort.Strings(attrs)
-	return strings.Join(attrs, ",")
+	return strings.Join(a.Attrs, ",")
 }
 
 // RSpan returns the RangeDescriptor's resolved span.

--- a/pkg/roachpb/metadata_test.go
+++ b/pkg/roachpb/metadata_test.go
@@ -23,46 +23,6 @@ import (
 	"github.com/pkg/errors"
 )
 
-func TestAttributesIsSubset(t *testing.T) {
-	a := Attributes{Attrs: []string{"a", "b", "c"}}
-	b := Attributes{Attrs: []string{"a", "b"}}
-	c := Attributes{Attrs: []string{"a"}}
-	if !b.IsSubset(a) {
-		t.Errorf("expected %+v to be a subset of %+v", b, a)
-	}
-	if !c.IsSubset(a) {
-		t.Errorf("expected %+v to be a subset of %+v", c, a)
-	}
-	if !c.IsSubset(b) {
-		t.Errorf("expected %+v to be a subset of %+v", c, b)
-	}
-	if a.IsSubset(b) {
-		t.Errorf("%+v should not be a subset of %+v", a, b)
-	}
-	if a.IsSubset(c) {
-		t.Errorf("%+v should not be a subset of %+v", a, c)
-	}
-	if b.IsSubset(c) {
-		t.Errorf("%+v should not be a subset of %+v", b, c)
-	}
-}
-
-func TestAttributesSortedString(t *testing.T) {
-	a := Attributes{Attrs: []string{"a", "b", "c"}}
-	if a.SortedString() != "a,b,c" {
-		t.Errorf("sorted string of %+v (%s) != \"a,b,c\"", a, a.SortedString())
-	}
-	b := Attributes{Attrs: []string{"c", "a", "b"}}
-	if b.SortedString() != "a,b,c" {
-		t.Errorf("sorted string of %+v (%s) != \"a,b,c\"", b, b.SortedString())
-	}
-	// Duplicates.
-	c := Attributes{Attrs: []string{"c", "c", "a", "a", "b", "b"}}
-	if c.SortedString() != "a,b,c" {
-		t.Errorf("sorted string of %+v (%s) != \"a,b,c\"", c, c.SortedString())
-	}
-}
-
 func TestPercentilesFromData(t *testing.T) {
 	testCases := []struct {
 		data      []float64


### PR DESCRIPTION
Also avoid unique-ifying Attributes when printing them, since we don't
unique-ify them when we actually use them. If there's anywhere that
having duplicate attributes would cause problems, it'll be much easier
to debug if we don't lie about the fact that there are duplicates when
printing them.

Release note: None