### PR TITLE
cherrypick-1.1: storage: Avoid transferring leases to draining stores

### DIFF
--- a/pkg/storage/allocator.go
+++ b/pkg/storage/allocator.go
@@ -659,6 +659,14 @@ func (a *Allocator) TransferLeaseTarget(
 		return roachpb.ReplicaDescriptor{}
 	}
 
+	// Only consider live, non-draining replicas.
+	existing, _ = a.storePool.liveAndDeadReplicas(rangeID, existing)
+
+	// Short-circuit if there are no valid targets out there.
+	if len(existing) == 0 || (len(existing) == 1 && existing[0].StoreID == source.StoreID) {
+		return roachpb.ReplicaDescriptor{}
+	}
+
 	// Try to pick a replica to transfer the lease to while also determining
 	// whether we actually should be transferring the lease. The transfer
 	// decision is only needed if we've been asked to check the source.
@@ -727,6 +735,14 @@ func (a *Allocator) ShouldTransferLease(
 	sl, _, _ := a.storePool.getStoreList(rangeID, storeFilterNone)
 	sl = sl.filter(constraints)
 	log.VEventf(ctx, 3, "ShouldTransferLease (lease-holder=%d):\n%s", leaseStoreID, sl)
+
+	// Only consider live, non-draining replicas.
+	existing, _ = a.storePool.liveAndDeadReplicas(rangeID, existing)
+
+	// Short-circuit if there are no valid targets out there.
+	if len(existing) == 0 || (len(existing) == 1 && existing[0].StoreID == source.StoreID) {
+		return false
+	}
 
 	transferDec, _ := a.shouldTransferLeaseUsingStats(ctx, sl, source, existing, stats)
 	var result bool

--- a/pkg/storage/allocator_test.go
+++ b/pkg/storage/allocator_test.go
@@ -1208,6 +1208,80 @@ func TestAllocatorTransferLeaseTarget(t *testing.T) {
 	}
 }
 
+// TestAllocatorTransferLeaseTargetDraining verifies that the allocator will
+// not choose to transfer leases to a store that is draining.
+func TestAllocatorTransferLeaseTargetDraining(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	stopper, g, _, storePool, nl := createTestStorePool(
+		TestTimeUntilStoreDeadOff, true /* deterministic */, nodeStatusLive)
+	a := MakeAllocator(storePool, func(string) (time.Duration, bool) {
+		return 0, true
+	})
+	defer stopper.Stop(context.Background())
+
+	// 3 stores where the lease count for each store is equal to 100x the store
+	// ID. We'll be draining the store with the fewest leases on it.
+	var stores []*roachpb.StoreDescriptor
+	for i := 1; i <= 3; i++ {
+		stores = append(stores, &roachpb.StoreDescriptor{
+			StoreID:  roachpb.StoreID(i),
+			Node:     roachpb.NodeDescriptor{NodeID: roachpb.NodeID(i)},
+			Capacity: roachpb.StoreCapacity{LeaseCount: int32(100 * i)},
+		})
+	}
+	sg := gossiputil.NewStoreGossiper(g)
+	sg.GossipStores(stores, t)
+
+	// nodeStatusUnknown is the node liveness status used for a node that's draining.
+	nl.setNodeStatus(1, nodeStatusUnknown)
+
+	existing := []roachpb.ReplicaDescriptor{
+		{StoreID: 1},
+		{StoreID: 2},
+		{StoreID: 3},
+	}
+
+	testCases := []struct {
+		existing    []roachpb.ReplicaDescriptor
+		leaseholder roachpb.StoreID
+		check       bool
+		expected    roachpb.StoreID
+	}{
+		// No existing lease holder, nothing to do.
+		{existing: existing, leaseholder: 0, check: true, expected: 0},
+		// Store 1 is draining, so it will try to transfer its lease if
+		// checkTransferLeaseSource is false. This behavior isn't relied upon,
+		// though; leases are manually transferred when draining.
+		{existing: existing, leaseholder: 1, check: true, expected: 0},
+		{existing: existing, leaseholder: 1, check: false, expected: 2},
+		// Store 2 is not a lease transfer source.
+		{existing: existing, leaseholder: 2, check: true, expected: 0},
+		{existing: existing, leaseholder: 2, check: false, expected: 0},
+		// Store 3 is a lease transfer source, but won't transfer to
+		// node 1 because it's draining.
+		{existing: existing, leaseholder: 3, check: true, expected: 2},
+		{existing: existing, leaseholder: 3, check: false, expected: 2},
+	}
+	for _, c := range testCases {
+		t.Run("", func(t *testing.T) {
+			target := a.TransferLeaseTarget(
+				context.Background(),
+				config.Constraints{},
+				c.existing,
+				c.leaseholder,
+				0,
+				nil, /* replicaStats */
+				c.check,
+				true,  /* checkCandidateFullness */
+				false, /* alwaysAllowDecisionWithoutStats */
+			)
+			if c.expected != target.StoreID {
+				t.Fatalf("expected %d, but found %d", c.expected, target.StoreID)
+			}
+		})
+	}
+}
+
 func TestAllocatorTransferLeaseTargetMultiStore(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	stopper, g, _, a, _ := createTestAllocator( /* deterministic */ true)
@@ -1298,12 +1372,86 @@ func TestAllocatorShouldTransferLease(t *testing.T) {
 		{leaseholder: 1, existing: nil, expected: false},
 		{leaseholder: 2, existing: nil, expected: false},
 		{leaseholder: 3, existing: nil, expected: false},
+		{leaseholder: 4, existing: nil, expected: false},
 		{leaseholder: 3, existing: replicas(1), expected: true},
 		{leaseholder: 3, existing: replicas(1, 2), expected: true},
 		{leaseholder: 3, existing: replicas(2), expected: false},
 		{leaseholder: 3, existing: replicas(3), expected: false},
 		{leaseholder: 3, existing: replicas(4), expected: false},
-		{leaseholder: 4, existing: nil, expected: true},
+		{leaseholder: 4, existing: replicas(1), expected: true},
+		{leaseholder: 4, existing: replicas(2), expected: true},
+		{leaseholder: 4, existing: replicas(3), expected: true},
+		{leaseholder: 4, existing: replicas(1, 2, 3), expected: true},
+	}
+	for _, c := range testCases {
+		t.Run("", func(t *testing.T) {
+			result := a.ShouldTransferLease(
+				context.Background(),
+				config.Constraints{},
+				c.existing,
+				c.leaseholder,
+				0,
+				nil, /* replicaStats */
+			)
+			if c.expected != result {
+				t.Fatalf("expected %v, but found %v", c.expected, result)
+			}
+		})
+	}
+}
+
+func TestAllocatorShouldTransferLeaseDraining(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	stopper, g, _, storePool, nl := createTestStorePool(
+		TestTimeUntilStoreDeadOff, true /* deterministic */, nodeStatusLive)
+	a := MakeAllocator(storePool, func(string) (time.Duration, bool) {
+		return 0, true
+	})
+	defer stopper.Stop(context.Background())
+
+	// 4 stores where the lease count for each store is equal to 10x the store
+	// ID.
+	var stores []*roachpb.StoreDescriptor
+	for i := 1; i <= 4; i++ {
+		stores = append(stores, &roachpb.StoreDescriptor{
+			StoreID:  roachpb.StoreID(i),
+			Node:     roachpb.NodeDescriptor{NodeID: roachpb.NodeID(i)},
+			Capacity: roachpb.StoreCapacity{LeaseCount: int32(10 * i)},
+		})
+	}
+	sg := gossiputil.NewStoreGossiper(g)
+	sg.GossipStores(stores, t)
+
+	// nodeStatusUnknown is the node liveness status used for a node that's draining.
+	nl.setNodeStatus(1, nodeStatusUnknown)
+
+	replicas := func(storeIDs ...roachpb.StoreID) []roachpb.ReplicaDescriptor {
+		var r []roachpb.ReplicaDescriptor
+		for _, storeID := range storeIDs {
+			r = append(r, roachpb.ReplicaDescriptor{
+				StoreID: storeID,
+			})
+		}
+		return r
+	}
+
+	testCases := []struct {
+		leaseholder roachpb.StoreID
+		existing    []roachpb.ReplicaDescriptor
+		expected    bool
+	}{
+		{leaseholder: 1, existing: nil, expected: false},
+		{leaseholder: 2, existing: nil, expected: false},
+		{leaseholder: 3, existing: nil, expected: false},
+		{leaseholder: 4, existing: nil, expected: false},
+		{leaseholder: 2, existing: replicas(1), expected: false},
+		{leaseholder: 3, existing: replicas(1), expected: false},
+		{leaseholder: 3, existing: replicas(1, 2), expected: false},
+		{leaseholder: 3, existing: replicas(1, 2, 4), expected: false},
+		{leaseholder: 4, existing: replicas(1), expected: false},
+		{leaseholder: 4, existing: replicas(1, 2), expected: true},
+		{leaseholder: 4, existing: replicas(1, 3), expected: true},
+		{leaseholder: 4, existing: replicas(1, 2, 3), expected: true},
 	}
 	for _, c := range testCases {
 		t.Run("", func(t *testing.T) {


### PR DESCRIPTION
This was apparently never fully implemented/tested when draining was
first added.

In local testing with verbose logging enabled, I'm seeing leases
transfer back (or at least say that they were being transferred back)
to a draining store before it shut down, which was sometimes causing
brief (e.g. 3s) QPS outages.

Fixes #22573

Release note (bug fix): Avoid disruptions in performance when gracefully
shutting a node down.

----------------

Cherrypicks #23265 to release-1.1 to fix the behavior of the graceful shutdown process. I had to slightly tweak a few of the test constants to make this compile on the 1.1 branch, but the changes are identical otherwise. I'll merge this, the 2.0 cherrypick, and #23265 tomorrow if there are no more comments.