### PR TITLE
cherry-pick 2.0: sql: ensure that db DDL stmts look up descs uncached

### DIFF
--- a/pkg/sql/drop_database.go
+++ b/pkg/sql/drop_database.go
@@ -48,7 +48,11 @@ func (p *planner) DropDatabase(ctx context.Context, n *tree.DropDatabase) (planN
 	}
 
 	// Check that the database exists.
-	dbDesc, err := ResolveDatabase(ctx, p, string(n.Name), !n.IfExists)
+	var dbDesc *DatabaseDescriptor
+	var err error
+	p.runWithOptions(resolveFlags{skipCache: true}, func() {
+		dbDesc, err = ResolveDatabase(ctx, p, string(n.Name), !n.IfExists)
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/rename_database.go
+++ b/pkg/sql/rename_database.go
@@ -37,7 +37,11 @@ func (p *planner) RenameDatabase(ctx context.Context, n *tree.RenameDatabase) (p
 		return nil, err
 	}
 
-	dbDesc, err := ResolveDatabase(ctx, p, string(n.Name), true /*required*/)
+	var dbDesc *DatabaseDescriptor
+	var err error
+	p.runWithOptions(resolveFlags{skipCache: true}, func() {
+		dbDesc, err = ResolveDatabase(ctx, p, string(n.Name), true /*required*/)
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/rename_table.go
+++ b/pkg/sql/rename_table.go
@@ -80,7 +80,7 @@ func (p *planner) RenameTable(ctx context.Context, n *tree.RenameTable) (planNod
 	}
 
 	var prevDbDesc *DatabaseDescriptor
-	p.runWithOptions(resolveFlags{skipCache: true, allowAdding: true}, func() {
+	p.runWithOptions(resolveFlags{skipCache: true}, func() {
 		prevDbDesc, err = ResolveDatabase(ctx, p, oldTn.Catalog(), true /*required*/)
 	})
 	if err != nil {


### PR DESCRIPTION
Cherry-picks #22866.

Spotted/suggested by @vivekmenezes: my previous changes for name
resolution improperly changed RENAME DATABASE and DROP DATABASE to use
cached descriptors. This caused bug #22798.

This patch fixes the issue.

Release note: None

cc @cockroachdb/release 