### PR TITLE
allocator: fix panic in currently unused selectGood code path

### DIFF
--- a/pkg/storage/allocator_scorer.go
+++ b/pkg/storage/allocator_scorer.go
@@ -374,10 +374,10 @@ func (cl candidateList) betterThan(c candidate) candidateList {
 // selectGood randomly chooses a good candidate store from a sorted (by score
 // reversed) candidate list using the provided random generator.
 func (cl candidateList) selectGood(randGen allocatorRand) *candidate {
+	cl = cl.best()
 	if len(cl) == 0 {
 		return nil
 	}
-	cl = cl.best()
 	if len(cl) == 1 {
 		return &cl[0]
 	}
@@ -396,10 +396,10 @@ func (cl candidateList) selectGood(randGen allocatorRand) *candidate {
 // selectBad randomly chooses a bad candidate store from a sorted (by score
 // reversed) candidate list using the provided random generator.
 func (cl candidateList) selectBad(randGen allocatorRand) *candidate {
+	cl = cl.worst()
 	if len(cl) == 0 {
 		return nil
 	}
-	cl = cl.worst()
 	if len(cl) == 1 {
 		return &cl[0]
 	}

--- a/pkg/storage/allocator_scorer_test.go
+++ b/pkg/storage/allocator_scorer_test.go
@@ -87,6 +87,22 @@ func TestOnlyValidAndNotFull(t *testing.T) {
 	}
 }
 
+// TestSelectGoodPanic is a basic regression test against a former panic in
+// selectGood when called with just invalid/full stores.
+func TestSelectGoodPanic(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	cl := candidateList{
+		candidate{
+			valid: false,
+		},
+	}
+	allocRand := makeAllocatorRand(rand.NewSource(0))
+	if good := cl.selectGood(allocRand); good != nil {
+		t.Errorf("cl.selectGood() got %v, want nil", good)
+	}
+}
+
 // TestCandidateSelection tests select{good,bad} and {best,worst}constraints.
 func TestCandidateSelection(t *testing.T) {
 	defer leaktest.AfterTest(t)()


### PR DESCRIPTION
The way the allocator scorer is currently written, selectGood should
never receive a candidateList with just invalid/full stores, but it's
still bad to have a potential panic there just waiting to happen.

Release note: None