### PR TITLE
cli: Print correct range count in node status

### DIFF
--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -1853,12 +1853,11 @@ func checkNodeStatus(t *testing.T, c cliTest, output string, start time.Time) {
 	if nodeCtx.statusShowRanges || nodeCtx.statusShowAll {
 		testcases = append(testcases,
 			testCase{"leader_ranges", baseIdx, 3},
-			testCase{"repl_ranges", baseIdx + 1, 3},
-			testCase{"avail_ranges", baseIdx + 2, 3},
+			testCase{"leaseholder_ranges", baseIdx + 1, 3},
+			testCase{"ranges", baseIdx + 2, 20},
+			testCase{"unavailable_ranges", baseIdx + 3, 0},
+			testCase{"underreplicated_ranges", baseIdx + 4, 0},
 		)
-
-		// Ranges actually adds 5 fields, but we only need to check
-		// the 3 above.
 		baseIdx += len(statusNodesColumnHeadersForRanges)
 	}
 

--- a/pkg/cli/node.go
+++ b/pkg/cli/node.go
@@ -278,7 +278,7 @@ func nodeStatusesToRows(
 			row = append(row,
 				strconv.FormatInt(int64(metricVals["replicas.leaders"]), 10),
 				strconv.FormatInt(int64(metricVals["replicas.leaseholders"]), 10),
-				strconv.FormatInt(int64(metricVals["ranges"]), 10),
+				strconv.FormatInt(int64(metricVals["replicas"]), 10),
 				strconv.FormatInt(int64(metricVals["ranges.unavailable"]), 10),
 				strconv.FormatInt(int64(metricVals["ranges.underreplicated"]), 10),
 			)


### PR DESCRIPTION
Fixes #23152

Release note (bug fix): Previously the `node status` command's "ranges"
column only included ranges whose raft leader was on the node in
question. It now includes the count of all ranges on the node,
regardless of where the raft leader is.