### PR TITLE
sql: fix panic for UPDATES on tables with an inverted index

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/inverted_index
+++ b/pkg/sql/logictest/testdata/logic_test/inverted_index
@@ -504,3 +504,190 @@ query T
 SELECT user_profile from users where user_profile @> '{"first_name":"Ernie"}';
 ----
  {"first_name": "Ernie", "location": "Brooklyn", "status": "Looking for treats"}
+
+statement ok
+CREATE TABLE update_test (i INT PRIMARY KEY, j JSONB, INVERTED INDEX(j));
+
+statement ok
+INSERT INTO update_test VALUES (1, '0');
+
+query IT
+SELECT * from update_test WHERE j @> '0';
+----
+1 0
+
+statement ok
+UPDATE update_test SET j = '{"a":"b", "c":"d"}' WHERE i = 1;
+
+query IT
+SELECT * from update_test WHERE j @> '0';
+----
+
+query IT
+SELECT * from update_test WHERE j @> '{"a":"b"}';
+----
+1 {"a": "b", "c": "d"}
+
+statement ok
+INSERT INTO update_test VALUES (2, '{"longKey1":"longValue1", "longKey2":"longValue2"}');
+
+statement ok
+UPDATE update_test SET j = ('"shortValue"') WHERE i = 2;
+
+query IT
+SELECT * from update_test where j @> '"shortValue"';
+----
+2 "shortValue"
+
+query IT
+SELECT * from update_test where j @> '{"longKey1":"longValue1"}}';
+----
+
+query IT
+SELECT * from update_test where j @> '{"longKey2":"longValue2"}}';
+----
+
+statement ok
+UPDATE update_test SET (i, j) = (10, '{"longKey1":"longValue1", "longKey2":"longValue2"}') WHERE i = 2;
+
+statement ok
+UPDATE update_test SET j = '{"a":"b", "a":"b"}' WHERE i = 1;
+
+statement ok
+UPDATE update_test SET (i, j) = (2, '["a", "a"]') WHERE i = 10;
+
+statement ok
+INSERT INTO update_test VALUES (3, '["a", "b", "c"]');
+
+query IT
+SELECT * from update_test where j @> '["a"]' ORDER BY i;
+----
+2 ["a", "a"]
+3 ["a", "b", "c"]
+
+statement ok
+UPDATE update_test SET j = '["b", "c", "e"]' WHERE i = 3;
+
+query IT
+SELECT * from update_test where j @> '["a"]' ORDER BY i;
+----
+2 ["a", "a"]
+
+query IT
+SELECT * from update_test where j @> '["b"]' ORDER BY i;
+----
+3 ["b", "c", "e"]
+
+
+statement ok
+INSERT INTO update_test VALUES (4, '["a", "b"]');
+
+statement ok
+UPDATE update_test SET j = '["b", "a"]' WHERE i = 4;
+
+query IT
+SELECT * from update_test where j @> '["a"]' ORDER BY i;
+----
+2 ["a", "a"]
+4 ["b", "a"]
+
+query IT
+SELECT * from update_test where j @> '["b"]' ORDER BY i;
+----
+3 ["b", "c", "e"]
+4 ["b", "a"]
+
+statement ok
+UPSERT INTO update_test VALUES (4, '["a", "b"]');
+
+query IT
+SELECT * from update_test where j @> '["a"]' ORDER BY i;
+----
+2 ["a", "a"]
+4 ["a", "b"]
+
+query IT
+SELECT * from update_test where j @> '["b"]' ORDER BY i;
+----
+3 ["b", "c", "e"]
+4 ["a", "b"]
+
+
+statement ok
+UPSERT INTO update_test VALUES (3, '["c", "e", "f"]');
+
+query IT
+SELECT * from update_test where j @> '["c"]' ORDER BY i;
+----
+3  ["c", "e", "f"]
+
+statement ok
+CREATE TABLE del_cascade_test (
+  delete_cascade INT NOT NULL REFERENCES update_test ON DELETE CASCADE
+ ,j JSONB
+ ,INVERTED INDEX(j)
+);
+
+
+statement ok
+CREATE TABLE update_cascade_test (
+ update_cascade INT NOT NULL REFERENCES update_test ON UPDATE CASCADE
+ ,j JSONB
+ ,INVERTED INDEX(j)
+);
+
+statement ok
+INSERT INTO del_cascade_test(delete_cascade, j) VALUES (1, '["a", "b"]'), (2, '{"a":"b", "c":"d"}'), (3, '["b", "c"]')
+
+
+query IT
+SELECT * from del_cascade_test ORDER BY delete_cascade;
+----
+1  ["a", "b"]
+2  {"a": "b", "c": "d"}
+3  ["b", "c"]
+
+statement ok
+DELETE FROM update_test where j @> '["c"]'
+
+query IT
+SELECT * from del_cascade_test ORDER BY delete_cascade;
+----
+1  ["a", "b"]
+2  {"a": "b", "c": "d"}
+
+query IT
+SELECT * from del_cascade_test ORDER BY delete_cascade;
+----
+1  ["a", "b"]
+2  {"a": "b", "c": "d"}
+
+statement ok
+INSERT INTO update_test VALUES (3, '["a", "b", "c"]');
+
+statement ok
+INSERT INTO update_cascade_test(update_cascade, j) VALUES (1, '["a", "b"]'), (2, '{"a":"b", "c":"d"}'), (3, '["b", "c"]')
+
+query IT
+SELECT * from update_cascade_test ORDER BY update_cascade;
+----
+1  ["a", "b"]
+2  {"a": "b", "c": "d"}
+3  ["b", "c"]
+
+statement error pq: foreign key violation: values \[1\] in columns \[i\] referenced in table "del_cascade_test"
+UPDATE update_test SET (i,j)  = (5, '{"a":"b", "a":"b"}') WHERE i = 1;
+
+statement ok
+DROP TABLE del_cascade_test
+
+statement ok
+UPDATE update_test SET (i,j)  = (5, '{"a":"b", "a":"b"}') WHERE i = 1;
+
+
+query IT
+SELECT * from update_cascade_test ORDER BY update_cascade;
+----
+2  {"a": "b", "c": "d"}
+3  ["b", "c"]
+5  ["a", "b"]

--- a/pkg/sql/sqlbase/fk.go
+++ b/pkg/sql/sqlbase/fk.go
@@ -568,8 +568,10 @@ func makeFKUpdateHelper(
 	return ret, err
 }
 
-func (fks fkUpdateHelper) addCheckForIndex(indexID IndexID) {
-	fks.indexIDsToCheck[indexID] = struct{}{}
+func (fks fkUpdateHelper) addCheckForIndex(indexID IndexID, descriptorType IndexDescriptor_Type) {
+	if descriptorType == IndexDescriptor_FORWARD {
+		fks.indexIDsToCheck[indexID] = struct{}{}
+	}
 }
 
 func (fks fkUpdateHelper) runIndexChecks(

--- a/pkg/sql/sqlbase/rowwriter.go
+++ b/pkg/sql/sqlbase/rowwriter.go
@@ -653,7 +653,7 @@ func (ru *RowUpdater) UpdateRow(
 		return nil, errors.Errorf("got %d values but expected %d", len(updateValues), len(ru.UpdateCols))
 	}
 
-	primaryIndexKey, secondaryIndexEntries, err := ru.Helper.encodeIndexes(ru.FetchColIDtoRowIndex, oldValues)
+	primaryIndexKey, oldSecondaryIndexEntries, err := ru.Helper.encodeIndexes(ru.FetchColIDtoRowIndex, oldValues)
 	if err != nil {
 		return nil, err
 	}
@@ -667,8 +667,8 @@ func (ru *RowUpdater) UpdateRow(
 	// The secondary index entries returned by rowHelper.encodeIndexes are only
 	// valid until the next call to encodeIndexes. We need to copy them so that
 	// we can compare against the new secondary index entries.
-	secondaryIndexEntries = append(ru.indexEntriesBuf[:0], secondaryIndexEntries...)
-	ru.indexEntriesBuf = secondaryIndexEntries
+	oldSecondaryIndexEntries = append(ru.indexEntriesBuf[:0], oldSecondaryIndexEntries...)
+	ru.indexEntriesBuf = oldSecondaryIndexEntries
 
 	// Check that the new value types match the column types. This needs to
 	// happen before index encoding because certain datum types (i.e. tuple)
@@ -712,10 +712,10 @@ func (ru *RowUpdater) UpdateRow(
 			return nil, err
 		}
 
-		ru.Fks.addCheckForIndex(ru.Helper.TableDesc.PrimaryIndex.ID)
-		for i := range newSecondaryIndexEntries {
-			if !bytes.Equal(newSecondaryIndexEntries[i].Key, secondaryIndexEntries[i].Key) {
-				ru.Fks.addCheckForIndex(ru.Helper.Indexes[i].ID)
+		ru.Fks.addCheckForIndex(ru.Helper.TableDesc.PrimaryIndex.ID, ru.Helper.TableDesc.PrimaryIndex.Type)
+		for i := range ru.Helper.Indexes {
+			if !bytes.Equal(newSecondaryIndexEntries[i].Key, oldSecondaryIndexEntries[i].Key) {
+				ru.Fks.addCheckForIndex(ru.Helper.Indexes[i].ID, ru.Helper.Indexes[i].Type)
 			}
 		}
 
@@ -842,33 +842,64 @@ func (ru *RowUpdater) UpdateRow(
 	}
 
 	// Update secondary indexes.
-	for i, newSecondaryIndexEntry := range newSecondaryIndexEntries {
-		secondaryIndexEntry := secondaryIndexEntries[i]
+	// We're iterating through all of the indexes, which should have corresponding entries in both oldSecondaryIndexEntries
+	// and newSecondaryIndexEntries. Inverted indexes could potentially have more entries at the end of both and we will
+	// update those separately.
+	for i, index := range ru.Helper.Indexes {
+		oldSecondaryIndexEntry := oldSecondaryIndexEntries[i]
+		newSecondaryIndexEntry := newSecondaryIndexEntries[i]
+
+		// We're skipping inverted indexes in this loop, but appending the inverted index entry to the back of
+		// newSecondaryIndexEntries to process later. For inverted indexes we need to remove all old entries before adding
+		// new ones.
+		if index.Type == IndexDescriptor_INVERTED {
+			newSecondaryIndexEntries = append(newSecondaryIndexEntries, newSecondaryIndexEntry)
+			oldSecondaryIndexEntries = append(oldSecondaryIndexEntries, oldSecondaryIndexEntry)
+
+			continue
+		}
+
 		var expValue interface{}
-		if !bytes.Equal(newSecondaryIndexEntry.Key, secondaryIndexEntry.Key) {
-			ru.Fks.addCheckForIndex(ru.Helper.Indexes[i].ID)
+		if !bytes.Equal(newSecondaryIndexEntry.Key, oldSecondaryIndexEntry.Key) {
+			ru.Fks.addCheckForIndex(ru.Helper.Indexes[i].ID, ru.Helper.Indexes[i].Type)
 			if traceKV {
-				log.VEventf(ctx, 2, "Del %s", keys.PrettyPrint(ru.Helper.secIndexValDirs[i], secondaryIndexEntry.Key))
+				log.VEventf(ctx, 2, "Del %s", keys.PrettyPrint(ru.Helper.secIndexValDirs[i], oldSecondaryIndexEntry.Key))
 			}
-			batch.Del(secondaryIndexEntry.Key)
-		} else if !bytes.Equal(newSecondaryIndexEntry.Value.RawBytes, secondaryIndexEntry.Value.RawBytes) {
-			expValue = &secondaryIndexEntry.Value
+			batch.Del(oldSecondaryIndexEntry.Key)
+		} else if !bytes.Equal(newSecondaryIndexEntry.Value.RawBytes, oldSecondaryIndexEntry.Value.RawBytes) {
+			expValue = &oldSecondaryIndexEntry.Value
 		} else {
 			continue
 		}
+
 		if traceKV {
 			log.VEventf(ctx, 2, "CPut %s -> %v", keys.PrettyPrint(ru.Helper.secIndexValDirs[i], newSecondaryIndexEntry.Key), newSecondaryIndexEntry.Value.PrettyPrint())
 		}
 		batch.CPut(newSecondaryIndexEntry.Key, &newSecondaryIndexEntry.Value, expValue)
 	}
 
-	// We're deleting indexes in a delete only state.
-	for i, deletedSecondaryIndexEntry := range deleteOldSecondaryIndexEntries {
-		ru.Fks.addCheckForIndex(ru.DeleteHelper.Indexes[i].ID)
-		if traceKV {
-			log.VEventf(ctx, 2, "Del %s", keys.PrettyPrint(ru.DeleteHelper.secIndexValDirs[i], deletedSecondaryIndexEntry.Key))
+	// We're deleting indexes in a delete only state. We're bounding this by the number of indexes because inverted
+	// indexed will be handled separately.
+	if ru.DeleteHelper != nil {
+		for i, deletedSecondaryIndexEntry := range deleteOldSecondaryIndexEntries {
+			if traceKV {
+				if i < len(ru.DeleteHelper.Indexes) {
+					log.VEventf(ctx, 2, "Del %s", oldSecondaryIndexEntries[i].Key)
+				}
+			}
+			batch.Del(deletedSecondaryIndexEntry.Key)
 		}
-		batch.Del(deletedSecondaryIndexEntry.Key)
+	}
+
+	// We're removing all of the inverted index entries from the row being updated.
+	for i := len(ru.Helper.Indexes); i < len(oldSecondaryIndexEntries); i++ {
+		batch.Del(oldSecondaryIndexEntries[i].Key)
+	}
+
+	putFn := insertInvertedPutFn
+	// We're adding all of the inverted index entries from the row being updated.
+	for i := len(ru.Helper.Indexes); i < len(newSecondaryIndexEntries); i++ {
+		putFn(ctx, b, &newSecondaryIndexEntries[i].Key, &newSecondaryIndexEntries[i].Value, traceKV)
 	}
 
 	if ru.cascader != nil {


### PR DESCRIPTION
Before this patch we would panic on updates to columns which had an
inverted index on them and the new column value would generate more
entries than the one being replaced.

After this patch we handle updates to indexes which generate a different
number of entries for the old and new values correctly.

Closes: #23290

Release note: None