### PR TITLE
cherrypick-2.0: settings/cluster: Introduce 2.0 cluster version

### DIFF
--- a/pkg/acceptance/version_upgrade_test.go
+++ b/pkg/acceptance/version_upgrade_test.go
@@ -192,6 +192,7 @@ func testVersionUpgrade(ctx context.Context, t *testing.T, cfg cluster.TestConfi
 		clusterVersionUpgrade("1.1"),
 		binaryVersionUpgrade(sourceVersion),
 		clusterVersionUpgrade("1.1-6"),
+		clusterVersionUpgrade("2.0"),
 		clusterVersionUpgrade(clusterversion.BinaryServerVersion.String()),
 	}
 

--- a/pkg/server/updates_test.go
+++ b/pkg/server/updates_test.go
@@ -390,7 +390,7 @@ func TestReportUsage(t *testing.T) {
 		"diagnostics.reporting.send_crash_reports": "false",
 		"server.time_until_store_dead":             "20s",
 		"trace.debug.enable":                       "false",
-		"version":                                  "1.1-15",
+		"version":                                  "2.0",
 		"cluster.secret":                           "<non-default>",
 	} {
 		if got, ok := r.last.AlteredSettings[key]; !ok {

--- a/pkg/server/version_cluster_test.go
+++ b/pkg/server/version_cluster_test.go
@@ -126,16 +126,16 @@ func setupMixedCluster(
 	return twh
 }
 
-func TestClusterVersionUpgrade1_0To1_2(t *testing.T) {
+func TestClusterVersionUpgrade1_0To2_0(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	ctx := context.Background()
 
 	dir, finish := testutils.TempDir(t)
 	defer finish()
 
-	// Four nodes that are all compatible with 1.0, but are really 1.2. This is
-	// what the official v1.2 binary will look like.
-	versions := [][2]string{{"1.0", "1.2"}, {"1.0", "1.2"}, {"1.0", "1.2"}, {"1.0", "1.2"}}
+	// Four nodes that are all compatible with 1.0, but are really 2.0. This is
+	// what the official v2.0 binary will look like.
+	versions := [][2]string{{"1.0", "2.0"}, {"1.0", "2.0"}, {"1.0", "2.0"}, {"1.0", "2.0"}}
 
 	// Start by running 1.0.
 	bootstrapVersion := cluster.ClusterVersion{
@@ -161,7 +161,7 @@ func TestClusterVersionUpgrade1_0To1_2(t *testing.T) {
 
 	// Put some legacy tombstones down. We're going to test the migration for
 	// removing those in the negative: the tombstones are to be removed only after
-	// a node at *cluster version* v1.2 boots up. We don't restart nodes in this
+	// a node at *cluster version* v2.0 boots up. We don't restart nodes in this
 	// test while the versions are bumped, so the only boot is at the initial
 	// version v1.0, and we verify that the tombstones remain. The rewrite
 	// functionality is tested in TestStoreInitAndBootstrap.

--- a/pkg/settings/cluster/cockroach_versions.go
+++ b/pkg/settings/cluster/cockroach_versions.go
@@ -47,6 +47,7 @@ const (
 	VersionReadUncommittedRangeLookups
 	VersionPerReplicaZoneConstraints
 	VersionLeasePreferences
+	Version2_0
 
 	// Add new versions here (step one of two).
 
@@ -181,6 +182,11 @@ var versionsSingleton = keyedVersions([]keyedVersion{
 		// VersionLeasePreferences is https://github.com/cockroachdb/cockroach/pull/23202.
 		Key:     VersionLeasePreferences,
 		Version: roachpb.Version{Major: 1, Minor: 1, Unstable: 15},
+	},
+	{
+		// Version2_0 is CockroachDB v2.0. It's used for all v2.0.x patch releases.
+		Key:     Version2_0,
+		Version: roachpb.Version{Major: 2, Minor: 0},
 	},
 
 	// Add new versions here (step two of two).

--- a/pkg/sql/logictest/testdata/logic_test/crdb_internal
+++ b/pkg/sql/logictest/testdata/logic_test/crdb_internal
@@ -241,7 +241,7 @@ select crdb_internal.set_vmodule('')
 query T
 select crdb_internal.node_executable_version()
 ----
-1.1-15
+2.0
 
 query ITTT colnames
 select node_id, component, field, regexp_replace(regexp_replace(value, '^\d+$', '<port>'), e':\\d+', ':<port>') as value from crdb_internal.node_runtime_info
@@ -323,4 +323,4 @@ select * from crdb_internal.kv_store_status
 query T
 select crdb_internal.node_executable_version()
 ----
-1.1-15
+2.0


### PR DESCRIPTION
This will be the cluster version used for the 2.0 release.

Fixes #21470

Release note: None