### PR TITLE
cherrypick-2.0: storage: Deflake TestReplicateRemovedNodeDisruptiveElection

### DIFF
--- a/pkg/storage/client_raft_test.go
+++ b/pkg/storage/client_raft_test.go
@@ -3011,7 +3011,7 @@ func TestReplicateRemovedNodeDisruptiveElection(t *testing.T) {
 		default:
 			t.Fatalf("unexpected error type %T: %s", pErr.GetDetail(), pErr)
 		}
-	case <-time.After(time.Second):
+	case <-time.After(5 * time.Second):
 		t.Fatal("did not get expected error")
 	}
 


### PR DESCRIPTION
Fixes #18582

Release note: None