### PR TITLE
kubernetes: start/stop pods in parallel

### DIFF
--- a/cloud/kubernetes/cockroachdb-statefulset-secure.yaml
+++ b/cloud/kubernetes/cockroachdb-statefulset-secure.yaml
@@ -220,6 +220,7 @@ spec:
           claimName: datadir
       - name: certs
         emptyDir: {}
+  podManagementPolicy: Parallel
   updateStrategy:
     type: RollingUpdate
   volumeClaimTemplates:

--- a/cloud/kubernetes/cockroachdb-statefulset.yaml
+++ b/cloud/kubernetes/cockroachdb-statefulset.yaml
@@ -118,6 +118,7 @@ spec:
       - name: datadir
         persistentVolumeClaim:
           claimName: datadir
+  podManagementPolicy: Parallel
   updateStrategy:
     type: RollingUpdate
   volumeClaimTemplates:


### PR DESCRIPTION
This makes starting a cluster faster, with no real downside for us since
Cockroach has been built to handle multiple nodes joining at a time.

This also takes nodes down in parallel, which isn't something someone
should do if they want their cluster to remain available, but it's
already true that taking multiple nodes down without decommissioning
them will take a cluster offline. This doesn't make that any worse.

Release note: None

------------------

Like #23475, this feature was added in kubernetes v1.8, so we shouldn't switch over to it immediately. We'll also have to update our kubernetes docs if/when this goes in to reflect that all the pods come up (and ask for their certs) in parallel.