### PR TITLE
opt: Add next batch of scalar rules to optimizer

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/builder_test.go
+++ b/pkg/sql/opt/exec/execbuilder/builder_test.go
@@ -141,8 +141,10 @@ func TestBuild(t *testing.T) {
 					defer eng.Close()
 
 					// Build and optimize the opt expression tree.
-					o := xform.NewOptimizer(eng.Catalog(), xform.OptimizeAll)
-					builder := optbuilder.New(ctx, &semaCtx, &evalCtx, o.Factory(), stmt)
+					o := xform.NewOptimizer(&evalCtx, xform.OptimizeAll)
+					builder := optbuilder.New(
+						ctx, &semaCtx, &evalCtx, eng.Catalog(), o.Factory(), stmt,
+					)
 					builder.AllowUnsupportedExpr = allowUnsupportedExpr
 					root, props, err := builder.Build()
 					if err != nil {

--- a/pkg/sql/opt/exec/execbuilder/testdata/scalar
+++ b/pkg/sql/opt/exec/execbuilder/testdata/scalar
@@ -151,7 +151,7 @@ exec-explain
 SELECT (a, b + c, 5 + d * 2) = (b+c, 8, a - c)  FROM t.t
 ----
 render     0  render  ·         ·                                                                (column8)                          ·
- │         0  ·       render 0  ((a = (b + c)) AND ((b + c) = 8)) AND ((5 + (d * 2)) = (a - c))  ·                                  ·
+ │         0  ·       render 0  ((a = (b + c)) AND ((b + c) = 8)) AND (((d * 2) + 5) = (a - c))  ·                                  ·
  └── scan  1  scan    ·         ·                                                                (a, b, c, d, j, s, rowid[hidden])  ·
 ·          1  ·       table     t@primary                                                        ·                                  ·
 ·          1  ·       spans     ALL                                                              ·                                  ·
@@ -231,11 +231,11 @@ render     0  render  ·         ·                     (column8)               
 exec-explain
 SELECT +a + (-b) FROM t.t
 ----
-render     0  render  ·         ·            (column8)                          ·
- │         0  ·       render 0  (+a) + (-b)  ·                                  ·
- └── scan  1  scan    ·         ·            (a, b, c, d, j, s, rowid[hidden])  ·
-·          1  ·       table     t@primary    ·                                  ·
-·          1  ·       spans     ALL          ·                                  ·
+render     0  render  ·         ·          (column8)                          ·
+ │         0  ·       render 0  a + (-b)   ·                                  ·
+ └── scan  1  scan    ·         ·          (a, b, c, d, j, s, rowid[hidden])  ·
+·          1  ·       table     t@primary  ·                                  ·
+·          1  ·       spans     ALL        ·                                  ·
 
 exec-explain
 SELECT CASE a WHEN 1 THEN 2 WHEN 2 THEN 3 ELSE 4 END FROM t.t
@@ -259,7 +259,7 @@ exec-explain
 SELECT CASE a + 3 WHEN 5 * b THEN 1 % b WHEN 6 THEN 2 ELSE -1 END FROM t.t
 ----
 render     0  render  ·         ·                                                           (column8)                          ·
- │         0  ·       render 0  CASE a + 3 WHEN 5 * b THEN 1 % b WHEN 6 THEN 2 ELSE -1 END  ·                                  ·
+ │         0  ·       render 0  CASE a + 3 WHEN b * 5 THEN 1 % b WHEN 6 THEN 2 ELSE -1 END  ·                                  ·
  └── scan  1  scan    ·         ·                                                           (a, b, c, d, j, s, rowid[hidden])  ·
 ·          1  ·       table     t@primary                                                   ·                                  ·
 ·          1  ·       spans     ALL                                                         ·                                  ·
@@ -349,7 +349,7 @@ exec-explain
 SELECT CAST(a + b + c AS string) FROM t.t
 ----
 render     0  render  ·         ·                      (column8)                          ·
- │         0  ·       render 0  ((a + b) + c)::STRING  ·                                  ·
+ │         0  ·       render 0  (c + (a + b))::STRING  ·                                  ·
  └── scan  1  scan    ·         ·                      (a, b, c, d, j, s, rowid[hidden])  ·
 ·          1  ·       table     t@primary              ·                                  ·
 ·          1  ·       spans     ALL                    ·                                  ·

--- a/pkg/sql/opt/factory.og.go
+++ b/pkg/sql/opt/factory.og.go
@@ -225,9 +225,6 @@ type Factory interface {
 	// ConstructFetchTextPath constructs an expression for the FetchTextPath operator.
 	ConstructFetchTextPath(json GroupID, path GroupID) GroupID
 
-	// ConstructUnaryPlus constructs an expression for the UnaryPlus operator.
-	ConstructUnaryPlus(input GroupID) GroupID
-
 	// ConstructUnaryMinus constructs an expression for the UnaryMinus operator.
 	ConstructUnaryMinus(input GroupID) GroupID
 

--- a/pkg/sql/opt/idxconstraint/index_constraints_test.go
+++ b/pkg/sql/opt/idxconstraint/index_constraints_test.go
@@ -88,8 +88,6 @@ func TestIndexConstraints(t *testing.T) {
 			semaCtx := tree.MakeSemaContext(false /* privileged */)
 			evalCtx := tree.MakeTestingEvalContext(cluster.MakeTestingClusterSettings())
 
-			catalog := testutils.NewTestCatalog()
-
 			datadriven.RunTest(t, path, func(d *datadriven.TestData) string {
 				var varTypes []types.T
 				var colInfos []IndexColumnInfo
@@ -158,7 +156,7 @@ func TestIndexConstraints(t *testing.T) {
 					if !normalize {
 						steps = xform.OptimizeNone
 					}
-					o := xform.NewOptimizer(catalog, steps)
+					o := xform.NewOptimizer(&evalCtx, steps)
 					b := optbuilder.NewScalar(ctx, &semaCtx, &evalCtx, o.Factory(), varNames, varTypes)
 					b.AllowUnsupportedExpr = true
 					group, err := b.Build(typedExpr)
@@ -256,9 +254,7 @@ func BenchmarkIndexConstraints(b *testing.B) {
 			for i := range varNames {
 				varNames[i] = fmt.Sprintf("@%d", i+1)
 			}
-			bld := optbuilder.NewScalar(
-				context.Background(), &semaCtx, &evalCtx, o.Factory(), varNames, varTypes,
-			)
+			bld := optbuilder.NewScalar(context.Background(), &semaCtx, &evalCtx, o.Factory(), varNames, varTypes)
 
 			group, err := bld.Build(typedExpr)
 			if err != nil {

--- a/pkg/sql/opt/metadata.go
+++ b/pkg/sql/opt/metadata.go
@@ -86,9 +86,6 @@ type mdCol struct {
 //   -- [0] -> x
 //   -- [1] -> y
 type Metadata struct {
-	// catalog contains system-wide metadata.
-	catalog optbase.Catalog
-
 	// cols stores information about each metadata column, indexed by
 	// ColumnIndex. Skip index 0 so that it is reserved for "unknown column".
 	cols []mdCol
@@ -99,16 +96,10 @@ type Metadata struct {
 	tables map[TableIndex]optbase.Table
 }
 
-// NewMetadata constructs a new instance of metadata based on the given
-// catalog.
-func NewMetadata(catalog optbase.Catalog) *Metadata {
+// NewMetadata constructs a new instance of metadata for the optimizer.
+func NewMetadata() *Metadata {
 	// Skip label index 0 so that it is reserved for "unknown column".
-	return &Metadata{catalog: catalog, cols: make([]mdCol, 1)}
-}
-
-// Catalog returns the system catalog from which query metadata is derived.
-func (md *Metadata) Catalog() optbase.Catalog {
-	return md.catalog
+	return &Metadata{cols: make([]mdCol, 1)}
 }
 
 // AddColumn indexes a new reference to a column within the query and records

--- a/pkg/sql/opt/metadata_test.go
+++ b/pkg/sql/opt/metadata_test.go
@@ -22,11 +22,7 @@ import (
 )
 
 func TestMetadataColumns(t *testing.T) {
-	cat := testutils.NewTestCatalog()
-	md := NewMetadata(cat)
-	if md.Catalog() != cat {
-		t.Fatal("metadata catalog didn't match catalog passed to newMetadata")
-	}
+	md := NewMetadata()
 
 	// Add standalone column.
 	colIndex := md.AddColumn("alias", types.Int)
@@ -70,11 +66,7 @@ func TestMetadataColumns(t *testing.T) {
 }
 
 func TestMetadataTables(t *testing.T) {
-	cat := testutils.NewTestCatalog()
-	md := NewMetadata(cat)
-	if md.Catalog() != cat {
-		t.Fatal("metadata catalog didn't match catalog passed to newMetadata")
-	}
+	md := NewMetadata()
 
 	// Add a table reference to the metadata.
 	a := &testutils.TestTable{Name: "a"}

--- a/pkg/sql/opt/operator.go
+++ b/pkg/sql/opt/operator.go
@@ -127,7 +127,6 @@ var BinaryOpReverseMap = [...]tree.BinaryOperator{
 // UnaryOpReverseMap maps from an optimizer operator type to a semantic tree
 // unary operator type.
 var UnaryOpReverseMap = [...]tree.UnaryOperator{
-	UnaryPlusOp:       tree.UnaryPlus,
 	UnaryMinusOp:      tree.UnaryMinus,
 	UnaryComplementOp: tree.UnaryComplement,
 }

--- a/pkg/sql/opt/operator.og.go
+++ b/pkg/sql/opt/operator.og.go
@@ -155,8 +155,6 @@ const (
 
 	FetchTextPathOp
 
-	UnaryPlusOp
-
 	UnaryMinusOp
 
 	UnaryComplementOp
@@ -365,9 +363,9 @@ const (
 	NumOperators
 )
 
-const opNames = "unknownsubqueryvariableconstnulltruefalseplaceholdertupleprojectionsaggregationsexistsandornoteqltgtlegeneinnot-inlikenot-likei-likenot-i-likesimilar-tonot-similar-toreg-matchnot-reg-matchreg-i-matchnot-reg-i-matchisis-notcontainsbitandbitorbitxorplusminusmultdivfloor-divmodpowconcatl-shiftr-shiftfetch-valfetch-textfetch-val-pathfetch-text-pathunary-plusunary-minusunary-complementcastcasewhenfunctioncoalesceunsupported-exprscanvaluesselectprojectinner-joinleft-joinright-joinfull-joinsemi-joinanti-joininner-join-applyleft-join-applyright-join-applyfull-join-applysemi-join-applyanti-join-applygroup-byunionintersectexceptunion-allintersect-allexcept-allsort"
+const opNames = "unknownsubqueryvariableconstnulltruefalseplaceholdertupleprojectionsaggregationsexistsandornoteqltgtlegeneinnot-inlikenot-likei-likenot-i-likesimilar-tonot-similar-toreg-matchnot-reg-matchreg-i-matchnot-reg-i-matchisis-notcontainsbitandbitorbitxorplusminusmultdivfloor-divmodpowconcatl-shiftr-shiftfetch-valfetch-textfetch-val-pathfetch-text-pathunary-minusunary-complementcastcasewhenfunctioncoalesceunsupported-exprscanvaluesselectprojectinner-joinleft-joinright-joinfull-joinsemi-joinanti-joininner-join-applyleft-join-applyright-join-applyfull-join-applysemi-join-applyanti-join-applygroup-byunionintersectexceptunion-allintersect-allexcept-allsort"
 
-var opIndexes = [...]uint32{0, 7, 15, 23, 28, 32, 36, 41, 52, 57, 68, 80, 86, 89, 91, 94, 96, 98, 100, 102, 104, 106, 108, 114, 118, 126, 132, 142, 152, 166, 175, 188, 199, 214, 216, 222, 230, 236, 241, 247, 251, 256, 260, 263, 272, 275, 278, 284, 291, 298, 307, 317, 331, 346, 356, 367, 383, 387, 391, 395, 403, 411, 427, 431, 437, 443, 450, 460, 469, 479, 488, 497, 506, 522, 537, 553, 568, 583, 598, 606, 611, 620, 626, 635, 648, 658, 662}
+var opIndexes = [...]uint32{0, 7, 15, 23, 28, 32, 36, 41, 52, 57, 68, 80, 86, 89, 91, 94, 96, 98, 100, 102, 104, 106, 108, 114, 118, 126, 132, 142, 152, 166, 175, 188, 199, 214, 216, 222, 230, 236, 241, 247, 251, 256, 260, 263, 272, 275, 278, 284, 291, 298, 307, 317, 331, 346, 357, 373, 377, 381, 385, 393, 401, 417, 421, 427, 433, 440, 450, 459, 469, 478, 487, 496, 512, 527, 543, 558, 573, 588, 596, 601, 610, 616, 625, 638, 648, 652}
 
 var ScalarOperators = [...]Operator{
 	SubqueryOp,
@@ -422,7 +420,6 @@ var ScalarOperators = [...]Operator{
 	FetchTextOp,
 	FetchValPathOp,
 	FetchTextPathOp,
-	UnaryPlusOp,
 	UnaryMinusOp,
 	UnaryComplementOp,
 	CastOp,
@@ -493,7 +490,6 @@ var BinaryOperators = [...]Operator{
 }
 
 var UnaryOperators = [...]Operator{
-	UnaryPlusOp,
 	UnaryMinusOp,
 	UnaryComplementOp,
 }

--- a/pkg/sql/opt/ops/scalar.opt
+++ b/pkg/sql/opt/ops/scalar.opt
@@ -349,11 +349,6 @@ define FetchTextPath {
 }
 
 [Scalar, Unary]
-define UnaryPlus {
-    Input Expr
-}
-
-[Scalar, Unary]
 define UnaryMinus {
     Input Expr
 }

--- a/pkg/sql/opt/optbuilder/builder.go
+++ b/pkg/sql/opt/optbuilder/builder.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
+	"github.com/cockroachdb/cockroach/pkg/sql/optbase"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 )
@@ -58,6 +59,7 @@ type Builder struct {
 	ctx     context.Context
 	semaCtx *tree.SemaContext
 	evalCtx *tree.EvalContext
+	catalog optbase.Catalog
 
 	// Skip index 0 in order to reserve it to indicate the "unknown" column.
 	colMap []columnProps
@@ -69,6 +71,7 @@ func New(
 	ctx context.Context,
 	semaCtx *tree.SemaContext,
 	evalCtx *tree.EvalContext,
+	catalog optbase.Catalog,
 	factory opt.Factory,
 	stmt tree.Statement,
 ) *Builder {
@@ -79,6 +82,7 @@ func New(
 		ctx:     ctx,
 		semaCtx: semaCtx,
 		evalCtx: evalCtx,
+		catalog: catalog,
 	}
 }
 

--- a/pkg/sql/opt/optbuilder/builder_test.go
+++ b/pkg/sql/opt/optbuilder/builder_test.go
@@ -124,8 +124,8 @@ func TestBuilder(t *testing.T) {
 						d.Fatalf(t, "%v", err)
 					}
 
-					o := xform.NewOptimizer(catalog, xform.OptimizeNone)
-					b := New(ctx, &semaCtx, &evalCtx, o.Factory(), stmt)
+					o := xform.NewOptimizer(&evalCtx, xform.OptimizeNone)
+					b := New(ctx, &semaCtx, &evalCtx, catalog, o.Factory(), stmt)
 					b.AllowUnsupportedExpr = allowUnsupportedExpr
 					root, props, err := b.Build()
 					if err != nil {
@@ -144,7 +144,7 @@ func TestBuilder(t *testing.T) {
 					for i := range varNames {
 						varNames[i] = fmt.Sprintf("@%d", i+1)
 					}
-					o := xform.NewOptimizer(catalog, xform.OptimizeNone)
+					o := xform.NewOptimizer(&evalCtx, xform.OptimizeNone)
 					b := NewScalar(ctx, &semaCtx, &evalCtx, o.Factory(), varNames, varTypes)
 					b.AllowUnsupportedExpr = allowUnsupportedExpr
 					group, err := b.Build(typedExpr)

--- a/pkg/sql/opt/optbuilder/scalar.go
+++ b/pkg/sql/opt/optbuilder/scalar.go
@@ -75,7 +75,6 @@ var binaryOpMap = [tree.NumBinaryOperators]binaryFactoryFunc{
 
 // Map from tree.UnaryOperator to Factory constructor function.
 var unaryOpMap = [tree.NumUnaryOperators]unaryFactoryFunc{
-	tree.UnaryPlus:       (opt.Factory).ConstructUnaryPlus,
 	tree.UnaryMinus:      (opt.Factory).ConstructUnaryMinus,
 	tree.UnaryComplement: (opt.Factory).ConstructUnaryComplement,
 }
@@ -223,7 +222,12 @@ func (b *Builder) buildScalar(scalar tree.TypedExpr, inScope *scope) (out opt.Gr
 		out = b.factory.ConstructTuple(b.factory.InternList(list))
 
 	case *tree.UnaryExpr:
-		out = unaryOpMap[t.Operator](b.factory, b.buildScalar(t.TypedInnerExpr(), inScope))
+		out = b.buildScalar(t.TypedInnerExpr(), inScope)
+
+		// Discard do-nothing unary plus operator.
+		if t.Operator != tree.UnaryPlus {
+			out = unaryOpMap[t.Operator](b.factory, out)
+		}
 
 	// NB: this is the exception to the sorting of the case statements. The
 	// tree.Datum case needs to occur after *tree.Placeholder which implements

--- a/pkg/sql/opt/optbuilder/select.go
+++ b/pkg/sql/opt/optbuilder/select.go
@@ -52,7 +52,7 @@ func (b *Builder) buildTable(
 		if err != nil {
 			panic(builderError{err})
 		}
-		tbl, err := b.factory.Metadata().Catalog().FindTable(b.ctx, tn)
+		tbl, err := b.catalog.FindTable(b.ctx, tn)
 		if err != nil {
 			panic(builderError{err})
 		}

--- a/pkg/sql/opt/optbuilder/testdata/aggregate
+++ b/pkg/sql/opt/optbuilder/testdata/aggregate
@@ -2145,15 +2145,13 @@ project
  │    │    ├── scan
  │    │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
  │    │    └── projections [outer=(1,3)]
- │    │         ├── unary-plus [type=int, outer=(1)]
- │    │         │    └── variable: kv.k [type=int, outer=(1)]
+ │    │         ├── variable: kv.k [type=int, outer=(1)]
  │    │         └── unary-minus [type=int, outer=(3)]
  │    │              └── variable: kv.w [type=int, outer=(3)]
  │    └── aggregations
  └── projections [outer=(1,3)]
       └── mult [type=int, outer=(1,3)]
-           ├── unary-plus [type=int, outer=(1)]
-           │    └── variable: kv.k [type=int, outer=(1)]
+           ├── variable: kv.k [type=int, outer=(1)]
            └── unary-minus [type=int, outer=(3)]
                 └── variable: kv.w [type=int, outer=(3)]
 
@@ -2180,8 +2178,7 @@ project
  │    └── aggregations
  └── projections [outer=(1,3)]
       └── mult [type=int, outer=(1,3)]
-           ├── unary-plus [type=int, outer=(1)]
-           │    └── variable: kv.k [type=int, outer=(1)]
+           ├── variable: kv.k [type=int, outer=(1)]
            └── unary-minus [type=int, outer=(3)]
                 └── variable: kv.w [type=int, outer=(3)]
 
@@ -2229,8 +2226,8 @@ project
  │    │         └── variable: kv.k [type=int, outer=(1)]
  │    └── aggregations
  │         └── function: count_rows [type=int]
- └── projections
-      └── variable: column5 [type=int]
+ └── projections [outer=(5)]
+      └── variable: column5 [type=int, outer=(5)]
 
 build
 SELECT COUNT(UPPER(s)) FROM t.kv GROUP BY UPPER(s)
@@ -2244,13 +2241,13 @@ project
  │    │    ├── columns: column5:string:null:5 column6:string:null:6
  │    │    ├── scan
  │    │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
- │    │    └── projections
- │    │         ├── function: upper [type=string]
- │    │         │    └── variable: kv.s [type=string]
- │    │         └── function: upper [type=string]
- │    │              └── variable: kv.s [type=string]
- │    └── aggregations
- │         └── function: count [type=int]
- │              └── variable: column5 [type=string]
- └── projections
-      └── variable: column7 [type=int]
+ │    │    └── projections [outer=(4)]
+ │    │         ├── function: upper [type=string, outer=(4)]
+ │    │         │    └── variable: kv.s [type=string, outer=(4)]
+ │    │         └── function: upper [type=string, outer=(4)]
+ │    │              └── variable: kv.s [type=string, outer=(4)]
+ │    └── aggregations [outer=(5)]
+ │         └── function: count [type=int, outer=(5)]
+ │              └── variable: column5 [type=string, outer=(5)]
+ └── projections [outer=(7)]
+      └── variable: column7 [type=int, outer=(7)]

--- a/pkg/sql/opt/optbuilder/testdata/aggregate
+++ b/pkg/sql/opt/optbuilder/testdata/aggregate
@@ -38,29 +38,29 @@ group-by
  │         ├── true [type=bool]
  │         ├── false [type=bool]
  │         └── const: '\x01' [type=bytes]
- └── aggregations
-      ├── function: min [type=int]
-      │    └── variable: column5 [type=int]
-      ├── function: max [type=int]
-      │    └── variable: column7 [type=int]
-      ├── function: count [type=int]
-      │    └── variable: column9 [type=int]
-      ├── function: sum_int [type=int]
-      │    └── variable: column11 [type=int]
-      ├── function: avg [type=decimal]
-      │    └── variable: column13 [type=int]
-      ├── function: sum [type=decimal]
-      │    └── variable: column15 [type=int]
-      ├── function: stddev [type=decimal]
-      │    └── variable: column17 [type=int]
-      ├── function: variance [type=decimal]
-      │    └── variable: column19 [type=int]
-      ├── function: bool_and [type=bool]
-      │    └── variable: column21 [type=bool]
-      ├── function: bool_and [type=bool]
-      │    └── variable: column23 [type=bool]
-      └── function: xor_agg [type=bytes]
-           └── variable: column25 [type=bytes]
+ └── aggregations [outer=(5,7,9,11,13,15,17,19,21,23,25)]
+      ├── function: min [type=int, outer=(5)]
+      │    └── variable: column5 [type=int, outer=(5)]
+      ├── function: max [type=int, outer=(7)]
+      │    └── variable: column7 [type=int, outer=(7)]
+      ├── function: count [type=int, outer=(9)]
+      │    └── variable: column9 [type=int, outer=(9)]
+      ├── function: sum_int [type=int, outer=(11)]
+      │    └── variable: column11 [type=int, outer=(11)]
+      ├── function: avg [type=decimal, outer=(13)]
+      │    └── variable: column13 [type=int, outer=(13)]
+      ├── function: sum [type=decimal, outer=(15)]
+      │    └── variable: column15 [type=int, outer=(15)]
+      ├── function: stddev [type=decimal, outer=(17)]
+      │    └── variable: column17 [type=int, outer=(17)]
+      ├── function: variance [type=decimal, outer=(19)]
+      │    └── variable: column19 [type=int, outer=(19)]
+      ├── function: bool_and [type=bool, outer=(21)]
+      │    └── variable: column21 [type=bool, outer=(21)]
+      ├── function: bool_and [type=bool, outer=(23)]
+      │    └── variable: column23 [type=bool, outer=(23)]
+      └── function: xor_agg [type=bytes, outer=(25)]
+           └── variable: column25 [type=bytes, outer=(25)]
 
 build
 SELECT MIN(v), MAX(v), COUNT(v), SUM_INT(1), AVG(v), SUM(v), STDDEV(v),
@@ -72,46 +72,46 @@ group-by
  │    ├── columns: kv.v:int:null:2 kv.v:int:null:2 kv.v:int:null:2 column8:int:null:8 kv.v:int:null:2 kv.v:int:null:2 kv.v:int:null:2 kv.v:int:null:2 column14:bool:null:14 column16:bool:null:16 column18:bytes:null:18
  │    ├── scan
  │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
- │    └── projections
- │         ├── variable: kv.v [type=int]
- │         ├── variable: kv.v [type=int]
- │         ├── variable: kv.v [type=int]
+ │    └── projections [outer=(2,4)]
+ │         ├── variable: kv.v [type=int, outer=(2)]
+ │         ├── variable: kv.v [type=int, outer=(2)]
+ │         ├── variable: kv.v [type=int, outer=(2)]
  │         ├── const: 1 [type=int]
- │         ├── variable: kv.v [type=int]
- │         ├── variable: kv.v [type=int]
- │         ├── variable: kv.v [type=int]
- │         ├── variable: kv.v [type=int]
- │         ├── eq [type=bool]
- │         │    ├── variable: kv.v [type=int]
+ │         ├── variable: kv.v [type=int, outer=(2)]
+ │         ├── variable: kv.v [type=int, outer=(2)]
+ │         ├── variable: kv.v [type=int, outer=(2)]
+ │         ├── variable: kv.v [type=int, outer=(2)]
+ │         ├── eq [type=bool, outer=(2)]
+ │         │    ├── variable: kv.v [type=int, outer=(2)]
  │         │    └── const: 1 [type=int]
- │         ├── eq [type=bool]
- │         │    ├── variable: kv.v [type=int]
+ │         ├── eq [type=bool, outer=(2)]
+ │         │    ├── variable: kv.v [type=int, outer=(2)]
  │         │    └── const: 1 [type=int]
- │         └── cast: bytes [type=bytes]
- │              └── variable: kv.s [type=string]
- └── aggregations
-      ├── function: min [type=int]
-      │    └── variable: kv.v [type=int]
-      ├── function: max [type=int]
-      │    └── variable: kv.v [type=int]
-      ├── function: count [type=int]
-      │    └── variable: kv.v [type=int]
-      ├── function: sum_int [type=int]
-      │    └── variable: column8 [type=int]
-      ├── function: avg [type=decimal]
-      │    └── variable: kv.v [type=int]
-      ├── function: sum [type=decimal]
-      │    └── variable: kv.v [type=int]
-      ├── function: stddev [type=decimal]
-      │    └── variable: kv.v [type=int]
-      ├── function: variance [type=decimal]
-      │    └── variable: kv.v [type=int]
-      ├── function: bool_and [type=bool]
-      │    └── variable: column14 [type=bool]
-      ├── function: bool_and [type=bool]
-      │    └── variable: column16 [type=bool]
-      └── function: xor_agg [type=bytes]
-           └── variable: column18 [type=bytes]
+ │         └── cast: bytes [type=bytes, outer=(4)]
+ │              └── variable: kv.s [type=string, outer=(4)]
+ └── aggregations [outer=(2,8,14,16,18)]
+      ├── function: min [type=int, outer=(2)]
+      │    └── variable: kv.v [type=int, outer=(2)]
+      ├── function: max [type=int, outer=(2)]
+      │    └── variable: kv.v [type=int, outer=(2)]
+      ├── function: count [type=int, outer=(2)]
+      │    └── variable: kv.v [type=int, outer=(2)]
+      ├── function: sum_int [type=int, outer=(8)]
+      │    └── variable: column8 [type=int, outer=(8)]
+      ├── function: avg [type=decimal, outer=(2)]
+      │    └── variable: kv.v [type=int, outer=(2)]
+      ├── function: sum [type=decimal, outer=(2)]
+      │    └── variable: kv.v [type=int, outer=(2)]
+      ├── function: stddev [type=decimal, outer=(2)]
+      │    └── variable: kv.v [type=int, outer=(2)]
+      ├── function: variance [type=decimal, outer=(2)]
+      │    └── variable: kv.v [type=int, outer=(2)]
+      ├── function: bool_and [type=bool, outer=(14)]
+      │    └── variable: column14 [type=bool, outer=(14)]
+      ├── function: bool_and [type=bool, outer=(16)]
+      │    └── variable: column16 [type=bool, outer=(16)]
+      └── function: xor_agg [type=bytes, outer=(18)]
+           └── variable: column18 [type=bytes, outer=(18)]
 
 build
 SELECT MIN(1), COUNT(1), MAX(1), SUM_INT(1), AVG(1)::float, SUM(1), STDDEV(1),
@@ -137,44 +137,44 @@ project
  │    │         ├── true [type=bool]
  │    │         ├── true [type=bool]
  │    │         └── const: '\x01' [type=bytes]
- │    └── aggregations
- │         ├── function: min [type=int]
- │         │    └── variable: column1 [type=int]
- │         ├── function: count [type=int]
- │         │    └── variable: column3 [type=int]
- │         ├── function: max [type=int]
- │         │    └── variable: column5 [type=int]
- │         ├── function: sum_int [type=int]
- │         │    └── variable: column7 [type=int]
- │         ├── function: avg [type=decimal]
- │         │    └── variable: column9 [type=int]
- │         ├── function: sum [type=decimal]
- │         │    └── variable: column12 [type=int]
- │         ├── function: stddev [type=decimal]
- │         │    └── variable: column14 [type=int]
- │         ├── function: variance [type=decimal]
- │         │    └── variable: column16 [type=int]
- │         ├── function: bool_and [type=bool]
- │         │    └── variable: column19 [type=bool]
- │         ├── function: bool_or [type=bool]
- │         │    └── variable: column21 [type=bool]
- │         └── function: xor_agg [type=bytes]
- │              └── variable: column23 [type=bytes]
- └── projections
-      ├── variable: column2 [type=int]
-      ├── variable: column4 [type=int]
-      ├── variable: column6 [type=int]
-      ├── variable: column8 [type=int]
-      ├── cast: float [type=float]
-      │    └── variable: column10 [type=decimal]
-      ├── variable: column13 [type=decimal]
-      ├── variable: column15 [type=decimal]
-      ├── cast: float [type=float]
-      │    └── variable: column17 [type=decimal]
-      ├── variable: column20 [type=bool]
-      ├── variable: column22 [type=bool]
-      └── function: to_hex [type=string]
-           └── variable: column24 [type=bytes]
+ │    └── aggregations [outer=(1,3,5,7,9,12,14,16,19,21,23)]
+ │         ├── function: min [type=int, outer=(1)]
+ │         │    └── variable: column1 [type=int, outer=(1)]
+ │         ├── function: count [type=int, outer=(3)]
+ │         │    └── variable: column3 [type=int, outer=(3)]
+ │         ├── function: max [type=int, outer=(5)]
+ │         │    └── variable: column5 [type=int, outer=(5)]
+ │         ├── function: sum_int [type=int, outer=(7)]
+ │         │    └── variable: column7 [type=int, outer=(7)]
+ │         ├── function: avg [type=decimal, outer=(9)]
+ │         │    └── variable: column9 [type=int, outer=(9)]
+ │         ├── function: sum [type=decimal, outer=(12)]
+ │         │    └── variable: column12 [type=int, outer=(12)]
+ │         ├── function: stddev [type=decimal, outer=(14)]
+ │         │    └── variable: column14 [type=int, outer=(14)]
+ │         ├── function: variance [type=decimal, outer=(16)]
+ │         │    └── variable: column16 [type=int, outer=(16)]
+ │         ├── function: bool_and [type=bool, outer=(19)]
+ │         │    └── variable: column19 [type=bool, outer=(19)]
+ │         ├── function: bool_or [type=bool, outer=(21)]
+ │         │    └── variable: column21 [type=bool, outer=(21)]
+ │         └── function: xor_agg [type=bytes, outer=(23)]
+ │              └── variable: column23 [type=bytes, outer=(23)]
+ └── projections [outer=(2,4,6,8,10,13,15,17,20,22,24)]
+      ├── variable: column2 [type=int, outer=(2)]
+      ├── variable: column4 [type=int, outer=(4)]
+      ├── variable: column6 [type=int, outer=(6)]
+      ├── variable: column8 [type=int, outer=(8)]
+      ├── cast: float [type=float, outer=(10)]
+      │    └── variable: column10 [type=decimal, outer=(10)]
+      ├── variable: column13 [type=decimal, outer=(13)]
+      ├── variable: column15 [type=decimal, outer=(15)]
+      ├── cast: float [type=float, outer=(17)]
+      │    └── variable: column17 [type=decimal, outer=(17)]
+      ├── variable: column20 [type=bool, outer=(20)]
+      ├── variable: column22 [type=bool, outer=(22)]
+      └── function: to_hex [type=string, outer=(24)]
+           └── variable: column24 [type=bytes, outer=(24)]
 
 build
 SELECT ARRAY_AGG(1) FROM t.kv
@@ -187,9 +187,9 @@ group-by
  │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
  │    └── projections
  │         └── const: 1 [type=int]
- └── aggregations
-      └── function: array_agg [type=int[]]
-           └── variable: column5 [type=int]
+ └── aggregations [outer=(5)]
+      └── function: array_agg [type=int[], outer=(5)]
+           └── variable: column5 [type=int, outer=(5)]
 
 build
 SELECT JSON_AGG(v) FROM t.kv
@@ -200,11 +200,11 @@ group-by
  │    ├── columns: kv.v:int:null:2
  │    ├── scan
  │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
- │    └── projections
- │         └── variable: kv.v [type=int]
- └── aggregations
-      └── function: json_agg [type=jsonb]
-           └── variable: kv.v [type=int]
+ │    └── projections [outer=(2)]
+ │         └── variable: kv.v [type=int, outer=(2)]
+ └── aggregations [outer=(2)]
+      └── function: json_agg [type=jsonb, outer=(2)]
+           └── variable: kv.v [type=int, outer=(2)]
 
 build
 SELECT JSONB_AGG(1)
@@ -217,9 +217,9 @@ group-by
  │    │    └── tuple [type=tuple{}]
  │    └── projections
  │         └── const: 1 [type=int]
- └── aggregations
-      └── function: jsonb_agg [type=jsonb]
-           └── variable: column1 [type=int]
+ └── aggregations [outer=(1)]
+      └── function: jsonb_agg [type=jsonb, outer=(1)]
+           └── variable: column1 [type=int, outer=(1)]
 
 # Even with no aggregate functions, grouping occurs in the presence of GROUP BY.
 build
@@ -234,8 +234,8 @@ project
  │    │    ├── columns: kv.v:int:null:2
  │    │    ├── scan
  │    │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
- │    │    └── projections
- │    │         └── variable: kv.v [type=int]
+ │    │    └── projections [outer=(2)]
+ │    │         └── variable: kv.v [type=int, outer=(2)]
  │    └── aggregations
  └── projections
       └── const: 1 [type=int]
@@ -274,9 +274,9 @@ group-by
  │    └── projections
  │         └── cast: string [type=string]
  │              └── null [type=unknown]
- └── aggregations
-      └── function: array_agg [type=string[]]
-           └── variable: column1 [type=string]
+ └── aggregations [outer=(1)]
+      └── function: array_agg [type=string[], outer=(1)]
+           └── variable: column1 [type=string, outer=(1)]
 
 build
 SELECT COUNT(*), k FROM t.kv
@@ -300,13 +300,13 @@ project
  │    │    ├── columns: kv.k:int:1
  │    │    ├── scan
  │    │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
- │    │    └── projections
- │    │         └── variable: kv.k [type=int]
+ │    │    └── projections [outer=(1)]
+ │    │         └── variable: kv.k [type=int, outer=(1)]
  │    └── aggregations
  │         └── function: count_rows [type=int]
- └── projections
-      ├── variable: column5 [type=int]
-      └── variable: kv.k [type=int]
+ └── projections [outer=(1,5)]
+      ├── variable: column5 [type=int, outer=(5)]
+      └── variable: kv.k [type=int, outer=(1)]
 
 # GROUP BY specified using column index works.
 build
@@ -321,13 +321,13 @@ project
  │    │    ├── columns: kv.k:int:1
  │    │    ├── scan
  │    │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
- │    │    └── projections
- │    │         └── variable: kv.k [type=int]
+ │    │    └── projections [outer=(1)]
+ │    │         └── variable: kv.k [type=int, outer=(1)]
  │    └── aggregations
  │         └── function: count_rows [type=int]
- └── projections
-      ├── variable: column5 [type=int]
-      └── variable: kv.k [type=int]
+ └── projections [outer=(1,5)]
+      ├── variable: column5 [type=int, outer=(5)]
+      └── variable: kv.k [type=int, outer=(1)]
 
 build
 SELECT COUNT(*), k FROM t.kv GROUP BY 5
@@ -357,13 +357,13 @@ project
  │    │    ├── columns: kv.s:string:null:4
  │    │    ├── scan
  │    │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
- │    │    └── projections
- │    │         └── variable: kv.s [type=string]
+ │    │    └── projections [outer=(4)]
+ │    │         └── variable: kv.s [type=string, outer=(4)]
  │    └── aggregations
  │         └── function: count_rows [type=int]
- └── projections
-      ├── variable: column5 [type=int]
-      └── variable: kv.s [type=string]
+ └── projections [outer=(4,5)]
+      ├── variable: column5 [type=int, outer=(5)]
+      └── variable: kv.s [type=string, outer=(4)]
 
 build
 SELECT COUNT(*), s FROM t.kv GROUP BY kv.s
@@ -377,13 +377,13 @@ project
  │    │    ├── columns: kv.s:string:null:4
  │    │    ├── scan
  │    │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
- │    │    └── projections
- │    │         └── variable: kv.s [type=string]
+ │    │    └── projections [outer=(4)]
+ │    │         └── variable: kv.s [type=string, outer=(4)]
  │    └── aggregations
  │         └── function: count_rows [type=int]
- └── projections
-      ├── variable: column5 [type=int]
-      └── variable: kv.s [type=string]
+ └── projections [outer=(4,5)]
+      ├── variable: column5 [type=int, outer=(5)]
+      └── variable: kv.s [type=string, outer=(4)]
 
 build
 SELECT COUNT(*), kv.s FROM t.kv GROUP BY kv.s
@@ -397,13 +397,13 @@ project
  │    │    ├── columns: kv.s:string:null:4
  │    │    ├── scan
  │    │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
- │    │    └── projections
- │    │         └── variable: kv.s [type=string]
+ │    │    └── projections [outer=(4)]
+ │    │         └── variable: kv.s [type=string, outer=(4)]
  │    └── aggregations
  │         └── function: count_rows [type=int]
- └── projections
-      ├── variable: column5 [type=int]
-      └── variable: kv.s [type=string]
+ └── projections [outer=(4,5)]
+      ├── variable: column5 [type=int, outer=(5)]
+      └── variable: kv.s [type=string, outer=(4)]
 
 build
 SELECT COUNT(*), s FROM t.kv GROUP BY s
@@ -417,13 +417,13 @@ project
  │    │    ├── columns: kv.s:string:null:4
  │    │    ├── scan
  │    │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
- │    │    └── projections
- │    │         └── variable: kv.s [type=string]
+ │    │    └── projections [outer=(4)]
+ │    │         └── variable: kv.s [type=string, outer=(4)]
  │    └── aggregations
  │         └── function: count_rows [type=int]
- └── projections
-      ├── variable: column5 [type=int]
-      └── variable: kv.s [type=string]
+ └── projections [outer=(4,5)]
+      ├── variable: column5 [type=int, outer=(5)]
+      └── variable: kv.s [type=string, outer=(4)]
 
 # Grouping by more than one column works.
 build
@@ -438,15 +438,15 @@ project
  │    │    ├── columns: kv.v:int:null:2 kv.w:int:null:3
  │    │    ├── scan
  │    │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
- │    │    └── projections
- │    │         ├── variable: kv.v [type=int]
- │    │         └── variable: kv.w [type=int]
+ │    │    └── projections [outer=(2,3)]
+ │    │         ├── variable: kv.v [type=int, outer=(2)]
+ │    │         └── variable: kv.w [type=int, outer=(3)]
  │    └── aggregations
  │         └── function: count_rows [type=int]
- └── projections
-      ├── variable: kv.v [type=int]
-      ├── variable: column5 [type=int]
-      └── variable: kv.w [type=int]
+ └── projections [outer=(2,3,5)]
+      ├── variable: kv.v [type=int, outer=(2)]
+      ├── variable: column5 [type=int, outer=(5)]
+      └── variable: kv.w [type=int, outer=(3)]
 
 # Grouping by more than one column using column numbers works.
 build
@@ -461,15 +461,15 @@ project
  │    │    ├── columns: kv.v:int:null:2 kv.w:int:null:3
  │    │    ├── scan
  │    │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
- │    │    └── projections
- │    │         ├── variable: kv.v [type=int]
- │    │         └── variable: kv.w [type=int]
+ │    │    └── projections [outer=(2,3)]
+ │    │         ├── variable: kv.v [type=int, outer=(2)]
+ │    │         └── variable: kv.w [type=int, outer=(3)]
  │    └── aggregations
  │         └── function: count_rows [type=int]
- └── projections
-      ├── variable: kv.v [type=int]
-      ├── variable: column5 [type=int]
-      └── variable: kv.w [type=int]
+ └── projections [outer=(2,3,5)]
+      ├── variable: kv.v [type=int, outer=(2)]
+      ├── variable: column5 [type=int, outer=(5)]
+      └── variable: kv.w [type=int, outer=(3)]
 
 # Selecting and grouping on a function expression works.
 build
@@ -484,14 +484,14 @@ project
  │    │    ├── columns: column5:string:null:5
  │    │    ├── scan
  │    │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
- │    │    └── projections
- │    │         └── function: upper [type=string]
- │    │              └── variable: kv.s [type=string]
+ │    │    └── projections [outer=(4)]
+ │    │         └── function: upper [type=string, outer=(4)]
+ │    │              └── variable: kv.s [type=string, outer=(4)]
  │    └── aggregations
  │         └── function: count_rows [type=int]
- └── projections
-      ├── variable: column6 [type=int]
-      └── variable: column5 [type=string]
+ └── projections [outer=(5,6)]
+      ├── variable: column6 [type=int, outer=(6)]
+      └── variable: column5 [type=string, outer=(5)]
 
 # Selecting and grouping on a constant works.
 build
@@ -510,8 +510,8 @@ project
  │    │         └── const: 3 [type=int]
  │    └── aggregations
  │         └── function: count_rows [type=int]
- └── projections
-      └── variable: column6 [type=int]
+ └── projections [outer=(6)]
+      └── variable: column6 [type=int, outer=(6)]
 
 build
 SELECT COUNT(*) FROM t.kv GROUP BY length('abc')
@@ -530,8 +530,8 @@ project
  │    │              └── const: 'abc' [type=string]
  │    └── aggregations
  │         └── function: count_rows [type=int]
- └── projections
-      └── variable: column6 [type=int]
+ └── projections [outer=(6)]
+      └── variable: column6 [type=int, outer=(6)]
 
 # Selecting a function of something which is grouped works.
 build
@@ -546,14 +546,14 @@ project
  │    │    ├── columns: kv.s:string:null:4
  │    │    ├── scan
  │    │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
- │    │    └── projections
- │    │         └── variable: kv.s [type=string]
+ │    │    └── projections [outer=(4)]
+ │    │         └── variable: kv.s [type=string, outer=(4)]
  │    └── aggregations
  │         └── function: count_rows [type=int]
- └── projections
-      ├── variable: column5 [type=int]
-      └── function: upper [type=string]
-           └── variable: kv.s [type=string]
+ └── projections [outer=(4,5)]
+      ├── variable: column5 [type=int, outer=(5)]
+      └── function: upper [type=string, outer=(4)]
+           └── variable: kv.s [type=string, outer=(4)]
 
 # Selecting a value that is not grouped, even if a function of it it, does not work.
 build
@@ -574,15 +574,15 @@ project
  │    │    ├── columns: column5:int:null:5
  │    │    ├── scan
  │    │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
- │    │    └── projections
- │    │         └── plus [type=int]
- │    │              ├── variable: kv.k [type=int]
- │    │              └── variable: kv.v [type=int]
+ │    │    └── projections [outer=(1,2)]
+ │    │         └── plus [type=int, outer=(1,2)]
+ │    │              ├── variable: kv.k [type=int, outer=(1)]
+ │    │              └── variable: kv.v [type=int, outer=(2)]
  │    └── aggregations
  │         └── function: count_rows [type=int]
- └── projections
-      ├── variable: column6 [type=int]
-      └── variable: column5 [type=int]
+ └── projections [outer=(5,6)]
+      ├── variable: column6 [type=int, outer=(6)]
+      └── variable: column5 [type=int, outer=(5)]
 
 
 # Selecting a more complex expression, made up of things which are each grouped, works.
@@ -598,16 +598,16 @@ project
  │    │    ├── columns: kv.k:int:1 kv.v:int:null:2
  │    │    ├── scan
  │    │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
- │    │    └── projections
- │    │         ├── variable: kv.k [type=int]
- │    │         └── variable: kv.v [type=int]
+ │    │    └── projections [outer=(1,2)]
+ │    │         ├── variable: kv.k [type=int, outer=(1)]
+ │    │         └── variable: kv.v [type=int, outer=(2)]
  │    └── aggregations
  │         └── function: count_rows [type=int]
- └── projections
-      ├── variable: column5 [type=int]
-      └── plus [type=int]
-           ├── variable: kv.k [type=int]
-           └── variable: kv.v [type=int]
+ └── projections [outer=(1,2,5)]
+      ├── variable: column5 [type=int, outer=(5)]
+      └── plus [type=int, outer=(1,2)]
+           ├── variable: kv.k [type=int, outer=(1)]
+           └── variable: kv.v [type=int, outer=(2)]
 
 build
 SELECT COUNT(*), k+v FROM t.kv GROUP BY k
@@ -647,17 +647,17 @@ project
  │    │    ├── columns: column5:int:null:5 kv.k:int:1
  │    │    ├── scan
  │    │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
- │    │    └── projections
- │    │         ├── plus [type=int]
- │    │         │    ├── variable: kv.v [type=int]
- │    │         │    └── variable: kv.w [type=int]
- │    │         └── variable: kv.k [type=int]
- │    └── aggregations
- │         └── function: count [type=int]
- │              └── variable: column5 [type=int]
- └── projections
-      ├── variable: count_1 [type=int]
-      └── variable: column5 [type=int]
+ │    │    └── projections [outer=(1-3)]
+ │    │         ├── plus [type=int, outer=(2,3)]
+ │    │         │    ├── variable: kv.v [type=int, outer=(2)]
+ │    │         │    └── variable: kv.w [type=int, outer=(3)]
+ │    │         └── variable: kv.k [type=int, outer=(1)]
+ │    └── aggregations [outer=(5)]
+ │         └── function: count [type=int, outer=(5)]
+ │              └── variable: column5 [type=int, outer=(5)]
+ └── projections [outer=(5,6)]
+      ├── variable: count_1 [type=int, outer=(6)]
+      └── variable: column5 [type=int, outer=(5)]
 
 build
 SELECT COUNT(*)
@@ -678,11 +678,11 @@ group-by
  │    ├── columns: kv.k:int:1
  │    ├── scan
  │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
- │    └── projections
- │         └── variable: kv.k [type=int]
- └── aggregations
-      └── function: count [type=int]
-           └── variable: kv.k [type=int]
+ │    └── projections [outer=(1)]
+ │         └── variable: kv.k [type=int, outer=(1)]
+ └── aggregations [outer=(1)]
+      └── function: count [type=int, outer=(1)]
+           └── variable: kv.k [type=int, outer=(1)]
 
 build
 SELECT COUNT(1)
@@ -695,9 +695,9 @@ group-by
  │    │    └── tuple [type=tuple{}]
  │    └── projections
  │         └── const: 1 [type=int]
- └── aggregations
-      └── function: count [type=int]
-           └── variable: column1 [type=int]
+ └── aggregations [outer=(1)]
+      └── function: count [type=int, outer=(1)]
+           └── variable: column1 [type=int, outer=(1)]
 
 build
 SELECT COUNT(1) from t.kv
@@ -710,9 +710,9 @@ group-by
  │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
  │    └── projections
  │         └── const: 1 [type=int]
- └── aggregations
-      └── function: count [type=int]
-           └── variable: column5 [type=int]
+ └── aggregations [outer=(5)]
+      └── function: count [type=int, outer=(5)]
+           └── variable: column5 [type=int, outer=(5)]
 
 build
 SELECT COUNT(k, v) FROM t.kv
@@ -728,15 +728,15 @@ group-by
  │    ├── columns: kv.k:int:1 kv.v:int:null:2
  │    ├── scan
  │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
- │    └── projections
- │         ├── variable: kv.k [type=int]
- │         └── variable: kv.v [type=int]
- └── aggregations
+ │    └── projections [outer=(1,2)]
+ │         ├── variable: kv.k [type=int, outer=(1)]
+ │         └── variable: kv.v [type=int, outer=(2)]
+ └── aggregations [outer=(1,2)]
       ├── function: count_rows [type=int]
-      ├── function: count [type=int]
-      │    └── variable: kv.k [type=int]
-      └── function: count [type=int]
-           └── variable: kv.v [type=int]
+      ├── function: count [type=int, outer=(1)]
+      │    └── variable: kv.k [type=int, outer=(1)]
+      └── function: count [type=int, outer=(2)]
+           └── variable: kv.v [type=int, outer=(2)]
 
 build
 SELECT COUNT(kv.*) FROM t.kv
@@ -747,15 +747,15 @@ group-by
  │    ├── columns: column5:tuple{int, int, int, string}:null:5
  │    ├── scan
  │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
- │    └── projections
- │         └── tuple [type=tuple{int, int, int, string}]
- │              ├── variable: kv.k [type=int]
- │              ├── variable: kv.v [type=int]
- │              ├── variable: kv.w [type=int]
- │              └── variable: kv.s [type=string]
- └── aggregations
-      └── function: count [type=int]
-           └── variable: column5 [type=tuple{int, int, int, string}]
+ │    └── projections [outer=(1-4)]
+ │         └── tuple [type=tuple{int, int, int, string}, outer=(1-4)]
+ │              ├── variable: kv.k [type=int, outer=(1)]
+ │              ├── variable: kv.v [type=int, outer=(2)]
+ │              ├── variable: kv.w [type=int, outer=(3)]
+ │              └── variable: kv.s [type=string, outer=(4)]
+ └── aggregations [outer=(5)]
+      └── function: count [type=int, outer=(5)]
+           └── variable: column5 [type=tuple{int, int, int, string}, outer=(5)]
 
 build
 SELECT COUNT((k, v)) FROM t.kv
@@ -766,13 +766,13 @@ group-by
  │    ├── columns: column5:tuple{int, int}:null:5
  │    ├── scan
  │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
- │    └── projections
- │         └── tuple [type=tuple{int, int}]
- │              ├── variable: kv.k [type=int]
- │              └── variable: kv.v [type=int]
- └── aggregations
-      └── function: count [type=int]
-           └── variable: column5 [type=tuple{int, int}]
+ │    └── projections [outer=(1,2)]
+ │         └── tuple [type=tuple{int, int}, outer=(1,2)]
+ │              ├── variable: kv.k [type=int, outer=(1)]
+ │              └── variable: kv.v [type=int, outer=(2)]
+ └── aggregations [outer=(5)]
+      └── function: count [type=int, outer=(5)]
+           └── variable: column5 [type=tuple{int, int}, outer=(5)]
 
 build
 SELECT COUNT(k)+COUNT(kv.v) FROM t.kv
@@ -785,18 +785,18 @@ project
  │    │    ├── columns: kv.k:int:1 kv.v:int:null:2
  │    │    ├── scan
  │    │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
- │    │    └── projections
- │    │         ├── variable: kv.k [type=int]
- │    │         └── variable: kv.v [type=int]
- │    └── aggregations
- │         ├── function: count [type=int]
- │         │    └── variable: kv.k [type=int]
- │         └── function: count [type=int]
- │              └── variable: kv.v [type=int]
- └── projections
-      └── plus [type=int]
-           ├── variable: column5 [type=int]
-           └── variable: column6 [type=int]
+ │    │    └── projections [outer=(1,2)]
+ │    │         ├── variable: kv.k [type=int, outer=(1)]
+ │    │         └── variable: kv.v [type=int, outer=(2)]
+ │    └── aggregations [outer=(1,2)]
+ │         ├── function: count [type=int, outer=(1)]
+ │         │    └── variable: kv.k [type=int, outer=(1)]
+ │         └── function: count [type=int, outer=(2)]
+ │              └── variable: kv.v [type=int, outer=(2)]
+ └── projections [outer=(5,6)]
+      └── plus [type=int, outer=(5,6)]
+           ├── variable: column5 [type=int, outer=(5)]
+           └── variable: column6 [type=int, outer=(6)]
 
 build
 SELECT COUNT(NULL::int), COUNT((NULL, NULL))
@@ -813,11 +813,11 @@ group-by
  │         └── tuple [type=tuple{unknown, unknown}]
  │              ├── null [type=unknown]
  │              └── null [type=unknown]
- └── aggregations
-      ├── function: count [type=int]
-      │    └── variable: column1 [type=int]
-      └── function: count [type=int]
-           └── variable: column3 [type=tuple{unknown, unknown}]
+ └── aggregations [outer=(1,3)]
+      ├── function: count [type=int, outer=(1)]
+      │    └── variable: column1 [type=int, outer=(1)]
+      └── function: count [type=int, outer=(3)]
+           └── variable: column3 [type=tuple{unknown, unknown}, outer=(3)]
 
 build
 SELECT MIN(k), MAX(k), MIN(v), MAX(v) FROM t.kv
@@ -828,20 +828,20 @@ group-by
  │    ├── columns: kv.k:int:1 kv.k:int:1 kv.v:int:null:2 kv.v:int:null:2
  │    ├── scan
  │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
- │    └── projections
- │         ├── variable: kv.k [type=int]
- │         ├── variable: kv.k [type=int]
- │         ├── variable: kv.v [type=int]
- │         └── variable: kv.v [type=int]
- └── aggregations
-      ├── function: min [type=int]
-      │    └── variable: kv.k [type=int]
-      ├── function: max [type=int]
-      │    └── variable: kv.k [type=int]
-      ├── function: min [type=int]
-      │    └── variable: kv.v [type=int]
-      └── function: max [type=int]
-           └── variable: kv.v [type=int]
+ │    └── projections [outer=(1,2)]
+ │         ├── variable: kv.k [type=int, outer=(1)]
+ │         ├── variable: kv.k [type=int, outer=(1)]
+ │         ├── variable: kv.v [type=int, outer=(2)]
+ │         └── variable: kv.v [type=int, outer=(2)]
+ └── aggregations [outer=(1,2)]
+      ├── function: min [type=int, outer=(1)]
+      │    └── variable: kv.k [type=int, outer=(1)]
+      ├── function: max [type=int, outer=(1)]
+      │    └── variable: kv.k [type=int, outer=(1)]
+      ├── function: min [type=int, outer=(2)]
+      │    └── variable: kv.v [type=int, outer=(2)]
+      └── function: max [type=int, outer=(2)]
+           └── variable: kv.v [type=int, outer=(2)]
 
 build
 SELECT MIN(k), MAX(k), MIN(v), MAX(v) FROM t.kv WHERE k > 8
@@ -854,23 +854,23 @@ group-by
  │    │    ├── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
  │    │    ├── scan
  │    │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
- │    │    └── gt [type=bool]
- │    │         ├── variable: kv.k [type=int]
+ │    │    └── gt [type=bool, outer=(1)]
+ │    │         ├── variable: kv.k [type=int, outer=(1)]
  │    │         └── const: 8 [type=int]
- │    └── projections
- │         ├── variable: kv.k [type=int]
- │         ├── variable: kv.k [type=int]
- │         ├── variable: kv.v [type=int]
- │         └── variable: kv.v [type=int]
- └── aggregations
-      ├── function: min [type=int]
-      │    └── variable: kv.k [type=int]
-      ├── function: max [type=int]
-      │    └── variable: kv.k [type=int]
-      ├── function: min [type=int]
-      │    └── variable: kv.v [type=int]
-      └── function: max [type=int]
-           └── variable: kv.v [type=int]
+ │    └── projections [outer=(1,2)]
+ │         ├── variable: kv.k [type=int, outer=(1)]
+ │         ├── variable: kv.k [type=int, outer=(1)]
+ │         ├── variable: kv.v [type=int, outer=(2)]
+ │         └── variable: kv.v [type=int, outer=(2)]
+ └── aggregations [outer=(1,2)]
+      ├── function: min [type=int, outer=(1)]
+      │    └── variable: kv.k [type=int, outer=(1)]
+      ├── function: max [type=int, outer=(1)]
+      │    └── variable: kv.k [type=int, outer=(1)]
+      ├── function: min [type=int, outer=(2)]
+      │    └── variable: kv.v [type=int, outer=(2)]
+      └── function: max [type=int, outer=(2)]
+           └── variable: kv.v [type=int, outer=(2)]
 
 build
 SELECT array_agg(s) FROM t.kv WHERE s IS NULL
@@ -883,14 +883,14 @@ group-by
  │    │    ├── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
  │    │    ├── scan
  │    │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
- │    │    └── is [type=bool]
- │    │         ├── variable: kv.s [type=string]
+ │    │    └── is [type=bool, outer=(4)]
+ │    │         ├── variable: kv.s [type=string, outer=(4)]
  │    │         └── null [type=unknown]
- │    └── projections
- │         └── variable: kv.s [type=string]
- └── aggregations
-      └── function: array_agg [type=string[]]
-           └── variable: kv.s [type=string]
+ │    └── projections [outer=(4)]
+ │         └── variable: kv.s [type=string, outer=(4)]
+ └── aggregations [outer=(4)]
+      └── function: array_agg [type=string[], outer=(4)]
+           └── variable: kv.s [type=string, outer=(4)]
 
 build
 SELECT AVG(k), AVG(v), SUM(k), SUM(v) FROM t.kv
@@ -901,20 +901,20 @@ group-by
  │    ├── columns: kv.k:int:1 kv.v:int:null:2 kv.k:int:1 kv.v:int:null:2
  │    ├── scan
  │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
- │    └── projections
- │         ├── variable: kv.k [type=int]
- │         ├── variable: kv.v [type=int]
- │         ├── variable: kv.k [type=int]
- │         └── variable: kv.v [type=int]
- └── aggregations
-      ├── function: avg [type=decimal]
-      │    └── variable: kv.k [type=int]
-      ├── function: avg [type=decimal]
-      │    └── variable: kv.v [type=int]
-      ├── function: sum [type=decimal]
-      │    └── variable: kv.k [type=int]
-      └── function: sum [type=decimal]
-           └── variable: kv.v [type=int]
+ │    └── projections [outer=(1,2)]
+ │         ├── variable: kv.k [type=int, outer=(1)]
+ │         ├── variable: kv.v [type=int, outer=(2)]
+ │         ├── variable: kv.k [type=int, outer=(1)]
+ │         └── variable: kv.v [type=int, outer=(2)]
+ └── aggregations [outer=(1,2)]
+      ├── function: avg [type=decimal, outer=(1)]
+      │    └── variable: kv.k [type=int, outer=(1)]
+      ├── function: avg [type=decimal, outer=(2)]
+      │    └── variable: kv.v [type=int, outer=(2)]
+      ├── function: sum [type=decimal, outer=(1)]
+      │    └── variable: kv.k [type=int, outer=(1)]
+      └── function: sum [type=decimal, outer=(2)]
+           └── variable: kv.v [type=int, outer=(2)]
 
 build
 SELECT AVG(k::decimal), AVG(v::decimal), SUM(k::decimal), SUM(v::decimal) FROM kv
@@ -925,24 +925,24 @@ group-by
  │    ├── columns: column5:decimal:null:5 column7:decimal:null:7 column9:decimal:null:9 column11:decimal:null:11
  │    ├── scan
  │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
- │    └── projections
- │         ├── cast: decimal [type=decimal]
- │         │    └── variable: kv.k [type=int]
- │         ├── cast: decimal [type=decimal]
- │         │    └── variable: kv.v [type=int]
- │         ├── cast: decimal [type=decimal]
- │         │    └── variable: kv.k [type=int]
- │         └── cast: decimal [type=decimal]
- │              └── variable: kv.v [type=int]
- └── aggregations
-      ├── function: avg [type=decimal]
-      │    └── variable: column5 [type=decimal]
-      ├── function: avg [type=decimal]
-      │    └── variable: column7 [type=decimal]
-      ├── function: sum [type=decimal]
-      │    └── variable: column9 [type=decimal]
-      └── function: sum [type=decimal]
-           └── variable: column11 [type=decimal]
+ │    └── projections [outer=(1,2)]
+ │         ├── cast: decimal [type=decimal, outer=(1)]
+ │         │    └── variable: kv.k [type=int, outer=(1)]
+ │         ├── cast: decimal [type=decimal, outer=(2)]
+ │         │    └── variable: kv.v [type=int, outer=(2)]
+ │         ├── cast: decimal [type=decimal, outer=(1)]
+ │         │    └── variable: kv.k [type=int, outer=(1)]
+ │         └── cast: decimal [type=decimal, outer=(2)]
+ │              └── variable: kv.v [type=int, outer=(2)]
+ └── aggregations [outer=(5,7,9,11)]
+      ├── function: avg [type=decimal, outer=(5)]
+      │    └── variable: column5 [type=decimal, outer=(5)]
+      ├── function: avg [type=decimal, outer=(7)]
+      │    └── variable: column7 [type=decimal, outer=(7)]
+      ├── function: sum [type=decimal, outer=(9)]
+      │    └── variable: column9 [type=decimal, outer=(9)]
+      └── function: sum [type=decimal, outer=(11)]
+           └── variable: column11 [type=decimal, outer=(11)]
 
 build
 SELECT AVG(k) * 2.0 + MAX(v)::DECIMAL FROM kv
@@ -955,21 +955,21 @@ project
  │    │    ├── columns: kv.k:int:1 kv.v:int:null:2
  │    │    ├── scan
  │    │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
- │    │    └── projections
- │    │         ├── variable: kv.k [type=int]
- │    │         └── variable: kv.v [type=int]
- │    └── aggregations
- │         ├── function: avg [type=decimal]
- │         │    └── variable: kv.k [type=int]
- │         └── function: max [type=int]
- │              └── variable: kv.v [type=int]
- └── projections
-      └── plus [type=decimal]
-           ├── mult [type=decimal]
-           │    ├── variable: column5 [type=decimal]
+ │    │    └── projections [outer=(1,2)]
+ │    │         ├── variable: kv.k [type=int, outer=(1)]
+ │    │         └── variable: kv.v [type=int, outer=(2)]
+ │    └── aggregations [outer=(1,2)]
+ │         ├── function: avg [type=decimal, outer=(1)]
+ │         │    └── variable: kv.k [type=int, outer=(1)]
+ │         └── function: max [type=int, outer=(2)]
+ │              └── variable: kv.v [type=int, outer=(2)]
+ └── projections [outer=(5,6)]
+      └── plus [type=decimal, outer=(5,6)]
+           ├── mult [type=decimal, outer=(5)]
+           │    ├── variable: column5 [type=decimal, outer=(5)]
            │    └── const: 2.0 [type=decimal]
-           └── cast: decimal [type=decimal]
-                └── variable: column6 [type=int]
+           └── cast: decimal [type=decimal, outer=(6)]
+                └── variable: column6 [type=int, outer=(6)]
 
 build
 SELECT AVG(k) * 2.0 + MAX(v)::DECIMAL FROM kv WHERE w*2 = k
@@ -984,26 +984,26 @@ project
  │    │    │    ├── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
  │    │    │    ├── scan
  │    │    │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
- │    │    │    └── eq [type=bool]
- │    │    │         ├── mult [type=int]
- │    │    │         │    ├── variable: kv.w [type=int]
+ │    │    │    └── eq [type=bool, outer=(1,3)]
+ │    │    │         ├── mult [type=int, outer=(3)]
+ │    │    │         │    ├── variable: kv.w [type=int, outer=(3)]
  │    │    │         │    └── const: 2 [type=int]
- │    │    │         └── variable: kv.k [type=int]
- │    │    └── projections
- │    │         ├── variable: kv.k [type=int]
- │    │         └── variable: kv.v [type=int]
- │    └── aggregations
- │         ├── function: avg [type=decimal]
- │         │    └── variable: kv.k [type=int]
- │         └── function: max [type=int]
- │              └── variable: kv.v [type=int]
- └── projections
-      └── plus [type=decimal]
-           ├── mult [type=decimal]
-           │    ├── variable: column5 [type=decimal]
+ │    │    │         └── variable: kv.k [type=int, outer=(1)]
+ │    │    └── projections [outer=(1,2)]
+ │    │         ├── variable: kv.k [type=int, outer=(1)]
+ │    │         └── variable: kv.v [type=int, outer=(2)]
+ │    └── aggregations [outer=(1,2)]
+ │         ├── function: avg [type=decimal, outer=(1)]
+ │         │    └── variable: kv.k [type=int, outer=(1)]
+ │         └── function: max [type=int, outer=(2)]
+ │              └── variable: kv.v [type=int, outer=(2)]
+ └── projections [outer=(5,6)]
+      └── plus [type=decimal, outer=(5,6)]
+           ├── mult [type=decimal, outer=(5)]
+           │    ├── variable: column5 [type=decimal, outer=(5)]
            │    └── const: 2.0 [type=decimal]
-           └── cast: decimal [type=decimal]
-                └── variable: column6 [type=int]
+           └── cast: decimal [type=decimal, outer=(6)]
+                └── variable: column6 [type=int, outer=(6)]
 
 exec-ddl
 CREATE TABLE t.abc (
@@ -1028,15 +1028,15 @@ group-by
  ├── columns: column5:string:null:5 column6:float:null:6 column7:bool:null:7 column8:decimal:null:8
  ├── scan
  │    └── columns: abc.a:string:1 abc.b:float:null:2 abc.c:bool:null:3 abc.d:decimal:null:4
- └── aggregations
-      ├── function: min [type=string]
-      │    └── variable: abc.a [type=string]
-      ├── function: min [type=float]
-      │    └── variable: abc.b [type=float]
-      ├── function: min [type=bool]
-      │    └── variable: abc.c [type=bool]
-      └── function: min [type=decimal]
-           └── variable: abc.d [type=decimal]
+ └── aggregations [outer=(1-4)]
+      ├── function: min [type=string, outer=(1)]
+      │    └── variable: abc.a [type=string, outer=(1)]
+      ├── function: min [type=float, outer=(2)]
+      │    └── variable: abc.b [type=float, outer=(2)]
+      ├── function: min [type=bool, outer=(3)]
+      │    └── variable: abc.c [type=bool, outer=(3)]
+      └── function: min [type=decimal, outer=(4)]
+           └── variable: abc.d [type=decimal, outer=(4)]
 
 build
 SELECT MAX(a), MAX(b), MAX(c), MAX(d) FROM t.abc
@@ -1045,15 +1045,15 @@ group-by
  ├── columns: column5:string:null:5 column6:float:null:6 column7:bool:null:7 column8:decimal:null:8
  ├── scan
  │    └── columns: abc.a:string:1 abc.b:float:null:2 abc.c:bool:null:3 abc.d:decimal:null:4
- └── aggregations
-      ├── function: max [type=string]
-      │    └── variable: abc.a [type=string]
-      ├── function: max [type=float]
-      │    └── variable: abc.b [type=float]
-      ├── function: max [type=bool]
-      │    └── variable: abc.c [type=bool]
-      └── function: max [type=decimal]
-           └── variable: abc.d [type=decimal]
+ └── aggregations [outer=(1-4)]
+      ├── function: max [type=string, outer=(1)]
+      │    └── variable: abc.a [type=string, outer=(1)]
+      ├── function: max [type=float, outer=(2)]
+      │    └── variable: abc.b [type=float, outer=(2)]
+      ├── function: max [type=bool, outer=(3)]
+      │    └── variable: abc.c [type=bool, outer=(3)]
+      └── function: max [type=decimal, outer=(4)]
+           └── variable: abc.d [type=decimal, outer=(4)]
 
 build
 SELECT AVG(b), SUM(b), AVG(d), SUM(d) FROM t.abc
@@ -1064,20 +1064,20 @@ group-by
  │    ├── columns: abc.b:float:null:2 abc.b:float:null:2 abc.d:decimal:null:4 abc.d:decimal:null:4
  │    ├── scan
  │    │    └── columns: abc.a:string:1 abc.b:float:null:2 abc.c:bool:null:3 abc.d:decimal:null:4
- │    └── projections
- │         ├── variable: abc.b [type=float]
- │         ├── variable: abc.b [type=float]
- │         ├── variable: abc.d [type=decimal]
- │         └── variable: abc.d [type=decimal]
- └── aggregations
-      ├── function: avg [type=float]
-      │    └── variable: abc.b [type=float]
-      ├── function: sum [type=float]
-      │    └── variable: abc.b [type=float]
-      ├── function: avg [type=decimal]
-      │    └── variable: abc.d [type=decimal]
-      └── function: sum [type=decimal]
-           └── variable: abc.d [type=decimal]
+ │    └── projections [outer=(2,4)]
+ │         ├── variable: abc.b [type=float, outer=(2)]
+ │         ├── variable: abc.b [type=float, outer=(2)]
+ │         ├── variable: abc.d [type=decimal, outer=(4)]
+ │         └── variable: abc.d [type=decimal, outer=(4)]
+ └── aggregations [outer=(2,4)]
+      ├── function: avg [type=float, outer=(2)]
+      │    └── variable: abc.b [type=float, outer=(2)]
+      ├── function: sum [type=float, outer=(2)]
+      │    └── variable: abc.b [type=float, outer=(2)]
+      ├── function: avg [type=decimal, outer=(4)]
+      │    └── variable: abc.d [type=decimal, outer=(4)]
+      └── function: sum [type=decimal, outer=(4)]
+           └── variable: abc.d [type=decimal, outer=(4)]
 
 # Verify summing of intervals
 exec-ddl
@@ -1097,9 +1097,9 @@ group-by
  ├── columns: column2:interval:null:2
  ├── scan
  │    └── columns: intervals.a:interval:1
- └── aggregations
-      └── function: sum [type=interval]
-           └── variable: intervals.a [type=interval]
+ └── aggregations [outer=(1)]
+      └── function: sum [type=interval, outer=(1)]
+           └── variable: intervals.a [type=interval, outer=(1)]
 
 build
 SELECT AVG(a) FROM t.abc
@@ -1166,11 +1166,11 @@ group-by
  │    ├── columns: xyz.x:int:1
  │    ├── scan
  │    │    └── columns: xyz.x:int:1 xyz.y:int:null:2 xyz.z:float:null:3
- │    └── projections
- │         └── variable: xyz.x [type=int]
- └── aggregations
-      └── function: min [type=int]
-           └── variable: xyz.x [type=int]
+ │    └── projections [outer=(1)]
+ │         └── variable: xyz.x [type=int, outer=(1)]
+ └── aggregations [outer=(1)]
+      └── function: min [type=int, outer=(1)]
+           └── variable: xyz.x [type=int, outer=(1)]
 
 build
 SELECT MIN(x) FROM t.xyz WHERE x in (0, 4, 7)
@@ -1183,17 +1183,17 @@ group-by
  │    │    ├── columns: xyz.x:int:1 xyz.y:int:null:2 xyz.z:float:null:3
  │    │    ├── scan
  │    │    │    └── columns: xyz.x:int:1 xyz.y:int:null:2 xyz.z:float:null:3
- │    │    └── in [type=bool]
- │    │         ├── variable: xyz.x [type=int]
+ │    │    └── in [type=bool, outer=(1)]
+ │    │         ├── variable: xyz.x [type=int, outer=(1)]
  │    │         └── tuple [type=tuple{int, int, int}]
  │    │              ├── const: 0 [type=int]
  │    │              ├── const: 4 [type=int]
  │    │              └── const: 7 [type=int]
- │    └── projections
- │         └── variable: xyz.x [type=int]
- └── aggregations
-      └── function: min [type=int]
-           └── variable: xyz.x [type=int]
+ │    └── projections [outer=(1)]
+ │         └── variable: xyz.x [type=int, outer=(1)]
+ └── aggregations [outer=(1)]
+      └── function: min [type=int, outer=(1)]
+           └── variable: xyz.x [type=int, outer=(1)]
 
 build
 SELECT MAX(x) FROM t.xyz
@@ -1204,11 +1204,11 @@ group-by
  │    ├── columns: xyz.x:int:1
  │    ├── scan
  │    │    └── columns: xyz.x:int:1 xyz.y:int:null:2 xyz.z:float:null:3
- │    └── projections
- │         └── variable: xyz.x [type=int]
- └── aggregations
-      └── function: max [type=int]
-           └── variable: xyz.x [type=int]
+ │    └── projections [outer=(1)]
+ │         └── variable: xyz.x [type=int, outer=(1)]
+ └── aggregations [outer=(1)]
+      └── function: max [type=int, outer=(1)]
+           └── variable: xyz.x [type=int, outer=(1)]
 
 build
 SELECT MAX(y) FROM t.xyz WHERE x = 1
@@ -1221,14 +1221,14 @@ group-by
  │    │    ├── columns: xyz.x:int:1 xyz.y:int:null:2 xyz.z:float:null:3
  │    │    ├── scan
  │    │    │    └── columns: xyz.x:int:1 xyz.y:int:null:2 xyz.z:float:null:3
- │    │    └── eq [type=bool]
- │    │         ├── variable: xyz.x [type=int]
+ │    │    └── eq [type=bool, outer=(1)]
+ │    │         ├── variable: xyz.x [type=int, outer=(1)]
  │    │         └── const: 1 [type=int]
- │    └── projections
- │         └── variable: xyz.y [type=int]
- └── aggregations
-      └── function: max [type=int]
-           └── variable: xyz.y [type=int]
+ │    └── projections [outer=(2)]
+ │         └── variable: xyz.y [type=int, outer=(2)]
+ └── aggregations [outer=(2)]
+      └── function: max [type=int, outer=(2)]
+           └── variable: xyz.y [type=int, outer=(2)]
 
 build
 SELECT MIN(y) FROM t.xyz WHERE x = 7
@@ -1241,14 +1241,14 @@ group-by
  │    │    ├── columns: xyz.x:int:1 xyz.y:int:null:2 xyz.z:float:null:3
  │    │    ├── scan
  │    │    │    └── columns: xyz.x:int:1 xyz.y:int:null:2 xyz.z:float:null:3
- │    │    └── eq [type=bool]
- │    │         ├── variable: xyz.x [type=int]
+ │    │    └── eq [type=bool, outer=(1)]
+ │    │         ├── variable: xyz.x [type=int, outer=(1)]
  │    │         └── const: 7 [type=int]
- │    └── projections
- │         └── variable: xyz.y [type=int]
- └── aggregations
-      └── function: min [type=int]
-           └── variable: xyz.y [type=int]
+ │    └── projections [outer=(2)]
+ │         └── variable: xyz.y [type=int, outer=(2)]
+ └── aggregations [outer=(2)]
+      └── function: min [type=int, outer=(2)]
+           └── variable: xyz.y [type=int, outer=(2)]
 
 build
 SELECT MIN(x) FROM t.xyz WHERE (y, z) = (2, 3.0)
@@ -1261,18 +1261,18 @@ group-by
  │    │    ├── columns: xyz.x:int:1 xyz.y:int:null:2 xyz.z:float:null:3
  │    │    ├── scan
  │    │    │    └── columns: xyz.x:int:1 xyz.y:int:null:2 xyz.z:float:null:3
- │    │    └── eq [type=bool]
- │    │         ├── tuple [type=tuple{int, float}]
- │    │         │    ├── variable: xyz.y [type=int]
- │    │         │    └── variable: xyz.z [type=float]
+ │    │    └── eq [type=bool, outer=(2,3)]
+ │    │         ├── tuple [type=tuple{int, float}, outer=(2,3)]
+ │    │         │    ├── variable: xyz.y [type=int, outer=(2)]
+ │    │         │    └── variable: xyz.z [type=float, outer=(3)]
  │    │         └── tuple [type=tuple{int, float}]
  │    │              ├── const: 2 [type=int]
  │    │              └── const: 3.0 [type=float]
- │    └── projections
- │         └── variable: xyz.x [type=int]
- └── aggregations
-      └── function: min [type=int]
-           └── variable: xyz.x [type=int]
+ │    └── projections [outer=(1)]
+ │         └── variable: xyz.x [type=int, outer=(1)]
+ └── aggregations [outer=(1)]
+      └── function: min [type=int, outer=(1)]
+           └── variable: xyz.x [type=int, outer=(1)]
 
 build
 SELECT MAX(x) FROM t.xyz WHERE (z, y) = (3.0, 2)
@@ -1285,18 +1285,18 @@ group-by
  │    │    ├── columns: xyz.x:int:1 xyz.y:int:null:2 xyz.z:float:null:3
  │    │    ├── scan
  │    │    │    └── columns: xyz.x:int:1 xyz.y:int:null:2 xyz.z:float:null:3
- │    │    └── eq [type=bool]
- │    │         ├── tuple [type=tuple{float, int}]
- │    │         │    ├── variable: xyz.z [type=float]
- │    │         │    └── variable: xyz.y [type=int]
+ │    │    └── eq [type=bool, outer=(2,3)]
+ │    │         ├── tuple [type=tuple{float, int}, outer=(2,3)]
+ │    │         │    ├── variable: xyz.z [type=float, outer=(3)]
+ │    │         │    └── variable: xyz.y [type=int, outer=(2)]
  │    │         └── tuple [type=tuple{float, int}]
  │    │              ├── const: 3.0 [type=float]
  │    │              └── const: 2 [type=int]
- │    └── projections
- │         └── variable: xyz.x [type=int]
- └── aggregations
-      └── function: max [type=int]
-           └── variable: xyz.x [type=int]
+ │    └── projections [outer=(1)]
+ │         └── variable: xyz.x [type=int, outer=(1)]
+ └── aggregations [outer=(1)]
+      └── function: max [type=int, outer=(1)]
+           └── variable: xyz.x [type=int, outer=(1)]
 
 
 # VARIANCE/STDDEV
@@ -1312,23 +1312,23 @@ project
  │    │    ├── columns: xyz.x:int:1 column5:decimal:null:5 xyz.z:float:null:3
  │    │    ├── scan
  │    │    │    └── columns: xyz.x:int:1 xyz.y:int:null:2 xyz.z:float:null:3
- │    │    └── projections
- │    │         ├── variable: xyz.x [type=int]
- │    │         ├── cast: decimal [type=decimal]
- │    │         │    └── variable: xyz.y [type=int]
- │    │         └── variable: xyz.z [type=float]
- │    └── aggregations
- │         ├── function: variance [type=decimal]
- │         │    └── variable: xyz.x [type=int]
- │         ├── function: variance [type=decimal]
- │         │    └── variable: column5 [type=decimal]
- │         └── function: variance [type=float]
- │              └── variable: xyz.z [type=float]
- └── projections
-      ├── variable: column4 [type=decimal]
-      ├── variable: column6 [type=decimal]
-      └── function: round [type=float]
-           ├── variable: column7 [type=float]
+ │    │    └── projections [outer=(1-3)]
+ │    │         ├── variable: xyz.x [type=int, outer=(1)]
+ │    │         ├── cast: decimal [type=decimal, outer=(2)]
+ │    │         │    └── variable: xyz.y [type=int, outer=(2)]
+ │    │         └── variable: xyz.z [type=float, outer=(3)]
+ │    └── aggregations [outer=(1,3,5)]
+ │         ├── function: variance [type=decimal, outer=(1)]
+ │         │    └── variable: xyz.x [type=int, outer=(1)]
+ │         ├── function: variance [type=decimal, outer=(5)]
+ │         │    └── variable: column5 [type=decimal, outer=(5)]
+ │         └── function: variance [type=float, outer=(3)]
+ │              └── variable: xyz.z [type=float, outer=(3)]
+ └── projections [outer=(4,6,7)]
+      ├── variable: column4 [type=decimal, outer=(4)]
+      ├── variable: column6 [type=decimal, outer=(6)]
+      └── function: round [type=float, outer=(7)]
+           ├── variable: column7 [type=float, outer=(7)]
            └── const: 14 [type=int]
 
 build
@@ -1342,14 +1342,14 @@ group-by
  │    │    ├── columns: xyz.x:int:1 xyz.y:int:null:2 xyz.z:float:null:3
  │    │    ├── scan
  │    │    │    └── columns: xyz.x:int:1 xyz.y:int:null:2 xyz.z:float:null:3
- │    │    └── eq [type=bool]
- │    │         ├── variable: xyz.x [type=int]
+ │    │    └── eq [type=bool, outer=(1)]
+ │    │         ├── variable: xyz.x [type=int, outer=(1)]
  │    │         └── const: 10 [type=int]
- │    └── projections
- │         └── variable: xyz.x [type=int]
- └── aggregations
-      └── function: variance [type=decimal]
-           └── variable: xyz.x [type=int]
+ │    └── projections [outer=(1)]
+ │         └── variable: xyz.x [type=int, outer=(1)]
+ └── aggregations [outer=(1)]
+      └── function: variance [type=decimal, outer=(1)]
+           └── variable: xyz.x [type=int, outer=(1)]
 
 build
 SELECT STDDEV(x), STDDEV(y::decimal), round(STDDEV(z), 14) FROM xyz
@@ -1362,23 +1362,23 @@ project
  │    │    ├── columns: xyz.x:int:1 column5:decimal:null:5 xyz.z:float:null:3
  │    │    ├── scan
  │    │    │    └── columns: xyz.x:int:1 xyz.y:int:null:2 xyz.z:float:null:3
- │    │    └── projections
- │    │         ├── variable: xyz.x [type=int]
- │    │         ├── cast: decimal [type=decimal]
- │    │         │    └── variable: xyz.y [type=int]
- │    │         └── variable: xyz.z [type=float]
- │    └── aggregations
- │         ├── function: stddev [type=decimal]
- │         │    └── variable: xyz.x [type=int]
- │         ├── function: stddev [type=decimal]
- │         │    └── variable: column5 [type=decimal]
- │         └── function: stddev [type=float]
- │              └── variable: xyz.z [type=float]
- └── projections
-      ├── variable: column4 [type=decimal]
-      ├── variable: column6 [type=decimal]
-      └── function: round [type=float]
-           ├── variable: column7 [type=float]
+ │    │    └── projections [outer=(1-3)]
+ │    │         ├── variable: xyz.x [type=int, outer=(1)]
+ │    │         ├── cast: decimal [type=decimal, outer=(2)]
+ │    │         │    └── variable: xyz.y [type=int, outer=(2)]
+ │    │         └── variable: xyz.z [type=float, outer=(3)]
+ │    └── aggregations [outer=(1,3,5)]
+ │         ├── function: stddev [type=decimal, outer=(1)]
+ │         │    └── variable: xyz.x [type=int, outer=(1)]
+ │         ├── function: stddev [type=decimal, outer=(5)]
+ │         │    └── variable: column5 [type=decimal, outer=(5)]
+ │         └── function: stddev [type=float, outer=(3)]
+ │              └── variable: xyz.z [type=float, outer=(3)]
+ └── projections [outer=(4,6,7)]
+      ├── variable: column4 [type=decimal, outer=(4)]
+      ├── variable: column6 [type=decimal, outer=(6)]
+      └── function: round [type=float, outer=(7)]
+           ├── variable: column7 [type=float, outer=(7)]
            └── const: 14 [type=int]
 
 build
@@ -1392,14 +1392,14 @@ group-by
  │    │    ├── columns: xyz.x:int:1 xyz.y:int:null:2 xyz.z:float:null:3
  │    │    ├── scan
  │    │    │    └── columns: xyz.x:int:1 xyz.y:int:null:2 xyz.z:float:null:3
- │    │    └── eq [type=bool]
- │    │         ├── variable: xyz.x [type=int]
+ │    │    └── eq [type=bool, outer=(1)]
+ │    │         ├── variable: xyz.x [type=int, outer=(1)]
  │    │         └── const: 1 [type=int]
- │    └── projections
- │         └── variable: xyz.x [type=int]
- └── aggregations
-      └── function: stddev [type=decimal]
-           └── variable: xyz.x [type=int]
+ │    └── projections [outer=(1)]
+ │         └── variable: xyz.x [type=int, outer=(1)]
+ └── aggregations [outer=(1)]
+      └── function: stddev [type=decimal, outer=(1)]
+           └── variable: xyz.x [type=int, outer=(1)]
 
 build
 SELECT AVG(1::int)::float, AVG(2::float)::float, AVG(3::decimal)::float
@@ -1419,20 +1419,20 @@ project
  │    │         │    └── const: 2.0 [type=float]
  │    │         └── cast: decimal [type=decimal]
  │    │              └── const: 3 [type=decimal]
- │    └── aggregations
- │         ├── function: avg [type=decimal]
- │         │    └── variable: column1 [type=int]
- │         ├── function: avg [type=float]
- │         │    └── variable: column4 [type=float]
- │         └── function: avg [type=decimal]
- │              └── variable: column7 [type=decimal]
- └── projections
-      ├── cast: float [type=float]
-      │    └── variable: column2 [type=decimal]
-      ├── cast: float [type=float]
-      │    └── variable: column5 [type=float]
-      └── cast: float [type=float]
-           └── variable: column8 [type=decimal]
+ │    └── aggregations [outer=(1,4,7)]
+ │         ├── function: avg [type=decimal, outer=(1)]
+ │         │    └── variable: column1 [type=int, outer=(1)]
+ │         ├── function: avg [type=float, outer=(4)]
+ │         │    └── variable: column4 [type=float, outer=(4)]
+ │         └── function: avg [type=decimal, outer=(7)]
+ │              └── variable: column7 [type=decimal, outer=(7)]
+ └── projections [outer=(2,5,8)]
+      ├── cast: float [type=float, outer=(2)]
+      │    └── variable: column2 [type=decimal, outer=(2)]
+      ├── cast: float [type=float, outer=(5)]
+      │    └── variable: column5 [type=float, outer=(5)]
+      └── cast: float [type=float, outer=(8)]
+           └── variable: column8 [type=decimal, outer=(8)]
 
 build
 SELECT COUNT(2::int), COUNT(3::float), COUNT(4::decimal)
@@ -1450,13 +1450,13 @@ group-by
  │         │    └── const: 3.0 [type=float]
  │         └── cast: decimal [type=decimal]
  │              └── const: 4 [type=decimal]
- └── aggregations
-      ├── function: count [type=int]
-      │    └── variable: column1 [type=int]
-      ├── function: count [type=int]
-      │    └── variable: column3 [type=float]
-      └── function: count [type=int]
-           └── variable: column5 [type=decimal]
+ └── aggregations [outer=(1,3,5)]
+      ├── function: count [type=int, outer=(1)]
+      │    └── variable: column1 [type=int, outer=(1)]
+      ├── function: count [type=int, outer=(3)]
+      │    └── variable: column3 [type=float, outer=(3)]
+      └── function: count [type=int, outer=(5)]
+           └── variable: column5 [type=decimal, outer=(5)]
 
 build
 SELECT SUM(1::int), SUM(2::float), SUM(3::decimal)
@@ -1474,13 +1474,13 @@ group-by
  │         │    └── const: 2.0 [type=float]
  │         └── cast: decimal [type=decimal]
  │              └── const: 3 [type=decimal]
- └── aggregations
-      ├── function: sum [type=decimal]
-      │    └── variable: column1 [type=int]
-      ├── function: sum [type=float]
-      │    └── variable: column3 [type=float]
-      └── function: sum [type=decimal]
-           └── variable: column5 [type=decimal]
+ └── aggregations [outer=(1,3,5)]
+      ├── function: sum [type=decimal, outer=(1)]
+      │    └── variable: column1 [type=int, outer=(1)]
+      ├── function: sum [type=float, outer=(3)]
+      │    └── variable: column3 [type=float, outer=(3)]
+      └── function: sum [type=decimal, outer=(5)]
+           └── variable: column5 [type=decimal, outer=(5)]
 
 build
 SELECT VARIANCE(1::int), VARIANCE(1::float), VARIANCE(1::decimal)
@@ -1498,13 +1498,13 @@ group-by
  │         │    └── const: 1.0 [type=float]
  │         └── cast: decimal [type=decimal]
  │              └── const: 1 [type=decimal]
- └── aggregations
-      ├── function: variance [type=decimal]
-      │    └── variable: column1 [type=int]
-      ├── function: variance [type=float]
-      │    └── variable: column3 [type=float]
-      └── function: variance [type=decimal]
-           └── variable: column5 [type=decimal]
+ └── aggregations [outer=(1,3,5)]
+      ├── function: variance [type=decimal, outer=(1)]
+      │    └── variable: column1 [type=int, outer=(1)]
+      ├── function: variance [type=float, outer=(3)]
+      │    └── variable: column3 [type=float, outer=(3)]
+      └── function: variance [type=decimal, outer=(5)]
+           └── variable: column5 [type=decimal, outer=(5)]
 
 build
 SELECT STDDEV(1::int), STDDEV(1::float), STDDEV(1::decimal)
@@ -1522,13 +1522,13 @@ group-by
  │         │    └── const: 1.0 [type=float]
  │         └── cast: decimal [type=decimal]
  │              └── const: 1 [type=decimal]
- └── aggregations
-      ├── function: stddev [type=decimal]
-      │    └── variable: column1 [type=int]
-      ├── function: stddev [type=float]
-      │    └── variable: column3 [type=float]
-      └── function: stddev [type=decimal]
-           └── variable: column5 [type=decimal]
+ └── aggregations [outer=(1,3,5)]
+      ├── function: stddev [type=decimal, outer=(1)]
+      │    └── variable: column1 [type=int, outer=(1)]
+      ├── function: stddev [type=float, outer=(3)]
+      │    └── variable: column3 [type=float, outer=(3)]
+      └── function: stddev [type=decimal, outer=(5)]
+           └── variable: column5 [type=decimal, outer=(5)]
 
 exec-ddl
 CREATE TABLE t.bools (b BOOL)
@@ -1548,14 +1548,14 @@ group-by
  │    ├── columns: bools.b:bool:null:1 bools.b:bool:null:1
  │    ├── scan
  │    │    └── columns: bools.b:bool:null:1 bools.rowid:int:2
- │    └── projections
- │         ├── variable: bools.b [type=bool]
- │         └── variable: bools.b [type=bool]
- └── aggregations
-      ├── function: bool_and [type=bool]
-      │    └── variable: bools.b [type=bool]
-      └── function: bool_or [type=bool]
-           └── variable: bools.b [type=bool]
+ │    └── projections [outer=(1)]
+ │         ├── variable: bools.b [type=bool, outer=(1)]
+ │         └── variable: bools.b [type=bool, outer=(1)]
+ └── aggregations [outer=(1)]
+      ├── function: bool_and [type=bool, outer=(1)]
+      │    └── variable: bools.b [type=bool, outer=(1)]
+      └── function: bool_or [type=bool, outer=(1)]
+           └── variable: bools.b [type=bool, outer=(1)]
 
 
 # Tests with * inside GROUP BY.
@@ -1595,18 +1595,18 @@ project
  │    │    ├── columns: xor_bytes.a:bytes:null:1 xor_bytes.c:int:null:3
  │    │    ├── scan
  │    │    │    └── columns: xor_bytes.a:bytes:null:1 xor_bytes.b:int:null:2 xor_bytes.c:int:null:3 xor_bytes.rowid:int:4
- │    │    └── projections
- │    │         ├── variable: xor_bytes.a [type=bytes]
- │    │         └── variable: xor_bytes.c [type=int]
- │    └── aggregations
- │         ├── function: xor_agg [type=bytes]
- │         │    └── variable: xor_bytes.a [type=bytes]
- │         └── function: xor_agg [type=int]
- │              └── variable: xor_bytes.c [type=int]
- └── projections
-      ├── function: to_hex [type=string]
-      │    └── variable: column5 [type=bytes]
-      └── variable: column7 [type=int]
+ │    │    └── projections [outer=(1,3)]
+ │    │         ├── variable: xor_bytes.a [type=bytes, outer=(1)]
+ │    │         └── variable: xor_bytes.c [type=int, outer=(3)]
+ │    └── aggregations [outer=(1,3)]
+ │         ├── function: xor_agg [type=bytes, outer=(1)]
+ │         │    └── variable: xor_bytes.a [type=bytes, outer=(1)]
+ │         └── function: xor_agg [type=int, outer=(3)]
+ │              └── variable: xor_bytes.c [type=int, outer=(3)]
+ └── projections [outer=(5,7)]
+      ├── function: to_hex [type=string, outer=(5)]
+      │    └── variable: column5 [type=bytes, outer=(5)]
+      └── variable: column7 [type=int, outer=(7)]
 
 build
 SELECT MAX(true), MIN(true)
@@ -1620,11 +1620,11 @@ group-by
  │    └── projections
  │         ├── true [type=bool]
  │         └── true [type=bool]
- └── aggregations
-      ├── function: max [type=bool]
-      │    └── variable: column1 [type=bool]
-      └── function: min [type=bool]
-           └── variable: column3 [type=bool]
+ └── aggregations [outer=(1,3)]
+      ├── function: max [type=bool, outer=(1)]
+      │    └── variable: column1 [type=bool, outer=(1)]
+      └── function: min [type=bool, outer=(3)]
+           └── variable: column3 [type=bool, outer=(3)]
 
 exec-ddl
 CREATE TABLE t.ab (
@@ -1663,14 +1663,14 @@ project
  │    │    ├── columns: ab.b:int:null:2 ab.a:int:1
  │    │    ├── scan
  │    │    │    └── columns: ab.a:int:1 ab.b:int:null:2
- │    │    └── projections
- │    │         ├── variable: ab.b [type=int]
- │    │         └── variable: ab.a [type=int]
+ │    │    └── projections [outer=(1,2)]
+ │    │         ├── variable: ab.b [type=int, outer=(2)]
+ │    │         └── variable: ab.a [type=int, outer=(1)]
  │    └── aggregations
- └── projections
-      └── tuple [type=tuple{int, int}]
-           ├── variable: ab.b [type=int]
-           └── variable: ab.a [type=int]
+ └── projections [outer=(1,2)]
+      └── tuple [type=tuple{int, int}, outer=(1,2)]
+           ├── variable: ab.b [type=int, outer=(2)]
+           └── variable: ab.a [type=int, outer=(1)]
 
 build
 SELECT MIN(y), (b, a)
@@ -1690,19 +1690,19 @@ project
  │    │    │    ├── scan
  │    │    │    │    └── columns: xy.x:string:null:3 xy.y:string:null:4 xy.rowid:int:5
  │    │    │    └── true [type=bool]
- │    │    └── projections
- │    │         ├── variable: xy.x [type=string]
- │    │         ├── variable: ab.a [type=int]
- │    │         ├── variable: ab.b [type=int]
- │    │         └── variable: xy.y [type=string]
- │    └── aggregations
- │         └── function: min [type=string]
- │              └── variable: xy.x [type=string]
- └── projections
-      ├── variable: column6 [type=string]
-      └── tuple [type=tuple{int, int}]
-           ├── variable: ab.b [type=int]
-           └── variable: ab.a [type=int]
+ │    │    └── projections [outer=(1-4)]
+ │    │         ├── variable: xy.x [type=string, outer=(3)]
+ │    │         ├── variable: ab.a [type=int, outer=(1)]
+ │    │         ├── variable: ab.b [type=int, outer=(2)]
+ │    │         └── variable: xy.y [type=string, outer=(4)]
+ │    └── aggregations [outer=(3)]
+ │         └── function: min [type=string, outer=(3)]
+ │              └── variable: xy.x [type=string, outer=(3)]
+ └── projections [outer=(1,2,6)]
+      ├── variable: column6 [type=string, outer=(6)]
+      └── tuple [type=tuple{int, int}, outer=(1,2)]
+           ├── variable: ab.b [type=int, outer=(2)]
+           └── variable: ab.a [type=int, outer=(1)]
 
 build
 SELECT (k+v)/(v+w) FROM t.kv GROUP BY k+v, v+w;
@@ -1716,22 +1716,22 @@ project
  │    │    ├── columns: column5:int:null:5 column6:int:null:6
  │    │    ├── scan
  │    │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
- │    │    └── projections
- │    │         ├── plus [type=int]
- │    │         │    ├── variable: kv.k [type=int]
- │    │         │    └── variable: kv.v [type=int]
- │    │         └── plus [type=int]
- │    │              ├── variable: kv.v [type=int]
- │    │              └── variable: kv.w [type=int]
+ │    │    └── projections [outer=(1-3)]
+ │    │         ├── plus [type=int, outer=(1,2)]
+ │    │         │    ├── variable: kv.k [type=int, outer=(1)]
+ │    │         │    └── variable: kv.v [type=int, outer=(2)]
+ │    │         └── plus [type=int, outer=(2,3)]
+ │    │              ├── variable: kv.v [type=int, outer=(2)]
+ │    │              └── variable: kv.w [type=int, outer=(3)]
  │    └── aggregations
- └── projections
-      └── div [type=decimal]
-           ├── plus [type=int]
-           │    ├── variable: kv.k [type=int]
-           │    └── variable: kv.v [type=int]
-           └── plus [type=int]
-                ├── variable: kv.v [type=int]
-                └── variable: kv.w [type=int]
+ └── projections [outer=(1-3)]
+      └── div [type=decimal, outer=(1-3)]
+           ├── plus [type=int, outer=(1,2)]
+           │    ├── variable: kv.k [type=int, outer=(1)]
+           │    └── variable: kv.v [type=int, outer=(2)]
+           └── plus [type=int, outer=(2,3)]
+                ├── variable: kv.v [type=int, outer=(2)]
+                └── variable: kv.w [type=int, outer=(3)]
 
 # Check that everything still works with differently qualified names
 build
@@ -1746,18 +1746,18 @@ project
  │    │    ├── columns: kv.v:int:null:2 column5:int:null:5 kv.w:int:null:3
  │    │    ├── scan
  │    │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
- │    │    └── projections
- │    │         ├── variable: kv.v [type=int]
- │    │         ├── mult [type=int]
- │    │         │    ├── variable: kv.k [type=int]
- │    │         │    └── variable: kv.w [type=int]
- │    │         └── variable: kv.w [type=int]
- │    └── aggregations
- │         └── function: sum [type=decimal]
- │              └── variable: kv.v [type=int]
- └── projections
-      ├── variable: column6 [type=decimal]
-      └── variable: kv.v [type=int]
+ │    │    └── projections [outer=(1-3)]
+ │    │         ├── variable: kv.v [type=int, outer=(2)]
+ │    │         ├── mult [type=int, outer=(1,3)]
+ │    │         │    ├── variable: kv.k [type=int, outer=(1)]
+ │    │         │    └── variable: kv.w [type=int, outer=(3)]
+ │    │         └── variable: kv.w [type=int, outer=(3)]
+ │    └── aggregations [outer=(2)]
+ │         └── function: sum [type=decimal, outer=(2)]
+ │              └── variable: kv.v [type=int, outer=(2)]
+ └── projections [outer=(2,6)]
+      ├── variable: column6 [type=decimal, outer=(6)]
+      └── variable: kv.v [type=int, outer=(2)]
 
 build
 SELECT SUM(t.kv.w), LOWER(s), t.kv.v + k * t.kv.w, t.kv.v FROM t.kv GROUP BY v, LOWER(kv.s), kv.k * w
@@ -1771,26 +1771,26 @@ project
  │    │    ├── columns: kv.v:int:null:2 column5:string:null:5 column6:int:null:6 kv.w:int:null:3
  │    │    ├── scan
  │    │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
- │    │    └── projections
- │    │         ├── variable: kv.v [type=int]
- │    │         ├── function: lower [type=string]
- │    │         │    └── variable: kv.s [type=string]
- │    │         ├── mult [type=int]
- │    │         │    ├── variable: kv.k [type=int]
- │    │         │    └── variable: kv.w [type=int]
- │    │         └── variable: kv.w [type=int]
- │    └── aggregations
- │         └── function: sum [type=decimal]
- │              └── variable: kv.v [type=int]
- └── projections
-      ├── variable: column7 [type=decimal]
-      ├── variable: column5 [type=string]
-      ├── plus [type=int]
-      │    ├── variable: kv.v [type=int]
-      │    └── mult [type=int]
-      │         ├── variable: kv.k [type=int]
-      │         └── variable: kv.w [type=int]
-      └── variable: kv.v [type=int]
+ │    │    └── projections [outer=(1-4)]
+ │    │         ├── variable: kv.v [type=int, outer=(2)]
+ │    │         ├── function: lower [type=string, outer=(4)]
+ │    │         │    └── variable: kv.s [type=string, outer=(4)]
+ │    │         ├── mult [type=int, outer=(1,3)]
+ │    │         │    ├── variable: kv.k [type=int, outer=(1)]
+ │    │         │    └── variable: kv.w [type=int, outer=(3)]
+ │    │         └── variable: kv.w [type=int, outer=(3)]
+ │    └── aggregations [outer=(2)]
+ │         └── function: sum [type=decimal, outer=(2)]
+ │              └── variable: kv.v [type=int, outer=(2)]
+ └── projections [outer=(1-3,5,7)]
+      ├── variable: column7 [type=decimal, outer=(7)]
+      ├── variable: column5 [type=string, outer=(5)]
+      ├── plus [type=int, outer=(1-3)]
+      │    ├── variable: kv.v [type=int, outer=(2)]
+      │    └── mult [type=int, outer=(1,3)]
+      │         ├── variable: kv.k [type=int, outer=(1)]
+      │         └── variable: kv.w [type=int, outer=(3)]
+      └── variable: kv.v [type=int, outer=(2)]
 
 # Check all the different types of scalar expressions as group by columns
 build
@@ -1815,18 +1815,18 @@ project
  │    │    │    ├── scan
  │    │    │    │    └── columns: abc.a:string:5 abc.b:float:null:6 abc.c:bool:null:7 abc.d:decimal:null:8
  │    │    │    └── true [type=bool]
- │    │    └── projections
- │    │         ├── and [type=bool]
- │    │         │    ├── variable: bools.b [type=bool]
- │    │         │    └── variable: abc.c [type=bool]
- │    │         └── variable: bools.b [type=bool]
+ │    │    └── projections [outer=(1,3,7)]
+ │    │         ├── and [type=bool, outer=(1,7)]
+ │    │         │    ├── variable: bools.b [type=bool, outer=(1)]
+ │    │         │    └── variable: abc.c [type=bool, outer=(7)]
+ │    │         └── variable: bools.b [type=bool, outer=(3)]
  │    └── aggregations
- └── projections
-      └── and [type=bool]
-           ├── and [type=bool]
-           │    ├── variable: bools.b [type=bool]
-           │    └── variable: abc.c [type=bool]
-           └── variable: bools.b [type=bool]
+ └── projections [outer=(1,3,7)]
+      └── and [type=bool, outer=(1,3,7)]
+           ├── and [type=bool, outer=(1,7)]
+           │    ├── variable: bools.b [type=bool, outer=(1)]
+           │    └── variable: abc.c [type=bool, outer=(7)]
+           └── variable: bools.b [type=bool, outer=(3)]
 
 build
 SELECT b1.b AND abc.c AND abc.c FROM bools b1, bools b2, abc GROUP BY b1.b AND abc.c, b2.b
@@ -1855,18 +1855,18 @@ project
  │    │    │    ├── scan
  │    │    │    │    └── columns: abc.a:string:5 abc.b:float:null:6 abc.c:bool:null:7 abc.d:decimal:null:8
  │    │    │    └── true [type=bool]
- │    │    └── projections
- │    │         ├── or [type=bool]
- │    │         │    ├── variable: bools.b [type=bool]
- │    │         │    └── variable: abc.c [type=bool]
- │    │         └── variable: bools.b [type=bool]
+ │    │    └── projections [outer=(1,3,7)]
+ │    │         ├── or [type=bool, outer=(1,7)]
+ │    │         │    ├── variable: bools.b [type=bool, outer=(1)]
+ │    │         │    └── variable: abc.c [type=bool, outer=(7)]
+ │    │         └── variable: bools.b [type=bool, outer=(3)]
  │    └── aggregations
- └── projections
-      └── or [type=bool]
-           ├── or [type=bool]
-           │    ├── variable: bools.b [type=bool]
-           │    └── variable: abc.c [type=bool]
-           └── variable: bools.b [type=bool]
+ └── projections [outer=(1,3,7)]
+      └── or [type=bool, outer=(1,3,7)]
+           ├── or [type=bool, outer=(1,7)]
+           │    ├── variable: bools.b [type=bool, outer=(1)]
+           │    └── variable: abc.c [type=bool, outer=(7)]
+           └── variable: bools.b [type=bool, outer=(3)]
 
 build
 SELECT b1.b OR abc.c OR abc.c FROM bools b1, bools b2, abc GROUP BY b1.b OR abc.c, b2.b
@@ -1885,18 +1885,18 @@ project
  │    │    ├── columns: column5:int:null:5 kv.v:int:null:2
  │    │    ├── scan
  │    │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
- │    │    └── projections
- │    │         ├── mod [type=int]
- │    │         │    ├── variable: kv.k [type=int]
- │    │         │    └── variable: kv.w [type=int]
- │    │         └── variable: kv.v [type=int]
+ │    │    └── projections [outer=(1-3)]
+ │    │         ├── mod [type=int, outer=(1,3)]
+ │    │         │    ├── variable: kv.k [type=int, outer=(1)]
+ │    │         │    └── variable: kv.w [type=int, outer=(3)]
+ │    │         └── variable: kv.v [type=int, outer=(2)]
  │    └── aggregations
- └── projections
-      └── mod [type=int]
-           ├── mod [type=int]
-           │    ├── variable: kv.k [type=int]
-           │    └── variable: kv.w [type=int]
-           └── variable: kv.v [type=int]
+ └── projections [outer=(1-3)]
+      └── mod [type=int, outer=(1-3)]
+           ├── mod [type=int, outer=(1,3)]
+           │    ├── variable: kv.k [type=int, outer=(1)]
+           │    └── variable: kv.w [type=int, outer=(3)]
+           └── variable: kv.v [type=int, outer=(2)]
 
 build
 SELECT CONCAT(CONCAT(s, a), a) FROM kv, abc GROUP BY CONCAT(s, a), a
@@ -1915,18 +1915,18 @@ project
  │    │    │    ├── scan
  │    │    │    │    └── columns: abc.a:string:5 abc.b:float:null:6 abc.c:bool:null:7 abc.d:decimal:null:8
  │    │    │    └── true [type=bool]
- │    │    └── projections
- │    │         ├── function: concat [type=string]
- │    │         │    ├── variable: kv.s [type=string]
- │    │         │    └── variable: abc.a [type=string]
- │    │         └── variable: abc.a [type=string]
+ │    │    └── projections [outer=(4,5)]
+ │    │         ├── function: concat [type=string, outer=(4,5)]
+ │    │         │    ├── variable: kv.s [type=string, outer=(4)]
+ │    │         │    └── variable: abc.a [type=string, outer=(5)]
+ │    │         └── variable: abc.a [type=string, outer=(5)]
  │    └── aggregations
- └── projections
-      └── function: concat [type=string]
-           ├── function: concat [type=string]
-           │    ├── variable: kv.s [type=string]
-           │    └── variable: abc.a [type=string]
-           └── variable: abc.a [type=string]
+ └── projections [outer=(4,5)]
+      └── function: concat [type=string, outer=(4,5)]
+           ├── function: concat [type=string, outer=(4,5)]
+           │    ├── variable: kv.s [type=string, outer=(4)]
+           │    └── variable: abc.a [type=string, outer=(5)]
+           └── variable: abc.a [type=string, outer=(5)]
 
 build
 SELECT CONCAT(CONCAT(s, a), s) FROM kv, abc GROUP BY CONCAT(s, a), a
@@ -1945,19 +1945,19 @@ project
  │    │    ├── columns: column5:bool:null:5 kv.v:int:null:2
  │    │    ├── scan
  │    │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
- │    │    └── projections
- │    │         ├── lt [type=bool]
- │    │         │    ├── variable: kv.k [type=int]
- │    │         │    └── variable: kv.w [type=int]
- │    │         └── variable: kv.v [type=int]
+ │    │    └── projections [outer=(1-3)]
+ │    │         ├── lt [type=bool, outer=(1,3)]
+ │    │         │    ├── variable: kv.k [type=int, outer=(1)]
+ │    │         │    └── variable: kv.w [type=int, outer=(3)]
+ │    │         └── variable: kv.v [type=int, outer=(2)]
  │    └── aggregations
- └── projections
-      └── and [type=bool]
-           ├── lt [type=bool]
-           │    ├── variable: kv.k [type=int]
-           │    └── variable: kv.w [type=int]
-           └── ne [type=bool]
-                ├── variable: kv.v [type=int]
+ └── projections [outer=(1-3)]
+      └── and [type=bool, outer=(1-3)]
+           ├── lt [type=bool, outer=(1,3)]
+           │    ├── variable: kv.k [type=int, outer=(1)]
+           │    └── variable: kv.w [type=int, outer=(3)]
+           └── ne [type=bool, outer=(2)]
+                ├── variable: kv.v [type=int, outer=(2)]
                 └── const: 5 [type=int]
 
 build
@@ -1992,20 +1992,20 @@ project
  │    │    │    ├── scan
  │    │    │    │    └── columns: foo.bar:jsonb:null:4 foo.baz:jsonb:null:5 foo.rowid:int:6
  │    │    │    └── true [type=bool]
- │    │    └── projections
- │    │         ├── contains [type=bool]
- │    │         │    ├── variable: foo.bar [type=jsonb]
- │    │         │    └── variable: foo.baz [type=jsonb]
- │    │         └── variable: foo.baz [type=jsonb]
+ │    │    └── projections [outer=(1,5)]
+ │    │         ├── contains [type=bool, outer=(1,5)]
+ │    │         │    ├── variable: foo.bar [type=jsonb, outer=(1)]
+ │    │         │    └── variable: foo.baz [type=jsonb, outer=(5)]
+ │    │         └── variable: foo.baz [type=jsonb, outer=(5)]
  │    └── aggregations
- └── projections
-      └── and [type=bool]
-           ├── contains [type=bool]
-           │    ├── variable: foo.bar [type=jsonb]
-           │    └── variable: foo.baz [type=jsonb]
-           └── contains [type=bool]
-                ├── variable: foo.baz [type=jsonb]
-                └── variable: foo.baz [type=jsonb]
+ └── projections [outer=(1,5)]
+      └── and [type=bool, outer=(1,5)]
+           ├── contains [type=bool, outer=(1,5)]
+           │    ├── variable: foo.bar [type=jsonb, outer=(1)]
+           │    └── variable: foo.baz [type=jsonb, outer=(5)]
+           └── contains [type=bool, outer=(5)]
+                ├── variable: foo.baz [type=jsonb, outer=(5)]
+                └── variable: foo.baz [type=jsonb, outer=(5)]
 
 build
 SELECT a.bar @> b.baz AND b.baz @> b.baz FROM foo AS a, foo AS b GROUP BY b.baz <@ a.bar, b.baz
@@ -2029,20 +2029,20 @@ project
  │    │    │    ├── scan
  │    │    │    │    └── columns: foo.bar:jsonb:null:4 foo.baz:jsonb:null:5 foo.rowid:int:6
  │    │    │    └── true [type=bool]
- │    │    └── projections
- │    │         ├── contains [type=bool]
- │    │         │    ├── variable: foo.bar [type=jsonb]
- │    │         │    └── variable: foo.baz [type=jsonb]
- │    │         └── variable: foo.baz [type=jsonb]
+ │    │    └── projections [outer=(1,5)]
+ │    │         ├── contains [type=bool, outer=(1,5)]
+ │    │         │    ├── variable: foo.bar [type=jsonb, outer=(1)]
+ │    │         │    └── variable: foo.baz [type=jsonb, outer=(5)]
+ │    │         └── variable: foo.baz [type=jsonb, outer=(5)]
  │    └── aggregations
- └── projections
-      └── and [type=bool]
-           ├── contains [type=bool]
-           │    ├── variable: foo.bar [type=jsonb]
-           │    └── variable: foo.baz [type=jsonb]
-           └── contains [type=bool]
-                ├── variable: foo.baz [type=jsonb]
-                └── variable: foo.baz [type=jsonb]
+ └── projections [outer=(1,5)]
+      └── and [type=bool, outer=(1,5)]
+           ├── contains [type=bool, outer=(1,5)]
+           │    ├── variable: foo.bar [type=jsonb, outer=(1)]
+           │    └── variable: foo.baz [type=jsonb, outer=(5)]
+           └── contains [type=bool, outer=(5)]
+                ├── variable: foo.baz [type=jsonb, outer=(5)]
+                └── variable: foo.baz [type=jsonb, outer=(5)]
 
 exec-ddl
 CREATE TABLE times (t time PRIMARY KEY)
@@ -2070,22 +2070,22 @@ project
  │    │    │    ├── scan
  │    │    │    │    └── columns: times.t:time:2
  │    │    │    └── true [type=bool]
- │    │    └── projections
- │    │         ├── function: date_trunc [type=interval]
+ │    │    └── projections [outer=(1,2)]
+ │    │         ├── function: date_trunc [type=interval, outer=(1)]
  │    │         │    ├── const: 'second' [type=string]
- │    │         │    └── variable: times.t [type=time]
- │    │         └── function: date_trunc [type=interval]
+ │    │         │    └── variable: times.t [type=time, outer=(1)]
+ │    │         └── function: date_trunc [type=interval, outer=(2)]
  │    │              ├── const: 'minute' [type=string]
- │    │              └── variable: times.t [type=time]
+ │    │              └── variable: times.t [type=time, outer=(2)]
  │    └── aggregations
- └── projections
-      └── minus [type=interval]
-           ├── function: date_trunc [type=interval]
+ └── projections [outer=(1,2)]
+      └── minus [type=interval, outer=(1,2)]
+           ├── function: date_trunc [type=interval, outer=(1)]
            │    ├── const: 'second' [type=string]
-           │    └── variable: times.t [type=time]
-           └── function: date_trunc [type=interval]
+           │    └── variable: times.t [type=time, outer=(1)]
+           └── function: date_trunc [type=interval, outer=(2)]
                 ├── const: 'minute' [type=string]
-                └── variable: times.t [type=time]
+                └── variable: times.t [type=time, outer=(2)]
 
 build
 SELECT date_trunc('second', a.t) - date_trunc('second', b.t) FROM times a, times b
@@ -2103,9 +2103,9 @@ group-by
  │    ├── columns: column3:bool:null:3
  │    ├── scan
  │    │    └── columns: bools.b:bool:null:1 bools.rowid:int:2
- │    └── projections
- │         └── not [type=bool]
- │              └── variable: bools.b [type=bool]
+ │    └── projections [outer=(1)]
+ │         └── not [type=bool, outer=(1)]
+ │              └── variable: bools.b [type=bool, outer=(1)]
  └── aggregations
 
 build
@@ -2125,12 +2125,12 @@ project
  │    │    ├── columns: bools.b:bool:null:1
  │    │    ├── scan
  │    │    │    └── columns: bools.b:bool:null:1 bools.rowid:int:2
- │    │    └── projections
- │    │         └── variable: bools.b [type=bool]
+ │    │    └── projections [outer=(1)]
+ │    │         └── variable: bools.b [type=bool, outer=(1)]
  │    └── aggregations
- └── projections
-      └── not [type=bool]
-           └── variable: bools.b [type=bool]
+ └── projections [outer=(1)]
+      └── not [type=bool, outer=(1)]
+           └── variable: bools.b [type=bool, outer=(1)]
 
 build
 SELECT +k * (-w) FROM kv GROUP BY +k, -w
@@ -2144,18 +2144,18 @@ project
  │    │    ├── columns: column5:int:null:5 column6:int:null:6
  │    │    ├── scan
  │    │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
- │    │    └── projections
- │    │         ├── unary-plus [type=int]
- │    │         │    └── variable: kv.k [type=int]
- │    │         └── unary-minus [type=int]
- │    │              └── variable: kv.w [type=int]
+ │    │    └── projections [outer=(1,3)]
+ │    │         ├── unary-plus [type=int, outer=(1)]
+ │    │         │    └── variable: kv.k [type=int, outer=(1)]
+ │    │         └── unary-minus [type=int, outer=(3)]
+ │    │              └── variable: kv.w [type=int, outer=(3)]
  │    └── aggregations
- └── projections
-      └── mult [type=int]
-           ├── unary-plus [type=int]
-           │    └── variable: kv.k [type=int]
-           └── unary-minus [type=int]
-                └── variable: kv.w [type=int]
+ └── projections [outer=(1,3)]
+      └── mult [type=int, outer=(1,3)]
+           ├── unary-plus [type=int, outer=(1)]
+           │    └── variable: kv.k [type=int, outer=(1)]
+           └── unary-minus [type=int, outer=(3)]
+                └── variable: kv.w [type=int, outer=(3)]
 
 build
 SELECT k * (-w) FROM kv GROUP BY +k, -w
@@ -2174,16 +2174,16 @@ project
  │    │    ├── columns: kv.k:int:1 kv.w:int:null:3
  │    │    ├── scan
  │    │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
- │    │    └── projections
- │    │         ├── variable: kv.k [type=int]
- │    │         └── variable: kv.w [type=int]
+ │    │    └── projections [outer=(1,3)]
+ │    │         ├── variable: kv.k [type=int, outer=(1)]
+ │    │         └── variable: kv.w [type=int, outer=(3)]
  │    └── aggregations
- └── projections
-      └── mult [type=int]
-           ├── unary-plus [type=int]
-           │    └── variable: kv.k [type=int]
-           └── unary-minus [type=int]
-                └── variable: kv.w [type=int]
+ └── projections [outer=(1,3)]
+      └── mult [type=int, outer=(1,3)]
+           ├── unary-plus [type=int, outer=(1)]
+           │    └── variable: kv.k [type=int, outer=(1)]
+           └── unary-minus [type=int, outer=(3)]
+                └── variable: kv.w [type=int, outer=(3)]
 
 build 
 SELECT 1 + MIN(v*2) FROM kv GROUP BY k+3
@@ -2197,20 +2197,20 @@ project
  │    │    ├── columns: column5:int:null:5 column6:int:null:6
  │    │    ├── scan
  │    │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
- │    │    └── projections
- │    │         ├── plus [type=int]
- │    │         │    ├── variable: kv.k [type=int]
+ │    │    └── projections [outer=(1,2)]
+ │    │         ├── plus [type=int, outer=(1)]
+ │    │         │    ├── variable: kv.k [type=int, outer=(1)]
  │    │         │    └── const: 3 [type=int]
- │    │         └── mult [type=int]
- │    │              ├── variable: kv.v [type=int]
+ │    │         └── mult [type=int, outer=(2)]
+ │    │              ├── variable: kv.v [type=int, outer=(2)]
  │    │              └── const: 2 [type=int]
- │    └── aggregations
- │         └── function: min [type=int]
- │              └── variable: column5 [type=int]
- └── projections
-      └── plus [type=int]
+ │    └── aggregations [outer=(5)]
+ │         └── function: min [type=int, outer=(5)]
+ │              └── variable: column5 [type=int, outer=(5)]
+ └── projections [outer=(7)]
+      └── plus [type=int, outer=(7)]
            ├── const: 1 [type=int]
-           └── variable: column7 [type=int]
+           └── variable: column7 [type=int, outer=(7)]
 
 build
 SELECT count(*) FROM kv GROUP BY k, k
@@ -2224,9 +2224,9 @@ project
  │    │    ├── columns: kv.k:int:1 kv.k:int:1
  │    │    ├── scan
  │    │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
- │    │    └── projections
- │    │         ├── variable: kv.k [type=int]
- │    │         └── variable: kv.k [type=int]
+ │    │    └── projections [outer=(1)]
+ │    │         ├── variable: kv.k [type=int, outer=(1)]
+ │    │         └── variable: kv.k [type=int, outer=(1)]
  │    └── aggregations
  │         └── function: count_rows [type=int]
  └── projections

--- a/pkg/sql/opt/optbuilder/testdata/distinct
+++ b/pkg/sql/opt/optbuilder/testdata/distinct
@@ -33,9 +33,9 @@ project
  ├── columns: y:int:null:2 z:float:null:3
  ├── scan
  │    └── columns: xyz.x:int:1 xyz.y:int:null:2 xyz.z:float:null:3
- └── projections
-      ├── variable: xyz.y [type=int]
-      └── variable: xyz.z [type=float]
+ └── projections [outer=(2,3)]
+      ├── variable: xyz.y [type=int, outer=(2)]
+      └── variable: xyz.z [type=float, outer=(3)]
 
 build
 SELECT DISTINCT y, z FROM t.xyz
@@ -47,9 +47,9 @@ group-by
  │    ├── columns: xyz.y:int:null:2 xyz.z:float:null:3
  │    ├── scan
  │    │    └── columns: xyz.x:int:1 xyz.y:int:null:2 xyz.z:float:null:3
- │    └── projections
- │         ├── variable: xyz.y [type=int]
- │         └── variable: xyz.z [type=float]
+ │    └── projections [outer=(2,3)]
+ │         ├── variable: xyz.y [type=int, outer=(2)]
+ │         └── variable: xyz.z [type=float, outer=(3)]
  └── aggregations
 
 build
@@ -64,12 +64,12 @@ project
  │    │    ├── columns: xyz.y:int:null:2 xyz.z:float:null:3
  │    │    ├── scan
  │    │    │    └── columns: xyz.x:int:1 xyz.y:int:null:2 xyz.z:float:null:3
- │    │    └── projections
- │    │         ├── variable: xyz.y [type=int]
- │    │         └── variable: xyz.z [type=float]
+ │    │    └── projections [outer=(2,3)]
+ │    │         ├── variable: xyz.y [type=int, outer=(2)]
+ │    │         └── variable: xyz.z [type=float, outer=(3)]
  │    └── aggregations
- └── projections
-      └── variable: xyz.y [type=int]
+ └── projections [outer=(2)]
+      └── variable: xyz.y [type=int, outer=(2)]
 
 build
 SELECT DISTINCT (y,z) FROM t.xyz
@@ -81,10 +81,10 @@ group-by
  │    ├── columns: column4:tuple{int, float}:null:4
  │    ├── scan
  │    │    └── columns: xyz.x:int:1 xyz.y:int:null:2 xyz.z:float:null:3
- │    └── projections
- │         └── tuple [type=tuple{int, float}]
- │              ├── variable: xyz.y [type=int]
- │              └── variable: xyz.z [type=float]
+ │    └── projections [outer=(2,3)]
+ │         └── tuple [type=tuple{int, float}, outer=(2,3)]
+ │              ├── variable: xyz.y [type=int, outer=(2)]
+ │              └── variable: xyz.z [type=float, outer=(3)]
  └── aggregations
 
 build
@@ -100,8 +100,8 @@ group-by
  │    │    │    ├── columns: xyz.y:int:null:2
  │    │    │    ├── scan
  │    │    │    │    └── columns: xyz.x:int:1 xyz.y:int:null:2 xyz.z:float:null:3
- │    │    │    └── projections
- │    │    │         └── variable: xyz.y [type=int]
+ │    │    │    └── projections [outer=(2)]
+ │    │    │         └── variable: xyz.y [type=int, outer=(2)]
  │    │    └── aggregations
  │    └── projections
  └── aggregations
@@ -119,11 +119,11 @@ group-by
  │    │    ├── columns: xyz.x:int:1 xyz.y:int:null:2 xyz.z:float:null:3
  │    │    ├── scan
  │    │    │    └── columns: xyz.x:int:1 xyz.y:int:null:2 xyz.z:float:null:3
- │    │    └── gt [type=bool]
- │    │         ├── variable: xyz.x [type=int]
+ │    │    └── gt [type=bool, outer=(1)]
+ │    │         ├── variable: xyz.x [type=int, outer=(1)]
  │    │         └── const: 0 [type=int]
- │    └── projections
- │         └── variable: xyz.x [type=int]
+ │    └── projections [outer=(1)]
+ │         └── variable: xyz.x [type=int, outer=(1)]
  └── aggregations
 
 build
@@ -138,11 +138,11 @@ group-by
  │    │    ├── columns: xyz.x:int:1 xyz.y:int:null:2 xyz.z:float:null:3
  │    │    ├── scan
  │    │    │    └── columns: xyz.x:int:1 xyz.y:int:null:2 xyz.z:float:null:3
- │    │    └── gt [type=bool]
- │    │         ├── variable: xyz.x [type=int]
+ │    │    └── gt [type=bool, outer=(1)]
+ │    │         ├── variable: xyz.x [type=int, outer=(1)]
  │    │         └── const: 0 [type=int]
- │    └── projections
- │         └── variable: xyz.z [type=float]
+ │    └── projections [outer=(3)]
+ │         └── variable: xyz.z [type=float, outer=(3)]
  └── aggregations
 
 build
@@ -160,14 +160,14 @@ group-by
  │    │    │    ├── columns: xyz.x:int:1 xyz.x:int:1
  │    │    │    ├── scan
  │    │    │    │    └── columns: xyz.x:int:1 xyz.y:int:null:2 xyz.z:float:null:3
- │    │    │    └── projections
- │    │    │         ├── variable: xyz.x [type=int]
- │    │    │         └── variable: xyz.x [type=int]
- │    │    └── aggregations
- │    │         └── function: max [type=int]
- │    │              └── variable: xyz.x [type=int]
- │    └── projections
- │         └── variable: column4 [type=int]
+ │    │    │    └── projections [outer=(1)]
+ │    │    │         ├── variable: xyz.x [type=int, outer=(1)]
+ │    │    │         └── variable: xyz.x [type=int, outer=(1)]
+ │    │    └── aggregations [outer=(1)]
+ │    │         └── function: max [type=int, outer=(1)]
+ │    │              └── variable: xyz.x [type=int, outer=(1)]
+ │    └── projections [outer=(4)]
+ │         └── variable: column4 [type=int, outer=(4)]
  └── aggregations
 
 build
@@ -180,10 +180,10 @@ group-by
  │    ├── columns: column4:int:null:4
  │    ├── scan
  │    │    └── columns: xyz.x:int:1 xyz.y:int:null:2 xyz.z:float:null:3
- │    └── projections
- │         └── plus [type=int]
- │              ├── variable: xyz.x [type=int]
- │              └── variable: xyz.y [type=int]
+ │    └── projections [outer=(1,2)]
+ │         └── plus [type=int, outer=(1,2)]
+ │              ├── variable: xyz.x [type=int, outer=(1)]
+ │              └── variable: xyz.y [type=int, outer=(2)]
  └── aggregations
 
 build
@@ -229,16 +229,16 @@ group-by
  │    │    │    ├── grouping columns: xyz.x:int:1 xyz.y:int:null:2
  │    │    │    ├── scan
  │    │    │    │    └── columns: xyz.x:int:1 xyz.y:int:null:2 xyz.z:float:null:3
- │    │    │    └── aggregations
- │    │    │         └── function: max [type=float]
- │    │    │              └── variable: xyz.x [type=int]
- │    │    └── gt [type=bool]
- │    │         ├── variable: xyz.y [type=int]
+ │    │    │    └── aggregations [outer=(1)]
+ │    │    │         └── function: max [type=float, outer=(1)]
+ │    │    │              └── variable: xyz.x [type=int, outer=(1)]
+ │    │    └── gt [type=bool, outer=(2)]
+ │    │         ├── variable: xyz.y [type=int, outer=(2)]
  │    │         └── const: 4 [type=int]
- │    └── projections
- │         ├── variable: column4 [type=float]
- │         ├── plus [type=int]
- │         │    ├── variable: xyz.x [type=int]
- │         │    └── variable: xyz.y [type=int]
+ │    └── projections [outer=(1,2,4)]
+ │         ├── variable: column4 [type=float, outer=(4)]
+ │         ├── plus [type=int, outer=(1,2)]
+ │         │    ├── variable: xyz.x [type=int, outer=(1)]
+ │         │    └── variable: xyz.y [type=int, outer=(2)]
  │         └── const: 3 [type=int]
  └── aggregations

--- a/pkg/sql/opt/optbuilder/testdata/having
+++ b/pkg/sql/opt/optbuilder/testdata/having
@@ -304,17 +304,17 @@ select
  │    │    ├── columns: column5:string:null:5 kv.s:string:null:4 column7:string:null:7
  │    │    ├── scan
  │    │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
- │    │    └── projections
- │    │         ├── function: upper [type=string]
- │    │         │    └── variable: kv.s [type=string]
- │    │         ├── variable: kv.s [type=string]
- │    │         └── function: upper [type=string]
- │    │              └── variable: kv.s [type=string]
- │    └── aggregations
- │         ├── function: count [type=int]
- │         │    └── variable: column5 [type=string]
- │         └── function: count [type=int]
- │              └── variable: kv.s [type=string]
- └── gt [type=bool]
-      ├── variable: column6 [type=int]
+ │    │    └── projections [outer=(4)]
+ │    │         ├── function: upper [type=string, outer=(4)]
+ │    │         │    └── variable: kv.s [type=string, outer=(4)]
+ │    │         ├── variable: kv.s [type=string, outer=(4)]
+ │    │         └── function: upper [type=string, outer=(4)]
+ │    │              └── variable: kv.s [type=string, outer=(4)]
+ │    └── aggregations [outer=(4,5)]
+ │         ├── function: count [type=int, outer=(5)]
+ │         │    └── variable: column5 [type=string, outer=(5)]
+ │         └── function: count [type=int, outer=(4)]
+ │              └── variable: kv.s [type=string, outer=(4)]
+ └── gt [type=bool, outer=(6)]
+      ├── variable: column6 [type=int, outer=(6)]
       └── const: 1 [type=int]

--- a/pkg/sql/opt/optbuilder/testdata/having
+++ b/pkg/sql/opt/optbuilder/testdata/having
@@ -45,12 +45,12 @@ select
  │    │    ├── columns: kv.s:string:null:4
  │    │    ├── scan
  │    │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
- │    │    └── projections
- │    │         └── variable: kv.s [type=string]
+ │    │    └── projections [outer=(4)]
+ │    │         └── variable: kv.s [type=string, outer=(4)]
  │    └── aggregations
  │         └── function: count_rows [type=int]
- └── gt [type=bool]
-      ├── variable: column5 [type=int]
+ └── gt [type=bool, outer=(5)]
+      ├── variable: column5 [type=int, outer=(5)]
       └── const: 1 [type=int]
 
 build
@@ -66,20 +66,20 @@ project
  │    │    │    ├── columns: kv.v:int:null:2 kv.k:int:1
  │    │    │    ├── scan
  │    │    │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
- │    │    │    └── projections
- │    │    │         ├── variable: kv.v [type=int]
- │    │    │         └── variable: kv.k [type=int]
- │    │    └── aggregations
- │    │         ├── function: min [type=int]
- │    │         │    └── variable: kv.v [type=int]
- │    │         └── function: max [type=int]
- │    │              └── variable: kv.k [type=int]
- │    └── gt [type=bool]
- │         ├── variable: column5 [type=int]
+ │    │    │    └── projections [outer=(1,2)]
+ │    │    │         ├── variable: kv.v [type=int, outer=(2)]
+ │    │    │         └── variable: kv.k [type=int, outer=(1)]
+ │    │    └── aggregations [outer=(1,2)]
+ │    │         ├── function: min [type=int, outer=(2)]
+ │    │         │    └── variable: kv.v [type=int, outer=(2)]
+ │    │         └── function: max [type=int, outer=(1)]
+ │    │              └── variable: kv.k [type=int, outer=(1)]
+ │    └── gt [type=bool, outer=(5)]
+ │         ├── variable: column5 [type=int, outer=(5)]
  │         └── const: 2 [type=int]
- └── projections
-      ├── variable: column6 [type=int]
-      └── variable: column5 [type=int]
+ └── projections [outer=(5,6)]
+      ├── variable: column6 [type=int, outer=(6)]
+      └── variable: column5 [type=int, outer=(5)]
 
 build
 SELECT MAX(k), MIN(v) FROM t.kv HAVING MAX(v) > 2
@@ -94,23 +94,23 @@ project
  │    │    │    ├── columns: kv.v:int:null:2 kv.k:int:1 kv.v:int:null:2
  │    │    │    ├── scan
  │    │    │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
- │    │    │    └── projections
- │    │    │         ├── variable: kv.v [type=int]
- │    │    │         ├── variable: kv.k [type=int]
- │    │    │         └── variable: kv.v [type=int]
- │    │    └── aggregations
- │    │         ├── function: max [type=int]
- │    │         │    └── variable: kv.v [type=int]
- │    │         ├── function: max [type=int]
- │    │         │    └── variable: kv.k [type=int]
- │    │         └── function: min [type=int]
- │    │              └── variable: kv.v [type=int]
- │    └── gt [type=bool]
- │         ├── variable: column5 [type=int]
+ │    │    │    └── projections [outer=(1,2)]
+ │    │    │         ├── variable: kv.v [type=int, outer=(2)]
+ │    │    │         ├── variable: kv.k [type=int, outer=(1)]
+ │    │    │         └── variable: kv.v [type=int, outer=(2)]
+ │    │    └── aggregations [outer=(1,2)]
+ │    │         ├── function: max [type=int, outer=(2)]
+ │    │         │    └── variable: kv.v [type=int, outer=(2)]
+ │    │         ├── function: max [type=int, outer=(1)]
+ │    │         │    └── variable: kv.k [type=int, outer=(1)]
+ │    │         └── function: min [type=int, outer=(2)]
+ │    │              └── variable: kv.v [type=int, outer=(2)]
+ │    └── gt [type=bool, outer=(5)]
+ │         ├── variable: column5 [type=int, outer=(5)]
  │         └── const: 2 [type=int]
- └── projections
-      ├── variable: column6 [type=int]
-      └── variable: column7 [type=int]
+ └── projections [outer=(6,7)]
+      ├── variable: column6 [type=int, outer=(6)]
+      └── variable: column7 [type=int, outer=(7)]
 
 build
 SELECT MAX(k), MIN(v) FROM t.kv HAVING MAX(MIN(v)) > 2
@@ -154,20 +154,20 @@ project
  │    │    │    ├── columns: column5:int:null:5
  │    │    │    ├── scan
  │    │    │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
- │    │    │    └── projections
- │    │    │         └── plus [type=int]
- │    │    │              ├── variable: kv.k [type=int]
- │    │    │              └── variable: kv.w [type=int]
+ │    │    │    └── projections [outer=(1,3)]
+ │    │    │         └── plus [type=int, outer=(1,3)]
+ │    │    │              ├── variable: kv.k [type=int, outer=(1)]
+ │    │    │              └── variable: kv.w [type=int, outer=(3)]
  │    │    └── aggregations
  │    │         └── function: count_rows [type=int]
- │    └── gt [type=bool]
- │         ├── plus [type=int]
- │         │    ├── variable: kv.k [type=int]
- │         │    └── variable: kv.w [type=int]
+ │    └── gt [type=bool, outer=(1,3)]
+ │         ├── plus [type=int, outer=(1,3)]
+ │         │    ├── variable: kv.k [type=int, outer=(1)]
+ │         │    └── variable: kv.w [type=int, outer=(3)]
  │         └── const: 5 [type=int]
- └── projections
-      ├── variable: column6 [type=int]
-      └── variable: column5 [type=int]
+ └── projections [outer=(5,6)]
+      ├── variable: column6 [type=int, outer=(6)]
+      └── variable: column5 [type=int, outer=(5)]
 
 build
 SELECT count(*), k+w FROM t.kv GROUP BY k+w HAVING (k+v) > 5
@@ -189,17 +189,17 @@ project
  │    │    │    ├── columns: kv.v:int:null:2 kv.v:int:null:2
  │    │    │    ├── scan
  │    │    │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
- │    │    │    └── projections
- │    │    │         ├── variable: kv.v [type=int]
- │    │    │         └── variable: kv.v [type=int]
- │    │    └── aggregations
- │    │         └── function: max [type=int]
- │    │              └── variable: kv.v [type=int]
- │    └── gt [type=bool]
- │         ├── variable: kv.v [type=int]
+ │    │    │    └── projections [outer=(2)]
+ │    │    │         ├── variable: kv.v [type=int, outer=(2)]
+ │    │    │         └── variable: kv.v [type=int, outer=(2)]
+ │    │    └── aggregations [outer=(2)]
+ │    │         └── function: max [type=int, outer=(2)]
+ │    │              └── variable: kv.v [type=int, outer=(2)]
+ │    └── gt [type=bool, outer=(2)]
+ │         ├── variable: kv.v [type=int, outer=(2)]
  │         └── const: 5 [type=int]
- └── projections
-      └── variable: column5 [type=int]
+ └── projections [outer=(5)]
+      └── variable: column5 [type=int, outer=(5)]
 
 build
 SELECT SUM(kv.w) FROM kv GROUP BY LOWER(s) HAVING LOWER(kv.s) LIKE 'test%'
@@ -215,19 +215,19 @@ project
  │    │    │    ├── columns: column5:string:null:5 kv.w:int:null:3
  │    │    │    ├── scan
  │    │    │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
- │    │    │    └── projections
- │    │    │         ├── function: lower [type=string]
- │    │    │         │    └── variable: kv.s [type=string]
- │    │    │         └── variable: kv.w [type=int]
- │    │    └── aggregations
- │    │         └── function: sum [type=decimal]
- │    │              └── variable: column5 [type=string]
- │    └── like [type=bool]
- │         ├── function: lower [type=string]
- │         │    └── variable: kv.s [type=string]
+ │    │    │    └── projections [outer=(3,4)]
+ │    │    │         ├── function: lower [type=string, outer=(4)]
+ │    │    │         │    └── variable: kv.s [type=string, outer=(4)]
+ │    │    │         └── variable: kv.w [type=int, outer=(3)]
+ │    │    └── aggregations [outer=(5)]
+ │    │         └── function: sum [type=decimal, outer=(5)]
+ │    │              └── variable: column5 [type=string, outer=(5)]
+ │    └── like [type=bool, outer=(4)]
+ │         ├── function: lower [type=string, outer=(4)]
+ │         │    └── variable: kv.s [type=string, outer=(4)]
  │         └── const: 'test%' [type=string]
- └── projections
-      └── variable: column6 [type=decimal]
+ └── projections [outer=(6)]
+      └── variable: column6 [type=decimal, outer=(6)]
 
 build
 SELECT SUM(kv.w) FROM kv GROUP BY LOWER(s) HAVING SUM(w) IN (4, 5, 6)
@@ -243,21 +243,21 @@ project
  │    │    │    ├── columns: column5:string:null:5 kv.w:int:null:3
  │    │    │    ├── scan
  │    │    │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
- │    │    │    └── projections
- │    │    │         ├── function: lower [type=string]
- │    │    │         │    └── variable: kv.s [type=string]
- │    │    │         └── variable: kv.w [type=int]
- │    │    └── aggregations
- │    │         └── function: sum [type=decimal]
- │    │              └── variable: column5 [type=string]
- │    └── in [type=bool]
- │         ├── variable: column6 [type=decimal]
+ │    │    │    └── projections [outer=(3,4)]
+ │    │    │         ├── function: lower [type=string, outer=(4)]
+ │    │    │         │    └── variable: kv.s [type=string, outer=(4)]
+ │    │    │         └── variable: kv.w [type=int, outer=(3)]
+ │    │    └── aggregations [outer=(5)]
+ │    │         └── function: sum [type=decimal, outer=(5)]
+ │    │              └── variable: column5 [type=string, outer=(5)]
+ │    └── in [type=bool, outer=(6)]
+ │         ├── variable: column6 [type=decimal, outer=(6)]
  │         └── tuple [type=tuple{decimal, decimal, decimal}]
  │              ├── const: 4 [type=decimal]
  │              ├── const: 5 [type=decimal]
  │              └── const: 6 [type=decimal]
- └── projections
-      └── variable: column6 [type=decimal]
+ └── projections [outer=(6)]
+      └── variable: column6 [type=decimal, outer=(6)]
 
 build
 SELECT t.kv.v FROM t.kv GROUP BY v, kv.k * w HAVING k * kv.w > 5
@@ -273,19 +273,19 @@ project
  │    │    │    ├── columns: kv.v:int:null:2 column5:int:null:5
  │    │    │    ├── scan
  │    │    │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
- │    │    │    └── projections
- │    │    │         ├── variable: kv.v [type=int]
- │    │    │         └── mult [type=int]
- │    │    │              ├── variable: kv.k [type=int]
- │    │    │              └── variable: kv.w [type=int]
+ │    │    │    └── projections [outer=(1-3)]
+ │    │    │         ├── variable: kv.v [type=int, outer=(2)]
+ │    │    │         └── mult [type=int, outer=(1,3)]
+ │    │    │              ├── variable: kv.k [type=int, outer=(1)]
+ │    │    │              └── variable: kv.w [type=int, outer=(3)]
  │    │    └── aggregations
- │    └── gt [type=bool]
- │         ├── mult [type=int]
- │         │    ├── variable: kv.k [type=int]
- │         │    └── variable: kv.w [type=int]
+ │    └── gt [type=bool, outer=(1,3)]
+ │         ├── mult [type=int, outer=(1,3)]
+ │         │    ├── variable: kv.k [type=int, outer=(1)]
+ │         │    └── variable: kv.w [type=int, outer=(3)]
  │         └── const: 5 [type=int]
- └── projections
-      └── variable: kv.v [type=int]
+ └── projections [outer=(2)]
+      └── variable: kv.v [type=int, outer=(2)]
 
 build
 SELECT t.kv.v FROM t.kv GROUP BY v, kv.k * w HAVING w > 5

--- a/pkg/sql/opt/optbuilder/testdata/inner-join
+++ b/pkg/sql/opt/optbuilder/testdata/inner-join
@@ -40,11 +40,11 @@ project
  │    ├── scan
  │    │    └── columns: b.x:int:null:3 b.y:float:null:4 b.rowid:int:5
  │    └── true [type=bool]
- └── projections
-      ├── variable: a.x [type=int]
-      ├── variable: a.y [type=float]
-      ├── variable: b.x [type=int]
-      └── variable: b.y [type=float]
+ └── projections [outer=(1-4)]
+      ├── variable: a.x [type=int, outer=(1)]
+      ├── variable: a.y [type=float, outer=(2)]
+      ├── variable: b.x [type=int, outer=(3)]
+      └── variable: b.y [type=float, outer=(4)]
 
 build
 SELECT a.x, b.y FROM t.a, t.b WHERE a.x = b.x
@@ -60,12 +60,12 @@ project
  │    │    ├── scan
  │    │    │    └── columns: b.x:int:null:3 b.y:float:null:4 b.rowid:int:5
  │    │    └── true [type=bool]
- │    └── eq [type=bool]
- │         ├── variable: a.x [type=int]
- │         └── variable: b.x [type=int]
- └── projections
-      ├── variable: a.x [type=int]
-      └── variable: b.y [type=float]
+ │    └── eq [type=bool, outer=(1,3)]
+ │         ├── variable: a.x [type=int, outer=(1)]
+ │         └── variable: b.x [type=int, outer=(3)]
+ └── projections [outer=(1,4)]
+      ├── variable: a.x [type=int, outer=(1)]
+      └── variable: b.y [type=float, outer=(4)]
 
 build
 SELECT * FROM t.c, t.b, t.a WHERE c.x = a.x AND b.x = a.x
@@ -86,18 +86,18 @@ project
  │    │    ├── scan
  │    │    │    └── columns: a.x:int:8 a.y:float:null:9
  │    │    └── true [type=bool]
- │    └── and [type=bool]
- │         ├── eq [type=bool]
- │         │    ├── variable: c.x [type=int]
- │         │    └── variable: a.x [type=int]
- │         └── eq [type=bool]
- │              ├── variable: b.x [type=int]
- │              └── variable: a.x [type=int]
- └── projections
-      ├── variable: c.x [type=int]
-      ├── variable: c.y [type=float]
-      ├── variable: c.z [type=string]
-      ├── variable: b.x [type=int]
-      ├── variable: b.y [type=float]
-      ├── variable: a.x [type=int]
-      └── variable: a.y [type=float]
+ │    └── and [type=bool, outer=(1,5,8)]
+ │         ├── eq [type=bool, outer=(1,8)]
+ │         │    ├── variable: c.x [type=int, outer=(1)]
+ │         │    └── variable: a.x [type=int, outer=(8)]
+ │         └── eq [type=bool, outer=(5,8)]
+ │              ├── variable: b.x [type=int, outer=(5)]
+ │              └── variable: a.x [type=int, outer=(8)]
+ └── projections [outer=(1-3,5,6,8,9)]
+      ├── variable: c.x [type=int, outer=(1)]
+      ├── variable: c.y [type=float, outer=(2)]
+      ├── variable: c.z [type=string, outer=(3)]
+      ├── variable: b.x [type=int, outer=(5)]
+      ├── variable: b.y [type=float, outer=(6)]
+      ├── variable: a.x [type=int, outer=(8)]
+      └── variable: a.y [type=float, outer=(9)]

--- a/pkg/sql/opt/optbuilder/testdata/join
+++ b/pkg/sql/opt/optbuilder/testdata/join
@@ -27,9 +27,9 @@ project
  │    ├── scan
  │    │    └── columns: onecolumn.x:int:null:3 onecolumn.rowid:int:4
  │    └── true [type=bool]
- └── projections
-      ├── variable: onecolumn.x [type=int]
-      └── variable: onecolumn.x [type=int]
+ └── projections [outer=(1,3)]
+      ├── variable: onecolumn.x [type=int, outer=(1)]
+      └── variable: onecolumn.x [type=int, outer=(3)]
 
 # Check that name resolution chokes on ambiguity when it needs to.
 build
@@ -62,8 +62,8 @@ project
  │    ├── scan
  │    │    └── columns: onecolumn.x:int:null:4 onecolumn.rowid:int:5
  │    └── true [type=bool]
- └── projections
-      └── variable: x [type=int]
+ └── projections [outer=(1)]
+      └── variable: x [type=int, outer=(1)]
 
 build
 SELECT * FROM onecolumn AS a(x) JOIN onecolumn AS b(y) ON a.x = b.y
@@ -76,12 +76,12 @@ project
  │    │    └── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2
  │    ├── scan
  │    │    └── columns: onecolumn.x:int:null:3 onecolumn.rowid:int:4
- │    └── eq [type=bool]
- │         ├── variable: onecolumn.x [type=int]
- │         └── variable: onecolumn.x [type=int]
- └── projections
-      ├── variable: onecolumn.x [type=int]
-      └── variable: onecolumn.x [type=int]
+ │    └── eq [type=bool, outer=(1,3)]
+ │         ├── variable: onecolumn.x [type=int, outer=(1)]
+ │         └── variable: onecolumn.x [type=int, outer=(3)]
+ └── projections [outer=(1,3)]
+      ├── variable: onecolumn.x [type=int, outer=(1)]
+      └── variable: onecolumn.x [type=int, outer=(3)]
 
 build
 SELECT * FROM onecolumn AS a JOIN onecolumn as b USING(x)
@@ -94,11 +94,11 @@ project
  │    │    └── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2
  │    ├── scan
  │    │    └── columns: onecolumn.x:int:null:3 onecolumn.rowid:int:4
- │    └── eq [type=bool]
- │         ├── variable: onecolumn.x [type=int]
- │         └── variable: onecolumn.x [type=int]
- └── projections
-      └── variable: onecolumn.x [type=int]
+ │    └── eq [type=bool, outer=(1,3)]
+ │         ├── variable: onecolumn.x [type=int, outer=(1)]
+ │         └── variable: onecolumn.x [type=int, outer=(3)]
+ └── projections [outer=(1)]
+      └── variable: onecolumn.x [type=int, outer=(1)]
 
 build
 SELECT * FROM onecolumn AS a NATURAL JOIN onecolumn as b
@@ -111,11 +111,11 @@ project
  │    │    └── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2
  │    ├── scan
  │    │    └── columns: onecolumn.x:int:null:3 onecolumn.rowid:int:4
- │    └── eq [type=bool]
- │         ├── variable: onecolumn.x [type=int]
- │         └── variable: onecolumn.x [type=int]
- └── projections
-      └── variable: onecolumn.x [type=int]
+ │    └── eq [type=bool, outer=(1,3)]
+ │         ├── variable: onecolumn.x [type=int, outer=(1)]
+ │         └── variable: onecolumn.x [type=int, outer=(3)]
+ └── projections [outer=(1)]
+      └── variable: onecolumn.x [type=int, outer=(1)]
 
 build
 SELECT * FROM onecolumn AS a(x) LEFT OUTER JOIN onecolumn AS b(y) ON a.x = b.y
@@ -128,12 +128,12 @@ project
  │    │    └── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2
  │    ├── scan
  │    │    └── columns: onecolumn.x:int:null:3 onecolumn.rowid:int:4
- │    └── eq [type=bool]
- │         ├── variable: onecolumn.x [type=int]
- │         └── variable: onecolumn.x [type=int]
- └── projections
-      ├── variable: onecolumn.x [type=int]
-      └── variable: onecolumn.x [type=int]
+ │    └── eq [type=bool, outer=(1,3)]
+ │         ├── variable: onecolumn.x [type=int, outer=(1)]
+ │         └── variable: onecolumn.x [type=int, outer=(3)]
+ └── projections [outer=(1,3)]
+      ├── variable: onecolumn.x [type=int, outer=(1)]
+      └── variable: onecolumn.x [type=int, outer=(3)]
 
 build
 SELECT * FROM onecolumn AS a LEFT OUTER JOIN onecolumn AS b USING(x)
@@ -146,11 +146,11 @@ project
  │    │    └── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2
  │    ├── scan
  │    │    └── columns: onecolumn.x:int:null:3 onecolumn.rowid:int:4
- │    └── eq [type=bool]
- │         ├── variable: onecolumn.x [type=int]
- │         └── variable: onecolumn.x [type=int]
- └── projections
-      └── variable: onecolumn.x [type=int]
+ │    └── eq [type=bool, outer=(1,3)]
+ │         ├── variable: onecolumn.x [type=int, outer=(1)]
+ │         └── variable: onecolumn.x [type=int, outer=(3)]
+ └── projections [outer=(1)]
+      └── variable: onecolumn.x [type=int, outer=(1)]
 
 build
 SELECT * FROM onecolumn AS a NATURAL LEFT OUTER JOIN onecolumn AS b
@@ -163,11 +163,11 @@ project
  │    │    └── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2
  │    ├── scan
  │    │    └── columns: onecolumn.x:int:null:3 onecolumn.rowid:int:4
- │    └── eq [type=bool]
- │         ├── variable: onecolumn.x [type=int]
- │         └── variable: onecolumn.x [type=int]
- └── projections
-      └── variable: onecolumn.x [type=int]
+ │    └── eq [type=bool, outer=(1,3)]
+ │         ├── variable: onecolumn.x [type=int, outer=(1)]
+ │         └── variable: onecolumn.x [type=int, outer=(3)]
+ └── projections [outer=(1)]
+      └── variable: onecolumn.x [type=int, outer=(1)]
 
 build
 SELECT * FROM onecolumn AS a(x) RIGHT OUTER JOIN onecolumn AS b(y) ON a.x = b.y
@@ -180,12 +180,12 @@ project
  │    │    └── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2
  │    ├── scan
  │    │    └── columns: onecolumn.x:int:null:3 onecolumn.rowid:int:4
- │    └── eq [type=bool]
- │         ├── variable: onecolumn.x [type=int]
- │         └── variable: onecolumn.x [type=int]
- └── projections
-      ├── variable: onecolumn.x [type=int]
-      └── variable: onecolumn.x [type=int]
+ │    └── eq [type=bool, outer=(1,3)]
+ │         ├── variable: onecolumn.x [type=int, outer=(1)]
+ │         └── variable: onecolumn.x [type=int, outer=(3)]
+ └── projections [outer=(1,3)]
+      ├── variable: onecolumn.x [type=int, outer=(1)]
+      └── variable: onecolumn.x [type=int, outer=(3)]
 
 build
 SELECT * FROM onecolumn AS a RIGHT OUTER JOIN onecolumn AS b USING(x)
@@ -198,11 +198,11 @@ project
  │    │    └── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2
  │    ├── scan
  │    │    └── columns: onecolumn.x:int:null:3 onecolumn.rowid:int:4
- │    └── eq [type=bool]
- │         ├── variable: onecolumn.x [type=int]
- │         └── variable: onecolumn.x [type=int]
- └── projections
-      └── variable: onecolumn.x [type=int]
+ │    └── eq [type=bool, outer=(1,3)]
+ │         ├── variable: onecolumn.x [type=int, outer=(1)]
+ │         └── variable: onecolumn.x [type=int, outer=(3)]
+ └── projections [outer=(3)]
+      └── variable: onecolumn.x [type=int, outer=(3)]
 
 build
 SELECT * FROM onecolumn AS a NATURAL RIGHT OUTER JOIN onecolumn AS b
@@ -215,11 +215,11 @@ project
  │    │    └── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2
  │    ├── scan
  │    │    └── columns: onecolumn.x:int:null:3 onecolumn.rowid:int:4
- │    └── eq [type=bool]
- │         ├── variable: onecolumn.x [type=int]
- │         └── variable: onecolumn.x [type=int]
- └── projections
-      └── variable: onecolumn.x [type=int]
+ │    └── eq [type=bool, outer=(1,3)]
+ │         ├── variable: onecolumn.x [type=int, outer=(1)]
+ │         └── variable: onecolumn.x [type=int, outer=(3)]
+ └── projections [outer=(3)]
+      └── variable: onecolumn.x [type=int, outer=(3)]
 
 exec-ddl
 CREATE TABLE onecolumn_w(w INT)
@@ -242,9 +242,9 @@ project
  │    ├── scan
  │    │    └── columns: onecolumn_w.w:int:null:3 onecolumn_w.rowid:int:4
  │    └── true [type=bool]
- └── projections
-      ├── variable: onecolumn.x [type=int]
-      └── variable: onecolumn_w.w [type=int]
+ └── projections [outer=(1,3)]
+      ├── variable: onecolumn.x [type=int, outer=(1)]
+      └── variable: onecolumn_w.w [type=int, outer=(3)]
 
 exec-ddl
 CREATE TABLE othercolumn (x INT)
@@ -266,12 +266,12 @@ project
  │    │    └── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2
  │    ├── scan
  │    │    └── columns: othercolumn.x:int:null:3 othercolumn.rowid:int:4
- │    └── eq [type=bool]
- │         ├── variable: onecolumn.x [type=int]
- │         └── variable: othercolumn.x [type=int]
- └── projections
-      ├── variable: onecolumn.x [type=int]
-      └── variable: othercolumn.x [type=int]
+ │    └── eq [type=bool, outer=(1,3)]
+ │         ├── variable: onecolumn.x [type=int, outer=(1)]
+ │         └── variable: othercolumn.x [type=int, outer=(3)]
+ └── projections [outer=(1,3)]
+      ├── variable: onecolumn.x [type=int, outer=(1)]
+      └── variable: othercolumn.x [type=int, outer=(3)]
 
 build
 SELECT * FROM onecolumn AS a FULL OUTER JOIN othercolumn AS b USING(x)
@@ -286,19 +286,19 @@ project
  │    │    │    └── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2
  │    │    ├── scan
  │    │    │    └── columns: othercolumn.x:int:null:3 othercolumn.rowid:int:4
- │    │    └── eq [type=bool]
- │    │         ├── variable: onecolumn.x [type=int]
- │    │         └── variable: othercolumn.x [type=int]
- │    └── projections
- │         ├── coalesce [type=int]
- │         │    ├── variable: onecolumn.x [type=int]
- │         │    └── variable: othercolumn.x [type=int]
- │         ├── variable: onecolumn.x [type=int]
- │         ├── variable: onecolumn.rowid [type=int]
- │         ├── variable: othercolumn.x [type=int]
- │         └── variable: othercolumn.rowid [type=int]
- └── projections
-      └── variable: x [type=int]
+ │    │    └── eq [type=bool, outer=(1,3)]
+ │    │         ├── variable: onecolumn.x [type=int, outer=(1)]
+ │    │         └── variable: othercolumn.x [type=int, outer=(3)]
+ │    └── projections [outer=(1-4)]
+ │         ├── coalesce [type=int, outer=(1,3)]
+ │         │    ├── variable: onecolumn.x [type=int, outer=(1)]
+ │         │    └── variable: othercolumn.x [type=int, outer=(3)]
+ │         ├── variable: onecolumn.x [type=int, outer=(1)]
+ │         ├── variable: onecolumn.rowid [type=int, outer=(2)]
+ │         ├── variable: othercolumn.x [type=int, outer=(3)]
+ │         └── variable: othercolumn.rowid [type=int, outer=(4)]
+ └── projections [outer=(5)]
+      └── variable: x [type=int, outer=(5)]
 
 # Check that the source columns can be selected separately from the
 # USING column (#12033).
@@ -315,21 +315,21 @@ project
  │    │    │    └── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2
  │    │    ├── scan
  │    │    │    └── columns: othercolumn.x:int:null:3 othercolumn.rowid:int:4
- │    │    └── eq [type=bool]
- │    │         ├── variable: onecolumn.x [type=int]
- │    │         └── variable: othercolumn.x [type=int]
- │    └── projections
- │         ├── coalesce [type=int]
- │         │    ├── variable: onecolumn.x [type=int]
- │         │    └── variable: othercolumn.x [type=int]
- │         ├── variable: onecolumn.x [type=int]
- │         ├── variable: onecolumn.rowid [type=int]
- │         ├── variable: othercolumn.x [type=int]
- │         └── variable: othercolumn.rowid [type=int]
- └── projections
-      ├── variable: x [type=int]
-      ├── variable: onecolumn.x [type=int]
-      └── variable: othercolumn.x [type=int]
+ │    │    └── eq [type=bool, outer=(1,3)]
+ │    │         ├── variable: onecolumn.x [type=int, outer=(1)]
+ │    │         └── variable: othercolumn.x [type=int, outer=(3)]
+ │    └── projections [outer=(1-4)]
+ │         ├── coalesce [type=int, outer=(1,3)]
+ │         │    ├── variable: onecolumn.x [type=int, outer=(1)]
+ │         │    └── variable: othercolumn.x [type=int, outer=(3)]
+ │         ├── variable: onecolumn.x [type=int, outer=(1)]
+ │         ├── variable: onecolumn.rowid [type=int, outer=(2)]
+ │         ├── variable: othercolumn.x [type=int, outer=(3)]
+ │         └── variable: othercolumn.rowid [type=int, outer=(4)]
+ └── projections [outer=(1,3,5)]
+      ├── variable: x [type=int, outer=(5)]
+      ├── variable: onecolumn.x [type=int, outer=(1)]
+      └── variable: othercolumn.x [type=int, outer=(3)]
 
 build
 SELECT * FROM onecolumn AS a NATURAL FULL OUTER JOIN othercolumn AS b
@@ -344,19 +344,19 @@ project
  │    │    │    └── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2
  │    │    ├── scan
  │    │    │    └── columns: othercolumn.x:int:null:3 othercolumn.rowid:int:4
- │    │    └── eq [type=bool]
- │    │         ├── variable: onecolumn.x [type=int]
- │    │         └── variable: othercolumn.x [type=int]
- │    └── projections
- │         ├── coalesce [type=int]
- │         │    ├── variable: onecolumn.x [type=int]
- │         │    └── variable: othercolumn.x [type=int]
- │         ├── variable: onecolumn.x [type=int]
- │         ├── variable: onecolumn.rowid [type=int]
- │         ├── variable: othercolumn.x [type=int]
- │         └── variable: othercolumn.rowid [type=int]
- └── projections
-      └── variable: x [type=int]
+ │    │    └── eq [type=bool, outer=(1,3)]
+ │    │         ├── variable: onecolumn.x [type=int, outer=(1)]
+ │    │         └── variable: othercolumn.x [type=int, outer=(3)]
+ │    └── projections [outer=(1-4)]
+ │         ├── coalesce [type=int, outer=(1,3)]
+ │         │    ├── variable: onecolumn.x [type=int, outer=(1)]
+ │         │    └── variable: othercolumn.x [type=int, outer=(3)]
+ │         ├── variable: onecolumn.x [type=int, outer=(1)]
+ │         ├── variable: onecolumn.rowid [type=int, outer=(2)]
+ │         ├── variable: othercolumn.x [type=int, outer=(3)]
+ │         └── variable: othercolumn.rowid [type=int, outer=(4)]
+ └── projections [outer=(5)]
+      └── variable: x [type=int, outer=(5)]
 
 exec-ddl
 CREATE TABLE empty (x INT)
@@ -379,9 +379,9 @@ project
  │    ├── scan
  │    │    └── columns: empty.x:int:null:3 empty.rowid:int:4
  │    └── true [type=bool]
- └── projections
-      ├── variable: onecolumn.x [type=int]
-      └── variable: empty.x [type=int]
+ └── projections [outer=(1,3)]
+      ├── variable: onecolumn.x [type=int, outer=(1)]
+      └── variable: empty.x [type=int, outer=(3)]
 
 build
 SELECT * FROM empty AS a CROSS JOIN onecolumn AS b
@@ -395,9 +395,9 @@ project
  │    ├── scan
  │    │    └── columns: onecolumn.x:int:null:3 onecolumn.rowid:int:4
  │    └── true [type=bool]
- └── projections
-      ├── variable: empty.x [type=int]
-      └── variable: onecolumn.x [type=int]
+ └── projections [outer=(1,3)]
+      ├── variable: empty.x [type=int, outer=(1)]
+      └── variable: onecolumn.x [type=int, outer=(3)]
 
 build
 SELECT * FROM onecolumn AS a(x) JOIN empty AS b(y) ON a.x = b.y
@@ -410,12 +410,12 @@ project
  │    │    └── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2
  │    ├── scan
  │    │    └── columns: empty.x:int:null:3 empty.rowid:int:4
- │    └── eq [type=bool]
- │         ├── variable: onecolumn.x [type=int]
- │         └── variable: empty.x [type=int]
- └── projections
-      ├── variable: onecolumn.x [type=int]
-      └── variable: empty.x [type=int]
+ │    └── eq [type=bool, outer=(1,3)]
+ │         ├── variable: onecolumn.x [type=int, outer=(1)]
+ │         └── variable: empty.x [type=int, outer=(3)]
+ └── projections [outer=(1,3)]
+      ├── variable: onecolumn.x [type=int, outer=(1)]
+      └── variable: empty.x [type=int, outer=(3)]
 
 build
 SELECT * FROM onecolumn AS a JOIN empty AS b USING(x)
@@ -428,11 +428,11 @@ project
  │    │    └── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2
  │    ├── scan
  │    │    └── columns: empty.x:int:null:3 empty.rowid:int:4
- │    └── eq [type=bool]
- │         ├── variable: onecolumn.x [type=int]
- │         └── variable: empty.x [type=int]
- └── projections
-      └── variable: onecolumn.x [type=int]
+ │    └── eq [type=bool, outer=(1,3)]
+ │         ├── variable: onecolumn.x [type=int, outer=(1)]
+ │         └── variable: empty.x [type=int, outer=(3)]
+ └── projections [outer=(1)]
+      └── variable: onecolumn.x [type=int, outer=(1)]
 
 build
 SELECT * FROM empty AS a(x) JOIN onecolumn AS b(y) ON a.x = b.y
@@ -445,12 +445,12 @@ project
  │    │    └── columns: empty.x:int:null:1 empty.rowid:int:2
  │    ├── scan
  │    │    └── columns: onecolumn.x:int:null:3 onecolumn.rowid:int:4
- │    └── eq [type=bool]
- │         ├── variable: empty.x [type=int]
- │         └── variable: onecolumn.x [type=int]
- └── projections
-      ├── variable: empty.x [type=int]
-      └── variable: onecolumn.x [type=int]
+ │    └── eq [type=bool, outer=(1,3)]
+ │         ├── variable: empty.x [type=int, outer=(1)]
+ │         └── variable: onecolumn.x [type=int, outer=(3)]
+ └── projections [outer=(1,3)]
+      ├── variable: empty.x [type=int, outer=(1)]
+      └── variable: onecolumn.x [type=int, outer=(3)]
 
 build
 SELECT * FROM empty AS a JOIN onecolumn AS b USING(x)
@@ -463,11 +463,11 @@ project
  │    │    └── columns: empty.x:int:null:1 empty.rowid:int:2
  │    ├── scan
  │    │    └── columns: onecolumn.x:int:null:3 onecolumn.rowid:int:4
- │    └── eq [type=bool]
- │         ├── variable: empty.x [type=int]
- │         └── variable: onecolumn.x [type=int]
- └── projections
-      └── variable: empty.x [type=int]
+ │    └── eq [type=bool, outer=(1,3)]
+ │         ├── variable: empty.x [type=int, outer=(1)]
+ │         └── variable: onecolumn.x [type=int, outer=(3)]
+ └── projections [outer=(1)]
+      └── variable: empty.x [type=int, outer=(1)]
 
 build
 SELECT * FROM onecolumn AS a(x) LEFT OUTER JOIN empty AS b(y) ON a.x = b.y
@@ -480,12 +480,12 @@ project
  │    │    └── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2
  │    ├── scan
  │    │    └── columns: empty.x:int:null:3 empty.rowid:int:4
- │    └── eq [type=bool]
- │         ├── variable: onecolumn.x [type=int]
- │         └── variable: empty.x [type=int]
- └── projections
-      ├── variable: onecolumn.x [type=int]
-      └── variable: empty.x [type=int]
+ │    └── eq [type=bool, outer=(1,3)]
+ │         ├── variable: onecolumn.x [type=int, outer=(1)]
+ │         └── variable: empty.x [type=int, outer=(3)]
+ └── projections [outer=(1,3)]
+      ├── variable: onecolumn.x [type=int, outer=(1)]
+      └── variable: empty.x [type=int, outer=(3)]
 
 build
 SELECT * FROM onecolumn AS a LEFT OUTER JOIN empty AS b USING(x)
@@ -498,11 +498,11 @@ project
  │    │    └── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2
  │    ├── scan
  │    │    └── columns: empty.x:int:null:3 empty.rowid:int:4
- │    └── eq [type=bool]
- │         ├── variable: onecolumn.x [type=int]
- │         └── variable: empty.x [type=int]
- └── projections
-      └── variable: onecolumn.x [type=int]
+ │    └── eq [type=bool, outer=(1,3)]
+ │         ├── variable: onecolumn.x [type=int, outer=(1)]
+ │         └── variable: empty.x [type=int, outer=(3)]
+ └── projections [outer=(1)]
+      └── variable: onecolumn.x [type=int, outer=(1)]
 
 build
 SELECT * FROM empty AS a(x) LEFT OUTER JOIN onecolumn AS b(y) ON a.x = b.y
@@ -515,12 +515,12 @@ project
  │    │    └── columns: empty.x:int:null:1 empty.rowid:int:2
  │    ├── scan
  │    │    └── columns: onecolumn.x:int:null:3 onecolumn.rowid:int:4
- │    └── eq [type=bool]
- │         ├── variable: empty.x [type=int]
- │         └── variable: onecolumn.x [type=int]
- └── projections
-      ├── variable: empty.x [type=int]
-      └── variable: onecolumn.x [type=int]
+ │    └── eq [type=bool, outer=(1,3)]
+ │         ├── variable: empty.x [type=int, outer=(1)]
+ │         └── variable: onecolumn.x [type=int, outer=(3)]
+ └── projections [outer=(1,3)]
+      ├── variable: empty.x [type=int, outer=(1)]
+      └── variable: onecolumn.x [type=int, outer=(3)]
 
 build
 SELECT * FROM empty AS a LEFT OUTER JOIN onecolumn AS b USING(x)
@@ -533,11 +533,11 @@ project
  │    │    └── columns: empty.x:int:null:1 empty.rowid:int:2
  │    ├── scan
  │    │    └── columns: onecolumn.x:int:null:3 onecolumn.rowid:int:4
- │    └── eq [type=bool]
- │         ├── variable: empty.x [type=int]
- │         └── variable: onecolumn.x [type=int]
- └── projections
-      └── variable: empty.x [type=int]
+ │    └── eq [type=bool, outer=(1,3)]
+ │         ├── variable: empty.x [type=int, outer=(1)]
+ │         └── variable: onecolumn.x [type=int, outer=(3)]
+ └── projections [outer=(1)]
+      └── variable: empty.x [type=int, outer=(1)]
 
 build
 SELECT * FROM onecolumn AS a(x) RIGHT OUTER JOIN empty AS b(y) ON a.x = b.y
@@ -550,12 +550,12 @@ project
  │    │    └── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2
  │    ├── scan
  │    │    └── columns: empty.x:int:null:3 empty.rowid:int:4
- │    └── eq [type=bool]
- │         ├── variable: onecolumn.x [type=int]
- │         └── variable: empty.x [type=int]
- └── projections
-      ├── variable: onecolumn.x [type=int]
-      └── variable: empty.x [type=int]
+ │    └── eq [type=bool, outer=(1,3)]
+ │         ├── variable: onecolumn.x [type=int, outer=(1)]
+ │         └── variable: empty.x [type=int, outer=(3)]
+ └── projections [outer=(1,3)]
+      ├── variable: onecolumn.x [type=int, outer=(1)]
+      └── variable: empty.x [type=int, outer=(3)]
 
 build
 SELECT * FROM onecolumn AS a RIGHT OUTER JOIN empty AS b USING(x)
@@ -568,11 +568,11 @@ project
  │    │    └── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2
  │    ├── scan
  │    │    └── columns: empty.x:int:null:3 empty.rowid:int:4
- │    └── eq [type=bool]
- │         ├── variable: onecolumn.x [type=int]
- │         └── variable: empty.x [type=int]
- └── projections
-      └── variable: empty.x [type=int]
+ │    └── eq [type=bool, outer=(1,3)]
+ │         ├── variable: onecolumn.x [type=int, outer=(1)]
+ │         └── variable: empty.x [type=int, outer=(3)]
+ └── projections [outer=(3)]
+      └── variable: empty.x [type=int, outer=(3)]
 
 build
 SELECT * FROM empty AS a(x) FULL OUTER JOIN onecolumn AS b(y) ON a.x = b.y
@@ -585,12 +585,12 @@ project
  │    │    └── columns: empty.x:int:null:1 empty.rowid:int:2
  │    ├── scan
  │    │    └── columns: onecolumn.x:int:null:3 onecolumn.rowid:int:4
- │    └── eq [type=bool]
- │         ├── variable: empty.x [type=int]
- │         └── variable: onecolumn.x [type=int]
- └── projections
-      ├── variable: empty.x [type=int]
-      └── variable: onecolumn.x [type=int]
+ │    └── eq [type=bool, outer=(1,3)]
+ │         ├── variable: empty.x [type=int, outer=(1)]
+ │         └── variable: onecolumn.x [type=int, outer=(3)]
+ └── projections [outer=(1,3)]
+      ├── variable: empty.x [type=int, outer=(1)]
+      └── variable: onecolumn.x [type=int, outer=(3)]
 
 build
 SELECT * FROM empty AS a FULL OUTER JOIN onecolumn AS b USING(x)
@@ -605,19 +605,19 @@ project
  │    │    │    └── columns: empty.x:int:null:1 empty.rowid:int:2
  │    │    ├── scan
  │    │    │    └── columns: onecolumn.x:int:null:3 onecolumn.rowid:int:4
- │    │    └── eq [type=bool]
- │    │         ├── variable: empty.x [type=int]
- │    │         └── variable: onecolumn.x [type=int]
- │    └── projections
- │         ├── coalesce [type=int]
- │         │    ├── variable: empty.x [type=int]
- │         │    └── variable: onecolumn.x [type=int]
- │         ├── variable: empty.x [type=int]
- │         ├── variable: empty.rowid [type=int]
- │         ├── variable: onecolumn.x [type=int]
- │         └── variable: onecolumn.rowid [type=int]
- └── projections
-      └── variable: x [type=int]
+ │    │    └── eq [type=bool, outer=(1,3)]
+ │    │         ├── variable: empty.x [type=int, outer=(1)]
+ │    │         └── variable: onecolumn.x [type=int, outer=(3)]
+ │    └── projections [outer=(1-4)]
+ │         ├── coalesce [type=int, outer=(1,3)]
+ │         │    ├── variable: empty.x [type=int, outer=(1)]
+ │         │    └── variable: onecolumn.x [type=int, outer=(3)]
+ │         ├── variable: empty.x [type=int, outer=(1)]
+ │         ├── variable: empty.rowid [type=int, outer=(2)]
+ │         ├── variable: onecolumn.x [type=int, outer=(3)]
+ │         └── variable: onecolumn.rowid [type=int, outer=(4)]
+ └── projections [outer=(5)]
+      └── variable: x [type=int, outer=(5)]
 
 build
 SELECT * FROM onecolumn AS a(x) FULL OUTER JOIN empty AS b(y) ON a.x = b.y
@@ -630,12 +630,12 @@ project
  │    │    └── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2
  │    ├── scan
  │    │    └── columns: empty.x:int:null:3 empty.rowid:int:4
- │    └── eq [type=bool]
- │         ├── variable: onecolumn.x [type=int]
- │         └── variable: empty.x [type=int]
- └── projections
-      ├── variable: onecolumn.x [type=int]
-      └── variable: empty.x [type=int]
+ │    └── eq [type=bool, outer=(1,3)]
+ │         ├── variable: onecolumn.x [type=int, outer=(1)]
+ │         └── variable: empty.x [type=int, outer=(3)]
+ └── projections [outer=(1,3)]
+      ├── variable: onecolumn.x [type=int, outer=(1)]
+      └── variable: empty.x [type=int, outer=(3)]
 
 build
 SELECT * FROM onecolumn AS a FULL OUTER JOIN empty AS b USING(x)
@@ -650,19 +650,19 @@ project
  │    │    │    └── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2
  │    │    ├── scan
  │    │    │    └── columns: empty.x:int:null:3 empty.rowid:int:4
- │    │    └── eq [type=bool]
- │    │         ├── variable: onecolumn.x [type=int]
- │    │         └── variable: empty.x [type=int]
- │    └── projections
- │         ├── coalesce [type=int]
- │         │    ├── variable: onecolumn.x [type=int]
- │         │    └── variable: empty.x [type=int]
- │         ├── variable: onecolumn.x [type=int]
- │         ├── variable: onecolumn.rowid [type=int]
- │         ├── variable: empty.x [type=int]
- │         └── variable: empty.rowid [type=int]
- └── projections
-      └── variable: x [type=int]
+ │    │    └── eq [type=bool, outer=(1,3)]
+ │    │         ├── variable: onecolumn.x [type=int, outer=(1)]
+ │    │         └── variable: empty.x [type=int, outer=(3)]
+ │    └── projections [outer=(1-4)]
+ │         ├── coalesce [type=int, outer=(1,3)]
+ │         │    ├── variable: onecolumn.x [type=int, outer=(1)]
+ │         │    └── variable: empty.x [type=int, outer=(3)]
+ │         ├── variable: onecolumn.x [type=int, outer=(1)]
+ │         ├── variable: onecolumn.rowid [type=int, outer=(2)]
+ │         ├── variable: empty.x [type=int, outer=(3)]
+ │         └── variable: empty.rowid [type=int, outer=(4)]
+ └── projections [outer=(5)]
+      └── variable: x [type=int, outer=(5)]
 
 exec-ddl
 CREATE TABLE twocolumn (x INT, y INT)
@@ -686,12 +686,12 @@ project
  │    │    └── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2
  │    ├── scan
  │    │    └── columns: twocolumn.x:int:null:3 twocolumn.y:int:null:4 twocolumn.rowid:int:5
- │    └── eq [type=bool]
- │         ├── variable: onecolumn.x [type=int]
- │         └── variable: twocolumn.x [type=int]
- └── projections
-      ├── variable: onecolumn.x [type=int]
-      └── variable: twocolumn.y [type=int]
+ │    └── eq [type=bool, outer=(1,3)]
+ │         ├── variable: onecolumn.x [type=int, outer=(1)]
+ │         └── variable: twocolumn.x [type=int, outer=(3)]
+ └── projections [outer=(1,4)]
+      ├── variable: onecolumn.x [type=int, outer=(1)]
+      └── variable: twocolumn.y [type=int, outer=(4)]
 
 build
 SELECT * FROM onecolumn JOIN twocolumn USING(x)
@@ -704,12 +704,12 @@ project
  │    │    └── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2
  │    ├── scan
  │    │    └── columns: twocolumn.x:int:null:3 twocolumn.y:int:null:4 twocolumn.rowid:int:5
- │    └── eq [type=bool]
- │         ├── variable: onecolumn.x [type=int]
- │         └── variable: twocolumn.x [type=int]
- └── projections
-      ├── variable: onecolumn.x [type=int]
-      └── variable: twocolumn.y [type=int]
+ │    └── eq [type=bool, outer=(1,3)]
+ │         ├── variable: onecolumn.x [type=int, outer=(1)]
+ │         └── variable: twocolumn.x [type=int, outer=(3)]
+ └── projections [outer=(1,4)]
+      ├── variable: onecolumn.x [type=int, outer=(1)]
+      └── variable: twocolumn.y [type=int, outer=(4)]
 
 build
 SELECT * FROM twocolumn AS a JOIN twocolumn AS b ON a.x = b.y
@@ -722,14 +722,14 @@ project
  │    │    └── columns: twocolumn.x:int:null:1 twocolumn.y:int:null:2 twocolumn.rowid:int:3
  │    ├── scan
  │    │    └── columns: twocolumn.x:int:null:4 twocolumn.y:int:null:5 twocolumn.rowid:int:6
- │    └── eq [type=bool]
- │         ├── variable: twocolumn.x [type=int]
- │         └── variable: twocolumn.y [type=int]
- └── projections
-      ├── variable: twocolumn.x [type=int]
-      ├── variable: twocolumn.y [type=int]
-      ├── variable: twocolumn.x [type=int]
-      └── variable: twocolumn.y [type=int]
+ │    └── eq [type=bool, outer=(1,5)]
+ │         ├── variable: twocolumn.x [type=int, outer=(1)]
+ │         └── variable: twocolumn.y [type=int, outer=(5)]
+ └── projections [outer=(1,2,4,5)]
+      ├── variable: twocolumn.x [type=int, outer=(1)]
+      ├── variable: twocolumn.y [type=int, outer=(2)]
+      ├── variable: twocolumn.x [type=int, outer=(4)]
+      └── variable: twocolumn.y [type=int, outer=(5)]
 
 build
 SELECT * FROM twocolumn AS a JOIN twocolumn AS b ON a.x = a.y
@@ -742,14 +742,14 @@ project
  │    │    └── columns: twocolumn.x:int:null:1 twocolumn.y:int:null:2 twocolumn.rowid:int:3
  │    ├── scan
  │    │    └── columns: twocolumn.x:int:null:4 twocolumn.y:int:null:5 twocolumn.rowid:int:6
- │    └── eq [type=bool]
- │         ├── variable: twocolumn.x [type=int]
- │         └── variable: twocolumn.y [type=int]
- └── projections
-      ├── variable: twocolumn.x [type=int]
-      ├── variable: twocolumn.y [type=int]
-      ├── variable: twocolumn.x [type=int]
-      └── variable: twocolumn.y [type=int]
+ │    └── eq [type=bool, outer=(1,2)]
+ │         ├── variable: twocolumn.x [type=int, outer=(1)]
+ │         └── variable: twocolumn.y [type=int, outer=(2)]
+ └── projections [outer=(1,2,4,5)]
+      ├── variable: twocolumn.x [type=int, outer=(1)]
+      ├── variable: twocolumn.y [type=int, outer=(2)]
+      ├── variable: twocolumn.x [type=int, outer=(4)]
+      └── variable: twocolumn.y [type=int, outer=(5)]
 
 build
 SELECT * FROM onecolumn AS a JOIN twocolumn AS b ON ((a.x)) = ((b.y))
@@ -762,13 +762,13 @@ project
  │    │    └── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2
  │    ├── scan
  │    │    └── columns: twocolumn.x:int:null:3 twocolumn.y:int:null:4 twocolumn.rowid:int:5
- │    └── eq [type=bool]
- │         ├── variable: onecolumn.x [type=int]
- │         └── variable: twocolumn.y [type=int]
- └── projections
-      ├── variable: onecolumn.x [type=int]
-      ├── variable: twocolumn.x [type=int]
-      └── variable: twocolumn.y [type=int]
+ │    └── eq [type=bool, outer=(1,4)]
+ │         ├── variable: onecolumn.x [type=int, outer=(1)]
+ │         └── variable: twocolumn.y [type=int, outer=(4)]
+ └── projections [outer=(1,3,4)]
+      ├── variable: onecolumn.x [type=int, outer=(1)]
+      ├── variable: twocolumn.x [type=int, outer=(3)]
+      └── variable: twocolumn.y [type=int, outer=(4)]
 
 build
 SELECT * FROM onecolumn JOIN twocolumn ON onecolumn.x = twocolumn.y
@@ -781,13 +781,13 @@ project
  │    │    └── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2
  │    ├── scan
  │    │    └── columns: twocolumn.x:int:null:3 twocolumn.y:int:null:4 twocolumn.rowid:int:5
- │    └── eq [type=bool]
- │         ├── variable: onecolumn.x [type=int]
- │         └── variable: twocolumn.y [type=int]
- └── projections
-      ├── variable: onecolumn.x [type=int]
-      ├── variable: twocolumn.x [type=int]
-      └── variable: twocolumn.y [type=int]
+ │    └── eq [type=bool, outer=(1,4)]
+ │         ├── variable: onecolumn.x [type=int, outer=(1)]
+ │         └── variable: twocolumn.y [type=int, outer=(4)]
+ └── projections [outer=(1,3,4)]
+      ├── variable: onecolumn.x [type=int, outer=(1)]
+      ├── variable: twocolumn.x [type=int, outer=(3)]
+      └── variable: twocolumn.y [type=int, outer=(4)]
 
 # Inner join with filter predicate
 build
@@ -801,14 +801,14 @@ project
  │    │    └── columns: twocolumn.x:int:null:1 twocolumn.y:int:null:2 twocolumn.rowid:int:3
  │    ├── scan
  │    │    └── columns: twocolumn.x:int:null:4 twocolumn.y:int:null:5 twocolumn.rowid:int:6
- │    └── eq [type=bool]
- │         ├── variable: twocolumn.x [type=int]
+ │    └── eq [type=bool, outer=(1)]
+ │         ├── variable: twocolumn.x [type=int, outer=(1)]
  │         └── const: 44 [type=int]
- └── projections
-      ├── variable: twocolumn.x [type=int]
-      ├── variable: twocolumn.y [type=int]
-      ├── variable: twocolumn.x [type=int]
-      └── variable: twocolumn.y [type=int]
+ └── projections [outer=(1,2,4,5)]
+      ├── variable: twocolumn.x [type=int, outer=(1)]
+      ├── variable: twocolumn.y [type=int, outer=(2)]
+      ├── variable: twocolumn.x [type=int, outer=(4)]
+      └── variable: twocolumn.y [type=int, outer=(5)]
 
 build
 SELECT o.x, t.y FROM onecolumn o INNER JOIN twocolumn t ON (o.x=t.x AND t.y=53)
@@ -821,16 +821,16 @@ project
  │    │    └── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2
  │    ├── scan
  │    │    └── columns: twocolumn.x:int:null:3 twocolumn.y:int:null:4 twocolumn.rowid:int:5
- │    └── and [type=bool]
- │         ├── eq [type=bool]
- │         │    ├── variable: onecolumn.x [type=int]
- │         │    └── variable: twocolumn.x [type=int]
- │         └── eq [type=bool]
- │              ├── variable: twocolumn.y [type=int]
+ │    └── and [type=bool, outer=(1,3,4)]
+ │         ├── eq [type=bool, outer=(1,3)]
+ │         │    ├── variable: onecolumn.x [type=int, outer=(1)]
+ │         │    └── variable: twocolumn.x [type=int, outer=(3)]
+ │         └── eq [type=bool, outer=(4)]
+ │              ├── variable: twocolumn.y [type=int, outer=(4)]
  │              └── const: 53 [type=int]
- └── projections
-      ├── variable: onecolumn.x [type=int]
-      └── variable: twocolumn.y [type=int]
+ └── projections [outer=(1,4)]
+      ├── variable: onecolumn.x [type=int, outer=(1)]
+      └── variable: twocolumn.y [type=int, outer=(4)]
 
 # Outer joins with filter predicate
 build
@@ -844,16 +844,16 @@ project
  │    │    └── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2
  │    ├── scan
  │    │    └── columns: twocolumn.x:int:null:3 twocolumn.y:int:null:4 twocolumn.rowid:int:5
- │    └── and [type=bool]
- │         ├── eq [type=bool]
- │         │    ├── variable: onecolumn.x [type=int]
- │         │    └── variable: twocolumn.x [type=int]
- │         └── eq [type=bool]
- │              ├── variable: twocolumn.y [type=int]
+ │    └── and [type=bool, outer=(1,3,4)]
+ │         ├── eq [type=bool, outer=(1,3)]
+ │         │    ├── variable: onecolumn.x [type=int, outer=(1)]
+ │         │    └── variable: twocolumn.x [type=int, outer=(3)]
+ │         └── eq [type=bool, outer=(4)]
+ │              ├── variable: twocolumn.y [type=int, outer=(4)]
  │              └── const: 53 [type=int]
- └── projections
-      ├── variable: onecolumn.x [type=int]
-      └── variable: twocolumn.y [type=int]
+ └── projections [outer=(1,4)]
+      ├── variable: onecolumn.x [type=int, outer=(1)]
+      └── variable: twocolumn.y [type=int, outer=(4)]
 
 build
 SELECT o.x, t.y FROM onecolumn o LEFT OUTER JOIN twocolumn t ON (o.x=t.x AND o.x=44)
@@ -866,16 +866,16 @@ project
  │    │    └── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2
  │    ├── scan
  │    │    └── columns: twocolumn.x:int:null:3 twocolumn.y:int:null:4 twocolumn.rowid:int:5
- │    └── and [type=bool]
- │         ├── eq [type=bool]
- │         │    ├── variable: onecolumn.x [type=int]
- │         │    └── variable: twocolumn.x [type=int]
- │         └── eq [type=bool]
- │              ├── variable: onecolumn.x [type=int]
+ │    └── and [type=bool, outer=(1,3)]
+ │         ├── eq [type=bool, outer=(1,3)]
+ │         │    ├── variable: onecolumn.x [type=int, outer=(1)]
+ │         │    └── variable: twocolumn.x [type=int, outer=(3)]
+ │         └── eq [type=bool, outer=(1)]
+ │              ├── variable: onecolumn.x [type=int, outer=(1)]
  │              └── const: 44 [type=int]
- └── projections
-      ├── variable: onecolumn.x [type=int]
-      └── variable: twocolumn.y [type=int]
+ └── projections [outer=(1,4)]
+      ├── variable: onecolumn.x [type=int, outer=(1)]
+      └── variable: twocolumn.y [type=int, outer=(4)]
 
 build
 SELECT o.x, t.y FROM onecolumn o LEFT OUTER JOIN twocolumn t ON (o.x=t.x AND t.x=44)
@@ -888,16 +888,16 @@ project
  │    │    └── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2
  │    ├── scan
  │    │    └── columns: twocolumn.x:int:null:3 twocolumn.y:int:null:4 twocolumn.rowid:int:5
- │    └── and [type=bool]
- │         ├── eq [type=bool]
- │         │    ├── variable: onecolumn.x [type=int]
- │         │    └── variable: twocolumn.x [type=int]
- │         └── eq [type=bool]
- │              ├── variable: twocolumn.x [type=int]
+ │    └── and [type=bool, outer=(1,3)]
+ │         ├── eq [type=bool, outer=(1,3)]
+ │         │    ├── variable: onecolumn.x [type=int, outer=(1)]
+ │         │    └── variable: twocolumn.x [type=int, outer=(3)]
+ │         └── eq [type=bool, outer=(3)]
+ │              ├── variable: twocolumn.x [type=int, outer=(3)]
  │              └── const: 44 [type=int]
- └── projections
-      ├── variable: onecolumn.x [type=int]
-      └── variable: twocolumn.y [type=int]
+ └── projections [outer=(1,4)]
+      ├── variable: onecolumn.x [type=int, outer=(1)]
+      └── variable: twocolumn.y [type=int, outer=(4)]
 
 build
 SELECT x, a.x, b.y FROM (SELECT * FROM onecolumn AS a NATURAL JOIN twocolumn AS b) AS q
@@ -942,13 +942,13 @@ project
  │    │    └── columns: a.i:int:null:1 a.rowid:int:2
  │    ├── scan
  │    │    └── columns: b.i:int:null:3 b.b:bool:null:4 b.rowid:int:5
- │    └── eq [type=bool]
- │         ├── variable: a.i [type=int]
- │         └── variable: b.i [type=int]
- └── projections
-      ├── variable: a.i [type=int]
-      ├── variable: b.i [type=int]
-      └── variable: b.b [type=bool]
+ │    └── eq [type=bool, outer=(1,3)]
+ │         ├── variable: a.i [type=int, outer=(1)]
+ │         └── variable: b.i [type=int, outer=(3)]
+ └── projections [outer=(1,3,4)]
+      ├── variable: a.i [type=int, outer=(1)]
+      ├── variable: b.i [type=int, outer=(3)]
+      └── variable: b.b [type=bool, outer=(4)]
 
 build
 SELECT * FROM a LEFT OUTER JOIN b ON a.i = b.i
@@ -961,13 +961,13 @@ project
  │    │    └── columns: a.i:int:null:1 a.rowid:int:2
  │    ├── scan
  │    │    └── columns: b.i:int:null:3 b.b:bool:null:4 b.rowid:int:5
- │    └── eq [type=bool]
- │         ├── variable: a.i [type=int]
- │         └── variable: b.i [type=int]
- └── projections
-      ├── variable: a.i [type=int]
-      ├── variable: b.i [type=int]
-      └── variable: b.b [type=bool]
+ │    └── eq [type=bool, outer=(1,3)]
+ │         ├── variable: a.i [type=int, outer=(1)]
+ │         └── variable: b.i [type=int, outer=(3)]
+ └── projections [outer=(1,3,4)]
+      ├── variable: a.i [type=int, outer=(1)]
+      ├── variable: b.i [type=int, outer=(3)]
+      └── variable: b.b [type=bool, outer=(4)]
 
 build
 SELECT * FROM a RIGHT OUTER JOIN b ON a.i = b.i
@@ -980,13 +980,13 @@ project
  │    │    └── columns: a.i:int:null:1 a.rowid:int:2
  │    ├── scan
  │    │    └── columns: b.i:int:null:3 b.b:bool:null:4 b.rowid:int:5
- │    └── eq [type=bool]
- │         ├── variable: a.i [type=int]
- │         └── variable: b.i [type=int]
- └── projections
-      ├── variable: a.i [type=int]
-      ├── variable: b.i [type=int]
-      └── variable: b.b [type=bool]
+ │    └── eq [type=bool, outer=(1,3)]
+ │         ├── variable: a.i [type=int, outer=(1)]
+ │         └── variable: b.i [type=int, outer=(3)]
+ └── projections [outer=(1,3,4)]
+      ├── variable: a.i [type=int, outer=(1)]
+      ├── variable: b.i [type=int, outer=(3)]
+      └── variable: b.b [type=bool, outer=(4)]
 
 build
 SELECT * FROM a FULL OUTER JOIN b ON a.i = b.i
@@ -999,13 +999,13 @@ project
  │    │    └── columns: a.i:int:null:1 a.rowid:int:2
  │    ├── scan
  │    │    └── columns: b.i:int:null:3 b.b:bool:null:4 b.rowid:int:5
- │    └── eq [type=bool]
- │         ├── variable: a.i [type=int]
- │         └── variable: b.i [type=int]
- └── projections
-      ├── variable: a.i [type=int]
-      ├── variable: b.i [type=int]
-      └── variable: b.b [type=bool]
+ │    └── eq [type=bool, outer=(1,3)]
+ │         ├── variable: a.i [type=int, outer=(1)]
+ │         └── variable: b.i [type=int, outer=(3)]
+ └── projections [outer=(1,3,4)]
+      ├── variable: a.i [type=int, outer=(1)]
+      ├── variable: b.i [type=int, outer=(3)]
+      └── variable: b.b [type=bool, outer=(4)]
 
 # Full outer join with filter predicate
 build
@@ -1019,17 +1019,17 @@ project
  │    │    └── columns: a.i:int:null:1 a.rowid:int:2
  │    ├── scan
  │    │    └── columns: b.i:int:null:3 b.b:bool:null:4 b.rowid:int:5
- │    └── and [type=bool]
- │         ├── eq [type=bool]
- │         │    ├── variable: a.i [type=int]
- │         │    └── variable: b.i [type=int]
- │         └── gt [type=bool]
- │              ├── variable: a.i [type=int]
+ │    └── and [type=bool, outer=(1,3)]
+ │         ├── eq [type=bool, outer=(1,3)]
+ │         │    ├── variable: a.i [type=int, outer=(1)]
+ │         │    └── variable: b.i [type=int, outer=(3)]
+ │         └── gt [type=bool, outer=(1)]
+ │              ├── variable: a.i [type=int, outer=(1)]
  │              └── const: 2 [type=int]
- └── projections
-      ├── variable: a.i [type=int]
-      ├── variable: b.i [type=int]
-      └── variable: b.b [type=bool]
+ └── projections [outer=(1,3,4)]
+      ├── variable: a.i [type=int, outer=(1)]
+      ├── variable: b.i [type=int, outer=(3)]
+      └── variable: b.b [type=bool, outer=(4)]
 
 # Check column orders and names.
 build
@@ -1050,25 +1050,25 @@ project
  │    │    │    └── true [type=bool]
  │    │    ├── scan
  │    │    │    └── columns: onecolumn.x:int:null:6 onecolumn.rowid:int:7
- │    │    └── eq [type=bool]
- │    │         ├── variable: onecolumn.x [type=int]
- │    │         └── variable: twocolumn.x [type=int]
+ │    │    └── eq [type=bool, outer=(3,6)]
+ │    │         ├── variable: onecolumn.x [type=int, outer=(6)]
+ │    │         └── variable: twocolumn.x [type=int, outer=(3)]
  │    ├── scan
  │    │    └── columns: twocolumn.x:int:null:8 twocolumn.y:int:null:9 twocolumn.rowid:int:10
- │    └── and [type=bool]
- │         ├── eq [type=bool]
- │         │    ├── variable: onecolumn.x [type=int]
- │         │    └── variable: twocolumn.x [type=int]
- │         └── eq [type=bool]
- │              ├── variable: twocolumn.x [type=int]
- │              └── variable: onecolumn.x [type=int]
- └── projections
-      ├── variable: onecolumn.x [type=int]
-      ├── variable: twocolumn.x [type=int]
-      ├── variable: twocolumn.y [type=int]
-      ├── variable: onecolumn.x [type=int]
-      ├── variable: twocolumn.x [type=int]
-      └── variable: twocolumn.y [type=int]
+ │    └── and [type=bool, outer=(1,6,8)]
+ │         ├── eq [type=bool, outer=(6,8)]
+ │         │    ├── variable: onecolumn.x [type=int, outer=(6)]
+ │         │    └── variable: twocolumn.x [type=int, outer=(8)]
+ │         └── eq [type=bool, outer=(1,8)]
+ │              ├── variable: twocolumn.x [type=int, outer=(8)]
+ │              └── variable: onecolumn.x [type=int, outer=(1)]
+ └── projections [outer=(1,3,4,6,8,9)]
+      ├── variable: onecolumn.x [type=int, outer=(1)]
+      ├── variable: twocolumn.x [type=int, outer=(3)]
+      ├── variable: twocolumn.y [type=int, outer=(4)]
+      ├── variable: onecolumn.x [type=int, outer=(6)]
+      ├── variable: twocolumn.x [type=int, outer=(8)]
+      └── variable: twocolumn.y [type=int, outer=(9)]
 
 build
 SELECT * FROM onecolumn JOIN (SELECT x + 2 AS x FROM onecolumn) USING(x)
@@ -1083,15 +1083,15 @@ project
  │    │    ├── columns: x:int:null:5
  │    │    ├── scan
  │    │    │    └── columns: onecolumn.x:int:null:3 onecolumn.rowid:int:4
- │    │    └── projections
- │    │         └── plus [type=int]
- │    │              ├── variable: onecolumn.x [type=int]
+ │    │    └── projections [outer=(3)]
+ │    │         └── plus [type=int, outer=(3)]
+ │    │              ├── variable: onecolumn.x [type=int, outer=(3)]
  │    │              └── const: 2 [type=int]
- │    └── eq [type=bool]
- │         ├── variable: onecolumn.x [type=int]
- │         └── variable: x [type=int]
- └── projections
-      └── variable: onecolumn.x [type=int]
+ │    └── eq [type=bool, outer=(1,5)]
+ │         ├── variable: onecolumn.x [type=int, outer=(1)]
+ │         └── variable: x [type=int, outer=(5)]
+ └── projections [outer=(1)]
+      └── variable: onecolumn.x [type=int, outer=(1)]
 
 # Check that a single column can have multiple table aliases.
 build
@@ -1107,19 +1107,19 @@ project
  │    │    │    └── columns: twocolumn.x:int:null:1 twocolumn.y:int:null:2 twocolumn.rowid:int:3
  │    │    ├── scan
  │    │    │    └── columns: twocolumn.x:int:null:4 twocolumn.y:int:null:5 twocolumn.rowid:int:6
- │    │    └── eq [type=bool]
- │    │         ├── variable: twocolumn.x [type=int]
- │    │         └── variable: twocolumn.x [type=int]
+ │    │    └── eq [type=bool, outer=(1,4)]
+ │    │         ├── variable: twocolumn.x [type=int, outer=(1)]
+ │    │         └── variable: twocolumn.x [type=int, outer=(4)]
  │    ├── scan
  │    │    └── columns: twocolumn.x:int:null:7 twocolumn.y:int:null:8 twocolumn.rowid:int:9
- │    └── eq [type=bool]
- │         ├── variable: twocolumn.x [type=int]
- │         └── variable: twocolumn.x [type=int]
- └── projections
-      ├── variable: twocolumn.x [type=int]
-      ├── variable: twocolumn.y [type=int]
-      ├── variable: twocolumn.y [type=int]
-      └── variable: twocolumn.y [type=int]
+ │    └── eq [type=bool, outer=(1,7)]
+ │         ├── variable: twocolumn.x [type=int, outer=(1)]
+ │         └── variable: twocolumn.x [type=int, outer=(7)]
+ └── projections [outer=(1,2,5,8)]
+      ├── variable: twocolumn.x [type=int, outer=(1)]
+      ├── variable: twocolumn.y [type=int, outer=(2)]
+      ├── variable: twocolumn.y [type=int, outer=(5)]
+      └── variable: twocolumn.y [type=int, outer=(8)]
 
 build
 SELECT a.x AS s, b.x, c.x, a.y, b.y, c.y FROM (twocolumn AS a JOIN twocolumn AS b USING(x) JOIN twocolumn AS c USING(x))
@@ -1134,21 +1134,21 @@ project
  │    │    │    └── columns: twocolumn.x:int:null:1 twocolumn.y:int:null:2 twocolumn.rowid:int:3
  │    │    ├── scan
  │    │    │    └── columns: twocolumn.x:int:null:4 twocolumn.y:int:null:5 twocolumn.rowid:int:6
- │    │    └── eq [type=bool]
- │    │         ├── variable: twocolumn.x [type=int]
- │    │         └── variable: twocolumn.x [type=int]
+ │    │    └── eq [type=bool, outer=(1,4)]
+ │    │         ├── variable: twocolumn.x [type=int, outer=(1)]
+ │    │         └── variable: twocolumn.x [type=int, outer=(4)]
  │    ├── scan
  │    │    └── columns: twocolumn.x:int:null:7 twocolumn.y:int:null:8 twocolumn.rowid:int:9
- │    └── eq [type=bool]
- │         ├── variable: twocolumn.x [type=int]
- │         └── variable: twocolumn.x [type=int]
- └── projections
-      ├── variable: twocolumn.x [type=int]
-      ├── variable: twocolumn.x [type=int]
-      ├── variable: twocolumn.x [type=int]
-      ├── variable: twocolumn.y [type=int]
-      ├── variable: twocolumn.y [type=int]
-      └── variable: twocolumn.y [type=int]
+ │    └── eq [type=bool, outer=(1,7)]
+ │         ├── variable: twocolumn.x [type=int, outer=(1)]
+ │         └── variable: twocolumn.x [type=int, outer=(7)]
+ └── projections [outer=(1,2,4,5,7,8)]
+      ├── variable: twocolumn.x [type=int, outer=(1)]
+      ├── variable: twocolumn.x [type=int, outer=(4)]
+      ├── variable: twocolumn.x [type=int, outer=(7)]
+      ├── variable: twocolumn.y [type=int, outer=(2)]
+      ├── variable: twocolumn.y [type=int, outer=(5)]
+      └── variable: twocolumn.y [type=int, outer=(8)]
 
 build
 SELECT * FROM (onecolumn AS a JOIN onecolumn AS b USING(y))
@@ -1194,14 +1194,14 @@ inner-join
  │    ├── columns: onecolumn.x:int:null:1
  │    ├── scan
  │    │    └── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2
- │    └── projections
- │         └── variable: onecolumn.x [type=int]
+ │    └── projections [outer=(1)]
+ │         └── variable: onecolumn.x [type=int, outer=(1)]
  ├── project
  │    ├── columns: onecolumn.x:int:null:3
  │    ├── scan
  │    │    └── columns: onecolumn.x:int:null:3 onecolumn.rowid:int:4
- │    └── projections
- │         └── variable: onecolumn.x [type=int]
+ │    └── projections [outer=(3)]
+ │         └── variable: onecolumn.x [type=int, outer=(3)]
  └── true [type=bool]
 
 # Check that anonymous sources are properly looked up without ambiguity.
@@ -1218,23 +1218,23 @@ project
  │    │    │    └── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2
  │    │    ├── scan
  │    │    │    └── columns: othercolumn.x:int:null:3 othercolumn.rowid:int:4
- │    │    └── eq [type=bool]
- │    │         ├── variable: onecolumn.x [type=int]
- │    │         └── variable: othercolumn.x [type=int]
+ │    │    └── eq [type=bool, outer=(1,3)]
+ │    │         ├── variable: onecolumn.x [type=int, outer=(1)]
+ │    │         └── variable: othercolumn.x [type=int, outer=(3)]
  │    ├── inner-join
  │    │    ├── columns: onecolumn.x:int:null:5 onecolumn.rowid:int:6 othercolumn.x:int:null:7 othercolumn.rowid:int:8
  │    │    ├── scan
  │    │    │    └── columns: onecolumn.x:int:null:5 onecolumn.rowid:int:6
  │    │    ├── scan
  │    │    │    └── columns: othercolumn.x:int:null:7 othercolumn.rowid:int:8
- │    │    └── eq [type=bool]
- │    │         ├── variable: onecolumn.x [type=int]
- │    │         └── variable: othercolumn.x [type=int]
- │    └── eq [type=bool]
- │         ├── variable: onecolumn.x [type=int]
- │         └── variable: onecolumn.x [type=int]
- └── projections
-      └── variable: onecolumn.x [type=int]
+ │    │    └── eq [type=bool, outer=(5,7)]
+ │    │         ├── variable: onecolumn.x [type=int, outer=(5)]
+ │    │         └── variable: othercolumn.x [type=int, outer=(7)]
+ │    └── eq [type=bool, outer=(1,5)]
+ │         ├── variable: onecolumn.x [type=int, outer=(1)]
+ │         └── variable: onecolumn.x [type=int, outer=(5)]
+ └── projections [outer=(1)]
+      └── variable: onecolumn.x [type=int, outer=(1)]
 
 # Check that multiple anonymous sources cause proper ambiguity errors.
 build
@@ -1265,9 +1265,9 @@ project
  │    ├── scan
  │    │    └── columns: twocolumn.x:int:null:4 twocolumn.y:int:null:5 twocolumn.rowid:int:6
  │    └── true [type=bool]
- └── projections
-      ├── variable: twocolumn.x [type=int]
-      └── variable: twocolumn.y [type=int]
+ └── projections [outer=(1,5)]
+      ├── variable: twocolumn.x [type=int, outer=(1)]
+      └── variable: twocolumn.y [type=int, outer=(5)]
 
 build
 SELECT b.y FROM (twocolumn AS a JOIN twocolumn AS b USING(x))
@@ -1280,11 +1280,11 @@ project
  │    │    └── columns: twocolumn.x:int:null:1 twocolumn.y:int:null:2 twocolumn.rowid:int:3
  │    ├── scan
  │    │    └── columns: twocolumn.x:int:null:4 twocolumn.y:int:null:5 twocolumn.rowid:int:6
- │    └── eq [type=bool]
- │         ├── variable: twocolumn.x [type=int]
- │         └── variable: twocolumn.x [type=int]
- └── projections
-      └── variable: twocolumn.y [type=int]
+ │    └── eq [type=bool, outer=(1,4)]
+ │         ├── variable: twocolumn.x [type=int, outer=(1)]
+ │         └── variable: twocolumn.x [type=int, outer=(4)]
+ └── projections [outer=(5)]
+      └── variable: twocolumn.y [type=int, outer=(5)]
 
 build
 SELECT b.y FROM (twocolumn AS a JOIN twocolumn AS b ON a.x = b.x)
@@ -1297,11 +1297,11 @@ project
  │    │    └── columns: twocolumn.x:int:null:1 twocolumn.y:int:null:2 twocolumn.rowid:int:3
  │    ├── scan
  │    │    └── columns: twocolumn.x:int:null:4 twocolumn.y:int:null:5 twocolumn.rowid:int:6
- │    └── eq [type=bool]
- │         ├── variable: twocolumn.x [type=int]
- │         └── variable: twocolumn.x [type=int]
- └── projections
-      └── variable: twocolumn.y [type=int]
+ │    └── eq [type=bool, outer=(1,4)]
+ │         ├── variable: twocolumn.x [type=int, outer=(1)]
+ │         └── variable: twocolumn.x [type=int, outer=(4)]
+ └── projections [outer=(5)]
+      └── variable: twocolumn.y [type=int, outer=(5)]
 
 build
 SELECT a.x FROM (twocolumn AS a JOIN twocolumn AS b ON a.x < b.y)
@@ -1314,11 +1314,11 @@ project
  │    │    └── columns: twocolumn.x:int:null:1 twocolumn.y:int:null:2 twocolumn.rowid:int:3
  │    ├── scan
  │    │    └── columns: twocolumn.x:int:null:4 twocolumn.y:int:null:5 twocolumn.rowid:int:6
- │    └── lt [type=bool]
- │         ├── variable: twocolumn.x [type=int]
- │         └── variable: twocolumn.y [type=int]
- └── projections
-      └── variable: twocolumn.x [type=int]
+ │    └── lt [type=bool, outer=(1,5)]
+ │         ├── variable: twocolumn.x [type=int, outer=(1)]
+ │         └── variable: twocolumn.y [type=int, outer=(5)]
+ └── projections [outer=(1)]
+      └── variable: twocolumn.x [type=int, outer=(1)]
 
 # Tests for filter propagation through joins.
 
@@ -1356,14 +1356,14 @@ project
  │    │    ├── scan
  │    │    │    └── columns: square.n:int:4 square.sq:int:null:5
  │    │    └── true [type=bool]
- │    └── eq [type=bool]
- │         ├── variable: pairs.b [type=int]
- │         └── variable: square.n [type=int]
- └── projections
-      ├── variable: pairs.a [type=int]
-      ├── variable: pairs.b [type=int]
-      ├── variable: square.n [type=int]
-      └── variable: square.sq [type=int]
+ │    └── eq [type=bool, outer=(2,4)]
+ │         ├── variable: pairs.b [type=int, outer=(2)]
+ │         └── variable: square.n [type=int, outer=(4)]
+ └── projections [outer=(1,2,4,5)]
+      ├── variable: pairs.a [type=int, outer=(1)]
+      ├── variable: pairs.b [type=int, outer=(2)]
+      ├── variable: square.n [type=int, outer=(4)]
+      └── variable: square.sq [type=int, outer=(5)]
 
 # The filter expression becomes an ON predicate.
 build
@@ -1380,16 +1380,16 @@ project
  │    │    ├── scan
  │    │    │    └── columns: square.n:int:4 square.sq:int:null:5
  │    │    └── true [type=bool]
- │    └── eq [type=bool]
- │         ├── plus [type=int]
- │         │    ├── variable: pairs.a [type=int]
- │         │    └── variable: pairs.b [type=int]
- │         └── variable: square.sq [type=int]
- └── projections
-      ├── variable: pairs.a [type=int]
-      ├── variable: pairs.b [type=int]
-      ├── variable: square.n [type=int]
-      └── variable: square.sq [type=int]
+ │    └── eq [type=bool, outer=(1,2,5)]
+ │         ├── plus [type=int, outer=(1,2)]
+ │         │    ├── variable: pairs.a [type=int, outer=(1)]
+ │         │    └── variable: pairs.b [type=int, outer=(2)]
+ │         └── variable: square.sq [type=int, outer=(5)]
+ └── projections [outer=(1,2,4,5)]
+      ├── variable: pairs.a [type=int, outer=(1)]
+      ├── variable: pairs.b [type=int, outer=(2)]
+      ├── variable: square.n [type=int, outer=(4)]
+      └── variable: square.sq [type=int, outer=(5)]
 
 # Query similar to the one above, but the filter refers to a rendered
 # expression and can't "break through". See the comment for propagateFilters
@@ -1410,22 +1410,22 @@ project
  │    │    │    ├── scan
  │    │    │    │    └── columns: square.n:int:4 square.sq:int:null:5
  │    │    │    └── true [type=bool]
- │    │    └── projections
- │    │         ├── variable: pairs.a [type=int]
- │    │         ├── variable: pairs.b [type=int]
- │    │         ├── plus [type=int]
- │    │         │    ├── variable: pairs.a [type=int]
- │    │         │    └── variable: pairs.b [type=int]
- │    │         ├── variable: square.n [type=int]
- │    │         └── variable: square.sq [type=int]
- │    └── eq [type=bool]
- │         ├── variable: sum [type=int]
- │         └── variable: square.sq [type=int]
- └── projections
-      ├── variable: pairs.a [type=int]
-      ├── variable: pairs.b [type=int]
-      ├── variable: square.n [type=int]
-      └── variable: square.sq [type=int]
+ │    │    └── projections [outer=(1,2,4,5)]
+ │    │         ├── variable: pairs.a [type=int, outer=(1)]
+ │    │         ├── variable: pairs.b [type=int, outer=(2)]
+ │    │         ├── plus [type=int, outer=(1,2)]
+ │    │         │    ├── variable: pairs.a [type=int, outer=(1)]
+ │    │         │    └── variable: pairs.b [type=int, outer=(2)]
+ │    │         ├── variable: square.n [type=int, outer=(4)]
+ │    │         └── variable: square.sq [type=int, outer=(5)]
+ │    └── eq [type=bool, outer=(5,6)]
+ │         ├── variable: sum [type=int, outer=(6)]
+ │         └── variable: square.sq [type=int, outer=(5)]
+ └── projections [outer=(1,2,4,5)]
+      ├── variable: pairs.a [type=int, outer=(1)]
+      ├── variable: pairs.b [type=int, outer=(2)]
+      ├── variable: square.n [type=int, outer=(4)]
+      └── variable: square.sq [type=int, outer=(5)]
 
 # The filter expression must stay on top of the outer join.
 build
@@ -1439,16 +1439,16 @@ project
  │    │    └── columns: pairs.a:int:null:1 pairs.b:int:null:2 pairs.rowid:int:3
  │    ├── scan
  │    │    └── columns: square.n:int:4 square.sq:int:null:5
- │    └── eq [type=bool]
- │         ├── plus [type=int]
- │         │    ├── variable: pairs.a [type=int]
- │         │    └── variable: pairs.b [type=int]
- │         └── variable: square.sq [type=int]
- └── projections
-      ├── variable: pairs.a [type=int]
-      ├── variable: pairs.b [type=int]
-      ├── variable: square.n [type=int]
-      └── variable: square.sq [type=int]
+ │    └── eq [type=bool, outer=(1,2,5)]
+ │         ├── plus [type=int, outer=(1,2)]
+ │         │    ├── variable: pairs.a [type=int, outer=(1)]
+ │         │    └── variable: pairs.b [type=int, outer=(2)]
+ │         └── variable: square.sq [type=int, outer=(5)]
+ └── projections [outer=(1,2,4,5)]
+      ├── variable: pairs.a [type=int, outer=(1)]
+      ├── variable: pairs.b [type=int, outer=(2)]
+      ├── variable: square.n [type=int, outer=(4)]
+      └── variable: square.sq [type=int, outer=(5)]
 
 build
 SELECT * FROM pairs FULL OUTER JOIN square ON pairs.a + pairs.b = square.sq WHERE pairs.b%2 <> square.sq%2
@@ -1463,23 +1463,23 @@ project
  │    │    │    └── columns: pairs.a:int:null:1 pairs.b:int:null:2 pairs.rowid:int:3
  │    │    ├── scan
  │    │    │    └── columns: square.n:int:4 square.sq:int:null:5
- │    │    └── eq [type=bool]
- │    │         ├── plus [type=int]
- │    │         │    ├── variable: pairs.a [type=int]
- │    │         │    └── variable: pairs.b [type=int]
- │    │         └── variable: square.sq [type=int]
- │    └── ne [type=bool]
- │         ├── mod [type=int]
- │         │    ├── variable: pairs.b [type=int]
+ │    │    └── eq [type=bool, outer=(1,2,5)]
+ │    │         ├── plus [type=int, outer=(1,2)]
+ │    │         │    ├── variable: pairs.a [type=int, outer=(1)]
+ │    │         │    └── variable: pairs.b [type=int, outer=(2)]
+ │    │         └── variable: square.sq [type=int, outer=(5)]
+ │    └── ne [type=bool, outer=(2,5)]
+ │         ├── mod [type=int, outer=(2)]
+ │         │    ├── variable: pairs.b [type=int, outer=(2)]
  │         │    └── const: 2 [type=int]
- │         └── mod [type=int]
- │              ├── variable: square.sq [type=int]
+ │         └── mod [type=int, outer=(5)]
+ │              ├── variable: square.sq [type=int, outer=(5)]
  │              └── const: 2 [type=int]
- └── projections
-      ├── variable: pairs.a [type=int]
-      ├── variable: pairs.b [type=int]
-      ├── variable: square.n [type=int]
-      └── variable: square.sq [type=int]
+ └── projections [outer=(1,2,4,5)]
+      ├── variable: pairs.a [type=int, outer=(1)]
+      ├── variable: pairs.b [type=int, outer=(2)]
+      ├── variable: square.n [type=int, outer=(4)]
+      └── variable: square.sq [type=int, outer=(5)]
 
 # Filter propagation through outer joins.
 
@@ -1498,41 +1498,41 @@ select
  │    │    │    └── columns: pairs.a:int:null:1 pairs.b:int:null:2 pairs.rowid:int:3
  │    │    ├── scan
  │    │    │    └── columns: square.n:int:4 square.sq:int:null:5
- │    │    └── and [type=bool]
- │    │         ├── and [type=bool]
- │    │         │    ├── eq [type=bool]
- │    │         │    │    ├── variable: pairs.b [type=int]
- │    │         │    │    └── variable: square.sq [type=int]
- │    │         │    └── gt [type=bool]
- │    │         │         ├── variable: pairs.a [type=int]
+ │    │    └── and [type=bool, outer=(1,2,4,5)]
+ │    │         ├── and [type=bool, outer=(1,2,5)]
+ │    │         │    ├── eq [type=bool, outer=(2,5)]
+ │    │         │    │    ├── variable: pairs.b [type=int, outer=(2)]
+ │    │         │    │    └── variable: square.sq [type=int, outer=(5)]
+ │    │         │    └── gt [type=bool, outer=(1)]
+ │    │         │         ├── variable: pairs.a [type=int, outer=(1)]
  │    │         │         └── const: 1 [type=int]
- │    │         └── lt [type=bool]
- │    │              ├── variable: square.n [type=int]
+ │    │         └── lt [type=bool, outer=(4)]
+ │    │              ├── variable: square.n [type=int, outer=(4)]
  │    │              └── const: 6 [type=int]
- │    └── projections
- │         ├── variable: pairs.a [type=int]
- │         ├── variable: pairs.b [type=int]
- │         ├── variable: square.n [type=int]
- │         └── variable: square.sq [type=int]
- └── and [type=bool]
-      ├── and [type=bool]
-      │    ├── gt [type=bool]
-      │    │    ├── variable: pairs.b [type=int]
+ │    └── projections [outer=(1,2,4,5)]
+ │         ├── variable: pairs.a [type=int, outer=(1)]
+ │         ├── variable: pairs.b [type=int, outer=(2)]
+ │         ├── variable: square.n [type=int, outer=(4)]
+ │         └── variable: square.sq [type=int, outer=(5)]
+ └── and [type=bool, outer=(1,2,4,5)]
+      ├── and [type=bool, outer=(2,4)]
+      │    ├── gt [type=bool, outer=(2)]
+      │    │    ├── variable: pairs.b [type=int, outer=(2)]
       │    │    └── const: 1 [type=int]
-      │    └── or [type=bool]
-      │         ├── is [type=bool]
-      │         │    ├── variable: square.n [type=int]
+      │    └── or [type=bool, outer=(4)]
+      │         ├── is [type=bool, outer=(4)]
+      │         │    ├── variable: square.n [type=int, outer=(4)]
       │         │    └── null [type=unknown]
-      │         └── gt [type=bool]
-      │              ├── variable: square.n [type=int]
+      │         └── gt [type=bool, outer=(4)]
+      │              ├── variable: square.n [type=int, outer=(4)]
       │              └── const: 1 [type=int]
-      └── or [type=bool]
-           ├── is [type=bool]
-           │    ├── variable: square.n [type=int]
+      └── or [type=bool, outer=(1,4,5)]
+           ├── is [type=bool, outer=(4)]
+           │    ├── variable: square.n [type=int, outer=(4)]
            │    └── null [type=unknown]
-           └── lt [type=bool]
-                ├── variable: pairs.a [type=int]
-                └── variable: square.sq [type=int]
+           └── lt [type=bool, outer=(1,5)]
+                ├── variable: pairs.a [type=int, outer=(1)]
+                └── variable: square.sq [type=int, outer=(5)]
 
 build
 SELECT *
@@ -1549,41 +1549,41 @@ select
  │    │    │    └── columns: pairs.a:int:null:1 pairs.b:int:null:2 pairs.rowid:int:3
  │    │    ├── scan
  │    │    │    └── columns: square.n:int:4 square.sq:int:null:5
- │    │    └── and [type=bool]
- │    │         ├── and [type=bool]
- │    │         │    ├── eq [type=bool]
- │    │         │    │    ├── variable: pairs.b [type=int]
- │    │         │    │    └── variable: square.sq [type=int]
- │    │         │    └── gt [type=bool]
- │    │         │         ├── variable: pairs.a [type=int]
+ │    │    └── and [type=bool, outer=(1,2,4,5)]
+ │    │         ├── and [type=bool, outer=(1,2,5)]
+ │    │         │    ├── eq [type=bool, outer=(2,5)]
+ │    │         │    │    ├── variable: pairs.b [type=int, outer=(2)]
+ │    │         │    │    └── variable: square.sq [type=int, outer=(5)]
+ │    │         │    └── gt [type=bool, outer=(1)]
+ │    │         │         ├── variable: pairs.a [type=int, outer=(1)]
  │    │         │         └── const: 1 [type=int]
- │    │         └── lt [type=bool]
- │    │              ├── variable: square.n [type=int]
+ │    │         └── lt [type=bool, outer=(4)]
+ │    │              ├── variable: square.n [type=int, outer=(4)]
  │    │              └── const: 6 [type=int]
- │    └── projections
- │         ├── variable: pairs.a [type=int]
- │         ├── variable: pairs.b [type=int]
- │         ├── variable: square.n [type=int]
- │         └── variable: square.sq [type=int]
- └── and [type=bool]
-      ├── and [type=bool]
-      │    ├── or [type=bool]
-      │    │    ├── is [type=bool]
-      │    │    │    ├── variable: pairs.a [type=int]
+ │    └── projections [outer=(1,2,4,5)]
+ │         ├── variable: pairs.a [type=int, outer=(1)]
+ │         ├── variable: pairs.b [type=int, outer=(2)]
+ │         ├── variable: square.n [type=int, outer=(4)]
+ │         └── variable: square.sq [type=int, outer=(5)]
+ └── and [type=bool, outer=(1,4,5)]
+      ├── and [type=bool, outer=(1,4)]
+      │    ├── or [type=bool, outer=(1)]
+      │    │    ├── is [type=bool, outer=(1)]
+      │    │    │    ├── variable: pairs.a [type=int, outer=(1)]
       │    │    │    └── null [type=unknown]
-      │    │    └── gt [type=bool]
-      │    │         ├── variable: pairs.a [type=int]
+      │    │    └── gt [type=bool, outer=(1)]
+      │    │         ├── variable: pairs.a [type=int, outer=(1)]
       │    │         └── const: 2 [type=int]
-      │    └── gt [type=bool]
-      │         ├── variable: square.n [type=int]
+      │    └── gt [type=bool, outer=(4)]
+      │         ├── variable: square.n [type=int, outer=(4)]
       │         └── const: 1 [type=int]
-      └── or [type=bool]
-           ├── is [type=bool]
-           │    ├── variable: pairs.a [type=int]
+      └── or [type=bool, outer=(1,5)]
+           ├── is [type=bool, outer=(1)]
+           │    ├── variable: pairs.a [type=int, outer=(1)]
            │    └── null [type=unknown]
-           └── lt [type=bool]
-                ├── variable: pairs.a [type=int]
-                └── variable: square.sq [type=int]
+           └── lt [type=bool, outer=(1,5)]
+                ├── variable: pairs.a [type=int, outer=(1)]
+                └── variable: square.sq [type=int, outer=(5)]
 
 # The simpler plan for an inner join, to compare.
 build
@@ -1601,41 +1601,41 @@ select
  │    │    │    └── columns: pairs.a:int:null:1 pairs.b:int:null:2 pairs.rowid:int:3
  │    │    ├── scan
  │    │    │    └── columns: square.n:int:4 square.sq:int:null:5
- │    │    └── and [type=bool]
- │    │         ├── and [type=bool]
- │    │         │    ├── eq [type=bool]
- │    │         │    │    ├── variable: pairs.b [type=int]
- │    │         │    │    └── variable: square.sq [type=int]
- │    │         │    └── gt [type=bool]
- │    │         │         ├── variable: pairs.a [type=int]
+ │    │    └── and [type=bool, outer=(1,2,4,5)]
+ │    │         ├── and [type=bool, outer=(1,2,5)]
+ │    │         │    ├── eq [type=bool, outer=(2,5)]
+ │    │         │    │    ├── variable: pairs.b [type=int, outer=(2)]
+ │    │         │    │    └── variable: square.sq [type=int, outer=(5)]
+ │    │         │    └── gt [type=bool, outer=(1)]
+ │    │         │         ├── variable: pairs.a [type=int, outer=(1)]
  │    │         │         └── const: 1 [type=int]
- │    │         └── lt [type=bool]
- │    │              ├── variable: square.n [type=int]
+ │    │         └── lt [type=bool, outer=(4)]
+ │    │              ├── variable: square.n [type=int, outer=(4)]
  │    │              └── const: 6 [type=int]
- │    └── projections
- │         ├── variable: pairs.a [type=int]
- │         ├── variable: pairs.b [type=int]
- │         ├── variable: square.n [type=int]
- │         └── variable: square.sq [type=int]
- └── and [type=bool]
-      ├── and [type=bool]
-      │    ├── or [type=bool]
-      │    │    ├── is [type=bool]
-      │    │    │    ├── variable: pairs.a [type=int]
+ │    └── projections [outer=(1,2,4,5)]
+ │         ├── variable: pairs.a [type=int, outer=(1)]
+ │         ├── variable: pairs.b [type=int, outer=(2)]
+ │         ├── variable: square.n [type=int, outer=(4)]
+ │         └── variable: square.sq [type=int, outer=(5)]
+ └── and [type=bool, outer=(1,4,5)]
+      ├── and [type=bool, outer=(1,4)]
+      │    ├── or [type=bool, outer=(1)]
+      │    │    ├── is [type=bool, outer=(1)]
+      │    │    │    ├── variable: pairs.a [type=int, outer=(1)]
       │    │    │    └── null [type=unknown]
-      │    │    └── gt [type=bool]
-      │    │         ├── variable: pairs.a [type=int]
+      │    │    └── gt [type=bool, outer=(1)]
+      │    │         ├── variable: pairs.a [type=int, outer=(1)]
       │    │         └── const: 2 [type=int]
-      │    └── gt [type=bool]
-      │         ├── variable: square.n [type=int]
+      │    └── gt [type=bool, outer=(4)]
+      │         ├── variable: square.n [type=int, outer=(4)]
       │         └── const: 1 [type=int]
-      └── or [type=bool]
-           ├── is [type=bool]
-           │    ├── variable: pairs.a [type=int]
+      └── or [type=bool, outer=(1,5)]
+           ├── is [type=bool, outer=(1)]
+           │    ├── variable: pairs.a [type=int, outer=(1)]
            │    └── null [type=unknown]
-           └── lt [type=bool]
-                ├── variable: pairs.a [type=int]
-                └── variable: square.sq [type=int]
+           └── lt [type=bool, outer=(1,5)]
+                ├── variable: pairs.a [type=int, outer=(1)]
+                └── variable: square.sq [type=int, outer=(5)]
 
 
 exec-ddl
@@ -1673,17 +1673,17 @@ project
  │    │    └── columns: t1.col1:int:null:1 t1.x:int:null:2 t1.col2:int:null:3 t1.y:int:null:4 t1.rowid:int:5
  │    ├── scan
  │    │    └── columns: t2.col3:int:null:6 t2.y:int:null:7 t2.x:int:null:8 t2.col4:int:null:9 t2.rowid:int:10
- │    └── eq [type=bool]
- │         ├── variable: t1.x [type=int]
- │         └── variable: t2.x [type=int]
- └── projections
-      ├── variable: t1.x [type=int]
-      ├── variable: t1.col1 [type=int]
-      ├── variable: t1.col2 [type=int]
-      ├── variable: t1.y [type=int]
-      ├── variable: t2.col3 [type=int]
-      ├── variable: t2.y [type=int]
-      └── variable: t2.col4 [type=int]
+ │    └── eq [type=bool, outer=(2,8)]
+ │         ├── variable: t1.x [type=int, outer=(2)]
+ │         └── variable: t2.x [type=int, outer=(8)]
+ └── projections [outer=(1-4,6,7,9)]
+      ├── variable: t1.x [type=int, outer=(2)]
+      ├── variable: t1.col1 [type=int, outer=(1)]
+      ├── variable: t1.col2 [type=int, outer=(3)]
+      ├── variable: t1.y [type=int, outer=(4)]
+      ├── variable: t2.col3 [type=int, outer=(6)]
+      ├── variable: t2.y [type=int, outer=(7)]
+      └── variable: t2.col4 [type=int, outer=(9)]
 
 build
 SELECT * FROM t1 NATURAL JOIN t2
@@ -1696,20 +1696,20 @@ project
  │    │    └── columns: t1.col1:int:null:1 t1.x:int:null:2 t1.col2:int:null:3 t1.y:int:null:4 t1.rowid:int:5
  │    ├── scan
  │    │    └── columns: t2.col3:int:null:6 t2.y:int:null:7 t2.x:int:null:8 t2.col4:int:null:9 t2.rowid:int:10
- │    └── and [type=bool]
- │         ├── eq [type=bool]
- │         │    ├── variable: t1.x [type=int]
- │         │    └── variable: t2.x [type=int]
- │         └── eq [type=bool]
- │              ├── variable: t1.y [type=int]
- │              └── variable: t2.y [type=int]
- └── projections
-      ├── variable: t1.x [type=int]
-      ├── variable: t1.y [type=int]
-      ├── variable: t1.col1 [type=int]
-      ├── variable: t1.col2 [type=int]
-      ├── variable: t2.col3 [type=int]
-      └── variable: t2.col4 [type=int]
+ │    └── and [type=bool, outer=(2,4,7,8)]
+ │         ├── eq [type=bool, outer=(2,8)]
+ │         │    ├── variable: t1.x [type=int, outer=(2)]
+ │         │    └── variable: t2.x [type=int, outer=(8)]
+ │         └── eq [type=bool, outer=(4,7)]
+ │              ├── variable: t1.y [type=int, outer=(4)]
+ │              └── variable: t2.y [type=int, outer=(7)]
+ └── projections [outer=(1-4,6,9)]
+      ├── variable: t1.x [type=int, outer=(2)]
+      ├── variable: t1.y [type=int, outer=(4)]
+      ├── variable: t1.col1 [type=int, outer=(1)]
+      ├── variable: t1.col2 [type=int, outer=(3)]
+      ├── variable: t2.col3 [type=int, outer=(6)]
+      └── variable: t2.col4 [type=int, outer=(9)]
 
 build
 SELECT * FROM t1 JOIN t2 ON t2.x=t1.x
@@ -1722,18 +1722,18 @@ project
  │    │    └── columns: t1.col1:int:null:1 t1.x:int:null:2 t1.col2:int:null:3 t1.y:int:null:4 t1.rowid:int:5
  │    ├── scan
  │    │    └── columns: t2.col3:int:null:6 t2.y:int:null:7 t2.x:int:null:8 t2.col4:int:null:9 t2.rowid:int:10
- │    └── eq [type=bool]
- │         ├── variable: t2.x [type=int]
- │         └── variable: t1.x [type=int]
- └── projections
-      ├── variable: t1.col1 [type=int]
-      ├── variable: t1.x [type=int]
-      ├── variable: t1.col2 [type=int]
-      ├── variable: t1.y [type=int]
-      ├── variable: t2.col3 [type=int]
-      ├── variable: t2.y [type=int]
-      ├── variable: t2.x [type=int]
-      └── variable: t2.col4 [type=int]
+ │    └── eq [type=bool, outer=(2,8)]
+ │         ├── variable: t2.x [type=int, outer=(8)]
+ │         └── variable: t1.x [type=int, outer=(2)]
+ └── projections [outer=(1-4,6-9)]
+      ├── variable: t1.col1 [type=int, outer=(1)]
+      ├── variable: t1.x [type=int, outer=(2)]
+      ├── variable: t1.col2 [type=int, outer=(3)]
+      ├── variable: t1.y [type=int, outer=(4)]
+      ├── variable: t2.col3 [type=int, outer=(6)]
+      ├── variable: t2.y [type=int, outer=(7)]
+      ├── variable: t2.x [type=int, outer=(8)]
+      └── variable: t2.col4 [type=int, outer=(9)]
 
 build
 SELECT * FROM t1 FULL OUTER JOIN t2 USING(x)
@@ -1748,31 +1748,31 @@ project
  │    │    │    └── columns: t1.col1:int:null:1 t1.x:int:null:2 t1.col2:int:null:3 t1.y:int:null:4 t1.rowid:int:5
  │    │    ├── scan
  │    │    │    └── columns: t2.col3:int:null:6 t2.y:int:null:7 t2.x:int:null:8 t2.col4:int:null:9 t2.rowid:int:10
- │    │    └── eq [type=bool]
- │    │         ├── variable: t1.x [type=int]
- │    │         └── variable: t2.x [type=int]
- │    └── projections
- │         ├── coalesce [type=int]
- │         │    ├── variable: t1.x [type=int]
- │         │    └── variable: t2.x [type=int]
- │         ├── variable: t1.col1 [type=int]
- │         ├── variable: t1.x [type=int]
- │         ├── variable: t1.col2 [type=int]
- │         ├── variable: t1.y [type=int]
- │         ├── variable: t1.rowid [type=int]
- │         ├── variable: t2.col3 [type=int]
- │         ├── variable: t2.y [type=int]
- │         ├── variable: t2.x [type=int]
- │         ├── variable: t2.col4 [type=int]
- │         └── variable: t2.rowid [type=int]
- └── projections
-      ├── variable: x [type=int]
-      ├── variable: t1.col1 [type=int]
-      ├── variable: t1.col2 [type=int]
-      ├── variable: t1.y [type=int]
-      ├── variable: t2.col3 [type=int]
-      ├── variable: t2.y [type=int]
-      └── variable: t2.col4 [type=int]
+ │    │    └── eq [type=bool, outer=(2,8)]
+ │    │         ├── variable: t1.x [type=int, outer=(2)]
+ │    │         └── variable: t2.x [type=int, outer=(8)]
+ │    └── projections [outer=(1-10)]
+ │         ├── coalesce [type=int, outer=(2,8)]
+ │         │    ├── variable: t1.x [type=int, outer=(2)]
+ │         │    └── variable: t2.x [type=int, outer=(8)]
+ │         ├── variable: t1.col1 [type=int, outer=(1)]
+ │         ├── variable: t1.x [type=int, outer=(2)]
+ │         ├── variable: t1.col2 [type=int, outer=(3)]
+ │         ├── variable: t1.y [type=int, outer=(4)]
+ │         ├── variable: t1.rowid [type=int, outer=(5)]
+ │         ├── variable: t2.col3 [type=int, outer=(6)]
+ │         ├── variable: t2.y [type=int, outer=(7)]
+ │         ├── variable: t2.x [type=int, outer=(8)]
+ │         ├── variable: t2.col4 [type=int, outer=(9)]
+ │         └── variable: t2.rowid [type=int, outer=(10)]
+ └── projections [outer=(1,3,4,6,7,9,11)]
+      ├── variable: x [type=int, outer=(11)]
+      ├── variable: t1.col1 [type=int, outer=(1)]
+      ├── variable: t1.col2 [type=int, outer=(3)]
+      ├── variable: t1.y [type=int, outer=(4)]
+      ├── variable: t2.col3 [type=int, outer=(6)]
+      ├── variable: t2.y [type=int, outer=(7)]
+      └── variable: t2.col4 [type=int, outer=(9)]
 
 build
 SELECT * FROM t1 NATURAL FULL OUTER JOIN t2
@@ -1787,37 +1787,37 @@ project
  │    │    │    └── columns: t1.col1:int:null:1 t1.x:int:null:2 t1.col2:int:null:3 t1.y:int:null:4 t1.rowid:int:5
  │    │    ├── scan
  │    │    │    └── columns: t2.col3:int:null:6 t2.y:int:null:7 t2.x:int:null:8 t2.col4:int:null:9 t2.rowid:int:10
- │    │    └── and [type=bool]
- │    │         ├── eq [type=bool]
- │    │         │    ├── variable: t1.x [type=int]
- │    │         │    └── variable: t2.x [type=int]
- │    │         └── eq [type=bool]
- │    │              ├── variable: t1.y [type=int]
- │    │              └── variable: t2.y [type=int]
- │    └── projections
- │         ├── coalesce [type=int]
- │         │    ├── variable: t1.x [type=int]
- │         │    └── variable: t2.x [type=int]
- │         ├── coalesce [type=int]
- │         │    ├── variable: t1.y [type=int]
- │         │    └── variable: t2.y [type=int]
- │         ├── variable: t1.col1 [type=int]
- │         ├── variable: t1.x [type=int]
- │         ├── variable: t1.col2 [type=int]
- │         ├── variable: t1.y [type=int]
- │         ├── variable: t1.rowid [type=int]
- │         ├── variable: t2.col3 [type=int]
- │         ├── variable: t2.y [type=int]
- │         ├── variable: t2.x [type=int]
- │         ├── variable: t2.col4 [type=int]
- │         └── variable: t2.rowid [type=int]
- └── projections
-      ├── variable: x [type=int]
-      ├── variable: y [type=int]
-      ├── variable: t1.col1 [type=int]
-      ├── variable: t1.col2 [type=int]
-      ├── variable: t2.col3 [type=int]
-      └── variable: t2.col4 [type=int]
+ │    │    └── and [type=bool, outer=(2,4,7,8)]
+ │    │         ├── eq [type=bool, outer=(2,8)]
+ │    │         │    ├── variable: t1.x [type=int, outer=(2)]
+ │    │         │    └── variable: t2.x [type=int, outer=(8)]
+ │    │         └── eq [type=bool, outer=(4,7)]
+ │    │              ├── variable: t1.y [type=int, outer=(4)]
+ │    │              └── variable: t2.y [type=int, outer=(7)]
+ │    └── projections [outer=(1-10)]
+ │         ├── coalesce [type=int, outer=(2,8)]
+ │         │    ├── variable: t1.x [type=int, outer=(2)]
+ │         │    └── variable: t2.x [type=int, outer=(8)]
+ │         ├── coalesce [type=int, outer=(4,7)]
+ │         │    ├── variable: t1.y [type=int, outer=(4)]
+ │         │    └── variable: t2.y [type=int, outer=(7)]
+ │         ├── variable: t1.col1 [type=int, outer=(1)]
+ │         ├── variable: t1.x [type=int, outer=(2)]
+ │         ├── variable: t1.col2 [type=int, outer=(3)]
+ │         ├── variable: t1.y [type=int, outer=(4)]
+ │         ├── variable: t1.rowid [type=int, outer=(5)]
+ │         ├── variable: t2.col3 [type=int, outer=(6)]
+ │         ├── variable: t2.y [type=int, outer=(7)]
+ │         ├── variable: t2.x [type=int, outer=(8)]
+ │         ├── variable: t2.col4 [type=int, outer=(9)]
+ │         └── variable: t2.rowid [type=int, outer=(10)]
+ └── projections [outer=(1,3,6,9,11,12)]
+      ├── variable: x [type=int, outer=(11)]
+      ├── variable: y [type=int, outer=(12)]
+      ├── variable: t1.col1 [type=int, outer=(1)]
+      ├── variable: t1.col2 [type=int, outer=(3)]
+      ├── variable: t2.col3 [type=int, outer=(6)]
+      └── variable: t2.col4 [type=int, outer=(9)]
 
 build
 SELECT * FROM t1 FULL OUTER JOIN t2 ON t1.x=t2.x
@@ -1830,18 +1830,18 @@ project
  │    │    └── columns: t1.col1:int:null:1 t1.x:int:null:2 t1.col2:int:null:3 t1.y:int:null:4 t1.rowid:int:5
  │    ├── scan
  │    │    └── columns: t2.col3:int:null:6 t2.y:int:null:7 t2.x:int:null:8 t2.col4:int:null:9 t2.rowid:int:10
- │    └── eq [type=bool]
- │         ├── variable: t1.x [type=int]
- │         └── variable: t2.x [type=int]
- └── projections
-      ├── variable: t1.col1 [type=int]
-      ├── variable: t1.x [type=int]
-      ├── variable: t1.col2 [type=int]
-      ├── variable: t1.y [type=int]
-      ├── variable: t2.col3 [type=int]
-      ├── variable: t2.y [type=int]
-      ├── variable: t2.x [type=int]
-      └── variable: t2.col4 [type=int]
+ │    └── eq [type=bool, outer=(2,8)]
+ │         ├── variable: t1.x [type=int, outer=(2)]
+ │         └── variable: t2.x [type=int, outer=(8)]
+ └── projections [outer=(1-4,6-9)]
+      ├── variable: t1.col1 [type=int, outer=(1)]
+      ├── variable: t1.x [type=int, outer=(2)]
+      ├── variable: t1.col2 [type=int, outer=(3)]
+      ├── variable: t1.y [type=int, outer=(4)]
+      ├── variable: t2.col3 [type=int, outer=(6)]
+      ├── variable: t2.y [type=int, outer=(7)]
+      ├── variable: t2.x [type=int, outer=(8)]
+      └── variable: t2.col4 [type=int, outer=(9)]
 
 build
 SELECT t2.x, t1.x, x FROM t1 JOIN t2 USING(x)
@@ -1854,13 +1854,13 @@ project
  │    │    └── columns: t1.col1:int:null:1 t1.x:int:null:2 t1.col2:int:null:3 t1.y:int:null:4 t1.rowid:int:5
  │    ├── scan
  │    │    └── columns: t2.col3:int:null:6 t2.y:int:null:7 t2.x:int:null:8 t2.col4:int:null:9 t2.rowid:int:10
- │    └── eq [type=bool]
- │         ├── variable: t1.x [type=int]
- │         └── variable: t2.x [type=int]
- └── projections
-      ├── variable: t2.x [type=int]
-      ├── variable: t1.x [type=int]
-      └── variable: t1.x [type=int]
+ │    └── eq [type=bool, outer=(2,8)]
+ │         ├── variable: t1.x [type=int, outer=(2)]
+ │         └── variable: t2.x [type=int, outer=(8)]
+ └── projections [outer=(2,8)]
+      ├── variable: t2.x [type=int, outer=(8)]
+      ├── variable: t1.x [type=int, outer=(2)]
+      └── variable: t1.x [type=int, outer=(2)]
 
 build
 SELECT t2.x, t1.x, x FROM t1 FULL OUTER JOIN t2 USING(x)
@@ -1875,27 +1875,27 @@ project
  │    │    │    └── columns: t1.col1:int:null:1 t1.x:int:null:2 t1.col2:int:null:3 t1.y:int:null:4 t1.rowid:int:5
  │    │    ├── scan
  │    │    │    └── columns: t2.col3:int:null:6 t2.y:int:null:7 t2.x:int:null:8 t2.col4:int:null:9 t2.rowid:int:10
- │    │    └── eq [type=bool]
- │    │         ├── variable: t1.x [type=int]
- │    │         └── variable: t2.x [type=int]
- │    └── projections
- │         ├── coalesce [type=int]
- │         │    ├── variable: t1.x [type=int]
- │         │    └── variable: t2.x [type=int]
- │         ├── variable: t1.col1 [type=int]
- │         ├── variable: t1.x [type=int]
- │         ├── variable: t1.col2 [type=int]
- │         ├── variable: t1.y [type=int]
- │         ├── variable: t1.rowid [type=int]
- │         ├── variable: t2.col3 [type=int]
- │         ├── variable: t2.y [type=int]
- │         ├── variable: t2.x [type=int]
- │         ├── variable: t2.col4 [type=int]
- │         └── variable: t2.rowid [type=int]
- └── projections
-      ├── variable: t2.x [type=int]
-      ├── variable: t1.x [type=int]
-      └── variable: x [type=int]
+ │    │    └── eq [type=bool, outer=(2,8)]
+ │    │         ├── variable: t1.x [type=int, outer=(2)]
+ │    │         └── variable: t2.x [type=int, outer=(8)]
+ │    └── projections [outer=(1-10)]
+ │         ├── coalesce [type=int, outer=(2,8)]
+ │         │    ├── variable: t1.x [type=int, outer=(2)]
+ │         │    └── variable: t2.x [type=int, outer=(8)]
+ │         ├── variable: t1.col1 [type=int, outer=(1)]
+ │         ├── variable: t1.x [type=int, outer=(2)]
+ │         ├── variable: t1.col2 [type=int, outer=(3)]
+ │         ├── variable: t1.y [type=int, outer=(4)]
+ │         ├── variable: t1.rowid [type=int, outer=(5)]
+ │         ├── variable: t2.col3 [type=int, outer=(6)]
+ │         ├── variable: t2.y [type=int, outer=(7)]
+ │         ├── variable: t2.x [type=int, outer=(8)]
+ │         ├── variable: t2.col4 [type=int, outer=(9)]
+ │         └── variable: t2.rowid [type=int, outer=(10)]
+ └── projections [outer=(2,8,11)]
+      ├── variable: t2.x [type=int, outer=(8)]
+      ├── variable: t1.x [type=int, outer=(2)]
+      └── variable: x [type=int, outer=(11)]
 
 # Test for #19536.
 build
@@ -1911,20 +1911,20 @@ project
  │    │    ├── columns: t2.col3:int:null:6 t2.y:int:null:7 t2.x:int:null:8 t2.col4:int:null:9
  │    │    ├── scan
  │    │    │    └── columns: t2.col3:int:null:6 t2.y:int:null:7 t2.x:int:null:8 t2.col4:int:null:9 t2.rowid:int:10
- │    │    └── projections
- │    │         ├── variable: t2.col3 [type=int]
- │    │         ├── variable: t2.y [type=int]
- │    │         ├── variable: t2.x [type=int]
- │    │         └── variable: t2.col4 [type=int]
- │    └── and [type=bool]
- │         ├── eq [type=bool]
- │         │    ├── variable: t1.x [type=int]
- │         │    └── variable: t2.x [type=int]
- │         └── eq [type=bool]
- │              ├── variable: t1.y [type=int]
- │              └── variable: t2.y [type=int]
- └── projections
-      └── variable: t1.x [type=int]
+ │    │    └── projections [outer=(6-9)]
+ │    │         ├── variable: t2.col3 [type=int, outer=(6)]
+ │    │         ├── variable: t2.y [type=int, outer=(7)]
+ │    │         ├── variable: t2.x [type=int, outer=(8)]
+ │    │         └── variable: t2.col4 [type=int, outer=(9)]
+ │    └── and [type=bool, outer=(2,4,7,8)]
+ │         ├── eq [type=bool, outer=(2,8)]
+ │         │    ├── variable: t1.x [type=int, outer=(2)]
+ │         │    └── variable: t2.x [type=int, outer=(8)]
+ │         └── eq [type=bool, outer=(4,7)]
+ │              ├── variable: t1.y [type=int, outer=(4)]
+ │              └── variable: t2.y [type=int, outer=(7)]
+ └── projections [outer=(2)]
+      └── variable: t1.x [type=int, outer=(2)]
 
 # Tests for merge join ordering information.
 exec-ddl
@@ -1986,17 +1986,17 @@ inner-join
  │    └── columns: pkba.a:int:1 pkba.b:int:2 pkba.c:int:null:3 pkba.d:int:null:4
  ├── scan
  │    └── columns: pkbc.a:int:null:5 pkbc.b:int:6 pkbc.c:int:7 pkbc.d:int:null:8
- └── and [type=bool]
-      ├── and [type=bool]
-      │    ├── eq [type=bool]
-      │    │    ├── variable: pkba.a [type=int]
-      │    │    └── variable: pkbc.a [type=int]
-      │    └── eq [type=bool]
-      │         ├── variable: pkba.b [type=int]
-      │         └── variable: pkbc.b [type=int]
-      └── eq [type=bool]
-           ├── variable: pkba.c [type=int]
-           └── variable: pkbc.c [type=int]
+ └── and [type=bool, outer=(1-3,5-7)]
+      ├── and [type=bool, outer=(1,2,5,6)]
+      │    ├── eq [type=bool, outer=(1,5)]
+      │    │    ├── variable: pkba.a [type=int, outer=(1)]
+      │    │    └── variable: pkbc.a [type=int, outer=(5)]
+      │    └── eq [type=bool, outer=(2,6)]
+      │         ├── variable: pkba.b [type=int, outer=(2)]
+      │         └── variable: pkbc.b [type=int, outer=(6)]
+      └── eq [type=bool, outer=(3,7)]
+           ├── variable: pkba.c [type=int, outer=(3)]
+           └── variable: pkbc.c [type=int, outer=(7)]
 
 build
 SELECT * FROM pkBA NATURAL JOIN pkBAD
@@ -2009,24 +2009,24 @@ project
  │    │    └── columns: pkba.a:int:1 pkba.b:int:2 pkba.c:int:null:3 pkba.d:int:null:4
  │    ├── scan
  │    │    └── columns: pkbad.a:int:5 pkbad.b:int:6 pkbad.c:int:null:7 pkbad.d:int:8
- │    └── and [type=bool]
- │         ├── eq [type=bool]
- │         │    ├── variable: pkba.a [type=int]
- │         │    └── variable: pkbad.a [type=int]
- │         ├── eq [type=bool]
- │         │    ├── variable: pkba.b [type=int]
- │         │    └── variable: pkbad.b [type=int]
- │         ├── eq [type=bool]
- │         │    ├── variable: pkba.c [type=int]
- │         │    └── variable: pkbad.c [type=int]
- │         └── eq [type=bool]
- │              ├── variable: pkba.d [type=int]
- │              └── variable: pkbad.d [type=int]
- └── projections
-      ├── variable: pkba.a [type=int]
-      ├── variable: pkba.b [type=int]
-      ├── variable: pkba.c [type=int]
-      └── variable: pkba.d [type=int]
+ │    └── and [type=bool, outer=(1-8)]
+ │         ├── eq [type=bool, outer=(1,5)]
+ │         │    ├── variable: pkba.a [type=int, outer=(1)]
+ │         │    └── variable: pkbad.a [type=int, outer=(5)]
+ │         ├── eq [type=bool, outer=(2,6)]
+ │         │    ├── variable: pkba.b [type=int, outer=(2)]
+ │         │    └── variable: pkbad.b [type=int, outer=(6)]
+ │         ├── eq [type=bool, outer=(3,7)]
+ │         │    ├── variable: pkba.c [type=int, outer=(3)]
+ │         │    └── variable: pkbad.c [type=int, outer=(7)]
+ │         └── eq [type=bool, outer=(4,8)]
+ │              ├── variable: pkba.d [type=int, outer=(4)]
+ │              └── variable: pkbad.d [type=int, outer=(8)]
+ └── projections [outer=(1-4)]
+      ├── variable: pkba.a [type=int, outer=(1)]
+      ├── variable: pkba.b [type=int, outer=(2)]
+      ├── variable: pkba.c [type=int, outer=(3)]
+      └── variable: pkba.d [type=int, outer=(4)]
 
 build
 SELECT * FROM pkBAC AS l JOIN pkBAC AS r USING(a, b, c)
@@ -2039,22 +2039,22 @@ project
  │    │    └── columns: pkbac.a:int:1 pkbac.b:int:2 pkbac.c:int:3 pkbac.d:int:null:4
  │    ├── scan
  │    │    └── columns: pkbac.a:int:5 pkbac.b:int:6 pkbac.c:int:7 pkbac.d:int:null:8
- │    └── and [type=bool]
- │         ├── eq [type=bool]
- │         │    ├── variable: pkbac.a [type=int]
- │         │    └── variable: pkbac.a [type=int]
- │         ├── eq [type=bool]
- │         │    ├── variable: pkbac.b [type=int]
- │         │    └── variable: pkbac.b [type=int]
- │         └── eq [type=bool]
- │              ├── variable: pkbac.c [type=int]
- │              └── variable: pkbac.c [type=int]
- └── projections
-      ├── variable: pkbac.a [type=int]
-      ├── variable: pkbac.b [type=int]
-      ├── variable: pkbac.c [type=int]
-      ├── variable: pkbac.d [type=int]
-      └── variable: pkbac.d [type=int]
+ │    └── and [type=bool, outer=(1-3,5-7)]
+ │         ├── eq [type=bool, outer=(1,5)]
+ │         │    ├── variable: pkbac.a [type=int, outer=(1)]
+ │         │    └── variable: pkbac.a [type=int, outer=(5)]
+ │         ├── eq [type=bool, outer=(2,6)]
+ │         │    ├── variable: pkbac.b [type=int, outer=(2)]
+ │         │    └── variable: pkbac.b [type=int, outer=(6)]
+ │         └── eq [type=bool, outer=(3,7)]
+ │              ├── variable: pkbac.c [type=int, outer=(3)]
+ │              └── variable: pkbac.c [type=int, outer=(7)]
+ └── projections [outer=(1-4,8)]
+      ├── variable: pkbac.a [type=int, outer=(1)]
+      ├── variable: pkbac.b [type=int, outer=(2)]
+      ├── variable: pkbac.c [type=int, outer=(3)]
+      ├── variable: pkbac.d [type=int, outer=(4)]
+      └── variable: pkbac.d [type=int, outer=(8)]
 
 build
 SELECT * FROM pkBAC AS l JOIN pkBAD AS r ON l.c = r.d AND l.a = r.a AND l.b = r.b
@@ -2065,17 +2065,17 @@ inner-join
  │    └── columns: pkbac.a:int:1 pkbac.b:int:2 pkbac.c:int:3 pkbac.d:int:null:4
  ├── scan
  │    └── columns: pkbad.a:int:5 pkbad.b:int:6 pkbad.c:int:null:7 pkbad.d:int:8
- └── and [type=bool]
-      ├── and [type=bool]
-      │    ├── eq [type=bool]
-      │    │    ├── variable: pkbac.c [type=int]
-      │    │    └── variable: pkbad.d [type=int]
-      │    └── eq [type=bool]
-      │         ├── variable: pkbac.a [type=int]
-      │         └── variable: pkbad.a [type=int]
-      └── eq [type=bool]
-           ├── variable: pkbac.b [type=int]
-           └── variable: pkbad.b [type=int]
+ └── and [type=bool, outer=(1-3,5,6,8)]
+      ├── and [type=bool, outer=(1,3,5,8)]
+      │    ├── eq [type=bool, outer=(3,8)]
+      │    │    ├── variable: pkbac.c [type=int, outer=(3)]
+      │    │    └── variable: pkbad.d [type=int, outer=(8)]
+      │    └── eq [type=bool, outer=(1,5)]
+      │         ├── variable: pkbac.a [type=int, outer=(1)]
+      │         └── variable: pkbad.a [type=int, outer=(5)]
+      └── eq [type=bool, outer=(2,6)]
+           ├── variable: pkbac.b [type=int, outer=(2)]
+           └── variable: pkbad.b [type=int, outer=(6)]
 
 # Tests with joins with merged columns of collated string type.
 exec-ddl
@@ -2107,13 +2107,13 @@ project
  │    │    └── columns: str1.a:int:1 str1.s:collatedstring{en_u_ks_level1}:null:2
  │    ├── scan
  │    │    └── columns: str2.a:int:3 str2.s:collatedstring{en_u_ks_level1}:null:4
- │    └── eq [type=bool]
- │         ├── variable: str1.s [type=collatedstring{en_u_ks_level1}]
- │         └── variable: str2.s [type=collatedstring{en_u_ks_level1}]
- └── projections
-      ├── variable: str1.s [type=collatedstring{en_u_ks_level1}]
-      ├── variable: str1.s [type=collatedstring{en_u_ks_level1}]
-      └── variable: str2.s [type=collatedstring{en_u_ks_level1}]
+ │    └── eq [type=bool, outer=(2,4)]
+ │         ├── variable: str1.s [type=collatedstring{en_u_ks_level1}, outer=(2)]
+ │         └── variable: str2.s [type=collatedstring{en_u_ks_level1}, outer=(4)]
+ └── projections [outer=(2,4)]
+      ├── variable: str1.s [type=collatedstring{en_u_ks_level1}, outer=(2)]
+      ├── variable: str1.s [type=collatedstring{en_u_ks_level1}, outer=(2)]
+      └── variable: str2.s [type=collatedstring{en_u_ks_level1}, outer=(4)]
 
 build
 SELECT s, str1.s, str2.s FROM str1 LEFT OUTER JOIN str2 USING(s)
@@ -2126,13 +2126,13 @@ project
  │    │    └── columns: str1.a:int:1 str1.s:collatedstring{en_u_ks_level1}:null:2
  │    ├── scan
  │    │    └── columns: str2.a:int:3 str2.s:collatedstring{en_u_ks_level1}:null:4
- │    └── eq [type=bool]
- │         ├── variable: str1.s [type=collatedstring{en_u_ks_level1}]
- │         └── variable: str2.s [type=collatedstring{en_u_ks_level1}]
- └── projections
-      ├── variable: str1.s [type=collatedstring{en_u_ks_level1}]
-      ├── variable: str1.s [type=collatedstring{en_u_ks_level1}]
-      └── variable: str2.s [type=collatedstring{en_u_ks_level1}]
+ │    └── eq [type=bool, outer=(2,4)]
+ │         ├── variable: str1.s [type=collatedstring{en_u_ks_level1}, outer=(2)]
+ │         └── variable: str2.s [type=collatedstring{en_u_ks_level1}, outer=(4)]
+ └── projections [outer=(2,4)]
+      ├── variable: str1.s [type=collatedstring{en_u_ks_level1}, outer=(2)]
+      ├── variable: str1.s [type=collatedstring{en_u_ks_level1}, outer=(2)]
+      └── variable: str2.s [type=collatedstring{en_u_ks_level1}, outer=(4)]
 
 build
 SELECT s, str1.s, str2.s FROM str1 RIGHT OUTER JOIN str2 USING(s)
@@ -2147,21 +2147,21 @@ project
  │    │    │    └── columns: str1.a:int:1 str1.s:collatedstring{en_u_ks_level1}:null:2
  │    │    ├── scan
  │    │    │    └── columns: str2.a:int:3 str2.s:collatedstring{en_u_ks_level1}:null:4
- │    │    └── eq [type=bool]
- │    │         ├── variable: str1.s [type=collatedstring{en_u_ks_level1}]
- │    │         └── variable: str2.s [type=collatedstring{en_u_ks_level1}]
- │    └── projections
- │         ├── coalesce [type=collatedstring{en_u_ks_level1}]
- │         │    ├── variable: str1.s [type=collatedstring{en_u_ks_level1}]
- │         │    └── variable: str2.s [type=collatedstring{en_u_ks_level1}]
- │         ├── variable: str1.a [type=int]
- │         ├── variable: str1.s [type=collatedstring{en_u_ks_level1}]
- │         ├── variable: str2.a [type=int]
- │         └── variable: str2.s [type=collatedstring{en_u_ks_level1}]
- └── projections
-      ├── variable: s [type=collatedstring{en_u_ks_level1}]
-      ├── variable: str1.s [type=collatedstring{en_u_ks_level1}]
-      └── variable: str2.s [type=collatedstring{en_u_ks_level1}]
+ │    │    └── eq [type=bool, outer=(2,4)]
+ │    │         ├── variable: str1.s [type=collatedstring{en_u_ks_level1}, outer=(2)]
+ │    │         └── variable: str2.s [type=collatedstring{en_u_ks_level1}, outer=(4)]
+ │    └── projections [outer=(1-4)]
+ │         ├── coalesce [type=collatedstring{en_u_ks_level1}, outer=(2,4)]
+ │         │    ├── variable: str1.s [type=collatedstring{en_u_ks_level1}, outer=(2)]
+ │         │    └── variable: str2.s [type=collatedstring{en_u_ks_level1}, outer=(4)]
+ │         ├── variable: str1.a [type=int, outer=(1)]
+ │         ├── variable: str1.s [type=collatedstring{en_u_ks_level1}, outer=(2)]
+ │         ├── variable: str2.a [type=int, outer=(3)]
+ │         └── variable: str2.s [type=collatedstring{en_u_ks_level1}, outer=(4)]
+ └── projections [outer=(2,4,5)]
+      ├── variable: s [type=collatedstring{en_u_ks_level1}, outer=(5)]
+      ├── variable: str1.s [type=collatedstring{en_u_ks_level1}, outer=(2)]
+      └── variable: str2.s [type=collatedstring{en_u_ks_level1}, outer=(4)]
 
 build
 SELECT s, str1.s, str2.s FROM str1 FULL OUTER JOIN str2 USING(s)
@@ -2176,21 +2176,21 @@ project
  │    │    │    └── columns: str1.a:int:1 str1.s:collatedstring{en_u_ks_level1}:null:2
  │    │    ├── scan
  │    │    │    └── columns: str2.a:int:3 str2.s:collatedstring{en_u_ks_level1}:null:4
- │    │    └── eq [type=bool]
- │    │         ├── variable: str1.s [type=collatedstring{en_u_ks_level1}]
- │    │         └── variable: str2.s [type=collatedstring{en_u_ks_level1}]
- │    └── projections
- │         ├── coalesce [type=collatedstring{en_u_ks_level1}]
- │         │    ├── variable: str1.s [type=collatedstring{en_u_ks_level1}]
- │         │    └── variable: str2.s [type=collatedstring{en_u_ks_level1}]
- │         ├── variable: str1.a [type=int]
- │         ├── variable: str1.s [type=collatedstring{en_u_ks_level1}]
- │         ├── variable: str2.a [type=int]
- │         └── variable: str2.s [type=collatedstring{en_u_ks_level1}]
- └── projections
-      ├── variable: s [type=collatedstring{en_u_ks_level1}]
-      ├── variable: str1.s [type=collatedstring{en_u_ks_level1}]
-      └── variable: str2.s [type=collatedstring{en_u_ks_level1}]
+ │    │    └── eq [type=bool, outer=(2,4)]
+ │    │         ├── variable: str1.s [type=collatedstring{en_u_ks_level1}, outer=(2)]
+ │    │         └── variable: str2.s [type=collatedstring{en_u_ks_level1}, outer=(4)]
+ │    └── projections [outer=(1-4)]
+ │         ├── coalesce [type=collatedstring{en_u_ks_level1}, outer=(2,4)]
+ │         │    ├── variable: str1.s [type=collatedstring{en_u_ks_level1}, outer=(2)]
+ │         │    └── variable: str2.s [type=collatedstring{en_u_ks_level1}, outer=(4)]
+ │         ├── variable: str1.a [type=int, outer=(1)]
+ │         ├── variable: str1.s [type=collatedstring{en_u_ks_level1}, outer=(2)]
+ │         ├── variable: str2.a [type=int, outer=(3)]
+ │         └── variable: str2.s [type=collatedstring{en_u_ks_level1}, outer=(4)]
+ └── projections [outer=(2,4,5)]
+      ├── variable: s [type=collatedstring{en_u_ks_level1}, outer=(5)]
+      ├── variable: str1.s [type=collatedstring{en_u_ks_level1}, outer=(2)]
+      └── variable: str2.s [type=collatedstring{en_u_ks_level1}, outer=(4)]
 
 # Verify that we resolve the merged column a to str2.a but use IFNULL for
 # column s which is a collated string.
@@ -2207,24 +2207,24 @@ project
  │    │    │    └── columns: str1.a:int:1 str1.s:collatedstring{en_u_ks_level1}:null:2
  │    │    ├── scan
  │    │    │    └── columns: str2.a:int:3 str2.s:collatedstring{en_u_ks_level1}:null:4
- │    │    └── and [type=bool]
- │    │         ├── eq [type=bool]
- │    │         │    ├── variable: str1.a [type=int]
- │    │         │    └── variable: str2.a [type=int]
- │    │         └── eq [type=bool]
- │    │              ├── variable: str1.s [type=collatedstring{en_u_ks_level1}]
- │    │              └── variable: str2.s [type=collatedstring{en_u_ks_level1}]
- │    └── projections
- │         ├── variable: str2.a [type=int]
- │         ├── coalesce [type=collatedstring{en_u_ks_level1}]
- │         │    ├── variable: str1.s [type=collatedstring{en_u_ks_level1}]
- │         │    └── variable: str2.s [type=collatedstring{en_u_ks_level1}]
- │         ├── variable: str1.a [type=int]
- │         ├── variable: str1.s [type=collatedstring{en_u_ks_level1}]
- │         └── variable: str2.s [type=collatedstring{en_u_ks_level1}]
- └── projections
-      ├── variable: str2.a [type=int]
-      └── variable: s [type=collatedstring{en_u_ks_level1}]
+ │    │    └── and [type=bool, outer=(1-4)]
+ │    │         ├── eq [type=bool, outer=(1,3)]
+ │    │         │    ├── variable: str1.a [type=int, outer=(1)]
+ │    │         │    └── variable: str2.a [type=int, outer=(3)]
+ │    │         └── eq [type=bool, outer=(2,4)]
+ │    │              ├── variable: str1.s [type=collatedstring{en_u_ks_level1}, outer=(2)]
+ │    │              └── variable: str2.s [type=collatedstring{en_u_ks_level1}, outer=(4)]
+ │    └── projections [outer=(1-4)]
+ │         ├── variable: str2.a [type=int, outer=(3)]
+ │         ├── coalesce [type=collatedstring{en_u_ks_level1}, outer=(2,4)]
+ │         │    ├── variable: str1.s [type=collatedstring{en_u_ks_level1}, outer=(2)]
+ │         │    └── variable: str2.s [type=collatedstring{en_u_ks_level1}, outer=(4)]
+ │         ├── variable: str1.a [type=int, outer=(1)]
+ │         ├── variable: str1.s [type=collatedstring{en_u_ks_level1}, outer=(2)]
+ │         └── variable: str2.s [type=collatedstring{en_u_ks_level1}, outer=(4)]
+ └── projections [outer=(3,5)]
+      ├── variable: str2.a [type=int, outer=(3)]
+      └── variable: s [type=collatedstring{en_u_ks_level1}, outer=(5)]
 
 
 exec-ddl
@@ -2264,21 +2264,21 @@ project
  │    │    │    └── columns: xyu.x:int:1 xyu.y:int:2 xyu.u:int:3
  │    │    ├── scan
  │    │    │    └── columns: xyv.x:int:4 xyv.y:int:5 xyv.v:int:6
- │    │    └── and [type=bool]
- │    │         ├── eq [type=bool]
- │    │         │    ├── variable: xyu.x [type=int]
- │    │         │    └── variable: xyv.x [type=int]
- │    │         └── eq [type=bool]
- │    │              ├── variable: xyu.y [type=int]
- │    │              └── variable: xyv.y [type=int]
- │    └── gt [type=bool]
- │         ├── variable: xyu.x [type=int]
+ │    │    └── and [type=bool, outer=(1,2,4,5)]
+ │    │         ├── eq [type=bool, outer=(1,4)]
+ │    │         │    ├── variable: xyu.x [type=int, outer=(1)]
+ │    │         │    └── variable: xyv.x [type=int, outer=(4)]
+ │    │         └── eq [type=bool, outer=(2,5)]
+ │    │              ├── variable: xyu.y [type=int, outer=(2)]
+ │    │              └── variable: xyv.y [type=int, outer=(5)]
+ │    └── gt [type=bool, outer=(1)]
+ │         ├── variable: xyu.x [type=int, outer=(1)]
  │         └── const: 2 [type=int]
- └── projections
-      ├── variable: xyu.x [type=int]
-      ├── variable: xyu.y [type=int]
-      ├── variable: xyu.u [type=int]
-      └── variable: xyv.v [type=int]
+ └── projections [outer=(1-3,6)]
+      ├── variable: xyu.x [type=int, outer=(1)]
+      ├── variable: xyu.y [type=int, outer=(2)]
+      ├── variable: xyu.u [type=int, outer=(3)]
+      └── variable: xyv.v [type=int, outer=(6)]
 
 build
 SELECT * FROM xyu LEFT OUTER JOIN xyv USING(x, y) WHERE x > 2
@@ -2293,21 +2293,21 @@ project
  │    │    │    └── columns: xyu.x:int:1 xyu.y:int:2 xyu.u:int:3
  │    │    ├── scan
  │    │    │    └── columns: xyv.x:int:4 xyv.y:int:5 xyv.v:int:6
- │    │    └── and [type=bool]
- │    │         ├── eq [type=bool]
- │    │         │    ├── variable: xyu.x [type=int]
- │    │         │    └── variable: xyv.x [type=int]
- │    │         └── eq [type=bool]
- │    │              ├── variable: xyu.y [type=int]
- │    │              └── variable: xyv.y [type=int]
- │    └── gt [type=bool]
- │         ├── variable: xyu.x [type=int]
+ │    │    └── and [type=bool, outer=(1,2,4,5)]
+ │    │         ├── eq [type=bool, outer=(1,4)]
+ │    │         │    ├── variable: xyu.x [type=int, outer=(1)]
+ │    │         │    └── variable: xyv.x [type=int, outer=(4)]
+ │    │         └── eq [type=bool, outer=(2,5)]
+ │    │              ├── variable: xyu.y [type=int, outer=(2)]
+ │    │              └── variable: xyv.y [type=int, outer=(5)]
+ │    └── gt [type=bool, outer=(1)]
+ │         ├── variable: xyu.x [type=int, outer=(1)]
  │         └── const: 2 [type=int]
- └── projections
-      ├── variable: xyu.x [type=int]
-      ├── variable: xyu.y [type=int]
-      ├── variable: xyu.u [type=int]
-      └── variable: xyv.v [type=int]
+ └── projections [outer=(1-3,6)]
+      ├── variable: xyu.x [type=int, outer=(1)]
+      ├── variable: xyu.y [type=int, outer=(2)]
+      ├── variable: xyu.u [type=int, outer=(3)]
+      └── variable: xyv.v [type=int, outer=(6)]
 
 build
 SELECT * FROM xyu RIGHT OUTER JOIN xyv USING(x, y) WHERE x > 2
@@ -2322,21 +2322,21 @@ project
  │    │    │    └── columns: xyu.x:int:1 xyu.y:int:2 xyu.u:int:3
  │    │    ├── scan
  │    │    │    └── columns: xyv.x:int:4 xyv.y:int:5 xyv.v:int:6
- │    │    └── and [type=bool]
- │    │         ├── eq [type=bool]
- │    │         │    ├── variable: xyu.x [type=int]
- │    │         │    └── variable: xyv.x [type=int]
- │    │         └── eq [type=bool]
- │    │              ├── variable: xyu.y [type=int]
- │    │              └── variable: xyv.y [type=int]
- │    └── gt [type=bool]
- │         ├── variable: xyv.x [type=int]
+ │    │    └── and [type=bool, outer=(1,2,4,5)]
+ │    │         ├── eq [type=bool, outer=(1,4)]
+ │    │         │    ├── variable: xyu.x [type=int, outer=(1)]
+ │    │         │    └── variable: xyv.x [type=int, outer=(4)]
+ │    │         └── eq [type=bool, outer=(2,5)]
+ │    │              ├── variable: xyu.y [type=int, outer=(2)]
+ │    │              └── variable: xyv.y [type=int, outer=(5)]
+ │    └── gt [type=bool, outer=(4)]
+ │         ├── variable: xyv.x [type=int, outer=(4)]
  │         └── const: 2 [type=int]
- └── projections
-      ├── variable: xyv.x [type=int]
-      ├── variable: xyv.y [type=int]
-      ├── variable: xyu.u [type=int]
-      └── variable: xyv.v [type=int]
+ └── projections [outer=(3-6)]
+      ├── variable: xyv.x [type=int, outer=(4)]
+      ├── variable: xyv.y [type=int, outer=(5)]
+      ├── variable: xyu.u [type=int, outer=(3)]
+      └── variable: xyv.v [type=int, outer=(6)]
 
 build
 SELECT * FROM xyu FULL OUTER JOIN xyv USING(x, y) WHERE x > 2
@@ -2353,34 +2353,34 @@ project
  │    │    │    │    └── columns: xyu.x:int:1 xyu.y:int:2 xyu.u:int:3
  │    │    │    ├── scan
  │    │    │    │    └── columns: xyv.x:int:4 xyv.y:int:5 xyv.v:int:6
- │    │    │    └── and [type=bool]
- │    │    │         ├── eq [type=bool]
- │    │    │         │    ├── variable: xyu.x [type=int]
- │    │    │         │    └── variable: xyv.x [type=int]
- │    │    │         └── eq [type=bool]
- │    │    │              ├── variable: xyu.y [type=int]
- │    │    │              └── variable: xyv.y [type=int]
- │    │    └── projections
- │    │         ├── coalesce [type=int]
- │    │         │    ├── variable: xyu.x [type=int]
- │    │         │    └── variable: xyv.x [type=int]
- │    │         ├── coalesce [type=int]
- │    │         │    ├── variable: xyu.y [type=int]
- │    │         │    └── variable: xyv.y [type=int]
- │    │         ├── variable: xyu.x [type=int]
- │    │         ├── variable: xyu.y [type=int]
- │    │         ├── variable: xyu.u [type=int]
- │    │         ├── variable: xyv.x [type=int]
- │    │         ├── variable: xyv.y [type=int]
- │    │         └── variable: xyv.v [type=int]
- │    └── gt [type=bool]
- │         ├── variable: x [type=int]
+ │    │    │    └── and [type=bool, outer=(1,2,4,5)]
+ │    │    │         ├── eq [type=bool, outer=(1,4)]
+ │    │    │         │    ├── variable: xyu.x [type=int, outer=(1)]
+ │    │    │         │    └── variable: xyv.x [type=int, outer=(4)]
+ │    │    │         └── eq [type=bool, outer=(2,5)]
+ │    │    │              ├── variable: xyu.y [type=int, outer=(2)]
+ │    │    │              └── variable: xyv.y [type=int, outer=(5)]
+ │    │    └── projections [outer=(1-6)]
+ │    │         ├── coalesce [type=int, outer=(1,4)]
+ │    │         │    ├── variable: xyu.x [type=int, outer=(1)]
+ │    │         │    └── variable: xyv.x [type=int, outer=(4)]
+ │    │         ├── coalesce [type=int, outer=(2,5)]
+ │    │         │    ├── variable: xyu.y [type=int, outer=(2)]
+ │    │         │    └── variable: xyv.y [type=int, outer=(5)]
+ │    │         ├── variable: xyu.x [type=int, outer=(1)]
+ │    │         ├── variable: xyu.y [type=int, outer=(2)]
+ │    │         ├── variable: xyu.u [type=int, outer=(3)]
+ │    │         ├── variable: xyv.x [type=int, outer=(4)]
+ │    │         ├── variable: xyv.y [type=int, outer=(5)]
+ │    │         └── variable: xyv.v [type=int, outer=(6)]
+ │    └── gt [type=bool, outer=(7)]
+ │         ├── variable: x [type=int, outer=(7)]
  │         └── const: 2 [type=int]
- └── projections
-      ├── variable: x [type=int]
-      ├── variable: y [type=int]
-      ├── variable: xyu.u [type=int]
-      └── variable: xyv.v [type=int]
+ └── projections [outer=(3,6-8)]
+      ├── variable: x [type=int, outer=(7)]
+      ├── variable: y [type=int, outer=(8)]
+      ├── variable: xyu.u [type=int, outer=(3)]
+      └── variable: xyv.v [type=int, outer=(6)]
 
 # Verify that we transfer constraints between the two sides.
 build
@@ -2394,19 +2394,19 @@ select
  │    │    └── columns: xyu.x:int:1 xyu.y:int:2 xyu.u:int:3
  │    ├── scan
  │    │    └── columns: xyv.x:int:4 xyv.y:int:5 xyv.v:int:6
- │    └── and [type=bool]
- │         ├── eq [type=bool]
- │         │    ├── variable: xyu.x [type=int]
- │         │    └── variable: xyv.x [type=int]
- │         └── eq [type=bool]
- │              ├── variable: xyu.y [type=int]
- │              └── variable: xyv.y [type=int]
- └── and [type=bool]
-      ├── eq [type=bool]
-      │    ├── variable: xyu.x [type=int]
+ │    └── and [type=bool, outer=(1,2,4,5)]
+ │         ├── eq [type=bool, outer=(1,4)]
+ │         │    ├── variable: xyu.x [type=int, outer=(1)]
+ │         │    └── variable: xyv.x [type=int, outer=(4)]
+ │         └── eq [type=bool, outer=(2,5)]
+ │              ├── variable: xyu.y [type=int, outer=(2)]
+ │              └── variable: xyv.y [type=int, outer=(5)]
+ └── and [type=bool, outer=(1,2)]
+      ├── eq [type=bool, outer=(1)]
+      │    ├── variable: xyu.x [type=int, outer=(1)]
       │    └── const: 1 [type=int]
-      └── lt [type=bool]
-           ├── variable: xyu.y [type=int]
+      └── lt [type=bool, outer=(2)]
+           ├── variable: xyu.y [type=int, outer=(2)]
            └── const: 10 [type=int]
 
 build
@@ -2418,20 +2418,20 @@ inner-join
  │    └── columns: xyu.x:int:1 xyu.y:int:2 xyu.u:int:3
  ├── scan
  │    └── columns: xyv.x:int:4 xyv.y:int:5 xyv.v:int:6
- └── and [type=bool]
-      ├── and [type=bool]
-      │    ├── and [type=bool]
-      │    │    ├── eq [type=bool]
-      │    │    │    ├── variable: xyu.x [type=int]
-      │    │    │    └── variable: xyv.x [type=int]
-      │    │    └── eq [type=bool]
-      │    │         ├── variable: xyu.y [type=int]
-      │    │         └── variable: xyv.y [type=int]
-      │    └── eq [type=bool]
-      │         ├── variable: xyu.x [type=int]
+ └── and [type=bool, outer=(1,2,4,5)]
+      ├── and [type=bool, outer=(1,2,4,5)]
+      │    ├── and [type=bool, outer=(1,2,4,5)]
+      │    │    ├── eq [type=bool, outer=(1,4)]
+      │    │    │    ├── variable: xyu.x [type=int, outer=(1)]
+      │    │    │    └── variable: xyv.x [type=int, outer=(4)]
+      │    │    └── eq [type=bool, outer=(2,5)]
+      │    │         ├── variable: xyu.y [type=int, outer=(2)]
+      │    │         └── variable: xyv.y [type=int, outer=(5)]
+      │    └── eq [type=bool, outer=(1)]
+      │         ├── variable: xyu.x [type=int, outer=(1)]
       │         └── const: 1 [type=int]
-      └── lt [type=bool]
-           ├── variable: xyu.y [type=int]
+      └── lt [type=bool, outer=(2)]
+           ├── variable: xyu.y [type=int, outer=(2)]
            └── const: 10 [type=int]
 
 build
@@ -2443,20 +2443,20 @@ left-join
  │    └── columns: xyu.x:int:1 xyu.y:int:2 xyu.u:int:3
  ├── scan
  │    └── columns: xyv.x:int:4 xyv.y:int:5 xyv.v:int:6
- └── and [type=bool]
-      ├── and [type=bool]
-      │    ├── and [type=bool]
-      │    │    ├── eq [type=bool]
-      │    │    │    ├── variable: xyu.x [type=int]
-      │    │    │    └── variable: xyv.x [type=int]
-      │    │    └── eq [type=bool]
-      │    │         ├── variable: xyu.y [type=int]
-      │    │         └── variable: xyv.y [type=int]
-      │    └── eq [type=bool]
-      │         ├── variable: xyu.x [type=int]
+ └── and [type=bool, outer=(1,2,4,5)]
+      ├── and [type=bool, outer=(1,2,4,5)]
+      │    ├── and [type=bool, outer=(1,2,4,5)]
+      │    │    ├── eq [type=bool, outer=(1,4)]
+      │    │    │    ├── variable: xyu.x [type=int, outer=(1)]
+      │    │    │    └── variable: xyv.x [type=int, outer=(4)]
+      │    │    └── eq [type=bool, outer=(2,5)]
+      │    │         ├── variable: xyu.y [type=int, outer=(2)]
+      │    │         └── variable: xyv.y [type=int, outer=(5)]
+      │    └── eq [type=bool, outer=(1)]
+      │         ├── variable: xyu.x [type=int, outer=(1)]
       │         └── const: 1 [type=int]
-      └── lt [type=bool]
-           ├── variable: xyu.y [type=int]
+      └── lt [type=bool, outer=(2)]
+           ├── variable: xyu.y [type=int, outer=(2)]
            └── const: 10 [type=int]
 
 build
@@ -2468,20 +2468,20 @@ right-join
  │    └── columns: xyu.x:int:1 xyu.y:int:2 xyu.u:int:3
  ├── scan
  │    └── columns: xyv.x:int:4 xyv.y:int:5 xyv.v:int:6
- └── and [type=bool]
-      ├── and [type=bool]
-      │    ├── and [type=bool]
-      │    │    ├── eq [type=bool]
-      │    │    │    ├── variable: xyu.x [type=int]
-      │    │    │    └── variable: xyv.x [type=int]
-      │    │    └── eq [type=bool]
-      │    │         ├── variable: xyu.y [type=int]
-      │    │         └── variable: xyv.y [type=int]
-      │    └── eq [type=bool]
-      │         ├── variable: xyu.x [type=int]
+ └── and [type=bool, outer=(1,2,4,5)]
+      ├── and [type=bool, outer=(1,2,4,5)]
+      │    ├── and [type=bool, outer=(1,2,4,5)]
+      │    │    ├── eq [type=bool, outer=(1,4)]
+      │    │    │    ├── variable: xyu.x [type=int, outer=(1)]
+      │    │    │    └── variable: xyv.x [type=int, outer=(4)]
+      │    │    └── eq [type=bool, outer=(2,5)]
+      │    │         ├── variable: xyu.y [type=int, outer=(2)]
+      │    │         └── variable: xyv.y [type=int, outer=(5)]
+      │    └── eq [type=bool, outer=(1)]
+      │         ├── variable: xyu.x [type=int, outer=(1)]
       │         └── const: 1 [type=int]
-      └── lt [type=bool]
-           ├── variable: xyu.y [type=int]
+      └── lt [type=bool, outer=(2)]
+           ├── variable: xyu.y [type=int, outer=(2)]
            └── const: 10 [type=int]
 
 
@@ -2500,21 +2500,21 @@ project
  │    │    │    └── columns: xyu.x:int:1 xyu.y:int:2 xyu.u:int:3
  │    │    ├── scan
  │    │    │    └── columns: xyv.x:int:4 xyv.y:int:5 xyv.v:int:6
- │    │    └── and [type=bool]
- │    │         ├── eq [type=bool]
- │    │         │    ├── variable: xyu.x [type=int]
- │    │         │    └── variable: xyv.x [type=int]
- │    │         └── eq [type=bool]
- │    │              ├── variable: xyu.y [type=int]
- │    │              └── variable: xyv.y [type=int]
- │    └── gt [type=bool]
- │         ├── variable: xyu.x [type=int]
+ │    │    └── and [type=bool, outer=(1,2,4,5)]
+ │    │         ├── eq [type=bool, outer=(1,4)]
+ │    │         │    ├── variable: xyu.x [type=int, outer=(1)]
+ │    │         │    └── variable: xyv.x [type=int, outer=(4)]
+ │    │         └── eq [type=bool, outer=(2,5)]
+ │    │              ├── variable: xyu.y [type=int, outer=(2)]
+ │    │              └── variable: xyv.y [type=int, outer=(5)]
+ │    └── gt [type=bool, outer=(1)]
+ │         ├── variable: xyu.x [type=int, outer=(1)]
  │         └── const: 2 [type=int]
- └── projections
-      ├── variable: xyu.x [type=int]
-      ├── variable: xyu.y [type=int]
-      ├── variable: xyu.u [type=int]
-      └── variable: xyv.v [type=int]
+ └── projections [outer=(1-3,6)]
+      ├── variable: xyu.x [type=int, outer=(1)]
+      ├── variable: xyu.y [type=int, outer=(2)]
+      ├── variable: xyu.u [type=int, outer=(3)]
+      └── variable: xyv.v [type=int, outer=(6)]
 
 build
 SELECT * FROM (SELECT * FROM xyu) AS xyu RIGHT OUTER JOIN (SELECT * FROM xyv) AS xyv USING(x, y) WHERE x > 2
@@ -2529,21 +2529,21 @@ project
  │    │    │    └── columns: xyu.x:int:1 xyu.y:int:2 xyu.u:int:3
  │    │    ├── scan
  │    │    │    └── columns: xyv.x:int:4 xyv.y:int:5 xyv.v:int:6
- │    │    └── and [type=bool]
- │    │         ├── eq [type=bool]
- │    │         │    ├── variable: xyu.x [type=int]
- │    │         │    └── variable: xyv.x [type=int]
- │    │         └── eq [type=bool]
- │    │              ├── variable: xyu.y [type=int]
- │    │              └── variable: xyv.y [type=int]
- │    └── gt [type=bool]
- │         ├── variable: xyv.x [type=int]
+ │    │    └── and [type=bool, outer=(1,2,4,5)]
+ │    │         ├── eq [type=bool, outer=(1,4)]
+ │    │         │    ├── variable: xyu.x [type=int, outer=(1)]
+ │    │         │    └── variable: xyv.x [type=int, outer=(4)]
+ │    │         └── eq [type=bool, outer=(2,5)]
+ │    │              ├── variable: xyu.y [type=int, outer=(2)]
+ │    │              └── variable: xyv.y [type=int, outer=(5)]
+ │    └── gt [type=bool, outer=(4)]
+ │         ├── variable: xyv.x [type=int, outer=(4)]
  │         └── const: 2 [type=int]
- └── projections
-      ├── variable: xyv.x [type=int]
-      ├── variable: xyv.y [type=int]
-      ├── variable: xyu.u [type=int]
-      └── variable: xyv.v [type=int]
+ └── projections [outer=(3-6)]
+      ├── variable: xyv.x [type=int, outer=(4)]
+      ├── variable: xyv.y [type=int, outer=(5)]
+      ├── variable: xyu.u [type=int, outer=(3)]
+      └── variable: xyv.v [type=int, outer=(6)]
 
 build
 SELECT * FROM (SELECT * FROM xyu) AS xyu FULL OUTER JOIN (SELECT * FROM xyv) AS xyv USING(x, y) WHERE x > 2
@@ -2560,34 +2560,34 @@ project
  │    │    │    │    └── columns: xyu.x:int:1 xyu.y:int:2 xyu.u:int:3
  │    │    │    ├── scan
  │    │    │    │    └── columns: xyv.x:int:4 xyv.y:int:5 xyv.v:int:6
- │    │    │    └── and [type=bool]
- │    │    │         ├── eq [type=bool]
- │    │    │         │    ├── variable: xyu.x [type=int]
- │    │    │         │    └── variable: xyv.x [type=int]
- │    │    │         └── eq [type=bool]
- │    │    │              ├── variable: xyu.y [type=int]
- │    │    │              └── variable: xyv.y [type=int]
- │    │    └── projections
- │    │         ├── coalesce [type=int]
- │    │         │    ├── variable: xyu.x [type=int]
- │    │         │    └── variable: xyv.x [type=int]
- │    │         ├── coalesce [type=int]
- │    │         │    ├── variable: xyu.y [type=int]
- │    │         │    └── variable: xyv.y [type=int]
- │    │         ├── variable: xyu.x [type=int]
- │    │         ├── variable: xyu.y [type=int]
- │    │         ├── variable: xyu.u [type=int]
- │    │         ├── variable: xyv.x [type=int]
- │    │         ├── variable: xyv.y [type=int]
- │    │         └── variable: xyv.v [type=int]
- │    └── gt [type=bool]
- │         ├── variable: x [type=int]
+ │    │    │    └── and [type=bool, outer=(1,2,4,5)]
+ │    │    │         ├── eq [type=bool, outer=(1,4)]
+ │    │    │         │    ├── variable: xyu.x [type=int, outer=(1)]
+ │    │    │         │    └── variable: xyv.x [type=int, outer=(4)]
+ │    │    │         └── eq [type=bool, outer=(2,5)]
+ │    │    │              ├── variable: xyu.y [type=int, outer=(2)]
+ │    │    │              └── variable: xyv.y [type=int, outer=(5)]
+ │    │    └── projections [outer=(1-6)]
+ │    │         ├── coalesce [type=int, outer=(1,4)]
+ │    │         │    ├── variable: xyu.x [type=int, outer=(1)]
+ │    │         │    └── variable: xyv.x [type=int, outer=(4)]
+ │    │         ├── coalesce [type=int, outer=(2,5)]
+ │    │         │    ├── variable: xyu.y [type=int, outer=(2)]
+ │    │         │    └── variable: xyv.y [type=int, outer=(5)]
+ │    │         ├── variable: xyu.x [type=int, outer=(1)]
+ │    │         ├── variable: xyu.y [type=int, outer=(2)]
+ │    │         ├── variable: xyu.u [type=int, outer=(3)]
+ │    │         ├── variable: xyv.x [type=int, outer=(4)]
+ │    │         ├── variable: xyv.y [type=int, outer=(5)]
+ │    │         └── variable: xyv.v [type=int, outer=(6)]
+ │    └── gt [type=bool, outer=(7)]
+ │         ├── variable: x [type=int, outer=(7)]
  │         └── const: 2 [type=int]
- └── projections
-      ├── variable: x [type=int]
-      ├── variable: y [type=int]
-      ├── variable: xyu.u [type=int]
-      └── variable: xyv.v [type=int]
+ └── projections [outer=(3,6-8)]
+      ├── variable: x [type=int, outer=(7)]
+      ├── variable: y [type=int, outer=(8)]
+      ├── variable: xyu.u [type=int, outer=(3)]
+      └── variable: xyv.v [type=int, outer=(6)]
 
 build
 SELECT * FROM (SELECT * FROM xyu) AS xyu LEFT OUTER JOIN (SELECT * FROM xyv) AS xyv ON xyu.x = xyv.x AND xyu.y = xyv.y AND xyu.x = 1 AND xyu.y < 10
@@ -2598,20 +2598,20 @@ left-join
  │    └── columns: xyu.x:int:1 xyu.y:int:2 xyu.u:int:3
  ├── scan
  │    └── columns: xyv.x:int:4 xyv.y:int:5 xyv.v:int:6
- └── and [type=bool]
-      ├── and [type=bool]
-      │    ├── and [type=bool]
-      │    │    ├── eq [type=bool]
-      │    │    │    ├── variable: xyu.x [type=int]
-      │    │    │    └── variable: xyv.x [type=int]
-      │    │    └── eq [type=bool]
-      │    │         ├── variable: xyu.y [type=int]
-      │    │         └── variable: xyv.y [type=int]
-      │    └── eq [type=bool]
-      │         ├── variable: xyu.x [type=int]
+ └── and [type=bool, outer=(1,2,4,5)]
+      ├── and [type=bool, outer=(1,2,4,5)]
+      │    ├── and [type=bool, outer=(1,2,4,5)]
+      │    │    ├── eq [type=bool, outer=(1,4)]
+      │    │    │    ├── variable: xyu.x [type=int, outer=(1)]
+      │    │    │    └── variable: xyv.x [type=int, outer=(4)]
+      │    │    └── eq [type=bool, outer=(2,5)]
+      │    │         ├── variable: xyu.y [type=int, outer=(2)]
+      │    │         └── variable: xyv.y [type=int, outer=(5)]
+      │    └── eq [type=bool, outer=(1)]
+      │         ├── variable: xyu.x [type=int, outer=(1)]
       │         └── const: 1 [type=int]
-      └── lt [type=bool]
-           ├── variable: xyu.y [type=int]
+      └── lt [type=bool, outer=(2)]
+           ├── variable: xyu.y [type=int, outer=(2)]
            └── const: 10 [type=int]
 
 build
@@ -2623,20 +2623,20 @@ right-join
  │    └── columns: xyu.x:int:1 xyu.y:int:2 xyu.u:int:3
  ├── scan
  │    └── columns: xyv.x:int:4 xyv.y:int:5 xyv.v:int:6
- └── and [type=bool]
-      ├── and [type=bool]
-      │    ├── and [type=bool]
-      │    │    ├── eq [type=bool]
-      │    │    │    ├── variable: xyu.x [type=int]
-      │    │    │    └── variable: xyv.x [type=int]
-      │    │    └── eq [type=bool]
-      │    │         ├── variable: xyu.y [type=int]
-      │    │         └── variable: xyv.y [type=int]
-      │    └── eq [type=bool]
-      │         ├── variable: xyu.x [type=int]
+ └── and [type=bool, outer=(1,2,4,5)]
+      ├── and [type=bool, outer=(1,2,4,5)]
+      │    ├── and [type=bool, outer=(1,2,4,5)]
+      │    │    ├── eq [type=bool, outer=(1,4)]
+      │    │    │    ├── variable: xyu.x [type=int, outer=(1)]
+      │    │    │    └── variable: xyv.x [type=int, outer=(4)]
+      │    │    └── eq [type=bool, outer=(2,5)]
+      │    │         ├── variable: xyu.y [type=int, outer=(2)]
+      │    │         └── variable: xyv.y [type=int, outer=(5)]
+      │    └── eq [type=bool, outer=(1)]
+      │         ├── variable: xyu.x [type=int, outer=(1)]
       │         └── const: 1 [type=int]
-      └── lt [type=bool]
-           ├── variable: xyu.y [type=int]
+      └── lt [type=bool, outer=(2)]
+           ├── variable: xyu.y [type=int, outer=(2)]
            └── const: 10 [type=int]
 
 # Regression test for #20472: break up tuple inequalities.
@@ -2653,27 +2653,27 @@ project
  │    │    │    └── columns: xyu.x:int:1 xyu.y:int:2 xyu.u:int:3
  │    │    ├── scan
  │    │    │    └── columns: xyv.x:int:4 xyv.y:int:5 xyv.v:int:6
- │    │    └── and [type=bool]
- │    │         ├── eq [type=bool]
- │    │         │    ├── variable: xyu.x [type=int]
- │    │         │    └── variable: xyv.x [type=int]
- │    │         └── eq [type=bool]
- │    │              ├── variable: xyu.y [type=int]
- │    │              └── variable: xyv.y [type=int]
- │    └── gt [type=bool]
- │         ├── tuple [type=tuple{int, int, int}]
- │         │    ├── variable: xyu.x [type=int]
- │         │    ├── variable: xyu.y [type=int]
- │         │    └── variable: xyu.u [type=int]
+ │    │    └── and [type=bool, outer=(1,2,4,5)]
+ │    │         ├── eq [type=bool, outer=(1,4)]
+ │    │         │    ├── variable: xyu.x [type=int, outer=(1)]
+ │    │         │    └── variable: xyv.x [type=int, outer=(4)]
+ │    │         └── eq [type=bool, outer=(2,5)]
+ │    │              ├── variable: xyu.y [type=int, outer=(2)]
+ │    │              └── variable: xyv.y [type=int, outer=(5)]
+ │    └── gt [type=bool, outer=(1-3)]
+ │         ├── tuple [type=tuple{int, int, int}, outer=(1-3)]
+ │         │    ├── variable: xyu.x [type=int, outer=(1)]
+ │         │    ├── variable: xyu.y [type=int, outer=(2)]
+ │         │    └── variable: xyu.u [type=int, outer=(3)]
  │         └── tuple [type=tuple{int, int, int}]
  │              ├── const: 1 [type=int]
  │              ├── const: 2 [type=int]
  │              └── const: 3 [type=int]
- └── projections
-      ├── variable: xyu.x [type=int]
-      ├── variable: xyu.y [type=int]
-      ├── variable: xyu.u [type=int]
-      └── variable: xyv.v [type=int]
+ └── projections [outer=(1-3,6)]
+      ├── variable: xyu.x [type=int, outer=(1)]
+      ├── variable: xyu.y [type=int, outer=(2)]
+      ├── variable: xyu.u [type=int, outer=(3)]
+      └── variable: xyv.v [type=int, outer=(6)]
 
 
 # Regression test for #20858.
@@ -2705,11 +2705,11 @@ select
  │    │    └── columns: l.a:int:1
  │    ├── scan
  │    │    └── columns: r.a:int:2
- │    └── eq [type=bool]
- │         ├── variable: l.a [type=int]
- │         └── variable: r.a [type=int]
- └── eq [type=bool]
-      ├── variable: l.a [type=int]
+ │    └── eq [type=bool, outer=(1,2)]
+ │         ├── variable: l.a [type=int, outer=(1)]
+ │         └── variable: r.a [type=int, outer=(2)]
+ └── eq [type=bool, outer=(1)]
+      ├── variable: l.a [type=int, outer=(1)]
       └── const: 3 [type=int]
 
 build
@@ -2723,11 +2723,11 @@ select
  │    │    └── columns: l.a:int:1
  │    ├── scan
  │    │    └── columns: r.a:int:2
- │    └── eq [type=bool]
- │         ├── variable: l.a [type=int]
- │         └── variable: r.a [type=int]
- └── eq [type=bool]
-      ├── variable: r.a [type=int]
+ │    └── eq [type=bool, outer=(1,2)]
+ │         ├── variable: l.a [type=int, outer=(1)]
+ │         └── variable: r.a [type=int, outer=(2)]
+ └── eq [type=bool, outer=(2)]
+      ├── variable: r.a [type=int, outer=(2)]
       └── const: 3 [type=int]
 
 build
@@ -2743,14 +2743,14 @@ project
  │    │    │    └── columns: l.a:int:1
  │    │    ├── scan
  │    │    │    └── columns: r.a:int:2
- │    │    └── eq [type=bool]
- │    │         ├── variable: l.a [type=int]
- │    │         └── variable: r.a [type=int]
- │    └── eq [type=bool]
- │         ├── variable: l.a [type=int]
+ │    │    └── eq [type=bool, outer=(1,2)]
+ │    │         ├── variable: l.a [type=int, outer=(1)]
+ │    │         └── variable: r.a [type=int, outer=(2)]
+ │    └── eq [type=bool, outer=(1)]
+ │         ├── variable: l.a [type=int, outer=(1)]
  │         └── const: 1 [type=int]
- └── projections
-      └── variable: l.a [type=int]
+ └── projections [outer=(1)]
+      └── variable: l.a [type=int, outer=(1)]
 
 build
 SELECT * FROM l RIGHT OUTER JOIN r USING(a) WHERE a = 3
@@ -2765,14 +2765,14 @@ project
  │    │    │    └── columns: l.a:int:1
  │    │    ├── scan
  │    │    │    └── columns: r.a:int:2
- │    │    └── eq [type=bool]
- │    │         ├── variable: l.a [type=int]
- │    │         └── variable: r.a [type=int]
- │    └── eq [type=bool]
- │         ├── variable: r.a [type=int]
+ │    │    └── eq [type=bool, outer=(1,2)]
+ │    │         ├── variable: l.a [type=int, outer=(1)]
+ │    │         └── variable: r.a [type=int, outer=(2)]
+ │    └── eq [type=bool, outer=(2)]
+ │         ├── variable: r.a [type=int, outer=(2)]
  │         └── const: 3 [type=int]
- └── projections
-      └── variable: r.a [type=int]
+ └── projections [outer=(2)]
+      └── variable: r.a [type=int, outer=(2)]
 
 # Regression tests for #21243
 exec-ddl
@@ -2828,54 +2828,54 @@ project
  │    │    │    └── columns: abcdef.a:int:1 abcdef.b:int:2 abcdef.c:int:3 abcdef.d:int:4 abcdef.e:int:null:5 abcdef.f:int:null:6
  │    │    ├── scan
  │    │    │    └── columns: abg.a:int:7 abg.b:int:8 abg.g:int:null:9
- │    │    └── and [type=bool]
- │    │         ├── eq [type=bool]
- │    │         │    ├── variable: abcdef.a [type=int]
- │    │         │    └── variable: abg.a [type=int]
- │    │         └── eq [type=bool]
- │    │              ├── variable: abcdef.b [type=int]
- │    │              └── variable: abg.b [type=int]
- │    └── or [type=bool]
- │         ├── or [type=bool]
- │         │    ├── gt [type=bool]
- │         │    │    ├── tuple [type=tuple{int, int}]
- │         │    │    │    ├── variable: abcdef.a [type=int]
- │         │    │    │    └── variable: abcdef.b [type=int]
+ │    │    └── and [type=bool, outer=(1,2,7,8)]
+ │    │         ├── eq [type=bool, outer=(1,7)]
+ │    │         │    ├── variable: abcdef.a [type=int, outer=(1)]
+ │    │         │    └── variable: abg.a [type=int, outer=(7)]
+ │    │         └── eq [type=bool, outer=(2,8)]
+ │    │              ├── variable: abcdef.b [type=int, outer=(2)]
+ │    │              └── variable: abg.b [type=int, outer=(8)]
+ │    └── or [type=bool, outer=(1-4)]
+ │         ├── or [type=bool, outer=(1-3)]
+ │         │    ├── gt [type=bool, outer=(1,2)]
+ │         │    │    ├── tuple [type=tuple{int, int}, outer=(1,2)]
+ │         │    │    │    ├── variable: abcdef.a [type=int, outer=(1)]
+ │         │    │    │    └── variable: abcdef.b [type=int, outer=(2)]
  │         │    │    └── tuple [type=tuple{int, int}]
  │         │    │         ├── const: 1 [type=int]
  │         │    │         └── const: 2 [type=int]
- │         │    └── and [type=bool]
- │         │         ├── eq [type=bool]
- │         │         │    ├── tuple [type=tuple{int, int}]
- │         │         │    │    ├── variable: abcdef.a [type=int]
- │         │         │    │    └── variable: abcdef.b [type=int]
+ │         │    └── and [type=bool, outer=(1-3)]
+ │         │         ├── eq [type=bool, outer=(1,2)]
+ │         │         │    ├── tuple [type=tuple{int, int}, outer=(1,2)]
+ │         │         │    │    ├── variable: abcdef.a [type=int, outer=(1)]
+ │         │         │    │    └── variable: abcdef.b [type=int, outer=(2)]
  │         │         │    └── tuple [type=tuple{int, int}]
  │         │         │         ├── const: 1 [type=int]
  │         │         │         └── const: 2 [type=int]
- │         │         └── lt [type=bool]
- │         │              ├── variable: abcdef.c [type=int]
+ │         │         └── lt [type=bool, outer=(3)]
+ │         │              ├── variable: abcdef.c [type=int, outer=(3)]
  │         │              └── const: 6 [type=int]
- │         └── and [type=bool]
- │              ├── eq [type=bool]
- │              │    ├── tuple [type=tuple{int, int, int}]
- │              │    │    ├── variable: abcdef.a [type=int]
- │              │    │    ├── variable: abcdef.b [type=int]
- │              │    │    └── variable: abcdef.c [type=int]
+ │         └── and [type=bool, outer=(1-4)]
+ │              ├── eq [type=bool, outer=(1-3)]
+ │              │    ├── tuple [type=tuple{int, int, int}, outer=(1-3)]
+ │              │    │    ├── variable: abcdef.a [type=int, outer=(1)]
+ │              │    │    ├── variable: abcdef.b [type=int, outer=(2)]
+ │              │    │    └── variable: abcdef.c [type=int, outer=(3)]
  │              │    └── tuple [type=tuple{int, int, int}]
  │              │         ├── const: 1 [type=int]
  │              │         ├── const: 2 [type=int]
  │              │         └── const: 6 [type=int]
- │              └── gt [type=bool]
- │                   ├── variable: abcdef.d [type=int]
+ │              └── gt [type=bool, outer=(4)]
+ │                   ├── variable: abcdef.d [type=int, outer=(4)]
  │                   └── const: 8 [type=int]
- └── projections
-      ├── variable: abcdef.a [type=int]
-      ├── variable: abcdef.b [type=int]
-      ├── variable: abcdef.c [type=int]
-      ├── variable: abcdef.d [type=int]
-      ├── variable: abcdef.e [type=int]
-      ├── variable: abcdef.f [type=int]
-      └── variable: abg.g [type=int]
+ └── projections [outer=(1-6,9)]
+      ├── variable: abcdef.a [type=int, outer=(1)]
+      ├── variable: abcdef.b [type=int, outer=(2)]
+      ├── variable: abcdef.c [type=int, outer=(3)]
+      ├── variable: abcdef.d [type=int, outer=(4)]
+      ├── variable: abcdef.e [type=int, outer=(5)]
+      ├── variable: abcdef.f [type=int, outer=(6)]
+      └── variable: abg.g [type=int, outer=(9)]
 
 # Regression tests for mixed-type equality columns (#22514).
 exec-ddl
@@ -2924,24 +2924,24 @@ project
  │    │    └── columns: foo.a:int:null:1 foo.b:int:null:2 foo.c:float:null:3 foo.d:float:null:4 foo.rowid:int:5
  │    ├── scan
  │    │    └── columns: bar.a:int:null:6 bar.b:float:null:7 bar.c:float:null:8 bar.d:int:null:9 bar.rowid:int:10
- │    └── and [type=bool]
- │         ├── eq [type=bool]
- │         │    ├── variable: foo.a [type=int]
- │         │    └── variable: bar.a [type=int]
- │         ├── eq [type=bool]
- │         │    ├── variable: foo.b [type=int]
- │         │    └── variable: bar.b [type=float]
- │         ├── eq [type=bool]
- │         │    ├── variable: foo.c [type=float]
- │         │    └── variable: bar.c [type=float]
- │         └── eq [type=bool]
- │              ├── variable: foo.d [type=float]
- │              └── variable: bar.d [type=int]
- └── projections
-      ├── variable: foo.a [type=int]
-      ├── variable: foo.b [type=int]
-      ├── variable: foo.c [type=float]
-      └── variable: foo.d [type=float]
+ │    └── and [type=bool, outer=(1-4,6-9)]
+ │         ├── eq [type=bool, outer=(1,6)]
+ │         │    ├── variable: foo.a [type=int, outer=(1)]
+ │         │    └── variable: bar.a [type=int, outer=(6)]
+ │         ├── eq [type=bool, outer=(2,7)]
+ │         │    ├── variable: foo.b [type=int, outer=(2)]
+ │         │    └── variable: bar.b [type=float, outer=(7)]
+ │         ├── eq [type=bool, outer=(3,8)]
+ │         │    ├── variable: foo.c [type=float, outer=(3)]
+ │         │    └── variable: bar.c [type=float, outer=(8)]
+ │         └── eq [type=bool, outer=(4,9)]
+ │              ├── variable: foo.d [type=float, outer=(4)]
+ │              └── variable: bar.d [type=int, outer=(9)]
+ └── projections [outer=(1-4)]
+      ├── variable: foo.a [type=int, outer=(1)]
+      ├── variable: foo.b [type=int, outer=(2)]
+      ├── variable: foo.c [type=float, outer=(3)]
+      └── variable: foo.d [type=float, outer=(4)]
 
 # b can't be an equality column.
 build
@@ -2955,17 +2955,17 @@ project
  │    │    └── columns: foo.a:int:null:1 foo.b:int:null:2 foo.c:float:null:3 foo.d:float:null:4 foo.rowid:int:5
  │    ├── scan
  │    │    └── columns: bar.a:int:null:6 bar.b:float:null:7 bar.c:float:null:8 bar.d:int:null:9 bar.rowid:int:10
- │    └── eq [type=bool]
- │         ├── variable: foo.b [type=int]
- │         └── variable: bar.b [type=float]
- └── projections
-      ├── variable: foo.b [type=int]
-      ├── variable: foo.a [type=int]
-      ├── variable: foo.c [type=float]
-      ├── variable: foo.d [type=float]
-      ├── variable: bar.a [type=int]
-      ├── variable: bar.c [type=float]
-      └── variable: bar.d [type=int]
+ │    └── eq [type=bool, outer=(2,7)]
+ │         ├── variable: foo.b [type=int, outer=(2)]
+ │         └── variable: bar.b [type=float, outer=(7)]
+ └── projections [outer=(1-4,6,8,9)]
+      ├── variable: foo.b [type=int, outer=(2)]
+      ├── variable: foo.a [type=int, outer=(1)]
+      ├── variable: foo.c [type=float, outer=(3)]
+      ├── variable: foo.d [type=float, outer=(4)]
+      ├── variable: bar.a [type=int, outer=(6)]
+      ├── variable: bar.c [type=float, outer=(8)]
+      └── variable: bar.d [type=int, outer=(9)]
 
 # Only a can be an equality column.
 build
@@ -2979,20 +2979,20 @@ project
  │    │    └── columns: foo.a:int:null:1 foo.b:int:null:2 foo.c:float:null:3 foo.d:float:null:4 foo.rowid:int:5
  │    ├── scan
  │    │    └── columns: bar.a:int:null:6 bar.b:float:null:7 bar.c:float:null:8 bar.d:int:null:9 bar.rowid:int:10
- │    └── and [type=bool]
- │         ├── eq [type=bool]
- │         │    ├── variable: foo.a [type=int]
- │         │    └── variable: bar.a [type=int]
- │         └── eq [type=bool]
- │              ├── variable: foo.b [type=int]
- │              └── variable: bar.b [type=float]
- └── projections
-      ├── variable: foo.a [type=int]
-      ├── variable: foo.b [type=int]
-      ├── variable: foo.c [type=float]
-      ├── variable: foo.d [type=float]
-      ├── variable: bar.c [type=float]
-      └── variable: bar.d [type=int]
+ │    └── and [type=bool, outer=(1,2,6,7)]
+ │         ├── eq [type=bool, outer=(1,6)]
+ │         │    ├── variable: foo.a [type=int, outer=(1)]
+ │         │    └── variable: bar.a [type=int, outer=(6)]
+ │         └── eq [type=bool, outer=(2,7)]
+ │              ├── variable: foo.b [type=int, outer=(2)]
+ │              └── variable: bar.b [type=float, outer=(7)]
+ └── projections [outer=(1-4,8,9)]
+      ├── variable: foo.a [type=int, outer=(1)]
+      ├── variable: foo.b [type=int, outer=(2)]
+      ├── variable: foo.c [type=float, outer=(3)]
+      ├── variable: foo.d [type=float, outer=(4)]
+      ├── variable: bar.c [type=float, outer=(8)]
+      └── variable: bar.d [type=int, outer=(9)]
 
 # Only a and c can be equality columns.
 build
@@ -3006,22 +3006,22 @@ project
  │    │    └── columns: foo.a:int:null:1 foo.b:int:null:2 foo.c:float:null:3 foo.d:float:null:4 foo.rowid:int:5
  │    ├── scan
  │    │    └── columns: bar.a:int:null:6 bar.b:float:null:7 bar.c:float:null:8 bar.d:int:null:9 bar.rowid:int:10
- │    └── and [type=bool]
- │         ├── eq [type=bool]
- │         │    ├── variable: foo.a [type=int]
- │         │    └── variable: bar.a [type=int]
- │         ├── eq [type=bool]
- │         │    ├── variable: foo.b [type=int]
- │         │    └── variable: bar.b [type=float]
- │         └── eq [type=bool]
- │              ├── variable: foo.c [type=float]
- │              └── variable: bar.c [type=float]
- └── projections
-      ├── variable: foo.a [type=int]
-      ├── variable: foo.b [type=int]
-      ├── variable: foo.c [type=float]
-      ├── variable: foo.d [type=float]
-      └── variable: bar.d [type=int]
+ │    └── and [type=bool, outer=(1-3,6-8)]
+ │         ├── eq [type=bool, outer=(1,6)]
+ │         │    ├── variable: foo.a [type=int, outer=(1)]
+ │         │    └── variable: bar.a [type=int, outer=(6)]
+ │         ├── eq [type=bool, outer=(2,7)]
+ │         │    ├── variable: foo.b [type=int, outer=(2)]
+ │         │    └── variable: bar.b [type=float, outer=(7)]
+ │         └── eq [type=bool, outer=(3,8)]
+ │              ├── variable: foo.c [type=float, outer=(3)]
+ │              └── variable: bar.c [type=float, outer=(8)]
+ └── projections [outer=(1-4,9)]
+      ├── variable: foo.a [type=int, outer=(1)]
+      ├── variable: foo.b [type=int, outer=(2)]
+      ├── variable: foo.c [type=float, outer=(3)]
+      ├── variable: foo.d [type=float, outer=(4)]
+      └── variable: bar.d [type=int, outer=(9)]
 
 # b can't be an equality column.
 build
@@ -3035,18 +3035,18 @@ project
  │    │    └── columns: foo.a:int:null:1 foo.b:int:null:2 foo.c:float:null:3 foo.d:float:null:4 foo.rowid:int:5
  │    ├── scan
  │    │    └── columns: bar.a:int:null:6 bar.b:float:null:7 bar.c:float:null:8 bar.d:int:null:9 bar.rowid:int:10
- │    └── eq [type=bool]
- │         ├── variable: foo.b [type=int]
- │         └── variable: bar.b [type=float]
- └── projections
-      ├── variable: foo.a [type=int]
-      ├── variable: foo.b [type=int]
-      ├── variable: foo.c [type=float]
-      ├── variable: foo.d [type=float]
-      ├── variable: bar.a [type=int]
-      ├── variable: bar.b [type=float]
-      ├── variable: bar.c [type=float]
-      └── variable: bar.d [type=int]
+ │    └── eq [type=bool, outer=(2,7)]
+ │         ├── variable: foo.b [type=int, outer=(2)]
+ │         └── variable: bar.b [type=float, outer=(7)]
+ └── projections [outer=(1-4,6-9)]
+      ├── variable: foo.a [type=int, outer=(1)]
+      ├── variable: foo.b [type=int, outer=(2)]
+      ├── variable: foo.c [type=float, outer=(3)]
+      ├── variable: foo.d [type=float, outer=(4)]
+      ├── variable: bar.a [type=int, outer=(6)]
+      ├── variable: bar.b [type=float, outer=(7)]
+      ├── variable: bar.c [type=float, outer=(8)]
+      └── variable: bar.d [type=int, outer=(9)]
 
 # Only a can be an equality column.
 build
@@ -3060,22 +3060,22 @@ project
  │    │    └── columns: foo.a:int:null:1 foo.b:int:null:2 foo.c:float:null:3 foo.d:float:null:4 foo.rowid:int:5
  │    ├── scan
  │    │    └── columns: bar.a:int:null:6 bar.b:float:null:7 bar.c:float:null:8 bar.d:int:null:9 bar.rowid:int:10
- │    └── and [type=bool]
- │         ├── eq [type=bool]
- │         │    ├── variable: foo.a [type=int]
- │         │    └── variable: bar.a [type=int]
- │         └── eq [type=bool]
- │              ├── variable: foo.b [type=int]
- │              └── variable: bar.b [type=float]
- └── projections
-      ├── variable: foo.a [type=int]
-      ├── variable: foo.b [type=int]
-      ├── variable: foo.c [type=float]
-      ├── variable: foo.d [type=float]
-      ├── variable: bar.a [type=int]
-      ├── variable: bar.b [type=float]
-      ├── variable: bar.c [type=float]
-      └── variable: bar.d [type=int]
+ │    └── and [type=bool, outer=(1,2,6,7)]
+ │         ├── eq [type=bool, outer=(1,6)]
+ │         │    ├── variable: foo.a [type=int, outer=(1)]
+ │         │    └── variable: bar.a [type=int, outer=(6)]
+ │         └── eq [type=bool, outer=(2,7)]
+ │              ├── variable: foo.b [type=int, outer=(2)]
+ │              └── variable: bar.b [type=float, outer=(7)]
+ └── projections [outer=(1-4,6-9)]
+      ├── variable: foo.a [type=int, outer=(1)]
+      ├── variable: foo.b [type=int, outer=(2)]
+      ├── variable: foo.c [type=float, outer=(3)]
+      ├── variable: foo.d [type=float, outer=(4)]
+      ├── variable: bar.a [type=int, outer=(6)]
+      ├── variable: bar.b [type=float, outer=(7)]
+      ├── variable: bar.c [type=float, outer=(8)]
+      └── variable: bar.d [type=int, outer=(9)]
 
 build
 SELECT * FROM foo, bar WHERE foo.b = bar.b
@@ -3091,18 +3091,18 @@ project
  │    │    ├── scan
  │    │    │    └── columns: bar.a:int:null:6 bar.b:float:null:7 bar.c:float:null:8 bar.d:int:null:9 bar.rowid:int:10
  │    │    └── true [type=bool]
- │    └── eq [type=bool]
- │         ├── variable: foo.b [type=int]
- │         └── variable: bar.b [type=float]
- └── projections
-      ├── variable: foo.a [type=int]
-      ├── variable: foo.b [type=int]
-      ├── variable: foo.c [type=float]
-      ├── variable: foo.d [type=float]
-      ├── variable: bar.a [type=int]
-      ├── variable: bar.b [type=float]
-      ├── variable: bar.c [type=float]
-      └── variable: bar.d [type=int]
+ │    └── eq [type=bool, outer=(2,7)]
+ │         ├── variable: foo.b [type=int, outer=(2)]
+ │         └── variable: bar.b [type=float, outer=(7)]
+ └── projections [outer=(1-4,6-9)]
+      ├── variable: foo.a [type=int, outer=(1)]
+      ├── variable: foo.b [type=int, outer=(2)]
+      ├── variable: foo.c [type=float, outer=(3)]
+      ├── variable: foo.d [type=float, outer=(4)]
+      ├── variable: bar.a [type=int, outer=(6)]
+      ├── variable: bar.b [type=float, outer=(7)]
+      ├── variable: bar.c [type=float, outer=(8)]
+      └── variable: bar.d [type=int, outer=(9)]
 
 # Only a can be an equality column.
 build
@@ -3119,22 +3119,22 @@ project
  │    │    ├── scan
  │    │    │    └── columns: bar.a:int:null:6 bar.b:float:null:7 bar.c:float:null:8 bar.d:int:null:9 bar.rowid:int:10
  │    │    └── true [type=bool]
- │    └── and [type=bool]
- │         ├── eq [type=bool]
- │         │    ├── variable: foo.a [type=int]
- │         │    └── variable: bar.a [type=int]
- │         └── eq [type=bool]
- │              ├── variable: foo.b [type=int]
- │              └── variable: bar.b [type=float]
- └── projections
-      ├── variable: foo.a [type=int]
-      ├── variable: foo.b [type=int]
-      ├── variable: foo.c [type=float]
-      ├── variable: foo.d [type=float]
-      ├── variable: bar.a [type=int]
-      ├── variable: bar.b [type=float]
-      ├── variable: bar.c [type=float]
-      └── variable: bar.d [type=int]
+ │    └── and [type=bool, outer=(1,2,6,7)]
+ │         ├── eq [type=bool, outer=(1,6)]
+ │         │    ├── variable: foo.a [type=int, outer=(1)]
+ │         │    └── variable: bar.a [type=int, outer=(6)]
+ │         └── eq [type=bool, outer=(2,7)]
+ │              ├── variable: foo.b [type=int, outer=(2)]
+ │              └── variable: bar.b [type=float, outer=(7)]
+ └── projections [outer=(1-4,6-9)]
+      ├── variable: foo.a [type=int, outer=(1)]
+      ├── variable: foo.b [type=int, outer=(2)]
+      ├── variable: foo.c [type=float, outer=(3)]
+      ├── variable: foo.d [type=float, outer=(4)]
+      ├── variable: bar.a [type=int, outer=(6)]
+      ├── variable: bar.b [type=float, outer=(7)]
+      ├── variable: bar.c [type=float, outer=(8)]
+      └── variable: bar.d [type=int, outer=(9)]
 
 # Only a and c can be equality columns.
 build
@@ -3150,27 +3150,27 @@ project
  │    │    │    └── columns: foo.a:int:null:1 foo.b:int:null:2 foo.c:float:null:3 foo.d:float:null:4 foo.rowid:int:5
  │    │    ├── scan
  │    │    │    └── columns: bar.a:int:null:6 bar.b:float:null:7 bar.c:float:null:8 bar.d:int:null:9 bar.rowid:int:10
- │    │    └── and [type=bool]
- │    │         ├── eq [type=bool]
- │    │         │    ├── variable: foo.a [type=int]
- │    │         │    └── variable: bar.a [type=int]
- │    │         └── eq [type=bool]
- │    │              ├── variable: foo.b [type=int]
- │    │              └── variable: bar.b [type=float]
- │    └── and [type=bool]
- │         ├── eq [type=bool]
- │         │    ├── variable: foo.c [type=float]
- │         │    └── variable: bar.c [type=float]
- │         └── eq [type=bool]
- │              ├── variable: foo.d [type=float]
- │              └── variable: bar.d [type=int]
- └── projections
-      ├── variable: foo.a [type=int]
-      ├── variable: foo.b [type=int]
-      ├── variable: foo.c [type=float]
-      ├── variable: foo.d [type=float]
-      ├── variable: bar.c [type=float]
-      └── variable: bar.d [type=int]
+ │    │    └── and [type=bool, outer=(1,2,6,7)]
+ │    │         ├── eq [type=bool, outer=(1,6)]
+ │    │         │    ├── variable: foo.a [type=int, outer=(1)]
+ │    │         │    └── variable: bar.a [type=int, outer=(6)]
+ │    │         └── eq [type=bool, outer=(2,7)]
+ │    │              ├── variable: foo.b [type=int, outer=(2)]
+ │    │              └── variable: bar.b [type=float, outer=(7)]
+ │    └── and [type=bool, outer=(3,4,8,9)]
+ │         ├── eq [type=bool, outer=(3,8)]
+ │         │    ├── variable: foo.c [type=float, outer=(3)]
+ │         │    └── variable: bar.c [type=float, outer=(8)]
+ │         └── eq [type=bool, outer=(4,9)]
+ │              ├── variable: foo.d [type=float, outer=(4)]
+ │              └── variable: bar.d [type=int, outer=(9)]
+ └── projections [outer=(1-4,8,9)]
+      ├── variable: foo.a [type=int, outer=(1)]
+      ├── variable: foo.b [type=int, outer=(2)]
+      ├── variable: foo.c [type=float, outer=(3)]
+      ├── variable: foo.d [type=float, outer=(4)]
+      ├── variable: bar.c [type=float, outer=(8)]
+      └── variable: bar.d [type=int, outer=(9)]
 
 exec-ddl
 CREATE TABLE t.kv (
@@ -3204,8 +3204,8 @@ project
  │    │    └── projections
  │    │         └── const: 1 [type=int]
  │    └── true [type=bool]
- └── projections
-      └── variable: k [type=int]
+ └── projections [outer=(5)]
+      └── variable: k [type=int, outer=(5)]
 
 # TODO(rytaft): This test case will fail until we implement subquery
 # replacement.

--- a/pkg/sql/opt/optbuilder/testdata/orderby
+++ b/pkg/sql/opt/optbuilder/testdata/orderby
@@ -25,8 +25,8 @@ project
  │    ├── ordering: +3
  │    └── scan
  │         └── columns: t.a:int:1 t.b:int:null:2 t.c:bool:null:3
- └── projections
-      └── variable: t.c [type=bool]
+ └── projections [outer=(3)]
+      └── variable: t.c [type=bool, outer=(3)]
 
 build
 SELECT c FROM t ORDER BY c DESC
@@ -39,8 +39,8 @@ project
  │    ├── ordering: -3
  │    └── scan
  │         └── columns: t.a:int:1 t.b:int:null:2 t.c:bool:null:3
- └── projections
-      └── variable: t.c [type=bool]
+ └── projections [outer=(3)]
+      └── variable: t.c [type=bool, outer=(3)]
 
 build
 SELECT a, b FROM t ORDER BY b
@@ -53,9 +53,9 @@ project
  │    ├── ordering: +2
  │    └── scan
  │         └── columns: t.a:int:1 t.b:int:null:2 t.c:bool:null:3
- └── projections
-      ├── variable: t.a [type=int]
-      └── variable: t.b [type=int]
+ └── projections [outer=(1,2)]
+      ├── variable: t.a [type=int, outer=(1)]
+      └── variable: t.b [type=int, outer=(2)]
 
 build
 SELECT a, b FROM t ORDER BY b DESC
@@ -68,9 +68,9 @@ project
  │    ├── ordering: -2
  │    └── scan
  │         └── columns: t.a:int:1 t.b:int:null:2 t.c:bool:null:3
- └── projections
-      ├── variable: t.a [type=int]
-      └── variable: t.b [type=int]
+ └── projections [outer=(1,2)]
+      ├── variable: t.a [type=int, outer=(1)]
+      └── variable: t.b [type=int, outer=(2)]
 
 build
 SELECT a AS foo, b FROM t ORDER BY foo DESC
@@ -83,9 +83,9 @@ project
  │    ├── ordering: -1
  │    └── scan
  │         └── columns: t.a:int:1 t.b:int:null:2 t.c:bool:null:3
- └── projections
-      ├── variable: t.a [type=int]
-      └── variable: t.b [type=int]
+ └── projections [outer=(1,2)]
+      ├── variable: t.a [type=int, outer=(1)]
+      └── variable: t.b [type=int, outer=(2)]
 
 build
 SELECT a, b FROM t WHERE b = 7 ORDER BY b, a
@@ -101,12 +101,12 @@ project
  │    │    ├── ordering: +2,+1
  │    │    └── scan
  │    │         └── columns: t.a:int:1 t.b:int:null:2 t.c:bool:null:3
- │    └── eq [type=bool]
- │         ├── variable: t.b [type=int]
+ │    └── eq [type=bool, outer=(2)]
+ │         ├── variable: t.b [type=int, outer=(2)]
  │         └── const: 7 [type=int]
- └── projections
-      ├── variable: t.a [type=int]
-      └── variable: t.b [type=int]
+ └── projections [outer=(1,2)]
+      ├── variable: t.a [type=int, outer=(1)]
+      └── variable: t.b [type=int, outer=(2)]
 
 build
 SELECT a, b FROM t ORDER BY b, a DESC
@@ -119,9 +119,9 @@ project
  │    ├── ordering: +2,-1
  │    └── scan
  │         └── columns: t.a:int:1 t.b:int:null:2 t.c:bool:null:3
- └── projections
-      ├── variable: t.a [type=int]
-      └── variable: t.b [type=int]
+ └── projections [outer=(1,2)]
+      ├── variable: t.a [type=int, outer=(1)]
+      └── variable: t.b [type=int, outer=(2)]
 
 build
 SELECT a, b, a+b AS ab FROM t WHERE b = 7 ORDER BY ab DESC, a
@@ -135,12 +135,12 @@ sort
       │    ├── columns: t.a:int:1 t.b:int:null:2 t.c:bool:null:3
       │    ├── scan
       │    │    └── columns: t.a:int:1 t.b:int:null:2 t.c:bool:null:3
-      │    └── eq [type=bool]
-      │         ├── variable: t.b [type=int]
+      │    └── eq [type=bool, outer=(2)]
+      │         ├── variable: t.b [type=int, outer=(2)]
       │         └── const: 7 [type=int]
-      └── projections
-           ├── variable: t.a [type=int]
-           ├── variable: t.b [type=int]
-           └── plus [type=int]
-                ├── variable: t.a [type=int]
-                └── variable: t.b [type=int]
+      └── projections [outer=(1,2)]
+           ├── variable: t.a [type=int, outer=(1)]
+           ├── variable: t.b [type=int, outer=(2)]
+           └── plus [type=int, outer=(1,2)]
+                ├── variable: t.a [type=int, outer=(1)]
+                └── variable: t.b [type=int, outer=(2)]

--- a/pkg/sql/opt/optbuilder/testdata/project
+++ b/pkg/sql/opt/optbuilder/testdata/project
@@ -34,8 +34,8 @@ project
  ├── columns: x:int:1
  ├── scan
  │    └── columns: a.x:int:1 a.y:float:null:2
- └── projections
-      └── variable: a.x [type=int]
+ └── projections [outer=(1)]
+      └── variable: a.x [type=int, outer=(1)]
 
 build
 SELECT a.x, a.y FROM t.a
@@ -50,9 +50,9 @@ project
  ├── columns: y:float:null:2 x:int:1
  ├── scan
  │    └── columns: a.x:int:1 a.y:float:null:2
- └── projections
-      ├── variable: a.y [type=float]
-      └── variable: a.x [type=int]
+ └── projections [outer=(1,2)]
+      ├── variable: a.y [type=float, outer=(2)]
+      └── variable: a.x [type=int, outer=(1)]
 
 build
 SELECT * FROM t.a
@@ -69,9 +69,9 @@ project
  ├── columns: x:int:null:1 y:float:null:2
  ├── scan
  │    └── columns: b.x:int:null:1 b.y:float:null:2 b.rowid:int:3
- └── projections
-      ├── variable: b.x [type=int]
-      └── variable: b.y [type=float]
+ └── projections [outer=(1,2)]
+      ├── variable: b.x [type=int, outer=(1)]
+      └── variable: b.y [type=float, outer=(2)]
 
 build
 SELECT (a.x + 3) AS "X", false AS "Y" FROM t.a
@@ -80,9 +80,9 @@ project
  ├── columns: X:int:null:3 Y:bool:null:4
  ├── scan
  │    └── columns: a.x:int:1 a.y:float:null:2
- └── projections
-      ├── plus [type=int]
-      │    ├── variable: a.x [type=int]
+ └── projections [outer=(1)]
+      ├── plus [type=int, outer=(1)]
+      │    ├── variable: a.x [type=int, outer=(1)]
       │    └── const: 3 [type=int]
       └── false [type=bool]
 
@@ -93,15 +93,15 @@ project
  ├── columns: x:int:1 y:float:null:2 column3:bool:null:3
  ├── scan
  │    └── columns: a.x:int:1 a.y:float:null:2
- └── projections
-      ├── variable: a.x [type=int]
-      ├── variable: a.y [type=float]
-      └── or [type=bool]
-           ├── lt [type=bool]
-           │    ├── variable: a.x [type=int]
-           │    └── variable: a.y [type=float]
-           └── gt [type=bool]
-                ├── variable: a.x [type=int]
+ └── projections [outer=(1,2)]
+      ├── variable: a.x [type=int, outer=(1)]
+      ├── variable: a.y [type=float, outer=(2)]
+      └── or [type=bool, outer=(1,2)]
+           ├── lt [type=bool, outer=(1,2)]
+           │    ├── variable: a.x [type=int, outer=(1)]
+           │    └── variable: a.y [type=float, outer=(2)]
+           └── gt [type=bool, outer=(1)]
+                ├── variable: a.x [type=int, outer=(1)]
                 └── const: 1000 [type=int]
 
 build
@@ -111,9 +111,9 @@ project
  ├── columns: x:int:1 y:float:null:2 column3:bool:null:3
  ├── scan
  │    └── columns: a.x:int:1 a.y:float:null:2
- └── projections
-      ├── variable: a.x [type=int]
-      ├── variable: a.y [type=float]
+ └── projections [outer=(1,2)]
+      ├── variable: a.x [type=int, outer=(1)]
+      ├── variable: a.y [type=float, outer=(2)]
       └── true [type=bool]
 
 build
@@ -125,19 +125,19 @@ project
  │    ├── columns: column3:int:null:3 column4:float:null:4
  │    ├── scan
  │    │    └── columns: a.x:int:1 a.y:float:null:2
- │    └── projections
- │         ├── plus [type=int]
- │         │    ├── variable: a.x [type=int]
+ │    └── projections [outer=(1,2)]
+ │         ├── plus [type=int, outer=(1)]
+ │         │    ├── variable: a.x [type=int, outer=(1)]
  │         │    └── const: 3 [type=int]
- │         └── plus [type=float]
- │              ├── variable: a.y [type=float]
+ │         └── plus [type=float, outer=(2)]
+ │              ├── variable: a.y [type=float, outer=(2)]
  │              └── const: 1.0 [type=float]
- └── projections
-      ├── plus [type=int]
-      │    ├── variable: column3 [type=int]
+ └── projections [outer=(3,4)]
+      ├── plus [type=int, outer=(3)]
+      │    ├── variable: column3 [type=int, outer=(3)]
       │    └── const: 1 [type=int]
-      └── plus [type=float]
-           ├── variable: column4 [type=float]
+      └── plus [type=float, outer=(4)]
+           ├── variable: column4 [type=float, outer=(4)]
            └── const: 1.0 [type=float]
 
 build
@@ -147,8 +147,8 @@ project
  ├── columns: rowid:int:3
  ├── scan
  │    └── columns: b.x:int:null:1 b.y:float:null:2 b.rowid:int:3
- └── projections
-      └── variable: b.rowid [type=int]
+ └── projections [outer=(3)]
+      └── variable: b.rowid [type=int, outer=(3)]
 
 build
 SELECT rowid FROM (SELECT * FROM b)
@@ -162,8 +162,8 @@ project
  ├── columns: rowid:int:3
  ├── scan
  │    └── columns: b.x:int:null:1 b.y:float:null:2 b.rowid:int:3
- └── projections
-      └── variable: b.rowid [type=int]
+ └── projections [outer=(3)]
+      └── variable: b.rowid [type=int, outer=(3)]
 
 build
 SELECT q.r FROM (SELECT rowid FROM b) AS q(r)
@@ -172,8 +172,8 @@ project
  ├── columns: r:int:3
  ├── scan
  │    └── columns: b.x:int:null:1 b.y:float:null:2 b.rowid:int:3
- └── projections
-      └── variable: b.rowid [type=int]
+ └── projections [outer=(3)]
+      └── variable: b.rowid [type=int, outer=(3)]
 
 build
 SELECT r FROM (SELECT rowid FROM b) AS q(r)
@@ -182,8 +182,8 @@ project
  ├── columns: r:int:3
  ├── scan
  │    └── columns: b.x:int:null:1 b.y:float:null:2 b.rowid:int:3
- └── projections
-      └── variable: b.rowid [type=int]
+ └── projections [outer=(3)]
+      └── variable: b.rowid [type=int, outer=(3)]
 
 exec-ddl
 CREATE TABLE c (x INT, y FLOAT)
@@ -207,9 +207,9 @@ project
  ├── columns: column4:string:null:4
  ├── scan
  │    └── columns: b.x:int:null:1 b.y:float:null:2 b.rowid:int:3
- └── projections
-      └── cast: string [type=string]
-           └── variable: b.rowid [type=int]
+ └── projections [outer=(3)]
+      └── cast: string [type=string, outer=(3)]
+           └── variable: b.rowid [type=int, outer=(3)]
 
 build
 SELECT (x, y)::timestamp FROM b

--- a/pkg/sql/opt/optbuilder/testdata/scalar
+++ b/pkg/sql/opt/optbuilder/testdata/scalar
@@ -185,8 +185,7 @@ build-scalar vars=(int, int)
 + @1 + (- @2)
 ----
 plus [type=int, outer=(1,2)]
- ├── unary-plus [type=int, outer=(1)]
- │    └── variable: @1 [type=int, outer=(1)]
+ ├── variable: @1 [type=int, outer=(1)]
  └── unary-minus [type=int, outer=(2)]
       └── variable: @2 [type=int, outer=(2)]
 

--- a/pkg/sql/opt/optbuilder/testdata/scalar
+++ b/pkg/sql/opt/optbuilder/testdata/scalar
@@ -13,37 +13,37 @@ plus [type=int]
 build-scalar vars=(string)
 @1
 ----
-variable: @1 [type=string]
+variable: @1 [type=string, outer=(1)]
 
 build-scalar vars=(int)
 @1 + 2
 ----
-plus [type=int]
- ├── variable: @1 [type=int]
+plus [type=int, outer=(1)]
+ ├── variable: @1 [type=int, outer=(1)]
  └── const: 2 [type=int]
 
 build-scalar vars=(int, int)
 @1 >= 5 AND @1 <= 10 AND @2 < 4
 ----
-and [type=bool]
- ├── and [type=bool]
- │    ├── ge [type=bool]
- │    │    ├── variable: @1 [type=int]
+and [type=bool, outer=(1,2)]
+ ├── and [type=bool, outer=(1)]
+ │    ├── ge [type=bool, outer=(1)]
+ │    │    ├── variable: @1 [type=int, outer=(1)]
  │    │    └── const: 5 [type=int]
- │    └── le [type=bool]
- │         ├── variable: @1 [type=int]
+ │    └── le [type=bool, outer=(1)]
+ │         ├── variable: @1 [type=int, outer=(1)]
  │         └── const: 10 [type=int]
- └── lt [type=bool]
-      ├── variable: @2 [type=int]
+ └── lt [type=bool, outer=(2)]
+      ├── variable: @2 [type=int, outer=(2)]
       └── const: 4 [type=int]
 
 build-scalar vars=(int, int)
 (@1, @2) = (1, 2)
 ----
-eq [type=bool]
- ├── tuple [type=tuple{int, int}]
- │    ├── variable: @1 [type=int]
- │    └── variable: @2 [type=int]
+eq [type=bool, outer=(1,2)]
+ ├── tuple [type=tuple{int, int}, outer=(1,2)]
+ │    ├── variable: @1 [type=int, outer=(1)]
+ │    └── variable: @2 [type=int, outer=(2)]
  └── tuple [type=tuple{int, int}]
       ├── const: 1 [type=int]
       └── const: 2 [type=int]
@@ -51,8 +51,8 @@ eq [type=bool]
 build-scalar vars=(int)
 @1 IN (1, 2)
 ----
-in [type=bool]
- ├── variable: @1 [type=int]
+in [type=bool, outer=(1)]
+ ├── variable: @1 [type=int, outer=(1)]
  └── tuple [type=tuple{int, int}]
       ├── const: 1 [type=int]
       └── const: 2 [type=int]
@@ -60,10 +60,10 @@ in [type=bool]
 build-scalar vars=(int, int)
 (@1, @2) IN ((1, 2), (3, 4))
 ----
-in [type=bool]
- ├── tuple [type=tuple{int, int}]
- │    ├── variable: @1 [type=int]
- │    └── variable: @2 [type=int]
+in [type=bool, outer=(1,2)]
+ ├── tuple [type=tuple{int, int}, outer=(1,2)]
+ │    ├── variable: @1 [type=int, outer=(1)]
+ │    └── variable: @2 [type=int, outer=(2)]
  └── tuple [type=tuple{tuple{int, int}, tuple{int, int}}]
       ├── tuple [type=tuple{int, int}]
       │    ├── const: 1 [type=int]
@@ -75,37 +75,37 @@ in [type=bool]
 build-scalar vars=(int, int, int, int)
 (@1, @2 + @3, 5 + @4 * 2) = (@2 + @3, 8, @1 - @4)
 ----
-eq [type=bool]
- ├── tuple [type=tuple{int, int, int}]
- │    ├── variable: @1 [type=int]
- │    ├── plus [type=int]
- │    │    ├── variable: @2 [type=int]
- │    │    └── variable: @3 [type=int]
- │    └── plus [type=int]
+eq [type=bool, outer=(1-4)]
+ ├── tuple [type=tuple{int, int, int}, outer=(1-4)]
+ │    ├── variable: @1 [type=int, outer=(1)]
+ │    ├── plus [type=int, outer=(2,3)]
+ │    │    ├── variable: @2 [type=int, outer=(2)]
+ │    │    └── variable: @3 [type=int, outer=(3)]
+ │    └── plus [type=int, outer=(4)]
  │         ├── const: 5 [type=int]
- │         └── mult [type=int]
- │              ├── variable: @4 [type=int]
+ │         └── mult [type=int, outer=(4)]
+ │              ├── variable: @4 [type=int, outer=(4)]
  │              └── const: 2 [type=int]
- └── tuple [type=tuple{int, int, int}]
-      ├── plus [type=int]
-      │    ├── variable: @2 [type=int]
-      │    └── variable: @3 [type=int]
+ └── tuple [type=tuple{int, int, int}, outer=(1-4)]
+      ├── plus [type=int, outer=(2,3)]
+      │    ├── variable: @2 [type=int, outer=(2)]
+      │    └── variable: @3 [type=int, outer=(3)]
       ├── const: 8 [type=int]
-      └── minus [type=int]
-           ├── variable: @1 [type=int]
-           └── variable: @4 [type=int]
+      └── minus [type=int, outer=(1,4)]
+           ├── variable: @1 [type=int, outer=(1)]
+           └── variable: @4 [type=int, outer=(4)]
 
 build-scalar vars=(int, int, int, int)
 ((@1, @2), (@3, @4)) = ((1, 2), (3, 4))
 ----
-eq [type=bool]
- ├── tuple [type=tuple{tuple{int, int}, tuple{int, int}}]
- │    ├── tuple [type=tuple{int, int}]
- │    │    ├── variable: @1 [type=int]
- │    │    └── variable: @2 [type=int]
- │    └── tuple [type=tuple{int, int}]
- │         ├── variable: @3 [type=int]
- │         └── variable: @4 [type=int]
+eq [type=bool, outer=(1-4)]
+ ├── tuple [type=tuple{tuple{int, int}, tuple{int, int}}, outer=(1-4)]
+ │    ├── tuple [type=tuple{int, int}, outer=(1,2)]
+ │    │    ├── variable: @1 [type=int, outer=(1)]
+ │    │    └── variable: @2 [type=int, outer=(2)]
+ │    └── tuple [type=tuple{int, int}, outer=(3,4)]
+ │         ├── variable: @3 [type=int, outer=(3)]
+ │         └── variable: @4 [type=int, outer=(4)]
  └── tuple [type=tuple{tuple{int, int}, tuple{int, int}}]
       ├── tuple [type=tuple{int, int}]
       │    ├── const: 1 [type=int]
@@ -117,87 +117,87 @@ eq [type=bool]
 build-scalar vars=(int, int, int, string)
 (@1, (@2, 'a'), (@3, 'b', 5)) = (9, (@1 + @3, @4), (5, @4, @1))
 ----
-eq [type=bool]
- ├── tuple [type=tuple{int, tuple{int, string}, tuple{int, string, int}}]
- │    ├── variable: @1 [type=int]
- │    ├── tuple [type=tuple{int, string}]
- │    │    ├── variable: @2 [type=int]
+eq [type=bool, outer=(1-4)]
+ ├── tuple [type=tuple{int, tuple{int, string}, tuple{int, string, int}}, outer=(1-3)]
+ │    ├── variable: @1 [type=int, outer=(1)]
+ │    ├── tuple [type=tuple{int, string}, outer=(2)]
+ │    │    ├── variable: @2 [type=int, outer=(2)]
  │    │    └── const: 'a' [type=string]
- │    └── tuple [type=tuple{int, string, int}]
- │         ├── variable: @3 [type=int]
+ │    └── tuple [type=tuple{int, string, int}, outer=(3)]
+ │         ├── variable: @3 [type=int, outer=(3)]
  │         ├── const: 'b' [type=string]
  │         └── const: 5 [type=int]
- └── tuple [type=tuple{int, tuple{int, string}, tuple{int, string, int}}]
+ └── tuple [type=tuple{int, tuple{int, string}, tuple{int, string, int}}, outer=(1,3,4)]
       ├── const: 9 [type=int]
-      ├── tuple [type=tuple{int, string}]
-      │    ├── plus [type=int]
-      │    │    ├── variable: @1 [type=int]
-      │    │    └── variable: @3 [type=int]
-      │    └── variable: @4 [type=string]
-      └── tuple [type=tuple{int, string, int}]
+      ├── tuple [type=tuple{int, string}, outer=(1,3,4)]
+      │    ├── plus [type=int, outer=(1,3)]
+      │    │    ├── variable: @1 [type=int, outer=(1)]
+      │    │    └── variable: @3 [type=int, outer=(3)]
+      │    └── variable: @4 [type=string, outer=(4)]
+      └── tuple [type=tuple{int, string, int}, outer=(1,4)]
            ├── const: 5 [type=int]
-           ├── variable: @4 [type=string]
-           └── variable: @1 [type=int]
+           ├── variable: @4 [type=string, outer=(4)]
+           └── variable: @1 [type=int, outer=(1)]
 
 build-scalar vars=(int, int)
 @1 IS NULL
 ----
-is [type=bool]
- ├── variable: @1 [type=int]
+is [type=bool, outer=(1)]
+ ├── variable: @1 [type=int, outer=(1)]
  └── null [type=unknown]
 
 build-scalar vars=(int, int)
 @1 IS NOT DISTINCT FROM NULL
 ----
-is [type=bool]
- ├── variable: @1 [type=int]
+is [type=bool, outer=(1)]
+ ├── variable: @1 [type=int, outer=(1)]
  └── null [type=unknown]
 
 build-scalar vars=(int, int)
 @1 IS NOT DISTINCT FROM @2
 ----
-is [type=bool]
- ├── variable: @1 [type=int]
- └── variable: @2 [type=int]
+is [type=bool, outer=(1,2)]
+ ├── variable: @1 [type=int, outer=(1)]
+ └── variable: @2 [type=int, outer=(2)]
 
 build-scalar vars=(int, int)
 @1 IS NOT NULL
 ----
-is-not [type=bool]
- ├── variable: @1 [type=int]
+is-not [type=bool, outer=(1)]
+ ├── variable: @1 [type=int, outer=(1)]
  └── null [type=unknown]
 
 build-scalar vars=(int, int)
 @1 IS DISTINCT FROM NULL
 ----
-is-not [type=bool]
- ├── variable: @1 [type=int]
+is-not [type=bool, outer=(1)]
+ ├── variable: @1 [type=int, outer=(1)]
  └── null [type=unknown]
 
 build-scalar vars=(int, int)
 @1 IS DISTINCT FROM @2
 ----
-is-not [type=bool]
- ├── variable: @1 [type=int]
- └── variable: @2 [type=int]
+is-not [type=bool, outer=(1,2)]
+ ├── variable: @1 [type=int, outer=(1)]
+ └── variable: @2 [type=int, outer=(2)]
 
 build-scalar vars=(int, int)
 + @1 + (- @2)
 ----
-plus [type=int]
- ├── unary-plus [type=int]
- │    └── variable: @1 [type=int]
- └── unary-minus [type=int]
-      └── variable: @2 [type=int]
+plus [type=int, outer=(1,2)]
+ ├── unary-plus [type=int, outer=(1)]
+ │    └── variable: @1 [type=int, outer=(1)]
+ └── unary-minus [type=int, outer=(2)]
+      └── variable: @2 [type=int, outer=(2)]
 
 build-scalar vars=(int, int)
 CASE WHEN @1 = 2 THEN 1 ELSE 2 END
 ----
-case [type=int]
+case [type=int, outer=(1)]
  ├── true [type=bool]
- ├── when [type=int]
- │    ├── eq [type=bool]
- │    │    ├── variable: @1 [type=int]
+ ├── when [type=int, outer=(1)]
+ │    ├── eq [type=bool, outer=(1)]
+ │    │    ├── variable: @1 [type=int, outer=(1)]
  │    │    └── const: 2 [type=int]
  │    └── const: 1 [type=int]
  └── const: 2 [type=int]
@@ -206,25 +206,25 @@ case [type=int]
 build-scalar vars=(string)
 LENGTH(@1) = 2
 ----
-eq [type=bool]
- ├── function: length [type=int]
- │    └── variable: @1 [type=string]
+eq [type=bool, outer=(1)]
+ ├── function: length [type=int, outer=(1)]
+ │    └── variable: @1 [type=string, outer=(1)]
  └── const: 2 [type=int]
 
 
 build-scalar vars=(jsonb)
 @1 @> '{"a":1}'
 ----
-contains [type=bool]
- ├── variable: @1 [type=jsonb]
+contains [type=bool, outer=(1)]
+ ├── variable: @1 [type=jsonb, outer=(1)]
  └── const: '{"a": 1}' [type=jsonb]
 
 
 build-scalar vars=(jsonb)
 '{"a":1}' <@ @1
 ----
-contains [type=bool]
- ├── variable: @1 [type=jsonb]
+contains [type=bool, outer=(1)]
+ ├── variable: @1 [type=jsonb, outer=(1)]
  └── const: '{"a": 1}' [type=jsonb]
 
 
@@ -271,26 +271,26 @@ cast: int [type=int]
 build-scalar vars=(int, int)
 IFNULL(@1, @2)
 ----
-coalesce [type=int]
- ├── variable: @1 [type=int]
- └── variable: @2 [type=int]
+coalesce [type=int, outer=(1,2)]
+ ├── variable: @1 [type=int, outer=(1)]
+ └── variable: @2 [type=int, outer=(2)]
 
 build-scalar vars=(int, int, int)
 COALESCE(@1, @2, @3)
 ----
-coalesce [type=int]
- ├── variable: @1 [type=int]
- ├── variable: @2 [type=int]
- └── variable: @3 [type=int]
+coalesce [type=int, outer=(1-3)]
+ ├── variable: @1 [type=int, outer=(1)]
+ ├── variable: @2 [type=int, outer=(2)]
+ └── variable: @3 [type=int, outer=(3)]
 
 build-scalar vars=(int)
 CASE WHEN @1 > 5 THEN 1 ELSE -1 END
 ----
-case [type=int]
+case [type=int, outer=(1)]
  ├── true [type=bool]
- ├── when [type=int]
- │    ├── gt [type=bool]
- │    │    ├── variable: @1 [type=int]
+ ├── when [type=int, outer=(1)]
+ │    ├── gt [type=bool, outer=(1)]
+ │    │    ├── variable: @1 [type=int, outer=(1)]
  │    │    └── const: 5 [type=int]
  │    └── const: 1 [type=int]
  └── unary-minus [type=int]
@@ -299,16 +299,16 @@ case [type=int]
 build-scalar vars=(int)
 CASE WHEN @1 > 5 THEN 1 WHEN @1 < 0 THEN 2 ELSE -1 END
 ----
-case [type=int]
+case [type=int, outer=(1)]
  ├── true [type=bool]
- ├── when [type=int]
- │    ├── gt [type=bool]
- │    │    ├── variable: @1 [type=int]
+ ├── when [type=int, outer=(1)]
+ │    ├── gt [type=bool, outer=(1)]
+ │    │    ├── variable: @1 [type=int, outer=(1)]
  │    │    └── const: 5 [type=int]
  │    └── const: 1 [type=int]
- ├── when [type=int]
- │    ├── lt [type=bool]
- │    │    ├── variable: @1 [type=int]
+ ├── when [type=int, outer=(1)]
+ │    ├── lt [type=bool, outer=(1)]
+ │    │    ├── variable: @1 [type=int, outer=(1)]
  │    │    └── const: 0 [type=int]
  │    └── const: 2 [type=int]
  └── unary-minus [type=int]
@@ -317,8 +317,8 @@ case [type=int]
 build-scalar vars=(int)
 CASE @1 WHEN 5 THEN 1 ELSE -1 END
 ----
-case [type=int]
- ├── variable: @1 [type=int]
+case [type=int, outer=(1)]
+ ├── variable: @1 [type=int, outer=(1)]
  ├── when [type=int]
  │    ├── const: 5 [type=int]
  │    └── const: 1 [type=int]
@@ -328,17 +328,17 @@ case [type=int]
 build-scalar vars=(int, int)
 CASE @1 + 3 WHEN 5 * @2 THEN 1 % @2 WHEN 6 THEN 2 ELSE -1 END
 ----
-case [type=int]
- ├── plus [type=int]
- │    ├── variable: @1 [type=int]
+case [type=int, outer=(1,2)]
+ ├── plus [type=int, outer=(1)]
+ │    ├── variable: @1 [type=int, outer=(1)]
  │    └── const: 3 [type=int]
- ├── when [type=int]
- │    ├── mult [type=int]
+ ├── when [type=int, outer=(2)]
+ │    ├── mult [type=int, outer=(2)]
  │    │    ├── const: 5 [type=int]
- │    │    └── variable: @2 [type=int]
- │    └── mod [type=int]
+ │    │    └── variable: @2 [type=int, outer=(2)]
+ │    └── mod [type=int, outer=(2)]
  │         ├── const: 1 [type=int]
- │         └── variable: @2 [type=int]
+ │         └── variable: @2 [type=int, outer=(2)]
  ├── when [type=int]
  │    ├── const: 6 [type=int]
  │    └── const: 2 [type=int]
@@ -349,11 +349,11 @@ case [type=int]
 build-scalar vars=(int)
 CASE WHEN @1 > 5 THEN 1 END
 ----
-case [type=int]
+case [type=int, outer=(1)]
  ├── true [type=bool]
- ├── when [type=int]
- │    ├── gt [type=bool]
- │    │    ├── variable: @1 [type=int]
+ ├── when [type=int, outer=(1)]
+ │    ├── gt [type=bool, outer=(1)]
+ │    │    ├── variable: @1 [type=int, outer=(1)]
  │    │    └── const: 5 [type=int]
  │    └── const: 1 [type=int]
  └── null [type=unknown]
@@ -361,8 +361,8 @@ case [type=int]
 build-scalar vars=(int)
 CASE @1 WHEN 5 THEN 1 END
 ----
-case [type=int]
- ├── variable: @1 [type=int]
+case [type=int, outer=(1)]
+ ├── variable: @1 [type=int, outer=(1)]
  ├── when [type=int]
  │    ├── const: 5 [type=int]
  │    └── const: 1 [type=int]

--- a/pkg/sql/opt/optbuilder/testdata/select
+++ b/pkg/sql/opt/optbuilder/testdata/select
@@ -63,11 +63,11 @@ project
  ├── columns: column4:unknown:null:4 a:int:1 b:int:null:2 c:int:null:3
  ├── scan
  │    └── columns: abc.a:int:1 abc.b:int:null:2 abc.c:int:null:3
- └── projections
+ └── projections [outer=(1-3)]
       ├── null [type=unknown]
-      ├── variable: abc.a [type=int]
-      ├── variable: abc.b [type=int]
-      └── variable: abc.c [type=int]
+      ├── variable: abc.a [type=int, outer=(1)]
+      ├── variable: abc.b [type=int, outer=(2)]
+      └── variable: abc.c [type=int, outer=(3)]
 
 
 # synonym for SELECT * FROM abc
@@ -102,13 +102,13 @@ project
  ├── columns: a:int:1 b:int:null:2 c:int:null:3 a:int:1 b:int:null:2 c:int:null:3
  ├── scan
  │    └── columns: abc.a:int:1 abc.b:int:null:2 abc.c:int:null:3
- └── projections
-      ├── variable: abc.a [type=int]
-      ├── variable: abc.b [type=int]
-      ├── variable: abc.c [type=int]
-      ├── variable: abc.a [type=int]
-      ├── variable: abc.b [type=int]
-      └── variable: abc.c [type=int]
+ └── projections [outer=(1-3)]
+      ├── variable: abc.a [type=int, outer=(1)]
+      ├── variable: abc.b [type=int, outer=(2)]
+      ├── variable: abc.c [type=int, outer=(3)]
+      ├── variable: abc.a [type=int, outer=(1)]
+      ├── variable: abc.b [type=int, outer=(2)]
+      └── variable: abc.c [type=int, outer=(3)]
 
 build
 SELECT a,a,a,a FROM abc
@@ -117,11 +117,11 @@ project
  ├── columns: a:int:1 a:int:1 a:int:1 a:int:1
  ├── scan
  │    └── columns: abc.a:int:1 abc.b:int:null:2 abc.c:int:null:3
- └── projections
-      ├── variable: abc.a [type=int]
-      ├── variable: abc.a [type=int]
-      ├── variable: abc.a [type=int]
-      └── variable: abc.a [type=int]
+ └── projections [outer=(1)]
+      ├── variable: abc.a [type=int, outer=(1)]
+      ├── variable: abc.a [type=int, outer=(1)]
+      ├── variable: abc.a [type=int, outer=(1)]
+      └── variable: abc.a [type=int, outer=(1)]
 
 build
 SELECT a,c FROM abc
@@ -130,9 +130,9 @@ project
  ├── columns: a:int:1 c:int:null:3
  ├── scan
  │    └── columns: abc.a:int:1 abc.b:int:null:2 abc.c:int:null:3
- └── projections
-      ├── variable: abc.a [type=int]
-      └── variable: abc.c [type=int]
+ └── projections [outer=(1,3)]
+      ├── variable: abc.a [type=int, outer=(1)]
+      └── variable: abc.c [type=int, outer=(3)]
 
 build
 SELECT a+b+c AS foo FROM abc
@@ -141,12 +141,12 @@ project
  ├── columns: foo:int:null:4
  ├── scan
  │    └── columns: abc.a:int:1 abc.b:int:null:2 abc.c:int:null:3
- └── projections
-      └── plus [type=int]
-           ├── plus [type=int]
-           │    ├── variable: abc.a [type=int]
-           │    └── variable: abc.b [type=int]
-           └── variable: abc.c [type=int]
+ └── projections [outer=(1-3)]
+      └── plus [type=int, outer=(1-3)]
+           ├── plus [type=int, outer=(1,2)]
+           │    ├── variable: abc.a [type=int, outer=(1)]
+           │    └── variable: abc.b [type=int, outer=(2)]
+           └── variable: abc.c [type=int, outer=(3)]
 
 build allow-unsupported
 SELECT a,b FROM abc WHERE CASE WHEN a != 0 THEN b/a > 1.5 ELSE false END
@@ -157,21 +157,21 @@ project
  │    ├── columns: abc.a:int:1 abc.b:int:null:2 abc.c:int:null:3
  │    ├── scan
  │    │    └── columns: abc.a:int:1 abc.b:int:null:2 abc.c:int:null:3
- │    └── case [type=bool]
+ │    └── case [type=bool, outer=(1,2)]
  │         ├── true [type=bool]
- │         ├── when [type=bool]
- │         │    ├── ne [type=bool]
- │         │    │    ├── variable: abc.a [type=int]
+ │         ├── when [type=bool, outer=(1,2)]
+ │         │    ├── ne [type=bool, outer=(1)]
+ │         │    │    ├── variable: abc.a [type=int, outer=(1)]
  │         │    │    └── const: 0 [type=int]
- │         │    └── gt [type=bool]
- │         │         ├── div [type=decimal]
- │         │         │    ├── variable: abc.b [type=int]
- │         │         │    └── variable: abc.a [type=int]
+ │         │    └── gt [type=bool, outer=(1,2)]
+ │         │         ├── div [type=decimal, outer=(1,2)]
+ │         │         │    ├── variable: abc.b [type=int, outer=(2)]
+ │         │         │    └── variable: abc.a [type=int, outer=(1)]
  │         │         └── const: 1.5 [type=decimal]
  │         └── false [type=bool]
- └── projections
-      ├── variable: abc.a [type=int]
-      └── variable: abc.b [type=int]
+ └── projections [outer=(1,2)]
+      ├── variable: abc.a [type=int, outer=(1)]
+      └── variable: abc.b [type=int, outer=(2)]
 
 # SELECT of NULL value.
 
@@ -203,9 +203,9 @@ project
  ├── columns: column3:string:null:3
  ├── scan
  │    └── columns: kv.k:string:1 kv.v:string:null:2
- └── projections
-      └── concat [type=string]
-           ├── variable: kv.v [type=string]
+ └── projections [outer=(2)]
+      └── concat [type=string, outer=(2)]
+           ├── variable: kv.v [type=string, outer=(2)]
            └── const: 'foo' [type=string]
 
 build
@@ -215,9 +215,9 @@ project
  ├── columns: column3:string:null:3
  ├── scan
  │    └── columns: kv.k:string:1 kv.v:string:null:2
- └── projections
-      └── function: lower [type=string]
-           └── variable: kv.v [type=string]
+ └── projections [outer=(2)]
+      └── function: lower [type=string, outer=(2)]
+           └── variable: kv.v [type=string, outer=(2)]
 
 build
 SELECT k FROM kv
@@ -226,8 +226,8 @@ project
  ├── columns: k:string:1
  ├── scan
  │    └── columns: kv.k:string:1 kv.v:string:null:2
- └── projections
-      └── variable: kv.k [type=string]
+ └── projections [outer=(1)]
+      └── variable: kv.k [type=string, outer=(1)]
 
 build
 SELECT kv.K,KV.v FROM kv
@@ -248,10 +248,10 @@ project
  ├── columns: column3:tuple{string, string}:null:3
  ├── scan
  │    └── columns: kv.k:string:1 kv.v:string:null:2
- └── projections
-      └── tuple [type=tuple{string, string}]
-           ├── variable: kv.k [type=string]
-           └── variable: kv.v [type=string]
+ └── projections [outer=(1,2)]
+      └── tuple [type=tuple{string, string}, outer=(1,2)]
+           ├── variable: kv.k [type=string, outer=(1)]
+           └── variable: kv.v [type=string, outer=(2)]
 
 build
 SELECT foo.* FROM kv
@@ -288,11 +288,11 @@ project
  │    ├── columns: kv.k:string:1 kv.v:string:null:2
  │    ├── scan
  │    │    └── columns: kv.k:string:1 kv.v:string:null:2
- │    └── eq [type=bool]
- │         ├── variable: kv.k [type=string]
+ │    └── eq [type=bool, outer=(1)]
+ │         ├── variable: kv.k [type=string, outer=(1)]
  │         └── const: 'a' [type=string]
- └── projections
-      └── variable: kv.k [type=string]
+ └── projections [outer=(1)]
+      └── variable: kv.k [type=string, outer=(1)]
 
 build
 SELECT "foo"."v" FROM kv AS foo WHERE foo.k = 'a'
@@ -303,11 +303,11 @@ project
  │    ├── columns: kv.k:string:1 kv.v:string:null:2
  │    ├── scan
  │    │    └── columns: kv.k:string:1 kv.v:string:null:2
- │    └── eq [type=bool]
- │         ├── variable: kv.k [type=string]
+ │    └── eq [type=bool, outer=(1)]
+ │         ├── variable: kv.k [type=string, outer=(1)]
  │         └── const: 'a' [type=string]
- └── projections
-      └── variable: kv.v [type=string]
+ └── projections [outer=(2)]
+      └── variable: kv.v [type=string, outer=(2)]
 
 exec-ddl
 CREATE TABLE kw ("from" INT PRIMARY KEY)
@@ -324,10 +324,10 @@ project
  ├── columns: from:int:1 from:int:1 from:int:1
  ├── scan
  │    └── columns: kw.from:int:1
- └── projections
-      ├── variable: kw.from [type=int]
-      ├── variable: kw.from [type=int]
-      └── variable: kw.from [type=int]
+ └── projections [outer=(1)]
+      ├── variable: kw.from [type=int, outer=(1)]
+      ├── variable: kw.from [type=int, outer=(1)]
+      └── variable: kw.from [type=int, outer=(1)]
 
 exec-ddl
 CREATE TABLE boolean_table (
@@ -348,8 +348,8 @@ project
  ├── columns: value:bool:null:2
  ├── scan
  │    └── columns: boolean_table.id:int:1 boolean_table.value:bool:null:2
- └── projections
-      └── variable: boolean_table.value [type=bool]
+ └── projections [outer=(2)]
+      └── variable: boolean_table.value [type=bool, outer=(2)]
 
 build allow-unsupported
 SELECT CASE WHEN NULL THEN 1 ELSE 2 END
@@ -373,16 +373,16 @@ project
  ├── columns: column4:int:null:4 column5:int:null:5 column6:int:null:6
  ├── scan
  │    └── columns: abc.a:int:1 abc.b:int:null:2 abc.c:int:null:3
- └── projections
-      ├── mult [type=int]
+ └── projections [outer=(2)]
+      ├── mult [type=int, outer=(2)]
       │    ├── const: 0 [type=int]
-      │    └── variable: abc.b [type=int]
-      ├── mod [type=int]
-      │    ├── variable: abc.b [type=int]
+      │    └── variable: abc.b [type=int, outer=(2)]
+      ├── mod [type=int, outer=(2)]
+      │    ├── variable: abc.b [type=int, outer=(2)]
       │    └── const: 1 [type=int]
-      └── mod [type=int]
+      └── mod [type=int, outer=(2)]
            ├── const: 0 [type=int]
-           └── variable: abc.b [type=int]
+           └── variable: abc.b [type=int, outer=(2)]
 
 # Regression tests for #22670.
 build
@@ -466,8 +466,8 @@ select
  ├── columns: x:int:1 y:float:null:2
  ├── scan
  │    └── columns: a.x:int:1 a.y:float:null:2
- └── gt [type=bool]
-      ├── variable: a.x [type=int]
+ └── gt [type=bool, outer=(1)]
+      ├── variable: a.x [type=int, outer=(1)]
       └── const: 10 [type=int]
 
 build
@@ -477,16 +477,16 @@ select
  ├── columns: x:int:1 y:float:null:2
  ├── scan
  │    └── columns: a.x:int:1 a.y:float:null:2
- └── and [type=bool]
-      ├── gt [type=bool]
-      │    ├── variable: a.x [type=int]
+ └── and [type=bool, outer=(1)]
+      ├── gt [type=bool, outer=(1)]
+      │    ├── variable: a.x [type=int, outer=(1)]
       │    └── const: 10 [type=int]
-      └── and [type=bool]
-           ├── lt [type=bool]
-           │    ├── variable: a.x [type=int]
+      └── and [type=bool, outer=(1)]
+           ├── lt [type=bool, outer=(1)]
+           │    ├── variable: a.x [type=int, outer=(1)]
            │    └── const: 20 [type=int]
-           └── ne [type=bool]
-                ├── variable: a.x [type=int]
+           └── ne [type=bool, outer=(1)]
+                ├── variable: a.x [type=int, outer=(1)]
                 └── const: 13 [type=int]
 
 build
@@ -496,8 +496,8 @@ select
  ├── columns: x:int:1 y:float:null:2
  ├── scan
  │    └── columns: a.x:int:1 a.y:float:null:2
- └── in [type=bool]
-      ├── variable: a.x [type=int]
+ └── in [type=bool, outer=(1)]
+      ├── variable: a.x [type=int, outer=(1)]
       └── tuple [type=tuple{int, int, int}]
            ├── const: 1 [type=int]
            ├── const: 2 [type=int]
@@ -516,9 +516,9 @@ project
  ├── columns: column3:int:null:3 column4:float:null:4
  ├── scan
  │    └── columns: a.x:int:1 a.y:float:null:2
- └── projections
-      ├── variable: a.x [type=int]
-      └── variable: a.y [type=float]
+ └── projections [outer=(1,2)]
+      ├── variable: a.x [type=int, outer=(1)]
+      └── variable: a.y [type=float, outer=(2)]
 
 build
 SELECT * FROM t.a WHERE (x > 10)::bool
@@ -527,9 +527,9 @@ select
  ├── columns: x:int:1 y:float:null:2
  ├── scan
  │    └── columns: a.x:int:1 a.y:float:null:2
- └── cast: bool [type=bool]
-      └── gt [type=bool]
-           ├── variable: a.x [type=int]
+ └── cast: bool [type=bool, outer=(1)]
+      └── gt [type=bool, outer=(1)]
+           ├── variable: a.x [type=int, outer=(1)]
            └── const: 10 [type=int]
 
 build

--- a/pkg/sql/opt/optbuilder/testdata/union
+++ b/pkg/sql/opt/optbuilder/testdata/union
@@ -260,10 +260,10 @@ project
  │         └── projections
  │              ├── const: 2 [type=int]
  │              └── const: 4 [type=int]
- └── projections
-      ├── variable: column1 [type=int]
-      └── function: pg_typeof [type=string]
-           └── variable: column2 [type=int]
+ └── projections [outer=(5,6)]
+      ├── variable: column1 [type=int, outer=(5)]
+      └── function: pg_typeof [type=string, outer=(6)]
+           └── variable: column2 [type=int, outer=(6)]
 
 build
 SELECT x, pg_typeof(y) FROM (SELECT 1, 3 UNION ALL SELECT 2, NULL) AS t(x, y)
@@ -288,10 +288,10 @@ project
  │         └── projections
  │              ├── const: 2 [type=int]
  │              └── null [type=unknown]
- └── projections
-      ├── variable: column1 [type=int]
-      └── function: pg_typeof [type=string]
-           └── variable: column2 [type=int]
+ └── projections [outer=(5,6)]
+      ├── variable: column1 [type=int, outer=(5)]
+      └── function: pg_typeof [type=string, outer=(6)]
+           └── variable: column2 [type=int, outer=(6)]
 
 exec-ddl
 CREATE TABLE uniontest (
@@ -319,22 +319,22 @@ union
  │    │    ├── columns: uniontest.k:int:null:1 uniontest.v:int:null:2 uniontest.rowid:int:3
  │    │    ├── scan
  │    │    │    └── columns: uniontest.k:int:null:1 uniontest.v:int:null:2 uniontest.rowid:int:3
- │    │    └── eq [type=bool]
- │    │         ├── variable: uniontest.k [type=int]
+ │    │    └── eq [type=bool, outer=(1)]
+ │    │         ├── variable: uniontest.k [type=int, outer=(1)]
  │    │         └── const: 1 [type=int]
- │    └── projections
- │         └── variable: uniontest.v [type=int]
+ │    └── projections [outer=(2)]
+ │         └── variable: uniontest.v [type=int, outer=(2)]
  └── project
       ├── columns: uniontest.v:int:null:5
       ├── select
       │    ├── columns: uniontest.k:int:null:4 uniontest.v:int:null:5 uniontest.rowid:int:6
       │    ├── scan
       │    │    └── columns: uniontest.k:int:null:4 uniontest.v:int:null:5 uniontest.rowid:int:6
-      │    └── eq [type=bool]
-      │         ├── variable: uniontest.k [type=int]
+      │    └── eq [type=bool, outer=(4)]
+      │         ├── variable: uniontest.k [type=int, outer=(4)]
       │         └── const: 2 [type=int]
-      └── projections
-           └── variable: uniontest.v [type=int]
+      └── projections [outer=(5)]
+           └── variable: uniontest.v [type=int, outer=(5)]
 
 build
 SELECT v FROM uniontest WHERE k = 1 UNION ALL SELECT v FROM uniontest WHERE k = 2
@@ -349,22 +349,22 @@ union-all
  │    │    ├── columns: uniontest.k:int:null:1 uniontest.v:int:null:2 uniontest.rowid:int:3
  │    │    ├── scan
  │    │    │    └── columns: uniontest.k:int:null:1 uniontest.v:int:null:2 uniontest.rowid:int:3
- │    │    └── eq [type=bool]
- │    │         ├── variable: uniontest.k [type=int]
+ │    │    └── eq [type=bool, outer=(1)]
+ │    │         ├── variable: uniontest.k [type=int, outer=(1)]
  │    │         └── const: 1 [type=int]
- │    └── projections
- │         └── variable: uniontest.v [type=int]
+ │    └── projections [outer=(2)]
+ │         └── variable: uniontest.v [type=int, outer=(2)]
  └── project
       ├── columns: uniontest.v:int:null:5
       ├── select
       │    ├── columns: uniontest.k:int:null:4 uniontest.v:int:null:5 uniontest.rowid:int:6
       │    ├── scan
       │    │    └── columns: uniontest.k:int:null:4 uniontest.v:int:null:5 uniontest.rowid:int:6
-      │    └── eq [type=bool]
-      │         ├── variable: uniontest.k [type=int]
+      │    └── eq [type=bool, outer=(4)]
+      │         ├── variable: uniontest.k [type=int, outer=(4)]
       │         └── const: 2 [type=int]
-      └── projections
-           └── variable: uniontest.v [type=int]
+      └── projections [outer=(5)]
+           └── variable: uniontest.v [type=int, outer=(5)]
 
 build
 SELECT v FROM uniontest WHERE k = 1 INTERSECT SELECT v FROM uniontest WHERE k = 2
@@ -379,22 +379,22 @@ intersect
  │    │    ├── columns: uniontest.k:int:null:1 uniontest.v:int:null:2 uniontest.rowid:int:3
  │    │    ├── scan
  │    │    │    └── columns: uniontest.k:int:null:1 uniontest.v:int:null:2 uniontest.rowid:int:3
- │    │    └── eq [type=bool]
- │    │         ├── variable: uniontest.k [type=int]
+ │    │    └── eq [type=bool, outer=(1)]
+ │    │         ├── variable: uniontest.k [type=int, outer=(1)]
  │    │         └── const: 1 [type=int]
- │    └── projections
- │         └── variable: uniontest.v [type=int]
+ │    └── projections [outer=(2)]
+ │         └── variable: uniontest.v [type=int, outer=(2)]
  └── project
       ├── columns: uniontest.v:int:null:5
       ├── select
       │    ├── columns: uniontest.k:int:null:4 uniontest.v:int:null:5 uniontest.rowid:int:6
       │    ├── scan
       │    │    └── columns: uniontest.k:int:null:4 uniontest.v:int:null:5 uniontest.rowid:int:6
-      │    └── eq [type=bool]
-      │         ├── variable: uniontest.k [type=int]
+      │    └── eq [type=bool, outer=(4)]
+      │         ├── variable: uniontest.k [type=int, outer=(4)]
       │         └── const: 2 [type=int]
-      └── projections
-           └── variable: uniontest.v [type=int]
+      └── projections [outer=(5)]
+           └── variable: uniontest.v [type=int, outer=(5)]
 
 build
 SELECT v FROM uniontest WHERE k = 1 INTERSECT ALL SELECT v FROM uniontest WHERE k = 2
@@ -409,22 +409,22 @@ intersect-all
  │    │    ├── columns: uniontest.k:int:null:1 uniontest.v:int:null:2 uniontest.rowid:int:3
  │    │    ├── scan
  │    │    │    └── columns: uniontest.k:int:null:1 uniontest.v:int:null:2 uniontest.rowid:int:3
- │    │    └── eq [type=bool]
- │    │         ├── variable: uniontest.k [type=int]
+ │    │    └── eq [type=bool, outer=(1)]
+ │    │         ├── variable: uniontest.k [type=int, outer=(1)]
  │    │         └── const: 1 [type=int]
- │    └── projections
- │         └── variable: uniontest.v [type=int]
+ │    └── projections [outer=(2)]
+ │         └── variable: uniontest.v [type=int, outer=(2)]
  └── project
       ├── columns: uniontest.v:int:null:5
       ├── select
       │    ├── columns: uniontest.k:int:null:4 uniontest.v:int:null:5 uniontest.rowid:int:6
       │    ├── scan
       │    │    └── columns: uniontest.k:int:null:4 uniontest.v:int:null:5 uniontest.rowid:int:6
-      │    └── eq [type=bool]
-      │         ├── variable: uniontest.k [type=int]
+      │    └── eq [type=bool, outer=(4)]
+      │         ├── variable: uniontest.k [type=int, outer=(4)]
       │         └── const: 2 [type=int]
-      └── projections
-           └── variable: uniontest.v [type=int]
+      └── projections [outer=(5)]
+           └── variable: uniontest.v [type=int, outer=(5)]
 
 build
 SELECT v FROM uniontest WHERE k = 1 EXCEPT SELECT v FROM uniontest WHERE k = 2
@@ -439,22 +439,22 @@ except
  │    │    ├── columns: uniontest.k:int:null:1 uniontest.v:int:null:2 uniontest.rowid:int:3
  │    │    ├── scan
  │    │    │    └── columns: uniontest.k:int:null:1 uniontest.v:int:null:2 uniontest.rowid:int:3
- │    │    └── eq [type=bool]
- │    │         ├── variable: uniontest.k [type=int]
+ │    │    └── eq [type=bool, outer=(1)]
+ │    │         ├── variable: uniontest.k [type=int, outer=(1)]
  │    │         └── const: 1 [type=int]
- │    └── projections
- │         └── variable: uniontest.v [type=int]
+ │    └── projections [outer=(2)]
+ │         └── variable: uniontest.v [type=int, outer=(2)]
  └── project
       ├── columns: uniontest.v:int:null:5
       ├── select
       │    ├── columns: uniontest.k:int:null:4 uniontest.v:int:null:5 uniontest.rowid:int:6
       │    ├── scan
       │    │    └── columns: uniontest.k:int:null:4 uniontest.v:int:null:5 uniontest.rowid:int:6
-      │    └── eq [type=bool]
-      │         ├── variable: uniontest.k [type=int]
+      │    └── eq [type=bool, outer=(4)]
+      │         ├── variable: uniontest.k [type=int, outer=(4)]
       │         └── const: 2 [type=int]
-      └── projections
-           └── variable: uniontest.v [type=int]
+      └── projections [outer=(5)]
+           └── variable: uniontest.v [type=int, outer=(5)]
 
 build
 SELECT v FROM uniontest WHERE k = 1 EXCEPT ALL SELECT v FROM uniontest WHERE k = 2
@@ -469,22 +469,22 @@ except-all
  │    │    ├── columns: uniontest.k:int:null:1 uniontest.v:int:null:2 uniontest.rowid:int:3
  │    │    ├── scan
  │    │    │    └── columns: uniontest.k:int:null:1 uniontest.v:int:null:2 uniontest.rowid:int:3
- │    │    └── eq [type=bool]
- │    │         ├── variable: uniontest.k [type=int]
+ │    │    └── eq [type=bool, outer=(1)]
+ │    │         ├── variable: uniontest.k [type=int, outer=(1)]
  │    │         └── const: 1 [type=int]
- │    └── projections
- │         └── variable: uniontest.v [type=int]
+ │    └── projections [outer=(2)]
+ │         └── variable: uniontest.v [type=int, outer=(2)]
  └── project
       ├── columns: uniontest.v:int:null:5
       ├── select
       │    ├── columns: uniontest.k:int:null:4 uniontest.v:int:null:5 uniontest.rowid:int:6
       │    ├── scan
       │    │    └── columns: uniontest.k:int:null:4 uniontest.v:int:null:5 uniontest.rowid:int:6
-      │    └── eq [type=bool]
-      │         ├── variable: uniontest.k [type=int]
+      │    └── eq [type=bool, outer=(4)]
+      │         ├── variable: uniontest.k [type=int, outer=(4)]
       │         └── const: 2 [type=int]
-      └── projections
-           └── variable: uniontest.v [type=int]
+      └── projections [outer=(5)]
+           └── variable: uniontest.v [type=int, outer=(5)]
 
 build
 SELECT v FROM uniontest UNION SELECT k FROM uniontest
@@ -497,14 +497,14 @@ union
  │    ├── columns: uniontest.v:int:null:2
  │    ├── scan
  │    │    └── columns: uniontest.k:int:null:1 uniontest.v:int:null:2 uniontest.rowid:int:3
- │    └── projections
- │         └── variable: uniontest.v [type=int]
+ │    └── projections [outer=(2)]
+ │         └── variable: uniontest.v [type=int, outer=(2)]
  └── project
       ├── columns: uniontest.k:int:null:4
       ├── scan
       │    └── columns: uniontest.k:int:null:4 uniontest.v:int:null:5 uniontest.rowid:int:6
-      └── projections
-           └── variable: uniontest.k [type=int]
+      └── projections [outer=(4)]
+           └── variable: uniontest.k [type=int, outer=(4)]
 
 build
 SELECT v FROM uniontest UNION ALL SELECT k FROM uniontest
@@ -517,14 +517,14 @@ union-all
  │    ├── columns: uniontest.v:int:null:2
  │    ├── scan
  │    │    └── columns: uniontest.k:int:null:1 uniontest.v:int:null:2 uniontest.rowid:int:3
- │    └── projections
- │         └── variable: uniontest.v [type=int]
+ │    └── projections [outer=(2)]
+ │         └── variable: uniontest.v [type=int, outer=(2)]
  └── project
       ├── columns: uniontest.k:int:null:4
       ├── scan
       │    └── columns: uniontest.k:int:null:4 uniontest.v:int:null:5 uniontest.rowid:int:6
-      └── projections
-           └── variable: uniontest.k [type=int]
+      └── projections [outer=(4)]
+           └── variable: uniontest.k [type=int, outer=(4)]
 
 build
 SELECT * FROM (SELECT * FROM (VALUES (1)) a LEFT JOIN (VALUES (1) UNION VALUES (2)) b on a.column1 = b.column1);
@@ -547,9 +547,9 @@ left-join
  │         ├── columns: column1:int:null:3
  │         └── tuple [type=tuple{int}]
  │              └── const: 2 [type=int]
- └── eq [type=bool]
-      ├── variable: column1 [type=int]
-      └── variable: column1 [type=int]
+ └── eq [type=bool, outer=(1,4)]
+      ├── variable: column1 [type=int, outer=(1)]
+      └── variable: column1 [type=int, outer=(4)]
 
 build
 SELECT * FROM (VALUES (1)) a LEFT JOIN (VALUES (1) UNION VALUES (2)) b on a.column1 = b.column1;
@@ -572,9 +572,9 @@ left-join
  │         ├── columns: column1:int:null:3
  │         └── tuple [type=tuple{int}]
  │              └── const: 2 [type=int]
- └── eq [type=bool]
-      ├── variable: column1 [type=int]
-      └── variable: column1 [type=int]
+ └── eq [type=bool, outer=(1,4)]
+      ├── variable: column1 [type=int, outer=(1)]
+      └── variable: column1 [type=int, outer=(4)]
 
 build
 SELECT 1, 2 UNION SELECT 3
@@ -667,15 +667,15 @@ union
  │    ├── columns: xy.x:string:1 xy.x:string:1 xy.y:string:2
  │    ├── scan
  │    │    └── columns: xy.x:string:1 xy.y:string:2 xy.rowid:int:3
- │    └── projections
- │         ├── variable: xy.x [type=string]
- │         ├── variable: xy.x [type=string]
- │         └── variable: xy.y [type=string]
+ │    └── projections [outer=(1,2)]
+ │         ├── variable: xy.x [type=string, outer=(1)]
+ │         ├── variable: xy.x [type=string, outer=(1)]
+ │         └── variable: xy.y [type=string, outer=(2)]
  └── project
       ├── columns: abc.a:string:null:4 abc.b:string:5 abc.c:string:6
       ├── scan
       │    └── columns: abc.a:string:null:4 abc.b:string:5 abc.c:string:6 abc.rowid:int:7
-      └── projections
-           ├── variable: abc.a [type=string]
-           ├── variable: abc.b [type=string]
-           └── variable: abc.c [type=string]
+      └── projections [outer=(4-6)]
+           ├── variable: abc.a [type=string, outer=(4)]
+           ├── variable: abc.b [type=string, outer=(5)]
+           └── variable: abc.c [type=string, outer=(6)]

--- a/pkg/sql/opt/optbuilder/testdata/values
+++ b/pkg/sql/opt/optbuilder/testdata/values
@@ -137,10 +137,10 @@ project
  │    └── tuple [type=tuple{unknown, unknown}]
  │         ├── null [type=unknown]
  │         └── null [type=unknown]
- └── projections
-      └── coalesce [type=int]
-           ├── variable: column1 [type=int]
-           └── variable: column2 [type=int]
+ └── projections [outer=(1,2)]
+      └── coalesce [type=int, outer=(1,2)]
+           ├── variable: column1 [type=int, outer=(1)]
+           └── variable: column2 [type=int, outer=(2)]
 
 
 # TODO(rytaft): uncomment these tests once subqueries are supported

--- a/pkg/sql/opt/xform/expr.go
+++ b/pkg/sql/opt/xform/expr.go
@@ -99,7 +99,7 @@ func makeExprView(mem *memo, group opt.GroupID, required opt.PhysicalPropsID) Ex
 		// expression, which is always the first expression in the group.
 		return ExprView{
 			mem:      mem,
-			loc:      memoLoc{group: group, expr: normExprID},
+			loc:      makeNormLoc(group),
 			op:       mgrp.lookupExpr(normExprID).op,
 			required: required,
 		}
@@ -200,20 +200,20 @@ func (ev ExprView) formatScalar(tp treeprinter.Node) {
 	if scalar == nil {
 		buf.WriteString(" [type=undefined]")
 	} else {
-		hasType := true
+		showType := true
 		switch ev.Operator() {
 		case opt.ProjectionsOp, opt.AggregationsOp:
 			// Don't show the type of these ops because they are simply tuple
 			// types of their children's types, and the types of children are
 			// already listed.
-			hasType = false
+			showType = false
 		}
 
 		hasOuterCols := !ev.Logical().Scalar.OuterCols.Empty()
 
-		if hasType || hasOuterCols {
+		if showType || hasOuterCols {
 			buf.WriteString(" [")
-			if hasType {
+			if showType {
 				fmt.Fprintf(&buf, "type=%s", scalar.Type)
 				if hasOuterCols {
 					buf.WriteString(", ")

--- a/pkg/sql/opt/xform/expr.og.go
+++ b/pkg/sql/opt/xform/expr.og.go
@@ -60,7 +60,6 @@ var opLayoutTable = [...]opLayout{
 	opt.FetchTextOp:       makeOpLayout(2 /*base*/, 0 /*list*/, 0 /*priv*/, 0 /*enforcer*/),
 	opt.FetchValPathOp:    makeOpLayout(2 /*base*/, 0 /*list*/, 0 /*priv*/, 0 /*enforcer*/),
 	opt.FetchTextPathOp:   makeOpLayout(2 /*base*/, 0 /*list*/, 0 /*priv*/, 0 /*enforcer*/),
-	opt.UnaryPlusOp:       makeOpLayout(1 /*base*/, 0 /*list*/, 0 /*priv*/, 0 /*enforcer*/),
 	opt.UnaryMinusOp:      makeOpLayout(1 /*base*/, 0 /*list*/, 0 /*priv*/, 0 /*enforcer*/),
 	opt.UnaryComplementOp: makeOpLayout(1 /*base*/, 0 /*list*/, 0 /*priv*/, 0 /*enforcer*/),
 	opt.CastOp:            makeOpLayout(1 /*base*/, 0 /*list*/, 2 /*priv*/, 0 /*enforcer*/),
@@ -150,7 +149,6 @@ var isScalarLookup = [...]bool{
 	true,  // FetchTextOp
 	true,  // FetchValPathOp
 	true,  // FetchTextPathOp
-	true,  // UnaryPlusOp
 	true,  // UnaryMinusOp
 	true,  // UnaryComplementOp
 	true,  // CastOp
@@ -240,7 +238,6 @@ var isConstValueLookup = [...]bool{
 	false, // FetchTextOp
 	false, // FetchValPathOp
 	false, // FetchTextPathOp
-	false, // UnaryPlusOp
 	false, // UnaryMinusOp
 	false, // UnaryComplementOp
 	false, // CastOp
@@ -330,7 +327,6 @@ var isBooleanLookup = [...]bool{
 	false, // FetchTextOp
 	false, // FetchValPathOp
 	false, // FetchTextPathOp
-	false, // UnaryPlusOp
 	false, // UnaryMinusOp
 	false, // UnaryComplementOp
 	false, // CastOp
@@ -420,7 +416,6 @@ var isComparisonLookup = [...]bool{
 	false, // FetchTextOp
 	false, // FetchValPathOp
 	false, // FetchTextPathOp
-	false, // UnaryPlusOp
 	false, // UnaryMinusOp
 	false, // UnaryComplementOp
 	false, // CastOp
@@ -510,7 +505,6 @@ var isBinaryLookup = [...]bool{
 	true,  // FetchTextOp
 	true,  // FetchValPathOp
 	true,  // FetchTextPathOp
-	false, // UnaryPlusOp
 	false, // UnaryMinusOp
 	false, // UnaryComplementOp
 	false, // CastOp
@@ -600,7 +594,6 @@ var isUnaryLookup = [...]bool{
 	false, // FetchTextOp
 	false, // FetchValPathOp
 	false, // FetchTextPathOp
-	true,  // UnaryPlusOp
 	true,  // UnaryMinusOp
 	true,  // UnaryComplementOp
 	false, // CastOp
@@ -690,7 +683,6 @@ var isRelationalLookup = [...]bool{
 	false, // FetchTextOp
 	false, // FetchValPathOp
 	false, // FetchTextPathOp
-	false, // UnaryPlusOp
 	false, // UnaryMinusOp
 	false, // UnaryComplementOp
 	false, // CastOp
@@ -780,7 +772,6 @@ var isJoinLookup = [...]bool{
 	false, // FetchTextOp
 	false, // FetchValPathOp
 	false, // FetchTextPathOp
-	false, // UnaryPlusOp
 	false, // UnaryMinusOp
 	false, // UnaryComplementOp
 	false, // CastOp
@@ -870,7 +861,6 @@ var isJoinApplyLookup = [...]bool{
 	false, // FetchTextOp
 	false, // FetchValPathOp
 	false, // FetchTextPathOp
-	false, // UnaryPlusOp
 	false, // UnaryMinusOp
 	false, // UnaryComplementOp
 	false, // CastOp
@@ -960,7 +950,6 @@ var isEnforcerLookup = [...]bool{
 	false, // FetchTextOp
 	false, // FetchValPathOp
 	false, // FetchTextPathOp
-	false, // UnaryPlusOp
 	false, // UnaryMinusOp
 	false, // UnaryComplementOp
 	false, // CastOp
@@ -2363,27 +2352,6 @@ func (m *memoExpr) asFetchTextPath() *fetchTextPathExpr {
 		return nil
 	}
 	return (*fetchTextPathExpr)(m)
-}
-
-type unaryPlusExpr memoExpr
-
-func makeUnaryPlusExpr(input opt.GroupID) unaryPlusExpr {
-	return unaryPlusExpr{op: opt.UnaryPlusOp, state: exprState{uint32(input)}}
-}
-
-func (e *unaryPlusExpr) input() opt.GroupID {
-	return opt.GroupID(e.state[0])
-}
-
-func (e *unaryPlusExpr) fingerprint() fingerprint {
-	return fingerprint(*e)
-}
-
-func (m *memoExpr) asUnaryPlus() *unaryPlusExpr {
-	if m.op != opt.UnaryPlusOp {
-		return nil
-	}
-	return (*unaryPlusExpr)(m)
 }
 
 type unaryMinusExpr memoExpr

--- a/pkg/sql/opt/xform/expr_test.go
+++ b/pkg/sql/opt/xform/expr_test.go
@@ -42,8 +42,10 @@ func BenchmarkExprView(b *testing.B) {
 			if err != nil {
 				b.Fatal(err)
 			}
-			o := NewOptimizer(catalog, OptimizeAll)
-			bld := optbuilder.New(context.Background(), &semaCtx, &evalCtx, o.Factory(), stmt)
+			o := NewOptimizer(&evalCtx, OptimizeAll)
+			bld := optbuilder.New(
+				context.Background(), &semaCtx, &evalCtx, catalog, o.Factory(), stmt,
+			)
 			root, props, err := bld.Build()
 			if err != nil {
 				b.Fatal(err)

--- a/pkg/sql/opt/xform/factory.go
+++ b/pkg/sql/opt/xform/factory.go
@@ -16,9 +16,9 @@ package xform
 
 import (
 	"fmt"
+	"sort"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
-	"github.com/cockroachdb/cockroach/pkg/sql/optbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
 )
@@ -39,7 +39,8 @@ import (
 // optgen DSL, the factory always calls the `onConstruct` method as its last
 // step, in order to allow any custom manual code to execute.
 type factory struct {
-	mem *memo
+	mem     *memo
+	evalCtx *tree.EvalContext
 
 	// maxSteps sets the maximum number of optimization patterns that the
 	// factory will apply. Once this maximum is reached, the factory will
@@ -53,8 +54,8 @@ var _ opt.Factory = &factory{}
 
 // NewFactory returns a new Factory structure with a new, blank memo
 // structure inside.
-func newFactory(catalog optbase.Catalog, maxSteps OptimizeSteps) *factory {
-	return &factory{mem: newMemo(catalog), maxSteps: maxSteps}
+func newFactory(evalCtx *tree.EvalContext, maxSteps OptimizeSteps) *factory {
+	return &factory{mem: newMemo(), evalCtx: evalCtx, maxSteps: maxSteps}
 }
 
 // Metadata returns the query-specific metadata, which includes information
@@ -121,6 +122,86 @@ func (f *factory) listOnlyHasNulls(list opt.ListID) bool {
 	return true
 }
 
+// isSortedUniqueList returns true if the list is in sorted order, with no
+// duplicates. See the comment for listSorter.compare for comparison rule
+// details.
+func (f *factory) isSortedUniqueList(list opt.ListID) bool {
+	ls := listSorter{f: f, list: f.mem.lookupList(list)}
+	for i := 0; i < int(list.Length-1); i++ {
+		if !ls.less(i, i+1) {
+			return false
+		}
+	}
+	return true
+}
+
+// constructSortedUniqueList sorts the given list and removes duplicates, and
+// returns the resulting list. See the comment for listSorter.compare for
+// comparison rule details.
+func (f *factory) constructSortedUniqueList(list opt.ListID) opt.ListID {
+	// Make a copy of the list, since it needs to stay immutable.
+	newList := make([]opt.GroupID, list.Length)
+	copy(newList, f.mem.lookupList(list))
+	ls := listSorter{f: f, list: newList}
+
+	// Sort the list.
+	sort.Slice(ls.list, ls.less)
+
+	// Remove duplicates from the list.
+	n := 0
+	for i := 0; i < int(list.Length); i++ {
+		if i == 0 || ls.compare(i-1, i) < 0 {
+			newList[n] = newList[i]
+			n++
+		}
+	}
+	return f.mem.internList(newList[:n])
+}
+
+// listSorter is a helper struct that implements the sort.Slice "less"
+// comparison function.
+type listSorter struct {
+	f    *factory
+	list []opt.GroupID
+}
+
+// less returns true if item i in the list compares less than item j.
+// sort.Slice uses this method to sort the list.
+func (s listSorter) less(i, j int) bool {
+	return s.compare(i, j) < 0
+}
+
+// compare returns -1 if item i compares less than item j, 0 if they are equal,
+// and 1 if item i compares greater. Constants sort before non-constants, and
+// are sorted and uniquified according to Datum comparison rules. Non-constants
+// are sorted and uniquified by GroupID (arbitrary, but stable).
+func (s listSorter) compare(i, j int) int {
+	// If both are constant values, then use datum comparison.
+	isLeftConst := s.f.mem.lookupNormExpr(s.list[i]).isConstValue()
+	isRightConst := s.f.mem.lookupNormExpr(s.list[j]).isConstValue()
+	if isLeftConst {
+		if !isRightConst {
+			// Constant always sorts before non-constant
+			return -1
+		}
+
+		leftD := extractConstDatum(s.f.mem, makeNormLoc(s.list[i]))
+		rightD := extractConstDatum(s.f.mem, makeNormLoc(s.list[j]))
+		return leftD.Compare(s.f.evalCtx, rightD)
+	} else if isRightConst {
+		// Non-constant always sorts after constant.
+		return 1
+	}
+
+	// Arbitrarily order by GroupID.
+	if s.list[i] < s.list[j] {
+		return -1
+	} else if s.list[i] > s.list[j] {
+		return 1
+	}
+	return 0
+}
+
 // ----------------------------------------------------------------------
 //
 // Typing functions
@@ -129,8 +210,42 @@ func (f *factory) listOnlyHasNulls(list opt.ListID) bool {
 //
 // ----------------------------------------------------------------------
 
+// hasType returns true if the given expression has a static type that's
+// equivalent to the requested type.
+func (f *factory) hasType(group opt.GroupID, typ opt.PrivateID) bool {
+	groupType := f.mem.lookupGroup(group).logical.Scalar.Type
+	requestedType := f.mem.lookupPrivate(typ).(types.T)
+	return groupType.Equivalent(requestedType)
+}
+
 func (f *factory) boolType() opt.PrivateID {
 	return f.InternPrivate(types.Bool)
+}
+
+// canConstructBinary returns true if (op left right) has a valid binary op
+// overload and is therefore legal to construct. For example, while
+// (Minus <date> <int>) is valid, (Minus <int> <date>) is not.
+func (f *factory) canConstructBinary(op opt.Operator, left, right opt.GroupID) bool {
+	leftType := f.mem.lookupGroup(left).logical.Scalar.Type
+	rightType := f.mem.lookupGroup(right).logical.Scalar.Type
+	_, ok := findBinaryOverload(opt.MinusOp, rightType, leftType)
+	return ok
+}
+
+// ----------------------------------------------------------------------
+//
+// Property functions
+//   General custom match and replace functions used to test expression
+//   logical properties.
+//
+// ----------------------------------------------------------------------
+
+// onlyConstants returns true if the scalar expression is a "constant
+// expression tree", meaning that it will always evaluate to the same result.
+// See the CommuteConst pattern comment for more details.
+func (f *factory) onlyConstants(group opt.GroupID) bool {
+	// TODO(andyk): Consider impact of "impure" functions with side effects.
+	return f.mem.lookupGroup(group).logical.Scalar.OuterCols.Empty()
 }
 
 // ----------------------------------------------------------------------
@@ -243,11 +358,11 @@ func (f *factory) simplifyOr(conditions opt.ListID) opt.GroupID {
 	return f.ConstructOr(f.mem.internList(list))
 }
 
-// invertComparison negates a comparison op like:
+// negateComparison negates a comparison op like:
 //   a.x = 5
 // to:
 //   a.x <> 5
-func (f *factory) invertComparison(cmp opt.Operator, left, right opt.GroupID) opt.GroupID {
+func (f *factory) negateComparison(cmp opt.Operator, left, right opt.GroupID) opt.GroupID {
 	switch cmp {
 	case opt.EqOp:
 		return f.ConstructNe(left, right)
@@ -292,6 +407,25 @@ func (f *factory) invertComparison(cmp opt.Operator, left, right opt.GroupID) op
 	default:
 		panic(fmt.Sprintf("unexpected operator: %v", cmp))
 	}
+}
+
+// commuteInequality swaps the operands of an inequality comparison expression,
+// changing the operator to compensate:
+//   5 < x
+// to:
+//   x > 5
+func (f *factory) commuteInequality(op opt.Operator, left, right opt.GroupID) opt.GroupID {
+	switch op {
+	case opt.GeOp:
+		return f.ConstructLe(right, left)
+	case opt.GtOp:
+		return f.ConstructLt(right, left)
+	case opt.LeOp:
+		return f.ConstructGe(right, left)
+	case opt.LtOp:
+		return f.ConstructGt(right, left)
+	}
+	panic(fmt.Sprintf("called commuteInequality with operator %s", op))
 }
 
 // ----------------------------------------------------------------------
@@ -355,8 +489,11 @@ func (f *factory) simplifyCoalesce(args opt.ListID) opt.GroupID {
 func (f *factory) allowNullArgs(op opt.Operator, left, right opt.GroupID) bool {
 	leftType := f.mem.lookupGroup(left).logical.Scalar.Type
 	rightType := f.mem.lookupGroup(right).logical.Scalar.Type
-	_, allowNulls := resolveBinary(op, leftType, rightType)
-	return allowNulls
+	overload, ok := findBinaryOverload(op, leftType, rightType)
+	if !ok {
+		panic(fmt.Sprintf("could not find overload for binary expression %s", op))
+	}
+	return overload.allowNullArgs
 }
 
 // foldNullUnary replaces the unary operator with a typed null value having the

--- a/pkg/sql/opt/xform/factory.og.go
+++ b/pkg/sql/opt/xform/factory.og.go
@@ -388,7 +388,7 @@ func (_f *factory) ConstructNot(
 			_contains := _f.mem.lookupNormExpr(input).asContains()
 			if _contains == nil {
 				_f.reportOptimization()
-				_group = _f.invertComparison(_f.mem.lookupNormExpr(input).op, left, right)
+				_group = _f.negateComparison(_f.mem.lookupNormExpr(input).op, left, right)
 				_f.mem.addAltFingerprint(_notExpr.fingerprint(), _group)
 				return _group
 			}
@@ -425,7 +425,7 @@ func (_f *factory) ConstructEq(
 		return _f.mem.memoizeNormExpr(memoExpr(_eqExpr))
 	}
 
-	// [NormalizeVar]
+	// [CommuteVar]
 	{
 		_variable := _f.mem.lookupNormExpr(left).asVariable()
 		if _variable == nil {
@@ -435,6 +435,81 @@ func (_f *factory) ConstructEq(
 				_group = _f.ConstructEq(right, left)
 				_f.mem.addAltFingerprint(_eqExpr.fingerprint(), _group)
 				return _group
+			}
+		}
+	}
+
+	// [CommuteConst]
+	{
+		if _f.onlyConstants(left) {
+			if !_f.onlyConstants(right) {
+				_f.reportOptimization()
+				_group = _f.ConstructEq(right, left)
+				_f.mem.addAltFingerprint(_eqExpr.fingerprint(), _group)
+				return _group
+			}
+		}
+	}
+
+	// [NormalizeCmpPlusConst]
+	{
+		_plus := _f.mem.lookupNormExpr(left).asPlus()
+		if _plus != nil {
+			leftLeft := _plus.left()
+			if !_f.onlyConstants(leftLeft) {
+				leftRight := _plus.right()
+				if _f.onlyConstants(leftRight) {
+					if _f.onlyConstants(right) {
+						if _f.canConstructBinary(opt.MinusOp, right, leftRight) {
+							_f.reportOptimization()
+							_group = _f.ConstructEq(leftLeft, _f.ConstructMinus(right, leftRight))
+							_f.mem.addAltFingerprint(_eqExpr.fingerprint(), _group)
+							return _group
+						}
+					}
+				}
+			}
+		}
+	}
+
+	// [NormalizeCmpMinusConst]
+	{
+		_minus := _f.mem.lookupNormExpr(left).asMinus()
+		if _minus != nil {
+			leftLeft := _minus.left()
+			if !_f.onlyConstants(leftLeft) {
+				leftRight := _minus.right()
+				if _f.onlyConstants(leftRight) {
+					if _f.onlyConstants(right) {
+						if _f.canConstructBinary(opt.PlusOp, right, leftRight) {
+							_f.reportOptimization()
+							_group = _f.ConstructEq(leftLeft, _f.ConstructPlus(right, leftRight))
+							_f.mem.addAltFingerprint(_eqExpr.fingerprint(), _group)
+							return _group
+						}
+					}
+				}
+			}
+		}
+	}
+
+	// [NormalizeCmpConstMinus]
+	{
+		_minus := _f.mem.lookupNormExpr(left).asMinus()
+		if _minus != nil {
+			leftLeft := _minus.left()
+			if _f.onlyConstants(leftLeft) {
+				leftRight := _minus.right()
+				if !_f.onlyConstants(leftRight) {
+					if _f.onlyConstants(right) {
+						if _f.canConstructBinary(opt.MinusOp, leftLeft, right) {
+							_f.reportOptimization()
+							_group = _f.ConstructEq(_f.ConstructMinus(leftLeft, right), leftRight)
+							_f.mem.addAltFingerprint(_eqExpr.fingerprint(), _group)
+							return _group
+						}
+					}
+				}
 			}
 		}
 	}
@@ -495,6 +570,95 @@ func (_f *factory) ConstructLt(
 		return _f.mem.memoizeNormExpr(memoExpr(_ltExpr))
 	}
 
+	// [CommuteVarInequality]
+	{
+		_variable := _f.mem.lookupNormExpr(left).asVariable()
+		if _variable == nil {
+			_variable2 := _f.mem.lookupNormExpr(right).asVariable()
+			if _variable2 != nil {
+				_f.reportOptimization()
+				_group = _f.commuteInequality(opt.LtOp, left, right)
+				_f.mem.addAltFingerprint(_ltExpr.fingerprint(), _group)
+				return _group
+			}
+		}
+	}
+
+	// [CommuteConstInequality]
+	{
+		if _f.onlyConstants(left) {
+			if !_f.onlyConstants(right) {
+				_f.reportOptimization()
+				_group = _f.commuteInequality(opt.LtOp, left, right)
+				_f.mem.addAltFingerprint(_ltExpr.fingerprint(), _group)
+				return _group
+			}
+		}
+	}
+
+	// [NormalizeCmpPlusConst]
+	{
+		_plus := _f.mem.lookupNormExpr(left).asPlus()
+		if _plus != nil {
+			leftLeft := _plus.left()
+			if !_f.onlyConstants(leftLeft) {
+				leftRight := _plus.right()
+				if _f.onlyConstants(leftRight) {
+					if _f.onlyConstants(right) {
+						if _f.canConstructBinary(opt.MinusOp, right, leftRight) {
+							_f.reportOptimization()
+							_group = _f.ConstructLt(leftLeft, _f.ConstructMinus(right, leftRight))
+							_f.mem.addAltFingerprint(_ltExpr.fingerprint(), _group)
+							return _group
+						}
+					}
+				}
+			}
+		}
+	}
+
+	// [NormalizeCmpMinusConst]
+	{
+		_minus := _f.mem.lookupNormExpr(left).asMinus()
+		if _minus != nil {
+			leftLeft := _minus.left()
+			if !_f.onlyConstants(leftLeft) {
+				leftRight := _minus.right()
+				if _f.onlyConstants(leftRight) {
+					if _f.onlyConstants(right) {
+						if _f.canConstructBinary(opt.PlusOp, right, leftRight) {
+							_f.reportOptimization()
+							_group = _f.ConstructLt(leftLeft, _f.ConstructPlus(right, leftRight))
+							_f.mem.addAltFingerprint(_ltExpr.fingerprint(), _group)
+							return _group
+						}
+					}
+				}
+			}
+		}
+	}
+
+	// [NormalizeCmpConstMinus]
+	{
+		_minus := _f.mem.lookupNormExpr(left).asMinus()
+		if _minus != nil {
+			leftLeft := _minus.left()
+			if _f.onlyConstants(leftLeft) {
+				leftRight := _minus.right()
+				if !_f.onlyConstants(leftRight) {
+					if _f.onlyConstants(right) {
+						if _f.canConstructBinary(opt.MinusOp, leftLeft, right) {
+							_f.reportOptimization()
+							_group = _f.ConstructLt(_f.ConstructMinus(leftLeft, right), leftRight)
+							_f.mem.addAltFingerprint(_ltExpr.fingerprint(), _group)
+							return _group
+						}
+					}
+				}
+			}
+		}
+	}
+
 	// [FoldNullComparisonLeft]
 	{
 		_null := _f.mem.lookupNormExpr(left).asNull()
@@ -533,6 +697,95 @@ func (_f *factory) ConstructGt(
 
 	if !_f.allowOptimizations() {
 		return _f.mem.memoizeNormExpr(memoExpr(_gtExpr))
+	}
+
+	// [CommuteVarInequality]
+	{
+		_variable := _f.mem.lookupNormExpr(left).asVariable()
+		if _variable == nil {
+			_variable2 := _f.mem.lookupNormExpr(right).asVariable()
+			if _variable2 != nil {
+				_f.reportOptimization()
+				_group = _f.commuteInequality(opt.GtOp, left, right)
+				_f.mem.addAltFingerprint(_gtExpr.fingerprint(), _group)
+				return _group
+			}
+		}
+	}
+
+	// [CommuteConstInequality]
+	{
+		if _f.onlyConstants(left) {
+			if !_f.onlyConstants(right) {
+				_f.reportOptimization()
+				_group = _f.commuteInequality(opt.GtOp, left, right)
+				_f.mem.addAltFingerprint(_gtExpr.fingerprint(), _group)
+				return _group
+			}
+		}
+	}
+
+	// [NormalizeCmpPlusConst]
+	{
+		_plus := _f.mem.lookupNormExpr(left).asPlus()
+		if _plus != nil {
+			leftLeft := _plus.left()
+			if !_f.onlyConstants(leftLeft) {
+				leftRight := _plus.right()
+				if _f.onlyConstants(leftRight) {
+					if _f.onlyConstants(right) {
+						if _f.canConstructBinary(opt.MinusOp, right, leftRight) {
+							_f.reportOptimization()
+							_group = _f.ConstructGt(leftLeft, _f.ConstructMinus(right, leftRight))
+							_f.mem.addAltFingerprint(_gtExpr.fingerprint(), _group)
+							return _group
+						}
+					}
+				}
+			}
+		}
+	}
+
+	// [NormalizeCmpMinusConst]
+	{
+		_minus := _f.mem.lookupNormExpr(left).asMinus()
+		if _minus != nil {
+			leftLeft := _minus.left()
+			if !_f.onlyConstants(leftLeft) {
+				leftRight := _minus.right()
+				if _f.onlyConstants(leftRight) {
+					if _f.onlyConstants(right) {
+						if _f.canConstructBinary(opt.PlusOp, right, leftRight) {
+							_f.reportOptimization()
+							_group = _f.ConstructGt(leftLeft, _f.ConstructPlus(right, leftRight))
+							_f.mem.addAltFingerprint(_gtExpr.fingerprint(), _group)
+							return _group
+						}
+					}
+				}
+			}
+		}
+	}
+
+	// [NormalizeCmpConstMinus]
+	{
+		_minus := _f.mem.lookupNormExpr(left).asMinus()
+		if _minus != nil {
+			leftLeft := _minus.left()
+			if _f.onlyConstants(leftLeft) {
+				leftRight := _minus.right()
+				if !_f.onlyConstants(leftRight) {
+					if _f.onlyConstants(right) {
+						if _f.canConstructBinary(opt.MinusOp, leftLeft, right) {
+							_f.reportOptimization()
+							_group = _f.ConstructGt(_f.ConstructMinus(leftLeft, right), leftRight)
+							_f.mem.addAltFingerprint(_gtExpr.fingerprint(), _group)
+							return _group
+						}
+					}
+				}
+			}
+		}
 	}
 
 	// [FoldNullComparisonLeft]
@@ -575,6 +828,95 @@ func (_f *factory) ConstructLe(
 		return _f.mem.memoizeNormExpr(memoExpr(_leExpr))
 	}
 
+	// [CommuteVarInequality]
+	{
+		_variable := _f.mem.lookupNormExpr(left).asVariable()
+		if _variable == nil {
+			_variable2 := _f.mem.lookupNormExpr(right).asVariable()
+			if _variable2 != nil {
+				_f.reportOptimization()
+				_group = _f.commuteInequality(opt.LeOp, left, right)
+				_f.mem.addAltFingerprint(_leExpr.fingerprint(), _group)
+				return _group
+			}
+		}
+	}
+
+	// [CommuteConstInequality]
+	{
+		if _f.onlyConstants(left) {
+			if !_f.onlyConstants(right) {
+				_f.reportOptimization()
+				_group = _f.commuteInequality(opt.LeOp, left, right)
+				_f.mem.addAltFingerprint(_leExpr.fingerprint(), _group)
+				return _group
+			}
+		}
+	}
+
+	// [NormalizeCmpPlusConst]
+	{
+		_plus := _f.mem.lookupNormExpr(left).asPlus()
+		if _plus != nil {
+			leftLeft := _plus.left()
+			if !_f.onlyConstants(leftLeft) {
+				leftRight := _plus.right()
+				if _f.onlyConstants(leftRight) {
+					if _f.onlyConstants(right) {
+						if _f.canConstructBinary(opt.MinusOp, right, leftRight) {
+							_f.reportOptimization()
+							_group = _f.ConstructLe(leftLeft, _f.ConstructMinus(right, leftRight))
+							_f.mem.addAltFingerprint(_leExpr.fingerprint(), _group)
+							return _group
+						}
+					}
+				}
+			}
+		}
+	}
+
+	// [NormalizeCmpMinusConst]
+	{
+		_minus := _f.mem.lookupNormExpr(left).asMinus()
+		if _minus != nil {
+			leftLeft := _minus.left()
+			if !_f.onlyConstants(leftLeft) {
+				leftRight := _minus.right()
+				if _f.onlyConstants(leftRight) {
+					if _f.onlyConstants(right) {
+						if _f.canConstructBinary(opt.PlusOp, right, leftRight) {
+							_f.reportOptimization()
+							_group = _f.ConstructLe(leftLeft, _f.ConstructPlus(right, leftRight))
+							_f.mem.addAltFingerprint(_leExpr.fingerprint(), _group)
+							return _group
+						}
+					}
+				}
+			}
+		}
+	}
+
+	// [NormalizeCmpConstMinus]
+	{
+		_minus := _f.mem.lookupNormExpr(left).asMinus()
+		if _minus != nil {
+			leftLeft := _minus.left()
+			if _f.onlyConstants(leftLeft) {
+				leftRight := _minus.right()
+				if !_f.onlyConstants(leftRight) {
+					if _f.onlyConstants(right) {
+						if _f.canConstructBinary(opt.MinusOp, leftLeft, right) {
+							_f.reportOptimization()
+							_group = _f.ConstructLe(_f.ConstructMinus(leftLeft, right), leftRight)
+							_f.mem.addAltFingerprint(_leExpr.fingerprint(), _group)
+							return _group
+						}
+					}
+				}
+			}
+		}
+	}
+
 	// [FoldNullComparisonLeft]
 	{
 		_null := _f.mem.lookupNormExpr(left).asNull()
@@ -613,6 +955,95 @@ func (_f *factory) ConstructGe(
 
 	if !_f.allowOptimizations() {
 		return _f.mem.memoizeNormExpr(memoExpr(_geExpr))
+	}
+
+	// [CommuteVarInequality]
+	{
+		_variable := _f.mem.lookupNormExpr(left).asVariable()
+		if _variable == nil {
+			_variable2 := _f.mem.lookupNormExpr(right).asVariable()
+			if _variable2 != nil {
+				_f.reportOptimization()
+				_group = _f.commuteInequality(opt.GeOp, left, right)
+				_f.mem.addAltFingerprint(_geExpr.fingerprint(), _group)
+				return _group
+			}
+		}
+	}
+
+	// [CommuteConstInequality]
+	{
+		if _f.onlyConstants(left) {
+			if !_f.onlyConstants(right) {
+				_f.reportOptimization()
+				_group = _f.commuteInequality(opt.GeOp, left, right)
+				_f.mem.addAltFingerprint(_geExpr.fingerprint(), _group)
+				return _group
+			}
+		}
+	}
+
+	// [NormalizeCmpPlusConst]
+	{
+		_plus := _f.mem.lookupNormExpr(left).asPlus()
+		if _plus != nil {
+			leftLeft := _plus.left()
+			if !_f.onlyConstants(leftLeft) {
+				leftRight := _plus.right()
+				if _f.onlyConstants(leftRight) {
+					if _f.onlyConstants(right) {
+						if _f.canConstructBinary(opt.MinusOp, right, leftRight) {
+							_f.reportOptimization()
+							_group = _f.ConstructGe(leftLeft, _f.ConstructMinus(right, leftRight))
+							_f.mem.addAltFingerprint(_geExpr.fingerprint(), _group)
+							return _group
+						}
+					}
+				}
+			}
+		}
+	}
+
+	// [NormalizeCmpMinusConst]
+	{
+		_minus := _f.mem.lookupNormExpr(left).asMinus()
+		if _minus != nil {
+			leftLeft := _minus.left()
+			if !_f.onlyConstants(leftLeft) {
+				leftRight := _minus.right()
+				if _f.onlyConstants(leftRight) {
+					if _f.onlyConstants(right) {
+						if _f.canConstructBinary(opt.PlusOp, right, leftRight) {
+							_f.reportOptimization()
+							_group = _f.ConstructGe(leftLeft, _f.ConstructPlus(right, leftRight))
+							_f.mem.addAltFingerprint(_geExpr.fingerprint(), _group)
+							return _group
+						}
+					}
+				}
+			}
+		}
+	}
+
+	// [NormalizeCmpConstMinus]
+	{
+		_minus := _f.mem.lookupNormExpr(left).asMinus()
+		if _minus != nil {
+			leftLeft := _minus.left()
+			if _f.onlyConstants(leftLeft) {
+				leftRight := _minus.right()
+				if !_f.onlyConstants(leftRight) {
+					if _f.onlyConstants(right) {
+						if _f.canConstructBinary(opt.MinusOp, leftLeft, right) {
+							_f.reportOptimization()
+							_group = _f.ConstructGe(_f.ConstructMinus(leftLeft, right), leftRight)
+							_f.mem.addAltFingerprint(_geExpr.fingerprint(), _group)
+							return _group
+						}
+					}
+				}
+			}
+		}
 	}
 
 	// [FoldNullComparisonLeft]
@@ -655,12 +1086,24 @@ func (_f *factory) ConstructNe(
 		return _f.mem.memoizeNormExpr(memoExpr(_neExpr))
 	}
 
-	// [NormalizeVar]
+	// [CommuteVar]
 	{
 		_variable := _f.mem.lookupNormExpr(left).asVariable()
 		if _variable == nil {
 			_variable2 := _f.mem.lookupNormExpr(right).asVariable()
 			if _variable2 != nil {
+				_f.reportOptimization()
+				_group = _f.ConstructNe(right, left)
+				_f.mem.addAltFingerprint(_neExpr.fingerprint(), _group)
+				return _group
+			}
+		}
+	}
+
+	// [CommuteConst]
+	{
+		if _f.onlyConstants(left) {
+			if !_f.onlyConstants(right) {
 				_f.reportOptimization()
 				_group = _f.ConstructNe(right, left)
 				_f.mem.addAltFingerprint(_neExpr.fingerprint(), _group)
@@ -709,6 +1152,69 @@ func (_f *factory) ConstructIn(
 		return _f.mem.memoizeNormExpr(memoExpr(_inExpr))
 	}
 
+	// [FoldNullInNonEmpty]
+	{
+		_null := _f.mem.lookupNormExpr(left).asNull()
+		if _null != nil {
+			_tuple := _f.mem.lookupNormExpr(right).asTuple()
+			if _tuple != nil {
+				if _tuple.elems().Length != 0 {
+					_f.reportOptimization()
+					_group = _f.ConstructNull(_f.boolType())
+					_f.mem.addAltFingerprint(_inExpr.fingerprint(), _group)
+					return _group
+				}
+			}
+		}
+	}
+
+	// [FoldNullInEmpty]
+	{
+		_null := _f.mem.lookupNormExpr(left).asNull()
+		if _null != nil {
+			_tuple := _f.mem.lookupNormExpr(right).asTuple()
+			if _tuple != nil {
+				if _tuple.elems().Length == 0 {
+					_f.reportOptimization()
+					_group = _f.ConstructFalse()
+					_f.mem.addAltFingerprint(_inExpr.fingerprint(), _group)
+					return _group
+				}
+			}
+		}
+	}
+
+	// [NormalizeInConst]
+	{
+		_tuple := _f.mem.lookupNormExpr(right).asTuple()
+		if _tuple != nil {
+			elems := _tuple.elems()
+			if !_f.isSortedUniqueList(elems) {
+				_f.reportOptimization()
+				_group = _f.ConstructIn(left, _f.ConstructTuple(_f.constructSortedUniqueList(elems)))
+				_f.mem.addAltFingerprint(_inExpr.fingerprint(), _group)
+				return _group
+			}
+		}
+	}
+
+	// [FoldInNull]
+	{
+		_tuple := _f.mem.lookupNormExpr(right).asTuple()
+		if _tuple != nil {
+			if _tuple.elems().Length == 1 {
+				_item := _f.mem.lookupList(_tuple.elems())[0]
+				_null := _f.mem.lookupNormExpr(_item).asNull()
+				if _null != nil {
+					_f.reportOptimization()
+					_group = _f.ConstructNull(_f.boolType())
+					_f.mem.addAltFingerprint(_inExpr.fingerprint(), _group)
+					return _group
+				}
+			}
+		}
+	}
+
 	return _f.onConstruct(_f.mem.memoizeNormExpr(memoExpr(_inExpr)))
 }
 
@@ -725,6 +1231,69 @@ func (_f *factory) ConstructNotIn(
 
 	if !_f.allowOptimizations() {
 		return _f.mem.memoizeNormExpr(memoExpr(_notInExpr))
+	}
+
+	// [FoldNullInNonEmpty]
+	{
+		_null := _f.mem.lookupNormExpr(left).asNull()
+		if _null != nil {
+			_tuple := _f.mem.lookupNormExpr(right).asTuple()
+			if _tuple != nil {
+				if _tuple.elems().Length != 0 {
+					_f.reportOptimization()
+					_group = _f.ConstructNull(_f.boolType())
+					_f.mem.addAltFingerprint(_notInExpr.fingerprint(), _group)
+					return _group
+				}
+			}
+		}
+	}
+
+	// [FoldNullNotInEmpty]
+	{
+		_null := _f.mem.lookupNormExpr(left).asNull()
+		if _null != nil {
+			_tuple := _f.mem.lookupNormExpr(right).asTuple()
+			if _tuple != nil {
+				if _tuple.elems().Length == 0 {
+					_f.reportOptimization()
+					_group = _f.ConstructTrue()
+					_f.mem.addAltFingerprint(_notInExpr.fingerprint(), _group)
+					return _group
+				}
+			}
+		}
+	}
+
+	// [NormalizeInConst]
+	{
+		_tuple := _f.mem.lookupNormExpr(right).asTuple()
+		if _tuple != nil {
+			elems := _tuple.elems()
+			if !_f.isSortedUniqueList(elems) {
+				_f.reportOptimization()
+				_group = _f.ConstructNotIn(left, _f.ConstructTuple(_f.constructSortedUniqueList(elems)))
+				_f.mem.addAltFingerprint(_notInExpr.fingerprint(), _group)
+				return _group
+			}
+		}
+	}
+
+	// [FoldInNull]
+	{
+		_tuple := _f.mem.lookupNormExpr(right).asTuple()
+		if _tuple != nil {
+			if _tuple.elems().Length == 1 {
+				_item := _f.mem.lookupList(_tuple.elems())[0]
+				_null := _f.mem.lookupNormExpr(_item).asNull()
+				if _null != nil {
+					_f.reportOptimization()
+					_group = _f.ConstructNull(_f.boolType())
+					_f.mem.addAltFingerprint(_notInExpr.fingerprint(), _group)
+					return _group
+				}
+			}
+		}
 	}
 
 	return _f.onConstruct(_f.mem.memoizeNormExpr(memoExpr(_notInExpr)))
@@ -1145,6 +1714,32 @@ func (_f *factory) ConstructIs(
 		return _f.mem.memoizeNormExpr(memoExpr(_isExpr))
 	}
 
+	// [CommuteVar]
+	{
+		_variable := _f.mem.lookupNormExpr(left).asVariable()
+		if _variable == nil {
+			_variable2 := _f.mem.lookupNormExpr(right).asVariable()
+			if _variable2 != nil {
+				_f.reportOptimization()
+				_group = _f.ConstructIs(right, left)
+				_f.mem.addAltFingerprint(_isExpr.fingerprint(), _group)
+				return _group
+			}
+		}
+	}
+
+	// [CommuteConst]
+	{
+		if _f.onlyConstants(left) {
+			if !_f.onlyConstants(right) {
+				_f.reportOptimization()
+				_group = _f.ConstructIs(right, left)
+				_f.mem.addAltFingerprint(_isExpr.fingerprint(), _group)
+				return _group
+			}
+		}
+	}
+
 	return _f.onConstruct(_f.mem.memoizeNormExpr(memoExpr(_isExpr)))
 }
 
@@ -1161,6 +1756,32 @@ func (_f *factory) ConstructIsNot(
 
 	if !_f.allowOptimizations() {
 		return _f.mem.memoizeNormExpr(memoExpr(_isNotExpr))
+	}
+
+	// [CommuteVar]
+	{
+		_variable := _f.mem.lookupNormExpr(left).asVariable()
+		if _variable == nil {
+			_variable2 := _f.mem.lookupNormExpr(right).asVariable()
+			if _variable2 != nil {
+				_f.reportOptimization()
+				_group = _f.ConstructIsNot(right, left)
+				_f.mem.addAltFingerprint(_isNotExpr.fingerprint(), _group)
+				return _group
+			}
+		}
+	}
+
+	// [CommuteConst]
+	{
+		if _f.onlyConstants(left) {
+			if !_f.onlyConstants(right) {
+				_f.reportOptimization()
+				_group = _f.ConstructIsNot(right, left)
+				_f.mem.addAltFingerprint(_isNotExpr.fingerprint(), _group)
+				return _group
+			}
+		}
 	}
 
 	return _f.onConstruct(_f.mem.memoizeNormExpr(memoExpr(_isNotExpr)))
@@ -1197,6 +1818,32 @@ func (_f *factory) ConstructBitand(
 
 	if !_f.allowOptimizations() {
 		return _f.mem.memoizeNormExpr(memoExpr(_bitandExpr))
+	}
+
+	// [CommuteVar]
+	{
+		_variable := _f.mem.lookupNormExpr(left).asVariable()
+		if _variable == nil {
+			_variable2 := _f.mem.lookupNormExpr(right).asVariable()
+			if _variable2 != nil {
+				_f.reportOptimization()
+				_group = _f.ConstructBitand(right, left)
+				_f.mem.addAltFingerprint(_bitandExpr.fingerprint(), _group)
+				return _group
+			}
+		}
+	}
+
+	// [CommuteConst]
+	{
+		if _f.onlyConstants(left) {
+			if !_f.onlyConstants(right) {
+				_f.reportOptimization()
+				_group = _f.ConstructBitand(right, left)
+				_f.mem.addAltFingerprint(_bitandExpr.fingerprint(), _group)
+				return _group
+			}
+		}
 	}
 
 	// [FoldNullBinaryLeft]
@@ -1243,6 +1890,32 @@ func (_f *factory) ConstructBitor(
 		return _f.mem.memoizeNormExpr(memoExpr(_bitorExpr))
 	}
 
+	// [CommuteVar]
+	{
+		_variable := _f.mem.lookupNormExpr(left).asVariable()
+		if _variable == nil {
+			_variable2 := _f.mem.lookupNormExpr(right).asVariable()
+			if _variable2 != nil {
+				_f.reportOptimization()
+				_group = _f.ConstructBitor(right, left)
+				_f.mem.addAltFingerprint(_bitorExpr.fingerprint(), _group)
+				return _group
+			}
+		}
+	}
+
+	// [CommuteConst]
+	{
+		if _f.onlyConstants(left) {
+			if !_f.onlyConstants(right) {
+				_f.reportOptimization()
+				_group = _f.ConstructBitor(right, left)
+				_f.mem.addAltFingerprint(_bitorExpr.fingerprint(), _group)
+				return _group
+			}
+		}
+	}
+
 	// [FoldNullBinaryLeft]
 	{
 		_null := _f.mem.lookupNormExpr(left).asNull()
@@ -1287,6 +1960,32 @@ func (_f *factory) ConstructBitxor(
 		return _f.mem.memoizeNormExpr(memoExpr(_bitxorExpr))
 	}
 
+	// [CommuteVar]
+	{
+		_variable := _f.mem.lookupNormExpr(left).asVariable()
+		if _variable == nil {
+			_variable2 := _f.mem.lookupNormExpr(right).asVariable()
+			if _variable2 != nil {
+				_f.reportOptimization()
+				_group = _f.ConstructBitxor(right, left)
+				_f.mem.addAltFingerprint(_bitxorExpr.fingerprint(), _group)
+				return _group
+			}
+		}
+	}
+
+	// [CommuteConst]
+	{
+		if _f.onlyConstants(left) {
+			if !_f.onlyConstants(right) {
+				_f.reportOptimization()
+				_group = _f.ConstructBitxor(right, left)
+				_f.mem.addAltFingerprint(_bitxorExpr.fingerprint(), _group)
+				return _group
+			}
+		}
+	}
+
 	// [FoldNullBinaryLeft]
 	{
 		_null := _f.mem.lookupNormExpr(left).asNull()
@@ -1329,6 +2028,32 @@ func (_f *factory) ConstructPlus(
 
 	if !_f.allowOptimizations() {
 		return _f.mem.memoizeNormExpr(memoExpr(_plusExpr))
+	}
+
+	// [CommuteVar]
+	{
+		_variable := _f.mem.lookupNormExpr(left).asVariable()
+		if _variable == nil {
+			_variable2 := _f.mem.lookupNormExpr(right).asVariable()
+			if _variable2 != nil {
+				_f.reportOptimization()
+				_group = _f.ConstructPlus(right, left)
+				_f.mem.addAltFingerprint(_plusExpr.fingerprint(), _group)
+				return _group
+			}
+		}
+	}
+
+	// [CommuteConst]
+	{
+		if _f.onlyConstants(left) {
+			if !_f.onlyConstants(right) {
+				_f.reportOptimization()
+				_group = _f.ConstructPlus(right, left)
+				_f.mem.addAltFingerprint(_plusExpr.fingerprint(), _group)
+				return _group
+			}
+		}
 	}
 
 	// [FoldNullBinaryLeft]
@@ -1456,6 +2181,32 @@ func (_f *factory) ConstructMult(
 
 	if !_f.allowOptimizations() {
 		return _f.mem.memoizeNormExpr(memoExpr(_multExpr))
+	}
+
+	// [CommuteVar]
+	{
+		_variable := _f.mem.lookupNormExpr(left).asVariable()
+		if _variable == nil {
+			_variable2 := _f.mem.lookupNormExpr(right).asVariable()
+			if _variable2 != nil {
+				_f.reportOptimization()
+				_group = _f.ConstructMult(right, left)
+				_f.mem.addAltFingerprint(_multExpr.fingerprint(), _group)
+				return _group
+			}
+		}
+	}
+
+	// [CommuteConst]
+	{
+		if _f.onlyConstants(left) {
+			if !_f.onlyConstants(right) {
+				_f.reportOptimization()
+				_group = _f.ConstructMult(right, left)
+				_f.mem.addAltFingerprint(_multExpr.fingerprint(), _group)
+				return _group
+			}
+		}
 	}
 
 	// [FoldNullBinaryLeft]
@@ -2039,34 +2790,6 @@ func (_f *factory) ConstructFetchTextPath(
 	return _f.onConstruct(_f.mem.memoizeNormExpr(memoExpr(_fetchTextPathExpr)))
 }
 
-// ConstructUnaryPlus constructs an expression for the UnaryPlus operator.
-func (_f *factory) ConstructUnaryPlus(
-	input opt.GroupID,
-) opt.GroupID {
-	_unaryPlusExpr := makeUnaryPlusExpr(input)
-	_group := _f.mem.lookupGroupByFingerprint(_unaryPlusExpr.fingerprint())
-	if _group != 0 {
-		return _group
-	}
-
-	if !_f.allowOptimizations() {
-		return _f.mem.memoizeNormExpr(memoExpr(_unaryPlusExpr))
-	}
-
-	// [FoldNullUnary]
-	{
-		_null := _f.mem.lookupNormExpr(input).asNull()
-		if _null != nil {
-			_f.reportOptimization()
-			_group = _f.foldNullUnary(opt.UnaryPlusOp, input)
-			_f.mem.addAltFingerprint(_unaryPlusExpr.fingerprint(), _group)
-			return _group
-		}
-	}
-
-	return _f.onConstruct(_f.mem.memoizeNormExpr(memoExpr(_unaryPlusExpr)))
-}
-
 // ConstructUnaryMinus constructs an expression for the UnaryMinus operator.
 func (_f *factory) ConstructUnaryMinus(
 	input opt.GroupID,
@@ -2087,6 +2810,33 @@ func (_f *factory) ConstructUnaryMinus(
 		if _null != nil {
 			_f.reportOptimization()
 			_group = _f.foldNullUnary(opt.UnaryMinusOp, input)
+			_f.mem.addAltFingerprint(_unaryMinusExpr.fingerprint(), _group)
+			return _group
+		}
+	}
+
+	// [InvertMinus]
+	{
+		_minus := _f.mem.lookupNormExpr(input).asMinus()
+		if _minus != nil {
+			left := _minus.left()
+			right := _minus.right()
+			if _f.canConstructBinary(opt.MinusOp, right, left) {
+				_f.reportOptimization()
+				_group = _f.ConstructMinus(right, left)
+				_f.mem.addAltFingerprint(_unaryMinusExpr.fingerprint(), _group)
+				return _group
+			}
+		}
+	}
+
+	// [EliminateUnaryMinus]
+	{
+		_unaryMinus := _f.mem.lookupNormExpr(input).asUnaryMinus()
+		if _unaryMinus != nil {
+			input := _unaryMinus.input()
+			_f.reportOptimization()
+			_group = input
 			_f.mem.addAltFingerprint(_unaryMinusExpr.fingerprint(), _group)
 			return _group
 		}
@@ -2136,6 +2886,16 @@ func (_f *factory) ConstructCast(
 
 	if !_f.allowOptimizations() {
 		return _f.mem.memoizeNormExpr(memoExpr(_castExpr))
+	}
+
+	// [EliminateCast]
+	{
+		if _f.hasType(input, typ) {
+			_f.reportOptimization()
+			_group = input
+			_f.mem.addAltFingerprint(_castExpr.fingerprint(), _group)
+			return _group
+		}
 	}
 
 	// [FoldNullCast]
@@ -2837,7 +3597,7 @@ func (_f *factory) ConstructExceptAll(
 
 type dynConstructLookupFunc func(f *factory, children []opt.GroupID, private opt.PrivateID) opt.GroupID
 
-var dynConstructLookup [85]dynConstructLookupFunc
+var dynConstructLookup [84]dynConstructLookupFunc
 
 func init() {
 	// UnknownOp
@@ -3103,11 +3863,6 @@ func init() {
 	// FetchTextPathOp
 	dynConstructLookup[opt.FetchTextPathOp] = func(f *factory, children []opt.GroupID, private opt.PrivateID) opt.GroupID {
 		return f.ConstructFetchTextPath(children[0], children[1])
-	}
-
-	// UnaryPlusOp
-	dynConstructLookup[opt.UnaryPlusOp] = func(f *factory, children []opt.GroupID, private opt.PrivateID) opt.GroupID {
-		return f.ConstructUnaryPlus(children[0])
 	}
 
 	// UnaryMinusOp

--- a/pkg/sql/opt/xform/logical_props.go
+++ b/pkg/sql/opt/xform/logical_props.go
@@ -58,6 +58,22 @@ type RelationalProps struct {
 type ScalarProps struct {
 	// Type is the data type of the scalar expression (int, string, etc).
 	Type types.T
+
+	// OuterCols is the set of columns that are referenced by variables within
+	// this scalar sub-expression, but are not bound within the scope of the
+	// expression. For example:
+	//
+	//   SELECT *
+	//   FROM a
+	//   WHERE EXISTS(SELECT * FROM b WHERE b.x = a.x AND b.y = 5)
+	//
+	// For the EXISTS expression, only a.x is an outer column, meaning that
+	// only it is defined "outside" the EXISTS expression (hence the name
+	// "outer"). Note that what constitutes an "outer column" is dependent on
+	// an expression's lcoation in the query. For example, while the b.x and
+	// b.y columns are not outer columns on the EXISTS expression, the *are*
+	// outer columns on the inner WHERE condition.
+	OuterCols opt.ColSet
 }
 
 func (p *LogicalProps) format(md *opt.Metadata, tp treeprinter.Node) {

--- a/pkg/sql/opt/xform/logical_props.go
+++ b/pkg/sql/opt/xform/logical_props.go
@@ -71,7 +71,7 @@ type ScalarProps struct {
 	// only it is defined "outside" the EXISTS expression (hence the name
 	// "outer"). Note that what constitutes an "outer column" is dependent on
 	// an expression's lcoation in the query. For example, while the b.x and
-	// b.y columns are not outer columns on the EXISTS expression, the *are*
+	// b.y columns are not outer columns on the EXISTS expression, they *are*
 	// outer columns on the inner WHERE condition.
 	OuterCols opt.ColSet
 }

--- a/pkg/sql/opt/xform/logical_props_test.go
+++ b/pkg/sql/opt/xform/logical_props_test.go
@@ -30,6 +30,7 @@ func TestLogicalProps(t *testing.T) {
 func TestLogicalJoinProps(t *testing.T) {
 	cat := createLogPropsCatalog(t)
 	f := newFactory(cat, 0)
+
 	a := f.Metadata().AddTable(cat.Table("a"))
 	b := f.Metadata().AddTable(cat.Table("b"))
 
@@ -54,47 +55,6 @@ func TestLogicalJoinProps(t *testing.T) {
 	joinFunc(opt.SemiJoinApplyOp, "columns: a.x:int:1 a.y:int:null:2\n")
 	joinFunc(opt.AntiJoinOp, "columns: a.x:int:1 a.y:int:null:2\n")
 	joinFunc(opt.AntiJoinApplyOp, "columns: a.x:int:1 a.y:int:null:2\n")
-}
-
-func TestLogicalSetProps(t *testing.T) {
-	cat := createLogPropsCatalog(t)
-	f := newFactory(cat, 0)
-	a := f.Metadata().AddTable(cat.Table("a"))
-	b := f.Metadata().AddTable(cat.Table("b"))
-
-	// (Union (Scan b) (Scan a))
-	leftGroup := f.ConstructScan(f.InternPrivate(b))
-	rightGroup := f.ConstructScan(f.InternPrivate(a))
-
-	a0 := f.Metadata().TableColumn(a, 0)
-	a1 := f.Metadata().TableColumn(a, 1)
-	b0 := f.Metadata().TableColumn(b, 0)
-	b1 := f.Metadata().TableColumn(b, 1)
-	colMap := &opt.SetOpColMap{}
-	colMap.Left = opt.ColList{b0, b1}
-	colMap.Right = opt.ColList{a1, a0}
-	colMap.Out = opt.ColList{b0, b1}
-
-	unionGroup := f.ConstructUnion(leftGroup, rightGroup, f.InternPrivate(colMap))
-
-	expected := "columns: b.x:int:null:3 b.z:int:4\n"
-	testLogicalProps(t, f, unionGroup, expected)
-}
-
-func TestLogicalValuesProps(t *testing.T) {
-	cat := createLogPropsCatalog(t)
-	f := newFactory(cat, 0)
-	a := f.Metadata().AddTable(cat.Table("a"))
-
-	// (Values)
-	rows := f.InternList(nil)
-	a0 := f.Metadata().TableColumn(a, 0)
-	a1 := f.Metadata().TableColumn(a, 1)
-	cols := opt.ColList{a0, a1}
-	valuesGroup := f.ConstructValues(rows, f.InternPrivate(&cols))
-
-	expected := "columns: a.x:int:null:1 a.y:int:null:2\n"
-	testLogicalProps(t, f, valuesGroup, expected)
 }
 
 func testLogicalProps(t *testing.T, f *factory, group opt.GroupID, expected string) {

--- a/pkg/sql/opt/xform/logical_props_test.go
+++ b/pkg/sql/opt/xform/logical_props_test.go
@@ -17,8 +17,10 @@ package xform
 import (
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/testutils"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/util/treeprinter"
 )
 
@@ -28,9 +30,11 @@ func TestLogicalProps(t *testing.T) {
 
 // Test joins that cannot yet be tested using SQL syntax + optimizer.
 func TestLogicalJoinProps(t *testing.T) {
-	cat := createLogPropsCatalog(t)
-	f := newFactory(cat, 0)
+	st := cluster.MakeTestingClusterSettings()
+	evalCtx := tree.MakeTestingEvalContext(st)
+	f := newFactory(&evalCtx, 0)
 
+	cat := createLogPropsCatalog(t)
 	a := f.Metadata().AddTable(cat.Table("a"))
 	b := f.Metadata().AddTable(cat.Table("b"))
 

--- a/pkg/sql/opt/xform/optimizer.go
+++ b/pkg/sql/opt/xform/optimizer.go
@@ -18,7 +18,7 @@ import (
 	"fmt"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
-	"github.com/cockroachdb/cockroach/pkg/sql/optbase"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"golang.org/x/tools/container/intsets"
 )
 
@@ -56,14 +56,13 @@ type Optimizer struct {
 	mem *memo
 }
 
-// NewOptimizer constructs an instance of the optimizer. Input expressions can
-// use metadata from the specified catalog. The maxSteps parameter limits the
-// number of normalization and exploration transformations that will be applied
-// by the optimizer. If maxSteps is zero, then the unaltered input expression
-// tree becomes the output expression tree (because no transformations are
-// applied).
-func NewOptimizer(cat optbase.Catalog, maxSteps OptimizeSteps) *Optimizer {
-	f := newFactory(cat, maxSteps)
+// NewOptimizer constructs an instance of the optimizer. The maxSteps parameter
+// limits the number of normalization and exploration transformations that will
+// be applied by the optimizer. If maxSteps is zero, then the unaltered input
+// expression tree becomes the output expression tree (because no transforms
+// are applied).
+func NewOptimizer(evalCtx *tree.EvalContext, maxSteps OptimizeSteps) *Optimizer {
+	f := newFactory(evalCtx, maxSteps)
 	return &Optimizer{f: f, mem: f.mem}
 }
 

--- a/pkg/sql/opt/xform/rules/bool.opt
+++ b/pkg/sql/opt/xform/rules/bool.opt
@@ -74,7 +74,7 @@ $item
 [NegateComparison, Normalize]
 (Not $input:(Comparison $left:* $right:*) & ^(Contains))
 =>
-(InvertComparison (OpName $input) $left $right)
+(NegateComparison (OpName $input) $left $right)
 
 # EliminateNot discards a doubled Not operator.
 [EliminateNot, Normalize]

--- a/pkg/sql/opt/xform/rules/comp.opt
+++ b/pkg/sql/opt/xform/rules/comp.opt
@@ -3,15 +3,102 @@
 # =============================================================================
 
 
-# NormalizeVar ensures that variable references are on the left side of
-# equality and inequality operators.
-[NormalizeVar, Normalize]
-(Eq | Ne
+# CommuteVarInequality is similar to CommuteVar (in scalar.opt), except it
+# handles inequality comparison operators that need special handling to commute
+# operands.
+[CommuteVarInequality, Normalize]
+(Le | Lt | Ge | Gt
     $left:^(Variable)
     $right:(Variable)
 )
 =>
-((OpName) $right $left)
+(CommuteInequality (OpName) $left $right)
+
+# CommuteConstInequality is similar to CommuteConst (in scalar.opt), except
+# that it handles inequality comparison operators that need special handling to
+# commute operands.
+[CommuteConstInequality, Normalize]
+(Le | Lt | Ge | Gt
+    $left:* & (OnlyConstants $left)
+    $right:* & ^(OnlyConstants $right)
+)
+=>
+(CommuteInequality (OpName) $left $right)
+
+# NormalizeCmpPlusConst builds up constant expression trees on one side of the
+# comparison, in cases like this:
+#       cmp          cmp
+#      /   \        /   \
+#    [+]    2  ->  a   [-]
+#   /   \             /   \
+#  a     1           2     1
+#
+# See the NormalizeConstEqNe pattern for the definition of constant expression
+# tree. Also, the NormalizePlusMult pattern ensures that constant expression
+# trees are on the right side of the expression, so no "flipped" pattern is
+# necessary. Other patterns will fold new constant expressions further.
+[NormalizeCmpPlusConst]
+(Eq | Ge | Gt | Le | Lt
+    (Plus
+        $leftLeft:* & ^(OnlyConstants $leftLeft)
+        $leftRight:* & (OnlyConstants $leftRight)
+    )
+    $right:* & (OnlyConstants $right) & (CanConstructBinary Minus $right $leftRight)
+)
+=>
+((OpName)
+    $leftLeft
+    (Minus $right $leftRight)
+)
+
+# NormalizeCmpMinusConst builds up constant expression trees on one side of the
+# comparison, in cases like this:
+#      cmp         cmp
+#      /  \        /  \
+#    [-]   2  ->  a  [+]
+#   /   \           /   \
+#  a     1         2     1
+#
+# See the NormalizeConstEqNe pattern for the definition of constant expression
+# tree. Other patterns will fold new constant expressions further.
+[NormalizeCmpMinusConst]
+(Eq | Ge | Gt | Le | Lt
+    (Minus
+        $leftLeft:* & ^(OnlyConstants $leftLeft)
+        $leftRight:* & (OnlyConstants $leftRight)
+    )
+    $right:* & (OnlyConstants $right) & (CanConstructBinary Plus $right $leftRight)
+)
+=>
+((OpName)
+    $leftLeft
+    (Plus $right $leftRight)
+)
+
+# NormalizeCmpConstMinus builds up constant expression trees on one side of the
+# comparison, in cases like this:
+#      cmp          cmp
+#      /  \         /  \
+#    [-]   2  ->  [-]   a
+#   /   \        /   \
+#  1     a      1     2
+#
+# See the NormalizeConstEqNe pattern for the definition of constant expression
+# tree. Other patterns will switch the constant to the right side and fold the
+# constant expression if possible.
+[NormalizeCmpConstMinus]
+(Eq | Ge | Gt | Le | Lt
+    (Minus
+        $leftLeft:* & (OnlyConstants $leftLeft)
+        $leftRight:* & ^(OnlyConstants $leftRight)
+    )
+    $right:* & (OnlyConstants $right) & (CanConstructBinary Minus $leftLeft $right)
+)
+=>
+((OpName)
+    (Minus $leftLeft $right)
+    $leftRight
+)
 
 # NormalizeTupleEquality breaks up expressions like:
 #   (a, b, c) = (x, y, z)

--- a/pkg/sql/opt/xform/rules/numeric.opt
+++ b/pkg/sql/opt/xform/rules/numeric.opt
@@ -2,7 +2,6 @@
 # numeric.opt contains normalization rules for numeric operators.
 # =============================================================================
 
-
 # FoldPlusZero folds $left + 0 for numeric types.
 [FoldPlusZero, Normalize]
 (Plus
@@ -56,3 +55,13 @@ $right
 )
 =>
 $left
+
+# InvertMinus rewrites -(a - b) to (b - a) if the operand types allow it.
+[InvertMinus, Normalize]
+(UnaryMinus (Minus $left:* $right:*) & (CanConstructBinary Minus $right $left))
+=>
+(Minus $right $left)
+
+# EliminateUnaryMinus discards a doubled UnaryMinus operator.
+[EliminateUnaryMinus, Normalize]
+(UnaryMinus (UnaryMinus $input:*)) => $input

--- a/pkg/sql/opt/xform/rules/scalar.opt
+++ b/pkg/sql/opt/xform/rules/scalar.opt
@@ -3,6 +3,43 @@
 # =============================================================================
 
 
+# CommuteVar ensures that variable references are on the left side of
+# commutative comparison and binary operators. Other patterns don't need to
+# handle both combinations.
+[CommuteVar, Normalize]
+(Eq | Ne | Is | IsNot | Plus | Mult | Bitand | Bitor | Bitxor
+    $left:^(Variable)
+    $right:(Variable)
+)
+=>
+((OpName) $right $left)
+
+# CommuteConst ensures that "constant expression trees" are on the right side
+# of commutative comparison and binary operators. A constant expression tree
+# has no unbound variables that refer to outer columns. It therefore always
+# evaluates to the same result. Note that this is possible even if the tree
+# contains variable expressions, as long as they are bound, such as in
+# uncorrelated subqueries:
+#
+#   SELECT * FROM a WHERE a.x = (SELECT SUM(b.x) FROM b)
+#
+# The right side of the equality expression is a constant expression tree, even
+# though it contains an entire subquery, because it always evalutes to the same
+# result. The left side is not a constant expression tree, even though it
+# contains just a single variable, because its value can be different for each
+# row in the table "a".
+#
+# The goal of this and related patterns is to push constant expression trees to
+# the right side until only a Variable remains on the left (if possible). Other
+# patterns can rely on this normal form and only handle one combination.
+[CommuteConst, Normalize]
+(Eq | Ne | Is | IsNot | Plus | Mult | Bitand | Bitor | Bitxor
+    $left:* & (OnlyConstants $left)
+    $right:* & ^(OnlyConstants $right)
+)
+=>
+((OpName) $right $left)
+
 # EliminateCoalesce discards the Coalesce operator if it has a single operand.
 [EliminateCoalesce, Normalize]
 (Coalesce [ $item:* ]) => $item
@@ -12,6 +49,11 @@
 # matches nulls as well as other constants.
 [SimplifyCoalesce, Normalize]
 (Coalesce $args:[ (ConstValue) ... ]) => (SimplifyCoalesce $args)
+
+# EliminateCast discards the cast operator if its input already has the desired
+# static type.
+[EliminateCast, Normalize]
+(Cast $input:* $typ:* & (HasType $input $typ)) => $input
 
 # FoldNullCast discards the cast operator if it has a null input. The resulting
 # null value has the target cast type.
@@ -42,3 +84,57 @@
 )
 =>
 (FoldNullBinary (OpName) $left $right)
+
+# FoldNullInNonEmpty replaces the In/NotIn with null when the left input is
+# null and the right input is not empty. Null is the unknown value, and if the
+# set is non-empty, it is unknown whether it's in/not in the set.
+[FoldNullInNonEmpty, Normalize]
+(In | NotIn
+    $left:(Null)
+    (Tuple ^[])
+)
+=>
+(Null (BoolType))
+
+# FoldNullInEmpty replaces the In with False when the left input is null and
+# the right input is empty, since even an unknown value can't be in an empty
+# set.
+[FoldNullInEmpty, Normalize]
+(In
+    $left:(Null)
+    (Tuple [])
+)
+=>
+(False)
+
+# FoldNullNotInEmpty replaces the NotIn with True when the left input is null
+# and the right input is empty, since even an unknown value can't be in an
+# empty set.
+[FoldNullNotInEmpty, Normalize]
+(NotIn
+    $left:(Null)
+    (Tuple [])
+)
+=>
+(True)
+
+# NormalizeInConst ensures that the In operator's tuple operand is sorted with
+# duplicates removed (since duplicates do not change the result).
+[NormalizeInConst, Normalize]
+(In | NotIn
+    $left:*
+    $right:(Tuple $elems:*) & ^(IsSortedUniqueList $elems)
+)
+=>
+((OpName) $left (Tuple (ConstructSortedUniqueList $elems)))
+
+# FoldInNull replaces the In/Not operator with Null when the tuple only
+# contains null. The NormalizeInConst pattern will reduce multiple nulls to a
+# single null when it removes duplicates, so this pattern will match that.
+[FoldInNull, Normalize]
+(In | NotIn
+    $left:*
+    (Tuple [ (Null) ])
+)
+=>
+(Null (BoolType))

--- a/pkg/sql/opt/xform/rules_test.go
+++ b/pkg/sql/opt/xform/rules_test.go
@@ -1,0 +1,76 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package xform
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
+)
+
+// Rules files can be run separately like this:
+//   make test PKG=./pkg/sql/opt/xform TESTS="TestRules/bool"
+//   make test PKG=./pkg/sql/opt/xform TESTS="TestRules/comp"
+//   ...
+func TestRules(t *testing.T) {
+	runDataDrivenTest(t, "testdata/rules/*")
+}
+
+// Test the FoldNullInEmpty rule. Can't create empty tuple on right side of
+// IN/NOT IN in SQL, so do it here.
+func TestRuleFoldNullInEmpty(t *testing.T) {
+	st := cluster.MakeTestingClusterSettings()
+	evalCtx := tree.MakeTestingEvalContext(st)
+	f := newFactory(&evalCtx, OptimizeAll)
+
+	null := f.ConstructNull(f.InternPrivate(types.Unknown))
+	empty := f.ConstructTuple(opt.EmptyList)
+	in := f.ConstructIn(null, empty)
+
+	if f.mem.lookupNormExpr(in).op != opt.FalseOp {
+		t.Errorf("expected NULL IN () to fold to False")
+	}
+
+	notIn := f.ConstructNotIn(null, empty)
+
+	if f.mem.lookupNormExpr(notIn).op != opt.TrueOp {
+		t.Errorf("expected NULL NOT IN () to fold to True")
+	}
+}
+
+// Ensure that every binary commutative operator overload can have its operands
+// switched. Patterns like CommuteConst rely on this being possible.
+func TestRuleBinaryAssumption(t *testing.T) {
+	fn := func(op opt.Operator) {
+		for _, overload := range tree.BinOps[opt.BinaryOpReverseMap[op]] {
+			binOp := overload.(tree.BinOp)
+
+			_, ok := findBinaryOverload(op, binOp.RightType, binOp.LeftType)
+			if !ok {
+				t.Errorf("could not find inverse for overload: %+v", op)
+			}
+		}
+	}
+
+	// Only include commutative binary operators.
+	fn(opt.PlusOp)
+	fn(opt.MultOp)
+	fn(opt.BitandOp)
+	fn(opt.BitorOp)
+	fn(opt.BitxorOp)
+}

--- a/pkg/sql/opt/xform/testdata/logprops/groupby
+++ b/pkg/sql/opt/xform/testdata/logprops/groupby
@@ -18,11 +18,11 @@ project
  │    ├── grouping columns: a.x:int:1 a.y:int:null:2
  │    ├── scan
  │    │    └── columns: a.x:int:1 a.y:int:null:2 a.z:float:3
- │    └── aggregations
- │         └── function: sum [type=float]
- │              └── variable: a.x [type=int]
- └── projections
-      ├── variable: a.y [type=int]
-      ├── variable: column4 [type=float]
-      ├── variable: a.x [type=int]
+ │    └── aggregations [outer=(1)]
+ │         └── function: sum [type=float, outer=(1)]
+ │              └── variable: a.x [type=int, outer=(1)]
+ └── projections [outer=(1,2,4)]
+      ├── variable: a.y [type=int, outer=(2)]
+      ├── variable: column4 [type=float, outer=(4)]
+      ├── variable: a.x [type=int, outer=(1)]
       └── false [type=bool]

--- a/pkg/sql/opt/xform/testdata/logprops/join
+++ b/pkg/sql/opt/xform/testdata/logprops/join
@@ -26,9 +26,9 @@ inner-join
  │    └── columns: a.x:int:1 a.y:int:null:2
  ├── scan
  │    └── columns: b.x:int:null:3 b.z:int:4 b.rowid:int:5
- └── eq [type=bool]
-      ├── variable: a.x [type=int]
-      └── variable: b.x [type=int]
+ └── eq [type=bool, outer=(1,3)]
+      ├── variable: a.x [type=int, outer=(1)]
+      └── variable: b.x [type=int, outer=(3)]
 
 build
 SELECT *, rowid FROM a LEFT JOIN b ON a.x=b.x
@@ -39,9 +39,9 @@ left-join
  │    └── columns: a.x:int:1 a.y:int:null:2
  ├── scan
  │    └── columns: b.x:int:null:3 b.z:int:4 b.rowid:int:5
- └── eq [type=bool]
-      ├── variable: a.x [type=int]
-      └── variable: b.x [type=int]
+ └── eq [type=bool, outer=(1,3)]
+      ├── variable: a.x [type=int, outer=(1)]
+      └── variable: b.x [type=int, outer=(3)]
 
 build
 SELECT *, rowid FROM a RIGHT JOIN b ON a.x=b.x
@@ -52,9 +52,9 @@ right-join
  │    └── columns: a.x:int:1 a.y:int:null:2
  ├── scan
  │    └── columns: b.x:int:null:3 b.z:int:4 b.rowid:int:5
- └── eq [type=bool]
-      ├── variable: a.x [type=int]
-      └── variable: b.x [type=int]
+ └── eq [type=bool, outer=(1,3)]
+      ├── variable: a.x [type=int, outer=(1)]
+      └── variable: b.x [type=int, outer=(3)]
 
 build
 SELECT *, rowid FROM a FULL JOIN b ON a.x=b.x
@@ -65,6 +65,6 @@ full-join
  │    └── columns: a.x:int:1 a.y:int:null:2
  ├── scan
  │    └── columns: b.x:int:null:3 b.z:int:4 b.rowid:int:5
- └── eq [type=bool]
-      ├── variable: a.x [type=int]
-      └── variable: b.x [type=int]
+ └── eq [type=bool, outer=(1,3)]
+      ├── variable: a.x [type=int, outer=(1)]
+      └── variable: b.x [type=int, outer=(3)]

--- a/pkg/sql/opt/xform/testdata/logprops/project
+++ b/pkg/sql/opt/xform/testdata/logprops/project
@@ -14,10 +14,10 @@ project
  ├── columns: y:int:null:2 column3:int:null:3 column4:int:null:4 x:int:1
  ├── scan
  │    └── columns: a.x:int:1 a.y:int:null:2
- └── projections
-      ├── variable: a.y [type=int]
-      ├── plus [type=int]
-      │    ├── variable: a.x [type=int]
+ └── projections [outer=(1,2)]
+      ├── variable: a.y [type=int, outer=(2)]
+      ├── plus [type=int, outer=(1)]
+      │    ├── variable: a.x [type=int, outer=(1)]
       │    └── const: 1 [type=int]
       ├── const: 1 [type=int]
-      └── variable: a.x [type=int]
+      └── variable: a.x [type=int, outer=(1)]

--- a/pkg/sql/opt/xform/testdata/logprops/scalar
+++ b/pkg/sql/opt/xform/testdata/logprops/scalar
@@ -1,0 +1,54 @@
+exec-ddl
+CREATE TABLE a (x INT PRIMARY KEY, y INT)
+----
+TABLE a
+ ├── x int not null
+ ├── y int
+ └── INDEX primary
+      └── x int not null
+
+exec-ddl
+CREATE TABLE b (x INT, z INT NOT NULL)
+----
+TABLE b
+ ├── x int
+ ├── z int not null
+ ├── rowid int not null (hidden)
+ └── INDEX primary
+      └── rowid int not null (hidden)
+
+build
+SELECT * FROM a WHERE x < 5
+----
+select
+ ├── columns: x:int:1 y:int:null:2
+ ├── scan
+ │    └── columns: a.x:int:1 a.y:int:null:2
+ └── lt [type=bool, outer=(1)]
+      ├── variable: a.x [type=int, outer=(1)]
+      └── const: 5 [type=int]
+
+build
+SELECT a.x + 1 = length('foo') + a.y, b.rowid * a.x FROM a, b
+----
+project
+ ├── columns: column6:bool:null:6 column7:int:null:7
+ ├── inner-join
+ │    ├── columns: a.x:int:1 a.y:int:null:2 b.x:int:null:3 b.z:int:4 b.rowid:int:5
+ │    ├── scan
+ │    │    └── columns: a.x:int:1 a.y:int:null:2
+ │    ├── scan
+ │    │    └── columns: b.x:int:null:3 b.z:int:4 b.rowid:int:5
+ │    └── true [type=bool]
+ └── projections [outer=(1,2,5)]
+      ├── eq [type=bool, outer=(1,2)]
+      │    ├── plus [type=int, outer=(1)]
+      │    │    ├── variable: a.x [type=int, outer=(1)]
+      │    │    └── const: 1 [type=int]
+      │    └── plus [type=int, outer=(2)]
+      │         ├── function: length [type=int]
+      │         │    └── const: 'foo' [type=string]
+      │         └── variable: a.y [type=int, outer=(2)]
+      └── mult [type=int, outer=(1,5)]
+           ├── variable: b.rowid [type=int, outer=(5)]
+           └── variable: a.x [type=int, outer=(1)]

--- a/pkg/sql/opt/xform/testdata/logprops/scan
+++ b/pkg/sql/opt/xform/testdata/logprops/scan
@@ -30,6 +30,6 @@ project
  ├── columns: x:int:null:1 z:int:2
  ├── scan
  │    └── columns: b.x:int:null:1 b.z:int:2 b.rowid:int:3
- └── projections
-      ├── variable: b.x [type=int]
-      └── variable: b.z [type=int]
+ └── projections [outer=(1,2)]
+      ├── variable: b.x [type=int, outer=(1)]
+      └── variable: b.z [type=int, outer=(2)]

--- a/pkg/sql/opt/xform/testdata/logprops/select
+++ b/pkg/sql/opt/xform/testdata/logprops/select
@@ -24,8 +24,8 @@ select
  ├── columns: x:int:1 y:int:null:2
  ├── scan
  │    └── columns: a.x:int:1 a.y:int:null:2
- └── eq [type=bool]
-      ├── variable: a.x [type=int]
+ └── eq [type=bool, outer=(1)]
+      ├── variable: a.x [type=int, outer=(1)]
       └── const: 1 [type=int]
 
 build
@@ -42,11 +42,11 @@ project
  │    │    ├── scan
  │    │    │    └── columns: b.x:int:null:3 b.z:int:4 b.rowid:int:5
  │    │    └── true [type=bool]
- │    └── eq [type=bool]
- │         ├── variable: a.x [type=int]
- │         └── variable: b.x [type=int]
- └── projections
-      ├── variable: a.x [type=int]
-      ├── variable: a.y [type=int]
-      ├── variable: b.x [type=int]
-      └── variable: b.z [type=int]
+ │    └── eq [type=bool, outer=(1,3)]
+ │         ├── variable: a.x [type=int, outer=(1)]
+ │         └── variable: b.x [type=int, outer=(3)]
+ └── projections [outer=(1-4)]
+      ├── variable: a.x [type=int, outer=(1)]
+      ├── variable: a.y [type=int, outer=(2)]
+      ├── variable: b.x [type=int, outer=(3)]
+      └── variable: b.z [type=int, outer=(4)]

--- a/pkg/sql/opt/xform/testdata/logprops/set
+++ b/pkg/sql/opt/xform/testdata/logprops/set
@@ -1,0 +1,83 @@
+exec-ddl
+CREATE TABLE a (x INT PRIMARY KEY, y INT)
+----
+TABLE a
+ ├── x int not null
+ ├── y int
+ └── INDEX primary
+      └── x int not null
+
+exec-ddl
+CREATE TABLE b (x INT, z INT NOT NULL)
+----
+TABLE b
+ ├── x int
+ ├── z int not null
+ ├── rowid int not null (hidden)
+ └── INDEX primary
+      └── rowid int not null (hidden)
+
+build
+SELECT * FROM a UNION SELECT * FROM b
+----
+union
+ ├── columns: x:int:null:6 y:int:null:7
+ ├── left columns: a.x:int:null:1 a.y:int:null:2
+ ├── right columns: b.x:int:null:3 b.z:int:null:4
+ ├── scan
+ │    └── columns: a.x:int:1 a.y:int:null:2
+ └── project
+      ├── columns: b.x:int:null:3 b.z:int:4
+      ├── scan
+      │    └── columns: b.x:int:null:3 b.z:int:4 b.rowid:int:5
+      └── projections [outer=(3,4)]
+           ├── variable: b.x [type=int, outer=(3)]
+           └── variable: b.z [type=int, outer=(4)]
+
+build
+SELECT x, y, x FROM a INTERSECT SELECT z, x, rowid FROM b
+----
+intersect
+ ├── columns: x:int:1 y:int:null:2 x:int:1
+ ├── left columns: a.x:int:1 a.y:int:null:2 a.x:int:1
+ ├── right columns: b.z:int:null:4 b.x:int:null:3 b.rowid:int:null:5
+ ├── project
+ │    ├── columns: a.x:int:1 a.y:int:null:2 a.x:int:1
+ │    ├── scan
+ │    │    └── columns: a.x:int:1 a.y:int:null:2
+ │    └── projections [outer=(1,2)]
+ │         ├── variable: a.x [type=int, outer=(1)]
+ │         ├── variable: a.y [type=int, outer=(2)]
+ │         └── variable: a.x [type=int, outer=(1)]
+ └── project
+      ├── columns: b.z:int:4 b.x:int:null:3 b.rowid:int:5
+      ├── scan
+      │    └── columns: b.x:int:null:3 b.z:int:4 b.rowid:int:5
+      └── projections [outer=(3-5)]
+           ├── variable: b.z [type=int, outer=(4)]
+           ├── variable: b.x [type=int, outer=(3)]
+           └── variable: b.rowid [type=int, outer=(5)]
+
+build
+SELECT x, x, y FROM a EXCEPT SELECT x, z, z FROM b
+----
+except
+ ├── columns: x:int:1 x:int:1 y:int:null:2
+ ├── left columns: a.x:int:1 a.x:int:1 a.y:int:null:2
+ ├── right columns: b.x:int:null:3 b.z:int:null:4 b.z:int:null:4
+ ├── project
+ │    ├── columns: a.x:int:1 a.x:int:1 a.y:int:null:2
+ │    ├── scan
+ │    │    └── columns: a.x:int:1 a.y:int:null:2
+ │    └── projections [outer=(1,2)]
+ │         ├── variable: a.x [type=int, outer=(1)]
+ │         ├── variable: a.x [type=int, outer=(1)]
+ │         └── variable: a.y [type=int, outer=(2)]
+ └── project
+      ├── columns: b.x:int:null:3 b.z:int:4 b.z:int:4
+      ├── scan
+      │    └── columns: b.x:int:null:3 b.z:int:4 b.rowid:int:5
+      └── projections [outer=(3,4)]
+           ├── variable: b.x [type=int, outer=(3)]
+           ├── variable: b.z [type=int, outer=(4)]
+           └── variable: b.z [type=int, outer=(4)]

--- a/pkg/sql/opt/xform/testdata/logprops/values
+++ b/pkg/sql/opt/xform/testdata/logprops/values
@@ -1,0 +1,14 @@
+build
+SELECT * FROM (VALUES (1, 2), (3, 4), (NULL, 5))
+----
+values
+ ├── columns: column1:int:null:1 column2:int:null:2
+ ├── tuple [type=tuple{int, int}]
+ │    ├── const: 1 [type=int]
+ │    └── const: 2 [type=int]
+ ├── tuple [type=tuple{int, int}]
+ │    ├── const: 3 [type=int]
+ │    └── const: 4 [type=int]
+ └── tuple [type=tuple{unknown, int}]
+      ├── null [type=unknown]
+      └── const: 5 [type=int]

--- a/pkg/sql/opt/xform/testdata/physprops/ordering
+++ b/pkg/sql/opt/xform/testdata/physprops/ordering
@@ -71,8 +71,8 @@ select
  ├── scan
  │    ├── columns: a.x:int:1 a.y:float:2 a.z:decimal:null:3 a.s:string:4
  │    └── ordering: +1,-2
- └── eq [type=bool]
-      ├── variable: a.x [type=int]
+ └── eq [type=bool, outer=(1)]
+      ├── variable: a.x [type=int, outer=(1)]
       └── const: 1 [type=int]
 
 # Pass through ordering to scan operator that can't support it.
@@ -87,8 +87,8 @@ select
  │    ├── ordering: -3
  │    └── scan
  │         └── columns: a.x:int:1 a.y:float:2 a.z:decimal:null:3 a.s:string:4
- └── eq [type=bool]
-      ├── variable: a.x [type=int]
+ └── eq [type=bool, outer=(1)]
+      ├── variable: a.x [type=int, outer=(1)]
       └── const: 1 [type=int]
 
 # --------------------------------------------------
@@ -105,9 +105,9 @@ project
  ├── scan
  │    ├── columns: a.x:int:1 a.y:float:2 a.z:decimal:null:3 a.s:string:4
  │    └── ordering: +1,-2
- └── projections
-      ├── variable: a.x [type=int]
-      └── variable: a.y [type=float]
+ └── projections [outer=(1,2)]
+      ├── variable: a.x [type=int, outer=(1)]
+      └── variable: a.y [type=float, outer=(2)]
 
 # Pass through ordering to scan operator that can't support it.
 opt
@@ -121,11 +121,11 @@ project
  │    ├── ordering: +1,+2
  │    └── scan
  │         └── columns: a.x:int:1 a.y:float:2 a.z:decimal:null:3 a.s:string:4
- └── projections
-      ├── variable: a.y [type=float]
-      ├── variable: a.x [type=int]
-      └── plus [type=decimal]
-           ├── variable: a.z [type=decimal]
+ └── projections [outer=(1-3)]
+      ├── variable: a.y [type=float, outer=(2)]
+      ├── variable: a.x [type=int, outer=(1)]
+      └── plus [type=decimal, outer=(3)]
+           ├── variable: a.z [type=decimal, outer=(3)]
            └── const: 1 [type=decimal]
 
 # Ordering cannot be passed through because it includes computed column.
@@ -139,10 +139,10 @@ sort
       ├── columns: a.x:int:1 one:int:null:5 a.y:float:2
       ├── scan
       │    └── columns: a.x:int:1 a.y:float:2 a.z:decimal:null:3 a.s:string:4
-      └── projections
-           ├── variable: a.x [type=int]
+      └── projections [outer=(1,2)]
+           ├── variable: a.x [type=int, outer=(1)]
            ├── const: 1 [type=int]
-           └── variable: a.y [type=float]
+           └── variable: a.y [type=float, outer=(2)]
 
 # --------------------------------------------------
 # Select + Project operators (pass through both).
@@ -161,12 +161,12 @@ project
  │    ├── scan
  │    │    ├── columns: a.x:int:1 a.y:float:2 a.z:decimal:null:3 a.s:string:4
  │    │    └── ordering: +1,-2
- │    └── eq [type=bool]
- │         ├── variable: a.x [type=int]
+ │    └── eq [type=bool, outer=(1)]
+ │         ├── variable: a.x [type=int, outer=(1)]
  │         └── const: 1 [type=int]
- └── projections
-      ├── variable: a.y [type=float]
-      └── variable: a.x [type=int]
+ └── projections [outer=(1,2)]
+      ├── variable: a.y [type=float, outer=(2)]
+      └── variable: a.x [type=int, outer=(1)]
 
 memo
 SELECT y, x FROM a WHERE x=1 ORDER BY x, y DESC
@@ -209,12 +209,12 @@ project
  │    │    ├── ordering: +2
  │    │    └── scan
  │    │         └── columns: a.x:int:1 a.y:float:2 a.z:decimal:null:3 a.s:string:4
- │    └── eq [type=bool]
- │         ├── variable: a.x [type=int]
+ │    └── eq [type=bool, outer=(1)]
+ │         ├── variable: a.x [type=int, outer=(1)]
  │         └── const: 1 [type=int]
- └── projections
-      ├── variable: a.y [type=float]
-      └── variable: a.z [type=decimal]
+ └── projections [outer=(2,3)]
+      ├── variable: a.y [type=float, outer=(2)]
+      └── variable: a.z [type=decimal, outer=(3)]
 
 memo
 SELECT y, z FROM a WHERE x=1 ORDER BY y

--- a/pkg/sql/opt/xform/testdata/physprops/presentation
+++ b/pkg/sql/opt/xform/testdata/physprops/presentation
@@ -32,8 +32,8 @@ select
  ├── columns: y:int:null:2 x:int:1 y2:int:null:2
  ├── scan
  │    └── columns: a.x:int:1 a.y:int:null:2
- └── eq [type=bool]
-      ├── variable: a.x [type=int]
+ └── eq [type=bool, outer=(1)]
+      ├── variable: a.x [type=int, outer=(1)]
       └── const: 1 [type=int]
 
 # Project operator.
@@ -44,11 +44,11 @@ project
  ├── columns: plus:int:null:3 x:int:1
  ├── scan
  │    └── columns: a.x:int:1 a.y:int:null:2
- └── projections
-      ├── plus [type=int]
+ └── projections [outer=(1,2)]
+      ├── plus [type=int, outer=(2)]
       │    ├── const: 1 [type=int]
-      │    └── variable: a.y [type=int]
-      └── variable: a.x [type=int]
+      │    └── variable: a.y [type=int, outer=(2)]
+      └── variable: a.x [type=int, outer=(1)]
 
 # Join operator.
 opt
@@ -71,6 +71,6 @@ group-by
  ├── grouping columns: a.x:int:1 a.y:int:null:2
  ├── scan
  │    └── columns: a.x:int:1 a.y:int:null:2
- └── aggregations
-      └── function: max [type=int]
-           └── variable: a.x [type=int]
+ └── aggregations [outer=(1)]
+      └── function: max [type=int, outer=(1)]
+           └── variable: a.x [type=int, outer=(1)]

--- a/pkg/sql/opt/xform/testdata/physprops/presentation
+++ b/pkg/sql/opt/xform/testdata/physprops/presentation
@@ -46,8 +46,8 @@ project
  │    └── columns: a.x:int:1 a.y:int:null:2
  └── projections [outer=(1,2)]
       ├── plus [type=int, outer=(2)]
-      │    ├── const: 1 [type=int]
-      │    └── variable: a.y [type=int, outer=(2)]
+      │    ├── variable: a.y [type=int, outer=(2)]
+      │    └── const: 1 [type=int]
       └── variable: a.x [type=int, outer=(1)]
 
 # Join operator.

--- a/pkg/sql/opt/xform/testdata/rules/bool
+++ b/pkg/sql/opt/xform/testdata/rules/bool
@@ -20,15 +20,15 @@ select
  ├── columns: k:int:1 i:int:null:2 f:float:null:3 s:string:null:4 j:jsonb:null:5
  ├── scan
  │    └── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5
- └── and [type=bool]
-      ├── gt [type=bool]
-      │    ├── variable: a.k [type=int]
+ └── and [type=bool, outer=(1,3)]
+      ├── gt [type=bool, outer=(1)]
+      │    ├── variable: a.k [type=int, outer=(1)]
       │    └── const: 1 [type=int]
-      ├── lt [type=bool]
-      │    ├── variable: a.k [type=int]
+      ├── lt [type=bool, outer=(1)]
+      │    ├── variable: a.k [type=int, outer=(1)]
       │    └── const: 5 [type=int]
-      └── eq [type=bool]
-           ├── variable: a.f [type=float]
+      └── eq [type=bool, outer=(3)]
+           ├── variable: a.f [type=float, outer=(3)]
            └── const: 3.5 [type=float]
 
 # --------------------------------------------------
@@ -41,15 +41,15 @@ select
  ├── columns: k:int:1 i:int:null:2 f:float:null:3 s:string:null:4 j:jsonb:null:5
  ├── scan
  │    └── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5
- └── or [type=bool]
-      ├── eq [type=bool]
-      │    ├── variable: a.k [type=int]
+ └── or [type=bool, outer=(1-3)]
+      ├── eq [type=bool, outer=(1)]
+      │    ├── variable: a.k [type=int, outer=(1)]
       │    └── const: 1 [type=int]
-      ├── eq [type=bool]
-      │    ├── variable: a.i [type=int]
+      ├── eq [type=bool, outer=(2)]
+      │    ├── variable: a.i [type=int, outer=(2)]
       │    └── const: 2 [type=int]
-      └── eq [type=bool]
-           ├── variable: a.f [type=float]
+      └── eq [type=bool, outer=(3)]
+           ├── variable: a.f [type=float, outer=(3)]
            └── const: 3.5 [type=float]
 
 # --------------------------------------------------
@@ -64,22 +64,22 @@ select
  ├── columns: k:int:1 i:int:null:2 f:float:null:3 s:string:null:4 j:jsonb:null:5
  ├── scan
  │    └── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5
- └── and [type=bool]
-      ├── or [type=bool]
-      │    ├── eq [type=bool]
-      │    │    ├── variable: a.k [type=int]
+ └── and [type=bool, outer=(1-4)]
+      ├── or [type=bool, outer=(1-3)]
+      │    ├── eq [type=bool, outer=(1)]
+      │    │    ├── variable: a.k [type=int, outer=(1)]
       │    │    └── const: 1 [type=int]
-      │    ├── eq [type=bool]
-      │    │    ├── variable: a.i [type=int]
+      │    ├── eq [type=bool, outer=(2)]
+      │    │    ├── variable: a.i [type=int, outer=(2)]
       │    │    └── const: 2 [type=int]
-      │    └── eq [type=bool]
-      │         ├── variable: a.f [type=float]
+      │    └── eq [type=bool, outer=(3)]
+      │         ├── variable: a.f [type=float, outer=(3)]
       │         └── const: 3.5 [type=float]
-      ├── eq [type=bool]
-      │    ├── variable: a.s [type=string]
+      ├── eq [type=bool, outer=(4)]
+      │    ├── variable: a.s [type=string, outer=(4)]
       │    └── const: 'foo' [type=string]
-      └── ne [type=bool]
-           ├── variable: a.s [type=string]
+      └── ne [type=bool, outer=(4)]
+           ├── variable: a.s [type=string, outer=(4)]
            └── const: 'bar' [type=string]
 
 # --------------------------------------------------
@@ -110,9 +110,9 @@ select
  ├── columns: k:int:1 i:int:null:2 f:float:null:3 s:string:null:4 j:jsonb:null:5
  ├── scan
  │    └── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5
- └── and [type=bool]
-      └── eq [type=bool]
-           ├── variable: a.k [type=int]
+ └── and [type=bool, outer=(1)]
+      └── eq [type=bool, outer=(1)]
+           ├── variable: a.k [type=int, outer=(1)]
            └── const: 1 [type=int]
 
 opt
@@ -122,12 +122,12 @@ select
  ├── columns: k:int:1 i:int:null:2 f:float:null:3 s:string:null:4 j:jsonb:null:5
  ├── scan
  │    └── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5
- └── and [type=bool]
-      ├── eq [type=bool]
-      │    ├── variable: a.k [type=int]
+ └── and [type=bool, outer=(1,2)]
+      ├── eq [type=bool, outer=(1)]
+      │    ├── variable: a.k [type=int, outer=(1)]
       │    └── const: 1 [type=int]
-      └── eq [type=bool]
-           ├── variable: a.i [type=int]
+      └── eq [type=bool, outer=(2)]
+           ├── variable: a.i [type=int, outer=(2)]
            └── const: 2 [type=int]
 
 opt
@@ -167,8 +167,8 @@ select
  ├── columns: k:int:1 i:int:null:2 f:float:null:3 s:string:null:4 j:jsonb:null:5
  ├── scan
  │    └── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5
- └── eq [type=bool]
-      ├── variable: a.k [type=int]
+ └── eq [type=bool, outer=(1)]
+      ├── variable: a.k [type=int, outer=(1)]
       └── const: 1 [type=int]
 
 opt
@@ -178,12 +178,12 @@ select
  ├── columns: k:int:1 i:int:null:2 f:float:null:3 s:string:null:4 j:jsonb:null:5
  ├── scan
  │    └── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5
- └── or [type=bool]
-      ├── eq [type=bool]
-      │    ├── variable: a.k [type=int]
+ └── or [type=bool, outer=(1,2)]
+      ├── eq [type=bool, outer=(1)]
+      │    ├── variable: a.k [type=int, outer=(1)]
       │    └── const: 1 [type=int]
-      └── eq [type=bool]
-           ├── variable: a.i [type=int]
+      └── eq [type=bool, outer=(2)]
+           ├── variable: a.i [type=int, outer=(2)]
            └── const: 2 [type=int]
 
 opt
@@ -205,12 +205,12 @@ select
  ├── columns: k:int:1 i:int:null:2 f:float:null:3 s:string:null:4 j:jsonb:null:5
  ├── scan
  │    └── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5
- └── and [type=bool]
-      ├── eq [type=bool]
-      │    ├── variable: a.k [type=int]
+ └── and [type=bool, outer=(1)]
+      ├── eq [type=bool, outer=(1)]
+      │    ├── variable: a.k [type=int, outer=(1)]
       │    └── const: 1 [type=int]
-      └── eq [type=bool]
-           ├── variable: a.k [type=int]
+      └── eq [type=bool, outer=(1)]
+           ├── variable: a.k [type=int, outer=(1)]
            └── const: 2 [type=int]
 
 # --------------------------------------------------
@@ -251,12 +251,12 @@ select
  ├── columns: k:int:1 i:int:null:2 f:float:null:3 s:string:null:4 j:jsonb:null:5
  ├── scan
  │    └── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5
- └── or [type=bool]
+ └── or [type=bool, outer=(1)]
       ├── null [type=unknown]
-      └── and [type=bool]
+      └── and [type=bool, outer=(1)]
            ├── null [type=unknown]
-           └── eq [type=bool]
-                ├── variable: a.k [type=int]
+           └── eq [type=bool, outer=(1)]
+                ├── variable: a.k [type=int, outer=(1)]
                 └── const: 1 [type=int]
 
 # --------------------------------------------------
@@ -271,24 +271,24 @@ select
  ├── columns: k:int:1 i:int:null:2 f:float:null:3 s:string:null:4 j:jsonb:null:5
  ├── scan
  │    └── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5
- └── and [type=bool]
-      ├── ne [type=bool]
-      │    ├── variable: a.i [type=int]
+ └── and [type=bool, outer=(2)]
+      ├── ne [type=bool, outer=(2)]
+      │    ├── variable: a.i [type=int, outer=(2)]
       │    └── const: 1 [type=int]
-      ├── eq [type=bool]
-      │    ├── variable: a.i [type=int]
+      ├── eq [type=bool, outer=(2)]
+      │    ├── variable: a.i [type=int, outer=(2)]
       │    └── const: 1 [type=int]
-      ├── le [type=bool]
-      │    ├── variable: a.i [type=int]
+      ├── le [type=bool, outer=(2)]
+      │    ├── variable: a.i [type=int, outer=(2)]
       │    └── const: 1 [type=int]
-      ├── lt [type=bool]
-      │    ├── variable: a.i [type=int]
+      ├── lt [type=bool, outer=(2)]
+      │    ├── variable: a.i [type=int, outer=(2)]
       │    └── const: 1 [type=int]
-      ├── ge [type=bool]
-      │    ├── variable: a.i [type=int]
+      ├── ge [type=bool, outer=(2)]
+      │    ├── variable: a.i [type=int, outer=(2)]
       │    └── const: 1 [type=int]
-      └── gt [type=bool]
-           ├── variable: a.i [type=int]
+      └── gt [type=bool, outer=(2)]
+           ├── variable: a.i [type=int, outer=(2)]
            └── const: 1 [type=int]
 
 # IN and IS comparisons.
@@ -301,22 +301,22 @@ select
  ├── columns: k:int:1 i:int:null:2 f:float:null:3 s:string:null:4 j:jsonb:null:5
  ├── scan
  │    └── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5
- └── and [type=bool]
-      ├── not-in [type=bool]
-      │    ├── variable: a.i [type=int]
+ └── and [type=bool, outer=(2)]
+      ├── not-in [type=bool, outer=(2)]
+      │    ├── variable: a.i [type=int, outer=(2)]
       │    └── tuple [type=tuple{int, int}]
       │         ├── const: 1 [type=int]
       │         └── const: 2 [type=int]
-      ├── in [type=bool]
-      │    ├── variable: a.i [type=int]
+      ├── in [type=bool, outer=(2)]
+      │    ├── variable: a.i [type=int, outer=(2)]
       │    └── tuple [type=tuple{int, int}]
       │         ├── const: 3 [type=int]
       │         └── const: 4 [type=int]
-      ├── is-not [type=bool]
-      │    ├── variable: a.i [type=int]
+      ├── is-not [type=bool, outer=(2)]
+      │    ├── variable: a.i [type=int, outer=(2)]
       │    └── null [type=unknown]
-      └── is [type=bool]
-           ├── variable: a.i [type=int]
+      └── is [type=bool, outer=(2)]
+           ├── variable: a.i [type=int, outer=(2)]
            └── null [type=unknown]
 
 # Like comparisons.
@@ -329,18 +329,18 @@ select
  ├── columns: k:int:1 i:int:null:2 f:float:null:3 s:string:null:4 j:jsonb:null:5
  ├── scan
  │    └── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5
- └── and [type=bool]
-      ├── not-like [type=bool]
-      │    ├── variable: a.s [type=string]
+ └── and [type=bool, outer=(4)]
+      ├── not-like [type=bool, outer=(4)]
+      │    ├── variable: a.s [type=string, outer=(4)]
       │    └── const: 'foo' [type=string]
-      ├── like [type=bool]
-      │    ├── variable: a.s [type=string]
+      ├── like [type=bool, outer=(4)]
+      │    ├── variable: a.s [type=string, outer=(4)]
       │    └── const: 'foo' [type=string]
-      ├── not-i-like [type=bool]
-      │    ├── variable: a.s [type=string]
+      ├── not-i-like [type=bool, outer=(4)]
+      │    ├── variable: a.s [type=string, outer=(4)]
       │    └── const: 'foo' [type=string]
-      └── i-like [type=bool]
-           ├── variable: a.s [type=string]
+      └── i-like [type=bool, outer=(4)]
+           ├── variable: a.s [type=string, outer=(4)]
            └── const: 'foo' [type=string]
 
 # SimilarTo comparisons.
@@ -351,12 +351,12 @@ select
  ├── columns: k:int:1 i:int:null:2 f:float:null:3 s:string:null:4 j:jsonb:null:5
  ├── scan
  │    └── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5
- └── and [type=bool]
-      ├── not-similar-to [type=bool]
-      │    ├── variable: a.s [type=string]
+ └── and [type=bool, outer=(4)]
+      ├── not-similar-to [type=bool, outer=(4)]
+      │    ├── variable: a.s [type=string, outer=(4)]
       │    └── const: 'foo' [type=string]
-      └── similar-to [type=bool]
-           ├── variable: a.s [type=string]
+      └── similar-to [type=bool, outer=(4)]
+           ├── variable: a.s [type=string, outer=(4)]
            └── const: 'foo' [type=string]
 
 # RegMatch comparisons.
@@ -367,18 +367,18 @@ select
  ├── columns: k:int:1 i:int:null:2 f:float:null:3 s:string:null:4 j:jsonb:null:5
  ├── scan
  │    └── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5
- └── and [type=bool]
-      ├── not-reg-match [type=bool]
-      │    ├── variable: a.s [type=string]
+ └── and [type=bool, outer=(4)]
+      ├── not-reg-match [type=bool, outer=(4)]
+      │    ├── variable: a.s [type=string, outer=(4)]
       │    └── const: 'foo' [type=string]
-      ├── reg-match [type=bool]
-      │    ├── variable: a.s [type=string]
+      ├── reg-match [type=bool, outer=(4)]
+      │    ├── variable: a.s [type=string, outer=(4)]
       │    └── const: 'foo' [type=string]
-      ├── not-reg-i-match [type=bool]
-      │    ├── variable: a.s [type=string]
+      ├── not-reg-i-match [type=bool, outer=(4)]
+      │    ├── variable: a.s [type=string, outer=(4)]
       │    └── const: 'foo' [type=string]
-      └── reg-i-match [type=bool]
-           ├── variable: a.s [type=string]
+      └── reg-i-match [type=bool, outer=(4)]
+           ├── variable: a.s [type=string, outer=(4)]
            └── const: 'foo' [type=string]
 
 # Contains comparison (should not be negated).
@@ -389,15 +389,15 @@ select
  ├── columns: k:int:1 i:int:null:2 f:float:null:3 s:string:null:4 j:jsonb:null:5
  ├── scan
  │    └── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5
- └── and [type=bool]
-      ├── not [type=bool]
-      │    └── contains [type=bool]
+ └── and [type=bool, outer=(5)]
+      ├── not [type=bool, outer=(5)]
+      │    └── contains [type=bool, outer=(5)]
       │         ├── const: '[1, 2]' [type=jsonb]
-      │         └── variable: a.j [type=jsonb]
-      └── not [type=bool]
-           └── contains [type=bool]
+      │         └── variable: a.j [type=jsonb, outer=(5)]
+      └── not [type=bool, outer=(5)]
+           └── contains [type=bool, outer=(5)]
                 ├── const: '[3, 4]' [type=jsonb]
-                └── variable: a.j [type=jsonb]
+                └── variable: a.j [type=jsonb, outer=(5)]
 
 # --------------------------------------------------
 # EliminateNot
@@ -409,6 +409,6 @@ select
  ├── columns: k:int:1 i:int:null:2 f:float:null:3 s:string:null:4 j:jsonb:null:5
  ├── scan
  │    └── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5
- └── contains [type=bool]
+ └── contains [type=bool, outer=(5)]
       ├── const: '[1, 2]' [type=jsonb]
-      └── variable: a.j [type=jsonb]
+      └── variable: a.j [type=jsonb, outer=(5)]

--- a/pkg/sql/opt/xform/testdata/rules/comp
+++ b/pkg/sql/opt/xform/testdata/rules/comp
@@ -11,22 +11,269 @@ TABLE a
       └── k int not null
 
 # --------------------------------------------------
-# NormalizeVar
+# CommuteVarInequality
 # --------------------------------------------------
+
+# Put variables on both sides of comparison operator to avoid matching constant
+# patterns.
 opt
-SELECT * FROM a WHERE 1=k AND 2<>i
+SELECT * FROM a WHERE 1+i<k AND k-1<=i AND i*i>k AND k/2>=i
 ----
 select
  ├── columns: k:int:1 i:int:null:2 f:float:null:3 s:string:null:4 j:jsonb:null:5
  ├── scan
  │    └── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5
  └── and [type=bool, outer=(1,2)]
-      ├── eq [type=bool, outer=(1)]
+      ├── gt [type=bool, outer=(1,2)]
       │    ├── variable: a.k [type=int, outer=(1)]
-      │    └── const: 1 [type=int]
-      └── ne [type=bool, outer=(2)]
+      │    └── plus [type=int, outer=(2)]
+      │         ├── variable: a.i [type=int, outer=(2)]
+      │         └── const: 1 [type=int]
+      ├── ge [type=bool, outer=(1,2)]
+      │    ├── variable: a.i [type=int, outer=(2)]
+      │    └── minus [type=int, outer=(1)]
+      │         ├── variable: a.k [type=int, outer=(1)]
+      │         └── const: 1 [type=int]
+      ├── lt [type=bool, outer=(1,2)]
+      │    ├── variable: a.k [type=int, outer=(1)]
+      │    └── mult [type=int, outer=(2)]
+      │         ├── variable: a.i [type=int, outer=(2)]
+      │         └── variable: a.i [type=int, outer=(2)]
+      └── le [type=bool, outer=(1,2)]
            ├── variable: a.i [type=int, outer=(2)]
-           └── const: 2 [type=int]
+           └── div [type=decimal, outer=(1)]
+                ├── variable: a.k [type=int, outer=(1)]
+                └── const: 2 [type=int]
+
+# --------------------------------------------------
+# CommuteConstInequality
+# --------------------------------------------------
+opt
+SELECT * FROM a WHERE length('foo')+1<i+k AND length('bar')<=i*2 AND 5>i AND 'foo'>=s
+----
+select
+ ├── columns: k:int:1 i:int:null:2 f:float:null:3 s:string:null:4 j:jsonb:null:5
+ ├── scan
+ │    └── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5
+ └── and [type=bool, outer=(1,2,4)]
+      ├── gt [type=bool, outer=(1,2)]
+      │    ├── plus [type=int, outer=(1,2)]
+      │    │    ├── variable: a.i [type=int, outer=(2)]
+      │    │    └── variable: a.k [type=int, outer=(1)]
+      │    └── plus [type=int]
+      │         ├── function: length [type=int]
+      │         │    └── const: 'foo' [type=string]
+      │         └── const: 1 [type=int]
+      ├── ge [type=bool, outer=(2)]
+      │    ├── mult [type=int, outer=(2)]
+      │    │    ├── variable: a.i [type=int, outer=(2)]
+      │    │    └── const: 2 [type=int]
+      │    └── function: length [type=int]
+      │         └── const: 'bar' [type=string]
+      ├── lt [type=bool, outer=(2)]
+      │    ├── variable: a.i [type=int, outer=(2)]
+      │    └── const: 5 [type=int]
+      └── le [type=bool, outer=(4)]
+           ├── variable: a.s [type=string, outer=(4)]
+           └── const: 'foo' [type=string]
+
+# --------------------------------------------------
+# NormalizeCmpPlusConst
+# --------------------------------------------------
+opt
+SELECT *
+FROM a
+WHERE
+    i+1 = 2 AND
+    (f+f)+2 < 5 AND
+    1::decimal+i <= length('foo') AND
+    i+2+2 > 10 AND
+    '1:00:00'::time + i::interval >= '2:00:00'::time
+----
+select
+ ├── columns: k:int:1 i:int:null:2 f:float:null:3 s:string:null:4 j:jsonb:null:5
+ ├── scan
+ │    └── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5
+ └── and [type=bool, outer=(2,3)]
+      ├── eq [type=bool, outer=(2)]
+      │    ├── variable: a.i [type=int, outer=(2)]
+      │    └── minus [type=int]
+      │         ├── const: 2 [type=int]
+      │         └── const: 1 [type=int]
+      ├── lt [type=bool, outer=(3)]
+      │    ├── plus [type=float, outer=(3)]
+      │    │    ├── variable: a.f [type=float, outer=(3)]
+      │    │    └── variable: a.f [type=float, outer=(3)]
+      │    └── minus [type=float]
+      │         ├── const: 5.0 [type=float]
+      │         └── const: 2.0 [type=float]
+      ├── le [type=bool, outer=(2)]
+      │    ├── variable: a.i [type=int, outer=(2)]
+      │    └── minus [type=decimal]
+      │         ├── function: length [type=int]
+      │         │    └── const: 'foo' [type=string]
+      │         └── const: 1 [type=decimal]
+      ├── gt [type=bool, outer=(2)]
+      │    ├── variable: a.i [type=int, outer=(2)]
+      │    └── minus [type=int]
+      │         ├── minus [type=int]
+      │         │    ├── const: 10 [type=int]
+      │         │    └── const: 2 [type=int]
+      │         └── const: 2 [type=int]
+      └── ge [type=bool, outer=(2)]
+           ├── cast: interval [type=interval, outer=(2)]
+           │    └── variable: a.i [type=int, outer=(2)]
+           └── minus [type=interval]
+                ├── const: '02:00:00' [type=time]
+                └── const: '01:00:00' [type=time]
+
+# Try case that should not match pattern because Minus overload is not defined.
+opt
+SELECT * FROM a WHERE s::date + '02:00:00'::time = '2000-01-01T02:00:00'::timestamp
+----
+select
+ ├── columns: k:int:1 i:int:null:2 f:float:null:3 s:string:null:4 j:jsonb:null:5
+ ├── scan
+ │    └── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5
+ └── eq [type=bool, outer=(4)]
+      ├── plus [type=timestamp, outer=(4)]
+      │    ├── cast: date [type=date, outer=(4)]
+      │    │    └── variable: a.s [type=string, outer=(4)]
+      │    └── const: '02:00:00' [type=time]
+      └── const: '2000-01-01 02:00:00+00:00' [type=timestamp]
+
+# --------------------------------------------------
+# NormalizeCmpMinusConst
+# --------------------------------------------------
+opt
+SELECT *
+FROM a
+WHERE
+    i-1 = 2 AND
+    (f+f)-2 < 5 AND
+    i-1::decimal <= length('foo') AND
+    i-2-2 > 10 AND
+    f+i::float-10.0 >= 100.0
+----
+select
+ ├── columns: k:int:1 i:int:null:2 f:float:null:3 s:string:null:4 j:jsonb:null:5
+ ├── scan
+ │    └── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5
+ └── and [type=bool, outer=(2,3)]
+      ├── eq [type=bool, outer=(2)]
+      │    ├── variable: a.i [type=int, outer=(2)]
+      │    └── plus [type=int]
+      │         ├── const: 2 [type=int]
+      │         └── const: 1 [type=int]
+      ├── lt [type=bool, outer=(3)]
+      │    ├── plus [type=float, outer=(3)]
+      │    │    ├── variable: a.f [type=float, outer=(3)]
+      │    │    └── variable: a.f [type=float, outer=(3)]
+      │    └── plus [type=float]
+      │         ├── const: 5.0 [type=float]
+      │         └── const: 2.0 [type=float]
+      ├── le [type=bool, outer=(2)]
+      │    ├── variable: a.i [type=int, outer=(2)]
+      │    └── plus [type=decimal]
+      │         ├── function: length [type=int]
+      │         │    └── const: 'foo' [type=string]
+      │         └── const: 1 [type=decimal]
+      ├── gt [type=bool, outer=(2)]
+      │    ├── variable: a.i [type=int, outer=(2)]
+      │    └── plus [type=int]
+      │         ├── plus [type=int]
+      │         │    ├── const: 10 [type=int]
+      │         │    └── const: 2 [type=int]
+      │         └── const: 2 [type=int]
+      └── ge [type=bool, outer=(2,3)]
+           ├── plus [type=float, outer=(2,3)]
+           │    ├── variable: a.f [type=float, outer=(3)]
+           │    └── cast: float [type=float, outer=(2)]
+           │         └── variable: a.i [type=int, outer=(2)]
+           └── plus [type=float]
+                ├── const: 100.0 [type=float]
+                └── const: 10.0 [type=float]
+
+# Try case that should not match pattern because Plus overload is not defined.
+opt
+SELECT * FROM a WHERE s::json - 1 = '[1]'::json
+----
+select
+ ├── columns: k:int:1 i:int:null:2 f:float:null:3 s:string:null:4 j:jsonb:null:5
+ ├── scan
+ │    └── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5
+ └── eq [type=bool, outer=(4)]
+      ├── minus [type=jsonb, outer=(4)]
+      │    ├── cast: jsonb [type=jsonb, outer=(4)]
+      │    │    └── variable: a.s [type=string, outer=(4)]
+      │    └── const: 1 [type=int]
+      └── const: '[1]' [type=jsonb]
+
+# --------------------------------------------------
+# NormalizeCmpConstMinus
+# --------------------------------------------------
+opt
+SELECT *
+FROM a
+WHERE
+    1-i = 2 AND
+    2-(f+f) < 5 AND
+    1::decimal-i <= length('foo') AND
+    2-(2-i) > 10 AND
+    10.0-(f+i::float) >= 100.0
+----
+select
+ ├── columns: k:int:1 i:int:null:2 f:float:null:3 s:string:null:4 j:jsonb:null:5
+ ├── scan
+ │    └── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5
+ └── and [type=bool, outer=(2,3)]
+      ├── eq [type=bool, outer=(2)]
+      │    ├── variable: a.i [type=int, outer=(2)]
+      │    └── minus [type=int]
+      │         ├── const: 1 [type=int]
+      │         └── const: 2 [type=int]
+      ├── gt [type=bool, outer=(3)]
+      │    ├── plus [type=float, outer=(3)]
+      │    │    ├── variable: a.f [type=float, outer=(3)]
+      │    │    └── variable: a.f [type=float, outer=(3)]
+      │    └── minus [type=float]
+      │         ├── const: 2.0 [type=float]
+      │         └── const: 5.0 [type=float]
+      ├── ge [type=bool, outer=(2)]
+      │    ├── variable: a.i [type=int, outer=(2)]
+      │    └── minus [type=decimal]
+      │         ├── const: 1 [type=decimal]
+      │         └── function: length [type=int]
+      │              └── const: 'foo' [type=string]
+      ├── gt [type=bool, outer=(2)]
+      │    ├── variable: a.i [type=int, outer=(2)]
+      │    └── minus [type=int]
+      │         ├── const: 2 [type=int]
+      │         └── minus [type=int]
+      │              ├── const: 2 [type=int]
+      │              └── const: 10 [type=int]
+      └── le [type=bool, outer=(2,3)]
+           ├── plus [type=float, outer=(2,3)]
+           │    ├── variable: a.f [type=float, outer=(3)]
+           │    └── cast: float [type=float, outer=(2)]
+           │         └── variable: a.i [type=int, outer=(2)]
+           └── minus [type=float]
+                ├── const: 10.0 [type=float]
+                └── const: 100.0 [type=float]
+
+# Try case that should not match pattern because Minus overload is not defined.
+opt
+SELECT * FROM a WHERE '[1, 2]'::json - i = '[1]'
+----
+select
+ ├── columns: k:int:1 i:int:null:2 f:float:null:3 s:string:null:4 j:jsonb:null:5
+ ├── scan
+ │    └── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5
+ └── eq [type=bool, outer=(2)]
+      ├── minus [type=jsonb, outer=(2)]
+      │    ├── const: '[1, 2]' [type=jsonb]
+      │    └── variable: a.i [type=int, outer=(2)]
+      └── const: '[1]' [type=jsonb]
 
 # --------------------------------------------------
 # NormalizeTupleEquality

--- a/pkg/sql/opt/xform/testdata/rules/comp
+++ b/pkg/sql/opt/xform/testdata/rules/comp
@@ -20,12 +20,12 @@ select
  ├── columns: k:int:1 i:int:null:2 f:float:null:3 s:string:null:4 j:jsonb:null:5
  ├── scan
  │    └── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5
- └── and [type=bool]
-      ├── eq [type=bool]
-      │    ├── variable: a.k [type=int]
+ └── and [type=bool, outer=(1,2)]
+      ├── eq [type=bool, outer=(1)]
+      │    ├── variable: a.k [type=int, outer=(1)]
       │    └── const: 1 [type=int]
-      └── ne [type=bool]
-           ├── variable: a.i [type=int]
+      └── ne [type=bool, outer=(2)]
+           ├── variable: a.i [type=int, outer=(2)]
            └── const: 2 [type=int]
 
 # --------------------------------------------------
@@ -38,15 +38,15 @@ select
  ├── columns: k:int:1 i:int:null:2 f:float:null:3 s:string:null:4 j:jsonb:null:5
  ├── scan
  │    └── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5
- └── and [type=bool]
-      ├── eq [type=bool]
-      │    ├── variable: a.i [type=int]
+ └── and [type=bool, outer=(2-4)]
+      ├── eq [type=bool, outer=(2)]
+      │    ├── variable: a.i [type=int, outer=(2)]
       │    └── const: 1 [type=int]
-      ├── eq [type=bool]
-      │    ├── variable: a.f [type=float]
+      ├── eq [type=bool, outer=(3)]
+      │    ├── variable: a.f [type=float, outer=(3)]
       │    └── const: 3.5 [type=float]
-      └── eq [type=bool]
-           ├── variable: a.s [type=string]
+      └── eq [type=bool, outer=(4)]
+           ├── variable: a.s [type=string, outer=(4)]
            └── const: 'foo' [type=string]
 
 # --------------------------------------------------
@@ -61,15 +61,15 @@ select
  ├── columns: k:int:1 i:int:null:2 f:float:null:3 s:string:null:4 j:jsonb:null:5
  ├── scan
  │    └── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5
- └── and [type=bool]
-      ├── eq [type=bool]
-      │    ├── variable: a.k [type=int]
+ └── and [type=bool, outer=(1,2,4)]
+      ├── eq [type=bool, outer=(1)]
+      │    ├── variable: a.k [type=int, outer=(1)]
       │    └── const: 1 [type=int]
-      ├── eq [type=bool]
-      │    ├── variable: a.i [type=int]
+      ├── eq [type=bool, outer=(2)]
+      │    ├── variable: a.i [type=int, outer=(2)]
       │    └── const: 2 [type=int]
-      └── eq [type=bool]
-           ├── variable: a.s [type=string]
+      └── eq [type=bool, outer=(4)]
+           ├── variable: a.s [type=string, outer=(4)]
            └── const: 'foo' [type=string]
 
 # --------------------------------------------------

--- a/pkg/sql/opt/xform/testdata/rules/numeric
+++ b/pkg/sql/opt/xform/testdata/rules/numeric
@@ -25,25 +25,25 @@ project
  ├── columns: column5:int:null:5 column6:int:null:6 column7:float:null:7 column8:float:null:8 column9:decimal:null:9 column10:decimal:null:10
  ├── scan
  │    └── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.d:decimal:null:4
- └── projections
-      ├── plus [type=int]
-      │    ├── variable: a.i [type=int]
-      │    └── variable: a.i [type=int]
-      ├── plus [type=int]
-      │    ├── variable: a.i [type=int]
-      │    └── variable: a.i [type=int]
-      ├── plus [type=float]
-      │    ├── variable: a.f [type=float]
-      │    └── variable: a.f [type=float]
-      ├── plus [type=float]
-      │    ├── variable: a.f [type=float]
-      │    └── variable: a.f [type=float]
-      ├── plus [type=decimal]
-      │    ├── variable: a.d [type=decimal]
-      │    └── variable: a.d [type=decimal]
-      └── plus [type=decimal]
-           ├── variable: a.d [type=decimal]
-           └── variable: a.d [type=decimal]
+ └── projections [outer=(2-4)]
+      ├── plus [type=int, outer=(2)]
+      │    ├── variable: a.i [type=int, outer=(2)]
+      │    └── variable: a.i [type=int, outer=(2)]
+      ├── plus [type=int, outer=(2)]
+      │    ├── variable: a.i [type=int, outer=(2)]
+      │    └── variable: a.i [type=int, outer=(2)]
+      ├── plus [type=float, outer=(3)]
+      │    ├── variable: a.f [type=float, outer=(3)]
+      │    └── variable: a.f [type=float, outer=(3)]
+      ├── plus [type=float, outer=(3)]
+      │    ├── variable: a.f [type=float, outer=(3)]
+      │    └── variable: a.f [type=float, outer=(3)]
+      ├── plus [type=decimal, outer=(4)]
+      │    ├── variable: a.d [type=decimal, outer=(4)]
+      │    └── variable: a.d [type=decimal, outer=(4)]
+      └── plus [type=decimal, outer=(4)]
+           ├── variable: a.d [type=decimal, outer=(4)]
+           └── variable: a.d [type=decimal, outer=(4)]
 
 # --------------------------------------------------
 # FoldMultOne, FoldOneMult
@@ -61,25 +61,25 @@ project
  ├── columns: column5:int:null:5 column6:int:null:6 column7:float:null:7 column8:float:null:8 column9:decimal:null:9 column10:decimal:null:10
  ├── scan
  │    └── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.d:decimal:null:4
- └── projections
-      ├── plus [type=int]
-      │    ├── variable: a.i [type=int]
-      │    └── variable: a.i [type=int]
-      ├── plus [type=int]
-      │    ├── variable: a.i [type=int]
-      │    └── variable: a.i [type=int]
-      ├── plus [type=float]
-      │    ├── variable: a.f [type=float]
-      │    └── variable: a.f [type=float]
-      ├── plus [type=float]
-      │    ├── variable: a.f [type=float]
-      │    └── variable: a.f [type=float]
-      ├── plus [type=decimal]
-      │    ├── variable: a.d [type=decimal]
-      │    └── variable: a.d [type=decimal]
-      └── plus [type=decimal]
-           ├── variable: a.d [type=decimal]
-           └── variable: a.d [type=decimal]
+ └── projections [outer=(2-4)]
+      ├── plus [type=int, outer=(2)]
+      │    ├── variable: a.i [type=int, outer=(2)]
+      │    └── variable: a.i [type=int, outer=(2)]
+      ├── plus [type=int, outer=(2)]
+      │    ├── variable: a.i [type=int, outer=(2)]
+      │    └── variable: a.i [type=int, outer=(2)]
+      ├── plus [type=float, outer=(3)]
+      │    ├── variable: a.f [type=float, outer=(3)]
+      │    └── variable: a.f [type=float, outer=(3)]
+      ├── plus [type=float, outer=(3)]
+      │    ├── variable: a.f [type=float, outer=(3)]
+      │    └── variable: a.f [type=float, outer=(3)]
+      ├── plus [type=decimal, outer=(4)]
+      │    ├── variable: a.d [type=decimal, outer=(4)]
+      │    └── variable: a.d [type=decimal, outer=(4)]
+      └── plus [type=decimal, outer=(4)]
+           ├── variable: a.d [type=decimal, outer=(4)]
+           └── variable: a.d [type=decimal, outer=(4)]
 
 # --------------------------------------------------
 # FoldDivOne
@@ -96,7 +96,7 @@ project
  ├── columns: column5:decimal:null:5 column6:float:null:6 column7:decimal:null:7
  ├── scan
  │    └── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.d:decimal:null:4
- └── projections
-      ├── variable: a.i [type=int]
-      ├── variable: a.f [type=float]
-      └── variable: a.d [type=decimal]
+ └── projections [outer=(2-4)]
+      ├── variable: a.i [type=int, outer=(2)]
+      ├── variable: a.f [type=float, outer=(3)]
+      └── variable: a.d [type=decimal, outer=(4)]

--- a/pkg/sql/opt/xform/testdata/rules/numeric
+++ b/pkg/sql/opt/xform/testdata/rules/numeric
@@ -1,11 +1,12 @@
 exec-ddl
-CREATE TABLE a (k INT PRIMARY KEY, i INT, f FLOAT, d DECIMAL)
+CREATE TABLE a (k INT PRIMARY KEY, i INT, f FLOAT, d DECIMAL, t TIME)
 ----
 TABLE a
  ├── k int not null
  ├── i int
  ├── f float
  ├── d decimal
+ ├── t time
  └── INDEX primary
       └── k int not null
 
@@ -22,9 +23,9 @@ SELECT
 FROM a
 ----
 project
- ├── columns: column5:int:null:5 column6:int:null:6 column7:float:null:7 column8:float:null:8 column9:decimal:null:9 column10:decimal:null:10
+ ├── columns: column6:int:null:6 column7:int:null:7 column8:float:null:8 column9:float:null:9 column10:decimal:null:10 column11:decimal:null:11
  ├── scan
- │    └── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.d:decimal:null:4
+ │    └── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.d:decimal:null:4 a.t:time:null:5
  └── projections [outer=(2-4)]
       ├── plus [type=int, outer=(2)]
       │    ├── variable: a.i [type=int, outer=(2)]
@@ -46,6 +47,33 @@ project
            └── variable: a.d [type=decimal, outer=(4)]
 
 # --------------------------------------------------
+# FoldMinusZero
+# --------------------------------------------------
+
+# Add columns to prevent NormalizeVar from swapping left and right.
+opt
+SELECT
+    (a.i + a.i) - 0,
+    (a.f + a.f) - 0,
+    (a.d + a.d) - 0
+FROM a
+----
+project
+ ├── columns: column6:int:null:6 column7:float:null:7 column8:decimal:null:8
+ ├── scan
+ │    └── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.d:decimal:null:4 a.t:time:null:5
+ └── projections [outer=(2-4)]
+      ├── plus [type=int, outer=(2)]
+      │    ├── variable: a.i [type=int, outer=(2)]
+      │    └── variable: a.i [type=int, outer=(2)]
+      ├── plus [type=float, outer=(3)]
+      │    ├── variable: a.f [type=float, outer=(3)]
+      │    └── variable: a.f [type=float, outer=(3)]
+      └── plus [type=decimal, outer=(4)]
+           ├── variable: a.d [type=decimal, outer=(4)]
+           └── variable: a.d [type=decimal, outer=(4)]
+
+# --------------------------------------------------
 # FoldMultOne, FoldOneMult
 # --------------------------------------------------
 
@@ -58,9 +86,9 @@ SELECT
 FROM a
 ----
 project
- ├── columns: column5:int:null:5 column6:int:null:6 column7:float:null:7 column8:float:null:8 column9:decimal:null:9 column10:decimal:null:10
+ ├── columns: column6:int:null:6 column7:int:null:7 column8:float:null:8 column9:float:null:9 column10:decimal:null:10 column11:decimal:null:11
  ├── scan
- │    └── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.d:decimal:null:4
+ │    └── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.d:decimal:null:4 a.t:time:null:5
  └── projections [outer=(2-4)]
       ├── plus [type=int, outer=(2)]
       │    ├── variable: a.i [type=int, outer=(2)]
@@ -93,10 +121,48 @@ SELECT
 FROM a
 ----
 project
- ├── columns: column5:decimal:null:5 column6:float:null:6 column7:decimal:null:7
+ ├── columns: column6:decimal:null:6 column7:float:null:7 column8:decimal:null:8
  ├── scan
- │    └── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.d:decimal:null:4
+ │    └── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.d:decimal:null:4 a.t:time:null:5
  └── projections [outer=(2-4)]
       ├── variable: a.i [type=int, outer=(2)]
       ├── variable: a.f [type=float, outer=(3)]
       └── variable: a.d [type=decimal, outer=(4)]
+
+# --------------------------------------------------
+# InvertMinus
+# --------------------------------------------------
+opt
+SELECT
+    -(a.f - a.f),
+    -(a.d - a.i),
+    -(a.t - a.t)
+FROM a
+----
+project
+ ├── columns: column6:float:null:6 column7:decimal:null:7 column8:interval:null:8
+ ├── scan
+ │    └── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.d:decimal:null:4 a.t:time:null:5
+ └── projections [outer=(2-5)]
+      ├── minus [type=float, outer=(3)]
+      │    ├── variable: a.f [type=float, outer=(3)]
+      │    └── variable: a.f [type=float, outer=(3)]
+      ├── minus [type=decimal, outer=(2,4)]
+      │    ├── variable: a.i [type=int, outer=(2)]
+      │    └── variable: a.d [type=decimal, outer=(4)]
+      └── minus [type=interval, outer=(5)]
+           ├── variable: a.t [type=time, outer=(5)]
+           └── variable: a.t [type=time, outer=(5)]
+
+# --------------------------------------------------
+# EliminateUnaryMinus
+# --------------------------------------------------
+opt
+SELECT -(-a.i::int) FROM a
+----
+project
+ ├── columns: column6:int:null:6
+ ├── scan
+ │    └── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.d:decimal:null:4 a.t:time:null:5
+ └── projections [outer=(2)]
+      └── variable: a.i [type=int, outer=(2)]

--- a/pkg/sql/opt/xform/testdata/rules/project
+++ b/pkg/sql/opt/xform/testdata/rules/project
@@ -50,9 +50,9 @@ project
  ├── columns: x:int:1 y:float:null:2 column3:int:null:3
  ├── scan
  │    └── columns: a.x:int:1 a.y:float:null:2
- └── projections
-      ├── variable: a.x [type=int]
-      ├── variable: a.y [type=float]
+ └── projections [outer=(1,2)]
+      ├── variable: a.x [type=int, outer=(1)]
+      ├── variable: a.y [type=float, outer=(2)]
       └── const: 1 [type=int]
 
 # Removed column (projection should not be eliminated).
@@ -63,5 +63,5 @@ project
  ├── columns: x:int:1
  ├── scan
  │    └── columns: a.x:int:1 a.y:float:null:2
- └── projections
-      └── variable: a.x [type=int]
+ └── projections [outer=(1)]
+      └── variable: a.x [type=int, outer=(1)]

--- a/pkg/sql/opt/xform/testdata/rules/scalar
+++ b/pkg/sql/opt/xform/testdata/rules/scalar
@@ -12,6 +12,158 @@ TABLE a
       └── k int not null
 
 # --------------------------------------------------
+# CommuteVar
+# --------------------------------------------------
+
+# Put variables on both sides of comparison operator to avoid matching constant
+# patterns.
+opt
+SELECT
+    (1+i) = k,
+    (2-k) <> i,
+    (i+1) IS NOT DISTINCT FROM k,
+    (i-1) IS DISTINCT FROM k,
+
+    (i*2) + k,
+    (i+2) * k,
+    (i^2) & k,
+    (i^2) | k,
+    (i*i) # k
+FROM a
+----
+project
+ ├── columns: column7:bool:null:7 column8:bool:null:8 column9:bool:null:9 column10:bool:null:10 column11:int:null:11 column12:int:null:12 column13:int:null:13 column14:int:null:14 column15:int:null:15
+ ├── scan
+ │    └── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5 a.arr:int[]:null:6
+ └── projections [outer=(1,2)]
+      ├── eq [type=bool, outer=(1,2)]
+      │    ├── variable: a.k [type=int, outer=(1)]
+      │    └── plus [type=int, outer=(2)]
+      │         ├── variable: a.i [type=int, outer=(2)]
+      │         └── const: 1 [type=int]
+      ├── ne [type=bool, outer=(1,2)]
+      │    ├── variable: a.i [type=int, outer=(2)]
+      │    └── minus [type=int, outer=(1)]
+      │         ├── const: 2 [type=int]
+      │         └── variable: a.k [type=int, outer=(1)]
+      ├── is [type=bool, outer=(1,2)]
+      │    ├── variable: a.k [type=int, outer=(1)]
+      │    └── plus [type=int, outer=(2)]
+      │         ├── variable: a.i [type=int, outer=(2)]
+      │         └── const: 1 [type=int]
+      ├── is-not [type=bool, outer=(1,2)]
+      │    ├── variable: a.k [type=int, outer=(1)]
+      │    └── minus [type=int, outer=(2)]
+      │         ├── variable: a.i [type=int, outer=(2)]
+      │         └── const: 1 [type=int]
+      ├── plus [type=int, outer=(1,2)]
+      │    ├── variable: a.k [type=int, outer=(1)]
+      │    └── mult [type=int, outer=(2)]
+      │         ├── variable: a.i [type=int, outer=(2)]
+      │         └── const: 2 [type=int]
+      ├── mult [type=int, outer=(1,2)]
+      │    ├── variable: a.k [type=int, outer=(1)]
+      │    └── plus [type=int, outer=(2)]
+      │         ├── variable: a.i [type=int, outer=(2)]
+      │         └── const: 2 [type=int]
+      ├── bitand [type=int, outer=(1,2)]
+      │    ├── variable: a.k [type=int, outer=(1)]
+      │    └── pow [type=int, outer=(2)]
+      │         ├── variable: a.i [type=int, outer=(2)]
+      │         └── const: 2 [type=int]
+      ├── bitor [type=int, outer=(1,2)]
+      │    ├── variable: a.k [type=int, outer=(1)]
+      │    └── pow [type=int, outer=(2)]
+      │         ├── variable: a.i [type=int, outer=(2)]
+      │         └── const: 2 [type=int]
+      └── bitxor [type=int, outer=(1,2)]
+           ├── variable: a.k [type=int, outer=(1)]
+           └── mult [type=int, outer=(2)]
+                ├── variable: a.i [type=int, outer=(2)]
+                └── variable: a.i [type=int, outer=(2)]
+
+# --------------------------------------------------
+# CommuteConst
+# --------------------------------------------------
+opt
+SELECT
+    (length('foo')+1) = (i+k),
+    length('bar') <> (i*2),
+    5 IS NOT DISTINCT FROM (1-k),
+    (10::decimal+1::int) IS DISTINCT FROM k,
+
+    1 + f,
+    (5*length('foo')) * (i*i),
+    (100 ^ 2) & (i+i),
+    length('foo')+1 | (i+i),
+    1-length('foo') # (k^2)
+FROM a
+----
+project
+ ├── columns: column7:bool:null:7 column8:bool:null:8 column9:bool:null:9 column10:bool:null:10 column11:float:null:11 column12:int:null:12 column13:int:null:13 column14:int:null:14 column15:int:null:15
+ ├── scan
+ │    └── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5 a.arr:int[]:null:6
+ └── projections [outer=(1-3)]
+      ├── eq [type=bool, outer=(1,2)]
+      │    ├── plus [type=int, outer=(1,2)]
+      │    │    ├── variable: a.i [type=int, outer=(2)]
+      │    │    └── variable: a.k [type=int, outer=(1)]
+      │    └── plus [type=int]
+      │         ├── function: length [type=int]
+      │         │    └── const: 'foo' [type=string]
+      │         └── const: 1 [type=int]
+      ├── ne [type=bool, outer=(2)]
+      │    ├── mult [type=int, outer=(2)]
+      │    │    ├── variable: a.i [type=int, outer=(2)]
+      │    │    └── const: 2 [type=int]
+      │    └── function: length [type=int]
+      │         └── const: 'bar' [type=string]
+      ├── is [type=bool, outer=(1)]
+      │    ├── minus [type=int, outer=(1)]
+      │    │    ├── const: 1 [type=int]
+      │    │    └── variable: a.k [type=int, outer=(1)]
+      │    └── const: 5 [type=int]
+      ├── is-not [type=bool, outer=(1)]
+      │    ├── variable: a.k [type=int, outer=(1)]
+      │    └── plus [type=decimal]
+      │         ├── const: 10 [type=decimal]
+      │         └── const: 1 [type=int]
+      ├── plus [type=float, outer=(3)]
+      │    ├── variable: a.f [type=float, outer=(3)]
+      │    └── const: 1.0 [type=float]
+      ├── mult [type=int, outer=(2)]
+      │    ├── mult [type=int, outer=(2)]
+      │    │    ├── variable: a.i [type=int, outer=(2)]
+      │    │    └── variable: a.i [type=int, outer=(2)]
+      │    └── mult [type=int]
+      │         ├── const: 5 [type=int]
+      │         └── function: length [type=int]
+      │              └── const: 'foo' [type=string]
+      ├── bitand [type=int, outer=(2)]
+      │    ├── plus [type=int, outer=(2)]
+      │    │    ├── variable: a.i [type=int, outer=(2)]
+      │    │    └── variable: a.i [type=int, outer=(2)]
+      │    └── pow [type=int]
+      │         ├── const: 100 [type=int]
+      │         └── const: 2 [type=int]
+      ├── bitor [type=int, outer=(2)]
+      │    ├── plus [type=int, outer=(2)]
+      │    │    ├── variable: a.i [type=int, outer=(2)]
+      │    │    └── variable: a.i [type=int, outer=(2)]
+      │    └── plus [type=int]
+      │         ├── function: length [type=int]
+      │         │    └── const: 'foo' [type=string]
+      │         └── const: 1 [type=int]
+      └── bitxor [type=int, outer=(1)]
+           ├── pow [type=int, outer=(1)]
+           │    ├── variable: a.k [type=int, outer=(1)]
+           │    └── const: 2 [type=int]
+           └── minus [type=int]
+                ├── const: 1 [type=int]
+                └── function: length [type=int]
+                     └── const: 'foo' [type=string]
+
+# --------------------------------------------------
 # EliminateCoalesce
 # --------------------------------------------------
 opt
@@ -76,6 +228,38 @@ project
            └── null [type=unknown]
 
 # --------------------------------------------------
+# EliminateCast
+# --------------------------------------------------
+opt
+SELECT i::int, arr::int[], '[1, 2]'::json::json, null::string::int FROM a
+----
+project
+ ├── columns: column7:int:null:7 column8:int[]:null:8 column9:jsonb:null:9 column10:int:null:10
+ ├── scan
+ │    └── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5 a.arr:int[]:null:6
+ └── projections [outer=(2,6)]
+      ├── variable: a.i [type=int, outer=(2)]
+      ├── variable: a.arr [type=int[], outer=(6)]
+      ├── const: '[1, 2]' [type=jsonb]
+      └── null [type=int]
+
+# Shouldn't eliminate these cases.
+opt
+SELECT i::float, arr::decimal[], s::json::json FROM a
+----
+project
+ ├── columns: column7:float:null:7 column8:decimal[]:null:8 column9:jsonb:null:9
+ ├── scan
+ │    └── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5 a.arr:int[]:null:6
+ └── projections [outer=(2,4,6)]
+      ├── cast: float [type=float, outer=(2)]
+      │    └── variable: a.i [type=int, outer=(2)]
+      ├── cast: decimal[] [type=decimal[], outer=(6)]
+      │    └── variable: a.arr [type=int[], outer=(6)]
+      └── cast: jsonb [type=jsonb, outer=(4)]
+           └── variable: a.s [type=string, outer=(4)]
+
+# --------------------------------------------------
 # FoldNullCast
 # --------------------------------------------------
 opt
@@ -105,7 +289,7 @@ project
       └── null [type=int]
 
 # --------------------------------------------------
-# FoldNullBinary
+# FoldNullBinaryLeft, FoldNullBinaryRight
 # --------------------------------------------------
 opt
 SELECT
@@ -154,3 +338,71 @@ project
            ├── null [type=unknown]
            └── cast: float [type=float, outer=(2)]
                 └── variable: a.i [type=int, outer=(2)]
+
+# --------------------------------------------------
+# FoldNullInNonEmpty
+# --------------------------------------------------
+opt
+SELECT null IN (i), null NOT IN (s) FROM a
+----
+project
+ ├── columns: column7:bool:null:7 column8:bool:null:8
+ ├── scan
+ │    └── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5 a.arr:int[]:null:6
+ └── projections
+      ├── null [type=bool]
+      └── null [type=bool]
+
+# --------------------------------------------------
+# FoldInNull
+# --------------------------------------------------
+opt
+SELECT i IN (null, null), k NOT IN (1 * null, null::int, 1 < null) FROM a
+----
+project
+ ├── columns: column7:bool:null:7 column8:bool:null:8
+ ├── scan
+ │    └── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5 a.arr:int[]:null:6
+ └── projections
+      ├── null [type=bool]
+      └── null [type=bool]
+
+# --------------------------------------------------
+# NormalizeInConst
+# --------------------------------------------------
+opt
+SELECT i IN (2, 1, 1, null, 3, null, 2, 3.0) FROM a
+----
+project
+ ├── columns: column7:bool:null:7
+ ├── scan
+ │    └── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5 a.arr:int[]:null:6
+ └── projections [outer=(2)]
+      └── in [type=bool, outer=(2)]
+           ├── variable: a.i [type=int, outer=(2)]
+           └── tuple [type=tuple{unknown, int, int, int}]
+                ├── null [type=unknown]
+                ├── const: 1 [type=int]
+                ├── const: 2 [type=int]
+                └── const: 3 [type=int]
+
+opt
+SELECT s NOT IN ('foo', s || 'foo', 'bar', length(s)::string, NULL) FROM a
+----
+project
+ ├── columns: column7:bool:null:7
+ ├── scan
+ │    └── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5 a.arr:int[]:null:6
+ └── projections [outer=(4)]
+      └── not-in [type=bool, outer=(4)]
+           ├── variable: a.s [type=string, outer=(4)]
+           └── tuple [type=tuple{unknown, string, string, string, string}, outer=(4)]
+                ├── null [type=unknown]
+                ├── const: 'bar' [type=string]
+                ├── const: 'foo' [type=string]
+                ├── concat [type=string, outer=(4)]
+                │    ├── variable: a.s [type=string, outer=(4)]
+                │    └── const: 'foo' [type=string]
+                └── cast: string [type=string, outer=(4)]
+                     └── function: length [type=int, outer=(4)]
+                          └── variable: a.s [type=string, outer=(4)]

--- a/pkg/sql/opt/xform/testdata/rules/scalar
+++ b/pkg/sql/opt/xform/testdata/rules/scalar
@@ -21,8 +21,8 @@ project
  ├── columns: column7:int:null:7
  ├── scan
  │    └── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5 a.arr:int[]:null:6
- └── projections
-      └── variable: a.i [type=int]
+ └── projections [outer=(2)]
+      └── variable: a.i [type=int, outer=(2)]
 
 # --------------------------------------------------
 # SimplifyCoalesce
@@ -54,11 +54,11 @@ project
  ├── columns: column7:string:null:7
  ├── scan
  │    └── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5 a.arr:int[]:null:6
- └── projections
-      └── coalesce [type=string]
-           ├── variable: a.s [type=string]
-           └── concat [type=string]
-                ├── variable: a.s [type=string]
+ └── projections [outer=(4)]
+      └── coalesce [type=string, outer=(4)]
+           ├── variable: a.s [type=string, outer=(4)]
+           └── concat [type=string, outer=(4)]
+                ├── variable: a.s [type=string, outer=(4)]
                 └── const: 'foo' [type=string]
 
 # Trailing null can't be removed.
@@ -69,9 +69,9 @@ project
  ├── columns: column7:int:null:7
  ├── scan
  │    └── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5 a.arr:int[]:null:6
- └── projections
-      └── coalesce [type=int]
-           ├── variable: a.i [type=int]
+ └── projections [outer=(2)]
+      └── coalesce [type=int, outer=(2)]
+           ├── variable: a.i [type=int, outer=(2)]
            ├── null [type=unknown]
            └── null [type=unknown]
 
@@ -127,7 +127,7 @@ project
  ├── columns: column7:int:null:7 column8:int:null:8 column9:decimal:null:9 column10:decimal:null:10 column11:float:null:11 column12:float:null:12 column13:int:null:13 column14:int:null:14 column15:jsonb:null:15 column16:jsonb:null:16 column17:decimal[]:null:17 column18:string[]:null:18 column19:decimal[]:null:19 column20:float[]:null:20
  ├── scan
  │    └── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5 a.arr:int[]:null:6
- └── projections
+ └── projections [outer=(2,6)]
       ├── null [type=int]
       ├── null [type=int]
       ├── null [type=decimal]
@@ -138,19 +138,19 @@ project
       ├── null [type=int]
       ├── null [type=jsonb]
       ├── null [type=jsonb]
-      ├── concat [type=decimal[]]
-      │    ├── cast: decimal[] [type=decimal[]]
-      │    │    └── variable: a.arr [type=int[]]
+      ├── concat [type=decimal[], outer=(6)]
+      │    ├── cast: decimal[] [type=decimal[], outer=(6)]
+      │    │    └── variable: a.arr [type=int[], outer=(6)]
       │    └── null [type=unknown]
-      ├── concat [type=string[]]
+      ├── concat [type=string[], outer=(6)]
       │    ├── null [type=unknown]
-      │    └── cast: string[] [type=string[]]
-      │         └── variable: a.arr [type=int[]]
-      ├── concat [type=decimal[]]
-      │    ├── cast: decimal [type=decimal]
-      │    │    └── variable: a.i [type=int]
+      │    └── cast: string[] [type=string[], outer=(6)]
+      │         └── variable: a.arr [type=int[], outer=(6)]
+      ├── concat [type=decimal[], outer=(2)]
+      │    ├── cast: decimal [type=decimal, outer=(2)]
+      │    │    └── variable: a.i [type=int, outer=(2)]
       │    └── null [type=unknown]
-      └── concat [type=float[]]
+      └── concat [type=float[], outer=(2)]
            ├── null [type=unknown]
-           └── cast: float [type=float]
-                └── variable: a.i [type=int]
+           └── cast: float [type=float, outer=(2)]
+                └── variable: a.i [type=int, outer=(2)]

--- a/pkg/sql/opt/xform/testdata/typing
+++ b/pkg/sql/opt/xform/testdata/typing
@@ -33,8 +33,8 @@ project
  ├── columns: x:int:1
  ├── scan
  │    └── columns: a.x:int:1 a.y:int:null:2
- └── projections
-      └── variable: a.x [type=int]
+ └── projections [outer=(1)]
+      └── variable: a.x [type=int, outer=(1)]
 
 # Const
 build
@@ -58,8 +58,8 @@ select
  ├── columns: x:int:1 y:int:null:2
  ├── scan
  │    └── columns: a.x:int:1 a.y:int:null:2
- └── eq [type=bool]
-      ├── variable: a.x [type=int]
+ └── eq [type=bool, outer=(1)]
+      ├── variable: a.x [type=int, outer=(1)]
       └── placeholder: $1 [type=int]
 
 # Tuple, Projections
@@ -70,11 +70,11 @@ project
  ├── columns: column3:tuple{int, decimal}:null:3 y:int:null:2
  ├── scan
  │    └── columns: a.x:int:1 a.y:int:null:2
- └── projections
-      ├── tuple [type=tuple{int, decimal}]
-      │    ├── variable: a.x [type=int]
+ └── projections [outer=(1,2)]
+      ├── tuple [type=tuple{int, decimal}, outer=(1)]
+      │    ├── variable: a.x [type=int, outer=(1)]
       │    └── const: 1.5 [type=decimal]
-      └── variable: a.y [type=int]
+      └── variable: a.y [type=int, outer=(2)]
 
 # And, Or, Not
 build
@@ -84,17 +84,17 @@ select
  ├── columns: x:int:1 y:int:null:2
  ├── scan
  │    └── columns: a.x:int:1 a.y:int:null:2
- └── and [type=bool]
-      ├── eq [type=bool]
-      │    ├── variable: a.x [type=int]
+ └── and [type=bool, outer=(1,2)]
+      ├── eq [type=bool, outer=(1)]
+      │    ├── variable: a.x [type=int, outer=(1)]
       │    └── const: 1 [type=int]
-      └── not [type=bool]
-           └── or [type=bool]
-                ├── eq [type=bool]
-                │    ├── variable: a.y [type=int]
+      └── not [type=bool, outer=(2)]
+           └── or [type=bool, outer=(2)]
+                ├── eq [type=bool, outer=(2)]
+                │    ├── variable: a.y [type=int, outer=(2)]
                 │    └── const: 2 [type=int]
-                └── eq [type=bool]
-                     ├── variable: a.y [type=int]
+                └── eq [type=bool, outer=(2)]
+                     ├── variable: a.y [type=int, outer=(2)]
                      └── const: 3.5 [type=decimal]
 
 # Eq, Ne
@@ -105,12 +105,12 @@ select
  ├── columns: x:int:1 y:int:null:2
  ├── scan
  │    └── columns: a.x:int:1 a.y:int:null:2
- └── and [type=bool]
-      ├── eq [type=bool]
-      │    ├── variable: a.x [type=int]
+ └── and [type=bool, outer=(1)]
+      ├── eq [type=bool, outer=(1)]
+      │    ├── variable: a.x [type=int, outer=(1)]
       │    └── const: 1 [type=int]
-      └── ne [type=bool]
-           ├── variable: a.x [type=int]
+      └── ne [type=bool, outer=(1)]
+           ├── variable: a.x [type=int, outer=(1)]
            └── const: 2 [type=int]
 
 # Le, Ge, Lt, Gt
@@ -121,20 +121,20 @@ select
  ├── columns: x:int:1 y:int:null:2
  ├── scan
  │    └── columns: a.x:int:1 a.y:int:null:2
- └── and [type=bool]
-      ├── and [type=bool]
-      │    ├── and [type=bool]
-      │    │    ├── ge [type=bool]
-      │    │    │    ├── variable: a.x [type=int]
+ └── and [type=bool, outer=(1,2)]
+      ├── and [type=bool, outer=(1,2)]
+      │    ├── and [type=bool, outer=(1)]
+      │    │    ├── ge [type=bool, outer=(1)]
+      │    │    │    ├── variable: a.x [type=int, outer=(1)]
       │    │    │    └── const: 1 [type=int]
-      │    │    └── le [type=bool]
-      │    │         ├── variable: a.x [type=int]
+      │    │    └── le [type=bool, outer=(1)]
+      │    │         ├── variable: a.x [type=int, outer=(1)]
       │    │         └── const: 10 [type=int]
-      │    └── gt [type=bool]
-      │         ├── variable: a.y [type=int]
+      │    └── gt [type=bool, outer=(2)]
+      │         ├── variable: a.y [type=int, outer=(2)]
       │         └── const: 1 [type=int]
-      └── lt [type=bool]
-           ├── variable: a.y [type=int]
+      └── lt [type=bool, outer=(2)]
+           ├── variable: a.y [type=int, outer=(2)]
            └── const: 10 [type=int]
 
 # In, NotIn
@@ -145,14 +145,14 @@ select
  ├── columns: x:int:1 y:int:null:2
  ├── scan
  │    └── columns: a.x:int:1 a.y:int:null:2
- └── and [type=bool]
-      ├── in [type=bool]
-      │    ├── variable: a.x [type=int]
+ └── and [type=bool, outer=(1,2)]
+      ├── in [type=bool, outer=(1)]
+      │    ├── variable: a.x [type=int, outer=(1)]
       │    └── tuple [type=tuple{int, int}]
       │         ├── const: 1 [type=int]
       │         └── const: 2 [type=int]
-      └── not-in [type=bool]
-           ├── variable: a.y [type=int]
+      └── not-in [type=bool, outer=(2)]
+           ├── variable: a.y [type=int, outer=(2)]
            └── tuple [type=tuple{int, int}]
                 ├── const: 3 [type=int]
                 └── const: 4 [type=int]
@@ -165,12 +165,12 @@ select
  ├── columns: x:string:1 z:decimal:2
  ├── scan
  │    └── columns: b.x:string:1 b.z:decimal:2
- └── and [type=bool]
-      ├── like [type=bool]
-      │    ├── variable: b.x [type=string]
+ └── and [type=bool, outer=(1)]
+      ├── like [type=bool, outer=(1)]
+      │    ├── variable: b.x [type=string, outer=(1)]
       │    └── const: '%foo%' [type=string]
-      └── not-like [type=bool]
-           ├── variable: b.x [type=string]
+      └── not-like [type=bool, outer=(1)]
+           ├── variable: b.x [type=string, outer=(1)]
            └── const: '%bar%' [type=string]
 
 # ILike, INotLike
@@ -181,12 +181,12 @@ select
  ├── columns: x:string:1 z:decimal:2
  ├── scan
  │    └── columns: b.x:string:1 b.z:decimal:2
- └── and [type=bool]
-      ├── i-like [type=bool]
-      │    ├── variable: b.x [type=string]
+ └── and [type=bool, outer=(1)]
+      ├── i-like [type=bool, outer=(1)]
+      │    ├── variable: b.x [type=string, outer=(1)]
       │    └── const: '%foo%' [type=string]
-      └── not-i-like [type=bool]
-           ├── variable: b.x [type=string]
+      └── not-i-like [type=bool, outer=(1)]
+           ├── variable: b.x [type=string, outer=(1)]
            └── const: '%bar%' [type=string]
 
 # RegMatch, NotRegMatch, RegIMatch, NotRegIMatch
@@ -197,20 +197,20 @@ select
  ├── columns: x:string:1 z:decimal:2
  ├── scan
  │    └── columns: b.x:string:1 b.z:decimal:2
- └── and [type=bool]
-      ├── and [type=bool]
-      │    ├── and [type=bool]
-      │    │    ├── reg-match [type=bool]
-      │    │    │    ├── variable: b.x [type=string]
+ └── and [type=bool, outer=(1)]
+      ├── and [type=bool, outer=(1)]
+      │    ├── and [type=bool, outer=(1)]
+      │    │    ├── reg-match [type=bool, outer=(1)]
+      │    │    │    ├── variable: b.x [type=string, outer=(1)]
       │    │    │    └── const: 'foo' [type=string]
-      │    │    └── not-reg-match [type=bool]
-      │    │         ├── variable: b.x [type=string]
+      │    │    └── not-reg-match [type=bool, outer=(1)]
+      │    │         ├── variable: b.x [type=string, outer=(1)]
       │    │         └── const: 'bar' [type=string]
-      │    └── reg-i-match [type=bool]
-      │         ├── variable: b.x [type=string]
+      │    └── reg-i-match [type=bool, outer=(1)]
+      │         ├── variable: b.x [type=string, outer=(1)]
       │         └── const: 'foo' [type=string]
-      └── not-reg-i-match [type=bool]
-           ├── variable: b.x [type=string]
+      └── not-reg-i-match [type=bool, outer=(1)]
+           ├── variable: b.x [type=string, outer=(1)]
            └── const: 'bar' [type=string]
 
 # Is, IsNot
@@ -221,12 +221,12 @@ select
  ├── columns: x:int:1 y:int:null:2
  ├── scan
  │    └── columns: a.x:int:1 a.y:int:null:2
- └── and [type=bool]
-      ├── is-not [type=bool]
-      │    ├── variable: a.x [type=int]
-      │    └── variable: a.y [type=int]
-      └── is [type=bool]
-           ├── variable: a.x [type=int]
+ └── and [type=bool, outer=(1,2)]
+      ├── is-not [type=bool, outer=(1,2)]
+      │    ├── variable: a.x [type=int, outer=(1)]
+      │    └── variable: a.y [type=int, outer=(2)]
+      └── is [type=bool, outer=(1)]
+           ├── variable: a.x [type=int, outer=(1)]
            └── null [type=unknown]
 
 # Bitand, Bitor, Bitxor
@@ -237,16 +237,16 @@ project
  ├── columns: column3:int:null:3 column4:int:null:4 column5:int:null:5
  ├── scan
  │    └── columns: a.x:int:1 a.y:int:null:2
- └── projections
-      ├── bitand [type=int]
-      │    ├── variable: a.x [type=int]
-      │    └── variable: a.y [type=int]
-      ├── bitor [type=int]
-      │    ├── variable: a.x [type=int]
-      │    └── variable: a.y [type=int]
-      └── bitxor [type=int]
-           ├── variable: a.x [type=int]
-           └── variable: a.y [type=int]
+ └── projections [outer=(1,2)]
+      ├── bitand [type=int, outer=(1,2)]
+      │    ├── variable: a.x [type=int, outer=(1)]
+      │    └── variable: a.y [type=int, outer=(2)]
+      ├── bitor [type=int, outer=(1,2)]
+      │    ├── variable: a.x [type=int, outer=(1)]
+      │    └── variable: a.y [type=int, outer=(2)]
+      └── bitxor [type=int, outer=(1,2)]
+           ├── variable: a.x [type=int, outer=(1)]
+           └── variable: a.y [type=int, outer=(2)]
 
 # Plus, Minus, Mult, Div, FloorDiv
 build
@@ -256,21 +256,21 @@ project
  ├── columns: column3:decimal:null:3 column4:date:null:4 column5:decimal:null:5 column6:decimal:null:6 column7:decimal:null:7
  ├── scan
  │    └── columns: a.x:int:1 a.y:int:null:2
- └── projections
-      ├── plus [type=decimal]
-      │    ├── variable: a.x [type=int]
+ └── projections [outer=(1,2)]
+      ├── plus [type=decimal, outer=(1)]
+      │    ├── variable: a.x [type=int, outer=(1)]
       │    └── const: 1.5 [type=decimal]
       ├── minus [type=date]
       │    ├── const: '2000-01-01' [type=date]
       │    └── const: 15 [type=int]
-      ├── mult [type=decimal]
+      ├── mult [type=decimal, outer=(1)]
       │    ├── const: 10.10 [type=decimal]
-      │    └── variable: a.x [type=int]
-      ├── div [type=decimal]
+      │    └── variable: a.x [type=int, outer=(1)]
+      ├── div [type=decimal, outer=(2)]
       │    ├── const: 1 [type=int]
-      │    └── variable: a.y [type=int]
-      └── floor-div [type=decimal]
-           ├── variable: a.x [type=int]
+      │    └── variable: a.y [type=int, outer=(2)]
+      └── floor-div [type=decimal, outer=(1)]
+           ├── variable: a.x [type=int, outer=(1)]
            └── const: 1.5 [type=decimal]
 
 # Mod, Pow, LShift, RShift
@@ -281,18 +281,18 @@ project
  ├── columns: column3:decimal:null:3 column4:decimal:null:4 column5:int:null:5 column6:int:null:6
  ├── scan
  │    └── columns: a.x:int:1 a.y:int:null:2
- └── projections
-      ├── mod [type=decimal]
+ └── projections [outer=(1,2)]
+      ├── mod [type=decimal, outer=(1)]
       │    ├── const: 100.1 [type=decimal]
-      │    └── variable: a.x [type=int]
-      ├── pow [type=decimal]
-      │    ├── variable: a.x [type=int]
+      │    └── variable: a.x [type=int, outer=(1)]
+      ├── pow [type=decimal, outer=(1)]
+      │    ├── variable: a.x [type=int, outer=(1)]
       │    └── const: 2.5 [type=decimal]
-      ├── l-shift [type=int]
-      │    ├── variable: a.x [type=int]
+      ├── l-shift [type=int, outer=(1)]
+      │    ├── variable: a.x [type=int, outer=(1)]
       │    └── const: 3 [type=int]
-      └── r-shift [type=int]
-           ├── variable: a.y [type=int]
+      └── r-shift [type=int, outer=(2)]
+           ├── variable: a.y [type=int, outer=(2)]
            └── const: 2 [type=int]
 
 # Concat
@@ -303,9 +303,9 @@ project
  ├── columns: column3:string:null:3
  ├── scan
  │    └── columns: b.x:string:1 b.z:decimal:2
- └── projections
-      └── concat [type=string]
-           ├── variable: b.x [type=string]
+ └── projections [outer=(1)]
+      └── concat [type=string, outer=(1)]
+           ├── variable: b.x [type=string, outer=(1)]
            └── const: 'more' [type=string]
 
 # UnaryPlus, UnaryMinus, UnaryComplement
@@ -316,13 +316,13 @@ project
  ├── columns: column3:int:null:3 column4:int:null:4 column5:int:null:5
  ├── scan
  │    └── columns: a.x:int:1 a.y:int:null:2
- └── projections
-      ├── unary-plus [type=int]
-      │    └── variable: a.x [type=int]
-      ├── unary-minus [type=int]
-      │    └── variable: a.y [type=int]
-      └── unary-complement [type=int]
-           └── variable: a.x [type=int]
+ └── projections [outer=(1,2)]
+      ├── unary-plus [type=int, outer=(1)]
+      │    └── variable: a.x [type=int, outer=(1)]
+      ├── unary-minus [type=int, outer=(2)]
+      │    └── variable: a.y [type=int, outer=(2)]
+      └── unary-complement [type=int, outer=(1)]
+           └── variable: a.x [type=int, outer=(1)]
 
 # Array Concat
 build
@@ -332,16 +332,16 @@ project
  ├── columns: column3:int[]:null:3 column4:int[]:null:4 column5:int[]:null:5
  ├── scan
  │    └── columns: unusual.x:int:1 unusual.arr:int[]:null:2
- └── projections
-      ├── concat [type=int[]]
-      │    ├── variable: unusual.arr [type=int[]]
-      │    └── variable: unusual.arr [type=int[]]
-      ├── concat [type=int[]]
-      │    ├── variable: unusual.arr [type=int[]]
+ └── projections [outer=(2)]
+      ├── concat [type=int[], outer=(2)]
+      │    ├── variable: unusual.arr [type=int[], outer=(2)]
+      │    └── variable: unusual.arr [type=int[], outer=(2)]
+      ├── concat [type=int[], outer=(2)]
+      │    ├── variable: unusual.arr [type=int[], outer=(2)]
       │    └── null [type=unknown]
-      └── concat [type=int[]]
+      └── concat [type=int[], outer=(2)]
            ├── null [type=unknown]
-           └── variable: unusual.arr [type=int[]]
+           └── variable: unusual.arr [type=int[], outer=(2)]
 
 # Array Element Concat
 build
@@ -351,19 +351,19 @@ project
  ├── columns: column3:int[]:null:3 column4:int[]:null:4 column5:int[]:null:5 column6:int[]:null:6
  ├── scan
  │    └── columns: unusual.x:int:1 unusual.arr:int[]:null:2
- └── projections
-      ├── concat [type=int[]]
-      │    ├── variable: unusual.x [type=int]
-      │    └── variable: unusual.arr [type=int[]]
-      ├── concat [type=int[]]
-      │    ├── variable: unusual.arr [type=int[]]
-      │    └── variable: unusual.x [type=int]
-      ├── concat [type=int[]]
-      │    ├── variable: unusual.x [type=int]
+ └── projections [outer=(1,2)]
+      ├── concat [type=int[], outer=(1,2)]
+      │    ├── variable: unusual.x [type=int, outer=(1)]
+      │    └── variable: unusual.arr [type=int[], outer=(2)]
+      ├── concat [type=int[], outer=(1,2)]
+      │    ├── variable: unusual.arr [type=int[], outer=(2)]
+      │    └── variable: unusual.x [type=int, outer=(1)]
+      ├── concat [type=int[], outer=(1)]
+      │    ├── variable: unusual.x [type=int, outer=(1)]
       │    └── null [type=unknown]
-      └── concat [type=int[]]
+      └── concat [type=int[], outer=(1)]
            ├── null [type=unknown]
-           └── variable: unusual.x [type=int]
+           └── variable: unusual.x [type=int, outer=(1)]
 
 # Function with fixed return type.
 build

--- a/pkg/sql/opt/xform/testdata/typing
+++ b/pkg/sql/opt/xform/testdata/typing
@@ -308,17 +308,15 @@ project
            ├── variable: b.x [type=string, outer=(1)]
            └── const: 'more' [type=string]
 
-# UnaryPlus, UnaryMinus, UnaryComplement
+# UnaryMinus, UnaryComplement
 build
-SELECT +a.x, -a.y, ~a.x FROM a
+SELECT -a.y, ~a.x FROM a
 ----
 project
- ├── columns: column3:int:null:3 column4:int:null:4 column5:int:null:5
+ ├── columns: column3:int:null:3 column4:int:null:4
  ├── scan
  │    └── columns: a.x:int:1 a.y:int:null:2
  └── projections [outer=(1,2)]
-      ├── unary-plus [type=int, outer=(1)]
-      │    └── variable: a.x [type=int, outer=(1)]
       ├── unary-minus [type=int, outer=(2)]
       │    └── variable: a.y [type=int, outer=(2)]
       └── unary-complement [type=int, outer=(1)]

--- a/pkg/sql/opt/xform/typing.go
+++ b/pkg/sql/opt/xform/typing.go
@@ -22,6 +22,19 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
 )
 
+// overload encapsulates information about a binary operator overload, to be
+// used for type inference and null folding. The tree.BinOp struct does not
+// work well for this use case, because it is quite large, and was not defined
+// in a way allowing it to be passed by reference (without extra allocation).
+type overload struct {
+	// returnType of the overload. This depends on the argument types.
+	returnType types.T
+
+	// allowNullArgs is true if the operator allows null arguments, and cannot
+	// therefore be folded away to null.
+	allowNullArgs bool
+}
+
 // inferType derives the type of the given scalar expression. Depending upon
 // the operator, the type may be fixed, or it may be dependent upon the
 // operands. inferType is called during initial construction of the expression,
@@ -52,8 +65,11 @@ func inferUnaryType(op opt.Operator, inputType types.T) types.T {
 // inferBinaryType infers the return type of a binary operator, given the type
 // of its inputs.
 func inferBinaryType(op opt.Operator, leftType, rightType types.T) types.T {
-	returnType, _ := resolveBinary(op, leftType, rightType)
-	return returnType
+	o, ok := findBinaryOverload(op, leftType, rightType)
+	if !ok {
+		panic(fmt.Sprintf("could not find type for binary expression %s", op))
+	}
+	return o.returnType
 }
 
 type typingFunc func(ev ExprView) types.T
@@ -141,8 +157,7 @@ func typeAsUnary(ev ExprView) types.T {
 func typeAsBinary(ev ExprView) types.T {
 	leftType := ev.Child(0).Logical().Scalar.Type
 	rightType := ev.Child(1).Logical().Scalar.Type
-	typ, _ := resolveBinary(ev.Operator(), leftType, rightType)
-	return typ
+	return inferBinaryType(ev.Operator(), leftType, rightType)
 }
 
 // typeFunction returns the type of a function expression by extracting it from
@@ -204,32 +219,33 @@ func typeAsPrivate(ev ExprView) types.T {
 	return ev.Private().(types.T)
 }
 
-// resolveBinary finds the correct type signature overload for the specified
-// binary operator, given the types of its inputs. resolveBinary returns the
-// overloads's return type, as well as a boolean indicating whether it allows
-// null values to be passed as inputs (if not, the operator can just be folded
-// to null).
-func resolveBinary(op opt.Operator, leftType, rightType types.T) (typ types.T, allowNulls bool) {
+// findBinaryOverload finds the correct type signature overload for the
+// specified binary operator, given the types of its inputs. If an overload is
+// found, findBinaryOverload returns true, plus information about the overload.
+// If an overload is not found, findBinaryOverload returns false.
+func findBinaryOverload(op opt.Operator, leftType, rightType types.T) (_ overload, ok bool) {
 	binOp := opt.BinaryOpReverseMap[op]
 
 	// Find the binary op that matches the type of the expression's left and
-	// right children.
-	for _, op := range tree.BinOps[binOp] {
-		o := op.(tree.BinOp)
+	// right children. No more than one match should ever be found. The
+	// TestTypingBinaryAssumptions test ensures this will be the case even if
+	// new operators or overloads are added.
+	for _, binOverloads := range tree.BinOps[binOp] {
+		o := binOverloads.(tree.BinOp)
 
 		if leftType == types.Unknown {
 			if rightType.Equivalent(o.RightType) {
-				return o.ReturnType, o.NullableArgs
+				return overload{returnType: o.ReturnType, allowNullArgs: o.NullableArgs}, true
 			}
 		} else if rightType == types.Unknown {
 			if leftType.Equivalent(o.LeftType) {
-				return o.ReturnType, o.NullableArgs
+				return overload{returnType: o.ReturnType, allowNullArgs: o.NullableArgs}, true
 			}
 		} else {
 			if leftType.Equivalent(o.LeftType) && rightType.Equivalent(o.RightType) {
-				return o.ReturnType, o.NullableArgs
+				return overload{returnType: o.ReturnType, allowNullArgs: o.NullableArgs}, true
 			}
 		}
 	}
-	panic(fmt.Sprintf("could not find type for binary expression %s", op))
+	return overload{}, false
 }

--- a/pkg/sql/opt/xform/typing_test.go
+++ b/pkg/sql/opt/xform/typing_test.go
@@ -17,8 +17,8 @@ package xform
 import (
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
-	"github.com/cockroachdb/cockroach/pkg/sql/opt/testutils"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
 )
@@ -28,7 +28,8 @@ func TestTyping(t *testing.T) {
 }
 
 func TestTypingJson(t *testing.T) {
-	o := NewOptimizer(createTypingCatalog(t), OptimizeNone)
+	evalCtx := tree.MakeTestingEvalContext(cluster.MakeTestingClusterSettings())
+	o := NewOptimizer(&evalCtx, OptimizeNone)
 	f := o.Factory()
 
 	// (Const <json>)
@@ -137,13 +138,6 @@ func TestTypingBinaryAssumptions(t *testing.T) {
 			}
 		}
 	}
-}
-
-func createTypingCatalog(t *testing.T) *testutils.TestCatalog {
-	cat := testutils.NewTestCatalog()
-	testutils.ExecuteTestDDL(t, "CREATE TABLE a (x INT PRIMARY KEY, y INT)", cat)
-	testutils.ExecuteTestDDL(t, "CREATE TABLE b (x STRING PRIMARY KEY, z DECIMAL NOT NULL)", cat)
-	return cat
 }
 
 func testTyping(t *testing.T, ev ExprView, expected types.T) {

--- a/pkg/sql/opt_index_selection.go
+++ b/pkg/sql/opt_index_selection.go
@@ -139,7 +139,7 @@ func (p *planner) selectIndex(
 			colNames[i] = s.resultColumns[i].Name
 			colTypes[i] = s.resultColumns[i].Typ
 		}
-		optimizer = xform.NewOptimizer(nil /* Catalog */, xform.OptimizeAll)
+		optimizer = xform.NewOptimizer(p.EvalContext(), xform.OptimizeAll)
 		bld := optbuilder.NewScalar(
 			ctx, &p.semaCtx, p.EvalContext(), optimizer.Factory(), colNames, colTypes,
 		)

--- a/pkg/sql/plan.go
+++ b/pkg/sql/plan.go
@@ -320,8 +320,8 @@ func (p *planner) makeOptimizerPlan(ctx context.Context, stmt Statement) error {
 	eng := newExecEngine(p, nil)
 	defer eng.Close()
 
-	o := xform.NewOptimizer(eng.Catalog(), xform.OptimizeAll)
-	bld := optbuilder.New(ctx, &p.semaCtx, p.EvalContext(), o.Factory(), stmt.AST)
+	o := xform.NewOptimizer(p.EvalContext(), xform.OptimizeAll)
+	bld := optbuilder.New(ctx, &p.semaCtx, p.EvalContext(), eng.Catalog(), o.Factory(), stmt.AST)
 	root, props, err := bld.Build()
 	if err != nil {
 		return err


### PR DESCRIPTION
This PR has two commits to make it easier to review. One adds the OuterCols property to the scalar logical properties (which was small change, but causes big test diffs), and the other adds a number of new scalar rewrite rules.