### PR TITLE
opt: Change formatting of column types

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/scan
+++ b/pkg/sql/opt/exec/execbuilder/testdata/scan
@@ -11,7 +11,7 @@ build
 SELECT * FROM t.a
 ----
 scan
- └── columns: x:int:1 y:float:null:2
+ └── columns: x:1(int!null) y:2(float)
 
 exec-explain
 SELECT * FROM t.a

--- a/pkg/sql/opt/optbuilder/testdata/aggregate
+++ b/pkg/sql/opt/optbuilder/testdata/aggregate
@@ -21,11 +21,11 @@ SELECT MIN(1), MAX(1), COUNT(1), SUM_INT(1), AVG(1), SUM(1), STDDEV(1),
   VARIANCE(1), BOOL_AND(true), BOOL_AND(false), XOR_AGG(b'\x01') FROM t.kv
 ----
 group-by
- ├── columns: column6:int:null:6 column8:int:null:8 column10:int:null:10 column12:int:null:12 column14:decimal:null:14 column16:decimal:null:16 column18:decimal:null:18 column20:decimal:null:20 column22:bool:null:22 column24:bool:null:24 column26:bytes:null:26
+ ├── columns: column6:6(int) column8:8(int) column10:10(int) column12:12(int) column14:14(decimal) column16:16(decimal) column18:18(decimal) column20:20(decimal) column22:22(bool) column24:24(bool) column26:26(bytes)
  ├── project
- │    ├── columns: column5:int:null:5 column7:int:null:7 column9:int:null:9 column11:int:null:11 column13:int:null:13 column15:int:null:15 column17:int:null:17 column19:int:null:19 column21:bool:null:21 column23:bool:null:23 column25:bytes:null:25
+ │    ├── columns: column5:5(int) column7:7(int) column9:9(int) column11:11(int) column13:13(int) column15:15(int) column17:17(int) column19:19(int) column21:21(bool) column23:23(bool) column25:25(bytes)
  │    ├── scan
- │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
+ │    │    └── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string)
  │    └── projections
  │         ├── const: 1 [type=int]
  │         ├── const: 1 [type=int]
@@ -67,11 +67,11 @@ SELECT MIN(v), MAX(v), COUNT(v), SUM_INT(1), AVG(v), SUM(v), STDDEV(v),
   VARIANCE(v), BOOL_AND(v = 1), BOOL_AND(v = 1), XOR_AGG(s::bytes) FROM kv
 ----
 group-by
- ├── columns: column5:int:null:5 column6:int:null:6 column7:int:null:7 column9:int:null:9 column10:decimal:null:10 column11:decimal:null:11 column12:decimal:null:12 column13:decimal:null:13 column15:bool:null:15 column17:bool:null:17 column19:bytes:null:19
+ ├── columns: column5:5(int) column6:6(int) column7:7(int) column9:9(int) column10:10(decimal) column11:11(decimal) column12:12(decimal) column13:13(decimal) column15:15(bool) column17:17(bool) column19:19(bytes)
  ├── project
- │    ├── columns: kv.v:int:null:2 kv.v:int:null:2 kv.v:int:null:2 column8:int:null:8 kv.v:int:null:2 kv.v:int:null:2 kv.v:int:null:2 kv.v:int:null:2 column14:bool:null:14 column16:bool:null:16 column18:bytes:null:18
+ │    ├── columns: kv.v:2(int) kv.v:2(int) kv.v:2(int) column8:8(int) kv.v:2(int) kv.v:2(int) kv.v:2(int) kv.v:2(int) column14:14(bool) column16:16(bool) column18:18(bytes)
  │    ├── scan
- │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
+ │    │    └── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string)
  │    └── projections [outer=(2,4)]
  │         ├── variable: kv.v [type=int, outer=(2)]
  │         ├── variable: kv.v [type=int, outer=(2)]
@@ -118,11 +118,11 @@ SELECT MIN(1), COUNT(1), MAX(1), SUM_INT(1), AVG(1)::float, SUM(1), STDDEV(1),
   VARIANCE(1)::float, BOOL_AND(true), BOOL_OR(true), TO_HEX(XOR_AGG(b'\x01'))
 ----
 project
- ├── columns: column2:int:null:2 column4:int:null:4 column6:int:null:6 column8:int:null:8 column11:float:null:11 column13:decimal:null:13 column15:decimal:null:15 column18:float:null:18 column20:bool:null:20 column22:bool:null:22 column25:string:null:25
+ ├── columns: column2:2(int) column4:4(int) column6:6(int) column8:8(int) column11:11(float) column13:13(decimal) column15:15(decimal) column18:18(float) column20:20(bool) column22:22(bool) column25:25(string)
  ├── group-by
- │    ├── columns: column2:int:null:2 column4:int:null:4 column6:int:null:6 column8:int:null:8 column10:decimal:null:10 column13:decimal:null:13 column15:decimal:null:15 column17:decimal:null:17 column20:bool:null:20 column22:bool:null:22 column24:bytes:null:24
+ │    ├── columns: column2:2(int) column4:4(int) column6:6(int) column8:8(int) column10:10(decimal) column13:13(decimal) column15:15(decimal) column17:17(decimal) column20:20(bool) column22:22(bool) column24:24(bytes)
  │    ├── project
- │    │    ├── columns: column1:int:null:1 column3:int:null:3 column5:int:null:5 column7:int:null:7 column9:int:null:9 column12:int:null:12 column14:int:null:14 column16:int:null:16 column19:bool:null:19 column21:bool:null:21 column23:bytes:null:23
+ │    │    ├── columns: column1:1(int) column3:3(int) column5:5(int) column7:7(int) column9:9(int) column12:12(int) column14:14(int) column16:16(int) column19:19(bool) column21:21(bool) column23:23(bytes)
  │    │    ├── values
  │    │    │    └── tuple [type=tuple{}]
  │    │    └── projections
@@ -180,11 +180,11 @@ build
 SELECT ARRAY_AGG(1) FROM t.kv
 ----
 group-by
- ├── columns: column6:int[]:null:6
+ ├── columns: column6:6(int[])
  ├── project
- │    ├── columns: column5:int:null:5
+ │    ├── columns: column5:5(int)
  │    ├── scan
- │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
+ │    │    └── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string)
  │    └── projections
  │         └── const: 1 [type=int]
  └── aggregations [outer=(5)]
@@ -195,11 +195,11 @@ build
 SELECT JSON_AGG(v) FROM t.kv
 ----
 group-by
- ├── columns: column5:jsonb:null:5
+ ├── columns: column5:5(jsonb)
  ├── project
- │    ├── columns: kv.v:int:null:2
+ │    ├── columns: kv.v:2(int)
  │    ├── scan
- │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
+ │    │    └── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string)
  │    └── projections [outer=(2)]
  │         └── variable: kv.v [type=int, outer=(2)]
  └── aggregations [outer=(2)]
@@ -210,9 +210,9 @@ build
 SELECT JSONB_AGG(1)
 ----
 group-by
- ├── columns: column2:jsonb:null:2
+ ├── columns: column2:2(jsonb)
  ├── project
- │    ├── columns: column1:int:null:1
+ │    ├── columns: column1:1(int)
  │    ├── values
  │    │    └── tuple [type=tuple{}]
  │    └── projections
@@ -226,14 +226,14 @@ build
 SELECT 1 FROM t.kv GROUP BY v
 ----
 project
- ├── columns: column5:int:null:5
+ ├── columns: column5:5(int)
  ├── group-by
- │    ├── columns: kv.v:int:null:2
- │    ├── grouping columns: kv.v:int:null:2
+ │    ├── columns: kv.v:2(int)
+ │    ├── grouping columns: kv.v:2(int)
  │    ├── project
- │    │    ├── columns: kv.v:int:null:2
+ │    │    ├── columns: kv.v:2(int)
  │    │    ├── scan
- │    │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
+ │    │    │    └── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string)
  │    │    └── projections [outer=(2)]
  │    │         └── variable: kv.v [type=int, outer=(2)]
  │    └── aggregations
@@ -266,9 +266,9 @@ build
 SELECT ARRAY_AGG(NULL::TEXT)
 ----
 group-by
- ├── columns: column2:string[]:null:2
+ ├── columns: column2:2(string[])
  ├── project
- │    ├── columns: column1:string:null:1
+ │    ├── columns: column1:1(string)
  │    ├── values
  │    │    └── tuple [type=tuple{}]
  │    └── projections
@@ -292,14 +292,14 @@ build
 SELECT COUNT(*), k FROM t.kv GROUP BY k
 ----
 project
- ├── columns: column5:int:null:5 k:int:1
+ ├── columns: column5:5(int) k:1(int!null)
  ├── group-by
- │    ├── columns: kv.k:int:1 column5:int:null:5
- │    ├── grouping columns: kv.k:int:1
+ │    ├── columns: kv.k:1(int!null) column5:5(int)
+ │    ├── grouping columns: kv.k:1(int!null)
  │    ├── project
- │    │    ├── columns: kv.k:int:1
+ │    │    ├── columns: kv.k:1(int!null)
  │    │    ├── scan
- │    │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
+ │    │    │    └── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string)
  │    │    └── projections [outer=(1)]
  │    │         └── variable: kv.k [type=int, outer=(1)]
  │    └── aggregations
@@ -313,14 +313,14 @@ build
 SELECT COUNT(*), k FROM t.kv GROUP BY 2
 ----
 project
- ├── columns: column5:int:null:5 k:int:1
+ ├── columns: column5:5(int) k:1(int!null)
  ├── group-by
- │    ├── columns: kv.k:int:1 column5:int:null:5
- │    ├── grouping columns: kv.k:int:1
+ │    ├── columns: kv.k:1(int!null) column5:5(int)
+ │    ├── grouping columns: kv.k:1(int!null)
  │    ├── project
- │    │    ├── columns: kv.k:int:1
+ │    │    ├── columns: kv.k:1(int!null)
  │    │    ├── scan
- │    │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
+ │    │    │    └── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string)
  │    │    └── projections [outer=(1)]
  │    │         └── variable: kv.k [type=int, outer=(1)]
  │    └── aggregations
@@ -349,14 +349,14 @@ build
 SELECT COUNT(*), kv.s FROM t.kv GROUP BY s
 ----
 project
- ├── columns: column5:int:null:5 s:string:null:4
+ ├── columns: column5:5(int) s:4(string)
  ├── group-by
- │    ├── columns: kv.s:string:null:4 column5:int:null:5
- │    ├── grouping columns: kv.s:string:null:4
+ │    ├── columns: kv.s:4(string) column5:5(int)
+ │    ├── grouping columns: kv.s:4(string)
  │    ├── project
- │    │    ├── columns: kv.s:string:null:4
+ │    │    ├── columns: kv.s:4(string)
  │    │    ├── scan
- │    │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
+ │    │    │    └── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string)
  │    │    └── projections [outer=(4)]
  │    │         └── variable: kv.s [type=string, outer=(4)]
  │    └── aggregations
@@ -369,14 +369,14 @@ build
 SELECT COUNT(*), s FROM t.kv GROUP BY kv.s
 ----
 project
- ├── columns: column5:int:null:5 s:string:null:4
+ ├── columns: column5:5(int) s:4(string)
  ├── group-by
- │    ├── columns: kv.s:string:null:4 column5:int:null:5
- │    ├── grouping columns: kv.s:string:null:4
+ │    ├── columns: kv.s:4(string) column5:5(int)
+ │    ├── grouping columns: kv.s:4(string)
  │    ├── project
- │    │    ├── columns: kv.s:string:null:4
+ │    │    ├── columns: kv.s:4(string)
  │    │    ├── scan
- │    │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
+ │    │    │    └── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string)
  │    │    └── projections [outer=(4)]
  │    │         └── variable: kv.s [type=string, outer=(4)]
  │    └── aggregations
@@ -389,14 +389,14 @@ build
 SELECT COUNT(*), kv.s FROM t.kv GROUP BY kv.s
 ----
 project
- ├── columns: column5:int:null:5 s:string:null:4
+ ├── columns: column5:5(int) s:4(string)
  ├── group-by
- │    ├── columns: kv.s:string:null:4 column5:int:null:5
- │    ├── grouping columns: kv.s:string:null:4
+ │    ├── columns: kv.s:4(string) column5:5(int)
+ │    ├── grouping columns: kv.s:4(string)
  │    ├── project
- │    │    ├── columns: kv.s:string:null:4
+ │    │    ├── columns: kv.s:4(string)
  │    │    ├── scan
- │    │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
+ │    │    │    └── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string)
  │    │    └── projections [outer=(4)]
  │    │         └── variable: kv.s [type=string, outer=(4)]
  │    └── aggregations
@@ -409,14 +409,14 @@ build
 SELECT COUNT(*), s FROM t.kv GROUP BY s
 ----
 project
- ├── columns: column5:int:null:5 s:string:null:4
+ ├── columns: column5:5(int) s:4(string)
  ├── group-by
- │    ├── columns: kv.s:string:null:4 column5:int:null:5
- │    ├── grouping columns: kv.s:string:null:4
+ │    ├── columns: kv.s:4(string) column5:5(int)
+ │    ├── grouping columns: kv.s:4(string)
  │    ├── project
- │    │    ├── columns: kv.s:string:null:4
+ │    │    ├── columns: kv.s:4(string)
  │    │    ├── scan
- │    │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
+ │    │    │    └── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string)
  │    │    └── projections [outer=(4)]
  │    │         └── variable: kv.s [type=string, outer=(4)]
  │    └── aggregations
@@ -430,14 +430,14 @@ build
 SELECT v, COUNT(*), w FROM t.kv GROUP BY v, w
 ----
 project
- ├── columns: v:int:null:2 column5:int:null:5 w:int:null:3
+ ├── columns: v:2(int) column5:5(int) w:3(int)
  ├── group-by
- │    ├── columns: kv.v:int:null:2 kv.w:int:null:3 column5:int:null:5
- │    ├── grouping columns: kv.v:int:null:2 kv.w:int:null:3
+ │    ├── columns: kv.v:2(int) kv.w:3(int) column5:5(int)
+ │    ├── grouping columns: kv.v:2(int) kv.w:3(int)
  │    ├── project
- │    │    ├── columns: kv.v:int:null:2 kv.w:int:null:3
+ │    │    ├── columns: kv.v:2(int) kv.w:3(int)
  │    │    ├── scan
- │    │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
+ │    │    │    └── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string)
  │    │    └── projections [outer=(2,3)]
  │    │         ├── variable: kv.v [type=int, outer=(2)]
  │    │         └── variable: kv.w [type=int, outer=(3)]
@@ -453,14 +453,14 @@ build
 SELECT v, COUNT(*), w FROM t.kv GROUP BY 1, 3
 ----
 project
- ├── columns: v:int:null:2 column5:int:null:5 w:int:null:3
+ ├── columns: v:2(int) column5:5(int) w:3(int)
  ├── group-by
- │    ├── columns: kv.v:int:null:2 kv.w:int:null:3 column5:int:null:5
- │    ├── grouping columns: kv.v:int:null:2 kv.w:int:null:3
+ │    ├── columns: kv.v:2(int) kv.w:3(int) column5:5(int)
+ │    ├── grouping columns: kv.v:2(int) kv.w:3(int)
  │    ├── project
- │    │    ├── columns: kv.v:int:null:2 kv.w:int:null:3
+ │    │    ├── columns: kv.v:2(int) kv.w:3(int)
  │    │    ├── scan
- │    │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
+ │    │    │    └── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string)
  │    │    └── projections [outer=(2,3)]
  │    │         ├── variable: kv.v [type=int, outer=(2)]
  │    │         └── variable: kv.w [type=int, outer=(3)]
@@ -476,14 +476,14 @@ build
 SELECT COUNT(*), UPPER(s) FROM t.kv GROUP BY UPPER(s)
 ----
 project
- ├── columns: column6:int:null:6 column5:string:null:5
+ ├── columns: column6:6(int) column5:5(string)
  ├── group-by
- │    ├── columns: column5:string:null:5 column6:int:null:6
- │    ├── grouping columns: column5:string:null:5
+ │    ├── columns: column5:5(string) column6:6(int)
+ │    ├── grouping columns: column5:5(string)
  │    ├── project
- │    │    ├── columns: column5:string:null:5
+ │    │    ├── columns: column5:5(string)
  │    │    ├── scan
- │    │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
+ │    │    │    └── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string)
  │    │    └── projections [outer=(4)]
  │    │         └── function: upper [type=string, outer=(4)]
  │    │              └── variable: kv.s [type=string, outer=(4)]
@@ -498,14 +498,14 @@ build
 SELECT COUNT(*) FROM t.kv GROUP BY 1+2
 ----
 project
- ├── columns: column6:int:null:6
+ ├── columns: column6:6(int)
  ├── group-by
- │    ├── columns: column5:int:null:5 column6:int:null:6
- │    ├── grouping columns: column5:int:null:5
+ │    ├── columns: column5:5(int) column6:6(int)
+ │    ├── grouping columns: column5:5(int)
  │    ├── project
- │    │    ├── columns: column5:int:null:5
+ │    │    ├── columns: column5:5(int)
  │    │    ├── scan
- │    │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
+ │    │    │    └── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string)
  │    │    └── projections
  │    │         └── const: 3 [type=int]
  │    └── aggregations
@@ -517,14 +517,14 @@ build
 SELECT COUNT(*) FROM t.kv GROUP BY length('abc')
 ----
 project
- ├── columns: column6:int:null:6
+ ├── columns: column6:6(int)
  ├── group-by
- │    ├── columns: column5:int:null:5 column6:int:null:6
- │    ├── grouping columns: column5:int:null:5
+ │    ├── columns: column5:5(int) column6:6(int)
+ │    ├── grouping columns: column5:5(int)
  │    ├── project
- │    │    ├── columns: column5:int:null:5
+ │    │    ├── columns: column5:5(int)
  │    │    ├── scan
- │    │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
+ │    │    │    └── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string)
  │    │    └── projections
  │    │         └── function: length [type=int]
  │    │              └── const: 'abc' [type=string]
@@ -538,14 +538,14 @@ build
 SELECT COUNT(*), UPPER(s) FROM t.kv GROUP BY s
 ----
 project
- ├── columns: column5:int:null:5 column6:string:null:6
+ ├── columns: column5:5(int) column6:6(string)
  ├── group-by
- │    ├── columns: kv.s:string:null:4 column5:int:null:5
- │    ├── grouping columns: kv.s:string:null:4
+ │    ├── columns: kv.s:4(string) column5:5(int)
+ │    ├── grouping columns: kv.s:4(string)
  │    ├── project
- │    │    ├── columns: kv.s:string:null:4
+ │    │    ├── columns: kv.s:4(string)
  │    │    ├── scan
- │    │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
+ │    │    │    └── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string)
  │    │    └── projections [outer=(4)]
  │    │         └── variable: kv.s [type=string, outer=(4)]
  │    └── aggregations
@@ -566,14 +566,14 @@ build
 SELECT COUNT(*), k+v FROM t.kv GROUP BY k+v
 ----
 project
- ├── columns: column6:int:null:6 column5:int:null:5
+ ├── columns: column6:6(int) column5:5(int)
  ├── group-by
- │    ├── columns: column5:int:null:5 column6:int:null:6
- │    ├── grouping columns: column5:int:null:5
+ │    ├── columns: column5:5(int) column6:6(int)
+ │    ├── grouping columns: column5:5(int)
  │    ├── project
- │    │    ├── columns: column5:int:null:5
+ │    │    ├── columns: column5:5(int)
  │    │    ├── scan
- │    │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
+ │    │    │    └── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string)
  │    │    └── projections [outer=(1,2)]
  │    │         └── plus [type=int, outer=(1,2)]
  │    │              ├── variable: kv.k [type=int, outer=(1)]
@@ -590,14 +590,14 @@ build
 SELECT COUNT(*), k+v FROM t.kv GROUP BY k, v
 ----
 project
- ├── columns: column5:int:null:5 column6:int:null:6
+ ├── columns: column5:5(int) column6:6(int)
  ├── group-by
- │    ├── columns: kv.k:int:1 kv.v:int:null:2 column5:int:null:5
- │    ├── grouping columns: kv.k:int:1 kv.v:int:null:2
+ │    ├── columns: kv.k:1(int!null) kv.v:2(int) column5:5(int)
+ │    ├── grouping columns: kv.k:1(int!null) kv.v:2(int)
  │    ├── project
- │    │    ├── columns: kv.k:int:1 kv.v:int:null:2
+ │    │    ├── columns: kv.k:1(int!null) kv.v:2(int)
  │    │    ├── scan
- │    │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
+ │    │    │    └── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string)
  │    │    └── projections [outer=(1,2)]
  │    │         ├── variable: kv.k [type=int, outer=(1)]
  │    │         └── variable: kv.v [type=int, outer=(2)]
@@ -639,14 +639,14 @@ build
 SELECT count(kv.k) AS count_1, kv.v + kv.w AS lx FROM t.kv GROUP BY kv.v + kv.w
 ----
 project
- ├── columns: count_1:int:null:6 lx:int:null:5
+ ├── columns: count_1:6(int) lx:5(int)
  ├── group-by
- │    ├── columns: column5:int:null:5 count_1:int:null:6
- │    ├── grouping columns: column5:int:null:5
+ │    ├── columns: column5:5(int) count_1:6(int)
+ │    ├── grouping columns: column5:5(int)
  │    ├── project
- │    │    ├── columns: column5:int:null:5 kv.k:int:1
+ │    │    ├── columns: column5:5(int) kv.k:1(int!null)
  │    │    ├── scan
- │    │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
+ │    │    │    └── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string)
  │    │    └── projections [outer=(1-3)]
  │    │         ├── plus [type=int, outer=(2,3)]
  │    │         │    ├── variable: kv.v [type=int, outer=(2)]
@@ -663,7 +663,7 @@ build
 SELECT COUNT(*)
 ----
 group-by
- ├── columns: column1:int:null:1
+ ├── columns: column1:1(int)
  ├── values
  │    └── tuple [type=tuple{}]
  └── aggregations
@@ -673,11 +673,11 @@ build
 SELECT COUNT(k) from t.kv
 ----
 group-by
- ├── columns: column5:int:null:5
+ ├── columns: column5:5(int)
  ├── project
- │    ├── columns: kv.k:int:1
+ │    ├── columns: kv.k:1(int!null)
  │    ├── scan
- │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
+ │    │    └── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string)
  │    └── projections [outer=(1)]
  │         └── variable: kv.k [type=int, outer=(1)]
  └── aggregations [outer=(1)]
@@ -688,9 +688,9 @@ build
 SELECT COUNT(1)
 ----
 group-by
- ├── columns: column2:int:null:2
+ ├── columns: column2:2(int)
  ├── project
- │    ├── columns: column1:int:null:1
+ │    ├── columns: column1:1(int)
  │    ├── values
  │    │    └── tuple [type=tuple{}]
  │    └── projections
@@ -703,11 +703,11 @@ build
 SELECT COUNT(1) from t.kv
 ----
 group-by
- ├── columns: column6:int:null:6
+ ├── columns: column6:6(int)
  ├── project
- │    ├── columns: column5:int:null:5
+ │    ├── columns: column5:5(int)
  │    ├── scan
- │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
+ │    │    └── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string)
  │    └── projections
  │         └── const: 1 [type=int]
  └── aggregations [outer=(5)]
@@ -723,11 +723,11 @@ build
 SELECT COUNT(*), COUNT(k), COUNT(kv.v) FROM t.kv
 ----
 group-by
- ├── columns: column5:int:null:5 column6:int:null:6 column7:int:null:7
+ ├── columns: column5:5(int) column6:6(int) column7:7(int)
  ├── project
- │    ├── columns: kv.k:int:1 kv.v:int:null:2
+ │    ├── columns: kv.k:1(int!null) kv.v:2(int)
  │    ├── scan
- │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
+ │    │    └── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string)
  │    └── projections [outer=(1,2)]
  │         ├── variable: kv.k [type=int, outer=(1)]
  │         └── variable: kv.v [type=int, outer=(2)]
@@ -742,11 +742,11 @@ build
 SELECT COUNT(kv.*) FROM t.kv
 ----
 group-by
- ├── columns: column6:int:null:6
+ ├── columns: column6:6(int)
  ├── project
- │    ├── columns: column5:tuple{int, int, int, string}:null:5
+ │    ├── columns: column5:5(tuple{int, int, int, string})
  │    ├── scan
- │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
+ │    │    └── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string)
  │    └── projections [outer=(1-4)]
  │         └── tuple [type=tuple{int, int, int, string}, outer=(1-4)]
  │              ├── variable: kv.k [type=int, outer=(1)]
@@ -761,11 +761,11 @@ build
 SELECT COUNT((k, v)) FROM t.kv
 ----
 group-by
- ├── columns: column6:int:null:6
+ ├── columns: column6:6(int)
  ├── project
- │    ├── columns: column5:tuple{int, int}:null:5
+ │    ├── columns: column5:5(tuple{int, int})
  │    ├── scan
- │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
+ │    │    └── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string)
  │    └── projections [outer=(1,2)]
  │         └── tuple [type=tuple{int, int}, outer=(1,2)]
  │              ├── variable: kv.k [type=int, outer=(1)]
@@ -778,13 +778,13 @@ build
 SELECT COUNT(k)+COUNT(kv.v) FROM t.kv
 ----
 project
- ├── columns: column7:int:null:7
+ ├── columns: column7:7(int)
  ├── group-by
- │    ├── columns: column5:int:null:5 column6:int:null:6
+ │    ├── columns: column5:5(int) column6:6(int)
  │    ├── project
- │    │    ├── columns: kv.k:int:1 kv.v:int:null:2
+ │    │    ├── columns: kv.k:1(int!null) kv.v:2(int)
  │    │    ├── scan
- │    │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
+ │    │    │    └── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string)
  │    │    └── projections [outer=(1,2)]
  │    │         ├── variable: kv.k [type=int, outer=(1)]
  │    │         └── variable: kv.v [type=int, outer=(2)]
@@ -802,9 +802,9 @@ build
 SELECT COUNT(NULL::int), COUNT((NULL, NULL))
 ----
 group-by
- ├── columns: column2:int:null:2 column4:int:null:4
+ ├── columns: column2:2(int) column4:4(int)
  ├── project
- │    ├── columns: column1:int:null:1 column3:tuple{unknown, unknown}:null:3
+ │    ├── columns: column1:1(int) column3:3(tuple{unknown, unknown})
  │    ├── values
  │    │    └── tuple [type=tuple{}]
  │    └── projections
@@ -823,11 +823,11 @@ build
 SELECT MIN(k), MAX(k), MIN(v), MAX(v) FROM t.kv
 ----
 group-by
- ├── columns: column5:int:null:5 column6:int:null:6 column7:int:null:7 column8:int:null:8
+ ├── columns: column5:5(int) column6:6(int) column7:7(int) column8:8(int)
  ├── project
- │    ├── columns: kv.k:int:1 kv.k:int:1 kv.v:int:null:2 kv.v:int:null:2
+ │    ├── columns: kv.k:1(int!null) kv.k:1(int!null) kv.v:2(int) kv.v:2(int)
  │    ├── scan
- │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
+ │    │    └── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string)
  │    └── projections [outer=(1,2)]
  │         ├── variable: kv.k [type=int, outer=(1)]
  │         ├── variable: kv.k [type=int, outer=(1)]
@@ -847,13 +847,13 @@ build
 SELECT MIN(k), MAX(k), MIN(v), MAX(v) FROM t.kv WHERE k > 8
 ----
 group-by
- ├── columns: column5:int:null:5 column6:int:null:6 column7:int:null:7 column8:int:null:8
+ ├── columns: column5:5(int) column6:6(int) column7:7(int) column8:8(int)
  ├── project
- │    ├── columns: kv.k:int:1 kv.k:int:1 kv.v:int:null:2 kv.v:int:null:2
+ │    ├── columns: kv.k:1(int!null) kv.k:1(int!null) kv.v:2(int) kv.v:2(int)
  │    ├── select
- │    │    ├── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
+ │    │    ├── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string)
  │    │    ├── scan
- │    │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
+ │    │    │    └── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string)
  │    │    └── gt [type=bool, outer=(1)]
  │    │         ├── variable: kv.k [type=int, outer=(1)]
  │    │         └── const: 8 [type=int]
@@ -876,13 +876,13 @@ build
 SELECT array_agg(s) FROM t.kv WHERE s IS NULL
 ----
 group-by
- ├── columns: column5:string[]:null:5
+ ├── columns: column5:5(string[])
  ├── project
- │    ├── columns: kv.s:string:null:4
+ │    ├── columns: kv.s:4(string)
  │    ├── select
- │    │    ├── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
+ │    │    ├── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string)
  │    │    ├── scan
- │    │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
+ │    │    │    └── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string)
  │    │    └── is [type=bool, outer=(4)]
  │    │         ├── variable: kv.s [type=string, outer=(4)]
  │    │         └── null [type=unknown]
@@ -896,11 +896,11 @@ build
 SELECT AVG(k), AVG(v), SUM(k), SUM(v) FROM t.kv
 ----
 group-by
- ├── columns: column5:decimal:null:5 column6:decimal:null:6 column7:decimal:null:7 column8:decimal:null:8
+ ├── columns: column5:5(decimal) column6:6(decimal) column7:7(decimal) column8:8(decimal)
  ├── project
- │    ├── columns: kv.k:int:1 kv.v:int:null:2 kv.k:int:1 kv.v:int:null:2
+ │    ├── columns: kv.k:1(int!null) kv.v:2(int) kv.k:1(int!null) kv.v:2(int)
  │    ├── scan
- │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
+ │    │    └── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string)
  │    └── projections [outer=(1,2)]
  │         ├── variable: kv.k [type=int, outer=(1)]
  │         ├── variable: kv.v [type=int, outer=(2)]
@@ -920,11 +920,11 @@ build
 SELECT AVG(k::decimal), AVG(v::decimal), SUM(k::decimal), SUM(v::decimal) FROM kv
 ----
 group-by
- ├── columns: column6:decimal:null:6 column8:decimal:null:8 column10:decimal:null:10 column12:decimal:null:12
+ ├── columns: column6:6(decimal) column8:8(decimal) column10:10(decimal) column12:12(decimal)
  ├── project
- │    ├── columns: column5:decimal:null:5 column7:decimal:null:7 column9:decimal:null:9 column11:decimal:null:11
+ │    ├── columns: column5:5(decimal) column7:7(decimal) column9:9(decimal) column11:11(decimal)
  │    ├── scan
- │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
+ │    │    └── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string)
  │    └── projections [outer=(1,2)]
  │         ├── cast: decimal [type=decimal, outer=(1)]
  │         │    └── variable: kv.k [type=int, outer=(1)]
@@ -948,13 +948,13 @@ build
 SELECT AVG(k) * 2.0 + MAX(v)::DECIMAL FROM kv
 ----
 project
- ├── columns: column7:decimal:null:7
+ ├── columns: column7:7(decimal)
  ├── group-by
- │    ├── columns: column5:decimal:null:5 column6:int:null:6
+ │    ├── columns: column5:5(decimal) column6:6(int)
  │    ├── project
- │    │    ├── columns: kv.k:int:1 kv.v:int:null:2
+ │    │    ├── columns: kv.k:1(int!null) kv.v:2(int)
  │    │    ├── scan
- │    │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
+ │    │    │    └── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string)
  │    │    └── projections [outer=(1,2)]
  │    │         ├── variable: kv.k [type=int, outer=(1)]
  │    │         └── variable: kv.v [type=int, outer=(2)]
@@ -975,15 +975,15 @@ build
 SELECT AVG(k) * 2.0 + MAX(v)::DECIMAL FROM kv WHERE w*2 = k
 ----
 project
- ├── columns: column7:decimal:null:7
+ ├── columns: column7:7(decimal)
  ├── group-by
- │    ├── columns: column5:decimal:null:5 column6:int:null:6
+ │    ├── columns: column5:5(decimal) column6:6(int)
  │    ├── project
- │    │    ├── columns: kv.k:int:1 kv.v:int:null:2
+ │    │    ├── columns: kv.k:1(int!null) kv.v:2(int)
  │    │    ├── select
- │    │    │    ├── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
+ │    │    │    ├── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string)
  │    │    │    ├── scan
- │    │    │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
+ │    │    │    │    └── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string)
  │    │    │    └── eq [type=bool, outer=(1,3)]
  │    │    │         ├── mult [type=int, outer=(3)]
  │    │    │         │    ├── variable: kv.w [type=int, outer=(3)]
@@ -1025,9 +1025,9 @@ build
 SELECT MIN(a), MIN(b), MIN(c), MIN(d) FROM t.abc
 ----
 group-by
- ├── columns: column5:string:null:5 column6:float:null:6 column7:bool:null:7 column8:decimal:null:8
+ ├── columns: column5:5(string) column6:6(float) column7:7(bool) column8:8(decimal)
  ├── scan
- │    └── columns: abc.a:string:1 abc.b:float:null:2 abc.c:bool:null:3 abc.d:decimal:null:4
+ │    └── columns: abc.a:1(string!null) abc.b:2(float) abc.c:3(bool) abc.d:4(decimal)
  └── aggregations [outer=(1-4)]
       ├── function: min [type=string, outer=(1)]
       │    └── variable: abc.a [type=string, outer=(1)]
@@ -1042,9 +1042,9 @@ build
 SELECT MAX(a), MAX(b), MAX(c), MAX(d) FROM t.abc
 ----
 group-by
- ├── columns: column5:string:null:5 column6:float:null:6 column7:bool:null:7 column8:decimal:null:8
+ ├── columns: column5:5(string) column6:6(float) column7:7(bool) column8:8(decimal)
  ├── scan
- │    └── columns: abc.a:string:1 abc.b:float:null:2 abc.c:bool:null:3 abc.d:decimal:null:4
+ │    └── columns: abc.a:1(string!null) abc.b:2(float) abc.c:3(bool) abc.d:4(decimal)
  └── aggregations [outer=(1-4)]
       ├── function: max [type=string, outer=(1)]
       │    └── variable: abc.a [type=string, outer=(1)]
@@ -1059,11 +1059,11 @@ build
 SELECT AVG(b), SUM(b), AVG(d), SUM(d) FROM t.abc
 ----
 group-by
- ├── columns: column5:float:null:5 column6:float:null:6 column7:decimal:null:7 column8:decimal:null:8
+ ├── columns: column5:5(float) column6:6(float) column7:7(decimal) column8:8(decimal)
  ├── project
- │    ├── columns: abc.b:float:null:2 abc.b:float:null:2 abc.d:decimal:null:4 abc.d:decimal:null:4
+ │    ├── columns: abc.b:2(float) abc.b:2(float) abc.d:4(decimal) abc.d:4(decimal)
  │    ├── scan
- │    │    └── columns: abc.a:string:1 abc.b:float:null:2 abc.c:bool:null:3 abc.d:decimal:null:4
+ │    │    └── columns: abc.a:1(string!null) abc.b:2(float) abc.c:3(bool) abc.d:4(decimal)
  │    └── projections [outer=(2,4)]
  │         ├── variable: abc.b [type=float, outer=(2)]
  │         ├── variable: abc.b [type=float, outer=(2)]
@@ -1094,9 +1094,9 @@ build
 SELECT SUM(a) FROM t.intervals
 ----
 group-by
- ├── columns: column2:interval:null:2
+ ├── columns: column2:2(interval)
  ├── scan
- │    └── columns: intervals.a:interval:1
+ │    └── columns: intervals.a:1(interval!null)
  └── aggregations [outer=(1)]
       └── function: sum [type=interval, outer=(1)]
            └── variable: intervals.a [type=interval, outer=(1)]
@@ -1161,11 +1161,11 @@ build
 SELECT MIN(x) FROM t.xyz
 ----
 group-by
- ├── columns: column4:int:null:4
+ ├── columns: column4:4(int)
  ├── project
- │    ├── columns: xyz.x:int:1
+ │    ├── columns: xyz.x:1(int!null)
  │    ├── scan
- │    │    └── columns: xyz.x:int:1 xyz.y:int:null:2 xyz.z:float:null:3
+ │    │    └── columns: xyz.x:1(int!null) xyz.y:2(int) xyz.z:3(float)
  │    └── projections [outer=(1)]
  │         └── variable: xyz.x [type=int, outer=(1)]
  └── aggregations [outer=(1)]
@@ -1176,13 +1176,13 @@ build
 SELECT MIN(x) FROM t.xyz WHERE x in (0, 4, 7)
 ----
 group-by
- ├── columns: column4:int:null:4
+ ├── columns: column4:4(int)
  ├── project
- │    ├── columns: xyz.x:int:1
+ │    ├── columns: xyz.x:1(int!null)
  │    ├── select
- │    │    ├── columns: xyz.x:int:1 xyz.y:int:null:2 xyz.z:float:null:3
+ │    │    ├── columns: xyz.x:1(int!null) xyz.y:2(int) xyz.z:3(float)
  │    │    ├── scan
- │    │    │    └── columns: xyz.x:int:1 xyz.y:int:null:2 xyz.z:float:null:3
+ │    │    │    └── columns: xyz.x:1(int!null) xyz.y:2(int) xyz.z:3(float)
  │    │    └── in [type=bool, outer=(1)]
  │    │         ├── variable: xyz.x [type=int, outer=(1)]
  │    │         └── tuple [type=tuple{int, int, int}]
@@ -1199,11 +1199,11 @@ build
 SELECT MAX(x) FROM t.xyz
 ----
 group-by
- ├── columns: column4:int:null:4
+ ├── columns: column4:4(int)
  ├── project
- │    ├── columns: xyz.x:int:1
+ │    ├── columns: xyz.x:1(int!null)
  │    ├── scan
- │    │    └── columns: xyz.x:int:1 xyz.y:int:null:2 xyz.z:float:null:3
+ │    │    └── columns: xyz.x:1(int!null) xyz.y:2(int) xyz.z:3(float)
  │    └── projections [outer=(1)]
  │         └── variable: xyz.x [type=int, outer=(1)]
  └── aggregations [outer=(1)]
@@ -1214,13 +1214,13 @@ build
 SELECT MAX(y) FROM t.xyz WHERE x = 1
 ----
 group-by
- ├── columns: column4:int:null:4
+ ├── columns: column4:4(int)
  ├── project
- │    ├── columns: xyz.y:int:null:2
+ │    ├── columns: xyz.y:2(int)
  │    ├── select
- │    │    ├── columns: xyz.x:int:1 xyz.y:int:null:2 xyz.z:float:null:3
+ │    │    ├── columns: xyz.x:1(int!null) xyz.y:2(int) xyz.z:3(float)
  │    │    ├── scan
- │    │    │    └── columns: xyz.x:int:1 xyz.y:int:null:2 xyz.z:float:null:3
+ │    │    │    └── columns: xyz.x:1(int!null) xyz.y:2(int) xyz.z:3(float)
  │    │    └── eq [type=bool, outer=(1)]
  │    │         ├── variable: xyz.x [type=int, outer=(1)]
  │    │         └── const: 1 [type=int]
@@ -1234,13 +1234,13 @@ build
 SELECT MIN(y) FROM t.xyz WHERE x = 7
 ----
 group-by
- ├── columns: column4:int:null:4
+ ├── columns: column4:4(int)
  ├── project
- │    ├── columns: xyz.y:int:null:2
+ │    ├── columns: xyz.y:2(int)
  │    ├── select
- │    │    ├── columns: xyz.x:int:1 xyz.y:int:null:2 xyz.z:float:null:3
+ │    │    ├── columns: xyz.x:1(int!null) xyz.y:2(int) xyz.z:3(float)
  │    │    ├── scan
- │    │    │    └── columns: xyz.x:int:1 xyz.y:int:null:2 xyz.z:float:null:3
+ │    │    │    └── columns: xyz.x:1(int!null) xyz.y:2(int) xyz.z:3(float)
  │    │    └── eq [type=bool, outer=(1)]
  │    │         ├── variable: xyz.x [type=int, outer=(1)]
  │    │         └── const: 7 [type=int]
@@ -1254,13 +1254,13 @@ build
 SELECT MIN(x) FROM t.xyz WHERE (y, z) = (2, 3.0)
 ----
 group-by
- ├── columns: column4:int:null:4
+ ├── columns: column4:4(int)
  ├── project
- │    ├── columns: xyz.x:int:1
+ │    ├── columns: xyz.x:1(int!null)
  │    ├── select
- │    │    ├── columns: xyz.x:int:1 xyz.y:int:null:2 xyz.z:float:null:3
+ │    │    ├── columns: xyz.x:1(int!null) xyz.y:2(int) xyz.z:3(float)
  │    │    ├── scan
- │    │    │    └── columns: xyz.x:int:1 xyz.y:int:null:2 xyz.z:float:null:3
+ │    │    │    └── columns: xyz.x:1(int!null) xyz.y:2(int) xyz.z:3(float)
  │    │    └── eq [type=bool, outer=(2,3)]
  │    │         ├── tuple [type=tuple{int, float}, outer=(2,3)]
  │    │         │    ├── variable: xyz.y [type=int, outer=(2)]
@@ -1278,13 +1278,13 @@ build
 SELECT MAX(x) FROM t.xyz WHERE (z, y) = (3.0, 2)
 ----
 group-by
- ├── columns: column4:int:null:4
+ ├── columns: column4:4(int)
  ├── project
- │    ├── columns: xyz.x:int:1
+ │    ├── columns: xyz.x:1(int!null)
  │    ├── select
- │    │    ├── columns: xyz.x:int:1 xyz.y:int:null:2 xyz.z:float:null:3
+ │    │    ├── columns: xyz.x:1(int!null) xyz.y:2(int) xyz.z:3(float)
  │    │    ├── scan
- │    │    │    └── columns: xyz.x:int:1 xyz.y:int:null:2 xyz.z:float:null:3
+ │    │    │    └── columns: xyz.x:1(int!null) xyz.y:2(int) xyz.z:3(float)
  │    │    └── eq [type=bool, outer=(2,3)]
  │    │         ├── tuple [type=tuple{float, int}, outer=(2,3)]
  │    │         │    ├── variable: xyz.z [type=float, outer=(3)]
@@ -1305,13 +1305,13 @@ build
 SELECT VARIANCE(x), VARIANCE(y::decimal), round(VARIANCE(z), 14) FROM xyz
 ----
 project
- ├── columns: column4:decimal:null:4 column6:decimal:null:6 column8:float:null:8
+ ├── columns: column4:4(decimal) column6:6(decimal) column8:8(float)
  ├── group-by
- │    ├── columns: column4:decimal:null:4 column6:decimal:null:6 column7:float:null:7
+ │    ├── columns: column4:4(decimal) column6:6(decimal) column7:7(float)
  │    ├── project
- │    │    ├── columns: xyz.x:int:1 column5:decimal:null:5 xyz.z:float:null:3
+ │    │    ├── columns: xyz.x:1(int!null) column5:5(decimal) xyz.z:3(float)
  │    │    ├── scan
- │    │    │    └── columns: xyz.x:int:1 xyz.y:int:null:2 xyz.z:float:null:3
+ │    │    │    └── columns: xyz.x:1(int!null) xyz.y:2(int) xyz.z:3(float)
  │    │    └── projections [outer=(1-3)]
  │    │         ├── variable: xyz.x [type=int, outer=(1)]
  │    │         ├── cast: decimal [type=decimal, outer=(2)]
@@ -1335,13 +1335,13 @@ build
 SELECT VARIANCE(x) FROM t.xyz WHERE x = 10
 ----
 group-by
- ├── columns: column4:decimal:null:4
+ ├── columns: column4:4(decimal)
  ├── project
- │    ├── columns: xyz.x:int:1
+ │    ├── columns: xyz.x:1(int!null)
  │    ├── select
- │    │    ├── columns: xyz.x:int:1 xyz.y:int:null:2 xyz.z:float:null:3
+ │    │    ├── columns: xyz.x:1(int!null) xyz.y:2(int) xyz.z:3(float)
  │    │    ├── scan
- │    │    │    └── columns: xyz.x:int:1 xyz.y:int:null:2 xyz.z:float:null:3
+ │    │    │    └── columns: xyz.x:1(int!null) xyz.y:2(int) xyz.z:3(float)
  │    │    └── eq [type=bool, outer=(1)]
  │    │         ├── variable: xyz.x [type=int, outer=(1)]
  │    │         └── const: 10 [type=int]
@@ -1355,13 +1355,13 @@ build
 SELECT STDDEV(x), STDDEV(y::decimal), round(STDDEV(z), 14) FROM xyz
 ----
 project
- ├── columns: column4:decimal:null:4 column6:decimal:null:6 column8:float:null:8
+ ├── columns: column4:4(decimal) column6:6(decimal) column8:8(float)
  ├── group-by
- │    ├── columns: column4:decimal:null:4 column6:decimal:null:6 column7:float:null:7
+ │    ├── columns: column4:4(decimal) column6:6(decimal) column7:7(float)
  │    ├── project
- │    │    ├── columns: xyz.x:int:1 column5:decimal:null:5 xyz.z:float:null:3
+ │    │    ├── columns: xyz.x:1(int!null) column5:5(decimal) xyz.z:3(float)
  │    │    ├── scan
- │    │    │    └── columns: xyz.x:int:1 xyz.y:int:null:2 xyz.z:float:null:3
+ │    │    │    └── columns: xyz.x:1(int!null) xyz.y:2(int) xyz.z:3(float)
  │    │    └── projections [outer=(1-3)]
  │    │         ├── variable: xyz.x [type=int, outer=(1)]
  │    │         ├── cast: decimal [type=decimal, outer=(2)]
@@ -1385,13 +1385,13 @@ build
 SELECT STDDEV(x) FROM t.xyz WHERE x = 1
 ----
 group-by
- ├── columns: column4:decimal:null:4
+ ├── columns: column4:4(decimal)
  ├── project
- │    ├── columns: xyz.x:int:1
+ │    ├── columns: xyz.x:1(int!null)
  │    ├── select
- │    │    ├── columns: xyz.x:int:1 xyz.y:int:null:2 xyz.z:float:null:3
+ │    │    ├── columns: xyz.x:1(int!null) xyz.y:2(int) xyz.z:3(float)
  │    │    ├── scan
- │    │    │    └── columns: xyz.x:int:1 xyz.y:int:null:2 xyz.z:float:null:3
+ │    │    │    └── columns: xyz.x:1(int!null) xyz.y:2(int) xyz.z:3(float)
  │    │    └── eq [type=bool, outer=(1)]
  │    │         ├── variable: xyz.x [type=int, outer=(1)]
  │    │         └── const: 1 [type=int]
@@ -1405,11 +1405,11 @@ build
 SELECT AVG(1::int)::float, AVG(2::float)::float, AVG(3::decimal)::float
 ----
 project
- ├── columns: column3:float:null:3 column6:float:null:6 column9:float:null:9
+ ├── columns: column3:3(float) column6:6(float) column9:9(float)
  ├── group-by
- │    ├── columns: column2:decimal:null:2 column5:float:null:5 column8:decimal:null:8
+ │    ├── columns: column2:2(decimal) column5:5(float) column8:8(decimal)
  │    ├── project
- │    │    ├── columns: column1:int:null:1 column4:float:null:4 column7:decimal:null:7
+ │    │    ├── columns: column1:1(int) column4:4(float) column7:7(decimal)
  │    │    ├── values
  │    │    │    └── tuple [type=tuple{}]
  │    │    └── projections
@@ -1438,9 +1438,9 @@ build
 SELECT COUNT(2::int), COUNT(3::float), COUNT(4::decimal)
 ----
 group-by
- ├── columns: column2:int:null:2 column4:int:null:4 column6:int:null:6
+ ├── columns: column2:2(int) column4:4(int) column6:6(int)
  ├── project
- │    ├── columns: column1:int:null:1 column3:float:null:3 column5:decimal:null:5
+ │    ├── columns: column1:1(int) column3:3(float) column5:5(decimal)
  │    ├── values
  │    │    └── tuple [type=tuple{}]
  │    └── projections
@@ -1462,9 +1462,9 @@ build
 SELECT SUM(1::int), SUM(2::float), SUM(3::decimal)
 ----
 group-by
- ├── columns: column2:decimal:null:2 column4:float:null:4 column6:decimal:null:6
+ ├── columns: column2:2(decimal) column4:4(float) column6:6(decimal)
  ├── project
- │    ├── columns: column1:int:null:1 column3:float:null:3 column5:decimal:null:5
+ │    ├── columns: column1:1(int) column3:3(float) column5:5(decimal)
  │    ├── values
  │    │    └── tuple [type=tuple{}]
  │    └── projections
@@ -1486,9 +1486,9 @@ build
 SELECT VARIANCE(1::int), VARIANCE(1::float), VARIANCE(1::decimal)
 ----
 group-by
- ├── columns: column2:decimal:null:2 column4:float:null:4 column6:decimal:null:6
+ ├── columns: column2:2(decimal) column4:4(float) column6:6(decimal)
  ├── project
- │    ├── columns: column1:int:null:1 column3:float:null:3 column5:decimal:null:5
+ │    ├── columns: column1:1(int) column3:3(float) column5:5(decimal)
  │    ├── values
  │    │    └── tuple [type=tuple{}]
  │    └── projections
@@ -1510,9 +1510,9 @@ build
 SELECT STDDEV(1::int), STDDEV(1::float), STDDEV(1::decimal)
 ----
 group-by
- ├── columns: column2:decimal:null:2 column4:float:null:4 column6:decimal:null:6
+ ├── columns: column2:2(decimal) column4:4(float) column6:6(decimal)
  ├── project
- │    ├── columns: column1:int:null:1 column3:float:null:3 column5:decimal:null:5
+ │    ├── columns: column1:1(int) column3:3(float) column5:5(decimal)
  │    ├── values
  │    │    └── tuple [type=tuple{}]
  │    └── projections
@@ -1543,11 +1543,11 @@ build
 SELECT BOOL_AND(b), BOOL_OR(b) FROM t.bools
 ----
 group-by
- ├── columns: column3:bool:null:3 column4:bool:null:4
+ ├── columns: column3:3(bool) column4:4(bool)
  ├── project
- │    ├── columns: bools.b:bool:null:1 bools.b:bool:null:1
+ │    ├── columns: bools.b:1(bool) bools.b:1(bool)
  │    ├── scan
- │    │    └── columns: bools.b:bool:null:1 bools.rowid:int:2
+ │    │    └── columns: bools.b:1(bool) bools.rowid:2(int!null)
  │    └── projections [outer=(1)]
  │         ├── variable: bools.b [type=bool, outer=(1)]
  │         └── variable: bools.b [type=bool, outer=(1)]
@@ -1563,12 +1563,12 @@ build
 SELECT 1 FROM t.kv GROUP BY kv.*;
 ----
 project
- ├── columns: column5:int:null:5
+ ├── columns: column5:5(int)
  ├── group-by
- │    ├── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
- │    ├── grouping columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
+ │    ├── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string)
+ │    ├── grouping columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string)
  │    ├── scan
- │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
+ │    │    └── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string)
  │    └── aggregations
  └── projections
       └── const: 1 [type=int]
@@ -1588,13 +1588,13 @@ build
 SELECT TO_HEX(XOR_AGG(a)), XOR_AGG(c) FROM t.xor_bytes
 ----
 project
- ├── columns: column6:string:null:6 column7:int:null:7
+ ├── columns: column6:6(string) column7:7(int)
  ├── group-by
- │    ├── columns: column5:bytes:null:5 column7:int:null:7
+ │    ├── columns: column5:5(bytes) column7:7(int)
  │    ├── project
- │    │    ├── columns: xor_bytes.a:bytes:null:1 xor_bytes.c:int:null:3
+ │    │    ├── columns: xor_bytes.a:1(bytes) xor_bytes.c:3(int)
  │    │    ├── scan
- │    │    │    └── columns: xor_bytes.a:bytes:null:1 xor_bytes.b:int:null:2 xor_bytes.c:int:null:3 xor_bytes.rowid:int:4
+ │    │    │    └── columns: xor_bytes.a:1(bytes) xor_bytes.b:2(int) xor_bytes.c:3(int) xor_bytes.rowid:4(int!null)
  │    │    └── projections [outer=(1,3)]
  │    │         ├── variable: xor_bytes.a [type=bytes, outer=(1)]
  │    │         └── variable: xor_bytes.c [type=int, outer=(3)]
@@ -1612,9 +1612,9 @@ build
 SELECT MAX(true), MIN(true)
 ----
 group-by
- ├── columns: column2:bool:null:2 column4:bool:null:4
+ ├── columns: column2:2(bool) column4:4(bool)
  ├── project
- │    ├── columns: column1:bool:null:1 column3:bool:null:3
+ │    ├── columns: column1:1(bool) column3:3(bool)
  │    ├── values
  │    │    └── tuple [type=tuple{}]
  │    └── projections
@@ -1655,14 +1655,14 @@ build
 SELECT (b, a) FROM t.ab GROUP BY (b, a)
 ----
 project
- ├── columns: column3:tuple{int, int}:null:3
+ ├── columns: column3:3(tuple{int, int})
  ├── group-by
- │    ├── columns: ab.a:int:1 ab.b:int:null:2
- │    ├── grouping columns: ab.a:int:1 ab.b:int:null:2
+ │    ├── columns: ab.a:1(int!null) ab.b:2(int)
+ │    ├── grouping columns: ab.a:1(int!null) ab.b:2(int)
  │    ├── project
- │    │    ├── columns: ab.b:int:null:2 ab.a:int:1
+ │    │    ├── columns: ab.b:2(int) ab.a:1(int!null)
  │    │    ├── scan
- │    │    │    └── columns: ab.a:int:1 ab.b:int:null:2
+ │    │    │    └── columns: ab.a:1(int!null) ab.b:2(int)
  │    │    └── projections [outer=(1,2)]
  │    │         ├── variable: ab.b [type=int, outer=(2)]
  │    │         └── variable: ab.a [type=int, outer=(1)]
@@ -1677,18 +1677,18 @@ SELECT MIN(y), (b, a)
  FROM t.ab, t.xy GROUP BY (x, (a, b))
 ----
 project
- ├── columns: column6:string:null:6 column7:tuple{int, int}:null:7
+ ├── columns: column6:6(string) column7:7(tuple{int, int})
  ├── group-by
- │    ├── columns: ab.a:int:1 ab.b:int:null:2 xy.x:string:null:3 column6:string:null:6
- │    ├── grouping columns: ab.a:int:1 ab.b:int:null:2 xy.x:string:null:3
+ │    ├── columns: ab.a:1(int!null) ab.b:2(int) xy.x:3(string) column6:6(string)
+ │    ├── grouping columns: ab.a:1(int!null) ab.b:2(int) xy.x:3(string)
  │    ├── project
- │    │    ├── columns: xy.x:string:null:3 ab.a:int:1 ab.b:int:null:2 xy.y:string:null:4
+ │    │    ├── columns: xy.x:3(string) ab.a:1(int!null) ab.b:2(int) xy.y:4(string)
  │    │    ├── inner-join
- │    │    │    ├── columns: ab.a:int:1 ab.b:int:null:2 xy.x:string:null:3 xy.y:string:null:4 xy.rowid:int:5
+ │    │    │    ├── columns: ab.a:1(int!null) ab.b:2(int) xy.x:3(string) xy.y:4(string) xy.rowid:5(int!null)
  │    │    │    ├── scan
- │    │    │    │    └── columns: ab.a:int:1 ab.b:int:null:2
+ │    │    │    │    └── columns: ab.a:1(int!null) ab.b:2(int)
  │    │    │    ├── scan
- │    │    │    │    └── columns: xy.x:string:null:3 xy.y:string:null:4 xy.rowid:int:5
+ │    │    │    │    └── columns: xy.x:3(string) xy.y:4(string) xy.rowid:5(int!null)
  │    │    │    └── true [type=bool]
  │    │    └── projections [outer=(1-4)]
  │    │         ├── variable: xy.x [type=string, outer=(3)]
@@ -1708,14 +1708,14 @@ build
 SELECT (k+v)/(v+w) FROM t.kv GROUP BY k+v, v+w;
 ----
 project
- ├── columns: column7:decimal:null:7
+ ├── columns: column7:7(decimal)
  ├── group-by
- │    ├── columns: column5:int:null:5 column6:int:null:6
- │    ├── grouping columns: column5:int:null:5 column6:int:null:6
+ │    ├── columns: column5:5(int) column6:6(int)
+ │    ├── grouping columns: column5:5(int) column6:6(int)
  │    ├── project
- │    │    ├── columns: column5:int:null:5 column6:int:null:6
+ │    │    ├── columns: column5:5(int) column6:6(int)
  │    │    ├── scan
- │    │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
+ │    │    │    └── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string)
  │    │    └── projections [outer=(1-3)]
  │    │         ├── plus [type=int, outer=(1,2)]
  │    │         │    ├── variable: kv.k [type=int, outer=(1)]
@@ -1738,14 +1738,14 @@ build
 SELECT SUM(t.kv.w), t.kv.v FROM t.kv GROUP BY v, kv.k * w
 ----
 project
- ├── columns: column6:decimal:null:6 v:int:null:2
+ ├── columns: column6:6(decimal) v:2(int)
  ├── group-by
- │    ├── columns: kv.v:int:null:2 column5:int:null:5 column6:decimal:null:6
- │    ├── grouping columns: kv.v:int:null:2 column5:int:null:5
+ │    ├── columns: kv.v:2(int) column5:5(int) column6:6(decimal)
+ │    ├── grouping columns: kv.v:2(int) column5:5(int)
  │    ├── project
- │    │    ├── columns: kv.v:int:null:2 column5:int:null:5 kv.w:int:null:3
+ │    │    ├── columns: kv.v:2(int) column5:5(int) kv.w:3(int)
  │    │    ├── scan
- │    │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
+ │    │    │    └── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string)
  │    │    └── projections [outer=(1-3)]
  │    │         ├── variable: kv.v [type=int, outer=(2)]
  │    │         ├── mult [type=int, outer=(1,3)]
@@ -1763,14 +1763,14 @@ build
 SELECT SUM(t.kv.w), LOWER(s), t.kv.v + k * t.kv.w, t.kv.v FROM t.kv GROUP BY v, LOWER(kv.s), kv.k * w
 ----
 project
- ├── columns: column7:decimal:null:7 column5:string:null:5 column8:int:null:8 v:int:null:2
+ ├── columns: column7:7(decimal) column5:5(string) column8:8(int) v:2(int)
  ├── group-by
- │    ├── columns: kv.v:int:null:2 column5:string:null:5 column6:int:null:6 column7:decimal:null:7
- │    ├── grouping columns: kv.v:int:null:2 column5:string:null:5 column6:int:null:6
+ │    ├── columns: kv.v:2(int) column5:5(string) column6:6(int) column7:7(decimal)
+ │    ├── grouping columns: kv.v:2(int) column5:5(string) column6:6(int)
  │    ├── project
- │    │    ├── columns: kv.v:int:null:2 column5:string:null:5 column6:int:null:6 kv.w:int:null:3
+ │    │    ├── columns: kv.v:2(int) column5:5(string) column6:6(int) kv.w:3(int)
  │    │    ├── scan
- │    │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
+ │    │    │    └── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string)
  │    │    └── projections [outer=(1-4)]
  │    │         ├── variable: kv.v [type=int, outer=(2)]
  │    │         ├── function: lower [type=string, outer=(4)]
@@ -1797,23 +1797,23 @@ build
 SELECT b1.b AND abc.c AND b2.b FROM bools b1, bools b2, abc GROUP BY b1.b AND abc.c, b2.b
 ----
 project
- ├── columns: column10:bool:null:10
+ ├── columns: column10:10(bool)
  ├── group-by
- │    ├── columns: bools.b:bool:null:3 column9:bool:null:9
- │    ├── grouping columns: bools.b:bool:null:3 column9:bool:null:9
+ │    ├── columns: bools.b:3(bool) column9:9(bool)
+ │    ├── grouping columns: bools.b:3(bool) column9:9(bool)
  │    ├── project
- │    │    ├── columns: column9:bool:null:9 bools.b:bool:null:3
+ │    │    ├── columns: column9:9(bool) bools.b:3(bool)
  │    │    ├── inner-join
- │    │    │    ├── columns: bools.b:bool:null:1 bools.rowid:int:2 bools.b:bool:null:3 bools.rowid:int:4 abc.a:string:5 abc.b:float:null:6 abc.c:bool:null:7 abc.d:decimal:null:8
+ │    │    │    ├── columns: bools.b:1(bool) bools.rowid:2(int!null) bools.b:3(bool) bools.rowid:4(int!null) abc.a:5(string!null) abc.b:6(float) abc.c:7(bool) abc.d:8(decimal)
  │    │    │    ├── inner-join
- │    │    │    │    ├── columns: bools.b:bool:null:1 bools.rowid:int:2 bools.b:bool:null:3 bools.rowid:int:4
+ │    │    │    │    ├── columns: bools.b:1(bool) bools.rowid:2(int!null) bools.b:3(bool) bools.rowid:4(int!null)
  │    │    │    │    ├── scan
- │    │    │    │    │    └── columns: bools.b:bool:null:1 bools.rowid:int:2
+ │    │    │    │    │    └── columns: bools.b:1(bool) bools.rowid:2(int!null)
  │    │    │    │    ├── scan
- │    │    │    │    │    └── columns: bools.b:bool:null:3 bools.rowid:int:4
+ │    │    │    │    │    └── columns: bools.b:3(bool) bools.rowid:4(int!null)
  │    │    │    │    └── true [type=bool]
  │    │    │    ├── scan
- │    │    │    │    └── columns: abc.a:string:5 abc.b:float:null:6 abc.c:bool:null:7 abc.d:decimal:null:8
+ │    │    │    │    └── columns: abc.a:5(string!null) abc.b:6(float) abc.c:7(bool) abc.d:8(decimal)
  │    │    │    └── true [type=bool]
  │    │    └── projections [outer=(1,3,7)]
  │    │         ├── and [type=bool, outer=(1,7)]
@@ -1837,23 +1837,23 @@ build
 SELECT b1.b OR abc.c OR b2.b FROM bools b1, bools b2, abc GROUP BY b1.b OR abc.c, b2.b
 ----
 project
- ├── columns: column10:bool:null:10
+ ├── columns: column10:10(bool)
  ├── group-by
- │    ├── columns: bools.b:bool:null:3 column9:bool:null:9
- │    ├── grouping columns: bools.b:bool:null:3 column9:bool:null:9
+ │    ├── columns: bools.b:3(bool) column9:9(bool)
+ │    ├── grouping columns: bools.b:3(bool) column9:9(bool)
  │    ├── project
- │    │    ├── columns: column9:bool:null:9 bools.b:bool:null:3
+ │    │    ├── columns: column9:9(bool) bools.b:3(bool)
  │    │    ├── inner-join
- │    │    │    ├── columns: bools.b:bool:null:1 bools.rowid:int:2 bools.b:bool:null:3 bools.rowid:int:4 abc.a:string:5 abc.b:float:null:6 abc.c:bool:null:7 abc.d:decimal:null:8
+ │    │    │    ├── columns: bools.b:1(bool) bools.rowid:2(int!null) bools.b:3(bool) bools.rowid:4(int!null) abc.a:5(string!null) abc.b:6(float) abc.c:7(bool) abc.d:8(decimal)
  │    │    │    ├── inner-join
- │    │    │    │    ├── columns: bools.b:bool:null:1 bools.rowid:int:2 bools.b:bool:null:3 bools.rowid:int:4
+ │    │    │    │    ├── columns: bools.b:1(bool) bools.rowid:2(int!null) bools.b:3(bool) bools.rowid:4(int!null)
  │    │    │    │    ├── scan
- │    │    │    │    │    └── columns: bools.b:bool:null:1 bools.rowid:int:2
+ │    │    │    │    │    └── columns: bools.b:1(bool) bools.rowid:2(int!null)
  │    │    │    │    ├── scan
- │    │    │    │    │    └── columns: bools.b:bool:null:3 bools.rowid:int:4
+ │    │    │    │    │    └── columns: bools.b:3(bool) bools.rowid:4(int!null)
  │    │    │    │    └── true [type=bool]
  │    │    │    ├── scan
- │    │    │    │    └── columns: abc.a:string:5 abc.b:float:null:6 abc.c:bool:null:7 abc.d:decimal:null:8
+ │    │    │    │    └── columns: abc.a:5(string!null) abc.b:6(float) abc.c:7(bool) abc.d:8(decimal)
  │    │    │    └── true [type=bool]
  │    │    └── projections [outer=(1,3,7)]
  │    │         ├── or [type=bool, outer=(1,7)]
@@ -1877,14 +1877,14 @@ build
 SELECT k % w % v FROM kv GROUP BY k % w, v
 ----
 project
- ├── columns: column6:int:null:6
+ ├── columns: column6:6(int)
  ├── group-by
- │    ├── columns: kv.v:int:null:2 column5:int:null:5
- │    ├── grouping columns: kv.v:int:null:2 column5:int:null:5
+ │    ├── columns: kv.v:2(int) column5:5(int)
+ │    ├── grouping columns: kv.v:2(int) column5:5(int)
  │    ├── project
- │    │    ├── columns: column5:int:null:5 kv.v:int:null:2
+ │    │    ├── columns: column5:5(int) kv.v:2(int)
  │    │    ├── scan
- │    │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
+ │    │    │    └── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string)
  │    │    └── projections [outer=(1-3)]
  │    │         ├── mod [type=int, outer=(1,3)]
  │    │         │    ├── variable: kv.k [type=int, outer=(1)]
@@ -1902,18 +1902,18 @@ build
 SELECT CONCAT(CONCAT(s, a), a) FROM kv, abc GROUP BY CONCAT(s, a), a
 ----
 project
- ├── columns: column10:string:null:10
+ ├── columns: column10:10(string)
  ├── group-by
- │    ├── columns: abc.a:string:5 column9:string:null:9
- │    ├── grouping columns: abc.a:string:5 column9:string:null:9
+ │    ├── columns: abc.a:5(string!null) column9:9(string)
+ │    ├── grouping columns: abc.a:5(string!null) column9:9(string)
  │    ├── project
- │    │    ├── columns: column9:string:null:9 abc.a:string:5
+ │    │    ├── columns: column9:9(string) abc.a:5(string!null)
  │    │    ├── inner-join
- │    │    │    ├── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4 abc.a:string:5 abc.b:float:null:6 abc.c:bool:null:7 abc.d:decimal:null:8
+ │    │    │    ├── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string) abc.a:5(string!null) abc.b:6(float) abc.c:7(bool) abc.d:8(decimal)
  │    │    │    ├── scan
- │    │    │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
+ │    │    │    │    └── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string)
  │    │    │    ├── scan
- │    │    │    │    └── columns: abc.a:string:5 abc.b:float:null:6 abc.c:bool:null:7 abc.d:decimal:null:8
+ │    │    │    │    └── columns: abc.a:5(string!null) abc.b:6(float) abc.c:7(bool) abc.d:8(decimal)
  │    │    │    └── true [type=bool]
  │    │    └── projections [outer=(4,5)]
  │    │         ├── function: concat [type=string, outer=(4,5)]
@@ -1937,14 +1937,14 @@ build
 SELECT k < w AND v != 5 FROM kv GROUP BY k < w, v
 ----
 project
- ├── columns: column6:bool:null:6
+ ├── columns: column6:6(bool)
  ├── group-by
- │    ├── columns: kv.v:int:null:2 column5:bool:null:5
- │    ├── grouping columns: kv.v:int:null:2 column5:bool:null:5
+ │    ├── columns: kv.v:2(int) column5:5(bool)
+ │    ├── grouping columns: kv.v:2(int) column5:5(bool)
  │    ├── project
- │    │    ├── columns: column5:bool:null:5 kv.v:int:null:2
+ │    │    ├── columns: column5:5(bool) kv.v:2(int)
  │    │    ├── scan
- │    │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
+ │    │    │    └── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string)
  │    │    └── projections [outer=(1-3)]
  │    │         ├── lt [type=bool, outer=(1,3)]
  │    │         │    ├── variable: kv.k [type=int, outer=(1)]
@@ -1979,18 +1979,18 @@ build
 SELECT a.bar @> b.baz AND b.baz @> b.baz FROM foo AS a, foo AS b GROUP BY a.bar @> b.baz, b.baz
 ----
 project
- ├── columns: column8:bool:null:8
+ ├── columns: column8:8(bool)
  ├── group-by
- │    ├── columns: foo.baz:jsonb:null:5 column7:bool:null:7
- │    ├── grouping columns: foo.baz:jsonb:null:5 column7:bool:null:7
+ │    ├── columns: foo.baz:5(jsonb) column7:7(bool)
+ │    ├── grouping columns: foo.baz:5(jsonb) column7:7(bool)
  │    ├── project
- │    │    ├── columns: column7:bool:null:7 foo.baz:jsonb:null:5
+ │    │    ├── columns: column7:7(bool) foo.baz:5(jsonb)
  │    │    ├── inner-join
- │    │    │    ├── columns: foo.bar:jsonb:null:1 foo.baz:jsonb:null:2 foo.rowid:int:3 foo.bar:jsonb:null:4 foo.baz:jsonb:null:5 foo.rowid:int:6
+ │    │    │    ├── columns: foo.bar:1(jsonb) foo.baz:2(jsonb) foo.rowid:3(int!null) foo.bar:4(jsonb) foo.baz:5(jsonb) foo.rowid:6(int!null)
  │    │    │    ├── scan
- │    │    │    │    └── columns: foo.bar:jsonb:null:1 foo.baz:jsonb:null:2 foo.rowid:int:3
+ │    │    │    │    └── columns: foo.bar:1(jsonb) foo.baz:2(jsonb) foo.rowid:3(int!null)
  │    │    │    ├── scan
- │    │    │    │    └── columns: foo.bar:jsonb:null:4 foo.baz:jsonb:null:5 foo.rowid:int:6
+ │    │    │    │    └── columns: foo.bar:4(jsonb) foo.baz:5(jsonb) foo.rowid:6(int!null)
  │    │    │    └── true [type=bool]
  │    │    └── projections [outer=(1,5)]
  │    │         ├── contains [type=bool, outer=(1,5)]
@@ -2016,18 +2016,18 @@ build
 SELECT b.baz <@ a.bar AND b.baz <@ b.baz FROM foo AS a, foo AS b GROUP BY b.baz <@ a.bar, b.baz
 ----
 project
- ├── columns: column8:bool:null:8
+ ├── columns: column8:8(bool)
  ├── group-by
- │    ├── columns: foo.baz:jsonb:null:5 column7:bool:null:7
- │    ├── grouping columns: foo.baz:jsonb:null:5 column7:bool:null:7
+ │    ├── columns: foo.baz:5(jsonb) column7:7(bool)
+ │    ├── grouping columns: foo.baz:5(jsonb) column7:7(bool)
  │    ├── project
- │    │    ├── columns: column7:bool:null:7 foo.baz:jsonb:null:5
+ │    │    ├── columns: column7:7(bool) foo.baz:5(jsonb)
  │    │    ├── inner-join
- │    │    │    ├── columns: foo.bar:jsonb:null:1 foo.baz:jsonb:null:2 foo.rowid:int:3 foo.bar:jsonb:null:4 foo.baz:jsonb:null:5 foo.rowid:int:6
+ │    │    │    ├── columns: foo.bar:1(jsonb) foo.baz:2(jsonb) foo.rowid:3(int!null) foo.bar:4(jsonb) foo.baz:5(jsonb) foo.rowid:6(int!null)
  │    │    │    ├── scan
- │    │    │    │    └── columns: foo.bar:jsonb:null:1 foo.baz:jsonb:null:2 foo.rowid:int:3
+ │    │    │    │    └── columns: foo.bar:1(jsonb) foo.baz:2(jsonb) foo.rowid:3(int!null)
  │    │    │    ├── scan
- │    │    │    │    └── columns: foo.bar:jsonb:null:4 foo.baz:jsonb:null:5 foo.rowid:int:6
+ │    │    │    │    └── columns: foo.bar:4(jsonb) foo.baz:5(jsonb) foo.rowid:6(int!null)
  │    │    │    └── true [type=bool]
  │    │    └── projections [outer=(1,5)]
  │    │         ├── contains [type=bool, outer=(1,5)]
@@ -2057,18 +2057,18 @@ SELECT date_trunc('second', a.t) - date_trunc('minute', b.t) FROM times a, times
   GROUP BY date_trunc('second', a.t), date_trunc('minute', b.t)
 ----
 project
- ├── columns: column5:interval:null:5
+ ├── columns: column5:5(interval)
  ├── group-by
- │    ├── columns: column3:interval:null:3 column4:interval:null:4
- │    ├── grouping columns: column3:interval:null:3 column4:interval:null:4
+ │    ├── columns: column3:3(interval) column4:4(interval)
+ │    ├── grouping columns: column3:3(interval) column4:4(interval)
  │    ├── project
- │    │    ├── columns: column3:interval:null:3 column4:interval:null:4
+ │    │    ├── columns: column3:3(interval) column4:4(interval)
  │    │    ├── inner-join
- │    │    │    ├── columns: times.t:time:1 times.t:time:2
+ │    │    │    ├── columns: times.t:1(time!null) times.t:2(time!null)
  │    │    │    ├── scan
- │    │    │    │    └── columns: times.t:time:1
+ │    │    │    │    └── columns: times.t:1(time!null)
  │    │    │    ├── scan
- │    │    │    │    └── columns: times.t:time:2
+ │    │    │    │    └── columns: times.t:2(time!null)
  │    │    │    └── true [type=bool]
  │    │    └── projections [outer=(1,2)]
  │    │         ├── function: date_trunc [type=interval, outer=(1)]
@@ -2097,12 +2097,12 @@ build
 SELECT NOT b FROM bools GROUP BY NOT b
 ----
 group-by
- ├── columns: column3:bool:null:3
- ├── grouping columns: column3:bool:null:3
+ ├── columns: column3:3(bool)
+ ├── grouping columns: column3:3(bool)
  ├── project
- │    ├── columns: column3:bool:null:3
+ │    ├── columns: column3:3(bool)
  │    ├── scan
- │    │    └── columns: bools.b:bool:null:1 bools.rowid:int:2
+ │    │    └── columns: bools.b:1(bool) bools.rowid:2(int!null)
  │    └── projections [outer=(1)]
  │         └── not [type=bool, outer=(1)]
  │              └── variable: bools.b [type=bool, outer=(1)]
@@ -2117,14 +2117,14 @@ build
 SELECT NOT b FROM bools GROUP BY b
 ----
 project
- ├── columns: column3:bool:null:3
+ ├── columns: column3:3(bool)
  ├── group-by
- │    ├── columns: bools.b:bool:null:1
- │    ├── grouping columns: bools.b:bool:null:1
+ │    ├── columns: bools.b:1(bool)
+ │    ├── grouping columns: bools.b:1(bool)
  │    ├── project
- │    │    ├── columns: bools.b:bool:null:1
+ │    │    ├── columns: bools.b:1(bool)
  │    │    ├── scan
- │    │    │    └── columns: bools.b:bool:null:1 bools.rowid:int:2
+ │    │    │    └── columns: bools.b:1(bool) bools.rowid:2(int!null)
  │    │    └── projections [outer=(1)]
  │    │         └── variable: bools.b [type=bool, outer=(1)]
  │    └── aggregations
@@ -2136,14 +2136,14 @@ build
 SELECT +k * (-w) FROM kv GROUP BY +k, -w
 ----
 project
- ├── columns: column7:int:null:7
+ ├── columns: column7:7(int)
  ├── group-by
- │    ├── columns: column5:int:null:5 column6:int:null:6
- │    ├── grouping columns: column5:int:null:5 column6:int:null:6
+ │    ├── columns: column5:5(int) column6:6(int)
+ │    ├── grouping columns: column5:5(int) column6:6(int)
  │    ├── project
- │    │    ├── columns: column5:int:null:5 column6:int:null:6
+ │    │    ├── columns: column5:5(int) column6:6(int)
  │    │    ├── scan
- │    │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
+ │    │    │    └── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string)
  │    │    └── projections [outer=(1,3)]
  │    │         ├── variable: kv.k [type=int, outer=(1)]
  │    │         └── unary-minus [type=int, outer=(3)]
@@ -2164,14 +2164,14 @@ build
 SELECT +k * (-w) FROM kv GROUP BY k, w
 ----
 project
- ├── columns: column5:int:null:5
+ ├── columns: column5:5(int)
  ├── group-by
- │    ├── columns: kv.k:int:1 kv.w:int:null:3
- │    ├── grouping columns: kv.k:int:1 kv.w:int:null:3
+ │    ├── columns: kv.k:1(int!null) kv.w:3(int)
+ │    ├── grouping columns: kv.k:1(int!null) kv.w:3(int)
  │    ├── project
- │    │    ├── columns: kv.k:int:1 kv.w:int:null:3
+ │    │    ├── columns: kv.k:1(int!null) kv.w:3(int)
  │    │    ├── scan
- │    │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
+ │    │    │    └── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string)
  │    │    └── projections [outer=(1,3)]
  │    │         ├── variable: kv.k [type=int, outer=(1)]
  │    │         └── variable: kv.w [type=int, outer=(3)]
@@ -2186,14 +2186,14 @@ build
 SELECT 1 + MIN(v*2) FROM kv GROUP BY k+3
 ----
 project
- ├── columns: column8:int:null:8
+ ├── columns: column8:8(int)
  ├── group-by
- │    ├── columns: column5:int:null:5 column7:int:null:7
- │    ├── grouping columns: column5:int:null:5
+ │    ├── columns: column5:5(int) column7:7(int)
+ │    ├── grouping columns: column5:5(int)
  │    ├── project
- │    │    ├── columns: column5:int:null:5 column6:int:null:6
+ │    │    ├── columns: column5:5(int) column6:6(int)
  │    │    ├── scan
- │    │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
+ │    │    │    └── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string)
  │    │    └── projections [outer=(1,2)]
  │    │         ├── plus [type=int, outer=(1)]
  │    │         │    ├── variable: kv.k [type=int, outer=(1)]
@@ -2213,14 +2213,14 @@ build
 SELECT count(*) FROM kv GROUP BY k, k
 ----
 project
- ├── columns: column5:int:null:5
+ ├── columns: column5:5(int)
  ├── group-by
- │    ├── columns: kv.k:int:1 column5:int:null:5
- │    ├── grouping columns: kv.k:int:1
+ │    ├── columns: kv.k:1(int!null) column5:5(int)
+ │    ├── grouping columns: kv.k:1(int!null)
  │    ├── project
- │    │    ├── columns: kv.k:int:1 kv.k:int:1
+ │    │    ├── columns: kv.k:1(int!null) kv.k:1(int!null)
  │    │    ├── scan
- │    │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
+ │    │    │    └── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string)
  │    │    └── projections [outer=(1)]
  │    │         ├── variable: kv.k [type=int, outer=(1)]
  │    │         └── variable: kv.k [type=int, outer=(1)]
@@ -2233,14 +2233,14 @@ build
 SELECT COUNT(UPPER(s)) FROM t.kv GROUP BY UPPER(s)
 ----
 project
- ├── columns: column7:int:null:7
+ ├── columns: column7:7(int)
  ├── group-by
- │    ├── columns: column5:string:null:5 column7:int:null:7
- │    ├── grouping columns: column5:string:null:5
+ │    ├── columns: column5:5(string) column7:7(int)
+ │    ├── grouping columns: column5:5(string)
  │    ├── project
- │    │    ├── columns: column5:string:null:5 column6:string:null:6
+ │    │    ├── columns: column5:5(string) column6:6(string)
  │    │    ├── scan
- │    │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
+ │    │    │    └── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string)
  │    │    └── projections [outer=(4)]
  │    │         ├── function: upper [type=string, outer=(4)]
  │    │         │    └── variable: kv.s [type=string, outer=(4)]
@@ -2256,18 +2256,18 @@ build
 SELECT SUM(abc.d) FROM t.kv JOIN t.abc ON kv.k >= abc.d GROUP BY kv.*
 ----
 project
- ├── columns: column9:decimal:null:9
+ ├── columns: column9:9(decimal)
  ├── group-by
- │    ├── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4 column9:decimal:null:9
- │    ├── grouping columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
+ │    ├── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string) column9:9(decimal)
+ │    ├── grouping columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string)
  │    ├── project
- │    │    ├── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4 abc.d:decimal:null:8
+ │    │    ├── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string) abc.d:8(decimal)
  │    │    ├── inner-join
- │    │    │    ├── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4 abc.a:string:5 abc.b:float:null:6 abc.c:bool:null:7 abc.d:decimal:null:8
+ │    │    │    ├── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string) abc.a:5(string!null) abc.b:6(float) abc.c:7(bool) abc.d:8(decimal)
  │    │    │    ├── scan
- │    │    │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
+ │    │    │    │    └── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string)
  │    │    │    ├── scan
- │    │    │    │    └── columns: abc.a:string:5 abc.b:float:null:6 abc.c:bool:null:7 abc.d:decimal:null:8
+ │    │    │    │    └── columns: abc.a:5(string!null) abc.b:6(float) abc.c:7(bool) abc.d:8(decimal)
  │    │    │    └── ge [type=bool, outer=(1,8)]
  │    │    │         ├── variable: kv.k [type=int, outer=(1)]
  │    │    │         └── variable: abc.d [type=decimal, outer=(8)]

--- a/pkg/sql/opt/optbuilder/testdata/distinct
+++ b/pkg/sql/opt/optbuilder/testdata/distinct
@@ -30,9 +30,9 @@ build
 SELECT y, z FROM t.xyz
 ----
 project
- ├── columns: y:int:null:2 z:float:null:3
+ ├── columns: y:2(int) z:3(float)
  ├── scan
- │    └── columns: xyz.x:int:1 xyz.y:int:null:2 xyz.z:float:null:3
+ │    └── columns: xyz.x:1(int!null) xyz.y:2(int) xyz.z:3(float)
  └── projections [outer=(2,3)]
       ├── variable: xyz.y [type=int, outer=(2)]
       └── variable: xyz.z [type=float, outer=(3)]
@@ -41,12 +41,12 @@ build
 SELECT DISTINCT y, z FROM t.xyz
 ----
 group-by
- ├── columns: y:int:null:2 z:float:null:3
- ├── grouping columns: xyz.y:int:null:2 xyz.z:float:null:3
+ ├── columns: y:2(int) z:3(float)
+ ├── grouping columns: xyz.y:2(int) xyz.z:3(float)
  ├── project
- │    ├── columns: xyz.y:int:null:2 xyz.z:float:null:3
+ │    ├── columns: xyz.y:2(int) xyz.z:3(float)
  │    ├── scan
- │    │    └── columns: xyz.x:int:1 xyz.y:int:null:2 xyz.z:float:null:3
+ │    │    └── columns: xyz.x:1(int!null) xyz.y:2(int) xyz.z:3(float)
  │    └── projections [outer=(2,3)]
  │         ├── variable: xyz.y [type=int, outer=(2)]
  │         └── variable: xyz.z [type=float, outer=(3)]
@@ -56,14 +56,14 @@ build
 SELECT y FROM (SELECT DISTINCT y, z FROM t.xyz)
 ----
 project
- ├── columns: y:int:null:2
+ ├── columns: y:2(int)
  ├── group-by
- │    ├── columns: xyz.y:int:null:2 xyz.z:float:null:3
- │    ├── grouping columns: xyz.y:int:null:2 xyz.z:float:null:3
+ │    ├── columns: xyz.y:2(int) xyz.z:3(float)
+ │    ├── grouping columns: xyz.y:2(int) xyz.z:3(float)
  │    ├── project
- │    │    ├── columns: xyz.y:int:null:2 xyz.z:float:null:3
+ │    │    ├── columns: xyz.y:2(int) xyz.z:3(float)
  │    │    ├── scan
- │    │    │    └── columns: xyz.x:int:1 xyz.y:int:null:2 xyz.z:float:null:3
+ │    │    │    └── columns: xyz.x:1(int!null) xyz.y:2(int) xyz.z:3(float)
  │    │    └── projections [outer=(2,3)]
  │    │         ├── variable: xyz.y [type=int, outer=(2)]
  │    │         └── variable: xyz.z [type=float, outer=(3)]
@@ -75,12 +75,12 @@ build
 SELECT DISTINCT (y,z) FROM t.xyz
 ----
 group-by
- ├── columns: column4:tuple{int, float}:null:4
- ├── grouping columns: column4:tuple{int, float}:null:4
+ ├── columns: column4:4(tuple{int, float})
+ ├── grouping columns: column4:4(tuple{int, float})
  ├── project
- │    ├── columns: column4:tuple{int, float}:null:4
+ │    ├── columns: column4:4(tuple{int, float})
  │    ├── scan
- │    │    └── columns: xyz.x:int:1 xyz.y:int:null:2 xyz.z:float:null:3
+ │    │    └── columns: xyz.x:1(int!null) xyz.y:2(int) xyz.z:3(float)
  │    └── projections [outer=(2,3)]
  │         └── tuple [type=tuple{int, float}, outer=(2,3)]
  │              ├── variable: xyz.y [type=int, outer=(2)]
@@ -91,15 +91,15 @@ build
 SELECT COUNT(*) FROM (SELECT DISTINCT y FROM t.xyz)
 ----
 group-by
- ├── columns: column4:int:null:4
+ ├── columns: column4:4(int)
  ├── project
  │    ├── group-by
- │    │    ├── columns: xyz.y:int:null:2
- │    │    ├── grouping columns: xyz.y:int:null:2
+ │    │    ├── columns: xyz.y:2(int)
+ │    │    ├── grouping columns: xyz.y:2(int)
  │    │    ├── project
- │    │    │    ├── columns: xyz.y:int:null:2
+ │    │    │    ├── columns: xyz.y:2(int)
  │    │    │    ├── scan
- │    │    │    │    └── columns: xyz.x:int:1 xyz.y:int:null:2 xyz.z:float:null:3
+ │    │    │    │    └── columns: xyz.x:1(int!null) xyz.y:2(int) xyz.z:3(float)
  │    │    │    └── projections [outer=(2)]
  │    │    │         └── variable: xyz.y [type=int, outer=(2)]
  │    │    └── aggregations
@@ -111,14 +111,14 @@ build
 SELECT DISTINCT x FROM t.xyz WHERE x > 0
 ----
 group-by
- ├── columns: x:int:1
- ├── grouping columns: xyz.x:int:1
+ ├── columns: x:1(int!null)
+ ├── grouping columns: xyz.x:1(int!null)
  ├── project
- │    ├── columns: xyz.x:int:1
+ │    ├── columns: xyz.x:1(int!null)
  │    ├── select
- │    │    ├── columns: xyz.x:int:1 xyz.y:int:null:2 xyz.z:float:null:3
+ │    │    ├── columns: xyz.x:1(int!null) xyz.y:2(int) xyz.z:3(float)
  │    │    ├── scan
- │    │    │    └── columns: xyz.x:int:1 xyz.y:int:null:2 xyz.z:float:null:3
+ │    │    │    └── columns: xyz.x:1(int!null) xyz.y:2(int) xyz.z:3(float)
  │    │    └── gt [type=bool, outer=(1)]
  │    │         ├── variable: xyz.x [type=int, outer=(1)]
  │    │         └── const: 0 [type=int]
@@ -130,14 +130,14 @@ build
 SELECT DISTINCT z FROM t.xyz WHERE x > 0
 ----
 group-by
- ├── columns: z:float:null:3
- ├── grouping columns: xyz.z:float:null:3
+ ├── columns: z:3(float)
+ ├── grouping columns: xyz.z:3(float)
  ├── project
- │    ├── columns: xyz.z:float:null:3
+ │    ├── columns: xyz.z:3(float)
  │    ├── select
- │    │    ├── columns: xyz.x:int:1 xyz.y:int:null:2 xyz.z:float:null:3
+ │    │    ├── columns: xyz.x:1(int!null) xyz.y:2(int) xyz.z:3(float)
  │    │    ├── scan
- │    │    │    └── columns: xyz.x:int:1 xyz.y:int:null:2 xyz.z:float:null:3
+ │    │    │    └── columns: xyz.x:1(int!null) xyz.y:2(int) xyz.z:3(float)
  │    │    └── gt [type=bool, outer=(1)]
  │    │         ├── variable: xyz.x [type=int, outer=(1)]
  │    │         └── const: 0 [type=int]
@@ -149,17 +149,17 @@ build
 SELECT DISTINCT MAX(x) FROM xyz GROUP BY x
 ----
 group-by
- ├── columns: column4:int:null:4
- ├── grouping columns: column4:int:null:4
+ ├── columns: column4:4(int)
+ ├── grouping columns: column4:4(int)
  ├── project
- │    ├── columns: column4:int:null:4
+ │    ├── columns: column4:4(int)
  │    ├── group-by
- │    │    ├── columns: xyz.x:int:1 column4:int:null:4
- │    │    ├── grouping columns: xyz.x:int:1
+ │    │    ├── columns: xyz.x:1(int!null) column4:4(int)
+ │    │    ├── grouping columns: xyz.x:1(int!null)
  │    │    ├── project
- │    │    │    ├── columns: xyz.x:int:1 xyz.x:int:1
+ │    │    │    ├── columns: xyz.x:1(int!null) xyz.x:1(int!null)
  │    │    │    ├── scan
- │    │    │    │    └── columns: xyz.x:int:1 xyz.y:int:null:2 xyz.z:float:null:3
+ │    │    │    │    └── columns: xyz.x:1(int!null) xyz.y:2(int) xyz.z:3(float)
  │    │    │    └── projections [outer=(1)]
  │    │    │         ├── variable: xyz.x [type=int, outer=(1)]
  │    │    │         └── variable: xyz.x [type=int, outer=(1)]
@@ -174,12 +174,12 @@ build
 SELECT DISTINCT x+y FROM xyz
 ----
 group-by
- ├── columns: column4:int:null:4
- ├── grouping columns: column4:int:null:4
+ ├── columns: column4:4(int)
+ ├── grouping columns: column4:4(int)
  ├── project
- │    ├── columns: column4:int:null:4
+ │    ├── columns: column4:4(int)
  │    ├── scan
- │    │    └── columns: xyz.x:int:1 xyz.y:int:null:2 xyz.z:float:null:3
+ │    │    └── columns: xyz.x:1(int!null) xyz.y:2(int) xyz.z:3(float)
  │    └── projections [outer=(1,2)]
  │         └── plus [type=int, outer=(1,2)]
  │              ├── variable: xyz.x [type=int, outer=(1)]
@@ -190,12 +190,12 @@ build
 SELECT DISTINCT 3 FROM xyz
 ----
 group-by
- ├── columns: column4:int:null:4
- ├── grouping columns: column4:int:null:4
+ ├── columns: column4:4(int)
+ ├── grouping columns: column4:4(int)
  ├── project
- │    ├── columns: column4:int:null:4
+ │    ├── columns: column4:4(int)
  │    ├── scan
- │    │    └── columns: xyz.x:int:1 xyz.y:int:null:2 xyz.z:float:null:3
+ │    │    └── columns: xyz.x:1(int!null) xyz.y:2(int) xyz.z:3(float)
  │    └── projections
  │         └── const: 3 [type=int]
  └── aggregations
@@ -204,10 +204,10 @@ build
 SELECT DISTINCT 3
 ----
 group-by
- ├── columns: column1:int:null:1
- ├── grouping columns: column1:int:null:1
+ ├── columns: column1:1(int)
+ ├── grouping columns: column1:1(int)
  ├── project
- │    ├── columns: column1:int:null:1
+ │    ├── columns: column1:1(int)
  │    ├── values
  │    │    └── tuple [type=tuple{}]
  │    └── projections
@@ -218,17 +218,17 @@ build
 SELECT DISTINCT MAX(z), x+y, 3 FROM xyz GROUP BY x, y HAVING y > 4
 ----
 group-by
- ├── columns: column4:float:null:4 column5:int:null:5 column6:int:null:6
- ├── grouping columns: column4:float:null:4 column5:int:null:5 column6:int:null:6
+ ├── columns: column4:4(float) column5:5(int) column6:6(int)
+ ├── grouping columns: column4:4(float) column5:5(int) column6:6(int)
  ├── project
- │    ├── columns: column4:float:null:4 column5:int:null:5 column6:int:null:6
+ │    ├── columns: column4:4(float) column5:5(int) column6:6(int)
  │    ├── select
- │    │    ├── columns: xyz.x:int:1 xyz.y:int:null:2 column4:float:null:4
+ │    │    ├── columns: xyz.x:1(int!null) xyz.y:2(int) column4:4(float)
  │    │    ├── group-by
- │    │    │    ├── columns: xyz.x:int:1 xyz.y:int:null:2 column4:float:null:4
- │    │    │    ├── grouping columns: xyz.x:int:1 xyz.y:int:null:2
+ │    │    │    ├── columns: xyz.x:1(int!null) xyz.y:2(int) column4:4(float)
+ │    │    │    ├── grouping columns: xyz.x:1(int!null) xyz.y:2(int)
  │    │    │    ├── scan
- │    │    │    │    └── columns: xyz.x:int:1 xyz.y:int:null:2 xyz.z:float:null:3
+ │    │    │    │    └── columns: xyz.x:1(int!null) xyz.y:2(int) xyz.z:3(float)
  │    │    │    └── aggregations [outer=(3)]
  │    │    │         └── function: max [type=float, outer=(3)]
  │    │    │              └── variable: xyz.z [type=float, outer=(3)]

--- a/pkg/sql/opt/optbuilder/testdata/having
+++ b/pkg/sql/opt/optbuilder/testdata/having
@@ -21,12 +21,12 @@ build
 SELECT 3 FROM t.kv HAVING TRUE
 ----
 project
- ├── columns: column5:int:null:5
+ ├── columns: column5:5(int)
  ├── select
  │    ├── group-by
  │    │    ├── project
  │    │    │    ├── scan
- │    │    │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
+ │    │    │    │    └── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string)
  │    │    │    └── projections
  │    │    └── aggregations
  │    └── true [type=bool]
@@ -37,14 +37,14 @@ build
 SELECT s, COUNT(*) FROM t.kv GROUP BY s HAVING COUNT(*) > 1
 ----
 select
- ├── columns: s:string:null:4 column5:int:null:5
+ ├── columns: s:4(string) column5:5(int)
  ├── group-by
- │    ├── columns: kv.s:string:null:4 column5:int:null:5
- │    ├── grouping columns: kv.s:string:null:4
+ │    ├── columns: kv.s:4(string) column5:5(int)
+ │    ├── grouping columns: kv.s:4(string)
  │    ├── project
- │    │    ├── columns: kv.s:string:null:4
+ │    │    ├── columns: kv.s:4(string)
  │    │    ├── scan
- │    │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
+ │    │    │    └── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string)
  │    │    └── projections [outer=(4)]
  │    │         └── variable: kv.s [type=string, outer=(4)]
  │    └── aggregations
@@ -57,15 +57,15 @@ build
 SELECT MAX(k), MIN(v) FROM t.kv HAVING MIN(v) > 2
 ----
 project
- ├── columns: column6:int:null:6 column5:int:null:5
+ ├── columns: column6:6(int) column5:5(int)
  ├── select
- │    ├── columns: column5:int:null:5 column6:int:null:6
+ │    ├── columns: column5:5(int) column6:6(int)
  │    ├── group-by
- │    │    ├── columns: column5:int:null:5 column6:int:null:6
+ │    │    ├── columns: column5:5(int) column6:6(int)
  │    │    ├── project
- │    │    │    ├── columns: kv.v:int:null:2 kv.k:int:1
+ │    │    │    ├── columns: kv.v:2(int) kv.k:1(int!null)
  │    │    │    ├── scan
- │    │    │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
+ │    │    │    │    └── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string)
  │    │    │    └── projections [outer=(1,2)]
  │    │    │         ├── variable: kv.v [type=int, outer=(2)]
  │    │    │         └── variable: kv.k [type=int, outer=(1)]
@@ -85,15 +85,15 @@ build
 SELECT MAX(k), MIN(v) FROM t.kv HAVING MAX(v) > 2
 ----
 project
- ├── columns: column6:int:null:6 column7:int:null:7
+ ├── columns: column6:6(int) column7:7(int)
  ├── select
- │    ├── columns: column5:int:null:5 column6:int:null:6 column7:int:null:7
+ │    ├── columns: column5:5(int) column6:6(int) column7:7(int)
  │    ├── group-by
- │    │    ├── columns: column5:int:null:5 column6:int:null:6 column7:int:null:7
+ │    │    ├── columns: column5:5(int) column6:6(int) column7:7(int)
  │    │    ├── project
- │    │    │    ├── columns: kv.v:int:null:2 kv.k:int:1 kv.v:int:null:2
+ │    │    │    ├── columns: kv.v:2(int) kv.k:1(int!null) kv.v:2(int)
  │    │    │    ├── scan
- │    │    │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
+ │    │    │    │    └── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string)
  │    │    │    └── projections [outer=(1,2)]
  │    │    │         ├── variable: kv.v [type=int, outer=(2)]
  │    │    │         ├── variable: kv.k [type=int, outer=(1)]
@@ -144,16 +144,16 @@ build
 SELECT count(*), k+w FROM t.kv GROUP BY k+w HAVING (k+w) > 5
 ----
 project
- ├── columns: column6:int:null:6 column5:int:null:5
+ ├── columns: column6:6(int) column5:5(int)
  ├── select
- │    ├── columns: column5:int:null:5 column6:int:null:6
+ │    ├── columns: column5:5(int) column6:6(int)
  │    ├── group-by
- │    │    ├── columns: column5:int:null:5 column6:int:null:6
- │    │    ├── grouping columns: column5:int:null:5
+ │    │    ├── columns: column5:5(int) column6:6(int)
+ │    │    ├── grouping columns: column5:5(int)
  │    │    ├── project
- │    │    │    ├── columns: column5:int:null:5
+ │    │    │    ├── columns: column5:5(int)
  │    │    │    ├── scan
- │    │    │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
+ │    │    │    │    └── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string)
  │    │    │    └── projections [outer=(1,3)]
  │    │    │         └── plus [type=int, outer=(1,3)]
  │    │    │              ├── variable: kv.k [type=int, outer=(1)]
@@ -179,16 +179,16 @@ build
 SELECT MAX(kv.v) FROM kv GROUP BY v HAVING kv.v > 5
 ----
 project
- ├── columns: column5:int:null:5
+ ├── columns: column5:5(int)
  ├── select
- │    ├── columns: kv.v:int:null:2 column5:int:null:5
+ │    ├── columns: kv.v:2(int) column5:5(int)
  │    ├── group-by
- │    │    ├── columns: kv.v:int:null:2 column5:int:null:5
- │    │    ├── grouping columns: kv.v:int:null:2
+ │    │    ├── columns: kv.v:2(int) column5:5(int)
+ │    │    ├── grouping columns: kv.v:2(int)
  │    │    ├── project
- │    │    │    ├── columns: kv.v:int:null:2 kv.v:int:null:2
+ │    │    │    ├── columns: kv.v:2(int) kv.v:2(int)
  │    │    │    ├── scan
- │    │    │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
+ │    │    │    │    └── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string)
  │    │    │    └── projections [outer=(2)]
  │    │    │         ├── variable: kv.v [type=int, outer=(2)]
  │    │    │         └── variable: kv.v [type=int, outer=(2)]
@@ -205,16 +205,16 @@ build
 SELECT SUM(kv.w) FROM kv GROUP BY LOWER(s) HAVING LOWER(kv.s) LIKE 'test%'
 ----
 project
- ├── columns: column6:decimal:null:6
+ ├── columns: column6:6(decimal)
  ├── select
- │    ├── columns: column5:string:null:5 column6:decimal:null:6
+ │    ├── columns: column5:5(string) column6:6(decimal)
  │    ├── group-by
- │    │    ├── columns: column5:string:null:5 column6:decimal:null:6
- │    │    ├── grouping columns: column5:string:null:5
+ │    │    ├── columns: column5:5(string) column6:6(decimal)
+ │    │    ├── grouping columns: column5:5(string)
  │    │    ├── project
- │    │    │    ├── columns: column5:string:null:5 kv.w:int:null:3
+ │    │    │    ├── columns: column5:5(string) kv.w:3(int)
  │    │    │    ├── scan
- │    │    │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
+ │    │    │    │    └── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string)
  │    │    │    └── projections [outer=(3,4)]
  │    │    │         ├── function: lower [type=string, outer=(4)]
  │    │    │         │    └── variable: kv.s [type=string, outer=(4)]
@@ -233,16 +233,16 @@ build
 SELECT SUM(kv.w) FROM kv GROUP BY LOWER(s) HAVING SUM(w) IN (4, 5, 6)
 ----
 project
- ├── columns: column6:decimal:null:6
+ ├── columns: column6:6(decimal)
  ├── select
- │    ├── columns: column5:string:null:5 column6:decimal:null:6
+ │    ├── columns: column5:5(string) column6:6(decimal)
  │    ├── group-by
- │    │    ├── columns: column5:string:null:5 column6:decimal:null:6
- │    │    ├── grouping columns: column5:string:null:5
+ │    │    ├── columns: column5:5(string) column6:6(decimal)
+ │    │    ├── grouping columns: column5:5(string)
  │    │    ├── project
- │    │    │    ├── columns: column5:string:null:5 kv.w:int:null:3
+ │    │    │    ├── columns: column5:5(string) kv.w:3(int)
  │    │    │    ├── scan
- │    │    │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
+ │    │    │    │    └── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string)
  │    │    │    └── projections [outer=(3,4)]
  │    │    │         ├── function: lower [type=string, outer=(4)]
  │    │    │         │    └── variable: kv.s [type=string, outer=(4)]
@@ -263,16 +263,16 @@ build
 SELECT t.kv.v FROM t.kv GROUP BY v, kv.k * w HAVING k * kv.w > 5
 ----
 project
- ├── columns: v:int:null:2
+ ├── columns: v:2(int)
  ├── select
- │    ├── columns: kv.v:int:null:2 column5:int:null:5
+ │    ├── columns: kv.v:2(int) column5:5(int)
  │    ├── group-by
- │    │    ├── columns: kv.v:int:null:2 column5:int:null:5
- │    │    ├── grouping columns: kv.v:int:null:2 column5:int:null:5
+ │    │    ├── columns: kv.v:2(int) column5:5(int)
+ │    │    ├── grouping columns: kv.v:2(int) column5:5(int)
  │    │    ├── project
- │    │    │    ├── columns: kv.v:int:null:2 column5:int:null:5
+ │    │    │    ├── columns: kv.v:2(int) column5:5(int)
  │    │    │    ├── scan
- │    │    │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
+ │    │    │    │    └── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string)
  │    │    │    └── projections [outer=(1-3)]
  │    │    │         ├── variable: kv.v [type=int, outer=(2)]
  │    │    │         └── mult [type=int, outer=(1,3)]
@@ -296,14 +296,14 @@ build
 SELECT UPPER(s), COUNT(s), COUNT(UPPER(s)) FROM t.kv GROUP BY UPPER(s) HAVING COUNT(s) > 1
 ----
 select
- ├── columns: column5:string:null:5 column6:int:null:6 column8:int:null:8
+ ├── columns: column5:5(string) column6:6(int) column8:8(int)
  ├── group-by
- │    ├── columns: column5:string:null:5 column6:int:null:6 column8:int:null:8
- │    ├── grouping columns: column5:string:null:5
+ │    ├── columns: column5:5(string) column6:6(int) column8:8(int)
+ │    ├── grouping columns: column5:5(string)
  │    ├── project
- │    │    ├── columns: column5:string:null:5 kv.s:string:null:4 column7:string:null:7
+ │    │    ├── columns: column5:5(string) kv.s:4(string) column7:7(string)
  │    │    ├── scan
- │    │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
+ │    │    │    └── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string)
  │    │    └── projections [outer=(4)]
  │    │         ├── function: upper [type=string, outer=(4)]
  │    │         │    └── variable: kv.s [type=string, outer=(4)]

--- a/pkg/sql/opt/optbuilder/testdata/inner-join
+++ b/pkg/sql/opt/optbuilder/testdata/inner-join
@@ -32,13 +32,13 @@ build
 SELECT * FROM t.a, t.b
 ----
 project
- ├── columns: x:int:1 y:float:null:2 x:int:null:3 y:float:null:4
+ ├── columns: x:1(int!null) y:2(float) x:3(int) y:4(float)
  ├── inner-join
- │    ├── columns: a.x:int:1 a.y:float:null:2 b.x:int:null:3 b.y:float:null:4 b.rowid:int:5
+ │    ├── columns: a.x:1(int!null) a.y:2(float) b.x:3(int) b.y:4(float) b.rowid:5(int!null)
  │    ├── scan
- │    │    └── columns: a.x:int:1 a.y:float:null:2
+ │    │    └── columns: a.x:1(int!null) a.y:2(float)
  │    ├── scan
- │    │    └── columns: b.x:int:null:3 b.y:float:null:4 b.rowid:int:5
+ │    │    └── columns: b.x:3(int) b.y:4(float) b.rowid:5(int!null)
  │    └── true [type=bool]
  └── projections [outer=(1-4)]
       ├── variable: a.x [type=int, outer=(1)]
@@ -50,15 +50,15 @@ build
 SELECT a.x, b.y FROM t.a, t.b WHERE a.x = b.x
 ----
 project
- ├── columns: x:int:1 y:float:null:4
+ ├── columns: x:1(int!null) y:4(float)
  ├── select
- │    ├── columns: a.x:int:1 a.y:float:null:2 b.x:int:null:3 b.y:float:null:4 b.rowid:int:5
+ │    ├── columns: a.x:1(int!null) a.y:2(float) b.x:3(int) b.y:4(float) b.rowid:5(int!null)
  │    ├── inner-join
- │    │    ├── columns: a.x:int:1 a.y:float:null:2 b.x:int:null:3 b.y:float:null:4 b.rowid:int:5
+ │    │    ├── columns: a.x:1(int!null) a.y:2(float) b.x:3(int) b.y:4(float) b.rowid:5(int!null)
  │    │    ├── scan
- │    │    │    └── columns: a.x:int:1 a.y:float:null:2
+ │    │    │    └── columns: a.x:1(int!null) a.y:2(float)
  │    │    ├── scan
- │    │    │    └── columns: b.x:int:null:3 b.y:float:null:4 b.rowid:int:5
+ │    │    │    └── columns: b.x:3(int) b.y:4(float) b.rowid:5(int!null)
  │    │    └── true [type=bool]
  │    └── eq [type=bool, outer=(1,3)]
  │         ├── variable: a.x [type=int, outer=(1)]
@@ -71,20 +71,20 @@ build
 SELECT * FROM t.c, t.b, t.a WHERE c.x = a.x AND b.x = a.x
 ----
 project
- ├── columns: x:int:null:1 y:float:null:2 z:string:null:3 x:int:null:5 y:float:null:6 x:int:8 y:float:null:9
+ ├── columns: x:1(int) y:2(float) z:3(string) x:5(int) y:6(float) x:8(int!null) y:9(float)
  ├── select
- │    ├── columns: c.x:int:null:1 c.y:float:null:2 c.z:string:null:3 c.rowid:int:4 b.x:int:null:5 b.y:float:null:6 b.rowid:int:7 a.x:int:8 a.y:float:null:9
+ │    ├── columns: c.x:1(int) c.y:2(float) c.z:3(string) c.rowid:4(int!null) b.x:5(int) b.y:6(float) b.rowid:7(int!null) a.x:8(int!null) a.y:9(float)
  │    ├── inner-join
- │    │    ├── columns: c.x:int:null:1 c.y:float:null:2 c.z:string:null:3 c.rowid:int:4 b.x:int:null:5 b.y:float:null:6 b.rowid:int:7 a.x:int:8 a.y:float:null:9
+ │    │    ├── columns: c.x:1(int) c.y:2(float) c.z:3(string) c.rowid:4(int!null) b.x:5(int) b.y:6(float) b.rowid:7(int!null) a.x:8(int!null) a.y:9(float)
  │    │    ├── inner-join
- │    │    │    ├── columns: c.x:int:null:1 c.y:float:null:2 c.z:string:null:3 c.rowid:int:4 b.x:int:null:5 b.y:float:null:6 b.rowid:int:7
+ │    │    │    ├── columns: c.x:1(int) c.y:2(float) c.z:3(string) c.rowid:4(int!null) b.x:5(int) b.y:6(float) b.rowid:7(int!null)
  │    │    │    ├── scan
- │    │    │    │    └── columns: c.x:int:null:1 c.y:float:null:2 c.z:string:null:3 c.rowid:int:4
+ │    │    │    │    └── columns: c.x:1(int) c.y:2(float) c.z:3(string) c.rowid:4(int!null)
  │    │    │    ├── scan
- │    │    │    │    └── columns: b.x:int:null:5 b.y:float:null:6 b.rowid:int:7
+ │    │    │    │    └── columns: b.x:5(int) b.y:6(float) b.rowid:7(int!null)
  │    │    │    └── true [type=bool]
  │    │    ├── scan
- │    │    │    └── columns: a.x:int:8 a.y:float:null:9
+ │    │    │    └── columns: a.x:8(int!null) a.y:9(float)
  │    │    └── true [type=bool]
  │    └── and [type=bool, outer=(1,5,8)]
  │         ├── eq [type=bool, outer=(1,8)]

--- a/pkg/sql/opt/optbuilder/testdata/join
+++ b/pkg/sql/opt/optbuilder/testdata/join
@@ -19,13 +19,13 @@ build
 SELECT * FROM onecolumn AS a(x) CROSS JOIN onecolumn AS b(y)
 ----
 project
- ├── columns: x:int:null:1 y:int:null:3
+ ├── columns: x:1(int) y:3(int)
  ├── inner-join
- │    ├── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2 onecolumn.x:int:null:3 onecolumn.rowid:int:4
+ │    ├── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null) onecolumn.x:3(int) onecolumn.rowid:4(int!null)
  │    ├── scan
- │    │    └── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2
+ │    │    └── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null)
  │    ├── scan
- │    │    └── columns: onecolumn.x:int:null:3 onecolumn.rowid:int:4
+ │    │    └── columns: onecolumn.x:3(int) onecolumn.rowid:4(int!null)
  │    └── true [type=bool]
  └── projections [outer=(1,3)]
       ├── variable: onecolumn.x [type=int, outer=(1)]
@@ -45,22 +45,22 @@ build
 SELECT x FROM (SELECT 1 AS x), onecolumn AS a, onecolumn AS b
 ----
 project
- ├── columns: x:int:null:1
+ ├── columns: x:1(int)
  ├── inner-join
- │    ├── columns: x:int:null:1 onecolumn.x:int:null:2 onecolumn.rowid:int:3 onecolumn.x:int:null:4 onecolumn.rowid:int:5
+ │    ├── columns: x:1(int) onecolumn.x:2(int) onecolumn.rowid:3(int!null) onecolumn.x:4(int) onecolumn.rowid:5(int!null)
  │    ├── inner-join
- │    │    ├── columns: x:int:null:1 onecolumn.x:int:null:2 onecolumn.rowid:int:3
+ │    │    ├── columns: x:1(int) onecolumn.x:2(int) onecolumn.rowid:3(int!null)
  │    │    ├── project
- │    │    │    ├── columns: x:int:null:1
+ │    │    │    ├── columns: x:1(int)
  │    │    │    ├── values
  │    │    │    │    └── tuple [type=tuple{}]
  │    │    │    └── projections
  │    │    │         └── const: 1 [type=int]
  │    │    ├── scan
- │    │    │    └── columns: onecolumn.x:int:null:2 onecolumn.rowid:int:3
+ │    │    │    └── columns: onecolumn.x:2(int) onecolumn.rowid:3(int!null)
  │    │    └── true [type=bool]
  │    ├── scan
- │    │    └── columns: onecolumn.x:int:null:4 onecolumn.rowid:int:5
+ │    │    └── columns: onecolumn.x:4(int) onecolumn.rowid:5(int!null)
  │    └── true [type=bool]
  └── projections [outer=(1)]
       └── variable: x [type=int, outer=(1)]
@@ -69,13 +69,13 @@ build
 SELECT * FROM onecolumn AS a(x) JOIN onecolumn AS b(y) ON a.x = b.y
 ----
 project
- ├── columns: x:int:null:1 y:int:null:3
+ ├── columns: x:1(int) y:3(int)
  ├── inner-join
- │    ├── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2 onecolumn.x:int:null:3 onecolumn.rowid:int:4
+ │    ├── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null) onecolumn.x:3(int) onecolumn.rowid:4(int!null)
  │    ├── scan
- │    │    └── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2
+ │    │    └── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null)
  │    ├── scan
- │    │    └── columns: onecolumn.x:int:null:3 onecolumn.rowid:int:4
+ │    │    └── columns: onecolumn.x:3(int) onecolumn.rowid:4(int!null)
  │    └── eq [type=bool, outer=(1,3)]
  │         ├── variable: onecolumn.x [type=int, outer=(1)]
  │         └── variable: onecolumn.x [type=int, outer=(3)]
@@ -87,13 +87,13 @@ build
 SELECT * FROM onecolumn AS a JOIN onecolumn as b USING(x)
 ----
 project
- ├── columns: x:int:null:1
+ ├── columns: x:1(int)
  ├── inner-join
- │    ├── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2 onecolumn.x:int:null:3 onecolumn.rowid:int:4
+ │    ├── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null) onecolumn.x:3(int) onecolumn.rowid:4(int!null)
  │    ├── scan
- │    │    └── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2
+ │    │    └── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null)
  │    ├── scan
- │    │    └── columns: onecolumn.x:int:null:3 onecolumn.rowid:int:4
+ │    │    └── columns: onecolumn.x:3(int) onecolumn.rowid:4(int!null)
  │    └── eq [type=bool, outer=(1,3)]
  │         ├── variable: onecolumn.x [type=int, outer=(1)]
  │         └── variable: onecolumn.x [type=int, outer=(3)]
@@ -104,13 +104,13 @@ build
 SELECT * FROM onecolumn AS a NATURAL JOIN onecolumn as b
 ----
 project
- ├── columns: x:int:null:1
+ ├── columns: x:1(int)
  ├── inner-join
- │    ├── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2 onecolumn.x:int:null:3 onecolumn.rowid:int:4
+ │    ├── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null) onecolumn.x:3(int) onecolumn.rowid:4(int!null)
  │    ├── scan
- │    │    └── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2
+ │    │    └── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null)
  │    ├── scan
- │    │    └── columns: onecolumn.x:int:null:3 onecolumn.rowid:int:4
+ │    │    └── columns: onecolumn.x:3(int) onecolumn.rowid:4(int!null)
  │    └── eq [type=bool, outer=(1,3)]
  │         ├── variable: onecolumn.x [type=int, outer=(1)]
  │         └── variable: onecolumn.x [type=int, outer=(3)]
@@ -121,13 +121,13 @@ build
 SELECT * FROM onecolumn AS a(x) LEFT OUTER JOIN onecolumn AS b(y) ON a.x = b.y
 ----
 project
- ├── columns: x:int:null:1 y:int:null:3
+ ├── columns: x:1(int) y:3(int)
  ├── left-join
- │    ├── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2 onecolumn.x:int:null:3 onecolumn.rowid:int:null:4
+ │    ├── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null) onecolumn.x:3(int) onecolumn.rowid:4(int)
  │    ├── scan
- │    │    └── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2
+ │    │    └── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null)
  │    ├── scan
- │    │    └── columns: onecolumn.x:int:null:3 onecolumn.rowid:int:4
+ │    │    └── columns: onecolumn.x:3(int) onecolumn.rowid:4(int!null)
  │    └── eq [type=bool, outer=(1,3)]
  │         ├── variable: onecolumn.x [type=int, outer=(1)]
  │         └── variable: onecolumn.x [type=int, outer=(3)]
@@ -139,13 +139,13 @@ build
 SELECT * FROM onecolumn AS a LEFT OUTER JOIN onecolumn AS b USING(x)
 ----
 project
- ├── columns: x:int:null:1
+ ├── columns: x:1(int)
  ├── left-join
- │    ├── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2 onecolumn.x:int:null:3 onecolumn.rowid:int:null:4
+ │    ├── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null) onecolumn.x:3(int) onecolumn.rowid:4(int)
  │    ├── scan
- │    │    └── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2
+ │    │    └── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null)
  │    ├── scan
- │    │    └── columns: onecolumn.x:int:null:3 onecolumn.rowid:int:4
+ │    │    └── columns: onecolumn.x:3(int) onecolumn.rowid:4(int!null)
  │    └── eq [type=bool, outer=(1,3)]
  │         ├── variable: onecolumn.x [type=int, outer=(1)]
  │         └── variable: onecolumn.x [type=int, outer=(3)]
@@ -156,13 +156,13 @@ build
 SELECT * FROM onecolumn AS a NATURAL LEFT OUTER JOIN onecolumn AS b
 ----
 project
- ├── columns: x:int:null:1
+ ├── columns: x:1(int)
  ├── left-join
- │    ├── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2 onecolumn.x:int:null:3 onecolumn.rowid:int:null:4
+ │    ├── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null) onecolumn.x:3(int) onecolumn.rowid:4(int)
  │    ├── scan
- │    │    └── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2
+ │    │    └── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null)
  │    ├── scan
- │    │    └── columns: onecolumn.x:int:null:3 onecolumn.rowid:int:4
+ │    │    └── columns: onecolumn.x:3(int) onecolumn.rowid:4(int!null)
  │    └── eq [type=bool, outer=(1,3)]
  │         ├── variable: onecolumn.x [type=int, outer=(1)]
  │         └── variable: onecolumn.x [type=int, outer=(3)]
@@ -173,13 +173,13 @@ build
 SELECT * FROM onecolumn AS a(x) RIGHT OUTER JOIN onecolumn AS b(y) ON a.x = b.y
 ----
 project
- ├── columns: x:int:null:1 y:int:null:3
+ ├── columns: x:1(int) y:3(int)
  ├── right-join
- │    ├── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:null:2 onecolumn.x:int:null:3 onecolumn.rowid:int:4
+ │    ├── columns: onecolumn.x:1(int) onecolumn.rowid:2(int) onecolumn.x:3(int) onecolumn.rowid:4(int!null)
  │    ├── scan
- │    │    └── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2
+ │    │    └── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null)
  │    ├── scan
- │    │    └── columns: onecolumn.x:int:null:3 onecolumn.rowid:int:4
+ │    │    └── columns: onecolumn.x:3(int) onecolumn.rowid:4(int!null)
  │    └── eq [type=bool, outer=(1,3)]
  │         ├── variable: onecolumn.x [type=int, outer=(1)]
  │         └── variable: onecolumn.x [type=int, outer=(3)]
@@ -191,13 +191,13 @@ build
 SELECT * FROM onecolumn AS a RIGHT OUTER JOIN onecolumn AS b USING(x)
 ----
 project
- ├── columns: x:int:null:3
+ ├── columns: x:3(int)
  ├── right-join
- │    ├── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:null:2 onecolumn.x:int:null:3 onecolumn.rowid:int:4
+ │    ├── columns: onecolumn.x:1(int) onecolumn.rowid:2(int) onecolumn.x:3(int) onecolumn.rowid:4(int!null)
  │    ├── scan
- │    │    └── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2
+ │    │    └── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null)
  │    ├── scan
- │    │    └── columns: onecolumn.x:int:null:3 onecolumn.rowid:int:4
+ │    │    └── columns: onecolumn.x:3(int) onecolumn.rowid:4(int!null)
  │    └── eq [type=bool, outer=(1,3)]
  │         ├── variable: onecolumn.x [type=int, outer=(1)]
  │         └── variable: onecolumn.x [type=int, outer=(3)]
@@ -208,13 +208,13 @@ build
 SELECT * FROM onecolumn AS a NATURAL RIGHT OUTER JOIN onecolumn AS b
 ----
 project
- ├── columns: x:int:null:3
+ ├── columns: x:3(int)
  ├── right-join
- │    ├── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:null:2 onecolumn.x:int:null:3 onecolumn.rowid:int:4
+ │    ├── columns: onecolumn.x:1(int) onecolumn.rowid:2(int) onecolumn.x:3(int) onecolumn.rowid:4(int!null)
  │    ├── scan
- │    │    └── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2
+ │    │    └── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null)
  │    ├── scan
- │    │    └── columns: onecolumn.x:int:null:3 onecolumn.rowid:int:4
+ │    │    └── columns: onecolumn.x:3(int) onecolumn.rowid:4(int!null)
  │    └── eq [type=bool, outer=(1,3)]
  │         ├── variable: onecolumn.x [type=int, outer=(1)]
  │         └── variable: onecolumn.x [type=int, outer=(3)]
@@ -234,13 +234,13 @@ build
 SELECT * FROM onecolumn AS a NATURAL JOIN onecolumn_w as b
 ----
 project
- ├── columns: x:int:null:1 w:int:null:3
+ ├── columns: x:1(int) w:3(int)
  ├── inner-join
- │    ├── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2 onecolumn_w.w:int:null:3 onecolumn_w.rowid:int:4
+ │    ├── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null) onecolumn_w.w:3(int) onecolumn_w.rowid:4(int!null)
  │    ├── scan
- │    │    └── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2
+ │    │    └── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null)
  │    ├── scan
- │    │    └── columns: onecolumn_w.w:int:null:3 onecolumn_w.rowid:int:4
+ │    │    └── columns: onecolumn_w.w:3(int) onecolumn_w.rowid:4(int!null)
  │    └── true [type=bool]
  └── projections [outer=(1,3)]
       ├── variable: onecolumn.x [type=int, outer=(1)]
@@ -259,13 +259,13 @@ build
 SELECT * FROM onecolumn AS a FULL OUTER JOIN othercolumn AS b ON a.x = b.x
 ----
 project
- ├── columns: x:int:null:1 x:int:null:3
+ ├── columns: x:1(int) x:3(int)
  ├── full-join
- │    ├── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:null:2 othercolumn.x:int:null:3 othercolumn.rowid:int:null:4
+ │    ├── columns: onecolumn.x:1(int) onecolumn.rowid:2(int) othercolumn.x:3(int) othercolumn.rowid:4(int)
  │    ├── scan
- │    │    └── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2
+ │    │    └── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null)
  │    ├── scan
- │    │    └── columns: othercolumn.x:int:null:3 othercolumn.rowid:int:4
+ │    │    └── columns: othercolumn.x:3(int) othercolumn.rowid:4(int!null)
  │    └── eq [type=bool, outer=(1,3)]
  │         ├── variable: onecolumn.x [type=int, outer=(1)]
  │         └── variable: othercolumn.x [type=int, outer=(3)]
@@ -277,15 +277,15 @@ build
 SELECT * FROM onecolumn AS a FULL OUTER JOIN othercolumn AS b USING(x)
 ----
 project
- ├── columns: x:int:null:5
+ ├── columns: x:5(int)
  ├── project
- │    ├── columns: x:int:null:5 onecolumn.x:int:null:1 onecolumn.rowid:int:null:2 othercolumn.x:int:null:3 othercolumn.rowid:int:null:4
+ │    ├── columns: x:5(int) onecolumn.x:1(int) onecolumn.rowid:2(int) othercolumn.x:3(int) othercolumn.rowid:4(int)
  │    ├── full-join
- │    │    ├── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:null:2 othercolumn.x:int:null:3 othercolumn.rowid:int:null:4
+ │    │    ├── columns: onecolumn.x:1(int) onecolumn.rowid:2(int) othercolumn.x:3(int) othercolumn.rowid:4(int)
  │    │    ├── scan
- │    │    │    └── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2
+ │    │    │    └── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null)
  │    │    ├── scan
- │    │    │    └── columns: othercolumn.x:int:null:3 othercolumn.rowid:int:4
+ │    │    │    └── columns: othercolumn.x:3(int) othercolumn.rowid:4(int!null)
  │    │    └── eq [type=bool, outer=(1,3)]
  │    │         ├── variable: onecolumn.x [type=int, outer=(1)]
  │    │         └── variable: othercolumn.x [type=int, outer=(3)]
@@ -306,15 +306,15 @@ build
 SELECT x AS s, a.x, b.x FROM onecolumn AS a FULL OUTER JOIN othercolumn AS b USING(x)
 ----
 project
- ├── columns: s:int:null:5 x:int:null:1 x:int:null:3
+ ├── columns: s:5(int) x:1(int) x:3(int)
  ├── project
- │    ├── columns: x:int:null:5 onecolumn.x:int:null:1 onecolumn.rowid:int:null:2 othercolumn.x:int:null:3 othercolumn.rowid:int:null:4
+ │    ├── columns: x:5(int) onecolumn.x:1(int) onecolumn.rowid:2(int) othercolumn.x:3(int) othercolumn.rowid:4(int)
  │    ├── full-join
- │    │    ├── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:null:2 othercolumn.x:int:null:3 othercolumn.rowid:int:null:4
+ │    │    ├── columns: onecolumn.x:1(int) onecolumn.rowid:2(int) othercolumn.x:3(int) othercolumn.rowid:4(int)
  │    │    ├── scan
- │    │    │    └── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2
+ │    │    │    └── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null)
  │    │    ├── scan
- │    │    │    └── columns: othercolumn.x:int:null:3 othercolumn.rowid:int:4
+ │    │    │    └── columns: othercolumn.x:3(int) othercolumn.rowid:4(int!null)
  │    │    └── eq [type=bool, outer=(1,3)]
  │    │         ├── variable: onecolumn.x [type=int, outer=(1)]
  │    │         └── variable: othercolumn.x [type=int, outer=(3)]
@@ -335,15 +335,15 @@ build
 SELECT * FROM onecolumn AS a NATURAL FULL OUTER JOIN othercolumn AS b
 ----
 project
- ├── columns: x:int:null:5
+ ├── columns: x:5(int)
  ├── project
- │    ├── columns: x:int:null:5 onecolumn.x:int:null:1 onecolumn.rowid:int:null:2 othercolumn.x:int:null:3 othercolumn.rowid:int:null:4
+ │    ├── columns: x:5(int) onecolumn.x:1(int) onecolumn.rowid:2(int) othercolumn.x:3(int) othercolumn.rowid:4(int)
  │    ├── full-join
- │    │    ├── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:null:2 othercolumn.x:int:null:3 othercolumn.rowid:int:null:4
+ │    │    ├── columns: onecolumn.x:1(int) onecolumn.rowid:2(int) othercolumn.x:3(int) othercolumn.rowid:4(int)
  │    │    ├── scan
- │    │    │    └── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2
+ │    │    │    └── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null)
  │    │    ├── scan
- │    │    │    └── columns: othercolumn.x:int:null:3 othercolumn.rowid:int:4
+ │    │    │    └── columns: othercolumn.x:3(int) othercolumn.rowid:4(int!null)
  │    │    └── eq [type=bool, outer=(1,3)]
  │    │         ├── variable: onecolumn.x [type=int, outer=(1)]
  │    │         └── variable: othercolumn.x [type=int, outer=(3)]
@@ -371,13 +371,13 @@ build
 SELECT * FROM onecolumn AS a(x) CROSS JOIN empty AS b(y)
 ----
 project
- ├── columns: x:int:null:1 y:int:null:3
+ ├── columns: x:1(int) y:3(int)
  ├── inner-join
- │    ├── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2 empty.x:int:null:3 empty.rowid:int:4
+ │    ├── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null) empty.x:3(int) empty.rowid:4(int!null)
  │    ├── scan
- │    │    └── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2
+ │    │    └── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null)
  │    ├── scan
- │    │    └── columns: empty.x:int:null:3 empty.rowid:int:4
+ │    │    └── columns: empty.x:3(int) empty.rowid:4(int!null)
  │    └── true [type=bool]
  └── projections [outer=(1,3)]
       ├── variable: onecolumn.x [type=int, outer=(1)]
@@ -387,13 +387,13 @@ build
 SELECT * FROM empty AS a CROSS JOIN onecolumn AS b
 ----
 project
- ├── columns: x:int:null:1 x:int:null:3
+ ├── columns: x:1(int) x:3(int)
  ├── inner-join
- │    ├── columns: empty.x:int:null:1 empty.rowid:int:2 onecolumn.x:int:null:3 onecolumn.rowid:int:4
+ │    ├── columns: empty.x:1(int) empty.rowid:2(int!null) onecolumn.x:3(int) onecolumn.rowid:4(int!null)
  │    ├── scan
- │    │    └── columns: empty.x:int:null:1 empty.rowid:int:2
+ │    │    └── columns: empty.x:1(int) empty.rowid:2(int!null)
  │    ├── scan
- │    │    └── columns: onecolumn.x:int:null:3 onecolumn.rowid:int:4
+ │    │    └── columns: onecolumn.x:3(int) onecolumn.rowid:4(int!null)
  │    └── true [type=bool]
  └── projections [outer=(1,3)]
       ├── variable: empty.x [type=int, outer=(1)]
@@ -403,13 +403,13 @@ build
 SELECT * FROM onecolumn AS a(x) JOIN empty AS b(y) ON a.x = b.y
 ----
 project
- ├── columns: x:int:null:1 y:int:null:3
+ ├── columns: x:1(int) y:3(int)
  ├── inner-join
- │    ├── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2 empty.x:int:null:3 empty.rowid:int:4
+ │    ├── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null) empty.x:3(int) empty.rowid:4(int!null)
  │    ├── scan
- │    │    └── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2
+ │    │    └── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null)
  │    ├── scan
- │    │    └── columns: empty.x:int:null:3 empty.rowid:int:4
+ │    │    └── columns: empty.x:3(int) empty.rowid:4(int!null)
  │    └── eq [type=bool, outer=(1,3)]
  │         ├── variable: onecolumn.x [type=int, outer=(1)]
  │         └── variable: empty.x [type=int, outer=(3)]
@@ -421,13 +421,13 @@ build
 SELECT * FROM onecolumn AS a JOIN empty AS b USING(x)
 ----
 project
- ├── columns: x:int:null:1
+ ├── columns: x:1(int)
  ├── inner-join
- │    ├── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2 empty.x:int:null:3 empty.rowid:int:4
+ │    ├── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null) empty.x:3(int) empty.rowid:4(int!null)
  │    ├── scan
- │    │    └── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2
+ │    │    └── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null)
  │    ├── scan
- │    │    └── columns: empty.x:int:null:3 empty.rowid:int:4
+ │    │    └── columns: empty.x:3(int) empty.rowid:4(int!null)
  │    └── eq [type=bool, outer=(1,3)]
  │         ├── variable: onecolumn.x [type=int, outer=(1)]
  │         └── variable: empty.x [type=int, outer=(3)]
@@ -438,13 +438,13 @@ build
 SELECT * FROM empty AS a(x) JOIN onecolumn AS b(y) ON a.x = b.y
 ----
 project
- ├── columns: x:int:null:1 y:int:null:3
+ ├── columns: x:1(int) y:3(int)
  ├── inner-join
- │    ├── columns: empty.x:int:null:1 empty.rowid:int:2 onecolumn.x:int:null:3 onecolumn.rowid:int:4
+ │    ├── columns: empty.x:1(int) empty.rowid:2(int!null) onecolumn.x:3(int) onecolumn.rowid:4(int!null)
  │    ├── scan
- │    │    └── columns: empty.x:int:null:1 empty.rowid:int:2
+ │    │    └── columns: empty.x:1(int) empty.rowid:2(int!null)
  │    ├── scan
- │    │    └── columns: onecolumn.x:int:null:3 onecolumn.rowid:int:4
+ │    │    └── columns: onecolumn.x:3(int) onecolumn.rowid:4(int!null)
  │    └── eq [type=bool, outer=(1,3)]
  │         ├── variable: empty.x [type=int, outer=(1)]
  │         └── variable: onecolumn.x [type=int, outer=(3)]
@@ -456,13 +456,13 @@ build
 SELECT * FROM empty AS a JOIN onecolumn AS b USING(x)
 ----
 project
- ├── columns: x:int:null:1
+ ├── columns: x:1(int)
  ├── inner-join
- │    ├── columns: empty.x:int:null:1 empty.rowid:int:2 onecolumn.x:int:null:3 onecolumn.rowid:int:4
+ │    ├── columns: empty.x:1(int) empty.rowid:2(int!null) onecolumn.x:3(int) onecolumn.rowid:4(int!null)
  │    ├── scan
- │    │    └── columns: empty.x:int:null:1 empty.rowid:int:2
+ │    │    └── columns: empty.x:1(int) empty.rowid:2(int!null)
  │    ├── scan
- │    │    └── columns: onecolumn.x:int:null:3 onecolumn.rowid:int:4
+ │    │    └── columns: onecolumn.x:3(int) onecolumn.rowid:4(int!null)
  │    └── eq [type=bool, outer=(1,3)]
  │         ├── variable: empty.x [type=int, outer=(1)]
  │         └── variable: onecolumn.x [type=int, outer=(3)]
@@ -473,13 +473,13 @@ build
 SELECT * FROM onecolumn AS a(x) LEFT OUTER JOIN empty AS b(y) ON a.x = b.y
 ----
 project
- ├── columns: x:int:null:1 y:int:null:3
+ ├── columns: x:1(int) y:3(int)
  ├── left-join
- │    ├── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2 empty.x:int:null:3 empty.rowid:int:null:4
+ │    ├── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null) empty.x:3(int) empty.rowid:4(int)
  │    ├── scan
- │    │    └── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2
+ │    │    └── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null)
  │    ├── scan
- │    │    └── columns: empty.x:int:null:3 empty.rowid:int:4
+ │    │    └── columns: empty.x:3(int) empty.rowid:4(int!null)
  │    └── eq [type=bool, outer=(1,3)]
  │         ├── variable: onecolumn.x [type=int, outer=(1)]
  │         └── variable: empty.x [type=int, outer=(3)]
@@ -491,13 +491,13 @@ build
 SELECT * FROM onecolumn AS a LEFT OUTER JOIN empty AS b USING(x)
 ----
 project
- ├── columns: x:int:null:1
+ ├── columns: x:1(int)
  ├── left-join
- │    ├── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2 empty.x:int:null:3 empty.rowid:int:null:4
+ │    ├── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null) empty.x:3(int) empty.rowid:4(int)
  │    ├── scan
- │    │    └── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2
+ │    │    └── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null)
  │    ├── scan
- │    │    └── columns: empty.x:int:null:3 empty.rowid:int:4
+ │    │    └── columns: empty.x:3(int) empty.rowid:4(int!null)
  │    └── eq [type=bool, outer=(1,3)]
  │         ├── variable: onecolumn.x [type=int, outer=(1)]
  │         └── variable: empty.x [type=int, outer=(3)]
@@ -508,13 +508,13 @@ build
 SELECT * FROM empty AS a(x) LEFT OUTER JOIN onecolumn AS b(y) ON a.x = b.y
 ----
 project
- ├── columns: x:int:null:1 y:int:null:3
+ ├── columns: x:1(int) y:3(int)
  ├── left-join
- │    ├── columns: empty.x:int:null:1 empty.rowid:int:2 onecolumn.x:int:null:3 onecolumn.rowid:int:null:4
+ │    ├── columns: empty.x:1(int) empty.rowid:2(int!null) onecolumn.x:3(int) onecolumn.rowid:4(int)
  │    ├── scan
- │    │    └── columns: empty.x:int:null:1 empty.rowid:int:2
+ │    │    └── columns: empty.x:1(int) empty.rowid:2(int!null)
  │    ├── scan
- │    │    └── columns: onecolumn.x:int:null:3 onecolumn.rowid:int:4
+ │    │    └── columns: onecolumn.x:3(int) onecolumn.rowid:4(int!null)
  │    └── eq [type=bool, outer=(1,3)]
  │         ├── variable: empty.x [type=int, outer=(1)]
  │         └── variable: onecolumn.x [type=int, outer=(3)]
@@ -526,13 +526,13 @@ build
 SELECT * FROM empty AS a LEFT OUTER JOIN onecolumn AS b USING(x)
 ----
 project
- ├── columns: x:int:null:1
+ ├── columns: x:1(int)
  ├── left-join
- │    ├── columns: empty.x:int:null:1 empty.rowid:int:2 onecolumn.x:int:null:3 onecolumn.rowid:int:null:4
+ │    ├── columns: empty.x:1(int) empty.rowid:2(int!null) onecolumn.x:3(int) onecolumn.rowid:4(int)
  │    ├── scan
- │    │    └── columns: empty.x:int:null:1 empty.rowid:int:2
+ │    │    └── columns: empty.x:1(int) empty.rowid:2(int!null)
  │    ├── scan
- │    │    └── columns: onecolumn.x:int:null:3 onecolumn.rowid:int:4
+ │    │    └── columns: onecolumn.x:3(int) onecolumn.rowid:4(int!null)
  │    └── eq [type=bool, outer=(1,3)]
  │         ├── variable: empty.x [type=int, outer=(1)]
  │         └── variable: onecolumn.x [type=int, outer=(3)]
@@ -543,13 +543,13 @@ build
 SELECT * FROM onecolumn AS a(x) RIGHT OUTER JOIN empty AS b(y) ON a.x = b.y
 ----
 project
- ├── columns: x:int:null:1 y:int:null:3
+ ├── columns: x:1(int) y:3(int)
  ├── right-join
- │    ├── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:null:2 empty.x:int:null:3 empty.rowid:int:4
+ │    ├── columns: onecolumn.x:1(int) onecolumn.rowid:2(int) empty.x:3(int) empty.rowid:4(int!null)
  │    ├── scan
- │    │    └── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2
+ │    │    └── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null)
  │    ├── scan
- │    │    └── columns: empty.x:int:null:3 empty.rowid:int:4
+ │    │    └── columns: empty.x:3(int) empty.rowid:4(int!null)
  │    └── eq [type=bool, outer=(1,3)]
  │         ├── variable: onecolumn.x [type=int, outer=(1)]
  │         └── variable: empty.x [type=int, outer=(3)]
@@ -561,13 +561,13 @@ build
 SELECT * FROM onecolumn AS a RIGHT OUTER JOIN empty AS b USING(x)
 ----
 project
- ├── columns: x:int:null:3
+ ├── columns: x:3(int)
  ├── right-join
- │    ├── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:null:2 empty.x:int:null:3 empty.rowid:int:4
+ │    ├── columns: onecolumn.x:1(int) onecolumn.rowid:2(int) empty.x:3(int) empty.rowid:4(int!null)
  │    ├── scan
- │    │    └── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2
+ │    │    └── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null)
  │    ├── scan
- │    │    └── columns: empty.x:int:null:3 empty.rowid:int:4
+ │    │    └── columns: empty.x:3(int) empty.rowid:4(int!null)
  │    └── eq [type=bool, outer=(1,3)]
  │         ├── variable: onecolumn.x [type=int, outer=(1)]
  │         └── variable: empty.x [type=int, outer=(3)]
@@ -578,13 +578,13 @@ build
 SELECT * FROM empty AS a(x) FULL OUTER JOIN onecolumn AS b(y) ON a.x = b.y
 ----
 project
- ├── columns: x:int:null:1 y:int:null:3
+ ├── columns: x:1(int) y:3(int)
  ├── full-join
- │    ├── columns: empty.x:int:null:1 empty.rowid:int:null:2 onecolumn.x:int:null:3 onecolumn.rowid:int:null:4
+ │    ├── columns: empty.x:1(int) empty.rowid:2(int) onecolumn.x:3(int) onecolumn.rowid:4(int)
  │    ├── scan
- │    │    └── columns: empty.x:int:null:1 empty.rowid:int:2
+ │    │    └── columns: empty.x:1(int) empty.rowid:2(int!null)
  │    ├── scan
- │    │    └── columns: onecolumn.x:int:null:3 onecolumn.rowid:int:4
+ │    │    └── columns: onecolumn.x:3(int) onecolumn.rowid:4(int!null)
  │    └── eq [type=bool, outer=(1,3)]
  │         ├── variable: empty.x [type=int, outer=(1)]
  │         └── variable: onecolumn.x [type=int, outer=(3)]
@@ -596,15 +596,15 @@ build
 SELECT * FROM empty AS a FULL OUTER JOIN onecolumn AS b USING(x)
 ----
 project
- ├── columns: x:int:null:5
+ ├── columns: x:5(int)
  ├── project
- │    ├── columns: x:int:null:5 empty.x:int:null:1 empty.rowid:int:null:2 onecolumn.x:int:null:3 onecolumn.rowid:int:null:4
+ │    ├── columns: x:5(int) empty.x:1(int) empty.rowid:2(int) onecolumn.x:3(int) onecolumn.rowid:4(int)
  │    ├── full-join
- │    │    ├── columns: empty.x:int:null:1 empty.rowid:int:null:2 onecolumn.x:int:null:3 onecolumn.rowid:int:null:4
+ │    │    ├── columns: empty.x:1(int) empty.rowid:2(int) onecolumn.x:3(int) onecolumn.rowid:4(int)
  │    │    ├── scan
- │    │    │    └── columns: empty.x:int:null:1 empty.rowid:int:2
+ │    │    │    └── columns: empty.x:1(int) empty.rowid:2(int!null)
  │    │    ├── scan
- │    │    │    └── columns: onecolumn.x:int:null:3 onecolumn.rowid:int:4
+ │    │    │    └── columns: onecolumn.x:3(int) onecolumn.rowid:4(int!null)
  │    │    └── eq [type=bool, outer=(1,3)]
  │    │         ├── variable: empty.x [type=int, outer=(1)]
  │    │         └── variable: onecolumn.x [type=int, outer=(3)]
@@ -623,13 +623,13 @@ build
 SELECT * FROM onecolumn AS a(x) FULL OUTER JOIN empty AS b(y) ON a.x = b.y
 ----
 project
- ├── columns: x:int:null:1 y:int:null:3
+ ├── columns: x:1(int) y:3(int)
  ├── full-join
- │    ├── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:null:2 empty.x:int:null:3 empty.rowid:int:null:4
+ │    ├── columns: onecolumn.x:1(int) onecolumn.rowid:2(int) empty.x:3(int) empty.rowid:4(int)
  │    ├── scan
- │    │    └── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2
+ │    │    └── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null)
  │    ├── scan
- │    │    └── columns: empty.x:int:null:3 empty.rowid:int:4
+ │    │    └── columns: empty.x:3(int) empty.rowid:4(int!null)
  │    └── eq [type=bool, outer=(1,3)]
  │         ├── variable: onecolumn.x [type=int, outer=(1)]
  │         └── variable: empty.x [type=int, outer=(3)]
@@ -641,15 +641,15 @@ build
 SELECT * FROM onecolumn AS a FULL OUTER JOIN empty AS b USING(x)
 ----
 project
- ├── columns: x:int:null:5
+ ├── columns: x:5(int)
  ├── project
- │    ├── columns: x:int:null:5 onecolumn.x:int:null:1 onecolumn.rowid:int:null:2 empty.x:int:null:3 empty.rowid:int:null:4
+ │    ├── columns: x:5(int) onecolumn.x:1(int) onecolumn.rowid:2(int) empty.x:3(int) empty.rowid:4(int)
  │    ├── full-join
- │    │    ├── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:null:2 empty.x:int:null:3 empty.rowid:int:null:4
+ │    │    ├── columns: onecolumn.x:1(int) onecolumn.rowid:2(int) empty.x:3(int) empty.rowid:4(int)
  │    │    ├── scan
- │    │    │    └── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2
+ │    │    │    └── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null)
  │    │    ├── scan
- │    │    │    └── columns: empty.x:int:null:3 empty.rowid:int:4
+ │    │    │    └── columns: empty.x:3(int) empty.rowid:4(int!null)
  │    │    └── eq [type=bool, outer=(1,3)]
  │    │         ├── variable: onecolumn.x [type=int, outer=(1)]
  │    │         └── variable: empty.x [type=int, outer=(3)]
@@ -679,13 +679,13 @@ build
 SELECT * FROM onecolumn NATURAL JOIN twocolumn
 ----
 project
- ├── columns: x:int:null:1 y:int:null:4
+ ├── columns: x:1(int) y:4(int)
  ├── inner-join
- │    ├── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2 twocolumn.x:int:null:3 twocolumn.y:int:null:4 twocolumn.rowid:int:5
+ │    ├── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null) twocolumn.x:3(int) twocolumn.y:4(int) twocolumn.rowid:5(int!null)
  │    ├── scan
- │    │    └── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2
+ │    │    └── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null)
  │    ├── scan
- │    │    └── columns: twocolumn.x:int:null:3 twocolumn.y:int:null:4 twocolumn.rowid:int:5
+ │    │    └── columns: twocolumn.x:3(int) twocolumn.y:4(int) twocolumn.rowid:5(int!null)
  │    └── eq [type=bool, outer=(1,3)]
  │         ├── variable: onecolumn.x [type=int, outer=(1)]
  │         └── variable: twocolumn.x [type=int, outer=(3)]
@@ -697,13 +697,13 @@ build
 SELECT * FROM onecolumn JOIN twocolumn USING(x)
 ----
 project
- ├── columns: x:int:null:1 y:int:null:4
+ ├── columns: x:1(int) y:4(int)
  ├── inner-join
- │    ├── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2 twocolumn.x:int:null:3 twocolumn.y:int:null:4 twocolumn.rowid:int:5
+ │    ├── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null) twocolumn.x:3(int) twocolumn.y:4(int) twocolumn.rowid:5(int!null)
  │    ├── scan
- │    │    └── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2
+ │    │    └── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null)
  │    ├── scan
- │    │    └── columns: twocolumn.x:int:null:3 twocolumn.y:int:null:4 twocolumn.rowid:int:5
+ │    │    └── columns: twocolumn.x:3(int) twocolumn.y:4(int) twocolumn.rowid:5(int!null)
  │    └── eq [type=bool, outer=(1,3)]
  │         ├── variable: onecolumn.x [type=int, outer=(1)]
  │         └── variable: twocolumn.x [type=int, outer=(3)]
@@ -715,13 +715,13 @@ build
 SELECT * FROM twocolumn AS a JOIN twocolumn AS b ON a.x = b.y
 ----
 project
- ├── columns: x:int:null:1 y:int:null:2 x:int:null:4 y:int:null:5
+ ├── columns: x:1(int) y:2(int) x:4(int) y:5(int)
  ├── inner-join
- │    ├── columns: twocolumn.x:int:null:1 twocolumn.y:int:null:2 twocolumn.rowid:int:3 twocolumn.x:int:null:4 twocolumn.y:int:null:5 twocolumn.rowid:int:6
+ │    ├── columns: twocolumn.x:1(int) twocolumn.y:2(int) twocolumn.rowid:3(int!null) twocolumn.x:4(int) twocolumn.y:5(int) twocolumn.rowid:6(int!null)
  │    ├── scan
- │    │    └── columns: twocolumn.x:int:null:1 twocolumn.y:int:null:2 twocolumn.rowid:int:3
+ │    │    └── columns: twocolumn.x:1(int) twocolumn.y:2(int) twocolumn.rowid:3(int!null)
  │    ├── scan
- │    │    └── columns: twocolumn.x:int:null:4 twocolumn.y:int:null:5 twocolumn.rowid:int:6
+ │    │    └── columns: twocolumn.x:4(int) twocolumn.y:5(int) twocolumn.rowid:6(int!null)
  │    └── eq [type=bool, outer=(1,5)]
  │         ├── variable: twocolumn.x [type=int, outer=(1)]
  │         └── variable: twocolumn.y [type=int, outer=(5)]
@@ -735,13 +735,13 @@ build
 SELECT * FROM twocolumn AS a JOIN twocolumn AS b ON a.x = a.y
 ----
 project
- ├── columns: x:int:null:1 y:int:null:2 x:int:null:4 y:int:null:5
+ ├── columns: x:1(int) y:2(int) x:4(int) y:5(int)
  ├── inner-join
- │    ├── columns: twocolumn.x:int:null:1 twocolumn.y:int:null:2 twocolumn.rowid:int:3 twocolumn.x:int:null:4 twocolumn.y:int:null:5 twocolumn.rowid:int:6
+ │    ├── columns: twocolumn.x:1(int) twocolumn.y:2(int) twocolumn.rowid:3(int!null) twocolumn.x:4(int) twocolumn.y:5(int) twocolumn.rowid:6(int!null)
  │    ├── scan
- │    │    └── columns: twocolumn.x:int:null:1 twocolumn.y:int:null:2 twocolumn.rowid:int:3
+ │    │    └── columns: twocolumn.x:1(int) twocolumn.y:2(int) twocolumn.rowid:3(int!null)
  │    ├── scan
- │    │    └── columns: twocolumn.x:int:null:4 twocolumn.y:int:null:5 twocolumn.rowid:int:6
+ │    │    └── columns: twocolumn.x:4(int) twocolumn.y:5(int) twocolumn.rowid:6(int!null)
  │    └── eq [type=bool, outer=(1,2)]
  │         ├── variable: twocolumn.x [type=int, outer=(1)]
  │         └── variable: twocolumn.y [type=int, outer=(2)]
@@ -755,13 +755,13 @@ build
 SELECT * FROM onecolumn AS a JOIN twocolumn AS b ON ((a.x)) = ((b.y))
 ----
 project
- ├── columns: x:int:null:1 x:int:null:3 y:int:null:4
+ ├── columns: x:1(int) x:3(int) y:4(int)
  ├── inner-join
- │    ├── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2 twocolumn.x:int:null:3 twocolumn.y:int:null:4 twocolumn.rowid:int:5
+ │    ├── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null) twocolumn.x:3(int) twocolumn.y:4(int) twocolumn.rowid:5(int!null)
  │    ├── scan
- │    │    └── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2
+ │    │    └── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null)
  │    ├── scan
- │    │    └── columns: twocolumn.x:int:null:3 twocolumn.y:int:null:4 twocolumn.rowid:int:5
+ │    │    └── columns: twocolumn.x:3(int) twocolumn.y:4(int) twocolumn.rowid:5(int!null)
  │    └── eq [type=bool, outer=(1,4)]
  │         ├── variable: onecolumn.x [type=int, outer=(1)]
  │         └── variable: twocolumn.y [type=int, outer=(4)]
@@ -774,13 +774,13 @@ build
 SELECT * FROM onecolumn JOIN twocolumn ON onecolumn.x = twocolumn.y
 ----
 project
- ├── columns: x:int:null:1 x:int:null:3 y:int:null:4
+ ├── columns: x:1(int) x:3(int) y:4(int)
  ├── inner-join
- │    ├── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2 twocolumn.x:int:null:3 twocolumn.y:int:null:4 twocolumn.rowid:int:5
+ │    ├── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null) twocolumn.x:3(int) twocolumn.y:4(int) twocolumn.rowid:5(int!null)
  │    ├── scan
- │    │    └── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2
+ │    │    └── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null)
  │    ├── scan
- │    │    └── columns: twocolumn.x:int:null:3 twocolumn.y:int:null:4 twocolumn.rowid:int:5
+ │    │    └── columns: twocolumn.x:3(int) twocolumn.y:4(int) twocolumn.rowid:5(int!null)
  │    └── eq [type=bool, outer=(1,4)]
  │         ├── variable: onecolumn.x [type=int, outer=(1)]
  │         └── variable: twocolumn.y [type=int, outer=(4)]
@@ -794,13 +794,13 @@ build
 SELECT * FROM twocolumn AS a JOIN twocolumn AS b ON a.x = 44
 ----
 project
- ├── columns: x:int:null:1 y:int:null:2 x:int:null:4 y:int:null:5
+ ├── columns: x:1(int) y:2(int) x:4(int) y:5(int)
  ├── inner-join
- │    ├── columns: twocolumn.x:int:null:1 twocolumn.y:int:null:2 twocolumn.rowid:int:3 twocolumn.x:int:null:4 twocolumn.y:int:null:5 twocolumn.rowid:int:6
+ │    ├── columns: twocolumn.x:1(int) twocolumn.y:2(int) twocolumn.rowid:3(int!null) twocolumn.x:4(int) twocolumn.y:5(int) twocolumn.rowid:6(int!null)
  │    ├── scan
- │    │    └── columns: twocolumn.x:int:null:1 twocolumn.y:int:null:2 twocolumn.rowid:int:3
+ │    │    └── columns: twocolumn.x:1(int) twocolumn.y:2(int) twocolumn.rowid:3(int!null)
  │    ├── scan
- │    │    └── columns: twocolumn.x:int:null:4 twocolumn.y:int:null:5 twocolumn.rowid:int:6
+ │    │    └── columns: twocolumn.x:4(int) twocolumn.y:5(int) twocolumn.rowid:6(int!null)
  │    └── eq [type=bool, outer=(1)]
  │         ├── variable: twocolumn.x [type=int, outer=(1)]
  │         └── const: 44 [type=int]
@@ -814,13 +814,13 @@ build
 SELECT o.x, t.y FROM onecolumn o INNER JOIN twocolumn t ON (o.x=t.x AND t.y=53)
 ----
 project
- ├── columns: x:int:null:1 y:int:null:4
+ ├── columns: x:1(int) y:4(int)
  ├── inner-join
- │    ├── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2 twocolumn.x:int:null:3 twocolumn.y:int:null:4 twocolumn.rowid:int:5
+ │    ├── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null) twocolumn.x:3(int) twocolumn.y:4(int) twocolumn.rowid:5(int!null)
  │    ├── scan
- │    │    └── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2
+ │    │    └── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null)
  │    ├── scan
- │    │    └── columns: twocolumn.x:int:null:3 twocolumn.y:int:null:4 twocolumn.rowid:int:5
+ │    │    └── columns: twocolumn.x:3(int) twocolumn.y:4(int) twocolumn.rowid:5(int!null)
  │    └── and [type=bool, outer=(1,3,4)]
  │         ├── eq [type=bool, outer=(1,3)]
  │         │    ├── variable: onecolumn.x [type=int, outer=(1)]
@@ -837,13 +837,13 @@ build
 SELECT o.x, t.y FROM onecolumn o LEFT OUTER JOIN twocolumn t ON (o.x=t.x AND t.y=53)
 ----
 project
- ├── columns: x:int:null:1 y:int:null:4
+ ├── columns: x:1(int) y:4(int)
  ├── left-join
- │    ├── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2 twocolumn.x:int:null:3 twocolumn.y:int:null:4 twocolumn.rowid:int:null:5
+ │    ├── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null) twocolumn.x:3(int) twocolumn.y:4(int) twocolumn.rowid:5(int)
  │    ├── scan
- │    │    └── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2
+ │    │    └── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null)
  │    ├── scan
- │    │    └── columns: twocolumn.x:int:null:3 twocolumn.y:int:null:4 twocolumn.rowid:int:5
+ │    │    └── columns: twocolumn.x:3(int) twocolumn.y:4(int) twocolumn.rowid:5(int!null)
  │    └── and [type=bool, outer=(1,3,4)]
  │         ├── eq [type=bool, outer=(1,3)]
  │         │    ├── variable: onecolumn.x [type=int, outer=(1)]
@@ -859,13 +859,13 @@ build
 SELECT o.x, t.y FROM onecolumn o LEFT OUTER JOIN twocolumn t ON (o.x=t.x AND o.x=44)
 ----
 project
- ├── columns: x:int:null:1 y:int:null:4
+ ├── columns: x:1(int) y:4(int)
  ├── left-join
- │    ├── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2 twocolumn.x:int:null:3 twocolumn.y:int:null:4 twocolumn.rowid:int:null:5
+ │    ├── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null) twocolumn.x:3(int) twocolumn.y:4(int) twocolumn.rowid:5(int)
  │    ├── scan
- │    │    └── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2
+ │    │    └── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null)
  │    ├── scan
- │    │    └── columns: twocolumn.x:int:null:3 twocolumn.y:int:null:4 twocolumn.rowid:int:5
+ │    │    └── columns: twocolumn.x:3(int) twocolumn.y:4(int) twocolumn.rowid:5(int!null)
  │    └── and [type=bool, outer=(1,3)]
  │         ├── eq [type=bool, outer=(1,3)]
  │         │    ├── variable: onecolumn.x [type=int, outer=(1)]
@@ -881,13 +881,13 @@ build
 SELECT o.x, t.y FROM onecolumn o LEFT OUTER JOIN twocolumn t ON (o.x=t.x AND t.x=44)
 ----
 project
- ├── columns: x:int:null:1 y:int:null:4
+ ├── columns: x:1(int) y:4(int)
  ├── left-join
- │    ├── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2 twocolumn.x:int:null:3 twocolumn.y:int:null:4 twocolumn.rowid:int:null:5
+ │    ├── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null) twocolumn.x:3(int) twocolumn.y:4(int) twocolumn.rowid:5(int)
  │    ├── scan
- │    │    └── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2
+ │    │    └── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null)
  │    ├── scan
- │    │    └── columns: twocolumn.x:int:null:3 twocolumn.y:int:null:4 twocolumn.rowid:int:5
+ │    │    └── columns: twocolumn.x:3(int) twocolumn.y:4(int) twocolumn.rowid:5(int!null)
  │    └── and [type=bool, outer=(1,3)]
  │         ├── eq [type=bool, outer=(1,3)]
  │         │    ├── variable: onecolumn.x [type=int, outer=(1)]
@@ -935,13 +935,13 @@ build
 SELECT * FROM a INNER JOIN b ON a.i = b.i
 ----
 project
- ├── columns: i:int:null:1 i:int:null:3 b:bool:null:4
+ ├── columns: i:1(int) i:3(int) b:4(bool)
  ├── inner-join
- │    ├── columns: a.i:int:null:1 a.rowid:int:2 b.i:int:null:3 b.b:bool:null:4 b.rowid:int:5
+ │    ├── columns: a.i:1(int) a.rowid:2(int!null) b.i:3(int) b.b:4(bool) b.rowid:5(int!null)
  │    ├── scan
- │    │    └── columns: a.i:int:null:1 a.rowid:int:2
+ │    │    └── columns: a.i:1(int) a.rowid:2(int!null)
  │    ├── scan
- │    │    └── columns: b.i:int:null:3 b.b:bool:null:4 b.rowid:int:5
+ │    │    └── columns: b.i:3(int) b.b:4(bool) b.rowid:5(int!null)
  │    └── eq [type=bool, outer=(1,3)]
  │         ├── variable: a.i [type=int, outer=(1)]
  │         └── variable: b.i [type=int, outer=(3)]
@@ -954,13 +954,13 @@ build
 SELECT * FROM a LEFT OUTER JOIN b ON a.i = b.i
 ----
 project
- ├── columns: i:int:null:1 i:int:null:3 b:bool:null:4
+ ├── columns: i:1(int) i:3(int) b:4(bool)
  ├── left-join
- │    ├── columns: a.i:int:null:1 a.rowid:int:2 b.i:int:null:3 b.b:bool:null:4 b.rowid:int:null:5
+ │    ├── columns: a.i:1(int) a.rowid:2(int!null) b.i:3(int) b.b:4(bool) b.rowid:5(int)
  │    ├── scan
- │    │    └── columns: a.i:int:null:1 a.rowid:int:2
+ │    │    └── columns: a.i:1(int) a.rowid:2(int!null)
  │    ├── scan
- │    │    └── columns: b.i:int:null:3 b.b:bool:null:4 b.rowid:int:5
+ │    │    └── columns: b.i:3(int) b.b:4(bool) b.rowid:5(int!null)
  │    └── eq [type=bool, outer=(1,3)]
  │         ├── variable: a.i [type=int, outer=(1)]
  │         └── variable: b.i [type=int, outer=(3)]
@@ -973,13 +973,13 @@ build
 SELECT * FROM a RIGHT OUTER JOIN b ON a.i = b.i
 ----
 project
- ├── columns: i:int:null:1 i:int:null:3 b:bool:null:4
+ ├── columns: i:1(int) i:3(int) b:4(bool)
  ├── right-join
- │    ├── columns: a.i:int:null:1 a.rowid:int:null:2 b.i:int:null:3 b.b:bool:null:4 b.rowid:int:5
+ │    ├── columns: a.i:1(int) a.rowid:2(int) b.i:3(int) b.b:4(bool) b.rowid:5(int!null)
  │    ├── scan
- │    │    └── columns: a.i:int:null:1 a.rowid:int:2
+ │    │    └── columns: a.i:1(int) a.rowid:2(int!null)
  │    ├── scan
- │    │    └── columns: b.i:int:null:3 b.b:bool:null:4 b.rowid:int:5
+ │    │    └── columns: b.i:3(int) b.b:4(bool) b.rowid:5(int!null)
  │    └── eq [type=bool, outer=(1,3)]
  │         ├── variable: a.i [type=int, outer=(1)]
  │         └── variable: b.i [type=int, outer=(3)]
@@ -992,13 +992,13 @@ build
 SELECT * FROM a FULL OUTER JOIN b ON a.i = b.i
 ----
 project
- ├── columns: i:int:null:1 i:int:null:3 b:bool:null:4
+ ├── columns: i:1(int) i:3(int) b:4(bool)
  ├── full-join
- │    ├── columns: a.i:int:null:1 a.rowid:int:null:2 b.i:int:null:3 b.b:bool:null:4 b.rowid:int:null:5
+ │    ├── columns: a.i:1(int) a.rowid:2(int) b.i:3(int) b.b:4(bool) b.rowid:5(int)
  │    ├── scan
- │    │    └── columns: a.i:int:null:1 a.rowid:int:2
+ │    │    └── columns: a.i:1(int) a.rowid:2(int!null)
  │    ├── scan
- │    │    └── columns: b.i:int:null:3 b.b:bool:null:4 b.rowid:int:5
+ │    │    └── columns: b.i:3(int) b.b:4(bool) b.rowid:5(int!null)
  │    └── eq [type=bool, outer=(1,3)]
  │         ├── variable: a.i [type=int, outer=(1)]
  │         └── variable: b.i [type=int, outer=(3)]
@@ -1012,13 +1012,13 @@ build
 SELECT * FROM a FULL OUTER JOIN b ON (a.i = b.i and a.i>2)
 ----
 project
- ├── columns: i:int:null:1 i:int:null:3 b:bool:null:4
+ ├── columns: i:1(int) i:3(int) b:4(bool)
  ├── full-join
- │    ├── columns: a.i:int:null:1 a.rowid:int:null:2 b.i:int:null:3 b.b:bool:null:4 b.rowid:int:null:5
+ │    ├── columns: a.i:1(int) a.rowid:2(int) b.i:3(int) b.b:4(bool) b.rowid:5(int)
  │    ├── scan
- │    │    └── columns: a.i:int:null:1 a.rowid:int:2
+ │    │    └── columns: a.i:1(int) a.rowid:2(int!null)
  │    ├── scan
- │    │    └── columns: b.i:int:null:3 b.b:bool:null:4 b.rowid:int:5
+ │    │    └── columns: b.i:3(int) b.b:4(bool) b.rowid:5(int!null)
  │    └── and [type=bool, outer=(1,3)]
  │         ├── eq [type=bool, outer=(1,3)]
  │         │    ├── variable: a.i [type=int, outer=(1)]
@@ -1036,25 +1036,25 @@ build
 SELECT * FROM (onecolumn CROSS JOIN twocolumn JOIN onecolumn AS a(b) ON a.b=twocolumn.x JOIN twocolumn AS c(d,e) ON a.b=c.d AND c.d=onecolumn.x)
 ----
 project
- ├── columns: x:int:null:1 x:int:null:3 y:int:null:4 b:int:null:6 d:int:null:8 e:int:null:9
+ ├── columns: x:1(int) x:3(int) y:4(int) b:6(int) d:8(int) e:9(int)
  ├── inner-join
- │    ├── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2 twocolumn.x:int:null:3 twocolumn.y:int:null:4 twocolumn.rowid:int:5 onecolumn.x:int:null:6 onecolumn.rowid:int:7 twocolumn.x:int:null:8 twocolumn.y:int:null:9 twocolumn.rowid:int:10
+ │    ├── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null) twocolumn.x:3(int) twocolumn.y:4(int) twocolumn.rowid:5(int!null) onecolumn.x:6(int) onecolumn.rowid:7(int!null) twocolumn.x:8(int) twocolumn.y:9(int) twocolumn.rowid:10(int!null)
  │    ├── inner-join
- │    │    ├── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2 twocolumn.x:int:null:3 twocolumn.y:int:null:4 twocolumn.rowid:int:5 onecolumn.x:int:null:6 onecolumn.rowid:int:7
+ │    │    ├── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null) twocolumn.x:3(int) twocolumn.y:4(int) twocolumn.rowid:5(int!null) onecolumn.x:6(int) onecolumn.rowid:7(int!null)
  │    │    ├── inner-join
- │    │    │    ├── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2 twocolumn.x:int:null:3 twocolumn.y:int:null:4 twocolumn.rowid:int:5
+ │    │    │    ├── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null) twocolumn.x:3(int) twocolumn.y:4(int) twocolumn.rowid:5(int!null)
  │    │    │    ├── scan
- │    │    │    │    └── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2
+ │    │    │    │    └── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null)
  │    │    │    ├── scan
- │    │    │    │    └── columns: twocolumn.x:int:null:3 twocolumn.y:int:null:4 twocolumn.rowid:int:5
+ │    │    │    │    └── columns: twocolumn.x:3(int) twocolumn.y:4(int) twocolumn.rowid:5(int!null)
  │    │    │    └── true [type=bool]
  │    │    ├── scan
- │    │    │    └── columns: onecolumn.x:int:null:6 onecolumn.rowid:int:7
+ │    │    │    └── columns: onecolumn.x:6(int) onecolumn.rowid:7(int!null)
  │    │    └── eq [type=bool, outer=(3,6)]
  │    │         ├── variable: onecolumn.x [type=int, outer=(6)]
  │    │         └── variable: twocolumn.x [type=int, outer=(3)]
  │    ├── scan
- │    │    └── columns: twocolumn.x:int:null:8 twocolumn.y:int:null:9 twocolumn.rowid:int:10
+ │    │    └── columns: twocolumn.x:8(int) twocolumn.y:9(int) twocolumn.rowid:10(int!null)
  │    └── and [type=bool, outer=(1,6,8)]
  │         ├── eq [type=bool, outer=(6,8)]
  │         │    ├── variable: onecolumn.x [type=int, outer=(6)]
@@ -1074,15 +1074,15 @@ build
 SELECT * FROM onecolumn JOIN (SELECT x + 2 AS x FROM onecolumn) USING(x)
 ----
 project
- ├── columns: x:int:null:1
+ ├── columns: x:1(int)
  ├── inner-join
- │    ├── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2 x:int:null:5
+ │    ├── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null) x:5(int)
  │    ├── scan
- │    │    └── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2
+ │    │    └── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null)
  │    ├── project
- │    │    ├── columns: x:int:null:5
+ │    │    ├── columns: x:5(int)
  │    │    ├── scan
- │    │    │    └── columns: onecolumn.x:int:null:3 onecolumn.rowid:int:4
+ │    │    │    └── columns: onecolumn.x:3(int) onecolumn.rowid:4(int!null)
  │    │    └── projections [outer=(3)]
  │    │         └── plus [type=int, outer=(3)]
  │    │              ├── variable: onecolumn.x [type=int, outer=(3)]
@@ -1098,20 +1098,20 @@ build
 SELECT * FROM (twocolumn AS a JOIN twocolumn AS b USING(x) JOIN twocolumn AS c USING(x))
 ----
 project
- ├── columns: x:int:null:1 y:int:null:2 y:int:null:5 y:int:null:8
+ ├── columns: x:1(int) y:2(int) y:5(int) y:8(int)
  ├── inner-join
- │    ├── columns: twocolumn.x:int:null:1 twocolumn.y:int:null:2 twocolumn.rowid:int:3 twocolumn.x:int:null:4 twocolumn.y:int:null:5 twocolumn.rowid:int:6 twocolumn.x:int:null:7 twocolumn.y:int:null:8 twocolumn.rowid:int:9
+ │    ├── columns: twocolumn.x:1(int) twocolumn.y:2(int) twocolumn.rowid:3(int!null) twocolumn.x:4(int) twocolumn.y:5(int) twocolumn.rowid:6(int!null) twocolumn.x:7(int) twocolumn.y:8(int) twocolumn.rowid:9(int!null)
  │    ├── inner-join
- │    │    ├── columns: twocolumn.x:int:null:1 twocolumn.y:int:null:2 twocolumn.rowid:int:3 twocolumn.x:int:null:4 twocolumn.y:int:null:5 twocolumn.rowid:int:6
+ │    │    ├── columns: twocolumn.x:1(int) twocolumn.y:2(int) twocolumn.rowid:3(int!null) twocolumn.x:4(int) twocolumn.y:5(int) twocolumn.rowid:6(int!null)
  │    │    ├── scan
- │    │    │    └── columns: twocolumn.x:int:null:1 twocolumn.y:int:null:2 twocolumn.rowid:int:3
+ │    │    │    └── columns: twocolumn.x:1(int) twocolumn.y:2(int) twocolumn.rowid:3(int!null)
  │    │    ├── scan
- │    │    │    └── columns: twocolumn.x:int:null:4 twocolumn.y:int:null:5 twocolumn.rowid:int:6
+ │    │    │    └── columns: twocolumn.x:4(int) twocolumn.y:5(int) twocolumn.rowid:6(int!null)
  │    │    └── eq [type=bool, outer=(1,4)]
  │    │         ├── variable: twocolumn.x [type=int, outer=(1)]
  │    │         └── variable: twocolumn.x [type=int, outer=(4)]
  │    ├── scan
- │    │    └── columns: twocolumn.x:int:null:7 twocolumn.y:int:null:8 twocolumn.rowid:int:9
+ │    │    └── columns: twocolumn.x:7(int) twocolumn.y:8(int) twocolumn.rowid:9(int!null)
  │    └── eq [type=bool, outer=(1,7)]
  │         ├── variable: twocolumn.x [type=int, outer=(1)]
  │         └── variable: twocolumn.x [type=int, outer=(7)]
@@ -1125,20 +1125,20 @@ build
 SELECT a.x AS s, b.x, c.x, a.y, b.y, c.y FROM (twocolumn AS a JOIN twocolumn AS b USING(x) JOIN twocolumn AS c USING(x))
 ----
 project
- ├── columns: s:int:null:1 x:int:null:4 x:int:null:7 y:int:null:2 y:int:null:5 y:int:null:8
+ ├── columns: s:1(int) x:4(int) x:7(int) y:2(int) y:5(int) y:8(int)
  ├── inner-join
- │    ├── columns: twocolumn.x:int:null:1 twocolumn.y:int:null:2 twocolumn.rowid:int:3 twocolumn.x:int:null:4 twocolumn.y:int:null:5 twocolumn.rowid:int:6 twocolumn.x:int:null:7 twocolumn.y:int:null:8 twocolumn.rowid:int:9
+ │    ├── columns: twocolumn.x:1(int) twocolumn.y:2(int) twocolumn.rowid:3(int!null) twocolumn.x:4(int) twocolumn.y:5(int) twocolumn.rowid:6(int!null) twocolumn.x:7(int) twocolumn.y:8(int) twocolumn.rowid:9(int!null)
  │    ├── inner-join
- │    │    ├── columns: twocolumn.x:int:null:1 twocolumn.y:int:null:2 twocolumn.rowid:int:3 twocolumn.x:int:null:4 twocolumn.y:int:null:5 twocolumn.rowid:int:6
+ │    │    ├── columns: twocolumn.x:1(int) twocolumn.y:2(int) twocolumn.rowid:3(int!null) twocolumn.x:4(int) twocolumn.y:5(int) twocolumn.rowid:6(int!null)
  │    │    ├── scan
- │    │    │    └── columns: twocolumn.x:int:null:1 twocolumn.y:int:null:2 twocolumn.rowid:int:3
+ │    │    │    └── columns: twocolumn.x:1(int) twocolumn.y:2(int) twocolumn.rowid:3(int!null)
  │    │    ├── scan
- │    │    │    └── columns: twocolumn.x:int:null:4 twocolumn.y:int:null:5 twocolumn.rowid:int:6
+ │    │    │    └── columns: twocolumn.x:4(int) twocolumn.y:5(int) twocolumn.rowid:6(int!null)
  │    │    └── eq [type=bool, outer=(1,4)]
  │    │         ├── variable: twocolumn.x [type=int, outer=(1)]
  │    │         └── variable: twocolumn.x [type=int, outer=(4)]
  │    ├── scan
- │    │    └── columns: twocolumn.x:int:null:7 twocolumn.y:int:null:8 twocolumn.rowid:int:9
+ │    │    └── columns: twocolumn.x:7(int) twocolumn.y:8(int) twocolumn.rowid:9(int!null)
  │    └── eq [type=bool, outer=(1,7)]
  │         ├── variable: twocolumn.x [type=int, outer=(1)]
  │         └── variable: twocolumn.x [type=int, outer=(7)]
@@ -1189,17 +1189,17 @@ build
 SELECT * FROM (SELECT * FROM onecolumn), (SELECT * FROM onecolumn)
 ----
 inner-join
- ├── columns: x:int:null:1 x:int:null:3
+ ├── columns: x:1(int) x:3(int)
  ├── project
- │    ├── columns: onecolumn.x:int:null:1
+ │    ├── columns: onecolumn.x:1(int)
  │    ├── scan
- │    │    └── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2
+ │    │    └── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null)
  │    └── projections [outer=(1)]
  │         └── variable: onecolumn.x [type=int, outer=(1)]
  ├── project
- │    ├── columns: onecolumn.x:int:null:3
+ │    ├── columns: onecolumn.x:3(int)
  │    ├── scan
- │    │    └── columns: onecolumn.x:int:null:3 onecolumn.rowid:int:4
+ │    │    └── columns: onecolumn.x:3(int) onecolumn.rowid:4(int!null)
  │    └── projections [outer=(3)]
  │         └── variable: onecolumn.x [type=int, outer=(3)]
  └── true [type=bool]
@@ -1209,24 +1209,24 @@ build
 SELECT x FROM (onecolumn JOIN othercolumn USING (x)) JOIN (onecolumn AS a JOIN othercolumn AS b USING(x)) USING(x)
 ----
 project
- ├── columns: x:int:null:1
+ ├── columns: x:1(int)
  ├── inner-join
- │    ├── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2 othercolumn.x:int:null:3 othercolumn.rowid:int:4 onecolumn.x:int:null:5 onecolumn.rowid:int:6 othercolumn.x:int:null:7 othercolumn.rowid:int:8
+ │    ├── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null) othercolumn.x:3(int) othercolumn.rowid:4(int!null) onecolumn.x:5(int) onecolumn.rowid:6(int!null) othercolumn.x:7(int) othercolumn.rowid:8(int!null)
  │    ├── inner-join
- │    │    ├── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2 othercolumn.x:int:null:3 othercolumn.rowid:int:4
+ │    │    ├── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null) othercolumn.x:3(int) othercolumn.rowid:4(int!null)
  │    │    ├── scan
- │    │    │    └── columns: onecolumn.x:int:null:1 onecolumn.rowid:int:2
+ │    │    │    └── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null)
  │    │    ├── scan
- │    │    │    └── columns: othercolumn.x:int:null:3 othercolumn.rowid:int:4
+ │    │    │    └── columns: othercolumn.x:3(int) othercolumn.rowid:4(int!null)
  │    │    └── eq [type=bool, outer=(1,3)]
  │    │         ├── variable: onecolumn.x [type=int, outer=(1)]
  │    │         └── variable: othercolumn.x [type=int, outer=(3)]
  │    ├── inner-join
- │    │    ├── columns: onecolumn.x:int:null:5 onecolumn.rowid:int:6 othercolumn.x:int:null:7 othercolumn.rowid:int:8
+ │    │    ├── columns: onecolumn.x:5(int) onecolumn.rowid:6(int!null) othercolumn.x:7(int) othercolumn.rowid:8(int!null)
  │    │    ├── scan
- │    │    │    └── columns: onecolumn.x:int:null:5 onecolumn.rowid:int:6
+ │    │    │    └── columns: onecolumn.x:5(int) onecolumn.rowid:6(int!null)
  │    │    ├── scan
- │    │    │    └── columns: othercolumn.x:int:null:7 othercolumn.rowid:int:8
+ │    │    │    └── columns: othercolumn.x:7(int) othercolumn.rowid:8(int!null)
  │    │    └── eq [type=bool, outer=(5,7)]
  │    │         ├── variable: onecolumn.x [type=int, outer=(5)]
  │    │         └── variable: othercolumn.x [type=int, outer=(7)]
@@ -1257,13 +1257,13 @@ build
 SELECT a.x, b.y FROM twocolumn AS a, twocolumn AS b
 ----
 project
- ├── columns: x:int:null:1 y:int:null:5
+ ├── columns: x:1(int) y:5(int)
  ├── inner-join
- │    ├── columns: twocolumn.x:int:null:1 twocolumn.y:int:null:2 twocolumn.rowid:int:3 twocolumn.x:int:null:4 twocolumn.y:int:null:5 twocolumn.rowid:int:6
+ │    ├── columns: twocolumn.x:1(int) twocolumn.y:2(int) twocolumn.rowid:3(int!null) twocolumn.x:4(int) twocolumn.y:5(int) twocolumn.rowid:6(int!null)
  │    ├── scan
- │    │    └── columns: twocolumn.x:int:null:1 twocolumn.y:int:null:2 twocolumn.rowid:int:3
+ │    │    └── columns: twocolumn.x:1(int) twocolumn.y:2(int) twocolumn.rowid:3(int!null)
  │    ├── scan
- │    │    └── columns: twocolumn.x:int:null:4 twocolumn.y:int:null:5 twocolumn.rowid:int:6
+ │    │    └── columns: twocolumn.x:4(int) twocolumn.y:5(int) twocolumn.rowid:6(int!null)
  │    └── true [type=bool]
  └── projections [outer=(1,5)]
       ├── variable: twocolumn.x [type=int, outer=(1)]
@@ -1273,13 +1273,13 @@ build
 SELECT b.y FROM (twocolumn AS a JOIN twocolumn AS b USING(x))
 ----
 project
- ├── columns: y:int:null:5
+ ├── columns: y:5(int)
  ├── inner-join
- │    ├── columns: twocolumn.x:int:null:1 twocolumn.y:int:null:2 twocolumn.rowid:int:3 twocolumn.x:int:null:4 twocolumn.y:int:null:5 twocolumn.rowid:int:6
+ │    ├── columns: twocolumn.x:1(int) twocolumn.y:2(int) twocolumn.rowid:3(int!null) twocolumn.x:4(int) twocolumn.y:5(int) twocolumn.rowid:6(int!null)
  │    ├── scan
- │    │    └── columns: twocolumn.x:int:null:1 twocolumn.y:int:null:2 twocolumn.rowid:int:3
+ │    │    └── columns: twocolumn.x:1(int) twocolumn.y:2(int) twocolumn.rowid:3(int!null)
  │    ├── scan
- │    │    └── columns: twocolumn.x:int:null:4 twocolumn.y:int:null:5 twocolumn.rowid:int:6
+ │    │    └── columns: twocolumn.x:4(int) twocolumn.y:5(int) twocolumn.rowid:6(int!null)
  │    └── eq [type=bool, outer=(1,4)]
  │         ├── variable: twocolumn.x [type=int, outer=(1)]
  │         └── variable: twocolumn.x [type=int, outer=(4)]
@@ -1290,13 +1290,13 @@ build
 SELECT b.y FROM (twocolumn AS a JOIN twocolumn AS b ON a.x = b.x)
 ----
 project
- ├── columns: y:int:null:5
+ ├── columns: y:5(int)
  ├── inner-join
- │    ├── columns: twocolumn.x:int:null:1 twocolumn.y:int:null:2 twocolumn.rowid:int:3 twocolumn.x:int:null:4 twocolumn.y:int:null:5 twocolumn.rowid:int:6
+ │    ├── columns: twocolumn.x:1(int) twocolumn.y:2(int) twocolumn.rowid:3(int!null) twocolumn.x:4(int) twocolumn.y:5(int) twocolumn.rowid:6(int!null)
  │    ├── scan
- │    │    └── columns: twocolumn.x:int:null:1 twocolumn.y:int:null:2 twocolumn.rowid:int:3
+ │    │    └── columns: twocolumn.x:1(int) twocolumn.y:2(int) twocolumn.rowid:3(int!null)
  │    ├── scan
- │    │    └── columns: twocolumn.x:int:null:4 twocolumn.y:int:null:5 twocolumn.rowid:int:6
+ │    │    └── columns: twocolumn.x:4(int) twocolumn.y:5(int) twocolumn.rowid:6(int!null)
  │    └── eq [type=bool, outer=(1,4)]
  │         ├── variable: twocolumn.x [type=int, outer=(1)]
  │         └── variable: twocolumn.x [type=int, outer=(4)]
@@ -1307,13 +1307,13 @@ build
 SELECT a.x FROM (twocolumn AS a JOIN twocolumn AS b ON a.x < b.y)
 ----
 project
- ├── columns: x:int:null:1
+ ├── columns: x:1(int)
  ├── inner-join
- │    ├── columns: twocolumn.x:int:null:1 twocolumn.y:int:null:2 twocolumn.rowid:int:3 twocolumn.x:int:null:4 twocolumn.y:int:null:5 twocolumn.rowid:int:6
+ │    ├── columns: twocolumn.x:1(int) twocolumn.y:2(int) twocolumn.rowid:3(int!null) twocolumn.x:4(int) twocolumn.y:5(int) twocolumn.rowid:6(int!null)
  │    ├── scan
- │    │    └── columns: twocolumn.x:int:null:1 twocolumn.y:int:null:2 twocolumn.rowid:int:3
+ │    │    └── columns: twocolumn.x:1(int) twocolumn.y:2(int) twocolumn.rowid:3(int!null)
  │    ├── scan
- │    │    └── columns: twocolumn.x:int:null:4 twocolumn.y:int:null:5 twocolumn.rowid:int:6
+ │    │    └── columns: twocolumn.x:4(int) twocolumn.y:5(int) twocolumn.rowid:6(int!null)
  │    └── lt [type=bool, outer=(1,5)]
  │         ├── variable: twocolumn.x [type=int, outer=(1)]
  │         └── variable: twocolumn.y [type=int, outer=(5)]
@@ -1346,15 +1346,15 @@ build
 SELECT * FROM pairs, square WHERE pairs.b = square.n
 ----
 project
- ├── columns: a:int:null:1 b:int:null:2 n:int:4 sq:int:null:5
+ ├── columns: a:1(int) b:2(int) n:4(int!null) sq:5(int)
  ├── select
- │    ├── columns: pairs.a:int:null:1 pairs.b:int:null:2 pairs.rowid:int:3 square.n:int:4 square.sq:int:null:5
+ │    ├── columns: pairs.a:1(int) pairs.b:2(int) pairs.rowid:3(int!null) square.n:4(int!null) square.sq:5(int)
  │    ├── inner-join
- │    │    ├── columns: pairs.a:int:null:1 pairs.b:int:null:2 pairs.rowid:int:3 square.n:int:4 square.sq:int:null:5
+ │    │    ├── columns: pairs.a:1(int) pairs.b:2(int) pairs.rowid:3(int!null) square.n:4(int!null) square.sq:5(int)
  │    │    ├── scan
- │    │    │    └── columns: pairs.a:int:null:1 pairs.b:int:null:2 pairs.rowid:int:3
+ │    │    │    └── columns: pairs.a:1(int) pairs.b:2(int) pairs.rowid:3(int!null)
  │    │    ├── scan
- │    │    │    └── columns: square.n:int:4 square.sq:int:null:5
+ │    │    │    └── columns: square.n:4(int!null) square.sq:5(int)
  │    │    └── true [type=bool]
  │    └── eq [type=bool, outer=(2,4)]
  │         ├── variable: pairs.b [type=int, outer=(2)]
@@ -1370,15 +1370,15 @@ build
 SELECT * FROM pairs, square WHERE pairs.a + pairs.b = square.sq
 ----
 project
- ├── columns: a:int:null:1 b:int:null:2 n:int:4 sq:int:null:5
+ ├── columns: a:1(int) b:2(int) n:4(int!null) sq:5(int)
  ├── select
- │    ├── columns: pairs.a:int:null:1 pairs.b:int:null:2 pairs.rowid:int:3 square.n:int:4 square.sq:int:null:5
+ │    ├── columns: pairs.a:1(int) pairs.b:2(int) pairs.rowid:3(int!null) square.n:4(int!null) square.sq:5(int)
  │    ├── inner-join
- │    │    ├── columns: pairs.a:int:null:1 pairs.b:int:null:2 pairs.rowid:int:3 square.n:int:4 square.sq:int:null:5
+ │    │    ├── columns: pairs.a:1(int) pairs.b:2(int) pairs.rowid:3(int!null) square.n:4(int!null) square.sq:5(int)
  │    │    ├── scan
- │    │    │    └── columns: pairs.a:int:null:1 pairs.b:int:null:2 pairs.rowid:int:3
+ │    │    │    └── columns: pairs.a:1(int) pairs.b:2(int) pairs.rowid:3(int!null)
  │    │    ├── scan
- │    │    │    └── columns: square.n:int:4 square.sq:int:null:5
+ │    │    │    └── columns: square.n:4(int!null) square.sq:5(int)
  │    │    └── true [type=bool]
  │    └── eq [type=bool, outer=(1,2,5)]
  │         ├── plus [type=int, outer=(1,2)]
@@ -1398,17 +1398,17 @@ build
 SELECT a, b, n, sq FROM (SELECT a, b, a + b AS sum, n, sq FROM pairs, square) WHERE sum = sq
 ----
 project
- ├── columns: a:int:null:1 b:int:null:2 n:int:4 sq:int:null:5
+ ├── columns: a:1(int) b:2(int) n:4(int!null) sq:5(int)
  ├── select
- │    ├── columns: pairs.a:int:null:1 pairs.b:int:null:2 square.n:int:4 square.sq:int:null:5 sum:int:null:6
+ │    ├── columns: pairs.a:1(int) pairs.b:2(int) square.n:4(int!null) square.sq:5(int) sum:6(int)
  │    ├── project
- │    │    ├── columns: pairs.a:int:null:1 pairs.b:int:null:2 sum:int:null:6 square.n:int:4 square.sq:int:null:5
+ │    │    ├── columns: pairs.a:1(int) pairs.b:2(int) sum:6(int) square.n:4(int!null) square.sq:5(int)
  │    │    ├── inner-join
- │    │    │    ├── columns: pairs.a:int:null:1 pairs.b:int:null:2 pairs.rowid:int:3 square.n:int:4 square.sq:int:null:5
+ │    │    │    ├── columns: pairs.a:1(int) pairs.b:2(int) pairs.rowid:3(int!null) square.n:4(int!null) square.sq:5(int)
  │    │    │    ├── scan
- │    │    │    │    └── columns: pairs.a:int:null:1 pairs.b:int:null:2 pairs.rowid:int:3
+ │    │    │    │    └── columns: pairs.a:1(int) pairs.b:2(int) pairs.rowid:3(int!null)
  │    │    │    ├── scan
- │    │    │    │    └── columns: square.n:int:4 square.sq:int:null:5
+ │    │    │    │    └── columns: square.n:4(int!null) square.sq:5(int)
  │    │    │    └── true [type=bool]
  │    │    └── projections [outer=(1,2,4,5)]
  │    │         ├── variable: pairs.a [type=int, outer=(1)]
@@ -1432,13 +1432,13 @@ build
 SELECT * FROM pairs FULL OUTER JOIN square ON pairs.a + pairs.b = square.sq
 ----
 project
- ├── columns: a:int:null:1 b:int:null:2 n:int:null:4 sq:int:null:5
+ ├── columns: a:1(int) b:2(int) n:4(int) sq:5(int)
  ├── full-join
- │    ├── columns: pairs.a:int:null:1 pairs.b:int:null:2 pairs.rowid:int:null:3 square.n:int:null:4 square.sq:int:null:5
+ │    ├── columns: pairs.a:1(int) pairs.b:2(int) pairs.rowid:3(int) square.n:4(int) square.sq:5(int)
  │    ├── scan
- │    │    └── columns: pairs.a:int:null:1 pairs.b:int:null:2 pairs.rowid:int:3
+ │    │    └── columns: pairs.a:1(int) pairs.b:2(int) pairs.rowid:3(int!null)
  │    ├── scan
- │    │    └── columns: square.n:int:4 square.sq:int:null:5
+ │    │    └── columns: square.n:4(int!null) square.sq:5(int)
  │    └── eq [type=bool, outer=(1,2,5)]
  │         ├── plus [type=int, outer=(1,2)]
  │         │    ├── variable: pairs.a [type=int, outer=(1)]
@@ -1454,15 +1454,15 @@ build
 SELECT * FROM pairs FULL OUTER JOIN square ON pairs.a + pairs.b = square.sq WHERE pairs.b%2 <> square.sq%2
 ----
 project
- ├── columns: a:int:null:1 b:int:null:2 n:int:null:4 sq:int:null:5
+ ├── columns: a:1(int) b:2(int) n:4(int) sq:5(int)
  ├── select
- │    ├── columns: pairs.a:int:null:1 pairs.b:int:null:2 pairs.rowid:int:null:3 square.n:int:null:4 square.sq:int:null:5
+ │    ├── columns: pairs.a:1(int) pairs.b:2(int) pairs.rowid:3(int) square.n:4(int) square.sq:5(int)
  │    ├── full-join
- │    │    ├── columns: pairs.a:int:null:1 pairs.b:int:null:2 pairs.rowid:int:null:3 square.n:int:null:4 square.sq:int:null:5
+ │    │    ├── columns: pairs.a:1(int) pairs.b:2(int) pairs.rowid:3(int) square.n:4(int) square.sq:5(int)
  │    │    ├── scan
- │    │    │    └── columns: pairs.a:int:null:1 pairs.b:int:null:2 pairs.rowid:int:3
+ │    │    │    └── columns: pairs.a:1(int) pairs.b:2(int) pairs.rowid:3(int!null)
  │    │    ├── scan
- │    │    │    └── columns: square.n:int:4 square.sq:int:null:5
+ │    │    │    └── columns: square.n:4(int!null) square.sq:5(int)
  │    │    └── eq [type=bool, outer=(1,2,5)]
  │    │         ├── plus [type=int, outer=(1,2)]
  │    │         │    ├── variable: pairs.a [type=int, outer=(1)]
@@ -1489,15 +1489,15 @@ SELECT *
  WHERE b > 1 AND (n IS NULL OR n > 1) AND (n IS NULL OR a  < sq)
 ----
 select
- ├── columns: a:int:null:1 b:int:null:2 n:int:null:4 sq:int:null:5
+ ├── columns: a:1(int) b:2(int) n:4(int) sq:5(int)
  ├── project
- │    ├── columns: pairs.a:int:null:1 pairs.b:int:null:2 square.n:int:null:4 square.sq:int:null:5
+ │    ├── columns: pairs.a:1(int) pairs.b:2(int) square.n:4(int) square.sq:5(int)
  │    ├── left-join
- │    │    ├── columns: pairs.a:int:null:1 pairs.b:int:null:2 pairs.rowid:int:3 square.n:int:null:4 square.sq:int:null:5
+ │    │    ├── columns: pairs.a:1(int) pairs.b:2(int) pairs.rowid:3(int!null) square.n:4(int) square.sq:5(int)
  │    │    ├── scan
- │    │    │    └── columns: pairs.a:int:null:1 pairs.b:int:null:2 pairs.rowid:int:3
+ │    │    │    └── columns: pairs.a:1(int) pairs.b:2(int) pairs.rowid:3(int!null)
  │    │    ├── scan
- │    │    │    └── columns: square.n:int:4 square.sq:int:null:5
+ │    │    │    └── columns: square.n:4(int!null) square.sq:5(int)
  │    │    └── and [type=bool, outer=(1,2,4,5)]
  │    │         ├── and [type=bool, outer=(1,2,5)]
  │    │         │    ├── eq [type=bool, outer=(2,5)]
@@ -1540,15 +1540,15 @@ SELECT *
  WHERE (a IS NULL OR a > 2) AND n > 1 AND (a IS NULL OR a < sq)
 ----
 select
- ├── columns: a:int:null:1 b:int:null:2 n:int:4 sq:int:null:5
+ ├── columns: a:1(int) b:2(int) n:4(int!null) sq:5(int)
  ├── project
- │    ├── columns: pairs.a:int:null:1 pairs.b:int:null:2 square.n:int:4 square.sq:int:null:5
+ │    ├── columns: pairs.a:1(int) pairs.b:2(int) square.n:4(int!null) square.sq:5(int)
  │    ├── right-join
- │    │    ├── columns: pairs.a:int:null:1 pairs.b:int:null:2 pairs.rowid:int:null:3 square.n:int:4 square.sq:int:null:5
+ │    │    ├── columns: pairs.a:1(int) pairs.b:2(int) pairs.rowid:3(int) square.n:4(int!null) square.sq:5(int)
  │    │    ├── scan
- │    │    │    └── columns: pairs.a:int:null:1 pairs.b:int:null:2 pairs.rowid:int:3
+ │    │    │    └── columns: pairs.a:1(int) pairs.b:2(int) pairs.rowid:3(int!null)
  │    │    ├── scan
- │    │    │    └── columns: square.n:int:4 square.sq:int:null:5
+ │    │    │    └── columns: square.n:4(int!null) square.sq:5(int)
  │    │    └── and [type=bool, outer=(1,2,4,5)]
  │    │         ├── and [type=bool, outer=(1,2,5)]
  │    │         │    ├── eq [type=bool, outer=(2,5)]
@@ -1592,15 +1592,15 @@ SELECT *
  WHERE (a IS NULL OR a > 2) AND n > 1 AND (a IS NULL OR a < sq)
 ----
 select
- ├── columns: a:int:null:1 b:int:null:2 n:int:4 sq:int:null:5
+ ├── columns: a:1(int) b:2(int) n:4(int!null) sq:5(int)
  ├── project
- │    ├── columns: pairs.a:int:null:1 pairs.b:int:null:2 square.n:int:4 square.sq:int:null:5
+ │    ├── columns: pairs.a:1(int) pairs.b:2(int) square.n:4(int!null) square.sq:5(int)
  │    ├── inner-join
- │    │    ├── columns: pairs.a:int:null:1 pairs.b:int:null:2 pairs.rowid:int:3 square.n:int:4 square.sq:int:null:5
+ │    │    ├── columns: pairs.a:1(int) pairs.b:2(int) pairs.rowid:3(int!null) square.n:4(int!null) square.sq:5(int)
  │    │    ├── scan
- │    │    │    └── columns: pairs.a:int:null:1 pairs.b:int:null:2 pairs.rowid:int:3
+ │    │    │    └── columns: pairs.a:1(int) pairs.b:2(int) pairs.rowid:3(int!null)
  │    │    ├── scan
- │    │    │    └── columns: square.n:int:4 square.sq:int:null:5
+ │    │    │    └── columns: square.n:4(int!null) square.sq:5(int)
  │    │    └── and [type=bool, outer=(1,2,4,5)]
  │    │         ├── and [type=bool, outer=(1,2,5)]
  │    │         │    ├── eq [type=bool, outer=(2,5)]
@@ -1666,13 +1666,13 @@ build
 SELECT * FROM t1 JOIN t2 USING(x)
 ----
 project
- ├── columns: x:int:null:2 col1:int:null:1 col2:int:null:3 y:int:null:4 col3:int:null:6 y:int:null:7 col4:int:null:9
+ ├── columns: x:2(int) col1:1(int) col2:3(int) y:4(int) col3:6(int) y:7(int) col4:9(int)
  ├── inner-join
- │    ├── columns: t1.col1:int:null:1 t1.x:int:null:2 t1.col2:int:null:3 t1.y:int:null:4 t1.rowid:int:5 t2.col3:int:null:6 t2.y:int:null:7 t2.x:int:null:8 t2.col4:int:null:9 t2.rowid:int:10
+ │    ├── columns: t1.col1:1(int) t1.x:2(int) t1.col2:3(int) t1.y:4(int) t1.rowid:5(int!null) t2.col3:6(int) t2.y:7(int) t2.x:8(int) t2.col4:9(int) t2.rowid:10(int!null)
  │    ├── scan
- │    │    └── columns: t1.col1:int:null:1 t1.x:int:null:2 t1.col2:int:null:3 t1.y:int:null:4 t1.rowid:int:5
+ │    │    └── columns: t1.col1:1(int) t1.x:2(int) t1.col2:3(int) t1.y:4(int) t1.rowid:5(int!null)
  │    ├── scan
- │    │    └── columns: t2.col3:int:null:6 t2.y:int:null:7 t2.x:int:null:8 t2.col4:int:null:9 t2.rowid:int:10
+ │    │    └── columns: t2.col3:6(int) t2.y:7(int) t2.x:8(int) t2.col4:9(int) t2.rowid:10(int!null)
  │    └── eq [type=bool, outer=(2,8)]
  │         ├── variable: t1.x [type=int, outer=(2)]
  │         └── variable: t2.x [type=int, outer=(8)]
@@ -1689,13 +1689,13 @@ build
 SELECT * FROM t1 NATURAL JOIN t2
 ----
 project
- ├── columns: x:int:null:2 y:int:null:4 col1:int:null:1 col2:int:null:3 col3:int:null:6 col4:int:null:9
+ ├── columns: x:2(int) y:4(int) col1:1(int) col2:3(int) col3:6(int) col4:9(int)
  ├── inner-join
- │    ├── columns: t1.col1:int:null:1 t1.x:int:null:2 t1.col2:int:null:3 t1.y:int:null:4 t1.rowid:int:5 t2.col3:int:null:6 t2.y:int:null:7 t2.x:int:null:8 t2.col4:int:null:9 t2.rowid:int:10
+ │    ├── columns: t1.col1:1(int) t1.x:2(int) t1.col2:3(int) t1.y:4(int) t1.rowid:5(int!null) t2.col3:6(int) t2.y:7(int) t2.x:8(int) t2.col4:9(int) t2.rowid:10(int!null)
  │    ├── scan
- │    │    └── columns: t1.col1:int:null:1 t1.x:int:null:2 t1.col2:int:null:3 t1.y:int:null:4 t1.rowid:int:5
+ │    │    └── columns: t1.col1:1(int) t1.x:2(int) t1.col2:3(int) t1.y:4(int) t1.rowid:5(int!null)
  │    ├── scan
- │    │    └── columns: t2.col3:int:null:6 t2.y:int:null:7 t2.x:int:null:8 t2.col4:int:null:9 t2.rowid:int:10
+ │    │    └── columns: t2.col3:6(int) t2.y:7(int) t2.x:8(int) t2.col4:9(int) t2.rowid:10(int!null)
  │    └── and [type=bool, outer=(2,4,7,8)]
  │         ├── eq [type=bool, outer=(2,8)]
  │         │    ├── variable: t1.x [type=int, outer=(2)]
@@ -1715,13 +1715,13 @@ build
 SELECT * FROM t1 JOIN t2 ON t2.x=t1.x
 ----
 project
- ├── columns: col1:int:null:1 x:int:null:2 col2:int:null:3 y:int:null:4 col3:int:null:6 y:int:null:7 x:int:null:8 col4:int:null:9
+ ├── columns: col1:1(int) x:2(int) col2:3(int) y:4(int) col3:6(int) y:7(int) x:8(int) col4:9(int)
  ├── inner-join
- │    ├── columns: t1.col1:int:null:1 t1.x:int:null:2 t1.col2:int:null:3 t1.y:int:null:4 t1.rowid:int:5 t2.col3:int:null:6 t2.y:int:null:7 t2.x:int:null:8 t2.col4:int:null:9 t2.rowid:int:10
+ │    ├── columns: t1.col1:1(int) t1.x:2(int) t1.col2:3(int) t1.y:4(int) t1.rowid:5(int!null) t2.col3:6(int) t2.y:7(int) t2.x:8(int) t2.col4:9(int) t2.rowid:10(int!null)
  │    ├── scan
- │    │    └── columns: t1.col1:int:null:1 t1.x:int:null:2 t1.col2:int:null:3 t1.y:int:null:4 t1.rowid:int:5
+ │    │    └── columns: t1.col1:1(int) t1.x:2(int) t1.col2:3(int) t1.y:4(int) t1.rowid:5(int!null)
  │    ├── scan
- │    │    └── columns: t2.col3:int:null:6 t2.y:int:null:7 t2.x:int:null:8 t2.col4:int:null:9 t2.rowid:int:10
+ │    │    └── columns: t2.col3:6(int) t2.y:7(int) t2.x:8(int) t2.col4:9(int) t2.rowid:10(int!null)
  │    └── eq [type=bool, outer=(2,8)]
  │         ├── variable: t2.x [type=int, outer=(8)]
  │         └── variable: t1.x [type=int, outer=(2)]
@@ -1739,15 +1739,15 @@ build
 SELECT * FROM t1 FULL OUTER JOIN t2 USING(x)
 ----
 project
- ├── columns: x:int:null:11 col1:int:null:1 col2:int:null:3 y:int:null:4 col3:int:null:6 y:int:null:7 col4:int:null:9
+ ├── columns: x:11(int) col1:1(int) col2:3(int) y:4(int) col3:6(int) y:7(int) col4:9(int)
  ├── project
- │    ├── columns: x:int:null:11 t1.col1:int:null:1 t1.x:int:null:2 t1.col2:int:null:3 t1.y:int:null:4 t1.rowid:int:null:5 t2.col3:int:null:6 t2.y:int:null:7 t2.x:int:null:8 t2.col4:int:null:9 t2.rowid:int:null:10
+ │    ├── columns: x:11(int) t1.col1:1(int) t1.x:2(int) t1.col2:3(int) t1.y:4(int) t1.rowid:5(int) t2.col3:6(int) t2.y:7(int) t2.x:8(int) t2.col4:9(int) t2.rowid:10(int)
  │    ├── full-join
- │    │    ├── columns: t1.col1:int:null:1 t1.x:int:null:2 t1.col2:int:null:3 t1.y:int:null:4 t1.rowid:int:null:5 t2.col3:int:null:6 t2.y:int:null:7 t2.x:int:null:8 t2.col4:int:null:9 t2.rowid:int:null:10
+ │    │    ├── columns: t1.col1:1(int) t1.x:2(int) t1.col2:3(int) t1.y:4(int) t1.rowid:5(int) t2.col3:6(int) t2.y:7(int) t2.x:8(int) t2.col4:9(int) t2.rowid:10(int)
  │    │    ├── scan
- │    │    │    └── columns: t1.col1:int:null:1 t1.x:int:null:2 t1.col2:int:null:3 t1.y:int:null:4 t1.rowid:int:5
+ │    │    │    └── columns: t1.col1:1(int) t1.x:2(int) t1.col2:3(int) t1.y:4(int) t1.rowid:5(int!null)
  │    │    ├── scan
- │    │    │    └── columns: t2.col3:int:null:6 t2.y:int:null:7 t2.x:int:null:8 t2.col4:int:null:9 t2.rowid:int:10
+ │    │    │    └── columns: t2.col3:6(int) t2.y:7(int) t2.x:8(int) t2.col4:9(int) t2.rowid:10(int!null)
  │    │    └── eq [type=bool, outer=(2,8)]
  │    │         ├── variable: t1.x [type=int, outer=(2)]
  │    │         └── variable: t2.x [type=int, outer=(8)]
@@ -1778,15 +1778,15 @@ build
 SELECT * FROM t1 NATURAL FULL OUTER JOIN t2
 ----
 project
- ├── columns: x:int:null:11 y:int:null:12 col1:int:null:1 col2:int:null:3 col3:int:null:6 col4:int:null:9
+ ├── columns: x:11(int) y:12(int) col1:1(int) col2:3(int) col3:6(int) col4:9(int)
  ├── project
- │    ├── columns: x:int:null:11 y:int:null:12 t1.col1:int:null:1 t1.x:int:null:2 t1.col2:int:null:3 t1.y:int:null:4 t1.rowid:int:null:5 t2.col3:int:null:6 t2.y:int:null:7 t2.x:int:null:8 t2.col4:int:null:9 t2.rowid:int:null:10
+ │    ├── columns: x:11(int) y:12(int) t1.col1:1(int) t1.x:2(int) t1.col2:3(int) t1.y:4(int) t1.rowid:5(int) t2.col3:6(int) t2.y:7(int) t2.x:8(int) t2.col4:9(int) t2.rowid:10(int)
  │    ├── full-join
- │    │    ├── columns: t1.col1:int:null:1 t1.x:int:null:2 t1.col2:int:null:3 t1.y:int:null:4 t1.rowid:int:null:5 t2.col3:int:null:6 t2.y:int:null:7 t2.x:int:null:8 t2.col4:int:null:9 t2.rowid:int:null:10
+ │    │    ├── columns: t1.col1:1(int) t1.x:2(int) t1.col2:3(int) t1.y:4(int) t1.rowid:5(int) t2.col3:6(int) t2.y:7(int) t2.x:8(int) t2.col4:9(int) t2.rowid:10(int)
  │    │    ├── scan
- │    │    │    └── columns: t1.col1:int:null:1 t1.x:int:null:2 t1.col2:int:null:3 t1.y:int:null:4 t1.rowid:int:5
+ │    │    │    └── columns: t1.col1:1(int) t1.x:2(int) t1.col2:3(int) t1.y:4(int) t1.rowid:5(int!null)
  │    │    ├── scan
- │    │    │    └── columns: t2.col3:int:null:6 t2.y:int:null:7 t2.x:int:null:8 t2.col4:int:null:9 t2.rowid:int:10
+ │    │    │    └── columns: t2.col3:6(int) t2.y:7(int) t2.x:8(int) t2.col4:9(int) t2.rowid:10(int!null)
  │    │    └── and [type=bool, outer=(2,4,7,8)]
  │    │         ├── eq [type=bool, outer=(2,8)]
  │    │         │    ├── variable: t1.x [type=int, outer=(2)]
@@ -1823,13 +1823,13 @@ build
 SELECT * FROM t1 FULL OUTER JOIN t2 ON t1.x=t2.x
 ----
 project
- ├── columns: col1:int:null:1 x:int:null:2 col2:int:null:3 y:int:null:4 col3:int:null:6 y:int:null:7 x:int:null:8 col4:int:null:9
+ ├── columns: col1:1(int) x:2(int) col2:3(int) y:4(int) col3:6(int) y:7(int) x:8(int) col4:9(int)
  ├── full-join
- │    ├── columns: t1.col1:int:null:1 t1.x:int:null:2 t1.col2:int:null:3 t1.y:int:null:4 t1.rowid:int:null:5 t2.col3:int:null:6 t2.y:int:null:7 t2.x:int:null:8 t2.col4:int:null:9 t2.rowid:int:null:10
+ │    ├── columns: t1.col1:1(int) t1.x:2(int) t1.col2:3(int) t1.y:4(int) t1.rowid:5(int) t2.col3:6(int) t2.y:7(int) t2.x:8(int) t2.col4:9(int) t2.rowid:10(int)
  │    ├── scan
- │    │    └── columns: t1.col1:int:null:1 t1.x:int:null:2 t1.col2:int:null:3 t1.y:int:null:4 t1.rowid:int:5
+ │    │    └── columns: t1.col1:1(int) t1.x:2(int) t1.col2:3(int) t1.y:4(int) t1.rowid:5(int!null)
  │    ├── scan
- │    │    └── columns: t2.col3:int:null:6 t2.y:int:null:7 t2.x:int:null:8 t2.col4:int:null:9 t2.rowid:int:10
+ │    │    └── columns: t2.col3:6(int) t2.y:7(int) t2.x:8(int) t2.col4:9(int) t2.rowid:10(int!null)
  │    └── eq [type=bool, outer=(2,8)]
  │         ├── variable: t1.x [type=int, outer=(2)]
  │         └── variable: t2.x [type=int, outer=(8)]
@@ -1847,13 +1847,13 @@ build
 SELECT t2.x, t1.x, x FROM t1 JOIN t2 USING(x)
 ----
 project
- ├── columns: x:int:null:8 x:int:null:2 x:int:null:2
+ ├── columns: x:8(int) x:2(int) x:2(int)
  ├── inner-join
- │    ├── columns: t1.col1:int:null:1 t1.x:int:null:2 t1.col2:int:null:3 t1.y:int:null:4 t1.rowid:int:5 t2.col3:int:null:6 t2.y:int:null:7 t2.x:int:null:8 t2.col4:int:null:9 t2.rowid:int:10
+ │    ├── columns: t1.col1:1(int) t1.x:2(int) t1.col2:3(int) t1.y:4(int) t1.rowid:5(int!null) t2.col3:6(int) t2.y:7(int) t2.x:8(int) t2.col4:9(int) t2.rowid:10(int!null)
  │    ├── scan
- │    │    └── columns: t1.col1:int:null:1 t1.x:int:null:2 t1.col2:int:null:3 t1.y:int:null:4 t1.rowid:int:5
+ │    │    └── columns: t1.col1:1(int) t1.x:2(int) t1.col2:3(int) t1.y:4(int) t1.rowid:5(int!null)
  │    ├── scan
- │    │    └── columns: t2.col3:int:null:6 t2.y:int:null:7 t2.x:int:null:8 t2.col4:int:null:9 t2.rowid:int:10
+ │    │    └── columns: t2.col3:6(int) t2.y:7(int) t2.x:8(int) t2.col4:9(int) t2.rowid:10(int!null)
  │    └── eq [type=bool, outer=(2,8)]
  │         ├── variable: t1.x [type=int, outer=(2)]
  │         └── variable: t2.x [type=int, outer=(8)]
@@ -1866,15 +1866,15 @@ build
 SELECT t2.x, t1.x, x FROM t1 FULL OUTER JOIN t2 USING(x)
 ----
 project
- ├── columns: x:int:null:8 x:int:null:2 x:int:null:11
+ ├── columns: x:8(int) x:2(int) x:11(int)
  ├── project
- │    ├── columns: x:int:null:11 t1.col1:int:null:1 t1.x:int:null:2 t1.col2:int:null:3 t1.y:int:null:4 t1.rowid:int:null:5 t2.col3:int:null:6 t2.y:int:null:7 t2.x:int:null:8 t2.col4:int:null:9 t2.rowid:int:null:10
+ │    ├── columns: x:11(int) t1.col1:1(int) t1.x:2(int) t1.col2:3(int) t1.y:4(int) t1.rowid:5(int) t2.col3:6(int) t2.y:7(int) t2.x:8(int) t2.col4:9(int) t2.rowid:10(int)
  │    ├── full-join
- │    │    ├── columns: t1.col1:int:null:1 t1.x:int:null:2 t1.col2:int:null:3 t1.y:int:null:4 t1.rowid:int:null:5 t2.col3:int:null:6 t2.y:int:null:7 t2.x:int:null:8 t2.col4:int:null:9 t2.rowid:int:null:10
+ │    │    ├── columns: t1.col1:1(int) t1.x:2(int) t1.col2:3(int) t1.y:4(int) t1.rowid:5(int) t2.col3:6(int) t2.y:7(int) t2.x:8(int) t2.col4:9(int) t2.rowid:10(int)
  │    │    ├── scan
- │    │    │    └── columns: t1.col1:int:null:1 t1.x:int:null:2 t1.col2:int:null:3 t1.y:int:null:4 t1.rowid:int:5
+ │    │    │    └── columns: t1.col1:1(int) t1.x:2(int) t1.col2:3(int) t1.y:4(int) t1.rowid:5(int!null)
  │    │    ├── scan
- │    │    │    └── columns: t2.col3:int:null:6 t2.y:int:null:7 t2.x:int:null:8 t2.col4:int:null:9 t2.rowid:int:10
+ │    │    │    └── columns: t2.col3:6(int) t2.y:7(int) t2.x:8(int) t2.col4:9(int) t2.rowid:10(int!null)
  │    │    └── eq [type=bool, outer=(2,8)]
  │    │         ├── variable: t1.x [type=int, outer=(2)]
  │    │         └── variable: t2.x [type=int, outer=(8)]
@@ -1902,15 +1902,15 @@ build
 SELECT x FROM t1 NATURAL JOIN (SELECT * FROM t2)
 ----
 project
- ├── columns: x:int:null:2
+ ├── columns: x:2(int)
  ├── inner-join
- │    ├── columns: t1.col1:int:null:1 t1.x:int:null:2 t1.col2:int:null:3 t1.y:int:null:4 t1.rowid:int:5 t2.col3:int:null:6 t2.y:int:null:7 t2.x:int:null:8 t2.col4:int:null:9
+ │    ├── columns: t1.col1:1(int) t1.x:2(int) t1.col2:3(int) t1.y:4(int) t1.rowid:5(int!null) t2.col3:6(int) t2.y:7(int) t2.x:8(int) t2.col4:9(int)
  │    ├── scan
- │    │    └── columns: t1.col1:int:null:1 t1.x:int:null:2 t1.col2:int:null:3 t1.y:int:null:4 t1.rowid:int:5
+ │    │    └── columns: t1.col1:1(int) t1.x:2(int) t1.col2:3(int) t1.y:4(int) t1.rowid:5(int!null)
  │    ├── project
- │    │    ├── columns: t2.col3:int:null:6 t2.y:int:null:7 t2.x:int:null:8 t2.col4:int:null:9
+ │    │    ├── columns: t2.col3:6(int) t2.y:7(int) t2.x:8(int) t2.col4:9(int)
  │    │    ├── scan
- │    │    │    └── columns: t2.col3:int:null:6 t2.y:int:null:7 t2.x:int:null:8 t2.col4:int:null:9 t2.rowid:int:10
+ │    │    │    └── columns: t2.col3:6(int) t2.y:7(int) t2.x:8(int) t2.col4:9(int) t2.rowid:10(int!null)
  │    │    └── projections [outer=(6-9)]
  │    │         ├── variable: t2.col3 [type=int, outer=(6)]
  │    │         ├── variable: t2.y [type=int, outer=(7)]
@@ -1981,11 +1981,11 @@ build
 SELECT * FROM pkBA AS l JOIN pkBC AS r ON l.a = r.a AND l.b = r.b AND l.c = r.c
 ----
 inner-join
- ├── columns: a:int:1 b:int:2 c:int:null:3 d:int:null:4 a:int:null:5 b:int:6 c:int:7 d:int:null:8
+ ├── columns: a:1(int!null) b:2(int!null) c:3(int) d:4(int) a:5(int) b:6(int!null) c:7(int!null) d:8(int)
  ├── scan
- │    └── columns: pkba.a:int:1 pkba.b:int:2 pkba.c:int:null:3 pkba.d:int:null:4
+ │    └── columns: pkba.a:1(int!null) pkba.b:2(int!null) pkba.c:3(int) pkba.d:4(int)
  ├── scan
- │    └── columns: pkbc.a:int:null:5 pkbc.b:int:6 pkbc.c:int:7 pkbc.d:int:null:8
+ │    └── columns: pkbc.a:5(int) pkbc.b:6(int!null) pkbc.c:7(int!null) pkbc.d:8(int)
  └── and [type=bool, outer=(1-3,5-7)]
       ├── and [type=bool, outer=(1,2,5,6)]
       │    ├── eq [type=bool, outer=(1,5)]
@@ -2002,13 +2002,13 @@ build
 SELECT * FROM pkBA NATURAL JOIN pkBAD
 ----
 project
- ├── columns: a:int:1 b:int:2 c:int:null:3 d:int:null:4
+ ├── columns: a:1(int!null) b:2(int!null) c:3(int) d:4(int)
  ├── inner-join
- │    ├── columns: pkba.a:int:1 pkba.b:int:2 pkba.c:int:null:3 pkba.d:int:null:4 pkbad.a:int:5 pkbad.b:int:6 pkbad.c:int:null:7 pkbad.d:int:8
+ │    ├── columns: pkba.a:1(int!null) pkba.b:2(int!null) pkba.c:3(int) pkba.d:4(int) pkbad.a:5(int!null) pkbad.b:6(int!null) pkbad.c:7(int) pkbad.d:8(int!null)
  │    ├── scan
- │    │    └── columns: pkba.a:int:1 pkba.b:int:2 pkba.c:int:null:3 pkba.d:int:null:4
+ │    │    └── columns: pkba.a:1(int!null) pkba.b:2(int!null) pkba.c:3(int) pkba.d:4(int)
  │    ├── scan
- │    │    └── columns: pkbad.a:int:5 pkbad.b:int:6 pkbad.c:int:null:7 pkbad.d:int:8
+ │    │    └── columns: pkbad.a:5(int!null) pkbad.b:6(int!null) pkbad.c:7(int) pkbad.d:8(int!null)
  │    └── and [type=bool, outer=(1-8)]
  │         ├── eq [type=bool, outer=(1,5)]
  │         │    ├── variable: pkba.a [type=int, outer=(1)]
@@ -2032,13 +2032,13 @@ build
 SELECT * FROM pkBAC AS l JOIN pkBAC AS r USING(a, b, c)
 ----
 project
- ├── columns: a:int:1 b:int:2 c:int:3 d:int:null:4 d:int:null:8
+ ├── columns: a:1(int!null) b:2(int!null) c:3(int!null) d:4(int) d:8(int)
  ├── inner-join
- │    ├── columns: pkbac.a:int:1 pkbac.b:int:2 pkbac.c:int:3 pkbac.d:int:null:4 pkbac.a:int:5 pkbac.b:int:6 pkbac.c:int:7 pkbac.d:int:null:8
+ │    ├── columns: pkbac.a:1(int!null) pkbac.b:2(int!null) pkbac.c:3(int!null) pkbac.d:4(int) pkbac.a:5(int!null) pkbac.b:6(int!null) pkbac.c:7(int!null) pkbac.d:8(int)
  │    ├── scan
- │    │    └── columns: pkbac.a:int:1 pkbac.b:int:2 pkbac.c:int:3 pkbac.d:int:null:4
+ │    │    └── columns: pkbac.a:1(int!null) pkbac.b:2(int!null) pkbac.c:3(int!null) pkbac.d:4(int)
  │    ├── scan
- │    │    └── columns: pkbac.a:int:5 pkbac.b:int:6 pkbac.c:int:7 pkbac.d:int:null:8
+ │    │    └── columns: pkbac.a:5(int!null) pkbac.b:6(int!null) pkbac.c:7(int!null) pkbac.d:8(int)
  │    └── and [type=bool, outer=(1-3,5-7)]
  │         ├── eq [type=bool, outer=(1,5)]
  │         │    ├── variable: pkbac.a [type=int, outer=(1)]
@@ -2060,11 +2060,11 @@ build
 SELECT * FROM pkBAC AS l JOIN pkBAD AS r ON l.c = r.d AND l.a = r.a AND l.b = r.b
 ----
 inner-join
- ├── columns: a:int:1 b:int:2 c:int:3 d:int:null:4 a:int:5 b:int:6 c:int:null:7 d:int:8
+ ├── columns: a:1(int!null) b:2(int!null) c:3(int!null) d:4(int) a:5(int!null) b:6(int!null) c:7(int) d:8(int!null)
  ├── scan
- │    └── columns: pkbac.a:int:1 pkbac.b:int:2 pkbac.c:int:3 pkbac.d:int:null:4
+ │    └── columns: pkbac.a:1(int!null) pkbac.b:2(int!null) pkbac.c:3(int!null) pkbac.d:4(int)
  ├── scan
- │    └── columns: pkbad.a:int:5 pkbad.b:int:6 pkbad.c:int:null:7 pkbad.d:int:8
+ │    └── columns: pkbad.a:5(int!null) pkbad.b:6(int!null) pkbad.c:7(int) pkbad.d:8(int!null)
  └── and [type=bool, outer=(1-3,5,6,8)]
       ├── and [type=bool, outer=(1,3,5,8)]
       │    ├── eq [type=bool, outer=(3,8)]
@@ -2100,13 +2100,13 @@ build
 SELECT s, str1.s, str2.s FROM str1 INNER JOIN str2 USING(s)
 ----
 project
- ├── columns: s:collatedstring{en_u_ks_level1}:null:2 s:collatedstring{en_u_ks_level1}:null:2 s:collatedstring{en_u_ks_level1}:null:4
+ ├── columns: s:2(collatedstring{en_u_ks_level1}) s:2(collatedstring{en_u_ks_level1}) s:4(collatedstring{en_u_ks_level1})
  ├── inner-join
- │    ├── columns: str1.a:int:1 str1.s:collatedstring{en_u_ks_level1}:null:2 str2.a:int:3 str2.s:collatedstring{en_u_ks_level1}:null:4
+ │    ├── columns: str1.a:1(int!null) str1.s:2(collatedstring{en_u_ks_level1}) str2.a:3(int!null) str2.s:4(collatedstring{en_u_ks_level1})
  │    ├── scan
- │    │    └── columns: str1.a:int:1 str1.s:collatedstring{en_u_ks_level1}:null:2
+ │    │    └── columns: str1.a:1(int!null) str1.s:2(collatedstring{en_u_ks_level1})
  │    ├── scan
- │    │    └── columns: str2.a:int:3 str2.s:collatedstring{en_u_ks_level1}:null:4
+ │    │    └── columns: str2.a:3(int!null) str2.s:4(collatedstring{en_u_ks_level1})
  │    └── eq [type=bool, outer=(2,4)]
  │         ├── variable: str1.s [type=collatedstring{en_u_ks_level1}, outer=(2)]
  │         └── variable: str2.s [type=collatedstring{en_u_ks_level1}, outer=(4)]
@@ -2119,13 +2119,13 @@ build
 SELECT s, str1.s, str2.s FROM str1 LEFT OUTER JOIN str2 USING(s)
 ----
 project
- ├── columns: s:collatedstring{en_u_ks_level1}:null:2 s:collatedstring{en_u_ks_level1}:null:2 s:collatedstring{en_u_ks_level1}:null:4
+ ├── columns: s:2(collatedstring{en_u_ks_level1}) s:2(collatedstring{en_u_ks_level1}) s:4(collatedstring{en_u_ks_level1})
  ├── left-join
- │    ├── columns: str1.a:int:1 str1.s:collatedstring{en_u_ks_level1}:null:2 str2.a:int:null:3 str2.s:collatedstring{en_u_ks_level1}:null:4
+ │    ├── columns: str1.a:1(int!null) str1.s:2(collatedstring{en_u_ks_level1}) str2.a:3(int) str2.s:4(collatedstring{en_u_ks_level1})
  │    ├── scan
- │    │    └── columns: str1.a:int:1 str1.s:collatedstring{en_u_ks_level1}:null:2
+ │    │    └── columns: str1.a:1(int!null) str1.s:2(collatedstring{en_u_ks_level1})
  │    ├── scan
- │    │    └── columns: str2.a:int:3 str2.s:collatedstring{en_u_ks_level1}:null:4
+ │    │    └── columns: str2.a:3(int!null) str2.s:4(collatedstring{en_u_ks_level1})
  │    └── eq [type=bool, outer=(2,4)]
  │         ├── variable: str1.s [type=collatedstring{en_u_ks_level1}, outer=(2)]
  │         └── variable: str2.s [type=collatedstring{en_u_ks_level1}, outer=(4)]
@@ -2138,15 +2138,15 @@ build
 SELECT s, str1.s, str2.s FROM str1 RIGHT OUTER JOIN str2 USING(s)
 ----
 project
- ├── columns: s:collatedstring{en_u_ks_level1}:null:5 s:collatedstring{en_u_ks_level1}:null:2 s:collatedstring{en_u_ks_level1}:null:4
+ ├── columns: s:5(collatedstring{en_u_ks_level1}) s:2(collatedstring{en_u_ks_level1}) s:4(collatedstring{en_u_ks_level1})
  ├── project
- │    ├── columns: s:collatedstring{en_u_ks_level1}:null:5 str1.a:int:null:1 str1.s:collatedstring{en_u_ks_level1}:null:2 str2.a:int:3 str2.s:collatedstring{en_u_ks_level1}:null:4
+ │    ├── columns: s:5(collatedstring{en_u_ks_level1}) str1.a:1(int) str1.s:2(collatedstring{en_u_ks_level1}) str2.a:3(int!null) str2.s:4(collatedstring{en_u_ks_level1})
  │    ├── right-join
- │    │    ├── columns: str1.a:int:null:1 str1.s:collatedstring{en_u_ks_level1}:null:2 str2.a:int:3 str2.s:collatedstring{en_u_ks_level1}:null:4
+ │    │    ├── columns: str1.a:1(int) str1.s:2(collatedstring{en_u_ks_level1}) str2.a:3(int!null) str2.s:4(collatedstring{en_u_ks_level1})
  │    │    ├── scan
- │    │    │    └── columns: str1.a:int:1 str1.s:collatedstring{en_u_ks_level1}:null:2
+ │    │    │    └── columns: str1.a:1(int!null) str1.s:2(collatedstring{en_u_ks_level1})
  │    │    ├── scan
- │    │    │    └── columns: str2.a:int:3 str2.s:collatedstring{en_u_ks_level1}:null:4
+ │    │    │    └── columns: str2.a:3(int!null) str2.s:4(collatedstring{en_u_ks_level1})
  │    │    └── eq [type=bool, outer=(2,4)]
  │    │         ├── variable: str1.s [type=collatedstring{en_u_ks_level1}, outer=(2)]
  │    │         └── variable: str2.s [type=collatedstring{en_u_ks_level1}, outer=(4)]
@@ -2167,15 +2167,15 @@ build
 SELECT s, str1.s, str2.s FROM str1 FULL OUTER JOIN str2 USING(s)
 ----
 project
- ├── columns: s:collatedstring{en_u_ks_level1}:null:5 s:collatedstring{en_u_ks_level1}:null:2 s:collatedstring{en_u_ks_level1}:null:4
+ ├── columns: s:5(collatedstring{en_u_ks_level1}) s:2(collatedstring{en_u_ks_level1}) s:4(collatedstring{en_u_ks_level1})
  ├── project
- │    ├── columns: s:collatedstring{en_u_ks_level1}:null:5 str1.a:int:null:1 str1.s:collatedstring{en_u_ks_level1}:null:2 str2.a:int:null:3 str2.s:collatedstring{en_u_ks_level1}:null:4
+ │    ├── columns: s:5(collatedstring{en_u_ks_level1}) str1.a:1(int) str1.s:2(collatedstring{en_u_ks_level1}) str2.a:3(int) str2.s:4(collatedstring{en_u_ks_level1})
  │    ├── full-join
- │    │    ├── columns: str1.a:int:null:1 str1.s:collatedstring{en_u_ks_level1}:null:2 str2.a:int:null:3 str2.s:collatedstring{en_u_ks_level1}:null:4
+ │    │    ├── columns: str1.a:1(int) str1.s:2(collatedstring{en_u_ks_level1}) str2.a:3(int) str2.s:4(collatedstring{en_u_ks_level1})
  │    │    ├── scan
- │    │    │    └── columns: str1.a:int:1 str1.s:collatedstring{en_u_ks_level1}:null:2
+ │    │    │    └── columns: str1.a:1(int!null) str1.s:2(collatedstring{en_u_ks_level1})
  │    │    ├── scan
- │    │    │    └── columns: str2.a:int:3 str2.s:collatedstring{en_u_ks_level1}:null:4
+ │    │    │    └── columns: str2.a:3(int!null) str2.s:4(collatedstring{en_u_ks_level1})
  │    │    └── eq [type=bool, outer=(2,4)]
  │    │         ├── variable: str1.s [type=collatedstring{en_u_ks_level1}, outer=(2)]
  │    │         └── variable: str2.s [type=collatedstring{en_u_ks_level1}, outer=(4)]
@@ -2198,15 +2198,15 @@ build
 SELECT * FROM str1 RIGHT OUTER JOIN str2 USING(a, s)
 ----
 project
- ├── columns: a:int:3 s:collatedstring{en_u_ks_level1}:null:5
+ ├── columns: a:3(int!null) s:5(collatedstring{en_u_ks_level1})
  ├── project
- │    ├── columns: str2.a:int:3 s:collatedstring{en_u_ks_level1}:null:5 str1.a:int:null:1 str1.s:collatedstring{en_u_ks_level1}:null:2 str2.s:collatedstring{en_u_ks_level1}:null:4
+ │    ├── columns: str2.a:3(int!null) s:5(collatedstring{en_u_ks_level1}) str1.a:1(int) str1.s:2(collatedstring{en_u_ks_level1}) str2.s:4(collatedstring{en_u_ks_level1})
  │    ├── right-join
- │    │    ├── columns: str1.a:int:null:1 str1.s:collatedstring{en_u_ks_level1}:null:2 str2.a:int:3 str2.s:collatedstring{en_u_ks_level1}:null:4
+ │    │    ├── columns: str1.a:1(int) str1.s:2(collatedstring{en_u_ks_level1}) str2.a:3(int!null) str2.s:4(collatedstring{en_u_ks_level1})
  │    │    ├── scan
- │    │    │    └── columns: str1.a:int:1 str1.s:collatedstring{en_u_ks_level1}:null:2
+ │    │    │    └── columns: str1.a:1(int!null) str1.s:2(collatedstring{en_u_ks_level1})
  │    │    ├── scan
- │    │    │    └── columns: str2.a:int:3 str2.s:collatedstring{en_u_ks_level1}:null:4
+ │    │    │    └── columns: str2.a:3(int!null) str2.s:4(collatedstring{en_u_ks_level1})
  │    │    └── and [type=bool, outer=(1-4)]
  │    │         ├── eq [type=bool, outer=(1,3)]
  │    │         │    ├── variable: str1.a [type=int, outer=(1)]
@@ -2255,15 +2255,15 @@ build
 SELECT * FROM xyu INNER JOIN xyv USING(x, y) WHERE x > 2
 ----
 project
- ├── columns: x:int:1 y:int:2 u:int:3 v:int:6
+ ├── columns: x:1(int!null) y:2(int!null) u:3(int!null) v:6(int!null)
  ├── select
- │    ├── columns: xyu.x:int:1 xyu.y:int:2 xyu.u:int:3 xyv.x:int:4 xyv.y:int:5 xyv.v:int:6
+ │    ├── columns: xyu.x:1(int!null) xyu.y:2(int!null) xyu.u:3(int!null) xyv.x:4(int!null) xyv.y:5(int!null) xyv.v:6(int!null)
  │    ├── inner-join
- │    │    ├── columns: xyu.x:int:1 xyu.y:int:2 xyu.u:int:3 xyv.x:int:4 xyv.y:int:5 xyv.v:int:6
+ │    │    ├── columns: xyu.x:1(int!null) xyu.y:2(int!null) xyu.u:3(int!null) xyv.x:4(int!null) xyv.y:5(int!null) xyv.v:6(int!null)
  │    │    ├── scan
- │    │    │    └── columns: xyu.x:int:1 xyu.y:int:2 xyu.u:int:3
+ │    │    │    └── columns: xyu.x:1(int!null) xyu.y:2(int!null) xyu.u:3(int!null)
  │    │    ├── scan
- │    │    │    └── columns: xyv.x:int:4 xyv.y:int:5 xyv.v:int:6
+ │    │    │    └── columns: xyv.x:4(int!null) xyv.y:5(int!null) xyv.v:6(int!null)
  │    │    └── and [type=bool, outer=(1,2,4,5)]
  │    │         ├── eq [type=bool, outer=(1,4)]
  │    │         │    ├── variable: xyu.x [type=int, outer=(1)]
@@ -2284,15 +2284,15 @@ build
 SELECT * FROM xyu LEFT OUTER JOIN xyv USING(x, y) WHERE x > 2
 ----
 project
- ├── columns: x:int:1 y:int:2 u:int:3 v:int:null:6
+ ├── columns: x:1(int!null) y:2(int!null) u:3(int!null) v:6(int)
  ├── select
- │    ├── columns: xyu.x:int:1 xyu.y:int:2 xyu.u:int:3 xyv.x:int:null:4 xyv.y:int:null:5 xyv.v:int:null:6
+ │    ├── columns: xyu.x:1(int!null) xyu.y:2(int!null) xyu.u:3(int!null) xyv.x:4(int) xyv.y:5(int) xyv.v:6(int)
  │    ├── left-join
- │    │    ├── columns: xyu.x:int:1 xyu.y:int:2 xyu.u:int:3 xyv.x:int:null:4 xyv.y:int:null:5 xyv.v:int:null:6
+ │    │    ├── columns: xyu.x:1(int!null) xyu.y:2(int!null) xyu.u:3(int!null) xyv.x:4(int) xyv.y:5(int) xyv.v:6(int)
  │    │    ├── scan
- │    │    │    └── columns: xyu.x:int:1 xyu.y:int:2 xyu.u:int:3
+ │    │    │    └── columns: xyu.x:1(int!null) xyu.y:2(int!null) xyu.u:3(int!null)
  │    │    ├── scan
- │    │    │    └── columns: xyv.x:int:4 xyv.y:int:5 xyv.v:int:6
+ │    │    │    └── columns: xyv.x:4(int!null) xyv.y:5(int!null) xyv.v:6(int!null)
  │    │    └── and [type=bool, outer=(1,2,4,5)]
  │    │         ├── eq [type=bool, outer=(1,4)]
  │    │         │    ├── variable: xyu.x [type=int, outer=(1)]
@@ -2313,15 +2313,15 @@ build
 SELECT * FROM xyu RIGHT OUTER JOIN xyv USING(x, y) WHERE x > 2
 ----
 project
- ├── columns: x:int:4 y:int:5 u:int:null:3 v:int:6
+ ├── columns: x:4(int!null) y:5(int!null) u:3(int) v:6(int!null)
  ├── select
- │    ├── columns: xyu.x:int:null:1 xyu.y:int:null:2 xyu.u:int:null:3 xyv.x:int:4 xyv.y:int:5 xyv.v:int:6
+ │    ├── columns: xyu.x:1(int) xyu.y:2(int) xyu.u:3(int) xyv.x:4(int!null) xyv.y:5(int!null) xyv.v:6(int!null)
  │    ├── right-join
- │    │    ├── columns: xyu.x:int:null:1 xyu.y:int:null:2 xyu.u:int:null:3 xyv.x:int:4 xyv.y:int:5 xyv.v:int:6
+ │    │    ├── columns: xyu.x:1(int) xyu.y:2(int) xyu.u:3(int) xyv.x:4(int!null) xyv.y:5(int!null) xyv.v:6(int!null)
  │    │    ├── scan
- │    │    │    └── columns: xyu.x:int:1 xyu.y:int:2 xyu.u:int:3
+ │    │    │    └── columns: xyu.x:1(int!null) xyu.y:2(int!null) xyu.u:3(int!null)
  │    │    ├── scan
- │    │    │    └── columns: xyv.x:int:4 xyv.y:int:5 xyv.v:int:6
+ │    │    │    └── columns: xyv.x:4(int!null) xyv.y:5(int!null) xyv.v:6(int!null)
  │    │    └── and [type=bool, outer=(1,2,4,5)]
  │    │         ├── eq [type=bool, outer=(1,4)]
  │    │         │    ├── variable: xyu.x [type=int, outer=(1)]
@@ -2342,17 +2342,17 @@ build
 SELECT * FROM xyu FULL OUTER JOIN xyv USING(x, y) WHERE x > 2
 ----
 project
- ├── columns: x:int:null:7 y:int:null:8 u:int:null:3 v:int:null:6
+ ├── columns: x:7(int) y:8(int) u:3(int) v:6(int)
  ├── select
- │    ├── columns: xyu.x:int:null:1 xyu.y:int:null:2 xyu.u:int:null:3 xyv.x:int:null:4 xyv.y:int:null:5 xyv.v:int:null:6 x:int:null:7 y:int:null:8
+ │    ├── columns: xyu.x:1(int) xyu.y:2(int) xyu.u:3(int) xyv.x:4(int) xyv.y:5(int) xyv.v:6(int) x:7(int) y:8(int)
  │    ├── project
- │    │    ├── columns: x:int:null:7 y:int:null:8 xyu.x:int:null:1 xyu.y:int:null:2 xyu.u:int:null:3 xyv.x:int:null:4 xyv.y:int:null:5 xyv.v:int:null:6
+ │    │    ├── columns: x:7(int) y:8(int) xyu.x:1(int) xyu.y:2(int) xyu.u:3(int) xyv.x:4(int) xyv.y:5(int) xyv.v:6(int)
  │    │    ├── full-join
- │    │    │    ├── columns: xyu.x:int:null:1 xyu.y:int:null:2 xyu.u:int:null:3 xyv.x:int:null:4 xyv.y:int:null:5 xyv.v:int:null:6
+ │    │    │    ├── columns: xyu.x:1(int) xyu.y:2(int) xyu.u:3(int) xyv.x:4(int) xyv.y:5(int) xyv.v:6(int)
  │    │    │    ├── scan
- │    │    │    │    └── columns: xyu.x:int:1 xyu.y:int:2 xyu.u:int:3
+ │    │    │    │    └── columns: xyu.x:1(int!null) xyu.y:2(int!null) xyu.u:3(int!null)
  │    │    │    ├── scan
- │    │    │    │    └── columns: xyv.x:int:4 xyv.y:int:5 xyv.v:int:6
+ │    │    │    │    └── columns: xyv.x:4(int!null) xyv.y:5(int!null) xyv.v:6(int!null)
  │    │    │    └── and [type=bool, outer=(1,2,4,5)]
  │    │    │         ├── eq [type=bool, outer=(1,4)]
  │    │    │         │    ├── variable: xyu.x [type=int, outer=(1)]
@@ -2387,13 +2387,13 @@ build
 SELECT * FROM xyu INNER JOIN xyv ON xyu.x = xyv.x AND xyu.y = xyv.y WHERE xyu.x = 1 AND xyu.y < 10
 ----
 select
- ├── columns: x:int:1 y:int:2 u:int:3 x:int:4 y:int:5 v:int:6
+ ├── columns: x:1(int!null) y:2(int!null) u:3(int!null) x:4(int!null) y:5(int!null) v:6(int!null)
  ├── inner-join
- │    ├── columns: xyu.x:int:1 xyu.y:int:2 xyu.u:int:3 xyv.x:int:4 xyv.y:int:5 xyv.v:int:6
+ │    ├── columns: xyu.x:1(int!null) xyu.y:2(int!null) xyu.u:3(int!null) xyv.x:4(int!null) xyv.y:5(int!null) xyv.v:6(int!null)
  │    ├── scan
- │    │    └── columns: xyu.x:int:1 xyu.y:int:2 xyu.u:int:3
+ │    │    └── columns: xyu.x:1(int!null) xyu.y:2(int!null) xyu.u:3(int!null)
  │    ├── scan
- │    │    └── columns: xyv.x:int:4 xyv.y:int:5 xyv.v:int:6
+ │    │    └── columns: xyv.x:4(int!null) xyv.y:5(int!null) xyv.v:6(int!null)
  │    └── and [type=bool, outer=(1,2,4,5)]
  │         ├── eq [type=bool, outer=(1,4)]
  │         │    ├── variable: xyu.x [type=int, outer=(1)]
@@ -2413,11 +2413,11 @@ build
 SELECT * FROM xyu INNER JOIN xyv ON xyu.x = xyv.x AND xyu.y = xyv.y AND xyu.x = 1 AND xyu.y < 10
 ----
 inner-join
- ├── columns: x:int:1 y:int:2 u:int:3 x:int:4 y:int:5 v:int:6
+ ├── columns: x:1(int!null) y:2(int!null) u:3(int!null) x:4(int!null) y:5(int!null) v:6(int!null)
  ├── scan
- │    └── columns: xyu.x:int:1 xyu.y:int:2 xyu.u:int:3
+ │    └── columns: xyu.x:1(int!null) xyu.y:2(int!null) xyu.u:3(int!null)
  ├── scan
- │    └── columns: xyv.x:int:4 xyv.y:int:5 xyv.v:int:6
+ │    └── columns: xyv.x:4(int!null) xyv.y:5(int!null) xyv.v:6(int!null)
  └── and [type=bool, outer=(1,2,4,5)]
       ├── and [type=bool, outer=(1,2,4,5)]
       │    ├── and [type=bool, outer=(1,2,4,5)]
@@ -2438,11 +2438,11 @@ build
 SELECT * FROM xyu LEFT OUTER JOIN xyv ON xyu.x = xyv.x AND xyu.y = xyv.y AND xyu.x = 1 AND xyu.y < 10
 ----
 left-join
- ├── columns: x:int:1 y:int:2 u:int:3 x:int:null:4 y:int:null:5 v:int:null:6
+ ├── columns: x:1(int!null) y:2(int!null) u:3(int!null) x:4(int) y:5(int) v:6(int)
  ├── scan
- │    └── columns: xyu.x:int:1 xyu.y:int:2 xyu.u:int:3
+ │    └── columns: xyu.x:1(int!null) xyu.y:2(int!null) xyu.u:3(int!null)
  ├── scan
- │    └── columns: xyv.x:int:4 xyv.y:int:5 xyv.v:int:6
+ │    └── columns: xyv.x:4(int!null) xyv.y:5(int!null) xyv.v:6(int!null)
  └── and [type=bool, outer=(1,2,4,5)]
       ├── and [type=bool, outer=(1,2,4,5)]
       │    ├── and [type=bool, outer=(1,2,4,5)]
@@ -2463,11 +2463,11 @@ build
 SELECT * FROM xyu RIGHT OUTER JOIN xyv ON xyu.x = xyv.x AND xyu.y = xyv.y AND xyu.x = 1 AND xyu.y < 10
 ----
 right-join
- ├── columns: x:int:null:1 y:int:null:2 u:int:null:3 x:int:4 y:int:5 v:int:6
+ ├── columns: x:1(int) y:2(int) u:3(int) x:4(int!null) y:5(int!null) v:6(int!null)
  ├── scan
- │    └── columns: xyu.x:int:1 xyu.y:int:2 xyu.u:int:3
+ │    └── columns: xyu.x:1(int!null) xyu.y:2(int!null) xyu.u:3(int!null)
  ├── scan
- │    └── columns: xyv.x:int:4 xyv.y:int:5 xyv.v:int:6
+ │    └── columns: xyv.x:4(int!null) xyv.y:5(int!null) xyv.v:6(int!null)
  └── and [type=bool, outer=(1,2,4,5)]
       ├── and [type=bool, outer=(1,2,4,5)]
       │    ├── and [type=bool, outer=(1,2,4,5)]
@@ -2491,15 +2491,15 @@ build
 SELECT * FROM (SELECT * FROM xyu) AS xyu LEFT OUTER JOIN (SELECT * FROM xyv) AS xyv USING(x, y) WHERE x > 2
 ----
 project
- ├── columns: x:int:1 y:int:2 u:int:3 v:int:null:6
+ ├── columns: x:1(int!null) y:2(int!null) u:3(int!null) v:6(int)
  ├── select
- │    ├── columns: xyu.x:int:1 xyu.y:int:2 xyu.u:int:3 xyv.x:int:null:4 xyv.y:int:null:5 xyv.v:int:null:6
+ │    ├── columns: xyu.x:1(int!null) xyu.y:2(int!null) xyu.u:3(int!null) xyv.x:4(int) xyv.y:5(int) xyv.v:6(int)
  │    ├── left-join
- │    │    ├── columns: xyu.x:int:1 xyu.y:int:2 xyu.u:int:3 xyv.x:int:null:4 xyv.y:int:null:5 xyv.v:int:null:6
+ │    │    ├── columns: xyu.x:1(int!null) xyu.y:2(int!null) xyu.u:3(int!null) xyv.x:4(int) xyv.y:5(int) xyv.v:6(int)
  │    │    ├── scan
- │    │    │    └── columns: xyu.x:int:1 xyu.y:int:2 xyu.u:int:3
+ │    │    │    └── columns: xyu.x:1(int!null) xyu.y:2(int!null) xyu.u:3(int!null)
  │    │    ├── scan
- │    │    │    └── columns: xyv.x:int:4 xyv.y:int:5 xyv.v:int:6
+ │    │    │    └── columns: xyv.x:4(int!null) xyv.y:5(int!null) xyv.v:6(int!null)
  │    │    └── and [type=bool, outer=(1,2,4,5)]
  │    │         ├── eq [type=bool, outer=(1,4)]
  │    │         │    ├── variable: xyu.x [type=int, outer=(1)]
@@ -2520,15 +2520,15 @@ build
 SELECT * FROM (SELECT * FROM xyu) AS xyu RIGHT OUTER JOIN (SELECT * FROM xyv) AS xyv USING(x, y) WHERE x > 2
 ----
 project
- ├── columns: x:int:4 y:int:5 u:int:null:3 v:int:6
+ ├── columns: x:4(int!null) y:5(int!null) u:3(int) v:6(int!null)
  ├── select
- │    ├── columns: xyu.x:int:null:1 xyu.y:int:null:2 xyu.u:int:null:3 xyv.x:int:4 xyv.y:int:5 xyv.v:int:6
+ │    ├── columns: xyu.x:1(int) xyu.y:2(int) xyu.u:3(int) xyv.x:4(int!null) xyv.y:5(int!null) xyv.v:6(int!null)
  │    ├── right-join
- │    │    ├── columns: xyu.x:int:null:1 xyu.y:int:null:2 xyu.u:int:null:3 xyv.x:int:4 xyv.y:int:5 xyv.v:int:6
+ │    │    ├── columns: xyu.x:1(int) xyu.y:2(int) xyu.u:3(int) xyv.x:4(int!null) xyv.y:5(int!null) xyv.v:6(int!null)
  │    │    ├── scan
- │    │    │    └── columns: xyu.x:int:1 xyu.y:int:2 xyu.u:int:3
+ │    │    │    └── columns: xyu.x:1(int!null) xyu.y:2(int!null) xyu.u:3(int!null)
  │    │    ├── scan
- │    │    │    └── columns: xyv.x:int:4 xyv.y:int:5 xyv.v:int:6
+ │    │    │    └── columns: xyv.x:4(int!null) xyv.y:5(int!null) xyv.v:6(int!null)
  │    │    └── and [type=bool, outer=(1,2,4,5)]
  │    │         ├── eq [type=bool, outer=(1,4)]
  │    │         │    ├── variable: xyu.x [type=int, outer=(1)]
@@ -2549,17 +2549,17 @@ build
 SELECT * FROM (SELECT * FROM xyu) AS xyu FULL OUTER JOIN (SELECT * FROM xyv) AS xyv USING(x, y) WHERE x > 2
 ----
 project
- ├── columns: x:int:null:7 y:int:null:8 u:int:null:3 v:int:null:6
+ ├── columns: x:7(int) y:8(int) u:3(int) v:6(int)
  ├── select
- │    ├── columns: xyu.x:int:null:1 xyu.y:int:null:2 xyu.u:int:null:3 xyv.x:int:null:4 xyv.y:int:null:5 xyv.v:int:null:6 x:int:null:7 y:int:null:8
+ │    ├── columns: xyu.x:1(int) xyu.y:2(int) xyu.u:3(int) xyv.x:4(int) xyv.y:5(int) xyv.v:6(int) x:7(int) y:8(int)
  │    ├── project
- │    │    ├── columns: x:int:null:7 y:int:null:8 xyu.x:int:null:1 xyu.y:int:null:2 xyu.u:int:null:3 xyv.x:int:null:4 xyv.y:int:null:5 xyv.v:int:null:6
+ │    │    ├── columns: x:7(int) y:8(int) xyu.x:1(int) xyu.y:2(int) xyu.u:3(int) xyv.x:4(int) xyv.y:5(int) xyv.v:6(int)
  │    │    ├── full-join
- │    │    │    ├── columns: xyu.x:int:null:1 xyu.y:int:null:2 xyu.u:int:null:3 xyv.x:int:null:4 xyv.y:int:null:5 xyv.v:int:null:6
+ │    │    │    ├── columns: xyu.x:1(int) xyu.y:2(int) xyu.u:3(int) xyv.x:4(int) xyv.y:5(int) xyv.v:6(int)
  │    │    │    ├── scan
- │    │    │    │    └── columns: xyu.x:int:1 xyu.y:int:2 xyu.u:int:3
+ │    │    │    │    └── columns: xyu.x:1(int!null) xyu.y:2(int!null) xyu.u:3(int!null)
  │    │    │    ├── scan
- │    │    │    │    └── columns: xyv.x:int:4 xyv.y:int:5 xyv.v:int:6
+ │    │    │    │    └── columns: xyv.x:4(int!null) xyv.y:5(int!null) xyv.v:6(int!null)
  │    │    │    └── and [type=bool, outer=(1,2,4,5)]
  │    │    │         ├── eq [type=bool, outer=(1,4)]
  │    │    │         │    ├── variable: xyu.x [type=int, outer=(1)]
@@ -2593,11 +2593,11 @@ build
 SELECT * FROM (SELECT * FROM xyu) AS xyu LEFT OUTER JOIN (SELECT * FROM xyv) AS xyv ON xyu.x = xyv.x AND xyu.y = xyv.y AND xyu.x = 1 AND xyu.y < 10
 ----
 left-join
- ├── columns: x:int:1 y:int:2 u:int:3 x:int:null:4 y:int:null:5 v:int:null:6
+ ├── columns: x:1(int!null) y:2(int!null) u:3(int!null) x:4(int) y:5(int) v:6(int)
  ├── scan
- │    └── columns: xyu.x:int:1 xyu.y:int:2 xyu.u:int:3
+ │    └── columns: xyu.x:1(int!null) xyu.y:2(int!null) xyu.u:3(int!null)
  ├── scan
- │    └── columns: xyv.x:int:4 xyv.y:int:5 xyv.v:int:6
+ │    └── columns: xyv.x:4(int!null) xyv.y:5(int!null) xyv.v:6(int!null)
  └── and [type=bool, outer=(1,2,4,5)]
       ├── and [type=bool, outer=(1,2,4,5)]
       │    ├── and [type=bool, outer=(1,2,4,5)]
@@ -2618,11 +2618,11 @@ build
 SELECT * FROM xyu RIGHT OUTER JOIN (SELECT * FROM xyv) AS xyv ON xyu.x = xyv.x AND xyu.y = xyv.y AND xyu.x = 1 AND xyu.y < 10
 ----
 right-join
- ├── columns: x:int:null:1 y:int:null:2 u:int:null:3 x:int:4 y:int:5 v:int:6
+ ├── columns: x:1(int) y:2(int) u:3(int) x:4(int!null) y:5(int!null) v:6(int!null)
  ├── scan
- │    └── columns: xyu.x:int:1 xyu.y:int:2 xyu.u:int:3
+ │    └── columns: xyu.x:1(int!null) xyu.y:2(int!null) xyu.u:3(int!null)
  ├── scan
- │    └── columns: xyv.x:int:4 xyv.y:int:5 xyv.v:int:6
+ │    └── columns: xyv.x:4(int!null) xyv.y:5(int!null) xyv.v:6(int!null)
  └── and [type=bool, outer=(1,2,4,5)]
       ├── and [type=bool, outer=(1,2,4,5)]
       │    ├── and [type=bool, outer=(1,2,4,5)]
@@ -2644,15 +2644,15 @@ build
 SELECT * FROM xyu JOIN xyv USING(x, y) WHERE (x, y, u) > (1, 2, 3)
 ----
 project
- ├── columns: x:int:1 y:int:2 u:int:3 v:int:6
+ ├── columns: x:1(int!null) y:2(int!null) u:3(int!null) v:6(int!null)
  ├── select
- │    ├── columns: xyu.x:int:1 xyu.y:int:2 xyu.u:int:3 xyv.x:int:4 xyv.y:int:5 xyv.v:int:6
+ │    ├── columns: xyu.x:1(int!null) xyu.y:2(int!null) xyu.u:3(int!null) xyv.x:4(int!null) xyv.y:5(int!null) xyv.v:6(int!null)
  │    ├── inner-join
- │    │    ├── columns: xyu.x:int:1 xyu.y:int:2 xyu.u:int:3 xyv.x:int:4 xyv.y:int:5 xyv.v:int:6
+ │    │    ├── columns: xyu.x:1(int!null) xyu.y:2(int!null) xyu.u:3(int!null) xyv.x:4(int!null) xyv.y:5(int!null) xyv.v:6(int!null)
  │    │    ├── scan
- │    │    │    └── columns: xyu.x:int:1 xyu.y:int:2 xyu.u:int:3
+ │    │    │    └── columns: xyu.x:1(int!null) xyu.y:2(int!null) xyu.u:3(int!null)
  │    │    ├── scan
- │    │    │    └── columns: xyv.x:int:4 xyv.y:int:5 xyv.v:int:6
+ │    │    │    └── columns: xyv.x:4(int!null) xyv.y:5(int!null) xyv.v:6(int!null)
  │    │    └── and [type=bool, outer=(1,2,4,5)]
  │    │         ├── eq [type=bool, outer=(1,4)]
  │    │         │    ├── variable: xyu.x [type=int, outer=(1)]
@@ -2698,13 +2698,13 @@ build
 SELECT * FROM l LEFT OUTER JOIN r ON l.a = r.a WHERE l.a = 3;
 ----
 select
- ├── columns: a:int:1 a:int:null:2
+ ├── columns: a:1(int!null) a:2(int)
  ├── left-join
- │    ├── columns: l.a:int:1 r.a:int:null:2
+ │    ├── columns: l.a:1(int!null) r.a:2(int)
  │    ├── scan
- │    │    └── columns: l.a:int:1
+ │    │    └── columns: l.a:1(int!null)
  │    ├── scan
- │    │    └── columns: r.a:int:2
+ │    │    └── columns: r.a:2(int!null)
  │    └── eq [type=bool, outer=(1,2)]
  │         ├── variable: l.a [type=int, outer=(1)]
  │         └── variable: r.a [type=int, outer=(2)]
@@ -2716,13 +2716,13 @@ build
 SELECT * FROM l RIGHT OUTER JOIN r ON l.a = r.a WHERE r.a = 3;
 ----
 select
- ├── columns: a:int:null:1 a:int:2
+ ├── columns: a:1(int) a:2(int!null)
  ├── right-join
- │    ├── columns: l.a:int:null:1 r.a:int:2
+ │    ├── columns: l.a:1(int) r.a:2(int!null)
  │    ├── scan
- │    │    └── columns: l.a:int:1
+ │    │    └── columns: l.a:1(int!null)
  │    ├── scan
- │    │    └── columns: r.a:int:2
+ │    │    └── columns: r.a:2(int!null)
  │    └── eq [type=bool, outer=(1,2)]
  │         ├── variable: l.a [type=int, outer=(1)]
  │         └── variable: r.a [type=int, outer=(2)]
@@ -2734,15 +2734,15 @@ build
 SELECT * FROM l LEFT OUTER JOIN r USING(a) WHERE a = 1
 ----
 project
- ├── columns: a:int:1
+ ├── columns: a:1(int!null)
  ├── select
- │    ├── columns: l.a:int:1 r.a:int:null:2
+ │    ├── columns: l.a:1(int!null) r.a:2(int)
  │    ├── left-join
- │    │    ├── columns: l.a:int:1 r.a:int:null:2
+ │    │    ├── columns: l.a:1(int!null) r.a:2(int)
  │    │    ├── scan
- │    │    │    └── columns: l.a:int:1
+ │    │    │    └── columns: l.a:1(int!null)
  │    │    ├── scan
- │    │    │    └── columns: r.a:int:2
+ │    │    │    └── columns: r.a:2(int!null)
  │    │    └── eq [type=bool, outer=(1,2)]
  │    │         ├── variable: l.a [type=int, outer=(1)]
  │    │         └── variable: r.a [type=int, outer=(2)]
@@ -2756,15 +2756,15 @@ build
 SELECT * FROM l RIGHT OUTER JOIN r USING(a) WHERE a = 3
 ----
 project
- ├── columns: a:int:2
+ ├── columns: a:2(int!null)
  ├── select
- │    ├── columns: l.a:int:null:1 r.a:int:2
+ │    ├── columns: l.a:1(int) r.a:2(int!null)
  │    ├── right-join
- │    │    ├── columns: l.a:int:null:1 r.a:int:2
+ │    │    ├── columns: l.a:1(int) r.a:2(int!null)
  │    │    ├── scan
- │    │    │    └── columns: l.a:int:1
+ │    │    │    └── columns: l.a:1(int!null)
  │    │    ├── scan
- │    │    │    └── columns: r.a:int:2
+ │    │    │    └── columns: r.a:2(int!null)
  │    │    └── eq [type=bool, outer=(1,2)]
  │    │         ├── variable: l.a [type=int, outer=(1)]
  │    │         └── variable: r.a [type=int, outer=(2)]
@@ -2819,15 +2819,15 @@ build
 SELECT * FROM abcdef join (select * from abg) USING (a,b) WHERE ((a,b)>(1,2) OR ((a,b)=(1,2) AND c < 6) OR ((a,b,c)=(1,2,6) AND d > 8))
 ----
 project
- ├── columns: a:int:1 b:int:2 c:int:3 d:int:4 e:int:null:5 f:int:null:6 g:int:null:9
+ ├── columns: a:1(int!null) b:2(int!null) c:3(int!null) d:4(int!null) e:5(int) f:6(int) g:9(int)
  ├── select
- │    ├── columns: abcdef.a:int:1 abcdef.b:int:2 abcdef.c:int:3 abcdef.d:int:4 abcdef.e:int:null:5 abcdef.f:int:null:6 abg.a:int:7 abg.b:int:8 abg.g:int:null:9
+ │    ├── columns: abcdef.a:1(int!null) abcdef.b:2(int!null) abcdef.c:3(int!null) abcdef.d:4(int!null) abcdef.e:5(int) abcdef.f:6(int) abg.a:7(int!null) abg.b:8(int!null) abg.g:9(int)
  │    ├── inner-join
- │    │    ├── columns: abcdef.a:int:1 abcdef.b:int:2 abcdef.c:int:3 abcdef.d:int:4 abcdef.e:int:null:5 abcdef.f:int:null:6 abg.a:int:7 abg.b:int:8 abg.g:int:null:9
+ │    │    ├── columns: abcdef.a:1(int!null) abcdef.b:2(int!null) abcdef.c:3(int!null) abcdef.d:4(int!null) abcdef.e:5(int) abcdef.f:6(int) abg.a:7(int!null) abg.b:8(int!null) abg.g:9(int)
  │    │    ├── scan
- │    │    │    └── columns: abcdef.a:int:1 abcdef.b:int:2 abcdef.c:int:3 abcdef.d:int:4 abcdef.e:int:null:5 abcdef.f:int:null:6
+ │    │    │    └── columns: abcdef.a:1(int!null) abcdef.b:2(int!null) abcdef.c:3(int!null) abcdef.d:4(int!null) abcdef.e:5(int) abcdef.f:6(int)
  │    │    ├── scan
- │    │    │    └── columns: abg.a:int:7 abg.b:int:8 abg.g:int:null:9
+ │    │    │    └── columns: abg.a:7(int!null) abg.b:8(int!null) abg.g:9(int)
  │    │    └── and [type=bool, outer=(1,2,7,8)]
  │    │         ├── eq [type=bool, outer=(1,7)]
  │    │         │    ├── variable: abcdef.a [type=int, outer=(1)]
@@ -2917,13 +2917,13 @@ build
 SELECT * FROM foo NATURAL JOIN bar
 ----
 project
- ├── columns: a:int:null:1 b:int:null:2 c:float:null:3 d:float:null:4
+ ├── columns: a:1(int) b:2(int) c:3(float) d:4(float)
  ├── inner-join
- │    ├── columns: foo.a:int:null:1 foo.b:int:null:2 foo.c:float:null:3 foo.d:float:null:4 foo.rowid:int:5 bar.a:int:null:6 bar.b:float:null:7 bar.c:float:null:8 bar.d:int:null:9 bar.rowid:int:10
+ │    ├── columns: foo.a:1(int) foo.b:2(int) foo.c:3(float) foo.d:4(float) foo.rowid:5(int!null) bar.a:6(int) bar.b:7(float) bar.c:8(float) bar.d:9(int) bar.rowid:10(int!null)
  │    ├── scan
- │    │    └── columns: foo.a:int:null:1 foo.b:int:null:2 foo.c:float:null:3 foo.d:float:null:4 foo.rowid:int:5
+ │    │    └── columns: foo.a:1(int) foo.b:2(int) foo.c:3(float) foo.d:4(float) foo.rowid:5(int!null)
  │    ├── scan
- │    │    └── columns: bar.a:int:null:6 bar.b:float:null:7 bar.c:float:null:8 bar.d:int:null:9 bar.rowid:int:10
+ │    │    └── columns: bar.a:6(int) bar.b:7(float) bar.c:8(float) bar.d:9(int) bar.rowid:10(int!null)
  │    └── and [type=bool, outer=(1-4,6-9)]
  │         ├── eq [type=bool, outer=(1,6)]
  │         │    ├── variable: foo.a [type=int, outer=(1)]
@@ -2948,13 +2948,13 @@ build
 SELECT * FROM foo JOIN bar USING (b)
 ----
 project
- ├── columns: b:int:null:2 a:int:null:1 c:float:null:3 d:float:null:4 a:int:null:6 c:float:null:8 d:int:null:9
+ ├── columns: b:2(int) a:1(int) c:3(float) d:4(float) a:6(int) c:8(float) d:9(int)
  ├── inner-join
- │    ├── columns: foo.a:int:null:1 foo.b:int:null:2 foo.c:float:null:3 foo.d:float:null:4 foo.rowid:int:5 bar.a:int:null:6 bar.b:float:null:7 bar.c:float:null:8 bar.d:int:null:9 bar.rowid:int:10
+ │    ├── columns: foo.a:1(int) foo.b:2(int) foo.c:3(float) foo.d:4(float) foo.rowid:5(int!null) bar.a:6(int) bar.b:7(float) bar.c:8(float) bar.d:9(int) bar.rowid:10(int!null)
  │    ├── scan
- │    │    └── columns: foo.a:int:null:1 foo.b:int:null:2 foo.c:float:null:3 foo.d:float:null:4 foo.rowid:int:5
+ │    │    └── columns: foo.a:1(int) foo.b:2(int) foo.c:3(float) foo.d:4(float) foo.rowid:5(int!null)
  │    ├── scan
- │    │    └── columns: bar.a:int:null:6 bar.b:float:null:7 bar.c:float:null:8 bar.d:int:null:9 bar.rowid:int:10
+ │    │    └── columns: bar.a:6(int) bar.b:7(float) bar.c:8(float) bar.d:9(int) bar.rowid:10(int!null)
  │    └── eq [type=bool, outer=(2,7)]
  │         ├── variable: foo.b [type=int, outer=(2)]
  │         └── variable: bar.b [type=float, outer=(7)]
@@ -2972,13 +2972,13 @@ build
 SELECT * FROM foo JOIN bar USING (a, b)
 ----
 project
- ├── columns: a:int:null:1 b:int:null:2 c:float:null:3 d:float:null:4 c:float:null:8 d:int:null:9
+ ├── columns: a:1(int) b:2(int) c:3(float) d:4(float) c:8(float) d:9(int)
  ├── inner-join
- │    ├── columns: foo.a:int:null:1 foo.b:int:null:2 foo.c:float:null:3 foo.d:float:null:4 foo.rowid:int:5 bar.a:int:null:6 bar.b:float:null:7 bar.c:float:null:8 bar.d:int:null:9 bar.rowid:int:10
+ │    ├── columns: foo.a:1(int) foo.b:2(int) foo.c:3(float) foo.d:4(float) foo.rowid:5(int!null) bar.a:6(int) bar.b:7(float) bar.c:8(float) bar.d:9(int) bar.rowid:10(int!null)
  │    ├── scan
- │    │    └── columns: foo.a:int:null:1 foo.b:int:null:2 foo.c:float:null:3 foo.d:float:null:4 foo.rowid:int:5
+ │    │    └── columns: foo.a:1(int) foo.b:2(int) foo.c:3(float) foo.d:4(float) foo.rowid:5(int!null)
  │    ├── scan
- │    │    └── columns: bar.a:int:null:6 bar.b:float:null:7 bar.c:float:null:8 bar.d:int:null:9 bar.rowid:int:10
+ │    │    └── columns: bar.a:6(int) bar.b:7(float) bar.c:8(float) bar.d:9(int) bar.rowid:10(int!null)
  │    └── and [type=bool, outer=(1,2,6,7)]
  │         ├── eq [type=bool, outer=(1,6)]
  │         │    ├── variable: foo.a [type=int, outer=(1)]
@@ -2999,13 +2999,13 @@ build
 SELECT * FROM foo JOIN bar USING (a, b, c)
 ----
 project
- ├── columns: a:int:null:1 b:int:null:2 c:float:null:3 d:float:null:4 d:int:null:9
+ ├── columns: a:1(int) b:2(int) c:3(float) d:4(float) d:9(int)
  ├── inner-join
- │    ├── columns: foo.a:int:null:1 foo.b:int:null:2 foo.c:float:null:3 foo.d:float:null:4 foo.rowid:int:5 bar.a:int:null:6 bar.b:float:null:7 bar.c:float:null:8 bar.d:int:null:9 bar.rowid:int:10
+ │    ├── columns: foo.a:1(int) foo.b:2(int) foo.c:3(float) foo.d:4(float) foo.rowid:5(int!null) bar.a:6(int) bar.b:7(float) bar.c:8(float) bar.d:9(int) bar.rowid:10(int!null)
  │    ├── scan
- │    │    └── columns: foo.a:int:null:1 foo.b:int:null:2 foo.c:float:null:3 foo.d:float:null:4 foo.rowid:int:5
+ │    │    └── columns: foo.a:1(int) foo.b:2(int) foo.c:3(float) foo.d:4(float) foo.rowid:5(int!null)
  │    ├── scan
- │    │    └── columns: bar.a:int:null:6 bar.b:float:null:7 bar.c:float:null:8 bar.d:int:null:9 bar.rowid:int:10
+ │    │    └── columns: bar.a:6(int) bar.b:7(float) bar.c:8(float) bar.d:9(int) bar.rowid:10(int!null)
  │    └── and [type=bool, outer=(1-3,6-8)]
  │         ├── eq [type=bool, outer=(1,6)]
  │         │    ├── variable: foo.a [type=int, outer=(1)]
@@ -3028,13 +3028,13 @@ build
 SELECT * FROM foo JOIN bar ON foo.b = bar.b
 ----
 project
- ├── columns: a:int:null:1 b:int:null:2 c:float:null:3 d:float:null:4 a:int:null:6 b:float:null:7 c:float:null:8 d:int:null:9
+ ├── columns: a:1(int) b:2(int) c:3(float) d:4(float) a:6(int) b:7(float) c:8(float) d:9(int)
  ├── inner-join
- │    ├── columns: foo.a:int:null:1 foo.b:int:null:2 foo.c:float:null:3 foo.d:float:null:4 foo.rowid:int:5 bar.a:int:null:6 bar.b:float:null:7 bar.c:float:null:8 bar.d:int:null:9 bar.rowid:int:10
+ │    ├── columns: foo.a:1(int) foo.b:2(int) foo.c:3(float) foo.d:4(float) foo.rowid:5(int!null) bar.a:6(int) bar.b:7(float) bar.c:8(float) bar.d:9(int) bar.rowid:10(int!null)
  │    ├── scan
- │    │    └── columns: foo.a:int:null:1 foo.b:int:null:2 foo.c:float:null:3 foo.d:float:null:4 foo.rowid:int:5
+ │    │    └── columns: foo.a:1(int) foo.b:2(int) foo.c:3(float) foo.d:4(float) foo.rowid:5(int!null)
  │    ├── scan
- │    │    └── columns: bar.a:int:null:6 bar.b:float:null:7 bar.c:float:null:8 bar.d:int:null:9 bar.rowid:int:10
+ │    │    └── columns: bar.a:6(int) bar.b:7(float) bar.c:8(float) bar.d:9(int) bar.rowid:10(int!null)
  │    └── eq [type=bool, outer=(2,7)]
  │         ├── variable: foo.b [type=int, outer=(2)]
  │         └── variable: bar.b [type=float, outer=(7)]
@@ -3053,13 +3053,13 @@ build
 SELECT * FROM foo JOIN bar ON foo.a = bar.a AND foo.b = bar.b
 ----
 project
- ├── columns: a:int:null:1 b:int:null:2 c:float:null:3 d:float:null:4 a:int:null:6 b:float:null:7 c:float:null:8 d:int:null:9
+ ├── columns: a:1(int) b:2(int) c:3(float) d:4(float) a:6(int) b:7(float) c:8(float) d:9(int)
  ├── inner-join
- │    ├── columns: foo.a:int:null:1 foo.b:int:null:2 foo.c:float:null:3 foo.d:float:null:4 foo.rowid:int:5 bar.a:int:null:6 bar.b:float:null:7 bar.c:float:null:8 bar.d:int:null:9 bar.rowid:int:10
+ │    ├── columns: foo.a:1(int) foo.b:2(int) foo.c:3(float) foo.d:4(float) foo.rowid:5(int!null) bar.a:6(int) bar.b:7(float) bar.c:8(float) bar.d:9(int) bar.rowid:10(int!null)
  │    ├── scan
- │    │    └── columns: foo.a:int:null:1 foo.b:int:null:2 foo.c:float:null:3 foo.d:float:null:4 foo.rowid:int:5
+ │    │    └── columns: foo.a:1(int) foo.b:2(int) foo.c:3(float) foo.d:4(float) foo.rowid:5(int!null)
  │    ├── scan
- │    │    └── columns: bar.a:int:null:6 bar.b:float:null:7 bar.c:float:null:8 bar.d:int:null:9 bar.rowid:int:10
+ │    │    └── columns: bar.a:6(int) bar.b:7(float) bar.c:8(float) bar.d:9(int) bar.rowid:10(int!null)
  │    └── and [type=bool, outer=(1,2,6,7)]
  │         ├── eq [type=bool, outer=(1,6)]
  │         │    ├── variable: foo.a [type=int, outer=(1)]
@@ -3081,15 +3081,15 @@ build
 SELECT * FROM foo, bar WHERE foo.b = bar.b
 ----
 project
- ├── columns: a:int:null:1 b:int:null:2 c:float:null:3 d:float:null:4 a:int:null:6 b:float:null:7 c:float:null:8 d:int:null:9
+ ├── columns: a:1(int) b:2(int) c:3(float) d:4(float) a:6(int) b:7(float) c:8(float) d:9(int)
  ├── select
- │    ├── columns: foo.a:int:null:1 foo.b:int:null:2 foo.c:float:null:3 foo.d:float:null:4 foo.rowid:int:5 bar.a:int:null:6 bar.b:float:null:7 bar.c:float:null:8 bar.d:int:null:9 bar.rowid:int:10
+ │    ├── columns: foo.a:1(int) foo.b:2(int) foo.c:3(float) foo.d:4(float) foo.rowid:5(int!null) bar.a:6(int) bar.b:7(float) bar.c:8(float) bar.d:9(int) bar.rowid:10(int!null)
  │    ├── inner-join
- │    │    ├── columns: foo.a:int:null:1 foo.b:int:null:2 foo.c:float:null:3 foo.d:float:null:4 foo.rowid:int:5 bar.a:int:null:6 bar.b:float:null:7 bar.c:float:null:8 bar.d:int:null:9 bar.rowid:int:10
+ │    │    ├── columns: foo.a:1(int) foo.b:2(int) foo.c:3(float) foo.d:4(float) foo.rowid:5(int!null) bar.a:6(int) bar.b:7(float) bar.c:8(float) bar.d:9(int) bar.rowid:10(int!null)
  │    │    ├── scan
- │    │    │    └── columns: foo.a:int:null:1 foo.b:int:null:2 foo.c:float:null:3 foo.d:float:null:4 foo.rowid:int:5
+ │    │    │    └── columns: foo.a:1(int) foo.b:2(int) foo.c:3(float) foo.d:4(float) foo.rowid:5(int!null)
  │    │    ├── scan
- │    │    │    └── columns: bar.a:int:null:6 bar.b:float:null:7 bar.c:float:null:8 bar.d:int:null:9 bar.rowid:int:10
+ │    │    │    └── columns: bar.a:6(int) bar.b:7(float) bar.c:8(float) bar.d:9(int) bar.rowid:10(int!null)
  │    │    └── true [type=bool]
  │    └── eq [type=bool, outer=(2,7)]
  │         ├── variable: foo.b [type=int, outer=(2)]
@@ -3109,15 +3109,15 @@ build
 SELECT * FROM foo, bar WHERE foo.a = bar.a AND foo.b = bar.b
 ----
 project
- ├── columns: a:int:null:1 b:int:null:2 c:float:null:3 d:float:null:4 a:int:null:6 b:float:null:7 c:float:null:8 d:int:null:9
+ ├── columns: a:1(int) b:2(int) c:3(float) d:4(float) a:6(int) b:7(float) c:8(float) d:9(int)
  ├── select
- │    ├── columns: foo.a:int:null:1 foo.b:int:null:2 foo.c:float:null:3 foo.d:float:null:4 foo.rowid:int:5 bar.a:int:null:6 bar.b:float:null:7 bar.c:float:null:8 bar.d:int:null:9 bar.rowid:int:10
+ │    ├── columns: foo.a:1(int) foo.b:2(int) foo.c:3(float) foo.d:4(float) foo.rowid:5(int!null) bar.a:6(int) bar.b:7(float) bar.c:8(float) bar.d:9(int) bar.rowid:10(int!null)
  │    ├── inner-join
- │    │    ├── columns: foo.a:int:null:1 foo.b:int:null:2 foo.c:float:null:3 foo.d:float:null:4 foo.rowid:int:5 bar.a:int:null:6 bar.b:float:null:7 bar.c:float:null:8 bar.d:int:null:9 bar.rowid:int:10
+ │    │    ├── columns: foo.a:1(int) foo.b:2(int) foo.c:3(float) foo.d:4(float) foo.rowid:5(int!null) bar.a:6(int) bar.b:7(float) bar.c:8(float) bar.d:9(int) bar.rowid:10(int!null)
  │    │    ├── scan
- │    │    │    └── columns: foo.a:int:null:1 foo.b:int:null:2 foo.c:float:null:3 foo.d:float:null:4 foo.rowid:int:5
+ │    │    │    └── columns: foo.a:1(int) foo.b:2(int) foo.c:3(float) foo.d:4(float) foo.rowid:5(int!null)
  │    │    ├── scan
- │    │    │    └── columns: bar.a:int:null:6 bar.b:float:null:7 bar.c:float:null:8 bar.d:int:null:9 bar.rowid:int:10
+ │    │    │    └── columns: bar.a:6(int) bar.b:7(float) bar.c:8(float) bar.d:9(int) bar.rowid:10(int!null)
  │    │    └── true [type=bool]
  │    └── and [type=bool, outer=(1,2,6,7)]
  │         ├── eq [type=bool, outer=(1,6)]
@@ -3141,15 +3141,15 @@ build
 SELECT * FROM foo JOIN bar USING (a, b) WHERE foo.c = bar.c AND foo.d = bar.d
 ----
 project
- ├── columns: a:int:null:1 b:int:null:2 c:float:null:3 d:float:null:4 c:float:null:8 d:int:null:9
+ ├── columns: a:1(int) b:2(int) c:3(float) d:4(float) c:8(float) d:9(int)
  ├── select
- │    ├── columns: foo.a:int:null:1 foo.b:int:null:2 foo.c:float:null:3 foo.d:float:null:4 foo.rowid:int:5 bar.a:int:null:6 bar.b:float:null:7 bar.c:float:null:8 bar.d:int:null:9 bar.rowid:int:10
+ │    ├── columns: foo.a:1(int) foo.b:2(int) foo.c:3(float) foo.d:4(float) foo.rowid:5(int!null) bar.a:6(int) bar.b:7(float) bar.c:8(float) bar.d:9(int) bar.rowid:10(int!null)
  │    ├── inner-join
- │    │    ├── columns: foo.a:int:null:1 foo.b:int:null:2 foo.c:float:null:3 foo.d:float:null:4 foo.rowid:int:5 bar.a:int:null:6 bar.b:float:null:7 bar.c:float:null:8 bar.d:int:null:9 bar.rowid:int:10
+ │    │    ├── columns: foo.a:1(int) foo.b:2(int) foo.c:3(float) foo.d:4(float) foo.rowid:5(int!null) bar.a:6(int) bar.b:7(float) bar.c:8(float) bar.d:9(int) bar.rowid:10(int!null)
  │    │    ├── scan
- │    │    │    └── columns: foo.a:int:null:1 foo.b:int:null:2 foo.c:float:null:3 foo.d:float:null:4 foo.rowid:int:5
+ │    │    │    └── columns: foo.a:1(int) foo.b:2(int) foo.c:3(float) foo.d:4(float) foo.rowid:5(int!null)
  │    │    ├── scan
- │    │    │    └── columns: bar.a:int:null:6 bar.b:float:null:7 bar.c:float:null:8 bar.d:int:null:9 bar.rowid:int:10
+ │    │    │    └── columns: bar.a:6(int) bar.b:7(float) bar.c:8(float) bar.d:9(int) bar.rowid:10(int!null)
  │    │    └── and [type=bool, outer=(1,2,6,7)]
  │    │         ├── eq [type=bool, outer=(1,6)]
  │    │         │    ├── variable: foo.a [type=int, outer=(1)]
@@ -3192,13 +3192,13 @@ build
 SELECT k FROM kv, (SELECT 1 AS k)
 ----
 project
- ├── columns: k:int:null:5
+ ├── columns: k:5(int)
  ├── inner-join
- │    ├── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4 k:int:null:5
+ │    ├── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string) k:5(int)
  │    ├── scan
- │    │    └── columns: kv.k:int:1 kv.v:int:null:2 kv.w:int:null:3 kv.s:string:null:4
+ │    │    └── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string)
  │    ├── project
- │    │    ├── columns: k:int:null:5
+ │    │    ├── columns: k:5(int)
  │    │    ├── values
  │    │    │    └── tuple [type=tuple{}]
  │    │    └── projections

--- a/pkg/sql/opt/optbuilder/testdata/orderby
+++ b/pkg/sql/opt/optbuilder/testdata/orderby
@@ -18,13 +18,13 @@ build
 SELECT c FROM t ORDER BY c
 ----
 project
- ├── columns: c:bool:null:3
+ ├── columns: c:3(bool)
  ├── ordering: +3
  ├── sort
- │    ├── columns: t.a:int:1 t.b:int:null:2 t.c:bool:null:3
+ │    ├── columns: t.a:1(int!null) t.b:2(int) t.c:3(bool)
  │    ├── ordering: +3
  │    └── scan
- │         └── columns: t.a:int:1 t.b:int:null:2 t.c:bool:null:3
+ │         └── columns: t.a:1(int!null) t.b:2(int) t.c:3(bool)
  └── projections [outer=(3)]
       └── variable: t.c [type=bool, outer=(3)]
 
@@ -32,13 +32,13 @@ build
 SELECT c FROM t ORDER BY c DESC
 ----
 project
- ├── columns: c:bool:null:3
+ ├── columns: c:3(bool)
  ├── ordering: -3
  ├── sort
- │    ├── columns: t.a:int:1 t.b:int:null:2 t.c:bool:null:3
+ │    ├── columns: t.a:1(int!null) t.b:2(int) t.c:3(bool)
  │    ├── ordering: -3
  │    └── scan
- │         └── columns: t.a:int:1 t.b:int:null:2 t.c:bool:null:3
+ │         └── columns: t.a:1(int!null) t.b:2(int) t.c:3(bool)
  └── projections [outer=(3)]
       └── variable: t.c [type=bool, outer=(3)]
 
@@ -46,13 +46,13 @@ build
 SELECT a, b FROM t ORDER BY b
 ----
 project
- ├── columns: a:int:1 b:int:null:2
+ ├── columns: a:1(int!null) b:2(int)
  ├── ordering: +2
  ├── sort
- │    ├── columns: t.a:int:1 t.b:int:null:2 t.c:bool:null:3
+ │    ├── columns: t.a:1(int!null) t.b:2(int) t.c:3(bool)
  │    ├── ordering: +2
  │    └── scan
- │         └── columns: t.a:int:1 t.b:int:null:2 t.c:bool:null:3
+ │         └── columns: t.a:1(int!null) t.b:2(int) t.c:3(bool)
  └── projections [outer=(1,2)]
       ├── variable: t.a [type=int, outer=(1)]
       └── variable: t.b [type=int, outer=(2)]
@@ -61,13 +61,13 @@ build
 SELECT a, b FROM t ORDER BY b DESC
 ----
 project
- ├── columns: a:int:1 b:int:null:2
+ ├── columns: a:1(int!null) b:2(int)
  ├── ordering: -2
  ├── sort
- │    ├── columns: t.a:int:1 t.b:int:null:2 t.c:bool:null:3
+ │    ├── columns: t.a:1(int!null) t.b:2(int) t.c:3(bool)
  │    ├── ordering: -2
  │    └── scan
- │         └── columns: t.a:int:1 t.b:int:null:2 t.c:bool:null:3
+ │         └── columns: t.a:1(int!null) t.b:2(int) t.c:3(bool)
  └── projections [outer=(1,2)]
       ├── variable: t.a [type=int, outer=(1)]
       └── variable: t.b [type=int, outer=(2)]
@@ -76,13 +76,13 @@ build
 SELECT a AS foo, b FROM t ORDER BY foo DESC
 ----
 project
- ├── columns: foo:int:1 b:int:null:2
+ ├── columns: foo:1(int!null) b:2(int)
  ├── ordering: -1
  ├── sort
- │    ├── columns: t.a:int:1 t.b:int:null:2 t.c:bool:null:3
+ │    ├── columns: t.a:1(int!null) t.b:2(int) t.c:3(bool)
  │    ├── ordering: -1
  │    └── scan
- │         └── columns: t.a:int:1 t.b:int:null:2 t.c:bool:null:3
+ │         └── columns: t.a:1(int!null) t.b:2(int) t.c:3(bool)
  └── projections [outer=(1,2)]
       ├── variable: t.a [type=int, outer=(1)]
       └── variable: t.b [type=int, outer=(2)]
@@ -91,16 +91,16 @@ build
 SELECT a, b FROM t WHERE b = 7 ORDER BY b, a
 ----
 project
- ├── columns: a:int:1 b:int:null:2
+ ├── columns: a:1(int!null) b:2(int)
  ├── ordering: +2,+1
  ├── select
- │    ├── columns: t.a:int:1 t.b:int:null:2 t.c:bool:null:3
+ │    ├── columns: t.a:1(int!null) t.b:2(int) t.c:3(bool)
  │    ├── ordering: +2,+1
  │    ├── sort
- │    │    ├── columns: t.a:int:1 t.b:int:null:2 t.c:bool:null:3
+ │    │    ├── columns: t.a:1(int!null) t.b:2(int) t.c:3(bool)
  │    │    ├── ordering: +2,+1
  │    │    └── scan
- │    │         └── columns: t.a:int:1 t.b:int:null:2 t.c:bool:null:3
+ │    │         └── columns: t.a:1(int!null) t.b:2(int) t.c:3(bool)
  │    └── eq [type=bool, outer=(2)]
  │         ├── variable: t.b [type=int, outer=(2)]
  │         └── const: 7 [type=int]
@@ -112,13 +112,13 @@ build
 SELECT a, b FROM t ORDER BY b, a DESC
 ----
 project
- ├── columns: a:int:1 b:int:null:2
+ ├── columns: a:1(int!null) b:2(int)
  ├── ordering: +2,-1
  ├── sort
- │    ├── columns: t.a:int:1 t.b:int:null:2 t.c:bool:null:3
+ │    ├── columns: t.a:1(int!null) t.b:2(int) t.c:3(bool)
  │    ├── ordering: +2,-1
  │    └── scan
- │         └── columns: t.a:int:1 t.b:int:null:2 t.c:bool:null:3
+ │         └── columns: t.a:1(int!null) t.b:2(int) t.c:3(bool)
  └── projections [outer=(1,2)]
       ├── variable: t.a [type=int, outer=(1)]
       └── variable: t.b [type=int, outer=(2)]
@@ -127,14 +127,14 @@ build
 SELECT a, b, a+b AS ab FROM t WHERE b = 7 ORDER BY ab DESC, a
 ----
 sort
- ├── columns: a:int:1 b:int:null:2 ab:int:null:4
+ ├── columns: a:1(int!null) b:2(int) ab:4(int)
  ├── ordering: -4,+1
  └── project
-      ├── columns: t.a:int:1 t.b:int:null:2 ab:int:null:4
+      ├── columns: t.a:1(int!null) t.b:2(int) ab:4(int)
       ├── select
-      │    ├── columns: t.a:int:1 t.b:int:null:2 t.c:bool:null:3
+      │    ├── columns: t.a:1(int!null) t.b:2(int) t.c:3(bool)
       │    ├── scan
-      │    │    └── columns: t.a:int:1 t.b:int:null:2 t.c:bool:null:3
+      │    │    └── columns: t.a:1(int!null) t.b:2(int) t.c:3(bool)
       │    └── eq [type=bool, outer=(2)]
       │         ├── variable: t.b [type=int, outer=(2)]
       │         └── const: 7 [type=int]

--- a/pkg/sql/opt/optbuilder/testdata/project
+++ b/pkg/sql/opt/optbuilder/testdata/project
@@ -21,7 +21,7 @@ build
 SELECT 5
 ----
 project
- ├── columns: column1:int:null:1
+ ├── columns: column1:1(int)
  ├── values
  │    └── tuple [type=tuple{}]
  └── projections
@@ -31,9 +31,9 @@ build
 SELECT a.x FROM t.a
 ----
 project
- ├── columns: x:int:1
+ ├── columns: x:1(int!null)
  ├── scan
- │    └── columns: a.x:int:1 a.y:float:null:2
+ │    └── columns: a.x:1(int!null) a.y:2(float)
  └── projections [outer=(1)]
       └── variable: a.x [type=int, outer=(1)]
 
@@ -41,15 +41,15 @@ build
 SELECT a.x, a.y FROM t.a
 ----
 scan
- └── columns: x:int:1 y:float:null:2
+ └── columns: x:1(int!null) y:2(float)
 
 build
 SELECT a.y, a.x FROM t.a
 ----
 project
- ├── columns: y:float:null:2 x:int:1
+ ├── columns: y:2(float) x:1(int!null)
  ├── scan
- │    └── columns: a.x:int:1 a.y:float:null:2
+ │    └── columns: a.x:1(int!null) a.y:2(float)
  └── projections [outer=(1,2)]
       ├── variable: a.y [type=float, outer=(2)]
       └── variable: a.x [type=int, outer=(1)]
@@ -58,7 +58,7 @@ build
 SELECT * FROM t.a
 ----
 scan
- └── columns: x:int:1 y:float:null:2
+ └── columns: x:1(int!null) y:2(float)
 
 # Note that an explicit projection operator is added for table b (unlike for
 # table a) to avoid projecting the hidden rowid column.
@@ -66,9 +66,9 @@ build
 SELECT * FROM t.b
 ----
 project
- ├── columns: x:int:null:1 y:float:null:2
+ ├── columns: x:1(int) y:2(float)
  ├── scan
- │    └── columns: b.x:int:null:1 b.y:float:null:2 b.rowid:int:3
+ │    └── columns: b.x:1(int) b.y:2(float) b.rowid:3(int!null)
  └── projections [outer=(1,2)]
       ├── variable: b.x [type=int, outer=(1)]
       └── variable: b.y [type=float, outer=(2)]
@@ -77,9 +77,9 @@ build
 SELECT (a.x + 3) AS "X", false AS "Y" FROM t.a
 ----
 project
- ├── columns: X:int:null:3 Y:bool:null:4
+ ├── columns: X:3(int) Y:4(bool)
  ├── scan
- │    └── columns: a.x:int:1 a.y:float:null:2
+ │    └── columns: a.x:1(int!null) a.y:2(float)
  └── projections [outer=(1)]
       ├── plus [type=int, outer=(1)]
       │    ├── variable: a.x [type=int, outer=(1)]
@@ -90,9 +90,9 @@ build
 SELECT *, ((x < y) OR x > 1000) FROM t.a
 ----
 project
- ├── columns: x:int:1 y:float:null:2 column3:bool:null:3
+ ├── columns: x:1(int!null) y:2(float) column3:3(bool)
  ├── scan
- │    └── columns: a.x:int:1 a.y:float:null:2
+ │    └── columns: a.x:1(int!null) a.y:2(float)
  └── projections [outer=(1,2)]
       ├── variable: a.x [type=int, outer=(1)]
       ├── variable: a.y [type=float, outer=(2)]
@@ -108,9 +108,9 @@ build
 SELECT a.*, true FROM t.a
 ----
 project
- ├── columns: x:int:1 y:float:null:2 column3:bool:null:3
+ ├── columns: x:1(int!null) y:2(float) column3:3(bool)
  ├── scan
- │    └── columns: a.x:int:1 a.y:float:null:2
+ │    └── columns: a.x:1(int!null) a.y:2(float)
  └── projections [outer=(1,2)]
       ├── variable: a.x [type=int, outer=(1)]
       ├── variable: a.y [type=float, outer=(2)]
@@ -120,11 +120,11 @@ build
 SELECT u + 1, v + 1 FROM (SELECT a.x + 3, a.y + 1.0 FROM t.a) AS foo(u, v)
 ----
 project
- ├── columns: column5:int:null:5 column6:float:null:6
+ ├── columns: column5:5(int) column6:6(float)
  ├── project
- │    ├── columns: column3:int:null:3 column4:float:null:4
+ │    ├── columns: column3:3(int) column4:4(float)
  │    ├── scan
- │    │    └── columns: a.x:int:1 a.y:float:null:2
+ │    │    └── columns: a.x:1(int!null) a.y:2(float)
  │    └── projections [outer=(1,2)]
  │         ├── plus [type=int, outer=(1)]
  │         │    ├── variable: a.x [type=int, outer=(1)]
@@ -144,9 +144,9 @@ build
 SELECT rowid FROM b;
 ----
 project
- ├── columns: rowid:int:3
+ ├── columns: rowid:3(int!null)
  ├── scan
- │    └── columns: b.x:int:null:1 b.y:float:null:2 b.rowid:int:3
+ │    └── columns: b.x:1(int) b.y:2(float) b.rowid:3(int!null)
  └── projections [outer=(3)]
       └── variable: b.rowid [type=int, outer=(3)]
 
@@ -159,9 +159,9 @@ build
 SELECT rowid FROM (SELECT rowid FROM b)
 ----
 project
- ├── columns: rowid:int:3
+ ├── columns: rowid:3(int!null)
  ├── scan
- │    └── columns: b.x:int:null:1 b.y:float:null:2 b.rowid:int:3
+ │    └── columns: b.x:1(int) b.y:2(float) b.rowid:3(int!null)
  └── projections [outer=(3)]
       └── variable: b.rowid [type=int, outer=(3)]
 
@@ -169,9 +169,9 @@ build
 SELECT q.r FROM (SELECT rowid FROM b) AS q(r)
 ----
 project
- ├── columns: r:int:3
+ ├── columns: r:3(int!null)
  ├── scan
- │    └── columns: b.x:int:null:1 b.y:float:null:2 b.rowid:int:3
+ │    └── columns: b.x:1(int) b.y:2(float) b.rowid:3(int!null)
  └── projections [outer=(3)]
       └── variable: b.rowid [type=int, outer=(3)]
 
@@ -179,9 +179,9 @@ build
 SELECT r FROM (SELECT rowid FROM b) AS q(r)
 ----
 project
- ├── columns: r:int:3
+ ├── columns: r:3(int!null)
  ├── scan
- │    └── columns: b.x:int:null:1 b.y:float:null:2 b.rowid:int:3
+ │    └── columns: b.x:1(int) b.y:2(float) b.rowid:3(int!null)
  └── projections [outer=(3)]
       └── variable: b.rowid [type=int, outer=(3)]
 
@@ -204,9 +204,9 @@ build
 SELECT rowid::string FROM b
 ----
 project
- ├── columns: column4:string:null:4
+ ├── columns: column4:4(string)
  ├── scan
- │    └── columns: b.x:int:null:1 b.y:float:null:2 b.rowid:int:3
+ │    └── columns: b.x:1(int) b.y:2(float) b.rowid:3(int!null)
  └── projections [outer=(3)]
       └── cast: string [type=string, outer=(3)]
            └── variable: b.rowid [type=int, outer=(3)]

--- a/pkg/sql/opt/optbuilder/testdata/select
+++ b/pkg/sql/opt/optbuilder/testdata/select
@@ -6,7 +6,7 @@ build
 SELECT 1
 ----
 project
- ├── columns: column1:int:null:1
+ ├── columns: column1:1(int)
  ├── values
  │    └── tuple [type=tuple{}]
  └── projections
@@ -16,7 +16,7 @@ build
 SELECT NULL
 ----
 project
- ├── columns: column1:unknown:null:1
+ ├── columns: column1:1(unknown)
  ├── values
  │    └── tuple [type=tuple{}]
  └── projections
@@ -26,7 +26,7 @@ build
 SELECT 1+1 AS two, 2+2 AS four
 ----
 project
- ├── columns: two:int:null:1 four:int:null:2
+ ├── columns: two:1(int) four:2(int)
  ├── values
  │    └── tuple [type=tuple{}]
  └── projections
@@ -54,15 +54,15 @@ build
 SELECT * FROM abc
 ----
 scan
- └── columns: a:int:1 b:int:null:2 c:int:null:3
+ └── columns: a:1(int!null) b:2(int) c:3(int)
 
 build
 SELECT NULL, * FROM abc
 ----
 project
- ├── columns: column4:unknown:null:4 a:int:1 b:int:null:2 c:int:null:3
+ ├── columns: column4:4(unknown) a:1(int!null) b:2(int) c:3(int)
  ├── scan
- │    └── columns: abc.a:int:1 abc.b:int:null:2 abc.c:int:null:3
+ │    └── columns: abc.a:1(int!null) abc.b:2(int) abc.c:3(int)
  └── projections [outer=(1-3)]
       ├── null [type=unknown]
       ├── variable: abc.a [type=int, outer=(1)]
@@ -75,33 +75,33 @@ build
 TABLE abc
 ----
 scan
- └── columns: a:int:1 b:int:null:2 c:int:null:3
+ └── columns: a:1(int!null) b:2(int) c:3(int)
 
 build
 SELECT * FROM abc WHERE NULL
 ----
 select
- ├── columns: a:int:1 b:int:null:2 c:int:null:3
+ ├── columns: a:1(int!null) b:2(int) c:3(int)
  ├── scan
- │    └── columns: abc.a:int:1 abc.b:int:null:2 abc.c:int:null:3
+ │    └── columns: abc.a:1(int!null) abc.b:2(int) abc.c:3(int)
  └── null [type=unknown]
 
 build
 SELECT * FROM abc WHERE a = NULL
 ----
 select
- ├── columns: a:int:1 b:int:null:2 c:int:null:3
+ ├── columns: a:1(int!null) b:2(int) c:3(int)
  ├── scan
- │    └── columns: abc.a:int:1 abc.b:int:null:2 abc.c:int:null:3
+ │    └── columns: abc.a:1(int!null) abc.b:2(int) abc.c:3(int)
  └── null [type=unknown]
 
 build
 SELECT *,* FROM abc
 ----
 project
- ├── columns: a:int:1 b:int:null:2 c:int:null:3 a:int:1 b:int:null:2 c:int:null:3
+ ├── columns: a:1(int!null) b:2(int) c:3(int) a:1(int!null) b:2(int) c:3(int)
  ├── scan
- │    └── columns: abc.a:int:1 abc.b:int:null:2 abc.c:int:null:3
+ │    └── columns: abc.a:1(int!null) abc.b:2(int) abc.c:3(int)
  └── projections [outer=(1-3)]
       ├── variable: abc.a [type=int, outer=(1)]
       ├── variable: abc.b [type=int, outer=(2)]
@@ -114,9 +114,9 @@ build
 SELECT a,a,a,a FROM abc
 ----
 project
- ├── columns: a:int:1 a:int:1 a:int:1 a:int:1
+ ├── columns: a:1(int!null) a:1(int!null) a:1(int!null) a:1(int!null)
  ├── scan
- │    └── columns: abc.a:int:1 abc.b:int:null:2 abc.c:int:null:3
+ │    └── columns: abc.a:1(int!null) abc.b:2(int) abc.c:3(int)
  └── projections [outer=(1)]
       ├── variable: abc.a [type=int, outer=(1)]
       ├── variable: abc.a [type=int, outer=(1)]
@@ -127,9 +127,9 @@ build
 SELECT a,c FROM abc
 ----
 project
- ├── columns: a:int:1 c:int:null:3
+ ├── columns: a:1(int!null) c:3(int)
  ├── scan
- │    └── columns: abc.a:int:1 abc.b:int:null:2 abc.c:int:null:3
+ │    └── columns: abc.a:1(int!null) abc.b:2(int) abc.c:3(int)
  └── projections [outer=(1,3)]
       ├── variable: abc.a [type=int, outer=(1)]
       └── variable: abc.c [type=int, outer=(3)]
@@ -138,9 +138,9 @@ build
 SELECT a+b+c AS foo FROM abc
 ----
 project
- ├── columns: foo:int:null:4
+ ├── columns: foo:4(int)
  ├── scan
- │    └── columns: abc.a:int:1 abc.b:int:null:2 abc.c:int:null:3
+ │    └── columns: abc.a:1(int!null) abc.b:2(int) abc.c:3(int)
  └── projections [outer=(1-3)]
       └── plus [type=int, outer=(1-3)]
            ├── plus [type=int, outer=(1,2)]
@@ -152,11 +152,11 @@ build allow-unsupported
 SELECT a,b FROM abc WHERE CASE WHEN a != 0 THEN b/a > 1.5 ELSE false END
 ----
 project
- ├── columns: a:int:1 b:int:null:2
+ ├── columns: a:1(int!null) b:2(int)
  ├── select
- │    ├── columns: abc.a:int:1 abc.b:int:null:2 abc.c:int:null:3
+ │    ├── columns: abc.a:1(int!null) abc.b:2(int) abc.c:3(int)
  │    ├── scan
- │    │    └── columns: abc.a:int:1 abc.b:int:null:2 abc.c:int:null:3
+ │    │    └── columns: abc.a:1(int!null) abc.b:2(int) abc.c:3(int)
  │    └── case [type=bool, outer=(1,2)]
  │         ├── true [type=bool]
  │         ├── when [type=bool, outer=(1,2)]
@@ -188,21 +188,21 @@ build
 SELECT * FROM kv
 ----
 scan
- └── columns: k:string:1 v:string:null:2
+ └── columns: k:1(string!null) v:2(string)
 
 build
 SELECT k,v FROM kv
 ----
 scan
- └── columns: k:string:1 v:string:null:2
+ └── columns: k:1(string!null) v:2(string)
 
 build
 SELECT v||'foo' FROM kv
 ----
 project
- ├── columns: column3:string:null:3
+ ├── columns: column3:3(string)
  ├── scan
- │    └── columns: kv.k:string:1 kv.v:string:null:2
+ │    └── columns: kv.k:1(string!null) kv.v:2(string)
  └── projections [outer=(2)]
       └── concat [type=string, outer=(2)]
            ├── variable: kv.v [type=string, outer=(2)]
@@ -212,9 +212,9 @@ build
 SELECT LOWER(v) FROM kv
 ----
 project
- ├── columns: column3:string:null:3
+ ├── columns: column3:3(string)
  ├── scan
- │    └── columns: kv.k:string:1 kv.v:string:null:2
+ │    └── columns: kv.k:1(string!null) kv.v:2(string)
  └── projections [outer=(2)]
       └── function: lower [type=string, outer=(2)]
            └── variable: kv.v [type=string, outer=(2)]
@@ -223,9 +223,9 @@ build
 SELECT k FROM kv
 ----
 project
- ├── columns: k:string:1
+ ├── columns: k:1(string!null)
  ├── scan
- │    └── columns: kv.k:string:1 kv.v:string:null:2
+ │    └── columns: kv.k:1(string!null) kv.v:2(string)
  └── projections [outer=(1)]
       └── variable: kv.k [type=string, outer=(1)]
 
@@ -233,21 +233,21 @@ build
 SELECT kv.K,KV.v FROM kv
 ----
 scan
- └── columns: k:string:1 v:string:null:2
+ └── columns: k:1(string!null) v:2(string)
 
 build
 SELECT kv.* FROM kv
 ----
 scan
- └── columns: k:string:1 v:string:null:2
+ └── columns: k:1(string!null) v:2(string)
 
 build
 SELECT (kv.*) FROM kv
 ----
 project
- ├── columns: column3:tuple{string, string}:null:3
+ ├── columns: column3:3(tuple{string, string})
  ├── scan
- │    └── columns: kv.k:string:1 kv.v:string:null:2
+ │    └── columns: kv.k:1(string!null) kv.v:2(string)
  └── projections [outer=(1,2)]
       └── tuple [type=tuple{string, string}, outer=(1,2)]
            ├── variable: kv.k [type=string, outer=(1)]
@@ -283,11 +283,11 @@ build
 SELECT FOO.k FROM kv AS foo WHERE foo.k = 'a'
 ----
 project
- ├── columns: k:string:1
+ ├── columns: k:1(string!null)
  ├── select
- │    ├── columns: kv.k:string:1 kv.v:string:null:2
+ │    ├── columns: kv.k:1(string!null) kv.v:2(string)
  │    ├── scan
- │    │    └── columns: kv.k:string:1 kv.v:string:null:2
+ │    │    └── columns: kv.k:1(string!null) kv.v:2(string)
  │    └── eq [type=bool, outer=(1)]
  │         ├── variable: kv.k [type=string, outer=(1)]
  │         └── const: 'a' [type=string]
@@ -298,11 +298,11 @@ build
 SELECT "foo"."v" FROM kv AS foo WHERE foo.k = 'a'
 ----
 project
- ├── columns: v:string:null:2
+ ├── columns: v:2(string)
  ├── select
- │    ├── columns: kv.k:string:1 kv.v:string:null:2
+ │    ├── columns: kv.k:1(string!null) kv.v:2(string)
  │    ├── scan
- │    │    └── columns: kv.k:string:1 kv.v:string:null:2
+ │    │    └── columns: kv.k:1(string!null) kv.v:2(string)
  │    └── eq [type=bool, outer=(1)]
  │         ├── variable: kv.k [type=string, outer=(1)]
  │         └── const: 'a' [type=string]
@@ -321,9 +321,9 @@ build
 SELECT *, "from", kw."from" FROM kw
 ----
 project
- ├── columns: from:int:1 from:int:1 from:int:1
+ ├── columns: from:1(int!null) from:1(int!null) from:1(int!null)
  ├── scan
- │    └── columns: kw.from:int:1
+ │    └── columns: kw.from:1(int!null)
  └── projections [outer=(1)]
       ├── variable: kw.from [type=int, outer=(1)]
       ├── variable: kw.from [type=int, outer=(1)]
@@ -345,9 +345,9 @@ build
 SELECT value FROM boolean_table
 ----
 project
- ├── columns: value:bool:null:2
+ ├── columns: value:2(bool)
  ├── scan
- │    └── columns: boolean_table.id:int:1 boolean_table.value:bool:null:2
+ │    └── columns: boolean_table.id:1(int!null) boolean_table.value:2(bool)
  └── projections [outer=(2)]
       └── variable: boolean_table.value [type=bool, outer=(2)]
 
@@ -355,7 +355,7 @@ build allow-unsupported
 SELECT CASE WHEN NULL THEN 1 ELSE 2 END
 ----
 project
- ├── columns: column1:int:null:1
+ ├── columns: column1:1(int)
  ├── values
  │    └── tuple [type=tuple{}]
  └── projections
@@ -370,9 +370,9 @@ build
 SELECT 0 * b, b % 1, 0 % b from abc
 ----
 project
- ├── columns: column4:int:null:4 column5:int:null:5 column6:int:null:6
+ ├── columns: column4:4(int) column5:5(int) column6:6(int)
  ├── scan
- │    └── columns: abc.a:int:1 abc.b:int:null:2 abc.c:int:null:3
+ │    └── columns: abc.a:1(int!null) abc.b:2(int) abc.c:3(int)
  └── projections [outer=(2)]
       ├── mult [type=int, outer=(2)]
       │    ├── const: 0 [type=int]
@@ -389,7 +389,7 @@ build
 SELECT 1 IN (1, 2)
 ----
 project
- ├── columns: column1:bool:null:1
+ ├── columns: column1:1(bool)
  ├── values
  │    └── tuple [type=tuple{}]
  └── projections
@@ -403,7 +403,7 @@ build
 SELECT NULL IN (1, 2)
 ----
 project
- ├── columns: column1:bool:null:1
+ ├── columns: column1:1(bool)
  ├── values
  │    └── tuple [type=tuple{}]
  └── projections
@@ -417,7 +417,7 @@ build
 SELECT 1 IN (NULL, 2)
 ----
 project
- ├── columns: column1:bool:null:1
+ ├── columns: column1:1(bool)
  ├── values
  │    └── tuple [type=tuple{}]
  └── projections
@@ -431,7 +431,7 @@ build
 SELECT (1, NULL) IN ((1, 1))
 ----
 project
- ├── columns: column1:bool:null:1
+ ├── columns: column1:1(bool)
  ├── values
  │    └── tuple [type=tuple{}]
  └── projections
@@ -457,15 +457,15 @@ build
 SELECT * FROM t.a
 ----
 scan
- └── columns: x:int:1 y:float:null:2
+ └── columns: x:1(int!null) y:2(float)
 
 build
 SELECT * FROM t.a WHERE x > 10
 ----
 select
- ├── columns: x:int:1 y:float:null:2
+ ├── columns: x:1(int!null) y:2(float)
  ├── scan
- │    └── columns: a.x:int:1 a.y:float:null:2
+ │    └── columns: a.x:1(int!null) a.y:2(float)
  └── gt [type=bool, outer=(1)]
       ├── variable: a.x [type=int, outer=(1)]
       └── const: 10 [type=int]
@@ -474,9 +474,9 @@ build
 SELECT * FROM t.a WHERE (x > 10 AND (x < 20 AND x != 13))
 ----
 select
- ├── columns: x:int:1 y:float:null:2
+ ├── columns: x:1(int!null) y:2(float)
  ├── scan
- │    └── columns: a.x:int:1 a.y:float:null:2
+ │    └── columns: a.x:1(int!null) a.y:2(float)
  └── and [type=bool, outer=(1)]
       ├── gt [type=bool, outer=(1)]
       │    ├── variable: a.x [type=int, outer=(1)]
@@ -493,9 +493,9 @@ build
 SELECT * FROM t.a WHERE x IN (1, 2, 3)
 ----
 select
- ├── columns: x:int:1 y:float:null:2
+ ├── columns: x:1(int!null) y:2(float)
  ├── scan
- │    └── columns: a.x:int:1 a.y:float:null:2
+ │    └── columns: a.x:1(int!null) a.y:2(float)
  └── in [type=bool, outer=(1)]
       ├── variable: a.x [type=int, outer=(1)]
       └── tuple [type=tuple{int, int, int}]
@@ -507,15 +507,15 @@ build
 SELECT * FROM t.a AS A(X, Y)
 ----
 scan
- └── columns: x:int:1 y:float:null:2
+ └── columns: x:1(int!null) y:2(float)
 
 build
 SELECT @1, @2 FROM t.a
 ----
 project
- ├── columns: column3:int:null:3 column4:float:null:4
+ ├── columns: column3:3(int) column4:4(float)
  ├── scan
- │    └── columns: a.x:int:1 a.y:float:null:2
+ │    └── columns: a.x:1(int!null) a.y:2(float)
  └── projections [outer=(1,2)]
       ├── variable: a.x [type=int, outer=(1)]
       └── variable: a.y [type=float, outer=(2)]
@@ -524,9 +524,9 @@ build
 SELECT * FROM t.a WHERE (x > 10)::bool
 ----
 select
- ├── columns: x:int:1 y:float:null:2
+ ├── columns: x:1(int!null) y:2(float)
  ├── scan
- │    └── columns: a.x:int:1 a.y:float:null:2
+ │    └── columns: a.x:1(int!null) a.y:2(float)
  └── cast: bool [type=bool, outer=(1)]
       └── gt [type=bool, outer=(1)]
            ├── variable: a.x [type=int, outer=(1)]

--- a/pkg/sql/opt/optbuilder/testdata/union
+++ b/pkg/sql/opt/optbuilder/testdata/union
@@ -4,11 +4,11 @@ build
 VALUES (1), (1), (1), (2), (2) UNION VALUES (1), (3), (1)
 ----
 union
- ├── columns: column1:int:null:3
- ├── left columns: column1:int:null:1
- ├── right columns: column1:int:null:2
+ ├── columns: column1:3(int)
+ ├── left columns: column1:1(int)
+ ├── right columns: column1:2(int)
  ├── values
- │    ├── columns: column1:int:null:1
+ │    ├── columns: column1:1(int)
  │    ├── tuple [type=tuple{int}]
  │    │    └── const: 1 [type=int]
  │    ├── tuple [type=tuple{int}]
@@ -20,7 +20,7 @@ union
  │    └── tuple [type=tuple{int}]
  │         └── const: 2 [type=int]
  └── values
-      ├── columns: column1:int:null:2
+      ├── columns: column1:2(int)
       ├── tuple [type=tuple{int}]
       │    └── const: 1 [type=int]
       ├── tuple [type=tuple{int}]
@@ -32,11 +32,11 @@ build
 VALUES (1), (1), (1), (2), (2) UNION ALL VALUES (1), (3), (1)
 ----
 union-all
- ├── columns: column1:int:null:3
- ├── left columns: column1:int:null:1
- ├── right columns: column1:int:null:2
+ ├── columns: column1:3(int)
+ ├── left columns: column1:1(int)
+ ├── right columns: column1:2(int)
  ├── values
- │    ├── columns: column1:int:null:1
+ │    ├── columns: column1:1(int)
  │    ├── tuple [type=tuple{int}]
  │    │    └── const: 1 [type=int]
  │    ├── tuple [type=tuple{int}]
@@ -48,7 +48,7 @@ union-all
  │    └── tuple [type=tuple{int}]
  │         └── const: 2 [type=int]
  └── values
-      ├── columns: column1:int:null:2
+      ├── columns: column1:2(int)
       ├── tuple [type=tuple{int}]
       │    └── const: 1 [type=int]
       ├── tuple [type=tuple{int}]
@@ -60,11 +60,11 @@ build
 VALUES (1), (1), (1), (2), (2) INTERSECT VALUES (1), (3), (1)
 ----
 intersect
- ├── columns: column1:int:null:1
- ├── left columns: column1:int:null:1
- ├── right columns: column1:int:null:2
+ ├── columns: column1:1(int)
+ ├── left columns: column1:1(int)
+ ├── right columns: column1:2(int)
  ├── values
- │    ├── columns: column1:int:null:1
+ │    ├── columns: column1:1(int)
  │    ├── tuple [type=tuple{int}]
  │    │    └── const: 1 [type=int]
  │    ├── tuple [type=tuple{int}]
@@ -76,7 +76,7 @@ intersect
  │    └── tuple [type=tuple{int}]
  │         └── const: 2 [type=int]
  └── values
-      ├── columns: column1:int:null:2
+      ├── columns: column1:2(int)
       ├── tuple [type=tuple{int}]
       │    └── const: 1 [type=int]
       ├── tuple [type=tuple{int}]
@@ -88,11 +88,11 @@ build
 VALUES (1), (1), (1), (2), (2) INTERSECT ALL VALUES (1), (3), (1)
 ----
 intersect-all
- ├── columns: column1:int:null:1
- ├── left columns: column1:int:null:1
- ├── right columns: column1:int:null:2
+ ├── columns: column1:1(int)
+ ├── left columns: column1:1(int)
+ ├── right columns: column1:2(int)
  ├── values
- │    ├── columns: column1:int:null:1
+ │    ├── columns: column1:1(int)
  │    ├── tuple [type=tuple{int}]
  │    │    └── const: 1 [type=int]
  │    ├── tuple [type=tuple{int}]
@@ -104,7 +104,7 @@ intersect-all
  │    └── tuple [type=tuple{int}]
  │         └── const: 2 [type=int]
  └── values
-      ├── columns: column1:int:null:2
+      ├── columns: column1:2(int)
       ├── tuple [type=tuple{int}]
       │    └── const: 1 [type=int]
       ├── tuple [type=tuple{int}]
@@ -116,11 +116,11 @@ build
 VALUES (1), (1), (1), (2), (2) EXCEPT VALUES (1), (3), (1)
 ----
 except
- ├── columns: column1:int:null:1
- ├── left columns: column1:int:null:1
- ├── right columns: column1:int:null:2
+ ├── columns: column1:1(int)
+ ├── left columns: column1:1(int)
+ ├── right columns: column1:2(int)
  ├── values
- │    ├── columns: column1:int:null:1
+ │    ├── columns: column1:1(int)
  │    ├── tuple [type=tuple{int}]
  │    │    └── const: 1 [type=int]
  │    ├── tuple [type=tuple{int}]
@@ -132,7 +132,7 @@ except
  │    └── tuple [type=tuple{int}]
  │         └── const: 2 [type=int]
  └── values
-      ├── columns: column1:int:null:2
+      ├── columns: column1:2(int)
       ├── tuple [type=tuple{int}]
       │    └── const: 1 [type=int]
       ├── tuple [type=tuple{int}]
@@ -144,11 +144,11 @@ build
 VALUES (1), (1), (1), (2), (2) EXCEPT ALL VALUES (1), (3), (1)
 ----
 except-all
- ├── columns: column1:int:null:1
- ├── left columns: column1:int:null:1
- ├── right columns: column1:int:null:2
+ ├── columns: column1:1(int)
+ ├── left columns: column1:1(int)
+ ├── right columns: column1:2(int)
  ├── values
- │    ├── columns: column1:int:null:1
+ │    ├── columns: column1:1(int)
  │    ├── tuple [type=tuple{int}]
  │    │    └── const: 1 [type=int]
  │    ├── tuple [type=tuple{int}]
@@ -160,7 +160,7 @@ except-all
  │    └── tuple [type=tuple{int}]
  │         └── const: 2 [type=int]
  └── values
-      ├── columns: column1:int:null:2
+      ├── columns: column1:2(int)
       ├── tuple [type=tuple{int}]
       │    └── const: 1 [type=int]
       ├── tuple [type=tuple{int}]
@@ -172,11 +172,11 @@ build
 VALUES (1, 2), (1, 1), (1, 2), (2, 1), (2, 1) UNION VALUES (1, 3), (3, 4), (1, 1)
 ----
 union
- ├── columns: column1:int:null:5 column2:int:null:6
- ├── left columns: column1:int:null:1 column2:int:null:2
- ├── right columns: column1:int:null:3 column2:int:null:4
+ ├── columns: column1:5(int) column2:6(int)
+ ├── left columns: column1:1(int) column2:2(int)
+ ├── right columns: column1:3(int) column2:4(int)
  ├── values
- │    ├── columns: column1:int:null:1 column2:int:null:2
+ │    ├── columns: column1:1(int) column2:2(int)
  │    ├── tuple [type=tuple{int, int}]
  │    │    ├── const: 1 [type=int]
  │    │    └── const: 2 [type=int]
@@ -193,7 +193,7 @@ union
  │         ├── const: 2 [type=int]
  │         └── const: 1 [type=int]
  └── values
-      ├── columns: column1:int:null:3 column2:int:null:4
+      ├── columns: column1:3(int) column2:4(int)
       ├── tuple [type=tuple{int, int}]
       │    ├── const: 1 [type=int]
       │    └── const: 3 [type=int]
@@ -209,15 +209,15 @@ build
 VALUES (NULL) UNION ALL VALUES (1)
 ----
 union-all
- ├── columns: column1:int:null:3
- ├── left columns: column1:unknown:null:1
- ├── right columns: column1:int:null:2
+ ├── columns: column1:3(int)
+ ├── left columns: column1:1(unknown)
+ ├── right columns: column1:2(int)
  ├── values
- │    ├── columns: column1:unknown:null:1
+ │    ├── columns: column1:1(unknown)
  │    └── tuple [type=tuple{unknown}]
  │         └── null [type=unknown]
  └── values
-      ├── columns: column1:int:null:2
+      ├── columns: column1:2(int)
       └── tuple [type=tuple{int}]
            └── const: 1 [type=int]
 
@@ -225,15 +225,15 @@ build
 VALUES (NULL) UNION ALL VALUES (NULL)
 ----
 union-all
- ├── columns: column1:unknown:null:3
- ├── left columns: column1:unknown:null:1
- ├── right columns: column1:unknown:null:2
+ ├── columns: column1:3(unknown)
+ ├── left columns: column1:1(unknown)
+ ├── right columns: column1:2(unknown)
  ├── values
- │    ├── columns: column1:unknown:null:1
+ │    ├── columns: column1:1(unknown)
  │    └── tuple [type=tuple{unknown}]
  │         └── null [type=unknown]
  └── values
-      ├── columns: column1:unknown:null:2
+      ├── columns: column1:2(unknown)
       └── tuple [type=tuple{unknown}]
            └── null [type=unknown]
 
@@ -241,20 +241,20 @@ build
 SELECT x, pg_typeof(y) FROM (SELECT 1, NULL UNION ALL SELECT 2, 4) AS t(x, y)
 ----
 project
- ├── columns: x:int:null:5 column7:string:null:7
+ ├── columns: x:5(int) column7:7(string)
  ├── union-all
- │    ├── columns: column1:int:null:5 column2:int:null:6
- │    ├── left columns: column1:int:null:1 column2:unknown:null:2
- │    ├── right columns: column3:int:null:3 column4:int:null:4
+ │    ├── columns: column1:5(int) column2:6(int)
+ │    ├── left columns: column1:1(int) column2:2(unknown)
+ │    ├── right columns: column3:3(int) column4:4(int)
  │    ├── project
- │    │    ├── columns: column1:int:null:1 column2:unknown:null:2
+ │    │    ├── columns: column1:1(int) column2:2(unknown)
  │    │    ├── values
  │    │    │    └── tuple [type=tuple{}]
  │    │    └── projections
  │    │         ├── const: 1 [type=int]
  │    │         └── null [type=unknown]
  │    └── project
- │         ├── columns: column3:int:null:3 column4:int:null:4
+ │         ├── columns: column3:3(int) column4:4(int)
  │         ├── values
  │         │    └── tuple [type=tuple{}]
  │         └── projections
@@ -269,20 +269,20 @@ build
 SELECT x, pg_typeof(y) FROM (SELECT 1, 3 UNION ALL SELECT 2, NULL) AS t(x, y)
 ----
 project
- ├── columns: x:int:null:5 column7:string:null:7
+ ├── columns: x:5(int) column7:7(string)
  ├── union-all
- │    ├── columns: column1:int:null:5 column2:int:null:6
- │    ├── left columns: column1:int:null:1 column2:int:null:2
- │    ├── right columns: column3:int:null:3 column4:unknown:null:4
+ │    ├── columns: column1:5(int) column2:6(int)
+ │    ├── left columns: column1:1(int) column2:2(int)
+ │    ├── right columns: column3:3(int) column4:4(unknown)
  │    ├── project
- │    │    ├── columns: column1:int:null:1 column2:int:null:2
+ │    │    ├── columns: column1:1(int) column2:2(int)
  │    │    ├── values
  │    │    │    └── tuple [type=tuple{}]
  │    │    └── projections
  │    │         ├── const: 1 [type=int]
  │    │         └── const: 3 [type=int]
  │    └── project
- │         ├── columns: column3:int:null:3 column4:unknown:null:4
+ │         ├── columns: column3:3(int) column4:4(unknown)
  │         ├── values
  │         │    └── tuple [type=tuple{}]
  │         └── projections
@@ -310,26 +310,26 @@ build
 SELECT v FROM uniontest WHERE k = 1 UNION SELECT v FROM uniontest WHERE k = 2
 ----
 union
- ├── columns: v:int:null:7
- ├── left columns: uniontest.v:int:null:2
- ├── right columns: uniontest.v:int:null:5
+ ├── columns: v:7(int)
+ ├── left columns: uniontest.v:2(int)
+ ├── right columns: uniontest.v:5(int)
  ├── project
- │    ├── columns: uniontest.v:int:null:2
+ │    ├── columns: uniontest.v:2(int)
  │    ├── select
- │    │    ├── columns: uniontest.k:int:null:1 uniontest.v:int:null:2 uniontest.rowid:int:3
+ │    │    ├── columns: uniontest.k:1(int) uniontest.v:2(int) uniontest.rowid:3(int!null)
  │    │    ├── scan
- │    │    │    └── columns: uniontest.k:int:null:1 uniontest.v:int:null:2 uniontest.rowid:int:3
+ │    │    │    └── columns: uniontest.k:1(int) uniontest.v:2(int) uniontest.rowid:3(int!null)
  │    │    └── eq [type=bool, outer=(1)]
  │    │         ├── variable: uniontest.k [type=int, outer=(1)]
  │    │         └── const: 1 [type=int]
  │    └── projections [outer=(2)]
  │         └── variable: uniontest.v [type=int, outer=(2)]
  └── project
-      ├── columns: uniontest.v:int:null:5
+      ├── columns: uniontest.v:5(int)
       ├── select
-      │    ├── columns: uniontest.k:int:null:4 uniontest.v:int:null:5 uniontest.rowid:int:6
+      │    ├── columns: uniontest.k:4(int) uniontest.v:5(int) uniontest.rowid:6(int!null)
       │    ├── scan
-      │    │    └── columns: uniontest.k:int:null:4 uniontest.v:int:null:5 uniontest.rowid:int:6
+      │    │    └── columns: uniontest.k:4(int) uniontest.v:5(int) uniontest.rowid:6(int!null)
       │    └── eq [type=bool, outer=(4)]
       │         ├── variable: uniontest.k [type=int, outer=(4)]
       │         └── const: 2 [type=int]
@@ -340,26 +340,26 @@ build
 SELECT v FROM uniontest WHERE k = 1 UNION ALL SELECT v FROM uniontest WHERE k = 2
 ----
 union-all
- ├── columns: v:int:null:7
- ├── left columns: uniontest.v:int:null:2
- ├── right columns: uniontest.v:int:null:5
+ ├── columns: v:7(int)
+ ├── left columns: uniontest.v:2(int)
+ ├── right columns: uniontest.v:5(int)
  ├── project
- │    ├── columns: uniontest.v:int:null:2
+ │    ├── columns: uniontest.v:2(int)
  │    ├── select
- │    │    ├── columns: uniontest.k:int:null:1 uniontest.v:int:null:2 uniontest.rowid:int:3
+ │    │    ├── columns: uniontest.k:1(int) uniontest.v:2(int) uniontest.rowid:3(int!null)
  │    │    ├── scan
- │    │    │    └── columns: uniontest.k:int:null:1 uniontest.v:int:null:2 uniontest.rowid:int:3
+ │    │    │    └── columns: uniontest.k:1(int) uniontest.v:2(int) uniontest.rowid:3(int!null)
  │    │    └── eq [type=bool, outer=(1)]
  │    │         ├── variable: uniontest.k [type=int, outer=(1)]
  │    │         └── const: 1 [type=int]
  │    └── projections [outer=(2)]
  │         └── variable: uniontest.v [type=int, outer=(2)]
  └── project
-      ├── columns: uniontest.v:int:null:5
+      ├── columns: uniontest.v:5(int)
       ├── select
-      │    ├── columns: uniontest.k:int:null:4 uniontest.v:int:null:5 uniontest.rowid:int:6
+      │    ├── columns: uniontest.k:4(int) uniontest.v:5(int) uniontest.rowid:6(int!null)
       │    ├── scan
-      │    │    └── columns: uniontest.k:int:null:4 uniontest.v:int:null:5 uniontest.rowid:int:6
+      │    │    └── columns: uniontest.k:4(int) uniontest.v:5(int) uniontest.rowid:6(int!null)
       │    └── eq [type=bool, outer=(4)]
       │         ├── variable: uniontest.k [type=int, outer=(4)]
       │         └── const: 2 [type=int]
@@ -370,26 +370,26 @@ build
 SELECT v FROM uniontest WHERE k = 1 INTERSECT SELECT v FROM uniontest WHERE k = 2
 ----
 intersect
- ├── columns: v:int:null:2
- ├── left columns: uniontest.v:int:null:2
- ├── right columns: uniontest.v:int:null:5
+ ├── columns: v:2(int)
+ ├── left columns: uniontest.v:2(int)
+ ├── right columns: uniontest.v:5(int)
  ├── project
- │    ├── columns: uniontest.v:int:null:2
+ │    ├── columns: uniontest.v:2(int)
  │    ├── select
- │    │    ├── columns: uniontest.k:int:null:1 uniontest.v:int:null:2 uniontest.rowid:int:3
+ │    │    ├── columns: uniontest.k:1(int) uniontest.v:2(int) uniontest.rowid:3(int!null)
  │    │    ├── scan
- │    │    │    └── columns: uniontest.k:int:null:1 uniontest.v:int:null:2 uniontest.rowid:int:3
+ │    │    │    └── columns: uniontest.k:1(int) uniontest.v:2(int) uniontest.rowid:3(int!null)
  │    │    └── eq [type=bool, outer=(1)]
  │    │         ├── variable: uniontest.k [type=int, outer=(1)]
  │    │         └── const: 1 [type=int]
  │    └── projections [outer=(2)]
  │         └── variable: uniontest.v [type=int, outer=(2)]
  └── project
-      ├── columns: uniontest.v:int:null:5
+      ├── columns: uniontest.v:5(int)
       ├── select
-      │    ├── columns: uniontest.k:int:null:4 uniontest.v:int:null:5 uniontest.rowid:int:6
+      │    ├── columns: uniontest.k:4(int) uniontest.v:5(int) uniontest.rowid:6(int!null)
       │    ├── scan
-      │    │    └── columns: uniontest.k:int:null:4 uniontest.v:int:null:5 uniontest.rowid:int:6
+      │    │    └── columns: uniontest.k:4(int) uniontest.v:5(int) uniontest.rowid:6(int!null)
       │    └── eq [type=bool, outer=(4)]
       │         ├── variable: uniontest.k [type=int, outer=(4)]
       │         └── const: 2 [type=int]
@@ -400,26 +400,26 @@ build
 SELECT v FROM uniontest WHERE k = 1 INTERSECT ALL SELECT v FROM uniontest WHERE k = 2
 ----
 intersect-all
- ├── columns: v:int:null:2
- ├── left columns: uniontest.v:int:null:2
- ├── right columns: uniontest.v:int:null:5
+ ├── columns: v:2(int)
+ ├── left columns: uniontest.v:2(int)
+ ├── right columns: uniontest.v:5(int)
  ├── project
- │    ├── columns: uniontest.v:int:null:2
+ │    ├── columns: uniontest.v:2(int)
  │    ├── select
- │    │    ├── columns: uniontest.k:int:null:1 uniontest.v:int:null:2 uniontest.rowid:int:3
+ │    │    ├── columns: uniontest.k:1(int) uniontest.v:2(int) uniontest.rowid:3(int!null)
  │    │    ├── scan
- │    │    │    └── columns: uniontest.k:int:null:1 uniontest.v:int:null:2 uniontest.rowid:int:3
+ │    │    │    └── columns: uniontest.k:1(int) uniontest.v:2(int) uniontest.rowid:3(int!null)
  │    │    └── eq [type=bool, outer=(1)]
  │    │         ├── variable: uniontest.k [type=int, outer=(1)]
  │    │         └── const: 1 [type=int]
  │    └── projections [outer=(2)]
  │         └── variable: uniontest.v [type=int, outer=(2)]
  └── project
-      ├── columns: uniontest.v:int:null:5
+      ├── columns: uniontest.v:5(int)
       ├── select
-      │    ├── columns: uniontest.k:int:null:4 uniontest.v:int:null:5 uniontest.rowid:int:6
+      │    ├── columns: uniontest.k:4(int) uniontest.v:5(int) uniontest.rowid:6(int!null)
       │    ├── scan
-      │    │    └── columns: uniontest.k:int:null:4 uniontest.v:int:null:5 uniontest.rowid:int:6
+      │    │    └── columns: uniontest.k:4(int) uniontest.v:5(int) uniontest.rowid:6(int!null)
       │    └── eq [type=bool, outer=(4)]
       │         ├── variable: uniontest.k [type=int, outer=(4)]
       │         └── const: 2 [type=int]
@@ -430,26 +430,26 @@ build
 SELECT v FROM uniontest WHERE k = 1 EXCEPT SELECT v FROM uniontest WHERE k = 2
 ----
 except
- ├── columns: v:int:null:2
- ├── left columns: uniontest.v:int:null:2
- ├── right columns: uniontest.v:int:null:5
+ ├── columns: v:2(int)
+ ├── left columns: uniontest.v:2(int)
+ ├── right columns: uniontest.v:5(int)
  ├── project
- │    ├── columns: uniontest.v:int:null:2
+ │    ├── columns: uniontest.v:2(int)
  │    ├── select
- │    │    ├── columns: uniontest.k:int:null:1 uniontest.v:int:null:2 uniontest.rowid:int:3
+ │    │    ├── columns: uniontest.k:1(int) uniontest.v:2(int) uniontest.rowid:3(int!null)
  │    │    ├── scan
- │    │    │    └── columns: uniontest.k:int:null:1 uniontest.v:int:null:2 uniontest.rowid:int:3
+ │    │    │    └── columns: uniontest.k:1(int) uniontest.v:2(int) uniontest.rowid:3(int!null)
  │    │    └── eq [type=bool, outer=(1)]
  │    │         ├── variable: uniontest.k [type=int, outer=(1)]
  │    │         └── const: 1 [type=int]
  │    └── projections [outer=(2)]
  │         └── variable: uniontest.v [type=int, outer=(2)]
  └── project
-      ├── columns: uniontest.v:int:null:5
+      ├── columns: uniontest.v:5(int)
       ├── select
-      │    ├── columns: uniontest.k:int:null:4 uniontest.v:int:null:5 uniontest.rowid:int:6
+      │    ├── columns: uniontest.k:4(int) uniontest.v:5(int) uniontest.rowid:6(int!null)
       │    ├── scan
-      │    │    └── columns: uniontest.k:int:null:4 uniontest.v:int:null:5 uniontest.rowid:int:6
+      │    │    └── columns: uniontest.k:4(int) uniontest.v:5(int) uniontest.rowid:6(int!null)
       │    └── eq [type=bool, outer=(4)]
       │         ├── variable: uniontest.k [type=int, outer=(4)]
       │         └── const: 2 [type=int]
@@ -460,26 +460,26 @@ build
 SELECT v FROM uniontest WHERE k = 1 EXCEPT ALL SELECT v FROM uniontest WHERE k = 2
 ----
 except-all
- ├── columns: v:int:null:2
- ├── left columns: uniontest.v:int:null:2
- ├── right columns: uniontest.v:int:null:5
+ ├── columns: v:2(int)
+ ├── left columns: uniontest.v:2(int)
+ ├── right columns: uniontest.v:5(int)
  ├── project
- │    ├── columns: uniontest.v:int:null:2
+ │    ├── columns: uniontest.v:2(int)
  │    ├── select
- │    │    ├── columns: uniontest.k:int:null:1 uniontest.v:int:null:2 uniontest.rowid:int:3
+ │    │    ├── columns: uniontest.k:1(int) uniontest.v:2(int) uniontest.rowid:3(int!null)
  │    │    ├── scan
- │    │    │    └── columns: uniontest.k:int:null:1 uniontest.v:int:null:2 uniontest.rowid:int:3
+ │    │    │    └── columns: uniontest.k:1(int) uniontest.v:2(int) uniontest.rowid:3(int!null)
  │    │    └── eq [type=bool, outer=(1)]
  │    │         ├── variable: uniontest.k [type=int, outer=(1)]
  │    │         └── const: 1 [type=int]
  │    └── projections [outer=(2)]
  │         └── variable: uniontest.v [type=int, outer=(2)]
  └── project
-      ├── columns: uniontest.v:int:null:5
+      ├── columns: uniontest.v:5(int)
       ├── select
-      │    ├── columns: uniontest.k:int:null:4 uniontest.v:int:null:5 uniontest.rowid:int:6
+      │    ├── columns: uniontest.k:4(int) uniontest.v:5(int) uniontest.rowid:6(int!null)
       │    ├── scan
-      │    │    └── columns: uniontest.k:int:null:4 uniontest.v:int:null:5 uniontest.rowid:int:6
+      │    │    └── columns: uniontest.k:4(int) uniontest.v:5(int) uniontest.rowid:6(int!null)
       │    └── eq [type=bool, outer=(4)]
       │         ├── variable: uniontest.k [type=int, outer=(4)]
       │         └── const: 2 [type=int]
@@ -490,19 +490,19 @@ build
 SELECT v FROM uniontest UNION SELECT k FROM uniontest
 ----
 union
- ├── columns: v:int:null:7
- ├── left columns: uniontest.v:int:null:2
- ├── right columns: uniontest.k:int:null:4
+ ├── columns: v:7(int)
+ ├── left columns: uniontest.v:2(int)
+ ├── right columns: uniontest.k:4(int)
  ├── project
- │    ├── columns: uniontest.v:int:null:2
+ │    ├── columns: uniontest.v:2(int)
  │    ├── scan
- │    │    └── columns: uniontest.k:int:null:1 uniontest.v:int:null:2 uniontest.rowid:int:3
+ │    │    └── columns: uniontest.k:1(int) uniontest.v:2(int) uniontest.rowid:3(int!null)
  │    └── projections [outer=(2)]
  │         └── variable: uniontest.v [type=int, outer=(2)]
  └── project
-      ├── columns: uniontest.k:int:null:4
+      ├── columns: uniontest.k:4(int)
       ├── scan
-      │    └── columns: uniontest.k:int:null:4 uniontest.v:int:null:5 uniontest.rowid:int:6
+      │    └── columns: uniontest.k:4(int) uniontest.v:5(int) uniontest.rowid:6(int!null)
       └── projections [outer=(4)]
            └── variable: uniontest.k [type=int, outer=(4)]
 
@@ -510,19 +510,19 @@ build
 SELECT v FROM uniontest UNION ALL SELECT k FROM uniontest
 ----
 union-all
- ├── columns: v:int:null:7
- ├── left columns: uniontest.v:int:null:2
- ├── right columns: uniontest.k:int:null:4
+ ├── columns: v:7(int)
+ ├── left columns: uniontest.v:2(int)
+ ├── right columns: uniontest.k:4(int)
  ├── project
- │    ├── columns: uniontest.v:int:null:2
+ │    ├── columns: uniontest.v:2(int)
  │    ├── scan
- │    │    └── columns: uniontest.k:int:null:1 uniontest.v:int:null:2 uniontest.rowid:int:3
+ │    │    └── columns: uniontest.k:1(int) uniontest.v:2(int) uniontest.rowid:3(int!null)
  │    └── projections [outer=(2)]
  │         └── variable: uniontest.v [type=int, outer=(2)]
  └── project
-      ├── columns: uniontest.k:int:null:4
+      ├── columns: uniontest.k:4(int)
       ├── scan
-      │    └── columns: uniontest.k:int:null:4 uniontest.v:int:null:5 uniontest.rowid:int:6
+      │    └── columns: uniontest.k:4(int) uniontest.v:5(int) uniontest.rowid:6(int!null)
       └── projections [outer=(4)]
            └── variable: uniontest.k [type=int, outer=(4)]
 
@@ -530,21 +530,21 @@ build
 SELECT * FROM (SELECT * FROM (VALUES (1)) a LEFT JOIN (VALUES (1) UNION VALUES (2)) b on a.column1 = b.column1);
 ----
 left-join
- ├── columns: column1:int:null:1 column1:int:null:4
+ ├── columns: column1:1(int) column1:4(int)
  ├── values
- │    ├── columns: column1:int:null:1
+ │    ├── columns: column1:1(int)
  │    └── tuple [type=tuple{int}]
  │         └── const: 1 [type=int]
  ├── union
- │    ├── columns: column1:int:null:4
- │    ├── left columns: column1:int:null:2
- │    ├── right columns: column1:int:null:3
+ │    ├── columns: column1:4(int)
+ │    ├── left columns: column1:2(int)
+ │    ├── right columns: column1:3(int)
  │    ├── values
- │    │    ├── columns: column1:int:null:2
+ │    │    ├── columns: column1:2(int)
  │    │    └── tuple [type=tuple{int}]
  │    │         └── const: 1 [type=int]
  │    └── values
- │         ├── columns: column1:int:null:3
+ │         ├── columns: column1:3(int)
  │         └── tuple [type=tuple{int}]
  │              └── const: 2 [type=int]
  └── eq [type=bool, outer=(1,4)]
@@ -555,21 +555,21 @@ build
 SELECT * FROM (VALUES (1)) a LEFT JOIN (VALUES (1) UNION VALUES (2)) b on a.column1 = b.column1;
 ----
 left-join
- ├── columns: column1:int:null:1 column1:int:null:4
+ ├── columns: column1:1(int) column1:4(int)
  ├── values
- │    ├── columns: column1:int:null:1
+ │    ├── columns: column1:1(int)
  │    └── tuple [type=tuple{int}]
  │         └── const: 1 [type=int]
  ├── union
- │    ├── columns: column1:int:null:4
- │    ├── left columns: column1:int:null:2
- │    ├── right columns: column1:int:null:3
+ │    ├── columns: column1:4(int)
+ │    ├── left columns: column1:2(int)
+ │    ├── right columns: column1:3(int)
  │    ├── values
- │    │    ├── columns: column1:int:null:2
+ │    │    ├── columns: column1:2(int)
  │    │    └── tuple [type=tuple{int}]
  │    │         └── const: 1 [type=int]
  │    └── values
- │         ├── columns: column1:int:null:3
+ │         ├── columns: column1:3(int)
  │         └── tuple [type=tuple{int}]
  │              └── const: 2 [type=int]
  └── eq [type=bool, outer=(1,4)]
@@ -610,17 +610,17 @@ build
 SELECT 1 UNION SELECT 3
 ----
 union
- ├── columns: column1:int:null:3
- ├── left columns: column1:int:null:1
- ├── right columns: column2:int:null:2
+ ├── columns: column1:3(int)
+ ├── left columns: column1:1(int)
+ ├── right columns: column2:2(int)
  ├── project
- │    ├── columns: column1:int:null:1
+ │    ├── columns: column1:1(int)
  │    ├── values
  │    │    └── tuple [type=tuple{}]
  │    └── projections
  │         └── const: 1 [type=int]
  └── project
-      ├── columns: column2:int:null:2
+      ├── columns: column2:2(int)
       ├── values
       │    └── tuple [type=tuple{}]
       └── projections
@@ -660,21 +660,21 @@ build
 (SELECT x, x, y FROM xy) UNION (SELECT a, b, c FROM abc)
 ----
 union
- ├── columns: x:string:null:8 x:string:9 y:string:10
- ├── left columns: xy.x:string:null:1 xy.x:string:null:1 xy.y:string:null:2
- ├── right columns: abc.a:string:null:4 abc.b:string:null:5 abc.c:string:null:6
+ ├── columns: x:8(string) x:9(string!null) y:10(string!null)
+ ├── left columns: xy.x:1(string) xy.x:1(string) xy.y:2(string)
+ ├── right columns: abc.a:4(string) abc.b:5(string) abc.c:6(string)
  ├── project
- │    ├── columns: xy.x:string:1 xy.x:string:1 xy.y:string:2
+ │    ├── columns: xy.x:1(string!null) xy.x:1(string!null) xy.y:2(string!null)
  │    ├── scan
- │    │    └── columns: xy.x:string:1 xy.y:string:2 xy.rowid:int:3
+ │    │    └── columns: xy.x:1(string!null) xy.y:2(string!null) xy.rowid:3(int!null)
  │    └── projections [outer=(1,2)]
  │         ├── variable: xy.x [type=string, outer=(1)]
  │         ├── variable: xy.x [type=string, outer=(1)]
  │         └── variable: xy.y [type=string, outer=(2)]
  └── project
-      ├── columns: abc.a:string:null:4 abc.b:string:5 abc.c:string:6
+      ├── columns: abc.a:4(string) abc.b:5(string!null) abc.c:6(string!null)
       ├── scan
-      │    └── columns: abc.a:string:null:4 abc.b:string:5 abc.c:string:6 abc.rowid:int:7
+      │    └── columns: abc.a:4(string) abc.b:5(string!null) abc.c:6(string!null) abc.rowid:7(int!null)
       └── projections [outer=(4-6)]
            ├── variable: abc.a [type=string, outer=(4)]
            ├── variable: abc.b [type=string, outer=(5)]

--- a/pkg/sql/opt/optbuilder/testdata/values
+++ b/pkg/sql/opt/optbuilder/testdata/values
@@ -4,7 +4,7 @@ build
 VALUES (1)
 ----
 values
- ├── columns: column1:int:null:1
+ ├── columns: column1:1(int)
  └── tuple [type=tuple{int}]
       └── const: 1 [type=int]
 
@@ -12,7 +12,7 @@ build
 VALUES (1, 2, 3), (4, 5, 6)
 ----
 values
- ├── columns: column1:int:null:1 column2:int:null:2 column3:int:null:3
+ ├── columns: column1:1(int) column2:2(int) column3:3(int)
  ├── tuple [type=tuple{int, int, int}]
  │    ├── const: 1 [type=int]
  │    ├── const: 2 [type=int]
@@ -31,7 +31,7 @@ build
 VALUES (1), (1), (2), (3)
 ----
 values
- ├── columns: column1:int:null:1
+ ├── columns: column1:1(int)
  ├── tuple [type=tuple{int}]
  │    └── const: 1 [type=int]
  ├── tuple [type=tuple{int}]
@@ -50,7 +50,7 @@ build
 VALUES ('one', 1, 1.0), ('two', 2, 2.0)
 ----
 values
- ├── columns: column1:string:null:1 column2:int:null:2 column3:decimal:null:3
+ ├── columns: column1:1(string) column2:2(int) column3:3(decimal)
  ├── tuple [type=tuple{string, int, decimal}]
  │    ├── const: 'one' [type=string]
  │    ├── const: 1 [type=int]
@@ -64,7 +64,7 @@ build
 VALUES (true), (true), (false)
 ----
 values
- ├── columns: column1:bool:null:1
+ ├── columns: column1:1(bool)
  ├── tuple [type=tuple{bool}]
  │    └── true [type=bool]
  ├── tuple [type=tuple{bool}]
@@ -76,7 +76,7 @@ build
 VALUES (NULL)
 ----
 values
- ├── columns: column1:unknown:null:1
+ ├── columns: column1:1(unknown)
  └── tuple [type=tuple{unknown}]
       └── null [type=unknown]
 
@@ -84,7 +84,7 @@ build
 VALUES (NULL, 1)
 ----
 values
- ├── columns: column1:unknown:null:1 column2:int:null:2
+ ├── columns: column1:1(unknown) column2:2(int)
  └── tuple [type=tuple{unknown, int}]
       ├── null [type=unknown]
       └── const: 1 [type=int]
@@ -93,7 +93,7 @@ build
 VALUES (NULL, 1), (2, NULL)
 ----
 values
- ├── columns: column1:int:null:1 column2:int:null:2
+ ├── columns: column1:1(int) column2:2(int)
  ├── tuple [type=tuple{unknown, int}]
  │    ├── null [type=unknown]
  │    └── const: 1 [type=int]
@@ -105,7 +105,7 @@ build
 VALUES (NULL, 1), (2, NULL)
 ----
 values
- ├── columns: column1:int:null:1 column2:int:null:2
+ ├── columns: column1:1(int) column2:2(int)
  ├── tuple [type=tuple{unknown, int}]
  │    ├── null [type=unknown]
  │    └── const: 1 [type=int]
@@ -122,9 +122,9 @@ build
 SELECT COALESCE(a, b) FROM (VALUES (1, 2), (3, NULL), (NULL, 4), (NULL, NULL)) AS v(a, b)
 ----
 project
- ├── columns: column3:int:null:3
+ ├── columns: column3:3(int)
  ├── values
- │    ├── columns: column1:int:null:1 column2:int:null:2
+ │    ├── columns: column1:1(int) column2:2(int)
  │    ├── tuple [type=tuple{int, int}]
  │    │    ├── const: 1 [type=int]
  │    │    └── const: 2 [type=int]

--- a/pkg/sql/opt/xform/logical_props.go
+++ b/pkg/sql/opt/xform/logical_props.go
@@ -124,10 +124,11 @@ func (p *LogicalProps) formatCol(
 	buf.WriteByte(' ')
 	buf.WriteString(label)
 	buf.WriteByte(':')
-	buf.WriteString(typ.String())
-	buf.WriteByte(':')
-	if !p.Relational.NotNullCols.Contains(int(index)) {
-		buf.WriteString("null:")
-	}
 	fmt.Fprintf(buf, "%d", index)
+	buf.WriteByte('(')
+	buf.WriteString(typ.String())
+	if p.Relational.NotNullCols.Contains(int(index)) {
+		buf.WriteString("!null")
+	}
+	buf.WriteByte(')')
 }

--- a/pkg/sql/opt/xform/logical_props_test.go
+++ b/pkg/sql/opt/xform/logical_props_test.go
@@ -51,14 +51,14 @@ func TestLogicalJoinProps(t *testing.T) {
 		testLogicalProps(t, f, joinGroup, expected)
 	}
 
-	joinFunc(opt.InnerJoinApplyOp, "columns: a.x:int:1 a.y:int:null:2 b.x:int:3 b.z:int:4\n")
-	joinFunc(opt.LeftJoinApplyOp, "columns: a.x:int:1 a.y:int:null:2 b.x:int:null:3 b.z:int:null:4\n")
-	joinFunc(opt.RightJoinApplyOp, "columns: a.x:int:null:1 a.y:int:null:2 b.x:int:3 b.z:int:4\n")
-	joinFunc(opt.FullJoinApplyOp, "columns: a.x:int:null:1 a.y:int:null:2 b.x:int:null:3 b.z:int:null:4\n")
-	joinFunc(opt.SemiJoinOp, "columns: a.x:int:1 a.y:int:null:2\n")
-	joinFunc(opt.SemiJoinApplyOp, "columns: a.x:int:1 a.y:int:null:2\n")
-	joinFunc(opt.AntiJoinOp, "columns: a.x:int:1 a.y:int:null:2\n")
-	joinFunc(opt.AntiJoinApplyOp, "columns: a.x:int:1 a.y:int:null:2\n")
+	joinFunc(opt.InnerJoinApplyOp, "columns: a.x:1(int!null) a.y:2(int) b.x:3(int!null) b.z:4(int!null)\n")
+	joinFunc(opt.LeftJoinApplyOp, "columns: a.x:1(int!null) a.y:2(int) b.x:3(int) b.z:4(int)\n")
+	joinFunc(opt.RightJoinApplyOp, "columns: a.x:1(int) a.y:2(int) b.x:3(int!null) b.z:4(int!null)\n")
+	joinFunc(opt.FullJoinApplyOp, "columns: a.x:1(int) a.y:2(int) b.x:3(int) b.z:4(int)\n")
+	joinFunc(opt.SemiJoinOp, "columns: a.x:1(int!null) a.y:2(int)\n")
+	joinFunc(opt.SemiJoinApplyOp, "columns: a.x:1(int!null) a.y:2(int)\n")
+	joinFunc(opt.AntiJoinOp, "columns: a.x:1(int!null) a.y:2(int)\n")
+	joinFunc(opt.AntiJoinApplyOp, "columns: a.x:1(int!null) a.y:2(int)\n")
 }
 
 func testLogicalProps(t *testing.T, f *factory, group opt.GroupID, expected string) {

--- a/pkg/sql/opt/xform/rules/comp.opt
+++ b/pkg/sql/opt/xform/rules/comp.opt
@@ -37,6 +37,9 @@
 # tree. Also, the NormalizePlusMult pattern ensures that constant expression
 # trees are on the right side of the expression, so no "flipped" pattern is
 # necessary. Other patterns will fold new constant expressions further.
+#
+# NOTE: Ne is not part of the operator choices because it wasn't handled in
+#       normalize.go either. We can add once we've proved it's OK to do so.
 [NormalizeCmpPlusConst]
 (Eq | Ge | Gt | Le | Lt
     (Plus

--- a/pkg/sql/opt/xform/testdata/logprops/groupby
+++ b/pkg/sql/opt/xform/testdata/logprops/groupby
@@ -12,12 +12,12 @@ build
 SELECT a.y, SUM(a.z), a.x, False FROM a GROUP BY a.x, a.y
 ----
 project
- ├── columns: y:int:null:2 column4:float:null:4 x:int:1 column5:bool:null:5
+ ├── columns: y:2(int) column4:4(float) x:1(int!null) column5:5(bool)
  ├── group-by
- │    ├── columns: a.x:int:1 a.y:int:null:2 column4:float:null:4
- │    ├── grouping columns: a.x:int:1 a.y:int:null:2
+ │    ├── columns: a.x:1(int!null) a.y:2(int) column4:4(float)
+ │    ├── grouping columns: a.x:1(int!null) a.y:2(int)
  │    ├── scan
- │    │    └── columns: a.x:int:1 a.y:int:null:2 a.z:float:3
+ │    │    └── columns: a.x:1(int!null) a.y:2(int) a.z:3(float!null)
  │    └── aggregations [outer=(3)]
  │         └── function: sum [type=float, outer=(3)]
  │              └── variable: a.z [type=float, outer=(3)]

--- a/pkg/sql/opt/xform/testdata/logprops/join
+++ b/pkg/sql/opt/xform/testdata/logprops/join
@@ -21,11 +21,11 @@ build
 SELECT *, rowid FROM a INNER JOIN b ON a.x=b.x
 ----
 inner-join
- ├── columns: x:int:1 y:int:null:2 x:int:null:3 z:int:4 rowid:int:5
+ ├── columns: x:1(int!null) y:2(int) x:3(int) z:4(int!null) rowid:5(int!null)
  ├── scan
- │    └── columns: a.x:int:1 a.y:int:null:2
+ │    └── columns: a.x:1(int!null) a.y:2(int)
  ├── scan
- │    └── columns: b.x:int:null:3 b.z:int:4 b.rowid:int:5
+ │    └── columns: b.x:3(int) b.z:4(int!null) b.rowid:5(int!null)
  └── eq [type=bool, outer=(1,3)]
       ├── variable: a.x [type=int, outer=(1)]
       └── variable: b.x [type=int, outer=(3)]
@@ -34,11 +34,11 @@ build
 SELECT *, rowid FROM a LEFT JOIN b ON a.x=b.x
 ----
 left-join
- ├── columns: x:int:1 y:int:null:2 x:int:null:3 z:int:null:4 rowid:int:null:5
+ ├── columns: x:1(int!null) y:2(int) x:3(int) z:4(int) rowid:5(int)
  ├── scan
- │    └── columns: a.x:int:1 a.y:int:null:2
+ │    └── columns: a.x:1(int!null) a.y:2(int)
  ├── scan
- │    └── columns: b.x:int:null:3 b.z:int:4 b.rowid:int:5
+ │    └── columns: b.x:3(int) b.z:4(int!null) b.rowid:5(int!null)
  └── eq [type=bool, outer=(1,3)]
       ├── variable: a.x [type=int, outer=(1)]
       └── variable: b.x [type=int, outer=(3)]
@@ -47,11 +47,11 @@ build
 SELECT *, rowid FROM a RIGHT JOIN b ON a.x=b.x
 ----
 right-join
- ├── columns: x:int:null:1 y:int:null:2 x:int:null:3 z:int:4 rowid:int:5
+ ├── columns: x:1(int) y:2(int) x:3(int) z:4(int!null) rowid:5(int!null)
  ├── scan
- │    └── columns: a.x:int:1 a.y:int:null:2
+ │    └── columns: a.x:1(int!null) a.y:2(int)
  ├── scan
- │    └── columns: b.x:int:null:3 b.z:int:4 b.rowid:int:5
+ │    └── columns: b.x:3(int) b.z:4(int!null) b.rowid:5(int!null)
  └── eq [type=bool, outer=(1,3)]
       ├── variable: a.x [type=int, outer=(1)]
       └── variable: b.x [type=int, outer=(3)]
@@ -60,11 +60,11 @@ build
 SELECT *, rowid FROM a FULL JOIN b ON a.x=b.x
 ----
 full-join
- ├── columns: x:int:null:1 y:int:null:2 x:int:null:3 z:int:null:4 rowid:int:null:5
+ ├── columns: x:1(int) y:2(int) x:3(int) z:4(int) rowid:5(int)
  ├── scan
- │    └── columns: a.x:int:1 a.y:int:null:2
+ │    └── columns: a.x:1(int!null) a.y:2(int)
  ├── scan
- │    └── columns: b.x:int:null:3 b.z:int:4 b.rowid:int:5
+ │    └── columns: b.x:3(int) b.z:4(int!null) b.rowid:5(int!null)
  └── eq [type=bool, outer=(1,3)]
       ├── variable: a.x [type=int, outer=(1)]
       └── variable: b.x [type=int, outer=(3)]

--- a/pkg/sql/opt/xform/testdata/logprops/project
+++ b/pkg/sql/opt/xform/testdata/logprops/project
@@ -11,9 +11,9 @@ build
 SELECT a.y, a.x+1, 1, a.x FROM a
 ----
 project
- ├── columns: y:int:null:2 column3:int:null:3 column4:int:null:4 x:int:1
+ ├── columns: y:2(int) column3:3(int) column4:4(int) x:1(int!null)
  ├── scan
- │    └── columns: a.x:int:1 a.y:int:null:2
+ │    └── columns: a.x:1(int!null) a.y:2(int)
  └── projections [outer=(1,2)]
       ├── variable: a.y [type=int, outer=(2)]
       ├── plus [type=int, outer=(1)]

--- a/pkg/sql/opt/xform/testdata/logprops/scalar
+++ b/pkg/sql/opt/xform/testdata/logprops/scalar
@@ -21,9 +21,9 @@ build
 SELECT * FROM a WHERE x < 5
 ----
 select
- ├── columns: x:int:1 y:int:null:2
+ ├── columns: x:1(int!null) y:2(int)
  ├── scan
- │    └── columns: a.x:int:1 a.y:int:null:2
+ │    └── columns: a.x:1(int!null) a.y:2(int)
  └── lt [type=bool, outer=(1)]
       ├── variable: a.x [type=int, outer=(1)]
       └── const: 5 [type=int]
@@ -32,13 +32,13 @@ build
 SELECT a.x + 1 = length('foo') + a.y, b.rowid * a.x FROM a, b
 ----
 project
- ├── columns: column6:bool:null:6 column7:int:null:7
+ ├── columns: column6:6(bool) column7:7(int)
  ├── inner-join
- │    ├── columns: a.x:int:1 a.y:int:null:2 b.x:int:null:3 b.z:int:4 b.rowid:int:5
+ │    ├── columns: a.x:1(int!null) a.y:2(int) b.x:3(int) b.z:4(int!null) b.rowid:5(int!null)
  │    ├── scan
- │    │    └── columns: a.x:int:1 a.y:int:null:2
+ │    │    └── columns: a.x:1(int!null) a.y:2(int)
  │    ├── scan
- │    │    └── columns: b.x:int:null:3 b.z:int:4 b.rowid:int:5
+ │    │    └── columns: b.x:3(int) b.z:4(int!null) b.rowid:5(int!null)
  │    └── true [type=bool]
  └── projections [outer=(1,2,5)]
       ├── eq [type=bool, outer=(1,2)]

--- a/pkg/sql/opt/xform/testdata/logprops/scan
+++ b/pkg/sql/opt/xform/testdata/logprops/scan
@@ -21,15 +21,15 @@ build
 SELECT * FROM a
 ----
 scan
- └── columns: x:int:1 y:int:null:2
+ └── columns: x:1(int!null) y:2(int)
 
 build
 SELECT * FROM b
 ----
 project
- ├── columns: x:int:null:1 z:int:2
+ ├── columns: x:1(int) z:2(int!null)
  ├── scan
- │    └── columns: b.x:int:null:1 b.z:int:2 b.rowid:int:3
+ │    └── columns: b.x:1(int) b.z:2(int!null) b.rowid:3(int!null)
  └── projections [outer=(1,2)]
       ├── variable: b.x [type=int, outer=(1)]
       └── variable: b.z [type=int, outer=(2)]

--- a/pkg/sql/opt/xform/testdata/logprops/select
+++ b/pkg/sql/opt/xform/testdata/logprops/select
@@ -21,9 +21,9 @@ build
 SELECT * FROM a WHERE x=1
 ----
 select
- ├── columns: x:int:1 y:int:null:2
+ ├── columns: x:1(int!null) y:2(int)
  ├── scan
- │    └── columns: a.x:int:1 a.y:int:null:2
+ │    └── columns: a.x:1(int!null) a.y:2(int)
  └── eq [type=bool, outer=(1)]
       ├── variable: a.x [type=int, outer=(1)]
       └── const: 1 [type=int]
@@ -32,15 +32,15 @@ build
 SELECT * FROM a,b WHERE a.x=b.x
 ----
 project
- ├── columns: x:int:1 y:int:null:2 x:int:null:3 z:int:4
+ ├── columns: x:1(int!null) y:2(int) x:3(int) z:4(int!null)
  ├── select
- │    ├── columns: a.x:int:1 a.y:int:null:2 b.x:int:null:3 b.z:int:4 b.rowid:int:5
+ │    ├── columns: a.x:1(int!null) a.y:2(int) b.x:3(int) b.z:4(int!null) b.rowid:5(int!null)
  │    ├── inner-join
- │    │    ├── columns: a.x:int:1 a.y:int:null:2 b.x:int:null:3 b.z:int:4 b.rowid:int:5
+ │    │    ├── columns: a.x:1(int!null) a.y:2(int) b.x:3(int) b.z:4(int!null) b.rowid:5(int!null)
  │    │    ├── scan
- │    │    │    └── columns: a.x:int:1 a.y:int:null:2
+ │    │    │    └── columns: a.x:1(int!null) a.y:2(int)
  │    │    ├── scan
- │    │    │    └── columns: b.x:int:null:3 b.z:int:4 b.rowid:int:5
+ │    │    │    └── columns: b.x:3(int) b.z:4(int!null) b.rowid:5(int!null)
  │    │    └── true [type=bool]
  │    └── eq [type=bool, outer=(1,3)]
  │         ├── variable: a.x [type=int, outer=(1)]

--- a/pkg/sql/opt/xform/testdata/logprops/set
+++ b/pkg/sql/opt/xform/testdata/logprops/set
@@ -21,15 +21,15 @@ build
 SELECT * FROM a UNION SELECT * FROM b
 ----
 union
- ├── columns: x:int:null:6 y:int:null:7
- ├── left columns: a.x:int:null:1 a.y:int:null:2
- ├── right columns: b.x:int:null:3 b.z:int:null:4
+ ├── columns: x:6(int) y:7(int)
+ ├── left columns: a.x:1(int) a.y:2(int)
+ ├── right columns: b.x:3(int) b.z:4(int)
  ├── scan
- │    └── columns: a.x:int:1 a.y:int:null:2
+ │    └── columns: a.x:1(int!null) a.y:2(int)
  └── project
-      ├── columns: b.x:int:null:3 b.z:int:4
+      ├── columns: b.x:3(int) b.z:4(int!null)
       ├── scan
-      │    └── columns: b.x:int:null:3 b.z:int:4 b.rowid:int:5
+      │    └── columns: b.x:3(int) b.z:4(int!null) b.rowid:5(int!null)
       └── projections [outer=(3,4)]
            ├── variable: b.x [type=int, outer=(3)]
            └── variable: b.z [type=int, outer=(4)]
@@ -38,21 +38,21 @@ build
 SELECT x, y, x FROM a INTERSECT SELECT z, x, rowid FROM b
 ----
 intersect
- ├── columns: x:int:1 y:int:null:2 x:int:1
- ├── left columns: a.x:int:1 a.y:int:null:2 a.x:int:1
- ├── right columns: b.z:int:null:4 b.x:int:null:3 b.rowid:int:null:5
+ ├── columns: x:1(int!null) y:2(int) x:1(int!null)
+ ├── left columns: a.x:1(int!null) a.y:2(int) a.x:1(int!null)
+ ├── right columns: b.z:4(int) b.x:3(int) b.rowid:5(int)
  ├── project
- │    ├── columns: a.x:int:1 a.y:int:null:2 a.x:int:1
+ │    ├── columns: a.x:1(int!null) a.y:2(int) a.x:1(int!null)
  │    ├── scan
- │    │    └── columns: a.x:int:1 a.y:int:null:2
+ │    │    └── columns: a.x:1(int!null) a.y:2(int)
  │    └── projections [outer=(1,2)]
  │         ├── variable: a.x [type=int, outer=(1)]
  │         ├── variable: a.y [type=int, outer=(2)]
  │         └── variable: a.x [type=int, outer=(1)]
  └── project
-      ├── columns: b.z:int:4 b.x:int:null:3 b.rowid:int:5
+      ├── columns: b.z:4(int!null) b.x:3(int) b.rowid:5(int!null)
       ├── scan
-      │    └── columns: b.x:int:null:3 b.z:int:4 b.rowid:int:5
+      │    └── columns: b.x:3(int) b.z:4(int!null) b.rowid:5(int!null)
       └── projections [outer=(3-5)]
            ├── variable: b.z [type=int, outer=(4)]
            ├── variable: b.x [type=int, outer=(3)]
@@ -62,21 +62,21 @@ build
 SELECT x, x, y FROM a EXCEPT SELECT x, z, z FROM b
 ----
 except
- ├── columns: x:int:1 x:int:1 y:int:null:2
- ├── left columns: a.x:int:1 a.x:int:1 a.y:int:null:2
- ├── right columns: b.x:int:null:3 b.z:int:null:4 b.z:int:null:4
+ ├── columns: x:1(int!null) x:1(int!null) y:2(int)
+ ├── left columns: a.x:1(int!null) a.x:1(int!null) a.y:2(int)
+ ├── right columns: b.x:3(int) b.z:4(int) b.z:4(int)
  ├── project
- │    ├── columns: a.x:int:1 a.x:int:1 a.y:int:null:2
+ │    ├── columns: a.x:1(int!null) a.x:1(int!null) a.y:2(int)
  │    ├── scan
- │    │    └── columns: a.x:int:1 a.y:int:null:2
+ │    │    └── columns: a.x:1(int!null) a.y:2(int)
  │    └── projections [outer=(1,2)]
  │         ├── variable: a.x [type=int, outer=(1)]
  │         ├── variable: a.x [type=int, outer=(1)]
  │         └── variable: a.y [type=int, outer=(2)]
  └── project
-      ├── columns: b.x:int:null:3 b.z:int:4 b.z:int:4
+      ├── columns: b.x:3(int) b.z:4(int!null) b.z:4(int!null)
       ├── scan
-      │    └── columns: b.x:int:null:3 b.z:int:4 b.rowid:int:5
+      │    └── columns: b.x:3(int) b.z:4(int!null) b.rowid:5(int!null)
       └── projections [outer=(3,4)]
            ├── variable: b.x [type=int, outer=(3)]
            ├── variable: b.z [type=int, outer=(4)]

--- a/pkg/sql/opt/xform/testdata/logprops/values
+++ b/pkg/sql/opt/xform/testdata/logprops/values
@@ -2,7 +2,7 @@ build
 SELECT * FROM (VALUES (1, 2), (3, 4), (NULL, 5))
 ----
 values
- ├── columns: column1:int:null:1 column2:int:null:2
+ ├── columns: column1:1(int) column2:2(int)
  ├── tuple [type=tuple{int, int}]
  │    ├── const: 1 [type=int]
  │    └── const: 2 [type=int]

--- a/pkg/sql/opt/xform/testdata/physprops/ordering
+++ b/pkg/sql/opt/xform/testdata/physprops/ordering
@@ -26,7 +26,7 @@ opt
 SELECT * FROM a ORDER BY x, y DESC
 ----
 scan
- ├── columns: x:int:1 y:float:2 z:decimal:null:3 s:string:4
+ ├── columns: x:1(int!null) y:2(float!null) z:3(decimal) s:4(string!null)
  └── ordering: +1,-2
 
 # Order by prefix.
@@ -34,7 +34,7 @@ opt
 SELECT * FROM a ORDER BY x
 ----
 scan
- ├── columns: x:int:1 y:float:2 z:decimal:null:3 s:string:4
+ ├── columns: x:1(int!null) y:2(float!null) z:3(decimal) s:4(string!null)
  └── ordering: +1
 
 # Order by suffix (scan shouldn't be able to provide).
@@ -42,20 +42,20 @@ opt
 SELECT * FROM a ORDER BY y DESC
 ----
 sort
- ├── columns: x:int:1 y:float:2 z:decimal:null:3 s:string:4
+ ├── columns: x:1(int!null) y:2(float!null) z:3(decimal) s:4(string!null)
  ├── ordering: -2
  └── scan
-      └── columns: a.x:int:1 a.y:float:2 a.z:decimal:null:3 a.s:string:4
+      └── columns: a.x:1(int!null) a.y:2(float!null) a.z:3(decimal) a.s:4(string!null)
 
 # Order by additional column (scan shouldn't be able to provide for now).
 opt
 SELECT * FROM a ORDER BY x, y DESC, z
 ----
 sort
- ├── columns: x:int:1 y:float:2 z:decimal:null:3 s:string:4
+ ├── columns: x:1(int!null) y:2(float!null) z:3(decimal) s:4(string!null)
  ├── ordering: +1,-2,+3
  └── scan
-      └── columns: a.x:int:1 a.y:float:2 a.z:decimal:null:3 a.s:string:4
+      └── columns: a.x:1(int!null) a.y:2(float!null) a.z:3(decimal) a.s:4(string!null)
 
 # --------------------------------------------------
 # Select operator (pass through).
@@ -66,10 +66,10 @@ opt
 SELECT * FROM a WHERE x=1 ORDER BY x, y DESC
 ----
 select
- ├── columns: x:int:1 y:float:2 z:decimal:null:3 s:string:4
+ ├── columns: x:1(int!null) y:2(float!null) z:3(decimal) s:4(string!null)
  ├── ordering: +1,-2
  ├── scan
- │    ├── columns: a.x:int:1 a.y:float:2 a.z:decimal:null:3 a.s:string:4
+ │    ├── columns: a.x:1(int!null) a.y:2(float!null) a.z:3(decimal) a.s:4(string!null)
  │    └── ordering: +1,-2
  └── eq [type=bool, outer=(1)]
       ├── variable: a.x [type=int, outer=(1)]
@@ -80,13 +80,13 @@ opt
 SELECT * FROM a WHERE x=1 ORDER BY z DESC
 ----
 select
- ├── columns: x:int:1 y:float:2 z:decimal:null:3 s:string:4
+ ├── columns: x:1(int!null) y:2(float!null) z:3(decimal) s:4(string!null)
  ├── ordering: -3
  ├── sort
- │    ├── columns: a.x:int:1 a.y:float:2 a.z:decimal:null:3 a.s:string:4
+ │    ├── columns: a.x:1(int!null) a.y:2(float!null) a.z:3(decimal) a.s:4(string!null)
  │    ├── ordering: -3
  │    └── scan
- │         └── columns: a.x:int:1 a.y:float:2 a.z:decimal:null:3 a.s:string:4
+ │         └── columns: a.x:1(int!null) a.y:2(float!null) a.z:3(decimal) a.s:4(string!null)
  └── eq [type=bool, outer=(1)]
       ├── variable: a.x [type=int, outer=(1)]
       └── const: 1 [type=int]
@@ -100,10 +100,10 @@ opt
 SELECT x, y FROM a ORDER BY x, y DESC
 ----
 project
- ├── columns: x:int:1 y:float:2
+ ├── columns: x:1(int!null) y:2(float!null)
  ├── ordering: +1,-2
  ├── scan
- │    ├── columns: a.x:int:1 a.y:float:2 a.z:decimal:null:3 a.s:string:4
+ │    ├── columns: a.x:1(int!null) a.y:2(float!null) a.z:3(decimal) a.s:4(string!null)
  │    └── ordering: +1,-2
  └── projections [outer=(1,2)]
       ├── variable: a.x [type=int, outer=(1)]
@@ -114,13 +114,13 @@ opt
 SELECT y, x, z+1 FROM a ORDER BY x, y
 ----
 project
- ├── columns: y:float:2 x:int:1 column5:decimal:null:5
+ ├── columns: y:2(float!null) x:1(int!null) column5:5(decimal)
  ├── ordering: +1,+2
  ├── sort
- │    ├── columns: a.x:int:1 a.y:float:2 a.z:decimal:null:3 a.s:string:4
+ │    ├── columns: a.x:1(int!null) a.y:2(float!null) a.z:3(decimal) a.s:4(string!null)
  │    ├── ordering: +1,+2
  │    └── scan
- │         └── columns: a.x:int:1 a.y:float:2 a.z:decimal:null:3 a.s:string:4
+ │         └── columns: a.x:1(int!null) a.y:2(float!null) a.z:3(decimal) a.s:4(string!null)
  └── projections [outer=(1-3)]
       ├── variable: a.y [type=float, outer=(2)]
       ├── variable: a.x [type=int, outer=(1)]
@@ -133,12 +133,12 @@ opt
 SELECT x, 1 one, y FROM a ORDER BY x, one
 ----
 sort
- ├── columns: x:int:1 one:int:null:5 y:float:2
+ ├── columns: x:1(int!null) one:5(int) y:2(float!null)
  ├── ordering: +1,+5
  └── project
-      ├── columns: a.x:int:1 one:int:null:5 a.y:float:2
+      ├── columns: a.x:1(int!null) one:5(int) a.y:2(float!null)
       ├── scan
-      │    └── columns: a.x:int:1 a.y:float:2 a.z:decimal:null:3 a.s:string:4
+      │    └── columns: a.x:1(int!null) a.y:2(float!null) a.z:3(decimal) a.s:4(string!null)
       └── projections [outer=(1,2)]
            ├── variable: a.x [type=int, outer=(1)]
            ├── const: 1 [type=int]
@@ -153,13 +153,13 @@ opt
 SELECT y, x FROM a WHERE x=1 ORDER BY x, y DESC
 ----
 project
- ├── columns: y:float:2 x:int:1
+ ├── columns: y:2(float!null) x:1(int!null)
  ├── ordering: +1,-2
  ├── select
- │    ├── columns: a.x:int:1 a.y:float:2 a.z:decimal:null:3 a.s:string:4
+ │    ├── columns: a.x:1(int!null) a.y:2(float!null) a.z:3(decimal) a.s:4(string!null)
  │    ├── ordering: +1,-2
  │    ├── scan
- │    │    ├── columns: a.x:int:1 a.y:float:2 a.z:decimal:null:3 a.s:string:4
+ │    │    ├── columns: a.x:1(int!null) a.y:2(float!null) a.z:3(decimal) a.s:4(string!null)
  │    │    └── ordering: +1,-2
  │    └── eq [type=bool, outer=(1)]
  │         ├── variable: a.x [type=int, outer=(1)]
@@ -199,16 +199,16 @@ opt
 SELECT y, z FROM a WHERE x=1 ORDER BY y
 ----
 project
- ├── columns: y:float:2 z:decimal:null:3
+ ├── columns: y:2(float!null) z:3(decimal)
  ├── ordering: +2
  ├── select
- │    ├── columns: a.x:int:1 a.y:float:2 a.z:decimal:null:3 a.s:string:4
+ │    ├── columns: a.x:1(int!null) a.y:2(float!null) a.z:3(decimal) a.s:4(string!null)
  │    ├── ordering: +2
  │    ├── sort
- │    │    ├── columns: a.x:int:1 a.y:float:2 a.z:decimal:null:3 a.s:string:4
+ │    │    ├── columns: a.x:1(int!null) a.y:2(float!null) a.z:3(decimal) a.s:4(string!null)
  │    │    ├── ordering: +2
  │    │    └── scan
- │    │         └── columns: a.x:int:1 a.y:float:2 a.z:decimal:null:3 a.s:string:4
+ │    │         └── columns: a.x:1(int!null) a.y:2(float!null) a.z:3(decimal) a.s:4(string!null)
  │    └── eq [type=bool, outer=(1)]
  │         ├── variable: a.x [type=int, outer=(1)]
  │         └── const: 1 [type=int]

--- a/pkg/sql/opt/xform/testdata/physprops/presentation
+++ b/pkg/sql/opt/xform/testdata/physprops/presentation
@@ -22,16 +22,16 @@ opt
 SELECT a.y, a.x, a.y y2 FROM a
 ----
 scan
- └── columns: y:int:null:2 x:int:1 y2:int:null:2
+ └── columns: y:2(int) x:1(int!null) y2:2(int)
 
 # Select operator.
 opt
 SELECT a.y, a.x, a.y y2 FROM a WHERE x=1
 ----
 select
- ├── columns: y:int:null:2 x:int:1 y2:int:null:2
+ ├── columns: y:2(int) x:1(int!null) y2:2(int)
  ├── scan
- │    └── columns: a.x:int:1 a.y:int:null:2
+ │    └── columns: a.x:1(int!null) a.y:2(int)
  └── eq [type=bool, outer=(1)]
       ├── variable: a.x [type=int, outer=(1)]
       └── const: 1 [type=int]
@@ -41,9 +41,9 @@ opt
 SELECT 1+a.y AS plus, a.x FROM a
 ----
 project
- ├── columns: plus:int:null:3 x:int:1
+ ├── columns: plus:3(int) x:1(int!null)
  ├── scan
- │    └── columns: a.x:int:1 a.y:int:null:2
+ │    └── columns: a.x:1(int!null) a.y:2(int)
  └── projections [outer=(1,2)]
       ├── plus [type=int, outer=(2)]
       │    ├── variable: a.y [type=int, outer=(2)]
@@ -55,11 +55,11 @@ opt
 SELECT b.x, rowid, a.y, a.x, a.y y2, b.y FROM a, b
 ----
 inner-join
- ├── columns: x:int:null:3 rowid:int:5 y:int:null:2 x:int:1 y2:int:null:2 y:float:null:4
+ ├── columns: x:3(int) rowid:5(int!null) y:2(int) x:1(int!null) y2:2(int) y:4(float)
  ├── scan
- │    └── columns: a.x:int:1 a.y:int:null:2
+ │    └── columns: a.x:1(int!null) a.y:2(int)
  ├── scan
- │    └── columns: b.x:int:null:3 b.y:float:null:4 b.rowid:int:5
+ │    └── columns: b.x:3(int) b.y:4(float) b.rowid:5(int!null)
  └── true [type=bool]
 
 # Groupby operator.
@@ -67,10 +67,10 @@ opt
 SELECT MAX(y), y, y, x FROM a GROUP BY a.x, a.y
 ----
 group-by
- ├── columns: column3:int:null:3 y:int:null:2 y:int:null:2 x:int:1
- ├── grouping columns: a.x:int:1 a.y:int:null:2
+ ├── columns: column3:3(int) y:2(int) y:2(int) x:1(int!null)
+ ├── grouping columns: a.x:1(int!null) a.y:2(int)
  ├── scan
- │    └── columns: a.x:int:1 a.y:int:null:2
+ │    └── columns: a.x:1(int!null) a.y:2(int)
  └── aggregations [outer=(2)]
       └── function: max [type=int, outer=(2)]
            └── variable: a.y [type=int, outer=(2)]

--- a/pkg/sql/opt/xform/testdata/rules/bool
+++ b/pkg/sql/opt/xform/testdata/rules/bool
@@ -17,9 +17,9 @@ opt
 SELECT * FROM a WHERE k>1 AND k<5 AND f=3.5
 ----
 select
- ├── columns: k:int:1 i:int:null:2 f:float:null:3 s:string:null:4 j:jsonb:null:5
+ ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
  ├── scan
- │    └── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5
+ │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
  └── and [type=bool, outer=(1,3)]
       ├── gt [type=bool, outer=(1)]
       │    ├── variable: a.k [type=int, outer=(1)]
@@ -38,9 +38,9 @@ opt
 SELECT * FROM a WHERE k=1 OR i=2 OR f=3.5
 ----
 select
- ├── columns: k:int:1 i:int:null:2 f:float:null:3 s:string:null:4 j:jsonb:null:5
+ ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
  ├── scan
- │    └── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5
+ │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
  └── or [type=bool, outer=(1-3)]
       ├── eq [type=bool, outer=(1)]
       │    ├── variable: a.k [type=int, outer=(1)]
@@ -61,9 +61,9 @@ opt
 SELECT * FROM a WHERE (k=1 OR (i=2 OR f=3.5)) AND (s='foo' AND s<>'bar')
 ----
 select
- ├── columns: k:int:1 i:int:null:2 f:float:null:3 s:string:null:4 j:jsonb:null:5
+ ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
  ├── scan
- │    └── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5
+ │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
  └── and [type=bool, outer=(1-4)]
       ├── or [type=bool, outer=(1-3)]
       │    ├── eq [type=bool, outer=(1)]
@@ -89,27 +89,27 @@ opt
 SELECT * FROM a WHERE k=1 AND False AND f=3.5
 ----
 select
- ├── columns: k:int:1 i:int:null:2 f:float:null:3 s:string:null:4 j:jsonb:null:5
+ ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
  ├── scan
- │    └── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5
+ │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
  └── false [type=bool]
 
 opt
 SELECT * FROM a WHERE False AND s='foo'
 ----
 select
- ├── columns: k:int:1 i:int:null:2 f:float:null:3 s:string:null:4 j:jsonb:null:5
+ ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
  ├── scan
- │    └── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5
+ │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
  └── false [type=bool]
 
 opt
 SELECT * FROM a WHERE true AND k=1
 ----
 select
- ├── columns: k:int:1 i:int:null:2 f:float:null:3 s:string:null:4 j:jsonb:null:5
+ ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
  ├── scan
- │    └── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5
+ │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
  └── and [type=bool, outer=(1)]
       └── eq [type=bool, outer=(1)]
            ├── variable: a.k [type=int, outer=(1)]
@@ -119,9 +119,9 @@ opt
 SELECT * FROM a WHERE k=1 AND i=2 AND true
 ----
 select
- ├── columns: k:int:1 i:int:null:2 f:float:null:3 s:string:null:4 j:jsonb:null:5
+ ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
  ├── scan
- │    └── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5
+ │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
  └── and [type=bool, outer=(1,2)]
       ├── eq [type=bool, outer=(1)]
       │    ├── variable: a.k [type=int, outer=(1)]
@@ -134,9 +134,9 @@ opt
 SELECT * FROM a WHERE true AND true
 ----
 select
- ├── columns: k:int:1 i:int:null:2 f:float:null:3 s:string:null:4 j:jsonb:null:5
+ ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
  ├── scan
- │    └── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5
+ │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
  └── true [type=bool]
 
 # --------------------------------------------------
@@ -146,27 +146,27 @@ opt
 SELECT * FROM a WHERE k=1 OR (i=2 OR True)
 ----
 select
- ├── columns: k:int:1 i:int:null:2 f:float:null:3 s:string:null:4 j:jsonb:null:5
+ ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
  ├── scan
- │    └── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5
+ │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
  └── true [type=bool]
 
 opt
 SELECT * FROM a WHERE k=1 OR True OR f=3.5
 ----
 select
- ├── columns: k:int:1 i:int:null:2 f:float:null:3 s:string:null:4 j:jsonb:null:5
+ ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
  ├── scan
- │    └── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5
+ │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
  └── true [type=bool]
 
 opt
 SELECT * FROM a WHERE false OR k=1
 ----
 select
- ├── columns: k:int:1 i:int:null:2 f:float:null:3 s:string:null:4 j:jsonb:null:5
+ ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
  ├── scan
- │    └── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5
+ │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
  └── eq [type=bool, outer=(1)]
       ├── variable: a.k [type=int, outer=(1)]
       └── const: 1 [type=int]
@@ -175,9 +175,9 @@ opt
 SELECT * FROM a WHERE k=1 OR i=2 OR false
 ----
 select
- ├── columns: k:int:1 i:int:null:2 f:float:null:3 s:string:null:4 j:jsonb:null:5
+ ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
  ├── scan
- │    └── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5
+ │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
  └── or [type=bool, outer=(1,2)]
       ├── eq [type=bool, outer=(1)]
       │    ├── variable: a.k [type=int, outer=(1)]
@@ -190,9 +190,9 @@ opt
 SELECT * FROM a WHERE false OR false
 ----
 select
- ├── columns: k:int:1 i:int:null:2 f:float:null:3 s:string:null:4 j:jsonb:null:5
+ ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
  ├── scan
- │    └── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5
+ │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
  └── false [type=bool]
 
 # --------------------------------------------------
@@ -202,9 +202,9 @@ opt
 SELECT * FROM a WHERE (k=1 OR false) AND (false OR k=2 OR false) AND true
 ----
 select
- ├── columns: k:int:1 i:int:null:2 f:float:null:3 s:string:null:4 j:jsonb:null:5
+ ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
  ├── scan
- │    └── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5
+ │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
  └── and [type=bool, outer=(1)]
       ├── eq [type=bool, outer=(1)]
       │    ├── variable: a.k [type=int, outer=(1)]
@@ -220,27 +220,27 @@ opt
 SELECT * FROM a WHERE null and null
 ----
 select
- ├── columns: k:int:1 i:int:null:2 f:float:null:3 s:string:null:4 j:jsonb:null:5
+ ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
  ├── scan
- │    └── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5
+ │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
  └── null [type=bool]
 
 opt
 SELECT * FROM a WHERE null or null
 ----
 select
- ├── columns: k:int:1 i:int:null:2 f:float:null:3 s:string:null:4 j:jsonb:null:5
+ ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
  ├── scan
- │    └── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5
+ │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
  └── null [type=bool]
 
 opt
 SELECT * FROM a WHERE null or (null and null and null) or null
 ----
 select
- ├── columns: k:int:1 i:int:null:2 f:float:null:3 s:string:null:4 j:jsonb:null:5
+ ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
  ├── scan
- │    └── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5
+ │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
  └── null [type=bool]
 
 # Don't fold.
@@ -248,9 +248,9 @@ opt
 SELECT * FROM a WHERE null or (null and k=1)
 ----
 select
- ├── columns: k:int:1 i:int:null:2 f:float:null:3 s:string:null:4 j:jsonb:null:5
+ ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
  ├── scan
- │    └── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5
+ │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
  └── or [type=bool, outer=(1)]
       ├── null [type=unknown]
       └── and [type=bool, outer=(1)]
@@ -268,9 +268,9 @@ opt
 SELECT * FROM a WHERE NOT(i=1) AND NOT(i<>1) AND NOT(i>1) AND NOT(i>=1) AND NOT(i<1) AND NOT(i<=1)
 ----
 select
- ├── columns: k:int:1 i:int:null:2 f:float:null:3 s:string:null:4 j:jsonb:null:5
+ ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
  ├── scan
- │    └── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5
+ │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
  └── and [type=bool, outer=(2)]
       ├── ne [type=bool, outer=(2)]
       │    ├── variable: a.i [type=int, outer=(2)]
@@ -298,9 +298,9 @@ FROM a
 WHERE NOT(i IN (1,2)) AND NOT(i NOT IN (3,4)) AND NOT(i IS NULL) AND NOT(i IS NOT NULL)
 ----
 select
- ├── columns: k:int:1 i:int:null:2 f:float:null:3 s:string:null:4 j:jsonb:null:5
+ ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
  ├── scan
- │    └── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5
+ │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
  └── and [type=bool, outer=(2)]
       ├── not-in [type=bool, outer=(2)]
       │    ├── variable: a.i [type=int, outer=(2)]
@@ -326,9 +326,9 @@ FROM a
 WHERE NOT(s LIKE 'foo') AND NOT(s NOT LIKE 'foo') AND NOT(s ILIKE 'foo') AND NOT(s NOT ILIKE 'foo')
 ----
 select
- ├── columns: k:int:1 i:int:null:2 f:float:null:3 s:string:null:4 j:jsonb:null:5
+ ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
  ├── scan
- │    └── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5
+ │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
  └── and [type=bool, outer=(4)]
       ├── not-like [type=bool, outer=(4)]
       │    ├── variable: a.s [type=string, outer=(4)]
@@ -348,9 +348,9 @@ opt
 SELECT * FROM a WHERE NOT(s SIMILAR TO 'foo') AND NOT(s NOT SIMILAR TO 'foo')
 ----
 select
- ├── columns: k:int:1 i:int:null:2 f:float:null:3 s:string:null:4 j:jsonb:null:5
+ ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
  ├── scan
- │    └── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5
+ │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
  └── and [type=bool, outer=(4)]
       ├── not-similar-to [type=bool, outer=(4)]
       │    ├── variable: a.s [type=string, outer=(4)]
@@ -364,9 +364,9 @@ opt
 SELECT * FROM a WHERE NOT(s ~ 'foo') AND NOT(s !~ 'foo') AND NOT(s ~* 'foo') AND NOT (s !~* 'foo')
 ----
 select
- ├── columns: k:int:1 i:int:null:2 f:float:null:3 s:string:null:4 j:jsonb:null:5
+ ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
  ├── scan
- │    └── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5
+ │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
  └── and [type=bool, outer=(4)]
       ├── not-reg-match [type=bool, outer=(4)]
       │    ├── variable: a.s [type=string, outer=(4)]
@@ -386,9 +386,9 @@ opt
 SELECT * FROM a WHERE NOT('[1, 2]' @> j) AND NOT(j <@ '[3, 4]')
 ----
 select
- ├── columns: k:int:1 i:int:null:2 f:float:null:3 s:string:null:4 j:jsonb:null:5
+ ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
  ├── scan
- │    └── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5
+ │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
  └── and [type=bool, outer=(5)]
       ├── not [type=bool, outer=(5)]
       │    └── contains [type=bool, outer=(5)]
@@ -406,9 +406,9 @@ opt
 SELECT * FROM a WHERE NOT(NOT('[1, 2]' @> j))
 ----
 select
- ├── columns: k:int:1 i:int:null:2 f:float:null:3 s:string:null:4 j:jsonb:null:5
+ ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
  ├── scan
- │    └── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5
+ │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
  └── contains [type=bool, outer=(5)]
       ├── const: '[1, 2]' [type=jsonb]
       └── variable: a.j [type=jsonb, outer=(5)]

--- a/pkg/sql/opt/xform/testdata/rules/comp
+++ b/pkg/sql/opt/xform/testdata/rules/comp
@@ -20,9 +20,9 @@ opt
 SELECT * FROM a WHERE 1+i<k AND k-1<=i AND i*i>k AND k/2>=i
 ----
 select
- ├── columns: k:int:1 i:int:null:2 f:float:null:3 s:string:null:4 j:jsonb:null:5
+ ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
  ├── scan
- │    └── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5
+ │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
  └── and [type=bool, outer=(1,2)]
       ├── gt [type=bool, outer=(1,2)]
       │    ├── variable: a.k [type=int, outer=(1)]
@@ -52,9 +52,9 @@ opt
 SELECT * FROM a WHERE length('foo')+1<i+k AND length('bar')<=i*2 AND 5>i AND 'foo'>=s
 ----
 select
- ├── columns: k:int:1 i:int:null:2 f:float:null:3 s:string:null:4 j:jsonb:null:5
+ ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
  ├── scan
- │    └── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5
+ │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
  └── and [type=bool, outer=(1,2,4)]
       ├── gt [type=bool, outer=(1,2)]
       │    ├── plus [type=int, outer=(1,2)]
@@ -91,9 +91,9 @@ WHERE
     '1:00:00'::time + i::interval >= '2:00:00'::time
 ----
 select
- ├── columns: k:int:1 i:int:null:2 f:float:null:3 s:string:null:4 j:jsonb:null:5
+ ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
  ├── scan
- │    └── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5
+ │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
  └── and [type=bool, outer=(2,3)]
       ├── eq [type=bool, outer=(2)]
       │    ├── variable: a.i [type=int, outer=(2)]
@@ -132,9 +132,9 @@ opt
 SELECT * FROM a WHERE s::date + '02:00:00'::time = '2000-01-01T02:00:00'::timestamp
 ----
 select
- ├── columns: k:int:1 i:int:null:2 f:float:null:3 s:string:null:4 j:jsonb:null:5
+ ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
  ├── scan
- │    └── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5
+ │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
  └── eq [type=bool, outer=(4)]
       ├── plus [type=timestamp, outer=(4)]
       │    ├── cast: date [type=date, outer=(4)]
@@ -156,9 +156,9 @@ WHERE
     f+i::float-10.0 >= 100.0
 ----
 select
- ├── columns: k:int:1 i:int:null:2 f:float:null:3 s:string:null:4 j:jsonb:null:5
+ ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
  ├── scan
- │    └── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5
+ │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
  └── and [type=bool, outer=(2,3)]
       ├── eq [type=bool, outer=(2)]
       │    ├── variable: a.i [type=int, outer=(2)]
@@ -199,9 +199,9 @@ opt
 SELECT * FROM a WHERE s::json - 1 = '[1]'::json
 ----
 select
- ├── columns: k:int:1 i:int:null:2 f:float:null:3 s:string:null:4 j:jsonb:null:5
+ ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
  ├── scan
- │    └── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5
+ │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
  └── eq [type=bool, outer=(4)]
       ├── minus [type=jsonb, outer=(4)]
       │    ├── cast: jsonb [type=jsonb, outer=(4)]
@@ -223,9 +223,9 @@ WHERE
     10.0-(f+i::float) >= 100.0
 ----
 select
- ├── columns: k:int:1 i:int:null:2 f:float:null:3 s:string:null:4 j:jsonb:null:5
+ ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
  ├── scan
- │    └── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5
+ │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
  └── and [type=bool, outer=(2,3)]
       ├── eq [type=bool, outer=(2)]
       │    ├── variable: a.i [type=int, outer=(2)]
@@ -266,9 +266,9 @@ opt
 SELECT * FROM a WHERE '[1, 2]'::json - i = '[1]'
 ----
 select
- ├── columns: k:int:1 i:int:null:2 f:float:null:3 s:string:null:4 j:jsonb:null:5
+ ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
  ├── scan
- │    └── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5
+ │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
  └── eq [type=bool, outer=(2)]
       ├── minus [type=jsonb, outer=(2)]
       │    ├── const: '[1, 2]' [type=jsonb]
@@ -282,9 +282,9 @@ opt
 SELECT * FROM a WHERE (i, f, s) = (1, 3.5, 'foo')
 ----
 select
- ├── columns: k:int:1 i:int:null:2 f:float:null:3 s:string:null:4 j:jsonb:null:5
+ ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
  ├── scan
- │    └── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5
+ │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
  └── and [type=bool, outer=(2-4)]
       ├── eq [type=bool, outer=(2)]
       │    ├── variable: a.i [type=int, outer=(2)]
@@ -305,9 +305,9 @@ opt
 SELECT * FROM a WHERE (1, (2, 'foo')) = (k, (i, s))
 ----
 select
- ├── columns: k:int:1 i:int:null:2 f:float:null:3 s:string:null:4 j:jsonb:null:5
+ ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
  ├── scan
- │    └── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5
+ │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
  └── and [type=bool, outer=(1,2,4)]
       ├── eq [type=bool, outer=(1)]
       │    ├── variable: a.k [type=int, outer=(1)]
@@ -346,7 +346,7 @@ WHERE
     null::string !~* 'foo' AND 'foo' !~* null::string
 ----
 select
- ├── columns: k:int:1 i:int:null:2 f:float:null:3 s:string:null:4 j:jsonb:null:5
+ ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
  ├── scan
- │    └── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5
+ │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
  └── null [type=bool]

--- a/pkg/sql/opt/xform/testdata/rules/numeric
+++ b/pkg/sql/opt/xform/testdata/rules/numeric
@@ -23,9 +23,9 @@ SELECT
 FROM a
 ----
 project
- ├── columns: column6:int:null:6 column7:int:null:7 column8:float:null:8 column9:float:null:9 column10:decimal:null:10 column11:decimal:null:11
+ ├── columns: column6:6(int) column7:7(int) column8:8(float) column9:9(float) column10:10(decimal) column11:11(decimal)
  ├── scan
- │    └── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.d:decimal:null:4 a.t:time:null:5
+ │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.d:4(decimal) a.t:5(time)
  └── projections [outer=(2-4)]
       ├── plus [type=int, outer=(2)]
       │    ├── variable: a.i [type=int, outer=(2)]
@@ -59,9 +59,9 @@ SELECT
 FROM a
 ----
 project
- ├── columns: column6:int:null:6 column7:float:null:7 column8:decimal:null:8
+ ├── columns: column6:6(int) column7:7(float) column8:8(decimal)
  ├── scan
- │    └── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.d:decimal:null:4 a.t:time:null:5
+ │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.d:4(decimal) a.t:5(time)
  └── projections [outer=(2-4)]
       ├── plus [type=int, outer=(2)]
       │    ├── variable: a.i [type=int, outer=(2)]
@@ -86,9 +86,9 @@ SELECT
 FROM a
 ----
 project
- ├── columns: column6:int:null:6 column7:int:null:7 column8:float:null:8 column9:float:null:9 column10:decimal:null:10 column11:decimal:null:11
+ ├── columns: column6:6(int) column7:7(int) column8:8(float) column9:9(float) column10:10(decimal) column11:11(decimal)
  ├── scan
- │    └── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.d:decimal:null:4 a.t:time:null:5
+ │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.d:4(decimal) a.t:5(time)
  └── projections [outer=(2-4)]
       ├── plus [type=int, outer=(2)]
       │    ├── variable: a.i [type=int, outer=(2)]
@@ -121,9 +121,9 @@ SELECT
 FROM a
 ----
 project
- ├── columns: column6:decimal:null:6 column7:float:null:7 column8:decimal:null:8
+ ├── columns: column6:6(decimal) column7:7(float) column8:8(decimal)
  ├── scan
- │    └── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.d:decimal:null:4 a.t:time:null:5
+ │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.d:4(decimal) a.t:5(time)
  └── projections [outer=(2-4)]
       ├── variable: a.i [type=int, outer=(2)]
       ├── variable: a.f [type=float, outer=(3)]
@@ -140,9 +140,9 @@ SELECT
 FROM a
 ----
 project
- ├── columns: column6:float:null:6 column7:decimal:null:7 column8:interval:null:8
+ ├── columns: column6:6(float) column7:7(decimal) column8:8(interval)
  ├── scan
- │    └── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.d:decimal:null:4 a.t:time:null:5
+ │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.d:4(decimal) a.t:5(time)
  └── projections [outer=(2-5)]
       ├── minus [type=float, outer=(3)]
       │    ├── variable: a.f [type=float, outer=(3)]
@@ -161,8 +161,8 @@ opt
 SELECT -(-a.i::int) FROM a
 ----
 project
- ├── columns: column6:int:null:6
+ ├── columns: column6:6(int)
  ├── scan
- │    └── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.d:decimal:null:4 a.t:time:null:5
+ │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.d:4(decimal) a.t:5(time)
  └── projections [outer=(2)]
       └── variable: a.i [type=int, outer=(2)]

--- a/pkg/sql/opt/xform/testdata/rules/project
+++ b/pkg/sql/opt/xform/testdata/rules/project
@@ -26,30 +26,30 @@ opt
 SELECT x, y FROM t.a
 ----
 scan
- └── columns: x:int:1 y:float:null:2
+ └── columns: x:1(int!null) y:2(float)
 
 # Different order, aliased names.
 opt
 SELECT a.y AS aliasy, a.x FROM t.a
 ----
 scan
- └── columns: aliasy:float:null:2 x:int:1
+ └── columns: aliasy:2(float) x:1(int!null)
 
 # Reordered, duplicate, aliased columns.
 opt
 SELECT a.y AS alias1, a.x, a.y AS alias1, a.x FROM t.a
 ----
 scan
- └── columns: alias1:float:null:2 x:int:1 alias1:float:null:2 x:int:1
+ └── columns: alias1:2(float) x:1(int!null) alias1:2(float) x:1(int!null)
 
 # Added column (projection should not be eliminated).
 opt
 SELECT x, y, 1 FROM t.a
 ----
 project
- ├── columns: x:int:1 y:float:null:2 column3:int:null:3
+ ├── columns: x:1(int!null) y:2(float) column3:3(int)
  ├── scan
- │    └── columns: a.x:int:1 a.y:float:null:2
+ │    └── columns: a.x:1(int!null) a.y:2(float)
  └── projections [outer=(1,2)]
       ├── variable: a.x [type=int, outer=(1)]
       ├── variable: a.y [type=float, outer=(2)]
@@ -60,8 +60,8 @@ opt
 SELECT x FROM t.a
 ----
 project
- ├── columns: x:int:1
+ ├── columns: x:1(int!null)
  ├── scan
- │    └── columns: a.x:int:1 a.y:float:null:2
+ │    └── columns: a.x:1(int!null) a.y:2(float)
  └── projections [outer=(1)]
       └── variable: a.x [type=int, outer=(1)]

--- a/pkg/sql/opt/xform/testdata/rules/scalar
+++ b/pkg/sql/opt/xform/testdata/rules/scalar
@@ -32,9 +32,9 @@ SELECT
 FROM a
 ----
 project
- ├── columns: column7:bool:null:7 column8:bool:null:8 column9:bool:null:9 column10:bool:null:10 column11:int:null:11 column12:int:null:12 column13:int:null:13 column14:int:null:14 column15:int:null:15
+ ├── columns: column7:7(bool) column8:8(bool) column9:9(bool) column10:10(bool) column11:11(int) column12:12(int) column13:13(int) column14:14(int) column15:15(int)
  ├── scan
- │    └── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5 a.arr:int[]:null:6
+ │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb) a.arr:6(int[])
  └── projections [outer=(1,2)]
       ├── eq [type=bool, outer=(1,2)]
       │    ├── variable: a.k [type=int, outer=(1)]
@@ -100,9 +100,9 @@ SELECT
 FROM a
 ----
 project
- ├── columns: column7:bool:null:7 column8:bool:null:8 column9:bool:null:9 column10:bool:null:10 column11:float:null:11 column12:int:null:12 column13:int:null:13 column14:int:null:14 column15:int:null:15
+ ├── columns: column7:7(bool) column8:8(bool) column9:9(bool) column10:10(bool) column11:11(float) column12:12(int) column13:13(int) column14:14(int) column15:15(int)
  ├── scan
- │    └── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5 a.arr:int[]:null:6
+ │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb) a.arr:6(int[])
  └── projections [outer=(1-3)]
       ├── eq [type=bool, outer=(1,2)]
       │    ├── plus [type=int, outer=(1,2)]
@@ -170,9 +170,9 @@ opt
 SELECT COALESCE(i) FROM a
 ----
 project
- ├── columns: column7:int:null:7
+ ├── columns: column7:7(int)
  ├── scan
- │    └── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5 a.arr:int[]:null:6
+ │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb) a.arr:6(int[])
  └── projections [outer=(2)]
       └── variable: a.i [type=int, outer=(2)]
 
@@ -183,9 +183,9 @@ opt
 SELECT COALESCE(NULL) FROM a
 ----
 project
- ├── columns: column7:unknown:null:7
+ ├── columns: column7:7(unknown)
  ├── scan
- │    └── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5 a.arr:int[]:null:6
+ │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb) a.arr:6(int[])
  └── projections
       └── null [type=unknown]
 
@@ -193,9 +193,9 @@ opt
 SELECT COALESCE(NULL, 'foo', s) FROM a
 ----
 project
- ├── columns: column7:string:null:7
+ ├── columns: column7:7(string)
  ├── scan
- │    └── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5 a.arr:int[]:null:6
+ │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb) a.arr:6(int[])
  └── projections
       └── const: 'foo' [type=string]
 
@@ -203,9 +203,9 @@ opt
 SELECT COALESCE(NULL, NULL, s, s || 'foo') FROM a
 ----
 project
- ├── columns: column7:string:null:7
+ ├── columns: column7:7(string)
  ├── scan
- │    └── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5 a.arr:int[]:null:6
+ │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb) a.arr:6(int[])
  └── projections [outer=(4)]
       └── coalesce [type=string, outer=(4)]
            ├── variable: a.s [type=string, outer=(4)]
@@ -218,9 +218,9 @@ opt
 SELECT COALESCE(i, NULL, NULL) FROM a
 ----
 project
- ├── columns: column7:int:null:7
+ ├── columns: column7:7(int)
  ├── scan
- │    └── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5 a.arr:int[]:null:6
+ │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb) a.arr:6(int[])
  └── projections [outer=(2)]
       └── coalesce [type=int, outer=(2)]
            ├── variable: a.i [type=int, outer=(2)]
@@ -234,9 +234,9 @@ opt
 SELECT i::int, arr::int[], '[1, 2]'::json::json, null::string::int FROM a
 ----
 project
- ├── columns: column7:int:null:7 column8:int[]:null:8 column9:jsonb:null:9 column10:int:null:10
+ ├── columns: column7:7(int) column8:8(int[]) column9:9(jsonb) column10:10(int)
  ├── scan
- │    └── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5 a.arr:int[]:null:6
+ │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb) a.arr:6(int[])
  └── projections [outer=(2,6)]
       ├── variable: a.i [type=int, outer=(2)]
       ├── variable: a.arr [type=int[], outer=(6)]
@@ -248,9 +248,9 @@ opt
 SELECT i::float, arr::decimal[], s::json::json FROM a
 ----
 project
- ├── columns: column7:float:null:7 column8:decimal[]:null:8 column9:jsonb:null:9
+ ├── columns: column7:7(float) column8:8(decimal[]) column9:9(jsonb)
  ├── scan
- │    └── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5 a.arr:int[]:null:6
+ │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb) a.arr:6(int[])
  └── projections [outer=(2,4,6)]
       ├── cast: float [type=float, outer=(2)]
       │    └── variable: a.i [type=int, outer=(2)]
@@ -266,7 +266,7 @@ opt
 SELECT null::int, null::timestamptz
 ----
 project
- ├── columns: column1:int:null:1 column2:timestamptz:null:2
+ ├── columns: column1:1(int) column2:2(timestamptz)
  ├── values
  │    └── tuple [type=tuple{}]
  └── projections
@@ -280,9 +280,9 @@ opt
 SELECT +null::int, -null::int, ~null::int FROM a
 ----
 project
- ├── columns: column7:int:null:7 column8:int:null:8 column9:int:null:9
+ ├── columns: column7:7(int) column8:8(int) column9:9(int)
  ├── scan
- │    └── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5 a.arr:int[]:null:6
+ │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb) a.arr:6(int[])
  └── projections
       ├── null [type=int]
       ├── null [type=int]
@@ -308,9 +308,9 @@ SELECT
 FROM a
 ----
 project
- ├── columns: column7:int:null:7 column8:int:null:8 column9:decimal:null:9 column10:decimal:null:10 column11:float:null:11 column12:float:null:12 column13:int:null:13 column14:int:null:14 column15:jsonb:null:15 column16:jsonb:null:16 column17:decimal[]:null:17 column18:string[]:null:18 column19:decimal[]:null:19 column20:float[]:null:20
+ ├── columns: column7:7(int) column8:8(int) column9:9(decimal) column10:10(decimal) column11:11(float) column12:12(float) column13:13(int) column14:14(int) column15:15(jsonb) column16:16(jsonb) column17:17(decimal[]) column18:18(string[]) column19:19(decimal[]) column20:20(float[])
  ├── scan
- │    └── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5 a.arr:int[]:null:6
+ │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb) a.arr:6(int[])
  └── projections [outer=(2,6)]
       ├── null [type=int]
       ├── null [type=int]
@@ -346,9 +346,9 @@ opt
 SELECT null IN (i), null NOT IN (s) FROM a
 ----
 project
- ├── columns: column7:bool:null:7 column8:bool:null:8
+ ├── columns: column7:7(bool) column8:8(bool)
  ├── scan
- │    └── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5 a.arr:int[]:null:6
+ │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb) a.arr:6(int[])
  └── projections
       ├── null [type=bool]
       └── null [type=bool]
@@ -360,9 +360,9 @@ opt
 SELECT i IN (null, null), k NOT IN (1 * null, null::int, 1 < null) FROM a
 ----
 project
- ├── columns: column7:bool:null:7 column8:bool:null:8
+ ├── columns: column7:7(bool) column8:8(bool)
  ├── scan
- │    └── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5 a.arr:int[]:null:6
+ │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb) a.arr:6(int[])
  └── projections
       ├── null [type=bool]
       └── null [type=bool]
@@ -374,9 +374,9 @@ opt
 SELECT i IN (2, 1, 1, null, 3, null, 2, 3.0) FROM a
 ----
 project
- ├── columns: column7:bool:null:7
+ ├── columns: column7:7(bool)
  ├── scan
- │    └── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5 a.arr:int[]:null:6
+ │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb) a.arr:6(int[])
  └── projections [outer=(2)]
       └── in [type=bool, outer=(2)]
            ├── variable: a.i [type=int, outer=(2)]
@@ -390,9 +390,9 @@ opt
 SELECT s NOT IN ('foo', s || 'foo', 'bar', length(s)::string, NULL) FROM a
 ----
 project
- ├── columns: column7:bool:null:7
+ ├── columns: column7:7(bool)
  ├── scan
- │    └── columns: a.k:int:1 a.i:int:null:2 a.f:float:null:3 a.s:string:null:4 a.j:jsonb:null:5 a.arr:int[]:null:6
+ │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb) a.arr:6(int[])
  └── projections [outer=(4)]
       └── not-in [type=bool, outer=(4)]
            ├── variable: a.s [type=string, outer=(4)]

--- a/pkg/sql/opt/xform/testdata/typing
+++ b/pkg/sql/opt/xform/testdata/typing
@@ -30,9 +30,9 @@ build
 SELECT a.x FROM a
 ----
 project
- ├── columns: x:int:1
+ ├── columns: x:1(int!null)
  ├── scan
- │    └── columns: a.x:int:1 a.y:int:null:2
+ │    └── columns: a.x:1(int!null) a.y:2(int)
  └── projections [outer=(1)]
       └── variable: a.x [type=int, outer=(1)]
 
@@ -41,7 +41,7 @@ build
 SELECT 1, TRUE, FALSE, NULL
 ----
 project
- ├── columns: column1:int:null:1 column2:bool:null:2 column3:bool:null:3 column4:unknown:null:4
+ ├── columns: column1:1(int) column2:2(bool) column3:3(bool) column4:4(unknown)
  ├── values
  │    └── tuple [type=tuple{}]
  └── projections
@@ -55,9 +55,9 @@ build
 SELECT * FROM a WHERE x = $1
 ----
 select
- ├── columns: x:int:1 y:int:null:2
+ ├── columns: x:1(int!null) y:2(int)
  ├── scan
- │    └── columns: a.x:int:1 a.y:int:null:2
+ │    └── columns: a.x:1(int!null) a.y:2(int)
  └── eq [type=bool, outer=(1)]
       ├── variable: a.x [type=int, outer=(1)]
       └── placeholder: $1 [type=int]
@@ -67,9 +67,9 @@ build
 SELECT (a.x, 1.5), a.y FROM a
 ----
 project
- ├── columns: column3:tuple{int, decimal}:null:3 y:int:null:2
+ ├── columns: column3:3(tuple{int, decimal}) y:2(int)
  ├── scan
- │    └── columns: a.x:int:1 a.y:int:null:2
+ │    └── columns: a.x:1(int!null) a.y:2(int)
  └── projections [outer=(1,2)]
       ├── tuple [type=tuple{int, decimal}, outer=(1)]
       │    ├── variable: a.x [type=int, outer=(1)]
@@ -81,9 +81,9 @@ build
 SELECT * FROM a WHERE a.x = 1 AND NOT (a.y = 2 OR a.y = 3.5)
 ----
 select
- ├── columns: x:int:1 y:int:null:2
+ ├── columns: x:1(int!null) y:2(int)
  ├── scan
- │    └── columns: a.x:int:1 a.y:int:null:2
+ │    └── columns: a.x:1(int!null) a.y:2(int)
  └── and [type=bool, outer=(1,2)]
       ├── eq [type=bool, outer=(1)]
       │    ├── variable: a.x [type=int, outer=(1)]
@@ -102,9 +102,9 @@ build
 SELECT * FROM a WHERE a.x = 1 AND a.x <> 2
 ----
 select
- ├── columns: x:int:1 y:int:null:2
+ ├── columns: x:1(int!null) y:2(int)
  ├── scan
- │    └── columns: a.x:int:1 a.y:int:null:2
+ │    └── columns: a.x:1(int!null) a.y:2(int)
  └── and [type=bool, outer=(1)]
       ├── eq [type=bool, outer=(1)]
       │    ├── variable: a.x [type=int, outer=(1)]
@@ -118,9 +118,9 @@ build
 SELECT * FROM a WHERE a.x >= 1 AND a.x <= 10 AND a.y > 1 AND a.y < 10
 ----
 select
- ├── columns: x:int:1 y:int:null:2
+ ├── columns: x:1(int!null) y:2(int)
  ├── scan
- │    └── columns: a.x:int:1 a.y:int:null:2
+ │    └── columns: a.x:1(int!null) a.y:2(int)
  └── and [type=bool, outer=(1,2)]
       ├── and [type=bool, outer=(1,2)]
       │    ├── and [type=bool, outer=(1)]
@@ -142,9 +142,9 @@ build
 SELECT * FROM a WHERE a.x IN (1, 2) AND a.y NOT IN (3, 4)
 ----
 select
- ├── columns: x:int:1 y:int:null:2
+ ├── columns: x:1(int!null) y:2(int)
  ├── scan
- │    └── columns: a.x:int:1 a.y:int:null:2
+ │    └── columns: a.x:1(int!null) a.y:2(int)
  └── and [type=bool, outer=(1,2)]
       ├── in [type=bool, outer=(1)]
       │    ├── variable: a.x [type=int, outer=(1)]
@@ -162,9 +162,9 @@ build
 SELECT * FROM b WHERE b.x LIKE '%foo%' AND b.x NOT LIKE '%bar%'
 ----
 select
- ├── columns: x:string:1 z:decimal:2
+ ├── columns: x:1(string!null) z:2(decimal!null)
  ├── scan
- │    └── columns: b.x:string:1 b.z:decimal:2
+ │    └── columns: b.x:1(string!null) b.z:2(decimal!null)
  └── and [type=bool, outer=(1)]
       ├── like [type=bool, outer=(1)]
       │    ├── variable: b.x [type=string, outer=(1)]
@@ -178,9 +178,9 @@ build
 SELECT * FROM b WHERE b.x ILIKE '%foo%' AND b.x NOT ILIKE '%bar%'
 ----
 select
- ├── columns: x:string:1 z:decimal:2
+ ├── columns: x:1(string!null) z:2(decimal!null)
  ├── scan
- │    └── columns: b.x:string:1 b.z:decimal:2
+ │    └── columns: b.x:1(string!null) b.z:2(decimal!null)
  └── and [type=bool, outer=(1)]
       ├── i-like [type=bool, outer=(1)]
       │    ├── variable: b.x [type=string, outer=(1)]
@@ -194,9 +194,9 @@ build
 SELECT * FROM b WHERE b.x ~ 'foo' AND b.x !~ 'bar' AND b.x ~* 'foo' AND b.x !~* 'bar'
 ----
 select
- ├── columns: x:string:1 z:decimal:2
+ ├── columns: x:1(string!null) z:2(decimal!null)
  ├── scan
- │    └── columns: b.x:string:1 b.z:decimal:2
+ │    └── columns: b.x:1(string!null) b.z:2(decimal!null)
  └── and [type=bool, outer=(1)]
       ├── and [type=bool, outer=(1)]
       │    ├── and [type=bool, outer=(1)]
@@ -218,9 +218,9 @@ build
 SELECT * FROM a WHERE a.x IS DISTINCT FROM a.y AND a.x IS NULL
 ----
 select
- ├── columns: x:int:1 y:int:null:2
+ ├── columns: x:1(int!null) y:2(int)
  ├── scan
- │    └── columns: a.x:int:1 a.y:int:null:2
+ │    └── columns: a.x:1(int!null) a.y:2(int)
  └── and [type=bool, outer=(1,2)]
       ├── is-not [type=bool, outer=(1,2)]
       │    ├── variable: a.x [type=int, outer=(1)]
@@ -234,9 +234,9 @@ build
 SELECT a.x & a.y, a.x | a.y, a.x # a.y FROM a
 ----
 project
- ├── columns: column3:int:null:3 column4:int:null:4 column5:int:null:5
+ ├── columns: column3:3(int) column4:4(int) column5:5(int)
  ├── scan
- │    └── columns: a.x:int:1 a.y:int:null:2
+ │    └── columns: a.x:1(int!null) a.y:2(int)
  └── projections [outer=(1,2)]
       ├── bitand [type=int, outer=(1,2)]
       │    ├── variable: a.x [type=int, outer=(1)]
@@ -253,9 +253,9 @@ build
 SELECT a.x + 1.5, DATE '2000-01-01' - 15, 10.10 * a.x, 1 / a.y, a.x // 1.5 FROM a
 ----
 project
- ├── columns: column3:decimal:null:3 column4:date:null:4 column5:decimal:null:5 column6:decimal:null:6 column7:decimal:null:7
+ ├── columns: column3:3(decimal) column4:4(date) column5:5(decimal) column6:6(decimal) column7:7(decimal)
  ├── scan
- │    └── columns: a.x:int:1 a.y:int:null:2
+ │    └── columns: a.x:1(int!null) a.y:2(int)
  └── projections [outer=(1,2)]
       ├── plus [type=decimal, outer=(1)]
       │    ├── variable: a.x [type=int, outer=(1)]
@@ -278,9 +278,9 @@ build
 SELECT 100.1 % a.x, a.x ^ 2.5, a.x << 3, a.y >> 2 FROM a
 ----
 project
- ├── columns: column3:decimal:null:3 column4:decimal:null:4 column5:int:null:5 column6:int:null:6
+ ├── columns: column3:3(decimal) column4:4(decimal) column5:5(int) column6:6(int)
  ├── scan
- │    └── columns: a.x:int:1 a.y:int:null:2
+ │    └── columns: a.x:1(int!null) a.y:2(int)
  └── projections [outer=(1,2)]
       ├── mod [type=decimal, outer=(1)]
       │    ├── const: 100.1 [type=decimal]
@@ -300,9 +300,9 @@ build
 SELECT b.x || 'more' FROM b
 ----
 project
- ├── columns: column3:string:null:3
+ ├── columns: column3:3(string)
  ├── scan
- │    └── columns: b.x:string:1 b.z:decimal:2
+ │    └── columns: b.x:1(string!null) b.z:2(decimal!null)
  └── projections [outer=(1)]
       └── concat [type=string, outer=(1)]
            ├── variable: b.x [type=string, outer=(1)]
@@ -313,9 +313,9 @@ build
 SELECT -a.y, ~a.x FROM a
 ----
 project
- ├── columns: column3:int:null:3 column4:int:null:4
+ ├── columns: column3:3(int) column4:4(int)
  ├── scan
- │    └── columns: a.x:int:1 a.y:int:null:2
+ │    └── columns: a.x:1(int!null) a.y:2(int)
  └── projections [outer=(1,2)]
       ├── unary-minus [type=int, outer=(2)]
       │    └── variable: a.y [type=int, outer=(2)]
@@ -327,9 +327,9 @@ build
 SELECT arr || arr, arr || NULL, NULL || arr FROM unusual
 ----
 project
- ├── columns: column3:int[]:null:3 column4:int[]:null:4 column5:int[]:null:5
+ ├── columns: column3:3(int[]) column4:4(int[]) column5:5(int[])
  ├── scan
- │    └── columns: unusual.x:int:1 unusual.arr:int[]:null:2
+ │    └── columns: unusual.x:1(int!null) unusual.arr:2(int[])
  └── projections [outer=(2)]
       ├── concat [type=int[], outer=(2)]
       │    ├── variable: unusual.arr [type=int[], outer=(2)]
@@ -346,9 +346,9 @@ build
 SELECT x || arr, arr || x, x || NULL, NULL || x FROM unusual
 ----
 project
- ├── columns: column3:int[]:null:3 column4:int[]:null:4 column5:int[]:null:5 column6:int[]:null:6
+ ├── columns: column3:3(int[]) column4:4(int[]) column5:5(int[]) column6:6(int[])
  ├── scan
- │    └── columns: unusual.x:int:1 unusual.arr:int[]:null:2
+ │    └── columns: unusual.x:1(int!null) unusual.arr:2(int[])
  └── projections [outer=(1,2)]
       ├── concat [type=int[], outer=(1,2)]
       │    ├── variable: unusual.x [type=int, outer=(1)]
@@ -368,7 +368,7 @@ build
 SELECT length('text')
 ----
 project
- ├── columns: column1:int:null:1
+ ├── columns: column1:1(int)
  ├── values
  │    └── tuple [type=tuple{}]
  └── projections
@@ -380,7 +380,7 @@ build
 SELECT div(1.0, 2.0)
 ----
 project
- ├── columns: column1:decimal:null:1
+ ├── columns: column1:1(decimal)
  ├── values
  │    └── tuple [type=tuple{}]
  └── projections
@@ -393,7 +393,7 @@ build
 SELECT NOW()
 ----
 project
- ├── columns: column1:timestamptz:null:1
+ ├── columns: column1:1(timestamptz)
  ├── values
  │    └── tuple [type=tuple{}]
  └── projections
@@ -404,7 +404,7 @@ build
 SELECT GREATEST(1, 2, 3, 4)
 ----
 project
- ├── columns: column1:int:null:1
+ ├── columns: column1:1(int)
  ├── values
  │    └── tuple [type=tuple{}]
  └── projections


### PR DESCRIPTION
Change how we format column types in tests and for debugging.
The format changes are as follows:

  x:int:1 => x:1(int!null)
  x:int:null:1 => x:1(int)

Release note: None