### PR TITLE
ui: clusterviz: correct liveness status text on nodes

### DIFF
--- a/pkg/ui/ccl/src/views/clusterviz/containers/map/circleLayout.tsx
+++ b/pkg/ui/ccl/src/views/clusterviz/containers/map/circleLayout.tsx
@@ -14,13 +14,16 @@ import { getChildLocalities } from "src/util/localities";
 import { LocalityView } from "./localityView";
 import { NodeView } from "./nodeView";
 import { LivenessStatus } from "src/redux/nodes";
+import { cockroach } from "src/js/protos";
+import Liveness = cockroach.storage.Liveness;
 
 const MIN_RADIUS = 150;
 const PADDING = 150;
 
 interface CircleLayoutProps {
   localityTree: LocalityTree;
-  liveness: { [id: string]: LivenessStatus };
+  livenessStatus: { [id: string]: LivenessStatus };
+  liveness: { [id: string]: Liveness };
   viewportSize: [number, number];
 }
 
@@ -53,7 +56,7 @@ export class CircleLayout extends React.Component<CircleLayoutProps> {
         {
           childLocalities.map((locality, i) => (
             <g transform={`translate(${this.coordsFor(i, total, radius)})`}>
-              <LocalityView localityTree={locality} liveness={this.props.liveness} />
+              <LocalityView localityTree={locality} liveness={this.props.livenessStatus} />
             </g>
           ))
         }
@@ -63,7 +66,8 @@ export class CircleLayout extends React.Component<CircleLayoutProps> {
               <g transform={`translate(${this.coordsFor(i + childLocalities.length, total, radius)})`}>
                 <NodeView
                   node={node}
-                  liveness={this.props.liveness}
+                  livenessStatus={this.props.livenessStatus}
+                  liveness={this.props.liveness[node.desc.node_id]}
                 />
               </g>
             );

--- a/pkg/ui/ccl/src/views/clusterviz/containers/map/mapLayout.tsx
+++ b/pkg/ui/ccl/src/views/clusterviz/containers/map/mapLayout.tsx
@@ -25,7 +25,7 @@ import "./mapLayout.styl";
 interface MapLayoutProps {
   localityTree: LocalityTree;
   locationTree: LocationTree;
-  liveness: { [id: string]: LivenessStatus };
+  livenessStatus: { [id: string]: LivenessStatus };
   viewportSize: [number, number];
 }
 
@@ -98,7 +98,7 @@ export class MapLayout extends React.Component<MapLayoutProps, MapLayoutState> {
 
       return (
         <g transform={`translate(${center})`}>
-          <LocalityView localityTree={locality} liveness={this.props.liveness} />
+          <LocalityView localityTree={locality} liveness={this.props.livenessStatus} />
         </g>
       );
     });

--- a/pkg/ui/ccl/src/views/clusterviz/containers/map/nodeCanvas.tsx
+++ b/pkg/ui/ccl/src/views/clusterviz/containers/map/nodeCanvas.tsx
@@ -21,13 +21,16 @@ import { CLUSTERVIZ_ROOT } from "src/routes/visualization";
 import { generateLocalityRoute, getLocalityLabel } from "src/util/localities";
 import arrowUpIcon from "!!raw-loader!assets/arrowUp.svg";
 import { trustIcon } from "src/util/trust";
+import { cockroach } from "src/js/protos";
+import Liveness = cockroach.storage.Liveness;
 
 const BACK_BUTTON_OFFSET = 26;
 
 interface NodeCanvasProps {
   localityTree: LocalityTree;
   locationTree: LocationTree;
-  liveness: { [id: string]: LivenessStatus };
+  livenessStatus: { [id: string]: LivenessStatus };
+  liveness: { [id: string]: Liveness };
   tiers: LocalityTier[];
 }
 
@@ -72,22 +75,23 @@ export class NodeCanvas extends React.Component<NodeCanvasProps, NodeCanvasState
       return null;
     }
 
-    const { localityTree, locationTree, liveness } = this.props;
+    const { localityTree, locationTree, livenessStatus, liveness } = this.props;
     const { viewportSize } = this.state;
 
     if (renderAsMap(locationTree, localityTree)) {
       return <MapLayout
         localityTree={localityTree}
         locationTree={locationTree}
-        liveness={liveness}
+        livenessStatus={livenessStatus}
         viewportSize={viewportSize}
       />;
     }
 
     return <CircleLayout
-      localityTree={localityTree}
-      liveness={liveness}
       viewportSize={viewportSize}
+      localityTree={localityTree}
+      livenessStatus={livenessStatus}
+      liveness={liveness}
     />;
   }
 

--- a/pkg/ui/ccl/src/views/clusterviz/containers/map/nodeCanvasContainer.tsx
+++ b/pkg/ui/ccl/src/views/clusterviz/containers/map/nodeCanvasContainer.tsx
@@ -12,6 +12,7 @@ import { connect } from "react-redux";
 import { withRouter, WithRouterProps } from "react-router";
 import { createSelector } from "reselect";
 
+import { cockroach } from "src/js/protos";
 import { refreshNodes, refreshLiveness, refreshLocations } from "src/redux/apiReducers";
 import { selectLocalityTree, LocalityTier, LocalityTree } from "src/redux/localities";
 import { selectLocationsRequestStatus, selectLocationTree, LocationTree } from "src/redux/locations";
@@ -22,21 +23,23 @@ import {
   selectLivenessRequestStatus,
   livenessStatusByNodeIDSelector,
   LivenessStatus,
+  livenessByNodeIDSelector,
 } from "src/redux/nodes";
 import { AdminUIState } from "src/redux/state";
 import { CLUSTERVIZ_ROOT } from "src/routes/visualization";
 import { getLocality } from "src/util/localities";
 import Loading from "src/views/shared/components/loading";
-
 import { NodeCanvas } from "./nodeCanvas";
-
 import spinner from "assets/spinner.gif";
+
+import Liveness = cockroach.storage.Liveness;
 
 interface NodeCanvasContainerProps {
   nodesSummary: NodesSummary;
   localityTree: LocalityTree;
   locationTree: LocationTree;
-  liveness: { [id: string]: LivenessStatus };
+  livenessStatus: { [id: string]: LivenessStatus };
+  liveness: { [id: string]: Liveness };
   dataExists: boolean;
   dataIsValid: boolean;
   refreshNodes: typeof refreshNodes;
@@ -76,8 +79,9 @@ class NodeCanvasContainer extends React.Component<NodeCanvasContainerProps & Nod
         <NodeCanvas
           localityTree={currentLocality}
           locationTree={this.props.locationTree}
-          liveness={this.props.liveness}
           tiers={this.props.tiers}
+          livenessStatus={this.props.livenessStatus}
+          liveness={this.props.liveness}
         />
       </Loading>
     );
@@ -103,7 +107,8 @@ export default connect(
     nodesSummary: nodesSummarySelector(state),
     localityTree: selectLocalityTree(state),
     locationTree: selectLocationTree(state),
-    liveness: livenessStatusByNodeIDSelector(state),
+    livenessStatus: livenessStatusByNodeIDSelector(state),
+    liveness: livenessByNodeIDSelector(state),
     dataIsValid: selectDataIsValid(state),
     dataExists: selectDataExists(state),
   }),


### PR DESCRIPTION
It used to always say "up for <duration>" no matter what the liveness status was. Now it will still say that if the node is live, and will say the status of the node otherwise.
Now:
![image](https://user-images.githubusercontent.com/7341/36818873-08024892-1cb5-11e8-9337-9929963a943c.png)

Would also be good to pipe in durations for other statuses (e.g. suspect), although this might be different enough to warrant a separate PR.

Fixes #23250 

Release note (admin ui change): clusterviz: correct liveness status text on nodes