### PR TITLE
cherrypick 2.0: sql: reintroduce the functionality of sql.trace.txn.enable_threshold

### DIFF
--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -437,8 +437,9 @@ func (s *Server) ServeConn(
 			nodeID: s.cfg.NodeID.Get(),
 			clock:  s.cfg.Clock,
 			// Future transaction's monitors will inherits from sessionRootMon.
-			connMon: &sessionRootMon,
-			tracer:  s.cfg.AmbientCtx.Tracer,
+			connMon:  &sessionRootMon,
+			tracer:   s.cfg.AmbientCtx.Tracer,
+			settings: s.cfg.Settings,
 		},
 		parallelizeQueue: MakeParallelizeQueue(NewSpanBasedDependencyAnalyzer()),
 		memMetrics:       memMetrics,
@@ -469,6 +470,7 @@ func (s *Server) ServeConn(
 	}
 	ex.dataMutator.SetApplicationName(args.ApplicationName)
 	ex.dataMutator.sessionTracing.ex = &ex
+	ex.transitionCtx.sessionTracing = &ex.dataMutator.sessionTracing
 
 	defer func() {
 		r := recover()

--- a/pkg/sql/txn_state.go
+++ b/pkg/sql/txn_state.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/util/contextutil"
@@ -32,6 +33,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 )
 
@@ -61,6 +63,11 @@ type txnState2 struct {
 	// sp is the span corresponding to the SQL txn. These are often root spans, as
 	// SQL txns are frequently the level at which we do tracing.
 	sp opentracing.Span
+	// recordingThreshold, is not zero, indicates that sp is recording and that
+	// the recording should be dumped to the log if execution of the transaction
+	// took more than this.
+	recordingThreshold time.Duration
+	recordingStart     time.Time
 
 	// cancel is the cancellation function for the above context. Called upon
 	// COMMIT/ROLLBACK of the transaction to release resources associated with the
@@ -159,6 +166,14 @@ func (ts *txnState2) resetForNewSQLTxn(
 		sp.SetTag("implicit", "true")
 	}
 
+	alreadyRecording := tranCtx.sessionTracing.Enabled()
+	duration := traceTxnThreshold.Get(&tranCtx.settings.SV)
+	if !alreadyRecording && (duration > 0) {
+		tracing.StartRecording(sp, tracing.SnowballRecording)
+		ts.recordingThreshold = duration
+		ts.recordingStart = timeutil.Now()
+	}
+
 	// Put the new span in the context.
 	txnCtx := opentracing.ContextWithSpan(connCtx, sp)
 
@@ -214,10 +229,25 @@ func (ts *txnState2) finishSQLTxn(connCtx context.Context) {
 			"attempting to finishSQLTxn(), but KV txn is not finalized: %+v", ts.mu.txn))
 	}
 
+	if ts.recordingThreshold > 0 {
+		if r := tracing.GetRecording(ts.sp); r != nil {
+			if elapsed := timeutil.Since(ts.recordingStart); elapsed >= ts.recordingThreshold {
+				dump := tracing.FormatRecordedSpans(r)
+				if len(dump) > 0 {
+					log.Infof(ts.Ctx, "SQL txn took %s, exceeding tracing threshold of %s:\n%s",
+						elapsed, ts.recordingThreshold, dump)
+				}
+			}
+		} else {
+			log.Warning(ts.Ctx, "Missing trace when sampled was enabled.")
+		}
+	}
+
 	ts.sp.Finish()
 	ts.sp = nil
 	ts.Ctx = nil
 	ts.mu.txn = nil
+	ts.recordingThreshold = 0
 }
 
 func (ts *txnState2) setIsolationLevel(isolation enginepb.IsolationType) error {
@@ -338,6 +368,10 @@ type transitionCtx struct {
 	// The Tracer used to create root spans for new txns if the parent ctx doesn't
 	// have a span.
 	tracer opentracing.Tracer
+	// sessionTracing provides access to the session's tracing interface. The
+	// state machine needs to see if session tracing is enabled.
+	sessionTracing *SessionTracing
+	settings       *cluster.Settings
 }
 
 var noRewind = rewindCapability{}


### PR DESCRIPTION
... cluster setting in the connExecutor.

cherry pick of #23031

That cluster settings lets one set a duration threshold and, if a txn
runs past that, its recording is dumped to the log when the txn
finishes.

In the future we should convert the threshold to be per-query, once we
have the infrastructure to record individual queries and not just whole
transactions.

Release note: None

cc @cockroachdb/release 