### PR TITLE
importccl: fix TestImportStmt

### DIFF
--- a/pkg/ccl/importccl/csv_test.go
+++ b/pkg/ccl/importccl/csv_test.go
@@ -869,7 +869,7 @@ func TestImportStmt(t *testing.T) {
 		)
 
 		data = ",5,e,,,"
-		if _, err := conn.Exec(query, srv.URL); !testutils.IsError(err, `parse "a" as INT: could not parse ""`) {
+		if _, err := conn.Exec(query, srv.URL); !testutils.IsError(err, `could not parse "" as type int`) {
 			t.Fatalf("unexpected: %v", err)
 		}
 		if _, err := conn.Exec(query+nullif, srv.URL); !testutils.IsError(err, `"a" violates not-null constraint`) {


### PR DESCRIPTION
Looks like merge skew, though it's not clear to me why there weren't
more failures on `master`.

Fixes #23430.

Release note: None