### PR TITLE
ui: don't call hover state actions

### DIFF
--- a/pkg/ui/src/views/cluster/components/linegraph/index.tsx
+++ b/pkg/ui/src/views/cluster/components/linegraph/index.tsx
@@ -75,6 +75,7 @@ export class LineGraph extends React.Component<LineGraphProps, {}> {
   }
 
   mouseMove = (e: any) => {
+    // TODO(couchand): make this defensive (seems to cause #23011)
     const datapoints = this.props.data.results[0].datapoints;
     const timeScale = this.chart.xAxis.scale();
 
@@ -178,20 +179,12 @@ export class LineGraph extends React.Component<LineGraphProps, {}> {
   }
 
   render() {
-    const { title, subtitle, tooltip, data, hoverOn} = this.props;
-
-    let hoverProps: Partial<React.SVGProps<SVGSVGElement>> = {};
-    if (hoverOn) {
-      hoverProps = {
-        onMouseMove: this.mouseMove,
-        onMouseLeave: this.mouseLeave,
-      };
-    }
+    const { title, subtitle, tooltip, data } = this.props;
 
     return (
       <Visualization title={title} subtitle={subtitle} tooltip={tooltip} loading={!data} >
         <div className="linegraph">
-          <svg className="graph linked-guideline" ref={(svg) => this.graphEl = svg} {...hoverProps} />
+          <svg className="graph linked-guideline" ref={(svg) => this.graphEl = svg} />
         </div>
       </Visualization>
     );


### PR DESCRIPTION
Don't call this broken, unused code.

The chart hover state code was added in anticipation of #20703, which isn't
going to get merged before 2.0, so there's no reason for us to call any of it.

Fixes: #23011
Release note: None