### PR TITLE
opt: Add Ordering physical property

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/optimizer
+++ b/pkg/sql/logictest/testdata/logic_test/optimizer
@@ -18,8 +18,8 @@ query II
 3  30
 
 # Select
-query error pq: ORDER BY not yet supported: SELECT \* FROM test.public.t ORDER BY t.k
-SELECT * FROM test.t ORDER BY t.k
+query error pq: ORDER BY only supports simple column references at this time
+SELECT * FROM test.t ORDER BY t.k+1
 
 # SelectClause
 query II

--- a/pkg/sql/opt/opt/physical_props_test.go
+++ b/pkg/sql/opt/opt/physical_props_test.go
@@ -46,6 +46,31 @@ func TestPhysicalProps(t *testing.T) {
 	if presentation.Provides(Presentation{}) {
 		t.Error("presentation should not provide the empty presentation")
 	}
+
+	// Add Ordering props.
+	ordering := Ordering{ColumnIndex(1), ColumnIndex(5)}
+	props.Ordering = ordering
+	testPhysicalProps(t, props, "p:a:1,b:2 o:+1,+5")
+
+	if !ordering.Defined() {
+		t.Error("ordering should be defined")
+	}
+
+	if !ordering.Provides(ordering) {
+		t.Error("ordering should provide itself")
+	}
+
+	if !ordering.Provides(Ordering{ColumnIndex(1)}) {
+		t.Error("ordering should provide the prefix ordering")
+	}
+
+	if (Ordering{}).Provides(ordering) {
+		t.Error("empty ordering should not provide ordering")
+	}
+
+	if !ordering.Provides(Ordering{}) {
+		t.Error("ordering should provide the empty ordering")
+	}
 }
 
 func testPhysicalProps(t *testing.T, physProps *PhysicalProps, expected string) {

--- a/pkg/sql/opt/optbuilder/builder.go
+++ b/pkg/sql/opt/optbuilder/builder.go
@@ -128,7 +128,7 @@ func (b *Builder) buildPhysicalProps(scope *scope) *opt.PhysicalProps {
 		col := &scope.cols[i]
 		presentation[i] = opt.LabeledColumn{Label: string(col.name), Index: col.index}
 	}
-	return &opt.PhysicalProps{Presentation: presentation}
+	return &opt.PhysicalProps{Presentation: presentation, Ordering: scope.ordering}
 }
 
 // buildStmt builds a set of memo groups that represent the given SQL

--- a/pkg/sql/opt/optbuilder/orderby.go
+++ b/pkg/sql/opt/optbuilder/orderby.go
@@ -1,0 +1,51 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package optbuilder
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/opt"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
+)
+
+// buildOrderBy builds an Ordering physical property from the ORDER BY clause.
+// ORDER BY is not a relational expression, but instead a required physical
+// property on the output. The Ordering property returned by buildOrderBy is
+// set on the scope and later becomes part of the required physical properties
+// returned by Build.
+// TODO(rytaft): Add support for ORDER BY clause that uses more than simple
+// column references.
+func (b *Builder) buildOrderBy(orderBy tree.OrderBy, inScope *scope) opt.Ordering {
+	if orderBy == nil {
+		return nil
+	}
+
+	ordering := make(opt.Ordering, 0, len(orderBy))
+
+	for i, order := range orderBy {
+		props, ok := inScope.resolveType(order.Expr, types.Any).(*columnProps)
+		if !ok {
+			panic(errorf("ORDER BY only supports simple column references at this time"))
+		}
+
+		index := props.index
+		if orderBy[i].Direction == tree.Descending {
+			index = -index
+		}
+		ordering = append(ordering, index)
+	}
+
+	return ordering
+}

--- a/pkg/sql/opt/optbuilder/scope.go
+++ b/pkg/sql/opt/optbuilder/scope.go
@@ -33,11 +33,11 @@ import (
 //
 // See builder.go for more details.
 type scope struct {
-	builder *Builder
-	parent  *scope
-	cols    []columnProps
-	groupby groupby
-	// TODO(rytaft): add ordering to scope.
+	builder  *Builder
+	parent   *scope
+	cols     []columnProps
+	groupby  groupby
+	ordering opt.Ordering
 }
 
 // groupByStrSet is a set of stringified GROUP BY expressions.

--- a/pkg/sql/opt/optbuilder/select.go
+++ b/pkg/sql/opt/optbuilder/select.go
@@ -143,23 +143,32 @@ func (b *Builder) buildSelect(
 	// NB: The case statements are sorted lexicographically.
 	switch t := stmt.Select.(type) {
 	case *tree.ParenSelect:
-		return b.buildSelect(t.Select, inScope)
+		out, outScope = b.buildSelect(t.Select, inScope)
 
 	case *tree.SelectClause:
-		return b.buildSelectClause(stmt, inScope)
+		out, outScope = b.buildSelectClause(stmt, inScope)
 
 	case *tree.ValuesClause:
-		return b.buildValuesClause(t, inScope)
+		out, outScope = b.buildValuesClause(t, inScope)
 
-	// TODO(rytaft): Add support for union clause.
+		// TODO(rytaft): Add support for union clause.
 
 	default:
 		panic(errorf("not yet implemented: select statement: %T", stmt.Select))
 	}
 
-	// TODO(rytaft): Add support for ORDER BY expression.
+	// TODO(rytaft): Add full support for ORDER BY expression. This simple
+	// version only supports ordering by projected columns. It does not support
+	// order by expressions, or ordering by FROM columns. Also, take care to
+	// correctly handle cases like `SELECT a FROM t ORDER BY c`. The ordered
+	// property can only contain refs to output columns, so the `c` column
+	// must be retained in the projection (and presentation property then omits
+	// it.
+	outScope.ordering = b.buildOrderBy(stmt.OrderBy, outScope)
+
 	// TODO(rytaft): Support FILTER expression.
 	// TODO(peter): stmt.Limit
+	return out, outScope
 }
 
 // buildSelectClause builds a set of memo groups that represent the given
@@ -189,11 +198,7 @@ func (b *Builder) buildSelectClause(
 		projections = b.buildProjectionList(sel.Exprs, fromScope, projectionsScope)
 	}
 
-	if stmt.OrderBy != nil {
-		// TODO(rytaft): Build Order By. Order By relies on the existence of
-		// ordering physical properties.
-		panic(errorf("ORDER BY not yet supported: %s", stmt.String()))
-	}
+	// TODO(rytaft): Handle Order By that can depend on from columns.
 
 	// Don't add an unnecessary "pass through" project expression.
 	if !projectionsScope.hasSameColumns(outScope) {

--- a/pkg/sql/opt/optbuilder/testdata/orderby
+++ b/pkg/sql/opt/optbuilder/testdata/orderby
@@ -1,0 +1,146 @@
+# tests adapted from logictest -- order_by
+
+exec-ddl
+CREATE TABLE t (
+  a INT PRIMARY KEY,
+  b INT,
+  c BOOLEAN
+)
+----
+TABLE t
+ ├── a int not null
+ ├── b int
+ ├── c bool
+ └── INDEX primary
+      └── a int not null
+
+build
+SELECT c FROM t ORDER BY c
+----
+project
+ ├── columns: c:bool:null:3
+ ├── ordering: +3
+ ├── sort
+ │    ├── columns: t.a:int:1 t.b:int:null:2 t.c:bool:null:3
+ │    ├── ordering: +3
+ │    └── scan
+ │         └── columns: t.a:int:1 t.b:int:null:2 t.c:bool:null:3
+ └── projections
+      └── variable: t.c [type=bool]
+
+build
+SELECT c FROM t ORDER BY c DESC
+----
+project
+ ├── columns: c:bool:null:3
+ ├── ordering: -3
+ ├── sort
+ │    ├── columns: t.a:int:1 t.b:int:null:2 t.c:bool:null:3
+ │    ├── ordering: -3
+ │    └── scan
+ │         └── columns: t.a:int:1 t.b:int:null:2 t.c:bool:null:3
+ └── projections
+      └── variable: t.c [type=bool]
+
+build
+SELECT a, b FROM t ORDER BY b
+----
+project
+ ├── columns: a:int:1 b:int:null:2
+ ├── ordering: +2
+ ├── sort
+ │    ├── columns: t.a:int:1 t.b:int:null:2 t.c:bool:null:3
+ │    ├── ordering: +2
+ │    └── scan
+ │         └── columns: t.a:int:1 t.b:int:null:2 t.c:bool:null:3
+ └── projections
+      ├── variable: t.a [type=int]
+      └── variable: t.b [type=int]
+
+build
+SELECT a, b FROM t ORDER BY b DESC
+----
+project
+ ├── columns: a:int:1 b:int:null:2
+ ├── ordering: -2
+ ├── sort
+ │    ├── columns: t.a:int:1 t.b:int:null:2 t.c:bool:null:3
+ │    ├── ordering: -2
+ │    └── scan
+ │         └── columns: t.a:int:1 t.b:int:null:2 t.c:bool:null:3
+ └── projections
+      ├── variable: t.a [type=int]
+      └── variable: t.b [type=int]
+
+build
+SELECT a AS foo, b FROM t ORDER BY foo DESC
+----
+project
+ ├── columns: foo:int:1 b:int:null:2
+ ├── ordering: -1
+ ├── sort
+ │    ├── columns: t.a:int:1 t.b:int:null:2 t.c:bool:null:3
+ │    ├── ordering: -1
+ │    └── scan
+ │         └── columns: t.a:int:1 t.b:int:null:2 t.c:bool:null:3
+ └── projections
+      ├── variable: t.a [type=int]
+      └── variable: t.b [type=int]
+
+build
+SELECT a, b FROM t WHERE b = 7 ORDER BY b, a
+----
+project
+ ├── columns: a:int:1 b:int:null:2
+ ├── ordering: +2,+1
+ ├── select
+ │    ├── columns: t.a:int:1 t.b:int:null:2 t.c:bool:null:3
+ │    ├── ordering: +2,+1
+ │    ├── sort
+ │    │    ├── columns: t.a:int:1 t.b:int:null:2 t.c:bool:null:3
+ │    │    ├── ordering: +2,+1
+ │    │    └── scan
+ │    │         └── columns: t.a:int:1 t.b:int:null:2 t.c:bool:null:3
+ │    └── eq [type=bool]
+ │         ├── variable: t.b [type=int]
+ │         └── const: 7 [type=int]
+ └── projections
+      ├── variable: t.a [type=int]
+      └── variable: t.b [type=int]
+
+build
+SELECT a, b FROM t ORDER BY b, a DESC
+----
+project
+ ├── columns: a:int:1 b:int:null:2
+ ├── ordering: +2,-1
+ ├── sort
+ │    ├── columns: t.a:int:1 t.b:int:null:2 t.c:bool:null:3
+ │    ├── ordering: +2,-1
+ │    └── scan
+ │         └── columns: t.a:int:1 t.b:int:null:2 t.c:bool:null:3
+ └── projections
+      ├── variable: t.a [type=int]
+      └── variable: t.b [type=int]
+
+build
+SELECT a, b, a+b AS ab FROM t WHERE b = 7 ORDER BY ab DESC, a
+----
+sort
+ ├── columns: a:int:1 b:int:null:2 ab:int:null:4
+ ├── ordering: -4,+1
+ └── project
+      ├── columns: t.a:int:1 t.b:int:null:2 ab:int:null:4
+      ├── select
+      │    ├── columns: t.a:int:1 t.b:int:null:2 t.c:bool:null:3
+      │    ├── scan
+      │    │    └── columns: t.a:int:1 t.b:int:null:2 t.c:bool:null:3
+      │    └── eq [type=bool]
+      │         ├── variable: t.b [type=int]
+      │         └── const: 7 [type=int]
+      └── projections
+           ├── variable: t.a [type=int]
+           ├── variable: t.b [type=int]
+           └── plus [type=int]
+                ├── variable: t.a [type=int]
+                └── variable: t.b [type=int]

--- a/pkg/sql/opt/xform/best_expr.go
+++ b/pkg/sql/opt/xform/best_expr.go
@@ -1,0 +1,70 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package xform
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/opt"
+	"github.com/cockroachdb/cockroach/pkg/util"
+)
+
+// bestExpr references the lowest cost expression in a memo group for a given
+// set of required physical properties. The memo group maintains a map from
+// physical property set to the best expression that provides that set.
+type bestExpr struct {
+	// op is the operator type of the lowest cost expression.
+	op opt.Operator
+
+	// fullyOptimized is true if the lowest cost expression has been found for
+	// this memo group, with respect to the physical properties which map to
+	// this bestExpr. A lower cost expression will never be found, no matter
+	// how many additional optimization passes are made.
+	fullyOptimized bool
+
+	// fullyOptimizedExprs contains the set of expression ids (exprIDs) that
+	// have been fully optimized for the required properties. These never need
+	// to be recosted, no matter how many additional optimization passes are
+	// made.
+	fullyOptimizedExprs util.FastIntSet
+
+	// lowest is the index of the lowest cost expression in the memo group,
+	// with respect to the physical properties which map to this bestExpr.
+	lowest exprID
+}
+
+// ratchetCost overwrites the existing best expression if the new cost is
+// lower.
+// TODO(andyk): Currently, there is no costing function, so just assume that
+// the first expression is the lowest cost.
+func (be *bestExpr) ratchetCost(ev ExprView) {
+	if be.op == opt.UnknownOp {
+		be.op = ev.Operator()
+		be.lowest = ev.loc.expr
+	}
+}
+
+// isFullyOptimized is set to true once the lowest cost expression is
+// guaranteed to have been found. No further changes to this bestExpr can
+// occur.
+func (be *bestExpr) isFullyOptimized() bool {
+	return be.fullyOptimized
+}
+
+func (be *bestExpr) isExprFullyOptimized(eid exprID) bool {
+	return be.fullyOptimizedExprs.Contains(int(eid))
+}
+
+func (be *bestExpr) markExprAsFullyOptimized(eid exprID) {
+	be.fullyOptimizedExprs.Add(int(eid))
+}

--- a/pkg/sql/opt/xform/memo.go
+++ b/pkg/sql/opt/xform/memo.go
@@ -17,10 +17,13 @@ package xform
 import (
 	"bytes"
 	"fmt"
+	"sort"
+	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/optbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/util/treeprinter"
 )
 
 // memoLoc describes the location of an expression in the memo, which is a
@@ -118,6 +121,11 @@ type memo struct {
 	// logPropsFactory is used to derive logical properties for an expression,
 	// based on the logical properties of its children.
 	logPropsFactory logicalPropsFactory
+
+	// physPropsFactory is used to derive required physical properties for the
+	// children of an expression, based on the required physical properties for
+	// the parent.
+	physPropsFactory physicalPropsFactory
 
 	// Intern the set of unique physical properties used by expressions in the
 	// memo, since there are so many duplicates.
@@ -296,12 +304,107 @@ func (m *memo) lookupPrivate(id opt.PrivateID) interface{} {
 }
 
 func (m *memo) String() string {
+	tp := treeprinter.New()
+	root := tp.Child("memo")
+
 	var buf bytes.Buffer
 	for i := len(m.groups) - 1; i > 0; i-- {
 		mgrp := &m.groups[i]
-		fmt.Fprintf(&buf, "%d:", i)
-		fmt.Fprintf(&buf, " %s", mgrp.memoGroupString(m))
-		fmt.Fprintf(&buf, "\n")
+
+		buf.Reset()
+		for i := range mgrp.exprs {
+			if i != 0 {
+				buf.WriteByte(' ')
+			}
+
+			// Wrap the memo expr in ExprView to make it easy to get children.
+			eid := exprID(i)
+			ev := ExprView{
+				mem:      m,
+				loc:      memoLoc{group: mgrp.id, expr: eid},
+				op:       mgrp.exprs[eid].op,
+				required: opt.MinPhysPropsID,
+			}
+
+			m.formatExpr(ev, &buf, false /* includeRequired */)
+		}
+
+		child := root.Childf("%d: %s", i, buf.String())
+		m.formatBestExprs(mgrp, child)
 	}
-	return buf.String()
+
+	return tp.String()
+}
+
+type bestExprSort struct {
+	required    opt.PhysicalPropsID
+	fingerprint string
+	bestExpr    *bestExpr
+}
+
+func (m *memo) formatBestExprs(mgrp *memoGroup, tp treeprinter.Node) {
+	// Sort the bestExprs by required properties.
+	beSort := make([]bestExprSort, 0, len(mgrp.bestExprs))
+	mgrp.forEachBestExpr(func(required opt.PhysicalPropsID, best *bestExpr) {
+		beSort = append(beSort, bestExprSort{
+			required:    required,
+			fingerprint: m.lookupPhysicalProps(required).Fingerprint(),
+			bestExpr:    best,
+		})
+	})
+
+	sort.Slice(beSort, func(i, j int) bool {
+		return strings.Compare(beSort[i].fingerprint, beSort[j].fingerprint) < 0
+	})
+
+	var buf bytes.Buffer
+	for _, be := range beSort {
+		buf.Reset()
+
+		// Don't show best expressions for scalar groups because they're not too
+		// interesting.
+		ev := makeExprView(m, mgrp.id, be.required)
+		if !ev.IsScalar() {
+			child := tp.Childf("\"%s\" [cost=0.0]", be.fingerprint)
+
+			m.formatExpr(ev, &buf, true /* includeRequired */)
+			child.Childf("best: %s", buf.String())
+		}
+	}
+}
+
+func (m *memo) formatExpr(ev ExprView, buf *bytes.Buffer, includeRequired bool) {
+	fmt.Fprintf(buf, "(%s", ev.Operator())
+
+	private := ev.Private()
+	if private != nil {
+		switch t := private.(type) {
+		case nil:
+		case opt.TableIndex:
+			fmt.Fprintf(buf, " %s", m.metadata.Table(t).TabName())
+		case opt.ColumnIndex:
+			fmt.Fprintf(buf, " %s", m.metadata.ColumnLabel(t))
+		case *opt.ColSet, *opt.ColMap, *opt.ColList:
+			// Don't show anything, because it's mostly redundant.
+		default:
+			fmt.Fprintf(buf, " %s", private)
+		}
+	}
+
+	if ev.ChildCount() > 0 {
+		for i := 0; i < ev.ChildCount(); i++ {
+			child := ev.ChildGroup(i)
+			fmt.Fprintf(buf, " %d", child)
+
+			if !includeRequired {
+				// Print properties required of the child if they are interesting.
+				required := m.physPropsFactory.constructChildProps(ev, i)
+				if required != opt.MinPhysPropsID {
+					fmt.Fprintf(buf, "=\"%s\"", m.lookupPhysicalProps(required).Fingerprint())
+				}
+			}
+		}
+	}
+
+	buf.WriteString(")")
 }

--- a/pkg/sql/opt/xform/optimizer.go
+++ b/pkg/sql/opt/xform/optimizer.go
@@ -15,6 +15,8 @@
 package xform
 
 import (
+	"fmt"
+
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/optbase"
 	"golang.org/x/tools/container/intsets"
@@ -76,9 +78,327 @@ func (o *Optimizer) Factory() opt.Factory {
 // properties at the lowest possible execution cost, but is still logically
 // equivalent to the given expression. If there is a cost "tie", then any one
 // of the qualifying lowest cost expressions may be selected by the optimizer.
-// TODO(andyk): For now, the input tree becomes the output tree, with no
-// transformations applied to it.
 func (o *Optimizer) Optimize(root opt.GroupID, requiredProps *opt.PhysicalProps) ExprView {
+	mgrp := o.mem.lookupGroup(root)
 	required := o.mem.internPhysicalProps(requiredProps)
+	best := o.optimizeGroup(mgrp, required)
+	if best.op == opt.UnknownOp {
+		panic("optimization step returned invalid result")
+	}
 	return makeExprView(o.mem, root, required)
+}
+
+// optimizeGroup enumerates expression trees rooted in the given memo group and
+// finds the expression tree with the lowest cost (i.e. the "best") that
+// provides the given required physical properties. Enforcers are added as
+// needed to provide the required properties.
+//
+// The following is a simplified walkthrough of how the optimizer might handle
+// the following SQL query:
+//
+//   SELECT * FROM a WHERE x=1 ORDER BY y
+//
+// Before the optimizer is invoked, the memo group contains a single normalized
+// expression:
+//
+//   memo
+//    ├── 5: (select 1 4)
+//    ├── 4: (eq 3 2)
+//    ├── 3: (variable x)
+//    ├── 2: (const 1)
+//    └── 1: (scan a)
+//
+// Optimization begins at the root of the memo (group #5), and calls
+// optimizeGroup with the properties required of that group ("ordering:y").
+// optimizeGroup then calls optimizeExpr for the Select expression, which
+// checks whether the expression can provide the required properties. Since
+// Select is a pass-through operator, it can provide the properties by passing
+// through the requirement to its input. Accordingly, optimizeExpr recursively
+// invokes optimizeGroup on select's input child (group #1), with the same set
+// of required properties.
+//
+// Now the same set of steps are applied to group #1. However, the Scan
+// expression cannot provide the required ordering (say because it's ordered on
+// x rather than y). The optimizer must add a Sort enforcer. It does this by
+// recursively invoking optimizeGroup on the same group #1, but this time
+// without the ordering requirement. The Scan operator is capable of meeting
+// these reduced requirements, so it is costed and added as the current lowest
+// cost expression (bestExpr) for that group for that set of properties (i.e.
+// the empty set).
+//
+//   memo
+//    ├── 5: (select 1 4)
+//    ├── 4: (eq 3 2)
+//    ├── 3: (variable x)
+//    ├── 2: (const 1)
+//    └── 1: (scan a)
+//         └── "" [cost=100.0]
+//              └── best: (scan a)
+//
+// The recursion pops up a level, and now the Sort enforcer knows its input,
+// and so it too can be costed (cost of input + extra cost of sort) and added
+// as the best expression for the property set with the ordering requirement.
+//
+//   memo
+//    ├── 5: (select 1 4)
+//    ├── 4: (eq 3 2)
+//    ├── 3: (variable x)
+//    ├── 2: (const 1)
+//    └── 1: (scan a)
+//         ├── "" [cost=100.0]
+//         │    └── best: (scan a)
+//         └── "ordering:y" [cost=150.0]
+//              └── best: (sort 1)
+//
+// Recursion pops up another level, and the Select operator now knows its input
+// (the Sort of the Scan). It then moves on to its scalar filter child and
+// optimizes it and its descendants, which is relatively uninteresting since
+// there are no enforcers to consider. Once all children have been optimized,
+// the Select operator can now be costed and added as the best expression for
+// the ordering requirement. It requires the same ordering requirement from its
+// input child (i.e. the scan).
+//
+//   memo
+//    ├── 5: (select 1 4)
+//    │    └── "ordering:y" [cost=160.0]
+//    │         └── best: (select 1="ordering:y" 4)
+//    ├── 4: (eq 3 2)
+//    ├── 3: (variable x)
+//    ├── 2: (const 1)
+//    └── 1: (scan a)
+//         ├── "" [cost=100.0]
+//         │    └── best: (scan a)
+//         └── "ordering:y" [cost=150.0]
+//              └── best: (sort 1)
+//
+// But the process is not yet complete. After traversing the Select child
+// groups, optimizeExpr generates an alternate plan that satisfies the ordering
+// property by using a top-level enforcer. It does this by recursively invoking
+// optimizeGroup for group #5, but without the ordering requirement, analogous
+// to what it did for group #1. This triggers optimization for each child group
+// of the Select operator. But this time, the memo already has fully-costed
+// best expressions available for both the Input and Filter children, and so
+// returns them immediately with no extra work. The Select expression is now
+// costed and added as the best expression without an ordering requirement.
+//
+//   memo
+//    ├── 5: (select 1 4)
+//    │    ├── "" [cost=110.0]
+//    │    │    └── best: (select 1 4)
+//    │    └── "ordering:y" [cost=160.0]
+//    │         └── best: (select 1="ordering:y" 4)
+//    ├── 4: (eq 3 2)
+//    ├── 3: (variable x)
+//    ├── 2: (const 1)
+//    └── 1: (scan a)
+//         ├── "" [cost=100.0]
+//         │    └── best: (scan a)
+//         └── "ordering:y" [cost=150.0]
+//              └── best: (sort 1)
+//
+// Finally, the Sort enforcer for group #5 has its input and can be costed. But
+// rather than costing 50.0 like the other Sort enforcer, this one only costs
+// 1.0, because it's sorting a tiny set of filtered rows. That means its total
+// cost is only 111.0, which makes it the new best expression for group #5 with
+// an ordering requirement:
+//
+//   memo
+//    ├── 5: (select 1 4)
+//    │    ├── "" [cost=110.0]
+//    │    │    └── best: (select 1 4)
+//    │    └── "ordering:y" [cost=111.0]
+//    │         └── best: (sort 5)
+//    ├── 4: (eq 3 2)
+//    ├── 3: (variable x)
+//    ├── 2: (const 1)
+//    └── 1: (scan a)
+//         ├── "" [cost=100.0]
+//         │    └── best: (scan a)
+//         └── "ordering:y" [cost=150.0]
+//              └── best: (sort 1)
+//
+// Now the memo has been fully optimized, and the best expression for group #5
+// and "ordering:y" can be recursively extracted by ExprView:
+//
+//   sort
+//    ├── columns: x:1(int) y:2(int)
+//    ├── ordering: +2
+//    └── select
+//         ├── columns: x:1(int) y:2(int)
+//         ├── scan
+//         │    └── columns: x:1(int) y:2(int)
+//         └── eq [type=bool]
+//              ├── variable: a.x [type=int]
+//              └── const: 1 [type=int]
+//
+func (o *Optimizer) optimizeGroup(mgrp *memoGroup, required opt.PhysicalPropsID) *bestExpr {
+	// If this group is already fully optimized, then return the already
+	// prepared best expression (won't ever get better than this).
+	best := mgrp.ensureBestExpr(required)
+	if best.fullyOptimized {
+		return best
+	}
+
+	groupFullyOptimized := true
+
+	for i := range mgrp.exprs {
+		eid := exprID(i)
+
+		// If this expression has already been fully optimized for the given
+		// required properties, then skip it, since it won't get better.
+		if best.isExprFullyOptimized(eid) {
+			continue
+		}
+
+		// Optimize the expression with respect to the required properties.
+		best = o.optimizeExpr(mgrp, eid, required)
+
+		// If any of the expressions have not yet been fully optimized, then
+		// the group is not yet fully optimized.
+		if !best.isExprFullyOptimized(eid) {
+			groupFullyOptimized = false
+		}
+	}
+
+	if groupFullyOptimized {
+		// If exploration and costing of this group for the given required
+		// properties is complete, then skip it in all future optimization
+		// passes.
+		best.fullyOptimized = true
+	}
+
+	return best
+}
+
+// optimizeExpr determines whether the given expression can provide the
+// required properties. If so, it recursively optimizes the expression's child
+// groups and computes the cost of the expression. In addition, optimizeExpr
+// calls enforceProps to check whether enforcers can provide the required
+// properties at a lower cost. The best expression is saved in the bestExpr map
+// in the memo group and returned.
+func (o *Optimizer) optimizeExpr(
+	mgrp *memoGroup, eid exprID, required opt.PhysicalPropsID,
+) (best *bestExpr) {
+	// Create an ExprView for convenient access to the expression. Don't
+	// use makeExprView to do this, because the bestExpr map isn't yet fully
+	// populated (that's what the optimizer is trying to do!).
+	ev := ExprView{
+		mem:      o.mem,
+		loc:      memoLoc{group: mgrp.id, expr: eid},
+		op:       mgrp.lookupExpr(eid).op,
+		required: required,
+	}
+
+	fullyOptimized := true
+
+	// If the expression cannot provide the required properties, then don't
+	// continue. But what if the expression is able to provide a subset of the
+	// properties? That case is taken care of by enforceProps, which will
+	// recursively optimize the group with property subsets and then add
+	// enforcers to provide the remainder.
+	if o.mem.physPropsFactory.canProvide(ev, required) {
+		for child := 0; child < ev.ChildCount(); child++ {
+			childGroup := o.mem.lookupGroup(ev.ChildGroup(child))
+
+			// Given required parent properties, get the properties required from
+			// the nth child.
+			childRequired := o.mem.physPropsFactory.constructChildProps(ev, child)
+
+			// Recursively optimize the child group with respect to that set of
+			// properties.
+			bestChild := o.optimizeGroup(childGroup, childRequired)
+
+			// If any child expression is not fully optimized, then the parent
+			// expression is also not fully optimized.
+			if !bestChild.isFullyOptimized() {
+				fullyOptimized = false
+			}
+		}
+
+		// Check whether this is the new lowest cost expression.
+		// TODO(andyk): Actually run the costing function in the future.
+		best = mgrp.lookupBestExpr(ev.required)
+		best.ratchetCost(ev)
+	}
+
+	// Compute the cost for enforcers to provide the required properties. This
+	// may be lower than the expression providing the properties itself. For
+	// example, it might be better to sort the results of a hash join than to
+	// use the results of a merge join that are already sorted, but at the cost
+	// of requiring one of the merge join children to be sorted.
+	fullyOptimized = o.enforceProps(ev) && fullyOptimized
+
+	// Get the lowest cost expression after considering enforcers, and mark it
+	// as fully optimized if all the combinations have been considered.
+	best = mgrp.lookupBestExpr(required)
+	if fullyOptimized {
+		best.markExprAsFullyOptimized(eid)
+	}
+
+	return best
+}
+
+// enforceProps costs an expression where one of the physical properties has
+// been provided by an enforcer rather than by the expression itself. There are
+// two reasons why this is necessary/desirable:
+//   1. The expression may not be able to provide the property on its own. For
+//      example, a hash join cannot provide ordered results.
+//   2. The enforcer might be able to provide the property at lower overall
+//      cost. For example, an enforced sort on top of a hash join might be
+//      lower cost than a merge join that is already sorted, but at the cost of
+//      requiring one of its children to be sorted.
+//
+// Note that enforceProps will recursively optimize this same group, but with
+// one less required physical property. The recursive call will eventually make
+// its way back here, at which point another physical property will be stripped
+// off, and so on. Afterwards, the group will have computed a bestExpr for each
+// sublist of physical properties, from all down to none.
+func (o *Optimizer) enforceProps(ev ExprView) (fullyOptimized bool) {
+	props := ev.Physical()
+	innerProps := *props
+
+	// Ignore the Presentation property, since any relational or enforcer
+	// operator can provide it.
+	innerProps.Presentation = nil
+
+	// Strip off one property that can be enforced. Other properties will be
+	// stripped by recursively optimizing the group with successively fewer
+	// properties. The properties are stripped off in a heuristic order, from
+	// least likely to be expensive to enforce to most likely.
+	var enforcerOp opt.Operator
+	if props.Ordering.Defined() {
+		enforcerOp = opt.SortOp
+		innerProps.Ordering = nil
+	} else {
+		// No remaining properties, so no more enforcers.
+		if innerProps.Defined() {
+			panic(fmt.Sprintf("unhandled physical property: %v", innerProps))
+		}
+		return
+	}
+
+	// Recursively optimize the same group, but now with respect to the "inner"
+	// properties (which are a sublist of the required properties).
+	mgrp := o.mem.lookupGroup(ev.loc.group)
+	innerRequired := o.mem.internPhysicalProps(&innerProps)
+	innerBest := o.optimizeGroup(mgrp, innerRequired)
+	fullyOptimized = innerBest.isFullyOptimized()
+
+	// Check whether this is the new lowest cost expression with the enforcer
+	// added. Note that the enforcer is not in the group's exprs slice, so its
+	// memoLoc.expr field is 0.
+	// TODO(andyk): Actually run the costing function in the future.
+	enforcer := ExprView{
+		mem:      o.mem,
+		loc:      memoLoc{group: ev.loc.group},
+		op:       enforcerOp,
+		required: ev.required,
+	}
+
+	best := mgrp.lookupBestExpr(ev.required)
+	best.ratchetCost(enforcer)
+
+	// Enforcer expression is fully optimized if its input expression is fully
+	// optimized.
+	return fullyOptimized
 }

--- a/pkg/sql/opt/xform/optimizer_test.go
+++ b/pkg/sql/opt/xform/optimizer_test.go
@@ -16,6 +16,7 @@ package xform
 
 import (
 	"context"
+	"fmt"
 	"path/filepath"
 	"testing"
 
@@ -31,6 +32,14 @@ import (
 //   ...
 func TestRules(t *testing.T) {
 	runDataDrivenTest(t, "testdata/rules/*")
+}
+
+// PhysProps files can be run separately like this:
+//   make test PKG=./pkg/sql/opt/xform TESTS="TestPhysicalProps/ordering"
+//   make test PKG=./pkg/sql/opt/xform TESTS="TestPhysicalProps/presentation"
+//   ...
+func TestPhysicalProps(t *testing.T) {
+	runDataDrivenTest(t, "testdata/physprops/*")
 }
 
 // runDataDrivenTest
@@ -58,7 +67,7 @@ func runDataDrivenTest(t *testing.T, testdataGlob string) {
 				}
 
 				switch d.Cmd {
-				case "build", "opt":
+				case "build", "opt", "memo":
 					// build command disables optimizations, opt enables them.
 					var steps OptimizeSteps
 					if d.Cmd == "build" {
@@ -73,6 +82,10 @@ func runDataDrivenTest(t *testing.T, testdataGlob string) {
 						d.Fatalf(t, "%v", err)
 					}
 					exprView := o.Optimize(root, props)
+
+					if d.Cmd == "memo" {
+						return fmt.Sprintf("[%d: \"%s\"]\n%s", root, props.String(), o.mem.String())
+					}
 					return exprView.String()
 
 				default:

--- a/pkg/sql/opt/xform/physical_props_factory.go
+++ b/pkg/sql/opt/xform/physical_props_factory.go
@@ -1,0 +1,165 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package xform
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/opt"
+)
+
+// physicalPropsFactory determines what physical properties a given expression
+// provides and constructs the physical properties required of its children
+// based on those properties. The optimizer calls the canProvide methods to
+// determine whether an expression provides a required physical property. If it
+// does not, then the optimizer inserts an enforcer operator that is able to
+// provide it. Some operators, like Select and Project, may not directly
+// provide a required physical property, but do "pass through" the requirement
+// to their input. Operators that do this should return true from the
+// appropriate canProvide method and then pass through that property in the
+// constructChildProps method.
+// NOTE: The factory is defined as an empty struct with methods rather than as
+//       functions in order to keep the methods grouped and self-contained.
+type physicalPropsFactory struct{}
+
+// canProvide returns true if the given expression can provide the required
+// physical properties. Don't access child expressions using the view (child
+// groups are OK), because they are not guaranteed to be available yet, since
+// physical properties are required starting at the root of the tree and
+// proceeding downwards (top-down).
+func (f physicalPropsFactory) canProvide(ev ExprView, required opt.PhysicalPropsID) bool {
+	requiredProps := ev.mem.lookupPhysicalProps(required)
+
+	if requiredProps.Presentation.Defined() {
+		if !f.canProvidePresentation(ev, requiredProps.Presentation) {
+			return false
+		}
+	}
+
+	if requiredProps.Ordering.Defined() {
+		if !f.canProvideOrdering(ev, requiredProps.Ordering) {
+			return false
+		}
+	}
+
+	return true
+}
+
+// canProvidePresentation returns true if the given expression can provide the
+// required presentation property. Currently, all relational operators are
+// capable of doing this.
+func (f physicalPropsFactory) canProvidePresentation(ev ExprView, required opt.Presentation) bool {
+	if !ev.IsRelational() {
+		panic("presentation property doesn't apply to non-relational operators")
+	}
+
+	// All operators can provide the Presentation property.
+	return true
+}
+
+// canProvideOrdering returns true if the given expression can provide the
+// required ordering property.
+func (f physicalPropsFactory) canProvideOrdering(ev ExprView, required opt.Ordering) bool {
+	if !ev.IsRelational() {
+		panic("ordering property doesn't apply to non-relational operators")
+	}
+
+	switch ev.Operator() {
+	case opt.SelectOp:
+		// Select operator can always pass through ordering to its input.
+		return true
+
+	case opt.ProjectOp:
+		// Project operator can pass through ordering if it operates only on
+		// input columns.
+		inputCols := ev.lookupChildGroup(0).logical.Relational.OutputCols
+		for _, colOrder := range required {
+			if colOrder < 0 {
+				// Descending order, so recover original index.
+				colOrder = -colOrder
+			}
+			if !inputCols.Contains(int(colOrder)) {
+				return false
+			}
+		}
+		return true
+
+	case opt.ScanOp:
+		// Scan naturally orders according to the primary index.
+		tblIdx := ev.Private().(opt.TableIndex)
+		primary := ev.Metadata().Table(tblIdx).Primary()
+
+		ordering := make(opt.Ordering, primary.ColumnCount())
+		for i := 0; i < primary.ColumnCount(); i++ {
+			idxCol := primary.Column(i)
+			ordering[i] = ev.Metadata().TableColumn(tblIdx, idxCol.Ordinal)
+			if idxCol.Descending {
+				// Negative metadata column index indicates descending order.
+				ordering[i] = -ordering[i]
+			}
+		}
+
+		return ordering.Provides(required)
+	}
+
+	return false
+}
+
+// constructChildProps returns the set of physical properties required of the
+// nth child, based upon the properties required of the parent. For example,
+// the Project operator passes through any ordering requirement to its child,
+// but provides any presentation requirement. This method is heavily called
+// during ExprView traversal, so performance is important.
+func (f physicalPropsFactory) constructChildProps(ev ExprView, nth int) opt.PhysicalPropsID {
+	// Fast path taken in common case when no properties are required of parent;
+	// in that case, no properties are required of children. This will change in
+	// the future when certain operators like MergeJoin require input properties
+	// from their children regardless of what's required of them.
+	if ev.required == opt.MinPhysPropsID {
+		return opt.MinPhysPropsID
+	}
+
+	parentProps := ev.Physical()
+
+	var childProps opt.PhysicalProps
+	var changed bool
+
+	// Presentation property is provided by all the relational operators, so
+	// don't add it to childProps.
+	if parentProps.Presentation.Defined() {
+		changed = true
+	}
+
+	// Check for operators that might pass through the ordering property to
+	// input.
+	if parentProps.Ordering.Defined() {
+		switch ev.Operator() {
+		case opt.SelectOp, opt.ProjectOp:
+			if nth == 0 {
+				childProps.Ordering = parentProps.Ordering
+				break
+			}
+			fallthrough
+
+		default:
+			changed = true
+		}
+	}
+
+	// If properties haven't changed, then don't need to re-intern them.
+	if !changed {
+		return ev.required
+	}
+
+	return ev.mem.internPhysicalProps(&childProps)
+}

--- a/pkg/sql/opt/xform/testdata/physprops/ordering
+++ b/pkg/sql/opt/xform/testdata/physprops/ordering
@@ -1,0 +1,244 @@
+exec-ddl
+CREATE TABLE t.a
+(
+    x INT,
+    y FLOAT,
+    z DECIMAL,
+    s STRING NOT NULL,
+    PRIMARY KEY (x, y DESC)
+)
+----
+TABLE a
+ ├── x int not null
+ ├── y float not null
+ ├── z decimal
+ ├── s string not null
+ └── INDEX primary
+      ├── x int not null
+      └── y float not null desc
+
+# --------------------------------------------------
+# Scan operator.
+# --------------------------------------------------
+
+# Order by entire key, in same order as key.
+opt
+SELECT * FROM a ORDER BY x, y DESC
+----
+scan
+ ├── columns: x:int:1 y:float:2 z:decimal:null:3 s:string:4
+ └── ordering: +1,-2
+
+# Order by prefix.
+opt
+SELECT * FROM a ORDER BY x
+----
+scan
+ ├── columns: x:int:1 y:float:2 z:decimal:null:3 s:string:4
+ └── ordering: +1
+
+# Order by suffix (scan shouldn't be able to provide).
+opt
+SELECT * FROM a ORDER BY y DESC
+----
+sort
+ ├── columns: x:int:1 y:float:2 z:decimal:null:3 s:string:4
+ ├── ordering: -2
+ └── scan
+      └── columns: a.x:int:1 a.y:float:2 a.z:decimal:null:3 a.s:string:4
+
+# Order by additional column (scan shouldn't be able to provide for now).
+opt
+SELECT * FROM a ORDER BY x, y DESC, z
+----
+sort
+ ├── columns: x:int:1 y:float:2 z:decimal:null:3 s:string:4
+ ├── ordering: +1,-2,+3
+ └── scan
+      └── columns: a.x:int:1 a.y:float:2 a.z:decimal:null:3 a.s:string:4
+
+# --------------------------------------------------
+# Select operator (pass through).
+# --------------------------------------------------
+
+# Pass through ordering to scan operator that can support it.
+opt
+SELECT * FROM a WHERE x=1 ORDER BY x, y DESC
+----
+select
+ ├── columns: x:int:1 y:float:2 z:decimal:null:3 s:string:4
+ ├── ordering: +1,-2
+ ├── scan
+ │    ├── columns: a.x:int:1 a.y:float:2 a.z:decimal:null:3 a.s:string:4
+ │    └── ordering: +1,-2
+ └── eq [type=bool]
+      ├── variable: a.x [type=int]
+      └── const: 1 [type=int]
+
+# Pass through ordering to scan operator that can't support it.
+opt
+SELECT * FROM a WHERE x=1 ORDER BY z DESC
+----
+select
+ ├── columns: x:int:1 y:float:2 z:decimal:null:3 s:string:4
+ ├── ordering: -3
+ ├── sort
+ │    ├── columns: a.x:int:1 a.y:float:2 a.z:decimal:null:3 a.s:string:4
+ │    ├── ordering: -3
+ │    └── scan
+ │         └── columns: a.x:int:1 a.y:float:2 a.z:decimal:null:3 a.s:string:4
+ └── eq [type=bool]
+      ├── variable: a.x [type=int]
+      └── const: 1 [type=int]
+
+# --------------------------------------------------
+# Project operator (pass through).
+# --------------------------------------------------
+
+# Pass through ordering to scan operator that can support it.
+opt
+SELECT x, y FROM a ORDER BY x, y DESC
+----
+project
+ ├── columns: x:int:1 y:float:2
+ ├── ordering: +1,-2
+ ├── scan
+ │    ├── columns: a.x:int:1 a.y:float:2 a.z:decimal:null:3 a.s:string:4
+ │    └── ordering: +1,-2
+ └── projections
+      ├── variable: a.x [type=int]
+      └── variable: a.y [type=float]
+
+# Pass through ordering to scan operator that can't support it.
+opt
+SELECT y, x, z+1 FROM a ORDER BY x, y
+----
+project
+ ├── columns: y:float:2 x:int:1 column5:decimal:null:5
+ ├── ordering: +1,+2
+ ├── sort
+ │    ├── columns: a.x:int:1 a.y:float:2 a.z:decimal:null:3 a.s:string:4
+ │    ├── ordering: +1,+2
+ │    └── scan
+ │         └── columns: a.x:int:1 a.y:float:2 a.z:decimal:null:3 a.s:string:4
+ └── projections
+      ├── variable: a.y [type=float]
+      ├── variable: a.x [type=int]
+      └── plus [type=decimal]
+           ├── variable: a.z [type=decimal]
+           └── const: 1 [type=decimal]
+
+# Ordering cannot be passed through because it includes computed column.
+opt
+SELECT x, 1 one, y FROM a ORDER BY x, one
+----
+sort
+ ├── columns: x:int:1 one:int:null:5 y:float:2
+ ├── ordering: +1,+5
+ └── project
+      ├── columns: a.x:int:1 one:int:null:5 a.y:float:2
+      ├── scan
+      │    └── columns: a.x:int:1 a.y:float:2 a.z:decimal:null:3 a.s:string:4
+      └── projections
+           ├── variable: a.x [type=int]
+           ├── const: 1 [type=int]
+           └── variable: a.y [type=float]
+
+# --------------------------------------------------
+# Select + Project operators (pass through both).
+# --------------------------------------------------
+
+# Pass through ordering to scan operator that can support it.
+opt
+SELECT y, x FROM a WHERE x=1 ORDER BY x, y DESC
+----
+project
+ ├── columns: y:float:2 x:int:1
+ ├── ordering: +1,-2
+ ├── select
+ │    ├── columns: a.x:int:1 a.y:float:2 a.z:decimal:null:3 a.s:string:4
+ │    ├── ordering: +1,-2
+ │    ├── scan
+ │    │    ├── columns: a.x:int:1 a.y:float:2 a.z:decimal:null:3 a.s:string:4
+ │    │    └── ordering: +1,-2
+ │    └── eq [type=bool]
+ │         ├── variable: a.x [type=int]
+ │         └── const: 1 [type=int]
+ └── projections
+      ├── variable: a.y [type=float]
+      └── variable: a.x [type=int]
+
+memo
+SELECT y, x FROM a WHERE x=1 ORDER BY x, y DESC
+----
+[8: "p:y:2,x:1 o:+1,-2"]
+memo
+ ├── 8: (project 5 7)
+ │    ├── "" [cost=0.0]
+ │    │    └── best: (project 5 7)
+ │    └── "p:y:2,x:1 o:+1,-2" [cost=0.0]
+ │         └── best: (project 5 7)
+ ├── 7: (projections 6 2)
+ ├── 6: (variable a.y)
+ ├── 5: (select 1 4)
+ │    ├── "" [cost=0.0]
+ │    │    └── best: (select 1 4)
+ │    └── "o:+1,-2" [cost=0.0]
+ │         └── best: (select 1 4)
+ ├── 4: (eq 2 3)
+ ├── 3: (const 1)
+ ├── 2: (variable a.x)
+ └── 1: (scan a)
+      ├── "" [cost=0.0]
+      │    └── best: (scan a)
+      └── "o:+1,-2" [cost=0.0]
+           └── best: (scan a)
+
+# Pass through ordering to scan operator that can't support it.
+opt
+SELECT y, z FROM a WHERE x=1 ORDER BY y
+----
+project
+ ├── columns: y:float:2 z:decimal:null:3
+ ├── ordering: +2
+ ├── select
+ │    ├── columns: a.x:int:1 a.y:float:2 a.z:decimal:null:3 a.s:string:4
+ │    ├── ordering: +2
+ │    ├── sort
+ │    │    ├── columns: a.x:int:1 a.y:float:2 a.z:decimal:null:3 a.s:string:4
+ │    │    ├── ordering: +2
+ │    │    └── scan
+ │    │         └── columns: a.x:int:1 a.y:float:2 a.z:decimal:null:3 a.s:string:4
+ │    └── eq [type=bool]
+ │         ├── variable: a.x [type=int]
+ │         └── const: 1 [type=int]
+ └── projections
+      ├── variable: a.y [type=float]
+      └── variable: a.z [type=decimal]
+
+memo
+SELECT y, z FROM a WHERE x=1 ORDER BY y
+----
+[9: "p:y:2,z:3 o:+2"]
+memo
+ ├── 9: (project 5 8)
+ │    ├── "" [cost=0.0]
+ │    │    └── best: (project 5 8)
+ │    └── "p:y:2,z:3 o:+2" [cost=0.0]
+ │         └── best: (project 5 8)
+ ├── 8: (projections 6 7)
+ ├── 7: (variable a.z)
+ ├── 6: (variable a.y)
+ ├── 5: (select 1 4)
+ │    ├── "" [cost=0.0]
+ │    │    └── best: (select 1 4)
+ │    └── "o:+2" [cost=0.0]
+ │         └── best: (select 1 4)
+ ├── 4: (eq 2 3)
+ ├── 3: (const 1)
+ ├── 2: (variable a.x)
+ └── 1: (scan a)
+      ├── "" [cost=0.0]
+      │    └── best: (scan a)
+      └── "o:+2" [cost=0.0]
+           └── best: (sort 1)

--- a/pkg/sql/opt/xform/testdata/physprops/presentation
+++ b/pkg/sql/opt/xform/testdata/physprops/presentation
@@ -1,0 +1,76 @@
+exec-ddl
+CREATE TABLE a (x INT PRIMARY KEY, y INT)
+----
+TABLE a
+ ├── x int not null
+ ├── y int
+ └── INDEX primary
+      └── x int not null
+
+exec-ddl
+CREATE TABLE t.b (x INT, y FLOAT)
+----
+TABLE b
+ ├── x int
+ ├── y float
+ ├── rowid int not null (hidden)
+ └── INDEX primary
+      └── rowid int not null (hidden)
+
+# Scan operator.
+opt
+SELECT a.y, a.x, a.y y2 FROM a
+----
+scan
+ └── columns: y:int:null:2 x:int:1 y2:int:null:2
+
+# Select operator.
+opt
+SELECT a.y, a.x, a.y y2 FROM a WHERE x=1
+----
+select
+ ├── columns: y:int:null:2 x:int:1 y2:int:null:2
+ ├── scan
+ │    └── columns: a.x:int:1 a.y:int:null:2
+ └── eq [type=bool]
+      ├── variable: a.x [type=int]
+      └── const: 1 [type=int]
+
+# Project operator.
+opt
+SELECT 1+a.y AS plus, a.x FROM a
+----
+project
+ ├── columns: plus:int:null:3 x:int:1
+ ├── scan
+ │    └── columns: a.x:int:1 a.y:int:null:2
+ └── projections
+      ├── plus [type=int]
+      │    ├── const: 1 [type=int]
+      │    └── variable: a.y [type=int]
+      └── variable: a.x [type=int]
+
+# Join operator.
+opt
+SELECT b.x, rowid, a.y, a.x, a.y y2, b.y FROM a, b
+----
+inner-join
+ ├── columns: x:int:null:3 rowid:int:5 y:int:null:2 x:int:1 y2:int:null:2 y:float:null:4
+ ├── scan
+ │    └── columns: a.x:int:1 a.y:int:null:2
+ ├── scan
+ │    └── columns: b.x:int:null:3 b.y:float:null:4 b.rowid:int:5
+ └── true [type=bool]
+
+# Groupby operator.
+opt
+SELECT MAX(y), y, y, x FROM a GROUP BY a.x, a.y
+----
+group-by
+ ├── columns: column3:int:null:3 y:int:null:2 y:int:null:2 x:int:1
+ ├── grouping columns: a.x:int:1 a.y:int:null:2
+ ├── scan
+ │    └── columns: a.x:int:1 a.y:int:null:2
+ └── aggregations
+      └── function: max [type=int]
+           └── variable: a.x [type=int]


### PR DESCRIPTION
The Ordering physical property requires result rows to be sorted
according to a desired key. This is usually the result of an ORDER BY
expression, but can also be a requirement imposed by an operator like
merge join. If an expression can provide the required ordering (e.g.
a Scan operator that returns rows in primary key order), then nothing
more is needed. If not, then the optimizer will insert a Sort enforcer
into the expression tree to provide the ordering.

The memo group now keeps a "best expression map", which remembers the
lowest cost expression for that group, that also provides each required
set of properties. As various alternatives are explored, the best expr
is updated as lower cost expressions are found. The optimizer now
traverses the whole expression tree in order to find best expression(s)
for each group and to insert enforcers where needed.

This PR also contains a bare-bones implementation of ORDER BY for
testing purposes; it will need to be fully implemented later.

Release note: None