### PR TITLE
cli: De-flake TestNodeStatus

### DIFF
--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -1850,13 +1850,18 @@ func checkNodeStatus(t *testing.T, c cliTest, output string, start time.Time) {
 	baseIdx := len(baseNodeColumnHeaders)
 
 	// Adding fields that need verification for --range flag.
+	// We have to allow up to 1 unavailable/underreplicated range because
+	// sometimes we run the `node status` command before the server has fully
+	// initialized itself and it doesn't consider itself live yet. In such cases,
+	// there will only be one range covering the entire keyspace because it won't
+	// have been able to do any splits yet.
 	if nodeCtx.statusShowRanges || nodeCtx.statusShowAll {
 		testcases = append(testcases,
 			testCase{"leader_ranges", baseIdx, 3},
 			testCase{"leaseholder_ranges", baseIdx + 1, 3},
 			testCase{"ranges", baseIdx + 2, 20},
-			testCase{"unavailable_ranges", baseIdx + 3, 0},
-			testCase{"underreplicated_ranges", baseIdx + 4, 0},
+			testCase{"unavailable_ranges", baseIdx + 3, 1},
+			testCase{"underreplicated_ranges", baseIdx + 4, 1},
 		)
 		baseIdx += len(statusNodesColumnHeadersForRanges)
 	}


### PR DESCRIPTION
Sorry for not catching this before it went in. Without this it flakes fairly often, but not often enough for teamcity to catch it consistently.