### PR TITLE
sql: rationalize client errors received on query cancelation

### DIFF
--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -431,6 +431,7 @@ func (s *Server) ServeConn(
 		},
 		state: txnState2{
 			mon:           &txnMon,
+			connCtx:       ctx,
 			txnAbortCount: s.StatementCounters.TxnAbortCount,
 		},
 		transitionCtx: transitionCtx{

--- a/pkg/sql/conn_fsm.go
+++ b/pkg/sql/conn_fsm.go
@@ -406,8 +406,10 @@ var TxnStateTransitions = Compile(Pattern{
 
 				payload := args.Payload.(eventTxnStartPayload)
 
+				// Note that we pass the connection's context here, not args.Ctx which
+				// was the previous txn's context.
 				ts.resetForNewSQLTxn(
-					args.Ctx,
+					ts.connCtx,
 					explicitTxn,
 					payload.txnSQLTimestamp, payload.iso, payload.pri, payload.readOnly,
 					args.Payload.(eventTxnStartPayload).tranCtx,

--- a/pkg/sql/conn_io.go
+++ b/pkg/sql/conn_io.go
@@ -632,11 +632,15 @@ type ResultBase interface {
 // CommandResultClose is a subset of CommandResult dealing with the closing of
 // the result.
 type CommandResultClose interface {
-	// Close marks a result as complete. All results must be eventually closed
-	// through Close()/CloseWithErr()/Discard. No further uses of the CommandResult are
-	// allowed.
-	// The implementation is free to deliver it to the client at will (except if
-	// there's a ClientLock in effect).
+	// Close marks a result as complete. No further uses of the CommandResult are
+	// allowed after this call. All results must be eventually closed through
+	// Close()/CloseWithErr()/Discard(), except in case query processing has
+	// encountered an irrecoverable error and the client connection will be
+	// closed; in such cases it is not mandated that these functions are called on
+	// the result that may have been open at the time the error occurred.
+	// NOTE(andrei): We might want to tighten the contract if the results get any
+	// state that needs to be closed even when the whole connection is about to be
+	// terminated.
 	Close(TransactionStatusIndicator)
 
 	// CloseWithErr is like Close, except it tells the client that an execution
@@ -679,14 +683,6 @@ type RestrictedCommandResult interface {
 	// The implementation cannot hold on to the row slice; it needs to make a
 	// shallow copy if it needs to.
 	AddRow(ctx context.Context, row tree.Datums) error
-
-	// SetFinishedCallback takes a callback that will be called once
-	// Close/CloseWithErr/Discard is called. This is used by SQL to unregister
-	// queries from a registry of running queries.
-	//
-	// This can be called multiple times, each time overwriting the previous
-	// value. The callback can be nil, in which case nothing will be called.
-	SetFinishedCallback(callback func())
 
 	// IncrementRowsAffected increments a counter by n. This is used for all
 	// result types other than tree.Rows.
@@ -834,11 +830,6 @@ func (r *errOnlyRestrictedCommandResult) ResetStmtType(stmt tree.Statement) {
 
 // AddRow is part of the RestrictedCommandResult interface.
 func (r *errOnlyRestrictedCommandResult) AddRow(ctx context.Context, row tree.Datums) error {
-	panic("unimplemented")
-}
-
-// SetFinishedCallback is part of the RestrictedCommandResult interface.
-func (r *errOnlyRestrictedCommandResult) SetFinishedCallback(callback func()) {
 	panic("unimplemented")
 }
 

--- a/pkg/sql/conn_io.go
+++ b/pkg/sql/conn_io.go
@@ -614,12 +614,19 @@ type CommandResult interface {
 // query execution error.
 type CommandResultErrBase interface {
 	// SetError accumulates an execution error that needs to be reported to the
-	// client. No further calls other than Close() and Discard() are allowed. In
-	// particular, CloseWithErr() is not allowed.
+	// client. No further calls other than OverwriteError(), Close() and Discard()
+	// are allowed. In particular, CloseWithErr() is not allowed.
 	SetError(error)
 
 	// Err returns the error previously set with SetError(), if any.
 	Err() error
+
+	// OverwriteError is like SetError(), except it can be called after SetError()
+	// has already been called and it will overwrite the error. Used by high-level
+	// code when it has a strong opinion about what the error that should be
+	// returned to the client is and doesn't much care about whether an error has
+	// already been set on the result.
+	OverwriteError(error)
 }
 
 // ResultBase is the common interface implemented by all the different command
@@ -835,6 +842,11 @@ func (r *errOnlyRestrictedCommandResult) AddRow(ctx context.Context, row tree.Da
 
 // SetError is part of the RestrictedCommandResult interface.
 func (r *errOnlyRestrictedCommandResult) SetError(err error) {
+	r.err = err
+}
+
+// OverwriteError is part of the RestrictedCommandResult interface.
+func (r *errOnlyRestrictedCommandResult) OverwriteError(err error) {
 	r.err = err
 }
 

--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -340,8 +340,10 @@ func makeDistSQLReceiver(
 		updateClock:  updateClock,
 		stmtType:     stmtType,
 	}
-	// When the root transaction finishes (i.e. it is abandoned,
-	// aborted, or committed), ensure the dist SQL flow is canceled.
+	// When the root transaction finishes (i.e. it is abandoned, aborted, or
+	// committed), ensure the flow is canceled so that we don't return results to
+	// the client that might have missed seeing their own writes. The committed
+	// case shouldn't happen.
 	if r.txn != nil {
 		r.txn.OnFinish(func(err error) {
 			r.canceled.Store(errWrap{err: err})

--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -247,11 +247,11 @@ type distSQLReceiver struct {
 	// Once set, no more rows are accepted.
 	commErr error
 
-	// canceled is atomically set to an error when this distSQL receiver
-	// has been marked as canceled. Upon the next Push(), err is set to
-	// this value, and ConsumerClosed is the ConsumerStatus.
-	// It contains errWraps only.
-	canceled atomic.Value
+	// txnAbortedErr is atomically set to an errWrap when the KV txn finishes
+	// asynchronously. Further results should not be returned to the client, as
+	// they risk missing seeing their own writes. Upon the next Push(), err is set
+	// and ConsumerStatus is set to ConsumerClosed.
+	txnAbortedErr atomic.Value
 
 	row    tree.Datums
 	status distsqlrun.ConsumerStatus
@@ -312,7 +312,6 @@ func (w *errOnlyResultWriter) IncrementRowsAffected(n int) {
 }
 
 var _ distsqlrun.RowReceiver = &distSQLReceiver{}
-var _ distsqlrun.CancellableRowReceiver = &distSQLReceiver{}
 
 // makeDistSQLReceiver creates a distSQLReceiver.
 //
@@ -344,9 +343,13 @@ func makeDistSQLReceiver(
 	// committed), ensure the flow is canceled so that we don't return results to
 	// the client that might have missed seeing their own writes. The committed
 	// case shouldn't happen.
+	//
+	// TODO(andrei): Instead of doing this, should we lift this transaction
+	// monitoring to connExecutor and have it cancel the SQL txn's context? Or for
+	// that matter, should the TxnCoordSender cancel the context itself?
 	if r.txn != nil {
 		r.txn.OnFinish(func(err error) {
-			r.canceled.Store(errWrap{err: err})
+			r.txnAbortedErr.Store(errWrap{err: err})
 		})
 	}
 	return r
@@ -408,12 +411,14 @@ func (r *distSQLReceiver) Push(
 		}
 		return r.status
 	}
-	if r.resultWriter.Err() == nil && r.canceled.Load() != nil {
-		// Set the error to reflect query cancellation.
-		r.resultWriter.SetError(r.canceled.Load().(errWrap).err)
+	if r.resultWriter.Err() == nil && r.txnAbortedErr.Load() != nil {
+		r.resultWriter.SetError(r.txnAbortedErr.Load().(errWrap).err)
+	}
+	if r.resultWriter.Err() == nil && r.ctx.Err() != nil {
+		r.resultWriter.SetError(r.ctx.Err())
 	}
 	if r.resultWriter.Err() != nil {
-		// TODO(andrei): We should drain here.
+		// TODO(andrei): We should drain here if we weren't canceled.
 		return distsqlrun.ConsumerClosed
 	}
 	if r.status != distsqlrun.NeedMoreRows {
@@ -465,11 +470,6 @@ func (r *distSQLReceiver) ProducerDone() {
 		panic("double close")
 	}
 	r.closed = true
-}
-
-// SetCanceled is part of the CancellableRowReceiver interface.
-func (r *distSQLReceiver) SetCanceled() {
-	r.canceled.Store(errWrap{err: sqlbase.NewQueryCanceledError()})
 }
 
 // updateCaches takes information about some ranges that were mis-planned and

--- a/pkg/sql/distsqlrun/base.go
+++ b/pkg/sql/distsqlrun/base.go
@@ -82,17 +82,6 @@ type RowReceiver interface {
 	ProducerDone()
 }
 
-// CancellableRowReceiver is a special type of a RowReceiver that can be set to
-// canceled asynchronously (i.e. concurrently or after Push()es and ProducerDone()s).
-// Once canceled, subsequent Push()es return ConsumerClosed. Implemented by distSQLReceiver
-// which is the final RowReceiver, and the origin point for propagation of ConsumerClosed
-// consumer statuses.
-type CancellableRowReceiver interface {
-	// SetCanceled sets this RowReceiver as canceled. Subsequent Push()es (if any)
-	// return a ConsumerStatus of ConsumerClosed.
-	SetCanceled()
-}
-
 // RowSource is any component of a flow that produces rows that cam be consumed
 // by another component.
 type RowSource interface {

--- a/pkg/sql/distsqlrun/flow.go
+++ b/pkg/sql/distsqlrun/flow.go
@@ -512,7 +512,6 @@ func (f *Flow) Cleanup(ctx context.Context) {
 }
 
 // cancel iterates through all unconnected streams of this flow and marks them canceled.
-// If the syncFlowConsumer is of type CancellableRowReceiver, mark it as canceled.
 // This function is called in Wait() after the associated context has been canceled.
 // In order to cancel a flow, call f.ctxCancel() instead of this function.
 //
@@ -536,12 +535,6 @@ func (f *Flow) cancel() {
 				&ProducerMetadata{Err: sqlbase.NewQueryCanceledError()})
 			is.receiver.ProducerDone()
 			f.flowRegistry.finishInboundStreamLocked(f.id, streamID)
-		}
-	}
-
-	if f.syncFlowConsumer != nil {
-		if recv, ok := f.syncFlowConsumer.(CancellableRowReceiver); ok {
-			recv.SetCanceled()
 		}
 	}
 }

--- a/pkg/sql/sqlbase/errors.go
+++ b/pkg/sql/sqlbase/errors.go
@@ -223,14 +223,17 @@ func NewStatementCompletionUnknownError(err error) error {
 	return pgerror.NewErrorf(pgerror.CodeStatementCompletionUnknownError, err.Error())
 }
 
+var queryCanceledError error = pgerror.NewErrorf(
+	pgerror.CodeQueryCanceledError, "query execution canceled")
+
 // NewQueryCanceledError creates a query cancellation error.
 func NewQueryCanceledError() error {
-	return pgerror.NewErrorf(pgerror.CodeQueryCanceledError, "query execution canceled")
+	return queryCanceledError
 }
 
 // IsQueryCanceledError checks whether this is a query canceled error.
 func IsQueryCanceledError(err error) bool {
-	return errHasCode(err, pgerror.CodeQueryCanceledError) || strings.Contains(err.Error(), "query execution canceled")
+	return errHasCode(err, pgerror.CodeQueryCanceledError)
 }
 
 func errHasCode(err error, code string) bool {

--- a/pkg/sql/txn_state.go
+++ b/pkg/sql/txn_state.go
@@ -56,6 +56,9 @@ type txnState2 struct {
 		txn *client.Txn
 	}
 
+	// connCtx is the connection's context. This is the parent of Ctx.
+	connCtx context.Context
+
 	// Ctx is the context for everything running in this SQL txn.
 	// This is only set while the session's state is not stateNoTxn.
 	Ctx context.Context
@@ -69,9 +72,9 @@ type txnState2 struct {
 	recordingThreshold time.Duration
 	recordingStart     time.Time
 
-	// cancel is the cancellation function for the above context. Called upon
-	// COMMIT/ROLLBACK of the transaction to release resources associated with the
-	// context. nil when no txn is in progress.
+	// cancel is Ctx's cancellation function. Called upon COMMIT/ROLLBACK of the
+	// transaction to release resources associated with the context. nil when no
+	// txn is in progress.
 	cancel context.CancelFunc
 
 	// The timestamp to report for current_timestamp(), now() etc.

--- a/pkg/sql/txn_state_test.go
+++ b/pkg/sql/txn_state_test.go
@@ -48,7 +48,7 @@ type testContext struct {
 	mockDB      *client.DB
 	mon         mon.BytesMonitor
 	tracer      opentracing.Tracer
-	// ctx is mimicking the spirit of a clientn connection's context
+	// ctx is mimicking the spirit of a client connection's context
 	ctx      context.Context
 	settings *cluster.Settings
 }
@@ -115,6 +115,7 @@ func (tc *testContext) createOpenState(
 
 	ts := txnState2{
 		Ctx:           ctx,
+		connCtx:       tc.ctx,
 		sp:            sp,
 		cancel:        cancel,
 		sqlTimestamp:  timeutil.Now(),
@@ -169,7 +170,7 @@ func (tc *testContext) createNoTxnState() (State, *txnState2) {
 		1000, /* noteworthy */
 		cluster.MakeTestingClusterSettings(),
 	)
-	ts := txnState2{mon: &txnStateMon}
+	ts := txnState2{mon: &txnStateMon, connCtx: tc.ctx}
 	return stateNoTxn{}, &ts
 }
 


### PR DESCRIPTION
CANCEL QUERY <id> is implemented by canceling a query's ctx (really, a
txn's). When that happens, all sort of actors can notice that
cancelation (see
https://reviewable.io/reviews/cockroachdb/cockroach/22832#-L5nh8qj1FfqJ6lpMp-A
for a list). Different errors were generated by different actors and so
the client wasn't always getting the right error code.
Rather then making sure that everybody produces the right error, this
patch adds a check after the query has completed that can overwrite
whatever error has been set before on the result.

The question about whether anybody but that check should generate
NewQueryCanceledError() errors begets asking. Everybody else could
return non-structured errors, since they're going to be overwritten on
the gateway. I chose to not change that... whomever has generating
structured errs before continues to do so. I thought that perhaps the
structured errs are nicer for intermediary DistSQL nodes.

Fixes #22654

Release note: none