### PR TITLE
opt/optbuilder: support set operations in optbuilder

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/optimizer
+++ b/pkg/sql/logictest/testdata/logic_test/optimizer
@@ -30,7 +30,7 @@ SELECT * FROM test.t
 3 30
 
 # UnionClause
-query error pq: not yet implemented: select statement: \*tree.UnionClause
+query error pq: unsupported relational op union
 SELECT * FROM test.t UNION SELECT * FROM test.t
 
 # Insert

--- a/pkg/sql/opt/exec/execbuilder/relational_builder.go
+++ b/pkg/sql/opt/exec/execbuilder/relational_builder.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/pkg/errors"
 )
 
 type execPlan struct {
@@ -98,7 +99,7 @@ func (b *Builder) buildRelational(ev xform.ExprView) (execPlan, error) {
 		return b.buildJoin(ev, sqlbase.LeftAntiJoin)
 
 	default:
-		panic(fmt.Sprintf("unsupported relational op %s", ev.Operator()))
+		return execPlan{}, errors.Errorf("unsupported relational op %s", ev.Operator())
 	}
 }
 

--- a/pkg/sql/opt/exec/factory.go
+++ b/pkg/sql/opt/exec/factory.go
@@ -50,7 +50,7 @@ type Factory interface {
 	// the given input node.
 	ConstructProject(n Node, exprs tree.TypedExprs, colNames []string) (Node, error)
 
-	// ConstructInnerJoin returns a node that runs a hash-join between the results
+	// ConstructJoin returns a node that runs a hash-join between the results
 	// of two input nodes. The expression can refer to columns from both inputs
 	// using IndexedVars (first the left columns, then the right columns).
 	ConstructJoin(joinType sqlbase.JoinType, left, right Node, onCond tree.TypedExpr) (Node, error)

--- a/pkg/sql/opt/factory.og.go
+++ b/pkg/sql/opt/factory.og.go
@@ -321,11 +321,90 @@ type Factory interface {
 	ConstructGroupBy(input GroupID, aggregations GroupID, groupingColumns PrivateID) GroupID
 
 	// ConstructUnion constructs an expression for the Union operator.
+	// Union is an operator used to combine the Left and Right input relations into
+	// a single set containing rows from both inputs. Duplicate rows are discarded.
+	// The private field, ColMap, matches columns from the Left and Right inputs
+	// of the Union with the output columns. See the comment above opt.SetOpColMap
+	// for more details.
 	ConstructUnion(left GroupID, right GroupID, colMap PrivateID) GroupID
 
 	// ConstructIntersect constructs an expression for the Intersect operator.
-	ConstructIntersect(left GroupID, right GroupID) GroupID
+	// Intersect is an operator used to perform an intersection between the Left
+	// and Right input relations. The result consists only of rows in the Left
+	// relation that are also present in the Right relation. Duplicate rows are
+	// discarded.
+	// The private field, ColMap, matches columns from the Left and Right inputs
+	// of the Intersect with the output columns. See the comment above
+	// opt.SetOpColMap for more details.
+	ConstructIntersect(left GroupID, right GroupID, colMap PrivateID) GroupID
 
 	// ConstructExcept constructs an expression for the Except operator.
-	ConstructExcept(left GroupID, right GroupID) GroupID
+	// Except is an operator used to perform a set difference between the Left and
+	// Right input relations. The result consists only of rows in the Left relation
+	// that are not present in the Right relation. Duplicate rows are discarded.
+	// The private field, ColMap, matches columns from the Left and Right inputs
+	// of the Except with the output columns. See the comment above opt.SetOpColMap
+	// for more details.
+	ConstructExcept(left GroupID, right GroupID, colMap PrivateID) GroupID
+
+	// ConstructUnionAll constructs an expression for the UnionAll operator.
+	// UnionAll is an operator used to combine the Left and Right input relations
+	// into a single set containing rows from both inputs. Duplicate rows are
+	// not discarded. For example:
+	//   SELECT x FROM xx UNION ALL SELECT y FROM yy
+	//     x       y         out
+	//   -----   -----      -----
+	//     1       1          1
+	//     1       2    ->    1
+	//     2       3          1
+	//                        2
+	//                        2
+	//                        3
+	//
+	// The private field, ColMap, matches columns from the Left and Right inputs
+	// of the UnionAll with the output columns. See the comment above
+	// opt.SetOpColMap for more details.
+	ConstructUnionAll(left GroupID, right GroupID, colMap PrivateID) GroupID
+
+	// ConstructIntersectAll constructs an expression for the IntersectAll operator.
+	// IntersectAll is an operator used to perform an intersection between the Left
+	// and Right input relations. The result consists only of rows in the Left
+	// relation that have a corresponding row in the Right relation. Duplicate rows
+	// are not discarded. This effectively creates a one-to-one mapping between the
+	// Left and Right rows. For example:
+	//   SELECT x FROM xx INTERSECT ALL SELECT y FROM yy
+	//     x       y         out
+	//   -----   -----      -----
+	//     1       1          1
+	//     1       1    ->    1
+	//     1       2          2
+	//     2       2          2
+	//     2       3
+	//     4
+	//
+	// The private field, ColMap, matches columns from the Left and Right inputs
+	// of the IntersectAll with the output columns. See the comment above
+	// opt.SetOpColMap for more details.
+	ConstructIntersectAll(left GroupID, right GroupID, colMap PrivateID) GroupID
+
+	// ConstructExceptAll constructs an expression for the ExceptAll operator.
+	// ExceptAll is an operator used to perform a set difference between the Left
+	// and Right input relations. The result consists only of rows in the Left
+	// relation that do not have a corresponding row in the Right relation.
+	// Duplicate rows are not discarded. This effectively creates a one-to-one
+	// mapping between the Left and Right rows. For example:
+	//   SELECT x FROM xx EXCEPT ALL SELECT y FROM yy
+	//     x       y         out
+	//   -----   -----      -----
+	//     1       1    ->    1
+	//     1       1          4
+	//     1       2
+	//     2       2
+	//     2       3
+	//     4
+	//
+	// The private field, ColMap, matches columns from the Left and Right inputs
+	// of the ExceptAll with the output columns. See the comment above
+	// opt.SetOpColMap for more details.
+	ConstructExceptAll(left GroupID, right GroupID, colMap PrivateID) GroupID
 }

--- a/pkg/sql/opt/operator.go
+++ b/pkg/sql/opt/operator.go
@@ -50,6 +50,32 @@ func (f FuncDef) String() string {
 	return f.Name
 }
 
+// SetOpColMap defines the value of the ColMap private field of the set
+// operators: Union, Intersect, Except, UnionAll, IntersectAll and ExceptAll.
+// It matches columns from the left and right inputs of the operator
+// with the output columns, since OutputCols are not ordered and may
+// not correspond to each other.
+//
+// For example, consider the following query:
+//   SELECT y, x FROM xy UNION SELECT b, a FROM ab
+//
+// Given:
+//   col  index
+//   x    1
+//   y    2
+//   a    3
+//   b    4
+//
+// SetOpColMap will contain the following values:
+//   Left:  [2, 1]
+//   Right: [4, 3]
+//   Out:   [5, 6]  <-- synthesized output columns
+type SetOpColMap struct {
+	Left  ColList
+	Right ColList
+	Out   ColList
+}
+
 // ComparisonOpReverseMap maps from an optimizer operator type to a semantic
 // tree comparison operator type.
 var ComparisonOpReverseMap = [...]tree.ComparisonOperator{

--- a/pkg/sql/opt/ops/relational.opt
+++ b/pkg/sql/opt/ops/relational.opt
@@ -168,21 +168,114 @@ define GroupBy {
     GroupingColumns ColSet
 }
 
+# Union is an operator used to combine the Left and Right input relations into
+# a single set containing rows from both inputs. Duplicate rows are discarded.
+# The private field, ColMap, matches columns from the Left and Right inputs
+# of the Union with the output columns. See the comment above opt.SetOpColMap
+# for more details.
 [Relational]
 define Union {
     Left   Expr
     Right  Expr
-    ColMap ColMap
+    ColMap SetOpColMap
 }
 
+# Intersect is an operator used to perform an intersection between the Left
+# and Right input relations. The result consists only of rows in the Left
+# relation that are also present in the Right relation. Duplicate rows are
+# discarded.
+# The private field, ColMap, matches columns from the Left and Right inputs
+# of the Intersect with the output columns. See the comment above
+# opt.SetOpColMap for more details.
 [Relational]
 define Intersect {
     Left  Expr
     Right Expr
+    ColMap SetOpColMap
 }
 
+# Except is an operator used to perform a set difference between the Left and
+# Right input relations. The result consists only of rows in the Left relation
+# that are not present in the Right relation. Duplicate rows are discarded.
+# The private field, ColMap, matches columns from the Left and Right inputs
+# of the Except with the output columns. See the comment above opt.SetOpColMap
+# for more details.
 [Relational]
 define Except {
     Left  Expr
     Right Expr
+    ColMap SetOpColMap
+}
+
+# UnionAll is an operator used to combine the Left and Right input relations
+# into a single set containing rows from both inputs. Duplicate rows are
+# not discarded. For example:
+#   SELECT x FROM xx UNION ALL SELECT y FROM yy
+#     x       y         out
+#   -----   -----      -----
+#     1       1          1
+#     1       2    ->    1
+#     2       3          1
+#                        2
+#                        2
+#                        3
+#
+# The private field, ColMap, matches columns from the Left and Right inputs
+# of the UnionAll with the output columns. See the comment above
+# opt.SetOpColMap for more details.
+[Relational]
+define UnionAll {
+    Left   Expr
+    Right  Expr
+    ColMap SetOpColMap
+}
+
+# IntersectAll is an operator used to perform an intersection between the Left
+# and Right input relations. The result consists only of rows in the Left
+# relation that have a corresponding row in the Right relation. Duplicate rows
+# are not discarded. This effectively creates a one-to-one mapping between the
+# Left and Right rows. For example:
+#   SELECT x FROM xx INTERSECT ALL SELECT y FROM yy
+#     x       y         out
+#   -----   -----      -----
+#     1       1          1
+#     1       1    ->    1
+#     1       2          2
+#     2       2          2
+#     2       3
+#     4
+#
+# The private field, ColMap, matches columns from the Left and Right inputs
+# of the IntersectAll with the output columns. See the comment above
+# opt.SetOpColMap for more details.
+[Relational]
+define IntersectAll {
+    Left  Expr
+    Right Expr
+    ColMap SetOpColMap
+}
+
+# ExceptAll is an operator used to perform a set difference between the Left
+# and Right input relations. The result consists only of rows in the Left
+# relation that do not have a corresponding row in the Right relation.
+# Duplicate rows are not discarded. This effectively creates a one-to-one
+# mapping between the Left and Right rows. For example:
+#   SELECT x FROM xx EXCEPT ALL SELECT y FROM yy
+#     x       y         out
+#   -----   -----      -----
+#     1       1    ->    1
+#     1       1          4
+#     1       2
+#     2       2
+#     2       3
+#     4
+#
+# The private field, ColMap, matches columns from the Left and Right inputs
+# of the ExceptAll with the output columns. See the comment above
+# opt.SetOpColMap for more details.
+[Relational]
+define ExceptAll {
+    Left  Expr
+    Right Expr
+    ColMap SetOpColMap
 }

--- a/pkg/sql/opt/optbuilder/select.go
+++ b/pkg/sql/opt/optbuilder/select.go
@@ -148,10 +148,11 @@ func (b *Builder) buildSelect(
 	case *tree.SelectClause:
 		out, outScope = b.buildSelectClause(stmt, inScope)
 
+	case *tree.UnionClause:
+		out, outScope = b.buildUnion(t, inScope)
+
 	case *tree.ValuesClause:
 		out, outScope = b.buildValuesClause(t, inScope)
-
-		// TODO(rytaft): Add support for union clause.
 
 	default:
 		panic(errorf("not yet implemented: select statement: %T", stmt.Select))

--- a/pkg/sql/opt/optbuilder/testdata/union
+++ b/pkg/sql/opt/optbuilder/testdata/union
@@ -1,0 +1,681 @@
+# tests adapted from logictest -- union
+
+build
+VALUES (1), (1), (1), (2), (2) UNION VALUES (1), (3), (1)
+----
+union
+ ├── columns: column1:int:null:3
+ ├── left columns: column1:int:null:1
+ ├── right columns: column1:int:null:2
+ ├── values
+ │    ├── columns: column1:int:null:1
+ │    ├── tuple [type=tuple{int}]
+ │    │    └── const: 1 [type=int]
+ │    ├── tuple [type=tuple{int}]
+ │    │    └── const: 1 [type=int]
+ │    ├── tuple [type=tuple{int}]
+ │    │    └── const: 1 [type=int]
+ │    ├── tuple [type=tuple{int}]
+ │    │    └── const: 2 [type=int]
+ │    └── tuple [type=tuple{int}]
+ │         └── const: 2 [type=int]
+ └── values
+      ├── columns: column1:int:null:2
+      ├── tuple [type=tuple{int}]
+      │    └── const: 1 [type=int]
+      ├── tuple [type=tuple{int}]
+      │    └── const: 3 [type=int]
+      └── tuple [type=tuple{int}]
+           └── const: 1 [type=int]
+
+build
+VALUES (1), (1), (1), (2), (2) UNION ALL VALUES (1), (3), (1)
+----
+union-all
+ ├── columns: column1:int:null:3
+ ├── left columns: column1:int:null:1
+ ├── right columns: column1:int:null:2
+ ├── values
+ │    ├── columns: column1:int:null:1
+ │    ├── tuple [type=tuple{int}]
+ │    │    └── const: 1 [type=int]
+ │    ├── tuple [type=tuple{int}]
+ │    │    └── const: 1 [type=int]
+ │    ├── tuple [type=tuple{int}]
+ │    │    └── const: 1 [type=int]
+ │    ├── tuple [type=tuple{int}]
+ │    │    └── const: 2 [type=int]
+ │    └── tuple [type=tuple{int}]
+ │         └── const: 2 [type=int]
+ └── values
+      ├── columns: column1:int:null:2
+      ├── tuple [type=tuple{int}]
+      │    └── const: 1 [type=int]
+      ├── tuple [type=tuple{int}]
+      │    └── const: 3 [type=int]
+      └── tuple [type=tuple{int}]
+           └── const: 1 [type=int]
+
+build
+VALUES (1), (1), (1), (2), (2) INTERSECT VALUES (1), (3), (1)
+----
+intersect
+ ├── columns: column1:int:null:1
+ ├── left columns: column1:int:null:1
+ ├── right columns: column1:int:null:2
+ ├── values
+ │    ├── columns: column1:int:null:1
+ │    ├── tuple [type=tuple{int}]
+ │    │    └── const: 1 [type=int]
+ │    ├── tuple [type=tuple{int}]
+ │    │    └── const: 1 [type=int]
+ │    ├── tuple [type=tuple{int}]
+ │    │    └── const: 1 [type=int]
+ │    ├── tuple [type=tuple{int}]
+ │    │    └── const: 2 [type=int]
+ │    └── tuple [type=tuple{int}]
+ │         └── const: 2 [type=int]
+ └── values
+      ├── columns: column1:int:null:2
+      ├── tuple [type=tuple{int}]
+      │    └── const: 1 [type=int]
+      ├── tuple [type=tuple{int}]
+      │    └── const: 3 [type=int]
+      └── tuple [type=tuple{int}]
+           └── const: 1 [type=int]
+
+build
+VALUES (1), (1), (1), (2), (2) INTERSECT ALL VALUES (1), (3), (1)
+----
+intersect-all
+ ├── columns: column1:int:null:1
+ ├── left columns: column1:int:null:1
+ ├── right columns: column1:int:null:2
+ ├── values
+ │    ├── columns: column1:int:null:1
+ │    ├── tuple [type=tuple{int}]
+ │    │    └── const: 1 [type=int]
+ │    ├── tuple [type=tuple{int}]
+ │    │    └── const: 1 [type=int]
+ │    ├── tuple [type=tuple{int}]
+ │    │    └── const: 1 [type=int]
+ │    ├── tuple [type=tuple{int}]
+ │    │    └── const: 2 [type=int]
+ │    └── tuple [type=tuple{int}]
+ │         └── const: 2 [type=int]
+ └── values
+      ├── columns: column1:int:null:2
+      ├── tuple [type=tuple{int}]
+      │    └── const: 1 [type=int]
+      ├── tuple [type=tuple{int}]
+      │    └── const: 3 [type=int]
+      └── tuple [type=tuple{int}]
+           └── const: 1 [type=int]
+
+build
+VALUES (1), (1), (1), (2), (2) EXCEPT VALUES (1), (3), (1)
+----
+except
+ ├── columns: column1:int:null:1
+ ├── left columns: column1:int:null:1
+ ├── right columns: column1:int:null:2
+ ├── values
+ │    ├── columns: column1:int:null:1
+ │    ├── tuple [type=tuple{int}]
+ │    │    └── const: 1 [type=int]
+ │    ├── tuple [type=tuple{int}]
+ │    │    └── const: 1 [type=int]
+ │    ├── tuple [type=tuple{int}]
+ │    │    └── const: 1 [type=int]
+ │    ├── tuple [type=tuple{int}]
+ │    │    └── const: 2 [type=int]
+ │    └── tuple [type=tuple{int}]
+ │         └── const: 2 [type=int]
+ └── values
+      ├── columns: column1:int:null:2
+      ├── tuple [type=tuple{int}]
+      │    └── const: 1 [type=int]
+      ├── tuple [type=tuple{int}]
+      │    └── const: 3 [type=int]
+      └── tuple [type=tuple{int}]
+           └── const: 1 [type=int]
+
+build
+VALUES (1), (1), (1), (2), (2) EXCEPT ALL VALUES (1), (3), (1)
+----
+except-all
+ ├── columns: column1:int:null:1
+ ├── left columns: column1:int:null:1
+ ├── right columns: column1:int:null:2
+ ├── values
+ │    ├── columns: column1:int:null:1
+ │    ├── tuple [type=tuple{int}]
+ │    │    └── const: 1 [type=int]
+ │    ├── tuple [type=tuple{int}]
+ │    │    └── const: 1 [type=int]
+ │    ├── tuple [type=tuple{int}]
+ │    │    └── const: 1 [type=int]
+ │    ├── tuple [type=tuple{int}]
+ │    │    └── const: 2 [type=int]
+ │    └── tuple [type=tuple{int}]
+ │         └── const: 2 [type=int]
+ └── values
+      ├── columns: column1:int:null:2
+      ├── tuple [type=tuple{int}]
+      │    └── const: 1 [type=int]
+      ├── tuple [type=tuple{int}]
+      │    └── const: 3 [type=int]
+      └── tuple [type=tuple{int}]
+           └── const: 1 [type=int]
+
+build
+VALUES (1, 2), (1, 1), (1, 2), (2, 1), (2, 1) UNION VALUES (1, 3), (3, 4), (1, 1)
+----
+union
+ ├── columns: column1:int:null:5 column2:int:null:6
+ ├── left columns: column1:int:null:1 column2:int:null:2
+ ├── right columns: column1:int:null:3 column2:int:null:4
+ ├── values
+ │    ├── columns: column1:int:null:1 column2:int:null:2
+ │    ├── tuple [type=tuple{int, int}]
+ │    │    ├── const: 1 [type=int]
+ │    │    └── const: 2 [type=int]
+ │    ├── tuple [type=tuple{int, int}]
+ │    │    ├── const: 1 [type=int]
+ │    │    └── const: 1 [type=int]
+ │    ├── tuple [type=tuple{int, int}]
+ │    │    ├── const: 1 [type=int]
+ │    │    └── const: 2 [type=int]
+ │    ├── tuple [type=tuple{int, int}]
+ │    │    ├── const: 2 [type=int]
+ │    │    └── const: 1 [type=int]
+ │    └── tuple [type=tuple{int, int}]
+ │         ├── const: 2 [type=int]
+ │         └── const: 1 [type=int]
+ └── values
+      ├── columns: column1:int:null:3 column2:int:null:4
+      ├── tuple [type=tuple{int, int}]
+      │    ├── const: 1 [type=int]
+      │    └── const: 3 [type=int]
+      ├── tuple [type=tuple{int, int}]
+      │    ├── const: 3 [type=int]
+      │    └── const: 4 [type=int]
+      └── tuple [type=tuple{int, int}]
+           ├── const: 1 [type=int]
+           └── const: 1 [type=int]
+
+# UNION with NULL columns in operands works.
+build
+VALUES (NULL) UNION ALL VALUES (1)
+----
+union-all
+ ├── columns: column1:int:null:3
+ ├── left columns: column1:unknown:null:1
+ ├── right columns: column1:int:null:2
+ ├── values
+ │    ├── columns: column1:unknown:null:1
+ │    └── tuple [type=tuple{unknown}]
+ │         └── const: NULL [type=unknown]
+ └── values
+      ├── columns: column1:int:null:2
+      └── tuple [type=tuple{int}]
+           └── const: 1 [type=int]
+
+build
+VALUES (NULL) UNION ALL VALUES (NULL)
+----
+union-all
+ ├── columns: column1:unknown:null:3
+ ├── left columns: column1:unknown:null:1
+ ├── right columns: column1:unknown:null:2
+ ├── values
+ │    ├── columns: column1:unknown:null:1
+ │    └── tuple [type=tuple{unknown}]
+ │         └── const: NULL [type=unknown]
+ └── values
+      ├── columns: column1:unknown:null:2
+      └── tuple [type=tuple{unknown}]
+           └── const: NULL [type=unknown]
+
+build
+SELECT x, pg_typeof(y) FROM (SELECT 1, NULL UNION ALL SELECT 2, 4) AS t(x, y)
+----
+project
+ ├── columns: x:int:null:5 column7:string:null:7
+ ├── union-all
+ │    ├── columns: column1:int:null:5 column2:int:null:6
+ │    ├── left columns: column1:int:null:1 column2:unknown:null:2
+ │    ├── right columns: column3:int:null:3 column4:int:null:4
+ │    ├── project
+ │    │    ├── columns: column1:int:null:1 column2:unknown:null:2
+ │    │    ├── values
+ │    │    │    └── tuple [type=tuple{}]
+ │    │    └── projections
+ │    │         ├── const: 1 [type=int]
+ │    │         └── const: NULL [type=unknown]
+ │    └── project
+ │         ├── columns: column3:int:null:3 column4:int:null:4
+ │         ├── values
+ │         │    └── tuple [type=tuple{}]
+ │         └── projections
+ │              ├── const: 2 [type=int]
+ │              └── const: 4 [type=int]
+ └── projections
+      ├── variable: column1 [type=int]
+      └── function: pg_typeof [type=string]
+           └── variable: column2 [type=int]
+
+build
+SELECT x, pg_typeof(y) FROM (SELECT 1, 3 UNION ALL SELECT 2, NULL) AS t(x, y)
+----
+project
+ ├── columns: x:int:null:5 column7:string:null:7
+ ├── union-all
+ │    ├── columns: column1:int:null:5 column2:int:null:6
+ │    ├── left columns: column1:int:null:1 column2:int:null:2
+ │    ├── right columns: column3:int:null:3 column4:unknown:null:4
+ │    ├── project
+ │    │    ├── columns: column1:int:null:1 column2:int:null:2
+ │    │    ├── values
+ │    │    │    └── tuple [type=tuple{}]
+ │    │    └── projections
+ │    │         ├── const: 1 [type=int]
+ │    │         └── const: 3 [type=int]
+ │    └── project
+ │         ├── columns: column3:int:null:3 column4:unknown:null:4
+ │         ├── values
+ │         │    └── tuple [type=tuple{}]
+ │         └── projections
+ │              ├── const: 2 [type=int]
+ │              └── const: NULL [type=unknown]
+ └── projections
+      ├── variable: column1 [type=int]
+      └── function: pg_typeof [type=string]
+           └── variable: column2 [type=int]
+
+exec-ddl
+CREATE TABLE uniontest (
+  k INT,
+  v INT
+)
+----
+TABLE uniontest
+ ├── k int
+ ├── v int
+ ├── rowid int not null (hidden)
+ └── INDEX primary
+      └── rowid int not null (hidden)
+
+build
+SELECT v FROM uniontest WHERE k = 1 UNION SELECT v FROM uniontest WHERE k = 2
+----
+union
+ ├── columns: v:int:null:7
+ ├── left columns: uniontest.v:int:null:2
+ ├── right columns: uniontest.v:int:null:5
+ ├── project
+ │    ├── columns: uniontest.v:int:null:2
+ │    ├── select
+ │    │    ├── columns: uniontest.k:int:null:1 uniontest.v:int:null:2 uniontest.rowid:int:3
+ │    │    ├── scan
+ │    │    │    └── columns: uniontest.k:int:null:1 uniontest.v:int:null:2 uniontest.rowid:int:3
+ │    │    └── eq [type=bool]
+ │    │         ├── variable: uniontest.k [type=int]
+ │    │         └── const: 1 [type=int]
+ │    └── projections
+ │         └── variable: uniontest.v [type=int]
+ └── project
+      ├── columns: uniontest.v:int:null:5
+      ├── select
+      │    ├── columns: uniontest.k:int:null:4 uniontest.v:int:null:5 uniontest.rowid:int:6
+      │    ├── scan
+      │    │    └── columns: uniontest.k:int:null:4 uniontest.v:int:null:5 uniontest.rowid:int:6
+      │    └── eq [type=bool]
+      │         ├── variable: uniontest.k [type=int]
+      │         └── const: 2 [type=int]
+      └── projections
+           └── variable: uniontest.v [type=int]
+
+build
+SELECT v FROM uniontest WHERE k = 1 UNION ALL SELECT v FROM uniontest WHERE k = 2
+----
+union-all
+ ├── columns: v:int:null:7
+ ├── left columns: uniontest.v:int:null:2
+ ├── right columns: uniontest.v:int:null:5
+ ├── project
+ │    ├── columns: uniontest.v:int:null:2
+ │    ├── select
+ │    │    ├── columns: uniontest.k:int:null:1 uniontest.v:int:null:2 uniontest.rowid:int:3
+ │    │    ├── scan
+ │    │    │    └── columns: uniontest.k:int:null:1 uniontest.v:int:null:2 uniontest.rowid:int:3
+ │    │    └── eq [type=bool]
+ │    │         ├── variable: uniontest.k [type=int]
+ │    │         └── const: 1 [type=int]
+ │    └── projections
+ │         └── variable: uniontest.v [type=int]
+ └── project
+      ├── columns: uniontest.v:int:null:5
+      ├── select
+      │    ├── columns: uniontest.k:int:null:4 uniontest.v:int:null:5 uniontest.rowid:int:6
+      │    ├── scan
+      │    │    └── columns: uniontest.k:int:null:4 uniontest.v:int:null:5 uniontest.rowid:int:6
+      │    └── eq [type=bool]
+      │         ├── variable: uniontest.k [type=int]
+      │         └── const: 2 [type=int]
+      └── projections
+           └── variable: uniontest.v [type=int]
+
+build
+SELECT v FROM uniontest WHERE k = 1 INTERSECT SELECT v FROM uniontest WHERE k = 2
+----
+intersect
+ ├── columns: v:int:null:2
+ ├── left columns: uniontest.v:int:null:2
+ ├── right columns: uniontest.v:int:null:5
+ ├── project
+ │    ├── columns: uniontest.v:int:null:2
+ │    ├── select
+ │    │    ├── columns: uniontest.k:int:null:1 uniontest.v:int:null:2 uniontest.rowid:int:3
+ │    │    ├── scan
+ │    │    │    └── columns: uniontest.k:int:null:1 uniontest.v:int:null:2 uniontest.rowid:int:3
+ │    │    └── eq [type=bool]
+ │    │         ├── variable: uniontest.k [type=int]
+ │    │         └── const: 1 [type=int]
+ │    └── projections
+ │         └── variable: uniontest.v [type=int]
+ └── project
+      ├── columns: uniontest.v:int:null:5
+      ├── select
+      │    ├── columns: uniontest.k:int:null:4 uniontest.v:int:null:5 uniontest.rowid:int:6
+      │    ├── scan
+      │    │    └── columns: uniontest.k:int:null:4 uniontest.v:int:null:5 uniontest.rowid:int:6
+      │    └── eq [type=bool]
+      │         ├── variable: uniontest.k [type=int]
+      │         └── const: 2 [type=int]
+      └── projections
+           └── variable: uniontest.v [type=int]
+
+build
+SELECT v FROM uniontest WHERE k = 1 INTERSECT ALL SELECT v FROM uniontest WHERE k = 2
+----
+intersect-all
+ ├── columns: v:int:null:2
+ ├── left columns: uniontest.v:int:null:2
+ ├── right columns: uniontest.v:int:null:5
+ ├── project
+ │    ├── columns: uniontest.v:int:null:2
+ │    ├── select
+ │    │    ├── columns: uniontest.k:int:null:1 uniontest.v:int:null:2 uniontest.rowid:int:3
+ │    │    ├── scan
+ │    │    │    └── columns: uniontest.k:int:null:1 uniontest.v:int:null:2 uniontest.rowid:int:3
+ │    │    └── eq [type=bool]
+ │    │         ├── variable: uniontest.k [type=int]
+ │    │         └── const: 1 [type=int]
+ │    └── projections
+ │         └── variable: uniontest.v [type=int]
+ └── project
+      ├── columns: uniontest.v:int:null:5
+      ├── select
+      │    ├── columns: uniontest.k:int:null:4 uniontest.v:int:null:5 uniontest.rowid:int:6
+      │    ├── scan
+      │    │    └── columns: uniontest.k:int:null:4 uniontest.v:int:null:5 uniontest.rowid:int:6
+      │    └── eq [type=bool]
+      │         ├── variable: uniontest.k [type=int]
+      │         └── const: 2 [type=int]
+      └── projections
+           └── variable: uniontest.v [type=int]
+
+build
+SELECT v FROM uniontest WHERE k = 1 EXCEPT SELECT v FROM uniontest WHERE k = 2
+----
+except
+ ├── columns: v:int:null:2
+ ├── left columns: uniontest.v:int:null:2
+ ├── right columns: uniontest.v:int:null:5
+ ├── project
+ │    ├── columns: uniontest.v:int:null:2
+ │    ├── select
+ │    │    ├── columns: uniontest.k:int:null:1 uniontest.v:int:null:2 uniontest.rowid:int:3
+ │    │    ├── scan
+ │    │    │    └── columns: uniontest.k:int:null:1 uniontest.v:int:null:2 uniontest.rowid:int:3
+ │    │    └── eq [type=bool]
+ │    │         ├── variable: uniontest.k [type=int]
+ │    │         └── const: 1 [type=int]
+ │    └── projections
+ │         └── variable: uniontest.v [type=int]
+ └── project
+      ├── columns: uniontest.v:int:null:5
+      ├── select
+      │    ├── columns: uniontest.k:int:null:4 uniontest.v:int:null:5 uniontest.rowid:int:6
+      │    ├── scan
+      │    │    └── columns: uniontest.k:int:null:4 uniontest.v:int:null:5 uniontest.rowid:int:6
+      │    └── eq [type=bool]
+      │         ├── variable: uniontest.k [type=int]
+      │         └── const: 2 [type=int]
+      └── projections
+           └── variable: uniontest.v [type=int]
+
+build
+SELECT v FROM uniontest WHERE k = 1 EXCEPT ALL SELECT v FROM uniontest WHERE k = 2
+----
+except-all
+ ├── columns: v:int:null:2
+ ├── left columns: uniontest.v:int:null:2
+ ├── right columns: uniontest.v:int:null:5
+ ├── project
+ │    ├── columns: uniontest.v:int:null:2
+ │    ├── select
+ │    │    ├── columns: uniontest.k:int:null:1 uniontest.v:int:null:2 uniontest.rowid:int:3
+ │    │    ├── scan
+ │    │    │    └── columns: uniontest.k:int:null:1 uniontest.v:int:null:2 uniontest.rowid:int:3
+ │    │    └── eq [type=bool]
+ │    │         ├── variable: uniontest.k [type=int]
+ │    │         └── const: 1 [type=int]
+ │    └── projections
+ │         └── variable: uniontest.v [type=int]
+ └── project
+      ├── columns: uniontest.v:int:null:5
+      ├── select
+      │    ├── columns: uniontest.k:int:null:4 uniontest.v:int:null:5 uniontest.rowid:int:6
+      │    ├── scan
+      │    │    └── columns: uniontest.k:int:null:4 uniontest.v:int:null:5 uniontest.rowid:int:6
+      │    └── eq [type=bool]
+      │         ├── variable: uniontest.k [type=int]
+      │         └── const: 2 [type=int]
+      └── projections
+           └── variable: uniontest.v [type=int]
+
+build
+SELECT v FROM uniontest UNION SELECT k FROM uniontest
+----
+union
+ ├── columns: v:int:null:7
+ ├── left columns: uniontest.v:int:null:2
+ ├── right columns: uniontest.k:int:null:4
+ ├── project
+ │    ├── columns: uniontest.v:int:null:2
+ │    ├── scan
+ │    │    └── columns: uniontest.k:int:null:1 uniontest.v:int:null:2 uniontest.rowid:int:3
+ │    └── projections
+ │         └── variable: uniontest.v [type=int]
+ └── project
+      ├── columns: uniontest.k:int:null:4
+      ├── scan
+      │    └── columns: uniontest.k:int:null:4 uniontest.v:int:null:5 uniontest.rowid:int:6
+      └── projections
+           └── variable: uniontest.k [type=int]
+
+build
+SELECT v FROM uniontest UNION ALL SELECT k FROM uniontest
+----
+union-all
+ ├── columns: v:int:null:7
+ ├── left columns: uniontest.v:int:null:2
+ ├── right columns: uniontest.k:int:null:4
+ ├── project
+ │    ├── columns: uniontest.v:int:null:2
+ │    ├── scan
+ │    │    └── columns: uniontest.k:int:null:1 uniontest.v:int:null:2 uniontest.rowid:int:3
+ │    └── projections
+ │         └── variable: uniontest.v [type=int]
+ └── project
+      ├── columns: uniontest.k:int:null:4
+      ├── scan
+      │    └── columns: uniontest.k:int:null:4 uniontest.v:int:null:5 uniontest.rowid:int:6
+      └── projections
+           └── variable: uniontest.k [type=int]
+
+build
+SELECT * FROM (SELECT * FROM (VALUES (1)) a LEFT JOIN (VALUES (1) UNION VALUES (2)) b on a.column1 = b.column1);
+----
+left-join
+ ├── columns: column1:int:null:1 column1:int:null:4
+ ├── values
+ │    ├── columns: column1:int:null:1
+ │    └── tuple [type=tuple{int}]
+ │         └── const: 1 [type=int]
+ ├── union
+ │    ├── columns: column1:int:null:4
+ │    ├── left columns: column1:int:null:2
+ │    ├── right columns: column1:int:null:3
+ │    ├── values
+ │    │    ├── columns: column1:int:null:2
+ │    │    └── tuple [type=tuple{int}]
+ │    │         └── const: 1 [type=int]
+ │    └── values
+ │         ├── columns: column1:int:null:3
+ │         └── tuple [type=tuple{int}]
+ │              └── const: 2 [type=int]
+ └── eq [type=bool]
+      ├── variable: column1 [type=int]
+      └── variable: column1 [type=int]
+
+build
+SELECT * FROM (VALUES (1)) a LEFT JOIN (VALUES (1) UNION VALUES (2)) b on a.column1 = b.column1;
+----
+left-join
+ ├── columns: column1:int:null:1 column1:int:null:4
+ ├── values
+ │    ├── columns: column1:int:null:1
+ │    └── tuple [type=tuple{int}]
+ │         └── const: 1 [type=int]
+ ├── union
+ │    ├── columns: column1:int:null:4
+ │    ├── left columns: column1:int:null:2
+ │    ├── right columns: column1:int:null:3
+ │    ├── values
+ │    │    ├── columns: column1:int:null:2
+ │    │    └── tuple [type=tuple{int}]
+ │    │         └── const: 1 [type=int]
+ │    └── values
+ │         ├── columns: column1:int:null:3
+ │         └── tuple [type=tuple{int}]
+ │              └── const: 2 [type=int]
+ └── eq [type=bool]
+      ├── variable: column1 [type=int]
+      └── variable: column1 [type=int]
+
+build
+SELECT 1, 2 UNION SELECT 3
+----
+error: each UNION query must have the same number of columns: 2 vs 1
+
+build
+SELECT 1, 2 INTERSECT SELECT 3
+----
+error: each INTERSECT query must have the same number of columns: 2 vs 1
+
+build
+SELECT 1, 2 EXCEPT SELECT 3
+----
+error: each EXCEPT query must have the same number of columns: 2 vs 1
+
+build
+SELECT 1 UNION SELECT '3'
+----
+error: UNION types int and string cannot be matched
+
+build
+SELECT 1 INTERSECT SELECT '3'
+----
+error: INTERSECT types int and string cannot be matched
+
+build
+SELECT 1 EXCEPT SELECT '3'
+----
+error: EXCEPT types int and string cannot be matched
+
+build
+SELECT 1 UNION SELECT 3
+----
+union
+ ├── columns: column1:int:null:3
+ ├── left columns: column1:int:null:1
+ ├── right columns: column2:int:null:2
+ ├── project
+ │    ├── columns: column1:int:null:1
+ │    ├── values
+ │    │    └── tuple [type=tuple{}]
+ │    └── projections
+ │         └── const: 1 [type=int]
+ └── project
+      ├── columns: column2:int:null:2
+      ├── values
+      │    └── tuple [type=tuple{}]
+      └── projections
+           └── const: 3 [type=int]
+
+build
+SELECT ARRAY[1] UNION ALL SELECT ARRAY['foo']
+----
+error: not yet implemented: scalar expr: *tree.Array
+
+exec-ddl
+CREATE TABLE t.xy (x STRING NOT NULL, y STRING NOT NULL)
+----
+TABLE xy
+ ├── x string not null
+ ├── y string not null
+ ├── rowid int not null (hidden)
+ └── INDEX primary
+      └── rowid int not null (hidden)
+
+exec-ddl
+CREATE TABLE t.abc (
+  a string,
+  b string NOT NULL,
+  c string NOT NULL
+)
+----
+TABLE abc
+ ├── a string
+ ├── b string not null
+ ├── c string not null
+ ├── rowid int not null (hidden)
+ └── INDEX primary
+      └── rowid int not null (hidden)
+
+build
+(SELECT x, x, y FROM xy) UNION (SELECT a, b, c FROM abc)
+----
+union
+ ├── columns: x:string:null:8 x:string:9 y:string:10
+ ├── left columns: xy.x:string:null:1 xy.x:string:null:1 xy.y:string:null:2
+ ├── right columns: abc.a:string:null:4 abc.b:string:null:5 abc.c:string:null:6
+ ├── project
+ │    ├── columns: xy.x:string:1 xy.x:string:1 xy.y:string:2
+ │    ├── scan
+ │    │    └── columns: xy.x:string:1 xy.y:string:2 xy.rowid:int:3
+ │    └── projections
+ │         ├── variable: xy.x [type=string]
+ │         ├── variable: xy.x [type=string]
+ │         └── variable: xy.y [type=string]
+ └── project
+      ├── columns: abc.a:string:null:4 abc.b:string:5 abc.c:string:6
+      ├── scan
+      │    └── columns: abc.a:string:null:4 abc.b:string:5 abc.c:string:6 abc.rowid:int:7
+      └── projections
+           ├── variable: abc.a [type=string]
+           ├── variable: abc.b [type=string]
+           └── variable: abc.c [type=string]

--- a/pkg/sql/opt/optbuilder/union.go
+++ b/pkg/sql/opt/optbuilder/union.go
@@ -1,0 +1,122 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package optbuilder
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/sql/opt"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
+)
+
+// buildUnion builds a set of memo groups that represent the given union
+// clause.
+//
+// See Builder.buildStmt for a description of the remaining input and
+// return values.
+func (b *Builder) buildUnion(
+	clause *tree.UnionClause, inScope *scope,
+) (out opt.GroupID, outScope *scope) {
+	left, leftScope := b.buildSelect(clause.Left, inScope)
+	right, rightScope := b.buildSelect(clause.Right, inScope)
+	outScope = leftScope
+
+	// Check that the number of columns matches.
+	if len(leftScope.cols) != len(rightScope.cols) {
+		panic(errorf("each %v query must have the same number of columns: %d vs %d",
+			clause.Type, len(leftScope.cols), len(rightScope.cols)))
+	}
+
+	// newColsNeeded indicates whether or not we need to synthesize output
+	// columns. This is always required for a UNION, because the output columns
+	// of the union contain values from the left and right relations, and we must
+	// synthesize new columns to contain these values. This is not necessary for
+	// INTERSECT or EXCEPT, since these operations are basically filters on the
+	// left relation.
+	//
+	// Another benefit to synthesizing new columns is to handle the case
+	// when the type of one of the columns in the left relation is unknown, but
+	// the type of the matching column in the right relation is known.
+	// For example:
+	//   SELECT NULL UNION SELECT 1
+	// The type of NULL is unknown, and the type of 1 is int. We need to
+	// synthesize a new column so the output column will have the correct type.
+	newColsNeeded := clause.Type == tree.UnionOp
+	if newColsNeeded {
+		// Create a new scope to hold the new synthesized columns.
+		outScope = leftScope.push()
+		outScope.cols = make([]columnProps, 0, len(leftScope.cols))
+	}
+
+	// Build map from left columns to right columns.
+	for i := range leftScope.cols {
+		l := &leftScope.cols[i]
+		r := &rightScope.cols[i]
+		// TODO(dan): This currently checks whether the types are exactly the same,
+		// but Postgres is more lenient:
+		// http://www.postgresql.org/docs/9.5/static/typeconv-union-case.html.
+		if !(l.typ.Equivalent(r.typ) || l.typ == types.Unknown || r.typ == types.Unknown) {
+			panic(errorf("%v types %s and %s cannot be matched", clause.Type, l.typ, r.typ))
+		}
+		if l.hidden != r.hidden {
+			panic(errorf("%v types cannot be matched", clause.Type))
+		}
+
+		if newColsNeeded {
+			var typ types.T
+			if l.typ != types.Unknown {
+				typ = l.typ
+			} else {
+				typ = r.typ
+			}
+
+			b.synthesizeColumn(outScope, string(l.name), typ)
+		}
+	}
+
+	// Create the mapping between the left-side columns, right-side columns and
+	// new columns (if needed).
+	leftCols := colsToColList(leftScope.cols)
+	rightCols := colsToColList(rightScope.cols)
+	var newCols opt.ColList
+	if newColsNeeded {
+		newCols = colsToColList(outScope.cols)
+	} else {
+		newCols = leftCols
+	}
+	setOpColMap := opt.SetOpColMap{Left: leftCols, Right: rightCols, Out: newCols}
+	private := b.factory.InternPrivate(&setOpColMap)
+
+	if clause.All {
+		switch clause.Type {
+		case tree.UnionOp:
+			out = b.factory.ConstructUnionAll(left, right, private)
+		case tree.IntersectOp:
+			out = b.factory.ConstructIntersectAll(left, right, private)
+		case tree.ExceptOp:
+			out = b.factory.ConstructExceptAll(left, right, private)
+		}
+	} else {
+		switch clause.Type {
+		case tree.UnionOp:
+			out = b.factory.ConstructUnion(left, right, private)
+		case tree.IntersectOp:
+			out = b.factory.ConstructIntersect(left, right, private)
+		case tree.ExceptOp:
+			out = b.factory.ConstructExcept(left, right, private)
+		}
+	}
+
+	return out, outScope
+}

--- a/pkg/sql/opt/optbuilder/util.go
+++ b/pkg/sql/opt/optbuilder/util.go
@@ -206,3 +206,11 @@ func flattenTuple(t *tree.Tuple, exprs []tree.TypedExpr) []tree.TypedExpr {
 func symbolicExprStr(expr tree.Expr) string {
 	return tree.AsStringWithFlags(expr, tree.FmtCheckEquivalence)
 }
+
+func colsToColList(cols []columnProps) opt.ColList {
+	colList := make(opt.ColList, len(cols))
+	for i := range cols {
+		colList[i] = cols[i].index
+	}
+	return colList
+}

--- a/pkg/sql/opt/optbuilder/values.go
+++ b/pkg/sql/opt/optbuilder/values.go
@@ -73,10 +73,7 @@ func (b *Builder) buildValuesClause(
 		b.synthesizeColumn(outScope, label, colTypes[i])
 	}
 
-	colList := make(opt.ColList, len(outScope.cols))
-	for i := range outScope.cols {
-		colList[i] = outScope.cols[i].index
-	}
+	colList := colsToColList(outScope.cols)
 	out = b.factory.ConstructValues(b.factory.InternList(rows), b.factory.InternPrivate(&colList))
 	return out, outScope
 }

--- a/pkg/sql/opt/xform/expr.og.go
+++ b/pkg/sql/opt/xform/expr.og.go
@@ -255,6 +255,15 @@ func (ev ExprView) ChildCount() int {
 	case opt.ExceptOp:
 		return 2
 
+	case opt.UnionAllOp:
+		return 2
+
+	case opt.IntersectAllOp:
+		return 2
+
+	case opt.ExceptAllOp:
+		return 2
+
 	case opt.SortOp:
 		return 1
 
@@ -1132,6 +1141,42 @@ func (ev ExprView) ChildGroup(n int) opt.GroupID {
 			panic("child index out of range")
 		}
 
+	case opt.UnionAllOp:
+		unionAllExpr := (*unionAllExpr)(ev.mem.lookupExpr(ev.loc))
+
+		switch n {
+		case 0:
+			return unionAllExpr.left()
+		case 1:
+			return unionAllExpr.right()
+		default:
+			panic("child index out of range")
+		}
+
+	case opt.IntersectAllOp:
+		intersectAllExpr := (*intersectAllExpr)(ev.mem.lookupExpr(ev.loc))
+
+		switch n {
+		case 0:
+			return intersectAllExpr.left()
+		case 1:
+			return intersectAllExpr.right()
+		default:
+			panic("child index out of range")
+		}
+
+	case opt.ExceptAllOp:
+		exceptAllExpr := (*exceptAllExpr)(ev.mem.lookupExpr(ev.loc))
+
+		switch n {
+		case 0:
+			return exceptAllExpr.left()
+		case 1:
+			return exceptAllExpr.right()
+		default:
+			panic("child index out of range")
+		}
+
 	case opt.SortOp:
 		if n == 0 {
 			return ev.loc.group
@@ -1547,12 +1592,32 @@ var privateLookup = [...]privateLookupFunc{
 
 	// IntersectOp
 	func(ev ExprView) opt.PrivateID {
-		return 0
+		intersectExpr := (*intersectExpr)(ev.mem.lookupExpr(ev.loc))
+		return intersectExpr.colMap()
 	},
 
 	// ExceptOp
 	func(ev ExprView) opt.PrivateID {
-		return 0
+		exceptExpr := (*exceptExpr)(ev.mem.lookupExpr(ev.loc))
+		return exceptExpr.colMap()
+	},
+
+	// UnionAllOp
+	func(ev ExprView) opt.PrivateID {
+		unionAllExpr := (*unionAllExpr)(ev.mem.lookupExpr(ev.loc))
+		return unionAllExpr.colMap()
+	},
+
+	// IntersectAllOp
+	func(ev ExprView) opt.PrivateID {
+		intersectAllExpr := (*intersectAllExpr)(ev.mem.lookupExpr(ev.loc))
+		return intersectAllExpr.colMap()
+	},
+
+	// ExceptAllOp
+	func(ev ExprView) opt.PrivateID {
+		exceptAllExpr := (*exceptAllExpr)(ev.mem.lookupExpr(ev.loc))
+		return exceptAllExpr.colMap()
 	},
 
 	// SortOp
@@ -1642,6 +1707,9 @@ var isScalarLookup = [...]bool{
 	false, // UnionOp
 	false, // IntersectOp
 	false, // ExceptOp
+	false, // UnionAllOp
+	false, // IntersectAllOp
+	false, // ExceptAllOp
 	false, // SortOp
 }
 
@@ -1726,6 +1794,9 @@ var isConstValueLookup = [...]bool{
 	false, // UnionOp
 	false, // IntersectOp
 	false, // ExceptOp
+	false, // UnionAllOp
+	false, // IntersectAllOp
+	false, // ExceptAllOp
 	false, // SortOp
 }
 
@@ -1810,6 +1881,9 @@ var isBooleanLookup = [...]bool{
 	false, // UnionOp
 	false, // IntersectOp
 	false, // ExceptOp
+	false, // UnionAllOp
+	false, // IntersectAllOp
+	false, // ExceptAllOp
 	false, // SortOp
 }
 
@@ -1894,6 +1968,9 @@ var isComparisonLookup = [...]bool{
 	false, // UnionOp
 	false, // IntersectOp
 	false, // ExceptOp
+	false, // UnionAllOp
+	false, // IntersectAllOp
+	false, // ExceptAllOp
 	false, // SortOp
 }
 
@@ -1978,6 +2055,9 @@ var isBinaryLookup = [...]bool{
 	false, // UnionOp
 	false, // IntersectOp
 	false, // ExceptOp
+	false, // UnionAllOp
+	false, // IntersectAllOp
+	false, // ExceptAllOp
 	false, // SortOp
 }
 
@@ -2062,6 +2142,9 @@ var isUnaryLookup = [...]bool{
 	false, // UnionOp
 	false, // IntersectOp
 	false, // ExceptOp
+	false, // UnionAllOp
+	false, // IntersectAllOp
+	false, // ExceptAllOp
 	false, // SortOp
 }
 
@@ -2146,6 +2229,9 @@ var isRelationalLookup = [...]bool{
 	true,  // UnionOp
 	true,  // IntersectOp
 	true,  // ExceptOp
+	true,  // UnionAllOp
+	true,  // IntersectAllOp
+	true,  // ExceptAllOp
 	false, // SortOp
 }
 
@@ -2230,6 +2316,9 @@ var isJoinLookup = [...]bool{
 	false, // UnionOp
 	false, // IntersectOp
 	false, // ExceptOp
+	false, // UnionAllOp
+	false, // IntersectAllOp
+	false, // ExceptAllOp
 	false, // SortOp
 }
 
@@ -2314,6 +2403,9 @@ var isJoinApplyLookup = [...]bool{
 	false, // UnionOp
 	false, // IntersectOp
 	false, // ExceptOp
+	false, // UnionAllOp
+	false, // IntersectAllOp
+	false, // ExceptAllOp
 	false, // SortOp
 }
 
@@ -2398,6 +2490,9 @@ var isEnforcerLookup = [...]bool{
 	false, // UnionOp
 	false, // IntersectOp
 	false, // ExceptOp
+	false, // UnionAllOp
+	false, // IntersectAllOp
+	false, // ExceptAllOp
 	true,  // SortOp
 }
 
@@ -4360,6 +4455,11 @@ func (m *memoExpr) asGroupBy() *groupByExpr {
 	return (*groupByExpr)(m)
 }
 
+// unionExpr is an operator used to combine the Left and Right input relations into
+// a single set containing rows from both inputs. Duplicate rows are discarded.
+// The private field, ColMap, matches columns from the Left and Right inputs
+// of the Union with the output columns. See the comment above opt.SetOpColMap
+// for more details.
 type unionExpr memoExpr
 
 func makeUnionExpr(left opt.GroupID, right opt.GroupID, colMap opt.PrivateID) unionExpr {
@@ -4389,10 +4489,17 @@ func (m *memoExpr) asUnion() *unionExpr {
 	return (*unionExpr)(m)
 }
 
+// intersectExpr is an operator used to perform an intersection between the Left
+// and Right input relations. The result consists only of rows in the Left
+// relation that are also present in the Right relation. Duplicate rows are
+// discarded.
+// The private field, ColMap, matches columns from the Left and Right inputs
+// of the Intersect with the output columns. See the comment above
+// opt.SetOpColMap for more details.
 type intersectExpr memoExpr
 
-func makeIntersectExpr(left opt.GroupID, right opt.GroupID) intersectExpr {
-	return intersectExpr{op: opt.IntersectOp, state: exprState{uint32(left), uint32(right)}}
+func makeIntersectExpr(left opt.GroupID, right opt.GroupID, colMap opt.PrivateID) intersectExpr {
+	return intersectExpr{op: opt.IntersectOp, state: exprState{uint32(left), uint32(right), uint32(colMap)}}
 }
 
 func (e *intersectExpr) left() opt.GroupID {
@@ -4401,6 +4508,10 @@ func (e *intersectExpr) left() opt.GroupID {
 
 func (e *intersectExpr) right() opt.GroupID {
 	return opt.GroupID(e.state[1])
+}
+
+func (e *intersectExpr) colMap() opt.PrivateID {
+	return opt.PrivateID(e.state[2])
 }
 
 func (e *intersectExpr) fingerprint() fingerprint {
@@ -4414,10 +4525,16 @@ func (m *memoExpr) asIntersect() *intersectExpr {
 	return (*intersectExpr)(m)
 }
 
+// exceptExpr is an operator used to perform a set difference between the Left and
+// Right input relations. The result consists only of rows in the Left relation
+// that are not present in the Right relation. Duplicate rows are discarded.
+// The private field, ColMap, matches columns from the Left and Right inputs
+// of the Except with the output columns. See the comment above opt.SetOpColMap
+// for more details.
 type exceptExpr memoExpr
 
-func makeExceptExpr(left opt.GroupID, right opt.GroupID) exceptExpr {
-	return exceptExpr{op: opt.ExceptOp, state: exprState{uint32(left), uint32(right)}}
+func makeExceptExpr(left opt.GroupID, right opt.GroupID, colMap opt.PrivateID) exceptExpr {
+	return exceptExpr{op: opt.ExceptOp, state: exprState{uint32(left), uint32(right), uint32(colMap)}}
 }
 
 func (e *exceptExpr) left() opt.GroupID {
@@ -4426,6 +4543,10 @@ func (e *exceptExpr) left() opt.GroupID {
 
 func (e *exceptExpr) right() opt.GroupID {
 	return opt.GroupID(e.state[1])
+}
+
+func (e *exceptExpr) colMap() opt.PrivateID {
+	return opt.PrivateID(e.state[2])
 }
 
 func (e *exceptExpr) fingerprint() fingerprint {
@@ -4437,4 +4558,143 @@ func (m *memoExpr) asExcept() *exceptExpr {
 		return nil
 	}
 	return (*exceptExpr)(m)
+}
+
+// unionAllExpr is an operator used to combine the Left and Right input relations
+// into a single set containing rows from both inputs. Duplicate rows are
+// not discarded. For example:
+//   SELECT x FROM xx UNION ALL SELECT y FROM yy
+//     x       y         out
+//   -----   -----      -----
+//     1       1          1
+//     1       2    ->    1
+//     2       3          1
+//                        2
+//                        2
+//                        3
+//
+// The private field, ColMap, matches columns from the Left and Right inputs
+// of the UnionAll with the output columns. See the comment above
+// opt.SetOpColMap for more details.
+type unionAllExpr memoExpr
+
+func makeUnionAllExpr(left opt.GroupID, right opt.GroupID, colMap opt.PrivateID) unionAllExpr {
+	return unionAllExpr{op: opt.UnionAllOp, state: exprState{uint32(left), uint32(right), uint32(colMap)}}
+}
+
+func (e *unionAllExpr) left() opt.GroupID {
+	return opt.GroupID(e.state[0])
+}
+
+func (e *unionAllExpr) right() opt.GroupID {
+	return opt.GroupID(e.state[1])
+}
+
+func (e *unionAllExpr) colMap() opt.PrivateID {
+	return opt.PrivateID(e.state[2])
+}
+
+func (e *unionAllExpr) fingerprint() fingerprint {
+	return fingerprint(*e)
+}
+
+func (m *memoExpr) asUnionAll() *unionAllExpr {
+	if m.op != opt.UnionAllOp {
+		return nil
+	}
+	return (*unionAllExpr)(m)
+}
+
+// intersectAllExpr is an operator used to perform an intersection between the Left
+// and Right input relations. The result consists only of rows in the Left
+// relation that have a corresponding row in the Right relation. Duplicate rows
+// are not discarded. This effectively creates a one-to-one mapping between the
+// Left and Right rows. For example:
+//   SELECT x FROM xx INTERSECT ALL SELECT y FROM yy
+//     x       y         out
+//   -----   -----      -----
+//     1       1          1
+//     1       1    ->    1
+//     1       2          2
+//     2       2          2
+//     2       3
+//     4
+//
+// The private field, ColMap, matches columns from the Left and Right inputs
+// of the IntersectAll with the output columns. See the comment above
+// opt.SetOpColMap for more details.
+type intersectAllExpr memoExpr
+
+func makeIntersectAllExpr(left opt.GroupID, right opt.GroupID, colMap opt.PrivateID) intersectAllExpr {
+	return intersectAllExpr{op: opt.IntersectAllOp, state: exprState{uint32(left), uint32(right), uint32(colMap)}}
+}
+
+func (e *intersectAllExpr) left() opt.GroupID {
+	return opt.GroupID(e.state[0])
+}
+
+func (e *intersectAllExpr) right() opt.GroupID {
+	return opt.GroupID(e.state[1])
+}
+
+func (e *intersectAllExpr) colMap() opt.PrivateID {
+	return opt.PrivateID(e.state[2])
+}
+
+func (e *intersectAllExpr) fingerprint() fingerprint {
+	return fingerprint(*e)
+}
+
+func (m *memoExpr) asIntersectAll() *intersectAllExpr {
+	if m.op != opt.IntersectAllOp {
+		return nil
+	}
+	return (*intersectAllExpr)(m)
+}
+
+// exceptAllExpr is an operator used to perform a set difference between the Left
+// and Right input relations. The result consists only of rows in the Left
+// relation that do not have a corresponding row in the Right relation.
+// Duplicate rows are not discarded. This effectively creates a one-to-one
+// mapping between the Left and Right rows. For example:
+//   SELECT x FROM xx EXCEPT ALL SELECT y FROM yy
+//     x       y         out
+//   -----   -----      -----
+//     1       1    ->    1
+//     1       1          4
+//     1       2
+//     2       2
+//     2       3
+//     4
+//
+// The private field, ColMap, matches columns from the Left and Right inputs
+// of the ExceptAll with the output columns. See the comment above
+// opt.SetOpColMap for more details.
+type exceptAllExpr memoExpr
+
+func makeExceptAllExpr(left opt.GroupID, right opt.GroupID, colMap opt.PrivateID) exceptAllExpr {
+	return exceptAllExpr{op: opt.ExceptAllOp, state: exprState{uint32(left), uint32(right), uint32(colMap)}}
+}
+
+func (e *exceptAllExpr) left() opt.GroupID {
+	return opt.GroupID(e.state[0])
+}
+
+func (e *exceptAllExpr) right() opt.GroupID {
+	return opt.GroupID(e.state[1])
+}
+
+func (e *exceptAllExpr) colMap() opt.PrivateID {
+	return opt.PrivateID(e.state[2])
+}
+
+func (e *exceptAllExpr) fingerprint() fingerprint {
+	return fingerprint(*e)
+}
+
+func (m *memoExpr) asExceptAll() *exceptAllExpr {
+	if m.op != opt.ExceptAllOp {
+		return nil
+	}
+	return (*exceptAllExpr)(m)
 }

--- a/pkg/sql/opt/xform/logical_props_factory.go
+++ b/pkg/sql/opt/xform/logical_props_factory.go
@@ -61,7 +61,8 @@ func (f logicalPropsFactory) constructRelationalProps(ev ExprView) LogicalProps 
 		opt.RightJoinApplyOp, opt.FullJoinApplyOp, opt.SemiJoinApplyOp, opt.AntiJoinApplyOp:
 		return f.constructJoinProps(ev)
 
-	case opt.UnionOp:
+	case opt.UnionOp, opt.IntersectOp, opt.ExceptOp,
+		opt.UnionAllOp, opt.IntersectAllOp, opt.ExceptAllOp:
 		return f.constructSetProps(ev)
 
 	case opt.GroupByOp:
@@ -179,24 +180,25 @@ func (f logicalPropsFactory) constructSetProps(ev ExprView) LogicalProps {
 
 	leftProps := ev.lookupChildGroup(0).logical
 	rightProps := ev.lookupChildGroup(1).logical
-	colMap := *ev.Private().(*opt.ColMap)
+	colMap := *ev.Private().(*opt.SetOpColMap)
+	if len(colMap.Out) != len(colMap.Left) || len(colMap.Out) != len(colMap.Right) {
+		panic(fmt.Errorf("lists in SetOpColMap are not all the same length. new:%d, left:%d, right:%d",
+			len(colMap.Out), len(colMap.Left), len(colMap.Right)))
+	}
 
-	// Use left input's output columns.
-	props.Relational.OutputCols = leftProps.Relational.OutputCols
+	// Set the new output columns.
+	props.Relational.OutputCols = opt.ColListToSet(colMap.Out)
 
 	// Columns have to be not-null on both sides to be not-null in result.
-	// colMap matches columns on the left side of the operator with columns on
-	// the right side, since OutputCols are not ordered and may not correspond
-	// to each other.
-	colMap.ForEach(func(key, val int) {
-		if !leftProps.Relational.NotNullCols.Contains(key) {
-			return
+	// colMap matches columns on the left and right sides of the operator
+	// with the output columns, since OutputCols are not ordered and may
+	// not correspond to each other.
+	for i := range colMap.Out {
+		if leftProps.Relational.NotNullCols.Contains(int((colMap.Left)[i])) &&
+			rightProps.Relational.NotNullCols.Contains(int((colMap.Right)[i])) {
+			props.Relational.NotNullCols.Add(int((colMap.Out)[i]))
 		}
-		if !rightProps.Relational.NotNullCols.Contains(val) {
-			return
-		}
-		props.Relational.NotNullCols.Add(key)
-	})
+	}
 
 	return props
 }

--- a/pkg/sql/opt/xform/logical_props_test.go
+++ b/pkg/sql/opt/xform/logical_props_test.go
@@ -70,9 +70,10 @@ func TestLogicalSetProps(t *testing.T) {
 	a1 := f.Metadata().TableColumn(a, 1)
 	b0 := f.Metadata().TableColumn(b, 0)
 	b1 := f.Metadata().TableColumn(b, 1)
-	colMap := &opt.ColMap{}
-	colMap.Set(int(b0), int(a1))
-	colMap.Set(int(b1), int(a0))
+	colMap := &opt.SetOpColMap{}
+	colMap.Left = opt.ColList{b0, b1}
+	colMap.Right = opt.ColList{a1, a0}
+	colMap.Out = opt.ColList{b0, b1}
 
 	unionGroup := f.ConstructUnion(leftGroup, rightGroup, f.InternPrivate(colMap))
 


### PR DESCRIPTION
This commit includes support for building a memo for queries
with a `UNION`, `INTERSECT`, or `EXCEPT` statement. The test cases
have been adapted from the union tests in logictests.

This code is based on code originally written as part of the
opttoy project.

Release note: None