### PR TITLE
distsql: Fix rowFetcher fetching duplicate rows

### DIFF
--- a/pkg/sql/sqlbase/errors.go
+++ b/pkg/sql/sqlbase/errors.go
@@ -253,12 +253,14 @@ type singleKVFetcher struct {
 }
 
 // nextBatch implements the kvFetcher interface.
-func (f *singleKVFetcher) nextBatch(_ context.Context) (bool, []roachpb.KeyValue, error) {
+func (f *singleKVFetcher) nextBatch(
+	_ context.Context,
+) (ok bool, kvs []roachpb.KeyValue, isNewScan bool, err error) {
 	if f.done {
-		return false, nil, nil
+		return false, nil, true, nil
 	}
 	f.done = true
-	return true, f.kvs[:], nil
+	return true, f.kvs[:], true, nil
 }
 
 // getRangesInfo implements the kvFetcher interface.

--- a/pkg/sql/sqlbase/fk.go
+++ b/pkg/sql/sqlbase/fk.go
@@ -272,13 +272,15 @@ type SpanKVFetcher struct {
 }
 
 // nextBatch implements the kvFetcher interface.
-func (f *SpanKVFetcher) nextBatch(_ context.Context) (bool, []roachpb.KeyValue, error) {
+func (f *SpanKVFetcher) nextBatch(
+	_ context.Context,
+) (ok bool, kvs []roachpb.KeyValue, isNewSpan bool, err error) {
 	if len(f.KVs) == 0 {
-		return false, nil, nil
+		return false, nil, true, nil
 	}
 	res := f.KVs
 	f.KVs = nil
-	return true, res, nil
+	return true, res, true, nil
 }
 
 // getRangesInfo implements the kvFetcher interface.


### PR DESCRIPTION
Fixes #22631

This change allows the rowFetcher to correctly fetch a batch of spans
which has two duplicate spans adjacent to each other. It does so by
detecting when a new span starts being processed by the rowFetcher and
using this information to determine which KV pair is the last in the
row.

Additionally tests were added to the rowFetcher to increase coverage
with repsect to batched fetches with specific limits on tables that were
split into families (to ensure multiple key-value paris per row).

Release note: none