### PR TITLE
rpc: Heartbeat local connections too

### DIFF
--- a/pkg/rpc/context.go
+++ b/pkg/rpc/context.go
@@ -500,11 +500,6 @@ func (ctx *Context) GRPCDial(target string) *Connection {
 	conn.initOnce.Do(func() {
 		var redialChan <-chan struct{}
 		conn.grpcConn, redialChan, conn.dialErr = ctx.GRPCDialRaw(target)
-		if ctx.GetLocalInternalServerForAddr(target) != nil {
-			conn.heartbeatResult.Store(heartbeatResult{err: nil, everSucceeded: true})
-			conn.setInitialHeartbeatDone()
-			return
-		}
 		if conn.dialErr == nil {
 			if err := ctx.Stopper.RunTask(
 				ctx.masterCtx, "rpc.Context: grpc heartbeat", func(masterCtx context.Context) {


### PR DESCRIPTION
Local connections can fail if the machine's network configuration
changes (for example, if you turn wifi off on a laptop). We disabled
heartbeating of local connections in #16526 to work around a UI issue
(in which the UI would fail to recover after a local connection
failed). This relied on GRPC's internal reconnections, which were
disabled in #22658. This commit re-enables local heartbeats so that
our reconnection logic works as usual (In the meantime, the UI has
gotten better about error recovery, so #16526 is no longer necessary).

Fixes #22951

Release note (bug fix): The admin UI no longer hangs after a node's
network configuration has changed.