### PR TITLE
tracing: distsender gets its own child span

### DIFF
--- a/pkg/kv/dist_sender.go
+++ b/pkg/kv/dist_sender.go
@@ -656,7 +656,7 @@ func (ds *DistSender) Send(
 	}
 
 	ctx = ds.AnnotateCtx(ctx)
-	ctx, cleanup := tracing.EnsureContext(ctx, ds.AmbientContext.Tracer, "dist sender")
+	ctx, cleanup := tracing.EnsureChildSpan(ctx, ds.AmbientContext.Tracer, "dist sender")
 	defer cleanup()
 
 	var rplChunks []*roachpb.BatchResponse

--- a/pkg/sql/logictest/testdata/logic_test/show_trace
+++ b/pkg/sql/logictest/testdata/logic_test/show_trace
@@ -61,27 +61,27 @@ SET tracing = on,kv; CREATE DATABASE t; SET tracing = off
 query ITT
 SELECT span, operation, message FROM [SHOW KV TRACE FOR SESSION] WHERE message NOT LIKE '%Z/%'
 ----
-2  sql txn  querying next range at /Table/2/1/0/"t"/3/1
-2  sql txn  r1: sending batch 1 Get to (n1,s1):1
-2  sql txn  querying next range at /System/"desc-idgen"
-2  sql txn  r1: sending batch 1 Inc to (n1,s1):1
-2  sql txn  CPut /Table/2/1/0/"t"/3/1 -> 51
-2  sql txn  CPut /Table/3/1/51/2/1 -> database:<name:"t" id:51 privileges:<users:<user:"admin" privileges:2 > users:<user:"root" privileges:2 > > >
-2  sql txn  querying next range at /Table/SystemConfigSpan/Start
-2  sql txn  r1: sending batch 2 CPut, 1 BeginTxn to (n1,s1):1
-2  sql txn  querying next range at /Table/2/1/0/"system"/3/1
-2  sql txn  r1: sending batch 1 Get to (n1,s1):1
-2  sql txn  querying next range at /Table/3/1/1/2/1
-2  sql txn  r1: sending batch 1 Get to (n1,s1):1
-2  sql txn  querying next range at /Table/2/1/1/"eventlog"/3/1
-2  sql txn  r1: sending batch 1 Get to (n1,s1):1
-2  sql txn  querying next range at /Table/3/1/12/2/1
-2  sql txn  r1: sending batch 1 Get to (n1,s1):1
-2  sql txn  querying next range at /Table/3/1/1/2/1
-2  sql txn  r1: sending batch 1 Get to (n1,s1):1
-2  sql txn  r1: sending batch 5 CPut to (n1,s1):1
-2  sql txn  querying next range at /Table/SystemConfigSpan/Start
-2  sql txn  r1: sending batch 1 EndTxn to (n1,s1):1
+3   dist sender  querying next range at /Table/2/1/0/"t"/3/1
+3   dist sender  r1: sending batch 1 Get to (n1,s1):1
+5   dist sender  querying next range at /System/"desc-idgen"
+5   dist sender  r1: sending batch 1 Inc to (n1,s1):1
+2   sql txn      CPut /Table/2/1/0/"t"/3/1 -> 51
+2   sql txn      CPut /Table/3/1/51/2/1 -> database:<name:"t" id:51 privileges:<users:<user:"admin" privileges:2 > users:<user:"root" privileges:2 > > >
+7   dist sender  querying next range at /Table/SystemConfigSpan/Start
+7   dist sender  r1: sending batch 2 CPut, 1 BeginTxn to (n1,s1):1
+10  dist sender  querying next range at /Table/2/1/0/"system"/3/1
+10  dist sender  r1: sending batch 1 Get to (n1,s1):1
+12  dist sender  querying next range at /Table/3/1/1/2/1
+12  dist sender  r1: sending batch 1 Get to (n1,s1):1
+14  dist sender  querying next range at /Table/2/1/1/"eventlog"/3/1
+14  dist sender  r1: sending batch 1 Get to (n1,s1):1
+16  dist sender  querying next range at /Table/3/1/12/2/1
+16  dist sender  r1: sending batch 1 Get to (n1,s1):1
+18  dist sender  querying next range at /Table/3/1/1/2/1
+18  dist sender  r1: sending batch 1 Get to (n1,s1):1
+20  dist sender  r1: sending batch 5 CPut to (n1,s1):1
+22  dist sender  querying next range at /Table/SystemConfigSpan/Start
+22  dist sender  r1: sending batch 1 EndTxn to (n1,s1):1
 
 
 # More KV operations.
@@ -90,74 +90,74 @@ query ITT
 SELECT span, operation, regexp_replace(message, 'wall_time:\d+', 'wall_time:...') as message
   FROM [SHOW KV TRACE FOR CREATE TABLE t.kv(k INT PRIMARY KEY, v INT)] WHERE message NOT LIKE '%Z/%'
 ----
-1  starting plan  querying next range at /Table/2/1/51/"kv"/3/1
-1  starting plan  r1: sending batch 1 Get to (n1,s1):1
-1  starting plan  querying next range at /System/"desc-idgen"
-1  starting plan  r1: sending batch 1 Inc to (n1,s1):1
-1  starting plan  CPut /Table/2/1/51/"kv"/3/1 -> 52
-1  starting plan  CPut /Table/3/1/52/2/1 -> table:<name:"kv" id:52 parent_id:51 version:1 up_version:false modification_time:<wall_time:... > columns:<name:"k" id:1 type:<semantic_type:INT width:0 precision:0 visible_type:NONE > nullable:false hidden:false > columns:<name:"v" id:2 type:<semantic_type:INT width:0 precision:0 visible_type:NONE > nullable:true hidden:false > next_column_id:3 families:<name:"primary" id:0 column_names:"k" column_names:"v" column_ids:1 column_ids:2 default_column_id:2 > next_family_id:1 primary_index:<name:"primary" id:1 unique:true column_names:"k" column_directions:ASC column_ids:1 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION > interleave:<> partitioning:<num_columns:0 > type:FORWARD > next_index_id:2 privileges:<users:<user:"admin" privileges:2 > users:<user:"root" privileges:2 > > next_mutation_id:1 format_version:3 state:PUBLIC view_query:"" drop_time:0 replacement_of:<id:0 time:<> > audit_mode:DISABLED >
-1  starting plan  querying next range at /Table/SystemConfigSpan/Start
-1  starting plan  r1: sending batch 2 CPut, 1 BeginTxn to (n1,s1):1
-1  starting plan  querying next range at /Table/3/1/51/2/1
-1  starting plan  r1: sending batch 1 Get to (n1,s1):1
-1  starting plan  querying next range at /Table/2/1/0/"system"/3/1
-1  starting plan  r1: sending batch 1 Get to (n1,s1):1
-1  starting plan  querying next range at /Table/3/1/1/2/1
-1  starting plan  r1: sending batch 1 Get to (n1,s1):1
-1  starting plan  querying next range at /Table/2/1/1/"eventlog"/3/1
-1  starting plan  r1: sending batch 1 Get to (n1,s1):1
-1  starting plan  querying next range at /Table/3/1/12/2/1
-1  starting plan  r1: sending batch 1 Get to (n1,s1):1
-1  starting plan  querying next range at /Table/3/1/1/2/1
-1  starting plan  r1: sending batch 1 Get to (n1,s1):1
-1  starting plan  r1: sending batch 5 CPut to (n1,s1):1
+2   dist sender    querying next range at /Table/2/1/51/"kv"/3/1
+2   dist sender    r1: sending batch 1 Get to (n1,s1):1
+4   dist sender    querying next range at /System/"desc-idgen"
+4   dist sender    r1: sending batch 1 Inc to (n1,s1):1
+1   starting plan  CPut /Table/2/1/51/"kv"/3/1 -> 52
+1   starting plan  CPut /Table/3/1/52/2/1 -> table:<name:"kv" id:52 parent_id:51 version:1 up_version:false modification_time:<wall_time:... > columns:<name:"k" id:1 type:<semantic_type:INT width:0 precision:0 visible_type:NONE > nullable:false hidden:false > columns:<name:"v" id:2 type:<semantic_type:INT width:0 precision:0 visible_type:NONE > nullable:true hidden:false > next_column_id:3 families:<name:"primary" id:0 column_names:"k" column_names:"v" column_ids:1 column_ids:2 default_column_id:2 > next_family_id:1 primary_index:<name:"primary" id:1 unique:true column_names:"k" column_directions:ASC column_ids:1 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION > interleave:<> partitioning:<num_columns:0 > type:FORWARD > next_index_id:2 privileges:<users:<user:"admin" privileges:2 > users:<user:"root" privileges:2 > > next_mutation_id:1 format_version:3 state:PUBLIC view_query:"" drop_time:0 replacement_of:<id:0 time:<> > audit_mode:DISABLED >
+6   dist sender    querying next range at /Table/SystemConfigSpan/Start
+6   dist sender    r1: sending batch 2 CPut, 1 BeginTxn to (n1,s1):1
+9   dist sender    querying next range at /Table/3/1/51/2/1
+9   dist sender    r1: sending batch 1 Get to (n1,s1):1
+11  dist sender    querying next range at /Table/2/1/0/"system"/3/1
+11  dist sender    r1: sending batch 1 Get to (n1,s1):1
+13  dist sender    querying next range at /Table/3/1/1/2/1
+13  dist sender    r1: sending batch 1 Get to (n1,s1):1
+15  dist sender    querying next range at /Table/2/1/1/"eventlog"/3/1
+15  dist sender    r1: sending batch 1 Get to (n1,s1):1
+17  dist sender    querying next range at /Table/3/1/12/2/1
+17  dist sender    r1: sending batch 1 Get to (n1,s1):1
+19  dist sender    querying next range at /Table/3/1/1/2/1
+19  dist sender    r1: sending batch 1 Get to (n1,s1):1
+21  dist sender    r1: sending batch 5 CPut to (n1,s1):1
 
 query ITT
 SELECT span, operation, regexp_replace(regexp_replace(message, 'mutationJobs:<[^>]*>', 'mutationJobs:<...>'), 'wall_time:\d+', 'wall_time:...') as message
   FROM [SHOW KV TRACE FOR CREATE UNIQUE INDEX woo ON t.kv(v)] WHERE message NOT LIKE '%Z/%'
 ----
-1  starting plan  querying next range at /Table/2/1/0/"system"/3/1
-1  starting plan  r1: sending batch 1 Get to (n1,s1):1
-1  starting plan  querying next range at /Table/3/1/1/2/1
-1  starting plan  r1: sending batch 1 Get to (n1,s1):1
-1  starting plan  querying next range at /Table/2/1/1/"jobs"/3/1
-1  starting plan  r1: sending batch 1 Get to (n1,s1):1
-1  starting plan  querying next range at /Table/3/1/15/2/1
-1  starting plan  r1: sending batch 1 Get to (n1,s1):1
-1  starting plan  querying next range at /Table/3/1/1/2/1
-1  starting plan  r1: sending batch 1 Get to (n1,s1):1
-1  starting plan  querying next range at /Table/SystemConfigSpan/Start
-1  starting plan  r1: sending batch 1 CPut, 1 BeginTxn, 1 InitPut to (n1,s1):1
-1  starting plan  Put /Table/3/1/52/2/1 -> table:<name:"kv" id:52 parent_id:51 version:1 up_version:true modification_time:<wall_time:... > columns:<name:"k" id:1 type:<semantic_type:INT width:0 precision:0 visible_type:NONE > nullable:false hidden:false > columns:<name:"v" id:2 type:<semantic_type:INT width:0 precision:0 visible_type:NONE > nullable:true hidden:false > next_column_id:3 families:<name:"primary" id:0 column_names:"k" column_names:"v" column_ids:1 column_ids:2 default_column_id:2 > next_family_id:1 primary_index:<name:"primary" id:1 unique:true column_names:"k" column_directions:ASC column_ids:1 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION > interleave:<> partitioning:<num_columns:0 > type:FORWARD > next_index_id:3 privileges:<users:<user:"admin" privileges:2 > users:<user:"root" privileges:2 > > mutations:<index:<name:"woo" id:2 unique:true column_names:"v" column_directions:ASC column_ids:2 extra_column_ids:1 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION > interleave:<> partitioning:<num_columns:0 > type:FORWARD > state:DELETE_ONLY direction:ADD mutation_id:1 rollback:false > next_mutation_id:2 format_version:3 state:PUBLIC view_query:"" mutationJobs:<...> drop_time:0 replacement_of:<id:0 time:<> > audit_mode:DISABLED >
-1  starting plan  querying next range at /Table/3/1/52/2/1
-1  starting plan  r1: sending batch 1 Put to (n1,s1):1
-1  starting plan  querying next range at /Table/2/1/0/"system"/3/1
-1  starting plan  r1: sending batch 1 Get to (n1,s1):1
-1  starting plan  querying next range at /Table/3/1/1/2/1
-1  starting plan  r1: sending batch 1 Get to (n1,s1):1
-1  starting plan  querying next range at /Table/2/1/1/"eventlog"/3/1
-1  starting plan  r1: sending batch 1 Get to (n1,s1):1
-1  starting plan  querying next range at /Table/3/1/12/2/1
-1  starting plan  r1: sending batch 1 Get to (n1,s1):1
-1  starting plan  querying next range at /Table/3/1/1/2/1
-1  starting plan  r1: sending batch 1 Get to (n1,s1):1
-1  starting plan  r1: sending batch 5 CPut to (n1,s1):1
+2   dist sender    querying next range at /Table/2/1/0/"system"/3/1
+2   dist sender    r1: sending batch 1 Get to (n1,s1):1
+4   dist sender    querying next range at /Table/3/1/1/2/1
+4   dist sender    r1: sending batch 1 Get to (n1,s1):1
+6   dist sender    querying next range at /Table/2/1/1/"jobs"/3/1
+6   dist sender    r1: sending batch 1 Get to (n1,s1):1
+8   dist sender    querying next range at /Table/3/1/15/2/1
+8   dist sender    r1: sending batch 1 Get to (n1,s1):1
+10  dist sender    querying next range at /Table/3/1/1/2/1
+10  dist sender    r1: sending batch 1 Get to (n1,s1):1
+12  dist sender    querying next range at /Table/SystemConfigSpan/Start
+12  dist sender    r1: sending batch 1 CPut, 1 BeginTxn, 1 InitPut to (n1,s1):1
+1   starting plan  Put /Table/3/1/52/2/1 -> table:<name:"kv" id:52 parent_id:51 version:1 up_version:true modification_time:<wall_time:... > columns:<name:"k" id:1 type:<semantic_type:INT width:0 precision:0 visible_type:NONE > nullable:false hidden:false > columns:<name:"v" id:2 type:<semantic_type:INT width:0 precision:0 visible_type:NONE > nullable:true hidden:false > next_column_id:3 families:<name:"primary" id:0 column_names:"k" column_names:"v" column_ids:1 column_ids:2 default_column_id:2 > next_family_id:1 primary_index:<name:"primary" id:1 unique:true column_names:"k" column_directions:ASC column_ids:1 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION > interleave:<> partitioning:<num_columns:0 > type:FORWARD > next_index_id:3 privileges:<users:<user:"admin" privileges:2 > users:<user:"root" privileges:2 > > mutations:<index:<name:"woo" id:2 unique:true column_names:"v" column_directions:ASC column_ids:2 extra_column_ids:1 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION > interleave:<> partitioning:<num_columns:0 > type:FORWARD > state:DELETE_ONLY direction:ADD mutation_id:1 rollback:false > next_mutation_id:2 format_version:3 state:PUBLIC view_query:"" mutationJobs:<...> drop_time:0 replacement_of:<id:0 time:<> > audit_mode:DISABLED >
+15  dist sender    querying next range at /Table/3/1/52/2/1
+15  dist sender    r1: sending batch 1 Put to (n1,s1):1
+17  dist sender    querying next range at /Table/2/1/0/"system"/3/1
+17  dist sender    r1: sending batch 1 Get to (n1,s1):1
+19  dist sender    querying next range at /Table/3/1/1/2/1
+19  dist sender    r1: sending batch 1 Get to (n1,s1):1
+21  dist sender    querying next range at /Table/2/1/1/"eventlog"/3/1
+21  dist sender    r1: sending batch 1 Get to (n1,s1):1
+23  dist sender    querying next range at /Table/3/1/12/2/1
+23  dist sender    r1: sending batch 1 Get to (n1,s1):1
+25  dist sender    querying next range at /Table/3/1/1/2/1
+25  dist sender    r1: sending batch 1 Get to (n1,s1):1
+27  dist sender    r1: sending batch 5 CPut to (n1,s1):1
 
 query ITT
 SELECT span, operation, message FROM [SHOW KV TRACE FOR INSERT INTO t.kv(k, v) VALUES (1,2)]
 ----
 0  sql txn         CPut /Table/52/1/1/0 -> /TUPLE/2:2:Int/2
 2  consuming rows  output row: []
-0  sql txn         querying next range at /Table/52/1/1/0
-0  sql txn         r1: sending batch 1 CPut, 1 BeginTxn, 1 InitPut to (n1,s1):1
+3  dist sender     querying next range at /Table/52/1/1/0
+3  dist sender     r1: sending batch 1 CPut, 1 BeginTxn, 1 InitPut to (n1,s1):1
 
 query ITT
 SELECT span, operation, message FROM [SHOW KV TRACE FOR INSERT INTO t.kv(k, v) VALUES (1,2)]
 ----
 0  sql txn         CPut /Table/52/1/1/0 -> /TUPLE/2:2:Int/2
 2  consuming rows  output row: []
-0  sql txn         querying next range at /Table/52/1/1/0
-0  sql txn         r1: sending batch 1 CPut, 1 BeginTxn, 1 InitPut to (n1,s1):1
+3  dist sender     querying next range at /Table/52/1/1/0
+3  dist sender     r1: sending batch 1 CPut, 1 BeginTxn, 1 InitPut to (n1,s1):1
 2  consuming rows  execution failed: duplicate key value (k)=(1) violates unique constraint "primary"
 
 query ITT
@@ -165,8 +165,8 @@ SELECT span, operation, message FROM [SHOW KV TRACE FOR INSERT INTO t.kv(k, v) V
 ----
 0  sql txn         CPut /Table/52/1/2/0 -> /TUPLE/2:2:Int/2
 2  consuming rows  output row: []
-0  sql txn         querying next range at /Table/52/1/2/0
-0  sql txn         r1: sending batch 1 CPut, 1 BeginTxn, 1 InitPut to (n1,s1):1
+3  dist sender     querying next range at /Table/52/1/2/0
+3  dist sender     r1: sending batch 1 CPut, 1 BeginTxn, 1 InitPut to (n1,s1):1
 2  consuming rows  execution failed: duplicate key value (v)=(2) violates unique constraint "woo"
 
 query ITT
@@ -174,137 +174,137 @@ SELECT span, operation, message FROM [SHOW KV TRACE FOR UPSERT INTO t.kv(k, v) V
 ----
 2  consuming rows  output row: []
 0  sql txn         Scan /Table/52/1/{2-3}
-0  sql txn         querying next range at /Table/52/1/2
-0  sql txn         r1: sending batch 1 Scan to (n1,s1):1
+3  dist sender     querying next range at /Table/52/1/2
+3  dist sender     r1: sending batch 1 Scan to (n1,s1):1
 0  sql txn         CPut /Table/52/1/2/0 -> /TUPLE/2:2:Int/3
-0  sql txn         querying next range at /Table/52/1/2/0
-0  sql txn         r1: sending batch 1 CPut, 1 BeginTxn, 1 InitPut to (n1,s1):1
+5  dist sender     querying next range at /Table/52/1/2/0
+5  dist sender     r1: sending batch 1 CPut, 1 BeginTxn, 1 InitPut to (n1,s1):1
 
 query ITT
 SELECT span, operation, message FROM [SHOW KV TRACE FOR UPSERT INTO t.kv(k, v) VALUES (1,2)]
 ----
 2  consuming rows  output row: []
 0  sql txn         Scan /Table/52/1/{1-2}
-0  sql txn         querying next range at /Table/52/1/1
-0  sql txn         r1: sending batch 1 Scan to (n1,s1):1
+3  dist sender     querying next range at /Table/52/1/1
+3  dist sender     r1: sending batch 1 Scan to (n1,s1):1
 0  sql txn         fetched: /kv/primary/1/v -> /2
 0  sql txn         Put /Table/52/1/1/0 -> /TUPLE/2:2:Int/2
-0  sql txn         querying next range at /Table/52/1/1/0
-0  sql txn         r1: sending batch 1 Put, 1 BeginTxn to (n1,s1):1
+5  dist sender     querying next range at /Table/52/1/1/0
+5  dist sender     r1: sending batch 1 Put, 1 BeginTxn to (n1,s1):1
 
 query ITT
 SELECT span, operation, message FROM [SHOW KV TRACE FOR UPSERT INTO t.kv(k, v) VALUES (2,2)]
 ----
 2  consuming rows  output row: []
 0  sql txn         Scan /Table/52/1/{2-3}
-0  sql txn         querying next range at /Table/52/1/2
-0  sql txn         r1: sending batch 1 Scan to (n1,s1):1
+3  dist sender     querying next range at /Table/52/1/2
+3  dist sender     r1: sending batch 1 Scan to (n1,s1):1
 0  sql txn         fetched: /kv/primary/2/v -> /3
 0  sql txn         Put /Table/52/1/2/0 -> /TUPLE/2:2:Int/2
 0  sql txn         Del /Table/52/2/3/0
 0  sql txn         CPut /Table/52/2/2/0 -> /BYTES/Š
-0  sql txn         querying next range at /Table/52/1/2/0
-0  sql txn         r1: sending batch 1 Put, 1 CPut, 1 Del, 1 BeginTxn to (n1,s1):1
+5  dist sender     querying next range at /Table/52/1/2/0
+5  dist sender     r1: sending batch 1 Put, 1 CPut, 1 Del, 1 BeginTxn to (n1,s1):1
 2  consuming rows  execution failed: duplicate key value (v)=(2) violates unique constraint "woo"
 
 query ITT
 SELECT span, operation, regexp_replace(regexp_replace(message, 'wall_time:\d+', 'wall_time:...'), '\d\d\d\d\d+', '...PK...') as message
   FROM [SHOW KV TRACE FOR CREATE TABLE t.kv2 AS TABLE t.kv] WHERE message NOT LIKE '%Z/%'
 ----
-1   starting plan   querying next range at /Table/2/1/51/"kv2"/3/1
-1   starting plan   r1: sending batch 1 Get to (n1,s1):1
-1   starting plan   querying next range at /System/"desc-idgen"
-1   starting plan   r1: sending batch 1 Inc to (n1,s1):1
+2   dist sender     querying next range at /Table/2/1/51/"kv2"/3/1
+2   dist sender     r1: sending batch 1 Get to (n1,s1):1
+4   dist sender     querying next range at /System/"desc-idgen"
+4   dist sender     r1: sending batch 1 Inc to (n1,s1):1
 1   starting plan   CPut /Table/2/1/51/"kv2"/3/1 -> 53
 1   starting plan   CPut /Table/3/1/53/2/1 -> table:<name:"kv2" id:53 parent_id:51 version:1 up_version:false modification_time:<wall_time:... > columns:<name:"k" id:1 type:<semantic_type:INT width:0 precision:0 visible_type:NONE > nullable:true hidden:false > columns:<name:"v" id:2 type:<semantic_type:INT width:0 precision:0 visible_type:NONE > nullable:true hidden:false > columns:<name:"rowid" id:3 type:<semantic_type:INT width:0 precision:0 visible_type:NONE > nullable:false default_expr:"unique_rowid()" hidden:true > next_column_id:4 families:<name:"primary" id:0 column_names:"k" column_names:"v" column_names:"rowid" column_ids:1 column_ids:2 column_ids:3 default_column_id:0 > next_family_id:1 primary_index:<name:"primary" id:1 unique:true column_names:"rowid" column_directions:ASC column_ids:3 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION > interleave:<> partitioning:<num_columns:0 > type:FORWARD > next_index_id:2 privileges:<users:<user:"admin" privileges:2 > users:<user:"root" privileges:2 > > next_mutation_id:1 format_version:3 state:PUBLIC view_query:"" drop_time:0 replacement_of:<id:0 time:<> > audit_mode:DISABLED >
-1   starting plan   querying next range at /Table/SystemConfigSpan/Start
-1   starting plan   r1: sending batch 2 CPut, 1 BeginTxn to (n1,s1):1
-1   starting plan   querying next range at /Table/3/1/51/2/1
-1   starting plan   r1: sending batch 1 Get to (n1,s1):1
-1   starting plan   querying next range at /Table/2/1/0/"system"/3/1
-1   starting plan   r1: sending batch 1 Get to (n1,s1):1
-1   starting plan   querying next range at /Table/3/1/1/2/1
-1   starting plan   r1: sending batch 1 Get to (n1,s1):1
-1   starting plan   querying next range at /Table/2/1/1/"eventlog"/3/1
-1   starting plan   r1: sending batch 1 Get to (n1,s1):1
-1   starting plan   querying next range at /Table/3/1/12/2/1
-1   starting plan   r1: sending batch 1 Get to (n1,s1):1
-1   starting plan   querying next range at /Table/3/1/1/2/1
-1   starting plan   r1: sending batch 1 Get to (n1,s1):1
-1   starting plan   r1: sending batch 5 CPut to (n1,s1):1
+6   dist sender     querying next range at /Table/SystemConfigSpan/Start
+6   dist sender     r1: sending batch 2 CPut, 1 BeginTxn to (n1,s1):1
+9   dist sender     querying next range at /Table/3/1/51/2/1
+9   dist sender     r1: sending batch 1 Get to (n1,s1):1
+11  dist sender     querying next range at /Table/2/1/0/"system"/3/1
+11  dist sender     r1: sending batch 1 Get to (n1,s1):1
+13  dist sender     querying next range at /Table/3/1/1/2/1
+13  dist sender     r1: sending batch 1 Get to (n1,s1):1
+15  dist sender     querying next range at /Table/2/1/1/"eventlog"/3/1
+15  dist sender     r1: sending batch 1 Get to (n1,s1):1
+17  dist sender     querying next range at /Table/3/1/12/2/1
+17  dist sender     r1: sending batch 1 Get to (n1,s1):1
+19  dist sender     querying next range at /Table/3/1/1/2/1
+19  dist sender     r1: sending batch 1 Get to (n1,s1):1
+21  dist sender     r1: sending batch 5 CPut to (n1,s1):1
 1   starting plan   Scan /Table/52/{1-2}
-1   starting plan   querying next range at /Table/52/1
-1   starting plan   r1: sending batch 1 Scan to (n1,s1):1
+23  dist sender     querying next range at /Table/52/1
+23  dist sender     r1: sending batch 1 Scan to (n1,s1):1
 1   starting plan   fetched: /kv/primary/1/v -> /2
 1   starting plan   CPut /Table/53/1/...PK.../0 -> /TUPLE/1:1:Int/1/1:2:Int/2
 1   starting plan   fetched: /kv/primary/2/v -> /3
 1   starting plan   CPut /Table/53/1/...PK.../0 -> /TUPLE/1:1:Int/2/1:2:Int/3
-1   starting plan   querying next range at /Table/SystemConfigSpan/Start
-1   starting plan   r1: sending batch 2 CPut, 1 EndTxn to (n1,s1):1
-15  consuming rows  fast path - rows affected: 2
+25  dist sender     querying next range at /Table/SystemConfigSpan/Start
+25  dist sender     r1: sending batch 2 CPut, 1 EndTxn to (n1,s1):1
+27  consuming rows  fast path - rows affected: 2
 
 query ITT
 SELECT span, operation, regexp_replace(message, '\d\d\d\d\d+', '...PK...') as message
   FROM [SHOW KV TRACE FOR UPDATE t.kv2 SET v = v + 2]
 ----
 0  sql txn         Scan /Table/53/{1-2}
-0  sql txn         querying next range at /Table/53/1
-0  sql txn         r1: sending batch 1 Scan to (n1,s1):1
+3  dist sender     querying next range at /Table/53/1
+3  dist sender     r1: sending batch 1 Scan to (n1,s1):1
 0  sql txn         fetched: /kv2/primary/...PK.../k/v -> /1/2
 0  sql txn         Put /Table/53/1/...PK.../0 -> /TUPLE/1:1:Int/1/1:2:Int/4
 2  consuming rows  output row: [...PK... 1 4]
 0  sql txn         fetched: /kv2/primary/...PK.../k/v -> /2/3
 0  sql txn         Put /Table/53/1/...PK.../0 -> /TUPLE/1:1:Int/2/1:2:Int/5
 2  consuming rows  output row: [...PK... 2 5]
-0  sql txn         querying next range at /Table/53/1/...PK.../0
-0  sql txn         r1: sending batch 2 Put, 1 BeginTxn to (n1,s1):1
+5  dist sender     querying next range at /Table/53/1/...PK.../0
+5  dist sender     r1: sending batch 2 Put, 1 BeginTxn to (n1,s1):1
 
 query ITT
 SELECT span, operation, message FROM [SHOW KV TRACE FOR DELETE FROM t.kv2]
 ----
 1  starting plan   Scan /Table/53/{1-2}
-1  starting plan   querying next range at /Table/53/1
-1  starting plan   r1: sending batch 1 Scan to (n1,s1):1
+2  dist sender     querying next range at /Table/53/1
+2  dist sender     r1: sending batch 1 Scan to (n1,s1):1
 1  starting plan   DelRange /Table/53/1 - /Table/53/2
-1  starting plan   querying next range at /Table/53/1
-1  starting plan   r1: sending batch 1 DelRng, 1 BeginTxn to (n1,s1):1
-5  consuming rows  fast path - rows affected: 2
+4  dist sender     querying next range at /Table/53/1
+4  dist sender     r1: sending batch 1 DelRng, 1 BeginTxn to (n1,s1):1
+7  consuming rows  fast path - rows affected: 2
 
 query ITT
 SELECT span, operation, regexp_replace(regexp_replace(message, 'wall_time:\d+', 'wall_time:...'), 'drop_time:\d+', 'drop_time:...') as message
   FROM [SHOW KV TRACE FOR DROP TABLE t.kv2] WHERE message NOT LIKE '%Z/%'
 ----
-1  starting plan  querying next range at /Table/5/1/53/2/1
-1  starting plan  r1: sending batch 1 Get to (n1,s1):1
-1  starting plan  querying next range at /Table/3/1/53/2/1
-1  starting plan  r1: sending batch 1 Get to (n1,s1):1
-1  starting plan  querying next range at /Table/5/1/51/2/1
-1  starting plan  r1: sending batch 1 Get to (n1,s1):1
-1  starting plan  querying next range at /Table/3/1/51/2/1
-1  starting plan  r1: sending batch 1 Get to (n1,s1):1
-1  starting plan  querying next range at /Table/5/1/0/2/1
-1  starting plan  r1: sending batch 1 Get to (n1,s1):1
-1  starting plan  Put /Table/3/1/53/2/1 -> table:<name:"kv2" id:53 parent_id:51 version:1 up_version:true modification_time:<wall_time:... > columns:<name:"k" id:1 type:<semantic_type:INT width:0 precision:0 visible_type:NONE > nullable:true hidden:false > columns:<name:"v" id:2 type:<semantic_type:INT width:0 precision:0 visible_type:NONE > nullable:true hidden:false > columns:<name:"rowid" id:3 type:<semantic_type:INT width:0 precision:0 visible_type:NONE > nullable:false default_expr:"unique_rowid()" hidden:true > next_column_id:4 families:<name:"primary" id:0 column_names:"k" column_names:"v" column_names:"rowid" column_ids:1 column_ids:2 column_ids:3 default_column_id:0 > next_family_id:1 primary_index:<name:"primary" id:1 unique:true column_names:"rowid" column_directions:ASC column_ids:3 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION > interleave:<> partitioning:<num_columns:0 > type:FORWARD > next_index_id:2 privileges:<users:<user:"admin" privileges:2 > users:<user:"root" privileges:2 > > next_mutation_id:1 format_version:3 state:DROP draining_names:<parent_id:51 name:"kv2" > view_query:"" drop_time:... replacement_of:<id:0 time:<> > audit_mode:DISABLED >
-1  starting plan  querying next range at /Table/SystemConfigSpan/Start
-1  starting plan  r1: sending batch 1 Put, 1 BeginTxn to (n1,s1):1
-1  starting plan  querying next range at /Table/2/1/0/"system"/3/1
-1  starting plan  r1: sending batch 1 Get to (n1,s1):1
-1  starting plan  querying next range at /Table/3/1/1/2/1
-1  starting plan  r1: sending batch 1 Get to (n1,s1):1
-1  starting plan  querying next range at /Table/2/1/1/"eventlog"/3/1
-1  starting plan  r1: sending batch 1 Get to (n1,s1):1
-1  starting plan  querying next range at /Table/3/1/12/2/1
-1  starting plan  r1: sending batch 1 Get to (n1,s1):1
-1  starting plan  querying next range at /Table/3/1/1/2/1
-1  starting plan  r1: sending batch 1 Get to (n1,s1):1
-1  starting plan  r1: sending batch 5 CPut to (n1,s1):1
+2   dist sender    querying next range at /Table/5/1/53/2/1
+2   dist sender    r1: sending batch 1 Get to (n1,s1):1
+4   dist sender    querying next range at /Table/3/1/53/2/1
+4   dist sender    r1: sending batch 1 Get to (n1,s1):1
+6   dist sender    querying next range at /Table/5/1/51/2/1
+6   dist sender    r1: sending batch 1 Get to (n1,s1):1
+8   dist sender    querying next range at /Table/3/1/51/2/1
+8   dist sender    r1: sending batch 1 Get to (n1,s1):1
+10  dist sender    querying next range at /Table/5/1/0/2/1
+10  dist sender    r1: sending batch 1 Get to (n1,s1):1
+1   starting plan  Put /Table/3/1/53/2/1 -> table:<name:"kv2" id:53 parent_id:51 version:1 up_version:true modification_time:<wall_time:... > columns:<name:"k" id:1 type:<semantic_type:INT width:0 precision:0 visible_type:NONE > nullable:true hidden:false > columns:<name:"v" id:2 type:<semantic_type:INT width:0 precision:0 visible_type:NONE > nullable:true hidden:false > columns:<name:"rowid" id:3 type:<semantic_type:INT width:0 precision:0 visible_type:NONE > nullable:false default_expr:"unique_rowid()" hidden:true > next_column_id:4 families:<name:"primary" id:0 column_names:"k" column_names:"v" column_names:"rowid" column_ids:1 column_ids:2 column_ids:3 default_column_id:0 > next_family_id:1 primary_index:<name:"primary" id:1 unique:true column_names:"rowid" column_directions:ASC column_ids:3 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION > interleave:<> partitioning:<num_columns:0 > type:FORWARD > next_index_id:2 privileges:<users:<user:"admin" privileges:2 > users:<user:"root" privileges:2 > > next_mutation_id:1 format_version:3 state:DROP draining_names:<parent_id:51 name:"kv2" > view_query:"" drop_time:... replacement_of:<id:0 time:<> > audit_mode:DISABLED >
+12  dist sender    querying next range at /Table/SystemConfigSpan/Start
+12  dist sender    r1: sending batch 1 Put, 1 BeginTxn to (n1,s1):1
+15  dist sender    querying next range at /Table/2/1/0/"system"/3/1
+15  dist sender    r1: sending batch 1 Get to (n1,s1):1
+17  dist sender    querying next range at /Table/3/1/1/2/1
+17  dist sender    r1: sending batch 1 Get to (n1,s1):1
+19  dist sender    querying next range at /Table/2/1/1/"eventlog"/3/1
+19  dist sender    r1: sending batch 1 Get to (n1,s1):1
+21  dist sender    querying next range at /Table/3/1/12/2/1
+21  dist sender    r1: sending batch 1 Get to (n1,s1):1
+23  dist sender    querying next range at /Table/3/1/1/2/1
+23  dist sender    r1: sending batch 1 Get to (n1,s1):1
+25  dist sender    r1: sending batch 5 CPut to (n1,s1):1
 
 query ITT
 SELECT span, operation, message FROM [SHOW KV TRACE FOR DELETE FROM t.kv]
 ----
 0  sql txn         Scan /Table/52/{1-2}
-0  sql txn         querying next range at /Table/52/1
-0  sql txn         r1: sending batch 1 Scan to (n1,s1):1
+3  dist sender     querying next range at /Table/52/1
+3  dist sender     r1: sending batch 1 Scan to (n1,s1):1
 0  sql txn         fetched: /kv/primary/1/v -> /2
 0  sql txn         Del /Table/52/2/2/0
 0  sql txn         DelRange /Table/52/1/1 - /Table/52/1/1/#
@@ -313,80 +313,80 @@ SELECT span, operation, message FROM [SHOW KV TRACE FOR DELETE FROM t.kv]
 0  sql txn         Del /Table/52/2/3/0
 0  sql txn         DelRange /Table/52/1/2 - /Table/52/1/2/#
 2  consuming rows  output row: [2 3]
-0  sql txn         querying next range at /Table/52/1/1
-0  sql txn         r1: sending batch 2 Del, 2 DelRng, 1 BeginTxn to (n1,s1):1
+5  dist sender     querying next range at /Table/52/1/1
+5  dist sender     r1: sending batch 2 Del, 2 DelRng, 1 BeginTxn to (n1,s1):1
 
 query ITT
 SELECT span, operation, regexp_replace(regexp_replace(message, 'mutationJobs:<[^>]*>', 'mutationJobs:<...>'), 'wall_time:\d+', 'wall_time:...') as message
   FROM [SHOW KV TRACE FOR DROP INDEX t.kv@woo CASCADE] WHERE message NOT LIKE '%Z/%'
 ----
-1  starting plan  querying next range at /Table/2/1/0/"t"/3/1
-1  starting plan  r1: sending batch 1 Get to (n1,s1):1
-1  starting plan  querying next range at /Table/3/1/51/2/1
-1  starting plan  r1: sending batch 1 Get to (n1,s1):1
-1  starting plan  querying next range at /Table/2/1/51/"kv"/3/1
-1  starting plan  r1: sending batch 1 Get to (n1,s1):1
-1  starting plan  querying next range at /Table/3/1/52/2/1
-1  starting plan  r1: sending batch 1 Get to (n1,s1):1
-1  starting plan  querying next range at /Table/3/1/51/2/1
-1  starting plan  r1: sending batch 1 Get to (n1,s1):1
-1  starting plan  querying next range at /Table/3/1/51/2/1
-1  starting plan  r1: sending batch 1 Get to (n1,s1):1
-1  starting plan  querying next range at /Table/2/1/0/"system"/3/1
-1  starting plan  r1: sending batch 1 Get to (n1,s1):1
-1  starting plan  querying next range at /Table/3/1/1/2/1
-1  starting plan  r1: sending batch 1 Get to (n1,s1):1
-1  starting plan  querying next range at /Table/2/1/1/"jobs"/3/1
-1  starting plan  r1: sending batch 1 Get to (n1,s1):1
-1  starting plan  querying next range at /Table/3/1/15/2/1
-1  starting plan  r1: sending batch 1 Get to (n1,s1):1
-1  starting plan  querying next range at /Table/3/1/1/2/1
-1  starting plan  r1: sending batch 1 Get to (n1,s1):1
-1  starting plan  querying next range at /Table/SystemConfigSpan/Start
-1  starting plan  r1: sending batch 1 CPut, 1 BeginTxn, 1 InitPut to (n1,s1):1
-1  starting plan  Put /Table/3/1/52/2/1 -> table:<name:"kv" id:52 parent_id:51 version:4 up_version:true modification_time:<wall_time:... > columns:<name:"k" id:1 type:<semantic_type:INT width:0 precision:0 visible_type:NONE > nullable:false hidden:false > columns:<name:"v" id:2 type:<semantic_type:INT width:0 precision:0 visible_type:NONE > nullable:true hidden:false > next_column_id:3 families:<name:"primary" id:0 column_names:"k" column_names:"v" column_ids:1 column_ids:2 default_column_id:2 > next_family_id:1 primary_index:<name:"primary" id:1 unique:true column_names:"k" column_directions:ASC column_ids:1 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION > interleave:<> partitioning:<num_columns:0 > type:FORWARD > next_index_id:3 privileges:<users:<user:"admin" privileges:2 > users:<user:"root" privileges:2 > > mutations:<index:<name:"woo" id:2 unique:true column_names:"v" column_directions:ASC column_ids:2 extra_column_ids:1 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION > interleave:<> partitioning:<num_columns:0 > type:FORWARD > state:DELETE_AND_WRITE_ONLY direction:DROP mutation_id:2 rollback:false > next_mutation_id:3 format_version:3 state:PUBLIC view_query:"" mutationJobs:<...> drop_time:0 replacement_of:<id:0 time:<> > audit_mode:DISABLED >
-1  starting plan  querying next range at /Table/3/1/52/2/1
-1  starting plan  r1: sending batch 1 Put to (n1,s1):1
-1  starting plan  querying next range at /Table/2/1/0/"system"/3/1
-1  starting plan  r1: sending batch 1 Get to (n1,s1):1
-1  starting plan  querying next range at /Table/3/1/1/2/1
-1  starting plan  r1: sending batch 1 Get to (n1,s1):1
-1  starting plan  querying next range at /Table/2/1/1/"eventlog"/3/1
-1  starting plan  r1: sending batch 1 Get to (n1,s1):1
-1  starting plan  querying next range at /Table/3/1/12/2/1
-1  starting plan  r1: sending batch 1 Get to (n1,s1):1
-1  starting plan  querying next range at /Table/3/1/1/2/1
-1  starting plan  r1: sending batch 1 Get to (n1,s1):1
-1  starting plan  r1: sending batch 5 CPut to (n1,s1):1
+2   dist sender    querying next range at /Table/2/1/0/"t"/3/1
+2   dist sender    r1: sending batch 1 Get to (n1,s1):1
+4   dist sender    querying next range at /Table/3/1/51/2/1
+4   dist sender    r1: sending batch 1 Get to (n1,s1):1
+6   dist sender    querying next range at /Table/2/1/51/"kv"/3/1
+6   dist sender    r1: sending batch 1 Get to (n1,s1):1
+8   dist sender    querying next range at /Table/3/1/52/2/1
+8   dist sender    r1: sending batch 1 Get to (n1,s1):1
+10  dist sender    querying next range at /Table/3/1/51/2/1
+10  dist sender    r1: sending batch 1 Get to (n1,s1):1
+12  dist sender    querying next range at /Table/3/1/51/2/1
+12  dist sender    r1: sending batch 1 Get to (n1,s1):1
+14  dist sender    querying next range at /Table/2/1/0/"system"/3/1
+14  dist sender    r1: sending batch 1 Get to (n1,s1):1
+16  dist sender    querying next range at /Table/3/1/1/2/1
+16  dist sender    r1: sending batch 1 Get to (n1,s1):1
+18  dist sender    querying next range at /Table/2/1/1/"jobs"/3/1
+18  dist sender    r1: sending batch 1 Get to (n1,s1):1
+20  dist sender    querying next range at /Table/3/1/15/2/1
+20  dist sender    r1: sending batch 1 Get to (n1,s1):1
+22  dist sender    querying next range at /Table/3/1/1/2/1
+22  dist sender    r1: sending batch 1 Get to (n1,s1):1
+24  dist sender    querying next range at /Table/SystemConfigSpan/Start
+24  dist sender    r1: sending batch 1 CPut, 1 BeginTxn, 1 InitPut to (n1,s1):1
+1   starting plan  Put /Table/3/1/52/2/1 -> table:<name:"kv" id:52 parent_id:51 version:4 up_version:true modification_time:<wall_time:... > columns:<name:"k" id:1 type:<semantic_type:INT width:0 precision:0 visible_type:NONE > nullable:false hidden:false > columns:<name:"v" id:2 type:<semantic_type:INT width:0 precision:0 visible_type:NONE > nullable:true hidden:false > next_column_id:3 families:<name:"primary" id:0 column_names:"k" column_names:"v" column_ids:1 column_ids:2 default_column_id:2 > next_family_id:1 primary_index:<name:"primary" id:1 unique:true column_names:"k" column_directions:ASC column_ids:1 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION > interleave:<> partitioning:<num_columns:0 > type:FORWARD > next_index_id:3 privileges:<users:<user:"admin" privileges:2 > users:<user:"root" privileges:2 > > mutations:<index:<name:"woo" id:2 unique:true column_names:"v" column_directions:ASC column_ids:2 extra_column_ids:1 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION > interleave:<> partitioning:<num_columns:0 > type:FORWARD > state:DELETE_AND_WRITE_ONLY direction:DROP mutation_id:2 rollback:false > next_mutation_id:3 format_version:3 state:PUBLIC view_query:"" mutationJobs:<...> drop_time:0 replacement_of:<id:0 time:<> > audit_mode:DISABLED >
+27  dist sender    querying next range at /Table/3/1/52/2/1
+27  dist sender    r1: sending batch 1 Put to (n1,s1):1
+29  dist sender    querying next range at /Table/2/1/0/"system"/3/1
+29  dist sender    r1: sending batch 1 Get to (n1,s1):1
+31  dist sender    querying next range at /Table/3/1/1/2/1
+31  dist sender    r1: sending batch 1 Get to (n1,s1):1
+33  dist sender    querying next range at /Table/2/1/1/"eventlog"/3/1
+33  dist sender    r1: sending batch 1 Get to (n1,s1):1
+35  dist sender    querying next range at /Table/3/1/12/2/1
+35  dist sender    r1: sending batch 1 Get to (n1,s1):1
+37  dist sender    querying next range at /Table/3/1/1/2/1
+37  dist sender    r1: sending batch 1 Get to (n1,s1):1
+39  dist sender    r1: sending batch 5 CPut to (n1,s1):1
 
 query ITT
 SELECT span, operation, regexp_replace(regexp_replace(regexp_replace(message, 'mutationJobs:<[^>]*>', 'mutationJobs:<...>'), 'wall_time:\d+', 'wall_time:...'), 'drop_time:\d+', 'drop_time:...') as message
   FROM [SHOW KV TRACE FOR DROP TABLE t.kv] WHERE message NOT LIKE '%Z/%'
 ----
-1  starting plan  querying next range at /Table/5/1/52/2/1
-1  starting plan  r1: sending batch 1 Get to (n1,s1):1
-1  starting plan  querying next range at /Table/3/1/52/2/1
-1  starting plan  r1: sending batch 1 Get to (n1,s1):1
-1  starting plan  querying next range at /Table/5/1/51/2/1
-1  starting plan  r1: sending batch 1 Get to (n1,s1):1
-1  starting plan  querying next range at /Table/3/1/51/2/1
-1  starting plan  r1: sending batch 1 Get to (n1,s1):1
-1  starting plan  querying next range at /Table/5/1/0/2/1
-1  starting plan  r1: sending batch 1 Get to (n1,s1):1
-1  starting plan  Put /Table/3/1/52/2/1 -> table:<name:"kv" id:52 parent_id:51 version:7 up_version:true modification_time:<wall_time:... > columns:<name:"k" id:1 type:<semantic_type:INT width:0 precision:0 visible_type:NONE > nullable:false hidden:false > columns:<name:"v" id:2 type:<semantic_type:INT width:0 precision:0 visible_type:NONE > nullable:true hidden:false > next_column_id:3 families:<name:"primary" id:0 column_names:"k" column_names:"v" column_ids:1 column_ids:2 default_column_id:2 > next_family_id:1 primary_index:<name:"primary" id:1 unique:true column_names:"k" column_directions:ASC column_ids:1 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION > interleave:<> partitioning:<num_columns:0 > type:FORWARD > next_index_id:3 privileges:<users:<user:"admin" privileges:2 > users:<user:"root" privileges:2 > > next_mutation_id:3 format_version:3 state:DROP draining_names:<parent_id:51 name:"kv" > view_query:"" drop_time:... replacement_of:<id:0 time:<> > audit_mode:DISABLED >
-1  starting plan  querying next range at /Table/SystemConfigSpan/Start
-1  starting plan  r1: sending batch 1 Put, 1 BeginTxn to (n1,s1):1
-1  starting plan  querying next range at /Table/2/1/0/"system"/3/1
-1  starting plan  r1: sending batch 1 Get to (n1,s1):1
-1  starting plan  querying next range at /Table/3/1/1/2/1
-1  starting plan  r1: sending batch 1 Get to (n1,s1):1
-1  starting plan  querying next range at /Table/2/1/1/"eventlog"/3/1
-1  starting plan  r1: sending batch 1 Get to (n1,s1):1
-1  starting plan  querying next range at /Table/3/1/12/2/1
-1  starting plan  r1: sending batch 1 Get to (n1,s1):1
-1  starting plan  querying next range at /Table/3/1/1/2/1
-1  starting plan  r1: sending batch 1 Get to (n1,s1):1
-1  starting plan  r1: sending batch 5 CPut to (n1,s1):1
+2   dist sender    querying next range at /Table/5/1/52/2/1
+2   dist sender    r1: sending batch 1 Get to (n1,s1):1
+4   dist sender    querying next range at /Table/3/1/52/2/1
+4   dist sender    r1: sending batch 1 Get to (n1,s1):1
+6   dist sender    querying next range at /Table/5/1/51/2/1
+6   dist sender    r1: sending batch 1 Get to (n1,s1):1
+8   dist sender    querying next range at /Table/3/1/51/2/1
+8   dist sender    r1: sending batch 1 Get to (n1,s1):1
+10  dist sender    querying next range at /Table/5/1/0/2/1
+10  dist sender    r1: sending batch 1 Get to (n1,s1):1
+1   starting plan  Put /Table/3/1/52/2/1 -> table:<name:"kv" id:52 parent_id:51 version:7 up_version:true modification_time:<wall_time:... > columns:<name:"k" id:1 type:<semantic_type:INT width:0 precision:0 visible_type:NONE > nullable:false hidden:false > columns:<name:"v" id:2 type:<semantic_type:INT width:0 precision:0 visible_type:NONE > nullable:true hidden:false > next_column_id:3 families:<name:"primary" id:0 column_names:"k" column_names:"v" column_ids:1 column_ids:2 default_column_id:2 > next_family_id:1 primary_index:<name:"primary" id:1 unique:true column_names:"k" column_directions:ASC column_ids:1 foreign_key:<table:0 index:0 name:"" validity:Validated shared_prefix_len:0 on_delete:NO_ACTION on_update:NO_ACTION > interleave:<> partitioning:<num_columns:0 > type:FORWARD > next_index_id:3 privileges:<users:<user:"admin" privileges:2 > users:<user:"root" privileges:2 > > next_mutation_id:3 format_version:3 state:DROP draining_names:<parent_id:51 name:"kv" > view_query:"" drop_time:... replacement_of:<id:0 time:<> > audit_mode:DISABLED >
+12  dist sender    querying next range at /Table/SystemConfigSpan/Start
+12  dist sender    r1: sending batch 1 Put, 1 BeginTxn to (n1,s1):1
+15  dist sender    querying next range at /Table/2/1/0/"system"/3/1
+15  dist sender    r1: sending batch 1 Get to (n1,s1):1
+17  dist sender    querying next range at /Table/3/1/1/2/1
+17  dist sender    r1: sending batch 1 Get to (n1,s1):1
+19  dist sender    querying next range at /Table/2/1/1/"eventlog"/3/1
+19  dist sender    r1: sending batch 1 Get to (n1,s1):1
+21  dist sender    querying next range at /Table/3/1/12/2/1
+21  dist sender    r1: sending batch 1 Get to (n1,s1):1
+23  dist sender    querying next range at /Table/3/1/1/2/1
+23  dist sender    r1: sending batch 1 Get to (n1,s1):1
+25  dist sender    r1: sending batch 5 CPut to (n1,s1):1
 
 # SELECT queries - used to exercise the KV tracing for other tests
 

--- a/pkg/sql/trace_test.go
+++ b/pkg/sql/trace_test.go
@@ -82,6 +82,7 @@ func TestTrace(t *testing.T) {
 			expSpans: []string{
 				"session recording",
 				"sql txn",
+				"dist sender",
 				"/cockroach.roachpb.Internal/Batch",
 			},
 		},
@@ -120,6 +121,7 @@ func TestTrace(t *testing.T) {
 				"sql txn",
 				"flow",
 				"table reader",
+				"dist sender",
 				"/cockroach.roachpb.Internal/Batch",
 			},
 			// Depending on whether the data is local or not, we may not see these
@@ -144,6 +146,7 @@ func TestTrace(t *testing.T) {
 				"sql txn",
 				"starting plan",
 				"consuming rows",
+				"dist sender",
 				"/cockroach.roachpb.Internal/Batch",
 			},
 		},
@@ -162,8 +165,8 @@ func TestTrace(t *testing.T) {
 						"WHERE message LIKE '%1 DelRng%' ORDER BY op")
 			},
 			expSpans: []string{
+				"dist sender",
 				"kv.DistSender: sending partial batch",
-				"starting plan",
 				"/cockroach.roachpb.Internal/Batch",
 			},
 		},

--- a/pkg/util/tracing/tracer.go
+++ b/pkg/util/tracing/tracer.go
@@ -607,6 +607,20 @@ func EnsureContext(
 	return ctx, func() {}
 }
 
+// EnsureChildSpan is the same as EnsureContext, except it creates a child
+// span for the input context if the input context already has an active
+// trace.
+func EnsureChildSpan(
+	ctx context.Context, tracer opentracing.Tracer, name string,
+) (context.Context, func()) {
+	if opentracing.SpanFromContext(ctx) == nil {
+		sp := tracer.StartSpan(name)
+		return opentracing.ContextWithSpan(ctx, sp), sp.Finish
+	}
+	ctx, sp := ChildSpan(ctx, name)
+	return ctx, sp.Finish
+}
+
 // StartSnowballTrace takes in a context and returns a derived one with a
 // "snowball span" in it. The caller takes ownership of this span from the
 // returned context and is in charge of Finish()ing it. The span has recording


### PR DESCRIPTION
Previously, distsender would only create a tracing span if there was no
active trace. Now, every call to distsender creates a child span - this
makes it easier to understand the grouping of the spans below it, namely
the actual Batch sends.

Release note: None