### PR TITLE
opt: Add null operand support for binary op type inference

### DIFF
--- a/pkg/sql/opt/xform/testdata/typing
+++ b/pkg/sql/opt/xform/testdata/typing
@@ -16,6 +16,15 @@ TABLE b
  └── INDEX primary
       └── x string not null
 
+exec-ddl
+CREATE TABLE unusual (x INT PRIMARY KEY, arr INT[])
+----
+TABLE unusual
+ ├── x int not null
+ ├── arr int[]
+ └── INDEX primary
+      └── x int not null
+
 # Variable
 build
 SELECT a.x FROM a
@@ -313,6 +322,47 @@ project
       │    └── variable: a.y [type=int]
       └── unary-complement [type=int]
            └── variable: a.x [type=int]
+
+# Array Concat
+build
+SELECT arr || arr, arr || NULL, NULL || arr FROM unusual
+----
+project
+ ├── columns: column3:int[]:null:3 column4:int[]:null:4 column5:int[]:null:5
+ ├── scan
+ │    └── columns: unusual.x:int:1 unusual.arr:int[]:null:2
+ └── projections
+      ├── concat [type=int[]]
+      │    ├── variable: unusual.arr [type=int[]]
+      │    └── variable: unusual.arr [type=int[]]
+      ├── concat [type=int[]]
+      │    ├── variable: unusual.arr [type=int[]]
+      │    └── const: NULL [type=unknown]
+      └── concat [type=int[]]
+           ├── const: NULL [type=unknown]
+           └── variable: unusual.arr [type=int[]]
+
+# Array Element Concat
+build
+SELECT x || arr, arr || x, x || NULL, NULL || x FROM unusual
+----
+project
+ ├── columns: column3:int[]:null:3 column4:int[]:null:4 column5:int[]:null:5 column6:int[]:null:6
+ ├── scan
+ │    └── columns: unusual.x:int:1 unusual.arr:int[]:null:2
+ └── projections
+      ├── concat [type=int[]]
+      │    ├── variable: unusual.x [type=int]
+      │    └── variable: unusual.arr [type=int[]]
+      ├── concat [type=int[]]
+      │    ├── variable: unusual.arr [type=int[]]
+      │    └── variable: unusual.x [type=int]
+      ├── concat [type=int[]]
+      │    ├── variable: unusual.x [type=int]
+      │    └── const: NULL [type=unknown]
+      └── concat [type=int[]]
+           ├── const: NULL [type=unknown]
+           └── variable: unusual.x [type=int]
 
 # Function with fixed return type.
 build

--- a/pkg/sql/opt/xform/typing.go
+++ b/pkg/sql/opt/xform/typing.go
@@ -139,8 +139,19 @@ func typeAsBinary(ev ExprView) types.T {
 	// right children.
 	for _, op := range tree.BinOps[binOp] {
 		o := op.(tree.BinOp)
-		if leftType.Equivalent(o.LeftType) && rightType.Equivalent(o.RightType) {
-			return o.ReturnType
+
+		if leftType == types.Unknown {
+			if rightType.Equivalent(o.RightType) {
+				return o.ReturnType
+			}
+		} else if rightType == types.Unknown {
+			if leftType.Equivalent(o.LeftType) {
+				return o.ReturnType
+			}
+		} else {
+			if leftType.Equivalent(o.LeftType) && rightType.Equivalent(o.RightType) {
+				return o.ReturnType
+			}
 		}
 	}
 

--- a/pkg/sql/opt/xform/typing_test.go
+++ b/pkg/sql/opt/xform/typing_test.go
@@ -62,6 +62,83 @@ func TestTypingJson(t *testing.T) {
 	testTyping(t, ev, types.String)
 }
 
+// TestTypingUnaryAssumptions ensures that unary overloads conform to certain
+// assumptions we're making in the type inference code:
+//   1. The return type can be inferred from the operator type and the data
+//      types of its operand.
+func TestTypingUnaryAssumptions(t *testing.T) {
+	for name, overloads := range tree.UnaryOps {
+		for i, overload := range overloads {
+			op := overload.(tree.UnaryOp)
+
+			// Check for basic ambiguity where two different unary op overloads
+			// both allow equivalent operand types.
+			for i2, overload2 := range overloads {
+				if i == i2 {
+					continue
+				}
+
+				op2 := overload2.(tree.UnaryOp)
+				if op.Typ.Equivalent(op2.Typ) {
+					format := "found equivalent operand type ambiguity for %s:\n%+v\n%+v"
+					t.Errorf(format, name, op, op2)
+				}
+			}
+		}
+	}
+}
+
+// TestTypingBinaryAssumptions ensures that binary overloads conform to certain
+// assumptions we're making in the type inference code:
+//   1. The return type can be inferred from the operator type and the data
+//      types of its operands.
+//   2. When of the operands is null, and if NullableArgs is true, then the
+//      return type can be inferred from just the non-null operand.
+func TestTypingBinaryAssumptions(t *testing.T) {
+	for name, overloads := range tree.BinOps {
+		for i, overload := range overloads {
+			op := overload.(tree.BinOp)
+
+			// Check for basic ambiguity where two different binary op overloads
+			// both allow equivalent operand types.
+			for i2, overload2 := range overloads {
+				if i == i2 {
+					continue
+				}
+
+				op2 := overload2.(tree.BinOp)
+				if op.LeftType.Equivalent(op2.LeftType) && op.RightType.Equivalent(op2.RightType) {
+					format := "found equivalent operand type ambiguity for %s:\n%+v\n%+v"
+					t.Errorf(format, name, op, op2)
+				}
+			}
+
+			// Handle ops that allow null operands. Check for ambiguity where
+			// the return type cannot be inferred from the non-null operand.
+			if op.NullableArgs {
+				for i2, overload2 := range overloads {
+					if i == i2 {
+						continue
+					}
+
+					op2 := overload2.(tree.BinOp)
+					if !op2.NullableArgs {
+						continue
+					}
+
+					if op.LeftType == op2.LeftType && op.ReturnType != op2.ReturnType {
+						t.Errorf("found null operand ambiguity for %s:\n%+v\n%+v", name, op, op2)
+					}
+
+					if op.RightType == op2.RightType && op.ReturnType != op2.ReturnType {
+						t.Errorf("found null operand ambiguity for %s:\n%+v\n%+v", name, op, op2)
+					}
+				}
+			}
+		}
+	}
+}
+
 func createTypingCatalog(t *testing.T) *testutils.TestCatalog {
 	cat := testutils.NewTestCatalog()
 	testutils.ExecuteTestDDL(t, "CREATE TABLE a (x INT PRIMARY KEY, y INT)", cat)


### PR DESCRIPTION
The type inference code was not handling the case where a binary op
has a null operand (left or right). Also add some test cases to ensure
that type inference assumptions stay non-ambiguous.

Release note: None