### PR TITLE
sql: implement session tracing for the connExecutor

### DIFF
--- a/pkg/sql/conn_io.go
+++ b/pkg/sql/conn_io.go
@@ -119,6 +119,7 @@ type StmtBuf struct {
 // Command is an interface implemented by all commands pushed by pgwire into the
 // buffer.
 type Command interface {
+	fmt.Stringer
 	command()
 }
 
@@ -127,7 +128,14 @@ type Command interface {
 type ExecStmt struct {
 	// Stmt can be nil, in which case a "empty query response" message should be
 	// produced.
+	//
+	// TODO(andrei): Many places call Stmt.String() (e.g. ExecStmt.String()),
+	// which seems inneficient. We should find a way to memo-ize this. Another
+	// option is to keep track of the query as we got it from the client, except
+	// that we might have gotten a batch of them at once, in which case only the
+	// parser can do the splitting.
 	Stmt tree.Statement
+
 	// TimeReceived is the time at which the exec message was received
 	// from the client. Used to compute the service latency.
 	TimeReceived time.Time
@@ -139,6 +147,10 @@ type ExecStmt struct {
 
 // command implements the Command interface.
 func (ExecStmt) command() {}
+
+func (e ExecStmt) String() string {
+	return fmt.Sprintf("ExecStmt: %s", e.Stmt.String())
+}
 
 var _ Command = ExecStmt{}
 
@@ -155,6 +167,10 @@ type ExecPortal struct {
 
 // command implements the Command interface.
 func (ExecPortal) command() {}
+
+func (e ExecPortal) String() string {
+	return fmt.Sprintf("ExecPortal name: %q", e.Name)
+}
 
 var _ Command = ExecPortal{}
 
@@ -175,6 +191,10 @@ type PrepareStmt struct {
 // command implements the Command interface.
 func (PrepareStmt) command() {}
 
+func (p PrepareStmt) String() string {
+	return fmt.Sprintf("PrepareStmt: %s", p.Stmt.String())
+}
+
 var _ Command = PrepareStmt{}
 
 // DescribeStmt is the Command for producing info about a prepared statement or
@@ -186,6 +206,10 @@ type DescribeStmt struct {
 
 // command implements the Command interface.
 func (DescribeStmt) command() {}
+
+func (d DescribeStmt) String() string {
+	return fmt.Sprintf("Describe: %q", d.Name)
+}
 
 var _ Command = DescribeStmt{}
 
@@ -214,6 +238,10 @@ type BindStmt struct {
 // command implements the Command interface.
 func (BindStmt) command() {}
 
+func (b BindStmt) String() string {
+	return fmt.Sprintf("BindStmt: %q->%q", b.PreparedStatementName, b.PortalName)
+}
+
 var _ Command = BindStmt{}
 
 // DeletePreparedStmt is the Command for freeing a prepared statement.
@@ -224,6 +252,10 @@ type DeletePreparedStmt struct {
 
 // command implements the Command interface.
 func (DeletePreparedStmt) command() {}
+
+func (d DeletePreparedStmt) String() string {
+	return fmt.Sprintf("DeletePreparedStmt: %q", d.Name)
+}
 
 var _ Command = DeletePreparedStmt{}
 
@@ -254,6 +286,10 @@ type Flush struct{}
 // command implements the Command interface.
 func (Flush) command() {}
 
+func (Flush) String() string {
+	return "Flush"
+}
+
 var _ Command = Flush{}
 
 // CopyIn is the command for execution of the Copy-in pgwire subprotocol.
@@ -270,6 +306,10 @@ type CopyIn struct {
 // command implements the Command interface.
 func (CopyIn) command() {}
 
+func (CopyIn) String() string {
+	return "CopyIn"
+}
+
 var _ Command = CopyIn{}
 
 // DrainRequest represents a notice that the server is draining and command
@@ -280,6 +320,10 @@ type DrainRequest struct{}
 
 // command implements the Command interface.
 func (DrainRequest) command() {}
+
+func (DrainRequest) String() string {
+	return "Drain"
+}
 
 var _ Command = DrainRequest{}
 
@@ -293,6 +337,10 @@ type SendError struct {
 
 // command implements the Command interface.
 func (SendError) command() {}
+
+func (s SendError) String() string {
+	return fmt.Sprintf("SendError: %s", s.Err)
+}
 
 var _ Command = SendError{}
 

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -576,10 +576,6 @@ CREATE TABLE crdb_internal.node_statement_statistics (
 var crdbInternalSessionTraceTable = virtualSchemaTable{
 	schema: `
 CREATE TABLE crdb_internal.session_trace (
-  txn_idx     INT NOT NULL,        -- The transaction's 0-based index, among all
-                                   -- transactions that have been traced.
-                                   -- Only filled for the first log message in a
-                                   -- transaction's top-level span.
   span_idx    INT NOT NULL,        -- The span's index.
   message_idx INT NOT NULL,        -- The message's index within its span.
   timestamp   TIMESTAMPTZ NOT NULL,-- The message's timestamp.
@@ -595,7 +591,7 @@ CREATE TABLE crdb_internal.session_trace (
 );
 `,
 	populate: func(ctx context.Context, p *planner, _ *DatabaseDescriptor, addRow func(...tree.Datum) error) error {
-		rows, err := p.ExtendedEvalContext().Tracing.generateSessionTraceVTable()
+		rows, err := p.ExtendedEvalContext().Tracing.getRecording()
 		if err != nil {
 			return err
 		}

--- a/pkg/sql/exec_log.go
+++ b/pkg/sql/exec_log.go
@@ -109,7 +109,7 @@ func (p *planner) maybeLogStatementInternal(
 	// Instead, make the logger work. This is critical for auditing - we
 	// can't miss any statement.
 
-	s := &p.sessionDataMutator
+	s := p.sessionDataMutator
 
 	logV := log.V(2)
 	logExecuteEnabled := logStatementsExecuteEnabled.Get(&s.settings.SV)

--- a/pkg/sql/logictest/testdata/logic_test/crdb_internal
+++ b/pkg/sql/logictest/testdata/logic_test/crdb_internal
@@ -88,10 +88,10 @@ SELECT * FROM crdb_internal.node_statement_statistics WHERE node_id < 0
 ----
 node_id  application_name  flags  key  anonymized  count  first_attempt_count  max_retries  last_error  rows_avg  rows_var  parse_lat_avg  parse_lat_var  plan_lat_avg  plan_lat_var  run_lat_avg  run_lat_var  service_lat_avg  service_lat_var  overhead_lat_avg  overhead_lat_var
 
-query IIITTTTTT colnames
-SELECT * FROM crdb_internal.session_trace WHERE txn_idx < 0
+query IITTTTTT colnames
+SELECT * FROM crdb_internal.session_trace WHERE span_idx < 0
 ----
-txn_idx  span_idx  message_idx  timestamp  duration  operation  loc  tag  message
+span_idx  message_idx  timestamp  duration  operation  loc  tag  message
 
 query TTTT colnames
 SELECT * FROM crdb_internal.cluster_settings WHERE name = ''

--- a/pkg/sql/logictest/testdata/logic_test/explain
+++ b/pkg/sql/logictest/testdata/logic_test/explain
@@ -75,15 +75,15 @@ render         0      render    ·         ·                         ("$1::INT"
 query TITTTTT
 EXPLAIN (METADATA) SHOW TRACE FOR SELECT 1
 ----
-sort                                         0  sort            ·      ·             ("timestamp", age, message, tag, loc, operation, span)                                 +"timestamp"
- │                                           0  ·               order  +"timestamp"  ·                                                                                      ·
- └── window                                  1  window          ·      ·             ("timestamp", age, message, tag, loc, operation, span)                                 ·
-      └── render                             2  render          ·      ·             ("timestamp", """timestamp""", message, tag, loc, operation, span)                     "timestamp"="""timestamp"""
-           └── window                        3  window          ·      ·             ("timestamp", message, tag, loc, operation, span)                                      ·
-                └── render                   4  render          ·      ·             ("timestamp", message, tag, loc, operation, span, txn_idx, span_idx, message_idx)      ·
-                     └── show trace for      5  show trace for  ·      ·             (txn_idx, span_idx, message_idx, "timestamp", duration, operation, loc, tag, message)  ·
-                          └── render         6  render          ·      ·             ("1")                                                                                  "1"=CONST
-                               └── emptyrow  7  emptyrow        ·      ·             ()                                                                                     ·
+sort                                         0  sort            ·      ·             ("timestamp", age, message, tag, loc, operation, span)                        +"timestamp"
+ │                                           0  ·               order  +"timestamp"  ·                                                                             ·
+ └── window                                  1  window          ·      ·             ("timestamp", age, message, tag, loc, operation, span)                        ·
+      └── render                             2  render          ·      ·             ("timestamp", """timestamp""", message, tag, loc, operation, span)            "timestamp"="""timestamp"""
+           └── window                        3  window          ·      ·             ("timestamp", message, tag, loc, operation, span)                             ·
+                └── render                   4  render          ·      ·             ("timestamp", message, tag, loc, operation, span, message_idx)                ·
+                     └── show trace for      5  show trace for  ·      ·             (span_idx, message_idx, "timestamp", duration, operation, loc, tag, message)  ·
+                          └── render         6  render          ·      ·             ("1")                                                                         "1"=CONST
+                               └── emptyrow  7  emptyrow        ·      ·             ()                                                                            ·
 
 # Ensure that all relevant statement types can be explained
 query TTT
@@ -224,7 +224,7 @@ sort                                       ·         ·
                      ├── render            ·         ·
                      │    └── filter       ·         ·
                      │         └── values  ·         ·
-                     │                     size      17 columns, 730 rows
+                     │                     size      17 columns, 729 rows
                      └── render            ·         ·
                           └── filter       ·         ·
                                └── values  ·         ·

--- a/pkg/sql/logictest/testdata/logic_test/show_trace
+++ b/pkg/sql/logictest/testdata/logic_test/show_trace
@@ -2,54 +2,54 @@
 
 # Prepare a trace to be inspected below.
 
-# TODO(andrei): #22783: skipping this test until figuring out the session
-# tracing story.
-# It used to be that all statements were executed in txn contexts. Now that's no
-# longer the case; BEGIN is executed in a session context. So SessionTracing
-# needs to learn how to record the session context too.
-# statement ok
-# SET tracing = on; BEGIN; SELECT 1; COMMIT; SELECT 2; SET tracing = off;
-#
-# # Inspect the trace: we exclude messages containing newlines as these
-# # may contain non-deterministic txn object descriptions.
-# # This also checks that the span column properly reports separate
-# # SQL transactions.
-# query TTT
-# SELECT span, message, operation FROM [SHOW TRACE FOR SESSION] WHERE message NOT LIKE e'%\n%' AND message NOT LIKE '%canceling context'
-# ----
-# (0,0)  === SPAN START: sql txn implicit ===  sql txn implicit
-# (1,0)  === SPAN START: sql txn ===           sql txn
-# (1,0)  executing 1/5: BEGIN TRANSACTION      sql txn
-# (1,0)  executing 2/5: SELECT 1               sql txn
-# (1,0)  executing 3/5: COMMIT TRANSACTION     sql txn
-# (2,0)  === SPAN START: sql txn implicit ===  sql txn implicit
-# (2,0)  executing 1/1: SELECT 2               sql txn implicit
-# (3,0)  === SPAN START: sql txn implicit ===  sql txn implicit
-# (3,0)  executing 1/1: SET tracing = off      sql txn implicit
+statement ok
+SET tracing = on; BEGIN; SELECT 1; COMMIT; SELECT 2; SET tracing = off;
+
+# Inspect the trace: we exclude messages containing newlines as these
+# may contain non-deterministic txn object descriptions.
+# This also checks that the span column properly reports separate
+# SQL transactions.
+query ITT
+SELECT span, message, operation FROM [SHOW TRACE FOR SESSION] WHERE message LIKE '%SPAN START%' OR message LIKE '%connEx executing%';
+----
+0  === SPAN START: sql txn ===                                      sql txn
+1  === SPAN START: session recording ===                            session recording
+1  [NoTxn pos:6] connEx executing cmd ExecStmt: BEGIN TRANSACTION   session recording
+2  === SPAN START: sql txn ===                                      sql txn
+2  [Open pos:7] connEx executing cmd ExecStmt: SELECT 1             sql txn
+2  [Open pos:8] connEx executing cmd ExecStmt: COMMIT TRANSACTION   sql txn
+1  [NoTxn pos:9] connEx executing cmd ExecStmt: SELECT 2            session recording
+3  === SPAN START: sql txn ===                                      sql txn
+3  [Open pos:9] connEx executing cmd ExecStmt: SELECT 2             sql txn
+1  [NoTxn pos:10] connEx executing cmd ExecStmt: SET tracing = off  session recording
+4  === SPAN START: sql txn ===                                      sql txn
+4  [Open pos:10] connEx executing cmd ExecStmt: SET tracing = off   sql txn
 
 # Same, with SHOW TRACE FOR.
 # This also tests that sub-spans are reported properly.
 
-query TTT
+query ITT
 SELECT span, message, operation FROM [SHOW TRACE FOR SELECT 1]
 ----
-(0,0)  === SPAN START: sql txn ===         sql txn
-(0,1)  === SPAN START: starting plan ===   starting plan
-(0,2)  === SPAN START: consuming rows ===  consuming rows
-(0,2)  plan completed execution            consuming rows
-(0,2)  resources released, stopping trace  consuming rows
+0  === SPAN START: sql txn ===            sql txn
+3  === SPAN START: session recording ===  session recording
+1  === SPAN START: starting plan ===      starting plan
+2  === SPAN START: consuming rows ===     consuming rows
+2  plan completed execution               consuming rows
+2  resources released, stopping trace     consuming rows
 
 statement ok
 PREPARE x AS SELECT 1
 
-query TTT
+query ITT
 SELECT span, message, operation FROM [SHOW TRACE FOR EXECUTE x]
 ----
-(0,0)  === SPAN START: sql txn ===         sql txn
-(0,1)  === SPAN START: starting plan ===   starting plan
-(0,2)  === SPAN START: consuming rows ===  consuming rows
-(0,2)  plan completed execution            consuming rows
-(0,2)  resources released, stopping trace  consuming rows
+0  === SPAN START: sql txn ===            sql txn
+3  === SPAN START: session recording ===  session recording
+1  === SPAN START: starting plan ===      starting plan
+2  === SPAN START: consuming rows ===     consuming rows
+2  plan completed execution               consuming rows
+2  resources released, stopping trace     consuming rows
 
 # Check SHOW KV TRACE FOR SESSION.
 
@@ -58,335 +58,335 @@ SET tracing = on,kv; CREATE DATABASE t; SET tracing = off
 
 # Check the KV trace; we need to remove the eventlog entry since the
 # timestamp is non-deterministic.
-query TTT
+query ITT
 SELECT span, operation, message FROM [SHOW KV TRACE FOR SESSION] WHERE message NOT LIKE '%Z/%'
 ----
-(1,0)  sql txn  querying next range at /Table/2/1/0/"t"/3/1
-(1,0)  sql txn  r1: sending batch 1 Get to (n1,s1):1
-(1,0)  sql txn  querying next range at /System/"desc-idgen"
-(1,0)  sql txn  r1: sending batch 1 Inc to (n1,s1):1
-(1,0)  sql txn  CPut /Table/2/1/0/"t"/3/1 -> 51
-(1,0)  sql txn  CPut /Table/3/1/51/2/1 -> database:<name:"t" id:51 privileges:<users:<user:"admin" privileges:2 > users:<user:"root" privileges:2 > > >
-(1,0)  sql txn  querying next range at /Table/SystemConfigSpan/Start
-(1,0)  sql txn  r1: sending batch 2 CPut, 1 BeginTxn to (n1,s1):1
-(1,0)  sql txn  querying next range at /Table/2/1/0/"system"/3/1
-(1,0)  sql txn  r1: sending batch 1 Get to (n1,s1):1
-(1,0)  sql txn  querying next range at /Table/3/1/1/2/1
-(1,0)  sql txn  r1: sending batch 1 Get to (n1,s1):1
-(1,0)  sql txn  querying next range at /Table/2/1/1/"eventlog"/3/1
-(1,0)  sql txn  r1: sending batch 1 Get to (n1,s1):1
-(1,0)  sql txn  querying next range at /Table/3/1/12/2/1
-(1,0)  sql txn  r1: sending batch 1 Get to (n1,s1):1
-(1,0)  sql txn  querying next range at /Table/3/1/1/2/1
-(1,0)  sql txn  r1: sending batch 1 Get to (n1,s1):1
-(1,0)  sql txn  r1: sending batch 5 CPut to (n1,s1):1
-(1,0)  sql txn  querying next range at /Table/SystemConfigSpan/Start
-(1,0)  sql txn  r1: sending batch 1 EndTxn to (n1,s1):1
+2  sql txn  querying next range at /Table/2/1/0/"t"/3/1
+2  sql txn  r1: sending batch 1 Get to (n1,s1):1
+2  sql txn  querying next range at /System/"desc-idgen"
+2  sql txn  r1: sending batch 1 Inc to (n1,s1):1
+2  sql txn  CPut /Table/2/1/0/"t"/3/1 -> 51
+2  sql txn  CPut /Table/3/1/51/2/1 -> database:<name:"t" id:51 privileges:<users:<user:"admin" privileges:2 > users:<user:"root" privileges:2 > > >
+2  sql txn  querying next range at /Table/SystemConfigSpan/Start
+2  sql txn  r1: sending batch 2 CPut, 1 BeginTxn to (n1,s1):1
+2  sql txn  querying next range at /Table/2/1/0/"system"/3/1
+2  sql txn  r1: sending batch 1 Get to (n1,s1):1
+2  sql txn  querying next range at /Table/3/1/1/2/1
+2  sql txn  r1: sending batch 1 Get to (n1,s1):1
+2  sql txn  querying next range at /Table/2/1/1/"eventlog"/3/1
+2  sql txn  r1: sending batch 1 Get to (n1,s1):1
+2  sql txn  querying next range at /Table/3/1/12/2/1
+2  sql txn  r1: sending batch 1 Get to (n1,s1):1
+2  sql txn  querying next range at /Table/3/1/1/2/1
+2  sql txn  r1: sending batch 1 Get to (n1,s1):1
+2  sql txn  r1: sending batch 5 CPut to (n1,s1):1
+2  sql txn  querying next range at /Table/SystemConfigSpan/Start
+2  sql txn  r1: sending batch 1 EndTxn to (n1,s1):1
 
 
 # More KV operations.
 
-query TTT
+query ITT
 SELECT span, operation, regexp_replace(message, 'wall_time:\d+', 'wall_time:...') as message
   FROM [SHOW KV TRACE FOR CREATE TABLE t.kv(k INT PRIMARY KEY, v INT)] WHERE message NOT LIKE '%Z/%'
 ----
-(0,1)  starting plan  querying next range at /Table/2/1/51/"kv"/3/1
-(0,1)  starting plan  r1: sending batch 1 Get to (n1,s1):1
-(0,1)  starting plan  querying next range at /System/"desc-idgen"
-(0,1)  starting plan  r1: sending batch 1 Inc to (n1,s1):1
-(0,1)  starting plan  CPut /Table/2/1/51/"kv"/3/1 -> 52
-(0,1)  starting plan  CPut /Table/3/1/52/2/1 -> table:<name:"kv" id:52 parent_id:51 version:1 up_version:false modification_time:<wall_time:... > columns:<name:"k" id:1 type:<semantic_type:INT width:0 precision:0 visible_type:NONE > nullable:false hidden:false > columns:<name:"v" id:2 type:<semantic_type:INT width:0 precision:0 visible_type:NONE > nullable:true hidden:false > next_column_id:3 families:<name:"primary" id:0 column_names:"k" column_names:"v" column_ids:1 column_ids:2 default_column_id:2 > next_family_id:1 primary_index:<name:"primary" id:1 unique:true column_names:"k" column_directions:ASC column_ids:1 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION > interleave:<> partitioning:<num_columns:0 > type:FORWARD > next_index_id:2 privileges:<users:<user:"admin" privileges:2 > users:<user:"root" privileges:2 > > next_mutation_id:1 format_version:3 state:PUBLIC view_query:"" drop_time:0 replacement_of:<id:0 time:<> > audit_mode:DISABLED >
-(0,1)  starting plan  querying next range at /Table/SystemConfigSpan/Start
-(0,1)  starting plan  r1: sending batch 2 CPut, 1 BeginTxn to (n1,s1):1
-(0,1)  starting plan  querying next range at /Table/3/1/51/2/1
-(0,1)  starting plan  r1: sending batch 1 Get to (n1,s1):1
-(0,1)  starting plan  querying next range at /Table/2/1/0/"system"/3/1
-(0,1)  starting plan  r1: sending batch 1 Get to (n1,s1):1
-(0,1)  starting plan  querying next range at /Table/3/1/1/2/1
-(0,1)  starting plan  r1: sending batch 1 Get to (n1,s1):1
-(0,1)  starting plan  querying next range at /Table/2/1/1/"eventlog"/3/1
-(0,1)  starting plan  r1: sending batch 1 Get to (n1,s1):1
-(0,1)  starting plan  querying next range at /Table/3/1/12/2/1
-(0,1)  starting plan  r1: sending batch 1 Get to (n1,s1):1
-(0,1)  starting plan  querying next range at /Table/3/1/1/2/1
-(0,1)  starting plan  r1: sending batch 1 Get to (n1,s1):1
-(0,1)  starting plan  r1: sending batch 5 CPut to (n1,s1):1
+1  starting plan  querying next range at /Table/2/1/51/"kv"/3/1
+1  starting plan  r1: sending batch 1 Get to (n1,s1):1
+1  starting plan  querying next range at /System/"desc-idgen"
+1  starting plan  r1: sending batch 1 Inc to (n1,s1):1
+1  starting plan  CPut /Table/2/1/51/"kv"/3/1 -> 52
+1  starting plan  CPut /Table/3/1/52/2/1 -> table:<name:"kv" id:52 parent_id:51 version:1 up_version:false modification_time:<wall_time:... > columns:<name:"k" id:1 type:<semantic_type:INT width:0 precision:0 visible_type:NONE > nullable:false hidden:false > columns:<name:"v" id:2 type:<semantic_type:INT width:0 precision:0 visible_type:NONE > nullable:true hidden:false > next_column_id:3 families:<name:"primary" id:0 column_names:"k" column_names:"v" column_ids:1 column_ids:2 default_column_id:2 > next_family_id:1 primary_index:<name:"primary" id:1 unique:true column_names:"k" column_directions:ASC column_ids:1 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION > interleave:<> partitioning:<num_columns:0 > type:FORWARD > next_index_id:2 privileges:<users:<user:"admin" privileges:2 > users:<user:"root" privileges:2 > > next_mutation_id:1 format_version:3 state:PUBLIC view_query:"" drop_time:0 replacement_of:<id:0 time:<> > audit_mode:DISABLED >
+1  starting plan  querying next range at /Table/SystemConfigSpan/Start
+1  starting plan  r1: sending batch 2 CPut, 1 BeginTxn to (n1,s1):1
+1  starting plan  querying next range at /Table/3/1/51/2/1
+1  starting plan  r1: sending batch 1 Get to (n1,s1):1
+1  starting plan  querying next range at /Table/2/1/0/"system"/3/1
+1  starting plan  r1: sending batch 1 Get to (n1,s1):1
+1  starting plan  querying next range at /Table/3/1/1/2/1
+1  starting plan  r1: sending batch 1 Get to (n1,s1):1
+1  starting plan  querying next range at /Table/2/1/1/"eventlog"/3/1
+1  starting plan  r1: sending batch 1 Get to (n1,s1):1
+1  starting plan  querying next range at /Table/3/1/12/2/1
+1  starting plan  r1: sending batch 1 Get to (n1,s1):1
+1  starting plan  querying next range at /Table/3/1/1/2/1
+1  starting plan  r1: sending batch 1 Get to (n1,s1):1
+1  starting plan  r1: sending batch 5 CPut to (n1,s1):1
 
-query TTT
+query ITT
 SELECT span, operation, regexp_replace(regexp_replace(message, 'mutationJobs:<[^>]*>', 'mutationJobs:<...>'), 'wall_time:\d+', 'wall_time:...') as message
   FROM [SHOW KV TRACE FOR CREATE UNIQUE INDEX woo ON t.kv(v)] WHERE message NOT LIKE '%Z/%'
 ----
-(0,1)  starting plan  querying next range at /Table/2/1/0/"system"/3/1
-(0,1)  starting plan  r1: sending batch 1 Get to (n1,s1):1
-(0,1)  starting plan  querying next range at /Table/3/1/1/2/1
-(0,1)  starting plan  r1: sending batch 1 Get to (n1,s1):1
-(0,1)  starting plan  querying next range at /Table/2/1/1/"jobs"/3/1
-(0,1)  starting plan  r1: sending batch 1 Get to (n1,s1):1
-(0,1)  starting plan  querying next range at /Table/3/1/15/2/1
-(0,1)  starting plan  r1: sending batch 1 Get to (n1,s1):1
-(0,1)  starting plan  querying next range at /Table/3/1/1/2/1
-(0,1)  starting plan  r1: sending batch 1 Get to (n1,s1):1
-(0,1)  starting plan  querying next range at /Table/SystemConfigSpan/Start
-(0,1)  starting plan  r1: sending batch 1 CPut, 1 BeginTxn, 1 InitPut to (n1,s1):1
-(0,1)  starting plan  Put /Table/3/1/52/2/1 -> table:<name:"kv" id:52 parent_id:51 version:1 up_version:true modification_time:<wall_time:... > columns:<name:"k" id:1 type:<semantic_type:INT width:0 precision:0 visible_type:NONE > nullable:false hidden:false > columns:<name:"v" id:2 type:<semantic_type:INT width:0 precision:0 visible_type:NONE > nullable:true hidden:false > next_column_id:3 families:<name:"primary" id:0 column_names:"k" column_names:"v" column_ids:1 column_ids:2 default_column_id:2 > next_family_id:1 primary_index:<name:"primary" id:1 unique:true column_names:"k" column_directions:ASC column_ids:1 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION > interleave:<> partitioning:<num_columns:0 > type:FORWARD > next_index_id:3 privileges:<users:<user:"admin" privileges:2 > users:<user:"root" privileges:2 > > mutations:<index:<name:"woo" id:2 unique:true column_names:"v" column_directions:ASC column_ids:2 extra_column_ids:1 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION > interleave:<> partitioning:<num_columns:0 > type:FORWARD > state:DELETE_ONLY direction:ADD mutation_id:1 rollback:false > next_mutation_id:2 format_version:3 state:PUBLIC view_query:"" mutationJobs:<...> drop_time:0 replacement_of:<id:0 time:<> > audit_mode:DISABLED >
-(0,1)  starting plan  querying next range at /Table/3/1/52/2/1
-(0,1)  starting plan  r1: sending batch 1 Put to (n1,s1):1
-(0,1)  starting plan  querying next range at /Table/2/1/0/"system"/3/1
-(0,1)  starting plan  r1: sending batch 1 Get to (n1,s1):1
-(0,1)  starting plan  querying next range at /Table/3/1/1/2/1
-(0,1)  starting plan  r1: sending batch 1 Get to (n1,s1):1
-(0,1)  starting plan  querying next range at /Table/2/1/1/"eventlog"/3/1
-(0,1)  starting plan  r1: sending batch 1 Get to (n1,s1):1
-(0,1)  starting plan  querying next range at /Table/3/1/12/2/1
-(0,1)  starting plan  r1: sending batch 1 Get to (n1,s1):1
-(0,1)  starting plan  querying next range at /Table/3/1/1/2/1
-(0,1)  starting plan  r1: sending batch 1 Get to (n1,s1):1
-(0,1)  starting plan  r1: sending batch 5 CPut to (n1,s1):1
+1  starting plan  querying next range at /Table/2/1/0/"system"/3/1
+1  starting plan  r1: sending batch 1 Get to (n1,s1):1
+1  starting plan  querying next range at /Table/3/1/1/2/1
+1  starting plan  r1: sending batch 1 Get to (n1,s1):1
+1  starting plan  querying next range at /Table/2/1/1/"jobs"/3/1
+1  starting plan  r1: sending batch 1 Get to (n1,s1):1
+1  starting plan  querying next range at /Table/3/1/15/2/1
+1  starting plan  r1: sending batch 1 Get to (n1,s1):1
+1  starting plan  querying next range at /Table/3/1/1/2/1
+1  starting plan  r1: sending batch 1 Get to (n1,s1):1
+1  starting plan  querying next range at /Table/SystemConfigSpan/Start
+1  starting plan  r1: sending batch 1 CPut, 1 BeginTxn, 1 InitPut to (n1,s1):1
+1  starting plan  Put /Table/3/1/52/2/1 -> table:<name:"kv" id:52 parent_id:51 version:1 up_version:true modification_time:<wall_time:... > columns:<name:"k" id:1 type:<semantic_type:INT width:0 precision:0 visible_type:NONE > nullable:false hidden:false > columns:<name:"v" id:2 type:<semantic_type:INT width:0 precision:0 visible_type:NONE > nullable:true hidden:false > next_column_id:3 families:<name:"primary" id:0 column_names:"k" column_names:"v" column_ids:1 column_ids:2 default_column_id:2 > next_family_id:1 primary_index:<name:"primary" id:1 unique:true column_names:"k" column_directions:ASC column_ids:1 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION > interleave:<> partitioning:<num_columns:0 > type:FORWARD > next_index_id:3 privileges:<users:<user:"admin" privileges:2 > users:<user:"root" privileges:2 > > mutations:<index:<name:"woo" id:2 unique:true column_names:"v" column_directions:ASC column_ids:2 extra_column_ids:1 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION > interleave:<> partitioning:<num_columns:0 > type:FORWARD > state:DELETE_ONLY direction:ADD mutation_id:1 rollback:false > next_mutation_id:2 format_version:3 state:PUBLIC view_query:"" mutationJobs:<...> drop_time:0 replacement_of:<id:0 time:<> > audit_mode:DISABLED >
+1  starting plan  querying next range at /Table/3/1/52/2/1
+1  starting plan  r1: sending batch 1 Put to (n1,s1):1
+1  starting plan  querying next range at /Table/2/1/0/"system"/3/1
+1  starting plan  r1: sending batch 1 Get to (n1,s1):1
+1  starting plan  querying next range at /Table/3/1/1/2/1
+1  starting plan  r1: sending batch 1 Get to (n1,s1):1
+1  starting plan  querying next range at /Table/2/1/1/"eventlog"/3/1
+1  starting plan  r1: sending batch 1 Get to (n1,s1):1
+1  starting plan  querying next range at /Table/3/1/12/2/1
+1  starting plan  r1: sending batch 1 Get to (n1,s1):1
+1  starting plan  querying next range at /Table/3/1/1/2/1
+1  starting plan  r1: sending batch 1 Get to (n1,s1):1
+1  starting plan  r1: sending batch 5 CPut to (n1,s1):1
 
-query TTT
+query ITT
 SELECT span, operation, message FROM [SHOW KV TRACE FOR INSERT INTO t.kv(k, v) VALUES (1,2)]
 ----
-(0,0)  sql txn         CPut /Table/52/1/1/0 -> /TUPLE/2:2:Int/2
-(0,2)  consuming rows  output row: []
-(0,0)  sql txn         querying next range at /Table/52/1/1/0
-(0,0)  sql txn         r1: sending batch 1 CPut, 1 BeginTxn, 1 InitPut to (n1,s1):1
+0  sql txn         CPut /Table/52/1/1/0 -> /TUPLE/2:2:Int/2
+2  consuming rows  output row: []
+0  sql txn         querying next range at /Table/52/1/1/0
+0  sql txn         r1: sending batch 1 CPut, 1 BeginTxn, 1 InitPut to (n1,s1):1
 
-query TTT
+query ITT
 SELECT span, operation, message FROM [SHOW KV TRACE FOR INSERT INTO t.kv(k, v) VALUES (1,2)]
 ----
-(0,0)  sql txn         CPut /Table/52/1/1/0 -> /TUPLE/2:2:Int/2
-(0,2)  consuming rows  output row: []
-(0,0)  sql txn         querying next range at /Table/52/1/1/0
-(0,0)  sql txn         r1: sending batch 1 CPut, 1 BeginTxn, 1 InitPut to (n1,s1):1
-(0,2)  consuming rows  execution failed: duplicate key value (k)=(1) violates unique constraint "primary"
+0  sql txn         CPut /Table/52/1/1/0 -> /TUPLE/2:2:Int/2
+2  consuming rows  output row: []
+0  sql txn         querying next range at /Table/52/1/1/0
+0  sql txn         r1: sending batch 1 CPut, 1 BeginTxn, 1 InitPut to (n1,s1):1
+2  consuming rows  execution failed: duplicate key value (k)=(1) violates unique constraint "primary"
 
-query TTT
+query ITT
 SELECT span, operation, message FROM [SHOW KV TRACE FOR INSERT INTO t.kv(k, v) VALUES (2,2)]
 ----
-(0,0)  sql txn         CPut /Table/52/1/2/0 -> /TUPLE/2:2:Int/2
-(0,2)  consuming rows  output row: []
-(0,0)  sql txn         querying next range at /Table/52/1/2/0
-(0,0)  sql txn         r1: sending batch 1 CPut, 1 BeginTxn, 1 InitPut to (n1,s1):1
-(0,2)  consuming rows  execution failed: duplicate key value (v)=(2) violates unique constraint "woo"
+0  sql txn         CPut /Table/52/1/2/0 -> /TUPLE/2:2:Int/2
+2  consuming rows  output row: []
+0  sql txn         querying next range at /Table/52/1/2/0
+0  sql txn         r1: sending batch 1 CPut, 1 BeginTxn, 1 InitPut to (n1,s1):1
+2  consuming rows  execution failed: duplicate key value (v)=(2) violates unique constraint "woo"
 
-query TTT
+query ITT
 SELECT span, operation, message FROM [SHOW KV TRACE FOR UPSERT INTO t.kv(k, v) VALUES (2,3)]
 ----
-(0,2)  consuming rows  output row: []
-(0,0)  sql txn         Scan /Table/52/1/{2-3}
-(0,0)  sql txn         querying next range at /Table/52/1/2
-(0,0)  sql txn         r1: sending batch 1 Scan to (n1,s1):1
-(0,0)  sql txn         CPut /Table/52/1/2/0 -> /TUPLE/2:2:Int/3
-(0,0)  sql txn         querying next range at /Table/52/1/2/0
-(0,0)  sql txn         r1: sending batch 1 CPut, 1 BeginTxn, 1 InitPut to (n1,s1):1
+2  consuming rows  output row: []
+0  sql txn         Scan /Table/52/1/{2-3}
+0  sql txn         querying next range at /Table/52/1/2
+0  sql txn         r1: sending batch 1 Scan to (n1,s1):1
+0  sql txn         CPut /Table/52/1/2/0 -> /TUPLE/2:2:Int/3
+0  sql txn         querying next range at /Table/52/1/2/0
+0  sql txn         r1: sending batch 1 CPut, 1 BeginTxn, 1 InitPut to (n1,s1):1
 
-query TTT
+query ITT
 SELECT span, operation, message FROM [SHOW KV TRACE FOR UPSERT INTO t.kv(k, v) VALUES (1,2)]
 ----
-(0,2)  consuming rows  output row: []
-(0,0)  sql txn         Scan /Table/52/1/{1-2}
-(0,0)  sql txn         querying next range at /Table/52/1/1
-(0,0)  sql txn         r1: sending batch 1 Scan to (n1,s1):1
-(0,0)  sql txn         fetched: /kv/primary/1/v -> /2
-(0,0)  sql txn         Put /Table/52/1/1/0 -> /TUPLE/2:2:Int/2
-(0,0)  sql txn         querying next range at /Table/52/1/1/0
-(0,0)  sql txn         r1: sending batch 1 Put, 1 BeginTxn to (n1,s1):1
+2  consuming rows  output row: []
+0  sql txn         Scan /Table/52/1/{1-2}
+0  sql txn         querying next range at /Table/52/1/1
+0  sql txn         r1: sending batch 1 Scan to (n1,s1):1
+0  sql txn         fetched: /kv/primary/1/v -> /2
+0  sql txn         Put /Table/52/1/1/0 -> /TUPLE/2:2:Int/2
+0  sql txn         querying next range at /Table/52/1/1/0
+0  sql txn         r1: sending batch 1 Put, 1 BeginTxn to (n1,s1):1
 
-query TTT
+query ITT
 SELECT span, operation, message FROM [SHOW KV TRACE FOR UPSERT INTO t.kv(k, v) VALUES (2,2)]
 ----
-(0,2)  consuming rows  output row: []
-(0,0)  sql txn         Scan /Table/52/1/{2-3}
-(0,0)  sql txn         querying next range at /Table/52/1/2
-(0,0)  sql txn         r1: sending batch 1 Scan to (n1,s1):1
-(0,0)  sql txn         fetched: /kv/primary/2/v -> /3
-(0,0)  sql txn         Put /Table/52/1/2/0 -> /TUPLE/2:2:Int/2
-(0,0)  sql txn         Del /Table/52/2/3/0
-(0,0)  sql txn         CPut /Table/52/2/2/0 -> /BYTES/Š
-(0,0)  sql txn         querying next range at /Table/52/1/2/0
-(0,0)  sql txn         r1: sending batch 1 Put, 1 CPut, 1 Del, 1 BeginTxn to (n1,s1):1
-(0,2)  consuming rows  execution failed: duplicate key value (v)=(2) violates unique constraint "woo"
+2  consuming rows  output row: []
+0  sql txn         Scan /Table/52/1/{2-3}
+0  sql txn         querying next range at /Table/52/1/2
+0  sql txn         r1: sending batch 1 Scan to (n1,s1):1
+0  sql txn         fetched: /kv/primary/2/v -> /3
+0  sql txn         Put /Table/52/1/2/0 -> /TUPLE/2:2:Int/2
+0  sql txn         Del /Table/52/2/3/0
+0  sql txn         CPut /Table/52/2/2/0 -> /BYTES/Š
+0  sql txn         querying next range at /Table/52/1/2/0
+0  sql txn         r1: sending batch 1 Put, 1 CPut, 1 Del, 1 BeginTxn to (n1,s1):1
+2  consuming rows  execution failed: duplicate key value (v)=(2) violates unique constraint "woo"
 
-query TTT
+query ITT
 SELECT span, operation, regexp_replace(regexp_replace(message, 'wall_time:\d+', 'wall_time:...'), '\d\d\d\d\d+', '...PK...') as message
   FROM [SHOW KV TRACE FOR CREATE TABLE t.kv2 AS TABLE t.kv] WHERE message NOT LIKE '%Z/%'
 ----
-(0,1)   starting plan   querying next range at /Table/2/1/51/"kv2"/3/1
-(0,1)   starting plan   r1: sending batch 1 Get to (n1,s1):1
-(0,1)   starting plan   querying next range at /System/"desc-idgen"
-(0,1)   starting plan   r1: sending batch 1 Inc to (n1,s1):1
-(0,1)   starting plan   CPut /Table/2/1/51/"kv2"/3/1 -> 53
-(0,1)   starting plan   CPut /Table/3/1/53/2/1 -> table:<name:"kv2" id:53 parent_id:51 version:1 up_version:false modification_time:<wall_time:... > columns:<name:"k" id:1 type:<semantic_type:INT width:0 precision:0 visible_type:NONE > nullable:true hidden:false > columns:<name:"v" id:2 type:<semantic_type:INT width:0 precision:0 visible_type:NONE > nullable:true hidden:false > columns:<name:"rowid" id:3 type:<semantic_type:INT width:0 precision:0 visible_type:NONE > nullable:false default_expr:"unique_rowid()" hidden:true > next_column_id:4 families:<name:"primary" id:0 column_names:"k" column_names:"v" column_names:"rowid" column_ids:1 column_ids:2 column_ids:3 default_column_id:0 > next_family_id:1 primary_index:<name:"primary" id:1 unique:true column_names:"rowid" column_directions:ASC column_ids:3 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION > interleave:<> partitioning:<num_columns:0 > type:FORWARD > next_index_id:2 privileges:<users:<user:"admin" privileges:2 > users:<user:"root" privileges:2 > > next_mutation_id:1 format_version:3 state:PUBLIC view_query:"" drop_time:0 replacement_of:<id:0 time:<> > audit_mode:DISABLED >
-(0,1)   starting plan   querying next range at /Table/SystemConfigSpan/Start
-(0,1)   starting plan   r1: sending batch 2 CPut, 1 BeginTxn to (n1,s1):1
-(0,1)   starting plan   querying next range at /Table/3/1/51/2/1
-(0,1)   starting plan   r1: sending batch 1 Get to (n1,s1):1
-(0,1)   starting plan   querying next range at /Table/2/1/0/"system"/3/1
-(0,1)   starting plan   r1: sending batch 1 Get to (n1,s1):1
-(0,1)   starting plan   querying next range at /Table/3/1/1/2/1
-(0,1)   starting plan   r1: sending batch 1 Get to (n1,s1):1
-(0,1)   starting plan   querying next range at /Table/2/1/1/"eventlog"/3/1
-(0,1)   starting plan   r1: sending batch 1 Get to (n1,s1):1
-(0,1)   starting plan   querying next range at /Table/3/1/12/2/1
-(0,1)   starting plan   r1: sending batch 1 Get to (n1,s1):1
-(0,1)   starting plan   querying next range at /Table/3/1/1/2/1
-(0,1)   starting plan   r1: sending batch 1 Get to (n1,s1):1
-(0,1)   starting plan   r1: sending batch 5 CPut to (n1,s1):1
-(0,1)   starting plan   Scan /Table/52/{1-2}
-(0,1)   starting plan   querying next range at /Table/52/1
-(0,1)   starting plan   r1: sending batch 1 Scan to (n1,s1):1
-(0,1)   starting plan   fetched: /kv/primary/1/v -> /2
-(0,1)   starting plan   CPut /Table/53/1/...PK.../0 -> /TUPLE/1:1:Int/1/1:2:Int/2
-(0,1)   starting plan   fetched: /kv/primary/2/v -> /3
-(0,1)   starting plan   CPut /Table/53/1/...PK.../0 -> /TUPLE/1:1:Int/2/1:2:Int/3
-(0,1)   starting plan   querying next range at /Table/SystemConfigSpan/Start
-(0,1)   starting plan   r1: sending batch 2 CPut, 1 EndTxn to (n1,s1):1
-(0,15)  consuming rows  fast path - rows affected: 2
+1   starting plan   querying next range at /Table/2/1/51/"kv2"/3/1
+1   starting plan   r1: sending batch 1 Get to (n1,s1):1
+1   starting plan   querying next range at /System/"desc-idgen"
+1   starting plan   r1: sending batch 1 Inc to (n1,s1):1
+1   starting plan   CPut /Table/2/1/51/"kv2"/3/1 -> 53
+1   starting plan   CPut /Table/3/1/53/2/1 -> table:<name:"kv2" id:53 parent_id:51 version:1 up_version:false modification_time:<wall_time:... > columns:<name:"k" id:1 type:<semantic_type:INT width:0 precision:0 visible_type:NONE > nullable:true hidden:false > columns:<name:"v" id:2 type:<semantic_type:INT width:0 precision:0 visible_type:NONE > nullable:true hidden:false > columns:<name:"rowid" id:3 type:<semantic_type:INT width:0 precision:0 visible_type:NONE > nullable:false default_expr:"unique_rowid()" hidden:true > next_column_id:4 families:<name:"primary" id:0 column_names:"k" column_names:"v" column_names:"rowid" column_ids:1 column_ids:2 column_ids:3 default_column_id:0 > next_family_id:1 primary_index:<name:"primary" id:1 unique:true column_names:"rowid" column_directions:ASC column_ids:3 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION > interleave:<> partitioning:<num_columns:0 > type:FORWARD > next_index_id:2 privileges:<users:<user:"admin" privileges:2 > users:<user:"root" privileges:2 > > next_mutation_id:1 format_version:3 state:PUBLIC view_query:"" drop_time:0 replacement_of:<id:0 time:<> > audit_mode:DISABLED >
+1   starting plan   querying next range at /Table/SystemConfigSpan/Start
+1   starting plan   r1: sending batch 2 CPut, 1 BeginTxn to (n1,s1):1
+1   starting plan   querying next range at /Table/3/1/51/2/1
+1   starting plan   r1: sending batch 1 Get to (n1,s1):1
+1   starting plan   querying next range at /Table/2/1/0/"system"/3/1
+1   starting plan   r1: sending batch 1 Get to (n1,s1):1
+1   starting plan   querying next range at /Table/3/1/1/2/1
+1   starting plan   r1: sending batch 1 Get to (n1,s1):1
+1   starting plan   querying next range at /Table/2/1/1/"eventlog"/3/1
+1   starting plan   r1: sending batch 1 Get to (n1,s1):1
+1   starting plan   querying next range at /Table/3/1/12/2/1
+1   starting plan   r1: sending batch 1 Get to (n1,s1):1
+1   starting plan   querying next range at /Table/3/1/1/2/1
+1   starting plan   r1: sending batch 1 Get to (n1,s1):1
+1   starting plan   r1: sending batch 5 CPut to (n1,s1):1
+1   starting plan   Scan /Table/52/{1-2}
+1   starting plan   querying next range at /Table/52/1
+1   starting plan   r1: sending batch 1 Scan to (n1,s1):1
+1   starting plan   fetched: /kv/primary/1/v -> /2
+1   starting plan   CPut /Table/53/1/...PK.../0 -> /TUPLE/1:1:Int/1/1:2:Int/2
+1   starting plan   fetched: /kv/primary/2/v -> /3
+1   starting plan   CPut /Table/53/1/...PK.../0 -> /TUPLE/1:1:Int/2/1:2:Int/3
+1   starting plan   querying next range at /Table/SystemConfigSpan/Start
+1   starting plan   r1: sending batch 2 CPut, 1 EndTxn to (n1,s1):1
+15  consuming rows  fast path - rows affected: 2
 
-query TTT
+query ITT
 SELECT span, operation, regexp_replace(message, '\d\d\d\d\d+', '...PK...') as message
   FROM [SHOW KV TRACE FOR UPDATE t.kv2 SET v = v + 2]
 ----
-(0,0)  sql txn         Scan /Table/53/{1-2}
-(0,0)  sql txn         querying next range at /Table/53/1
-(0,0)  sql txn         r1: sending batch 1 Scan to (n1,s1):1
-(0,0)  sql txn         fetched: /kv2/primary/...PK.../k/v -> /1/2
-(0,0)  sql txn         Put /Table/53/1/...PK.../0 -> /TUPLE/1:1:Int/1/1:2:Int/4
-(0,2)  consuming rows  output row: [...PK... 1 4]
-(0,0)  sql txn         fetched: /kv2/primary/...PK.../k/v -> /2/3
-(0,0)  sql txn         Put /Table/53/1/...PK.../0 -> /TUPLE/1:1:Int/2/1:2:Int/5
-(0,2)  consuming rows  output row: [...PK... 2 5]
-(0,0)  sql txn         querying next range at /Table/53/1/...PK.../0
-(0,0)  sql txn         r1: sending batch 2 Put, 1 BeginTxn to (n1,s1):1
+0  sql txn         Scan /Table/53/{1-2}
+0  sql txn         querying next range at /Table/53/1
+0  sql txn         r1: sending batch 1 Scan to (n1,s1):1
+0  sql txn         fetched: /kv2/primary/...PK.../k/v -> /1/2
+0  sql txn         Put /Table/53/1/...PK.../0 -> /TUPLE/1:1:Int/1/1:2:Int/4
+2  consuming rows  output row: [...PK... 1 4]
+0  sql txn         fetched: /kv2/primary/...PK.../k/v -> /2/3
+0  sql txn         Put /Table/53/1/...PK.../0 -> /TUPLE/1:1:Int/2/1:2:Int/5
+2  consuming rows  output row: [...PK... 2 5]
+0  sql txn         querying next range at /Table/53/1/...PK.../0
+0  sql txn         r1: sending batch 2 Put, 1 BeginTxn to (n1,s1):1
 
-query TTT
+query ITT
 SELECT span, operation, message FROM [SHOW KV TRACE FOR DELETE FROM t.kv2]
 ----
-(0,1)  starting plan   Scan /Table/53/{1-2}
-(0,1)  starting plan   querying next range at /Table/53/1
-(0,1)  starting plan   r1: sending batch 1 Scan to (n1,s1):1
-(0,1)  starting plan   DelRange /Table/53/1 - /Table/53/2
-(0,1)  starting plan   querying next range at /Table/53/1
-(0,1)  starting plan   r1: sending batch 1 DelRng, 1 BeginTxn to (n1,s1):1
-(0,5)  consuming rows  fast path - rows affected: 2
+1  starting plan   Scan /Table/53/{1-2}
+1  starting plan   querying next range at /Table/53/1
+1  starting plan   r1: sending batch 1 Scan to (n1,s1):1
+1  starting plan   DelRange /Table/53/1 - /Table/53/2
+1  starting plan   querying next range at /Table/53/1
+1  starting plan   r1: sending batch 1 DelRng, 1 BeginTxn to (n1,s1):1
+5  consuming rows  fast path - rows affected: 2
 
-query TTT
+query ITT
 SELECT span, operation, regexp_replace(regexp_replace(message, 'wall_time:\d+', 'wall_time:...'), 'drop_time:\d+', 'drop_time:...') as message
   FROM [SHOW KV TRACE FOR DROP TABLE t.kv2] WHERE message NOT LIKE '%Z/%'
 ----
-(0,1)  starting plan  querying next range at /Table/5/1/53/2/1
-(0,1)  starting plan  r1: sending batch 1 Get to (n1,s1):1
-(0,1)  starting plan  querying next range at /Table/3/1/53/2/1
-(0,1)  starting plan  r1: sending batch 1 Get to (n1,s1):1
-(0,1)  starting plan  querying next range at /Table/5/1/51/2/1
-(0,1)  starting plan  r1: sending batch 1 Get to (n1,s1):1
-(0,1)  starting plan  querying next range at /Table/3/1/51/2/1
-(0,1)  starting plan  r1: sending batch 1 Get to (n1,s1):1
-(0,1)  starting plan  querying next range at /Table/5/1/0/2/1
-(0,1)  starting plan  r1: sending batch 1 Get to (n1,s1):1
-(0,1)  starting plan  Put /Table/3/1/53/2/1 -> table:<name:"kv2" id:53 parent_id:51 version:1 up_version:true modification_time:<wall_time:... > columns:<name:"k" id:1 type:<semantic_type:INT width:0 precision:0 visible_type:NONE > nullable:true hidden:false > columns:<name:"v" id:2 type:<semantic_type:INT width:0 precision:0 visible_type:NONE > nullable:true hidden:false > columns:<name:"rowid" id:3 type:<semantic_type:INT width:0 precision:0 visible_type:NONE > nullable:false default_expr:"unique_rowid()" hidden:true > next_column_id:4 families:<name:"primary" id:0 column_names:"k" column_names:"v" column_names:"rowid" column_ids:1 column_ids:2 column_ids:3 default_column_id:0 > next_family_id:1 primary_index:<name:"primary" id:1 unique:true column_names:"rowid" column_directions:ASC column_ids:3 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION > interleave:<> partitioning:<num_columns:0 > type:FORWARD > next_index_id:2 privileges:<users:<user:"admin" privileges:2 > users:<user:"root" privileges:2 > > next_mutation_id:1 format_version:3 state:DROP draining_names:<parent_id:51 name:"kv2" > view_query:"" drop_time:... replacement_of:<id:0 time:<> > audit_mode:DISABLED >
-(0,1)  starting plan  querying next range at /Table/SystemConfigSpan/Start
-(0,1)  starting plan  r1: sending batch 1 Put, 1 BeginTxn to (n1,s1):1
-(0,1)  starting plan  querying next range at /Table/2/1/0/"system"/3/1
-(0,1)  starting plan  r1: sending batch 1 Get to (n1,s1):1
-(0,1)  starting plan  querying next range at /Table/3/1/1/2/1
-(0,1)  starting plan  r1: sending batch 1 Get to (n1,s1):1
-(0,1)  starting plan  querying next range at /Table/2/1/1/"eventlog"/3/1
-(0,1)  starting plan  r1: sending batch 1 Get to (n1,s1):1
-(0,1)  starting plan  querying next range at /Table/3/1/12/2/1
-(0,1)  starting plan  r1: sending batch 1 Get to (n1,s1):1
-(0,1)  starting plan  querying next range at /Table/3/1/1/2/1
-(0,1)  starting plan  r1: sending batch 1 Get to (n1,s1):1
-(0,1)  starting plan  r1: sending batch 5 CPut to (n1,s1):1
+1  starting plan  querying next range at /Table/5/1/53/2/1
+1  starting plan  r1: sending batch 1 Get to (n1,s1):1
+1  starting plan  querying next range at /Table/3/1/53/2/1
+1  starting plan  r1: sending batch 1 Get to (n1,s1):1
+1  starting plan  querying next range at /Table/5/1/51/2/1
+1  starting plan  r1: sending batch 1 Get to (n1,s1):1
+1  starting plan  querying next range at /Table/3/1/51/2/1
+1  starting plan  r1: sending batch 1 Get to (n1,s1):1
+1  starting plan  querying next range at /Table/5/1/0/2/1
+1  starting plan  r1: sending batch 1 Get to (n1,s1):1
+1  starting plan  Put /Table/3/1/53/2/1 -> table:<name:"kv2" id:53 parent_id:51 version:1 up_version:true modification_time:<wall_time:... > columns:<name:"k" id:1 type:<semantic_type:INT width:0 precision:0 visible_type:NONE > nullable:true hidden:false > columns:<name:"v" id:2 type:<semantic_type:INT width:0 precision:0 visible_type:NONE > nullable:true hidden:false > columns:<name:"rowid" id:3 type:<semantic_type:INT width:0 precision:0 visible_type:NONE > nullable:false default_expr:"unique_rowid()" hidden:true > next_column_id:4 families:<name:"primary" id:0 column_names:"k" column_names:"v" column_names:"rowid" column_ids:1 column_ids:2 column_ids:3 default_column_id:0 > next_family_id:1 primary_index:<name:"primary" id:1 unique:true column_names:"rowid" column_directions:ASC column_ids:3 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION > interleave:<> partitioning:<num_columns:0 > type:FORWARD > next_index_id:2 privileges:<users:<user:"admin" privileges:2 > users:<user:"root" privileges:2 > > next_mutation_id:1 format_version:3 state:DROP draining_names:<parent_id:51 name:"kv2" > view_query:"" drop_time:... replacement_of:<id:0 time:<> > audit_mode:DISABLED >
+1  starting plan  querying next range at /Table/SystemConfigSpan/Start
+1  starting plan  r1: sending batch 1 Put, 1 BeginTxn to (n1,s1):1
+1  starting plan  querying next range at /Table/2/1/0/"system"/3/1
+1  starting plan  r1: sending batch 1 Get to (n1,s1):1
+1  starting plan  querying next range at /Table/3/1/1/2/1
+1  starting plan  r1: sending batch 1 Get to (n1,s1):1
+1  starting plan  querying next range at /Table/2/1/1/"eventlog"/3/1
+1  starting plan  r1: sending batch 1 Get to (n1,s1):1
+1  starting plan  querying next range at /Table/3/1/12/2/1
+1  starting plan  r1: sending batch 1 Get to (n1,s1):1
+1  starting plan  querying next range at /Table/3/1/1/2/1
+1  starting plan  r1: sending batch 1 Get to (n1,s1):1
+1  starting plan  r1: sending batch 5 CPut to (n1,s1):1
 
-query TTT
+query ITT
 SELECT span, operation, message FROM [SHOW KV TRACE FOR DELETE FROM t.kv]
 ----
-(0,0)  sql txn         Scan /Table/52/{1-2}
-(0,0)  sql txn         querying next range at /Table/52/1
-(0,0)  sql txn         r1: sending batch 1 Scan to (n1,s1):1
-(0,0)  sql txn         fetched: /kv/primary/1/v -> /2
-(0,0)  sql txn         Del /Table/52/2/2/0
-(0,0)  sql txn         DelRange /Table/52/1/1 - /Table/52/1/1/#
-(0,2)  consuming rows  output row: [1 2]
-(0,0)  sql txn         fetched: /kv/primary/2/v -> /3
-(0,0)  sql txn         Del /Table/52/2/3/0
-(0,0)  sql txn         DelRange /Table/52/1/2 - /Table/52/1/2/#
-(0,2)  consuming rows  output row: [2 3]
-(0,0)  sql txn         querying next range at /Table/52/1/1
-(0,0)  sql txn         r1: sending batch 2 Del, 2 DelRng, 1 BeginTxn to (n1,s1):1
+0  sql txn         Scan /Table/52/{1-2}
+0  sql txn         querying next range at /Table/52/1
+0  sql txn         r1: sending batch 1 Scan to (n1,s1):1
+0  sql txn         fetched: /kv/primary/1/v -> /2
+0  sql txn         Del /Table/52/2/2/0
+0  sql txn         DelRange /Table/52/1/1 - /Table/52/1/1/#
+2  consuming rows  output row: [1 2]
+0  sql txn         fetched: /kv/primary/2/v -> /3
+0  sql txn         Del /Table/52/2/3/0
+0  sql txn         DelRange /Table/52/1/2 - /Table/52/1/2/#
+2  consuming rows  output row: [2 3]
+0  sql txn         querying next range at /Table/52/1/1
+0  sql txn         r1: sending batch 2 Del, 2 DelRng, 1 BeginTxn to (n1,s1):1
 
-query TTT
+query ITT
 SELECT span, operation, regexp_replace(regexp_replace(message, 'mutationJobs:<[^>]*>', 'mutationJobs:<...>'), 'wall_time:\d+', 'wall_time:...') as message
   FROM [SHOW KV TRACE FOR DROP INDEX t.kv@woo CASCADE] WHERE message NOT LIKE '%Z/%'
 ----
-(0,1)  starting plan  querying next range at /Table/2/1/0/"t"/3/1
-(0,1)  starting plan  r1: sending batch 1 Get to (n1,s1):1
-(0,1)  starting plan  querying next range at /Table/3/1/51/2/1
-(0,1)  starting plan  r1: sending batch 1 Get to (n1,s1):1
-(0,1)  starting plan  querying next range at /Table/2/1/51/"kv"/3/1
-(0,1)  starting plan  r1: sending batch 1 Get to (n1,s1):1
-(0,1)  starting plan  querying next range at /Table/3/1/52/2/1
-(0,1)  starting plan  r1: sending batch 1 Get to (n1,s1):1
-(0,1)  starting plan  querying next range at /Table/3/1/51/2/1
-(0,1)  starting plan  r1: sending batch 1 Get to (n1,s1):1
-(0,1)  starting plan  querying next range at /Table/3/1/51/2/1
-(0,1)  starting plan  r1: sending batch 1 Get to (n1,s1):1
-(0,1)  starting plan  querying next range at /Table/2/1/0/"system"/3/1
-(0,1)  starting plan  r1: sending batch 1 Get to (n1,s1):1
-(0,1)  starting plan  querying next range at /Table/3/1/1/2/1
-(0,1)  starting plan  r1: sending batch 1 Get to (n1,s1):1
-(0,1)  starting plan  querying next range at /Table/2/1/1/"jobs"/3/1
-(0,1)  starting plan  r1: sending batch 1 Get to (n1,s1):1
-(0,1)  starting plan  querying next range at /Table/3/1/15/2/1
-(0,1)  starting plan  r1: sending batch 1 Get to (n1,s1):1
-(0,1)  starting plan  querying next range at /Table/3/1/1/2/1
-(0,1)  starting plan  r1: sending batch 1 Get to (n1,s1):1
-(0,1)  starting plan  querying next range at /Table/SystemConfigSpan/Start
-(0,1)  starting plan  r1: sending batch 1 CPut, 1 BeginTxn, 1 InitPut to (n1,s1):1
-(0,1)  starting plan  Put /Table/3/1/52/2/1 -> table:<name:"kv" id:52 parent_id:51 version:4 up_version:true modification_time:<wall_time:... > columns:<name:"k" id:1 type:<semantic_type:INT width:0 precision:0 visible_type:NONE > nullable:false hidden:false > columns:<name:"v" id:2 type:<semantic_type:INT width:0 precision:0 visible_type:NONE > nullable:true hidden:false > next_column_id:3 families:<name:"primary" id:0 column_names:"k" column_names:"v" column_ids:1 column_ids:2 default_column_id:2 > next_family_id:1 primary_index:<name:"primary" id:1 unique:true column_names:"k" column_directions:ASC column_ids:1 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION > interleave:<> partitioning:<num_columns:0 > type:FORWARD > next_index_id:3 privileges:<users:<user:"admin" privileges:2 > users:<user:"root" privileges:2 > > mutations:<index:<name:"woo" id:2 unique:true column_names:"v" column_directions:ASC column_ids:2 extra_column_ids:1 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION > interleave:<> partitioning:<num_columns:0 > type:FORWARD > state:DELETE_AND_WRITE_ONLY direction:DROP mutation_id:2 rollback:false > next_mutation_id:3 format_version:3 state:PUBLIC view_query:"" mutationJobs:<...> drop_time:0 replacement_of:<id:0 time:<> > audit_mode:DISABLED >
-(0,1)  starting plan  querying next range at /Table/3/1/52/2/1
-(0,1)  starting plan  r1: sending batch 1 Put to (n1,s1):1
-(0,1)  starting plan  querying next range at /Table/2/1/0/"system"/3/1
-(0,1)  starting plan  r1: sending batch 1 Get to (n1,s1):1
-(0,1)  starting plan  querying next range at /Table/3/1/1/2/1
-(0,1)  starting plan  r1: sending batch 1 Get to (n1,s1):1
-(0,1)  starting plan  querying next range at /Table/2/1/1/"eventlog"/3/1
-(0,1)  starting plan  r1: sending batch 1 Get to (n1,s1):1
-(0,1)  starting plan  querying next range at /Table/3/1/12/2/1
-(0,1)  starting plan  r1: sending batch 1 Get to (n1,s1):1
-(0,1)  starting plan  querying next range at /Table/3/1/1/2/1
-(0,1)  starting plan  r1: sending batch 1 Get to (n1,s1):1
-(0,1)  starting plan  r1: sending batch 5 CPut to (n1,s1):1
+1  starting plan  querying next range at /Table/2/1/0/"t"/3/1
+1  starting plan  r1: sending batch 1 Get to (n1,s1):1
+1  starting plan  querying next range at /Table/3/1/51/2/1
+1  starting plan  r1: sending batch 1 Get to (n1,s1):1
+1  starting plan  querying next range at /Table/2/1/51/"kv"/3/1
+1  starting plan  r1: sending batch 1 Get to (n1,s1):1
+1  starting plan  querying next range at /Table/3/1/52/2/1
+1  starting plan  r1: sending batch 1 Get to (n1,s1):1
+1  starting plan  querying next range at /Table/3/1/51/2/1
+1  starting plan  r1: sending batch 1 Get to (n1,s1):1
+1  starting plan  querying next range at /Table/3/1/51/2/1
+1  starting plan  r1: sending batch 1 Get to (n1,s1):1
+1  starting plan  querying next range at /Table/2/1/0/"system"/3/1
+1  starting plan  r1: sending batch 1 Get to (n1,s1):1
+1  starting plan  querying next range at /Table/3/1/1/2/1
+1  starting plan  r1: sending batch 1 Get to (n1,s1):1
+1  starting plan  querying next range at /Table/2/1/1/"jobs"/3/1
+1  starting plan  r1: sending batch 1 Get to (n1,s1):1
+1  starting plan  querying next range at /Table/3/1/15/2/1
+1  starting plan  r1: sending batch 1 Get to (n1,s1):1
+1  starting plan  querying next range at /Table/3/1/1/2/1
+1  starting plan  r1: sending batch 1 Get to (n1,s1):1
+1  starting plan  querying next range at /Table/SystemConfigSpan/Start
+1  starting plan  r1: sending batch 1 CPut, 1 BeginTxn, 1 InitPut to (n1,s1):1
+1  starting plan  Put /Table/3/1/52/2/1 -> table:<name:"kv" id:52 parent_id:51 version:4 up_version:true modification_time:<wall_time:... > columns:<name:"k" id:1 type:<semantic_type:INT width:0 precision:0 visible_type:NONE > nullable:false hidden:false > columns:<name:"v" id:2 type:<semantic_type:INT width:0 precision:0 visible_type:NONE > nullable:true hidden:false > next_column_id:3 families:<name:"primary" id:0 column_names:"k" column_names:"v" column_ids:1 column_ids:2 default_column_id:2 > next_family_id:1 primary_index:<name:"primary" id:1 unique:true column_names:"k" column_directions:ASC column_ids:1 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION > interleave:<> partitioning:<num_columns:0 > type:FORWARD > next_index_id:3 privileges:<users:<user:"admin" privileges:2 > users:<user:"root" privileges:2 > > mutations:<index:<name:"woo" id:2 unique:true column_names:"v" column_directions:ASC column_ids:2 extra_column_ids:1 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION > interleave:<> partitioning:<num_columns:0 > type:FORWARD > state:DELETE_AND_WRITE_ONLY direction:DROP mutation_id:2 rollback:false > next_mutation_id:3 format_version:3 state:PUBLIC view_query:"" mutationJobs:<...> drop_time:0 replacement_of:<id:0 time:<> > audit_mode:DISABLED >
+1  starting plan  querying next range at /Table/3/1/52/2/1
+1  starting plan  r1: sending batch 1 Put to (n1,s1):1
+1  starting plan  querying next range at /Table/2/1/0/"system"/3/1
+1  starting plan  r1: sending batch 1 Get to (n1,s1):1
+1  starting plan  querying next range at /Table/3/1/1/2/1
+1  starting plan  r1: sending batch 1 Get to (n1,s1):1
+1  starting plan  querying next range at /Table/2/1/1/"eventlog"/3/1
+1  starting plan  r1: sending batch 1 Get to (n1,s1):1
+1  starting plan  querying next range at /Table/3/1/12/2/1
+1  starting plan  r1: sending batch 1 Get to (n1,s1):1
+1  starting plan  querying next range at /Table/3/1/1/2/1
+1  starting plan  r1: sending batch 1 Get to (n1,s1):1
+1  starting plan  r1: sending batch 5 CPut to (n1,s1):1
 
-query TTT
+query ITT
 SELECT span, operation, regexp_replace(regexp_replace(regexp_replace(message, 'mutationJobs:<[^>]*>', 'mutationJobs:<...>'), 'wall_time:\d+', 'wall_time:...'), 'drop_time:\d+', 'drop_time:...') as message
   FROM [SHOW KV TRACE FOR DROP TABLE t.kv] WHERE message NOT LIKE '%Z/%'
 ----
-(0,1)  starting plan  querying next range at /Table/5/1/52/2/1
-(0,1)  starting plan  r1: sending batch 1 Get to (n1,s1):1
-(0,1)  starting plan  querying next range at /Table/3/1/52/2/1
-(0,1)  starting plan  r1: sending batch 1 Get to (n1,s1):1
-(0,1)  starting plan  querying next range at /Table/5/1/51/2/1
-(0,1)  starting plan  r1: sending batch 1 Get to (n1,s1):1
-(0,1)  starting plan  querying next range at /Table/3/1/51/2/1
-(0,1)  starting plan  r1: sending batch 1 Get to (n1,s1):1
-(0,1)  starting plan  querying next range at /Table/5/1/0/2/1
-(0,1)  starting plan  r1: sending batch 1 Get to (n1,s1):1
-(0,1)  starting plan  Put /Table/3/1/52/2/1 -> table:<name:"kv" id:52 parent_id:51 version:7 up_version:true modification_time:<wall_time:... > columns:<name:"k" id:1 type:<semantic_type:INT width:0 precision:0 visible_type:NONE > nullable:false hidden:false > columns:<name:"v" id:2 type:<semantic_type:INT width:0 precision:0 visible_type:NONE > nullable:true hidden:false > next_column_id:3 families:<name:"primary" id:0 column_names:"k" column_names:"v" column_ids:1 column_ids:2 default_column_id:2 > next_family_id:1 primary_index:<name:"primary" id:1 unique:true column_names:"k" column_directions:ASC column_ids:1 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION > interleave:<> partitioning:<num_columns:0 > type:FORWARD > next_index_id:3 privileges:<users:<user:"admin" privileges:2 > users:<user:"root" privileges:2 > > next_mutation_id:3 format_version:3 state:DROP draining_names:<parent_id:51 name:"kv" > view_query:"" drop_time:... replacement_of:<id:0 time:<> > audit_mode:DISABLED >
-(0,1)  starting plan  querying next range at /Table/SystemConfigSpan/Start
-(0,1)  starting plan  r1: sending batch 1 Put, 1 BeginTxn to (n1,s1):1
-(0,1)  starting plan  querying next range at /Table/2/1/0/"system"/3/1
-(0,1)  starting plan  r1: sending batch 1 Get to (n1,s1):1
-(0,1)  starting plan  querying next range at /Table/3/1/1/2/1
-(0,1)  starting plan  r1: sending batch 1 Get to (n1,s1):1
-(0,1)  starting plan  querying next range at /Table/2/1/1/"eventlog"/3/1
-(0,1)  starting plan  r1: sending batch 1 Get to (n1,s1):1
-(0,1)  starting plan  querying next range at /Table/3/1/12/2/1
-(0,1)  starting plan  r1: sending batch 1 Get to (n1,s1):1
-(0,1)  starting plan  querying next range at /Table/3/1/1/2/1
-(0,1)  starting plan  r1: sending batch 1 Get to (n1,s1):1
-(0,1)  starting plan  r1: sending batch 5 CPut to (n1,s1):1
+1  starting plan  querying next range at /Table/5/1/52/2/1
+1  starting plan  r1: sending batch 1 Get to (n1,s1):1
+1  starting plan  querying next range at /Table/3/1/52/2/1
+1  starting plan  r1: sending batch 1 Get to (n1,s1):1
+1  starting plan  querying next range at /Table/5/1/51/2/1
+1  starting plan  r1: sending batch 1 Get to (n1,s1):1
+1  starting plan  querying next range at /Table/3/1/51/2/1
+1  starting plan  r1: sending batch 1 Get to (n1,s1):1
+1  starting plan  querying next range at /Table/5/1/0/2/1
+1  starting plan  r1: sending batch 1 Get to (n1,s1):1
+1  starting plan  Put /Table/3/1/52/2/1 -> table:<name:"kv" id:52 parent_id:51 version:7 up_version:true modification_time:<wall_time:... > columns:<name:"k" id:1 type:<semantic_type:INT width:0 precision:0 visible_type:NONE > nullable:false hidden:false > columns:<name:"v" id:2 type:<semantic_type:INT width:0 precision:0 visible_type:NONE > nullable:true hidden:false > next_column_id:3 families:<name:"primary" id:0 column_names:"k" column_names:"v" column_ids:1 column_ids:2 default_column_id:2 > next_family_id:1 primary_index:<name:"primary" id:1 unique:true column_names:"k" column_directions:ASC column_ids:1 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION > interleave:<> partitioning:<num_columns:0 > type:FORWARD > next_index_id:3 privileges:<users:<user:"admin" privileges:2 > users:<user:"root" privileges:2 > > next_mutation_id:3 format_version:3 state:DROP draining_names:<parent_id:51 name:"kv" > view_query:"" drop_time:... replacement_of:<id:0 time:<> > audit_mode:DISABLED >
+1  starting plan  querying next range at /Table/SystemConfigSpan/Start
+1  starting plan  r1: sending batch 1 Put, 1 BeginTxn to (n1,s1):1
+1  starting plan  querying next range at /Table/2/1/0/"system"/3/1
+1  starting plan  r1: sending batch 1 Get to (n1,s1):1
+1  starting plan  querying next range at /Table/3/1/1/2/1
+1  starting plan  r1: sending batch 1 Get to (n1,s1):1
+1  starting plan  querying next range at /Table/2/1/1/"eventlog"/3/1
+1  starting plan  r1: sending batch 1 Get to (n1,s1):1
+1  starting plan  querying next range at /Table/3/1/12/2/1
+1  starting plan  r1: sending batch 1 Get to (n1,s1):1
+1  starting plan  querying next range at /Table/3/1/1/2/1
+1  starting plan  r1: sending batch 1 Get to (n1,s1):1
+1  starting plan  r1: sending batch 5 CPut to (n1,s1):1
 
 # SELECT queries - used to exercise the KV tracing for other tests
 

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -41,7 +41,7 @@ import (
 type extendedEvalContext struct {
 	tree.EvalContext
 
-	SessionMutator sessionDataMutator
+	SessionMutator *sessionDataMutator
 
 	// VirtualSchemas can be used to access virtual tables.
 	VirtualSchemas VirtualTabler
@@ -98,7 +98,7 @@ type planner struct {
 
 	// sessionDataMutator is used to mutate the session variables. Read
 	// access to them is provided through evalCtx.
-	sessionDataMutator sessionDataMutator
+	sessionDataMutator *sessionDataMutator
 
 	// execCfg is used to access the server configuration for the Executor.
 	execCfg *ExecutorConfig

--- a/pkg/sql/set_var.go
+++ b/pkg/sql/set_var.go
@@ -139,7 +139,7 @@ func getStringVal(evalCtx *tree.EvalContext, name string, values []tree.TypedExp
 }
 
 func setTimeZone(
-	_ context.Context, m sessionDataMutator, evalCtx *extendedEvalContext, values []tree.TypedExpr,
+	_ context.Context, m *sessionDataMutator, evalCtx *extendedEvalContext, values []tree.TypedExpr,
 ) error {
 	if len(values) != 1 {
 		return errors.New("set time zone requires a single argument")

--- a/pkg/sql/show_trace.go
+++ b/pkg/sql/show_trace.go
@@ -64,8 +64,8 @@ SELECT %s
                message,
                tag,
                loc,
-               first_value(operation) OVER (PARTITION BY txn_idx, span_idx ORDER BY message_idx) as operation,
-               (txn_idx, span_idx) AS span
+               first_value(operation) OVER (PARTITION BY span_idx ORDER BY message_idx) as operation,
+               span_idx AS span
           FROM crdb_internal.session_trace)
  %s
  ORDER BY timestamp
@@ -206,7 +206,7 @@ func (n *showTraceNode) startExec(params runParams) error {
 		return errTracingAlreadyEnabled
 	}
 	if err := params.extendedEvalCtx.SessionMutator.StartSessionTracing(
-		params.ctx, tracing.SnowballRecording, n.kvTracingEnabled,
+		tracing.SnowballRecording, n.kvTracingEnabled,
 	); err != nil {
 		return err
 	}
@@ -266,7 +266,7 @@ func (n *showTraceNode) Next(params runParams) (bool, error) {
 		n.run.stopTracing = nil
 
 		var err error
-		n.run.traceRows, err = params.extendedEvalCtx.Tracing.generateSessionTraceVTable()
+		n.run.traceRows, err = params.extendedEvalCtx.Tracing.getRecording()
 		if err != nil {
 			return false, err
 		}

--- a/pkg/sql/trace_test.go
+++ b/pkg/sql/trace_test.go
@@ -80,6 +80,7 @@ func TestTrace(t *testing.T) {
 						"WHERE operation IS NOT NULL ORDER BY op")
 			},
 			expSpans: []string{
+				"session recording",
 				"sql txn",
 				"/cockroach.roachpb.Internal/Batch",
 			},
@@ -115,6 +116,7 @@ func TestTrace(t *testing.T) {
 						"WHERE operation IS NOT NULL ORDER BY op")
 			},
 			expSpans: []string{
+				"session recording",
 				"sql txn",
 				"flow",
 				"table reader",
@@ -138,6 +140,7 @@ func TestTrace(t *testing.T) {
 						"WHERE operation IS NOT NULL ORDER BY op")
 			},
 			expSpans: []string{
+				"session recording",
 				"sql txn",
 				"starting plan",
 				"consuming rows",

--- a/pkg/sql/txn_state.go
+++ b/pkg/sql/txn_state.go
@@ -94,9 +94,6 @@ type txnState2 struct {
 	// consumeAdvanceInfo().
 	adv advanceInfo
 
-	// tracing facilitates the implementation of session tracing functionality
-	tracing SessionTracing
-
 	// txnAbortCount is incremented whenever the state transitions to
 	// stateAborted.
 	txnAbortCount *metric.Counter
@@ -171,7 +168,6 @@ func (ts *txnState2) resetForNewSQLTxn(
 
 	ts.sp = sp
 	ts.Ctx, ts.cancel = contextutil.WithCancel(txnCtx)
-	ts.tracing.onNewSQLTxn(ts.sp)
 
 	ts.mon.Start(ts.Ctx, tranCtx.connMon, mon.BoundAccount{} /* reserved */)
 
@@ -219,9 +215,6 @@ func (ts *txnState2) finishSQLTxn(connCtx context.Context) {
 	}
 
 	ts.sp.Finish()
-	if err := ts.tracing.onFinishSQLTxn(); err != nil {
-		log.Errorf(connCtx, "error finishing trace: %s", err)
-	}
 	ts.sp = nil
 	ts.Ctx = nil
 	ts.mu.txn = nil


### PR DESCRIPTION
Since introducing the connExecutor, session tracing (SET TRACING=on; ...
SHOW TRACE FOR SESSION;) wasn't working properly. Or, rather, the
implementation was always quite dubious, but it became more so with the
connExecutor. In the old Executor world, the trace was being recorded at
the level of a transaction: transaction are always getting a Recordable
span and, when session tracing is in effect, it registered an event
handler for transaction start/stop which would start/stop recording on
the respective spans. Whatever wasn't running in the context of a
transaction (i.e. whatever was running on the session's context) wasn't
being recorded; most things however did run in transactions - for
example we'd create "implicit" transactions for queries running outside
of one.
In the new world, more stuff runs outside of a transaction - for example
a BEGIN statement runs in the connection's context.
This patch reimplements how session tracing works: for the most part,
session tracing is not longer concerned with transactions. Instead, when
session tracing starts, the connection's context is "hijacked" -
replaced with a context with a span with the lifetime of the tracing.
This span will be recording. The transactions' spans will be
automatically recording, as they'll be children of the hijacked ctx.

This led to a change to the schema of the crdb_internal.session_trace
table and of the SHOW TRACE FOR statement: the recorded messages used to
have a txn_idx column which identified the index of the respective txn
within the recorded txns. Providing that was simple because of how we
collected the recordings - there used to be a recording per txn.
However, now there's a single big recording, so it's not so easy so
identify different txns. In any case, I say good riddance to that field
- it didn't make sense for SHOW TRACE FOR <stmt>, as it was always 0,
and also SHOW TRACE FOR was providing it as part of an awkward tuple
that nobody knew what it meant. Also, who traces more than one txn
anyway?
What we should have instead is a way to identify the traces of different
statements, which hopefully will become a thing soon.

Fixes #22783

Release note: None