### PR TITLE
sql: fix panic in inverted indexes

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/inverted_index
+++ b/pkg/sql/logictest/testdata/logic_test/inverted_index
@@ -458,3 +458,27 @@ SELECT * from d where b @> 'null' ORDER BY a;
 ----
 11  null
 27  [true, false, null, 1.23, "a"]
+
+statement ok
+CREATE TABLE users (
+  profile_id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  last_updated TIMESTAMP DEFAULT now(),
+  user_profile JSONB
+);
+
+statement ok
+INSERT INTO users (user_profile) VALUES  ('{"first_name": "Lola", "last_name": "Dog", "location": "NYC", "online" : true, "friends" : 547}'),
+                                         ('{"first_name": "Ernie", "status": "Looking for treats", "location" : "Brooklyn"}');
+
+statement ok
+CREATE INVERTED INDEX dogs on users(user_profile);
+
+query T
+SELECT user_profile from users where user_profile @> '{"first_name":"Lola"}';
+----
+{"first_name": "Lola", "friends": 547, "last_name": "Dog", "location": "NYC", "online": true}
+
+query T
+SELECT user_profile from users where user_profile @> '{"first_name":"Ernie"}';
+----
+ {"first_name": "Ernie", "location": "Brooklyn", "status": "Looking for treats"}

--- a/pkg/sql/sqlbase/table.go
+++ b/pkg/sql/sqlbase/table.go
@@ -1709,16 +1709,20 @@ func EncodeSecondaryIndexes(
 	values []tree.Datum,
 	secondaryIndexEntries []IndexEntry,
 ) ([]IndexEntry, error) {
+	if len(secondaryIndexEntries) != len(indexes) {
+		panic("Length of secondaryIndexEntries is not equal to the number of indexes.")
+	}
 	for i := range indexes {
 		entries, err := EncodeSecondaryIndex(tableDesc, &indexes[i], colMap, values)
 		if err != nil {
 			return secondaryIndexEntries, err
 		}
+		secondaryIndexEntries[i] = entries[0]
+
+		// This is specifically for inverted indexes which can have more than one entry
+		// associated with them.
 		if len(entries) > 1 {
 			secondaryIndexEntries = append(secondaryIndexEntries, entries[1:]...)
-		}
-		if len(entries) > 0 {
-			secondaryIndexEntries[i] = entries[0]
 		}
 	}
 	return secondaryIndexEntries, nil


### PR DESCRIPTION
Before this patch, creating and inverted index on a table with rows
containing JSON would cause a panic.

Now the optimization to reduce memory allocations in
EncodeSecondaryIndexes is modified to allow us to reuse slices, but will
also return the amount of the slice used. This will make sure we don't
have duplicates from reusing a longer slice.

Closes #23190

Release note: None