### PR TITLE
Revert "partitionccl: deflake TestInitialRepartitioning"

### DIFF
--- a/pkg/ccl/partitionccl/partition_test.go
+++ b/pkg/ccl/partitionccl/partition_test.go
@@ -1219,7 +1219,6 @@ func TestSelectPartitionExprs(t *testing.T) {
 
 func TestRepartitioning(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	t.Skip("#22360")
 
 	rng, _ := randutil.NewPseudoRand()
 	testCases, err := allRepartitioningTests(allPartitioningTests(rng))

--- a/pkg/ccl/partitionccl/partition_test.go
+++ b/pkg/ccl/partitionccl/partition_test.go
@@ -1219,6 +1219,7 @@ func TestSelectPartitionExprs(t *testing.T) {
 
 func TestRepartitioning(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	t.Skip("#22360")
 
 	rng, _ := randutil.NewPseudoRand()
 	testCases, err := allRepartitioningTests(allPartitioningTests(rng))
@@ -1230,14 +1231,11 @@ func TestRepartitioning(t *testing.T) {
 	sqlDB, cleanup := setupPartitioningTestCluster(ctx, t)
 	defer cleanup()
 
-	for i, test := range testCases {
+	for _, test := range testCases {
 		t.Run(fmt.Sprintf("%s/%s", test.old.name, test.new.name), func(t *testing.T) {
-			// NOTE: We used to drop and recreate a database named
-			// "data" at the start of every test, but DROP DATABASE
-			// would occasionally hang forever.
-			dbName := fmt.Sprintf("data%d", i)
-			sqlDB.Exec(t, `CREATE DATABASE `+dbName)
-			sqlDB.Exec(t, `USE `+dbName)
+			sqlDB.Exec(t, `DROP DATABASE IF EXISTS data`)
+			sqlDB.Exec(t, `CREATE DATABASE data`)
+			sqlDB.Exec(t, `USE data`)
 
 			{
 				if err := test.old.parse(); err != nil {


### PR DESCRIPTION
This reverts commit 39bce4b6eea869c5c26f172f7b262da2837fb499.

The root cause was addressed in #22866, so this workaround should
no longer be required.

Release note: None