### PR TITLE
sql: support a `pg_catalog.` prefix for cast target types

### DIFF
--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -916,8 +916,7 @@ c_expr ::=
 	| 'EXISTS' select_with_parens
 
 cast_target ::=
-	typename
-	| postgres_oid
+	unprefixed_cast_target
 
 typename ::=
 	simple_typename opt_array_bounds
@@ -1254,12 +1253,9 @@ array_subscripts ::=
 case_expr ::=
 	'CASE' case_arg when_clause_list case_default 'END'
 
-postgres_oid ::=
-	'REGPROC'
-	| 'REGPROCEDURE'
-	| 'REGCLASS'
-	| 'REGTYPE'
-	| 'REGNAMESPACE'
+unprefixed_cast_target ::=
+	typename
+	| postgres_oid
 
 simple_typename ::=
 	const_typename
@@ -1574,6 +1570,13 @@ when_clause_list ::=
 case_default ::=
 	'ELSE' a_expr
 	| 
+
+postgres_oid ::=
+	'REGPROC'
+	| 'REGPROCEDURE'
+	| 'REGCLASS'
+	| 'REGTYPE'
+	| 'REGNAMESPACE'
 
 bit_with_length ::=
 	'BIT' opt_varying '(' iconst64 ')'

--- a/pkg/sql/parser/parse_test.go
+++ b/pkg/sql/parser/parse_test.go
@@ -1009,6 +1009,12 @@ func TestParse2(t *testing.T) {
 		{`SELECT b >>= c`, `SELECT inet_contains_or_equals(b, c)`},
 		{`SELECT b && c`, `SELECT inet_contains_or_contained_by(b, c)`},
 
+		// Ensure that cast types can be qualified in pg_catalog (pg compat).
+		{`SELECT 'foo'::PG_CATALOG.BOOL`,
+			`SELECT 'foo'::BOOL`},
+		{`SELECT 'foo'::PG_CATALOG.REGCLASS::OID`,
+			`SELECT 'foo'::REGCLASS::OID`},
+
 		// Escaped string literals are not always escaped the same because
 		// '''' and e'\'' scan to the same token. It's more convenient to
 		// prefer escaping ' and \, so we do that.
@@ -1660,9 +1666,9 @@ HINT: try \h ALTER TABLE`,
 		},
 		{
 			`SELECT CAST(1.2+2.3 AS notatype)`,
-			`syntax error at or near "notatype"
+			`syntax error at or near ")"
 SELECT CAST(1.2+2.3 AS notatype)
-                       ^
+                               ^
 `,
 		},
 		{
@@ -1751,9 +1757,9 @@ SELECT 1 + ANY ARRAY[1, 2, 3]
 		},
 		{
 			`SELECT 'f'::"blah"`,
-			`syntax error at or near "blah"
+			`syntax error at or near "EOF"
 SELECT 'f'::"blah"
-            ^
+                  ^
 `,
 		},
 		{


### PR DESCRIPTION
Fixes #18856.
Replaces #23166.

In PostgreSQL, type names belong to a namespace (a schema in new
terminology). For example, all the basic SQL types belong to the
virtual schema `pg_catalog`. For any type that appears to be called X
(e.g. `bool`, `int`, etc) its real full name is `pg_catalog.X`
(`pg_catalog.bool`, `pg_catalog.int`, etc.)

This entails that even without supporting user-defined types, both the
short name `bool` and the long name `pg_catalog.bool` are equivalent -
because `pg_catalog` is always in `search_path`, the name resolution
of the short name will find the type there.

Prior to this patch, CockroachDB assumed that type names only belong to
the global namespace, and thus failed to recognized the syntax
`pg_catalog.X` for types.

This is relevant since some tools (e.g. PsqlForks) use the syntax
`::pg_catalog.regclass` in casts to avoid ambiguity with a
user-defined type called "regclass".

Meanwhile, we do not want to implement fully-fledged qualified type
names and full name resolution for types in CockroachDB just yet,
because it would be overkill (we don't support custom types yet) and
to avoid the latency overhead.

So this patch bridges the compatibility gap by simply recognizing the
_syntax_ `::pg_catalog.X` as an alias for `::X` during parsing.

This patch is restricted as follows:

- it only extends the grammar for _casts_. The other positions where
  type name can occur (e.g. `<type> <literalstring>` like `BOOL
  'true'`, `CREATE TABLE ...(... <typename>)` etc) cannot be extended
  in this way without a large rework of the SQL grammar.

- PostgreSQL also supports fully qualified type names of the form
  `mydb.pg_catalog.int` and this patch stops short of supporting that
  form (the grammar changes to achieve this would also be more
  invasive).

Release note (sql change): CockroachDB now supports the syntax
`::pg_catalog.<type>` as an alias for `::<type>` for better
compatibility with PostgreSQL.