### PR TITLE
sql: fix `cockroach dump` for sequences

### DIFF
--- a/pkg/cli/dump_test.go
+++ b/pkg/cli/dump_test.go
@@ -914,10 +914,10 @@ func TestDumpSequence(t *testing.T) {
 
 	const create = `
 	CREATE DATABASE d;
-	CREATE SEQUENCE d.s1; -- test one sequence right at its minval
-	CREATE SEQUENCE d.s2; -- test another that's been incremented
+	CREATE SEQUENCE d.s1 INCREMENT 123; -- test one sequence right at its minval
+	CREATE SEQUENCE d.s2 INCREMENT 456; -- test another that's been incremented
 	SELECT nextval('d.s2'); -- 1
-	SELECT nextval('d.s2'); -- 2
+	SELECT nextval('d.s2'); -- 457
 `
 	if createOut, err := c.RunWithCaptureArgs([]string{"sql", "-e", create}); err != nil {
 		t.Fatal(err)
@@ -927,13 +927,13 @@ func TestDumpSequence(t *testing.T) {
 
 	// Dump the database.
 
-	const expectSQL = `CREATE SEQUENCE s1 MINVALUE 1 MAXVALUE 9223372036854775807 INCREMENT 1 START 1;
+	const expectSQL = `CREATE SEQUENCE s1 MINVALUE 1 MAXVALUE 9223372036854775807 INCREMENT 123 START 1;
 
-CREATE SEQUENCE s2 MINVALUE 1 MAXVALUE 9223372036854775807 INCREMENT 1 START 1;
+CREATE SEQUENCE s2 MINVALUE 1 MAXVALUE 9223372036854775807 INCREMENT 456 START 1;
 
 SELECT setval('s1', 1, false);
 
-SELECT setval('s2', 3, false);
+SELECT setval('s2', 913, false);
 `
 
 	dumpOut, err := c.RunWithCaptureArgs([]string{"dump", "d"})
@@ -1003,7 +1003,7 @@ SELECT setval('s2', 3, false);
 	}
 	incOutValueS2 := removeFirstLine(incOutS2)
 	const expectedOutValueS2 = `nextval
-3
+913
 `
 	if incOutValueS2 != expectedOutValueS2 {
 		t.Fatalf("expected: %s\ngot: %s", expectedOutValueS2, incOutValueS2)

--- a/pkg/cli/sql_util.go
+++ b/pkg/cli/sql_util.go
@@ -359,6 +359,19 @@ func (c *sqlConn) QueryRow(query string, args []driver.Value) ([]driver.Value, e
 	defer func() { _ = rows.Close() }()
 	vals := make([]driver.Value, len(rows.Columns()))
 	err = rows.Next(vals)
+
+	// Assert that there is just one row.
+	if err == nil {
+		nextVals := make([]driver.Value, len(rows.Columns()))
+		nextErr := rows.Next(nextVals)
+		if nextErr != io.EOF {
+			if nextErr != nil {
+				return nil, err
+			}
+			return nil, fmt.Errorf("programming error: %q: expected just 1 row of result, got more", query)
+		}
+	}
+
 	return vals, err
 }
 


### PR DESCRIPTION
Prior to this patch, `cockroach dump` would attempt to determine the
increment for a given sequence using a query to
`pg_catalog.pg_sequences`. Unfortunately this query did not constraint
the OID to the sequence considered, and so it would always retrieve
the metata for the 1st sequence defined in the cluster overall, not
the sequence being considered. This wasn't visible in tests because
the tests all used the default sequence parameters.

This patch fixes the issue by constraining the `pg_sequence` query
appropriately.

A related issue, which also prevented earlier recognition of this bug,
is that the object `sqlConn` internal to the `cli` package (that
attempts to emulate `sql.Conn` over the in-memory connection to the
test server) is not appropriately checking that queries passed to its
`QueryRow` method only return 1 row. If it did, it would have
determined earlier that there were multiple results for the query on
`pg_sequences`. This will be addressed separately.

Release note (bug fix): `cockroach dump` is now able to dump sequences
with non-default parameters.