### PR TITLE
acceptance: disable crash reporting in tcl tests

### DIFF
--- a/pkg/acceptance/cli_test.go
+++ b/pkg/acceptance/cli_test.go
@@ -32,6 +32,7 @@ const containerPath = "/go/src/github.com/cockroachdb/cockroach/cli/interactive_
 var cmdBase = []string{
 	"/usr/bin/env",
 	"COCKROACH_SKIP_UPDATE_CHECK=1",
+	"COCKROACH_CRASH_REPORTS=",
 	"/bin/bash",
 	"-c",
 }

--- a/pkg/acceptance/cluster/dockercluster.go
+++ b/pkg/acceptance/cluster/dockercluster.go
@@ -511,6 +511,7 @@ func (l *DockerCluster) startNode(ctx context.Context, node *testNode) {
 		"COCKROACH_SCAN_MAX_IDLE_TIME=200ms",
 		"COCKROACH_CONSISTENCY_CHECK_PANIC_ON_FAILURE=true",
 		"COCKROACH_SKIP_UPDATE_CHECK=1",
+		"COCKROACH_CRASH_REPORTS=",
 	}
 	l.createRoach(ctx, node, l.vols, env, cmd...)
 	maybePanic(node.Start(ctx))


### PR DESCRIPTION
these include tests that cause intentional crashes, but we don't need automated crashes sending us reports.

Release note: none.