### PR TITLE
build,github-post: tag test failures with current milestone

### DIFF
--- a/build/teamcity-post-failures.py
+++ b/build/teamcity-post-failures.py
@@ -11,10 +11,12 @@ Requires the following environment variables:
 import json
 import os
 import re
+import subprocess
 import urllib.error
 import urllib.request
 import xml.etree.ElementTree as ET
 
+from pkg_resources import parse_version
 from urllib.parse import urljoin, urlencode
 
 BASEURL = "https://teamcity.cockroachdb.com/httpAuth/app/rest/"
@@ -56,6 +58,36 @@ def collect_build_results(build_id):
             o.findtext("details"))
         yield (test_name, test_log)
 
+def get_probable_milestone():
+    try:
+        tag = subprocess.check_output(['git', 'describe', '--abbrev=0', '--tags'],
+            universal_newlines=True)
+    except subprocess.CalledProcessError as e:
+        print('warning: unable to load latest tag: {0}'.format(e))
+        print('issue will be posted without milestone')
+        return None
+
+    match = re.match(r'v(\d+\.\d+)', tag)
+    if not match:
+        print('unable to parse version {0}; issue will be posted without milestone'.format(tag))
+        return None
+    version = match.group(1)
+
+    try:
+        res = urllib.request.urlopen(
+            'https://api.github.com/repos/cockroachdb/cockroach/milestones?state=open')
+        milestones = json.load(res)
+    except (ValueError, urllib.error.HTTPError) as e:
+        print('warning: unable to load milestones: {0}'.format(e))
+        print('issue will be posted without milestone')
+        return None
+
+    for m in milestones:
+        if m['title'] == version:
+            return m['number']
+    print('no milestone matching {0}; issue will be posted without milestone'.format(version))
+    return None
+
 
 def create_issue(build_id, failed_tests):
     """Format a list of failed tests as an issue.
@@ -79,6 +111,7 @@ The following tests appear to have failed:
 Please assign, take a look and update the issue accordingly.
 '''.format(build_id, ''.join(t[1] for t in failed_tests)),
         'labels': ['test-failure', 'Robot'],
+        'milestone': get_probable_milestone(),
     }
 
 

--- a/pkg/cmd/github-post/main.go
+++ b/pkg/cmd/github-post/main.go
@@ -29,6 +29,7 @@ import (
 	"golang.org/x/oauth2"
 
 	"github.com/google/go-github/github"
+	version "github.com/hashicorp/go-version"
 	"github.com/pkg/errors"
 	"github.com/tebeka/go2xunit/lib"
 )
@@ -64,7 +65,25 @@ func main() {
 		&oauth2.Token{AccessToken: token},
 	)))
 
-	if err := runGH(ctx, os.Stdin, client.Issues.Create, client.Search.Issues, client.Issues.CreateComment, client.Repositories.ListCommits); err != nil {
+	getLatestTag := func() (string, error) {
+		cmd := exec.Command("git", "describe", "--abbrev=0", "--tags")
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			return "", err
+		}
+		return strings.TrimSpace(string(out)), nil
+	}
+
+	if err := runGH(
+		ctx,
+		os.Stdin,
+		client.Issues.Create,
+		client.Search.Issues,
+		client.Issues.CreateComment,
+		client.Repositories.ListCommits,
+		client.Issues.ListMilestones,
+		getLatestTag,
+	); err != nil {
 		log.Fatal(err)
 	}
 }
@@ -176,6 +195,47 @@ func getAssignee(
 	return assignee, nil
 }
 
+func getProbableMilestone(
+	ctx context.Context,
+	getLatestTag func() (string, error),
+	listMilestones func(ctx context.Context, owner string, repo string, opt *github.MilestoneListOptions) ([]*github.Milestone, *github.Response, error),
+) *int {
+	tag, err := getLatestTag()
+	if err != nil {
+		log.Printf("unable to get latest tag: %s", err)
+		log.Printf("issues will be posted without milestone")
+		return nil
+	}
+
+	v, err := version.NewVersion(tag)
+	if err != nil {
+		log.Printf("unable to parse version from tag: %s", err)
+		log.Printf("issues will be posted without milestone")
+		return nil
+	}
+	if len(v.Segments()) < 2 {
+		log.Printf("version %s has less than two components; issues will be posted without milestone", tag)
+		return nil
+	}
+	vstring := fmt.Sprintf("%d.%d", v.Segments()[0], v.Segments()[1])
+
+	milestones, _, err := listMilestones(ctx, githubUser, githubRepo, &github.MilestoneListOptions{
+		State: "open",
+	})
+	if err != nil {
+		log.Printf("unable to list milestones: %s", err)
+		log.Printf("issues will be posted without milestone")
+		return nil
+	}
+
+	for _, m := range milestones {
+		if m.GetTitle() == vstring {
+			return m.Number
+		}
+	}
+	return nil
+}
+
 func runGH(
 	ctx context.Context,
 	input io.Reader,
@@ -183,6 +243,8 @@ func runGH(
 	searchIssues func(ctx context.Context, query string, opt *github.SearchOptions) (*github.IssuesSearchResult, *github.Response, error),
 	createComment func(ctx context.Context, owner string, repo string, number int, comment *github.IssueComment) (*github.IssueComment, *github.Response, error),
 	listCommits func(ctx context.Context, owner string, repo string, opts *github.CommitsListOptions) ([]*github.RepositoryCommit, *github.Response, error),
+	listMilestones func(ctx context.Context, owner string, repo string, opt *github.MilestoneListOptions) ([]*github.Milestone, *github.Response, error),
+	getLatestTag func() (string, error),
 ) error {
 	sha, ok := os.LookupEnv(teamcityVCSNumberEnv)
 	if !ok {
@@ -231,6 +293,8 @@ Parameters:
 
 Stress build found a failed test: %s`
 
+	milestone := getProbableMilestone(ctx, getLatestTag, listMilestones)
+
 	newIssueRequest := func(packageName, testName, message, assignee string) *github.IssueRequest {
 		title := fmt.Sprintf("%s: %s failed under stress",
 			strings.TrimPrefix(packageName, cockroachPkgPrefix), testName)
@@ -243,10 +307,11 @@ Stress build found a failed test: %s`
 		body = fmt.Sprintf(body, trimIssueRequestBody(message, len(body)))
 
 		return &github.IssueRequest{
-			Title:    &title,
-			Body:     &body,
-			Labels:   &issueLabels,
-			Assignee: &assignee,
+			Title:     &title,
+			Body:      &body,
+			Labels:    &issueLabels,
+			Assignee:  &assignee,
+			Milestone: milestone,
 		}
 	}
 

--- a/pkg/cmd/github-post/main_test.go
+++ b/pkg/cmd/github-post/main_test.go
@@ -29,17 +29,18 @@ import (
 
 func TestRunGH(t *testing.T) {
 	const (
-		expOwner    = "cockroachdb"
-		expRepo     = "cockroach"
-		expAssignee = "hodor"
-		envPkg      = "storage"
-		envTags     = "deadlock"
-		envGoFlags  = "race"
-		sha         = "abcd123"
-		serverURL   = "https://teamcity.example.com"
-		buildID     = 8008135
-		issueID     = 1337
-		issueNumber = 30
+		expOwner     = "cockroachdb"
+		expRepo      = "cockroach"
+		expAssignee  = "hodor"
+		expMilestone = 2
+		envPkg       = "storage"
+		envTags      = "deadlock"
+		envGoFlags   = "race"
+		sha          = "abcd123"
+		serverURL    = "https://teamcity.example.com"
+		buildID      = 8008135
+		issueID      = 1337
+		issueNumber  = 30
 	)
 
 	for key, value := range map[string]string{
@@ -150,6 +151,9 @@ Stress build found a failed test: %s`,
 					if length := len(*issue.Body); length > githubIssueBodyMaximumLength {
 						t.Fatalf("issue length %d exceeds (undocumented) maximum %d", length, githubIssueBodyMaximumLength)
 					}
+					if *issue.Milestone != expMilestone {
+						t.Fatalf("expected milestone %d, but got %d", expMilestone, *issue.Milestone)
+					}
 					return &github.Issue{ID: github.Int64(issueID)}, nil, nil
 				}
 				searchIssues := func(_ context.Context, query string, opt *github.SearchOptions) (*github.IssuesSearchResult, *github.Response, error) {
@@ -201,7 +205,32 @@ Stress build found a failed test: %s`,
 						},
 					}, nil, nil
 				}
-				if err := runGH(context.Background(), file, postIssue, searchIssues, postComment, listCommits); err != nil {
+
+				listMilestones := func(_ context.Context, owner, repo string, _ *github.MilestoneListOptions) ([]*github.Milestone, *github.Response, error) {
+					if owner != expOwner {
+						t.Fatalf("got %s, expected %s", owner, expOwner)
+					}
+					if repo != expRepo {
+						t.Fatalf("got %s, expected %s", repo, expRepo)
+					}
+					return []*github.Milestone{
+						{Title: github.String("3.3"), Number: github.Int(expMilestone)},
+						{Title: github.String("3.2"), Number: github.Int(1)},
+					}, nil, nil
+				}
+
+				getLatestTag := func() (string, error) { return "3.3", nil }
+
+				if err := runGH(
+					context.Background(),
+					file,
+					postIssue,
+					searchIssues,
+					postComment,
+					listCommits,
+					listMilestones,
+					getLatestTag,
+				); err != nil {
 					t.Fatal(err)
 				}
 				expectedIssues := 1


### PR DESCRIPTION
The current milestone is determined by matching the most recent tag
against the list of milestones. If the latest tag is
"v2.0-alpha...", for example, the issue-posting scripts will
attempt to assign a milestone titled "2.0". Failing to find a matching
milestone does not prevent the issue from being posted.

Fix #23344.

Release note: None