### PR TITLE
roachtest: begin porting allocator tests

### DIFF
--- a/pkg/cmd/roachtest/allocator.go
+++ b/pkg/cmd/roachtest/allocator.go
@@ -1,0 +1,230 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+
+package main
+
+import (
+	"context"
+	gosql "database/sql"
+	"fmt"
+	"math"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/pkg/errors"
+)
+
+func init() {
+	runAllocator := func(t *test, start, end int) {
+		const fixturePath = `gs://cockroach-fixtures/workload/tpch/scalefactor=10/backup`
+
+		ctx := context.Background()
+		c := newCluster(ctx, t, end)
+		defer c.Destroy(ctx)
+
+		c.Put(ctx, cockroach, "./cockroach")
+		c.Put(ctx, workload, "./workload")
+
+		// Start the first `start` nodes and restore the fixture
+		c.Start(ctx, c.Range(1, start))
+		db := c.Conn(ctx, 1)
+		defer db.Close()
+
+		m := newMonitor(ctx, c, c.Range(1, start))
+		m.Go(func(ctx context.Context) error {
+			t.Status("loading fixture")
+			if _, err := db.Exec(`RESTORE DATABASE workload FROM $1`, fixturePath); err != nil {
+				t.Fatal(err)
+			}
+			return nil
+		})
+		m.Wait()
+
+		// Start the remaining nodes to kick off upreplication/rebalancing.
+		c.Start(ctx, c.Range(start+1, end))
+
+		c.Run(ctx, 1, `./workload init kv`)
+		m = newMonitor(ctx, c, c.All())
+		for node := 1; node <= end; node++ {
+			node := node
+			m.Go(func(ctx context.Context) error {
+				const cmd = `./workload run kv --tolerate-errors --min-block-bytes=8 --max-block-bytes=128`
+				l, err := c.l.childLogger(fmt.Sprintf(`kv-%d`, node))
+				if err != nil {
+					t.Fatal(err)
+				}
+				defer l.close()
+				c.RunL(ctx, l, node, cmd)
+				return nil
+			})
+		}
+		m.Go(func(ctx context.Context) error {
+			t.Status("waiting for reblance")
+			return waitForRebalance(ctx, c.l, db)
+		})
+		m.Wait()
+	}
+
+	tests.Add(`upreplicate/1to3`, func(t *test) { runAllocator(t, 1, 3) })
+	tests.Add(`rebalance/3to5`, func(t *test) { runAllocator(t, 3, 5) })
+}
+
+// printRebalanceStats prints the time it took for rebalancing to finish and the
+// final standard deviation of replica counts across stores.
+func printRebalanceStats(l *logger, db *gosql.DB) error {
+	// TODO(cuongdo): Output these in a machine-friendly way and graph.
+
+	// Output time it took to rebalance.
+	{
+		var rebalanceIntervalStr string
+		if err := db.QueryRow(
+			`SELECT (SELECT MAX(timestamp) FROM system.rangelog) - `+
+				`(SELECT MAX(timestamp) FROM system.eventlog WHERE "eventType"=$1)`,
+			`node_join`, /* sql.EventLogNodeJoin */
+		).Scan(&rebalanceIntervalStr); err != nil {
+			return err
+		}
+		rebalanceInterval, err := time.ParseDuration(rebalanceIntervalStr)
+		if err != nil {
+			return err
+		}
+		l.printf("cluster took %s to rebalance\n", rebalanceInterval)
+	}
+
+	// Output # of range events that occurred. All other things being equal,
+	// larger numbers are worse and potentially indicate thrashing.
+	{
+		var rangeEvents int64
+		q := `SELECT COUNT(*) from system.rangelog`
+		if err := db.QueryRow(q).Scan(&rangeEvents); err != nil {
+			return err
+		}
+		l.printf("%d range events\n", rangeEvents)
+	}
+
+	// Output standard deviation of the replica counts for all stores.
+	{
+		var stdDev float64
+		if err := db.QueryRow(
+			`SELECT STDDEV(range_count) FROM crdb_internal.kv_store_status`,
+		).Scan(&stdDev); err != nil {
+			return err
+		}
+		l.printf("stdDev(replica count) = %.2f\n", stdDev)
+	}
+
+	return nil
+}
+
+type replicationStats struct {
+	ElapsedSinceLastEvent time.Duration
+	EventType             string
+	RangeID               int64
+	StoreID               int64
+	ReplicaCountStdDev    float64
+}
+
+func (s replicationStats) String() string {
+	return fmt.Sprintf("last range event: %s for range %d/store %d (%s ago)",
+		s.EventType, s.RangeID, s.StoreID, s.ElapsedSinceLastEvent)
+}
+
+// allocatorStats returns the duration of stability (i.e. no replication
+// changes) and the standard deviation in replica counts. Only unrecoverable
+// errors are returned.
+func allocatorStats(db *gosql.DB) (s replicationStats, err error) {
+	defer func() {
+		if err != nil {
+			s.ReplicaCountStdDev = math.MaxFloat64
+		}
+	}()
+
+	// NB: These are the storage.RangeLogEventType enum, but it's intentionally
+	// not used to avoid pulling in the dep.
+	eventTypes := []interface{}{
+		`split`, `add`, `remove`,
+	}
+
+	q := `SELECT NOW()-timestamp, "rangeID", "storeID", "eventType" FROM system.rangelog ` +
+		`WHERE "eventType" IN ($1, $2, $3) ORDER BY timestamp DESC LIMIT 1`
+
+	var elapsedStr string
+
+	row := db.QueryRow(q, eventTypes...)
+	if row == nil {
+		// This should never happen, because the archived store we're starting with
+		// will always have some range events.
+		return replicationStats{}, errors.New("couldn't find any range events")
+	}
+	if err := row.Scan(&elapsedStr, &s.RangeID, &s.StoreID, &s.EventType); err != nil {
+		return replicationStats{}, err
+	}
+	s.ElapsedSinceLastEvent, err = time.ParseDuration(elapsedStr)
+	if err != nil {
+		return replicationStats{}, err
+	}
+
+	if err := db.QueryRow(
+		`SELECT STDDEV(range_count) FROM crdb_internal.kv_store_status`,
+	).Scan(&s.ReplicaCountStdDev); err != nil {
+		return replicationStats{}, err
+	}
+
+	return s, nil
+}
+
+// waitForRebalance waits until there's been no recent range adds, removes, and
+// splits. We wait until the cluster is balanced or until `StableInterval`
+// elapses, whichever comes first. Then, it prints stats about the rebalancing
+// process. If the replica count appears unbalanced, an error is returned.
+//
+// This method is crude but necessary. If we were to wait until range counts
+// were just about even, we'd miss potential post-rebalance thrashing.
+func waitForRebalance(ctx context.Context, l *logger, db *gosql.DB) error {
+	// const statsInterval = 20 * time.Second
+	const statsInterval = 2 * time.Second
+	const stableInterval = 3 * time.Minute
+	const maxStdDev = 10.0
+
+	var statsTimer timeutil.Timer
+	defer statsTimer.Stop()
+	statsTimer.Reset(statsInterval)
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-statsTimer.C:
+			statsTimer.Read = true
+			stats, err := allocatorStats(db)
+			if err != nil {
+				return err
+			}
+
+			l.printf("%v\n", stats)
+			if stableInterval <= stats.ElapsedSinceLastEvent {
+				l.printf("num replicas stddev = %f, max = %f\n", stats.ReplicaCountStdDev, maxStdDev)
+				if stats.ReplicaCountStdDev > maxStdDev {
+					_ = printRebalanceStats(l, db)
+					return errors.Errorf(
+						"%s elapsed without changes, but replica count standard "+
+							"deviation is %.2f (>%.2f)", stats.ElapsedSinceLastEvent,
+						stats.ReplicaCountStdDev, maxStdDev)
+				}
+				return printRebalanceStats(l, db)
+			}
+			statsTimer.Reset(statsInterval)
+		}
+	}
+}

--- a/pkg/cmd/roachtest/cluster_test.go
+++ b/pkg/cmd/roachtest/cluster_test.go
@@ -46,7 +46,7 @@ func TestClusterNodes(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run("", func(t *testing.T) {
-			nodes := c.makeNodes(tc.opts)
+			nodes := c.makeNodes(tc.opts...)
 			if tc.expected != nodes {
 				t.Fatalf("expected %s, but found %s", tc.expected, nodes)
 			}


### PR DESCRIPTION
It's easier in roachtest to make SQL connections than to scrape the
admin ui, so one of the stats (stddev of #ranges) was ported. I also
replaced block_writer with kv (which was a TODO in the old code) and cut
photos (could easily replace this with tpcc if we think there's value in
two different workloads running). Other than that, everything else is
more or less the same.

The old tests are currently broken because the store dumps are 1.0 and
2.0 binaries no longer start on them directly, so I had to download this
one, start up a 1.1 binary on it, and reupload it. Unfortunately I
accidentally did the 10gb 1 node instead of the 17gb. This will be fixed
in a followup along with adding the rest of these tests.

Release note: None

@a-robinson I don't have a good feel for what's proven useful from the nightly allocator tests. I'd love to hear your thoughts. For example, have the existing stats been interesting? How much of the `runSchemaChanges` stuff is valuable to port?