### PR TITLE
sql: Add statement_timeout session variable

### DIFF
--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"strconv"
+	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/coltypes"
@@ -111,29 +112,55 @@ func (ex *connExecutor) execStmtInOpenState(
 	ex.server.StatementCounters.incrementCount(stmt.AST)
 	os := ex.machine.CurState().(stateOpen)
 
-	defer func() {
+	var timeoutTicker *time.Timer
+	queryTimedOut := false
+	doneAfterFunc := make(chan struct{}, 1)
+
+	// Canceling a query cancels its transaction's context so we take a reference
+	// to the cancelation function here.
+	unregisterFn := ex.addActiveQuery(stmt.queryID, stmt.AST, ex.state.cancel)
+	queryDone := func(ctx context.Context, res RestrictedCommandResult) {
+		if timeoutTicker != nil {
+			if !timeoutTicker.Stop() {
+				// Wait for the timer callback to complete to avoid a data race on
+				// queryTimedOut.
+				<-doneAfterFunc
+			}
+		}
+		unregisterFn()
+
 		// Detect context cancelation and overwrite whatever error might have been
 		// set on the result before. The idea is that once the query's context is
 		// canceled, all sorts of actors can detect the cancelation and set all
 		// sorts of errors on the result. Rather than trying to impose discipline
 		// in that jungle, we just overwrite them all here with an error that's
 		// nicer to look at for the client.
-		if ctx.Err() != nil {
-			res.OverwriteError(sqlbase.QueryCanceledError)
+		if ctx.Err() != nil && res.Err() != nil {
+			if queryTimedOut {
+				res.OverwriteError(sqlbase.QueryTimeoutError)
+			} else {
+				res.OverwriteError(sqlbase.QueryCanceledError)
+			}
 		}
-	}()
-
-	// Canceling a query cancels its transaction's context so we take a reference
-	// to the cancelation function here.
-	unregisterFn := ex.addActiveQuery(stmt.queryID, stmt.AST, ex.state.cancel)
+	}
 	// Generally we want to unregister after the auto-commit below. However, in
 	// case we'll execute the statement through the parallel execution queue,
 	// we'll pass the responsibility for unregistering to the queue.
 	defer func() {
-		if unregisterFn != nil {
-			unregisterFn()
+		if queryDone != nil {
+			queryDone(ctx, res)
 		}
 	}()
+
+	if ex.sessionData.StmtTimeout > 0 {
+		timeoutTicker = time.AfterFunc(
+			ex.sessionData.StmtTimeout-timeutil.Since(ex.phaseTimes[sessionQueryReceived]),
+			func() {
+				ex.cancelQuery(stmt.queryID)
+				queryTimedOut = true
+				doneAfterFunc <- struct{}{}
+			})
+	}
 
 	defer func() {
 		if filter := ex.server.cfg.TestingKnobs.StatementFilter; retErr == nil && filter != nil {
@@ -325,8 +352,8 @@ func (ex *connExecutor) execStmtInOpenState(
 	defer constantMemAcc.Close(ctx)
 
 	if runInParallel {
-		cols, err := ex.execStmtInParallel(ctx, stmt, p, unregisterFn)
-		unregisterFn = nil
+		cols, err := ex.execStmtInParallel(ctx, stmt, p, queryDone)
+		queryDone = nil
 		if err != nil {
 			return makeErrEvent(err)
 		}
@@ -399,12 +426,15 @@ func (ex *connExecutor) rollbackSQLTransaction(ctx context.Context) (fsm.Event, 
 // other queries).
 //
 // Args:
-// unregisterQuery: A cleanup function to be called when the execution is done.
+// queryDone: A cleanup function to be called when the execution is done.
 //
 // TODO(nvanbenschoten): We do not currently support parallelizing distributed SQL
 // queries, so this method can only be used with local SQL.
 func (ex *connExecutor) execStmtInParallel(
-	ctx context.Context, stmt Statement, planner *planner, unregisterQuery func(),
+	ctx context.Context,
+	stmt Statement,
+	planner *planner,
+	queryDone func(context.Context, RestrictedCommandResult),
 ) (sqlbase.ResultColumns, error) {
 	params := runParams{
 		ctx:             ctx,
@@ -434,9 +464,9 @@ func (ex *connExecutor) execStmtInParallel(
 	ex.mu.Unlock()
 
 	if err := ex.parallelizeQueue.Add(params, func() error {
-		defer unregisterQuery()
-
 		res := &errOnlyRestrictedCommandResult{}
+
+		defer queryDone(ctx, res)
 
 		defer func() {
 			planner.maybeLogStatement(ctx, "par-exec" /* lbl */, res.RowsAffected(), res.Err())
@@ -452,12 +482,6 @@ func (ex *connExecutor) execStmtInParallel(
 
 		planner.statsCollector.PhaseTimes()[plannerStartExecStmt] = timeutil.Now()
 		err := ex.execWithLocalEngine(ctx, planner, stmt.AST.StatementType(), res)
-
-		// Detect context cancelation and overwrite whatever error might have been
-		// set on the result before.
-		if ctx.Err() != nil {
-			res.OverwriteError(sqlbase.QueryCanceledError)
-		}
 
 		planner.statsCollector.PhaseTimes()[plannerEndExecStmt] = timeutil.Now()
 		recordStatementSummary(

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -119,7 +119,7 @@ func (ex *connExecutor) execStmtInOpenState(
 		// in that jungle, we just overwrite them all here with an error that's
 		// nicer to look at for the client.
 		if ctx.Err() != nil {
-			res.OverwriteError(sqlbase.NewQueryCanceledError())
+			res.OverwriteError(sqlbase.QueryCanceledError)
 		}
 	}()
 
@@ -456,7 +456,7 @@ func (ex *connExecutor) execStmtInParallel(
 		// Detect context cancelation and overwrite whatever error might have been
 		// set on the result before.
 		if ctx.Err() != nil {
-			res.OverwriteError(sqlbase.NewQueryCanceledError())
+			res.OverwriteError(sqlbase.QueryCanceledError)
 		}
 
 		planner.statsCollector.PhaseTimes()[plannerEndExecStmt] = timeutil.Now()

--- a/pkg/sql/distsqlrun/flow.go
+++ b/pkg/sql/distsqlrun/flow.go
@@ -532,7 +532,7 @@ func (f *Flow) cancel() {
 			// receiver and prevent it from being connected.
 			is.receiver.Push(
 				nil, /* row */
-				&ProducerMetadata{Err: sqlbase.NewQueryCanceledError()})
+				&ProducerMetadata{Err: sqlbase.QueryCanceledError})
 			is.receiver.ProducerDone()
 			f.flowRegistry.finishInboundStreamLocked(f.id, streamID)
 		}

--- a/pkg/sql/distsqlrun/inbound.go
+++ b/pkg/sql/distsqlrun/inbound.go
@@ -121,7 +121,7 @@ func processInboundStreamHelper(
 	// goroutine.
 	select {
 	case <-f.Ctx.Done():
-		return sqlbase.NewQueryCanceledError()
+		return sqlbase.QueryCanceledError
 	case err := <-errChan:
 		return err
 	}

--- a/pkg/sql/distsqlrun/outbox_test.go
+++ b/pkg/sql/distsqlrun/outbox_test.go
@@ -421,7 +421,7 @@ func TestOutboxCancelsFlowOnError(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	streamNotification.donec <- sqlbase.NewQueryCanceledError()
+	streamNotification.donec <- sqlbase.QueryCanceledError
 
 	wg.Wait()
 	if !ctxCanceled {

--- a/pkg/sql/logictest/testdata/logic_test/explain
+++ b/pkg/sql/logictest/testdata/logic_test/explain
@@ -175,7 +175,7 @@ EXPLAIN SHOW DATABASE
 render            ·     ·
  └── filter       ·     ·
       └── values  ·     ·
-·                 size  2 columns, 26 rows
+·                 size  2 columns, 27 rows
 
 query TTT
 EXPLAIN SHOW TIME ZONE
@@ -183,7 +183,7 @@ EXPLAIN SHOW TIME ZONE
 render            ·     ·
  └── filter       ·     ·
       └── values  ·     ·
-·                 size  2 columns, 26 rows
+·                 size  2 columns, 27 rows
 
 query TTT
 EXPLAIN SHOW DEFAULT_TRANSACTION_ISOLATION
@@ -191,7 +191,7 @@ EXPLAIN SHOW DEFAULT_TRANSACTION_ISOLATION
 render            ·     ·
  └── filter       ·     ·
       └── values  ·     ·
-·                 size  2 columns, 26 rows
+·                 size  2 columns, 27 rows
 
 query TTT
 EXPLAIN SHOW TRANSACTION ISOLATION LEVEL
@@ -199,7 +199,7 @@ EXPLAIN SHOW TRANSACTION ISOLATION LEVEL
 render            ·     ·
  └── filter       ·     ·
       └── values  ·     ·
-·                 size  2 columns, 26 rows
+·                 size  2 columns, 27 rows
 
 query TTT
 EXPLAIN SHOW TRANSACTION PRIORITY
@@ -207,7 +207,7 @@ EXPLAIN SHOW TRANSACTION PRIORITY
 render            ·     ·
  └── filter       ·     ·
       └── values  ·     ·
-·                 size  2 columns, 26 rows
+·                 size  2 columns, 27 rows
 
 query TTT
 EXPLAIN SHOW COLUMNS FROM foo

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -1149,6 +1149,7 @@ server_version_num              90500         NULL      NULL        NULL        
 session_user                    root          NULL      NULL        NULL        string
 sql_safe_updates                false         NULL      NULL        NULL        string
 standard_conforming_strings     on            NULL      NULL        NULL        string
+statement_timeout               0s            NULL      NULL        NULL        string
 timezone                        UTC           NULL      NULL        NULL        string
 tracing                         off           NULL      NULL        NULL        string
 transaction_isolation           serializable  NULL      NULL        NULL        string
@@ -1180,6 +1181,7 @@ server_version_num              90500         NULL  user     NULL      90500    
 session_user                    root          NULL  user     NULL      root          root
 sql_safe_updates                false         NULL  user     NULL      false         false
 standard_conforming_strings     on            NULL  user     NULL      on            on
+statement_timeout               0s            NULL  user     NULL      0s            0s
 timezone                        UTC           NULL  user     NULL      UTC           UTC
 tracing                         off           NULL  user     NULL      off           off
 transaction_isolation           serializable  NULL  user     NULL      serializable  serializable
@@ -1190,33 +1192,34 @@ transaction_status              NoTxn         NULL  user     NULL      NoTxn    
 query TTTTTT colnames
 SELECT name, source, min_val, max_val, sourcefile, sourceline FROM pg_catalog.pg_settings
 ----
-name                             source  min_val  max_val  sourcefile  sourceline
-application_name                 NULL    NULL     NULL     NULL        NULL
-client_encoding                  NULL    NULL     NULL     NULL        NULL
-client_min_messages              NULL    NULL     NULL     NULL        NULL
-database                         NULL    NULL     NULL     NULL        NULL
-datestyle                        NULL    NULL     NULL     NULL        NULL
-default_transaction_isolation    NULL    NULL     NULL     NULL        NULL
-default_transaction_read_only    NULL    NULL     NULL     NULL        NULL
-distsql                          NULL    NULL     NULL     NULL        NULL
-experimental_force_lookup_join   NULL    NULL     NULL     NULL        NULL
-experimental_opt                 NULL    NULL     NULL     NULL        NULL
-extra_float_digits               NULL    NULL     NULL     NULL        NULL
-intervalstyle                    NULL    NULL     NULL     NULL        NULL
-max_index_keys                   NULL    NULL     NULL     NULL        NULL
-node_id                          NULL    NULL     NULL     NULL        NULL
-search_path                      NULL    NULL     NULL     NULL        NULL
-server_version                   NULL    NULL     NULL     NULL        NULL
-server_version_num               NULL    NULL     NULL     NULL        NULL
-session_user                     NULL    NULL     NULL     NULL        NULL
-sql_safe_updates                 NULL    NULL     NULL     NULL        NULL
-standard_conforming_strings      NULL    NULL     NULL     NULL        NULL
-timezone                         NULL    NULL     NULL     NULL        NULL
-tracing                          NULL    NULL     NULL     NULL        NULL
-transaction_isolation            NULL    NULL     NULL     NULL        NULL
-transaction_priority             NULL    NULL     NULL     NULL        NULL
-transaction_read_only            NULL    NULL     NULL     NULL        NULL
-transaction_status               NULL    NULL     NULL     NULL        NULL
+name                            source  min_val  max_val  sourcefile  sourceline
+application_name                NULL    NULL     NULL     NULL        NULL
+client_encoding                 NULL    NULL     NULL     NULL        NULL
+client_min_messages             NULL    NULL     NULL     NULL        NULL
+database                        NULL    NULL     NULL     NULL        NULL
+datestyle                       NULL    NULL     NULL     NULL        NULL
+default_transaction_isolation   NULL    NULL     NULL     NULL        NULL
+default_transaction_read_only   NULL    NULL     NULL     NULL        NULL
+distsql                         NULL    NULL     NULL     NULL        NULL
+experimental_force_lookup_join  NULL    NULL     NULL     NULL        NULL
+experimental_opt                NULL    NULL     NULL     NULL        NULL
+extra_float_digits              NULL    NULL     NULL     NULL        NULL
+intervalstyle                   NULL    NULL     NULL     NULL        NULL
+max_index_keys                  NULL    NULL     NULL     NULL        NULL
+node_id                         NULL    NULL     NULL     NULL        NULL
+search_path                     NULL    NULL     NULL     NULL        NULL
+server_version                  NULL    NULL     NULL     NULL        NULL
+server_version_num              NULL    NULL     NULL     NULL        NULL
+session_user                    NULL    NULL     NULL     NULL        NULL
+sql_safe_updates                NULL    NULL     NULL     NULL        NULL
+standard_conforming_strings     NULL    NULL     NULL     NULL        NULL
+statement_timeout               NULL    NULL     NULL     NULL        NULL
+timezone                        NULL    NULL     NULL     NULL        NULL
+tracing                         NULL    NULL     NULL     NULL        NULL
+transaction_isolation           NULL    NULL     NULL     NULL        NULL
+transaction_priority            NULL    NULL     NULL     NULL        NULL
+transaction_read_only           NULL    NULL     NULL     NULL        NULL
+transaction_status              NULL    NULL     NULL     NULL        NULL
 
 # pg_catalog.pg_sequence
 

--- a/pkg/sql/logictest/testdata/logic_test/set
+++ b/pkg/sql/logictest/testdata/logic_test/set
@@ -102,6 +102,7 @@ server_version_num              90500
 session_user                    root
 sql_safe_updates                false
 standard_conforming_strings     on
+statement_timeout               0s
 timezone                        UTC
 tracing                         off
 transaction_isolation           serializable
@@ -250,3 +251,14 @@ UTC
 # Regression test for #19727 - invalid EvalContext used to evaluate arguments to set.
 statement ok
 SET APPLICATION_NAME = current_timestamp()::string
+
+# Test statement_timeout on a long-running query.
+statement ok
+SET statement_timeout = 1
+
+statement error query execution canceled due to statement timeout
+SELECT * FROM generate_series(1,1000000)
+
+# Test that statement_timeout can be set with an interval string.
+statement ok
+SET statement_timeout = '0ms'

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -42,6 +42,7 @@ server_version_num              90500
 session_user                    root
 sql_safe_updates                false
 standard_conforming_strings     on
+statement_timeout               0s
 timezone                        UTC
 tracing                         off
 transaction_isolation           serializable

--- a/pkg/sql/session.go
+++ b/pkg/sql/session.go
@@ -1937,6 +1937,10 @@ func (m *sessionDataMutator) SetReadOnly(val bool) {
 	*m.curTxnReadOnly = val
 }
 
+func (m *sessionDataMutator) SetStmtTimeout(timeout time.Duration) {
+	m.data.StmtTimeout = timeout
+}
+
 func (m *sessionDataMutator) StopSessionTracing() error {
 	return m.sessionTracing.StopTracing()
 }

--- a/pkg/sql/sessiondata/session_data.go
+++ b/pkg/sql/sessiondata/session_data.go
@@ -52,6 +52,9 @@ type SessionData struct {
 	// before the database. Currently, this is used only for SELECTs.
 	// Names in the search path must have been normalized already.
 	SearchPath SearchPath
+	// StmtTimeout is the duration a query is permitted to run before it is
+	// canceled by the session. If set to 0, there is no timeout.
+	StmtTimeout time.Duration
 	// User is the name of the user logged into the session.
 	User string
 	// SafeUpdates causes errors when the client

--- a/pkg/sql/sqlbase/cancel_checker.go
+++ b/pkg/sql/sqlbase/cancel_checker.go
@@ -48,7 +48,7 @@ func (c *CancelChecker) Check() error {
 			// Once the context is canceled, we no longer increment
 			// callsSinceLastCheck and will fall into this path on subsequent calls
 			// to Check().
-			return NewQueryCanceledError()
+			return QueryCanceledError
 		default:
 		}
 	}

--- a/pkg/sql/sqlbase/cascader.go
+++ b/pkg/sql/sqlbase/cascader.go
@@ -956,7 +956,7 @@ func (c *cascader) cascadeAll(
 	for {
 		select {
 		case <-ctx.Done():
-			return NewQueryCanceledError()
+			return QueryCanceledError
 		default:
 		}
 		elem, exists := cascadeQ.dequeue()

--- a/pkg/sql/sqlbase/errors.go
+++ b/pkg/sql/sqlbase/errors.go
@@ -223,13 +223,9 @@ func NewStatementCompletionUnknownError(err error) error {
 	return pgerror.NewErrorf(pgerror.CodeStatementCompletionUnknownError, err.Error())
 }
 
-var queryCanceledError error = pgerror.NewErrorf(
+// QueryCanceledError is an error representing query cancellation.
+var QueryCanceledError error = pgerror.NewErrorf(
 	pgerror.CodeQueryCanceledError, "query execution canceled")
-
-// NewQueryCanceledError creates a query cancellation error.
-func NewQueryCanceledError() error {
-	return queryCanceledError
-}
 
 // IsQueryCanceledError checks whether this is a query canceled error.
 func IsQueryCanceledError(err error) bool {

--- a/pkg/sql/sqlbase/errors.go
+++ b/pkg/sql/sqlbase/errors.go
@@ -227,6 +227,10 @@ func NewStatementCompletionUnknownError(err error) error {
 var QueryCanceledError error = pgerror.NewErrorf(
 	pgerror.CodeQueryCanceledError, "query execution canceled")
 
+// QueryTimeoutError is an error representing a query timeout.
+var QueryTimeoutError error = pgerror.NewErrorf(
+	pgerror.CodeQueryCanceledError, "query execution canceled due to statement timeout")
+
 // IsQueryCanceledError checks whether this is a query canceled error.
 func IsQueryCanceledError(err error) bool {
 	return errHasCode(err, pgerror.CodeQueryCanceledError)

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -447,6 +447,17 @@ var varGen = map[string]sessionVar{
 		Reset: func(_ *sessionDataMutator) error { return nil },
 	},
 
+	`statement_timeout`: {
+		Set: setStmtTimeout,
+		Get: func(evalCtx *extendedEvalContext) string {
+			return evalCtx.SessionData.StmtTimeout.String()
+		},
+		Reset: func(m *sessionDataMutator) error {
+			m.SetStmtTimeout(0)
+			return nil
+		},
+	},
+
 	// See https://www.postgresql.org/docs/10/static/runtime-config-client.html#GUC-TIMEZONE
 	`timezone`: {
 		Get: func(evalCtx *extendedEvalContext) string {


### PR DESCRIPTION
This new session variable is similar to the `statement_timeout` variable
in Postgres, but instead of starting the timer when the query reaches
the server, as documented [in the Postgres docs](https://www.postgresql.org/docs/9.4/static/runtime-config-client.html), the timer starts
when the query is registered as active. In practice, this should make
little to no difference on usage.

Fixes #20789.

Release note (sql change): Add `statement_timeout` session variable.