### PR TITLE
cherrypick-2.0: storage: don't set destroyStatus on re-added replicas

### DIFF
--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -257,6 +257,10 @@ func (s *destroyStatus) Set(err error, reason DestroyReason) {
 	s.reason = reason
 }
 
+func (s *destroyStatus) Reset() {
+	s.Set(nil, destroyReasonAlive)
+}
+
 // A Replica is a contiguous keyspace with writes managed via an
 // instance of the Raft consensus algorithm. Many ranges may exist
 // in a store and they are unlikely to be contiguous. Ranges are
@@ -905,8 +909,7 @@ func (r *Replica) setReplicaIDRaftMuLockedMuLocked(replicaID roachpb.ReplicaID) 
 	if r.mu.destroyStatus.reason == destroyReasonRemovalPending {
 		// An earlier incarnation of this replica was removed, but apparently it has been re-added
 		// now, so reset the status.
-		r.mu.destroyStatus.err = nil
-		r.mu.destroyStatus.reason = destroyReasonAlive
+		r.mu.destroyStatus.Reset()
 	}
 
 	// if r.mu.replicaID != 0 {


### PR DESCRIPTION
This fixes a 0 QPS bug where splits would occasionally stall. The bug's symptoms
were that an update to the LHS descriptor in AdminSplit was getting stuck in a
retry loop in DistSender. Each time the update's CPut was sent it was returning
with a `RangeNotFoundError`. This was causing `DistSender` to evict its range
descriptors and performs a new range lookup, where it would get back the
*correct* range descriptor. The surprising thing was that the range did exist
and it was the leaseholder, so the `RangeNotFoundError` made no sense.

I was able to trace the error down to `Replica.propose`, which checks the
replica's `destroyStatus` before proposing a Raft command. This status was being
set to `destroyReasonRemovalPending` due to a `ReplicaTooOldError` after the
replica was added to the `replicaGCQueue`. This would imply that the replica
would eventually be GCed and we'd get un-stuck, but this wasn't happening. It
turns out that the `destroyStatus` was being set on the wrong Replica. A replica
was being GC-ed and then re-added with a new replica ID, but we weren't taking
this into account when deciding whether we should add the replica to the
`replicaGCQueue` and set the `destroyStatus`. This meant that we were setting
the status on the re-added replica, which would never end up getting GC-ed.

We now only set the `destroyStatus` to `destroyReasonRemovalPending` when we
see a `ReplicaTooOldError` for a replica ID that we know about.

The easiest way to reproduce this was to run:
```
roachprod test peter-perf kv_0 --duration=2s
```

It no longer reproduces.

Note that this was easiest to reproduce with splits, but in theory the 0 QPS
scenario was possible under any workload.

Release note (bug fix): Fix a bug where ranges could get stuck in an
infinite "removal pending" state and would refuse to accept new writes.