### PR TITLE
sql: use the new OrigTimestamp() method on client.TxnProto

### DIFF
--- a/pkg/sql/jobs/jobs.go
+++ b/pkg/sql/jobs/jobs.go
@@ -367,7 +367,7 @@ func (j *Job) insert(ctx context.Context, id int64, payload *Payload) error {
 		// to be equal *or greater* than previously inserted timestamps
 		// computed by now(). For now OrigTimestamp can only move forward
 		// and the assertion OrigTimestamp >= now() holds at all times.
-		payload.ModifiedMicros = timeutil.ToUnixMicros(txn.Proto().OrigTimestamp.GoTime())
+		payload.ModifiedMicros = timeutil.ToUnixMicros(txn.OrigTimestamp().GoTime())
 		payloadBytes, err := protoutil.Marshal(payload)
 		if err != nil {
 			return err

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -249,10 +249,11 @@ func newInternalPlanner(
 
 	var ts time.Time
 	if txn != nil {
-		if txn.Proto().OrigTimestamp == (hlc.Timestamp{}) {
+		origTimestamp := txn.OrigTimestamp()
+		if origTimestamp == (hlc.Timestamp{}) {
 			panic("makeInternalPlanner called with a transaction without timestamps")
 		}
-		ts = txn.Proto().OrigTimestamp.GoTime()
+		ts = origTimestamp.GoTime()
 	}
 	p := s.newPlanner(
 		txn, ts /* txnTimestamp */, ts, /* stmtTimestamp */


### PR DESCRIPTION
Informs #22909.
Follows up on https://github.com/cockroachdb/cockroach/pull/22440#pullrequestreview-98518416.

Instead of `txn.Proto().OrigTimestamp` use `txn.OrigTimestamp` where
appropriate. This more effectively redirects the reader of the code to
the definition of this method and the explanatory comment immediately
above it.

Suggested/required by @vivekmenezes.

Release note: None