### PR TITLE
opt/idxconstraint: support normalization directives in tests

### DIFF
--- a/pkg/sql/opt/idxconstraint/testdata/all
+++ b/pkg/sql/opt/idxconstraint/testdata/all
@@ -372,21 +372,19 @@ index-constraints vars=(int) index=(@1 desc)
 [/2 - /2]
 [/1 - /1]
 
-# semtree-normalize,build-scalar,index-constraints vars=(int) index=(@1)
-#index-constraints vars=(int) index=(@1)
-#@1 IN (1, 5, 1, 4)
-#----
-#[/1 - /1]
-#[/4 - /4]
-#[/5 - /5]
+index-constraints vars=(int) index=(@1) semtree-normalize
+@1 IN (1, 5, 1, 4)
+----
+[/1 - /1]
+[/4 - /4]
+[/5 - /5]
 
-# semtree-normalize,build-scalar,index-constraints vars=(int) index=(@1 desc)
-#index-constraints vars=(int) index=(@1 desc)
-#@1 IN (1, 5, 1, 4)
-#----
-#[/5 - /5]
-#[/4 - /4]
-#[/1 - /1]
+index-constraints vars=(int) index=(@1 desc) semtree-normalize
+@1 IN (1, 5, 1, 4)
+----
+[/5 - /5]
+[/4 - /4]
+[/1 - /1]
 
 index-constraints vars=(int) index=(@1)
 @1 IN (1, 2, 3, NULL)
@@ -698,20 +696,18 @@ index-constraints vars=(int, int) index=(@1, @2)
 # Remaining filter: (@1, @2) <= (3, 4)
 
 
-# semtree-normalize,build-scalar,index-constraints vars=(int, int) index=(@1, @2)
-#index-constraints vars=(int, int) index=(@1, @2)
-#(@1, @2) BETWEEN (1, 2) AND (3, 4)
-#----
-#[/1/2 - /3/4]
+index-constraints vars=(int, int) index=(@1, @2) semtree-normalize
+(@1, @2) BETWEEN (1, 2) AND (3, 4)
+----
+[/1/2 - /3/4]
 
 # Remaining filter: (@1, @2) <= (3, 4)
 
 
-# semtree-normalize,build-scalar,index-constraints vars=(int, int, int, int) index=(@1, @2, @3, @4)
-#index-constraints vars=(int, int, int, int) index=(@1, @2, @3, @4)
-#(@1, @2, @4) BETWEEN (1, 2, 3) AND (4, 5, 6)
-#----
-#[/1/2 - /4/5]
+index-constraints vars=(int, int, int, int) index=(@1, @2, @3, @4) semtree-normalize
+(@1, @2, @4) BETWEEN (1, 2, 3) AND (4, 5, 6)
+----
+[/1/2 - /4/5]
 
 # Remaining filter: ((@1, @2, @4) >= (1, 2, 3)) AND ((@1, @2, @4) <= (4, 5, 6))
 
@@ -1242,8 +1238,7 @@ index-constraints vars=(int, int, int) index=(@1, @2, @3)
 # This testcase exposed an issue around extending spans. We don't normalize the
 # expression so we have a hierarchy of ANDs (which requires a more complex path
 # for calculating spans).
-# TODO(radu): disable normalization
-index-constraints vars=(int, int, int, int) index=(@1, @2, @3, @4)
+index-constraints vars=(int, int, int, int) index=(@1, @2, @3, @4) nonormalize
 @1 = 1 AND @2 = 2 AND @3 = 3 AND @4 IN (4,5,6)
 ----
 [/1/2/3/4 - /1/2/3/4]


### PR DESCRIPTION
Adding support for disabling the optimizer normalization and for
running TypedExpr normalization. Enabling the test cases that needed
this.

Release note: None