### PR TITLE
opt: add rules to simplify and/or

### DIFF
--- a/pkg/sql/opt/xform/factory.og.go
+++ b/pkg/sql/opt/xform/factory.og.go
@@ -257,6 +257,19 @@ func (_f *factory) ConstructAnd(
 		}
 	}
 
+	// [SimplifyAnd]
+	{
+		for _, _item := range _f.mem.lookupList(conditions) {
+			_true := _f.mem.lookupNormExpr(_item).asTrue()
+			if _true != nil {
+				_f.reportOptimization()
+				_group = _f.simplifyAnd(conditions)
+				_f.mem.addAltFingerprint(_andExpr.fingerprint(), _group)
+				return _group
+			}
+		}
+	}
+
 	return _f.onConstruct(_f.mem.memoizeNormExpr((*memoExpr)(&_andExpr)))
 }
 
@@ -300,6 +313,29 @@ func (_f *factory) ConstructOr(
 				_f.mem.addAltFingerprint(_orExpr.fingerprint(), _group)
 				return _group
 			}
+		}
+	}
+
+	// [SimplifyOr]
+	{
+		for _, _item := range _f.mem.lookupList(conditions) {
+			_false := _f.mem.lookupNormExpr(_item).asFalse()
+			if _false != nil {
+				_f.reportOptimization()
+				_group = _f.simplifyOr(conditions)
+				_f.mem.addAltFingerprint(_orExpr.fingerprint(), _group)
+				return _group
+			}
+		}
+	}
+
+	// [EliminateSingletonOr]
+	{
+		if _f.isSingletonList(conditions) {
+			_f.reportOptimization()
+			_group = _f.firstListItem(conditions)
+			_f.mem.addAltFingerprint(_orExpr.fingerprint(), _group)
+			return _group
 		}
 	}
 

--- a/pkg/sql/opt/xform/rules/bool.opt
+++ b/pkg/sql/opt/xform/rules/bool.opt
@@ -41,6 +41,38 @@
 =>
 (FlattenOr $conditions)
 
+# SimplifyAnd removes True children of an And. If all children are True,
+# replaces the And node with True.
+# This rule is especially important when we build a simplified filter.
+[SimplifyAnd, Normalize]
+(And
+    $conditions:[ ... (True) ... ]
+)
+=>
+(SimplifyAnd $conditions)
+
+# SimplifyOr removes False children of an Or. If all children are False,
+# replaces the Or node with False.
+# This rule is especially important when we build a simplified filter.
+[SimplifyOr, Normalize]
+(Or
+    $conditions:[ ... (False) ... ]
+)
+=>
+(SimplifyOr $conditions)
+
+# TODO(radu): we don't yet eliminate singleton Ands because we assume filters
+# are always under an And.
+
+# EliminateSingletonOr replaces an Or node with a single condition with that
+# condition.
+[EliminateSingletonOr, Normalize]
+(Or
+    $conditions:* & (IsSingletonList $conditions)
+)
+=>
+(FirstListItem $conditions)
+
 # NegateComparison inverts eligible comparison operators when they are negated
 # by the Not operator. For example, Eq maps to Ne, and Gt maps to Le.
 [NegateComparison, Normalize]

--- a/pkg/sql/opt/xform/testdata/rules/bool
+++ b/pkg/sql/opt/xform/testdata/rules/bool
@@ -129,6 +129,92 @@ select
            └── const: 'bar' [type=string]
 
 #
+# SimplifyAnd
+#
+opt
+SELECT * FROM a WHERE k=1 AND i=2 AND true
+----
+select
+ ├── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5
+ ├── scan
+ │    └── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5
+ └── and [type=bool]
+      ├── eq [type=bool]
+      │    ├── variable: a.k [type=int]
+      │    └── const: 1 [type=int]
+      └── eq [type=bool]
+           ├── variable: a.i [type=int]
+           └── const: 2 [type=int]
+
+opt
+SELECT * FROM a WHERE true AND true
+----
+select
+ ├── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5
+ ├── scan
+ │    └── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5
+ └── true [type=bool]
+
+#
+# SimplifyOr
+#
+opt
+SELECT * FROM a WHERE k=1 OR i=2 OR false
+----
+select
+ ├── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5
+ ├── scan
+ │    └── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5
+ └── or [type=bool]
+      ├── eq [type=bool]
+      │    ├── variable: a.k [type=int]
+      │    └── const: 1 [type=int]
+      └── eq [type=bool]
+           ├── variable: a.i [type=int]
+           └── const: 2 [type=int]
+
+opt
+SELECT * FROM a WHERE false OR false
+----
+select
+ ├── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5
+ ├── scan
+ │    └── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5
+ └── false [type=bool]
+
+#
+# SimplifyAnd + SimplifyOr
+#
+opt
+SELECT * FROM a WHERE (k=1 OR false) AND (false OR k=2 OR false) AND true
+----
+select
+ ├── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5
+ ├── scan
+ │    └── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5
+ └── and [type=bool]
+      ├── eq [type=bool]
+      │    ├── variable: a.k [type=int]
+      │    └── const: 1 [type=int]
+      └── eq [type=bool]
+           ├── variable: a.k [type=int]
+           └── const: 2 [type=int]
+
+#
+# SimplifyOr + ElideOr
+#
+opt
+SELECT * FROM a WHERE k=1 OR false
+----
+select
+ ├── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5
+ ├── scan
+ │    └── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5
+ └── eq [type=bool]
+      ├── variable: a.k [type=int]
+      └── const: 1 [type=int]
+
+#
 # NegateComparison
 #   Equality and inequality comparisons.
 #

--- a/pkg/testutils/datadriven/datadriven.go
+++ b/pkg/testutils/datadriven/datadriven.go
@@ -66,7 +66,15 @@ func RunTest(t *testing.T, path string, f func(d *TestData) string) {
 	r := newTestDataReader(t, path)
 	for r.Next(t) {
 		d := &r.data
-		actual := f(d)
+		actual := func() string {
+			defer func() {
+				if r := recover(); r != nil {
+					fmt.Printf("\npanic during %s:\n%s\n", d.Pos, d.Input)
+					panic(r)
+				}
+			}()
+			return f(d)
+		}()
 
 		if r.rewrite != nil {
 			r.emit("----")


### PR DESCRIPTION
#### datadriven: show position when panic occurs

If a testcase hits a panic, we don't know which case it was, unless in
verbose mode. Adding a function that catches any panic, prints out the
position information, and rethrows it.

Release note: None

#### opt: add rules to simplify and/or

Adding rules to remove True children of And ops, and False children of
Or ops. This is useful when trimming down filters after removing index
constraints.

Also, elide an Or op with a single child. We don't yet do this for And
because we currently assume filters always start with an AndOp.

Release note: None