### PR TITLE
opt/exec: add primitive for simple projections

### DIFF
--- a/pkg/sql/opt/exec/factory.go
+++ b/pkg/sql/opt/exec/factory.go
@@ -46,9 +46,15 @@ type Factory interface {
 	// the given input node.
 	ConstructFilter(n Node, filter tree.TypedExpr) (Node, error)
 
-	// ConstructProject returns a node that applies a projection on the results of
-	// the given input node.
-	ConstructProject(n Node, exprs tree.TypedExprs, colNames []string) (Node, error)
+	// ConstructSimpleProject returns a node that applies a "simple" projection on the
+	// results of the given input node. A simple projection is one that does not
+	// involve new expressions; it's just a reshuffling of columns. This is a
+	// more efficient version of ConstructRender.
+	ConstructSimpleProject(n Node, cols []int, colNames []string) (Node, error)
+
+	// ConstructRender returns a node that applies a projection on the results of
+	// the given input node. The projection can contain new expressions.
+	ConstructRender(n Node, exprs tree.TypedExprs, colNames []string) (Node, error)
 
 	// ConstructJoin returns a node that runs a hash-join between the results
 	// of two input nodes. The expression can refer to columns from both inputs

--- a/pkg/sql/opt_exec_engine.go
+++ b/pkg/sql/opt_exec_engine.go
@@ -176,8 +176,45 @@ func (ee *execEngine) ConstructFilter(n exec.Node, filter tree.TypedExpr) (exec.
 	return f, nil
 }
 
-// ConstructProject is part of the exec.Factory interface.
-func (ee *execEngine) ConstructProject(
+// ConstructSimpleProject is part of the exec.Factory interface.
+func (ee *execEngine) ConstructSimpleProject(
+	n exec.Node, cols []int, colNames []string,
+) (exec.Node, error) {
+	// Check if this is the identity projection, in which case we only need to
+	// rename columns.
+	inputCols := planColumns(n.(planNode))
+	if len(cols) == len(inputCols) {
+		identity := true
+		for i := range cols {
+			if cols[i] != i {
+				identity = false
+				break
+			}
+		}
+		if identity {
+			renameColumns(n, colNames)
+			return n, nil
+		}
+	}
+
+	src := asDataSource(n)
+	r := &renderNode{
+		source:     src,
+		sourceInfo: sqlbase.MultiSourceInfo{src.info},
+		render:     make([]tree.TypedExpr, len(cols)),
+		columns:    make([]sqlbase.ResultColumn, len(cols)),
+	}
+	r.ivarHelper = tree.MakeIndexedVarHelper(r, len(src.info.SourceColumns))
+	for i := range cols {
+		v := r.ivarHelper.IndexedVar(cols[i])
+		r.render[i] = v
+		r.columns[i] = sqlbase.ResultColumn{Name: colNames[i], Typ: v.ResolvedType()}
+	}
+	return r, nil
+}
+
+// ConstructRender is part of the exec.Factory interface.
+func (ee *execEngine) ConstructRender(
 	n exec.Node, exprs tree.TypedExprs, colNames []string,
 ) (exec.Node, error) {
 	// Check if this is the identity projection, in which case we only need to
@@ -192,10 +229,7 @@ func (ee *execEngine) ConstructProject(
 			}
 		}
 		if identity {
-			inputCols = planMutableColumns(n.(planNode))
-			for i := range inputCols {
-				inputCols[i].Name = colNames[i]
-			}
+			renameColumns(n, colNames)
 			return n, nil
 		}
 	}
@@ -204,16 +238,23 @@ func (ee *execEngine) ConstructProject(
 	r := &renderNode{
 		source:     src,
 		sourceInfo: sqlbase.MultiSourceInfo{src.info},
+		render:     make([]tree.TypedExpr, len(exprs)),
+		columns:    make([]sqlbase.ResultColumn, len(exprs)),
 	}
 	r.ivarHelper = tree.MakeIndexedVarHelper(r, len(src.info.SourceColumns))
 	for i, expr := range exprs {
 		expr = r.ivarHelper.Rebind(expr, false /* alsoReset */, true /* normalizeToNonNil */)
-		col := sqlbase.ResultColumn{Name: colNames[i], Typ: expr.ResolvedType()}
-		// We don't need to pass the render string, it is only used
-		// in planning code.
-		r.addRenderColumn(expr, "" /* exprStr */, col)
+		r.render[i] = expr
+		r.columns[i] = sqlbase.ResultColumn{Name: colNames[i], Typ: expr.ResolvedType()}
 	}
 	return r, nil
+}
+
+func renameColumns(n exec.Node, colNames []string) {
+	inputCols := planMutableColumns(n.(planNode))
+	for i := range inputCols {
+		inputCols[i].Name = colNames[i]
+	}
 }
 
 // ConstructJoin is part of the exec.Factory interface.


### PR DESCRIPTION
Rename `ConstructProject` to `ConstructRender` and add a
`ConstructSimpleProject` primitive for the special (but common) case
where all the expressions are variables.

Release note: None