### PR TITLE
cherry-pick-2.0: ui: fix showing "this.props.long" instead of job desc

### DIFF
--- a/pkg/ui/src/views/shared/components/expandableString/index.tsx
+++ b/pkg/ui/src/views/shared/components/expandableString/index.tsx
@@ -50,7 +50,7 @@ export class ExpandableString extends React.Component<ExpandableStringProps, Exp
 
     const neverCollapse = _.isNil(short) && long.length <= truncateLength + 2;
     if (neverCollapse) {
-      return <span>this.props.long</span>;
+      return <span>{ this.props.long }</span>;
     }
 
     const { expanded } = this.state;


### PR DESCRIPTION
Cherry pick of #23169 

Fixes #23168

Release note (admin ui change): Fix bug with showing description on jobs page.