### PR TITLE
ui: readability tweaks to logs page

### DIFF
--- a/pkg/ui/src/views/cluster/containers/nodeLogs/index.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodeLogs/index.tsx
@@ -12,17 +12,20 @@ import { SortableTable } from "src/views/shared/components/sortabletable";
 import { AdminUIState } from "src/redux/state";
 import { refreshLogs, refreshNodes } from "src/redux/apiReducers";
 import { currentNode } from "src/views/cluster/containers/nodeOverview";
+import { CachedDataReducerState } from "oss/src/redux/cachedDataReducer";
+import Loading from "src/views/shared/components/loading";
+import spinner from "assets/spinner.gif";
 import "./logs.styl";
 
 interface LogProps {
-  logs: LogEntriesResponseMessage;
+  logs: CachedDataReducerState<LogEntriesResponseMessage>;
   currentNode: NodeStatus$Properties;
   refreshLogs: typeof refreshLogs;
   refreshNodes: typeof refreshNodes;
 }
 
 /**
- * Renders the main content of the help us page.
+ * Renders the main content of the logs page.
  */
 class Logs extends React.Component<LogProps & RouterState, {}> {
   componentWillMount() {
@@ -36,8 +39,8 @@ class Logs extends React.Component<LogProps & RouterState, {}> {
       ? this.props.currentNode.desc.address.address_field
       : null;
 
-    if (this.props.logs) {
-      const logEntries = _.sortBy(this.props.logs.entries, (e) => e.time);
+    if (this.props.logs.data) {
+      const logEntries = _.sortBy(this.props.logs.data.entries, (e) => e.time);
       const columns = [
         {
           title: "Time",
@@ -77,20 +80,24 @@ class Logs extends React.Component<LogProps & RouterState, {}> {
           <h2>Logs Node { this.props.params[nodeIDAttr] } / { nodeAddress }</h2>
         </div>
         <section className="section">
-          { content }
+          <Loading
+            loading={ !this.props.logs.data }
+            className="loading-image loading-image__spinner-left"
+            image={ spinner }
+          >
+            { content }
+          </Loading>
         </section>
       </div>
     );
   }
 }
 
-const logs = (state: AdminUIState): LogEntriesResponseMessage => state.cachedData.logs.data;
-
 // Connect the EventsList class with our redux store.
 const logsConnected = connect(
   (state: AdminUIState, ownProps: RouterState) => {
     return {
-      logs: logs(state),
+      logs: state.cachedData.logs,
       currentNode: currentNode(state, ownProps),
     };
   },

--- a/pkg/ui/src/views/cluster/containers/nodeLogs/index.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodeLogs/index.tsx
@@ -11,8 +11,8 @@ import { LongToMoment } from "src/util/convert";
 import { SortableTable } from "src/views/shared/components/sortabletable";
 import { AdminUIState } from "src/redux/state";
 import { refreshLogs, refreshNodes } from "src/redux/apiReducers";
-
 import { currentNode } from "src/views/cluster/containers/nodeOverview";
+import "./logs.styl";
 
 interface LogProps {
   logs: LogEntriesResponseMessage;
@@ -50,9 +50,9 @@ class Logs extends React.Component<LogProps & RouterState, {}> {
         {
           title: "Message",
           cell: (index: number) => (
-            <div className="sort-table__unbounded-column">
+            <pre className="sort-table__unbounded-column logs-table__message">
               { logEntries[index].message }
-            </div>
+            </pre>
           ),
         },
         {
@@ -60,7 +60,13 @@ class Logs extends React.Component<LogProps & RouterState, {}> {
           cell: (index: number) => `${logEntries[index].file}:${logEntries[index].line}`,
         },
       ];
-      content = <SortableTable count={logEntries.length} columns={columns} />;
+      content = (
+        <SortableTable
+          count={logEntries.length}
+          columns={columns}
+          className="logs-table"
+        />
+      );
     }
     return (
       <div>

--- a/pkg/ui/src/views/cluster/containers/nodeLogs/logs.styl
+++ b/pkg/ui/src/views/cluster/containers/nodeLogs/logs.styl
@@ -1,0 +1,9 @@
+.logs-table
+  tbody
+    font-family monospace
+
+  &__message
+    white-space pre
+
+  td.sort-table__cell
+    padding 4px


### PR DESCRIPTION
Scratching a couple of itches:
- render newlines (fixes #15990)
- densify (fixes #15874)
- monospace font
- show loading spinner instead of "no data"

Before:
![image](https://user-images.githubusercontent.com/7341/37054304-7ce0bd42-214c-11e8-8a41-cf389c9f7603.png)

After:
![image](https://user-images.githubusercontent.com/7341/37054314-82eef690-214c-11e8-9a4e-f83ab00b6a65.png)
(Scroll to right to see file & line)
