### PR TITLE
storage: improve liveness heartbeat tracing

### DIFF
--- a/pkg/storage/node_liveness.go
+++ b/pkg/storage/node_liveness.go
@@ -34,6 +34,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 )
 
 var (
@@ -394,7 +395,7 @@ func (nl *NodeLiveness) StartHeartbeat(
 					// Give the context a timeout approximately as long as the time we
 					// have left before our liveness entry expires.
 					ctx, cancel := context.WithTimeout(context.Background(), nl.livenessThreshold-nl.heartbeatInterval)
-					ctx, sp := ambient.AnnotateCtxWithSpan(ctx, "heartbeat")
+					ctx, sp := ambient.AnnotateCtxWithSpan(ctx, "liveness heartbeat loop")
 					defer cancel()
 					defer sp.Finish()
 
@@ -466,6 +467,8 @@ func (nl *NodeLiveness) Heartbeat(ctx context.Context, liveness *Liveness) error
 func (nl *NodeLiveness) heartbeatInternal(
 	ctx context.Context, liveness *Liveness, incrementEpoch bool,
 ) error {
+	ctx, finish := tracing.EnsureChildSpan(ctx, nl.ambientCtx.Tracer, "liveness heartbeat")
+	defer finish()
 	defer func(start time.Time) {
 		dur := timeutil.Now().Sub(start)
 		nl.metrics.HeartbeatLatency.RecordValue(dur.Nanoseconds())


### PR DESCRIPTION
- internalHeartbeat now owns a span called "liveness heartbeat"
- the top level periodic heartbeat span is renamed from "heartbeat" to
  "liveness heartbeat loop"

Previously, on-demand liveness heartbeats didn't show up in their own
span, leading to some confusion. Now, they'll show up in their own span,
named the same as the span that's generated by the heartbeat loop.

Release note: None