### PR TITLE
cherrypick-2.0: storage: only backpressure writes to UserTableData keyspace 

### DIFF
--- a/pkg/keys/constants.go
+++ b/pkg/keys/constants.go
@@ -18,7 +18,6 @@ import (
 	"math"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
-	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 )
 
 // These constants are single bytes for performance. They allow single-byte
@@ -252,11 +251,13 @@ var (
 
 	// TimeseriesPrefix is the key prefix for all timeseries data.
 	TimeseriesPrefix = roachpb.Key(makeKey(SystemPrefix, roachpb.RKey("tsd")))
+	// TimeseriesKeyMax is the maximum value for any timeseries data.
+	TimeseriesKeyMax = TimeseriesPrefix.PrefixEnd()
 
 	// TableDataMin is the start of the range of table data keys.
-	TableDataMin = roachpb.Key(encoding.EncodeVarintAscending(nil, 0))
+	TableDataMin = roachpb.Key(MakeTablePrefix(0))
 	// TableDataMin is the end of the range of table data keys.
-	TableDataMax = roachpb.Key(encoding.EncodeVarintAscending(nil, math.MaxInt64))
+	TableDataMax = roachpb.Key(MakeTablePrefix(math.MaxUint32))
 
 	// SystemConfigSplitKey is the key to split at immediately prior to the
 	// system config span. NB: Split keys need to be valid column keys.

--- a/pkg/util/log/every_n.go
+++ b/pkg/util/log/every_n.go
@@ -44,6 +44,10 @@ func (e *EveryN) ShouldLog() bool {
 }
 
 func (e *EveryN) shouldLog(now time.Time) bool {
+	if VDepth(2 /* level */, 2 /* depth */) {
+		// Always log when high verbosity is desired.
+		return true
+	}
 	var shouldLog bool
 	e.Lock()
 	if now.Sub(e.lastLog) >= e.N {


### PR DESCRIPTION
Cherry-pick of https://github.com/cockroachdb/cockroach/pull/22771.