### PR TITLE
ui: Debug Page Flashes

### DIFF
--- a/pkg/ui/src/views/devtools/containers/raftRanges/index.tsx
+++ b/pkg/ui/src/views/devtools/containers/raftRanges/index.tsx
@@ -130,7 +130,7 @@ class RangesMain extends React.Component<RangesMainProps, RangesMainState> {
       errors.push(this.props.state.lastError.message);
     }
 
-    if (this.props.state.inFlight) {
+    if (!this.props.state.data) {
       content = <div className="section">Loading...</div>;
     } else if (statuses) {
       errors = errors.concat(statuses.errors.map(err => err.message));

--- a/pkg/ui/src/views/reports/containers/localities/index.tsx
+++ b/pkg/ui/src/views/reports/containers/localities/index.tsx
@@ -95,7 +95,7 @@ class Localities extends React.Component<LocalitiesProps, {}> {
   render() {
     return (
       <Loading
-        loading={ !this.props.localityStatus.valid || !this.props.locationStatus.valid }
+        loading={ !this.props.localityStatus.data || !this.props.locationStatus.data }
         className="loading-image loading-image__spinner-left"
         image={ spinner }
       >


### PR DESCRIPTION
Two debug pages (Localities and Raft Ranges) were flashing content while
refreshing data; this is because they were using the wrong criteria for
determing whether to display a "loading..." message instead of content.

Fixes #23411
Fixes #21700

Release note: None