### PR TITLE
tracing: minor usability improvements

### DIFF
--- a/pkg/kv/transport.go
+++ b/pkg/kv/transport.go
@@ -236,7 +236,7 @@ func (gt *grpcTransport) send(
 			log.VEvent(ctx, 2, "sending request to local server")
 
 			// Create a new context from the existing one with the "local request" field set.
-			// This tells the handler that this is an in-procress request, bypassing ctx.Peer checks.
+			// This tells the handler that this is an in-process request, bypassing ctx.Peer checks.
 			localCtx := grpcutil.NewLocalRequestContext(ctx)
 
 			gt.opts.metrics.LocalSentCount.Inc(1)

--- a/pkg/kv/txn_coord_sender.go
+++ b/pkg/kv/txn_coord_sender.go
@@ -40,7 +40,7 @@ import (
 
 const (
 	opTxnCoordSender = "txn coordinator"
-	opHeartbeatLoop  = "heartbeat"
+	opHeartbeatLoop  = "heartbeat txn"
 )
 
 // maxTxnIntentsBytes is a threshold in bytes for intent spans stored

--- a/pkg/sql/logictest/testdata/logic_test/show_trace
+++ b/pkg/sql/logictest/testdata/logic_test/show_trace
@@ -33,11 +33,11 @@
 query TTT
 SELECT span, message, operation FROM [SHOW TRACE FOR SELECT 1]
 ----
-(0,0)  === SPAN START: sql txn implicit ===  sql txn implicit
-(0,1)  === SPAN START: starting plan ===     starting plan
-(0,2)  === SPAN START: consuming rows ===    consuming rows
-(0,2)  plan completed execution              consuming rows
-(0,2)  resources released, stopping trace    consuming rows
+(0,0)  === SPAN START: sql txn ===         sql txn
+(0,1)  === SPAN START: starting plan ===   starting plan
+(0,2)  === SPAN START: consuming rows ===  consuming rows
+(0,2)  plan completed execution            consuming rows
+(0,2)  resources released, stopping trace  consuming rows
 
 statement ok
 PREPARE x AS SELECT 1
@@ -45,11 +45,11 @@ PREPARE x AS SELECT 1
 query TTT
 SELECT span, message, operation FROM [SHOW TRACE FOR EXECUTE x]
 ----
-(0,0)  === SPAN START: sql txn implicit ===  sql txn implicit
-(0,1)  === SPAN START: starting plan ===     starting plan
-(0,2)  === SPAN START: consuming rows ===    consuming rows
-(0,2)  plan completed execution              consuming rows
-(0,2)  resources released, stopping trace    consuming rows
+(0,0)  === SPAN START: sql txn ===         sql txn
+(0,1)  === SPAN START: starting plan ===   starting plan
+(0,2)  === SPAN START: consuming rows ===  consuming rows
+(0,2)  plan completed execution            consuming rows
+(0,2)  resources released, stopping trace  consuming rows
 
 # Check SHOW KV TRACE FOR SESSION.
 
@@ -61,27 +61,27 @@ SET tracing = on,kv; CREATE DATABASE t; SET tracing = off
 query TTT
 SELECT span, operation, message FROM [SHOW KV TRACE FOR SESSION] WHERE message NOT LIKE '%Z/%'
 ----
-(1,0)  sql txn implicit  querying next range at /Table/2/1/0/"t"/3/1
-(1,0)  sql txn implicit  r1: sending batch 1 Get to (n1,s1):1
-(1,0)  sql txn implicit  querying next range at /System/"desc-idgen"
-(1,0)  sql txn implicit  r1: sending batch 1 Inc to (n1,s1):1
-(1,0)  sql txn implicit  CPut /Table/2/1/0/"t"/3/1 -> 51
-(1,0)  sql txn implicit  CPut /Table/3/1/51/2/1 -> database:<name:"t" id:51 privileges:<users:<user:"admin" privileges:2 > users:<user:"root" privileges:2 > > >
-(1,0)  sql txn implicit  querying next range at /Table/SystemConfigSpan/Start
-(1,0)  sql txn implicit  r1: sending batch 2 CPut, 1 BeginTxn to (n1,s1):1
-(1,0)  sql txn implicit  querying next range at /Table/2/1/0/"system"/3/1
-(1,0)  sql txn implicit  r1: sending batch 1 Get to (n1,s1):1
-(1,0)  sql txn implicit  querying next range at /Table/3/1/1/2/1
-(1,0)  sql txn implicit  r1: sending batch 1 Get to (n1,s1):1
-(1,0)  sql txn implicit  querying next range at /Table/2/1/1/"eventlog"/3/1
-(1,0)  sql txn implicit  r1: sending batch 1 Get to (n1,s1):1
-(1,0)  sql txn implicit  querying next range at /Table/3/1/12/2/1
-(1,0)  sql txn implicit  r1: sending batch 1 Get to (n1,s1):1
-(1,0)  sql txn implicit  querying next range at /Table/3/1/1/2/1
-(1,0)  sql txn implicit  r1: sending batch 1 Get to (n1,s1):1
-(1,0)  sql txn implicit  r1: sending batch 5 CPut to (n1,s1):1
-(1,0)  sql txn implicit  querying next range at /Table/SystemConfigSpan/Start
-(1,0)  sql txn implicit  r1: sending batch 1 EndTxn to (n1,s1):1
+(1,0)  sql txn  querying next range at /Table/2/1/0/"t"/3/1
+(1,0)  sql txn  r1: sending batch 1 Get to (n1,s1):1
+(1,0)  sql txn  querying next range at /System/"desc-idgen"
+(1,0)  sql txn  r1: sending batch 1 Inc to (n1,s1):1
+(1,0)  sql txn  CPut /Table/2/1/0/"t"/3/1 -> 51
+(1,0)  sql txn  CPut /Table/3/1/51/2/1 -> database:<name:"t" id:51 privileges:<users:<user:"admin" privileges:2 > users:<user:"root" privileges:2 > > >
+(1,0)  sql txn  querying next range at /Table/SystemConfigSpan/Start
+(1,0)  sql txn  r1: sending batch 2 CPut, 1 BeginTxn to (n1,s1):1
+(1,0)  sql txn  querying next range at /Table/2/1/0/"system"/3/1
+(1,0)  sql txn  r1: sending batch 1 Get to (n1,s1):1
+(1,0)  sql txn  querying next range at /Table/3/1/1/2/1
+(1,0)  sql txn  r1: sending batch 1 Get to (n1,s1):1
+(1,0)  sql txn  querying next range at /Table/2/1/1/"eventlog"/3/1
+(1,0)  sql txn  r1: sending batch 1 Get to (n1,s1):1
+(1,0)  sql txn  querying next range at /Table/3/1/12/2/1
+(1,0)  sql txn  r1: sending batch 1 Get to (n1,s1):1
+(1,0)  sql txn  querying next range at /Table/3/1/1/2/1
+(1,0)  sql txn  r1: sending batch 1 Get to (n1,s1):1
+(1,0)  sql txn  r1: sending batch 5 CPut to (n1,s1):1
+(1,0)  sql txn  querying next range at /Table/SystemConfigSpan/Start
+(1,0)  sql txn  r1: sending batch 1 EndTxn to (n1,s1):1
 
 
 # More KV operations.
@@ -146,66 +146,66 @@ SELECT span, operation, regexp_replace(regexp_replace(message, 'mutationJobs:<[^
 query TTT
 SELECT span, operation, message FROM [SHOW KV TRACE FOR INSERT INTO t.kv(k, v) VALUES (1,2)]
 ----
-(0,0)  sql txn implicit  CPut /Table/52/1/1/0 -> /TUPLE/2:2:Int/2
-(0,2)  consuming rows    output row: []
-(0,0)  sql txn implicit  querying next range at /Table/52/1/1/0
-(0,0)  sql txn implicit  r1: sending batch 1 CPut, 1 BeginTxn, 1 InitPut to (n1,s1):1
+(0,0)  sql txn         CPut /Table/52/1/1/0 -> /TUPLE/2:2:Int/2
+(0,2)  consuming rows  output row: []
+(0,0)  sql txn         querying next range at /Table/52/1/1/0
+(0,0)  sql txn         r1: sending batch 1 CPut, 1 BeginTxn, 1 InitPut to (n1,s1):1
 
 query TTT
 SELECT span, operation, message FROM [SHOW KV TRACE FOR INSERT INTO t.kv(k, v) VALUES (1,2)]
 ----
-(0,0)  sql txn implicit  CPut /Table/52/1/1/0 -> /TUPLE/2:2:Int/2
-(0,2)  consuming rows    output row: []
-(0,0)  sql txn implicit  querying next range at /Table/52/1/1/0
-(0,0)  sql txn implicit  r1: sending batch 1 CPut, 1 BeginTxn, 1 InitPut to (n1,s1):1
-(0,2)  consuming rows    execution failed: duplicate key value (k)=(1) violates unique constraint "primary"
+(0,0)  sql txn         CPut /Table/52/1/1/0 -> /TUPLE/2:2:Int/2
+(0,2)  consuming rows  output row: []
+(0,0)  sql txn         querying next range at /Table/52/1/1/0
+(0,0)  sql txn         r1: sending batch 1 CPut, 1 BeginTxn, 1 InitPut to (n1,s1):1
+(0,2)  consuming rows  execution failed: duplicate key value (k)=(1) violates unique constraint "primary"
 
 query TTT
 SELECT span, operation, message FROM [SHOW KV TRACE FOR INSERT INTO t.kv(k, v) VALUES (2,2)]
 ----
-(0,0)  sql txn implicit  CPut /Table/52/1/2/0 -> /TUPLE/2:2:Int/2
-(0,2)  consuming rows    output row: []
-(0,0)  sql txn implicit  querying next range at /Table/52/1/2/0
-(0,0)  sql txn implicit  r1: sending batch 1 CPut, 1 BeginTxn, 1 InitPut to (n1,s1):1
-(0,2)  consuming rows    execution failed: duplicate key value (v)=(2) violates unique constraint "woo"
+(0,0)  sql txn         CPut /Table/52/1/2/0 -> /TUPLE/2:2:Int/2
+(0,2)  consuming rows  output row: []
+(0,0)  sql txn         querying next range at /Table/52/1/2/0
+(0,0)  sql txn         r1: sending batch 1 CPut, 1 BeginTxn, 1 InitPut to (n1,s1):1
+(0,2)  consuming rows  execution failed: duplicate key value (v)=(2) violates unique constraint "woo"
 
 query TTT
 SELECT span, operation, message FROM [SHOW KV TRACE FOR UPSERT INTO t.kv(k, v) VALUES (2,3)]
 ----
-(0,2)  consuming rows    output row: []
-(0,0)  sql txn implicit  Scan /Table/52/1/{2-3}
-(0,0)  sql txn implicit  querying next range at /Table/52/1/2
-(0,0)  sql txn implicit  r1: sending batch 1 Scan to (n1,s1):1
-(0,0)  sql txn implicit  CPut /Table/52/1/2/0 -> /TUPLE/2:2:Int/3
-(0,0)  sql txn implicit  querying next range at /Table/52/1/2/0
-(0,0)  sql txn implicit  r1: sending batch 1 CPut, 1 BeginTxn, 1 InitPut to (n1,s1):1
+(0,2)  consuming rows  output row: []
+(0,0)  sql txn         Scan /Table/52/1/{2-3}
+(0,0)  sql txn         querying next range at /Table/52/1/2
+(0,0)  sql txn         r1: sending batch 1 Scan to (n1,s1):1
+(0,0)  sql txn         CPut /Table/52/1/2/0 -> /TUPLE/2:2:Int/3
+(0,0)  sql txn         querying next range at /Table/52/1/2/0
+(0,0)  sql txn         r1: sending batch 1 CPut, 1 BeginTxn, 1 InitPut to (n1,s1):1
 
 query TTT
 SELECT span, operation, message FROM [SHOW KV TRACE FOR UPSERT INTO t.kv(k, v) VALUES (1,2)]
 ----
-(0,2)  consuming rows    output row: []
-(0,0)  sql txn implicit  Scan /Table/52/1/{1-2}
-(0,0)  sql txn implicit  querying next range at /Table/52/1/1
-(0,0)  sql txn implicit  r1: sending batch 1 Scan to (n1,s1):1
-(0,0)  sql txn implicit  fetched: /kv/primary/1/v -> /2
-(0,0)  sql txn implicit  Put /Table/52/1/1/0 -> /TUPLE/2:2:Int/2
-(0,0)  sql txn implicit  querying next range at /Table/52/1/1/0
-(0,0)  sql txn implicit  r1: sending batch 1 Put, 1 BeginTxn to (n1,s1):1
+(0,2)  consuming rows  output row: []
+(0,0)  sql txn         Scan /Table/52/1/{1-2}
+(0,0)  sql txn         querying next range at /Table/52/1/1
+(0,0)  sql txn         r1: sending batch 1 Scan to (n1,s1):1
+(0,0)  sql txn         fetched: /kv/primary/1/v -> /2
+(0,0)  sql txn         Put /Table/52/1/1/0 -> /TUPLE/2:2:Int/2
+(0,0)  sql txn         querying next range at /Table/52/1/1/0
+(0,0)  sql txn         r1: sending batch 1 Put, 1 BeginTxn to (n1,s1):1
 
 query TTT
 SELECT span, operation, message FROM [SHOW KV TRACE FOR UPSERT INTO t.kv(k, v) VALUES (2,2)]
 ----
-(0,2)  consuming rows    output row: []
-(0,0)  sql txn implicit  Scan /Table/52/1/{2-3}
-(0,0)  sql txn implicit  querying next range at /Table/52/1/2
-(0,0)  sql txn implicit  r1: sending batch 1 Scan to (n1,s1):1
-(0,0)  sql txn implicit  fetched: /kv/primary/2/v -> /3
-(0,0)  sql txn implicit  Put /Table/52/1/2/0 -> /TUPLE/2:2:Int/2
-(0,0)  sql txn implicit  Del /Table/52/2/3/0
-(0,0)  sql txn implicit  CPut /Table/52/2/2/0 -> /BYTES/Š
-(0,0)  sql txn implicit  querying next range at /Table/52/1/2/0
-(0,0)  sql txn implicit  r1: sending batch 1 Put, 1 CPut, 1 Del, 1 BeginTxn to (n1,s1):1
-(0,2)  consuming rows    execution failed: duplicate key value (v)=(2) violates unique constraint "woo"
+(0,2)  consuming rows  output row: []
+(0,0)  sql txn         Scan /Table/52/1/{2-3}
+(0,0)  sql txn         querying next range at /Table/52/1/2
+(0,0)  sql txn         r1: sending batch 1 Scan to (n1,s1):1
+(0,0)  sql txn         fetched: /kv/primary/2/v -> /3
+(0,0)  sql txn         Put /Table/52/1/2/0 -> /TUPLE/2:2:Int/2
+(0,0)  sql txn         Del /Table/52/2/3/0
+(0,0)  sql txn         CPut /Table/52/2/2/0 -> /BYTES/Š
+(0,0)  sql txn         querying next range at /Table/52/1/2/0
+(0,0)  sql txn         r1: sending batch 1 Put, 1 CPut, 1 Del, 1 BeginTxn to (n1,s1):1
+(0,2)  consuming rows  execution failed: duplicate key value (v)=(2) violates unique constraint "woo"
 
 query TTT
 SELECT span, operation, regexp_replace(regexp_replace(message, 'wall_time:\d+', 'wall_time:...'), '\d\d\d\d\d+', '...PK...') as message
@@ -247,17 +247,17 @@ query TTT
 SELECT span, operation, regexp_replace(message, '\d\d\d\d\d+', '...PK...') as message
   FROM [SHOW KV TRACE FOR UPDATE t.kv2 SET v = v + 2]
 ----
-(0,0)  sql txn implicit  Scan /Table/53/{1-2}
-(0,0)  sql txn implicit  querying next range at /Table/53/1
-(0,0)  sql txn implicit  r1: sending batch 1 Scan to (n1,s1):1
-(0,0)  sql txn implicit  fetched: /kv2/primary/...PK.../k/v -> /1/2
-(0,0)  sql txn implicit  Put /Table/53/1/...PK.../0 -> /TUPLE/1:1:Int/1/1:2:Int/4
-(0,2)  consuming rows    output row: [...PK... 1 4]
-(0,0)  sql txn implicit  fetched: /kv2/primary/...PK.../k/v -> /2/3
-(0,0)  sql txn implicit  Put /Table/53/1/...PK.../0 -> /TUPLE/1:1:Int/2/1:2:Int/5
-(0,2)  consuming rows    output row: [...PK... 2 5]
-(0,0)  sql txn implicit  querying next range at /Table/53/1/...PK.../0
-(0,0)  sql txn implicit  r1: sending batch 2 Put, 1 BeginTxn to (n1,s1):1
+(0,0)  sql txn         Scan /Table/53/{1-2}
+(0,0)  sql txn         querying next range at /Table/53/1
+(0,0)  sql txn         r1: sending batch 1 Scan to (n1,s1):1
+(0,0)  sql txn         fetched: /kv2/primary/...PK.../k/v -> /1/2
+(0,0)  sql txn         Put /Table/53/1/...PK.../0 -> /TUPLE/1:1:Int/1/1:2:Int/4
+(0,2)  consuming rows  output row: [...PK... 1 4]
+(0,0)  sql txn         fetched: /kv2/primary/...PK.../k/v -> /2/3
+(0,0)  sql txn         Put /Table/53/1/...PK.../0 -> /TUPLE/1:1:Int/2/1:2:Int/5
+(0,2)  consuming rows  output row: [...PK... 2 5]
+(0,0)  sql txn         querying next range at /Table/53/1/...PK.../0
+(0,0)  sql txn         r1: sending batch 2 Put, 1 BeginTxn to (n1,s1):1
 
 query TTT
 SELECT span, operation, message FROM [SHOW KV TRACE FOR DELETE FROM t.kv2]
@@ -302,19 +302,19 @@ SELECT span, operation, regexp_replace(regexp_replace(message, 'wall_time:\d+', 
 query TTT
 SELECT span, operation, message FROM [SHOW KV TRACE FOR DELETE FROM t.kv]
 ----
-(0,0)  sql txn implicit  Scan /Table/52/{1-2}
-(0,0)  sql txn implicit  querying next range at /Table/52/1
-(0,0)  sql txn implicit  r1: sending batch 1 Scan to (n1,s1):1
-(0,0)  sql txn implicit  fetched: /kv/primary/1/v -> /2
-(0,0)  sql txn implicit  Del /Table/52/2/2/0
-(0,0)  sql txn implicit  DelRange /Table/52/1/1 - /Table/52/1/1/#
-(0,2)  consuming rows    output row: [1 2]
-(0,0)  sql txn implicit  fetched: /kv/primary/2/v -> /3
-(0,0)  sql txn implicit  Del /Table/52/2/3/0
-(0,0)  sql txn implicit  DelRange /Table/52/1/2 - /Table/52/1/2/#
-(0,2)  consuming rows    output row: [2 3]
-(0,0)  sql txn implicit  querying next range at /Table/52/1/1
-(0,0)  sql txn implicit  r1: sending batch 2 Del, 2 DelRng, 1 BeginTxn to (n1,s1):1
+(0,0)  sql txn         Scan /Table/52/{1-2}
+(0,0)  sql txn         querying next range at /Table/52/1
+(0,0)  sql txn         r1: sending batch 1 Scan to (n1,s1):1
+(0,0)  sql txn         fetched: /kv/primary/1/v -> /2
+(0,0)  sql txn         Del /Table/52/2/2/0
+(0,0)  sql txn         DelRange /Table/52/1/1 - /Table/52/1/1/#
+(0,2)  consuming rows  output row: [1 2]
+(0,0)  sql txn         fetched: /kv/primary/2/v -> /3
+(0,0)  sql txn         Del /Table/52/2/3/0
+(0,0)  sql txn         DelRange /Table/52/1/2 - /Table/52/1/2/#
+(0,2)  consuming rows  output row: [2 3]
+(0,0)  sql txn         querying next range at /Table/52/1/1
+(0,0)  sql txn         r1: sending batch 2 Del, 2 DelRng, 1 BeginTxn to (n1,s1):1
 
 query TTT
 SELECT span, operation, regexp_replace(regexp_replace(message, 'mutationJobs:<[^>]*>', 'mutationJobs:<...>'), 'wall_time:\d+', 'wall_time:...') as message

--- a/pkg/sql/trace_test.go
+++ b/pkg/sql/trace_test.go
@@ -80,7 +80,7 @@ func TestTrace(t *testing.T) {
 						"WHERE operation IS NOT NULL ORDER BY op")
 			},
 			expSpans: []string{
-				"sql txn implicit",
+				"sql txn",
 				"/cockroach.roachpb.Internal/Batch",
 			},
 		},
@@ -115,7 +115,7 @@ func TestTrace(t *testing.T) {
 						"WHERE operation IS NOT NULL ORDER BY op")
 			},
 			expSpans: []string{
-				"sql txn implicit",
+				"sql txn",
 				"flow",
 				"table reader",
 				"/cockroach.roachpb.Internal/Batch",
@@ -138,7 +138,7 @@ func TestTrace(t *testing.T) {
 						"WHERE operation IS NOT NULL ORDER BY op")
 			},
 			expSpans: []string{
-				"sql txn implicit",
+				"sql txn",
 				"starting plan",
 				"consuming rows",
 				"/cockroach.roachpb.Internal/Batch",

--- a/pkg/sql/txn_state.go
+++ b/pkg/sql/txn_state.go
@@ -145,12 +145,7 @@ func (ts *txnState2) resetForNewSQLTxn(
 	// TODO(andrei): figure out how to close these spans on server shutdown? Ties
 	// into a larger discussion about how to drain SQL and rollback open txns.
 	var sp opentracing.Span
-	var opName string
-	if txnType == implicitTxn {
-		opName = sqlImplicitTxnName
-	} else {
-		opName = sqlTxnName
-	}
+	opName := sqlTxnName
 
 	// Create a span for the new txn. The span is always Recordable to support the
 	// use of session tracing, which may start recording on it.
@@ -161,6 +156,10 @@ func (ts *txnState2) resetForNewSQLTxn(
 	} else {
 		// Create a root span for this SQL txn.
 		sp = tranCtx.tracer.StartSpan(opName, tracing.Recordable)
+	}
+
+	if txnType == implicitTxn {
+		sp.SetTag("implicit", "true")
 	}
 
 	// Put the new span in the context.

--- a/pkg/sql/txn_state_test.go
+++ b/pkg/sql/txn_state_test.go
@@ -260,8 +260,7 @@ func TestTransitions(t *testing.T) {
 		expEv   txnEvent
 	}
 
-	implicitTxnName := sqlImplicitTxnName
-	explicitTxnName := sqlTxnName
+	txnName := sqlTxnName
 	now := testCon.clock.Now()
 	iso := enginepb.SERIALIZABLE
 	pri := roachpb.NormalUserPriority
@@ -315,7 +314,7 @@ func TestTransitions(t *testing.T) {
 				expEv:   txnStart,
 			},
 			expTxn: &expKVTxn{
-				debugName:    &implicitTxnName,
+				debugName:    &txnName,
 				isolation:    &iso,
 				userPriority: &pri,
 				tsNanos:      &now.WallTime,
@@ -339,7 +338,7 @@ func TestTransitions(t *testing.T) {
 				expEv:   txnStart,
 			},
 			expTxn: &expKVTxn{
-				debugName:    &explicitTxnName,
+				debugName:    &txnName,
 				isolation:    &iso,
 				userPriority: &pri,
 				tsNanos:      &now.WallTime,


### PR DESCRIPTION
- rename txn heartbeat trace to "heartbeat txn" from "heartbeat"
- rename "sql txn implicit" trace to "sql txn" with the "implicit=true" tag