### PR TITLE
opt: first batch of changes for porting the index constraints code

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/scalar_builder.go
+++ b/pkg/sql/opt/exec/execbuilder/scalar_builder.go
@@ -85,7 +85,7 @@ func (b *Builder) buildVariable(ctx *buildScalarCtx, ev xform.ExprView) tree.Typ
 }
 
 func (b *Builder) buildTuple(ctx *buildScalarCtx, ev xform.ExprView) tree.TypedExpr {
-	if isTupleOfConstants(ev) {
+	if xform.MatchesTupleOfConstants(ev) {
 		datums := make(tree.Datums, ev.ChildCount())
 		for i := 0; i < ev.ChildCount(); i++ {
 			child := ev.Child(i)
@@ -152,17 +152,4 @@ func (b *Builder) buildBinary(ctx *buildScalarCtx, ev xform.ExprView) tree.Typed
 		b.buildScalar(ctx, ev.Child(1)),
 		ev.Logical().Scalar.Type,
 	)
-}
-
-func isTupleOfConstants(ev xform.ExprView) bool {
-	if ev.Operator() != opt.TupleOp {
-		return false
-	}
-	for i := 0; i < ev.ChildCount(); i++ {
-		child := ev.Child(i)
-		if child.Operator() != opt.ConstOp {
-			return false
-		}
-	}
-	return true
 }

--- a/pkg/sql/opt/idxconstraint/index_constraints.go
+++ b/pkg/sql/opt/idxconstraint/index_constraints.go
@@ -19,15 +19,17 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/opt"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/xform"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/cockroach/pkg/util/json"
 )
 
-// makeEqSpan returns a span that constraints column <offset> to a single value.
+// makeEqSpan returns a span that constrains a column to a single value.
 // The value can be NULL.
-func (c *indexConstraintCtx) makeEqSpan(offset int, value tree.Datum) LogicalSpan {
+func (c *indexConstraintCtx) makeEqSpan(value tree.Datum) LogicalSpan {
 	return LogicalSpan{
 		Start: LogicalKey{Vals: tree.Datums{value}, Inclusive: true},
 		End:   LogicalKey{Vals: tree.Datums{value}, Inclusive: true},
@@ -51,7 +53,7 @@ func (c *indexConstraintCtx) makeNotNullSpan(offset int) LogicalSpan {
 	return sp
 }
 
-// makeStringPrefixSpan returns a span that constraints string column <offset>
+// makeStringPrefixSpan returns a span that constrains string column <offset>
 // to strings having the given prefix.
 func (c *indexConstraintCtx) makeStringPrefixSpan(offset int, prefix string) LogicalSpan {
 	span := c.makeNotNullSpan(offset)
@@ -99,13 +101,13 @@ func (c *indexConstraintCtx) verifyType(offset int, typ types.T) bool {
 // operand. The <tight> return value indicates if the spans are exactly
 // equivalent to the expression (and not weaker).
 func (c *indexConstraintCtx) makeSpansForSingleColumn(
-	offset int, op operator, val *Expr,
+	offset int, op opt.Operator, val xform.ExprView,
 ) (_ LogicalSpans, ok bool, tight bool) {
-	if op == inOp && isTupleOfConstants(val) {
+	if op == opt.InOp && xform.MatchesTupleOfConstants(val) {
 		// We assume that the values of the tuple are already ordered and distinct.
-		spans := make(LogicalSpans, 0, len(val.children))
-		for _, v := range val.children {
-			datum := v.private.(tree.Datum)
+		spans := make(LogicalSpans, 0, val.ChildCount())
+		for i, n := 0, val.ChildCount(); i < n; i++ {
+			datum := getConstDatum(val.Child(i))
 			if !c.verifyType(offset, datum.ResolvedType()) {
 				return nil, false, false
 			}
@@ -113,10 +115,7 @@ func (c *indexConstraintCtx) makeSpansForSingleColumn(
 				// Ignore NULLs - they can't match any values
 				continue
 			}
-			spans = append(spans, LogicalSpan{
-				Start: LogicalKey{Vals: tree.Datums{datum}, Inclusive: true},
-				End:   LogicalKey{Vals: tree.Datums{datum}, Inclusive: true},
-			})
+			spans = append(spans, c.makeEqSpan(datum))
 		}
 		if c.colInfos[offset].Direction == encoding.Descending {
 			// Reverse the order of the spans.
@@ -126,44 +125,59 @@ func (c *indexConstraintCtx) makeSpansForSingleColumn(
 		}
 		return spans, true, true
 	}
+
 	// The rest of the supported expressions must have a constant scalar on the
 	// right-hand side.
-	if val.op != constOp {
+	if !val.IsConstValue() {
 		return nil, false, false
 	}
-	datum := val.private.(tree.Datum)
+	return c.makeSpansForSingleColumnDatum(offset, op, getConstDatum(val))
+}
+
+// makeSpansForSingleColumn creates spans for a single index column from a
+// simple comparison expression with a constant value on the right-hand side.
+func (c *indexConstraintCtx) makeSpansForSingleColumnDatum(
+	offset int, op opt.Operator, datum tree.Datum,
+) (_ LogicalSpans, ok bool, tight bool) {
 	if !c.verifyType(offset, datum.ResolvedType()) {
 		return nil, false, false
 	}
 	if datum == tree.DNull {
 		switch op {
-		case eqOp, ltOp, gtOp, leOp, geOp, neOp:
+		case opt.EqOp, opt.LtOp, opt.GtOp, opt.LeOp, opt.GeOp, opt.NeOp:
 			// The result of this expression is always NULL. Normally, this expression
 			// should have been converted to NULL during type checking; but if the
 			// NULL is coming from a placeholder, that doesn't happen.
 			return LogicalSpans{}, true, true
 
-		case isOp:
+		case opt.IsOp:
 			if !c.colInfos[offset].Nullable {
 				// The column is not nullable; IS NULL is always false.
 				return LogicalSpans{}, true, true
 			}
-			return LogicalSpans{c.makeEqSpan(offset, tree.DNull)}, true, true
+			return LogicalSpans{c.makeEqSpan(tree.DNull)}, true, true
 
-		case isNotOp:
+		case opt.IsNotOp:
 			return LogicalSpans{c.makeNotNullSpan(offset)}, true, true
 		}
 		return nil, false, false
 	}
 
 	switch op {
-	case eqOp, isOp:
-		return LogicalSpans{c.makeEqSpan(offset, datum)}, true, true
+	case opt.EqOp, opt.IsOp:
+		return LogicalSpans{c.makeEqSpan(datum)}, true, true
 
-	case ltOp, gtOp, leOp, geOp:
+	case opt.LtOp, opt.GtOp, opt.LeOp, opt.GeOp:
 		sp := c.makeNotNullSpan(offset)
-		inclusive := (op == leOp || op == geOp)
-		if (op == ltOp || op == leOp) == (c.colInfos[offset].Direction == encoding.Ascending) {
+		// We have an upper bound if the direction of the comparison "matches" the
+		// direction of the column, or a lower bound otherwise. More precisely:
+		//
+		//  Op \ Dir |  Ascending  |  Descending
+		//  ---------+-------------+------------
+		//  LT,LE    | Upper bound | Lower bound
+		//  GT,GE    | Lower bound | Upper bound
+		inclusive := (op == opt.LeOp || op == opt.GeOp)
+		if (op == opt.LtOp || op == opt.LeOp) == (c.colInfos[offset].Direction == encoding.Ascending) {
 			sp.End = LogicalKey{Vals: tree.Datums{datum}, Inclusive: inclusive}
 		} else {
 			sp.Start = LogicalKey{Vals: tree.Datums{datum}, Inclusive: inclusive}
@@ -173,7 +187,7 @@ func (c *indexConstraintCtx) makeSpansForSingleColumn(
 		}
 		return LogicalSpans{sp}, true, true
 
-	case neOp, isNotOp:
+	case opt.NeOp, opt.IsNotOp:
 		spans := LogicalSpans{c.makeNotNullSpan(offset), c.makeNotNullSpan(offset)}
 		spans[0].End = LogicalKey{Vals: tree.Datums{datum}, Inclusive: false}
 		spans[1].Start = LogicalKey{Vals: tree.Datums{datum}, Inclusive: false}
@@ -181,7 +195,7 @@ func (c *indexConstraintCtx) makeSpansForSingleColumn(
 		c.preferInclusive(offset, &spans[1])
 		return spans, true, true
 
-	case likeOp:
+	case opt.LikeOp:
 		if s, ok := tree.AsDString(datum); ok {
 			if i := strings.IndexAny(string(s), "_%"); i >= 0 {
 				if i == 0 {
@@ -196,17 +210,17 @@ func (c *indexConstraintCtx) makeSpansForSingleColumn(
 				return LogicalSpans{span}, true, tight
 			}
 			// No wildcard characters, this is an equality.
-			return LogicalSpans{c.makeEqSpan(offset, &s)}, true, true
+			return LogicalSpans{c.makeEqSpan(&s)}, true, true
 		}
 
-	case similarToOp:
+	case opt.SimilarToOp:
 		// a SIMILAR TO 'foo_*' -> prefix "foo"
 		if s, ok := tree.AsDString(datum); ok {
 			pattern := tree.SimilarEscape(string(s))
 			if re, err := regexp.Compile(pattern); err == nil {
 				prefix, complete := re.LiteralPrefix()
 				if complete {
-					return LogicalSpans{c.makeEqSpan(offset, tree.NewDString(prefix))}, true, true
+					return LogicalSpans{c.makeEqSpan(tree.NewDString(prefix))}, true, true
 				}
 				span := c.makeStringPrefixSpan(offset, prefix)
 				return LogicalSpans{span}, true, false
@@ -218,40 +232,41 @@ func (c *indexConstraintCtx) makeSpansForSingleColumn(
 
 // makeSpansForTupleInequality creates spans for index columns starting at
 // <offset> from a tuple inequality.
-// Assumes that e.op is an inequality and both sides are tuples.
+// Assumes that e.Operator() is an inequality and both sides are tuples.
 // The <tight> return value indicates if the spans are exactly equivalent
 // to the expression (and not weaker).
 func (c *indexConstraintCtx) makeSpansForTupleInequality(
-	offset int, e *Expr,
+	offset int, ev xform.ExprView,
 ) (_ LogicalSpans, ok bool, tight bool) {
-	lhs, rhs := e.children[0], e.children[1]
+	lhs, rhs := ev.Child(0), ev.Child(1)
 
 	// Find the longest prefix of the tuple that maps to index columns (with the
 	// same direction) starting at <offset>.
 	prefixLen := 0
 	dir := c.colInfos[offset].Direction
 	nullVal := false
-	for i := range lhs.children {
-		if !(offset+i < len(c.colInfos) && c.isIndexColumn(lhs.children[i], offset+i)) {
-			// Variable doesn't refer to the right column.
+	for i, n := 0, lhs.ChildCount(); i < n; i++ {
+		leftChild, rightChild := lhs.Child(i), rhs.Child(i)
+		if !(offset+i < len(c.colInfos) && c.isIndexColumn(leftChild, offset+i)) {
+			// Variable doesn't refer to the column of interest.
 			break
 		}
-		if rhs.children[i].op != constOp {
+		if !rightChild.IsConstValue() {
 			// Right-hand value is not a constant.
 			break
 		}
-		if !c.verifyType(offset+i, rhs.children[i].scalarProps.typ) {
+		if !c.verifyType(offset+i, rightChild.Logical().Scalar.Type) {
 			// We have a mixed-type comparison; we can't encode this in a span
 			// (see #4313).
 			break
 		}
-		if isConstNull(rhs.children[i]) {
+		if xform.MatchesConstNull(rightChild) {
 			// NULLs are tricky and require special handling; see
 			// nullVal related code below.
 			nullVal = true
 			break
 		}
-		if c.colInfos[offset+i].Direction != dir && e.op != neOp {
+		if c.colInfos[offset+i].Direction != dir && ev.Operator() != opt.NeOp {
 			// The direction changed. For example:
 			//   a ASCENDING, b DESCENDING, c ASCENDING
 			//   (a, b, c) >= (1, 2, 3)
@@ -274,16 +289,16 @@ func (c *indexConstraintCtx) makeSpansForTupleInequality(
 
 	datums := make(tree.Datums, prefixLen)
 	for i := range datums {
-		datums[i] = rhs.children[i].private.(tree.Datum)
+		datums[i] = getConstDatum(rhs.Child(i))
 	}
 
 	// less is true if the op is < or <= and false if the op is > or >=.
 	// inclusive is true if the op is <= or >= and false if the op is < or >.
 	var less, inclusive bool
 
-	switch e.op {
-	case neOp:
-		if prefixLen < len(lhs.children) {
+	switch ev.Operator() {
+	case opt.NeOp:
+		if prefixLen < lhs.ChildCount() {
 			// If we have (a, b, c) != (1, 2, 3), we cannot
 			// determine any constraint on (a, b).
 			return nil, false, false
@@ -315,20 +330,20 @@ func (c *indexConstraintCtx) makeSpansForTupleInequality(
 		}
 		return spans, true, tight
 
-	case ltOp:
+	case opt.LtOp:
 		less, inclusive = true, false
-	case leOp:
+	case opt.LeOp:
 		less, inclusive = true, true
-	case gtOp:
+	case opt.GtOp:
 		less, inclusive = false, false
-	case geOp:
+	case opt.GeOp:
 		less, inclusive = false, true
 	default:
-		panic(fmt.Sprintf("unsupported op %s", e.op))
+		panic(fmt.Sprintf("unsupported op %s", ev.Operator()))
 	}
 
 	// The spans are "tight" unless we used just a prefix.
-	tight = (prefixLen == len(lhs.children))
+	tight = (prefixLen == lhs.ChildCount())
 
 	if nullVal {
 		// NULL is treated semantically as "unknown value", so
@@ -342,8 +357,8 @@ func (c *indexConstraintCtx) makeSpansForTupleInequality(
 		// is true if and only if a > 1.
 		inclusive = false
 		tight = true
-	} else if prefixLen < len(lhs.children) {
-		// If we only keep a prefix, exclusive inequalities become exclusive.
+	} else if !tight {
+		// If we only keep a prefix, exclusive inequalities become inclusive.
 		// For example:
 		//   (a, b, c) > (1, 2, 3) becomes (a, b) >= (1, 2)
 		inclusive = true
@@ -401,9 +416,9 @@ func (c *indexConstraintCtx) makeSpansForTupleInequality(
 // The <tight> return value indicates if the spans are exactly equivalent
 // to the expression (and not weaker).
 func (c *indexConstraintCtx) makeSpansForTupleIn(
-	offset int, e *Expr,
+	offset int, ev xform.ExprView,
 ) (_ LogicalSpans, ok bool, tight bool) {
-	lhs, rhs := e.children[0], e.children[1]
+	lhs, rhs := ev.Child(0), ev.Child(1)
 
 	// Find the longest prefix of columns starting at <offset> which is contained
 	// in the left-hand tuple; tuplePos[i] is the position of column <offset+i> in
@@ -411,8 +426,8 @@ func (c *indexConstraintCtx) makeSpansForTupleIn(
 	var tuplePos []int
 	for i := offset; i < len(c.colInfos); i++ {
 		found := false
-		for j := range lhs.children {
-			if c.isIndexColumn(lhs.children[j], i) {
+		for j, n := 0, lhs.ChildCount(); j < n; j++ {
+			if c.isIndexColumn(lhs.Child(j), i) {
 				tuplePos = append(tuplePos, j)
 				found = true
 				break
@@ -427,18 +442,19 @@ func (c *indexConstraintCtx) makeSpansForTupleIn(
 	}
 
 	// Create a span for each (tuple) value inside the right-hand side tuple.
-	spans := make(LogicalSpans, 0, len(rhs.children))
-	for _, valTuple := range rhs.children {
-		if valTuple.op != tupleOp {
+	spans := make(LogicalSpans, 0, rhs.ChildCount())
+	for i, n := 0, rhs.ChildCount(); i < n; i++ {
+		valTuple := rhs.Child(i)
+		if valTuple.Operator() != opt.TupleOp {
 			return nil, false, false
 		}
 		vals := make(tree.Datums, len(tuplePos))
 		for i, pos := range tuplePos {
-			val := valTuple.children[pos]
-			if val.op != constOp {
+			val := valTuple.Child(pos)
+			if !val.IsConstValue() {
 				return nil, false, false
 			}
-			datum := val.private.(tree.Datum)
+			datum := getConstDatum(val)
 			if !c.verifyType(offset+i, datum.ResolvedType()) {
 				return nil, false, false
 			}
@@ -472,7 +488,7 @@ func (c *indexConstraintCtx) makeSpansForTupleIn(
 		res = append(res, spans[i])
 	}
 	// The spans are "tight" unless we used just a prefix.
-	tight = len(tuplePos) == len(lhs.children)
+	tight = len(tuplePos) == rhs.ChildCount()
 	return res, true, tight
 }
 
@@ -482,70 +498,75 @@ func (c *indexConstraintCtx) makeSpansForTupleIn(
 // The <tight> return value indicates if the spans are exactly equivalent to the
 // expression (and not weaker). See simplifyFilter for more information.
 func (c *indexConstraintCtx) makeSpansForExpr(
-	offset int, e *Expr,
+	offset int, ev xform.ExprView,
 ) (_ LogicalSpans, ok bool, tight bool) {
-	switch e.op {
-	case constOp:
-		datum := e.private.(tree.Datum)
+
+	if ev.IsConstValue() {
+		datum := getConstDatum(ev)
 		if datum == tree.DBoolFalse || datum == tree.DNull {
 			// Condition is never true, return no spans.
 			return LogicalSpans{}, true, true
 		}
 		return nil, false, false
+	}
 
-	case andOp:
-		spans, ok := c.makeSpansForAndExprs(offset, e.children)
+	switch ev.Operator() {
+	case opt.AndOp:
+		// TODO(radu): special-case AndOp with 1 child?
+		spans, ok := c.makeSpansForAnd(offset, ev)
 		// We don't have enough information to know if the spans are "tight".
 		return spans, ok, false
 
-	case orOp:
-		return c.makeSpansForOrExprs(offset, e.children)
+	case opt.OrOp:
+		return c.makeSpansForOr(offset, ev)
 
-	case variableOp:
+	case opt.VariableOp:
 		// Support (@1) as (@1 = TRUE) if @1 is boolean.
-		if c.colInfos[offset].Typ == types.Bool && c.isIndexColumn(e, offset) {
-			return c.makeSpansForSingleColumn(offset, eqOp, constTrueExpr)
+		if c.colInfos[offset].Typ == types.Bool && c.isIndexColumn(ev, offset) {
+			return c.makeSpansForSingleColumnDatum(offset, opt.EqOp, tree.DBoolTrue)
 		}
 
-	case notOp:
+	case opt.NotOp:
 		// Support (NOT @1) as (@1 = FALSE) is @1 is boolean.
-		if c.colInfos[offset].Typ == types.Bool && c.isIndexColumn(e.children[0], offset) {
-			return c.makeSpansForSingleColumn(offset, eqOp, constFalseExpr)
+		if c.colInfos[offset].Typ == types.Bool && c.isIndexColumn(ev.Child(0), offset) {
+			return c.makeSpansForSingleColumnDatum(offset, opt.EqOp, tree.DBoolFalse)
 		}
 	}
 
-	if len(e.children) < 2 {
+	if ev.ChildCount() < 2 {
 		return nil, false, false
 	}
+	child0, child1 := ev.Child(0), ev.Child(1)
+
 	// Check for an operation where the left-hand side is an
 	// indexed var for this column.
-	if c.isIndexColumn(e.children[0], offset) {
-		spans, ok, tight := c.makeSpansForSingleColumn(offset, e.op, e.children[1])
+	if c.isIndexColumn(child0, offset) {
+		spans, ok, tight := c.makeSpansForSingleColumn(offset, ev.Operator(), child1)
 		if ok {
 			return spans, ok, tight
 		}
 		// We couldn't get any constraints for the column; see if we can at least
 		// deduce a not-NULL constraint.
-		if c.colInfos[offset].Nullable && opRequiresNotNullArgs(e.op) {
+		if c.colInfos[offset].Nullable && opRequiresNotNullArgs(ev.Operator()) {
 			return LogicalSpans{c.makeNotNullSpan(offset)}, true, false
 		}
 	}
 	// Check for tuple operations.
-	if e.children[0].op == tupleOp && e.children[1].op == tupleOp {
-		switch e.op {
-		case ltOp, leOp, gtOp, geOp, neOp:
+	if child0.Operator() == opt.TupleOp && child1.Operator() == opt.TupleOp {
+		switch ev.Operator() {
+		case opt.LtOp, opt.LeOp, opt.GtOp, opt.GeOp, opt.NeOp:
 			// Tuple inequality.
-			return c.makeSpansForTupleInequality(offset, e)
-		case inOp:
+			return c.makeSpansForTupleInequality(offset, ev)
+		case opt.InOp:
 			// Tuple IN tuple.
-			return c.makeSpansForTupleIn(offset, e)
+			return c.makeSpansForTupleIn(offset, ev)
 		}
 	}
 
 	// Last resort: for conditions like a > b, our column can appear on the right
 	// side. We can deduce a not-null constraint from such conditions.
-	if c.colInfos[offset].Nullable && c.isIndexColumn(e.children[1], offset) &&
-		opRequiresNotNullArgs(e.op) {
+	if c.colInfos[offset].Nullable && c.isIndexColumn(child1, offset) &&
+		opRequiresNotNullArgs(ev.Operator()) {
 		return LogicalSpans{c.makeNotNullSpan(offset)}, true, false
 	}
 
@@ -554,12 +575,12 @@ func (c *indexConstraintCtx) makeSpansForExpr(
 
 // opRequiresNotNullArgs returns true if the operator can never evaluate
 // to true if one of the children is NULL.
-func opRequiresNotNullArgs(op operator) bool {
+func opRequiresNotNullArgs(op opt.Operator) bool {
 	switch op {
 	case
-		eqOp, ltOp, leOp, gtOp, geOp, neOp,
-		likeOp, notLikeOp, iLikeOp, notILikeOp, similarToOp, notSimilarToOp,
-		regMatchOp, notRegMatchOp, regIMatchOp, notRegIMatchOp:
+		opt.EqOp, opt.LtOp, opt.LeOp, opt.GtOp, opt.GeOp, opt.NeOp,
+		opt.LikeOp, opt.NotLikeOp, opt.ILikeOp, opt.NotILikeOp, opt.SimilarToOp, opt.NotSimilarToOp,
+		opt.RegMatchOp, opt.NotRegMatchOp, opt.RegIMatchOp, opt.NotRegIMatchOp:
 		return true
 	}
 	return false
@@ -571,7 +592,7 @@ type indexConstraintConjunctionCtx struct {
 	*indexConstraintCtx
 
 	// andExprs is a set of conjuncts that make up the filter.
-	andExprs []*Expr
+	andExprs []xform.ExprView
 
 	// Memoization data structure for calcOffset.
 	results []calcOffsetResult
@@ -586,14 +607,17 @@ type calcOffsetResult struct {
 	spans          LogicalSpans
 }
 
-// makeSpansForAndExprs calculates spans for a conjunction.
-func (c *indexConstraintCtx) makeSpansForAndExprs(
-	offset int, andExprs []*Expr,
+// makeSpansForAndcalculates spans for an AndOp.
+func (c *indexConstraintCtx) makeSpansForAnd(
+	offset int, ev xform.ExprView,
 ) (_ LogicalSpans, ok bool) {
 	conjCtx := indexConstraintConjunctionCtx{
 		indexConstraintCtx: c,
-		andExprs:           andExprs,
+		andExprs:           make([]xform.ExprView, ev.ChildCount()),
 		results:            make([]calcOffsetResult, len(c.colInfos)),
+	}
+	for i := range conjCtx.andExprs {
+		conjCtx.andExprs[i] = ev.Child(i)
 	}
 	return conjCtx.calcOffset(offset)
 }
@@ -790,15 +814,15 @@ func (c indexConstraintConjunctionCtx) calcOffset(offset int) (_ LogicalSpans, o
 	return spans, true
 }
 
-// makeSpansForOrExprs calculates spans for a disjunction.
-func (c *indexConstraintCtx) makeSpansForOrExprs(
-	offset int, orExprs []*Expr,
+// makeSpansForOr calculates spans for an OrOp.
+func (c *indexConstraintCtx) makeSpansForOr(
+	offset int, ev xform.ExprView,
 ) (_ LogicalSpans, ok bool, tight bool) {
 	var spans LogicalSpans
 
 	tight = true
-	for i, orExpr := range orExprs {
-		exprSpans, ok, exprTight := c.makeSpansForExpr(offset, orExpr)
+	for i, n := 0, ev.ChildCount(); i < n; i++ {
+		exprSpans, ok, exprTight := c.makeSpansForExpr(offset, ev.Child(i))
 		if !ok {
 			// If we can't generate spans for a disjunct, exit early (this is
 			// equivalent to a full span).
@@ -821,22 +845,22 @@ func (c *indexConstraintCtx) makeSpansForOrExprs(
 // makeInvertedIndexSpansForExpr is analogous to makeSpansForExpr, but it is
 // used for inverted indexes.
 func (c *indexConstraintCtx) makeInvertedIndexSpansForExpr(
-	e *Expr,
+	ev xform.ExprView,
 ) (_ LogicalSpans, ok bool, tight bool) {
-	switch e.op {
-	case containsOp:
-		lhs, rhs := e.children[0], e.children[1]
+	switch ev.Operator() {
+	case opt.ContainsOp:
+		lhs, rhs := ev.Child(0), ev.Child(1)
 
-		if !c.isIndexColumn(lhs, 0 /* index */) || rhs.op != constOp {
+		if !c.isIndexColumn(lhs, 0 /* index */) || !rhs.IsConstValue() {
 			return nil, false, false
 		}
 
-		rightDatum := rhs.private.(tree.Datum)
+		rightDatum := getConstDatum(rhs)
 		rd := rightDatum.(*tree.DJSON).JSON
 
 		switch rd.Type() {
 		case json.ArrayJSONType, json.ObjectJSONType:
-			return LogicalSpans{c.makeEqSpan(0 /* offset */, rhs.private.(tree.Datum))}, true, true
+			return LogicalSpans{c.makeEqSpan(getConstDatum(rhs))}, true, true
 		default:
 			// If we find a scalar on the right side of the @> operator it means that we need to find
 			// both matching scalars and arrays that contain that value. In order to do this we generate
@@ -864,9 +888,9 @@ func (c *indexConstraintCtx) makeInvertedIndexSpansForExpr(
 			return spans, true, true
 		}
 
-	case andOp:
-		for _, child := range e.children {
-			sp, ok, _ := c.makeInvertedIndexSpansForExpr(child)
+	case opt.AndOp:
+		for i, n := 0, ev.ChildCount(); i < n; i++ {
+			sp, ok, _ := c.makeInvertedIndexSpansForExpr(ev.Child(i))
 			if ok {
 				// TODO(radu, masha): for now, the best we can do is to generate
 				// constraints for at most one "contains" op in the disjunction; the
@@ -881,24 +905,24 @@ func (c *indexConstraintCtx) makeInvertedIndexSpansForExpr(
 	return nil, false, false
 }
 
-var constTrueExpr = &Expr{
-	op:          constOp,
-	scalarProps: &scalarProps{typ: types.Bool},
-	private:     tree.DBoolTrue,
-}
-
-var constFalseExpr = &Expr{
-	op:          constOp,
-	scalarProps: &scalarProps{typ: types.Bool},
-	private:     tree.DBoolFalse,
-}
-
-func constBoolExpr(val bool) *Expr {
-	if val {
-		return constTrueExpr
-	}
-	return constFalseExpr
-}
+//var constTrueExpr = &Expr{
+//	op:          opt.ConstOp,
+//	scalarProps: &scalarProps{typ: types.Bool},
+//	private:     tree.DBoolTrue,
+//}
+//
+//var constFalseExpr = &Expr{
+//	op:          opt.ConstOp,
+//	scalarProps: &scalarProps{typ: types.Bool},
+//	private:     tree.DBoolFalse,
+//}
+//
+//func constBoolExpr(val bool) *Expr {
+//	if val {
+//		return constTrueExpr
+//	}
+//	return constFalseExpr
+//}
 
 // getMaxSimplifyPrefix finds the longest prefix (maxSimplifyPrefix) such that
 // every span has the same first maxSimplifyPrefix values for the start and end
@@ -949,133 +973,134 @@ func (c *indexConstraintCtx) getMaxSimplifyPrefix(spans LogicalSpans) int {
 	return maxOffset
 }
 
-// simplifyFilterImpl is the internal (recursive) implementation of simplifyFilter.
-// <maxSimplifyPrefix> must be the result of getMaxSimplifyPrefix(spans); see that
-// function for more information.
-// Can return true (as a constOp).
+//// simplifyFilterImpl is the internal (recursive) implementation of simplifyFilter.
+//// <maxSimplifyPrefix> must be the result of getMaxSimplifyPrefix(spans); see that
+//// function for more information.
+//// Can return true (as a opt.ConstOp).
+////
+//// We use an approach based on spans: we have the generated spans for the entire
+//// filter; for each sub-expression, we use existing code to generate spans for
+//// that sub-expression and see if we can prove that the sub-expression is always
+//// true when the space is restricted to the spans for the entire filter.
+////
+//// The following conditions are (together) sufficient for a sub-expression to be
+//// true:
+////
+////  - the spans generated for this sub-expression are equivalent to the
+////    expression; we call such spans "tight". For example the condition
+////    `@1 >= 1` results in span `[/1 - ]` which is tight: inside this span, the
+////    condition is always true. On the other hand, if we have an index on
+////    @1,@2,@3 and condition `(@1, @3) >= (1, 3)`, the generated span is
+////    `[/1 - ]` which is not tight: we still need to verify the condition on @3
+////    inside this span.
+////
+////  - the spans for the entire filter are completely contained in the (tight)
+////    spans for this sub-expression. In this case, there can be no rows that are
+////    inside the filter span but outside the expression span.
+////
+////    For example: `@1 = 1 AND @2 = 2` with span `[/1/2 - /1/2]`. When looking
+////    at sub-expression `@1 = 1` and its span `[/1 - /1]`, we see that it
+////    contains the filter span `[/1/2 - /1/2]` and thus the condition is always
+////    true inside `[/1/2 - /1/2`].  For `@2 = 2` we have the span `[/2 - /2]`
+////    but this span refers to the second index column (so it's actually
+////    equivalent to a collection of spans `[/?/2 - /?/2]`); the only way we can
+////    compare it against the filter span is if the latter restricts the previous
+////    column to a single value (which it does in this case; this is determined
+////    by getMaxSimplifyPrefix). So `[/1/2 - /1/2]` is contained in the
+////    expression span and we can simplify `@2 = 2` to `true`.
+////
+////    An example where this doesn't work well is with disjunctions:
+////    `@1 <= 1 OR @1 >= 4` has spans `[ - /1], [/1 - ]` but in separation neither
+////    sub-expression is always true inside these spans.
+//func (c *indexConstraintCtx) simplifyFilterImpl(
+//	ev xform.ExprView, spans LogicalSpans, maxSimplifyPrefix int,
+//) *Expr {
+//	// Special handling for AND and OR.
+//	if e.Operator() == opt.OrOp || e.Operator() == opt.AndOp {
+//		// If a child expression is simplified to a const bool of
+//		// shortcircuitValue, then the entire node has the same value;
+//		// false for AND and true for OR.
+//		var shortcircuitValue = (e.Operator() == opt.OrOp)
 //
-// We use an approach based on spans: we have the generated spans for the entire
-// filter; for each sub-expression, we use existing code to generate spans for
-// that sub-expression and see if we can prove that the sub-expression is always
-// true when the space is restricted to the spans for the entire filter.
+//		var children []*Expr
+//		for i, child := range e.children {
+//			simplified := c.simplifyFilterImpl(child, spans, maxSimplifyPrefix)
+//			if ok, val := isConstBool(simplified); ok {
+//				if val == shortcircuitValue {
+//					return constBoolExpr(shortcircuitValue)
+//				}
+//				// We can ignore this child (it is true for AND, false for OR).
+//			} else {
+//				if children == nil {
+//					children = make([]*Expr, 0, len(e.children)-i)
+//				}
+//				children = append(children, simplified)
+//			}
+//		}
+//		switch len(children) {
+//		case 0:
+//			// All children simplify to nothing.
+//			return constBoolExpr(!shortcircuitValue)
+//		case 1:
+//			return children[0]
+//		default:
+//			scalarPropsCopy := *e.scalarProps
+//			return &Expr{
+//				op:          e.Operator(),
+//				scalarProps: &scalarPropsCopy,
+//				private:     e.private,
+//				children:    children,
+//			}
+//		}
+//	}
 //
-// The following conditions are (together) sufficient for a sub-expression to be
-// true:
+//	// We try to create tight spans for the expression (as allowed by
+//	// maxSimplifyPrefix), and check if the condition is implied by the final
+//	// spans.
+//	for offset := 0; offset <= maxSimplifyPrefix; offset++ {
+//		if offset > 0 {
+//			if offset == 1 {
+//				// Copy the spans, we are about to modify them.
+//				spans = append(LogicalSpans(nil), spans...)
+//			}
+//			// Chop away the first value in all spans to end up with spans
+//			// for this offset.
+//			for i := range spans {
+//				spans[i].Start.Vals = spans[i].Start.Vals[1:]
+//				spans[i].End.Vals = spans[i].End.Vals[1:]
+//			}
+//		}
+//		var exprSpans LogicalSpans
+//		var ok, tight bool
+//		if c.isInverted {
+//			if offset == 0 {
+//				exprSpans, ok, tight = c.makeInvertedIndexSpansForExpr(e)
+//			}
+//		} else {
+//			exprSpans, ok, tight = c.makeSpansForExpr(offset, e)
+//		}
+//		if ok && tight {
+//			if c.isSpanSubset(offset, spans, exprSpans) {
+//				// The final spans are a subset of the spans for this expression; there
+//				// is no need for a remaining filter for this condition.
+//				return constTrueExpr
+//			}
+//		}
+//	}
 //
-//  - the spans generated for this sub-expression are equivalent to the
-//    expression; we call such spans "tight". For example the condition
-//    `@1 >= 1` results in span `[/1 - ]` which is tight: inside this span, the
-//    condition is always true. On the other hand, if we have an index on
-//    @1,@2,@3 and condition `(@1, @3) >= (1, 3)`, the generated span is
-//    `[/1 - ]` which is not tight: we still need to verify the condition on @3
-//    inside this span.
+//	return e.deepCopy()
+//}
 //
-//  - the spans for the entire filter are completely contained in the (tight)
-//    spans for this sub-expression. In this case, there can be no rows that are
-//    inside the filter span but outside the expression span.
-//
-//    For example: `@1 = 1 AND @2 = 2` with span `[/1/2 - /1/2]`. When looking
-//    at sub-expression `@1 = 1` and its span `[/1 - /1]`, we see that it
-//    contains the filter span `[/1/2 - /1/2]` and thus the condition is always
-//    true inside `[/1/2 - /1/2`].  For `@2 = 2` we have the span `[/2 - /2]`
-//    but this span refers to the second index column (so it's actually
-//    equivalent to a collection of spans `[/?/2 - /?/2]`); the only way we can
-//    compare it against the filter span is if the latter restricts the previous
-//    column to a single value (which it does in this case; this is determined
-//    by getMaxSimplifyPrefix). So `[/1/2 - /1/2]` is contained in the
-//    expression span and we can simplify `@2 = 2` to `true`.
-//
-//    An example where this doesn't work well is with disjunctions:
-//    `@1 <= 1 OR @1 >= 4` has spans `[ - /1], [/1 - ]` but in separation neither
-//    sub-expression is always true inside these spans.
-func (c *indexConstraintCtx) simplifyFilterImpl(
-	e *Expr, spans LogicalSpans, maxSimplifyPrefix int,
-) *Expr {
-	// Special handling for AND and OR.
-	if e.op == orOp || e.op == andOp {
-		// If a child expression is simplified to a const bool of
-		// shortcircuitValue, then the entire node has the same value;
-		// false for AND and true for OR.
-		var shortcircuitValue = (e.op == orOp)
-
-		var children []*Expr
-		for i, child := range e.children {
-			simplified := c.simplifyFilterImpl(child, spans, maxSimplifyPrefix)
-			if ok, val := isConstBool(simplified); ok {
-				if val == shortcircuitValue {
-					return constBoolExpr(shortcircuitValue)
-				}
-				// We can ignore this child (it is true for AND, false for OR).
-			} else {
-				if children == nil {
-					children = make([]*Expr, 0, len(e.children)-i)
-				}
-				children = append(children, simplified)
-			}
-		}
-		switch len(children) {
-		case 0:
-			// All children simplify to nothing.
-			return constBoolExpr(!shortcircuitValue)
-		case 1:
-			return children[0]
-		default:
-			scalarPropsCopy := *e.scalarProps
-			return &Expr{
-				op:          e.op,
-				scalarProps: &scalarPropsCopy,
-				private:     e.private,
-				children:    children,
-			}
-		}
-	}
-
-	// We try to create tight spans for the expression (as allowed by
-	// maxSimplifyPrefix), and check if the condition is implied by the final
-	// spans.
-	for offset := 0; offset <= maxSimplifyPrefix; offset++ {
-		if offset > 0 {
-			if offset == 1 {
-				// Copy the spans, we are about to modify them.
-				spans = append(LogicalSpans(nil), spans...)
-			}
-			// Chop away the first value in all spans to end up with spans
-			// for this offset.
-			for i := range spans {
-				spans[i].Start.Vals = spans[i].Start.Vals[1:]
-				spans[i].End.Vals = spans[i].End.Vals[1:]
-			}
-		}
-		var exprSpans LogicalSpans
-		var ok, tight bool
-		if c.isInverted {
-			if offset == 0 {
-				exprSpans, ok, tight = c.makeInvertedIndexSpansForExpr(e)
-			}
-		} else {
-			exprSpans, ok, tight = c.makeSpansForExpr(offset, e)
-		}
-		if ok && tight {
-			if c.isSpanSubset(offset, spans, exprSpans) {
-				// The final spans are a subset of the spans for this expression; there
-				// is no need for a remaining filter for this condition.
-				return constTrueExpr
-			}
-		}
-	}
-
-	return e.deepCopy()
-}
-
-// simplifyFilter removes parts of the filter that are satisfied by the spans. It
-// is best-effort. Returns nil if there is no remaining filter.
-func (c *indexConstraintCtx) simplifyFilter(filter *Expr, spans LogicalSpans) *Expr {
-	remainingFilter := c.simplifyFilterImpl(filter, spans, c.getMaxSimplifyPrefix(spans))
-	if ok, val := isConstBool(remainingFilter); ok && val {
-		return nil
-	}
-	return remainingFilter
-}
+//// simplifyFilter removes parts of the filter that are satisfied by the spans. It
+//// is best-effort. Returns nil if there is no remaining filter.
+//func (c *indexConstraintCtx) simplifyFilter(filter *Expr, spans LogicalSpans) *Expr {
+//	remainingFilter := c.simplifyFilterImpl(filter, spans, c.getMaxSimplifyPrefix(spans))
+//	if ok, val := isConstBool(remainingFilter); ok && val {
+//		return nil
+//	}
+//	return remainingFilter
+//}
+var _ = (*indexConstraintCtx).getMaxSimplifyPrefix
 
 // IndexConstraints is used to generate index constraints from a scalar boolean
 // filter expression.
@@ -1090,7 +1115,7 @@ func (c *indexConstraintCtx) simplifyFilter(filter *Expr, spans LogicalSpans) *E
 type IndexConstraints struct {
 	indexConstraintCtx
 
-	filter *Expr
+	filter xform.ExprView
 
 	spansPopulated bool
 	spansTight     bool
@@ -1099,7 +1124,7 @@ type IndexConstraints struct {
 
 // Init processes the filter and calculates the spans.
 func (ic *IndexConstraints) Init(
-	filter *Expr, colInfos []IndexColumnInfo, isInverted bool, evalCtx *tree.EvalContext,
+	filter xform.ExprView, colInfos []IndexColumnInfo, isInverted bool, evalCtx *tree.EvalContext,
 ) {
 	*ic = IndexConstraints{
 		filter:             filter,
@@ -1121,31 +1146,46 @@ func (ic *IndexConstraints) Spans() (_ LogicalSpans, ok bool) {
 	return ic.spans, true
 }
 
-// RemainingFilter calculates a simplified filter that needs to be applied
-// within the returned Spans.
-func (ic *IndexConstraints) RemainingFilter(ivh *tree.IndexedVarHelper) tree.TypedExpr {
-	var res *Expr
-	if !ic.spansPopulated {
-		if ok, val := isConstBool(ic.filter); ok && val {
-			return nil
-		}
-		res = ic.filter
-	} else {
-		if ic.spansTight || len(ic.spans) == 0 {
-			// The spans are "tight", or we have a contradiction; there is no remaining filter.
-			return nil
-		}
-		res = ic.simplifyFilter(ic.filter, ic.spans)
-	}
-	if res == nil {
-		return nil
-	}
-	c := typedExprConvCtx{ivh: ivh}
-	return scalarToTypedExpr(&c, res)
-}
+//// RemainingFilter calculates a simplified filter that needs to be applied
+//// within the returned Spans.
+//func (ic *IndexConstraints) RemainingFilter(ivh *tree.IndexedVarHelper) tree.TypedExpr {
+//	var res *Expr
+//	if !ic.spansPopulated {
+//		if ok, val := isConstBool(ic.filter); ok && val {
+//			return nil
+//		}
+//		res = ic.filter
+//	} else {
+//		if ic.spansTight || len(ic.spans) == 0 {
+//			// The spans are "tight", or we have a contradiction; there is no remaining filter.
+//			return nil
+//		}
+//		res = ic.simplifyFilter(ic.filter, ic.spans)
+//	}
+//	if res == nil {
+//		return nil
+//	}
+//	c := typedExprConvCtx{ivh: ivh}
+//	return scalarToTypedExpr(&c, res)
+//}
 
 // isIndexColumn returns true if e is an indexed var that corresponds
 // to index column <offset>.
-func (c *indexConstraintCtx) isIndexColumn(e *Expr, index int) bool {
-	return isIndexedVar(e, c.colInfos[index].VarIdx)
+func (c *indexConstraintCtx) isIndexColumn(ev xform.ExprView, index int) bool {
+	return ev.Operator() == opt.VariableOp && ev.Private().(opt.ColumnIndex) == c.colInfos[index].VarIdx
+}
+
+// getConstDatum wraps the logic of getting a Datum from an expression which
+// IsConstValue.
+func getConstDatum(ev xform.ExprView) tree.Datum {
+	switch ev.Operator() {
+	case opt.TrueOp:
+		return tree.DBoolTrue
+	case opt.FalseOp:
+		return tree.DBoolFalse
+	case opt.ConstOp:
+		return ev.Private().(tree.Datum)
+	default:
+		panic(fmt.Sprintf("unsupported op %s", ev.Operator()))
+	}
 }

--- a/pkg/sql/opt/idxconstraint/index_constraints.go
+++ b/pkg/sql/opt/idxconstraint/index_constraints.go
@@ -1,0 +1,1151 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package idxconstraint
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
+	"github.com/cockroachdb/cockroach/pkg/util/encoding"
+	"github.com/cockroachdb/cockroach/pkg/util/json"
+)
+
+// makeEqSpan returns a span that constraints column <offset> to a single value.
+// The value can be NULL.
+func (c *indexConstraintCtx) makeEqSpan(offset int, value tree.Datum) LogicalSpan {
+	return LogicalSpan{
+		Start: LogicalKey{Vals: tree.Datums{value}, Inclusive: true},
+		End:   LogicalKey{Vals: tree.Datums{value}, Inclusive: true},
+	}
+}
+
+// makeNotNullSpan returns a span that constrains the column to non-NULL values.
+// If the column is not nullable, returns a full span.
+func (c *indexConstraintCtx) makeNotNullSpan(offset int) LogicalSpan {
+	sp := MakeFullSpan()
+	if !c.colInfos[offset].Nullable {
+		// The column is not nullable; not-null constraints aren't useful.
+		return sp
+	}
+	if c.colInfos[offset].Direction == encoding.Ascending {
+		sp.Start = LogicalKey{Vals: tree.Datums{tree.DNull}, Inclusive: false}
+	} else {
+		sp.End = LogicalKey{Vals: tree.Datums{tree.DNull}, Inclusive: false}
+	}
+
+	return sp
+}
+
+// makeStringPrefixSpan returns a span that constraints string column <offset>
+// to strings having the given prefix.
+func (c *indexConstraintCtx) makeStringPrefixSpan(offset int, prefix string) LogicalSpan {
+	span := c.makeNotNullSpan(offset)
+	startKey := LogicalKey{Vals: tree.Datums{tree.NewDString(prefix)}, Inclusive: true}
+	if c.colInfos[offset].Direction == encoding.Ascending {
+		span.Start = startKey
+	} else {
+		span.End = startKey
+	}
+
+	i := len(prefix) - 1
+	for ; i >= 0 && prefix[i] == 0xFF; i-- {
+	}
+	if i < 0 {
+		// We have a prefix like "\xff\xff\xff"; there is no ending value.
+		return span
+	}
+	// A few examples:
+	//   prefix      -> endValue
+	//   ABC         -> ABD
+	//   ABC\xff     -> ABD
+	//   ABC\xff\xff -> ABD
+	endVal := []byte(prefix[:i+1])
+	endVal[i]++
+	endDatum := tree.NewDString(string(endVal))
+	endKey := LogicalKey{Vals: tree.Datums{endDatum}, Inclusive: false}
+	if c.colInfos[offset].Direction == encoding.Ascending {
+		span.End = endKey
+	} else {
+		span.Start = endKey
+	}
+
+	return span
+}
+
+// verifyType checks that the type of the index column <offset> matches the
+// given type. We disallow mixed-type comparisons because it would result in
+// incorrect encodings (#4313).
+func (c *indexConstraintCtx) verifyType(offset int, typ types.T) bool {
+	return typ == types.Null || c.colInfos[offset].Typ.Equivalent(typ)
+}
+
+// makeSpansForSingleColumn creates spans for a single index column from a
+// simple comparison expression. The arguments are the operator and right
+// operand. The <tight> return value indicates if the spans are exactly
+// equivalent to the expression (and not weaker).
+func (c *indexConstraintCtx) makeSpansForSingleColumn(
+	offset int, op operator, val *Expr,
+) (_ LogicalSpans, ok bool, tight bool) {
+	if op == inOp && isTupleOfConstants(val) {
+		// We assume that the values of the tuple are already ordered and distinct.
+		spans := make(LogicalSpans, 0, len(val.children))
+		for _, v := range val.children {
+			datum := v.private.(tree.Datum)
+			if !c.verifyType(offset, datum.ResolvedType()) {
+				return nil, false, false
+			}
+			if datum == tree.DNull {
+				// Ignore NULLs - they can't match any values
+				continue
+			}
+			spans = append(spans, LogicalSpan{
+				Start: LogicalKey{Vals: tree.Datums{datum}, Inclusive: true},
+				End:   LogicalKey{Vals: tree.Datums{datum}, Inclusive: true},
+			})
+		}
+		if c.colInfos[offset].Direction == encoding.Descending {
+			// Reverse the order of the spans.
+			for i, j := 0, len(spans)-1; i < j; i, j = i+1, j-1 {
+				spans[i], spans[j] = spans[j], spans[i]
+			}
+		}
+		return spans, true, true
+	}
+	// The rest of the supported expressions must have a constant scalar on the
+	// right-hand side.
+	if val.op != constOp {
+		return nil, false, false
+	}
+	datum := val.private.(tree.Datum)
+	if !c.verifyType(offset, datum.ResolvedType()) {
+		return nil, false, false
+	}
+	if datum == tree.DNull {
+		switch op {
+		case eqOp, ltOp, gtOp, leOp, geOp, neOp:
+			// The result of this expression is always NULL. Normally, this expression
+			// should have been converted to NULL during type checking; but if the
+			// NULL is coming from a placeholder, that doesn't happen.
+			return LogicalSpans{}, true, true
+
+		case isOp:
+			if !c.colInfos[offset].Nullable {
+				// The column is not nullable; IS NULL is always false.
+				return LogicalSpans{}, true, true
+			}
+			return LogicalSpans{c.makeEqSpan(offset, tree.DNull)}, true, true
+
+		case isNotOp:
+			return LogicalSpans{c.makeNotNullSpan(offset)}, true, true
+		}
+		return nil, false, false
+	}
+
+	switch op {
+	case eqOp, isOp:
+		return LogicalSpans{c.makeEqSpan(offset, datum)}, true, true
+
+	case ltOp, gtOp, leOp, geOp:
+		sp := c.makeNotNullSpan(offset)
+		inclusive := (op == leOp || op == geOp)
+		if (op == ltOp || op == leOp) == (c.colInfos[offset].Direction == encoding.Ascending) {
+			sp.End = LogicalKey{Vals: tree.Datums{datum}, Inclusive: inclusive}
+		} else {
+			sp.Start = LogicalKey{Vals: tree.Datums{datum}, Inclusive: inclusive}
+		}
+		if !inclusive {
+			c.preferInclusive(offset, &sp)
+		}
+		return LogicalSpans{sp}, true, true
+
+	case neOp, isNotOp:
+		spans := LogicalSpans{c.makeNotNullSpan(offset), c.makeNotNullSpan(offset)}
+		spans[0].End = LogicalKey{Vals: tree.Datums{datum}, Inclusive: false}
+		spans[1].Start = LogicalKey{Vals: tree.Datums{datum}, Inclusive: false}
+		c.preferInclusive(offset, &spans[0])
+		c.preferInclusive(offset, &spans[1])
+		return spans, true, true
+
+	case likeOp:
+		if s, ok := tree.AsDString(datum); ok {
+			if i := strings.IndexAny(string(s), "_%"); i >= 0 {
+				if i == 0 {
+					// Mask starts with _ or %.
+					return nil, false, false
+				}
+				span := c.makeStringPrefixSpan(offset, string(s[:i]))
+				// A mask like ABC% is equivalent to restricting the prefix to ABC.
+				// A mask like ABC%Z requires restricting the prefix, but is a stronger
+				// condition.
+				tight := (i == len(s)-1) && s[i] == '%'
+				return LogicalSpans{span}, true, tight
+			}
+			// No wildcard characters, this is an equality.
+			return LogicalSpans{c.makeEqSpan(offset, &s)}, true, true
+		}
+
+	case similarToOp:
+		// a SIMILAR TO 'foo_*' -> prefix "foo"
+		if s, ok := tree.AsDString(datum); ok {
+			pattern := tree.SimilarEscape(string(s))
+			if re, err := regexp.Compile(pattern); err == nil {
+				prefix, complete := re.LiteralPrefix()
+				if complete {
+					return LogicalSpans{c.makeEqSpan(offset, tree.NewDString(prefix))}, true, true
+				}
+				span := c.makeStringPrefixSpan(offset, prefix)
+				return LogicalSpans{span}, true, false
+			}
+		}
+	}
+	return nil, false, false
+}
+
+// makeSpansForTupleInequality creates spans for index columns starting at
+// <offset> from a tuple inequality.
+// Assumes that e.op is an inequality and both sides are tuples.
+// The <tight> return value indicates if the spans are exactly equivalent
+// to the expression (and not weaker).
+func (c *indexConstraintCtx) makeSpansForTupleInequality(
+	offset int, e *Expr,
+) (_ LogicalSpans, ok bool, tight bool) {
+	lhs, rhs := e.children[0], e.children[1]
+
+	// Find the longest prefix of the tuple that maps to index columns (with the
+	// same direction) starting at <offset>.
+	prefixLen := 0
+	dir := c.colInfos[offset].Direction
+	nullVal := false
+	for i := range lhs.children {
+		if !(offset+i < len(c.colInfos) && c.isIndexColumn(lhs.children[i], offset+i)) {
+			// Variable doesn't refer to the right column.
+			break
+		}
+		if rhs.children[i].op != constOp {
+			// Right-hand value is not a constant.
+			break
+		}
+		if !c.verifyType(offset+i, rhs.children[i].scalarProps.typ) {
+			// We have a mixed-type comparison; we can't encode this in a span
+			// (see #4313).
+			break
+		}
+		if isConstNull(rhs.children[i]) {
+			// NULLs are tricky and require special handling; see
+			// nullVal related code below.
+			nullVal = true
+			break
+		}
+		if c.colInfos[offset+i].Direction != dir && e.op != neOp {
+			// The direction changed. For example:
+			//   a ASCENDING, b DESCENDING, c ASCENDING
+			//   (a, b, c) >= (1, 2, 3)
+			// We can only use a >= 1 here.
+			//
+			// TODO(radu): we could support inequalities for cases like this by
+			// allowing negation, for example:
+			//  (a, -b, c) >= (1, -2, 3)
+			//
+			// The != operator is an exception where the column directions don't
+			// matter. For example, for (a, b, c) != (1, 2, 3) the spans
+			// [ - /1/2/2], [1/2/4 - ] apply for any combination of directions.
+			break
+		}
+		prefixLen++
+	}
+	if prefixLen == 0 {
+		return nil, false, false
+	}
+
+	datums := make(tree.Datums, prefixLen)
+	for i := range datums {
+		datums[i] = rhs.children[i].private.(tree.Datum)
+	}
+
+	// less is true if the op is < or <= and false if the op is > or >=.
+	// inclusive is true if the op is <= or >= and false if the op is < or >.
+	var less, inclusive bool
+
+	switch e.op {
+	case neOp:
+		if prefixLen < len(lhs.children) {
+			// If we have (a, b, c) != (1, 2, 3), we cannot
+			// determine any constraint on (a, b).
+			return nil, false, false
+		}
+		spans := LogicalSpans{MakeFullSpan(), MakeFullSpan()}
+		spans[0].End = LogicalKey{Vals: datums, Inclusive: false}
+		// We don't want the spans to alias each other, the preferInclusive
+		// calls below could mangle them.
+		datumsCopy := append([]tree.Datum(nil), datums...)
+		spans[1].Start = LogicalKey{Vals: datumsCopy, Inclusive: false}
+		c.preferInclusive(offset, &spans[0])
+		c.preferInclusive(offset, &spans[1])
+		// If any columns are nullable, the spans could include unwanted NULLs.
+		// For example, for
+		//   (@1, @2, @3) != (1, 2, 3)
+		// we need to exclude tuples like
+		//   (1, NULL, NULL)
+		//   (NULL, 2, 3)
+		//
+		// But note that some tuples with NULLs can satisfy the condition, e.g.
+		//   (5, NULL, NULL)
+		//   (NULL, 5, 5)
+		tight = true
+		for i := 0; i < prefixLen; i++ {
+			if c.colInfos[offset+i].Nullable {
+				tight = false
+				break
+			}
+		}
+		return spans, true, tight
+
+	case ltOp:
+		less, inclusive = true, false
+	case leOp:
+		less, inclusive = true, true
+	case gtOp:
+		less, inclusive = false, false
+	case geOp:
+		less, inclusive = false, true
+	default:
+		panic(fmt.Sprintf("unsupported op %s", e.op))
+	}
+
+	// The spans are "tight" unless we used just a prefix.
+	tight = (prefixLen == len(lhs.children))
+
+	if nullVal {
+		// NULL is treated semantically as "unknown value", so
+		//   (1, 2) > (1, NULL) is NULL,
+		// but
+		//   (2, 2) > (1, NULL) is true.
+		//
+		// So either of these constraints:
+		//   (a, b) > (1, NULL)
+		//   (a, b) >= (1, NULL)
+		// is true if and only if a > 1.
+		inclusive = false
+		tight = true
+	} else if prefixLen < len(lhs.children) {
+		// If we only keep a prefix, exclusive inequalities become exclusive.
+		// For example:
+		//   (a, b, c) > (1, 2, 3) becomes (a, b) >= (1, 2)
+		inclusive = true
+	}
+
+	if dir == encoding.Descending {
+		// If the direction is descending, the inequality is reversed.
+		less = !less
+	}
+
+	// We use makeNotNullSpan to disallow NULLs on the first column.
+	sp := c.makeNotNullSpan(offset)
+	if less {
+		sp.End = LogicalKey{Vals: datums, Inclusive: inclusive}
+	} else {
+		sp.Start = LogicalKey{Vals: datums, Inclusive: inclusive}
+	}
+
+	// Consider (a, b, c) <= (1, 2, 3).
+	//
+	// If the columns are not null, the condition is equivalent to
+	// the span [ - /1/2/3].
+	//
+	// If column a is nullable, the condition is equivalent to the
+	// span (/NULL - /1/2/3].
+	//
+	// However, if column b or c is nullable, we still have to filter
+	// out the NULLs on those columns, so whatever span we generate is
+	// not "tight". For example, the span (/NULL - /1/2/3] can contain
+	// (1, NULL, NULL) which is not <= (1, 2, 3).
+	// TODO(radu): we could generate multiple spans:
+	//   (/NULL - /0], (/1/NULL - /1/1], (/1/2/NULL, /1/2/3]
+	//
+	// If the condition is > or >= this is not a problem. For example
+	// (a, b, c) >= (1, 2, 3) has the span [/1/2/3 - ] which excludes
+	// any values of the form (1, NULL, x) or (1, 2, NULL). Other values
+	// with NULLs like (2, NULL, NULL) are ok because
+	// (2, NULL, NULL) >= (1, 2, 3).
+	if tight && less {
+		for i := 1; i < prefixLen; i++ {
+			if c.colInfos[offset+i].Nullable {
+				tight = false
+				break
+			}
+		}
+	}
+	c.preferInclusive(offset, &sp)
+	return LogicalSpans{sp}, true, tight
+}
+
+// makeSpansForTupleIn creates spans for index columns starting at
+// <offset> from a tuple IN tuple expression, for example:
+//   (a, b, c) IN ((1, 2, 3), (4, 5, 6))
+// Assumes that both sides are tuples.
+// The <tight> return value indicates if the spans are exactly equivalent
+// to the expression (and not weaker).
+func (c *indexConstraintCtx) makeSpansForTupleIn(
+	offset int, e *Expr,
+) (_ LogicalSpans, ok bool, tight bool) {
+	lhs, rhs := e.children[0], e.children[1]
+
+	// Find the longest prefix of columns starting at <offset> which is contained
+	// in the left-hand tuple; tuplePos[i] is the position of column <offset+i> in
+	// the tuple.
+	var tuplePos []int
+	for i := offset; i < len(c.colInfos); i++ {
+		found := false
+		for j := range lhs.children {
+			if c.isIndexColumn(lhs.children[j], i) {
+				tuplePos = append(tuplePos, j)
+				found = true
+				break
+			}
+		}
+		if !found {
+			break
+		}
+	}
+	if len(tuplePos) == 0 {
+		return nil, false, false
+	}
+
+	// Create a span for each (tuple) value inside the right-hand side tuple.
+	spans := make(LogicalSpans, 0, len(rhs.children))
+	for _, valTuple := range rhs.children {
+		if valTuple.op != tupleOp {
+			return nil, false, false
+		}
+		vals := make(tree.Datums, len(tuplePos))
+		for i, pos := range tuplePos {
+			val := valTuple.children[pos]
+			if val.op != constOp {
+				return nil, false, false
+			}
+			datum := val.private.(tree.Datum)
+			if !c.verifyType(offset+i, datum.ResolvedType()) {
+				return nil, false, false
+			}
+			vals[i] = datum
+		}
+		containsNull := false
+		for _, d := range vals {
+			containsNull = containsNull || (d == tree.DNull)
+		}
+		// If the tuple contains a NULL, ignore it (it can't match any values).
+		if !containsNull {
+			spans = append(spans, LogicalSpan{
+				Start: LogicalKey{Vals: vals, Inclusive: true},
+				End:   LogicalKey{Vals: vals, Inclusive: true},
+			})
+		}
+	}
+
+	// Sort and de-duplicate the values.
+	// We don't rely on the sorted order of the right-hand side tuple because it's
+	// only useful if all of the following are met:
+	//  - we use all columns in the tuple, i.e. len(tuplePos) = len(lhs.children).
+	//  - the columns are in the right order, i.e. tuplePos[i] = i.
+	//  - the columns have the same directions
+	c.sortSpans(offset, spans)
+	res := spans[:0]
+	for i := range spans {
+		if i > 0 && c.compare(offset, spans[i-1].Start, spans[i].Start, compareStartKeys) == 0 {
+			continue
+		}
+		res = append(res, spans[i])
+	}
+	// The spans are "tight" unless we used just a prefix.
+	tight = len(tuplePos) == len(lhs.children)
+	return res, true, tight
+}
+
+// makeSpansForExpr creates spans for index columns starting at <offset>
+// from the given expression.
+//
+// The <tight> return value indicates if the spans are exactly equivalent to the
+// expression (and not weaker). See simplifyFilter for more information.
+func (c *indexConstraintCtx) makeSpansForExpr(
+	offset int, e *Expr,
+) (_ LogicalSpans, ok bool, tight bool) {
+	switch e.op {
+	case constOp:
+		datum := e.private.(tree.Datum)
+		if datum == tree.DBoolFalse || datum == tree.DNull {
+			// Condition is never true, return no spans.
+			return LogicalSpans{}, true, true
+		}
+		return nil, false, false
+
+	case andOp:
+		spans, ok := c.makeSpansForAndExprs(offset, e.children)
+		// We don't have enough information to know if the spans are "tight".
+		return spans, ok, false
+
+	case orOp:
+		return c.makeSpansForOrExprs(offset, e.children)
+
+	case variableOp:
+		// Support (@1) as (@1 = TRUE) if @1 is boolean.
+		if c.colInfos[offset].Typ == types.Bool && c.isIndexColumn(e, offset) {
+			return c.makeSpansForSingleColumn(offset, eqOp, constTrueExpr)
+		}
+
+	case notOp:
+		// Support (NOT @1) as (@1 = FALSE) is @1 is boolean.
+		if c.colInfos[offset].Typ == types.Bool && c.isIndexColumn(e.children[0], offset) {
+			return c.makeSpansForSingleColumn(offset, eqOp, constFalseExpr)
+		}
+	}
+
+	if len(e.children) < 2 {
+		return nil, false, false
+	}
+	// Check for an operation where the left-hand side is an
+	// indexed var for this column.
+	if c.isIndexColumn(e.children[0], offset) {
+		spans, ok, tight := c.makeSpansForSingleColumn(offset, e.op, e.children[1])
+		if ok {
+			return spans, ok, tight
+		}
+		// We couldn't get any constraints for the column; see if we can at least
+		// deduce a not-NULL constraint.
+		if c.colInfos[offset].Nullable && opRequiresNotNullArgs(e.op) {
+			return LogicalSpans{c.makeNotNullSpan(offset)}, true, false
+		}
+	}
+	// Check for tuple operations.
+	if e.children[0].op == tupleOp && e.children[1].op == tupleOp {
+		switch e.op {
+		case ltOp, leOp, gtOp, geOp, neOp:
+			// Tuple inequality.
+			return c.makeSpansForTupleInequality(offset, e)
+		case inOp:
+			// Tuple IN tuple.
+			return c.makeSpansForTupleIn(offset, e)
+		}
+	}
+
+	// Last resort: for conditions like a > b, our column can appear on the right
+	// side. We can deduce a not-null constraint from such conditions.
+	if c.colInfos[offset].Nullable && c.isIndexColumn(e.children[1], offset) &&
+		opRequiresNotNullArgs(e.op) {
+		return LogicalSpans{c.makeNotNullSpan(offset)}, true, false
+	}
+
+	return nil, false, false
+}
+
+// opRequiresNotNullArgs returns true if the operator can never evaluate
+// to true if one of the children is NULL.
+func opRequiresNotNullArgs(op operator) bool {
+	switch op {
+	case
+		eqOp, ltOp, leOp, gtOp, geOp, neOp,
+		likeOp, notLikeOp, iLikeOp, notILikeOp, similarToOp, notSimilarToOp,
+		regMatchOp, notRegMatchOp, regIMatchOp, notRegIMatchOp:
+		return true
+	}
+	return false
+}
+
+// indexConstraintConjunctionCtx stores the context for an index constraint
+// calculation on a conjunction (AND-ed expressions).
+type indexConstraintConjunctionCtx struct {
+	*indexConstraintCtx
+
+	// andExprs is a set of conjuncts that make up the filter.
+	andExprs []*Expr
+
+	// Memoization data structure for calcOffset.
+	results []calcOffsetResult
+}
+
+// calcOffsetResult stores the result of calcOffset for a given offset.
+type calcOffsetResult struct {
+	// visited indicates if calcOffset was already called for this given offset,
+	// in which case the other fields are populated.
+	visited        bool
+	spansPopulated bool
+	spans          LogicalSpans
+}
+
+// makeSpansForAndExprs calculates spans for a conjunction.
+func (c *indexConstraintCtx) makeSpansForAndExprs(
+	offset int, andExprs []*Expr,
+) (_ LogicalSpans, ok bool) {
+	conjCtx := indexConstraintConjunctionCtx{
+		indexConstraintCtx: c,
+		andExprs:           andExprs,
+		results:            make([]calcOffsetResult, len(c.colInfos)),
+	}
+	return conjCtx.calcOffset(offset)
+}
+
+// calcOffset calculates constraints for the sequence of index columns starting
+// at <offset>.
+//
+// It works as follows: we look at expressions which constrain column <offset>
+// (or a sequence of columns starting at <offset>) and generate spans from those
+// expressions. Then, we try to extend those span keys with more columns by
+// recursively calculating the constraints for a higher <offset>. The results
+// are memoized so each offset is calculated at most once.
+//
+// For example:
+//   @1 >= 5 AND @1 <= 10 AND @2 = 2 AND @3 > 1
+//
+// - calcOffset(offset = 0):          // calculate constraints for @1, @2, @3
+//   - process expressions, generating span [/5 - /10]
+//   - call calcOffset(offset = 1):   // calculate constraints for @2, @3
+//     - process expressions, generating span [/2 - /2]
+//     - call calcOffset(offset = 2): // calculate constraints for @3
+//       - process expressions, return span (/1 - ]
+//     - extend the keys in the span [/2 - /2] with (/1 - ], return (/2/1 - /2].
+//   - extend the keys in the span [/5 - /10] with (/2/1 - /2], return
+//     (/5/2/1 - /10/2].
+//
+// TODO(radu): add an example with tuple constraints once they are supported.
+func (c indexConstraintConjunctionCtx) calcOffset(offset int) (_ LogicalSpans, ok bool) {
+	if c.results[offset].visited {
+		// The results of this function are memoized.
+		return c.results[offset].spans, c.results[offset].spansPopulated
+	}
+
+	// Start with a span with no boundaries.
+	var spans LogicalSpans
+	var spansPopulated bool
+
+	// TODO(radu): sorting the expressions by the variable index, or pre-building
+	// a map could help here.
+	for _, e := range c.andExprs {
+		exprSpans, ok, _ := c.makeSpansForExpr(offset, e)
+		if !ok {
+			continue
+		}
+		if !spansPopulated {
+			spans = exprSpans
+			spansPopulated = true
+			continue
+		}
+
+		if len(exprSpans) == 1 {
+			// More efficient path for the common case of a single expression span.
+			for i := 0; i < len(spans); i++ {
+				if spans[i], ok = c.intersectSpan(offset, &spans[i], &exprSpans[0]); !ok {
+					// Remove this span.
+					copy(spans[i:], spans[i+1:])
+					spans = spans[:len(spans)-1]
+				}
+			}
+		} else {
+			var newSpans LogicalSpans
+			for i := range spans {
+				newSpans = append(newSpans, c.intersectSpanSet(offset, &spans[i], exprSpans)...)
+			}
+			spans = newSpans
+		}
+	}
+	if !spansPopulated {
+		c.results[offset] = calcOffsetResult{visited: true}
+		return nil, false
+	}
+
+	// Try to extend the spans with constraints on more columns.
+
+	// newSpans accumulates the extended spans, but is initialized only if we need
+	// to remove a span or break up a span into multiple spans (otherwise spans is
+	// modified in place).
+	var newSpans LogicalSpans
+	for i := 0; i < len(spans); i++ {
+		start, end := spans[i].Start, spans[i].End
+		startLen, endLen := len(start.Vals), len(end.Vals)
+
+		if startLen == endLen && startLen > 0 && offset+startLen < len(c.colInfos) &&
+			c.compareKeyVals(offset, start.Vals, end.Vals) == 0 {
+			// Special case when the start and end keys are equal (i.e. an exact value
+			// on this column). This is the only case where we can break up a single
+			// span into multiple spans.
+			//
+			// For example:
+			//  @1 = 1 AND @2 IN (3, 4, 5)
+			//  At offset 0 so far we have:
+			//    [/1 - /1]
+			//  At offset 1 we have:
+			//    [/3 - /3]
+			//    [/4 - /4]
+			//    [/5 - /5]
+			//  We break up the span to get:
+			//    [/1/3 - /1/3]
+			//    [/1/4 - /1/4]
+			//    [/1/5 - /1/5]
+			s, ok := c.calcOffset(offset + startLen)
+			if !ok {
+				continue
+			}
+			switch len(s) {
+			case 0:
+				// We found a contradiction.
+				spans = LogicalSpans{}
+				c.results[offset] = calcOffsetResult{
+					visited:        true,
+					spansPopulated: true,
+					spans:          spans,
+				}
+				return spans, true
+
+			case 1:
+				spans[i].Start.extend(s[0].Start)
+				spans[i].End.extend(s[0].End)
+				if newSpans != nil {
+					newSpans = append(newSpans, spans[i])
+				}
+
+			default:
+				if newSpans == nil {
+					newSpans = make(LogicalSpans, 0, len(spans)-1+len(s))
+					newSpans = append(newSpans, spans[:i]...)
+				}
+				for j := range s {
+					newSpan := spans[i]
+					newSpan.Start.extend(s[j].Start)
+					newSpan.End.extend(s[j].End)
+					newSpans = append(newSpans, newSpan)
+				}
+			}
+			continue
+		}
+
+		var modified bool
+		if startLen > 0 && offset+startLen < len(c.colInfos) && spans[i].Start.Inclusive {
+			// We can advance the starting boundary. Calculate constraints for the
+			// column that follows.
+			if s, ok := c.calcOffset(offset + startLen); ok && len(s) > 0 {
+				// If we have multiple constraints, we can only use the start of the
+				// first one to tighten the span.
+				// For example:
+				//   @1 >= 2 AND @2 IN (1, 2, 3).
+				//   At offset 0 so far we have:
+				//     [/2 - ]
+				//   At offset 1 we have:
+				//     [/1 - /1]
+				//     [/2 - /2]
+				//     [/3 - /3]
+				//   The best we can do is tighten the span to:
+				//     [/2/1 - ]
+				spans[i].Start.extend(s[0].Start)
+				modified = true
+			}
+		}
+
+		if endLen > 0 && offset+endLen < len(c.colInfos) && spans[i].End.Inclusive {
+			// We can restrict the ending boundary. Calculate constraints for the
+			// column that follows.
+			if s, ok := c.calcOffset(offset + endLen); ok && len(s) > 0 {
+				// If we have multiple constraints, we can only use the end of the
+				// last one to tighten the span.
+				spans[i].End.extend(s[len(s)-1].End)
+			}
+			modified = true
+		}
+		if modified && !c.isSpanValid(offset, &spans[i]) {
+			// The span became invalid and needs to be removed. For example:
+			//   @1 >= 1 AND (@1, @2) <= (1, 2) AND @2 = 5
+			// We start with the span [/1 - /1/2] and we try to extend it with the
+			// span [/5 - /5] on the second column. This results in an invalid span
+			// [/1/5 - /1/2].
+			if newSpans == nil {
+				newSpans = spans[:i:i]
+			}
+			continue
+		}
+		if newSpans != nil {
+			newSpans = append(newSpans, spans[i])
+		}
+	}
+	if newSpans != nil {
+		spans = newSpans
+	}
+	c.checkSpans(offset, spans)
+	c.results[offset] = calcOffsetResult{
+		visited:        true,
+		spansPopulated: true,
+		spans:          spans,
+	}
+	return spans, true
+}
+
+// makeSpansForOrExprs calculates spans for a disjunction.
+func (c *indexConstraintCtx) makeSpansForOrExprs(
+	offset int, orExprs []*Expr,
+) (_ LogicalSpans, ok bool, tight bool) {
+	var spans LogicalSpans
+
+	tight = true
+	for i, orExpr := range orExprs {
+		exprSpans, ok, exprTight := c.makeSpansForExpr(offset, orExpr)
+		if !ok {
+			// If we can't generate spans for a disjunct, exit early (this is
+			// equivalent to a full span).
+			return nil, false, false
+		}
+		// The OR is "tight" if all the spans are tight.
+		tight = tight && exprTight
+		if i == 0 {
+			spans = exprSpans
+		} else {
+			spans = c.mergeSpanSets(offset, spans, exprSpans)
+			if len(spans) == 1 && spans[0].IsFullSpan() {
+				return nil, false, false
+			}
+		}
+	}
+	return spans, true, tight
+}
+
+// makeInvertedIndexSpansForExpr is analogous to makeSpansForExpr, but it is
+// used for inverted indexes.
+func (c *indexConstraintCtx) makeInvertedIndexSpansForExpr(
+	e *Expr,
+) (_ LogicalSpans, ok bool, tight bool) {
+	switch e.op {
+	case containsOp:
+		lhs, rhs := e.children[0], e.children[1]
+
+		if !c.isIndexColumn(lhs, 0 /* index */) || rhs.op != constOp {
+			return nil, false, false
+		}
+
+		rightDatum := rhs.private.(tree.Datum)
+		rd := rightDatum.(*tree.DJSON).JSON
+
+		switch rd.Type() {
+		case json.ArrayJSONType, json.ObjectJSONType:
+			return LogicalSpans{c.makeEqSpan(0 /* offset */, rhs.private.(tree.Datum))}, true, true
+		default:
+			// If we find a scalar on the right side of the @> operator it means that we need to find
+			// both matching scalars and arrays that contain that value. In order to do this we generate
+			// two logical spans, one for the original scalar and one for arrays containing the scalar.
+			// This is valid because in JSON something can either be an array or scalar so the spans are
+			// guaranteed not to overlap when mapped onto the primary key space. Therefore there won't be
+			// any duplicate primary keys when we retrieve rows for both sets.
+			spans := make(LogicalSpans, 2)
+
+			j := json.NewArrayBuilder(1)
+			j.Add(rd)
+			dJSON, err := tree.MakeDJSON(j.Build())
+			if err != nil {
+				break
+			}
+
+			// This is the span for the scalar.
+			spans[0].Start = LogicalKey{Vals: tree.Datums{rightDatum}, Inclusive: true}
+			spans[0].End = spans[0].Start
+
+			// This is the span to match arrays.
+			spans[1].Start = LogicalKey{Vals: tree.Datums{dJSON}, Inclusive: true}
+			spans[1].End = spans[1].Start
+
+			return spans, true, true
+		}
+
+	case andOp:
+		for _, child := range e.children {
+			sp, ok, _ := c.makeInvertedIndexSpansForExpr(child)
+			if ok {
+				// TODO(radu, masha): for now, the best we can do is to generate
+				// constraints for at most one "contains" op in the disjunction; the
+				// rest are remaining filters.
+				//
+				// The spans are not tight because we have other conditions in the
+				// conjunction.
+				return sp, true, false
+			}
+		}
+	}
+	return nil, false, false
+}
+
+var constTrueExpr = &Expr{
+	op:          constOp,
+	scalarProps: &scalarProps{typ: types.Bool},
+	private:     tree.DBoolTrue,
+}
+
+var constFalseExpr = &Expr{
+	op:          constOp,
+	scalarProps: &scalarProps{typ: types.Bool},
+	private:     tree.DBoolFalse,
+}
+
+func constBoolExpr(val bool) *Expr {
+	if val {
+		return constTrueExpr
+	}
+	return constFalseExpr
+}
+
+// getMaxSimplifyPrefix finds the longest prefix (maxSimplifyPrefix) such that
+// every span has the same first maxSimplifyPrefix values for the start and end
+// key. For example, for:
+//  [/1/2/3 - /1/2/4]
+//  [/2/3/4 - /2/3/4]
+// the longest prefix is 2.
+//
+// This prefix is significant for filter simplification: we can only
+// drop an expression based on its spans if the offset is at most
+// maxSimplifyPrefix. Examples:
+//
+//   Filter:           @1 = 1 AND @2 >= 5
+//   Spans:            [/1/5 - /1]
+//   Remaining filter: <none>
+//   Here maxSimplifyPrefix is 1; we can drop @2 >= 5 from the filter.
+//
+//   Filter:           @1 >= 1 AND @1 <= 3 AND @2 >= 5
+//   Spans:            [/1/5 - /3]
+//   Remaining filter: @2 >= 5
+//   Here maxSimplifyPrefix is 0; we cannot drop @2 >= 5. Because the span
+//   contains more than one value for the first column, there are areas where
+//   the condition needs to be checked, e.g for /2/0 to /2/4.
+//
+//   Filter:           (@1, @2) IN ((1, 1), (2, 2)) AND @3 >= 3 AND @4 = 4
+//   Spans:            [/1/1/3/4 - /1/1]
+//                     [/2/2/3/4 - /2/2]
+//   Remaining filter: @4 = 4
+//   Here maxSimplifyPrefix is 2; we can drop the IN and @3 >= 3 but we can't
+//   drop @4 = 4.
+func (c *indexConstraintCtx) getMaxSimplifyPrefix(spans LogicalSpans) int {
+	maxOffset := len(c.colInfos) - 1
+	for _, sp := range spans {
+		i := 0
+		// Find the longest prefix of equal values.
+		for ; i < len(sp.Start.Vals) && i < len(sp.End.Vals); i++ {
+			if sp.Start.Vals[i].Compare(c.evalCtx, sp.End.Vals[i]) != 0 {
+				break
+			}
+		}
+		if i == 0 {
+			return 0
+		}
+		if maxOffset > i {
+			maxOffset = i
+		}
+	}
+	return maxOffset
+}
+
+// simplifyFilterImpl is the internal (recursive) implementation of simplifyFilter.
+// <maxSimplifyPrefix> must be the result of getMaxSimplifyPrefix(spans); see that
+// function for more information.
+// Can return true (as a constOp).
+//
+// We use an approach based on spans: we have the generated spans for the entire
+// filter; for each sub-expression, we use existing code to generate spans for
+// that sub-expression and see if we can prove that the sub-expression is always
+// true when the space is restricted to the spans for the entire filter.
+//
+// The following conditions are (together) sufficient for a sub-expression to be
+// true:
+//
+//  - the spans generated for this sub-expression are equivalent to the
+//    expression; we call such spans "tight". For example the condition
+//    `@1 >= 1` results in span `[/1 - ]` which is tight: inside this span, the
+//    condition is always true. On the other hand, if we have an index on
+//    @1,@2,@3 and condition `(@1, @3) >= (1, 3)`, the generated span is
+//    `[/1 - ]` which is not tight: we still need to verify the condition on @3
+//    inside this span.
+//
+//  - the spans for the entire filter are completely contained in the (tight)
+//    spans for this sub-expression. In this case, there can be no rows that are
+//    inside the filter span but outside the expression span.
+//
+//    For example: `@1 = 1 AND @2 = 2` with span `[/1/2 - /1/2]`. When looking
+//    at sub-expression `@1 = 1` and its span `[/1 - /1]`, we see that it
+//    contains the filter span `[/1/2 - /1/2]` and thus the condition is always
+//    true inside `[/1/2 - /1/2`].  For `@2 = 2` we have the span `[/2 - /2]`
+//    but this span refers to the second index column (so it's actually
+//    equivalent to a collection of spans `[/?/2 - /?/2]`); the only way we can
+//    compare it against the filter span is if the latter restricts the previous
+//    column to a single value (which it does in this case; this is determined
+//    by getMaxSimplifyPrefix). So `[/1/2 - /1/2]` is contained in the
+//    expression span and we can simplify `@2 = 2` to `true`.
+//
+//    An example where this doesn't work well is with disjunctions:
+//    `@1 <= 1 OR @1 >= 4` has spans `[ - /1], [/1 - ]` but in separation neither
+//    sub-expression is always true inside these spans.
+func (c *indexConstraintCtx) simplifyFilterImpl(
+	e *Expr, spans LogicalSpans, maxSimplifyPrefix int,
+) *Expr {
+	// Special handling for AND and OR.
+	if e.op == orOp || e.op == andOp {
+		// If a child expression is simplified to a const bool of
+		// shortcircuitValue, then the entire node has the same value;
+		// false for AND and true for OR.
+		var shortcircuitValue = (e.op == orOp)
+
+		var children []*Expr
+		for i, child := range e.children {
+			simplified := c.simplifyFilterImpl(child, spans, maxSimplifyPrefix)
+			if ok, val := isConstBool(simplified); ok {
+				if val == shortcircuitValue {
+					return constBoolExpr(shortcircuitValue)
+				}
+				// We can ignore this child (it is true for AND, false for OR).
+			} else {
+				if children == nil {
+					children = make([]*Expr, 0, len(e.children)-i)
+				}
+				children = append(children, simplified)
+			}
+		}
+		switch len(children) {
+		case 0:
+			// All children simplify to nothing.
+			return constBoolExpr(!shortcircuitValue)
+		case 1:
+			return children[0]
+		default:
+			scalarPropsCopy := *e.scalarProps
+			return &Expr{
+				op:          e.op,
+				scalarProps: &scalarPropsCopy,
+				private:     e.private,
+				children:    children,
+			}
+		}
+	}
+
+	// We try to create tight spans for the expression (as allowed by
+	// maxSimplifyPrefix), and check if the condition is implied by the final
+	// spans.
+	for offset := 0; offset <= maxSimplifyPrefix; offset++ {
+		if offset > 0 {
+			if offset == 1 {
+				// Copy the spans, we are about to modify them.
+				spans = append(LogicalSpans(nil), spans...)
+			}
+			// Chop away the first value in all spans to end up with spans
+			// for this offset.
+			for i := range spans {
+				spans[i].Start.Vals = spans[i].Start.Vals[1:]
+				spans[i].End.Vals = spans[i].End.Vals[1:]
+			}
+		}
+		var exprSpans LogicalSpans
+		var ok, tight bool
+		if c.isInverted {
+			if offset == 0 {
+				exprSpans, ok, tight = c.makeInvertedIndexSpansForExpr(e)
+			}
+		} else {
+			exprSpans, ok, tight = c.makeSpansForExpr(offset, e)
+		}
+		if ok && tight {
+			if c.isSpanSubset(offset, spans, exprSpans) {
+				// The final spans are a subset of the spans for this expression; there
+				// is no need for a remaining filter for this condition.
+				return constTrueExpr
+			}
+		}
+	}
+
+	return e.deepCopy()
+}
+
+// simplifyFilter removes parts of the filter that are satisfied by the spans. It
+// is best-effort. Returns nil if there is no remaining filter.
+func (c *indexConstraintCtx) simplifyFilter(filter *Expr, spans LogicalSpans) *Expr {
+	remainingFilter := c.simplifyFilterImpl(filter, spans, c.getMaxSimplifyPrefix(spans))
+	if ok, val := isConstBool(remainingFilter); ok && val {
+		return nil
+	}
+	return remainingFilter
+}
+
+// IndexConstraints is used to generate index constraints from a scalar boolean
+// filter expression.
+//
+// Sample usage:
+//   var ic IndexConstraints
+//   if err := ic.Init(filter, colInfos, evalCtx); err != nil {
+//     ..
+//   }
+//   spans, ok := ic.Spans()
+//   remainingFilter := ic.RemainingFilter(&iVarHelper)
+type IndexConstraints struct {
+	indexConstraintCtx
+
+	filter *Expr
+
+	spansPopulated bool
+	spansTight     bool
+	spans          LogicalSpans
+}
+
+// Init processes the filter and calculates the spans.
+func (ic *IndexConstraints) Init(
+	filter *Expr, colInfos []IndexColumnInfo, isInverted bool, evalCtx *tree.EvalContext,
+) {
+	*ic = IndexConstraints{
+		filter:             filter,
+		indexConstraintCtx: makeIndexConstraintCtx(colInfos, isInverted, evalCtx),
+	}
+	if isInverted {
+		ic.spans, ic.spansPopulated, ic.spansTight = ic.makeInvertedIndexSpansForExpr(ic.filter)
+	} else {
+		ic.spans, ic.spansPopulated, ic.spansTight = ic.makeSpansForExpr(0 /* offset */, ic.filter)
+	}
+}
+
+// Spans returns the spans created by Init. If ok is false, no constraints
+// could be generated.
+func (ic *IndexConstraints) Spans() (_ LogicalSpans, ok bool) {
+	if !ic.spansPopulated || (len(ic.spans) == 1 && ic.spans[0].IsFullSpan()) {
+		return nil, false
+	}
+	return ic.spans, true
+}
+
+// RemainingFilter calculates a simplified filter that needs to be applied
+// within the returned Spans.
+func (ic *IndexConstraints) RemainingFilter(ivh *tree.IndexedVarHelper) tree.TypedExpr {
+	var res *Expr
+	if !ic.spansPopulated {
+		if ok, val := isConstBool(ic.filter); ok && val {
+			return nil
+		}
+		res = ic.filter
+	} else {
+		if ic.spansTight || len(ic.spans) == 0 {
+			// The spans are "tight", or we have a contradiction; there is no remaining filter.
+			return nil
+		}
+		res = ic.simplifyFilter(ic.filter, ic.spans)
+	}
+	if res == nil {
+		return nil
+	}
+	c := typedExprConvCtx{ivh: ivh}
+	return scalarToTypedExpr(&c, res)
+}
+
+// isIndexColumn returns true if e is an indexed var that corresponds
+// to index column <offset>.
+func (c *indexConstraintCtx) isIndexColumn(e *Expr, index int) bool {
+	return isIndexedVar(e, c.colInfos[index].VarIdx)
+}

--- a/pkg/sql/opt/idxconstraint/index_constraints_test.go
+++ b/pkg/sql/opt/idxconstraint/index_constraints_test.go
@@ -15,81 +15,133 @@
 package idxconstraint
 
 import (
+	"flag"
+	"fmt"
+	"strconv"
 	"strings"
-	"testing"
 
-	"github.com/cockroachdb/cockroach/pkg/sql/opt/testutils"
-	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/opt"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
+	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 )
 
-func BenchmarkIndexConstraints(b *testing.B) {
-	testCases := []struct {
-		name, varTypes, indexInfo, expr string
-	}{
-		{
-			name:      "point-lookup",
-			varTypes:  "int",
-			indexInfo: "@1",
-			expr:      "@1 = 1",
-		},
-		{
-			name:      "no-constraints",
-			varTypes:  "int, int",
-			indexInfo: "@2",
-			expr:      "@1 = 1",
-		},
-		{
-			name:      "range",
-			varTypes:  "int",
-			indexInfo: "@1",
-			expr:      "@1 >= 1 AND @1 <= 10",
-		},
-		{
-			name:      "range-2d",
-			varTypes:  "int, int",
-			indexInfo: "@1, @2",
-			expr:      "@1 >= 1 AND @1 <= 10 AND @2 >= 1 AND @2 <= 10",
-		},
-		{
-			name:      "many-columns",
-			varTypes:  "int, int, int, int, int",
-			indexInfo: "@1, @2, @3, @4, @5",
-			expr:      "@1 = 1 AND @2 >= 2 AND @2 <= 4 AND (@3, @4, @5) IN ((3, 4, 5), (6, 7, 8))",
-		},
+var (
+	testDataGlob = flag.String("d", "testdata/[^.]*", "test data glob")
+)
+
+//func BenchmarkIndexConstraints(b *testing.B) {
+//	testCases := []struct {
+//		name, varTypes, indexInfo, expr string
+//	}{
+//		{
+//			name:      "point-lookup",
+//			varTypes:  "int",
+//			indexInfo: "@1",
+//			expr:      "@1 = 1",
+//		},
+//		{
+//			name:      "no-constraints",
+//			varTypes:  "int, int",
+//			indexInfo: "@2",
+//			expr:      "@1 = 1",
+//		},
+//		{
+//			name:      "range",
+//			varTypes:  "int",
+//			indexInfo: "@1",
+//			expr:      "@1 >= 1 AND @1 <= 10",
+//		},
+//		{
+//			name:      "range-2d",
+//			varTypes:  "int, int",
+//			indexInfo: "@1, @2",
+//			expr:      "@1 >= 1 AND @1 <= 10 AND @2 >= 1 AND @2 <= 10",
+//		},
+//		{
+//			name:      "many-columns",
+//			varTypes:  "int, int, int, int, int",
+//			indexInfo: "@1, @2, @3, @4, @5",
+//			expr:      "@1 = 1 AND @2 >= 2 AND @2 <= 4 AND (@3, @4, @5) IN ((3, 4, 5), (6, 7, 8))",
+//		},
+//	}
+//
+//	for _, tc := range testCases {
+//		b.Run(tc.name, func(b *testing.B) {
+//			varTypes, err := testutils.ParseTypes(strings.Split(tc.varTypes, ", "))
+//			if err != nil {
+//				b.Fatal(err)
+//			}
+//			colInfos, err := parseIndexColumns(varTypes, strings.Split(tc.indexInfo, ", "))
+//			if err != nil {
+//				b.Fatal(err)
+//			}
+//
+//			iVarHelper := tree.MakeTypesOnlyIndexedVarHelper(varTypes)
+//
+//			typedExpr, err := testutils.ParseScalarExpr(tc.expr, &iVarHelper)
+//			if err != nil {
+//				b.Fatal(err)
+//			}
+//
+//			evalCtx := tree.MakeTestingEvalContext()
+//			e, err := BuildScalarExpr(typedExpr, &evalCtx)
+//			if err != nil {
+//				b.Fatal(err)
+//			}
+//
+//			b.ResetTimer()
+//			for i := 0; i < b.N; i++ {
+//				var ic IndexConstraints
+//
+//				ic.Init(e, colInfos, false /*isInverted */, &evalCtx)
+//				_, _ = ic.Spans()
+//				// _ = ic.RemainingFilter(&iVarHelper)
+//			}
+//		})
+//	}
+//}
+
+// parseIndexColumns parses descriptions of index columns; each
+// string corresponds to an index column and is of the form:
+//   <type> [ascending|descending]
+func parseIndexColumns(indexVarTypes []types.T, colStrs []string) ([]IndexColumnInfo, error) {
+	res := make([]IndexColumnInfo, len(colStrs))
+	for i := range colStrs {
+		fields := strings.Fields(colStrs[i])
+		if fields[0][0] != '@' {
+			return nil, fmt.Errorf("index column must start with @<index>")
+		}
+		idx, err := strconv.Atoi(fields[0][1:])
+		if err != nil {
+			return nil, err
+		}
+		if idx < 1 || idx > len(indexVarTypes) {
+			return nil, fmt.Errorf("invalid index var @%d", idx)
+		}
+		res[i].VarIdx = opt.ColumnIndex(idx)
+		res[i].Typ = indexVarTypes[res[i].VarIdx]
+		res[i].Direction = encoding.Ascending
+		res[i].Nullable = true
+		fields = fields[1:]
+		for len(fields) > 0 {
+			switch strings.ToLower(fields[0]) {
+			case "ascending", "asc":
+				// ascending is the default.
+				fields = fields[1:]
+			case "descending", "desc":
+				res[i].Direction = encoding.Descending
+				fields = fields[1:]
+
+			case "not":
+				if len(fields) < 2 || strings.ToLower(fields[1]) != "null" {
+					return nil, fmt.Errorf("unknown column attribute %s", fields)
+				}
+				res[i].Nullable = false
+				fields = fields[2:]
+			default:
+				return nil, fmt.Errorf("unknown column attribute %s", fields)
+			}
+		}
 	}
-
-	for _, tc := range testCases {
-		b.Run(tc.name, func(b *testing.B) {
-			varTypes, err := testutils.ParseTypes(strings.Split(tc.varTypes, ", "))
-			if err != nil {
-				b.Fatal(err)
-			}
-			colInfos, err := parseIndexColumns(varTypes, strings.Split(tc.indexInfo, ", "))
-			if err != nil {
-				b.Fatal(err)
-			}
-
-			iVarHelper := tree.MakeTypesOnlyIndexedVarHelper(varTypes)
-
-			typedExpr, err := testutils.ParseScalarExpr(tc.expr, &iVarHelper)
-			if err != nil {
-				b.Fatal(err)
-			}
-
-			evalCtx := tree.MakeTestingEvalContext()
-			e, err := BuildScalarExpr(typedExpr, &evalCtx)
-			if err != nil {
-				b.Fatal(err)
-			}
-
-			b.ResetTimer()
-			for i := 0; i < b.N; i++ {
-				var ic IndexConstraints
-
-				ic.Init(e, colInfos, false /*isInverted */, &evalCtx)
-				_, _ = ic.Spans()
-				_ = ic.RemainingFilter(&iVarHelper)
-			}
-		})
-	}
+	return res, nil
 }

--- a/pkg/sql/opt/idxconstraint/index_constraints_test.go
+++ b/pkg/sql/opt/idxconstraint/index_constraints_test.go
@@ -1,0 +1,95 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package idxconstraint
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/testutils"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+)
+
+func BenchmarkIndexConstraints(b *testing.B) {
+	testCases := []struct {
+		name, varTypes, indexInfo, expr string
+	}{
+		{
+			name:      "point-lookup",
+			varTypes:  "int",
+			indexInfo: "@1",
+			expr:      "@1 = 1",
+		},
+		{
+			name:      "no-constraints",
+			varTypes:  "int, int",
+			indexInfo: "@2",
+			expr:      "@1 = 1",
+		},
+		{
+			name:      "range",
+			varTypes:  "int",
+			indexInfo: "@1",
+			expr:      "@1 >= 1 AND @1 <= 10",
+		},
+		{
+			name:      "range-2d",
+			varTypes:  "int, int",
+			indexInfo: "@1, @2",
+			expr:      "@1 >= 1 AND @1 <= 10 AND @2 >= 1 AND @2 <= 10",
+		},
+		{
+			name:      "many-columns",
+			varTypes:  "int, int, int, int, int",
+			indexInfo: "@1, @2, @3, @4, @5",
+			expr:      "@1 = 1 AND @2 >= 2 AND @2 <= 4 AND (@3, @4, @5) IN ((3, 4, 5), (6, 7, 8))",
+		},
+	}
+
+	for _, tc := range testCases {
+		b.Run(tc.name, func(b *testing.B) {
+			varTypes, err := testutils.ParseTypes(strings.Split(tc.varTypes, ", "))
+			if err != nil {
+				b.Fatal(err)
+			}
+			colInfos, err := parseIndexColumns(varTypes, strings.Split(tc.indexInfo, ", "))
+			if err != nil {
+				b.Fatal(err)
+			}
+
+			iVarHelper := tree.MakeTypesOnlyIndexedVarHelper(varTypes)
+
+			typedExpr, err := testutils.ParseScalarExpr(tc.expr, &iVarHelper)
+			if err != nil {
+				b.Fatal(err)
+			}
+
+			evalCtx := tree.MakeTestingEvalContext()
+			e, err := BuildScalarExpr(typedExpr, &evalCtx)
+			if err != nil {
+				b.Fatal(err)
+			}
+
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				var ic IndexConstraints
+
+				ic.Init(e, colInfos, false /*isInverted */, &evalCtx)
+				_, _ = ic.Spans()
+				_ = ic.RemainingFilter(&iVarHelper)
+			}
+		})
+	}
+}

--- a/pkg/sql/opt/idxconstraint/spans.go
+++ b/pkg/sql/opt/idxconstraint/spans.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"sort"
 
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
@@ -162,11 +163,13 @@ func ExactPrefix(spans LogicalSpans, evalCtx *tree.EvalContext) int {
 	}
 }
 
+var _ = ExactPrefix
+
 // IndexColumnInfo encompasses the information for index columns, needed for
 // index constraints.
 type IndexColumnInfo struct {
 	// VarIdx identifies the indexed var that corresponds to this column.
-	VarIdx    int
+	VarIdx    opt.ColumnIndex
 	Typ       types.T
 	Direction encoding.Direction
 	// Nullable should be set to false if this column cannot store NULLs; used
@@ -206,6 +209,8 @@ func makeIndexConstraintCtx(
 // taken into account.
 //
 // Returns 0 if the lists are equal, or one is a prefix of the other.
+// Otherwise returns -1 or +1 depending which is lexicographically smaller
+// (taking into account the index column directions).
 func (c *indexConstraintCtx) compareKeyVals(offset int, a, b tree.Datums) int {
 	for i := 0; i < len(a) && i < len(b); i++ {
 		if cmp := a[i].Compare(c.evalCtx, b[i]); cmp != 0 {

--- a/pkg/sql/opt/idxconstraint/spans.go
+++ b/pkg/sql/opt/idxconstraint/spans.go
@@ -1,0 +1,537 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// This file implements data structures used by index constraints generation.
+
+package idxconstraint
+
+import (
+	"bytes"
+	"fmt"
+	"sort"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
+	"github.com/cockroachdb/cockroach/pkg/util/encoding"
+)
+
+// LogicalKey is a high-level representation of a span boundary.
+type LogicalKey struct {
+	// Vals is a list of values on consecutive index columns.
+	Vals tree.Datums
+	// Inclusive is true if the boundary includes Vals, or false otherwise.
+	// An Inclusive span can be extended with constraints on more columns.
+	// Empty keys (empty vals) are always Inclusive.
+	Inclusive bool
+}
+
+func (k LogicalKey) String() string {
+	if len(k.Vals) == 0 {
+		return ""
+	}
+	var buf bytes.Buffer
+	for _, val := range k.Vals {
+		fmt.Fprintf(&buf, "/%s", val)
+	}
+	if k.Inclusive {
+		buf.WriteString(" (inclusive)")
+	} else {
+		buf.WriteString(" (exclusive)")
+	}
+	return buf.String()
+}
+
+// extend appends the given key.
+func (k *LogicalKey) extend(l LogicalKey) {
+	if !k.Inclusive {
+		panic("extending exclusive logicalKey")
+	}
+	// We allow aliasing between the Vals of different LogicalKeys. This is safe
+	// as long as we never modify the slices in-place (which is why we limit the
+	// capacity here).
+	k.Vals = append(k.Vals[:len(k.Vals):len(k.Vals)], l.Vals...)
+	k.Inclusive = l.Inclusive
+}
+
+// LogicalSpan is a high-level representation of a span. The Vals in Start and
+// End are values for contiguous prefixes of index columns.
+//
+// Note: internally, we also use LogicalKeys with values for a non-prefix
+// sequence of index columns (index columns starting at a given offset). Such
+// a LogicalSpan is only meaningful in the context of a certain offset.
+type LogicalSpan struct {
+	// boundaries for the span.
+	// If a column i is ascending, start.Vals[i] <= end.Vals[i].
+	// If a column i is descending, start.Vals[i] >= end.Vals[i].
+	Start, End LogicalKey
+}
+
+// MakeFullSpan creates an unconstrained span.
+func MakeFullSpan() LogicalSpan {
+	return LogicalSpan{
+		Start: LogicalKey{Inclusive: true},
+		End:   LogicalKey{Inclusive: true},
+	}
+}
+
+// IsFullSpan returns true if the given span is unconstrained.
+func (sp LogicalSpan) IsFullSpan() bool {
+	return len(sp.Start.Vals) == 0 && len(sp.End.Vals) == 0
+}
+
+// String formats a LogicalSpan. Inclusivity/exclusivity is shown using
+// brackets/parens. Some examples:
+//   [/1 - /2]
+//   (/1/1 - /2)
+//   [ - /5/6)
+//   [/1 - ]
+//   [ - ]
+func (sp LogicalSpan) String() string {
+	var buf bytes.Buffer
+
+	print := func(k LogicalKey) {
+		for _, val := range k.Vals {
+			fmt.Fprintf(&buf, "/%s", val)
+		}
+	}
+	if sp.Start.Inclusive {
+		buf.WriteString("[")
+	} else {
+		buf.WriteString("(")
+	}
+	print(sp.Start)
+	buf.WriteString(" - ")
+	print(sp.End)
+	if sp.End.Inclusive {
+		buf.WriteString("]")
+	} else {
+		buf.WriteString(")")
+	}
+	return buf.String()
+}
+
+// LogicalSpans represents index constraints as a list of disjoint,
+// ordered LogicalSpans.
+//
+// A few examples:
+//  - no constraints: a single span with no boundaries [ - ]
+//  - a constraint on @1 > 1: a single span (/1 - ]
+//  - a constraint on @1 = 1 AND @2 > 1: a single span (/1/1 - /1]
+//  - a contradiction: empty list.
+//
+// Note: internally, we also use LogicalSpans that correspond to a
+// contiguous sequence of index columns, starting at a given offset.
+type LogicalSpans []LogicalSpan
+
+// ExactPrefix returns the longest prefix of columns that are
+// constrained to a single value. For example:
+//   filter: @1 = 1 AND (@2 = 3 OR @2 >= 5 AND @2 <= 7)
+//   spans: [/1/3 - /1/3]
+//          [/1/5 - /1/7]
+//   exact prefix: 1
+func ExactPrefix(spans LogicalSpans, evalCtx *tree.EvalContext) int {
+	if len(spans) == 0 {
+		return 0
+	}
+	for i := 0; ; i++ {
+		var val tree.Datum
+		for j, sp := range spans {
+			if len(sp.Start.Vals) <= i || len(sp.End.Vals) <= i {
+				return i
+			}
+			if sp.Start.Vals[i].Compare(evalCtx, sp.End.Vals[i]) != 0 {
+				return i
+			}
+			if j == 0 {
+				val = sp.Start.Vals[i]
+			} else if sp.Start.Vals[i].Compare(evalCtx, val) != 0 {
+				return i
+			}
+		}
+	}
+}
+
+// IndexColumnInfo encompasses the information for index columns, needed for
+// index constraints.
+type IndexColumnInfo struct {
+	// VarIdx identifies the indexed var that corresponds to this column.
+	VarIdx    int
+	Typ       types.T
+	Direction encoding.Direction
+	// Nullable should be set to false if this column cannot store NULLs; used
+	// to keep the spans simple, e.g. [ - /5] instead of (/NULL - /5].
+	Nullable bool
+}
+
+type indexConstraintCtx struct {
+	// types of the columns of the index we are generating constraints for.
+	colInfos []IndexColumnInfo
+
+	// isInverted indicates if the index is an inverted index (e.g. JSONB).
+	// An inverted index behaves differently than a normal index because a PK
+	// can appear in multiple index entries. For example, `a @> x AND a @> y` is
+	// not a contradiction because some PKs can appear in both regions of the
+	// index (so AND is no longer just span intersection).
+	isInverted bool
+
+	evalCtx *tree.EvalContext
+}
+
+func makeIndexConstraintCtx(
+	colInfos []IndexColumnInfo, isInverted bool, evalCtx *tree.EvalContext,
+) indexConstraintCtx {
+	if isInverted && len(colInfos) > 1 {
+		panic(fmt.Sprintf("inverted index on multiple columns"))
+	}
+	return indexConstraintCtx{
+		colInfos:   colInfos,
+		isInverted: isInverted,
+		evalCtx:    evalCtx,
+	}
+}
+
+// compareKeyVals compares two lists of values for a sequence of index columns
+// (namely <offset>, <offset+1>, ...). The directions of the index columns are
+// taken into account.
+//
+// Returns 0 if the lists are equal, or one is a prefix of the other.
+func (c *indexConstraintCtx) compareKeyVals(offset int, a, b tree.Datums) int {
+	for i := 0; i < len(a) && i < len(b); i++ {
+		if cmp := a[i].Compare(c.evalCtx, b[i]); cmp != 0 {
+			if c.colInfos[offset+i].Direction == encoding.Descending {
+				return -cmp
+			}
+			return cmp
+		}
+	}
+	return 0
+}
+
+type comparisonDirection int
+
+const (
+	compareStartKeys = +1
+	compareEndKeys   = -1
+)
+
+// Compares two logicalKeys.
+//
+// The comparison between two logical keys depends on whether we are comparing
+// start keys or end keys.
+//
+// For example:
+//   a = /1/2
+//   b = /1
+//
+// For start keys, a > b: [/1/2 - ...] is tighter than [/1 - ...].
+// For end keys, a < b:   [... - /1/2] is tighter than [... - /1].
+//
+// A similar situation is when the keys have equal values (or one is a prefix of
+// the other), and one is exclusive and one is not.
+//
+// For example:
+//   a = /5 (inclusive)
+//   b = /5 (exclusive)
+//
+// If we are comparing start keys, direction must be compareStartKeys (+1).
+// If we are comparing end keys, direction must be compareEndKeys (-1).
+func (c *indexConstraintCtx) compare(
+	offset int, a, b LogicalKey, direction comparisonDirection,
+) int {
+	if cmp := c.compareKeyVals(offset, a.Vals, b.Vals); cmp != 0 {
+		return cmp
+	}
+	dirVal := int(direction)
+	if len(a.Vals) < len(b.Vals) {
+		// a matches a prefix of b.
+		if !a.Inclusive {
+			// Example:
+			//  a = /1 (exclusive)
+			//  b = /1/2 (inclusive)
+			// Which of these is "smaller" depends on whether we are looking at a
+			// start or end key.
+			return dirVal
+		}
+		// Example:
+		//   a = /1 (inclusive)
+		//   b = /1/2 (inclusive)
+		return -dirVal
+	}
+	// Case symmetric with the above.
+	if len(a.Vals) > len(b.Vals) {
+		if !b.Inclusive {
+			return -dirVal
+		}
+		return dirVal
+	}
+
+	// Equal keys.
+	if !a.Inclusive && b.Inclusive {
+		// Example:
+		//   a = /5 (exclusive)
+		//   b = /5 (inclusive)
+		return dirVal
+	}
+	if a.Inclusive && !b.Inclusive {
+		return -dirVal
+	}
+	return 0
+}
+
+// startsAfter returns true if a span that ends in prevSpanEnd cannot
+// overlap with a span that starts at spanStart.
+func (c *indexConstraintCtx) startsAfter(offset int, prevSpanEnd, spanStart LogicalKey) bool {
+	cmp := c.compareKeyVals(offset, prevSpanEnd.Vals, spanStart.Vals)
+	if cmp != 0 {
+		return cmp < 0
+	}
+	switch {
+	case len(prevSpanEnd.Vals) < len(spanStart.Vals):
+		// The previous end key is a prefix of the current start key.
+		// Overlap only if the end key is inclusive.
+		return !prevSpanEnd.Inclusive
+
+	case len(prevSpanEnd.Vals) > len(spanStart.Vals):
+		// The current start key is a prefix of the previous end key.
+		// Overlap only if the start key is inclusive.
+		return !spanStart.Inclusive
+
+	default:
+		// The previous end key and the current start key have the same values.
+		// If either is inclusive, the spans "touch".
+		return !prevSpanEnd.Inclusive && !spanStart.Inclusive
+	}
+}
+
+func (c *indexConstraintCtx) isSpanValid(offset int, sp *LogicalSpan) bool {
+	a, b := sp.Start, sp.End
+	if cmp := c.compareKeyVals(offset, a.Vals, b.Vals); cmp != 0 {
+		return cmp < 0
+	}
+	if len(a.Vals) < len(b.Vals) {
+		// a is a prefix of b; a must be inclusive.
+		return a.Inclusive
+	}
+	if len(a.Vals) > len(b.Vals) {
+		// b is a prefix of a; b must be inclusive
+		return b.Inclusive
+	}
+	return a.Inclusive && b.Inclusive
+}
+
+// checkSpans asserts that the given spans are ordered and non-overlapping.
+func (c *indexConstraintCtx) checkSpans(offset int, ls LogicalSpans) {
+	for i := range ls {
+		if !c.isSpanValid(offset, &ls[i]) {
+			panic(fmt.Sprintf("invalid span %s", ls[i]))
+		}
+		if i > 0 && !c.startsAfter(offset, ls[i-1].End, ls[i].Start) {
+			panic(fmt.Sprintf("spans not ordered and disjoint: %s, %s\n", ls[i-1], ls[i]))
+		}
+	}
+}
+
+// nextDatum returns the datum that follows d, in the given direction.
+func (c *indexConstraintCtx) nextDatum(
+	d tree.Datum, direction encoding.Direction,
+) (tree.Datum, bool) {
+	if direction == encoding.Descending {
+		if d.IsMin(c.evalCtx) {
+			return nil, false
+		}
+		return d.Prev(c.evalCtx)
+	}
+	if d.IsMax(c.evalCtx) {
+		return nil, false
+	}
+	return d.Next(c.evalCtx)
+}
+
+// preferInclusive tries to convert exclusive keys to inclusive keys. This is
+// only possible if the type supports Next/Prev.
+//
+// We prefer inclusive constraints because we can extend inclusive constraints
+// with more constraints on columns that follow.
+//
+// Examples:
+//  - for an integer column (/1 - /5)  =>  [/2 - /4].
+//  - for a descending integer column (/5 - /1) => (/4 - /2).
+//  - for a string column, we don't have Prev so
+//      (/foo - /qux)  =>  [/foo\x00 - /qux).
+//  - for a decimal column, we don't have either Next or Prev so we can't
+//    change anything.
+func (c *indexConstraintCtx) preferInclusive(offset int, sp *LogicalSpan) {
+	if !sp.Start.Inclusive {
+		col := len(sp.Start.Vals) - 1
+		if nextVal, hasNext := c.nextDatum(
+			sp.Start.Vals[col], c.colInfos[offset+col].Direction,
+		); hasNext {
+			sp.Start.Vals[col] = nextVal
+			sp.Start.Inclusive = true
+		}
+	}
+
+	if !sp.End.Inclusive {
+		col := len(sp.End.Vals) - 1
+		if prevVal, hasPrev := c.nextDatum(
+			sp.End.Vals[col], c.colInfos[offset+col].Direction.Reverse(),
+		); hasPrev {
+			sp.End.Vals[col] = prevVal
+			sp.End.Inclusive = true
+		}
+	}
+}
+
+// intersectSpan intersects two LogicalSpans and returns
+// a new LogicalSpan. If there is no intersection, returns ok=false.
+func (c *indexConstraintCtx) intersectSpan(
+	offset int, a *LogicalSpan, b *LogicalSpan,
+) (_ LogicalSpan, ok bool) {
+	res := *a
+	changed := 0
+	if c.compare(offset, a.Start, b.Start, compareStartKeys) < 0 {
+		res.Start = b.Start
+		changed++
+	}
+	if c.compare(offset, a.End, b.End, compareEndKeys) > 0 {
+		res.End = b.End
+		changed++
+	}
+	// If changed is 0 or 2, the result is identical to one of the input spans.
+	if changed == 1 && !c.isSpanValid(offset, &res) {
+		return LogicalSpan{}, false
+	}
+	return res, true
+}
+
+// intersectSpanSet intersects a span with (the union of) a set of spans. The
+// spans in spanSet must be ordered and non-overlapping. The resulting spans are
+// guaranteed to be ordered and non-overlapping.
+func (c *indexConstraintCtx) intersectSpanSet(
+	offset int, a *LogicalSpan, spanSet LogicalSpans,
+) LogicalSpans {
+	res := make(LogicalSpans, 0, len(spanSet))
+	for i := range spanSet {
+		if sp, ok := c.intersectSpan(offset, a, &spanSet[i]); ok {
+			res = append(res, sp)
+		}
+	}
+	c.checkSpans(offset, res)
+	return res
+}
+
+// mergeSpanSets takes two sets of (ordered, non-overlapping) spans and
+// generates their union (as ordered, non-overlapping spans).
+func (c *indexConstraintCtx) mergeSpanSets(
+	offset int, a LogicalSpans, b LogicalSpans,
+) LogicalSpans {
+	if len(a) == 0 && len(b) == 0 {
+		return LogicalSpans{}
+	}
+	result := make(LogicalSpans, 0, len(a)+len(b))
+	for len(a) > 0 || len(b) > 0 {
+		if len(b) > 0 &&
+			(len(a) == 0 || c.compare(offset, a[0].Start, b[0].Start, compareStartKeys) > 0) {
+			// Swap the two sets, so that going forward a[0] starts before b[0].
+			a, b = b, a
+		}
+		span := a[0]
+		a = a[1:]
+
+		// Merge this span with any overlapping spans in a or b. Initially, it can
+		// only overlap with spans in b, but after the merge we can have new
+		// overlaps; hence why this is a loop and we check against both a and b. For
+		// example:
+		//   a: [/1 /10] [/20 - /30] [/40 - /50]
+		//   b: [/5 /25] [/30 - /40]
+		//                           span
+		//   initial:                [/1 - /10]
+		//   merge with [/5 - /25]:  [/1 - /25]
+		//   merge with [/20 - /30]: [/1 - /30]
+		//   merge with [/30 - /40]: [/1 - /40]
+		//   merge with [/40 - /50]: [/1 - /50]
+		//
+		for {
+			var mergeSpan LogicalSpan
+			if len(a) > 0 && !c.startsAfter(offset, span.End, a[0].Start) {
+				mergeSpan = a[0]
+				a = a[1:]
+			} else if len(b) > 0 && !c.startsAfter(offset, span.End, b[0].Start) {
+				mergeSpan = b[0]
+				b = b[1:]
+			} else {
+				break
+			}
+
+			// Take the "max" of the end keys.
+			if c.compare(offset, span.End, mergeSpan.End, compareEndKeys) < 0 {
+				span.End = mergeSpan.End
+			}
+		}
+		result = append(result, span)
+	}
+	return result
+}
+
+// isSpanSubset returns true if the spans in a are completely
+// contained in the spans in b.
+func (c *indexConstraintCtx) isSpanSubset(offset int, a LogicalSpans, b LogicalSpans) bool {
+	for _, sp := range a {
+		for len(b) > 0 && c.startsAfter(offset, b[0].End, sp.Start) {
+			// b[0] ends before the first span in a.
+			b = b[1:]
+		}
+		// b[0] is the first span that ends at or after sp.Start.
+		// If a is a subset of b, b[0] must completely contain sp.
+		if len(b) == 0 ||
+			c.compare(offset, sp.Start, b[0].Start, compareStartKeys) < 0 ||
+			c.compare(offset, sp.End, b[0].End, compareEndKeys) > 0 {
+			return false
+		}
+	}
+	return true
+}
+
+type logicalSpanSorter struct {
+	c      *indexConstraintCtx
+	offset int
+	spans  []LogicalSpan
+}
+
+var _ sort.Interface = &logicalSpanSorter{}
+
+// Len is part of sort.Interface.
+func (ss *logicalSpanSorter) Len() int {
+	return len(ss.spans)
+}
+
+// Less is part of sort.Interface.
+func (ss *logicalSpanSorter) Less(i, j int) bool {
+	// Compare start keys.
+	return ss.c.compare(ss.offset, ss.spans[i].Start, ss.spans[j].Start, compareStartKeys) < 0
+}
+
+// Swap is part of sort.Interface.
+func (ss *logicalSpanSorter) Swap(i, j int) {
+	ss.spans[i], ss.spans[j] = ss.spans[j], ss.spans[i]
+}
+
+func (c *indexConstraintCtx) sortSpans(offset int, spans LogicalSpans) {
+	ss := logicalSpanSorter{
+		c:      c,
+		offset: offset,
+		spans:  spans,
+	}
+	sort.Sort(&ss)
+}

--- a/pkg/sql/opt/idxconstraint/spans_test.go
+++ b/pkg/sql/opt/idxconstraint/spans_test.go
@@ -1,0 +1,408 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package idxconstraint
+
+import (
+	"fmt"
+	"math/rand"
+	"reflect"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/util/encoding"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
+)
+
+// parses a span with integer column values in the format of LogicalSpan.String.
+func parseSpan(str string) LogicalSpan {
+	if len(str) < len("[ - ]") {
+		panic(str)
+	}
+	var start, end LogicalKey
+	switch str[0] {
+	case '[':
+		start.Inclusive = true
+	case '(':
+	default:
+		panic(str)
+	}
+	switch str[len(str)-1] {
+	case ']':
+		end.Inclusive = true
+	case ')':
+	default:
+		panic(str)
+	}
+	sepIdx := strings.Index(str, " - ")
+	if sepIdx == -1 {
+		panic(str)
+	}
+	startVal := str[1:sepIdx]
+	endVal := str[sepIdx+len(" - ") : len(str)-1]
+
+	parseVals := func(str string) tree.Datums {
+		if str == "" {
+			return nil
+		}
+		if str[0] != '/' {
+			panic(str)
+		}
+		var res tree.Datums
+		for i := 1; i < len(str); {
+			length := strings.Index(str[i:], "/")
+			if length == -1 {
+				length = len(str) - i
+			}
+			val, err := strconv.Atoi(str[i : i+length])
+			if err != nil {
+				panic(err)
+			}
+			res = append(res, tree.NewDInt(tree.DInt(val)))
+			i += length + 1
+		}
+		return res
+	}
+
+	start.Vals = parseVals(startVal)
+	end.Vals = parseVals(endVal)
+	return LogicalSpan{Start: start, End: end}
+}
+
+// parseSpans parses a list of spans with integer values
+// like:
+//   [/1 - /2], [/5 - /6]
+func parseSpans(str string) LogicalSpans {
+	if str == "" {
+		return nil
+	}
+	var result LogicalSpans
+	for _, s := range strings.Split(str, ", ") {
+		result = append(result, parseSpan(s))
+	}
+	return result
+}
+
+func spansStr(spans LogicalSpans) string {
+	var str string
+	for _, sp := range spans {
+		if str != "" {
+			str += ", "
+		}
+		str += sp.String()
+	}
+	return str
+}
+
+func TestIntersectSpan(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	testData := []struct {
+		a, b string
+		// expected value
+		e string
+	}{
+		{
+			a: "[ - ]",
+			b: "(/5 - /6]",
+			e: "(/5 - /6]",
+		},
+		{
+			// Equal values but exclusive vs inclusive keys.
+			a: "[/1 - /2)",
+			b: "(/1 - /2]",
+			e: "(/1 - /2)",
+		},
+		{
+			// Equal prefix values (inclusive).
+			a: "[/1/2 - /5]",
+			b: "[/1 - /5/6]",
+			e: "[/1/2 - /5/6]",
+		},
+		{
+			// Equal prefix values (exclusive).
+			a: "(/1/2 - /5)",
+			b: "(/1 - /5/6)",
+			e: "(/1 - /5)",
+		},
+		{
+			// Equal prefix values (mixed).
+			a: "[/1/2 - /5)",
+			b: "(/1 - /5/6]",
+			e: "(/1 - /5)",
+		},
+		{
+			a: "[/1 - /2]",
+			b: "[/2 - /5]",
+			e: "[/2 - /2]",
+		},
+		{
+			a: "[/1 - /2)",
+			b: "[/2 - /5]",
+			e: "",
+		},
+		{
+			a: "[/1 - /2/4)",
+			b: "[/2 - /5]",
+			e: "[/2 - /2/4)",
+		},
+	}
+
+	evalCtx := tree.MakeTestingEvalContext()
+
+	for i, tc := range testData {
+		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+			sp1 := parseSpan(tc.a)
+			sp2 := parseSpan(tc.b)
+			c := indexConstraintCtx{
+				// Only the directions from colInfos are used by intersectSpan
+				colInfos: []IndexColumnInfo{
+					{Direction: encoding.Ascending},
+					{Direction: encoding.Ascending},
+				},
+				evalCtx: &evalCtx,
+			}
+			res := ""
+			if sp3, ok := c.intersectSpan(0 /* offset */, &sp1, &sp2); ok {
+				res = sp3.String()
+			}
+			if res != tc.e {
+				t.Errorf("expected  %s  got  %s", tc.e, res)
+			}
+		})
+	}
+}
+
+// randSpans is a set of randomly generated LogicalSpans with
+// integer endpoints, along with a bitmap representation of the
+// intervals.
+type randSpans struct {
+	spans  LogicalSpans
+	bitmap []bool
+}
+
+const randSpansBitmapSize = 1000
+
+func makeRandSpans(rng *rand.Rand, allowExclusive bool) randSpans {
+	spans := make(LogicalSpans, rng.Intn(5))
+	bitmap := make([]bool, randSpansBitmapSize)
+	last := 0
+	for i := range spans {
+		// Generate an integer interval [start, end].
+		// We multiply by two to make sure we don't generate intervals
+		// like [0, 1] and [2, 3] which seem disjoint but are not disjoint
+		// in the bitmap.
+		start := last + 2 + 2*rng.Intn(10)
+		end := start + 2 + 2*rng.Intn(10)
+		last = end
+		for k := start; k <= end; k++ {
+			bitmap[k] = true
+		}
+
+		sp := &spans[i]
+		*sp = MakeFullSpan()
+		// Randomly make the endpoints inclusive or exclusive (while
+		// effectively indicating the same interval).
+		if allowExclusive && rng.Intn(2) == 0 {
+			sp.Start.Inclusive = false
+			start--
+		}
+		if allowExclusive && rng.Intn(2) == 0 {
+			sp.End.Inclusive = false
+			end++
+		}
+		sp.Start.Vals = tree.Datums{tree.NewDInt(tree.DInt(start))}
+		sp.End.Vals = tree.Datums{tree.NewDInt(tree.DInt(end))}
+	}
+	return randSpans{spans: spans, bitmap: bitmap}
+}
+
+// mergeRandSpans merges the bitmaps of two randSpans and returns
+// the result as a list of intervals.
+func mergeRandSpans(a randSpans, b randSpans) [][2]int {
+	var result [][2]int
+
+	for i := 0; i < randSpansBitmapSize; i++ {
+		if !a.bitmap[i] && !b.bitmap[i] {
+			continue
+		}
+		start := i
+		for i++; a.bitmap[i] || b.bitmap[i]; i++ {
+		}
+		end := i - 1
+		result = append(result, [2]int{start, end})
+	}
+	return result
+}
+
+func isRandSpanSubset(a randSpans, b randSpans) bool {
+	for i := 0; i < randSpansBitmapSize; i++ {
+		if a.bitmap[i] && !b.bitmap[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func TestMergeSpanSets(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	testData := []struct {
+		a, b string
+		// expected value
+		e string
+	}{
+		{
+			a: "[/1 - /3]",
+			b: "[/2 - /4]",
+			e: "[/1 - /4]",
+		},
+		{
+			a: "",
+			b: "[/1 - /2]",
+			e: "[/1 - /2]",
+		},
+		{
+			a: "[ - ]",
+			b: "[/1 - /2]",
+			e: "[ - ]",
+		},
+		{
+			a: "[/1 - /2], [/3 - /5]",
+			b: "[/2 - /4]",
+			e: "[/1 - /5]",
+		},
+		{
+			a: "[/1 - /2], [/3 - /5]",
+			b: "[/2/5 - /4]",
+			e: "[/1 - /5]",
+		},
+		{
+			a: "[/1 - /2), [/3 - /5]",
+			b: "[/2/5 - /4]",
+			e: "[/1 - /2), [/2/5 - /5]",
+		},
+		{
+			a: "[/1 - /2], [/4 - /5]",
+			b: "(/2 - /4)",
+			e: "[/1 - /5]",
+		},
+		{
+			a: "[/1 - /2), (/4 - /5]",
+			b: "[/2 - /4]",
+			e: "[/1 - /5]",
+		},
+		{
+			a: "[/1 - /3], [/8 - /10], (/13 - /15)",
+			b: "[/0 - /0], (/4 - /5], (/9 - /14]",
+			e: "[/0 - /0], [/1 - /3], (/4 - /5], [/8 - /15)",
+		},
+	}
+
+	evalCtx := tree.MakeTestingEvalContext()
+
+	for i, tc := range testData {
+		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+			a := parseSpans(tc.a)
+			b := parseSpans(tc.b)
+			c := indexConstraintCtx{
+				colInfos: []IndexColumnInfo{
+					{Direction: encoding.Ascending},
+					{Direction: encoding.Ascending},
+				},
+				evalCtx: &evalCtx,
+			}
+			res := spansStr(c.mergeSpanSets(0 /* offset */, a, b))
+			if res != tc.e {
+				t.Errorf("expected  %s  got  %s", tc.e, res)
+			}
+		})
+	}
+
+	t.Run("rand", func(t *testing.T) {
+		rng, _ := randutil.NewPseudoRand()
+		for n := 0; n < 500; n++ {
+			// We generate two random sets of intervals with small integer values and
+			// cross-check mergeSpanSets with a simple bitmap-based implementation.
+			a := makeRandSpans(rng, true /* allowExclusive */)
+			b := makeRandSpans(rng, true /* allowExclusive */)
+			c := indexConstraintCtx{
+				colInfos: []IndexColumnInfo{{Direction: encoding.Ascending}},
+				evalCtx:  &evalCtx,
+			}
+			mergedSpans := c.mergeSpanSets(0 /* offset */, a.spans, b.spans)
+			// Convert back to integer intervals and check against the bitmap.
+			var result [][2]int
+			for _, sp := range mergedSpans {
+				start := int(*sp.Start.Vals[0].(*tree.DInt))
+				if !sp.Start.Inclusive {
+					start++
+				}
+				end := int(*sp.End.Vals[0].(*tree.DInt))
+				if !sp.End.Inclusive {
+					end--
+				}
+				result = append(result, [2]int{start, end})
+			}
+			expected := mergeRandSpans(a, b)
+			if !reflect.DeepEqual(expected, result) {
+				t.Errorf(`
+       a: %v
+       b: %v
+  merged: %v
+  result: %v
+expected: %v
+`,
+					a.spans, b.spans, mergedSpans, result, expected)
+			}
+		}
+	})
+}
+
+func TestIsSpanSubset(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	evalCtx := tree.MakeTestingEvalContext()
+
+	rng, _ := randutil.NewPseudoRand()
+	for n := 0; n < 500; n++ {
+		// We generate two random sets of intervals with small integer values and
+		// cross-check mergeSpanSets with a simple bitmap-based implementation.
+		// We don't allow exclusive spans because of cases like:
+		//  (/5 - /10]
+		//  [/6 - /20]
+		// which doesn't look like a subset but it is according to the bitmap.
+		a := makeRandSpans(rng, false /* allowExclusive */)
+		b := makeRandSpans(rng, false /* allowExclusive */)
+		c := indexConstraintCtx{
+			colInfos: []IndexColumnInfo{{Direction: encoding.Ascending}},
+			evalCtx:  &evalCtx,
+		}
+		result := c.isSpanSubset(0 /* offset */, a.spans, b.spans)
+		expected := isRandSpanSubset(a, b)
+
+		if result != expected {
+			t.Errorf(`
+a: %v
+b: %v
+result: %t
+`,
+				a.spans, b.spans, result,
+			)
+		}
+	}
+}

--- a/pkg/sql/opt/idxconstraint/spans_test.go
+++ b/pkg/sql/opt/idxconstraint/spans_test.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -162,7 +163,8 @@ func TestIntersectSpan(t *testing.T) {
 		},
 	}
 
-	evalCtx := tree.MakeTestingEvalContext()
+	st := cluster.MakeTestingClusterSettings()
+	evalCtx := tree.MakeTestingEvalContext(st)
 
 	for i, tc := range testData {
 		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
@@ -313,7 +315,8 @@ func TestMergeSpanSets(t *testing.T) {
 		},
 	}
 
-	evalCtx := tree.MakeTestingEvalContext()
+	st := cluster.MakeTestingClusterSettings()
+	evalCtx := tree.MakeTestingEvalContext(st)
 
 	for i, tc := range testData {
 		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
@@ -376,7 +379,8 @@ expected: %v
 func TestIsSpanSubset(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	evalCtx := tree.MakeTestingEvalContext()
+	st := cluster.MakeTestingClusterSettings()
+	evalCtx := tree.MakeTestingEvalContext(st)
 
 	rng, _ := randutil.NewPseudoRand()
 	for n := 0; n < 500; n++ {

--- a/pkg/sql/opt/idxconstraint/testdata/all
+++ b/pkg/sql/opt/idxconstraint/testdata/all
@@ -1,0 +1,1432 @@
+# TODO(radu): split this into multiple files.
+
+index-constraints vars=(int) index=(@1)
+NULL
+----
+
+index-constraints vars=(int) index=(@1)
+false
+----
+
+index-constraints vars=(int) index=(@1)
+true
+----
+[ - ]
+
+index-constraints vars=(int) index=(@1)
+@1
+----
+[ - ]
+
+# Remaining filter: @1
+
+
+index-constraints vars=(int) index=(@1)
+@1 > 2
+----
+[/3 - ]
+
+index-constraints vars=(int) index=(@1)
+NOT (@1 <= 2)
+----
+[/3 - ]
+
+index-constraints vars=(int) index=(@1 desc)
+@1 > 2
+----
+[ - /3]
+
+index-constraints vars=(int) index=(@1)
+@1 >= 2
+----
+[/2 - ]
+
+index-constraints vars=(int) index=(@1 desc)
+@1 >= 2
+----
+[ - /2]
+
+index-constraints vars=(int) index=(@1 not null)
+@1 != 2
+----
+[ - /1]
+[/3 - ]
+
+index-constraints vars=(int) index=(@1 not null)
+NOT (@1 = 2)
+----
+[ - /1]
+[/3 - ]
+
+index-constraints vars=(int) index=(@1 desc not null)
+@1 != 2
+----
+[ - /3]
+[/1 - ]
+
+index-constraints vars=(int) index=(@1 not null)
+@1 < 2
+----
+[ - /1]
+
+index-constraints vars=(int) index=(@1 desc not null)
+@1 < 2
+----
+[/1 - ]
+
+index-constraints vars=(int) index=(@1 not null)
+@1 = 2
+----
+[/2 - /2]
+
+index-constraints vars=(int) index=(@1 desc not null)
+@1 = 2
+----
+[/2 - /2]
+
+index-constraints vars=(int) index=(@1)
+@1 != 2
+----
+(/NULL - /1]
+[/3 - ]
+
+index-constraints vars=(int) index=(@1 desc)
+@1 != 2
+----
+[ - /3]
+[/1 - /NULL)
+
+index-constraints vars=(int) index=(@1)
+@1 < 2
+----
+(/NULL - /1]
+
+index-constraints vars=(int) index=(@1 desc)
+@1 < 2
+----
+[/1 - /NULL)
+
+index-constraints vars=(int) index=(@1)
+@1 = 2
+----
+[/2 - /2]
+
+index-constraints vars=(int) index=(@1 desc)
+@1 = 2
+----
+[/2 - /2]
+
+index-constraints vars=(int) index=(@1)
+NULL
+----
+
+index-constraints vars=(int) index=(@1)
+@1 > NULL
+----
+
+index-constraints vars=(int) index=(@1)
+@1 < NULL
+----
+
+index-constraints vars=(int) index=(@1)
+@1 >= NULL
+----
+
+index-constraints vars=(int) index=(@1)
+@1 >= NULL
+----
+
+index-constraints vars=(int) index=(@1)
+@1 = NULL
+----
+
+index-constraints vars=(int) index=(@1)
+@1 != NULL
+----
+
+index-constraints vars=(bool) index=(@1)
+@1
+----
+[/true - /true]
+
+index-constraints vars=(bool) index=(@1)
+NOT @1
+----
+[/false - /false]
+
+index-constraints vars=(int, int) index=(@1)
+@1 = 1 AND @2 = 2
+----
+[/1 - /1]
+
+# Remaining filter: @2 = 2
+
+
+index-constraints vars=(int, int) index=(@2)
+@1 = 1 AND @2 = 2
+----
+[/2 - /2]
+
+# Remaining filter: @1 = 1
+
+
+index-constraints vars=(int, int) index=(@1, @2)
+@1 = 1 AND @2 > NULL
+----
+
+index-constraints vars=(int, int) index=(@1, @2)
+@2 = 1 AND @1 > NULL
+----
+
+index-constraints vars=(int) index=(@1)
+@1 > 2 AND @1 < 4
+----
+[/3 - /3]
+
+index-constraints vars=(int) index=(@1)
+@1 >= 2 AND @1 <= 4
+----
+[/2 - /4]
+
+index-constraints vars=(int, int) index=(@1, @2)
+@1 > 2 AND @2 > 5
+----
+[/3/6 - ]
+
+# Remaining filter: @2 > 5
+
+
+index-constraints vars=(int, int) index=(@1, @2 desc)
+@1 > 2 AND @2 < 5
+----
+[/3/4 - ]
+
+# Remaining filter: @2 < 5
+
+
+index-constraints vars=(int, int) index=(@1, @2)
+@1 != 1 AND @2 > 5
+----
+(/NULL - /0]
+[/2/6 - ]
+
+# Remaining filter: @2 > 5
+
+
+index-constraints vars=(int, int) index=(@1, @2)
+@1 != 1 AND @2 < 5
+----
+(/NULL - /0/4]
+(/2/NULL - ]
+
+# Remaining filter: @2 < 5
+
+
+index-constraints vars=(int) index=(@1)
+@1 >= 1 AND @1 <= 5 AND @1 != 3
+----
+[/1 - /2]
+[/4 - /5]
+
+index-constraints vars=(int, int) index=(@1, @2)
+@1 >= 1 AND @1 <= 2 AND @2 >= 8 AND @2 <= 9
+----
+[/1/8 - /2/9]
+
+# Remaining filter: (@2 >= 8) AND (@2 <= 9)
+
+
+index-constraints vars=(int, int) index=(@1 desc, @2)
+@1 >= 1 AND @1 <= 2 AND @2 >= 8 AND @2 <= 9
+----
+[/2/8 - /1/9]
+
+# Remaining filter: (@2 >= 8) AND (@2 <= 9)
+
+
+index-constraints vars=(int, int) index=(@1, @2 desc)
+@1 >= 1 AND @1 <= 2 AND @2 >= 8 AND @2 <= 9
+----
+[/1/9 - /2/8]
+
+# Remaining filter: (@2 >= 8) AND (@2 <= 9)
+
+
+index-constraints vars=(int, int) index=(@1, @2)
+@1 > 1 AND @1 < 4 AND @2 > 5 AND @2 < 8
+----
+[/2/6 - /3/7]
+
+# Remaining filter: (@2 > 5) AND (@2 < 8)
+
+
+index-constraints vars=(int, int) index=(@1, @2)
+@1 > 1 AND @1 < 4 AND @2 = 5
+----
+[/2/5 - /3/5]
+
+# Remaining filter: @2 = 5
+
+
+index-constraints vars=(int, int) index=(@1, @2)
+@1 = 1 AND @2 > 3 AND @2 < 5
+----
+[/1/4 - /1/4]
+
+index-constraints vars=(int, int) index=(@1, @2)
+@1 = 1 AND @2 > 3 AND @2 < 8
+----
+[/1/4 - /1/7]
+
+index-constraints vars=(int) index=(@1)
+@1 > 2 AND @1 < 1
+----
+
+index-constraints vars=(int, int) index=(@1, @2)
+@1 = 1 AND @2 != 2
+----
+(/1/NULL - /1/1]
+[/1/3 - /1]
+
+index-constraints vars=(int, int) index=(@1, @2)
+@1 >= 1 AND @1 <= 5 AND @2 != 2
+----
+(/1/NULL - /5]
+
+# Remaining filter: @2 != 2
+
+
+# Tests with a type that doesn't support Prev.
+index-constraints vars=(string) index=(@1)
+@1 > 'a' AND @1 < 'z'
+----
+[/e'a\x00' - /'z')
+
+index-constraints vars=(string, int) index=(@1, @2)
+@1 > 'a' AND @1 < 'z' AND @2 = 5
+----
+[/e'a\x00'/5 - /'z')
+
+# Remaining filter: @2 = 5
+
+
+index-constraints vars=(string) index=(@1 desc)
+@1 > 'a' AND @1 < 'z'
+----
+(/'z' - /e'a\x00']
+
+index-constraints vars=(string, int) index=(@1 desc, @2)
+@1 > 'a' AND @1 < 'z' AND @2 = 5
+----
+(/'z' - /e'a\x00'/5]
+
+# Remaining filter: @2 = 5
+
+
+# Tests with a type that doesn't support Next or Prev.
+index-constraints vars=(decimal) index=(@1)
+@1 > 1.5
+----
+(/1.5 - ]
+
+index-constraints vars=(decimal) index=(@1)
+@1 > 1.5 AND @1 < 2
+----
+(/1.5 - /2)
+
+# Tests with a type that supports Next/Prev but we have a maximal/minimal value.
+
+index-constraints vars=(bool) index=(@1)
+@1 > true
+----
+(/true - ]
+
+index-constraints vars=(bool) index=(@1)
+@1 < false
+----
+(/NULL - /false)
+
+# Note the difference here between decimal and int: we
+# can't extend the exclusive start key.
+index-constraints vars=(decimal, decimal) index=(@1, @2)
+@1 > 1.5 AND @2 > 2
+----
+(/1.5 - ]
+
+# Remaining filter: @2 > 2
+
+
+# Tests with variable IN tuple.
+
+index-constraints vars=(int) index=(@1)
+@1 IN (1, 2, 3)
+----
+[/1 - /1]
+[/2 - /2]
+[/3 - /3]
+
+index-constraints vars=(int) index=(@1 desc)
+@1 IN (1, 2, 3)
+----
+[/3 - /3]
+[/2 - /2]
+[/1 - /1]
+
+# semtree-normalize,build-scalar,index-constraints vars=(int) index=(@1)
+#index-constraints vars=(int) index=(@1)
+#@1 IN (1, 5, 1, 4)
+#----
+#[/1 - /1]
+#[/4 - /4]
+#[/5 - /5]
+
+# semtree-normalize,build-scalar,index-constraints vars=(int) index=(@1 desc)
+#index-constraints vars=(int) index=(@1 desc)
+#@1 IN (1, 5, 1, 4)
+#----
+#[/5 - /5]
+#[/4 - /4]
+#[/1 - /1]
+
+index-constraints vars=(int) index=(@1)
+@1 IN (1, 2, 3, NULL)
+----
+[/1 - /1]
+[/2 - /2]
+[/3 - /3]
+
+index-constraints vars=(int, int) index=(@1, @2)
+@1 = 1 AND @2 IN (1, 2, 3)
+----
+[/1/1 - /1/1]
+[/1/2 - /1/2]
+[/1/3 - /1/3]
+
+index-constraints vars=(int, int) index=(@1, @2 desc)
+@1 = 1 AND @2 IN (1, 2, 3)
+----
+[/1/3 - /1/3]
+[/1/2 - /1/2]
+[/1/1 - /1/1]
+
+index-constraints vars=(int, int) index=(@1, @2)
+@1 IN (1, 2) AND @2 IN (1, 2, 3)
+----
+[/1/1 - /1/1]
+[/1/2 - /1/2]
+[/1/3 - /1/3]
+[/2/1 - /2/1]
+[/2/2 - /2/2]
+[/2/3 - /2/3]
+
+# Remaining filter: @2 IN (1, 2, 3)
+
+
+index-constraints vars=(int, int) index=(@1 desc, @2 desc)
+@1 IN (1, 2) AND @2 IN (1, 2, 3)
+----
+[/2/3 - /2/3]
+[/2/2 - /2/2]
+[/2/1 - /2/1]
+[/1/3 - /1/3]
+[/1/2 - /1/2]
+[/1/1 - /1/1]
+
+# Remaining filter: @2 IN (1, 2, 3)
+
+
+index-constraints vars=(int, int) index=(@1, @2)
+@1 >= 2 AND @1 <= 4 AND @2 IN (1, 2, 3)
+----
+[/2/1 - /4/3]
+
+# Remaining filter: @2 IN (1, 2, 3)
+
+
+index-constraints vars=(int, int) index=(@1 desc, @2 desc)
+@1 >= 2 AND @1 <= 4 AND @2 IN (1, 2, 3)
+----
+[/4/3 - /2/1]
+
+# Remaining filter: @2 IN (1, 2, 3)
+
+
+
+index-constraints vars=(int, int) index=(@1, @2)
+@1 IN (1, 2, 3) AND @2 = 4
+----
+[/1/4 - /1/4]
+[/2/4 - /2/4]
+[/3/4 - /3/4]
+
+index-constraints vars=(int, int) index=(@1 desc, @2)
+@1 IN (1, 2, 3) AND @2 = 4
+----
+[/3/4 - /3/4]
+[/2/4 - /2/4]
+[/1/4 - /1/4]
+
+index-constraints vars=(int, int) index=(@1, @2 desc)
+@1 IN (1, 2, 3) AND @2 = 4
+----
+[/1/4 - /1/4]
+[/2/4 - /2/4]
+[/3/4 - /3/4]
+
+index-constraints vars=(int, int) index=(@1, @2)
+@1 IN (1, 2, 3) AND @2 >= 2 AND @2 <= 4
+----
+[/1/2 - /1/4]
+[/2/2 - /2/4]
+[/3/2 - /3/4]
+
+# Tests with tuple equality.
+
+index-constraints vars=(int, int, int) index=(@1, @2, @3)
+(@1, @2, @3) = (1, 2, 3)
+----
+[/1/2/3 - /1/2/3]
+
+index-constraints vars=(int, int, int) index=(@1, @3)
+(@1, @2, @3) = (1, 2, 3)
+----
+[/1/3 - /1/3]
+
+# Remaining filter: @2 = 2
+
+
+index-constraints vars=(int, int, int) index=(@3, @2)
+(@1, @2, @3) = (1, 2, 3)
+----
+[/3/2 - /3/2]
+
+# Remaining filter: @1 = 1
+
+
+index-constraints vars=(int, int, int, int, int) index=(@1, @2, @3, @4, @5)
+(@1, @2, 3, (4, @5)) = (1, 2, @3, (@4, 5))
+----
+[/1/2/3/4/5 - /1/2/3/4/5]
+
+index-constraints vars=(int, int, int, int) index=(@1, @2, @3, @4)
+(@1, @2, @3) = (1, 2, 3) AND @4 > 4
+----
+[/1/2/3/5 - /1/2/3]
+
+index-constraints vars=(int, int, int, int) index=(@1, @2, @3, @4)
+@1 > 5 AND @1 < 10 AND (@2, @3, @4) = (2, 3, 4)
+----
+[/6/2/3/4 - /9/2/3/4]
+
+# Remaining filter: ((@2 = 2) AND (@3 = 3)) AND (@4 = 4)
+
+
+index-constraints \
+  vars=(int, int, int, int) \
+  index=(@1 desc, @2 desc, @3 desc, @4 desc)
+@1 > 5 AND @1 < 10 AND (@2, @3, @4) = (2, 3, 4)
+----
+[/9/2/3/4 - /6/2/3/4]
+
+# Remaining filter: ((@2 = 2) AND (@3 = 3)) AND (@4 = 4)
+
+
+# Tests with tuple inequalities.
+
+index-constraints vars=(int, int, int) index=(@1, @2, @3)
+(@1, @2, @3) >= (1, 2, 3)
+----
+[/1/2/3 - ]
+
+index-constraints vars=(int, int, int) index=(@1, @2, @3)
+(@1, @2, @3) >= (1, 2, @1)
+----
+[/1/2 - ]
+
+# Remaining filter: (@1, @2, @3) >= (1, 2, @1)
+
+
+index-constraints vars=(int, int, int) index=(@1, @2, @3)
+(@1, @2, @3) > (1, 2, 3)
+----
+[/1/2/4 - ]
+
+index-constraints vars=(int, int, int) index=(@1, @2)
+(@1, @2, @3) > (1, 2, 3)
+----
+[/1/2 - ]
+
+# Remaining filter: (@1, @2, @3) > (1, 2, 3)
+
+
+index-constraints vars=(int, int, int) index=(@1, @2)
+(@1, @2, @3) < (1, 2, 3)
+----
+(/NULL - /1/2]
+
+# Remaining filter: (@1, @2, @3) < (1, 2, 3)
+
+
+index-constraints vars=(int, int, int) index=(@1, @2, @3)
+(@1, @2, @3) <= (1, 2, 3)
+----
+(/NULL - /1/2/3]
+
+# Remaining filter: (@1, @2, @3) <= (1, 2, 3)
+
+
+index-constraints vars=(int, int, int) index=(@1, @2, @3)
+(@1, @2, @3) <= (1, 2, @1)
+----
+(/NULL - /1/2]
+
+# Remaining filter: (@1, @2, @3) <= (1, 2, @1)
+
+
+index-constraints vars=(int, int, int) index=(@1, @2, @3)
+(@1, @2, @3) < (1, 2, 3)
+----
+(/NULL - /1/2/2]
+
+# Remaining filter: (@1, @2, @3) < (1, 2, 3)
+
+
+index-constraints vars=(int, int, int) index=(@1, @2, @3)
+(@1, @2, @3) < (1, 2, @1)
+----
+(/NULL - /1/2]
+
+# Remaining filter: (@1, @2, @3) < (1, 2, @1)
+
+
+index-constraints vars=(int, int, int) index=(@1, @2, @3)
+(@1, @2, @3) != (1, 2, 3)
+----
+[ - /1/2/2]
+[/1/2/4 - ]
+
+# Remaining filter: (@1, @2, @3) != (1, 2, 3)
+
+
+index-constraints vars=(int, int, int) index=(@1 desc, @2 desc, @3 desc)
+(@1, @2, @3) != (1, 2, 3)
+----
+[ - /1/2/4]
+[/1/2/2 - ]
+
+# Remaining filter: (@1, @2, @3) != (1, 2, 3)
+
+
+index-constraints vars=(int, int, int) index=(@1 desc, @2, @3)
+(@1, @2, @3) != (1, 2, 3)
+----
+[ - /1/2/2]
+[/1/2/4 - ]
+
+# Remaining filter: (@1, @2, @3) != (1, 2, 3)
+
+
+index-constraints vars=(int, int, int) index=(@1 not null, @2, @3)
+(@1, @2, @3) != (1, 2, 3)
+----
+[ - /1/2/2]
+[/1/2/4 - ]
+
+# Remaining filter: (@1, @2, @3) != (1, 2, 3)
+
+
+index-constraints vars=(int, int, int) index=(@1 not null, @2 not null, @3 not null)
+(@1, @2, @3) != (1, 2, 3)
+----
+[ - /1/2/2]
+[/1/2/4 - ]
+
+index-constraints vars=(int, int, int) index=(@1, @2 not null, @3 not null)
+(@1, @2, @3) != (1, 2, 3)
+----
+[ - /1/2/2]
+[/1/2/4 - ]
+
+# Remaining filter: (@1, @2, @3) != (1, 2, 3)
+
+
+index-constraints vars=(int, int, int) index=(@1, @2, @3)
+(@1, @2, @3) != (1, 2, @1)
+----
+[ - ]
+
+# Remaining filter: (@1, @2, @3) != (1, 2, @1)
+
+
+index-constraints vars=(int, int, int) index=(@1 desc, @2 desc, @3 desc)
+(@1, @2, @3) >= (1, 2, 3)
+----
+[ - /1/2/3]
+
+# Remaining filter: (@1, @2, @3) >= (1, 2, 3)
+
+
+index-constraints vars=(int, int, int) index=(@1 desc, @2 desc, @3)
+(@1, @2, @3) > (1, 2, 3)
+----
+[ - /1/2]
+
+# Remaining filter: (@1, @2, @3) > (1, 2, 3)
+
+
+index-constraints vars=(int, int, int) index=(@1, @2, @3 desc)
+(@1, @2, @3) > (1, 2, 3)
+----
+[/1/2 - ]
+
+# Remaining filter: (@1, @2, @3) > (1, 2, 3)
+
+
+index-constraints vars=(int, int, int) index=(@1, @2, @3 desc)
+(@2, @3) > (1, 2)
+----
+[ - ]
+
+# Remaining filter: (@2, @3) > (1, 2)
+
+
+index-constraints vars=(int, int) index=(@1, @2)
+(@1, @2) >= (1, 2) AND (@1, @2) <= (3, 4)
+----
+[/1/2 - /3/4]
+
+# Remaining filter: (@1, @2) <= (3, 4)
+
+
+# semtree-normalize,build-scalar,index-constraints vars=(int, int) index=(@1, @2)
+#index-constraints vars=(int, int) index=(@1, @2)
+#(@1, @2) BETWEEN (1, 2) AND (3, 4)
+#----
+#[/1/2 - /3/4]
+
+# Remaining filter: (@1, @2) <= (3, 4)
+
+
+# semtree-normalize,build-scalar,index-constraints vars=(int, int, int, int) index=(@1, @2, @3, @4)
+#index-constraints vars=(int, int, int, int) index=(@1, @2, @3, @4)
+#(@1, @2, @4) BETWEEN (1, 2, 3) AND (4, 5, 6)
+#----
+#[/1/2 - /4/5]
+
+# Remaining filter: ((@1, @2, @4) >= (1, 2, 3)) AND ((@1, @2, @4) <= (4, 5, 6))
+
+
+index-constraints vars=(int, bool) index=(@1, @2)
+(@1, @2) > (1, true)
+----
+(/1/true - ]
+
+index-constraints vars=(int, bool) index=(@1, @2)
+(@1, @2) < (1, false)
+----
+(/NULL - /1/false)
+
+# Remaining filter: (@1, @2) < (1, false)
+
+
+index-constraints vars=(int, int, int) index=(@1 not null, @2 not null, @3 not null)
+(@1, @2, @3) <= (1, 2, 3)
+----
+[ - /1/2/3]
+
+index-constraints vars=(int, int, int) index=(@1 not null, @2 not null, @3 not null)
+(@1, @2, @3) >= (1, 2, 3)
+----
+[/1/2/3 - ]
+
+index-constraints vars=(int, int, int) index=(@1 not null, @2 not null, @3 not null)
+(@1, @2, @3) < (1, 2, 3)
+----
+[ - /1/2/2]
+
+index-constraints vars=(int, int, int) index=(@1 not null, @2 not null, @3 not null)
+(@1, @2, @3) > (1, 2, 3)
+----
+[/1/2/4 - ]
+
+index-constraints vars=(int, int, int) index=(@1, @2 not null, @3 not null)
+(@1, @2, @3) <= (1, 2, 3)
+----
+(/NULL - /1/2/3]
+
+index-constraints vars=(int, int, int) index=(@1, @2 not null, @3)
+(@1, @2, @3) <= (1, 2, 3)
+----
+(/NULL - /1/2/3]
+
+# Remaining filter: (@1, @2, @3) <= (1, 2, 3)
+
+
+index-constraints vars=(int, int, int) index=(@1, @2, @3 not null)
+(@1, @2, @3) <= (1, 2, 3)
+----
+(/NULL - /1/2/3]
+
+# Remaining filter: (@1, @2, @3) <= (1, 2, 3)
+
+
+index-constraints \
+  vars=(int, int, int) \
+  index=(@1 desc not null, @2 desc not null, @3 desc not null)
+(@1, @2, @3) > (1, 2, 3)
+----
+[ - /1/2/4]
+
+index-constraints vars=(int, int, int) index=(@1 desc, @2 desc not null, @3 desc)
+(@1, @2, @3) > (1, 2, 3)
+----
+[ - /1/2/4]
+
+# Remaining filter: (@1, @2, @3) > (1, 2, 3)
+
+
+index-constraints vars=(int, int, int) index=(@1 desc, @2 desc, @3 desc not null)
+(@1, @2, @3) > (1, 2, 3)
+----
+[ - /1/2/4]
+
+# Remaining filter: (@1, @2, @3) > (1, 2, 3)
+
+
+index-constraints vars=(int, int, int) index=(@1, @2, @3)
+(@1, @3, @2) != (1, NULL, 2)
+----
+[ - ]
+
+# Remaining filter: (@1, @3, @2) != (1, NULL, 2)
+
+
+index-constraints vars=(int, int, int) index=(@1 not null, @2 not null)
+(@1, @2, @3) > (1, 2, 3)
+----
+[/1/2 - ]
+
+# Remaining filter: (@1, @2, @3) > (1, 2, 3)
+
+
+index-constraints vars=(int, int, int) index=(@1 not null, @2 not null)
+(@1, @2, @3) <= (1, 2, 3)
+----
+[ - /1/2]
+
+# Remaining filter: (@1, @2, @3) <= (1, 2, 3)
+
+
+# Cases with NULLs in tuple inequalities. These conditions are true only when
+# they don't depend on the NULL value, i.e. when the inequality holds true for
+# the prefix up to the first NULL.
+
+index-constraints vars=(int, int) index=(@1, @2)
+(@1, @2) > (1, NULL)
+----
+[/2 - ]
+
+index-constraints vars=(int, int) index=(@1, @2)
+(@1, @2) >= (1, NULL)
+----
+[/2 - ]
+
+index-constraints vars=(int, int) index=(@1, @2)
+(@1, @2) < (1, NULL)
+----
+(/NULL - /0]
+
+index-constraints vars=(int, int) index=(@1 not null, @2)
+(@1, @2) < (1, NULL)
+----
+[ - /0]
+
+index-constraints vars=(int, int) index=(@1, @2)
+(@1, @2) <= (1, NULL)
+----
+(/NULL - /0]
+
+index-constraints vars=(int, int, int) index=(@1, @2, @3)
+(@1, @2, @3) < (1, NULL, 1)
+----
+(/NULL - /0]
+
+index-constraints vars=(int, int, int) index=(@1, @2, @3)
+(@1, @2, @3) >= (1, NULL, 1)
+----
+[/2 - ]
+
+# TODO(radu): here we could be smarter - the condition below is equivalent to
+# (@1, @3) != (1, 3).
+index-constraints vars=(int, int, int) index=(@1, @2, @3)
+(@1, @2, @3) != (1, NULL, 3)
+----
+[ - ]
+
+# Remaining filter: (@1, @2, @3) != (1, NULL, 3)
+
+
+# Tests with tuple IN tuple.
+
+index-constraints vars=(int, int, int) index=(@1, @2, @3)
+(@1, @2, @3) IN ((1, 2, 3), (4, 5, 6))
+----
+[/1/2/3 - /1/2/3]
+[/4/5/6 - /4/5/6]
+
+index-constraints vars=(int, int, int) index=(@1, @2, @3)
+(@1, @2, @3) IN ((4, 5, 6), (1, 2, 3))
+----
+[/1/2/3 - /1/2/3]
+[/4/5/6 - /4/5/6]
+
+index-constraints vars=(int, int, int) index=(@1, @2, @3)
+(@1, @2, @3) IN ((1, 2, 3), (1, 2, 3))
+----
+[/1/2/3 - /1/2/3]
+
+index-constraints vars=(int, int, int) index=(@1, @2, @3)
+(@1, @2, @3) IN ((1, 2, 3), (4, 5, 6), (1, 2, 3))
+----
+[/1/2/3 - /1/2/3]
+[/4/5/6 - /4/5/6]
+
+index-constraints vars=(int, int, int) index=(@1, @2, @3)
+(@1+5, @1, @1+@2, @2) IN ((1, 5, 1, 6), (2, 7, 2, 8), (3, 9, 3, 10))
+----
+[/5/6 - /5/6]
+[/7/8 - /7/8]
+[/9/10 - /9/10]
+
+# Remaining filter: (@1 + 5, @1, @1 + @2, @2) IN ((1, 5, 1, 6), (2, 7, 2, 8), (3, 9, 3, 10))
+
+
+# Test that we properly handle NULLs inside IN tuples.
+index-constraints vars=(int, int) index=(@1, @2)
+(@1, @2) IN ((1, 2), (3, NULL))
+----
+[/1/2 - /1/2]
+
+index-constraints vars=(int, int) index=(@1, @2)
+(@1, @2) IN ((3, NULL))
+----
+
+index-constraints vars=(int, int) index=(@1, @2)
+(@1, @2) IN ((1, 2), (NULL, 4))
+----
+[/1/2 - /1/2]
+
+index-constraints vars=(int, int, int) index=(@1, @2, @3)
+(@1, @2, @3) IN ((1, 2, 3), (4, 5, 6), (NULL, 8, 9))
+----
+[/1/2/3 - /1/2/3]
+[/4/5/6 - /4/5/6]
+
+# Verify that we sort and de-duplicate if we "project" the tuples;
+# in this case the expression becomes:
+#   (@1, @2) IN ((5, 5), (4, 4), (5, 5))
+index-constraints vars=(int, int, int, int) index=(@2, @4)
+(@1, @2, @3, @4) IN ((1, 5, 1, 5), (2, 4, 2, 4), (3, 5, 3, 5))
+----
+[/4/4 - /4/4]
+[/5/5 - /5/5]
+
+# Remaining filter: (@1, @2, @3, @4) IN ((1, 5, 1, 5), (2, 4, 2, 4), (3, 5, 3, 5))
+
+
+index-constraints vars=(int, int, int, int) index=(@2)
+(@1, @2, @3, @4) IN ((1, 5, 1, 5), (2, 4, 2, 4), (3, 5, 3, 5))
+----
+[/4 - /4]
+[/5 - /5]
+
+# Remaining filter: (@1, @2, @3, @4) IN ((1, 5, 1, 5), (2, 4, 2, 4), (3, 5, 3, 5))
+
+
+index-constraints vars=(int, int) index=(@1, @2)
+(@2, @1) IN ((1, 5), (2, 1), (3, 4), (4, 1))
+----
+[/1/2 - /1/2]
+[/1/4 - /1/4]
+[/4/3 - /4/3]
+[/5/1 - /5/1]
+
+index-constraints vars=(int, int) index=(@1 desc, @2)
+(@2, @1) IN ((1, 5), (2, 1), (3, 4), (4, 1))
+----
+[/5/1 - /5/1]
+[/4/3 - /4/3]
+[/1/2 - /1/2]
+[/1/4 - /1/4]
+
+index-constraints vars=(int, int) index=(@1, @2 desc)
+(@2, @1) IN ((1, 5), (2, 1), (3, 4), (4, 1))
+----
+[/1/4 - /1/4]
+[/1/2 - /1/2]
+[/4/3 - /4/3]
+[/5/1 - /5/1]
+
+index-constraints vars=(int, int) index=(@1 desc, @2 desc)
+(@2, @1) IN ((1, 5), (2, 1), (3, 4), (4, 1))
+----
+[/5/1 - /5/1]
+[/4/3 - /4/3]
+[/1/4 - /1/4]
+[/1/2 - /1/2]
+
+index-constraints vars=(int, int, int) index=(@1, @2, @3)
+@1 = 1 AND (@2, @3) IN ((2, 3), (4, 5), (6, 7))
+----
+[/1/2/3 - /1/2/3]
+[/1/4/5 - /1/4/5]
+[/1/6/7 - /1/6/7]
+
+index-constraints vars=(int, int, int) index=(@1, @2, @3)
+@3 = 1 AND (@1, @2) IN ((2, 3), (4, 5), (6, 7))
+----
+[/2/3/1 - /2/3/1]
+[/4/5/1 - /4/5/1]
+[/6/7/1 - /6/7/1]
+
+# Here the best we can do is to effectively break up the IN constraint into
+# constraints on @1 and on @3, which results in more spans than we need.
+index-constraints vars=(int, int, int) index=(@1, @2, @3)
+@2 = 1 AND (@1, @3) IN ((2, 3), (4, 5), (6, 7))
+----
+[/2/1/3 - /2/1/3]
+[/2/1/5 - /2/1/5]
+[/2/1/7 - /2/1/7]
+[/4/1/3 - /4/1/3]
+[/4/1/5 - /4/1/5]
+[/4/1/7 - /4/1/7]
+[/6/1/3 - /6/1/3]
+[/6/1/5 - /6/1/5]
+[/6/1/7 - /6/1/7]
+
+# Remaining filter: (@1, @3) IN ((2, 3), (4, 5), (6, 7))
+
+
+index-constraints vars=(int, int, int) index=(@1, @2, @3)
+@1 > 1 AND (@2, @3) IN ((2, 3), (4, 5), (6, 7))
+----
+[/2/2/3 - ]
+
+# Remaining filter: (@2, @3) IN ((2, 3), (4, 5), (6, 7))
+
+
+index-constraints vars=(int) index=(@1)
+@1 IS NULL
+----
+[/NULL - /NULL]
+
+index-constraints vars=(int, int) index=(@1, @2)
+@1 IS NULL AND @2 = 2
+----
+[/NULL/2 - /NULL/2]
+
+index-constraints vars=(int, int) index=(@1, @2)
+@1 IS NULL AND @2 > 2
+----
+[/NULL/3 - /NULL]
+
+index-constraints vars=(int, int) index=(@1, @2)
+@1 = 1 AND @2 IS NULL
+----
+[/1/NULL - /1/NULL]
+
+index-constraints vars=(int, int) index=(@1, @2)
+@1 >= 1 AND @2 IS NULL
+----
+[/1/NULL - ]
+
+# Remaining filter: @2 IS NULL
+
+
+index-constraints vars=(int) index=(@1)
+@1 IS NOT DISTINCT FROM NULL
+----
+[/NULL - /NULL]
+
+index-constraints vars=(int) index=(@1)
+@1 IS NOT NULL
+----
+(/NULL - ]
+
+index-constraints vars=(int) index=(@1)
+@1 IS DISTINCT FROM NULL
+----
+(/NULL - ]
+
+index-constraints vars=(int) index=(@1 desc)
+@1 IS NOT NULL
+----
+[ - /NULL)
+
+index-constraints vars=(int) index=(@1 not null)
+@1 IS NULL
+----
+
+index-constraints vars=(int) index=(@1 not null)
+@1 IS NOT DISTINCT FROM NULL
+----
+
+index-constraints vars=(int) index=(@1 not null)
+@1 IS NOT NULL
+----
+[ - ]
+
+index-constraints vars=(int) index=(@1 not null)
+@1 IS DISTINCT FROM NULL
+----
+[ - ]
+
+index-constraints vars=(int) index=(@1 desc not null)
+@1 IS NOT NULL
+----
+[ - ]
+
+index-constraints vars=(int) index=(@1 not null)
+@1 IS NOT DISTINCT FROM 1
+----
+[/1 - /1]
+
+index-constraints vars=(int, int) index=(@1, @2)
+@2 = @1
+----
+(/NULL - ]
+
+# Remaining filter: @2 = @1
+
+
+index-constraints vars=(int, int) index=(@1, @2)
+@2 < @1
+----
+(/NULL - ]
+
+# Remaining filter: @2 < @1
+
+
+index-constraints vars=(int, int) index=(@1 not null, @2)
+@1 = @2
+----
+[ - ]
+
+# Remaining filter: @1 = @2
+
+
+# Tests with top-level OR.
+# TODO(radu): expression simplification is limited when dealing with ORs; some
+# of the remaining filters below are not necessary (or could be simplified
+# further).
+
+index-constraints vars=(int) index=(@1)
+@1 = 1 OR @1 = 2
+----
+[/1 - /1]
+[/2 - /2]
+
+index-constraints vars=(int) index=(@1)
+@1 IS NULL OR @1 = 1
+----
+[/NULL - /NULL]
+[/1 - /1]
+
+index-constraints vars=(int) index=(@1)
+(@1 >= 1 AND @1 <= 5) OR (@1 >= 2 AND @1 <= 8)
+----
+[/1 - /8]
+
+# Remaining filter: (@1 <= 5) OR (@1 >= 2)
+
+
+index-constraints vars=(int) index=(@1)
+(@1 >= 1 AND @1 <= 3) OR (@1 >= 5 AND @1 <= 8)
+----
+[/1 - /3]
+[/5 - /8]
+
+# Remaining filter: (@1 <= 3) OR (@1 >= 5)
+
+
+index-constraints vars=(int, int) index=(@1)
+(@1 = 1 AND @2 = 5) OR (@1 = 2 and @2 = 6)
+----
+[/1 - /1]
+[/2 - /2]
+
+# Remaining filter: ((@1 = 1) AND (@2 = 5)) OR ((@1 = 2) AND (@2 = 6))
+
+
+index-constraints vars=(int, int) index=(@2)
+(@1 = 1 AND @2 = 5) OR (@1 = 2 and @2 = 6)
+----
+[/5 - /5]
+[/6 - /6]
+
+# Remaining filter: ((@1 = 1) AND (@2 = 5)) OR ((@1 = 2) AND (@2 = 6))
+
+
+index-constraints vars=(int, int) index=(@2)
+@1 = 1 OR @2 = 2
+----
+[ - ]
+
+# Remaining filter: (@1 = 1) OR (@2 = 2)
+
+
+index-constraints vars=(int, int, int) index=(@1, @2, @3)
+@1 = 1 OR (@1, @2, @3) IN ((4, 5, 6), (7, 8, 9))
+----
+[/1 - /1]
+[/4/5/6 - /4/5/6]
+[/7/8/9 - /7/8/9]
+
+index-constraints vars=(int, int, int) index=(@1, @2, @3)
+@1 = 1 OR (@1 = 2 AND (@2, @3) IN ((4, 5), (6, 7))) OR (@1 = 3)
+----
+[/1 - /1]
+[/2/4/5 - /2/4/5]
+[/2/6/7 - /2/6/7]
+[/3 - /3]
+
+# Remaining filter: ((@1 = 1) OR ((@1 = 2) AND ((@2, @3) IN ((4, 5), (6, 7))))) OR (@1 = 3)
+
+
+# Tests with inner OR.
+
+index-constraints vars=(int, int) index=(@1, @2)
+@1 = 1 AND (@2 = 2 OR @2 = 3)
+----
+[/1/2 - /1/2]
+[/1/3 - /1/3]
+
+# Remaining filter: (@2 = 2) OR (@2 = 3)
+
+
+index-constraints vars=(int, int, int) index=(@1, @2, @3)
+@1 = 1 AND (@2 = 2 OR (@2 = 3 AND @3 = 4))
+----
+[/1/2 - /1/2]
+[/1/3/4 - /1/3/4]
+
+# Remaining filter: (@2 = 2) OR ((@2 = 3) AND (@3 = 4))
+
+
+index-constraints vars=(int, int) index=(@1, @2)
+@1 >= 1 AND (@2 = 2 OR @2 = 3)
+----
+[/1/2 - ]
+
+# Remaining filter: (@2 = 2) OR (@2 = 3)
+
+
+index-constraints vars=(int, int, int) index=(@1, @2, @3)
+@1 = 1 AND (@2 = 2 OR @2 = 3) AND (@3 >= 4)
+----
+[/1/2/4 - /1/2]
+[/1/3/4 - /1/3]
+
+# Remaining filter: (@2 = 2) OR (@2 = 3)
+
+
+# TODO(radu): unsupported CASE
+#index-constraints vars=(int, int, int) index=(@1, @2, @3)
+#@1 = 1 AND @2 = CASE WHEN @3 = 2 THEN 1 ELSE 2 END
+#----
+#(/1/NULL - /1]
+
+# Remaining filter: @2 = CASE WHEN @3 = 2 THEN 1 ELSE 2 END
+
+
+# This testcase exposed an issue around extending spans. We don't normalize the
+# expression so we have a hierarchy of ANDs (which requires a more complex path
+# for calculating spans).
+# TODO(radu): disable normalization
+index-constraints vars=(int, int, int, int) index=(@1, @2, @3, @4)
+@1 = 1 AND @2 = 2 AND @3 = 3 AND @4 IN (4,5,6)
+----
+[/1/2/3/4 - /1/2/3/4]
+[/1/2/3/5 - /1/2/3/5]
+[/1/2/3/6 - /1/2/3/6]
+
+index-constraints vars=(int, int) index=(@1, @2)
+(@1 = 1) AND (@2 > 5) AND (@2 < 1)
+----
+
+# Verify that we ignore mixed-type comparisons (they would result in incorrect
+# encodings, see #4313). We don't have testcases for IN because those error
+# out early (during type-checking).
+index-constraints vars=(int) index=(@1)
+@1 = 1.5
+----
+(/NULL - ]
+
+# Remaining filter: @1 = 1.5
+
+
+index-constraints vars=(int) index=(@1)
+@1 > 1.5
+----
+(/NULL - ]
+
+# Remaining filter: @1 > 1.5
+
+
+index-constraints vars=(int, int) index=(@1, @2)
+(@1, @2) = (1, 2.5)
+----
+(/1/NULL - /1]
+
+# Remaining filter: @2 = 2.5
+
+
+index-constraints vars=(int, int) index=(@1, @2)
+(@1, @2) >= (1, 2.5)
+----
+[/1 - ]
+
+# Remaining filter: (@1, @2) >= (1, 2.5)
+
+
+# Verify that we ignore spans that become invalid after extension.
+index-constraints vars=(int, int) index=(@1, @2)
+@1 >= 1 AND (@1, @2) < (1, 2) AND @2 = 5
+----
+
+index-constraints vars=(int, int) index=(@1, @2)
+(@1 >= 1 AND (@1, @2) < (1, 2) OR @1 > 3) AND @2 = 5
+----
+[/4/5 - ]
+
+# Remaining filter: @2 = 5
+
+
+# Regression test for #3472.
+index-constraints vars=(int, int) index=(@1, @2)
+(@1,@2) IN ((1, 2)) AND @1 = 1
+----
+[/1/2 - /1/2]
+
+index-constraints vars=(jsonb) inverted-index=@1
+@1 @> '{"a": 1}'
+----
+[/'{"a": 1}' - /'{"a": 1}']
+
+index-constraints vars=(jsonb) inverted-index=@1
+'{"a": 1}' <@ @1
+----
+[/'{"a": 1}' - /'{"a": 1}']
+
+# Currently we only generate spans from one of the @> expressions.
+index-constraints vars=(jsonb) inverted-index=@1
+@1 @> '{"a": 1}' AND @1 @> '{"b": 1}'
+----
+[/'{"a": 1}' - /'{"a": 1}']
+
+# Remaining filter: @1 @> '{"b": 1}'
+
+
+index-constraints vars=(jsonb) inverted-index=@1
+'{"a": 1}' <@ @1 AND '{"b": 1}' <@ @1
+----
+[/'{"a": 1}' - /'{"a": 1}']
+
+# Remaining filter: @1 @> '{"b": 1}'
+
+
+index-constraints vars=(jsonb, int) inverted-index=@1
+@2 = 1 AND @1 @> '{"a": 1}' AND @1 @> '{"b": 1}'
+----
+[/'{"a": 1}' - /'{"a": 1}']
+
+# Remaining filter: (@2 = 1) AND (@1 @> '{"b": 1}')
+
+
+index-constraints vars=(string) index=@1
+@1 LIKE 'ABC%'
+----
+[/'ABC' - /'ABD')
+
+index-constraints vars=(string) index=@1
+@1 LIKE 'ABC_'
+----
+[/'ABC' - /'ABD')
+
+# Remaining filter: @1 LIKE 'ABC_'
+
+
+index-constraints vars=(string) index=@1
+@1 LIKE 'ABC%Z'
+----
+[/'ABC' - /'ABD')
+
+# Remaining filter: @1 LIKE 'ABC%Z'
+
+
+index-constraints vars=(string) index=@1
+@1 LIKE 'ABC'
+----
+[/'ABC' - /'ABC']
+
+index-constraints vars=(string) index=@1
+@1 LIKE '%'
+----
+(/NULL - ]
+
+# Remaining filter: @1 LIKE '%'
+
+
+index-constraints vars=(string) index=@1
+@1 LIKE '%XY'
+----
+(/NULL - ]
+
+# Remaining filter: @1 LIKE '%XY'
+
+
+index-constraints vars=(string) index=(@1 desc)
+@1 LIKE 'ABC%'
+----
+(/'ABD' - /'ABC']
+
+index-constraints vars=(int,string) index=(@1, @2 desc)
+@1 = 1 AND @2 LIKE 'ABC%'
+----
+(/1/'ABD' - /1/'ABC']
+
+index-constraints vars=(int,string) index=(@1, @2 desc)
+@1 >= 1 AND @1 <= 4 AND @2 LIKE 'ABC%'
+----
+(/1/'ABD' - /4/'ABC']
+
+# Remaining filter: @2 LIKE 'ABC%'
+
+
+index-constraints vars=(string) index=(@1)
+@1 SIMILAR TO 'ABC.*'
+----
+[/'ABC' - /'ABD')
+
+# Remaining filter: @1 SIMILAR TO 'ABC.*'
+
+
+index-constraints vars=(string) index=(@1)
+@1 SIMILAR TO 'ABC.*Z'
+----
+[/'ABC' - /'ABD')
+
+# Remaining filter: @1 SIMILAR TO 'ABC.*Z'
+
+
+index-constraints vars=(string) index=(@1)
+@1 SIMILAR TO 'ABC'
+----
+[/'ABC' - /'ABC']
+
+index-constraints vars=(string) index=(@1)
+@1 SIMILAR TO '(ABC|ABCDEF)%'
+----
+[/'ABC' - /'ABD')
+
+# Remaining filter: @1 SIMILAR TO '(ABC|ABCDEF)%'

--- a/pkg/sql/opt/index_constraints.go
+++ b/pkg/sql/opt/index_constraints.go
@@ -1077,18 +1077,6 @@ func (c *indexConstraintCtx) simplifyFilter(filter *Expr, spans LogicalSpans) *E
 	return remainingFilter
 }
 
-// IndexColumnInfo encompasses the information for index columns, needed for
-// index constraints.
-type IndexColumnInfo struct {
-	// VarIdx identifies the indexed var that corresponds to this column.
-	VarIdx    int
-	Typ       types.T
-	Direction encoding.Direction
-	// Nullable should be set to false if this column cannot store NULLs; used
-	// to keep the spans simple, e.g. [ - /5] instead of (/NULL - /5].
-	Nullable bool
-}
-
 // IndexConstraints is used to generate index constraints from a scalar boolean
 // filter expression.
 //
@@ -1154,4 +1142,10 @@ func (ic *IndexConstraints) RemainingFilter(ivh *tree.IndexedVarHelper) tree.Typ
 	}
 	c := typedExprConvCtx{ivh: ivh}
 	return scalarToTypedExpr(&c, res)
+}
+
+// isIndexColumn returns true if e is an indexed var that corresponds
+// to index column <offset>.
+func (c *indexConstraintCtx) isIndexColumn(e *Expr, index int) bool {
+	return isIndexedVar(e, c.colInfos[index].VarIdx)
 }

--- a/pkg/sql/opt/index_constraints_spans.go
+++ b/pkg/sql/opt/index_constraints_spans.go
@@ -162,6 +162,8 @@ func ExactPrefix(spans LogicalSpans, evalCtx *tree.EvalContext) int {
 	}
 }
 
+var _ = ExactPrefix
+
 // IndexColumnInfo encompasses the information for index columns, needed for
 // index constraints.
 type IndexColumnInfo struct {

--- a/pkg/sql/opt/xform/match.go
+++ b/pkg/sql/opt/xform/match.go
@@ -1,0 +1,44 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package xform
+
+// This file contains various helper functions that can be used to
+// check properties of an ExprView.
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/opt"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+)
+
+// MatchesTupleOfConstants returns true if the expression is a TupleOp with
+// ConstValue children.
+func MatchesTupleOfConstants(ev ExprView) bool {
+	if ev.Operator() != opt.TupleOp {
+		return false
+	}
+	for i := 0; i < ev.ChildCount(); i++ {
+		child := ev.Child(i)
+		if !child.IsConstValue() {
+			return false
+		}
+	}
+	return true
+}
+
+// MatchesConstNull returns true if ev is a ConstOp with NULL value.
+// TODO(radu): perhaps add a NullOp instead.
+func MatchesConstNull(ev ExprView) bool {
+	return ev.Operator() == opt.ConstOp && ev.Private() == tree.DNull
+}


### PR DESCRIPTION
This is the first batch of commits for porting the index constraints code. I broke it up into commits so it's easier to see the diffs - the main changes are in r3->r4 and r4->r5

#### opt: minor cleanup to index constraints code

Moving isIndexedVar out of index_constraint_spans, and moving
in IndexColumnInfo.

Release note: None

#### opt: copy index_constraints_spans code to idxconstraints

This is the first in a series of commits that attempt to port the
index constraints code to a new package that uses the new optimizer
structures (ExprView).

Release note: None

#### opt: copy index_constraints code

Copying the index constraints code; this does not build yet.

Release note: None

#### opt: refactor index constraints code

Refactor the code to use the new opt structures.

The code for computing a remaining filter is not refactored; instead
it is commented out for now.

Release note: None

#### opt: port the index constraints tests

Refactoring (part of) opt_test to an idxconstraints test.

The test file has the Remaining filter results commented out as well
as some test cases that we don't yet support.

Release note: None
