### PR TITLE
sql: make sure the event log contains fully qualified object names 

### DIFF
--- a/pkg/sql/alter_index.go
+++ b/pkg/sql/alter_index.go
@@ -122,7 +122,7 @@ func (n *alterIndexNode) startExec(params runParams) error {
 			User       string
 			MutationID uint32
 		}{
-			n.tableDesc.Name, n.indexDesc.Name, n.n.String(),
+			n.n.Index.Table.TableName().FQString(), n.indexDesc.Name, n.n.String(),
 			params.SessionData().User, uint32(mutationID),
 		},
 	); err != nil {

--- a/pkg/sql/alter_sequence.go
+++ b/pkg/sql/alter_sequence.go
@@ -79,7 +79,7 @@ func (n *alterSequenceNode) startExec(params runParams) error {
 			SequenceName string
 			Statement    string
 			User         string
-		}{n.seqDesc.Name, n.n.String(), params.SessionData().User},
+		}{n.n.Name.TableName().FQString(), n.n.String(), params.SessionData().User},
 	); err != nil {
 		return err
 	}

--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -69,6 +69,7 @@ func (n *alterTableNode) startExec(params runParams) error {
 	descriptorChanged := false
 	origNumMutations := len(n.tableDesc.Mutations)
 	var droppedViews []string
+	tn := n.n.Table.TableName()
 
 	for _, cmd := range n.n.Cmds {
 		switch t := cmd.(type) {
@@ -353,7 +354,7 @@ func (n *alterTableNode) startExec(params runParams) error {
 				if containsThisColumn {
 					if containsOnlyThisColumn || t.DropBehavior == tree.DropCascade {
 						if err := params.p.dropIndexByName(
-							params.ctx, tree.UnrestrictedName(idx.Name), n.tableDesc, false,
+							params.ctx, tn, tree.UnrestrictedName(idx.Name), n.tableDesc, false,
 							t.DropBehavior, ignoreIdxConstraint,
 							tree.AsStringWithFlags(n.n, tree.FmtAlwaysQualifyTableNames),
 						); err != nil {
@@ -590,7 +591,8 @@ func (n *alterTableNode) startExec(params runParams) error {
 			User                string
 			MutationID          uint32
 			CascadeDroppedViews []string
-		}{n.tableDesc.Name, n.n.String(), params.SessionData().User, uint32(mutationID), droppedViews},
+		}{n.n.Table.TableName().FQString(), n.n.String(),
+			params.SessionData().User, uint32(mutationID), droppedViews},
 	); err != nil {
 		return err
 	}

--- a/pkg/sql/create_index.go
+++ b/pkg/sql/create_index.go
@@ -147,7 +147,7 @@ func (n *createIndexNode) startExec(params runParams) error {
 			User       string
 			MutationID uint32
 		}{
-			n.tableDesc.Name, n.n.Name.String(), n.n.String(),
+			n.n.Table.TableName().FQString(), n.n.Name.String(), n.n.String(),
 			params.SessionData().User, uint32(mutationID),
 		},
 	); err != nil {

--- a/pkg/sql/create_sequence.go
+++ b/pkg/sql/create_sequence.go
@@ -115,7 +115,7 @@ func (n *createSequenceNode) startExec(params runParams) error {
 			SequenceName string
 			Statement    string
 			User         string
-		}{n.n.Name.String(), n.n.String(), params.SessionData().User},
+		}{n.n.Name.TableName().FQString(), n.n.String(), params.SessionData().User},
 	)
 }
 

--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -193,7 +193,7 @@ func (n *createTableNode) startExec(params runParams) error {
 			TableName string
 			Statement string
 			User      string
-		}{n.n.Table.String(), n.n.String(), params.SessionData().User},
+		}{n.n.Table.TableName().FQString(), n.n.String(), params.SessionData().User},
 	); err != nil {
 		return err
 	}

--- a/pkg/sql/create_view.go
+++ b/pkg/sql/create_view.go
@@ -195,7 +195,7 @@ func (n *createViewNode) startExec(params runParams) error {
 			ViewName  string
 			Statement string
 			User      string
-		}{n.n.Name.String(), n.n.String(), params.SessionData().User},
+		}{n.n.Name.TableName().FQString(), n.n.String(), params.SessionData().User},
 	)
 }
 

--- a/pkg/sql/drop_index.go
+++ b/pkg/sql/drop_index.go
@@ -86,7 +86,7 @@ func (n *dropIndexNode) startExec(params runParams) error {
 		}
 
 		if err := params.p.dropIndexByName(
-			ctx, index.idxName, tableDesc, n.n.IfExists, n.n.DropBehavior, checkIdxConstraint,
+			ctx, index.tn, index.idxName, tableDesc, n.n.IfExists, n.n.DropBehavior, checkIdxConstraint,
 			tree.AsStringWithFlags(n.n, tree.FmtAlwaysQualifyTableNames),
 		); err != nil {
 			return err
@@ -118,6 +118,7 @@ const (
 
 func (p *planner) dropIndexByName(
 	ctx context.Context,
+	tn *tree.TableName,
 	idxName tree.UnrestrictedName,
 	tableDesc *sqlbase.TableDescriptor,
 	ifExists bool,
@@ -239,7 +240,7 @@ func (p *planner) dropIndexByName(
 			User                string
 			MutationID          uint32
 			CascadeDroppedViews []string
-		}{tableDesc.Name, string(idxName), jobDesc, p.SessionData().User, uint32(mutationID),
+		}{tn.FQString(), string(idxName), jobDesc, p.SessionData().User, uint32(mutationID),
 			droppedViews},
 	); err != nil {
 		return err

--- a/pkg/sql/logictest/testdata/logic_test/event_log
+++ b/pkg/sql/logictest/testdata/logic_test/event_log
@@ -8,10 +8,10 @@
 ##################
 
 statement ok
-CREATE TABLE test.a (id INT PRIMARY KEY)
+CREATE TABLE a (id INT PRIMARY KEY)
 
 statement ok
-CREATE TABLE IF NOT EXISTS test.b (id INT PRIMARY KEY)
+CREATE TABLE IF NOT EXISTS b (id INT PRIMARY KEY)
 
 statement ok
 CREATE TABLE IF NOT EXISTS a (id INT PRIMARY KEY)
@@ -32,21 +32,21 @@ WHERE "eventType" = 'create_table'
 # statement.
 ##################
 
-query II
-SELECT "targetID", "reportingID"
+query IIT
+SELECT "targetID", "reportingID", info::JSONB->>'TableName'
 FROM system.eventlog
 WHERE "eventType" = 'create_table'
-  AND info LIKE '%CREATE TABLE test.public.a%'
+  AND info::JSONB->>'Statement' LIKE 'CREATE TABLE a%'
 ----
-51 1
+51 1 test.public.a
 
-query II
-SELECT "targetID", "reportingID"
+query IIT
+SELECT "targetID", "reportingID", info::JSONB->>'TableName'
 FROM system.eventlog
 WHERE "eventType" = 'create_table'
-  AND info LIKE '%CREATE TABLE IF NOT EXISTS test.public.b%'
+  AND info::JSONB->>'Statement' LIKE 'CREATE TABLE IF NOT EXISTS b%'
 ----
-52 1
+52 1 test.public.b
 
 # Sanity check - check for a non-matching info value.
 ##################
@@ -62,21 +62,21 @@ WHERE "eventType" = 'create_table'
 # Alter the table. Expect "alter_table" and "finish_schema_change" events.
 ##################
 
-query II rowsort
-SELECT "targetID", "reportingID" FROM system.eventlog
+query IIT rowsort
+SELECT "targetID", "reportingID", info::JSONB->>'TableName' FROM system.eventlog
 WHERE "eventType" = 'alter_table'
 ----
-4  1
+4  1 system.public.users
 
 statement ok
-ALTER TABLE test.a ADD val INT
+ALTER TABLE a ADD val INT
 
-query II rowsort
-SELECT "targetID", "reportingID" FROM system.eventlog
+query IIT rowsort
+SELECT "targetID", "reportingID", info::JSONB->>'TableName' FROM system.eventlog
 WHERE "eventType" = 'alter_table'
 ----
-4  1
-51 1
+4  1 system.public.users
+51 1 test.public.a
 
 query II rowsort
 SELECT "targetID", "reportingID" FROM system.eventlog
@@ -93,33 +93,33 @@ WHERE "eventType" = 'reverse_schema_change'
 # Verify the contents of the 'Info' field of each log message using a LIKE
 # statement.
 ##################
-query II
-SELECT "targetID", "reportingID" FROM system.eventlog
+query IIT
+SELECT "targetID", "reportingID", info::JSONB->>'TableName' FROM system.eventlog
 WHERE "eventType" = 'alter_table'
-  AND info LIKE '%ALTER TABLE test.public.a%'
+  AND info::JSONB->>'Statement' LIKE 'ALTER TABLE a%'
 ----
-51 1
+51 1 test.public.a
 
 # Add a UNIQUE constraint to the table in a way that will ensure the schema
 # change is reversed.
 ##################
 
 statement ok
-INSERT INTO test.a VALUES (1, 1), (2, 1)
+INSERT INTO a VALUES (1, 1), (2, 1)
 
 statement error pq: duplicate key value \(val\)=\(1\) violates unique constraint \"foo\"
-ALTER TABLE test.a ADD CONSTRAINT foo UNIQUE(val)
+ALTER TABLE a ADD CONSTRAINT foo UNIQUE(val)
 
-query II rowsort
-SELECT "targetID", "reportingID" FROM system.eventlog
+query IIT rowsort
+SELECT "targetID", "reportingID", info::JSONB->>'TableName' FROM system.eventlog
 WHERE "eventType" = 'alter_table'
 ----
-4  1
-51 1
-51 1
+4  1 system.public.users
+51 1 test.public.a
+51 1 test.public.a
 
 query II rowsort
-SELECT "targetID", "reportingID" FROM system.eventlog
+SELECT "targetID", "reportingID"  FROM system.eventlog
 WHERE "eventType" = 'finish_schema_change'
 ----
 4  1
@@ -142,14 +142,14 @@ WHERE "eventType" = 'finish_schema_change_rollback'
 #################
 
 statement ok
-CREATE INDEX a_foo ON test.a (val)
+CREATE INDEX a_foo ON a (val)
 
-query II
-SELECT "targetID", "reportingID" FROM system.eventlog
+query IIT
+SELECT "targetID", "reportingID", info::JSONB->>'TableName' FROM system.eventlog
 WHERE "eventType" = 'create_index'
-  AND info LIKE '%a_foo%'
+  AND info::JSONB->>'Statement' LIKE 'CREATE INDEX a_foo%'
 ----
-51 1
+51 1 test.public.a
 
 query II rowsort
 SELECT "targetID", "reportingID" FROM system.eventlog
@@ -163,14 +163,14 @@ WHERE "eventType" = 'finish_schema_change'
 #################
 
 statement ok
-DROP INDEX test.a@a_foo
+DROP INDEX a@a_foo
 
-query II
-SELECT "targetID", "reportingID" FROM system.eventlog
+query IIT
+SELECT "targetID", "reportingID", info::JSONB->>'TableName' FROM system.eventlog
 WHERE "eventType" = 'drop_index'
-  AND info LIKE '%a_foo%'
+  AND info::JSONB->>'Statement' LIKE 'DROP INDEX%a_foo'
 ----
-51 1
+51 1 test.public.a
 
 query II rowsort
 SELECT "targetID", "reportingID" FROM system.eventlog
@@ -185,45 +185,45 @@ WHERE "eventType" = 'finish_schema_change'
 ##################
 
 statement ok
-DROP TABLE test.a
+DROP TABLE a
 
 statement ok
-DROP TABLE IF EXISTS test.b
+DROP TABLE IF EXISTS b
 
 statement ok
-DROP TABLE IF EXISTS test.b
+DROP TABLE IF EXISTS b
 
 
 # Verify that two drop table events were logged - the second IF EXISTS statement
 # should have failed.
 ##################
 
-query II rowsort
-SELECT "targetID", "reportingID"
+query IIT rowsort
+SELECT "targetID", "reportingID", info::JSONB->>'TableName'
 FROM system.eventlog
 WHERE "eventType" = 'drop_table'
 ----
-51 1
-52 1
+51 1 test.public.a
+52 1 test.public.b
 
 # Verify the contents of the 'info' field of each event.
 ##################
 
-query II
-SELECT "targetID", "reportingID"
+query IIT
+SELECT "targetID", "reportingID", info::JSONB->>'TableName'
 FROM system.eventlog
 WHERE "eventType" = 'drop_table'
-  AND info LIKE '%DROP TABLE test.a%'
+  AND info::JSONB->>'Statement' LIKE 'DROP TABLE a%'
 ----
-51 1
+51 1 test.public.a
 
-query II
-SELECT "targetID", "reportingID"
+query IIT
+SELECT "targetID", "reportingID", info::JSONB->>'TableName'
 FROM system.eventlog
 WHERE "eventType" = 'drop_table'
-  AND info LIKE '%DROP TABLE IF EXISTS test.b%'
+  AND info::JSONB->>'Statement' LIKE 'DROP TABLE IF EXISTS b%'
 ----
-52 1
+52 1 test.public.b
 
 
 ##################
@@ -250,7 +250,7 @@ query II
 SELECT "targetID", "reportingID"
 FROM system.eventlog
 WHERE "eventType" = 'create_database'
-  AND info LIKE '%CREATE DATABASE eventlogtest%'
+  AND info::JSONB->>'Statement' LIKE 'CREATE DATABASE eventlogtest%'
 ----
 53 1
 
@@ -258,7 +258,7 @@ query II
 SELECT "targetID", "reportingID"
 FROM system.eventlog
 WHERE "eventType" = 'create_database'
-  AND info LIKE '%CREATE DATABASE IF NOT EXISTS othereventlogtest%'
+  AND info::JSONB->>'Statement' LIKE 'CREATE DATABASE IF NOT EXISTS othereventlogtest%'
 ----
 54 1
 
@@ -289,32 +289,26 @@ DROP DATABASE IF EXISTS othereventlogtest CASCADE
 # verify contents of drop event
 ##################
 
-query II
-SELECT "targetID", "reportingID"
-FROM system.eventlog
-WHERE "eventType" = 'drop_database'
-  AND info LIKE '%DROP DATABASE eventlogtest%'
-----
-53 1
+# verify event is there, and cascading table drops are logged.
 
-query II
-SELECT "targetID", "reportingID"
+query IIT
+SELECT "targetID", "reportingID", info::JSONB->>'DroppedTablesAndViews'
 FROM system.eventlog
 WHERE "eventType" = 'drop_database'
-  AND info LIKE '%DROP DATABASE IF EXISTS othereventlogtest%'
+  AND info::JSONB->>'Statement' LIKE 'DROP DATABASE eventlogtest%'
 ----
-54 1
+53 1 ["eventlogtest.public.anothertesttable", "eventlogtest.public.testtable"]
 
-# verify cascading table drops are logged.
-##################
-query II
-SELECT "targetID", "reportingID"
+query IIT
+SELECT "targetID", "reportingID", info::JSONB->>'DroppedTablesAndViews'
 FROM system.eventlog
 WHERE "eventType" = 'drop_database'
-  AND info LIKE '%testtable%'
-  AND info LIKE '%anothertesttable%'
+  AND info::JSONB->>'Statement' LIKE 'DROP DATABASE IF EXISTS othereventlogtest%'
 ----
-53 1
+54 1 []
+
+statement ok
+SET DATABASE = test
 
 ##################
 # Cluster Settings
@@ -342,3 +336,39 @@ ORDER BY "timestamp"
 0  1  {"SettingName":"cluster.secret","Value":"gen_random_uuid()::STRING","User":"node"}
 0  1  {"SettingName":"kv.allocator.load_based_lease_rebalancing.enabled","Value":"false","User":"root"}
 0  1  {"SettingName":"kv.allocator.load_based_lease_rebalancing.enabled","Value":"DEFAULT","User":"root"}
+
+# Sequences
+
+statement ok
+CREATE SEQUENCE s
+
+statement ok
+ALTER SEQUENCE s START 10
+
+statement ok
+DROP SEQUENCE s
+
+query TIIT rowsort
+SELECT "eventType", "targetID", "reportingID", info::JSONB->>'SequenceName'
+  FROM system.eventlog
+ WHERE "eventType" in ('create_sequence', 'alter_sequence', 'drop_sequence')
+----
+create_sequence  57  1  test.public.s
+alter_sequence   57  1  test.public.s
+drop_sequence    57  1  test.public.s
+
+# Views
+
+statement ok
+CREATE VIEW v AS SELECT 1
+
+statement ok
+DROP VIEW v
+
+query TIIT rowsort
+SELECT "eventType", "targetID", "reportingID", info::JSONB->>'ViewName'
+  FROM system.eventlog
+ WHERE "eventType" in ('create_view', 'drop_view')
+----
+drop_view    58  1  test.public.v
+create_view  58  1  test.public.v

--- a/pkg/sql/pgwire/pgwire_test.go
+++ b/pkg/sql/pgwire/pgwire_test.go
@@ -1114,88 +1114,88 @@ func TestPGPreparedExec(t *testing.T) {
 			},
 		},
 		{
-			"CREATE TABLE d.t (i INT, s STRING, d INT)",
+			"CREATE TABLE d.public.t (i INT, s STRING, d INT)",
 			[]preparedExecTest{
 				baseTest,
 				baseTest.Error(`pq: relation "t" already exists`),
 			},
 		},
 		{
-			"INSERT INTO d.t VALUES ($1, $2, $3)",
+			"INSERT INTO d.public.t VALUES ($1, $2, $3)",
 			[]preparedExecTest{
 				baseTest.SetArgs(1, "one", 2).RowsAffected(1),
 				baseTest.SetArgs("two", 2, 2).Error(`pq: error in argument for $1: strconv.ParseInt: parsing "two": invalid syntax`),
 			},
 		},
 		{
-			"UPDATE d.t SET s = $1, i = i + $2, d = 1 + $3 WHERE i = $4",
+			"UPDATE d.public.t SET s = $1, i = i + $2, d = 1 + $3 WHERE i = $4",
 			[]preparedExecTest{
 				baseTest.SetArgs(4, 3, 2, 1).RowsAffected(1),
 			},
 		},
 		{
-			"UPDATE d.t SET i = $1 WHERE (i, s) = ($2, $3)",
+			"UPDATE d.public.t SET i = $1 WHERE (i, s) = ($2, $3)",
 			[]preparedExecTest{
 				baseTest.SetArgs(8, 4, "4").RowsAffected(1),
 			},
 		},
 		{
-			"DELETE FROM d.t WHERE s = $1 and i = $2 and d = 2 + $3",
+			"DELETE FROM d.public.t WHERE s = $1 and i = $2 and d = 2 + $3",
 			[]preparedExecTest{
 				baseTest.SetArgs(1, 2, 3).RowsAffected(0),
 			},
 		},
 		{
-			"INSERT INTO d.t VALUES ($1), ($2)",
+			"INSERT INTO d.public.t VALUES ($1), ($2)",
 			[]preparedExecTest{
 				baseTest.SetArgs(1, 2).RowsAffected(2),
 			},
 		},
 		{
-			"INSERT INTO d.t VALUES ($1), ($2) RETURNING $3 + 1",
+			"INSERT INTO d.public.t VALUES ($1), ($2) RETURNING $3 + 1",
 			[]preparedExecTest{
 				baseTest.SetArgs(3, 4, 5).RowsAffected(2),
 			},
 		},
 		{
-			"UPDATE d.t SET i = CASE WHEN $1 THEN i-$3 WHEN $2 THEN i+$3 END",
+			"UPDATE d.public.t SET i = CASE WHEN $1 THEN i-$3 WHEN $2 THEN i+$3 END",
 			[]preparedExecTest{
 				baseTest.SetArgs(true, true, 3).RowsAffected(5),
 			},
 		},
 		{
-			"UPDATE d.t SET i = CASE i WHEN $1 THEN i-$3 WHEN $2 THEN i+$3 END",
+			"UPDATE d.public.t SET i = CASE i WHEN $1 THEN i-$3 WHEN $2 THEN i+$3 END",
 			[]preparedExecTest{
 				baseTest.SetArgs(1, 2, 3).RowsAffected(5),
 			},
 		},
 		{
-			"UPDATE d.t SET d = CASE WHEN TRUE THEN $1 END",
+			"UPDATE d.public.t SET d = CASE WHEN TRUE THEN $1 END",
 			[]preparedExecTest{
 				baseTest.SetArgs(2).RowsAffected(5),
 			},
 		},
 		{
-			"DELETE FROM d.t RETURNING $1+1",
+			"DELETE FROM d.public.t RETURNING $1+1",
 			[]preparedExecTest{
 				baseTest.SetArgs(1).RowsAffected(5),
 			},
 		},
 		{
-			"DROP TABLE d.t",
+			"DROP TABLE d.public.t",
 			[]preparedExecTest{
 				baseTest,
-				baseTest.Error(`pq: relation "d.t" does not exist`),
+				baseTest.Error(`pq: relation "d.public.t" does not exist`),
 			},
 		},
 		{
-			"CREATE TABLE d.types (i int, f float, s string, b bytes, d date, m timestamp, z timestamp with time zone, n interval, o bool, e decimal)",
+			"CREATE TABLE d.public.types (i int, f float, s string, b bytes, d date, m timestamp, z timestamp with time zone, n interval, o bool, e decimal)",
 			[]preparedExecTest{
 				baseTest,
 			},
 		},
 		{
-			"INSERT INTO d.types VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)",
+			"INSERT INTO d.public.types VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)",
 			[]preparedExecTest{
 				baseTest.RowsAffected(1).SetArgs(
 					int64(0),

--- a/pkg/sql/resolver.go
+++ b/pkg/sql/resolver.go
@@ -73,6 +73,10 @@ func GetObjectNames(
 // ResolveExistingObject looks up an existing object.
 // If required is true, an error is returned if the object does not exist.
 // Optionally, if a desired descriptor type is specified, that type is checked.
+//
+// The object name is modified in-place with the result of the name
+// resolution, if successful. It is not modified in case of error or
+// if no object is found.
 func ResolveExistingObject(
 	ctx context.Context, sc SchemaResolver, tn *ObjectName, required bool, requiredType requiredType,
 ) (res *ObjectDescriptor, err error) {
@@ -136,6 +140,9 @@ type resolveFlags struct {
 // ResolveTargetObject determines a valid target path for an object
 // that may not exist yet. It returns the descriptor for the database
 // where the target object lives.
+//
+// The object name is modified in-place with the result of the name
+// resolution.
 func ResolveTargetObject(
 	ctx context.Context, sc SchemaResolver, tn *ObjectName,
 ) (res *DatabaseDescriptor, err error) {

--- a/pkg/sql/resolver.go
+++ b/pkg/sql/resolver.go
@@ -154,7 +154,7 @@ func ResolveTargetObject(
 		return nil, pgerror.NewErrorf(pgerror.CodeInvalidNameError,
 			"invalid target name: %q", tree.ErrString(tn))
 	}
-	if tn.Schema() != "public" {
+	if tn.Schema() != tree.PublicSchema {
 		return nil, sqlbase.NewUnsupportedSchemaUsageError(tree.ErrString(tn))
 	}
 	return descI.(*DatabaseDescriptor), nil

--- a/pkg/sql/sem/tree/table_name.go
+++ b/pkg/sql/sem/tree/table_name.go
@@ -88,6 +88,12 @@ func (t *TableName) Format(ctx *FmtCtx) {
 }
 func (t *TableName) String() string { return AsString(t) }
 
+// FQString renders the table name in full, not omitting the prefix
+// schema and catalog names. Suitable for logging, etc.
+func (t *TableName) FQString() string {
+	return AsStringWithFlags(t, FmtAlwaysQualifyTableNames)
+}
+
 // Table retrieves the unqualified table name.
 func (t *TableName) Table() string {
 	return string(t.TableName)


### PR DESCRIPTION
Prior to this patch, the table/view/sequence name logged into the
event log for create/drop/alter events etc. would only contain the
short name of the object (or, in some case, the *specified* name prior
to name resolution).

This is insufficient because if the same object exists in multiple
databases it becomes ambiguous which object is being targeted. This
makes the event log e.g. in the admin UI much less usable.

This patch enhances the situation by ensuring the FQN name is logged
into the event log in most cases. This is also verified by better
logic tests on the event log data that properly utilize the new JSONB
type.

Release note (sql change): the full name of tables/view/sequences is
now properly logged in the system event log.

Will cherry-pick into 2.0.