### PR TITLE
Do not merge: Add OrigTimestampWasObserved to schema change backfill

### DIFF
--- a/pkg/sql/distsqlrun/columnbackfiller.go
+++ b/pkg/sql/distsqlrun/columnbackfiller.go
@@ -255,6 +255,7 @@ func (cb *columnBackfiller) runChunk(
 				return err
 			}
 		}
+		txn.OrigTimestampWasObserved()
 		// Write the new row values.
 		if err := txn.CommitInBatch(ctx, b); err != nil {
 			return ConvertBackfillError(ctx, &cb.spec.Table, b)

--- a/pkg/sql/distsqlrun/indexbackfiller.go
+++ b/pkg/sql/distsqlrun/indexbackfiller.go
@@ -201,6 +201,7 @@ func (ib *indexBackfiller) runChunk(
 			for _, entry := range entries {
 				batch.InitPut(entry.Key, &entry.Value, false /* failOnTombstones */)
 			}
+			txn.OrigTimestampWasObserved()
 			if err := txn.CommitInBatch(ctx, batch); err != nil {
 				return ConvertBackfillError(ctx, &ib.spec.Table, batch)
 			}
@@ -235,6 +236,7 @@ func (ib *indexBackfiller) runChunk(
 	// Write the new index values.
 	if err := ib.flowCtx.clientDB.Txn(ctx, func(ctx context.Context, txn *client.Txn) error {
 		batch := txn.NewBatch()
+		txn.OrigTimestampWasObserved()
 
 		for _, entry := range entries {
 			// Since we're not regenerating the index entries here, if the


### PR DESCRIPTION
Some of these might be needed but certainly the one I've
added for column backfill is not needed. I'm quite confident
we have a serialization consistency bug observed by running
```make stress PKG=./pkg/sql TESTS=TestRaceWithBackfill```

Release note: None