### PR TITLE
cherrypick-2.0: sql: allow "request range lease" span in TestTrace

### DIFF
--- a/pkg/sql/trace_test.go
+++ b/pkg/sql/trace_test.go
@@ -41,6 +41,7 @@ func TestTrace(t *testing.T) {
 	// These are always appended, even without the test specifying it.
 	alwaysOptionalSpans := []string{
 		"[async] storage.pendingLeaseRequest: requesting lease",
+		"request range lease",
 		"range lookup",
 	}
 


### PR DESCRIPTION
Fixes #23238.

Release note: None