### PR TITLE
cherrypick-2.0: server: change server.shutdown.drain_wait default to 0s

### DIFF
--- a/pkg/acceptance/decommission_test.go
+++ b/pkg/acceptance/decommission_test.go
@@ -122,8 +122,7 @@ func testDecommissionInner(
 		}
 	}
 
-	withDB(1, "SET CLUSTER SETTING server.remote_debugging.mode = 'any';"+
-		"SET CLUSTER SETTING server.shutdown.drain_wait='0s'")
+	withDB(1, "SET CLUSTER SETTING server.remote_debugging.mode = 'any';")
 
 	// Get the ids for each node.
 	idMap := make(map[int]roachpb.NodeID)

--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -329,7 +329,6 @@ func TestQuit(t *testing.T) {
 	c := newCLITest(cliTestParams{t: t})
 	defer c.cleanup()
 
-	c.RunWithArgs([]string{"sql", "-e", "set cluster setting server.shutdown.drain_wait = '0s'"})
 	c.Run("quit")
 	// Wait until this async command cleanups the server.
 	<-c.Stopper().IsStopped()

--- a/pkg/cli/interactive_tests/common.tcl
+++ b/pkg/cli/interactive_tests/common.tcl
@@ -95,7 +95,6 @@ proc send_eof {} {
 proc start_server {argv} {
     report "BEGIN START SERVER"
     system "mkfifo pid_fifo || true; $argv start --insecure --pid-file=pid_fifo --background -s=path=logs/db >>logs/expect-cmd.log 2>&1 & cat pid_fifo > server_pid"
-    system "$argv sql -e \"SET CLUSTER SETTING server.shutdown.drain_wait = \'0s\'\""
     report "START SERVER DONE"
 }
 proc stop_server {argv} {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -98,7 +98,7 @@ var (
 		"server.shutdown.drain_wait",
 		"the amount of time a server waits in an unready state before proceeding with the rest "+
 			"of the shutdown process",
-		15*time.Second,
+		0*time.Second,
 	)
 )
 

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -41,7 +41,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
-	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/httputil"
@@ -594,13 +593,10 @@ func TestListenerFileCreation(t *testing.T) {
 
 func TestHeartbeatCallbackForDecommissioning(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	s, db, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
 	defer s.Stopper().Stop(context.TODO())
 	ts := s.(*TestServer)
 	nodeLiveness := ts.nodeLiveness
-
-	// Don't bother waiting before draining.
-	sqlutils.MakeSQLRunner(db).Exec(t, "SET CLUSTER SETTING server.shutdown.drain_wait = '0s'")
 
 	for {
 		// Morally this loop only runs once. However, early in the boot

--- a/pkg/sql/pgwire/pgwire_test.go
+++ b/pkg/sql/pgwire/pgwire_test.go
@@ -239,9 +239,6 @@ func TestPGWireDrainClient(t *testing.T) {
 	}
 	defer db.Close()
 
-	// Don't bother waiting before draining.
-	sqlutils.MakeSQLRunner(db).Exec(t, "SET CLUSTER SETTING server.shutdown.drain_wait = '0s'")
-
 	txn, err := db.Begin()
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
#23333

This feature should be opt-in as it's meant for load balancers. This
avoids long waits for shutdown that could time out tests and be
surprising for users.

Release note: None