### PR TITLE
opt: show result column names and types in execbuilder tests

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/join
+++ b/pkg/sql/opt/exec/execbuilder/testdata/join
@@ -24,15 +24,16 @@ join       0  join  ·      ·          (x, y, x, z)  ·
 exec
 SELECT * FROM t.a, t.b
 ----
-1  10  2  200
-1  10  3  300
-1  10  4  400
-2  20  2  200
-2  20  3  300
-2  20  4  400
-3  30  2  200
-3  30  3  300
-3  30  4  400
+x:int  y:int  x:int  z:int
+1      10     2      200
+1      10     3      300
+1      10     4      400
+2      20     2      200
+2      20     3      300
+2      20     4      400
+3      30     2      200
+3      30     3      300
+3      30     4      400
 
 # We don't yet push the filter into the join.
 exec-explain
@@ -52,8 +53,9 @@ filter          0  filter  ·       ·          (x, y, x, z)  ·
 exec
 SELECT * FROM t.a, t.b WHERE a.x = b.x
 ----
-2  20  2  200
-3  30  3  300
+x:int  y:int  x:int  z:int
+2      20     2      200
+3      30     3      300
 
 exec-explain
 SELECT * FROM t.a INNER JOIN t.b ON a.x = b.x
@@ -71,8 +73,9 @@ join       0  join  ·         ·          (x, y, x, z)  ·
 exec
 SELECT * FROM t.a INNER JOIN t.b ON a.x = b.x
 ----
-2  20  2  200
-3  30  3  300
+x:int  y:int  x:int  z:int
+2      20     2      200
+3      30     3      300
 
 exec-explain
 SELECT * FROM t.a NATURAL JOIN t.b
@@ -94,8 +97,9 @@ render          0  render  ·         ·          ("a.x", "a.y", "b.z")  ·
 exec
 SELECT * FROM t.a NATURAL JOIN t.b
 ----
-2  20  200
-3  30  300
+a.x:int  a.y:int  b.z:int
+2        20       200
+3        30       300
 
 exec-explain
 SELECT * FROM t.a LEFT OUTER JOIN t.b ON a.x = b.x
@@ -113,9 +117,10 @@ join       0  join  ·         ·           (x, y, x, z)  ·
 exec
 SELECT * FROM t.a LEFT OUTER JOIN t.b ON a.x = b.x
 ----
-1  10  NULL  NULL
-2  20  2     200
-3  30  3     300
+x:int  y:int  x:int  z:int
+1      10     NULL   NULL
+2      20     2      200
+3      30     3      300
 
 exec-explain
 SELECT * FROM t.a NATURAL RIGHT OUTER JOIN t.b
@@ -137,9 +142,10 @@ render          0  render  ·         ·            ("b.x", "a.y", "b.z")  ·
 exec
 SELECT * FROM t.a NATURAL RIGHT OUTER JOIN t.b
 ----
-2  20    200
-3  30    300
-4  NULL  400
+b.x:int  a.y:int  b.z:int
+2        20       200
+3        30       300
+4        NULL     400
 
 exec-explain
 SELECT * FROM t.a FULL OUTER JOIN t.b USING(x)
@@ -167,7 +173,8 @@ render               0  render  ·         ·               (x, "a.y", "b.z")   
 exec
 SELECT * FROM t.a FULL OUTER JOIN t.b USING(x)
 ----
-1  10    NULL
-2  20    200
-3  30    300
-4  NULL  400
+x:int  a.y:int  b.z:int
+1      10       NULL
+2      20       200
+3      30       300
+4      NULL     400

--- a/pkg/sql/opt/exec/execbuilder/testdata/project
+++ b/pkg/sql/opt/exec/execbuilder/testdata/project
@@ -22,8 +22,9 @@ filter     0  filter  ·       ·          (x, y)  ·
 exec
 SELECT * FROM t.a WHERE x > 1
 ----
-2  20
-3  30
+x:int  y:int
+2      20
+3      30
 
 exec-explain
 SELECT * FROM t.a WHERE y > 1
@@ -37,9 +38,10 @@ filter     0  filter  ·       ·          (x, y)  ·
 exec
 SELECT * FROM t.a WHERE y > 1
 ----
-1  10
-2  20
-3  30
+x:int  y:int
+1      10
+2      20
+3      30
 
 exec-explain
 SELECT * FROM t.a WHERE x > 1 AND x < 3
@@ -53,7 +55,8 @@ filter     0  filter  ·       ·                    (x, y)  ·
 exec
 SELECT * FROM t.a WHERE x > 1 AND x < 3
 ----
-2  20
+x:int  y:int
+2      20
 
 exec-explain
 SELECT x + 1 FROM t.a
@@ -67,6 +70,7 @@ render     0  render  ·         ·          (column3)  ·
 exec
 SELECT x + 1 FROM t.a
 ----
+column3:int
 2
 3
 4
@@ -87,9 +91,10 @@ render     0  render  ·         ·          ("a.x", column3, "a.y", column4, co
 exec
 SELECT x, x + 1, y, y + 1, x + y FROM t.a
 ----
-1  2  10  11  11
-2  3  20  21  22
-3  4  30  31  33
+a.x:int  column3:int  a.y:int  column4:int  column5:int
+1        2            10       11           11
+2        3            20       21           22
+3        4            30       31           33
 
 exec-explain
 SELECT u + v FROM (SELECT x + 3, y + 10 FROM t.a) AS foo(u, v)
@@ -106,6 +111,7 @@ render          0  render  ·         ·                  (column5)           ·
 exec
 SELECT u + v FROM (SELECT x + 3, y + 10 FROM t.a) AS foo(u, v)
 ----
+column5:int
 24
 35
 46
@@ -147,8 +153,9 @@ render          0  render  ·         ·             (column3, column4)  ·
 exec
 SELECT x + 1, x + y FROM t.a WHERE x + y > 20
 ----
-3  22
-4  33
+column3:int  column4:int
+3            22
+4            33
 
 exec-raw
 CREATE TABLE t.b (x INT, y INT);
@@ -169,9 +176,10 @@ render     0  render  ·         ·          ("b.x", "b.y")         ·
 exec
 SELECT * FROM t.b
 ----
-1  10
-2  20
-3  30
+b.x:int  b.y:int
+1        10
+2        20
+3        30
 
 exec-explain
 SELECT x FROM t.b WHERE rowid > 0
@@ -187,6 +195,7 @@ render          0  render  ·         ·          ("b.x")                ·
 exec
 SELECT x FROM t.b WHERE rowid > 0
 ----
+b.x:int
 1
 2
 3

--- a/pkg/sql/opt/exec/execbuilder/testdata/scalar
+++ b/pkg/sql/opt/exec/execbuilder/testdata/scalar
@@ -264,6 +264,7 @@ INSERT INTO t.str VALUES ('a'), ('ab'), ('abc')
 exec
 SELECT LENGTH(s) FROM t.str
 ----
+column3:int
 1
 2
 3
@@ -308,9 +309,10 @@ render     0  render  ·         ·                      (column8)              
 exec
 SELECT LENGTH(s)::float, s FROM t.str
 ----
-1.0  a
-2.0  ab
-3.0  abc
+column3:float  str.s:string
+1.0            a
+2.0            ab
+3.0            abc
 
 exec-explain
 SELECT COALESCE(a, b) FROM (VALUES (1, 2), (3, NULL), (NULL, 4), (NULL, NULL)) AS v(a, b)
@@ -331,6 +333,7 @@ render       0  render  ·              ·                           (column3)  
 exec
 SELECT COALESCE(a, b) FROM (VALUES (1, 2), (3, NULL), (NULL, 4), (NULL, NULL)) AS v(a, b)
 ----
+column3:int
 1
 3
 4
@@ -359,6 +362,7 @@ render       0  render  ·              ·                                    (c
 exec
 SELECT COALESCE(a, b, c) FROM (VALUES (1, 2, 3), (NULL, 4, 5), (NULL, NULL, 6), (NULL, NULL, NULL)) AS v(a, b, c)
 ----
+column4:int
 1
 4
 6

--- a/pkg/sql/opt/exec/execbuilder/testdata/scan
+++ b/pkg/sql/opt/exec/execbuilder/testdata/scan
@@ -23,9 +23,10 @@ scan  0  scan  ·      ·          (x, y)  ·
 exec
 SELECT * FROM t.a
 ----
-1  1.0
-2  2.0
-3  3.0
+x:int  y:float
+1      1.0
+2      2.0
+3      3.0
 
 exec-raw
 CREATE TABLE t.b (x INT, y INT);

--- a/pkg/sql/opt/exec/execbuilder/testdata/select
+++ b/pkg/sql/opt/exec/execbuilder/testdata/select
@@ -19,8 +19,9 @@ filter     0  filter  ·       ·          (x, y)  ·
 exec
 SELECT * FROM t.a WHERE x > 1
 ----
-2  20
-3  30
+x:int  y:int
+2      20
+3      30
 
 exec-explain
 SELECT * FROM t.a WHERE y > 10
@@ -34,8 +35,9 @@ filter     0  filter  ·       ·          (x, y)  ·
 exec
 SELECT * FROM t.a WHERE y > 10
 ----
-2  20
-3  30
+x:int  y:int
+2      20
+3      30
 
 exec-explain
 SELECT * FROM t.a WHERE x > 1 AND x < 3
@@ -49,7 +51,8 @@ filter     0  filter  ·       ·                    (x, y)  ·
 exec
 SELECT * FROM t.a WHERE x > 1 AND x < 3
 ----
-2  20
+x:int  y:int
+2      20
 
 exec-explain
 SELECT * FROM t.a WHERE x > 1 AND y < 30
@@ -63,7 +66,8 @@ filter     0  filter  ·       ·                     (x, y)  ·
 exec
 SELECT * FROM t.a WHERE x > 1 AND y < 30
 ----
-2  20
+x:int  y:int
+2      20
 
 exec-raw
 CREATE TABLE t.b (x INT, y INT);

--- a/pkg/sql/opt/exec/execbuilder/testdata/values
+++ b/pkg/sql/opt/exec/execbuilder/testdata/values
@@ -10,6 +10,7 @@ render       0  render  ·         ·                 (column1)  ·
 exec
 SELECT 1
 ----
+column1:int
 1
 
 exec-explain
@@ -23,6 +24,7 @@ render       0  render  ·         ·                 (column1)  ·
 exec
 SELECT 1 + 2
 ----
+column1:int
 3
 
 exec-explain
@@ -40,8 +42,9 @@ values  0  values  ·              ·                  (column1, column2, column
 exec
 VALUES (1, 2, 3), (4, 5, 6)
 ----
-1  2  3
-4  5  6
+column1:int  column2:int  column3:int
+1            2            3
+4            5            6
 
 exec-explain
 VALUES (LENGTH('a')), (1 + LENGTH('a')), (LENGTH('abc')), (LENGTH('ab') * 2)
@@ -56,6 +59,7 @@ values  0  values  ·              ·                 (column1)  ·
 exec
 VALUES (LENGTH('a')), (1 + LENGTH('a')), (LENGTH('abc')), (LENGTH('ab') * 2)
 ----
+column1:int
 1
 2
 3
@@ -78,6 +82,7 @@ render       0  render  ·              ·                  (column3)           
 exec
 SELECT a + b FROM (VALUES (1, 2), (3, 4), (5, 6)) AS v(a, b)
 ----
+column3:int
 3
 7
 11

--- a/pkg/sql/opt/exec/factory.go
+++ b/pkg/sql/opt/exec/factory.go
@@ -17,7 +17,6 @@ package exec
 import (
 	"github.com/cockroachdb/cockroach/pkg/sql/optbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
-	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 )
 
@@ -36,7 +35,7 @@ type Node interface{}
 // via IndexedVars.
 type Factory interface {
 	// ConstructValues returns a node that outputs the given rows as results.
-	ConstructValues(rows [][]tree.TypedExpr, colTypes []types.T, colNames []string) (Node, error)
+	ConstructValues(rows [][]tree.TypedExpr, cols sqlbase.ResultColumns) (Node, error)
 
 	// ConstructScan returns a node that represents a scan of the given table.
 	// TODO(radu): support list of columns, index, index constraints

--- a/pkg/sql/opt/exec/test_engine.go
+++ b/pkg/sql/opt/exec/test_engine.go
@@ -17,6 +17,7 @@ package exec
 import (
 	"github.com/cockroachdb/cockroach/pkg/sql/optbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 )
 
 // TestEngine enables the creation and execution of plans for testing.
@@ -31,6 +32,10 @@ type TestEngine interface {
 	// Factory returns the execution Factory associated with this engine, which
 	// can be used to create an execution plan.
 	Factory() Factory
+
+	// Columns returns the column information for the given execution node
+	// (created through the factory).
+	Columns(n Node) sqlbase.ResultColumns
 
 	// Execute runs the given execution node (created through the Factory) and
 	// returns the results as a Datum table.

--- a/pkg/sql/opt_exec_engine.go
+++ b/pkg/sql/opt_exec_engine.go
@@ -57,6 +57,11 @@ func (ee *execEngine) Catalog() optbase.Catalog {
 	return &ee.catalog
 }
 
+// Columns is part of the exec.TestEngine interface.
+func (ee *execEngine) Columns(n exec.Node) sqlbase.ResultColumns {
+	return planColumns(n.(planNode))
+}
+
 // Execute is part of the exec.TestEngine interface.
 func (ee *execEngine) Execute(n exec.Node) ([]tree.Datums, error) {
 	plan := n.(planNode)

--- a/pkg/sql/opt_exec_engine.go
+++ b/pkg/sql/opt_exec_engine.go
@@ -21,7 +21,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/exec"
 	"github.com/cockroachdb/cockroach/pkg/sql/optbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
-	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 )
 
@@ -117,17 +116,12 @@ var _ exec.Factory = &execEngine{}
 
 // ConstructValues is part of the exec.Factory interface.
 func (ee *execEngine) ConstructValues(
-	rows [][]tree.TypedExpr, colTypes []types.T, colNames []string,
+	rows [][]tree.TypedExpr, cols sqlbase.ResultColumns,
 ) (exec.Node, error) {
-	v := &valuesNode{
-		columns: make(sqlbase.ResultColumns, len(colTypes)),
+	return &valuesNode{
+		columns: cols,
 		tuples:  rows,
-	}
-	for i := range v.columns {
-		v.columns[i].Name = colNames[i]
-		v.columns[i].Typ = colTypes[i]
-	}
-	return v, nil
+	}, nil
 }
 
 // ConstructScan is part of the exec.Factory interface.


### PR DESCRIPTION
#### opt/exec: use ResultColumns for ConstructValues

Release note: None

#### opt: show result column names and types in execbuilder tests

Show the column names and types in the execbuilder tests.
This is necessary to test handling of the Presentation property.

Release note: None