### PR TITLE
kubernetes: Let secure client pod be deleted with no delay

### DIFF
--- a/cloud/kubernetes/client-secure.yaml
+++ b/cloud/kubernetes/client-secure.yaml
@@ -41,6 +41,8 @@ spec:
     command:
     - sleep
     - "2147483648" # 2^31
+  # This pod isn't doing anything important, so don't bother waiting to terminate it.
+  terminationGracePeriodSeconds: 0
   volumes:
   - name: client-certs
     emptyDir: {}


### PR DESCRIPTION
Our docs say that you can delete this pod and recreate it as needed, but
without this field it's given a minute to gracefully shut itself down,
which it won't ever do on its own since it's just running sleep. This
tells Kubernetes it's ok to kill it with no wait.

Release note: None