### PR TITLE
cherrypick-2.0: log: replace ErrEventf family with VErrEventf family

### DIFF
--- a/pkg/kv/dist_sender.go
+++ b/pkg/kv/dist_sender.go
@@ -462,7 +462,7 @@ func (ds *DistSender) sendSingleRange(
 
 	br, err := ds.sendRPC(ctx, desc.RangeID, replicas, ba)
 	if err != nil {
-		log.ErrEvent(ctx, err.Error())
+		log.VErrEvent(ctx, 2, err.Error())
 		return nil, roachpb.NewError(err)
 	}
 
@@ -1063,7 +1063,7 @@ func (ds *DistSender) sendPartialBatch(
 			}
 			desc, evictToken, err = ds.getDescriptor(ctx, descKey, nil, isReverse)
 			if err != nil {
-				log.ErrEventf(ctx, "range descriptor re-lookup failed: %s", err)
+				log.VErrEventf(ctx, 1, "range descriptor re-lookup failed: %s", err)
 				continue
 			}
 		}
@@ -1081,7 +1081,7 @@ func (ds *DistSender) sendPartialBatch(
 			pErr.Index.Index = int32(positions[pErr.Index.Index])
 		}
 
-		log.ErrEventf(ctx, "reply error %s: %s", ba, pErr)
+		log.VErrEventf(ctx, 2, "reply error %s: %s", ba, pErr)
 
 		// Error handling: If the error indicates that our range
 		// descriptor is out of date, evict it from the cache and try
@@ -1327,7 +1327,7 @@ func (ds *DistSender) sendToReplicas(
 				if haveCommit && !grpcutil.RequestDidNotStart(err) {
 					ambiguousError = err
 				}
-				log.ErrEventf(ctx, "RPC error: %s", err)
+				log.VErrEventf(ctx, 2, "RPC error: %s", err)
 			} else {
 				propagateError := false
 				switch tErr := call.Reply.Error.GetDetail().(type) {
@@ -1369,7 +1369,7 @@ func (ds *DistSender) sendToReplicas(
 					return call.Reply, nil
 				}
 
-				log.ErrEventf(ctx, "application error: %s", call.Reply.Error)
+				log.VErrEventf(ctx, 1, "application error: %s", call.Reply.Error)
 			}
 
 			if transport.IsExhausted() {

--- a/pkg/kv/range_cache.go
+++ b/pkg/kv/range_cache.go
@@ -415,7 +415,7 @@ func (rdc *RangeDescriptorCache) performRangeLookup(
 	ctx context.Context, key roachpb.RKey, useReverseScan bool,
 ) ([]roachpb.RangeDescriptor, []roachpb.RangeDescriptor, error) {
 	// Tag inner operations.
-	ctx = log.WithLogTag(ctx, "range-lookup", nil)
+	ctx = log.WithLogTag(ctx, "range-lookup", key)
 	if !rdc.st.Version.IsActive(cluster.VersionMeta2Splits) {
 		return rdc.performLegacyRangeLookup(ctx, key, useReverseScan)
 	}

--- a/pkg/server/node.go
+++ b/pkg/server/node.go
@@ -897,7 +897,7 @@ func (n *Node) batchInternal(
 		br, pErr = n.stores.Send(ctx, *args)
 		if pErr != nil {
 			br = &roachpb.BatchResponse{}
-			log.ErrEventf(ctx, "%T", pErr.GetDetail())
+			log.VErrEventf(ctx, 3, "%T", pErr.GetDetail())
 		}
 		if br.Error != nil {
 			panic(roachpb.ErrorUnexpectedlySet(n.stores, br))

--- a/pkg/storage/compactor/compactor.go
+++ b/pkg/storage/compactor/compactor.go
@@ -428,7 +428,7 @@ func (c *Compactor) Suggest(ctx context.Context, sc storagebase.SuggestedCompact
 	var existing storagebase.Compaction
 	ok, _, _, err := c.eng.GetProto(engine.MVCCKey{Key: key}, &existing)
 	if err != nil {
-		log.ErrEventf(ctx, "unable to record suggested compaction: %s", err)
+		log.VErrEventf(ctx, 2, "unable to record suggested compaction: %s", err)
 		return
 	}
 

--- a/pkg/storage/consistency_queue.go
+++ b/pkg/storage/consistency_queue.go
@@ -85,7 +85,7 @@ func (q *consistencyQueue) shouldQueue(
 	if repl.store.cfg.NodeLiveness != nil {
 		for _, rep := range repl.Desc().Replicas {
 			if live, err := repl.store.cfg.NodeLiveness.IsLive(rep.NodeID); err != nil {
-				log.ErrEventf(ctx, "node %d liveness failed: %s", rep.NodeID, err)
+				log.VErrEventf(ctx, 3, "node %d liveness failed: %s", rep.NodeID, err)
 				return false, 0
 			} else if !live {
 				return false, 0
@@ -113,7 +113,7 @@ func (q *consistencyQueue) process(
 	}
 	// Update the last processed time for this queue.
 	if err := repl.setQueueLastProcessed(ctx, q.name, repl.store.Clock().Now()); err != nil {
-		log.ErrEventf(ctx, "failed to update last processed time: %v", err)
+		log.VErrEventf(ctx, 2, "failed to update last processed time: %v", err)
 	}
 	return nil
 }

--- a/pkg/storage/consistency_queue.go
+++ b/pkg/storage/consistency_queue.go
@@ -75,7 +75,7 @@ func (q *consistencyQueue) shouldQueue(
 	if !repl.store.cfg.TestingKnobs.DisableLastProcessedCheck {
 		lpTS, err := repl.getQueueLastProcessed(ctx, q.name)
 		if err != nil {
-			log.ErrEventf(ctx, "consistency queue last processed timestamp: %s", err)
+			return false, 0
 		}
 		if shouldQ, priority = shouldQueueAgain(now, lpTS, interval); !shouldQ {
 			return false, 0

--- a/pkg/storage/gc_queue.go
+++ b/pkg/storage/gc_queue.go
@@ -574,7 +574,7 @@ func (gcq *gcQueue) processImpl(
 				ba.Add(&gcArgs)
 				log.Eventf(ctx, "sending batch %d of %d", i+1, len(batches))
 				if _, pErr := repl.Send(ctx, ba); pErr != nil {
-					log.ErrEvent(ctx, pErr.String())
+					log.VErrEvent(ctx, 2, pErr.String())
 					return pErr.GoError()
 				}
 			}

--- a/pkg/storage/intent_resolver.go
+++ b/pkg/storage/intent_resolver.go
@@ -449,7 +449,7 @@ func (ir *intentResolver) cleanupTxnIntentsOnGCAsync(
 			// before resolving the intents.
 			if txn.Status == roachpb.PENDING {
 				if !txnwait.IsExpired(now, txn) {
-					log.ErrEventf(ctx, "cannot push a PENDING transaction which is not expired: %s", txn)
+					log.VErrEventf(ctx, 3, "cannot push a PENDING transaction which is not expired: %s", txn)
 					return
 				}
 				b := &client.Batch{}
@@ -464,7 +464,7 @@ func (ir *intentResolver) cleanupTxnIntentsOnGCAsync(
 				})
 				ir.store.metrics.GCPushTxn.Inc(1)
 				if err := ir.store.DB().Run(ctx, b); err != nil {
-					log.ErrEventf(ctx, "failed to push PENDING, expired txn (%s): %s", txn, err)
+					log.VErrEventf(ctx, 2, "failed to push PENDING, expired txn (%s): %s", txn, err)
 					return
 				}
 				// Get the pushed txn and update the intents slice.

--- a/pkg/storage/queue.go
+++ b/pkg/storage/queue.go
@@ -711,7 +711,7 @@ func (bq *baseQueue) processReplica(queueCtx context.Context, repl *Replica) err
 				log.Eventf(ctx, "%s; skipping", v)
 				return nil
 			default:
-				log.ErrEventf(ctx, "could not obtain lease: %s", pErr)
+				log.VErrEventf(ctx, 2, "could not obtain lease: %s", pErr)
 				return errors.Wrapf(pErr.GoError(), "%s: could not obtain lease", repl)
 			}
 		}

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -1692,9 +1692,11 @@ func (r *Replica) getQueueLastProcessed(ctx context.Context, queue string) (hlc.
 	if r.store != nil {
 		_, err := engine.MVCCGetProto(ctx, r.store.Engine(), key, hlc.Timestamp{}, true, nil, &timestamp)
 		if err != nil {
+			log.ErrEventf(ctx, "last processed timestamp unavailable: %s", err)
 			return hlc.Timestamp{}, err
 		}
 	}
+	log.VEventf(ctx, 2, "last processed timestamp: %s", timestamp)
 	return timestamp, nil
 }
 

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -1488,7 +1488,7 @@ func (r *Replica) redirectOnOrAcquireLease(ctx context.Context) (LeaseStatus, *r
 					defer r.store.metrics.SlowLeaseRequests.Dec(1)
 				case <-ctx.Done():
 					llHandle.Cancel()
-					log.ErrEventf(ctx, "lease acquisition failed: %s", ctx.Err())
+					log.VErrEventf(ctx, 2, "lease acquisition failed: %s", ctx.Err())
 					return roachpb.NewError(newNotLeaseHolderError(nil, r.store.StoreID(), r.Desc()))
 				case <-r.store.Stopper().ShouldStop():
 					llHandle.Cancel()
@@ -1692,7 +1692,7 @@ func (r *Replica) getQueueLastProcessed(ctx context.Context, queue string) (hlc.
 	if r.store != nil {
 		_, err := engine.MVCCGetProto(ctx, r.store.Engine(), key, hlc.Timestamp{}, true, nil, &timestamp)
 		if err != nil {
-			log.ErrEventf(ctx, "last processed timestamp unavailable: %s", err)
+			log.VErrEventf(ctx, 2, "last processed timestamp unavailable: %s", err)
 			return hlc.Timestamp{}, err
 		}
 	}
@@ -1826,7 +1826,7 @@ func (r *Replica) maybeInitializeRaftGroup(ctx context.Context) {
 	if err := r.withRaftGroupLocked(shouldCampaignOnCreation, func(raftGroup *raft.RawNode) (bool, error) {
 		return true, nil
 	}); err != nil {
-		log.ErrEventf(ctx, "unable to initialize raft group: %s", err)
+		log.VErrEventf(ctx, 1, "unable to initialize raft group: %s", err)
 	}
 }
 
@@ -2540,7 +2540,7 @@ func (r *Replica) executeReadOnlyBatch(
 		}
 	}
 	if pErr != nil {
-		log.ErrEvent(ctx, pErr.String())
+		log.VErrEvent(ctx, 3, pErr.String())
 	} else {
 		log.Event(ctx, "read completed")
 	}
@@ -2997,7 +2997,6 @@ func (r *Replica) propose(
 	if err := ctx.Err(); err != nil {
 		errStr := fmt.Sprintf("%s before proposing: %s", err, ba.Summary())
 		log.Warning(ctx, errStr)
-		log.ErrEvent(ctx, errStr)
 		return nil, nil, noop, roachpb.NewError(err)
 	}
 

--- a/pkg/storage/ts_maintenance_queue.go
+++ b/pkg/storage/ts_maintenance_queue.go
@@ -109,7 +109,7 @@ func (q *timeSeriesMaintenanceQueue) shouldQueue(
 	if !repl.store.cfg.TestingKnobs.DisableLastProcessedCheck {
 		lpTS, err := repl.getQueueLastProcessed(ctx, q.name)
 		if err != nil {
-			log.ErrEventf(ctx, "time series maintenance queue last processed timestamp: %s", err)
+			return false, 0
 		}
 		shouldQ, priority = shouldQueueAgain(now, lpTS, TimeSeriesMaintenanceInterval)
 		if !shouldQ {

--- a/pkg/storage/ts_maintenance_queue.go
+++ b/pkg/storage/ts_maintenance_queue.go
@@ -135,7 +135,7 @@ func (q *timeSeriesMaintenanceQueue) process(
 	}
 	// Update the last processed time for this queue.
 	if err := repl.setQueueLastProcessed(ctx, q.name, now); err != nil {
-		log.ErrEventf(ctx, "failed to update last processed time: %v", err)
+		log.VErrEventf(ctx, 2, "failed to update last processed time: %v", err)
 	}
 	return nil
 }

--- a/pkg/util/log/structured.go
+++ b/pkg/util/log/structured.go
@@ -125,7 +125,9 @@ func formatTags(ctx context.Context, buf *msgBuf) bool {
 func MakeMessage(ctx context.Context, format string, args []interface{}) string {
 	var buf msgBuf
 	formatTags(ctx, &buf)
-	if len(format) == 0 {
+	if len(args) == 0 {
+		buf.WriteString(format)
+	} else if len(format) == 0 {
 		fmt.Fprint(&buf, args...)
 	} else {
 		fmt.Fprintf(&buf, format, args...)

--- a/pkg/util/log/trace.go
+++ b/pkg/util/log/trace.go
@@ -154,65 +154,74 @@ func eventInternal(ctx context.Context, isErr, withTags bool, format string, arg
 // message to it. If no Trace is found, it looks for an EventLog in the context
 // and logs the message to it. If neither is found, does nothing.
 func Event(ctx context.Context, msg string) {
-	eventInternal(ctx, false /*isErr*/, true /*withTags*/, msg)
+	eventInternal(ctx, false /* isErr */, true /* withTags */, msg)
 }
 
 // Eventf looks for an opentracing.Trace in the context and formats and logs
 // the given message to it. If no Trace is found, it looks for an EventLog in
 // the context and logs the message to it. If neither is found, does nothing.
 func Eventf(ctx context.Context, format string, args ...interface{}) {
-	eventInternal(ctx, false /*isErr*/, true /*withTags*/, format, args...)
+	eventInternal(ctx, false /* isErr */, true /* withTags */, format, args...)
 }
 
-// ErrEvent looks for an opentracing.Trace in the context and logs the given
-// message to it. If no Trace is found, it looks for an EventLog in the context
-// and logs the message to it (as an error). If neither is found, does nothing.
-func ErrEvent(ctx context.Context, msg string) {
-	eventInternal(ctx, true /*isErr*/, true /*withTags*/, msg)
-}
-
-// ErrEventf looks for an opentracing.Trace in the context and formats and logs
-// the given message to it. If no Trace is found, it looks for an EventLog in
-// the context and formats and logs the message to it (as an error). If neither
-// is found, does nothing.
-func ErrEventf(ctx context.Context, format string, args ...interface{}) {
-	eventInternal(ctx, true /*isErr*/, true /*withTags*/, format, args...)
+func vEventf(
+	ctx context.Context, isErr bool, depth int, level int32, format string, args ...interface{},
+) {
+	if VDepth(level, 1+depth) {
+		// Log the message (which also logs an event).
+		sev := Severity_INFO
+		if isErr {
+			sev = Severity_ERROR
+		}
+		logDepth(ctx, 1+depth, sev, format, args)
+	} else {
+		eventInternal(ctx, isErr, true /* withTags */, format, args...)
+	}
 }
 
 // VEvent either logs a message to the log files (which also outputs to the
 // active trace or event log) or to the trace/event log alone, depending on
 // whether the specified verbosity level is active.
 func VEvent(ctx context.Context, level int32, msg string) {
-	if VDepth(level, 1) {
-		// Log to INFO (which also logs an event).
-		logDepth(ctx, 1, Severity_INFO, "", []interface{}{msg})
-	} else {
-		eventInternal(ctx, false /*isErr*/, true /*withTags*/, msg)
-	}
+	vEventf(ctx, false /* isErr */, 1, level, msg)
 }
 
 // VEventf either logs a message to the log files (which also outputs to the
 // active trace or event log) or to the trace/event log alone, depending on
 // whether the specified verbosity level is active.
 func VEventf(ctx context.Context, level int32, format string, args ...interface{}) {
-	if VDepth(level, 1) {
-		// Log to INFO (which also logs an event).
-		logDepth(ctx, 1, Severity_INFO, format, args)
-	} else {
-		eventInternal(ctx, false /*isErr*/, true /*withTags*/, format, args...)
-	}
+	vEventf(ctx, false /* isErr */, 1, level, format, args...)
 }
 
 // VEventfDepth performs the same as VEventf but checks the verbosity level
 // at the given depth in the call stack.
 func VEventfDepth(ctx context.Context, depth int, level int32, format string, args ...interface{}) {
-	if VDepth(level, 1+depth) {
-		// Log to INFO (which also logs an event).
-		logDepth(ctx, 1+depth, Severity_INFO, format, args)
-	} else {
-		eventInternal(ctx, false /*isErr*/, true /*withTags*/, format, args...)
-	}
+	vEventf(ctx, false /* isErr */, 1+depth, level, format, args...)
 }
+
+// VErrEvent either logs an error message to the log files (which also outputs
+// to the active trace or event log) or to the trace/event log alone, depending
+// on whether the specified verbosity level is active.
+func VErrEvent(ctx context.Context, level int32, msg string) {
+	vEventf(ctx, true /* isErr */, 1, level, msg)
+}
+
+// VErrEventf either logs an error message to the log files (which also outputs
+// to the active trace or event log) or to the trace/event log alone, depending
+// on whether the specified verbosity level is active.
+func VErrEventf(ctx context.Context, level int32, format string, args ...interface{}) {
+	vEventf(ctx, true /* isErr */, 1, level, format, args...)
+}
+
+// VErrEventfDepth performs the same as VErrEventf but checks the verbosity
+// level at the given depth in the call stack.
+func VErrEventfDepth(
+	ctx context.Context, depth int, level int32, format string, args ...interface{},
+) {
+	vEventf(ctx, true /* isErr */, 1+depth, level, format, args...)
+}
+
+var _ = VErrEventfDepth // silence unused warning
 
 // HasSpanOrEvent returns true if the context has a span or event that should
 // be logged to.


### PR DESCRIPTION
Cherry-pick of https://github.com/cockroachdb/cockroach/pull/22919.