### PR TITLE
sql: unwrap types to check if array can be cast

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/array
+++ b/pkg/sql/logictest/testdata/logic_test/array
@@ -153,6 +153,9 @@ SELECT ARRAY[1,2,3]::TEXT[]
 ----
 {"1","2","3"}
 
+statement error invalid cast: int\[\] -> INT2VECTOR
+SELECT ARRAY[1,2,3]::INT2VECTOR
+
 # array subscript access
 
 query T

--- a/pkg/sql/sem/tree/type_check.go
+++ b/pkg/sql/sem/tree/type_check.go
@@ -266,6 +266,8 @@ func (expr *CaseExpr) TypeCheck(ctx *SemaContext, desired types.T) (TypedExpr, e
 }
 
 func isCastDeepValid(castFrom, castTo types.T) bool {
+	castFrom = types.UnwrapType(castFrom)
+	castTo = types.UnwrapType(castTo)
 	if castTo.FamilyEqual(types.FamArray) && castFrom.FamilyEqual(types.FamArray) {
 		return isCastDeepValid(castFrom.(types.TArray).Typ, castTo.(types.TArray).Typ)
 	}


### PR DESCRIPTION
Fixes #23529.

Release note (bug fix): Fixed a panic that could occur with certain
types of casts.