### PR TITLE
cherrypick-2.0: sql: disable distsql for casts to OID types

### DIFF
--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -29,6 +29,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/rpc"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/sql/coltypes"
 	"github.com/cockroachdb/cockroach/pkg/sql/distsqlplan"
 	"github.com/cockroachdb/cockroach/pkg/sql/distsqlrun"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -170,6 +171,12 @@ func (v *distSQLExprCheckVisitor) VisitPre(expr tree.Expr) (recurse bool, newExp
 	case *tree.FuncExpr:
 		if t.IsDistSQLBlacklist() {
 			v.err = newQueryNotSupportedErrorf("function %s cannot be executed with distsql", t)
+			return false, expr
+		}
+	case *tree.CastExpr:
+		switch t.Type.(type) {
+		case *coltypes.TOid:
+			v.err = newQueryNotSupportedErrorf("cast to %s is not supported by distsql", t.Type)
 			return false, expr
 		}
 	}

--- a/pkg/sql/logictest/testdata/logic_test/regclass22249
+++ b/pkg/sql/logictest/testdata/logic_test/regclass22249
@@ -1,6 +1,4 @@
-# LogicTest: default parallel-stmts
-
-# This still fails in DistSQL, #22264.
+# LogicTest: default distsql parallel-stmts
 
 statement ok
 CREATE TABLE d (id INT PRIMARY KEY, str STRING);


### PR DESCRIPTION
Distsql has incomplete handling for OID types like REGCLASS, as
evidenced by #22264. These queries are unlikely to benefit from
distributed processing anyway, since they're generally used for schema
introspection, so I've disabled distsql for queries that include casts
to OID types.

Release note (bug fix): Fixed panics related to distributed execution of
queries with REGCLASS casts.