### PR TITLE
cherrypick-2.0: kv: move setting the gateway node's observed timestamp to client.Txn

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -247,7 +247,9 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 		s.stopper,
 		txnMetrics,
 	)
-	s.db = client.NewDB(s.tcsFactory, s.clock)
+	dbCtx := client.DefaultDBContext()
+	dbCtx.NodeID = &s.nodeIDContainer
+	s.db = client.NewDBWithContext(s.tcsFactory, s.clock, dbCtx)
 
 	nlActive, nlRenewal := s.cfg.NodeLivenessDurations()
 

--- a/pkg/testutils/localtestcluster/local_test_cluster.go
+++ b/pkg/testutils/localtestcluster/local_test_cluster.go
@@ -111,6 +111,7 @@ func (ltc *LocalTestCluster) Start(t testing.TB, baseCtx *base.Config, initFacto
 		dbCtx := client.DefaultDBContext()
 		ltc.DBContext = &dbCtx
 	}
+	ltc.DBContext.NodeID.Set(context.Background(), nodeID)
 	ltc.DB = client.NewDBWithContext(factory, ltc.Clock, *ltc.DBContext)
 	transport := storage.NewDummyRaftTransport(cfg.Settings)
 	// By default, disable the replica scanner and split queue, which


### PR DESCRIPTION
This allows us to avoid setting the observed timestamp at remote leaf
transactions in a distributed SQL setting.

Release note: None