### PR TITLE
sql: try to track non-pgerrors by source location

### DIFF
--- a/pkg/server/updates_test.go
+++ b/pkg/server/updates_test.go
@@ -336,12 +336,23 @@ func TestReportUsage(t *testing.T) {
 		t.Fatalf("expected %d error codes counts in report, got %d (%v)", expected, actual, r.last.ErrorCounts)
 	}
 
+	// this test would be infuriating if it had to be updated on every edit to
+	// builtins.go that changed the line number of force_error, so just scrub the
+	// line number here.
+	for k := range r.last.ErrorCounts {
+		if strings.HasPrefix(k, "builtins.go") {
+			r.last.ErrorCounts["builtins.go"] = r.last.ErrorCounts[k]
+			delete(r.last.ErrorCounts, k)
+			break
+		}
+	}
+
 	for code, expected := range map[string]int64{
 		pgerror.CodeSyntaxError:              10,
 		pgerror.CodeFeatureNotSupportedError: 30,
 		pgerror.CodeDivisionByZeroError:      20,
-		"blah":    10,
-		"unknown": 10,
+		"blah":        10,
+		"builtins.go": 10,
 	} {
 		if actual := r.last.ErrorCounts[code]; expected != actual {
 			t.Fatalf(

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -317,7 +317,11 @@ func (s *Server) recordError(err error) {
 			}
 		}
 	} else {
-		s.errorCounts.codes["unknown"]++
+		typ := util.ErrorSource(err)
+		if typ == "" {
+			typ = "unknown"
+		}
+		s.errorCounts.codes[typ]++
 	}
 	s.errorCounts.Unlock()
 }

--- a/pkg/util/error.go
+++ b/pkg/util/error.go
@@ -14,7 +14,11 @@
 
 package util
 
-import "fmt"
+import (
+	"fmt"
+
+	"github.com/pkg/errors"
+)
 
 // UnexpectedWithIssueErr indicates an error with an associated Github issue.
 // It's supposed to be used for conditions that would otherwise be checked by
@@ -46,4 +50,19 @@ func (e UnexpectedWithIssueErr) Error() string {
 	return fmt.Sprintf("unexpected error%s (we've been trying to track this particular issue down; "+
 		"please report your reproduction at "+
 		"https://github.com/cockroachdb/cockroach/issues/%d)", fmtMsg, e.issue)
+}
+
+// ErrorSource attempts to return the file:line where `i` was created if `i` has
+// that information (i.e. if it is an errors.withStack). Returns "" otherwise.
+func ErrorSource(i interface{}) string {
+	type stackTracer interface {
+		StackTrace() errors.StackTrace
+	}
+	if e, ok := i.(stackTracer); ok {
+		tr := e.StackTrace()
+		if len(tr) > 0 {
+			return fmt.Sprintf("%v", tr[0]) // prints file:line
+		}
+	}
+	return ""
 }

--- a/pkg/util/log/crash_reporting.go
+++ b/pkg/util/log/crash_reporting.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/build"
 	"github.com/cockroachdb/cockroach/pkg/settings"
+	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/caller"
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
@@ -270,15 +271,9 @@ func (e *safeError) Error() string {
 // anonymized reporting.
 func Redact(r interface{}) string {
 	typAnd := func(i interface{}, text string) string {
-		type stackTracer interface {
-			StackTrace() errors.StackTrace
-		}
-		typ := fmt.Sprintf("%T", i)
-		if e, ok := i.(stackTracer); ok {
-			tr := e.StackTrace()
-			if len(tr) > 0 {
-				typ = fmt.Sprintf("%v", tr[0]) // prints file:line
-			}
+		typ := util.ErrorSource(i)
+		if typ == "" {
+			typ = fmt.Sprintf("%T", i)
 		}
 		if text == "" {
 			return typ


### PR DESCRIPTION
for non-pgerror errors, we can attempt to track them by where they came from before falling back to 'unknown'.

Release note: none.