### PR TITLE
storage: treat InitPut the same as CPut

### DIFF
--- a/pkg/roachpb/api.go
+++ b/pkg/roachpb/api.go
@@ -964,13 +964,12 @@ func (*ConditionalPutRequest) flags() int {
 	return isRead | isWrite | isTxn | isTxnWrite | updatesReadTSCache | updatesTSCacheOnError | consultsTSCache
 }
 
-// InitPut may read but not write, however, it "reads" effectively
-// at the timestamp of any existing value, and should not prevent
-// subsequent writers from writing at a timestamp between this req's
-// putative timestamp and the timestamp of the existing value. This
-// also allows us to avoid tracking refresh spans for InitPuts ops.
+// InitPut, like ConditionalPut, effectively reads and may not write.
+// It also may return the actual data read on ConditionFailedErrors,
+// so must update the timestamp cache on errors. Like CPut, InitPuts
+// do not require a refresh because they return errors on write-too-old.
 func (*InitPutRequest) flags() int {
-	return isRead | isWrite | isTxn | isTxnWrite | consultsTSCache
+	return isRead | isWrite | isTxn | isTxnWrite | updatesReadTSCache | updatesTSCacheOnError | consultsTSCache
 }
 
 // Increment reads the existing value, but always leaves an intent so

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -5521,6 +5521,11 @@ func evaluateBatch(
 						// commit, we'll need a client-side retry, so we return immediately
 						// to see if we can do a txn coord sender retry instead.
 						returnWriteTooOldErr = true
+					case *roachpb.InitPutRequest:
+						// Init puts are also an exception. There's no reason to believe they
+						// will succeed on a retry, so better to short circuit and return the
+						// write too old error.
+						returnWriteTooOldErr = true
 					}
 				}
 				if ba.Txn != nil {


### PR DESCRIPTION
Previously the semantics for `InitPut` were incorrect with the faulty
assumption that `InitPut` didn't read and return the results on error
(it does), and that it would effectively read at the timestamp of the
existing value's write (it reads at the batch timestamp).

This change sets the `InitPut` flags to exactly those used by `CPut`,
which fixes errors related to index backfilling in `TestBackfillWithRace`.

See #22543

Release note: None