### PR TITLE
libroach: improve format string hygiene

### DIFF
--- a/c-deps/libroach/ccl/key_manager.cc
+++ b/c-deps/libroach/ccl/key_manager.cc
@@ -54,7 +54,7 @@ rocksdb::Status KeyFromFile(rocksdb::Env* env, const std::string& path,
     break;
   default:
     return rocksdb::Status::InvalidArgument(
-        fmt::StringPrintf("file %s is %llu bytes long, it must be <key ID length (%llu)> + <key "
+        fmt::StringPrintf("file %s is %zu bytes long, it must be <key ID length (%zu)> + <key "
                           "size (16, 24, or 32)> long",
                           path.c_str(), contents.size(), kKeyIDLength));
   }

--- a/c-deps/libroach/ccl/key_manager_test.cc
+++ b/c-deps/libroach/ccl/key_manager_test.cc
@@ -143,7 +143,7 @@ rocksdb::Status compareNonRandomKeyInfo(const enginepbccl::KeyInfo& actual,
   auto diff = actual.creation_time() - expected.approximate_timestamp;
   if (diff > 5 || diff < -5) {
     return rocksdb::Status::InvalidArgument(
-        fmt::StringPrintf("actual creation time %lld does not match expected timestamp %lld",
+        fmt::StringPrintf("actual creation time %" PRId64 " does not match expected timestamp %" PRId64,
                           actual.creation_time(), expected.approximate_timestamp));
   }
 

--- a/c-deps/libroach/db.cc
+++ b/c-deps/libroach/db.cc
@@ -628,7 +628,8 @@ DBStatus DBSstFileWriterFinish(DBSstFileWriter* fw, DBString* data) {
     return ToDBStatus(status);
   }
   if (sst_contents.size() != file_size) {
-    return FmtStatus("expected to read %d bytes but got %d", file_size, sst_contents.size());
+    return FmtStatus("expected to read %" PRIu64 " bytes but got %zu",
+      file_size, sst_contents.size());
   }
 
   // The contract of the SequentialFile.Read call above is that it _might_ use

--- a/c-deps/libroach/fmt.h
+++ b/c-deps/libroach/fmt.h
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include <cinttypes>
 #include <google/protobuf/stubs/stringprintf.h>
 
 namespace fmt = google::protobuf;

--- a/c-deps/libroach/status.h
+++ b/c-deps/libroach/status.h
@@ -30,6 +30,7 @@ inline DBStatus ToDBStatus(const rocksdb::Status& status) {
 }
 
 // FmtStatus formats the given arguments printf-style into a DBStatus.
+__attribute__((__format__(__printf__, 1, 2)))
 inline DBStatus FmtStatus(const char* fmt_str, ...) {
   va_list ap;
   va_start(ap, fmt_str);


### PR DESCRIPTION
Teach the compiler about our custom printf-like functions (FmtStatus,
StringPrintf, et al.) so that format arguments can be typechecked. This
turned up a few incorrect format strings.

Release note: None