### PR TITLE
roachtest: add support for starting a cluster with store dir snapshot

### DIFF
--- a/pkg/ccl/workloadccl/fixture_test.go
+++ b/pkg/ccl/workloadccl/fixture_test.go
@@ -94,16 +94,16 @@ func TestFixture(t *testing.T) {
 		t.Fatalf(`%+v`, err)
 	}
 
-	store := FixtureStore{
+	config := FixtureConfig{
 		GCSBucket: gcsBucket,
 		GCSPrefix: fmt.Sprintf(`TestFixture-%d`, timeutil.Now().UnixNano()),
 	}
 
-	if _, err := GetFixture(ctx, gcs, store, gen); !testutils.IsError(err, `fixture not found`) {
+	if _, err := GetFixture(ctx, gcs, config, gen); !testutils.IsError(err, `fixture not found`) {
 		t.Fatalf(`expected "fixture not found" error but got: %+v`, err)
 	}
 
-	fixtures, err := ListFixtures(ctx, gcs, store)
+	fixtures, err := ListFixtures(ctx, gcs, config)
 	if err != nil {
 		t.Fatalf(`%+v`, err)
 	}
@@ -111,17 +111,17 @@ func TestFixture(t *testing.T) {
 		t.Errorf(`expected no fixtures but got: %+v`, fixtures)
 	}
 
-	fixture, err := MakeFixture(ctx, sqlDB.DB, gcs, store, gen)
+	fixture, err := MakeFixture(ctx, sqlDB.DB, gcs, config, gen)
 	if err != nil {
 		t.Fatalf(`%+v`, err)
 	}
 
-	_, err = MakeFixture(ctx, sqlDB.DB, gcs, store, gen)
+	_, err = MakeFixture(ctx, sqlDB.DB, gcs, config, gen)
 	if !testutils.IsError(err, `already exists`) {
 		t.Fatalf(`expected 'already exists' error got: %+v`, err)
 	}
 
-	fixtures, err = ListFixtures(ctx, gcs, store)
+	fixtures, err = ListFixtures(ctx, gcs, config)
 	if err != nil {
 		t.Fatalf(`%+v`, err)
 	}

--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -40,13 +40,13 @@ import (
 )
 
 var (
-	local       bool
-	artifacts   string
-	cockroach   string
-	workload    string
-	clusterName string
-	clusterID   string
-	username    = os.Getenv("ROACHPROD_USER")
+	local         bool
+	artifacts     string
+	cockroachPath string
+	workloadPath  string
+	clusterName   string
+	clusterID     string
+	username      = os.Getenv("ROACHPROD_USER")
 )
 
 func ifLocal(trueVal, falseVal string) string {
@@ -91,12 +91,12 @@ func findBinary(binary, defValue string) (string, error) {
 
 func initBinaries() {
 	var err error
-	cockroach, err = findBinary(cockroach, "cockroach")
+	cockroachPath, err = findBinary(cockroachPath, "cockroach")
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
-	workload, err = findBinary(workload, "workload")
+	workloadPath, err = findBinary(workloadPath, "workload")
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
@@ -327,7 +327,7 @@ func (c *cluster) All() nodeListOption {
 	return c.Range(1, c.nodes)
 }
 
-// All returns a node list containing the nodes [begin,end].
+// Range returns a node list containing the nodes [begin,end].
 func (c *cluster) Range(begin, end int) nodeListOption {
 	if begin < 1 || end > c.nodes {
 		c.t.Fatalf("invalid node range: %d-%d (1-%d)", begin, end, c.nodes)
@@ -339,7 +339,7 @@ func (c *cluster) Range(begin, end int) nodeListOption {
 	return r
 }
 
-// All returns a node list containing only the node i.
+// Node returns a node list containing only the node i.
 func (c *cluster) Node(i int) nodeListOption {
 	return c.Range(i, i)
 }
@@ -443,9 +443,7 @@ func (c *cluster) Wipe(ctx context.Context, opts ...option) {
 	}
 }
 
-// TODO(pmattis): cluster.Stop and cluster.Wipe are neither used or
-// tested. Silence unused warning.
-var _ = (*cluster).Stop
+// TODO(pmattis): cluster.Wipe is not used or tested. Silence unused warning.
 var _ = (*cluster).Wipe
 
 // Run a command on the specified node.

--- a/pkg/cmd/roachtest/import.go
+++ b/pkg/cmd/roachtest/import.go
@@ -38,7 +38,7 @@ func init() {
 		m := newMonitor(ctx, c, c.Range(1, nodes))
 		m.Go(func(ctx context.Context) error {
 			cmd := fmt.Sprintf(
-				`./workload fixtures store tpcc --warehouses=%d --csv-server='http://localhost:8081' `+
+				`./workload fixtures make tpcc --warehouses=%d --csv-server='http://localhost:8081' `+
 					`--gcs-bucket-override=cockroachdb-backup-testing --gcs-prefix-override=%s`,
 				warehouses, c.name)
 			c.Run(ctx, 1, cmd)

--- a/pkg/cmd/roachtest/kv.go
+++ b/pkg/cmd/roachtest/kv.go
@@ -27,8 +27,8 @@ func init() {
 		c := newCluster(ctx, t, nodes+1, "--local-ssd")
 		defer c.Destroy(ctx)
 
-		c.Put(ctx, cockroach, "./cockroach", c.Range(1, nodes))
-		c.Put(ctx, workload, "./workload", c.Node(nodes+1))
+		c.Put(ctx, cockroachPath, "./cockroach", c.Range(1, nodes))
+		c.Put(ctx, workloadPath, "./workload", c.Node(nodes+1))
 		c.Start(ctx, c.Range(1, nodes))
 
 		t.Status("running workload")
@@ -65,8 +65,8 @@ func init() {
 		c := newCluster(ctx, t, nodes+1, "--local-ssd")
 		defer c.Destroy(ctx)
 
-		c.Put(ctx, cockroach, "./cockroach", c.Range(1, nodes))
-		c.Put(ctx, workload, "./workload", c.Node(nodes+1))
+		c.Put(ctx, cockroachPath, "./cockroach", c.Range(1, nodes))
+		c.Put(ctx, workloadPath, "./workload", c.Node(nodes+1))
 		c.Start(ctx, c.Range(1, nodes))
 
 		t.Status("running workload")
@@ -111,8 +111,8 @@ func init() {
 			wg.Wait()
 		}
 
-		c.Put(ctx, cockroach, "./cockroach", c.Range(1, nodes))
-		c.Put(ctx, workload, "./workload", c.Node(nodes+1))
+		c.Put(ctx, cockroachPath, "./cockroach", c.Range(1, nodes))
+		c.Put(ctx, workloadPath, "./workload", c.Node(nodes+1))
 
 		const maxPerNodeConcurrency = 64
 		for i := nodes; i <= nodes*maxPerNodeConcurrency; i += nodes {

--- a/pkg/cmd/roachtest/main.go
+++ b/pkg/cmd/roachtest/main.go
@@ -66,11 +66,11 @@ func main() {
 	runCmd.Flags().StringVar(
 		&clusterID, "cluster-id", "", "an identifier to use in the test cluster's name")
 	runCmd.Flags().StringVar(
-		&cockroach, "cockroach", "", "path to cockroach binary to use")
+		&cockroachPath, "cockroach", "", "path to cockroach binary to use")
 	runCmd.Flags().StringVarP(
 		&username, "user", "u", username, "username to run under, detect if blank")
 	runCmd.Flags().StringVar(
-		&workload, "workload", "", "path to workload binary to use")
+		&workloadPath, "workload", "", "path to workload binary to use")
 
 	if err := rootCmd.Execute(); err != nil {
 		// Cobra has already printed the error message.

--- a/pkg/cmd/roachtest/roachmart.go
+++ b/pkg/cmd/roachtest/roachmart.go
@@ -26,8 +26,8 @@ func init() {
 		c := newCluster(ctx, t, 9, "--geo")
 		defer c.Destroy(ctx)
 
-		c.Put(ctx, cockroach, "./cockroach")
-		c.Put(ctx, workload, "./workload")
+		c.Put(ctx, cockroachPath, "./cockroach")
+		c.Put(ctx, workloadPath, "./workload")
 		c.Start(ctx)
 
 		// TODO(benesch): avoid hardcoding this list.

--- a/pkg/cmd/roachtest/storedir.go
+++ b/pkg/cmd/roachtest/storedir.go
@@ -1,0 +1,79 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+
+package main
+
+import (
+	"context"
+	"sync"
+
+	"github.com/cockroachdb/cockroach/pkg/ccl/workloadccl"
+	"github.com/cockroachdb/cockroach/pkg/workload"
+)
+
+const (
+	gcsURLScheme  = `gs`
+	gcsTestBucket = `cockroachdb-backup-testing`
+)
+
+func fixtureConfig() workloadccl.FixtureConfig {
+	return workloadccl.FixtureConfig{
+		GCSBucket: `cockroach-fixtures`,
+		GCSPrefix: `workload`,
+	}
+}
+
+// TODO(dan): There should be tooling for making these snapshots (and it should
+// be much less roundabout). In the meantime, manually run something like the
+// following:
+//
+// roachprod create <cluster> -n <nodes>
+// roachprod put <cluster> <linux build of cockroach> cockroach
+// roachprod put <cluster> <linux build of workload> workload
+// roachprod start <cluster>
+// for i in {1..<nodes>}; do roachprod ssh <cluster>:$i -- './workload csv-server --port=8081 &> logs/workload-csv-server.log < /dev/null &'; done
+// roachprod ssh <cluster>:1 -- ./workload fixtures make <workload and flags> --csv-server=http://localhost:8081
+// roachprod ssh <cluster>:1 -- ./workload fixtures load <workload and flags>
+// for i in {1..<nodes>}; do roachprod ssh <cluster>:$i -- 'tar czf - -C /mnt/data1/cockroach . | gsutil cp - `./workload fixtures store-dir <workload and flags> $i <nodes>`'
+// roachprod destroy <cluster>
+
+// RestoreStoreDirSnapshots completely overwrites the store directories of every
+// node in the cluster with a previously taken .tgz snapshot stored in GCS.
+func (c *cluster) RestoreStoreDirSnapshots(ctx context.Context, gen workload.Generator) {
+	if c.isLocal() {
+		c.t.Fatal(`TODO(dan): support store dir snapshots on local clusters`)
+	}
+
+	var wg sync.WaitGroup
+	for node := 1; node <= c.nodes; node++ {
+		node := node
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+
+			// Assumes cluster configuration of 1 store per node.
+			storeIdx, numStores := node-1, c.nodes
+			path := workloadccl.StoreDir(fixtureConfig(), gen, storeIdx, numStores)
+
+			c.Stop(ctx, c.Node(node))
+			// TODO(dan): Get this path from roachprod instead of hardcoding it.
+			c.Run(ctx, node, `rm -rf /mnt/data1/cockroach/*`)
+			c.Run(ctx, node, `mkdir -p /mnt/data1/cockroach`)
+			cmd := `gsutil cat ` + path + ` | tar xvzf - -C /mnt/data1/cockroach/`
+			c.Run(ctx, node, cmd)
+		}()
+	}
+	wg.Wait()
+}

--- a/pkg/cmd/roachtest/tpcc.go
+++ b/pkg/cmd/roachtest/tpcc.go
@@ -26,8 +26,8 @@ func init() {
 		c := newCluster(ctx, t, nodes+1)
 		defer c.Destroy(ctx)
 
-		c.Put(ctx, cockroach, "./cockroach", c.Range(1, nodes))
-		c.Put(ctx, workload, "./workload", c.Node(nodes+1))
+		c.Put(ctx, cockroachPath, "./cockroach", c.Range(1, nodes))
+		c.Put(ctx, workloadPath, "./workload", c.Node(nodes+1))
 		c.Start(ctx, c.Range(1, nodes))
 
 		t.Status("running workload")

--- a/pkg/cmd/workload/fixtures.go
+++ b/pkg/cmd/workload/fixtures.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	gosql "database/sql"
 	"fmt"
+	"strconv"
 
 	"cloud.google.com/go/storage"
 	"github.com/pkg/errors"
@@ -38,6 +39,18 @@ var useast1bFixtures = workloadccl.FixtureConfig{
 	GCSPrefix: `workload`,
 }
 
+func config() workloadccl.FixtureConfig {
+	config := useast1bFixtures
+	if len(*gcsBucketOverride) > 0 {
+		config.GCSBucket = *gcsBucketOverride
+	}
+	if len(*gcsPrefixOverride) > 0 {
+		config.GCSPrefix = *gcsPrefixOverride
+	}
+	config.CSVServerURL = *fixturesMakeCSVServerURL
+	return config
+}
+
 var fixturesCmd = &cobra.Command{Use: `fixtures`}
 var fixturesListCmd = &cobra.Command{
 	Use:   `list`,
@@ -49,9 +62,13 @@ var fixturesMakeCmd = &cobra.Command{
 	Short: `Regenerate and store a fixture on GCS`,
 }
 var fixturesLoadCmd = &cobra.Command{
-	Use: `load`,
-	Short: `Load a fixture into a running cluster. ` +
-		`An enterprise license is required.`,
+	Use:   `load`,
+	Short: `Load a fixture into a running cluster. An enterprise license is required.`,
+}
+var fixturesStoreDirCmd = &cobra.Command{
+	Use: `store-dir`,
+	Short: `URL for a tar-gzip'd snapshot of a CockroachDB store directory ` +
+		`from a cluster with the initial tables of a fixture loaded.`,
 }
 
 var fixturesMakeCSVServerURL = fixturesMakeCmd.PersistentFlags().String(
@@ -62,10 +79,10 @@ var fixturesMakeCSVServerURL = fixturesMakeCmd.PersistentFlags().String(
 var gcsBucketOverride, gcsPrefixOverride *string
 
 func init() {
-	gcsBucketOverride = fixturesMakeCmd.PersistentFlags().String(`gcs-bucket-override`, ``, ``)
-	gcsPrefixOverride = fixturesMakeCmd.PersistentFlags().String(`gcs-prefix-override`, ``, ``)
-	_ = fixturesMakeCmd.PersistentFlags().MarkHidden(`gcs-bucket-override`)
-	_ = fixturesMakeCmd.PersistentFlags().MarkHidden(`gcs-prefix-override`)
+	gcsBucketOverride = fixturesCmd.PersistentFlags().String(`gcs-bucket-override`, ``, ``)
+	gcsPrefixOverride = fixturesCmd.PersistentFlags().String(`gcs-prefix-override`, ``, ``)
+	_ = fixturesCmd.PersistentFlags().MarkHidden(`gcs-bucket-override`)
+	_ = fixturesCmd.PersistentFlags().MarkHidden(`gcs-prefix-override`)
 }
 
 var fixturesLoadDB = fixturesLoadCmd.PersistentFlags().String(
@@ -91,6 +108,15 @@ func init() {
 		var genFlags *pflag.FlagSet
 		if f, ok := gen.(workload.Flagser); ok {
 			genFlags = f.Flags().FlagSet
+			// Hide runtime-only flags so they don't clutter up the help text,
+			// but don't remove them entirely so if someone switches from
+			// `./workload run` to `./workload fixtures` they don't have to
+			// remove them from the invocation.
+			for flagName, meta := range f.Flags().Meta {
+				if meta.RuntimeOnly {
+					_ = genFlags.MarkHidden(flagName)
+				}
+			}
 		}
 
 		genMakeCmd := &cobra.Command{
@@ -98,12 +124,12 @@ func init() {
 			Args: cobra.RangeArgs(0, 1),
 		}
 		genMakeCmd.Flags().AddFlagSet(genFlags)
-		genMakeCmd.RunE = func(cmd *cobra.Command, args []string) error {
+		genMakeCmd.RunE = func(_ *cobra.Command, args []string) error {
 			crdb := crdbDefaultURI
 			if len(args) > 0 {
 				crdb = args[0]
 			}
-			return fixturesMake(cmd, gen, crdb)
+			return fixturesMake(gen, crdb)
 		}
 		fixturesMakeCmd.AddCommand(genMakeCmd)
 
@@ -112,29 +138,52 @@ func init() {
 			Args: cobra.RangeArgs(0, 1),
 		}
 		genLoadCmd.Flags().AddFlagSet(genFlags)
-		genLoadCmd.RunE = func(cmd *cobra.Command, args []string) error {
+		genLoadCmd.RunE = func(_ *cobra.Command, args []string) error {
 			crdb := crdbDefaultURI
 			if len(args) > 0 {
 				crdb = args[0]
 			}
-			return fixturesLoad(cmd, gen, crdb)
+			return fixturesLoad(gen, crdb)
 		}
 		fixturesLoadCmd.AddCommand(genLoadCmd)
+
+		genStoreDirCmd := &cobra.Command{
+			Use:  meta.Name + ` [STORE IDX] [NUM STORES]`,
+			Args: cobra.ExactArgs(2),
+		}
+		genStoreDirCmd.Flags().AddFlagSet(genFlags)
+		genStoreDirCmd.RunE = func(cmd *cobra.Command, args []string) error {
+			storeIdx, err := strconv.Atoi(args[0])
+			if err != nil {
+				return err
+			}
+			numStores, err := strconv.Atoi(args[1])
+			if err != nil {
+				return err
+			}
+			if storeIdx < 0 || numStores <= 0 || storeIdx >= numStores {
+				return cmd.Usage()
+			}
+			fmt.Println(workloadccl.StoreDir(config(), gen, storeIdx, numStores))
+			return nil
+		}
+		fixturesStoreDirCmd.AddCommand(genStoreDirCmd)
 	}
 	fixturesCmd.AddCommand(fixturesListCmd)
 	fixturesCmd.AddCommand(fixturesMakeCmd)
 	fixturesCmd.AddCommand(fixturesLoadCmd)
+	fixturesCmd.AddCommand(fixturesStoreDirCmd)
 	rootCmd.AddCommand(fixturesCmd)
 }
 
-func fixturesList(cmd *cobra.Command, _ []string) error {
+func fixturesList(_ *cobra.Command, _ []string) error {
 	ctx := context.Background()
 	gcs, err := getStorage(ctx)
 	if err != nil {
 		return err
 	}
 	defer func() { _ = gcs.Close() }()
-	fixtures, err := workloadccl.ListFixtures(ctx, gcs, useast1bFixtures)
+	fixtures, err := workloadccl.ListFixtures(ctx, gcs, config())
 	if err != nil {
 		return err
 	}
@@ -144,7 +193,7 @@ func fixturesList(cmd *cobra.Command, _ []string) error {
 	return nil
 }
 
-func fixturesMake(cmd *cobra.Command, gen workload.Generator, crdbURI string) error {
+func fixturesMake(gen workload.Generator, crdbURI string) error {
 	ctx := context.Background()
 	gcs, err := getStorage(ctx)
 	if err != nil {
@@ -156,15 +205,7 @@ func fixturesMake(cmd *cobra.Command, gen workload.Generator, crdbURI string) er
 	if err != nil {
 		return err
 	}
-	config := useast1bFixtures
-	if len(*gcsBucketOverride) > 0 {
-		config.GCSBucket = *gcsBucketOverride
-	}
-	if len(*gcsPrefixOverride) > 0 {
-		config.GCSPrefix = *gcsPrefixOverride
-	}
-	config.CSVServerURL = *fixturesMakeCSVServerURL
-	fixture, err := workloadccl.MakeFixture(ctx, sqlDB, gcs, config, gen)
+	fixture, err := workloadccl.MakeFixture(ctx, sqlDB, gcs, config(), gen)
 	if err != nil {
 		return err
 	}
@@ -174,7 +215,7 @@ func fixturesMake(cmd *cobra.Command, gen workload.Generator, crdbURI string) er
 	return nil
 }
 
-func fixturesLoad(cmd *cobra.Command, gen workload.Generator, crdbURI string) error {
+func fixturesLoad(gen workload.Generator, crdbURI string) error {
 	ctx := context.Background()
 	gcs, err := getStorage(ctx)
 	if err != nil {
@@ -190,7 +231,7 @@ func fixturesLoad(cmd *cobra.Command, gen workload.Generator, crdbURI string) er
 		return err
 	}
 
-	fixture, err := workloadccl.GetFixture(ctx, gcs, useast1bFixtures, gen)
+	fixture, err := workloadccl.GetFixture(ctx, gcs, config(), gen)
 	if err != nil {
 		return errors.Wrap(err, `finding fixture`)
 	}

--- a/pkg/cmd/workload/run.go
+++ b/pkg/cmd/workload/run.go
@@ -163,9 +163,9 @@ func sanitizeDBURL(dbURL string) (string, error) {
 	}
 	if strings.TrimPrefix(parsedURL.Path, "/") != "" {
 		return "", fmt.Errorf(
-			`database URL specifies database %q, but database "test" is always used`, parsedURL.Path)
+			`database URL specifies database %q, but database "workload" is always used`, parsedURL.Path)
 	}
-	parsedURL.Path = "test"
+	parsedURL.Path = "workload"
 
 	switch parsedURL.Scheme {
 	case "postgres", "postgresql":
@@ -213,11 +213,11 @@ func runInit(gen workload.Generator, args []string) error {
 
 func runInitImpl(gen workload.Generator, db *gosql.DB) error {
 	if *drop {
-		if _, err := db.Exec(`DROP DATABASE IF EXISTS test`); err != nil {
+		if _, err := db.Exec(`DROP DATABASE IF EXISTS workload`); err != nil {
 			return err
 		}
 	}
-	if _, err := db.Exec("CREATE DATABASE IF NOT EXISTS test"); err != nil {
+	if _, err := db.Exec("CREATE DATABASE IF NOT EXISTS workload"); err != nil {
 		return err
 	}
 

--- a/pkg/workload/bank/bank.go
+++ b/pkg/workload/bank/bank.go
@@ -83,12 +83,12 @@ func FromConfig(rows int, payloadBytes int, ranges int) workload.Generator {
 	if ranges > rows {
 		ranges = rows
 	}
-	return &bank{
-		seed:         timeutil.Now().UnixNano(),
-		rows:         rows,
-		payloadBytes: payloadBytes,
-		ranges:       ranges,
-	}
+	b := bankMeta.New().(*bank)
+	b.seed = timeutil.Now().UnixNano()
+	b.rows = rows
+	b.payloadBytes = payloadBytes
+	b.ranges = ranges
+	return b
 }
 
 // Meta implements the Generator interface.

--- a/pkg/workload/tpcc/tpcc.go
+++ b/pkg/workload/tpcc/tpcc.go
@@ -60,8 +60,9 @@ var tpccMeta = workload.Meta{
 		g.flags.Int64Var(&g.seed, `seed`, 1, `Random number generator seed`)
 		g.flags.IntVar(&g.warehouses, `warehouses`, 1, `Number of warehouses for loading`)
 		g.flags.BoolVar(&g.interleaved, `interleaved`, false, `Use interleaved tables`)
-		g.flags.StringVar(&g.nowString, `now`, `2006-01-02 15:04:05`,
-			`Timestamp to use in data generation`)
+		// Hardcode this since it doesn't seem like anyone will want to change
+		// it and it's really noisy in the generated fixture paths.
+		g.nowString = `2006-01-02 15:04:05`
 
 		g.flags.StringVar(&g.mix, `mix`,
 			`newOrder=45,payment=43,orderStatus=4,delivery=4,stockLevel=4`,


### PR DESCRIPTION
The motivating examples are things like the 2TB backup test and the
pkg/acceptance allocator tests. I'm still working on creating the 2TB
backup store directories, so this works through a very small example
backup test.

A couple small cleanups while I'm in here: copy `defaultRetryOptions`
from base, shaving a significant time off the compilation of
./pkg/cmd/workload and require "workload" instead of "test" as the
database when loading fixtures.

Release note: None