### PR TITLE
libroach: detected leaked iterators

### DIFF
--- a/c-deps/libroach/batch.cc
+++ b/c-deps/libroach/batch.cc
@@ -420,7 +420,7 @@ class DBBatchInserter : public rocksdb::WriteBatch::Handler {
 }  // namespace
 
 DBBatch::DBBatch(DBEngine* db)
-    : DBEngine(db->rep), updates(0), has_delete_range(false), batch(&kComparator) {}
+    : DBEngine(db->rep, db->iters), updates(0), has_delete_range(false), batch(&kComparator) {}
 
 DBBatch::~DBBatch() {}
 
@@ -493,7 +493,7 @@ DBStatus DBBatch::ApplyBatchRepr(DBSlice repr, bool sync) {
 DBSlice DBBatch::BatchRepr() { return ToDBSlice(batch.GetWriteBatch()->Data()); }
 
 DBIterator* DBBatch::NewIter(rocksdb::ReadOptions* read_opts) {
-  DBIterator* iter = new DBIterator;
+  DBIterator* iter = new DBIterator(iters);
   if (has_delete_range) {
     // TODO(peter): We don't support iterators when the batch contains
     // delete range entries.
@@ -511,7 +511,7 @@ DBString DBBatch::GetCompactionStats() { return ToDBString("unsupported"); }
 
 DBStatus DBBatch::EnvWriteFile(DBSlice path, DBSlice contents) { return FmtStatus("unsupported"); }
 
-DBWriteOnlyBatch::DBWriteOnlyBatch(DBEngine* db) : DBEngine(db->rep), updates(0) {}
+DBWriteOnlyBatch::DBWriteOnlyBatch(DBEngine* db) : DBEngine(db->rep, db->iters), updates(0) {}
 
 DBWriteOnlyBatch::~DBWriteOnlyBatch() {}
 

--- a/c-deps/libroach/chunked_buffer.cc
+++ b/c-deps/libroach/chunked_buffer.cc
@@ -26,14 +26,8 @@ void chunkedBuffer::Put(const rocksdb::Slice& key, const rocksdb::Slice& value) 
   const uint32_t key_size = key.size();
   const uint32_t val_size = value.size();
   const uint8_t size_buf[sizeof(uint64_t)] = {
-    uint8_t(val_size),
-    uint8_t(val_size >> 8),
-    uint8_t(val_size >> 16),
-    uint8_t(val_size >> 24),
-    uint8_t(key_size),
-    uint8_t(key_size >> 8),
-    uint8_t(key_size >> 16),
-    uint8_t(key_size >> 24),
+      uint8_t(val_size), uint8_t(val_size >> 8), uint8_t(val_size >> 16), uint8_t(val_size >> 24),
+      uint8_t(key_size), uint8_t(key_size >> 8), uint8_t(key_size >> 16), uint8_t(key_size >> 24),
   };
   put((const char*)size_buf, sizeof(size_buf), key.size() + value.size());
   put(key.data(), key.size(), value.size());
@@ -55,8 +49,7 @@ void chunkedBuffer::Clear() {
 // indicate that the required size of this buffer will soon be
 // len+next_size_hint, to prevent excessive resize operations.
 void chunkedBuffer::put(const char* data, int len, int next_size_hint) {
-  const int avail = bufs_.empty() ? 0 :
-      (bufs_.back().len - (buf_ptr_ - bufs_.back().data));
+  const int avail = bufs_.empty() ? 0 : (bufs_.back().len - (buf_ptr_ - bufs_.back().data));
   if (len > avail) {
     // If it's bigger than the last buf's capacity, we fill the last buf,
     // allocate a new one, and write the remainder to the new one.  Our new

--- a/c-deps/libroach/chunked_buffer.h
+++ b/c-deps/libroach/chunked_buffer.h
@@ -21,12 +21,8 @@ namespace cockroach {
 
 class chunkedBuffer {
  public:
-  chunkedBuffer() {
-    Clear();
-  }
-  ~chunkedBuffer() {
-    Clear();
-  }
+  chunkedBuffer() { Clear(); }
+  ~chunkedBuffer() { Clear(); }
 
   // Write a key/value pair to this chunkedBuffer.
   void Put(const rocksdb::Slice& key, const rocksdb::Slice& value);
@@ -34,18 +30,16 @@ class chunkedBuffer {
   // Clear this chunkedBuffer.
   void Clear();
 
-  void GetChunks(DBSlice **bufs, int32_t *len) {
+  void GetChunks(DBSlice** bufs, int32_t* len) {
     // Cap the last buffer's size to the amount that's been written to it.
-    DBSlice &last = bufs_.back();
+    DBSlice& last = bufs_.back();
     last.len = buf_ptr_ - last.data;
     *bufs = &bufs_.front();
     *len = bufs_.size();
   }
 
   // Get the number of key/value pairs written to this chunkedBuffer.
-  int Count() const {
-    return count_;
-  }
+  int Count() const { return count_; }
 
  private:
   void put(const char* data, int len, int next_size_hint);

--- a/c-deps/libroach/db.cc
+++ b/c-deps/libroach/db.cc
@@ -147,7 +147,13 @@ DBStatus DBDestroy(DBSlice dir) {
   return ToDBStatus(rocksdb::DestroyDB(ToString(dir), options));
 }
 
-void DBClose(DBEngine* db) { delete db; }
+DBStatus DBClose(DBEngine* db) {
+  DBStatus status = db->AssertPreClose();
+  if (status.data == nullptr) {
+    delete db;
+  }
+  return status;
+}
 
 DBStatus DBFlush(DBEngine* db) {
   rocksdb::FlushOptions options;

--- a/c-deps/libroach/include/libroach.h
+++ b/c-deps/libroach/include/libroach.h
@@ -96,7 +96,7 @@ DBStatus DBOpen(DBEngine** db, DBSlice dir, DBOptions options);
 DBStatus DBDestroy(DBSlice dir);
 
 // Closes the database, freeing memory and other resources.
-void DBClose(DBEngine* db);
+DBStatus DBClose(DBEngine* db);
 
 // Flushes all mem-table data to disk, blocking until the operation is
 // complete.
@@ -251,7 +251,7 @@ typedef struct {
 } DBTxn;
 
 typedef struct {
-  DBSlice *bufs;
+  DBSlice* bufs;
   // len is the number of DBSlices in bufs.
   int32_t len;
   // count is the number of key/value pairs in bufs.

--- a/c-deps/libroach/iterator.h
+++ b/c-deps/libroach/iterator.h
@@ -14,13 +14,18 @@
 
 #pragma once
 
+#include <atomic>
 #include <memory>
-#include "chunked_buffer.h"
-#include "encoding.h"
 #include <rocksdb/iterator.h>
 #include <rocksdb/write_batch.h>
+#include "chunked_buffer.h"
+#include "encoding.h"
 
 struct DBIterator {
+  DBIterator(std::atomic<int64_t>* iters) : iters_count(iters) { ++(*iters_count); }
+  ~DBIterator() { --(*iters_count); }
+
+  std::atomic<int64_t>* const iters_count;
   std::unique_ptr<rocksdb::Iterator> rep;
   std::unique_ptr<cockroach::chunkedBuffer> kvs;
   std::unique_ptr<rocksdb::WriteBatch> intents;

--- a/c-deps/libroach/mvcc.cc
+++ b/c-deps/libroach/mvcc.cc
@@ -270,12 +270,14 @@ DBScanResults MVCCGet(DBIterator* iter, DBSlice key, DBTimestamp timestamp, DBTx
   // don't retrieve a key different than the start key. This is a bit
   // of a hack.
   const DBSlice end = {0, 0};
-  mvccForwardScanner scanner(iter, key, end, timestamp, 0 /* max_keys */, txn, consistent, tombstones);
+  mvccForwardScanner scanner(iter, key, end, timestamp, 0 /* max_keys */, txn, consistent,
+                             tombstones);
   return scanner.get();
 }
 
 DBScanResults MVCCScan(DBIterator* iter, DBSlice start, DBSlice end, DBTimestamp timestamp,
-                       int64_t max_keys, DBTxn txn, bool consistent, bool reverse, bool tombstones) {
+                       int64_t max_keys, DBTxn txn, bool consistent, bool reverse,
+                       bool tombstones) {
   if (reverse) {
     mvccReverseScanner scanner(iter, end, start, timestamp, max_keys, txn, consistent, tombstones);
     return scanner.scan();

--- a/c-deps/libroach/snapshot.cc
+++ b/c-deps/libroach/snapshot.cc
@@ -44,7 +44,7 @@ DBSlice DBSnapshot::BatchRepr() { return ToDBSlice("unsupported"); }
 
 DBIterator* DBSnapshot::NewIter(rocksdb::ReadOptions* read_opts) {
   read_opts->snapshot = snapshot;
-  DBIterator* iter = new DBIterator;
+  DBIterator* iter = new DBIterator(iters);
   iter->rep.reset(rep->NewIterator(*read_opts));
   return iter;
 }

--- a/c-deps/libroach/snapshot.h
+++ b/c-deps/libroach/snapshot.h
@@ -23,7 +23,7 @@ namespace cockroach {
 struct DBSnapshot : public DBEngine {
   const rocksdb::Snapshot* snapshot;
 
-  DBSnapshot(DBEngine* db) : DBEngine(db->rep), snapshot(db->rep->GetSnapshot()) {}
+  DBSnapshot(DBEngine* db) : DBEngine(db->rep, db->iters), snapshot(db->rep->GetSnapshot()) {}
   virtual ~DBSnapshot();
 
   virtual DBStatus Put(DBKey key, DBSlice value);

--- a/pkg/ccl/importccl/csv.go
+++ b/pkg/ccl/importccl/csv.go
@@ -1530,6 +1530,7 @@ func (sp *sstWriter) Run(wg *sync.WaitGroup) {
 
 		// Fetch all the keys in each span and write them to storage.
 		iter := store.NewIterator()
+		defer iter.Close()
 		iter.Rewind()
 		maxSize := storageccl.MaxImportBatchSize(sp.settings)
 		for i, span := range sp.spec.Spans {

--- a/pkg/storage/engine/batch_test.go
+++ b/pkg/storage/engine/batch_test.go
@@ -174,8 +174,8 @@ func TestReadOnlyBasics(t *testing.T) {
 		func() { _, _ = b.Get(a) },
 		func() { _, _, _, _ = b.GetProto(a, getVal) },
 		func() { _ = b.Iterate(a, a, func(MVCCKeyValue) (bool, error) { return true, nil }) },
-		func() { _ = b.NewIterator(false) },
-		func() { _ = b.NewTimeBoundIterator(hlc.Timestamp{}, hlc.Timestamp{}) },
+		func() { b.NewIterator(false).Close() },
+		func() { b.NewTimeBoundIterator(hlc.Timestamp{}, hlc.Timestamp{}).Close() },
 	}
 	defer func() {
 		b.Close()

--- a/pkg/storage/engine/rocksdb_test.go
+++ b/pkg/storage/engine/rocksdb_test.go
@@ -759,6 +759,7 @@ func TestRocksDBTimeBound(t *testing.T) {
 	}
 
 	batch := rocksdb.NewBatch()
+	defer batch.Close()
 
 	// Make a time bounded iterator that skips the SSTable containing our writes.
 	func() {


### PR DESCRIPTION
Keep track of the number of live iterators and assert when an engine is
closed that the value is 0.

Fixes #23138

Release note: None