### PR TITLE
sql: fix the batching behavior of UPDATE, especially with RETURNING

### DIFF
--- a/pkg/sql/delete.go
+++ b/pkg/sql/delete.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 )
 
 var deleteNodePool = sync.Pool{
@@ -33,13 +34,14 @@ var deleteNodePool = sync.Pool{
 }
 
 type deleteNode struct {
-	editNodeBase
-	n *tree.Delete
+	source planNode
 
-	tw tableDeleter
+	// columns is set if this DELETE is returning any rows, to be
+	// consumed by a renderNode upstream. This occurs when there is a
+	// RETURNING clause with some scalar expressions.
+	columns sqlbase.ResultColumns
 
-	run        deleteRun
-	autoCommit autoCommitOpt
+	run deleteRun
 }
 
 // deleteNode implements the autoCommitNode interface.
@@ -52,6 +54,12 @@ var _ autoCommitNode = &deleteNode{}
 func (p *planner) Delete(
 	ctx context.Context, n *tree.Delete, desiredTypes []types.T,
 ) (planNode, error) {
+	// UX friendliness safeguard.
+	if n.Where == nil && p.SessionData().SafeUpdates {
+		return nil, pgerror.NewDangerousStatementErrorf("DELETE without WHERE clause")
+	}
+
+	// CTE analysis.
 	resetter, err := p.initWith(ctx, n.With)
 	if err != nil {
 		return nil, err
@@ -60,30 +68,29 @@ func (p *planner) Delete(
 		defer resetter(p)
 	}
 
-	if n.Where == nil && p.SessionData().SafeUpdates {
-		return nil, pgerror.NewDangerousStatementErrorf("DELETE without WHERE clause")
-	}
+	tracing.AnnotateTrace()
 
+	// DELETE FROM xx AS yy - we want to know about xx (tn) because
+	// that's what we get the descriptor with, and yy (alias) because
+	// that's what RETURNING will use.
 	tn, alias, err := p.getAliasedTableName(n.Table)
 	if err != nil {
 		return nil, err
 	}
 
-	en, err := p.makeEditNode(ctx, tn, privilege.DELETE)
+	// Find which table we're working on, check the permissions.
+	desc, err := ResolveExistingObject(ctx, p, tn, true /*required*/, requireTableDesc)
 	if err != nil {
 		return nil, err
 	}
-
-	var requestedCols []sqlbase.ColumnDescriptor
-	if _, retExprs := n.Returning.(*tree.ReturningExprs); retExprs {
-		// TODO(dan): This could be made tighter, just the rows needed for RETURNING
-		// exprs.
-		requestedCols = en.tableDesc.Columns
+	if err := p.CheckPrivilege(ctx, desc, privilege.DELETE); err != nil {
+		return nil, err
 	}
 
+	// Determine what are the foreign key tables that are involved in the deletion.
 	fkTables, err := sqlbase.TablesNeededForFKs(
 		ctx,
-		*en.tableDesc,
+		*desc,
 		sqlbase.CheckDeletes,
 		p.lookupFKTable,
 		p.CheckPrivilege,
@@ -92,172 +99,301 @@ func (p *planner) Delete(
 	if err != nil {
 		return nil, err
 	}
+
+	// rowsNeeded will help determine whether we can use the fast path
+	// in startExec.
+	rowsNeeded := resultsNeeded(n.Returning)
+
+	// Also, rowsNeeded determines which rows of the source we need
+	// in the table deleter.
+	var requestedCols []sqlbase.ColumnDescriptor
+	if rowsNeeded {
+		// Note: in contrast to INSERT and UPDATE which also require the
+		// data if there are CHECK expressions, DELETE does not care about
+		// constraint checking (because the rows are being deleted after
+		// all).
+
+		// TODO(dan): This could be made tighter, just the rows needed for RETURNING
+		// exprs.
+		requestedCols = desc.Columns
+	}
+
+	// Create the table deleter, which does the bulk of the work.
 	rd, err := sqlbase.MakeRowDeleter(
-		p.txn, en.tableDesc, fkTables, requestedCols, sqlbase.CheckFKs, p.EvalContext(), &p.alloc,
+		p.txn, desc, fkTables, requestedCols, sqlbase.CheckFKs, p.EvalContext(), &p.alloc,
 	)
 	if err != nil {
 		return nil, err
 	}
-	tw := tableDeleter{rd: rd, alloc: &p.alloc}
+	td := tableDeleter{rd: rd, alloc: &p.alloc}
 
-	// TODO(knz): Until we split the creation of the node from Start()
-	// for the SelectClause too, we cannot cache this. This is because
-	// this node's initSelect() method both does type checking and also
-	// performs index selection. We cannot perform index selection
-	// properly until the placeholder values are known.
+	tracing.AnnotateTrace()
+
+	// Determine the source for the deletion: the rows that are
+	// read, filtered, limited, ordered, etc, prior to the deletion. One
+	// would think there is only so much one wants to do rows prior to a
+	// deletion, but ORDER BY / LIMIT really determines which rows are
+	// being deleted. Also RETURNING will expose this.
 	rows, err := p.SelectClause(ctx, &tree.SelectClause{
 		Exprs: sqlbase.ColumnsSelectors(rd.FetchCols, true /* forUpdateOrDelete */),
 		From:  &tree.From{Tables: []tree.TableExpr{n.Table}},
 		Where: n.Where,
-	}, n.OrderBy, n.Limit, nil, nil, publicAndNonPublicColumns)
+	}, n.OrderBy, n.Limit, nil /*with*/, nil /*desiredTypes*/, publicAndNonPublicColumns)
 	if err != nil {
 		return nil, err
 	}
 
+	var columns sqlbase.ResultColumns
+	if rowsNeeded {
+		columns = planColumns(rows)
+	}
+
+	// Now make a delete node. We use a pool.
 	dn := deleteNodePool.Get().(*deleteNode)
 	*dn = deleteNode{
-		n:            n,
-		editNodeBase: en,
-		tw:           tw,
+		source:  rows,
+		columns: columns,
+		run: deleteRun{
+			td:         td,
+			rowsNeeded: rowsNeeded,
+		},
 	}
 
-	if err := dn.run.initEditNode(
-		ctx, &dn.editNodeBase, rows, &dn.tw, alias, n.Returning, desiredTypes); err != nil {
-		return nil, err
+	// Finally, handle RETURNING, if any.
+	r, err := p.Returning(ctx, dn, n.Returning, desiredTypes, alias)
+	if err != nil {
+		// We close explicitly here to release the node to the pool.
+		dn.Close(ctx)
 	}
-
-	return dn, nil
+	return r, err
 }
 
 // deleteRun contains the run-time state of deleteNode during local execution.
 type deleteRun struct {
-	// The following fields are populated during Start().
-	editNodeRun
+	td         tableDeleter
+	rowsNeeded bool
 
+	// fastPath indicates whether the delete operation is running to
+	// completion during startExec.
 	fastPath bool
+
+	// rowCount is the total row count if fastPath is set,
+	// or the number of rows in the current batch otherwise.
+	rowCount int
+
+	// done informs a new call to BatchedNext() that the previous call
+	// to BatchedNext() has completed the work already.
+	done bool
+
+	// rows contains the accumulated result rows if rowsNeeded is set.
+	rows *sqlbase.RowContainer
+
+	// autoCommit indicates whether the last KV batch processed by
+	// this delete will also commit the KV txn.
+	autoCommit autoCommitOpt
+
+	// traceKV caches the current KV tracing flag.
+	traceKV bool
 }
 
+// maxDeleteBatchSize is the max number of entries in the KV batch for
+// the delete operation (including secondary index updates, FK
+// cascading updates, etc), before the current KV batch commits.
+const maxDeleteBatchSize = 10000
+
 func (d *deleteNode) startExec(params runParams) error {
-	if err := d.run.startEditNode(params, &d.editNodeBase); err != nil {
-		return err
+	if sqlbase.IsSystemConfigID(d.run.td.tableDesc().GetID()) {
+		// Mark transaction as operating on the system DB.
+		if err := params.p.txn.SetSystemConfigTrigger(); err != nil {
+			return err
+		}
 	}
-	// Check if we can avoid doing a round-trip to read the values and just
-	// "fast-path" skip to deleting the key ranges without reading them first.
-	// TODO(dt): We could probably be smarter when presented with an index-join,
-	// but this goes away anyway once we push-down more of SQL.
-	maybeScan := d.run.rows
-	if sel, ok := maybeScan.(*renderNode); ok {
-		maybeScan = sel.source.plan
-	}
-	if scan, ok := maybeScan.(*scanNode); ok && canDeleteWithoutScan(params.ctx, d.n, scan, &d.tw) {
+
+	// cache traceKV during execution, to avoid re-evaluating it for every row.
+	d.run.traceKV = params.p.ExtendedEvalContext().Tracing.KVTracingEnabled()
+
+	if scan, ok := canDeleteFast(params.ctx, d.source, &d.run); ok {
 		d.run.fastPath = true
 		return d.fastDelete(params, scan)
 	}
 
-	return d.run.tw.init(d.p.txn, params.EvalContext())
+	if d.run.rowsNeeded {
+		d.run.rows = sqlbase.NewRowContainer(
+			params.EvalContext().Mon.MakeBoundAccount(),
+			sqlbase.ColTypeInfoFromResCols(d.columns),
+			maxDeleteBatchSize)
+	}
+	return d.run.td.init(params.p.txn, params.EvalContext())
 }
 
-func (d *deleteNode) Next(params runParams) (bool, error) {
-	if d.run.fastPath {
+// Next is required because batchedPlanNode inherits from planNode, but
+// batchedPlanNode doesn't really provide it. See the explanatory comments
+// in plan_batch.go.
+func (d *deleteNode) Next(params runParams) (bool, error) { panic("not valid") }
+
+// Values is required because batchedPlanNode inherits from planNode, but
+// batchedPlanNode doesn't really provide it. See the explanatory comments
+// in plan_batch.go.
+func (d *deleteNode) Values() tree.Datums { panic("not valid") }
+
+// BatchedNext implements the batchedPlanNode interface.
+func (d *deleteNode) BatchedNext(params runParams) (bool, error) {
+	if d.run.fastPath || d.run.done {
 		return false, nil
 	}
 
-	traceKV := d.p.ExtendedEvalContext().Tracing.KVTracingEnabled()
+	tracing.AnnotateTrace()
 
-	next, err := d.run.rows.Next(params)
-	if !next {
-		if err == nil {
-			if err := params.p.cancelChecker.Check(); err != nil {
+	// Advance one batch. First, clear the current batch.
+	d.run.rowCount = 0
+	if d.run.rows != nil {
+		d.run.rows.Clear(params.ctx)
+	}
+	// Now consume/accumulate the rows for this batch.
+	lastBatch := false
+	for {
+		if err := params.p.cancelChecker.Check(); err != nil {
+			return false, err
+		}
+
+		// Advance one individual row.
+		if next, err := d.source.Next(params); !next {
+			lastBatch = true
+			if err != nil {
 				return false, err
 			}
-			// We're done. Finish the batch.
-			_, err = d.tw.finalize(params.ctx, d.autoCommit, traceKV)
+			break
 		}
-		return false, err
+
+		// Process the write.
+		curSourceRow := d.source.Values()
+		if _, err := d.run.td.row(params.ctx, curSourceRow, d.run.traceKV); err != nil {
+			return false, err
+		}
+
+		// Remember this row for later.
+		if d.run.rows != nil {
+			// If we'll need the data later, save it now.
+			if _, err := d.run.rows.AddRow(params.ctx, curSourceRow); err != nil {
+				return false, err
+			}
+		}
+		d.run.rowCount++
+
+		// Are we done yet with the current batch?
+		if d.run.td.batchSize >= maxDeleteBatchSize {
+			break
+		}
 	}
 
-	rowVals := d.run.rows.Values()
-
-	_, err = d.tw.row(params.ctx, rowVals, traceKV)
-	if err != nil {
-		return false, err
+	if d.run.rowCount > 0 && !lastBatch {
+		// We only run/commit the batch if there were some rows processed
+		// in this batch.
+		if err := d.run.td.rotateBatch(params.ctx); err != nil {
+			return false, err
+		}
 	}
 
-	resultRow, err := d.rh.cookResultRow(rowVals)
-	if err != nil {
-		return false, err
+	if lastBatch {
+		if _, err := d.run.td.finalize(params.ctx, d.run.autoCommit, d.run.traceKV); err != nil {
+			return false, err
+		}
+		// Remember we're done for the next call to BatchedNext().
+		d.run.done = true
 	}
-	d.run.resultRow = resultRow
 
-	return true, nil
+	return d.run.rowCount > 0, nil
 }
 
-func (d *deleteNode) Values() tree.Datums {
-	return d.run.resultRow
-}
+// BatchedCount implements the batchedPlanNode interface.
+func (d *deleteNode) BatchedCount() int { return d.run.rowCount }
+
+// BatchedCount implements the batchedPlanNode interface.
+func (d *deleteNode) BatchedValues(rowIdx int) tree.Datums { return d.run.rows.At(rowIdx) }
 
 func (d *deleteNode) Close(ctx context.Context) {
-	d.run.rows.Close(ctx)
-	d.tw.close(ctx)
+	d.source.Close(ctx)
+	if d.run.rows != nil {
+		d.run.rows.Close(ctx)
+		d.run.rows = nil
+	}
+	d.run.td.close(ctx)
 	*d = deleteNode{}
 	deleteNodePool.Put(d)
 }
 
+// FastPathResults implements the planNodeFastPath interface.
 func (d *deleteNode) FastPathResults() (int, bool) {
-	if d.run.fastPath {
-		return d.rh.rowCount, true
-	}
-	return 0, false
+	return d.run.rowCount, d.run.fastPath
 }
 
-// Determine if the deletion of `rows` can be done without actually scanning them,
-// i.e. if we do not need to know their values for filtering expressions or a
-// RETURNING clause or for updating secondary indexes.
-func canDeleteWithoutScan(
-	ctx context.Context, n *tree.Delete, scan *scanNode, td *tableDeleter,
-) bool {
-	if !td.fastPathAvailable(ctx) {
-		return false
+// canDeleteFast determines if the deletion of `rows` can be done
+// without actually scanning them.
+// This should be called after plan simplification for optimal results.
+func canDeleteFast(ctx context.Context, source planNode, r *deleteRun) (*scanNode, bool) {
+	// Check that there are no secondary indexes, interleaving, FK
+	// references checks, etc., ie. there is no extra work to be done
+	// per row deleted.
+	if !r.td.fastPathAvailable(ctx) {
+		return nil, false
 	}
-	if _, ok := n.Returning.(*tree.ReturningExprs); ok {
-		if log.V(2) {
-			log.Infof(ctx, "delete forced to scan: values required for RETURNING")
-		}
-		return false
+
+	// If the rows are needed (a RETURNING clause), we can't skip them.
+	if r.rowsNeeded {
+		return nil, false
 	}
+
+	// Check whether the source plan is "simple": that it contains no
+	// remaining filtering, limiting, sorting, etc.
+	// TODO(dt): We could probably be smarter when presented with an
+	// index-join, but this goes away anyway once we push-down more of
+	// SQL.
+	maybeScan := source
+	if sel, ok := maybeScan.(*renderNode); ok {
+		// There may be a projection to drop/rename some columns which the
+		// optimizations did not remove at this point. We just ignore that
+		// projection for the purpose of this check.
+		maybeScan = sel.source.plan
+	}
+
+	scan, ok := maybeScan.(*scanNode)
+	if !ok {
+		// Not simple enough. Bail.
+		return nil, false
+	}
+
+	// A scan ought to be simple enough, except when it's not: a scan
+	// may have a remaining filter. We can't be fast over that.
 	if scan.filter != nil {
 		if log.V(2) {
 			log.Infof(ctx, "delete forced to scan: values required for filter (%s)", scan.filter)
 		}
-		return false
+		return nil, false
 	}
-	return true
+
+	return scan, true
 }
 
 // `fastDelete` skips the scan of rows and just deletes the ranges that
-// `rows` would scan. Should only be used if `canDeleteWithoutScan` indicates
+// `scan` would scan. Should only be used if `canDeleteFast` indicates
 // that it is safe to do so.
 func (d *deleteNode) fastDelete(params runParams, scan *scanNode) error {
 	if err := scan.initScan(params); err != nil {
 		return err
 	}
-
-	if err := d.tw.init(params.p.txn, params.EvalContext()); err != nil {
+	if err := d.run.td.init(params.p.txn, params.EvalContext()); err != nil {
 		return err
 	}
 	if err := params.p.cancelChecker.Check(); err != nil {
 		return err
 	}
-	rowCount, err := d.tw.fastDelete(
-		params.ctx, scan, d.autoCommit, params.extendedEvalCtx.Tracing.KVTracingEnabled())
-	if err != nil {
-		return err
-	}
-	d.rh.rowCount += rowCount
-	return nil
+	var err error
+	d.run.rowCount, err = d.run.td.fastDelete(
+		params.ctx, scan, d.run.autoCommit, d.run.traceKV)
+	return err
 }
 
 // enableAutoCommit is part of the autoCommitNode interface.
 func (d *deleteNode) enableAutoCommit() {
-	d.autoCommit = autoCommitEnabled
+	d.run.autoCommit = autoCommitEnabled
 }

--- a/pkg/sql/expand_plan.go
+++ b/pkg/sql/expand_plan.go
@@ -69,7 +69,17 @@ func doExpandPlan(
 		n.run.rows, err = doExpandPlan(ctx, p, noParams, n.run.rows)
 
 	case *deleteNode:
-		n.run.rows, err = doExpandPlan(ctx, p, noParams, n.run.rows)
+		n.source, err = doExpandPlan(ctx, p, noParams, n.source)
+
+	case *rowCountNode:
+		var newPlan planNode
+		newPlan, err = doExpandPlan(ctx, p, noParams, n.source)
+		n.source = newPlan.(batchedPlanNode)
+
+	case *serializeNode:
+		var newPlan planNode
+		newPlan, err = doExpandPlan(ctx, p, noParams, n.source)
+		n.source = newPlan.(batchedPlanNode)
 
 	case *explainDistSQLNode:
 		n.plan, err = doExpandPlan(ctx, p, noParams, n.plan)
@@ -479,7 +489,13 @@ func (p *planner) simplifyOrderings(plan planNode, usefulOrdering sqlbase.Column
 		n.run.rows = p.simplifyOrderings(n.run.rows, nil)
 
 	case *deleteNode:
-		n.run.rows = p.simplifyOrderings(n.run.rows, nil)
+		n.source = p.simplifyOrderings(n.source, nil)
+
+	case *rowCountNode:
+		n.source = p.simplifyOrderings(n.source, nil).(batchedPlanNode)
+
+	case *serializeNode:
+		n.source = p.simplifyOrderings(n.source, nil).(batchedPlanNode)
 
 	case *explainDistSQLNode:
 		n.plan = p.simplifyOrderings(n.plan, nil)

--- a/pkg/sql/expand_plan.go
+++ b/pkg/sql/expand_plan.go
@@ -63,7 +63,7 @@ func doExpandPlan(
 		n.sourcePlan, err = doExpandPlan(ctx, p, noParams, n.sourcePlan)
 
 	case *updateNode:
-		n.run.rows, err = doExpandPlan(ctx, p, noParams, n.run.rows)
+		n.source, err = doExpandPlan(ctx, p, noParams, n.source)
 
 	case *insertNode:
 		n.run.rows, err = doExpandPlan(ctx, p, noParams, n.run.rows)
@@ -483,7 +483,7 @@ func (p *planner) simplifyOrderings(plan planNode, usefulOrdering sqlbase.Column
 		n.sourcePlan = p.simplifyOrderings(n.sourcePlan, nil)
 
 	case *updateNode:
-		n.run.rows = p.simplifyOrderings(n.run.rows, nil)
+		n.source = p.simplifyOrderings(n.source, nil)
 
 	case *insertNode:
 		n.run.rows = p.simplifyOrderings(n.run.rows, nil)

--- a/pkg/sql/logictest/testdata/logic_test/cascade
+++ b/pkg/sql/logictest/testdata/logic_test/cascade
@@ -2736,7 +2736,7 @@ statement ok
 TRUNCATE a, b1, b2, b3, b4;
 
 statement ok
-INSERT INTO a VALUES ('delete_me'), ('untouched');
+INSERT INTO a VALUES ('delete_me'), ('untouched'), ('b2-default'), ('b3-default'), ('b4-default');
 INSERT INTO b1 VALUES ('b1-pk1', 'untouched'), ('b1-pk2', 'untouched');
 INSERT INTO b2 VALUES ('b2-pk1', 'untouched'), ('b2-pk2', 'delete_me');
 INSERT INTO b3 VALUES ('b3-pk1', 'delete_me'), ('b3-pk2', 'untouched');

--- a/pkg/sql/logictest/testdata/logic_test/delete
+++ b/pkg/sql/logictest/testdata/logic_test/delete
@@ -143,13 +143,14 @@ k v
 query TTT colnames
 EXPLAIN DELETE FROM unindexed
 ----
-Tree            Field  Description
-delete          ·      ·
- │              from   unindexed
- └── render     ·      ·
-      └── scan  ·      ·
-·               table  unindexed@primary
-·               spans  ALL
+Tree                 Field  Description
+count                ·      ·
+ └── delete          ·      ·
+      │              from   unindexed
+      └── render     ·      ·
+           └── scan  ·      ·
+·                    table  unindexed@primary
+·                    spans  ALL
 
 query II colnames,rowsort
 SELECT k, v FROM unindexed
@@ -182,13 +183,14 @@ INSERT INTO unindexed VALUES (1, 9), (8, 2), (3, 7), (6, 4)
 query TTT
 EXPLAIN DELETE FROM unindexed WHERE v = 7 ORDER BY v
 ----
-delete          ·      ·
- │              from   unindexed
- └── nosort     ·      ·
-      │         order  +v
-      └── scan  ·      ·
-·               table  unindexed@primary
-·               spans  ALL
+count                ·      ·
+ └── delete          ·      ·
+      │              from   unindexed
+      └── nosort     ·      ·
+           │         order  +v
+           └── scan  ·      ·
+·                    table  unindexed@primary
+·                    spans  ALL
 
 query II
 DELETE FROM unindexed WHERE k > 1 AND v < 7 ORDER BY v DESC RETURNING v,k
@@ -210,13 +212,14 @@ INSERT INTO unindexed VALUES (1, 2), (3, 4), (5, 6), (7, 8)
 query TTT
 EXPLAIN DELETE FROM unindexed WHERE v = 5 LIMIT 10
 ----
-delete               ·      ·
- │                   from   unindexed
- └── limit           ·      ·
-      └── render     ·      ·
-           └── scan  ·      ·
-·                    table  unindexed@primary
-·                    spans  ALL
+count                     ·      ·
+ └── delete               ·      ·
+      │                   from   unindexed
+      └── limit           ·      ·
+           └── render     ·      ·
+                └── scan  ·      ·
+·                         table  unindexed@primary
+·                         spans  ALL
 
 query I
 SELECT COUNT(*) FROM [DELETE FROM unindexed LIMIT 2 RETURNING v]
@@ -236,37 +239,41 @@ SELECT COUNT(*) FROM [DELETE FROM unindexed LIMIT 5 RETURNING v]
 query TTT
 EXPLAIN DELETE FROM indexed WHERE value = 5 LIMIT 10
 ----
-delete               ·      ·
- │                   from   indexed
- └── limit           ·      ·
-      └── render     ·      ·
-           └── scan  ·      ·
-·                    table  indexed@indexed_value_idx
-·                    spans  /5-/6
-·                    limit  10
+count                     ·      ·
+ └── delete               ·      ·
+      │                   from   indexed
+      └── limit           ·      ·
+           └── render     ·      ·
+                └── scan  ·      ·
+·                         table  indexed@indexed_value_idx
+·                         spans  /5-/6
+·                         limit  10
 
 query TTT
 EXPLAIN DELETE FROM indexed LIMIT 10
 ----
-delete               ·      ·
- │                   from   indexed
- └── limit           ·      ·
-      └── render     ·      ·
-           └── scan  ·      ·
-·                    table  indexed@primary
-·                    spans  ALL
-·                    limit  10
+count                     ·      ·
+ └── delete               ·      ·
+      │                   from   indexed
+      └── limit           ·      ·
+           └── render     ·      ·
+                └── scan  ·      ·
+·                         table  indexed@primary
+·                         spans  ALL
+·                         limit  10
 
 query TTT
 EXPLAIN DELETE FROM indexed WHERE value = 5 LIMIT 10 RETURNING id
 ----
-delete                ·      ·
- │                    from   indexed
- └── limit            ·      ·
-      └── index-join  ·      ·
-           ├── scan   ·      ·
-           │          table  indexed@indexed_value_idx
-           │          spans  /5-/6
-           │          limit  10
-           └── scan   ·      ·
-·                     table  indexed@primary
+render                          ·      ·
+ └── run                        ·      ·
+      └── delete                ·      ·
+           │                    from   indexed
+           └── limit            ·      ·
+                └── index-join  ·      ·
+                     ├── scan   ·      ·
+                     │          table  indexed@indexed_value_idx
+                     │          spans  /5-/6
+                     │          limit  10
+                     └── scan   ·      ·
+·                               table  indexed@primary

--- a/pkg/sql/logictest/testdata/logic_test/explain_types
+++ b/pkg/sql/logictest/testdata/logic_test/explain_types
@@ -154,31 +154,33 @@ count                0  count   ·         ·                            ()     
 query TITTTTT
 EXPLAIN (TYPES) UPDATE t SET v = k + 1 WHERE v > 123
 ----
-update          0  update  ·         ·                              ()                           ·
- │              0  ·       table     t                              ·                            ·
- │              0  ·       set       v                              ·                            ·
- └── render     1  render  ·         ·                              (k int, v int, "k + 1" int)  k!=NULL; v!=NULL; key(k)
-      │         1  ·       render 0  (k)[int]                       ·                            ·
-      │         1  ·       render 1  (v)[int]                       ·                            ·
-      │         1  ·       render 2  ((k)[int] + (1)[int])[int]     ·                            ·
-      └── scan  2  scan    ·         ·                              (k int, v int)               k!=NULL; v!=NULL; key(k)
-·               2  ·       table     t@primary                      ·                            ·
-·               2  ·       spans     ALL                            ·                            ·
-·               2  ·       filter    ((v)[int] > (123)[int])[bool]  ·                            ·
+count                0  count   ·         ·                              ()                           ·
+ └── update          1  update  ·         ·                              ()                           ·
+      │              1  ·       table     t                              ·                            ·
+      │              1  ·       set       v                              ·                            ·
+      └── render     2  render  ·         ·                              (k int, v int, "k + 1" int)  k!=NULL; v!=NULL; key(k)
+           │         2  ·       render 0  (k)[int]                       ·                            ·
+           │         2  ·       render 1  (v)[int]                       ·                            ·
+           │         2  ·       render 2  ((k)[int] + (1)[int])[int]     ·                            ·
+           └── scan  3  scan    ·         ·                              (k int, v int)               k!=NULL; v!=NULL; key(k)
+·                    3  ·       table     t@primary                      ·                            ·
+·                    3  ·       spans     ALL                            ·                            ·
+·                    3  ·       filter    ((v)[int] > (123)[int])[bool]  ·                            ·
 
 query TITTTTT
 EXPLAIN (TYPES,NOEXPAND) UPDATE t SET v = k + 1 WHERE v > 123
 ----
-update          0  update  ·         ·                              ()                           ·
- │              0  ·       table     t                              ·                            ·
- │              0  ·       set       v                              ·                            ·
- └── render     1  render  ·         ·                              (k int, v int, "k + 1" int)  ·
-      │         1  ·       render 0  (k)[int]                       ·                            ·
-      │         1  ·       render 1  (v)[int]                       ·                            ·
-      │         1  ·       render 2  ((k)[int] + (1)[int])[int]     ·                            ·
-      └── scan  2  scan    ·         ·                              (k int, v int)               ·
-·               2  ·       table     t@primary                      ·                            ·
-·               2  ·       filter    ((v)[int] > (123)[int])[bool]  ·                            ·
+count                0  count   ·         ·                              ()                           ·
+ └── update          1  update  ·         ·                              ()                           ·
+      │              1  ·       table     t                              ·                            ·
+      │              1  ·       set       v                              ·                            ·
+      └── render     2  render  ·         ·                              (k int, v int, "k + 1" int)  ·
+           │         2  ·       render 0  (k)[int]                       ·                            ·
+           │         2  ·       render 1  (v)[int]                       ·                            ·
+           │         2  ·       render 2  ((k)[int] + (1)[int])[int]     ·                            ·
+           └── scan  3  scan    ·         ·                              (k int, v int)               ·
+·                    3  ·       table     t@primary                      ·                            ·
+·                    3  ·       filter    ((v)[int] > (123)[int])[bool]  ·                            ·
 
 query TITTTTT
 EXPLAIN (TYPES) VALUES (1) UNION VALUES (2)

--- a/pkg/sql/logictest/testdata/logic_test/explain_types
+++ b/pkg/sql/logictest/testdata/logic_test/explain_types
@@ -129,25 +129,27 @@ render                    0  render  ·            ·                           
 query TITTTTT
 EXPLAIN (TYPES,NOEXPAND) DELETE FROM t WHERE v > 1
 ----
-delete          0  delete  ·         ·                            ()              ·
- │              0  ·       from      t                            ·               ·
- └── render     1  render  ·         ·                            (k int)         ·
-      │         1  ·       render 0  (k)[int]                     ·               ·
-      └── scan  2  scan    ·         ·                            (k int, v int)  ·
-·               2  ·       table     t@primary                    ·               ·
-·               2  ·       filter    ((v)[int] > (1)[int])[bool]  ·               ·
+count                0  count   ·         ·                            ()              ·
+ └── delete          1  delete  ·         ·                            ()              ·
+      │              1  ·       from      t                            ·               ·
+      └── render     2  render  ·         ·                            (k int)         ·
+           │         2  ·       render 0  (k)[int]                     ·               ·
+           └── scan  3  scan    ·         ·                            (k int, v int)  ·
+·                    3  ·       table     t@primary                    ·               ·
+·                    3  ·       filter    ((v)[int] > (1)[int])[bool]  ·               ·
 
 query TITTTTT
 EXPLAIN (TYPES) DELETE FROM t WHERE v > 1
 ----
-delete          0  delete  ·         ·                            ()              ·
- │              0  ·       from      t                            ·               ·
- └── render     1  render  ·         ·                            (k int)         k!=NULL; key(k)
-      │         1  ·       render 0  (k)[int]                     ·               ·
-      └── scan  2  scan    ·         ·                            (k int, v int)  k!=NULL; v!=NULL; key(k)
-·               2  ·       table     t@primary                    ·               ·
-·               2  ·       spans     ALL                          ·               ·
-·               2  ·       filter    ((v)[int] > (1)[int])[bool]  ·               ·
+count                0  count   ·         ·                            ()              ·
+ └── delete          1  delete  ·         ·                            ()              ·
+      │              1  ·       from      t                            ·               ·
+      └── render     2  render  ·         ·                            (k int)         k!=NULL; key(k)
+           │         2  ·       render 0  (k)[int]                     ·               ·
+           └── scan  3  scan    ·         ·                            (k int, v int)  k!=NULL; v!=NULL; key(k)
+·                    3  ·       table     t@primary                    ·               ·
+·                    3  ·       spans     ALL                          ·               ·
+·                    3  ·       filter    ((v)[int] > (1)[int])[bool]  ·               ·
 
 query TITTTTT
 EXPLAIN (TYPES) UPDATE t SET v = k + 1 WHERE v > 123

--- a/pkg/sql/logictest/testdata/logic_test/needed_columns
+++ b/pkg/sql/logictest/testdata/logic_test/needed_columns
@@ -141,12 +141,13 @@ insert                   0  insert    ·     ·         ()                      
 query TITTTTT
 EXPLAIN (METADATA) DELETE FROM kv WHERE k = 3
 ----
-delete          0  delete  ·      ·           ()               ·
- │              0  ·       from   kv          ·                ·
- └── render     1  render  ·      ·           (k)              k=CONST; key()
-      └── scan  2  scan    ·      ·           (k, v[omitted])  k=CONST; key()
-·               2  ·       table  kv@primary  ·                ·
-·               2  ·       spans  /3-/3/#     ·                ·
+count                0  count   ·      ·           ()               ·
+ └── delete          1  delete  ·      ·           ()               ·
+      │              1  ·       from   kv          ·                ·
+      └── render     2  render  ·      ·           (k)              k=CONST; key()
+           └── scan  3  scan    ·      ·           (k, v[omitted])  k=CONST; key()
+·                    3  ·       table  kv@primary  ·                ·
+·                    3  ·       spans  /3-/3/#     ·                ·
 
 # Ensure that propagations through a render node removes the renders
 # and properly propagates the remaining needed columns.

--- a/pkg/sql/logictest/testdata/logic_test/order_by
+++ b/pkg/sql/logictest/testdata/logic_test/order_by
@@ -789,13 +789,15 @@ render               0  render  ·      ·          (b)        key()
 query TITTTTT
 EXPLAIN (METADATA) UPDATE t SET c = TRUE RETURNING b
 ----
-update          0  update  ·      ·          (b)                ·
- │              0  ·       table  t          ·                  ·
- │              0  ·       set    c          ·                  ·
- └── render     1  render  ·      ·          (a, b, c, "true")  "true"=CONST; a!=NULL; key(a)
-      └── scan  2  scan    ·      ·          (a, b, c)          a!=NULL; key(a)
-·               2  ·       table  t@primary  ·                  ·
-·               2  ·       spans  ALL        ·                  ·
+render                    0  render  ·      ·          (b)                ·
+ └── run                  1  run     ·      ·          (a, b, c)          ·
+      └── update          2  update  ·      ·          (a, b, c)          ·
+           │              2  ·       table  t          ·                  ·
+           │              2  ·       set    c          ·                  ·
+           └── render     3  render  ·      ·          (a, b, c, "true")  "true"=CONST; a!=NULL; key(a)
+                └── scan  4  scan    ·      ·          (a, b, c)          a!=NULL; key(a)
+·                         4  ·       table  t@primary  ·                  ·
+·                         4  ·       spans  ALL        ·                  ·
 
 statement ok
 CREATE TABLE uvwxyz (

--- a/pkg/sql/logictest/testdata/logic_test/order_by
+++ b/pkg/sql/logictest/testdata/logic_test/order_by
@@ -778,11 +778,13 @@ insert              0  insert    ·     ·        (b)     ·
 query TITTTTT
 EXPLAIN (METADATA) DELETE FROM t WHERE a = 3 RETURNING b
 ----
-delete     0  delete  ·      ·          (b)        ·
- │         0  ·       from   t          ·          ·
- └── scan  1  scan    ·      ·          (a, b, c)  a=CONST; key()
-·          1  ·       table  t@primary  ·          ·
-·          1  ·       spans  /3-/3/#    ·          ·
+render               0  render  ·      ·          (b)        key()
+ └── run             1  run     ·      ·          (a, b, c)  a=CONST; key()
+      └── delete     2  delete  ·      ·          (a, b, c)  a=CONST; key()
+           │         2  ·       from   t          ·          ·
+           └── scan  3  scan    ·      ·          (a, b, c)  a=CONST; key()
+·                    3  ·       table  t@primary  ·          ·
+·                    3  ·       spans  /3-/3/#    ·          ·
 
 query TITTTTT
 EXPLAIN (METADATA) UPDATE t SET c = TRUE RETURNING b

--- a/pkg/sql/logictest/testdata/logic_test/show_trace
+++ b/pkg/sql/logictest/testdata/logic_test/show_trace
@@ -760,13 +760,9 @@ fetched: /ab/primary/2/1 -> NULL
 fetched: /ab/primary/2/2 -> NULL
 fetched: /ab/primary/2/6 -> NULL
 fetched: /ab/primary/3/9 -> NULL
-output row: [4 9]
 fetched: /ab/primary/4/10 -> NULL
-output row: [5 10]
 fetched: /ab/primary/42/51 -> NULL
-output row: [43 51]
 fetched: /ab/primary/43/52 -> NULL
-output row: [44 52]
 
 query T
 SELECT message FROM [SHOW KV TRACE FOR DELETE FROM ab WHERE b > 6]

--- a/pkg/sql/logictest/testdata/logic_test/show_trace
+++ b/pkg/sql/logictest/testdata/logic_test/show_trace
@@ -778,13 +778,9 @@ fetched: /ab/primary/2/1 -> NULL
 fetched: /ab/primary/2/2 -> NULL
 fetched: /ab/primary/2/6 -> NULL
 fetched: /ab/primary/4/9 -> NULL
-output row: [4 9]
 fetched: /ab/primary/5/10 -> NULL
-output row: [5 10]
 fetched: /ab/primary/43/51 -> NULL
-output row: [43 51]
 fetched: /ab/primary/44/52 -> NULL
-output row: [44 52]
 
 query T
 SELECT message FROM [SHOW KV TRACE FOR DELETE FROM ab]

--- a/pkg/sql/logictest/testdata/logic_test/update
+++ b/pkg/sql/logictest/testdata/logic_test/update
@@ -336,44 +336,48 @@ SELECT * from xyz
 query TTT
 EXPLAIN UPDATE xyz SET y = x
 ----
-update     ·      ·
- │         table  xyz
- │         set    y
- └── scan  ·      ·
-·          table  xyz@primary
-·          spans  ALL
+count           ·      ·
+ └── update     ·      ·
+      │         table  xyz
+      │         set    y
+      └── scan  ·      ·
+·               table  xyz@primary
+·               spans  ALL
 
 query TITTTTT
 EXPLAIN (METADATA) UPDATE xyz SET (x, y) = (1, 2)
 ----
-update          0  update  ·      ·            ()                   ·
- │              0  ·       table  xyz          ·                    ·
- │              0  ·       set    x, y         ·                    ·
- └── render     1  render  ·      ·            (x, y, z, "1", "2")  "1"=CONST; "2"=CONST; x!=NULL; key(x)
-      └── scan  2  scan    ·      ·            (x, y, z)            x!=NULL; key(x)
-·               2  ·       table  xyz@primary  ·                    ·
-·               2  ·       spans  ALL          ·                    ·
+count                0  count   ·      ·            ()                   ·
+ └── update          1  update  ·      ·            ()                   ·
+      │              1  ·       table  xyz          ·                    ·
+      │              1  ·       set    x, y         ·                    ·
+      └── render     2  render  ·      ·            (x, y, z, "1", "2")  "1"=CONST; "2"=CONST; x!=NULL; key(x)
+           └── scan  3  scan    ·      ·            (x, y, z)            x!=NULL; key(x)
+·                    3  ·       table  xyz@primary  ·                    ·
+·                    3  ·       spans  ALL          ·                    ·
 
 query TITTTTT
 EXPLAIN (METADATA) UPDATE xyz SET (x, y) = (y, x)
 ----
-update     0  update  ·      ·            ()         ·
- │         0  ·       table  xyz          ·          ·
- │         0  ·       set    x, y         ·          ·
- └── scan  1  scan    ·      ·            (x, y, z)  x!=NULL; key(x)
-·          1  ·       table  xyz@primary  ·          ·
-·          1  ·       spans  ALL          ·          ·
+count           0  count   ·      ·            ()         ·
+ └── update     1  update  ·      ·            ()         ·
+      │         1  ·       table  xyz          ·          ·
+      │         1  ·       set    x, y         ·          ·
+      └── scan  2  scan    ·      ·            (x, y, z)  x!=NULL; key(x)
+·               2  ·       table  xyz@primary  ·          ·
+·               2  ·       spans  ALL          ·          ·
 
 query TITTTTT
 EXPLAIN (METADATA) UPDATE xyz SET (x, y) = (2, 2)
 ----
-update          0  update  ·      ·            ()              ·
- │              0  ·       table  xyz          ·               ·
- │              0  ·       set    x, y         ·               ·
- └── render     1  render  ·      ·            (x, y, z, "2")  "2"=CONST; x!=NULL; key(x)
-      └── scan  2  scan    ·      ·            (x, y, z)       x!=NULL; key(x)
-·               2  ·       table  xyz@primary  ·               ·
-·               2  ·       spans  ALL          ·               ·
+count                0  count   ·      ·            ()              ·
+ └── update          1  update  ·      ·            ()              ·
+      │              1  ·       table  xyz          ·               ·
+      │              1  ·       set    x, y         ·               ·
+      └── render     2  render  ·      ·            (x, y, z, "2")  "2"=CONST; x!=NULL; key(x)
+           └── scan  3  scan    ·      ·            (x, y, z)       x!=NULL; key(x)
+·                    3  ·       table  xyz@primary  ·               ·
+·                    3  ·       spans  ALL          ·               ·
 
 statement ok
 CREATE TABLE lots (
@@ -444,15 +448,16 @@ INSERT INTO kv VALUES (1, 9), (8, 2), (3, 7), (6, 4)
 query TTT
 EXPLAIN UPDATE kv SET v = v + 1 ORDER BY v DESC
 ----
-update               ·      ·
- │                   table  kv
- │                   set    v
- └── render          ·      ·
-      └── sort       ·      ·
-           │         order  -v
-           └── scan  ·      ·
-·                    table  kv@primary
-·                    spans  ALL
+count                     ·      ·
+ └── update               ·      ·
+      │                   table  kv
+      │                   set    v
+      └── render          ·      ·
+           └── sort       ·      ·
+                │         order  -v
+                └── scan  ·      ·
+·                         table  kv@primary
+·                         spans  ALL
 
 query II
 UPDATE kv SET v = v + 1 ORDER BY v DESC RETURNING k,v
@@ -478,15 +483,16 @@ TRUNCATE kv; INSERT INTO kv VALUES (1, 2), (2, 3), (3, 4)
 query TTT
 EXPLAIN UPDATE kv SET v = v - 1 WHERE k < 3 LIMIT 1
 ----
-update               ·      ·
- │                   table  kv
- │                   set    v
- └── render          ·      ·
-      └── limit      ·      ·
-           └── scan  ·      ·
-·                    table  kv@primary
-·                    spans  -/2/#
-·                    limit  1
+count                     ·      ·
+ └── update               ·      ·
+      │                   table  kv
+      │                   set    v
+      └── render          ·      ·
+           └── limit      ·      ·
+                └── scan  ·      ·
+·                         table  kv@primary
+·                         spans  -/2/#
+·                         limit  1
 
 query II
 UPDATE kv SET v = v - 1 WHERE k < 10 ORDER BY k LIMIT 1 RETURNING k, v

--- a/pkg/sql/opt_filters.go
+++ b/pkg/sql/opt_filters.go
@@ -262,9 +262,23 @@ func (p *planner) propagateFilters(
 		}
 
 	case *deleteNode:
-		if n.run.rows, err = p.triggerFilterPropagation(ctx, n.run.rows); err != nil {
+		if n.source, err = p.triggerFilterPropagation(ctx, n.source); err != nil {
 			return plan, extraFilter, err
 		}
+
+	case *rowCountNode:
+		newSource, err := p.triggerFilterPropagation(ctx, n.source)
+		if err != nil {
+			return plan, extraFilter, err
+		}
+		n.source = newSource.(batchedPlanNode)
+
+	case *serializeNode:
+		newSource, err := p.triggerFilterPropagation(ctx, n.source)
+		if err != nil {
+			return plan, extraFilter, err
+		}
+		n.source = newSource.(batchedPlanNode)
 
 	case *insertNode:
 		if n.run.rows, err = p.triggerFilterPropagation(ctx, n.run.rows); err != nil {

--- a/pkg/sql/opt_filters.go
+++ b/pkg/sql/opt_filters.go
@@ -286,7 +286,7 @@ func (p *planner) propagateFilters(
 		}
 
 	case *updateNode:
-		if n.run.rows, err = p.triggerFilterPropagation(ctx, n.run.rows); err != nil {
+		if n.source, err = p.triggerFilterPropagation(ctx, n.source); err != nil {
 			return plan, extraFilter, err
 		}
 

--- a/pkg/sql/opt_limits.go
+++ b/pkg/sql/opt_limits.go
@@ -143,7 +143,7 @@ func (p *planner) applyLimit(plan planNode, numRows int64, soft bool) {
 	case *deleteNode:
 		p.setUnlimited(n.source)
 	case *updateNode:
-		p.setUnlimited(n.run.rows)
+		p.setUnlimited(n.source)
 	case *insertNode:
 		p.setUnlimited(n.run.rows)
 	case *createTableNode:

--- a/pkg/sql/opt_limits.go
+++ b/pkg/sql/opt_limits.go
@@ -136,8 +136,12 @@ func (p *planner) applyLimit(plan planNode, numRows int64, soft bool) {
 			p.applyLimit(n.plan, numRows, soft)
 		}
 
+	case *rowCountNode:
+		p.setUnlimited(n.source)
+	case *serializeNode:
+		p.setUnlimited(n.source)
 	case *deleteNode:
-		p.setUnlimited(n.run.rows)
+		p.setUnlimited(n.source)
 	case *updateNode:
 		p.setUnlimited(n.run.rows)
 	case *insertNode:

--- a/pkg/sql/opt_needed.go
+++ b/pkg/sql/opt_needed.go
@@ -171,10 +171,7 @@ func setNeededColumns(plan planNode, needed []bool) {
 		setNeededColumns(n.source, allColumns(n.source))
 
 	case *updateNode:
-		// TODO(knz): This can be optimized by omitting the columns that
-		// are not part of the primary key, do not participate in
-		// foreign key relations and that are not needed for RETURNING.
-		setNeededColumns(n.run.rows, allColumns(n.run.rows))
+		setNeededColumns(n.source, allColumns(n.source))
 
 	case *insertNode:
 		// TODO(knz): This can be optimized by omitting the columns that

--- a/pkg/sql/opt_needed.go
+++ b/pkg/sql/opt_needed.go
@@ -168,10 +168,7 @@ func setNeededColumns(plan planNode, needed []bool) {
 		setNeededColumns(n.plan, allColumns(n.plan))
 
 	case *deleteNode:
-		// TODO(knz): This can be optimized by omitting the columns that
-		// are not part of the primary key, do not participate in
-		// foreign key relations and that are not needed for RETURNING.
-		setNeededColumns(n.run.rows, allColumns(n.run.rows))
+		setNeededColumns(n.source, allColumns(n.source))
 
 	case *updateNode:
 		// TODO(knz): This can be optimized by omitting the columns that
@@ -190,6 +187,14 @@ func setNeededColumns(plan planNode, needed []bool) {
 
 	case *testingRelocateNode:
 		setNeededColumns(n.rows, allColumns(n.rows))
+
+	case *rowCountNode:
+		// The sub-node is a DELETE, INSERT, UPDATE etc. and will decide which columns it needs.
+		setNeededColumns(n.source, nil)
+
+	case *serializeNode:
+		// The sub-node is a DELETE, INSERT, UPDATE etc. and will decide which columns it needs.
+		setNeededColumns(n.source, nil)
 
 	case *alterIndexNode:
 	case *alterTableNode:

--- a/pkg/sql/plan.go
+++ b/pkg/sql/plan.go
@@ -189,8 +189,10 @@ var _ planNode = &limitNode{}
 var _ planNode = &ordinalityNode{}
 var _ planNode = &testingRelocateNode{}
 var _ planNode = &renderNode{}
+var _ planNode = &rowCountNode{}
 var _ planNode = &scanNode{}
 var _ planNode = &scatterNode{}
+var _ planNode = &serializeNode{}
 var _ planNode = &showRangesNode{}
 var _ planNode = &showFingerprintsNode{}
 var _ planNode = &sortNode{}
@@ -203,11 +205,13 @@ var _ planNode = &windowNode{}
 var _ planNode = &CreateUserNode{}
 var _ planNode = &DropUserNode{}
 
+var _ planNodeFastPath = &CreateUserNode{}
+var _ planNodeFastPath = &DropUserNode{}
 var _ planNodeFastPath = &alterUserSetPasswordNode{}
 var _ planNodeFastPath = &createTableNode{}
-var _ planNodeFastPath = &CreateUserNode{}
 var _ planNodeFastPath = &deleteNode{}
-var _ planNodeFastPath = &DropUserNode{}
+var _ planNodeFastPath = &rowCountNode{}
+var _ planNodeFastPath = &serializeNode{}
 var _ planNodeFastPath = &setZoneConfigNode{}
 
 // planTop is the struct that collects the properties

--- a/pkg/sql/plan_batch.go
+++ b/pkg/sql/plan_batch.go
@@ -1,0 +1,190 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package sql
+
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+)
+
+// batchedPlanNode is an interface that complements planNode to
+// indicate that the local execution behavior operates in batches.
+// The word "complement" here contrasts with "specializes" as follows:
+//
+// - batchedPlanNode specializes planNode for the purpose of logical
+//   planning: a node implementing batchedPlanNode behaves in all
+//   respects like a planNode from the perspective of the various
+//   logical planning transforms.
+//
+// - batchedPlanNode *replaces* planNode for the purpose of local
+//   execution.
+type batchedPlanNode interface {
+	// batchedPlanNode is currently intended for use by data-modifying
+	// statements. These are all sensitive to the auto commit bit, so
+	// ensure the autoCommitNode interface is implemented. This
+	// simplifies the definition of this interface by serializeNode and
+	// rowCountNode below.
+	autoCommitNode
+
+	// batchedPlanNode specializes planNode for the purpose of the recursions
+	// on planNode trees performed during logical planning, so it should "inherit"
+	// planNode. However this interface inheritance does not imply that
+	// batchedPlanNode *specializes* planNode in all respects; as described
+	// in the comment above, it only specializes it for logical planning,
+	// and *replaces* it for the semantics of local execution.
+	//
+	// In particular, nodes implementing batchedPlanNode do not have valid
+	// Next() and Values() methods.
+	//
+	// TODO(knz/andrei): nodes that implement this interface cannot
+	// properly implement planNode's Next() and Values() in the way
+	// required defined by planNode. This violates the principle that no
+	// implementer of a derived interface can change any contract of the
+	// base interfaces - or at least not in ways that can break
+	// unsuspecting clients of the interface.
+	// To fix this wart requires splitting planNode into a planNodeBase
+	// interface, which only supports, say, Close(), and then two
+	// interfaces that extend planNodeBase; namely serializeNode
+	// providing Next/Values and this new interface batchedPlanNode
+	// which provides BatchedNext/BatchedCount/BatchedValues.
+	// See issue https://github.com/cockroachdb/cockroach/issues/23522.
+	planNode
+
+	// BatchedNext() performs one batch of work, returning false
+	// if an error is encountered or if there is no more work to do.
+	// After BatchedNext() returns, BatchedCount() and BatchedValues()
+	// provide access to the rows in the last processed batch.
+	//
+	// Note: Nodes that perform writes (e.g. INSERT) do not complete a
+	// batch and let BatchedNext() return before checking foreign key,
+	// uniqueness and other CHECK constraints. The implementations
+	// execute the KV requests for writing the respective rows (which
+	// implicitly checks for some of the constraints) and otherwise
+	// perform all other checks before making any result observable to
+	// the caller.
+	BatchedNext(params runParams) (bool, error)
+
+	// BatchedCount() returns the number of rows processed in the last
+	// processed batch.
+	BatchedCount() int
+
+	// BatchedValues exposes one of the rows in the last processed
+	// batch, in the range 0 to BatchedCount() exclusive.
+	BatchedValues(rowIdx int) tree.Datums
+}
+
+var _ batchedPlanNode = &deleteNode{}
+
+// serializeNode serializes the results of a batchedPlanNode into a
+// plain planNode interface. In other words, it wraps around
+// batchedPlanNode's Next() method which advances full batches to
+// provide a Next() method that advances row-by-row.
+//
+// The FastPathResults behavior of the source plan, if any, is also
+// preserved.
+type serializeNode struct {
+	source batchedPlanNode
+
+	// fastPath is set to true during startExec if the source plan
+	// was able to use the fast path and provide a row count.
+	fastPath bool
+
+	// rowCount is set either to the total row count if fastPath is true,
+	// or to the row count of the current batch otherwise.
+	rowCount int
+
+	// rowIdx is the index of the current row in the current batch.
+	rowIdx int
+}
+
+func (s *serializeNode) startExec(params runParams) error {
+	if f, ok := s.source.(planNodeFastPath); ok {
+		s.rowCount, s.fastPath = f.FastPathResults()
+	}
+	return nil
+}
+
+func (s *serializeNode) Next(params runParams) (bool, error) {
+	if s.fastPath {
+		return false, nil
+	}
+	if s.rowIdx+1 >= s.rowCount {
+		// First batch, or finished previous batch; advance one.
+		if next, err := s.source.BatchedNext(params); !next {
+			return false, err
+		}
+		s.rowCount = s.source.BatchedCount()
+		s.rowIdx = 0
+	} else {
+		// Advance one position in the current batch.
+		s.rowIdx++
+	}
+	return s.rowCount > 0, nil
+}
+
+func (s *serializeNode) Values() tree.Datums       { return s.source.BatchedValues(s.rowIdx) }
+func (s *serializeNode) Close(ctx context.Context) { s.source.Close(ctx) }
+
+// FastPathResults implements the planNodeFastPath interface.
+func (s *serializeNode) FastPathResults() (int, bool) {
+	return s.rowCount, s.fastPath
+}
+
+// enableAutocommit implements the autoCommitNode interface.
+func (s *serializeNode) enableAutoCommit() { s.source.enableAutoCommit() }
+
+// rowCountNode serializes the results of a batchedPlanNode into a
+// plain planNode interface that has guaranteed FastPathResults
+// behavior and no result columns (i.e. just the count of rows
+// affected).
+// All the batches are consumed in startExec().
+//
+// This is an optimization upon serializeNode when it is known in
+// advance that the result rows will be discarded (e.g.  a
+// data-modifying statement with no RETURNING clause or RETURNING
+// NOTHING). In that case, we do not need to have individual calls to
+// Next() consume the batched rows individually and instead quickly
+// accumulate the batch counts themselves.
+type rowCountNode struct {
+	source   batchedPlanNode
+	rowCount int
+}
+
+func (r *rowCountNode) startExec(params runParams) error {
+	done := false
+	if f, ok := r.source.(planNodeFastPath); ok {
+		r.rowCount, done = f.FastPathResults()
+	}
+	if !done {
+		for {
+			if next, err := r.source.BatchedNext(params); !next {
+				return err
+			}
+			r.rowCount += r.source.BatchedCount()
+		}
+	}
+	return nil
+}
+
+func (r *rowCountNode) Next(params runParams) (bool, error) { return false, nil }
+func (r *rowCountNode) Values() tree.Datums                 { return nil }
+func (r *rowCountNode) Close(ctx context.Context)           { r.source.Close(ctx) }
+
+// FastPathResults implements the planNodeFastPath interface.
+func (r *rowCountNode) FastPathResults() (int, bool) { return r.rowCount, true }
+
+// enableAutocommit implements the autoCommitNode interface.
+func (r *rowCountNode) enableAutoCommit() { r.source.enableAutoCommit() }

--- a/pkg/sql/plan_batch.go
+++ b/pkg/sql/plan_batch.go
@@ -87,6 +87,7 @@ type batchedPlanNode interface {
 }
 
 var _ batchedPlanNode = &deleteNode{}
+var _ batchedPlanNode = &updateNode{}
 
 // serializeNode serializes the results of a batchedPlanNode into a
 // plain planNode interface. In other words, it wraps around

--- a/pkg/sql/plan_columns.go
+++ b/pkg/sql/plan_columns.go
@@ -77,6 +77,8 @@ func getPlanColumns(plan planNode, mut bool) sqlbase.ResultColumns {
 		return n.run.values.columns
 	case *showTraceNode:
 		return n.columns
+	case *deleteNode:
+		return n.columns
 
 	// Nodes with a fixed schema.
 	case *scrubNode:
@@ -101,8 +103,6 @@ func getPlanColumns(plan planNode, mut bool) sqlbase.ResultColumns {
 		return n.getColumns(mut, sequenceSelectColumns)
 
 	// Nodes using the RETURNING helper.
-	case *deleteNode:
-		return n.rh.columns
 	case *insertNode:
 		return n.rh.columns
 	case *updateNode:
@@ -118,6 +118,8 @@ func getPlanColumns(plan planNode, mut bool) sqlbase.ResultColumns {
 		return getPlanColumns(n.table, mut)
 	case *limitNode:
 		return getPlanColumns(n.plan, mut)
+	case *serializeNode:
+		return getPlanColumns(n.source, mut)
 	}
 
 	// Every other node has no columns in their results.

--- a/pkg/sql/plan_columns.go
+++ b/pkg/sql/plan_columns.go
@@ -79,6 +79,8 @@ func getPlanColumns(plan planNode, mut bool) sqlbase.ResultColumns {
 		return n.columns
 	case *deleteNode:
 		return n.columns
+	case *updateNode:
+		return n.columns
 
 	// Nodes with a fixed schema.
 	case *scrubNode:
@@ -104,8 +106,6 @@ func getPlanColumns(plan planNode, mut bool) sqlbase.ResultColumns {
 
 	// Nodes using the RETURNING helper.
 	case *insertNode:
-		return n.rh.columns
-	case *updateNode:
 		return n.rh.columns
 
 	// Nodes that have the same schema as their source or their

--- a/pkg/sql/plan_physical_props.go
+++ b/pkg/sql/plan_physical_props.go
@@ -35,6 +35,12 @@ func planPhysicalProps(plan planNode) physicalProps {
 		return planPhysicalProps(n.plan)
 	case *indexJoinNode:
 		return planPhysicalProps(n.index)
+	case *serializeNode:
+		return planPhysicalProps(n.source)
+	case *deleteNode:
+		if n.run.rowsNeeded {
+			return planPhysicalProps(n.source)
+		}
 
 	case *filterNode:
 		return n.props
@@ -50,8 +56,6 @@ func planPhysicalProps(plan planNode) physicalProps {
 	case *unionNode:
 		// TODO(knz): this can be ordered if the source is ordered already.
 	case *insertNode:
-		// TODO(knz): RETURNING is ordered by the PK.
-	case *deleteNode:
 		// TODO(knz): RETURNING is ordered by the PK.
 	case *updateNode:
 		// TODO(knz): RETURNING is ordered by the PK.

--- a/pkg/sql/plan_physical_props.go
+++ b/pkg/sql/plan_physical_props.go
@@ -58,7 +58,14 @@ func planPhysicalProps(plan planNode) physicalProps {
 	case *insertNode:
 		// TODO(knz): RETURNING is ordered by the PK.
 	case *updateNode:
-		// TODO(knz): RETURNING is ordered by the PK.
+		// After an update, the original order may have been destroyed.
+		// For example, if the PK is updated by a SET expression.
+		// So we can't assume any ordering.
+		//
+		// TODO(knz/radu): this can be refined by an analysis which
+		// determines whether the columns that participate in the ordering
+		// of the source are being updated. If they are not, the source
+		// ordering can be propagated.
 
 	case *scanNode:
 		return n.props

--- a/pkg/sql/plan_spans.go
+++ b/pkg/sql/plan_spans.go
@@ -43,7 +43,7 @@ func collectSpans(params runParams, plan planNode) (reads, writes roachpb.Spans,
 		return n.spans, nil, nil
 
 	case *updateNode:
-		return editNodeSpans(params, n.run.rows, n.run.tw)
+		return editNodeSpans(params, n.source, &n.run.tu)
 	case *insertNode:
 		if v, ok := n.run.editNodeRun.rows.(*valuesNode); ok && !n.isUpsert() {
 			// subqueries, even within valuesNodes, can be arbitrarily complex,

--- a/pkg/sql/returning.go
+++ b/pkg/sql/returning.go
@@ -24,6 +24,55 @@ import (
 	"github.com/pkg/errors"
 )
 
+// resultsNeeded determines whether a statement that might have a
+// RETURNING clause needs to provide values for result rows for a
+// downstream plan.
+func resultsNeeded(r tree.ReturningClause) bool {
+	switch t := r.(type) {
+	case *tree.ReturningExprs:
+		return true
+	case *tree.ReturningNothing, *tree.NoReturningClause:
+		return false
+	default:
+		panic(errors.Errorf("unexpected ReturningClause type: %T", t))
+	}
+}
+
+// Returning wraps the given source node in a way suitable for the
+// given RETURNING specification.
+func (p *planner) Returning(
+	ctx context.Context,
+	source batchedPlanNode,
+	r tree.ReturningClause,
+	desiredTypes []types.T,
+	tn *tree.TableName,
+) (planNode, error) {
+	// serialize the data-modifying plan to ensure that no data is
+	// observed that hasn't been validated first. See the comments
+	// on BatchedNext() in plan_batch.go.
+
+	switch t := r.(type) {
+	case *tree.ReturningNothing, *tree.NoReturningClause:
+		// We could use serializeNode here, but using rowCountNode is an
+		// optimization that saves on calls to Next() by the caller.
+		return &rowCountNode{source: source}, nil
+
+	case *tree.ReturningExprs:
+		serialized := &serializeNode{source: source}
+		info := sqlbase.NewSourceInfoForSingleTable(*tn, planColumns(source))
+		r := &renderNode{
+			source:     planDataSource{info: info, plan: serialized},
+			sourceInfo: sqlbase.MultiSourceInfo{info},
+		}
+		r.ivarHelper = tree.MakeIndexedVarHelper(r, len(r.source.info.SourceColumns))
+		err := p.initTargets(ctx, r, tree.SelectExprs(*t), desiredTypes)
+		return r, err
+
+	default:
+		panic(errors.Errorf("unexpected ReturningClause type: %T", t))
+	}
+}
+
 // returningHelper implements the logic used for statements with RETURNING clauses. It accumulates
 // result rows, one for each call to append().
 type returningHelper struct {

--- a/pkg/sql/update.go
+++ b/pkg/sql/update.go
@@ -35,19 +35,14 @@ var updateNodePool = sync.Pool{
 }
 
 type updateNode struct {
-	// The following fields are populated during makePlan.
-	editNodeBase
-	n             *tree.Update
-	updateCols    []sqlbase.ColumnDescriptor
-	computedCols  []sqlbase.ColumnDescriptor
-	updateColsIdx map[sqlbase.ColumnID]int // index in updateCols slice
-	computeExprs  []tree.TypedExpr
-	tw            tableUpdater
-	checkHelper   *sqlbase.CheckHelper
-	sourceSlots   []sourceSlot
+	source planNode
 
-	run        updateRun
-	autoCommit autoCommitOpt
+	// columns is set if this UPDATE is returning any rows, to be
+	// consumed by a renderNode upstream. This occurs when there is a
+	// RETURNING clause with some scalar expressions.
+	columns sqlbase.ResultColumns
+
+	run updateRun
 }
 
 // updateNode implements the autoCommitNode interface.
@@ -60,9 +55,12 @@ var _ autoCommitNode = &updateNode{}
 func (p *planner) Update(
 	ctx context.Context, n *tree.Update, desiredTypes []types.T,
 ) (planNode, error) {
+	// UX friendliness safeguard.
 	if n.Where == nil && p.SessionData().SafeUpdates {
 		return nil, pgerror.NewDangerousStatementErrorf("UPDATE without WHERE clause")
 	}
+
+	// CTE analysis.
 	resetter, err := p.initWith(ctx, n.With)
 	if err != nil {
 		return nil, err
@@ -73,69 +71,27 @@ func (p *planner) Update(
 
 	tracing.AnnotateTrace()
 
+	// UPDATE xx AS yy - we want to know about xx (tn) because
+	// that's what we get the descriptor with, and yy (alias) because
+	// that's what RETURNING will use.
 	tn, alias, err := p.getAliasedTableName(n.Table)
 	if err != nil {
 		return nil, err
 	}
 
-	en, err := p.makeEditNode(ctx, tn, privilege.UPDATE)
+	// Find which table we're working on, check the permissions.
+	desc, err := ResolveExistingObject(ctx, p, tn, true /*required*/, requireTableDesc)
 	if err != nil {
 		return nil, err
 	}
-
-	setExprs := make([]*tree.UpdateExpr, len(n.Exprs))
-	for i, expr := range n.Exprs {
-		// Analyze the sub-query nodes.
-		newExpr, err := p.analyzeSubqueries(ctx, expr.Expr, len(expr.Names))
-		if err != nil {
-			return nil, err
-		}
-		setExprs[i] = &tree.UpdateExpr{Tuple: expr.Tuple, Expr: newExpr, Names: expr.Names}
-	}
-
-	// Determine which columns we're inserting into.
-	names, err := p.namesForExprs(setExprs)
-	if err != nil {
+	if err := p.CheckPrivilege(ctx, desc, privilege.UPDATE); err != nil {
 		return nil, err
 	}
 
-	updateCols, err := p.processColumns(en.tableDesc, names)
-	if err != nil {
-		return nil, err
-	}
-
-	defaultExprs, err := sqlbase.MakeDefaultExprs(
-		updateCols, &p.txCtx, p.EvalContext())
-	if err != nil {
-		return nil, err
-	}
-
-	// TODO(justin): this is incorrect: we should allow this, but then it should
-	// error unless we both have a VALUES clause and every value being "inserted"
-	// into a computed column is DEFAULT. See #22434.
-	if err := checkHasNoComputedCols(updateCols); err != nil {
-		return nil, err
-	}
-
-	// We update the set of columns being updated into with any computed columns.
-	updateCols, computedCols, computeExprs, err :=
-		ProcessComputedColumns(ctx, updateCols, tn, en.tableDesc, &p.txCtx, p.EvalContext())
-	if err != nil {
-		return nil, err
-	}
-
-	var requestedCols []sqlbase.ColumnDescriptor
-	if _, retExprs := n.Returning.(*tree.ReturningExprs); retExprs || len(en.tableDesc.Checks) > 0 {
-		// TODO(dan): This could be made tighter, just the rows needed for RETURNING
-		// exprs.
-		// TODO(nvanbenschoten): This could be made tighter, just the rows needed for
-		// the CHECK exprs.
-		requestedCols = en.tableDesc.Columns
-	}
-
+	// Determine what are the foreign key tables that are involved in the update.
 	fkTables, err := sqlbase.TablesNeededForFKs(
 		ctx,
-		*en.tableDesc,
+		*desc,
 		sqlbase.CheckUpdates,
 		p.lookupFKTable,
 		p.CheckPrivilege,
@@ -144,9 +100,107 @@ func (p *planner) Update(
 	if err != nil {
 		return nil, err
 	}
+
+	// Pre-perform early subquery analysis and extraction. Usually
+	// this is done by analyzeExpr(), and, in fact, analyzeExpr() is indirectly
+	// called below as well. Why not call analyzeExpr() already?
+	//
+	// The obstacle is that there's a circular dependency here.
+	//
+	// - We can't call analyzeExpr() at this point because the RHS of
+	//   UPDATE SET can contain the special expression "DEFAULT", and
+	//   analyzeExpr() does not work with DEFAULT.
+	//
+	// - The substitution of DEFAULT by the actual default expression
+	//   occurs below (in addOrMergeExpr), but we can't do that yet here
+	//   because we first need to decompose a tuple in the LHS into
+	//   multiple assignments.
+	//
+	// - We can't decompose the tuple in the LHS without validating it
+	//   against the arity of the RHS (to properly reject mismatched
+	//   arities with an error) until subquery analysis has occurred.
+	//
+	// So we need the subquery analysis to be done early and we can't
+	// call analyzeExpr() to do so.
+	//
+	// TODO(knz): arguably we could do the tuple decomposition _before_
+	// the arity check, in this order: decompose tuples, substitute
+	// DEFAULT / run addOrMergeExpr which itself calls analyzeExpr, and
+	// then check the arity. This improvement is left as an exercise for
+	// the reader.
+	setExprs := make([]*tree.UpdateExpr, len(n.Exprs))
+	for i, expr := range n.Exprs {
+		// Analyze subqueries and determine their type.
+		newExpr, err := p.analyzeSubqueries(ctx, expr.Expr, len(expr.Names))
+		if err != nil {
+			return nil, err
+		}
+		setExprs[i] = &tree.UpdateExpr{Tuple: expr.Tuple, Expr: newExpr, Names: expr.Names}
+	}
+
+	// Extract all the LHS column names, and verify that the arity of
+	// the LHS and RHS match when assigning tuples.
+	names, err := p.namesForExprs(setExprs)
+	if err != nil {
+		return nil, err
+	}
+
+	// Extract the column descriptors for the column names listed
+	// in the LHS operands of SET expressions. This also checks
+	// that each column is assigned at most once.
+	updateCols, err := p.processColumns(desc, names)
+	if err != nil {
+		return nil, err
+	}
+
+	// Ensure that the columns being updated are not computed.
+	// We do this check as early as possible to avoid doing
+	// unnecessary work below in case there's an error.
+	// TODO(justin): this is incorrect: we should allow this, but then it should
+	// error unless we both have a VALUES clause and every value being "inserted"
+	// into a computed column is DEFAULT. See #22434.
+	if err := checkHasNoComputedCols(updateCols); err != nil {
+		return nil, err
+	}
+
+	// Extract the pre-analyzed, pre-typed default expressions for all
+	// the updated columns. There are as many defaultExprs as there are
+	// updateCols.
+	defaultExprs, err := sqlbase.MakeDefaultExprs(
+		updateCols, &p.txCtx, p.EvalContext())
+	if err != nil {
+		return nil, err
+	}
+
+	// Extract the computed columns, if any. This extends updateCols with
+	// all the computed columns. The computedCols result is an alias for the suffix
+	// of updateCols that corresponds to computed columns.
+	updateCols, computedCols, computeExprs, err :=
+		ProcessComputedColumns(ctx, updateCols, tn, desc, &p.txCtx, p.EvalContext())
+	if err != nil {
+		return nil, err
+	}
+
+	// rowsNeeded will help determine whether we need to allocate a
+	// rowsContainer.
+	rowsNeeded := resultsNeeded(n.Returning)
+
+	var requestedCols []sqlbase.ColumnDescriptor
+	if rowsNeeded || len(desc.Checks) > 0 {
+		// TODO(dan): This could be made tighter, just the rows needed for RETURNING
+		// exprs.
+		// TODO(nvanbenschoten): This could be made tighter, just the rows needed for
+		// the CHECK exprs.
+		requestedCols = desc.Columns
+	}
+
+	// Create the table updater, which does the bulk of the work.
+	// As a result of MakeRowUpdater, ru.FetchCols include all the
+	// columns in the table descriptor + any columns currently in the
+	// process of being added.
 	ru, err := sqlbase.MakeRowUpdater(
 		p.txn,
-		en.tableDesc,
+		desc,
 		fkTables,
 		updateCols,
 		requestedCols,
@@ -157,12 +211,13 @@ func (p *planner) Update(
 	if err != nil {
 		return nil, err
 	}
-	tw := tableUpdater{ru: ru}
+	tu := tableUpdater{ru: ru}
 
 	tracing.AnnotateTrace()
 
-	// We construct a query containing the columns being updated, and then later merge the values
-	// they are being updated with into that renderNode to ideally reuse some of the queries.
+	// We construct a query containing the columns being updated, and
+	// then later merge the values they are being updated with into that
+	// renderNode to ideally reuse some of the queries.
 	rows, err := p.SelectClause(ctx, &tree.SelectClause{
 		Exprs: sqlbase.ColumnsSelectors(ru.FetchCols, true /* forUpdateOrDelete */),
 		From:  &tree.From{Tables: []tree.TableExpr{n.Table}},
@@ -172,8 +227,13 @@ func (p *planner) Update(
 		return nil, err
 	}
 
-	// This capacity is an overestimate, since subqueries only take up one sourceSlot.
-	sourceSlots := make([]sourceSlot, 0, len(ru.FetchCols))
+	// sourceSlots describes the RHS operands to potential tuple-wise
+	// assignments to the LHS operands. See the comment on
+	// updateRun.sourceSlots for details.
+	//
+	// UPDATE ... SET (a,b) = (...), (c,d) = (...)
+	//                ^^^^^^^^^^(1)  ^^^^^^^^^^(2) len(n.Exprs) == len(sourceSlots)
+	sourceSlots := make([]sourceSlot, 0, len(n.Exprs))
 
 	// currentUpdateIdx is the index of the first column descriptor in updateCols
 	// that is assigned to by the current setExpr.
@@ -192,6 +252,14 @@ func (p *planner) Update(
 		}
 		// The new renderNode is also the new data source for the update.
 		rows = render
+	}
+
+	// Capture the columns of the source, prior to the insertion of
+	// extra renders. This will be the input for RETURNING, if any, and
+	// this must not see the additional renders added below.
+	var columns sqlbase.ResultColumns
+	if rowsNeeded {
+		columns = planColumns(rows)
 	}
 
 	for _, setExpr := range setExprs {
@@ -263,6 +331,8 @@ func (p *planner) Update(
 		}
 	}
 
+	// updateColsIdx inverts the mapping of UpdateCols to FetchCols. See
+	// the explanatory comments in updateRun.
 	updateColsIdx := make(map[sqlbase.ColumnID]int, len(ru.UpdateCols))
 	for i, col := range ru.UpdateCols {
 		updateColsIdx[col.ID] = i
@@ -270,146 +340,325 @@ func (p *planner) Update(
 
 	un := updateNodePool.Get().(*updateNode)
 	*un = updateNode{
-		n:             n,
-		editNodeBase:  en,
-		updateCols:    ru.UpdateCols,
-		computedCols:  computedCols,
-		computeExprs:  computeExprs,
-		updateColsIdx: updateColsIdx,
-		tw:            tw,
-		sourceSlots:   sourceSlots,
-		checkHelper:   fkTables[en.tableDesc.ID].CheckHelper,
+		source:  rows,
+		columns: columns,
+		run: updateRun{
+			tu:           tu,
+			checkHelper:  fkTables[desc.ID].CheckHelper,
+			rowsNeeded:   rowsNeeded,
+			computedCols: computedCols,
+			computeExprs: computeExprs,
+			iVarContainerForComputedCols: rowIndexedVarContainer{
+				curSourceRow: make(tree.Datums, len(ru.FetchCols)),
+				cols:         tu.tableDesc().Columns,
+				mapping:      ru.FetchColIDtoRowIndex,
+			},
+			sourceSlots:   sourceSlots,
+			updateValues:  make(tree.Datums, len(ru.UpdateCols)),
+			updateColsIdx: updateColsIdx,
+		},
 	}
-	if err := un.run.initEditNode(
-		ctx, &un.editNodeBase, rows, &un.tw, alias, n.Returning, desiredTypes); err != nil {
-		return nil, err
+
+	// Finally, handle RETURNING, if any.
+	r, err := p.Returning(ctx, un, n.Returning, desiredTypes, alias)
+	if err != nil {
+		// We close explicitly here to release the node to the pool.
+		un.Close(ctx)
 	}
-	return un, nil
+	return r, err
 }
 
 // updateRun contains the run-time state of updateNode during local execution.
 type updateRun struct {
-	// The following fields are populated during Start().
-	editNodeRun
+	tu          tableUpdater
+	checkHelper *sqlbase.CheckHelper
+	rowsNeeded  bool
+
+	// rowCount is the total row count if fastPath is set,
+	// or the number of rows in the current batch otherwise.
+	rowCount int
+
+	// done informs a new call to BatchedNext() that the previous call to
+	// BatchedNext() has completed the work already.
+	done bool
+
+	// rows contains the accumulated result rows if rowsNeeded is set.
+	rows *sqlbase.RowContainer
+
+	// autoCommit indicates whether the last KV batch processed by
+	// this update will also commit the KV txn.
+	autoCommit autoCommitOpt
+
+	// traceKV caches the current KV tracing flag.
+	traceKV bool
+
+	// computedCols are the columns that need to be (re-)computed as
+	// the result of updating some of the columns in updateCols.
+	computedCols []sqlbase.ColumnDescriptor
+	// computeExprs are the expressions to evaluate to re-compute the
+	// columns in computedCols.
+	computeExprs []tree.TypedExpr
+	// iVarContainerForComputedCols is used as a temporary buffer that
+	// holds the updated values for every column in the source, to
+	// serve as input for indexed vars contained in the computeExprs.
+	iVarContainerForComputedCols rowIndexedVarContainer
+
+	// sourceSlots is the helper that maps RHS expressions to LHS targets.
+	// This is necessary because there may be fewer RHS expressions than
+	// LHS targets. For example, SET (a, b) = (SELECT 1,2) has:
+	// - 2 targets (a, b)
+	// - 1 source slot, the subquery (SELECT 1, 2).
+	// Each call to extractValues() on a sourceSlot will return 1 or more
+	// datums suitable for assignments. In the example above, the
+	// method would return 2 values.
+	sourceSlots []sourceSlot
+
+	// updateValues will hold the new values for every column
+	// mentioned in the LHS of the SET expressions, in the
+	// order specified by those SET expressions (thus potentially
+	// a different order than the source).
+	updateValues tree.Datums
+
+	// During the update, the expressions provided by the source plan
+	// contain the columns that are being assigned in the order
+	// specified by the table descriptor.
+	//
+	// For example, with UPDATE kv SET v=3, k=2, the source plan will
+	// provide the values in the order k, v (assuming this is the order
+	// the columns are defined in kv's descriptor).
+	//
+	// Then during the update, the columns are updated in the order of
+	// the setExprs (or, equivalently, the order of the sourceSlots),
+	// for the example above that would be v, k. The results
+	// are stored in updateValues above.
+	//
+	// Then at the end of the update, the values need to be presented
+	// back to the TableRowUpdater in the order of the table descriptor
+	// again.
+	//
+	// updateVals is the buffer for this 2nd stage.
+	// updateColsIdx maps the order of the 2nd stage into the order of the 3rd stage.
+	// This provides the inverse mapping of sourceSlots.
+	//
+	updateColsIdx map[sqlbase.ColumnID]int
 }
+
+// maxUpdateBatchSize is the max number of entries in the KV batch for
+// the update operation (including secondary index updates, FK
+// cascading updates, etc), before the current KV batch commits.
+const maxUpdateBatchSize = 10000
 
 func (u *updateNode) startExec(params runParams) error {
-	if err := u.run.startEditNode(params, &u.editNodeBase); err != nil {
-		return err
+	if sqlbase.IsSystemConfigID(u.run.tu.tableDesc().GetID()) {
+		// Mark transaction as operating on the system DB.
+		if err := params.p.txn.SetSystemConfigTrigger(); err != nil {
+			return err
+		}
 	}
-	return u.run.tw.init(params.p.txn, params.EvalContext())
+
+	// cache traceKV during execution, to avoid re-evaluating it for every row.
+	u.run.traceKV = params.p.ExtendedEvalContext().Tracing.KVTracingEnabled()
+
+	if u.run.rowsNeeded {
+		u.run.rows = sqlbase.NewRowContainer(
+			params.EvalContext().Mon.MakeBoundAccount(),
+			sqlbase.ColTypeInfoFromResCols(u.columns),
+			maxUpdateBatchSize)
+	}
+	return u.run.tu.init(params.p.txn, params.EvalContext())
 }
 
-func (u *updateNode) Next(params runParams) (bool, error) {
-	next, err := u.run.rows.Next(params)
-	if !next {
-		if err == nil {
-			if err := params.p.cancelChecker.Check(); err != nil {
-				return false, err
-			}
-			// We're done. Finish the batch.
-			_, err = u.tw.finalize(params.ctx, u.autoCommit, params.extendedEvalCtx.Tracing.KVTracingEnabled())
-		}
-		return false, err
+// Next is required because batchedPlanNode inherits from planNode, but
+// batchedPlanNode doesn't really provide it. See the explanatory comments
+// in plan_batch.go.
+func (u *updateNode) Next(params runParams) (bool, error) { panic("not valid") }
+
+// Values is required because batchedPlanNode inherits from planNode, but
+// batchedPlanNode doesn't really provide it. See the explanatory comments
+// in plan_batch.go.
+func (u *updateNode) Values() tree.Datums { panic("not valid") }
+
+// BatchedNext implements the batchedPlanNode interface.
+func (u *updateNode) BatchedNext(params runParams) (bool, error) {
+	if u.run.done {
+		return false, nil
 	}
 
 	tracing.AnnotateTrace()
 
-	entireRow := u.run.rows.Values()
-
-	// Our updated value expressions occur immediately after the plain
-	// columns in the output.
-	oldValues := entireRow[:len(u.tw.ru.FetchCols)]
-
-	updateValues := make(tree.Datums, len(u.tw.ru.UpdateCols))
-	valueIdx := 0
-
-	for _, slot := range u.sourceSlots {
-		for _, value := range slot.extractValues(entireRow) {
-			updateValues[valueIdx] = value
-			valueIdx++
-		}
+	// Advance one batch. First, clear the current batch.
+	u.run.rowCount = 0
+	if u.run.rows != nil {
+		u.run.rows.Clear(params.ctx)
 	}
-
-	if len(u.computeExprs) > 0 {
-		// Evaluate computed columns if necessary.
-		newVals := make(tree.Datums, len(oldValues))
-		copy(newVals, oldValues)
-		for i, col := range u.tw.ru.UpdateCols {
-			newVals[u.tw.ru.FetchColIDtoRowIndex[col.ID]] = updateValues[i]
+	// Now consume/accumulate the rows for this batch.
+	lastBatch := false
+	for {
+		if err := params.p.cancelChecker.Check(); err != nil {
+			return false, err
 		}
 
-		iv := &rowIndexedVarContainer{newVals, u.tableDesc.Columns, u.tw.ru.FetchColIDtoRowIndex}
-		params.EvalContext().IVarContainer = iv
-
-		for i := range u.computedCols {
-			d, err := u.computeExprs[i].Eval(params.EvalContext())
+		// Advance one individual row.
+		if next, err := u.source.Next(params); !next {
+			lastBatch = true
 			if err != nil {
 				return false, err
 			}
-			updateValues[u.updateColsIdx[u.computedCols[i].ID]] = d
+			break
+		}
+
+		// entireRow are the columns from the table, in the order of the
+		// table descriptor. (One per column in u.tw.ru.FetchCols)
+		// And then after all the extra expressions potentially added via
+		// a renderNode for the RHS of the assignments.
+		entireRow := u.source.Values()
+
+		// oldValues is the prefix of entireRow that corresponds to real
+		// stored columns in the table, that is, excluding the RHS assignment
+		// expressions.
+		oldValues := entireRow[:len(u.run.tu.ru.FetchCols)]
+
+		// valueIdx is used in the loop below to map sourceSlots to
+		// entries in updateValues.
+		valueIdx := 0
+
+		// Propagate the values computed for the RHS expressions into
+		// updateValues at the right positions. The positions in
+		// updateValues correspond to the columns named in the LHS
+		// operands for SET.
+		for _, slot := range u.run.sourceSlots {
+			for _, value := range slot.extractValues(entireRow) {
+				u.run.updateValues[valueIdx] = value
+				valueIdx++
+			}
+		}
+
+		// At this point, we have populated updateValues with the result of
+		// computing the RHS for every assignment.
+		//
+
+		if len(u.run.computeExprs) > 0 {
+			// We now need to (re-)compute the computed column values, using
+			// the updated values above as input.
+			//
+			// This needs to happen in the context of a row containing all the
+			// table's columns as if they had been updated already. This is not
+			// yet reflected neither by oldValues (which contain non-updated values)
+			// nor updateValues (which contain only those columns mentioned in the SET LHS).
+			//
+			// So we need to construct a buffer that groups them together.
+			// iVarContainerForComputedCols does this.
+			copy(u.run.iVarContainerForComputedCols.curSourceRow, oldValues)
+			for i, col := range u.run.tu.ru.UpdateCols {
+				u.run.iVarContainerForComputedCols.curSourceRow[u.run.tu.ru.FetchColIDtoRowIndex[col.ID]] = u.run.updateValues[i]
+			}
+
+			// Now (re-)compute the computed columns.
+			// Note that it's safe to do this in any order, because we currently
+			// prevent computed columns from depending on other computed columns.
+			params.EvalContext().IVarContainer = &u.run.iVarContainerForComputedCols
+			for i := range u.run.computedCols {
+				d, err := u.run.computeExprs[i].Eval(params.EvalContext())
+				if err != nil {
+					params.EvalContext().IVarContainer = nil
+					return false, err
+				}
+				u.run.updateValues[u.run.updateColsIdx[u.run.computedCols[i].ID]] = d
+			}
+			params.EvalContext().IVarContainer = nil
+		}
+
+		// TODO(justin): we have actually constructed the whole row at this point and
+		// thus should be able to avoid loading it separately like this now.
+		if err := u.run.checkHelper.LoadRow(
+			u.run.tu.ru.FetchColIDtoRowIndex, oldValues, false); err != nil {
+			return false, err
+		}
+		if err := u.run.checkHelper.LoadRow(
+			u.run.updateColsIdx, u.run.updateValues, true); err != nil {
+			return false, err
+		}
+		if err := u.run.checkHelper.Check(params.EvalContext()); err != nil {
+			return false, err
+		}
+
+		// Ensure that the values honor the specified column widths.
+		for i := range u.run.updateValues {
+			if err := sqlbase.CheckValueWidth(
+				u.run.tu.ru.UpdateCols[i].Type,
+				u.run.updateValues[i],
+				u.run.tu.ru.UpdateCols[i].Name,
+			); err != nil {
+				return false, err
+			}
+		}
+
+		for i, col := range u.run.tu.ru.UpdateCols {
+			val := u.run.updateValues[i]
+			if !col.Nullable && val == tree.DNull {
+				return false, sqlbase.NewNonNullViolationError(col.Name)
+			}
+		}
+
+		// Update the row values.
+		newValues, err := u.run.tu.row2(params.ctx, oldValues, u.run.updateValues, u.run.traceKV)
+		if err != nil {
+			return false, err
+		}
+
+		// Remember this row for later.
+		if u.run.rows != nil {
+			if _, err := u.run.rows.AddRow(params.ctx, newValues); err != nil {
+				return false, err
+			}
+		}
+		u.run.rowCount++
+
+		// Are we done yet with the current batch?
+		if u.run.tu.batchSize >= maxUpdateBatchSize {
+			break
 		}
 	}
 
-	params.EvalContext().IVarContainer = nil
-
-	// TODO(justin): we have actually constructed the whole row at this point and
-	// thus should be able to avoid loading it separately like this now.
-	if err := u.checkHelper.LoadRow(u.tw.ru.FetchColIDtoRowIndex, oldValues, false); err != nil {
-		return false, err
-	}
-	if err := u.checkHelper.LoadRow(u.updateColsIdx, updateValues, true); err != nil {
-		return false, err
-	}
-	if err := u.checkHelper.Check(params.EvalContext()); err != nil {
-		return false, err
-	}
-
-	// Ensure that the values honor the specified column widths.
-	for i := range updateValues {
-		if err := sqlbase.CheckValueWidth(u.tw.ru.UpdateCols[i].Type, updateValues[i], u.tw.ru.UpdateCols[i].Name); err != nil {
+	if u.run.rowCount > 0 && !lastBatch {
+		// We only run/commit the batch if there were some rows processed
+		// in this batch.
+		if err := u.run.tu.rotateBatch(params.ctx); err != nil {
 			return false, err
 		}
 	}
 
-	for i, col := range u.tw.ru.UpdateCols {
-		val := updateValues[i]
-		if !col.Nullable && val == tree.DNull {
-			return false, sqlbase.NewNonNullViolationError(col.Name)
+	if lastBatch {
+		if _, err := u.run.tu.finalize(params.ctx, u.run.autoCommit, u.run.traceKV); err != nil {
+			return false, err
 		}
+		// Remember we're done for the next call to BatchedNext().
+		u.run.done = true
 	}
 
-	// Update the row values.
-	newValues, err := u.tw.row(
-		params.ctx, append(oldValues, updateValues...), params.p.extendedEvalCtx.Tracing.KVTracingEnabled(),
-	)
-	if err != nil {
-		return false, err
-	}
-
-	resultRow, err := u.rh.cookResultRow(newValues)
-	if err != nil {
-		return false, err
-	}
-	u.run.resultRow = resultRow
-
-	return true, nil
+	return u.run.rowCount > 0, nil
 }
 
-func (u *updateNode) Values() tree.Datums {
-	return u.run.resultRow
-}
+// BatchedCount implements the batchedPlanNode interface.
+func (u *updateNode) BatchedCount() int { return u.run.rowCount }
+
+// BatchedCount implements the batchedPlanNode interface.
+func (u *updateNode) BatchedValues(rowIdx int) tree.Datums { return u.run.rows.At(rowIdx) }
 
 func (u *updateNode) Close(ctx context.Context) {
-	u.run.rows.Close(ctx)
-	u.tw.close(ctx)
+	u.source.Close(ctx)
+	if u.run.rows != nil {
+		u.run.rows.Close(ctx)
+		u.run.rows = nil
+	}
+	u.run.tu.close(ctx)
 	*u = updateNode{}
 	updateNodePool.Put(u)
 }
 
-// enableAutoCommit is part of the autoCommitNode interface.
+// enableAutoCommit implements the autoCommitNode interface.
 func (u *updateNode) enableAutoCommit() {
-	u.autoCommit = autoCommitEnabled
+	u.run.autoCommit = autoCommitEnabled
 }
 
 // editNode (Base, Run) is shared between all row updating

--- a/pkg/sql/walk.go
+++ b/pkg/sql/walk.go
@@ -385,10 +385,10 @@ func (v *planVisitor) visit(plan planNode) {
 
 	case *updateNode:
 		if v.observer.attr != nil {
-			v.observer.attr(name, "table", n.tableDesc.Name)
-			if len(n.tw.ru.UpdateCols) > 0 {
+			v.observer.attr(name, "table", n.run.tu.tableDesc().Name)
+			if len(n.run.tu.ru.UpdateCols) > 0 {
 				var buf bytes.Buffer
-				for i, col := range n.tw.ru.UpdateCols {
+				for i, col := range n.run.tu.ru.UpdateCols {
 					if i > 0 {
 						buf.WriteString(", ")
 					}
@@ -398,14 +398,15 @@ func (v *planVisitor) visit(plan planNode) {
 			}
 		}
 		if v.observer.expr != nil {
-			for i, rexpr := range n.rh.exprs {
-				v.expr(name, "returning", i, rexpr)
+			for i, cexpr := range n.run.computeExprs {
+				v.expr(name, "computed", i, cexpr)
 			}
-			n.tw.walkExprs(func(d string, i int, e tree.TypedExpr) {
-				v.expr(name, d, i, e)
-			})
+			for i, cexpr := range n.run.checkHelper.Exprs {
+				v.expr(name, "check", i, cexpr)
+			}
 		}
-		v.visit(n.run.rows)
+		// An updater has no sub-expressions, so nothing special to do here.
+		v.visit(n.source)
 
 	case *deleteNode:
 		if v.observer.attr != nil {

--- a/pkg/sql/walk.go
+++ b/pkg/sql/walk.go
@@ -409,17 +409,16 @@ func (v *planVisitor) visit(plan planNode) {
 
 	case *deleteNode:
 		if v.observer.attr != nil {
-			v.observer.attr(name, "from", n.tableDesc.Name)
+			v.observer.attr(name, "from", n.run.td.tableDesc().Name)
 		}
-		if v.observer.expr != nil {
-			for i, rexpr := range n.rh.exprs {
-				v.expr(name, "returning", i, rexpr)
-			}
-			n.tw.walkExprs(func(d string, i int, e tree.TypedExpr) {
-				v.expr(name, d, i, e)
-			})
-		}
-		v.visit(n.run.rows)
+		// A deleter has no sub-expressions, so nothing special to do here.
+		v.visit(n.source)
+
+	case *serializeNode:
+		v.visit(n.source)
+
+	case *rowCountNode:
+		v.visit(n.source)
 
 	case *createTableNode:
 		if n.n.As() {
@@ -560,10 +559,12 @@ var planNodeNames = map[reflect.Type]string{
 	reflect.TypeOf(&ordinalityNode{}):           "ordinality",
 	reflect.TypeOf(&testingRelocateNode{}):      "testingRelocate",
 	reflect.TypeOf(&renderNode{}):               "render",
+	reflect.TypeOf(&rowCountNode{}):             "count",
 	reflect.TypeOf(&scanNode{}):                 "scan",
 	reflect.TypeOf(&scatterNode{}):              "scatter",
 	reflect.TypeOf(&scrubNode{}):                "scrub",
 	reflect.TypeOf(&sequenceSelectNode{}):       "sequence select",
+	reflect.TypeOf(&serializeNode{}):            "run",
 	reflect.TypeOf(&setVarNode{}):               "set",
 	reflect.TypeOf(&setClusterSettingNode{}):    "set cluster setting",
 	reflect.TypeOf(&setZoneConfigNode{}):        "configure zone",


### PR DESCRIPTION
First commit from #23373.

This patch applies the new pattern introduced by DELETE in the
previous patch and introduces proper batching behavior for UPDATE.

Release note (bug fix): Removed a limitation where `UPDATE` would fail
if the number of modified rows was too large.

Release note (bug fix): Fixed a bug where `SELECT * FROM [UPDATE
... RETURNING ...] LIMIT 1` or `WITH d AS (UPDATE ... RETURNING ...)
SELECT * FROM d LIMIT 1` would fail to properly update some rows.

Release note (sql change): The EXPLAIN output for UPDATE statements
now also report the default and check expressions, for consistency
with INSERT.