### PR TITLE
Revert "backupccl: unskip test"

### DIFF
--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -809,6 +809,7 @@ func TestBackupRestoreResume(t *testing.T) {
 // work as intended on backup and restore jobs.
 func TestBackupRestoreControlJob(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	t.Skipf("#22665")
 
 	defer func(oldInterval time.Duration) {
 		jobs.DefaultAdoptInterval = oldInterval


### PR DESCRIPTION
This reverts commit efcb837565bc64030b2d66efb01ed5419312976d.

I guess there were two bugs and only one got fixed.