### PR TITLE
storage: Don't allow node liveness expiration to move backwards

### DIFF
--- a/pkg/storage/node_liveness.go
+++ b/pkg/storage/node_liveness.go
@@ -511,6 +511,13 @@ func (nl *NodeLiveness) heartbeatInternal(
 		}
 		newLiveness.Expiration = hlc.LegacyTimestamp(
 			nl.clock.Now().Add((nl.livenessThreshold + maxOffset).Nanoseconds(), 0))
+		// This guards against the system clock moving backwards. As long
+		// as the cockroach process is running, checks inside hlc.Clock
+		// will ensure that the clock never moves backwards, but these
+		// checks don't work across process restarts.
+		if liveness != nil && newLiveness.Expiration.Less(liveness.Expiration) {
+			return errors.Errorf("proposed liveness update expires earlier than previous record")
+		}
 	}
 	if err := nl.updateLiveness(ctx, &newLiveness, liveness, func(actual Liveness) error {
 		// Update liveness to actual value on mismatch.


### PR DESCRIPTION
This ensures that if the system clock moves backwards while the
`cockroach` process is not running, the node will not be able to
become live until the clock has caught up with its previous value.
If it did, it would be possible to serve stale reads.

Release note (bug fix): Guard against stale reads caused by the system
clock moving backwards while the `cockroach` process is not running.

Unfortunately, it's not easy to test for this since we don't have any testing hooks to bypass the hlc.Clock ratchet. There's a reproduction of the underlying issue in https://gist.github.com/tschottdorf/543e053309ecb9c4627abc0b2cd933e6