### PR TITLE
opt: Infer type for Function operator.

### DIFF
--- a/pkg/sql/opt/ops/scalar.opt
+++ b/pkg/sql/opt/ops/scalar.opt
@@ -353,6 +353,6 @@ define UnaryComplement {
 
 [Scalar]
 define Function {
+    Name Expr
     Args ExprList
-    Def  FuncDef
 }

--- a/pkg/sql/opt/opt/factory.og.go
+++ b/pkg/sql/opt/opt/factory.og.go
@@ -222,7 +222,7 @@ type Factory interface {
 	ConstructUnaryComplement(input GroupID) GroupID
 
 	// ConstructFunction constructs an expression for the Function operator.
-	ConstructFunction(args ListID, def PrivateID) GroupID
+	ConstructFunction(name GroupID, args ListID) GroupID
 
 	// ------------------------------------------------------------
 	// Relational Operators

--- a/pkg/sql/opt/optbuilder/builder.go
+++ b/pkg/sql/opt/optbuilder/builder.go
@@ -461,7 +461,7 @@ func (b *Builder) buildFunction(
 		argList = append(argList, arg)
 	}
 
-	out = b.factory.ConstructFunction(b.factory.InternList(argList), b.factory.InternPrivate(def))
+	out = b.factory.ConstructFunction(b.constructString(def.Name), b.factory.InternList(argList))
 
 	if isAgg {
 		refScope := inScope.endAggFunc()
@@ -1125,6 +1125,12 @@ func (b *Builder) constructList(
 	}
 
 	panic(fmt.Sprintf("unexpected operator: %s", op))
+}
+
+// constructString invokes the factory to create a string-valued Const
+// operator.
+func (b *Builder) constructString(s string) opt.GroupID {
+	return b.factory.ConstructConst(b.factory.InternPrivate(tree.NewDString(s)))
 }
 
 func (b *Builder) buildDistinct(

--- a/pkg/sql/opt/optbuilder/testdata/aggregate
+++ b/pkg/sql/opt/optbuilder/testdata/aggregate
@@ -24,27 +24,38 @@ group-by
  │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
  ├── groupings
  └── aggregations
-      ├── function: min [type=NULL]
+      ├── function [type=int]
+      │    ├── const: 'min' [type=string]
       │    └── const: 1 [type=int]
-      ├── function: max [type=NULL]
+      ├── function [type=int]
+      │    ├── const: 'max' [type=string]
       │    └── const: 1 [type=int]
-      ├── function: count [type=NULL]
+      ├── function [type=int]
+      │    ├── const: 'count' [type=string]
       │    └── const: 1 [type=int]
-      ├── function: sum_int [type=NULL]
+      ├── function [type=int]
+      │    ├── const: 'sum_int' [type=string]
       │    └── const: 1 [type=int]
-      ├── function: avg [type=NULL]
+      ├── function [type=decimal]
+      │    ├── const: 'avg' [type=string]
       │    └── const: 1 [type=int]
-      ├── function: sum [type=NULL]
+      ├── function [type=decimal]
+      │    ├── const: 'sum' [type=string]
       │    └── const: 1 [type=int]
-      ├── function: stddev [type=NULL]
+      ├── function [type=decimal]
+      │    ├── const: 'stddev' [type=string]
       │    └── const: 1 [type=int]
-      ├── function: variance [type=NULL]
+      ├── function [type=decimal]
+      │    ├── const: 'variance' [type=string]
       │    └── const: 1 [type=int]
-      ├── function: bool_and [type=NULL]
+      ├── function [type=bool]
+      │    ├── const: 'bool_and' [type=string]
       │    └── true [type=bool]
-      ├── function: bool_and [type=NULL]
+      ├── function [type=bool]
+      │    ├── const: 'bool_and' [type=string]
       │    └── false [type=bool]
-      └── function: xor_agg [type=NULL]
+      └── function [type=bytes]
+           ├── const: 'xor_agg' [type=string]
            └── const: '\x01' [type=bytes]
 
 build
@@ -56,7 +67,8 @@ group-by
  │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
  ├── groupings
  └── aggregations
-      └── function: array_agg [type=NULL]
+      └── function [type=int[]]
+           ├── const: 'array_agg' [type=string]
            └── const: 1 [type=int]
 
 build
@@ -68,7 +80,8 @@ group-by
  │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
  ├── groupings
  └── aggregations
-      └── function: json_agg [type=NULL]
+      └── function [type=jsonb]
+           ├── const: 'json_agg' [type=string]
            └── variable: kv.v [type=int]
 
 build
@@ -80,7 +93,8 @@ group-by
  │    └── tuple [type=tuple{}]
  ├── groupings
  └── aggregations
-      └── function: jsonb_agg [type=NULL]
+      └── function [type=jsonb]
+           ├── const: 'jsonb_agg' [type=string]
            └── const: 1 [type=int]
 
 # Even with no aggregate functions, grouping occurs in the presence of GROUP BY.
@@ -121,7 +135,8 @@ project
  │    ├── groupings
  │    │    └── variable: kv.k [type=int]
  │    └── aggregations
- │         └── function: count_rows [type=NULL]
+ │         └── function [type=int]
+ │              └── const: 'count_rows' [type=string]
  └── projections
       ├── variable: column5 [type=int]
       └── variable: kv.k [type=int]
@@ -139,7 +154,8 @@ project
  │    ├── groupings
  │    │    └── variable: kv.k [type=int]
  │    └── aggregations
- │         └── function: count_rows [type=NULL]
+ │         └── function [type=int]
+ │              └── const: 'count_rows' [type=string]
  └── projections
       ├── variable: column5 [type=int]
       └── variable: kv.k [type=int]
@@ -172,7 +188,8 @@ project
  │    ├── groupings
  │    │    └── variable: kv.s [type=string]
  │    └── aggregations
- │         └── function: count_rows [type=NULL]
+ │         └── function [type=int]
+ │              └── const: 'count_rows' [type=string]
  └── projections
       ├── variable: column5 [type=int]
       └── variable: kv.s [type=string]
@@ -189,7 +206,8 @@ project
  │    ├── groupings
  │    │    └── variable: kv.s [type=string]
  │    └── aggregations
- │         └── function: count_rows [type=NULL]
+ │         └── function [type=int]
+ │              └── const: 'count_rows' [type=string]
  └── projections
       ├── variable: column5 [type=int]
       └── variable: kv.s [type=string]
@@ -206,7 +224,8 @@ project
  │    ├── groupings
  │    │    └── variable: kv.s [type=string]
  │    └── aggregations
- │         └── function: count_rows [type=NULL]
+ │         └── function [type=int]
+ │              └── const: 'count_rows' [type=string]
  └── projections
       ├── variable: column5 [type=int]
       └── variable: kv.s [type=string]
@@ -223,7 +242,8 @@ project
  │    ├── groupings
  │    │    └── variable: kv.s [type=string]
  │    └── aggregations
- │         └── function: count_rows [type=NULL]
+ │         └── function [type=int]
+ │              └── const: 'count_rows' [type=string]
  └── projections
       ├── variable: column5 [type=int]
       └── variable: kv.s [type=string]
@@ -242,7 +262,8 @@ project
  │    │    ├── variable: kv.v [type=int]
  │    │    └── variable: kv.w [type=int]
  │    └── aggregations
- │         └── function: count_rows [type=NULL]
+ │         └── function [type=int]
+ │              └── const: 'count_rows' [type=string]
  └── projections
       ├── variable: kv.v [type=int]
       ├── variable: column5 [type=int]
@@ -262,7 +283,8 @@ project
  │    │    ├── variable: kv.v [type=int]
  │    │    └── variable: kv.w [type=int]
  │    └── aggregations
- │         └── function: count_rows [type=NULL]
+ │         └── function [type=int]
+ │              └── const: 'count_rows' [type=string]
  └── projections
       ├── variable: kv.v [type=int]
       ├── variable: column5 [type=int]
@@ -279,10 +301,12 @@ project
  │    ├── scan
  │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
  │    ├── groupings
- │    │    └── function: upper [type=NULL]
+ │    │    └── function [type=string]
+ │    │         ├── const: 'upper' [type=string]
  │    │         └── variable: kv.s [type=string]
  │    └── aggregations
- │         └── function: count_rows [type=NULL]
+ │         └── function [type=int]
+ │              └── const: 'count_rows' [type=string]
  └── projections
       ├── variable: column6 [type=int]
       └── variable: column5 [type=string]
@@ -300,7 +324,8 @@ project
  │    ├── groupings
  │    │    └── const: 3 [type=int]
  │    └── aggregations
- │         └── function: count_rows [type=NULL]
+ │         └── function [type=int]
+ │              └── const: 'count_rows' [type=string]
  └── projections
       └── variable: column6 [type=int]
 
@@ -314,10 +339,12 @@ project
  │    ├── scan
  │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
  │    ├── groupings
- │    │    └── function: length [type=NULL]
+ │    │    └── function [type=int]
+ │    │         ├── const: 'length' [type=string]
  │    │         └── const: 'abc' [type=string]
  │    └── aggregations
- │         └── function: count_rows [type=NULL]
+ │         └── function [type=int]
+ │              └── const: 'count_rows' [type=string]
  └── projections
       └── variable: column6 [type=int]
 
@@ -334,10 +361,12 @@ project
  │    ├── groupings
  │    │    └── variable: kv.s [type=string]
  │    └── aggregations
- │         └── function: count_rows [type=NULL]
+ │         └── function [type=int]
+ │              └── const: 'count_rows' [type=string]
  └── projections
       ├── variable: column5 [type=int]
-      └── function: upper [type=NULL]
+      └── function [type=string]
+           ├── const: 'upper' [type=string]
            └── variable: kv.s [type=string]
 
 # Selecting a value that is not grouped, even if a function of it it, does not work.
@@ -361,7 +390,8 @@ project
  │    │         ├── variable: kv.k [type=int]
  │    │         └── variable: kv.v [type=int]
  │    └── aggregations
- │         └── function: count_rows [type=NULL]
+ │         └── function [type=int]
+ │              └── const: 'count_rows' [type=string]
  └── projections
       ├── variable: column6 [type=int]
       └── variable: column5 [type=int]
@@ -381,7 +411,8 @@ project
  │    │    ├── variable: kv.k [type=int]
  │    │    └── variable: kv.v [type=int]
  │    └── aggregations
- │         └── function: count_rows [type=NULL]
+ │         └── function [type=int]
+ │              └── const: 'count_rows' [type=string]
  └── projections
       ├── variable: column5 [type=int]
       └── plus [type=int]
@@ -428,7 +459,8 @@ project
  │    │         ├── variable: kv.v [type=int]
  │    │         └── variable: kv.w [type=int]
  │    └── aggregations
- │         └── function: count [type=NULL]
+ │         └── function [type=int]
+ │              ├── const: 'count' [type=string]
  │              └── variable: kv.k [type=int]
  └── projections
       ├── variable: count_1 [type=int]
@@ -443,7 +475,8 @@ group-by
  │    └── tuple [type=tuple{}]
  ├── groupings
  └── aggregations
-      └── function: count_rows [type=NULL]
+      └── function [type=int]
+           └── const: 'count_rows' [type=string]
 
 build
 SELECT COUNT(k) from t.kv
@@ -454,7 +487,8 @@ group-by
  │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
  ├── groupings
  └── aggregations
-      └── function: count [type=NULL]
+      └── function [type=int]
+           ├── const: 'count' [type=string]
            └── variable: kv.k [type=int]
 
 build
@@ -466,7 +500,8 @@ group-by
  │    └── tuple [type=tuple{}]
  ├── groupings
  └── aggregations
-      └── function: count [type=NULL]
+      └── function [type=int]
+           ├── const: 'count' [type=string]
            └── const: 1 [type=int]
 
 build
@@ -478,7 +513,8 @@ group-by
  │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
  ├── groupings
  └── aggregations
-      └── function: count [type=NULL]
+      └── function [type=int]
+           ├── const: 'count' [type=string]
            └── const: 1 [type=int]
 
 build
@@ -495,10 +531,13 @@ group-by
  │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
  ├── groupings
  └── aggregations
-      ├── function: count_rows [type=NULL]
-      ├── function: count [type=NULL]
+      ├── function [type=int]
+      │    └── const: 'count_rows' [type=string]
+      ├── function [type=int]
+      │    ├── const: 'count' [type=string]
       │    └── variable: kv.k [type=int]
-      └── function: count [type=NULL]
+      └── function [type=int]
+           ├── const: 'count' [type=string]
            └── variable: kv.v [type=int]
 
 # TODO(rytaft): This should work once we add support for the AllColumnSelector.
@@ -516,7 +555,8 @@ group-by
  │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
  ├── groupings
  └── aggregations
-      └── function: count [type=NULL]
+      └── function [type=int]
+           ├── const: 'count' [type=string]
            └── tuple [type=tuple{int, int}]
                 ├── variable: kv.k [type=int]
                 └── variable: kv.v [type=int]
@@ -532,9 +572,11 @@ project
  │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
  │    ├── groupings
  │    └── aggregations
- │         ├── function: count [type=NULL]
+ │         ├── function [type=int]
+ │         │    ├── const: 'count' [type=string]
  │         │    └── variable: kv.k [type=int]
- │         └── function: count [type=NULL]
+ │         └── function [type=int]
+ │              ├── const: 'count' [type=string]
  │              └── variable: kv.v [type=int]
  └── projections
       └── plus [type=int]
@@ -550,13 +592,17 @@ group-by
  │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
  ├── groupings
  └── aggregations
-      ├── function: min [type=NULL]
+      ├── function [type=int]
+      │    ├── const: 'min' [type=string]
       │    └── variable: kv.k [type=int]
-      ├── function: max [type=NULL]
+      ├── function [type=int]
+      │    ├── const: 'max' [type=string]
       │    └── variable: kv.k [type=int]
-      ├── function: min [type=NULL]
+      ├── function [type=int]
+      │    ├── const: 'min' [type=string]
       │    └── variable: kv.v [type=int]
-      └── function: max [type=NULL]
+      └── function [type=int]
+           ├── const: 'max' [type=string]
            └── variable: kv.v [type=int]
 
 build
@@ -573,13 +619,17 @@ group-by
  │         └── const: 8 [type=int]
  ├── groupings
  └── aggregations
-      ├── function: min [type=NULL]
+      ├── function [type=int]
+      │    ├── const: 'min' [type=string]
       │    └── variable: kv.k [type=int]
-      ├── function: max [type=NULL]
+      ├── function [type=int]
+      │    ├── const: 'max' [type=string]
       │    └── variable: kv.k [type=int]
-      ├── function: min [type=NULL]
+      ├── function [type=int]
+      │    ├── const: 'min' [type=string]
       │    └── variable: kv.v [type=int]
-      └── function: max [type=NULL]
+      └── function [type=int]
+           ├── const: 'max' [type=string]
            └── variable: kv.v [type=int]
 
 build
@@ -596,7 +646,8 @@ group-by
  │         └── const: NULL [type=NULL]
  ├── groupings
  └── aggregations
-      └── function: array_agg [type=NULL]
+      └── function [type=string[]]
+           ├── const: 'array_agg' [type=string]
            └── variable: kv.s [type=string]
 
 build
@@ -608,13 +659,17 @@ group-by
  │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
  ├── groupings
  └── aggregations
-      ├── function: avg [type=NULL]
+      ├── function [type=decimal]
+      │    ├── const: 'avg' [type=string]
       │    └── variable: kv.k [type=int]
-      ├── function: avg [type=NULL]
+      ├── function [type=decimal]
+      │    ├── const: 'avg' [type=string]
       │    └── variable: kv.v [type=int]
-      ├── function: sum [type=NULL]
+      ├── function [type=decimal]
+      │    ├── const: 'sum' [type=string]
       │    └── variable: kv.k [type=int]
-      └── function: sum [type=NULL]
+      └── function [type=decimal]
+           ├── const: 'sum' [type=string]
            └── variable: kv.v [type=int]
 
 exec-ddl
@@ -640,13 +695,17 @@ group-by
  │    └── columns: abc.a:string:1 abc.b:float:null:2 abc.c:bool:null:3 abc.d:decimal:null:4
  ├── groupings
  └── aggregations
-      ├── function: min [type=NULL]
+      ├── function [type=string]
+      │    ├── const: 'min' [type=string]
       │    └── variable: abc.a [type=string]
-      ├── function: min [type=NULL]
+      ├── function [type=float]
+      │    ├── const: 'min' [type=string]
       │    └── variable: abc.b [type=float]
-      ├── function: min [type=NULL]
+      ├── function [type=bool]
+      │    ├── const: 'min' [type=string]
       │    └── variable: abc.c [type=bool]
-      └── function: min [type=NULL]
+      └── function [type=decimal]
+           ├── const: 'min' [type=string]
            └── variable: abc.d [type=decimal]
 
 build
@@ -658,13 +717,17 @@ group-by
  │    └── columns: abc.a:string:1 abc.b:float:null:2 abc.c:bool:null:3 abc.d:decimal:null:4
  ├── groupings
  └── aggregations
-      ├── function: max [type=NULL]
+      ├── function [type=string]
+      │    ├── const: 'max' [type=string]
       │    └── variable: abc.a [type=string]
-      ├── function: max [type=NULL]
+      ├── function [type=float]
+      │    ├── const: 'max' [type=string]
       │    └── variable: abc.b [type=float]
-      ├── function: max [type=NULL]
+      ├── function [type=bool]
+      │    ├── const: 'max' [type=string]
       │    └── variable: abc.c [type=bool]
-      └── function: max [type=NULL]
+      └── function [type=decimal]
+           ├── const: 'max' [type=string]
            └── variable: abc.d [type=decimal]
 
 build
@@ -676,13 +739,17 @@ group-by
  │    └── columns: abc.a:string:1 abc.b:float:null:2 abc.c:bool:null:3 abc.d:decimal:null:4
  ├── groupings
  └── aggregations
-      ├── function: avg [type=NULL]
+      ├── function [type=float]
+      │    ├── const: 'avg' [type=string]
       │    └── variable: abc.b [type=float]
-      ├── function: sum [type=NULL]
+      ├── function [type=float]
+      │    ├── const: 'sum' [type=string]
       │    └── variable: abc.b [type=float]
-      ├── function: avg [type=NULL]
+      ├── function [type=decimal]
+      │    ├── const: 'avg' [type=string]
       │    └── variable: abc.d [type=decimal]
-      └── function: sum [type=NULL]
+      └── function [type=decimal]
+           ├── const: 'sum' [type=string]
            └── variable: abc.d [type=decimal]
 
 # Verify summing of intervals
@@ -703,7 +770,8 @@ group-by
  │    └── columns: intervals.a:interval:1
  ├── groupings
  └── aggregations
-      └── function: sum [type=NULL]
+      └── function [type=interval]
+           ├── const: 'sum' [type=string]
            └── variable: intervals.a [type=interval]
 
 build
@@ -762,7 +830,8 @@ group-by
  │    └── columns: xyz.x:int:1 xyz.y:int:null:2 xyz.z:float:null:3
  ├── groupings
  └── aggregations
-      └── function: min [type=NULL]
+      └── function [type=int]
+           ├── const: 'min' [type=string]
            └── variable: xyz.x [type=int]
 
 build
@@ -782,7 +851,8 @@ group-by
  │              └── const: 7 [type=int]
  ├── groupings
  └── aggregations
-      └── function: min [type=NULL]
+      └── function [type=int]
+           ├── const: 'min' [type=string]
            └── variable: xyz.x [type=int]
 
 build
@@ -794,7 +864,8 @@ group-by
  │    └── columns: xyz.x:int:1 xyz.y:int:null:2 xyz.z:float:null:3
  ├── groupings
  └── aggregations
-      └── function: max [type=NULL]
+      └── function [type=int]
+           ├── const: 'max' [type=string]
            └── variable: xyz.x [type=int]
 
 build
@@ -811,7 +882,8 @@ group-by
  │         └── const: 1 [type=int]
  ├── groupings
  └── aggregations
-      └── function: max [type=NULL]
+      └── function [type=int]
+           ├── const: 'max' [type=string]
            └── variable: xyz.y [type=int]
 
 build
@@ -828,7 +900,8 @@ group-by
  │         └── const: 7 [type=int]
  ├── groupings
  └── aggregations
-      └── function: min [type=NULL]
+      └── function [type=int]
+           ├── const: 'min' [type=string]
            └── variable: xyz.y [type=int]
 
 build
@@ -849,7 +922,8 @@ group-by
  │              └── const: 3.0 [type=float]
  ├── groupings
  └── aggregations
-      └── function: min [type=NULL]
+      └── function [type=int]
+           ├── const: 'min' [type=string]
            └── variable: xyz.x [type=int]
 
 build
@@ -870,7 +944,8 @@ group-by
  │              └── const: 2 [type=int]
  ├── groupings
  └── aggregations
-      └── function: max [type=NULL]
+      └── function [type=int]
+           ├── const: 'max' [type=string]
            └── variable: xyz.x [type=int]
 
 
@@ -890,7 +965,8 @@ group-by
  │         └── const: 10 [type=int]
  ├── groupings
  └── aggregations
-      └── function: variance [type=NULL]
+      └── function [type=decimal]
+           ├── const: 'variance' [type=string]
            └── variable: xyz.x [type=int]
 
 build
@@ -907,7 +983,8 @@ group-by
  │         └── const: 1 [type=int]
  ├── groupings
  └── aggregations
-      └── function: stddev [type=NULL]
+      └── function [type=decimal]
+           ├── const: 'stddev' [type=string]
            └── variable: xyz.x [type=int]
 
 exec-ddl
@@ -926,9 +1003,11 @@ group-by
  │    └── columns: bools.b:bool:null:1 bools.rowid:int:2
  ├── groupings
  └── aggregations
-      ├── function: bool_and [type=NULL]
+      ├── function [type=bool]
+      │    ├── const: 'bool_and' [type=string]
       │    └── variable: bools.b [type=bool]
-      └── function: bool_or [type=NULL]
+      └── function [type=bool]
+           ├── const: 'bool_or' [type=string]
            └── variable: bools.b [type=bool]
 
 
@@ -971,12 +1050,15 @@ project
  │    │    └── columns: xor_bytes.a:bytes:null:1 xor_bytes.b:int:null:2 xor_bytes.c:int:null:3 xor_bytes.rowid:int:4
  │    ├── groupings
  │    └── aggregations
- │         ├── function: xor_agg [type=NULL]
+ │         ├── function [type=bytes]
+ │         │    ├── const: 'xor_agg' [type=string]
  │         │    └── variable: xor_bytes.a [type=bytes]
- │         └── function: xor_agg [type=NULL]
+ │         └── function [type=int]
+ │              ├── const: 'xor_agg' [type=string]
  │              └── variable: xor_bytes.c [type=int]
  └── projections
-      ├── function: to_hex [type=NULL]
+      ├── function [type=string]
+      │    ├── const: 'to_hex' [type=string]
       │    └── variable: column5 [type=bytes]
       └── variable: column7 [type=int]
 
@@ -989,9 +1071,11 @@ group-by
  │    └── tuple [type=tuple{}]
  ├── groupings
  └── aggregations
-      ├── function: max [type=NULL]
+      ├── function [type=bool]
+      │    ├── const: 'max' [type=string]
       │    └── true [type=bool]
-      └── function: min [type=NULL]
+      └── function [type=bool]
+           ├── const: 'min' [type=string]
            └── true [type=bool]
 
 exec-ddl
@@ -1053,7 +1137,8 @@ project
  │    │    ├── variable: ab.a [type=int]
  │    │    └── variable: ab.b [type=int]
  │    └── aggregations
- │         └── function: min [type=NULL]
+ │         └── function [type=string]
+ │              ├── const: 'min' [type=string]
  │              └── variable: xy.y [type=string]
  └── projections
       ├── variable: column6 [type=string]
@@ -1103,7 +1188,8 @@ project
  │    │         ├── variable: kv.k [type=int]
  │    │         └── variable: kv.w [type=int]
  │    └── aggregations
- │         └── function: sum [type=NULL]
+ │         └── function [type=decimal]
+ │              ├── const: 'sum' [type=string]
  │              └── variable: kv.w [type=int]
  └── projections
       ├── variable: column6 [type=decimal]
@@ -1120,13 +1206,15 @@ project
  │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
  │    ├── groupings
  │    │    ├── variable: kv.v [type=int]
- │    │    ├── function: lower [type=NULL]
+ │    │    ├── function [type=string]
+ │    │    │    ├── const: 'lower' [type=string]
  │    │    │    └── variable: kv.s [type=string]
  │    │    └── mult [type=int]
  │    │         ├── variable: kv.k [type=int]
  │    │         └── variable: kv.w [type=int]
  │    └── aggregations
- │         └── function: sum [type=NULL]
+ │         └── function [type=decimal]
+ │              ├── const: 'sum' [type=string]
  │              └── variable: kv.w [type=int]
  └── projections
       ├── variable: column7 [type=decimal]
@@ -1250,14 +1338,17 @@ project
  │    │    │    └── columns: abc.a:string:5 abc.b:float:null:6 abc.c:bool:null:7 abc.d:decimal:null:8
  │    │    └── true [type=bool]
  │    ├── groupings
- │    │    ├── function: concat [type=NULL]
+ │    │    ├── function [type=string]
+ │    │    │    ├── const: 'concat' [type=string]
  │    │    │    ├── variable: kv.s [type=string]
  │    │    │    └── variable: abc.a [type=string]
  │    │    └── variable: abc.a [type=string]
  │    └── aggregations
  └── projections
-      └── function: concat [type=NULL]
-           ├── function: concat [type=NULL]
+      └── function [type=string]
+           ├── const: 'concat' [type=string]
+           ├── function [type=string]
+           │    ├── const: 'concat' [type=string]
            │    ├── variable: kv.s [type=string]
            │    └── variable: abc.a [type=string]
            └── variable: abc.a [type=string]
@@ -1389,19 +1480,23 @@ project
  │    │    │    └── columns: times.t:time:2
  │    │    └── true [type=bool]
  │    ├── groupings
- │    │    ├── function: date_trunc [type=NULL]
+ │    │    ├── function [type=interval]
+ │    │    │    ├── const: 'date_trunc' [type=string]
  │    │    │    ├── const: 'second' [type=string]
  │    │    │    └── variable: times.t [type=time]
- │    │    └── function: date_trunc [type=NULL]
+ │    │    └── function [type=interval]
+ │    │         ├── const: 'date_trunc' [type=string]
  │    │         ├── const: 'minute' [type=string]
  │    │         └── variable: times.t [type=time]
  │    └── aggregations
  └── projections
-      └── minus [type=NULL]
-           ├── function: date_trunc [type=NULL]
+      └── minus [type=interval]
+           ├── function [type=interval]
+           │    ├── const: 'date_trunc' [type=string]
            │    ├── const: 'second' [type=string]
            │    └── variable: times.t [type=time]
-           └── function: date_trunc [type=NULL]
+           └── function [type=interval]
+                ├── const: 'date_trunc' [type=string]
                 ├── const: 'minute' [type=string]
                 └── variable: times.t [type=time]
 

--- a/pkg/sql/opt/optbuilder/testdata/distinct
+++ b/pkg/sql/opt/optbuilder/testdata/distinct
@@ -101,7 +101,8 @@ group-by
  │    └── aggregations
  ├── groupings
  └── aggregations
-      └── function: count_rows [type=NULL]
+      └── function [type=int]
+           └── const: 'count_rows' [type=string]
 
 build
 SELECT DISTINCT x FROM t.xyz WHERE x > 0
@@ -157,7 +158,8 @@ group-by
  │    │    ├── groupings
  │    │    │    └── variable: xyz.x [type=int]
  │    │    └── aggregations
- │    │         └── function: max [type=NULL]
+ │    │         └── function [type=int]
+ │    │              ├── const: 'max' [type=string]
  │    │              └── variable: xyz.x [type=int]
  │    └── projections
  │         └── variable: column4 [type=int]
@@ -229,7 +231,8 @@ group-by
  │    │    │    │    ├── variable: xyz.x [type=int]
  │    │    │    │    └── variable: xyz.y [type=int]
  │    │    │    └── aggregations
- │    │    │         └── function: max [type=NULL]
+ │    │    │         └── function [type=float]
+ │    │    │              ├── const: 'max' [type=string]
  │    │    │              └── variable: xyz.z [type=float]
  │    │    └── gt [type=bool]
  │    │         ├── variable: xyz.y [type=int]

--- a/pkg/sql/opt/optbuilder/testdata/having
+++ b/pkg/sql/opt/optbuilder/testdata/having
@@ -42,7 +42,8 @@ select
  │    ├── groupings
  │    │    └── variable: kv.s [type=string]
  │    └── aggregations
- │         └── function: count_rows [type=NULL]
+ │         └── function [type=int]
+ │              └── const: 'count_rows' [type=string]
  └── gt [type=bool]
       ├── variable: column5 [type=int]
       └── const: 1 [type=int]
@@ -60,9 +61,11 @@ project
  │    │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
  │    │    ├── groupings
  │    │    └── aggregations
- │    │         ├── function: min [type=NULL]
+ │    │         ├── function [type=int]
+ │    │         │    ├── const: 'min' [type=string]
  │    │         │    └── variable: kv.v [type=int]
- │    │         └── function: max [type=NULL]
+ │    │         └── function [type=int]
+ │    │              ├── const: 'max' [type=string]
  │    │              └── variable: kv.k [type=int]
  │    └── gt [type=bool]
  │         ├── variable: column5 [type=int]
@@ -84,11 +87,14 @@ project
  │    │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
  │    │    ├── groupings
  │    │    └── aggregations
- │    │         ├── function: max [type=NULL]
+ │    │         ├── function [type=int]
+ │    │         │    ├── const: 'max' [type=string]
  │    │         │    └── variable: kv.v [type=int]
- │    │         ├── function: max [type=NULL]
+ │    │         ├── function [type=int]
+ │    │         │    ├── const: 'max' [type=string]
  │    │         │    └── variable: kv.k [type=int]
- │    │         └── function: min [type=NULL]
+ │    │         └── function [type=int]
+ │    │              ├── const: 'min' [type=string]
  │    │              └── variable: kv.v [type=int]
  │    └── gt [type=bool]
  │         ├── variable: column5 [type=int]
@@ -141,7 +147,8 @@ project
  │    │    │         ├── variable: kv.k [type=int]
  │    │    │         └── variable: kv.w [type=int]
  │    │    └── aggregations
- │    │         └── function: count_rows [type=NULL]
+ │    │         └── function [type=int]
+ │    │              └── const: 'count_rows' [type=string]
  │    └── gt [type=bool]
  │         ├── plus [type=int]
  │         │    ├── variable: kv.k [type=int]
@@ -171,7 +178,8 @@ project
  │    │    ├── groupings
  │    │    │    └── variable: kv.v [type=int]
  │    │    └── aggregations
- │    │         └── function: max [type=NULL]
+ │    │         └── function [type=int]
+ │    │              ├── const: 'max' [type=string]
  │    │              └── variable: kv.v [type=int]
  │    └── gt [type=bool]
  │         ├── variable: kv.v [type=int]
@@ -191,13 +199,16 @@ project
  │    │    ├── scan
  │    │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
  │    │    ├── groupings
- │    │    │    └── function: lower [type=NULL]
+ │    │    │    └── function [type=string]
+ │    │    │         ├── const: 'lower' [type=string]
  │    │    │         └── variable: kv.s [type=string]
  │    │    └── aggregations
- │    │         └── function: sum [type=NULL]
+ │    │         └── function [type=decimal]
+ │    │              ├── const: 'sum' [type=string]
  │    │              └── variable: kv.w [type=int]
  │    └── like [type=bool]
- │         ├── function: lower [type=NULL]
+ │         ├── function [type=string]
+ │         │    ├── const: 'lower' [type=string]
  │         │    └── variable: kv.s [type=string]
  │         └── const: 'test%' [type=string]
  └── projections
@@ -215,10 +226,12 @@ project
  │    │    ├── scan
  │    │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
  │    │    ├── groupings
- │    │    │    └── function: lower [type=NULL]
+ │    │    │    └── function [type=string]
+ │    │    │         ├── const: 'lower' [type=string]
  │    │    │         └── variable: kv.s [type=string]
  │    │    └── aggregations
- │    │         └── function: sum [type=NULL]
+ │    │         └── function [type=decimal]
+ │    │              ├── const: 'sum' [type=string]
  │    │              └── variable: kv.w [type=int]
  │    └── in [type=bool]
  │         ├── variable: column6 [type=decimal]

--- a/pkg/sql/opt/optbuilder/testdata/scalar
+++ b/pkg/sql/opt/optbuilder/testdata/scalar
@@ -200,7 +200,8 @@ build-scalar vars=(string)
 LENGTH(@1) = 2
 ----
 eq [type=bool]
- ├── function: length [type=NULL]
+ ├── function [type=int]
+ │    ├── const: 'length' [type=string]
  │    └── variable: @1 [type=string]
  └── const: 2 [type=int]
 

--- a/pkg/sql/opt/xform/expr.og.go
+++ b/pkg/sql/opt/xform/expr.og.go
@@ -298,7 +298,7 @@ var childCountLookup = [...]childCountLookupFunc{
 	// FunctionOp
 	func(ev ExprView) int {
 		functionExpr := (*functionExpr)(ev.mem.lookupExpr(ev.loc))
-		return 0 + int(functionExpr.args().Length)
+		return 1 + int(functionExpr.args().Length)
 	},
 
 	// ScanOp
@@ -1123,9 +1123,11 @@ var childGroupLookup = [...]childGroupLookupFunc{
 		functionExpr := (*functionExpr)(ev.mem.lookupExpr(ev.loc))
 
 		switch n {
+		case 0:
+			return functionExpr.name()
 		default:
 			list := ev.mem.lookupList(functionExpr.args())
-			return list[n-0]
+			return list[n-1]
 		}
 	},
 
@@ -1733,8 +1735,7 @@ var privateLookup = [...]privateLookupFunc{
 
 	// FunctionOp
 	func(ev ExprView) opt.PrivateID {
-		functionExpr := (*functionExpr)(ev.mem.lookupExpr(ev.loc))
-		return functionExpr.def()
+		return 0
 	},
 
 	// ScanOp
@@ -4067,16 +4068,16 @@ func (m *memoExpr) asUnaryComplement() *unaryComplementExpr {
 
 type functionExpr memoExpr
 
-func makeFunctionExpr(args opt.ListID, def opt.PrivateID) functionExpr {
-	return functionExpr{op: opt.FunctionOp, state: exprState{args.Offset, args.Length, uint32(def)}}
+func makeFunctionExpr(name opt.GroupID, args opt.ListID) functionExpr {
+	return functionExpr{op: opt.FunctionOp, state: exprState{uint32(name), args.Offset, args.Length}}
+}
+
+func (e *functionExpr) name() opt.GroupID {
+	return opt.GroupID(e.state[0])
 }
 
 func (e *functionExpr) args() opt.ListID {
-	return opt.ListID{Offset: e.state[0], Length: e.state[1]}
-}
-
-func (e *functionExpr) def() opt.PrivateID {
-	return opt.PrivateID(e.state[2])
+	return opt.ListID{Offset: e.state[1], Length: e.state[2]}
 }
 
 func (e *functionExpr) fingerprint() fingerprint {

--- a/pkg/sql/opt/xform/factory.og.go
+++ b/pkg/sql/opt/xform/factory.og.go
@@ -1167,10 +1167,10 @@ func (_f *factory) ConstructUnaryComplement(
 
 // ConstructFunction constructs an expression for the Function operator.
 func (_f *factory) ConstructFunction(
+	name opt.GroupID,
 	args opt.ListID,
-	def opt.PrivateID,
 ) opt.GroupID {
-	_functionExpr := makeFunctionExpr(args, def)
+	_functionExpr := makeFunctionExpr(name, args)
 	_group := _f.mem.lookupGroupByFingerprint(_functionExpr.fingerprint())
 	if _group != 0 {
 		return _group
@@ -1866,7 +1866,7 @@ func init() {
 
 	// FunctionOp
 	dynConstructLookup[opt.FunctionOp] = func(f *factory, children []opt.GroupID, private opt.PrivateID) opt.GroupID {
-		return f.ConstructFunction(f.InternList(children), private)
+		return f.ConstructFunction(children[0], f.InternList(children[1:]))
 	}
 
 	// ScanOp

--- a/pkg/sql/opt/xform/typing_test.go
+++ b/pkg/sql/opt/xform/typing_test.go
@@ -16,12 +16,14 @@ package xform
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/optbuilder"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/testutils"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/builtins"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
 	"github.com/cockroachdb/cockroach/pkg/testutils/datadriven"
@@ -97,6 +99,81 @@ func TestTypingJson(t *testing.T) {
 	fetchTextPathGroup := f.ConstructFetchTextPath(jsonGroup, arrGroup)
 	ev = o.Optimize(fetchTextPathGroup, &opt.PhysicalProps{})
 	testTyping(t, ev, types.String)
+}
+
+func TestTypingFunction(t *testing.T) {
+	o := NewOptimizer(createTypingCatalog(), 0 /* maxSteps */)
+	f := o.Factory()
+
+	// Function with fixed return type.
+	// (Function (Const "length") (Const "text"))
+	nameGroup := f.ConstructConst(f.InternPrivate(tree.NewDString("length")))
+	arg1Group := f.ConstructConst(f.InternPrivate(tree.NewDString("text")))
+	argsList := f.InternList([]opt.GroupID{arg1Group})
+	funcGroup := f.ConstructFunction(nameGroup, argsList)
+	ev := o.Optimize(funcGroup, &opt.PhysicalProps{})
+	testTyping(t, ev, types.Int)
+
+	// Function with return type dependent on arg types.
+	// (Function (Const "div") (Const 1.0) (Const 2.0))
+	nameGroup = f.ConstructConst(f.InternPrivate(tree.NewDString("div")))
+	arg1Group = f.ConstructConst(f.InternPrivate(tree.NewDFloat(1.0)))
+	arg2Group := f.ConstructConst(f.InternPrivate(tree.NewDFloat(2.0)))
+	argsList = f.InternList([]opt.GroupID{arg1Group, arg2Group})
+	funcGroup = f.ConstructFunction(nameGroup, argsList)
+	ev = o.Optimize(funcGroup, &opt.PhysicalProps{})
+	testTyping(t, ev, types.Float)
+
+	// Function with same arguments in multiple overloads.
+	// (Function (Const "now::timestamp"))
+	nameGroup = f.ConstructConst(f.InternPrivate(tree.NewDString("now:::timestamp")))
+	funcGroup = f.ConstructFunction(nameGroup, opt.EmptyList)
+	ev = o.Optimize(funcGroup, &opt.PhysicalProps{})
+	testTyping(t, ev, types.Timestamp)
+
+	// Function with same arguments in multiple overloads (different overload).
+	// (Function (Const "now::timestamptz"))
+	nameGroup = f.ConstructConst(f.InternPrivate(tree.NewDString("now:::timestamptz")))
+	funcGroup = f.ConstructFunction(nameGroup, opt.EmptyList)
+	ev = o.Optimize(funcGroup, &opt.PhysicalProps{})
+	testTyping(t, ev, types.TimestampTZ)
+
+	// Variadic function.
+	// (Function (Const "greatest") (Const 1) (Const 2))
+	nameGroup = f.ConstructConst(f.InternPrivate(tree.NewDString("greatest")))
+	arg1Group = f.ConstructConst(f.InternPrivate(tree.NewDInt(1)))
+	arg2Group = f.ConstructConst(f.InternPrivate(tree.NewDInt(2)))
+	argsList = f.InternList([]opt.GroupID{arg1Group, arg2Group})
+	funcGroup = f.ConstructFunction(nameGroup, argsList)
+	ev = o.Optimize(funcGroup, &opt.PhysicalProps{})
+	testTyping(t, ev, types.Int)
+}
+
+// This "test" is special, in that it is verifying that we don't add functions
+// in the future that break assumptions in the optimizer's typing code.
+func TestTypingAssumptions(t *testing.T) {
+	// Assumption: It is possible to infer the return type from the types of
+	//             function arguments for all but a small set of well-known
+	//             functions.
+	for name, builtin := range builtins.Builtins {
+		// Skip past known ambiguous functions.
+		if opt.DisambiguateFunction(name, types.Any) != name {
+			continue
+		}
+		if opt.DisambiguateFunction(strings.ToLower(name), types.Any) != name {
+			continue
+		}
+
+		seen := make([]tree.TypeList, 0)
+		for _, overload := range builtin {
+			for _, sig := range seen {
+				if sig.Match(overload.Types.Types()) {
+					t.Errorf("%s function has ambiguous arguments", name)
+				}
+			}
+			seen = append(seen, overload.Types)
+		}
+	}
 }
 
 func createTypingCatalog() *testutils.TestCatalog {

--- a/pkg/sql/sem/builtins/aggregate_builtins.go
+++ b/pkg/sql/sem/builtins/aggregate_builtins.go
@@ -83,13 +83,13 @@ var Aggregates = map[string][]tree.Builtin{
 	"array_agg": arrayBuiltin(func(t types.T) tree.Builtin {
 		return makeAggBuiltinWithReturnType(
 			[]types.T{t},
-			func(args []tree.TypedExpr) types.T {
-				if len(args) == 0 {
+			func(argTypes []types.T) types.T {
+				if len(argTypes) == 0 {
 					return types.TArray{Typ: t}
 				}
 				// Whenever possible, use the expression's type, so we can properly
 				// handle aliased types that don't explicitly have overloads.
-				return types.TArray{Typ: args[0].ResolvedType()}
+				return types.TArray{Typ: argTypes[0]}
 			},
 			newArrayAggregate,
 			"Aggregates the selected values into an array.",

--- a/pkg/sql/sem/builtins/generator_builtins.go
+++ b/pkg/sql/sem/builtins/generator_builtins.go
@@ -86,12 +86,12 @@ var Generators = map[string][]tree.Builtin{
 	"unnest": {
 		makeGeneratorBuiltinWithReturnType(
 			tree.ArgTypes{{"input", types.AnyArray}},
-			func(args []tree.TypedExpr) types.T {
-				if len(args) == 0 {
+			func(argTypes []types.T) types.T {
+				if len(argTypes) == 0 {
 					return tree.UnknownReturnType
 				}
 				return types.TTable{
-					Cols:   types.TTuple{args[0].ResolvedType().(types.TArray).Typ},
+					Cols:   types.TTuple{argTypes[0].(types.TArray).Typ},
 					Labels: arrayValueGeneratorLabels,
 				}
 			},

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -203,7 +203,7 @@ func (op BinOp) params() TypeList {
 }
 
 func (op BinOp) matchParams(l, r types.T) bool {
-	return op.params().matchAt(l, 0) && op.params().matchAt(r, 1)
+	return op.params().MatchAt(l, 0) && op.params().MatchAt(r, 1)
 }
 
 func (op BinOp) returnType() ReturnTyper {
@@ -1491,7 +1491,7 @@ func (op CmpOp) params() TypeList {
 }
 
 func (op CmpOp) matchParams(l, r types.T) bool {
-	return op.params().matchAt(l, 0) && op.params().matchAt(r, 1)
+	return op.params().MatchAt(l, 0) && op.params().MatchAt(r, 1)
 }
 
 var cmpOpReturnType = FixedReturnType(types.Bool)

--- a/pkg/sql/sem/tree/overload.go
+++ b/pkg/sql/sem/tree/overload.go
@@ -35,17 +35,17 @@ type overloadImpl interface {
 
 // TypeList is a list of types representing a function parameter list.
 type TypeList interface {
-	// match checks if all types in the TypeList match the corresponding elements in types.
-	match(types []types.T) bool
-	// matchAt checks if the parameter type at index i of the TypeList matches type typ.
+	// Match checks if all types in the TypeList match the corresponding elements in types.
+	Match(types []types.T) bool
+	// MatchAt checks if the parameter type at index i of the TypeList matches type typ.
 	// In all implementations, types.Null will match with each parameter type, allowing
 	// NULL values to be used as arguments.
-	matchAt(typ types.T, i int) bool
-	// matchLen checks that the TypeList can support l parameters.
-	matchLen(l int) bool
-	// getAt returns the type at the given index in the TypeList, or nil if the TypeList
+	MatchAt(typ types.T, i int) bool
+	// MatchLen checks that the TypeList can support l parameters.
+	MatchLen(l int) bool
+	// TypeAt returns the type at the given index in the TypeList, or nil if the TypeList
 	// cannot have a parameter at index i.
-	getAt(i int) types.T
+	TypeAt(i int) types.T
 	// Length returns the number of types in the list
 	Length() int
 	// Types returns a realized copy of the list. variadic lists return a list of size one.
@@ -66,19 +66,21 @@ type ArgTypes []struct {
 	Typ  types.T
 }
 
-func (a ArgTypes) match(types []types.T) bool {
+// Match implements the TypeList interface.
+func (a ArgTypes) Match(types []types.T) bool {
 	if len(types) != len(a) {
 		return false
 	}
 	for i := range types {
-		if !a.matchAt(types[i], i) {
+		if !a.MatchAt(types[i], i) {
 			return false
 		}
 	}
 	return true
 }
 
-func (a ArgTypes) matchAt(typ types.T, i int) bool {
+// MatchAt implements the TypeList interface.
+func (a ArgTypes) MatchAt(typ types.T, i int) bool {
 	// The parameterized types for Tuples are checked in the type checking
 	// routines before getting here, so we only need to check if the argument
 	// type is a types.FamTuple below. This allows us to avoid defining overloads
@@ -90,11 +92,13 @@ func (a ArgTypes) matchAt(typ types.T, i int) bool {
 	return i < len(a) && (typ == types.Null || a[i].Typ.Equivalent(typ))
 }
 
-func (a ArgTypes) matchLen(l int) bool {
+// MatchLen implements the TypeList interface.
+func (a ArgTypes) MatchLen(l int) bool {
 	return len(a) == l
 }
 
-func (a ArgTypes) getAt(i int) types.T {
+// TypeAt implements the TypeList interface.
+func (a ArgTypes) TypeAt(i int) types.T {
 	return a[i].Typ
 }
 
@@ -131,19 +135,23 @@ func (a ArgTypes) String() string {
 // in typeCheckOverloadedExprs.
 type HomogeneousType struct{}
 
-func (HomogeneousType) match(types []types.T) bool {
+// Match implements the TypeList interface.
+func (HomogeneousType) Match(types []types.T) bool {
 	return true
 }
 
-func (HomogeneousType) matchAt(typ types.T, i int) bool {
+// MatchAt implements the TypeList interface.
+func (HomogeneousType) MatchAt(typ types.T, i int) bool {
 	return true
 }
 
-func (HomogeneousType) matchLen(l int) bool {
+// MatchLen implements the TypeList interface.
+func (HomogeneousType) MatchLen(l int) bool {
 	return true
 }
 
-func (HomogeneousType) getAt(i int) types.T {
+// TypeAt implements the TypeList interface.
+func (HomogeneousType) TypeAt(i int) types.T {
 	return types.Any
 }
 
@@ -169,27 +177,31 @@ type VariadicType struct {
 	VarType    types.T
 }
 
-func (v VariadicType) match(types []types.T) bool {
+// Match implements the TypeList interface.
+func (v VariadicType) Match(types []types.T) bool {
 	for i := range types {
-		if !v.matchAt(types[i], i) {
+		if !v.MatchAt(types[i], i) {
 			return false
 		}
 	}
 	return true
 }
 
-func (v VariadicType) matchAt(typ types.T, i int) bool {
+// MatchAt implements the TypeList interface.
+func (v VariadicType) MatchAt(typ types.T, i int) bool {
 	if i < len(v.FixedTypes) {
 		return typ == types.Null || v.FixedTypes[i].Equivalent(typ)
 	}
 	return typ == types.Null || v.VarType.Equivalent(typ)
 }
 
-func (v VariadicType) matchLen(l int) bool {
+// MatchLen implements the TypeList interface.
+func (v VariadicType) MatchLen(l int) bool {
 	return l >= len(v.FixedTypes)
 }
 
-func (v VariadicType) getAt(i int) types.T {
+// TypeAt implements the TypeList interface.
+func (v VariadicType) TypeAt(i int) types.T {
 	if i < len(v.FixedTypes) {
 		return v.FixedTypes[i]
 	}
@@ -237,21 +249,21 @@ var UnknownReturnType types.T
 
 // ReturnTyper defines the type-level function in which a builtin function's return type
 // is determined. ReturnTypers should make sure to return unknownReturnType when necessary.
-type ReturnTyper func(args []TypedExpr) types.T
+type ReturnTyper func(argTypes []types.T) types.T
 
 // FixedReturnType functions simply return a fixed type, independent of argument types.
 func FixedReturnType(typ types.T) ReturnTyper {
-	return func(args []TypedExpr) types.T { return typ }
+	return func(argTypes []types.T) types.T { return typ }
 }
 
 // IdentityReturnType creates a returnType that is a projection of the idx'th
 // argument type.
 func IdentityReturnType(idx int) ReturnTyper {
-	return func(args []TypedExpr) types.T {
-		if len(args) == 0 {
+	return func(argTypes []types.T) types.T {
+		if len(argTypes) == 0 {
 			return UnknownReturnType
 		}
-		return args[idx].ResolvedType()
+		return argTypes[idx]
 	}
 }
 
@@ -337,7 +349,7 @@ func typeCheckOverloadedExprs(
 	// Filter out incorrect parameter length overloads.
 	s.overloadIdxs = filterOverloads(s.overloads, s.overloadIdxs,
 		func(o overloadImpl) bool {
-			return o.params().matchLen(len(exprs))
+			return o.params().MatchLen(len(exprs))
 		})
 
 	// Filter out overloads which constants cannot become.
@@ -345,7 +357,7 @@ func typeCheckOverloadedExprs(
 		constExpr := exprs[i].(Constant)
 		s.overloadIdxs = filterOverloads(s.overloads, s.overloadIdxs,
 			func(o overloadImpl) bool {
-				return canConstantBecome(constExpr, o.params().getAt(i))
+				return canConstantBecome(constExpr, o.params().TypeAt(i))
 			})
 	}
 
@@ -359,7 +371,7 @@ func typeCheckOverloadedExprs(
 		if len(s.overloadIdxs) == 1 {
 			// Once we get down to a single overload candidate, begin desiring its
 			// parameter types for the corresponding argument expressions.
-			paramDesired = s.overloads[s.overloadIdxs[0]].params().getAt(i)
+			paramDesired = s.overloads[s.overloadIdxs[0]].params().TypeAt(i)
 		}
 		typ, err := exprs[i].TypeCheck(ctx, paramDesired)
 		if err != nil {
@@ -368,7 +380,7 @@ func typeCheckOverloadedExprs(
 		s.typedExprs[i] = typ
 		s.overloadIdxs = filterOverloads(s.overloads, s.overloadIdxs,
 			func(o overloadImpl) bool {
-				return o.params().matchAt(typ.ResolvedType(), i)
+				return o.params().MatchAt(typ.ResolvedType(), i)
 			})
 	}
 
@@ -427,7 +439,7 @@ func typeCheckOverloadedExprs(
 					for _, i := range s.constIdxs {
 						s.overloadIdxs = filterOverloads(s.overloads, s.overloadIdxs,
 							func(o overloadImpl) bool {
-								return o.params().getAt(i).Equivalent(homogeneousTyp)
+								return o.params().TypeAt(i).Equivalent(homogeneousTyp)
 							})
 					}
 				}
@@ -444,7 +456,7 @@ func typeCheckOverloadedExprs(
 				if natural != nil {
 					s.overloadIdxs = filterOverloads(s.overloads, s.overloadIdxs,
 						func(o overloadImpl) bool {
-							return o.params().getAt(i).Equivalent(natural)
+							return o.params().TypeAt(i).Equivalent(natural)
 						})
 				}
 			}
@@ -468,7 +480,7 @@ func typeCheckOverloadedExprs(
 			constExpr := exprs[i].(Constant)
 			s.overloadIdxs = filterOverloads(s.overloads, s.overloadIdxs,
 				func(o overloadImpl) bool {
-					_, err := constExpr.ResolveAsType(&SemaContext{}, o.params().getAt(i))
+					_, err := constExpr.ResolveAsType(&SemaContext{}, o.params().TypeAt(i))
 					return err == nil
 				})
 		}
@@ -482,7 +494,7 @@ func typeCheckOverloadedExprs(
 			for _, i := range s.constIdxs {
 				s.overloadIdxs = filterOverloads(s.overloads, s.overloadIdxs,
 					func(o overloadImpl) bool {
-						return o.params().getAt(i).Equivalent(bestConstType)
+						return o.params().TypeAt(i).Equivalent(bestConstType)
 					})
 			}
 			if types, fns, ok, err := checkReturn(ctx, s); ok {
@@ -506,7 +518,7 @@ func typeCheckOverloadedExprs(
 		for _, i := range s.placeholderIdxs {
 			s.overloadIdxs = filterOverloads(s.overloads, s.overloadIdxs,
 				func(o overloadImpl) bool {
-					return o.params().getAt(i).Equivalent(homogeneousTyp)
+					return o.params().TypeAt(i).Equivalent(homogeneousTyp)
 				})
 		}
 		if types, fns, ok, err := checkReturn(ctx, s); ok {
@@ -549,8 +561,8 @@ func typeCheckOverloadedExprs(
 				}
 				s.overloadIdxs = filterOverloads(s.overloads, s.overloadIdxs,
 					func(o overloadImpl) bool {
-						return o.params().getAt(0).Equivalent(leftType) &&
-							o.params().getAt(1).Equivalent(rightType)
+						return o.params().TypeAt(0).Equivalent(leftType) &&
+							o.params().TypeAt(1).Equivalent(rightType)
 					})
 			}
 		}); ok {
@@ -657,7 +669,7 @@ func checkReturn(
 		o := s.overloads[idx]
 		p := o.params()
 		for _, i := range s.constIdxs {
-			des := p.getAt(i)
+			des := p.TypeAt(i)
 			typ, err := s.exprs[i].TypeCheck(ctx, des)
 			if err != nil {
 				return s.typedExprs, nil, true, errors.Wrap(err, "error type checking constant value")
@@ -669,7 +681,7 @@ func checkReturn(
 		}
 
 		for _, i := range s.placeholderIdxs {
-			des := p.getAt(i)
+			des := p.TypeAt(i)
 			typ, err := s.exprs[i].TypeCheck(ctx, des)
 			if err != nil {
 				return s.typedExprs, nil, true, err
@@ -690,7 +702,7 @@ func formatCandidates(prefix string, candidates []overloadImpl) string {
 		params := candidate.params()
 		tLen := params.Length()
 		for i := 0; i < tLen; i++ {
-			t := params.getAt(i)
+			t := params.TypeAt(i)
 			if i > 0 {
 				buf.WriteString(", ")
 			}

--- a/pkg/sql/sem/tree/overload_test.go
+++ b/pkg/sql/sem/tree/overload_test.go
@@ -75,14 +75,14 @@ func TestVariadicFunctions(t *testing.T) {
 		for _, v := range data.cases {
 			t.Run(fmt.Sprintf("%v/%v", fn, v), func(t *testing.T) {
 				if v.matches {
-					if !fn.matchLen(len(v.args)) {
-						t.Fatalf("expected fn %v to matchLen %v", fn, v.args)
+					if !fn.MatchLen(len(v.args)) {
+						t.Fatalf("expected fn %v to match len %v", fn, v.args)
 					}
 
-					if !fn.match(v.args) {
+					if !fn.Match(v.args) {
 						t.Fatalf("expected fn %v to match %v", fn, v.args)
 					}
-				} else if fn.matchLen(len(v.args)) && fn.match(v.args) {
+				} else if fn.MatchLen(len(v.args)) && fn.Match(v.args) {
 					t.Fatalf("expected fn %v to not match %v", fn, v.args)
 				}
 			})

--- a/pkg/sql/sem/tree/type_check.go
+++ b/pkg/sql/sem/tree/type_check.go
@@ -209,7 +209,7 @@ func (expr *BinaryExpr) TypeCheck(ctx *SemaContext, desired types.T) (TypedExpr,
 	binOp := fns[0].(BinOp)
 	expr.Left, expr.Right = leftTyped, rightTyped
 	expr.fn = binOp
-	expr.typ = binOp.returnType()(typedSubExprs)
+	expr.typ = binOp.returnType()([]types.T{leftReturn, rightReturn})
 	return expr, nil
 }
 
@@ -569,11 +569,13 @@ func (expr *FuncExpr) TypeCheck(ctx *SemaContext, desired types.T) (TypedExpr, e
 			"insufficient privilege to use %s", expr.Func)
 	}
 
+	argTypes := make([]types.T, len(typedSubExprs))
 	for i, subExpr := range typedSubExprs {
 		expr.Exprs[i] = subExpr
+		argTypes[i] = subExpr.ResolvedType()
 	}
 	expr.fn = builtin
-	expr.typ = builtin.returnType()(typedSubExprs)
+	expr.typ = builtin.returnType()(argTypes)
 	return expr, nil
 }
 
@@ -747,7 +749,7 @@ func (expr *UnaryExpr) TypeCheck(ctx *SemaContext, desired types.T) (TypedExpr, 
 	unaryOp := fns[0].(UnaryOp)
 	expr.Expr = exprTyped
 	expr.fn = unaryOp
-	expr.typ = unaryOp.returnType()(typedSubExprs)
+	expr.typ = unaryOp.returnType()([]types.T{exprReturn})
 	return expr, nil
 }
 


### PR DESCRIPTION
Each opt operator is purposely defined in a way that allows its
type to be inferred from its operands. This allows simple matching
and construction in transformation patterns. However, the function
operator presented challenges, because of the complexity of SQL
function overloads and because existing overload resolution code
couldn't be directly reused. This PR makes several changes to
allow simple bottom-up type inference for Function operators:

  - Export methods on the TypeList interface so that the opt code
    can invoke them. Since I'm changing this code anyway, also
    rename the getAt method to TypeAt, to make the name a bit less
    generic.
  - Change the ReturnTyper argument from []TypedExpr to []types.T.
    The opt code doesn't use TypedExpr's, so it was not possible
    to reuse the function overload code. The downside of making
    this change is the type checking code now needs to allocate an
    additional array. I tried to use an interface to avoid the
    allocation, but no matter what I tried, an allocation was
    happening one way or another. So I decided to just make the
    ReturnTyper parameter as simple and straightforward as
    possible.
  - Several time-related functions (e.g. now, current_timestamp,
    etc) cannot infer a return type based solely on their name and
    their arguments, since they may return a timestamp with or
    without a timezone depending on the context in which they're
    used. The solution is for the opt code to use a name that is
    disambiguated with the return type while building and
    transforming the expression tree, and then to map the name
    back to the original when constructing the execution tree.

Release note: None