### PR TITLE
opt: minor fixes for type inference and testing

### DIFF
--- a/pkg/sql/opt/optbuilder/builder_test.go
+++ b/pkg/sql/opt/optbuilder/builder_test.go
@@ -135,7 +135,7 @@ func TestBuilder(t *testing.T) {
 					b.AllowUnsupportedExpr = allowUnsupportedExpr
 					root, props, err := b.Build()
 					if err != nil {
-						return fmt.Sprintf("error: %v\n", err)
+						return fmt.Sprintf("error: %s\n", strings.TrimSpace(err.Error()))
 					}
 					exprView := o.Optimize(root, props)
 					return exprView.String()
@@ -155,7 +155,7 @@ func TestBuilder(t *testing.T) {
 					b.AllowUnsupportedExpr = allowUnsupportedExpr
 					group, err := b.Build(typedExpr)
 					if err != nil {
-						return fmt.Sprintf("error: %v\n", err)
+						return fmt.Sprintf("error: %s\n", strings.TrimSpace(err.Error()))
 					}
 					exprView := o.Optimize(group, &opt.PhysicalProps{})
 					return exprView.String()

--- a/pkg/sql/opt/optbuilder/testdata/aggregate
+++ b/pkg/sql/opt/optbuilder/testdata/aggregate
@@ -245,7 +245,6 @@ project
 build
 SELECT ARRAY_AGG(NULL)
 ----
-----
 error: ambiguous call: array_agg(unknown), candidates are:
 array_agg(int) -> int[]
 array_agg(float) -> float[]
@@ -262,8 +261,6 @@ array_agg(inet) -> inet[]
 array_agg(oid) -> oid[]
 array_agg(bool) -> bool[]
 
-----
-----
 # With an explicit cast, this works as expected.
 build
 SELECT ARRAY_AGG(NULL::TEXT)

--- a/pkg/sql/opt/xform/typing.go
+++ b/pkg/sql/opt/xform/typing.go
@@ -164,17 +164,13 @@ func typeAsAny(_ ExprView) types.T {
 // typeCoalesce returns the type of a coalesce expression, which is equal to
 // the type of its children.
 func typeCoalesce(ev ExprView) types.T {
-	typ := types.Unknown
 	for i := 0; i < ev.ChildCount(); i++ {
 		childType := ev.Child(i).Logical().Scalar.Type
-		if typ == types.Unknown {
-			typ = childType
-		} else if childType != types.Unknown && !typ.Equivalent(childType) {
-			panic(fmt.Sprintf("could not find type for coalesce expression: %v", ev))
+		if childType != types.Unknown {
+			return childType
 		}
 	}
-
-	return typ
+	return types.Unknown
 }
 
 func typeCast(ev ExprView) types.T {


### PR DESCRIPTION
There were a couple of late comments for #22724 and #23115.
This commit addresses both of them.

The first was a suggestion from @andy-kimball to improve
the performance of typeCoalesce by assuming all children
of coalesce have the same type.

The second was a suggestion from @RaduBerinde to remove
extra lines from error messages during testing of the
optbuilder.

Release note: None