### PR TITLE
kv: distsender quits early if context is cancelled

### DIFF
--- a/pkg/kv/dist_sender.go
+++ b/pkg/kv/dist_sender.go
@@ -1308,6 +1308,12 @@ func (ds *DistSender) sendToReplicas(
 			ds.metrics.SlowRequestsCount.Inc(1)
 			defer ds.metrics.SlowRequestsCount.Dec(1)
 
+		case <-ctx.Done():
+			// Caller has given up.
+			errMsg := fmt.Sprintf("context finished during distsender send: %v", ctx.Err())
+			log.Eventf(ctx, errMsg)
+			return nil, roachpb.NewAmbiguousResultError(errMsg)
+
 		case call := <-done:
 			if err := call.Err; err != nil {
 				// For most connection errors, we cannot tell whether or not


### PR DESCRIPTION
Previously, the distsender wouldn't exit early if its context was
cancelled, instead waiting until its transport was exhausted (due to the
same cancelled context) to return.

Now, it short circuits.

Closes #23195.

Release note: None