### PR TITLE
sql: support arbitrary grouping columns in groupNode

### DIFF
--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -1037,9 +1037,9 @@ func (dsp *DistSQLPlanner) addAggregators(
 
 	inputTypes := p.ResultTypes
 
-	groupCols := make([]uint32, n.numGroupCols)
-	for i := 0; i < n.numGroupCols; i++ {
-		groupCols[i] = uint32(p.planToStreamColMap[i])
+	groupCols := make([]uint32, len(n.groupCols))
+	for i, idx := range n.groupCols {
+		groupCols[i] = uint32(p.planToStreamColMap[idx])
 	}
 
 	// We either have a local stage on each stream followed by a final stage, or

--- a/pkg/sql/group.go
+++ b/pkg/sql/group.go
@@ -48,9 +48,8 @@ type groupNode struct {
 	// The source node (which returns values that feed into the aggregation).
 	plan planNode
 
-	// The group-by columns are the first numGroupCols columns of
-	// the source plan.
-	numGroupCols int
+	// Indices of the group by columns in the source plan.
+	groupCols []int
 
 	// funcs are the aggregation functions that the renders use.
 	funcs []*aggregateFuncHolder
@@ -232,7 +231,12 @@ func (p *planner) groupBy(
 			groupStrs[symbolicExprStr(e)] = colIdxs[i]
 		}
 	}
-	group.numGroupCols = len(r.render)
+	// Because of the way we set up the pre-projection above, the grouping columns
+	// are always the first columns.
+	group.groupCols = make([]int, len(r.render))
+	for i := range group.groupCols {
+		group.groupCols[i] = i
+	}
 
 	var havingNode *filterNode
 	plan := planNode(group)
@@ -377,7 +381,7 @@ func (n *groupNode) Next(params runParams) (bool, error) {
 		// TODO(dt): optimization: skip buckets when underlying plan is ordered by grouped values.
 
 		bucket := scratch
-		for idx := 0; idx < n.numGroupCols; idx++ {
+		for _, idx := range n.groupCols {
 			var err error
 			bucket, err = sqlbase.EncodeDatum(bucket, values[idx])
 			if err != nil {
@@ -497,7 +501,7 @@ func (n *groupNode) addIsDistinctFromNullFilter(where *filterNode, render *rende
 // instead have another variable (e.g. from the AST) tell us what type
 // of aggregation we're dealing with, and test that here.
 func (n *groupNode) desiredAggregateOrdering(evalCtx *tree.EvalContext) sqlbase.ColumnOrdering {
-	if n.numGroupCols > 0 {
+	if len(n.groupCols) > 0 {
 		return nil
 	}
 

--- a/pkg/sql/group_test.go
+++ b/pkg/sql/group_test.go
@@ -72,7 +72,7 @@ func TestDesiredAggregateOrder(t *testing.T) {
 				t.Fatalf("%s: expected %v, but found %v", d.expr, d.ordering, ordering)
 			}
 			// Verify we never have a desired ordering if there is a GROUP BY.
-			group.numGroupCols = 1
+			group.groupCols = []int{0}
 			ordering = group.desiredAggregateOrdering(p.EvalContext())
 			if len(ordering) > 0 {
 				t.Fatalf("%s: expected no ordering when there is a GROUP BY, found %v", d.expr, ordering)


### PR DESCRIPTION
The grouping columns in groupNode were hardcoded to 0 to
`numGroupCols-1`. Replace `numGroupCols` with a `groupCols` slice to
support arbitrary indices. This is necessary for groupNodes built from
the optimizer.

Release note: None