### PR TITLE
sql: implement encode(..., 'escape')

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -607,9 +607,9 @@ Compatible elements: hour, minute, second, millisecond, microsecond.</p>
 <tr><td><code>concat_ws(<a href="string.html">string</a>...) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Uses the first argument as a separator between the concatenation of the subsequent arguments.</p>
 <p>For example <code>concat_ws('!','wow','great')</code> returns <code>wow!great</code>.</p>
 </span></td></tr>
-<tr><td><code>decode(text: <a href="string.html">string</a>, format: <a href="string.html">string</a>) &rarr; <a href="bytes.html">bytes</a></code></td><td><span class="funcdesc"><p>Decodes <code>data</code> as the format specified by <code>format</code> (only “hex” is supported).</p>
+<tr><td><code>decode(text: <a href="string.html">string</a>, format: <a href="string.html">string</a>) &rarr; <a href="bytes.html">bytes</a></code></td><td><span class="funcdesc"><p>Decodes <code>data</code> as the format specified by <code>format</code> (only “hex” and “escape” are supported).</p>
 </span></td></tr>
-<tr><td><code>encode(data: <a href="bytes.html">bytes</a>, format: <a href="string.html">string</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Encodes <code>data</code> in the text format specified by <code>format</code> (only “hex” is supported).</p>
+<tr><td><code>encode(data: <a href="bytes.html">bytes</a>, format: <a href="string.html">string</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Encodes <code>data</code> in the text format specified by <code>format</code> (only “hex” and “escape” are supported).</p>
 </span></td></tr>
 <tr><td><code>from_ip(val: <a href="bytes.html">bytes</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Converts the byte string representation of an IP to its character string representation.</p>
 </span></td></tr>

--- a/pkg/sql/logictest/testdata/logic_test/builtin_function
+++ b/pkg/sql/logictest/testdata/logic_test/builtin_function
@@ -1341,19 +1341,25 @@ SELECT array_upper(ARRAY[ARRAY[1, 2]], 2)
 ----
 2
 
-query error only 'hex' format is supported for ENCODE
-SELECT ENCODE('abc', 'escape')
-
-query error only 'hex' format is supported for DECODE
-SELECT DECODE('abc', 'escape')
-
-query error invalid UTF-8
+query T
 SELECT ENCODE('\xa7', 'hex')
+----
+a7
 
 query TT
 SELECT ENCODE('abc', 'hex'), DECODE('616263', 'hex')
 ----
 616263 abc
+
+query T
+SELECT ENCODE(e'123\000456', 'escape')
+----
+123\000456
+
+query T
+SELECT DECODE('123\000456', 'escape')::STRING
+----
+\x31323300343536
 
 query T
 SELECT FROM_IP(b'\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xff\xff\x01\x02\x03\x04')


### PR DESCRIPTION
It's become evident that this is an important feature - I know it's a
bit late, but I would really like to cherry-pick this change.

I think the decode version is not as important - this version is
important so that it's possible to migrate a BYTES column to a STRING.

Release note (sql change): Add 'escape' option to the encode builtin.