### PR TITLE
Makefile: get smarter about GOPATHs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -193,11 +193,19 @@ UI_ROOT        := $(PKG_ROOT)/ui
 SQLPARSER_ROOT := $(PKG_ROOT)/sql/parser
 
 # Ensure we have an unambiguous GOPATH.
-export GOPATH := $(realpath ../../../..)
-#                           ^  ^  ^  ^~ GOPATH
-#                           |  |  |~ GOPATH/src
-#                           |  |~ GOPATH/src/github.com
-#                           |~ GOPATH/src/github.com/cockroachdb
+GOPATH := $(shell $(GO) env GOPATH)
+
+ifneq "$(or $(findstring :,$(GOPATH)),$(findstring ;,$(GOPATH)))" ""
+$(error GOPATHs with multiple entries are not supported)
+endif
+
+ifeq "$(filter $(GOPATH)%,$(CURDIR))" ""
+$(error Current directory "$(CURDIR)" is not within GOPATH "$(GOPATH)")
+endif
+
+ifeq "$(GOPATH)" "/"
+$(error GOPATH=/ is not supported)
+endif
 
 # Avoid printing twice if Make restarts (because a Makefile was changed) or is
 # called recursively from another Makefile.

--- a/build/archive/contents/Makefile
+++ b/build/archive/contents/Makefile
@@ -1,3 +1,4 @@
+export GOPATH = $(CURDIR)
 export BUILDCHANNEL := source-archive
 
 .PHONY: all build buildoss check clean install test


### PR DESCRIPTION
Teach Make to check that the GOPATH does not contain multiple entries
and is not the root directory. Also check that the CWD is actually
within the GOPATH.

All this allows us to build from a directory besides
GOPATH/src/github.com/cockroachdb/cockroach, e.g. when we're vendored in
another Go program.

Fix #17886.
Fix #24358.

Release note: None