### PR TITLE
datadriven: move arg parsing into datadriven

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/builder_test.go
+++ b/pkg/sql/opt/exec/execbuilder/builder_test.go
@@ -112,12 +112,12 @@ func TestBuild(t *testing.T) {
 			datadriven.RunTest(t, path, func(d *datadriven.TestData) string {
 				var allowUnsupportedExpr bool
 				for _, arg := range d.CmdArgs {
-					switch arg {
+					switch arg.Key {
 					case "allow-unsupported":
 						allowUnsupportedExpr = true
 
 					default:
-						d.Fatalf(t, "unknown argument: %s", arg)
+						d.Fatalf(t, "unknown argument: %s", arg.Key)
 					}
 				}
 

--- a/pkg/sql/opt/idxconstraint/index_constraints_test.go
+++ b/pkg/sql/opt/idxconstraint/index_constraints_test.go
@@ -99,16 +99,7 @@ func TestIndexConstraints(t *testing.T) {
 				normalize := true
 
 				for _, arg := range d.CmdArgs {
-					key := arg
-					val := ""
-					if pos := strings.Index(key, "="); pos >= 0 {
-						key = arg[:pos]
-						val = arg[pos+1:]
-					}
-					if len(val) > 2 && val[0] == '(' && val[len(val)-1] == ')' {
-						val = val[1 : len(val)-1]
-					}
-					vals := strings.Split(val, ",")
+					key, vals := arg.Key, arg.Vals
 					switch key {
 					case "vars":
 						varTypes, err = testutils.ParseTypes(vals)

--- a/pkg/sql/opt/opt_test.go
+++ b/pkg/sql/opt/opt_test.go
@@ -124,16 +124,7 @@ func TestOpt(t *testing.T) {
 				evalCtx := tree.MakeTestingEvalContext(st)
 
 				for _, arg := range d.CmdArgs {
-					key := arg
-					val := ""
-					if pos := strings.Index(key, "="); pos >= 0 {
-						key = arg[:pos]
-						val = arg[pos+1:]
-					}
-					if len(val) > 2 && val[0] == '(' && val[len(val)-1] == ')' {
-						val = val[1 : len(val)-1]
-					}
-					vals := strings.Split(val, ",")
+					key, vals := arg.Key, arg.Vals
 					switch key {
 					case "vars":
 						varTypes, err = testutils.ParseTypes(vals)

--- a/pkg/sql/opt/optbuilder/builder_test.go
+++ b/pkg/sql/opt/optbuilder/builder_test.go
@@ -99,16 +99,7 @@ func TestBuilder(t *testing.T) {
 				var allowUnsupportedExpr bool
 
 				for _, arg := range d.CmdArgs {
-					key := arg
-					val := ""
-					if pos := strings.Index(key, "="); pos >= 0 {
-						key = arg[:pos]
-						val = arg[pos+1:]
-					}
-					if len(val) > 2 && val[0] == '(' && val[len(val)-1] == ')' {
-						val = val[1 : len(val)-1]
-					}
-					vals := strings.Split(val, ",")
+					key, vals := arg.Key, arg.Vals
 					switch key {
 					case "vars":
 						varTypes, err = testutils.ParseTypes(vals)

--- a/pkg/sql/opt/optgen/cmd/optgen/main_test.go
+++ b/pkg/sql/opt/optgen/cmd/optgen/main_test.go
@@ -50,7 +50,11 @@ func TestOptgen(t *testing.T) {
 					return strings.NewReader(d.Input), nil
 				}
 
-				gen.run(d.CmdArgs...)
+				args := make([]string, len(d.CmdArgs))
+				for i := range args {
+					args[i] = d.CmdArgs[i].String()
+				}
+				gen.run(args...)
 
 				// Suppress DO NOT EDIT so that reviewable will still show the
 				// file by default.

--- a/pkg/sql/opt/optgen/lang/scanner_test.go
+++ b/pkg/sql/opt/optgen/lang/scanner_test.go
@@ -37,11 +37,10 @@ func TestScanner(t *testing.T) {
 		// test case.
 		count := -1
 		for _, arg := range d.CmdArgs {
-			s := strings.Split(arg, "=")
-			if s[0] != "fail" {
+			if arg.Key != "fail" || len(arg.Vals) != 1 {
 				t.FailNow()
 			}
-			count, _ = strconv.Atoi(s[1])
+			count, _ = strconv.Atoi(arg.Vals[0])
 		}
 
 		r := io.Reader(strings.NewReader(d.Input))

--- a/pkg/testutils/datadriven/datadriven.go
+++ b/pkg/testutils/datadriven/datadriven.go
@@ -108,11 +108,38 @@ func RunTest(t *testing.T, path string, f func(d *TestData) string) {
 // TestData contains information about one data-driven test case that was
 // parsed from the test file.
 type TestData struct {
-	Pos      string // file and line number
-	Cmd      string
-	CmdArgs  []string
+	Pos string // file and line number
+
+	// Cmd is the first string on the directive line (up to the first whitespace).
+	Cmd string
+
+	CmdArgs []CmdArg
+
 	Input    string
 	Expected string
+}
+
+// CmdArg contains information about an argument on the directive line. An
+// argument is specified in one of the following forms:
+//  - argument
+//  - argument=value
+//  - argument=(values, ...)
+type CmdArg struct {
+	Key  string
+	Vals []string
+}
+
+func (arg *CmdArg) String() string {
+	switch len(arg.Vals) {
+	case 0:
+		return arg.Key
+
+	case 1:
+		return fmt.Sprintf("%s=%s", arg.Key, arg.Vals[0])
+
+	default:
+		return fmt.Sprintf("%s=(%s)", arg.Key, strings.Join(arg.Vals, ", "))
+	}
 }
 
 // Fatalf wraps a fatal testing error with test file position information, so

--- a/pkg/testutils/datadriven/test_data_reader.go
+++ b/pkg/testutils/datadriven/test_data_reader.go
@@ -83,7 +83,25 @@ func (r *testDataReader) Next(t *testing.T) bool {
 		cmd := fields[0]
 		r.data.Pos = fmt.Sprintf("%s:%d", r.path, r.scanner.line)
 		r.data.Cmd = cmd
-		r.data.CmdArgs = fields[1:]
+
+		for _, arg := range fields[1:] {
+			key := arg
+			var vals []string
+			if pos := strings.Index(key, "="); pos >= 0 {
+				key = arg[:pos]
+				val := arg[pos+1:]
+
+				if len(val) > 2 && val[0] == '(' && val[len(val)-1] == ')' {
+					vals = strings.Split(val[1:len(val)-1], ",")
+					for i := range vals {
+						vals[i] = strings.TrimSpace(vals[i])
+					}
+				} else {
+					vals = []string{val}
+				}
+			}
+			r.data.CmdArgs = append(r.data.CmdArgs, CmdArg{Key: key, Vals: vals})
+		}
 
 		var buf bytes.Buffer
 		var separator bool


### PR DESCRIPTION
We have a few separate places where we parse the args into keys and
values. Moving this code in the datadriven wrapper.

Release note: None