### PR TITLE
roachtest: tweak some ergonomics

### DIFF
--- a/pkg/cmd/roachtest/allocator.go
+++ b/pkg/cmd/roachtest/allocator.go
@@ -55,7 +55,7 @@ func init() {
 		// Start the remaining nodes to kick off upreplication/rebalancing.
 		c.Start(ctx, c.Range(start+1, end))
 
-		c.Run(ctx, 1, `./workload init kv`)
+		c.Run(ctx, 1, `./workload init kv --drop`)
 		for node := 1; node <= end; node++ {
 			node := node
 			// TODO(dan): Ideally, the test would fail if this queryload failed,

--- a/pkg/cmd/roachtest/main.go
+++ b/pkg/cmd/roachtest/main.go
@@ -65,6 +65,9 @@ func main() {
 		&clusterName, "cluster", "c", "", "name of an existing cluster to use for running tests")
 	runCmd.Flags().StringVar(
 		&clusterID, "cluster-id", "", "an identifier to use in the test cluster's name")
+	runCmd.Flags().BoolVar(
+		&clusterWipe, "wipe", true,
+		"wipe existing cluster before starting test (for use with --cluster)")
 	runCmd.Flags().StringVar(
 		&cockroach, "cockroach", "", "path to cockroach binary to use")
 	runCmd.Flags().StringVarP(

--- a/pkg/cmd/roachtest/schemachange.go
+++ b/pkg/cmd/roachtest/schemachange.go
@@ -51,7 +51,7 @@ func init() {
 		})
 		m.Wait()
 
-		c.Run(ctx, 1, `./workload init kv  --drop`)
+		c.Run(ctx, 1, `./workload init kv --drop`)
 		for node := 1; node <= nodes; node++ {
 			node := node
 			// TODO(dan): Ideally, the test would fail if this queryload failed,


### PR DESCRIPTION
On tests that load a large fixture, I've found myself frequently
commenting out the destroy and wipe code. The `--wipe=false` option
bypasses this, while still stopping the cluster at the beginning of the
test to keep some of the idempotency.

I considered making this a parameter to newCluster so the behavior could
be selected but the test, but I think that's a recipe for confusion.

Release note: None