### PR TITLE
storage: Change "RangeCounter" Selection Criteria

### DIFF
--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -6031,39 +6031,41 @@ func calcReplicaMetrics(
 	m.Leader = isRaftLeader(raftStatus)
 	m.Quiescent = quiescent
 
-	// We gather per-range stats on either the leader or, if there is no leader,
-	// the first live replica in the descriptor. Note that the first live replica
-	// is an arbitrary choice. We want to select one live replica to do the
-	// counting that all replicas can agree on.
+	// We compute an estimated range count across the cluster by counting the
+	// first live replica in each descriptor. Note that the first live replica is
+	// an arbitrary choice. We want to select one live replica to do the counting
+	// that all replicas can agree on.
 	//
-	// Note that the current heuristics can double count. If the first live
-	// replica is on a node that is partitioned from the other replicas in the
-	// range it may not know the leader even though there is one. This scenario
-	// seems rare as it requires the partitioned node to be alive enough to be
-	// performing liveness heartbeats.
-	if !HasRaftLeader(raftStatus) {
-		// The range doesn't have a leader or we don't know who the leader is.
-		for _, rd := range desc.Replicas {
-			if livenessMap[rd.NodeID] {
-				m.RangeCounter = rd.StoreID == storeID
-				break
-			}
+	// Note that this heuristic can double count. If the first live replica is on
+	// a node that is partitioned from the other replicas in the range, there may
+	// be multiple nodes which believe they are the first live replica. This
+	// scenario seems rare as it requires the partitioned node to be alive enough
+	// to be performing liveness heartbeats.
+	for _, rd := range desc.Replicas {
+		if livenessMap[rd.NodeID] {
+			m.RangeCounter = rd.StoreID == storeID
+			break
 		}
-	} else {
-		m.RangeCounter = m.Leader
 	}
 
+	// We also compute an estimated per-range count of under-replicated and
+	// unavailable ranges for each range based on the liveness table.
 	if m.RangeCounter {
-		var goodReplicas int
-		goodReplicas, m.BehindCount = calcGoodReplicas(raftStatus, desc, livenessMap)
-		if goodReplicas < computeQuorum(len(desc.Replicas)) {
+		liveReplicas := calcLiveReplicas(desc, livenessMap)
+		if liveReplicas < computeQuorum(len(desc.Replicas)) {
 			m.Unavailable = true
 		}
 		if zoneConfig, err := cfg.GetZoneConfigForKey(desc.StartKey); err != nil {
 			log.Error(ctx, err)
-		} else if int32(goodReplicas) < zoneConfig.NumReplicas {
+		} else if int32(liveReplicas) < zoneConfig.NumReplicas {
 			m.Underreplicated = true
 		}
+	}
+
+	// The raft leader computes the number of raft entries that replicas are
+	// behind.
+	if m.Leader {
+		m.BehindCount = calcBehindCount(raftStatus, desc, livenessMap)
 	}
 
 	m.CmdQMetricsLocal = cmdQMetricsLocal
@@ -6072,48 +6074,34 @@ func calcReplicaMetrics(
 	return m
 }
 
-// calcGoodReplicas returns a count of the "good" replicas and a count of the
-// number of log entries the replicas are behind. The log entry count is only
-// returned if the local replica is the leader. A "good" replica must be on a
-// live node and, if there is a leader, not too far behind.
-func calcGoodReplicas(
-	raftStatus *raft.Status, desc *roachpb.RangeDescriptor, livenessMap map[roachpb.NodeID]bool,
-) (int, int64) {
-	leader := isRaftLeader(raftStatus)
+// calcLiveReplicas returns a count of the live replicas; a live replica is
+// determined by checking its node in the provided liveness map.
+func calcLiveReplicas(desc *roachpb.RangeDescriptor, livenessMap map[roachpb.NodeID]bool) int {
 	var goodReplicas int
+	for _, rd := range desc.Replicas {
+		if livenessMap[rd.NodeID] {
+			goodReplicas++
+		}
+	}
+	return goodReplicas
+}
+
+// calcBehindCount returns a total count of log entries that follower replicas
+// are behind. This can only be computed on the raft leader.
+func calcBehindCount(
+	raftStatus *raft.Status, desc *roachpb.RangeDescriptor, livenessMap map[roachpb.NodeID]bool,
+) int64 {
 	var behindCount int64
 	for _, rd := range desc.Replicas {
-		live := livenessMap[rd.NodeID]
-		if !leader {
-			if live {
-				goodReplicas++
-			}
-			continue
-		}
-
 		if progress, ok := raftStatus.Progress[uint64(rd.ReplicaID)]; ok {
-			if live {
-				// A single range can process thousands of ops/sec, so a replica that
-				// is 10 Raft log entries behind is fairly current. Setting this value
-				// to 0 makes the under-replicated metric overly sensitive. Setting
-				// this value too high makes the metric not show all of the
-				// under-replicated replicas.
-				const behindThreshold = 10
-				// TODO(peter): progress.Match will be 0 if this node recently
-				// became the leader. Presume such replicas are up to date until we
-				// hear otherwise. This is a bit of a hack.
-				if progress.Match == 0 ||
-					progress.Match+behindThreshold >= raftStatus.Commit {
-					goodReplicas++
-				}
-			}
 			if progress.Match > 0 &&
 				progress.Match < raftStatus.Commit {
 				behindCount += int64(raftStatus.Commit) - int64(progress.Match)
 			}
 		}
 	}
-	return goodReplicas, behindCount
+
+	return behindCount
 }
 
 // QueriesPerSecond returns the range's average QPS if it is the current

--- a/pkg/storage/replica_test.go
+++ b/pkg/storage/replica_test.go
@@ -8451,8 +8451,8 @@ func TestReplicaMetrics(t *testing.T) {
 			ReplicaMetrics{
 				Leader:          true,
 				RangeCounter:    true,
-				Unavailable:     true,
-				Underreplicated: true,
+				Unavailable:     false,
+				Underreplicated: false,
 				BehindCount:     21,
 			}},
 		// Both replicas of a 2-replica range are up to date, but follower is dead.
@@ -8498,7 +8498,7 @@ func TestReplicaMetrics(t *testing.T) {
 				Leader:          true,
 				RangeCounter:    true,
 				Unavailable:     false,
-				Underreplicated: true,
+				Underreplicated: false,
 				BehindCount:     31,
 			}},
 		// All replicas of a 3-replica range are live but two replicas are behind.
@@ -8506,8 +8506,8 @@ func TestReplicaMetrics(t *testing.T) {
 			ReplicaMetrics{
 				Leader:          true,
 				RangeCounter:    true,
-				Unavailable:     true,
-				Underreplicated: true,
+				Unavailable:     false,
+				Underreplicated: false,
 				BehindCount:     32,
 			}},
 		// All replicas of a 3-replica range are up to date, but one replica is dead.
@@ -8527,6 +8527,16 @@ func TestReplicaMetrics(t *testing.T) {
 				Unavailable:     true,
 				Underreplicated: true,
 				BehindCount:     30,
+			}},
+		// All replicas of a 3-replica range are up to date, but two replicas are
+		// dead, including the leader.
+		{3, 2, desc(1, 2, 3), status(0, progress(2, 2, 2)), live(2),
+			ReplicaMetrics{
+				Leader:          false,
+				RangeCounter:    true,
+				Unavailable:     true,
+				Underreplicated: true,
+				BehindCount:     0,
 			}},
 		// Range has no leader, local replica is the range counter.
 		{3, 1, desc(1, 2, 3), status(0, progress(2, 2, 2)), live(1, 2, 3),


### PR DESCRIPTION
Updates the criteria for selecting a "Range Counter" replica for each
range; the range counter is now the first live replica found in the
replica descriptor (i.e. live replica with the lowest replica ID).

Previously, the raft leader was preferred, with a backup of using the
first live replica. However, it is apparently fairly common for a subset
of replicas within a quiescent range to lose raft state, and thus
disagree over which node should be the "Range Counter".

Fixes #21109

Release note: Fixed a bug where the "Range Count" metric on the cluster
overview could significantly undercount the number of ranges.

Bonus PR Screenshot - This is a graph from my local machine of a three-node cluster, both with and without this fix applied.  There are 25 ranges on this cluster.

![screen shot 2018-03-05 at 3 19 02 pm](https://user-images.githubusercontent.com/6969858/36998278-53b39ee8-208a-11e8-9845-d8e0f2cb8cb9.png)

Note the two spikes in the purple "underreplicated ranges" stat, representing two distinct events where I stopped a single node.  The first is on master code; notice that the range count metric spikes to nearly 30 (well above the actual count), before settling down at 21, with several ranges uncounted.

The second spike represents the code with this fix; notice that the range count is steady at 25, the correct number. Also notice that the leader/leaseholder counts are significantly lower, as these cannot be counted correctly without raft state in memory (and the cluster restart left several ranges without in-memory raft state).