### PR TITLE
distsql: increment DistSQL version

### DIFF
--- a/pkg/sql/distsqlrun/server.go
+++ b/pkg/sql/distsqlrun/server.go
@@ -74,7 +74,7 @@ type DistSQLVersion uint32
 //
 // ATTENTION: When updating these fields, add to version_history.txt explaining
 // what changed.
-const Version DistSQLVersion = 8
+const Version DistSQLVersion = 9
 
 // MinAcceptedVersion is the oldest version that the server is
 // compatible with; see above.

--- a/pkg/sql/distsqlrun/version_history.txt
+++ b/pkg/sql/distsqlrun/version_history.txt
@@ -18,3 +18,28 @@
     unrecognized by a server running older versions, hence the version bump.
     Servers running v7 can still execute regular joins between interleaved
     tables from servers running v6, thus the MinAcceptedVersion is kept at 6.
+- Version: 9 (MinAcceptedVersion: 6)
+  - Many changes were made without bumping the version. These changes involved
+    changes to the semantics of existing processors. These changes include:
+    - Two new join types (LEFT_SEMI, LEFT_ANTI) were added to the JoinType enum
+      to support new types of joins that can be used to improve performance of
+      certain queries. The new join types would not be recognized by a server
+      with an old version number.
+    - The JoinReaderSpec was modified by adding three new properties
+      (lookup_columns, on_expr, and index_map) to enable the JoinReader to perform
+      lookup joins enabling more efficient joins for certain queries. Old server
+      versions would not recognize these new properties.
+    - Two new join types (INTERSECT_ALL, EXCEPT_ALL) were added to the sqlbase.JoinType
+      enum to support INTERSECT and EXCEPT queries. These "set operation" queries
+      can now be planned by DistSQL, and older versions will not be capable of
+      supporting these queries.
+    - The ARRAY_AGG and JSON_AGG aggregate functions were added to the
+      AggregatorSpec_Func enum. Older versions will not recognize these new enum
+      members, and will not be able to support aggregations with either.
+    - IMPORT was changed to support importing CSVs with no primary key specified.
+      This required a change to the CSV proto semantics, making old and new
+      versions mutually incompatible. This was an EXPERIMENTAL feature in 1.1 and
+      thus we do not bump the MinAcceptedVersion, even though IMPORT in mixed
+      clusters without primary keys will succeed with incorrect results.
+    - TableReader was extended to support physical checks. Old versions would not
+      recognize these new fields.


### PR DESCRIPTION
In the past release cycle, many changes were made that should have
incremented the DistSQL version and the MinAcceptedVersion. The code
is currently faulty as using any of these features will cause
incorrect behavior. This patch sets the correct version and minimum
accepted version.

This commit should be cherry-picked into the 2.0 release branch. 