### PR TITLE
sql: fix insertNode iteration bug

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/upsert
+++ b/pkg/sql/logictest/testdata/logic_test/upsert
@@ -228,6 +228,13 @@ upsert INTO upsert_returning VALUES (1, 5, 4, 3), (6, 5, 4, 3) RETURNING *
 statement ok
 COMMIT
 
+# For #22300. Test UPSERT ... RETURNING with UNION.
+query I rowsort
+SELECT a FROM [UPSERT INTO upsert_returning VALUES (7) RETURNING a] UNION VALUES (8)
+----
+7
+8
+
 # For #6710. Add an unused column to disable the fast path which doesn't have this bug.
 statement ok
 CREATE TABLE issue_6710 (a INT PRIMARY KEY, b STRING, c INT)


### PR DESCRIPTION
Previously, multiple calls to insertNode.Values() without calling
Next() between would cause a panic. This manifested itself when the
result of an upsert was used in a union (and probably in other places
yet to be discovered.) I moved some logic from Values() into Next() so
that it can safely be called multiple times in a row.

Fixes #22300.

Release note (bug fix): Fixed a panic when UPSERT ... RETURNING was
combined with UNION.