### PR TITLE
server: Serve the /health endpoint before the node is initialized

### DIFF
--- a/pkg/server/servemode.go
+++ b/pkg/server/servemode.go
@@ -43,6 +43,7 @@ func (s *Server) Intercept() func(string) error {
 		"/cockroach.rpc.Heartbeat/Ping":             {},
 		"/cockroach.gossip.Gossip/Gossip":           {},
 		"/cockroach.server.serverpb.Init/Bootstrap": {},
+		"/cockroach.server.serverpb.Status/Details": {},
 	}
 	return func(fullName string) error {
 		if s.serveMode.operational() {


### PR DESCRIPTION
This is needed to make the /health endpoint usable by systems like
Kubernetes that need to verify node liveness independently of whether
the node is a successful member of the cluster yet.

It's worth noting that we could also just rely on TCP health checks if
we don't want to rely on this, but leaving it as is makes it tougher to
advertise the /health endpoint for other uses as well.

Touches #22468

Release note (bug fix): The /health HTTP endpoint is now accessible
before a node has successfully become part of an initialized cluster,
meaning that it now accurately reflects the health of the process rather
than the ability of the process to serve queries. This has been the
intention all along, but it didn't work until the node had joined a
cluster or had `cockroach init` run on it.

--------------

This is just pretty naive code movement to make things work. All other grpc endpoints still return a 404 due to the servemode `Interceptor`, so I think this is safe, but a close look would be appreciated since `server.Start` is a beast of a function.