### PR TITLE
sql: Export binary and comparison op nullableArgs field

### DIFF
--- a/pkg/sql/sem/builtins/aggregate_builtins.go
+++ b/pkg/sql/sem/builtins/aggregate_builtins.go
@@ -93,7 +93,7 @@ var Aggregates = map[string][]tree.Builtin{
 			},
 			newArrayAggregate,
 			"Aggregates the selected values into an array.",
-			true /* nullableArgs */)
+			true /* NullableArgs */)
 	}),
 
 	"avg": {

--- a/pkg/sql/sem/tree/normalize.go
+++ b/pkg/sql/sem/tree/normalize.go
@@ -129,7 +129,7 @@ func (expr *BinaryExpr) normalize(v *NormalizeVisitor) TypedExpr {
 	right := expr.TypedRight()
 	expectedType := expr.ResolvedType()
 
-	if !expr.fn.nullableArgs && (left == DNull || right == DNull) {
+	if !expr.fn.NullableArgs && (left == DNull || right == DNull) {
 		return DNull
 	}
 

--- a/pkg/sql/sem/tree/type_check.go
+++ b/pkg/sql/sem/tree/type_check.go
@@ -177,7 +177,7 @@ func (expr *BinaryExpr) TypeCheck(ctx *SemaContext, desired types.T) (TypedExpr,
 		if len(fns) > 0 {
 			noneAcceptNull := true
 			for _, e := range fns {
-				if e.(BinOp).nullableArgs {
+				if e.(BinOp).NullableArgs {
 					noneAcceptNull = false
 					break
 				}
@@ -1234,7 +1234,7 @@ func typeCheckComparisonOp(
 		if len(fns) > 0 {
 			noneAcceptNull := true
 			for _, e := range fns {
-				if e.(CmpOp).nullableArgs {
+				if e.(CmpOp).NullableArgs {
 					noneAcceptNull = false
 					break
 				}


### PR DESCRIPTION
Binary and Comparison op definitions currently do not export the
nullableArgs field, which indicates whether a NULL input might
result in a non-NULL output. This field will be needed by the
optimizer in order to constant fold, so export it.

Release note: None