### PR TITLE
opt: support cast operation in optbuilder

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/scalar_builder.go
+++ b/pkg/sql/opt/exec/execbuilder/scalar_builder.go
@@ -44,6 +44,7 @@ func init() {
 		opt.PlaceholderOp:     (*Builder).buildTypedExpr,
 		opt.TupleOp:           (*Builder).buildTuple,
 		opt.FunctionOp:        (*Builder).buildFunction,
+		opt.CastOp:            (*Builder).buildCast,
 		opt.UnsupportedExprOp: (*Builder).buildUnsupportedExpr,
 	}
 
@@ -171,6 +172,17 @@ func (b *Builder) buildFunction(ctx *buildScalarCtx, ev xform.ExprView) tree.Typ
 		ev.Logical().Scalar.Type,
 		funcDef.Overload,
 	)
+}
+
+func (b *Builder) buildCast(ctx *buildScalarCtx, ev xform.ExprView) tree.TypedExpr {
+	expr, err := tree.NewTypedCastExpr(
+		b.buildScalar(ctx, ev.Child(0)),
+		ev.Logical().Scalar.Type,
+	)
+	if err != nil {
+		panic(err)
+	}
+	return expr
 }
 
 func (b *Builder) buildUnsupportedExpr(ctx *buildScalarCtx, ev xform.ExprView) tree.TypedExpr {

--- a/pkg/sql/opt/exec/execbuilder/testdata/scalar
+++ b/pkg/sql/opt/exec/execbuilder/testdata/scalar
@@ -285,3 +285,20 @@ render     0  render  ·         ·                (column8)                    
  └── scan  1  scan    ·         ·                (a, b, c, d, j, s, rowid[hidden])  ·
 ·          1  ·       table     t@primary        ·                                  ·
 ·          1  ·       spans     ALL              ·                                  ·
+
+exec-explain
+SELECT CAST(a AS string), b::float FROM t.t
+----
+render     0  render  ·         ·                  (column8, column9)                 ·
+ │         0  ·       render 0  CAST(a AS STRING)  ·                                  ·
+ │         0  ·       render 1  CAST(b AS FLOAT)   ·                                  ·
+ └── scan  1  scan    ·         ·                  (a, b, c, d, j, s, rowid[hidden])  ·
+·          1  ·       table     t@primary          ·                                  ·
+·          1  ·       spans     ALL                ·                                  ·
+
+exec
+SELECT LENGTH(s)::float, s FROM t.str
+----
+1.0  a
+2.0  ab
+3.0  abc

--- a/pkg/sql/opt/ops/scalar.opt
+++ b/pkg/sql/opt/ops/scalar.opt
@@ -342,6 +342,12 @@ define UnaryComplement {
     Input Expr
 }
 
+[Scalar]
+define Cast {
+    Input Expr
+    Typ   Type
+}
+
 # Function invokes a builtin SQL function like CONCAT or NOW, passing the given
 # arguments. The private field is an opt.FuncDef struct that provides the name
 # of the function as well as a pointer to the builtin overload definition.

--- a/pkg/sql/opt/opt/factory.og.go
+++ b/pkg/sql/opt/opt/factory.og.go
@@ -215,6 +215,9 @@ type Factory interface {
 	// ConstructUnaryComplement constructs an expression for the UnaryComplement operator.
 	ConstructUnaryComplement(input GroupID) GroupID
 
+	// ConstructCast constructs an expression for the Cast operator.
+	ConstructCast(input GroupID, typ PrivateID) GroupID
+
 	// ConstructFunction constructs an expression for the Function operator.
 	// Function invokes a builtin SQL function like CONCAT or NOW, passing the given
 	// arguments. The private field is an opt.FuncDef struct that provides the name

--- a/pkg/sql/opt/opt/operator.og.go
+++ b/pkg/sql/opt/opt/operator.og.go
@@ -143,6 +143,8 @@ const (
 
 	UnaryComplementOp
 
+	CastOp
+
 	// FunctionOp invokes a builtin SQL function like CONCAT or NOW, passing the given
 	// arguments. The private field is an opt.FuncDef struct that provides the name
 	// of the function as well as a pointer to the builtin overload definition.
@@ -246,9 +248,9 @@ const (
 	NumOperators
 )
 
-const opNames = "unknownsubqueryvariableconsttruefalseplaceholdertupleprojectionsaggregationsexistsandornoteqltgtlegeneinnot-inlikenot-likei-likenot-i-likesimilar-tonot-similar-toreg-matchnot-reg-matchreg-i-matchnot-reg-i-matchisis-notcontainsbitandbitorbitxorplusminusmultdivfloor-divmodpowconcatl-shiftr-shiftfetch-valfetch-textfetch-val-pathfetch-text-pathunary-plusunary-minusunary-complementfunctioncoalesceunsupported-exprscanvaluesselectprojectinner-joinleft-joinright-joinfull-joinsemi-joinanti-joininner-join-applyleft-join-applyright-join-applyfull-join-applysemi-join-applyanti-join-applygroup-byunionintersectexceptsort"
+const opNames = "unknownsubqueryvariableconsttruefalseplaceholdertupleprojectionsaggregationsexistsandornoteqltgtlegeneinnot-inlikenot-likei-likenot-i-likesimilar-tonot-similar-toreg-matchnot-reg-matchreg-i-matchnot-reg-i-matchisis-notcontainsbitandbitorbitxorplusminusmultdivfloor-divmodpowconcatl-shiftr-shiftfetch-valfetch-textfetch-val-pathfetch-text-pathunary-plusunary-minusunary-complementcastfunctioncoalesceunsupported-exprscanvaluesselectprojectinner-joinleft-joinright-joinfull-joinsemi-joinanti-joininner-join-applyleft-join-applyright-join-applyfull-join-applysemi-join-applyanti-join-applygroup-byunionintersectexceptsort"
 
-var opIndexes = [...]uint32{0, 7, 15, 23, 28, 32, 37, 48, 53, 64, 76, 82, 85, 87, 90, 92, 94, 96, 98, 100, 102, 104, 110, 114, 122, 128, 138, 148, 162, 171, 184, 195, 210, 212, 218, 226, 232, 237, 243, 247, 252, 256, 259, 268, 271, 274, 280, 287, 294, 303, 313, 327, 342, 352, 363, 379, 387, 395, 411, 415, 421, 427, 434, 444, 453, 463, 472, 481, 490, 506, 521, 537, 552, 567, 582, 590, 595, 604, 610, 614}
+var opIndexes = [...]uint32{0, 7, 15, 23, 28, 32, 37, 48, 53, 64, 76, 82, 85, 87, 90, 92, 94, 96, 98, 100, 102, 104, 110, 114, 122, 128, 138, 148, 162, 171, 184, 195, 210, 212, 218, 226, 232, 237, 243, 247, 252, 256, 259, 268, 271, 274, 280, 287, 294, 303, 313, 327, 342, 352, 363, 379, 383, 391, 399, 415, 419, 425, 431, 438, 448, 457, 467, 476, 485, 494, 510, 525, 541, 556, 571, 586, 594, 599, 608, 614, 618}
 
 var ScalarOperators = [...]Operator{
 	SubqueryOp,
@@ -305,6 +307,7 @@ var ScalarOperators = [...]Operator{
 	UnaryPlusOp,
 	UnaryMinusOp,
 	UnaryComplementOp,
+	CastOp,
 	FunctionOp,
 	CoalesceOp,
 	UnsupportedExprOp,

--- a/pkg/sql/opt/optbuilder/builder.go
+++ b/pkg/sql/opt/optbuilder/builder.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 
+	"github.com/cockroachdb/cockroach/pkg/sql/coltypes"
 	"github.com/cockroachdb/cockroach/pkg/sql/optbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/builtins"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -367,6 +368,11 @@ func (b *Builder) buildScalar(scalar tree.TypedExpr, inScope *scope) (out opt.Gr
 			b.buildScalar(t.TypedLeft(), inScope),
 			b.buildScalar(t.TypedRight(), inScope),
 		)
+
+	case *tree.CastExpr:
+		arg := b.buildScalar(inScope.resolveType(t.Expr, types.Any), inScope)
+		typ := coltypes.CastTargetToDatumType(t.Type)
+		out = b.factory.ConstructCast(arg, b.factory.InternPrivate(typ))
 
 	case *tree.ComparisonExpr:
 		left := b.buildScalar(t.TypedLeft(), inScope)

--- a/pkg/sql/opt/optbuilder/testdata/aggregate
+++ b/pkg/sql/opt/optbuilder/testdata/aggregate
@@ -63,6 +63,120 @@ group-by
            └── variable: column25 [type=bytes]
 
 build
+SELECT MIN(v), MAX(v), COUNT(v), SUM_INT(1), AVG(v), SUM(v), STDDEV(v),
+  VARIANCE(v), BOOL_AND(v = 1), BOOL_AND(v = 1), XOR_AGG(s::bytes) FROM kv
+----
+group-by
+ ├── columns: column5:int:null:5 column6:int:null:6 column7:int:null:7 column9:int:null:9 column10:decimal:null:10 column11:decimal:null:11 column12:decimal:null:12 column13:decimal:null:13 column15:bool:null:15 column17:bool:null:17 column19:bytes:null:19
+ ├── project
+ │    ├── columns: kv.v:int:null:2 kv.v:int:null:2 kv.v:int:null:2 column8:int:null:8 kv.v:int:null:2 kv.v:int:null:2 kv.v:int:null:2 kv.v:int:null:2 column14:bool:null:14 column16:bool:null:16 column18:bytes:null:18
+ │    ├── scan
+ │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
+ │    └── projections
+ │         ├── variable: kv.v [type=int]
+ │         ├── variable: kv.v [type=int]
+ │         ├── variable: kv.v [type=int]
+ │         ├── const: 1 [type=int]
+ │         ├── variable: kv.v [type=int]
+ │         ├── variable: kv.v [type=int]
+ │         ├── variable: kv.v [type=int]
+ │         ├── variable: kv.v [type=int]
+ │         ├── eq [type=bool]
+ │         │    ├── variable: kv.v [type=int]
+ │         │    └── const: 1 [type=int]
+ │         ├── eq [type=bool]
+ │         │    ├── variable: kv.v [type=int]
+ │         │    └── const: 1 [type=int]
+ │         └── cast: bytes [type=bytes]
+ │              └── variable: kv.s [type=string]
+ └── aggregations
+      ├── function: min [type=int]
+      │    └── variable: kv.v [type=int]
+      ├── function: max [type=int]
+      │    └── variable: kv.v [type=int]
+      ├── function: count [type=int]
+      │    └── variable: kv.v [type=int]
+      ├── function: sum_int [type=int]
+      │    └── variable: column8 [type=int]
+      ├── function: avg [type=decimal]
+      │    └── variable: kv.v [type=int]
+      ├── function: sum [type=decimal]
+      │    └── variable: kv.v [type=int]
+      ├── function: stddev [type=decimal]
+      │    └── variable: kv.v [type=int]
+      ├── function: variance [type=decimal]
+      │    └── variable: kv.v [type=int]
+      ├── function: bool_and [type=bool]
+      │    └── variable: column14 [type=bool]
+      ├── function: bool_and [type=bool]
+      │    └── variable: column16 [type=bool]
+      └── function: xor_agg [type=bytes]
+           └── variable: column18 [type=bytes]
+
+build
+SELECT MIN(1), COUNT(1), MAX(1), SUM_INT(1), AVG(1)::float, SUM(1), STDDEV(1),
+  VARIANCE(1)::float, BOOL_AND(true), BOOL_OR(true), TO_HEX(XOR_AGG(b'\x01'))
+----
+project
+ ├── columns: column2:int:null:2 column4:int:null:4 column6:int:null:6 column8:int:null:8 column11:float:null:11 column13:decimal:null:13 column15:decimal:null:15 column18:float:null:18 column20:bool:null:20 column22:bool:null:22 column25:string:null:25
+ ├── group-by
+ │    ├── columns: column2:int:null:2 column4:int:null:4 column6:int:null:6 column8:int:null:8 column10:decimal:null:10 column13:decimal:null:13 column15:decimal:null:15 column17:decimal:null:17 column20:bool:null:20 column22:bool:null:22 column24:bytes:null:24
+ │    ├── project
+ │    │    ├── columns: column1:int:null:1 column3:int:null:3 column5:int:null:5 column7:int:null:7 column9:int:null:9 column12:int:null:12 column14:int:null:14 column16:int:null:16 column19:bool:null:19 column21:bool:null:21 column23:bytes:null:23
+ │    │    ├── values
+ │    │    │    └── tuple [type=tuple{}]
+ │    │    └── projections
+ │    │         ├── const: 1 [type=int]
+ │    │         ├── const: 1 [type=int]
+ │    │         ├── const: 1 [type=int]
+ │    │         ├── const: 1 [type=int]
+ │    │         ├── const: 1 [type=int]
+ │    │         ├── const: 1 [type=int]
+ │    │         ├── const: 1 [type=int]
+ │    │         ├── const: 1 [type=int]
+ │    │         ├── true [type=bool]
+ │    │         ├── true [type=bool]
+ │    │         └── const: '\x01' [type=bytes]
+ │    └── aggregations
+ │         ├── function: min [type=int]
+ │         │    └── variable: column1 [type=int]
+ │         ├── function: count [type=int]
+ │         │    └── variable: column3 [type=int]
+ │         ├── function: max [type=int]
+ │         │    └── variable: column5 [type=int]
+ │         ├── function: sum_int [type=int]
+ │         │    └── variable: column7 [type=int]
+ │         ├── function: avg [type=decimal]
+ │         │    └── variable: column9 [type=int]
+ │         ├── function: sum [type=decimal]
+ │         │    └── variable: column12 [type=int]
+ │         ├── function: stddev [type=decimal]
+ │         │    └── variable: column14 [type=int]
+ │         ├── function: variance [type=decimal]
+ │         │    └── variable: column16 [type=int]
+ │         ├── function: bool_and [type=bool]
+ │         │    └── variable: column19 [type=bool]
+ │         ├── function: bool_or [type=bool]
+ │         │    └── variable: column21 [type=bool]
+ │         └── function: xor_agg [type=bytes]
+ │              └── variable: column23 [type=bytes]
+ └── projections
+      ├── variable: column2 [type=int]
+      ├── variable: column4 [type=int]
+      ├── variable: column6 [type=int]
+      ├── variable: column8 [type=int]
+      ├── cast: float [type=float]
+      │    └── variable: column10 [type=decimal]
+      ├── variable: column13 [type=decimal]
+      ├── variable: column15 [type=decimal]
+      ├── cast: float [type=float]
+      │    └── variable: column17 [type=decimal]
+      ├── variable: column20 [type=bool]
+      ├── variable: column22 [type=bool]
+      └── function: to_hex [type=string]
+           └── variable: column24 [type=bytes]
+
+build
 SELECT ARRAY_AGG(1) FROM t.kv
 ----
 group-by
@@ -125,6 +239,47 @@ project
  │    └── aggregations
  └── projections
       └── const: 1 [type=int]
+
+# This should ideally return {NULL}, but this is a pathological case, and
+# Postgres has the same behavior, so it's sufficient for now.
+build
+SELECT ARRAY_AGG(NULL)
+----
+----
+error: ambiguous call: array_agg(NULL), candidates are:
+array_agg(int) -> int[]
+array_agg(float) -> float[]
+array_agg(decimal) -> decimal[]
+array_agg(string) -> string[]
+array_agg(bytes) -> bytes[]
+array_agg(date) -> date[]
+array_agg(time) -> time[]
+array_agg(timestamp) -> timestamp[]
+array_agg(timestamptz) -> timestamptz[]
+array_agg(interval) -> interval[]
+array_agg(uuid) -> uuid[]
+array_agg(inet) -> inet[]
+array_agg(oid) -> oid[]
+array_agg(bool) -> bool[]
+
+----
+----
+# With an explicit cast, this works as expected.
+build
+SELECT ARRAY_AGG(NULL::TEXT)
+----
+group-by
+ ├── columns: column2:string[]:null:2
+ ├── project
+ │    ├── columns: column1:string:null:1
+ │    ├── values
+ │    │    └── tuple [type=tuple{}]
+ │    └── projections
+ │         └── cast: string [type=string]
+ │              └── const: NULL [type=NULL]
+ └── aggregations
+      └── function: array_agg [type=string[]]
+           └── variable: column1 [type=string]
 
 build
 SELECT COUNT(*), k FROM t.kv
@@ -634,6 +789,27 @@ project
            └── variable: column6 [type=int]
 
 build
+SELECT COUNT(NULL::int), COUNT((NULL, NULL))
+----
+group-by
+ ├── columns: column2:int:null:2 column4:int:null:4
+ ├── project
+ │    ├── columns: column1:int:null:1 column3:tuple{NULL, NULL}:null:3
+ │    ├── values
+ │    │    └── tuple [type=tuple{}]
+ │    └── projections
+ │         ├── cast: int [type=int]
+ │         │    └── const: NULL [type=NULL]
+ │         └── tuple [type=tuple{NULL, NULL}]
+ │              ├── const: NULL [type=NULL]
+ │              └── const: NULL [type=NULL]
+ └── aggregations
+      ├── function: count [type=int]
+      │    └── variable: column1 [type=int]
+      └── function: count [type=int]
+           └── variable: column3 [type=tuple{NULL, NULL}]
+
+build
 SELECT MIN(k), MAX(k), MIN(v), MAX(v) FROM t.kv
 ----
 group-by
@@ -729,6 +905,95 @@ group-by
       │    └── variable: kv.k [type=int]
       └── function: sum [type=decimal]
            └── variable: kv.v [type=int]
+
+build
+SELECT AVG(k::decimal), AVG(v::decimal), SUM(k::decimal), SUM(v::decimal) FROM kv
+----
+group-by
+ ├── columns: column6:decimal:null:6 column8:decimal:null:8 column10:decimal:null:10 column12:decimal:null:12
+ ├── project
+ │    ├── columns: column5:decimal:null:5 column7:decimal:null:7 column9:decimal:null:9 column11:decimal:null:11
+ │    ├── scan
+ │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
+ │    └── projections
+ │         ├── cast: decimal [type=decimal]
+ │         │    └── variable: kv.k [type=int]
+ │         ├── cast: decimal [type=decimal]
+ │         │    └── variable: kv.v [type=int]
+ │         ├── cast: decimal [type=decimal]
+ │         │    └── variable: kv.k [type=int]
+ │         └── cast: decimal [type=decimal]
+ │              └── variable: kv.v [type=int]
+ └── aggregations
+      ├── function: avg [type=decimal]
+      │    └── variable: column5 [type=decimal]
+      ├── function: avg [type=decimal]
+      │    └── variable: column7 [type=decimal]
+      ├── function: sum [type=decimal]
+      │    └── variable: column9 [type=decimal]
+      └── function: sum [type=decimal]
+           └── variable: column11 [type=decimal]
+
+build
+SELECT AVG(k) * 2.0 + MAX(v)::DECIMAL FROM kv
+----
+project
+ ├── columns: column7:decimal:null:7
+ ├── group-by
+ │    ├── columns: column5:decimal:null:5 column6:int:null:6
+ │    ├── project
+ │    │    ├── columns: kv.k:int:1 kv.v:int:null:2
+ │    │    ├── scan
+ │    │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
+ │    │    └── projections
+ │    │         ├── variable: kv.k [type=int]
+ │    │         └── variable: kv.v [type=int]
+ │    └── aggregations
+ │         ├── function: avg [type=decimal]
+ │         │    └── variable: kv.k [type=int]
+ │         └── function: max [type=int]
+ │              └── variable: kv.v [type=int]
+ └── projections
+      └── plus [type=decimal]
+           ├── mult [type=decimal]
+           │    ├── variable: column5 [type=decimal]
+           │    └── const: 2.0 [type=decimal]
+           └── cast: decimal [type=decimal]
+                └── variable: column6 [type=int]
+
+build
+SELECT AVG(k) * 2.0 + MAX(v)::DECIMAL FROM kv WHERE w*2 = k
+----
+project
+ ├── columns: column7:decimal:null:7
+ ├── group-by
+ │    ├── columns: column5:decimal:null:5 column6:int:null:6
+ │    ├── project
+ │    │    ├── columns: kv.k:int:1 kv.v:int:null:2
+ │    │    ├── select
+ │    │    │    ├── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
+ │    │    │    ├── scan
+ │    │    │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
+ │    │    │    └── eq [type=bool]
+ │    │    │         ├── mult [type=int]
+ │    │    │         │    ├── variable: kv.w [type=int]
+ │    │    │         │    └── const: 2 [type=int]
+ │    │    │         └── variable: kv.k [type=int]
+ │    │    └── projections
+ │    │         ├── variable: kv.k [type=int]
+ │    │         └── variable: kv.v [type=int]
+ │    └── aggregations
+ │         ├── function: avg [type=decimal]
+ │         │    └── variable: kv.k [type=int]
+ │         └── function: max [type=int]
+ │              └── variable: kv.v [type=int]
+ └── projections
+      └── plus [type=decimal]
+           ├── mult [type=decimal]
+           │    ├── variable: column5 [type=decimal]
+           │    └── const: 2.0 [type=decimal]
+           └── cast: decimal [type=decimal]
+                └── variable: column6 [type=int]
 
 exec-ddl
 CREATE TABLE t.abc (
@@ -1027,6 +1292,36 @@ group-by
 # VARIANCE/STDDEV
 
 build
+SELECT VARIANCE(x), VARIANCE(y::decimal), round(VARIANCE(z), 14) FROM xyz
+----
+project
+ ├── columns: column4:decimal:null:4 column6:decimal:null:6 column8:float:null:8
+ ├── group-by
+ │    ├── columns: column4:decimal:null:4 column6:decimal:null:6 column7:float:null:7
+ │    ├── project
+ │    │    ├── columns: xyz.x:int:1 column5:decimal:null:5 xyz.z:float:null:3
+ │    │    ├── scan
+ │    │    │    └── columns: xyz.x:int:1 xyz.y:int:null:2 xyz.z:float:null:3
+ │    │    └── projections
+ │    │         ├── variable: xyz.x [type=int]
+ │    │         ├── cast: decimal [type=decimal]
+ │    │         │    └── variable: xyz.y [type=int]
+ │    │         └── variable: xyz.z [type=float]
+ │    └── aggregations
+ │         ├── function: variance [type=decimal]
+ │         │    └── variable: xyz.x [type=int]
+ │         ├── function: variance [type=decimal]
+ │         │    └── variable: column5 [type=decimal]
+ │         └── function: variance [type=float]
+ │              └── variable: xyz.z [type=float]
+ └── projections
+      ├── variable: column4 [type=decimal]
+      ├── variable: column6 [type=decimal]
+      └── function: round [type=float]
+           ├── variable: column7 [type=float]
+           └── const: 14 [type=int]
+
+build
 SELECT VARIANCE(x) FROM t.xyz WHERE x = 10
 ----
 group-by
@@ -1047,6 +1342,36 @@ group-by
            └── variable: xyz.x [type=int]
 
 build
+SELECT STDDEV(x), STDDEV(y::decimal), round(STDDEV(z), 14) FROM xyz
+----
+project
+ ├── columns: column4:decimal:null:4 column6:decimal:null:6 column8:float:null:8
+ ├── group-by
+ │    ├── columns: column4:decimal:null:4 column6:decimal:null:6 column7:float:null:7
+ │    ├── project
+ │    │    ├── columns: xyz.x:int:1 column5:decimal:null:5 xyz.z:float:null:3
+ │    │    ├── scan
+ │    │    │    └── columns: xyz.x:int:1 xyz.y:int:null:2 xyz.z:float:null:3
+ │    │    └── projections
+ │    │         ├── variable: xyz.x [type=int]
+ │    │         ├── cast: decimal [type=decimal]
+ │    │         │    └── variable: xyz.y [type=int]
+ │    │         └── variable: xyz.z [type=float]
+ │    └── aggregations
+ │         ├── function: stddev [type=decimal]
+ │         │    └── variable: xyz.x [type=int]
+ │         ├── function: stddev [type=decimal]
+ │         │    └── variable: column5 [type=decimal]
+ │         └── function: stddev [type=float]
+ │              └── variable: xyz.z [type=float]
+ └── projections
+      ├── variable: column4 [type=decimal]
+      ├── variable: column6 [type=decimal]
+      └── function: round [type=float]
+           ├── variable: column7 [type=float]
+           └── const: 14 [type=int]
+
+build
 SELECT STDDEV(x) FROM t.xyz WHERE x = 1
 ----
 group-by
@@ -1065,6 +1390,135 @@ group-by
  └── aggregations
       └── function: stddev [type=decimal]
            └── variable: xyz.x [type=int]
+
+build
+SELECT AVG(1::int)::float, AVG(2::float)::float, AVG(3::decimal)::float
+----
+project
+ ├── columns: column3:float:null:3 column6:float:null:6 column9:float:null:9
+ ├── group-by
+ │    ├── columns: column2:decimal:null:2 column5:float:null:5 column8:decimal:null:8
+ │    ├── project
+ │    │    ├── columns: column1:int:null:1 column4:float:null:4 column7:decimal:null:7
+ │    │    ├── values
+ │    │    │    └── tuple [type=tuple{}]
+ │    │    └── projections
+ │    │         ├── cast: int [type=int]
+ │    │         │    └── const: 1 [type=int]
+ │    │         ├── cast: float [type=float]
+ │    │         │    └── const: 2.0 [type=float]
+ │    │         └── cast: decimal [type=decimal]
+ │    │              └── const: 3 [type=decimal]
+ │    └── aggregations
+ │         ├── function: avg [type=decimal]
+ │         │    └── variable: column1 [type=int]
+ │         ├── function: avg [type=float]
+ │         │    └── variable: column4 [type=float]
+ │         └── function: avg [type=decimal]
+ │              └── variable: column7 [type=decimal]
+ └── projections
+      ├── cast: float [type=float]
+      │    └── variable: column2 [type=decimal]
+      ├── cast: float [type=float]
+      │    └── variable: column5 [type=float]
+      └── cast: float [type=float]
+           └── variable: column8 [type=decimal]
+
+build
+SELECT COUNT(2::int), COUNT(3::float), COUNT(4::decimal)
+----
+group-by
+ ├── columns: column2:int:null:2 column4:int:null:4 column6:int:null:6
+ ├── project
+ │    ├── columns: column1:int:null:1 column3:float:null:3 column5:decimal:null:5
+ │    ├── values
+ │    │    └── tuple [type=tuple{}]
+ │    └── projections
+ │         ├── cast: int [type=int]
+ │         │    └── const: 2 [type=int]
+ │         ├── cast: float [type=float]
+ │         │    └── const: 3.0 [type=float]
+ │         └── cast: decimal [type=decimal]
+ │              └── const: 4 [type=decimal]
+ └── aggregations
+      ├── function: count [type=int]
+      │    └── variable: column1 [type=int]
+      ├── function: count [type=int]
+      │    └── variable: column3 [type=float]
+      └── function: count [type=int]
+           └── variable: column5 [type=decimal]
+
+build
+SELECT SUM(1::int), SUM(2::float), SUM(3::decimal)
+----
+group-by
+ ├── columns: column2:decimal:null:2 column4:float:null:4 column6:decimal:null:6
+ ├── project
+ │    ├── columns: column1:int:null:1 column3:float:null:3 column5:decimal:null:5
+ │    ├── values
+ │    │    └── tuple [type=tuple{}]
+ │    └── projections
+ │         ├── cast: int [type=int]
+ │         │    └── const: 1 [type=int]
+ │         ├── cast: float [type=float]
+ │         │    └── const: 2.0 [type=float]
+ │         └── cast: decimal [type=decimal]
+ │              └── const: 3 [type=decimal]
+ └── aggregations
+      ├── function: sum [type=decimal]
+      │    └── variable: column1 [type=int]
+      ├── function: sum [type=float]
+      │    └── variable: column3 [type=float]
+      └── function: sum [type=decimal]
+           └── variable: column5 [type=decimal]
+
+build
+SELECT VARIANCE(1::int), VARIANCE(1::float), VARIANCE(1::decimal)
+----
+group-by
+ ├── columns: column2:decimal:null:2 column4:float:null:4 column6:decimal:null:6
+ ├── project
+ │    ├── columns: column1:int:null:1 column3:float:null:3 column5:decimal:null:5
+ │    ├── values
+ │    │    └── tuple [type=tuple{}]
+ │    └── projections
+ │         ├── cast: int [type=int]
+ │         │    └── const: 1 [type=int]
+ │         ├── cast: float [type=float]
+ │         │    └── const: 1.0 [type=float]
+ │         └── cast: decimal [type=decimal]
+ │              └── const: 1 [type=decimal]
+ └── aggregations
+      ├── function: variance [type=decimal]
+      │    └── variable: column1 [type=int]
+      ├── function: variance [type=float]
+      │    └── variable: column3 [type=float]
+      └── function: variance [type=decimal]
+           └── variable: column5 [type=decimal]
+
+build
+SELECT STDDEV(1::int), STDDEV(1::float), STDDEV(1::decimal)
+----
+group-by
+ ├── columns: column2:decimal:null:2 column4:float:null:4 column6:decimal:null:6
+ ├── project
+ │    ├── columns: column1:int:null:1 column3:float:null:3 column5:decimal:null:5
+ │    ├── values
+ │    │    └── tuple [type=tuple{}]
+ │    └── projections
+ │         ├── cast: int [type=int]
+ │         │    └── const: 1 [type=int]
+ │         ├── cast: float [type=float]
+ │         │    └── const: 1.0 [type=float]
+ │         └── cast: decimal [type=decimal]
+ │              └── const: 1 [type=decimal]
+ └── aggregations
+      ├── function: stddev [type=decimal]
+      │    └── variable: column1 [type=int]
+      ├── function: stddev [type=float]
+      │    └── variable: column3 [type=float]
+      └── function: stddev [type=decimal]
+           └── variable: column5 [type=decimal]
 
 exec-ddl
 CREATE TABLE t.bools (b BOOL)

--- a/pkg/sql/opt/optbuilder/testdata/project
+++ b/pkg/sql/opt/optbuilder/testdata/project
@@ -199,3 +199,24 @@ build
 SELECT rowid FROM b, c
 ----
 error: column reference "rowid" is ambiguous (candidates: b.rowid, c.rowid)
+
+build
+SELECT rowid::string FROM b
+----
+project
+ ├── columns: column4:string:null:4
+ ├── scan
+ │    └── columns: b.x:int:null:1 b.y:float:null:2 b.rowid:int:3
+ └── projections
+      └── cast: string [type=string]
+           └── variable: b.rowid [type=int]
+
+build
+SELECT (x, y)::timestamp FROM b
+----
+error: invalid cast: tuple{int, float} -> TIMESTAMP
+
+build
+SELECT CAST(x AS int[]) FROM b
+----
+error: invalid cast: int -> INT[]

--- a/pkg/sql/opt/optbuilder/testdata/scalar
+++ b/pkg/sql/opt/optbuilder/testdata/scalar
@@ -232,6 +232,35 @@ FALSE
 ----
 false [type=bool]
 
+build-scalar
+1::decimal
+----
+cast: decimal [type=decimal]
+ └── const: 1 [type=decimal]
+
+build-scalar
+1::float
+----
+cast: float [type=float]
+ └── const: 1.0 [type=float]
+
+build-scalar
+1.1::int
+----
+cast: int [type=int]
+ └── const: 1.1 [type=decimal]
+
+build-scalar
+'2010-05-12'::timestamp
+----
+const: '2010-05-12 00:00:00+00:00' [type=timestamp]
+
+build-scalar
+'123'::int
+----
+cast: int [type=int]
+ └── const: 123 [type=int]
+
 build-scalar vars=(int) allow-unsupported
 CASE WHEN @1 > 5 THEN 1 ELSE -1 END
 ----

--- a/pkg/sql/opt/optbuilder/testdata/select
+++ b/pkg/sql/opt/optbuilder/testdata/select
@@ -73,3 +73,20 @@ project
  └── projections
       ├── variable: a.x [type=int]
       └── variable: a.y [type=float]
+
+build
+SELECT * FROM t.a WHERE (x > 10)::bool
+----
+select
+ ├── columns: x:int:1 y:float:null:2
+ ├── scan
+ │    └── columns: a.x:int:1 a.y:float:null:2
+ └── cast: bool [type=bool]
+      └── gt [type=bool]
+           ├── variable: a.x [type=int]
+           └── const: 10 [type=int]
+
+build
+SELECT * FROM t.a WHERE (x > 10)::INT[]
+----
+error: invalid cast: bool -> INT[]

--- a/pkg/sql/opt/xform/expr.og.go
+++ b/pkg/sql/opt/xform/expr.og.go
@@ -289,6 +289,11 @@ var childCountLookup = [...]childCountLookupFunc{
 		return 1
 	},
 
+	// CastOp
+	func(ev ExprView) int {
+		return 1
+	},
+
 	// FunctionOp
 	func(ev ExprView) int {
 		functionExpr := (*functionExpr)(ev.mem.lookupExpr(ev.loc))
@@ -1107,6 +1112,18 @@ var childGroupLookup = [...]childGroupLookupFunc{
 		}
 	},
 
+	// CastOp
+	func(ev ExprView, n int) opt.GroupID {
+		castExpr := (*castExpr)(ev.mem.lookupExpr(ev.loc))
+
+		switch n {
+		case 0:
+			return castExpr.input()
+		default:
+			panic("child index out of range")
+		}
+	},
+
 	// FunctionOp
 	func(ev ExprView, n int) opt.GroupID {
 		functionExpr := (*functionExpr)(ev.mem.lookupExpr(ev.loc))
@@ -1719,6 +1736,12 @@ var privateLookup = [...]privateLookupFunc{
 		return 0
 	},
 
+	// CastOp
+	func(ev ExprView) opt.PrivateID {
+		castExpr := (*castExpr)(ev.mem.lookupExpr(ev.loc))
+		return castExpr.typ()
+	},
+
 	// FunctionOp
 	func(ev ExprView) opt.PrivateID {
 		functionExpr := (*functionExpr)(ev.mem.lookupExpr(ev.loc))
@@ -1903,6 +1926,7 @@ var isScalarLookup = [...]bool{
 	true,  // UnaryPlusOp
 	true,  // UnaryMinusOp
 	true,  // UnaryComplementOp
+	true,  // CastOp
 	true,  // FunctionOp
 	true,  // CoalesceOp
 	true,  // UnsupportedExprOp
@@ -1986,6 +2010,7 @@ var isConstValueLookup = [...]bool{
 	false, // UnaryPlusOp
 	false, // UnaryMinusOp
 	false, // UnaryComplementOp
+	false, // CastOp
 	false, // FunctionOp
 	false, // CoalesceOp
 	false, // UnsupportedExprOp
@@ -2069,6 +2094,7 @@ var isBooleanLookup = [...]bool{
 	false, // UnaryPlusOp
 	false, // UnaryMinusOp
 	false, // UnaryComplementOp
+	false, // CastOp
 	false, // FunctionOp
 	false, // CoalesceOp
 	false, // UnsupportedExprOp
@@ -2152,6 +2178,7 @@ var isComparisonLookup = [...]bool{
 	false, // UnaryPlusOp
 	false, // UnaryMinusOp
 	false, // UnaryComplementOp
+	false, // CastOp
 	false, // FunctionOp
 	false, // CoalesceOp
 	false, // UnsupportedExprOp
@@ -2235,6 +2262,7 @@ var isBinaryLookup = [...]bool{
 	false, // UnaryPlusOp
 	false, // UnaryMinusOp
 	false, // UnaryComplementOp
+	false, // CastOp
 	false, // FunctionOp
 	false, // CoalesceOp
 	false, // UnsupportedExprOp
@@ -2318,6 +2346,7 @@ var isUnaryLookup = [...]bool{
 	true,  // UnaryPlusOp
 	true,  // UnaryMinusOp
 	true,  // UnaryComplementOp
+	false, // CastOp
 	false, // FunctionOp
 	false, // CoalesceOp
 	false, // UnsupportedExprOp
@@ -2401,6 +2430,7 @@ var isRelationalLookup = [...]bool{
 	false, // UnaryPlusOp
 	false, // UnaryMinusOp
 	false, // UnaryComplementOp
+	false, // CastOp
 	false, // FunctionOp
 	false, // CoalesceOp
 	false, // UnsupportedExprOp
@@ -2484,6 +2514,7 @@ var isJoinLookup = [...]bool{
 	false, // UnaryPlusOp
 	false, // UnaryMinusOp
 	false, // UnaryComplementOp
+	false, // CastOp
 	false, // FunctionOp
 	false, // CoalesceOp
 	false, // UnsupportedExprOp
@@ -2567,6 +2598,7 @@ var isJoinApplyLookup = [...]bool{
 	false, // UnaryPlusOp
 	false, // UnaryMinusOp
 	false, // UnaryComplementOp
+	false, // CastOp
 	false, // FunctionOp
 	false, // CoalesceOp
 	false, // UnsupportedExprOp
@@ -2650,6 +2682,7 @@ var isEnforcerLookup = [...]bool{
 	false, // UnaryPlusOp
 	false, // UnaryMinusOp
 	false, // UnaryComplementOp
+	false, // CastOp
 	false, // FunctionOp
 	false, // CoalesceOp
 	false, // UnsupportedExprOp
@@ -4030,6 +4063,31 @@ func (m *memoExpr) asUnaryComplement() *unaryComplementExpr {
 		return nil
 	}
 	return (*unaryComplementExpr)(m)
+}
+
+type castExpr memoExpr
+
+func makeCastExpr(input opt.GroupID, typ opt.PrivateID) castExpr {
+	return castExpr{op: opt.CastOp, state: exprState{uint32(input), uint32(typ)}}
+}
+
+func (e *castExpr) input() opt.GroupID {
+	return opt.GroupID(e.state[0])
+}
+
+func (e *castExpr) typ() opt.PrivateID {
+	return opt.PrivateID(e.state[1])
+}
+
+func (e *castExpr) fingerprint() fingerprint {
+	return fingerprint(*e)
+}
+
+func (m *memoExpr) asCast() *castExpr {
+	if m.op != opt.CastOp {
+		return nil
+	}
+	return (*castExpr)(m)
 }
 
 // functionExpr invokes a builtin SQL function like CONCAT or NOW, passing the given

--- a/pkg/sql/opt/xform/typing.go
+++ b/pkg/sql/opt/xform/typing.go
@@ -52,6 +52,7 @@ func init() {
 		opt.ExistsOp:          typeAsBool,
 		opt.FunctionOp:        typeFunction,
 		opt.CoalesceOp:        typeCoalesce,
+		opt.CastOp:            typeCast,
 	}
 
 	for _, op := range opt.BooleanOperators {
@@ -174,4 +175,8 @@ func typeCoalesce(ev ExprView) types.T {
 	}
 
 	return typ
+}
+
+func typeCast(ev ExprView) types.T {
+	return ev.Private().(types.T)
 }

--- a/pkg/sql/sem/tree/expr.go
+++ b/pkg/sql/sem/tree/expr.go
@@ -1234,6 +1234,17 @@ func (node *CastExpr) Format(ctx *FmtCtx) {
 	}
 }
 
+// NewTypedCastExpr returns a new CastExpr that is verified to be well-typed.
+func NewTypedCastExpr(expr TypedExpr, typ types.T) (*CastExpr, error) {
+	colType, err := coltypes.DatumTypeToColumnType(typ)
+	if err != nil {
+		return nil, err
+	}
+	node := &CastExpr{Expr: expr, Type: colType}
+	node.typ = typ
+	return node, nil
+}
+
 func (node *CastExpr) castType() types.T {
 	return coltypes.CastTargetToDatumType(node.Type)
 }


### PR DESCRIPTION
Support the scalar operation Cast in the optbuilder. For
example:
  `x::int`
or
  `CAST(y AS bool)`

As part of this change, create a new scalar operator `CastOp`,
a special unary operator that stores the cast target type
as a private data member.

Release note: None