### PR TITLE
roachtest: add DELETE/TRUNCATE/DROP test

### DIFF
--- a/pkg/ccl/workloadccl/fixture.go
+++ b/pkg/ccl/workloadccl/fixture.go
@@ -194,8 +194,9 @@ func (c *groupCSVWriter) groupWriteCSVs(
 			newBytesWritten := atomic.AddInt64(&c.csvBytesWritten, w.Attrs().Size)
 			d := timeutil.Since(c.start)
 			throughput := float64(newBytesWritten) / (d.Seconds() * float64(1<<20) /* 1MiB */)
-			log.Infof(ctx, `wrote csv %s [%d,%d] of %d rows (total %s in %s: %.1f MB/s)`,
+			log.Infof(ctx, `wrote csv %s [%d,%d] of %d rows (%.2f%% (%s) in %s: %.1f MB/s)`,
 				table.Name, rowStart, rowIdx, table.InitialRowCount,
+				float64(100*table.InitialRowCount)/float64(rowIdx),
 				humanizeutil.IBytes(newBytesWritten), d, throughput)
 
 			return nil

--- a/pkg/cmd/roachtest/drop.go
+++ b/pkg/cmd/roachtest/drop.go
@@ -1,0 +1,54 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+
+package main
+
+import (
+	"context"
+	"fmt"
+)
+
+func init() {
+	runTPCC := func(t *test, warehouses, nodes int, extra string) {
+		ctx := context.Background()
+		c := newCluster(ctx, t, nodes+1)
+		defer c.Destroy(ctx)
+
+		c.Put(ctx, cockroach, "./cockroach", c.Range(1, nodes))
+		c.Put(ctx, workload, "./workload", c.Node(nodes+1))
+		c.Start(ctx, c.Range(1, nodes))
+
+		t.Status("running workload")
+		m := newMonitor(ctx, c, c.Range(1, nodes))
+		m.Go(func(ctx context.Context) error {
+			duration := " --duration=" + ifLocal("10s", "10m")
+			cmd := fmt.Sprintf(
+				"./workload run tpcc --init --warehouses=%d"+
+					extra+duration+" {pgurl:1-%d}",
+				warehouses, nodes)
+			c.Run(ctx, nodes+1, cmd)
+			return nil
+		})
+		m.Wait()
+	}
+
+	tests.Add("tpcc/w=1/nodes=3", func(t *test) {
+		concurrency := ifLocal("", " --concurrency=384")
+		runTPCC(t, 1, 3, " --wait=false"+concurrency)
+	})
+	tests.Add("tpmc/w=1/nodes=3", func(t *test) {
+		runTPCC(t, 1, 3, " --concurrency=10")
+	})
+}

--- a/pkg/cmd/roachtest/test.go
+++ b/pkg/cmd/roachtest/test.go
@@ -148,14 +148,9 @@ func (r *registry) Run(filter []string) int {
 		close(done)
 	}()
 
-	// If we're running with parallelism > 1, periodically output test status to
-	// give an indication of progress.
-	var tick <-chan time.Time
-	if parallelism > 1 {
-		ticker := time.NewTicker(time.Minute)
-		defer ticker.Stop()
-		tick = ticker.C
-	}
+	// Periodically output test status to give an indication of progress.
+	ticker := time.NewTicker(time.Minute)
+	defer ticker.Stop()
 
 	for i := 1; ; i++ {
 		select {
@@ -167,7 +162,7 @@ func (r *registry) Run(filter []string) int {
 			fmt.Fprintln(r.out, "PASS")
 			return 0
 
-		case <-tick:
+		case <-ticker.C:
 			running.Lock()
 			runningTests := make([]*test, 0, len(running.m))
 			for t := range running.m {

--- a/pkg/cmd/roachtest/test.go
+++ b/pkg/cmd/roachtest/test.go
@@ -212,7 +212,7 @@ func (t *test) Name() string {
 func (t *test) Status(args ...interface{}) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
-	t.mu.status = fmt.Sprint(args...)
+	t.mu.status = strings.SplitN(fmt.Sprint(args...), "\n", 2)[0]
 	t.mu.statusTime = timeutil.Now()
 }
 


### PR DESCRIPTION
Add a test that exercises a) deletion of a large number of rows and b) the DROP
fast path for a nontrivial schema.

Release note: None