### PR TITLE
roachtest: install license for enterprise tests

### DIFF
--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -469,6 +469,16 @@ func (c *cluster) RunL(ctx context.Context, l *logger, node int, args ...string)
 	}
 }
 
+func (c *cluster) InitEnterprise(ctx context.Context) {
+	licenseKey := os.Getenv("COCKROACH_DEV_LICENSE")
+	if licenseKey == "" {
+		c.t.Fatal("COCKROACH_DEV_LICENSE must be set to run enterprise tests")
+	}
+	sql := "SET CLUSTER SETTING cluster.organization = 'Cockroach Labs - Production Testing';"
+	sql += fmt.Sprintf("SET CLUSTER SETTING enterprise.license = '%s';", licenseKey)
+	c.Run(ctx, 1, fmt.Sprintf("./cockroach sql --insecure -e %q", sql))
+}
+
 func (c *cluster) makeNodes(opts []option) string {
 	var r nodeListOption
 	for _, o := range opts {

--- a/pkg/cmd/roachtest/roachmart.go
+++ b/pkg/cmd/roachtest/roachmart.go
@@ -29,6 +29,7 @@ func init() {
 		c.Put(ctx, cockroach, "./cockroach")
 		c.Put(ctx, workload, "./workload")
 		c.Start(ctx)
+		c.InitEnterprise(ctx)
 
 		// TODO(benesch): avoid hardcoding this list.
 		nodes := []struct {


### PR DESCRIPTION
Partitioning recently learned to require an enterprise license, so the
roachmart tests need to install such a license.

Release note: None