### PR TITLE
sql: ensure that db DDL stmts look up descs uncached

### DIFF
--- a/pkg/sql/drop_database.go
+++ b/pkg/sql/drop_database.go
@@ -48,7 +48,11 @@ func (p *planner) DropDatabase(ctx context.Context, n *tree.DropDatabase) (planN
 	}
 
 	// Check that the database exists.
-	dbDesc, err := ResolveDatabase(ctx, p, string(n.Name), !n.IfExists)
+	var dbDesc *DatabaseDescriptor
+	var err error
+	p.runWithOptions(resolveFlags{skipCache: true}, func() {
+		dbDesc, err = ResolveDatabase(ctx, p, string(n.Name), !n.IfExists)
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/logictest/testdata/logic_test/database
+++ b/pkg/sql/logictest/testdata/logic_test/database
@@ -161,11 +161,5 @@ GRANT DROP ON DATABASE privs TO testuser
 
 user testuser
 
-# Wait for gossip to propagate the new version of the database descriptor.
-#
-# TODO: block the `GRANT` statement until the new version has been propagated.
-# See #22841.
-sleep 250ms
-
 statement ok
 DROP DATABASE privs CASCADE

--- a/pkg/sql/rename_database.go
+++ b/pkg/sql/rename_database.go
@@ -37,7 +37,11 @@ func (p *planner) RenameDatabase(ctx context.Context, n *tree.RenameDatabase) (p
 		return nil, err
 	}
 
-	dbDesc, err := ResolveDatabase(ctx, p, string(n.Name), true /*required*/)
+	var dbDesc *DatabaseDescriptor
+	var err error
+	p.runWithOptions(resolveFlags{skipCache: true}, func() {
+		dbDesc, err = ResolveDatabase(ctx, p, string(n.Name), true /*required*/)
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/rename_table.go
+++ b/pkg/sql/rename_table.go
@@ -80,7 +80,7 @@ func (p *planner) RenameTable(ctx context.Context, n *tree.RenameTable) (planNod
 	}
 
 	var prevDbDesc *DatabaseDescriptor
-	p.runWithOptions(resolveFlags{skipCache: true, allowAdding: true}, func() {
+	p.runWithOptions(resolveFlags{skipCache: true}, func() {
 		prevDbDesc, err = ResolveDatabase(ctx, p, oldTn.Catalog(), true /*required*/)
 	})
 	if err != nil {


### PR DESCRIPTION
Spotted/suggested by @vivekmenezes: my previous changes for name
resolution improperly changed RENAME DATABASE and DROP DATABASE to use
cached descriptors. This caused bug #22798.

This patch fixes the issue and reverts the tentative workaround in #22805.

Release note: None

Fixes #22841.
Truly fixes  #22798.
Reverts #22805.