### PR TITLE
settings: introduce retired setting state

### DIFF
--- a/pkg/settings/registry.go
+++ b/pkg/settings/registry.go
@@ -32,7 +32,10 @@ var Registry = make(map[string]Setting)
 // When a setting is removed, it should be added to this list so that we cannot
 // accidentally reuse its name, potentially mis-handling older values.
 var retiredSettings = map[string]struct{}{
-	"diagnostics.reporting.report_metrics": {}, // removed as of 2.0.
+	//removed as of 2.0.
+	"kv.gc.batch_size":                     {},
+	"kv.transaction.max_intents":           {},
+	"diagnostics.reporting.report_metrics": {},
 }
 
 // Register adds a setting to the registry.

--- a/pkg/settings/registry.go
+++ b/pkg/settings/registry.go
@@ -29,8 +29,17 @@ import (
 // read concurrently by different callers.
 var Registry = make(map[string]Setting)
 
+// When a setting is removed, it should be added to this list so that we cannot
+// accidentally reuse its name, potentially mis-handling older values.
+var retiredSettings = map[string]struct{}{
+	"diagnostics.reporting.report_metrics": {}, // removed as of 2.0.
+}
+
 // Register adds a setting to the registry.
 func register(key, desc string, s Setting) {
+	if _, ok := retiredSettings[key]; ok {
+		panic(fmt.Sprintf("cannot reuse previously defined setting name: %s", key))
+	}
 	if _, ok := Registry[key]; ok {
 		panic(fmt.Sprintf("setting already defined: %s", key))
 	}

--- a/pkg/settings/updater.go
+++ b/pkg/settings/updater.go
@@ -78,6 +78,9 @@ func NewUpdater(sv *Values) Updater {
 func (u updater) Set(key, rawValue string, vt string) error {
 	d, ok := Registry[key]
 	if !ok {
+		if _, ok := retiredSettings[key]; ok {
+			return nil
+		}
 		// Likely a new setting this old node doesn't know about.
 		return errors.Errorf("unknown setting '%s'", key)
 	}

--- a/pkg/sqlmigrations/migrations.go
+++ b/pkg/sqlmigrations/migrations.go
@@ -167,16 +167,12 @@ var backwardCompatibleMigrations = []migrationDescriptor{
 		workFn: upgradeTableDescsToInterleavedFormatVersion,
 	},
 	{
-		// Introduced in v2.0.
-		// TODO(benesch): bake this migration into v2.1.
-		name:   "remove cluster setting `kv.gc.batch_size`",
-		workFn: purgeClusterSettingKVGCBatchSize,
+		// Introduced in v2.0 alphas then folded into `retiredSettings`.
+		name: "remove cluster setting `kv.gc.batch_size`",
 	},
 	{
-		// Introduced in v2.0.
-		// TODO(benesch): bake this migration into v2.1.
-		name:   "remove cluster setting `kv.transaction.max_intents`",
-		workFn: purgeClusterSettingKVTransactionMaxIntents,
+		// Introduced in v2.0 alphas then folded into `retiredSettings`.
+		name: "remove cluster setting `kv.transaction.max_intents`",
 	},
 	{
 		// Introduced in v2.0.
@@ -956,16 +952,6 @@ func upgradeTableDescsWithFn(
 		}
 	}
 	return nil
-}
-
-func purgeClusterSettingKVGCBatchSize(ctx context.Context, r runner) error {
-	// This cluster setting has been removed.
-	return runStmtAsRootWithRetry(ctx, r, `DELETE FROM SYSTEM.SETTINGS WHERE name='kv.gc.batch_size'`)
-}
-
-func purgeClusterSettingKVTransactionMaxIntents(ctx context.Context, r runner) error {
-	// This cluster setting has been removed.
-	return runStmtAsRootWithRetry(ctx, r, `DELETE FROM SYSTEM.SETTINGS WHERE name='kv.transaction.max_intents'`)
 }
 
 func addDefaultSystemJobsZoneConfig(ctx context.Context, r runner) error {

--- a/pkg/sqlmigrations/migrations_test.go
+++ b/pkg/sqlmigrations/migrations_test.go
@@ -449,34 +449,6 @@ func (mt *migrationTest) close(ctx context.Context) {
 	backwardCompatibleMigrations = mt.oldMigrations
 }
 
-func TestRemoveClusterSettingKVGCBatchSize(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-	ctx := context.Background()
-
-	mt := makeMigrationTest(ctx, t)
-	defer mt.close(ctx)
-
-	migration := mt.pop(t, "remove cluster setting `kv.gc.batch_size`")
-	mt.start(t, base.TestServerArgs{})
-
-	mt.sqlDB.Exec(t, `INSERT INTO system.settings (name, "lastUpdated", "valueType", value) `+
-		`values('kv.gc.batch_size', NOW(), 'i', '10000')`)
-
-	if err := mt.runMigration(ctx, migration); err != nil {
-		t.Fatal(err)
-	}
-	var n int
-	if err := mt.sqlDB.DB.QueryRow(
-		`SELECT COUNT(*) from system.settings WHERE name = 'kv.gc.batch_size'`,
-	).Scan(&n); err != nil {
-		t.Fatal(err)
-	}
-
-	if n != 0 {
-		t.Fatalf("migration did not clear out cluster setting, got %d rows", n)
-	}
-}
-
 func TestCreateSystemTable(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	ctx := context.Background()


### PR DESCRIPTION
Addresses discussion in #21129: eagerly introducing a migration to delete a removed setting's value is risky, as older nodes are likely still using that value. We should delay any removal until after the cluster upgrade process is completed and no old nodes could be affected by the deletion. 

However, we can also just avoid accidental re-use of the name, and the log spam of an unknown value, by maintaining a list of retired settings, without needing to delete at all for now. 

In the future, if this list grows large, we can add version-protected migrations that flush this list,  cleaning up old values for all the previous version's retired settings at once, once the upgrade process ensures it is safe to do so, without adding that overhead on each individual setting removal.

Release note: none.