### PR TITLE
*: let per-replica constraints specify less than all a zone's replicas

### DIFF
--- a/pkg/config/zone.go
+++ b/pkg/config/zone.go
@@ -343,16 +343,17 @@ func (z *ZoneConfig) Validate() error {
 			}
 			numConstrainedRepls += int64(constraints.NumReplicas)
 			for _, constraint := range constraints.Constraints {
+				// TODO(a-robinson): Relax this constraint to allow prohibited replicas,
+				// as discussed on #23014.
 				if constraint.Type != Constraint_REQUIRED && constraints.NumReplicas != z.NumReplicas {
 					return fmt.Errorf(
 						"only required constraints (prefixed with a '+') can be applied to a subset of replicas")
 				}
 			}
 		}
-		// TODO(a-robinson): Relax this constraint, as discussed on #22412.
-		if numConstrainedRepls != int64(z.NumReplicas) {
-			return fmt.Errorf(
-				"the number of replicas specified in constraints (%d) does not equal the number of replicas configured for the zone (%d)",
+		if numConstrainedRepls > int64(z.NumReplicas) {
+			return fmt.Errorf("the number of replicas specified in constraints (%d) cannot be greater "+
+				"than the number of replicas configured for the zone (%d)",
 				numConstrainedRepls, z.NumReplicas)
 		}
 	}

--- a/pkg/config/zone_test.go
+++ b/pkg/config/zone_test.go
@@ -109,7 +109,7 @@ func TestZoneConfigValidate(t *testing.T) {
 					},
 				},
 			},
-			"the number of replicas specified in constraints .+ does not equal",
+			"the number of replicas specified in constraints .+ cannot be greater than",
 		},
 		{
 			ZoneConfig{
@@ -122,7 +122,7 @@ func TestZoneConfigValidate(t *testing.T) {
 					},
 				},
 			},
-			"the number of replicas specified in constraints .+ does not equal",
+			"",
 		},
 		{
 			ZoneConfig{

--- a/pkg/storage/allocator_scorer.go
+++ b/pkg/storage/allocator_scorer.go
@@ -965,6 +965,11 @@ func storeHasConstraint(store roachpb.StoreDescriptor, c config.Constraint) bool
 
 type analyzedConstraints struct {
 	constraints []config.Constraints
+	// True if the per-replica constraints don't fully cover all the desired
+	// replicas in the range (sum(constraints.NumReplicas) < zone.NumReplicas).
+	// In such cases, we allow replicas that don't match any of the per-replica
+	// constraints, but never mark them as necessary.
+	unconstrainedReplicas bool
 	// For each set of constraints in the above slice, track which StoreIDs
 	// satisfy them. This field is unused if there are no constraints.
 	satisfiedBy [][]roachpb.StoreID
@@ -982,18 +987,20 @@ func analyzeConstraints(
 	ctx context.Context,
 	getStoreDescFn func(roachpb.StoreID) (roachpb.StoreDescriptor, bool),
 	existing []roachpb.ReplicaDescriptor,
-	constraints []config.Constraints,
+	zone config.ZoneConfig,
 ) analyzedConstraints {
 	result := analyzedConstraints{
-		constraints: constraints,
+		constraints: zone.Constraints,
 	}
 
-	if len(constraints) > 0 {
-		result.satisfiedBy = make([][]roachpb.StoreID, len(constraints))
+	if len(zone.Constraints) > 0 {
+		result.satisfiedBy = make([][]roachpb.StoreID, len(zone.Constraints))
 		result.satisfies = make(map[roachpb.StoreID][]int)
 	}
 
-	for i, subConstraints := range constraints {
+	var constrainedReplicas int32
+	for i, subConstraints := range zone.Constraints {
+		constrainedReplicas += subConstraints.NumReplicas
 		for _, repl := range existing {
 			// If for some reason we don't have the store descriptor (which shouldn't
 			// happen once a node is hooked into gossip), trust that it's valid. This
@@ -1005,6 +1012,9 @@ func analyzeConstraints(
 				result.satisfies[store.StoreID] = append(result.satisfies[store.StoreID], i)
 			}
 		}
+	}
+	if constrainedReplicas > 0 && constrainedReplicas < zone.NumReplicas {
+		result.unconstrainedReplicas = true
 	}
 	return result
 }
@@ -1036,6 +1046,10 @@ func allocateConstraintsCheck(
 		}
 	}
 
+	if analyzed.unconstrainedReplicas {
+		valid = true
+	}
+
 	return valid, false
 }
 
@@ -1052,8 +1066,9 @@ func removeConstraintsCheck(
 		return true, false
 	}
 
-	// The store satisfies none of the constraints.
-	if len(analyzed.satisfies[store.StoreID]) == 0 {
+	// The store satisfies none of the constraints, and the zone is not configured
+	// to desire more replicas than constraints have been specified for.
+	if len(analyzed.satisfies[store.StoreID]) == 0 && !analyzed.unconstrainedReplicas {
 		return false, false
 	}
 
@@ -1104,6 +1119,10 @@ func rebalanceFromConstraintsCheck(
 				return true, true
 			}
 		}
+	}
+
+	if analyzed.unconstrainedReplicas {
+		valid = true
 	}
 
 	return valid, false

--- a/pkg/storage/allocator_test.go
+++ b/pkg/storage/allocator_test.go
@@ -385,7 +385,7 @@ func TestAllocatorSimpleRetrieval(t *testing.T) {
 	gossiputil.NewStoreGossiper(g).GossipStores(singleStore, t)
 	result, _, err := a.AllocateTarget(
 		context.Background(),
-		simpleZoneConfig.Constraints,
+		simpleZoneConfig,
 		[]roachpb.ReplicaDescriptor{},
 		firstRangeInfo,
 		false,
@@ -419,7 +419,7 @@ func TestAllocatorCorruptReplica(t *testing.T) {
 
 	result, _, err := a.AllocateTarget(
 		context.Background(),
-		simpleZoneConfig.Constraints,
+		simpleZoneConfig,
 		[]roachpb.ReplicaDescriptor{},
 		firstRangeInfo,
 		false,
@@ -439,7 +439,7 @@ func TestAllocatorNoAvailableDisks(t *testing.T) {
 	defer stopper.Stop(context.Background())
 	result, _, err := a.AllocateTarget(
 		context.Background(),
-		simpleZoneConfig.Constraints,
+		simpleZoneConfig,
 		[]roachpb.ReplicaDescriptor{},
 		firstRangeInfo,
 		false,
@@ -461,7 +461,7 @@ func TestAllocatorTwoDatacenters(t *testing.T) {
 	ctx := context.Background()
 	result1, _, err := a.AllocateTarget(
 		ctx,
-		multiDCConfig.Constraints,
+		multiDCConfig,
 		[]roachpb.ReplicaDescriptor{},
 		firstRangeInfo,
 		false,
@@ -471,7 +471,7 @@ func TestAllocatorTwoDatacenters(t *testing.T) {
 	}
 	result2, _, err := a.AllocateTarget(
 		ctx,
-		multiDCConfig.Constraints,
+		multiDCConfig,
 		[]roachpb.ReplicaDescriptor{{
 			NodeID:  result1.Node.NodeID,
 			StoreID: result1.StoreID,
@@ -490,7 +490,7 @@ func TestAllocatorTwoDatacenters(t *testing.T) {
 	// Verify that no result is forthcoming if we already have a replica.
 	result3, _, err := a.AllocateTarget(
 		ctx,
-		multiDCConfig.Constraints,
+		multiDCConfig,
 		[]roachpb.ReplicaDescriptor{
 			{
 				NodeID:  result1.Node.NodeID,
@@ -517,11 +517,13 @@ func TestAllocatorExistingReplica(t *testing.T) {
 	gossiputil.NewStoreGossiper(g).GossipStores(sameDCStores, t)
 	result, _, err := a.AllocateTarget(
 		context.Background(),
-		[]config.Constraints{
-			{
-				Constraints: []config.Constraint{
-					{Value: "a", Type: config.Constraint_REQUIRED},
-					{Value: "hdd", Type: config.Constraint_REQUIRED},
+		config.ZoneConfig{
+			Constraints: []config.Constraints{
+				{
+					Constraints: []config.Constraint{
+						{Value: "a", Type: config.Constraint_REQUIRED},
+						{Value: "hdd", Type: config.Constraint_REQUIRED},
+					},
 				},
 			},
 		},
@@ -603,7 +605,7 @@ func TestAllocatorRebalance(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		result, _ := a.RebalanceTarget(
 			ctx,
-			nil, /* constraints */
+			config.ZoneConfig{},
 			nil,
 			testRangeInfo([]roachpb.ReplicaDescriptor{{NodeID: 3, StoreID: 3}}, firstRange),
 			storeFilterThrottled,
@@ -758,7 +760,7 @@ func TestAllocatorRebalanceTarget(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		result, details := a.RebalanceTarget(
 			context.Background(),
-			nil, /* constraints */
+			config.ZoneConfig{},
 			status,
 			rangeInfo,
 			storeFilterThrottled,
@@ -778,7 +780,7 @@ func TestAllocatorRebalanceTarget(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		result, details := a.RebalanceTarget(
 			context.Background(),
-			nil, /* constraints */
+			config.ZoneConfig{},
 			status,
 			rangeInfo,
 			storeFilterThrottled,
@@ -795,7 +797,7 @@ func TestAllocatorRebalanceTarget(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		result, details := a.RebalanceTarget(
 			context.Background(),
-			nil, /* constraints */
+			config.ZoneConfig{},
 			status,
 			rangeInfo,
 			storeFilterThrottled,
@@ -881,7 +883,12 @@ func TestAllocatorRebalanceDeadNodes(t *testing.T) {
 	for _, c := range testCases {
 		t.Run("", func(t *testing.T) {
 			result, _ := a.RebalanceTarget(
-				ctx, nil, nil, testRangeInfo(c.existing, firstRange), storeFilterThrottled, false)
+				ctx,
+				config.ZoneConfig{},
+				nil,
+				testRangeInfo(c.existing, firstRange),
+				storeFilterThrottled,
+				false)
 			if c.expected > 0 {
 				if result == nil {
 					t.Fatalf("expected %d, but found nil", c.expected)
@@ -1075,7 +1082,7 @@ func TestAllocatorRebalanceByCount(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		result, _ := a.RebalanceTarget(
 			ctx,
-			nil, /* constraints */
+			config.ZoneConfig{},
 			nil,
 			testRangeInfo([]roachpb.ReplicaDescriptor{{StoreID: stores[0].StoreID}}, firstRange),
 			storeFilterThrottled,
@@ -1326,7 +1333,7 @@ func TestAllocatorRemoveTargetLocality(t *testing.T) {
 		}
 		targetRepl, details, err := a.RemoveTarget(
 			context.Background(),
-			nil, /* constraints */
+			config.ZoneConfig{},
 			existingRepls,
 			testRangeInfo(existingRepls, firstRange),
 			false,
@@ -1410,7 +1417,7 @@ func TestAllocatorAllocateTargetLocality(t *testing.T) {
 		}
 		targetStore, details, err := a.AllocateTarget(
 			context.Background(),
-			nil, /* constraints */
+			config.ZoneConfig{},
 			existingRepls,
 			testRangeInfo(existingRepls, firstRange),
 			false,
@@ -1532,7 +1539,7 @@ func TestAllocatorRebalanceTargetLocality(t *testing.T) {
 		}
 		targetStore, details := a.RebalanceTarget(
 			context.Background(),
-			nil, /* constraints */
+			config.ZoneConfig{},
 			nil,
 			testRangeInfo(existingRepls, firstRange),
 			storeFilterThrottled,
@@ -1649,6 +1656,21 @@ var (
 		{
 			Constraints: []config.Constraint{
 				{Value: "even", Type: config.Constraint_REQUIRED},
+			},
+			NumReplicas: 1,
+		},
+	}
+
+	twoSpecificLocalities = []config.Constraints{
+		{
+			Constraints: []config.Constraint{
+				{Key: "datacenter", Value: "a", Type: config.Constraint_REQUIRED},
+			},
+			NumReplicas: 1,
+		},
+		{
+			Constraints: []config.Constraint{
+				{Key: "datacenter", Value: "b", Type: config.Constraint_REQUIRED},
 			},
 			NumReplicas: 1,
 		},
@@ -1863,8 +1885,9 @@ func TestAllocateCandidatesNumReplicasConstraints(t *testing.T) {
 			}
 		}
 		rangeInfo := testRangeInfo(existingRepls, firstRange)
+		zone := config.ZoneConfig{Constraints: tc.constraints}
 		analyzed := analyzeConstraints(
-			context.Background(), a.storePool.getStoreDescriptor, rangeInfo.Desc.Replicas, tc.constraints)
+			context.Background(), a.storePool.getStoreDescriptor, rangeInfo.Desc.Replicas, zone)
 		candidates := allocateCandidates(
 			sl,
 			analyzed,
@@ -2087,8 +2110,9 @@ func TestRemoveCandidatesNumReplicasConstraints(t *testing.T) {
 			}
 		}
 		rangeInfo := testRangeInfo(existingRepls, firstRange)
+		zone := config.ZoneConfig{Constraints: tc.constraints}
 		analyzed := analyzeConstraints(
-			context.Background(), a.storePool.getStoreDescriptor, rangeInfo.Desc.Replicas, tc.constraints)
+			context.Background(), a.storePool.getStoreDescriptor, rangeInfo.Desc.Replicas, zone)
 		candidates := removeCandidates(
 			sl,
 			analyzed,
@@ -2135,10 +2159,11 @@ func TestRebalanceCandidatesNumReplicasConstraints(t *testing.T) {
 		candidates []roachpb.StoreID
 	}
 	testCases := []struct {
-		constraints  []config.Constraints
-		existing     []roachpb.StoreID
-		expected     []rebalanceStoreIDs
-		validTargets []roachpb.StoreID
+		constraints     []config.Constraints
+		zoneNumReplicas int32
+		existing        []roachpb.StoreID
+		expected        []rebalanceStoreIDs
+		validTargets    []roachpb.StoreID
 	}{
 		{
 			constraints:  threeSpecificLocalities,
@@ -2721,6 +2746,151 @@ func TestRebalanceCandidatesNumReplicasConstraints(t *testing.T) {
 			},
 			validTargets: []roachpb.StoreID{3, 4, 6, 8},
 		},
+		{
+			constraints:     twoSpecificLocalities,
+			zoneNumReplicas: 3,
+			existing:        []roachpb.StoreID{1, 3, 5},
+			expected:        []rebalanceStoreIDs{},
+			validTargets:    []roachpb.StoreID{},
+		},
+		{
+			constraints:     twoSpecificLocalities,
+			zoneNumReplicas: 3,
+			existing:        []roachpb.StoreID{1, 3, 7},
+			expected:        []rebalanceStoreIDs{},
+			validTargets:    []roachpb.StoreID{},
+		},
+		{
+			constraints:     twoSpecificLocalities,
+			zoneNumReplicas: 3,
+			existing:        []roachpb.StoreID{2, 4, 8},
+			expected:        []rebalanceStoreIDs{},
+			validTargets:    []roachpb.StoreID{},
+		},
+		{
+			constraints:     twoSpecificLocalities,
+			zoneNumReplicas: 3,
+			existing:        []roachpb.StoreID{1, 2, 3},
+			expected: []rebalanceStoreIDs{
+				{
+					existing:   []roachpb.StoreID{1},
+					candidates: []roachpb.StoreID{5, 6, 7, 8},
+				},
+				{
+					existing:   []roachpb.StoreID{2},
+					candidates: []roachpb.StoreID{5, 6, 7, 8},
+				},
+			},
+			validTargets: []roachpb.StoreID{5, 6, 7, 8},
+		},
+		{
+			constraints:     twoSpecificLocalities,
+			zoneNumReplicas: 3,
+			existing:        []roachpb.StoreID{2, 3, 4},
+			expected: []rebalanceStoreIDs{
+				{
+					existing:   []roachpb.StoreID{3},
+					candidates: []roachpb.StoreID{5, 6, 7, 8},
+				},
+				{
+					existing:   []roachpb.StoreID{4},
+					candidates: []roachpb.StoreID{5, 6, 7, 8},
+				},
+			},
+			validTargets: []roachpb.StoreID{5, 6, 7, 8},
+		},
+		{
+			constraints:     twoSpecificLocalities,
+			zoneNumReplicas: 3,
+			existing:        []roachpb.StoreID{1, 2, 5},
+			expected: []rebalanceStoreIDs{
+				{
+					existing:   []roachpb.StoreID{1},
+					candidates: []roachpb.StoreID{3, 4},
+				},
+				{
+					existing:   []roachpb.StoreID{2},
+					candidates: []roachpb.StoreID{3, 4},
+				},
+				{
+					existing:   []roachpb.StoreID{5},
+					candidates: []roachpb.StoreID{3, 4},
+				},
+			},
+			validTargets: []roachpb.StoreID{3, 4},
+		},
+		{
+			constraints:     twoSpecificLocalities,
+			zoneNumReplicas: 3,
+			existing:        []roachpb.StoreID{3, 4, 5},
+			expected: []rebalanceStoreIDs{
+				{
+					existing:   []roachpb.StoreID{3},
+					candidates: []roachpb.StoreID{1, 2},
+				},
+				{
+					existing:   []roachpb.StoreID{4},
+					candidates: []roachpb.StoreID{1, 2},
+				},
+				{
+					existing:   []roachpb.StoreID{5},
+					candidates: []roachpb.StoreID{1, 2},
+				},
+			},
+			validTargets: []roachpb.StoreID{1, 2},
+		},
+		{
+			constraints:     twoSpecificLocalities,
+			zoneNumReplicas: 3,
+			existing:        []roachpb.StoreID{1, 5, 7},
+			expected: []rebalanceStoreIDs{
+				{
+					existing:   []roachpb.StoreID{5},
+					candidates: []roachpb.StoreID{3, 4},
+				},
+				{
+					existing:   []roachpb.StoreID{7},
+					candidates: []roachpb.StoreID{3, 4},
+				},
+			},
+			validTargets: []roachpb.StoreID{3, 4},
+		},
+		{
+			constraints:     twoSpecificLocalities,
+			zoneNumReplicas: 3,
+			existing:        []roachpb.StoreID{1, 5, 6},
+			expected: []rebalanceStoreIDs{
+				{
+					existing:   []roachpb.StoreID{5},
+					candidates: []roachpb.StoreID{3, 4},
+				},
+				{
+					existing:   []roachpb.StoreID{6},
+					candidates: []roachpb.StoreID{3, 4},
+				},
+			},
+			validTargets: []roachpb.StoreID{3, 4},
+		},
+		{
+			constraints:     twoSpecificLocalities,
+			zoneNumReplicas: 3,
+			existing:        []roachpb.StoreID{5, 6, 7},
+			expected: []rebalanceStoreIDs{
+				{
+					existing:   []roachpb.StoreID{5},
+					candidates: []roachpb.StoreID{1, 2, 3, 4},
+				},
+				{
+					existing:   []roachpb.StoreID{6},
+					candidates: []roachpb.StoreID{1, 2, 3, 4},
+				},
+				{
+					existing:   []roachpb.StoreID{7},
+					candidates: []roachpb.StoreID{1, 2, 3, 4},
+				},
+			},
+			validTargets: []roachpb.StoreID{1, 2, 3, 4},
+		},
 	}
 
 	for testIdx, tc := range testCases {
@@ -2732,8 +2902,12 @@ func TestRebalanceCandidatesNumReplicasConstraints(t *testing.T) {
 			}
 		}
 		rangeInfo := testRangeInfo(existingRepls, firstRange)
+		zone := config.ZoneConfig{
+			Constraints: tc.constraints,
+			NumReplicas: tc.zoneNumReplicas,
+		}
 		analyzed := analyzeConstraints(
-			context.Background(), a.storePool.getStoreDescriptor, rangeInfo.Desc.Replicas, tc.constraints)
+			context.Background(), a.storePool.getStoreDescriptor, rangeInfo.Desc.Replicas, zone)
 		results := rebalanceCandidates(
 			context.Background(),
 			sl,
@@ -2765,12 +2939,7 @@ func TestRebalanceCandidatesNumReplicasConstraints(t *testing.T) {
 			// Also verify that RebalanceTarget picks out one of the best options as
 			// the final rebalance choice.
 			target, details := a.RebalanceTarget(
-				context.Background(),
-				tc.constraints,
-				nil,
-				rangeInfo,
-				storeFilterThrottled,
-				false)
+				context.Background(), zone, nil, rangeInfo, storeFilterThrottled, false)
 			var found bool
 			if target == nil && len(tc.validTargets) == 0 {
 				found = true
@@ -3143,7 +3312,7 @@ func TestAllocatorRemoveTarget(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		targetRepl, _, err := a.RemoveTarget(
 			ctx,
-			nil, /* constraints */
+			config.ZoneConfig{},
 			replicas,
 			testRangeInfo(replicas, firstRange),
 			false,
@@ -3632,7 +3801,7 @@ func TestAllocatorRebalanceTargetDisableStatsRebalance(t *testing.T) {
 	for i := 0; i < 50; i++ {
 		target, _ := a.RebalanceTarget(
 			context.Background(),
-			nil, /* constraints */
+			config.ZoneConfig{},
 			nil,
 			testRangeInfo(desc.Replicas, desc.RangeID),
 			storeFilterThrottled,
@@ -3646,7 +3815,7 @@ func TestAllocatorRebalanceTargetDisableStatsRebalance(t *testing.T) {
 	for i := 0; i < 50; i++ {
 		target, _ := a.RebalanceTarget(
 			context.Background(),
-			nil, /* constraints */
+			config.ZoneConfig{},
 			nil,
 			testRangeInfo(desc.Replicas, desc.RangeID),
 			storeFilterThrottled,
@@ -4031,7 +4200,7 @@ func TestAllocatorThrottled(t *testing.T) {
 	// First test to make sure we would send the replica to purgatory.
 	_, _, err := a.AllocateTarget(
 		ctx,
-		simpleZoneConfig.Constraints,
+		simpleZoneConfig,
 		[]roachpb.ReplicaDescriptor{},
 		firstRangeInfo,
 		false,
@@ -4044,7 +4213,7 @@ func TestAllocatorThrottled(t *testing.T) {
 	gossiputil.NewStoreGossiper(g).GossipStores(singleStore, t)
 	result, _, err := a.AllocateTarget(
 		ctx,
-		simpleZoneConfig.Constraints,
+		simpleZoneConfig,
 		[]roachpb.ReplicaDescriptor{},
 		firstRangeInfo,
 		false,
@@ -4067,7 +4236,7 @@ func TestAllocatorThrottled(t *testing.T) {
 	a.storePool.detailsMu.Unlock()
 	_, _, err = a.AllocateTarget(
 		ctx,
-		simpleZoneConfig.Constraints,
+		simpleZoneConfig,
 		[]roachpb.ReplicaDescriptor{},
 		firstRangeInfo,
 		false,
@@ -4333,7 +4502,7 @@ func TestAllocatorRebalanceAway(t *testing.T) {
 
 			actual, _ := a.RebalanceTarget(
 				ctx,
-				[]config.Constraints{constraints},
+				config.ZoneConfig{Constraints: []config.Constraints{constraints}},
 				nil,
 				testRangeInfo(existingReplicas, firstRange),
 				storeFilterThrottled,
@@ -4492,7 +4661,7 @@ func TestAllocatorFullDisks(t *testing.T) {
 				if ts.Capacity.RangeCount > 0 {
 					target, details := alloc.RebalanceTarget(
 						ctx,
-						nil, /* constraints */
+						config.ZoneConfig{},
 						nil,
 						testRangeInfo([]roachpb.ReplicaDescriptor{{NodeID: ts.Node.NodeID, StoreID: ts.StoreID}}, firstRange),
 						storeFilterThrottled,
@@ -4612,7 +4781,7 @@ func Example_rebalancing() {
 			ts := &testStores[j]
 			target, details := alloc.RebalanceTarget(
 				context.Background(),
-				nil, /* constraints */
+				config.ZoneConfig{},
 				nil,
 				testRangeInfo([]roachpb.ReplicaDescriptor{{NodeID: ts.Node.NodeID, StoreID: ts.StoreID}}, firstRange),
 				storeFilterThrottled,

--- a/pkg/storage/replicate_queue.go
+++ b/pkg/storage/replicate_queue.go
@@ -180,7 +180,7 @@ func (rq *replicateQueue) shouldQueue(
 	}
 
 	if !rq.store.TestingKnobs().DisableReplicaRebalancing {
-		target, _ := rq.allocator.RebalanceTarget(ctx, zone.Constraints, repl.RaftStatus(), rangeInfo, storeFilterThrottled, false)
+		target, _ := rq.allocator.RebalanceTarget(ctx, zone, repl.RaftStatus(), rangeInfo, storeFilterThrottled, false)
 		if target != nil {
 			log.VEventf(ctx, 2, "rebalance target found, enqueuing")
 			return true, 0
@@ -270,7 +270,7 @@ func (rq *replicateQueue) processOneChange(
 		log.VEventf(ctx, 1, "adding a new replica")
 		newStore, details, err := rq.allocator.AllocateTarget(
 			ctx,
-			zone.Constraints,
+			zone,
 			desc.Replicas,
 			rangeInfo,
 			disableStatsBasedRebalancing,
@@ -305,7 +305,7 @@ func (rq *replicateQueue) processOneChange(
 			})
 			_, _, err := rq.allocator.AllocateTarget(
 				ctx,
-				zone.Constraints,
+				zone,
 				oldPlusNewReplicas,
 				rangeInfo,
 				disableStatsBasedRebalancing,
@@ -344,7 +344,7 @@ func (rq *replicateQueue) processOneChange(
 			return false, errors.Errorf("no removable replicas from range that needs a removal: %s",
 				rangeRaftProgress(repl.RaftStatus(), desc.Replicas))
 		}
-		removeReplica, details, err := rq.allocator.RemoveTarget(ctx, zone.Constraints, candidates, rangeInfo, disableStatsBasedRebalancing)
+		removeReplica, details, err := rq.allocator.RemoveTarget(ctx, zone, candidates, rangeInfo, disableStatsBasedRebalancing)
 		if err != nil {
 			return false, err
 		}
@@ -458,7 +458,7 @@ func (rq *replicateQueue) processOneChange(
 
 		if !rq.store.TestingKnobs().DisableReplicaRebalancing {
 			rebalanceStore, details := rq.allocator.RebalanceTarget(
-				ctx, zone.Constraints, repl.RaftStatus(), rangeInfo, storeFilterThrottled, disableStatsBasedRebalancing)
+				ctx, zone, repl.RaftStatus(), rangeInfo, storeFilterThrottled, disableStatsBasedRebalancing)
 			if rebalanceStore == nil {
 				log.VEventf(ctx, 1, "no suitable rebalance target")
 			} else {


### PR DESCRIPTION
Release note (cli change): Per-replica constraints no longer have to add
up to the total number of replicas in a range. If don't specify all the
replicas, then the remaining replicas will be allowed on any store.