### PR TITLE
Use GNU-style formatting directives on Windows

### DIFF
--- a/c-deps/libroach/status.h
+++ b/c-deps/libroach/status.h
@@ -30,7 +30,7 @@ inline DBStatus ToDBStatus(const rocksdb::Status& status) {
 }
 
 // FmtStatus formats the given arguments printf-style into a DBStatus.
-__attribute__((__format__(__printf__, 1, 2)))
+__attribute__((__format__(GOOGLE_PRINTF_FORMAT, 1, 2)))
 inline DBStatus FmtStatus(const char* fmt_str, ...) {
   va_list ap;
   va_start(ap, fmt_str);


### PR DESCRIPTION
By default, on Windows, GCC will check to make sure that formatting directives
that are not supported on Windows, like %llu and %zu, are not used.  Recent
versions of MinGW ship POSIX-compliant printf replacements that do support
these directives, but GCC is not smart enough to realize this on its own.

Release note: None