### PR TITLE
sql: unskip TestDropAndCreateDatabase

### DIFF
--- a/pkg/sql/drop_test.go
+++ b/pkg/sql/drop_test.go
@@ -810,7 +810,6 @@ func TestDropAndCreateTable(t *testing.T) {
 
 func TestDropAndCreateDatabase(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	t.Skip(`#22256`)
 
 	ctx := context.Background()
 	s, db, _ := serverutils.StartServer(t, base.TestServerArgs{UseDatabase: `test`})


### PR DESCRIPTION
this is no longer failing under stress.

I suspect some consistency issue fix could have fixed this.

fixes #22256

Release note: None