### PR TITLE
opt: support CASE statements

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/scalar
+++ b/pkg/sql/opt/exec/execbuilder/testdata/scalar
@@ -237,14 +237,62 @@ render     0  render  ·         ·            (column8)                        
 ·          1  ·       table     t@primary    ·                                  ·
 ·          1  ·       spans     ALL          ·                                  ·
 
-exec-explain allow-unsupported
+exec-explain
+SELECT CASE a WHEN 1 THEN 2 WHEN 2 THEN 3 ELSE 4 END FROM t.t
+----
+render     0  render  ·         ·                                              (column8)                          ·
+ │         0  ·       render 0  CASE a WHEN 1 THEN 2 WHEN 2 THEN 3 ELSE 4 END  ·                                  ·
+ └── scan  1  scan    ·         ·                                              (a, b, c, d, j, s, rowid[hidden])  ·
+·          1  ·       table     t@primary                                      ·                                  ·
+·          1  ·       spans     ALL                                            ·                                  ·
+
+exec-explain
 SELECT CASE WHEN a = 2 THEN 1 ELSE 2 END FROM t.t
 ----
-render     0  render  ·         ·                                             (column8)                          ·
- │         0  ·       render 0  CASE WHEN t.public.t.a = 2 THEN 1 ELSE 2 END  ·                                  ·
- └── scan  1  scan    ·         ·                                             (a, b, c, d, j, s, rowid[hidden])  ·
-·          1  ·       table     t@primary                                     ·                                  ·
-·          1  ·       spans     ALL                                           ·                                  ·
+render     0  render  ·         ·                                  (column8)                          ·
+ │         0  ·       render 0  CASE WHEN a = 2 THEN 1 ELSE 2 END  ·                                  ·
+ └── scan  1  scan    ·         ·                                  (a, b, c, d, j, s, rowid[hidden])  ·
+·          1  ·       table     t@primary                          ·                                  ·
+·          1  ·       spans     ALL                                ·                                  ·
+
+exec-explain
+SELECT CASE a + 3 WHEN 5 * b THEN 1 % b WHEN 6 THEN 2 ELSE -1 END FROM t.t
+----
+render     0  render  ·         ·                                                           (column8)                          ·
+ │         0  ·       render 0  CASE a + 3 WHEN 5 * b THEN 1 % b WHEN 6 THEN 2 ELSE -1 END  ·                                  ·
+ └── scan  1  scan    ·         ·                                                           (a, b, c, d, j, s, rowid[hidden])  ·
+·          1  ·       table     t@primary                                                   ·                                  ·
+·          1  ·       spans     ALL                                                         ·                                  ·
+
+# Tests for CASE with no ELSE statement
+exec-explain
+SELECT CASE WHEN a = 2 THEN 1 END FROM t.t
+----
+render     0  render  ·         ·                           (column8)                          ·
+ │         0  ·       render 0  CASE WHEN a = 2 THEN 1 END  ·                                  ·
+ └── scan  1  scan    ·         ·                           (a, b, c, d, j, s, rowid[hidden])  ·
+·          1  ·       table     t@primary                   ·                                  ·
+·          1  ·       spans     ALL                         ·                                  ·
+
+exec-explain
+SELECT CASE a WHEN 2 THEN 1 END FROM t.t
+----
+render     0  render  ·         ·                         (column8)                          ·
+ │         0  ·       render 0  CASE a WHEN 2 THEN 1 END  ·                                  ·
+ └── scan  1  scan    ·         ·                         (a, b, c, d, j, s, rowid[hidden])  ·
+·          1  ·       table     t@primary                 ·                                  ·
+·          1  ·       spans     ALL                       ·                                  ·
+
+exec-explain allow-unsupported
+SELECT a FROM t.t WHERE a IS OF (INT)
+----
+render          0  render  ·         ·                         ("t.a")                            ·
+ │              0  ·       render 0  a                         ·                                  ·
+ └── filter     1  filter  ·         ·                         (a, b, c, d, j, s, rowid[hidden])  ·
+      │         1  ·       filter    t.public.t.a IS OF (INT)  ·                                  ·
+      └── scan  2  scan    ·         ·                         (a, b, c, d, j, s, rowid[hidden])  ·
+·               2  ·       table     t@primary                 ·                                  ·
+·               2  ·       spans     ALL                       ·                                  ·
 
 exec-explain
 SELECT LENGTH(s) FROM t.t

--- a/pkg/sql/opt/factory.og.go
+++ b/pkg/sql/opt/factory.og.go
@@ -237,6 +237,31 @@ type Factory interface {
 	// ConstructCast constructs an expression for the Cast operator.
 	ConstructCast(input GroupID, typ PrivateID) GroupID
 
+	// ConstructCase constructs an expression for the Case operator.
+	// Case is a CASE statement of the form:
+	//   CASE [ <Input> ]
+	//       WHEN <condval1> THEN <expr1>
+	//     [ WHEN <condval2> THEN <expr2> ] ...
+	//     [ ELSE <expr> ]
+	//   END
+	//
+	// The Case operator evaluates <Input> (if not provided, Input is set to True),
+	// then picks the WHEN branch where <condval> is equal to
+	// <cond>, then evaluates and returns the corresponding THEN expression. If no
+	// WHEN branch matches, the ELSE expression is evaluated and returned, if any.
+	// Otherwise, NULL is returned.
+	//
+	// Note that the Whens list inside Case is used to represent all the WHEN
+	// branches as well as the ELSE statement if it exists. It is of the form:
+	// [(When <condval1> <expr1>),(When <condval2> <expr2>),...,<expr>]
+	ConstructCase(input GroupID, whens ListID) GroupID
+
+	// ConstructWhen constructs an expression for the When operator.
+	// When represents a single WHEN ... THEN ... condition inside a CASE statement.
+	// It is the type of each list item in Whens (except for the last item which is
+	// a raw expression for the ELSE statement).
+	ConstructWhen(condition GroupID, value GroupID) GroupID
+
 	// ConstructFunction constructs an expression for the Function operator.
 	// Function invokes a builtin SQL function like CONCAT or NOW, passing the given
 	// arguments. The private field is an opt.FuncDef struct that provides the name

--- a/pkg/sql/opt/idxconstraint/testdata/misc
+++ b/pkg/sql/opt/idxconstraint/testdata/misc
@@ -176,6 +176,12 @@ index-constraints vars=(int, int, int) index=(@1, @2, @3)
 (/1/NULL - /1]
 Remaining filter: @2 = CASE WHEN @3 = 2 THEN 1 ELSE 2 END
 
+index-constraints vars=(int, int) index=(@1, @2)
+@1 = 1 AND @2 IS OF (INT)
+----
+[/1 - /1]
+Remaining filter: @2 IS OF (INT)
+
 # This testcase exposed an issue around extending spans. We don't normalize the
 # expression so we have a hierarchy of ANDs (which requires a more complex path
 # for calculating spans). As a side-effect of disabling normalization, an

--- a/pkg/sql/opt/operator.og.go
+++ b/pkg/sql/opt/operator.og.go
@@ -163,6 +163,29 @@ const (
 
 	CastOp
 
+	// CaseOp is a CASE statement of the form:
+	//   CASE [ <Input> ]
+	//       WHEN <condval1> THEN <expr1>
+	//     [ WHEN <condval2> THEN <expr2> ] ...
+	//     [ ELSE <expr> ]
+	//   END
+	//
+	// The Case operator evaluates <Input> (if not provided, Input is set to True),
+	// then picks the WHEN branch where <condval> is equal to
+	// <cond>, then evaluates and returns the corresponding THEN expression. If no
+	// WHEN branch matches, the ELSE expression is evaluated and returned, if any.
+	// Otherwise, NULL is returned.
+	//
+	// Note that the Whens list inside Case is used to represent all the WHEN
+	// branches as well as the ELSE statement if it exists. It is of the form:
+	// [(When <condval1> <expr1>),(When <condval2> <expr2>),...,<expr>]
+	CaseOp
+
+	// WhenOp represents a single WHEN ... THEN ... condition inside a CASE statement.
+	// It is the type of each list item in Whens (except for the last item which is
+	// a raw expression for the ELSE statement).
+	WhenOp
+
 	// FunctionOp invokes a builtin SQL function like CONCAT or NOW, passing the given
 	// arguments. The private field is an opt.FuncDef struct that provides the name
 	// of the function as well as a pointer to the builtin overload definition.
@@ -342,9 +365,9 @@ const (
 	NumOperators
 )
 
-const opNames = "unknownsubqueryvariableconstnulltruefalseplaceholdertupleprojectionsaggregationsexistsandornoteqltgtlegeneinnot-inlikenot-likei-likenot-i-likesimilar-tonot-similar-toreg-matchnot-reg-matchreg-i-matchnot-reg-i-matchisis-notcontainsbitandbitorbitxorplusminusmultdivfloor-divmodpowconcatl-shiftr-shiftfetch-valfetch-textfetch-val-pathfetch-text-pathunary-plusunary-minusunary-complementcastfunctioncoalesceunsupported-exprscanvaluesselectprojectinner-joinleft-joinright-joinfull-joinsemi-joinanti-joininner-join-applyleft-join-applyright-join-applyfull-join-applysemi-join-applyanti-join-applygroup-byunionintersectexceptunion-allintersect-allexcept-allsort"
+const opNames = "unknownsubqueryvariableconstnulltruefalseplaceholdertupleprojectionsaggregationsexistsandornoteqltgtlegeneinnot-inlikenot-likei-likenot-i-likesimilar-tonot-similar-toreg-matchnot-reg-matchreg-i-matchnot-reg-i-matchisis-notcontainsbitandbitorbitxorplusminusmultdivfloor-divmodpowconcatl-shiftr-shiftfetch-valfetch-textfetch-val-pathfetch-text-pathunary-plusunary-minusunary-complementcastcasewhenfunctioncoalesceunsupported-exprscanvaluesselectprojectinner-joinleft-joinright-joinfull-joinsemi-joinanti-joininner-join-applyleft-join-applyright-join-applyfull-join-applysemi-join-applyanti-join-applygroup-byunionintersectexceptunion-allintersect-allexcept-allsort"
 
-var opIndexes = [...]uint32{0, 7, 15, 23, 28, 32, 36, 41, 52, 57, 68, 80, 86, 89, 91, 94, 96, 98, 100, 102, 104, 106, 108, 114, 118, 126, 132, 142, 152, 166, 175, 188, 199, 214, 216, 222, 230, 236, 241, 247, 251, 256, 260, 263, 272, 275, 278, 284, 291, 298, 307, 317, 331, 346, 356, 367, 383, 387, 395, 403, 419, 423, 429, 435, 442, 452, 461, 471, 480, 489, 498, 514, 529, 545, 560, 575, 590, 598, 603, 612, 618, 627, 640, 650, 654}
+var opIndexes = [...]uint32{0, 7, 15, 23, 28, 32, 36, 41, 52, 57, 68, 80, 86, 89, 91, 94, 96, 98, 100, 102, 104, 106, 108, 114, 118, 126, 132, 142, 152, 166, 175, 188, 199, 214, 216, 222, 230, 236, 241, 247, 251, 256, 260, 263, 272, 275, 278, 284, 291, 298, 307, 317, 331, 346, 356, 367, 383, 387, 391, 395, 403, 411, 427, 431, 437, 443, 450, 460, 469, 479, 488, 497, 506, 522, 537, 553, 568, 583, 598, 606, 611, 620, 626, 635, 648, 658, 662}
 
 var ScalarOperators = [...]Operator{
 	SubqueryOp,
@@ -403,6 +426,8 @@ var ScalarOperators = [...]Operator{
 	UnaryMinusOp,
 	UnaryComplementOp,
 	CastOp,
+	CaseOp,
+	WhenOp,
 	FunctionOp,
 	CoalesceOp,
 	UnsupportedExprOp,

--- a/pkg/sql/opt/ops/scalar.opt
+++ b/pkg/sql/opt/ops/scalar.opt
@@ -369,6 +369,37 @@ define Cast {
     Typ   Type
 }
 
+# Case is a CASE statement of the form:
+#   CASE [ <Input> ]
+#       WHEN <condval1> THEN <expr1>
+#     [ WHEN <condval2> THEN <expr2> ] ...
+#     [ ELSE <expr> ]
+#   END
+#
+# The Case operator evaluates <Input> (if not provided, Input is set to True),
+# then picks the WHEN branch where <condval> is equal to
+# <cond>, then evaluates and returns the corresponding THEN expression. If no
+# WHEN branch matches, the ELSE expression is evaluated and returned, if any.
+# Otherwise, NULL is returned.
+#
+# Note that the Whens list inside Case is used to represent all the WHEN
+# branches as well as the ELSE statement if it exists. It is of the form:
+# [(When <condval1> <expr1>),(When <condval2> <expr2>),...,<expr>]
+[Scalar]
+define Case {
+    Input Expr
+    Whens ExprList
+}
+
+# When represents a single WHEN ... THEN ... condition inside a CASE statement.
+# It is the type of each list item in Whens (except for the last item which is
+# a raw expression for the ELSE statement).
+[Scalar]
+define When {
+    Condition Expr
+    Value     Expr
+}
+
 # Function invokes a builtin SQL function like CONCAT or NOW, passing the given
 # arguments. The private field is an opt.FuncDef struct that provides the name
 # of the function as well as a pointer to the builtin overload definition.

--- a/pkg/sql/opt/optbuilder/testdata/scalar
+++ b/pkg/sql/opt/optbuilder/testdata/scalar
@@ -193,7 +193,14 @@ plus [type=int]
 build-scalar vars=(int, int)
 CASE WHEN @1 = 2 THEN 1 ELSE 2 END
 ----
-error: not yet implemented: scalar expr: *tree.CaseExpr
+case [type=int]
+ ├── true [type=bool]
+ ├── when [type=int]
+ │    ├── eq [type=bool]
+ │    │    ├── variable: @1 [type=int]
+ │    │    └── const: 2 [type=int]
+ │    └── const: 1 [type=int]
+ └── const: 2 [type=int]
 
 
 build-scalar vars=(string)
@@ -276,10 +283,90 @@ coalesce [type=int]
  ├── variable: @2 [type=int]
  └── variable: @3 [type=int]
 
-build-scalar vars=(int) allow-unsupported
+build-scalar vars=(int)
 CASE WHEN @1 > 5 THEN 1 ELSE -1 END
 ----
-unsupported-expr: CASE WHEN @1 > 5 THEN 1 ELSE -1 END [type=int]
+case [type=int]
+ ├── true [type=bool]
+ ├── when [type=int]
+ │    ├── gt [type=bool]
+ │    │    ├── variable: @1 [type=int]
+ │    │    └── const: 5 [type=int]
+ │    └── const: 1 [type=int]
+ └── unary-minus [type=int]
+      └── const: 1 [type=int]
+
+build-scalar vars=(int)
+CASE WHEN @1 > 5 THEN 1 WHEN @1 < 0 THEN 2 ELSE -1 END
+----
+case [type=int]
+ ├── true [type=bool]
+ ├── when [type=int]
+ │    ├── gt [type=bool]
+ │    │    ├── variable: @1 [type=int]
+ │    │    └── const: 5 [type=int]
+ │    └── const: 1 [type=int]
+ ├── when [type=int]
+ │    ├── lt [type=bool]
+ │    │    ├── variable: @1 [type=int]
+ │    │    └── const: 0 [type=int]
+ │    └── const: 2 [type=int]
+ └── unary-minus [type=int]
+      └── const: 1 [type=int]
+
+build-scalar vars=(int)
+CASE @1 WHEN 5 THEN 1 ELSE -1 END
+----
+case [type=int]
+ ├── variable: @1 [type=int]
+ ├── when [type=int]
+ │    ├── const: 5 [type=int]
+ │    └── const: 1 [type=int]
+ └── unary-minus [type=int]
+      └── const: 1 [type=int]
+
+build-scalar vars=(int, int)
+CASE @1 + 3 WHEN 5 * @2 THEN 1 % @2 WHEN 6 THEN 2 ELSE -1 END
+----
+case [type=int]
+ ├── plus [type=int]
+ │    ├── variable: @1 [type=int]
+ │    └── const: 3 [type=int]
+ ├── when [type=int]
+ │    ├── mult [type=int]
+ │    │    ├── const: 5 [type=int]
+ │    │    └── variable: @2 [type=int]
+ │    └── mod [type=int]
+ │         ├── const: 1 [type=int]
+ │         └── variable: @2 [type=int]
+ ├── when [type=int]
+ │    ├── const: 6 [type=int]
+ │    └── const: 2 [type=int]
+ └── unary-minus [type=int]
+      └── const: 1 [type=int]
+
+# Tests for CASE with no ELSE statement
+build-scalar vars=(int)
+CASE WHEN @1 > 5 THEN 1 END
+----
+case [type=int]
+ ├── true [type=bool]
+ ├── when [type=int]
+ │    ├── gt [type=bool]
+ │    │    ├── variable: @1 [type=int]
+ │    │    └── const: 5 [type=int]
+ │    └── const: 1 [type=int]
+ └── null [type=unknown]
+
+build-scalar vars=(int)
+CASE @1 WHEN 5 THEN 1 END
+----
+case [type=int]
+ ├── variable: @1 [type=int]
+ ├── when [type=int]
+ │    ├── const: 5 [type=int]
+ │    └── const: 1 [type=int]
+ └── null [type=unknown]
 
 build-scalar vars=(json) allow-unsupported
 @1->>'a' = 'b'

--- a/pkg/sql/opt/optbuilder/testdata/select
+++ b/pkg/sql/opt/optbuilder/testdata/select
@@ -157,7 +157,18 @@ project
  │    ├── columns: abc.a:int:1 abc.b:int:null:2 abc.c:int:null:3
  │    ├── scan
  │    │    └── columns: abc.a:int:1 abc.b:int:null:2 abc.c:int:null:3
- │    └── unsupported-expr: CASE WHEN abc.a != 0 THEN (abc.b / abc.a) > 1.5 ELSE false END [type=bool]
+ │    └── case [type=bool]
+ │         ├── true [type=bool]
+ │         ├── when [type=bool]
+ │         │    ├── ne [type=bool]
+ │         │    │    ├── variable: abc.a [type=int]
+ │         │    │    └── const: 0 [type=int]
+ │         │    └── gt [type=bool]
+ │         │         ├── div [type=decimal]
+ │         │         │    ├── variable: abc.b [type=int]
+ │         │         │    └── variable: abc.a [type=int]
+ │         │         └── const: 1.5 [type=decimal]
+ │         └── false [type=bool]
  └── projections
       ├── variable: abc.a [type=int]
       └── variable: abc.b [type=int]
@@ -348,7 +359,12 @@ project
  ├── values
  │    └── tuple [type=tuple{}]
  └── projections
-      └── unsupported-expr: CASE WHEN NULL THEN 1 ELSE 2 END [type=int]
+      └── case [type=int]
+           ├── true [type=bool]
+           ├── when [type=int]
+           │    ├── null [type=unknown]
+           │    └── const: 1 [type=int]
+           └── const: 2 [type=int]
 
 build
 SELECT 0 * b, b % 1, 0 % b from abc

--- a/pkg/sql/opt/xform/factory.og.go
+++ b/pkg/sql/opt/xform/factory.og.go
@@ -2152,6 +2152,61 @@ func (_f *factory) ConstructCast(
 	return _f.onConstruct(_f.mem.memoizeNormExpr(memoExpr(_castExpr)))
 }
 
+// ConstructCase constructs an expression for the Case operator.
+// Case is a CASE statement of the form:
+//   CASE [ <Input> ]
+//       WHEN <condval1> THEN <expr1>
+//     [ WHEN <condval2> THEN <expr2> ] ...
+//     [ ELSE <expr> ]
+//   END
+//
+// The Case operator evaluates <Input> (if not provided, Input is set to True),
+// then picks the WHEN branch where <condval> is equal to
+// <cond>, then evaluates and returns the corresponding THEN expression. If no
+// WHEN branch matches, the ELSE expression is evaluated and returned, if any.
+// Otherwise, NULL is returned.
+//
+// Note that the Whens list inside Case is used to represent all the WHEN
+// branches as well as the ELSE statement if it exists. It is of the form:
+// [(When <condval1> <expr1>),(When <condval2> <expr2>),...,<expr>]
+func (_f *factory) ConstructCase(
+	input opt.GroupID,
+	whens opt.ListID,
+) opt.GroupID {
+	_caseExpr := makeCaseExpr(input, whens)
+	_group := _f.mem.lookupGroupByFingerprint(_caseExpr.fingerprint())
+	if _group != 0 {
+		return _group
+	}
+
+	if !_f.allowOptimizations() {
+		return _f.mem.memoizeNormExpr(memoExpr(_caseExpr))
+	}
+
+	return _f.onConstruct(_f.mem.memoizeNormExpr(memoExpr(_caseExpr)))
+}
+
+// ConstructWhen constructs an expression for the When operator.
+// When represents a single WHEN ... THEN ... condition inside a CASE statement.
+// It is the type of each list item in Whens (except for the last item which is
+// a raw expression for the ELSE statement).
+func (_f *factory) ConstructWhen(
+	condition opt.GroupID,
+	value opt.GroupID,
+) opt.GroupID {
+	_whenExpr := makeWhenExpr(condition, value)
+	_group := _f.mem.lookupGroupByFingerprint(_whenExpr.fingerprint())
+	if _group != 0 {
+		return _group
+	}
+
+	if !_f.allowOptimizations() {
+		return _f.mem.memoizeNormExpr(memoExpr(_whenExpr))
+	}
+
+	return _f.onConstruct(_f.mem.memoizeNormExpr(memoExpr(_whenExpr)))
+}
+
 // ConstructFunction constructs an expression for the Function operator.
 // Function invokes a builtin SQL function like CONCAT or NOW, passing the given
 // arguments. The private field is an opt.FuncDef struct that provides the name
@@ -2782,7 +2837,7 @@ func (_f *factory) ConstructExceptAll(
 
 type dynConstructLookupFunc func(f *factory, children []opt.GroupID, private opt.PrivateID) opt.GroupID
 
-var dynConstructLookup [83]dynConstructLookupFunc
+var dynConstructLookup [85]dynConstructLookupFunc
 
 func init() {
 	// UnknownOp
@@ -3068,6 +3123,16 @@ func init() {
 	// CastOp
 	dynConstructLookup[opt.CastOp] = func(f *factory, children []opt.GroupID, private opt.PrivateID) opt.GroupID {
 		return f.ConstructCast(children[0], private)
+	}
+
+	// CaseOp
+	dynConstructLookup[opt.CaseOp] = func(f *factory, children []opt.GroupID, private opt.PrivateID) opt.GroupID {
+		return f.ConstructCase(children[0], f.InternList(children[1:]))
+	}
+
+	// WhenOp
+	dynConstructLookup[opt.WhenOp] = func(f *factory, children []opt.GroupID, private opt.PrivateID) opt.GroupID {
+		return f.ConstructWhen(children[0], children[1])
 	}
 
 	// FunctionOp

--- a/pkg/sql/sem/tree/expr.go
+++ b/pkg/sql/sem/tree/expr.go
@@ -1187,6 +1187,15 @@ func (node *CaseExpr) Format(ctx *FmtCtx) {
 	ctx.WriteString("END")
 }
 
+// NewTypedCaseExpr returns a new CaseExpr that is verified to be well-typed.
+func NewTypedCaseExpr(
+	expr TypedExpr, whens []*When, elseStmt TypedExpr, typ types.T,
+) (*CaseExpr, error) {
+	node := &CaseExpr{Expr: expr, Whens: whens, Else: elseStmt}
+	node.typ = typ
+	return node, nil
+}
+
 // When represents a WHEN sub-expression.
 type When struct {
 	Cond Expr


### PR DESCRIPTION
This commit adds support for `CASE` statements in
the optimizer. It enables building a memo
in the optbuilder for queries with a `CASE` statement.
It also adds support for execution of optimized `CASE`
statements in the execbuilder.

There are two types of `CASE` statements: simple and
searched. Simple case statements are of the form:
```
CASE <cond>
    WHEN <condval1> THEN <expr1>
  [ WHEN <condvalx> THEN <exprx> ] ...
  [ ELSE <expr2> ]
END
```
Searched case statements are of the form:
```
CASE WHEN <cond1> THEN <expr1>
   [ WHEN <cond2> THEN <expr2> ] ...
   [ ELSE <expr> ]
END
```
This commit adds support for both types.

Release note: None