### PR TITLE
logictest: deflake GRANT test

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/database
+++ b/pkg/sql/logictest/testdata/logic_test/database
@@ -161,5 +161,11 @@ GRANT DROP ON DATABASE privs TO testuser
 
 user testuser
 
+# Wait for gossip to propagate the new version of the database descriptor.
+#
+# TODO: block the `GRANT` statement until the new version has been propagated.
+# See #22841.
+sleep 250ms
+
 statement ok
 DROP DATABASE privs CASCADE


### PR DESCRIPTION
The effects of GRANT are non-transactional and do not appear immediately.
Introduce a sleep before performing a query that relies on the effects of a
GRANT.

Fix #22798.

Release note: None