### PR TITLE
acceptance: fix timeouts due to server.shutdown.drain_wait

### DIFF
--- a/pkg/acceptance/decommission_test.go
+++ b/pkg/acceptance/decommission_test.go
@@ -122,8 +122,7 @@ func testDecommissionInner(
 		}
 	}
 
-	withDB(1, "SET CLUSTER SETTING server.remote_debugging.mode = 'any';"+
-		"SET CLUSTER SETTING server.shutdown.drain_wait='0s'")
+	withDB(1, "SET CLUSTER SETTING server.remote_debugging.mode = 'any';")
 
 	// Get the ids for each node.
 	idMap := make(map[int]roachpb.NodeID)


### PR DESCRIPTION
PR #23233 added a 15s wait to the drain process, some acceptance tests
would time out because of this.

Release note: None

Will cherrypick into 2.0