### PR TITLE
cherrypick-2.0: cli: Print info to stderr if node gets stuck waiting for join/init

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -947,6 +947,19 @@ func (s *Server) Start(ctx context.Context) error {
 	s.gossip.Start(unresolvedAdvertAddr, filtered)
 	log.Event(ctx, "started gossip")
 
+	defer time.AfterFunc(30*time.Second, func() {
+		msg := `The server appears to be unable to contact the other nodes in the cluster. Please try
+
+- starting the other nodes, if you haven't already
+- double-checking that the '--join' and '--host' flags are set up correctly
+- running the 'cockroach init' command if you are trying to initialize a new cluster
+
+If problems persist, please see ` + base.DocsURL("cluster-setup-troubleshooting.html") + "."
+
+		log.Shout(context.Background(), log.Severity_WARNING,
+			msg)
+	}).Stop()
+
 	if len(bootstrappedEngines) > 0 {
 		// We might have to sleep a bit to protect against this node producing non-
 		// monotonic timestamps. Before restarting, its clock might have been driven
@@ -1028,19 +1041,6 @@ func (s *Server) Start(ctx context.Context) error {
 	if err != nil {
 		return errors.Wrap(err, "inspecting engines")
 	}
-
-	defer time.AfterFunc(30*time.Second, func() {
-		msg := `The server appears to be unable to contact the other nodes in the cluster. Please try
-
-- starting the other nodes, if you haven't already
-- double-checking that the '--join' and '--host' flags are set up correctly
-- not using the '--background' flag.
-
-If problems persist, please see ` + base.DocsURL("cluster-setup-troubleshooting.html") + "."
-
-		log.Shout(context.Background(), log.Severity_WARNING,
-			msg)
-	}).Stop()
 
 	// Initialize grpc-gateway mux and context.
 	jsonpb := &protoutil.JSONPb{


### PR DESCRIPTION
This repurposes the message added in #17997.

Fixes #22579

Release note (cli change): Print a help message if a node spends more
than 30 seconds waiting for an init command or to join a cluster.

-------------

Cherrypicks #23175 to release-2.0.