### PR TITLE
kv: scale LeaseHolderCache size in tests by shard count

### DIFF
--- a/pkg/kv/leaseholder_cache_test.go
+++ b/pkg/kv/leaseholder_cache_test.go
@@ -31,7 +31,7 @@ func staticSize(size int64) func() int64 {
 func TestLeaseHolderCache(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	ctx := context.TODO()
-	cacheSize := 1 << 5
+	cacheSize := (1 << 4) * defaultShards
 	lc := NewLeaseHolderCache(staticSize(int64(cacheSize)))
 	if repStoreID, ok := lc.Lookup(ctx, 12); ok {
 		t.Errorf("lookup of missing key returned: %d", repStoreID)
@@ -70,7 +70,7 @@ func TestLeaseHolderCache(t *testing.T) {
 func BenchmarkLeaseHolderCacheParallel(b *testing.B) {
 	defer leaktest.AfterTest(b)()
 	ctx := context.TODO()
-	cacheSize := 1 << 6
+	cacheSize := (1 << 4) * defaultShards
 	lc := NewLeaseHolderCache(staticSize(int64(cacheSize)))
 	numRanges := 2 * len(lc.shards)
 	for i := 1; i <= numRanges; i++ {


### PR DESCRIPTION
The LeaseHolderCache splits its available capacity across all shards.
This means that in tests where the total size is static, the size
available per shard shrinks as the number of CPUs grow. This was causing
the tests to fail on a 24 CPU machine.

This change addresses this by scaling the cache capacity by the shard
count.

Release note: None