### PR TITLE
sql/distsqlrun: drain the source if the dest requests draining

### DIFF
--- a/pkg/sql/distsqlrun/base.go
+++ b/pkg/sql/distsqlrun/base.go
@@ -150,20 +150,18 @@ func Run(ctx context.Context, src RowSource, dst RowReceiver) {
 			case NeedMoreRows:
 				continue
 			case DrainRequested:
-				row = nil
+				DrainAndForwardMetadata(ctx, src, dst)
+				dst.ProducerDone()
+				return
 			case ConsumerClosed:
 				src.ConsumerClosed()
 				dst.ProducerDone()
 				return
 			}
 		}
-		if row == nil {
-			if meta != nil {
-				DrainAndForwardMetadata(ctx, src, dst)
-			}
-			dst.ProducerDone()
-			return
-		}
+		// row == nil && meta == nil: the source has been fully drained.
+		dst.ProducerDone()
+		return
 	}
 }
 


### PR DESCRIPTION
Fix a bug in `Run` where the source was not drainined and closed if the
producer requested draining.

Closes #22824
Fixes #22655
Fixes #22654
Fixes #22642

Release note: None