### PR TITLE
sql: support SET SCHEMA for better compatibility with pg and the SQL standard

### DIFF
--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -719,6 +719,7 @@ unreserved_keyword ::=
 	| 'STATUS'
 	| 'SAVEPOINT'
 	| 'SCATTER'
+	| 'SCHEMA'
 	| 'SCRUB'
 	| 'SEARCH'
 	| 'SECOND'

--- a/pkg/sql/parser/parse_test.go
+++ b/pkg/sql/parser/parse_test.go
@@ -1123,6 +1123,8 @@ func TestParse2(t *testing.T) {
 		{`SELECT FAMILY(x)`,
 			`SELECT "family"(x)`},
 
+		{`SET SCHEMA 'public'`,
+			`SET search_path = 'public'`},
 		{`SET TIME ZONE 'pst8pdt'`,
 			`SET timezone = 'pst8pdt'`},
 		{`SET TIME ZONE 'Europe/Rome'`,


### PR DESCRIPTION
Informs #22937.

At least one client app (Zappix) uses `SET SCHEMA`, defined by the SQL
standard.  `SET SCHEMA` is used by an app after discovering the
available schemas in the `information_schema` tables. Postgres
implements `SET SCHEMA` as an alias for `SET search_path =`, since the
"current schema" in pg's dialect is defined exactly as "the first item
in `search_path`".

This patch makes CockroachDB do the same as pg.

Release note (sql change): CockroachDB now recognizes the special
syntax `SET SCHEMA <name>` as an alias for `SET search_path = <name>`
for better compatibility with PostgreSQL.