### PR TITLE
cherry-pick-2.0: ui: clusterviz: fix polygons being filled black

### DIFF
--- a/pkg/ui/ccl/src/views/clusterviz/containers/map/mapLayout.styl
+++ b/pkg/ui/ccl/src/views/clusterviz/containers/map/mapLayout.styl
@@ -1,0 +1,13 @@
+/* Copyright 2017 The Cockroach Authors.
+ *
+ * Licensed under the Cockroach Community Licence (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+ */
+
+.geopath
+  fill #f7f7ff
+  stroke #ccc
+  stroke-width .5px

--- a/pkg/ui/ccl/src/views/clusterviz/containers/map/mapLayout.tsx
+++ b/pkg/ui/ccl/src/views/clusterviz/containers/map/mapLayout.tsx
@@ -20,6 +20,8 @@ import { WorldMap } from "./worldmap";
 import { Box, ZoomTransformer } from "./zoom";
 import { LivenessStatus } from "src/redux/nodes";
 
+import "./mapLayout.styl";
+
 interface MapLayoutProps {
   localityTree: LocalityTree;
   locationTree: LocationTree;


### PR DESCRIPTION
Cherry pick of #22949 

regression introduced in #22905

Release note: None