### PR TITLE
ui: fix padding on node diagnostics page

### DIFF
--- a/pkg/ui/src/views/reports/containers/nodes/index.tsx
+++ b/pkg/ui/src/views/reports/containers/nodes/index.tsx
@@ -322,16 +322,16 @@ class Nodes extends React.Component<NodesProps, {}> {
 
     if (_.isEmpty(orderedNodeIDs)) {
       return (
-        <div>
+        <section className="section">
           <h1>Node Diagnostics</h1>
           <NodeFilterList nodeIDs={filters.nodeIDs} localityRegex={filters.localityRegex} />
           <h2>No nodes match the filters</h2>
-        </div>
+        </section>
       );
     }
 
     return (
-      <div className="section">
+      <section className="section">
         <h1>Node Diagnostics</h1>
         <NodeFilterList nodeIDs={filters.nodeIDs} localityRegex={filters.localityRegex} />
         <h2>Nodes</h2>
@@ -351,7 +351,7 @@ class Nodes extends React.Component<NodesProps, {}> {
             }
           </tbody>
         </table>
-      </div>
+      </section>
     );
   }
 }


### PR DESCRIPTION
Fixes #21854 

Now:
![image](https://user-images.githubusercontent.com/7341/36557569-a1a92544-17d6-11e8-8a8e-a42417854373.png)
![image](https://user-images.githubusercontent.com/7341/36557572-a3328a7c-17d6-11e8-8c0f-fc0994612cbe.png)

Release note (admin ui change): fixes #21854