### PR TITLE
distsql: fix rowFetcher column count bug

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/interleaved_join
+++ b/pkg/sql/logictest/testdata/logic_test/interleaved_join
@@ -847,10 +847,100 @@ https://cockroachdb.github.io/distsqlplan/decode.html?eJzklkFv2j4Yxu__T1G9p_80T8
 # Regression test for #22655.
 
 statement ok
-CREATE TABLE a (a string, b string, primary key (a, b))
+CREATE TABLE a (a STRING, b STRING, PRIMARY KEY (a, b))
 
 statement ok
-CREATE TABLE b (a string, b string, primary key (a, b)) interleave in parent a (a, b)
+CREATE TABLE b (a STRING, b STRING, PRIMARY KEY (a, b)) INTERLEAVE IN PARENT a (a, b)
 
 statement ok
 SELECT * FROM a JOIN b ON a.a=b.a AND a.b=b.b WHERE a.a='foo'
+
+subtest ParentChildDifferentSize
+# Regression test for #22647. Test when child is a few columns larger than parent.
+statement ok
+CREATE TABLE small_parent (a STRING PRIMARY KEY, b STRING); INSERT INTO small_parent VALUES ('first', 'second')
+
+statement ok
+CREATE TABLE large_child (a STRING PRIMARY KEY, c STRING, d STRING, e STRING, f STRING) INTERLEAVE IN PARENT small_parent (a)
+
+statement ok
+INSERT INTO large_child VALUES ('first', 'second_child', 'third_child', 'fourth_child', 'fifth_child')
+
+query TTTTTT
+SELECT * FROM large_child JOIN small_parent USING (a)
+----
+first  second_child  third_child  fourth_child  fifth_child second
+
+# Test with composite keys.
+statement ok
+CREATE TABLE small_parent_ck (a STRING, b STRING, c STRING, PRIMARY KEY (a, b)); INSERT INTO small_parent_ck VALUES ('first', 'second', 'third')
+
+statement ok
+CREATE TABLE large_child_ck (a STRING, b STRING, d STRING, e STRING, f STRING, PRIMARY KEY (a, b, d)) INTERLEAVE IN PARENT small_parent_ck (a, b)
+
+statement ok
+INSERT INTO large_child_ck VALUES ('first', 'second', 'third_child', 'fourth_child', 'fifth_child')
+
+query TTTTTTT
+SELECT * FROM large_child_ck JOIN small_parent_ck USING (a)
+----
+first  second  third_child  fourth_child  fifth_child  second  third
+
+
+# Test with families.
+statement ok
+CREATE TABLE small_parent_fam (a STRING, b STRING, c STRING, PRIMARY KEY (a, b)); INSERT INTO small_parent_fam VALUES ('first', 'second', 'third')
+
+statement ok
+CREATE TABLE large_child_fam (
+   a STRING,
+   b STRING,
+   d STRING,
+   e STRING,
+   f STRING,
+   PRIMARY KEY (a, b, d),
+   FAMILY f1 (a, b, d, e),
+   FAMILY f2 (f)
+) INTERLEAVE IN PARENT small_parent_fam (a, b)
+
+statement ok
+INSERT INTO large_child_fam VALUES ('first', 'second', 'third_child', 'fourth_child', 'fifth_child')
+
+query TTTTTTT
+SELECT * FROM large_child_fam JOIN small_parent_fam USING (a)
+----
+first  second  third_child  fourth_child  fifth_child  second  third
+
+
+# Test with parent being much larger than child.
+statement ok
+CREATE TABLE large_parent_fam (
+  a STRING,
+  b STRING,
+  c STRING,
+  d STRING,
+  e STRING,
+  f STRING,
+  PRIMARY KEY (a, b),
+  FAMILY f1 (a, b, c, d),
+  FAMILY f2 (e, f)
+)
+
+statement ok
+INSERT INTO large_parent_fam VALUES ('first', 'second', 'third', 'fourth', 'fifth', 'sixth')
+
+statement ok
+CREATE TABLE small_child_fam (
+   a STRING,
+   b STRING,
+   g STRING,
+   PRIMARY KEY (a, b)
+) INTERLEAVE IN PARENT large_parent_fam (a, b)
+
+statement ok
+INSERT INTO small_child_fam VALUES ('first', 'second', 'third_child')
+
+query TTTTTTTT
+SELECT * FROM small_child_fam JOIN large_parent_fam USING (a)
+----
+first  second  third_child  second  third  fourth  fifth  sixth

--- a/pkg/sql/sqlbase/rowfetcher.go
+++ b/pkg/sql/sqlbase/rowfetcher.go
@@ -67,6 +67,11 @@ type tableInfo struct {
 	// in the value part.
 	neededValueColsByIdx util.FastIntSet
 
+	// The number of needed columns from the value part of the row. Once we've
+	// seen this number of value columns for a particular row, we can stop
+	// decoding values in that row.
+	neededValueCols int
+
 	// Map used to get the index for columns in cols.
 	colIdxMap map[ColumnID]int
 
@@ -159,11 +164,6 @@ type RowFetcher struct {
 	// This is only false if there are no needed columns and the (single)
 	// table has no interleave children.
 	mustDecodeIndexKey bool
-
-	// The number of needed columns from the value part of the row. Once we've
-	// seen this number of value columns for a particular row, we can stop
-	// decoding values in that row.
-	neededValueCols int
 
 	knownPrefixLength int
 
@@ -312,7 +312,7 @@ func (rf *RowFetcher) Init(
 		// The number of columns we need to read from the value part of the key.
 		// It's the total number of needed columns minus the ones we read from the
 		// index key, except for composite columns.
-		rf.neededValueCols = table.neededCols.Len() - neededIndexCols + len(table.index.CompositeColumnIDs)
+		table.neededValueCols = table.neededCols.Len() - neededIndexCols + len(table.index.CompositeColumnIDs)
 
 		if table.isSecondaryIndex {
 			for i := range table.cols {
@@ -813,7 +813,7 @@ func (rf *RowFetcher) processValueBytes(
 	var lastColID ColumnID
 	var typeOffset, dataOffset int
 	var typ encoding.Type
-	for len(valueBytes) > 0 && rf.valueColsFound < rf.neededValueCols {
+	for len(valueBytes) > 0 && rf.valueColsFound < table.neededValueCols {
 		typeOffset, dataOffset, colIDDiff, typ, err = encoding.DecodeValueTag(valueBytes)
 		if err != nil {
 			return "", "", err
@@ -1127,7 +1127,7 @@ func (rf *RowFetcher) finalizeRow() error {
 	table := rf.rowReadyTable
 	// Fill in any missing values with NULLs
 	for i := range table.cols {
-		if rf.valueColsFound == rf.neededValueCols {
+		if rf.valueColsFound == table.neededValueCols {
 			// Found all cols - done!
 			return nil
 		}


### PR DESCRIPTION
Fixes: #22647

Bug:
There was a bug when using the rowFetcher to fetch columns from multiple
tables that it would only fetch the number of columns needed by the last
table specified.

Fix:
Store the number of columns that need to be fetched for each table
rather than just once for the entire rowFetcher.

Tests:
Added tests with interleaved tables where there was a difference in the
number of columns that needed to be fetched between the parent and child
table. Also added tests for cases with composite keys, families, and
when the child is larger as well as when the child is smaller than the
parent.

Release note: None