### PR TITLE
sql: allow "gossip on capacity change" span in TestTrace

### DIFF
--- a/pkg/sql/trace_test.go
+++ b/pkg/sql/trace_test.go
@@ -41,6 +41,7 @@ func TestTrace(t *testing.T) {
 	// These are always appended, even without the test specifying it.
 	alwaysOptionalSpans := []string{
 		"[async] storage.pendingLeaseRequest: requesting lease",
+		"[async] storage.Store: gossip on capacity change",
 		"request range lease",
 		"range lookup",
 	}


### PR DESCRIPTION
Release note: None