### PR TITLE
opt/optbuilder: support VALUES clause in the optbuilder

### DIFF
--- a/pkg/sql/opt/optbuilder/select.go
+++ b/pkg/sql/opt/optbuilder/select.go
@@ -148,7 +148,10 @@ func (b *Builder) buildSelect(
 	case *tree.SelectClause:
 		return b.buildSelectClause(stmt, inScope)
 
-	// TODO(rytaft): Add support for union clause and values clause.
+	case *tree.ValuesClause:
+		return b.buildValuesClause(t, inScope)
+
+	// TODO(rytaft): Add support for union clause.
 
 	default:
 		panic(errorf("not yet implemented: select statement: %T", stmt.Select))

--- a/pkg/sql/opt/optbuilder/testdata/values
+++ b/pkg/sql/opt/optbuilder/testdata/values
@@ -1,0 +1,84 @@
+# tests adapted from logictest -- values
+
+build
+VALUES (1)
+----
+values
+ ├── columns: column1:unknown:null:1
+ └── tuple [type=tuple{int}]
+      └── const: 1 [type=int]
+
+build
+VALUES (1, 2, 3), (4, 5, 6)
+----
+values
+ ├── columns: column1:unknown:null:1 column2:unknown:null:2 column3:unknown:null:3
+ ├── tuple [type=tuple{int, int, int}]
+ │    ├── const: 1 [type=int]
+ │    ├── const: 2 [type=int]
+ │    └── const: 3 [type=int]
+ └── tuple [type=tuple{int, int, int}]
+      ├── const: 4 [type=int]
+      ├── const: 5 [type=int]
+      └── const: 6 [type=int]
+
+build
+VALUES (1), (2, 3)
+----
+error: VALUES lists must all be the same length, expected 1 columns, found 2
+
+build
+VALUES (1), (1), (2), (3)
+----
+values
+ ├── columns: column1:unknown:null:1
+ ├── tuple [type=tuple{int}]
+ │    └── const: 1 [type=int]
+ ├── tuple [type=tuple{int}]
+ │    └── const: 1 [type=int]
+ ├── tuple [type=tuple{int}]
+ │    └── const: 2 [type=int]
+ └── tuple [type=tuple{int}]
+      └── const: 3 [type=int]
+
+build
+VALUES ('this', 'is', 'a', 'test'), (1, 2, 3, 4)
+----
+error: VALUES list type mismatch, int for string
+
+build
+VALUES ('one', 1, 1.0), ('two', 2, 2.0)
+----
+values
+ ├── columns: column1:unknown:null:1 column2:unknown:null:2 column3:unknown:null:3
+ ├── tuple [type=tuple{string, int, decimal}]
+ │    ├── const: 'one' [type=string]
+ │    ├── const: 1 [type=int]
+ │    └── const: 1.0 [type=decimal]
+ └── tuple [type=tuple{string, int, decimal}]
+      ├── const: 'two' [type=string]
+      ├── const: 2 [type=int]
+      └── const: 2.0 [type=decimal]
+
+build
+VALUES (true), (true), (false)
+----
+values
+ ├── columns: column1:unknown:null:1
+ ├── tuple [type=tuple{bool}]
+ │    └── true [type=bool]
+ ├── tuple [type=tuple{bool}]
+ │    └── true [type=bool]
+ └── tuple [type=tuple{bool}]
+      └── false [type=bool]
+
+# TODO(rytaft): uncomment these tests once subqueries are supported
+## subqueries can be evaluated in VALUES
+#build
+#VALUES ((SELECT 1)), ((SELECT 2))
+#----
+#
+## the subquery's plan must be visible in EXPLAIN
+#build
+#VALUES (1), ((SELECT 2))
+#----

--- a/pkg/sql/opt/optbuilder/values.go
+++ b/pkg/sql/opt/optbuilder/values.go
@@ -1,0 +1,75 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package optbuilder
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/opt"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
+)
+
+// buildValuesClause builds a set of memo groups that represent the given values
+// clause.
+//
+// See Builder.buildStmt for a description of the remaining input and
+// return values.
+func (b *Builder) buildValuesClause(
+	values *tree.ValuesClause, inScope *scope,
+) (out opt.GroupID, outScope *scope) {
+	var numCols int
+	if len(values.Tuples) > 0 {
+		numCols = len(values.Tuples[0].Exprs)
+	}
+
+	// Synthesize correct number of unknown-typed columns.
+	outScope = inScope.push()
+	for i := 0; i < numCols; i++ {
+		b.synthesizeColumn(outScope, "", types.Unknown)
+	}
+
+	rows := make([]opt.GroupID, 0, len(values.Tuples))
+
+	for _, tuple := range values.Tuples {
+		if numCols != len(tuple.Exprs) {
+			panic(errorf(
+				"VALUES lists must all be the same length, expected %d columns, found %d",
+				numCols, len(tuple.Exprs)))
+		}
+
+		elems := make([]opt.GroupID, numCols)
+
+		for i, expr := range tuple.Exprs {
+			texpr := inScope.resolveType(expr, types.Any)
+			typ := texpr.ResolvedType()
+			elems[i] = b.buildScalar(texpr, inScope)
+
+			// Verify that types of each tuple match one another.
+			if outScope.cols[i].typ == types.Unknown {
+				outScope.cols[i].typ = typ
+			} else if typ != types.Unknown && !typ.Equivalent(outScope.cols[i].typ) {
+				panic(errorf("VALUES list type mismatch, %s for %s", typ, outScope.cols[i].typ))
+			}
+		}
+
+		rows = append(rows, b.factory.ConstructTuple(b.factory.InternList(elems)))
+	}
+
+	colList := make(opt.ColList, len(outScope.cols))
+	for i := range outScope.cols {
+		colList[i] = outScope.cols[i].index
+	}
+	out = b.factory.ConstructValues(b.factory.InternList(rows), b.factory.InternPrivate(&colList))
+	return out, outScope
+}


### PR DESCRIPTION
This commit includes support for building a memo for queries
with a `VALUES` clause. The test cases have been adapted from
the values tests in logictests.

This code is based on code originally written as part of the
opttoy project.

Release note: None