### PR TITLE
sql: fix CREATE TABLE AS with subqueries, also cure major wart

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/create_as
+++ b/pkg/sql/logictest/testdata/logic_test/create_as
@@ -98,3 +98,9 @@ CREATE TABLE foo3 (x) AS VALUES (1), (NULL); SELECT * FROM foo3 ORDER BY x
 ----
 NULL
 1
+
+# Check that CREATE TABLE AS can use subqueries (#23002)
+query B
+CREATE TABLE foo4 (x) AS SELECT EXISTS(SELECT * FROM foo3 WHERE x IS NULL); SELECT * FROM foo4
+----
+true

--- a/pkg/sql/logictest/testdata/logic_test/show_trace
+++ b/pkg/sql/logictest/testdata/logic_test/show_trace
@@ -87,31 +87,50 @@ SELECT span, operation, message FROM [SHOW KV TRACE FOR SESSION] WHERE message N
 # More KV operations.
 
 query ITT
+SET tracing=kv;
+CREATE TABLE t.kv(k INT PRIMARY KEY, v INT);
+SET tracing=off;
 SELECT span, operation, regexp_replace(message, 'wall_time:\d+', 'wall_time:...') as message
-  FROM [SHOW KV TRACE FOR CREATE TABLE t.kv(k INT PRIMARY KEY, v INT)] WHERE message NOT LIKE '%Z/%'
+  FROM [SHOW KV TRACE FOR SESSION] WHERE message NOT LIKE '%Z/%'
 ----
-2   dist sender    querying next range at /Table/2/1/51/"kv"/3/1
-2   dist sender    r1: sending batch 1 Get to (n1,s1):1
-4   dist sender    querying next range at /System/"desc-idgen"
-4   dist sender    r1: sending batch 1 Inc to (n1,s1):1
-1   starting plan  CPut /Table/2/1/51/"kv"/3/1 -> 52
-1   starting plan  CPut /Table/3/1/52/2/1 -> table:<name:"kv" id:52 parent_id:51 version:1 up_version:false modification_time:<wall_time:... > columns:<name:"k" id:1 type:<semantic_type:INT width:0 precision:0 visible_type:NONE > nullable:false hidden:false > columns:<name:"v" id:2 type:<semantic_type:INT width:0 precision:0 visible_type:NONE > nullable:true hidden:false > next_column_id:3 families:<name:"primary" id:0 column_names:"k" column_names:"v" column_ids:1 column_ids:2 default_column_id:2 > next_family_id:1 primary_index:<name:"primary" id:1 unique:true column_names:"k" column_directions:ASC column_ids:1 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION > interleave:<> partitioning:<num_columns:0 > type:FORWARD > next_index_id:2 privileges:<users:<user:"admin" privileges:2 > users:<user:"root" privileges:2 > > next_mutation_id:1 format_version:3 state:PUBLIC view_query:"" drop_time:0 replacement_of:<id:0 time:<> > audit_mode:DISABLED >
-6   dist sender    querying next range at /Table/SystemConfigSpan/Start
-6   dist sender    r1: sending batch 2 CPut, 1 BeginTxn to (n1,s1):1
-9   dist sender    querying next range at /Table/3/1/51/2/1
-9   dist sender    r1: sending batch 1 Get to (n1,s1):1
-11  dist sender    querying next range at /Table/2/1/0/"system"/3/1
-11  dist sender    r1: sending batch 1 Get to (n1,s1):1
-13  dist sender    querying next range at /Table/3/1/1/2/1
-13  dist sender    r1: sending batch 1 Get to (n1,s1):1
-15  dist sender    querying next range at /Table/2/1/1/"eventlog"/3/1
-15  dist sender    r1: sending batch 1 Get to (n1,s1):1
-17  dist sender    querying next range at /Table/3/1/12/2/1
-17  dist sender    r1: sending batch 1 Get to (n1,s1):1
-19  dist sender    querying next range at /Table/3/1/1/2/1
-19  dist sender    r1: sending batch 1 Get to (n1,s1):1
-21  dist sender    r1: sending batch 5 CPut to (n1,s1):1
+3   dist sender  querying next range at /Table/2/1/0/"test"/3/1
+3   dist sender  r1: sending batch 1 Get to (n1,s1):1
+5   dist sender  querying next range at /Table/3/1/50/2/1
+5   dist sender  r1: sending batch 1 Get to (n1,s1):1
+7   dist sender  querying next range at /Table/2/1/0/"t"/3/1
+7   dist sender  r1: sending batch 1 Get to (n1,s1):1
+9   dist sender  querying next range at /Table/3/1/51/2/1
+9   dist sender  r1: sending batch 1 Get to (n1,s1):1
+11  dist sender  querying next range at /Table/2/1/51/"kv"/3/1
+11  dist sender  r1: sending batch 1 Get to (n1,s1):1
+13  dist sender  querying next range at /System/"desc-idgen"
+13  dist sender  r1: sending batch 1 Inc to (n1,s1):1
+2   sql txn      CPut /Table/2/1/51/"kv"/3/1 -> 52
+2   sql txn      CPut /Table/3/1/52/2/1 -> table:<name:"kv" id:52 parent_id:51 version:1 up_version:false modification_time:<wall_time:... > columns:<name:"k" id:1 type:<semantic_type:INT width:0 precision:0 visible_type:NONE > nullable:false hidden:false > columns:<name:"v" id:2 type:<semantic_type:INT width:0 precision:0 visible_type:NONE > nullable:true hidden:false > next_column_id:3 families:<name:"primary" id:0 column_names:"k" column_names:"v" column_ids:1 column_ids:2 default_column_id:2 > next_family_id:1 primary_index:<name:"primary" id:1 unique:true column_names:"k" column_directions:ASC column_ids:1 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION > interleave:<> partitioning:<num_columns:0 > type:FORWARD > next_index_id:2 privileges:<users:<user:"admin" privileges:2 > users:<user:"root" privileges:2 > > next_mutation_id:1 format_version:3 state:PUBLIC view_query:"" drop_time:0 replacement_of:<id:0 time:<> > audit_mode:DISABLED >
+15  dist sender  querying next range at /Table/SystemConfigSpan/Start
+15  dist sender  r1: sending batch 2 CPut, 1 BeginTxn to (n1,s1):1
+18  dist sender  querying next range at /Table/3/1/51/2/1
+18  dist sender  r1: sending batch 1 Get to (n1,s1):1
+20  dist sender  querying next range at /Table/2/1/0/"system"/3/1
+20  dist sender  r1: sending batch 1 Get to (n1,s1):1
+22  dist sender  querying next range at /Table/3/1/1/2/1
+22  dist sender  r1: sending batch 1 Get to (n1,s1):1
+24  dist sender  querying next range at /Table/2/1/1/"eventlog"/3/1
+24  dist sender  r1: sending batch 1 Get to (n1,s1):1
+26  dist sender  querying next range at /Table/3/1/12/2/1
+26  dist sender  r1: sending batch 1 Get to (n1,s1):1
+28  dist sender  querying next range at /Table/3/1/1/2/1
+28  dist sender  r1: sending batch 1 Get to (n1,s1):1
+30  dist sender  r1: sending batch 5 CPut to (n1,s1):1
+32  dist sender  querying next range at /Table/SystemConfigSpan/Start
+32  dist sender  r1: sending batch 1 EndTxn to (n1,s1):1
 
+# We avoid SHOW KV TRACE FOR <stmt> here, because that would make the
+# ensuing trace especially chatty, as it traces the index backfill at
+# the end of the implicit transaction. A chatty trace could be OK in
+# tests, however the backfill also incur job table traffic which has a
+# timestamp index, and we can't use (non-deterministic) timestamp
+# values in expected values.
 query ITT
 SELECT span, operation, regexp_replace(regexp_replace(message, 'mutationJobs:<[^>]*>', 'mutationJobs:<...>'), 'wall_time:\d+', 'wall_time:...') as message
   FROM [SHOW KV TRACE FOR CREATE UNIQUE INDEX woo ON t.kv(v)] WHERE message NOT LIKE '%Z/%'
@@ -144,13 +163,17 @@ SELECT span, operation, regexp_replace(regexp_replace(message, 'mutationJobs:<[^
 27  dist sender    r1: sending batch 5 CPut to (n1,s1):1
 
 query ITT
-SELECT span, operation, message FROM [SHOW KV TRACE FOR INSERT INTO t.kv(k, v) VALUES (1,2)]
+SET tracing=kv;
+INSERT INTO t.kv(k, v) VALUES (1,2);
+SET tracing=off;
+SELECT span, operation, message FROM [SHOW KV TRACE FOR SESSION]
 ----
-0  sql txn         CPut /Table/52/1/1/0 -> /TUPLE/2:2:Int/2
-2  consuming rows  output row: []
-3  dist sender     querying next range at /Table/52/1/1/0
-3  dist sender     r1: sending batch 1 CPut, 1 BeginTxn, 1 InitPut to (n1,s1):1
+2  sql txn      CPut /Table/52/1/1/0 -> /TUPLE/2:2:Int/2
+3  dist sender  querying next range at /Table/52/1/1/0
+3  dist sender  r1: sending batch 1 CPut, 1 BeginTxn, 1 EndTxn, 1 InitPut to (n1,s1):1
 
+
+# We use SHOW KV TRACE FOR <stmt> here to reveal how the error shows up in traces.
 query ITT
 SELECT span, operation, message FROM [SHOW KV TRACE FOR INSERT INTO t.kv(k, v) VALUES (1,2)]
 ----
@@ -170,28 +193,33 @@ SELECT span, operation, message FROM [SHOW KV TRACE FOR INSERT INTO t.kv(k, v) V
 2  consuming rows  execution failed: duplicate key value (v)=(2) violates unique constraint "woo"
 
 query ITT
-SELECT span, operation, message FROM [SHOW KV TRACE FOR UPSERT INTO t.kv(k, v) VALUES (2,3)]
+SET tracing=kv;
+UPSERT INTO t.kv(k, v) VALUES (2,3);
+SET tracing=off;
+SELECT span, operation, message FROM [SHOW KV TRACE FOR SESSION]
 ----
-2  consuming rows  output row: []
-0  sql txn         Scan /Table/52/1/{2-3}
-3  dist sender     querying next range at /Table/52/1/2
-3  dist sender     r1: sending batch 1 Scan to (n1,s1):1
-0  sql txn         CPut /Table/52/1/2/0 -> /TUPLE/2:2:Int/3
-5  dist sender     querying next range at /Table/52/1/2/0
-5  dist sender     r1: sending batch 1 CPut, 1 BeginTxn, 1 InitPut to (n1,s1):1
+2  sql txn      Scan /Table/52/1/{2-3}
+3  dist sender  querying next range at /Table/52/1/2
+3  dist sender  r1: sending batch 1 Scan to (n1,s1):1
+2  sql txn      CPut /Table/52/1/2/0 -> /TUPLE/2:2:Int/3
+5  dist sender  querying next range at /Table/52/1/2/0
+5  dist sender  r1: sending batch 1 CPut, 1 BeginTxn, 1 EndTxn, 1 InitPut to (n1,s1):1
 
 query ITT
-SELECT span, operation, message FROM [SHOW KV TRACE FOR UPSERT INTO t.kv(k, v) VALUES (1,2)]
+SET tracing=kv;
+UPSERT INTO t.kv(k, v) VALUES (1,2);
+SET tracing=off;
+SELECT span, operation, message FROM [SHOW KV TRACE FOR SESSION]
 ----
-2  consuming rows  output row: []
-0  sql txn         Scan /Table/52/1/{1-2}
-3  dist sender     querying next range at /Table/52/1/1
-3  dist sender     r1: sending batch 1 Scan to (n1,s1):1
-0  sql txn         fetched: /kv/primary/1/v -> /2
-0  sql txn         Put /Table/52/1/1/0 -> /TUPLE/2:2:Int/2
-5  dist sender     querying next range at /Table/52/1/1/0
-5  dist sender     r1: sending batch 1 Put, 1 BeginTxn to (n1,s1):1
+2  sql txn      Scan /Table/52/1/{1-2}
+3  dist sender  querying next range at /Table/52/1/1
+3  dist sender  r1: sending batch 1 Scan to (n1,s1):1
+2  sql txn      fetched: /kv/primary/1/v -> /2
+2  sql txn      Put /Table/52/1/1/0 -> /TUPLE/2:2:Int/2
+5  dist sender  querying next range at /Table/52/1/1/0
+5  dist sender  r1: sending batch 1 Put, 1 BeginTxn, 1 EndTxn to (n1,s1):1
 
+# We use SHOW KV TRACE FOR <stmt> here to reveal how the error shows up.
 query ITT
 SELECT span, operation, message FROM [SHOW KV TRACE FOR UPSERT INTO t.kv(k, v) VALUES (2,2)]
 ----
@@ -208,68 +236,100 @@ SELECT span, operation, message FROM [SHOW KV TRACE FOR UPSERT INTO t.kv(k, v) V
 2  consuming rows  execution failed: duplicate key value (v)=(2) violates unique constraint "woo"
 
 query ITT
+SET tracing=kv;
+CREATE TABLE t.kv2 AS TABLE t.kv;
+SET tracing=off;
 SELECT span, operation, regexp_replace(regexp_replace(message, 'wall_time:\d+', 'wall_time:...'), '\d\d\d\d\d+', '...PK...') as message
-  FROM [SHOW KV TRACE FOR CREATE TABLE t.kv2 AS TABLE t.kv] WHERE message NOT LIKE '%Z/%'
+  FROM [SHOW KV TRACE FOR SESSION] WHERE message NOT LIKE '%Z/%'
 ----
-2   dist sender     querying next range at /Table/2/1/51/"kv2"/3/1
-2   dist sender     r1: sending batch 1 Get to (n1,s1):1
-4   dist sender     querying next range at /System/"desc-idgen"
-4   dist sender     r1: sending batch 1 Inc to (n1,s1):1
-1   starting plan   CPut /Table/2/1/51/"kv2"/3/1 -> 53
-1   starting plan   CPut /Table/3/1/53/2/1 -> table:<name:"kv2" id:53 parent_id:51 version:1 up_version:false modification_time:<wall_time:... > columns:<name:"k" id:1 type:<semantic_type:INT width:0 precision:0 visible_type:NONE > nullable:true hidden:false > columns:<name:"v" id:2 type:<semantic_type:INT width:0 precision:0 visible_type:NONE > nullable:true hidden:false > columns:<name:"rowid" id:3 type:<semantic_type:INT width:0 precision:0 visible_type:NONE > nullable:false default_expr:"unique_rowid()" hidden:true > next_column_id:4 families:<name:"primary" id:0 column_names:"k" column_names:"v" column_names:"rowid" column_ids:1 column_ids:2 column_ids:3 default_column_id:0 > next_family_id:1 primary_index:<name:"primary" id:1 unique:true column_names:"rowid" column_directions:ASC column_ids:3 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION > interleave:<> partitioning:<num_columns:0 > type:FORWARD > next_index_id:2 privileges:<users:<user:"admin" privileges:2 > users:<user:"root" privileges:2 > > next_mutation_id:1 format_version:3 state:PUBLIC view_query:"" drop_time:0 replacement_of:<id:0 time:<> > audit_mode:DISABLED >
-6   dist sender     querying next range at /Table/SystemConfigSpan/Start
-6   dist sender     r1: sending batch 2 CPut, 1 BeginTxn to (n1,s1):1
-9   dist sender     querying next range at /Table/3/1/51/2/1
-9   dist sender     r1: sending batch 1 Get to (n1,s1):1
-11  dist sender     querying next range at /Table/2/1/0/"system"/3/1
-11  dist sender     r1: sending batch 1 Get to (n1,s1):1
-13  dist sender     querying next range at /Table/3/1/1/2/1
-13  dist sender     r1: sending batch 1 Get to (n1,s1):1
-15  dist sender     querying next range at /Table/2/1/1/"eventlog"/3/1
-15  dist sender     r1: sending batch 1 Get to (n1,s1):1
-17  dist sender     querying next range at /Table/3/1/12/2/1
-17  dist sender     r1: sending batch 1 Get to (n1,s1):1
-19  dist sender     querying next range at /Table/3/1/1/2/1
-19  dist sender     r1: sending batch 1 Get to (n1,s1):1
-21  dist sender     r1: sending batch 5 CPut to (n1,s1):1
-1   starting plan   Scan /Table/52/{1-2}
-23  dist sender     querying next range at /Table/52/1
-23  dist sender     r1: sending batch 1 Scan to (n1,s1):1
-1   starting plan   fetched: /kv/primary/1/v -> /2
-1   starting plan   CPut /Table/53/1/...PK.../0 -> /TUPLE/1:1:Int/1/1:2:Int/2
-1   starting plan   fetched: /kv/primary/2/v -> /3
-1   starting plan   CPut /Table/53/1/...PK.../0 -> /TUPLE/1:1:Int/2/1:2:Int/3
-25  dist sender     querying next range at /Table/SystemConfigSpan/Start
-25  dist sender     r1: sending batch 2 CPut, 1 EndTxn to (n1,s1):1
-27  consuming rows  fast path - rows affected: 2
+3   dist sender  querying next range at /Table/2/1/0/"test"/3/1
+3   dist sender  r1: sending batch 1 Get to (n1,s1):1
+5   dist sender  querying next range at /Table/3/1/50/2/1
+5   dist sender  r1: sending batch 1 Get to (n1,s1):1
+7   dist sender  querying next range at /Table/2/1/0/"t"/3/1
+7   dist sender  r1: sending batch 1 Get to (n1,s1):1
+9   dist sender  querying next range at /Table/3/1/51/2/1
+9   dist sender  r1: sending batch 1 Get to (n1,s1):1
+11  dist sender  querying next range at /Table/2/1/51/"kv2"/3/1
+11  dist sender  r1: sending batch 1 Get to (n1,s1):1
+13  dist sender  querying next range at /System/"desc-idgen"
+13  dist sender  r1: sending batch 1 Inc to (n1,s1):1
+2   sql txn      CPut /Table/2/1/51/"kv2"/3/1 -> 53
+2   sql txn      CPut /Table/3/1/53/2/1 -> table:<name:"kv2" id:53 parent_id:51 version:1 up_version:false modification_time:<wall_time:... > columns:<name:"k" id:1 type:<semantic_type:INT width:0 precision:0 visible_type:NONE > nullable:true hidden:false > columns:<name:"v" id:2 type:<semantic_type:INT width:0 precision:0 visible_type:NONE > nullable:true hidden:false > columns:<name:"rowid" id:3 type:<semantic_type:INT width:0 precision:0 visible_type:NONE > nullable:false default_expr:"unique_rowid()" hidden:true > next_column_id:4 families:<name:"primary" id:0 column_names:"k" column_names:"v" column_names:"rowid" column_ids:1 column_ids:2 column_ids:3 default_column_id:0 > next_family_id:1 primary_index:<name:"primary" id:1 unique:true column_names:"rowid" column_directions:ASC column_ids:3 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION > interleave:<> partitioning:<num_columns:0 > type:FORWARD > next_index_id:2 privileges:<users:<user:"admin" privileges:2 > users:<user:"root" privileges:2 > > next_mutation_id:1 format_version:3 state:PUBLIC view_query:"" drop_time:0 replacement_of:<id:0 time:<> > audit_mode:DISABLED >
+15  dist sender  querying next range at /Table/SystemConfigSpan/Start
+15  dist sender  r1: sending batch 2 CPut, 1 BeginTxn to (n1,s1):1
+18  dist sender  querying next range at /Table/3/1/51/2/1
+18  dist sender  r1: sending batch 1 Get to (n1,s1):1
+20  dist sender  querying next range at /Table/2/1/0/"system"/3/1
+20  dist sender  r1: sending batch 1 Get to (n1,s1):1
+22  dist sender  querying next range at /Table/3/1/1/2/1
+22  dist sender  r1: sending batch 1 Get to (n1,s1):1
+24  dist sender  querying next range at /Table/2/1/1/"eventlog"/3/1
+24  dist sender  r1: sending batch 1 Get to (n1,s1):1
+26  dist sender  querying next range at /Table/3/1/12/2/1
+26  dist sender  r1: sending batch 1 Get to (n1,s1):1
+28  dist sender  querying next range at /Table/3/1/1/2/1
+28  dist sender  r1: sending batch 1 Get to (n1,s1):1
+30  dist sender  r1: sending batch 5 CPut to (n1,s1):1
+2   sql txn      Scan /Table/52/{1-2}
+32  dist sender  querying next range at /Table/52/1
+32  dist sender  r1: sending batch 1 Scan to (n1,s1):1
+2   sql txn      fetched: /kv/primary/1/v -> /2
+2   sql txn      CPut /Table/53/1/...PK.../0 -> /TUPLE/1:1:Int/1/1:2:Int/2
+2   sql txn      fetched: /kv/primary/2/v -> /3
+2   sql txn      CPut /Table/53/1/...PK.../0 -> /TUPLE/1:1:Int/2/1:2:Int/3
+34  dist sender  querying next range at /Table/SystemConfigSpan/Start
+34  dist sender  r1: sending batch 2 CPut, 1 EndTxn to (n1,s1):1
 
 query ITT
-SELECT span, operation, regexp_replace(message, '\d\d\d\d\d+', '...PK...') as message
-  FROM [SHOW KV TRACE FOR UPDATE t.kv2 SET v = v + 2]
+SET tracing=kv;
+UPDATE t.kv2 SET v = v + 2;
+SET tracing=off;
+SELECT span, operation, regexp_replace(message, '(\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d\.)?\d\d\d\d\d+', '...PK...') as message
+  FROM [SHOW KV TRACE FOR SESSION] WHERE message NOT LIKE '%Z/%'
 ----
-0  sql txn         Scan /Table/53/{1-2}
-3  dist sender     querying next range at /Table/53/1
-3  dist sender     r1: sending batch 1 Scan to (n1,s1):1
-0  sql txn         fetched: /kv2/primary/...PK.../k/v -> /1/2
-0  sql txn         Put /Table/53/1/...PK.../0 -> /TUPLE/1:1:Int/1/1:2:Int/4
-2  consuming rows  output row: [...PK... 1 4]
-0  sql txn         fetched: /kv2/primary/...PK.../k/v -> /2/3
-0  sql txn         Put /Table/53/1/...PK.../0 -> /TUPLE/1:1:Int/2/1:2:Int/5
-2  consuming rows  output row: [...PK... 2 5]
-5  dist sender     querying next range at /Table/53/1/...PK.../0
-5  dist sender     r1: sending batch 2 Put, 1 BeginTxn to (n1,s1):1
+3   dist sender  querying next range at /Table/2/1/51/"kv2"/3/1
+3   dist sender  r1: sending batch 1 Get to (n1,s1):1
+5   dist sender  querying next range at /Table/3/1/53/2/1
+5   dist sender  r1: sending batch 1 Get to (n1,s1):1
+7   dist sender  querying next range at /Table/2/1/0/"system"/3/1
+7   dist sender  r1: sending batch 1 Get to (n1,s1):1
+9   dist sender  querying next range at /Table/3/1/1/2/1
+9   dist sender  r1: sending batch 1 Get to (n1,s1):1
+11  dist sender  querying next range at /Table/2/1/1/"lease"/3/1
+11  dist sender  r1: sending batch 1 Get to (n1,s1):1
+13  dist sender  querying next range at /Table/3/1/11/2/1
+13  dist sender  r1: sending batch 1 Get to (n1,s1):1
+15  dist sender  querying next range at /Table/3/1/1/2/1
+15  dist sender  r1: sending batch 1 Get to (n1,s1):1
+17  dist sender  r1: sending batch 1 CPut, 1 BeginTxn to (n1,s1):1
+20  dist sender  r1: sending batch 1 EndTxn to (n1,s1):1
+2   sql txn      Scan /Table/53/{1-2}
+22  dist sender  querying next range at /Table/53/1
+22  dist sender  r1: sending batch 1 Scan to (n1,s1):1
+2   sql txn      fetched: /kv2/primary/...PK.../k/v -> /1/2
+2   sql txn      Put /Table/53/1/...PK.../0 -> /TUPLE/1:1:Int/1/1:2:Int/4
+2   sql txn      fetched: /kv2/primary/...PK.../k/v -> /2/3
+2   sql txn      Put /Table/53/1/...PK.../0 -> /TUPLE/1:1:Int/2/1:2:Int/5
+24  dist sender  querying next range at /Table/53/1/...PK.../0
+24  dist sender  r1: sending batch 2 Put, 1 BeginTxn, 1 EndTxn to (n1,s1):1
 
 query ITT
-SELECT span, operation, message FROM [SHOW KV TRACE FOR DELETE FROM t.kv2]
+SET tracing=kv;
+DELETE FROM t.kv2;
+SET tracing=off;
+SELECT span, operation, message FROM [SHOW KV TRACE FOR SESSION]
 ----
-1  starting plan   Scan /Table/53/{1-2}
-2  dist sender     querying next range at /Table/53/1
-2  dist sender     r1: sending batch 1 Scan to (n1,s1):1
-1  starting plan   DelRange /Table/53/1 - /Table/53/2
-4  dist sender     querying next range at /Table/53/1
-4  dist sender     r1: sending batch 1 DelRng, 1 BeginTxn to (n1,s1):1
-7  consuming rows  fast path - rows affected: 2
+2  sql txn      Scan /Table/53/{1-2}
+3  dist sender  querying next range at /Table/53/1
+3  dist sender  r1: sending batch 1 Scan to (n1,s1):1
+2  sql txn      DelRange /Table/53/1 - /Table/53/2
+5  dist sender  querying next range at /Table/53/1
+5  dist sender  r1: sending batch 1 DelRng, 1 BeginTxn, 1 EndTxn to (n1,s1):1
 
+# Like for CREATE UNIQUE INDEX ABOVE, we use SHOW KV TRACE FOR <stmt>
+# here to reduce the chattiness of the trace and avoid showing
+# non-deterministic accesses to the lease and job tables.
 query ITT
 SELECT span, operation, regexp_replace(regexp_replace(message, 'wall_time:\d+', 'wall_time:...'), 'drop_time:\d+', 'drop_time:...') as message
   FROM [SHOW KV TRACE FOR DROP TABLE t.kv2] WHERE message NOT LIKE '%Z/%'
@@ -300,22 +360,26 @@ SELECT span, operation, regexp_replace(regexp_replace(message, 'wall_time:\d+', 
 25  dist sender    r1: sending batch 5 CPut to (n1,s1):1
 
 query ITT
-SELECT span, operation, message FROM [SHOW KV TRACE FOR DELETE FROM t.kv]
+SET tracing=kv;
+DELETE FROM t.kv;
+SET tracing=off;
+SELECT span, operation, message FROM [SHOW KV TRACE FOR SESSION]
 ----
-0  sql txn         Scan /Table/52/{1-2}
-3  dist sender     querying next range at /Table/52/1
-3  dist sender     r1: sending batch 1 Scan to (n1,s1):1
-0  sql txn         fetched: /kv/primary/1/v -> /2
-0  sql txn         Del /Table/52/2/2/0
-0  sql txn         Del /Table/52/1/1/0
-2  consuming rows  output row: [1 2]
-0  sql txn         fetched: /kv/primary/2/v -> /3
-0  sql txn         Del /Table/52/2/3/0
-0  sql txn         Del /Table/52/1/2/0
-2  consuming rows  output row: [2 3]
-5  dist sender     querying next range at /Table/52/1/1/0
-5  dist sender     r1: sending batch 4 Del, 1 BeginTxn to (n1,s1):1
+2  sql txn      Scan /Table/52/{1-2}
+3  dist sender  querying next range at /Table/52/1
+3  dist sender  r1: sending batch 1 Scan to (n1,s1):1
+2  sql txn      fetched: /kv/primary/1/v -> /2
+2  sql txn      Del /Table/52/2/2/0
+2  sql txn      Del /Table/52/1/1/0
+2  sql txn      fetched: /kv/primary/2/v -> /3
+2  sql txn      Del /Table/52/2/3/0
+2  sql txn      Del /Table/52/1/2/0
+5  dist sender  querying next range at /Table/52/1/1/0
+5  dist sender  r1: sending batch 4 Del, 1 BeginTxn, 1 EndTxn to (n1,s1):1
 
+# Like for CREATE UNIQUE INDEX ABOVE, we use SHOW KV TRACE FOR <stmt>
+# here to reduce the chattiness of the trace and avoid showing
+# non-deterministic accesses to the lease and job tables.
 query ITT
 SELECT span, operation, regexp_replace(regexp_replace(message, 'mutationJobs:<[^>]*>', 'mutationJobs:<...>'), 'wall_time:\d+', 'wall_time:...') as message
   FROM [SHOW KV TRACE FOR DROP INDEX t.kv@woo CASCADE] WHERE message NOT LIKE '%Z/%'
@@ -359,6 +423,9 @@ SELECT span, operation, regexp_replace(regexp_replace(message, 'mutationJobs:<[^
 37  dist sender    r1: sending batch 1 Get to (n1,s1):1
 39  dist sender    r1: sending batch 5 CPut to (n1,s1):1
 
+# Like for CREATE UNIQUE INDEX ABOVE, we use SHOW KV TRACE FOR <stmt>
+# here to reduce the chattiness of the trace and avoid showing
+# non-deterministic accesses to the lease and job tables.
 query ITT
 SELECT span, operation, regexp_replace(regexp_replace(regexp_replace(message, 'mutationJobs:<[^>]*>', 'mutationJobs:<...>'), 'wall_time:\d+', 'wall_time:...'), 'drop_time:\d+', 'drop_time:...') as message
   FROM [SHOW KV TRACE FOR DROP TABLE t.kv] WHERE message NOT LIKE '%Z/%'


### PR DESCRIPTION
Prior to this patch, CREATE TABLE AS would instantiate a logical plan
for its query operand once during the prepare phase, and then *again*
during execution so that it could use the same logic as the INSERT
statement.

This was done because it is not possible to instantiate the same logic
as the INSERT statement during the prepare phase, when the descriptor
for the newly created table doesn't exist yet.

Unfortunately, doing so created a problem at some point in the 2.0
development cycle, when the handling of subqueries was improved to
collect the subqueries in the top-level plan structure
(planner.curTop): if there are any subqueries in the CREATE TABLE AS
operand, the 2nd plan creation would fail to initialize their subquery
nodes properly!

This patch fixes this by keeping the logical plan created during the
prepare phase and using it to fetch the rows to insert in the execute
phase. This fixes the problem with subqueries and avoids duplicating
the logical planning work, which was a major wart ever since CREATE
TABLE AS was initially implemented.

This is achieved by avoiding to reuse the entirety of the INSERT logic
and using a simplified insert loop.

This also fixes an obscure bug where CREATE TABLE AS would incorrectly
autocommit when used as a data source (either in CTE or as an operand
of [SHOW TRACE ... ]).

Release note (bug fix): CREATE TABLE AS can now be used again with
scalar subqueries.

Fixes #23002.