### PR TITLE
*: Clarify units of metrics in their help messages

### DIFF
--- a/pkg/kv/txn_coord_sender.go
+++ b/pkg/kv/txn_coord_sender.go
@@ -178,7 +178,7 @@ var (
 		Help: "Number of abandoned KV transactions"}
 	metaDurationsHistograms = metric.Metadata{
 		Name: "txn.durations",
-		Help: "KV transaction durations"}
+		Help: "KV transaction durations in nanoseconds"}
 	metaRestartsHistogram = metric.Metadata{
 		Name: "txn.restarts",
 		Help: "Number of restarted KV transactions"}

--- a/pkg/rpc/clock_offset.go
+++ b/pkg/rpc/clock_offset.go
@@ -46,13 +46,13 @@ const avgLatencyMeasurementAge = 20.0
 var (
 	metaClockOffsetMeanNanos = metric.Metadata{
 		Name: "clock-offset.meannanos",
-		Help: "Mean clock offset with other nodes"}
+		Help: "Mean clock offset with other nodes in nanoseconds"}
 	metaClockOffsetStdDevNanos = metric.Metadata{
 		Name: "clock-offset.stddevnanos",
-		Help: "Stdddev clock offset with other nodes"}
+		Help: "Stdddev clock offset with other nodes in nanoseconds"}
 	metaLatencyHistogramNanos = metric.Metadata{
 		Name: "round-trip-latency",
-		Help: "Distribution of round-trip latencies with other nodes"}
+		Help: "Distribution of round-trip latencies with other nodes in nanoseconds"}
 )
 
 // RemoteClockMonitor keeps track of the most recent measurements of remote

--- a/pkg/security/certificate_manager.go
+++ b/pkg/security/certificate_manager.go
@@ -33,10 +33,10 @@ import (
 var (
 	metaCAExpiration = metric.Metadata{
 		Name: "security.certificate.expiration.ca",
-		Help: "Expiration timestamp for the CA certificate. 0 means no certificate or error."}
+		Help: "Expiration timestamp in seconds since Unix epoch for the CA certificate. 0 means no certificate or error."}
 	metaNodeExpiration = metric.Metadata{
 		Name: "security.certificate.expiration.node",
-		Help: "Expiration timestamp for the node certificate. 0 means no certificate or error."}
+		Help: "Expiration timestamp in seconds since Unix epoch for the node certificate. 0 means no certificate or error."}
 )
 
 // CertificateManager lives for the duration of the process and manages certificates and keys.

--- a/pkg/server/node.go
+++ b/pkg/server/node.go
@@ -69,7 +69,7 @@ const (
 var (
 	metaExecLatency = metric.Metadata{
 		Name: "exec.latency",
-		Help: "Latency of batch KV requests executed on this node"}
+		Help: "Latency in nanoseconds of batch KV requests executed on this node"}
 	metaExecSuccess = metric.Metadata{
 		Name: "exec.success",
 		Help: "Number of batch KV requests executed successfully on this node"}

--- a/pkg/server/status/runtime.go
+++ b/pkg/server/status/runtime.go
@@ -32,10 +32,10 @@ import (
 var (
 	metaCgoCalls       = metric.Metadata{Name: "sys.cgocalls", Help: "Total number of cgo calls"}
 	metaGoroutines     = metric.Metadata{Name: "sys.goroutines", Help: "Current number of goroutines"}
-	metaGoAllocBytes   = metric.Metadata{Name: "sys.go.allocbytes", Help: "Current bytes allocated by go"}
-	metaGoTotalBytes   = metric.Metadata{Name: "sys.go.totalbytes", Help: "Total bytes allocated by go, but not released"}
-	metaCgoAllocBytes  = metric.Metadata{Name: "sys.cgo.allocbytes", Help: "Current bytes allocated by cgo"}
-	metaCgoTotalBytes  = metric.Metadata{Name: "sys.cgo.totalbytes", Help: "Total bytes allocated by cgo, but not released"}
+	metaGoAllocBytes   = metric.Metadata{Name: "sys.go.allocbytes", Help: "Current bytes of memory allocated by go"}
+	metaGoTotalBytes   = metric.Metadata{Name: "sys.go.totalbytes", Help: "Total bytes of memory allocated by go, but not released"}
+	metaCgoAllocBytes  = metric.Metadata{Name: "sys.cgo.allocbytes", Help: "Current bytes of memory allocated by cgo"}
+	metaCgoTotalBytes  = metric.Metadata{Name: "sys.cgo.totalbytes", Help: "Total bytes of memory allocated by cgo, but not released"}
 	metaGCCount        = metric.Metadata{Name: "sys.gc.count", Help: "Total number of GC runs"}
 	metaGCPauseNS      = metric.Metadata{Name: "sys.gc.pause.ns", Help: "Total GC pause in nanoseconds"}
 	metaGCPausePercent = metric.Metadata{Name: "sys.gc.pause.percent", Help: "Current GC pause percentage"}

--- a/pkg/sql/executor.go
+++ b/pkg/sql/executor.go
@@ -102,19 +102,19 @@ var (
 		Help: "Number of SQL SELECT statements"}
 	MetaSQLExecLatency = metric.Metadata{
 		Name: "sql.exec.latency",
-		Help: "Latency of SQL statement execution"}
+		Help: "Latency in nanoseconds of SQL statement execution"}
 	MetaSQLServiceLatency = metric.Metadata{
 		Name: "sql.service.latency",
-		Help: "Latency of SQL request execution"}
+		Help: "Latency in nanoseconds of SQL request execution"}
 	MetaDistSQLSelect = metric.Metadata{
 		Name: "sql.distsql.select.count",
 		Help: "Number of DistSQL SELECT statements"}
 	MetaDistSQLExecLatency = metric.Metadata{
 		Name: "sql.distsql.exec.latency",
-		Help: "Latency of DistSQL statement execution"}
+		Help: "Latency in nanoseconds of DistSQL statement execution"}
 	MetaDistSQLServiceLatency = metric.Metadata{
 		Name: "sql.distsql.service.latency",
-		Help: "Latency of DistSQL request execution"}
+		Help: "Latency in nanoseconds of DistSQL request execution"}
 	MetaUpdate = metric.Metadata{
 		Name: "sql.update.count",
 		Help: "Number of SQL UPDATE statements"}

--- a/pkg/storage/metrics.go
+++ b/pkg/storage/metrics.go
@@ -134,13 +134,13 @@ var (
 		Help: "Count of intent keys"}
 	metaIntentAge = metric.Metadata{
 		Name: "intentage",
-		Help: "Cumulative age of intents"}
+		Help: "Cumulative age of intents in seconds"}
 	metaGcBytesAge = metric.Metadata{
 		Name: "gcbytesage",
-		Help: "Cumulative age of non-live data"}
+		Help: "Cumulative age of non-live data in seconds"}
 	metaLastUpdateNanos = metric.Metadata{
 		Name: "lastupdatenanos",
-		Help: "Time at which ages were last updated"}
+		Help: "Time in nanoseconds since Unix epoch at which bytes/keys/intents metrics were last updated"}
 
 	// Disk usage diagram (CR=Cockroach):
 	//                            ---------------------------------
@@ -197,7 +197,7 @@ var (
 		Help: "Number of times the bloom filter helped avoid iterator creation"}
 	metaRdbMemtableTotalSize = metric.Metadata{
 		Name: "rocksdb.memtable.total-size",
-		Help: "Current size of memtable"}
+		Help: "Current size of memtable in bytes"}
 	metaRdbFlushes = metric.Metadata{
 		Name: "rocksdb.flushes",
 		Help: "Number of table flushes"}
@@ -252,10 +252,10 @@ var (
 		Help: "Count of Raft commands applied"}
 	metaRaftLogCommitLatency = metric.Metadata{
 		Name: "raft.process.logcommit.latency",
-		Help: "Latency histogram for committing Raft log entries"}
+		Help: "Latency histogram in nanoseconds for committing Raft log entries"}
 	metaRaftCommandCommitLatency = metric.Metadata{
 		Name: "raft.process.commandcommit.latency",
-		Help: "Latency histogram for committing Raft commands"}
+		Help: "Latency histogram in nanoseconds for committing Raft commands"}
 
 	// Raft message metrics.
 	metaRaftRcvdProp = metric.Metadata{
@@ -425,7 +425,7 @@ var (
 		Help: "Number of associated distinct transactions"}
 	metaGCTransactionSpanScanned = metric.Metadata{
 		Name: "queue.gc.info.transactionspanscanned",
-		Help: "Number of entries in the transaction span scanned from the engine"}
+		Help: "Number of entries in transaction spans scanned from the engine"}
 	metaGCTransactionSpanGCAborted = metric.Metadata{
 		Name: "queue.gc.info.transactionspangcaborted",
 		Help: "Number of GC'able entries corresponding to aborted txns"}

--- a/pkg/storage/node_liveness.go
+++ b/pkg/storage/node_liveness.go
@@ -77,7 +77,7 @@ var (
 		Help: "Number of times this node has incremented its liveness epoch"}
 	metaHeartbeatLatency = metric.Metadata{
 		Name: "liveness.heartbeatlatency",
-		Help: "Node liveness heartbeat latency"}
+		Help: "Node liveness heartbeat latency in nanoseconds"}
 )
 
 // IsLive returns whether the node is considered live at the given time with the


### PR DESCRIPTION
Not being sure about whether something is in seconds or nanoseconds has
bugged me in the past, and now that we're better documenting this stuff
it's worth making clearer to users.

Release note: None

Companion to https://github.com/cockroachdb/docs/pull/2564