### PR TITLE
cherrypick-2.0: sql: the type of NULL is "unknown", not "NULL"

### DIFF
--- a/docs/generated/sql/operators.md
+++ b/docs/generated/sql/operators.md
@@ -308,7 +308,6 @@
 <table><thead>
 <tr><td><code>IS NOT DISTINCT FROM</code></td><td>Return</td></tr>
 </thead><tbody>
-<tr><td>NULL <code>IS NOT DISTINCT FROM</code> NULL</td><td><a href="bool.html">bool</a></td></tr>
 <tr><td><a href="bool.html">bool</a> <code>IS NOT DISTINCT FROM</code> <a href="bool.html">bool</a></td><td><a href="bool.html">bool</a></td></tr>
 <tr><td><a href="bool.html">bool[]</a> <code>IS NOT DISTINCT FROM</code> <a href="bool.html">bool[]</a></td><td><a href="bool.html">bool</a></td></tr>
 <tr><td><a href="bytes.html">bytes</a> <code>IS NOT DISTINCT FROM</code> <a href="bytes.html">bytes</a></td><td><a href="bool.html">bool</a></td></tr>
@@ -349,6 +348,7 @@
 <tr><td><a href="timestamp.html">timestamptz</a> <code>IS NOT DISTINCT FROM</code> <a href="timestamp.html">timestamptz</a></td><td><a href="bool.html">bool</a></td></tr>
 <tr><td>timestamptz <code>IS NOT DISTINCT FROM</code> timestamptz</td><td><a href="bool.html">bool</a></td></tr>
 <tr><td>tuple <code>IS NOT DISTINCT FROM</code> tuple</td><td><a href="bool.html">bool</a></td></tr>
+<tr><td>unknown <code>IS NOT DISTINCT FROM</code> unknown</td><td><a href="bool.html">bool</a></td></tr>
 <tr><td><a href="uuid.html">uuid</a> <code>IS NOT DISTINCT FROM</code> <a href="uuid.html">uuid</a></td><td><a href="bool.html">bool</a></td></tr>
 <tr><td><a href="uuid.html">uuid[]</a> <code>IS NOT DISTINCT FROM</code> <a href="uuid.html">uuid[]</a></td><td><a href="bool.html">bool</a></td></tr>
 </tbody></table>

--- a/pkg/server/authentication.go
+++ b/pkg/server/authentication.go
@@ -203,7 +203,7 @@ WHERE id = $1`
 		hashedSecret = []byte(*datum[0].(*tree.DBytes))
 		username = string(*datum[1].(*tree.DString))
 		expiresAt = datum[2].(*tree.DTimestamp).Time
-		isRevoked = datum[3].ResolvedType() != types.Null
+		isRevoked = datum[3].ResolvedType() != types.Unknown
 		return nil
 	}); err != nil {
 		return false, "", err

--- a/pkg/sql/executor.go
+++ b/pkg/sql/executor.go
@@ -2395,7 +2395,7 @@ func golangFillQueryArguments(pinfo *tree.PlaceholderInfo, args []interface{}) {
 func checkResultType(typ types.T) error {
 	// Compare all types that can rely on == equality.
 	switch types.UnwrapType(typ) {
-	case types.Null:
+	case types.Unknown:
 	case types.Bool:
 	case types.Int:
 	case types.Float:

--- a/pkg/sql/expr_filter.go
+++ b/pkg/sql/expr_filter.go
@@ -480,7 +480,7 @@ func extractNotNullConstraintsFromNotNullExpr(expr tree.TypedExpr) util.FastIntS
 // NULL; a filter "x > y" implies that both x and y are not NULL. It is
 // best-effort so there may be false negatives (but no false positives).
 func extractNotNullConstraints(filter tree.TypedExpr) util.FastIntSet {
-	if typ := filter.ResolvedType(); typ == types.Null {
+	if typ := filter.ResolvedType(); typ == types.Unknown {
 		return util.FastIntSet{}
 	} else if typ != types.Bool {
 		panic(fmt.Sprintf("non-bool filter expression: %s (type: %s)", filter, filter.ResolvedType()))

--- a/pkg/sql/logictest/testdata/logic_test/builtin_function
+++ b/pkg/sql/logictest/testdata/logic_test/builtin_function
@@ -175,7 +175,7 @@ SELECT CONCAT_WS(',', 'abcde', '2')
 ----
 abcde,2
 
-statement error unknown signature: concat_ws\(string, string, int, NULL, int\)
+statement error unknown signature: concat_ws\(string, string, int, unknown, int\)
 SELECT CONCAT_WS(',', 'abcde', 2, NULL, 22)
 
 query T
@@ -1423,7 +1423,7 @@ query T
 VALUES (pg_typeof(1:::int)),
        (pg_typeof('a':::string)),
        (pg_typeof(true)),
-       (pg_typeof(null)),
+       (pg_typeof(NULL)),
        (pg_typeof('3m':::interval)),
        (pg_typeof('2016-11-12':::date)),
        (pg_typeof(now():::timestamptz)),
@@ -1433,7 +1433,7 @@ VALUES (pg_typeof(1:::int)),
 int
 string
 bool
-NULL
+unknown
 interval
 date
 timestamptz

--- a/pkg/sql/logictest/testdata/logic_test/create_as
+++ b/pkg/sql/logictest/testdata/logic_test/create_as
@@ -89,7 +89,7 @@ CREATE TABLE foo2 (x) AS (VALUES(ROW()))
 statement error pq: value type setof tuple{int} cannot be used for table columns
 CREATE TABLE foo2 (x) AS (VALUES(generate_series(1,3)))
 
-statement error pq: value type NULL cannot be used for table columns
+statement error pq: value type unknown cannot be used for table columns
 CREATE TABLE foo2 (x) AS (VALUES(NULL))
 
 # Check nulls are handled properly (#13921)

--- a/pkg/sql/logictest/testdata/logic_test/union
+++ b/pkg/sql/logictest/testdata/logic_test/union
@@ -86,14 +86,14 @@ NULL
 query IT
 SELECT x, pg_typeof(y) FROM (SELECT 1, NULL UNION ALL SELECT 2, 4) AS t(x, y)
 ----
-1  NULL
+1  unknown
 2  int
 
 query IT
 SELECT x, pg_typeof(y) FROM (SELECT 1, 3 UNION ALL SELECT 2, NULL) AS t(x, y)
 ----
 1  int
-2  NULL
+2  unknown
 
 statement ok
 CREATE TABLE uniontest (

--- a/pkg/sql/opt/index_constraints.go
+++ b/pkg/sql/opt/index_constraints.go
@@ -91,7 +91,7 @@ func (c *indexConstraintCtx) makeStringPrefixSpan(offset int, prefix string) Log
 // given type. We disallow mixed-type comparisons because it would result in
 // incorrect encodings (#4313).
 func (c *indexConstraintCtx) verifyType(offset int, typ types.T) bool {
-	return typ == types.Null || c.colInfos[offset].Typ.Equivalent(typ)
+	return typ == types.Unknown || c.colInfos[offset].Typ.Equivalent(typ)
 }
 
 // makeSpansForSingleColumn creates spans for a single index column from a

--- a/pkg/sql/opt/optbuilder/testdata/aggregate
+++ b/pkg/sql/opt/optbuilder/testdata/aggregate
@@ -24,27 +24,27 @@ group-by
  │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
  ├── groupings
  └── aggregations
-      ├── function: min [type=NULL]
+      ├── function: min [type=unknown]
       │    └── const: 1 [type=int]
-      ├── function: max [type=NULL]
+      ├── function: max [type=unknown]
       │    └── const: 1 [type=int]
-      ├── function: count [type=NULL]
+      ├── function: count [type=unknown]
       │    └── const: 1 [type=int]
-      ├── function: sum_int [type=NULL]
+      ├── function: sum_int [type=unknown]
       │    └── const: 1 [type=int]
-      ├── function: avg [type=NULL]
+      ├── function: avg [type=unknown]
       │    └── const: 1 [type=int]
-      ├── function: sum [type=NULL]
+      ├── function: sum [type=unknown]
       │    └── const: 1 [type=int]
-      ├── function: stddev [type=NULL]
+      ├── function: stddev [type=unknown]
       │    └── const: 1 [type=int]
-      ├── function: variance [type=NULL]
+      ├── function: variance [type=unknown]
       │    └── const: 1 [type=int]
-      ├── function: bool_and [type=NULL]
+      ├── function: bool_and [type=unknown]
       │    └── true [type=bool]
-      ├── function: bool_and [type=NULL]
+      ├── function: bool_and [type=unknown]
       │    └── false [type=bool]
-      └── function: xor_agg [type=NULL]
+      └── function: xor_agg [type=unknown]
            └── const: '\x01' [type=bytes]
 
 build
@@ -56,7 +56,7 @@ group-by
  │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
  ├── groupings
  └── aggregations
-      └── function: array_agg [type=NULL]
+      └── function: array_agg [type=unknown]
            └── const: 1 [type=int]
 
 build
@@ -68,7 +68,7 @@ group-by
  │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
  ├── groupings
  └── aggregations
-      └── function: json_agg [type=NULL]
+      └── function: json_agg [type=unknown]
            └── variable: kv.v [type=int]
 
 build
@@ -80,7 +80,7 @@ group-by
  │    └── tuple [type=tuple{}]
  ├── groupings
  └── aggregations
-      └── function: jsonb_agg [type=NULL]
+      └── function: jsonb_agg [type=unknown]
            └── const: 1 [type=int]
 
 # Even with no aggregate functions, grouping occurs in the presence of GROUP BY.
@@ -121,7 +121,7 @@ project
  │    ├── groupings
  │    │    └── variable: kv.k [type=int]
  │    └── aggregations
- │         └── function: count_rows [type=NULL]
+ │         └── function: count_rows [type=unknown]
  └── projections
       ├── variable: column5 [type=int]
       └── variable: kv.k [type=int]
@@ -139,7 +139,7 @@ project
  │    ├── groupings
  │    │    └── variable: kv.k [type=int]
  │    └── aggregations
- │         └── function: count_rows [type=NULL]
+ │         └── function: count_rows [type=unknown]
  └── projections
       ├── variable: column5 [type=int]
       └── variable: kv.k [type=int]
@@ -172,7 +172,7 @@ project
  │    ├── groupings
  │    │    └── variable: kv.s [type=string]
  │    └── aggregations
- │         └── function: count_rows [type=NULL]
+ │         └── function: count_rows [type=unknown]
  └── projections
       ├── variable: column5 [type=int]
       └── variable: kv.s [type=string]
@@ -189,7 +189,7 @@ project
  │    ├── groupings
  │    │    └── variable: kv.s [type=string]
  │    └── aggregations
- │         └── function: count_rows [type=NULL]
+ │         └── function: count_rows [type=unknown]
  └── projections
       ├── variable: column5 [type=int]
       └── variable: kv.s [type=string]
@@ -206,7 +206,7 @@ project
  │    ├── groupings
  │    │    └── variable: kv.s [type=string]
  │    └── aggregations
- │         └── function: count_rows [type=NULL]
+ │         └── function: count_rows [type=unknown]
  └── projections
       ├── variable: column5 [type=int]
       └── variable: kv.s [type=string]
@@ -223,7 +223,7 @@ project
  │    ├── groupings
  │    │    └── variable: kv.s [type=string]
  │    └── aggregations
- │         └── function: count_rows [type=NULL]
+ │         └── function: count_rows [type=unknown]
  └── projections
       ├── variable: column5 [type=int]
       └── variable: kv.s [type=string]
@@ -242,7 +242,7 @@ project
  │    │    ├── variable: kv.v [type=int]
  │    │    └── variable: kv.w [type=int]
  │    └── aggregations
- │         └── function: count_rows [type=NULL]
+ │         └── function: count_rows [type=unknown]
  └── projections
       ├── variable: kv.v [type=int]
       ├── variable: column5 [type=int]
@@ -262,7 +262,7 @@ project
  │    │    ├── variable: kv.v [type=int]
  │    │    └── variable: kv.w [type=int]
  │    └── aggregations
- │         └── function: count_rows [type=NULL]
+ │         └── function: count_rows [type=unknown]
  └── projections
       ├── variable: kv.v [type=int]
       ├── variable: column5 [type=int]
@@ -279,10 +279,10 @@ project
  │    ├── scan
  │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
  │    ├── groupings
- │    │    └── function: upper [type=NULL]
+ │    │    └── function: upper [type=unknown]
  │    │         └── variable: kv.s [type=string]
  │    └── aggregations
- │         └── function: count_rows [type=NULL]
+ │         └── function: count_rows [type=unknown]
  └── projections
       ├── variable: column6 [type=int]
       └── variable: column5 [type=string]
@@ -300,7 +300,7 @@ project
  │    ├── groupings
  │    │    └── const: 3 [type=int]
  │    └── aggregations
- │         └── function: count_rows [type=NULL]
+ │         └── function: count_rows [type=unknown]
  └── projections
       └── variable: column6 [type=int]
 
@@ -314,10 +314,10 @@ project
  │    ├── scan
  │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
  │    ├── groupings
- │    │    └── function: length [type=NULL]
+ │    │    └── function: length [type=unknown]
  │    │         └── const: 'abc' [type=string]
  │    └── aggregations
- │         └── function: count_rows [type=NULL]
+ │         └── function: count_rows [type=unknown]
  └── projections
       └── variable: column6 [type=int]
 
@@ -334,10 +334,10 @@ project
  │    ├── groupings
  │    │    └── variable: kv.s [type=string]
  │    └── aggregations
- │         └── function: count_rows [type=NULL]
+ │         └── function: count_rows [type=unknown]
  └── projections
       ├── variable: column5 [type=int]
-      └── function: upper [type=NULL]
+      └── function: upper [type=unknown]
            └── variable: kv.s [type=string]
 
 # Selecting a value that is not grouped, even if a function of it it, does not work.
@@ -361,7 +361,7 @@ project
  │    │         ├── variable: kv.k [type=int]
  │    │         └── variable: kv.v [type=int]
  │    └── aggregations
- │         └── function: count_rows [type=NULL]
+ │         └── function: count_rows [type=unknown]
  └── projections
       ├── variable: column6 [type=int]
       └── variable: column5 [type=int]
@@ -381,7 +381,7 @@ project
  │    │    ├── variable: kv.k [type=int]
  │    │    └── variable: kv.v [type=int]
  │    └── aggregations
- │         └── function: count_rows [type=NULL]
+ │         └── function: count_rows [type=unknown]
  └── projections
       ├── variable: column5 [type=int]
       └── plus [type=int]
@@ -428,7 +428,7 @@ project
  │    │         ├── variable: kv.v [type=int]
  │    │         └── variable: kv.w [type=int]
  │    └── aggregations
- │         └── function: count [type=NULL]
+ │         └── function: count [type=unknown]
  │              └── variable: kv.k [type=int]
  └── projections
       ├── variable: count_1 [type=int]
@@ -443,7 +443,7 @@ group-by
  │    └── tuple [type=tuple{}]
  ├── groupings
  └── aggregations
-      └── function: count_rows [type=NULL]
+      └── function: count_rows [type=unknown]
 
 build
 SELECT COUNT(k) from t.kv
@@ -454,7 +454,7 @@ group-by
  │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
  ├── groupings
  └── aggregations
-      └── function: count [type=NULL]
+      └── function: count [type=unknown]
            └── variable: kv.k [type=int]
 
 build
@@ -466,7 +466,7 @@ group-by
  │    └── tuple [type=tuple{}]
  ├── groupings
  └── aggregations
-      └── function: count [type=NULL]
+      └── function: count [type=unknown]
            └── const: 1 [type=int]
 
 build
@@ -478,7 +478,7 @@ group-by
  │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
  ├── groupings
  └── aggregations
-      └── function: count [type=NULL]
+      └── function: count [type=unknown]
            └── const: 1 [type=int]
 
 build
@@ -495,10 +495,10 @@ group-by
  │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
  ├── groupings
  └── aggregations
-      ├── function: count_rows [type=NULL]
-      ├── function: count [type=NULL]
+      ├── function: count_rows [type=unknown]
+      ├── function: count [type=unknown]
       │    └── variable: kv.k [type=int]
-      └── function: count [type=NULL]
+      └── function: count [type=unknown]
            └── variable: kv.v [type=int]
 
 # TODO(rytaft): This should work once we add support for the AllColumnSelector.
@@ -516,7 +516,7 @@ group-by
  │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
  ├── groupings
  └── aggregations
-      └── function: count [type=NULL]
+      └── function: count [type=unknown]
            └── tuple [type=tuple{int, int}]
                 ├── variable: kv.k [type=int]
                 └── variable: kv.v [type=int]
@@ -532,9 +532,9 @@ project
  │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
  │    ├── groupings
  │    └── aggregations
- │         ├── function: count [type=NULL]
+ │         ├── function: count [type=unknown]
  │         │    └── variable: kv.k [type=int]
- │         └── function: count [type=NULL]
+ │         └── function: count [type=unknown]
  │              └── variable: kv.v [type=int]
  └── projections
       └── plus [type=int]
@@ -550,13 +550,13 @@ group-by
  │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
  ├── groupings
  └── aggregations
-      ├── function: min [type=NULL]
+      ├── function: min [type=unknown]
       │    └── variable: kv.k [type=int]
-      ├── function: max [type=NULL]
+      ├── function: max [type=unknown]
       │    └── variable: kv.k [type=int]
-      ├── function: min [type=NULL]
+      ├── function: min [type=unknown]
       │    └── variable: kv.v [type=int]
-      └── function: max [type=NULL]
+      └── function: max [type=unknown]
            └── variable: kv.v [type=int]
 
 build
@@ -573,13 +573,13 @@ group-by
  │         └── const: 8 [type=int]
  ├── groupings
  └── aggregations
-      ├── function: min [type=NULL]
+      ├── function: min [type=unknown]
       │    └── variable: kv.k [type=int]
-      ├── function: max [type=NULL]
+      ├── function: max [type=unknown]
       │    └── variable: kv.k [type=int]
-      ├── function: min [type=NULL]
+      ├── function: min [type=unknown]
       │    └── variable: kv.v [type=int]
-      └── function: max [type=NULL]
+      └── function: max [type=unknown]
            └── variable: kv.v [type=int]
 
 build
@@ -593,10 +593,10 @@ group-by
  │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
  │    └── is [type=bool]
  │         ├── variable: kv.s [type=string]
- │         └── const: NULL [type=NULL]
+ │         └── const: NULL [type=unknown]
  ├── groupings
  └── aggregations
-      └── function: array_agg [type=NULL]
+      └── function: array_agg [type=unknown]
            └── variable: kv.s [type=string]
 
 build
@@ -608,13 +608,13 @@ group-by
  │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
  ├── groupings
  └── aggregations
-      ├── function: avg [type=NULL]
+      ├── function: avg [type=unknown]
       │    └── variable: kv.k [type=int]
-      ├── function: avg [type=NULL]
+      ├── function: avg [type=unknown]
       │    └── variable: kv.v [type=int]
-      ├── function: sum [type=NULL]
+      ├── function: sum [type=unknown]
       │    └── variable: kv.k [type=int]
-      └── function: sum [type=NULL]
+      └── function: sum [type=unknown]
            └── variable: kv.v [type=int]
 
 exec-ddl
@@ -640,13 +640,13 @@ group-by
  │    └── columns: abc.a:string:1 abc.b:float:null:2 abc.c:bool:null:3 abc.d:decimal:null:4
  ├── groupings
  └── aggregations
-      ├── function: min [type=NULL]
+      ├── function: min [type=unknown]
       │    └── variable: abc.a [type=string]
-      ├── function: min [type=NULL]
+      ├── function: min [type=unknown]
       │    └── variable: abc.b [type=float]
-      ├── function: min [type=NULL]
+      ├── function: min [type=unknown]
       │    └── variable: abc.c [type=bool]
-      └── function: min [type=NULL]
+      └── function: min [type=unknown]
            └── variable: abc.d [type=decimal]
 
 build
@@ -658,13 +658,13 @@ group-by
  │    └── columns: abc.a:string:1 abc.b:float:null:2 abc.c:bool:null:3 abc.d:decimal:null:4
  ├── groupings
  └── aggregations
-      ├── function: max [type=NULL]
+      ├── function: max [type=unknown]
       │    └── variable: abc.a [type=string]
-      ├── function: max [type=NULL]
+      ├── function: max [type=unknown]
       │    └── variable: abc.b [type=float]
-      ├── function: max [type=NULL]
+      ├── function: max [type=unknown]
       │    └── variable: abc.c [type=bool]
-      └── function: max [type=NULL]
+      └── function: max [type=unknown]
            └── variable: abc.d [type=decimal]
 
 build
@@ -676,13 +676,13 @@ group-by
  │    └── columns: abc.a:string:1 abc.b:float:null:2 abc.c:bool:null:3 abc.d:decimal:null:4
  ├── groupings
  └── aggregations
-      ├── function: avg [type=NULL]
+      ├── function: avg [type=unknown]
       │    └── variable: abc.b [type=float]
-      ├── function: sum [type=NULL]
+      ├── function: sum [type=unknown]
       │    └── variable: abc.b [type=float]
-      ├── function: avg [type=NULL]
+      ├── function: avg [type=unknown]
       │    └── variable: abc.d [type=decimal]
-      └── function: sum [type=NULL]
+      └── function: sum [type=unknown]
            └── variable: abc.d [type=decimal]
 
 # Verify summing of intervals
@@ -703,7 +703,7 @@ group-by
  │    └── columns: intervals.a:interval:1
  ├── groupings
  └── aggregations
-      └── function: sum [type=NULL]
+      └── function: sum [type=unknown]
            └── variable: intervals.a [type=interval]
 
 build
@@ -762,7 +762,7 @@ group-by
  │    └── columns: xyz.x:int:1 xyz.y:int:null:2 xyz.z:float:null:3
  ├── groupings
  └── aggregations
-      └── function: min [type=NULL]
+      └── function: min [type=unknown]
            └── variable: xyz.x [type=int]
 
 build
@@ -782,7 +782,7 @@ group-by
  │              └── const: 7 [type=int]
  ├── groupings
  └── aggregations
-      └── function: min [type=NULL]
+      └── function: min [type=unknown]
            └── variable: xyz.x [type=int]
 
 build
@@ -794,7 +794,7 @@ group-by
  │    └── columns: xyz.x:int:1 xyz.y:int:null:2 xyz.z:float:null:3
  ├── groupings
  └── aggregations
-      └── function: max [type=NULL]
+      └── function: max [type=unknown]
            └── variable: xyz.x [type=int]
 
 build
@@ -811,7 +811,7 @@ group-by
  │         └── const: 1 [type=int]
  ├── groupings
  └── aggregations
-      └── function: max [type=NULL]
+      └── function: max [type=unknown]
            └── variable: xyz.y [type=int]
 
 build
@@ -828,7 +828,7 @@ group-by
  │         └── const: 7 [type=int]
  ├── groupings
  └── aggregations
-      └── function: min [type=NULL]
+      └── function: min [type=unknown]
            └── variable: xyz.y [type=int]
 
 build
@@ -849,7 +849,7 @@ group-by
  │              └── const: 3.0 [type=float]
  ├── groupings
  └── aggregations
-      └── function: min [type=NULL]
+      └── function: min [type=unknown]
            └── variable: xyz.x [type=int]
 
 build
@@ -870,7 +870,7 @@ group-by
  │              └── const: 2 [type=int]
  ├── groupings
  └── aggregations
-      └── function: max [type=NULL]
+      └── function: max [type=unknown]
            └── variable: xyz.x [type=int]
 
 
@@ -890,7 +890,7 @@ group-by
  │         └── const: 10 [type=int]
  ├── groupings
  └── aggregations
-      └── function: variance [type=NULL]
+      └── function: variance [type=unknown]
            └── variable: xyz.x [type=int]
 
 build
@@ -907,7 +907,7 @@ group-by
  │         └── const: 1 [type=int]
  ├── groupings
  └── aggregations
-      └── function: stddev [type=NULL]
+      └── function: stddev [type=unknown]
            └── variable: xyz.x [type=int]
 
 exec-ddl
@@ -926,9 +926,9 @@ group-by
  │    └── columns: bools.b:bool:null:1 bools.rowid:int:2
  ├── groupings
  └── aggregations
-      ├── function: bool_and [type=NULL]
+      ├── function: bool_and [type=unknown]
       │    └── variable: bools.b [type=bool]
-      └── function: bool_or [type=NULL]
+      └── function: bool_or [type=unknown]
            └── variable: bools.b [type=bool]
 
 
@@ -971,12 +971,12 @@ project
  │    │    └── columns: xor_bytes.a:bytes:null:1 xor_bytes.b:int:null:2 xor_bytes.c:int:null:3 xor_bytes.rowid:int:4
  │    ├── groupings
  │    └── aggregations
- │         ├── function: xor_agg [type=NULL]
+ │         ├── function: xor_agg [type=unknown]
  │         │    └── variable: xor_bytes.a [type=bytes]
- │         └── function: xor_agg [type=NULL]
+ │         └── function: xor_agg [type=unknown]
  │              └── variable: xor_bytes.c [type=int]
  └── projections
-      ├── function: to_hex [type=NULL]
+      ├── function: to_hex [type=unknown]
       │    └── variable: column5 [type=bytes]
       └── variable: column7 [type=int]
 
@@ -989,9 +989,9 @@ group-by
  │    └── tuple [type=tuple{}]
  ├── groupings
  └── aggregations
-      ├── function: max [type=NULL]
+      ├── function: max [type=unknown]
       │    └── true [type=bool]
-      └── function: min [type=NULL]
+      └── function: min [type=unknown]
            └── true [type=bool]
 
 exec-ddl
@@ -1053,7 +1053,7 @@ project
  │    │    ├── variable: ab.a [type=int]
  │    │    └── variable: ab.b [type=int]
  │    └── aggregations
- │         └── function: min [type=NULL]
+ │         └── function: min [type=unknown]
  │              └── variable: xy.y [type=string]
  └── projections
       ├── variable: column6 [type=string]
@@ -1103,7 +1103,7 @@ project
  │    │         ├── variable: kv.k [type=int]
  │    │         └── variable: kv.w [type=int]
  │    └── aggregations
- │         └── function: sum [type=NULL]
+ │         └── function: sum [type=unknown]
  │              └── variable: kv.w [type=int]
  └── projections
       ├── variable: column6 [type=decimal]
@@ -1120,13 +1120,13 @@ project
  │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
  │    ├── groupings
  │    │    ├── variable: kv.v [type=int]
- │    │    ├── function: lower [type=NULL]
+ │    │    ├── function: lower [type=unknown]
  │    │    │    └── variable: kv.s [type=string]
  │    │    └── mult [type=int]
  │    │         ├── variable: kv.k [type=int]
  │    │         └── variable: kv.w [type=int]
  │    └── aggregations
- │         └── function: sum [type=NULL]
+ │         └── function: sum [type=unknown]
  │              └── variable: kv.w [type=int]
  └── projections
       ├── variable: column7 [type=decimal]

--- a/pkg/sql/opt/optbuilder/testdata/distinct
+++ b/pkg/sql/opt/optbuilder/testdata/distinct
@@ -101,7 +101,7 @@ group-by
  │    └── aggregations
  ├── groupings
  └── aggregations
-      └── function: count_rows [type=NULL]
+      └── function: count_rows [type=unknown]
 
 build
 SELECT DISTINCT x FROM t.xyz WHERE x > 0
@@ -157,7 +157,7 @@ group-by
  │    │    ├── groupings
  │    │    │    └── variable: xyz.x [type=int]
  │    │    └── aggregations
- │    │         └── function: max [type=NULL]
+ │    │         └── function: max [type=unknown]
  │    │              └── variable: xyz.x [type=int]
  │    └── projections
  │         └── variable: column4 [type=int]
@@ -229,7 +229,7 @@ group-by
  │    │    │    │    ├── variable: xyz.x [type=int]
  │    │    │    │    └── variable: xyz.y [type=int]
  │    │    │    └── aggregations
- │    │    │         └── function: max [type=NULL]
+ │    │    │         └── function: max [type=unknown]
  │    │    │              └── variable: xyz.z [type=float]
  │    │    └── gt [type=bool]
  │    │         ├── variable: xyz.y [type=int]

--- a/pkg/sql/opt/optbuilder/testdata/having
+++ b/pkg/sql/opt/optbuilder/testdata/having
@@ -42,7 +42,7 @@ select
  │    ├── groupings
  │    │    └── variable: kv.s [type=string]
  │    └── aggregations
- │         └── function: count_rows [type=NULL]
+ │         └── function: count_rows [type=unknown]
  └── gt [type=bool]
       ├── variable: column5 [type=int]
       └── const: 1 [type=int]
@@ -60,9 +60,9 @@ project
  │    │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
  │    │    ├── groupings
  │    │    └── aggregations
- │    │         ├── function: min [type=NULL]
+ │    │         ├── function: min [type=unknown]
  │    │         │    └── variable: kv.v [type=int]
- │    │         └── function: max [type=NULL]
+ │    │         └── function: max [type=unknown]
  │    │              └── variable: kv.k [type=int]
  │    └── gt [type=bool]
  │         ├── variable: column5 [type=int]
@@ -84,11 +84,11 @@ project
  │    │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
  │    │    ├── groupings
  │    │    └── aggregations
- │    │         ├── function: max [type=NULL]
+ │    │         ├── function: max [type=unknown]
  │    │         │    └── variable: kv.v [type=int]
- │    │         ├── function: max [type=NULL]
+ │    │         ├── function: max [type=unknown]
  │    │         │    └── variable: kv.k [type=int]
- │    │         └── function: min [type=NULL]
+ │    │         └── function: min [type=unknown]
  │    │              └── variable: kv.v [type=int]
  │    └── gt [type=bool]
  │         ├── variable: column5 [type=int]
@@ -141,7 +141,7 @@ project
  │    │    │         ├── variable: kv.k [type=int]
  │    │    │         └── variable: kv.w [type=int]
  │    │    └── aggregations
- │    │         └── function: count_rows [type=NULL]
+ │    │         └── function: count_rows [type=unknown]
  │    └── gt [type=bool]
  │         ├── plus [type=int]
  │         │    ├── variable: kv.k [type=int]
@@ -171,7 +171,7 @@ project
  │    │    ├── groupings
  │    │    │    └── variable: kv.v [type=int]
  │    │    └── aggregations
- │    │         └── function: max [type=NULL]
+ │    │         └── function: max [type=unknown]
  │    │              └── variable: kv.v [type=int]
  │    └── gt [type=bool]
  │         ├── variable: kv.v [type=int]
@@ -191,13 +191,13 @@ project
  │    │    ├── scan
  │    │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
  │    │    ├── groupings
- │    │    │    └── function: lower [type=NULL]
+ │    │    │    └── function: lower [type=unknown]
  │    │    │         └── variable: kv.s [type=string]
  │    │    └── aggregations
- │    │         └── function: sum [type=NULL]
+ │    │         └── function: sum [type=unknown]
  │    │              └── variable: kv.w [type=int]
  │    └── like [type=bool]
- │         ├── function: lower [type=NULL]
+ │         ├── function: lower [type=unknown]
  │         │    └── variable: kv.s [type=string]
  │         └── const: 'test%' [type=string]
  └── projections
@@ -215,10 +215,10 @@ project
  │    │    ├── scan
  │    │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
  │    │    ├── groupings
- │    │    │    └── function: lower [type=NULL]
+ │    │    │    └── function: lower [type=unknown]
  │    │    │         └── variable: kv.s [type=string]
  │    │    └── aggregations
- │    │         └── function: sum [type=NULL]
+ │    │         └── function: sum [type=unknown]
  │    │              └── variable: kv.w [type=int]
  │    └── in [type=bool]
  │         ├── variable: column6 [type=decimal]

--- a/pkg/sql/opt/optbuilder/testdata/scalar
+++ b/pkg/sql/opt/optbuilder/testdata/scalar
@@ -144,14 +144,14 @@ build-scalar vars=(int, int)
 ----
 is [type=bool]
  ├── variable: @1 [type=int]
- └── const: NULL [type=NULL]
+ └── const: NULL [type=unknown]
 
 build-scalar vars=(int, int)
 @1 IS NOT DISTINCT FROM NULL
 ----
 is [type=bool]
  ├── variable: @1 [type=int]
- └── const: NULL [type=NULL]
+ └── const: NULL [type=unknown]
 
 build-scalar vars=(int, int)
 @1 IS NOT DISTINCT FROM @2
@@ -165,14 +165,14 @@ build-scalar vars=(int, int)
 ----
 is-not [type=bool]
  ├── variable: @1 [type=int]
- └── const: NULL [type=NULL]
+ └── const: NULL [type=unknown]
 
 build-scalar vars=(int, int)
 @1 IS DISTINCT FROM NULL
 ----
 is-not [type=bool]
  ├── variable: @1 [type=int]
- └── const: NULL [type=NULL]
+ └── const: NULL [type=unknown]
 
 build-scalar vars=(int, int)
 @1 IS DISTINCT FROM @2
@@ -200,7 +200,7 @@ build-scalar vars=(string)
 LENGTH(@1) = 2
 ----
 eq [type=bool]
- ├── function: length [type=NULL]
+ ├── function: length [type=unknown]
  │    └── variable: @1 [type=string]
  └── const: 2 [type=int]
 

--- a/pkg/sql/opt/testdata/build-scalar
+++ b/pkg/sql/opt/testdata/build-scalar
@@ -155,7 +155,7 @@ build-scalar,semtree-expr vars=(int, int)
 ----
 is (type: bool)
  ├── variable (@1) (type: int)
- └── const (NULL) (type: NULL)
+ └── const (NULL) (type: unknown)
 @1 IS NULL
 
 build-scalar,semtree-expr vars=(int, int)
@@ -163,7 +163,7 @@ build-scalar,semtree-expr vars=(int, int)
 ----
 is (type: bool)
  ├── variable (@1) (type: int)
- └── const (NULL) (type: NULL)
+ └── const (NULL) (type: unknown)
 @1 IS NULL
 
 build-scalar,semtree-expr vars=(int, int)
@@ -179,7 +179,7 @@ build-scalar,semtree-expr vars=(int, int)
 ----
 is-not (type: bool)
  ├── variable (@1) (type: int)
- └── const (NULL) (type: NULL)
+ └── const (NULL) (type: unknown)
 @1 IS NOT NULL
 
 build-scalar,semtree-expr vars=(int, int)
@@ -187,7 +187,7 @@ build-scalar,semtree-expr vars=(int, int)
 ----
 is-not (type: bool)
  ├── variable (@1) (type: int)
- └── const (NULL) (type: NULL)
+ └── const (NULL) (type: unknown)
 @1 IS NOT NULL
 
 build-scalar,semtree-expr vars=(int, int)

--- a/pkg/sql/opt/testdata/normalize
+++ b/pkg/sql/opt/testdata/normalize
@@ -322,7 +322,7 @@ NOT (@1 IS NULL)
 ----
 is-not (type: bool)
  ├── variable (@1) (type: int)
- └── const (NULL) (type: NULL)
+ └── const (NULL) (type: unknown)
 @1 IS NOT NULL
 
 build-scalar,normalize,semtree-expr vars=(int)
@@ -330,7 +330,7 @@ NOT (@1 IS NOT NULL)
 ----
 is (type: bool)
  ├── variable (@1) (type: int)
- └── const (NULL) (type: NULL)
+ └── const (NULL) (type: unknown)
 @1 IS NULL
 
 build-scalar,normalize,semtree-expr vars=(int, int)

--- a/pkg/sql/opt/xform/testdata/rules/bool
+++ b/pkg/sql/opt/xform/testdata/rules/bool
@@ -185,10 +185,10 @@ select
       │         └── const: 4 [type=int]
       ├── is-not [type=bool]
       │    ├── variable: a.i [type=int]
-      │    └── const: NULL [type=NULL]
+      │    └── const: NULL [type=unknown]
       └── is [type=bool]
            ├── variable: a.i [type=int]
-           └── const: NULL [type=NULL]
+           └── const: NULL [type=unknown]
 
 #
 # NegateComparison

--- a/pkg/sql/opt/xform/testdata/typing
+++ b/pkg/sql/opt/xform/testdata/typing
@@ -199,7 +199,7 @@ select
       │    └── variable: a.y [type=int]
       └── is [type=bool]
            ├── variable: a.x [type=int]
-           └── const: NULL [type=NULL]
+           └── const: NULL [type=unknown]
 
 # Bitand, Bitor, Bitxor
 build

--- a/pkg/sql/opt/xform/typing.go
+++ b/pkg/sql/opt/xform/typing.go
@@ -29,9 +29,9 @@ import (
 func inferType(ev ExprView) types.T {
 	fn := typingFuncMap[ev.Operator()]
 	if fn == nil {
-		// TODO(rytaft): This should cause a panic, but for now just return NULL
+		// TODO(rytaft): This should cause a panic, but for now just return Unknown
 		// so the builder code can be implemented and tested.
-		return types.Null
+		return types.Unknown
 	}
 	return fn(ev)
 }

--- a/pkg/sql/sem/builtins/pg_builtins.go
+++ b/pkg/sql/sem/builtins/pg_builtins.go
@@ -278,11 +278,10 @@ var pgBuiltins = map[string][]tree.Builtin{
 	},
 
 	"pg_typeof": {
-		// TODO(knz): This is a proof-of-concept until types.Any works
-		// properly.
 		tree.Builtin{
-			Types:      tree.ArgTypes{{"val", types.Any}},
-			ReturnType: tree.FixedReturnType(types.String),
+			Types:        tree.ArgTypes{{"val", types.Any}},
+			NullableArgs: true,
+			ReturnType:   tree.FixedReturnType(types.String),
 			Fn: func(_ *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
 				return tree.NewDString(args[0].ResolvedType().String()), nil
 			},

--- a/pkg/sql/sem/tree/datum.go
+++ b/pkg/sql/sem/tree/datum.go
@@ -2585,7 +2585,7 @@ type dNull struct{}
 
 // ResolvedType implements the TypedExpr interface.
 func (dNull) ResolvedType() types.T {
-	return types.Null
+	return types.Unknown
 }
 
 // Compare implements the Datum interface.
@@ -3251,7 +3251,7 @@ var baseDatumTypeSizes = map[types.T]struct {
 	sz       uintptr
 	variable bool
 }{
-	types.Null:        {unsafe.Sizeof(dNull{}), fixedSize},
+	types.Unknown:     {unsafe.Sizeof(dNull{}), fixedSize},
 	types.Bool:        {unsafe.Sizeof(DBool(false)), fixedSize},
 	types.Int:         {unsafe.Sizeof(DInt(0)), fixedSize},
 	types.Float:       {unsafe.Sizeof(DFloat(0.0)), fixedSize},

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -1712,8 +1712,8 @@ var CmpOps = map[ComparisonOperator]cmpOpOverload{
 
 	IsNotDistinctFrom: {
 		CmpOp{
-			LeftType:     types.Null,
-			RightType:    types.Null,
+			LeftType:     types.Unknown,
+			RightType:    types.Unknown,
 			fn:           cmpOpScalarIsFn,
 			nullableArgs: true,
 			// Avoids ambiguous comparison error for NULL IS NOT DISTINCT FROM NULL>
@@ -3310,7 +3310,7 @@ func (expr *FuncExpr) Eval(ctx *EvalContext) (Datum, error) {
 // provided type. If the expected type is Any or if the datum is a Null
 // type, then no error will be returned.
 func ensureExpectedType(exp types.T, d Datum) error {
-	if !(exp.FamilyEqual(types.Any) || d.ResolvedType().Equivalent(types.Null) ||
+	if !(exp.FamilyEqual(types.Any) || d.ResolvedType().Equivalent(types.Unknown) ||
 		d.ResolvedType().Equivalent(exp)) {
 		return errors.Errorf("expected return type %q, got: %q", exp, d.ResolvedType())
 	}

--- a/pkg/sql/sem/tree/expr.go
+++ b/pkg/sql/sem/tree/expr.go
@@ -1208,25 +1208,25 @@ func (node *CastExpr) castType() types.T {
 }
 
 var (
-	boolCastTypes = []types.T{types.Null, types.Bool, types.Int, types.Float, types.Decimal, types.String, types.FamCollatedString}
-	intCastTypes  = []types.T{types.Null, types.Bool, types.Int, types.Float, types.Decimal, types.String, types.FamCollatedString,
+	boolCastTypes = []types.T{types.Unknown, types.Bool, types.Int, types.Float, types.Decimal, types.String, types.FamCollatedString}
+	intCastTypes  = []types.T{types.Unknown, types.Bool, types.Int, types.Float, types.Decimal, types.String, types.FamCollatedString,
 		types.Timestamp, types.TimestampTZ, types.Date, types.Interval, types.Oid}
-	floatCastTypes = []types.T{types.Null, types.Bool, types.Int, types.Float, types.Decimal, types.String, types.FamCollatedString,
+	floatCastTypes = []types.T{types.Unknown, types.Bool, types.Int, types.Float, types.Decimal, types.String, types.FamCollatedString,
 		types.Timestamp, types.TimestampTZ, types.Date, types.Interval}
-	decimalCastTypes = []types.T{types.Null, types.Bool, types.Int, types.Float, types.Decimal, types.String, types.FamCollatedString,
+	decimalCastTypes = []types.T{types.Unknown, types.Bool, types.Int, types.Float, types.Decimal, types.String, types.FamCollatedString,
 		types.Timestamp, types.TimestampTZ, types.Date, types.Interval}
-	stringCastTypes = []types.T{types.Null, types.Bool, types.Int, types.Float, types.Decimal, types.String, types.FamCollatedString,
+	stringCastTypes = []types.T{types.Unknown, types.Bool, types.Int, types.Float, types.Decimal, types.String, types.FamCollatedString,
 		types.Bytes, types.Timestamp, types.TimestampTZ, types.Interval, types.UUID, types.Date, types.Time, types.Oid, types.INet}
-	bytesCastTypes     = []types.T{types.Null, types.String, types.FamCollatedString, types.Bytes, types.UUID}
-	dateCastTypes      = []types.T{types.Null, types.String, types.FamCollatedString, types.Date, types.Timestamp, types.TimestampTZ, types.Int}
-	timeCastTypes      = []types.T{types.Null, types.String, types.FamCollatedString, types.Time, types.Timestamp, types.TimestampTZ, types.Interval}
-	timestampCastTypes = []types.T{types.Null, types.String, types.FamCollatedString, types.Date, types.Timestamp, types.TimestampTZ, types.Int}
-	intervalCastTypes  = []types.T{types.Null, types.String, types.FamCollatedString, types.Int, types.Time, types.Interval}
-	oidCastTypes       = []types.T{types.Null, types.String, types.FamCollatedString, types.Int, types.Oid}
-	uuidCastTypes      = []types.T{types.Null, types.String, types.FamCollatedString, types.Bytes, types.UUID}
-	inetCastTypes      = []types.T{types.Null, types.String, types.FamCollatedString, types.INet}
-	arrayCastTypes     = []types.T{types.Null, types.String}
-	jsonCastTypes      = []types.T{types.Null, types.String, types.JSON}
+	bytesCastTypes     = []types.T{types.Unknown, types.String, types.FamCollatedString, types.Bytes, types.UUID}
+	dateCastTypes      = []types.T{types.Unknown, types.String, types.FamCollatedString, types.Date, types.Timestamp, types.TimestampTZ, types.Int}
+	timeCastTypes      = []types.T{types.Unknown, types.String, types.FamCollatedString, types.Time, types.Timestamp, types.TimestampTZ, types.Interval}
+	timestampCastTypes = []types.T{types.Unknown, types.String, types.FamCollatedString, types.Date, types.Timestamp, types.TimestampTZ, types.Int}
+	intervalCastTypes  = []types.T{types.Unknown, types.String, types.FamCollatedString, types.Int, types.Time, types.Interval}
+	oidCastTypes       = []types.T{types.Unknown, types.String, types.FamCollatedString, types.Int, types.Oid}
+	uuidCastTypes      = []types.T{types.Unknown, types.String, types.FamCollatedString, types.Bytes, types.UUID}
+	inetCastTypes      = []types.T{types.Unknown, types.String, types.FamCollatedString, types.INet}
+	arrayCastTypes     = []types.T{types.Unknown, types.String}
+	jsonCastTypes      = []types.T{types.Unknown, types.String, types.JSON}
 )
 
 // validCastTypes returns a set of types that can be cast into the provided type.

--- a/pkg/sql/sem/tree/format_test.go
+++ b/pkg/sql/sem/tree/format_test.go
@@ -152,7 +152,7 @@ func TestFormatExpr(t *testing.T) {
 		expected string
 	}{
 		{`null`, tree.FmtShowTypes,
-			`(NULL)[NULL]`},
+			`(NULL)[unknown]`},
 		{`true`, tree.FmtShowTypes,
 			`(true)[bool]`},
 		{`123`, tree.FmtShowTypes,

--- a/pkg/sql/sem/tree/overload.go
+++ b/pkg/sql/sem/tree/overload.go
@@ -87,7 +87,7 @@ func (a ArgTypes) matchAt(typ types.T, i int) bool {
 	if typ.FamilyEqual(types.FamTuple) {
 		typ = types.FamTuple
 	}
-	return i < len(a) && (typ == types.Null || a[i].Typ.Equivalent(typ))
+	return i < len(a) && (typ == types.Unknown || a[i].Typ.Equivalent(typ))
 }
 
 func (a ArgTypes) matchLen(l int) bool {
@@ -180,9 +180,9 @@ func (v VariadicType) match(types []types.T) bool {
 
 func (v VariadicType) matchAt(typ types.T, i int) bool {
 	if i < len(v.FixedTypes) {
-		return typ == types.Null || v.FixedTypes[i].Equivalent(typ)
+		return typ == types.Unknown || v.FixedTypes[i].Equivalent(typ)
 	}
-	return typ == types.Null || v.VarType.Equivalent(typ)
+	return typ == types.Unknown || v.VarType.Equivalent(typ)
 }
 
 func (v VariadicType) matchLen(l int) bool {
@@ -537,8 +537,8 @@ func typeCheckOverloadedExprs(
 			}
 			leftType := left.ResolvedType()
 			rightType := right.ResolvedType()
-			leftIsNull := leftType == types.Null
-			rightIsNull := rightType == types.Null
+			leftIsNull := leftType == types.Unknown
+			rightIsNull := rightType == types.Unknown
 			oneIsNull := (leftIsNull || rightIsNull) && !(leftIsNull && rightIsNull)
 			if oneIsNull {
 				if leftIsNull {

--- a/pkg/sql/sem/tree/overload_test.go
+++ b/pkg/sql/sem/tree/overload_test.go
@@ -40,8 +40,8 @@ func TestVariadicFunctions(t *testing.T) {
 			"string...", []variadicTestCase{
 				{[]types.T{types.String}, true},
 				{[]types.T{types.String, types.String}, true},
-				{[]types.T{types.String, types.Null}, true},
-				{[]types.T{types.String, types.Null, types.String}, true},
+				{[]types.T{types.String, types.Unknown}, true},
+				{[]types.T{types.String, types.Unknown, types.String}, true},
 				{[]types.T{types.Int}, false},
 			}},
 		{FixedTypes: []types.T{types.Int}, VarType: types.String}: {
@@ -49,7 +49,7 @@ func TestVariadicFunctions(t *testing.T) {
 				{[]types.T{types.Int}, true},
 				{[]types.T{types.Int, types.String}, true},
 				{[]types.T{types.Int, types.String, types.String}, true},
-				{[]types.T{types.Int, types.Null, types.String}, true},
+				{[]types.T{types.Int, types.Unknown, types.String}, true},
 				{[]types.T{types.String}, false},
 			}},
 		{FixedTypes: []types.T{types.Int, types.Bool}, VarType: types.String}: {
@@ -57,7 +57,7 @@ func TestVariadicFunctions(t *testing.T) {
 				{[]types.T{types.Int}, false},
 				{[]types.T{types.Int, types.Bool}, true},
 				{[]types.T{types.Int, types.Bool, types.String}, true},
-				{[]types.T{types.Int, types.Null, types.String}, true},
+				{[]types.T{types.Int, types.Unknown, types.String}, true},
 				{[]types.T{types.Int, types.Bool, types.String, types.Bool}, false},
 				{[]types.T{types.Int, types.String}, false},
 				{[]types.T{types.Int, types.String, types.String}, false},

--- a/pkg/sql/sem/tree/type_check.go
+++ b/pkg/sql/sem/tree/type_check.go
@@ -135,7 +135,7 @@ func TypeCheckAndRequire(
 	if err != nil {
 		return nil, err
 	}
-	if typ := typedExpr.ResolvedType(); !(typ.Equivalent(required) || typ == types.Null) {
+	if typ := typedExpr.ResolvedType(); !(typ.Equivalent(required) || typ == types.Unknown) {
 		return typedExpr, pgerror.NewErrorf(
 			pgerror.CodeDatatypeMismatchError, "argument of %s must be type %s, not type %s", op, required, typ)
 	}
@@ -172,7 +172,7 @@ func (expr *BinaryExpr) TypeCheck(ctx *SemaContext, desired types.T) (TypedExpr,
 
 	// Return NULL if at least one overload is possible, NULL is an argument,
 	// and none of the overloads accept NULL.
-	if leftReturn == types.Null || rightReturn == types.Null {
+	if leftReturn == types.Unknown || rightReturn == types.Unknown {
 		if len(fns) > 0 {
 			noneAcceptNull := true
 			for _, e := range fns {
@@ -377,7 +377,7 @@ func (expr *CollateExpr) TypeCheck(ctx *SemaContext, desired types.T) (TypedExpr
 		return nil, err
 	}
 	t := subExpr.ResolvedType()
-	if types.IsStringType(t) || t == types.Null {
+	if types.IsStringType(t) || t == types.Unknown {
 		expr.Expr = subExpr
 		expr.typ = types.TCollatedString{Locale: expr.Locale}
 		return expr, nil
@@ -471,7 +471,7 @@ func (expr *FuncExpr) TypeCheck(ctx *SemaContext, desired types.T) (TypedExpr, e
 		}
 		if !handledNull {
 			for _, expr := range typedSubExprs {
-				if expr.ResolvedType() == types.Null {
+				if expr.ResolvedType() == types.Unknown {
 					return DNull, nil
 				}
 			}
@@ -721,7 +721,7 @@ func (expr *UnaryExpr) TypeCheck(ctx *SemaContext, desired types.T) (TypedExpr, 
 
 	// Return NULL if at least one overload is possible and NULL is an argument.
 	if len(fns) > 0 {
-		if exprReturn == types.Null {
+		if exprReturn == types.Unknown {
 			return DNull, nil
 		}
 	}
@@ -996,7 +996,7 @@ func typeCheckAndRequire(
 	if err != nil {
 		return nil, err
 	}
-	if typ := typedExpr.ResolvedType(); !(typ == types.Null || typ.Equivalent(required)) {
+	if typ := typedExpr.ResolvedType(); !(typ == types.Unknown || typ.Equivalent(required)) {
 		return nil, pgerror.NewErrorf(pgerror.CodeDatatypeMismatchError, "incompatible %s type: %s", op, typ)
 	}
 	return typedExpr, nil
@@ -1060,7 +1060,7 @@ func typeCheckComparisonOpWithSubOperator(
 		cmpTypeRight = retType
 
 		// Return early without looking up a CmpOp if the comparison type is types.Null.
-		if leftTyped.ResolvedType() == types.Null || retType == types.Null {
+		if leftTyped.ResolvedType() == types.Unknown || retType == types.Unknown {
 			return leftTyped, rightTyped, CmpOp{}, true /* alwaysNull */, nil
 		}
 	} else {
@@ -1092,7 +1092,7 @@ func typeCheckComparisonOpWithSubOperator(
 		}
 
 		rightReturn := rightTyped.ResolvedType()
-		if cmpTypeLeft == types.Null || rightReturn == types.Null {
+		if cmpTypeLeft == types.Unknown || rightReturn == types.Unknown {
 			return leftTyped, rightTyped, CmpOp{}, true /* alwaysNull */, nil
 		}
 
@@ -1229,7 +1229,7 @@ func typeCheckComparisonOp(
 
 	// Return early if at least one overload is possible, NULL is an argument,
 	// and none of the overloads accept NULL.
-	if leftReturn == types.Null || rightReturn == types.Null {
+	if leftReturn == types.Unknown || rightReturn == types.Unknown {
 		if len(fns) > 0 {
 			noneAcceptNull := true
 			for _, e := range fns {
@@ -1319,28 +1319,28 @@ func TypeCheckSameTypedExprs(
 		return typeCheckConstsAndPlaceholdersWithDesired(s, desired)
 	default:
 		firstValidIdx := -1
-		firstValidType := types.Null
+		firstValidType := types.Unknown
 		for i, j := range resolvableIdxs {
 			typedExpr, err := exprs[j].TypeCheck(ctx, desired)
 			if err != nil {
 				return nil, nil, err
 			}
 			typedExprs[j] = typedExpr
-			if returnType := typedExpr.ResolvedType(); returnType != types.Null {
+			if returnType := typedExpr.ResolvedType(); returnType != types.Unknown {
 				firstValidType = returnType
 				firstValidIdx = i
 				break
 			}
 		}
 
-		if firstValidType == types.Null {
+		if firstValidType == types.Unknown {
 			switch {
 			case len(constIdxs) > 0:
 				return typeCheckConstsAndPlaceholdersWithDesired(s, desired)
 			case len(placeholderIdxs) > 0:
 				return nil, nil, placeholderTypeAmbiguityError{s.exprs[placeholderIdxs[0]].(*Placeholder)}
 			default:
-				return typedExprs, types.Null, nil
+				return typedExprs, types.Unknown, nil
 			}
 		}
 
@@ -1349,7 +1349,7 @@ func TypeCheckSameTypedExprs(
 			if err != nil {
 				return nil, nil, err
 			}
-			if typ := typedExpr.ResolvedType(); !(typ.Equivalent(firstValidType) || typ == types.Null) {
+			if typ := typedExpr.ResolvedType(); !(typ.Equivalent(firstValidType) || typ == types.Unknown) {
 				return nil, nil, unexpectedTypeError{exprs[i], firstValidType, typ}
 			}
 			typedExprs[i] = typedExpr

--- a/pkg/sql/sem/tree/type_check_internal_test.go
+++ b/pkg/sql/sem/tree/type_check_internal_test.go
@@ -226,8 +226,8 @@ func TestTypeCheckSameTypedExprs(t *testing.T) {
 		{nil, nil, exprs(intConst("1"), placeholder("a")), types.Int, mapPTypesInt},
 		{nil, nil, exprs(decConst("1.1"), placeholder("a")), types.Decimal, mapPTypesDecimal},
 		// Verify dealing with Null.
-		{nil, nil, exprs(dnull), types.Null, nil},
-		{nil, nil, exprs(dnull, dnull), types.Null, nil},
+		{nil, nil, exprs(dnull), types.Unknown, nil},
+		{nil, nil, exprs(dnull, dnull), types.Unknown, nil},
 		{nil, nil, exprs(dnull, intConst("1")), types.Int, nil},
 		{nil, nil, exprs(dnull, decConst("1.1")), types.Decimal, nil},
 		{nil, nil, exprs(dnull, dint(1)), types.Int, nil},

--- a/pkg/sql/sem/types/oid.go
+++ b/pkg/sql/sem/types/oid.go
@@ -245,7 +245,7 @@ func (t TOidWrapper) Oid() oid.Oid { return t.oid }
 // WrapTypeWithOid wraps a T with a custom Oid.
 func WrapTypeWithOid(t T, oid oid.Oid) T {
 	switch v := t.(type) {
-	case tNull, tAny, TOidWrapper:
+	case tUnknown, tAny, TOidWrapper:
 		panic(pgerror.NewErrorf(pgerror.CodeInternalError, "cannot wrap %T with an Oid", v))
 	}
 	return TOidWrapper{

--- a/pkg/sql/sem/types/types.go
+++ b/pkg/sql/sem/types/types.go
@@ -46,8 +46,9 @@ type T interface {
 }
 
 var (
-	// Null is the type of a DNull. Can be compared with ==.
-	Null T = tNull{}
+	// Unknown is the type of an expression that statically evaluates to
+	// NULL. Can be compared with ==.
+	Unknown T = tUnknown{}
 	// Bool is the type of a DBool. Can be compared with ==.
 	Bool T = tBool{}
 	// Int is the type of a DInt. Can be compared with ==.
@@ -117,14 +118,14 @@ var (
 
 // Do not instantiate the tXxx types elsewhere. The variables above are intended
 // to be singletons.
-type tNull struct{}
+type tUnknown struct{}
 
-func (tNull) String() string           { return "NULL" }
-func (tNull) Equivalent(other T) bool  { return other == Null || other == Any }
-func (tNull) FamilyEqual(other T) bool { return other == Null }
-func (tNull) Oid() oid.Oid             { return oid.T_unknown }
-func (tNull) SQLName() string          { return "unknown" }
-func (tNull) IsAmbiguous() bool        { return true }
+func (tUnknown) String() string           { return "unknown" }
+func (tUnknown) Equivalent(other T) bool  { return other == Unknown || other == Any }
+func (tUnknown) FamilyEqual(other T) bool { return other == Unknown }
+func (tUnknown) Oid() oid.Oid             { return oid.T_unknown }
+func (tUnknown) SQLName() string          { return "unknown" }
+func (tUnknown) IsAmbiguous() bool        { return true }
 
 type tBool struct{}
 

--- a/pkg/sql/sqlbase/result_columns.go
+++ b/pkg/sql/sqlbase/result_columns.go
@@ -62,7 +62,7 @@ func (r ResultColumns) TypesEqual(other ResultColumns) bool {
 		// NULLs are considered equal because some types of queries (SELECT CASE,
 		// for example) can change their output types between a type and NULL based
 		// on input.
-		if other[i].Typ == types.Null {
+		if other[i].Typ == types.Unknown {
 			continue
 		}
 		if !c.Typ.Equivalent(other[i].Typ) {

--- a/pkg/sql/sqlbase/result_columns_test.go
+++ b/pkg/sql/sqlbase/result_columns_test.go
@@ -37,18 +37,18 @@ func TestResultColumnsTypesEqual(t *testing.T) {
 			equal: false,
 		},
 		{
-			r:     ResultColumns{{Typ: types.Null}},
+			r:     ResultColumns{{Typ: types.Unknown}},
 			o:     ResultColumns{{Typ: types.Int}},
 			equal: false,
 		},
 		{
 			r:     ResultColumns{{Typ: types.Int}},
-			o:     ResultColumns{{Typ: types.Null}},
+			o:     ResultColumns{{Typ: types.Unknown}},
 			equal: true,
 		},
 		{
-			r:     ResultColumns{{Typ: types.Null}},
-			o:     ResultColumns{{Typ: types.Null}},
+			r:     ResultColumns{{Typ: types.Unknown}},
+			o:     ResultColumns{{Typ: types.Unknown}},
 			equal: true,
 		},
 		{
@@ -58,7 +58,7 @@ func TestResultColumnsTypesEqual(t *testing.T) {
 		},
 		{
 			r:     ResultColumns{},
-			o:     ResultColumns{{Typ: types.Null}},
+			o:     ResultColumns{{Typ: types.Unknown}},
 			equal: false,
 		},
 	}

--- a/pkg/sql/sqlbase/structured.go
+++ b/pkg/sql/sqlbase/structured.go
@@ -2231,7 +2231,7 @@ func DatumTypeToColumnSemanticType(ptyp types.T) (ColumnType_SemanticType, error
 		return ColumnType_INET, nil
 	case types.Oid:
 		return ColumnType_OID, nil
-	case types.Null:
+	case types.Unknown:
 		return ColumnType_NULL, nil
 	case types.IntVector:
 		return ColumnType_INT2VECTOR, nil
@@ -2313,7 +2313,7 @@ func columnSemanticTypeToDatumType(c *ColumnType, k ColumnType_SemanticType) typ
 	case ColumnType_OID:
 		return types.Oid
 	case ColumnType_NULL:
-		return types.Null
+		return types.Unknown
 	case ColumnType_INT2VECTOR:
 		return types.IntVector
 	}

--- a/pkg/sql/sqlbase/table.go
+++ b/pkg/sql/sqlbase/table.go
@@ -1728,7 +1728,7 @@ func EncodeSecondaryIndexes(
 // with the type requested by the column. If the value is a
 // placeholder, the type of the placeholder gets populated.
 func CheckColumnType(col ColumnDescriptor, typ types.T, pmap *tree.PlaceholderInfo) error {
-	if typ == types.Null {
+	if typ == types.Unknown {
 		return nil
 	}
 

--- a/pkg/sql/stats/stats_cache.go
+++ b/pkg/sql/stats/stats_cache.go
@@ -284,7 +284,7 @@ func parseStats(datums tree.Datums) (*TableStatistic, error) {
 	}
 	for _, v := range expectedTypes {
 		if datums[v.fieldIndex].ResolvedType() != v.expectedType &&
-			(!v.nullable || datums[v.fieldIndex].ResolvedType() != types.Null) {
+			(!v.nullable || datums[v.fieldIndex].ResolvedType() != types.Unknown) {
 			return nil, errors.Errorf("%s returned from table statistics lookup has type %s. Expected %s",
 				v.fieldName, datums[v.fieldIndex].ResolvedType(), v.expectedType)
 		}
@@ -325,7 +325,7 @@ func parseHistogram(datums tree.Datums) (*HistogramData, error) {
 	datum := datums[0]
 
 	// Validate the input type.
-	if datum.ResolvedType() != types.Bytes && datum.ResolvedType() != types.Null {
+	if datum.ResolvedType() != types.Bytes && datum.ResolvedType() != types.Unknown {
 		return nil, errors.Errorf("histogram returned from table statistics lookup has type %s. Expected %s",
 			datum.ResolvedType(), types.Bytes)
 	}

--- a/pkg/sql/union.go
+++ b/pkg/sql/union.go
@@ -137,13 +137,13 @@ func (p *planner) Union(
 		// TODO(dan): This currently checks whether the types are exactly the same,
 		// but Postgres is more lenient:
 		// http://www.postgresql.org/docs/9.5/static/typeconv-union-case.html.
-		if !(l.Typ.Equivalent(r.Typ) || l.Typ == types.Null || r.Typ == types.Null) {
+		if !(l.Typ.Equivalent(r.Typ) || l.Typ == types.Unknown || r.Typ == types.Unknown) {
 			return nil, fmt.Errorf("%v types %s and %s cannot be matched", n.Type, l.Typ, r.Typ)
 		}
 		if l.Hidden != r.Hidden {
 			return nil, fmt.Errorf("%v types cannot be matched", n.Type)
 		}
-		if l.Typ == types.Null {
+		if l.Typ == types.Unknown {
 			unionColumns[i].Typ = r.Typ
 		}
 	}

--- a/pkg/sql/values.go
+++ b/pkg/sql/values.go
@@ -94,9 +94,9 @@ func (p *planner) Values(
 			typ := typedExpr.ResolvedType()
 			if num == 0 {
 				v.columns = append(v.columns, sqlbase.ResultColumn{Name: "column" + strconv.Itoa(i+1), Typ: typ})
-			} else if v.columns[i].Typ == types.Null {
+			} else if v.columns[i].Typ == types.Unknown {
 				v.columns[i].Typ = typ
-			} else if typ != types.Null && !typ.Equivalent(v.columns[i].Typ) {
+			} else if typ != types.Unknown && !typ.Equivalent(v.columns[i].Typ) {
 				return nil, fmt.Errorf("VALUES list type mismatch, %s for %s", typ, v.columns[i].Typ)
 			}
 

--- a/pkg/sql/values_test.go
+++ b/pkg/sql/values_test.go
@@ -188,7 +188,7 @@ func TestGolangQueryArgs(t *testing.T) {
 		expectedType reflect.Type
 	}{
 		// Null type.
-		{nil, reflect.TypeOf(types.Null)},
+		{nil, reflect.TypeOf(types.Unknown)},
 
 		// Bool type.
 		{true, reflect.TypeOf(types.Bool)},


### PR DESCRIPTION
Picks #23142.

Picked for pg compat + minimize divergence with master.

This renames `types.Null` to `types.Unknown` and adjusts its type name
accordingly.

`pg_typeof()` is also modified to accept NULL arguments, so that it can return
"unknown" as expected.

Release note (sql change): the type determined for constant NULL
expressions is renamed to "unknown" for better compatibility with
PostgreSQL.