### PR TITLE
importccl: remove double pause in import test

### DIFF
--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -1064,9 +1064,6 @@ func TestBackupRestoreControlJob(t *testing.T) {
 		csvURLs := strings.Join(urls, ", ")
 		query := fmt.Sprintf(`IMPORT TABLE pauseimport.t (i INT PRIMARY KEY) CSV DATA (%s) WITH sstsize = '50B'`, csvURLs)
 
-		if _, err := run(t, "pause", query); !testutils.IsError(err, "job paused") {
-			t.Fatalf("expected 'job paused' error, but got %+v", err)
-		}
 		jobID, err := run(t, "PAUSE", query)
 		if !testutils.IsError(err, "job paused") {
 			t.Fatalf("unexpected: %v", err)


### PR DESCRIPTION
Unsure why this was here. Probably a copy/paste typo. Maybe this will
fix the flake?

Release note: None