### PR TITLE
opt: pass SemaContext and EvalContext to optbuilder

### DIFF
--- a/pkg/sql/opt/idxconstraint/index_constraints_test.go
+++ b/pkg/sql/opt/idxconstraint/index_constraints_test.go
@@ -85,6 +85,9 @@ func TestIndexConstraints(t *testing.T) {
 	for _, path := range paths {
 		t.Run(filepath.Base(path), func(t *testing.T) {
 			ctx := context.Background()
+			semaCtx := tree.MakeSemaContext(false /* privileged */)
+			evalCtx := tree.MakeTestingEvalContext(cluster.MakeTestingClusterSettings())
+
 			catalog := testutils.NewTestCatalog()
 
 			datadriven.RunTest(t, path, func(d *datadriven.TestData) string {
@@ -94,9 +97,6 @@ func TestIndexConstraints(t *testing.T) {
 				var invertedIndex bool
 				var normalizeTypedExpr bool
 				normalize := true
-
-				st := cluster.MakeTestingClusterSettings()
-				evalCtx := tree.MakeTestingEvalContext(st)
 
 				for _, arg := range d.CmdArgs {
 					key := arg
@@ -168,7 +168,7 @@ func TestIndexConstraints(t *testing.T) {
 						steps = xform.OptimizeNone
 					}
 					o := xform.NewOptimizer(catalog, steps)
-					b := optbuilder.NewScalar(ctx, o.Factory(), varNames, varTypes)
+					b := optbuilder.NewScalar(ctx, &semaCtx, &evalCtx, o.Factory(), varNames, varTypes)
 					b.AllowUnsupportedExpr = true
 					group, err := b.Build(typedExpr)
 					if err != nil {

--- a/pkg/sql/opt/optbuilder/builder.go
+++ b/pkg/sql/opt/optbuilder/builder.go
@@ -54,26 +54,32 @@ type Builder struct {
 
 	factory opt.Factory
 	stmt    tree.Statement
-	semaCtx tree.SemaContext
+
 	ctx     context.Context
+	semaCtx *tree.SemaContext
+	evalCtx *tree.EvalContext
 
 	// Skip index 0 in order to reserve it to indicate the "unknown" column.
 	colMap []columnProps
 }
 
 // New creates a new Builder structure initialized with the given
-// Context, Factory, and parsed SQL statement.
-func New(ctx context.Context, factory opt.Factory, stmt tree.Statement) *Builder {
-	b := &Builder{
+// parsed SQL statement.
+func New(
+	ctx context.Context,
+	semaCtx *tree.SemaContext,
+	evalCtx *tree.EvalContext,
+	factory opt.Factory,
+	stmt tree.Statement,
+) *Builder {
+	return &Builder{
 		factory: factory,
 		stmt:    stmt,
 		colMap:  make([]columnProps, 1),
 		ctx:     ctx,
+		semaCtx: semaCtx,
+		evalCtx: evalCtx,
 	}
-
-	b.semaCtx.Placeholders = tree.MakePlaceholderInfo()
-
-	return b
 }
 
 // Build is the top-level function to build the memo structure inside

--- a/pkg/sql/opt/optbuilder/scalar.go
+++ b/pkg/sql/opt/optbuilder/scalar.go
@@ -266,13 +266,20 @@ type ScalarBuilder struct {
 // from scalar expressions via IndexedVars.
 // columnNames and columnTypes must have the same length.
 func NewScalar(
-	ctx context.Context, factory opt.Factory, columnNames []string, columnTypes []types.T,
+	ctx context.Context,
+	semaCtx *tree.SemaContext,
+	evalCtx *tree.EvalContext,
+	factory opt.Factory,
+	columnNames []string,
+	columnTypes []types.T,
 ) *ScalarBuilder {
 	sb := &ScalarBuilder{
 		Builder: Builder{
 			factory: factory,
 			colMap:  make([]columnProps, 1),
 			ctx:     ctx,
+			semaCtx: semaCtx,
+			evalCtx: evalCtx,
 		},
 	}
 	sb.scope.builder = &sb.Builder

--- a/pkg/sql/opt/optbuilder/scope.go
+++ b/pkg/sql/opt/optbuilder/scope.go
@@ -77,7 +77,7 @@ func (s *scope) appendColumns(src *scope) {
 func (s *scope) resolveType(expr tree.Expr, desired types.T) tree.TypedExpr {
 	expr, _ = tree.WalkExpr(s, expr)
 	s.builder.semaCtx.IVarContainer = s
-	texpr, err := tree.TypeCheck(expr, &s.builder.semaCtx, desired)
+	texpr, err := tree.TypeCheck(expr, s.builder.semaCtx, desired)
 	if err != nil {
 		panic(builderError{err})
 	}

--- a/pkg/sql/plan.go
+++ b/pkg/sql/plan.go
@@ -320,7 +320,8 @@ func (p *planner) makeOptimizerPlan(ctx context.Context, stmt Statement) error {
 	defer eng.Close()
 
 	o := xform.NewOptimizer(eng.Catalog(), xform.OptimizeAll)
-	root, props, err := optbuilder.New(ctx, o.Factory(), stmt.AST).Build()
+	bld := optbuilder.New(ctx, &p.semaCtx, p.EvalContext(), o.Factory(), stmt.AST)
+	root, props, err := bld.Build()
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
The `EvalContext` will be used to replace placeholders with their
values.

Release note: None