### PR TITLE
sql, kv: use Delete instead of DeleteRange to lessen impact on tscache

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/show_trace
+++ b/pkg/sql/logictest/testdata/logic_test/show_trace
@@ -307,14 +307,14 @@ SELECT span, operation, message FROM [SHOW KV TRACE FOR DELETE FROM t.kv]
 3  dist sender     r1: sending batch 1 Scan to (n1,s1):1
 0  sql txn         fetched: /kv/primary/1/v -> /2
 0  sql txn         Del /Table/52/2/2/0
-0  sql txn         DelRange /Table/52/1/1 - /Table/52/1/1/#
+0  sql txn         Del /Table/52/1/1/0
 2  consuming rows  output row: [1 2]
 0  sql txn         fetched: /kv/primary/2/v -> /3
 0  sql txn         Del /Table/52/2/3/0
-0  sql txn         DelRange /Table/52/1/2 - /Table/52/1/2/#
+0  sql txn         Del /Table/52/1/2/0
 2  consuming rows  output row: [2 3]
-5  dist sender     querying next range at /Table/52/1/1
-5  dist sender     r1: sending batch 2 Del, 2 DelRng, 1 BeginTxn to (n1,s1):1
+5  dist sender     querying next range at /Table/52/1/1/0
+5  dist sender     r1: sending batch 4 Del, 1 BeginTxn to (n1,s1):1
 
 query ITT
 SELECT span, operation, regexp_replace(regexp_replace(message, 'mutationJobs:<[^>]*>', 'mutationJobs:<...>'), 'wall_time:\d+', 'wall_time:...') as message

--- a/pkg/storage/batcheval/cmd_delete_range.go
+++ b/pkg/storage/batcheval/cmd_delete_range.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage/batcheval/result"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
+	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 )
 
@@ -45,8 +46,9 @@ func DeleteRange(
 	)
 	if err == nil {
 		reply.Keys = deleted
-		// DeleteRange requires that we retry on push to avoid the lost delete range anomaly.
-		if h.Txn != nil {
+		// DeleteRange requires that we retry on push (for snapshot) to
+		// avoid the lost delete range anomaly.
+		if h.Txn != nil && h.Txn.Isolation == enginepb.SNAPSHOT {
 			clonedTxn := h.Txn.Clone()
 			clonedTxn.RetryOnPush = true
 			reply.Txn = &clonedTxn


### PR DESCRIPTION
Previously, on the slow path for deletion from SQL, rows were deleted
using a call to `DeleteRange` in order to remove all column families
with a single statement. It turns out this is better done using one
call per column family to `Delete`. `DeleteRange` must update the
write timestamp cache in order to avoid lost update anomalies. By
lessening the pressure on the timestamp cache, we can avoid pushing
a transaction's commit timestamp forward and triggering a retry. This
allow substantially longer / larger `DELETE FROM` statements to run
to completion, assuming there is no other concurrency which will force
a retry.

In conjunction, a realization from #21165 was that large `DELETE FROM`
statements can end up running forever. This occurs because they are
retryable from the SQL executor and continue to get retryable errors
due to the timestamp cache being unable to avoid pushing their
timestamps forward.

Fixes #17921 

Release note (SQL change): will fix endless churn experienced from
large `DELETE FROM` statements, either by allowing them to complete,
or by exiting with an error message indicating the transaction is too
large to complete.