### PR TITLE
ui: nodes debug page: don't put source of toString function in tooltip

### DIFF
--- a/pkg/ui/src/views/reports/containers/nodes/index.tsx
+++ b/pkg/ui/src/views/reports/containers/nodes/index.tsx
@@ -107,7 +107,7 @@ function titleTimestampValue(value: string) {
       return null;
     }
     const raw = FixLong(_.get(status, value) as Long);
-    return `${LongToMoment(raw).format(dateFormat)}\n${raw.toString}`;
+    return `${LongToMoment(raw).format(dateFormat)}\n${raw.toString()}`;
   };
 }
 


### PR DESCRIPTION
Before:
Title tooltip on the bottom-most column (a timestamp) of nodes debug page contained entire source of `Long#toString`, because in JS the `.toString()` of a function is its source.

After:
![image](https://user-images.githubusercontent.com/7341/37002560-21a269e4-2098-11e8-8346-a82a101d83f5.png)

Release note: None