### PR TITLE
cherrypick-2.0: cli: make cockroach user atomic

### DIFF
--- a/pkg/cli/user.go
+++ b/pkg/cli/user.go
@@ -150,17 +150,13 @@ func runSetUser(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	if err := runQueryAndFormatResults(conn, os.Stdout,
-		makeQuery(`CREATE USER IF NOT EXISTS $1`, args[0])); err != nil {
-		return err
-	}
 	if password {
-		// TODO(asubiotto): Implement appropriate server-side authorization rules
-		// for users to be able to change their own passwords.
 		return runQueryAndFormatResults(conn, os.Stdout,
-			makeQuery(`ALTER USER $1 WITH PASSWORD $2`, args[0], pwdString))
+			makeQuery(`CREATE USER IF NOT EXISTS $1 PASSWORD $2`, args[0], pwdString),
+		)
 	}
-	return nil
+	return runQueryAndFormatResults(conn, os.Stdout,
+		makeQuery(`CREATE USER IF NOT EXISTS $1`, args[0]))
 }
 
 var userCmds = []*cobra.Command{


### PR DESCRIPTION
Run CREATE USER in a single transaction
so that a failure doesn't result in a partial success.
Before this change cockroach user would call
CREATE USER and ALTER USER FOR PASSWORD as two command.
If the ALTER USER failed after the CREATE USER the
user would still be created.

fixes #23203

Release note: None