### PR TITLE
ui: remove license header from util/vector

### DIFF
--- a/pkg/ui/src/util/vector.ts
+++ b/pkg/ui/src/util/vector.ts
@@ -1,11 +1,3 @@
-// Copyright 2017 The Cockroach Authors.
-//
-// Licensed under the Cockroach Community Licence (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
-
 export function distance(v1: [number, number], v2: [number, number]) {
     return length(sub(v1, v2));
 }


### PR DESCRIPTION
In #22303 we moved the vector helpers to the OSS side, but left the license
header on that file.  This removes it.

Fixes: #23058
Release note: None