### PR TITLE
build: bump acceptance timeout to 30m

### DIFF
--- a/build/teamcity-acceptance.sh
+++ b/build/teamcity-acceptance.sh
@@ -29,5 +29,5 @@ tc_end_block "Compile acceptance tests"
 
 tc_start_block "Run acceptance tests"
 run cd pkg/acceptance
-run ./acceptance.test -nodes 4 -l "$TMPDIR" -test.v -test.timeout 20m 2>&1 | tee "$TMPDIR/acceptance.log" | go-test-teamcity
+run ./acceptance.test -nodes 4 -l "$TMPDIR" -test.v -test.timeout 30m 2>&1 | tee "$TMPDIR/acceptance.log" | go-test-teamcity
 tc_end_block "Run acceptance tests"


### PR DESCRIPTION
The acceptance tests rarely run in 16 minutes or less; more often they
scrape at the 20 minute time limit or time out. The behavior in that
case is pretty bad: the test runner will print the panic but then hang,
waiting for teamcity to kill it after an hour. On top of that, it
naively looks as if an acceptance test hung itself which wastes
debugging time.

Bump the limit to half an hour to avoid this sort of confusion.

That this test suite is taking so long is pretty horrible and largely
because the amount of Docker-based clusters that are set up is high. We
need to invest here; this has been the slowest part of the build process
for a while now.

Release note: None