### PR TITLE
opt: Add index support to the optbase.Catalog interface

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/relational_builder.go
+++ b/pkg/sql/opt/exec/execbuilder/relational_builder.go
@@ -107,7 +107,7 @@ func (b *Builder) buildScan(ev xform.ExprView) (execPlan, error) {
 		return execPlan{}, err
 	}
 	res := execPlan{root: node}
-	for i := 0; i < tbl.NumColumns(); i++ {
+	for i := 0; i < tbl.ColumnCount(); i++ {
 		res.outputCols.Set(int(md.TableColumn(tblIndex, i)), i)
 	}
 	return res, nil

--- a/pkg/sql/opt/exec/execbuilder/testdata/catalog
+++ b/pkg/sql/opt/exec/execbuilder/testdata/catalog
@@ -1,0 +1,81 @@
+exec-raw
+CREATE DATABASE t
+----
+
+#
+# Basic table with single column primary key.
+#
+exec-raw
+CREATE TABLE t.a (x INT PRIMARY KEY, y STRING, z FLOAT NOT NULL);
+----
+
+catalog
+t.a
+----
+TABLE a
+ ├── x int not null
+ ├── y string
+ ├── z float not null
+ └── INDEX primary
+      └── x int not null
+
+#
+# Table with auto-generated hidden primary key column.
+#
+exec-raw
+CREATE TABLE t.b (x INT, y STRING, z FLOAT NOT NULL);
+----
+
+catalog
+t.b
+----
+TABLE b
+ ├── x int
+ ├── y string
+ ├── z float not null
+ ├── rowid int not null (hidden)
+ └── INDEX primary
+      └── rowid int not null (hidden)
+
+#
+# Table with multi-column primary key and secondary indexes. Secondary indexes
+# are both unique and non-unique, with storing columns and missing primary key
+# columns.
+#
+exec-raw
+CREATE TABLE t.c (
+    x STRING,
+    y DECIMAL,
+    z FLOAT,
+    i INT NOT NULL,
+    PRIMARY KEY (x, y DESC),
+    UNIQUE INDEX myindex (x DESC, z) STORING (i),
+    INDEX (x) STORING(i),
+    INDEX (z)
+)
+----
+
+catalog
+t.c
+----
+TABLE c
+ ├── x string not null
+ ├── y decimal not null
+ ├── z float
+ ├── i int not null
+ ├── INDEX primary
+ │    ├── x string not null
+ │    └── y decimal not null desc
+ ├── INDEX myindex
+ │    ├── x string not null desc
+ │    ├── z float
+ │    ├── y decimal not null (storing)
+ │    └── i int not null (storing)
+ ├── INDEX c_x_idx
+ │    ├── x string not null
+ │    ├── y decimal not null
+ │    └── i int not null (storing)
+ └── INDEX c_z_idx
+      ├── z float
+      ├── x string not null
+      └── y decimal not null

--- a/pkg/sql/opt/opt/metadata.go
+++ b/pkg/sql/opt/opt/metadata.go
@@ -149,7 +149,7 @@ func (md *Metadata) ColumnType(index ColumnIndex) types.T {
 func (md *Metadata) AddTable(tbl optbase.Table) TableIndex {
 	tblIndex := TableIndex(md.NumColumns() + 1)
 
-	for i := 0; i < tbl.NumColumns(); i++ {
+	for i := 0; i < tbl.ColumnCount(); i++ {
 		col := tbl.Column(i)
 		if tbl.TabName() == "" {
 			md.AddColumn(string(col.ColName()), col.DatumType())

--- a/pkg/sql/opt/optbuilder/builder.go
+++ b/pkg/sql/opt/optbuilder/builder.go
@@ -316,7 +316,7 @@ func (b *Builder) buildScan(
 	tblIndex := b.factory.Metadata().AddTable(tbl)
 
 	outScope = inScope.push()
-	for i := 0; i < tbl.NumColumns(); i++ {
+	for i := 0; i < tbl.ColumnCount(); i++ {
 		col := tbl.Column(i)
 		colIndex := b.factory.Metadata().TableColumn(tblIndex, i)
 		colProps := columnProps{

--- a/pkg/sql/opt/testutils/test_catalog.go
+++ b/pkg/sql/opt/testutils/test_catalog.go
@@ -112,14 +112,32 @@ func (t *TestTable) TabName() optbase.TableName {
 	return optbase.TableName(t.Name)
 }
 
-// NumColumns is part of the optbase.Table interface.
-func (t *TestTable) NumColumns() int {
+// ColumnCount is part of the optbase.Table interface.
+func (t *TestTable) ColumnCount() int {
 	return len(t.Columns)
 }
 
 // Column is part of the optbase.Table interface.
 func (t *TestTable) Column(i int) optbase.Column {
 	return t.Columns[i]
+}
+
+// Primary is part of the optbase.Table interface.
+func (t *TestTable) Primary() optbase.Index {
+	// TODO(andyk): Implement this.
+	return nil
+}
+
+// SecondaryCount is part of the optbase.Table interface.
+func (t *TestTable) SecondaryCount() int {
+	// TODO(andyk): Implement this.
+	return 0
+}
+
+// Secondary is part of the optbase.Table interface.
+func (t *TestTable) Secondary(i int) optbase.Index {
+	// TODO(andyk): Implement this.
+	panic("no secondary indexes")
 }
 
 // TestCatalog implements the optbase.Catalog interface for testing purposes.

--- a/pkg/sql/opt/xform/logical_props_factory.go
+++ b/pkg/sql/opt/xform/logical_props_factory.go
@@ -82,10 +82,10 @@ func (f *logicalPropsFactory) constructScanProps(ev ExprView) LogicalProps {
 	tbl := f.mem.metadata.Table(tblIndex)
 
 	// A table's output column indexes are contiguous.
-	props.Relational.OutputCols.AddRange(int(tblIndex), int(tblIndex)+tbl.NumColumns()-1)
+	props.Relational.OutputCols.AddRange(int(tblIndex), int(tblIndex)+tbl.ColumnCount()-1)
 
 	// Initialize not-NULL columns from the table schema.
-	for i := 0; i < tbl.NumColumns(); i++ {
+	for i := 0; i < tbl.ColumnCount(); i++ {
 		if !tbl.Column(i).IsNullable() {
 			props.Relational.NotNullCols.Add(int(tblIndex) + i)
 		}

--- a/pkg/sql/opt_catalog.go
+++ b/pkg/sql/opt_catalog.go
@@ -1,0 +1,215 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package sql
+
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/optbase"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+)
+
+// optCatalog implements the optbase.Catalog interface over the SchemaResolver
+// interface for the use of the new optimizer. The interfaces are simplified to
+// only include what the optimizer needs, and certain common lookups are cached
+// for faster performance.
+type optCatalog struct {
+	// resolver needs to be set via a call to init before calling other methods.
+	resolver SchemaResolver
+
+	// wrappers is a cache of table wrappers that's used to satisfy repeated
+	// calls to the FindTable method for the same table.
+	wrappers map[*sqlbase.TableDescriptor]*optTable
+}
+
+var _ optbase.Catalog = &optCatalog{}
+
+// init allows the optCatalog wrapper to be inlined.
+func (oc *optCatalog) init(resolver SchemaResolver) {
+	oc.resolver = resolver
+}
+
+// FindTable is part of the optbase.Catalog interface.
+func (oc *optCatalog) FindTable(ctx context.Context, name *tree.TableName) (optbase.Table, error) {
+	desc, err := ResolveExistingObject(ctx, oc.resolver, name, true /*required*/, requireTableDesc)
+	if err != nil {
+		return nil, err
+	}
+
+	// Check to see if there's already a wrapper for this table descriptor.
+	if oc.wrappers == nil {
+		oc.wrappers = make(map[*sqlbase.TableDescriptor]*optTable)
+	}
+	wrapper, ok := oc.wrappers[desc]
+	if !ok {
+		wrapper = newOptTable(desc)
+		oc.wrappers[desc] = wrapper
+	}
+	return wrapper, nil
+}
+
+// optTable is a wrapper around sqlbase.TableDescriptor that caches index
+// wrappers and maintains a ColumnID => Column mapping for fast lookup.
+type optTable struct {
+	desc *sqlbase.TableDescriptor
+
+	// primary is the inlined wrapper for the table's primary index.
+	primary optIndex
+
+	// colMap is a mapping from unique ColumnID to column ordinal within the
+	// table. This is a common lookup that needs to be fast.
+	colMap map[sqlbase.ColumnID]int
+
+	// wrappers is a cache of index wrappers that's used to satisfy repeated
+	// calls to the SecondaryIndex method for the same index.
+	wrappers map[*sqlbase.IndexDescriptor]*optIndex
+}
+
+var _ optbase.Table = &optTable{}
+
+func newOptTable(desc *sqlbase.TableDescriptor) *optTable {
+	ot := &optTable{}
+	ot.init(desc)
+	return ot
+}
+
+// init allows the optTable wrapper to be inlined.
+func (ot *optTable) init(desc *sqlbase.TableDescriptor) {
+	ot.desc = desc
+	ot.primary.init(ot, &desc.PrimaryIndex)
+}
+
+// TabName is part of the optbase.Table interface.
+func (ot *optTable) TabName() optbase.TableName {
+	return optbase.TableName(ot.desc.Name)
+}
+
+// ColumnCount is part of the optbase.Table interface.
+func (ot *optTable) ColumnCount() int {
+	return len(ot.desc.Columns)
+}
+
+// Column is part of the optbase.Table interface.
+func (ot *optTable) Column(i int) optbase.Column {
+	return &ot.desc.Columns[i]
+}
+
+// Primary is part of the optbase.Table interface.
+func (ot *optTable) Primary() optbase.Index {
+	return &ot.primary
+}
+
+// SecondaryCount is part of the optbase.Table interface.
+func (ot *optTable) SecondaryCount() int {
+	return len(ot.desc.Indexes)
+}
+
+// Secondary is part of the optbase.Table interface.
+func (ot *optTable) Secondary(i int) optbase.Index {
+	desc := &ot.desc.Indexes[i]
+
+	// Check to see if there's already a wrapper for this index descriptor.
+	if ot.wrappers == nil {
+		ot.wrappers = make(map[*sqlbase.IndexDescriptor]*optIndex, len(ot.desc.Indexes))
+	}
+	wrapper, ok := ot.wrappers[desc]
+	if !ok {
+		wrapper = newOptIndex(ot, desc)
+		ot.wrappers[desc] = wrapper
+	}
+	return wrapper
+}
+
+// lookupColumnOrdinal returns the ordinal of the column with the given ID. A
+// cache makes the lookup O(1).
+func (ot *optTable) lookupColumnOrdinal(colID sqlbase.ColumnID) int {
+	if ot.colMap == nil {
+		ot.colMap = make(map[sqlbase.ColumnID]int, len(ot.desc.Columns))
+		for i := range ot.desc.Columns {
+			ot.colMap[ot.desc.Columns[i].ID] = i
+		}
+	}
+	return ot.colMap[colID]
+}
+
+// optIndex is a wrapper around sqlbase.IndexDescriptor that caches some
+// commonly accessed information and keeps a reference to the table wrapper.
+type optIndex struct {
+	tbl           *optTable
+	desc          *sqlbase.IndexDescriptor
+	numCols       int
+	numUniqueCols int
+}
+
+var _ optbase.Index = &optIndex{}
+
+func newOptIndex(tbl *optTable, desc *sqlbase.IndexDescriptor) *optIndex {
+	oi := &optIndex{}
+	oi.init(tbl, desc)
+	return oi
+}
+
+// init allows the optIndex wrapper to be inlined.
+func (oi *optIndex) init(tbl *optTable, desc *sqlbase.IndexDescriptor) {
+	oi.tbl = tbl
+	oi.desc = desc
+	oi.numCols = len(desc.ColumnIDs) + len(desc.ExtraColumnIDs) + len(desc.StoreColumnIDs)
+
+	// If index is not unique, extra key columns are added.
+	oi.numUniqueCols = len(desc.ColumnIDs)
+	if !desc.Unique {
+		oi.numUniqueCols += len(desc.ExtraColumnIDs)
+	}
+}
+
+// IdxName is part of the optbase.Index interface.
+func (oi *optIndex) IdxName() string {
+	return oi.desc.Name
+}
+
+// ColumnCount is part of the optbase.Index interface.
+func (oi *optIndex) ColumnCount() int {
+	return oi.numCols
+}
+
+// UniqueColumnCount is part of the optbase.Index interface.
+func (oi *optIndex) UniqueColumnCount() int {
+	return oi.numUniqueCols
+}
+
+// Column is part of the optbase.Index interface.
+func (oi *optIndex) Column(i int) optbase.IndexColumn {
+	length := len(oi.desc.ColumnIDs)
+	if i < length {
+		ord := oi.tbl.lookupColumnOrdinal(oi.desc.ColumnIDs[i])
+		return optbase.IndexColumn{
+			Column:     oi.tbl.Column(ord),
+			Ordinal:    ord,
+			Descending: oi.desc.ColumnDirections[i] == sqlbase.IndexDescriptor_DESC,
+		}
+	}
+
+	i -= length
+	length = len(oi.desc.ExtraColumnIDs)
+	if i < length {
+		ord := oi.tbl.lookupColumnOrdinal(oi.desc.ExtraColumnIDs[i])
+		return optbase.IndexColumn{Column: oi.tbl.Column(ord), Ordinal: ord}
+	}
+
+	i -= length
+	ord := oi.tbl.lookupColumnOrdinal(oi.desc.StoreColumnIDs[i])
+	return optbase.IndexColumn{Column: oi.tbl.Column(ord), Ordinal: ord}
+}

--- a/pkg/sql/optbase/catalog.go
+++ b/pkg/sql/optbase/catalog.go
@@ -15,10 +15,13 @@
 package optbase
 
 import (
+	"bytes"
 	"context"
+	"fmt"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
+	"github.com/cockroachdb/cockroach/pkg/util/treeprinter"
 )
 
 // This file contains interfaces that are used by the query optimizer to avoid
@@ -33,18 +36,60 @@ type TableName string
 // Column is an interface to a table column, exposing only the information
 // needed by the query optimizer.
 type Column interface {
-	// IsNullable returns true if the column is nullable.
-	IsNullable() bool
-
 	// ColName returns the name of the column.
 	ColName() ColumnName
 
 	// DatumType returns the data type of the column.
 	DatumType() types.T
 
+	// IsNullable returns true if the column is nullable.
+	IsNullable() bool
+
 	// IsHidden returns true if the column is hidden (e.g., there is always a
 	// hidden column called rowid if there is no primary key on the table).
 	IsHidden() bool
+}
+
+// IndexColumn describes a single column that is part of an index definition.
+type IndexColumn struct {
+	// Column is a reference to the column returned by Table.Column, given the
+	// column ordinal.
+	Column Column
+
+	// Ordinal is the ordinal position of the indexed column in the table being
+	// indexed. It is always >= 0 and < Table.ColumnCount.
+	Ordinal int
+
+	// Descending is true if the index is ordered from greatest to least on
+	// this column, rather than least to greatest.
+	Descending bool
+}
+
+// Index is an interface to a database index, exposing only the information
+// needed by the query optimizer. Every index is treated as unique by the
+// optimizer. If an index was declared as non-unique, then the system will add
+// implicit columns from the primary key in order to make it unique (and even
+// add an implicit primary key based on a hidden rowid column if a primary key
+// was not explicitly declared).
+type Index interface {
+	// IdxName is the name of the index.
+	IdxName() string
+
+	// ColumnCount returns the number of columns in the index. This includes
+	// columns that were part of the index definition (including the STORING
+	// clause), as well as implicitly added primary key columns.
+	ColumnCount() int
+
+	// UniqueColumnCount returns the number of columns in the index that are
+	// part of its unique key. Every index has a set of unique columns, even if
+	// it was not originally declared unique, due to implicitly added primary
+	// key columns. The unique columns are always a prefix of the full column
+	// list, where UniqueColumnCount <= ColumnCount.
+	UniqueColumnCount() int
+
+	// Column returns the ith IndexColumn within the index definition, where
+	// i < ColumnCount.
+	Column(i int) IndexColumn
 }
 
 // Table is an interface to a database table, exposing only the information
@@ -53,11 +98,25 @@ type Table interface {
 	// TabName returns the name of the table.
 	TabName() TableName
 
-	// NumColumns returns the number of columns in the table.
-	NumColumns() int
+	// ColumnCount returns the number of columns in the table.
+	ColumnCount() int
 
-	// Column returns a Column interface to the ith column of the table.
+	// Column returns a Column interface to the column at the ith ordinal
+	// position within the table, where i < ColumnCount.
 	Column(i int) Column
+
+	// Primary returns the unique index that specifies the primary ordering of
+	// the rows in the table. It corresponds to the table's primary key, and is
+	// always present. If a primary key was not explicitly specified, then the
+	// system implicitly creates one based on a hidden rowid column.
+	Primary() Index
+
+	// SecondaryCount returns the number of secondary indexes defined on this
+	// table.
+	SecondaryCount() int
+
+	// Secondary returns the ith secondary index, where i < SecondaryCount.
+	Secondary(i int) Index
 }
 
 // Catalog is an interface to a database catalog, exposing only the information
@@ -66,4 +125,56 @@ type Catalog interface {
 	// FindTable returns a Table interface for the database table matching the
 	// given table name.  Returns an error if the table does not exist.
 	FindTable(ctx context.Context, name *tree.TableName) (Table, error)
+}
+
+// FormatCatalogTable nicely formats a catalog table using a treeprinter for
+// debugging and testing.
+func FormatCatalogTable(tbl Table, tp treeprinter.Node) {
+	child := tp.Childf("TABLE %s", tbl.TabName())
+
+	var buf bytes.Buffer
+	for i := 0; i < tbl.ColumnCount(); i++ {
+		buf.Reset()
+		formatColumn(tbl.Column(i), &buf)
+		child.Child(buf.String())
+	}
+
+	FormatCatalogIndex(tbl.Primary(), child)
+
+	for i := 0; i < tbl.SecondaryCount(); i++ {
+		FormatCatalogIndex(tbl.Secondary(i), child)
+	}
+}
+
+// FormatCatalogIndex nicely formats a catalog index using a treeprinter for
+// debugging and testing.
+func FormatCatalogIndex(idx Index, tp treeprinter.Node) {
+	child := tp.Childf("INDEX %s", idx.IdxName())
+
+	var buf bytes.Buffer
+	for i := 0; i < idx.ColumnCount(); i++ {
+		buf.Reset()
+
+		idxCol := idx.Column(i)
+		formatColumn(idxCol.Column, &buf)
+		if idxCol.Descending {
+			fmt.Fprintf(&buf, " desc")
+		}
+
+		if i >= idx.UniqueColumnCount() {
+			fmt.Fprintf(&buf, " (storing)")
+		}
+
+		child.Child(buf.String())
+	}
+}
+
+func formatColumn(col Column, buf *bytes.Buffer) {
+	fmt.Fprintf(buf, "%s %s", col.ColName(), col.DatumType())
+	if !col.IsNullable() {
+		fmt.Fprintf(buf, " not null")
+	}
+	if col.IsHidden() {
+		fmt.Fprintf(buf, " (hidden)")
+	}
 }

--- a/pkg/sql/plan.go
+++ b/pkg/sql/plan.go
@@ -314,12 +314,12 @@ func (p *planner) makePlan(ctx context.Context, stmt Statement) error {
 // makeOptimizerPlan is an alternative to makePlan which uses the (experimental)
 // optimizer.
 func (p *planner) makeOptimizerPlan(ctx context.Context, stmt Statement) error {
-	// execEngine is both an exec.Factory and an optbase.Catalog.
-	eng := &execEngine{
-		planner: p,
-	}
+	// execEngine is both an exec.Factory and an optbase.Catalog. cleanup is
+	// not required on the engine, since planner is cleaned up elsewhere.
+	eng := newExecEngine(p, nil)
+	defer eng.Close()
 
-	o := xform.NewOptimizer(eng, xform.OptimizeAll)
+	o := xform.NewOptimizer(eng.Catalog(), xform.OptimizeAll)
 	root, props, err := optbuilder.New(ctx, o.Factory(), stmt.AST).Build()
 	if err != nil {
 		return err

--- a/pkg/sql/sqlbase/structured.go
+++ b/pkg/sql/sqlbase/structured.go
@@ -2590,23 +2590,6 @@ func (desc *ColumnDescriptor) CheckCanBeFKRef() error {
 	return nil
 }
 
-var _ optbase.Table = &TableDescriptor{}
-
-// TabName is part of the optbase.Table interface.
-func (desc *TableDescriptor) TabName() optbase.TableName {
-	return optbase.TableName(desc.GetName())
-}
-
-// NumColumns is part of the optbase.Table interface.
-func (desc *TableDescriptor) NumColumns() int {
-	return len(desc.Columns)
-}
-
-// Column is part of the optbase.Table interface.
-func (desc *TableDescriptor) Column(i int) optbase.Column {
-	return &desc.Columns[i]
-}
-
 // PartitionNames returns a slice containing the name of every partition and
 // subpartition in an arbitrary order.
 func (desc *TableDescriptor) PartitionNames() []string {


### PR DESCRIPTION
Add support for primary and secondary indexes to the optbase.Catalog
interface. This consists of additional methods on optbase.Table to
get the indexes, as well as an additional Index interface and
IndexColumn struct. Provide an implementation of the expanded interface
over SchemaResolver. This requires adding wrapper objects for Table
and Index descriptors, in order to link index columns back to table
columns, as well as to add a ColumnID lookup map.

Also rename and split executor_opt_interface.go and provide a catalog
table formatting method for debugging and testing.

Release note: None