### PR TITLE
opt: use a new UnsupportedExprOp for unsupported scalar expressions

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/builder_test.go
+++ b/pkg/sql/opt/exec/execbuilder/builder_test.go
@@ -77,7 +77,9 @@ func TestBuild(t *testing.T) {
 
 					// Build and optimize the opt expression tree.
 					o := xform.NewOptimizer(eng.Catalog(), xform.OptimizeAll)
-					root, props, err := optbuilder.New(ctx, o.Factory(), stmt).Build()
+					builder := optbuilder.New(ctx, o.Factory(), stmt)
+					builder.AllowUnsupportedExpr = true
+					root, props, err := builder.Build()
 					if err != nil {
 						d.Fatalf(t, "BuildOpt: %v", err)
 					}

--- a/pkg/sql/opt/exec/execbuilder/scalar_builder.go
+++ b/pkg/sql/opt/exec/execbuilder/scalar_builder.go
@@ -39,10 +39,11 @@ func init() {
 	// the functions depend on scalarBuildFuncMap which in turn depends on the
 	// functions).
 	scalarBuildFuncMap = [opt.NumOperators]buildFunc{
-		opt.VariableOp:    (*Builder).buildVariable,
-		opt.ConstOp:       (*Builder).buildTypedExpr,
-		opt.PlaceholderOp: (*Builder).buildTypedExpr,
-		opt.TupleOp:       (*Builder).buildTuple,
+		opt.VariableOp:        (*Builder).buildVariable,
+		opt.ConstOp:           (*Builder).buildTypedExpr,
+		opt.PlaceholderOp:     (*Builder).buildTypedExpr,
+		opt.TupleOp:           (*Builder).buildTuple,
+		opt.UnsupportedExprOp: (*Builder).buildUnsupportedExpr,
 	}
 
 	for _, op := range opt.BooleanOperators {
@@ -151,4 +152,8 @@ func (b *Builder) buildBinary(ctx *buildScalarCtx, ev xform.ExprView) tree.Typed
 		b.buildScalar(ctx, ev.Child(1)),
 		ev.Logical().Scalar.Type,
 	)
+}
+
+func (b *Builder) buildUnsupportedExpr(ctx *buildScalarCtx, ev xform.ExprView) tree.TypedExpr {
+	return ev.Private().(tree.TypedExpr)
 }

--- a/pkg/sql/opt/exec/execbuilder/testdata/scalar
+++ b/pkg/sql/opt/exec/execbuilder/testdata/scalar
@@ -237,12 +237,16 @@ render     0  render  ·         ·            (column8)                        
 ·          1  ·       table     t@primary    ·                                  ·
 ·          1  ·       spans     ALL          ·                                  ·
 
-# CASE not supported yet.
-#exec-explain
-#SELECT CASE WHEN a = 2 THEN 1 ELSE 2 END FROM t.t
-#----
+exec-explain
+SELECT CASE WHEN a = 2 THEN 1 ELSE 2 END FROM t.t
+----
+render     0  render  ·         ·                                    (column8)                          ·
+ │         0  ·       render 0  CASE WHEN t.a = 2 THEN 1 ELSE 2 END  ·                                  ·
+ └── scan  1  scan    ·         ·                                    (a, b, c, d, j, s, rowid[hidden])  ·
+·          1  ·       table     t@primary                            ·                                  ·
+·          1  ·       spans     ALL                                  ·                                  ·
 
-# Functions not supported yet.
+## Functions not supported yet.
 #exec-explain
 #SELECT LENGTH(s) = 2 FROM t.t
 #----

--- a/pkg/sql/opt/idxconstraint/index_constraints_test.go
+++ b/pkg/sql/opt/idxconstraint/index_constraints_test.go
@@ -69,6 +69,7 @@ var (
 //     - semtree-normalize
 //
 //       Run TypedExpr normalization before building the memo.
+//
 func TestIndexConstraints(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
@@ -167,6 +168,7 @@ func TestIndexConstraints(t *testing.T) {
 					}
 					o := xform.NewOptimizer(catalog, steps)
 					b := optbuilder.NewScalar(ctx, o.Factory(), varNames, varTypes)
+					b.AllowUnsupportedExpr = true
 					group, err := b.Build(typedExpr)
 					if err != nil {
 						return fmt.Sprintf("error: %v\n", err)

--- a/pkg/sql/opt/idxconstraint/testdata/all
+++ b/pkg/sql/opt/idxconstraint/testdata/all
@@ -1226,11 +1226,10 @@ index-constraints vars=(int, int, int) index=(@1, @2, @3)
 # Remaining filter: (@2 = 2) OR (@2 = 3)
 
 
-# TODO(radu): unsupported CASE
-#index-constraints vars=(int, int, int) index=(@1, @2, @3)
-#@1 = 1 AND @2 = CASE WHEN @3 = 2 THEN 1 ELSE 2 END
-#----
-#(/1/NULL - /1]
+index-constraints vars=(int, int, int) index=(@1, @2, @3)
+@1 = 1 AND @2 = CASE WHEN @3 = 2 THEN 1 ELSE 2 END
+----
+(/1/NULL - /1]
 
 # Remaining filter: @2 = CASE WHEN @3 = 2 THEN 1 ELSE 2 END
 

--- a/pkg/sql/opt/ops/scalar.opt
+++ b/pkg/sql/opt/ops/scalar.opt
@@ -359,3 +359,10 @@ define Function {
     Args ExprList
     Def  FuncDef
 }
+
+# UnsupportedExpr is used for interfacing with the old planner code. It can
+# encapsulate a TypedExpr that is otherwise not supported by the optimizer.
+[Scalar]
+define UnsupportedExpr {
+  Value TypedExpr
+}

--- a/pkg/sql/opt/opt/factory.og.go
+++ b/pkg/sql/opt/opt/factory.og.go
@@ -227,6 +227,11 @@ type Factory interface {
 	// of the function as well as a pointer to the builtin overload definition.
 	ConstructFunction(args ListID, def PrivateID) GroupID
 
+	// ConstructUnsupportedExpr constructs an expression for the UnsupportedExpr operator.
+	// UnsupportedExpr is used for interfacing with the old planner code. It can
+	// encapsulate a TypedExpr that is otherwise not supported by the optimizer.
+	ConstructUnsupportedExpr(value PrivateID) GroupID
+
 	// ------------------------------------------------------------
 	// Relational Operators
 	// ------------------------------------------------------------

--- a/pkg/sql/opt/opt/operator.og.go
+++ b/pkg/sql/opt/opt/operator.og.go
@@ -153,6 +153,10 @@ const (
 	// of the function as well as a pointer to the builtin overload definition.
 	FunctionOp
 
+	// UnsupportedExprOp is used for interfacing with the old planner code. It can
+	// encapsulate a TypedExpr that is otherwise not supported by the optimizer.
+	UnsupportedExprOp
+
 	// ------------------------------------------------------------
 	// Relational Operators
 	// ------------------------------------------------------------
@@ -246,9 +250,9 @@ const (
 	NumOperators
 )
 
-const opNames = "unknownsubqueryvariableconsttruefalseplaceholdertupleprojectionsaggregationsgroupingsexistsandornoteqltgtlegeneinnot-inlikenot-likei-likenot-i-likesimilar-tonot-similar-toreg-matchnot-reg-matchreg-i-matchnot-reg-i-matchisis-notcontainsbitandbitorbitxorplusminusmultdivfloor-divmodpowconcatl-shiftr-shiftfetch-valfetch-textfetch-val-pathfetch-text-pathunary-plusunary-minusunary-complementfunctionscanvaluesselectprojectinner-joinleft-joinright-joinfull-joinsemi-joinanti-joininner-join-applyleft-join-applyright-join-applyfull-join-applysemi-join-applyanti-join-applygroup-byunionintersectexceptsortpresent"
+const opNames = "unknownsubqueryvariableconsttruefalseplaceholdertupleprojectionsaggregationsgroupingsexistsandornoteqltgtlegeneinnot-inlikenot-likei-likenot-i-likesimilar-tonot-similar-toreg-matchnot-reg-matchreg-i-matchnot-reg-i-matchisis-notcontainsbitandbitorbitxorplusminusmultdivfloor-divmodpowconcatl-shiftr-shiftfetch-valfetch-textfetch-val-pathfetch-text-pathunary-plusunary-minusunary-complementfunctionunsupported-exprscanvaluesselectprojectinner-joinleft-joinright-joinfull-joinsemi-joinanti-joininner-join-applyleft-join-applyright-join-applyfull-join-applysemi-join-applyanti-join-applygroup-byunionintersectexceptsortpresent"
 
-var opIndexes = [...]uint32{0, 7, 15, 23, 28, 32, 37, 48, 53, 64, 76, 85, 91, 94, 96, 99, 101, 103, 105, 107, 109, 111, 113, 119, 123, 131, 137, 147, 157, 171, 180, 193, 204, 219, 221, 227, 235, 241, 246, 252, 256, 261, 265, 268, 277, 280, 283, 289, 296, 303, 312, 322, 336, 351, 361, 372, 388, 396, 400, 406, 412, 419, 429, 438, 448, 457, 466, 475, 491, 506, 522, 537, 552, 567, 575, 580, 589, 595, 599, 606}
+var opIndexes = [...]uint32{0, 7, 15, 23, 28, 32, 37, 48, 53, 64, 76, 85, 91, 94, 96, 99, 101, 103, 105, 107, 109, 111, 113, 119, 123, 131, 137, 147, 157, 171, 180, 193, 204, 219, 221, 227, 235, 241, 246, 252, 256, 261, 265, 268, 277, 280, 283, 289, 296, 303, 312, 322, 336, 351, 361, 372, 388, 396, 412, 416, 422, 428, 435, 445, 454, 464, 473, 482, 491, 507, 522, 538, 553, 568, 583, 591, 596, 605, 611, 615, 622}
 
 var ScalarOperators = [...]Operator{
 	SubqueryOp,
@@ -307,6 +311,7 @@ var ScalarOperators = [...]Operator{
 	UnaryMinusOp,
 	UnaryComplementOp,
 	FunctionOp,
+	UnsupportedExprOp,
 }
 
 var ConstValueOperators = [...]Operator{

--- a/pkg/sql/opt/optbuilder/builder_test.go
+++ b/pkg/sql/opt/optbuilder/builder_test.go
@@ -18,7 +18,7 @@ package optbuilder
 // is used for optimizer builder-specific testcases.
 //
 // Each testfile contains testcases of the form
-//   <command>
+//   <command> [<args>]...
 //   <SQL statement or expression>
 //   ----
 //   <expected results>
@@ -40,6 +40,15 @@ package optbuilder
 //    Parses a CREATE TABLE statement, creates a test table, and adds the
 //    table to the catalog.
 //
+// The supported args are:
+//
+//  - vars=(type1,type2,...)
+//
+//    Information about IndexedVar columns.
+//
+//  - allow-unsupported
+//
+//    Allows building unsupported scalar expressions into UnsupportedExprOp.
 
 import (
 	"context"
@@ -84,6 +93,7 @@ func TestBuilder(t *testing.T) {
 			datadriven.RunTest(t, path, func(d *datadriven.TestData) string {
 				var varTypes []types.T
 				var iVarHelper tree.IndexedVarHelper
+				var allowUnsupportedExpr bool
 
 				for _, arg := range d.CmdArgs {
 					key := arg
@@ -105,6 +115,9 @@ func TestBuilder(t *testing.T) {
 
 						iVarHelper = tree.MakeTypesOnlyIndexedVarHelper(varTypes)
 
+					case "allow-unsupported":
+						allowUnsupportedExpr = true
+
 					default:
 						d.Fatalf(t, "unknown argument: %s", key)
 					}
@@ -119,6 +132,7 @@ func TestBuilder(t *testing.T) {
 
 					o := xform.NewOptimizer(catalog, xform.OptimizeNone)
 					b := New(ctx, o.Factory(), stmt)
+					b.AllowUnsupportedExpr = allowUnsupportedExpr
 					root, props, err := b.Build()
 					if err != nil {
 						return fmt.Sprintf("error: %v\n", err)
@@ -138,6 +152,7 @@ func TestBuilder(t *testing.T) {
 					}
 					o := xform.NewOptimizer(catalog, xform.OptimizeNone)
 					b := NewScalar(ctx, o.Factory(), varNames, varTypes)
+					b.AllowUnsupportedExpr = allowUnsupportedExpr
 					group, err := b.Build(typedExpr)
 					if err != nil {
 						return fmt.Sprintf("error: %v\n", err)

--- a/pkg/sql/opt/optbuilder/testdata/scalar
+++ b/pkg/sql/opt/optbuilder/testdata/scalar
@@ -231,3 +231,8 @@ build-scalar
 FALSE
 ----
 false [type=bool]
+
+build-scalar vars=(int) allow-unsupported
+CASE WHEN @1 > 5 THEN 1 ELSE -1 END
+----
+unsupported-expr: CASE WHEN @1 > 5 THEN 1 ELSE -1 END [type=int]

--- a/pkg/sql/opt/xform/typing.go
+++ b/pkg/sql/opt/xform/typing.go
@@ -42,15 +42,16 @@ var typingFuncMap [opt.NumOperators]typingFunc
 
 func init() {
 	typingFuncMap = [opt.NumOperators]typingFunc{
-		opt.VariableOp:     typeVariable,
-		opt.ConstOp:        typeAsTypedExpr,
-		opt.PlaceholderOp:  typeAsTypedExpr,
-		opt.TupleOp:        typeAsTuple,
-		opt.ProjectionsOp:  typeAsAny,
-		opt.GroupingsOp:    typeAsAny,
-		opt.AggregationsOp: typeAsAny,
-		opt.ExistsOp:       typeAsBool,
-		opt.FunctionOp:     typeFunction,
+		opt.VariableOp:        typeVariable,
+		opt.ConstOp:           typeAsTypedExpr,
+		opt.PlaceholderOp:     typeAsTypedExpr,
+		opt.UnsupportedExprOp: typeAsTypedExpr,
+		opt.TupleOp:           typeAsTuple,
+		opt.ProjectionsOp:     typeAsAny,
+		opt.GroupingsOp:       typeAsAny,
+		opt.AggregationsOp:    typeAsAny,
+		opt.ExistsOp:          typeAsBool,
+		opt.FunctionOp:        typeFunction,
 	}
 
 	for _, op := range opt.BooleanOperators {


### PR DESCRIPTION
The motivation for this is to "pass through" unsupported scalars when
doing index constraints (specifically, simplifying the expression).
This is temporary and will not be necessary when we replace the
current planning code.

To avoid hiding errors in the non-index-constraints path, we add a
flag to Builder.

Release note: None