### PR TITLE
opt/optbuilder: support ORDER BY in the optbuilder

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/optimizer
+++ b/pkg/sql/logictest/testdata/logic_test/optimizer
@@ -18,7 +18,7 @@ query II
 3  30
 
 # Select
-query error pq: ORDER BY only supports simple column references at this time
+query error pq: building execution for non-relational operator sort
 SELECT * FROM test.t ORDER BY t.k+1
 
 # SelectClause

--- a/pkg/sql/opt/exec/execbuilder/builder.go
+++ b/pkg/sql/opt/exec/execbuilder/builder.go
@@ -15,11 +15,10 @@
 package execbuilder
 
 import (
-	"fmt"
-
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/exec"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/xform"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/pkg/errors"
 )
 
 // Builder constructs a tree of execution nodes (exec.Node) from an optimized
@@ -44,7 +43,7 @@ func (b *Builder) Build() (exec.Node, error) {
 
 func (b *Builder) build(ev xform.ExprView) (exec.Node, error) {
 	if !ev.IsRelational() {
-		panic(fmt.Sprintf("building execution for non-relational operator %s", ev.Operator()))
+		return nil, errors.Errorf("building execution for non-relational operator %s", ev.Operator())
 	}
 	plan, err := b.buildRelational(ev)
 	if err != nil {

--- a/pkg/sql/opt/optbuilder/builder.go
+++ b/pkg/sql/opt/optbuilder/builder.go
@@ -133,12 +133,10 @@ func errorf(format string, a ...interface{}) builderError {
 // buildPhysicalProps construct a set of required physical properties from the
 // given scope.
 func (b *Builder) buildPhysicalProps(scope *scope) *opt.PhysicalProps {
-	presentation := make(opt.Presentation, len(scope.cols))
-	for i := range scope.cols {
-		col := &scope.cols[i]
-		presentation[i] = opt.LabeledColumn{Label: string(col.name), Index: col.index}
+	if scope.presentation == nil {
+		scope.presentation = makePresentation(scope.cols)
 	}
-	return &opt.PhysicalProps{Presentation: presentation, Ordering: scope.ordering}
+	return &opt.PhysicalProps{Presentation: scope.presentation, Ordering: scope.ordering}
 }
 
 // buildStmt builds a set of memo groups that represent the given SQL

--- a/pkg/sql/opt/optbuilder/groupby.go
+++ b/pkg/sql/opt/optbuilder/groupby.go
@@ -389,7 +389,7 @@ func (b *Builder) buildAggregateFunction(
 	// expression and synthesize a column for the aggregation result.
 	col = aggOutScope.findAggregate(info)
 	if col == nil {
-		col = b.synthesizeColumn(aggOutScope, label, f.ResolvedType())
+		col = b.synthesizeColumn(aggOutScope, label, f.ResolvedType(), f)
 
 		// Add the aggregate to the list of aggregates that need to be computed by
 		// the groupby expression.

--- a/pkg/sql/opt/optbuilder/join.go
+++ b/pkg/sql/opt/optbuilder/join.go
@@ -273,7 +273,14 @@ func (b *Builder) buildUsingJoinPredicate(
 			outScope.cols = append(outScope.cols, *rightCol)
 		} else {
 			// Construct a new merged column to represent IFNULL(left, right).
-			col := b.synthesizeColumn(outScope, string(leftCol.name), leftCol.typ)
+			var typ types.T
+			if leftCol.typ != types.Unknown {
+				typ = leftCol.typ
+			} else {
+				typ = rightCol.typ
+			}
+			texpr := tree.NewTypedCoalesceExpr(tree.TypedExprs{leftCol, rightCol}, typ)
+			col := b.synthesizeColumn(outScope, string(leftCol.name), typ, texpr)
 			merged := b.factory.ConstructCoalesce(b.factory.InternList([]opt.GroupID{leftVar, rightVar}))
 			mergedCols[col.index] = merged
 		}

--- a/pkg/sql/opt/optbuilder/orderby.go
+++ b/pkg/sql/opt/optbuilder/orderby.go
@@ -16,36 +16,180 @@ package optbuilder
 
 import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
 )
 
 // buildOrderBy builds an Ordering physical property from the ORDER BY clause.
 // ORDER BY is not a relational expression, but instead a required physical
-// property on the output. The Ordering property returned by buildOrderBy is
-// set on the scope and later becomes part of the required physical properties
-// returned by Build.
-// TODO(rytaft): Add support for ORDER BY clause that uses more than simple
-// column references.
-func (b *Builder) buildOrderBy(orderBy tree.OrderBy, inScope *scope) opt.Ordering {
+// property on the output.
+//
+// Since the ordering property can only refer to output columns, we may need
+// to add a projection for the ordering columns. For example, consider the
+// following query:
+//     SELECT a FROM t ORDER BY c
+// The `c` column must be retained in the projection (and the presentation
+// property then omits it).
+//
+// buildOrderBy builds a projection combining the projected columns and
+// order by columns (only if it's not a "pass through" projection), and sets
+// the ordering and presentation properties on the output scope. These
+// properties later become part of the required physical properties returned
+// by Build.
+func (b *Builder) buildOrderBy(
+	orderBy tree.OrderBy, in opt.GroupID, projections []opt.GroupID, inScope, projectionsScope *scope,
+) (out opt.GroupID, outScope *scope) {
 	if orderBy == nil {
-		return nil
+		return in, nil
 	}
 
-	ordering := make(opt.Ordering, 0, len(orderBy))
+	orderByScope := inScope.push()
+	orderByScope.ordering = make(opt.Ordering, 0, len(orderBy))
+	orderByProjections := make([]opt.GroupID, 0, len(orderBy))
 
-	for i, order := range orderBy {
-		props, ok := inScope.resolveType(order.Expr, types.Any).(*columnProps)
-		if !ok {
-			panic(errorf("ORDER BY only supports simple column references at this time"))
-		}
+	// TODO(rytaft): rewrite ORDER BY if it uses ORDER BY INDEX tbl@idx or
+	// ORDER BY PRIMARY KEY syntax.
 
-		index := props.index
-		if orderBy[i].Direction == tree.Descending {
+	for i := range orderBy {
+		p := b.buildOrdering(orderBy[i], orderByProjections, inScope, projectionsScope, orderByScope)
+		orderByProjections = append(orderByProjections, p...)
+	}
+
+	out, outScope = b.buildOrderByProject(
+		in, projections, orderByProjections, inScope, projectionsScope, orderByScope,
+	)
+	return out, outScope
+
+}
+
+func (b *Builder) buildOrdering(
+	order *tree.Order, projections []opt.GroupID, inScope, projectionsScope, orderByScope *scope,
+) []opt.GroupID {
+	// Unwrap parenthesized expressions like "((a))" to "a".
+	expr := tree.StripParens(order.Expr)
+
+	// The logical data source for ORDER BY is the list of column
+	// expressions for a SELECT, as specified in the input SQL text
+	// (or an entire UNION or VALUES clause).  Alas, SQL has some
+	// historical baggage from SQL92 and there are some special cases:
+	//
+	// SQL92 rules:
+	//
+	// 1) if the expression is the aliased (AS) name of an
+	//    expression in a SELECT clause, then use that
+	//    expression as sort key.
+	//    e.g. SELECT a AS b, b AS c ORDER BY b
+	//    this sorts on the first column.
+	//
+	// 2) column ordinals. If a simple integer literal is used,
+	//    optionally enclosed within parentheses but *not subject to
+	//    any arithmetic*, then this refers to one of the columns of
+	//    the data source. Then use the SELECT expression at that
+	//    ordinal position as sort key.
+	//
+	// SQL99 rules:
+	//
+	// 3) otherwise, if the expression is already in the SELECT list,
+	//    then use that expression as sort key.
+	//    e.g. SELECT b AS c ORDER BY b
+	//    this sorts on the first column.
+	//    (this is an optimization)
+	//
+	// 4) if the sort key is not dependent on the data source (no
+	//    IndexedVar) then simply do not sort. (this is an optimization)
+	//
+	// 5) otherwise, add a new projection with the ORDER BY expression
+	//    and use that as sort key.
+	//    e.g. SELECT a FROM t ORDER by b
+	//    e.g. SELECT a, b FROM t ORDER by a+b
+
+	// First, deal with projection aliases.
+	idx := colIdxByProjectionAlias(expr, "ORDER BY", projectionsScope)
+
+	// If the expression does not refer to an alias, deal with
+	// column ordinals.
+	if idx == -1 {
+		idx = colIndex(len(projectionsScope.cols), expr, "ORDER BY")
+	}
+
+	var exprs []tree.TypedExpr
+	if idx != -1 {
+		exprs = []tree.TypedExpr{&projectionsScope.cols[idx]}
+	} else {
+		exprs = b.expandStarAndResolveType(expr, inScope)
+
+		// ORDER BY (a, b) -> ORDER BY a, b
+		exprs = flattenTuples(exprs)
+	}
+
+	// Build each of the ORDER BY columns. As a side effect, this will append new
+	// columns to the end of outScope.cols.
+	start := len(orderByScope.cols)
+	for _, e := range exprs {
+		// Ensure we can order on the given column.
+		ensureColumnOrderable(e)
+		scalar := b.buildScalarProjection(e, "", inScope, orderByScope)
+		projections = append(projections, scalar)
+	}
+
+	// Add the new columns to the ordering.
+	for i := start; i < len(orderByScope.cols); i++ {
+		index := orderByScope.cols[i].index
+		if order.Direction == tree.Descending {
 			index = -index
 		}
-		ordering = append(ordering, index)
+		orderByScope.ordering = append(orderByScope.ordering, index)
 	}
 
-	return ordering
+	return projections
+}
+
+// buildOrderByProject builds a projection that combines projected
+// columns from a SELECT list and ORDER BY columns.
+// If the combined set of output columns matches the set of input columns,
+// buildOrderByProject simply returns the input -- it does not construct
+// a "pass through" projection.
+func (b *Builder) buildOrderByProject(
+	in opt.GroupID,
+	projections, orderByProjections []opt.GroupID,
+	inScope, projectionsScope, orderByScope *scope,
+) (out opt.GroupID, outScope *scope) {
+	outScope = inScope.push()
+
+	outScope.cols = make([]columnProps, 0, len(projectionsScope.cols)+len(orderByScope.cols))
+	outScope.appendColumns(projectionsScope)
+	combined := make([]opt.GroupID, 0, len(projectionsScope.cols)+len(orderByScope.cols))
+	combined = append(combined, projections...)
+
+	for i := range orderByScope.cols {
+		col := &orderByScope.cols[i]
+
+		// Only append order by columns that aren't already present.
+		if findColByIndex(outScope.cols, col.index) == nil {
+			outScope.cols = append(outScope.cols, *col)
+			combined = append(combined, orderByProjections[i])
+		}
+	}
+
+	if outScope.hasSameColumns(inScope) {
+		// All order by and projection columns were already present, so no need to
+		// construct the projection expression.
+		inScope.ordering = orderByScope.ordering
+		inScope.presentation = makePresentation(projectionsScope.cols)
+		return in, inScope
+	}
+
+	p := b.constructList(opt.ProjectionsOp, combined, outScope.cols)
+	out = b.factory.ConstructProject(in, p)
+	outScope.ordering = orderByScope.ordering
+	outScope.presentation = makePresentation(projectionsScope.cols)
+	return out, outScope
+}
+
+func ensureColumnOrderable(e tree.TypedExpr) {
+	if _, ok := e.ResolvedType().(types.TArray); ok || e.ResolvedType() == types.JSON {
+		panic(builderError{pgerror.NewErrorf(pgerror.CodeFeatureNotSupportedError,
+			"can't order by column type %s", e.ResolvedType())})
+	}
 }

--- a/pkg/sql/opt/optbuilder/project.go
+++ b/pkg/sql/opt/optbuilder/project.go
@@ -23,9 +23,10 @@ import (
 // buildProjectionList builds a set of memo groups that represent the given
 // list of select expressions.
 //
-// The first return value `projections` is an ordered list of top-level memo
-// groups corresponding to each select expression. See Builder.buildStmt above
-// for a description of the remaining input and return values.
+// The return value `projections` is an ordered list of top-level memo
+// groups corresponding to each select expression. See Builder.buildStmt
+// for a description of the remaining input values (outScope is passed as
+// a parameter here rather than a return value).
 //
 // As a side-effect, the appropriate scopes are updated with aggregations
 // (scope.groupby.aggs)
@@ -197,6 +198,6 @@ func (b *Builder) buildDefaultScalarProjection(
 		}
 	}
 
-	b.synthesizeColumn(outScope, label, texpr.ResolvedType())
+	b.synthesizeColumn(outScope, label, texpr.ResolvedType(), texpr)
 	return group
 }

--- a/pkg/sql/opt/optbuilder/scalar.go
+++ b/pkg/sql/opt/optbuilder/scalar.go
@@ -342,7 +342,7 @@ func NewScalar(
 	}
 	sb.scope.builder = &sb.Builder
 	for i := range columnNames {
-		sb.synthesizeColumn(&sb.scope, columnNames[i], columnTypes[i])
+		sb.synthesizeColumn(&sb.scope, columnNames[i], columnTypes[i], nil)
 	}
 	return sb
 }

--- a/pkg/sql/opt/optbuilder/scope.go
+++ b/pkg/sql/opt/optbuilder/scope.go
@@ -33,11 +33,12 @@ import (
 //
 // See builder.go for more details.
 type scope struct {
-	builder  *Builder
-	parent   *scope
-	cols     []columnProps
-	groupby  groupby
-	ordering opt.Ordering
+	builder      *Builder
+	parent       *scope
+	cols         []columnProps
+	groupby      groupby
+	ordering     opt.Ordering
+	presentation opt.Presentation
 }
 
 // groupByStrSet is a set of stringified GROUP BY expressions.

--- a/pkg/sql/opt/optbuilder/testdata/join
+++ b/pkg/sql/opt/optbuilder/testdata/join
@@ -3239,3 +3239,45 @@ project
 #            │    └── projections
 #            │         └── variable: kv.k [type=int]
 #            └── variable: kv.k [type=int]
+
+# Test natural outer join when the left side has unknown type
+build
+SELECT * FROM (VALUES (NULL, NULL)) NATURAL FULL OUTER JOIN (SELECT * FROM (VALUES (1, 1)))
+----
+project
+ ├── columns: column1:5(int) column2:6(int)
+ ├── project
+ │    ├── columns: column1:5(int) column2:6(int) column1:1(unknown) column2:2(unknown) column1:3(int) column2:4(int)
+ │    ├── full-join
+ │    │    ├── columns: column1:1(unknown) column2:2(unknown) column1:3(int) column2:4(int)
+ │    │    ├── values
+ │    │    │    ├── columns: column1:1(unknown) column2:2(unknown)
+ │    │    │    └── tuple [type=tuple{unknown, unknown}]
+ │    │    │         ├── null [type=unknown]
+ │    │    │         └── null [type=unknown]
+ │    │    ├── values
+ │    │    │    ├── columns: column1:3(int) column2:4(int)
+ │    │    │    └── tuple [type=tuple{int, int}]
+ │    │    │         ├── const: 1 [type=int]
+ │    │    │         └── const: 1 [type=int]
+ │    │    └── and [type=bool, outer=(1-4)]
+ │    │         ├── eq [type=bool, outer=(1,3)]
+ │    │         │    ├── variable: column1 [type=unknown, outer=(1)]
+ │    │         │    └── variable: column1 [type=int, outer=(3)]
+ │    │         └── eq [type=bool, outer=(2,4)]
+ │    │              ├── variable: column2 [type=unknown, outer=(2)]
+ │    │              └── variable: column2 [type=int, outer=(4)]
+ │    └── projections [outer=(1-4)]
+ │         ├── coalesce [type=int, outer=(1,3)]
+ │         │    ├── variable: column1 [type=unknown, outer=(1)]
+ │         │    └── variable: column1 [type=int, outer=(3)]
+ │         ├── coalesce [type=int, outer=(2,4)]
+ │         │    ├── variable: column2 [type=unknown, outer=(2)]
+ │         │    └── variable: column2 [type=int, outer=(4)]
+ │         ├── variable: column1 [type=unknown, outer=(1)]
+ │         ├── variable: column2 [type=unknown, outer=(2)]
+ │         ├── variable: column1 [type=int, outer=(3)]
+ │         └── variable: column2 [type=int, outer=(4)]
+ └── projections [outer=(5,6)]
+      ├── variable: column1 [type=int, outer=(5)]
+      └── variable: column2 [type=int, outer=(6)]

--- a/pkg/sql/opt/optbuilder/testdata/orderby
+++ b/pkg/sql/opt/optbuilder/testdata/orderby
@@ -73,6 +73,32 @@ project
       └── variable: t.b [type=int, outer=(2)]
 
 build
+SELECT a FROM t ORDER BY 1 DESC
+----
+project
+ ├── columns: a:1(int!null)
+ ├── ordering: -1
+ ├── sort
+ │    ├── columns: t.a:1(int!null) t.b:2(int) t.c:3(bool)
+ │    ├── ordering: -1
+ │    └── scan
+ │         └── columns: t.a:1(int!null) t.b:2(int) t.c:3(bool)
+ └── projections [outer=(1)]
+      └── variable: t.a [type=int, outer=(1)]
+
+# TODO(rytaft): This query causes an error in Postgres, but it is supported by
+# CockroachDB with the semantics:
+#   SELECT c FROM t GROUP BY c ORDER BY max(b) DESC;
+# We may decide to support this later, but for now this should cause an error.
+# TODO(rytaft): Improve this error message to be more descriptive. E.g., the
+# Postgres error message is "for SELECT DISTINCT, ORDER BY expressions must
+# appear in select list".
+build
+SELECT DISTINCT c FROM t ORDER BY b DESC
+----
+error: column name "b" not found
+
+build
 SELECT a AS foo, b FROM t ORDER BY foo DESC
 ----
 project
@@ -86,6 +112,171 @@ project
  └── projections [outer=(1,2)]
       ├── variable: t.a [type=int, outer=(1)]
       └── variable: t.b [type=int, outer=(2)]
+
+# Check that ambiguous references to renders are properly reported.
+build
+SELECT a AS foo, b AS foo FROM t ORDER BY foo
+----
+error: ORDER BY "foo" is ambiguous
+
+# Check that no ambiguity is reported if the ORDER BY name refers
+# to two or more equivalent renders (special case in SQL92).
+build
+SELECT a AS foo, (a) AS foo FROM t ORDER BY foo
+----
+project
+ ├── columns: foo:1(int!null) foo:1(int!null)
+ ├── ordering: +1
+ ├── scan
+ │    ├── columns: t.a:1(int!null) t.b:2(int) t.c:3(bool)
+ │    └── ordering: +1
+ └── projections [outer=(1)]
+      ├── variable: t.a [type=int, outer=(1)]
+      └── variable: t.a [type=int, outer=(1)]
+
+# Check that this orders by the aliased column b (i.e., column a), not the
+# original column b.
+build
+SELECT a AS b, b AS c FROM t ORDER BY b
+----
+project
+ ├── columns: b:1(int!null) c:2(int)
+ ├── ordering: +1
+ ├── scan
+ │    ├── columns: t.a:1(int!null) t.b:2(int) t.c:3(bool)
+ │    └── ordering: +1
+ └── projections [outer=(1,2)]
+      ├── variable: t.a [type=int, outer=(1)]
+      └── variable: t.b [type=int, outer=(2)]
+
+build
+SELECT a AS "foo.bar", b FROM t ORDER BY "foo.bar" DESC
+----
+project
+ ├── columns: foo.bar:1(int!null) b:2(int)
+ ├── ordering: -1
+ ├── sort
+ │    ├── columns: t.a:1(int!null) t.b:2(int) t.c:3(bool)
+ │    ├── ordering: -1
+ │    └── scan
+ │         └── columns: t.a:1(int!null) t.b:2(int) t.c:3(bool)
+ └── projections [outer=(1,2)]
+      ├── variable: t.a [type=int, outer=(1)]
+      └── variable: t.b [type=int, outer=(2)]
+
+build
+SELECT a AS foo, b FROM t ORDER BY a DESC
+----
+project
+ ├── columns: foo:1(int!null) b:2(int)
+ ├── ordering: -1
+ ├── sort
+ │    ├── columns: t.a:1(int!null) t.b:2(int) t.c:3(bool)
+ │    ├── ordering: -1
+ │    └── scan
+ │         └── columns: t.a:1(int!null) t.b:2(int) t.c:3(bool)
+ └── projections [outer=(1,2)]
+      ├── variable: t.a [type=int, outer=(1)]
+      └── variable: t.b [type=int, outer=(2)]
+
+build
+SELECT b FROM t ORDER BY a DESC
+----
+project
+ ├── columns: b:2(int)
+ ├── ordering: -1
+ ├── sort
+ │    ├── columns: t.a:1(int!null) t.b:2(int) t.c:3(bool)
+ │    ├── ordering: -1
+ │    └── scan
+ │         └── columns: t.a:1(int!null) t.b:2(int) t.c:3(bool)
+ └── projections [outer=(1,2)]
+      ├── variable: t.b [type=int, outer=(2)]
+      └── variable: t.a [type=int, outer=(1)]
+
+build
+SELECT b FROM t ORDER BY a DESC, b ASC
+----
+project
+ ├── columns: b:2(int)
+ ├── ordering: -1,+2
+ ├── sort
+ │    ├── columns: t.a:1(int!null) t.b:2(int) t.c:3(bool)
+ │    ├── ordering: -1,+2
+ │    └── scan
+ │         └── columns: t.a:1(int!null) t.b:2(int) t.c:3(bool)
+ └── projections [outer=(1,2)]
+      ├── variable: t.b [type=int, outer=(2)]
+      └── variable: t.a [type=int, outer=(1)]
+
+build
+SELECT b FROM t ORDER BY a DESC, b DESC
+----
+project
+ ├── columns: b:2(int)
+ ├── ordering: -1,-2
+ ├── sort
+ │    ├── columns: t.a:1(int!null) t.b:2(int) t.c:3(bool)
+ │    ├── ordering: -1,-2
+ │    └── scan
+ │         └── columns: t.a:1(int!null) t.b:2(int) t.c:3(bool)
+ └── projections [outer=(1,2)]
+      ├── variable: t.b [type=int, outer=(2)]
+      └── variable: t.a [type=int, outer=(1)]
+
+# both presentation and ordering
+build
+SELECT a, b, b FROM t ORDER BY c
+----
+project
+ ├── columns: a:1(int!null) b:2(int) b:2(int)
+ ├── ordering: +3
+ ├── sort
+ │    ├── columns: t.a:1(int!null) t.b:2(int) t.c:3(bool)
+ │    ├── ordering: +3
+ │    └── scan
+ │         └── columns: t.a:1(int!null) t.b:2(int) t.c:3(bool)
+ └── projections [outer=(1-3)]
+      ├── variable: t.a [type=int, outer=(1)]
+      ├── variable: t.b [type=int, outer=(2)]
+      ├── variable: t.b [type=int, outer=(2)]
+      └── variable: t.c [type=bool, outer=(3)]
+
+build
+SELECT * FROM t ORDER BY (b, t.*)
+----
+sort
+ ├── columns: a:1(int!null) b:2(int) c:3(bool)
+ ├── ordering: +2,+1,+2,+3
+ └── scan
+      └── columns: t.a:1(int!null) t.b:2(int) t.c:3(bool)
+
+build
+SELECT * FROM t ORDER BY (b, a), c
+----
+sort
+ ├── columns: a:1(int!null) b:2(int) c:3(bool)
+ ├── ordering: +2,+1,+3
+ └── scan
+      └── columns: t.a:1(int!null) t.b:2(int) t.c:3(bool)
+
+build
+SELECT * FROM t ORDER BY b, (a, c)
+----
+sort
+ ├── columns: a:1(int!null) b:2(int) c:3(bool)
+ ├── ordering: +2,+1,+3
+ └── scan
+      └── columns: t.a:1(int!null) t.b:2(int) t.c:3(bool)
+
+build
+SELECT * FROM t ORDER BY (b, (a, c))
+----
+sort
+ ├── columns: a:1(int!null) b:2(int) c:3(bool)
+ ├── ordering: +2,+1,+3
+ └── scan
+      └── columns: t.a:1(int!null) t.b:2(int) t.c:3(bool)
 
 build
 SELECT a, b FROM t WHERE b = 7 ORDER BY b, a
@@ -144,3 +335,360 @@ sort
            └── plus [type=int, outer=(1,2)]
                 ├── variable: t.a [type=int, outer=(1)]
                 └── variable: t.b [type=int, outer=(2)]
+
+build
+SELECT a FROM t ORDER BY a+b DESC, a
+----
+sort
+ ├── columns: a:1(int!null)
+ ├── ordering: -4,+1
+ └── project
+      ├── columns: t.a:1(int!null) column4:4(int)
+      ├── scan
+      │    └── columns: t.a:1(int!null) t.b:2(int) t.c:3(bool)
+      └── projections [outer=(1,2)]
+           ├── variable: t.a [type=int, outer=(1)]
+           └── plus [type=int, outer=(1,2)]
+                ├── variable: t.a [type=int, outer=(1)]
+                └── variable: t.b [type=int, outer=(2)]
+
+build
+SELECT a FROM t ORDER BY (((a)))
+----
+project
+ ├── columns: a:1(int!null)
+ ├── ordering: +1
+ ├── scan
+ │    ├── columns: t.a:1(int!null) t.b:2(int) t.c:3(bool)
+ │    └── ordering: +1
+ └── projections [outer=(1)]
+      └── variable: t.a [type=int, outer=(1)]
+
+build
+(((SELECT a FROM t))) ORDER BY a DESC
+----
+project
+ ├── columns: a:1(int!null)
+ ├── ordering: -1
+ ├── sort
+ │    ├── columns: t.a:1(int!null) t.b:2(int) t.c:3(bool)
+ │    ├── ordering: -1
+ │    └── scan
+ │         └── columns: t.a:1(int!null) t.b:2(int) t.c:3(bool)
+ └── projections [outer=(1)]
+      └── variable: t.a [type=int, outer=(1)]
+
+build
+(((SELECT a FROM t ORDER BY a DESC)))
+----
+project
+ ├── columns: a:1(int!null)
+ ├── ordering: -1
+ ├── sort
+ │    ├── columns: t.a:1(int!null) t.b:2(int) t.c:3(bool)
+ │    ├── ordering: -1
+ │    └── scan
+ │         └── columns: t.a:1(int!null) t.b:2(int) t.c:3(bool)
+ └── projections [outer=(1)]
+      └── variable: t.a [type=int, outer=(1)]
+
+build
+((SELECT a FROM t ORDER BY a)) ORDER BY a
+----
+error: multiple ORDER BY clauses not allowed
+
+build
+SELECT CASE a WHEN 1 THEN b ELSE c END as val FROM t ORDER BY val
+----
+error: incompatible value type:: expected t.c to be of type int, found type bool
+
+build
+SELECT * FROM t ORDER BY 0
+----
+error: ORDER BY position 0 is not in select list
+
+build
+SELECT * FROM t ORDER BY true
+----
+error: non-integer constant in ORDER BY: true
+
+build
+SELECT * FROM t ORDER BY 'a'
+----
+error: non-integer constant in ORDER BY: 'a'
+
+build
+SELECT * FROM t ORDER BY 2.5
+----
+error: non-integer constant in ORDER BY: 2.5
+
+build
+SELECT * FROM t ORDER BY foo
+----
+error: column name "foo" not found
+
+build
+SELECT a FROM t ORDER BY a.b
+----
+error: no data source matches prefix: a
+
+build
+SELECT GENERATE_SERIES FROM GENERATE_SERIES(1, 100) ORDER BY ARRAY[GENERATE_SERIES]
+----
+error: not yet implemented: table expr: *tree.FuncExpr
+
+build
+SELECT ARRAY[GENERATE_SERIES] FROM GENERATE_SERIES(1, 100) ORDER BY ARRAY[GENERATE_SERIES]
+----
+error: not yet implemented: table expr: *tree.FuncExpr
+
+build
+SELECT ARRAY[GENERATE_SERIES] FROM GENERATE_SERIES(1, 100) ORDER BY 1
+----
+error: not yet implemented: table expr: *tree.FuncExpr
+
+build
+SELECT ARRAY[GENERATE_SERIES] AS a FROM GENERATE_SERIES(1, 100) ORDER BY a
+----
+error: not yet implemented: table expr: *tree.FuncExpr
+
+build
+SELECT GENERATE_SERIES, ARRAY[GENERATE_SERIES] FROM GENERATE_SERIES(1, 1) ORDER BY 1
+----
+error: not yet implemented: table expr: *tree.FuncExpr
+
+build
+SELECT GENERATE_SERIES, ARRAY[GENERATE_SERIES] FROM GENERATE_SERIES(1, 1) ORDER BY GENERATE_SERIES
+----
+error: not yet implemented: table expr: *tree.FuncExpr
+
+build
+SELECT GENERATE_SERIES, ARRAY[GENERATE_SERIES] FROM GENERATE_SERIES(1, 1) ORDER BY -GENERATE_SERIES
+----
+error: not yet implemented: table expr: *tree.FuncExpr
+
+
+# Sort should be skipped if the ORDER BY clause is constant.
+# (This skipping will probably happen later during optimization. The below
+# tests should just show that the ordering column is constant.)
+build
+SELECT * FROM t ORDER BY 1+2
+----
+sort
+ ├── columns: a:1(int!null) b:2(int) c:3(bool)
+ ├── ordering: +4
+ └── project
+      ├── columns: t.a:1(int!null) t.b:2(int) t.c:3(bool) column4:4(int)
+      ├── scan
+      │    └── columns: t.a:1(int!null) t.b:2(int) t.c:3(bool)
+      └── projections [outer=(1-3)]
+           ├── variable: t.a [type=int, outer=(1)]
+           ├── variable: t.b [type=int, outer=(2)]
+           ├── variable: t.c [type=bool, outer=(3)]
+           └── const: 3 [type=int]
+
+build
+SELECT 1, * FROM t ORDER BY 1
+----
+sort
+ ├── columns: column4:4(int) a:1(int!null) b:2(int) c:3(bool)
+ ├── ordering: +4
+ └── project
+      ├── columns: column4:4(int) t.a:1(int!null) t.b:2(int) t.c:3(bool)
+      ├── scan
+      │    └── columns: t.a:1(int!null) t.b:2(int) t.c:3(bool)
+      └── projections [outer=(1-3)]
+           ├── const: 1 [type=int]
+           ├── variable: t.a [type=int, outer=(1)]
+           ├── variable: t.b [type=int, outer=(2)]
+           └── variable: t.c [type=bool, outer=(3)]
+
+build
+SELECT * FROM t ORDER BY length('abc')
+----
+sort
+ ├── columns: a:1(int!null) b:2(int) c:3(bool)
+ ├── ordering: +4
+ └── project
+      ├── columns: t.a:1(int!null) t.b:2(int) t.c:3(bool) column4:4(int)
+      ├── scan
+      │    └── columns: t.a:1(int!null) t.b:2(int) t.c:3(bool)
+      └── projections [outer=(1-3)]
+           ├── variable: t.a [type=int, outer=(1)]
+           ├── variable: t.b [type=int, outer=(2)]
+           ├── variable: t.c [type=bool, outer=(3)]
+           └── function: length [type=int]
+                └── const: 'abc' [type=string]
+
+# TODO(rytaft): The sort should reuse the synthesized column for b+2.
+build
+SELECT b+2 FROM t ORDER BY b+2
+----
+sort
+ ├── columns: column4:4(int)
+ ├── ordering: +5
+ └── project
+      ├── columns: column4:4(int) column5:5(int)
+      ├── scan
+      │    └── columns: t.a:1(int!null) t.b:2(int) t.c:3(bool)
+      └── projections [outer=(2)]
+           ├── plus [type=int, outer=(2)]
+           │    ├── variable: t.b [type=int, outer=(2)]
+           │    └── const: 2 [type=int]
+           └── plus [type=int, outer=(2)]
+                ├── variable: t.b [type=int, outer=(2)]
+                └── const: 2 [type=int]
+
+# Check that the sort picks up a renamed render properly.
+build
+SELECT b+2 AS y FROM t ORDER BY y
+----
+sort
+ ├── columns: y:4(int)
+ ├── ordering: +4
+ └── project
+      ├── columns: y:4(int)
+      ├── scan
+      │    └── columns: t.a:1(int!null) t.b:2(int) t.c:3(bool)
+      └── projections [outer=(2)]
+           └── plus [type=int, outer=(2)]
+                ├── variable: t.b [type=int, outer=(2)]
+                └── const: 2 [type=int]
+
+# TODO(rytaft): The sort should reuse a synthesized column even after a rename.
+build
+SELECT b+2 AS y FROM t ORDER BY b+2
+----
+sort
+ ├── columns: y:4(int)
+ ├── ordering: +5
+ └── project
+      ├── columns: y:4(int) column5:5(int)
+      ├── scan
+      │    └── columns: t.a:1(int!null) t.b:2(int) t.c:3(bool)
+      └── projections [outer=(2)]
+           ├── plus [type=int, outer=(2)]
+           │    ├── variable: t.b [type=int, outer=(2)]
+           │    └── const: 2 [type=int]
+           └── plus [type=int, outer=(2)]
+                ├── variable: t.b [type=int, outer=(2)]
+                └── const: 2 [type=int]
+
+exec-ddl
+CREATE TABLE bar (id INT PRIMARY KEY, baz STRING, UNIQUE INDEX i_bar (baz))
+----
+TABLE bar
+ ├── id int not null
+ ├── baz string
+ ├── INDEX primary
+ │    └── id int not null
+ └── INDEX i_bar
+      ├── baz string
+      └── id int not null (storing)
+
+build
+SELECT * FROM bar ORDER BY baz, id
+----
+sort
+ ├── columns: id:1(int!null) baz:2(string)
+ ├── ordering: +2,+1
+ └── scan
+      └── columns: bar.id:1(int!null) bar.baz:2(string)
+
+exec-ddl
+CREATE TABLE abcd (
+  a INT PRIMARY KEY,
+  b INT,
+  c INT,
+  d INT,
+  INDEX abc (a, b, c)
+)
+----
+TABLE abcd
+ ├── a int not null
+ ├── b int
+ ├── c int
+ ├── d int
+ ├── INDEX primary
+ │    └── a int not null
+ └── INDEX abc
+      ├── a int not null
+      ├── b int
+      └── c int
+
+# Verify that projections after ORDER BY perform correctly (i.e., the outer
+# expression does not guarantee it will apply the ORDER BY).
+
+build
+SELECT a+b FROM (SELECT * FROM abcd ORDER BY d)
+----
+project
+ ├── columns: column5:5(int)
+ ├── scan
+ │    └── columns: abcd.a:1(int!null) abcd.b:2(int) abcd.c:3(int) abcd.d:4(int)
+ └── projections [outer=(1,2)]
+      └── plus [type=int, outer=(1,2)]
+           ├── variable: abcd.a [type=int, outer=(1)]
+           └── variable: abcd.b [type=int, outer=(2)]
+
+build
+SELECT b+d FROM (SELECT * FROM abcd ORDER BY a,d)
+----
+project
+ ├── columns: column5:5(int)
+ ├── scan
+ │    └── columns: abcd.a:1(int!null) abcd.b:2(int) abcd.c:3(int) abcd.d:4(int)
+ └── projections [outer=(2,4)]
+      └── plus [type=int, outer=(2,4)]
+           ├── variable: abcd.b [type=int, outer=(2)]
+           └── variable: abcd.d [type=int, outer=(4)]
+
+build
+SELECT * FROM (SELECT * FROM (VALUES ('a'), ('b'), ('c')) AS c(x) ORDER BY x)
+----
+sort
+ ├── columns: x:1(string)
+ ├── ordering: +1
+ └── values
+      ├── columns: column1:1(string)
+      ├── tuple [type=tuple{string}]
+      │    └── const: 'a' [type=string]
+      ├── tuple [type=tuple{string}]
+      │    └── const: 'b' [type=string]
+      └── tuple [type=tuple{string}]
+           └── const: 'c' [type=string]
+
+exec-ddl
+CREATE TABLE blocks (
+  block_id  INT,
+  writer_id STRING,
+  block_num INT,
+  raw_bytes BYTES,
+  PRIMARY KEY (block_id, writer_id, block_num)
+)
+----
+TABLE blocks
+ ├── block_id int not null
+ ├── writer_id string not null
+ ├── block_num int not null
+ ├── raw_bytes bytes
+ └── INDEX primary
+      ├── block_id int not null
+      ├── writer_id string not null
+      └── block_num int not null
+
+# Regression test for #13696.
+build
+SELECT block_id,writer_id,block_num,block_id FROM blocks ORDER BY block_id, writer_id, block_num
+----
+project
+ ├── columns: block_id:1(int!null) writer_id:2(string!null) block_num:3(int!null) block_id:1(int!null)
+ ├── ordering: +1,+2,+3
+ ├── scan
+ │    ├── columns: blocks.block_id:1(int!null) blocks.writer_id:2(string!null) blocks.block_num:3(int!null) blocks.raw_bytes:4(bytes)
+ │    └── ordering: +1,+2,+3
+ └── projections [outer=(1-3)]
+      ├── variable: blocks.block_id [type=int, outer=(1)]
+      ├── variable: blocks.writer_id [type=string, outer=(2)]
+      ├── variable: blocks.block_num [type=int, outer=(3)]
+      └── variable: blocks.block_id [type=int, outer=(1)]

--- a/pkg/sql/opt/optbuilder/union.go
+++ b/pkg/sql/opt/optbuilder/union.go
@@ -81,7 +81,7 @@ func (b *Builder) buildUnion(
 				typ = r.typ
 			}
 
-			b.synthesizeColumn(outScope, string(l.name), typ)
+			b.synthesizeColumn(outScope, string(l.name), typ, nil)
 		}
 	}
 

--- a/pkg/sql/opt/optbuilder/util.go
+++ b/pkg/sql/opt/optbuilder/util.go
@@ -101,15 +101,25 @@ func (b *Builder) expandStarAndResolveType(
 // label  This is an optional label for the new column (e.g., if specified with
 //        the AS keyword).
 // typ    The type of the column.
+// expr   The expression this column refers to (if any).
 //
 // The new column is returned as a columnProps object.
-func (b *Builder) synthesizeColumn(scope *scope, label string, typ types.T) *columnProps {
+func (b *Builder) synthesizeColumn(
+	scope *scope, label string, typ types.T, expr tree.TypedExpr,
+) *columnProps {
 	if label == "" {
 		label = fmt.Sprintf("column%d", len(b.colMap))
 	}
 
+	name := tree.Name(label)
 	colIndex := b.factory.Metadata().AddColumn(label, typ)
-	col := columnProps{name: tree.Name(label), typ: typ, index: colIndex}
+	col := columnProps{
+		origName: name,
+		name:     name,
+		typ:      typ,
+		index:    colIndex,
+		expr:     expr,
+	}
 	b.colMap = append(b.colMap, col)
 	scope.cols = append(scope.cols, col)
 	return &scope.cols[len(scope.cols)-1]
@@ -175,6 +185,53 @@ func colIndex(numOriginalCols int, expr tree.Expr, context string) int {
 	return int(ord)
 }
 
+// colIdxByProjectionAlias returns the corresponding index in columns of an expression
+// that may refer to a column alias.
+// If there are no aliases in columns that expr refers to, then -1 is returned.
+// This method is pertinent to ORDER BY and DISTINCT ON clauses that may refer
+// to a column alias.
+func colIdxByProjectionAlias(expr tree.Expr, op string, scope *scope) int {
+	index := -1
+
+	if vBase, ok := expr.(tree.VarName); ok {
+		v, err := vBase.NormalizeVarName()
+		if err != nil {
+			panic(builderError{err})
+		}
+
+		if c, ok := v.(*tree.ColumnItem); ok && c.TableName.Parts[0] == "" {
+			// Look for an output column that matches the name. This
+			// handles cases like:
+			//
+			//   SELECT a AS b FROM t ORDER BY b
+			//   SELECT DISTINCT ON (b) a AS b FROM t
+			target := c.ColumnName
+			for j, col := range scope.cols {
+				if col.name == target {
+					if index != -1 {
+						// There is more than one projection alias that matches the clause.
+						// Here, SQL92 is specific as to what should be done: if the
+						// underlying expression is known and it is equivalent, then just
+						// accept that and ignore the ambiguity. This plays nice with
+						// `SELECT b, * FROM t ORDER BY b`. Otherwise, reject with an
+						// ambiguity error.
+						if scope.cols[j].getExprStr() != scope.cols[index].getExprStr() {
+							panic(builderError{pgerror.NewErrorf(
+								pgerror.CodeAmbiguousAliasError, "%s \"%s\" is ambiguous", op, target,
+							)})
+						}
+						// Use the index of the first matching column.
+						continue
+					}
+					index = j
+				}
+			}
+		}
+	}
+
+	return index
+}
+
 // flattenTuples extracts the members of tuples into a list of columns.
 func flattenTuples(exprs []tree.TypedExpr) []tree.TypedExpr {
 	// We want to avoid allocating new slices unless strictly necessary.
@@ -225,4 +282,24 @@ func colsToColList(cols []columnProps) opt.ColList {
 		colList[i] = cols[i].index
 	}
 	return colList
+}
+
+func findColByIndex(cols []columnProps, colIndex opt.ColumnIndex) *columnProps {
+	for i := range cols {
+		col := &cols[i]
+		if col.index == colIndex {
+			return col
+		}
+	}
+
+	return nil
+}
+
+func makePresentation(cols []columnProps) opt.Presentation {
+	presentation := make(opt.Presentation, len(cols))
+	for i := range cols {
+		col := &cols[i]
+		presentation[i] = opt.LabeledColumn{Label: string(col.name), Index: col.index}
+	}
+	return presentation
 }

--- a/pkg/sql/opt/optbuilder/values.go
+++ b/pkg/sql/opt/optbuilder/values.go
@@ -70,7 +70,7 @@ func (b *Builder) buildValuesClause(
 	for i := 0; i < numCols; i++ {
 		// The column names for VALUES are column1, column2, etc.
 		label := fmt.Sprintf("column%d", i+1)
-		b.synthesizeColumn(outScope, label, colTypes[i])
+		b.synthesizeColumn(outScope, label, colTypes[i], nil)
 	}
 
 	colList := colsToColList(outScope.cols)


### PR DESCRIPTION
This commit builds on #23123 to support all types of
`ORDER BY` expressions in the optbuilder, not just `ORDER BY`
expressions containing variables found in the `SELECT` list.

For example, it is possible to order by column aliases,
`GROUP BY`/`FROM` columns that are not in the `SELECT` list,
scalar expressions using these `GROUP BY`/`FROM` columns,
ordinal indexes into the `SELECT` list, etc.

Some examples of supported queries are:
```
  SELECT a FROM t ORDER BY b, c
  SELECT a, b, a+b AS ab FROM t ORDER BY ab DESC
  SELECT * FROM t ORDER BY t.*
  SELECT a, b, c FROM t ORDER BY 2 DESC
```

The test cases have been adapted from the order_by tests
in logictests.

This commit does NOT include support for `ORDER BY INDEX idx@tbl`
 or `ORDER BY PRIMARY KEY`. Some optimizations are also left for a
future PR. For example,
```
  SELECT a+b FROM t ORDER BY a+b
```
causes two projections to be built for `a+b`. A future PR
should perform de-duplication.

This code is based on code originally written as part of the
opttoy project.

Release note: None