### PR TITLE
opt: simplify the GroupBy operator

### DIFF
--- a/pkg/sql/opt/ops/relational.opt
+++ b/pkg/sql/opt/ops/relational.opt
@@ -156,11 +156,16 @@ define AntiJoinApply {
     On    Expr
 }
 
+# GroupBy is an operator that is used for performing aggregations (for queries
+# with aggregate functions, HAVING clauses and/or group by expressions). It
+# groups results that are equal on the grouping columns and computes
+# aggregations as described by Aggregations (which is always an Aggregations
+# operator). The arguments of the aggregations are columns from the input.
 [Relational]
 define GroupBy {
-    Input        Expr
-    Groupings    Expr
-    Aggregations Expr
+    Input           Expr
+    Aggregations    Expr
+    GroupingColumns ColSet
 }
 
 [Relational]

--- a/pkg/sql/opt/ops/scalar.opt
+++ b/pkg/sql/opt/ops/scalar.opt
@@ -63,23 +63,12 @@ define Projections {
 
 # Aggregations is a set of aggregate expressions that will become output
 # columns for a containing GroupBy operator. The private Cols field contains
-# the list of column indexes returned by the expression, as a *opt.ColList. It
+# the list of column indexes returned by the expression, as a *ColList. It
 # is legal for Cols to be empty.
 [Scalar]
 define Aggregations {
     Aggs ExprList
     Cols ColList
-}
-
-# Groupings is a set of grouping expressions that will become output columns
-# for a containing GroupBy operator. The GroupBy operator groups its input by
-# the value of these expressions, and may compute aggregates over the groups.
-# The private Cols field contains the list of column indexes returned by the
-# expression, as a *opt.ColList. It is legal for Cols to be empty.
-[Scalar]
-define Groupings {
-    Elems ExprList
-    Cols  ColList
 }
 
 [Scalar]

--- a/pkg/sql/opt/opt/factory.og.go
+++ b/pkg/sql/opt/opt/factory.og.go
@@ -68,17 +68,9 @@ type Factory interface {
 	// ConstructAggregations constructs an expression for the Aggregations operator.
 	// Aggregations is a set of aggregate expressions that will become output
 	// columns for a containing GroupBy operator. The private Cols field contains
-	// the list of column indexes returned by the expression, as a *opt.ColList. It
+	// the list of column indexes returned by the expression, as a *ColList. It
 	// is legal for Cols to be empty.
 	ConstructAggregations(aggs ListID, cols PrivateID) GroupID
-
-	// ConstructGroupings constructs an expression for the Groupings operator.
-	// Groupings is a set of grouping expressions that will become output columns
-	// for a containing GroupBy operator. The GroupBy operator groups its input by
-	// the value of these expressions, and may compute aggregates over the groups.
-	// The private Cols field contains the list of column indexes returned by the
-	// expression, as a *opt.ColList. It is legal for Cols to be empty.
-	ConstructGroupings(elems ListID, cols PrivateID) GroupID
 
 	// ConstructExists constructs an expression for the Exists operator.
 	ConstructExists(input GroupID) GroupID
@@ -318,7 +310,12 @@ type Factory interface {
 	ConstructAntiJoinApply(left GroupID, right GroupID, on GroupID) GroupID
 
 	// ConstructGroupBy constructs an expression for the GroupBy operator.
-	ConstructGroupBy(input GroupID, groupings GroupID, aggregations GroupID) GroupID
+	// GroupBy is an operator that is used for performing aggregations (for queries
+	// with aggregate functions, HAVING clauses and/or group by expressions). It
+	// groups results that are equal on the grouping columns and computes
+	// aggregations as described by Aggregations (which is always an Aggregations
+	// operator). The arguments of the aggregations are columns from the input.
+	ConstructGroupBy(input GroupID, aggregations GroupID, groupingColumns PrivateID) GroupID
 
 	// ConstructUnion constructs an expression for the Union operator.
 	ConstructUnion(left GroupID, right GroupID, colMap PrivateID) GroupID

--- a/pkg/sql/opt/opt/operator.og.go
+++ b/pkg/sql/opt/opt/operator.og.go
@@ -41,16 +41,9 @@ const (
 
 	// AggregationsOp is a set of aggregate expressions that will become output
 	// columns for a containing GroupBy operator. The private Cols field contains
-	// the list of column indexes returned by the expression, as a *opt.ColList. It
+	// the list of column indexes returned by the expression, as a *ColList. It
 	// is legal for Cols to be empty.
 	AggregationsOp
-
-	// GroupingsOp is a set of grouping expressions that will become output columns
-	// for a containing GroupBy operator. The GroupBy operator groups its input by
-	// the value of these expressions, and may compute aggregates over the groups.
-	// The private Cols field contains the list of column indexes returned by the
-	// expression, as a *opt.ColList. It is legal for Cols to be empty.
-	GroupingsOp
 
 	ExistsOp
 
@@ -225,6 +218,11 @@ const (
 
 	AntiJoinApplyOp
 
+	// GroupByOp is an operator that is used for performing aggregations (for queries
+	// with aggregate functions, HAVING clauses and/or group by expressions). It
+	// groups results that are equal on the grouping columns and computes
+	// aggregations as described by Aggregations (which is always an Aggregations
+	// operator). The arguments of the aggregations are columns from the input.
 	GroupByOp
 
 	UnionOp
@@ -259,9 +257,9 @@ const (
 	NumOperators
 )
 
-const opNames = "unknownsubqueryvariableconsttruefalseplaceholdertupleprojectionsaggregationsgroupingsexistsandornoteqltgtlegeneinnot-inlikenot-likei-likenot-i-likesimilar-tonot-similar-toreg-matchnot-reg-matchreg-i-matchnot-reg-i-matchisis-notcontainsbitandbitorbitxorplusminusmultdivfloor-divmodpowconcatl-shiftr-shiftfetch-valfetch-textfetch-val-pathfetch-text-pathunary-plusunary-minusunary-complementfunctioncoalesceunsupported-exprscanvaluesselectprojectinner-joinleft-joinright-joinfull-joinsemi-joinanti-joininner-join-applyleft-join-applyright-join-applyfull-join-applysemi-join-applyanti-join-applygroup-byunionintersectexceptsortpresent"
+const opNames = "unknownsubqueryvariableconsttruefalseplaceholdertupleprojectionsaggregationsexistsandornoteqltgtlegeneinnot-inlikenot-likei-likenot-i-likesimilar-tonot-similar-toreg-matchnot-reg-matchreg-i-matchnot-reg-i-matchisis-notcontainsbitandbitorbitxorplusminusmultdivfloor-divmodpowconcatl-shiftr-shiftfetch-valfetch-textfetch-val-pathfetch-text-pathunary-plusunary-minusunary-complementfunctioncoalesceunsupported-exprscanvaluesselectprojectinner-joinleft-joinright-joinfull-joinsemi-joinanti-joininner-join-applyleft-join-applyright-join-applyfull-join-applysemi-join-applyanti-join-applygroup-byunionintersectexceptsortpresent"
 
-var opIndexes = [...]uint32{0, 7, 15, 23, 28, 32, 37, 48, 53, 64, 76, 85, 91, 94, 96, 99, 101, 103, 105, 107, 109, 111, 113, 119, 123, 131, 137, 147, 157, 171, 180, 193, 204, 219, 221, 227, 235, 241, 246, 252, 256, 261, 265, 268, 277, 280, 283, 289, 296, 303, 312, 322, 336, 351, 361, 372, 388, 396, 404, 420, 424, 430, 436, 443, 453, 462, 472, 481, 490, 499, 515, 530, 546, 561, 576, 591, 599, 604, 613, 619, 623, 630}
+var opIndexes = [...]uint32{0, 7, 15, 23, 28, 32, 37, 48, 53, 64, 76, 82, 85, 87, 90, 92, 94, 96, 98, 100, 102, 104, 110, 114, 122, 128, 138, 148, 162, 171, 184, 195, 210, 212, 218, 226, 232, 237, 243, 247, 252, 256, 259, 268, 271, 274, 280, 287, 294, 303, 313, 327, 342, 352, 363, 379, 387, 395, 411, 415, 421, 427, 434, 444, 453, 463, 472, 481, 490, 506, 521, 537, 552, 567, 582, 590, 595, 604, 610, 614, 621}
 
 var ScalarOperators = [...]Operator{
 	SubqueryOp,
@@ -273,7 +271,6 @@ var ScalarOperators = [...]Operator{
 	TupleOp,
 	ProjectionsOp,
 	AggregationsOp,
-	GroupingsOp,
 	ExistsOp,
 	AndOp,
 	OrOp,

--- a/pkg/sql/opt/optbuilder/groupby.go
+++ b/pkg/sql/opt/optbuilder/groupby.go
@@ -1,0 +1,402 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package optbuilder
+
+// This file has builder code specific to aggregations (queries with GROUP BY,
+// HAVING, or aggregate functions).
+//
+// We build such queries using three operators:
+//
+//  - a pre-projection: a ProjectOp which generates the columns needed for
+//    the aggregation:
+//      - group by expressions
+//      - arguments to aggregation functions
+//
+//  - the aggregation: a GroupByOp which has the pre-projection as the
+//    input and produces columns with the results of the aggregation
+//    functions. The group by columns are also passed through.
+//
+//  - a post-projection: calculates expressions using the results of the
+//    aggregations; this is analogous to the ProjectOp that we would use for a
+//    no-aggregation Select.
+//
+// For example:
+//   SELECT 1 + MIN(v*2) FROM kv GROUP BY k+3
+//
+//   pre-projection:  k+3 (as col1), v*2 (as col2)
+//   aggregation:     group by col1, calculate MIN(col2) (as col3)
+//   post-projection: 1 + col3
+
+import (
+	"fmt"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/opt"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/transform"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
+)
+
+// groupby information stored in scopes.
+type groupby struct {
+	// See buildAggregation for a description of these scopes.
+	aggInScope  *scope
+	aggOutScope *scope
+
+	// aggs is used by aggOutScope (see buildAggregation); it contains information
+	// about aggregate functions encountered.
+	aggs []aggregateInfo
+
+	// groupings contains all group by expressions that were extracted from the
+	// query and which will become columns in this scope.
+	groupings []opt.GroupID
+
+	// groupStrs contains a string representation of each GROUP BY expression
+	// using symbolic notation. These strings are used to determine if SELECT
+	// and HAVING expressions contain sub-expressions matching a GROUP BY
+	// expression. This enables queries such as:
+	//    SELECT x+y FROM t GROUP BY x+y
+	// but not:
+	//    SELECT x+y FROM t GROUP BY y+x
+	groupStrs groupByStrSet
+
+	// inAgg is true within the body of an aggregate function. inAgg is used
+	// to ensure that nested aggregates are disallowed.
+	inAgg bool
+
+	// varsUsed is only utilized when groupingsScope is not nil.
+	// It keeps track of variables that are encountered by the builder that are:
+	//   (1) not explicit GROUP BY columns,
+	//   (2) not part of a sub-expression that matches a GROUP BY expression, and
+	//   (3) not contained in an aggregate.
+	//
+	// varsUsed is a slice rather than a set because the builder appends
+	// variables found in each sub-expression, and variables from individual
+	// sub-expresssions may be removed if they are found to match a GROUP BY
+	// expression. If any variables remain in varsUsed when the builder is
+	// done building a SELECT expression or HAVING clause, the builder throws
+	// an error.
+	//
+	// For example, consider this query:
+	//   SELECT COUNT(*), v/(k+v) FROM t.kv GROUP BY k+v
+	// When building the expression v/(k+v), varsUsed will contain the variables
+	// shown in brackets after each of the following expressions is built (in
+	// order of completed recursive calls):
+	//
+	//  1.   Build v [v]
+	//          \
+	//  2.       \  Build k [v, k]
+	//            \    \
+	//  3.         \    \  Build v [v, k, v]
+	//              \    \   /
+	//  4.           \  Build (k+v) [v]  <- truncate varsUsed since (k+v) matches
+	//                \   /                 a GROUP BY expression
+	//  5.          Build v/(k+v) [v] <- error - build is complete and varsUsed
+	//                                   is not empty
+	varsUsed []opt.ColumnIndex
+}
+
+// aggregateInfo stores information about an aggregation function call.
+type aggregateInfo struct {
+	def  opt.FuncDef
+	args []opt.GroupID
+}
+
+func (b *Builder) needsAggregation(sel *tree.SelectClause) bool {
+	// We have an aggregation if:
+	//  - we have a GROUP BY, or
+	//  - we have a HAVING clause, or
+	//  - we have aggregate functions in the select expressions.
+	return len(sel.GroupBy) > 0 || sel.Having != nil || b.hasAggregates(sel.Exprs)
+}
+
+// hasAggregates determines if any of the given select expressions contain an
+// aggregate function.
+func (b *Builder) hasAggregates(selects tree.SelectExprs) bool {
+	exprTransformCtx := transform.ExprTransformContext{}
+	for _, sel := range selects {
+		// TODO(rytaft): This function does not recurse into subqueries, so this
+		// will be incorrect for correlated subqueries.
+		if exprTransformCtx.AggregateInExpr(sel.Expr, b.semaCtx.SearchPath) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// buildAggregation builds the pre-projection and the aggregation operators.
+// Returns:
+//  - the group with the aggregation operator and the corresponding scope
+//  - post-projections with corresponding scope.
+func (b *Builder) buildAggregation(
+	sel *tree.SelectClause, fromGroup opt.GroupID, fromScope *scope,
+) (outGroup opt.GroupID, outScope *scope, projections []opt.GroupID, projectionsScope *scope) {
+	// We use two scopes:
+	//   - aggInScope contains columns that are used as input by the
+	//     GroupBy operator, specifically:
+	//      - grouping columns (from the GROUP BY)
+	//      - columns for the arguments to aggregate functions
+	//     The grouping columns always come first.
+	//
+	//   - aggOutScope contains columns that are produced by the GroupBy operator,
+	//     specifically:
+	//       - the grouping columns
+	//       - columns for the results of the aggregate functions.
+	//
+	// For example:
+	//
+	//   SELECT 1 + MIN(v*2) FROM kv GROUP BY k+3
+	//
+	//   aggInScope:   k+3 (as col1), v*2 (as col2)
+	//   aggOutScope:  k+3 (as col1), MIN(col2) (as col3)
+	//
+	// Any aggregate functions which contain column references to this scope
+	// trigger the creation of new grouping columns in the grouping scope. In
+	// addition, if an aggregate function contains no column references, then the
+	// aggregate will be added to the "nearest" grouping scope. For example:
+	//   SELECT MAX(1) FROM t1
+	//
+	// TODO(radu): we aren't really using these as scopes, just as columnProps
+	// containers. Perhaps separate the columnProps in a separate structure and
+	// pass that instead of scopes.
+	aggInScope := fromScope.replace()
+	aggOutScope := fromScope.replace()
+
+	// The "from" columns are visible to any grouping expressions.
+	groupings := b.buildGroupingList(sel.GroupBy, sel.Exprs, fromScope, aggInScope)
+
+	// Copy the grouping columns to the aggOutScope.
+	aggOutScope.appendColumns(aggInScope)
+
+	fromScope.groupby.groupings = groupings
+	fromScope.groupby.aggInScope = aggInScope
+	fromScope.groupby.aggOutScope = aggOutScope
+
+	var having opt.GroupID
+	if sel.Having != nil {
+		// Any "grouping" columns are visible to both the "having" and "projection"
+		// expressions. The build has the side effect of extracting aggregation
+		// columns.
+		having = b.buildHaving(sel.Having.Expr, fromScope)
+	}
+
+	projectionsScope = fromScope.replace()
+	// This is where the magic happens. When this call reaches an aggregate
+	// function that refers to variables in fromScope, buildAggregateFunction is
+	// called which adds columns to the aggInScope and aggOutScope.
+	projections = b.buildProjectionList(sel.Exprs, fromScope, projectionsScope)
+
+	aggInfos := aggOutScope.groupby.aggs
+
+	// Construct the pre-projection, which renders the grouping columns and the
+	// aggregate arguments.
+	outGroup = b.buildPreProjection(fromGroup, fromScope, aggInfos, aggInScope, groupings)
+
+	// Construct the aggregation. We represent the aggregations as Function
+	// operators with Variable arguments; construct those now.
+	aggExprs := make([]opt.GroupID, len(aggInfos))
+	argIdx := 0
+	for i, agg := range aggInfos {
+		argList := make([]opt.GroupID, len(agg.args))
+		for j := range agg.args {
+			colIndex := aggInScope.cols[argIdx].index
+			argIdx++
+			argList[j] = b.factory.ConstructVariable(b.factory.InternPrivate(colIndex))
+		}
+		aggExprs[i] = b.factory.ConstructFunction(
+			b.factory.InternList(argList),
+			b.factory.InternPrivate(agg.def),
+		)
+	}
+
+	aggList := b.constructList(opt.AggregationsOp, aggExprs, aggOutScope.getAggregateCols())
+	var groupingColSet opt.ColSet
+	for i := range groupings {
+		groupingColSet.Add(int(aggInScope.cols[i].index))
+	}
+	outGroup = b.factory.ConstructGroupBy(outGroup, aggList, b.factory.InternPrivate(&groupingColSet))
+
+	// Wrap with having filter if it exists.
+	if having != 0 {
+		outGroup = b.factory.ConstructSelect(outGroup, having)
+	}
+	return outGroup, aggOutScope, projections, projectionsScope
+}
+
+// buildPreProjection constructs the projection before a GroupBy. This
+// projection renders:
+//  - grouping columns
+//  - arguments to aggregate functions
+func (b *Builder) buildPreProjection(
+	fromGroup opt.GroupID,
+	fromScope *scope,
+	aggInfos []aggregateInfo,
+	aggInScope *scope,
+	groupings []opt.GroupID,
+) (outGroup opt.GroupID) {
+	// Don't add an unnecessary "pass-through" projection.
+	if fromScope.hasSameColumns(aggInScope) {
+		return fromGroup
+	}
+
+	preProjGroups := make([]opt.GroupID, 0, len(aggInScope.cols))
+	preProjGroups = append(preProjGroups, groupings...)
+
+	// Add the aggregate function arguments.
+	for _, agg := range aggInfos {
+		preProjGroups = append(preProjGroups, agg.args...)
+	}
+	// The aggInScope columns should match up with the grouping columns and the
+	// arguments.
+	if len(preProjGroups) != len(aggInScope.cols) {
+		panic(fmt.Sprintf(
+			"mismatch between aggregates and input scope columns: %d groups; cols: %v",
+			len(preProjGroups), aggInScope.cols,
+		))
+	}
+
+	preProjList := b.constructList(opt.ProjectionsOp, preProjGroups, aggInScope.cols)
+	return b.factory.ConstructProject(fromGroup, preProjList)
+}
+
+// buildHaving builds a set of memo groups that represent the given HAVING
+// clause. inScope contains the name bindings that are visible for this HAVING
+// clause (e.g., passed in from an enclosing statement).
+//
+// The return value corresponds to the top-level memo group ID for this
+// HAVING clause.
+func (b *Builder) buildHaving(having tree.Expr, inScope *scope) opt.GroupID {
+	out := b.buildScalar(inScope.resolveType(having, types.Bool), inScope)
+	if len(inScope.groupby.varsUsed) > 0 {
+		i := inScope.groupby.varsUsed[0]
+		col := b.colMap[i]
+		panic(groupingError(col.String()))
+	}
+	return out
+}
+
+// buildGroupingList builds a set of memo groups that represent a list of
+// GROUP BY expressions.
+//
+// groupBy  The given GROUP BY expressions.
+// selects  The select expressions are needed in case one of the GROUP BY
+//          expressions is an index into to the select list. For example,
+//              SELECT count(*), k FROM t GROUP BY 2
+//          indicates that the grouping is on the second select expression, k.
+//
+// The first return value `groupings` is an ordered list of top-level memo
+// groups corresponding to each GROUP BY expression. See Builder.buildStmt
+// above for a description of the remaining input and return values.
+func (b *Builder) buildGroupingList(
+	groupBy tree.GroupBy, selects tree.SelectExprs, inScope *scope, outScope *scope,
+) (groupings []opt.GroupID) {
+
+	groupings = make([]opt.GroupID, 0, len(groupBy))
+	inScope.groupby.groupStrs = make(groupByStrSet, len(groupBy))
+	for _, e := range groupBy {
+		subset := b.buildGrouping(e, selects, inScope, outScope)
+		groupings = append(groupings, subset...)
+	}
+
+	return groupings
+}
+
+// buildGrouping builds a set of memo groups that represent a GROUP BY
+// expression.
+//
+// groupBy  The given GROUP BY expression.
+// selects  The select expressions are needed in case the GROUP BY expression
+//          is an index into to the select list.
+//
+// The return value is an ordered list of top-level memo groups corresponding
+// to the expression. The list generally consists of a single memo group except
+// in the case of "*", where the expression is expanded to multiple columns.
+//
+// See Builder.buildStmt above for a description of the remaining input values
+// (outScope is passed as a parameter here rather than a return value because
+// the newly bound variables are appended to a growing list to be returned by
+// buildGroupingList).
+func (b *Builder) buildGrouping(
+	groupBy tree.Expr, selects tree.SelectExprs, inScope, outScope *scope,
+) []opt.GroupID {
+	// Unwrap parenthesized expressions like "((a))" to "a".
+	groupBy = tree.StripParens(groupBy)
+
+	// Check whether the GROUP BY clause refers to a column in the SELECT list
+	// by index, e.g. `SELECT a, SUM(b) FROM y GROUP BY 1`.
+	col := colIndex(len(selects), groupBy, "GROUP BY")
+	label := ""
+	if col != -1 {
+		groupBy = selects[col].Expr
+		label = string(selects[col].As)
+	}
+
+	// Resolve types, expand stars, and flatten tuples.
+	exprs := b.expandStarAndResolveType(groupBy, inScope)
+	exprs = flattenTuples(exprs)
+
+	// Finally, build each of the GROUP BY columns.
+	out := make([]opt.GroupID, 0, len(exprs))
+	for _, e := range exprs {
+		// Save a representation of the GROUP BY expression for validation of the
+		// SELECT and HAVING expressions. This enables queries such as:
+		//    SELECT x+y FROM t GROUP BY x+y
+		inScope.groupby.groupStrs[symbolicExprStr(e)] = exists
+		out = append(out, b.buildScalarProjection(e, label, inScope, outScope))
+	}
+	return out
+}
+
+// buildAggregateFunction is called when we are building a function which is an
+// aggregate.
+func (b *Builder) buildAggregateFunction(
+	f *tree.FuncExpr, funcDef opt.FuncDef, label string, inScope *scope,
+) (out opt.GroupID, col *columnProps) {
+	aggInScope, aggOutScope := inScope.startAggFunc()
+
+	info := aggregateInfo{
+		def:  funcDef,
+		args: make([]opt.GroupID, len(f.Exprs)),
+	}
+	aggInScopeColsBefore := len(aggInScope.cols)
+	for i, pexpr := range f.Exprs {
+		// This synthesizes a new aggInScope column, unless the argument is a simple
+		// VariableOp.
+		info.args[i] = b.buildScalarProjection(
+			pexpr.(tree.TypedExpr), "" /* label */, inScope, aggInScope,
+		)
+	}
+
+	inScope.endAggFunc()
+
+	// If we already have the same aggregation, reuse it. Otherwise add it
+	// to the list of aggregates that need to be computed by the groupby
+	// expression and synthesize a column for the aggregation result.
+	col = aggOutScope.findAggregate(info)
+	if col == nil {
+		col = b.synthesizeColumn(aggOutScope, label, f.ResolvedType())
+
+		// Add the aggregate to the list of aggregates that need to be computed by
+		// the groupby expression.
+		aggOutScope.groupby.aggs = append(aggOutScope.groupby.aggs, info)
+	} else {
+		// Undo the adding of the args.
+		// TODO(radu): is there a cleaner way to do this?
+		aggInScope.cols = aggInScope.cols[:aggInScopeColsBefore]
+	}
+
+	// Replace the function call with a reference to the column.
+	return b.factory.ConstructVariable(b.factory.InternPrivate(col.index)), col
+}

--- a/pkg/sql/opt/optbuilder/testdata/aggregate
+++ b/pkg/sql/opt/optbuilder/testdata/aggregate
@@ -19,54 +19,73 @@ SELECT MIN(1), MAX(1), COUNT(1), SUM_INT(1), AVG(1), SUM(1), STDDEV(1),
   VARIANCE(1), BOOL_AND(true), BOOL_AND(false), XOR_AGG(b'\x01') FROM t.kv
 ----
 group-by
- ├── columns: column5:int:null:5 column6:int:null:6 column7:int:null:7 column8:int:null:8 column9:decimal:null:9 column10:decimal:null:10 column11:decimal:null:11 column12:decimal:null:12 column13:bool:null:13 column14:bool:null:14 column15:bytes:null:15
- ├── scan
- │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
- ├── groupings
+ ├── aggregation columns: column6:int:null:6 column8:int:null:8 column10:int:null:10 column12:int:null:12 column14:decimal:null:14 column16:decimal:null:16 column18:decimal:null:18 column20:decimal:null:20 column22:bool:null:22 column24:bool:null:24 column26:bytes:null:26
+ ├── project
+ │    ├── columns: column5:int:null:5 column7:int:null:7 column9:int:null:9 column11:int:null:11 column13:int:null:13 column15:int:null:15 column17:int:null:17 column19:int:null:19 column21:bool:null:21 column23:bool:null:23 column25:bytes:null:25
+ │    ├── scan
+ │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
+ │    └── projections
+ │         ├── const: 1 [type=int]
+ │         ├── const: 1 [type=int]
+ │         ├── const: 1 [type=int]
+ │         ├── const: 1 [type=int]
+ │         ├── const: 1 [type=int]
+ │         ├── const: 1 [type=int]
+ │         ├── const: 1 [type=int]
+ │         ├── const: 1 [type=int]
+ │         ├── true [type=bool]
+ │         ├── false [type=bool]
+ │         └── const: '\x01' [type=bytes]
  └── aggregations
       ├── function: min [type=int]
-      │    └── const: 1 [type=int]
+      │    └── variable: column5 [type=int]
       ├── function: max [type=int]
-      │    └── const: 1 [type=int]
+      │    └── variable: column7 [type=int]
       ├── function: count [type=int]
-      │    └── const: 1 [type=int]
+      │    └── variable: column9 [type=int]
       ├── function: sum_int [type=int]
-      │    └── const: 1 [type=int]
+      │    └── variable: column11 [type=int]
       ├── function: avg [type=decimal]
-      │    └── const: 1 [type=int]
+      │    └── variable: column13 [type=int]
       ├── function: sum [type=decimal]
-      │    └── const: 1 [type=int]
+      │    └── variable: column15 [type=int]
       ├── function: stddev [type=decimal]
-      │    └── const: 1 [type=int]
+      │    └── variable: column17 [type=int]
       ├── function: variance [type=decimal]
-      │    └── const: 1 [type=int]
+      │    └── variable: column19 [type=int]
       ├── function: bool_and [type=bool]
-      │    └── true [type=bool]
+      │    └── variable: column21 [type=bool]
       ├── function: bool_and [type=bool]
-      │    └── false [type=bool]
+      │    └── variable: column23 [type=bool]
       └── function: xor_agg [type=bytes]
-           └── const: '\x01' [type=bytes]
+           └── variable: column25 [type=bytes]
 
 build
 SELECT ARRAY_AGG(1) FROM t.kv
 ----
 group-by
- ├── columns: column5:int[]:null:5
- ├── scan
- │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
- ├── groupings
+ ├── aggregation columns: column6:int[]:null:6
+ ├── project
+ │    ├── columns: column5:int:null:5
+ │    ├── scan
+ │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
+ │    └── projections
+ │         └── const: 1 [type=int]
  └── aggregations
       └── function: array_agg [type=int[]]
-           └── const: 1 [type=int]
+           └── variable: column5 [type=int]
 
 build
 SELECT JSON_AGG(v) FROM t.kv
 ----
 group-by
- ├── columns: column5:jsonb:null:5
- ├── scan
- │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
- ├── groupings
+ ├── aggregation columns: column5:jsonb:null:5
+ ├── project
+ │    ├── columns: kv.v:int:null:2
+ │    ├── scan
+ │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
+ │    └── projections
+ │         └── variable: kv.v [type=int]
  └── aggregations
       └── function: json_agg [type=jsonb]
            └── variable: kv.v [type=int]
@@ -75,13 +94,16 @@ build
 SELECT JSONB_AGG(1)
 ----
 group-by
- ├── columns: column1:jsonb:null:1
- ├── values
- │    └── tuple [type=tuple{}]
- ├── groupings
+ ├── aggregation columns: column2:jsonb:null:2
+ ├── project
+ │    ├── columns: column1:int:null:1
+ │    ├── values
+ │    │    └── tuple [type=tuple{}]
+ │    └── projections
+ │         └── const: 1 [type=int]
  └── aggregations
       └── function: jsonb_agg [type=jsonb]
-           └── const: 1 [type=int]
+           └── variable: column1 [type=int]
 
 # Even with no aggregate functions, grouping occurs in the presence of GROUP BY.
 build
@@ -90,11 +112,13 @@ SELECT 1 FROM t.kv GROUP BY v
 project
  ├── columns: column5:int:null:5
  ├── group-by
- │    ├── columns: kv.v:int:null:2
- │    ├── scan
- │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
- │    ├── groupings
- │    │    └── variable: kv.v [type=int]
+ │    ├── grouping columns: kv.v:int:null:2
+ │    ├── project
+ │    │    ├── columns: kv.v:int:null:2
+ │    │    ├── scan
+ │    │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
+ │    │    └── projections
+ │    │         └── variable: kv.v [type=int]
  │    └── aggregations
  └── projections
       └── const: 1 [type=int]
@@ -115,11 +139,14 @@ SELECT COUNT(*), k FROM t.kv GROUP BY k
 project
  ├── columns: column5:int:null:5 kv.k:int:null:1
  ├── group-by
- │    ├── columns: kv.k:int:null:1 column5:int:null:5
- │    ├── scan
- │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
- │    ├── groupings
- │    │    └── variable: kv.k [type=int]
+ │    ├── grouping columns: kv.k:int:null:1
+ │    ├── aggregation columns: column5:int:null:5
+ │    ├── project
+ │    │    ├── columns: kv.k:int:1
+ │    │    ├── scan
+ │    │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
+ │    │    └── projections
+ │    │         └── variable: kv.k [type=int]
  │    └── aggregations
  │         └── function: count_rows [type=int]
  └── projections
@@ -133,11 +160,14 @@ SELECT COUNT(*), k FROM t.kv GROUP BY 2
 project
  ├── columns: column5:int:null:5 kv.k:int:null:1
  ├── group-by
- │    ├── columns: kv.k:int:null:1 column5:int:null:5
- │    ├── scan
- │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
- │    ├── groupings
- │    │    └── variable: kv.k [type=int]
+ │    ├── grouping columns: kv.k:int:null:1
+ │    ├── aggregation columns: column5:int:null:5
+ │    ├── project
+ │    │    ├── columns: kv.k:int:1
+ │    │    ├── scan
+ │    │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
+ │    │    └── projections
+ │    │         └── variable: kv.k [type=int]
  │    └── aggregations
  │         └── function: count_rows [type=int]
  └── projections
@@ -166,11 +196,14 @@ SELECT COUNT(*), kv.s FROM t.kv GROUP BY s
 project
  ├── columns: column5:int:null:5 kv.s:string:null:4
  ├── group-by
- │    ├── columns: kv.s:string:null:4 column5:int:null:5
- │    ├── scan
- │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
- │    ├── groupings
- │    │    └── variable: kv.s [type=string]
+ │    ├── grouping columns: kv.s:string:null:4
+ │    ├── aggregation columns: column5:int:null:5
+ │    ├── project
+ │    │    ├── columns: kv.s:string:null:4
+ │    │    ├── scan
+ │    │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
+ │    │    └── projections
+ │    │         └── variable: kv.s [type=string]
  │    └── aggregations
  │         └── function: count_rows [type=int]
  └── projections
@@ -183,11 +216,14 @@ SELECT COUNT(*), s FROM t.kv GROUP BY kv.s
 project
  ├── columns: column5:int:null:5 kv.s:string:null:4
  ├── group-by
- │    ├── columns: kv.s:string:null:4 column5:int:null:5
- │    ├── scan
- │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
- │    ├── groupings
- │    │    └── variable: kv.s [type=string]
+ │    ├── grouping columns: kv.s:string:null:4
+ │    ├── aggregation columns: column5:int:null:5
+ │    ├── project
+ │    │    ├── columns: kv.s:string:null:4
+ │    │    ├── scan
+ │    │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
+ │    │    └── projections
+ │    │         └── variable: kv.s [type=string]
  │    └── aggregations
  │         └── function: count_rows [type=int]
  └── projections
@@ -200,11 +236,14 @@ SELECT COUNT(*), kv.s FROM t.kv GROUP BY kv.s
 project
  ├── columns: column5:int:null:5 kv.s:string:null:4
  ├── group-by
- │    ├── columns: kv.s:string:null:4 column5:int:null:5
- │    ├── scan
- │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
- │    ├── groupings
- │    │    └── variable: kv.s [type=string]
+ │    ├── grouping columns: kv.s:string:null:4
+ │    ├── aggregation columns: column5:int:null:5
+ │    ├── project
+ │    │    ├── columns: kv.s:string:null:4
+ │    │    ├── scan
+ │    │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
+ │    │    └── projections
+ │    │         └── variable: kv.s [type=string]
  │    └── aggregations
  │         └── function: count_rows [type=int]
  └── projections
@@ -217,11 +256,14 @@ SELECT COUNT(*), s FROM t.kv GROUP BY s
 project
  ├── columns: column5:int:null:5 kv.s:string:null:4
  ├── group-by
- │    ├── columns: kv.s:string:null:4 column5:int:null:5
- │    ├── scan
- │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
- │    ├── groupings
- │    │    └── variable: kv.s [type=string]
+ │    ├── grouping columns: kv.s:string:null:4
+ │    ├── aggregation columns: column5:int:null:5
+ │    ├── project
+ │    │    ├── columns: kv.s:string:null:4
+ │    │    ├── scan
+ │    │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
+ │    │    └── projections
+ │    │         └── variable: kv.s [type=string]
  │    └── aggregations
  │         └── function: count_rows [type=int]
  └── projections
@@ -235,12 +277,15 @@ SELECT v, COUNT(*), w FROM t.kv GROUP BY v, w
 project
  ├── columns: kv.v:int:null:2 column5:int:null:5 kv.w:int:null:3
  ├── group-by
- │    ├── columns: kv.v:int:null:2 kv.w:int:null:3 column5:int:null:5
- │    ├── scan
- │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
- │    ├── groupings
- │    │    ├── variable: kv.v [type=int]
- │    │    └── variable: kv.w [type=int]
+ │    ├── grouping columns: kv.v:int:null:2 kv.w:int:null:3
+ │    ├── aggregation columns: column5:int:null:5
+ │    ├── project
+ │    │    ├── columns: kv.v:int:null:2 kv.w:int:null:3
+ │    │    ├── scan
+ │    │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
+ │    │    └── projections
+ │    │         ├── variable: kv.v [type=int]
+ │    │         └── variable: kv.w [type=int]
  │    └── aggregations
  │         └── function: count_rows [type=int]
  └── projections
@@ -255,12 +300,15 @@ SELECT v, COUNT(*), w FROM t.kv GROUP BY 1, 3
 project
  ├── columns: kv.v:int:null:2 column5:int:null:5 kv.w:int:null:3
  ├── group-by
- │    ├── columns: kv.v:int:null:2 kv.w:int:null:3 column5:int:null:5
- │    ├── scan
- │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
- │    ├── groupings
- │    │    ├── variable: kv.v [type=int]
- │    │    └── variable: kv.w [type=int]
+ │    ├── grouping columns: kv.v:int:null:2 kv.w:int:null:3
+ │    ├── aggregation columns: column5:int:null:5
+ │    ├── project
+ │    │    ├── columns: kv.v:int:null:2 kv.w:int:null:3
+ │    │    ├── scan
+ │    │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
+ │    │    └── projections
+ │    │         ├── variable: kv.v [type=int]
+ │    │         └── variable: kv.w [type=int]
  │    └── aggregations
  │         └── function: count_rows [type=int]
  └── projections
@@ -275,12 +323,15 @@ SELECT COUNT(*), UPPER(s) FROM t.kv GROUP BY UPPER(s)
 project
  ├── columns: column6:int:null:6 column5:string:null:5
  ├── group-by
- │    ├── columns: column5:string:null:5 column6:int:null:6
- │    ├── scan
- │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
- │    ├── groupings
- │    │    └── function: upper [type=string]
- │    │         └── variable: kv.s [type=string]
+ │    ├── grouping columns: column5:string:null:5
+ │    ├── aggregation columns: column6:int:null:6
+ │    ├── project
+ │    │    ├── columns: column5:string:null:5
+ │    │    ├── scan
+ │    │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
+ │    │    └── projections
+ │    │         └── function: upper [type=string]
+ │    │              └── variable: kv.s [type=string]
  │    └── aggregations
  │         └── function: count_rows [type=int]
  └── projections
@@ -294,11 +345,14 @@ SELECT COUNT(*) FROM t.kv GROUP BY 1+2
 project
  ├── columns: column6:int:null:6
  ├── group-by
- │    ├── columns: column5:int:null:5 column6:int:null:6
- │    ├── scan
- │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
- │    ├── groupings
- │    │    └── const: 3 [type=int]
+ │    ├── grouping columns: column5:int:null:5
+ │    ├── aggregation columns: column6:int:null:6
+ │    ├── project
+ │    │    ├── columns: column5:int:null:5
+ │    │    ├── scan
+ │    │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
+ │    │    └── projections
+ │    │         └── const: 3 [type=int]
  │    └── aggregations
  │         └── function: count_rows [type=int]
  └── projections
@@ -310,12 +364,15 @@ SELECT COUNT(*) FROM t.kv GROUP BY length('abc')
 project
  ├── columns: column6:int:null:6
  ├── group-by
- │    ├── columns: column5:int:null:5 column6:int:null:6
- │    ├── scan
- │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
- │    ├── groupings
- │    │    └── function: length [type=int]
- │    │         └── const: 'abc' [type=string]
+ │    ├── grouping columns: column5:int:null:5
+ │    ├── aggregation columns: column6:int:null:6
+ │    ├── project
+ │    │    ├── columns: column5:int:null:5
+ │    │    ├── scan
+ │    │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
+ │    │    └── projections
+ │    │         └── function: length [type=int]
+ │    │              └── const: 'abc' [type=string]
  │    └── aggregations
  │         └── function: count_rows [type=int]
  └── projections
@@ -328,11 +385,14 @@ SELECT COUNT(*), UPPER(s) FROM t.kv GROUP BY s
 project
  ├── columns: column5:int:null:5 column6:string:null:6
  ├── group-by
- │    ├── columns: kv.s:string:null:4 column5:int:null:5
- │    ├── scan
- │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
- │    ├── groupings
- │    │    └── variable: kv.s [type=string]
+ │    ├── grouping columns: kv.s:string:null:4
+ │    ├── aggregation columns: column5:int:null:5
+ │    ├── project
+ │    │    ├── columns: kv.s:string:null:4
+ │    │    ├── scan
+ │    │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
+ │    │    └── projections
+ │    │         └── variable: kv.s [type=string]
  │    └── aggregations
  │         └── function: count_rows [type=int]
  └── projections
@@ -353,13 +413,16 @@ SELECT COUNT(*), k+v FROM t.kv GROUP BY k+v
 project
  ├── columns: column6:int:null:6 column5:int:null:5
  ├── group-by
- │    ├── columns: column5:int:null:5 column6:int:null:6
- │    ├── scan
- │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
- │    ├── groupings
- │    │    └── plus [type=int]
- │    │         ├── variable: kv.k [type=int]
- │    │         └── variable: kv.v [type=int]
+ │    ├── grouping columns: column5:int:null:5
+ │    ├── aggregation columns: column6:int:null:6
+ │    ├── project
+ │    │    ├── columns: column5:int:null:5
+ │    │    ├── scan
+ │    │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
+ │    │    └── projections
+ │    │         └── plus [type=int]
+ │    │              ├── variable: kv.k [type=int]
+ │    │              └── variable: kv.v [type=int]
  │    └── aggregations
  │         └── function: count_rows [type=int]
  └── projections
@@ -374,12 +437,15 @@ SELECT COUNT(*), k+v FROM t.kv GROUP BY k, v
 project
  ├── columns: column5:int:null:5 column6:int:null:6
  ├── group-by
- │    ├── columns: kv.k:int:null:1 kv.v:int:null:2 column5:int:null:5
- │    ├── scan
- │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
- │    ├── groupings
- │    │    ├── variable: kv.k [type=int]
- │    │    └── variable: kv.v [type=int]
+ │    ├── grouping columns: kv.k:int:null:1 kv.v:int:null:2
+ │    ├── aggregation columns: column5:int:null:5
+ │    ├── project
+ │    │    ├── columns: kv.k:int:1 kv.v:int:null:2
+ │    │    ├── scan
+ │    │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
+ │    │    └── projections
+ │    │         ├── variable: kv.k [type=int]
+ │    │         └── variable: kv.v [type=int]
  │    └── aggregations
  │         └── function: count_rows [type=int]
  └── projections
@@ -420,16 +486,20 @@ SELECT count(kv.k) AS count_1, kv.v + kv.w AS lx FROM t.kv GROUP BY kv.v + kv.w
 project
  ├── columns: count_1:int:null:6 column5:int:null:5
  ├── group-by
- │    ├── columns: column5:int:null:5 count_1:int:null:6
- │    ├── scan
- │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
- │    ├── groupings
- │    │    └── plus [type=int]
- │    │         ├── variable: kv.v [type=int]
- │    │         └── variable: kv.w [type=int]
+ │    ├── grouping columns: column5:int:null:5
+ │    ├── aggregation columns: count_1:int:null:6
+ │    ├── project
+ │    │    ├── columns: column5:int:null:5 kv.k:int:1
+ │    │    ├── scan
+ │    │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
+ │    │    └── projections
+ │    │         ├── plus [type=int]
+ │    │         │    ├── variable: kv.v [type=int]
+ │    │         │    └── variable: kv.w [type=int]
+ │    │         └── variable: kv.k [type=int]
  │    └── aggregations
  │         └── function: count [type=int]
- │              └── variable: kv.k [type=int]
+ │              └── variable: column5 [type=int]
  └── projections
       ├── variable: count_1 [type=int]
       └── variable: column5 [type=int]
@@ -438,10 +508,9 @@ build
 SELECT COUNT(*)
 ----
 group-by
- ├── columns: column1:int:null:1
+ ├── aggregation columns: column1:int:null:1
  ├── values
  │    └── tuple [type=tuple{}]
- ├── groupings
  └── aggregations
       └── function: count_rows [type=int]
 
@@ -449,10 +518,13 @@ build
 SELECT COUNT(k) from t.kv
 ----
 group-by
- ├── columns: column5:int:null:5
- ├── scan
- │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
- ├── groupings
+ ├── aggregation columns: column5:int:null:5
+ ├── project
+ │    ├── columns: kv.k:int:1
+ │    ├── scan
+ │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
+ │    └── projections
+ │         └── variable: kv.k [type=int]
  └── aggregations
       └── function: count [type=int]
            └── variable: kv.k [type=int]
@@ -461,25 +533,31 @@ build
 SELECT COUNT(1)
 ----
 group-by
- ├── columns: column1:int:null:1
- ├── values
- │    └── tuple [type=tuple{}]
- ├── groupings
+ ├── aggregation columns: column2:int:null:2
+ ├── project
+ │    ├── columns: column1:int:null:1
+ │    ├── values
+ │    │    └── tuple [type=tuple{}]
+ │    └── projections
+ │         └── const: 1 [type=int]
  └── aggregations
       └── function: count [type=int]
-           └── const: 1 [type=int]
+           └── variable: column1 [type=int]
 
 build
 SELECT COUNT(1) from t.kv
 ----
 group-by
- ├── columns: column5:int:null:5
- ├── scan
- │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
- ├── groupings
+ ├── aggregation columns: column6:int:null:6
+ ├── project
+ │    ├── columns: column5:int:null:5
+ │    ├── scan
+ │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
+ │    └── projections
+ │         └── const: 1 [type=int]
  └── aggregations
       └── function: count [type=int]
-           └── const: 1 [type=int]
+           └── variable: column5 [type=int]
 
 build
 SELECT COUNT(k, v) FROM t.kv
@@ -490,10 +568,14 @@ build
 SELECT COUNT(*), COUNT(k), COUNT(kv.v) FROM t.kv
 ----
 group-by
- ├── columns: column5:int:null:5 column6:int:null:6 column7:int:null:7
- ├── scan
- │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
- ├── groupings
+ ├── aggregation columns: column5:int:null:5 column6:int:null:6 column7:int:null:7
+ ├── project
+ │    ├── columns: kv.k:int:1 kv.v:int:null:2
+ │    ├── scan
+ │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
+ │    └── projections
+ │         ├── variable: kv.k [type=int]
+ │         └── variable: kv.v [type=int]
  └── aggregations
       ├── function: count_rows [type=int]
       ├── function: count [type=int]
@@ -511,15 +593,18 @@ build
 SELECT COUNT((k, v)) FROM t.kv
 ----
 group-by
- ├── columns: column5:int:null:5
- ├── scan
- │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
- ├── groupings
+ ├── aggregation columns: column6:int:null:6
+ ├── project
+ │    ├── columns: column5:tuple{int, int}:null:5
+ │    ├── scan
+ │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
+ │    └── projections
+ │         └── tuple [type=tuple{int, int}]
+ │              ├── variable: kv.k [type=int]
+ │              └── variable: kv.v [type=int]
  └── aggregations
       └── function: count [type=int]
-           └── tuple [type=tuple{int, int}]
-                ├── variable: kv.k [type=int]
-                └── variable: kv.v [type=int]
+           └── variable: column5 [type=tuple{int, int}]
 
 build
 SELECT COUNT(k)+COUNT(kv.v) FROM t.kv
@@ -527,10 +612,14 @@ SELECT COUNT(k)+COUNT(kv.v) FROM t.kv
 project
  ├── columns: column7:int:null:7
  ├── group-by
- │    ├── columns: column5:int:null:5 column6:int:null:6
- │    ├── scan
- │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
- │    ├── groupings
+ │    ├── aggregation columns: column5:int:null:5 column6:int:null:6
+ │    ├── project
+ │    │    ├── columns: kv.k:int:1 kv.v:int:null:2
+ │    │    ├── scan
+ │    │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
+ │    │    └── projections
+ │    │         ├── variable: kv.k [type=int]
+ │    │         └── variable: kv.v [type=int]
  │    └── aggregations
  │         ├── function: count [type=int]
  │         │    └── variable: kv.k [type=int]
@@ -545,10 +634,16 @@ build
 SELECT MIN(k), MAX(k), MIN(v), MAX(v) FROM t.kv
 ----
 group-by
- ├── columns: column5:int:null:5 column6:int:null:6 column7:int:null:7 column8:int:null:8
- ├── scan
- │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
- ├── groupings
+ ├── aggregation columns: column5:int:null:5 column6:int:null:6 column7:int:null:7 column8:int:null:8
+ ├── project
+ │    ├── columns: kv.k:int:1 kv.k:int:1 kv.v:int:null:2 kv.v:int:null:2
+ │    ├── scan
+ │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
+ │    └── projections
+ │         ├── variable: kv.k [type=int]
+ │         ├── variable: kv.k [type=int]
+ │         ├── variable: kv.v [type=int]
+ │         └── variable: kv.v [type=int]
  └── aggregations
       ├── function: min [type=int]
       │    └── variable: kv.k [type=int]
@@ -563,15 +658,21 @@ build
 SELECT MIN(k), MAX(k), MIN(v), MAX(v) FROM t.kv WHERE k > 8
 ----
 group-by
- ├── columns: column5:int:null:5 column6:int:null:6 column7:int:null:7 column8:int:null:8
- ├── select
- │    ├── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
- │    ├── scan
- │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
- │    └── gt [type=bool]
+ ├── aggregation columns: column5:int:null:5 column6:int:null:6 column7:int:null:7 column8:int:null:8
+ ├── project
+ │    ├── columns: kv.k:int:1 kv.k:int:1 kv.v:int:null:2 kv.v:int:null:2
+ │    ├── select
+ │    │    ├── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
+ │    │    ├── scan
+ │    │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
+ │    │    └── gt [type=bool]
+ │    │         ├── variable: kv.k [type=int]
+ │    │         └── const: 8 [type=int]
+ │    └── projections
  │         ├── variable: kv.k [type=int]
- │         └── const: 8 [type=int]
- ├── groupings
+ │         ├── variable: kv.k [type=int]
+ │         ├── variable: kv.v [type=int]
+ │         └── variable: kv.v [type=int]
  └── aggregations
       ├── function: min [type=int]
       │    └── variable: kv.k [type=int]
@@ -586,15 +687,18 @@ build
 SELECT array_agg(s) FROM t.kv WHERE s IS NULL
 ----
 group-by
- ├── columns: column5:string[]:null:5
- ├── select
- │    ├── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
- │    ├── scan
- │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
- │    └── is [type=bool]
- │         ├── variable: kv.s [type=string]
- │         └── const: NULL [type=NULL]
- ├── groupings
+ ├── aggregation columns: column5:string[]:null:5
+ ├── project
+ │    ├── columns: kv.s:string:null:4
+ │    ├── select
+ │    │    ├── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
+ │    │    ├── scan
+ │    │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
+ │    │    └── is [type=bool]
+ │    │         ├── variable: kv.s [type=string]
+ │    │         └── const: NULL [type=NULL]
+ │    └── projections
+ │         └── variable: kv.s [type=string]
  └── aggregations
       └── function: array_agg [type=string[]]
            └── variable: kv.s [type=string]
@@ -603,10 +707,16 @@ build
 SELECT AVG(k), AVG(v), SUM(k), SUM(v) FROM t.kv
 ----
 group-by
- ├── columns: column5:decimal:null:5 column6:decimal:null:6 column7:decimal:null:7 column8:decimal:null:8
- ├── scan
- │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
- ├── groupings
+ ├── aggregation columns: column5:decimal:null:5 column6:decimal:null:6 column7:decimal:null:7 column8:decimal:null:8
+ ├── project
+ │    ├── columns: kv.k:int:1 kv.v:int:null:2 kv.k:int:1 kv.v:int:null:2
+ │    ├── scan
+ │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
+ │    └── projections
+ │         ├── variable: kv.k [type=int]
+ │         ├── variable: kv.v [type=int]
+ │         ├── variable: kv.k [type=int]
+ │         └── variable: kv.v [type=int]
  └── aggregations
       ├── function: avg [type=decimal]
       │    └── variable: kv.k [type=int]
@@ -635,10 +745,9 @@ build
 SELECT MIN(a), MIN(b), MIN(c), MIN(d) FROM t.abc
 ----
 group-by
- ├── columns: column5:string:null:5 column6:float:null:6 column7:bool:null:7 column8:decimal:null:8
+ ├── aggregation columns: column5:string:null:5 column6:float:null:6 column7:bool:null:7 column8:decimal:null:8
  ├── scan
  │    └── columns: abc.a:string:1 abc.b:float:null:2 abc.c:bool:null:3 abc.d:decimal:null:4
- ├── groupings
  └── aggregations
       ├── function: min [type=string]
       │    └── variable: abc.a [type=string]
@@ -653,10 +762,9 @@ build
 SELECT MAX(a), MAX(b), MAX(c), MAX(d) FROM t.abc
 ----
 group-by
- ├── columns: column5:string:null:5 column6:float:null:6 column7:bool:null:7 column8:decimal:null:8
+ ├── aggregation columns: column5:string:null:5 column6:float:null:6 column7:bool:null:7 column8:decimal:null:8
  ├── scan
  │    └── columns: abc.a:string:1 abc.b:float:null:2 abc.c:bool:null:3 abc.d:decimal:null:4
- ├── groupings
  └── aggregations
       ├── function: max [type=string]
       │    └── variable: abc.a [type=string]
@@ -671,10 +779,16 @@ build
 SELECT AVG(b), SUM(b), AVG(d), SUM(d) FROM t.abc
 ----
 group-by
- ├── columns: column5:float:null:5 column6:float:null:6 column7:decimal:null:7 column8:decimal:null:8
- ├── scan
- │    └── columns: abc.a:string:1 abc.b:float:null:2 abc.c:bool:null:3 abc.d:decimal:null:4
- ├── groupings
+ ├── aggregation columns: column5:float:null:5 column6:float:null:6 column7:decimal:null:7 column8:decimal:null:8
+ ├── project
+ │    ├── columns: abc.b:float:null:2 abc.b:float:null:2 abc.d:decimal:null:4 abc.d:decimal:null:4
+ │    ├── scan
+ │    │    └── columns: abc.a:string:1 abc.b:float:null:2 abc.c:bool:null:3 abc.d:decimal:null:4
+ │    └── projections
+ │         ├── variable: abc.b [type=float]
+ │         ├── variable: abc.b [type=float]
+ │         ├── variable: abc.d [type=decimal]
+ │         └── variable: abc.d [type=decimal]
  └── aggregations
       ├── function: avg [type=float]
       │    └── variable: abc.b [type=float]
@@ -698,10 +812,9 @@ build
 SELECT SUM(a) FROM t.intervals
 ----
 group-by
- ├── columns: column2:interval:null:2
+ ├── aggregation columns: column2:interval:null:2
  ├── scan
  │    └── columns: intervals.a:interval:1
- ├── groupings
  └── aggregations
       └── function: sum [type=interval]
            └── variable: intervals.a [type=interval]
@@ -757,10 +870,13 @@ build
 SELECT MIN(x) FROM t.xyz
 ----
 group-by
- ├── columns: column4:int:null:4
- ├── scan
- │    └── columns: xyz.x:int:1 xyz.y:int:null:2 xyz.z:float:null:3
- ├── groupings
+ ├── aggregation columns: column4:int:null:4
+ ├── project
+ │    ├── columns: xyz.x:int:1
+ │    ├── scan
+ │    │    └── columns: xyz.x:int:1 xyz.y:int:null:2 xyz.z:float:null:3
+ │    └── projections
+ │         └── variable: xyz.x [type=int]
  └── aggregations
       └── function: min [type=int]
            └── variable: xyz.x [type=int]
@@ -769,18 +885,21 @@ build
 SELECT MIN(x) FROM t.xyz WHERE x in (0, 4, 7)
 ----
 group-by
- ├── columns: column4:int:null:4
- ├── select
- │    ├── columns: xyz.x:int:1 xyz.y:int:null:2 xyz.z:float:null:3
- │    ├── scan
- │    │    └── columns: xyz.x:int:1 xyz.y:int:null:2 xyz.z:float:null:3
- │    └── in [type=bool]
- │         ├── variable: xyz.x [type=int]
- │         └── tuple [type=tuple{int, int, int}]
- │              ├── const: 0 [type=int]
- │              ├── const: 4 [type=int]
- │              └── const: 7 [type=int]
- ├── groupings
+ ├── aggregation columns: column4:int:null:4
+ ├── project
+ │    ├── columns: xyz.x:int:1
+ │    ├── select
+ │    │    ├── columns: xyz.x:int:1 xyz.y:int:null:2 xyz.z:float:null:3
+ │    │    ├── scan
+ │    │    │    └── columns: xyz.x:int:1 xyz.y:int:null:2 xyz.z:float:null:3
+ │    │    └── in [type=bool]
+ │    │         ├── variable: xyz.x [type=int]
+ │    │         └── tuple [type=tuple{int, int, int}]
+ │    │              ├── const: 0 [type=int]
+ │    │              ├── const: 4 [type=int]
+ │    │              └── const: 7 [type=int]
+ │    └── projections
+ │         └── variable: xyz.x [type=int]
  └── aggregations
       └── function: min [type=int]
            └── variable: xyz.x [type=int]
@@ -789,10 +908,13 @@ build
 SELECT MAX(x) FROM t.xyz
 ----
 group-by
- ├── columns: column4:int:null:4
- ├── scan
- │    └── columns: xyz.x:int:1 xyz.y:int:null:2 xyz.z:float:null:3
- ├── groupings
+ ├── aggregation columns: column4:int:null:4
+ ├── project
+ │    ├── columns: xyz.x:int:1
+ │    ├── scan
+ │    │    └── columns: xyz.x:int:1 xyz.y:int:null:2 xyz.z:float:null:3
+ │    └── projections
+ │         └── variable: xyz.x [type=int]
  └── aggregations
       └── function: max [type=int]
            └── variable: xyz.x [type=int]
@@ -801,15 +923,18 @@ build
 SELECT MAX(y) FROM t.xyz WHERE x = 1
 ----
 group-by
- ├── columns: column4:int:null:4
- ├── select
- │    ├── columns: xyz.x:int:1 xyz.y:int:null:2 xyz.z:float:null:3
- │    ├── scan
- │    │    └── columns: xyz.x:int:1 xyz.y:int:null:2 xyz.z:float:null:3
- │    └── eq [type=bool]
- │         ├── variable: xyz.x [type=int]
- │         └── const: 1 [type=int]
- ├── groupings
+ ├── aggregation columns: column4:int:null:4
+ ├── project
+ │    ├── columns: xyz.y:int:null:2
+ │    ├── select
+ │    │    ├── columns: xyz.x:int:1 xyz.y:int:null:2 xyz.z:float:null:3
+ │    │    ├── scan
+ │    │    │    └── columns: xyz.x:int:1 xyz.y:int:null:2 xyz.z:float:null:3
+ │    │    └── eq [type=bool]
+ │    │         ├── variable: xyz.x [type=int]
+ │    │         └── const: 1 [type=int]
+ │    └── projections
+ │         └── variable: xyz.y [type=int]
  └── aggregations
       └── function: max [type=int]
            └── variable: xyz.y [type=int]
@@ -818,15 +943,18 @@ build
 SELECT MIN(y) FROM t.xyz WHERE x = 7
 ----
 group-by
- ├── columns: column4:int:null:4
- ├── select
- │    ├── columns: xyz.x:int:1 xyz.y:int:null:2 xyz.z:float:null:3
- │    ├── scan
- │    │    └── columns: xyz.x:int:1 xyz.y:int:null:2 xyz.z:float:null:3
- │    └── eq [type=bool]
- │         ├── variable: xyz.x [type=int]
- │         └── const: 7 [type=int]
- ├── groupings
+ ├── aggregation columns: column4:int:null:4
+ ├── project
+ │    ├── columns: xyz.y:int:null:2
+ │    ├── select
+ │    │    ├── columns: xyz.x:int:1 xyz.y:int:null:2 xyz.z:float:null:3
+ │    │    ├── scan
+ │    │    │    └── columns: xyz.x:int:1 xyz.y:int:null:2 xyz.z:float:null:3
+ │    │    └── eq [type=bool]
+ │    │         ├── variable: xyz.x [type=int]
+ │    │         └── const: 7 [type=int]
+ │    └── projections
+ │         └── variable: xyz.y [type=int]
  └── aggregations
       └── function: min [type=int]
            └── variable: xyz.y [type=int]
@@ -835,19 +963,22 @@ build
 SELECT MIN(x) FROM t.xyz WHERE (y, z) = (2, 3.0)
 ----
 group-by
- ├── columns: column4:int:null:4
- ├── select
- │    ├── columns: xyz.x:int:1 xyz.y:int:null:2 xyz.z:float:null:3
- │    ├── scan
- │    │    └── columns: xyz.x:int:1 xyz.y:int:null:2 xyz.z:float:null:3
- │    └── eq [type=bool]
- │         ├── tuple [type=tuple{int, float}]
- │         │    ├── variable: xyz.y [type=int]
- │         │    └── variable: xyz.z [type=float]
- │         └── tuple [type=tuple{int, float}]
- │              ├── const: 2 [type=int]
- │              └── const: 3.0 [type=float]
- ├── groupings
+ ├── aggregation columns: column4:int:null:4
+ ├── project
+ │    ├── columns: xyz.x:int:1
+ │    ├── select
+ │    │    ├── columns: xyz.x:int:1 xyz.y:int:null:2 xyz.z:float:null:3
+ │    │    ├── scan
+ │    │    │    └── columns: xyz.x:int:1 xyz.y:int:null:2 xyz.z:float:null:3
+ │    │    └── eq [type=bool]
+ │    │         ├── tuple [type=tuple{int, float}]
+ │    │         │    ├── variable: xyz.y [type=int]
+ │    │         │    └── variable: xyz.z [type=float]
+ │    │         └── tuple [type=tuple{int, float}]
+ │    │              ├── const: 2 [type=int]
+ │    │              └── const: 3.0 [type=float]
+ │    └── projections
+ │         └── variable: xyz.x [type=int]
  └── aggregations
       └── function: min [type=int]
            └── variable: xyz.x [type=int]
@@ -856,19 +987,22 @@ build
 SELECT MAX(x) FROM t.xyz WHERE (z, y) = (3.0, 2)
 ----
 group-by
- ├── columns: column4:int:null:4
- ├── select
- │    ├── columns: xyz.x:int:1 xyz.y:int:null:2 xyz.z:float:null:3
- │    ├── scan
- │    │    └── columns: xyz.x:int:1 xyz.y:int:null:2 xyz.z:float:null:3
- │    └── eq [type=bool]
- │         ├── tuple [type=tuple{float, int}]
- │         │    ├── variable: xyz.z [type=float]
- │         │    └── variable: xyz.y [type=int]
- │         └── tuple [type=tuple{float, int}]
- │              ├── const: 3.0 [type=float]
- │              └── const: 2 [type=int]
- ├── groupings
+ ├── aggregation columns: column4:int:null:4
+ ├── project
+ │    ├── columns: xyz.x:int:1
+ │    ├── select
+ │    │    ├── columns: xyz.x:int:1 xyz.y:int:null:2 xyz.z:float:null:3
+ │    │    ├── scan
+ │    │    │    └── columns: xyz.x:int:1 xyz.y:int:null:2 xyz.z:float:null:3
+ │    │    └── eq [type=bool]
+ │    │         ├── tuple [type=tuple{float, int}]
+ │    │         │    ├── variable: xyz.z [type=float]
+ │    │         │    └── variable: xyz.y [type=int]
+ │    │         └── tuple [type=tuple{float, int}]
+ │    │              ├── const: 3.0 [type=float]
+ │    │              └── const: 2 [type=int]
+ │    └── projections
+ │         └── variable: xyz.x [type=int]
  └── aggregations
       └── function: max [type=int]
            └── variable: xyz.x [type=int]
@@ -880,15 +1014,18 @@ build
 SELECT VARIANCE(x) FROM t.xyz WHERE x = 10
 ----
 group-by
- ├── columns: column4:decimal:null:4
- ├── select
- │    ├── columns: xyz.x:int:1 xyz.y:int:null:2 xyz.z:float:null:3
- │    ├── scan
- │    │    └── columns: xyz.x:int:1 xyz.y:int:null:2 xyz.z:float:null:3
- │    └── eq [type=bool]
- │         ├── variable: xyz.x [type=int]
- │         └── const: 10 [type=int]
- ├── groupings
+ ├── aggregation columns: column4:decimal:null:4
+ ├── project
+ │    ├── columns: xyz.x:int:1
+ │    ├── select
+ │    │    ├── columns: xyz.x:int:1 xyz.y:int:null:2 xyz.z:float:null:3
+ │    │    ├── scan
+ │    │    │    └── columns: xyz.x:int:1 xyz.y:int:null:2 xyz.z:float:null:3
+ │    │    └── eq [type=bool]
+ │    │         ├── variable: xyz.x [type=int]
+ │    │         └── const: 10 [type=int]
+ │    └── projections
+ │         └── variable: xyz.x [type=int]
  └── aggregations
       └── function: variance [type=decimal]
            └── variable: xyz.x [type=int]
@@ -897,15 +1034,18 @@ build
 SELECT STDDEV(x) FROM t.xyz WHERE x = 1
 ----
 group-by
- ├── columns: column4:decimal:null:4
- ├── select
- │    ├── columns: xyz.x:int:1 xyz.y:int:null:2 xyz.z:float:null:3
- │    ├── scan
- │    │    └── columns: xyz.x:int:1 xyz.y:int:null:2 xyz.z:float:null:3
- │    └── eq [type=bool]
- │         ├── variable: xyz.x [type=int]
- │         └── const: 1 [type=int]
- ├── groupings
+ ├── aggregation columns: column4:decimal:null:4
+ ├── project
+ │    ├── columns: xyz.x:int:1
+ │    ├── select
+ │    │    ├── columns: xyz.x:int:1 xyz.y:int:null:2 xyz.z:float:null:3
+ │    │    ├── scan
+ │    │    │    └── columns: xyz.x:int:1 xyz.y:int:null:2 xyz.z:float:null:3
+ │    │    └── eq [type=bool]
+ │    │         ├── variable: xyz.x [type=int]
+ │    │         └── const: 1 [type=int]
+ │    └── projections
+ │         └── variable: xyz.x [type=int]
  └── aggregations
       └── function: stddev [type=decimal]
            └── variable: xyz.x [type=int]
@@ -921,10 +1061,14 @@ build
 SELECT BOOL_AND(b), BOOL_OR(b) FROM t.bools
 ----
 group-by
- ├── columns: column3:bool:null:3 column4:bool:null:4
- ├── scan
- │    └── columns: bools.b:bool:null:1 bools.rowid:int:2
- ├── groupings
+ ├── aggregation columns: column3:bool:null:3 column4:bool:null:4
+ ├── project
+ │    ├── columns: bools.b:bool:null:1 bools.b:bool:null:1
+ │    ├── scan
+ │    │    └── columns: bools.b:bool:null:1 bools.rowid:int:2
+ │    └── projections
+ │         ├── variable: bools.b [type=bool]
+ │         └── variable: bools.b [type=bool]
  └── aggregations
       ├── function: bool_and [type=bool]
       │    └── variable: bools.b [type=bool]
@@ -939,14 +1083,9 @@ SELECT 1 FROM t.kv GROUP BY kv.*;
 project
  ├── columns: column5:int:null:5
  ├── group-by
- │    ├── columns: kv.k:int:null:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
+ │    ├── grouping columns: kv.k:int:null:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
  │    ├── scan
  │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
- │    ├── groupings
- │    │    ├── variable: kv.k [type=int]
- │    │    ├── variable: kv.v [type=int]
- │    │    ├── variable: kv.w [type=int]
- │    │    └── variable: kv.s [type=string]
  │    └── aggregations
  └── projections
       └── const: 1 [type=int]
@@ -966,10 +1105,14 @@ SELECT TO_HEX(XOR_AGG(a)), XOR_AGG(c) FROM t.xor_bytes
 project
  ├── columns: column6:string:null:6 column7:int:null:7
  ├── group-by
- │    ├── columns: column5:bytes:null:5 column7:int:null:7
- │    ├── scan
- │    │    └── columns: xor_bytes.a:bytes:null:1 xor_bytes.b:int:null:2 xor_bytes.c:int:null:3 xor_bytes.rowid:int:4
- │    ├── groupings
+ │    ├── aggregation columns: column5:bytes:null:5 column7:int:null:7
+ │    ├── project
+ │    │    ├── columns: xor_bytes.a:bytes:null:1 xor_bytes.c:int:null:3
+ │    │    ├── scan
+ │    │    │    └── columns: xor_bytes.a:bytes:null:1 xor_bytes.b:int:null:2 xor_bytes.c:int:null:3 xor_bytes.rowid:int:4
+ │    │    └── projections
+ │    │         ├── variable: xor_bytes.a [type=bytes]
+ │    │         └── variable: xor_bytes.c [type=int]
  │    └── aggregations
  │         ├── function: xor_agg [type=bytes]
  │         │    └── variable: xor_bytes.a [type=bytes]
@@ -984,15 +1127,19 @@ build
 SELECT MAX(true), MIN(true)
 ----
 group-by
- ├── columns: column1:bool:null:1 column2:bool:null:2
- ├── values
- │    └── tuple [type=tuple{}]
- ├── groupings
+ ├── aggregation columns: column2:bool:null:2 column4:bool:null:4
+ ├── project
+ │    ├── columns: column1:bool:null:1 column3:bool:null:3
+ │    ├── values
+ │    │    └── tuple [type=tuple{}]
+ │    └── projections
+ │         ├── true [type=bool]
+ │         └── true [type=bool]
  └── aggregations
       ├── function: max [type=bool]
-      │    └── true [type=bool]
+      │    └── variable: column1 [type=bool]
       └── function: min [type=bool]
-           └── true [type=bool]
+           └── variable: column3 [type=bool]
 
 exec-ddl
 CREATE TABLE t.ab (
@@ -1021,12 +1168,14 @@ SELECT (b, a) FROM t.ab GROUP BY (b, a)
 project
  ├── columns: column3:tuple{int, int}:null:3
  ├── group-by
- │    ├── columns: ab.a:int:null:1 ab.b:int:null:2
- │    ├── scan
- │    │    └── columns: ab.a:int:1 ab.b:int:null:2
- │    ├── groupings
- │    │    ├── variable: ab.b [type=int]
- │    │    └── variable: ab.a [type=int]
+ │    ├── grouping columns: ab.a:int:null:1 ab.b:int:null:2
+ │    ├── project
+ │    │    ├── columns: ab.b:int:null:2 ab.a:int:1
+ │    │    ├── scan
+ │    │    │    └── columns: ab.a:int:1 ab.b:int:null:2
+ │    │    └── projections
+ │    │         ├── variable: ab.b [type=int]
+ │    │         └── variable: ab.a [type=int]
  │    └── aggregations
  └── projections
       └── tuple [type=tuple{int, int}]
@@ -1040,21 +1189,25 @@ SELECT MIN(y), (b, a)
 project
  ├── columns: column6:string:null:6 column7:tuple{int, int}:null:7
  ├── group-by
- │    ├── columns: ab.a:int:null:1 ab.b:int:null:2 xy.x:string:null:3 column6:string:null:6
- │    ├── inner-join
- │    │    ├── columns: ab.a:int:1 ab.b:int:null:2 xy.x:string:null:3 xy.y:string:null:4 xy.rowid:int:5
- │    │    ├── scan
- │    │    │    └── columns: ab.a:int:1 ab.b:int:null:2
- │    │    ├── scan
- │    │    │    └── columns: xy.x:string:null:3 xy.y:string:null:4 xy.rowid:int:5
- │    │    └── true [type=bool]
- │    ├── groupings
- │    │    ├── variable: xy.x [type=string]
- │    │    ├── variable: ab.a [type=int]
- │    │    └── variable: ab.b [type=int]
+ │    ├── grouping columns: ab.a:int:null:1 ab.b:int:null:2 xy.x:string:null:3
+ │    ├── aggregation columns: column6:string:null:6
+ │    ├── project
+ │    │    ├── columns: xy.x:string:null:3 ab.a:int:1 ab.b:int:null:2 xy.y:string:null:4
+ │    │    ├── inner-join
+ │    │    │    ├── columns: ab.a:int:1 ab.b:int:null:2 xy.x:string:null:3 xy.y:string:null:4 xy.rowid:int:5
+ │    │    │    ├── scan
+ │    │    │    │    └── columns: ab.a:int:1 ab.b:int:null:2
+ │    │    │    ├── scan
+ │    │    │    │    └── columns: xy.x:string:null:3 xy.y:string:null:4 xy.rowid:int:5
+ │    │    │    └── true [type=bool]
+ │    │    └── projections
+ │    │         ├── variable: xy.x [type=string]
+ │    │         ├── variable: ab.a [type=int]
+ │    │         ├── variable: ab.b [type=int]
+ │    │         └── variable: xy.y [type=string]
  │    └── aggregations
  │         └── function: min [type=string]
- │              └── variable: xy.y [type=string]
+ │              └── variable: xy.x [type=string]
  └── projections
       ├── variable: column6 [type=string]
       └── tuple [type=tuple{int, int}]
@@ -1067,16 +1220,18 @@ SELECT (k+v)/(v+w) FROM t.kv GROUP BY k+v, v+w;
 project
  ├── columns: column7:decimal:null:7
  ├── group-by
- │    ├── columns: column5:int:null:5 column6:int:null:6
- │    ├── scan
- │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
- │    ├── groupings
- │    │    ├── plus [type=int]
- │    │    │    ├── variable: kv.k [type=int]
- │    │    │    └── variable: kv.v [type=int]
- │    │    └── plus [type=int]
- │    │         ├── variable: kv.v [type=int]
- │    │         └── variable: kv.w [type=int]
+ │    ├── grouping columns: column5:int:null:5 column6:int:null:6
+ │    ├── project
+ │    │    ├── columns: column5:int:null:5 column6:int:null:6
+ │    │    ├── scan
+ │    │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
+ │    │    └── projections
+ │    │         ├── plus [type=int]
+ │    │         │    ├── variable: kv.k [type=int]
+ │    │         │    └── variable: kv.v [type=int]
+ │    │         └── plus [type=int]
+ │    │              ├── variable: kv.v [type=int]
+ │    │              └── variable: kv.w [type=int]
  │    └── aggregations
  └── projections
       └── div [type=decimal]
@@ -1094,17 +1249,21 @@ SELECT SUM(t.kv.w), t.kv.v FROM t.kv GROUP BY v, kv.k * w
 project
  ├── columns: column6:decimal:null:6 kv.v:int:null:2
  ├── group-by
- │    ├── columns: kv.v:int:null:2 column5:int:null:5 column6:decimal:null:6
- │    ├── scan
- │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
- │    ├── groupings
- │    │    ├── variable: kv.v [type=int]
- │    │    └── mult [type=int]
- │    │         ├── variable: kv.k [type=int]
+ │    ├── grouping columns: kv.v:int:null:2 column5:int:null:5
+ │    ├── aggregation columns: column6:decimal:null:6
+ │    ├── project
+ │    │    ├── columns: kv.v:int:null:2 column5:int:null:5 kv.w:int:null:3
+ │    │    ├── scan
+ │    │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
+ │    │    └── projections
+ │    │         ├── variable: kv.v [type=int]
+ │    │         ├── mult [type=int]
+ │    │         │    ├── variable: kv.k [type=int]
+ │    │         │    └── variable: kv.w [type=int]
  │    │         └── variable: kv.w [type=int]
  │    └── aggregations
  │         └── function: sum [type=decimal]
- │              └── variable: kv.w [type=int]
+ │              └── variable: kv.v [type=int]
  └── projections
       ├── variable: column6 [type=decimal]
       └── variable: kv.v [type=int]
@@ -1115,19 +1274,23 @@ SELECT SUM(t.kv.w), LOWER(s), t.kv.v + k * t.kv.w, t.kv.v FROM t.kv GROUP BY v, 
 project
  ├── columns: column7:decimal:null:7 column5:string:null:5 column8:int:null:8 kv.v:int:null:2
  ├── group-by
- │    ├── columns: kv.v:int:null:2 column5:string:null:5 column6:int:null:6 column7:decimal:null:7
- │    ├── scan
- │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
- │    ├── groupings
- │    │    ├── variable: kv.v [type=int]
- │    │    ├── function: lower [type=string]
- │    │    │    └── variable: kv.s [type=string]
- │    │    └── mult [type=int]
- │    │         ├── variable: kv.k [type=int]
+ │    ├── grouping columns: kv.v:int:null:2 column5:string:null:5 column6:int:null:6
+ │    ├── aggregation columns: column7:decimal:null:7
+ │    ├── project
+ │    │    ├── columns: kv.v:int:null:2 column5:string:null:5 column6:int:null:6 kv.w:int:null:3
+ │    │    ├── scan
+ │    │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
+ │    │    └── projections
+ │    │         ├── variable: kv.v [type=int]
+ │    │         ├── function: lower [type=string]
+ │    │         │    └── variable: kv.s [type=string]
+ │    │         ├── mult [type=int]
+ │    │         │    ├── variable: kv.k [type=int]
+ │    │         │    └── variable: kv.w [type=int]
  │    │         └── variable: kv.w [type=int]
  │    └── aggregations
  │         └── function: sum [type=decimal]
- │              └── variable: kv.w [type=int]
+ │              └── variable: kv.v [type=int]
  └── projections
       ├── variable: column7 [type=decimal]
       ├── variable: column5 [type=string]
@@ -1145,24 +1308,26 @@ SELECT b1.b AND abc.c AND b2.b FROM bools b1, bools b2, abc GROUP BY b1.b AND ab
 project
  ├── columns: column10:bool:null:10
  ├── group-by
- │    ├── columns: bools.b:bool:null:3 column9:bool:null:9
- │    ├── inner-join
- │    │    ├── columns: bools.b:bool:null:1 bools.rowid:int:2 bools.b:bool:null:3 bools.rowid:int:4 abc.a:string:5 abc.b:float:null:6 abc.c:bool:null:7 abc.d:decimal:null:8
+ │    ├── grouping columns: bools.b:bool:null:3 column9:bool:null:9
+ │    ├── project
+ │    │    ├── columns: column9:bool:null:9 bools.b:bool:null:3
  │    │    ├── inner-join
- │    │    │    ├── columns: bools.b:bool:null:1 bools.rowid:int:2 bools.b:bool:null:3 bools.rowid:int:4
+ │    │    │    ├── columns: bools.b:bool:null:1 bools.rowid:int:2 bools.b:bool:null:3 bools.rowid:int:4 abc.a:string:5 abc.b:float:null:6 abc.c:bool:null:7 abc.d:decimal:null:8
+ │    │    │    ├── inner-join
+ │    │    │    │    ├── columns: bools.b:bool:null:1 bools.rowid:int:2 bools.b:bool:null:3 bools.rowid:int:4
+ │    │    │    │    ├── scan
+ │    │    │    │    │    └── columns: bools.b:bool:null:1 bools.rowid:int:2
+ │    │    │    │    ├── scan
+ │    │    │    │    │    └── columns: bools.b:bool:null:3 bools.rowid:int:4
+ │    │    │    │    └── true [type=bool]
  │    │    │    ├── scan
- │    │    │    │    └── columns: bools.b:bool:null:1 bools.rowid:int:2
- │    │    │    ├── scan
- │    │    │    │    └── columns: bools.b:bool:null:3 bools.rowid:int:4
+ │    │    │    │    └── columns: abc.a:string:5 abc.b:float:null:6 abc.c:bool:null:7 abc.d:decimal:null:8
  │    │    │    └── true [type=bool]
- │    │    ├── scan
- │    │    │    └── columns: abc.a:string:5 abc.b:float:null:6 abc.c:bool:null:7 abc.d:decimal:null:8
- │    │    └── true [type=bool]
- │    ├── groupings
- │    │    ├── and [type=bool]
- │    │    │    ├── variable: bools.b [type=bool]
- │    │    │    └── variable: abc.c [type=bool]
- │    │    └── variable: bools.b [type=bool]
+ │    │    └── projections
+ │    │         ├── and [type=bool]
+ │    │         │    ├── variable: bools.b [type=bool]
+ │    │         │    └── variable: abc.c [type=bool]
+ │    │         └── variable: bools.b [type=bool]
  │    └── aggregations
  └── projections
       └── and [type=bool]
@@ -1182,24 +1347,26 @@ SELECT b1.b OR abc.c OR b2.b FROM bools b1, bools b2, abc GROUP BY b1.b OR abc.c
 project
  ├── columns: column10:bool:null:10
  ├── group-by
- │    ├── columns: bools.b:bool:null:3 column9:bool:null:9
- │    ├── inner-join
- │    │    ├── columns: bools.b:bool:null:1 bools.rowid:int:2 bools.b:bool:null:3 bools.rowid:int:4 abc.a:string:5 abc.b:float:null:6 abc.c:bool:null:7 abc.d:decimal:null:8
+ │    ├── grouping columns: bools.b:bool:null:3 column9:bool:null:9
+ │    ├── project
+ │    │    ├── columns: column9:bool:null:9 bools.b:bool:null:3
  │    │    ├── inner-join
- │    │    │    ├── columns: bools.b:bool:null:1 bools.rowid:int:2 bools.b:bool:null:3 bools.rowid:int:4
+ │    │    │    ├── columns: bools.b:bool:null:1 bools.rowid:int:2 bools.b:bool:null:3 bools.rowid:int:4 abc.a:string:5 abc.b:float:null:6 abc.c:bool:null:7 abc.d:decimal:null:8
+ │    │    │    ├── inner-join
+ │    │    │    │    ├── columns: bools.b:bool:null:1 bools.rowid:int:2 bools.b:bool:null:3 bools.rowid:int:4
+ │    │    │    │    ├── scan
+ │    │    │    │    │    └── columns: bools.b:bool:null:1 bools.rowid:int:2
+ │    │    │    │    ├── scan
+ │    │    │    │    │    └── columns: bools.b:bool:null:3 bools.rowid:int:4
+ │    │    │    │    └── true [type=bool]
  │    │    │    ├── scan
- │    │    │    │    └── columns: bools.b:bool:null:1 bools.rowid:int:2
- │    │    │    ├── scan
- │    │    │    │    └── columns: bools.b:bool:null:3 bools.rowid:int:4
+ │    │    │    │    └── columns: abc.a:string:5 abc.b:float:null:6 abc.c:bool:null:7 abc.d:decimal:null:8
  │    │    │    └── true [type=bool]
- │    │    ├── scan
- │    │    │    └── columns: abc.a:string:5 abc.b:float:null:6 abc.c:bool:null:7 abc.d:decimal:null:8
- │    │    └── true [type=bool]
- │    ├── groupings
- │    │    ├── or [type=bool]
- │    │    │    ├── variable: bools.b [type=bool]
- │    │    │    └── variable: abc.c [type=bool]
- │    │    └── variable: bools.b [type=bool]
+ │    │    └── projections
+ │    │         ├── or [type=bool]
+ │    │         │    ├── variable: bools.b [type=bool]
+ │    │         │    └── variable: abc.c [type=bool]
+ │    │         └── variable: bools.b [type=bool]
  │    └── aggregations
  └── projections
       └── or [type=bool]
@@ -1219,14 +1386,16 @@ SELECT k % w % v FROM kv GROUP BY k % w, v
 project
  ├── columns: column6:int:null:6
  ├── group-by
- │    ├── columns: kv.v:int:null:2 column5:int:null:5
- │    ├── scan
- │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
- │    ├── groupings
- │    │    ├── mod [type=int]
- │    │    │    ├── variable: kv.k [type=int]
- │    │    │    └── variable: kv.w [type=int]
- │    │    └── variable: kv.v [type=int]
+ │    ├── grouping columns: kv.v:int:null:2 column5:int:null:5
+ │    ├── project
+ │    │    ├── columns: column5:int:null:5 kv.v:int:null:2
+ │    │    ├── scan
+ │    │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
+ │    │    └── projections
+ │    │         ├── mod [type=int]
+ │    │         │    ├── variable: kv.k [type=int]
+ │    │         │    └── variable: kv.w [type=int]
+ │    │         └── variable: kv.v [type=int]
  │    └── aggregations
  └── projections
       └── mod [type=int]
@@ -1241,19 +1410,21 @@ SELECT CONCAT(CONCAT(s, a), a) FROM kv, abc GROUP BY CONCAT(s, a), a
 project
  ├── columns: column10:string:null:10
  ├── group-by
- │    ├── columns: abc.a:string:null:5 column9:string:null:9
- │    ├── inner-join
- │    │    ├── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4 abc.a:string:5 abc.b:float:null:6 abc.c:bool:null:7 abc.d:decimal:null:8
- │    │    ├── scan
- │    │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
- │    │    ├── scan
- │    │    │    └── columns: abc.a:string:5 abc.b:float:null:6 abc.c:bool:null:7 abc.d:decimal:null:8
- │    │    └── true [type=bool]
- │    ├── groupings
- │    │    ├── function: concat [type=string]
- │    │    │    ├── variable: kv.s [type=string]
- │    │    │    └── variable: abc.a [type=string]
- │    │    └── variable: abc.a [type=string]
+ │    ├── grouping columns: abc.a:string:null:5 column9:string:null:9
+ │    ├── project
+ │    │    ├── columns: column9:string:null:9 abc.a:string:5
+ │    │    ├── inner-join
+ │    │    │    ├── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4 abc.a:string:5 abc.b:float:null:6 abc.c:bool:null:7 abc.d:decimal:null:8
+ │    │    │    ├── scan
+ │    │    │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
+ │    │    │    ├── scan
+ │    │    │    │    └── columns: abc.a:string:5 abc.b:float:null:6 abc.c:bool:null:7 abc.d:decimal:null:8
+ │    │    │    └── true [type=bool]
+ │    │    └── projections
+ │    │         ├── function: concat [type=string]
+ │    │         │    ├── variable: kv.s [type=string]
+ │    │         │    └── variable: abc.a [type=string]
+ │    │         └── variable: abc.a [type=string]
  │    └── aggregations
  └── projections
       └── function: concat [type=string]
@@ -1273,14 +1444,16 @@ SELECT k < w AND v != 5 FROM kv GROUP BY k < w, v
 project
  ├── columns: column6:bool:null:6
  ├── group-by
- │    ├── columns: kv.v:int:null:2 column5:bool:null:5
- │    ├── scan
- │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
- │    ├── groupings
- │    │    ├── lt [type=bool]
- │    │    │    ├── variable: kv.k [type=int]
- │    │    │    └── variable: kv.w [type=int]
- │    │    └── variable: kv.v [type=int]
+ │    ├── grouping columns: kv.v:int:null:2 column5:bool:null:5
+ │    ├── project
+ │    │    ├── columns: column5:bool:null:5 kv.v:int:null:2
+ │    │    ├── scan
+ │    │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
+ │    │    └── projections
+ │    │         ├── lt [type=bool]
+ │    │         │    ├── variable: kv.k [type=int]
+ │    │         │    └── variable: kv.w [type=int]
+ │    │         └── variable: kv.v [type=int]
  │    └── aggregations
  └── projections
       └── and [type=bool]
@@ -1310,19 +1483,21 @@ SELECT a.bar @> b.baz AND b.baz @> b.baz FROM foo AS a, foo AS b GROUP BY a.bar 
 project
  ├── columns: column8:bool:null:8
  ├── group-by
- │    ├── columns: foo.baz:jsonb:null:5 column7:bool:null:7
- │    ├── inner-join
- │    │    ├── columns: foo.bar:jsonb:null:1 foo.baz:jsonb:null:2 foo.rowid:int:3 foo.bar:jsonb:null:4 foo.baz:jsonb:null:5 foo.rowid:int:6
- │    │    ├── scan
- │    │    │    └── columns: foo.bar:jsonb:null:1 foo.baz:jsonb:null:2 foo.rowid:int:3
- │    │    ├── scan
- │    │    │    └── columns: foo.bar:jsonb:null:4 foo.baz:jsonb:null:5 foo.rowid:int:6
- │    │    └── true [type=bool]
- │    ├── groupings
- │    │    ├── contains [type=bool]
- │    │    │    ├── variable: foo.bar [type=jsonb]
- │    │    │    └── variable: foo.baz [type=jsonb]
- │    │    └── variable: foo.baz [type=jsonb]
+ │    ├── grouping columns: foo.baz:jsonb:null:5 column7:bool:null:7
+ │    ├── project
+ │    │    ├── columns: column7:bool:null:7 foo.baz:jsonb:null:5
+ │    │    ├── inner-join
+ │    │    │    ├── columns: foo.bar:jsonb:null:1 foo.baz:jsonb:null:2 foo.rowid:int:3 foo.bar:jsonb:null:4 foo.baz:jsonb:null:5 foo.rowid:int:6
+ │    │    │    ├── scan
+ │    │    │    │    └── columns: foo.bar:jsonb:null:1 foo.baz:jsonb:null:2 foo.rowid:int:3
+ │    │    │    ├── scan
+ │    │    │    │    └── columns: foo.bar:jsonb:null:4 foo.baz:jsonb:null:5 foo.rowid:int:6
+ │    │    │    └── true [type=bool]
+ │    │    └── projections
+ │    │         ├── contains [type=bool]
+ │    │         │    ├── variable: foo.bar [type=jsonb]
+ │    │         │    └── variable: foo.baz [type=jsonb]
+ │    │         └── variable: foo.baz [type=jsonb]
  │    └── aggregations
  └── projections
       └── and [type=bool]
@@ -1344,19 +1519,21 @@ SELECT b.baz <@ a.bar AND b.baz <@ b.baz FROM foo AS a, foo AS b GROUP BY b.baz 
 project
  ├── columns: column8:bool:null:8
  ├── group-by
- │    ├── columns: foo.baz:jsonb:null:5 column7:bool:null:7
- │    ├── inner-join
- │    │    ├── columns: foo.bar:jsonb:null:1 foo.baz:jsonb:null:2 foo.rowid:int:3 foo.bar:jsonb:null:4 foo.baz:jsonb:null:5 foo.rowid:int:6
- │    │    ├── scan
- │    │    │    └── columns: foo.bar:jsonb:null:1 foo.baz:jsonb:null:2 foo.rowid:int:3
- │    │    ├── scan
- │    │    │    └── columns: foo.bar:jsonb:null:4 foo.baz:jsonb:null:5 foo.rowid:int:6
- │    │    └── true [type=bool]
- │    ├── groupings
- │    │    ├── contains [type=bool]
- │    │    │    ├── variable: foo.bar [type=jsonb]
- │    │    │    └── variable: foo.baz [type=jsonb]
- │    │    └── variable: foo.baz [type=jsonb]
+ │    ├── grouping columns: foo.baz:jsonb:null:5 column7:bool:null:7
+ │    ├── project
+ │    │    ├── columns: column7:bool:null:7 foo.baz:jsonb:null:5
+ │    │    ├── inner-join
+ │    │    │    ├── columns: foo.bar:jsonb:null:1 foo.baz:jsonb:null:2 foo.rowid:int:3 foo.bar:jsonb:null:4 foo.baz:jsonb:null:5 foo.rowid:int:6
+ │    │    │    ├── scan
+ │    │    │    │    └── columns: foo.bar:jsonb:null:1 foo.baz:jsonb:null:2 foo.rowid:int:3
+ │    │    │    ├── scan
+ │    │    │    │    └── columns: foo.bar:jsonb:null:4 foo.baz:jsonb:null:5 foo.rowid:int:6
+ │    │    │    └── true [type=bool]
+ │    │    └── projections
+ │    │         ├── contains [type=bool]
+ │    │         │    ├── variable: foo.bar [type=jsonb]
+ │    │         │    └── variable: foo.baz [type=jsonb]
+ │    │         └── variable: foo.baz [type=jsonb]
  │    └── aggregations
  └── projections
       └── and [type=bool]
@@ -1380,21 +1557,23 @@ SELECT date_trunc('second', a.t) - date_trunc('minute', b.t) FROM times a, times
 project
  ├── columns: column5:interval:null:5
  ├── group-by
- │    ├── columns: column3:interval:null:3 column4:interval:null:4
- │    ├── inner-join
- │    │    ├── columns: times.t:time:1 times.t:time:2
- │    │    ├── scan
- │    │    │    └── columns: times.t:time:1
- │    │    ├── scan
- │    │    │    └── columns: times.t:time:2
- │    │    └── true [type=bool]
- │    ├── groupings
- │    │    ├── function: date_trunc [type=interval]
- │    │    │    ├── const: 'second' [type=string]
- │    │    │    └── variable: times.t [type=time]
- │    │    └── function: date_trunc [type=interval]
- │    │         ├── const: 'minute' [type=string]
- │    │         └── variable: times.t [type=time]
+ │    ├── grouping columns: column3:interval:null:3 column4:interval:null:4
+ │    ├── project
+ │    │    ├── columns: column3:interval:null:3 column4:interval:null:4
+ │    │    ├── inner-join
+ │    │    │    ├── columns: times.t:time:1 times.t:time:2
+ │    │    │    ├── scan
+ │    │    │    │    └── columns: times.t:time:1
+ │    │    │    ├── scan
+ │    │    │    │    └── columns: times.t:time:2
+ │    │    │    └── true [type=bool]
+ │    │    └── projections
+ │    │         ├── function: date_trunc [type=interval]
+ │    │         │    ├── const: 'second' [type=string]
+ │    │         │    └── variable: times.t [type=time]
+ │    │         └── function: date_trunc [type=interval]
+ │    │              ├── const: 'minute' [type=string]
+ │    │              └── variable: times.t [type=time]
  │    └── aggregations
  └── projections
       └── minus [type=interval]
@@ -1415,12 +1594,14 @@ build
 SELECT NOT b FROM bools GROUP BY NOT b
 ----
 group-by
- ├── columns: column3:bool:null:3
- ├── scan
- │    └── columns: bools.b:bool:null:1 bools.rowid:int:2
- ├── groupings
- │    └── not [type=bool]
- │         └── variable: bools.b [type=bool]
+ ├── grouping columns: column3:bool:null:3
+ ├── project
+ │    ├── columns: column3:bool:null:3
+ │    ├── scan
+ │    │    └── columns: bools.b:bool:null:1 bools.rowid:int:2
+ │    └── projections
+ │         └── not [type=bool]
+ │              └── variable: bools.b [type=bool]
  └── aggregations
 
 build
@@ -1434,11 +1615,13 @@ SELECT NOT b FROM bools GROUP BY b
 project
  ├── columns: column3:bool:null:3
  ├── group-by
- │    ├── columns: bools.b:bool:null:1
- │    ├── scan
- │    │    └── columns: bools.b:bool:null:1 bools.rowid:int:2
- │    ├── groupings
- │    │    └── variable: bools.b [type=bool]
+ │    ├── grouping columns: bools.b:bool:null:1
+ │    ├── project
+ │    │    ├── columns: bools.b:bool:null:1
+ │    │    ├── scan
+ │    │    │    └── columns: bools.b:bool:null:1 bools.rowid:int:2
+ │    │    └── projections
+ │    │         └── variable: bools.b [type=bool]
  │    └── aggregations
  └── projections
       └── not [type=bool]
@@ -1450,14 +1633,16 @@ SELECT +k * (-w) FROM kv GROUP BY +k, -w
 project
  ├── columns: column7:int:null:7
  ├── group-by
- │    ├── columns: column5:int:null:5 column6:int:null:6
- │    ├── scan
- │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
- │    ├── groupings
- │    │    ├── unary-plus [type=int]
- │    │    │    └── variable: kv.k [type=int]
- │    │    └── unary-minus [type=int]
- │    │         └── variable: kv.w [type=int]
+ │    ├── grouping columns: column5:int:null:5 column6:int:null:6
+ │    ├── project
+ │    │    ├── columns: column5:int:null:5 column6:int:null:6
+ │    │    ├── scan
+ │    │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
+ │    │    └── projections
+ │    │         ├── unary-plus [type=int]
+ │    │         │    └── variable: kv.k [type=int]
+ │    │         └── unary-minus [type=int]
+ │    │              └── variable: kv.w [type=int]
  │    └── aggregations
  └── projections
       └── mult [type=int]
@@ -1477,12 +1662,14 @@ SELECT +k * (-w) FROM kv GROUP BY k, w
 project
  ├── columns: column5:int:null:5
  ├── group-by
- │    ├── columns: kv.k:int:null:1 kv.w:int:null:3
- │    ├── scan
- │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
- │    ├── groupings
- │    │    ├── variable: kv.k [type=int]
- │    │    └── variable: kv.w [type=int]
+ │    ├── grouping columns: kv.k:int:null:1 kv.w:int:null:3
+ │    ├── project
+ │    │    ├── columns: kv.k:int:1 kv.w:int:null:3
+ │    │    ├── scan
+ │    │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
+ │    │    └── projections
+ │    │         ├── variable: kv.k [type=int]
+ │    │         └── variable: kv.w [type=int]
  │    └── aggregations
  └── projections
       └── mult [type=int]
@@ -1495,21 +1682,45 @@ build
 SELECT 1 + MIN(v*2) FROM kv GROUP BY k+3
 ----
 project
- ├── columns: column7:int:null:7
+ ├── columns: column8:int:null:8
  ├── group-by
- │    ├── columns: column5:int:null:5 column6:int:null:6
- │    ├── scan
- │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
- │    ├── groupings
- │    │    └── plus [type=int]
- │    │         ├── variable: kv.k [type=int]
- │    │         └── const: 3 [type=int]
+ │    ├── grouping columns: column5:int:null:5
+ │    ├── aggregation columns: column7:int:null:7
+ │    ├── project
+ │    │    ├── columns: column5:int:null:5 column6:int:null:6
+ │    │    ├── scan
+ │    │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
+ │    │    └── projections
+ │    │         ├── plus [type=int]
+ │    │         │    ├── variable: kv.k [type=int]
+ │    │         │    └── const: 3 [type=int]
+ │    │         └── mult [type=int]
+ │    │              ├── variable: kv.v [type=int]
+ │    │              └── const: 2 [type=int]
  │    └── aggregations
  │         └── function: min [type=int]
- │              └── mult [type=int]
- │                   ├── variable: kv.v [type=int]
- │                   └── const: 2 [type=int]
+ │              └── variable: column5 [type=int]
  └── projections
       └── plus [type=int]
            ├── const: 1 [type=int]
-           └── variable: column6 [type=int]
+           └── variable: column7 [type=int]
+
+build
+SELECT count(*) FROM kv GROUP BY k, k
+----
+project
+ ├── columns: column5:int:null:5
+ ├── group-by
+ │    ├── grouping columns: kv.k:int:null:1
+ │    ├── aggregation columns: column5:int:null:5
+ │    ├── project
+ │    │    ├── columns: kv.k:int:1 kv.k:int:1
+ │    │    ├── scan
+ │    │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
+ │    │    └── projections
+ │    │         ├── variable: kv.k [type=int]
+ │    │         └── variable: kv.k [type=int]
+ │    └── aggregations
+ │         └── function: count_rows [type=int]
+ └── projections
+      └── variable: column5 [type=int]

--- a/pkg/sql/opt/optbuilder/testdata/distinct
+++ b/pkg/sql/opt/optbuilder/testdata/distinct
@@ -32,7 +32,7 @@ build
 SELECT DISTINCT y, z FROM t.xyz
 ----
 group-by
- ├── columns: xyz.y:int:null:2 xyz.z:float:null:3
+ ├── grouping columns: xyz.y:int:null:2 xyz.z:float:null:3
  ├── project
  │    ├── columns: xyz.y:int:null:2 xyz.z:float:null:3
  │    ├── scan
@@ -40,9 +40,6 @@ group-by
  │    └── projections
  │         ├── variable: xyz.y [type=int]
  │         └── variable: xyz.z [type=float]
- ├── groupings
- │    ├── variable: xyz.y [type=int]
- │    └── variable: xyz.z [type=float]
  └── aggregations
 
 build
@@ -51,7 +48,7 @@ SELECT y FROM (SELECT DISTINCT y, z FROM t.xyz)
 project
  ├── columns: xyz.y:int:null:2
  ├── group-by
- │    ├── columns: xyz.y:int:null:2 xyz.z:float:null:3
+ │    ├── grouping columns: xyz.y:int:null:2 xyz.z:float:null:3
  │    ├── project
  │    │    ├── columns: xyz.y:int:null:2 xyz.z:float:null:3
  │    │    ├── scan
@@ -59,9 +56,6 @@ project
  │    │    └── projections
  │    │         ├── variable: xyz.y [type=int]
  │    │         └── variable: xyz.z [type=float]
- │    ├── groupings
- │    │    ├── variable: xyz.y [type=int]
- │    │    └── variable: xyz.z [type=float]
  │    └── aggregations
  └── projections
       └── variable: xyz.y [type=int]
@@ -70,7 +64,7 @@ build
 SELECT DISTINCT (y,z) FROM t.xyz
 ----
 group-by
- ├── columns: column4:tuple{int, float}:null:4
+ ├── grouping columns: column4:tuple{int, float}:null:4
  ├── project
  │    ├── columns: column4:tuple{int, float}:null:4
  │    ├── scan
@@ -79,27 +73,24 @@ group-by
  │         └── tuple [type=tuple{int, float}]
  │              ├── variable: xyz.y [type=int]
  │              └── variable: xyz.z [type=float]
- ├── groupings
- │    └── variable: column4 [type=tuple{int, float}]
  └── aggregations
 
 build
 SELECT COUNT(*) FROM (SELECT DISTINCT y FROM t.xyz)
 ----
 group-by
- ├── columns: column4:int:null:4
- ├── group-by
- │    ├── columns: xyz.y:int:null:2
- │    ├── project
- │    │    ├── columns: xyz.y:int:null:2
- │    │    ├── scan
- │    │    │    └── columns: xyz.x:int:1 xyz.y:int:null:2 xyz.z:float:null:3
- │    │    └── projections
- │    │         └── variable: xyz.y [type=int]
- │    ├── groupings
- │    │    └── variable: xyz.y [type=int]
- │    └── aggregations
- ├── groupings
+ ├── aggregation columns: column4:int:null:4
+ ├── project
+ │    ├── group-by
+ │    │    ├── grouping columns: xyz.y:int:null:2
+ │    │    ├── project
+ │    │    │    ├── columns: xyz.y:int:null:2
+ │    │    │    ├── scan
+ │    │    │    │    └── columns: xyz.x:int:1 xyz.y:int:null:2 xyz.z:float:null:3
+ │    │    │    └── projections
+ │    │    │         └── variable: xyz.y [type=int]
+ │    │    └── aggregations
+ │    └── projections
  └── aggregations
       └── function: count_rows [type=int]
 
@@ -107,7 +98,7 @@ build
 SELECT DISTINCT x FROM t.xyz WHERE x > 0
 ----
 group-by
- ├── columns: xyz.x:int:null:1
+ ├── grouping columns: xyz.x:int:null:1
  ├── project
  │    ├── columns: xyz.x:int:1
  │    ├── select
@@ -119,15 +110,13 @@ group-by
  │    │         └── const: 0 [type=int]
  │    └── projections
  │         └── variable: xyz.x [type=int]
- ├── groupings
- │    └── variable: xyz.x [type=int]
  └── aggregations
 
 build
 SELECT DISTINCT z FROM t.xyz WHERE x > 0
 ----
 group-by
- ├── columns: xyz.z:float:null:3
+ ├── grouping columns: xyz.z:float:null:3
  ├── project
  │    ├── columns: xyz.z:float:null:3
  │    ├── select
@@ -139,37 +128,37 @@ group-by
  │    │         └── const: 0 [type=int]
  │    └── projections
  │         └── variable: xyz.z [type=float]
- ├── groupings
- │    └── variable: xyz.z [type=float]
  └── aggregations
 
 build
 SELECT DISTINCT MAX(x) FROM xyz GROUP BY x
 ----
 group-by
- ├── columns: column4:int:null:4
+ ├── grouping columns: column4:int:null:4
  ├── project
  │    ├── columns: column4:int:null:4
  │    ├── group-by
- │    │    ├── columns: xyz.x:int:null:1 column4:int:null:4
- │    │    ├── scan
- │    │    │    └── columns: xyz.x:int:1 xyz.y:int:null:2 xyz.z:float:null:3
- │    │    ├── groupings
- │    │    │    └── variable: xyz.x [type=int]
+ │    │    ├── grouping columns: xyz.x:int:null:1
+ │    │    ├── aggregation columns: column4:int:null:4
+ │    │    ├── project
+ │    │    │    ├── columns: xyz.x:int:1 xyz.x:int:1
+ │    │    │    ├── scan
+ │    │    │    │    └── columns: xyz.x:int:1 xyz.y:int:null:2 xyz.z:float:null:3
+ │    │    │    └── projections
+ │    │    │         ├── variable: xyz.x [type=int]
+ │    │    │         └── variable: xyz.x [type=int]
  │    │    └── aggregations
  │    │         └── function: max [type=int]
  │    │              └── variable: xyz.x [type=int]
  │    └── projections
  │         └── variable: column4 [type=int]
- ├── groupings
- │    └── variable: column4 [type=int]
  └── aggregations
 
 build
 SELECT DISTINCT x+y FROM xyz
 ----
 group-by
- ├── columns: column4:int:null:4
+ ├── grouping columns: column4:int:null:4
  ├── project
  │    ├── columns: column4:int:null:4
  │    ├── scan
@@ -178,59 +167,51 @@ group-by
  │         └── plus [type=int]
  │              ├── variable: xyz.x [type=int]
  │              └── variable: xyz.y [type=int]
- ├── groupings
- │    └── variable: column4 [type=int]
  └── aggregations
 
 build
 SELECT DISTINCT 3 FROM xyz
 ----
 group-by
- ├── columns: column4:int:null:4
+ ├── grouping columns: column4:int:null:4
  ├── project
  │    ├── columns: column4:int:null:4
  │    ├── scan
  │    │    └── columns: xyz.x:int:1 xyz.y:int:null:2 xyz.z:float:null:3
  │    └── projections
  │         └── const: 3 [type=int]
- ├── groupings
- │    └── variable: column4 [type=int]
  └── aggregations
 
 build
 SELECT DISTINCT 3
 ----
 group-by
- ├── columns: column1:int:null:1
+ ├── grouping columns: column1:int:null:1
  ├── project
  │    ├── columns: column1:int:null:1
  │    ├── values
  │    │    └── tuple [type=tuple{}]
  │    └── projections
  │         └── const: 3 [type=int]
- ├── groupings
- │    └── variable: column1 [type=int]
  └── aggregations
 
 build
 SELECT DISTINCT MAX(z), x+y, 3 FROM xyz GROUP BY x, y HAVING y > 4
 ----
 group-by
- ├── columns: column4:float:null:4 column5:int:null:5 column6:int:null:6
+ ├── grouping columns: column4:float:null:4 column5:int:null:5 column6:int:null:6
  ├── project
  │    ├── columns: column4:float:null:4 column5:int:null:5 column6:int:null:6
  │    ├── select
  │    │    ├── columns: xyz.x:int:null:1 xyz.y:int:null:2 column4:float:null:4
  │    │    ├── group-by
- │    │    │    ├── columns: xyz.x:int:null:1 xyz.y:int:null:2 column4:float:null:4
+ │    │    │    ├── grouping columns: xyz.x:int:null:1 xyz.y:int:null:2
+ │    │    │    ├── aggregation columns: column4:float:null:4
  │    │    │    ├── scan
  │    │    │    │    └── columns: xyz.x:int:1 xyz.y:int:null:2 xyz.z:float:null:3
- │    │    │    ├── groupings
- │    │    │    │    ├── variable: xyz.x [type=int]
- │    │    │    │    └── variable: xyz.y [type=int]
  │    │    │    └── aggregations
  │    │    │         └── function: max [type=float]
- │    │    │              └── variable: xyz.z [type=float]
+ │    │    │              └── variable: xyz.x [type=int]
  │    │    └── gt [type=bool]
  │    │         ├── variable: xyz.y [type=int]
  │    │         └── const: 4 [type=int]
@@ -240,8 +221,4 @@ group-by
  │         │    ├── variable: xyz.x [type=int]
  │         │    └── variable: xyz.y [type=int]
  │         └── const: 3 [type=int]
- ├── groupings
- │    ├── variable: column4 [type=float]
- │    ├── variable: column5 [type=int]
- │    └── variable: column6 [type=int]
  └── aggregations

--- a/pkg/sql/opt/optbuilder/testdata/having
+++ b/pkg/sql/opt/optbuilder/testdata/having
@@ -22,9 +22,10 @@ project
  ├── columns: column5:int:null:5
  ├── select
  │    ├── group-by
- │    │    ├── scan
- │    │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
- │    │    ├── groupings
+ │    │    ├── project
+ │    │    │    ├── scan
+ │    │    │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
+ │    │    │    └── projections
  │    │    └── aggregations
  │    └── true [type=bool]
  └── projections
@@ -36,11 +37,14 @@ SELECT s, COUNT(*) FROM t.kv GROUP BY s HAVING COUNT(*) > 1
 select
  ├── columns: kv.s:string:null:4 column5:int:null:5
  ├── group-by
- │    ├── columns: kv.s:string:null:4 column5:int:null:5
- │    ├── scan
- │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
- │    ├── groupings
- │    │    └── variable: kv.s [type=string]
+ │    ├── grouping columns: kv.s:string:null:4
+ │    ├── aggregation columns: column5:int:null:5
+ │    ├── project
+ │    │    ├── columns: kv.s:string:null:4
+ │    │    ├── scan
+ │    │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
+ │    │    └── projections
+ │    │         └── variable: kv.s [type=string]
  │    └── aggregations
  │         └── function: count_rows [type=int]
  └── gt [type=bool]
@@ -55,10 +59,14 @@ project
  ├── select
  │    ├── columns: column5:int:null:5 column6:int:null:6
  │    ├── group-by
- │    │    ├── columns: column5:int:null:5 column6:int:null:6
- │    │    ├── scan
- │    │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
- │    │    ├── groupings
+ │    │    ├── aggregation columns: column5:int:null:5 column6:int:null:6
+ │    │    ├── project
+ │    │    │    ├── columns: kv.v:int:null:2 kv.k:int:1
+ │    │    │    ├── scan
+ │    │    │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
+ │    │    │    └── projections
+ │    │    │         ├── variable: kv.v [type=int]
+ │    │    │         └── variable: kv.k [type=int]
  │    │    └── aggregations
  │    │         ├── function: min [type=int]
  │    │         │    └── variable: kv.v [type=int]
@@ -79,10 +87,15 @@ project
  ├── select
  │    ├── columns: column5:int:null:5 column6:int:null:6 column7:int:null:7
  │    ├── group-by
- │    │    ├── columns: column5:int:null:5 column6:int:null:6 column7:int:null:7
- │    │    ├── scan
- │    │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
- │    │    ├── groupings
+ │    │    ├── aggregation columns: column5:int:null:5 column6:int:null:6 column7:int:null:7
+ │    │    ├── project
+ │    │    │    ├── columns: kv.v:int:null:2 kv.k:int:1 kv.v:int:null:2
+ │    │    │    ├── scan
+ │    │    │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
+ │    │    │    └── projections
+ │    │    │         ├── variable: kv.v [type=int]
+ │    │    │         ├── variable: kv.k [type=int]
+ │    │    │         └── variable: kv.v [type=int]
  │    │    └── aggregations
  │    │         ├── function: max [type=int]
  │    │         │    └── variable: kv.v [type=int]
@@ -133,13 +146,16 @@ project
  ├── select
  │    ├── columns: column5:int:null:5 column6:int:null:6
  │    ├── group-by
- │    │    ├── columns: column5:int:null:5 column6:int:null:6
- │    │    ├── scan
- │    │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
- │    │    ├── groupings
- │    │    │    └── plus [type=int]
- │    │    │         ├── variable: kv.k [type=int]
- │    │    │         └── variable: kv.w [type=int]
+ │    │    ├── grouping columns: column5:int:null:5
+ │    │    ├── aggregation columns: column6:int:null:6
+ │    │    ├── project
+ │    │    │    ├── columns: column5:int:null:5
+ │    │    │    ├── scan
+ │    │    │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
+ │    │    │    └── projections
+ │    │    │         └── plus [type=int]
+ │    │    │              ├── variable: kv.k [type=int]
+ │    │    │              └── variable: kv.w [type=int]
  │    │    └── aggregations
  │    │         └── function: count_rows [type=int]
  │    └── gt [type=bool]
@@ -165,11 +181,15 @@ project
  ├── select
  │    ├── columns: kv.v:int:null:2 column5:int:null:5
  │    ├── group-by
- │    │    ├── columns: kv.v:int:null:2 column5:int:null:5
- │    │    ├── scan
- │    │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
- │    │    ├── groupings
- │    │    │    └── variable: kv.v [type=int]
+ │    │    ├── grouping columns: kv.v:int:null:2
+ │    │    ├── aggregation columns: column5:int:null:5
+ │    │    ├── project
+ │    │    │    ├── columns: kv.v:int:null:2 kv.v:int:null:2
+ │    │    │    ├── scan
+ │    │    │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
+ │    │    │    └── projections
+ │    │    │         ├── variable: kv.v [type=int]
+ │    │    │         └── variable: kv.v [type=int]
  │    │    └── aggregations
  │    │         └── function: max [type=int]
  │    │              └── variable: kv.v [type=int]
@@ -187,15 +207,19 @@ project
  ├── select
  │    ├── columns: column5:string:null:5 column6:decimal:null:6
  │    ├── group-by
- │    │    ├── columns: column5:string:null:5 column6:decimal:null:6
- │    │    ├── scan
- │    │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
- │    │    ├── groupings
- │    │    │    └── function: lower [type=string]
- │    │    │         └── variable: kv.s [type=string]
+ │    │    ├── grouping columns: column5:string:null:5
+ │    │    ├── aggregation columns: column6:decimal:null:6
+ │    │    ├── project
+ │    │    │    ├── columns: column5:string:null:5 kv.w:int:null:3
+ │    │    │    ├── scan
+ │    │    │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
+ │    │    │    └── projections
+ │    │    │         ├── function: lower [type=string]
+ │    │    │         │    └── variable: kv.s [type=string]
+ │    │    │         └── variable: kv.w [type=int]
  │    │    └── aggregations
  │    │         └── function: sum [type=decimal]
- │    │              └── variable: kv.w [type=int]
+ │    │              └── variable: column5 [type=string]
  │    └── like [type=bool]
  │         ├── function: lower [type=string]
  │         │    └── variable: kv.s [type=string]
@@ -211,15 +235,19 @@ project
  ├── select
  │    ├── columns: column5:string:null:5 column6:decimal:null:6
  │    ├── group-by
- │    │    ├── columns: column5:string:null:5 column6:decimal:null:6
- │    │    ├── scan
- │    │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
- │    │    ├── groupings
- │    │    │    └── function: lower [type=string]
- │    │    │         └── variable: kv.s [type=string]
+ │    │    ├── grouping columns: column5:string:null:5
+ │    │    ├── aggregation columns: column6:decimal:null:6
+ │    │    ├── project
+ │    │    │    ├── columns: column5:string:null:5 kv.w:int:null:3
+ │    │    │    ├── scan
+ │    │    │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
+ │    │    │    └── projections
+ │    │    │         ├── function: lower [type=string]
+ │    │    │         │    └── variable: kv.s [type=string]
+ │    │    │         └── variable: kv.w [type=int]
  │    │    └── aggregations
  │    │         └── function: sum [type=decimal]
- │    │              └── variable: kv.w [type=int]
+ │    │              └── variable: column5 [type=string]
  │    └── in [type=bool]
  │         ├── variable: column6 [type=decimal]
  │         └── tuple [type=tuple{decimal, decimal, decimal}]
@@ -237,14 +265,16 @@ project
  ├── select
  │    ├── columns: kv.v:int:null:2 column5:int:null:5
  │    ├── group-by
- │    │    ├── columns: kv.v:int:null:2 column5:int:null:5
- │    │    ├── scan
- │    │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
- │    │    ├── groupings
- │    │    │    ├── variable: kv.v [type=int]
- │    │    │    └── mult [type=int]
- │    │    │         ├── variable: kv.k [type=int]
- │    │    │         └── variable: kv.w [type=int]
+ │    │    ├── grouping columns: kv.v:int:null:2 column5:int:null:5
+ │    │    ├── project
+ │    │    │    ├── columns: kv.v:int:null:2 column5:int:null:5
+ │    │    │    ├── scan
+ │    │    │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
+ │    │    │    └── projections
+ │    │    │         ├── variable: kv.v [type=int]
+ │    │    │         └── mult [type=int]
+ │    │    │              ├── variable: kv.k [type=int]
+ │    │    │              └── variable: kv.w [type=int]
  │    │    └── aggregations
  │    └── gt [type=bool]
  │         ├── mult [type=int]

--- a/pkg/sql/opt/xform/expr.og.go
+++ b/pkg/sql/opt/xform/expr.og.go
@@ -62,12 +62,6 @@ var childCountLookup = [...]childCountLookupFunc{
 		return 0 + int(aggregationsExpr.aggs().Length)
 	},
 
-	// GroupingsOp
-	func(ev ExprView) int {
-		groupingsExpr := (*groupingsExpr)(ev.mem.lookupExpr(ev.loc))
-		return 0 + int(groupingsExpr.elems().Length)
-	},
-
 	// ExistsOp
 	func(ev ExprView) int {
 		return 1
@@ -395,7 +389,7 @@ var childCountLookup = [...]childCountLookupFunc{
 
 	// GroupByOp
 	func(ev ExprView) int {
-		return 3
+		return 2
 	},
 
 	// UnionOp
@@ -500,17 +494,6 @@ var childGroupLookup = [...]childGroupLookupFunc{
 		switch n {
 		default:
 			list := ev.mem.lookupList(aggregationsExpr.aggs())
-			return list[n-0]
-		}
-	},
-
-	// GroupingsOp
-	func(ev ExprView, n int) opt.GroupID {
-		groupingsExpr := (*groupingsExpr)(ev.mem.lookupExpr(ev.loc))
-
-		switch n {
-		default:
-			list := ev.mem.lookupList(groupingsExpr.elems())
 			return list[n-0]
 		}
 	},
@@ -1400,8 +1383,6 @@ var childGroupLookup = [...]childGroupLookupFunc{
 		case 0:
 			return groupByExpr.input()
 		case 1:
-			return groupByExpr.groupings()
-		case 2:
 			return groupByExpr.aggregations()
 		default:
 			panic("child index out of range")
@@ -1525,12 +1506,6 @@ var privateLookup = [...]privateLookupFunc{
 	func(ev ExprView) opt.PrivateID {
 		aggregationsExpr := (*aggregationsExpr)(ev.mem.lookupExpr(ev.loc))
 		return aggregationsExpr.cols()
-	},
-
-	// GroupingsOp
-	func(ev ExprView) opt.PrivateID {
-		groupingsExpr := (*groupingsExpr)(ev.mem.lookupExpr(ev.loc))
-		return groupingsExpr.cols()
 	},
 
 	// ExistsOp
@@ -1859,7 +1834,8 @@ var privateLookup = [...]privateLookupFunc{
 
 	// GroupByOp
 	func(ev ExprView) opt.PrivateID {
-		return 0
+		groupByExpr := (*groupByExpr)(ev.mem.lookupExpr(ev.loc))
+		return groupByExpr.groupingColumns()
 	},
 
 	// UnionOp
@@ -1901,7 +1877,6 @@ var isScalarLookup = [...]bool{
 	true,  // TupleOp
 	true,  // ProjectionsOp
 	true,  // AggregationsOp
-	true,  // GroupingsOp
 	true,  // ExistsOp
 	true,  // AndOp
 	true,  // OrOp
@@ -1986,7 +1961,6 @@ var isConstValueLookup = [...]bool{
 	false, // TupleOp
 	false, // ProjectionsOp
 	false, // AggregationsOp
-	false, // GroupingsOp
 	false, // ExistsOp
 	false, // AndOp
 	false, // OrOp
@@ -2071,7 +2045,6 @@ var isBooleanLookup = [...]bool{
 	false, // TupleOp
 	false, // ProjectionsOp
 	false, // AggregationsOp
-	false, // GroupingsOp
 	false, // ExistsOp
 	true,  // AndOp
 	true,  // OrOp
@@ -2156,7 +2129,6 @@ var isComparisonLookup = [...]bool{
 	false, // TupleOp
 	false, // ProjectionsOp
 	false, // AggregationsOp
-	false, // GroupingsOp
 	false, // ExistsOp
 	false, // AndOp
 	false, // OrOp
@@ -2241,7 +2213,6 @@ var isBinaryLookup = [...]bool{
 	false, // TupleOp
 	false, // ProjectionsOp
 	false, // AggregationsOp
-	false, // GroupingsOp
 	false, // ExistsOp
 	false, // AndOp
 	false, // OrOp
@@ -2326,7 +2297,6 @@ var isUnaryLookup = [...]bool{
 	false, // TupleOp
 	false, // ProjectionsOp
 	false, // AggregationsOp
-	false, // GroupingsOp
 	false, // ExistsOp
 	false, // AndOp
 	false, // OrOp
@@ -2411,7 +2381,6 @@ var isRelationalLookup = [...]bool{
 	false, // TupleOp
 	false, // ProjectionsOp
 	false, // AggregationsOp
-	false, // GroupingsOp
 	false, // ExistsOp
 	false, // AndOp
 	false, // OrOp
@@ -2496,7 +2465,6 @@ var isJoinLookup = [...]bool{
 	false, // TupleOp
 	false, // ProjectionsOp
 	false, // AggregationsOp
-	false, // GroupingsOp
 	false, // ExistsOp
 	false, // AndOp
 	false, // OrOp
@@ -2581,7 +2549,6 @@ var isJoinApplyLookup = [...]bool{
 	false, // TupleOp
 	false, // ProjectionsOp
 	false, // AggregationsOp
-	false, // GroupingsOp
 	false, // ExistsOp
 	false, // AndOp
 	false, // OrOp
@@ -2666,7 +2633,6 @@ var isEnforcerLookup = [...]bool{
 	false, // TupleOp
 	false, // ProjectionsOp
 	false, // AggregationsOp
-	false, // GroupingsOp
 	false, // ExistsOp
 	false, // AndOp
 	false, // OrOp
@@ -2963,7 +2929,7 @@ func (m *memoExpr) asProjections() *projectionsExpr {
 
 // aggregationsExpr is a set of aggregate expressions that will become output
 // columns for a containing GroupBy operator. The private Cols field contains
-// the list of column indexes returned by the expression, as a *opt.ColList. It
+// the list of column indexes returned by the expression, as a *ColList. It
 // is legal for Cols to be empty.
 type aggregationsExpr memoExpr
 
@@ -2988,36 +2954,6 @@ func (m *memoExpr) asAggregations() *aggregationsExpr {
 		return nil
 	}
 	return (*aggregationsExpr)(m)
-}
-
-// groupingsExpr is a set of grouping expressions that will become output columns
-// for a containing GroupBy operator. The GroupBy operator groups its input by
-// the value of these expressions, and may compute aggregates over the groups.
-// The private Cols field contains the list of column indexes returned by the
-// expression, as a *opt.ColList. It is legal for Cols to be empty.
-type groupingsExpr memoExpr
-
-func makeGroupingsExpr(elems opt.ListID, cols opt.PrivateID) groupingsExpr {
-	return groupingsExpr{op: opt.GroupingsOp, state: exprState{elems.Offset, elems.Length, uint32(cols)}}
-}
-
-func (e *groupingsExpr) elems() opt.ListID {
-	return opt.ListID{Offset: e.state[0], Length: e.state[1]}
-}
-
-func (e *groupingsExpr) cols() opt.PrivateID {
-	return opt.PrivateID(e.state[2])
-}
-
-func (e *groupingsExpr) fingerprint() fingerprint {
-	return fingerprint(*e)
-}
-
-func (m *memoExpr) asGroupings() *groupingsExpr {
-	if m.op != opt.GroupingsOp {
-		return nil
-	}
-	return (*groupingsExpr)(m)
 }
 
 type existsExpr memoExpr
@@ -4669,22 +4605,27 @@ func (m *memoExpr) asAntiJoinApply() *antiJoinApplyExpr {
 	return (*antiJoinApplyExpr)(m)
 }
 
+// groupByExpr is an operator that is used for performing aggregations (for queries
+// with aggregate functions, HAVING clauses and/or group by expressions). It
+// groups results that are equal on the grouping columns and computes
+// aggregations as described by Aggregations (which is always an Aggregations
+// operator). The arguments of the aggregations are columns from the input.
 type groupByExpr memoExpr
 
-func makeGroupByExpr(input opt.GroupID, groupings opt.GroupID, aggregations opt.GroupID) groupByExpr {
-	return groupByExpr{op: opt.GroupByOp, state: exprState{uint32(input), uint32(groupings), uint32(aggregations)}}
+func makeGroupByExpr(input opt.GroupID, aggregations opt.GroupID, groupingColumns opt.PrivateID) groupByExpr {
+	return groupByExpr{op: opt.GroupByOp, state: exprState{uint32(input), uint32(aggregations), uint32(groupingColumns)}}
 }
 
 func (e *groupByExpr) input() opt.GroupID {
 	return opt.GroupID(e.state[0])
 }
 
-func (e *groupByExpr) groupings() opt.GroupID {
+func (e *groupByExpr) aggregations() opt.GroupID {
 	return opt.GroupID(e.state[1])
 }
 
-func (e *groupByExpr) aggregations() opt.GroupID {
-	return opt.GroupID(e.state[2])
+func (e *groupByExpr) groupingColumns() opt.PrivateID {
+	return opt.PrivateID(e.state[2])
 }
 
 func (e *groupByExpr) fingerprint() fingerprint {

--- a/pkg/sql/opt/xform/factory.og.go
+++ b/pkg/sql/opt/xform/factory.og.go
@@ -157,7 +157,7 @@ func (_f *factory) ConstructProjections(
 // ConstructAggregations constructs an expression for the Aggregations operator.
 // Aggregations is a set of aggregate expressions that will become output
 // columns for a containing GroupBy operator. The private Cols field contains
-// the list of column indexes returned by the expression, as a *opt.ColList. It
+// the list of column indexes returned by the expression, as a *ColList. It
 // is legal for Cols to be empty.
 func (_f *factory) ConstructAggregations(
 	aggs opt.ListID,
@@ -174,29 +174,6 @@ func (_f *factory) ConstructAggregations(
 	}
 
 	return _f.onConstruct(_f.mem.memoizeNormExpr((*memoExpr)(&_aggregationsExpr)))
-}
-
-// ConstructGroupings constructs an expression for the Groupings operator.
-// Groupings is a set of grouping expressions that will become output columns
-// for a containing GroupBy operator. The GroupBy operator groups its input by
-// the value of these expressions, and may compute aggregates over the groups.
-// The private Cols field contains the list of column indexes returned by the
-// expression, as a *opt.ColList. It is legal for Cols to be empty.
-func (_f *factory) ConstructGroupings(
-	elems opt.ListID,
-	cols opt.PrivateID,
-) opt.GroupID {
-	_groupingsExpr := makeGroupingsExpr(elems, cols)
-	_group := _f.mem.lookupGroupByFingerprint(_groupingsExpr.fingerprint())
-	if _group != 0 {
-		return _group
-	}
-
-	if !_f.allowOptimizations() {
-		return _f.mem.memoizeNormExpr((*memoExpr)(&_groupingsExpr))
-	}
-
-	return _f.onConstruct(_f.mem.memoizeNormExpr((*memoExpr)(&_groupingsExpr)))
 }
 
 // ConstructExists constructs an expression for the Exists operator.
@@ -1552,12 +1529,17 @@ func (_f *factory) ConstructAntiJoinApply(
 }
 
 // ConstructGroupBy constructs an expression for the GroupBy operator.
+// GroupBy is an operator that is used for performing aggregations (for queries
+// with aggregate functions, HAVING clauses and/or group by expressions). It
+// groups results that are equal on the grouping columns and computes
+// aggregations as described by Aggregations (which is always an Aggregations
+// operator). The arguments of the aggregations are columns from the input.
 func (_f *factory) ConstructGroupBy(
 	input opt.GroupID,
-	groupings opt.GroupID,
 	aggregations opt.GroupID,
+	groupingColumns opt.PrivateID,
 ) opt.GroupID {
-	_groupByExpr := makeGroupByExpr(input, groupings, aggregations)
+	_groupByExpr := makeGroupByExpr(input, aggregations, groupingColumns)
 	_group := _f.mem.lookupGroupByFingerprint(_groupByExpr.fingerprint())
 	if _group != 0 {
 		return _group
@@ -1627,7 +1609,7 @@ func (_f *factory) ConstructExcept(
 
 type dynConstructLookupFunc func(f *factory, children []opt.GroupID, private opt.PrivateID) opt.GroupID
 
-var dynConstructLookup [79]dynConstructLookupFunc
+var dynConstructLookup [78]dynConstructLookupFunc
 
 func init() {
 	// UnknownOp
@@ -1678,11 +1660,6 @@ func init() {
 	// AggregationsOp
 	dynConstructLookup[opt.AggregationsOp] = func(f *factory, children []opt.GroupID, private opt.PrivateID) opt.GroupID {
 		return f.ConstructAggregations(f.InternList(children), private)
-	}
-
-	// GroupingsOp
-	dynConstructLookup[opt.GroupingsOp] = func(f *factory, children []opt.GroupID, private opt.PrivateID) opt.GroupID {
-		return f.ConstructGroupings(f.InternList(children), private)
 	}
 
 	// ExistsOp
@@ -2007,7 +1984,7 @@ func init() {
 
 	// GroupByOp
 	dynConstructLookup[opt.GroupByOp] = func(f *factory, children []opt.GroupID, private opt.PrivateID) opt.GroupID {
-		return f.ConstructGroupBy(children[0], children[1], children[2])
+		return f.ConstructGroupBy(children[0], children[1], private)
 	}
 
 	// UnionOp

--- a/pkg/sql/opt/xform/logical_props.go
+++ b/pkg/sql/opt/xform/logical_props.go
@@ -69,12 +69,31 @@ func (p *LogicalProps) format(mem *memo, tp treeprinter.Node) {
 }
 
 func (p *LogicalProps) formatOutputCols(mem *memo, tp treeprinter.Node) {
-	if !p.Relational.OutputCols.Empty() {
+	p.formatColSet("columns:", p.Relational.OutputCols, mem, tp)
+}
+
+func (p *LogicalProps) formatColSet(
+	heading string, colSet opt.ColSet, mem *memo, tp treeprinter.Node,
+) {
+	if !colSet.Empty() {
 		var buf bytes.Buffer
-		buf.WriteString("columns:")
-		p.Relational.OutputCols.ForEach(func(i int) {
+		buf.WriteString(heading)
+		colSet.ForEach(func(i int) {
 			p.formatCol(mem, &buf, opt.ColumnIndex(i))
 		})
+		tp.Child(buf.String())
+	}
+}
+
+func (p *LogicalProps) formatColList(
+	heading string, colList opt.ColList, mem *memo, tp treeprinter.Node,
+) {
+	if len(colList) > 0 {
+		var buf bytes.Buffer
+		buf.WriteString(heading)
+		for _, col := range colList {
+			p.formatCol(mem, &buf, col)
+		}
 		tp.Child(buf.String())
 	}
 }

--- a/pkg/sql/opt/xform/logical_props_factory.go
+++ b/pkg/sql/opt/xform/logical_props_factory.go
@@ -160,12 +160,11 @@ func (f logicalPropsFactory) constructJoinProps(ev ExprView) LogicalProps {
 func (f logicalPropsFactory) constructGroupByProps(ev ExprView) LogicalProps {
 	props := LogicalProps{Relational: &RelationalProps{}}
 
-	// Output columns are the union of columns from grouping and aggregate
-	// projection lists.
-	groupings := ev.Child(1)
-	props.Relational.OutputCols = opt.ColListToSet(*groupings.Private().(*opt.ColList))
-	aggs := ev.Child(2)
-	props.Relational.OutputCols.UnionWith(opt.ColListToSet(*aggs.Private().(*opt.ColList)))
+	// Output columns are the union of grouping columns with columns from the
+	// aggregate projection list.
+	props.Relational.OutputCols = *ev.Private().(*opt.ColSet)
+	aggColList := *ev.Child(1).Private().(*opt.ColList)
+	props.Relational.OutputCols.UnionWith(opt.ColListToSet(aggColList))
 
 	return props
 }

--- a/pkg/sql/opt/xform/typing.go
+++ b/pkg/sql/opt/xform/typing.go
@@ -48,7 +48,6 @@ func init() {
 		opt.UnsupportedExprOp: typeAsTypedExpr,
 		opt.TupleOp:           typeAsTuple,
 		opt.ProjectionsOp:     typeAsAny,
-		opt.GroupingsOp:       typeAsAny,
 		opt.AggregationsOp:    typeAsAny,
 		opt.ExistsOp:          typeAsBool,
 		opt.FunctionOp:        typeFunction,


### PR DESCRIPTION
This change simplifies the GroupBy operator in that it no longer deals
with arbitrary expressions. Grouping columns and aggregate arguments
are always input columns; we use a pre-projection to generate the
necessary columns.

We store information about all aggregate argument expressions in
`groupby.aggs`: group, type, and column index if the arg is a
`VariableOp`. We then use this information to construct the
pre-projection and the aggregations.

Release note: None