### PR TITLE
cherrypick-2.0: sql: speedup TestDropTableWhileUpgradingFormat

### DIFF
--- a/pkg/sql/drop_test.go
+++ b/pkg/sql/drop_test.go
@@ -664,6 +664,7 @@ func TestDropTableWhileUpgradingFormat(t *testing.T) {
 				<-blockSchemaChanges
 				return nil
 			},
+			AsyncExecQuickly: true,
 		},
 		SQLMigrationManager: &sqlmigrations.MigrationManagerTestingKnobs{
 			DisableBackfillMigrations: true,


### PR DESCRIPTION
sets AsyncExecQuickly to speed up this test.

fixes #22989

Release note: None