### PR TITLE
roachtest: add INSERT ... SELECT ... table copy test

### DIFF
--- a/pkg/cmd/roachtest/copy.go
+++ b/pkg/cmd/roachtest/copy.go
@@ -81,6 +81,9 @@ func init() {
 			rowsPerInsert := (60 << 20 /* 60MB */) / rowEstimate
 			t.Status("copying from bank_orig to bank")
 			for lastID := -1; lastID+1 < rows; {
+				if lastID > 0 {
+					t.Progress(float64(lastID+1) / float64(rows))
+				}
 				q := fmt.Sprintf(`
 					SELECT id FROM [
 						INSERT INTO bank.bank

--- a/pkg/cmd/roachtest/copy.go
+++ b/pkg/cmd/roachtest/copy.go
@@ -1,0 +1,127 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+
+package main
+
+import (
+	"context"
+	"fmt"
+
+	_ "github.com/lib/pq"
+	"github.com/pkg/errors"
+)
+
+func init() {
+	// This test imports a fully-populated Bank table. It then creates an empty
+	// Bank schema. Finally, it performs a series of `INSERT ... SELECT ...`
+	// statements to copy all data from the first table into the second table.
+	runCopy := func(t *test, rows, nodes int) {
+		// payload is the size of the payload column for each row in the Bank
+		// table. If this is adjusted, a new fixture may need to be generated.
+		const payload = 100
+		// rowOverheadEstimate is an estimate of the overhead of a single
+		// row in the Bank table, not including the size of the payload
+		// itself. This overhead includes the size of the other two columns
+		// in the table along with the size of each row's associated KV key.
+		const rowOverheadEstimate = 160
+		const rowEstimate = rowOverheadEstimate + payload
+
+		ctx := context.Background()
+		c := newCluster(ctx, t, nodes)
+		defer c.Destroy(ctx)
+
+		c.Put(ctx, cockroach, "./cockroach", c.All())
+		c.Put(ctx, workload, "./workload", c.All())
+		c.Start(ctx, c.All())
+
+		m := newMonitor(ctx, c, c.All())
+		m.Go(func(ctx context.Context) error {
+			db := c.Conn(ctx, 1)
+			defer db.Close()
+
+			t.Status("importing Bank fixture")
+			c.Run(ctx, 1, fmt.Sprintf(
+				"./workload fixtures load bank --rows=%d --payload-bytes=%d {pgurl:1}",
+				rows, payload))
+			if _, err := db.Exec("ALTER TABLE bank.bank RENAME TO bank.bank_orig"); err != nil {
+				t.Fatalf("failed to rename table: %v", err)
+			}
+
+			t.Status("create copy of Bank schema")
+			c.Run(ctx, 1, "./workload init bank --rows=0 --ranges=1 {pgurl:1}")
+
+			rangeCount := func() int {
+				var count int
+				const q = "SELECT COUNT(*) FROM [SHOW TESTING_RANGES FROM TABLE bank.bank]"
+				if err := db.QueryRow(q).Scan(&count); err != nil {
+					t.Fatalf("failed to get range count: %v", err)
+				}
+				return count
+			}
+			if rc := rangeCount(); rc != 1 {
+				return errors.Errorf("empty bank table split over multiple ranges")
+			}
+
+			// Copy batches of rows from bank_orig to bank. Each batch needs to
+			// be under kv.raft.command.max_size=64MB or we'll hit a "command is
+			// too large" error. We play it safe and chose batches whose rows
+			// add up to well less than this limit.
+			rowsPerInsert := (60 << 20 /* 60MB */) / rowEstimate
+			t.Status("copying from bank_orig to bank")
+			for lastID := -1; lastID+1 < rows; {
+				q := fmt.Sprintf(`
+					SELECT id FROM [
+						INSERT INTO bank.bank
+						SELECT * FROM bank.bank_orig
+						WHERE id > %d
+						ORDER BY id ASC
+						LIMIT %d
+						RETURNING ID
+					]
+					ORDER BY id DESC
+					LIMIT 1`,
+					lastID, rowsPerInsert)
+				if err := db.QueryRow(q).Scan(&lastID); err != nil {
+					t.Fatalf("failed to copy rows: %v", err)
+				}
+			}
+
+			rc := rangeCount()
+			c.l.printf("range count after copy = %d\n", rc)
+			highExp := (rows * rowEstimate) / (32 << 20 /* 32MB */)
+			lowExp := (rows * rowEstimate) / (64 << 20 /* 64MB */)
+			if rc > highExp || rc < lowExp {
+				return errors.Errorf("expected range count for table between %d and %d, found %d",
+					lowExp, highExp, rc)
+			}
+			return nil
+		})
+		m.Wait()
+	}
+
+	rows := int(1E7)
+	nodes := 9
+
+	tests.Add(
+		fmt.Sprintf("copy/bank/rows=%d,nodes=%d", rows, nodes),
+		func(t *test) {
+			if local {
+				rows = 1E6
+				nodes = 4
+				fmt.Printf("running with nodes=%d in local mode\n", nodes)
+			}
+			runCopy(t, rows, nodes)
+		})
+}


### PR DESCRIPTION
Closes #15713.

This change adds a test that first imports a fully-populated Bank table. It
then creates a second empty Bank schema. Finally, it performs a series of
paginated `INSERT ... SELECT ...` statements to copy all data from the first
table into the second table. This stresses both large transactions and the
ability for range splits to keep up with a large amount of data movement.

Release note: None