### PR TITLE
roachtest: port 2TB restore test from pkg/acceptance

### DIFF
--- a/pkg/cmd/roachtest/restore.go
+++ b/pkg/cmd/roachtest/restore.go
@@ -1,0 +1,44 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+
+package main
+
+import (
+	"context"
+)
+
+func init() {
+	tests.Add(`restore2TB`, func(t *test) {
+		ctx := context.Background()
+		c := newCluster(ctx, t, 10)
+		defer c.Destroy(ctx)
+
+		c.Put(ctx, cockroach, "./cockroach")
+		c.Start(ctx)
+		m := newMonitor(ctx, c)
+		m.Go(func(ctx context.Context) error {
+			c.Run(ctx, 1, `./cockroach sql --insecure -e "CREATE DATABASE restore2tb"`)
+			c.status(`running 2tb restore`)
+			// TODO(dan): It'd be nice if we could keep track over time of how
+			// long this next line took.
+			c.Run(ctx, 1, `./cockroach sql --insecure -e "
+				RESTORE csv.bank FROM
+				'gs://cockroach-fixtures/workload/bank/version=1.0.0,payload-bytes=10240,ranges=0,rows=65104166,seed=1/bank'
+				WITH into_db = 'restore2tb'"`)
+			return nil
+		})
+		m.Wait()
+	})
+}


### PR DESCRIPTION
Still TODO is making it back into some sort of benchmark, but we never
used that anyway.

Release note: None