### PR TITLE
ui: clusterviz: add rect to NodeView to make it more clickable

### DIFF
--- a/pkg/ui/ccl/src/views/clusterviz/containers/map/nodeView.tsx
+++ b/pkg/ui/ccl/src/views/clusterviz/containers/map/nodeView.tsx
@@ -88,6 +88,7 @@ export class NodeView extends React.Component<NodeViewProps> {
         style={{ cursor: "pointer" }}
       >
         <g transform={`translate(${TRANSLATE_X},${TRANSLATE_Y})scale(${SCALE_FACTOR})`}>
+          <rect width={180} height={210} opacity={0} />
           <Labels
             label={`Node ${node.desc.node_id}`}
             subLabel={this.getUptimeText()}


### PR DESCRIPTION
Fixes #23400

Release note (admin ui change): clusterviz: allow clicking on the entire node component, not just the visible elements