### PR TITLE
 server: skip check for new versions if diagnostics reports are disabled

### DIFF
--- a/pkg/server/admin_test.go
+++ b/pkg/server/admin_test.go
@@ -835,7 +835,7 @@ func TestAdminAPISettings(t *testing.T) {
 	defer s.Stopper().Stop(context.TODO())
 
 	// Any bool that defaults to true will work here.
-	const settingKey = "diagnostics.reporting.report_metrics"
+	const settingKey = "sql.metrics.statement_details.enabled"
 	st := s.ClusterSettings()
 	allKeys := settings.Keys()
 

--- a/pkg/server/updates.go
+++ b/pkg/server/updates.go
@@ -84,12 +84,6 @@ var diagnosticReportFrequency = settings.RegisterNonNegativeDurationSetting(
 	time.Hour,
 )
 
-var diagnosticsMetricsEnabled = settings.RegisterBoolSetting(
-	"diagnostics.reporting.report_metrics",
-	"enable collection and reporting diagnostic metrics to cockroach labs",
-	true,
-)
-
 // randomly shift `d` to be up to `jitterSec` shorter or longer.
 func addJitter(d time.Duration, jitterSec int) time.Duration {
 	j := time.Duration(rand.Intn(jitterSec*2)-jitterSec) * time.Second
@@ -248,7 +242,7 @@ func (s *Server) maybeReportDiagnostics(
 	// TODO(dt): we should allow tuning the reset and report intervals separately.
 	// Consider something like rand.Float() > resetFreq/reportFreq here to sample
 	// stat reset periods for reporting.
-	if log.DiagnosticsReportingEnabled.Get(&s.st.SV) && diagnosticsMetricsEnabled.Get(&s.st.SV) {
+	if log.DiagnosticsReportingEnabled.Get(&s.st.SV) {
 		s.reportDiagnostics(running)
 	}
 	if !s.cfg.UseLegacyConnHandling {

--- a/pkg/server/updates.go
+++ b/pkg/server/updates.go
@@ -143,6 +143,12 @@ func (s *Server) maybeCheckForUpdates(
 		return scheduled
 	}
 
+	// if diagnostics reporting is disabled, we should assume that means that the
+	// user doesn't want us phoning home for new-version checks either.
+	if !log.DiagnosticsReportingEnabled.Get(&s.st.SV) {
+		return now.Add(updateCheckFrequency)
+	}
+
 	// checkForUpdates handles its own errors, but it returns a bool indicating if
 	// it succeeded, so we can schedule a re-attempt if it did not.
 	if succeeded := s.checkForUpdates(runningTime); !succeeded {


### PR DESCRIPTION
If a user has disabled diagnostics reporting, we should assume that that expressed a preference that we not “phone-home” at all, including for the new-version checks.

Release note (general change): disabling diagnostics reporting also disables new version notification checks.

While I'm here:
This setting is duplicative with diagnostics.reporting.enabled — the only reason to set it would be to disable the diagnostics reports while leaving other diagnostics enabled — i.e. crash reporting and new-version checks, but it’s easier to explain if there’s just a single flag to toggle.

Release note (general change): remove diagnostics.reporting.report_metrics setting.
