### PR TITLE
cherrypick-2.0: fixes for disabling new-version pings

### DIFF
--- a/pkg/server/admin_test.go
+++ b/pkg/server/admin_test.go
@@ -835,7 +835,7 @@ func TestAdminAPISettings(t *testing.T) {
 	defer s.Stopper().Stop(context.TODO())
 
 	// Any bool that defaults to true will work here.
-	const settingKey = "diagnostics.reporting.report_metrics"
+	const settingKey = "sql.metrics.statement_details.enabled"
 	st := s.ClusterSettings()
 	allKeys := settings.Keys()
 

--- a/pkg/server/updates.go
+++ b/pkg/server/updates.go
@@ -180,6 +180,9 @@ func addInfoToURL(ctx context.Context, url *url.URL, s *Server, runningTime time
 // The returned boolean indicates if the check succeeded (and thus does not need
 // to be re-attempted by the scheduler after a retry-interval).
 func (s *Server) checkForUpdates(runningTime time.Duration) bool {
+	if updatesURL == nil {
+		return true // don't bother with asking for retry -- we'll never succeed.
+	}
 	ctx, span := s.AnnotateCtxWithSpan(context.Background(), "checkForUpdates")
 	defer span.Finish()
 
@@ -337,6 +340,9 @@ func (s *Server) getReportingInfo(ctx context.Context) *diagnosticspb.Diagnostic
 }
 
 func (s *Server) reportDiagnostics(runningTime time.Duration) {
+	if reportingURL == nil {
+		return
+	}
 	ctx, span := s.AnnotateCtxWithSpan(context.Background(), "usageReport")
 	defer span.Finish()
 

--- a/pkg/server/updates.go
+++ b/pkg/server/updates.go
@@ -137,6 +137,12 @@ func (s *Server) maybeCheckForUpdates(
 		return scheduled
 	}
 
+	// if diagnostics reporting is disabled, we should assume that means that the
+	// user doesn't want us phoning home for new-version checks either.
+	if !log.DiagnosticsReportingEnabled.Get(&s.st.SV) {
+		return now.Add(updateCheckFrequency)
+	}
+
 	// checkForUpdates handles its own errors, but it returns a bool indicating if
 	// it succeeded, so we can schedule a re-attempt if it did not.
 	if succeeded := s.checkForUpdates(runningTime); !succeeded {

--- a/pkg/server/updates.go
+++ b/pkg/server/updates.go
@@ -84,12 +84,6 @@ var diagnosticReportFrequency = settings.RegisterNonNegativeDurationSetting(
 	time.Hour,
 )
 
-var diagnosticsMetricsEnabled = settings.RegisterBoolSetting(
-	"diagnostics.reporting.report_metrics",
-	"enable collection and reporting diagnostic metrics to cockroach labs",
-	true,
-)
-
 // randomly shift `d` to be up to `jitterSec` shorter or longer.
 func addJitter(d time.Duration, jitterSec int) time.Duration {
 	j := time.Duration(rand.Intn(jitterSec*2)-jitterSec) * time.Second
@@ -239,7 +233,7 @@ func (s *Server) maybeReportDiagnostics(
 	// TODO(dt): we should allow tuning the reset and report intervals separately.
 	// Consider something like rand.Float() > resetFreq/reportFreq here to sample
 	// stat reset periods for reporting.
-	if log.DiagnosticsReportingEnabled.Get(&s.st.SV) && diagnosticsMetricsEnabled.Get(&s.st.SV) {
+	if log.DiagnosticsReportingEnabled.Get(&s.st.SV) {
 		s.reportDiagnostics(running)
 	}
 	if !s.cfg.UseLegacyConnHandling {

--- a/pkg/settings/registry.go
+++ b/pkg/settings/registry.go
@@ -32,7 +32,10 @@ var Registry = make(map[string]Setting)
 // When a setting is removed, it should be added to this list so that we cannot
 // accidentally reuse its name, potentially mis-handling older values.
 var retiredSettings = map[string]struct{}{
-	"diagnostics.reporting.report_metrics": {}, // removed as of 2.0.
+	//removed as of 2.0.
+	"kv.gc.batch_size":                     {},
+	"kv.transaction.max_intents":           {},
+	"diagnostics.reporting.report_metrics": {},
 }
 
 // Register adds a setting to the registry.

--- a/pkg/settings/registry.go
+++ b/pkg/settings/registry.go
@@ -29,8 +29,17 @@ import (
 // read concurrently by different callers.
 var Registry = make(map[string]Setting)
 
+// When a setting is removed, it should be added to this list so that we cannot
+// accidentally reuse its name, potentially mis-handling older values.
+var retiredSettings = map[string]struct{}{
+	"diagnostics.reporting.report_metrics": {}, // removed as of 2.0.
+}
+
 // Register adds a setting to the registry.
 func register(key, desc string, s Setting) {
+	if _, ok := retiredSettings[key]; ok {
+		panic(fmt.Sprintf("cannot reuse previously defined setting name: %s", key))
+	}
 	if _, ok := Registry[key]; ok {
 		panic(fmt.Sprintf("setting already defined: %s", key))
 	}

--- a/pkg/settings/updater.go
+++ b/pkg/settings/updater.go
@@ -78,6 +78,9 @@ func NewUpdater(sv *Values) Updater {
 func (u updater) Set(key, rawValue string, vt string) error {
 	d, ok := Registry[key]
 	if !ok {
+		if _, ok := retiredSettings[key]; ok {
+			return nil
+		}
 		// Likely a new setting this old node doesn't know about.
 		return errors.Errorf("unknown setting '%s'", key)
 	}

--- a/pkg/sqlmigrations/migrations.go
+++ b/pkg/sqlmigrations/migrations.go
@@ -167,16 +167,12 @@ var backwardCompatibleMigrations = []migrationDescriptor{
 		workFn: upgradeTableDescsToInterleavedFormatVersion,
 	},
 	{
-		// Introduced in v2.0.
-		// TODO(benesch): bake this migration into v2.1.
-		name:   "remove cluster setting `kv.gc.batch_size`",
-		workFn: purgeClusterSettingKVGCBatchSize,
+		// Introduced in v2.0 alphas then folded into `retiredSettings`.
+		name: "remove cluster setting `kv.gc.batch_size`",
 	},
 	{
-		// Introduced in v2.0.
-		// TODO(benesch): bake this migration into v2.1.
-		name:   "remove cluster setting `kv.transaction.max_intents`",
-		workFn: purgeClusterSettingKVTransactionMaxIntents,
+		// Introduced in v2.0 alphas then folded into `retiredSettings`.
+		name: "remove cluster setting `kv.transaction.max_intents`",
 	},
 	{
 		// Introduced in v2.0.
@@ -956,16 +952,6 @@ func upgradeTableDescsWithFn(
 		}
 	}
 	return nil
-}
-
-func purgeClusterSettingKVGCBatchSize(ctx context.Context, r runner) error {
-	// This cluster setting has been removed.
-	return runStmtAsRootWithRetry(ctx, r, `DELETE FROM SYSTEM.SETTINGS WHERE name='kv.gc.batch_size'`)
-}
-
-func purgeClusterSettingKVTransactionMaxIntents(ctx context.Context, r runner) error {
-	// This cluster setting has been removed.
-	return runStmtAsRootWithRetry(ctx, r, `DELETE FROM SYSTEM.SETTINGS WHERE name='kv.transaction.max_intents'`)
 }
 
 func addDefaultSystemJobsZoneConfig(ctx context.Context, r runner) error {

--- a/pkg/sqlmigrations/migrations_test.go
+++ b/pkg/sqlmigrations/migrations_test.go
@@ -449,34 +449,6 @@ func (mt *migrationTest) close(ctx context.Context) {
 	backwardCompatibleMigrations = mt.oldMigrations
 }
 
-func TestRemoveClusterSettingKVGCBatchSize(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-	ctx := context.Background()
-
-	mt := makeMigrationTest(ctx, t)
-	defer mt.close(ctx)
-
-	migration := mt.pop(t, "remove cluster setting `kv.gc.batch_size`")
-	mt.start(t, base.TestServerArgs{})
-
-	mt.sqlDB.Exec(t, `INSERT INTO system.settings (name, "lastUpdated", "valueType", value) `+
-		`values('kv.gc.batch_size', NOW(), 'i', '10000')`)
-
-	if err := mt.runMigration(ctx, migration); err != nil {
-		t.Fatal(err)
-	}
-	var n int
-	if err := mt.sqlDB.DB.QueryRow(
-		`SELECT COUNT(*) from system.settings WHERE name = 'kv.gc.batch_size'`,
-	).Scan(&n); err != nil {
-		t.Fatal(err)
-	}
-
-	if n != 0 {
-		t.Fatalf("migration did not clear out cluster setting, got %d rows", n)
-	}
-}
-
 func TestCreateSystemTable(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	ctx := context.Background()


### PR DESCRIPTION
went back and forth on cherrypicking the first commit removing the pointless setting: initially I was reluctant, as it is unlikely we'd include something like it in a hypothetical 2.0.1 patch release, but in conjunction with the other fixes here, it helps simplify the ux for diagnostics / phone-home behavior.