### PR TITLE
log,cli: Stop serving earlier when log.Fatal is called

### DIFF
--- a/pkg/cli/start.go
+++ b/pkg/cli/start.go
@@ -682,11 +682,11 @@ func runStart(cmd *cobra.Command, args []string) error {
 			// still be running after shutdownCtx's span has been finished.
 			ac := log.AmbientContext{}
 			ac.AddLogTag("server drain process", nil)
-			ctx := ac.AnnotateCtx(context.Background())
-			if _, err := s.Drain(ctx, server.GracefulDrainModes); err != nil {
-				log.Warning(ctx, err)
+			drainCtx := ac.AnnotateCtx(context.Background())
+			if _, err := s.Drain(drainCtx, server.GracefulDrainModes); err != nil {
+				log.Warning(drainCtx, err)
 			}
-			stopper.Stop(ctx)
+			stopper.Stop(drainCtx)
 		}()
 
 		// Don't return: we're shutting down gracefully.

--- a/pkg/cli/start.go
+++ b/pkg/cli/start.go
@@ -689,7 +689,21 @@ func runStart(cmd *cobra.Command, args []string) error {
 			stopper.Stop(drainCtx)
 		}()
 
-		// Don't return: we're shutting down gracefully.
+	// Don't return: we're shutting down gracefully.
+
+	case <-log.FatalChan():
+		// A fatal error has occurred. Stop everything (gracelessly) to
+		// avoid serving incorrect data while the final log messages are
+		// being written.
+		// https://github.com/cockroachdb/cockroach/issues/23414
+		// TODO(bdarnell): This could be more graceless, for example by
+		// reaching into the server objects and closing all the
+		// connections while they're in use. That would be more in line
+		// with the expected effect of a log.Fatal.
+		stopper.Stop(ctx)
+		// The logging goroutine is now responsible for killing this
+		// process, so just block this goroutine.
+		select {}
 	}
 
 	// At this point, a signal has been received to shut down the


### PR DESCRIPTION
log.Fatal can take a while (there are 10s timeouts on sending crash
reports and writing to the logs), and during that time we don't want
to serve any bad data (for example, if the fatal error is due to
observed clock inconsistencies).

Fixes #23414

Release note (bug fix): Reduced risk that a node in the process of
crashing could serve inconsistent data.