### PR TITLE
sql: disable distsql for casts to OID types

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/regclass22249
+++ b/pkg/sql/logictest/testdata/logic_test/regclass22249
@@ -1,6 +1,4 @@
-# LogicTest: default parallel-stmts
-
-# This still fails in DistSQL, #22264.
+# LogicTest: default distsql parallel-stmts
 
 statement ok
 CREATE TABLE d (id INT PRIMARY KEY, str STRING);


### PR DESCRIPTION
Distsql has incomplete handling for OID types like REGCLASS, as
evidenced by #22264. These queries are unlikely to benefit from
distributed processing anyway, since they're generally used for schema
introspection, so I've disabled distsql for queries that include casts
to OID types.

Release note (bug fix): Fixed panics related to distributed execution of
queries with REGCLASS casts.