### PR TITLE
cherrypick-1.1: sql: avoid leaking database names when scrubbing virtual table names

### DIFF
--- a/pkg/sql/app_stats.go
+++ b/pkg/sql/app_stats.go
@@ -267,8 +267,11 @@ func scrubStmtStatKey(vt virtualSchemaHolder, key string) (string, bool) {
 				buf.WriteByte('_')
 				return
 			}
-			// Virtual table: we want to keep the name.
-			tn.Format(buf, parser.FmtParsable)
+			// Virtual table: we want to keep the name; however we need to
+			// scrub the database name prefix.
+			newTn := *tn
+			newTn.PrefixName = "_"
+			newTn.Format(buf, parser.FmtParsable)
 		})
 	return parser.AsStringWithFlags(stmt, formatter), true
 }

--- a/pkg/sql/logictest/testdata/logic_test/statement_statistics
+++ b/pkg/sql/logictest/testdata/logic_test/statement_statistics
@@ -51,7 +51,7 @@ SELECT sqrt(-1.0)
 # Check that shortened queries can use virtual tables.
 
 statement ok
-SELECT key FROM crdb_internal.node_statement_statistics
+SELECT key FROM test.crdb_internal.node_statement_statistics
 
 # Check that multi-value clauses are shortened.
 
@@ -100,7 +100,7 @@ SELECT key,flags FROM crdb_internal.node_statement_statistics WHERE application_
 key                                                      flags
 INSERT INTO test VALUES (_, _, _)                        ·
 SELECT ROW(_, _, _, _, _) FROM test WHERE _              ·
-SELECT key FROM crdb_internal.node_statement_statistics  ·
+SELECT key FROM test.crdb_internal.node_statement_statistics  ·
 SELECT sin(_)                                            ·
 SELECT sqrt(-_)                                          !
 SELECT x FROM (VALUES (_, _, _)) AS t (x)                ·
@@ -113,12 +113,13 @@ SELECT x FROM test WHERE y NOT IN (_, _)                 ·
 # Check that names are anonymized properly:
 # - virtual table names are preserved
 # - function names are preserved
+# - database name prefixes for vtables are scrubbed (#22700)
 query T
 SELECT anonymized FROM crdb_internal.node_statement_statistics WHERE application_name = 'valuetest' ORDER BY key
 ----
 INSERT INTO _ VALUES (_, _, _)
 SELECT ROW(_, _, _, _, _) FROM _ WHERE _
-SELECT _ FROM crdb_internal.node_statement_statistics
+SELECT _ FROM _.crdb_internal.node_statement_statistics
 SELECT sin(_)
 SELECT sqrt(-_)
 SELECT _ FROM (VALUES (_, _, _)) AS _ (_)


### PR DESCRIPTION
Release note (bug fix): Queries over virtual tables with an explicit
database name prefix (e.g. `select * from mydb.crdb_internal.tables`)
would not be scrubbed properly from reported statistics. This is now
fixed.

Fixes #22700.