### PR TITLE
kubernetes: Switch to newer form of the unready endpoints setting

### DIFF
--- a/cloud/kubernetes/cockroachdb-statefulset-secure.yaml
+++ b/cloud/kubernetes/cockroachdb-statefulset-secure.yaml
@@ -99,13 +99,6 @@ metadata:
   labels:
     app: cockroachdb
   annotations:
-    # This is needed to make the peer-finder work properly and to help avoid
-    # edge cases where instance 0 comes up after losing its data and needs to
-    # decide whether it should create a new cluster or try to join an existing
-    # one. If it creates a new cluster when it should have joined an existing
-    # one, we'd end up with two separate clusters listening at the same service
-    # endpoint, which would be very bad.
-    service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
     # Enable automatic monitoring of all instances when Prometheus is running in the cluster.
     prometheus.io/scrape: "true"
     prometheus.io/path: "_status/vars"
@@ -118,6 +111,10 @@ spec:
   - port: 8080
     targetPort: 8080
     name: http
+  # We want all pods in the StatefulSet to have their addresses published for
+  # the sake of the other CockroachDB pods even before they're ready, since they
+  # have to be able to talk to each other in order to become ready.
+  publishNotReadyAddresses: true
   clusterIP: None
   selector:
     app: cockroachdb

--- a/cloud/kubernetes/cockroachdb-statefulset.yaml
+++ b/cloud/kubernetes/cockroachdb-statefulset.yaml
@@ -31,13 +31,6 @@ metadata:
   labels:
     app: cockroachdb
   annotations:
-    # This is needed to make the peer-finder work properly and to help avoid
-    # edge cases where instance 0 comes up after losing its data and needs to
-    # decide whether it should create a new cluster or try to join an existing
-    # one. If it creates a new cluster when it should have joined an existing
-    # one, we'd end up with two separate clusters listening at the same service
-    # endpoint, which would be very bad.
-    service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
     # Enable automatic monitoring of all instances when Prometheus is running in the cluster.
     prometheus.io/scrape: "true"
     prometheus.io/path: "_status/vars"
@@ -50,6 +43,10 @@ spec:
   - port: 8080
     targetPort: 8080
     name: http
+  # We want all pods in the StatefulSet to have their addresses published for
+  # the sake of the other CockroachDB pods even before they're ready, since they
+  # have to be able to talk to each other in order to become ready.
+  publishNotReadyAddresses: true
   clusterIP: None
   selector:
     app: cockroachdb


### PR DESCRIPTION
The annotation will be deprecated soon, and the real field is supported
starting in v1.8.

Release note: None

-----------

We should probably wait a little longer before switching over here, since we currently support kubernetes 1.7 and the old annotation still isn't deprecated yet in their new 1.10 release. I just wanted to send this out to avoid leaving it bouncing around in my memory forever.