### PR TITLE
workload/tpch: port loadgen/tpch to implement workload.Generator 

### DIFF
--- a/pkg/ccl/workloadccl/allccl/all.go
+++ b/pkg/ccl/workloadccl/allccl/all.go
@@ -18,5 +18,6 @@ import (
 	_ "github.com/cockroachdb/cockroach/pkg/workload/examples"
 	_ "github.com/cockroachdb/cockroach/pkg/workload/kv"
 	_ "github.com/cockroachdb/cockroach/pkg/workload/tpcc"
+	_ "github.com/cockroachdb/cockroach/pkg/workload/tpch"
 	_ "github.com/cockroachdb/cockroach/pkg/workload/ycsb"
 )

--- a/pkg/workload/tpch/queries.go
+++ b/pkg/workload/tpch/queries.go
@@ -1,0 +1,736 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+
+package tpch
+
+var queriesByName = map[string]string{
+	`1`:  query1,
+	`2`:  query2,
+	`3`:  query3,
+	`4`:  query4,
+	`5`:  query5,
+	`6`:  query6,
+	`7`:  query7,
+	`8`:  query8,
+	`9`:  query9,
+	`10`: query10,
+	`11`: query11,
+	`12`: query12,
+	`13`: query13,
+	`14`: query14,
+	`15`: query15,
+	`16`: query16,
+	`17`: query17,
+	`18`: query18,
+	`19`: query19,
+	`20`: query20,
+	`21`: query21,
+	`22`: query22,
+}
+
+const (
+	query1 = `
+SELECT
+	l_returnflag,
+	l_linestatus,
+	SUM(l_quantity) AS sum_qty,
+	SUM(l_extendedprice) AS sum_base_price,
+	SUM(l_extendedprice * (1 - l_discount)) AS sum_disc_price,
+	SUM(l_extendedprice * (1 - l_discount) * (1 + l_tax)) AS sum_charge,
+	AVG(l_quantity) AS avg_qty,
+	AVG(l_extendedprice) AS avg_price,
+	AVG(l_discount) AS avg_disc,
+	COUNT(*) AS count_order
+FROM
+	lineitem
+WHERE
+	l_shipdate <= DATE '1998-12-01' - INTERVAL '95' DAY
+GROUP BY
+	l_returnflag,
+	l_linestatus
+ORDER BY
+	l_returnflag,
+	l_linestatus;
+`
+
+	query2 = `
+SELECT
+	s_acctbal,
+	s_name,
+	n_name,
+	p_partkey,
+	p_mfgr,
+	s_address,
+	s_phone,
+	s_comment
+FROM
+	part,
+	supplier,
+	partsupp,
+	nation,
+	region
+WHERE
+	p_partkey = ps_partkey
+	AND s_suppkey = ps_suppkey
+	AND p_size = 42
+	AND p_type LIKE '%STEEL'
+	AND s_nationkey = n_nationkey
+	AND n_regionkey = r_regionkey
+	AND r_name = 'AMERICA'
+	AND ps_supplycost = (
+		SELECT
+			min(ps_supplycost)
+		FROM
+			partsupp,
+			supplier,
+			nation,
+			region
+		WHERE
+			p_partkey = ps_partkey
+			AND s_suppkey = ps_suppkey
+			AND s_nationkey = n_nationkey
+			AND n_regionkey = r_regionkey
+			AND r_name = 'AMERICA'
+	)
+ORDER BY
+	s_acctbal DESC,
+	n_name,
+	s_name,
+	p_partkey;
+`
+
+	query3 = `
+SELECT
+	l_orderkey,
+	SUM(l_extendedprice * (1 - l_discount)) AS revenue,
+	o_orderdate,
+	o_shippriority
+FROM
+	customer,
+	orders,
+	lineitem
+WHERE
+	c_mktsegment = 'MACHINERY'
+	AND c_custkey = o_custkey
+	AND l_orderkey = o_orderkey
+	AND o_orderDATE < DATE '1995-03-10'
+	AND l_shipdate > DATE '1995-03-10'
+GROUP BY
+	l_orderkey,
+	o_orderdate,
+	o_shippriority
+ORDER BY
+	revenue DESC,
+	o_orderdate;
+`
+
+	query4 = `
+SELECT
+	o_orderpriority,
+	COUNT(*) AS order_count
+FROM
+	orders
+WHERE
+	o_orderdate >= DATE '1994-08-01'
+	AND o_orderdate < DATE '1994-08-01' + INTERVAL '3' MONTH
+	AND EXISTS (
+		SELECT
+			*
+		FROM
+			lineitem
+		WHERE
+			l_orderkey = o_orderkey
+			AND l_commitDATE < l_receiptdate
+	)
+GROUP BY
+	o_orderpriority
+ORDER BY
+	o_orderpriority;
+`
+
+	query5 = `
+SELECT
+	n_name,
+	SUM(l_extendedprice * (1 - l_discount)) AS revenue
+FROM
+	customer,
+	orders,
+	lineitem,
+	supplier,
+	nation,
+	region
+WHERE
+	c_custkey = o_custkey
+	AND l_orderkey = o_orderkey
+	AND l_suppkey = s_suppkey
+	AND c_nationkey = s_nationkey
+	AND s_nationkey = n_nationkey
+	AND n_regionkey = r_regionkey
+	AND r_name = 'AFRICA'
+	AND o_orderDATE >= DATE '1997-01-01'
+	AND o_orderDATE < DATE '1997-01-01' + INTERVAL '1' YEAR
+GROUP BY
+	n_name
+ORDER BY
+	revenue DESC;
+`
+
+	query6 = `
+SELECT
+	SUM(l_extendedprice * l_discount) AS revenue
+FROM
+	lineitem
+WHERE
+	l_shipdate >= DATE '1997-01-01'
+	AND l_shipdate < DATE '1997-01-01' + INTERVAL '1' YEAR
+	AND l_discount BETWEEN 0.07 - 0.01 AND 0.07 + 0.01
+	AND l_quantity < 24;
+`
+
+	query7 = `
+SELECT
+	supp_nation,
+	cust_nation,
+	l_year,
+	SUM(volume) AS revenue
+FROM
+	(
+		SELECT
+			n1.n_name AS supp_nation,
+			n2.n_name AS cust_nation,
+			EXTRACT(year FROM l_shipdate) AS l_year,
+			l_extendedprice * (1 - l_discount) AS volume
+		FROM
+			supplier,
+			lineitem,
+			orders,
+			customer,
+			nation n1,
+			nation n2
+		WHERE
+			s_suppkey = l_suppkey
+			AND o_orderkey = l_orderkey
+			AND c_custkey = o_custkey
+			AND s_nationkey = n1.n_nationkey
+			AND c_nationkey = n2.n_nationkey
+			AND (
+				(n1.n_name = 'MOZAMBIQUE' AND n2.n_name = 'CANADA')
+				or (n1.n_name = 'CANADA' AND n2.n_name = 'MOZAMBIQUE')
+			)
+			AND l_shipdate BETWEEN DATE '1995-01-01' AND DATE '1996-12-31'
+	) AS shipping
+GROUP BY
+	supp_nation,
+	cust_nation,
+	l_year
+ORDER BY
+	supp_nation,
+	cust_nation,
+	l_year;
+`
+
+	query8 = `
+SELECT
+	o_year,
+	SUM(CASE
+		WHEN nation = 'CANADA' THEN volume
+		ELSE 0
+	END) / SUM(volume) AS mkt_share
+FROM
+	(
+		SELECT
+			EXTRACT(year FROM o_orderdate) AS o_year,
+			l_extendedprice * (1 - l_discount) AS volume,
+			n2.n_name AS nation
+		FROM
+			part,
+			supplier,
+			lineitem,
+			orders,
+			customer,
+			nation n1,
+			nation n2,
+			region
+		WHERE
+			p_partkey = l_partkey
+			AND s_suppkey = l_suppkey
+			AND l_orderkey = o_orderkey
+			AND o_custkey = c_custkey
+			AND c_nationkey = n1.n_nationkey
+			AND n1.n_regionkey = r_regionkey
+			AND r_name = 'AMERICA'
+			AND s_nationkey = n2.n_nationkey
+			AND o_orderdate BETWEEN DATE '1995-01-01' AND DATE '1996-12-31'
+			AND p_type = 'ECONOMY POLISHED STEEL'
+	) AS all_nations
+GROUP BY
+	o_year
+ORDER BY
+	o_year;
+`
+
+	query9 = `
+SELECT
+	nation,
+	o_year,
+	SUM(amount) AS sum_profit
+FROM
+	(
+		SELECT
+			n_name AS nation,
+			EXTRACT(year FROM o_orderdate) AS o_year,
+			l_extendedprice * (1 - l_discount) - ps_supplycost * l_quantity AS amount
+		FROM
+			part,
+			supplier,
+			lineitem,
+			partsupp,
+			orders,
+			nation
+		WHERE
+			s_suppkey = l_suppkey
+			AND ps_suppkey = l_suppkey
+			AND ps_partkey = l_partkey
+			AND p_partkey = l_partkey
+			AND o_orderkey = l_orderkey
+			AND s_nationkey = n_nationkey
+			AND p_name LIKE '%royal%'
+	) AS profit
+GROUP BY
+	nation,
+	o_year
+ORDER BY
+	nation,
+	o_year DESC;
+`
+
+	query10 = `
+SELECT
+	c_custkey,
+	c_name,
+	SUM(l_extendedprice * (1 - l_discount)) AS revenue,
+	c_acctbal,
+	n_name,
+	c_address,
+	c_phone,
+	c_comment
+FROM
+	customer,
+	orders,
+	lineitem,
+	nation
+WHERE
+	c_custkey = o_custkey
+	AND l_orderkey = o_orderkey
+	AND o_orderDATE >= DATE '1994-12-01'
+	AND o_orderDATE < DATE '1994-12-01' + INTERVAL '3' MONTH
+	AND l_returnflag = 'R'
+	AND c_nationkey = n_nationkey
+GROUP BY
+	c_custkey,
+	c_name,
+	c_acctbal,
+	c_phone,
+	n_name,
+	c_address,
+	c_comment
+ORDER BY
+	revenue DESC;
+`
+
+	query11 = `
+SELECT
+	ps_partkey,
+	SUM(ps_supplycost * ps_availqty) AS value
+FROM
+	partsupp,
+	supplier,
+	nation
+WHERE
+	ps_suppkey = s_suppkey
+	AND s_nationkey = n_nationkey
+	AND n_name = 'ETHIOPIA'
+GROUP BY
+	ps_partkey HAVING
+		SUM(ps_supplycost * ps_availqty) > (
+			SELECT
+				SUM(ps_supplycost * ps_availqty) * 0.0000003333
+			FROM
+				partsupp,
+				supplier,
+				nation
+			WHERE
+				ps_suppkey = s_suppkey
+				AND s_nationkey = n_nationkey
+				AND n_name = 'ETHIOPIA'
+		)
+ORDER BY
+	value DESC;
+`
+
+	query12 = `
+SELECT
+	l_shipmode,
+	SUM(CASE
+		WHEN o_orderpriority = '1-URGENT'
+			or o_orderpriority = '2-HIGH'
+			THEN 1
+		ELSE 0
+	END) AS high_line_count,
+	SUM(CASE
+		WHEN o_orderpriority <> '1-URGENT'
+			AND o_orderpriority <> '2-HIGH'
+			THEN 1
+		ELSE 0
+	END) AS low_line_count
+FROM
+	orders,
+	lineitem
+WHERE
+	o_orderkey = l_orderkey
+	AND l_shipmode IN ('AIR', 'REG AIR')
+	AND l_commitdate < l_receiptdate
+	AND l_shipdate < l_commitdate
+	AND l_receiptdate >= DATE '1997-01-01'
+	AND l_receiptdate < DATE '1997-01-01' + INTERVAL '1' YEAR
+GROUP BY
+	l_shipmode
+ORDER BY
+	l_shipmode;
+`
+
+	query13 = `
+SELECT
+	c_count,
+	COUNT(*) AS custdist
+FROM
+	(
+		SELECT
+			c_custkey,
+			COUNT(o_orderkey) AS c_count
+		FROM
+			customer LEFT OUTER JOIN orders ON
+				c_custkey = o_custkey
+				AND o_comment NOT LIKE '%special%deposits%'
+		GROUP BY
+			c_custkey
+	) AS c_orders
+GROUP BY
+	c_count
+ORDER BY
+	custdist DESC,
+	c_count DESC;
+`
+
+	query14 = `
+SELECT
+	100.00 * SUM(CASE
+		WHEN p_type LIKE 'PROMO%'
+			THEN l_extendedprice * (1 - l_discount)
+		ELSE 0
+	END) / SUM(l_extendedprice * (1 - l_discount)) AS promo_revenue
+FROM
+	lineitem,
+	part
+WHERE
+	l_partkey = p_partkey
+	AND l_shipdate >= DATE '1997-04-01'
+	AND l_shipdate < DATE '1997-04-01' + INTERVAL '1' MONTH;
+`
+
+	query15 = `
+CREATE VIEW revenue0 (supplier_no, total_revenue) AS
+	SELECT
+		l_suppkey,
+		SUM(l_extendedprice * (1 - l_discount))
+	FROM
+		lineitem
+	WHERE
+		l_shipdate >= DATE '1997-03-01'
+		AND l_shipdate < DATE '1997-03-01' + INTERVAL '3' MONTH
+	GROUP BY
+		l_suppkey;
+
+SELECT
+	s_suppkey,
+	s_name,
+	s_address,
+	s_phone,
+	total_revenue
+FROM
+	supplier,
+	revenue0
+WHERE
+	s_suppkey = supplier_no
+	AND total_revenue = (
+		SELECT
+			MAX(total_revenue)
+		FROM
+			revenue0
+	)
+ORDER BY
+	s_suppkey;
+
+DROP VIEW revenue0;
+`
+
+	query16 = `
+SELECT
+	p_brand,
+	p_type,
+	p_size,
+	COUNT(distinct ps_suppkey) AS supplier_cnt
+FROM
+	partsupp,
+	part
+WHERE
+	p_partkey = ps_partkey
+	AND p_brand <> 'Brand#41'
+	AND p_type NOT LIKE 'ECONOMY BURNISHED%'
+	AND p_size IN (22, 33, 42, 5, 27, 49, 4, 18)
+	AND ps_suppkey NOT IN (
+		SELECT
+			s_suppkey
+		FROM
+			supplier
+		WHERE
+			s_comment LIKE '%Customer%Complaints%'
+	)
+GROUP BY
+	p_brand,
+	p_type,
+	p_size
+ORDER BY
+	supplier_cnt DESC,
+	p_brand,
+	p_type,
+	p_size;
+`
+
+	query17 = `
+SELECT
+	SUM(l_extendedprice) / 7.0 AS avg_yearly
+FROM
+	lineitem,
+	part
+WHERE
+	p_partkey = l_partkey
+	AND p_brand = 'Brand#14'
+	AND p_container = 'MED BOX'
+	AND l_quantity < (
+		SELECT
+			0.2 * AVG(l_quantity)
+		FROM
+			lineitem
+		WHERE
+			l_partkey = p_partkey
+	);
+`
+
+	query18 = `
+SELECT
+	c_name,
+	c_custkey,
+	o_orderkey,
+	o_orderdate,
+	o_totalprice,
+	SUM(l_quantity)
+FROM
+	customer,
+	orders,
+	lineitem
+WHERE
+	o_orderkey IN (
+		SELECT
+			l_orderkey
+		FROM
+			lineitem
+		GROUP BY
+			l_orderkey HAVING
+				SUM(l_quantity) > 314
+	)
+	AND c_custkey = o_custkey
+	AND o_orderkey = l_orderkey
+GROUP BY
+	c_name,
+	c_custkey,
+	o_orderkey,
+	o_orderdate,
+	o_totalprice
+ORDER BY
+	o_totalprice DESC,
+	o_orderdate;
+`
+
+	query19 = `
+SELECT
+	SUM(l_extendedprice* (1 - l_discount)) AS revenue
+FROM
+	lineitem,
+	part
+WHERE
+	(
+		p_partkey = l_partkey
+		AND p_brand = 'Brand#34'
+		AND p_container IN ('SM CASE', 'SM BOX', 'SM PACK', 'SM PKG')
+		AND l_quantity >= 5 AND l_quantity <= 5 + 10
+		AND p_size BETWEEN 1 AND 5
+		AND l_shipmode IN ('AIR', 'AIR REG')
+		AND l_shipinstruct = 'DELIVER IN PERSON'
+	)
+	OR
+	(
+		p_partkey = l_partkey
+		AND p_brand = 'Brand#51'
+		AND p_container IN ('MED BAG', 'MED BOX', 'MED PKG', 'MED PACK')
+		AND l_quantity >= 12 AND l_quantity <= 12 + 10
+		AND p_size BETWEEN 1 AND 10
+		AND l_shipmode IN ('AIR', 'AIR REG')
+		AND l_shipinstruct = 'DELIVER IN PERSON'
+	)
+	OR
+	(
+		p_partkey = l_partkey
+		AND p_brand = 'Brand#35'
+		AND p_container IN ('LG CASE', 'LG BOX', 'LG PACK', 'LG PKG')
+		AND l_quantity >= 30 AND l_quantity <= 30 + 10
+		AND p_size BETWEEN 1 AND 15
+		AND l_shipmode IN ('AIR', 'AIR REG')
+		AND l_shipinstruct = 'DELIVER IN PERSON'
+	);
+`
+
+	query20 = `
+SELECT
+	s_name,
+	s_address
+FROM
+	supplier,
+	nation
+WHERE
+	s_suppkey IN (
+		SELECT
+			ps_suppkey
+		FROM
+			partsupp
+		WHERE
+			ps_partkey IN (
+				SELECT
+					p_partkey
+				FROM
+					part
+				WHERE
+					p_name LIKE 'orange%'
+			)
+			AND ps_availqty > (
+				SELECT
+					0.5 * SUM(l_quantity)
+				FROM
+					lineitem
+				WHERE
+					l_partkey = ps_partkey
+					AND l_suppkey = ps_suppkey
+					AND l_shipdate >= DATE '1997-01-01'
+					AND l_shipdate < DATE '1997-01-01' + INTERVAL '1' YEAR
+			)
+	)
+	AND s_nationkey = n_nationkey
+	AND n_name = 'ALGERIA'
+ORDER BY
+	s_name;
+`
+
+	query21 = `
+SELECT
+	s_name,
+	COUNT(*) AS numwait
+FROM
+	supplier,
+	lineitem l1,
+	orders,
+	nation
+WHERE
+	s_suppkey = l1.l_suppkey
+	AND o_orderkey = l1.l_orderkey
+	AND o_orderstatus = 'F'
+	AND l1.l_receiptDATE > l1.l_commitdate
+	AND EXISTS (
+		SELECT
+			*
+		FROM
+			lineitem l2
+		WHERE
+			l2.l_orderkey = l1.l_orderkey
+			AND l2.l_suppkey <> l1.l_suppkey
+	)
+	AND NOT EXISTS (
+		SELECT
+			*
+		FROM
+			lineitem l3
+		WHERE
+			l3.l_orderkey = l1.l_orderkey
+			AND l3.l_suppkey <> l1.l_suppkey
+			AND l3.l_receiptDATE > l3.l_commitdate
+	)
+	AND s_nationkey = n_nationkey
+	AND n_name = 'SAUDI ARABIA'
+GROUP BY
+	s_name
+ORDER BY
+	numwait DESC,
+	s_name;
+`
+
+	query22 = `
+SELECT
+	cntrycode,
+	COUNT(*) AS numcust,
+	SUM(c_acctbal) AS totacctbal
+FROM
+	(
+		SELECT
+			substring(c_phone FROM 1 FOR 2) AS cntrycode,
+			c_acctbal
+		FROM
+			customer
+		WHERE
+			substring(c_phone FROM 1 FOR 2) in
+				('20', '32', '44', '33', '29', '22', '31')
+			AND c_acctbal > (
+				SELECT
+					AVG(c_acctbal)
+				FROM
+					customer
+				WHERE
+					c_acctbal > 0.00
+					AND substring(c_phone FROM 1 FOR 2) in
+						('20', '32', '44', '33', '29', '22', '31')
+			)
+			AND NOT EXISTS (
+				SELECT
+					*
+				FROM
+					orders
+				WHERE
+					o_custkey = c_custkey
+			)
+	) AS custsale
+GROUP BY
+	cntrycode
+ORDER BY
+	cntrycode;
+`
+)

--- a/pkg/workload/tpch/tpch.go
+++ b/pkg/workload/tpch/tpch.go
@@ -1,0 +1,323 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+
+package tpch
+
+import (
+	"context"
+	gosql "database/sql"
+	"strings"
+
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/cockroachdb/cockroach/pkg/workload"
+	"github.com/pkg/errors"
+	"github.com/spf13/pflag"
+)
+
+const (
+	numNation        = 25
+	numRegion        = 5
+	numPartPerSF     = 200000
+	numSupplierPerSF = 10000
+	numPartSuppPerSF = 800000
+	numCustomerPerSF = 150000
+	numOrderPerSF    = 1500000
+	numLineItemPerSF = 6001215
+)
+
+type tpch struct {
+	flags     workload.Flags
+	connFlags *workload.ConnFlags
+
+	seed        int64
+	scaleFactor int
+
+	distsql bool
+
+	queriesRaw      string
+	selectedQueries []string
+}
+
+func init() {
+	workload.Register(tpchMeta)
+}
+
+var tpchMeta = workload.Meta{
+	Name:        `tpch`,
+	Description: `TPC-H is a read-only workload of "analytics" queries on large datasets.`,
+	Version:     `1.0.0`,
+	New: func() workload.Generator {
+		g := &tpch{}
+		g.flags.FlagSet = pflag.NewFlagSet(`tpcc`, pflag.ContinueOnError)
+		g.flags.Meta = map[string]workload.FlagMeta{
+			`queries`:  {RuntimeOnly: true},
+			`dist-sql`: {RuntimeOnly: true},
+		}
+		g.flags.Int64Var(&g.seed, `seed`, 1, `Random number generator seed`)
+		g.flags.IntVar(&g.scaleFactor, `scale-factor`, 1,
+			`Linear scale of how much data to use (each SF is ~1GB)`)
+		g.flags.StringVar(&g.queriesRaw, `queries`, `1,3,7,8,9,19`,
+			`Queries to run. Use a comma separated list of query numbers`)
+		g.flags.BoolVar(&g.distsql, `dist-sql`, true, `Use DistSQL for query execution`)
+		g.connFlags = workload.NewConnFlags(&g.flags)
+		return g
+	},
+}
+
+// Meta implements the Generator interface.
+func (*tpch) Meta() workload.Meta { return tpchMeta }
+
+// Flags implements the Flagser interface.
+func (w *tpch) Flags() workload.Flags { return w.flags }
+
+// Hooks implements the Hookser interface.
+func (w *tpch) Hooks() workload.Hooks {
+	return workload.Hooks{
+		Validate: func() error {
+			for _, queryName := range strings.Split(w.queriesRaw, `,`) {
+				queryName = strings.TrimSpace(queryName)
+				switch queryName {
+				case `2`, `4`, `13`, `16`, `17`, `18`, `20`, `21`, `22`:
+					return errors.Errorf(`query is unsupported: %s`, queryName)
+				case `5`, `6`, `10`, `12`, `14`:
+					return errors.Errorf(`query causes Cockroach panic (see #13692): %s`, queryName)
+				case `11`:
+					return errors.Errorf(`group with having not supported yet: %s`, queryName)
+				}
+				if _, ok := queriesByName[queryName]; !ok {
+					return errors.Errorf(`unknown query: %s`, queryName)
+				}
+				w.selectedQueries = append(w.selectedQueries, queryName)
+			}
+			return nil
+		},
+	}
+}
+
+// Tables implements the Generator interface.
+func (w *tpch) Tables() []workload.Table {
+	// TODO(dan): Implement the InitialRowFns for these.
+	nation := workload.Table{
+		Name:            `nation`,
+		Schema:          tpchNationSchema,
+		InitialRowCount: numNation,
+	}
+	region := workload.Table{
+		Name:            `region`,
+		Schema:          tpchRegionSchema,
+		InitialRowCount: numRegion,
+	}
+	part := workload.Table{
+		Name:            `part`,
+		Schema:          tpchPartSchema,
+		InitialRowCount: numPartPerSF * w.scaleFactor,
+	}
+	supplier := workload.Table{
+		Name:            `supplier`,
+		Schema:          tpchSupplierSchema,
+		InitialRowCount: numSupplierPerSF * w.scaleFactor,
+	}
+	partsupp := workload.Table{
+		Name:            `partsupp`,
+		Schema:          tpchPartSuppSchema,
+		InitialRowCount: numPartSuppPerSF * w.scaleFactor,
+	}
+	customer := workload.Table{
+		Name:            `customer`,
+		Schema:          tpchCustomerSchema,
+		InitialRowCount: numCustomerPerSF * w.scaleFactor,
+	}
+	orders := workload.Table{
+		Name:            `orders`,
+		Schema:          tpchOrdersSchema,
+		InitialRowCount: numOrderPerSF * w.scaleFactor,
+	}
+	lineitem := workload.Table{
+		Name:            `lineitem`,
+		Schema:          tpchLineItemSchema,
+		InitialRowCount: numLineItemPerSF * w.scaleFactor,
+	}
+
+	return []workload.Table{
+		nation, region, part, supplier, partsupp, customer, orders, lineitem,
+	}
+}
+
+// Ops implements the Opser interface.
+func (w *tpch) Ops(urls []string, reg *workload.HistogramRegistry) (workload.QueryLoad, error) {
+	sqlDatabase, err := workload.SanitizeUrls(w, w.connFlags.DBOverride, urls)
+	if err != nil {
+		return workload.QueryLoad{}, err
+	}
+	db, err := gosql.Open(`cockroach`, strings.Join(urls, ` `))
+	if err != nil {
+		return workload.QueryLoad{}, err
+	}
+	// Allow a maximum of concurrency+1 connections to the database.
+	db.SetMaxOpenConns(w.connFlags.Concurrency + 1)
+	db.SetMaxIdleConns(w.connFlags.Concurrency + 1)
+
+	ql := workload.QueryLoad{SQLDatabase: sqlDatabase}
+	for i := 0; i < w.connFlags.Concurrency; i++ {
+		worker := &worker{
+			config: w,
+			hists:  reg.GetHandle(),
+			db:     db,
+		}
+		ql.WorkerFns = append(ql.WorkerFns, worker.run)
+	}
+	return ql, nil
+}
+
+type worker struct {
+	config *tpch
+	hists  *workload.Histograms
+	db     *gosql.DB
+	ops    int
+}
+
+func (w *worker) run(ctx context.Context) error {
+	queryName := w.config.selectedQueries[w.ops%len(w.config.selectedQueries)]
+	w.ops++
+
+	var query string
+	if w.config.distsql {
+		query = `SET DISTSQL = 'always'; ` + queriesByName[queryName]
+	} else {
+		query = `SET DISTSQL = 'off'; ` + queriesByName[queryName]
+	}
+
+	start := timeutil.Now()
+	rows, err := w.db.Query(query)
+	if err != nil {
+		return err
+	}
+	var numRows int
+	for rows.Next() {
+		numRows++
+	}
+	if err := rows.Err(); err != nil {
+		return err
+	}
+	elapsed := timeutil.Since(start)
+	w.hists.Get(queryName).Record(elapsed)
+	log.Infof(ctx, "[%s] return %d rows after %4.2f seconds:\n  %s",
+		queryName, numRows, elapsed.Seconds(), query)
+	return nil
+}
+
+const (
+	tpchNationSchema = `(
+		n_nationkey       INTEGER NOT NULL,
+		n_name            CHAR(25) NOT NULL,
+		n_regionkey       INTEGER NOT NULL,
+		n_comment         VARCHAR(152),
+		INDEX n_rk (n_regionkey ASC),
+		UNIQUE INDEX n_nk (n_nationkey ASC)
+	)`
+	tpchRegionSchema = `(
+		r_regionkey       INTEGER NOT NULL,
+		r_name            CHAR(25) NOT NULL,
+		r_comment         VARCHAR(152),
+		UNIQUE INDEX r_rk (r_regionkey ASC)
+	)`
+	tpchPartSchema = `(
+		p_partkey         INTEGER NOT NULL,
+		p_name            VARCHAR(55) NOT NULL,
+		p_mfgr            CHAR(25) NOT NULL,
+		p_brand           CHAR(10) NOT NULL,
+		p_type            VARCHAR(25) NOT NULL,
+		p_size            INTEGER NOT NULL,
+		p_container       CHAR(10) NOT NULL,
+		p_retailprice     DECIMAL(15,2) NOT NULL,
+		p_comment         VARCHAR(23) NOT NULL,
+		UNIQUE INDEX p_pk (p_partkey ASC)
+	)`
+	tpchSupplierSchema = `(
+		s_suppkey         INTEGER NOT NULL,
+		s_name            CHAR(25) NOT NULL,
+		s_address         VARCHAR(40) NOT NULL,
+		s_nationkey       INTEGER NOT NULL,
+		s_phone           CHAR(15) NOT NULL,
+		s_acctbal         DECIMAL(15,2) NOT NULL,
+		s_comment         VARCHAR(101) NOT NULL,
+		UNIQUE INDEX s_sk (s_suppkey ASC),
+		INDEX s_nk (s_nationkey ASC)
+	)`
+	tpchPartSuppSchema = `(
+		ps_partkey            INTEGER NOT NULL,
+		ps_suppkey            INTEGER NOT NULL,
+		ps_availqty           INTEGER NOT NULL,
+		ps_supplycost         DECIMAL(15,2) NOT NULL,
+		ps_comment            VARCHAR(199) NOT NULL,
+		INDEX ps_pk (ps_partkey ASC),
+		INDEX ps_sk (ps_suppkey ASC),
+		UNIQUE INDEX ps_pk_sk (ps_partkey ASC, ps_suppkey ASC),
+		UNIQUE INDEX ps_sk_pk (ps_suppkey ASC, ps_partkey ASC)
+	)`
+	tpchCustomerSchema = `(
+		c_custkey         INTEGER NOT NULL,
+		c_name            VARCHAR(25) NOT NULL,
+		c_address         VARCHAR(40) NOT NULL,
+		c_nationkey       INTEGER NOT NULL,
+		c_phone           CHAR(15) NOT NULL,
+		c_acctbal         DECIMAL(15,2)   NOT NULL,
+		c_mktsegment      CHAR(10) NOT NULL,
+		c_comment         VARCHAR(117) NOT NULL,
+		UNIQUE INDEX c_ck (c_custkey ASC),
+		INDEX c_nk (c_nationkey ASC)
+	)`
+	tpchOrdersSchema = `(
+		o_orderkey           INTEGER NOT NULL,
+		o_custkey            INTEGER NOT NULL,
+		o_orderstatus        CHAR(1) NOT NULL,
+		o_totalprice         DECIMAL(15,2) NOT NULL,
+		o_orderdate          DATE NOT NULL,
+		o_orderpriority      CHAR(15) NOT NULL,
+		o_clerk              CHAR(15) NOT NULL,
+		o_shippriority       INTEGER NOT NULL,
+		o_comment            VARCHAR(79) NOT NULL,
+		UNIQUE INDEX o_ok (o_orderkey ASC),
+		INDEX o_ck (o_custkey ASC),
+		INDEX o_od (o_orderdate ASC)
+	)`
+	tpchLineItemSchema = `(
+		l_orderkey      INTEGER NOT NULL,
+		l_partkey       INTEGER NOT NULL,
+		l_suppkey       INTEGER NOT NULL,
+		l_linenumber    INTEGER NOT NULL,
+		l_quantity      DECIMAL(15,2) NOT NULL,
+		l_extendedprice DECIMAL(15,2) NOT NULL,
+		l_discount      DECIMAL(15,2) NOT NULL,
+		l_tax           DECIMAL(15,2) NOT NULL,
+		l_returnflag    CHAR(1) NOT NULL,
+		l_linestatus    CHAR(1) NOT NULL,
+		l_shipdate      DATE NOT NULL,
+		l_commitdate    DATE NOT NULL,
+		l_receiptdate   DATE NOT NULL,
+		l_shipinstruct  CHAR(25) NOT NULL,
+		l_shipmode      CHAR(10) NOT NULL,
+		l_comment       VARCHAR(44) NOT NULL,
+		INDEX l_ok (l_orderkey ASC),
+		INDEX l_pk (l_partkey ASC),
+		INDEX l_sk (l_suppkey ASC),
+		INDEX l_sd (l_shipdate ASC),
+		INDEX l_cd (l_commitdate ASC),
+		INDEX l_rd (l_receiptdate ASC),
+		INDEX l_pk_sk (l_partkey ASC, l_suppkey ASC),
+		INDEX l_sk_pk (l_suppkey ASC, l_partkey ASC)
+	)`
+)

--- a/pkg/workload/tpch/tpch.go
+++ b/pkg/workload/tpch/tpch.go
@@ -221,21 +221,19 @@ func (w *worker) run(ctx context.Context) error {
 
 const (
 	tpchNationSchema = `(
-		n_nationkey       INTEGER NOT NULL,
+		n_nationkey       INTEGER NOT NULL PRIMARY KEY,
 		n_name            CHAR(25) NOT NULL,
 		n_regionkey       INTEGER NOT NULL,
 		n_comment         VARCHAR(152),
-		INDEX n_rk (n_regionkey ASC),
-		UNIQUE INDEX n_nk (n_nationkey ASC)
+		INDEX n_rk (n_regionkey ASC)
 	)`
 	tpchRegionSchema = `(
-		r_regionkey       INTEGER NOT NULL,
+		r_regionkey       INTEGER NOT NULL PRIMARY KEY,
 		r_name            CHAR(25) NOT NULL,
-		r_comment         VARCHAR(152),
-		UNIQUE INDEX r_rk (r_regionkey ASC)
+		r_comment         VARCHAR(152)
 	)`
 	tpchPartSchema = `(
-		p_partkey         INTEGER NOT NULL,
+		p_partkey         INTEGER NOT NULL PRIMARY KEY,
 		p_name            VARCHAR(55) NOT NULL,
 		p_mfgr            CHAR(25) NOT NULL,
 		p_brand           CHAR(10) NOT NULL,
@@ -243,18 +241,16 @@ const (
 		p_size            INTEGER NOT NULL,
 		p_container       CHAR(10) NOT NULL,
 		p_retailprice     DECIMAL(15,2) NOT NULL,
-		p_comment         VARCHAR(23) NOT NULL,
-		UNIQUE INDEX p_pk (p_partkey ASC)
+		p_comment         VARCHAR(23) NOT NULL
 	)`
 	tpchSupplierSchema = `(
-		s_suppkey         INTEGER NOT NULL,
+		s_suppkey         INTEGER NOT NULL PRIMARY KEY,
 		s_name            CHAR(25) NOT NULL,
 		s_address         VARCHAR(40) NOT NULL,
 		s_nationkey       INTEGER NOT NULL,
 		s_phone           CHAR(15) NOT NULL,
 		s_acctbal         DECIMAL(15,2) NOT NULL,
 		s_comment         VARCHAR(101) NOT NULL,
-		UNIQUE INDEX s_sk (s_suppkey ASC),
 		INDEX s_nk (s_nationkey ASC)
 	)`
 	tpchPartSuppSchema = `(
@@ -263,13 +259,12 @@ const (
 		ps_availqty           INTEGER NOT NULL,
 		ps_supplycost         DECIMAL(15,2) NOT NULL,
 		ps_comment            VARCHAR(199) NOT NULL,
-		INDEX ps_pk (ps_partkey ASC),
 		INDEX ps_sk (ps_suppkey ASC),
-		UNIQUE INDEX ps_pk_sk (ps_partkey ASC, ps_suppkey ASC),
+		PRIMARY KEY (ps_partkey ASC, ps_suppkey ASC),
 		UNIQUE INDEX ps_sk_pk (ps_suppkey ASC, ps_partkey ASC)
 	)`
 	tpchCustomerSchema = `(
-		c_custkey         INTEGER NOT NULL,
+		c_custkey         INTEGER NOT NULL PRIMARY KEY,
 		c_name            VARCHAR(25) NOT NULL,
 		c_address         VARCHAR(40) NOT NULL,
 		c_nationkey       INTEGER NOT NULL,
@@ -277,11 +272,10 @@ const (
 		c_acctbal         DECIMAL(15,2)   NOT NULL,
 		c_mktsegment      CHAR(10) NOT NULL,
 		c_comment         VARCHAR(117) NOT NULL,
-		UNIQUE INDEX c_ck (c_custkey ASC),
 		INDEX c_nk (c_nationkey ASC)
 	)`
 	tpchOrdersSchema = `(
-		o_orderkey           INTEGER NOT NULL,
+		o_orderkey           INTEGER NOT NULL PRIMARY KEY,
 		o_custkey            INTEGER NOT NULL,
 		o_orderstatus        CHAR(1) NOT NULL,
 		o_totalprice         DECIMAL(15,2) NOT NULL,
@@ -290,7 +284,6 @@ const (
 		o_clerk              CHAR(15) NOT NULL,
 		o_shippriority       INTEGER NOT NULL,
 		o_comment            VARCHAR(79) NOT NULL,
-		UNIQUE INDEX o_ok (o_orderkey ASC),
 		INDEX o_ck (o_custkey ASC),
 		INDEX o_od (o_orderdate ASC)
 	)`
@@ -311,6 +304,7 @@ const (
 		l_shipinstruct  CHAR(25) NOT NULL,
 		l_shipmode      CHAR(10) NOT NULL,
 		l_comment       VARCHAR(44) NOT NULL,
+		PRIMARY KEY (l_orderkey, l_linenumber),
 		INDEX l_ok (l_orderkey ASC),
 		INDEX l_pk (l_partkey ASC),
 		INDEX l_sk (l_suppkey ASC),


### PR DESCRIPTION
This one is a little awkward because we don't have a go implementation
for generating the table data, but I've glanced at the `dbgen` source
and it doesn't seem out of the question that we could do it eventually.

I still think it's useful to have the queryload part ported, plus
there's some potential upcoming work with store dump fixtures and having
this will let us keep them in the standard locations.

Release note: None