### PR TITLE
all: require go1.10 to build CockroachDB

### DIFF
--- a/build/bootstrap/bootstrap-go.sh
+++ b/build/bootstrap/bootstrap-go.sh
@@ -4,7 +4,7 @@
 
 set -euxo pipefail
 
-GOVERSION=1.9
+GOVERSION=1.10
 
 sudo apt-get install -y gcc g++ make
 

--- a/build/builder/Dockerfile
+++ b/build/builder/Dockerfile
@@ -126,8 +126,12 @@ RUN git clone --depth 1 https://github.com/tpoechtrager/osxcross.git \
  && mv osxcross/target /x-tools/x86_64-apple-darwin13 \
  && rm -rf osxcross
 
-# Compile Go from source so that CC defaults to clang instead of gcc.
-# This requires a Go toolchain to bootstrap.
+# Compile Go from source so that CC defaults to clang instead of gcc. This
+# requires a Go toolchain to bootstrap.
+#
+# NB: care needs to be taken when updating this version because earlier
+# releases of Go will no longer be run in CI once it is changed. Consider
+# bumping the minimum allowed version of Go in /build/go-version-chech.sh.
 RUN apt-get install -y --no-install-recommends golang \
  && curl -fsSL https://storage.googleapis.com/golang/go1.10.src.tar.gz -o golang.tar.gz \
  && echo 'f3de49289405fda5fd1483a8fe6bd2fa5469e005fd567df64485c4fa000c7f24 golang.tar.gz' | sha256sum -c - \

--- a/build/go-version-check.sh
+++ b/build/go-version-check.sh
@@ -27,7 +27,7 @@ fi
 
 version_major=$(cut -f1 -d. <<< "$version")
 version_minor=$(cut -f2 -d. <<< "$version")
-if (( version_major != 1 )) || (( version_minor < 9 )); then
-  echo "go1.9+ required (detected go$version)"
+if (( version_major != 1 )) || (( version_minor < 10 )); then
+  echo "go1.10+ required (detected go$version)"
   exit
 fi


### PR DESCRIPTION
We just had our first code that requires go1.10 land on master (#23425),
so CockroachDB can no longer be built using go1.9. This change updates
the `go-version-check` script to enforce this.

Release note (build change): Go 1.10 is now the minimum required version
necessary to build CockroachDB.