### PR TITLE
cherrypick-2.0: server: use temp rather than permanent https redirect

### DIFF
--- a/pkg/server/authentication_test.go
+++ b/pkg/server/authentication_test.go
@@ -110,35 +110,35 @@ func TestSSLEnforcement(t *testing.T) {
 		{"", nodeCertsContext, http.StatusOK},
 		{"", testCertsContext, http.StatusOK},
 		{"", noCertsContext, http.StatusOK},
-		{"", insecureContext, http.StatusPermanentRedirect},
+		{"", insecureContext, http.StatusTemporaryRedirect},
 
 		// /_admin/: server.adminServer: no auth.
 		{adminPrefix + "health", rootCertsContext, http.StatusOK},
 		{adminPrefix + "health", nodeCertsContext, http.StatusOK},
 		{adminPrefix + "health", testCertsContext, http.StatusOK},
 		{adminPrefix + "health", noCertsContext, http.StatusOK},
-		{adminPrefix + "health", insecureContext, http.StatusPermanentRedirect},
+		{adminPrefix + "health", insecureContext, http.StatusTemporaryRedirect},
 
 		// /debug/: server.adminServer: no auth.
 		{debug.Endpoint + "vars", rootCertsContext, http.StatusOK},
 		{debug.Endpoint + "vars", nodeCertsContext, http.StatusOK},
 		{debug.Endpoint + "vars", testCertsContext, http.StatusOK},
 		{debug.Endpoint + "vars", noCertsContext, http.StatusOK},
-		{debug.Endpoint + "vars", insecureContext, http.StatusPermanentRedirect},
+		{debug.Endpoint + "vars", insecureContext, http.StatusTemporaryRedirect},
 
 		// /_status/nodes: server.statusServer: no auth.
 		{statusPrefix + "nodes", rootCertsContext, http.StatusOK},
 		{statusPrefix + "nodes", nodeCertsContext, http.StatusOK},
 		{statusPrefix + "nodes", testCertsContext, http.StatusOK},
 		{statusPrefix + "nodes", noCertsContext, http.StatusOK},
-		{statusPrefix + "nodes", insecureContext, http.StatusPermanentRedirect},
+		{statusPrefix + "nodes", insecureContext, http.StatusTemporaryRedirect},
 
 		// /ts/: ts.Server: no auth.
 		{ts.URLPrefix, rootCertsContext, http.StatusNotFound},
 		{ts.URLPrefix, nodeCertsContext, http.StatusNotFound},
 		{ts.URLPrefix, testCertsContext, http.StatusNotFound},
 		{ts.URLPrefix, noCertsContext, http.StatusNotFound},
-		{ts.URLPrefix, insecureContext, http.StatusPermanentRedirect},
+		{ts.URLPrefix, insecureContext, http.StatusTemporaryRedirect},
 	} {
 		t.Run("", func(t *testing.T) {
 			client, err := tc.ctx.GetHTTPClient()

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -812,7 +812,7 @@ func (s *Server) Start(ctx context.Context) error {
 		s.stopper.RunWorker(workersCtx, func(context.Context) {
 			mux := http.NewServeMux()
 			mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-				http.Redirect(w, r, "https://"+r.Host+r.RequestURI, http.StatusPermanentRedirect)
+				http.Redirect(w, r, "https://"+r.Host+r.RequestURI, http.StatusTemporaryRedirect)
 			})
 			mux.Handle("/health", s)
 

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -154,8 +154,8 @@ func TestSecureHTTPRedirect(t *testing.T) {
 		t.Fatal(err)
 	} else {
 		resp.Body.Close()
-		if resp.StatusCode != http.StatusPermanentRedirect {
-			t.Errorf("expected status code %d; got %d", http.StatusPermanentRedirect, resp.StatusCode)
+		if resp.StatusCode != http.StatusTemporaryRedirect {
+			t.Errorf("expected status code %d; got %d", http.StatusTemporaryRedirect, resp.StatusCode)
 		}
 		if redirectURL, err := resp.Location(); err != nil {
 			t.Error(err)
@@ -168,8 +168,8 @@ func TestSecureHTTPRedirect(t *testing.T) {
 		t.Fatal(err)
 	} else {
 		resp.Body.Close()
-		if resp.StatusCode != http.StatusPermanentRedirect {
-			t.Errorf("expected status code %d; got %d", http.StatusPermanentRedirect, resp.StatusCode)
+		if resp.StatusCode != http.StatusTemporaryRedirect {
+			t.Errorf("expected status code %d; got %d", http.StatusTemporaryRedirect, resp.StatusCode)
 		}
 		if redirectURL, err := resp.Location(); err != nil {
 			t.Error(err)


### PR DESCRIPTION
Users may often have cockroach's admin UI  only temporarily accessible on some port, e.g. if port-forwarding to get to the admin ui.
If we use a temporary redirect instead, if a user later has some different application on that port (not unlikely given our use of 8080)
they won't have their browser trying to go to https instead.

Release note: none.