### PR TITLE
rfcs: mark zone config RFC as obsolete in light of recent changes

### DIFF
--- a/docs/RFCS/20160706_expressive_zone_config.md
+++ b/docs/RFCS/20160706_expressive_zone_config.md
@@ -1,11 +1,15 @@
 - Feature Name: Expressive ZoneConfig
-- Status: completed
+- Status: obsolete
 - Start Date: 2016-07-06
 - Authors: @d4l3k
 - RFC PR: [#7660](https://github.com/cockroachdb/cockroach/pull/7660)
 - Cockroach Issue: [#4868](https://github.com/cockroachdb/cockroach/issues/4868)
 
 # Summary
+
+This document has been made partially obsolete by more recent changes to
+ZoneConfig constraints. For the latest information, please see [the
+docs](https://www.cockroachlabs.com/docs/stable/configure-replication-zones.html).
 
 # Motivation
 


### PR DESCRIPTION
It still has some relevancy, but now that positive constraints are
deprecated and zone configs can be expressed per-replica, it isn't a
great authoritative source on the subject.

Release note: None