### PR TITLE
opt: execbuilder support for COALESCE, VALUES

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/scalar
+++ b/pkg/sql/opt/exec/execbuilder/testdata/scalar
@@ -237,7 +237,7 @@ render     0  render  ·         ·            (column8)                        
 ·          1  ·       table     t@primary    ·                                  ·
 ·          1  ·       spans     ALL          ·                                  ·
 
-exec-explain
+exec-explain allow-unsupported
 SELECT CASE WHEN a = 2 THEN 1 ELSE 2 END FROM t.t
 ----
 render     0  render  ·         ·                                             (column8)                          ·
@@ -302,3 +302,55 @@ SELECT LENGTH(s)::float, s FROM t.str
 1.0  a
 2.0  ab
 3.0  abc
+
+exec-explain
+SELECT COALESCE(a, b) FROM (VALUES (1, 2), (3, NULL), (NULL, 4), (NULL, NULL)) AS v(a, b)
+----
+render       0  render  ·              ·                           (column3)           ·
+ │           0  ·       render 0       COALESCE(column1, column2)  ·                   ·
+ └── values  1  values  ·              ·                           (column1, column2)  ·
+·            1  ·       size           2 columns, 4 rows           ·                   ·
+·            1  ·       row 0, expr 0  1                           ·                   ·
+·            1  ·       row 0, expr 1  2                           ·                   ·
+·            1  ·       row 1, expr 0  3                           ·                   ·
+·            1  ·       row 1, expr 1  NULL                        ·                   ·
+·            1  ·       row 2, expr 0  NULL                        ·                   ·
+·            1  ·       row 2, expr 1  4                           ·                   ·
+·            1  ·       row 3, expr 0  NULL                        ·                   ·
+·            1  ·       row 3, expr 1  NULL                        ·                   ·
+
+exec
+SELECT COALESCE(a, b) FROM (VALUES (1, 2), (3, NULL), (NULL, 4), (NULL, NULL)) AS v(a, b)
+----
+1
+3
+4
+NULL
+
+exec-explain
+SELECT COALESCE(a, b, c) FROM (VALUES (1, 2, 3), (NULL, 4, 5), (NULL, NULL, 6), (NULL, NULL, NULL)) AS v(a, b, c)
+----
+render       0  render  ·              ·                                    (column4)                    ·
+ │           0  ·       render 0       COALESCE(column1, column2, column3)  ·                            ·
+ └── values  1  values  ·              ·                                    (column1, column2, column3)  ·
+·            1  ·       size           3 columns, 4 rows                    ·                            ·
+·            1  ·       row 0, expr 0  1                                    ·                            ·
+·            1  ·       row 0, expr 1  2                                    ·                            ·
+·            1  ·       row 0, expr 2  3                                    ·                            ·
+·            1  ·       row 1, expr 0  NULL                                 ·                            ·
+·            1  ·       row 1, expr 1  4                                    ·                            ·
+·            1  ·       row 1, expr 2  5                                    ·                            ·
+·            1  ·       row 2, expr 0  NULL                                 ·                            ·
+·            1  ·       row 2, expr 1  NULL                                 ·                            ·
+·            1  ·       row 2, expr 2  6                                    ·                            ·
+·            1  ·       row 3, expr 0  NULL                                 ·                            ·
+·            1  ·       row 3, expr 1  NULL                                 ·                            ·
+·            1  ·       row 3, expr 2  NULL                                 ·                            ·
+
+exec
+SELECT COALESCE(a, b, c) FROM (VALUES (1, 2, 3), (NULL, 4, 5), (NULL, NULL, 6), (NULL, NULL, NULL)) AS v(a, b, c)
+----
+1
+4
+6
+NULL

--- a/pkg/sql/opt/exec/execbuilder/testdata/values
+++ b/pkg/sql/opt/exec/execbuilder/testdata/values
@@ -1,3 +1,4 @@
+# Tests for the implicit one row, zero column values operator.
 exec-explain
 SELECT 1
 ----
@@ -23,3 +24,60 @@ exec
 SELECT 1 + 2
 ----
 3
+
+exec-explain
+VALUES (1, 2, 3), (4, 5, 6)
+----
+values  0  values  ·              ·                  (column1, column2, column3)  ·
+·       0  ·       size           3 columns, 2 rows  ·                            ·
+·       0  ·       row 0, expr 0  1                  ·                            ·
+·       0  ·       row 0, expr 1  2                  ·                            ·
+·       0  ·       row 0, expr 2  3                  ·                            ·
+·       0  ·       row 1, expr 0  4                  ·                            ·
+·       0  ·       row 1, expr 1  5                  ·                            ·
+·       0  ·       row 1, expr 2  6                  ·                            ·
+
+exec
+VALUES (1, 2, 3), (4, 5, 6)
+----
+1  2  3
+4  5  6
+
+exec-explain
+VALUES (LENGTH('a')), (1 + LENGTH('a')), (LENGTH('abc')), (LENGTH('ab') * 2)
+----
+values  0  values  ·              ·                 (column1)  ·
+·       0  ·       size           1 column, 4 rows  ·          ·
+·       0  ·       row 0, expr 0  length('a')       ·          ·
+·       0  ·       row 1, expr 0  1 + length('a')   ·          ·
+·       0  ·       row 2, expr 0  length('abc')     ·          ·
+·       0  ·       row 3, expr 0  length('ab') * 2  ·          ·
+
+exec
+VALUES (LENGTH('a')), (1 + LENGTH('a')), (LENGTH('abc')), (LENGTH('ab') * 2)
+----
+1
+2
+3
+4
+
+exec-explain
+SELECT a + b FROM (VALUES (1, 2), (3, 4), (5, 6)) AS v(a, b)
+----
+render       0  render  ·              ·                  (column3)           ·
+ │           0  ·       render 0       column1 + column2  ·                   ·
+ └── values  1  values  ·              ·                  (column1, column2)  ·
+·            1  ·       size           2 columns, 3 rows  ·                   ·
+·            1  ·       row 0, expr 0  1                  ·                   ·
+·            1  ·       row 0, expr 1  2                  ·                   ·
+·            1  ·       row 1, expr 0  3                  ·                   ·
+·            1  ·       row 1, expr 1  4                  ·                   ·
+·            1  ·       row 2, expr 0  5                  ·                   ·
+·            1  ·       row 2, expr 1  6                  ·                   ·
+
+exec
+SELECT a + b FROM (VALUES (1, 2), (3, 4), (5, 6)) AS v(a, b)
+----
+3
+7
+11

--- a/pkg/sql/opt/optbuilder/scalar.go
+++ b/pkg/sql/opt/optbuilder/scalar.go
@@ -119,6 +119,13 @@ func (b *Builder) buildScalar(scalar tree.TypedExpr, inScope *scope) (out opt.Gr
 		typ := coltypes.CastTargetToDatumType(t.Type)
 		out = b.factory.ConstructCast(arg, b.factory.InternPrivate(typ))
 
+	case *tree.CoalesceExpr:
+		args := make([]opt.GroupID, len(t.Exprs))
+		for i := range args {
+			args[i] = b.buildScalar(t.TypedExprAt(i), inScope)
+		}
+		out = b.factory.ConstructCoalesce(b.factory.InternList(args))
+
 	case *tree.ComparisonExpr:
 		left := b.buildScalar(t.TypedLeft(), inScope)
 		right := b.buildScalar(t.TypedRight(), inScope)

--- a/pkg/sql/opt/optbuilder/testdata/scalar
+++ b/pkg/sql/opt/optbuilder/testdata/scalar
@@ -261,6 +261,21 @@ build-scalar
 cast: int [type=int]
  └── const: 123 [type=int]
 
+build-scalar vars=(int, int)
+IFNULL(@1, @2)
+----
+coalesce [type=int]
+ ├── variable: @1 [type=int]
+ └── variable: @2 [type=int]
+
+build-scalar vars=(int, int, int)
+COALESCE(@1, @2, @3)
+----
+coalesce [type=int]
+ ├── variable: @1 [type=int]
+ ├── variable: @2 [type=int]
+ └── variable: @3 [type=int]
+
 build-scalar vars=(int) allow-unsupported
 CASE WHEN @1 > 5 THEN 1 ELSE -1 END
 ----

--- a/pkg/sql/opt/optbuilder/testdata/values
+++ b/pkg/sql/opt/optbuilder/testdata/values
@@ -118,6 +118,30 @@ VALUES (NULL, 1), (2, NULL), (NULL, 'a')
 ----
 error: VALUES list type mismatch, string for int
 
+build
+SELECT COALESCE(a, b) FROM (VALUES (1, 2), (3, NULL), (NULL, 4), (NULL, NULL)) AS v(a, b)
+----
+project
+ ├── columns: column3:int:null:3
+ ├── values
+ │    ├── columns: column1:int:null:1 column2:int:null:2
+ │    ├── tuple [type=tuple{int, int}]
+ │    │    ├── const: 1 [type=int]
+ │    │    └── const: 2 [type=int]
+ │    ├── tuple [type=tuple{int, unknown}]
+ │    │    ├── const: 3 [type=int]
+ │    │    └── const: NULL [type=unknown]
+ │    ├── tuple [type=tuple{unknown, int}]
+ │    │    ├── const: NULL [type=unknown]
+ │    │    └── const: 4 [type=int]
+ │    └── tuple [type=tuple{unknown, unknown}]
+ │         ├── const: NULL [type=unknown]
+ │         └── const: NULL [type=unknown]
+ └── projections
+      └── coalesce [type=int]
+           ├── variable: column1 [type=int]
+           └── variable: column2 [type=int]
+
 
 # TODO(rytaft): uncomment these tests once subqueries are supported
 ## subqueries can be evaluated in VALUES

--- a/pkg/sql/opt_exec_engine.go
+++ b/pkg/sql/opt_exec_engine.go
@@ -119,16 +119,15 @@ var _ exec.Factory = &execEngine{}
 func (ee *execEngine) ConstructValues(
 	rows [][]tree.TypedExpr, colTypes []types.T, colNames []string,
 ) (exec.Node, error) {
-	if len(colTypes) != 0 {
-		panic("values with columns not implemented")
+	v := &valuesNode{
+		columns: make(sqlbase.ResultColumns, len(colTypes)),
+		tuples:  rows,
 	}
-	values := ee.planner.newContainerValuesNode(sqlbase.ResultColumns{}, len(rows))
-	for range rows {
-		if _, err := values.rows.AddRow(context.TODO(), tree.Datums{}); err != nil {
-			return nil, err
-		}
+	for i := range v.columns {
+		v.columns[i].Name = colNames[i]
+		v.columns[i].Typ = colTypes[i]
 	}
-	return values, nil
+	return v, nil
 }
 
 // ConstructScan is part of the exec.Factory interface.


### PR DESCRIPTION
#### opt: optbuilder support for COALESCE

Release note: None

#### opt: execbuilder support for VALUES

The execbuilder only supported zero-column VALUES. Adding full
support.

Release note: None.

#### opt: add execbuilder tests for COALESCE

Release note: None
