### PR TITLE
cherrypick-2.0: config/storage: Expressive zone config follow-ups

### DIFF
--- a/pkg/config/zone.go
+++ b/pkg/config/zone.go
@@ -343,16 +343,17 @@ func (z *ZoneConfig) Validate() error {
 			}
 			numConstrainedRepls += int64(constraints.NumReplicas)
 			for _, constraint := range constraints.Constraints {
+				// TODO(a-robinson): Relax this constraint to allow prohibited replicas,
+				// as discussed on #23014.
 				if constraint.Type != Constraint_REQUIRED && constraints.NumReplicas != z.NumReplicas {
 					return fmt.Errorf(
 						"only required constraints (prefixed with a '+') can be applied to a subset of replicas")
 				}
 			}
 		}
-		// TODO(a-robinson): Relax this constraint, as discussed on #22412.
-		if numConstrainedRepls != int64(z.NumReplicas) {
-			return fmt.Errorf(
-				"the number of replicas specified in constraints (%d) does not equal the number of replicas configured for the zone (%d)",
+		if numConstrainedRepls > int64(z.NumReplicas) {
+			return fmt.Errorf("the number of replicas specified in constraints (%d) cannot be greater "+
+				"than the number of replicas configured for the zone (%d)",
 				numConstrainedRepls, z.NumReplicas)
 		}
 	}

--- a/pkg/config/zone.go
+++ b/pkg/config/zone.go
@@ -303,24 +303,38 @@ func (z *ZoneConfig) Validate() error {
 			return err
 		}
 	}
-	switch z.NumReplicas {
-	case 0:
+
+	switch {
+	case z.NumReplicas < 0:
+		return fmt.Errorf("at least one replica is required")
+	case z.NumReplicas == 0:
 		if len(z.Subzones) > 0 {
 			// NumReplicas == 0 is allowed when this ZoneConfig is a subzone
 			// placeholder. See IsSubzonePlaceholder.
 			return nil
 		}
 		return fmt.Errorf("at least one replica is required")
-	case 2:
+	case z.NumReplicas == 2:
 		return fmt.Errorf("at least 3 replicas are required for multi-replica configurations")
 	}
+
 	if z.RangeMaxBytes < minRangeMaxBytes {
 		return fmt.Errorf("RangeMaxBytes %d less than minimum allowed %d",
 			z.RangeMaxBytes, minRangeMaxBytes)
 	}
+
+	if z.RangeMinBytes < 0 {
+		return fmt.Errorf("RangeMinBytes %d less than minimum allowed 0", z.RangeMinBytes)
+	}
 	if z.RangeMinBytes >= z.RangeMaxBytes {
 		return fmt.Errorf("RangeMinBytes %d is greater than or equal to RangeMaxBytes %d",
 			z.RangeMinBytes, z.RangeMaxBytes)
+	}
+
+	// Reserve the value 0 to potentially have some special meaning in the future,
+	// such as to disable GC.
+	if z.GC.TTLSeconds < 1 {
+		return fmt.Errorf("GC.TTLSeconds %d less than minimum allowed 1", z.GC.TTLSeconds)
 	}
 
 	for _, constraints := range z.Constraints {
@@ -357,6 +371,7 @@ func (z *ZoneConfig) Validate() error {
 				numConstrainedRepls, z.NumReplicas)
 		}
 	}
+
 	return nil
 }
 

--- a/pkg/config/zone.go
+++ b/pkg/config/zone.go
@@ -347,9 +347,6 @@ func (z *ZoneConfig) Validate() error {
 					return fmt.Errorf(
 						"only required constraints (prefixed with a '+') can be applied to a subset of replicas")
 				}
-				if strings.Contains(constraint.Key, ":") || strings.Contains(constraint.Value, ":") {
-					return fmt.Errorf("the ':' character is not allowed in constraint keys or values")
-				}
 			}
 		}
 		// TODO(a-robinson): Relax this constraint, as discussed on #22412.

--- a/pkg/config/zone_test.go
+++ b/pkg/config/zone_test.go
@@ -109,7 +109,7 @@ func TestZoneConfigValidate(t *testing.T) {
 					},
 				},
 			},
-			"the number of replicas specified in constraints .+ does not equal",
+			"the number of replicas specified in constraints .+ cannot be greater than",
 		},
 		{
 			ZoneConfig{
@@ -122,7 +122,7 @@ func TestZoneConfigValidate(t *testing.T) {
 					},
 				},
 			},
-			"the number of replicas specified in constraints .+ does not equal",
+			"",
 		},
 		{
 			ZoneConfig{

--- a/pkg/config/zone_test.go
+++ b/pkg/config/zone_test.go
@@ -80,6 +80,29 @@ func TestZoneConfigValidate(t *testing.T) {
 				NumReplicas:   1,
 				RangeMaxBytes: DefaultZoneConfig().RangeMaxBytes,
 				Constraints: []Constraints{
+					{Constraints: []Constraint{{Value: "a", Type: Constraint_PROHIBITED}}},
+				},
+			},
+			"",
+		},
+		{
+			ZoneConfig{
+				NumReplicas:   1,
+				RangeMaxBytes: DefaultZoneConfig().RangeMaxBytes,
+				Constraints: []Constraints{
+					{
+						Constraints: []Constraint{{Value: "a", Type: Constraint_PROHIBITED}},
+						NumReplicas: 1,
+					},
+				},
+			},
+			"",
+		},
+		{
+			ZoneConfig{
+				NumReplicas:   1,
+				RangeMaxBytes: DefaultZoneConfig().RangeMaxBytes,
+				Constraints: []Constraints{
 					{
 						Constraints: []Constraint{{Value: "a", Type: Constraint_REQUIRED}},
 						NumReplicas: 2,
@@ -117,6 +140,23 @@ func TestZoneConfigValidate(t *testing.T) {
 				},
 			},
 			"constraints must apply to at least one replica",
+		},
+		{
+			ZoneConfig{
+				NumReplicas:   3,
+				RangeMaxBytes: DefaultZoneConfig().RangeMaxBytes,
+				Constraints: []Constraints{
+					{
+						Constraints: []Constraint{{Value: "a", Type: Constraint_REQUIRED}},
+						NumReplicas: 2,
+					},
+					{
+						Constraints: []Constraint{{Value: "b", Type: Constraint_PROHIBITED}},
+						NumReplicas: 1,
+					},
+				},
+			},
+			"only required constraints .+ can be applied to a subset of replicas",
 		},
 	}
 

--- a/pkg/config/zone_test.go
+++ b/pkg/config/zone_test.go
@@ -40,6 +40,12 @@ func TestZoneConfigValidate(t *testing.T) {
 		},
 		{
 			ZoneConfig{
+				NumReplicas: -1,
+			},
+			"at least one replica is required",
+		},
+		{
+			ZoneConfig{
 				NumReplicas: 2,
 			},
 			"at least 3 replicas are required for multi-replica configurations",
@@ -55,13 +61,31 @@ func TestZoneConfigValidate(t *testing.T) {
 				NumReplicas:   1,
 				RangeMaxBytes: DefaultZoneConfig().RangeMaxBytes,
 			},
+			"GC.TTLSeconds 0 less than minimum allowed",
+		},
+		{
+			ZoneConfig{
+				NumReplicas:   1,
+				RangeMaxBytes: DefaultZoneConfig().RangeMaxBytes,
+				GC:            GCPolicy{TTLSeconds: 1},
+			},
 			"",
+		},
+		{
+			ZoneConfig{
+				NumReplicas:   1,
+				RangeMinBytes: -1,
+				RangeMaxBytes: DefaultZoneConfig().RangeMaxBytes,
+				GC:            GCPolicy{TTLSeconds: 1},
+			},
+			"RangeMinBytes -1 less than minimum allowed",
 		},
 		{
 			ZoneConfig{
 				NumReplicas:   1,
 				RangeMinBytes: DefaultZoneConfig().RangeMaxBytes,
 				RangeMaxBytes: DefaultZoneConfig().RangeMaxBytes,
+				GC:            GCPolicy{TTLSeconds: 1},
 			},
 			"is greater than or equal to RangeMaxBytes",
 		},
@@ -69,6 +93,7 @@ func TestZoneConfigValidate(t *testing.T) {
 			ZoneConfig{
 				NumReplicas:   1,
 				RangeMaxBytes: DefaultZoneConfig().RangeMaxBytes,
+				GC:            GCPolicy{TTLSeconds: 1},
 				Constraints: []Constraints{
 					{Constraints: []Constraint{{Value: "a", Type: Constraint_DEPRECATED_POSITIVE}}},
 				},
@@ -79,6 +104,7 @@ func TestZoneConfigValidate(t *testing.T) {
 			ZoneConfig{
 				NumReplicas:   1,
 				RangeMaxBytes: DefaultZoneConfig().RangeMaxBytes,
+				GC:            GCPolicy{TTLSeconds: 1},
 				Constraints: []Constraints{
 					{Constraints: []Constraint{{Value: "a", Type: Constraint_PROHIBITED}}},
 				},
@@ -89,6 +115,7 @@ func TestZoneConfigValidate(t *testing.T) {
 			ZoneConfig{
 				NumReplicas:   1,
 				RangeMaxBytes: DefaultZoneConfig().RangeMaxBytes,
+				GC:            GCPolicy{TTLSeconds: 1},
 				Constraints: []Constraints{
 					{
 						Constraints: []Constraint{{Value: "a", Type: Constraint_PROHIBITED}},
@@ -102,6 +129,7 @@ func TestZoneConfigValidate(t *testing.T) {
 			ZoneConfig{
 				NumReplicas:   1,
 				RangeMaxBytes: DefaultZoneConfig().RangeMaxBytes,
+				GC:            GCPolicy{TTLSeconds: 1},
 				Constraints: []Constraints{
 					{
 						Constraints: []Constraint{{Value: "a", Type: Constraint_REQUIRED}},
@@ -115,6 +143,7 @@ func TestZoneConfigValidate(t *testing.T) {
 			ZoneConfig{
 				NumReplicas:   3,
 				RangeMaxBytes: DefaultZoneConfig().RangeMaxBytes,
+				GC:            GCPolicy{TTLSeconds: 1},
 				Constraints: []Constraints{
 					{
 						Constraints: []Constraint{{Value: "a", Type: Constraint_REQUIRED}},
@@ -128,6 +157,7 @@ func TestZoneConfigValidate(t *testing.T) {
 			ZoneConfig{
 				NumReplicas:   1,
 				RangeMaxBytes: DefaultZoneConfig().RangeMaxBytes,
+				GC:            GCPolicy{TTLSeconds: 1},
 				Constraints: []Constraints{
 					{
 						Constraints: []Constraint{{Value: "a", Type: Constraint_REQUIRED}},
@@ -145,6 +175,7 @@ func TestZoneConfigValidate(t *testing.T) {
 			ZoneConfig{
 				NumReplicas:   3,
 				RangeMaxBytes: DefaultZoneConfig().RangeMaxBytes,
+				GC:            GCPolicy{TTLSeconds: 1},
 				Constraints: []Constraints{
 					{
 						Constraints: []Constraint{{Value: "a", Type: Constraint_REQUIRED}},

--- a/pkg/roachpb/metadata.go
+++ b/pkg/roachpb/metadata.go
@@ -75,7 +75,7 @@ func (a Attributes) IsSubset(b Attributes) bool {
 }
 
 // Equals returns whether the Attributes lists are equivalent. Attributes lists
-// are treated as sets, meaaning that ordering and duplicates are ignored.
+// are treated as sets, meaning that ordering and duplicates are ignored.
 func (a Attributes) Equals(b Attributes) bool {
 	// This is O(n^2), but Attribute lists should never be long enough for that
 	// to matter, and allocating memory every time this is called would be worse.

--- a/pkg/settings/cluster/cockroach_versions.go
+++ b/pkg/settings/cluster/cockroach_versions.go
@@ -172,7 +172,7 @@ var versionsSingleton = keyedVersions([]keyedVersion{
 		Version: roachpb.Version{Major: 1, Minor: 1, Unstable: 13},
 	},
 	{
-		// VersionReadUncommittedRangeLookups is https://github.com/cockroachdb/cockroach/pull/21276.
+		// VersionPerReplicaZoneConstraints is https://github.com/cockroachdb/cockroach/pull/22819.
 		Key:     VersionPerReplicaZoneConstraints,
 		Version: roachpb.Version{Major: 1, Minor: 1, Unstable: 14},
 	},

--- a/pkg/sql/drop_test.go
+++ b/pkg/sql/drop_test.go
@@ -678,7 +678,7 @@ func TestDropTableWhileUpgradingFormat(t *testing.T) {
 	sqlutils.CreateTable(t, sqlDB.DB, "t", "a INT", numRows, sqlutils.ToRowFn(sqlutils.RowIdxFn))
 
 	// Set TTL so the data is deleted immediately.
-	sqlDB.Exec(t, `ALTER TABLE test.t EXPERIMENTAL CONFIGURE ZONE '{gc: {ttlseconds: 0}}'`)
+	sqlDB.Exec(t, `ALTER TABLE test.t EXPERIMENTAL CONFIGURE ZONE '{gc: {ttlseconds: 1}}'`)
 
 	// Give the table an old format version.
 	tableDesc := sqlbase.GetTableDescriptor(kvDB, "test", "t")

--- a/pkg/storage/allocator_test.go
+++ b/pkg/storage/allocator_test.go
@@ -1163,6 +1163,226 @@ func TestAllocatorTransferLeaseTarget(t *testing.T) {
 	}
 }
 
+func TestAllocatorRebalanceDifferentLocalitySizes(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	stopper, g, _, a, _ := createTestAllocator( /* deterministic */ false)
+	ctx := context.Background()
+	defer stopper.Stop(ctx)
+
+	// Set up 8 stores -- 2 in each of the first 2 localities, and 4 in the third.
+	// Because of the desire for diversity, the nodes in the small localities end
+	// up being fuller than the nodes in the large locality. In the past this has
+	// caused an over-eagerness to rebalance to nodes in the large locality, and
+	// not enough willingness to rebalance within the small localities. This test
+	// verifies that we compare fairly amongst stores that will givve the store
+	// an optimal diversity score, not considering the fullness of those that
+	// will make for worse diversity.
+	stores := []*roachpb.StoreDescriptor{
+		{
+			StoreID: 1,
+			Node: roachpb.NodeDescriptor{
+				NodeID: roachpb.NodeID(1),
+				Locality: roachpb.Locality{
+					Tiers: []roachpb.Tier{{Key: "locale", Value: "1"}},
+				},
+			},
+			Capacity: testStoreCapacitySetup(50, 50),
+		},
+		{
+			StoreID: 2,
+			Node: roachpb.NodeDescriptor{
+				NodeID: roachpb.NodeID(2),
+				Locality: roachpb.Locality{
+					Tiers: []roachpb.Tier{{Key: "locale", Value: "1"}},
+				},
+			},
+			Capacity: testStoreCapacitySetup(40, 60),
+		},
+		{
+			StoreID: 3,
+			Node: roachpb.NodeDescriptor{
+				NodeID: roachpb.NodeID(3),
+				Locality: roachpb.Locality{
+					Tiers: []roachpb.Tier{{Key: "locale", Value: "2"}},
+				},
+			},
+			Capacity: testStoreCapacitySetup(50, 50),
+		},
+		{
+			StoreID: 4,
+			Node: roachpb.NodeDescriptor{
+				NodeID: roachpb.NodeID(4),
+				Locality: roachpb.Locality{
+					Tiers: []roachpb.Tier{{Key: "locale", Value: "2"}},
+				},
+			},
+			Capacity: testStoreCapacitySetup(40, 60),
+		},
+		{
+			StoreID: 5,
+			Node: roachpb.NodeDescriptor{
+				NodeID: roachpb.NodeID(5),
+				Locality: roachpb.Locality{
+					Tiers: []roachpb.Tier{{Key: "locale", Value: "3"}},
+				},
+			},
+			Capacity: testStoreCapacitySetup(90, 10),
+		},
+		{
+			StoreID: 6,
+			Node: roachpb.NodeDescriptor{
+				NodeID: roachpb.NodeID(6),
+				Locality: roachpb.Locality{
+					Tiers: []roachpb.Tier{{Key: "locale", Value: "3"}},
+				},
+			},
+			Capacity: testStoreCapacitySetup(80, 20),
+		},
+		{
+			StoreID: 7,
+			Node: roachpb.NodeDescriptor{
+				NodeID: roachpb.NodeID(7),
+				Locality: roachpb.Locality{
+					Tiers: []roachpb.Tier{{Key: "locale", Value: "3"}},
+				},
+			},
+			Capacity: testStoreCapacitySetup(80, 20),
+		},
+		{
+			StoreID: 8,
+			Node: roachpb.NodeDescriptor{
+				NodeID: roachpb.NodeID(8),
+				Locality: roachpb.Locality{
+					Tiers: []roachpb.Tier{{Key: "locale", Value: "3"}},
+				},
+			},
+			Capacity: testStoreCapacitySetup(80, 20),
+		},
+	}
+
+	sg := gossiputil.NewStoreGossiper(g)
+	sg.GossipStores(stores, t)
+
+	replicas := func(storeIDs ...roachpb.StoreID) []roachpb.ReplicaDescriptor {
+		res := make([]roachpb.ReplicaDescriptor, len(storeIDs))
+		for i, storeID := range storeIDs {
+			res[i].NodeID = roachpb.NodeID(storeID)
+			res[i].StoreID = storeID
+		}
+		return res
+	}
+
+	testCases := []struct {
+		existing []roachpb.ReplicaDescriptor
+		expected roachpb.StoreID // 0 if no rebalance is expected
+	}{
+		{replicas(1, 3, 5), 0},
+		{replicas(2, 3, 5), 1},
+		{replicas(1, 4, 5), 3},
+		{replicas(1, 3, 6), 5},
+		{replicas(1, 5, 6), 3},
+		{replicas(2, 5, 6), 3},
+		{replicas(3, 5, 6), 1},
+		{replicas(4, 5, 6), 1},
+	}
+
+	for i, tc := range testCases {
+		result, details := a.RebalanceTarget(
+			ctx,
+			config.ZoneConfig{},
+			nil, /* raftStatus */
+			testRangeInfo(tc.existing, firstRange),
+			storeFilterThrottled,
+			false,
+		)
+		var resultID roachpb.StoreID
+		if result != nil {
+			resultID = result.StoreID
+		}
+		if resultID != tc.expected {
+			t.Errorf("%d: RebalanceTarget(%v) expected s%d; got %v: %s", i, tc.existing, tc.expected, result, details)
+		}
+	}
+
+	// Add a couple less full nodes in a fourth locality, then run a few more tests:
+	stores = append(stores, &roachpb.StoreDescriptor{
+		StoreID: 9,
+		Node: roachpb.NodeDescriptor{
+			NodeID: roachpb.NodeID(9),
+			Locality: roachpb.Locality{
+				Tiers: []roachpb.Tier{{Key: "locale", Value: "4"}},
+			},
+		},
+		Capacity: testStoreCapacitySetup(70, 30),
+	})
+	stores = append(stores, &roachpb.StoreDescriptor{
+		StoreID: 10,
+		Node: roachpb.NodeDescriptor{
+			NodeID: roachpb.NodeID(10),
+			Locality: roachpb.Locality{
+				Tiers: []roachpb.Tier{{Key: "locale", Value: "4"}},
+			},
+		},
+		Capacity: testStoreCapacitySetup(60, 40),
+	})
+
+	sg.GossipStores(stores, t)
+
+	testCases2 := []struct {
+		existing []roachpb.ReplicaDescriptor
+		expected []roachpb.StoreID
+	}{
+		{replicas(1, 3, 5), []roachpb.StoreID{9}},
+		{replicas(2, 3, 5), []roachpb.StoreID{9}},
+		{replicas(1, 4, 5), []roachpb.StoreID{9}},
+		{replicas(1, 3, 6), []roachpb.StoreID{9}},
+		{replicas(1, 5, 6), []roachpb.StoreID{9}},
+		{replicas(2, 5, 6), []roachpb.StoreID{9}},
+		{replicas(3, 5, 6), []roachpb.StoreID{9}},
+		{replicas(4, 5, 6), []roachpb.StoreID{9}},
+		{replicas(5, 6, 7), []roachpb.StoreID{9}},
+		{replicas(1, 5, 9), nil},
+		{replicas(3, 5, 9), nil},
+		{replicas(1, 3, 9), []roachpb.StoreID{5, 6, 7, 8}},
+		{replicas(1, 3, 10), []roachpb.StoreID{5, 6, 7, 8}},
+		// This last case is a bit more interesting - the difference in range count
+		// between s10 an s9 is significant enough to motivate a rebalance if they
+		// were the only two valid options, but they're both considered underful
+		// relative to the other equally valid placement options (s3 and s4), so
+		// the system doesn't consider it helpful to rebalance between them. It'd
+		// prefer to move replicas onto both s9 and s10 from other stores.
+		{replicas(1, 5, 10), nil},
+	}
+
+	for i, tc := range testCases2 {
+		log.Infof(ctx, "case #%d", i)
+		result, details := a.RebalanceTarget(
+			ctx,
+			config.ZoneConfig{},
+			nil, /* raftStatus */
+			testRangeInfo(tc.existing, firstRange),
+			storeFilterThrottled,
+			false,
+		)
+		var gotExpected bool
+		if result == nil {
+			gotExpected = (tc.expected == nil)
+		} else {
+			for _, expectedStoreID := range tc.expected {
+				if result.StoreID == expectedStoreID {
+					gotExpected = true
+					break
+				}
+			}
+		}
+		if !gotExpected {
+			t.Errorf("%d: RebalanceTarget(%v) expected store in %v; got %v: %s",
+				i, tc.existing, tc.expected, result, details)
+		}
+	}
+}
+
 func TestAllocatorTransferLeaseTargetMultiStore(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	stopper, g, _, a, _ := createTestAllocator( /* deterministic */ true)

--- a/pkg/storage/replicate_queue.go
+++ b/pkg/storage/replicate_queue.go
@@ -180,7 +180,7 @@ func (rq *replicateQueue) shouldQueue(
 	}
 
 	if !rq.store.TestingKnobs().DisableReplicaRebalancing {
-		target, _ := rq.allocator.RebalanceTarget(ctx, zone.Constraints, repl.RaftStatus(), rangeInfo, storeFilterThrottled, false)
+		target, _ := rq.allocator.RebalanceTarget(ctx, zone, repl.RaftStatus(), rangeInfo, storeFilterThrottled, false)
 		if target != nil {
 			log.VEventf(ctx, 2, "rebalance target found, enqueuing")
 			return true, 0
@@ -270,7 +270,7 @@ func (rq *replicateQueue) processOneChange(
 		log.VEventf(ctx, 1, "adding a new replica")
 		newStore, details, err := rq.allocator.AllocateTarget(
 			ctx,
-			zone.Constraints,
+			zone,
 			desc.Replicas,
 			rangeInfo,
 			disableStatsBasedRebalancing,
@@ -305,7 +305,7 @@ func (rq *replicateQueue) processOneChange(
 			})
 			_, _, err := rq.allocator.AllocateTarget(
 				ctx,
-				zone.Constraints,
+				zone,
 				oldPlusNewReplicas,
 				rangeInfo,
 				disableStatsBasedRebalancing,
@@ -344,7 +344,7 @@ func (rq *replicateQueue) processOneChange(
 			return false, errors.Errorf("no removable replicas from range that needs a removal: %s",
 				rangeRaftProgress(repl.RaftStatus(), desc.Replicas))
 		}
-		removeReplica, details, err := rq.allocator.RemoveTarget(ctx, zone.Constraints, candidates, rangeInfo, disableStatsBasedRebalancing)
+		removeReplica, details, err := rq.allocator.RemoveTarget(ctx, zone, candidates, rangeInfo, disableStatsBasedRebalancing)
 		if err != nil {
 			return false, err
 		}
@@ -458,7 +458,7 @@ func (rq *replicateQueue) processOneChange(
 
 		if !rq.store.TestingKnobs().DisableReplicaRebalancing {
 			rebalanceStore, details := rq.allocator.RebalanceTarget(
-				ctx, zone.Constraints, repl.RaftStatus(), rangeInfo, storeFilterThrottled, disableStatsBasedRebalancing)
+				ctx, zone, repl.RaftStatus(), rangeInfo, storeFilterThrottled, disableStatsBasedRebalancing)
 			if rebalanceStore == nil {
 				log.VEventf(ctx, 1, "no suitable rebalance target")
 			} else {


### PR DESCRIPTION
Cherry-picks:
1. #23014 to avoid restricting colons in constraints
2. #23036 to fix bug where we'd sometimes pick a suboptimal store to allocate/rebalance onto
3. #23057 to allow per-replica constraints that don't specify constraints for all replicas in a range
4. #22870 to not allow negative zone config fields like `NumReplicas` or `GC.TTLSeconds`.

@cockroachdb/release 