### PR TITLE
sql: ensure that the parsing latency is properly tracked

### DIFF
--- a/pkg/sql/conn_io.go
+++ b/pkg/sql/conn_io.go
@@ -128,6 +128,9 @@ type ExecStmt struct {
 	// Stmt can be nil, in which case a "empty query response" message should be
 	// produced.
 	Stmt tree.Statement
+	// TimeReceived is the time at which the exec message was received
+	// from the client. Used to compute the service latency.
+	TimeReceived time.Time
 	// ParseStart/ParseEnd are the timing info for parsing of the query. Used for
 	// stats reporting.
 	ParseStart time.Time
@@ -145,6 +148,9 @@ type ExecPortal struct {
 	// limit is a feature of pgwire that we don't really support. We accept it and
 	// don't complain as long as the statement produces fewer results than this.
 	Limit int
+	// TimeReceived is the time at which the exec message was received
+	// from the client. Used to compute the service latency.
+	TimeReceived time.Time
 }
 
 // command implements the Command interface.

--- a/pkg/sql/exec_log.go
+++ b/pkg/sql/exec_log.go
@@ -94,7 +94,7 @@ var logStatementsExecuteEnabled = settings.RegisterBoolSetting(
 // (p.curPlan) to the exec / audit logs.
 func (p *planner) maybeLogStatement(ctx context.Context, lbl string, rows int, err error) {
 	p.maybeLogStatementInternal(
-		ctx, lbl, rows, err, p.statsCollector.PhaseTimes()[sessionStartParse])
+		ctx, lbl, rows, err, p.statsCollector.PhaseTimes()[sessionQueryReceived])
 }
 
 func (p *planner) maybeLogStatementInternal(

--- a/pkg/sql/executor.go
+++ b/pkg/sql/executor.go
@@ -623,7 +623,6 @@ func (e *Executor) ExecuteStatements(
 	session *Session, stmts string, pinfo *tree.PlaceholderInfo,
 ) error {
 	session.resetForBatch(e)
-	session.phaseTimes[sessionStartBatch] = timeutil.Now()
 
 	defer session.maybeRecover("executing", stmts)
 
@@ -643,6 +642,7 @@ func (e *Executor) ExecutePreparedStatement(
 		// because the service latency is measured from
 		// phaseTimes[sessionStartParse].
 		now := timeutil.Now()
+		session.phaseTimes[sessionQueryReceived] = now
 		session.phaseTimes[sessionStartParse] = now
 		session.phaseTimes[sessionEndParse] = now
 	}
@@ -685,7 +685,9 @@ func (e *Executor) execPrepared(
 func (e *Executor) execRequest(session *Session, sql string, pinfo *tree.PlaceholderInfo) error {
 	txnState := &session.TxnState
 
-	session.phaseTimes[sessionStartParse] = timeutil.Now()
+	now := timeutil.Now()
+	session.phaseTimes[sessionQueryReceived] = now
+	session.phaseTimes[sessionStartParse] = now
 	sl, err := parser.Parse(sql)
 	stmts := NewStatementList(sl)
 	session.phaseTimes[sessionEndParse] = timeutil.Now()

--- a/pkg/sql/logictest/testdata/logic_test/statement_statistics
+++ b/pkg/sql/logictest/testdata/logic_test/statement_statistics
@@ -131,3 +131,26 @@ SELECT _ FROM _ WHERE _ IN (_, _)
 SELECT _ FROM _ WHERE _ IN (_, _)
 SELECT _ FROM _ WHERE _ IN (_, _, _ + _, _, _)
 SELECT _ FROM _ WHERE _ NOT IN (_, _)
+
+# Check that the latency measurements looks reasonable, protecting
+# against failure to measure (#22877).
+
+# We use the keys left over by the two unary selects
+# performed at the start of this test above.
+#
+# The latency metrics are expressed in seconds. Check that some time
+# was consumed, but not so much to verify that the computation has not
+# incorrectly overflowed.
+query TBBBBB colnames
+SELECT key,
+       service_lat_avg > 0 and service_lat_avg < 10 as svc_ok,
+       parse_lat_avg > 0   and parse_lat_avg < 10   as parse_ok,
+       plan_lat_avg > 0    and plan_lat_avg < 10    as plan_ok,
+       run_lat_avg > 0     and run_lat_avg < 10     as run_ok,
+                           overhead_lat_avg < 10    as ovh_ok
+  FROM crdb_internal.node_statement_statistics
+ WHERE key = 'SELECT _'
+----
+key       svc_ok  parse_ok  plan_ok  run_ok  ovh_ok
+SELECT _  true    true      true     true    true
+SELECT _  true    true      true     true    true


### PR DESCRIPTION
The previous patch that introduced a buffer of incoming
SQL commands also extracted parsing to occur outside of
the executor logic. However that change incorrectly
omitted to propagate the measurement of the parsing time
until the point where it is used, during execution.

This patch does this and restores proper tracking of
the parsing and service latency.

Release note (bug fix): the execution time of SQL statements
is now (again) properly tracked.

Fixes #22877.
Fixes #22891.
Fixes #22821.