### PR TITLE
sql: improve cluster version upgrade semantics

### DIFF
--- a/pkg/acceptance/version_upgrade_test.go
+++ b/pkg/acceptance/version_upgrade_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/pkg/errors"
 
 	"github.com/cockroachdb/cockroach/pkg/acceptance/cluster"
@@ -117,15 +118,35 @@ func (cv clusterVersionUpgrade) name() string { return fmt.Sprintf("cluster=%s",
 func (cv clusterVersionUpgrade) run(ctx context.Context, t *testing.T, c cluster.Cluster) {
 	t.Helper()
 
+	// hasShowSettingBug is true when we're working around
+	// https://github.com/cockroachdb/cockroach/issues/22796.
+	//
+	// The problem there is that `SHOW CLUSTER SETTING version` does not take into
+	// account the gossiped value of that setting but reads it straight from the
+	// KV store. This means that even though a node may report a certain version,
+	// it may not actually have processed it yet, which leads to illegal upgrades
+	// in this test. When this flag is set to true, we query
+	// `crdb_internal.cluster_settings` instead, which *does* take everything from
+	// Gossip.
+	v, err := roachpb.ParseVersion(string(cv))
+	if err != nil {
+		t.Fatal(err)
+	}
+	hasShowSettingBug := v.Less(roachpb.Version{Major: 1, Minor: 1, Unstable: 1})
+
 	func() {
 		db := makePGClient(t, c.PGUrl(ctx, rand.Intn(c.NumNodes())))
 		defer db.Close()
 
-		log.Infof(ctx, "upgrading cluster version to %s", string(cv))
-		if _, err := db.Exec(fmt.Sprintf(`SET CLUSTER SETTING version = '%s'`, string(cv))); err != nil {
+		log.Infof(ctx, "upgrading cluster version to %s", cv)
+		if _, err := db.Exec(fmt.Sprintf(`SET CLUSTER SETTING version = '%s'`, cv)); err != nil {
 			t.Fatal(err)
 		}
 	}()
+
+	if hasShowSettingBug {
+		log.Infof(ctx, "using workaround for upgrade to %s", cv)
+	}
 
 	for i := 0; i < c.NumNodes(); i++ {
 		testutils.SucceedsSoon(t, func() error {
@@ -133,22 +154,33 @@ func (cv clusterVersionUpgrade) run(ctx context.Context, t *testing.T, c cluster
 			defer db.Close()
 
 			var version string
-			if err := db.QueryRow("SHOW CLUSTER SETTING version").Scan(&version); err != nil {
-				t.Fatalf("%d: %s", i, err)
+			if !hasShowSettingBug {
+				if err := db.QueryRow("SHOW CLUSTER SETTING version").Scan(&version); err != nil {
+					t.Fatalf("%d: %s", i, err)
+				}
+			} else {
+				// This uses the receiving node's Gossip and as such allows us to verify that all of the
+				// nodes have gotten wind of the version bump.
+				if err := db.QueryRow(
+					`SELECT current_value FROM crdb_internal.cluster_settings WHERE name = 'version'`,
+				).Scan(&version); err != nil {
+					t.Fatalf("%d: %s", i, err)
+				}
 			}
 			if version != string(cv) {
-				return errors.Errorf("%d: expected version %s, got %s", i, string(cv), version)
+				return errors.Errorf("%d: expected version %s, got %s", i, cv, version)
 			}
 			return nil
 		})
 	}
+
+	log.Infof(ctx, "cluster is now at version %s", cv)
 
 	// TODO(nvanbenschoten): add upgrade qualification step.
 	time.Sleep(1 * time.Second)
 }
 
 func testVersionUpgrade(ctx context.Context, t *testing.T, cfg cluster.TestConfig) {
-	t.Skip("#22796")
 	steps := []versionStep{
 		binaryVersionUpgrade("v1.0.6"),
 		// v1.1.0 is the first binary version that knows about cluster versions,

--- a/pkg/sql/show_cluster_setting.go
+++ b/pkg/sql/show_cluster_setting.go
@@ -15,18 +15,73 @@
 package sql
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/util/retry"
 	"github.com/pkg/errors"
 
 	"github.com/cockroachdb/cockroach/pkg/settings"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/util/duration"
 )
+
+func (p *planner) showStateMachineSetting(
+	ctx context.Context, st *cluster.Settings, s *settings.StateMachineSetting, name string,
+) (*tree.DString, error) {
+	var d *tree.DString
+	// For statemachine settings (at the time of writing, this is only the cluster version setting)
+	// we show the value from the KV store and additionally wait for the local Gossip instance to
+	// have observed the value as well. This makes sure that cluster version bumps become visible
+	// immediately while at the same time guaranteeing that a node reporting a certain version has
+	// also processed the corresponding Gossip update (which is important as only then does the node
+	// update its persisted state; see #22796).
+	if err := retry.ForDuration(10*time.Second, func() error {
+		datums, err := p.QueryRow(ctx, "SELECT value FROM system.settings WHERE name = $1", name)
+		if err != nil {
+			return err
+		}
+		var prevRawVal []byte
+		if len(datums) != 0 {
+			dStr, ok := datums[0].(*tree.DString)
+			if !ok {
+				return errors.New("the existing value is not a string")
+			}
+			prevRawVal = []byte(string(*dStr))
+		}
+		// Note that if no entry is found, we pretend that an entry
+		// exists which is the version used for the running binary. This
+		// may not be 100.00% correct, but it will do. The input is
+		// checked more thoroughly when a user tries to change the
+		// value, and the corresponding sql migration that makes sure
+		// the above select finds something usually runs pretty quickly
+		// when the cluster is bootstrapped.
+		kvRawVal, obj, err := s.Validate(&st.SV, prevRawVal, nil)
+		if err != nil {
+			return errors.Errorf("unable to read existing value: %s", err)
+		}
+
+		// NB: if there is no persisted cluster version yet, this will match
+		// kvRawVal (which is taken from `st.SV` in this case too).
+		gossipRawVal := []byte(s.Get(&st.SV))
+		if !bytes.Equal(gossipRawVal, kvRawVal) {
+			return errors.Errorf("gossip and KV store disagree about value")
+		}
+
+		d = tree.NewDString(obj.(fmt.Stringer).String())
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+
+	return d, nil
+}
 
 func (p *planner) ShowClusterSetting(
 	ctx context.Context, n *tree.ShowClusterSetting,
@@ -76,32 +131,11 @@ func (p *planner) ShowClusterSetting(
 			case *settings.StringSetting:
 				d = tree.NewDString(s.String(&st.SV))
 			case *settings.StateMachineSetting:
-				// Show consistent values for statemachine settings. This isn't necessary
-				// for correctness, but helpful for testability.
-				datums, err := p.QueryRow(ctx, "SELECT value FROM system.settings WHERE name = $1", name)
+				var err error
+				d, err = p.showStateMachineSetting(ctx, st, s, name)
 				if err != nil {
 					return nil, err
 				}
-				var prevRawVal []byte
-				if len(datums) != 0 {
-					dStr, ok := datums[0].(*tree.DString)
-					if !ok {
-						return nil, errors.New("the existing value is not a string")
-					}
-					prevRawVal = []byte(string(*dStr))
-				}
-				// Note that if no entry is found, we pretend that an entry
-				// exists which is the version used for the running binary. This
-				// may not be 100.00% correct, but it will do. The input is
-				// checked more thoroughly when a user tries to change the
-				// value, and the corresponding sql migration that makes sure
-				// the above select finds something usually runs pretty quickly
-				// when the cluster is bootstrapped.
-				_, obj, err := s.Validate(&st.SV, prevRawVal, nil)
-				if err != nil {
-					return nil, errors.Errorf("unable to read existing value: %s", err)
-				}
-				d = tree.NewDString(obj.(fmt.Stringer).String())
 			case *settings.BoolSetting:
 				d = tree.MakeDBool(tree.DBool(s.Get(&st.SV)))
 			case *settings.FloatSetting:


### PR DESCRIPTION
Prior to this change, `SHOW CLUSTER SETTING version` read the version
straight from the KV store. This was a terrible decision made by yours
truly to make tests that bumped the version not flaky but at the same
time implied that to check whether a node had processed a cluster
version bump, it was not enough to run `SHOW CLUSTER SETTING version`.

This manifested itself as a flake in the `TestVersionUpgrade` acceptance
test: we'd upgrade from 1.0 to 1.1 and prematurely restart a node into
`master`; that node would then refuse to start since its last persisted
cluster setting was 1.0 which is not compatible with a post-1.1.x
binary.

Since the test deals mostly in historical binaries which can't be
changed now, I adapted the test to use `SHOW ALL CLUSTER SETTINGS`
instead. This goes straight to Gossip and thus has the semantics wanted
by this test. For the source binary, we don't use this workaround.

As future-proofing, I changed `SHOW CLUSTER SETTING version` to read
both the Gossip variable *and* the KV store, and retry for a reasonable
amount of time until they are equal. This makes sure that a cluster
version bump immediately becomes reported on all nodes (i.e. you won't
ever be able to issue a bump and then not see the version variable
bumped) *and* that the node has actually applied the version upgrade
before reporting it.

Fixes #22796.
Fixes #23257.

Release note (bug fix): Hardened the cluster version upgrade mechanism.
Rapid upgrades through more than two versions could sometimes fail
recoverably.

@knz: I'll not forget cherry-picking this. :)