### PR TITLE
deps: bump go-libedit for bracketed paste support

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -686,8 +686,8 @@
     "unix",
     "unix/sigtramp"
   ]
-  revision = "7be5ed21ea38120269a1976f06dfd2570e41386f"
-  version = "v1.6.3"
+  revision = "92ff7be0fe45ff74fdea05fcbcaef25467f19779"
+  version = "v1.6.4"
 
 [[projects]]
   branch = "master"


### PR DESCRIPTION
"Bracketed paste" is a feature of modern terminal emulators that allows
libedit to distinguish between typed-in text and pasted-in text. Pasted
text thus won't accidentally trigger libedit macros. For example,
pasting a tab would previously trigger an unhelpful "tab completion not
supported" warning.

Fix #22706.

Release note (cli change): Bracketed pastes are requested from the
terminal emulator when possible. Pasting text into the interactive SQL
shell is more reliable as a result.