### PR TITLE
cherry-pick 2.0: storage: refresh spans on InitPut; heed tombstones on Refresh / Refre…

### DIFF
--- a/c-deps/libroach/include/libroach.h
+++ b/c-deps/libroach/include/libroach.h
@@ -268,9 +268,9 @@ typedef struct {
 } DBScanResults;
 
 DBScanResults MVCCGet(DBIterator* iter, DBSlice key, DBTimestamp timestamp, DBTxn txn,
-                      bool consistent);
+                      bool consistent, bool tombstones);
 DBScanResults MVCCScan(DBIterator* iter, DBSlice start, DBSlice end, DBTimestamp timestamp,
-                       int64_t max_keys, DBTxn txn, bool consistent, bool reverse);
+                       int64_t max_keys, DBTxn txn, bool consistent, bool reverse, bool tombstones);
 
 // DBStatsResult contains various runtime stats for RocksDB.
 typedef struct {

--- a/c-deps/libroach/mvcc.cc
+++ b/c-deps/libroach/mvcc.cc
@@ -260,7 +260,7 @@ DBStatus MVCCFindSplitKey(DBIterator* iter, DBKey start, DBKey end, DBKey min_sp
 }
 
 DBScanResults MVCCGet(DBIterator* iter, DBSlice key, DBTimestamp timestamp, DBTxn txn,
-                      bool consistent) {
+                      bool consistent, bool tombstones) {
   // Get is implemented as a scan where we retrieve a single key. Note
   // that the semantics of max_keys is that we retrieve one more key
   // than is specified in order to maintain the existing semantics of
@@ -270,17 +270,17 @@ DBScanResults MVCCGet(DBIterator* iter, DBSlice key, DBTimestamp timestamp, DBTx
   // don't retrieve a key different than the start key. This is a bit
   // of a hack.
   const DBSlice end = {0, 0};
-  mvccForwardScanner scanner(iter, key, end, timestamp, 0 /* max_keys */, txn, consistent);
+  mvccForwardScanner scanner(iter, key, end, timestamp, 0 /* max_keys */, txn, consistent, tombstones);
   return scanner.get();
 }
 
 DBScanResults MVCCScan(DBIterator* iter, DBSlice start, DBSlice end, DBTimestamp timestamp,
-                       int64_t max_keys, DBTxn txn, bool consistent, bool reverse) {
+                       int64_t max_keys, DBTxn txn, bool consistent, bool reverse, bool tombstones) {
   if (reverse) {
-    mvccReverseScanner scanner(iter, end, start, timestamp, max_keys, txn, consistent);
+    mvccReverseScanner scanner(iter, end, start, timestamp, max_keys, txn, consistent, tombstones);
     return scanner.scan();
   } else {
-    mvccForwardScanner scanner(iter, start, end, timestamp, max_keys, txn, consistent);
+    mvccForwardScanner scanner(iter, start, end, timestamp, max_keys, txn, consistent, tombstones);
     return scanner.scan();
   }
 }

--- a/c-deps/libroach/mvcc.h
+++ b/c-deps/libroach/mvcc.h
@@ -50,7 +50,7 @@ static const int kMaxItersBeforeSeek = 10;
 template <bool reverse> class mvccScanner {
  public:
   mvccScanner(DBIterator* iter, DBSlice start, DBSlice end, DBTimestamp timestamp, int64_t max_keys,
-              DBTxn txn, bool consistent)
+              DBTxn txn, bool consistent, bool tombstones)
       : iter_(iter),
         iter_rep_(iter->rep.get()),
         start_key_(ToSlice(start)),
@@ -61,6 +61,7 @@ template <bool reverse> class mvccScanner {
         txn_epoch_(txn.epoch),
         txn_max_timestamp_(txn.max_timestamp),
         consistent_(consistent),
+        tombstones_(tombstones),
         check_uncertainty_(timestamp < txn.max_timestamp),
         kvs_(new chunkedBuffer),
         intents_(new rocksdb::WriteBatch),
@@ -418,7 +419,9 @@ template <bool reverse> class mvccScanner {
   }
 
   bool addAndAdvance(const rocksdb::Slice& value) {
-    if (value.size() > 0) {
+    // Don't include deleted versions (value.size() == 0), unless we've been
+    // instructed to include tombstones in the results.
+    if (value.size() > 0 || tombstones_) {
       kvs_->Put(cur_raw_key_, value);
       if (kvs_->Count() > max_keys_) {
         return false;
@@ -605,6 +608,7 @@ template <bool reverse> class mvccScanner {
   const uint32_t txn_epoch_;
   const DBTimestamp txn_max_timestamp_;
   const bool consistent_;
+  const bool tombstones_;
   const bool check_uncertainty_;
   DBScanResults results_;
   std::unique_ptr<chunkedBuffer> kvs_;

--- a/pkg/cli/debug.go
+++ b/pkg/cli/debug.go
@@ -566,7 +566,7 @@ func runDebugGCCmd(cmd *cobra.Command, args []string) error {
 	var descs []roachpb.RangeDescriptor
 
 	if _, err := engine.MVCCIterate(context.Background(), db, start, end, hlc.MaxTimestamp,
-		false /* consistent */, nil, /* txn */
+		false /* consistent */, false /* tombstones */, nil, /* txn */
 		false /* reverse */, func(kv roachpb.KeyValue) (bool, error) {
 			var desc roachpb.RangeDescriptor
 			_, suffix, _, err := keys.DecodeRangeKey(kv.Key)
@@ -705,7 +705,7 @@ func runDebugCheckStoreRaft(ctx context.Context, db *engine.RocksDB) error {
 	}
 
 	if _, err := engine.MVCCIterate(ctx, db, start, end, hlc.MaxTimestamp,
-		false /* consistent */, nil, /* txn */
+		false /* consistent */, false /* tombstones */, nil, /* txn */
 		false /* reverse */, func(kv roachpb.KeyValue) (bool, error) {
 			rangeID, _, suffix, detail, err := keys.DecodeRangeIDKey(kv.Key)
 			if err != nil {

--- a/pkg/roachpb/api.go
+++ b/pkg/roachpb/api.go
@@ -966,10 +966,12 @@ func (*ConditionalPutRequest) flags() int {
 
 // InitPut, like ConditionalPut, effectively reads and may not write.
 // It also may return the actual data read on ConditionFailedErrors,
-// so must update the timestamp cache on errors. Like CPut, InitPuts
-// do not require a refresh because they return errors on write-too-old.
+// so must update the timestamp cache on errors. Unlike CPut, InitPuts
+// require a refresh because they may execute successfully without
+// leaving an intent (i.e., when the existing value is equal to the
+// proposed value).
 func (*InitPutRequest) flags() int {
-	return isRead | isWrite | isTxn | isTxnWrite | updatesReadTSCache | updatesTSCacheOnError | consultsTSCache
+	return isRead | isWrite | isTxn | isTxnWrite | updatesReadTSCache | updatesTSCacheOnError | needsRefresh | consultsTSCache
 }
 
 // Increment reads the existing value, but always leaves an intent so

--- a/pkg/roachpb/batch_test.go
+++ b/pkg/roachpb/batch_test.go
@@ -259,7 +259,7 @@ func TestRefreshSpanIterate(t *testing.T) {
 	}
 	ba.RefreshSpanIterate(&br, fn)
 	// Only the conditional put isn't considered a read span.
-	expReadSpans := []Span{testCases[4].span, testCases[5].span, testCases[6].span}
+	expReadSpans := []Span{testCases[2].span, testCases[4].span, testCases[5].span, testCases[6].span}
 	expWriteSpans := []Span{testCases[7].span}
 	if !reflect.DeepEqual(expReadSpans, readSpans) {
 		t.Fatalf("unexpected read spans: expected %+v, found = %+v", expReadSpans, readSpans)
@@ -284,6 +284,7 @@ func TestRefreshSpanIterate(t *testing.T) {
 	writeSpans = []Span{}
 	ba.RefreshSpanIterate(&br, fn)
 	expReadSpans = []Span{
+		{Key: Key("a-initput")},
 		{Key("a"), Key("b")},
 		{Key: Key("b")},
 		{Key("e"), Key("f")},

--- a/pkg/storage/abortspan/abortspan.go
+++ b/pkg/storage/abortspan/abortspan.go
@@ -112,7 +112,7 @@ func (sc *AbortSpan) Iterate(
 	ctx context.Context, e engine.Reader, f func([]byte, roachpb.AbortSpanEntry),
 ) {
 	_, _ = engine.MVCCIterate(ctx, e, sc.min(), sc.max(), hlc.Timestamp{},
-		true /* consistent */, nil /* txn */, false, /* reverse */
+		true /* consistent */, false /* tombstones */, nil /* txn */, false, /* reverse */
 		func(kv roachpb.KeyValue) (bool, error) {
 			var entry roachpb.AbortSpanEntry
 			if _, err := keys.DecodeAbortSpanKey(kv.Key, nil); err != nil {

--- a/pkg/storage/batcheval/cmd_refresh.go
+++ b/pkg/storage/batcheval/cmd_refresh.go
@@ -42,11 +42,13 @@ func Refresh(
 	}
 
 	// Get the most recent committed value and return any intent by
-	// specifying consistent=false.
+	// specifying consistent=false. Note that we include tombstones,
+	// which must be considered as updates on refresh.
 	log.VEventf(ctx, 2, "refresh %s @[%s-%s]", args.Header(), h.Txn.OrigTimestamp, h.Txn.Timestamp)
-	val, intents, err := engine.MVCCGet(
+	val, intents, err := engine.MVCCGetWithTombstone(
 		ctx, batch, args.Key, h.Txn.Timestamp, false /* consistent */, nil, /* txn */
 	)
+
 	if err != nil {
 		return result.Result{}, err
 	} else if val != nil {

--- a/pkg/storage/batcheval/cmd_refresh_range.go
+++ b/pkg/storage/batcheval/cmd_refresh_range.go
@@ -51,7 +51,8 @@ func RefreshRange(
 	// timestamp. Note that we do not iterate using the txn and the
 	// iteration is done with consistent=false. This reads only
 	// committed values and returns all intents, including those from
-	// the txn itself.
+	// the txn itself. Note that we include tombstones, which must be
+	// considered as updates on refresh.
 	log.VEventf(ctx, 2, "refresh %s @[%s-%s]", args.Header(), h.Txn.OrigTimestamp, h.Txn.Timestamp)
 	intents, err := engine.MVCCIterateUsingIter(
 		ctx,
@@ -60,6 +61,7 @@ func RefreshRange(
 		args.EndKey,
 		h.Txn.Timestamp,
 		false, /* consistent */
+		true,  /* tombstones */
 		nil,   /* txn */
 		false, /* reverse */
 		iter,

--- a/pkg/storage/client_merge_test.go
+++ b/pkg/storage/client_merge_test.go
@@ -102,7 +102,7 @@ func TestStoreRangeMergeMetadataCleanup(t *testing.T) {
 	store := createTestStoreWithConfig(t, stopper, storeCfg)
 
 	scan := func(f func(roachpb.KeyValue) (bool, error)) {
-		if _, err := engine.MVCCIterate(context.Background(), store.Engine(), roachpb.KeyMin, roachpb.KeyMax, hlc.Timestamp{}, true, nil, false, f); err != nil {
+		if _, err := engine.MVCCIterate(context.Background(), store.Engine(), roachpb.KeyMin, roachpb.KeyMax, hlc.Timestamp{}, true, false, nil, false, f); err != nil {
 			t.Fatal(err)
 		}
 	}

--- a/pkg/storage/engine/engine.go
+++ b/pkg/storage/engine/engine.go
@@ -102,15 +102,19 @@ type Iterator interface {
 	// value is returned in batch repr format with the key being present as the
 	// empty string. If an intent exists at the specified key, it will be
 	// returned in batch repr format in the separate intent return value.
+	// Specify true for tombstones to return a value if the key has been
+	// deleted (Value.RawBytes will be empty).
 	MVCCGet(key roachpb.Key, timestamp hlc.Timestamp,
-		txn *roachpb.Transaction, consistent bool,
+		txn *roachpb.Transaction, consistent, tombstones bool,
 	) (*roachpb.Value, []roachpb.Intent, error)
 	// MVCCScan scans the underlying engine from start to end keys and returns
 	// key/value pairs which have a timestamp less than or equal to the supplied
 	// timestamp, up to a max rows. The key/value pairs are returned as a buffer
 	// of varint-prefixed slices, alternating from key to value, numKvs pairs.
+	// Specify true for tombstones to return deleted values (the value portion
+	// will be empty).
 	MVCCScan(start, end roachpb.Key, max int64, timestamp hlc.Timestamp,
-		txn *roachpb.Transaction, consistent, reverse bool,
+		txn *roachpb.Transaction, consistent, reverse, tombstone bool,
 	) (kvs []byte, numKvs int64, intents []byte, err error)
 }
 

--- a/pkg/storage/gc_queue.go
+++ b/pkg/storage/gc_queue.go
@@ -441,7 +441,7 @@ func processLocalKeyRange(
 	endKey := keys.MakeRangeKeyPrefix(desc.EndKey)
 
 	_, err := engine.MVCCIterate(ctx, snap, startKey, endKey,
-		hlc.Timestamp{}, true /* consistent */, nil, /* txn */
+		hlc.Timestamp{}, true /* consistent */, false /* tombstones */, nil, /* txn */
 		false /* reverse */, func(kv roachpb.KeyValue) (bool, error) {
 			return false, handleOne(kv)
 		})

--- a/pkg/storage/gc_queue_test.go
+++ b/pkg/storage/gc_queue_test.go
@@ -786,7 +786,7 @@ func TestGCQueueTransactionTable(t *testing.T) {
 	outsideTxnPrefixEnd := keys.TransactionKey(outsideKey.Next(), uuid.UUID{})
 	var count int
 	if _, err := engine.MVCCIterate(context.Background(), tc.store.Engine(), outsideTxnPrefix, outsideTxnPrefixEnd, hlc.Timestamp{},
-		true, nil, false, func(roachpb.KeyValue) (bool, error) {
+		true, false, nil, false, func(roachpb.KeyValue) (bool, error) {
 			count++
 			return false, nil
 		}); err != nil {

--- a/pkg/storage/replica_raftstorage.go
+++ b/pkg/storage/replica_raftstorage.go
@@ -229,6 +229,7 @@ func iterateEntries(
 		keys.RaftLogKey(rangeID, hi),
 		hlc.Timestamp{},
 		true,  /* consistent */
+		false, /* tombstones */
 		nil,   /* txn */
 		false, /* reverse */
 		scanFunc,

--- a/pkg/storage/spanset/batch.go
+++ b/pkg/storage/spanset/batch.go
@@ -166,12 +166,12 @@ func (s *Iterator) FindSplitKey(
 
 // MVCCGet is part of the engine.Iterator interface.
 func (s *Iterator) MVCCGet(
-	key roachpb.Key, timestamp hlc.Timestamp, txn *roachpb.Transaction, consistent bool,
+	key roachpb.Key, timestamp hlc.Timestamp, txn *roachpb.Transaction, consistent, tombstones bool,
 ) (*roachpb.Value, []roachpb.Intent, error) {
 	if err := s.spans.CheckAllowed(SpanReadOnly, roachpb.Span{Key: key}); err != nil {
 		return nil, nil, err
 	}
-	return s.i.MVCCGet(key, timestamp, txn, consistent)
+	return s.i.MVCCGet(key, timestamp, txn, consistent, tombstones)
 }
 
 // MVCCScan is part of the engine.Iterator interface.
@@ -180,12 +180,12 @@ func (s *Iterator) MVCCScan(
 	max int64,
 	timestamp hlc.Timestamp,
 	txn *roachpb.Transaction,
-	consistent, reverse bool,
+	consistent, reverse, tombstones bool,
 ) (kvs []byte, numKvs int64, intents []byte, err error) {
 	if err := s.spans.CheckAllowed(SpanReadOnly, roachpb.Span{Key: start, EndKey: end}); err != nil {
 		return nil, 0, nil, err
 	}
-	return s.i.MVCCScan(start, end, max, timestamp, txn, consistent, reverse)
+	return s.i.MVCCScan(start, end, max, timestamp, txn, consistent, reverse, tombstones)
 }
 
 type spanSetReader struct {

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -1128,8 +1128,8 @@ func IterateRangeDescriptors(
 		return fn(desc)
 	}
 
-	_, err := engine.MVCCIterate(ctx, eng, start, end, hlc.MaxTimestamp, false /* consistent */, nil, /* txn */
-		false /* reverse */, kvToDesc)
+	_, err := engine.MVCCIterate(ctx, eng, start, end, hlc.MaxTimestamp, false /* consistent */, false, /* tombstones */
+		nil /* txn */, false /* reverse */, kvToDesc)
 	log.Eventf(ctx, "iterated over %d keys to find %d range descriptors (by suffix: %v)",
 		allCount, matchCount, bySuffix)
 	return err


### PR DESCRIPTION
…shRange

A closer examination of `InitPut` made it clear that because it always
reads, but may not write, we must refresh the span to ensure that no
further writes have occurred. This is different from `ConditionalPut`,
which always leaves an intent on success.

A test case for serializable retries which verifies that `InitPut` must
do a client-side retry in the event that it refreshes its key to fail
on a new tombstone showed that we were not failing on new tombstones.
This revealed a bug in `Refresh` and `RefreshRange`, where we should be
discovering tombstones, but weren't. This PR adds an optional parameter
to `MVCCScan` and `MVCCGet` to return tombstone values.

Fixes #22543

Release note: None