### PR TITLE
ui: Refresh Liveness on Single Node page

### DIFF
--- a/pkg/ui/src/redux/nodes.ts
+++ b/pkg/ui/src/redux/nodes.ts
@@ -240,3 +240,11 @@ export const nodesSummarySelector = createSelector(
 
 const nodesSummaryType = nullOfReturnType(nodesSummarySelector);
 export type NodesSummary = typeof nodesSummaryType;
+
+// selectNodesSummaryValid is a selector that returns true if the current
+// nodesSummary is "valid" (i.e. based on acceptably recent data). This is
+// included in the redux-connected state of some pages in order to support
+// automatically refreshing data.
+export function selectNodesSummaryValid(state: AdminUIState) {
+  return state.cachedData.nodes.valid && state.cachedData.liveness.valid;
+}

--- a/pkg/ui/src/views/cluster/containers/nodeOverview/index.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodeOverview/index.tsx
@@ -7,11 +7,11 @@ import _ from "lodash";
 import "./nodeOverview.styl";
 
 import {
-  livenessNomenclature, LivenessStatus, NodesSummary, nodesSummarySelector,
+  livenessNomenclature, LivenessStatus, NodesSummary, nodesSummarySelector, selectNodesSummaryValid,
 } from "src/redux/nodes";
 import { nodeIDAttr } from "src/util/constants";
 import { AdminUIState } from "src/redux/state";
-import { refreshNodes } from "src/redux/apiReducers";
+import { refreshLiveness, refreshNodes } from "src/redux/apiReducers";
 import { NodeStatus$Properties, MetricConstants, StatusMetrics } from  "src/util/proto";
 import { Bytes, Percentage } from "src/util/format";
 import { LongToMoment } from "src/util/convert";
@@ -23,6 +23,8 @@ interface NodeOverviewProps extends RouterState {
   node: NodeStatus$Properties;
   nodesSummary: NodesSummary;
   refreshNodes: typeof refreshNodes;
+  refreshLiveness: typeof refreshLiveness;
+  nodesSummaryValid: boolean;
 }
 
 /**
@@ -32,12 +34,14 @@ class NodeOverview extends React.Component<NodeOverviewProps, {}> {
   componentWillMount() {
     // Refresh nodes status query when mounting.
     this.props.refreshNodes();
+    this.props.refreshNodes();
   }
 
   componentWillReceiveProps(props: NodeOverviewProps) {
     // Refresh nodes status query when props are received; this will immediately
     // trigger a new request if previous results are invalidated.
     props.refreshNodes();
+    props.refreshLiveness();
   }
 
   render() {
@@ -180,9 +184,11 @@ export default connect(
     return {
       node: currentNode(state, ownProps),
       nodesSummary: nodesSummarySelector(state),
+      nodesSummaryValid: selectNodesSummaryValid(state),
     };
   },
   {
     refreshNodes,
+    refreshLiveness,
   },
 )(NodeOverview);

--- a/pkg/ui/src/views/cluster/containers/nodesOverview/index.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodesOverview/index.tsx
@@ -6,7 +6,7 @@ import { createSelector } from "reselect";
 import _ from "lodash";
 
 import {
-  livenessNomenclature, LivenessStatus, NodesSummary, nodesSummarySelector,
+  livenessNomenclature, LivenessStatus, NodesSummary, nodesSummarySelector, selectNodesSummaryValid,
 } from "src/redux/nodes";
 import { AdminUIState } from "src/redux/state";
 import { refreshNodes, refreshLiveness } from "src/redux/apiReducers";
@@ -241,9 +241,6 @@ class NotLiveNodeList extends React.Component<NotLiveNodeListProps, {}> {
   }
 }
 
-// Base selectors to extract data from redux state.
-const nodeQueryValid = (state: AdminUIState): boolean => state.cachedData.nodes.valid && state.cachedData.liveness.valid;
-
 /**
  * partitionedStatuses divides the list of node statuses into "live" and "dead".
  */
@@ -336,7 +333,7 @@ interface NodesMainProps {
   refreshLiveness: typeof refreshLiveness;
   // True if current status results are still valid. Needed so that this
   // component refreshes status query when it becomes invalid.
-  statusesValid: boolean;
+  nodesSummaryValid: boolean;
 }
 
 /**
@@ -373,7 +370,7 @@ class NodesMain extends React.Component<NodesMainProps, {}> {
 const NodesMainConnected = connect(
   (state: AdminUIState) => {
     return {
-      statusesValid: nodeQueryValid(state),
+      nodesSummaryValid: selectNodesSummaryValid(state),
     };
   },
   {


### PR DESCRIPTION
Liveness records were not being refreshed at all while viewing the
single-node page.

Fixes #17554

Release note (admin ui): Fixed a bug where liveness status would not
always display correctly on the single-node page.