### PR TITLE
ui: Custom graph debug page

### DIFF
--- a/pkg/ui/src/index.tsx
+++ b/pkg/ui/src/index.tsx
@@ -52,6 +52,7 @@ import Range from "src/views/reports/containers/range";
 import CommandQueue from "src/views/reports/containers/commandQueue";
 import Debug from "src/views/reports/containers/debug";
 import ReduxDebug from "src/views/reports/containers/redux";
+import CustomGraph from "src/views/reports/containers/customgraph";
 import NotFound from "src/views/app/components/NotFound";
 
 import { alertDataSync } from "src/redux/alerts";
@@ -128,6 +129,7 @@ ReactDOM.render(
         <Route path="debug">
           <IndexRoute component={Debug} />
           <Route path="redux" component={ReduxDebug} />
+          <Route path="graph" component={CustomGraph} />
         </Route>
         <Route path="raft" component={ Raft }>
           <IndexRedirect to="ranges" />

--- a/pkg/ui/src/views/cluster/components/linegraph/index.tsx
+++ b/pkg/ui/src/views/cluster/components/linegraph/index.tsx
@@ -111,6 +111,10 @@ export class LineGraph extends React.Component<LineGraphProps, {}> {
       result = moment(new Date(series[index]));
     }
 
+    if (!this.props.hoverState) {
+      return;
+    }
+
     // Only dispatch if we have something to change to avoid action spamming.
     if (this.props.hoverState.hoverChart !== this.props.title || !result.isSame(this.props.hoverState.hoverTime)) {
       this.props.hoverOn({
@@ -141,11 +145,13 @@ export class LineGraph extends React.Component<LineGraphProps, {}> {
         return;
       }
 
-      const { currentlyHovering, hoverChart } = this.props.hoverState;
       let hoverTime: moment.Moment;
-      // Don't draw the linked guideline on the hovered chart, NVD3 does that for us.
-      if (currentlyHovering && hoverChart !== this.props.title) {
-        hoverTime = this.props.hoverState.hoverTime;
+      if (this.props.hoverState) {
+        const { currentlyHovering, hoverChart } = this.props.hoverState;
+        // Don't draw the linked guideline on the hovered chart, NVD3 does that for us.
+        if (currentlyHovering && hoverChart !== this.props.title) {
+          hoverTime = this.props.hoverState.hoverTime;
+        }
       }
 
       ConfigureLineChart(
@@ -172,12 +178,22 @@ export class LineGraph extends React.Component<LineGraphProps, {}> {
   }
 
   render() {
-    const { title, subtitle, tooltip, data } = this.props;
+    const { title, subtitle, tooltip, data, hoverOn} = this.props;
 
-    return <Visualization title={title} subtitle={subtitle} tooltip={tooltip} loading={!data} >
-      <div className="linegraph">
-        <svg className="graph linked-guideline" ref={(svg) => this.graphEl = svg} onMouseMove={this.mouseMove} onMouseLeave={this.mouseLeave} />
-      </div>
-    </Visualization>;
+    let hoverProps: Partial<React.SVGProps<SVGSVGElement>> = {};
+    if (hoverOn) {
+      hoverProps = {
+        onMouseMove: this.mouseMove,
+        onMouseLeave: this.mouseLeave,
+      };
+    }
+
+    return (
+      <Visualization title={title} subtitle={subtitle} tooltip={tooltip} loading={!data} >
+        <div className="linegraph">
+          <svg className="graph linked-guideline" ref={(svg) => this.graphEl = svg} {...hoverProps} />
+        </div>
+      </Visualization>
+    );
   }
 }

--- a/pkg/ui/src/views/reports/containers/customgraph/customMetric.tsx
+++ b/pkg/ui/src/views/reports/containers/customgraph/customMetric.tsx
@@ -1,0 +1,157 @@
+import _ from "lodash";
+import * as React from "react";
+import Select from "react-select";
+
+import * as protos from  "src/js/protos";
+import { DropdownOption } from "src/views/shared/components/dropdown";
+
+import TimeSeriesQueryAggregator = protos.cockroach.ts.tspb.TimeSeriesQueryAggregator;
+import TimeSeriesQueryDerivative = protos.cockroach.ts.tspb.TimeSeriesQueryDerivative;
+
+const aggregatorOptions: DropdownOption[] = [
+  TimeSeriesQueryAggregator.AVG,
+  TimeSeriesQueryAggregator.MAX,
+  TimeSeriesQueryAggregator.MIN,
+  TimeSeriesQueryAggregator.SUM,
+].map(agg => ({ label: TimeSeriesQueryAggregator[agg], value: agg.toString() }));
+
+const derivativeOptions: DropdownOption[] = [
+  { label: "Normal", value: TimeSeriesQueryDerivative.NONE.toString() },
+  { label: "Rate", value: TimeSeriesQueryDerivative.DERIVATIVE.toString() },
+  { label: "Non-negative Rate", value: TimeSeriesQueryDerivative.NON_NEGATIVE_DERIVATIVE.toString() },
+];
+
+export class CustomMetricState {
+  metric: string;
+  downsampler = TimeSeriesQueryAggregator.AVG;
+  aggregator = TimeSeriesQueryAggregator.SUM;
+  derivative = TimeSeriesQueryDerivative.NONE;
+  source = "";
+}
+
+interface CustomMetricRowProps {
+  metricOptions: DropdownOption[];
+  nodeOptions: DropdownOption[];
+  index: number;
+  rowState: CustomMetricState;
+  onChange: (index: number, newState: CustomMetricState) => void;
+  onDelete: (index: number) => void;
+}
+
+export class CustomMetricRow extends React.Component<CustomMetricRowProps> {
+  changeState(newState: Partial<CustomMetricState>) {
+    this.props.onChange(this.props.index, _.assign(this.props.rowState, newState));
+  }
+
+  changeMetric = (selectedOption: DropdownOption) => {
+    this.changeState({
+      metric: selectedOption.value,
+    });
+  }
+
+  changeDownsampler = (selectedOption: DropdownOption) => {
+    this.changeState({
+      downsampler: +selectedOption.value,
+    });
+  }
+
+  changeAggregator = (selectedOption: DropdownOption) => {
+    this.changeState({
+      aggregator: +selectedOption.value,
+    });
+  }
+
+  changeDerivative = (selectedOption: DropdownOption) => {
+    this.changeState({
+      derivative: +selectedOption.value,
+    });
+  }
+
+  changeSource = (selectedOption: DropdownOption) => {
+    this.changeState({
+      source: selectedOption.value,
+    });
+  }
+
+  deleteOption = () => {
+    this.props.onDelete(this.props.index);
+  }
+
+  render() {
+    const {
+      metricOptions,
+      nodeOptions,
+      rowState: { metric, downsampler, aggregator, derivative, source },
+    } = this.props;
+
+    return (
+      <tr>
+        <td>
+          <div className="metric-table-dropdown">
+            <Select
+              className="metric-table-dropdown__select"
+              clearable={true}
+              resetValue=""
+              searchable={true}
+              value={metric}
+              options={metricOptions}
+              onChange={this.changeMetric}
+              placeholder="Select a metric..."
+            />
+          </div>
+        </td>
+        <td>
+          <div className="metric-table-dropdown">
+            <Select
+              className="metric-table-dropdown__select"
+              clearable={false}
+              searchable={false}
+              value={downsampler.toString()}
+              options={aggregatorOptions}
+              onChange={this.changeDownsampler}
+            />
+          </div>
+        </td>
+        <td>
+          <div className="metric-table-dropdown">
+            <Select
+              className="metric-table-dropdown__select"
+              clearable={false}
+              searchable={false}
+              value={aggregator.toString()}
+              options={aggregatorOptions}
+              onChange={this.changeAggregator}
+            />
+          </div>
+        </td>
+        <td>
+          <div className="metric-table-dropdown">
+            <Select
+              className="metric-table-dropdown__select"
+              clearable={false}
+              searchable={false}
+              value={derivative.toString()}
+              options={derivativeOptions}
+              onChange={this.changeDerivative}
+            />
+          </div>
+        </td>
+        <td>
+          <div className="metric-table-dropdown">
+            <Select
+              className="metric-table-dropdown__select"
+              clearable={false}
+              searchable={false}
+              value={source}
+              options={nodeOptions}
+              onChange={this.changeSource}
+            />
+          </div>
+        </td>
+        <td>
+          <button className="metric-edit-button" onClick={this.deleteOption}>Remove</button>
+        </td>
+      </tr>
+    );
+  }
+}

--- a/pkg/ui/src/views/reports/containers/customgraph/customgraph.styl
+++ b/pkg/ui/src/views/reports/containers/customgraph/customgraph.styl
@@ -1,0 +1,49 @@
+@require nib
+@require "~styl/base/palette.styl"
+
+.metric-table-dropdown
+  line-height 17px
+  padding 6px 12px
+  vertical-align middle
+  border-radius 2px
+  padding-right 10px
+  color $body-color
+
+  &:hover
+    background-color $dropdown-hover-color
+
+  &__title
+    vertical-align middle
+    display inline-block
+
+  &__select
+    display inline-block
+    vertical-align middle
+    white-space nowrap
+
+    &:hover
+      background-color $dropdown-hover-color
+
+.metric-edit-button
+    padding 3px 9px
+    margin 0px 9px
+
+    &--add
+      margin 17px 9px
+
+.metric-table
+  &__header
+    background white
+    padding 10px 20px
+    font-family Lato-Regular
+    font-size 12px
+    font-weight bold
+    letter-spacing 2px
+    text-transform uppercase
+    text-align left
+    color $body-color
+
+    &--no-title
+      background inherit
+      padding 0
+

--- a/pkg/ui/src/views/reports/containers/customgraph/index.tsx
+++ b/pkg/ui/src/views/reports/containers/customgraph/index.tsx
@@ -1,0 +1,264 @@
+import _ from "lodash";
+import * as React from "react";
+import { connect } from "react-redux";
+import { withRouter, WithRouterProps } from "react-router";
+import { createSelector } from "reselect";
+
+import { refreshNodes } from "src/redux/apiReducers";
+import { nodesSummarySelector, NodesSummary } from "src/redux/nodes";
+import { AdminUIState } from "src/redux/state";
+import { LineGraph } from "src/views/cluster/components/linegraph";
+import TimeScaleDropdown from "src/views/cluster/containers/timescale";
+import Dropdown, { DropdownOption } from "src/views/shared/components/dropdown";
+import { MetricsDataProvider } from "src/views/shared/containers/metricDataProvider";
+import { Metric, Axis, AxisUnits } from "src/views/shared/components/metricQuery";
+import { PageConfig, PageConfigItem } from "src/views/shared/components/pageconfig";
+
+import { CustomMetricState, CustomMetricRow } from "./customMetric";
+import "./customgraph.styl";
+
+const axisUnitsOptions: DropdownOption[] = [
+  AxisUnits.Count,
+  AxisUnits.Bytes,
+  AxisUnits.Duration,
+].map(au => ({ label: AxisUnits[au], value: au.toString() }));
+
+export interface CustomGraphProps {
+  refreshNodes: typeof refreshNodes;
+  nodesQueryValid: boolean;
+  nodesSummary: NodesSummary;
+}
+
+interface UrlState {
+  metrics: string;
+  units: string;
+}
+
+class CustomGraph extends React.Component<CustomGraphProps & WithRouterProps> {
+  // Selector which computes dropdown options based on the nodes available on
+  // the cluster.
+  private nodeOptions = createSelector(
+    (summary: NodesSummary) => summary.nodeStatuses,
+    (summary: NodesSummary) => summary.nodeDisplayNameByID,
+    (nodeStatuses, nodeDisplayNameByID): DropdownOption[] => {
+      const base = [{value: "", label: "Cluster"}];
+      return base.concat(_.map(nodeStatuses, (ns) => {
+        return {
+          value: ns.desc.node_id.toString(),
+          label: nodeDisplayNameByID[ns.desc.node_id],
+        };
+      }));
+    },
+  );
+
+  // Selector which computes dropdown options based on the metrics which are
+  // currently being stored on the cluster.
+  private metricOptions = createSelector(
+    (summary: NodesSummary) => summary.nodeStatuses,
+    (nodeStatuses): DropdownOption[] => {
+      if (_.isEmpty(nodeStatuses)) {
+        return [];
+      }
+
+      return _.keys(nodeStatuses[0].metrics).map(k => {
+        const fullMetricName =
+          _.has(nodeStatuses[0].store_statuses[0].metrics, k)
+          ? "cr.store." + k
+          : "cr.node." + k;
+
+        return {
+          value: fullMetricName,
+          label: k,
+        };
+      });
+    },
+  );
+
+  static title() {
+    return "Custom Graph";
+  }
+
+  refresh(props = this.props) {
+    if (!props.nodesQueryValid) {
+      props.refreshNodes();
+    }
+  }
+
+  componentWillMount() {
+    this.refresh();
+  }
+
+  componentWillReceiveProps(props: CustomGraphProps & WithRouterProps) {
+    this.refresh(props);
+  }
+
+  currentMetrics(): CustomMetricState[] {
+    try {
+      return JSON.parse(this.props.location.query.metrics);
+    } catch (e) {
+      return [];
+    }
+  }
+
+  updateUrl(newState: Partial<UrlState>) {
+    const pathname = this.props.location.pathname;
+    this.props.router.push({
+      pathname,
+      query: _.assign({}, this.props.location.query, newState),
+    });
+  }
+
+  updateUrlMetrics(newState: CustomMetricState[]) {
+    const metrics = JSON.stringify(newState);
+    this.updateUrl({
+      metrics,
+    });
+  }
+
+  updateMetricRow = (index: number, newState: CustomMetricState) => {
+    const arr = this.currentMetrics().slice();
+    arr[index] = newState;
+    this.updateUrlMetrics(arr);
+  }
+
+  addMetric = () => {
+    this.updateUrlMetrics([...this.currentMetrics(), new CustomMetricState()]);
+  }
+
+  removeMetric = (index: number) => {
+    const metrics = this.currentMetrics();
+    this.updateUrlMetrics(metrics.slice(0, index).concat(metrics.slice(index + 1)));
+  }
+
+  currentAxisUnits(): AxisUnits {
+    return +this.props.location.query.units || AxisUnits.Count;
+  }
+
+  changeAxisUnits = (selected: DropdownOption) => {
+    this.updateUrl({
+      units: selected.value,
+    });
+  }
+
+  // Render a graph of the currently selected metrics.
+  renderGraph() {
+    const metrics = this.currentMetrics();
+    const units = this.currentAxisUnits();
+    if (_.isEmpty(metrics)) {
+      return (
+        <section className="section">
+          <h3>Click "Add Metric" to add a metric to the custom graph.</h3>
+        </section>
+      );
+    }
+
+    return (
+      <section className="section">
+        <MetricsDataProvider id="debug-custom-graph">
+          <LineGraph>
+            <Axis units={units}>
+              {
+                metrics.map((m, i) => {
+                  if (m.metric !== "") {
+                    return (
+                      <Metric
+                        key={i}
+                        title={m.metric}
+                        name={m.metric}
+                        aggregator={m.aggregator}
+                        downsampler={m.downsampler}
+                        derivative={m.derivative}
+                        sources={m.source === "" ? [] : [m.source]}
+                      />
+                    );
+                  }
+                  return "";
+                })
+              }
+            </Axis>
+          </LineGraph>
+        </MetricsDataProvider>
+      </section>
+    );
+  }
+
+  // Render a table containing all of the currently added metrics, with editing
+  // inputs for each metric.
+  renderMetricsTable() {
+    const metrics = this.currentMetrics();
+    let table: JSX.Element = null;
+
+    if (!_.isEmpty(metrics)) {
+      table = (
+        <table className="metric-table">
+          <thead>
+            <tr>
+              <td className="metric-table__header">Metric Name</td>
+              <td className="metric-table__header">Downsampler</td>
+              <td className="metric-table__header">Aggregator</td>
+              <td className="metric-table__header">Rate</td>
+              <td className="metric-table__header">Source</td>
+              <td className="metric-table__header metric-table__header--no-title"></td>
+            </tr>
+          </thead>
+          <tbody>
+            { metrics.map((row, i) =>
+              <CustomMetricRow
+                key={i}
+                metricOptions={this.metricOptions(this.props.nodesSummary)}
+                nodeOptions={this.nodeOptions(this.props.nodesSummary)}
+                index={i}
+                rowState={row}
+                onChange={this.updateMetricRow}
+                onDelete={this.removeMetric}
+              />,
+            )}
+          </tbody>
+        </table>
+      );
+    }
+
+    return (
+      <section className="section">
+        { table }
+        <button className="metric-edit-button metric-edit-button--add" onClick={this.addMetric}>Add Metric</button>
+      </section>
+    );
+  }
+
+  render() {
+    const units = this.currentAxisUnits();
+    return (
+      <div>
+        <PageConfig>
+          <PageConfigItem>
+            <TimeScaleDropdown />
+          </PageConfigItem>
+          <PageConfigItem>
+            <Dropdown
+              title="Units"
+              selected={units.toString()}
+              options={axisUnitsOptions}
+              onChange={this.changeAxisUnits}
+            />
+          </PageConfigItem>
+        </PageConfig>
+        { this.renderGraph() }
+        { this.renderMetricsTable() }
+      </div>
+    );
+  }
+}
+
+function mapStateToProps(state: AdminUIState) {
+  return {
+    nodesSummary: nodesSummarySelector(state),
+    nodesQueryValid: state.cachedData.nodes.valid,
+  };
+}
+
+const mapDispatchToProps = {
+  refreshNodes,
+};
+
+export default connect(mapStateToProps, mapDispatchToProps)(withRouter(CustomGraph));

--- a/pkg/ui/src/views/reports/containers/debug/index.tsx
+++ b/pkg/ui/src/views/reports/containers/debug/index.tsx
@@ -221,6 +221,12 @@ export default function Debug() {
             url="#/debug/redux"
           />
         </DebugTableRow>
+        <DebugTableRow title="Custom Time-Series Graph">
+          <DebugTableLink
+            name="Customizable graph of time series metrics"
+            url="#/debug/graph"
+          />
+        </DebugTableRow>
       </DebugTable>
       <LicenseType />
     </div>

--- a/pkg/ui/src/views/shared/components/metricQuery/index.tsx
+++ b/pkg/ui/src/views/shared/components/metricQuery/index.tsx
@@ -23,6 +23,8 @@ import React from "react";
 import * as protos from  "src/js/protos";
 
 type TSResponse = protos.cockroach.ts.tspb.TimeSeriesQueryResponse;
+import TimeSeriesQueryAggregator = protos.cockroach.ts.tspb.TimeSeriesQueryAggregator;
+import TimeSeriesQueryDerivative = protos.cockroach.ts.tspb.TimeSeriesQueryDerivative;
 
 /**
  * AxisUnits is an enumeration used to specify the type of units being displayed
@@ -74,6 +76,16 @@ export class Axis extends React.Component<AxisProps, {}> {
 /**
  * MetricProps reperesents the properties of a Metric being selected as part of
  * a query.
+ *
+ * Note that there are redundant specifiers for several of the options
+ * (derivatives, aggregators, downsamplers). These exist because, while the
+ * exact specifiers (e.g. "aggregator") are convenient when constructing metrics
+ * programmatically, the boolean specifiers (e.g. "aggregateMax") are convenient
+ * when writing JSX directly. This is purely a syntactic helper.
+ *
+ * Only one option should be specified for each of the (derivative, aggregator,
+ * downsampler); if multiple options are specified, the exact specifier takes
+ * precedence.
  */
 export interface MetricProps {
   name: string;
@@ -86,6 +98,9 @@ export interface MetricProps {
   aggregateAvg?: boolean;
   downsampleMax?: boolean;
   downsampleMin?: boolean;
+  derivative?: TimeSeriesQueryDerivative;
+  aggregator?: TimeSeriesQueryAggregator;
+  downsampler?: TimeSeriesQueryAggregator;
 }
 
 /**

--- a/pkg/ui/src/views/shared/containers/metricDataProvider/index.tsx
+++ b/pkg/ui/src/views/shared/containers/metricDataProvider/index.tsx
@@ -27,19 +27,25 @@ function queryFromProps(
     let downsampler = protos.cockroach.ts.tspb.TimeSeriesQueryAggregator.AVG;
 
     // Compute derivative function.
-    if (metricProps.rate) {
+    if (!_.isNil(metricProps.derivative)) {
+      derivative = metricProps.derivative;
+    } else if (metricProps.rate) {
       derivative = protos.cockroach.ts.tspb.TimeSeriesQueryDerivative.DERIVATIVE;
     } else if (metricProps.nonNegativeRate) {
       derivative = protos.cockroach.ts.tspb.TimeSeriesQueryDerivative.NON_NEGATIVE_DERIVATIVE;
     }
     // Compute downsample function.
-    if (metricProps.downsampleMax) {
+    if (!_.isNil(metricProps.downsampler)) {
+      downsampler = metricProps.downsampler;
+    } else if (metricProps.downsampleMax) {
       downsampler = protos.cockroach.ts.tspb.TimeSeriesQueryAggregator.MAX;
     } else if (metricProps.downsampleMin) {
       downsampler = protos.cockroach.ts.tspb.TimeSeriesQueryAggregator.MIN;
     }
     // Compute aggregation function.
-    if (metricProps.aggregateMax) {
+    if (!_.isNil(metricProps.aggregator)) {
+      sourceAggregator = metricProps.aggregator;
+    } else if (metricProps.aggregateMax) {
       sourceAggregator = protos.cockroach.ts.tspb.TimeSeriesQueryAggregator.MAX;
     } else if (metricProps.aggregateMin) {
       sourceAggregator = protos.cockroach.ts.tspb.TimeSeriesQueryAggregator.MIN;

--- a/pkg/ui/styl/shame.styl
+++ b/pkg/ui/styl/shame.styl
@@ -11,7 +11,7 @@
   &.is-selected
     color $link-color !important
 
-.Select-value
+.Select-value, .Select-placeholder
   line-height inherit !important
   height auto !important
   position relative !important
@@ -58,7 +58,7 @@
   border-top-color $link-color !important
 
 .Select
-  display inline-block
+  display block
   width 100%
 
 .dropdown--side-arrows


### PR DESCRIPTION
Two commits
+ A small update to LineGraph to support graphs without line-related hover events
+ The custom graph debug page

Adds a debug page which allows users to create a "custom" graph,
displaying any combination of metrics they wish. The currently selected
metrics are stored in the URL, so graphs can be shared by copying the
link.

<img width="1431" alt="screen shot 2018-02-25 at 9 22 44 pm" src="https://user-images.githubusercontent.com/6969858/36650698-d58ca892-1a72-11e8-8b1a-56ba7a9ce5dc.png">
