### PR TITLE
opt: Set type of function operator.

### DIFF
--- a/pkg/sql/opt/ops/scalar.opt
+++ b/pkg/sql/opt/ops/scalar.opt
@@ -351,6 +351,9 @@ define UnaryComplement {
     Input Expr
 }
 
+# Function invokes a builtin SQL function like CONCAT or NOW, passing the given
+# arguments. The private field is an opt.FuncDef struct that provides the name
+# of the function as well as a pointer to the builtin overload definition.
 [Scalar]
 define Function {
     Args ExprList

--- a/pkg/sql/opt/opt/factory.og.go
+++ b/pkg/sql/opt/opt/factory.og.go
@@ -222,6 +222,9 @@ type Factory interface {
 	ConstructUnaryComplement(input GroupID) GroupID
 
 	// ConstructFunction constructs an expression for the Function operator.
+	// Function invokes a builtin SQL function like CONCAT or NOW, passing the given
+	// arguments. The private field is an opt.FuncDef struct that provides the name
+	// of the function as well as a pointer to the builtin overload definition.
 	ConstructFunction(args ListID, def PrivateID) GroupID
 
 	// ------------------------------------------------------------

--- a/pkg/sql/opt/opt/operator.go
+++ b/pkg/sql/opt/opt/operator.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
 )
 
 //go:generate optgen -out operator.og.go ops ../ops/scalar.opt ../ops/relational.opt ../ops/enforcer.opt
@@ -34,6 +35,19 @@ func (i Operator) String() string {
 	}
 
 	return opNames[opIndexes[i]:opIndexes[i+1]]
+}
+
+// FuncDef defines the value of the Def private field of the Function operator.
+// It provides the name and return type of the function, as well as a pointer
+// to an already resolved builtin overload definition.
+type FuncDef struct {
+	Name     string
+	Type     types.T
+	Overload *tree.Builtin
+}
+
+func (f FuncDef) String() string {
+	return f.Name
 }
 
 // ComparisonOpReverseMap maps from an optimizer operator type to a semantic

--- a/pkg/sql/opt/opt/operator.og.go
+++ b/pkg/sql/opt/opt/operator.og.go
@@ -148,6 +148,9 @@ const (
 
 	UnaryComplementOp
 
+	// FunctionOp invokes a builtin SQL function like CONCAT or NOW, passing the given
+	// arguments. The private field is an opt.FuncDef struct that provides the name
+	// of the function as well as a pointer to the builtin overload definition.
 	FunctionOp
 
 	// ------------------------------------------------------------

--- a/pkg/sql/opt/optbuilder/builder.go
+++ b/pkg/sql/opt/optbuilder/builder.go
@@ -461,7 +461,9 @@ func (b *Builder) buildFunction(
 		argList = append(argList, arg)
 	}
 
-	out = b.factory.ConstructFunction(b.factory.InternList(argList), b.factory.InternPrivate(def))
+	// Construct a private FuncDef that refers to a resolved function overload.
+	outDef := opt.FuncDef{Name: def.Name, Type: f.ResolvedType(), Overload: f.ResolvedBuiltin()}
+	out = b.factory.ConstructFunction(b.factory.InternList(argList), b.factory.InternPrivate(outDef))
 
 	if isAgg {
 		refScope := inScope.endAggFunc()

--- a/pkg/sql/opt/optbuilder/testdata/aggregate
+++ b/pkg/sql/opt/optbuilder/testdata/aggregate
@@ -24,27 +24,27 @@ group-by
  │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
  ├── groupings
  └── aggregations
-      ├── function: min [type=NULL]
+      ├── function: min [type=int]
       │    └── const: 1 [type=int]
-      ├── function: max [type=NULL]
+      ├── function: max [type=int]
       │    └── const: 1 [type=int]
-      ├── function: count [type=NULL]
+      ├── function: count [type=int]
       │    └── const: 1 [type=int]
-      ├── function: sum_int [type=NULL]
+      ├── function: sum_int [type=int]
       │    └── const: 1 [type=int]
-      ├── function: avg [type=NULL]
+      ├── function: avg [type=decimal]
       │    └── const: 1 [type=int]
-      ├── function: sum [type=NULL]
+      ├── function: sum [type=decimal]
       │    └── const: 1 [type=int]
-      ├── function: stddev [type=NULL]
+      ├── function: stddev [type=decimal]
       │    └── const: 1 [type=int]
-      ├── function: variance [type=NULL]
+      ├── function: variance [type=decimal]
       │    └── const: 1 [type=int]
-      ├── function: bool_and [type=NULL]
+      ├── function: bool_and [type=bool]
       │    └── true [type=bool]
-      ├── function: bool_and [type=NULL]
+      ├── function: bool_and [type=bool]
       │    └── false [type=bool]
-      └── function: xor_agg [type=NULL]
+      └── function: xor_agg [type=bytes]
            └── const: '\x01' [type=bytes]
 
 build
@@ -56,7 +56,7 @@ group-by
  │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
  ├── groupings
  └── aggregations
-      └── function: array_agg [type=NULL]
+      └── function: array_agg [type=int[]]
            └── const: 1 [type=int]
 
 build
@@ -68,7 +68,7 @@ group-by
  │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
  ├── groupings
  └── aggregations
-      └── function: json_agg [type=NULL]
+      └── function: json_agg [type=jsonb]
            └── variable: kv.v [type=int]
 
 build
@@ -80,7 +80,7 @@ group-by
  │    └── tuple [type=tuple{}]
  ├── groupings
  └── aggregations
-      └── function: jsonb_agg [type=NULL]
+      └── function: jsonb_agg [type=jsonb]
            └── const: 1 [type=int]
 
 # Even with no aggregate functions, grouping occurs in the presence of GROUP BY.
@@ -121,7 +121,7 @@ project
  │    ├── groupings
  │    │    └── variable: kv.k [type=int]
  │    └── aggregations
- │         └── function: count_rows [type=NULL]
+ │         └── function: count_rows [type=int]
  └── projections
       ├── variable: column5 [type=int]
       └── variable: kv.k [type=int]
@@ -139,7 +139,7 @@ project
  │    ├── groupings
  │    │    └── variable: kv.k [type=int]
  │    └── aggregations
- │         └── function: count_rows [type=NULL]
+ │         └── function: count_rows [type=int]
  └── projections
       ├── variable: column5 [type=int]
       └── variable: kv.k [type=int]
@@ -172,7 +172,7 @@ project
  │    ├── groupings
  │    │    └── variable: kv.s [type=string]
  │    └── aggregations
- │         └── function: count_rows [type=NULL]
+ │         └── function: count_rows [type=int]
  └── projections
       ├── variable: column5 [type=int]
       └── variable: kv.s [type=string]
@@ -189,7 +189,7 @@ project
  │    ├── groupings
  │    │    └── variable: kv.s [type=string]
  │    └── aggregations
- │         └── function: count_rows [type=NULL]
+ │         └── function: count_rows [type=int]
  └── projections
       ├── variable: column5 [type=int]
       └── variable: kv.s [type=string]
@@ -206,7 +206,7 @@ project
  │    ├── groupings
  │    │    └── variable: kv.s [type=string]
  │    └── aggregations
- │         └── function: count_rows [type=NULL]
+ │         └── function: count_rows [type=int]
  └── projections
       ├── variable: column5 [type=int]
       └── variable: kv.s [type=string]
@@ -223,7 +223,7 @@ project
  │    ├── groupings
  │    │    └── variable: kv.s [type=string]
  │    └── aggregations
- │         └── function: count_rows [type=NULL]
+ │         └── function: count_rows [type=int]
  └── projections
       ├── variable: column5 [type=int]
       └── variable: kv.s [type=string]
@@ -242,7 +242,7 @@ project
  │    │    ├── variable: kv.v [type=int]
  │    │    └── variable: kv.w [type=int]
  │    └── aggregations
- │         └── function: count_rows [type=NULL]
+ │         └── function: count_rows [type=int]
  └── projections
       ├── variable: kv.v [type=int]
       ├── variable: column5 [type=int]
@@ -262,7 +262,7 @@ project
  │    │    ├── variable: kv.v [type=int]
  │    │    └── variable: kv.w [type=int]
  │    └── aggregations
- │         └── function: count_rows [type=NULL]
+ │         └── function: count_rows [type=int]
  └── projections
       ├── variable: kv.v [type=int]
       ├── variable: column5 [type=int]
@@ -279,10 +279,10 @@ project
  │    ├── scan
  │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
  │    ├── groupings
- │    │    └── function: upper [type=NULL]
+ │    │    └── function: upper [type=string]
  │    │         └── variable: kv.s [type=string]
  │    └── aggregations
- │         └── function: count_rows [type=NULL]
+ │         └── function: count_rows [type=int]
  └── projections
       ├── variable: column6 [type=int]
       └── variable: column5 [type=string]
@@ -300,7 +300,7 @@ project
  │    ├── groupings
  │    │    └── const: 3 [type=int]
  │    └── aggregations
- │         └── function: count_rows [type=NULL]
+ │         └── function: count_rows [type=int]
  └── projections
       └── variable: column6 [type=int]
 
@@ -314,10 +314,10 @@ project
  │    ├── scan
  │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
  │    ├── groupings
- │    │    └── function: length [type=NULL]
+ │    │    └── function: length [type=int]
  │    │         └── const: 'abc' [type=string]
  │    └── aggregations
- │         └── function: count_rows [type=NULL]
+ │         └── function: count_rows [type=int]
  └── projections
       └── variable: column6 [type=int]
 
@@ -334,10 +334,10 @@ project
  │    ├── groupings
  │    │    └── variable: kv.s [type=string]
  │    └── aggregations
- │         └── function: count_rows [type=NULL]
+ │         └── function: count_rows [type=int]
  └── projections
       ├── variable: column5 [type=int]
-      └── function: upper [type=NULL]
+      └── function: upper [type=string]
            └── variable: kv.s [type=string]
 
 # Selecting a value that is not grouped, even if a function of it it, does not work.
@@ -361,7 +361,7 @@ project
  │    │         ├── variable: kv.k [type=int]
  │    │         └── variable: kv.v [type=int]
  │    └── aggregations
- │         └── function: count_rows [type=NULL]
+ │         └── function: count_rows [type=int]
  └── projections
       ├── variable: column6 [type=int]
       └── variable: column5 [type=int]
@@ -381,7 +381,7 @@ project
  │    │    ├── variable: kv.k [type=int]
  │    │    └── variable: kv.v [type=int]
  │    └── aggregations
- │         └── function: count_rows [type=NULL]
+ │         └── function: count_rows [type=int]
  └── projections
       ├── variable: column5 [type=int]
       └── plus [type=int]
@@ -428,7 +428,7 @@ project
  │    │         ├── variable: kv.v [type=int]
  │    │         └── variable: kv.w [type=int]
  │    └── aggregations
- │         └── function: count [type=NULL]
+ │         └── function: count [type=int]
  │              └── variable: kv.k [type=int]
  └── projections
       ├── variable: count_1 [type=int]
@@ -443,7 +443,7 @@ group-by
  │    └── tuple [type=tuple{}]
  ├── groupings
  └── aggregations
-      └── function: count_rows [type=NULL]
+      └── function: count_rows [type=int]
 
 build
 SELECT COUNT(k) from t.kv
@@ -454,7 +454,7 @@ group-by
  │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
  ├── groupings
  └── aggregations
-      └── function: count [type=NULL]
+      └── function: count [type=int]
            └── variable: kv.k [type=int]
 
 build
@@ -466,7 +466,7 @@ group-by
  │    └── tuple [type=tuple{}]
  ├── groupings
  └── aggregations
-      └── function: count [type=NULL]
+      └── function: count [type=int]
            └── const: 1 [type=int]
 
 build
@@ -478,7 +478,7 @@ group-by
  │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
  ├── groupings
  └── aggregations
-      └── function: count [type=NULL]
+      └── function: count [type=int]
            └── const: 1 [type=int]
 
 build
@@ -495,10 +495,10 @@ group-by
  │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
  ├── groupings
  └── aggregations
-      ├── function: count_rows [type=NULL]
-      ├── function: count [type=NULL]
+      ├── function: count_rows [type=int]
+      ├── function: count [type=int]
       │    └── variable: kv.k [type=int]
-      └── function: count [type=NULL]
+      └── function: count [type=int]
            └── variable: kv.v [type=int]
 
 # TODO(rytaft): This should work once we add support for the AllColumnSelector.
@@ -516,7 +516,7 @@ group-by
  │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
  ├── groupings
  └── aggregations
-      └── function: count [type=NULL]
+      └── function: count [type=int]
            └── tuple [type=tuple{int, int}]
                 ├── variable: kv.k [type=int]
                 └── variable: kv.v [type=int]
@@ -532,9 +532,9 @@ project
  │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
  │    ├── groupings
  │    └── aggregations
- │         ├── function: count [type=NULL]
+ │         ├── function: count [type=int]
  │         │    └── variable: kv.k [type=int]
- │         └── function: count [type=NULL]
+ │         └── function: count [type=int]
  │              └── variable: kv.v [type=int]
  └── projections
       └── plus [type=int]
@@ -550,13 +550,13 @@ group-by
  │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
  ├── groupings
  └── aggregations
-      ├── function: min [type=NULL]
+      ├── function: min [type=int]
       │    └── variable: kv.k [type=int]
-      ├── function: max [type=NULL]
+      ├── function: max [type=int]
       │    └── variable: kv.k [type=int]
-      ├── function: min [type=NULL]
+      ├── function: min [type=int]
       │    └── variable: kv.v [type=int]
-      └── function: max [type=NULL]
+      └── function: max [type=int]
            └── variable: kv.v [type=int]
 
 build
@@ -573,13 +573,13 @@ group-by
  │         └── const: 8 [type=int]
  ├── groupings
  └── aggregations
-      ├── function: min [type=NULL]
+      ├── function: min [type=int]
       │    └── variable: kv.k [type=int]
-      ├── function: max [type=NULL]
+      ├── function: max [type=int]
       │    └── variable: kv.k [type=int]
-      ├── function: min [type=NULL]
+      ├── function: min [type=int]
       │    └── variable: kv.v [type=int]
-      └── function: max [type=NULL]
+      └── function: max [type=int]
            └── variable: kv.v [type=int]
 
 build
@@ -596,7 +596,7 @@ group-by
  │         └── const: NULL [type=NULL]
  ├── groupings
  └── aggregations
-      └── function: array_agg [type=NULL]
+      └── function: array_agg [type=string[]]
            └── variable: kv.s [type=string]
 
 build
@@ -608,13 +608,13 @@ group-by
  │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
  ├── groupings
  └── aggregations
-      ├── function: avg [type=NULL]
+      ├── function: avg [type=decimal]
       │    └── variable: kv.k [type=int]
-      ├── function: avg [type=NULL]
+      ├── function: avg [type=decimal]
       │    └── variable: kv.v [type=int]
-      ├── function: sum [type=NULL]
+      ├── function: sum [type=decimal]
       │    └── variable: kv.k [type=int]
-      └── function: sum [type=NULL]
+      └── function: sum [type=decimal]
            └── variable: kv.v [type=int]
 
 exec-ddl
@@ -640,13 +640,13 @@ group-by
  │    └── columns: abc.a:string:1 abc.b:float:null:2 abc.c:bool:null:3 abc.d:decimal:null:4
  ├── groupings
  └── aggregations
-      ├── function: min [type=NULL]
+      ├── function: min [type=string]
       │    └── variable: abc.a [type=string]
-      ├── function: min [type=NULL]
+      ├── function: min [type=float]
       │    └── variable: abc.b [type=float]
-      ├── function: min [type=NULL]
+      ├── function: min [type=bool]
       │    └── variable: abc.c [type=bool]
-      └── function: min [type=NULL]
+      └── function: min [type=decimal]
            └── variable: abc.d [type=decimal]
 
 build
@@ -658,13 +658,13 @@ group-by
  │    └── columns: abc.a:string:1 abc.b:float:null:2 abc.c:bool:null:3 abc.d:decimal:null:4
  ├── groupings
  └── aggregations
-      ├── function: max [type=NULL]
+      ├── function: max [type=string]
       │    └── variable: abc.a [type=string]
-      ├── function: max [type=NULL]
+      ├── function: max [type=float]
       │    └── variable: abc.b [type=float]
-      ├── function: max [type=NULL]
+      ├── function: max [type=bool]
       │    └── variable: abc.c [type=bool]
-      └── function: max [type=NULL]
+      └── function: max [type=decimal]
            └── variable: abc.d [type=decimal]
 
 build
@@ -676,13 +676,13 @@ group-by
  │    └── columns: abc.a:string:1 abc.b:float:null:2 abc.c:bool:null:3 abc.d:decimal:null:4
  ├── groupings
  └── aggregations
-      ├── function: avg [type=NULL]
+      ├── function: avg [type=float]
       │    └── variable: abc.b [type=float]
-      ├── function: sum [type=NULL]
+      ├── function: sum [type=float]
       │    └── variable: abc.b [type=float]
-      ├── function: avg [type=NULL]
+      ├── function: avg [type=decimal]
       │    └── variable: abc.d [type=decimal]
-      └── function: sum [type=NULL]
+      └── function: sum [type=decimal]
            └── variable: abc.d [type=decimal]
 
 # Verify summing of intervals
@@ -703,7 +703,7 @@ group-by
  │    └── columns: intervals.a:interval:1
  ├── groupings
  └── aggregations
-      └── function: sum [type=NULL]
+      └── function: sum [type=interval]
            └── variable: intervals.a [type=interval]
 
 build
@@ -762,7 +762,7 @@ group-by
  │    └── columns: xyz.x:int:1 xyz.y:int:null:2 xyz.z:float:null:3
  ├── groupings
  └── aggregations
-      └── function: min [type=NULL]
+      └── function: min [type=int]
            └── variable: xyz.x [type=int]
 
 build
@@ -782,7 +782,7 @@ group-by
  │              └── const: 7 [type=int]
  ├── groupings
  └── aggregations
-      └── function: min [type=NULL]
+      └── function: min [type=int]
            └── variable: xyz.x [type=int]
 
 build
@@ -794,7 +794,7 @@ group-by
  │    └── columns: xyz.x:int:1 xyz.y:int:null:2 xyz.z:float:null:3
  ├── groupings
  └── aggregations
-      └── function: max [type=NULL]
+      └── function: max [type=int]
            └── variable: xyz.x [type=int]
 
 build
@@ -811,7 +811,7 @@ group-by
  │         └── const: 1 [type=int]
  ├── groupings
  └── aggregations
-      └── function: max [type=NULL]
+      └── function: max [type=int]
            └── variable: xyz.y [type=int]
 
 build
@@ -828,7 +828,7 @@ group-by
  │         └── const: 7 [type=int]
  ├── groupings
  └── aggregations
-      └── function: min [type=NULL]
+      └── function: min [type=int]
            └── variable: xyz.y [type=int]
 
 build
@@ -849,7 +849,7 @@ group-by
  │              └── const: 3.0 [type=float]
  ├── groupings
  └── aggregations
-      └── function: min [type=NULL]
+      └── function: min [type=int]
            └── variable: xyz.x [type=int]
 
 build
@@ -870,7 +870,7 @@ group-by
  │              └── const: 2 [type=int]
  ├── groupings
  └── aggregations
-      └── function: max [type=NULL]
+      └── function: max [type=int]
            └── variable: xyz.x [type=int]
 
 
@@ -890,7 +890,7 @@ group-by
  │         └── const: 10 [type=int]
  ├── groupings
  └── aggregations
-      └── function: variance [type=NULL]
+      └── function: variance [type=decimal]
            └── variable: xyz.x [type=int]
 
 build
@@ -907,7 +907,7 @@ group-by
  │         └── const: 1 [type=int]
  ├── groupings
  └── aggregations
-      └── function: stddev [type=NULL]
+      └── function: stddev [type=decimal]
            └── variable: xyz.x [type=int]
 
 exec-ddl
@@ -926,9 +926,9 @@ group-by
  │    └── columns: bools.b:bool:null:1 bools.rowid:int:2
  ├── groupings
  └── aggregations
-      ├── function: bool_and [type=NULL]
+      ├── function: bool_and [type=bool]
       │    └── variable: bools.b [type=bool]
-      └── function: bool_or [type=NULL]
+      └── function: bool_or [type=bool]
            └── variable: bools.b [type=bool]
 
 
@@ -971,12 +971,12 @@ project
  │    │    └── columns: xor_bytes.a:bytes:null:1 xor_bytes.b:int:null:2 xor_bytes.c:int:null:3 xor_bytes.rowid:int:4
  │    ├── groupings
  │    └── aggregations
- │         ├── function: xor_agg [type=NULL]
+ │         ├── function: xor_agg [type=bytes]
  │         │    └── variable: xor_bytes.a [type=bytes]
- │         └── function: xor_agg [type=NULL]
+ │         └── function: xor_agg [type=int]
  │              └── variable: xor_bytes.c [type=int]
  └── projections
-      ├── function: to_hex [type=NULL]
+      ├── function: to_hex [type=string]
       │    └── variable: column5 [type=bytes]
       └── variable: column7 [type=int]
 
@@ -989,9 +989,9 @@ group-by
  │    └── tuple [type=tuple{}]
  ├── groupings
  └── aggregations
-      ├── function: max [type=NULL]
+      ├── function: max [type=bool]
       │    └── true [type=bool]
-      └── function: min [type=NULL]
+      └── function: min [type=bool]
            └── true [type=bool]
 
 exec-ddl
@@ -1053,7 +1053,7 @@ project
  │    │    ├── variable: ab.a [type=int]
  │    │    └── variable: ab.b [type=int]
  │    └── aggregations
- │         └── function: min [type=NULL]
+ │         └── function: min [type=string]
  │              └── variable: xy.y [type=string]
  └── projections
       ├── variable: column6 [type=string]
@@ -1103,7 +1103,7 @@ project
  │    │         ├── variable: kv.k [type=int]
  │    │         └── variable: kv.w [type=int]
  │    └── aggregations
- │         └── function: sum [type=NULL]
+ │         └── function: sum [type=decimal]
  │              └── variable: kv.w [type=int]
  └── projections
       ├── variable: column6 [type=decimal]
@@ -1120,13 +1120,13 @@ project
  │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
  │    ├── groupings
  │    │    ├── variable: kv.v [type=int]
- │    │    ├── function: lower [type=NULL]
+ │    │    ├── function: lower [type=string]
  │    │    │    └── variable: kv.s [type=string]
  │    │    └── mult [type=int]
  │    │         ├── variable: kv.k [type=int]
  │    │         └── variable: kv.w [type=int]
  │    └── aggregations
- │         └── function: sum [type=NULL]
+ │         └── function: sum [type=decimal]
  │              └── variable: kv.w [type=int]
  └── projections
       ├── variable: column7 [type=decimal]
@@ -1250,14 +1250,14 @@ project
  │    │    │    └── columns: abc.a:string:5 abc.b:float:null:6 abc.c:bool:null:7 abc.d:decimal:null:8
  │    │    └── true [type=bool]
  │    ├── groupings
- │    │    ├── function: concat [type=NULL]
+ │    │    ├── function: concat [type=string]
  │    │    │    ├── variable: kv.s [type=string]
  │    │    │    └── variable: abc.a [type=string]
  │    │    └── variable: abc.a [type=string]
  │    └── aggregations
  └── projections
-      └── function: concat [type=NULL]
-           ├── function: concat [type=NULL]
+      └── function: concat [type=string]
+           ├── function: concat [type=string]
            │    ├── variable: kv.s [type=string]
            │    └── variable: abc.a [type=string]
            └── variable: abc.a [type=string]
@@ -1389,19 +1389,19 @@ project
  │    │    │    └── columns: times.t:time:2
  │    │    └── true [type=bool]
  │    ├── groupings
- │    │    ├── function: date_trunc [type=NULL]
+ │    │    ├── function: date_trunc [type=interval]
  │    │    │    ├── const: 'second' [type=string]
  │    │    │    └── variable: times.t [type=time]
- │    │    └── function: date_trunc [type=NULL]
+ │    │    └── function: date_trunc [type=interval]
  │    │         ├── const: 'minute' [type=string]
  │    │         └── variable: times.t [type=time]
  │    └── aggregations
  └── projections
-      └── minus [type=NULL]
-           ├── function: date_trunc [type=NULL]
+      └── minus [type=interval]
+           ├── function: date_trunc [type=interval]
            │    ├── const: 'second' [type=string]
            │    └── variable: times.t [type=time]
-           └── function: date_trunc [type=NULL]
+           └── function: date_trunc [type=interval]
                 ├── const: 'minute' [type=string]
                 └── variable: times.t [type=time]
 

--- a/pkg/sql/opt/optbuilder/testdata/distinct
+++ b/pkg/sql/opt/optbuilder/testdata/distinct
@@ -101,7 +101,7 @@ group-by
  │    └── aggregations
  ├── groupings
  └── aggregations
-      └── function: count_rows [type=NULL]
+      └── function: count_rows [type=int]
 
 build
 SELECT DISTINCT x FROM t.xyz WHERE x > 0
@@ -157,7 +157,7 @@ group-by
  │    │    ├── groupings
  │    │    │    └── variable: xyz.x [type=int]
  │    │    └── aggregations
- │    │         └── function: max [type=NULL]
+ │    │         └── function: max [type=int]
  │    │              └── variable: xyz.x [type=int]
  │    └── projections
  │         └── variable: column4 [type=int]
@@ -229,7 +229,7 @@ group-by
  │    │    │    │    ├── variable: xyz.x [type=int]
  │    │    │    │    └── variable: xyz.y [type=int]
  │    │    │    └── aggregations
- │    │    │         └── function: max [type=NULL]
+ │    │    │         └── function: max [type=float]
  │    │    │              └── variable: xyz.z [type=float]
  │    │    └── gt [type=bool]
  │    │         ├── variable: xyz.y [type=int]

--- a/pkg/sql/opt/optbuilder/testdata/having
+++ b/pkg/sql/opt/optbuilder/testdata/having
@@ -42,7 +42,7 @@ select
  │    ├── groupings
  │    │    └── variable: kv.s [type=string]
  │    └── aggregations
- │         └── function: count_rows [type=NULL]
+ │         └── function: count_rows [type=int]
  └── gt [type=bool]
       ├── variable: column5 [type=int]
       └── const: 1 [type=int]
@@ -60,9 +60,9 @@ project
  │    │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
  │    │    ├── groupings
  │    │    └── aggregations
- │    │         ├── function: min [type=NULL]
+ │    │         ├── function: min [type=int]
  │    │         │    └── variable: kv.v [type=int]
- │    │         └── function: max [type=NULL]
+ │    │         └── function: max [type=int]
  │    │              └── variable: kv.k [type=int]
  │    └── gt [type=bool]
  │         ├── variable: column5 [type=int]
@@ -84,11 +84,11 @@ project
  │    │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
  │    │    ├── groupings
  │    │    └── aggregations
- │    │         ├── function: max [type=NULL]
+ │    │         ├── function: max [type=int]
  │    │         │    └── variable: kv.v [type=int]
- │    │         ├── function: max [type=NULL]
+ │    │         ├── function: max [type=int]
  │    │         │    └── variable: kv.k [type=int]
- │    │         └── function: min [type=NULL]
+ │    │         └── function: min [type=int]
  │    │              └── variable: kv.v [type=int]
  │    └── gt [type=bool]
  │         ├── variable: column5 [type=int]
@@ -141,7 +141,7 @@ project
  │    │    │         ├── variable: kv.k [type=int]
  │    │    │         └── variable: kv.w [type=int]
  │    │    └── aggregations
- │    │         └── function: count_rows [type=NULL]
+ │    │         └── function: count_rows [type=int]
  │    └── gt [type=bool]
  │         ├── plus [type=int]
  │         │    ├── variable: kv.k [type=int]
@@ -171,7 +171,7 @@ project
  │    │    ├── groupings
  │    │    │    └── variable: kv.v [type=int]
  │    │    └── aggregations
- │    │         └── function: max [type=NULL]
+ │    │         └── function: max [type=int]
  │    │              └── variable: kv.v [type=int]
  │    └── gt [type=bool]
  │         ├── variable: kv.v [type=int]
@@ -191,13 +191,13 @@ project
  │    │    ├── scan
  │    │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
  │    │    ├── groupings
- │    │    │    └── function: lower [type=NULL]
+ │    │    │    └── function: lower [type=string]
  │    │    │         └── variable: kv.s [type=string]
  │    │    └── aggregations
- │    │         └── function: sum [type=NULL]
+ │    │         └── function: sum [type=decimal]
  │    │              └── variable: kv.w [type=int]
  │    └── like [type=bool]
- │         ├── function: lower [type=NULL]
+ │         ├── function: lower [type=string]
  │         │    └── variable: kv.s [type=string]
  │         └── const: 'test%' [type=string]
  └── projections
@@ -215,10 +215,10 @@ project
  │    │    ├── scan
  │    │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
  │    │    ├── groupings
- │    │    │    └── function: lower [type=NULL]
+ │    │    │    └── function: lower [type=string]
  │    │    │         └── variable: kv.s [type=string]
  │    │    └── aggregations
- │    │         └── function: sum [type=NULL]
+ │    │         └── function: sum [type=decimal]
  │    │              └── variable: kv.w [type=int]
  │    └── in [type=bool]
  │         ├── variable: column6 [type=decimal]

--- a/pkg/sql/opt/optbuilder/testdata/scalar
+++ b/pkg/sql/opt/optbuilder/testdata/scalar
@@ -200,7 +200,7 @@ build-scalar vars=(string)
 LENGTH(@1) = 2
 ----
 eq [type=bool]
- ├── function: length [type=NULL]
+ ├── function: length [type=int]
  │    └── variable: @1 [type=string]
  └── const: 2 [type=int]
 

--- a/pkg/sql/opt/xform/expr.og.go
+++ b/pkg/sql/opt/xform/expr.og.go
@@ -4065,6 +4065,9 @@ func (m *memoExpr) asUnaryComplement() *unaryComplementExpr {
 	return (*unaryComplementExpr)(m)
 }
 
+// functionExpr invokes a builtin SQL function like CONCAT or NOW, passing the given
+// arguments. The private field is an opt.FuncDef struct that provides the name
+// of the function as well as a pointer to the builtin overload definition.
 type functionExpr memoExpr
 
 func makeFunctionExpr(args opt.ListID, def opt.PrivateID) functionExpr {

--- a/pkg/sql/opt/xform/factory.og.go
+++ b/pkg/sql/opt/xform/factory.og.go
@@ -1166,6 +1166,9 @@ func (_f *factory) ConstructUnaryComplement(
 }
 
 // ConstructFunction constructs an expression for the Function operator.
+// Function invokes a builtin SQL function like CONCAT or NOW, passing the given
+// arguments. The private field is an opt.FuncDef struct that provides the name
+// of the function as well as a pointer to the builtin overload definition.
 func (_f *factory) ConstructFunction(
 	args opt.ListID,
 	def opt.PrivateID,

--- a/pkg/sql/opt/xform/testdata/typing
+++ b/pkg/sql/opt/xform/testdata/typing
@@ -295,3 +295,54 @@ project
       │    └── variable: a.y [type=int]
       └── unary-complement [type=int]
            └── variable: a.x [type=int]
+
+# Function with fixed return type.
+build
+SELECT length('text')
+----
+project
+ ├── columns: column1:int:null:1
+ ├── values
+ │    └── tuple [type=tuple{}]
+ └── projections
+      └── function: length [type=int]
+           └── const: 'text' [type=string]
+
+# Function with return type dependent on arg types.
+build
+SELECT div(1.0, 2.0)
+----
+project
+ ├── columns: column1:decimal:null:1
+ ├── values
+ │    └── tuple [type=tuple{}]
+ └── projections
+      └── function: div [type=decimal]
+           ├── const: 1.0 [type=decimal]
+           └── const: 2.0 [type=decimal]
+
+# Function with same arguments in multiple overloads.
+build
+SELECT NOW()
+----
+project
+ ├── columns: column1:timestamptz:null:1
+ ├── values
+ │    └── tuple [type=tuple{}]
+ └── projections
+      └── function: now [type=timestamptz]
+
+# Variadic function.
+build
+SELECT GREATEST(1, 2, 3, 4)
+----
+project
+ ├── columns: column1:int:null:1
+ ├── values
+ │    └── tuple [type=tuple{}]
+ └── projections
+      └── function: greatest [type=int]
+           ├── const: 1 [type=int]
+           ├── const: 2 [type=int]
+           ├── const: 3 [type=int]
+           └── const: 4 [type=int]

--- a/pkg/sql/parser/help.go
+++ b/pkg/sql/parser/help.go
@@ -111,7 +111,7 @@ func helpWithFunction(sqllex sqlLexer, f tree.ResolvableFunctionReference) int {
 	// together.
 	lastInfo := ""
 	for i, overload := range d.Definition {
-		b := overload.(tree.Builtin)
+		b := overload.(*tree.Builtin)
 		if b.Info != "" && b.Info != lastInfo {
 			if i > 0 {
 				fmt.Fprintln(w, "---")

--- a/pkg/sql/sem/builtins/all_builtins.go
+++ b/pkg/sql/sem/builtins/all_builtins.go
@@ -42,9 +42,9 @@ func init() {
 	// Generate missing categories.
 	for _, name := range AllBuiltinNames {
 		def := Builtins[name]
-		for i, b := range def {
-			if b.Category == "" {
-				def[i].Category = getCategory(def[i])
+		for i := range def {
+			if def[i].Category == "" {
+				def[i].Category = getCategory(&def[i])
 			}
 		}
 	}
@@ -52,7 +52,7 @@ func init() {
 	sort.Strings(AllBuiltinNames)
 }
 
-func getCategory(b tree.Builtin) string {
+func getCategory(b *tree.Builtin) string {
 	// If single argument attempt to categorize by the type of the argument.
 	switch typ := b.Types.(type) {
 	case tree.ArgTypes:

--- a/pkg/sql/sem/tree/function_definition.go
+++ b/pkg/sql/sem/tree/function_definition.go
@@ -32,9 +32,9 @@ type FunctionDefinition struct {
 func NewFunctionDefinition(name string, def []Builtin) *FunctionDefinition {
 	hasRowDependentOverloads := false
 	overloads := make([]overloadImpl, len(def))
-	for i, d := range def {
-		overloads[i] = d
-		if d.NeedsRepeatedEvaluation {
+	for i := range def {
+		overloads[i] = &def[i]
+		if def[i].NeedsRepeatedEvaluation {
 			hasRowDependentOverloads = true
 		}
 	}

--- a/pkg/sql/sem/tree/type_check.go
+++ b/pkg/sql/sem/tree/type_check.go
@@ -465,7 +465,7 @@ func (expr *FuncExpr) TypeCheck(ctx *SemaContext, desired types.T) (TypedExpr, e
 		// arguments, we don't want to take the NULL argument fast-path.
 		handledNull := false
 		for _, fn := range fns {
-			if fn.(Builtin).NullableArgs {
+			if fn.(*Builtin).NullableArgs {
 				handledNull = true
 				break
 			}
@@ -528,7 +528,7 @@ func (expr *FuncExpr) TypeCheck(ctx *SemaContext, desired types.T) (TypedExpr, e
 		expr.Filter = typedFilter
 	}
 
-	builtin := fns[0].(Builtin)
+	builtin := fns[0].(*Builtin)
 	if expr.IsWindowFunctionApplication() {
 		// Make sure the window function application is of either a built-in window
 		// function or of a builtin aggregate function.
@@ -1727,7 +1727,7 @@ func (v stripFuncsVisitor) VisitPre(expr Expr) (recurse bool, newExpr Expr) {
 	case *ComparisonExpr:
 		t.fn = CmpOp{}
 	case *FuncExpr:
-		t.fn = Builtin{}
+		t.fn = nil
 	}
 	return true, expr
 }


### PR DESCRIPTION
This PR propagates additional typing and overload information for
Function operators. The new opt.FuncDef struct stores the function
name, type, and overload. The type is later used to set the logical
prop's scalar type field. In addition, the overload will be used
by the execbuilder to construct the correct function exec node.

Release note: None