### PR TITLE
server: fail readiness checks for server.drain.unready_wait

### DIFF
--- a/pkg/acceptance/decommission_test.go
+++ b/pkg/acceptance/decommission_test.go
@@ -122,7 +122,8 @@ func testDecommissionInner(
 		}
 	}
 
-	withDB(1, "SET CLUSTER SETTING server.remote_debugging.mode = 'any'")
+	withDB(1, "SET CLUSTER SETTING server.remote_debugging.mode = 'any';"+
+		"SET CLUSTER SETTING server.shutdown.drain_wait='0s'")
 
 	// Get the ids for each node.
 	idMap := make(map[int]roachpb.NodeID)

--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -329,6 +329,7 @@ func TestQuit(t *testing.T) {
 	c := newCLITest(cliTestParams{t: t})
 	defer c.cleanup()
 
+	c.RunWithArgs([]string{"sql", "-e", "set cluster setting server.shutdown.drain_wait = '0s'"})
 	c.Run("quit")
 	// Wait until this async command cleanups the server.
 	<-c.Stopper().IsStopped()

--- a/pkg/cli/interactive_tests/common.tcl
+++ b/pkg/cli/interactive_tests/common.tcl
@@ -95,6 +95,7 @@ proc send_eof {} {
 proc start_server {argv} {
     report "BEGIN START SERVER"
     system "mkfifo pid_fifo || true; $argv start --insecure --pid-file=pid_fifo --background -s=path=logs/db >>logs/expect-cmd.log 2>&1 & cat pid_fifo > server_pid"
+    system "$argv sql -e \"SET CLUSTER SETTING server.shutdown.drain_wait = \'0s\'\""
     report "START SERVER DONE"
 }
 proc stop_server {argv} {

--- a/pkg/server/servemode.go
+++ b/pkg/server/servemode.go
@@ -30,6 +30,9 @@ const (
 	// modeOperational is intended for completely initialized server
 	// and thus allows all RPC methods.
 	modeOperational
+	// modeDraining is intended for an operational server in the process of
+	// shutting down. The difference is that readiness checks will fail.
+	modeDraining
 )
 
 type serveMode int32
@@ -58,6 +61,11 @@ func (s *serveMode) set(mode serveMode) {
 	atomic.StoreInt32((*int32)(s), int32(mode))
 }
 
+func (s *serveMode) get() serveMode {
+	return serveMode(atomic.LoadInt32((*int32)(s)))
+}
+
 func (s *serveMode) operational() bool {
-	return atomic.LoadInt32((*int32)(s)) == int32(modeOperational)
+	sMode := s.get()
+	return sMode == modeOperational || sMode == modeDraining
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -88,9 +88,9 @@ var (
 	// for a graceful shutdown.
 	GracefulDrainModes = []serverpb.DrainMode{serverpb.DrainMode_CLIENT, serverpb.DrainMode_LEASES}
 
-	settingDrainMaxWait = settings.RegisterDurationSetting(
-		"server.drain_max_wait",
-		"the amount of time subsystems wait for work to finish before shutting down",
+	queryWait = settings.RegisterDurationSetting(
+		"server.shutdown.query_wait",
+		"the server will wait for at least this amount of time for active queries to finish",
 		10*time.Second,
 	)
 )
@@ -1372,7 +1372,7 @@ func (s *Server) doDrain(
 					return nil
 				}
 
-				drainMaxWait := settingDrainMaxWait.Get(&s.st.SV)
+				drainMaxWait := queryWait.Get(&s.st.SV)
 				if err := s.pgServer.Drain(drainMaxWait); err != nil {
 					return err
 				}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -93,6 +93,13 @@ var (
 		"the server will wait for at least this amount of time for active queries to finish",
 		10*time.Second,
 	)
+
+	drainWait = settings.RegisterDurationSetting(
+		"server.shutdown.drain_wait",
+		"the amount of time a server waits in an unready state before proceeding with the rest "+
+			"of the shutdown process",
+		15*time.Second,
+	)
 )
 
 // Server is the cockroach server node.
@@ -1359,7 +1366,17 @@ func (s *Server) doDrain(
 	for _, mode := range modes {
 		switch mode {
 		case serverpb.DrainMode_CLIENT:
+			if setTo {
+				s.serveMode.set(modeDraining)
+				// Wait for drainUnreadyWait. This will fail load balancer checks and
+				// delay draining so that client traffic can move off this node.
+				time.Sleep(drainWait.Get(&s.st.SV))
+			}
 			if err := func() error {
+				if !setTo {
+					// Execute this last.
+					defer func() { s.serveMode.set(modeOperational) }()
+				}
 				// Since enabling the lease manager's draining mode will prevent
 				// the acquisition of new leases, the switch must be made after
 				// the pgServer has given sessions a chance to finish ongoing

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -41,6 +41,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/httputil"
@@ -593,10 +594,13 @@ func TestListenerFileCreation(t *testing.T) {
 
 func TestHeartbeatCallbackForDecommissioning(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	s, db, _ := serverutils.StartServer(t, base.TestServerArgs{})
 	defer s.Stopper().Stop(context.TODO())
 	ts := s.(*TestServer)
 	nodeLiveness := ts.nodeLiveness
+
+	// Don't bother waiting before draining.
+	sqlutils.MakeSQLRunner(db).Exec(t, "SET CLUSTER SETTING server.shutdown.drain_wait = '0s'")
 
 	for {
 		// Morally this loop only runs once. However, early in the boot

--- a/pkg/server/status.go
+++ b/pkg/server/status.go
@@ -523,7 +523,8 @@ func (s *statusServer) Details(
 		return resp, nil
 	}
 
-	if !s.admin.server.operational() {
+	serveMode := s.admin.server.serveMode.get()
+	if serveMode != modeOperational {
 		return nil, grpcstatus.Error(codes.Unavailable, "node is not ready")
 	}
 

--- a/pkg/sql/pgwire/pgwire_test.go
+++ b/pkg/sql/pgwire/pgwire_test.go
@@ -96,7 +96,6 @@ func TestPGWire(t *testing.T) {
 	for _, insecure := range [...]bool{true, false} {
 		params := base.TestServerArgs{Insecure: insecure}
 		s, _, _ := serverutils.StartServer(t, params)
-
 		host, port, err := net.SplitHostPort(s.ServingAddr())
 		if err != nil {
 			t.Fatal(err)
@@ -218,6 +217,7 @@ func TestPGWireDrainClient(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	params := base.TestServerArgs{Insecure: true}
 	s, _, _ := serverutils.StartServer(t, params)
+
 	ctx := context.TODO()
 	defer s.Stopper().Stop(ctx)
 
@@ -238,6 +238,10 @@ func TestPGWireDrainClient(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer db.Close()
+
+	// Don't bother waiting before draining.
+	sqlutils.MakeSQLRunner(db).Exec(t, "SET CLUSTER SETTING server.shutdown.drain_wait = '0s'")
+
 	txn, err := db.Begin()
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION

    To interact well with load balancers, we should wait an amount of time
    in an unready state yet still be operational. Otherwise load balancers
    may not pick up draining nodes and may send them client traffic.

    A cluster setting has been added (server.drain.unready_wait) to control
    the length of time spent in this state since it is dependent on load
    balancer settings set by the operator.

    Addresses #22424 (will close manually once it is a confirmed fix)

    Release note (bug fix): Add server.drain.unready_wait cluster setting
    and wait for that length of time in an unready state before draining to
    not get client requests while draining behind a load balancer.

Will be cherrypicked into 1.1 and 2.0