### PR TITLE
sql: don't generate spans on implicit columns not part of the key

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/order_by
+++ b/pkg/sql/logictest/testdata/logic_test/order_by
@@ -481,7 +481,7 @@ sort             ·      ·
  │               order  +b,+a,+d
  └── index-join  ·      ·
       ├── scan   ·      ·
-      │          table  abc@ba
+      │          table  abc@bc
       │          spans  /11-
       └── scan   ·      ·
 ·                table  abc@primary

--- a/pkg/sql/logictest/testdata/logic_test/select_index
+++ b/pkg/sql/logictest/testdata/logic_test/select_index
@@ -884,7 +884,8 @@ SELECT * FROM abcd@abcd WHERE a = 1 AND b IS NULL AND c > 0 AND c < 10 ORDER BY 
 1  NULL  1  NULL
 1  NULL  5  NULL
 
-# Regression test for #3548: verify we create constraints on implicit columns.
+# Regression test for #3548: verify we create constraints on implicit columns
+# when they are part of the key (non-unique index).
 statement ok
 CREATE TABLE abc (a INT, b INT, c INT, PRIMARY KEY(a,b), INDEX(c))
 
@@ -896,6 +897,21 @@ render     0  render  ·         ·                  (c)                        
  └── scan  1  scan    ·         ·                  (a[omitted], b[omitted], c)  a=CONST; c=CONST; b!=NULL; key(b)
 ·          1  ·       table     abc@abc_c_idx      ·                            ·
 ·          1  ·       spans     /1/3-/1/4          ·                            ·
+
+# Verify we don't create constraints on implicit columns when they are not part
+# of the key (unique index).
+statement ok
+CREATE TABLE def (d INT, e INT, f INT, PRIMARY KEY(d,e), UNIQUE INDEX(f))
+
+query TITTTTT
+EXPLAIN (VERBOSE) SELECT f FROM def WHERE f = 1 and d = 3
+----
+render     0  render  ·         ·                  (f)                 f=CONST; key()
+ │         0  ·       render 0  test.public.def.f  ·                   ·
+ └── scan  1  scan    ·         ·                  (d, e[omitted], f)  d=CONST; f=CONST; key()
+·          1  ·       table     def@def_f_key      ·                   ·
+·          1  ·       spans     /1-/2              ·                   ·
+·          1  ·       filter    d = 3              ·                   ·
 
 # Regression test for #20504.
 query TITTTTT

--- a/pkg/sql/opt_index_selection.go
+++ b/pkg/sql/opt_index_selection.go
@@ -379,13 +379,15 @@ func (v indexInfoByCost) Sort() {
 // baseline cost for the index).
 func (v *indexInfo) makeIndexConstraints(filter *opt.Expr, evalCtx *tree.EvalContext) error {
 	numIndexCols := len(v.index.ColumnIDs)
-	numExtraCols := len(v.index.ExtraColumnIDs)
 
+	numExtraCols := 0
 	isInverted := (v.index.Type == sqlbase.IndexDescriptor_INVERTED)
-	if isInverted {
-		// TODO(radu): we currently don't support index constraints on PK
-		// columns on an inverted index.
-		numExtraCols = 0
+	// TODO(radu): we currently don't support index constraints on PK
+	// columns on an inverted index.
+	if !isInverted && !v.index.Unique {
+		// We have a non-unique index; the extra columns are added to the key and we
+		// can use them for index constraints.
+		numExtraCols = len(v.index.ExtraColumnIDs)
 	}
 
 	colIdxMap := make(map[sqlbase.ColumnID]int, len(v.desc.Columns))


### PR DESCRIPTION
The new index selection code can generate spans that incorporate
values on implicit columns. However, this is only correct when
implicit columns are part of the key, i.e. non-unique indexes.

Release note (bug fix): fixed incorrect index constraints on primary
key columns on unique indexes (there was a possibility of returning
fewer results, though unclear if it can happen in practice).