### PR TITLE
opt: consolidate consecutive spans

### DIFF
--- a/pkg/sql/opt/idxconstraint/index_constraints.go
+++ b/pkg/sql/opt/idxconstraint/index_constraints.go
@@ -1070,9 +1070,10 @@ type IndexConstraints struct {
 
 	filter xform.ExprView
 
-	spansPopulated bool
-	spansTight     bool
-	spans          LogicalSpans
+	spansPopulated    bool
+	spansTight        bool
+	spans             LogicalSpans
+	consolidatedSpans LogicalSpans
 }
 
 // Init processes the filter and calculates the spans.
@@ -1092,15 +1093,33 @@ func (ic *IndexConstraints) Init(
 	} else {
 		ic.spans, ic.spansPopulated, ic.spansTight = ic.makeSpansForExpr(0 /* offset */, ic.filter)
 	}
+	// Note: we only consolidate spans at the end; consolidating partial results
+	// can lead to worse spans, for example:
+	//   a IN (1, 2) AND b = 4
+	//
+	// We want this to be:
+	//   [/1/4 - /1/4]
+	//   [/2/4 - /2/4]
+	//
+	// If we eagerly consolidate the spans for a, we would get loose spans:
+	//   [/1/4 - /2/4]
+	//
+	// We also want to remember the original spans because the filter
+	// simplification code works better with them. For example:
+	//   @1 = 1 AND @2 IN (1, 2)
+	// The filter simplification code is able to simplify both expressions
+	// if we have the spans [/1/1 - /1/1], [/1/2 - /1/2] but not if
+	// we have [/1/1 - /1/2].
+	ic.consolidatedSpans = ic.consolidateSpans(0 /* offset */, ic.spans)
 }
 
 // Spans returns the spans created by Init. If ok is false, no constraints
 // could be generated.
 func (ic *IndexConstraints) Spans() (_ LogicalSpans, ok bool) {
-	if !ic.spansPopulated || (len(ic.spans) == 1 && ic.spans[0].IsFullSpan()) {
+	if !ic.spansPopulated || (len(ic.consolidatedSpans) == 1 && ic.consolidatedSpans[0].IsFullSpan()) {
 		return nil, false
 	}
-	return ic.spans, true
+	return ic.consolidatedSpans, true
 }
 
 // RemainingFilter calculates a simplified filter that needs to be applied

--- a/pkg/sql/opt/idxconstraint/spans.go
+++ b/pkg/sql/opt/idxconstraint/spans.go
@@ -492,6 +492,55 @@ func (c *indexConstraintCtx) mergeSpanSets(
 	return result
 }
 
+// areKeysConsecutive returns true if:
+//  - a and b are both inclusive,
+//  - a and b have the same length,
+//  - all but the last datums match between a and b,
+//  - the last datum of b is the next datum after a (for types that support it).
+func (c *indexConstraintCtx) areKeysConsecutive(offset int, a, b LogicalKey) bool {
+	if !a.Inclusive || !b.Inclusive {
+		return false
+	}
+	n := len(a.Vals)
+	if len(b.Vals) != n {
+		return false
+	}
+	// All the datums up to the last one must be equal.
+	if c.compareKeyVals(offset, a.Vals[:n-1], b.Vals[:n-1]) != 0 {
+		return false
+	}
+	next, ok := c.nextDatum(a.Vals[n-1], c.colInfos[offset+n-1].Direction)
+	if !ok {
+		return false
+	}
+	return next.Compare(c.evalCtx, b.Vals[n-1]) == 0
+}
+
+// consolidateSpans merges spans that have consecutive keys, for example:
+// [/1 - /2], [/3 - /4] are equivalent to [/1 - /4].
+func (c *indexConstraintCtx) consolidateSpans(offset int, spans LogicalSpans) LogicalSpans {
+	var result LogicalSpans
+	for i := 1; i < len(spans); i++ {
+		if c.areKeysConsecutive(offset, spans[i-1].End, spans[i].Start) {
+			// We only allocate the result if we need to change something.
+			if result == nil {
+				result = make(LogicalSpans, 0, len(spans)-1)
+				result = append(result, spans[:i]...)
+			}
+			// Adjust the last span.
+			result[len(result)-1].End = spans[i].End
+		} else {
+			if result != nil {
+				result = append(result, spans[i])
+			}
+		}
+	}
+	if result == nil {
+		return spans
+	}
+	return result
+}
+
 // isSpanSubset returns true if the spans in a are completely
 // contained in the spans in b.
 func (c *indexConstraintCtx) isSpanSubset(offset int, a LogicalSpans, b LogicalSpans) bool {

--- a/pkg/sql/opt/idxconstraint/testdata/inverted
+++ b/pkg/sql/opt/idxconstraint/testdata/inverted
@@ -26,4 +26,3 @@ index-constraints vars=(jsonb, int) inverted-index=@1
 ----
 [/'{"a": 1}' - /'{"a": 1}']
 Remaining filter: (@2 = 1) AND (@1 @> '{"b": 1}')
-

--- a/pkg/sql/opt/idxconstraint/testdata/misc
+++ b/pkg/sql/opt/idxconstraint/testdata/misc
@@ -87,8 +87,7 @@ Remaining filter: @1 = @2
 index-constraints vars=(int) index=(@1)
 @1 = 1 OR @1 = 2
 ----
-[/1 - /1]
-[/2 - /2]
+[/1 - /2]
 
 index-constraints vars=(int) index=(@1)
 @1 IS NULL OR @1 = 1
@@ -112,15 +111,13 @@ Remaining filter: (@1 <= 3) OR (@1 >= 5)
 index-constraints vars=(int, int) index=(@1)
 (@1 = 1 AND @2 = 5) OR (@1 = 2 and @2 = 6)
 ----
-[/1 - /1]
-[/2 - /2]
+[/1 - /2]
 Remaining filter: ((@1 = 1) AND (@2 = 5)) OR ((@1 = 2) AND (@2 = 6))
 
 index-constraints vars=(int, int) index=(@2)
 (@1 = 1 AND @2 = 5) OR (@1 = 2 and @2 = 6)
 ----
-[/5 - /5]
-[/6 - /6]
+[/5 - /6]
 Remaining filter: ((@1 = 1) AND (@2 = 5)) OR ((@1 = 2) AND (@2 = 6))
 
 index-constraints vars=(int, int) index=(@2)
@@ -150,8 +147,7 @@ Remaining filter: ((@1 = 1) OR ((@1 = 2) AND ((@2, @3) IN ((4, 5), (6, 7))))) OR
 index-constraints vars=(int, int) index=(@1, @2)
 @1 = 1 AND (@2 = 2 OR @2 = 3)
 ----
-[/1/2 - /1/2]
-[/1/3 - /1/3]
+[/1/2 - /1/3]
 Remaining filter: (@2 = 2) OR (@2 = 3)
 
 index-constraints vars=(int, int, int) index=(@1, @2, @3)
@@ -187,9 +183,7 @@ Remaining filter: @2 = CASE WHEN @3 = 2 THEN 1 ELSE 2 END
 index-constraints vars=(int, int, int, int) index=(@1, @2, @3, @4) nonormalize
 @1 = 1 AND @2 = 2 AND @3 = 3 AND @4 IN (4,5,6)
 ----
-[/1/2/3/4 - /1/2/3/4]
-[/1/2/3/5 - /1/2/3/5]
-[/1/2/3/6 - /1/2/3/6]
+[/1/2/3/4 - /1/2/3/6]
 Remaining filter: ((true AND true) AND true) AND true
 
 index-constraints vars=(int, int) index=(@1, @2)

--- a/pkg/sql/opt/idxconstraint/testdata/multi-column
+++ b/pkg/sql/opt/idxconstraint/testdata/multi-column
@@ -115,4 +115,3 @@ index-constraints vars=(int, int) index=(@1, @2)
 ----
 (/1/NULL - /5]
 Remaining filter: @2 != 2
-

--- a/pkg/sql/opt/idxconstraint/testdata/single-column
+++ b/pkg/sql/opt/idxconstraint/testdata/single-column
@@ -149,4 +149,3 @@ index-constraints vars=(bool) index=(@1)
 NOT @1
 ----
 [/false - /false]
-

--- a/pkg/sql/opt/idxconstraint/testdata/tuple
+++ b/pkg/sql/opt/idxconstraint/testdata/tuple
@@ -3,72 +3,52 @@
 index-constraints vars=(int) index=(@1)
 @1 IN (1, 2, 3)
 ----
-[/1 - /1]
-[/2 - /2]
-[/3 - /3]
+[/1 - /3]
 
 index-constraints vars=(int) index=(@1 desc)
 @1 IN (1, 2, 3)
 ----
-[/3 - /3]
-[/2 - /2]
-[/1 - /1]
+[/3 - /1]
 
 index-constraints vars=(int) index=(@1) semtree-normalize
 @1 IN (1, 5, 1, 4)
 ----
 [/1 - /1]
-[/4 - /4]
-[/5 - /5]
+[/4 - /5]
 
 index-constraints vars=(int) index=(@1 desc) semtree-normalize
 @1 IN (1, 5, 1, 4)
 ----
-[/5 - /5]
-[/4 - /4]
+[/5 - /4]
 [/1 - /1]
 
 index-constraints vars=(int) index=(@1)
 @1 IN (1, 2, 3, NULL)
 ----
-[/1 - /1]
-[/2 - /2]
-[/3 - /3]
+[/1 - /3]
 
 index-constraints vars=(int, int) index=(@1, @2)
 @1 = 1 AND @2 IN (1, 2, 3)
 ----
-[/1/1 - /1/1]
-[/1/2 - /1/2]
-[/1/3 - /1/3]
+[/1/1 - /1/3]
 
 index-constraints vars=(int, int) index=(@1, @2 desc)
 @1 = 1 AND @2 IN (1, 2, 3)
 ----
-[/1/3 - /1/3]
-[/1/2 - /1/2]
-[/1/1 - /1/1]
+[/1/3 - /1/1]
 
 index-constraints vars=(int, int) index=(@1, @2)
 @1 IN (1, 2) AND @2 IN (1, 2, 3)
 ----
-[/1/1 - /1/1]
-[/1/2 - /1/2]
-[/1/3 - /1/3]
-[/2/1 - /2/1]
-[/2/2 - /2/2]
-[/2/3 - /2/3]
+[/1/1 - /1/3]
+[/2/1 - /2/3]
 Remaining filter: @2 IN (1, 2, 3)
 
 index-constraints vars=(int, int) index=(@1 desc, @2 desc)
 @1 IN (1, 2) AND @2 IN (1, 2, 3)
 ----
-[/2/3 - /2/3]
-[/2/2 - /2/2]
-[/2/1 - /2/1]
-[/1/3 - /1/3]
-[/1/2 - /1/2]
-[/1/1 - /1/1]
+[/2/3 - /2/1]
+[/1/3 - /1/1]
 Remaining filter: @2 IN (1, 2, 3)
 
 index-constraints vars=(int, int) index=(@1, @2)
@@ -497,8 +477,7 @@ Remaining filter: (@1, @2, @3, @4) IN ((1, 5, 1, 5), (2, 4, 2, 4), (3, 5, 3, 5))
 index-constraints vars=(int, int, int, int) index=(@2)
 (@1, @2, @3, @4) IN ((1, 5, 1, 5), (2, 4, 2, 4), (3, 5, 3, 5))
 ----
-[/4 - /4]
-[/5 - /5]
+[/4 - /5]
 Remaining filter: (@1, @2, @3, @4) IN ((1, 5, 1, 5), (2, 4, 2, 4), (3, 5, 3, 5))
 
 index-constraints vars=(int, int) index=(@1, @2)
@@ -568,4 +547,3 @@ index-constraints vars=(int, int, int) index=(@1, @2, @3)
 ----
 [/2/2/3 - ]
 Remaining filter: (@2, @3) IN ((2, 3), (4, 5), (6, 7))
-


### PR DESCRIPTION
This is a port of PR #22823 (for issue #22451).

The index constraint generation code can return spans like
[/1 - /1], [/2 - /2], [/3 - /3]; this change adds post-processing of
the spans to obtain [/1 - /3].

Release note: None