### PR TITLE
sql: clarify why it's not possible to write to virtual schemas

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/crdb_internal
+++ b/pkg/sql/logictest/testdata/logic_test/crdb_internal
@@ -3,7 +3,7 @@
 query error database "crdb_internal" does not exist
 ALTER DATABASE crdb_internal RENAME TO not_crdb_internal
 
-statement error unsupported schema specification
+statement error schema cannot be modified: "crdb_internal"
 CREATE TABLE crdb_internal.t (x INT)
 
 query error database "crdb_internal" does not exist

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -5,7 +5,7 @@
 query error database "information_schema" does not exist
 ALTER DATABASE information_schema RENAME TO not_information_schema
 
-statement error unsupported schema specification
+statement error schema cannot be modified: "information_schema"
 CREATE TABLE information_schema.t (x INT)
 
 query error database "information_schema" does not exist

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -5,7 +5,7 @@
 query error database "pg_catalog" does not exist
 ALTER DATABASE pg_catalog RENAME TO not_pg_catalog
 
-statement error unsupported schema specification: "pg_catalog.t"
+statement error schema cannot be modified: "pg_catalog"
 CREATE TABLE pg_catalog.t (x INT)
 
 query error database "pg_catalog" does not exist

--- a/pkg/sql/resolver.go
+++ b/pkg/sql/resolver.go
@@ -155,7 +155,8 @@ func ResolveTargetObject(
 			"invalid target name: %q", tree.ErrString(tn))
 	}
 	if tn.Schema() != tree.PublicSchema {
-		return nil, sqlbase.NewUnsupportedSchemaUsageError(tree.ErrString(tn))
+		return nil, pgerror.NewErrorf(pgerror.CodeInvalidNameError,
+			"schema cannot be modified: %q", tree.ErrString(&tn.TableNamePrefix))
 	}
 	return descI.(*DatabaseDescriptor), nil
 }


### PR DESCRIPTION
Fixes #22969.

Prior to this patch, an attempt to populate one of the virtual schemas
with a DDL statement would fail with the error "unsupported schema
specification". This is not extremely clear, also incorrect on its
face, since the virtual schemas are actually supported.

This patch clarifies the error by reporting "schema cannot be
modified" more explicitly.

Suggested/requested by @rytaft.

Release note (sql change): attempts to modify virtual schemas with DDL
statements now fail with a clearer error message.