### PR TITLE
cherrypick-2.0: backupccl: unskip test

### DIFF
--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -809,7 +809,6 @@ func TestBackupRestoreResume(t *testing.T) {
 // work as intended on backup and restore jobs.
 func TestBackupRestoreControlJob(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	t.Skipf("#22665")
 
 	defer func(oldInterval time.Duration) {
 		jobs.DefaultAdoptInterval = oldInterval


### PR DESCRIPTION
Underlying issue has been closed.

See #22665

Release note: None

Cherrypick #22900