### PR TITLE
cherry-pick 2.0: sql: use the new OrigTimestamp() method on client.TxnProto

### DIFF
--- a/pkg/kv/dist_sender_server_test.go
+++ b/pkg/kv/dist_sender_server_test.go
@@ -2451,7 +2451,9 @@ func TestTxnCoordSenderRetries(t *testing.T) {
 			epoch := 0
 			if err := db.Txn(ctx, func(ctx context.Context, txn *client.Txn) error {
 				if tc.tsLeaked {
-					txn.OrigTimestampWasObserved()
+					// Read the commit timestamp so the expectation is that
+					// this transaction cannot be restarted internally.
+					_ = txn.CommitTimestamp()
 				}
 				if epoch > 0 {
 					if !tc.clientRetry {

--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -576,7 +576,7 @@ func (sc *SchemaChanger) backfillIndexes(
 	if err := sc.db.Txn(ctx, func(ctx context.Context, txn *client.Txn) error {
 		details := *sc.job.WithTxn(txn).Payload().Details.(*jobs.Payload_SchemaChange).SchemaChange
 		if details.ReadAsOf == (hlc.Timestamp{}) {
-			details.ReadAsOf = txn.OrigTimestamp(true /*mattersForTxnOrdering*/)
+			details.ReadAsOf = txn.CommitTimestamp()
 			if err := sc.job.WithTxn(txn).SetDetails(ctx, details); err != nil {
 				return errors.Wrapf(err, "failed to store readAsOf on job %d", *sc.job.ID())
 			}

--- a/pkg/sql/create_sequence.go
+++ b/pkg/sql/create_sequence.go
@@ -136,7 +136,7 @@ func (n *createSequenceNode) makeSequenceTableDesc(
 	privileges *sqlbase.PrivilegeDescriptor,
 ) (sqlbase.TableDescriptor, error) {
 	desc := initTableDescriptor(id, parentID, sequenceName,
-		params.p.txn.OrigTimestamp(true /*mattersForTxnOrdering*/), privileges)
+		params.p.txn.CommitTimestamp(), privileges)
 
 	// Mimic a table with one column, "value".
 	desc.Columns = []sqlbase.ColumnDescriptor{

--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -136,7 +136,7 @@ func (n *createTableNode) startExec(params runParams) error {
 
 	var desc sqlbase.TableDescriptor
 	var affected map[sqlbase.ID]*sqlbase.TableDescriptor
-	creationTime := params.p.txn.OrigTimestamp(true /*mattersForTxnOrdering*/)
+	creationTime := params.p.txn.CommitTimestamp()
 	if n.n.As() {
 		desc, err = makeTableDescIfAs(
 			n.n, n.dbDesc.ID, id, creationTime, planColumns(n.sourcePlan),

--- a/pkg/sql/create_view.go
+++ b/pkg/sql/create_view.go
@@ -220,7 +220,7 @@ func (n *createViewNode) makeViewTableDesc(
 	privileges *sqlbase.PrivilegeDescriptor,
 ) (sqlbase.TableDescriptor, error) {
 	desc := initTableDescriptor(id, parentID, viewName,
-		params.p.txn.OrigTimestamp(true /*mattersForTxnOrdering*/), privileges)
+		params.p.txn.CommitTimestamp(), privileges)
 	desc.ViewQuery = tree.AsStringWithFlags(n.n.AsSource, tree.FmtParsable)
 	for i, colRes := range resultColumns {
 		colType, err := coltypes.DatumTypeToColumnType(colRes.Typ)

--- a/pkg/sql/jobs/jobs.go
+++ b/pkg/sql/jobs/jobs.go
@@ -367,7 +367,7 @@ func (j *Job) insert(ctx context.Context, id int64, payload *Payload) error {
 		// to be equal *or greater* than previously inserted timestamps
 		// computed by now(). For now OrigTimestamp can only move forward
 		// and the assertion OrigTimestamp >= now() holds at all times.
-		payload.ModifiedMicros = timeutil.ToUnixMicros(txn.Proto().OrigTimestamp.GoTime())
+		payload.ModifiedMicros = timeutil.ToUnixMicros(txn.OrigTimestamp().GoTime())
 		payloadBytes, err := protoutil.Marshal(payload)
 		if err != nil {
 			return err

--- a/pkg/sql/lease.go
+++ b/pkg/sql/lease.go
@@ -142,7 +142,7 @@ func (s LeaseStore) acquire(
 ) (*tableVersionState, error) {
 	var table *tableVersionState
 	err := s.execCfg.DB.Txn(ctx, func(ctx context.Context, txn *client.Txn) error {
-		expiration := txn.OrigTimestamp(false /*mattersForTxnOrdering*/)
+		expiration := txn.OrigTimestamp()
 		expiration.WallTime += int64(s.jitteredLeaseDuration())
 		if expiration.Less(minExpirationTime) {
 			expiration = minExpirationTime
@@ -346,8 +346,8 @@ func (s LeaseStore) Publish(
 			// will be OrigTimestamp. However, once we've used the
 			// timestamp, it's rather essential that we have a guarantee
 			// that the txn will commit at that exact timestamp. Using
-			// mattersForTxnOrdering=true provides this guarantee.
-			modTime := txn.OrigTimestamp(true /*mattersForTxnOrdering*/)
+			// CommitTimestamp() provides this guarantee.
+			modTime := txn.CommitTimestamp()
 			tableDesc.ModificationTime = modTime
 			log.Infof(ctx, "publish: descID=%d (%s) version=%d mtime=%s",
 				tableDesc.ID, tableDesc.Name, tableDesc.Version, modTime.GoTime())

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -249,10 +249,11 @@ func newInternalPlanner(
 
 	var ts time.Time
 	if txn != nil {
-		if txn.Proto().OrigTimestamp == (hlc.Timestamp{}) {
+		origTimestamp := txn.OrigTimestamp()
+		if origTimestamp == (hlc.Timestamp{}) {
 			panic("makeInternalPlanner called with a transaction without timestamps")
 		}
-		ts = txn.Proto().OrigTimestamp.GoTime()
+		ts = origTimestamp.GoTime()
 	}
 	p := s.newPlanner(
 		txn, ts /* txnTimestamp */, ts, /* stmtTimestamp */

--- a/pkg/sql/render.go
+++ b/pkg/sql/render.go
@@ -489,7 +489,7 @@ func (p *planner) getTimestamp(asOf tree.AsOfClause) (hlc.Timestamp, bool, error
 		if err != nil {
 			return hlc.MaxTimestamp, false, err
 		}
-		if ts != p.txn.OrigTimestamp(false /*mattersForTxnOrdering*/) {
+		if ts != p.txn.OrigTimestamp() {
 			return hlc.MaxTimestamp, false,
 				fmt.Errorf("cannot specify AS OF SYSTEM TIME with different timestamps")
 		}

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -2411,7 +2411,7 @@ func (ctx *EvalContext) GetStmtTimestamp() time.Time {
 // GetClusterTimestamp retrieves the current cluster timestamp as per
 // the evaluation context. The timestamp is guaranteed to be nonzero.
 func (ctx *EvalContext) GetClusterTimestamp() *DDecimal {
-	ts := ctx.Txn.OrigTimestamp(true /*mattersForTxnOrdering*/)
+	ts := ctx.Txn.CommitTimestamp()
 	if ts == (hlc.Timestamp{}) {
 		panic("zero cluster timestamp in txn")
 	}

--- a/pkg/sql/truncate.go
+++ b/pkg/sql/truncate.go
@@ -123,7 +123,7 @@ func (p *planner) truncateTable(ctx context.Context, id sqlbase.ID, traceKV bool
 	}
 	newTableDesc := *tableDesc
 	newTableDesc.ReplacementOf = sqlbase.TableDescriptor_Replacement{
-		ID: id, Time: p.txn.OrigTimestamp(true /*mattersForTxnOrdering*/),
+		ID: id, Time: p.txn.CommitTimestamp(),
 	}
 	newTableDesc.SetID(0)
 	newTableDesc.Version = 1

--- a/pkg/sql/txn_state_test.go
+++ b/pkg/sql/txn_state_test.go
@@ -226,7 +226,7 @@ func checkTxn(txn *client.Txn, exp expKVTxn) error {
 		return errors.Errorf("expected Timestamp: %d, but got: %s",
 			*exp.tsNanos, txn.Proto().Timestamp)
 	}
-	if origTimestamp := txn.OrigTimestamp(false /*mattersForTxnOrdering*/); exp.origTSNanos != nil &&
+	if origTimestamp := txn.OrigTimestamp(); exp.origTSNanos != nil &&
 		*exp.origTSNanos != origTimestamp.WallTime {
 		return errors.Errorf("expected OrigTimestamp: %d, but got: %s",
 			*exp.origTSNanos, origTimestamp)


### PR DESCRIPTION
Picks #22932.
Picks #22950.

Instead of `txn.Proto().OrigTimestamp` use `txn.OrigTimestamp` where
appropriate. This more effectively redirects the reader of the code to
the definition of this method and the explanatory comment immediately
above it.

Suggested/required by @vivekmenezes.

Release note: None