### PR TITLE
sql: enable inspection of schemas with SHOW SCHEMAS

### DIFF
--- a/docs/generated/sql/bnf/show_var.bnf
+++ b/docs/generated/sql/bnf/show_var.bnf
@@ -13,6 +13,7 @@ show_stmt ::=
 	| show_jobs_stmt
 	| show_queries_stmt
 	| show_roles_stmt
+	| show_schemas_stmt
 	| show_session_stmt
 	| show_sessions_stmt
 	| show_stats_stmt

--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -151,6 +151,7 @@ show_stmt ::=
 	| show_jobs_stmt
 	| show_queries_stmt
 	| show_roles_stmt
+	| show_schemas_stmt
 	| show_session_stmt
 	| show_sessions_stmt
 	| show_stats_stmt
@@ -457,6 +458,10 @@ show_queries_stmt ::=
 show_roles_stmt ::=
 	'SHOW' 'ROLES'
 
+show_schemas_stmt ::=
+	'SHOW' 'SCHEMAS' 'FROM' name
+	| 'SHOW' 'SCHEMAS'
+
 show_session_stmt ::=
 	'SHOW' session_var
 	| 'SHOW' 'SESSION' session_var
@@ -720,6 +725,7 @@ unreserved_keyword ::=
 	| 'SAVEPOINT'
 	| 'SCATTER'
 	| 'SCHEMA'
+	| 'SCHEMAS'
 	| 'SCRUB'
 	| 'SEARCH'
 	| 'SECOND'

--- a/pkg/sql/logictest/testdata/logic_test/database
+++ b/pkg/sql/logictest/testdata/logic_test/database
@@ -20,6 +20,15 @@ a
 system
 test
 
+query T colnames
+SHOW SCHEMAS FROM a
+----
+Schema
+crdb_internal
+information_schema
+pg_catalog
+public
+
 statement ok
 CREATE DATABASE b TEMPLATE=template0
 

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -108,6 +108,15 @@ Table       Name     Unique  Seq  Column  Direction  Storing  Implicit
 descriptor  primary  true    1    id      ASC        false    false
 
 query T colnames
+SELECT * FROM [SHOW SCHEMAS FROM system]
+----
+Schema
+crdb_internal
+information_schema
+pg_catalog
+public
+
+query T colnames
 SELECT * FROM [SHOW TABLES FROM system]
 ----
 Table
@@ -138,6 +147,15 @@ SELECT node_id, username, query FROM [SHOW QUERIES]
 node_id   username   query
 1         root       SELECT node_id, username, query FROM [SHOW CLUSTER QUERIES]
 
+
+query T colnames
+SELECT * FROM [SHOW SCHEMAS]
+----
+Schema
+crdb_internal
+information_schema
+pg_catalog
+public
 
 query T colnames
 CREATE TABLE foo(x INT); SELECT * FROM [SHOW TABLES]

--- a/pkg/sql/parser/help_test.go
+++ b/pkg/sql/parser/help_test.go
@@ -266,6 +266,9 @@ func TestContextualHelp(t *testing.T) {
 
 		{`SHOW ROLES ??`, `SHOW ROLES`},
 
+		{`SHOW SCHEMAS FROM ??`, `SHOW SCHEMAS`},
+		{`SHOW SCHEMAS FROM blah ??`, `SHOW SCHEMAS`},
+
 		{`SHOW TABLES FROM ??`, `SHOW TABLES`},
 		{`SHOW TABLES FROM blah ??`, `SHOW TABLES`},
 

--- a/pkg/sql/parser/parse_test.go
+++ b/pkg/sql/parser/parse_test.go
@@ -322,6 +322,8 @@ func TestParse(t *testing.T) {
 		{`SHOW CLUSTER SETTING all`},
 
 		{`SHOW DATABASES`},
+		{`SHOW SCHEMAS`},
+		{`SHOW SCHEMAS FROM a`},
 		{`SHOW TABLES`},
 		{`SHOW TABLES FROM a.public`},
 		{`SHOW COLUMNS FROM a`},

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -513,7 +513,7 @@ func newNameFromStr(s string) *tree.Name {
 %token <str>   RELEASE RESET RESTORE RESTRICT RESUME RETURNING REVOKE RIGHT
 %token <str>   ROLE ROLES ROLLBACK ROLLUP ROW ROWS RSHIFT
 
-%token <str>   SAVEPOINT SCATTER SCHEMA SCRUB SEARCH SECOND SELECT SEQUENCE SEQUENCES
+%token <str>   SAVEPOINT SCATTER SCHEMA SCHEMAS SCRUB SEARCH SECOND SELECT SEQUENCE SEQUENCES
 %token <str>   SERIAL SERIAL2 SERIAL4 SERIAL8
 %token <str>   SERIALIZABLE SESSION SESSIONS SESSION_USER SET SETTING SETTINGS
 %token <str>   SHOW SIMILAR SIMPLE SMALLINT SMALLSERIAL SNAPSHOT SOME SPLIT SQL
@@ -687,6 +687,7 @@ func newNameFromStr(s string) *tree.Name {
 %type <tree.Statement> show_jobs_stmt
 %type <tree.Statement> show_queries_stmt
 %type <tree.Statement> show_roles_stmt
+%type <tree.Statement> show_schemas_stmt
 %type <tree.Statement> show_session_stmt
 %type <tree.Statement> show_sessions_stmt
 %type <tree.Statement> show_stats_stmt
@@ -2586,6 +2587,7 @@ show_stmt:
 | show_jobs_stmt            // EXTEND WITH HELP: SHOW JOBS
 | show_queries_stmt         // EXTEND WITH HELP: SHOW QUERIES
 | show_roles_stmt           // EXTEND WITH HELP: SHOW ROLES
+| show_schemas_stmt         // EXTEND WITH HELP: SHOW SCHEMAS
 | show_session_stmt         // EXTEND WITH HELP: SHOW SESSION
 | show_sessions_stmt        // EXTEND WITH HELP: SHOW SESSIONS
 | show_stats_stmt           // EXTEND WITH HELP: SHOW STATISTICS
@@ -2869,6 +2871,20 @@ show_tables_stmt:
     $$.val = &tree.ShowTables{Schema: tree.PublicSchemaName}
   }
 | SHOW TABLES error // SHOW HELP: SHOW TABLES
+
+// %Help: SHOW SCHEMAS - list schemas
+// %Category: DDL
+// %Text: SHOW SCHEMAS [FROM <databasename> ]
+show_schemas_stmt:
+  SHOW SCHEMAS FROM name
+  {
+    $$.val = &tree.ShowSchemas{Database: tree.Name($4)}
+  }
+| SHOW SCHEMAS
+  {
+    $$.val = &tree.ShowSchemas{}
+  }
+| SHOW SCHEMAS error // SHOW HELP: SHOW SCHEMAS
 
 // %Help: SHOW SYNTAX - analyze SQL syntax
 // %Category: Misc
@@ -7501,6 +7517,7 @@ unreserved_keyword:
 | SAVEPOINT
 | SCATTER
 | SCHEMA
+| SCHEMAS
 | SCRUB
 | SEARCH
 | SECOND

--- a/pkg/sql/pgwire/pgwire_test.go
+++ b/pkg/sql/pgwire/pgwire_test.go
@@ -735,6 +735,9 @@ func TestPGPreparedQuery(t *testing.T) {
 		"SHOW TABLES FROM system": {
 			baseTest.Results("descriptor").Others(13),
 		},
+		"SHOW SCHEMAS FROM system": {
+			baseTest.Results("crdb_internal").Others(3),
+		},
 		"SHOW CONSTRAINTS FROM system.users": {
 			baseTest.Results("users", "primary", "PRIMARY KEY", "username", gosql.NullString{}),
 		},

--- a/pkg/sql/plan.go
+++ b/pkg/sql/plan.go
@@ -700,6 +700,8 @@ func (p *planner) newPlan(
 		return p.ShowSyntax(ctx, n)
 	case *tree.ShowTables:
 		return p.ShowTables(ctx, n)
+	case *tree.ShowSchemas:
+		return p.ShowSchemas(ctx, n)
 	case *tree.ShowTrace:
 		return p.ShowTrace(ctx, n)
 	case *tree.ShowTransactionStatus:
@@ -819,6 +821,8 @@ func (p *planner) doPrepare(ctx context.Context, stmt tree.Statement) (planNode,
 		return p.ShowSessions(ctx, n)
 	case *tree.ShowTables:
 		return p.ShowTables(ctx, n)
+	case *tree.ShowSchemas:
+		return p.ShowSchemas(ctx, n)
 	case *tree.ShowTrace:
 		return p.ShowTrace(ctx, n)
 	case *tree.ShowUsers:

--- a/pkg/sql/sem/tree/show.go
+++ b/pkg/sql/sem/tree/show.go
@@ -162,10 +162,35 @@ func (node *ShowSessions) Format(ctx *FmtCtx) {
 	}
 }
 
+// ShowSchemas represents a SHOW TABLES statement.
+type ShowSchemas struct {
+	Database Name
+}
+
+// Format implements the NodeFormatter interface.
+func (node *ShowSchemas) Format(ctx *FmtCtx) {
+	ctx.WriteString("SHOW SCHEMAS")
+	if node.Database != "" {
+		ctx.WriteString(" FROM ")
+		ctx.FormatNode(&node.Database)
+	}
+}
+
 // ShowTables represents a SHOW TABLES statement.
 type ShowTables struct {
 	Database Name
 	Schema   Name
+}
+
+// Format implements the NodeFormatter interface.
+func (node *ShowTables) Format(ctx *FmtCtx) {
+	ctx.WriteString("SHOW TABLES")
+	if node.Database != "" {
+		ctx.WriteString(" FROM ")
+		ctx.FormatNode(&node.Database)
+		ctx.WriteByte('.')
+		ctx.FormatNode(&node.Schema)
+	}
 }
 
 // ShowConstraints represents a SHOW CONSTRAINTS statement.
@@ -179,17 +204,6 @@ func (node *ShowConstraints) Format(ctx *FmtCtx) {
 	if node.Table.TableNameReference != nil {
 		ctx.WriteString(" FROM ")
 		ctx.FormatNode(&node.Table)
-	}
-}
-
-// Format implements the NodeFormatter interface.
-func (node *ShowTables) Format(ctx *FmtCtx) {
-	ctx.WriteString("SHOW TABLES")
-	if node.Database != "" {
-		ctx.WriteString(" FROM ")
-		ctx.FormatNode(&node.Database)
-		ctx.WriteByte('.')
-		ctx.FormatNode(&node.Schema)
 	}
 }
 

--- a/pkg/sql/sem/tree/stmt.go
+++ b/pkg/sql/sem/tree/stmt.go
@@ -815,6 +815,15 @@ func (*ShowTables) hiddenFromStats()                   {}
 func (*ShowTables) independentFromParallelizedPriors() {}
 
 // StatementType implements the Statement interface.
+func (*ShowSchemas) StatementType() StatementType { return Rows }
+
+// StatementTag returns a short string identifying the type of statement.
+func (*ShowSchemas) StatementTag() string { return "SHOW SCHEMAS" }
+
+func (*ShowSchemas) hiddenFromStats()                   {}
+func (*ShowSchemas) independentFromParallelizedPriors() {}
+
+// StatementType implements the Statement interface.
 func (*Split) StatementType() StatementType { return Rows }
 
 // StatementTag returns a short string identifying the type of statement.
@@ -925,6 +934,7 @@ func (n *ShowQueries) String() string               { return AsString(n) }
 func (n *ShowRanges) String() string                { return AsString(n) }
 func (n *ShowRoleGrants) String() string            { return AsString(n) }
 func (n *ShowRoles) String() string                 { return AsString(n) }
+func (n *ShowSchemas) String() string               { return AsString(n) }
 func (n *ShowSessions) String() string              { return AsString(n) }
 func (n *ShowSyntax) String() string                { return AsString(n) }
 func (n *ShowTableStats) String() string            { return AsString(n) }

--- a/pkg/sql/show_schemas.go
+++ b/pkg/sql/show_schemas.go
@@ -1,0 +1,49 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package sql
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/lex"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+)
+
+// ShowSchemas returns all the schemas in the given or current database.
+// Privileges: None.
+//   Notes: postgres does not have a SHOW SCHEMAS statement.
+func (p *planner) ShowSchemas(ctx context.Context, n *tree.ShowSchemas) (planNode, error) {
+	name := p.SessionData().Database
+	if n.Database != "" {
+		name = string(n.Database)
+	}
+	if name == "" {
+		return nil, errNoDatabase
+	}
+	if _, err := ResolveDatabase(ctx, p, name, true /*required*/); err != nil {
+		return nil, err
+	}
+
+	const getSchemasQuery = `
+				SELECT schema_name AS "Schema"
+				FROM %[1]s.information_schema.schemata
+				WHERE catalog_name = %[2]s
+				ORDER BY schema_name`
+
+	return p.delegateQuery(ctx, "SHOW SCHEMAS",
+		fmt.Sprintf(getSchemasQuery, (*tree.Name)(&name), lex.EscapeSQLString(name)),
+		func(_ context.Context) error { return nil }, nil)
+}


### PR DESCRIPTION
Fixes #22964.

Now that SHOW TABLES only shows tables in the public schema by
default, and SET DATABASE only supports real databases and not
(virtual) schemas, there is no simple way for a user to realize that
there are multiple schemas in the first place, and which virtual
schemas exist / are recognized.

Release note (sql change): the new statement `SHOW SCHEMAS` reveals
which are the valid virtual schemas next to the physical schema
`public`.