### PR TITLE
opt: fix GROUP BY build problem

### DIFF
--- a/pkg/sql/opt/optbuilder/project.go
+++ b/pkg/sql/opt/optbuilder/project.go
@@ -171,7 +171,7 @@ func (b *Builder) buildVariableProjection(
 func (b *Builder) buildDefaultScalarProjection(
 	texpr tree.TypedExpr, group opt.GroupID, label string, inScope, outScope *scope,
 ) opt.GroupID {
-	if inScope.inGroupingContext() {
+	if inScope.inGroupingContext() && !inScope.groupby.inAgg {
 		if len(inScope.groupby.varsUsed) > 0 {
 			if _, ok := inScope.groupby.groupStrs[symbolicExprStr(texpr)]; !ok {
 				// This expression was not found among the GROUP BY expressions.

--- a/pkg/sql/opt/optbuilder/testdata/aggregate
+++ b/pkg/sql/opt/optbuilder/testdata/aggregate
@@ -2231,3 +2231,26 @@ project
  │         └── function: count_rows [type=int]
  └── projections
       └── variable: column5 [type=int]
+
+build
+SELECT COUNT(UPPER(s)) FROM t.kv GROUP BY UPPER(s)
+----
+project
+ ├── columns: column7:int:null:7
+ ├── group-by
+ │    ├── columns: column5:string:null:5 column7:int:null:7
+ │    ├── grouping columns: column5:string:null:5
+ │    ├── project
+ │    │    ├── columns: column5:string:null:5 column6:string:null:6
+ │    │    ├── scan
+ │    │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
+ │    │    └── projections
+ │    │         ├── function: upper [type=string]
+ │    │         │    └── variable: kv.s [type=string]
+ │    │         └── function: upper [type=string]
+ │    │              └── variable: kv.s [type=string]
+ │    └── aggregations
+ │         └── function: count [type=int]
+ │              └── variable: column5 [type=string]
+ └── projections
+      └── variable: column7 [type=int]

--- a/pkg/sql/opt/optbuilder/testdata/having
+++ b/pkg/sql/opt/optbuilder/testdata/having
@@ -291,3 +291,30 @@ build
 SELECT t.kv.v FROM t.kv GROUP BY v, kv.k * w HAVING w > 5
 ----
 error: column "t.kv.w" must appear in the GROUP BY clause or be used in an aggregate function
+
+build
+SELECT UPPER(s), COUNT(s), COUNT(UPPER(s)) FROM t.kv GROUP BY UPPER(s) HAVING COUNT(s) > 1
+----
+select
+ ├── columns: column5:string:null:5 column6:int:null:6 column8:int:null:8
+ ├── group-by
+ │    ├── columns: column5:string:null:5 column6:int:null:6 column8:int:null:8
+ │    ├── grouping columns: column5:string:null:5
+ │    ├── project
+ │    │    ├── columns: column5:string:null:5 kv.s:string:null:4 column7:string:null:7
+ │    │    ├── scan
+ │    │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
+ │    │    └── projections
+ │    │         ├── function: upper [type=string]
+ │    │         │    └── variable: kv.s [type=string]
+ │    │         ├── variable: kv.s [type=string]
+ │    │         └── function: upper [type=string]
+ │    │              └── variable: kv.s [type=string]
+ │    └── aggregations
+ │         ├── function: count [type=int]
+ │         │    └── variable: column5 [type=string]
+ │         └── function: count [type=int]
+ │              └── variable: kv.s [type=string]
+ └── gt [type=bool]
+      ├── variable: column6 [type=int]
+      └── const: 1 [type=int]


### PR DESCRIPTION
The first commit adds a test case showing the invalid output. The diff in the second commit shows the correction.

#### opt: add test showing the problem

Release note: None

#### opt: fix GROUP BY build problem

We were incorrectly handling functions which are arguments to
aggregate functions and which exist as a grouping column (we were
processing them as top-level grouping column references and adding an
invalid expression in the pre-projection).

Note that deduplication of the pre-projections is a separate TODO
item.

Release note: None
