### PR TITLE
workload: move control of sql connections inside workloads

### DIFF
--- a/pkg/cmd/workload/run.go
+++ b/pkg/cmd/workload/run.go
@@ -19,7 +19,6 @@ import (
 	"context"
 	gosql "database/sql"
 	"fmt"
-	"net/url"
 	"os"
 	"os/signal"
 	"runtime"
@@ -41,8 +40,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/workload"
 )
-
-const crdbDefaultURI = `postgres://root@localhost:26257?sslmode=disable`
 
 var runCmd = &cobra.Command{
 	Use:   `run`,
@@ -80,22 +77,11 @@ func init() {
 		if f, ok := gen.(workload.Flagser); ok {
 			genFlags = f.Flags().FlagSet
 		}
-		var genHooks workload.Hooks
-		if h, ok := gen.(workload.Hookser); ok {
-			genHooks = h.Hooks()
-		}
 
 		genInitCmd := &cobra.Command{Use: meta.Name, Short: meta.Description}
 		genInitCmd.Flags().AddFlagSet(initFlags)
 		genInitCmd.Flags().AddFlagSet(genFlags)
-		genInitCmd.RunE = func(cmd *cobra.Command, args []string) error {
-			if genHooks.Validate != nil {
-				if err := genHooks.Validate(); err != nil {
-					return err
-				}
-			}
-			return runInit(gen, args)
-		}
+		genInitCmd.RunE = cmdHelper(gen, runInit)
 		initCmd.AddCommand(genInitCmd)
 
 		genRunCmd := &cobra.Command{Use: meta.Name, Short: meta.Description}
@@ -107,32 +93,54 @@ func init() {
 			f.Usage += ` (implies --init)`
 			genRunCmd.Flags().AddFlag(&f)
 		})
-		genRunCmd.RunE = func(cmd *cobra.Command, args []string) error {
-			if genHooks.Validate != nil {
-				if err := genHooks.Validate(); err != nil {
-					return err
-				}
-			}
-			return runRun(gen, args)
-		}
+		genRunCmd.RunE = cmdHelper(gen, runRun)
 		runCmd.AddCommand(genRunCmd)
 	}
 	rootCmd.AddCommand(initCmd)
 	rootCmd.AddCommand(runCmd)
 }
 
+func cmdHelper(
+	gen workload.Generator, fn func(gen workload.Generator, urls []string, dbName string) error,
+) func(*cobra.Command, []string) error {
+	const crdbDefaultURL = `postgres://root@localhost:26257?sslmode=disable`
+
+	return func(cmd *cobra.Command, args []string) error {
+		if h, ok := gen.(workload.Hookser); ok {
+			if err := h.Hooks().Validate(); err != nil {
+				return err
+			}
+		}
+
+		// HACK: Steal the dbOverride out of flags. This should go away
+		// once more of run.go moves inside workload.
+		var dbOverride string
+		if dbFlag := cmd.Flag(`db`); dbFlag != nil {
+			dbOverride = dbFlag.Value.String()
+		}
+		urls := args
+		if len(urls) == 0 {
+			urls = []string{crdbDefaultURL}
+		}
+		dbName, err := workload.SanitizeUrls(gen, dbOverride, urls)
+		if err != nil {
+			return err
+		}
+		return fn(gen, urls, dbName)
+	}
+}
+
 // numOps keeps a global count of successful operations.
 var numOps uint64
 
-type worker struct {
-	db *gosql.DB
-	op func(context.Context) error
-}
-
-// run is an infinite loop in which the worker continuously attempts to
+// workerRun is an infinite loop in which the worker continuously attempts to
 // read / write blocks of random data into a table in cockroach DB.
-func (w *worker) run(
-	ctx context.Context, errCh chan<- error, wg *sync.WaitGroup, limiter *rate.Limiter,
+func workerRun(
+	ctx context.Context,
+	errCh chan<- error,
+	wg *sync.WaitGroup,
+	limiter *rate.Limiter,
+	workFn func(context.Context) error,
 ) {
 	defer wg.Done()
 
@@ -144,7 +152,7 @@ func (w *worker) run(
 			}
 		}
 
-		if err := w.op(ctx); err != nil {
+		if err := workFn(ctx); err != nil {
 			errCh <- err
 			continue
 		}
@@ -156,113 +164,46 @@ func (w *worker) run(
 	}
 }
 
-func sanitizeDBURL(dbURL string) (string, error) {
-	parsedURL, err := url.Parse(dbURL)
-	if err != nil {
-		return "", err
-	}
-	if strings.TrimPrefix(parsedURL.Path, "/") != "" {
-		return "", fmt.Errorf(
-			`database URL specifies database %q, but database "test" is always used`, parsedURL.Path)
-	}
-	parsedURL.Path = "test"
-
-	switch parsedURL.Scheme {
-	case "postgres", "postgresql":
-		return parsedURL.String(), nil
-	default:
-		return "", fmt.Errorf("unsupported database: %s", parsedURL.Scheme)
-	}
-}
-
-func setupCockroach(dbURLs []string) (*gosql.DB, error) {
-	if len(dbURLs) == 0 {
-		dbURLs = []string{crdbDefaultURI}
-	}
-
-	var sanitizedURLs = make([]string, len(dbURLs))
-	for i, dbURL := range dbURLs {
-		var err error
-		sanitizedURLs[i], err = sanitizeDBURL(dbURL)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	// Open connection to server and create a database.
-	db, err := gosql.Open("cockroach", strings.Join(sanitizedURLs, " "))
-	if err != nil {
-		return nil, err
-	}
-
-	// Allow a maximum of concurrency+1 connections to the database.
-	db.SetMaxOpenConns(*concurrency + 1)
-	db.SetMaxIdleConns(*concurrency + 1)
-
-	return db, nil
-}
-
-func runInit(gen workload.Generator, args []string) error {
-	db, err := setupCockroach(args)
+func runInit(gen workload.Generator, urls []string, dbName string) error {
+	initDB, err := gosql.Open(`cockroach`, strings.Join(urls, ` `))
 	if err != nil {
 		return err
 	}
 
-	return runInitImpl(gen, db)
+	return runInitImpl(gen, initDB, dbName)
 }
 
-func runInitImpl(gen workload.Generator, db *gosql.DB) error {
+func runInitImpl(gen workload.Generator, initDB *gosql.DB, dbName string) error {
 	if *drop {
-		if _, err := db.Exec(`DROP DATABASE IF EXISTS test`); err != nil {
+		if _, err := initDB.Exec(`DROP DATABASE IF EXISTS ` + dbName); err != nil {
 			return err
 		}
 	}
-	if _, err := db.Exec("CREATE DATABASE IF NOT EXISTS test"); err != nil {
+	if _, err := initDB.Exec(`CREATE DATABASE IF NOT EXISTS ` + dbName); err != nil {
 		return err
 	}
 
 	const batchSize = -1
-	_, err := workload.Setup(db, gen, batchSize)
+	_, err := workload.Setup(initDB, gen, batchSize)
 	return err
 }
 
-func runRun(gen workload.Generator, args []string) error {
+func runRun(gen workload.Generator, urls []string, dbName string) error {
 	ctx := context.Background()
 
-	if *concurrency < 1 {
-		return errors.Errorf(
-			"Value of 'concurrency' flag (%d) must be greater than or equal to 1", *concurrency)
+	initDB, err := gosql.Open(`cockroach`, strings.Join(urls, ` `))
+	if err != nil {
+		return err
 	}
-
-	var db *gosql.DB
-	{
-		var err error
-		for {
-			db, err = setupCockroach(args)
-			if err == nil {
-				break
-			}
-			if !*tolerateErrors {
-				return err
-			}
-		}
-	}
-
 	if *doInit || *drop {
-		var err error
 		for {
-			err = runInitImpl(gen, db)
+			err = runInitImpl(gen, initDB, dbName)
 			if err == nil {
 				break
 			}
 			if !*tolerateErrors {
 				return err
 			}
-		}
-	}
-	for _, table := range gen.Tables() {
-		if err := workload.Split(ctx, db, table, *concurrency); err != nil {
-			return err
 		}
 	}
 
@@ -273,28 +214,30 @@ func runRun(gen workload.Generator, args []string) error {
 		limiter = rate.NewLimiter(rate.Limit(*maxRate), 1)
 	}
 
-	var ops workload.Operations
-	if o, ok := gen.(workload.Opser); ok {
-		ops = o.Ops()
-	}
-	if ops.Fn == nil {
+	o, ok := gen.(workload.Opser)
+	if !ok {
 		return errors.Errorf(`no operations defined for %s`, gen.Meta().Name)
+	}
+	reg := workload.NewHistogramRegistry()
+	ops, err := o.Ops(urls, reg)
+	if err != nil {
+		return err
+	}
+
+	for _, table := range gen.Tables() {
+		splitConcurrency := len(ops.WorkerFns)
+		if err := workload.Split(ctx, initDB, table, splitConcurrency); err != nil {
+			return err
+		}
 	}
 
 	start := timeutil.Now()
-	reg := workload.NewHistogramRegistry()
-	workers := make([]*worker, *concurrency)
-
 	errCh := make(chan error)
 	var wg sync.WaitGroup
-	for i := range workers {
+	for _, workFn := range ops.WorkerFns {
+		workFn := workFn
 		wg.Add(1)
-		opFn, err := ops.Fn(db, reg)
-		if err != nil {
-			return err
-		}
-		workers[i] = &worker{db: db, op: opFn}
-		go workers[i].run(ctx, errCh, &wg, limiter)
+		go workerRun(ctx, errCh, &wg, limiter, workFn)
 	}
 
 	var numErr int

--- a/pkg/workload/connection.go
+++ b/pkg/workload/connection.go
@@ -1,0 +1,77 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package workload
+
+import (
+	"fmt"
+	"net/url"
+	"runtime"
+	"strings"
+
+	"github.com/spf13/pflag"
+)
+
+// ConnFlags is helper of common flags that are relevant to QueryLoads.
+type ConnFlags struct {
+	*pflag.FlagSet
+	DBOverride  string
+	Concurrency int
+}
+
+// NewConnFlags returns an initialized ConnFlags.
+func NewConnFlags(genFlags *Flags) *ConnFlags {
+	c := &ConnFlags{}
+	c.FlagSet = pflag.NewFlagSet(`conn`, pflag.ContinueOnError)
+	c.StringVar(&c.DBOverride, `db`, ``,
+		`Override for the SQL database to use. If empty, defaults to the generator name`)
+	c.IntVar(&c.Concurrency, `concurrency`, 2*runtime.NumCPU(),
+		`Number of concurrent workers`)
+	genFlags.AddFlagSet(c.FlagSet)
+	if genFlags.Meta == nil {
+		genFlags.Meta = make(map[string]FlagMeta)
+	}
+	genFlags.Meta[`db`] = FlagMeta{RuntimeOnly: true}
+	genFlags.Meta[`concurrency`] = FlagMeta{RuntimeOnly: true}
+	return c
+}
+
+// SanitizeUrls verifies that the give SQL connection strings have the correct
+// SQL database set, rewriting them in place if necessary. This database name is
+// returned.
+func SanitizeUrls(gen Generator, dbOverride string, urls []string) (string, error) {
+	dbName := gen.Meta().Name
+	if dbOverride != `` {
+		dbName = dbOverride
+	}
+	for i := range urls {
+		parsed, err := url.Parse(urls[i])
+		if err != nil {
+			return "", err
+		}
+		if d := strings.TrimPrefix(parsed.Path, `/`); d != `` && d != dbName {
+			return "", fmt.Errorf(`%s specifies database %q, but database %q is expected`,
+				urls[i], d, dbName)
+		}
+		parsed.Path = dbName
+
+		switch parsed.Scheme {
+		case "postgres", "postgresql":
+			urls[i] = parsed.String()
+		default:
+			return ``, fmt.Errorf(`unsupported scheme: %s`, parsed.Scheme)
+		}
+	}
+	return dbName, nil
+}

--- a/pkg/workload/driver.go
+++ b/pkg/workload/driver.go
@@ -13,7 +13,7 @@
 // permissions and limitations under the License. See the AUTHORS file
 // for names of contributors.
 
-package main
+package workload
 
 import (
 	gosql "database/sql"

--- a/pkg/workload/tpcc/worker.go
+++ b/pkg/workload/tpcc/worker.go
@@ -115,11 +115,6 @@ func initializeMix(config *tpcc) error {
 }
 
 func (w *worker) run(ctx context.Context) error {
-	// TODO(dan): Remove this when the real check in Hooks.Validate is added.
-	if w.config.doWaits && w.warehouse >= w.config.warehouses {
-		return errors.New(`--wait=true expects 10 workers per warehouse`)
-	}
-
 	transactionType := rand.Intn(w.config.totalWeight)
 	weightSum := 0
 	var t tx

--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -73,7 +73,7 @@ type Flagser interface {
 // to have been created and initialized before running these.
 type Opser interface {
 	Generator
-	Ops() Operations
+	Ops(urls []string, reg *HistogramRegistry) (QueryLoad, error)
 }
 
 // Hookser returns any hooks associated with the generator.
@@ -129,17 +129,14 @@ type Table struct {
 	SplitFn func(int) []interface{}
 }
 
-// Operations represents some SQL query workload performable on a database
+// QueryLoad represents some SQL query workload performable on a database
 // initialized with the requisite tables.
-//
-// TODO(dan): Finish nailing down the invariants of Operations as more workloads
-// are ported to this framework. TPCC in particular should be informative.
-type Operations struct {
-	// Name is a name for the work performed.
-	Name string
-	// Fn returns a function to be called once per unit of work to be done.
-	// Various generator tools use this to track progress.
-	Fn func(*gosql.DB, *HistogramRegistry) (func(context.Context) error, error)
+type QueryLoad struct {
+	SQLDatabase string
+
+	// WorkerFns one function per worker. It is to be called once per unit of
+	// work to be done.
+	WorkerFns []func(context.Context) error
 
 	// ResultHist is the name of the NamedHistogram to use for the benchmark
 	// formatted results output at the end of `./workload run`. The empty string


### PR DESCRIPTION
Part of the general effort to avoid prescription by movinv more of
run.go inside the workloads. Specifically motivated by TPCC wanting to
pin workers to connections.

This also unifies selecting which SQL database to use.

Release note: None