### PR TITLE
cherrypick-2.0: engine: maintain write-too-old timestamp on successive intents

### DIFF
--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -5493,7 +5493,7 @@ func evaluateBatch(
 					writeTooOldErr.GetDetail().(*roachpb.WriteTooOldError).ActualTimestamp.Forward(tErr.ActualTimestamp)
 				} else {
 					writeTooOldErr = pErr
-					// For transaction, we want to swallow the write too old error
+					// For transactions, we want to swallow the write too old error
 					// and just move the transaction timestamp forward and set the
 					// WriteTooOld flag. See below for exceptions.
 					if ba.Txn != nil {


### PR DESCRIPTION
We write an intent with an advanced timestamp when putting a value
for which a `WriteTooOldError` is generated. However, if the same
key is written again twice in the txn, the timestamp would revert
to `txn.OrigTimestamp`, leaving the intent *below* the more recently
written version. This wasn't likely to be a visible problem, because
it only shows up if doing inconsistent reads, but that's what the
`Refresh` and `RefreshRange` calls do, and they were failing to see
the newer version because the `MVCCMetadata` points to the intent.

Note that on intent resolution, the txn's commit timestamp controls,
so the old version would previously be correctly moved to the commit
timestamp. This change correctly enforces a common sense assumption
that the intent is always the newest version.

Fixes #22539

Release note: None