### PR TITLE
config: Validate zone config fields against negative numbers

### DIFF
--- a/pkg/config/zone.go
+++ b/pkg/config/zone.go
@@ -303,24 +303,38 @@ func (z *ZoneConfig) Validate() error {
 			return err
 		}
 	}
-	switch z.NumReplicas {
-	case 0:
+
+	switch {
+	case z.NumReplicas < 0:
+		return fmt.Errorf("at least one replica is required")
+	case z.NumReplicas == 0:
 		if len(z.Subzones) > 0 {
 			// NumReplicas == 0 is allowed when this ZoneConfig is a subzone
 			// placeholder. See IsSubzonePlaceholder.
 			return nil
 		}
 		return fmt.Errorf("at least one replica is required")
-	case 2:
+	case z.NumReplicas == 2:
 		return fmt.Errorf("at least 3 replicas are required for multi-replica configurations")
 	}
+
 	if z.RangeMaxBytes < minRangeMaxBytes {
 		return fmt.Errorf("RangeMaxBytes %d less than minimum allowed %d",
 			z.RangeMaxBytes, minRangeMaxBytes)
 	}
+
+	if z.RangeMinBytes < 0 {
+		return fmt.Errorf("RangeMinBytes %d less than minimum allowed 0", z.RangeMinBytes)
+	}
 	if z.RangeMinBytes >= z.RangeMaxBytes {
 		return fmt.Errorf("RangeMinBytes %d is greater than or equal to RangeMaxBytes %d",
 			z.RangeMinBytes, z.RangeMaxBytes)
+	}
+
+	// Reserve the value 0 to potentially have some special meaning in the future,
+	// such as to disable GC.
+	if z.GC.TTLSeconds < 1 {
+		return fmt.Errorf("GC.TTLSeconds %d less than minimum allowed 1", z.GC.TTLSeconds)
 	}
 
 	for _, constraints := range z.Constraints {
@@ -357,6 +371,7 @@ func (z *ZoneConfig) Validate() error {
 				numConstrainedRepls, z.NumReplicas)
 		}
 	}
+
 	return nil
 }
 

--- a/pkg/config/zone_test.go
+++ b/pkg/config/zone_test.go
@@ -40,6 +40,12 @@ func TestZoneConfigValidate(t *testing.T) {
 		},
 		{
 			ZoneConfig{
+				NumReplicas: -1,
+			},
+			"at least one replica is required",
+		},
+		{
+			ZoneConfig{
 				NumReplicas: 2,
 			},
 			"at least 3 replicas are required for multi-replica configurations",
@@ -55,13 +61,31 @@ func TestZoneConfigValidate(t *testing.T) {
 				NumReplicas:   1,
 				RangeMaxBytes: DefaultZoneConfig().RangeMaxBytes,
 			},
+			"GC.TTLSeconds 0 less than minimum allowed",
+		},
+		{
+			ZoneConfig{
+				NumReplicas:   1,
+				RangeMaxBytes: DefaultZoneConfig().RangeMaxBytes,
+				GC:            GCPolicy{TTLSeconds: 1},
+			},
 			"",
+		},
+		{
+			ZoneConfig{
+				NumReplicas:   1,
+				RangeMinBytes: -1,
+				RangeMaxBytes: DefaultZoneConfig().RangeMaxBytes,
+				GC:            GCPolicy{TTLSeconds: 1},
+			},
+			"RangeMinBytes -1 less than minimum allowed",
 		},
 		{
 			ZoneConfig{
 				NumReplicas:   1,
 				RangeMinBytes: DefaultZoneConfig().RangeMaxBytes,
 				RangeMaxBytes: DefaultZoneConfig().RangeMaxBytes,
+				GC:            GCPolicy{TTLSeconds: 1},
 			},
 			"is greater than or equal to RangeMaxBytes",
 		},
@@ -69,6 +93,7 @@ func TestZoneConfigValidate(t *testing.T) {
 			ZoneConfig{
 				NumReplicas:   1,
 				RangeMaxBytes: DefaultZoneConfig().RangeMaxBytes,
+				GC:            GCPolicy{TTLSeconds: 1},
 				Constraints: []Constraints{
 					{Constraints: []Constraint{{Value: "a", Type: Constraint_DEPRECATED_POSITIVE}}},
 				},
@@ -79,6 +104,7 @@ func TestZoneConfigValidate(t *testing.T) {
 			ZoneConfig{
 				NumReplicas:   1,
 				RangeMaxBytes: DefaultZoneConfig().RangeMaxBytes,
+				GC:            GCPolicy{TTLSeconds: 1},
 				Constraints: []Constraints{
 					{Constraints: []Constraint{{Value: "a", Type: Constraint_PROHIBITED}}},
 				},
@@ -89,6 +115,7 @@ func TestZoneConfigValidate(t *testing.T) {
 			ZoneConfig{
 				NumReplicas:   1,
 				RangeMaxBytes: DefaultZoneConfig().RangeMaxBytes,
+				GC:            GCPolicy{TTLSeconds: 1},
 				Constraints: []Constraints{
 					{
 						Constraints: []Constraint{{Value: "a", Type: Constraint_PROHIBITED}},
@@ -102,6 +129,7 @@ func TestZoneConfigValidate(t *testing.T) {
 			ZoneConfig{
 				NumReplicas:   1,
 				RangeMaxBytes: DefaultZoneConfig().RangeMaxBytes,
+				GC:            GCPolicy{TTLSeconds: 1},
 				Constraints: []Constraints{
 					{
 						Constraints: []Constraint{{Value: "a", Type: Constraint_REQUIRED}},
@@ -115,6 +143,7 @@ func TestZoneConfigValidate(t *testing.T) {
 			ZoneConfig{
 				NumReplicas:   3,
 				RangeMaxBytes: DefaultZoneConfig().RangeMaxBytes,
+				GC:            GCPolicy{TTLSeconds: 1},
 				Constraints: []Constraints{
 					{
 						Constraints: []Constraint{{Value: "a", Type: Constraint_REQUIRED}},
@@ -128,6 +157,7 @@ func TestZoneConfigValidate(t *testing.T) {
 			ZoneConfig{
 				NumReplicas:   1,
 				RangeMaxBytes: DefaultZoneConfig().RangeMaxBytes,
+				GC:            GCPolicy{TTLSeconds: 1},
 				Constraints: []Constraints{
 					{
 						Constraints: []Constraint{{Value: "a", Type: Constraint_REQUIRED}},
@@ -145,6 +175,7 @@ func TestZoneConfigValidate(t *testing.T) {
 			ZoneConfig{
 				NumReplicas:   3,
 				RangeMaxBytes: DefaultZoneConfig().RangeMaxBytes,
+				GC:            GCPolicy{TTLSeconds: 1},
 				Constraints: []Constraints{
 					{
 						Constraints: []Constraint{{Value: "a", Type: Constraint_REQUIRED}},

--- a/pkg/sql/drop_test.go
+++ b/pkg/sql/drop_test.go
@@ -679,7 +679,7 @@ func TestDropTableWhileUpgradingFormat(t *testing.T) {
 	sqlutils.CreateTable(t, sqlDB.DB, "t", "a INT", numRows, sqlutils.ToRowFn(sqlutils.RowIdxFn))
 
 	// Set TTL so the data is deleted immediately.
-	sqlDB.Exec(t, `ALTER TABLE test.t EXPERIMENTAL CONFIGURE ZONE '{gc: {ttlseconds: 0}}'`)
+	sqlDB.Exec(t, `ALTER TABLE test.t EXPERIMENTAL CONFIGURE ZONE '{gc: {ttlseconds: 1}}'`)
 
 	// Give the table an old format version.
 	tableDesc := sqlbase.GetTableDescriptor(kvDB, "test", "t")


### PR DESCRIPTION
In particular, allowing a negative NumReplicas can mess with the
allocator.

Release note (bug fix): Replication zone configs will no longer
accept negative numbers as input.

I plan to cherry-pick this to the release-2.0 branch as well.