### PR TITLE
opt: Cleanup logical properties and ColList expressions

### DIFF
--- a/pkg/sql/opt/ops/relational.opt
+++ b/pkg/sql/opt/ops/relational.opt
@@ -53,6 +53,11 @@ define Select {
     Filter Expr
 }
 
+# Project modifies the set of columns returned by the input result set. Columns
+# can be removed, reordered, or renamed. In addition, new columns can be
+# synthesized. Projections is a scalar Projections list operator that contains
+# the list of expressions that describe the output columns. The Cols field of
+# the Projections operator provides the indexes of each of the output columns.
 [Relational]
 define Project {
     Input       Expr

--- a/pkg/sql/opt/ops/scalar.opt
+++ b/pkg/sql/opt/ops/scalar.opt
@@ -53,7 +53,8 @@ define Tuple {
 
 # Projections is a set of typed scalar expressions that will become output
 # columns for a containing Project operator. The private Cols field contains
-# the set of column indexes returned by the expression, as a *ColList.
+# the list of column indexes returned by the expression, as a *opt.ColList. It
+# is not legal for Cols to be empty.
 [Scalar]
 define Projections {
     Elems ExprList
@@ -62,7 +63,8 @@ define Projections {
 
 # Aggregations is a set of aggregate expressions that will become output
 # columns for a containing GroupBy operator. The private Cols field contains
-# the set of column indexes returned by the expression, as a *ColList.
+# the list of column indexes returned by the expression, as a *opt.ColList. It
+# is legal for Cols to be empty.
 [Scalar]
 define Aggregations {
     Aggs ExprList
@@ -72,8 +74,8 @@ define Aggregations {
 # Groupings is a set of grouping expressions that will become output columns
 # for a containing GroupBy operator. The GroupBy operator groups its input by
 # the value of these expressions, and may compute aggregates over the groups.
-# The private Cols field contains the set of column indexes returned by the
-# expression, as a *ColList.
+# The private Cols field contains the list of column indexes returned by the
+# expression, as a *opt.ColList. It is legal for Cols to be empty.
 [Scalar]
 define Groupings {
     Elems ExprList

--- a/pkg/sql/opt/opt/factory.og.go
+++ b/pkg/sql/opt/opt/factory.og.go
@@ -61,21 +61,23 @@ type Factory interface {
 	// ConstructProjections constructs an expression for the Projections operator.
 	// Projections is a set of typed scalar expressions that will become output
 	// columns for a containing Project operator. The private Cols field contains
-	// the set of column indexes returned by the expression, as a *ColList.
+	// the list of column indexes returned by the expression, as a *opt.ColList. It
+	// is not legal for Cols to be empty.
 	ConstructProjections(elems ListID, cols PrivateID) GroupID
 
 	// ConstructAggregations constructs an expression for the Aggregations operator.
 	// Aggregations is a set of aggregate expressions that will become output
 	// columns for a containing GroupBy operator. The private Cols field contains
-	// the set of column indexes returned by the expression, as a *ColList.
+	// the list of column indexes returned by the expression, as a *opt.ColList. It
+	// is legal for Cols to be empty.
 	ConstructAggregations(aggs ListID, cols PrivateID) GroupID
 
 	// ConstructGroupings constructs an expression for the Groupings operator.
 	// Groupings is a set of grouping expressions that will become output columns
 	// for a containing GroupBy operator. The GroupBy operator groups its input by
 	// the value of these expressions, and may compute aggregates over the groups.
-	// The private Cols field contains the set of column indexes returned by the
-	// expression, as a *ColList.
+	// The private Cols field contains the list of column indexes returned by the
+	// expression, as a *opt.ColList. It is legal for Cols to be empty.
 	ConstructGroupings(elems ListID, cols PrivateID) GroupID
 
 	// ConstructExists constructs an expression for the Exists operator.
@@ -264,6 +266,11 @@ type Factory interface {
 	ConstructSelect(input GroupID, filter GroupID) GroupID
 
 	// ConstructProject constructs an expression for the Project operator.
+	// Project modifies the set of columns returned by the input result set. Columns
+	// can be removed, reordered, or renamed. In addition, new columns can be
+	// synthesized. Projections is a scalar Projections list operator that contains
+	// the list of expressions that describe the output columns. The Cols field of
+	// the Projections operator provides the indexes of each of the output columns.
 	ConstructProject(input GroupID, projections GroupID) GroupID
 
 	// ConstructInnerJoin constructs an expression for the InnerJoin operator.

--- a/pkg/sql/opt/opt/operator.og.go
+++ b/pkg/sql/opt/opt/operator.og.go
@@ -35,19 +35,21 @@ const (
 
 	// ProjectionsOp is a set of typed scalar expressions that will become output
 	// columns for a containing Project operator. The private Cols field contains
-	// the set of column indexes returned by the expression, as a *ColList.
+	// the list of column indexes returned by the expression, as a *opt.ColList. It
+	// is not legal for Cols to be empty.
 	ProjectionsOp
 
 	// AggregationsOp is a set of aggregate expressions that will become output
 	// columns for a containing GroupBy operator. The private Cols field contains
-	// the set of column indexes returned by the expression, as a *ColList.
+	// the list of column indexes returned by the expression, as a *opt.ColList. It
+	// is legal for Cols to be empty.
 	AggregationsOp
 
 	// GroupingsOp is a set of grouping expressions that will become output columns
 	// for a containing GroupBy operator. The GroupBy operator groups its input by
 	// the value of these expressions, and may compute aggregates over the groups.
-	// The private Cols field contains the set of column indexes returned by the
-	// expression, as a *ColList.
+	// The private Cols field contains the list of column indexes returned by the
+	// expression, as a *opt.ColList. It is legal for Cols to be empty.
 	GroupingsOp
 
 	ExistsOp
@@ -184,6 +186,11 @@ const (
 	// predicate expression. Rows which do not match the filter are discarded.
 	SelectOp
 
+	// ProjectOp modifies the set of columns returned by the input result set. Columns
+	// can be removed, reordered, or renamed. In addition, new columns can be
+	// synthesized. Projections is a scalar Projections list operator that contains
+	// the list of expressions that describe the output columns. The Cols field of
+	// the Projections operator provides the indexes of each of the output columns.
 	ProjectOp
 
 	// InnerJoinOp creates a result set that combines columns from its left and right

--- a/pkg/sql/opt/xform/expr.go
+++ b/pkg/sql/opt/xform/expr.go
@@ -155,6 +155,10 @@ func (ev ExprView) String() string {
 	return tp.String()
 }
 
+func (ev ExprView) lookupChildGroup(nth int) *memoGroup {
+	return ev.mem.lookupGroup(ev.ChildGroup(nth))
+}
+
 func (ev ExprView) privateID() opt.PrivateID {
 	return privateLookup[ev.op](ev)
 }
@@ -240,8 +244,8 @@ func (ev ExprView) formatRelational(tp treeprinter.Node) {
 		formatColList(ev.mem, logicalProps, *ev.Private().(*opt.ColList), tp)
 
 	default:
-		// Write the output columns. Fall back to writing output columns in column
-		// index order, with best guess label.
+		// Fall back to writing output columns in column index order, with best
+		// guess label.
 		logicalProps.formatOutputCols(ev.mem, tp)
 	}
 

--- a/pkg/sql/opt/xform/expr.og.go
+++ b/pkg/sql/opt/xform/expr.og.go
@@ -2934,7 +2934,8 @@ func (m *memoExpr) asTuple() *tupleExpr {
 
 // projectionsExpr is a set of typed scalar expressions that will become output
 // columns for a containing Project operator. The private Cols field contains
-// the set of column indexes returned by the expression, as a *ColList.
+// the list of column indexes returned by the expression, as a *opt.ColList. It
+// is not legal for Cols to be empty.
 type projectionsExpr memoExpr
 
 func makeProjectionsExpr(elems opt.ListID, cols opt.PrivateID) projectionsExpr {
@@ -2962,7 +2963,8 @@ func (m *memoExpr) asProjections() *projectionsExpr {
 
 // aggregationsExpr is a set of aggregate expressions that will become output
 // columns for a containing GroupBy operator. The private Cols field contains
-// the set of column indexes returned by the expression, as a *ColList.
+// the list of column indexes returned by the expression, as a *opt.ColList. It
+// is legal for Cols to be empty.
 type aggregationsExpr memoExpr
 
 func makeAggregationsExpr(aggs opt.ListID, cols opt.PrivateID) aggregationsExpr {
@@ -2991,8 +2993,8 @@ func (m *memoExpr) asAggregations() *aggregationsExpr {
 // groupingsExpr is a set of grouping expressions that will become output columns
 // for a containing GroupBy operator. The GroupBy operator groups its input by
 // the value of these expressions, and may compute aggregates over the groups.
-// The private Cols field contains the set of column indexes returned by the
-// expression, as a *ColList.
+// The private Cols field contains the list of column indexes returned by the
+// expression, as a *opt.ColList. It is legal for Cols to be empty.
 type groupingsExpr memoExpr
 
 func makeGroupingsExpr(elems opt.ListID, cols opt.PrivateID) groupingsExpr {
@@ -4281,6 +4283,11 @@ func (m *memoExpr) asSelect() *selectExpr {
 	return (*selectExpr)(m)
 }
 
+// projectExpr modifies the set of columns returned by the input result set. Columns
+// can be removed, reordered, or renamed. In addition, new columns can be
+// synthesized. Projections is a scalar Projections list operator that contains
+// the list of expressions that describe the output columns. The Cols field of
+// the Projections operator provides the indexes of each of the output columns.
 type projectExpr memoExpr
 
 func makeProjectExpr(input opt.GroupID, projections opt.GroupID) projectExpr {

--- a/pkg/sql/opt/xform/factory.og.go
+++ b/pkg/sql/opt/xform/factory.og.go
@@ -135,7 +135,8 @@ func (_f *factory) ConstructTuple(
 // ConstructProjections constructs an expression for the Projections operator.
 // Projections is a set of typed scalar expressions that will become output
 // columns for a containing Project operator. The private Cols field contains
-// the set of column indexes returned by the expression, as a *ColList.
+// the list of column indexes returned by the expression, as a *opt.ColList. It
+// is not legal for Cols to be empty.
 func (_f *factory) ConstructProjections(
 	elems opt.ListID,
 	cols opt.PrivateID,
@@ -156,7 +157,8 @@ func (_f *factory) ConstructProjections(
 // ConstructAggregations constructs an expression for the Aggregations operator.
 // Aggregations is a set of aggregate expressions that will become output
 // columns for a containing GroupBy operator. The private Cols field contains
-// the set of column indexes returned by the expression, as a *ColList.
+// the list of column indexes returned by the expression, as a *opt.ColList. It
+// is legal for Cols to be empty.
 func (_f *factory) ConstructAggregations(
 	aggs opt.ListID,
 	cols opt.PrivateID,
@@ -178,8 +180,8 @@ func (_f *factory) ConstructAggregations(
 // Groupings is a set of grouping expressions that will become output columns
 // for a containing GroupBy operator. The GroupBy operator groups its input by
 // the value of these expressions, and may compute aggregates over the groups.
-// The private Cols field contains the set of column indexes returned by the
-// expression, as a *ColList.
+// The private Cols field contains the list of column indexes returned by the
+// expression, as a *opt.ColList. It is legal for Cols to be empty.
 func (_f *factory) ConstructGroupings(
 	elems opt.ListID,
 	cols opt.PrivateID,
@@ -1291,6 +1293,11 @@ func (_f *factory) ConstructSelect(
 }
 
 // ConstructProject constructs an expression for the Project operator.
+// Project modifies the set of columns returned by the input result set. Columns
+// can be removed, reordered, or renamed. In addition, new columns can be
+// synthesized. Projections is a scalar Projections list operator that contains
+// the list of expressions that describe the output columns. The Cols field of
+// the Projections operator provides the indexes of each of the output columns.
 func (_f *factory) ConstructProject(
 	input opt.GroupID,
 	projections opt.GroupID,

--- a/pkg/sql/opt/xform/memo.go
+++ b/pkg/sql/opt/xform/memo.go
@@ -135,7 +135,6 @@ func newMemo(catalog optbase.Catalog) *memo {
 	}
 
 	m.listStorage.init()
-	m.logPropsFactory.init(m)
 	return m
 }
 

--- a/pkg/sql/opt/xform/testdata/logical_props
+++ b/pkg/sql/opt/xform/testdata/logical_props
@@ -1,3 +1,18 @@
+exec-ddl
+CREATE TABLE a (x INT PRIMARY KEY, y INT)
+----
+table a
+  x int NOT NULL
+  y int NULL
+
+exec-ddl
+CREATE TABLE b (x INT, z INT NOT NULL, FOREIGN KEY (x) REFERENCES a (x))
+----
+table b
+  x int NULL
+  z int NOT NULL
+  rowid int NOT NULL (hidden)
+
 props
 SELECT * FROM a
 ----
@@ -18,3 +33,10 @@ SELECT b.z, false FROM b
 relational
  ├── columns: b.z:2 column3:3
  └── not null: b.z:2
+
+props
+SELECT a.y, SUM(a.x), False FROM a GROUP BY a.y
+----
+relational
+ ├── columns: a.y:2 column3:3 column4:4
+ └── not null:

--- a/pkg/sql/opt/xform/testdata/typing
+++ b/pkg/sql/opt/xform/testdata/typing
@@ -1,3 +1,18 @@
+exec-ddl
+CREATE TABLE a (x INT PRIMARY KEY, y INT)
+----
+table a
+  x int NOT NULL
+  y int NULL
+
+exec-ddl
+CREATE TABLE b (x INT, z INT NOT NULL, FOREIGN KEY (x) REFERENCES a (x))
+----
+table b
+  x int NULL
+  z int NOT NULL
+  rowid int NOT NULL (hidden)
+
 # Variable
 build
 SELECT a.x FROM a


### PR DESCRIPTION
This PR contains some miscellaneous cleanup items:
  - Improve comments for several ColList operators
  - Update LogicalPropsFactory to be empty struct and cleanup code a bit
  - Update logprop and typing tests to use exec-ddl to create schema

Release note: None