### PR TITLE
ui: add command line args to node page

### DIFF
--- a/pkg/ui/src/views/cluster/containers/nodeOverview/index.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodeOverview/index.tsx
@@ -51,7 +51,7 @@ class NodeOverview extends React.Component<NodeOverviewProps, {}> {
     if (!node) {
       return (
         <div className="section">
-          <h1>Loading cluster status...</h1>
+          <h1>Loading node status...</h1>
         </div>
       );
     }
@@ -67,6 +67,9 @@ class NodeOverview extends React.Component<NodeOverviewProps, {}> {
         <div className="section section--heading">
           <h2>{`Node ${node.desc.node_id} / ${node.desc.address.address_field}`}</h2>
         </div>
+        <section className="section">
+          <pre>{node.args.join(" ")}</pre>
+        </section>
         <section className="section l-columns">
           <div className="l-columns__left">
             <table className="table">


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/7341/37001480-a3c93f3c-2094-11e8-9ea7-dbec25e7d898.png)

Not on the list for 2.0 but I figured I would just do it (always miss this when I click through to a node on the cluster viz). Also could use a better design; cc @josueeee. We can park this here until we get around to actually designing this.

Release note: None