### PR TITLE
cherrypick-1.1: ui: exclude decommissioned nodes from cluster stats

### DIFF
--- a/pkg/ui/src/redux/nodes.ts
+++ b/pkg/ui/src/redux/nodes.ts
@@ -164,7 +164,7 @@ const nodeSumsSelector = createSelector(
             result.nodeCounts.dead++;
             break;
         }
-        if (status !== LivenessStatus.DEAD) {
+        if (status !== LivenessStatus.DEAD && status !== LivenessStatus.DECOMMISSIONED) {
           result.capacityUsed += n.metrics[MetricConstants.usedCapacity];
           result.capacityAvailable += n.metrics[MetricConstants.availableCapacity];
           result.capacityTotal += n.metrics[MetricConstants.capacity];


### PR DESCRIPTION
Fixes #22710, #19782
Release note (admin ui change): Fixes an issue where decommissioned nodes are included in cluster stats aggregates.

cc @cockroachdb/release, @vilterp 