### PR TITLE
kv: stop concerning the TxnCoordSender with abandoned txns

### DIFF
--- a/pkg/ccl/backupccl/backup.go
+++ b/pkg/ccl/backupccl/backup.go
@@ -512,7 +512,7 @@ func loadAllDescs(
 	// express that whatever this txn does should not count towards lease
 	// placement stats.
 	txn := client.NewTxn(db, 0 /* gatewayNodeID */, client.RootTxn)
-	opt := client.TxnExecOptions{AutoRetry: true, AutoCommit: true}
+	opt := client.TxnExecOptions{AutoRetry: true}
 	err := txn.Exec(ctx, opt, func(ctx context.Context, txn *client.Txn, opt *client.TxnExecOptions) error {
 		var err error
 		txn.SetFixedTimestamp(ctx, asOf)

--- a/pkg/ccl/backupccl/backup.go
+++ b/pkg/ccl/backupccl/backup.go
@@ -508,18 +508,14 @@ func loadAllDescs(
 	ctx context.Context, db *client.DB, asOf hlc.Timestamp,
 ) ([]sqlbase.Descriptor, error) {
 	var allDescs []sqlbase.Descriptor
-	// TODO(andrei): Plumb a gatewayNodeID in here and also find a way to
-	// express that whatever this txn does should not count towards lease
-	// placement stats.
-	txn := client.NewTxn(db, 0 /* gatewayNodeID */, client.RootTxn)
-	opt := client.TxnExecOptions{AutoRetry: true}
-	err := txn.Exec(ctx, opt, func(ctx context.Context, txn *client.Txn, opt *client.TxnExecOptions) error {
-		var err error
-		txn.SetFixedTimestamp(ctx, asOf)
-		allDescs, err = allSQLDescriptors(ctx, txn)
-		return err
-	})
-	if err != nil {
+	if err := db.Txn(
+		ctx,
+		func(ctx context.Context, txn *client.Txn) error {
+			var err error
+			txn.SetFixedTimestamp(ctx, asOf)
+			allDescs, err = allSQLDescriptors(ctx, txn)
+			return err
+		}); err != nil {
 		return nil, err
 	}
 	return allDescs, nil

--- a/pkg/internal/client/client_test.go
+++ b/pkg/internal/client/client_test.go
@@ -860,8 +860,9 @@ func TestReadOnlyTxnObeysDeadline(t *testing.T) {
 	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
 	defer s.Stopper().Stop(context.TODO())
 	db := createTestClient(t, s)
+	ctx := context.TODO()
 
-	if err := db.Put(context.TODO(), "k", "v"); err != nil {
+	if err := db.Put(ctx, "k", "v"); err != nil {
 		t.Fatal(err)
 	}
 
@@ -871,18 +872,15 @@ func TestReadOnlyTxnObeysDeadline(t *testing.T) {
 	if err := txn.SetIsolation(enginepb.SNAPSHOT); err != nil {
 		t.Fatal(err)
 	}
-	opts := client.TxnExecOptions{
-		AutoRetry: false,
+
+	// Set a deadline, then set a higher commit timestamp for the txn.
+	txn.UpdateDeadlineMaybe(ctx, s.Clock().Now())
+	txn.Proto().Timestamp.Forward(s.Clock().Now())
+	if _, err := txn.Get(ctx, "k"); err != nil {
+		t.Fatal(err)
 	}
-	if err := txn.Exec(
-		context.TODO(), opts,
-		func(ctx context.Context, txn *client.Txn, _ *client.TxnExecOptions) error {
-			// Set a deadline, then set a higher commit timestamp for the txn.
-			txn.UpdateDeadlineMaybe(ctx, s.Clock().Now())
-			txn.Proto().Timestamp.Forward(s.Clock().Now())
-			_, err := txn.Get(ctx, "k")
-			return err
-		}); !testutils.IsError(err, "deadline exceeded before transaction finalization") {
+	if err := txn.Commit(ctx); !testutils.IsError(
+		err, "deadline exceeded before transaction finalization") {
 		// We test for TransactionAbortedError. If this was not a read-only txn,
 		// the error returned by the server would have been different - a
 		// TransactionStatusError. This inconsistency is unfortunate.

--- a/pkg/internal/client/client_test.go
+++ b/pkg/internal/client/client_test.go
@@ -872,8 +872,7 @@ func TestReadOnlyTxnObeysDeadline(t *testing.T) {
 		t.Fatal(err)
 	}
 	opts := client.TxnExecOptions{
-		AutoRetry:  false,
-		AutoCommit: true,
+		AutoRetry: false,
 	}
 	if err := txn.Exec(
 		context.TODO(), opts,

--- a/pkg/internal/client/client_test.go
+++ b/pkg/internal/client/client_test.go
@@ -810,7 +810,7 @@ func TestReadConsistencyTypes(t *testing.T) {
 			})
 
 			clock := hlc.NewClock(hlc.UnixNano, time.Nanosecond)
-			db := client.NewDB(factory, clock)
+			db := client.NewDB(testutils.MakeAmbientCtx(), factory, clock)
 			ctx := context.TODO()
 
 			prepWithRC := func() *client.Batch {
@@ -982,7 +982,7 @@ func TestNodeIDAndObservedTimestamps(t *testing.T) {
 	clock := hlc.NewClock(hlc.UnixNano, time.Nanosecond)
 	dbCtx := client.DefaultDBContext()
 	dbCtx.NodeID = &base.NodeIDContainer{}
-	db := client.NewDBWithContext(factory, clock, dbCtx)
+	db := client.NewDBWithContext(testutils.MakeAmbientCtx(), factory, clock, dbCtx)
 	ctx := context.Background()
 
 	// Verify direct creation of Txns.
@@ -1083,5 +1083,41 @@ func TestIntentCleanupUnblocksReaders(t *testing.T) {
 		if dur > 800*time.Millisecond {
 			t.Fatalf("txn wasn't cleaned up. Get took: %s", dur)
 		}
+	}
+}
+
+// Test that a transaction can be rolled back even with a canceled context.
+// This relies on custom code in txn.rollback(), otherwise RPCs can't be sent.
+func TestCleanupWithCanceledContext(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	s, _, db := serverutils.StartServer(t, base.TestServerArgs{})
+	defer s.Stopper().Stop(context.TODO())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	key := roachpb.Key("a")
+	err := db.Txn(ctx, func(ctx context.Context, txn *client.Txn) error {
+		if err := txn.Put(ctx, key, "txn-value"); err != nil {
+			return err
+		}
+		cancel()
+		return fmt.Errorf("test err")
+	})
+	if !testutils.IsError(err, "test err") {
+		t.Fatal(err)
+	}
+	start := timeutil.Now()
+	// Do a Get using a different ctx (not the canceled one), and check that it
+	// didn't take too long - take that as proof that it was not blocked on
+	// intents. If the Get would have been blocked, it would have had to wait for
+	// the transaction abandon timeout before the Get would proceed.
+	// TODO(andrei): It'd be better to use tracing to verify what we were and
+	// weren't blocked on. Similar in TestSessionFinishRollsBackTxn.
+	if _, err := db.Get(context.TODO(), key); err != nil {
+		t.Fatal(err)
+	}
+	dur := timeutil.Since(start)
+	if dur > 500*time.Millisecond {
+		t.Fatalf("txn wasn't cleaned up. Get took: %s", dur)
 	}
 }

--- a/pkg/internal/client/db.go
+++ b/pkg/internal/client/db.go
@@ -515,8 +515,6 @@ func (db *DB) Run(ctx context.Context, b *Batch) error {
 // from recoverable internal errors, and is automatically committed
 // otherwise. The retryable function should have no side effects which could
 // cause problems in the event it must be run more than once.
-//
-// If you need more control over how the txn is executed, check out txn.Exec().
 func (db *DB) Txn(ctx context.Context, retryable func(context.Context, *Txn) error) error {
 	// TODO(radu): we should open a tracing Span here (we need to figure out how
 	// to use the correct tracer).
@@ -530,10 +528,7 @@ func (db *DB) Txn(ctx context.Context, retryable func(context.Context, *Txn) err
 	}
 	txn := NewTxn(db, db.ctx.NodeID.Get(), RootTxn)
 	txn.SetDebugName("unnamed")
-	opts := TxnExecOptions{
-		AutoRetry: true,
-	}
-	err := txn.Exec(ctx, opts, func(ctx context.Context, txn *Txn, _ *TxnExecOptions) error {
+	err := txn.exec(ctx, func(ctx context.Context, txn *Txn) error {
 		return retryable(ctx, txn)
 	})
 	if err != nil {

--- a/pkg/internal/client/db.go
+++ b/pkg/internal/client/db.go
@@ -531,8 +531,7 @@ func (db *DB) Txn(ctx context.Context, retryable func(context.Context, *Txn) err
 	txn := NewTxn(db, db.ctx.NodeID.Get(), RootTxn)
 	txn.SetDebugName("unnamed")
 	opts := TxnExecOptions{
-		AutoCommit: true,
-		AutoRetry:  true,
+		AutoRetry: true,
 	}
 	err := txn.Exec(ctx, opts, func(ctx context.Context, txn *Txn, _ *TxnExecOptions) error {
 		return retryable(ctx, txn)

--- a/pkg/internal/client/db.go
+++ b/pkg/internal/client/db.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
+	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 )
 
@@ -172,6 +173,8 @@ type DBContext struct {
 	// NodeID provides the node ID for setting the gateway node and avoiding
 	// clock uncertainty for root transactions started at the gateway.
 	NodeID *base.NodeIDContainer
+	// Stopper is used for async tasks.
+	Stopper *stop.Stopper
 	// UseNonCancelableCtxForTxn, when set, means that db.Txn() doesn't signal
 	// transaction completion to the TxnCoordSender through context cancelation.
 	// This means that the TxnCoordSender will consider a transaction to be
@@ -188,6 +191,7 @@ func DefaultDBContext() DBContext {
 	return DBContext{
 		UserPriority: roachpb.NormalUserPriority,
 		NodeID:       &base.NodeIDContainer{},
+		Stopper:      stop.NewStopper(),
 	}
 }
 

--- a/pkg/internal/client/txn.go
+++ b/pkg/internal/client/txn.go
@@ -735,17 +735,6 @@ func endTxnReq(commit bool, deadline *hlc.Timestamp, hasTrigger bool) roachpb.Re
 	return req
 }
 
-// TxnExecOptions controls how Exec() runs a transaction and the corresponding
-// closure.
-type TxnExecOptions struct {
-	// If set, the transaction is automatically aborted if the closure returns any
-	// error aside from recoverable internal errors, in which case the closure is
-	// retried. The retryable function should have no side effects which could
-	// cause problems in the event it must be run more than once.
-	// If not set, all errors cause the txn to be aborted.
-	AutoRetry bool
-}
-
 // AutoCommitError wraps a non-retryable error coming from auto-commit.
 type AutoCommitError struct {
 	cause error
@@ -755,47 +744,30 @@ func (e *AutoCommitError) Error() string {
 	return e.cause.Error()
 }
 
-// Exec executes fn in the context of a distributed transaction.
-// Execution is controlled by opt (see comments in TxnExecOptions).
+// exec executes fn in the context of a distributed transaction. The closure is
+// retried on retriable errors.
 // If no error is returned by the closure, an attempt to commit the txn is made.
 //
-// opt is passed to fn, and it's valid for fn to modify opt as it sees
-// fit during each execution attempt.
-//
-// It is not permitted to call Commit concurrently with any call to Exec.
-//
-// When this method returns, txn might be in any state; Exec does not attempt
+// When this method returns, txn might be in any state; exec does not attempt
 // to clean up the transaction before returning an error. In case of
 // TransactionAbortedError, txn is reset to a fresh transaction, ready to be
 // used.
-//
-// TODO(andrei): The SQL Executor was the most complex user of this interface.
-// It needed fine control by using TxnExecOptions. Now SQL no longer uses this
-// interface, so it's time to see how it can be simplified. TxnExecOptions can
-// probably go away, and so can AutoCommitError. The method should also be
-// documented to not allow calls concurrent with any other txn use, so that the
-// Commit() call inside it is clearly correct (as in, it won't run concurrently
-// with other txn calls).
-func (txn *Txn) Exec(
-	ctx context.Context, opt TxnExecOptions, fn func(context.Context, *Txn, *TxnExecOptions) error,
-) (err error) {
+func (txn *Txn) exec(ctx context.Context, fn func(context.Context, *Txn) error) (err error) {
 	// Run fn in a retry loop until we encounter a success or
 	// error condition this loop isn't capable of handling.
 	for {
 		if err := ctx.Err(); err != nil {
 			return err
 		}
-		err = fn(ctx, txn, &opt)
+		err = fn(ctx, txn)
 
+		// Commit on success, unless the txn has already been committed by the
+		// closure. We allow that, as closure might want to run 1PC transactions.
 		if err == nil {
-			status := txn.status()
-			switch status {
-			case roachpb.ABORTED:
-				// TODO(andrei): Until 7881 is fixed.
-				log.Errorf(ctx, "#7881: no err but aborted txn proto. opt: %+v, txn: %+v",
-					opt, txn)
-			case roachpb.PENDING:
-				// fn succeeded, but didn't commit.
+			if txn.status() == roachpb.ABORTED {
+				log.Fatalf(ctx, "no err but aborted txn proto. txn: %+v", txn)
+			}
+			if txn.status() == roachpb.PENDING {
 				err = txn.Commit(ctx)
 				log.Eventf(ctx, "client.Txn did AutoCommit. err: %v\ntxn: %+v", err, txn.Proto())
 				if err != nil {
@@ -817,7 +789,7 @@ func (txn *Txn) Exec(
 				// We sent transactional requests, so the TxnCoordSender was supposed to
 				// turn retryable errors into HandledRetryableTxnError. Note that this
 				// applies only in the case where this is the root transaction.
-				log.Fatalf(ctx, "unexpected UnhandledRetryableError at the txn.Exec level: %s", err)
+				log.Fatalf(ctx, "unexpected UnhandledRetryableError at the txn.exec() level: %s", err)
 			}
 
 		case *roachpb.HandledRetryableTxnError:
@@ -833,7 +805,7 @@ func (txn *Txn) Exec(
 			retryable = true
 		}
 
-		if !opt.AutoRetry || !retryable {
+		if !retryable {
 			break
 		}
 

--- a/pkg/internal/client/txn.go
+++ b/pkg/internal/client/txn.go
@@ -744,10 +744,6 @@ type TxnExecOptions struct {
 	// cause problems in the event it must be run more than once.
 	// If not set, all errors cause the txn to be aborted.
 	AutoRetry bool
-	// If set, then the txn is automatically committed if no errors are
-	// encountered. If not set, committing or leaving open the txn is the
-	// responsibility of the client.
-	AutoCommit bool
 }
 
 // AutoCommitError wraps a non-retryable error coming from auto-commit.
@@ -761,20 +757,12 @@ func (e *AutoCommitError) Error() string {
 
 // Exec executes fn in the context of a distributed transaction.
 // Execution is controlled by opt (see comments in TxnExecOptions).
+// If no error is returned by the closure, an attempt to commit the txn is made.
 //
 // opt is passed to fn, and it's valid for fn to modify opt as it sees
 // fit during each execution attempt.
 //
-// It's valid for txn to be nil (meaning the txn has already aborted) if fn
-// can handle that. This is useful for continuing transactions that have been
-// aborted because of an error in a previous batch of statements in the hope
-// that a ROLLBACK will reset the state. Neither opt.AutoRetry not opt.AutoCommit
-// can be set in this case.
-//
-// It is not permitted to call Commit concurrently with any call to Exec. Since
-// Exec with the AutoCommitflag is equivalent to an Exec possibly followed by a
-// Commit, it must not be called concurrently with any other call to Exec or
-// Commit.
+// It is not permitted to call Commit concurrently with any call to Exec.
 //
 // When this method returns, txn might be in any state; Exec does not attempt
 // to clean up the transaction before returning an error. In case of
@@ -793,17 +781,13 @@ func (txn *Txn) Exec(
 ) (err error) {
 	// Run fn in a retry loop until we encounter a success or
 	// error condition this loop isn't capable of handling.
-	if txn == nil && (opt.AutoRetry || opt.AutoCommit) {
-		log.Fatal(ctx, "asked to retry or commit a txn that is already aborted")
-	}
-
 	for {
 		if err := ctx.Err(); err != nil {
 			return err
 		}
 		err = fn(ctx, txn, &opt)
 
-		if err == nil && opt.AutoCommit {
+		if err == nil {
 			status := txn.status()
 			switch status {
 			case roachpb.ABORTED:

--- a/pkg/internal/client/txn.go
+++ b/pkg/internal/client/txn.go
@@ -134,6 +134,10 @@ const (
 // transaction is the top level (root), or one of potentially many
 // distributed transactions (leaf).
 //
+// If the transaction is used to send any operations, CommitOrCleanup() or
+// CleanupOnError() should eventually be called to commit/rollback the
+// transaction (including stopping the heartbeat loop).
+//
 // gatewayNodeID: If != 0, this is the ID of the node on whose behalf this
 //   transaction is running. Normally this is the current node, but in the case
 //   of Txns created on remote nodes by DistSQL this will be the gateway.
@@ -592,9 +596,6 @@ func (txn *Txn) CommitOrCleanup(ctx context.Context) error {
 	if err != nil {
 		txn.CleanupOnError(ctx, err)
 	}
-	if !txn.IsFinalized() {
-		log.Fatal(ctx, "Commit() failed to move txn to a final state")
-	}
 	return err
 }
 
@@ -626,17 +627,46 @@ func (txn *Txn) Rollback(ctx context.Context) error {
 	return txn.rollback(ctx).GoError()
 }
 
+// TODO(andrei): It's common for rollbacks to fail with TransactionStatusError:
+// txn record not found (REASON_TXN_NOT_FOUND), in case the txn record was never
+// written (e.g. if a 1PC failed). One would think that, depending on the error
+// received by a 1PC batch, we'd know if a txn record was written and, if it
+// wasn't, we could short-circuit the rollback. There's two tricky things about
+// that, though: a) we'd need to know whether the DistSender has split what
+// looked like a 1PC batch to the client and b) ambiguous errors.
 func (txn *Txn) rollback(ctx context.Context) *roachpb.Error {
-	// TODO(andrei): It's common for rollbacks to fail with
-	// TransactionStatusError: txn record not found (REASON_TXN_NOT_FOUND),
-	// in case the txn record was never written (e.g. if a 1PC failed). One would
-	// think that, depending on the error received by a 1PC batch, we'd know if a
-	// txn record was written and, if it wasn't, we could short-circuit the
-	// rollback. There's two tricky things about that, though: a) we'd need to
-	// know whether the DistSender has split what looked like a 1PC batch to the
-	// client and b) ambiguous errors.
 	log.VEventf(ctx, 2, "rolling back transaction")
-	return txn.sendEndTxnReq(ctx, false /* commit */, nil)
+
+	// Mark the txn as finalized. We don't allow any more requests to be sent once
+	// a rollback is attempted. Also, the SQL layer likes to assert that the
+	// transaction has been finalized after attempting cleanup.
+	txn.mu.Lock()
+	txn.mu.finalized = true
+	txn.mu.Unlock()
+
+	sync := true
+	if ctx.Err() != nil {
+		sync = false
+	}
+	if sync {
+		pErr := txn.sendEndTxnReq(ctx, false /* commit */, nil)
+		if pErr == nil {
+			return nil
+		}
+		// If ctx has been canceled, assume that caused the error and try again
+		// async below.
+		if ctx.Err() == nil {
+			return pErr
+		}
+	}
+
+	ctx = txn.db.AnnotateCtx(context.Background())
+	go func() {
+		if err := txn.sendEndTxnReq(ctx, false /* commit */, nil); err != nil {
+			log.Infof(ctx, "async rollback failed: %s", err)
+		}
+	}()
+	return nil
 }
 
 // AddCommitTrigger adds a closure to be executed on successful commit
@@ -900,9 +930,12 @@ func (txn *Txn) Send(
 
 		sender = txn.mu.sender
 		if txn.mu.Proto.Status != roachpb.PENDING || txn.mu.finalized {
-			return roachpb.NewErrorf(
-				"attempting to use transaction with wrong status or finalized: %s %v",
-				txn.mu.Proto.Status, txn.mu.finalized)
+			onlyRollback := lastIndex == 0 && haveEndTxn && !endTxnRequest.Commit
+			if !onlyRollback {
+				return roachpb.NewErrorf(
+					"attempting to use transaction with wrong status or finalized: %s %v",
+					txn.mu.Proto.Status, txn.mu.finalized)
+			}
 		}
 
 		// For testing purposes, txn.UserPriority can be a negative value (see

--- a/pkg/internal/client/txn.go
+++ b/pkg/internal/client/txn.go
@@ -1081,6 +1081,10 @@ func (txn *Txn) Send(
 					requestTxnID, retryErr.TxnID, retryErr)
 			}
 			txn.updateStateOnRetryableErrLocked(ctx, retryErr)
+		default:
+			if errTxn := pErr.GetTxn(); txn != nil {
+				txn.mu.Proto.Update(errTxn)
+			}
 		}
 		// Note that unhandled retryable txn errors are allowed from leaf
 		// transactions. We pass them up through distributed SQL flows to

--- a/pkg/internal/client/txn_test.go
+++ b/pkg/internal/client/txn_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
+	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 )
 
 var (
@@ -733,25 +734,8 @@ func TestWrongTxnRetry(t *testing.T) {
 		if err := outerTxn.Put(ctx, "a", "b"); err != nil {
 			t.Fatal(err)
 		}
-		var execOpt TxnExecOptions
-		execOpt.AutoRetry = false
-		innerClosure := func(ctx context.Context, innerTxn *Txn, opt *TxnExecOptions) error {
-			log.Infof(ctx, "starting inner: %s", innerTxn.Proto())
-			// Ensure the KV transaction is created.
-			if err := innerTxn.Put(ctx, "x", "y"); err != nil {
-				t.Fatal(err)
-			}
-			// HACK ALERT: to do without a TxnCoordSender, we jump through hoops to
-			// get the retryable error expected by txn.Exec().
-			return roachpb.NewHandledRetryableTxnError(
-				"test error", innerTxn.Proto().ID, *innerTxn.Proto())
-		}
-		innerTxn := NewTxn(db, 0 /* gatewayNodeID */, RootTxn)
-		err := innerTxn.Exec(ctx, execOpt, innerClosure)
-		if !testutils.IsError(err, "test error") {
-			t.Fatalf("unexpected inner failure: %v", err)
-		}
-		return err
+		// Simulate an inner txn by generating an error with a bogus txn id.
+		return roachpb.NewHandledRetryableTxnError("test error", uuid.MakeV4(), roachpb.Transaction{})
 	}
 
 	if err := db.Txn(context.TODO(), txnClosure); !testutils.IsError(err, "test error") {

--- a/pkg/internal/client/txn_test.go
+++ b/pkg/internal/client/txn_test.go
@@ -49,7 +49,7 @@ func TestTxnSnowballTrace(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	clock := hlc.NewClock(hlc.UnixNano, time.Nanosecond)
-	db := NewDB(newTestTxnFactory(nil), clock)
+	db := NewDB(testutils.MakeAmbientCtx(), newTestTxnFactory(nil), clock)
 	tracer := tracing.NewTracer()
 	ctx, sp, err := tracing.StartSnowballTrace(context.Background(), tracer, "test-txn")
 	if err != nil {
@@ -156,10 +156,12 @@ func TestInitPut(t *testing.T) {
 	// TODO(vivekmenezes): update test or remove when InitPut is being
 	// considered sufficiently tested and this path exercised.
 	clock := hlc.NewClock(hlc.UnixNano, time.Nanosecond)
-	db := NewDB(newTestTxnFactory(func(ba roachpb.BatchRequest) (*roachpb.BatchResponse, *roachpb.Error) {
-		br := ba.CreateReply()
-		return br, nil
-	}), clock)
+	db := NewDB(
+		testutils.MakeAmbientCtx(),
+		newTestTxnFactory(func(ba roachpb.BatchRequest) (*roachpb.BatchResponse, *roachpb.Error) {
+			br := ba.CreateReply()
+			return br, nil
+		}), clock)
 
 	txn := NewTxn(db, 0 /* gatewayNodeID */, RootTxn)
 	if pErr := txn.InitPut(context.Background(), "a", "b", false); pErr != nil {
@@ -188,17 +190,19 @@ func TestTxnRequestTxnTimestamp(t *testing.T) {
 	manual := hlc.NewManualClock(testCases[0].expRequestTS.WallTime)
 	clock := hlc.NewClock(manual.UnixNano, time.Nanosecond)
 	var testIdx int
-	db := NewDB(newTestTxnFactory(func(ba roachpb.BatchRequest) (*roachpb.BatchResponse, *roachpb.Error) {
-		test := testCases[testIdx]
-		if test.expRequestTS != ba.Txn.Timestamp {
-			return nil, roachpb.NewErrorf("%d: expected ts %s got %s", testIdx, test.expRequestTS, ba.Txn.Timestamp)
-		}
-		br := ba.CreateReply()
-		txnClone := ba.Txn.Clone()
-		br.Txn = &txnClone
-		br.Txn.Timestamp = test.responseTS
-		return br, nil
-	}), clock)
+	db := NewDB(
+		testutils.MakeAmbientCtx(),
+		newTestTxnFactory(func(ba roachpb.BatchRequest) (*roachpb.BatchResponse, *roachpb.Error) {
+			test := testCases[testIdx]
+			if test.expRequestTS != ba.Txn.Timestamp {
+				return nil, roachpb.NewErrorf("%d: expected ts %s got %s", testIdx, test.expRequestTS, ba.Txn.Timestamp)
+			}
+			br := ba.CreateReply()
+			txnClone := ba.Txn.Clone()
+			br.Txn = &txnClone
+			br.Txn.Timestamp = test.responseTS
+			return br, nil
+		}), clock)
 
 	txn := NewTxn(db, 0 /* gatewayNodeID */, RootTxn)
 
@@ -218,7 +222,9 @@ func TestTransactionConfig(t *testing.T) {
 	clock := hlc.NewClock(hlc.UnixNano, time.Nanosecond)
 	dbCtx := DefaultDBContext()
 	dbCtx.UserPriority = 101
-	db := NewDBWithContext(newTestTxnFactory(nil), clock, dbCtx)
+	db := NewDBWithContext(
+		testutils.MakeAmbientCtx(),
+		newTestTxnFactory(nil), clock, dbCtx)
 	if err := db.Txn(context.TODO(), func(ctx context.Context, txn *Txn) error {
 		if txn.db.ctx.UserPriority != db.ctx.UserPriority {
 			t.Errorf("expected txn user priority %f; got %f",
@@ -237,10 +243,12 @@ func TestCommitReadOnlyTransaction(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	clock := hlc.NewClock(hlc.UnixNano, time.Nanosecond)
 	var calls []roachpb.Method
-	db := NewDB(newTestTxnFactory(func(ba roachpb.BatchRequest) (*roachpb.BatchResponse, *roachpb.Error) {
-		calls = append(calls, ba.Methods()...)
-		return ba.CreateReply(), nil
-	}), clock)
+	db := NewDB(
+		testutils.MakeAmbientCtx(),
+		newTestTxnFactory(func(ba roachpb.BatchRequest) (*roachpb.BatchResponse, *roachpb.Error) {
+			calls = append(calls, ba.Methods()...)
+			return ba.CreateReply(), nil
+		}), clock)
 	if err := db.Txn(context.TODO(), func(ctx context.Context, txn *Txn) error {
 		_, err := txn.Get(ctx, "a")
 		return err
@@ -261,10 +269,12 @@ func TestCommitReadOnlyTransactionExplicit(t *testing.T) {
 	clock := hlc.NewClock(hlc.UnixNano, time.Nanosecond)
 	for _, withGet := range []bool{true, false} {
 		var calls []roachpb.Method
-		db := NewDB(newTestTxnFactory(func(ba roachpb.BatchRequest) (*roachpb.BatchResponse, *roachpb.Error) {
-			calls = append(calls, ba.Methods()...)
-			return ba.CreateReply(), nil
-		}), clock)
+		db := NewDB(
+			testutils.MakeAmbientCtx(),
+			newTestTxnFactory(func(ba roachpb.BatchRequest) (*roachpb.BatchResponse, *roachpb.Error) {
+				calls = append(calls, ba.Methods()...)
+				return ba.CreateReply(), nil
+			}), clock)
 		if err := db.Txn(context.TODO(), func(ctx context.Context, txn *Txn) error {
 			b := txn.NewBatch()
 			if withGet {
@@ -290,16 +300,18 @@ func TestCommitMutatingTransaction(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	clock := hlc.NewClock(hlc.UnixNano, time.Nanosecond)
 	var calls []roachpb.Method
-	db := NewDB(newTestTxnFactory(func(ba roachpb.BatchRequest) (*roachpb.BatchResponse, *roachpb.Error) {
-		calls = append(calls, ba.Methods()...)
-		if bt, ok := ba.GetArg(roachpb.BeginTransaction); ok && !bt.Header().Key.Equal(roachpb.Key("a")) {
-			t.Errorf("expected begin transaction key to be \"a\"; got %s", bt.Header().Key)
-		}
-		if et, ok := ba.GetArg(roachpb.EndTransaction); ok && !et.(*roachpb.EndTransactionRequest).Commit {
-			t.Errorf("expected commit to be true")
-		}
-		return ba.CreateReply(), nil
-	}), clock)
+	db := NewDB(
+		testutils.MakeAmbientCtx(),
+		newTestTxnFactory(func(ba roachpb.BatchRequest) (*roachpb.BatchResponse, *roachpb.Error) {
+			calls = append(calls, ba.Methods()...)
+			if bt, ok := ba.GetArg(roachpb.BeginTransaction); ok && !bt.Header().Key.Equal(roachpb.Key("a")) {
+				t.Errorf("expected begin transaction key to be \"a\"; got %s", bt.Header().Key)
+			}
+			if et, ok := ba.GetArg(roachpb.EndTransaction); ok && !et.(*roachpb.EndTransactionRequest).Commit {
+				t.Errorf("expected commit to be true")
+			}
+			return ba.CreateReply(), nil
+		}), clock)
 
 	// Test all transactional write methods.
 	testArgs := []struct {
@@ -335,10 +347,12 @@ func TestTxnInsertBeginTransaction(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	clock := hlc.NewClock(hlc.UnixNano, time.Nanosecond)
 	var calls []roachpb.Method
-	db := NewDB(newTestTxnFactory(func(ba roachpb.BatchRequest) (*roachpb.BatchResponse, *roachpb.Error) {
-		calls = append(calls, ba.Methods()...)
-		return ba.CreateReply(), nil
-	}), clock)
+	db := NewDB(
+		testutils.MakeAmbientCtx(),
+		newTestTxnFactory(func(ba roachpb.BatchRequest) (*roachpb.BatchResponse, *roachpb.Error) {
+			calls = append(calls, ba.Methods()...)
+			return ba.CreateReply(), nil
+		}), clock)
 	if err := db.Txn(context.TODO(), func(ctx context.Context, txn *Txn) error {
 		if _, err := txn.Get(ctx, "foo"); err != nil {
 			return err
@@ -358,11 +372,13 @@ func TestTxnInsertBeginTransaction(t *testing.T) {
 func TestBeginTransactionErrorIndex(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	clock := hlc.NewClock(hlc.UnixNano, time.Nanosecond)
-	db := NewDB(newTestTxnFactory(func(ba roachpb.BatchRequest) (*roachpb.BatchResponse, *roachpb.Error) {
-		pErr := roachpb.NewError(&roachpb.WriteIntentError{})
-		pErr.SetErrorIndex(0)
-		return nil, pErr
-	}), clock)
+	db := NewDB(
+		testutils.MakeAmbientCtx(),
+		newTestTxnFactory(func(ba roachpb.BatchRequest) (*roachpb.BatchResponse, *roachpb.Error) {
+			pErr := roachpb.NewError(&roachpb.WriteIntentError{})
+			pErr.SetErrorIndex(0)
+			return nil, pErr
+		}), clock)
 	_ = db.Txn(context.TODO(), func(ctx context.Context, txn *Txn) error {
 		b := txn.NewBatch()
 		b.Put("a", "b")
@@ -386,10 +402,12 @@ func TestCommitTransactionOnce(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	clock := hlc.NewClock(hlc.UnixNano, time.Nanosecond)
 	count := 0
-	db := NewDB(newTestTxnFactory(func(ba roachpb.BatchRequest) (*roachpb.BatchResponse, *roachpb.Error) {
-		count++
-		return ba.CreateReply(), nil
-	}), clock)
+	db := NewDB(
+		testutils.MakeAmbientCtx(),
+		newTestTxnFactory(func(ba roachpb.BatchRequest) (*roachpb.BatchResponse, *roachpb.Error) {
+			count++
+			return ba.CreateReply(), nil
+		}), clock)
 	if err := db.Txn(context.TODO(), func(ctx context.Context, txn *Txn) error {
 		b := txn.NewBatch()
 		b.Put("z", "adding a write exposed a bug in #1882")
@@ -407,12 +425,14 @@ func TestCommitTransactionOnce(t *testing.T) {
 func TestAbortReadOnlyTransaction(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	clock := hlc.NewClock(hlc.UnixNano, time.Nanosecond)
-	db := NewDB(newTestTxnFactory(func(ba roachpb.BatchRequest) (*roachpb.BatchResponse, *roachpb.Error) {
-		if _, ok := ba.GetArg(roachpb.EndTransaction); ok {
-			t.Errorf("did not expect EndTransaction")
-		}
-		return ba.CreateReply(), nil
-	}), clock)
+	db := NewDB(
+		testutils.MakeAmbientCtx(),
+		newTestTxnFactory(func(ba roachpb.BatchRequest) (*roachpb.BatchResponse, *roachpb.Error) {
+			if _, ok := ba.GetArg(roachpb.EndTransaction); ok {
+				t.Errorf("did not expect EndTransaction")
+			}
+			return ba.CreateReply(), nil
+		}), clock)
 	if err := db.Txn(context.TODO(), func(ctx context.Context, txn *Txn) error {
 		return errors.New("foo")
 	}); err == nil {
@@ -431,10 +451,12 @@ func TestEndWriteRestartReadOnlyTransaction(t *testing.T) {
 	for _, success := range []bool{true, false} {
 		expCalls := []roachpb.Method{roachpb.BeginTransaction, roachpb.Put, roachpb.EndTransaction}
 		var calls []roachpb.Method
-		db := NewDB(newTestTxnFactory(func(ba roachpb.BatchRequest) (*roachpb.BatchResponse, *roachpb.Error) {
-			calls = append(calls, ba.Methods()...)
-			return ba.CreateReply(), nil
-		}), clock)
+		db := NewDB(
+			testutils.MakeAmbientCtx(),
+			newTestTxnFactory(func(ba roachpb.BatchRequest) (*roachpb.BatchResponse, *roachpb.Error) {
+				calls = append(calls, ba.Methods()...)
+				return ba.CreateReply(), nil
+			}), clock)
 		ok := false
 		if err := db.Txn(context.TODO(), func(ctx context.Context, txn *Txn) error {
 			if !ok {
@@ -470,41 +492,43 @@ func TestTransactionKeyNotChangedInRestart(t *testing.T) {
 	clock := hlc.NewClock(hlc.UnixNano, time.Nanosecond)
 	attempt := 0
 	keys := []string{"first", "second"}
-	db := NewDB(newTestTxnFactory(func(ba roachpb.BatchRequest) (*roachpb.BatchResponse, *roachpb.Error) {
-		// Ignore the final EndTxnRequest.
-		if _, ok := ba.GetArg(roachpb.EndTransaction); ok {
-			return ba.CreateReply(), nil
-		}
-
-		// Attempt 0 should have a BeginTxnRequest, and a PutRequest.
-		// Attempt 1 should have a PutRequest.
-		if attempt == 0 {
-			if _, ok := ba.GetArg(roachpb.BeginTransaction); !ok {
-				t.Fatalf("failed to find a begin transaction request: %v", ba)
+	db := NewDB(
+		testutils.MakeAmbientCtx(),
+		newTestTxnFactory(func(ba roachpb.BatchRequest) (*roachpb.BatchResponse, *roachpb.Error) {
+			// Ignore the final EndTxnRequest.
+			if _, ok := ba.GetArg(roachpb.EndTransaction); ok {
+				return ba.CreateReply(), nil
 			}
-		}
-		if _, ok := ba.GetArg(roachpb.Put); !ok {
-			t.Fatalf("failed to find a put request: %v", ba)
-		}
 
-		// In the first attempt, the transaction key is the key of the first write command.
-		// This key is retained between restarts, so we see the same key in the second attempt.
-		if expectedKey := []byte(keys[0]); !bytes.Equal(expectedKey, ba.Txn.Key) {
-			t.Fatalf("expected transaction key %v, got %v", expectedKey, ba.Txn.Key)
-		}
+			// Attempt 0 should have a BeginTxnRequest, and a PutRequest.
+			// Attempt 1 should have a PutRequest.
+			if attempt == 0 {
+				if _, ok := ba.GetArg(roachpb.BeginTransaction); !ok {
+					t.Fatalf("failed to find a begin transaction request: %v", ba)
+				}
+			}
+			if _, ok := ba.GetArg(roachpb.Put); !ok {
+				t.Fatalf("failed to find a put request: %v", ba)
+			}
 
-		if attempt == 0 {
-			// Abort the first attempt so that we need to retry with
-			// a new transaction proto.
-			//
-			// HACK ALERT: to do without a TxnCoordSender, we jump through hoops to
-			// get the retryable error expected by db.Txn().
-			return nil, roachpb.NewError(
-				roachpb.NewHandledRetryableTxnError(
-					"bogus retryable error", ba.Txn.ID, *ba.Txn))
-		}
-		return ba.CreateReply(), nil
-	}), clock)
+			// In the first attempt, the transaction key is the key of the first write command.
+			// This key is retained between restarts, so we see the same key in the second attempt.
+			if expectedKey := []byte(keys[0]); !bytes.Equal(expectedKey, ba.Txn.Key) {
+				t.Fatalf("expected transaction key %v, got %v", expectedKey, ba.Txn.Key)
+			}
+
+			if attempt == 0 {
+				// Abort the first attempt so that we need to retry with
+				// a new transaction proto.
+				//
+				// HACK ALERT: to do without a TxnCoordSender, we jump through hoops to
+				// get the retryable error expected by db.Txn().
+				return nil, roachpb.NewError(
+					roachpb.NewHandledRetryableTxnError(
+						"bogus retryable error", ba.Txn.ID, *ba.Txn))
+			}
+			return ba.CreateReply(), nil
+		}), clock)
 
 	if err := db.Txn(context.TODO(), func(ctx context.Context, txn *Txn) error {
 		defer func() { attempt++ }()
@@ -526,13 +550,15 @@ func TestAbortMutatingTransaction(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	clock := hlc.NewClock(hlc.UnixNano, time.Nanosecond)
 	var calls []roachpb.Method
-	db := NewDB(newTestTxnFactory(func(ba roachpb.BatchRequest) (*roachpb.BatchResponse, *roachpb.Error) {
-		calls = append(calls, ba.Methods()...)
-		if et, ok := ba.GetArg(roachpb.EndTransaction); ok && et.(*roachpb.EndTransactionRequest).Commit {
-			t.Errorf("expected commit to be false")
-		}
-		return ba.CreateReply(), nil
-	}), clock)
+	db := NewDB(
+		testutils.MakeAmbientCtx(),
+		newTestTxnFactory(func(ba roachpb.BatchRequest) (*roachpb.BatchResponse, *roachpb.Error) {
+			calls = append(calls, ba.Methods()...)
+			if et, ok := ba.GetArg(roachpb.EndTransaction); ok && et.(*roachpb.EndTransactionRequest).Commit {
+				t.Errorf("expected commit to be false")
+			}
+			return ba.CreateReply(), nil
+		}), clock)
 
 	if err := db.Txn(context.TODO(), func(ctx context.Context, txn *Txn) error {
 		if err := txn.Put(ctx, "a", "b"); err != nil {
@@ -574,34 +600,36 @@ func TestRunTransactionRetryOnErrors(t *testing.T) {
 	for _, test := range testCases {
 		t.Run(fmt.Sprintf("%T", test.err), func(t *testing.T) {
 			count := 0
-			db := NewDB(newTestTxnFactory(
-				func(ba roachpb.BatchRequest) (*roachpb.BatchResponse, *roachpb.Error) {
+			db := NewDB(
+				testutils.MakeAmbientCtx(),
+				newTestTxnFactory(
+					func(ba roachpb.BatchRequest) (*roachpb.BatchResponse, *roachpb.Error) {
 
-					if _, ok := ba.GetArg(roachpb.Put); ok {
-						count++
-						if count == 1 {
-							var pErr *roachpb.Error
-							if _, ok := test.err.(*roachpb.ReadWithinUncertaintyIntervalError); ok {
-								// This error requires an observed timestamp to have been
-								// recorded on the origin node.
-								ba.Txn.UpdateObservedTimestamp(1, hlc.Timestamp{WallTime: 1, Logical: 1})
-								pErr = roachpb.NewErrorWithTxn(test.err, ba.Txn)
-								pErr.OriginNode = 1
-							} else {
-								pErr = roachpb.NewErrorWithTxn(test.err, ba.Txn)
-							}
+						if _, ok := ba.GetArg(roachpb.Put); ok {
+							count++
+							if count == 1 {
+								var pErr *roachpb.Error
+								if _, ok := test.err.(*roachpb.ReadWithinUncertaintyIntervalError); ok {
+									// This error requires an observed timestamp to have been
+									// recorded on the origin node.
+									ba.Txn.UpdateObservedTimestamp(1, hlc.Timestamp{WallTime: 1, Logical: 1})
+									pErr = roachpb.NewErrorWithTxn(test.err, ba.Txn)
+									pErr.OriginNode = 1
+								} else {
+									pErr = roachpb.NewErrorWithTxn(test.err, ba.Txn)
+								}
 
-							if pErr.TransactionRestart != roachpb.TransactionRestart_NONE {
-								// HACK ALERT: to do without a TxnCoordSender, we jump through
-								// hoops to get the retryable error expected by db.Txn().
-								return nil, roachpb.NewError(roachpb.NewHandledRetryableTxnError(
-									pErr.Message, ba.Txn.ID, *ba.Txn))
+								if pErr.TransactionRestart != roachpb.TransactionRestart_NONE {
+									// HACK ALERT: to do without a TxnCoordSender, we jump through
+									// hoops to get the retryable error expected by db.Txn().
+									return nil, roachpb.NewError(roachpb.NewHandledRetryableTxnError(
+										pErr.Message, ba.Txn.ID, *ba.Txn))
+								}
+								return nil, pErr
 							}
-							return nil, pErr
 						}
-					}
-					return ba.CreateReply(), nil
-				}), clock)
+						return ba.CreateReply(), nil
+					}), clock)
 			err := db.Txn(context.TODO(), func(ctx context.Context, txn *Txn) error {
 				return txn.Put(ctx, "a", "b")
 			})
@@ -630,7 +658,7 @@ func TestTransactionStatus(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	clock := hlc.NewClock(hlc.UnixNano, time.Nanosecond)
-	db := NewDB(newTestTxnFactory(nil), clock)
+	db := NewDB(testutils.MakeAmbientCtx(), newTestTxnFactory(nil), clock)
 	for _, write := range []bool{true, false} {
 		for _, commit := range []bool{true, false} {
 			txn := NewTxn(db, 0 /* gatewayNodeID */, RootTxn)
@@ -665,7 +693,7 @@ func TestTransactionStatus(t *testing.T) {
 func TestCommitInBatchWrongTxn(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	clock := hlc.NewClock(hlc.UnixNano, time.Nanosecond)
-	db := NewDB(newTestTxnFactory(nil), clock)
+	db := NewDB(testutils.MakeAmbientCtx(), newTestTxnFactory(nil), clock)
 	txn := NewTxn(db, 0 /* gatewayNodeID */, RootTxn)
 
 	b1 := &Batch{}
@@ -686,19 +714,21 @@ func TestSetPriority(t *testing.T) {
 
 	clock := hlc.NewClock(hlc.UnixNano, time.Nanosecond)
 	var expected roachpb.UserPriority
-	db := NewDB(newTestTxnFactory(
-		func(ba roachpb.BatchRequest) (*roachpb.BatchResponse, *roachpb.Error) {
-			if ba.UserPriority != expected {
-				pErr := roachpb.NewErrorf("Priority not set correctly in the batch! "+
-					"(expected: %s, value: %s)", expected, ba.UserPriority)
-				return nil, pErr
-			}
+	db := NewDB(
+		testutils.MakeAmbientCtx(),
+		newTestTxnFactory(
+			func(ba roachpb.BatchRequest) (*roachpb.BatchResponse, *roachpb.Error) {
+				if ba.UserPriority != expected {
+					pErr := roachpb.NewErrorf("Priority not set correctly in the batch! "+
+						"(expected: %s, value: %s)", expected, ba.UserPriority)
+					return nil, pErr
+				}
 
-			br := &roachpb.BatchResponse{}
-			br.Txn = &roachpb.Transaction{}
-			br.Txn.Update(ba.Txn) // copy
-			return br, nil
-		}), clock)
+				br := &roachpb.BatchResponse{}
+				br.Txn = &roachpb.Transaction{}
+				br.Txn.Update(ba.Txn) // copy
+				return br, nil
+			}), clock)
 
 	// Verify the normal priority setting path.
 	expected = roachpb.NormalUserPriority
@@ -724,7 +754,7 @@ func TestSetPriority(t *testing.T) {
 func TestWrongTxnRetry(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	clock := hlc.NewClock(hlc.UnixNano, time.Nanosecond)
-	db := NewDB(newTestTxnFactory(nil), clock)
+	db := NewDB(testutils.MakeAmbientCtx(), newTestTxnFactory(nil), clock)
 
 	var retries int
 	txnClosure := func(ctx context.Context, outerTxn *Txn) error {
@@ -749,7 +779,7 @@ func TestWrongTxnRetry(t *testing.T) {
 func TestBatchMixRawRequest(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	clock := hlc.NewClock(hlc.UnixNano, time.Nanosecond)
-	db := NewDB(newTestTxnFactory(nil), clock)
+	db := NewDB(testutils.MakeAmbientCtx(), newTestTxnFactory(nil), clock)
 
 	b := &Batch{}
 	b.AddRawRequest(&roachpb.EndTransactionRequest{})
@@ -763,7 +793,9 @@ func TestUpdateDeadlineMaybe(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	mc := hlc.NewManualClock(1)
 	clock := hlc.NewClock(mc.UnixNano, time.Nanosecond)
-	db := NewDB(TxnSenderFactoryFunc(func(_ TxnType) TxnSender { return nil }), clock)
+	db := NewDB(
+		testutils.MakeAmbientCtx(),
+		TxnSenderFactoryFunc(func(_ TxnType) TxnSender { return nil }), clock)
 	txn := NewTxn(db, 0 /* gatewayNodeID */, RootTxn)
 
 	if txn.deadline != nil {
@@ -802,21 +834,23 @@ func TestSequenceNumbers(t *testing.T) {
 	clock := hlc.NewClock(hlc.UnixNano, time.Nanosecond)
 
 	expSequence := int32(0)
-	db := NewDB(newTestTxnFactory(func(ba roachpb.BatchRequest) (*roachpb.BatchResponse, *roachpb.Error) {
-		for _, ru := range ba.Requests {
-			args := ru.GetInner()
-			expSequence++
-			if seq := args.Header().Sequence; expSequence != seq {
-				t.Errorf("expected Request sequence %d; got %d", expSequence, seq)
+	db := NewDB(
+		testutils.MakeAmbientCtx(),
+		newTestTxnFactory(func(ba roachpb.BatchRequest) (*roachpb.BatchResponse, *roachpb.Error) {
+			for _, ru := range ba.Requests {
+				args := ru.GetInner()
+				expSequence++
+				if seq := args.Header().Sequence; expSequence != seq {
+					t.Errorf("expected Request sequence %d; got %d", expSequence, seq)
+				}
 			}
-		}
-		if expSequence != ba.Txn.Sequence {
-			t.Errorf("expected header sequence %d; got %d", expSequence, ba.Txn.Sequence)
-		}
-		br := ba.CreateReply()
-		br.Txn = ba.Txn
-		return br, nil
-	}), clock)
+			if expSequence != ba.Txn.Sequence {
+				t.Errorf("expected header sequence %d; got %d", expSequence, ba.Txn.Sequence)
+			}
+			br := ba.CreateReply()
+			br.Txn = ba.Txn
+			return br, nil
+		}), clock)
 
 	txn := NewTxn(db, 0 /* gatewayNodeID */, RootTxn)
 	for i := 0; i < 5; i++ {
@@ -839,14 +873,16 @@ func TestConcurrentTxnRequests(t *testing.T) {
 	clock := hlc.NewClock(hlc.UnixNano, time.Nanosecond)
 	var callCountsMu syncutil.Mutex
 	callCounts := make(map[roachpb.Method]int)
-	db := NewDB(newTestTxnFactory(func(ba roachpb.BatchRequest) (*roachpb.BatchResponse, *roachpb.Error) {
-		callCountsMu.Lock()
-		for _, m := range ba.Methods() {
-			callCounts[m]++
-		}
-		callCountsMu.Unlock()
-		return ba.CreateReply(), nil
-	}), clock)
+	db := NewDB(
+		testutils.MakeAmbientCtx(),
+		newTestTxnFactory(func(ba roachpb.BatchRequest) (*roachpb.BatchResponse, *roachpb.Error) {
+			callCountsMu.Lock()
+			for _, m := range ba.Methods() {
+				callCounts[m]++
+			}
+			callCountsMu.Unlock()
+			return ba.CreateReply(), nil
+		}), clock)
 
 	const keys = "abcdefghijklmnopqrstuvwxyz"
 	const value = "value"

--- a/pkg/internal/client/txn_test.go
+++ b/pkg/internal/client/txn_test.go
@@ -678,32 +678,6 @@ func TestCommitInBatchWrongTxn(t *testing.T) {
 	}
 }
 
-// TestTimestampSelectionInOptions verifies that a client can set the
-// Txn timestamp using client.TxnExecOptions.
-func TestTimestampSelectionInOptions(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-	mc := hlc.NewManualClock(100)
-	clock := hlc.NewClock(mc.UnixNano, time.Nanosecond)
-	db := NewDB(newTestTxnFactory(nil), clock)
-	txn := NewTxn(db, 0 /* gatewayNodeID */, RootTxn)
-
-	refTimestamp := clock.Now()
-
-	txnClosure := func(ctx context.Context, txn *Txn, opt *TxnExecOptions) error {
-		// Ensure the KV transaction is created.
-		return txn.Put(ctx, "a", "b")
-	}
-
-	if err := txn.Exec(context.Background(), TxnExecOptions{}, txnClosure); err != nil {
-		t.Fatal(err)
-	}
-
-	// Check the timestamp was initialized.
-	if txn.Proto().OrigTimestamp.WallTime != refTimestamp.WallTime {
-		t.Errorf("expected txn orig ts to be %s; got %s", refTimestamp, txn.Proto().OrigTimestamp)
-	}
-}
-
 // TestSetPriority verifies that the batch UserPriority is correctly set
 // depending on the transaction priority.
 func TestSetPriority(t *testing.T) {

--- a/pkg/kv/dist_sender_server_test.go
+++ b/pkg/kv/dist_sender_server_test.go
@@ -15,7 +15,6 @@
 package kv_test
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"sort"
@@ -1771,33 +1770,28 @@ func TestTxnStarvation(t *testing.T) {
 	}
 }
 
-// TestTxnCoordSenderHeartbeatFailurePostSplit verifies that on
-// heartbeat timeout, the transaction is aborted asynchronously,
-// leaving abort span entries which cause concurrent reads to fail
-// with txn aborted errors on a range different that the txn's anchor.
-//
-// Note that this is a post-split version of TestTxnCoordSenderGCTimeout.
-func TestTxnCoordSenderHeartbeatFailurePostSplit(t *testing.T) {
+// Test that, if the TxnCoordSender gets a TransactionAbortError, it sends an
+// EndTransaction with Poison=true (the poisoning is so that concurrent readers
+// don't miss their writes).
+func TestAsyncAbortPoisons(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	// Add a testing request filter which pauses a get request for the
 	// key until after the signal channel is closed.
 	var storeKnobs storage.StoreTestingKnobs
 	keyA := roachpb.Key("a")
-	keyB := roachpb.Key("b")
-	signal := make(chan struct{})
+	var expectPoison int64
+	commitCh := make(chan error, 1)
 	storeKnobs.TestingRequestFilter = func(ba roachpb.BatchRequest) *roachpb.Error {
 		for _, req := range ba.Requests {
 			switch r := req.GetInner().(type) {
-			case *roachpb.GetRequest:
-				if r.Key.Equal(keyA) || r.Key.Equal(keyB) {
-					log.VEventf(context.TODO(), 1, "waiting on read of key %s", r.Key)
-					<-signal
-				}
-			case *roachpb.HeartbeatTxnRequest:
-				if bytes.Equal(ba.Txn.Key, keyA) {
-					log.VEventf(context.TODO(), 1, "failing heartbeat of txn %s", r.Key)
-					return roachpb.NewErrorf("induced heartbeat failure")
+			case *roachpb.EndTransactionRequest:
+				if r.Key.Equal(keyA) && atomic.LoadInt64(&expectPoison) == 1 {
+					if r.Poison {
+						close(commitCh)
+					} else {
+						commitCh <- fmt.Errorf("EndTransaction didn't have expected Poison flag")
+					}
 				}
 			}
 		}
@@ -1810,59 +1804,32 @@ func TestTxnCoordSenderHeartbeatFailurePostSplit(t *testing.T) {
 
 	// Setup two userspace ranges: /Min-b, b-/Max.
 	db := s.DB()
-	if err := setupMultipleRanges(ctx, db, "b"); err != nil {
-		t.Fatal(err)
-	}
 
-	// Write values to keys "a" and "b", on separate ranges.
+	// Write values to key "a".
 	txn := client.NewTxn(db, 0 /* gatewayNodeID */, client.RootTxn)
 	b := txn.NewBatch()
 	b.Put(keyA, []byte("value"))
-	b.Put(keyB, []byte("value"))
 	if err := txn.Run(context.TODO(), b); err != nil {
 		t.Fatal(err)
 	}
 
-	startReader := func(key roachpb.Key) chan error {
-		errCh := make(chan error)
-		go func() {
-			if _, err := txn.Get(context.TODO(), key); err != nil {
-				log.Infof(context.TODO(), "read of key %s: %s", key, err)
-				errCh <- err
-			} else {
-				errCh <- errors.New("expected error")
-			}
-		}()
-		return errCh
-	}
-	errChB := startReader(keyB)
-
-	stores := s.GetStores().(*storage.Stores)
-	store, err := stores.GetStore(1)
-	if err != nil {
+	// Run a high-priority txn that will abort the previous one.
+	if err := db.Txn(context.TODO(), func(ctx context.Context, txn *client.Txn) error {
+		if err := txn.SetUserPriority(roachpb.MaxUserPriority); err != nil {
+			return err
+		}
+		return txn.Put(ctx, keyA, []byte("value2"))
+	}); err != nil {
 		t.Fatal(err)
 	}
-	// Wait for the transaction to fail the heartbeat and cleanup
-	// intents (and poison the abort span for the txn ID).
-	testutils.SucceedsSoon(t, func() error {
-		for _, key := range []roachpb.Key{keyA, keyB} {
-			meta := &enginepb.MVCCMetadata{}
-			ok, _, _, err := store.Engine().GetProto(engine.MakeMVCCMetadataKey(key), meta)
-			if err != nil {
-				return fmt.Errorf("error getting MVCC metadata: %s", err)
-			}
-			if ok && meta.Txn != nil {
-				return fmt.Errorf("found unexpected write intent: %s", meta)
-			}
-		}
-		return nil
-	})
 
-	// Now signal the inflight readers to continue; they should witness
-	// abort span entries.
-	close(signal)
-	if err := <-errChB; !testutils.IsError(err, "txn aborted") {
-		t.Errorf("expected transaction aborted error reading %s; got %s", keyB, err)
+	atomic.StoreInt64(&expectPoison, 1)
+
+	if _, err := txn.Get(context.TODO(), keyA); !testutils.IsError(err, "txn aborted") {
+		t.Fatal(err)
+	}
+	if err := <-commitCh; err != nil {
+		t.Fatal(err)
 	}
 }
 

--- a/pkg/kv/dist_sender_server_test.go
+++ b/pkg/kv/dist_sender_server_test.go
@@ -105,7 +105,7 @@ func TestRangeLookupWithOpenTransaction(t *testing.T) {
 		s.Stopper(),
 		kv.MakeTxnMetrics(metric.TestSampleInterval),
 	)
-	db := client.NewDB(tsf, s.Clock())
+	db := client.NewDB(ambient, tsf, s.Clock())
 
 	// Now, with an intent pending, attempt (asynchronously) to read
 	// from an arbitrary key. This will cause the distributed sender to

--- a/pkg/kv/txn_coord_sender.go
+++ b/pkg/kv/txn_coord_sender.go
@@ -1383,6 +1383,7 @@ func (tc *TxnCoordSender) resendWithTxn(
 	// through here.
 	dbCtx := client.DefaultDBContext()
 	dbCtx.UserPriority = ba.UserPriority
+	dbCtx.Stopper = tc.stopper
 	tmpDB := client.NewDBWithContext(tc.AmbientContext, tc.TxnCoordSenderFactory, tc.clock, dbCtx)
 	var br *roachpb.BatchResponse
 	err := tmpDB.Txn(ctx, func(ctx context.Context, txn *client.Txn) error {

--- a/pkg/kv/txn_coord_sender.go
+++ b/pkg/kv/txn_coord_sender.go
@@ -180,7 +180,6 @@ type TxnMetrics struct {
 	Commits     *metric.CounterWithRates
 	Commits1PC  *metric.CounterWithRates // Commits which finished in a single phase
 	AutoRetries *metric.CounterWithRates // Auto retries which avoid client-side restarts
-	Abandons    *metric.CounterWithRates
 	Durations   *metric.Histogram
 
 	// Restarts is the number of times we had to restart the transaction.
@@ -209,9 +208,6 @@ var (
 	metaAutoRetriesRates = metric.Metadata{
 		Name: "txn.autoretries",
 		Help: "Number of automatic retries to avoid serializable restarts"}
-	metaAbandonsRates = metric.Metadata{
-		Name: "txn.abandons",
-		Help: "Number of abandoned KV transactions"}
 	metaDurationsHistograms = metric.Metadata{
 		Name: "txn.durations",
 		Help: "KV transaction durations in nanoseconds"}
@@ -240,7 +236,6 @@ func MakeTxnMetrics(histogramWindow time.Duration) TxnMetrics {
 		Commits:                metric.NewCounterWithRates(metaCommitsRates),
 		Commits1PC:             metric.NewCounterWithRates(metaCommits1PCRates),
 		AutoRetries:            metric.NewCounterWithRates(metaAutoRetriesRates),
-		Abandons:               metric.NewCounterWithRates(metaAbandonsRates),
 		Durations:              metric.NewLatency(metaDurationsHistograms, histogramWindow),
 		Restarts:               metric.NewHistogram(metaRestartsHistogram, histogramWindow, 100, 3),
 		RestartsWriteTooOld:    metric.NewCounter(metaRestartsWriteTooOld),
@@ -258,15 +253,12 @@ type TxnCoordSenderFactory struct {
 	wrapped           client.Sender
 	clock             *hlc.Clock
 	heartbeatInterval time.Duration
-	clientTimeout     time.Duration
 	linearizable      bool // enables linearizable behavior
 	stopper           *stop.Stopper
 	metrics           TxnMetrics
 }
 
 var _ client.TxnSenderFactory = &TxnCoordSenderFactory{}
-
-const defaultClientTimeout = 10 * time.Second
 
 // NewTxnCoordSenderFactory creates a new TxnCoordSenderFactory. The
 // factory creates new instances of TxnCoordSenders.
@@ -288,7 +280,6 @@ func NewTxnCoordSenderFactory(
 		wrapped:           wrapped,
 		clock:             clock,
 		heartbeatInterval: base.DefaultHeartbeatInterval,
-		clientTimeout:     defaultClientTimeout,
 		linearizable:      linearizable,
 		stopper:           stopper,
 		metrics:           txnMetrics,
@@ -1002,11 +993,6 @@ func (tc *TxnCoordSender) finalTxnStatsLocked() (duration, restarts int64, statu
 // attempting to resolve the intents. When the heartbeat stops, the transaction
 // stats are updated based on its final disposition.
 //
-// TODO(dan): The Context we use for this is currently the one from the first
-// request in a Txn, but the semantics of this aren't good. Each context has its
-// own associated lifetime and we're ignoring all but the first. It happens now
-// that we pass the same one in every request, but it's brittle to rely on this
-// forever.
 // TODO(wiz): Update (*DBServer).Batch to not use context.TODO().
 func (tc *TxnCoordSender) heartbeatLoop(ctx context.Context) {
 	var tickChan <-chan time.Time
@@ -1052,24 +1038,6 @@ func (tc *TxnCoordSender) heartbeatLoop(ctx context.Context) {
 		case <-closer:
 			// Transaction finished normally.
 			return
-		case <-ctx.Done():
-			// Note that if ctx is not cancelable, then ctx.Done() returns a nil
-			// channel, which blocks forever. In this case, the heartbeat loop is
-			// responsible for timing out transactions. If ctx.Done() is not nil, then
-			// then heartbeat loop ignores the timeout check and this case is
-			// responsible for client timeouts.
-			log.VEventf(ctx, 2, "transaction heartbeat stopped: %s", ctx.Err())
-
-			// Check if the closer channel had also been closed; in that case, that
-			// takes priority.
-			select {
-			case <-closer:
-				// Transaction finished normally.
-				return
-			default:
-				tc.tryAsyncAbort(ctx)
-				return
-			}
 		case <-tc.stopper.ShouldQuiesce():
 			return
 		}
@@ -1140,8 +1108,6 @@ func (tc *TxnCoordSender) tryAsyncAbort(ctx context.Context) {
 func (tc *TxnCoordSender) heartbeat(ctx context.Context) bool {
 	tc.mu.Lock()
 	txn := tc.mu.meta.Txn.Clone()
-	timeout := tc.clock.PhysicalNow() - tc.clientTimeout.Nanoseconds()
-	hasAbandoned := tc.mu.lastUpdateNanos < timeout
 	tc.mu.Unlock()
 
 	if txn.Status != roachpb.PENDING {
@@ -1150,31 +1116,6 @@ func (tc *TxnCoordSender) heartbeat(ctx context.Context) bool {
 		// want to keep our state for the time being (to dish out the right
 		// error once it returns).
 		return true
-	}
-
-	// Before we send a heartbeat, determine whether this transaction should be
-	// considered abandoned. If so, exit heartbeat. If ctx.Done() is not nil, then
-	// it is a cancellable Context and we skip this check and use the ctx lifetime
-	// instead of a timeout.
-	//
-	// TODO(andrei): We should disallow non-cancellable contexts in the heartbeat
-	// goroutine and enforce that our kv client cancels the context when it's
-	// done. We get non-cancellable contexts from remote clients
-	// (roachpb.ExternalClient) because we override the gRPC context to make it
-	// non-cancellable in DBServer.Batch (as that context is not tied to a txn
-	// lifetime).
-	// Further note that, unfortunately, the Sender interface generally makes it
-	// difficult for the TxnCoordSender to get a context with the same lifetime as
-	// the transaction (the TxnCoordSender associates the context of the txn's
-	// first write with the txn). We should move to using only use local clients
-	// (i.e. merge, or at least co-locate client.Txn and the TxnCoordSender). At
-	// that point, we probably don't even need to deal with context cancellation
-	// any more; the client will be trusted to always send an EndRequest when it's
-	// done with a transaction.
-	if ctx.Done() == nil && hasAbandoned {
-		log.VEvent(ctx, 2, "transaction abandoned heartbeat stopped")
-		tc.tryAsyncAbort(ctx)
-		return false
 	}
 
 	ba := roachpb.BatchRequest{}
@@ -1249,9 +1190,12 @@ func (tc *TxnCoordSender) startTracking(ctx context.Context) error {
 	// Create a channel to stop the heartbeat with the lock held
 	// to avoid a race between the async task and a subsequent commit.
 	tc.mu.txnEnd = make(chan struct{})
+	// Create a new context so that the heartbeat loop doesn't inherit the
+	// caller's cancelation.
+	hbCtx := tc.AnnotateCtx(context.Background())
 	if err := tc.stopper.RunAsyncTask(
 		ctx, "kv.TxnCoordSender: heartbeat loop", func(ctx context.Context) {
-			tc.heartbeatLoop(ctx)
+			tc.heartbeatLoop(hbCtx)
 		}); err != nil {
 		// The system is already draining and we can't start the
 		// heartbeat. We refuse new transactions for now because
@@ -1460,7 +1404,7 @@ func (tc *TxnCoordSender) resendWithTxn(
 	// through here.
 	dbCtx := client.DefaultDBContext()
 	dbCtx.UserPriority = ba.UserPriority
-	tmpDB := client.NewDBWithContext(tc.TxnCoordSenderFactory, tc.clock, dbCtx)
+	tmpDB := client.NewDBWithContext(tc.AmbientContext, tc.TxnCoordSenderFactory, tc.clock, dbCtx)
 	var br *roachpb.BatchResponse
 	err := tmpDB.Txn(ctx, func(ctx context.Context, txn *client.Txn) error {
 		txn.SetDebugName("auto-wrap")
@@ -1489,7 +1433,8 @@ func (tc *TxnCoordSender) updateStats(duration, restarts int64, status roachpb.T
 	case roachpb.ABORTED:
 		tc.metrics.Aborts.Inc(1)
 	case roachpb.PENDING:
-		tc.metrics.Abandons.Inc(1)
+		// NOTE(andrei): Getting a PENDING status here is possible if the heartbeat
+		// loop has stopped because the stopper is quiescing.
 	case roachpb.COMMITTED:
 		tc.metrics.Commits.Inc(1)
 	}

--- a/pkg/kv/txn_coord_sender.go
+++ b/pkg/kv/txn_coord_sender.go
@@ -425,10 +425,8 @@ func (tc *TxnCoordSender) Send(
 			return nil, roachpb.NewError(err)
 		}
 
-		txnID := ba.Txn.ID
-
 		// Associate the txnID with the trace.
-		txnIDStr := txnID.String()
+		txnIDStr := ba.Txn.ID.String()
 		sp.SetBaggageItem("txnID", txnIDStr)
 
 		_, hasBegin := ba.GetArg(roachpb.BeginTransaction)
@@ -953,7 +951,8 @@ func (tc *TxnCoordSender) validateTxnForBatch(ctx context.Context, ba *roachpb.B
 }
 
 // cleanupTxnLocked is called when a transaction ends. The heartbeat
-// goroutine is signaled to clean up the transaction gracefully.
+// goroutine is signaled to stop. The TxnCoordSender's state is set to `state`.
+// Future Send() calls are rejected.
 func (tc *TxnCoordSender) cleanupTxnLocked(ctx context.Context, state txnCoordState) {
 	tc.mu.state = state
 	if tc.mu.onFinishFn != nil {
@@ -1044,38 +1043,19 @@ func (tc *TxnCoordSender) heartbeatLoop(ctx context.Context) {
 	}
 }
 
-// tryAsyncAbort (synchronously) grabs a copy of the txn proto and the
-// intents (which it then clears from meta), and asynchronously tries
-// to abort the transaction.
-func (tc *TxnCoordSender) tryAsyncAbort(ctx context.Context) {
-	tc.mu.Lock()
-	defer tc.mu.Unlock()
-	// Clone the intents and the txn to avoid data races.
-	intentSpans, _ := roachpb.MergeSpans(append([]roachpb.Span(nil), tc.mu.meta.Intents...))
-	tc.cleanupTxnLocked(ctx, aborted)
-	txn := tc.mu.meta.Txn.Clone()
-
-	// Since we don't hold the lock continuously, it's possible that two aborts
-	// raced here. That's fine (and probably better than the alternative, which
-	// is missing new intents sometimes). Note that the txn may be uninitialized
-	// here if a failure occurred before the first write succeeded.
-	if txn.Status != roachpb.PENDING {
-		return
-	}
-
-	// Update out status to Aborted, since we're about to send a rollback. Besides
-	// being sane, this prevents the heartbeat loop from incrementing an
-	// "Abandons" metric.
-	tc.mu.meta.Txn.Status = roachpb.ABORTED
-
-	// NB: use context.Background() here because we may be called when the
-	// caller's context has been canceled.
-	if err := tc.stopper.RunAsyncTask(
-		tc.AnnotateCtx(context.Background()), "kv.TxnCoordSender: aborting txn", func(ctx context.Context) {
-			// Use the wrapped sender since the normal Sender does not allow
-			// clients to specify intents.
-			resp, pErr := client.SendWrappedWith(
-				ctx, tc.wrapped, roachpb.Header{Txn: &txn}, &roachpb.EndTransactionRequest{
+// abortTxnAsync sends an EndTransaction asynchronously to the wrapped Sender.
+func abortTxnAsync(
+	ctx context.Context,
+	txn roachpb.Transaction,
+	intentSpans []roachpb.Span,
+	wrapped client.Sender,
+	stopper *stop.Stopper,
+) {
+	log.VEventf(ctx, 2, "async abort for txn: %s", txn)
+	if err := stopper.RunAsyncTask(
+		ctx, "kv.TxnCoordSender: aborting txn", func(ctx context.Context) {
+			_, pErr := client.SendWrappedWith(
+				ctx, wrapped, roachpb.Header{Txn: &txn}, &roachpb.EndTransactionRequest{
 					RequestHeader: roachpb.RequestHeader{
 						Key: txn.Key,
 					},
@@ -1087,17 +1067,9 @@ func (tc *TxnCoordSender) tryAsyncAbort(ctx context.Context) {
 					Poison: true,
 				},
 			)
-			tc.mu.Lock()
-			defer tc.mu.Unlock()
 			if pErr != nil {
-				if log.V(1) {
-					log.Warningf(ctx, "abort due to inactivity failed for %s: %s ", txn, pErr)
-				}
-				if errTxn := pErr.GetTxn(); errTxn != nil {
-					tc.mu.meta.Txn.Update(errTxn)
-				}
-			} else {
-				tc.mu.meta.Txn.Update(resp.(*roachpb.EndTransactionResponse).Txn)
+				log.VErrEventf(ctx, 1,
+					"abort due to inactivity failed for %s: %s ", txn, pErr)
 			}
 		},
 	); err != nil {
@@ -1105,6 +1077,11 @@ func (tc *TxnCoordSender) tryAsyncAbort(ctx context.Context) {
 	}
 }
 
+// heartbeat sends a HeartbeatTxnRequest to the txn record.
+// Errors that carry update txn information (e.g.  TransactionAbortedError) will
+// update the txn. Other errors are swallowed.
+// Returns true if heartbeating should continue, false if the transaction is no
+// longer Pending and so there's no point in heartbeating further.
 func (tc *TxnCoordSender) heartbeat(ctx context.Context) bool {
 	tc.mu.Lock()
 	txn := tc.mu.meta.Txn.Clone()
@@ -1112,53 +1089,46 @@ func (tc *TxnCoordSender) heartbeat(ctx context.Context) bool {
 
 	if txn.Status != roachpb.PENDING {
 		// A previous iteration has already determined that the transaction is
-		// already finalized, so we wait for the client to realize that and
-		// want to keep our state for the time being (to dish out the right
-		// error once it returns).
-		return true
+		// already finalized.
+		return false
 	}
 
 	ba := roachpb.BatchRequest{}
 	ba.Txn = &txn
 
 	hb := &roachpb.HeartbeatTxnRequest{
+		RequestHeader: roachpb.RequestHeader{
+			Key: txn.Key,
+		},
 		Now: tc.clock.Now(),
 	}
-	hb.Key = txn.Key
 	ba.Add(hb)
 
 	log.VEvent(ctx, 2, "heartbeat")
 	br, pErr := tc.wrapped.Send(ctx, ba)
 
-	// Correctness mandates that when we can't heartbeat the transaction, we
-	// make sure the client doesn't keep going. This is particularly relevant
-	// in the case of an ABORTED transaction, but event if we can't reach the
-	// transaction record at all, we have to assume it's been aborted as well.
 	if pErr != nil {
 		log.VEventf(ctx, 2, "heartbeat failed: %s", pErr)
 
 		// If the heartbeat request arrived to find a missing transaction record
-		// then we ignore the error and continue the heartbeat loop. This is
-		// possible if the heartbeat loop was started before a BeginTxn request
-		// succeeds because of ambiguity in the first write request's response.
+		// then we ignore the error. This is possible if the heartbeat loop was
+		// started before a BeginTxn request succeeds because of ambiguity in the
+		// first write request's response.
 		if tse, ok := pErr.GetDetail().(*roachpb.TransactionStatusError); ok &&
 			tse.Reason == roachpb.TransactionStatusError_REASON_TXN_NOT_FOUND {
 			return true
 		}
 
+		// If the error contains updated txn info, ingest it. For example, we might
+		// find out this way that the transaction has been Aborted in the meantime
+		// (e.g. someone else pushed it).
 		if errTxn := pErr.GetTxn(); errTxn != nil {
 			tc.mu.Lock()
 			tc.mu.meta.Txn.Update(errTxn)
 			tc.mu.Unlock()
 		}
-		// We're not going to let the client carry out additional requests, so
-		// try to clean up if the known txn disposition remains PENDING.
-		if txn.Status == roachpb.PENDING {
-			log.VEventf(ctx, 2, "transaction heartbeat failed: %s", pErr)
-			tc.tryAsyncAbort(ctx)
-		}
-		// Stop the heartbeat.
-		return false
+
+		return tc.mu.meta.Txn.Status == roachpb.PENDING
 	}
 	txn.Update(br.Responses[0].GetInner().(*roachpb.HeartbeatTxnResponse).Txn)
 
@@ -1306,8 +1276,34 @@ func (tc *TxnCoordSender) updateState(
 			}
 			newTxn = roachpb.PrepareTransactionForRetry(ctx, pErr, ba.UserPriority, tc.clock)
 
-			// Reset state as this is a retryable txn error. Note that
-			// intents are tracked cumulatively across epochs on retries.
+			// We'll pass a HandledRetryableTxnError up to the next layer.
+			pErr = roachpb.NewError(
+				roachpb.NewHandledRetryableTxnError(
+					pErr.Message,
+					errTxnID, // the id of the transaction that encountered the error
+					newTxn))
+
+			// If the ID changed, it means we had to start a new transaction and the
+			// old one is toast. This TxnCoordSender cannot be used any more - future
+			// Send() calls will be rejected; the client is supposed to create a new
+			// one.
+			if errTxnID != newTxn.ID {
+				tc.mu.Lock()
+				tc.cleanupTxnLocked(ctx, aborted)
+
+				// NB: We use context.Background() here because we don't want a canceled
+				// context to interrupt the aborting.
+				abortCtx := tc.AnnotateCtx(context.Background())
+				// Clone the intents and the txn to avoid data races.
+				intentSpans, _ := roachpb.MergeSpans(append([]roachpb.Span(nil), tc.mu.meta.Intents...))
+				txn := tc.mu.meta.Txn.Clone()
+
+				abortTxnAsync(abortCtx, txn, intentSpans, tc.wrapped, tc.stopper)
+				tc.mu.Unlock()
+				return pErr
+			}
+			// Reset state as this is a retryable txn error. Note that intents are
+			// tracked cumulatively across epochs on retries.
 			log.VEventf(ctx, 2, "resetting epoch-based coordinator state on retry")
 			tc.mu.Lock()
 			tc.mu.meta.CommandCount = 0
@@ -1316,23 +1312,6 @@ func (tc *TxnCoordSender) updateState(
 			tc.mu.meta.RefreshValid = true
 			tc.mu.refreshSpansBytes = 0
 			tc.mu.Unlock()
-
-			// Pass a HandledRetryableTxnError up to the next layer.
-			pErr = roachpb.NewError(
-				roachpb.NewHandledRetryableTxnError(
-					pErr.Message,
-					errTxnID, // the id of the transaction that encountered the error
-					newTxn))
-
-			// If the ID changed, it means we had to start a new transaction
-			// and the old one is toast. Try an asynchronous abort of the
-			// bound transaction to clean up its intents immediately, which
-			// likely will otherwise require synchronous cleanup by the
-			// restated transaction and return without any update to
-			if errTxnID != newTxn.ID {
-				tc.tryAsyncAbort(ctx)
-				return pErr
-			}
 		} else {
 			// We got a non-retryable error, or a retryable error at a leaf
 			// transaction, and need to pass responsibility for handling it

--- a/pkg/kv/txn_coord_sender_test.go
+++ b/pkg/kv/txn_coord_sender_test.go
@@ -40,7 +40,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
-	"github.com/cockroachdb/cockroach/pkg/util/retry"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
@@ -367,7 +366,7 @@ func TestTxnCoordSenderCondenseIntentSpans(t *testing.T) {
 		s.Stopper,
 		MakeTxnMetrics(metric.TestSampleInterval),
 	)
-	db := client.NewDB(tsf, s.Clock)
+	db := client.NewDB(ambient, tsf, s.Clock)
 
 	txn := client.NewTxn(db, 0 /* gatewayNodeID */, client.RootTxn)
 	for i, tc := range testCases {
@@ -681,173 +680,6 @@ func TestTxnCoordSenderCleanupOnAborted(t *testing.T) {
 	verifyCleanup(key, s.Eng, t, txn1.Sender().(*TxnCoordSender), txn2.Sender().(*TxnCoordSender))
 }
 
-func TestTxnCoordSenderCancel(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-	s := createTestDB(t)
-	defer s.Stop()
-
-	ctx, cancel := context.WithCancel(context.Background())
-
-	factory := s.DB.GetFactory().(*TxnCoordSenderFactory)
-	origSender := factory.WrappedSender()
-	factory.wrapped = client.SenderFunc(
-		func(ctx context.Context, args roachpb.BatchRequest) (*roachpb.BatchResponse, *roachpb.Error) {
-			if _, hasET := args.GetArg(roachpb.EndTransaction); hasET {
-				// Cancel the transaction while also sending it along. This tickled a
-				// data race in TxnCoordSender.tryAsyncAbort. See #7726.
-				cancel()
-			}
-			return origSender.Send(ctx, args)
-		})
-
-	// Create a transaction with bunch of intents.
-	txn := client.NewTxn(s.DB, 0 /* gatewayNodeID */, client.RootTxn)
-	batch := txn.NewBatch()
-	for i := 0; i < 100; i++ {
-		key := roachpb.Key(fmt.Sprintf("%d", i))
-		batch.Put(key, []byte("value"))
-	}
-	if err := txn.Run(ctx, batch); err != nil {
-		t.Fatal(err)
-	}
-
-	// Commit the transaction. Note that we cancel the transaction when the
-	// commit is sent which stresses the TxnCoordSender.tryAsyncAbort code
-	// path. We'll either succeed, or get a context canceled error. Anything else
-	// is unexpected.
-	err := txn.CommitOrCleanup(ctx)
-	if err != nil && err.Error() != context.Canceled.Error() {
-		t.Fatal(err)
-	}
-}
-
-// TestTxnCoordSenderGCTimeout verifies that the coordinator cleans up extant
-// transactions and intents after the lastUpdateNanos exceeds the timeout.
-func TestTxnCoordSenderGCTimeout(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-	// Add a testing request filter which pauses a get request for the
-	// key until after the signal channel is closed.
-	key := roachpb.Key("a")
-	value := []byte("value")
-	signal := make(chan struct{})
-	knobs := &storage.StoreTestingKnobs{
-		DisableScanner:    true,
-		DisableSplitQueue: true,
-		TestingRequestFilter: func(ba roachpb.BatchRequest) *roachpb.Error {
-			for _, req := range ba.Requests {
-				if getReq, ok := req.GetInner().(*roachpb.GetRequest); ok && getReq.Key.Equal(key) {
-					<-signal
-				}
-			}
-			return nil
-		},
-	}
-
-	s := createTestDBWithContextAndKnobs(t, client.DefaultDBContext(), knobs)
-	defer s.Stop()
-
-	// Set heartbeat interval to 1ms for testing.
-	s.DB.GetFactory().(*TxnCoordSenderFactory).heartbeatInterval = 1 * time.Millisecond
-
-	txn := client.NewTxn(s.DB, 0 /* gatewayNodeID */, client.RootTxn)
-	tc := txn.Sender().(*TxnCoordSender)
-	if err := txn.Put(context.TODO(), key, value); err != nil {
-		t.Fatal(err)
-	}
-	errCh := make(chan error)
-	go func() {
-		if _, err := txn.Get(context.TODO(), key); err != nil {
-			errCh <- err
-		} else {
-			errCh <- errors.New("expected error")
-		}
-	}()
-
-	// Now, advance clock past the default client timeout.
-	s.Manual.Increment(defaultClientTimeout.Nanoseconds() + 1)
-
-	testutils.SucceedsSoon(t, func() error {
-		// Locking the TxnCoordSender to prevent a data race.
-		tc.mu.Lock()
-		done := tc.mu.txnEnd == nil
-		tc.mu.Unlock()
-		if !done {
-			return errors.Errorf("expected garbage collection")
-		}
-		return nil
-	})
-
-	// Verify all intents have been cleaned up.
-	verifyCleanup(key, s.Eng, t, tc)
-
-	// Verify that the inflight get request receives a transaction
-	// aborted error.
-	close(signal)
-	if err := <-errCh; !testutils.IsError(err, "txn aborted") {
-		t.Errorf("expected transaction aborted error; got %s", err)
-	}
-}
-
-// TestTxnCoordSenderGCWithCancel verifies that the coordinator cleans up extant
-// transactions and intents after transaction context is canceled.
-func TestTxnCoordSenderGCWithCancel(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-	s := createTestDB(t)
-	defer s.Stop()
-
-	ctx, cancel := context.WithCancel(context.Background())
-	txn := client.NewTxn(s.DB, 0 /* gatewayNodeID */, client.RootTxn)
-	tc := txn.Sender().(*TxnCoordSender)
-	// Set heartbeat interval to 1ms for testing.
-	tc.TxnCoordSenderFactory.heartbeatInterval = 1 * time.Millisecond
-	key := roachpb.Key("a")
-	if pErr := txn.Put(ctx, key, []byte("value")); pErr != nil {
-		t.Fatal(pErr)
-	}
-	// Wait for heartbeat to kick in after Put.
-	testutils.SucceedsSoon(t, func() error {
-		tc.mu.Lock()
-		defer tc.mu.Unlock()
-		if tc.mu.txnEnd != nil {
-			return nil
-		}
-		return errors.Errorf("expected heartbeat to start")
-	})
-
-	// Now, advance clock past the default client timeout.
-	// Locking the TxnCoordSender to prevent a data race.
-	tc.mu.Lock()
-	s.Manual.Increment(defaultClientTimeout.Nanoseconds() + 1)
-	tc.mu.Unlock()
-
-	// Verify that the transaction is alive despite the timeout having
-	// been exceeded.
-	errStillActive := errors.New("transaction is still active")
-	if err := retry.ForDuration(1*time.Second, func() error {
-		tc.mu.Lock()
-		done := tc.mu.txnEnd == nil
-		tc.mu.Unlock()
-		if done {
-			return nil
-		}
-		meta := &enginepb.MVCCMetadata{}
-		ok, _, _, err := s.Eng.GetProto(engine.MakeMVCCMetadataKey(key), meta)
-		if err != nil {
-			t.Fatalf("error getting MVCC metadata: %s", err)
-		}
-		if !ok || meta.Txn == nil {
-			return nil
-		}
-		return errStillActive
-	}); err != errStillActive {
-		t.Fatalf("expected transaction to be active, got: %v", err)
-	}
-
-	// After the context is canceled, the heartbeat should stop.
-	cancel()
-	verifyCleanup(key, s.Eng, t, tc)
-}
-
 // TestTxnCoordSenderGCWithAmbiguousResultErr verifies that the coordinator
 // cleans up extant transactions and intents after an ambiguous result error is
 // observed, even if the error is on the first request.
@@ -871,7 +703,7 @@ func TestTxnCoordSenderGCWithAmbiguousResultErr(t *testing.T) {
 		s := createTestDBWithContextAndKnobs(t, client.DefaultDBContext(), knobs)
 		defer s.Stop()
 
-		ctx, cancel := context.WithCancel(context.Background())
+		ctx := context.Background()
 		txn := client.NewTxn(s.DB, 0 /* gatewayNodeID */, client.RootTxn)
 		tc := txn.Sender().(*TxnCoordSender)
 		defer teardownHeartbeat(tc)
@@ -885,8 +717,10 @@ func TestTxnCoordSenderGCWithAmbiguousResultErr(t *testing.T) {
 			t.Fatalf("expected error %v, found %v", are, err)
 		}
 
-		// After the context is canceled, the transaction should be cleaned up.
-		cancel()
+		if err := txn.Rollback(ctx); err != nil {
+			t.Fatal(err)
+		}
+
 		testutils.SucceedsSoon(t, func() error {
 			// Locking the TxnCoordSender to prevent a data race.
 			tc.mu.Lock()
@@ -1022,7 +856,7 @@ func TestTxnCoordSenderTxnUpdatedOnError(t *testing.T) {
 				stopper,
 				MakeTxnMetrics(metric.TestSampleInterval),
 			)
-			db := client.NewDB(tsf, clock)
+			db := client.NewDB(ambient, tsf, clock)
 			key := roachpb.Key("test-key")
 			origTxnProto := roachpb.MakeTransaction(
 				"test txn",
@@ -1250,7 +1084,7 @@ func TestTxnCoordSenderNoDuplicateIntents(t *testing.T) {
 	)
 	defer stopper.Stop(context.TODO())
 
-	db := client.NewDB(factory, clock)
+	db := client.NewDB(ambient, factory, clock)
 	txn := client.NewTxn(db, 0 /* gatewayNodeID */, client.RootTxn)
 
 	// Write to a, b, u-w before the final batch.
@@ -1314,7 +1148,6 @@ func checkTxnMetricsOnce(
 	}{
 		{"commits", metrics.Commits.Count(), commits},
 		{"commits1PC", metrics.Commits1PC.Count(), commits1PC},
-		{"abandons", metrics.Abandons.Count(), abandons},
 		{"aborts", metrics.Aborts.Count(), aborts},
 		{"durations", metrics.Durations.TotalCount(),
 			commits + abandons + aborts},
@@ -1416,130 +1249,6 @@ func TestTxnOnePhaseCommit(t *testing.T) {
 		t.Fatalf("expected: %s, got: %s", value, val)
 	}
 	checkTxnMetrics(t, metrics, "commit 1PC txn", 1 /* commits */, 1 /* 1PC */, 0, 0, 0)
-}
-
-// createTimeoutDB returns a DB whose txns are considered abandoned by the
-// TxnCoordSender after a given timeout.
-func createTimeoutDB(
-	db *client.DB, dbCtx client.DBContext, hbInterval time.Duration, clientTimeout time.Duration,
-) *client.DB {
-	origFactory := db.GetFactory().(*TxnCoordSenderFactory)
-	factory := *origFactory
-	factory.heartbeatInterval = hbInterval
-	factory.clientTimeout = clientTimeout
-	dbCtx.UseTimeoutTxnAbandonment = true
-	return client.NewDBWithContext(&factory, factory.clock, dbCtx)
-}
-
-func TestTxnAbandonCount(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-	s, metrics, cleanupFn := setupMetricsTest(t)
-	defer cleanupFn()
-	value := []byte("value")
-	manual := s.Manual
-
-	ctx := context.Background()
-
-	var count int
-	doneErr := errors.New("retry on abandoned successful; exiting")
-
-	hbInterval := 2 * time.Millisecond
-	clientTimeout := 1 * time.Millisecond
-	db := createTimeoutDB(s.DB, *s.DBContext, hbInterval, clientTimeout)
-
-	if err := db.Txn(ctx, func(ctx context.Context, txn *client.Txn) error {
-		count++
-		if count == 2 {
-			return doneErr
-		}
-		key := []byte("key-abandon")
-
-		if err := txn.SetIsolation(enginepb.SNAPSHOT); err != nil {
-			return err
-		}
-
-		if err := txn.Put(ctx, key, value); err != nil {
-			return err
-		}
-
-		testutils.SucceedsSoon(t, func() error {
-			// Note that we must bump the clock before every attempt (not just once)
-			// because otherwise there is a race in which we bump, a heartbeat happens
-			// at the new timestamp, and the transaction never expires.
-			manual.Increment(int64(clientTimeout + hbInterval*2))
-			err := checkTxnMetricsOnce(
-				t, metrics, "abandon txn", 0, 0, 1 /* abandons */, 0, 0,
-			)
-			if err == nil {
-				return nil
-			}
-			// There's another race here: if (*TxnCoordSender).heartbeat sees the expired txn, it will
-			// asynchronously call tryAsyncAbort, which may beat the parent heartbeat loop's stats taking.
-			// In that case, we see an aborted txn.
-			return checkTxnMetricsOnce(
-				t, metrics, "abort txn", 0, 0, 0, 1 /* aborts */, 0,
-			)
-		})
-
-		return nil
-	}); err != doneErr {
-		t.Fatalf("unexpected error: %v", err)
-	}
-}
-
-// TestTxnReadAfterAbandon checks the fix for the condition in issue #4787:
-// after a transaction is abandoned we do a read as part of that transaction
-// which should fail.
-func TestTxnReadAfterAbandon(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-	s, metrics, cleanupFn := setupMetricsTest(t)
-	manual := s.Manual
-	defer cleanupFn()
-
-	value := []byte("value")
-
-	var count int
-	doneErr := errors.New("retry on abandoned successful; exiting")
-
-	hbInterval := s.DB.GetFactory().(*TxnCoordSenderFactory).heartbeatInterval
-	clientTimeout := s.DB.GetFactory().(*TxnCoordSenderFactory).clientTimeout
-	db := createTimeoutDB(s.DB, *s.DBContext, hbInterval, clientTimeout)
-
-	err := db.Txn(context.Background(), func(ctx context.Context, txn *client.Txn) error {
-		count++
-		if count == 2 {
-			return doneErr
-		}
-		key := []byte("key-abandon")
-
-		if err := txn.SetIsolation(enginepb.SNAPSHOT); err != nil {
-			t.Fatal(err)
-		}
-
-		if err := txn.Put(ctx, key, value); err != nil {
-			t.Fatal(err)
-		}
-
-		testutils.SucceedsSoon(t, func() error {
-			// See #22762 for very similar code and an explanation.
-			manual.Increment(int64(clientTimeout + hbInterval*2))
-			err := checkTxnMetricsOnce(t, metrics, "abandon txn", 0, 0, 1 /* abandons */, 0, 0)
-			if err == nil {
-				return nil
-			}
-			return checkTxnMetricsOnce(t, metrics, "abort txn", 0, 0, 0, 1 /* aborts */, 0)
-		})
-
-		_, err := txn.Get(ctx, key)
-		if !testutils.IsError(err, "txn aborted") {
-			t.Fatalf("unexpected error from Get on abandoned txn: %v", err)
-		}
-		return err // appease compiler
-	})
-
-	if err == nil {
-		t.Fatalf("abandoned txn didn't fail")
-	}
 }
 
 func TestTxnAbortCount(t *testing.T) {
@@ -1677,34 +1386,6 @@ func TestTxnDurations(t *testing.T) {
 	}
 }
 
-// We rely on context.Background() having a nil Done() channel. It's documented
-// as "Done may return nil if this context can never be canceled", so we check
-// that the "may" is actually "will".
-//
-// TODO(dan): If this ever breaks, we can do something with the context values:
-// type contextLifetimeKey struct{}
-// func SetIsContextLifetime(ctx) context.Context {
-//   return context.WithValue(ctx, contextLifetimeKey{}, struct{}{})
-// }
-// func HasContextLifetime(ctx) bool {
-//   _, ok := ctx.Value(contextLifetimeKey{})
-//   return ok
-// }
-//
-// In TxnCoordSender:
-// func heartbeatLoop(ctx context.Context, ...) {
-//   if !HasContextLifetime(ctx) && txnMeta.hasClientAbandonedCoord ... {
-//     tc.tryAsyncAbort()
-//     return
-//   }
-// }
-func TestContextDoneNil(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-	if context.Background().Done() != nil {
-		t.Error("context.Background().Done()'s behavior has changed")
-	}
-}
-
 // TestAbortTransactionOnCommitErrors verifies that transactions are
 // aborted on the correct errors.
 func TestAbortTransactionOnCommitErrors(t *testing.T) {
@@ -1788,7 +1469,7 @@ func TestAbortTransactionOnCommitErrors(t *testing.T) {
 				MakeTxnMetrics(metric.TestSampleInterval),
 			)
 
-			db := client.NewDB(factory, clock)
+			db := client.NewDB(ambient, factory, clock)
 			txn := client.NewTxn(db, 0 /* gatewayNodeID */, client.RootTxn)
 			if pErr := txn.Put(context.Background(), "a", "b"); pErr != nil {
 				t.Fatalf("put failed: %s", pErr)
@@ -1812,6 +1493,46 @@ func TestAbortTransactionOnCommitErrors(t *testing.T) {
 			}
 		})
 	}
+}
+
+// Test that, after a heartbeat fails, requests start being rejected.
+func TestRejectionAfterFailedHeartbeat(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	key := roachpb.Key("a")
+	value := []byte("value")
+	// We're going to fail all heartbeats.
+	knobs := &storage.StoreTestingKnobs{
+		TestingResponseFilter: func(ba roachpb.BatchRequest, br *roachpb.BatchResponse) *roachpb.Error {
+			for _, req := range ba.Requests {
+				if hb, ok := req.GetInner().(*roachpb.HeartbeatTxnRequest); ok && hb.Key.Equal(key) {
+					return roachpb.NewErrorf("induced heartbeat failure")
+				}
+			}
+			return nil
+		},
+	}
+
+	s := createTestDBWithContextAndKnobs(t, client.DefaultDBContext(), knobs)
+	defer s.Stop()
+
+	txn := client.NewTxn(s.DB, 0 /* gatewayNodeID */, client.RootTxn)
+	tc := txn.Sender().(*TxnCoordSender)
+	tc.TxnCoordSenderFactory.heartbeatInterval = 1 * time.Millisecond
+
+	// Do a write, to start the heartbeat.
+	if err := txn.Put(context.TODO(), key, value); err != nil {
+		t.Fatal(err)
+	}
+
+	// The heartbeat failure and the resulting cleanup are async, so it might take
+	// a bit for the client to see the effects.
+	testutils.SucceedsSoon(t, func() error {
+		if _, err := txn.Get(context.TODO(), key); !testutils.IsError(err, "txn aborted") {
+			return fmt.Errorf("expected transaction aborted err, found %v", err)
+		}
+		return nil
+	})
 }
 
 // mockSender is a client.Sender implementation that passes requests to a list
@@ -1864,7 +1585,7 @@ func TestRollbackErrorStopsHeartbeat(t *testing.T) {
 		stopper,
 		MakeTxnMetrics(metric.TestSampleInterval),
 	)
-	db := client.NewDB(factory, clock)
+	db := client.NewDB(ambient, factory, clock)
 
 	sender.match(func(ba roachpb.BatchRequest) (*roachpb.BatchResponse, *roachpb.Error) {
 		if _, ok := ba.GetArg(roachpb.EndTransaction); !ok {
@@ -1932,7 +1653,7 @@ func TestOnePCErrorTracking(t *testing.T) {
 		stopper,
 		MakeTxnMetrics(metric.TestSampleInterval),
 	)
-	db := client.NewDB(factory, clock)
+	db := client.NewDB(ambient, factory, clock)
 	var key = roachpb.Key("a")
 
 	// Register a matcher catching the commit attempt.

--- a/pkg/server/node.go
+++ b/pkg/server/node.go
@@ -193,7 +193,7 @@ func bootstrapCluster(
 	})
 	tcsFactory := kv.NewTxnCoordSenderFactory(cfg.AmbientCtx, cfg.Settings, localSender, cfg.Clock,
 		false /* linearizable */, stopper, txnMetrics)
-	cfg.DB = client.NewDB(tcsFactory, cfg.Clock)
+	cfg.DB = client.NewDB(cfg.AmbientCtx, tcsFactory, cfg.Clock)
 	cfg.Transport = storage.NewDummyRaftTransport(cfg.Settings)
 	if err := cfg.Settings.InitializeVersion(bootstrapVersion); err != nil {
 		return uuid.UUID{}, errors.Wrap(err, "while initializing cluster version")

--- a/pkg/server/node_test.go
+++ b/pkg/server/node_test.go
@@ -93,7 +93,7 @@ func createTestNode(
 		stopper,
 		kv.MakeTxnMetrics(metric.TestSampleInterval),
 	)
-	cfg.DB = client.NewDB(tsf, cfg.Clock)
+	cfg.DB = client.NewDB(cfg.AmbientCtx, tsf, cfg.Clock)
 	cfg.Transport = storage.NewDummyRaftTransport(st)
 	active, renewal := cfg.NodeLivenessDurations()
 	cfg.HistogramWindowInterval = metric.TestSampleInterval

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -281,7 +281,7 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 	)
 	dbCtx := client.DefaultDBContext()
 	dbCtx.NodeID = &s.nodeIDContainer
-	s.db = client.NewDBWithContext(s.tcsFactory, s.clock, dbCtx)
+	s.db = client.NewDBWithContext(s.cfg.AmbientCtx, s.tcsFactory, s.clock, dbCtx)
 
 	nlActive, nlRenewal := s.cfg.NodeLivenessDurations()
 
@@ -453,7 +453,7 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 		Settings:       st,
 		DB:             s.db,
 		Executor:       internalExecutor,
-		FlowDB:         client.NewDB(s.tcsFactory, s.clock),
+		FlowDB:         client.NewDB(s.cfg.AmbientCtx, s.tcsFactory, s.clock),
 		RPCContext:     s.rpcContext,
 		Stopper:        s.stopper,
 		NodeID:         &s.nodeIDContainer,

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -281,6 +281,7 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 	)
 	dbCtx := client.DefaultDBContext()
 	dbCtx.NodeID = &s.nodeIDContainer
+	dbCtx.Stopper = s.stopper
 	s.db = client.NewDBWithContext(s.cfg.AmbientCtx, s.tcsFactory, s.clock, dbCtx)
 
 	nlActive, nlRenewal := s.cfg.NodeLivenessDurations()

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -670,13 +670,18 @@ func TestHeartbeatCallbackForDecommissioning(t *testing.T) {
 		}
 		break
 	}
-	if _, err := nodeLiveness.SetDecommissioning(context.Background(), ts.nodeIDContainer.Get(), true); err != nil {
+	ctx := context.Background()
+	log.Infof(ctx, "test starting decomissioning")
+	var err error
+	if _, err = nodeLiveness.SetDecommissioning(
+		ctx, ts.nodeIDContainer.Get(), true, /* decomission */
+	); err != nil {
 		t.Fatal(err)
 	}
 
 	// Node should realize it is decommissioning after next heartbeat update.
 	testutils.SucceedsSoon(t, func() error {
-		nodeLiveness.PauseHeartbeat(false) // trigger immediate heartbeat
+		nodeLiveness.PauseHeartbeat(false /* pause */) // trigger immediate heartbeat
 		if liveness, err := nodeLiveness.Self(); err != nil {
 			// Record must exist at this point, so any error is fatal now.
 			t.Fatal(err)

--- a/pkg/sql/conn_executor_prepare.go
+++ b/pkg/sql/conn_executor_prepare.go
@@ -169,6 +169,9 @@ func (ex *connExecutor) prepare(
 	}
 	// Preparing needs a transaction because it needs to retrieve db/table
 	// descriptors for type checking.
+	// TODO(andrei): Needing a transaction for preparing seems non-sensical, as
+	// the prepared statement outlives the txn. I hope that it's not used for
+	// anything other than getting a timestamp.
 	txn := client.NewTxn(ex.server.cfg.DB, ex.server.cfg.NodeID.Get(), client.RootTxn)
 
 	// Create a plan for the statement to figure out the typing, then close the
@@ -216,6 +219,10 @@ func (ex *connExecutor) prepare(
 		prepared.Types = p.semaCtx.Placeholders.Types
 		return nil
 	}(); err != nil {
+		txn.CleanupOnError(ctx, err)
+		return nil, err
+	}
+	if err := txn.CommitOrCleanup(ctx); err != nil {
 		return nil, err
 	}
 

--- a/pkg/sql/txn_state_test.go
+++ b/pkg/sql/txn_state_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
+	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -65,10 +66,11 @@ func makeTestContext() testContext {
 	})
 
 	settings := cluster.MakeTestingClusterSettings()
+	ambient := testutils.MakeAmbientCtx()
 	return testContext{
 		manualClock: manual,
 		clock:       clock,
-		mockDB:      client.NewDB(factory, clock),
+		mockDB:      client.NewDB(ambient, factory, clock),
 		mon: mon.MakeMonitor(
 			"test root mon",
 			mon.MemoryResource,
@@ -78,7 +80,7 @@ func makeTestContext() testContext {
 			1000, /* noteworthy */
 			settings,
 		),
-		tracer:   tracing.NewTracer(),
+		tracer:   ambient.Tracer,
 		ctx:      context.TODO(),
 		settings: settings,
 	}

--- a/pkg/storage/addressing_test.go
+++ b/pkg/storage/addressing_test.go
@@ -141,12 +141,13 @@ func TestUpdateRangeAddressing(t *testing.T) {
 		// interface without sending through a TxnCoordSender (which initializes a
 		// transaction id). Also, we need the TxnCoordSender to clean up the
 		// intents, otherwise the MVCCScan that the test does below fails.
+		actx := testutils.MakeAmbientCtx()
 		tcsf := kv.NewTxnCoordSenderFactory(
-			log.AmbientContext{Tracer: st.Tracer}, st,
+			actx, st,
 			store.TestSender(), store.cfg.Clock,
 			false, stopper, kv.MakeTxnMetrics(time.Second),
 		)
-		db := client.NewDB(tcsf, store.cfg.Clock)
+		db := client.NewDB(actx, tcsf, store.cfg.Clock)
 		txn := client.NewTxn(db, 0 /* gatewayNodeID */, client.RootTxn)
 		ctx := context.Background()
 		if err := txn.Run(ctx, b); err != nil {

--- a/pkg/storage/client_split_test.go
+++ b/pkg/storage/client_split_test.go
@@ -2332,10 +2332,7 @@ func TestDistributedTxnCleanup(t *testing.T) {
 			var txnKey roachpb.Key
 			ctx := context.Background()
 			txn := client.NewTxn(store.DB(), 0 /* gatewayNodeID */, client.RootTxn)
-			opts := client.TxnExecOptions{
-				AutoRetry: false,
-			}
-			if err := txn.Exec(ctx, opts, func(ctx context.Context, txn *client.Txn, _ *client.TxnExecOptions) error {
+			txnFn := func(ctx context.Context, txn *client.Txn) error {
 				b := txn.NewBatch()
 				b.Put(fmt.Sprintf("%s.force=%t,commit=%t", string(lhsKey), force, commit), "lhsValue")
 				b.Put(fmt.Sprintf("%s.force=%t,commit=%t", string(rhsKey), force, commit), "rhsValue")
@@ -2360,14 +2357,15 @@ func TestDistributedTxnCleanup(t *testing.T) {
 					})
 					_, pErr := store.Send(ctx, ba)
 					if pErr != nil {
-						t.Errorf("failed to abort the txn: %s", pErr)
+						t.Fatalf("failed to abort the txn: %s", pErr)
 					}
 				}
 				if commit {
-					return nil
+					return txn.Commit(ctx)
 				}
 				return errors.New("forced abort")
-			}); err != nil {
+			}
+			if err := txnFn(ctx, txn); err != nil {
 				txn.CleanupOnError(ctx, err)
 				if !force && commit {
 					t.Fatalf("expected success with commit == true; got %v", err)

--- a/pkg/storage/client_split_test.go
+++ b/pkg/storage/client_split_test.go
@@ -2333,8 +2333,7 @@ func TestDistributedTxnCleanup(t *testing.T) {
 			ctx := context.Background()
 			txn := client.NewTxn(store.DB(), 0 /* gatewayNodeID */, client.RootTxn)
 			opts := client.TxnExecOptions{
-				AutoCommit: true,
-				AutoRetry:  false,
+				AutoRetry: false,
 			}
 			if err := txn.Exec(ctx, opts, func(ctx context.Context, txn *client.Txn, _ *client.TxnExecOptions) error {
 				b := txn.NewBatch()

--- a/pkg/storage/replica_test.go
+++ b/pkg/storage/replica_test.go
@@ -186,7 +186,7 @@ func (tc *testContext) StartWithStoreConfig(t testing.TB, stopper *stop.Stopper,
 		// circular dependency between the test sender and the store. The actual
 		// store will be passed to the sender after it is created and bootstrapped.
 		factory := &testSenderFactory{}
-		cfg.DB = client.NewDB(factory, cfg.Clock)
+		cfg.DB = client.NewDB(cfg.AmbientCtx, factory, cfg.Clock)
 		tc.store = NewStore(cfg, tc.engine, &roachpb.NodeDescriptor{NodeID: 1})
 		if err := tc.store.Bootstrap(ctx, roachpb.StoreIdent{
 			ClusterID: uuid.MakeV4(),

--- a/pkg/storage/store_test.go
+++ b/pkg/storage/store_test.go
@@ -144,7 +144,7 @@ func createTestStoreWithoutStart(t testing.TB, stopper *stop.Stopper, cfg *Store
 	config.TestingSetupZoneConfigHook(stopper)
 
 	rpcContext := rpc.NewContext(
-		log.AmbientContext{Tracer: cfg.Settings.Tracer}, &base.Config{Insecure: true}, cfg.Clock,
+		cfg.AmbientCtx, &base.Config{Insecure: true}, cfg.Clock,
 		stopper, &cfg.Settings.Version)
 	server := rpc.NewServer(rpcContext) // never started
 	cfg.Gossip = gossip.NewTest(1, rpcContext, server, stopper, metric.NewRegistry())
@@ -163,7 +163,7 @@ func createTestStoreWithoutStart(t testing.TB, stopper *stop.Stopper, cfg *Store
 	stopper.AddCloser(eng)
 	cfg.Transport = NewDummyRaftTransport(cfg.Settings)
 	factory := &testSenderFactory{}
-	cfg.DB = client.NewDB(factory, cfg.Clock)
+	cfg.DB = client.NewDB(cfg.AmbientCtx, factory, cfg.Clock)
 	store := NewStore(*cfg, eng, &roachpb.NodeDescriptor{NodeID: 1})
 	factory.store = store
 	if err := store.Bootstrap(

--- a/pkg/testutils/localtestcluster/local_test_cluster.go
+++ b/pkg/testutils/localtestcluster/local_test_cluster.go
@@ -109,6 +109,7 @@ func (ltc *LocalTestCluster) Start(t testing.TB, baseCtx *base.Config, initFacto
 	factory := initFactory(cfg.Settings, nodeDesc, ambient.Tracer, ltc.Clock, ltc.Latency, ltc.Stores, ltc.Stopper, ltc.Gossip)
 	if ltc.DBContext == nil {
 		dbCtx := client.DefaultDBContext()
+		dbCtx.Stopper = ltc.Stopper
 		ltc.DBContext = &dbCtx
 	}
 	ltc.DBContext.NodeID.Set(context.Background(), nodeID)

--- a/pkg/testutils/localtestcluster/local_test_cluster.go
+++ b/pkg/testutils/localtestcluster/local_test_cluster.go
@@ -112,7 +112,7 @@ func (ltc *LocalTestCluster) Start(t testing.TB, baseCtx *base.Config, initFacto
 		ltc.DBContext = &dbCtx
 	}
 	ltc.DBContext.NodeID.Set(context.Background(), nodeID)
-	ltc.DB = client.NewDBWithContext(factory, ltc.Clock, *ltc.DBContext)
+	ltc.DB = client.NewDBWithContext(cfg.AmbientCtx, factory, ltc.Clock, *ltc.DBContext)
 	transport := storage.NewDummyRaftTransport(cfg.Settings)
 	// By default, disable the replica scanner and split queue, which
 	// confuse tests using LocalTestCluster.

--- a/pkg/testutils/trace.go
+++ b/pkg/testutils/trace.go
@@ -18,7 +18,17 @@ import (
 	"regexp"
 
 	"github.com/pkg/errors"
+
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 )
+
+// MakeAmbientCtx creates an AmbientContext with a Tracer in it.
+func MakeAmbientCtx() log.AmbientContext {
+	return log.AmbientContext{
+		Tracer: tracing.NewTracer(),
+	}
+}
 
 // MatchInOrder matches interprets the given slice of strings as a slice of
 // regular expressions and checks that they match, in order and without overlap,

--- a/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/distributed.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/distributed.tsx
@@ -37,7 +37,6 @@ export default function (props: GraphDashboardProps) {
         <Metric name="cr.node.txn.commits" title="Committed" nonNegativeRate />
         <Metric name="cr.node.txn.commits1PC" title="Fast-path Committed" nonNegativeRate />
         <Metric name="cr.node.txn.aborts" title="Aborted" nonNegativeRate />
-        <Metric name="cr.node.txn.abandons" title="Abandoned" nonNegativeRate />
       </Axis>
     </LineGraph>,
 


### PR DESCRIPTION
Assorted cleanups of the client.Txn interface and the TxnCoordSender. See individual commits. The main point is the last one, which reads:


kv: stop concerning the TxnCoordSender with abandoned txns  …
Before this patch, the TxnCoordSender had a role in cleaning up
abandoned transactions, where abandoned was defined in a funky way:
1) for txns with a cancelable context, a txn was abandoned if the ctx
had been canceled.
2) for the other txns, the txn was considered abandoned if it ran for 10
seconds.

SQL only triggers 1).

The 10 second timeout was a relicv of the past, from a time where the
coordinator was possibly removed from the client. No more, they have
been collocated for years.
In fact, the whole idea of the TCS detecting abandoned txns is a relicv
of that past: all the txn users are already always cleaning up after
themselves.

The pressing motivation for this change is that there's an issue with
checking the context: there is currently no way to pass a ctx with the
same lifetime as the txn to the TxnCoordSender (as it is only a Sender).
And so the TCS was capturing the ctx of the first Send() op as the ctx
of the txn: this was a major hack that's a big problem - we can't have
per-statement contexts, for example. This also restricts the possible
implementations of statement cancelation: we have been forced to cancel
the whole transaction, which is not ideal.

This patch removes TCS' involvement in cleanup by relying on the client
to always send an EndTransaction. SQL was already doing that, as was
everybody else. The TCS is simplified.

The GCQueue maintains its role in detecting abandoned transactions - it
coninues to do so with an one hour timeout. This detection is needed, of
course, since the client is not collocated with the txn's range.

This patch removes the txn.Abandons metric which was maintained by the
TCS. There is a similar metric maintained by the GCQueue. The TCS one
was incorrect anyway, as it was being incremented on ctx cancelation.

Release note: None