### PR TITLE
sqlmigrations: fix bug in 1.0 -> 1.1 -> 2.0 migration

### DIFF
--- a/pkg/sqlmigrations/migrations.go
+++ b/pkg/sqlmigrations/migrations.go
@@ -825,6 +825,7 @@ func grantAdminPrivileges(ctx context.Context, r runner) error {
 					return err
 				}
 			case *sqlbase.TableDescriptor:
+				_ = d.MaybeUpgradeFormatVersion()
 				if err := d.Validate(ctx, txn); err != nil {
 					return err
 				}


### PR DESCRIPTION
A 2.0 binary running the grantAdminPrivileges migration implictly
depended on all of tables being a format version >= 2. Unfortunately,
the migration to actually do this format version upgrade was run after
it. This meant that if a cluster was upgraded from 1.0 to 2.0 through
1.1, it was possible to get into a state where 2.0 binaries would panic
on startup. This fixes it by upgrading the format version in
grantAdminPrivileges immediately before it's required to be upgraded.

Release note (bug fix): fixes a panic when upgrading from quickly from 1.0.x to 2.0.x