### PR TITLE
opt: fix const value handling in execbuilder

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/scalar_builder.go
+++ b/pkg/sql/opt/exec/execbuilder/scalar_builder.go
@@ -87,9 +87,8 @@ func (b *Builder) buildVariable(ctx *buildScalarCtx, ev xform.ExprView) tree.Typ
 func (b *Builder) buildTuple(ctx *buildScalarCtx, ev xform.ExprView) tree.TypedExpr {
 	if xform.MatchesTupleOfConstants(ev) {
 		datums := make(tree.Datums, ev.ChildCount())
-		for i := 0; i < ev.ChildCount(); i++ {
-			child := ev.Child(i)
-			datums[i] = child.Private().(tree.Datum)
+		for i := range datums {
+			datums[i] = xform.ExtractConstDatum(ev.Child(i))
 		}
 		return tree.NewDTuple(datums...)
 	}

--- a/pkg/sql/opt/exec/execbuilder/testdata/scalar
+++ b/pkg/sql/opt/exec/execbuilder/testdata/scalar
@@ -32,6 +32,22 @@ render       0  render  ·         ·                 (column1)  ·
 ·            1  ·       size      0 columns, 1 row  ·          ·
 
 exec-explain
+SELECT (1, 2)
+----
+render       0  render  ·         ·                 (column1)  ·
+ │           0  ·       render 0  (1, 2)            ·          ·
+ └── values  1  values  ·         ·                 ()         ·
+·            1  ·       size      0 columns, 1 row  ·          ·
+
+exec-explain
+SELECT (true, false)
+----
+render       0  render  ·         ·                 (column1)  ·
+ │           0  ·       render 0  (true, false)     ·          ·
+ └── values  1  values  ·         ·                 ()         ·
+·            1  ·       size      0 columns, 1 row  ·          ·
+
+exec-explain
 SELECT 1 + 2 FROM t.t
 ----
 render     0  render  ·         ·          (column8)                          ·

--- a/pkg/sql/opt/xform/extract.go
+++ b/pkg/sql/opt/xform/extract.go
@@ -1,0 +1,40 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package xform
+
+import (
+	"fmt"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/opt"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+)
+
+// This file contains various helper functions that extract an
+// op-specific field from an ExprView.
+
+// ExtractConstDatum returns the Datum that represents the value
+// of an operator in the ConstValue group.
+func ExtractConstDatum(ev ExprView) tree.Datum {
+	switch ev.Operator() {
+	case opt.TrueOp:
+		return tree.DBoolTrue
+	case opt.FalseOp:
+		return tree.DBoolFalse
+	case opt.ConstOp:
+		return ev.Private().(tree.Datum)
+	default:
+		panic(fmt.Sprintf("non-const op %s", ev.Operator()))
+	}
+}


### PR DESCRIPTION
The exec builder panics if it's trying to build a tuple of const
values where values are not ConstOp (e.g. TrueOp).

We move the `getConstDatum` function to `xform.ExtractConstDatum` and
use it in the execbuilder.

Release note: None