### PR TITLE
cherry-pick 2.0: sql: fix panic in computed columns

### DIFF
--- a/pkg/sql/insert.go
+++ b/pkg/sql/insert.go
@@ -128,17 +128,19 @@ func (p *planner) Insert(
 	// columns receiving a default value, or computed columns.
 	numInputColumns := len(cols)
 
-	// We update the set of columns being inserted into with any default values
-	// for columns.
-	cols, defaultExprs, err :=
-		sqlbase.ProcessDefaultColumns(cols, en.tableDesc, &p.txCtx, p.EvalContext())
+	// We update the set of columns being inserted into with any computed columns.
+	cols, computedCols, computeExprs, err :=
+		ProcessComputedColumns(ctx, cols, tn, en.tableDesc, &p.txCtx, p.EvalContext())
 	if err != nil {
 		return nil, err
 	}
 
-	// We update the set of columns being inserted into with any computed columns.
-	cols, computedCols, computeExprs, err :=
-		ProcessComputedColumns(ctx, cols, tn, en.tableDesc, &p.txCtx, p.EvalContext())
+	// We update the set of columns being inserted into with any default values
+	// for columns. This needs to happen after we process the computed columns,
+	// because `defaultExprs` is expected to line up with the final set of
+	// columns being inserted into.
+	cols, defaultExprs, err :=
+		sqlbase.ProcessDefaultColumns(cols, en.tableDesc, &p.txCtx, p.EvalContext())
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/logictest/testdata/logic_test/computed
+++ b/pkg/sql/logictest/testdata/logic_test/computed
@@ -626,3 +626,31 @@ WHERE table_name = 'x' and generation_expression = ''
 # TODO(justin): #22652
 statement error adding a computed column via ALTER not supported
 ALTER TABLE x ADD COLUMN c INT AS (4) STORED
+
+statement ok
+DROP TABLE x
+
+# Regression test for #23109
+statement ok
+CREATE TABLE x (
+  a INT DEFAULT 1,
+  b INT AS (2) STORED
+)
+
+statement ok
+INSERT INTO x (a) SELECT 1
+
+statement ok
+DROP TABLE x
+
+statement ok
+CREATE TABLE x (
+  b INT AS (2) STORED,
+  a INT DEFAULT 1
+)
+
+statement ok
+INSERT INTO x (a) SELECT 1
+
+statement ok
+DROP TABLE x


### PR DESCRIPTION
Prior to this patch, certain combinations of defaults and computed
columns could cause panics, since we would construct `defaultExprs` to
line up with the set of columns being inserted into *before* it was
augmented with any computed columns. This patch switches their order so
that this doesn't happen.

Release note (bug fix): Fix a panic with computed columns.

cc @cockroachdb/release 