### PR TITLE
backupccl: re-enable TestBackupRestoreControlJob

### DIFF
--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -868,7 +868,6 @@ func TestBackupRestoreResume(t *testing.T) {
 // work as intended on backup and restore jobs.
 func TestBackupRestoreControlJob(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	t.Skipf("#22665")
 
 	defer func(oldInterval time.Duration) {
 		jobs.DefaultAdoptInterval = oldInterval


### PR DESCRIPTION
Attempting to reproduce the bug seen in the listed issue was
unsuccessful. Re-enabling this test to see if it starts flaking again.

See #22984

Release note: None