### PR TITLE
sql/distsqlrun: fix various buglets in starting and closing processors

### DIFF
--- a/pkg/sql/distsqlrun/aggregator.go
+++ b/pkg/sql/distsqlrun/aggregator.go
@@ -203,6 +203,7 @@ func (ag *aggregator) close() {
 				aggFunc.Close(ag.ctx)
 			}
 		}
+		ag.accumulating = false
 	}
 	ag.internalClose()
 }

--- a/pkg/sql/distsqlrun/algebraic_set_op.go
+++ b/pkg/sql/distsqlrun/algebraic_set_op.go
@@ -132,10 +132,13 @@ func (e *algebraicSetOp) producerMeta(err error) *ProducerMetadata {
 }
 
 func (e *algebraicSetOp) Next() (sqlbase.EncDatumRow, *ProducerMetadata) {
-	var row sqlbase.EncDatumRow
-	var meta *ProducerMetadata
+	if e.closed {
+		return nil, e.producerMeta(nil /* err */)
+	}
 
 	for {
+		var row sqlbase.EncDatumRow
+		var meta *ProducerMetadata
 		switch e.opType {
 		case AlgebraicSetOpSpec_Except_all:
 			row, meta = e.nextExceptAll()
@@ -198,7 +201,6 @@ func (e *algebraicSetOp) nextExceptAll() (sqlbase.EncDatumRow, *ProducerMetadata
 		for i := range e.allCols {
 			e.allCols[i] = uint32(i)
 		}
-
 	}
 
 	// The loop below forms a restartable state machine that iterates over a

--- a/pkg/sql/distsqlrun/distinct.go
+++ b/pkg/sql/distsqlrun/distinct.go
@@ -152,6 +152,10 @@ func (d *distinct) Next() (sqlbase.EncDatumRow, *ProducerMetadata) {
 		d.evalCtx = d.flowCtx.NewEvalCtx()
 	}
 
+	if d.closed {
+		return nil, d.producerMeta(nil /* err */)
+	}
+
 	for {
 		row, meta := d.input.Next()
 		if d.closed || meta != nil {

--- a/pkg/sql/distsqlrun/mergejoiner.go
+++ b/pkg/sql/distsqlrun/mergejoiner.go
@@ -138,6 +138,10 @@ func (m *mergeJoiner) Next() (sqlbase.EncDatumRow, *ProducerMetadata) {
 		log.VEventf(m.ctx, 2, "starting merge joiner run")
 	}
 
+	if m.closed {
+		return nil, m.producerMeta(nil /* err */)
+	}
+
 	for {
 		row, meta := m.nextRow()
 		if m.closed || meta != nil {

--- a/pkg/sql/distsqlrun/values.go
+++ b/pkg/sql/distsqlrun/values.go
@@ -101,6 +101,9 @@ func (v *valuesProcessor) Next() (sqlbase.EncDatumRow, *ProducerMetadata) {
 
 		v.rowBuf = make(sqlbase.EncDatumRow, len(v.columns))
 	}
+	if v.closed {
+		return nil, v.producerMeta(nil /* err */)
+	}
 
 	for {
 		row, meta, err := v.sd.GetRow(v.rowBuf)


### PR DESCRIPTION
The change to make processors implement `RowSource` introduced fragility
in the protocol for closing processors. Specifically, processors could
only be closed after `Next` was called at least once, and calling `Next`
after a processor was closed could lead to use-after-free issues with
tracing. Fix these bugs and add a test which exercises various
cases. `processorBase.ctx` is now always valid and is initialized to
`FlowCtx.Ctx` before `Next` is called and reset to `FlowCtx.Ctx` in
`internalClose`.

Note that the alternative of fixing all the usage of
processors-as-RowSource to ensure that `Next` is never called after
`ConsumerClosed` was rejected as being too fragile.

Fixes #22772

Release note: None