### PR TITLE
server: don't crash on empty update check or diagnostic report overrides

### DIFF
--- a/pkg/server/updates.go
+++ b/pkg/server/updates.go
@@ -186,6 +186,9 @@ func addInfoToURL(ctx context.Context, url *url.URL, s *Server, runningTime time
 // The returned boolean indicates if the check succeeded (and thus does not need
 // to be re-attempted by the scheduler after a retry-interval).
 func (s *Server) checkForUpdates(runningTime time.Duration) bool {
+	if updatesURL == nil {
+		return true // don't bother with asking for retry -- we'll never succeed.
+	}
 	ctx, span := s.AnnotateCtxWithSpan(context.Background(), "checkForUpdates")
 	defer span.Finish()
 
@@ -343,6 +346,9 @@ func (s *Server) getReportingInfo(ctx context.Context) *diagnosticspb.Diagnostic
 }
 
 func (s *Server) reportDiagnostics(runningTime time.Duration) {
+	if reportingURL == nil {
+		return
+	}
 	ctx, span := s.AnnotateCtxWithSpan(context.Background(), "usageReport")
 	defer span.Finish()
 


### PR DESCRIPTION
You can override the updates check or diagnoatics report endpoints via env vars, but overriding them to empty would result in a nil pointer deference crash when the server attempted to check for new versions or send a diagnostics report.
Fixes #22967.

Release note (bug fix): do not crash if COCKROACH_UPDATE_CHECK_URL or COCKROACH_USAGE_REPORT_URL overrides are empty.