### PR TITLE
sql: support placeholders with CREATE TABLE AS

### DIFF
--- a/pkg/sql/pgwire/pgwire_test.go
+++ b/pkg/sql/pgwire/pgwire_test.go
@@ -1189,6 +1189,12 @@ func TestPGPreparedExec(t *testing.T) {
 			},
 		},
 		{
+			"CREATE TABLE d.public.t AS SELECT $1+1 AS x",
+			[]preparedExecTest{
+				baseTest.SetArgs(1).RowsAffected(1),
+			},
+		},
+		{
 			"CREATE TABLE d.public.types (i int, f float, s string, b bytes, d date, m timestamp, z timestamp with time zone, n interval, o bool, e decimal)",
 			[]preparedExecTest{
 				baseTest,

--- a/pkg/sql/plan.go
+++ b/pkg/sql/plan.go
@@ -766,6 +766,8 @@ func (p *planner) doPrepare(ctx context.Context, stmt tree.Statement) (planNode,
 		return p.CancelJob(ctx, n)
 	case *tree.CreateUser:
 		return p.CreateUser(ctx, n)
+	case *tree.CreateTable:
+		return p.CreateTable(ctx, n)
 	case *tree.Delete:
 		return p.Delete(ctx, n, nil)
 	case *tree.DropUser:


### PR DESCRIPTION
Release note (bug fix): the special form of `CREATE TABLE .. AS`
now properly supports placeholders in the subquery.

Found while investigating #23002.