### PR TITLE
Fix typo in version_history.txt

### DIFF
--- a/pkg/sql/distsqlrun/version_history.txt
+++ b/pkg/sql/distsqlrun/version_history.txt
@@ -16,5 +16,5 @@
   - An InterleavedReaderJoiner processor was introduced to enable more
     efficient joins between interleaved tables. The new processor spec would be
     unrecognized by a server running older versions, hence the version bump.
-    Servers running v7 can still execute regular joins between interleaved
+    Servers running v8 can still execute regular joins between interleaved
     tables from servers running v6, thus the MinAcceptedVersion is kept at 6.


### PR DESCRIPTION
It appears that there is a typo in the version_history.txt file that
specified the wrong version. It appears that this line was copy and
pasted from the v7 comment, but the version number was not incremented.

Release note: None