### PR TITLE
cherrypick-1.0: sql: avoid leaking database names when scrubbing virtual table names

### DIFF
--- a/pkg/sql/app_stats.go
+++ b/pkg/sql/app_stats.go
@@ -263,8 +263,11 @@ func scrubStmtStatKey(vt virtualSchemaHolder, key string) (string, bool) {
 				buf.WriteByte('_')
 				return
 			}
-			// Virtual table: we want to keep the name.
-			tn.Format(buf, parser.FmtParsable)
+			// Virtual table: we want to keep the name; however we need to
+			// scrub the database name prefix.
+			newTn := *tn
+			newTn.PrefixName = "_"
+			newTn.Format(buf, parser.FmtParsable)
 		})
 	return parser.AsStringWithFlags(stmt, formatter), true
 }


### PR DESCRIPTION
Release note (bug fix): Queries over virtual tables with an explicit
database name prefix (e.g. `select * from mydb.crdb_internal.tables`)
would not be scrubbed properly from reported statistics. This is now
fixed.

Fixes #22700.

cc @cockroachdb/release 