### PR TITLE
cherrypick-2.0: sql: disallow the use of `pg_catalog` tables with no cur db defined

### DIFF
--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -653,7 +653,7 @@ func Example_sql() {
 	c.RunWithArgs([]string{"sql", "-e", "create table t.g2 as select * from generate_series(1,10)"})
 	// It must be possible to access pre-defined/virtual tables even if the current database
 	// does not exist yet.
-	c.RunWithArgs([]string{"sql", "-d", "nonexistent", "-e", "select count(*) from \"\".pg_catalog.pg_class limit 0"})
+	c.RunWithArgs([]string{"sql", "-d", "nonexistent", "-e", "select count(*) from \"\".information_schema.tables limit 0"})
 	// It must be possible to create the current database after the
 	// connection was established.
 	c.RunWithArgs([]string{"sql", "-d", "nonexistent", "-e", "create database nonexistent; create table foo(x int); select * from foo"})
@@ -698,7 +698,7 @@ func Example_sql() {
 	// CREATE TABLE
 	// sql -e create table t.g2 as select * from generate_series(1,10)
 	// SELECT 10
-	// sql -d nonexistent -e select count(*) from "".pg_catalog.pg_class limit 0
+	// sql -d nonexistent -e select count(*) from "".information_schema.tables limit 0
 	// count
 	// sql -d nonexistent -e create database nonexistent; create table foo(x int); select * from foo
 	// x

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -82,6 +82,7 @@ var crdbInternal = virtualSchema{
 		crdbInternalTablesTable,
 		crdbInternalZonesTable,
 	},
+	validWithNoDatabaseContext: true,
 }
 
 var crdbInternalBuildInfoTable = virtualSchemaTable{

--- a/pkg/sql/information_schema.go
+++ b/pkg/sql/information_schema.go
@@ -55,7 +55,8 @@ var informationSchema = virtualSchema{
 		informationSchemaViewsTable,
 		informationSchemaUserPrivileges,
 	},
-	tableValidator: validateInformationSchemaTable,
+	tableValidator:             validateInformationSchemaTable,
+	validWithNoDatabaseContext: true,
 }
 
 var (

--- a/pkg/sql/logictest/testdata/logic_test/namespace
+++ b/pkg/sql/logictest/testdata/logic_test/namespace
@@ -51,12 +51,9 @@ SELECT x FROM pg_type
 42
 
 # Leave database, check name resolves to default.
-# There are two rows because we have two databases (system and test).
-query T
-SET DATABASE = ''; SELECT typname FROM pg_type WHERE typname = 'date'
-----
-date
-date
+# The expected error can only occur on the virtual pg_type, not the physical one.
+query error no database specified
+SET DATABASE = ''; SELECT * FROM pg_type
 
 # Go to different database, check name still resolves to default.
 query T

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -1292,6 +1292,8 @@ SELECT COUNT(*) FROM pg_catalog.pg_tables WHERE schemaname='public'
 ----
 3
 
+user root
+
 # Verify that an unset database shows tables across databases.
 # But only those items visible to this user are reported.
 # (Tests below show that root sees more).
@@ -1299,68 +1301,30 @@ SELECT COUNT(*) FROM pg_catalog.pg_tables WHERE schemaname='public'
 statement ok
 SET DATABASE = ''
 
-query T
+query error no database specified
 SELECT tablename FROM pg_catalog.pg_tables WHERE schemaname='public' ORDER BY 1
-----
-t1
-t2
-t3
 
-query T
+query error no database specified
 SELECT viewname FROM pg_catalog.pg_views WHERE schemaname='public' ORDER BY 1
-----
-v1
 
-query T
+query error no database specified
 SELECT relname FROM pg_catalog.pg_class c
 JOIN pg_catalog.pg_namespace n ON c.relnamespace = n.oid
 WHERE nspname='public'
-----
 
-query T
+query error no database specified
 SELECT conname FROM pg_catalog.pg_constraint con
 JOIN pg_catalog.pg_namespace n ON con.connamespace = n.oid
 WHERE n.nspname = 'public'
-----
 
-query I
+query error no database specified
 SELECT COUNT(*) FROM pg_catalog.pg_depend
-----
-2
 
-# Verify that an unset database shows everything in pg_catalog for the root
-# user.
+query error no database specified
+select 'upper'::REGPROC;
 
-user root
-
-query I
-SELECT COUNT(*) FROM pg_catalog.pg_tables WHERE schemaname='public'
-----
-19
-
-query I
-SELECT COUNT(*) FROM pg_catalog.pg_views WHERE schemaname='public'
-----
-1
-
-query I
-SELECT COUNT(*) FROM pg_catalog.pg_class c
-JOIN pg_catalog.pg_namespace n ON c.relnamespace = n.oid
-WHERE nspname='public'
-----
-46
-
-query I
-SELECT COUNT(*) FROM pg_catalog.pg_constraint con
-JOIN pg_catalog.pg_namespace n ON con.connamespace = n.oid
-WHERE n.nspname = 'public'
-----
-22
-
-query I
-SELECT COUNT(*) FROM pg_catalog.pg_depend
-----
-2
+query error no database specified
+select 'system.namespace'::regclass
 
 statement ok
 SET DATABASE = test
@@ -1374,7 +1338,6 @@ JOIN pg_type t ON t.typinput = p.oid
 WHERE t.typname = '_int4'
 ----
 2590763490  array_in  array_in
-
 
 ## #16285
 ## int2vectors should be 0-indexed

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -91,6 +91,10 @@ var pgCatalog = virtualSchema{
 		pgCatalogTypeTable,
 		pgCatalogViewsTable,
 	},
+	// Postgres's catalogs are ill-defined when there is no current
+	// database set. Simply reject any attempts to use them in that
+	// case.
+	validWithNoDatabaseContext: false,
 }
 
 // See: https://www.postgresql.org/docs/current/static/catalog-pg-am.html.

--- a/pkg/sql/pgwire/conn.go
+++ b/pkg/sql/pgwire/conn.go
@@ -138,6 +138,11 @@ func serveConn(
 	insecure bool,
 ) error {
 	sArgs.RemoteAddr = netConn.RemoteAddr()
+
+	if log.V(2) {
+		log.Infof(ctx, "new connection with options: %+v", sArgs)
+	}
+
 	c := newConn(netConn, sArgs, metrics, execCfg)
 
 	if err := c.handleAuthentication(ctx, insecure); err != nil {

--- a/pkg/sql/pgwire/conn_test.go
+++ b/pkg/sql/pgwire/conn_test.go
@@ -63,7 +63,7 @@ func TestConn(t *testing.T) {
 	// server that the client will connect to; we just use it on the side to
 	// execute some metadata queries that pgx sends whenever it opens a
 	// connection.
-	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{Insecure: true})
+	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{Insecure: true, UseDatabase: "system"})
 	defer s.Stopper().Stop(context.TODO())
 
 	// Start a pgwire "server".
@@ -235,6 +235,7 @@ func client(ctx context.Context, serverAddr net.Addr, wg *sync.WaitGroup) error 
 			// connection are not using prepared statements. That simplifies the
 			// scaffolding of the test.
 			PreferSimpleProtocol: true,
+			Database:             "system",
 		})
 	if err != nil {
 		return err

--- a/pkg/sql/pgwire/pgwire_test.go
+++ b/pkg/sql/pgwire/pgwire_test.go
@@ -897,7 +897,7 @@ func TestPGPreparedQuery(t *testing.T) {
 			baseTest.SetArgs("1").Results(true),
 			baseTest.SetArgs("2").Results(false),
 		},
-		"SELECT * FROM pg_catalog.pg_class WHERE relnamespace = $1": {
+		"SELECT * FROM d.pg_catalog.pg_class WHERE relnamespace = $1": {
 			baseTest.SetArgs(1),
 		},
 		"SELECT $1::UUID": {

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -208,6 +208,7 @@ func newInternalPlanner(
 			SearchPath: sqlbase.DefaultSearchPath,
 			Location:   time.UTC,
 			User:       user,
+			Database:   "system",
 		},
 		TxnState: txnState{Ctx: ctx, implicitTxn: true},
 		context:  ctx,


### PR DESCRIPTION
Picks  #23045.

The contents of the various `pg_catalog` tables are very ill-defined
when there is no current database set.

(For context, in PostgreSQL it is not possible for a client to have no
"current database" set. There is always a current database in a pg
session.)

This ill definition surfaces in the shape of mildly confusing
situations, like duplicate schema/table names in `pg_tables` when
there there are two tables with the same name in different databases
(because `pg_catalog` tables do not contain a catalog column, unlike
`information_schema` tables), to blatantly problematic output
(`pg_proc` wants a `pronamespace` OID column, which suggests separate
entries for each database/schema, but all the built-in functions
should only be listed once) and outright bugs (`::regproc` and
`::regclass` conversions don't resolve properly with no current
database set).

In order to restore sanity, this patch outright disallows using any of
the `pg_catalog` vtables with no current databaset set. This should
not create incompatibility with pg-specific tools anyways, since these
should have been designed to always specify a current db in the
connection string, and would have been bound to not-work with no
current database set anyway.

The other vtables (`crdb_internal` and `information_schema`) do not
have these problems are are thus still allowed when there is no
current database set.

Release note (sql change): the `pg_catalog` virtual tables, as well as
the special casts `::regproc` and `::regclass`, can only be queried by
clients that properly set a current database (`SET database = ...` or
`USE`).