### PR TITLE
cherrypick-1.1: storage: transfer raft leadership and wait grace period when draining

### DIFF
--- a/pkg/storage/client_test.go
+++ b/pkg/storage/client_test.go
@@ -1208,7 +1208,7 @@ func (m *multiTestContext) getRaftLeader(rangeID roachpb.RangeID) *storage.Repli
 				// status yet.
 				continue
 			}
-			if raftStatus.Term > latestTerm {
+			if raftStatus.Term > latestTerm || (raftLeaderRepl == nil && raftStatus.Term == latestTerm) {
 				// If we find any newer term, it means any previous election is
 				// invalid.
 				raftLeaderRepl = nil

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -455,6 +455,11 @@ type Replica struct {
 		// Note that there are two replicaStateLoaders, in raftMu and mu,
 		// depending on which lock is being held.
 		stateLoader replicaStateLoader
+
+		// draining specifies whether this replica is draining. Raft leadership
+		// transfers due to a lease change will be attempted even if the target does
+		// not have all the log entries.
+		draining bool
 	}
 
 	unreachablesMu struct {

--- a/pkg/storage/replica_proposal.go
+++ b/pkg/storage/replica_proposal.go
@@ -622,8 +622,11 @@ func (r *Replica) maybeTransferRaftLeadership(ctx context.Context, target roachp
 	err := r.withRaftGroup(func(raftGroup *raft.RawNode) (bool, error) {
 		// Only the raft leader can attempt a leadership transfer.
 		if status := raftGroup.Status(); status.RaftState == raft.StateLeader {
-			// Only attempt this if the target has all the log entries.
-			if pr, ok := status.Progress[uint64(target)]; ok && pr.Match == r.mu.lastIndex {
+			// Only attempt this if the target has all the log entries. Although
+			// TransferLeader is supposed to do the right thing if the target is not
+			// caught up, this check avoids periods of 0 QPS:
+			// https://github.com/cockroachdb/cockroach/issues/22573#issuecomment-366106118
+			if pr, ok := status.Progress[uint64(target)]; (ok && pr.Match == r.mu.lastIndex) || r.mu.draining {
 				log.VEventf(ctx, 1, "transferring raft leadership to replica ID %v", target)
 				r.store.metrics.RangeRaftLeaderTransfers.Inc(1)
 				raftGroup.TransferLeader(uint64(target))


### PR DESCRIPTION
#22767 