### PR TITLE
opt: Add Presentation physical property

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/builder.go
+++ b/pkg/sql/opt/exec/execbuilder/builder.go
@@ -51,6 +51,7 @@ func (b *Builder) build(ev xform.ExprView) (exec.Node, error) {
 		return nil, err
 	}
 	// TODO(radu): plan.outputCols will be used to apply a final projection.
+	// TODO(radu): check physical props for final presentation.
 	return plan.root, err
 }
 

--- a/pkg/sql/opt/exec/execbuilder/testdata/project
+++ b/pkg/sql/opt/exec/execbuilder/testdata/project
@@ -110,24 +110,27 @@ SELECT u + v FROM (SELECT x + 3, y + 10 FROM t.a) AS foo(u, v)
 35
 46
 
-exec-explain
-SELECT x, x, y, x FROM t.a
-----
-render     0  render  ·         ·          ("a.x", "a.x", "a.y", "a.x")  ·
- │         0  ·       render 0  x          ·                             ·
- │         0  ·       render 1  x          ·                             ·
- │         0  ·       render 2  y          ·                             ·
- │         0  ·       render 3  x          ·                             ·
- └── scan  1  scan    ·         ·          (x, y)                        ·
-·          1  ·       table     a@primary  ·                             ·
-·          1  ·       spans     ALL        ·                             ·
+# TODO(radu): Uncomment this test once execbuilder handles the Presentation
+#             physical property.
 
-exec
-SELECT x, x, y, x FROM t.a
-----
-1  1  10  1
-2  2  20  2
-3  3  30  3
+# exec-explain
+# SELECT x, x, y, x FROM t.a
+# ----
+# render     0  render  ·         ·          ("a.x", "a.x", "a.y", "a.x")  ·
+#  │         0  ·       render 0  x          ·                             ·
+#  │         0  ·       render 1  x          ·                             ·
+#  │         0  ·       render 2  y          ·                             ·
+#  │         0  ·       render 3  x          ·                             ·
+#  └── scan  1  scan    ·         ·          (x, y)                        ·
+# ·          1  ·       table     a@primary  ·                             ·
+# ·          1  ·       spans     ALL        ·                             ·
+
+# exec
+# SELECT x, x, y, x FROM t.a
+# ----
+# 1  1  10  1
+# 2  2  20  2
+# 3  3  30  3
 
 exec-explain
 SELECT x + 1, x + y FROM t.a WHERE x + y > 20

--- a/pkg/sql/opt/exec/execbuilder/testdata/scan
+++ b/pkg/sql/opt/exec/execbuilder/testdata/scan
@@ -11,7 +11,7 @@ build
 SELECT * FROM t.a
 ----
 scan
- └── columns: a.x:int:1 a.y:float:null:2
+ └── columns: x:int:1 y:float:null:2
 
 exec-explain
 SELECT * FROM t.a

--- a/pkg/sql/opt/ops/enforcer.opt
+++ b/pkg/sql/opt/ops/enforcer.opt
@@ -19,17 +19,3 @@
 define Sort {
     Input Expr
 }
-
-# Present enforces physical properties related to column presentation, which
-# includes column ordering, column naming, and duplicate columns. While the
-# input expression must project the columns used by Present, it can project
-# a superset of columns in any order and using any names. Whereas the Project
-# operator modifies logical properties (i.e. the set of columns returned), the
-# Present operator enforces physical properties (i.e. the presentation of the
-# set of columns returned). See the Presentation field in the PhysicalProps
-# struct.
-# TODO(andyk): Add the Presentation field.
-[Enforcer]
-define Present {
-    Input Expr
-}

--- a/pkg/sql/opt/opt/operator.og.go
+++ b/pkg/sql/opt/opt/operator.og.go
@@ -242,24 +242,13 @@ const (
 	// TODO(andyk): Add the Ordering field.
 	SortOp
 
-	// PresentOp enforces physical properties related to column presentation, which
-	// includes column ordering, column naming, and duplicate columns. While the
-	// input expression must project the columns used by Present, it can project
-	// a superset of columns in any order and using any names. Whereas the Project
-	// operator modifies logical properties (i.e. the set of columns returned), the
-	// Present operator enforces physical properties (i.e. the presentation of the
-	// set of columns returned). See the Presentation field in the PhysicalProps
-	// struct.
-	// TODO(andyk): Add the Presentation field.
-	PresentOp
-
 	// NumOperators tracks the total count of operators.
 	NumOperators
 )
 
-const opNames = "unknownsubqueryvariableconsttruefalseplaceholdertupleprojectionsaggregationsexistsandornoteqltgtlegeneinnot-inlikenot-likei-likenot-i-likesimilar-tonot-similar-toreg-matchnot-reg-matchreg-i-matchnot-reg-i-matchisis-notcontainsbitandbitorbitxorplusminusmultdivfloor-divmodpowconcatl-shiftr-shiftfetch-valfetch-textfetch-val-pathfetch-text-pathunary-plusunary-minusunary-complementfunctioncoalesceunsupported-exprscanvaluesselectprojectinner-joinleft-joinright-joinfull-joinsemi-joinanti-joininner-join-applyleft-join-applyright-join-applyfull-join-applysemi-join-applyanti-join-applygroup-byunionintersectexceptsortpresent"
+const opNames = "unknownsubqueryvariableconsttruefalseplaceholdertupleprojectionsaggregationsexistsandornoteqltgtlegeneinnot-inlikenot-likei-likenot-i-likesimilar-tonot-similar-toreg-matchnot-reg-matchreg-i-matchnot-reg-i-matchisis-notcontainsbitandbitorbitxorplusminusmultdivfloor-divmodpowconcatl-shiftr-shiftfetch-valfetch-textfetch-val-pathfetch-text-pathunary-plusunary-minusunary-complementfunctioncoalesceunsupported-exprscanvaluesselectprojectinner-joinleft-joinright-joinfull-joinsemi-joinanti-joininner-join-applyleft-join-applyright-join-applyfull-join-applysemi-join-applyanti-join-applygroup-byunionintersectexceptsort"
 
-var opIndexes = [...]uint32{0, 7, 15, 23, 28, 32, 37, 48, 53, 64, 76, 82, 85, 87, 90, 92, 94, 96, 98, 100, 102, 104, 110, 114, 122, 128, 138, 148, 162, 171, 184, 195, 210, 212, 218, 226, 232, 237, 243, 247, 252, 256, 259, 268, 271, 274, 280, 287, 294, 303, 313, 327, 342, 352, 363, 379, 387, 395, 411, 415, 421, 427, 434, 444, 453, 463, 472, 481, 490, 506, 521, 537, 552, 567, 582, 590, 595, 604, 610, 614, 621}
+var opIndexes = [...]uint32{0, 7, 15, 23, 28, 32, 37, 48, 53, 64, 76, 82, 85, 87, 90, 92, 94, 96, 98, 100, 102, 104, 110, 114, 122, 128, 138, 148, 162, 171, 184, 195, 210, 212, 218, 226, 232, 237, 243, 247, 252, 256, 259, 268, 271, 274, 280, 287, 294, 303, 313, 327, 342, 352, 363, 379, 387, 395, 411, 415, 421, 427, 434, 444, 453, 463, 472, 481, 490, 506, 521, 537, 552, 567, 582, 590, 595, 604, 610, 614}
 
 var ScalarOperators = [...]Operator{
 	SubqueryOp,
@@ -434,5 +423,4 @@ var JoinApplyOperators = [...]Operator{
 
 var EnforcerOperators = [...]Operator{
 	SortOp,
-	PresentOp,
 }

--- a/pkg/sql/opt/opt/physical_props.go
+++ b/pkg/sql/opt/opt/physical_props.go
@@ -14,22 +14,46 @@
 
 package opt
 
+import (
+	"bytes"
+	"fmt"
+)
+
 // PhysicalPropsID identifies a set of physical properties that has been
-// interned by a memo instance. If two ids are different, then the physical
-// properties are different.
+// interned by a memo instance. If two ids are the same, then the physical
+// properties are the same.
 type PhysicalPropsID uint32
 
 const (
+	// NormPhysPropsID is a special id used to create and traverse a normalized
+	// expression tree before it's been fully explored and costed. Before then,
+	// its physical properties are still undefined, and they cannot not be
+	// used. But the id itself can still be used with ExprView to traverse the
+	// normalized logical expression tree (with no enforcers or physical
+	// properties present).
+	//
+	// While NormPhysPropsID and MinPhysPropsID refer to the same default
+	// normalized expression at the beginning of optimization, the
+	// MinPhysPropsID expression tree quickly diverges as the optimizer finds
+	// alternate expressions with lower cost.
+	NormPhysPropsID PhysicalPropsID = 1
+
 	// MinPhysPropsID is the id of the well-known set of physical properties
 	// that requires nothing of an operator. Therefore, every operator is
-	// guaranteed to provide this set of properties.
-	MinPhysPropsID PhysicalPropsID = 1
+	// guaranteed to provide this set of properties. This is typically the most
+	// commonly used set of physical properties in the memo, since most
+	// operators do not require any physical properties from their children.
+	MinPhysPropsID PhysicalPropsID = 2
 )
 
 // PhysicalProps are interesting characteristics of an expression that impact
-// its layout, presentation, or location, but not its logical content. For
-// example, sort order will change the order of rows, but not the membership or
-// data content of the rows.
+// its layout, presentation, or location, but not its logical content. Examples
+// include row order, column naming, and data distribution (physical location
+// of data ranges). Physical properties exist outside of the relational
+// algebra, and arise from both the SQL query itself (e.g. the non-relational
+// ORDER BY operator) and by the selection of specific implementations during
+// optimization (e.g. a merge join requires the inputs to be sorted in a
+// particular order).
 //
 // Physical properties can be provided by an operator or required of it. Some
 // operators "naturally" provide a physical property such as ordering on a
@@ -38,8 +62,85 @@ const (
 // is always with respect to a particular set of required physical properties.
 // The goal is to find the lowest cost expression that provides those
 // properties while still remaining logically equivalent.
-//
-// TODO(andyk): add physical properties to the struct once we're ready for
-// them.
 type PhysicalProps struct {
+	// Presentation specifies the naming, membership (including duplicates),
+	// and order of result columns. If Presentation is not defined, then no
+	// particular column presentation is required or provided.
+	Presentation Presentation
+}
+
+// Defined returns true if any physical property is defined. If none is
+// defined, then this is an instance of MinPhysProps.
+func (p *PhysicalProps) Defined() bool {
+	return p.Presentation.Defined()
+}
+
+// Fingerprint returns a string that uniquely describes this set of physical
+// properties. It is suitable for use as a hash key in a map.
+func (p *PhysicalProps) Fingerprint() string {
+	hasProjection := p.Presentation.Defined()
+
+	// Handle default properties case.
+	if !hasProjection {
+		return ""
+	}
+
+	var buf bytes.Buffer
+
+	if hasProjection {
+		buf.WriteString("p:")
+		p.Presentation.format(&buf)
+	}
+
+	return buf.String()
+}
+
+// Presentation specifies the naming, membership (including duplicates), and
+// order of result columns that are required of or provided by an operator.
+// While it cannot add unique columns, Presentation can rename, reorder,
+// duplicate and discard columns. If Presentation is not defined, then no
+// particular column presentation is required or provided. For example:
+//   a.y:2 a.x:1 a.y:2 column1:3
+type Presentation []LabeledColumn
+
+// Defined is true if a particular column presentation is required or provided.
+func (p Presentation) Defined() bool {
+	return p != nil
+}
+
+// Provides returns true iff this presentation exactly matches the given
+// presentation.
+func (p Presentation) Provides(required Presentation) bool {
+	if len(p) != len(required) {
+		return false
+	}
+
+	for i := 0; i < len(p); i++ {
+		if p[i] != required[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func (p Presentation) String() string {
+	var buf bytes.Buffer
+	p.format(&buf)
+	return buf.String()
+}
+
+func (p Presentation) format(buf *bytes.Buffer) {
+	for i, col := range p {
+		if i > 0 {
+			buf.WriteString(",")
+		}
+
+		fmt.Fprintf(buf, "%s:%d", col.Label, col.Index)
+	}
+}
+
+// LabeledColumn specifies the label and index of a column.
+type LabeledColumn struct {
+	Label string
+	Index ColumnIndex
 }

--- a/pkg/sql/opt/opt/physical_props_test.go
+++ b/pkg/sql/opt/opt/physical_props_test.go
@@ -1,0 +1,56 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package opt
+
+import (
+	"testing"
+)
+
+func TestPhysicalProps(t *testing.T) {
+	// Empty props.
+	props := &PhysicalProps{}
+	testPhysicalProps(t, props, "")
+
+	if props.Defined() {
+		t.Error("no props should be defined")
+	}
+
+	// Presentation props.
+	presentation := Presentation{
+		LabeledColumn{Label: "a", Index: 1},
+		LabeledColumn{Label: "b", Index: 2},
+	}
+	props = &PhysicalProps{Presentation: presentation}
+	testPhysicalProps(t, props, "p:a:1,b:2")
+
+	if !presentation.Defined() {
+		t.Error("presentation should be defined")
+	}
+
+	if !presentation.Provides(presentation) {
+		t.Error("presentation should provide itself")
+	}
+
+	if presentation.Provides(Presentation{}) {
+		t.Error("presentation should not provide the empty presentation")
+	}
+}
+
+func testPhysicalProps(t *testing.T, physProps *PhysicalProps, expected string) {
+	actual := physProps.Fingerprint()
+	if actual != expected {
+		t.Errorf("\nexpected: %s\nactual: %s", expected, actual)
+	}
+}

--- a/pkg/sql/opt/optbuilder/testdata/aggregate
+++ b/pkg/sql/opt/optbuilder/testdata/aggregate
@@ -21,7 +21,7 @@ SELECT MIN(1), MAX(1), COUNT(1), SUM_INT(1), AVG(1), SUM(1), STDDEV(1),
   VARIANCE(1), BOOL_AND(true), BOOL_AND(false), XOR_AGG(b'\x01') FROM t.kv
 ----
 group-by
- ├── aggregation columns: column6:int:null:6 column8:int:null:8 column10:int:null:10 column12:int:null:12 column14:decimal:null:14 column16:decimal:null:16 column18:decimal:null:18 column20:decimal:null:20 column22:bool:null:22 column24:bool:null:24 column26:bytes:null:26
+ ├── columns: column6:int:null:6 column8:int:null:8 column10:int:null:10 column12:int:null:12 column14:decimal:null:14 column16:decimal:null:16 column18:decimal:null:18 column20:decimal:null:20 column22:bool:null:22 column24:bool:null:24 column26:bytes:null:26
  ├── project
  │    ├── columns: column5:int:null:5 column7:int:null:7 column9:int:null:9 column11:int:null:11 column13:int:null:13 column15:int:null:15 column17:int:null:17 column19:int:null:19 column21:bool:null:21 column23:bool:null:23 column25:bytes:null:25
  │    ├── scan
@@ -66,7 +66,7 @@ build
 SELECT ARRAY_AGG(1) FROM t.kv
 ----
 group-by
- ├── aggregation columns: column6:int[]:null:6
+ ├── columns: column6:int[]:null:6
  ├── project
  │    ├── columns: column5:int:null:5
  │    ├── scan
@@ -81,7 +81,7 @@ build
 SELECT JSON_AGG(v) FROM t.kv
 ----
 group-by
- ├── aggregation columns: column5:jsonb:null:5
+ ├── columns: column5:jsonb:null:5
  ├── project
  │    ├── columns: kv.v:int:null:2
  │    ├── scan
@@ -96,7 +96,7 @@ build
 SELECT JSONB_AGG(1)
 ----
 group-by
- ├── aggregation columns: column2:jsonb:null:2
+ ├── columns: column2:jsonb:null:2
  ├── project
  │    ├── columns: column1:int:null:1
  │    ├── values
@@ -114,6 +114,7 @@ SELECT 1 FROM t.kv GROUP BY v
 project
  ├── columns: column5:int:null:5
  ├── group-by
+ │    ├── columns: kv.v:int:null:2
  │    ├── grouping columns: kv.v:int:null:2
  │    ├── project
  │    │    ├── columns: kv.v:int:null:2
@@ -139,10 +140,10 @@ build
 SELECT COUNT(*), k FROM t.kv GROUP BY k
 ----
 project
- ├── columns: column5:int:null:5 kv.k:int:1
+ ├── columns: column5:int:null:5 k:int:1
  ├── group-by
+ │    ├── columns: kv.k:int:1 column5:int:null:5
  │    ├── grouping columns: kv.k:int:1
- │    ├── aggregation columns: column5:int:null:5
  │    ├── project
  │    │    ├── columns: kv.k:int:1
  │    │    ├── scan
@@ -160,10 +161,10 @@ build
 SELECT COUNT(*), k FROM t.kv GROUP BY 2
 ----
 project
- ├── columns: column5:int:null:5 kv.k:int:1
+ ├── columns: column5:int:null:5 k:int:1
  ├── group-by
+ │    ├── columns: kv.k:int:1 column5:int:null:5
  │    ├── grouping columns: kv.k:int:1
- │    ├── aggregation columns: column5:int:null:5
  │    ├── project
  │    │    ├── columns: kv.k:int:1
  │    │    ├── scan
@@ -196,10 +197,10 @@ build
 SELECT COUNT(*), kv.s FROM t.kv GROUP BY s
 ----
 project
- ├── columns: column5:int:null:5 kv.s:string:null:4
+ ├── columns: column5:int:null:5 s:string:null:4
  ├── group-by
+ │    ├── columns: kv.s:string:null:4 column5:int:null:5
  │    ├── grouping columns: kv.s:string:null:4
- │    ├── aggregation columns: column5:int:null:5
  │    ├── project
  │    │    ├── columns: kv.s:string:null:4
  │    │    ├── scan
@@ -216,10 +217,10 @@ build
 SELECT COUNT(*), s FROM t.kv GROUP BY kv.s
 ----
 project
- ├── columns: column5:int:null:5 kv.s:string:null:4
+ ├── columns: column5:int:null:5 s:string:null:4
  ├── group-by
+ │    ├── columns: kv.s:string:null:4 column5:int:null:5
  │    ├── grouping columns: kv.s:string:null:4
- │    ├── aggregation columns: column5:int:null:5
  │    ├── project
  │    │    ├── columns: kv.s:string:null:4
  │    │    ├── scan
@@ -236,10 +237,10 @@ build
 SELECT COUNT(*), kv.s FROM t.kv GROUP BY kv.s
 ----
 project
- ├── columns: column5:int:null:5 kv.s:string:null:4
+ ├── columns: column5:int:null:5 s:string:null:4
  ├── group-by
+ │    ├── columns: kv.s:string:null:4 column5:int:null:5
  │    ├── grouping columns: kv.s:string:null:4
- │    ├── aggregation columns: column5:int:null:5
  │    ├── project
  │    │    ├── columns: kv.s:string:null:4
  │    │    ├── scan
@@ -256,10 +257,10 @@ build
 SELECT COUNT(*), s FROM t.kv GROUP BY s
 ----
 project
- ├── columns: column5:int:null:5 kv.s:string:null:4
+ ├── columns: column5:int:null:5 s:string:null:4
  ├── group-by
+ │    ├── columns: kv.s:string:null:4 column5:int:null:5
  │    ├── grouping columns: kv.s:string:null:4
- │    ├── aggregation columns: column5:int:null:5
  │    ├── project
  │    │    ├── columns: kv.s:string:null:4
  │    │    ├── scan
@@ -277,10 +278,10 @@ build
 SELECT v, COUNT(*), w FROM t.kv GROUP BY v, w
 ----
 project
- ├── columns: kv.v:int:null:2 column5:int:null:5 kv.w:int:null:3
+ ├── columns: v:int:null:2 column5:int:null:5 w:int:null:3
  ├── group-by
+ │    ├── columns: kv.v:int:null:2 kv.w:int:null:3 column5:int:null:5
  │    ├── grouping columns: kv.v:int:null:2 kv.w:int:null:3
- │    ├── aggregation columns: column5:int:null:5
  │    ├── project
  │    │    ├── columns: kv.v:int:null:2 kv.w:int:null:3
  │    │    ├── scan
@@ -300,10 +301,10 @@ build
 SELECT v, COUNT(*), w FROM t.kv GROUP BY 1, 3
 ----
 project
- ├── columns: kv.v:int:null:2 column5:int:null:5 kv.w:int:null:3
+ ├── columns: v:int:null:2 column5:int:null:5 w:int:null:3
  ├── group-by
+ │    ├── columns: kv.v:int:null:2 kv.w:int:null:3 column5:int:null:5
  │    ├── grouping columns: kv.v:int:null:2 kv.w:int:null:3
- │    ├── aggregation columns: column5:int:null:5
  │    ├── project
  │    │    ├── columns: kv.v:int:null:2 kv.w:int:null:3
  │    │    ├── scan
@@ -325,8 +326,8 @@ SELECT COUNT(*), UPPER(s) FROM t.kv GROUP BY UPPER(s)
 project
  ├── columns: column6:int:null:6 column5:string:null:5
  ├── group-by
+ │    ├── columns: column5:string:null:5 column6:int:null:6
  │    ├── grouping columns: column5:string:null:5
- │    ├── aggregation columns: column6:int:null:6
  │    ├── project
  │    │    ├── columns: column5:string:null:5
  │    │    ├── scan
@@ -347,8 +348,8 @@ SELECT COUNT(*) FROM t.kv GROUP BY 1+2
 project
  ├── columns: column6:int:null:6
  ├── group-by
+ │    ├── columns: column5:int:null:5 column6:int:null:6
  │    ├── grouping columns: column5:int:null:5
- │    ├── aggregation columns: column6:int:null:6
  │    ├── project
  │    │    ├── columns: column5:int:null:5
  │    │    ├── scan
@@ -366,8 +367,8 @@ SELECT COUNT(*) FROM t.kv GROUP BY length('abc')
 project
  ├── columns: column6:int:null:6
  ├── group-by
+ │    ├── columns: column5:int:null:5 column6:int:null:6
  │    ├── grouping columns: column5:int:null:5
- │    ├── aggregation columns: column6:int:null:6
  │    ├── project
  │    │    ├── columns: column5:int:null:5
  │    │    ├── scan
@@ -387,8 +388,8 @@ SELECT COUNT(*), UPPER(s) FROM t.kv GROUP BY s
 project
  ├── columns: column5:int:null:5 column6:string:null:6
  ├── group-by
+ │    ├── columns: kv.s:string:null:4 column5:int:null:5
  │    ├── grouping columns: kv.s:string:null:4
- │    ├── aggregation columns: column5:int:null:5
  │    ├── project
  │    │    ├── columns: kv.s:string:null:4
  │    │    ├── scan
@@ -415,8 +416,8 @@ SELECT COUNT(*), k+v FROM t.kv GROUP BY k+v
 project
  ├── columns: column6:int:null:6 column5:int:null:5
  ├── group-by
+ │    ├── columns: column5:int:null:5 column6:int:null:6
  │    ├── grouping columns: column5:int:null:5
- │    ├── aggregation columns: column6:int:null:6
  │    ├── project
  │    │    ├── columns: column5:int:null:5
  │    │    ├── scan
@@ -439,8 +440,8 @@ SELECT COUNT(*), k+v FROM t.kv GROUP BY k, v
 project
  ├── columns: column5:int:null:5 column6:int:null:6
  ├── group-by
+ │    ├── columns: kv.k:int:1 kv.v:int:null:2 column5:int:null:5
  │    ├── grouping columns: kv.k:int:1 kv.v:int:null:2
- │    ├── aggregation columns: column5:int:null:5
  │    ├── project
  │    │    ├── columns: kv.k:int:1 kv.v:int:null:2
  │    │    ├── scan
@@ -486,10 +487,10 @@ build
 SELECT count(kv.k) AS count_1, kv.v + kv.w AS lx FROM t.kv GROUP BY kv.v + kv.w
 ----
 project
- ├── columns: count_1:int:null:6 column5:int:null:5
+ ├── columns: count_1:int:null:6 lx:int:null:5
  ├── group-by
+ │    ├── columns: column5:int:null:5 count_1:int:null:6
  │    ├── grouping columns: column5:int:null:5
- │    ├── aggregation columns: count_1:int:null:6
  │    ├── project
  │    │    ├── columns: column5:int:null:5 kv.k:int:1
  │    │    ├── scan
@@ -510,7 +511,7 @@ build
 SELECT COUNT(*)
 ----
 group-by
- ├── aggregation columns: column1:int:null:1
+ ├── columns: column1:int:null:1
  ├── values
  │    └── tuple [type=tuple{}]
  └── aggregations
@@ -520,7 +521,7 @@ build
 SELECT COUNT(k) from t.kv
 ----
 group-by
- ├── aggregation columns: column5:int:null:5
+ ├── columns: column5:int:null:5
  ├── project
  │    ├── columns: kv.k:int:1
  │    ├── scan
@@ -535,7 +536,7 @@ build
 SELECT COUNT(1)
 ----
 group-by
- ├── aggregation columns: column2:int:null:2
+ ├── columns: column2:int:null:2
  ├── project
  │    ├── columns: column1:int:null:1
  │    ├── values
@@ -550,7 +551,7 @@ build
 SELECT COUNT(1) from t.kv
 ----
 group-by
- ├── aggregation columns: column6:int:null:6
+ ├── columns: column6:int:null:6
  ├── project
  │    ├── columns: column5:int:null:5
  │    ├── scan
@@ -570,7 +571,7 @@ build
 SELECT COUNT(*), COUNT(k), COUNT(kv.v) FROM t.kv
 ----
 group-by
- ├── aggregation columns: column5:int:null:5 column6:int:null:6 column7:int:null:7
+ ├── columns: column5:int:null:5 column6:int:null:6 column7:int:null:7
  ├── project
  │    ├── columns: kv.k:int:1 kv.v:int:null:2
  │    ├── scan
@@ -595,7 +596,7 @@ build
 SELECT COUNT((k, v)) FROM t.kv
 ----
 group-by
- ├── aggregation columns: column6:int:null:6
+ ├── columns: column6:int:null:6
  ├── project
  │    ├── columns: column5:tuple{int, int}:null:5
  │    ├── scan
@@ -614,7 +615,7 @@ SELECT COUNT(k)+COUNT(kv.v) FROM t.kv
 project
  ├── columns: column7:int:null:7
  ├── group-by
- │    ├── aggregation columns: column5:int:null:5 column6:int:null:6
+ │    ├── columns: column5:int:null:5 column6:int:null:6
  │    ├── project
  │    │    ├── columns: kv.k:int:1 kv.v:int:null:2
  │    │    ├── scan
@@ -636,7 +637,7 @@ build
 SELECT MIN(k), MAX(k), MIN(v), MAX(v) FROM t.kv
 ----
 group-by
- ├── aggregation columns: column5:int:null:5 column6:int:null:6 column7:int:null:7 column8:int:null:8
+ ├── columns: column5:int:null:5 column6:int:null:6 column7:int:null:7 column8:int:null:8
  ├── project
  │    ├── columns: kv.k:int:1 kv.k:int:1 kv.v:int:null:2 kv.v:int:null:2
  │    ├── scan
@@ -660,7 +661,7 @@ build
 SELECT MIN(k), MAX(k), MIN(v), MAX(v) FROM t.kv WHERE k > 8
 ----
 group-by
- ├── aggregation columns: column5:int:null:5 column6:int:null:6 column7:int:null:7 column8:int:null:8
+ ├── columns: column5:int:null:5 column6:int:null:6 column7:int:null:7 column8:int:null:8
  ├── project
  │    ├── columns: kv.k:int:1 kv.k:int:1 kv.v:int:null:2 kv.v:int:null:2
  │    ├── select
@@ -689,7 +690,7 @@ build
 SELECT array_agg(s) FROM t.kv WHERE s IS NULL
 ----
 group-by
- ├── aggregation columns: column5:string[]:null:5
+ ├── columns: column5:string[]:null:5
  ├── project
  │    ├── columns: kv.s:string:null:4
  │    ├── select
@@ -709,7 +710,7 @@ build
 SELECT AVG(k), AVG(v), SUM(k), SUM(v) FROM t.kv
 ----
 group-by
- ├── aggregation columns: column5:decimal:null:5 column6:decimal:null:6 column7:decimal:null:7 column8:decimal:null:8
+ ├── columns: column5:decimal:null:5 column6:decimal:null:6 column7:decimal:null:7 column8:decimal:null:8
  ├── project
  │    ├── columns: kv.k:int:1 kv.v:int:null:2 kv.k:int:1 kv.v:int:null:2
  │    ├── scan
@@ -749,7 +750,7 @@ build
 SELECT MIN(a), MIN(b), MIN(c), MIN(d) FROM t.abc
 ----
 group-by
- ├── aggregation columns: column5:string:null:5 column6:float:null:6 column7:bool:null:7 column8:decimal:null:8
+ ├── columns: column5:string:null:5 column6:float:null:6 column7:bool:null:7 column8:decimal:null:8
  ├── scan
  │    └── columns: abc.a:string:1 abc.b:float:null:2 abc.c:bool:null:3 abc.d:decimal:null:4
  └── aggregations
@@ -766,7 +767,7 @@ build
 SELECT MAX(a), MAX(b), MAX(c), MAX(d) FROM t.abc
 ----
 group-by
- ├── aggregation columns: column5:string:null:5 column6:float:null:6 column7:bool:null:7 column8:decimal:null:8
+ ├── columns: column5:string:null:5 column6:float:null:6 column7:bool:null:7 column8:decimal:null:8
  ├── scan
  │    └── columns: abc.a:string:1 abc.b:float:null:2 abc.c:bool:null:3 abc.d:decimal:null:4
  └── aggregations
@@ -783,7 +784,7 @@ build
 SELECT AVG(b), SUM(b), AVG(d), SUM(d) FROM t.abc
 ----
 group-by
- ├── aggregation columns: column5:float:null:5 column6:float:null:6 column7:decimal:null:7 column8:decimal:null:8
+ ├── columns: column5:float:null:5 column6:float:null:6 column7:decimal:null:7 column8:decimal:null:8
  ├── project
  │    ├── columns: abc.b:float:null:2 abc.b:float:null:2 abc.d:decimal:null:4 abc.d:decimal:null:4
  │    ├── scan
@@ -818,7 +819,7 @@ build
 SELECT SUM(a) FROM t.intervals
 ----
 group-by
- ├── aggregation columns: column2:interval:null:2
+ ├── columns: column2:interval:null:2
  ├── scan
  │    └── columns: intervals.a:interval:1
  └── aggregations
@@ -885,7 +886,7 @@ build
 SELECT MIN(x) FROM t.xyz
 ----
 group-by
- ├── aggregation columns: column4:int:null:4
+ ├── columns: column4:int:null:4
  ├── project
  │    ├── columns: xyz.x:int:1
  │    ├── scan
@@ -900,7 +901,7 @@ build
 SELECT MIN(x) FROM t.xyz WHERE x in (0, 4, 7)
 ----
 group-by
- ├── aggregation columns: column4:int:null:4
+ ├── columns: column4:int:null:4
  ├── project
  │    ├── columns: xyz.x:int:1
  │    ├── select
@@ -923,7 +924,7 @@ build
 SELECT MAX(x) FROM t.xyz
 ----
 group-by
- ├── aggregation columns: column4:int:null:4
+ ├── columns: column4:int:null:4
  ├── project
  │    ├── columns: xyz.x:int:1
  │    ├── scan
@@ -938,7 +939,7 @@ build
 SELECT MAX(y) FROM t.xyz WHERE x = 1
 ----
 group-by
- ├── aggregation columns: column4:int:null:4
+ ├── columns: column4:int:null:4
  ├── project
  │    ├── columns: xyz.y:int:null:2
  │    ├── select
@@ -958,7 +959,7 @@ build
 SELECT MIN(y) FROM t.xyz WHERE x = 7
 ----
 group-by
- ├── aggregation columns: column4:int:null:4
+ ├── columns: column4:int:null:4
  ├── project
  │    ├── columns: xyz.y:int:null:2
  │    ├── select
@@ -978,7 +979,7 @@ build
 SELECT MIN(x) FROM t.xyz WHERE (y, z) = (2, 3.0)
 ----
 group-by
- ├── aggregation columns: column4:int:null:4
+ ├── columns: column4:int:null:4
  ├── project
  │    ├── columns: xyz.x:int:1
  │    ├── select
@@ -1002,7 +1003,7 @@ build
 SELECT MAX(x) FROM t.xyz WHERE (z, y) = (3.0, 2)
 ----
 group-by
- ├── aggregation columns: column4:int:null:4
+ ├── columns: column4:int:null:4
  ├── project
  │    ├── columns: xyz.x:int:1
  │    ├── select
@@ -1029,7 +1030,7 @@ build
 SELECT VARIANCE(x) FROM t.xyz WHERE x = 10
 ----
 group-by
- ├── aggregation columns: column4:decimal:null:4
+ ├── columns: column4:decimal:null:4
  ├── project
  │    ├── columns: xyz.x:int:1
  │    ├── select
@@ -1049,7 +1050,7 @@ build
 SELECT STDDEV(x) FROM t.xyz WHERE x = 1
 ----
 group-by
- ├── aggregation columns: column4:decimal:null:4
+ ├── columns: column4:decimal:null:4
  ├── project
  │    ├── columns: xyz.x:int:1
  │    ├── select
@@ -1078,7 +1079,7 @@ build
 SELECT BOOL_AND(b), BOOL_OR(b) FROM t.bools
 ----
 group-by
- ├── aggregation columns: column3:bool:null:3 column4:bool:null:4
+ ├── columns: column3:bool:null:3 column4:bool:null:4
  ├── project
  │    ├── columns: bools.b:bool:null:1 bools.b:bool:null:1
  │    ├── scan
@@ -1100,6 +1101,7 @@ SELECT 1 FROM t.kv GROUP BY kv.*;
 project
  ├── columns: column5:int:null:5
  ├── group-by
+ │    ├── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
  │    ├── grouping columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
  │    ├── scan
  │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
@@ -1124,7 +1126,7 @@ SELECT TO_HEX(XOR_AGG(a)), XOR_AGG(c) FROM t.xor_bytes
 project
  ├── columns: column6:string:null:6 column7:int:null:7
  ├── group-by
- │    ├── aggregation columns: column5:bytes:null:5 column7:int:null:7
+ │    ├── columns: column5:bytes:null:5 column7:int:null:7
  │    ├── project
  │    │    ├── columns: xor_bytes.a:bytes:null:1 xor_bytes.c:int:null:3
  │    │    ├── scan
@@ -1146,7 +1148,7 @@ build
 SELECT MAX(true), MIN(true)
 ----
 group-by
- ├── aggregation columns: column2:bool:null:2 column4:bool:null:4
+ ├── columns: column2:bool:null:2 column4:bool:null:4
  ├── project
  │    ├── columns: column1:bool:null:1 column3:bool:null:3
  │    ├── values
@@ -1191,6 +1193,7 @@ SELECT (b, a) FROM t.ab GROUP BY (b, a)
 project
  ├── columns: column3:tuple{int, int}:null:3
  ├── group-by
+ │    ├── columns: ab.a:int:1 ab.b:int:null:2
  │    ├── grouping columns: ab.a:int:1 ab.b:int:null:2
  │    ├── project
  │    │    ├── columns: ab.b:int:null:2 ab.a:int:1
@@ -1212,8 +1215,8 @@ SELECT MIN(y), (b, a)
 project
  ├── columns: column6:string:null:6 column7:tuple{int, int}:null:7
  ├── group-by
+ │    ├── columns: ab.a:int:1 ab.b:int:null:2 xy.x:string:null:3 column6:string:null:6
  │    ├── grouping columns: ab.a:int:1 ab.b:int:null:2 xy.x:string:null:3
- │    ├── aggregation columns: column6:string:null:6
  │    ├── project
  │    │    ├── columns: xy.x:string:null:3 ab.a:int:1 ab.b:int:null:2 xy.y:string:null:4
  │    │    ├── inner-join
@@ -1243,6 +1246,7 @@ SELECT (k+v)/(v+w) FROM t.kv GROUP BY k+v, v+w;
 project
  ├── columns: column7:decimal:null:7
  ├── group-by
+ │    ├── columns: column5:int:null:5 column6:int:null:6
  │    ├── grouping columns: column5:int:null:5 column6:int:null:6
  │    ├── project
  │    │    ├── columns: column5:int:null:5 column6:int:null:6
@@ -1270,10 +1274,10 @@ build
 SELECT SUM(t.kv.w), t.kv.v FROM t.kv GROUP BY v, kv.k * w
 ----
 project
- ├── columns: column6:decimal:null:6 kv.v:int:null:2
+ ├── columns: column6:decimal:null:6 v:int:null:2
  ├── group-by
+ │    ├── columns: kv.v:int:null:2 column5:int:null:5 column6:decimal:null:6
  │    ├── grouping columns: kv.v:int:null:2 column5:int:null:5
- │    ├── aggregation columns: column6:decimal:null:6
  │    ├── project
  │    │    ├── columns: kv.v:int:null:2 column5:int:null:5 kv.w:int:null:3
  │    │    ├── scan
@@ -1295,10 +1299,10 @@ build
 SELECT SUM(t.kv.w), LOWER(s), t.kv.v + k * t.kv.w, t.kv.v FROM t.kv GROUP BY v, LOWER(kv.s), kv.k * w
 ----
 project
- ├── columns: column7:decimal:null:7 column5:string:null:5 column8:int:null:8 kv.v:int:null:2
+ ├── columns: column7:decimal:null:7 column5:string:null:5 column8:int:null:8 v:int:null:2
  ├── group-by
+ │    ├── columns: kv.v:int:null:2 column5:string:null:5 column6:int:null:6 column7:decimal:null:7
  │    ├── grouping columns: kv.v:int:null:2 column5:string:null:5 column6:int:null:6
- │    ├── aggregation columns: column7:decimal:null:7
  │    ├── project
  │    │    ├── columns: kv.v:int:null:2 column5:string:null:5 column6:int:null:6 kv.w:int:null:3
  │    │    ├── scan
@@ -1331,6 +1335,7 @@ SELECT b1.b AND abc.c AND b2.b FROM bools b1, bools b2, abc GROUP BY b1.b AND ab
 project
  ├── columns: column10:bool:null:10
  ├── group-by
+ │    ├── columns: bools.b:bool:null:3 column9:bool:null:9
  │    ├── grouping columns: bools.b:bool:null:3 column9:bool:null:9
  │    ├── project
  │    │    ├── columns: column9:bool:null:9 bools.b:bool:null:3
@@ -1370,6 +1375,7 @@ SELECT b1.b OR abc.c OR b2.b FROM bools b1, bools b2, abc GROUP BY b1.b OR abc.c
 project
  ├── columns: column10:bool:null:10
  ├── group-by
+ │    ├── columns: bools.b:bool:null:3 column9:bool:null:9
  │    ├── grouping columns: bools.b:bool:null:3 column9:bool:null:9
  │    ├── project
  │    │    ├── columns: column9:bool:null:9 bools.b:bool:null:3
@@ -1409,6 +1415,7 @@ SELECT k % w % v FROM kv GROUP BY k % w, v
 project
  ├── columns: column6:int:null:6
  ├── group-by
+ │    ├── columns: kv.v:int:null:2 column5:int:null:5
  │    ├── grouping columns: kv.v:int:null:2 column5:int:null:5
  │    ├── project
  │    │    ├── columns: column5:int:null:5 kv.v:int:null:2
@@ -1433,6 +1440,7 @@ SELECT CONCAT(CONCAT(s, a), a) FROM kv, abc GROUP BY CONCAT(s, a), a
 project
  ├── columns: column10:string:null:10
  ├── group-by
+ │    ├── columns: abc.a:string:5 column9:string:null:9
  │    ├── grouping columns: abc.a:string:5 column9:string:null:9
  │    ├── project
  │    │    ├── columns: column9:string:null:9 abc.a:string:5
@@ -1467,6 +1475,7 @@ SELECT k < w AND v != 5 FROM kv GROUP BY k < w, v
 project
  ├── columns: column6:bool:null:6
  ├── group-by
+ │    ├── columns: kv.v:int:null:2 column5:bool:null:5
  │    ├── grouping columns: kv.v:int:null:2 column5:bool:null:5
  │    ├── project
  │    │    ├── columns: column5:bool:null:5 kv.v:int:null:2
@@ -1508,6 +1517,7 @@ SELECT a.bar @> b.baz AND b.baz @> b.baz FROM foo AS a, foo AS b GROUP BY a.bar 
 project
  ├── columns: column8:bool:null:8
  ├── group-by
+ │    ├── columns: foo.baz:jsonb:null:5 column7:bool:null:7
  │    ├── grouping columns: foo.baz:jsonb:null:5 column7:bool:null:7
  │    ├── project
  │    │    ├── columns: column7:bool:null:7 foo.baz:jsonb:null:5
@@ -1544,6 +1554,7 @@ SELECT b.baz <@ a.bar AND b.baz <@ b.baz FROM foo AS a, foo AS b GROUP BY b.baz 
 project
  ├── columns: column8:bool:null:8
  ├── group-by
+ │    ├── columns: foo.baz:jsonb:null:5 column7:bool:null:7
  │    ├── grouping columns: foo.baz:jsonb:null:5 column7:bool:null:7
  │    ├── project
  │    │    ├── columns: column7:bool:null:7 foo.baz:jsonb:null:5
@@ -1584,6 +1595,7 @@ SELECT date_trunc('second', a.t) - date_trunc('minute', b.t) FROM times a, times
 project
  ├── columns: column5:interval:null:5
  ├── group-by
+ │    ├── columns: column3:interval:null:3 column4:interval:null:4
  │    ├── grouping columns: column3:interval:null:3 column4:interval:null:4
  │    ├── project
  │    │    ├── columns: column3:interval:null:3 column4:interval:null:4
@@ -1621,6 +1633,7 @@ build
 SELECT NOT b FROM bools GROUP BY NOT b
 ----
 group-by
+ ├── columns: column3:bool:null:3
  ├── grouping columns: column3:bool:null:3
  ├── project
  │    ├── columns: column3:bool:null:3
@@ -1642,6 +1655,7 @@ SELECT NOT b FROM bools GROUP BY b
 project
  ├── columns: column3:bool:null:3
  ├── group-by
+ │    ├── columns: bools.b:bool:null:1
  │    ├── grouping columns: bools.b:bool:null:1
  │    ├── project
  │    │    ├── columns: bools.b:bool:null:1
@@ -1660,6 +1674,7 @@ SELECT +k * (-w) FROM kv GROUP BY +k, -w
 project
  ├── columns: column7:int:null:7
  ├── group-by
+ │    ├── columns: column5:int:null:5 column6:int:null:6
  │    ├── grouping columns: column5:int:null:5 column6:int:null:6
  │    ├── project
  │    │    ├── columns: column5:int:null:5 column6:int:null:6
@@ -1689,6 +1704,7 @@ SELECT +k * (-w) FROM kv GROUP BY k, w
 project
  ├── columns: column5:int:null:5
  ├── group-by
+ │    ├── columns: kv.k:int:1 kv.w:int:null:3
  │    ├── grouping columns: kv.k:int:1 kv.w:int:null:3
  │    ├── project
  │    │    ├── columns: kv.k:int:1 kv.w:int:null:3
@@ -1711,8 +1727,8 @@ SELECT 1 + MIN(v*2) FROM kv GROUP BY k+3
 project
  ├── columns: column8:int:null:8
  ├── group-by
+ │    ├── columns: column5:int:null:5 column7:int:null:7
  │    ├── grouping columns: column5:int:null:5
- │    ├── aggregation columns: column7:int:null:7
  │    ├── project
  │    │    ├── columns: column5:int:null:5 column6:int:null:6
  │    │    ├── scan
@@ -1738,8 +1754,8 @@ SELECT count(*) FROM kv GROUP BY k, k
 project
  ├── columns: column5:int:null:5
  ├── group-by
+ │    ├── columns: kv.k:int:1 column5:int:null:5
  │    ├── grouping columns: kv.k:int:1
- │    ├── aggregation columns: column5:int:null:5
  │    ├── project
  │    │    ├── columns: kv.k:int:1 kv.k:int:1
  │    │    ├── scan

--- a/pkg/sql/opt/optbuilder/testdata/distinct
+++ b/pkg/sql/opt/optbuilder/testdata/distinct
@@ -30,7 +30,7 @@ build
 SELECT y, z FROM t.xyz
 ----
 project
- ├── columns: xyz.y:int:null:2 xyz.z:float:null:3
+ ├── columns: y:int:null:2 z:float:null:3
  ├── scan
  │    └── columns: xyz.x:int:1 xyz.y:int:null:2 xyz.z:float:null:3
  └── projections
@@ -41,6 +41,7 @@ build
 SELECT DISTINCT y, z FROM t.xyz
 ----
 group-by
+ ├── columns: y:int:null:2 z:float:null:3
  ├── grouping columns: xyz.y:int:null:2 xyz.z:float:null:3
  ├── project
  │    ├── columns: xyz.y:int:null:2 xyz.z:float:null:3
@@ -55,8 +56,9 @@ build
 SELECT y FROM (SELECT DISTINCT y, z FROM t.xyz)
 ----
 project
- ├── columns: xyz.y:int:null:2
+ ├── columns: y:int:null:2
  ├── group-by
+ │    ├── columns: xyz.y:int:null:2 xyz.z:float:null:3
  │    ├── grouping columns: xyz.y:int:null:2 xyz.z:float:null:3
  │    ├── project
  │    │    ├── columns: xyz.y:int:null:2 xyz.z:float:null:3
@@ -73,6 +75,7 @@ build
 SELECT DISTINCT (y,z) FROM t.xyz
 ----
 group-by
+ ├── columns: column4:tuple{int, float}:null:4
  ├── grouping columns: column4:tuple{int, float}:null:4
  ├── project
  │    ├── columns: column4:tuple{int, float}:null:4
@@ -88,9 +91,10 @@ build
 SELECT COUNT(*) FROM (SELECT DISTINCT y FROM t.xyz)
 ----
 group-by
- ├── aggregation columns: column4:int:null:4
+ ├── columns: column4:int:null:4
  ├── project
  │    ├── group-by
+ │    │    ├── columns: xyz.y:int:null:2
  │    │    ├── grouping columns: xyz.y:int:null:2
  │    │    ├── project
  │    │    │    ├── columns: xyz.y:int:null:2
@@ -107,6 +111,7 @@ build
 SELECT DISTINCT x FROM t.xyz WHERE x > 0
 ----
 group-by
+ ├── columns: x:int:1
  ├── grouping columns: xyz.x:int:1
  ├── project
  │    ├── columns: xyz.x:int:1
@@ -125,6 +130,7 @@ build
 SELECT DISTINCT z FROM t.xyz WHERE x > 0
 ----
 group-by
+ ├── columns: z:float:null:3
  ├── grouping columns: xyz.z:float:null:3
  ├── project
  │    ├── columns: xyz.z:float:null:3
@@ -143,12 +149,13 @@ build
 SELECT DISTINCT MAX(x) FROM xyz GROUP BY x
 ----
 group-by
+ ├── columns: column4:int:null:4
  ├── grouping columns: column4:int:null:4
  ├── project
  │    ├── columns: column4:int:null:4
  │    ├── group-by
+ │    │    ├── columns: xyz.x:int:1 column4:int:null:4
  │    │    ├── grouping columns: xyz.x:int:1
- │    │    ├── aggregation columns: column4:int:null:4
  │    │    ├── project
  │    │    │    ├── columns: xyz.x:int:1 xyz.x:int:1
  │    │    │    ├── scan
@@ -167,6 +174,7 @@ build
 SELECT DISTINCT x+y FROM xyz
 ----
 group-by
+ ├── columns: column4:int:null:4
  ├── grouping columns: column4:int:null:4
  ├── project
  │    ├── columns: column4:int:null:4
@@ -182,6 +190,7 @@ build
 SELECT DISTINCT 3 FROM xyz
 ----
 group-by
+ ├── columns: column4:int:null:4
  ├── grouping columns: column4:int:null:4
  ├── project
  │    ├── columns: column4:int:null:4
@@ -195,6 +204,7 @@ build
 SELECT DISTINCT 3
 ----
 group-by
+ ├── columns: column1:int:null:1
  ├── grouping columns: column1:int:null:1
  ├── project
  │    ├── columns: column1:int:null:1
@@ -208,14 +218,15 @@ build
 SELECT DISTINCT MAX(z), x+y, 3 FROM xyz GROUP BY x, y HAVING y > 4
 ----
 group-by
+ ├── columns: column4:float:null:4 column5:int:null:5 column6:int:null:6
  ├── grouping columns: column4:float:null:4 column5:int:null:5 column6:int:null:6
  ├── project
  │    ├── columns: column4:float:null:4 column5:int:null:5 column6:int:null:6
  │    ├── select
  │    │    ├── columns: xyz.x:int:1 xyz.y:int:null:2 column4:float:null:4
  │    │    ├── group-by
+ │    │    │    ├── columns: xyz.x:int:1 xyz.y:int:null:2 column4:float:null:4
  │    │    │    ├── grouping columns: xyz.x:int:1 xyz.y:int:null:2
- │    │    │    ├── aggregation columns: column4:float:null:4
  │    │    │    ├── scan
  │    │    │    │    └── columns: xyz.x:int:1 xyz.y:int:null:2 xyz.z:float:null:3
  │    │    │    └── aggregations

--- a/pkg/sql/opt/optbuilder/testdata/having
+++ b/pkg/sql/opt/optbuilder/testdata/having
@@ -37,10 +37,10 @@ build
 SELECT s, COUNT(*) FROM t.kv GROUP BY s HAVING COUNT(*) > 1
 ----
 select
- ├── columns: kv.s:string:null:4 column5:int:null:5
+ ├── columns: s:string:null:4 column5:int:null:5
  ├── group-by
+ │    ├── columns: kv.s:string:null:4 column5:int:null:5
  │    ├── grouping columns: kv.s:string:null:4
- │    ├── aggregation columns: column5:int:null:5
  │    ├── project
  │    │    ├── columns: kv.s:string:null:4
  │    │    ├── scan
@@ -61,7 +61,7 @@ project
  ├── select
  │    ├── columns: column5:int:null:5 column6:int:null:6
  │    ├── group-by
- │    │    ├── aggregation columns: column5:int:null:5 column6:int:null:6
+ │    │    ├── columns: column5:int:null:5 column6:int:null:6
  │    │    ├── project
  │    │    │    ├── columns: kv.v:int:null:2 kv.k:int:1
  │    │    │    ├── scan
@@ -89,7 +89,7 @@ project
  ├── select
  │    ├── columns: column5:int:null:5 column6:int:null:6 column7:int:null:7
  │    ├── group-by
- │    │    ├── aggregation columns: column5:int:null:5 column6:int:null:6 column7:int:null:7
+ │    │    ├── columns: column5:int:null:5 column6:int:null:6 column7:int:null:7
  │    │    ├── project
  │    │    │    ├── columns: kv.v:int:null:2 kv.k:int:1 kv.v:int:null:2
  │    │    │    ├── scan
@@ -148,8 +148,8 @@ project
  ├── select
  │    ├── columns: column5:int:null:5 column6:int:null:6
  │    ├── group-by
+ │    │    ├── columns: column5:int:null:5 column6:int:null:6
  │    │    ├── grouping columns: column5:int:null:5
- │    │    ├── aggregation columns: column6:int:null:6
  │    │    ├── project
  │    │    │    ├── columns: column5:int:null:5
  │    │    │    ├── scan
@@ -183,8 +183,8 @@ project
  ├── select
  │    ├── columns: kv.v:int:null:2 column5:int:null:5
  │    ├── group-by
+ │    │    ├── columns: kv.v:int:null:2 column5:int:null:5
  │    │    ├── grouping columns: kv.v:int:null:2
- │    │    ├── aggregation columns: column5:int:null:5
  │    │    ├── project
  │    │    │    ├── columns: kv.v:int:null:2 kv.v:int:null:2
  │    │    │    ├── scan
@@ -209,8 +209,8 @@ project
  ├── select
  │    ├── columns: column5:string:null:5 column6:decimal:null:6
  │    ├── group-by
+ │    │    ├── columns: column5:string:null:5 column6:decimal:null:6
  │    │    ├── grouping columns: column5:string:null:5
- │    │    ├── aggregation columns: column6:decimal:null:6
  │    │    ├── project
  │    │    │    ├── columns: column5:string:null:5 kv.w:int:null:3
  │    │    │    ├── scan
@@ -237,8 +237,8 @@ project
  ├── select
  │    ├── columns: column5:string:null:5 column6:decimal:null:6
  │    ├── group-by
+ │    │    ├── columns: column5:string:null:5 column6:decimal:null:6
  │    │    ├── grouping columns: column5:string:null:5
- │    │    ├── aggregation columns: column6:decimal:null:6
  │    │    ├── project
  │    │    │    ├── columns: column5:string:null:5 kv.w:int:null:3
  │    │    │    ├── scan
@@ -263,10 +263,11 @@ build
 SELECT t.kv.v FROM t.kv GROUP BY v, kv.k * w HAVING k * kv.w > 5
 ----
 project
- ├── columns: kv.v:int:null:2
+ ├── columns: v:int:null:2
  ├── select
  │    ├── columns: kv.v:int:null:2 column5:int:null:5
  │    ├── group-by
+ │    │    ├── columns: kv.v:int:null:2 column5:int:null:5
  │    │    ├── grouping columns: kv.v:int:null:2 column5:int:null:5
  │    │    ├── project
  │    │    │    ├── columns: kv.v:int:null:2 column5:int:null:5

--- a/pkg/sql/opt/optbuilder/testdata/inner-join
+++ b/pkg/sql/opt/optbuilder/testdata/inner-join
@@ -32,7 +32,7 @@ build
 SELECT * FROM t.a, t.b
 ----
 project
- ├── columns: a.x:int:1 a.y:float:null:2 b.x:int:null:3 b.y:float:null:4
+ ├── columns: x:int:1 y:float:null:2 x:int:null:3 y:float:null:4
  ├── inner-join
  │    ├── columns: a.x:int:1 a.y:float:null:2 b.x:int:null:3 b.y:float:null:4 b.rowid:int:5
  │    ├── scan
@@ -50,7 +50,7 @@ build
 SELECT a.x, b.y FROM t.a, t.b WHERE a.x = b.x
 ----
 project
- ├── columns: a.x:int:1 b.y:float:null:4
+ ├── columns: x:int:1 y:float:null:4
  ├── select
  │    ├── columns: a.x:int:1 a.y:float:null:2 b.x:int:null:3 b.y:float:null:4 b.rowid:int:5
  │    ├── inner-join
@@ -71,7 +71,7 @@ build
 SELECT * FROM t.c, t.b, t.a WHERE c.x = a.x AND b.x = a.x
 ----
 project
- ├── columns: c.x:int:null:1 c.y:float:null:2 c.z:string:null:3 b.x:int:null:5 b.y:float:null:6 a.x:int:8 a.y:float:null:9
+ ├── columns: x:int:null:1 y:float:null:2 z:string:null:3 x:int:null:5 y:float:null:6 x:int:8 y:float:null:9
  ├── select
  │    ├── columns: c.x:int:null:1 c.y:float:null:2 c.z:string:null:3 c.rowid:int:4 b.x:int:null:5 b.y:float:null:6 b.rowid:int:7 a.x:int:8 a.y:float:null:9
  │    ├── inner-join

--- a/pkg/sql/opt/optbuilder/testdata/join
+++ b/pkg/sql/opt/optbuilder/testdata/join
@@ -19,7 +19,7 @@ build
 SELECT * FROM onecolumn AS a(x) CROSS JOIN onecolumn AS b(y)
 ----
 project
- ├── columns: onecolumn.x:int:null:1 onecolumn.x:int:null:3
+ ├── columns: x:int:null:1 y:int:null:3
  ├── inner-join
  │    ├── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2 onecolumn.x:int:null:3 onecolumn.rowid:int:4
  │    ├── scan
@@ -69,7 +69,7 @@ build
 SELECT * FROM onecolumn AS a(x) JOIN onecolumn AS b(y) ON a.x = b.y
 ----
 project
- ├── columns: onecolumn.x:int:null:1 onecolumn.x:int:null:3
+ ├── columns: x:int:null:1 y:int:null:3
  ├── inner-join
  │    ├── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2 onecolumn.x:int:null:3 onecolumn.rowid:int:4
  │    ├── scan
@@ -87,7 +87,7 @@ build
 SELECT * FROM onecolumn AS a JOIN onecolumn as b USING(x)
 ----
 project
- ├── columns: onecolumn.x:int:null:1
+ ├── columns: x:int:null:1
  ├── inner-join
  │    ├── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2 onecolumn.x:int:null:3 onecolumn.rowid:int:4
  │    ├── scan
@@ -104,7 +104,7 @@ build
 SELECT * FROM onecolumn AS a NATURAL JOIN onecolumn as b
 ----
 project
- ├── columns: onecolumn.x:int:null:1
+ ├── columns: x:int:null:1
  ├── inner-join
  │    ├── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2 onecolumn.x:int:null:3 onecolumn.rowid:int:4
  │    ├── scan
@@ -121,7 +121,7 @@ build
 SELECT * FROM onecolumn AS a(x) LEFT OUTER JOIN onecolumn AS b(y) ON a.x = b.y
 ----
 project
- ├── columns: onecolumn.x:int:null:1 onecolumn.x:int:null:3
+ ├── columns: x:int:null:1 y:int:null:3
  ├── left-join
  │    ├── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2 onecolumn.x:int:null:3 onecolumn.rowid:int:null:4
  │    ├── scan
@@ -139,7 +139,7 @@ build
 SELECT * FROM onecolumn AS a LEFT OUTER JOIN onecolumn AS b USING(x)
 ----
 project
- ├── columns: onecolumn.x:int:null:1
+ ├── columns: x:int:null:1
  ├── left-join
  │    ├── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2 onecolumn.x:int:null:3 onecolumn.rowid:int:null:4
  │    ├── scan
@@ -156,7 +156,7 @@ build
 SELECT * FROM onecolumn AS a NATURAL LEFT OUTER JOIN onecolumn AS b
 ----
 project
- ├── columns: onecolumn.x:int:null:1
+ ├── columns: x:int:null:1
  ├── left-join
  │    ├── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2 onecolumn.x:int:null:3 onecolumn.rowid:int:null:4
  │    ├── scan
@@ -173,7 +173,7 @@ build
 SELECT * FROM onecolumn AS a(x) RIGHT OUTER JOIN onecolumn AS b(y) ON a.x = b.y
 ----
 project
- ├── columns: onecolumn.x:int:null:1 onecolumn.x:int:null:3
+ ├── columns: x:int:null:1 y:int:null:3
  ├── right-join
  │    ├── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:null:2 onecolumn.x:int:null:3 onecolumn.rowid:int:4
  │    ├── scan
@@ -191,7 +191,7 @@ build
 SELECT * FROM onecolumn AS a RIGHT OUTER JOIN onecolumn AS b USING(x)
 ----
 project
- ├── columns: onecolumn.x:int:null:3
+ ├── columns: x:int:null:3
  ├── right-join
  │    ├── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:null:2 onecolumn.x:int:null:3 onecolumn.rowid:int:4
  │    ├── scan
@@ -208,7 +208,7 @@ build
 SELECT * FROM onecolumn AS a NATURAL RIGHT OUTER JOIN onecolumn AS b
 ----
 project
- ├── columns: onecolumn.x:int:null:3
+ ├── columns: x:int:null:3
  ├── right-join
  │    ├── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:null:2 onecolumn.x:int:null:3 onecolumn.rowid:int:4
  │    ├── scan
@@ -234,7 +234,7 @@ build
 SELECT * FROM onecolumn AS a NATURAL JOIN onecolumn_w as b
 ----
 project
- ├── columns: onecolumn.x:int:null:1 onecolumn_w.w:int:null:3
+ ├── columns: x:int:null:1 w:int:null:3
  ├── inner-join
  │    ├── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2 onecolumn_w.w:int:null:3 onecolumn_w.rowid:int:4
  │    ├── scan
@@ -259,7 +259,7 @@ build
 SELECT * FROM onecolumn AS a FULL OUTER JOIN othercolumn AS b ON a.x = b.x
 ----
 project
- ├── columns: onecolumn.x:int:null:1 othercolumn.x:int:null:3
+ ├── columns: x:int:null:1 x:int:null:3
  ├── full-join
  │    ├── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:null:2 othercolumn.x:int:null:3 othercolumn.rowid:int:null:4
  │    ├── scan
@@ -306,7 +306,7 @@ build
 SELECT x AS s, a.x, b.x FROM onecolumn AS a FULL OUTER JOIN othercolumn AS b USING(x)
 ----
 project
- ├── columns: x:int:null:5 onecolumn.x:int:null:1 othercolumn.x:int:null:3
+ ├── columns: s:int:null:5 x:int:null:1 x:int:null:3
  ├── project
  │    ├── columns: x:int:null:5 onecolumn.x:int:null:1 onecolumn.rowid:int:null:2 othercolumn.x:int:null:3 othercolumn.rowid:int:null:4
  │    ├── full-join
@@ -371,7 +371,7 @@ build
 SELECT * FROM onecolumn AS a(x) CROSS JOIN empty AS b(y)
 ----
 project
- ├── columns: onecolumn.x:int:null:1 empty.x:int:null:3
+ ├── columns: x:int:null:1 y:int:null:3
  ├── inner-join
  │    ├── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2 empty.x:int:null:3 empty.rowid:int:4
  │    ├── scan
@@ -387,7 +387,7 @@ build
 SELECT * FROM empty AS a CROSS JOIN onecolumn AS b
 ----
 project
- ├── columns: empty.x:int:null:1 onecolumn.x:int:null:3
+ ├── columns: x:int:null:1 x:int:null:3
  ├── inner-join
  │    ├── columns: empty.x:int:null:1 empty.rowid:int:2 onecolumn.x:int:null:3 onecolumn.rowid:int:4
  │    ├── scan
@@ -403,7 +403,7 @@ build
 SELECT * FROM onecolumn AS a(x) JOIN empty AS b(y) ON a.x = b.y
 ----
 project
- ├── columns: onecolumn.x:int:null:1 empty.x:int:null:3
+ ├── columns: x:int:null:1 y:int:null:3
  ├── inner-join
  │    ├── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2 empty.x:int:null:3 empty.rowid:int:4
  │    ├── scan
@@ -421,7 +421,7 @@ build
 SELECT * FROM onecolumn AS a JOIN empty AS b USING(x)
 ----
 project
- ├── columns: onecolumn.x:int:null:1
+ ├── columns: x:int:null:1
  ├── inner-join
  │    ├── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2 empty.x:int:null:3 empty.rowid:int:4
  │    ├── scan
@@ -438,7 +438,7 @@ build
 SELECT * FROM empty AS a(x) JOIN onecolumn AS b(y) ON a.x = b.y
 ----
 project
- ├── columns: empty.x:int:null:1 onecolumn.x:int:null:3
+ ├── columns: x:int:null:1 y:int:null:3
  ├── inner-join
  │    ├── columns: empty.x:int:null:1 empty.rowid:int:2 onecolumn.x:int:null:3 onecolumn.rowid:int:4
  │    ├── scan
@@ -456,7 +456,7 @@ build
 SELECT * FROM empty AS a JOIN onecolumn AS b USING(x)
 ----
 project
- ├── columns: empty.x:int:null:1
+ ├── columns: x:int:null:1
  ├── inner-join
  │    ├── columns: empty.x:int:null:1 empty.rowid:int:2 onecolumn.x:int:null:3 onecolumn.rowid:int:4
  │    ├── scan
@@ -473,7 +473,7 @@ build
 SELECT * FROM onecolumn AS a(x) LEFT OUTER JOIN empty AS b(y) ON a.x = b.y
 ----
 project
- ├── columns: onecolumn.x:int:null:1 empty.x:int:null:3
+ ├── columns: x:int:null:1 y:int:null:3
  ├── left-join
  │    ├── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2 empty.x:int:null:3 empty.rowid:int:null:4
  │    ├── scan
@@ -491,7 +491,7 @@ build
 SELECT * FROM onecolumn AS a LEFT OUTER JOIN empty AS b USING(x)
 ----
 project
- ├── columns: onecolumn.x:int:null:1
+ ├── columns: x:int:null:1
  ├── left-join
  │    ├── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2 empty.x:int:null:3 empty.rowid:int:null:4
  │    ├── scan
@@ -508,7 +508,7 @@ build
 SELECT * FROM empty AS a(x) LEFT OUTER JOIN onecolumn AS b(y) ON a.x = b.y
 ----
 project
- ├── columns: empty.x:int:null:1 onecolumn.x:int:null:3
+ ├── columns: x:int:null:1 y:int:null:3
  ├── left-join
  │    ├── columns: empty.x:int:null:1 empty.rowid:int:2 onecolumn.x:int:null:3 onecolumn.rowid:int:null:4
  │    ├── scan
@@ -526,7 +526,7 @@ build
 SELECT * FROM empty AS a LEFT OUTER JOIN onecolumn AS b USING(x)
 ----
 project
- ├── columns: empty.x:int:null:1
+ ├── columns: x:int:null:1
  ├── left-join
  │    ├── columns: empty.x:int:null:1 empty.rowid:int:2 onecolumn.x:int:null:3 onecolumn.rowid:int:null:4
  │    ├── scan
@@ -543,7 +543,7 @@ build
 SELECT * FROM onecolumn AS a(x) RIGHT OUTER JOIN empty AS b(y) ON a.x = b.y
 ----
 project
- ├── columns: onecolumn.x:int:null:1 empty.x:int:null:3
+ ├── columns: x:int:null:1 y:int:null:3
  ├── right-join
  │    ├── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:null:2 empty.x:int:null:3 empty.rowid:int:4
  │    ├── scan
@@ -561,7 +561,7 @@ build
 SELECT * FROM onecolumn AS a RIGHT OUTER JOIN empty AS b USING(x)
 ----
 project
- ├── columns: empty.x:int:null:3
+ ├── columns: x:int:null:3
  ├── right-join
  │    ├── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:null:2 empty.x:int:null:3 empty.rowid:int:4
  │    ├── scan
@@ -578,7 +578,7 @@ build
 SELECT * FROM empty AS a(x) FULL OUTER JOIN onecolumn AS b(y) ON a.x = b.y
 ----
 project
- ├── columns: empty.x:int:null:1 onecolumn.x:int:null:3
+ ├── columns: x:int:null:1 y:int:null:3
  ├── full-join
  │    ├── columns: empty.x:int:null:1 empty.rowid:int:null:2 onecolumn.x:int:null:3 onecolumn.rowid:int:null:4
  │    ├── scan
@@ -623,7 +623,7 @@ build
 SELECT * FROM onecolumn AS a(x) FULL OUTER JOIN empty AS b(y) ON a.x = b.y
 ----
 project
- ├── columns: onecolumn.x:int:null:1 empty.x:int:null:3
+ ├── columns: x:int:null:1 y:int:null:3
  ├── full-join
  │    ├── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:null:2 empty.x:int:null:3 empty.rowid:int:null:4
  │    ├── scan
@@ -679,7 +679,7 @@ build
 SELECT * FROM onecolumn NATURAL JOIN twocolumn
 ----
 project
- ├── columns: onecolumn.x:int:null:1 twocolumn.y:int:null:4
+ ├── columns: x:int:null:1 y:int:null:4
  ├── inner-join
  │    ├── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2 twocolumn.x:int:null:3 twocolumn.y:int:null:4 twocolumn.rowid:int:5
  │    ├── scan
@@ -697,7 +697,7 @@ build
 SELECT * FROM onecolumn JOIN twocolumn USING(x)
 ----
 project
- ├── columns: onecolumn.x:int:null:1 twocolumn.y:int:null:4
+ ├── columns: x:int:null:1 y:int:null:4
  ├── inner-join
  │    ├── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2 twocolumn.x:int:null:3 twocolumn.y:int:null:4 twocolumn.rowid:int:5
  │    ├── scan
@@ -715,7 +715,7 @@ build
 SELECT * FROM twocolumn AS a JOIN twocolumn AS b ON a.x = b.y
 ----
 project
- ├── columns: twocolumn.x:int:null:1 twocolumn.y:int:null:2 twocolumn.x:int:null:4 twocolumn.y:int:null:5
+ ├── columns: x:int:null:1 y:int:null:2 x:int:null:4 y:int:null:5
  ├── inner-join
  │    ├── columns: twocolumn.x:int:null:1 twocolumn.y:int:null:2 twocolumn.rowid:int:3 twocolumn.x:int:null:4 twocolumn.y:int:null:5 twocolumn.rowid:int:6
  │    ├── scan
@@ -735,7 +735,7 @@ build
 SELECT * FROM twocolumn AS a JOIN twocolumn AS b ON a.x = a.y
 ----
 project
- ├── columns: twocolumn.x:int:null:1 twocolumn.y:int:null:2 twocolumn.x:int:null:4 twocolumn.y:int:null:5
+ ├── columns: x:int:null:1 y:int:null:2 x:int:null:4 y:int:null:5
  ├── inner-join
  │    ├── columns: twocolumn.x:int:null:1 twocolumn.y:int:null:2 twocolumn.rowid:int:3 twocolumn.x:int:null:4 twocolumn.y:int:null:5 twocolumn.rowid:int:6
  │    ├── scan
@@ -755,7 +755,7 @@ build
 SELECT * FROM onecolumn AS a JOIN twocolumn AS b ON ((a.x)) = ((b.y))
 ----
 project
- ├── columns: onecolumn.x:int:null:1 twocolumn.x:int:null:3 twocolumn.y:int:null:4
+ ├── columns: x:int:null:1 x:int:null:3 y:int:null:4
  ├── inner-join
  │    ├── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2 twocolumn.x:int:null:3 twocolumn.y:int:null:4 twocolumn.rowid:int:5
  │    ├── scan
@@ -774,7 +774,7 @@ build
 SELECT * FROM onecolumn JOIN twocolumn ON onecolumn.x = twocolumn.y
 ----
 project
- ├── columns: onecolumn.x:int:null:1 twocolumn.x:int:null:3 twocolumn.y:int:null:4
+ ├── columns: x:int:null:1 x:int:null:3 y:int:null:4
  ├── inner-join
  │    ├── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2 twocolumn.x:int:null:3 twocolumn.y:int:null:4 twocolumn.rowid:int:5
  │    ├── scan
@@ -794,7 +794,7 @@ build
 SELECT * FROM twocolumn AS a JOIN twocolumn AS b ON a.x = 44
 ----
 project
- ├── columns: twocolumn.x:int:null:1 twocolumn.y:int:null:2 twocolumn.x:int:null:4 twocolumn.y:int:null:5
+ ├── columns: x:int:null:1 y:int:null:2 x:int:null:4 y:int:null:5
  ├── inner-join
  │    ├── columns: twocolumn.x:int:null:1 twocolumn.y:int:null:2 twocolumn.rowid:int:3 twocolumn.x:int:null:4 twocolumn.y:int:null:5 twocolumn.rowid:int:6
  │    ├── scan
@@ -814,7 +814,7 @@ build
 SELECT o.x, t.y FROM onecolumn o INNER JOIN twocolumn t ON (o.x=t.x AND t.y=53)
 ----
 project
- ├── columns: onecolumn.x:int:null:1 twocolumn.y:int:null:4
+ ├── columns: x:int:null:1 y:int:null:4
  ├── inner-join
  │    ├── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2 twocolumn.x:int:null:3 twocolumn.y:int:null:4 twocolumn.rowid:int:5
  │    ├── scan
@@ -837,7 +837,7 @@ build
 SELECT o.x, t.y FROM onecolumn o LEFT OUTER JOIN twocolumn t ON (o.x=t.x AND t.y=53)
 ----
 project
- ├── columns: onecolumn.x:int:null:1 twocolumn.y:int:null:4
+ ├── columns: x:int:null:1 y:int:null:4
  ├── left-join
  │    ├── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2 twocolumn.x:int:null:3 twocolumn.y:int:null:4 twocolumn.rowid:int:null:5
  │    ├── scan
@@ -859,7 +859,7 @@ build
 SELECT o.x, t.y FROM onecolumn o LEFT OUTER JOIN twocolumn t ON (o.x=t.x AND o.x=44)
 ----
 project
- ├── columns: onecolumn.x:int:null:1 twocolumn.y:int:null:4
+ ├── columns: x:int:null:1 y:int:null:4
  ├── left-join
  │    ├── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2 twocolumn.x:int:null:3 twocolumn.y:int:null:4 twocolumn.rowid:int:null:5
  │    ├── scan
@@ -881,7 +881,7 @@ build
 SELECT o.x, t.y FROM onecolumn o LEFT OUTER JOIN twocolumn t ON (o.x=t.x AND t.x=44)
 ----
 project
- ├── columns: onecolumn.x:int:null:1 twocolumn.y:int:null:4
+ ├── columns: x:int:null:1 y:int:null:4
  ├── left-join
  │    ├── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2 twocolumn.x:int:null:3 twocolumn.y:int:null:4 twocolumn.rowid:int:null:5
  │    ├── scan
@@ -935,7 +935,7 @@ build
 SELECT * FROM a INNER JOIN b ON a.i = b.i
 ----
 project
- ├── columns: a.i:int:null:1 b.i:int:null:3 b.b:bool:null:4
+ ├── columns: i:int:null:1 i:int:null:3 b:bool:null:4
  ├── inner-join
  │    ├── columns: a.i:int:null:1 a.rowid:int:2 b.i:int:null:3 b.b:bool:null:4 b.rowid:int:5
  │    ├── scan
@@ -954,7 +954,7 @@ build
 SELECT * FROM a LEFT OUTER JOIN b ON a.i = b.i
 ----
 project
- ├── columns: a.i:int:null:1 b.i:int:null:3 b.b:bool:null:4
+ ├── columns: i:int:null:1 i:int:null:3 b:bool:null:4
  ├── left-join
  │    ├── columns: a.i:int:null:1 a.rowid:int:2 b.i:int:null:3 b.b:bool:null:4 b.rowid:int:null:5
  │    ├── scan
@@ -973,7 +973,7 @@ build
 SELECT * FROM a RIGHT OUTER JOIN b ON a.i = b.i
 ----
 project
- ├── columns: a.i:int:null:1 b.i:int:null:3 b.b:bool:null:4
+ ├── columns: i:int:null:1 i:int:null:3 b:bool:null:4
  ├── right-join
  │    ├── columns: a.i:int:null:1 a.rowid:int:null:2 b.i:int:null:3 b.b:bool:null:4 b.rowid:int:5
  │    ├── scan
@@ -992,7 +992,7 @@ build
 SELECT * FROM a FULL OUTER JOIN b ON a.i = b.i
 ----
 project
- ├── columns: a.i:int:null:1 b.i:int:null:3 b.b:bool:null:4
+ ├── columns: i:int:null:1 i:int:null:3 b:bool:null:4
  ├── full-join
  │    ├── columns: a.i:int:null:1 a.rowid:int:null:2 b.i:int:null:3 b.b:bool:null:4 b.rowid:int:null:5
  │    ├── scan
@@ -1012,7 +1012,7 @@ build
 SELECT * FROM a FULL OUTER JOIN b ON (a.i = b.i and a.i>2)
 ----
 project
- ├── columns: a.i:int:null:1 b.i:int:null:3 b.b:bool:null:4
+ ├── columns: i:int:null:1 i:int:null:3 b:bool:null:4
  ├── full-join
  │    ├── columns: a.i:int:null:1 a.rowid:int:null:2 b.i:int:null:3 b.b:bool:null:4 b.rowid:int:null:5
  │    ├── scan
@@ -1036,7 +1036,7 @@ build
 SELECT * FROM (onecolumn CROSS JOIN twocolumn JOIN onecolumn AS a(b) ON a.b=twocolumn.x JOIN twocolumn AS c(d,e) ON a.b=c.d AND c.d=onecolumn.x)
 ----
 project
- ├── columns: onecolumn.x:int:null:1 twocolumn.x:int:null:3 twocolumn.y:int:null:4 onecolumn.x:int:null:6 twocolumn.x:int:null:8 twocolumn.y:int:null:9
+ ├── columns: x:int:null:1 x:int:null:3 y:int:null:4 b:int:null:6 d:int:null:8 e:int:null:9
  ├── inner-join
  │    ├── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2 twocolumn.x:int:null:3 twocolumn.y:int:null:4 twocolumn.rowid:int:5 onecolumn.x:int:null:6 onecolumn.rowid:int:7 twocolumn.x:int:null:8 twocolumn.y:int:null:9 twocolumn.rowid:int:10
  │    ├── inner-join
@@ -1074,7 +1074,7 @@ build
 SELECT * FROM onecolumn JOIN (SELECT x + 2 AS x FROM onecolumn) USING(x)
 ----
 project
- ├── columns: onecolumn.x:int:null:1
+ ├── columns: x:int:null:1
  ├── inner-join
  │    ├── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2 x:int:null:5
  │    ├── scan
@@ -1098,7 +1098,7 @@ build
 SELECT * FROM (twocolumn AS a JOIN twocolumn AS b USING(x) JOIN twocolumn AS c USING(x))
 ----
 project
- ├── columns: twocolumn.x:int:null:1 twocolumn.y:int:null:2 twocolumn.y:int:null:5 twocolumn.y:int:null:8
+ ├── columns: x:int:null:1 y:int:null:2 y:int:null:5 y:int:null:8
  ├── inner-join
  │    ├── columns: twocolumn.x:int:null:1 twocolumn.y:int:null:2 twocolumn.rowid:int:3 twocolumn.x:int:null:4 twocolumn.y:int:null:5 twocolumn.rowid:int:6 twocolumn.x:int:null:7 twocolumn.y:int:null:8 twocolumn.rowid:int:9
  │    ├── inner-join
@@ -1125,7 +1125,7 @@ build
 SELECT a.x AS s, b.x, c.x, a.y, b.y, c.y FROM (twocolumn AS a JOIN twocolumn AS b USING(x) JOIN twocolumn AS c USING(x))
 ----
 project
- ├── columns: twocolumn.x:int:null:1 twocolumn.x:int:null:4 twocolumn.x:int:null:7 twocolumn.y:int:null:2 twocolumn.y:int:null:5 twocolumn.y:int:null:8
+ ├── columns: s:int:null:1 x:int:null:4 x:int:null:7 y:int:null:2 y:int:null:5 y:int:null:8
  ├── inner-join
  │    ├── columns: twocolumn.x:int:null:1 twocolumn.y:int:null:2 twocolumn.rowid:int:3 twocolumn.x:int:null:4 twocolumn.y:int:null:5 twocolumn.rowid:int:6 twocolumn.x:int:null:7 twocolumn.y:int:null:8 twocolumn.rowid:int:9
  │    ├── inner-join
@@ -1189,7 +1189,7 @@ build
 SELECT * FROM (SELECT * FROM onecolumn), (SELECT * FROM onecolumn)
 ----
 inner-join
- ├── columns: onecolumn.x:int:null:1 onecolumn.x:int:null:3
+ ├── columns: x:int:null:1 x:int:null:3
  ├── project
  │    ├── columns: onecolumn.x:int:null:1
  │    ├── scan
@@ -1209,7 +1209,7 @@ build
 SELECT x FROM (onecolumn JOIN othercolumn USING (x)) JOIN (onecolumn AS a JOIN othercolumn AS b USING(x)) USING(x)
 ----
 project
- ├── columns: onecolumn.x:int:null:1
+ ├── columns: x:int:null:1
  ├── inner-join
  │    ├── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2 othercolumn.x:int:null:3 othercolumn.rowid:int:4 onecolumn.x:int:null:5 onecolumn.rowid:int:6 othercolumn.x:int:null:7 othercolumn.rowid:int:8
  │    ├── inner-join
@@ -1257,7 +1257,7 @@ build
 SELECT a.x, b.y FROM twocolumn AS a, twocolumn AS b
 ----
 project
- ├── columns: twocolumn.x:int:null:1 twocolumn.y:int:null:5
+ ├── columns: x:int:null:1 y:int:null:5
  ├── inner-join
  │    ├── columns: twocolumn.x:int:null:1 twocolumn.y:int:null:2 twocolumn.rowid:int:3 twocolumn.x:int:null:4 twocolumn.y:int:null:5 twocolumn.rowid:int:6
  │    ├── scan
@@ -1273,7 +1273,7 @@ build
 SELECT b.y FROM (twocolumn AS a JOIN twocolumn AS b USING(x))
 ----
 project
- ├── columns: twocolumn.y:int:null:5
+ ├── columns: y:int:null:5
  ├── inner-join
  │    ├── columns: twocolumn.x:int:null:1 twocolumn.y:int:null:2 twocolumn.rowid:int:3 twocolumn.x:int:null:4 twocolumn.y:int:null:5 twocolumn.rowid:int:6
  │    ├── scan
@@ -1290,7 +1290,7 @@ build
 SELECT b.y FROM (twocolumn AS a JOIN twocolumn AS b ON a.x = b.x)
 ----
 project
- ├── columns: twocolumn.y:int:null:5
+ ├── columns: y:int:null:5
  ├── inner-join
  │    ├── columns: twocolumn.x:int:null:1 twocolumn.y:int:null:2 twocolumn.rowid:int:3 twocolumn.x:int:null:4 twocolumn.y:int:null:5 twocolumn.rowid:int:6
  │    ├── scan
@@ -1307,7 +1307,7 @@ build
 SELECT a.x FROM (twocolumn AS a JOIN twocolumn AS b ON a.x < b.y)
 ----
 project
- ├── columns: twocolumn.x:int:null:1
+ ├── columns: x:int:null:1
  ├── inner-join
  │    ├── columns: twocolumn.x:int:null:1 twocolumn.y:int:null:2 twocolumn.rowid:int:3 twocolumn.x:int:null:4 twocolumn.y:int:null:5 twocolumn.rowid:int:6
  │    ├── scan
@@ -1346,7 +1346,7 @@ build
 SELECT * FROM pairs, square WHERE pairs.b = square.n
 ----
 project
- ├── columns: pairs.a:int:null:1 pairs.b:int:null:2 square.n:int:4 square.sq:int:null:5
+ ├── columns: a:int:null:1 b:int:null:2 n:int:4 sq:int:null:5
  ├── select
  │    ├── columns: pairs.a:int:null:1 pairs.b:int:null:2 pairs.rowid:int:3 square.n:int:4 square.sq:int:null:5
  │    ├── inner-join
@@ -1370,7 +1370,7 @@ build
 SELECT * FROM pairs, square WHERE pairs.a + pairs.b = square.sq
 ----
 project
- ├── columns: pairs.a:int:null:1 pairs.b:int:null:2 square.n:int:4 square.sq:int:null:5
+ ├── columns: a:int:null:1 b:int:null:2 n:int:4 sq:int:null:5
  ├── select
  │    ├── columns: pairs.a:int:null:1 pairs.b:int:null:2 pairs.rowid:int:3 square.n:int:4 square.sq:int:null:5
  │    ├── inner-join
@@ -1398,7 +1398,7 @@ build
 SELECT a, b, n, sq FROM (SELECT a, b, a + b AS sum, n, sq FROM pairs, square) WHERE sum = sq
 ----
 project
- ├── columns: pairs.a:int:null:1 pairs.b:int:null:2 square.n:int:4 square.sq:int:null:5
+ ├── columns: a:int:null:1 b:int:null:2 n:int:4 sq:int:null:5
  ├── select
  │    ├── columns: pairs.a:int:null:1 pairs.b:int:null:2 square.n:int:4 square.sq:int:null:5 sum:int:null:6
  │    ├── project
@@ -1432,7 +1432,7 @@ build
 SELECT * FROM pairs FULL OUTER JOIN square ON pairs.a + pairs.b = square.sq
 ----
 project
- ├── columns: pairs.a:int:null:1 pairs.b:int:null:2 square.n:int:null:4 square.sq:int:null:5
+ ├── columns: a:int:null:1 b:int:null:2 n:int:null:4 sq:int:null:5
  ├── full-join
  │    ├── columns: pairs.a:int:null:1 pairs.b:int:null:2 pairs.rowid:int:null:3 square.n:int:null:4 square.sq:int:null:5
  │    ├── scan
@@ -1454,7 +1454,7 @@ build
 SELECT * FROM pairs FULL OUTER JOIN square ON pairs.a + pairs.b = square.sq WHERE pairs.b%2 <> square.sq%2
 ----
 project
- ├── columns: pairs.a:int:null:1 pairs.b:int:null:2 square.n:int:null:4 square.sq:int:null:5
+ ├── columns: a:int:null:1 b:int:null:2 n:int:null:4 sq:int:null:5
  ├── select
  │    ├── columns: pairs.a:int:null:1 pairs.b:int:null:2 pairs.rowid:int:null:3 square.n:int:null:4 square.sq:int:null:5
  │    ├── full-join
@@ -1489,7 +1489,7 @@ SELECT *
  WHERE b > 1 AND (n IS NULL OR n > 1) AND (n IS NULL OR a  < sq)
 ----
 select
- ├── columns: pairs.a:int:null:1 pairs.b:int:null:2 square.n:int:null:4 square.sq:int:null:5
+ ├── columns: a:int:null:1 b:int:null:2 n:int:null:4 sq:int:null:5
  ├── project
  │    ├── columns: pairs.a:int:null:1 pairs.b:int:null:2 square.n:int:null:4 square.sq:int:null:5
  │    ├── left-join
@@ -1540,7 +1540,7 @@ SELECT *
  WHERE (a IS NULL OR a > 2) AND n > 1 AND (a IS NULL OR a < sq)
 ----
 select
- ├── columns: pairs.a:int:null:1 pairs.b:int:null:2 square.n:int:4 square.sq:int:null:5
+ ├── columns: a:int:null:1 b:int:null:2 n:int:4 sq:int:null:5
  ├── project
  │    ├── columns: pairs.a:int:null:1 pairs.b:int:null:2 square.n:int:4 square.sq:int:null:5
  │    ├── right-join
@@ -1592,7 +1592,7 @@ SELECT *
  WHERE (a IS NULL OR a > 2) AND n > 1 AND (a IS NULL OR a < sq)
 ----
 select
- ├── columns: pairs.a:int:null:1 pairs.b:int:null:2 square.n:int:4 square.sq:int:null:5
+ ├── columns: a:int:null:1 b:int:null:2 n:int:4 sq:int:null:5
  ├── project
  │    ├── columns: pairs.a:int:null:1 pairs.b:int:null:2 square.n:int:4 square.sq:int:null:5
  │    ├── inner-join
@@ -1666,7 +1666,7 @@ build
 SELECT * FROM t1 JOIN t2 USING(x)
 ----
 project
- ├── columns: t1.x:int:null:2 t1.col1:int:null:1 t1.col2:int:null:3 t1.y:int:null:4 t2.col3:int:null:6 t2.y:int:null:7 t2.col4:int:null:9
+ ├── columns: x:int:null:2 col1:int:null:1 col2:int:null:3 y:int:null:4 col3:int:null:6 y:int:null:7 col4:int:null:9
  ├── inner-join
  │    ├── columns: t1.col1:int:null:1 t1.x:int:null:2 t1.col2:int:null:3 t1.y:int:null:4 t1.rowid:int:5 t2.col3:int:null:6 t2.y:int:null:7 t2.x:int:null:8 t2.col4:int:null:9 t2.rowid:int:10
  │    ├── scan
@@ -1689,7 +1689,7 @@ build
 SELECT * FROM t1 NATURAL JOIN t2
 ----
 project
- ├── columns: t1.x:int:null:2 t1.y:int:null:4 t1.col1:int:null:1 t1.col2:int:null:3 t2.col3:int:null:6 t2.col4:int:null:9
+ ├── columns: x:int:null:2 y:int:null:4 col1:int:null:1 col2:int:null:3 col3:int:null:6 col4:int:null:9
  ├── inner-join
  │    ├── columns: t1.col1:int:null:1 t1.x:int:null:2 t1.col2:int:null:3 t1.y:int:null:4 t1.rowid:int:5 t2.col3:int:null:6 t2.y:int:null:7 t2.x:int:null:8 t2.col4:int:null:9 t2.rowid:int:10
  │    ├── scan
@@ -1715,7 +1715,7 @@ build
 SELECT * FROM t1 JOIN t2 ON t2.x=t1.x
 ----
 project
- ├── columns: t1.col1:int:null:1 t1.x:int:null:2 t1.col2:int:null:3 t1.y:int:null:4 t2.col3:int:null:6 t2.y:int:null:7 t2.x:int:null:8 t2.col4:int:null:9
+ ├── columns: col1:int:null:1 x:int:null:2 col2:int:null:3 y:int:null:4 col3:int:null:6 y:int:null:7 x:int:null:8 col4:int:null:9
  ├── inner-join
  │    ├── columns: t1.col1:int:null:1 t1.x:int:null:2 t1.col2:int:null:3 t1.y:int:null:4 t1.rowid:int:5 t2.col3:int:null:6 t2.y:int:null:7 t2.x:int:null:8 t2.col4:int:null:9 t2.rowid:int:10
  │    ├── scan
@@ -1739,7 +1739,7 @@ build
 SELECT * FROM t1 FULL OUTER JOIN t2 USING(x)
 ----
 project
- ├── columns: x:int:null:11 t1.col1:int:null:1 t1.col2:int:null:3 t1.y:int:null:4 t2.col3:int:null:6 t2.y:int:null:7 t2.col4:int:null:9
+ ├── columns: x:int:null:11 col1:int:null:1 col2:int:null:3 y:int:null:4 col3:int:null:6 y:int:null:7 col4:int:null:9
  ├── project
  │    ├── columns: x:int:null:11 t1.col1:int:null:1 t1.x:int:null:2 t1.col2:int:null:3 t1.y:int:null:4 t1.rowid:int:null:5 t2.col3:int:null:6 t2.y:int:null:7 t2.x:int:null:8 t2.col4:int:null:9 t2.rowid:int:null:10
  │    ├── full-join
@@ -1778,7 +1778,7 @@ build
 SELECT * FROM t1 NATURAL FULL OUTER JOIN t2
 ----
 project
- ├── columns: x:int:null:11 y:int:null:12 t1.col1:int:null:1 t1.col2:int:null:3 t2.col3:int:null:6 t2.col4:int:null:9
+ ├── columns: x:int:null:11 y:int:null:12 col1:int:null:1 col2:int:null:3 col3:int:null:6 col4:int:null:9
  ├── project
  │    ├── columns: x:int:null:11 y:int:null:12 t1.col1:int:null:1 t1.x:int:null:2 t1.col2:int:null:3 t1.y:int:null:4 t1.rowid:int:null:5 t2.col3:int:null:6 t2.y:int:null:7 t2.x:int:null:8 t2.col4:int:null:9 t2.rowid:int:null:10
  │    ├── full-join
@@ -1823,7 +1823,7 @@ build
 SELECT * FROM t1 FULL OUTER JOIN t2 ON t1.x=t2.x
 ----
 project
- ├── columns: t1.col1:int:null:1 t1.x:int:null:2 t1.col2:int:null:3 t1.y:int:null:4 t2.col3:int:null:6 t2.y:int:null:7 t2.x:int:null:8 t2.col4:int:null:9
+ ├── columns: col1:int:null:1 x:int:null:2 col2:int:null:3 y:int:null:4 col3:int:null:6 y:int:null:7 x:int:null:8 col4:int:null:9
  ├── full-join
  │    ├── columns: t1.col1:int:null:1 t1.x:int:null:2 t1.col2:int:null:3 t1.y:int:null:4 t1.rowid:int:null:5 t2.col3:int:null:6 t2.y:int:null:7 t2.x:int:null:8 t2.col4:int:null:9 t2.rowid:int:null:10
  │    ├── scan
@@ -1847,7 +1847,7 @@ build
 SELECT t2.x, t1.x, x FROM t1 JOIN t2 USING(x)
 ----
 project
- ├── columns: t2.x:int:null:8 t1.x:int:null:2 t1.x:int:null:2
+ ├── columns: x:int:null:8 x:int:null:2 x:int:null:2
  ├── inner-join
  │    ├── columns: t1.col1:int:null:1 t1.x:int:null:2 t1.col2:int:null:3 t1.y:int:null:4 t1.rowid:int:5 t2.col3:int:null:6 t2.y:int:null:7 t2.x:int:null:8 t2.col4:int:null:9 t2.rowid:int:10
  │    ├── scan
@@ -1866,7 +1866,7 @@ build
 SELECT t2.x, t1.x, x FROM t1 FULL OUTER JOIN t2 USING(x)
 ----
 project
- ├── columns: t2.x:int:null:8 t1.x:int:null:2 x:int:null:11
+ ├── columns: x:int:null:8 x:int:null:2 x:int:null:11
  ├── project
  │    ├── columns: x:int:null:11 t1.col1:int:null:1 t1.x:int:null:2 t1.col2:int:null:3 t1.y:int:null:4 t1.rowid:int:null:5 t2.col3:int:null:6 t2.y:int:null:7 t2.x:int:null:8 t2.col4:int:null:9 t2.rowid:int:null:10
  │    ├── full-join
@@ -1902,7 +1902,7 @@ build
 SELECT x FROM t1 NATURAL JOIN (SELECT * FROM t2)
 ----
 project
- ├── columns: t1.x:int:null:2
+ ├── columns: x:int:null:2
  ├── inner-join
  │    ├── columns: t1.col1:int:null:1 t1.x:int:null:2 t1.col2:int:null:3 t1.y:int:null:4 t1.rowid:int:5 t2.col3:int:null:6 t2.y:int:null:7 t2.x:int:null:8 t2.col4:int:null:9
  │    ├── scan
@@ -1981,7 +1981,7 @@ build
 SELECT * FROM pkBA AS l JOIN pkBC AS r ON l.a = r.a AND l.b = r.b AND l.c = r.c
 ----
 inner-join
- ├── columns: pkba.a:int:1 pkba.b:int:2 pkba.c:int:null:3 pkba.d:int:null:4 pkbc.a:int:null:5 pkbc.b:int:6 pkbc.c:int:7 pkbc.d:int:null:8
+ ├── columns: a:int:1 b:int:2 c:int:null:3 d:int:null:4 a:int:null:5 b:int:6 c:int:7 d:int:null:8
  ├── scan
  │    └── columns: pkba.a:int:1 pkba.b:int:2 pkba.c:int:null:3 pkba.d:int:null:4
  ├── scan
@@ -2002,7 +2002,7 @@ build
 SELECT * FROM pkBA NATURAL JOIN pkBAD
 ----
 project
- ├── columns: pkba.a:int:1 pkba.b:int:2 pkba.c:int:null:3 pkba.d:int:null:4
+ ├── columns: a:int:1 b:int:2 c:int:null:3 d:int:null:4
  ├── inner-join
  │    ├── columns: pkba.a:int:1 pkba.b:int:2 pkba.c:int:null:3 pkba.d:int:null:4 pkbad.a:int:5 pkbad.b:int:6 pkbad.c:int:null:7 pkbad.d:int:8
  │    ├── scan
@@ -2032,7 +2032,7 @@ build
 SELECT * FROM pkBAC AS l JOIN pkBAC AS r USING(a, b, c)
 ----
 project
- ├── columns: pkbac.a:int:1 pkbac.b:int:2 pkbac.c:int:3 pkbac.d:int:null:4 pkbac.d:int:null:8
+ ├── columns: a:int:1 b:int:2 c:int:3 d:int:null:4 d:int:null:8
  ├── inner-join
  │    ├── columns: pkbac.a:int:1 pkbac.b:int:2 pkbac.c:int:3 pkbac.d:int:null:4 pkbac.a:int:5 pkbac.b:int:6 pkbac.c:int:7 pkbac.d:int:null:8
  │    ├── scan
@@ -2060,7 +2060,7 @@ build
 SELECT * FROM pkBAC AS l JOIN pkBAD AS r ON l.c = r.d AND l.a = r.a AND l.b = r.b
 ----
 inner-join
- ├── columns: pkbac.a:int:1 pkbac.b:int:2 pkbac.c:int:3 pkbac.d:int:null:4 pkbad.a:int:5 pkbad.b:int:6 pkbad.c:int:null:7 pkbad.d:int:8
+ ├── columns: a:int:1 b:int:2 c:int:3 d:int:null:4 a:int:5 b:int:6 c:int:null:7 d:int:8
  ├── scan
  │    └── columns: pkbac.a:int:1 pkbac.b:int:2 pkbac.c:int:3 pkbac.d:int:null:4
  ├── scan
@@ -2100,7 +2100,7 @@ build
 SELECT s, str1.s, str2.s FROM str1 INNER JOIN str2 USING(s)
 ----
 project
- ├── columns: str1.s:collatedstring{en_u_ks_level1}:null:2 str1.s:collatedstring{en_u_ks_level1}:null:2 str2.s:collatedstring{en_u_ks_level1}:null:4
+ ├── columns: s:collatedstring{en_u_ks_level1}:null:2 s:collatedstring{en_u_ks_level1}:null:2 s:collatedstring{en_u_ks_level1}:null:4
  ├── inner-join
  │    ├── columns: str1.a:int:1 str1.s:collatedstring{en_u_ks_level1}:null:2 str2.a:int:3 str2.s:collatedstring{en_u_ks_level1}:null:4
  │    ├── scan
@@ -2119,7 +2119,7 @@ build
 SELECT s, str1.s, str2.s FROM str1 LEFT OUTER JOIN str2 USING(s)
 ----
 project
- ├── columns: str1.s:collatedstring{en_u_ks_level1}:null:2 str1.s:collatedstring{en_u_ks_level1}:null:2 str2.s:collatedstring{en_u_ks_level1}:null:4
+ ├── columns: s:collatedstring{en_u_ks_level1}:null:2 s:collatedstring{en_u_ks_level1}:null:2 s:collatedstring{en_u_ks_level1}:null:4
  ├── left-join
  │    ├── columns: str1.a:int:1 str1.s:collatedstring{en_u_ks_level1}:null:2 str2.a:int:null:3 str2.s:collatedstring{en_u_ks_level1}:null:4
  │    ├── scan
@@ -2138,7 +2138,7 @@ build
 SELECT s, str1.s, str2.s FROM str1 RIGHT OUTER JOIN str2 USING(s)
 ----
 project
- ├── columns: s:collatedstring{en_u_ks_level1}:null:5 str1.s:collatedstring{en_u_ks_level1}:null:2 str2.s:collatedstring{en_u_ks_level1}:null:4
+ ├── columns: s:collatedstring{en_u_ks_level1}:null:5 s:collatedstring{en_u_ks_level1}:null:2 s:collatedstring{en_u_ks_level1}:null:4
  ├── project
  │    ├── columns: s:collatedstring{en_u_ks_level1}:null:5 str1.a:int:null:1 str1.s:collatedstring{en_u_ks_level1}:null:2 str2.a:int:3 str2.s:collatedstring{en_u_ks_level1}:null:4
  │    ├── right-join
@@ -2167,7 +2167,7 @@ build
 SELECT s, str1.s, str2.s FROM str1 FULL OUTER JOIN str2 USING(s)
 ----
 project
- ├── columns: s:collatedstring{en_u_ks_level1}:null:5 str1.s:collatedstring{en_u_ks_level1}:null:2 str2.s:collatedstring{en_u_ks_level1}:null:4
+ ├── columns: s:collatedstring{en_u_ks_level1}:null:5 s:collatedstring{en_u_ks_level1}:null:2 s:collatedstring{en_u_ks_level1}:null:4
  ├── project
  │    ├── columns: s:collatedstring{en_u_ks_level1}:null:5 str1.a:int:null:1 str1.s:collatedstring{en_u_ks_level1}:null:2 str2.a:int:null:3 str2.s:collatedstring{en_u_ks_level1}:null:4
  │    ├── full-join
@@ -2198,7 +2198,7 @@ build
 SELECT * FROM str1 RIGHT OUTER JOIN str2 USING(a, s)
 ----
 project
- ├── columns: str2.a:int:3 s:collatedstring{en_u_ks_level1}:null:5
+ ├── columns: a:int:3 s:collatedstring{en_u_ks_level1}:null:5
  ├── project
  │    ├── columns: str2.a:int:3 s:collatedstring{en_u_ks_level1}:null:5 str1.a:int:null:1 str1.s:collatedstring{en_u_ks_level1}:null:2 str2.s:collatedstring{en_u_ks_level1}:null:4
  │    ├── right-join
@@ -2255,7 +2255,7 @@ build
 SELECT * FROM xyu INNER JOIN xyv USING(x, y) WHERE x > 2
 ----
 project
- ├── columns: xyu.x:int:1 xyu.y:int:2 xyu.u:int:3 xyv.v:int:6
+ ├── columns: x:int:1 y:int:2 u:int:3 v:int:6
  ├── select
  │    ├── columns: xyu.x:int:1 xyu.y:int:2 xyu.u:int:3 xyv.x:int:4 xyv.y:int:5 xyv.v:int:6
  │    ├── inner-join
@@ -2284,7 +2284,7 @@ build
 SELECT * FROM xyu LEFT OUTER JOIN xyv USING(x, y) WHERE x > 2
 ----
 project
- ├── columns: xyu.x:int:1 xyu.y:int:2 xyu.u:int:3 xyv.v:int:null:6
+ ├── columns: x:int:1 y:int:2 u:int:3 v:int:null:6
  ├── select
  │    ├── columns: xyu.x:int:1 xyu.y:int:2 xyu.u:int:3 xyv.x:int:null:4 xyv.y:int:null:5 xyv.v:int:null:6
  │    ├── left-join
@@ -2313,7 +2313,7 @@ build
 SELECT * FROM xyu RIGHT OUTER JOIN xyv USING(x, y) WHERE x > 2
 ----
 project
- ├── columns: xyv.x:int:4 xyv.y:int:5 xyu.u:int:null:3 xyv.v:int:6
+ ├── columns: x:int:4 y:int:5 u:int:null:3 v:int:6
  ├── select
  │    ├── columns: xyu.x:int:null:1 xyu.y:int:null:2 xyu.u:int:null:3 xyv.x:int:4 xyv.y:int:5 xyv.v:int:6
  │    ├── right-join
@@ -2342,7 +2342,7 @@ build
 SELECT * FROM xyu FULL OUTER JOIN xyv USING(x, y) WHERE x > 2
 ----
 project
- ├── columns: x:int:null:7 y:int:null:8 xyu.u:int:null:3 xyv.v:int:null:6
+ ├── columns: x:int:null:7 y:int:null:8 u:int:null:3 v:int:null:6
  ├── select
  │    ├── columns: xyu.x:int:null:1 xyu.y:int:null:2 xyu.u:int:null:3 xyv.x:int:null:4 xyv.y:int:null:5 xyv.v:int:null:6 x:int:null:7 y:int:null:8
  │    ├── project
@@ -2387,7 +2387,7 @@ build
 SELECT * FROM xyu INNER JOIN xyv ON xyu.x = xyv.x AND xyu.y = xyv.y WHERE xyu.x = 1 AND xyu.y < 10
 ----
 select
- ├── columns: xyu.x:int:1 xyu.y:int:2 xyu.u:int:3 xyv.x:int:4 xyv.y:int:5 xyv.v:int:6
+ ├── columns: x:int:1 y:int:2 u:int:3 x:int:4 y:int:5 v:int:6
  ├── inner-join
  │    ├── columns: xyu.x:int:1 xyu.y:int:2 xyu.u:int:3 xyv.x:int:4 xyv.y:int:5 xyv.v:int:6
  │    ├── scan
@@ -2413,7 +2413,7 @@ build
 SELECT * FROM xyu INNER JOIN xyv ON xyu.x = xyv.x AND xyu.y = xyv.y AND xyu.x = 1 AND xyu.y < 10
 ----
 inner-join
- ├── columns: xyu.x:int:1 xyu.y:int:2 xyu.u:int:3 xyv.x:int:4 xyv.y:int:5 xyv.v:int:6
+ ├── columns: x:int:1 y:int:2 u:int:3 x:int:4 y:int:5 v:int:6
  ├── scan
  │    └── columns: xyu.x:int:1 xyu.y:int:2 xyu.u:int:3
  ├── scan
@@ -2438,7 +2438,7 @@ build
 SELECT * FROM xyu LEFT OUTER JOIN xyv ON xyu.x = xyv.x AND xyu.y = xyv.y AND xyu.x = 1 AND xyu.y < 10
 ----
 left-join
- ├── columns: xyu.x:int:1 xyu.y:int:2 xyu.u:int:3 xyv.x:int:null:4 xyv.y:int:null:5 xyv.v:int:null:6
+ ├── columns: x:int:1 y:int:2 u:int:3 x:int:null:4 y:int:null:5 v:int:null:6
  ├── scan
  │    └── columns: xyu.x:int:1 xyu.y:int:2 xyu.u:int:3
  ├── scan
@@ -2463,7 +2463,7 @@ build
 SELECT * FROM xyu RIGHT OUTER JOIN xyv ON xyu.x = xyv.x AND xyu.y = xyv.y AND xyu.x = 1 AND xyu.y < 10
 ----
 right-join
- ├── columns: xyu.x:int:null:1 xyu.y:int:null:2 xyu.u:int:null:3 xyv.x:int:4 xyv.y:int:5 xyv.v:int:6
+ ├── columns: x:int:null:1 y:int:null:2 u:int:null:3 x:int:4 y:int:5 v:int:6
  ├── scan
  │    └── columns: xyu.x:int:1 xyu.y:int:2 xyu.u:int:3
  ├── scan
@@ -2491,7 +2491,7 @@ build
 SELECT * FROM (SELECT * FROM xyu) AS xyu LEFT OUTER JOIN (SELECT * FROM xyv) AS xyv USING(x, y) WHERE x > 2
 ----
 project
- ├── columns: xyu.x:int:1 xyu.y:int:2 xyu.u:int:3 xyv.v:int:null:6
+ ├── columns: x:int:1 y:int:2 u:int:3 v:int:null:6
  ├── select
  │    ├── columns: xyu.x:int:1 xyu.y:int:2 xyu.u:int:3 xyv.x:int:null:4 xyv.y:int:null:5 xyv.v:int:null:6
  │    ├── left-join
@@ -2520,7 +2520,7 @@ build
 SELECT * FROM (SELECT * FROM xyu) AS xyu RIGHT OUTER JOIN (SELECT * FROM xyv) AS xyv USING(x, y) WHERE x > 2
 ----
 project
- ├── columns: xyv.x:int:4 xyv.y:int:5 xyu.u:int:null:3 xyv.v:int:6
+ ├── columns: x:int:4 y:int:5 u:int:null:3 v:int:6
  ├── select
  │    ├── columns: xyu.x:int:null:1 xyu.y:int:null:2 xyu.u:int:null:3 xyv.x:int:4 xyv.y:int:5 xyv.v:int:6
  │    ├── right-join
@@ -2549,7 +2549,7 @@ build
 SELECT * FROM (SELECT * FROM xyu) AS xyu FULL OUTER JOIN (SELECT * FROM xyv) AS xyv USING(x, y) WHERE x > 2
 ----
 project
- ├── columns: x:int:null:7 y:int:null:8 xyu.u:int:null:3 xyv.v:int:null:6
+ ├── columns: x:int:null:7 y:int:null:8 u:int:null:3 v:int:null:6
  ├── select
  │    ├── columns: xyu.x:int:null:1 xyu.y:int:null:2 xyu.u:int:null:3 xyv.x:int:null:4 xyv.y:int:null:5 xyv.v:int:null:6 x:int:null:7 y:int:null:8
  │    ├── project
@@ -2593,7 +2593,7 @@ build
 SELECT * FROM (SELECT * FROM xyu) AS xyu LEFT OUTER JOIN (SELECT * FROM xyv) AS xyv ON xyu.x = xyv.x AND xyu.y = xyv.y AND xyu.x = 1 AND xyu.y < 10
 ----
 left-join
- ├── columns: xyu.x:int:1 xyu.y:int:2 xyu.u:int:3 xyv.x:int:null:4 xyv.y:int:null:5 xyv.v:int:null:6
+ ├── columns: x:int:1 y:int:2 u:int:3 x:int:null:4 y:int:null:5 v:int:null:6
  ├── scan
  │    └── columns: xyu.x:int:1 xyu.y:int:2 xyu.u:int:3
  ├── scan
@@ -2618,7 +2618,7 @@ build
 SELECT * FROM xyu RIGHT OUTER JOIN (SELECT * FROM xyv) AS xyv ON xyu.x = xyv.x AND xyu.y = xyv.y AND xyu.x = 1 AND xyu.y < 10
 ----
 right-join
- ├── columns: xyu.x:int:null:1 xyu.y:int:null:2 xyu.u:int:null:3 xyv.x:int:4 xyv.y:int:5 xyv.v:int:6
+ ├── columns: x:int:null:1 y:int:null:2 u:int:null:3 x:int:4 y:int:5 v:int:6
  ├── scan
  │    └── columns: xyu.x:int:1 xyu.y:int:2 xyu.u:int:3
  ├── scan
@@ -2644,7 +2644,7 @@ build
 SELECT * FROM xyu JOIN xyv USING(x, y) WHERE (x, y, u) > (1, 2, 3)
 ----
 project
- ├── columns: xyu.x:int:1 xyu.y:int:2 xyu.u:int:3 xyv.v:int:6
+ ├── columns: x:int:1 y:int:2 u:int:3 v:int:6
  ├── select
  │    ├── columns: xyu.x:int:1 xyu.y:int:2 xyu.u:int:3 xyv.x:int:4 xyv.y:int:5 xyv.v:int:6
  │    ├── inner-join
@@ -2698,7 +2698,7 @@ build
 SELECT * FROM l LEFT OUTER JOIN r ON l.a = r.a WHERE l.a = 3;
 ----
 select
- ├── columns: l.a:int:1 r.a:int:null:2
+ ├── columns: a:int:1 a:int:null:2
  ├── left-join
  │    ├── columns: l.a:int:1 r.a:int:null:2
  │    ├── scan
@@ -2716,7 +2716,7 @@ build
 SELECT * FROM l RIGHT OUTER JOIN r ON l.a = r.a WHERE r.a = 3;
 ----
 select
- ├── columns: l.a:int:null:1 r.a:int:2
+ ├── columns: a:int:null:1 a:int:2
  ├── right-join
  │    ├── columns: l.a:int:null:1 r.a:int:2
  │    ├── scan
@@ -2734,7 +2734,7 @@ build
 SELECT * FROM l LEFT OUTER JOIN r USING(a) WHERE a = 1
 ----
 project
- ├── columns: l.a:int:1
+ ├── columns: a:int:1
  ├── select
  │    ├── columns: l.a:int:1 r.a:int:null:2
  │    ├── left-join
@@ -2756,7 +2756,7 @@ build
 SELECT * FROM l RIGHT OUTER JOIN r USING(a) WHERE a = 3
 ----
 project
- ├── columns: r.a:int:2
+ ├── columns: a:int:2
  ├── select
  │    ├── columns: l.a:int:null:1 r.a:int:2
  │    ├── right-join
@@ -2819,7 +2819,7 @@ build
 SELECT * FROM abcdef join (select * from abg) USING (a,b) WHERE ((a,b)>(1,2) OR ((a,b)=(1,2) AND c < 6) OR ((a,b,c)=(1,2,6) AND d > 8))
 ----
 project
- ├── columns: abcdef.a:int:1 abcdef.b:int:2 abcdef.c:int:3 abcdef.d:int:4 abcdef.e:int:null:5 abcdef.f:int:null:6 abg.g:int:null:9
+ ├── columns: a:int:1 b:int:2 c:int:3 d:int:4 e:int:null:5 f:int:null:6 g:int:null:9
  ├── select
  │    ├── columns: abcdef.a:int:1 abcdef.b:int:2 abcdef.c:int:3 abcdef.d:int:4 abcdef.e:int:null:5 abcdef.f:int:null:6 abg.a:int:7 abg.b:int:8 abg.g:int:null:9
  │    ├── inner-join
@@ -2917,7 +2917,7 @@ build
 SELECT * FROM foo NATURAL JOIN bar
 ----
 project
- ├── columns: foo.a:int:null:1 foo.b:int:null:2 foo.c:float:null:3 foo.d:float:null:4
+ ├── columns: a:int:null:1 b:int:null:2 c:float:null:3 d:float:null:4
  ├── inner-join
  │    ├── columns: foo.a:int:null:1 foo.b:int:null:2 foo.c:float:null:3 foo.d:float:null:4 foo.rowid:int:5 bar.a:int:null:6 bar.b:float:null:7 bar.c:float:null:8 bar.d:int:null:9 bar.rowid:int:10
  │    ├── scan
@@ -2948,7 +2948,7 @@ build
 SELECT * FROM foo JOIN bar USING (b)
 ----
 project
- ├── columns: foo.b:int:null:2 foo.a:int:null:1 foo.c:float:null:3 foo.d:float:null:4 bar.a:int:null:6 bar.c:float:null:8 bar.d:int:null:9
+ ├── columns: b:int:null:2 a:int:null:1 c:float:null:3 d:float:null:4 a:int:null:6 c:float:null:8 d:int:null:9
  ├── inner-join
  │    ├── columns: foo.a:int:null:1 foo.b:int:null:2 foo.c:float:null:3 foo.d:float:null:4 foo.rowid:int:5 bar.a:int:null:6 bar.b:float:null:7 bar.c:float:null:8 bar.d:int:null:9 bar.rowid:int:10
  │    ├── scan
@@ -2972,7 +2972,7 @@ build
 SELECT * FROM foo JOIN bar USING (a, b)
 ----
 project
- ├── columns: foo.a:int:null:1 foo.b:int:null:2 foo.c:float:null:3 foo.d:float:null:4 bar.c:float:null:8 bar.d:int:null:9
+ ├── columns: a:int:null:1 b:int:null:2 c:float:null:3 d:float:null:4 c:float:null:8 d:int:null:9
  ├── inner-join
  │    ├── columns: foo.a:int:null:1 foo.b:int:null:2 foo.c:float:null:3 foo.d:float:null:4 foo.rowid:int:5 bar.a:int:null:6 bar.b:float:null:7 bar.c:float:null:8 bar.d:int:null:9 bar.rowid:int:10
  │    ├── scan
@@ -2999,7 +2999,7 @@ build
 SELECT * FROM foo JOIN bar USING (a, b, c)
 ----
 project
- ├── columns: foo.a:int:null:1 foo.b:int:null:2 foo.c:float:null:3 foo.d:float:null:4 bar.d:int:null:9
+ ├── columns: a:int:null:1 b:int:null:2 c:float:null:3 d:float:null:4 d:int:null:9
  ├── inner-join
  │    ├── columns: foo.a:int:null:1 foo.b:int:null:2 foo.c:float:null:3 foo.d:float:null:4 foo.rowid:int:5 bar.a:int:null:6 bar.b:float:null:7 bar.c:float:null:8 bar.d:int:null:9 bar.rowid:int:10
  │    ├── scan
@@ -3028,7 +3028,7 @@ build
 SELECT * FROM foo JOIN bar ON foo.b = bar.b
 ----
 project
- ├── columns: foo.a:int:null:1 foo.b:int:null:2 foo.c:float:null:3 foo.d:float:null:4 bar.a:int:null:6 bar.b:float:null:7 bar.c:float:null:8 bar.d:int:null:9
+ ├── columns: a:int:null:1 b:int:null:2 c:float:null:3 d:float:null:4 a:int:null:6 b:float:null:7 c:float:null:8 d:int:null:9
  ├── inner-join
  │    ├── columns: foo.a:int:null:1 foo.b:int:null:2 foo.c:float:null:3 foo.d:float:null:4 foo.rowid:int:5 bar.a:int:null:6 bar.b:float:null:7 bar.c:float:null:8 bar.d:int:null:9 bar.rowid:int:10
  │    ├── scan
@@ -3053,7 +3053,7 @@ build
 SELECT * FROM foo JOIN bar ON foo.a = bar.a AND foo.b = bar.b
 ----
 project
- ├── columns: foo.a:int:null:1 foo.b:int:null:2 foo.c:float:null:3 foo.d:float:null:4 bar.a:int:null:6 bar.b:float:null:7 bar.c:float:null:8 bar.d:int:null:9
+ ├── columns: a:int:null:1 b:int:null:2 c:float:null:3 d:float:null:4 a:int:null:6 b:float:null:7 c:float:null:8 d:int:null:9
  ├── inner-join
  │    ├── columns: foo.a:int:null:1 foo.b:int:null:2 foo.c:float:null:3 foo.d:float:null:4 foo.rowid:int:5 bar.a:int:null:6 bar.b:float:null:7 bar.c:float:null:8 bar.d:int:null:9 bar.rowid:int:10
  │    ├── scan
@@ -3081,7 +3081,7 @@ build
 SELECT * FROM foo, bar WHERE foo.b = bar.b
 ----
 project
- ├── columns: foo.a:int:null:1 foo.b:int:null:2 foo.c:float:null:3 foo.d:float:null:4 bar.a:int:null:6 bar.b:float:null:7 bar.c:float:null:8 bar.d:int:null:9
+ ├── columns: a:int:null:1 b:int:null:2 c:float:null:3 d:float:null:4 a:int:null:6 b:float:null:7 c:float:null:8 d:int:null:9
  ├── select
  │    ├── columns: foo.a:int:null:1 foo.b:int:null:2 foo.c:float:null:3 foo.d:float:null:4 foo.rowid:int:5 bar.a:int:null:6 bar.b:float:null:7 bar.c:float:null:8 bar.d:int:null:9 bar.rowid:int:10
  │    ├── inner-join
@@ -3109,7 +3109,7 @@ build
 SELECT * FROM foo, bar WHERE foo.a = bar.a AND foo.b = bar.b
 ----
 project
- ├── columns: foo.a:int:null:1 foo.b:int:null:2 foo.c:float:null:3 foo.d:float:null:4 bar.a:int:null:6 bar.b:float:null:7 bar.c:float:null:8 bar.d:int:null:9
+ ├── columns: a:int:null:1 b:int:null:2 c:float:null:3 d:float:null:4 a:int:null:6 b:float:null:7 c:float:null:8 d:int:null:9
  ├── select
  │    ├── columns: foo.a:int:null:1 foo.b:int:null:2 foo.c:float:null:3 foo.d:float:null:4 foo.rowid:int:5 bar.a:int:null:6 bar.b:float:null:7 bar.c:float:null:8 bar.d:int:null:9 bar.rowid:int:10
  │    ├── inner-join
@@ -3141,7 +3141,7 @@ build
 SELECT * FROM foo JOIN bar USING (a, b) WHERE foo.c = bar.c AND foo.d = bar.d
 ----
 project
- ├── columns: foo.a:int:null:1 foo.b:int:null:2 foo.c:float:null:3 foo.d:float:null:4 bar.c:float:null:8 bar.d:int:null:9
+ ├── columns: a:int:null:1 b:int:null:2 c:float:null:3 d:float:null:4 c:float:null:8 d:int:null:9
  ├── select
  │    ├── columns: foo.a:int:null:1 foo.b:int:null:2 foo.c:float:null:3 foo.d:float:null:4 foo.rowid:int:5 bar.a:int:null:6 bar.b:float:null:7 bar.c:float:null:8 bar.d:int:null:9 bar.rowid:int:10
  │    ├── inner-join

--- a/pkg/sql/opt/optbuilder/testdata/project
+++ b/pkg/sql/opt/optbuilder/testdata/project
@@ -31,7 +31,7 @@ build
 SELECT a.x FROM t.a
 ----
 project
- ├── columns: a.x:int:1
+ ├── columns: x:int:1
  ├── scan
  │    └── columns: a.x:int:1 a.y:float:null:2
  └── projections
@@ -41,13 +41,13 @@ build
 SELECT a.x, a.y FROM t.a
 ----
 scan
- └── columns: a.x:int:1 a.y:float:null:2
+ └── columns: x:int:1 y:float:null:2
 
 build
 SELECT a.y, a.x FROM t.a
 ----
 project
- ├── columns: a.y:float:null:2 a.x:int:1
+ ├── columns: y:float:null:2 x:int:1
  ├── scan
  │    └── columns: a.x:int:1 a.y:float:null:2
  └── projections
@@ -58,7 +58,7 @@ build
 SELECT * FROM t.a
 ----
 scan
- └── columns: a.x:int:1 a.y:float:null:2
+ └── columns: x:int:1 y:float:null:2
 
 # Note that an explicit projection operator is added for table b (unlike for
 # table a) to avoid projecting the hidden rowid column.
@@ -66,7 +66,7 @@ build
 SELECT * FROM t.b
 ----
 project
- ├── columns: b.x:int:null:1 b.y:float:null:2
+ ├── columns: x:int:null:1 y:float:null:2
  ├── scan
  │    └── columns: b.x:int:null:1 b.y:float:null:2 b.rowid:int:3
  └── projections
@@ -90,7 +90,7 @@ build
 SELECT *, ((x < y) OR x > 1000) FROM t.a
 ----
 project
- ├── columns: a.x:int:1 a.y:float:null:2 column3:bool:null:3
+ ├── columns: x:int:1 y:float:null:2 column3:bool:null:3
  ├── scan
  │    └── columns: a.x:int:1 a.y:float:null:2
  └── projections
@@ -108,7 +108,7 @@ build
 SELECT a.*, true FROM t.a
 ----
 project
- ├── columns: a.x:int:1 a.y:float:null:2 column3:bool:null:3
+ ├── columns: x:int:1 y:float:null:2 column3:bool:null:3
  ├── scan
  │    └── columns: a.x:int:1 a.y:float:null:2
  └── projections
@@ -144,7 +144,7 @@ build
 SELECT rowid FROM b;
 ----
 project
- ├── columns: b.rowid:int:3
+ ├── columns: rowid:int:3
  ├── scan
  │    └── columns: b.x:int:null:1 b.y:float:null:2 b.rowid:int:3
  └── projections
@@ -159,7 +159,7 @@ build
 SELECT rowid FROM (SELECT rowid FROM b)
 ----
 project
- ├── columns: b.rowid:int:3
+ ├── columns: rowid:int:3
  ├── scan
  │    └── columns: b.x:int:null:1 b.y:float:null:2 b.rowid:int:3
  └── projections
@@ -169,7 +169,7 @@ build
 SELECT q.r FROM (SELECT rowid FROM b) AS q(r)
 ----
 project
- ├── columns: b.rowid:int:3
+ ├── columns: r:int:3
  ├── scan
  │    └── columns: b.x:int:null:1 b.y:float:null:2 b.rowid:int:3
  └── projections
@@ -179,7 +179,7 @@ build
 SELECT r FROM (SELECT rowid FROM b) AS q(r)
 ----
 project
- ├── columns: b.rowid:int:3
+ ├── columns: r:int:3
  ├── scan
  │    └── columns: b.x:int:null:1 b.y:float:null:2 b.rowid:int:3
  └── projections

--- a/pkg/sql/opt/optbuilder/testdata/select
+++ b/pkg/sql/opt/optbuilder/testdata/select
@@ -11,13 +11,13 @@ build
 SELECT * FROM t.a
 ----
 scan
- └── columns: a.x:int:1 a.y:float:null:2
+ └── columns: x:int:1 y:float:null:2
 
 build
 SELECT * FROM t.a WHERE x > 10
 ----
 select
- ├── columns: a.x:int:1 a.y:float:null:2
+ ├── columns: x:int:1 y:float:null:2
  ├── scan
  │    └── columns: a.x:int:1 a.y:float:null:2
  └── gt [type=bool]
@@ -28,7 +28,7 @@ build
 SELECT * FROM t.a WHERE (x > 10 AND (x < 20 AND x != 13))
 ----
 select
- ├── columns: a.x:int:1 a.y:float:null:2
+ ├── columns: x:int:1 y:float:null:2
  ├── scan
  │    └── columns: a.x:int:1 a.y:float:null:2
  └── and [type=bool]
@@ -47,7 +47,7 @@ build
 SELECT * FROM t.a WHERE x IN (1, 2, 3)
 ----
 select
- ├── columns: a.x:int:1 a.y:float:null:2
+ ├── columns: x:int:1 y:float:null:2
  ├── scan
  │    └── columns: a.x:int:1 a.y:float:null:2
  └── in [type=bool]
@@ -61,7 +61,7 @@ build
 SELECT * FROM t.a AS A(X, Y)
 ----
 scan
- └── columns: a.x:int:1 a.y:float:null:2
+ └── columns: x:int:1 y:float:null:2
 
 build
 SELECT @1, @2 FROM t.a

--- a/pkg/sql/opt/xform/expr.og.go
+++ b/pkg/sql/opt/xform/expr.og.go
@@ -411,11 +411,6 @@ var childCountLookup = [...]childCountLookupFunc{
 	func(ev ExprView) int {
 		return 1
 	},
-
-	// PresentOp
-	func(ev ExprView) int {
-		return 1
-	},
 }
 
 type childGroupLookupFunc func(ev ExprView, n int) opt.GroupID
@@ -1439,15 +1434,6 @@ var childGroupLookup = [...]childGroupLookupFunc{
 
 		panic("child index out of range")
 	},
-
-	// PresentOp
-	func(ev ExprView, n int) opt.GroupID {
-		if n == 0 {
-			return ev.loc.group
-		}
-
-		panic("child index out of range")
-	},
 }
 
 type privateLookupFunc func(ev ExprView) opt.PrivateID
@@ -1858,11 +1844,6 @@ var privateLookup = [...]privateLookupFunc{
 	func(ev ExprView) opt.PrivateID {
 		return 0
 	},
-
-	// PresentOp
-	func(ev ExprView) opt.PrivateID {
-		return 0
-	},
 }
 
 var isScalarLookup = [...]bool{
@@ -1946,7 +1927,6 @@ var isScalarLookup = [...]bool{
 	false, // IntersectOp
 	false, // ExceptOp
 	false, // SortOp
-	false, // PresentOp
 }
 
 var isConstValueLookup = [...]bool{
@@ -2030,7 +2010,6 @@ var isConstValueLookup = [...]bool{
 	false, // IntersectOp
 	false, // ExceptOp
 	false, // SortOp
-	false, // PresentOp
 }
 
 var isBooleanLookup = [...]bool{
@@ -2114,7 +2093,6 @@ var isBooleanLookup = [...]bool{
 	false, // IntersectOp
 	false, // ExceptOp
 	false, // SortOp
-	false, // PresentOp
 }
 
 var isComparisonLookup = [...]bool{
@@ -2198,7 +2176,6 @@ var isComparisonLookup = [...]bool{
 	false, // IntersectOp
 	false, // ExceptOp
 	false, // SortOp
-	false, // PresentOp
 }
 
 var isBinaryLookup = [...]bool{
@@ -2282,7 +2259,6 @@ var isBinaryLookup = [...]bool{
 	false, // IntersectOp
 	false, // ExceptOp
 	false, // SortOp
-	false, // PresentOp
 }
 
 var isUnaryLookup = [...]bool{
@@ -2366,7 +2342,6 @@ var isUnaryLookup = [...]bool{
 	false, // IntersectOp
 	false, // ExceptOp
 	false, // SortOp
-	false, // PresentOp
 }
 
 var isRelationalLookup = [...]bool{
@@ -2450,7 +2425,6 @@ var isRelationalLookup = [...]bool{
 	true,  // IntersectOp
 	true,  // ExceptOp
 	false, // SortOp
-	false, // PresentOp
 }
 
 var isJoinLookup = [...]bool{
@@ -2534,7 +2508,6 @@ var isJoinLookup = [...]bool{
 	false, // IntersectOp
 	false, // ExceptOp
 	false, // SortOp
-	false, // PresentOp
 }
 
 var isJoinApplyLookup = [...]bool{
@@ -2618,7 +2591,6 @@ var isJoinApplyLookup = [...]bool{
 	false, // IntersectOp
 	false, // ExceptOp
 	false, // SortOp
-	false, // PresentOp
 }
 
 var isEnforcerLookup = [...]bool{
@@ -2702,7 +2674,6 @@ var isEnforcerLookup = [...]bool{
 	false, // IntersectOp
 	false, // ExceptOp
 	true,  // SortOp
-	true,  // PresentOp
 }
 
 func (ev ExprView) IsScalar() bool {

--- a/pkg/sql/opt/xform/factory.og.go
+++ b/pkg/sql/opt/xform/factory.og.go
@@ -1289,6 +1289,16 @@ func (_f *factory) ConstructProject(
 		return _f.mem.memoizeNormExpr((*memoExpr)(&_projectExpr))
 	}
 
+	// [EliminateProject]
+	{
+		if _f.hasSameProjectionCols(input, projections) {
+			_f.reportOptimization()
+			_group = input
+			_f.mem.addAltFingerprint(_projectExpr.fingerprint(), _group)
+			return _group
+		}
+	}
+
 	return _f.onConstruct(_f.mem.memoizeNormExpr((*memoExpr)(&_projectExpr)))
 }
 

--- a/pkg/sql/opt/xform/memo_group.go
+++ b/pkg/sql/opt/xform/memo_group.go
@@ -64,16 +64,16 @@ func (g *memoGroup) memoGroupString(mem *memo) string {
 		}
 
 		// Wrap the memo expr in ExprView to make it easy to get children.
-		e := ExprView{
+		ev := ExprView{
 			mem:      mem,
 			loc:      memoLoc{group: g.id, expr: exprID(i)},
 			op:       mexpr.op,
-			required: opt.MinPhysPropsID,
+			required: opt.NormPhysPropsID,
 		}
 
-		fmt.Fprintf(&buf, "[%s", e.Operator())
+		fmt.Fprintf(&buf, "[%s", ev.Operator())
 
-		private := e.Private()
+		private := ev.Private()
 		if private != nil {
 			switch t := private.(type) {
 			case nil:
@@ -88,10 +88,10 @@ func (g *memoGroup) memoGroupString(mem *memo) string {
 			}
 		}
 
-		if e.ChildCount() > 0 {
+		if ev.ChildCount() > 0 {
 			fmt.Fprintf(&buf, " [")
-			for i := 0; i < e.ChildCount(); i++ {
-				child := e.ChildGroup(i)
+			for i := 0; i < ev.ChildCount(); i++ {
+				child := ev.ChildGroup(i)
 				if i > 0 {
 					buf.WriteString(" ")
 				}

--- a/pkg/sql/opt/xform/optimizer.go
+++ b/pkg/sql/opt/xform/optimizer.go
@@ -78,8 +78,7 @@ func (o *Optimizer) Factory() opt.Factory {
 // of the qualifying lowest cost expressions may be selected by the optimizer.
 // TODO(andyk): For now, the input tree becomes the output tree, with no
 // transformations applied to it.
-func (o *Optimizer) Optimize(root opt.GroupID, required *opt.PhysicalProps) ExprView {
-	// TODO(andyk): Need to intern the physical props once there are actually
-	// fields in the physical props.
-	return makeExprView(o.mem, root, opt.MinPhysPropsID)
+func (o *Optimizer) Optimize(root opt.GroupID, requiredProps *opt.PhysicalProps) ExprView {
+	required := o.mem.internPhysicalProps(requiredProps)
+	return makeExprView(o.mem, root, required)
 }

--- a/pkg/sql/opt/xform/rules/project.opt
+++ b/pkg/sql/opt/xform/rules/project.opt
@@ -1,0 +1,14 @@
+# =============================================================================
+# project.opt contains patterns which normalize the Project operator.
+# =============================================================================
+
+
+# EliminateProject discards a Project operator which is not adding or removing
+# columns, but instead is just reordering existing columns.
+[EliminateProject, Normalize]
+(Project
+    $input:*
+    $projections:* & (HasSameProjectionCols $input $projections)
+)
+=>
+$input

--- a/pkg/sql/opt/xform/testdata/logprops/groupby
+++ b/pkg/sql/opt/xform/testdata/logprops/groupby
@@ -12,10 +12,10 @@ build
 SELECT a.y, SUM(a.z), a.x, False FROM a GROUP BY a.x, a.y
 ----
 project
- ├── columns: a.y:int:null:2 column4:float:null:4 a.x:int:1 column5:bool:null:5
+ ├── columns: y:int:null:2 column4:float:null:4 x:int:1 column5:bool:null:5
  ├── group-by
+ │    ├── columns: a.x:int:1 a.y:int:null:2 column4:float:null:4
  │    ├── grouping columns: a.x:int:1 a.y:int:null:2
- │    ├── aggregation columns: column4:float:null:4
  │    ├── scan
  │    │    └── columns: a.x:int:1 a.y:int:null:2 a.z:float:3
  │    └── aggregations

--- a/pkg/sql/opt/xform/testdata/logprops/join
+++ b/pkg/sql/opt/xform/testdata/logprops/join
@@ -21,7 +21,7 @@ build
 SELECT *, rowid FROM a INNER JOIN b ON a.x=b.x
 ----
 inner-join
- ├── columns: a.x:int:1 a.y:int:null:2 b.x:int:null:3 b.z:int:4 b.rowid:int:5
+ ├── columns: x:int:1 y:int:null:2 x:int:null:3 z:int:4 rowid:int:5
  ├── scan
  │    └── columns: a.x:int:1 a.y:int:null:2
  ├── scan
@@ -34,7 +34,7 @@ build
 SELECT *, rowid FROM a LEFT JOIN b ON a.x=b.x
 ----
 left-join
- ├── columns: a.x:int:1 a.y:int:null:2 b.x:int:null:3 b.z:int:null:4 b.rowid:int:null:5
+ ├── columns: x:int:1 y:int:null:2 x:int:null:3 z:int:null:4 rowid:int:null:5
  ├── scan
  │    └── columns: a.x:int:1 a.y:int:null:2
  ├── scan
@@ -47,7 +47,7 @@ build
 SELECT *, rowid FROM a RIGHT JOIN b ON a.x=b.x
 ----
 right-join
- ├── columns: a.x:int:null:1 a.y:int:null:2 b.x:int:null:3 b.z:int:4 b.rowid:int:5
+ ├── columns: x:int:null:1 y:int:null:2 x:int:null:3 z:int:4 rowid:int:5
  ├── scan
  │    └── columns: a.x:int:1 a.y:int:null:2
  ├── scan
@@ -60,7 +60,7 @@ build
 SELECT *, rowid FROM a FULL JOIN b ON a.x=b.x
 ----
 full-join
- ├── columns: a.x:int:null:1 a.y:int:null:2 b.x:int:null:3 b.z:int:null:4 b.rowid:int:null:5
+ ├── columns: x:int:null:1 y:int:null:2 x:int:null:3 z:int:null:4 rowid:int:null:5
  ├── scan
  │    └── columns: a.x:int:1 a.y:int:null:2
  ├── scan

--- a/pkg/sql/opt/xform/testdata/logprops/project
+++ b/pkg/sql/opt/xform/testdata/logprops/project
@@ -11,7 +11,7 @@ build
 SELECT a.y, a.x+1, 1, a.x FROM a
 ----
 project
- ├── columns: a.y:int:null:2 column3:int:null:3 column4:int:null:4 a.x:int:1
+ ├── columns: y:int:null:2 column3:int:null:3 column4:int:null:4 x:int:1
  ├── scan
  │    └── columns: a.x:int:1 a.y:int:null:2
  └── projections

--- a/pkg/sql/opt/xform/testdata/logprops/scan
+++ b/pkg/sql/opt/xform/testdata/logprops/scan
@@ -21,13 +21,13 @@ build
 SELECT * FROM a
 ----
 scan
- └── columns: a.x:int:1 a.y:int:null:2
+ └── columns: x:int:1 y:int:null:2
 
 build
 SELECT * FROM b
 ----
 project
- ├── columns: b.x:int:null:1 b.z:int:2
+ ├── columns: x:int:null:1 z:int:2
  ├── scan
  │    └── columns: b.x:int:null:1 b.z:int:2 b.rowid:int:3
  └── projections

--- a/pkg/sql/opt/xform/testdata/logprops/select
+++ b/pkg/sql/opt/xform/testdata/logprops/select
@@ -21,7 +21,7 @@ build
 SELECT * FROM a WHERE x=1
 ----
 select
- ├── columns: a.x:int:1 a.y:int:null:2
+ ├── columns: x:int:1 y:int:null:2
  ├── scan
  │    └── columns: a.x:int:1 a.y:int:null:2
  └── eq [type=bool]
@@ -32,7 +32,7 @@ build
 SELECT * FROM a,b WHERE a.x=b.x
 ----
 project
- ├── columns: a.x:int:1 a.y:int:null:2 b.x:int:null:3 b.z:int:4
+ ├── columns: x:int:1 y:int:null:2 x:int:null:3 z:int:4
  ├── select
  │    ├── columns: a.x:int:1 a.y:int:null:2 b.x:int:null:3 b.z:int:4 b.rowid:int:5
  │    ├── inner-join

--- a/pkg/sql/opt/xform/testdata/rules/bool
+++ b/pkg/sql/opt/xform/testdata/rules/bool
@@ -10,62 +10,56 @@ TABLE a
  └── INDEX primary
       └── k int not null
 
-#
+# --------------------------------------------------
 # EliminateAnd
-#
+# --------------------------------------------------
 opt
 SELECT * FROM a WHERE k=1 AND False AND f=3.5
 ----
 select
- ├── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5
+ ├── columns: k:int:1 i:int:null:2 f:float:null:3 s:string:null:4 j:jsonb:null:5
  ├── scan
  │    └── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5
  └── false [type=bool]
 
-#
-# EliminateAnd
-#
 opt
 SELECT * FROM a WHERE False AND s='foo'
 ----
 select
- ├── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5
+ ├── columns: k:int:1 i:int:null:2 f:float:null:3 s:string:null:4 j:jsonb:null:5
  ├── scan
  │    └── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5
  └── false [type=bool]
 
-#
+# --------------------------------------------------
 # EliminateOr
-#
+# --------------------------------------------------
 opt
 SELECT * FROM a WHERE k=1 OR (i=2 OR True)
 ----
 select
- ├── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5
+ ├── columns: k:int:1 i:int:null:2 f:float:null:3 s:string:null:4 j:jsonb:null:5
  ├── scan
  │    └── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5
  └── true [type=bool]
 
-#
-# EliminateOr
-#
 opt
 SELECT * FROM a WHERE k=1 OR True OR f=3.5
 ----
 select
- ├── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5
+ ├── columns: k:int:1 i:int:null:2 f:float:null:3 s:string:null:4 j:jsonb:null:5
  ├── scan
  │    └── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5
  └── true [type=bool]
 
-#
+# --------------------------------------------------
 # FlattenAnd
-#
+# --------------------------------------------------
 opt
 SELECT * FROM a WHERE k=1 AND i=2 AND f=3.5
 ----
 select
- ├── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5
+ ├── columns: k:int:1 i:int:null:2 f:float:null:3 s:string:null:4 j:jsonb:null:5
  ├── scan
  │    └── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5
  └── and [type=bool]
@@ -79,14 +73,14 @@ select
            ├── variable: a.f [type=float]
            └── const: 3.5 [type=float]
 
-#
+# --------------------------------------------------
 # FlattenOr
-#
+# --------------------------------------------------
 opt
 SELECT * FROM a WHERE k=1 OR i=2 OR f=3.5
 ----
 select
- ├── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5
+ ├── columns: k:int:1 i:int:null:2 f:float:null:3 s:string:null:4 j:jsonb:null:5
  ├── scan
  │    └── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5
  └── or [type=bool]
@@ -100,16 +94,16 @@ select
            ├── variable: a.f [type=float]
            └── const: 3.5 [type=float]
 
-#
+# --------------------------------------------------
 # FlattenAnd + FlattenOr
 #   Combine and/or ops.
 #   Use parentheses to make and/or tree right-heavy instead of left-heavy.
-#
+# --------------------------------------------------
 opt
 SELECT * FROM a WHERE (k=1 OR (i=2 OR f=3.5)) AND (s='foo' AND s<>'bar')
 ----
 select
- ├── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5
+ ├── columns: k:int:1 i:int:null:2 f:float:null:3 s:string:null:4 j:jsonb:null:5
  ├── scan
  │    └── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5
  └── and [type=bool]
@@ -130,14 +124,14 @@ select
            ├── variable: a.s [type=string]
            └── const: 'bar' [type=string]
 
-#
+# --------------------------------------------------
 # SimplifyAnd
-#
+# --------------------------------------------------
 opt
 SELECT * FROM a WHERE k=1 AND i=2 AND true
 ----
 select
- ├── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5
+ ├── columns: k:int:1 i:int:null:2 f:float:null:3 s:string:null:4 j:jsonb:null:5
  ├── scan
  │    └── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5
  └── and [type=bool]
@@ -152,19 +146,19 @@ opt
 SELECT * FROM a WHERE true AND true
 ----
 select
- ├── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5
+ ├── columns: k:int:1 i:int:null:2 f:float:null:3 s:string:null:4 j:jsonb:null:5
  ├── scan
  │    └── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5
  └── true [type=bool]
 
-#
+# --------------------------------------------------
 # SimplifyOr
-#
+# --------------------------------------------------
 opt
 SELECT * FROM a WHERE k=1 OR i=2 OR false
 ----
 select
- ├── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5
+ ├── columns: k:int:1 i:int:null:2 f:float:null:3 s:string:null:4 j:jsonb:null:5
  ├── scan
  │    └── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5
  └── or [type=bool]
@@ -179,19 +173,19 @@ opt
 SELECT * FROM a WHERE false OR false
 ----
 select
- ├── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5
+ ├── columns: k:int:1 i:int:null:2 f:float:null:3 s:string:null:4 j:jsonb:null:5
  ├── scan
  │    └── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5
  └── false [type=bool]
 
-#
+# --------------------------------------------------
 # SimplifyAnd + SimplifyOr
-#
+# --------------------------------------------------
 opt
 SELECT * FROM a WHERE (k=1 OR false) AND (false OR k=2 OR false) AND true
 ----
 select
- ├── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5
+ ├── columns: k:int:1 i:int:null:2 f:float:null:3 s:string:null:4 j:jsonb:null:5
  ├── scan
  │    └── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5
  └── and [type=bool]
@@ -202,29 +196,30 @@ select
            ├── variable: a.k [type=int]
            └── const: 2 [type=int]
 
-#
-# SimplifyOr + ElideOr
-#
+# --------------------------------------------------
+# SimplifyOr + EliminateOr
+# --------------------------------------------------
 opt
 SELECT * FROM a WHERE k=1 OR false
 ----
 select
- ├── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5
+ ├── columns: k:int:1 i:int:null:2 f:float:null:3 s:string:null:4 j:jsonb:null:5
  ├── scan
  │    └── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5
  └── eq [type=bool]
       ├── variable: a.k [type=int]
       └── const: 1 [type=int]
 
-#
+# --------------------------------------------------
 # NegateComparison
-#   Equality and inequality comparisons.
-#
+# --------------------------------------------------
+
+# Equality and inequality comparisons.
 opt
 SELECT * FROM a WHERE NOT(i=1) AND NOT(i<>1) AND NOT(i>1) AND NOT(i>=1) AND NOT(i<1) AND NOT(i<=1)
 ----
 select
- ├── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5
+ ├── columns: k:int:1 i:int:null:2 f:float:null:3 s:string:null:4 j:jsonb:null:5
  ├── scan
  │    └── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5
  └── and [type=bool]
@@ -247,17 +242,14 @@ select
            ├── variable: a.i [type=int]
            └── const: 1 [type=int]
 
-#
-# NegateComparison
-#   IN and IS comparisons.
-#
+# IN and IS comparisons.
 opt
 SELECT *
 FROM a
 WHERE NOT(i IN (1,2)) AND NOT(i NOT IN (3,4)) AND NOT(i IS NULL) AND NOT(i IS NOT NULL)
 ----
 select
- ├── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5
+ ├── columns: k:int:1 i:int:null:2 f:float:null:3 s:string:null:4 j:jsonb:null:5
  ├── scan
  │    └── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5
  └── and [type=bool]
@@ -278,17 +270,14 @@ select
            ├── variable: a.i [type=int]
            └── const: NULL [type=NULL]
 
-#
-# NegateComparison
-#   Like comparisons.
-#
+# Like comparisons.
 opt
 SELECT *
 FROM a
 WHERE NOT(s LIKE 'foo') AND NOT(s NOT LIKE 'foo') AND NOT(s ILIKE 'foo') AND NOT(s NOT ILIKE 'foo')
 ----
 select
- ├── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5
+ ├── columns: k:int:1 i:int:null:2 f:float:null:3 s:string:null:4 j:jsonb:null:5
  ├── scan
  │    └── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5
  └── and [type=bool]
@@ -305,15 +294,12 @@ select
            ├── variable: a.s [type=string]
            └── const: 'foo' [type=string]
 
-#
-# NegateComparison
-#   SimilarTo comparisons.
-#
+# SimilarTo comparisons.
 opt
 SELECT * FROM a WHERE NOT(s SIMILAR TO 'foo') AND NOT(s NOT SIMILAR TO 'foo')
 ----
 select
- ├── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5
+ ├── columns: k:int:1 i:int:null:2 f:float:null:3 s:string:null:4 j:jsonb:null:5
  ├── scan
  │    └── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5
  └── and [type=bool]
@@ -324,15 +310,12 @@ select
            ├── variable: a.s [type=string]
            └── const: 'foo' [type=string]
 
-#
-# NegateComparison
-#   RegMatch comparisons.
-#
+# RegMatch comparisons.
 opt
 SELECT * FROM a WHERE NOT(s ~ 'foo') AND NOT(s !~ 'foo') AND NOT(s ~* 'foo') AND NOT (s !~* 'foo')
 ----
 select
- ├── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5
+ ├── columns: k:int:1 i:int:null:2 f:float:null:3 s:string:null:4 j:jsonb:null:5
  ├── scan
  │    └── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5
  └── and [type=bool]
@@ -349,15 +332,12 @@ select
            ├── variable: a.s [type=string]
            └── const: 'foo' [type=string]
 
-#
-# NegateComparison
-#   Contains comparison (should not be negated).
-#
+# Contains comparison (should not be negated).
 opt
 SELECT * FROM a WHERE NOT('[1, 2]' @> j) AND NOT(j <@ '[3, 4]')
 ----
 select
- ├── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5
+ ├── columns: k:int:1 i:int:null:2 f:float:null:3 s:string:null:4 j:jsonb:null:5
  ├── scan
  │    └── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5
  └── and [type=bool]
@@ -370,14 +350,14 @@ select
                 ├── const: '[3, 4]' [type=jsonb]
                 └── variable: a.j [type=jsonb]
 
-#
+# --------------------------------------------------
 # EliminateNot
-#
+# --------------------------------------------------
 opt
 SELECT * FROM a WHERE NOT(NOT('[1, 2]' @> j))
 ----
 select
- ├── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5
+ ├── columns: k:int:1 i:int:null:2 f:float:null:3 s:string:null:4 j:jsonb:null:5
  ├── scan
  │    └── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5
  └── contains [type=bool]

--- a/pkg/sql/opt/xform/testdata/rules/comp
+++ b/pkg/sql/opt/xform/testdata/rules/comp
@@ -10,14 +10,14 @@ TABLE a
  └── INDEX primary
       └── k int not null
 
-#
+# --------------------------------------------------
 # NormalizeVar
-#
+# --------------------------------------------------
 opt
 SELECT * FROM a WHERE 1=k AND 2<>i
 ----
 select
- ├── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5
+ ├── columns: k:int:1 i:int:null:2 f:float:null:3 s:string:null:4 j:jsonb:null:5
  ├── scan
  │    └── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5
  └── and [type=bool]
@@ -28,14 +28,14 @@ select
            ├── variable: a.i [type=int]
            └── const: 2 [type=int]
 
-#
+# --------------------------------------------------
 # NormalizeTupleEquality
-#
+# --------------------------------------------------
 opt
 SELECT * FROM a WHERE (i, f, s) = (1, 3.5, 'foo')
 ----
 select
- ├── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5
+ ├── columns: k:int:1 i:int:null:2 f:float:null:3 s:string:null:4 j:jsonb:null:5
  ├── scan
  │    └── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5
  └── and [type=bool]
@@ -49,15 +49,16 @@ select
            ├── variable: a.s [type=string]
            └── const: 'foo' [type=string]
 
-#
+# --------------------------------------------------
 # NormalizeTupleEquality, FlattenAnd
-#   Nested tuples.
-#
+# --------------------------------------------------
+
+# Nested tuples.
 opt
 SELECT * FROM a WHERE (1, (2, 'foo')) = (k, (i, s))
 ----
 select
- ├── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5
+ ├── columns: k:int:1 i:int:null:2 f:float:null:3 s:string:null:4 j:jsonb:null:5
  ├── scan
  │    └── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5
  └── and [type=bool]

--- a/pkg/sql/opt/xform/testdata/rules/project
+++ b/pkg/sql/opt/xform/testdata/rules/project
@@ -1,0 +1,67 @@
+exec-ddl
+CREATE TABLE t.a (x INT PRIMARY KEY, y FLOAT)
+----
+TABLE a
+ ├── x int not null
+ ├── y float
+ └── INDEX primary
+      └── x int not null
+
+exec-ddl
+CREATE TABLE t.b (x INT, y FLOAT)
+----
+TABLE b
+ ├── x int
+ ├── y float
+ ├── rowid int not null (hidden)
+ └── INDEX primary
+      └── rowid int not null (hidden)
+
+# --------------------------------------------------
+# EliminateProject
+# --------------------------------------------------
+
+# Same order, same names.
+opt
+SELECT x, y FROM t.a
+----
+scan
+ └── columns: x:int:1 y:float:null:2
+
+# Different order, aliased names.
+opt
+SELECT a.y AS aliasy, a.x FROM t.a
+----
+scan
+ └── columns: aliasy:float:null:2 x:int:1
+
+# Reordered, duplicate, aliased columns.
+opt
+SELECT a.y AS alias1, a.x, a.y AS alias1, a.x FROM t.a
+----
+scan
+ └── columns: alias1:float:null:2 x:int:1 alias1:float:null:2 x:int:1
+
+# Added column (projection should not be eliminated).
+opt
+SELECT x, y, 1 FROM t.a
+----
+project
+ ├── columns: x:int:1 y:float:null:2 column3:int:null:3
+ ├── scan
+ │    └── columns: a.x:int:1 a.y:float:null:2
+ └── projections
+      ├── variable: a.x [type=int]
+      ├── variable: a.y [type=float]
+      └── const: 1 [type=int]
+
+# Removed column (projection should not be eliminated).
+opt
+SELECT x FROM t.a
+----
+project
+ ├── columns: x:int:1
+ ├── scan
+ │    └── columns: a.x:int:1 a.y:float:null:2
+ └── projections
+      └── variable: a.x [type=int]

--- a/pkg/sql/opt/xform/testdata/typing
+++ b/pkg/sql/opt/xform/testdata/typing
@@ -21,7 +21,7 @@ build
 SELECT a.x FROM a
 ----
 project
- ├── columns: a.x:int:1
+ ├── columns: x:int:1
  ├── scan
  │    └── columns: a.x:int:1 a.y:int:null:2
  └── projections
@@ -45,7 +45,7 @@ build
 SELECT * FROM a WHERE x = $1
 ----
 select
- ├── columns: a.x:int:1 a.y:int:null:2
+ ├── columns: x:int:1 y:int:null:2
  ├── scan
  │    └── columns: a.x:int:1 a.y:int:null:2
  └── eq [type=bool]
@@ -57,7 +57,7 @@ build
 SELECT (a.x, 1.5), a.y FROM a
 ----
 project
- ├── columns: column3:tuple{int, decimal}:null:3 a.y:int:null:2
+ ├── columns: column3:tuple{int, decimal}:null:3 y:int:null:2
  ├── scan
  │    └── columns: a.x:int:1 a.y:int:null:2
  └── projections
@@ -71,7 +71,7 @@ build
 SELECT * FROM a WHERE a.x = 1 AND NOT (a.y = 2 OR a.y = 3.5)
 ----
 select
- ├── columns: a.x:int:1 a.y:int:null:2
+ ├── columns: x:int:1 y:int:null:2
  ├── scan
  │    └── columns: a.x:int:1 a.y:int:null:2
  └── and [type=bool]
@@ -92,7 +92,7 @@ build
 SELECT * FROM a WHERE a.x = 1 AND a.x <> 2
 ----
 select
- ├── columns: a.x:int:1 a.y:int:null:2
+ ├── columns: x:int:1 y:int:null:2
  ├── scan
  │    └── columns: a.x:int:1 a.y:int:null:2
  └── and [type=bool]
@@ -108,7 +108,7 @@ build
 SELECT * FROM a WHERE a.x >= 1 AND a.x <= 10 AND a.y > 1 AND a.y < 10
 ----
 select
- ├── columns: a.x:int:1 a.y:int:null:2
+ ├── columns: x:int:1 y:int:null:2
  ├── scan
  │    └── columns: a.x:int:1 a.y:int:null:2
  └── and [type=bool]
@@ -132,7 +132,7 @@ build
 SELECT * FROM a WHERE a.x IN (1, 2) AND a.y NOT IN (3, 4)
 ----
 select
- ├── columns: a.x:int:1 a.y:int:null:2
+ ├── columns: x:int:1 y:int:null:2
  ├── scan
  │    └── columns: a.x:int:1 a.y:int:null:2
  └── and [type=bool]
@@ -152,7 +152,7 @@ build
 SELECT * FROM b WHERE b.x LIKE '%foo%' AND b.x NOT LIKE '%bar%'
 ----
 select
- ├── columns: b.x:string:1 b.z:decimal:2
+ ├── columns: x:string:1 z:decimal:2
  ├── scan
  │    └── columns: b.x:string:1 b.z:decimal:2
  └── and [type=bool]
@@ -168,7 +168,7 @@ build
 SELECT * FROM b WHERE b.x ILIKE '%foo%' AND b.x NOT ILIKE '%bar%'
 ----
 select
- ├── columns: b.x:string:1 b.z:decimal:2
+ ├── columns: x:string:1 z:decimal:2
  ├── scan
  │    └── columns: b.x:string:1 b.z:decimal:2
  └── and [type=bool]
@@ -184,7 +184,7 @@ build
 SELECT * FROM b WHERE b.x ~ 'foo' AND b.x !~ 'bar' AND b.x ~* 'foo' AND b.x !~* 'bar'
 ----
 select
- ├── columns: b.x:string:1 b.z:decimal:2
+ ├── columns: x:string:1 z:decimal:2
  ├── scan
  │    └── columns: b.x:string:1 b.z:decimal:2
  └── and [type=bool]
@@ -208,7 +208,7 @@ build
 SELECT * FROM a WHERE a.x IS DISTINCT FROM a.y AND a.x IS NULL
 ----
 select
- ├── columns: a.x:int:1 a.y:int:null:2
+ ├── columns: x:int:1 y:int:null:2
  ├── scan
  │    └── columns: a.x:int:1 a.y:int:null:2
  └── and [type=bool]


### PR DESCRIPTION
This PR adds support for Presentation, the first physical property.
Presentation specifies the naming, membership (including duplicates), and
order of result columns that are required of or provided by an operator.
The Presentation property can be provided any relational operator, and
will only be required of the root of an expression tree. For this reason,
Presentation is a fairly simple physical property.

Future physical props will require more support from the optimizer in
order to work. In particular, the optimizer will soon get support for
maintaining the lowest cost expression for a particular set of physical
props. Until then, the optimizer produces a hardcoded ExprView that
traverses the normalized expression tree rather than the lowest cost
tree.

In order to test the new property, this PR also contains a new optimizer
rule which eliminates a Project operator if it projects the same set of
columns as its input. This eliminates many top-level Project operators
and ensures that the Presentation property still produces the correctly
labeled list of output columns.

Release note: None