### PR TITLE
storage: plug an iterator leak

### DIFF
--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -1036,6 +1036,7 @@ func IterateIDPrefixKeys(
 ) error {
 	rangeID := roachpb.RangeID(1)
 	iter := eng.NewIterator(false /* prefix */)
+	defer iter.Close()
 
 	for {
 		bumped := false


### PR DESCRIPTION
migrateLegacyTombstones was leaking an iterator during server startup.
This would prevent RocksDB from garbage collecting any of the SSTs
touched by the iterator, and may have been the cause of #23117.

Release note (bug fix): Fix a bug that could prevent disk space from
being reclaimed.