### PR TITLE
cherrypick-2.0: sql: avoid unnecessary calls to collectSubquerySpans; fix bug

### DIFF
--- a/pkg/sql/parallel_stmts.go
+++ b/pkg/sql/parallel_stmts.go
@@ -292,7 +292,7 @@ func NewSpanBasedDependencyAnalyzer() DependencyAnalyzer {
 
 func (a *spanBasedDependencyAnalyzer) Analyze(params runParams) error {
 	p := params.p.curPlan.plan
-	readSpans, writeSpans, err := collectSpans(params, p)
+	readSpans, writeSpans, err := params.p.curPlan.collectSpans(params)
 	if err != nil {
 		return err
 	}

--- a/pkg/sql/parallel_stmts_test.go
+++ b/pkg/sql/parallel_stmts_test.go
@@ -394,6 +394,11 @@ func TestSpanBasedDependencyAnalyzer(t *testing.T) {
 		{`DELETE FROM bar`, `SELECT * FROM bar`, false},
 		{`DELETE FROM bar`, `SELECT * FROM bar@idx`, false},
 
+		{`DELETE FROM bar`, `WITH a AS (DELETE FROM bar RETURNING v) SELECT EXISTS(SELECT * FROM a) AS e`, false},
+		{`DELETE FROM bar`, `SELECT EXISTS(SELECT * FROM [DELETE FROM bar RETURNING v]) AS e`, false},
+		{`SELECT EXISTS(SELECT * FROM [DELETE FROM foo WHERE k = 1 RETURNING k]) AS e`,
+			`SELECT EXISTS(SELECT * FROM [DELETE FROM bar WHERE k = 1 RETURNING v]) AS e`, true},
+
 		{`INSERT INTO foo VALUES (1)`, `INSERT INTO bar VALUES (1)`, true},
 		{`INSERT INTO foo VALUES (1)`, `INSERT INTO bar SELECT k FROM foo`, false},
 		{`INSERT INTO foo VALUES (1)`, `INSERT INTO bar SELECT f FROM fks`, true},

--- a/pkg/sql/plan.go
+++ b/pkg/sql/plan.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/pkg/errors"
 
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/exec/execbuilder"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/optbuilder"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/xform"
@@ -392,6 +393,22 @@ func (p *planTop) start(params runParams) error {
 // columns retrieves the plan's columns.
 func (p *planTop) columns() sqlbase.ResultColumns {
 	return planColumns(p.plan)
+}
+
+func (p *planTop) collectSpans(params runParams) (readSpans, writeSpans roachpb.Spans, err error) {
+	readSpans, writeSpans, err = collectSpans(params, p.plan)
+	if err != nil {
+		return nil, nil, err
+	}
+	for i := range params.p.curPlan.subqueryPlans {
+		reads, writes, err := collectSpans(params, params.p.curPlan.subqueryPlans[i].plan)
+		if err != nil {
+			return nil, nil, err
+		}
+		readSpans = append(readSpans, reads...)
+		writeSpans = append(writeSpans, writes...)
+	}
+	return readSpans, writeSpans, nil
 }
 
 // startPlan starts the given plan and all its sub-query nodes.

--- a/pkg/sql/plan_spans.go
+++ b/pkg/sql/plan_spans.go
@@ -102,22 +102,13 @@ func collectSpans(params runParams, plan planNode) (reads, writes roachpb.Spans,
 // Where possible, we should try to specialize this analysis like we do with
 // insertNodeWithValuesSpans.
 func editNodeSpans(params runParams, r *editNodeRun) (reads, writes roachpb.Spans, err error) {
-	scanReads, scanWrites, err := collectSpans(params, r.rows)
+	readerReads, readerWrites, err := collectSpans(params, r.rows)
 	if err != nil {
 		return nil, nil, err
 	}
-	if len(scanWrites) > 0 {
-		return nil, nil, errors.Errorf("unexpected scan span writes: %v", scanWrites)
-	}
-
 	writerReads, writerWrites := tableWriterSpans(params, r.tw)
 
-	sqReads, err := collectSubquerySpans(params, r.rows)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	return append(scanReads, append(writerReads, sqReads...)...), writerWrites, nil
+	return append(readerReads, writerReads...), append(readerWrites, writerWrites...), nil
 }
 
 func tableWriterSpans(params runParams, tw tableWriter) (reads, writes roachpb.Spans) {

--- a/pkg/sql/subquery.go
+++ b/pkg/sql/subquery.go
@@ -18,9 +18,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/pkg/errors"
-
-	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
@@ -243,21 +240,6 @@ func (s *subquery) subqueryTupleOrdering() (bool, encoding.Direction) {
 		return true, encoding.Descending
 	}
 	return false, 0
-}
-
-func collectSubquerySpans(params runParams, plan planNode) (roachpb.Spans, error) {
-	var ret roachpb.Spans
-	for i := range params.p.curPlan.subqueryPlans {
-		reads, writes, err := collectSpans(params, params.p.curPlan.subqueryPlans[i].plan)
-		if err != nil {
-			return nil, err
-		}
-		if len(writes) > 0 {
-			return nil, errors.Errorf("unexpected span writes in subquery: %v", writes)
-		}
-		ret = append(ret, reads...)
-	}
-	return ret, nil
 }
 
 // subqueryVisitor replaces tree.Subquery syntax nodes by a


### PR DESCRIPTION
Picks #23363.

cc @cockroachdb/release 