### PR TITLE
cherrypick-2.0: sql: fix prepared stmt start time in SHOW QUERIES

### DIFF
--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -878,7 +878,7 @@ func (ex *connExecutor) addActiveQuery(
 
 	_, hidden := stmt.(tree.HiddenFromShowQueries)
 	qm := queryMeta{
-		start:         ex.phaseTimes[sessionEndParse],
+		start:         ex.phaseTimes[sessionQueryReceived],
 		stmt:          stmt,
 		phase:         preparing,
 		isDistributed: false,


### PR DESCRIPTION
Previously, executing a prepared statement from pgwire would result in a
start time of 0 in SHOW QUERIES, due to looking at the start time of the
parse phase instead of the time the ExecPortal message was received.

Release note: None