### PR TITLE
sql: introduce PG-compatible access privilege inquiry functions

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -833,6 +833,162 @@ Compatible elements: hour, minute, second, millisecond, microsecond.</p>
 </span></td></tr>
 <tr><td><code>generate_series(start: <a href="timestamp.html">timestamp</a>, end: <a href="timestamp.html">timestamp</a>, step: <a href="interval.html">interval</a>) &rarr; setof tuple{timestamp}</code></td><td><span class="funcdesc"><p>Produces a virtual table containing the timestamp values from <code>start</code> to <code>end</code>, inclusive, by increment of <code>step</code>.</p>
 </span></td></tr>
+<tr><td><code>has_any_column_privilege(table: <a href="string.html">string</a>, privilege: <a href="string.html">string</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>does current user have privilege for any column of table</p>
+</span></td></tr>
+<tr><td><code>has_any_column_privilege(table: oid, privilege: <a href="string.html">string</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>does current user have privilege for any column of table</p>
+</span></td></tr>
+<tr><td><code>has_any_column_privilege(user: <a href="string.html">string</a>, table: <a href="string.html">string</a>, privilege: <a href="string.html">string</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>does user have privilege for any column of table</p>
+</span></td></tr>
+<tr><td><code>has_any_column_privilege(user: <a href="string.html">string</a>, table: oid, privilege: <a href="string.html">string</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>does user have privilege for any column of table</p>
+</span></td></tr>
+<tr><td><code>has_any_column_privilege(user: oid, table: <a href="string.html">string</a>, privilege: <a href="string.html">string</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>does user have privilege for any column of table</p>
+</span></td></tr>
+<tr><td><code>has_any_column_privilege(user: oid, table: oid, privilege: <a href="string.html">string</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>does user have privilege for any column of table</p>
+</span></td></tr>
+<tr><td><code>has_column_privilege(table: <a href="string.html">string</a>, column: <a href="int.html">int</a>, privilege: <a href="string.html">string</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>does current user have privilege for column</p>
+</span></td></tr>
+<tr><td><code>has_column_privilege(table: <a href="string.html">string</a>, column: <a href="string.html">string</a>, privilege: <a href="string.html">string</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>does current user have privilege for column</p>
+</span></td></tr>
+<tr><td><code>has_column_privilege(table: oid, column: <a href="int.html">int</a>, privilege: <a href="string.html">string</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>does current user have privilege for column</p>
+</span></td></tr>
+<tr><td><code>has_column_privilege(table: oid, column: <a href="string.html">string</a>, privilege: <a href="string.html">string</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>does current user have privilege for column</p>
+</span></td></tr>
+<tr><td><code>has_column_privilege(user: <a href="string.html">string</a>, table: <a href="string.html">string</a>, column: <a href="int.html">int</a>, privilege: <a href="string.html">string</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>does user have privilege for column</p>
+</span></td></tr>
+<tr><td><code>has_column_privilege(user: <a href="string.html">string</a>, table: <a href="string.html">string</a>, column: <a href="string.html">string</a>, privilege: <a href="string.html">string</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>does user have privilege for column</p>
+</span></td></tr>
+<tr><td><code>has_column_privilege(user: <a href="string.html">string</a>, table: oid, column: <a href="int.html">int</a>, privilege: <a href="string.html">string</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>does user have privilege for column</p>
+</span></td></tr>
+<tr><td><code>has_column_privilege(user: <a href="string.html">string</a>, table: oid, column: <a href="string.html">string</a>, privilege: <a href="string.html">string</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>does user have privilege for column</p>
+</span></td></tr>
+<tr><td><code>has_column_privilege(user: oid, table: <a href="string.html">string</a>, column: <a href="int.html">int</a>, privilege: <a href="string.html">string</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>does user have privilege for column</p>
+</span></td></tr>
+<tr><td><code>has_column_privilege(user: oid, table: <a href="string.html">string</a>, column: <a href="string.html">string</a>, privilege: <a href="string.html">string</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>does user have privilege for column</p>
+</span></td></tr>
+<tr><td><code>has_column_privilege(user: oid, table: oid, column: <a href="int.html">int</a>, privilege: <a href="string.html">string</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>does user have privilege for column</p>
+</span></td></tr>
+<tr><td><code>has_column_privilege(user: oid, table: oid, column: <a href="string.html">string</a>, privilege: <a href="string.html">string</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>does user have privilege for column</p>
+</span></td></tr>
+<tr><td><code>has_database_privilege(database: <a href="string.html">string</a>, privilege: <a href="string.html">string</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>does current user have privilege for database</p>
+</span></td></tr>
+<tr><td><code>has_database_privilege(database: oid, privilege: <a href="string.html">string</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>does current user have privilege for database</p>
+</span></td></tr>
+<tr><td><code>has_database_privilege(user: <a href="string.html">string</a>, database: <a href="string.html">string</a>, privilege: <a href="string.html">string</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>does user have privilege for database</p>
+</span></td></tr>
+<tr><td><code>has_database_privilege(user: <a href="string.html">string</a>, database: oid, privilege: <a href="string.html">string</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>does user have privilege for database</p>
+</span></td></tr>
+<tr><td><code>has_database_privilege(user: oid, database: <a href="string.html">string</a>, privilege: <a href="string.html">string</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>does user have privilege for database</p>
+</span></td></tr>
+<tr><td><code>has_database_privilege(user: oid, database: oid, privilege: <a href="string.html">string</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>does user have privilege for database</p>
+</span></td></tr>
+<tr><td><code>has_foreign_data_wrapper_privilege(fdw: <a href="string.html">string</a>, privilege: <a href="string.html">string</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>does current user have privilege for foreign-data wrapper</p>
+</span></td></tr>
+<tr><td><code>has_foreign_data_wrapper_privilege(fdw: oid, privilege: <a href="string.html">string</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>does current user have privilege for foreign-data wrapper</p>
+</span></td></tr>
+<tr><td><code>has_foreign_data_wrapper_privilege(user: <a href="string.html">string</a>, fdw: <a href="string.html">string</a>, privilege: <a href="string.html">string</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>does user have privilege for foreign-data wrapper</p>
+</span></td></tr>
+<tr><td><code>has_foreign_data_wrapper_privilege(user: <a href="string.html">string</a>, fdw: oid, privilege: <a href="string.html">string</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>does user have privilege for foreign-data wrapper</p>
+</span></td></tr>
+<tr><td><code>has_foreign_data_wrapper_privilege(user: oid, fdw: <a href="string.html">string</a>, privilege: <a href="string.html">string</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>does user have privilege for foreign-data wrapper</p>
+</span></td></tr>
+<tr><td><code>has_foreign_data_wrapper_privilege(user: oid, fdw: oid, privilege: <a href="string.html">string</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>does user have privilege for foreign-data wrapper</p>
+</span></td></tr>
+<tr><td><code>has_function_privilege(function: <a href="string.html">string</a>, privilege: <a href="string.html">string</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>does current user have privilege for function</p>
+</span></td></tr>
+<tr><td><code>has_function_privilege(function: oid, privilege: <a href="string.html">string</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>does current user have privilege for function</p>
+</span></td></tr>
+<tr><td><code>has_function_privilege(user: <a href="string.html">string</a>, function: <a href="string.html">string</a>, privilege: <a href="string.html">string</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>does user have privilege for function</p>
+</span></td></tr>
+<tr><td><code>has_function_privilege(user: <a href="string.html">string</a>, function: oid, privilege: <a href="string.html">string</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>does user have privilege for function</p>
+</span></td></tr>
+<tr><td><code>has_function_privilege(user: oid, function: <a href="string.html">string</a>, privilege: <a href="string.html">string</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>does user have privilege for function</p>
+</span></td></tr>
+<tr><td><code>has_function_privilege(user: oid, function: oid, privilege: <a href="string.html">string</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>does user have privilege for function</p>
+</span></td></tr>
+<tr><td><code>has_language_privilege(language: <a href="string.html">string</a>, privilege: <a href="string.html">string</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>does current user have privilege for language</p>
+</span></td></tr>
+<tr><td><code>has_language_privilege(language: oid, privilege: <a href="string.html">string</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>does current user have privilege for language</p>
+</span></td></tr>
+<tr><td><code>has_language_privilege(user: <a href="string.html">string</a>, language: <a href="string.html">string</a>, privilege: <a href="string.html">string</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>does user have privilege for language</p>
+</span></td></tr>
+<tr><td><code>has_language_privilege(user: <a href="string.html">string</a>, language: oid, privilege: <a href="string.html">string</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>does user have privilege for language</p>
+</span></td></tr>
+<tr><td><code>has_language_privilege(user: oid, language: <a href="string.html">string</a>, privilege: <a href="string.html">string</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>does user have privilege for language</p>
+</span></td></tr>
+<tr><td><code>has_language_privilege(user: oid, language: oid, privilege: <a href="string.html">string</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>does user have privilege for language</p>
+</span></td></tr>
+<tr><td><code>has_schema_privilege(schema: <a href="string.html">string</a>, privilege: <a href="string.html">string</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>does current user have privilege for schema</p>
+</span></td></tr>
+<tr><td><code>has_schema_privilege(schema: oid, privilege: <a href="string.html">string</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>does current user have privilege for schema</p>
+</span></td></tr>
+<tr><td><code>has_schema_privilege(user: <a href="string.html">string</a>, schema: <a href="string.html">string</a>, privilege: <a href="string.html">string</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>does user have privilege for schema</p>
+</span></td></tr>
+<tr><td><code>has_schema_privilege(user: <a href="string.html">string</a>, schema: oid, privilege: <a href="string.html">string</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>does user have privilege for schema</p>
+</span></td></tr>
+<tr><td><code>has_schema_privilege(user: oid, schema: <a href="string.html">string</a>, privilege: <a href="string.html">string</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>does user have privilege for schema</p>
+</span></td></tr>
+<tr><td><code>has_schema_privilege(user: oid, schema: oid, privilege: <a href="string.html">string</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>does user have privilege for schema</p>
+</span></td></tr>
+<tr><td><code>has_sequence_privilege(sequence: <a href="string.html">string</a>, privilege: <a href="string.html">string</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>does current user have privilege for sequence</p>
+</span></td></tr>
+<tr><td><code>has_sequence_privilege(sequence: oid, privilege: <a href="string.html">string</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>does current user have privilege for sequence</p>
+</span></td></tr>
+<tr><td><code>has_sequence_privilege(user: <a href="string.html">string</a>, sequence: <a href="string.html">string</a>, privilege: <a href="string.html">string</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>does user have privilege for sequence</p>
+</span></td></tr>
+<tr><td><code>has_sequence_privilege(user: <a href="string.html">string</a>, sequence: oid, privilege: <a href="string.html">string</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>does user have privilege for sequence</p>
+</span></td></tr>
+<tr><td><code>has_sequence_privilege(user: oid, sequence: <a href="string.html">string</a>, privilege: <a href="string.html">string</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>does user have privilege for sequence</p>
+</span></td></tr>
+<tr><td><code>has_sequence_privilege(user: oid, sequence: oid, privilege: <a href="string.html">string</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>does user have privilege for sequence</p>
+</span></td></tr>
+<tr><td><code>has_server_privilege(server: <a href="string.html">string</a>, privilege: <a href="string.html">string</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>does current user have privilege for foreign server</p>
+</span></td></tr>
+<tr><td><code>has_server_privilege(server: oid, privilege: <a href="string.html">string</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>does current user have privilege for foreign server</p>
+</span></td></tr>
+<tr><td><code>has_server_privilege(user: <a href="string.html">string</a>, server: <a href="string.html">string</a>, privilege: <a href="string.html">string</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>does user have privilege for foreign server</p>
+</span></td></tr>
+<tr><td><code>has_server_privilege(user: <a href="string.html">string</a>, server: oid, privilege: <a href="string.html">string</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>does user have privilege for foreign server</p>
+</span></td></tr>
+<tr><td><code>has_server_privilege(user: oid, server: <a href="string.html">string</a>, privilege: <a href="string.html">string</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>does user have privilege for foreign server</p>
+</span></td></tr>
+<tr><td><code>has_server_privilege(user: oid, server: oid, privilege: <a href="string.html">string</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>does user have privilege for foreign server</p>
+</span></td></tr>
+<tr><td><code>has_table_privilege(table: <a href="string.html">string</a>, privilege: <a href="string.html">string</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>does current user have privilege for table</p>
+</span></td></tr>
+<tr><td><code>has_table_privilege(table: oid, privilege: <a href="string.html">string</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>does current user have privilege for table</p>
+</span></td></tr>
+<tr><td><code>has_table_privilege(user: <a href="string.html">string</a>, table: <a href="string.html">string</a>, privilege: <a href="string.html">string</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>does user have privilege for table</p>
+</span></td></tr>
+<tr><td><code>has_table_privilege(user: <a href="string.html">string</a>, table: oid, privilege: <a href="string.html">string</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>does user have privilege for table</p>
+</span></td></tr>
+<tr><td><code>has_table_privilege(user: oid, table: <a href="string.html">string</a>, privilege: <a href="string.html">string</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>does user have privilege for table</p>
+</span></td></tr>
+<tr><td><code>has_table_privilege(user: oid, table: oid, privilege: <a href="string.html">string</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>does user have privilege for table</p>
+</span></td></tr>
+<tr><td><code>has_tablespace_privilege(tablespace: <a href="string.html">string</a>, privilege: <a href="string.html">string</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>does current user have privilege for tablespace</p>
+</span></td></tr>
+<tr><td><code>has_tablespace_privilege(tablespace: oid, privilege: <a href="string.html">string</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>does current user have privilege for tablespace</p>
+</span></td></tr>
+<tr><td><code>has_tablespace_privilege(user: <a href="string.html">string</a>, tablespace: <a href="string.html">string</a>, privilege: <a href="string.html">string</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>does user have privilege for tablespace</p>
+</span></td></tr>
+<tr><td><code>has_tablespace_privilege(user: <a href="string.html">string</a>, tablespace: oid, privilege: <a href="string.html">string</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>does user have privilege for tablespace</p>
+</span></td></tr>
+<tr><td><code>has_tablespace_privilege(user: oid, tablespace: <a href="string.html">string</a>, privilege: <a href="string.html">string</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>does user have privilege for tablespace</p>
+</span></td></tr>
+<tr><td><code>has_tablespace_privilege(user: oid, tablespace: oid, privilege: <a href="string.html">string</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>does user have privilege for tablespace</p>
+</span></td></tr>
+<tr><td><code>has_type_privilege(type: <a href="string.html">string</a>, privilege: <a href="string.html">string</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>does current user have privilege for type</p>
+</span></td></tr>
+<tr><td><code>has_type_privilege(type: oid, privilege: <a href="string.html">string</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>does current user have privilege for type</p>
+</span></td></tr>
+<tr><td><code>has_type_privilege(user: <a href="string.html">string</a>, type: <a href="string.html">string</a>, privilege: <a href="string.html">string</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>does user have privilege for type</p>
+</span></td></tr>
+<tr><td><code>has_type_privilege(user: <a href="string.html">string</a>, type: oid, privilege: <a href="string.html">string</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>does user have privilege for type</p>
+</span></td></tr>
+<tr><td><code>has_type_privilege(user: oid, type: <a href="string.html">string</a>, privilege: <a href="string.html">string</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>does user have privilege for type</p>
+</span></td></tr>
+<tr><td><code>has_type_privilege(user: oid, type: oid, privilege: <a href="string.html">string</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>does user have privilege for type</p>
+</span></td></tr>
 <tr><td><code>json_array_elements(input: jsonb) &rarr; setof tuple{jsonb}</code></td><td><span class="funcdesc"><p>Expands a JSON array to a set of JSON values.</p>
 </span></td></tr>
 <tr><td><code>json_array_elements_text(input: jsonb) &rarr; setof tuple{string}</code></td><td><span class="funcdesc"><p>Expands a JSON array to a set of text values.</p>

--- a/pkg/sql/logictest/testdata/logic_test/explain
+++ b/pkg/sql/logictest/testdata/logic_test/explain
@@ -167,7 +167,7 @@ sort                   ·      ·
  └── render            ·      ·
       └── filter       ·      ·
            └── values  ·      ·
-·                      size   6 columns, 80 rows
+·                      size   6 columns, 81 rows
 
 query TTT
 EXPLAIN SHOW DATABASE
@@ -230,7 +230,7 @@ sort                                       ·            ·
                      ├── render            ·            ·
                      │    └── filter       ·            ·
                      │         └── values  ·            ·
-                     │                     size         17 columns, 730 rows
+                     │                     size         17 columns, 739 rows
                      └── render            ·            ·
                           └── filter       ·            ·
                                └── values  ·            ·

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -268,6 +268,7 @@ pg_catalog          pg_foreign_table
 pg_catalog          pg_index
 pg_catalog          pg_indexes
 pg_catalog          pg_inherits
+pg_catalog          pg_language
 pg_catalog          pg_namespace
 pg_catalog          pg_operator
 pg_catalog          pg_proc
@@ -382,6 +383,7 @@ pg_foreign_table
 pg_index
 pg_indexes
 pg_inherits
+pg_language
 pg_namespace
 pg_operator
 pg_proc
@@ -503,6 +505,7 @@ system         pg_catalog          pg_foreign_table                   SYSTEM VIE
 system         pg_catalog          pg_index                           SYSTEM VIEW  NO                 1
 system         pg_catalog          pg_indexes                         SYSTEM VIEW  NO                 1
 system         pg_catalog          pg_inherits                        SYSTEM VIEW  NO                 1
+system         pg_catalog          pg_language                        SYSTEM VIEW  NO                 1
 system         pg_catalog          pg_namespace                       SYSTEM VIEW  NO                 1
 system         pg_catalog          pg_operator                        SYSTEM VIEW  NO                 1
 system         pg_catalog          pg_proc                            SYSTEM VIEW  NO                 1

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -32,6 +32,7 @@ pg_foreign_table
 pg_index
 pg_indexes
 pg_inherits
+pg_language
 pg_namespace
 pg_operator
 pg_proc
@@ -91,6 +92,7 @@ pg_foreign_table
 pg_index
 pg_indexes
 pg_inherits
+pg_language
 pg_namespace
 pg_operator
 pg_proc

--- a/pkg/sql/logictest/testdata/logic_test/privilege_builtins
+++ b/pkg/sql/logictest/testdata/logic_test/privilege_builtins
@@ -1,0 +1,869 @@
+# LogicTest: default distsql
+
+statement ok
+CREATE USER bar
+
+statement ok
+GRANT CREATE ON DATABASE test TO bar
+
+statement ok
+CREATE TABLE t (a INT, b INT);
+
+statement ok
+GRANT GRANT ON t TO bar;
+
+statement ok
+GRANT DELETE ON t TO bar;
+
+statement ok
+CREATE SEQUENCE seq;
+
+statement ok
+GRANT SELECT ON seq TO bar;
+
+statement ok
+GRANT SELECT ON seq TO testuser;
+
+statement ok
+GRANT GRANT ON seq TO testuser;
+
+
+## has_any_column_privilege
+
+query BBBB
+SELECT has_any_column_privilege(12345, 'SELECT'),
+       has_any_column_privilege(12345, 'INSERT'),
+       has_any_column_privilege(12345, 'UPDATE'),
+       has_any_column_privilege(12345, 'REFERENCES')
+----
+NULL  NULL  NULL  NULL
+
+query BBBB
+SELECT has_any_column_privilege((SELECT oid FROM pg_class WHERE relname = 'pg_type'), 'SELECT'),
+       has_any_column_privilege((SELECT oid FROM pg_class WHERE relname = 'pg_type'), 'INSERT'),
+       has_any_column_privilege((SELECT oid FROM pg_class WHERE relname = 'pg_type'), 'UPDATE'),
+       has_any_column_privilege((SELECT oid FROM pg_class WHERE relname = 'pg_type'), 'REFERENCES')
+----
+false  false  false  false
+
+query BBBB
+SELECT has_any_column_privilege((SELECT oid FROM pg_class WHERE relname = 't'), 'SELECT'),
+       has_any_column_privilege((SELECT oid FROM pg_class WHERE relname = 't'), 'INSERT'),
+       has_any_column_privilege((SELECT oid FROM pg_class WHERE relname = 't'), 'UPDATE'),
+       has_any_column_privilege((SELECT oid FROM pg_class WHERE relname = 't'), 'REFERENCES')
+----
+true  true  true  true
+
+query error pgcode 42P01 relation "does_not_exist" does not exist
+SELECT has_any_column_privilege('does_not_exist', 'SELECT')
+
+query BBBBB
+SELECT has_any_column_privilege('pg_type', 'SELECT'),
+       has_any_column_privilege('pg_type', 'INSERT'),
+       has_any_column_privilege('pg_type', 'UPDATE'),
+       has_any_column_privilege('pg_type', 'REFERENCES'),
+       has_any_column_privilege('pg_type', 'SELECT, INSERT, UPDATE')
+----
+false  false  false  false  false
+
+query BBBBB
+SELECT has_any_column_privilege('t', 'SELECT'),
+       has_any_column_privilege('t', 'INSERT'),
+       has_any_column_privilege('t', 'UPDATE'),
+       has_any_column_privilege('t', 'REFERENCES'),
+       has_any_column_privilege('t', 'SELECT, INSERT, UPDATE')
+----
+true  true  true  true  true
+
+query BBBBB
+SELECT has_any_column_privilege('t', 'SELECT WITH GRANT OPTION'),
+       has_any_column_privilege('t', 'INSERT WITH GRANT OPTION'),
+       has_any_column_privilege('t', 'UPDATE WITH GRANT OPTION'),
+       has_any_column_privilege('t', 'REFERENCES WITH GRANT OPTION'),
+       has_any_column_privilege('t', 'SELECT WITH GRANT OPTION, INSERT WITH GRANT OPTION, UPDATE WITH GRANT OPTION')
+----
+true  true  true  true  true
+
+query error pgcode 22023 unrecognized privilege type: ""
+SELECT has_any_column_privilege((SELECT oid FROM pg_class WHERE relname = 'pg_type'), '')
+
+query error pgcode 22023 unrecognized privilege type: "USAGE"
+SELECT has_any_column_privilege('t', 'USAGE')
+
+query error pgcode 22023 unrecognized privilege type: "USAGE"
+SELECT has_any_column_privilege('t', 'SELECT, USAGE')
+
+query error pgcode 42704 role 'no_user' does not exist
+SELECT has_any_column_privilege('no_user', 't', 'SELECT')
+
+query BBBBB
+SELECT has_any_column_privilege('bar', 't', 'SELECT'),
+       has_any_column_privilege('bar', 't', 'INSERT'),
+       has_any_column_privilege('bar', 't', 'UPDATE'),
+       has_any_column_privilege('bar', 't', 'REFERENCES'),
+       has_any_column_privilege('bar', 't', 'SELECT, INSERT, UPDATE')
+----
+false  false  false  false  false
+
+query BBBBB
+SELECT has_any_column_privilege('bar', 't', 'SELECT WITH GRANT OPTION'),
+       has_any_column_privilege('bar', 't', 'INSERT WITH GRANT OPTION'),
+       has_any_column_privilege('bar', 't', 'UPDATE WITH GRANT OPTION'),
+       has_any_column_privilege('bar', 't', 'REFERENCES WITH GRANT OPTION'),
+       has_any_column_privilege('bar', 't', 'SELECT WITH GRANT OPTION, INSERT WITH GRANT OPTION, UPDATE WITH GRANT OPTION')
+----
+false  false  false  false  false
+
+
+## has_column_privilege
+
+query BBBB
+SELECT has_column_privilege(12345, 1, 'SELECT'),
+       has_column_privilege(12345, 1, 'INSERT'),
+       has_column_privilege(12345, 1, 'UPDATE'),
+       has_column_privilege(12345, 1, 'REFERENCES')
+----
+NULL  NULL  NULL  NULL
+
+query BBBB
+SELECT has_column_privilege((SELECT oid FROM pg_class WHERE relname = 'pg_type'), 1, 'SELECT'),
+       has_column_privilege((SELECT oid FROM pg_class WHERE relname = 'pg_type'), 1, 'INSERT'),
+       has_column_privilege((SELECT oid FROM pg_class WHERE relname = 'pg_type'), 1, 'UPDATE'),
+       has_column_privilege((SELECT oid FROM pg_class WHERE relname = 'pg_type'), 1, 'REFERENCES')
+----
+false  false  false  false
+
+query BBBB
+SELECT has_column_privilege((SELECT oid FROM pg_class WHERE relname = 't'), 1, 'SELECT'),
+       has_column_privilege((SELECT oid FROM pg_class WHERE relname = 't'), 2, 'INSERT'),
+       has_column_privilege((SELECT oid FROM pg_class WHERE relname = 't'), 1, 'UPDATE'),
+       has_column_privilege((SELECT oid FROM pg_class WHERE relname = 't'), 2, 'REFERENCES')
+----
+true  true  true  true
+
+query error pgcode 42P01 relation "does_not_exist" does not exist
+SELECT has_column_privilege('does_not_exist', 1, 'SELECT')
+
+query error pgcode 42703 column 100 of relation 'pg_type' does not exist
+SELECT has_column_privilege('pg_type', 100, 'SELECT')
+
+query BBBBB
+SELECT has_column_privilege('pg_type', 1, 'SELECT'),
+       has_column_privilege('pg_type', 1, 'INSERT'),
+       has_column_privilege('pg_type', 1, 'UPDATE'),
+       has_column_privilege('pg_type', 1, 'REFERENCES'),
+       has_column_privilege('pg_type', 1, 'SELECT, INSERT, UPDATE')
+----
+false  false  false  false  false
+
+query BBBBB
+SELECT has_column_privilege('t', 1, 'SELECT'),
+       has_column_privilege('t', 1, 'INSERT'),
+       has_column_privilege('t', 1, 'UPDATE'),
+       has_column_privilege('t', 1, 'REFERENCES'),
+       has_column_privilege('t', 1, 'SELECT, INSERT, UPDATE')
+----
+true  true  true  true  true
+
+query BBBBB
+SELECT has_column_privilege('t', 1, 'SELECT WITH GRANT OPTION'),
+       has_column_privilege('t', 1, 'INSERT WITH GRANT OPTION'),
+       has_column_privilege('t', 1, 'UPDATE WITH GRANT OPTION'),
+       has_column_privilege('t', 1, 'REFERENCES WITH GRANT OPTION'),
+       has_column_privilege('t', 1, 'SELECT WITH GRANT OPTION, INSERT WITH GRANT OPTION, UPDATE WITH GRANT OPTION')
+----
+true  true  true  true  true
+
+query error pgcode 22023 unrecognized privilege type: "USAGE"
+SELECT has_column_privilege('t', 1, 'USAGE')
+
+query error pgcode 42704 role 'no_user' does not exist
+SELECT has_column_privilege('no_user', 't', 1, 'SELECT')
+
+query BBBBB
+SELECT has_column_privilege('bar', 't', 1, 'SELECT'),
+       has_column_privilege('bar', 't', 1, 'INSERT'),
+       has_column_privilege('bar', 't', 1, 'UPDATE'),
+       has_column_privilege('bar', 't', 1, 'REFERENCES'),
+       has_column_privilege('bar', 't', 1, 'SELECT, INSERT, UPDATE')
+----
+false  false  false  false  false
+
+query BBBBB
+SELECT has_column_privilege('bar', 't', 1, 'SELECT WITH GRANT OPTION'),
+       has_column_privilege('bar', 't', 1, 'INSERT WITH GRANT OPTION'),
+       has_column_privilege('bar', 't', 1, 'UPDATE WITH GRANT OPTION'),
+       has_column_privilege('bar', 't', 1, 'REFERENCES WITH GRANT OPTION'),
+       has_column_privilege('bar', 't', 1, 'SELECT WITH GRANT OPTION, INSERT WITH GRANT OPTION, UPDATE WITH GRANT OPTION')
+----
+false  false  false  false  false
+
+query BBBB
+SELECT has_column_privilege(12345, 'col', 'SELECT'),
+       has_column_privilege(12345, 'col', 'INSERT'),
+       has_column_privilege(12345, 'col', 'UPDATE'),
+       has_column_privilege(12345, 'col', 'REFERENCES')
+----
+NULL  NULL  NULL  NULL
+
+query BBBB
+SELECT has_column_privilege((SELECT oid FROM pg_class WHERE relname = 'pg_type'), 'typname', 'SELECT'),
+       has_column_privilege((SELECT oid FROM pg_class WHERE relname = 'pg_type'), 'typname', 'INSERT'),
+       has_column_privilege((SELECT oid FROM pg_class WHERE relname = 'pg_type'), 'typname', 'UPDATE'),
+       has_column_privilege((SELECT oid FROM pg_class WHERE relname = 'pg_type'), 'typname', 'REFERENCES')
+----
+false  false  false  false
+
+query BBBB
+SELECT has_column_privilege((SELECT oid FROM pg_class WHERE relname = 't'), 'a', 'SELECT'),
+       has_column_privilege((SELECT oid FROM pg_class WHERE relname = 't'), 'b', 'INSERT'),
+       has_column_privilege((SELECT oid FROM pg_class WHERE relname = 't'), 'a', 'UPDATE'),
+       has_column_privilege((SELECT oid FROM pg_class WHERE relname = 't'), 'b', 'REFERENCES')
+----
+true  true  true  true
+
+query error pgcode 42P01 relation "does_not_exist" does not exist
+SELECT has_column_privilege('does_not_exist', 'col', 'SELECT')
+
+query error pgcode 42703 column 'does not exist' of relation 'pg_type' does not exist
+SELECT has_column_privilege('pg_type', 'does not exist', 'SELECT')
+
+query BBBBB
+SELECT has_column_privilege('pg_type', 'typname', 'SELECT'),
+       has_column_privilege('pg_type', 'typname', 'INSERT'),
+       has_column_privilege('pg_type', 'typname', 'UPDATE'),
+       has_column_privilege('pg_type', 'typname', 'REFERENCES'),
+       has_column_privilege('pg_type', 'typname', 'SELECT, INSERT, UPDATE')
+----
+false  false  false  false  false
+
+query BBBBB
+SELECT has_column_privilege('t', 'a', 'SELECT'),
+       has_column_privilege('t', 'a', 'INSERT'),
+       has_column_privilege('t', 'a', 'UPDATE'),
+       has_column_privilege('t', 'a', 'REFERENCES'),
+       has_column_privilege('t', 'a', 'SELECT, INSERT, UPDATE')
+----
+true  true  true  true  true
+
+query BBBBB
+SELECT has_column_privilege('t', 'a', 'SELECT WITH GRANT OPTION'),
+       has_column_privilege('t', 'a', 'INSERT WITH GRANT OPTION'),
+       has_column_privilege('t', 'a', 'UPDATE WITH GRANT OPTION'),
+       has_column_privilege('t', 'a', 'REFERENCES WITH GRANT OPTION'),
+       has_column_privilege('t', 'a', 'SELECT WITH GRANT OPTION, INSERT WITH GRANT OPTION, UPDATE WITH GRANT OPTION')
+----
+true  true  true  true  true
+
+query error pgcode 22023 unrecognized privilege type: "USAGE"
+SELECT has_column_privilege('t', 'a', 'USAGE')
+
+query error pgcode 42704 role 'no_user' does not exist
+SELECT has_column_privilege('no_user', 't', 'a', 'SELECT')
+
+query BBBBB
+SELECT has_column_privilege('bar', 't', 'a', 'SELECT'),
+       has_column_privilege('bar', 't', 'a', 'INSERT'),
+       has_column_privilege('bar', 't', 'a', 'UPDATE'),
+       has_column_privilege('bar', 't', 'a', 'REFERENCES'),
+       has_column_privilege('bar', 't', 'a', 'SELECT, INSERT, UPDATE')
+----
+false  false  false  false  false
+
+query BBBBB
+SELECT has_column_privilege('bar', 't', 'a', 'SELECT WITH GRANT OPTION'),
+       has_column_privilege('bar', 't', 'a', 'INSERT WITH GRANT OPTION'),
+       has_column_privilege('bar', 't', 'a', 'UPDATE WITH GRANT OPTION'),
+       has_column_privilege('bar', 't', 'a', 'REFERENCES WITH GRANT OPTION'),
+       has_column_privilege('bar', 't', 'a', 'SELECT WITH GRANT OPTION, INSERT WITH GRANT OPTION, UPDATE WITH GRANT OPTION')
+----
+false  false  false  false  false
+
+
+## has_database_privilege
+
+query BBBB
+SELECT has_database_privilege(12345, 'CREATE'),
+       has_database_privilege(12345, 'CONNECT'),
+       has_database_privilege(12345, 'TEMPORARY'),
+       has_database_privilege(12345, 'TEMP')
+----
+NULL  NULL  NULL  NULL
+
+query BBBB
+SELECT has_database_privilege((SELECT oid FROM pg_database WHERE datname = 'system'), 'CREATE'),
+       has_database_privilege((SELECT oid FROM pg_database WHERE datname = 'system'), 'CONNECT'),
+       has_database_privilege((SELECT oid FROM pg_database WHERE datname = 'system'), 'TEMPORARY'),
+       has_database_privilege((SELECT oid FROM pg_database WHERE datname = 'system'), 'TEMP')
+----
+false  true  false  false
+
+query BBBB
+SELECT has_database_privilege((SELECT oid FROM pg_database WHERE datname = 'test'), 'CREATE'),
+       has_database_privilege((SELECT oid FROM pg_database WHERE datname = 'test'), 'CONNECT'),
+       has_database_privilege((SELECT oid FROM pg_database WHERE datname = 'test'), 'TEMPORARY'),
+       has_database_privilege((SELECT oid FROM pg_database WHERE datname = 'test'), 'TEMP')
+----
+true  true  true  true
+
+query error pgcode 3D000 database 'does_not_exist' does not exist
+SELECT has_database_privilege('does_not_exist', 'CREATE')
+
+query BBBBB
+SELECT has_database_privilege('system', '  CrEaTe      '),
+       has_database_privilege('system', '      CONNECT'),
+       has_database_privilege('system', 'TEMPORARY'),
+       has_database_privilege('system', 'TEMP'),
+       has_database_privilege('system', '  CrEaTe      ,CONNECT')
+----
+false  true  false  false  false
+
+query BBBBB
+SELECT has_database_privilege('test', '  CrEaTe      '),
+       has_database_privilege('test', '      CONNECT'),
+       has_database_privilege('test', 'TEMPORARY'),
+       has_database_privilege('test', 'TEMP'),
+       has_database_privilege('test', '  CrEaTe      ,CONNECT')
+----
+true  true  true  true  true
+
+query BBBBB
+SELECT has_database_privilege('test', 'CREATE WITH GRANT OPTION'),
+       has_database_privilege('test', 'CONNECT WITH GRANT OPTION'),
+       has_database_privilege('test', 'TEMPORARY WITH GRANT OPTION'),
+       has_database_privilege('test', 'TEMP WITH GRANT OPTION'),
+       has_database_privilege('test', 'CREATE WITH GRANT OPTION, CONNECT WITH GRANT OPTION')
+----
+true  true  true  true  true
+
+query error pgcode 22023 unrecognized privilege type: "UPDATE"
+SELECT has_database_privilege('test', 'UPDATE')
+
+query error pgcode 22023 unrecognized privilege type: "UPDATE"
+SELECT has_database_privilege('test', 'CREATE, UPDATE')
+
+query error pgcode 42704 role 'no_user' does not exist
+SELECT has_database_privilege('no_user', 'test', 'CREATE')
+
+query BBBBBB
+SELECT has_database_privilege('bar', 'test', 'CREATE'),
+       has_database_privilege('bar', 'test', 'CONNECT'),
+       has_database_privilege('bar', 'test', 'TEMPORARY'),
+       has_database_privilege('bar', 'test', 'TEMP'),
+       has_database_privilege('bar', 'test', 'CREATE, CONNECT'),
+       has_database_privilege('bar', 'test', 'CREATE, TEMP')
+----
+true  true  true  true  true  true
+
+query BBBBBB
+SELECT has_database_privilege('bar', 'test', 'CREATE WITH GRANT OPTION'),
+       has_database_privilege('bar', 'test', 'CONNECT WITH GRANT OPTION'),
+       has_database_privilege('bar', 'test', 'TEMPORARY WITH GRANT OPTION'),
+       has_database_privilege('bar', 'test', 'TEMP WITH GRANT OPTION'),
+       has_database_privilege('bar', 'test', 'CREATE WITH GRANT OPTION, CONNECT WITH GRANT OPTION'),
+       has_database_privilege('bar', 'test', 'CREATE WITH GRANT OPTION, TEMP WITH GRANT OPTION')
+----
+false  true  false  false  false  false
+
+
+## has_foreign_data_wrapper_privilege
+
+query B
+SELECT has_foreign_data_wrapper_privilege(12345, 'USAGE')
+----
+true
+
+query error pgcode 42704 foreign-data wrapper 'does_not_exist' does not exist
+SELECT has_foreign_data_wrapper_privilege('does_not_exist', 'USAGE')
+
+query B
+SELECT has_foreign_data_wrapper_privilege(12345, 'USAGE WITH GRANT OPTION')
+----
+true
+
+query error pgcode 22023 unrecognized privilege type: "UPDATE"
+SELECT has_foreign_data_wrapper_privilege(12345, 'UPDATE')
+
+query error pgcode 22023 unrecognized privilege type: "UPDATE"
+SELECT has_foreign_data_wrapper_privilege(12345, 'USAGE, UPDATE')
+
+query error pgcode 42704 role 'no_user' does not exist
+SELECT has_foreign_data_wrapper_privilege('no_user', 12345, 'USAGE')
+
+query B
+SELECT has_foreign_data_wrapper_privilege('bar', 12345, 'USAGE')
+----
+true
+
+
+## has_function_privilege
+
+query B
+SELECT has_function_privilege(12345, 'EXECUTE')
+----
+NULL
+
+query B
+SELECT has_function_privilege((SELECT oid FROM pg_proc LIMIT 1), 'EXECUTE')
+----
+true
+
+query error pgcode 42883 unknown function: does_not_exist()
+SELECT has_function_privilege('does_not_exist', 'EXECUTE')
+
+query error pgcode 42883 unknown function: does_not_exist()
+SELECT has_function_privilege('does_not_exist()', 'EXECUTE')
+
+query B
+SELECT has_function_privilege('version', '  EXECUTE      ')
+----
+true
+
+query B
+SELECT has_function_privilege('version()', 'EXECUTE')
+----
+true
+
+query B
+SELECT has_function_privilege('cos(float)', 'EXECUTE WITH GRANT OPTION')
+----
+true
+
+query error pgcode 22023 unrecognized privilege type: "UPDATE"
+SELECT has_function_privilege('acos(float)', 'UPDATE')
+
+query error pgcode 22023 unrecognized privilege type: "UPDATE"
+SELECT has_function_privilege('acos(float)', 'EXECUTE, UPDATE')
+
+query error pgcode 42704 role 'no_user' does not exist
+SELECT has_function_privilege('no_user', 'acos(float)', 'EXECUTE')
+
+query B
+SELECT has_function_privilege('bar', 'current_date'::REGPROC, 'EXECUTE')
+----
+true
+
+query B
+SELECT has_function_privilege('bar', 'current_date'::REGPROC::OID, 'EXECUTE')
+----
+true
+
+
+## has_language_privilege
+
+query B
+SELECT has_language_privilege(12345, 'USAGE')
+----
+NULL
+
+query error pgcode 42704 language 'does_not_exist' does not exist
+SELECT has_language_privilege('does_not_exist', 'USAGE')
+
+query B
+SELECT has_language_privilege(12345, 'USAGE WITH GRANT OPTION')
+----
+NULL
+
+query error pgcode 22023 unrecognized privilege type: "UPDATE"
+SELECT has_language_privilege(12345, 'UPDATE')
+
+query error pgcode 22023 unrecognized privilege type: "UPDATE"
+SELECT has_language_privilege(12345, 'USAGE, UPDATE')
+
+query error pgcode 42704 role 'no_user' does not exist
+SELECT has_language_privilege('no_user', 12345, 'USAGE')
+
+query B
+SELECT has_language_privilege('bar', 12345, 'USAGE')
+----
+NULL
+
+
+## has_schema_privilege
+
+query BB
+SELECT has_schema_privilege(12345, 'CREATE'), 
+       has_schema_privilege(12345, 'USAGE')
+----
+NULL  NULL
+
+query BB
+SELECT has_schema_privilege((SELECT oid FROM pg_namespace WHERE nspname = 'crdb_internal'), 'CREATE'),
+       has_schema_privilege((SELECT oid FROM pg_namespace WHERE nspname = 'crdb_internal'), 'USAGE')
+----
+true  true
+
+query BB
+SELECT has_schema_privilege((SELECT oid FROM pg_namespace WHERE nspname = 'pg_catalog'), 'CREATE'),
+       has_schema_privilege((SELECT oid FROM pg_namespace WHERE nspname = 'pg_catalog'), 'USAGE')
+----
+true  true
+
+query BB
+SELECT has_schema_privilege((SELECT oid FROM pg_namespace WHERE nspname = 'public'), 'CREATE'),
+       has_schema_privilege((SELECT oid FROM pg_namespace WHERE nspname = 'public'), 'USAGE')
+----
+true  true
+
+query error pgcode 3F000 schema 'does_not_exist' does not exist
+SELECT has_schema_privilege('does_not_exist', 'CREATE')
+
+query BBB
+SELECT has_schema_privilege('public', 'CREATE'),
+       has_schema_privilege('public', 'USAGE'),
+       has_schema_privilege('public', 'CREATE, USAGE')
+----
+true  true  true
+
+query BBB
+SELECT has_schema_privilege('public', 'CREATE WITH GRANT OPTION'),
+       has_schema_privilege('public', 'USAGE WITH GRANT OPTION'),
+       has_schema_privilege('public', 'CREATE WITH GRANT OPTION, USAGE WITH GRANT OPTION')
+----
+true  true  true
+
+query error pgcode 22023 unrecognized privilege type: "UPDATE"
+SELECT has_schema_privilege('public', 'UPDATE')
+
+query error pgcode 22023 unrecognized privilege type: "UPDATE"
+SELECT has_schema_privilege('public', 'CREATE, UPDATE')
+
+query error pgcode 42704 role 'no_user' does not exist
+SELECT has_schema_privilege('no_user', 'public', 'CREATE')
+
+query BBB
+SELECT has_schema_privilege('bar', 'public', 'CREATE'),
+       has_schema_privilege('bar', 'public', 'USAGE'),
+       has_schema_privilege('bar', 'public', 'CREATE, USAGE')
+----
+true  false  false
+
+query BBB
+SELECT has_schema_privilege('bar', 'public', 'CREATE WITH GRANT OPTION'),
+       has_schema_privilege('bar', 'public', 'USAGE WITH GRANT OPTION'),
+       has_schema_privilege('bar', 'public', 'CREATE WITH GRANT OPTION, USAGE WITH GRANT OPTION')
+----
+false  false  false
+
+
+## has_sequence_privilege
+
+query BBB
+SELECT has_sequence_privilege(12345, 'USAGE'),
+       has_sequence_privilege(12345, 'SELECT'),
+       has_sequence_privilege(12345, 'UPDATE')
+----
+NULL  NULL  NULL
+
+query BBB
+SELECT has_sequence_privilege((SELECT oid FROM pg_class WHERE relname = 'seq'), 'USAGE'),
+       has_sequence_privilege((SELECT oid FROM pg_class WHERE relname = 'seq'), 'SELECT'),
+       has_sequence_privilege((SELECT oid FROM pg_class WHERE relname = 'seq'), 'UPDATE')
+----
+true  true  true
+
+query error pgcode 42P01 relation "does_not_exist" does not exist
+SELECT has_sequence_privilege('does_not_exist', 'SELECT')
+
+query error pgcode 42809 't' is not a sequence
+SELECT has_sequence_privilege('t', 'SELECT')
+
+query BBB
+SELECT has_sequence_privilege('seq', 'USAGE'),
+       has_sequence_privilege('seq', 'SELECT'),
+       has_sequence_privilege('seq', 'UPDATE')
+----
+true  true  true
+
+query BBB
+SELECT has_sequence_privilege('seq', 'USAGE WITH GRANT OPTION'),
+       has_sequence_privilege('seq', 'SELECT WITH GRANT OPTION'),
+       has_sequence_privilege('seq', 'UPDATE WITH GRANT OPTION')
+----
+true  true  true
+
+query error pgcode 22023 unrecognized privilege type: "DELETE"
+SELECT has_sequence_privilege('seq', 'DELETE')
+
+query error pgcode 22023 unrecognized privilege type: "DELETE"
+SELECT has_sequence_privilege('seq', 'SELECT, DELETE')
+
+user testuser
+
+query BBB
+SELECT has_sequence_privilege('seq', 'USAGE'),
+       has_sequence_privilege('seq', 'SELECT'),
+       has_sequence_privilege('seq', 'UPDATE')
+----
+true  true  false
+
+query BBB
+SELECT has_sequence_privilege('seq', 'USAGE WITH GRANT OPTION'),
+       has_sequence_privilege('seq', 'SELECT WITH GRANT OPTION'),
+       has_sequence_privilege('seq', 'UPDATE WITH GRANT OPTION')
+----
+true  true  false
+
+user root
+
+query error pgcode 42704 role 'no_user' does not exist
+SELECT has_sequence_privilege('no_user', 'seq', 'SELECT')
+
+query BBB
+SELECT has_sequence_privilege('bar', 'seq', 'USAGE'),
+       has_sequence_privilege('bar', 'seq', 'SELECT'),
+       has_sequence_privilege('bar', 'seq', 'UPDATE')
+----
+true  true  false
+
+query BBB
+SELECT has_sequence_privilege('bar', 'seq', 'USAGE WITH GRANT OPTION'),
+       has_sequence_privilege('bar', 'seq', 'SELECT WITH GRANT OPTION'),
+       has_sequence_privilege('bar', 'seq', 'UPDATE WITH GRANT OPTION')
+----
+false  false  false
+
+
+## has_server_privilege
+
+query B
+SELECT has_server_privilege(12345, 'USAGE')
+----
+true
+
+query error pgcode 42704 server 'does_not_exist' does not exist
+SELECT has_server_privilege('does_not_exist', 'USAGE')
+
+query B
+SELECT has_server_privilege(12345, 'USAGE WITH GRANT OPTION')
+----
+true
+
+query error pgcode 22023 unrecognized privilege type: "UPDATE"
+SELECT has_server_privilege(12345, 'UPDATE')
+
+query error pgcode 22023 unrecognized privilege type: "UPDATE"
+SELECT has_server_privilege(12345, 'USAGE, UPDATE')
+
+query error pgcode 42704 role 'no_user' does not exist
+SELECT has_server_privilege('no_user', 12345, 'USAGE')
+
+query B
+SELECT has_server_privilege('bar', 12345, 'USAGE')
+----
+true
+
+
+## has_table_privilege
+
+query BBBBBBB
+SELECT has_table_privilege(12345, 'SELECT'),
+       has_table_privilege(12345, 'INSERT'),
+       has_table_privilege(12345, 'UPDATE'),
+       has_table_privilege(12345, 'DELETE'),
+       has_table_privilege(12345, 'TRUNCATE'),
+       has_table_privilege(12345, 'REFERENCES'),
+       has_table_privilege(12345, 'TRIGGER')
+----
+NULL  NULL  NULL  NULL  NULL  NULL  NULL
+
+query BBBBBBB
+SELECT has_table_privilege((SELECT oid FROM pg_class WHERE relname = 'pg_type'), 'SELECT'),
+       has_table_privilege((SELECT oid FROM pg_class WHERE relname = 'pg_type'), 'INSERT'),
+       has_table_privilege((SELECT oid FROM pg_class WHERE relname = 'pg_type'), 'UPDATE'),
+       has_table_privilege((SELECT oid FROM pg_class WHERE relname = 'pg_type'), 'DELETE'),
+       has_table_privilege((SELECT oid FROM pg_class WHERE relname = 'pg_type'), 'TRUNCATE'),
+       has_table_privilege((SELECT oid FROM pg_class WHERE relname = 'pg_type'), 'REFERENCES'),
+       has_table_privilege((SELECT oid FROM pg_class WHERE relname = 'pg_type'), 'TRIGGER')
+----
+false  false  false  false  false  false  false
+
+query BBBBBBB
+SELECT has_table_privilege((SELECT oid FROM pg_class WHERE relname = 't'), 'SELECT'),
+       has_table_privilege((SELECT oid FROM pg_class WHERE relname = 't'), 'INSERT'),
+       has_table_privilege((SELECT oid FROM pg_class WHERE relname = 't'), 'UPDATE'),
+       has_table_privilege((SELECT oid FROM pg_class WHERE relname = 't'), 'DELETE'),
+       has_table_privilege((SELECT oid FROM pg_class WHERE relname = 't'), 'TRUNCATE'),
+       has_table_privilege((SELECT oid FROM pg_class WHERE relname = 't'), 'REFERENCES'),
+       has_table_privilege((SELECT oid FROM pg_class WHERE relname = 't'), 'TRIGGER')
+----
+true  true  true  true  true  true  true
+
+query error pgcode 42P01 relation "does_not_exist" does not exist
+SELECT has_table_privilege('does_not_exist', 'SELECT')
+
+query BBBBBBBBB
+SELECT has_table_privilege('pg_type', 'SELECT'),
+       has_table_privilege('pg_type', 'INSERT'),
+       has_table_privilege('pg_type', 'UPDATE'),
+       has_table_privilege('pg_type', 'DELETE'),
+       has_table_privilege('pg_type', 'TRUNCATE'),
+       has_table_privilege('pg_type', 'REFERENCES'),
+       has_table_privilege('pg_type', 'TRIGGER'),
+       has_table_privilege('pg_type', 'SELECT, INSERT, UPDATE'),
+       has_table_privilege('pg_type', 'SELECT, TRUNCATE')
+----
+false  false  false  false  false  false  false  false  false
+
+query BBBBBBBBB
+SELECT has_table_privilege('t', 'SELECT'),
+       has_table_privilege('t', 'INSERT'),
+       has_table_privilege('t', 'UPDATE'),
+       has_table_privilege('t', 'DELETE'),
+       has_table_privilege('t', 'TRUNCATE'),
+       has_table_privilege('t', 'REFERENCES'),
+       has_table_privilege('t', 'TRIGGER'),
+       has_table_privilege('t', 'SELECT, INSERT, UPDATE'),
+       has_table_privilege('t', 'SELECT, TRUNCATE')
+----
+true  true  true  true  true  true  true  true  true
+
+query BBBBBBBBB
+SELECT has_table_privilege('t', 'SELECT WITH GRANT OPTION'),
+       has_table_privilege('t', 'INSERT WITH GRANT OPTION'),
+       has_table_privilege('t', 'UPDATE WITH GRANT OPTION'),
+       has_table_privilege('t', 'DELETE WITH GRANT OPTION'),
+       has_table_privilege('t', 'TRUNCATE WITH GRANT OPTION'),
+       has_table_privilege('t', 'REFERENCES WITH GRANT OPTION'),
+       has_table_privilege('t', 'TRIGGER WITH GRANT OPTION'),
+       has_table_privilege('t', 'SELECT WITH GRANT OPTION, INSERT WITH GRANT OPTION, UPDATE WITH GRANT OPTION'),
+       has_table_privilege('t', 'SELECT WITH GRANT OPTION, TRUNCATE WITH GRANT OPTION')
+----
+true  true  true  true  true  true  true  true  true
+
+# has_table_privilege works with sequences as well.
+query BBBBBBBBB
+SELECT has_table_privilege('seq', 'SELECT'),
+       has_table_privilege('seq', 'INSERT'),
+       has_table_privilege('seq', 'UPDATE'),
+       has_table_privilege('seq', 'DELETE'),
+       has_table_privilege('seq', 'TRUNCATE'),
+       has_table_privilege('seq', 'REFERENCES'),
+       has_table_privilege('seq', 'TRIGGER'),
+       has_table_privilege('seq', 'SELECT, INSERT, UPDATE'),
+       has_table_privilege('seq', 'SELECT, TRUNCATE')
+----
+true  true  true  true  true  true  true  true  true
+
+query error pgcode 22023 unrecognized privilege type: "USAGE"
+SELECT has_table_privilege('t', 'USAGE')
+
+query error pgcode 22023 unrecognized privilege type: "USAGE"
+SELECT has_table_privilege('t', 'SELECT, USAGE')
+
+query error pgcode 42704 role 'no_user' does not exist
+SELECT has_table_privilege('no_user', 't', 'SELECT')
+
+query BBBBBBBBB
+SELECT has_table_privilege('bar', 't', 'SELECT'),
+       has_table_privilege('bar', 't', 'INSERT'),
+       has_table_privilege('bar', 't', 'UPDATE'),
+       has_table_privilege('bar', 't', 'DELETE'),
+       has_table_privilege('bar', 't', 'TRUNCATE'),
+       has_table_privilege('bar', 't', 'REFERENCES'),
+       has_table_privilege('bar', 't', 'TRIGGER'),
+       has_table_privilege('bar', 't', 'SELECT, INSERT, UPDATE'),
+       has_table_privilege('bar', 't', 'SELECT, TRUNCATE')
+----
+false  false  false  true  true  false  true  false  false
+
+query BBBBBBBBB
+SELECT has_table_privilege('bar', 't', 'SELECT WITH GRANT OPTION'),
+       has_table_privilege('bar', 't', 'INSERT WITH GRANT OPTION'),
+       has_table_privilege('bar', 't', 'UPDATE WITH GRANT OPTION'),
+       has_table_privilege('bar', 't', 'DELETE WITH GRANT OPTION'),
+       has_table_privilege('bar', 't', 'TRUNCATE WITH GRANT OPTION'),
+       has_table_privilege('bar', 't', 'REFERENCES WITH GRANT OPTION'),
+       has_table_privilege('bar', 't', 'TRIGGER WITH GRANT OPTION'),
+       has_table_privilege('bar', 't', 'SELECT WITH GRANT OPTION, INSERT WITH GRANT OPTION, UPDATE WITH GRANT OPTION'),
+       has_table_privilege('bar', 't', 'SELECT WITH GRANT OPTION, TRUNCATE WITH GRANT OPTION')
+----
+false  false  false  true  true  false  true  false  false
+
+
+## has_tablespace_privilege
+
+query B
+SELECT has_tablespace_privilege(12345, 'CREATE')
+----
+true
+
+query B
+SELECT has_tablespace_privilege((SELECT oid FROM pg_tablespace LIMIT 1), 'CREATE')
+----
+true
+
+query error pgcode 42704 tablespace 'does_not_exist' does not exist
+SELECT has_tablespace_privilege('does_not_exist', 'CREATE')
+
+query B
+SELECT has_tablespace_privilege('pg_default', '  CrEaTe      ')
+----
+true
+
+query B
+SELECT has_tablespace_privilege('pg_default', 'CREATE WITH GRANT OPTION')
+----
+true
+
+query error pgcode 22023 unrecognized privilege type: "CREATE    WITH GRANT OPTION"
+SELECT has_tablespace_privilege('pg_default', 'CREATE    WITH GRANT OPTION')
+
+query error pgcode 22023 unrecognized privilege type: "UPDATE"
+SELECT has_tablespace_privilege('pg_default', 'UPDATE')
+
+query error pgcode 22023 unrecognized privilege type: "UPDATE"
+SELECT has_tablespace_privilege('pg_default', 'CREATE, UPDATE')
+
+query error pgcode 42704 role 'no_user' does not exist
+SELECT has_tablespace_privilege('no_user', 'pg_default', 'CREATE')
+
+query B
+SELECT has_tablespace_privilege('bar', (SELECT oid FROM pg_tablespace LIMIT 1), 'CREATE')
+----
+true
+
+
+## has_type_privilege
+
+query B
+SELECT has_type_privilege(12345, 'USAGE')
+----
+NULL
+
+query B
+SELECT has_type_privilege((SELECT oid FROM pg_type LIMIT 1), 'USAGE')
+----
+true
+
+query error pgcode 42704 type 'does_not_exist' does not exist
+SELECT has_type_privilege('does_not_exist', 'USAGE')
+
+query B
+SELECT has_type_privilege('int', '  USAGE      ')
+----
+true
+
+query B
+SELECT has_type_privilege('decimal(18,2)', 'USAGE WITH GRANT OPTION')
+----
+true
+
+query error pgcode 22023 unrecognized privilege type: "UPDATE"
+SELECT has_type_privilege('int4', 'UPDATE')
+
+query error pgcode 22023 unrecognized privilege type: "UPDATE"
+SELECT has_type_privilege('int4', 'USAGE, UPDATE')
+
+query error pgcode 42704 role 'no_user' does not exist
+SELECT has_type_privilege('no_user', 'int4', 'USAGE')
+
+query B
+SELECT has_type_privilege('bar', 'text'::REGTYPE, 'USAGE')
+----
+true
+
+query B
+SELECT has_type_privilege('bar', 'text'::REGTYPE::OID, 'USAGE')
+----
+true

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -74,6 +74,7 @@ var pgCatalog = virtualSchema{
 		pgCatalogIndexTable,
 		pgCatalogIndexesTable,
 		pgCatalogInheritsTable,
+		pgCatalogLanguageTable,
 		pgCatalogNamespaceTable,
 		pgCatalogOperatorTable,
 		pgCatalogProcTable,
@@ -1068,6 +1069,27 @@ CREATE TABLE pg_catalog.pg_inherits (
 `,
 	populate: func(_ context.Context, p *planner, _ *DatabaseDescriptor, addRow func(...tree.Datum) error) error {
 		// Table inheritance is not supported.
+		return nil
+	},
+}
+
+// See: https://www.postgresql.org/docs/9.6/static/catalog-pg-language.html.
+var pgCatalogLanguageTable = virtualSchemaTable{
+	schema: `
+CREATE TABLE pg_catalog.pg_language (
+	oid OID,
+	lanname NAME,
+	lanowner OID,
+	lanispl BOOL,
+	lanpltrusted BOOL,
+	lanplcallfoid OID,
+	laninline OID,
+	lanvalidator OID,
+	lanacl STRING[]
+);
+`,
+	populate: func(_ context.Context, p *planner, _ *DatabaseDescriptor, addRow func(...tree.Datum) error) error {
+		// Languages to write functions and stored procedures are not supported.
 		return nil
 	},
 }

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -96,7 +96,7 @@ var pgCatalog = virtualSchema{
 	validWithNoDatabaseContext: false,
 }
 
-// See: https://www.postgresql.org/docs/current/static/catalog-pg-am.html.
+// See: https://www.postgresql.org/docs/9.6/static/catalog-pg-am.html.
 var pgCatalogAmTable = virtualSchemaTable{
 	schema: `
 CREATE TABLE pg_catalog.pg_am (
@@ -837,7 +837,7 @@ CREATE TABLE pg_catalog.pg_extension (
 	},
 }
 
-// See: https://www.postgresql.org/docs/10/static/catalog-pg-foreign-data-wrapper.html
+// See: https://www.postgresql.org/docs/9.6/static/catalog-pg-foreign-data-wrapper.html.
 var pgCatalogForeignDataWrapperTable = virtualSchemaTable{
 	schema: `
 CREATE TABLE pg_catalog.pg_foreign_data_wrapper (
@@ -1106,25 +1106,25 @@ var (
 	_ = postfixKind
 )
 
-// See: https://www.postgresql.org/docs/10/static/catalog-pg-operator.html.
+// See: https://www.postgresql.org/docs/9.6/static/catalog-pg-operator.html.
 var pgCatalogOperatorTable = virtualSchemaTable{
 	schema: `
 CREATE TABLE pg_catalog.pg_operator (
 	oid OID,
-  oprname NAME,
-  oprnamespace OID,
-  oprowner OID,
-  oprkind TEXT,
-  oprcanmerge BOOL,
-  oprcanhash BOOL,
-  oprleft OID,
-  oprright OID,
-  oprresult OID,
-  oprcom OID,
-  oprnegate OID,
-  oprcode OID,
-  oprrest OID,
-  oprjoin OID
+	oprname NAME,
+	oprnamespace OID,
+	oprowner OID,
+	oprkind TEXT,
+	oprcanmerge BOOL,
+	oprcanhash BOOL,
+	oprleft OID,
+	oprright OID,
+	oprresult OID,
+	oprcom OID,
+	oprnegate OID,
+	oprcode OID,
+	oprrest OID,
+	oprjoin OID
 );
 `,
 	populate: func(ctx context.Context, p *planner, db *DatabaseDescriptor, addRow func(...tree.Datum) error) error {
@@ -1215,7 +1215,7 @@ var (
 	_ = proArgModeTable
 )
 
-// See: https://www.postgresql.org/docs/9.6/static/catalog-pg-proc.html
+// See: https://www.postgresql.org/docs/9.6/static/catalog-pg-proc.html.
 var pgCatalogProcTable = virtualSchemaTable{
 	schema: `
 CREATE TABLE pg_catalog.pg_proc (
@@ -1392,18 +1392,18 @@ CREATE TABLE pg_catalog.pg_range (
 	},
 }
 
-// See: https://www.postgresql.org/docs/10/static/catalog-pg-rewrite.html.
+// See: https://www.postgresql.org/docs/9.6/static/catalog-pg-rewrite.html.
 var pgCatalogRewriteTable = virtualSchemaTable{
 	schema: `
 CREATE TABLE pg_catalog.pg_rewrite (
-  oid OID,
-  rulename NAME,
-  ev_class OID,
-  ev_type TEXT,
-  ev_enabled TEXT,
-  is_instead BOOL,
-  ev_qual TEXT,
-  ev_action TEXT
+	oid OID,
+	rulename NAME,
+	ev_class OID,
+	ev_type TEXT,
+	ev_enabled TEXT,
+	is_instead BOOL,
+	ev_qual TEXT,
+	ev_action TEXT
 );
 `,
 	populate: func(_ context.Context, p *planner, _ *DatabaseDescriptor, addRow func(...tree.Datum) error) error {
@@ -1462,7 +1462,7 @@ CREATE TABLE pg_catalog.pg_roles (
 	},
 }
 
-// See: https://www.postgresql.org/docs/10/static/catalog-pg-sequence.html
+// See: https://www.postgresql.org/docs/10/static/catalog-pg-sequence.html.
 var pgCatalogSequencesTable = virtualSchemaTable{
 	schema: `
 CREATE TABLE pg_catalog.pg_sequence (
@@ -1594,16 +1594,16 @@ CREATE TABLE pg_catalog.pg_tables (
 	},
 }
 
-// See: https://www.postgresql.org/docs/9.6/static/catalog-pg-tablespace.html
+// See: https://www.postgresql.org/docs/9.6/static/catalog-pg-tablespace.html.
 var pgCatalogTablespaceTable = virtualSchemaTable{
 	schema: `
 CREATE TABLE pg_catalog.pg_tablespace (
-  oid OID,
-  spcname NAME,
-  spcowner OID,
-  spclocation TEXT,
-  spcacl TEXT[],
-  spcoptions TEXT[]
+	oid OID,
+	spcname NAME,
+	spcowner OID,
+	spclocation TEXT,
+	spcacl TEXT[],
+	spcoptions TEXT[]
 );
 `,
 	populate: func(ctx context.Context, p *planner, prefix *DatabaseDescriptor, addRow func(...tree.Datum) error) error {
@@ -1618,28 +1618,28 @@ CREATE TABLE pg_catalog.pg_tablespace (
 	},
 }
 
-// See: https://www.postgresql.org/docs/10/static/catalog-pg-trigger.html
+// See: https://www.postgresql.org/docs/9.6/static/catalog-pg-trigger.html.
 var pgCatalogTriggerTable = virtualSchemaTable{
 	schema: `
 CREATE TABLE pg_catalog.pg_trigger (
-  oid OID,
-  tgrelid OID,
-  tgname NAME,
-  tgfoid OID,
-  tgtype INT,
-  tgenabled TEXT,
-  tgisinternal BOOL,
-  tgconstrrelid OID,
-  tgconstrindid OID,
-  tgconstraint OID,
-  tgdeferrable BOOL,
-  tginitdeferred BOOL,
-  tgnargs INT,
-  tgattr INT2VECTOR,
-  tgargs BYTEA,
-  tgqual TEXT,
-  tgoldtable NAME,
-  tgnewtable NAME
+	oid OID,
+	tgrelid OID,
+	tgname NAME,
+	tgfoid OID,
+	tgtype INT,
+	tgenabled TEXT,
+	tgisinternal BOOL,
+	tgconstrrelid OID,
+	tgconstrindid OID,
+	tgconstraint OID,
+	tgdeferrable BOOL,
+	tginitdeferred BOOL,
+	tgnargs INT,
+	tgattr INT2VECTOR,
+	tgargs BYTEA,
+	tgqual TEXT,
+	tgoldtable NAME,
+	tgnewtable NAME
 );
 `,
 	populate: func(ctx context.Context, p *planner, prefix *DatabaseDescriptor, addRow func(...tree.Datum) error) error {
@@ -1807,19 +1807,19 @@ CREATE TABLE pg_catalog.pg_type (
 	},
 }
 
-// See: https://www.postgresql.org/docs/10/static/view-pg-user.html
+// See: https://www.postgresql.org/docs/9.6/static/view-pg-user.html.
 var pgCatalogUserTable = virtualSchemaTable{
 	schema: `
 CREATE TABLE pg_catalog.pg_user (
-  usename NAME,
-  usesysid OID,
-  usecreatedb BOOL,
-  usesuper BOOL,
-  userepl  BOOL,
-  usebypassrls BOOL,
-  passwd TEXT,
-  valuntil TIMESTAMP,
-  useconfig TEXT[]
+	usename NAME,
+	usesysid OID,
+	usecreatedb BOOL,
+	usesuper BOOL,
+	userepl  BOOL,
+	usebypassrls BOOL,
+	passwd TEXT,
+	valuntil TIMESTAMP,
+	useconfig TEXT[]
 );
 `,
 	populate: func(ctx context.Context, p *planner, _ *DatabaseDescriptor, addRow func(...tree.Datum) error) error {
@@ -1845,14 +1845,14 @@ CREATE TABLE pg_catalog.pg_user (
 	},
 }
 
-// See: https://www.postgresql.org/docs/10/static/view-pg-user.html
+// See: https://www.postgresql.org/docs/9.6/static/catalog-pg-user-mapping.html.
 var pgCatalogUserMappingTable = virtualSchemaTable{
 	schema: `
 CREATE TABLE pg_catalog.pg_user_mapping (
-  oid OID,
-  umuser OID,
-  umserver OID,
-  umoptions TEXT[]
+	oid OID,
+	umuser OID,
+	umserver OID,
+	umoptions TEXT[]
 );
 `,
 	populate: func(ctx context.Context, p *planner, _ *DatabaseDescriptor, addRow func(...tree.Datum) error) error {

--- a/pkg/sql/sem/tree/parse_array.go
+++ b/pkg/sql/sem/tree/parse_array.go
@@ -138,7 +138,7 @@ func (p *parseState) parseElement() error {
 		}
 	}
 
-	d, err := performCast(p.evalCtx, NewDString(next), p.t)
+	d, err := PerformCast(p.evalCtx, NewDString(next), p.t)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Fixes #22734.
Fixes #20784.
Relates to #15441.

This change introduces a series of Postgres-compatible privilege-related
builtin functions:
- `has_any_column_privilege`
- `has_column_privilege`
- `has_database_privilege`
- `has_foreign_data_wrapper_privilege`
- `has_function_privilege`
- `has_language_privilege`
- `has_schema_privilege`
- `has_sequence_privilege`
- `has_server_privilege`
- `has_table_privilege`
- `has_tablespace_privilege`
- `has_type_privilege`
- `pg_has_role` (_coming soon!_)

These all follow the specification documented by Postgres in:
https://www.postgresql.org/docs/8.4/static/functions-info.html#FUNCTIONS-INFO-ACCESS-TABLE

These Access Privilege Inquiry Functions allow users to query object
access privileges programmatically. Each function has a number of
variants, which differ based on their function signatures. These
signatures have the following structure:
```
- optional "user" argument
  - if used, can be a STRING or an OID type
  - if not used, current_user is assumed
- series of one or more object specifier arguments
  - each can accept multiple types
- a "privilege" argument
  - must be a STRING
  - parsed as a comma-separated list of privilege
```

This means that in total, each function has at least 6 variants.

The main reason for adding these builtins in is because they were the
last remaining issue that was blocking full compatibility with [pgweb](http://sosedoff.github.io/pgweb/).
Pgweb is a web-based database browser written in Go, which means that
can run on OSX, Linux and Windows machines! Here's what TPC-C looks
like in pgweb:

![screenshot-2018-3-2 pgweb](https://user-images.githubusercontent.com/5438456/36929801-f26b5acc-1e63-11e8-863c-a8f06a990ead.png) 

Release note (sql change): Introduces a series of Postgres-compatible
privilege-related builtin functions.