### PR TITLE
sql: wire up the ported index constraints code

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/scalar
+++ b/pkg/sql/opt/exec/execbuilder/testdata/scalar
@@ -289,12 +289,21 @@ render     0  render  ·         ·                (column8)                    
 exec-explain
 SELECT CAST(a AS string), b::float FROM t.t
 ----
-render     0  render  ·         ·                  (column8, column9)                 ·
- │         0  ·       render 0  CAST(a AS STRING)  ·                                  ·
- │         0  ·       render 1  CAST(b AS FLOAT)   ·                                  ·
- └── scan  1  scan    ·         ·                  (a, b, c, d, j, s, rowid[hidden])  ·
-·          1  ·       table     t@primary          ·                                  ·
-·          1  ·       spans     ALL                ·                                  ·
+render     0  render  ·         ·          (column8, column9)                 ·
+ │         0  ·       render 0  a::STRING  ·                                  ·
+ │         0  ·       render 1  b::FLOAT   ·                                  ·
+ └── scan  1  scan    ·         ·          (a, b, c, d, j, s, rowid[hidden])  ·
+·          1  ·       table     t@primary  ·                                  ·
+·          1  ·       spans     ALL        ·                                  ·
+
+exec-explain
+SELECT CAST(a + b + c AS string) FROM t.t
+----
+render     0  render  ·         ·                      (column8)                          ·
+ │         0  ·       render 0  ((a + b) + c)::STRING  ·                                  ·
+ └── scan  1  scan    ·         ·                      (a, b, c, d, j, s, rowid[hidden])  ·
+·          1  ·       table     t@primary              ·                                  ·
+·          1  ·       spans     ALL                    ·                                  ·
 
 exec
 SELECT LENGTH(s)::float, s FROM t.str

--- a/pkg/sql/opt/idxconstraint/spans.go
+++ b/pkg/sql/opt/idxconstraint/spans.go
@@ -163,8 +163,6 @@ func ExactPrefix(spans LogicalSpans, evalCtx *tree.EvalContext) int {
 	}
 }
 
-var _ = ExactPrefix
-
 // IndexColumnInfo encompasses the information for index columns, needed for
 // index constraints.
 type IndexColumnInfo struct {

--- a/pkg/sql/sem/tree/expr.go
+++ b/pkg/sql/sem/tree/expr.go
@@ -1259,7 +1259,7 @@ func NewTypedCastExpr(expr TypedExpr, typ types.T) (*CastExpr, error) {
 	if err != nil {
 		return nil, err
 	}
-	node := &CastExpr{Expr: expr, Type: colType}
+	node := &CastExpr{Expr: expr, Type: colType, SyntaxMode: CastShort}
 	node.typ = typ
 	return node, nil
 }


### PR DESCRIPTION
#### opt: replace placeholders with values

If we have value for placeholders, replace them with their values
during build.

Release note: None

#### opt: prefer short cast syntax

We are building CastExpr using the explicit syntax. This causes some
churn in some distsql tests when the new index constraints code is on.
Switching to the short syntax.

Release note: None

#### sql: wire up the ported index constraints code

The new index constraints code was ported to the new optimizer
structures (in `opt/idxconstraint`). This change rewires sql to use
that.

Planning benchmark differences below. Note that we will be looking at
improving the performance before 2.1 ships.

```
name                                                             old time/op    new time/op    delta
Planning/SELECT_*_FROM_abc-8                                        265µs ± 3%     266µs ± 3%     ~     (p=0.886 n=4+4)
Planning/SELECT_*_FROM_abc_WHERE_a_>_5_ORDER_BY_a-8                 200µs ± 1%     214µs ± 1%   +6.88%  (p=0.029 n=4+4)
Planning/SELECT_*_FROM_abc_WHERE_b_=_5-8                            196µs ± 2%     213µs ± 5%   +8.59%  (p=0.029 n=4+4)
Planning/SELECT_*_FROM_abc_WHERE_b_=_5_ORDER_BY_a-8                 211µs ± 4%     225µs ± 2%   +6.54%  (p=0.029 n=4+4)
Planning/SELECT_*_FROM_abc_WHERE_c_=_5-8                            195µs ± 3%     209µs ± 4%   +6.85%  (p=0.029 n=4+4)
Planning/SELECT_*_FROM_abc_JOIN_abc_AS_abc2_ON_abc.a_=_abc2.a-8     459µs ± 4%     435µs ± 4%     ~     (p=0.057 n=4+4)

name                                                             old alloc/op   new alloc/op   delta
Planning/SELECT_*_FROM_abc-8                                       33.8kB ± 2%    33.8kB ± 2%     ~     (p=1.000 n=4+4)
Planning/SELECT_*_FROM_abc_WHERE_a_>_5_ORDER_BY_a-8                23.4kB ± 2%    27.1kB ± 1%  +15.86%  (p=0.029 n=4+4)
Planning/SELECT_*_FROM_abc_WHERE_b_=_5-8                           25.1kB ± 1%    28.9kB ± 2%  +15.26%  (p=0.029 n=4+4)
Planning/SELECT_*_FROM_abc_WHERE_b_=_5_ORDER_BY_a-8                26.2kB ± 3%    29.7kB ± 0%  +13.19%  (p=0.029 n=4+4)
Planning/SELECT_*_FROM_abc_WHERE_c_=_5-8                           24.9kB ± 0%    28.7kB ± 1%  +15.48%  (p=0.029 n=4+4)
Planning/SELECT_*_FROM_abc_JOIN_abc_AS_abc2_ON_abc.a_=_abc2.a-8    70.0kB ± 2%    69.6kB ± 0%     ~     (p=0.886 n=4+4)

name                                                             old allocs/op  new allocs/op  delta
Planning/SELECT_*_FROM_abc-8                                          354 ± 0%       354 ± 0%     ~     (p=1.000 n=4+4)
Planning/SELECT_*_FROM_abc_WHERE_a_>_5_ORDER_BY_a-8                   328 ± 0%       372 ± 0%  +13.41%  (p=0.029 n=4+4)
Planning/SELECT_*_FROM_abc_WHERE_b_=_5-8                              320 ± 0%       364 ± 0%  +13.74%  (p=0.029 n=4+4)
Planning/SELECT_*_FROM_abc_WHERE_b_=_5_ORDER_BY_a-8                   360 ± 0%       404 ± 0%  +12.14%  (p=0.029 n=4+4)
Planning/SELECT_*_FROM_abc_WHERE_c_=_5-8                              317 ± 0%       361 ± 0%  +13.96%  (p=0.029 n=4+4)
Planning/SELECT_*_FROM_abc_JOIN_abc_AS_abc2_ON_abc.a_=_abc2.a-8       649 ± 0%       648 ± 0%     ~     (p=0.429 n=4+4)
```

Release note: None
