### PR TITLE
rsg: skip running pg_sleep

### DIFF
--- a/pkg/sql/tests/rsg_test.go
+++ b/pkg/sql/tests/rsg_test.go
@@ -155,7 +155,7 @@ func TestRandomSyntaxFunctions(t *testing.T) {
 		for {
 			for name, variations := range builtins.Builtins {
 				switch strings.ToLower(name) {
-				case "crdb_internal.force_panic", "crdb_internal.force_log_fatal":
+				case "crdb_internal.force_panic", "crdb_internal.force_log_fatal", "pg_sleep":
 					continue
 				}
 				for _, builtin := range variations {


### PR DESCRIPTION
It causes timeouts, for obvious reasons.

Release note: None