### PR TITLE
opt: support more types of joins in execbuilder

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/scalar_builder.go
+++ b/pkg/sql/opt/exec/execbuilder/scalar_builder.go
@@ -45,6 +45,7 @@ func init() {
 		opt.TupleOp:           (*Builder).buildTuple,
 		opt.FunctionOp:        (*Builder).buildFunction,
 		opt.CastOp:            (*Builder).buildCast,
+		opt.CoalesceOp:        (*Builder).buildCoalesce,
 		opt.UnsupportedExprOp: (*Builder).buildUnsupportedExpr,
 	}
 
@@ -183,6 +184,14 @@ func (b *Builder) buildCast(ctx *buildScalarCtx, ev xform.ExprView) tree.TypedEx
 		panic(err)
 	}
 	return expr
+}
+
+func (b *Builder) buildCoalesce(ctx *buildScalarCtx, ev xform.ExprView) tree.TypedExpr {
+	exprs := make(tree.TypedExprs, ev.ChildCount())
+	for i := range exprs {
+		exprs[i] = b.buildScalar(ctx, ev.Child(i))
+	}
+	return tree.NewTypedCoalesceExpr(exprs, ev.Logical().Scalar.Type)
 }
 
 func (b *Builder) buildUnsupportedExpr(ctx *buildScalarCtx, ev xform.ExprView) tree.TypedExpr {

--- a/pkg/sql/opt/exec/execbuilder/testdata/join
+++ b/pkg/sql/opt/exec/execbuilder/testdata/join
@@ -54,3 +54,120 @@ SELECT * FROM t.a, t.b WHERE a.x = b.x
 ----
 2  20  2  200
 3  30  3  300
+
+exec-explain
+SELECT * FROM t.a INNER JOIN t.b ON a.x = b.x
+----
+join       0  join  ·         ·          (x, y, x, z)  ·
+ │         0  ·     type      inner      ·             ·
+ │         0  ·     equality  (x) = (x)  ·             ·
+ ├── scan  1  scan  ·         ·          (x, y)        ·
+ │         1  ·     table     a@primary  ·             ·
+ │         1  ·     spans     ALL        ·             ·
+ └── scan  1  scan  ·         ·          (x, z)        ·
+·          1  ·     table     b@primary  ·             ·
+·          1  ·     spans     ALL        ·             ·
+
+exec
+SELECT * FROM t.a INNER JOIN t.b ON a.x = b.x
+----
+2  20  2  200
+3  30  3  300
+
+exec-explain
+SELECT * FROM t.a NATURAL JOIN t.b
+----
+render          0  render  ·         ·          ("a.x", "a.y", "b.z")  ·
+ │              0  ·       render 0  x          ·                      ·
+ │              0  ·       render 1  y          ·                      ·
+ │              0  ·       render 2  z          ·                      ·
+ └── join       1  join    ·         ·          (x, y, x, z)           ·
+      │         1  ·       type      inner      ·                      ·
+      │         1  ·       equality  (x) = (x)  ·                      ·
+      ├── scan  2  scan    ·         ·          (x, y)                 ·
+      │         2  ·       table     a@primary  ·                      ·
+      │         2  ·       spans     ALL        ·                      ·
+      └── scan  2  scan    ·         ·          (x, z)                 ·
+·               2  ·       table     b@primary  ·                      ·
+·               2  ·       spans     ALL        ·                      ·
+
+exec
+SELECT * FROM t.a NATURAL JOIN t.b
+----
+2  20  200
+3  30  300
+
+exec-explain
+SELECT * FROM t.a LEFT OUTER JOIN t.b ON a.x = b.x
+----
+join       0  join  ·         ·           (x, y, x, z)  ·
+ │         0  ·     type      left outer  ·             ·
+ │         0  ·     equality  (x) = (x)   ·             ·
+ ├── scan  1  scan  ·         ·           (x, y)        ·
+ │         1  ·     table     a@primary   ·             ·
+ │         1  ·     spans     ALL         ·             ·
+ └── scan  1  scan  ·         ·           (x, z)        ·
+·          1  ·     table     b@primary   ·             ·
+·          1  ·     spans     ALL         ·             ·
+
+exec
+SELECT * FROM t.a LEFT OUTER JOIN t.b ON a.x = b.x
+----
+1  10  NULL  NULL
+2  20  2     200
+3  30  3     300
+
+exec-explain
+SELECT * FROM t.a NATURAL RIGHT OUTER JOIN t.b
+----
+render          0  render  ·         ·            ("b.x", "a.y", "b.z")  ·
+ │              0  ·       render 0  x            ·                      ·
+ │              0  ·       render 1  y            ·                      ·
+ │              0  ·       render 2  z            ·                      ·
+ └── join       1  join    ·         ·            (x, y, x, z)           ·
+      │         1  ·       type      right outer  ·                      ·
+      │         1  ·       equality  (x) = (x)    ·                      ·
+      ├── scan  2  scan    ·         ·            (x, y)                 ·
+      │         2  ·       table     a@primary    ·                      ·
+      │         2  ·       spans     ALL          ·                      ·
+      └── scan  2  scan    ·         ·            (x, z)                 ·
+·               2  ·       table     b@primary    ·                      ·
+·               2  ·       spans     ALL          ·                      ·
+
+exec
+SELECT * FROM t.a NATURAL RIGHT OUTER JOIN t.b
+----
+2  20    200
+3  30    300
+4  NULL  400
+
+exec-explain
+SELECT * FROM t.a FULL OUTER JOIN t.b USING(x)
+----
+render               0  render  ·         ·               (x, "a.y", "b.z")                ·
+ │                   0  ·       render 0  x               ·                                ·
+ │                   0  ·       render 1  "a.y"           ·                                ·
+ │                   0  ·       render 2  "b.z"           ·                                ·
+ └── render          1  render  ·         ·               (x, "a.x", "a.y", "b.x", "b.z")  ·
+      │              1  ·       render 0  COALESCE(x, x)  ·                                ·
+      │              1  ·       render 1  x               ·                                ·
+      │              1  ·       render 2  y               ·                                ·
+      │              1  ·       render 3  x               ·                                ·
+      │              1  ·       render 4  z               ·                                ·
+      └── join       2  join    ·         ·               (x, y, x, z)                     ·
+           │         2  ·       type      full outer      ·                                ·
+           │         2  ·       equality  (x) = (x)       ·                                ·
+           ├── scan  3  scan    ·         ·               (x, y)                           ·
+           │         3  ·       table     a@primary       ·                                ·
+           │         3  ·       spans     ALL             ·                                ·
+           └── scan  3  scan    ·         ·               (x, z)                           ·
+·                    3  ·       table     b@primary       ·                                ·
+·                    3  ·       spans     ALL             ·                                ·
+
+exec
+SELECT * FROM t.a FULL OUTER JOIN t.b USING(x)
+----
+1  10    NULL
+2  20    200
+3  30    300
+4  NULL  400

--- a/pkg/sql/opt/exec/factory.go
+++ b/pkg/sql/opt/exec/factory.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/optbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 )
 
 // Node represents a node in the execution tree (currently maps to a
@@ -52,5 +53,5 @@ type Factory interface {
 	// ConstructInnerJoin returns a node that runs a hash-join between the results
 	// of two input nodes. The expression can refer to columns from both inputs
 	// using IndexedVars (first the left columns, then the right columns).
-	ConstructInnerJoin(left, right Node, onCond tree.TypedExpr) (Node, error)
+	ConstructJoin(joinType sqlbase.JoinType, left, right Node, onCond tree.TypedExpr) (Node, error)
 }

--- a/pkg/sql/opt_exec_engine.go
+++ b/pkg/sql/opt_exec_engine.go
@@ -193,15 +193,15 @@ func (ee *execEngine) ConstructProject(
 	return r, nil
 }
 
-// ConstructInnerJoin is part of the exec.Factory interface.
-func (ee *execEngine) ConstructInnerJoin(
-	left, right exec.Node, onCond tree.TypedExpr,
+// ConstructJoin is part of the exec.Factory interface.
+func (ee *execEngine) ConstructJoin(
+	joinType sqlbase.JoinType, left, right exec.Node, onCond tree.TypedExpr,
 ) (exec.Node, error) {
 	p := ee.planner
 	leftSrc := asDataSource(left)
 	rightSrc := asDataSource(right)
 	pred, _, err := p.makeJoinPredicate(
-		context.TODO(), leftSrc.info, rightSrc.info, sqlbase.InnerJoin, nil, /* cond */
+		context.TODO(), leftSrc.info, rightSrc.info, joinType, nil, /* cond */
 	)
 	if err != nil {
 		return nil, err

--- a/pkg/sql/sem/tree/expr.go
+++ b/pkg/sql/sem/tree/expr.go
@@ -592,6 +592,19 @@ type CoalesceExpr struct {
 	typeAnnotation
 }
 
+// NewTypedCoalesceExpr returns a CoalesceExpr that is well-typed.
+func NewTypedCoalesceExpr(typedExprs TypedExprs, typ types.T) *CoalesceExpr {
+	c := &CoalesceExpr{
+		Name:  "COALESCE",
+		Exprs: make(Exprs, len(typedExprs)),
+	}
+	for i := range typedExprs {
+		c.Exprs[i] = typedExprs[i]
+	}
+	c.typ = typ
+	return c
+}
+
 // TypedExprAt returns the expression at the specified index as a TypedExpr.
 func (node *CoalesceExpr) TypedExprAt(idx int) TypedExpr {
 	return node.Exprs[idx].(TypedExpr)


### PR DESCRIPTION
Also add execbuilder support for CoalesceOp (used by outer joins).

Release note: None