### PR TITLE
workloadccl: restore fixture tables in parallel

### DIFF
--- a/pkg/cmd/workload/fixtures.go
+++ b/pkg/cmd/workload/fixtures.go
@@ -232,8 +232,5 @@ func fixturesLoad(gen workload.Generator, urls []string, dbName string) error {
 	if err := workloadccl.RestoreFixture(ctx, sqlDB, fixture, dbName); err != nil {
 		return errors.Wrap(err, `restoring fixture`)
 	}
-	for _, table := range fixture.Tables {
-		log.Infof(ctx, `loaded %s`, table.BackupURI)
-	}
 	return nil
 }


### PR DESCRIPTION
This should speed up `./workload fixture load`, especially when we're
seeing the long-tail behavior described in #23509.

Release note: None