### PR TITLE
sql: avoid the word "pattern" in expansion error strings

### DIFF
--- a/pkg/ccl/backupccl/targets_test.go
+++ b/pkg/ccl/backupccl/targets_test.go
@@ -59,9 +59,9 @@ func TestDescriptorsMatchingTargets(t *testing.T) {
 		{"system", "TABLE foo, foo", []string{"system", "foo"}, nil, ``},
 		{"data", "TABLE foo", nil, nil, `table "foo" does not exist`},
 
-		{"", "TABLE *", nil, nil, `pattern "\*" did not match any valid database or schema`},
-		{"", "TABLE *, system.public.foo", nil, nil, `pattern "\*" did not match any valid database or schema`},
-		{"noexist", "TABLE *", nil, nil, `pattern "\*" did not match any valid database or schema`},
+		{"", "TABLE *", nil, nil, `"\*" does not match any valid database or schema`},
+		{"", "TABLE *, system.public.foo", nil, nil, `"\*" does not match any valid database or schema`},
+		{"noexist", "TABLE *", nil, nil, `"\*" does not match any valid database or schema`},
 		{"system", "TABLE *", []string{"system", "foo", "bar"}, nil, ``},
 		{"data", "TABLE *", []string{"data", "baz"}, nil, ``},
 		{"empty", "TABLE *", []string{"empty"}, nil, ``},
@@ -80,7 +80,7 @@ func TestDescriptorsMatchingTargets(t *testing.T) {
 		{"system", "TABLE system.public.foo, bar", []string{"system", "foo", "bar"}, nil, ``},
 		{"system", "TABLE system.foo, bar", []string{"system", "foo", "bar"}, nil, ``},
 
-		{"", "TABLE noexist.*", nil, nil, `pattern "noexist\.\*" did not match any valid database or schema`},
+		{"", "TABLE noexist.*", nil, nil, `"noexist\.\*" does not match any valid database or schema`},
 		{"", "TABLE empty.*", []string{"empty"}, nil, ``},
 		{"", "TABLE system.*", []string{"system", "foo", "bar"}, nil, ``},
 		{"", "TABLE system.public.*", []string{"system", "foo", "bar"}, nil, ``},

--- a/pkg/sql/logictest/testdata/logic_test/case_sensitive_names
+++ b/pkg/sql/logictest/testdata/logic_test/case_sensitive_names
@@ -8,13 +8,13 @@ CREATE DATABASE D
 statement ok
 SHOW TABLES FROM d
 
-statement error pattern "D" did not match any valid database or schema
+statement error "D" does not match any valid database or schema
 SHOW TABLES FROM "D"
 
 statement ok
 CREATE DATABASE "E"
 
-statement error pattern "e" did not match any valid database or schema
+statement error "e" does not match any valid database or schema
 SHOW TABLES FROM e
 
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/grant_table
+++ b/pkg/sql/logictest/testdata/logic_test/grant_table
@@ -604,7 +604,7 @@ SET DATABASE = ""
 statement error pq: syntax error at or near "@"
 GRANT ALL ON a.t@xyz TO readwrite
 
-statement error pq: pattern "\*" did not match any valid database or schema
+statement error pq: "\*" does not match any valid database or schema
 GRANT ALL ON * TO readwrite
 
 statement error pgcode 42P01 relation "a.tt" does not exist

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -2870,6 +2870,8 @@ show_tables_stmt:
 | SHOW TABLES FROM name
   {
     $$.val = &tree.ShowTables{TableNamePrefix:tree.TableNamePrefix{
+        // Note: the schema name may be interpreted as database name,
+	// see name_resolution.go.
         SchemaName: tree.Name($4),
         ExplicitSchema: true,
     }}

--- a/pkg/sql/sqlbase/errors.go
+++ b/pkg/sql/sqlbase/errors.go
@@ -146,7 +146,7 @@ func NewUndefinedDatabaseError(name string) error {
 func NewInvalidWildcardError(name string) error {
 	return pgerror.NewErrorf(
 		pgerror.CodeInvalidCatalogNameError,
-		"pattern %q did not match any valid database or schema", name)
+		"%q does not match any valid database or schema", name)
 }
 
 // NewUndefinedRelationError creates an error that represents a missing database table or view.


### PR DESCRIPTION
Fixes #23039.
First commit from #22994.

Requested/suggested by @rytaft: "pattern" is a bit of a technical word
and is not necessary to convey the right meaning in the error message.