### PR TITLE
opt: Only project needed columns

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/scalar_builder.go
+++ b/pkg/sql/opt/exec/execbuilder/scalar_builder.go
@@ -168,7 +168,7 @@ func (b *Builder) buildFunction(ctx *buildScalarCtx, ev xform.ExprView) tree.Typ
 	for i := range exprs {
 		exprs[i] = b.buildScalar(ctx, ev.Child(i))
 	}
-	funcDef := ev.Private().(opt.FuncDef)
+	funcDef := ev.Private().(opt.FuncOpDef)
 	funcRef := tree.WrapFunction(funcDef.Name)
 	return tree.NewTypedFuncExpr(
 		funcRef,

--- a/pkg/sql/opt/exec/execbuilder/testdata/aggregate
+++ b/pkg/sql/opt/exec/execbuilder/testdata/aggregate
@@ -12,33 +12,34 @@ CREATE TABLE kv (
 exec-explain
 SELECT MIN(1), MAX(1), COUNT(1), SUM_INT(1), AVG(1), SUM(1), STDDEV(1), VARIANCE(1), BOOL_AND(true), BOOL_AND(false), XOR_AGG(b'\x01') FROM kv
 ----
-group           0  group   ·             ·                   (column6, column8, column10, column12, column14, column16, column18, column20, column22, column24, column26)  ·
- │              0  ·       aggregate 0   min(column5)        ·                                                                                                             ·
- │              0  ·       aggregate 1   max(column7)        ·                                                                                                             ·
- │              0  ·       aggregate 2   count(column9)      ·                                                                                                             ·
- │              0  ·       aggregate 3   sum_int(column11)   ·                                                                                                             ·
- │              0  ·       aggregate 4   avg(column13)       ·                                                                                                             ·
- │              0  ·       aggregate 5   sum(column15)       ·                                                                                                             ·
- │              0  ·       aggregate 6   stddev(column17)    ·                                                                                                             ·
- │              0  ·       aggregate 7   variance(column19)  ·                                                                                                             ·
- │              0  ·       aggregate 8   bool_and(column21)  ·                                                                                                             ·
- │              0  ·       aggregate 9   bool_and(column23)  ·                                                                                                             ·
- │              0  ·       aggregate 10  xor_agg(column25)   ·                                                                                                             ·
- └── render     1  render  ·             ·                   (column5, column7, column9, column11, column13, column15, column17, column19, column21, column23, column25)   ·
-      │         1  ·       render 0      1                   ·                                                                                                             ·
-      │         1  ·       render 1      1                   ·                                                                                                             ·
-      │         1  ·       render 2      1                   ·                                                                                                             ·
-      │         1  ·       render 3      1                   ·                                                                                                             ·
-      │         1  ·       render 4      1                   ·                                                                                                             ·
-      │         1  ·       render 5      1                   ·                                                                                                             ·
-      │         1  ·       render 6      1                   ·                                                                                                             ·
-      │         1  ·       render 7      1                   ·                                                                                                             ·
-      │         1  ·       render 8      true                ·                                                                                                             ·
-      │         1  ·       render 9      false               ·                                                                                                             ·
-      │         1  ·       render 10     '\x01'              ·                                                                                                             ·
-      └── scan  2  scan    ·             ·                   (k, v, w, s)                                                                                                  ·
-·               2  ·       table         kv@primary          ·                                                                                                             ·
-·               2  ·       spans         ALL                 ·                                                                                                             ·
+group                0  group   ·             ·                   (column6, column8, column10, column12, column14, column16, column18, column20, column22, column24, column26)  ·
+ │                   0  ·       aggregate 0   min(column5)        ·                                                                                                             ·
+ │                   0  ·       aggregate 1   max(column7)        ·                                                                                                             ·
+ │                   0  ·       aggregate 2   count(column9)      ·                                                                                                             ·
+ │                   0  ·       aggregate 3   sum_int(column11)   ·                                                                                                             ·
+ │                   0  ·       aggregate 4   avg(column13)       ·                                                                                                             ·
+ │                   0  ·       aggregate 5   sum(column15)       ·                                                                                                             ·
+ │                   0  ·       aggregate 6   stddev(column17)    ·                                                                                                             ·
+ │                   0  ·       aggregate 7   variance(column19)  ·                                                                                                             ·
+ │                   0  ·       aggregate 8   bool_and(column21)  ·                                                                                                             ·
+ │                   0  ·       aggregate 9   bool_and(column23)  ·                                                                                                             ·
+ │                   0  ·       aggregate 10  xor_agg(column25)   ·                                                                                                             ·
+ └── render          1  render  ·             ·                   (column5, column7, column9, column11, column13, column15, column17, column19, column21, column23, column25)   ·
+      │              1  ·       render 0      1                   ·                                                                                                             ·
+      │              1  ·       render 1      1                   ·                                                                                                             ·
+      │              1  ·       render 2      1                   ·                                                                                                             ·
+      │              1  ·       render 3      1                   ·                                                                                                             ·
+      │              1  ·       render 4      1                   ·                                                                                                             ·
+      │              1  ·       render 5      1                   ·                                                                                                             ·
+      │              1  ·       render 6      1                   ·                                                                                                             ·
+      │              1  ·       render 7      1                   ·                                                                                                             ·
+      │              1  ·       render 8      true                ·                                                                                                             ·
+      │              1  ·       render 9      false               ·                                                                                                             ·
+      │              1  ·       render 10     '\x01'              ·                                                                                                             ·
+      └── render     2  render  ·             ·                   ()                                                                                                            ·
+           └── scan  3  scan    ·             ·                   (k, v, w, s)                                                                                                  ·
+·                    3  ·       table         kv@primary          ·                                                                                                             ·
+·                    3  ·       spans         ALL                 ·                                                                                                             ·
 
 exec
 SELECT MIN(1), MAX(1), COUNT(1), SUM_INT(1), AVG(1), SUM(1), STDDEV(1), VARIANCE(1), BOOL_AND(true), BOOL_AND(false), XOR_AGG(b'\x01') FROM kv
@@ -68,33 +69,36 @@ NULL
 exec-explain
 SELECT MIN(v), MAX(v), COUNT(v), SUM_INT(1), AVG(v), SUM(v), STDDEV(v), VARIANCE(v), BOOL_AND(v = 1), BOOL_AND(v = 1), XOR_AGG(s::bytes) FROM kv
 ----
-group           0  group   ·             ·                   (column5, column6, column7, column9, column10, column11, column12, column13, column15, column17, column19)  ·
- │              0  ·       aggregate 0   min(kv.v)           ·                                                                                                           ·
- │              0  ·       aggregate 1   max(kv.v)           ·                                                                                                           ·
- │              0  ·       aggregate 2   count(kv.v)         ·                                                                                                           ·
- │              0  ·       aggregate 3   sum_int(column8)    ·                                                                                                           ·
- │              0  ·       aggregate 4   avg(kv.v)           ·                                                                                                           ·
- │              0  ·       aggregate 5   sum(kv.v)           ·                                                                                                           ·
- │              0  ·       aggregate 6   stddev(kv.v)        ·                                                                                                           ·
- │              0  ·       aggregate 7   variance(kv.v)      ·                                                                                                           ·
- │              0  ·       aggregate 8   bool_and(column14)  ·                                                                                                           ·
- │              0  ·       aggregate 9   bool_and(column16)  ·                                                                                                           ·
- │              0  ·       aggregate 10  xor_agg(column18)   ·                                                                                                           ·
- └── render     1  render  ·             ·                   ("kv.v", "kv.v", "kv.v", column8, "kv.v", "kv.v", "kv.v", "kv.v", column14, column16, column18)             ·
-      │         1  ·       render 0      v                   ·                                                                                                           ·
-      │         1  ·       render 1      v                   ·                                                                                                           ·
-      │         1  ·       render 2      v                   ·                                                                                                           ·
-      │         1  ·       render 3      1                   ·                                                                                                           ·
-      │         1  ·       render 4      v                   ·                                                                                                           ·
-      │         1  ·       render 5      v                   ·                                                                                                           ·
-      │         1  ·       render 6      v                   ·                                                                                                           ·
-      │         1  ·       render 7      v                   ·                                                                                                           ·
-      │         1  ·       render 8      v = 1               ·                                                                                                           ·
-      │         1  ·       render 9      v = 1               ·                                                                                                           ·
-      │         1  ·       render 10     s::BYTES            ·                                                                                                           ·
-      └── scan  2  scan    ·             ·                   (k, v, w, s)                                                                                                ·
-·               2  ·       table         kv@primary          ·                                                                                                           ·
-·               2  ·       spans         ALL                 ·                                                                                                           ·
+group                0  group   ·             ·                   (column5, column6, column7, column9, column10, column11, column12, column13, column15, column17, column19)  ·
+ │                   0  ·       aggregate 0   min(kv.v)           ·                                                                                                           ·
+ │                   0  ·       aggregate 1   max(kv.v)           ·                                                                                                           ·
+ │                   0  ·       aggregate 2   count(kv.v)         ·                                                                                                           ·
+ │                   0  ·       aggregate 3   sum_int(column8)    ·                                                                                                           ·
+ │                   0  ·       aggregate 4   avg(kv.v)           ·                                                                                                           ·
+ │                   0  ·       aggregate 5   sum(kv.v)           ·                                                                                                           ·
+ │                   0  ·       aggregate 6   stddev(kv.v)        ·                                                                                                           ·
+ │                   0  ·       aggregate 7   variance(kv.v)      ·                                                                                                           ·
+ │                   0  ·       aggregate 8   bool_and(column14)  ·                                                                                                           ·
+ │                   0  ·       aggregate 9   bool_and(column16)  ·                                                                                                           ·
+ │                   0  ·       aggregate 10  xor_agg(column18)   ·                                                                                                           ·
+ └── render          1  render  ·             ·                   ("kv.v", "kv.v", "kv.v", column8, "kv.v", "kv.v", "kv.v", "kv.v", column14, column16, column18)             ·
+      │              1  ·       render 0      v                   ·                                                                                                           ·
+      │              1  ·       render 1      v                   ·                                                                                                           ·
+      │              1  ·       render 2      v                   ·                                                                                                           ·
+      │              1  ·       render 3      1                   ·                                                                                                           ·
+      │              1  ·       render 4      v                   ·                                                                                                           ·
+      │              1  ·       render 5      v                   ·                                                                                                           ·
+      │              1  ·       render 6      v                   ·                                                                                                           ·
+      │              1  ·       render 7      v                   ·                                                                                                           ·
+      │              1  ·       render 8      v = 1               ·                                                                                                           ·
+      │              1  ·       render 9      v = 1               ·                                                                                                           ·
+      │              1  ·       render 10     s::BYTES            ·                                                                                                           ·
+      └── render     2  render  ·             ·                   (v, s)                                                                                                      ·
+           │         2  ·       render 0      v                   ·                                                                                                           ·
+           │         2  ·       render 1      s                   ·                                                                                                           ·
+           └── scan  3  scan    ·             ·                   (k, v, w, s)                                                                                                ·
+·                    3  ·       table         kv@primary          ·                                                                                                           ·
+·                    3  ·       spans         ALL                 ·                                                                                                           ·
 
 exec
 SELECT MIN(v), MAX(v), COUNT(v), SUM_INT(1), AVG(v), SUM(v), STDDEV(v), VARIANCE(v), BOOL_AND(v = 1), BOOL_AND(v = 1), XOR_AGG(s::bytes) FROM kv
@@ -324,18 +328,18 @@ column5:int  k:int
 exec-explain
 SELECT COUNT(*), k FROM kv GROUP BY 2
 ----
-render               0  render  ·            ·             (column5, k)    ·
- │                   0  ·       render 0     agg0          ·               ·
- │                   0  ·       render 1     "kv.k"        ·               ·
- └── group           1  group   ·            ·             ("kv.k", agg0)  ·
-      │              1  ·       aggregate 0  kv.k          ·               ·
-      │              1  ·       aggregate 1  count_rows()  ·               ·
-      │              1  ·       group by     @1            ·               ·
-      └── render     2  render  ·            ·             ("kv.k")        ·
-           │         2  ·       render 0     k             ·               ·
-           └── scan  3  scan    ·            ·             (k, v, w, s)    ·
-·                    3  ·       table        kv@primary    ·               ·
-·                    3  ·       spans        ALL           ·               ·
+render               0  render  ·            ·             (column5, k)  ·
+ │                   0  ·       render 0     agg0          ·             ·
+ │                   0  ·       render 1     k             ·             ·
+ └── group           1  group   ·            ·             (k, agg0)     ·
+      │              1  ·       aggregate 0  k             ·             ·
+      │              1  ·       aggregate 1  count_rows()  ·             ·
+      │              1  ·       group by     @1            ·             ·
+      └── render     2  render  ·            ·             (k)           ·
+           │         2  ·       render 0     k             ·             ·
+           └── scan  3  scan    ·            ·             (k, v, w, s)  ·
+·                    3  ·       table        kv@primary    ·             ·
+·                    3  ·       spans        ALL           ·             ·
 
 # GROUP BY specified using column index works.
 exec rowsort
@@ -407,18 +411,21 @@ column5:int  column6:string
 exec-explain
 SELECT COUNT(*), k+v FROM kv GROUP BY k+v
 ----
-render               0  render  ·            ·             (column6, column5)  ·
- │                   0  ·       render 0     agg0          ·                   ·
- │                   0  ·       render 1     column5       ·                   ·
- └── group           1  group   ·            ·             (column5, agg0)     ·
-      │              1  ·       aggregate 0  column5       ·                   ·
-      │              1  ·       aggregate 1  count_rows()  ·                   ·
-      │              1  ·       group by     @1            ·                   ·
-      └── render     2  render  ·            ·             (column5)           ·
-           │         2  ·       render 0     k + v         ·                   ·
-           └── scan  3  scan    ·            ·             (k, v, w, s)        ·
-·                    3  ·       table        kv@primary    ·                   ·
-·                    3  ·       spans        ALL           ·                   ·
+render                    0  render  ·            ·             (column6, column5)  ·
+ │                        0  ·       render 0     agg0          ·                   ·
+ │                        0  ·       render 1     column5       ·                   ·
+ └── group                1  group   ·            ·             (column5, agg0)     ·
+      │                   1  ·       aggregate 0  column5       ·                   ·
+      │                   1  ·       aggregate 1  count_rows()  ·                   ·
+      │                   1  ·       group by     @1            ·                   ·
+      └── render          2  render  ·            ·             (column5)           ·
+           │              2  ·       render 0     k + v         ·                   ·
+           └── render     3  render  ·            ·             (k, v)              ·
+                │         3  ·       render 0     k             ·                   ·
+                │         3  ·       render 1     v             ·                   ·
+                └── scan  4  scan    ·            ·             (k, v, w, s)        ·
+·                         4  ·       table        kv@primary    ·                   ·
+·                         4  ·       spans        ALL           ·                   ·
 
 exec rowsort
 SELECT COUNT(*), k+v FROM kv GROUP BY k+v
@@ -435,20 +442,20 @@ column6:int  column5:int
 exec-explain
 SELECT COUNT(*), k+v FROM kv GROUP BY k, v
 ----
-render               0  render  ·            ·                (column5, column6)      ·
- │                   0  ·       render 0     agg0             ·                       ·
- │                   0  ·       render 1     "kv.k" + "kv.v"  ·                       ·
- └── group           1  group   ·            ·                ("kv.k", "kv.v", agg0)  ·
-      │              1  ·       aggregate 0  kv.k             ·                       ·
-      │              1  ·       aggregate 1  kv.v             ·                       ·
-      │              1  ·       aggregate 2  count_rows()     ·                       ·
-      │              1  ·       group by     @1-@2            ·                       ·
-      └── render     2  render  ·            ·                ("kv.k", "kv.v")        ·
-           │         2  ·       render 0     k                ·                       ·
-           │         2  ·       render 1     v                ·                       ·
-           └── scan  3  scan    ·            ·                (k, v, w, s)            ·
-·                    3  ·       table        kv@primary       ·                       ·
-·                    3  ·       spans        ALL              ·                       ·
+render               0  render  ·            ·             (column5, column6)  ·
+ │                   0  ·       render 0     agg0          ·                   ·
+ │                   0  ·       render 1     k + v         ·                   ·
+ └── group           1  group   ·            ·             (k, v, agg0)        ·
+      │              1  ·       aggregate 0  k             ·                   ·
+      │              1  ·       aggregate 1  v             ·                   ·
+      │              1  ·       aggregate 2  count_rows()  ·                   ·
+      │              1  ·       group by     @1-@2         ·                   ·
+      └── render     2  render  ·            ·             (k, v)              ·
+           │         2  ·       render 0     k             ·                   ·
+           │         2  ·       render 1     v             ·                   ·
+           └── scan  3  scan    ·            ·             (k, v, w, s)        ·
+·                    3  ·       table        kv@primary    ·                   ·
+·                    3  ·       spans        ALL           ·                   ·
 
 exec rowsort
 SELECT COUNT(*), k+v FROM kv GROUP BY k, v
@@ -695,28 +702,26 @@ column7:decimal
 exec-explain
 SELECT COUNT(k) FROM kv
 ----
-group           0  group   ·            ·            (column5)     ·
- │              0  ·       aggregate 0  count(kv.k)  ·             ·
- └── render     1  render  ·            ·            ("kv.k")      ·
-      │         1  ·       render 0     k            ·             ·
-      └── scan  2  scan    ·            ·            (k, v, w, s)  ·
-·               2  ·       table        kv@primary   ·             ·
-·               2  ·       spans        ALL          ·             ·
+group           0  group   ·            ·           (column5)     ·
+ │              0  ·       aggregate 0  count(k)    ·             ·
+ └── render     1  render  ·            ·           (k)           ·
+      │         1  ·       render 0     k           ·             ·
+      └── scan  2  scan    ·            ·           (k, v, w, s)  ·
+·               2  ·       table        kv@primary  ·             ·
+·               2  ·       spans        ALL         ·             ·
 
 exec-explain
 SELECT COUNT(k), SUM(k), MAX(k) FROM kv
 ----
-group           0  group   ·            ·            (column5, column6, column7)  ·
- │              0  ·       aggregate 0  count(kv.k)  ·                            ·
- │              0  ·       aggregate 1  sum(kv.k)    ·                            ·
- │              0  ·       aggregate 2  max(kv.k)    ·                            ·
- └── render     1  render  ·            ·            ("kv.k", "kv.k", "kv.k")     ·
-      │         1  ·       render 0     k            ·                            ·
-      │         1  ·       render 1     k            ·                            ·
-      │         1  ·       render 2     k            ·                            ·
-      └── scan  2  scan    ·            ·            (k, v, w, s)                 ·
-·               2  ·       table        kv@primary   ·                            ·
-·               2  ·       spans        ALL          ·                            ·
+group           0  group   ·            ·           (column5, column6, column7)  ·
+ │              0  ·       aggregate 0  count(k)    ·                            ·
+ │              0  ·       aggregate 1  sum(k)      ·                            ·
+ │              0  ·       aggregate 2  max(k)      ·                            ·
+ └── render     1  render  ·            ·           (k)                          ·
+      │         1  ·       render 0     k           ·                            ·
+      └── scan  2  scan    ·            ·           (k, v, w, s)                 ·
+·               2  ·       table        kv@primary  ·                            ·
+·               2  ·       spans        ALL         ·                            ·
 
 exec-raw
 CREATE TABLE abc (
@@ -735,8 +740,8 @@ exec-explain
 SELECT MIN(a) FROM abc
 ----
 group           0  group   ·            ·            (column5)     ·
- │              0  ·       aggregate 0  min(abc.a)   ·             ·
- └── render     1  render  ·            ·            ("abc.a")     ·
+ │              0  ·       aggregate 0  min(a)       ·             ·
+ └── render     1  render  ·            ·            (a)           ·
       │         1  ·       render 0     a            ·             ·
       └── scan  2  scan    ·            ·            (a, b, c, d)  ·
 ·               2  ·       table        abc@primary  ·             ·
@@ -804,8 +809,8 @@ exec-explain
 SELECT MIN(x) FROM xyz
 ----
 group           0  group   ·            ·            (column4)  ·
- │              0  ·       aggregate 0  min(xyz.x)   ·          ·
- └── render     1  render  ·            ·            ("xyz.x")  ·
+ │              0  ·       aggregate 0  min(x)       ·          ·
+ └── render     1  render  ·            ·            (x)        ·
       │         1  ·       render 0     x            ·          ·
       └── scan  2  scan    ·            ·            (x, y, z)  ·
 ·               2  ·       table        xyz@primary  ·          ·
@@ -822,11 +827,11 @@ exec-explain
 SELECT MIN(x) FROM xyz WHERE x in (0, 4, 7)
 ----
 group                0  group   ·            ·               (column4)  ·
- │                   0  ·       aggregate 0  min(xyz.x)      ·          ·
- └── render          1  render  ·            ·               ("xyz.x")  ·
-      │              1  ·       render 0     x               ·          ·
-      └── filter     2  filter  ·            ·               (x, y, z)  ·
-           │         2  ·       filter       x IN (0, 4, 7)  ·          ·
+ │                   0  ·       aggregate 0  min(x)          ·          ·
+ └── filter          1  filter  ·            ·               (x)        ·
+      │              1  ·       filter       x IN (0, 4, 7)  ·          ·
+      └── render     2  render  ·            ·               (x)        ·
+           │         2  ·       render 0     x               ·          ·
            └── scan  3  scan    ·            ·               (x, y, z)  ·
 ·                    3  ·       table        xyz@primary     ·          ·
 ·                    3  ·       spans        ALL             ·          ·
@@ -842,8 +847,8 @@ exec-explain
 SELECT MAX(x) FROM xyz
 ----
 group           0  group   ·            ·            (column4)  ·
- │              0  ·       aggregate 0  max(xyz.x)   ·          ·
- └── render     1  render  ·            ·            ("xyz.x")  ·
+ │              0  ·       aggregate 0  max(x)       ·          ·
+ └── render     1  render  ·            ·            (x)        ·
       │         1  ·       render 0     x            ·          ·
       └── scan  2  scan    ·            ·            (x, y, z)  ·
 ·               2  ·       table        xyz@primary  ·          ·
@@ -858,15 +863,18 @@ column4:int
 exec-explain
 SELECT MIN(y) FROM xyz WHERE x = 1
 ----
-group                0  group   ·            ·            (column4)  ·
- │                   0  ·       aggregate 0  min(xyz.y)   ·          ·
- └── render          1  render  ·            ·            ("xyz.y")  ·
-      │              1  ·       render 0     y            ·          ·
-      └── filter     2  filter  ·            ·            (x, y, z)  ·
-           │         2  ·       filter       x = 1        ·          ·
-           └── scan  3  scan    ·            ·            (x, y, z)  ·
-·                    3  ·       table        xyz@primary  ·          ·
-·                    3  ·       spans        ALL          ·          ·
+group                     0  group   ·            ·            (column4)  ·
+ │                        0  ·       aggregate 0  min(xyz.y)   ·          ·
+ └── render               1  render  ·            ·            ("xyz.y")  ·
+      │                   1  ·       render 0     y            ·          ·
+      └── filter          2  filter  ·            ·            (x, y)     ·
+           │              2  ·       filter       x = 1        ·          ·
+           └── render     3  render  ·            ·            (x, y)     ·
+                │         3  ·       render 0     x            ·          ·
+                │         3  ·       render 1     y            ·          ·
+                └── scan  4  scan    ·            ·            (x, y, z)  ·
+·                         4  ·       table        xyz@primary  ·          ·
+·                         4  ·       spans        ALL          ·          ·
 
 exec
 SELECT MAX(y) FROM xyz WHERE x = 1
@@ -877,15 +885,18 @@ column4:int
 exec-explain
 SELECT MAX(y) FROM xyz WHERE x = 1
 ----
-group                0  group   ·            ·            (column4)  ·
- │                   0  ·       aggregate 0  max(xyz.y)   ·          ·
- └── render          1  render  ·            ·            ("xyz.y")  ·
-      │              1  ·       render 0     y            ·          ·
-      └── filter     2  filter  ·            ·            (x, y, z)  ·
-           │         2  ·       filter       x = 1        ·          ·
-           └── scan  3  scan    ·            ·            (x, y, z)  ·
-·                    3  ·       table        xyz@primary  ·          ·
-·                    3  ·       spans        ALL          ·          ·
+group                     0  group   ·            ·            (column4)  ·
+ │                        0  ·       aggregate 0  max(xyz.y)   ·          ·
+ └── render               1  render  ·            ·            ("xyz.y")  ·
+      │                   1  ·       render 0     y            ·          ·
+      └── filter          2  filter  ·            ·            (x, y)     ·
+           │              2  ·       filter       x = 1        ·          ·
+           └── render     3  render  ·            ·            (x, y)     ·
+                │         3  ·       render 0     x            ·          ·
+                │         3  ·       render 1     y            ·          ·
+                └── scan  4  scan    ·            ·            (x, y, z)  ·
+·                         4  ·       table        xyz@primary  ·          ·
+·                         4  ·       spans        ALL          ·          ·
 
 exec
 SELECT MIN(y) FROM xyz WHERE x = 7
@@ -896,15 +907,18 @@ NULL
 exec-explain
 SELECT MIN(y) FROM xyz WHERE x = 7
 ----
-group                0  group   ·            ·            (column4)  ·
- │                   0  ·       aggregate 0  min(xyz.y)   ·          ·
- └── render          1  render  ·            ·            ("xyz.y")  ·
-      │              1  ·       render 0     y            ·          ·
-      └── filter     2  filter  ·            ·            (x, y, z)  ·
-           │         2  ·       filter       x = 7        ·          ·
-           └── scan  3  scan    ·            ·            (x, y, z)  ·
-·                    3  ·       table        xyz@primary  ·          ·
-·                    3  ·       spans        ALL          ·          ·
+group                     0  group   ·            ·            (column4)  ·
+ │                        0  ·       aggregate 0  min(xyz.y)   ·          ·
+ └── render               1  render  ·            ·            ("xyz.y")  ·
+      │                   1  ·       render 0     y            ·          ·
+      └── filter          2  filter  ·            ·            (x, y)     ·
+           │              2  ·       filter       x = 7        ·          ·
+           └── render     3  render  ·            ·            (x, y)     ·
+                │         3  ·       render 0     x            ·          ·
+                │         3  ·       render 1     y            ·          ·
+                └── scan  4  scan    ·            ·            (x, y, z)  ·
+·                         4  ·       table        xyz@primary  ·          ·
+·                         4  ·       spans        ALL          ·          ·
 
 exec
 SELECT MAX(y) FROM xyz WHERE x = 7
@@ -915,15 +929,18 @@ NULL
 exec-explain
 SELECT MAX(y) FROM xyz WHERE x = 7
 ----
-group                0  group   ·            ·            (column4)  ·
- │                   0  ·       aggregate 0  max(xyz.y)   ·          ·
- └── render          1  render  ·            ·            ("xyz.y")  ·
-      │              1  ·       render 0     y            ·          ·
-      └── filter     2  filter  ·            ·            (x, y, z)  ·
-           │         2  ·       filter       x = 7        ·          ·
-           └── scan  3  scan    ·            ·            (x, y, z)  ·
-·                    3  ·       table        xyz@primary  ·          ·
-·                    3  ·       spans        ALL          ·          ·
+group                     0  group   ·            ·            (column4)  ·
+ │                        0  ·       aggregate 0  max(xyz.y)   ·          ·
+ └── render               1  render  ·            ·            ("xyz.y")  ·
+      │                   1  ·       render 0     y            ·          ·
+      └── filter          2  filter  ·            ·            (x, y)     ·
+           │              2  ·       filter       x = 7        ·          ·
+           └── render     3  render  ·            ·            (x, y)     ·
+                │         3  ·       render 0     x            ·          ·
+                │         3  ·       render 1     y            ·          ·
+                └── scan  4  scan    ·            ·            (x, y, z)  ·
+·                         4  ·       table        xyz@primary  ·          ·
+·                         4  ·       spans        ALL          ·          ·
 
 exec
 SELECT MIN(x) FROM xyz WHERE (y, z) = (2, 3.0)
@@ -986,15 +1003,15 @@ NULL
 exec-explain
 SELECT VARIANCE(x) FROM xyz WHERE x = 1
 ----
-group                0  group   ·            ·                (column4)  ·
- │                   0  ·       aggregate 0  variance(xyz.x)  ·          ·
- └── render          1  render  ·            ·                ("xyz.x")  ·
-      │              1  ·       render 0     x                ·          ·
-      └── filter     2  filter  ·            ·                (x, y, z)  ·
-           │         2  ·       filter       x = 1            ·          ·
-           └── scan  3  scan    ·            ·                (x, y, z)  ·
-·                    3  ·       table        xyz@primary      ·          ·
-·                    3  ·       spans        ALL              ·          ·
+group                0  group   ·            ·            (column4)  ·
+ │                   0  ·       aggregate 0  variance(x)  ·          ·
+ └── filter          1  filter  ·            ·            (x)        ·
+      │              1  ·       filter       x = 1        ·          ·
+      └── render     2  render  ·            ·            (x)        ·
+           │         2  ·       render 0     x            ·          ·
+           └── scan  3  scan    ·            ·            (x, y, z)  ·
+·                    3  ·       table        xyz@primary  ·          ·
+·                    3  ·       spans        ALL          ·          ·
 
 exec
 SELECT STDDEV(x), STDDEV(y::decimal), round(STDDEV(z), 14) FROM xyz
@@ -1327,30 +1344,26 @@ column5:int
 exec-explain
 SELECT SUM(abc.d) FROM kv JOIN abc ON kv.k >= abc.d GROUP BY kv.*;
 ----
-render                    0  render  ·            ·            (column9)                                  ·
- │                        0  ·       render 0     agg0         ·                                          ·
- └── group                1  group   ·            ·            ("kv.k", "kv.v", "kv.w", "kv.s", agg0)     ·
-      │                   1  ·       aggregate 0  kv.k         ·                                          ·
-      │                   1  ·       aggregate 1  kv.v         ·                                          ·
-      │                   1  ·       aggregate 2  kv.w         ·                                          ·
-      │                   1  ·       aggregate 3  kv.s         ·                                          ·
-      │                   1  ·       aggregate 4  sum(abc.d)   ·                                          ·
-      │                   1  ·       group by     @1-@4        ·                                          ·
-      └── render          2  render  ·            ·            ("kv.k", "kv.v", "kv.w", "kv.s", "abc.d")  ·
-           │              2  ·       render 0     k            ·                                          ·
-           │              2  ·       render 1     v            ·                                          ·
-           │              2  ·       render 2     w            ·                                          ·
-           │              2  ·       render 3     s            ·                                          ·
-           │              2  ·       render 4     d            ·                                          ·
-           └── join       3  join    ·            ·            (k, v, w, s, a, b, c, d)                   ·
-                │         3  ·       type         inner        ·                                          ·
-                │         3  ·       pred         k >= d       ·                                          ·
-                ├── scan  4  scan    ·            ·            (k, v, w, s)                               ·
-                │         4  ·       table        kv@primary   ·                                          ·
-                │         4  ·       spans        ALL          ·                                          ·
-                └── scan  4  scan    ·            ·            (a, b, c, d)                               ·
-·                         4  ·       table        abc@primary  ·                                          ·
-·                         4  ·       spans        ALL          ·                                          ·
+render                    0  render  ·            ·            (column9)           ·
+ │                        0  ·       render 0     agg0         ·                   ·
+ └── group                1  group   ·            ·            (k, v, w, s, agg0)  ·
+      │                   1  ·       aggregate 0  k            ·                   ·
+      │                   1  ·       aggregate 1  v            ·                   ·
+      │                   1  ·       aggregate 2  w            ·                   ·
+      │                   1  ·       aggregate 3  s            ·                   ·
+      │                   1  ·       aggregate 4  sum(d)       ·                   ·
+      │                   1  ·       group by     @1-@4        ·                   ·
+      └── join            2  join    ·            ·            (k, v, w, s, d)     ·
+           │              2  ·       type         inner        ·                   ·
+           │              2  ·       pred         k >= d       ·                   ·
+           ├── scan       3  scan    ·            ·            (k, v, w, s)        ·
+           │              3  ·       table        kv@primary   ·                   ·
+           │              3  ·       spans        ALL          ·                   ·
+           └── render     3  render  ·            ·            (d)                 ·
+                │         3  ·       render 0     d            ·                   ·
+                └── scan  4  scan    ·            ·            (a, b, c, d)        ·
+·                         4  ·       table        abc@primary  ·                   ·
+·                         4  ·       spans        ALL          ·                   ·
 
 exec rowsort
 SELECT SUM(abc.d) FROM kv JOIN abc ON kv.k >= abc.d GROUP BY kv.*;
@@ -1529,25 +1542,23 @@ d               (4, 3)
 exec-explain
 SELECT MIN(y), (b, a) FROM ab, xy GROUP BY (x, (a, b))
 ----
-render                    0  render  ·            ·                 (column6, column7)                ·
- │                        0  ·       render 0     agg0              ·                                 ·
- │                        0  ·       render 1     ("ab.b", "ab.a")  ·                                 ·
- └── group                1  group   ·            ·                 ("ab.a", "ab.b", "xy.x", agg0)    ·
-      │                   1  ·       aggregate 0  ab.a              ·                                 ·
-      │                   1  ·       aggregate 1  ab.b              ·                                 ·
-      │                   1  ·       aggregate 2  xy.x              ·                                 ·
-      │                   1  ·       aggregate 3  min(xy.y)         ·                                 ·
-      │                   1  ·       group by     @2,@3,@1          ·                                 ·
-      └── render          2  render  ·            ·                 ("xy.x", "ab.a", "ab.b", "xy.y")  ·
-           │              2  ·       render 0     x                 ·                                 ·
-           │              2  ·       render 1     a                 ·                                 ·
-           │              2  ·       render 2     b                 ·                                 ·
-           │              2  ·       render 3     y                 ·                                 ·
-           └── join       3  join    ·            ·                 (a, b, x, y, rowid[hidden])       ·
-                │         3  ·       type         cross             ·                                 ·
-                ├── scan  4  scan    ·            ·                 (a, b)                            ·
-                │         4  ·       table        ab@primary        ·                                 ·
-                │         4  ·       spans        ALL               ·                                 ·
-                └── scan  4  scan    ·            ·                 (x, y, rowid[hidden])             ·
-·                         4  ·       table        xy@primary        ·                                 ·
-·                         4  ·       spans        ALL               ·                                 ·
+render                    0  render  ·            ·           (column6, column7)     ·
+ │                        0  ·       render 0     agg0        ·                      ·
+ │                        0  ·       render 1     (b, a)      ·                      ·
+ └── group                1  group   ·            ·           (a, b, x, agg0)        ·
+      │                   1  ·       aggregate 0  a           ·                      ·
+      │                   1  ·       aggregate 1  b           ·                      ·
+      │                   1  ·       aggregate 2  x           ·                      ·
+      │                   1  ·       aggregate 3  min(y)      ·                      ·
+      │                   1  ·       group by     @1-@3       ·                      ·
+      └── join            2  join    ·            ·           (a, b, x, y)           ·
+           │              2  ·       type         cross       ·                      ·
+           ├── scan       3  scan    ·            ·           (a, b)                 ·
+           │              3  ·       table        ab@primary  ·                      ·
+           │              3  ·       spans        ALL         ·                      ·
+           └── render     3  render  ·            ·           (x, y)                 ·
+                │         3  ·       render 0     x           ·                      ·
+                │         3  ·       render 1     y           ·                      ·
+                └── scan  4  scan    ·            ·           (x, y, rowid[hidden])  ·
+·                         4  ·       table        xy@primary  ·                      ·
+·                         4  ·       spans        ALL         ·                      ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/join
+++ b/pkg/sql/opt/exec/execbuilder/testdata/join
@@ -150,25 +150,19 @@ x:int  y:int  z:int
 exec-explain
 SELECT * FROM t.a FULL OUTER JOIN t.b USING(x)
 ----
-render               0  render  ·         ·               (x, y, z)                        ·
- │                   0  ·       render 0  x               ·                                ·
- │                   0  ·       render 1  "a.y"           ·                                ·
- │                   0  ·       render 2  "b.z"           ·                                ·
- └── render          1  render  ·         ·               (x, "a.x", "a.y", "b.x", "b.z")  ·
-      │              1  ·       render 0  COALESCE(x, x)  ·                                ·
-      │              1  ·       render 1  x               ·                                ·
-      │              1  ·       render 2  y               ·                                ·
-      │              1  ·       render 3  x               ·                                ·
-      │              1  ·       render 4  z               ·                                ·
-      └── join       2  join    ·         ·               (x, y, x, z)                     ·
-           │         2  ·       type      full outer      ·                                ·
-           │         2  ·       equality  (x) = (x)       ·                                ·
-           ├── scan  3  scan    ·         ·               (x, y)                           ·
-           │         3  ·       table     a@primary       ·                                ·
-           │         3  ·       spans     ALL             ·                                ·
-           └── scan  3  scan    ·         ·               (x, z)                           ·
-·                    3  ·       table     b@primary       ·                                ·
-·                    3  ·       spans     ALL             ·                                ·
+render          0  render  ·         ·               (x, y, z)     ·
+ │              0  ·       render 0  COALESCE(x, x)  ·             ·
+ │              0  ·       render 1  y               ·             ·
+ │              0  ·       render 2  z               ·             ·
+ └── join       1  join    ·         ·               (x, y, x, z)  ·
+      │         1  ·       type      full outer      ·             ·
+      │         1  ·       equality  (x) = (x)       ·             ·
+      ├── scan  2  scan    ·         ·               (x, y)        ·
+      │         2  ·       table     a@primary       ·             ·
+      │         2  ·       spans     ALL             ·             ·
+      └── scan  2  scan    ·         ·               (x, z)        ·
+·               2  ·       table     b@primary       ·             ·
+·               2  ·       spans     ALL             ·             ·
 
 exec
 SELECT * FROM t.a FULL OUTER JOIN t.b USING(x)

--- a/pkg/sql/opt/exec/execbuilder/testdata/project
+++ b/pkg/sql/opt/exec/execbuilder/testdata/project
@@ -61,11 +61,13 @@ x:int  y:int
 exec-explain
 SELECT x + 1 FROM t.a
 ----
-render     0  render  ·         ·          (column3)  ·
- │         0  ·       render 0  x + 1      ·          ·
- └── scan  1  scan    ·         ·          (x, y)     ·
-·          1  ·       table     a@primary  ·          ·
-·          1  ·       spans     ALL        ·          ·
+render          0  render  ·         ·          (column3)  ·
+ │              0  ·       render 0  x + 1      ·          ·
+ └── render     1  render  ·         ·          (x)        ·
+      │         1  ·       render 0  x          ·          ·
+      └── scan  2  scan    ·         ·          (x, y)     ·
+·               2  ·       table     a@primary  ·          ·
+·               2  ·       spans     ALL        ·          ·
 
 exec
 SELECT x + 1 FROM t.a
@@ -182,13 +184,16 @@ x:int  y:int
 exec-explain
 SELECT x FROM t.b WHERE rowid > 0
 ----
-render          0  render  ·         ·          (x)                    ·
- │              0  ·       render 0  x          ·                      ·
- └── filter     1  filter  ·         ·          (x, y, rowid[hidden])  ·
-      │         1  ·       filter    rowid > 0  ·                      ·
-      └── scan  2  scan    ·         ·          (x, y, rowid[hidden])  ·
-·               2  ·       table     b@primary  ·                      ·
-·               2  ·       spans     ALL        ·                      ·
+render               0  render  ·         ·          (x)                    ·
+ │                   0  ·       render 0  x          ·                      ·
+ └── filter          1  filter  ·         ·          (x, rowid)             ·
+      │              1  ·       filter    rowid > 0  ·                      ·
+      └── render     2  render  ·         ·          (x, rowid)             ·
+           │         2  ·       render 0  x          ·                      ·
+           │         2  ·       render 1  rowid      ·                      ·
+           └── scan  3  scan    ·         ·          (x, y, rowid[hidden])  ·
+·                    3  ·       table     b@primary  ·                      ·
+·                    3  ·       spans     ALL        ·                      ·
 
 exec
 SELECT x FROM t.b WHERE rowid > 0
@@ -214,11 +219,12 @@ TABLE nocols
 exec-explain
 SELECT 1, * FROM t.nocols
 ----
-render     0  render  ·         ·               (column2)        ·
- │         0  ·       render 0  1               ·                ·
- └── scan  1  scan    ·         ·               (rowid[hidden])  ·
-·          1  ·       table     nocols@primary  ·                ·
-·          1  ·       spans     ALL             ·                ·
+render          0  render  ·         ·               (column2)        ·
+ │              0  ·       render 0  1               ·                ·
+ └── render     1  render  ·         ·               ()               ·
+      └── scan  2  scan    ·         ·               (rowid[hidden])  ·
+·               2  ·       table     nocols@primary  ·                ·
+·               2  ·       spans     ALL             ·                ·
 
 exec
 SELECT 1, * FROM t.nocols

--- a/pkg/sql/opt/exec/execbuilder/testdata/scalar
+++ b/pkg/sql/opt/exec/execbuilder/testdata/scalar
@@ -50,246 +50,320 @@ render       0  render  ·         ·                 (column1)  ·
 exec-explain
 SELECT 1 + 2 FROM t.t
 ----
-render     0  render  ·         ·          (column8)                          ·
- │         0  ·       render 0  3          ·                                  ·
- └── scan  1  scan    ·         ·          (a, b, c, d, j, s, rowid[hidden])  ·
-·          1  ·       table     t@primary  ·                                  ·
-·          1  ·       spans     ALL        ·                                  ·
+render          0  render  ·         ·          (column8)                          ·
+ │              0  ·       render 0  3          ·                                  ·
+ └── render     1  render  ·         ·          ()                                 ·
+      └── scan  2  scan    ·         ·          (a, b, c, d, j, s, rowid[hidden])  ·
+·               2  ·       table     t@primary  ·                                  ·
+·               2  ·       spans     ALL        ·                                  ·
 
 exec-explain
 SELECT a + 2 FROM t.t
 ----
-render     0  render  ·         ·          (column8)                          ·
- │         0  ·       render 0  a + 2      ·                                  ·
- └── scan  1  scan    ·         ·          (a, b, c, d, j, s, rowid[hidden])  ·
-·          1  ·       table     t@primary  ·                                  ·
-·          1  ·       spans     ALL        ·                                  ·
+render          0  render  ·         ·          (column8)                          ·
+ │              0  ·       render 0  a + 2      ·                                  ·
+ └── render     1  render  ·         ·          (a)                                ·
+      │         1  ·       render 0  a          ·                                  ·
+      └── scan  2  scan    ·         ·          (a, b, c, d, j, s, rowid[hidden])  ·
+·               2  ·       table     t@primary  ·                                  ·
+·               2  ·       spans     ALL        ·                                  ·
 
 exec-explain
 SELECT a >= 5 AND b <= 10 AND c < 4 FROM t.t
 ----
-render     0  render  ·         ·                                     (column8)                          ·
- │         0  ·       render 0  ((a >= 5) AND (b <= 10)) AND (c < 4)  ·                                  ·
- └── scan  1  scan    ·         ·                                     (a, b, c, d, j, s, rowid[hidden])  ·
-·          1  ·       table     t@primary                             ·                                  ·
-·          1  ·       spans     ALL                                   ·                                  ·
+render          0  render  ·         ·                                     (column8)                          ·
+ │              0  ·       render 0  ((a >= 5) AND (b <= 10)) AND (c < 4)  ·                                  ·
+ └── render     1  render  ·         ·                                     (a, b, c)                          ·
+      │         1  ·       render 0  a                                     ·                                  ·
+      │         1  ·       render 1  b                                     ·                                  ·
+      │         1  ·       render 2  c                                     ·                                  ·
+      └── scan  2  scan    ·         ·                                     (a, b, c, d, j, s, rowid[hidden])  ·
+·               2  ·       table     t@primary                             ·                                  ·
+·               2  ·       spans     ALL                                   ·                                  ·
 
 exec-explain
 SELECT a >= 5 OR b <= 10 OR c < 4  FROM t.t
 ----
-render     0  render  ·         ·                                   (column8)                          ·
- │         0  ·       render 0  ((a >= 5) OR (b <= 10)) OR (c < 4)  ·                                  ·
- └── scan  1  scan    ·         ·                                   (a, b, c, d, j, s, rowid[hidden])  ·
-·          1  ·       table     t@primary                           ·                                  ·
-·          1  ·       spans     ALL                                 ·                                  ·
+render          0  render  ·         ·                                   (column8)                          ·
+ │              0  ·       render 0  ((a >= 5) OR (b <= 10)) OR (c < 4)  ·                                  ·
+ └── render     1  render  ·         ·                                   (a, b, c)                          ·
+      │         1  ·       render 0  a                                   ·                                  ·
+      │         1  ·       render 1  b                                   ·                                  ·
+      │         1  ·       render 2  c                                   ·                                  ·
+      └── scan  2  scan    ·         ·                                   (a, b, c, d, j, s, rowid[hidden])  ·
+·               2  ·       table     t@primary                           ·                                  ·
+·               2  ·       spans     ALL                                 ·                                  ·
 
 exec-explain
 SELECT NOT (a = 5) FROM t.t
 ----
-render     0  render  ·         ·          (column8)                          ·
- │         0  ·       render 0  a != 5     ·                                  ·
- └── scan  1  scan    ·         ·          (a, b, c, d, j, s, rowid[hidden])  ·
-·          1  ·       table     t@primary  ·                                  ·
-·          1  ·       spans     ALL        ·                                  ·
+render          0  render  ·         ·          (column8)                          ·
+ │              0  ·       render 0  a != 5     ·                                  ·
+ └── render     1  render  ·         ·          (a)                                ·
+      │         1  ·       render 0  a          ·                                  ·
+      └── scan  2  scan    ·         ·          (a, b, c, d, j, s, rowid[hidden])  ·
+·               2  ·       table     t@primary  ·                                  ·
+·               2  ·       spans     ALL        ·                                  ·
 
 exec-explain
 SELECT NOT (a > 5 AND b >= 10) FROM t.t
 ----
-render     0  render  ·         ·                     (column8)                          ·
- │         0  ·       render 0  (a <= 5) OR (b < 10)  ·                                  ·
- └── scan  1  scan    ·         ·                     (a, b, c, d, j, s, rowid[hidden])  ·
-·          1  ·       table     t@primary             ·                                  ·
-·          1  ·       spans     ALL                   ·                                  ·
+render          0  render  ·         ·                     (column8)                          ·
+ │              0  ·       render 0  (a <= 5) OR (b < 10)  ·                                  ·
+ └── render     1  render  ·         ·                     (a, b)                             ·
+      │         1  ·       render 0  a                     ·                                  ·
+      │         1  ·       render 1  b                     ·                                  ·
+      └── scan  2  scan    ·         ·                     (a, b, c, d, j, s, rowid[hidden])  ·
+·               2  ·       table     t@primary             ·                                  ·
+·               2  ·       spans     ALL                   ·                                  ·
 
 exec-explain
 SELECT (a >= 5 AND b <= 10) OR (a <= 10 AND c > 5) FROM t.t
 ----
-render     0  render  ·         ·                                                    (column8)                          ·
- │         0  ·       render 0  ((a >= 5) AND (b <= 10)) OR ((a <= 10) AND (c > 5))  ·                                  ·
- └── scan  1  scan    ·         ·                                                    (a, b, c, d, j, s, rowid[hidden])  ·
-·          1  ·       table     t@primary                                            ·                                  ·
-·          1  ·       spans     ALL                                                  ·                                  ·
+render          0  render  ·         ·                                                    (column8)                          ·
+ │              0  ·       render 0  ((a >= 5) AND (b <= 10)) OR ((a <= 10) AND (c > 5))  ·                                  ·
+ └── render     1  render  ·         ·                                                    (a, b, c)                          ·
+      │         1  ·       render 0  a                                                    ·                                  ·
+      │         1  ·       render 1  b                                                    ·                                  ·
+      │         1  ·       render 2  c                                                    ·                                  ·
+      └── scan  2  scan    ·         ·                                                    (a, b, c, d, j, s, rowid[hidden])  ·
+·               2  ·       table     t@primary                                            ·                                  ·
+·               2  ·       spans     ALL                                                  ·                                  ·
 
 exec-explain
 SELECT NOT (a >= 5 OR b <= 10) AND NOT (c >= 10) FROM t.t
 ----
-render     0  render  ·         ·                                    (column8)                          ·
- │         0  ·       render 0  ((a < 5) AND (b > 10)) AND (c < 10)  ·                                  ·
- └── scan  1  scan    ·         ·                                    (a, b, c, d, j, s, rowid[hidden])  ·
-·          1  ·       table     t@primary                            ·                                  ·
-·          1  ·       spans     ALL                                  ·                                  ·
-
+render          0  render  ·         ·                                    (column8)                          ·
+ │              0  ·       render 0  ((a < 5) AND (b > 10)) AND (c < 10)  ·                                  ·
+ └── render     1  render  ·         ·                                    (a, b, c)                          ·
+      │         1  ·       render 0  a                                    ·                                  ·
+      │         1  ·       render 1  b                                    ·                                  ·
+      │         1  ·       render 2  c                                    ·                                  ·
+      └── scan  2  scan    ·         ·                                    (a, b, c, d, j, s, rowid[hidden])  ·
+·               2  ·       table     t@primary                            ·                                  ·
+·               2  ·       spans     ALL                                  ·                                  ·
 
 exec-explain
 SELECT (a, b) = (1, 2)  FROM t.t
 ----
-render     0  render  ·         ·                    (column8)                          ·
- │         0  ·       render 0  (a = 1) AND (b = 2)  ·                                  ·
- └── scan  1  scan    ·         ·                    (a, b, c, d, j, s, rowid[hidden])  ·
-·          1  ·       table     t@primary            ·                                  ·
-·          1  ·       spans     ALL                  ·                                  ·
+render          0  render  ·         ·                    (column8)                          ·
+ │              0  ·       render 0  (a = 1) AND (b = 2)  ·                                  ·
+ └── render     1  render  ·         ·                    (a, b)                             ·
+      │         1  ·       render 0  a                    ·                                  ·
+      │         1  ·       render 1  b                    ·                                  ·
+      └── scan  2  scan    ·         ·                    (a, b, c, d, j, s, rowid[hidden])  ·
+·               2  ·       table     t@primary            ·                                  ·
+·               2  ·       spans     ALL                  ·                                  ·
 
 exec-explain
 SELECT a IN (1, 2) FROM t.t
 ----
-render     0  render  ·         ·            (column8)                          ·
- │         0  ·       render 0  a IN (1, 2)  ·                                  ·
- └── scan  1  scan    ·         ·            (a, b, c, d, j, s, rowid[hidden])  ·
-·          1  ·       table     t@primary    ·                                  ·
-·          1  ·       spans     ALL          ·                                  ·
+render          0  render  ·         ·            (column8)                          ·
+ │              0  ·       render 0  a IN (1, 2)  ·                                  ·
+ └── render     1  render  ·         ·            (a)                                ·
+      │         1  ·       render 0  a            ·                                  ·
+      └── scan  2  scan    ·         ·            (a, b, c, d, j, s, rowid[hidden])  ·
+·               2  ·       table     t@primary    ·                                  ·
+·               2  ·       spans     ALL          ·                                  ·
 
 exec-explain
 SELECT (a, b) IN ((1, 2), (3, 4)) FROM t.t
 ----
-render     0  render  ·         ·                           (column8)                          ·
- │         0  ·       render 0  (a, b) IN ((1, 2), (3, 4))  ·                                  ·
- └── scan  1  scan    ·         ·                           (a, b, c, d, j, s, rowid[hidden])  ·
-·          1  ·       table     t@primary                   ·                                  ·
-·          1  ·       spans     ALL                         ·                                  ·
+render          0  render  ·         ·                           (column8)                          ·
+ │              0  ·       render 0  (a, b) IN ((1, 2), (3, 4))  ·                                  ·
+ └── render     1  render  ·         ·                           (a, b)                             ·
+      │         1  ·       render 0  a                           ·                                  ·
+      │         1  ·       render 1  b                           ·                                  ·
+      └── scan  2  scan    ·         ·                           (a, b, c, d, j, s, rowid[hidden])  ·
+·               2  ·       table     t@primary                   ·                                  ·
+·               2  ·       spans     ALL                         ·                                  ·
 
 exec-explain
 SELECT (a, b + c, 5 + d * 2) = (b+c, 8, a - c)  FROM t.t
 ----
-render     0  render  ·         ·                                                                (column8)                          ·
- │         0  ·       render 0  ((a = (b + c)) AND ((b + c) = 8)) AND (((d * 2) + 5) = (a - c))  ·                                  ·
- └── scan  1  scan    ·         ·                                                                (a, b, c, d, j, s, rowid[hidden])  ·
-·          1  ·       table     t@primary                                                        ·                                  ·
-·          1  ·       spans     ALL                                                              ·                                  ·
+render          0  render  ·         ·                                                                (column8)                          ·
+ │              0  ·       render 0  ((a = (b + c)) AND ((b + c) = 8)) AND (((d * 2) + 5) = (a - c))  ·                                  ·
+ └── render     1  render  ·         ·                                                                (a, b, c, d)                       ·
+      │         1  ·       render 0  a                                                                ·                                  ·
+      │         1  ·       render 1  b                                                                ·                                  ·
+      │         1  ·       render 2  c                                                                ·                                  ·
+      │         1  ·       render 3  d                                                                ·                                  ·
+      └── scan  2  scan    ·         ·                                                                (a, b, c, d, j, s, rowid[hidden])  ·
+·               2  ·       table     t@primary                                                        ·                                  ·
+·               2  ·       spans     ALL                                                              ·                                  ·
 
 exec-explain
 SELECT ((a, b), (c, d)) = ((1, 2), (3, 4))  FROM t.t
 ----
-render     0  render  ·         ·                                                (column8)                          ·
- │         0  ·       render 0  (((a = 1) AND (b = 2)) AND (c = 3)) AND (d = 4)  ·                                  ·
- └── scan  1  scan    ·         ·                                                (a, b, c, d, j, s, rowid[hidden])  ·
-·          1  ·       table     t@primary                                        ·                                  ·
-·          1  ·       spans     ALL                                              ·                                  ·
+render          0  render  ·         ·                                                (column8)                          ·
+ │              0  ·       render 0  (((a = 1) AND (b = 2)) AND (c = 3)) AND (d = 4)  ·                                  ·
+ └── render     1  render  ·         ·                                                (a, b, c, d)                       ·
+      │         1  ·       render 0  a                                                ·                                  ·
+      │         1  ·       render 1  b                                                ·                                  ·
+      │         1  ·       render 2  c                                                ·                                  ·
+      │         1  ·       render 3  d                                                ·                                  ·
+      └── scan  2  scan    ·         ·                                                (a, b, c, d, j, s, rowid[hidden])  ·
+·               2  ·       table     t@primary                                        ·                                  ·
+·               2  ·       spans     ALL                                              ·                                  ·
 
 exec-explain
 SELECT (a, (b, 'a'), (c, 'b', 5)) = (9, (a+c, s), (5, s, a)) FROM t.t
 ----
-render     0  render  ·         ·                                                                                      (column8)                          ·
- │         0  ·       render 0  (((((a = 9) AND (b = (a + c))) AND (s = 'a')) AND (c = 5)) AND (s = 'b')) AND (a = 5)  ·                                  ·
- └── scan  1  scan    ·         ·                                                                                      (a, b, c, d, j, s, rowid[hidden])  ·
-·          1  ·       table     t@primary                                                                              ·                                  ·
-·          1  ·       spans     ALL                                                                                    ·                                  ·
+render          0  render  ·         ·                                                                                      (column8)                          ·
+ │              0  ·       render 0  (((((a = 9) AND (b = (a + c))) AND (s = 'a')) AND (c = 5)) AND (s = 'b')) AND (a = 5)  ·                                  ·
+ └── render     1  render  ·         ·                                                                                      (a, b, c, s)                       ·
+      │         1  ·       render 0  a                                                                                      ·                                  ·
+      │         1  ·       render 1  b                                                                                      ·                                  ·
+      │         1  ·       render 2  c                                                                                      ·                                  ·
+      │         1  ·       render 3  s                                                                                      ·                                  ·
+      └── scan  2  scan    ·         ·                                                                                      (a, b, c, d, j, s, rowid[hidden])  ·
+·               2  ·       table     t@primary                                                                              ·                                  ·
+·               2  ·       spans     ALL                                                                                    ·                                  ·
 
 exec-explain
 SELECT a IS NULL FROM t.t
 ----
-render     0  render  ·         ·          (column8)                          ·
- │         0  ·       render 0  a IS NULL  ·                                  ·
- └── scan  1  scan    ·         ·          (a, b, c, d, j, s, rowid[hidden])  ·
-·          1  ·       table     t@primary  ·                                  ·
-·          1  ·       spans     ALL        ·                                  ·
+render          0  render  ·         ·          (column8)                          ·
+ │              0  ·       render 0  a IS NULL  ·                                  ·
+ └── render     1  render  ·         ·          (a)                                ·
+      │         1  ·       render 0  a          ·                                  ·
+      └── scan  2  scan    ·         ·          (a, b, c, d, j, s, rowid[hidden])  ·
+·               2  ·       table     t@primary  ·                                  ·
+·               2  ·       spans     ALL        ·                                  ·
 
 exec-explain
 SELECT a IS NOT DISTINCT FROM NULL FROM t.t
 ----
-render     0  render  ·         ·          (column8)                          ·
- │         0  ·       render 0  a IS NULL  ·                                  ·
- └── scan  1  scan    ·         ·          (a, b, c, d, j, s, rowid[hidden])  ·
-·          1  ·       table     t@primary  ·                                  ·
-·          1  ·       spans     ALL        ·                                  ·
+render          0  render  ·         ·          (column8)                          ·
+ │              0  ·       render 0  a IS NULL  ·                                  ·
+ └── render     1  render  ·         ·          (a)                                ·
+      │         1  ·       render 0  a          ·                                  ·
+      └── scan  2  scan    ·         ·          (a, b, c, d, j, s, rowid[hidden])  ·
+·               2  ·       table     t@primary  ·                                  ·
+·               2  ·       spans     ALL        ·                                  ·
 
 exec-explain
 SELECT a IS NOT DISTINCT FROM b FROM t.t
 ----
-render     0  render  ·         ·                         (column8)                          ·
- │         0  ·       render 0  a IS NOT DISTINCT FROM b  ·                                  ·
- └── scan  1  scan    ·         ·                         (a, b, c, d, j, s, rowid[hidden])  ·
-·          1  ·       table     t@primary                 ·                                  ·
-·          1  ·       spans     ALL                       ·                                  ·
+render          0  render  ·         ·                         (column8)                          ·
+ │              0  ·       render 0  a IS NOT DISTINCT FROM b  ·                                  ·
+ └── render     1  render  ·         ·                         (a, b)                             ·
+      │         1  ·       render 0  a                         ·                                  ·
+      │         1  ·       render 1  b                         ·                                  ·
+      └── scan  2  scan    ·         ·                         (a, b, c, d, j, s, rowid[hidden])  ·
+·               2  ·       table     t@primary                 ·                                  ·
+·               2  ·       spans     ALL                       ·                                  ·
 
 exec-explain
 SELECT a IS NOT NULL FROM t.t
 ----
-render     0  render  ·         ·              (column8)                          ·
- │         0  ·       render 0  a IS NOT NULL  ·                                  ·
- └── scan  1  scan    ·         ·              (a, b, c, d, j, s, rowid[hidden])  ·
-·          1  ·       table     t@primary      ·                                  ·
-·          1  ·       spans     ALL            ·                                  ·
+render          0  render  ·         ·              (column8)                          ·
+ │              0  ·       render 0  a IS NOT NULL  ·                                  ·
+ └── render     1  render  ·         ·              (a)                                ·
+      │         1  ·       render 0  a              ·                                  ·
+      └── scan  2  scan    ·         ·              (a, b, c, d, j, s, rowid[hidden])  ·
+·               2  ·       table     t@primary      ·                                  ·
+·               2  ·       spans     ALL            ·                                  ·
 
 exec-explain
 SELECT a IS DISTINCT FROM NULL FROM t.t
 ----
-render     0  render  ·         ·              (column8)                          ·
- │         0  ·       render 0  a IS NOT NULL  ·                                  ·
- └── scan  1  scan    ·         ·              (a, b, c, d, j, s, rowid[hidden])  ·
-·          1  ·       table     t@primary      ·                                  ·
-·          1  ·       spans     ALL            ·                                  ·
+render          0  render  ·         ·              (column8)                          ·
+ │              0  ·       render 0  a IS NOT NULL  ·                                  ·
+ └── render     1  render  ·         ·              (a)                                ·
+      │         1  ·       render 0  a              ·                                  ·
+      └── scan  2  scan    ·         ·              (a, b, c, d, j, s, rowid[hidden])  ·
+·               2  ·       table     t@primary      ·                                  ·
+·               2  ·       spans     ALL            ·                                  ·
 
 exec-explain
 SELECT a IS DISTINCT FROM b FROM t.t
 ----
-render     0  render  ·         ·                     (column8)                          ·
- │         0  ·       render 0  a IS DISTINCT FROM b  ·                                  ·
- └── scan  1  scan    ·         ·                     (a, b, c, d, j, s, rowid[hidden])  ·
-·          1  ·       table     t@primary             ·                                  ·
-·          1  ·       spans     ALL                   ·                                  ·
+render          0  render  ·         ·                     (column8)                          ·
+ │              0  ·       render 0  a IS DISTINCT FROM b  ·                                  ·
+ └── render     1  render  ·         ·                     (a, b)                             ·
+      │         1  ·       render 0  a                     ·                                  ·
+      │         1  ·       render 1  b                     ·                                  ·
+      └── scan  2  scan    ·         ·                     (a, b, c, d, j, s, rowid[hidden])  ·
+·               2  ·       table     t@primary             ·                                  ·
+·               2  ·       spans     ALL                   ·                                  ·
 
 exec-explain
 SELECT +a + (-b) FROM t.t
 ----
-render     0  render  ·         ·          (column8)                          ·
- │         0  ·       render 0  a + (-b)   ·                                  ·
- └── scan  1  scan    ·         ·          (a, b, c, d, j, s, rowid[hidden])  ·
-·          1  ·       table     t@primary  ·                                  ·
-·          1  ·       spans     ALL        ·                                  ·
+render          0  render  ·         ·          (column8)                          ·
+ │              0  ·       render 0  a + (-b)   ·                                  ·
+ └── render     1  render  ·         ·          (a, b)                             ·
+      │         1  ·       render 0  a          ·                                  ·
+      │         1  ·       render 1  b          ·                                  ·
+      └── scan  2  scan    ·         ·          (a, b, c, d, j, s, rowid[hidden])  ·
+·               2  ·       table     t@primary  ·                                  ·
+·               2  ·       spans     ALL        ·                                  ·
 
 exec-explain
 SELECT CASE a WHEN 1 THEN 2 WHEN 2 THEN 3 ELSE 4 END FROM t.t
 ----
-render     0  render  ·         ·                                              (column8)                          ·
- │         0  ·       render 0  CASE a WHEN 1 THEN 2 WHEN 2 THEN 3 ELSE 4 END  ·                                  ·
- └── scan  1  scan    ·         ·                                              (a, b, c, d, j, s, rowid[hidden])  ·
-·          1  ·       table     t@primary                                      ·                                  ·
-·          1  ·       spans     ALL                                            ·                                  ·
+render          0  render  ·         ·                                              (column8)                          ·
+ │              0  ·       render 0  CASE a WHEN 1 THEN 2 WHEN 2 THEN 3 ELSE 4 END  ·                                  ·
+ └── render     1  render  ·         ·                                              (a)                                ·
+      │         1  ·       render 0  a                                              ·                                  ·
+      └── scan  2  scan    ·         ·                                              (a, b, c, d, j, s, rowid[hidden])  ·
+·               2  ·       table     t@primary                                      ·                                  ·
+·               2  ·       spans     ALL                                            ·                                  ·
 
 exec-explain
 SELECT CASE WHEN a = 2 THEN 1 ELSE 2 END FROM t.t
 ----
-render     0  render  ·         ·                                  (column8)                          ·
- │         0  ·       render 0  CASE WHEN a = 2 THEN 1 ELSE 2 END  ·                                  ·
- └── scan  1  scan    ·         ·                                  (a, b, c, d, j, s, rowid[hidden])  ·
-·          1  ·       table     t@primary                          ·                                  ·
-·          1  ·       spans     ALL                                ·                                  ·
+render          0  render  ·         ·                                  (column8)                          ·
+ │              0  ·       render 0  CASE WHEN a = 2 THEN 1 ELSE 2 END  ·                                  ·
+ └── render     1  render  ·         ·                                  (a)                                ·
+      │         1  ·       render 0  a                                  ·                                  ·
+      └── scan  2  scan    ·         ·                                  (a, b, c, d, j, s, rowid[hidden])  ·
+·               2  ·       table     t@primary                          ·                                  ·
+·               2  ·       spans     ALL                                ·                                  ·
 
 exec-explain
 SELECT CASE a + 3 WHEN 5 * b THEN 1 % b WHEN 6 THEN 2 ELSE -1 END FROM t.t
 ----
-render     0  render  ·         ·                                                           (column8)                          ·
- │         0  ·       render 0  CASE a + 3 WHEN b * 5 THEN 1 % b WHEN 6 THEN 2 ELSE -1 END  ·                                  ·
- └── scan  1  scan    ·         ·                                                           (a, b, c, d, j, s, rowid[hidden])  ·
-·          1  ·       table     t@primary                                                   ·                                  ·
-·          1  ·       spans     ALL                                                         ·                                  ·
+render          0  render  ·         ·                                                           (column8)                          ·
+ │              0  ·       render 0  CASE a + 3 WHEN b * 5 THEN 1 % b WHEN 6 THEN 2 ELSE -1 END  ·                                  ·
+ └── render     1  render  ·         ·                                                           (a, b)                             ·
+      │         1  ·       render 0  a                                                           ·                                  ·
+      │         1  ·       render 1  b                                                           ·                                  ·
+      └── scan  2  scan    ·         ·                                                           (a, b, c, d, j, s, rowid[hidden])  ·
+·               2  ·       table     t@primary                                                   ·                                  ·
+·               2  ·       spans     ALL                                                         ·                                  ·
 
 # Tests for CASE with no ELSE statement
 exec-explain
 SELECT CASE WHEN a = 2 THEN 1 END FROM t.t
 ----
-render     0  render  ·         ·                           (column8)                          ·
- │         0  ·       render 0  CASE WHEN a = 2 THEN 1 END  ·                                  ·
- └── scan  1  scan    ·         ·                           (a, b, c, d, j, s, rowid[hidden])  ·
-·          1  ·       table     t@primary                   ·                                  ·
-·          1  ·       spans     ALL                         ·                                  ·
+render          0  render  ·         ·                           (column8)                          ·
+ │              0  ·       render 0  CASE WHEN a = 2 THEN 1 END  ·                                  ·
+ └── render     1  render  ·         ·                           (a)                                ·
+      │         1  ·       render 0  a                           ·                                  ·
+      └── scan  2  scan    ·         ·                           (a, b, c, d, j, s, rowid[hidden])  ·
+·               2  ·       table     t@primary                   ·                                  ·
+·               2  ·       spans     ALL                         ·                                  ·
 
 exec-explain
 SELECT CASE a WHEN 2 THEN 1 END FROM t.t
 ----
-render     0  render  ·         ·                         (column8)                          ·
- │         0  ·       render 0  CASE a WHEN 2 THEN 1 END  ·                                  ·
- └── scan  1  scan    ·         ·                         (a, b, c, d, j, s, rowid[hidden])  ·
-·          1  ·       table     t@primary                 ·                                  ·
-·          1  ·       spans     ALL                       ·                                  ·
+render          0  render  ·         ·                         (column8)                          ·
+ │              0  ·       render 0  CASE a WHEN 2 THEN 1 END  ·                                  ·
+ └── render     1  render  ·         ·                         (a)                                ·
+      │         1  ·       render 0  a                         ·                                  ·
+      └── scan  2  scan    ·         ·                         (a, b, c, d, j, s, rowid[hidden])  ·
+·               2  ·       table     t@primary                 ·                                  ·
+·               2  ·       spans     ALL                       ·                                  ·
 
 exec-explain allow-unsupported
 SELECT a FROM t.t WHERE a IS OF (INT)
 ----
-render          0  render  ·         ·                         (a)                                ·
- │              0  ·       render 0  a                         ·                                  ·
- └── filter     1  filter  ·         ·                         (a, b, c, d, j, s, rowid[hidden])  ·
-      │         1  ·       filter    t.public.t.a IS OF (INT)  ·                                  ·
+filter          0  filter  ·         ·                         (a)                                ·
+ │              0  ·       filter    t.public.t.a IS OF (INT)  ·                                  ·
+ └── render     1  render  ·         ·                         (a)                                ·
+      │         1  ·       render 0  a                         ·                                  ·
       └── scan  2  scan    ·         ·                         (a, b, c, d, j, s, rowid[hidden])  ·
 ·               2  ·       table     t@primary                 ·                                  ·
 ·               2  ·       spans     ALL                       ·                                  ·
@@ -297,11 +371,13 @@ render          0  render  ·         ·                         (a)            
 exec-explain
 SELECT LENGTH(s) FROM t.t
 ----
-render     0  render  ·         ·          (column8)                          ·
- │         0  ·       render 0  length(s)  ·                                  ·
- └── scan  1  scan    ·         ·          (a, b, c, d, j, s, rowid[hidden])  ·
-·          1  ·       table     t@primary  ·                                  ·
-·          1  ·       spans     ALL        ·                                  ·
+render          0  render  ·         ·          (column8)                          ·
+ │              0  ·       render 0  length(s)  ·                                  ·
+ └── render     1  render  ·         ·          (s)                                ·
+      │         1  ·       render 0  s          ·                                  ·
+      └── scan  2  scan    ·         ·          (a, b, c, d, j, s, rowid[hidden])  ·
+·               2  ·       table     t@primary  ·                                  ·
+·               2  ·       spans     ALL        ·                                  ·
 
 # Verify that the built function can be executed.
 exec-raw
@@ -320,39 +396,50 @@ column3:int
 exec-explain
 SELECT j @> '{"a": 1}' FROM t.t
 ----
-render     0  render  ·         ·                (column8)                          ·
- │         0  ·       render 0  j @> '{"a": 1}'  ·                                  ·
- └── scan  1  scan    ·         ·                (a, b, c, d, j, s, rowid[hidden])  ·
-·          1  ·       table     t@primary        ·                                  ·
-·          1  ·       spans     ALL              ·                                  ·
+render          0  render  ·         ·                (column8)                          ·
+ │              0  ·       render 0  j @> '{"a": 1}'  ·                                  ·
+ └── render     1  render  ·         ·                (j)                                ·
+      │         1  ·       render 0  j                ·                                  ·
+      └── scan  2  scan    ·         ·                (a, b, c, d, j, s, rowid[hidden])  ·
+·               2  ·       table     t@primary        ·                                  ·
+·               2  ·       spans     ALL              ·                                  ·
 
 exec-explain
 SELECT '{"a": 1}' <@ j FROM t.t
 ----
-render     0  render  ·         ·                (column8)                          ·
- │         0  ·       render 0  j @> '{"a": 1}'  ·                                  ·
- └── scan  1  scan    ·         ·                (a, b, c, d, j, s, rowid[hidden])  ·
-·          1  ·       table     t@primary        ·                                  ·
-·          1  ·       spans     ALL              ·                                  ·
+render          0  render  ·         ·                (column8)                          ·
+ │              0  ·       render 0  j @> '{"a": 1}'  ·                                  ·
+ └── render     1  render  ·         ·                (j)                                ·
+      │         1  ·       render 0  j                ·                                  ·
+      └── scan  2  scan    ·         ·                (a, b, c, d, j, s, rowid[hidden])  ·
+·               2  ·       table     t@primary        ·                                  ·
+·               2  ·       spans     ALL              ·                                  ·
 
 exec-explain
 SELECT CAST(a AS string), b::float FROM t.t
 ----
-render     0  render  ·         ·          (column8, column9)                 ·
- │         0  ·       render 0  a::STRING  ·                                  ·
- │         0  ·       render 1  b::FLOAT   ·                                  ·
- └── scan  1  scan    ·         ·          (a, b, c, d, j, s, rowid[hidden])  ·
-·          1  ·       table     t@primary  ·                                  ·
-·          1  ·       spans     ALL        ·                                  ·
+render          0  render  ·         ·          (column8, column9)                 ·
+ │              0  ·       render 0  a::STRING  ·                                  ·
+ │              0  ·       render 1  b::FLOAT   ·                                  ·
+ └── render     1  render  ·         ·          (a, b)                             ·
+      │         1  ·       render 0  a          ·                                  ·
+      │         1  ·       render 1  b          ·                                  ·
+      └── scan  2  scan    ·         ·          (a, b, c, d, j, s, rowid[hidden])  ·
+·               2  ·       table     t@primary  ·                                  ·
+·               2  ·       spans     ALL        ·                                  ·
 
 exec-explain
 SELECT CAST(a + b + c AS string) FROM t.t
 ----
-render     0  render  ·         ·                      (column8)                          ·
- │         0  ·       render 0  (c + (a + b))::STRING  ·                                  ·
- └── scan  1  scan    ·         ·                      (a, b, c, d, j, s, rowid[hidden])  ·
-·          1  ·       table     t@primary              ·                                  ·
-·          1  ·       spans     ALL                    ·                                  ·
+render          0  render  ·         ·                      (column8)                          ·
+ │              0  ·       render 0  (c + (a + b))::STRING  ·                                  ·
+ └── render     1  render  ·         ·                      (a, b, c)                          ·
+      │         1  ·       render 0  a                      ·                                  ·
+      │         1  ·       render 1  b                      ·                                  ·
+      │         1  ·       render 2  c                      ·                                  ·
+      └── scan  2  scan    ·         ·                      (a, b, c, d, j, s, rowid[hidden])  ·
+·               2  ·       table     t@primary              ·                                  ·
+·               2  ·       spans     ALL                    ·                                  ·
 
 exec
 SELECT LENGTH(s)::float, s FROM t.str
@@ -419,39 +506,55 @@ NULL
 exec-explain
 SELECT a FROM t.t WHERE a BETWEEN b AND d
 ----
-render          0  render  ·         ·                      (a)                                ·
- │              0  ·       render 0  a                      ·                                  ·
- └── filter     1  filter  ·         ·                      (a, b, c, d, j, s, rowid[hidden])  ·
-      │         1  ·       filter    (a >= b) AND (a <= d)  ·                                  ·
-      └── scan  2  scan    ·         ·                      (a, b, c, d, j, s, rowid[hidden])  ·
-·               2  ·       table     t@primary              ·                                  ·
-·               2  ·       spans     ALL                    ·                                  ·
+render               0  render  ·         ·                      (a)                                ·
+ │                   0  ·       render 0  a                      ·                                  ·
+ └── filter          1  filter  ·         ·                      (a, b, d)                          ·
+      │              1  ·       filter    (a >= b) AND (a <= d)  ·                                  ·
+      └── render     2  render  ·         ·                      (a, b, d)                          ·
+           │         2  ·       render 0  a                      ·                                  ·
+           │         2  ·       render 1  b                      ·                                  ·
+           │         2  ·       render 2  d                      ·                                  ·
+           └── scan  3  scan    ·         ·                      (a, b, c, d, j, s, rowid[hidden])  ·
+·                    3  ·       table     t@primary              ·                                  ·
+·                    3  ·       spans     ALL                    ·                                  ·
 
 exec-explain
 SELECT a FROM t.t WHERE a NOT BETWEEN b AND d
 ----
-render          0  render  ·         ·                   (a)                                ·
- │              0  ·       render 0  a                   ·                                  ·
- └── filter     1  filter  ·         ·                   (a, b, c, d, j, s, rowid[hidden])  ·
-      │         1  ·       filter    (a < b) OR (a > d)  ·                                  ·
-      └── scan  2  scan    ·         ·                   (a, b, c, d, j, s, rowid[hidden])  ·
-·               2  ·       table     t@primary           ·                                  ·
-·               2  ·       spans     ALL                 ·                                  ·
+render               0  render  ·         ·                   (a)                                ·
+ │                   0  ·       render 0  a                   ·                                  ·
+ └── filter          1  filter  ·         ·                   (a, b, d)                          ·
+      │              1  ·       filter    (a < b) OR (a > d)  ·                                  ·
+      └── render     2  render  ·         ·                   (a, b, d)                          ·
+           │         2  ·       render 0  a                   ·                                  ·
+           │         2  ·       render 1  b                   ·                                  ·
+           │         2  ·       render 2  d                   ·                                  ·
+           └── scan  3  scan    ·         ·                   (a, b, c, d, j, s, rowid[hidden])  ·
+·                    3  ·       table     t@primary           ·                                  ·
+·                    3  ·       spans     ALL                 ·                                  ·
 
 exec-explain
 SELECT a BETWEEN SYMMETRIC b AND d FROM t.t
 ----
-render     0  render  ·         ·                                                   (column8)                          ·
- │         0  ·       render 0  ((a >= b) AND (a <= d)) OR ((a >= d) AND (a <= b))  ·                                  ·
- └── scan  1  scan    ·         ·                                                   (a, b, c, d, j, s, rowid[hidden])  ·
-·          1  ·       table     t@primary                                           ·                                  ·
-·          1  ·       spans     ALL                                                 ·                                  ·
+render          0  render  ·         ·                                                   (column8)                          ·
+ │              0  ·       render 0  ((a >= b) AND (a <= d)) OR ((a >= d) AND (a <= b))  ·                                  ·
+ └── render     1  render  ·         ·                                                   (a, b, d)                          ·
+      │         1  ·       render 0  a                                                   ·                                  ·
+      │         1  ·       render 1  b                                                   ·                                  ·
+      │         1  ·       render 2  d                                                   ·                                  ·
+      └── scan  2  scan    ·         ·                                                   (a, b, c, d, j, s, rowid[hidden])  ·
+·               2  ·       table     t@primary                                           ·                                  ·
+·               2  ·       spans     ALL                                                 ·                                  ·
 
 exec-explain
 SELECT a NOT BETWEEN SYMMETRIC b AND d FROM t.t
 ----
-render     0  render  ·         ·                                              (column8)                          ·
- │         0  ·       render 0  ((a < b) OR (a > d)) AND ((a < d) OR (a > b))  ·                                  ·
- └── scan  1  scan    ·         ·                                              (a, b, c, d, j, s, rowid[hidden])  ·
-·          1  ·       table     t@primary                                      ·                                  ·
-·          1  ·       spans     ALL                                            ·                                  ·
+render          0  render  ·         ·                                              (column8)                          ·
+ │              0  ·       render 0  ((a < b) OR (a > d)) AND ((a < d) OR (a > b))  ·                                  ·
+ └── render     1  render  ·         ·                                              (a, b, d)                          ·
+      │         1  ·       render 0  a                                              ·                                  ·
+      │         1  ·       render 1  b                                              ·                                  ·
+      │         1  ·       render 2  d                                              ·                                  ·
+      └── scan  2  scan    ·         ·                                              (a, b, c, d, j, s, rowid[hidden])  ·
+·               2  ·       table     t@primary                                      ·                                  ·
+·               2  ·       spans     ALL                                            ·                                  ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/scan
+++ b/pkg/sql/opt/exec/execbuilder/testdata/scan
@@ -3,40 +3,88 @@ CREATE DATABASE t
 ----
 
 exec-raw
-CREATE TABLE t.a (x INT PRIMARY KEY, y FLOAT);
-INSERT INTO t.a VALUES (1, 1.0), (2, 2.0), (3, 3.0)
+CREATE TABLE t.a (x INT PRIMARY KEY, y FLOAT, s STRING);
+INSERT INTO t.a VALUES (1, 1.0, 'apple'), (2, 2.0, 'banana'), (3, 3.0, 'cherry')
 ----
 
 build
 SELECT * FROM t.a
 ----
 scan
- └── columns: x:1(int!null) y:2(float)
+ └── columns: x:1(int!null) y:2(float) s:3(string)
 
 exec-explain
 SELECT * FROM t.a
 ----
-scan  0  scan  ·      ·          (x, y)  ·
-·     0  ·     table  a@primary  ·       ·
-·     0  ·     spans  ALL        ·       ·
+scan  0  scan  ·      ·          (x, y, s)  ·
+·     0  ·     table  a@primary  ·          ·
+·     0  ·     spans  ALL        ·          ·
 
 exec
 SELECT * FROM t.a
 ----
-x:int  y:float
-1      1.0
-2      2.0
-3      3.0
+x:int  y:float  s:string
+1      1.0      apple
+2      2.0      banana
+3      3.0      cherry
 
-exec-raw
-CREATE TABLE t.b (x INT, y INT);
-INSERT INTO t.b VALUES (1, 10), (2, 20), (3, 30)
+# Test projecting subset of table columns.
+build
+SELECT s, x FROM t.a
 ----
+scan
+ └── columns: s:3(string) x:1(int!null)
+
+exec-explain
+SELECT s, x FROM t.a
+----
+render          0  render  ·         ·          (s, x)     ·
+ │              0  ·       render 0  s          ·          ·
+ │              0  ·       render 1  x          ·          ·
+ └── render     1  render  ·         ·          (x, s)     ·
+      │         1  ·       render 0  x          ·          ·
+      │         1  ·       render 1  s          ·          ·
+      └── scan  2  scan    ·         ·          (x, y, s)  ·
+·               2  ·       table     a@primary  ·          ·
+·               2  ·       spans     ALL        ·          ·
+
+exec
+SELECT s, x FROM t.a
+----
+s:string  x:int
+apple     1
+banana    2
+cherry    3
 
 # Test with a hidden column.
-exec-explain
-SELECT x, y, rowid FROM t.b
+exec-raw
+CREATE TABLE t.b (x INT, y INT, s STRING);
+INSERT INTO t.b VALUES (1, 10, 'apple'), (2, 20, 'banana'), (3, 30, 'cherry')
 ----
-scan  0  scan  ·      ·          (x, y, rowid[hidden])  ·
-·     0  ·     table  b@primary  ·                      ·
-·     0  ·     spans  ALL        ·                      ·
+
+build
+SELECT s, x FROM t.b
+----
+scan
+ └── columns: s:3(string) x:1(int)
+
+exec
+SELECT s, x FROM t.b
+----
+s:string  x:int
+apple     1
+banana    2
+cherry    3
+
+exec-explain
+SELECT s, x FROM t.b
+----
+render          0  render  ·         ·          (s, x)                    ·
+ │              0  ·       render 0  s          ·                         ·
+ │              0  ·       render 1  x          ·                         ·
+ └── render     1  render  ·         ·          (x, s)                    ·
+      │         1  ·       render 0  x          ·                         ·
+      │         1  ·       render 1  s          ·                         ·
+      └── scan  2  scan    ·         ·          (x, y, s, rowid[hidden])  ·
+·               2  ·       table     b@primary  ·                         ·
+·               2  ·       spans     ALL        ·                         ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/union
+++ b/pkg/sql/opt/exec/execbuilder/testdata/union
@@ -192,12 +192,12 @@ exec-explain
 SELECT v FROM t.uniontest UNION SELECT k FROM t.uniontest
 ----
 union           0  union   ·         ·                  (v)                    ·
- ├── render     1  render  ·         ·                  ("uniontest.k")        ·
+ ├── render     1  render  ·         ·                  (k)                    ·
  │    │         1  ·       render 0  k                  ·                      ·
  │    └── scan  2  scan    ·         ·                  (k, v, rowid[hidden])  ·
  │              2  ·       table     uniontest@primary  ·                      ·
  │              2  ·       spans     ALL                ·                      ·
- └── render     1  render  ·         ·                  ("uniontest.v")        ·
+ └── render     1  render  ·         ·                  (v)                    ·
       │         1  ·       render 0  v                  ·                      ·
       └── scan  2  scan    ·         ·                  (k, v, rowid[hidden])  ·
 ·               2  ·       table     uniontest@primary  ·                      ·
@@ -207,12 +207,12 @@ exec-explain
 SELECT v FROM t.uniontest UNION ALL SELECT k FROM t.uniontest
 ----
 append          0  append  ·         ·                  (v)                    ·
- ├── render     1  render  ·         ·                  ("uniontest.k")        ·
+ ├── render     1  render  ·         ·                  (k)                    ·
  │    │         1  ·       render 0  k                  ·                      ·
  │    └── scan  2  scan    ·         ·                  (k, v, rowid[hidden])  ·
  │              2  ·       table     uniontest@primary  ·                      ·
  │              2  ·       spans     ALL                ·                      ·
- └── render     1  render  ·         ·                  ("uniontest.v")        ·
+ └── render     1  render  ·         ·                  (v)                    ·
       │         1  ·       render 0  v                  ·                      ·
       └── scan  2  scan    ·         ·                  (k, v, rowid[hidden])  ·
 ·               2  ·       table     uniontest@primary  ·                      ·

--- a/pkg/sql/opt/exec/factory.go
+++ b/pkg/sql/opt/exec/factory.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/pkg/util"
 )
 
 // Node represents a node in the execution tree (currently maps to a
@@ -39,8 +40,9 @@ type Factory interface {
 	ConstructValues(rows [][]tree.TypedExpr, cols sqlbase.ResultColumns) (Node, error)
 
 	// ConstructScan returns a node that represents a scan of the given table.
-	// TODO(radu): support list of columns, index, index constraints
-	ConstructScan(table opt.Table) (Node, error)
+	// Only the given set of needed columns are part of the result.
+	// TODO(radu): support index, index constraints
+	ConstructScan(table opt.Table, needed ColumnOrdinalSet) (Node, error)
 
 	// ConstructFilter returns a node that applies a filter on the results of
 	// the given input node.
@@ -79,6 +81,9 @@ type Factory interface {
 
 // ColumnOrdinal is the 0-based ordinal index of a column produced by a Node.
 type ColumnOrdinal int32
+
+// ColumnOrdinalSet contains a set of ColumnOrdinal values as ints.
+type ColumnOrdinalSet = util.FastIntSet
 
 // AggInfo represents an aggregation (see ConstructGroupBy).
 type AggInfo struct {

--- a/pkg/sql/opt/factory.og.go
+++ b/pkg/sql/opt/factory.og.go
@@ -261,8 +261,8 @@ type Factory interface {
 
 	// ConstructFunction constructs an expression for the Function operator.
 	// Function invokes a builtin SQL function like CONCAT or NOW, passing the given
-	// arguments. The private field is an opt.FuncDef struct that provides the name
-	// of the function as well as a pointer to the builtin overload definition.
+	// arguments. The private field is an opt.FuncOpDef struct that provides the
+	// name of the function as well as a pointer to the builtin overload definition.
 	ConstructFunction(args ListID, def PrivateID) GroupID
 
 	// ConstructCoalesce constructs an expression for the Coalesce operator.
@@ -278,11 +278,12 @@ type Factory interface {
 	// ------------------------------------------------------------
 
 	// ConstructScan constructs an expression for the Scan operator.
-	// Scan returns a result set containing every row in the specified table. Rows
-	// and columns are not expected to have any particular ordering. The private
-	// Table field is a Metadata.TableIndex that references an opt.Table
-	// definition in the query's metadata.
-	ConstructScan(table PrivateID) GroupID
+	// Scan returns a result set containing every row in the specified table. The
+	// private Def field is an *opt.ScanOpDef that identifies the table to scan, as
+	// well as the subset of columns to project from it. Rows and columns are not
+	// expected to have any particular ordering unless a physical property requires
+	// it.
+	ConstructScan(def PrivateID) GroupID
 
 	// ConstructValues constructs an expression for the Values operator.
 	// Values returns a manufactured result set containing a constant number of rows.
@@ -359,7 +360,7 @@ type Factory interface {
 	// groups results that are equal on the grouping columns and computes
 	// aggregations as described by Aggregations (which is always an Aggregations
 	// operator). The arguments of the aggregations are columns from the input.
-	ConstructGroupBy(input GroupID, aggregations GroupID, groupingColumns PrivateID) GroupID
+	ConstructGroupBy(input GroupID, aggregations GroupID, groupingCols PrivateID) GroupID
 
 	// ConstructUnion constructs an expression for the Union operator.
 	// Union is an operator used to combine the Left and Right input relations into

--- a/pkg/sql/opt/operator.go
+++ b/pkg/sql/opt/operator.go
@@ -37,17 +37,28 @@ func (i Operator) String() string {
 	return opNames[opIndexes[i]:opIndexes[i+1]]
 }
 
-// FuncDef defines the value of the Def private field of the Function operator.
-// It provides the name and return type of the function, as well as a pointer
-// to an already resolved builtin overload definition.
-type FuncDef struct {
+// FuncOpDef defines the value of the Def private field of the Function
+// operator. It provides the name and return type of the function, as well as a
+// pointer to an already resolved builtin overload definition.
+type FuncOpDef struct {
 	Name     string
 	Type     types.T
 	Overload *tree.Builtin
 }
 
-func (f FuncDef) String() string {
+func (f FuncOpDef) String() string {
 	return f.Name
+}
+
+// ScanOpDef defines the value of the Def private field of the Scan operator.
+type ScanOpDef struct {
+	// Table identifies the table to scan. It is an index that can be passed to
+	// the Metadata.Table method in order to fetch optbase.Table metadata.
+	Table TableIndex
+
+	// Cols specifies the set of columns that the scan operator projects. This
+	// may be a subset of the columns that the table contains.
+	Cols ColSet
 }
 
 // SetOpColMap defines the value of the ColMap private field of the set

--- a/pkg/sql/opt/operator.og.go
+++ b/pkg/sql/opt/operator.og.go
@@ -185,8 +185,8 @@ const (
 	WhenOp
 
 	// FunctionOp invokes a builtin SQL function like CONCAT or NOW, passing the given
-	// arguments. The private field is an opt.FuncDef struct that provides the name
-	// of the function as well as a pointer to the builtin overload definition.
+	// arguments. The private field is an opt.FuncOpDef struct that provides the
+	// name of the function as well as a pointer to the builtin overload definition.
 	FunctionOp
 
 	CoalesceOp
@@ -199,10 +199,11 @@ const (
 	// Relational Operators
 	// ------------------------------------------------------------
 
-	// ScanOp returns a result set containing every row in the specified table. Rows
-	// and columns are not expected to have any particular ordering. The private
-	// Table field is a Metadata.TableIndex that references an opt.Table
-	// definition in the query's metadata.
+	// ScanOp returns a result set containing every row in the specified table. The
+	// private Def field is an *opt.ScanOpDef that identifies the table to scan, as
+	// well as the subset of columns to project from it. Rows and columns are not
+	// expected to have any particular ordering unless a physical property requires
+	// it.
 	ScanOp
 
 	// ValuesOp returns a manufactured result set containing a constant number of rows.

--- a/pkg/sql/opt/ops/relational.opt
+++ b/pkg/sql/opt/ops/relational.opt
@@ -21,13 +21,14 @@
 #             step in some important transformations (like eliminating
 #             subqueries).
 
-# Scan returns a result set containing every row in the specified table. Rows
-# and columns are not expected to have any particular ordering. The private
-# Table field is a Metadata.TableIndex that references an opt.Table
-# definition in the query's metadata.
+# Scan returns a result set containing every row in the specified table. The
+# private Def field is an *opt.ScanOpDef that identifies the table to scan, as
+# well as the subset of columns to project from it. Rows and columns are not
+# expected to have any particular ordering unless a physical property requires
+# it.
 [Relational]
 define Scan {
-    Table TableIndex
+    Def ScanOpDef
 }
 
 # Values returns a manufactured result set containing a constant number of rows.
@@ -163,9 +164,9 @@ define AntiJoinApply {
 # operator). The arguments of the aggregations are columns from the input.
 [Relational]
 define GroupBy {
-    Input           Expr
-    Aggregations    Expr
-    GroupingColumns ColSet
+    Input        Expr
+    Aggregations Expr
+    GroupingCols ColSet
 }
 
 # Union is an operator used to combine the Left and Right input relations into

--- a/pkg/sql/opt/ops/scalar.opt
+++ b/pkg/sql/opt/ops/scalar.opt
@@ -396,12 +396,12 @@ define When {
 }
 
 # Function invokes a builtin SQL function like CONCAT or NOW, passing the given
-# arguments. The private field is an opt.FuncDef struct that provides the name
-# of the function as well as a pointer to the builtin overload definition.
+# arguments. The private field is an opt.FuncOpDef struct that provides the
+# name of the function as well as a pointer to the builtin overload definition.
 [Scalar]
 define Function {
     Args ExprList
-    Def  FuncDef
+    Def  FuncOpDef
 }
 
 [Scalar]

--- a/pkg/sql/opt/optbuilder/groupby.go
+++ b/pkg/sql/opt/optbuilder/groupby.go
@@ -112,7 +112,7 @@ type groupby struct {
 
 // aggregateInfo stores information about an aggregation function call.
 type aggregateInfo struct {
-	def  opt.FuncDef
+	def  opt.FuncOpDef
 	args []opt.GroupID
 }
 
@@ -365,7 +365,7 @@ func (b *Builder) buildGrouping(
 // buildAggregateFunction is called when we are building a function which is an
 // aggregate.
 func (b *Builder) buildAggregateFunction(
-	f *tree.FuncExpr, funcDef opt.FuncDef, label string, inScope *scope,
+	f *tree.FuncExpr, funcDef opt.FuncOpDef, label string, inScope *scope,
 ) (out opt.GroupID, col *columnProps) {
 	aggInScope, aggOutScope := inScope.startAggFunc()
 

--- a/pkg/sql/opt/optbuilder/scalar.go
+++ b/pkg/sql/opt/optbuilder/scalar.go
@@ -297,7 +297,7 @@ func (b *Builder) buildFunction(
 		panic(builderError{err})
 	}
 
-	funcDef := opt.FuncDef{Name: def.Name, Type: f.ResolvedType(), Overload: f.ResolvedBuiltin()}
+	funcDef := opt.FuncOpDef{Name: def.Name, Type: f.ResolvedType(), Overload: f.ResolvedBuiltin()}
 
 	if isAggregate(def) {
 		return b.buildAggregateFunction(f, funcDef, label, inScope)
@@ -308,7 +308,7 @@ func (b *Builder) buildFunction(
 		argList[i] = b.buildScalar(pexpr.(tree.TypedExpr), inScope)
 	}
 
-	// Construct a private FuncDef that refers to a resolved function overload.
+	// Construct a private FuncOpDef that refers to a resolved function overload.
 	return b.factory.ConstructFunction(
 		b.factory.InternList(argList), b.factory.InternPrivate(funcDef),
 	), nil

--- a/pkg/sql/opt/optbuilder/select.go
+++ b/pkg/sql/opt/optbuilder/select.go
@@ -110,6 +110,7 @@ func (b *Builder) buildScan(
 	tbl opt.Table, tn *tree.TableName, inScope *scope,
 ) (out opt.GroupID, outScope *scope) {
 	tblIndex := b.factory.Metadata().AddTable(tbl)
+	scanOpDef := opt.ScanOpDef{Table: tblIndex}
 
 	outScope = inScope.push()
 	for i := 0; i < tbl.ColumnCount(); i++ {
@@ -125,11 +126,12 @@ func (b *Builder) buildScan(
 			hidden:   col.IsHidden(),
 		}
 
+		scanOpDef.Cols.Add(int(colIndex))
 		b.colMap = append(b.colMap, colProps)
 		outScope.cols = append(outScope.cols, colProps)
 	}
 
-	return b.factory.ConstructScan(b.factory.InternPrivate(tblIndex)), outScope
+	return b.factory.ConstructScan(b.factory.InternPrivate(&scanOpDef)), outScope
 }
 
 // buildSelect builds a set of memo groups that represent the given select

--- a/pkg/sql/opt/optbuilder/values.go
+++ b/pkg/sql/opt/optbuilder/values.go
@@ -41,14 +41,16 @@ func (b *Builder) buildValuesClause(
 	}
 	rows := make([]opt.GroupID, 0, len(values.Tuples))
 
+	// elems is used to store tuple values, and can be allocated once and reused
+	// repeatedly, since InternList will copy values to memo storage.
+	elems := make([]opt.GroupID, numCols)
+
 	for _, tuple := range values.Tuples {
 		if numCols != len(tuple.Exprs) {
 			panic(errorf(
 				"VALUES lists must all be the same length, expected %d columns, found %d",
 				numCols, len(tuple.Exprs)))
 		}
-
-		elems := make([]opt.GroupID, numCols)
 
 		for i, expr := range tuple.Exprs {
 			texpr := inScope.resolveType(expr, types.Any)

--- a/pkg/sql/opt/optgen/cmd/optgen/factory_gen.go
+++ b/pkg/sql/opt/optgen/cmd/optgen/factory_gen.go
@@ -475,7 +475,7 @@ func (g *factoryGen) genConstruct(construct *lang.ConstructExpr) {
 	case *lang.CustomFuncExpr:
 		// Construct expression based on dynamic type of referenced op.
 		ref := t.Args[0].(*lang.RefExpr)
-		g.w.write("_f.DynamicConstruct(_f.mem.lookupNormExpr(%s).op, []GroupID{", ref.Label)
+		g.w.write("_f.DynamicConstruct(_f.mem.lookupNormExpr(%s).op, []opt.GroupID{", ref.Label)
 
 	default:
 		panic(fmt.Sprintf("unexpected name expression: %s", construct.Name))

--- a/pkg/sql/opt/optgen/cmd/optgen/testdata/factory
+++ b/pkg/sql/opt/optgen/cmd/optgen/testdata/factory
@@ -590,7 +590,7 @@ func (_f *factory) ConstructSelect(
 					t := _e2.ChildGroup(0)
 					u := _e2.ChildGroup(1)
 					_f.reportOptimization()
-					_group = _f.DynamicConstruct(_f.mem.lookupNormExpr(item).op, []GroupID{_f.ConstructSelect(t, u), _f.custom(item, opt.SelectOp)}, 0)
+					_group = _f.DynamicConstruct(_f.mem.lookupNormExpr(item).op, []opt.GroupID{_f.ConstructSelect(t, u), _f.custom(item, opt.SelectOp)}, 0)
 					_f.mem.addAltFingerprint(_selectExpr.fingerprint(), _group)
 					return _group
 				}

--- a/pkg/sql/opt/xform/logical_props.go
+++ b/pkg/sql/opt/xform/logical_props.go
@@ -35,6 +35,8 @@ type LogicalProps struct {
 	// operators.
 	Relational *RelationalProps
 
+	// Scalar contains the set of properties that describe scalar operators,
+	// like And, Plus, and Const. It is nil for relational operators.
 	Scalar *ScalarProps
 }
 
@@ -51,6 +53,23 @@ type RelationalProps struct {
 	// The NULL-ability of columns flows from the inputs and can also be
 	// derived from filters that are NULL-intolerant.
 	NotNullCols opt.ColSet
+
+	// OuterCols is the set of columns that are referenced by variables within
+	// this relational sub-expression, but are not bound within the scope of
+	// the expression. For example:
+	//
+	//   SELECT *
+	//   FROM a
+	//   WHERE EXISTS(SELECT * FROM b WHERE b.x = a.x AND b.y = 5)
+	//
+	// For the inner SELECT expression, a.x is an outer column, meaning that it
+	// is defined "outside" the SELECT expression (hence the name "outer"). The
+	// SELECT expression binds the b.x and b.y references, so they are not
+	// part of the outer column set. The outer SELECT binds the a.x column, and
+	// so its outer column set is empty.
+	//
+	// TODO(andyk): populate this when we have subquery support
+	OuterCols opt.ColSet
 }
 
 // ScalarProps are the subset of logical properties that are computed for
@@ -70,18 +89,19 @@ type ScalarProps struct {
 	// For the EXISTS expression, only a.x is an outer column, meaning that
 	// only it is defined "outside" the EXISTS expression (hence the name
 	// "outer"). Note that what constitutes an "outer column" is dependent on
-	// an expression's lcoation in the query. For example, while the b.x and
+	// an expression's location in the query. For example, while the b.x and
 	// b.y columns are not outer columns on the EXISTS expression, they *are*
 	// outer columns on the inner WHERE condition.
 	OuterCols opt.ColSet
 }
 
-func (p *LogicalProps) format(md *opt.Metadata, tp treeprinter.Node) {
-	if p.Relational != nil {
-		p.formatOutputCols(md, tp)
-	} else {
-		tp.Child(fmt.Sprintf("type: %s", p.Scalar.Type))
+// OuterCols is a helper method that returns either the relational or scalar
+// OuterCols field, depending on the operator's type.
+func (p *LogicalProps) OuterCols() opt.ColSet {
+	if p.Scalar != nil {
+		return p.Scalar.OuterCols
 	}
+	return p.Relational.OuterCols
 }
 
 func (p *LogicalProps) formatOutputCols(md *opt.Metadata, tp treeprinter.Node) {

--- a/pkg/sql/opt/xform/memo.go
+++ b/pkg/sql/opt/xform/memo.go
@@ -385,8 +385,8 @@ func (m *memo) formatExpr(ev ExprView, buf *bytes.Buffer, includeRequired bool) 
 	if private != nil {
 		switch t := private.(type) {
 		case nil:
-		case opt.TableIndex:
-			fmt.Fprintf(buf, " %s", m.metadata.Table(t).TabName())
+		case *opt.ScanOpDef:
+			fmt.Fprintf(buf, " %s", m.metadata.Table(t.Table).TabName())
 		case opt.ColumnIndex:
 			fmt.Fprintf(buf, " %s", m.metadata.ColumnLabel(t))
 		case *opt.ColSet, *opt.ColMap, *opt.ColList:

--- a/pkg/sql/opt/xform/physical_props_factory.go
+++ b/pkg/sql/opt/xform/physical_props_factory.go
@@ -96,16 +96,18 @@ func (f physicalPropsFactory) canProvideOrdering(ev ExprView, required opt.Order
 
 	case opt.ScanOp:
 		// Scan naturally orders according to the primary index.
-		tblIdx := ev.Private().(opt.TableIndex)
-		primary := ev.Metadata().Table(tblIdx).Primary()
+		def := ev.Private().(*opt.ScanOpDef)
+		primary := ev.Metadata().Table(def.Table).Primary()
 
-		ordering := make(opt.Ordering, primary.ColumnCount())
+		// Scan can project subset of columns.
+		ordering := make(opt.Ordering, 0, primary.ColumnCount())
 		for i := 0; i < primary.ColumnCount(); i++ {
-			idxCol := primary.Column(i)
-			ordering[i] = opt.MakeOrderingColumn(
-				ev.Metadata().TableColumn(tblIdx, idxCol.Ordinal),
-				idxCol.Descending,
-			)
+			primaryCol := primary.Column(i)
+			colIndex := ev.Metadata().TableColumn(def.Table, primaryCol.Ordinal)
+			if def.Cols.Contains(int(colIndex)) {
+				orderingCol := opt.MakeOrderingColumn(colIndex, primaryCol.Descending)
+				ordering = append(ordering, orderingCol)
+			}
 		}
 
 		return ordering.Provides(required)

--- a/pkg/sql/opt/xform/rules/project.opt
+++ b/pkg/sql/opt/xform/rules/project.opt
@@ -8,7 +8,145 @@
 [EliminateProject, Normalize]
 (Project
     $input:*
-    $projections:* & (HasSameProjectionCols $input $projections)
+    $projections:* & (HasSameCols $input $projections)
 )
 =>
 $input
+
+# FilterUnusedProjectCols discards nested project columns that are never used.
+[FilterUnusedProjectCols]
+(Project
+    (Project
+        $innerInput:*
+        $innerProjections:*
+    )
+    $projections:* & (HasUnusedColumns $innerProjections (NeededCols $projections))
+)
+=>
+(Project
+    (Project
+        $innerInput
+        (FilterUnusedColumns $innerProjections (NeededCols $projections))
+    )
+    $projections
+)
+
+# FilterUnusedScanCols discards Scan operator columns that are never used. The
+# needed columns are pushed down into the Scan's opt.ScanOpDef private.
+[FilterUnusedScanCols]
+(Project
+    $input:(Scan)
+    $projections:* & (HasUnusedColumns $input (NeededCols $projections))
+)
+=>
+(Project
+    (FilterUnusedColumns $input (NeededCols $projections))
+    $projections
+)
+
+# FilterUnusedSelectCols discards Select input columns that are never used.
+[FilterUnusedSelectCols]
+(Project
+    (Select
+        $innerInput:*
+        $filter:*
+    )
+    $projections:* & (HasUnusedColumns $innerInput (NeededCols2 $projections $filter))
+)
+=>
+(Project
+    (Select
+        (FilterUnusedColumns $innerInput (NeededCols2 $projections $filter))
+        $filter
+    )
+    $projections
+)
+
+# FilterUnusedJoinLeftCols discards columns on the left side of a join that are
+# never used.
+[FilterUnusedJoinLeftCols]
+(Project
+    $input:(Join
+        $left:*
+        $right:*
+        $on:*
+    )
+    $projections:* & (HasUnusedColumns $left (NeededCols3 $projections $right $on))
+)
+=>
+(Project
+    ((OpName $input)
+        (FilterUnusedColumns $left (NeededCols3 $projections $right $on))
+        $right
+        $on
+    )
+    $projections
+)
+
+# FilterUnusedJoinRightCols discards columns on the right side of a join that
+# are never used.
+[FilterUnusedJoinRightCols]
+(Project
+    $input:(Join
+        $left:*
+        $right:*
+        $on:*
+    )
+    $projections:* & (HasUnusedColumns $right (NeededCols2 $projections $on))
+)
+=>
+(Project
+    ((OpName $input)
+        $left
+        (FilterUnusedColumns $right (NeededCols2 $projections $on))
+        $on
+    )
+    $projections
+)
+
+# FilterUnusedAggCols discards aggregation columns in a GroupBy that are never
+# used.
+[FilterUnusedAggCols]
+(Project
+    (GroupBy
+        $innerInput:*
+        $aggregations:*
+        $groupingCols:*
+    )
+    $projections:* & (HasUnusedColumns $aggregations (NeededCols $projections))
+)
+=>
+(Project
+    (GroupBy
+        $innerInput
+        (FilterUnusedColumns $aggregations (NeededCols $projections))
+        $groupingCols
+    )
+    $projections
+)
+
+# FilterUnusedGroupByCols discards GroupBy input columns that are never used.
+[FilterUnusedGroupByCols]
+(GroupBy
+    $input:*
+    $aggregations:*
+    $groupingCols:* & (HasUnusedColumns $input (GroupByNeededCols $aggregations $groupingCols))
+)
+=>
+(GroupBy
+    (FilterUnusedColumns $input (GroupByNeededCols $aggregations $groupingCols))
+    $aggregations
+    $groupingCols
+)
+
+# FilterUnusedValueCols discards Values columns that are never used.
+[FilterUnusedValueCols]
+(Project
+    $input:(Values)
+    $projections:* & (HasUnusedColumns $input (NeededCols $projections))
+)
+=>
+(Project
+    (FilterUnusedColumns $input (NeededCols $projections))
+    $projections
+)

--- a/pkg/sql/opt/xform/testdata/logprops/scan
+++ b/pkg/sql/opt/xform/testdata/logprops/scan
@@ -1,9 +1,11 @@
 exec-ddl
-CREATE TABLE a (x INT PRIMARY KEY, y INT)
+CREATE TABLE a (x INT PRIMARY KEY, y INT, s STRING, d DECIMAL NOT NULL)
 ----
 TABLE a
  ├── x int not null
  ├── y int
+ ├── s string
+ ├── d decimal not null
  └── INDEX primary
       └── x int not null
 
@@ -21,7 +23,7 @@ build
 SELECT * FROM a
 ----
 scan
- └── columns: x:1(int!null) y:2(int)
+ └── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null)
 
 build
 SELECT * FROM b
@@ -33,3 +35,10 @@ project
  └── projections [outer=(1,2)]
       ├── variable: b.x [type=int, outer=(1)]
       └── variable: b.z [type=int, outer=(2)]
+
+# Select subset of columns.
+opt
+SELECT s, x FROM a
+----
+scan
+ └── columns: s:3(string) x:1(int!null)

--- a/pkg/sql/opt/xform/testdata/physprops/ordering
+++ b/pkg/sql/opt/xform/testdata/physprops/ordering
@@ -97,17 +97,20 @@ select
 
 # Pass through ordering to scan operator that can support it.
 opt
-SELECT x, y FROM a ORDER BY x, y DESC
+SELECT x+1, y FROM a ORDER BY x, y DESC
 ----
 project
- ├── columns: x:1(int!null) y:2(float!null)
+ ├── columns: column5:5(int) y:2(float!null)
  ├── ordering: +1,-2
  ├── scan
- │    ├── columns: a.x:1(int!null) a.y:2(float!null) a.z:3(decimal) a.s:4(string!null)
+ │    ├── columns: a.x:1(int!null) a.y:2(float!null)
  │    └── ordering: +1,-2
  └── projections [outer=(1,2)]
-      ├── variable: a.x [type=int, outer=(1)]
-      └── variable: a.y [type=float, outer=(2)]
+      ├── plus [type=int, outer=(1)]
+      │    ├── variable: a.x [type=int, outer=(1)]
+      │    └── const: 1 [type=int]
+      ├── variable: a.y [type=float, outer=(2)]
+      └── variable: a.x [type=int, outer=(1)]
 
 # Pass through ordering to scan operator that can't support it.
 opt
@@ -117,10 +120,10 @@ project
  ├── columns: y:2(float!null) x:1(int!null) column5:5(decimal)
  ├── ordering: +1,+2
  ├── sort
- │    ├── columns: a.x:1(int!null) a.y:2(float!null) a.z:3(decimal) a.s:4(string!null)
+ │    ├── columns: a.x:1(int!null) a.y:2(float!null) a.z:3(decimal)
  │    ├── ordering: +1,+2
  │    └── scan
- │         └── columns: a.x:1(int!null) a.y:2(float!null) a.z:3(decimal) a.s:4(string!null)
+ │         └── columns: a.x:1(int!null) a.y:2(float!null) a.z:3(decimal)
  └── projections [outer=(1-3)]
       ├── variable: a.y [type=float, outer=(2)]
       ├── variable: a.x [type=int, outer=(1)]
@@ -138,7 +141,7 @@ sort
  └── project
       ├── columns: a.x:1(int!null) one:5(int) a.y:2(float!null)
       ├── scan
-      │    └── columns: a.x:1(int!null) a.y:2(float!null) a.z:3(decimal) a.s:4(string!null)
+      │    └── columns: a.x:1(int!null) a.y:2(float!null)
       └── projections [outer=(1,2)]
            ├── variable: a.x [type=int, outer=(1)]
            ├── const: 1 [type=int]
@@ -150,49 +153,56 @@ sort
 
 # Pass through ordering to scan operator that can support it.
 opt
-SELECT y, x FROM a WHERE x=1 ORDER BY x, y DESC
+SELECT y, x-1 FROM a WHERE x=1 ORDER BY x, y DESC
 ----
 project
- ├── columns: y:2(float!null) x:1(int!null)
+ ├── columns: y:2(float!null) column5:5(int)
  ├── ordering: +1,-2
  ├── select
- │    ├── columns: a.x:1(int!null) a.y:2(float!null) a.z:3(decimal) a.s:4(string!null)
+ │    ├── columns: a.x:1(int!null) a.y:2(float!null)
  │    ├── ordering: +1,-2
  │    ├── scan
- │    │    ├── columns: a.x:1(int!null) a.y:2(float!null) a.z:3(decimal) a.s:4(string!null)
+ │    │    ├── columns: a.x:1(int!null) a.y:2(float!null)
  │    │    └── ordering: +1,-2
  │    └── eq [type=bool, outer=(1)]
  │         ├── variable: a.x [type=int, outer=(1)]
  │         └── const: 1 [type=int]
  └── projections [outer=(1,2)]
       ├── variable: a.y [type=float, outer=(2)]
+      ├── minus [type=int, outer=(1)]
+      │    ├── variable: a.x [type=int, outer=(1)]
+      │    └── const: 1 [type=int]
       └── variable: a.x [type=int, outer=(1)]
 
 memo
-SELECT y, x FROM a WHERE x=1 ORDER BY x, y DESC
+SELECT y, x-1 FROM a WHERE x=1 ORDER BY x, y DESC
 ----
-[8: "p:y:2,x:1 o:+1,-2"]
+[12: "p:y:2,column5:5 o:+1,-2"]
 memo
- ├── 8: (project 5 7)
+ ├── 12: (project 11 9)
  │    ├── "" [cost=0.0]
- │    │    └── best: (project 5 7)
- │    └── "p:y:2,x:1 o:+1,-2" [cost=0.0]
- │         └── best: (project 5 7)
- ├── 7: (projections 6 2)
+ │    │    └── best: (project 11 9)
+ │    └── "p:y:2,column5:5 o:+1,-2" [cost=0.0]
+ │         └── best: (project 11 9)
+ ├── 11: (select 10 4)
+ │    ├── "" [cost=0.0]
+ │    │    └── best: (select 10 4)
+ │    └── "o:+1,-2" [cost=0.0]
+ │         └── best: (select 10 4)
+ ├── 10: (scan a)
+ │    ├── "" [cost=0.0]
+ │    │    └── best: (scan a)
+ │    └── "o:+1,-2" [cost=0.0]
+ │         └── best: (scan a)
+ ├── 9: (projections 6 8 2)
+ ├── 8: (minus 2 7)
+ ├── 7: (const 1)
  ├── 6: (variable a.y)
  ├── 5: (select 1 4)
- │    ├── "" [cost=0.0]
- │    │    └── best: (select 1 4)
- │    └── "o:+1,-2" [cost=0.0]
- │         └── best: (select 1 4)
  ├── 4: (eq 2 3)
  ├── 3: (const 1)
  ├── 2: (variable a.x)
  └── 1: (scan a)
-      ├── "" [cost=0.0]
-      │    └── best: (scan a)
-      └── "o:+1,-2" [cost=0.0]
-           └── best: (scan a)
 
 # Pass through ordering to scan operator that can't support it.
 opt
@@ -202,13 +212,13 @@ project
  ├── columns: y:2(float!null) z:3(decimal)
  ├── ordering: +2
  ├── select
- │    ├── columns: a.x:1(int!null) a.y:2(float!null) a.z:3(decimal) a.s:4(string!null)
+ │    ├── columns: a.x:1(int!null) a.y:2(float!null) a.z:3(decimal)
  │    ├── ordering: +2
  │    ├── sort
- │    │    ├── columns: a.x:1(int!null) a.y:2(float!null) a.z:3(decimal) a.s:4(string!null)
+ │    │    ├── columns: a.x:1(int!null) a.y:2(float!null) a.z:3(decimal)
  │    │    ├── ordering: +2
  │    │    └── scan
- │    │         └── columns: a.x:1(int!null) a.y:2(float!null) a.z:3(decimal) a.s:4(string!null)
+ │    │         └── columns: a.x:1(int!null) a.y:2(float!null) a.z:3(decimal)
  │    └── eq [type=bool, outer=(1)]
  │         ├── variable: a.x [type=int, outer=(1)]
  │         └── const: 1 [type=int]
@@ -219,26 +229,28 @@ project
 memo
 SELECT y, z FROM a WHERE x=1 ORDER BY y
 ----
-[9: "p:y:2,z:3 o:+2"]
+[11: "p:y:2,z:3 o:+2"]
 memo
- ├── 9: (project 5 8)
+ ├── 11: (project 10 8)
  │    ├── "" [cost=0.0]
- │    │    └── best: (project 5 8)
+ │    │    └── best: (project 10 8)
  │    └── "p:y:2,z:3 o:+2" [cost=0.0]
- │         └── best: (project 5 8)
+ │         └── best: (project 10 8)
+ ├── 10: (select 9 4)
+ │    ├── "" [cost=0.0]
+ │    │    └── best: (select 9 4)
+ │    └── "o:+2" [cost=0.0]
+ │         └── best: (select 9 4)
+ ├── 9: (scan a)
+ │    ├── "" [cost=0.0]
+ │    │    └── best: (scan a)
+ │    └── "o:+2" [cost=0.0]
+ │         └── best: (sort 9)
  ├── 8: (projections 6 7)
  ├── 7: (variable a.z)
  ├── 6: (variable a.y)
  ├── 5: (select 1 4)
- │    ├── "" [cost=0.0]
- │    │    └── best: (select 1 4)
- │    └── "o:+2" [cost=0.0]
- │         └── best: (select 1 4)
  ├── 4: (eq 2 3)
  ├── 3: (const 1)
  ├── 2: (variable a.x)
  └── 1: (scan a)
-      ├── "" [cost=0.0]
-      │    └── best: (scan a)
-      └── "o:+2" [cost=0.0]
-           └── best: (sort 1)

--- a/pkg/sql/opt/xform/testdata/rules/numeric
+++ b/pkg/sql/opt/xform/testdata/rules/numeric
@@ -25,7 +25,7 @@ FROM a
 project
  ├── columns: column6:6(int) column7:7(int) column8:8(float) column9:9(float) column10:10(decimal) column11:11(decimal)
  ├── scan
- │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.d:4(decimal) a.t:5(time)
+ │    └── columns: a.i:2(int) a.f:3(float) a.d:4(decimal)
  └── projections [outer=(2-4)]
       ├── plus [type=int, outer=(2)]
       │    ├── variable: a.i [type=int, outer=(2)]
@@ -61,7 +61,7 @@ FROM a
 project
  ├── columns: column6:6(int) column7:7(float) column8:8(decimal)
  ├── scan
- │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.d:4(decimal) a.t:5(time)
+ │    └── columns: a.i:2(int) a.f:3(float) a.d:4(decimal)
  └── projections [outer=(2-4)]
       ├── plus [type=int, outer=(2)]
       │    ├── variable: a.i [type=int, outer=(2)]
@@ -88,7 +88,7 @@ FROM a
 project
  ├── columns: column6:6(int) column7:7(int) column8:8(float) column9:9(float) column10:10(decimal) column11:11(decimal)
  ├── scan
- │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.d:4(decimal) a.t:5(time)
+ │    └── columns: a.i:2(int) a.f:3(float) a.d:4(decimal)
  └── projections [outer=(2-4)]
       ├── plus [type=int, outer=(2)]
       │    ├── variable: a.i [type=int, outer=(2)]
@@ -123,7 +123,7 @@ FROM a
 project
  ├── columns: column6:6(decimal) column7:7(float) column8:8(decimal)
  ├── scan
- │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.d:4(decimal) a.t:5(time)
+ │    └── columns: a.i:2(int) a.f:3(float) a.d:4(decimal)
  └── projections [outer=(2-4)]
       ├── variable: a.i [type=int, outer=(2)]
       ├── variable: a.f [type=float, outer=(3)]
@@ -142,7 +142,7 @@ FROM a
 project
  ├── columns: column6:6(float) column7:7(decimal) column8:8(interval)
  ├── scan
- │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.d:4(decimal) a.t:5(time)
+ │    └── columns: a.i:2(int) a.f:3(float) a.d:4(decimal) a.t:5(time)
  └── projections [outer=(2-5)]
       ├── minus [type=float, outer=(3)]
       │    ├── variable: a.f [type=float, outer=(3)]
@@ -163,6 +163,6 @@ SELECT -(-a.i::int) FROM a
 project
  ├── columns: column6:6(int)
  ├── scan
- │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.d:4(decimal) a.t:5(time)
+ │    └── columns: a.i:2(int)
  └── projections [outer=(2)]
       └── variable: a.i [type=int, outer=(2)]

--- a/pkg/sql/opt/xform/testdata/rules/project
+++ b/pkg/sql/opt/xform/testdata/rules/project
@@ -1,21 +1,22 @@
 exec-ddl
-CREATE TABLE t.a (x INT PRIMARY KEY, y FLOAT)
+CREATE TABLE t.a (x INT PRIMARY KEY, y INT, f FLOAT, s STRING)
 ----
 TABLE a
  ├── x int not null
- ├── y float
+ ├── y int
+ ├── f float
+ ├── s string
  └── INDEX primary
       └── x int not null
 
 exec-ddl
-CREATE TABLE t.b (x INT, y FLOAT)
+CREATE TABLE t.b (x INT PRIMARY KEY, z INT)
 ----
 TABLE b
- ├── x int
- ├── y float
- ├── rowid int not null (hidden)
+ ├── x int not null
+ ├── z int
  └── INDEX primary
-      └── rowid int not null (hidden)
+      └── x int not null
 
 # --------------------------------------------------
 # EliminateProject
@@ -26,42 +27,862 @@ opt
 SELECT x, y FROM t.a
 ----
 scan
- └── columns: x:1(int!null) y:2(float)
+ └── columns: x:1(int!null) y:2(int)
 
 # Different order, aliased names.
 opt
 SELECT a.y AS aliasy, a.x FROM t.a
 ----
 scan
- └── columns: aliasy:2(float) x:1(int!null)
+ └── columns: aliasy:2(int) x:1(int!null)
 
 # Reordered, duplicate, aliased columns.
 opt
 SELECT a.y AS alias1, a.x, a.y AS alias1, a.x FROM t.a
 ----
 scan
- └── columns: alias1:2(float) x:1(int!null) alias1:2(float) x:1(int!null)
+ └── columns: alias1:2(int) x:1(int!null) alias1:2(int) x:1(int!null)
 
 # Added column (projection should not be eliminated).
 opt
-SELECT x, y, 1 FROM t.a
+SELECT *, 1 FROM t.a
 ----
 project
- ├── columns: x:1(int!null) y:2(float) column3:3(int)
+ ├── columns: x:1(int!null) y:2(int) f:3(float) s:4(string) column5:5(int)
  ├── scan
- │    └── columns: a.x:1(int!null) a.y:2(float)
- └── projections [outer=(1,2)]
+ │    └── columns: a.x:1(int!null) a.y:2(int) a.f:3(float) a.s:4(string)
+ └── projections [outer=(1-4)]
       ├── variable: a.x [type=int, outer=(1)]
-      ├── variable: a.y [type=float, outer=(2)]
+      ├── variable: a.y [type=int, outer=(2)]
+      ├── variable: a.f [type=float, outer=(3)]
+      ├── variable: a.s [type=string, outer=(4)]
       └── const: 1 [type=int]
 
-# Removed column (projection should not be eliminated).
+# --------------------------------------------------
+# FilterUnusedProjectCols
+# --------------------------------------------------
+
+# Discard some of columns.
+opt
+SELECT x FROM (SELECT x, y+1 FROM t.a) a
+----
+scan
+ └── columns: x:1(int!null)
+
+# Discard all columns.
+opt
+SELECT 1 FROM (SELECT y+1, x FROM t.a) a
+----
+project
+ ├── columns: column6:6(int)
+ ├── scan
+ └── projections
+      └── const: 1 [type=int]
+
+# Use column values within computed column.
+opt
+SELECT x+y FROM (SELECT y, x, s || 'foo' FROM t.a) a
+----
+project
+ ├── columns: column6:6(int)
+ ├── scan
+ │    └── columns: a.x:1(int!null) a.y:2(int)
+ └── projections [outer=(1,2)]
+      └── plus [type=int, outer=(1,2)]
+           ├── variable: a.x [type=int, outer=(1)]
+           └── variable: a.y [type=int, outer=(2)]
+
+# Discard non-computed columns and keep computed column.
+opt
+SELECT l, x FROM (SELECT length(s) l, * FROM a) a
+----
+project
+ ├── columns: l:5(int) x:1(int!null)
+ ├── scan
+ │    └── columns: a.x:1(int!null) a.s:4(string)
+ └── projections [outer=(1,4)]
+      ├── function: length [type=int, outer=(4)]
+      │    └── variable: a.s [type=string, outer=(4)]
+      └── variable: a.x [type=int, outer=(1)]
+
+# Compute column based on another computed column.
+opt
+SELECT l*l, x FROM (SELECT x, length(s) l, y FROM a) a
+----
+project
+ ├── columns: column6:6(int) x:1(int!null)
+ ├── project
+ │    ├── columns: a.x:1(int!null) l:5(int)
+ │    ├── scan
+ │    │    └── columns: a.x:1(int!null) a.s:4(string)
+ │    └── projections [outer=(1,4)]
+ │         ├── variable: a.x [type=int, outer=(1)]
+ │         └── function: length [type=int, outer=(4)]
+ │              └── variable: a.s [type=string, outer=(4)]
+ └── projections [outer=(1,5)]
+      ├── mult [type=int, outer=(5)]
+      │    ├── variable: l [type=int, outer=(5)]
+      │    └── variable: l [type=int, outer=(5)]
+      └── variable: a.x [type=int, outer=(1)]
+
+# --------------------------------------------------
+# FilterUnusedScanCols
+# --------------------------------------------------
+
+# Project subset of columns.
 opt
 SELECT x FROM t.a
 ----
+scan
+ └── columns: x:1(int!null)
+
+# Project subset of columns, some used in computed columns.
+opt
+SELECT x, x+1, y+1 FROM t.a
+----
+project
+ ├── columns: x:1(int!null) column5:5(int) column6:6(int)
+ ├── scan
+ │    └── columns: a.x:1(int!null) a.y:2(int)
+ └── projections [outer=(1,2)]
+      ├── variable: a.x [type=int, outer=(1)]
+      ├── plus [type=int, outer=(1)]
+      │    ├── variable: a.x [type=int, outer=(1)]
+      │    └── const: 1 [type=int]
+      └── plus [type=int, outer=(2)]
+           ├── variable: a.y [type=int, outer=(2)]
+           └── const: 1 [type=int]
+
+# Use columns only in computed columns.
+opt
+SELECT x+y FROM t.a
+----
+project
+ ├── columns: column5:5(int)
+ ├── scan
+ │    └── columns: a.x:1(int!null) a.y:2(int)
+ └── projections [outer=(1,2)]
+      └── plus [type=int, outer=(1,2)]
+           ├── variable: a.x [type=int, outer=(1)]
+           └── variable: a.y [type=int, outer=(2)]
+
+# Use no scan columns.
+opt
+SELECT 1 FROM t.a
+----
+project
+ ├── columns: column5:5(int)
+ ├── scan
+ └── projections
+      └── const: 1 [type=int]
+
+# --------------------------------------------------
+# FilterUnusedSelectCols
+# --------------------------------------------------
+
+# Columns used only by projection or filter, but not both.
+opt
+SELECT x FROM t.a WHERE y<5
+----
 project
  ├── columns: x:1(int!null)
+ ├── select
+ │    ├── columns: a.x:1(int!null) a.y:2(int)
+ │    ├── scan
+ │    │    └── columns: a.x:1(int!null) a.y:2(int)
+ │    └── lt [type=bool, outer=(2)]
+ │         ├── variable: a.y [type=int, outer=(2)]
+ │         └── const: 5 [type=int]
+ └── projections [outer=(1)]
+      └── variable: a.x [type=int, outer=(1)]
+
+# Columns used by both projection and filter.
+opt
+SELECT x, y FROM t.a WHERE x=1 AND y<5
+----
+select
+ ├── columns: x:1(int!null) y:2(int)
  ├── scan
- │    └── columns: a.x:1(int!null) a.y:2(float)
+ │    └── columns: a.x:1(int!null) a.y:2(int)
+ └── and [type=bool, outer=(1,2)]
+      ├── eq [type=bool, outer=(1)]
+      │    ├── variable: a.x [type=int, outer=(1)]
+      │    └── const: 1 [type=int]
+      └── lt [type=bool, outer=(2)]
+           ├── variable: a.y [type=int, outer=(2)]
+           └── const: 5 [type=int]
+
+# No needed select columns.
+opt
+SELECT 1 FROM t.a WHERE now()<'2000-01-01T02:00:00'::timestamp
+----
+project
+ ├── columns: column5:5(int)
+ ├── select
+ │    ├── scan
+ │    └── lt [type=bool]
+ │         ├── function: now [type=timestamptz]
+ │         └── const: '2000-01-01 02:00:00+00:00' [type=timestamp]
+ └── projections
+      └── const: 1 [type=int]
+
+# Select columns used in computed columns.
+opt
+SELECT y-1, x*x FROM t.a WHERE x+1<5 AND s||'o'='foo'
+----
+project
+ ├── columns: column5:5(int) column6:6(int)
+ ├── select
+ │    ├── columns: a.x:1(int!null) a.y:2(int) a.s:4(string)
+ │    ├── scan
+ │    │    └── columns: a.x:1(int!null) a.y:2(int) a.s:4(string)
+ │    └── and [type=bool, outer=(1,4)]
+ │         ├── lt [type=bool, outer=(1)]
+ │         │    ├── variable: a.x [type=int, outer=(1)]
+ │         │    └── minus [type=int]
+ │         │         ├── const: 5 [type=int]
+ │         │         └── const: 1 [type=int]
+ │         └── eq [type=bool, outer=(4)]
+ │              ├── concat [type=string, outer=(4)]
+ │              │    ├── variable: a.s [type=string, outer=(4)]
+ │              │    └── const: 'o' [type=string]
+ │              └── const: 'foo' [type=string]
+ └── projections [outer=(1,2)]
+      ├── minus [type=int, outer=(2)]
+      │    ├── variable: a.y [type=int, outer=(2)]
+      │    └── const: 1 [type=int]
+      └── mult [type=int, outer=(1)]
+           ├── variable: a.x [type=int, outer=(1)]
+           └── variable: a.x [type=int, outer=(1)]
+
+# Select nested in select.
+opt
+SELECT y FROM (SELECT * FROM a WHERE x = 5) a2 WHERE y::float = f
+----
+project
+ ├── columns: y:2(int)
+ ├── select
+ │    ├── columns: a.y:2(int) a.f:3(float)
+ │    ├── project
+ │    │    ├── columns: a.y:2(int) a.f:3(float)
+ │    │    ├── select
+ │    │    │    ├── columns: a.x:1(int!null) a.y:2(int) a.f:3(float)
+ │    │    │    ├── scan
+ │    │    │    │    └── columns: a.x:1(int!null) a.y:2(int) a.f:3(float)
+ │    │    │    └── eq [type=bool, outer=(1)]
+ │    │    │         ├── variable: a.x [type=int, outer=(1)]
+ │    │    │         └── const: 5 [type=int]
+ │    │    └── projections [outer=(2,3)]
+ │    │         ├── variable: a.y [type=int, outer=(2)]
+ │    │         └── variable: a.f [type=float, outer=(3)]
+ │    └── eq [type=bool, outer=(2,3)]
+ │         ├── variable: a.f [type=float, outer=(3)]
+ │         └── cast: float [type=float, outer=(2)]
+ │              └── variable: a.y [type=int, outer=(2)]
+ └── projections [outer=(2)]
+      └── variable: a.y [type=int, outer=(2)]
+
+# --------------------------------------------------
+# FilterUnusedJoinLeftCols
+# --------------------------------------------------
+
+# Columns used only by projection or on condition, but not both.
+opt
+SELECT a.y, b.* FROM t.a INNER JOIN t.b ON a.x=b.x
+----
+project
+ ├── columns: y:2(int) x:5(int!null) z:6(int)
+ ├── inner-join
+ │    ├── columns: a.x:1(int!null) a.y:2(int) b.x:5(int!null) b.z:6(int)
+ │    ├── scan
+ │    │    └── columns: a.x:1(int!null) a.y:2(int)
+ │    ├── scan
+ │    │    └── columns: b.x:5(int!null) b.z:6(int)
+ │    └── eq [type=bool, outer=(1,5)]
+ │         ├── variable: a.x [type=int, outer=(1)]
+ │         └── variable: b.x [type=int, outer=(5)]
+ └── projections [outer=(2,5,6)]
+      ├── variable: a.y [type=int, outer=(2)]
+      ├── variable: b.x [type=int, outer=(5)]
+      └── variable: b.z [type=int, outer=(6)]
+
+# Columns used by both projection and on condition, left join.
+opt
+SELECT a.x, a.y, b.* FROM t.a LEFT JOIN t.b ON a.x=b.x AND a.y<5
+----
+left-join
+ ├── columns: x:1(int!null) y:2(int) x:5(int) z:6(int)
+ ├── scan
+ │    └── columns: a.x:1(int!null) a.y:2(int)
+ ├── scan
+ │    └── columns: b.x:5(int!null) b.z:6(int)
+ └── and [type=bool, outer=(1,2,5)]
+      ├── eq [type=bool, outer=(1,5)]
+      │    ├── variable: a.x [type=int, outer=(1)]
+      │    └── variable: b.x [type=int, outer=(5)]
+      └── lt [type=bool, outer=(2)]
+           ├── variable: a.y [type=int, outer=(2)]
+           └── const: 5 [type=int]
+
+# Columns only used by on condition, right join
+opt
+SELECT b.* FROM t.a RIGHT JOIN t.b ON a.x=b.x
+----
+project
+ ├── columns: x:5(int!null) z:6(int)
+ ├── right-join
+ │    ├── columns: a.x:1(int) b.x:5(int!null) b.z:6(int)
+ │    ├── scan
+ │    │    └── columns: a.x:1(int!null)
+ │    ├── scan
+ │    │    └── columns: b.x:5(int!null) b.z:6(int)
+ │    └── eq [type=bool, outer=(1,5)]
+ │         ├── variable: a.x [type=int, outer=(1)]
+ │         └── variable: b.x [type=int, outer=(5)]
+ └── projections [outer=(5,6)]
+      ├── variable: b.x [type=int, outer=(5)]
+      └── variable: b.z [type=int, outer=(6)]
+
+# Columns needed only by projection, full join.
+opt
+SELECT a.x+1, b.* FROM t.a FULL JOIN t.b ON True
+----
+project
+ ├── columns: column7:7(int) x:5(int) z:6(int)
+ ├── full-join
+ │    ├── columns: a.x:1(int) b.x:5(int) b.z:6(int)
+ │    ├── scan
+ │    │    └── columns: a.x:1(int!null)
+ │    ├── scan
+ │    │    └── columns: b.x:5(int!null) b.z:6(int)
+ │    └── true [type=bool]
+ └── projections [outer=(1,5,6)]
+      ├── plus [type=int, outer=(1)]
+      │    ├── variable: a.x [type=int, outer=(1)]
+      │    └── const: 1 [type=int]
+      ├── variable: b.x [type=int, outer=(5)]
+      └── variable: b.z [type=int, outer=(6)]
+
+# No columns needed from left side of join.
+opt
+SELECT b.* FROM t.a, t.b
+----
+inner-join
+ ├── columns: x:5(int!null) z:6(int)
+ ├── scan
+ ├── scan
+ │    └── columns: b.x:5(int!null) b.z:6(int)
+ └── true [type=bool]
+
+# Computed columns.
+opt
+SELECT a.x+1, a.y/2, b.* FROM t.a INNER JOIN t.b ON a.x*a.x=b.x AND a.s||'o'='foo'
+----
+project
+ ├── columns: column7:7(int) column8:8(decimal) x:5(int!null) z:6(int)
+ ├── inner-join
+ │    ├── columns: a.x:1(int!null) a.y:2(int) a.s:4(string) b.x:5(int!null) b.z:6(int)
+ │    ├── scan
+ │    │    └── columns: a.x:1(int!null) a.y:2(int) a.s:4(string)
+ │    ├── scan
+ │    │    └── columns: b.x:5(int!null) b.z:6(int)
+ │    └── and [type=bool, outer=(1,4,5)]
+ │         ├── eq [type=bool, outer=(1,5)]
+ │         │    ├── variable: b.x [type=int, outer=(5)]
+ │         │    └── mult [type=int, outer=(1)]
+ │         │         ├── variable: a.x [type=int, outer=(1)]
+ │         │         └── variable: a.x [type=int, outer=(1)]
+ │         └── eq [type=bool, outer=(4)]
+ │              ├── concat [type=string, outer=(4)]
+ │              │    ├── variable: a.s [type=string, outer=(4)]
+ │              │    └── const: 'o' [type=string]
+ │              └── const: 'foo' [type=string]
+ └── projections [outer=(1,2,5,6)]
+      ├── plus [type=int, outer=(1)]
+      │    ├── variable: a.x [type=int, outer=(1)]
+      │    └── const: 1 [type=int]
+      ├── div [type=decimal, outer=(2)]
+      │    ├── variable: a.y [type=int, outer=(2)]
+      │    └── const: 2 [type=int]
+      ├── variable: b.x [type=int, outer=(5)]
+      └── variable: b.z [type=int, outer=(6)]
+
+# Join that is nested in another join.
+opt
+SELECT a.x, b.*
+FROM
+(
+    SELECT * FROM a NATURAL JOIN b
+) a
+INNER JOIN b
+ON a.y < b.z
+----
+project
+ ├── columns: x:1(int!null) x:7(int!null) z:8(int)
+ ├── inner-join
+ │    ├── columns: a.x:1(int!null) a.y:2(int) b.x:7(int!null) b.z:8(int)
+ │    ├── project
+ │    │    ├── columns: a.x:1(int!null) a.y:2(int)
+ │    │    ├── inner-join
+ │    │    │    ├── columns: a.x:1(int!null) a.y:2(int) b.x:5(int!null)
+ │    │    │    ├── scan
+ │    │    │    │    └── columns: a.x:1(int!null) a.y:2(int)
+ │    │    │    ├── scan
+ │    │    │    │    └── columns: b.x:5(int!null)
+ │    │    │    └── eq [type=bool, outer=(1,5)]
+ │    │    │         ├── variable: a.x [type=int, outer=(1)]
+ │    │    │         └── variable: b.x [type=int, outer=(5)]
+ │    │    └── projections [outer=(1,2)]
+ │    │         ├── variable: a.x [type=int, outer=(1)]
+ │    │         └── variable: a.y [type=int, outer=(2)]
+ │    ├── scan
+ │    │    └── columns: b.x:7(int!null) b.z:8(int)
+ │    └── lt [type=bool, outer=(2,8)]
+ │         ├── variable: a.y [type=int, outer=(2)]
+ │         └── variable: b.z [type=int, outer=(8)]
+ └── projections [outer=(1,7,8)]
+      ├── variable: a.x [type=int, outer=(1)]
+      ├── variable: b.x [type=int, outer=(7)]
+      └── variable: b.z [type=int, outer=(8)]
+
+# --------------------------------------------------
+# FilterUnusedJoinRightCols
+# --------------------------------------------------
+
+# Columns used only by projection or on condition, but not both.
+opt
+SELECT b.*, a.y FROM t.b INNER JOIN t.a ON b.x=a.x
+----
+project
+ ├── columns: x:1(int!null) z:2(int) y:4(int)
+ ├── inner-join
+ │    ├── columns: b.x:1(int!null) b.z:2(int) a.x:3(int!null) a.y:4(int)
+ │    ├── scan
+ │    │    └── columns: b.x:1(int!null) b.z:2(int)
+ │    ├── scan
+ │    │    └── columns: a.x:3(int!null) a.y:4(int)
+ │    └── eq [type=bool, outer=(1,3)]
+ │         ├── variable: b.x [type=int, outer=(1)]
+ │         └── variable: a.x [type=int, outer=(3)]
+ └── projections [outer=(1,2,4)]
+      ├── variable: b.x [type=int, outer=(1)]
+      ├── variable: b.z [type=int, outer=(2)]
+      └── variable: a.y [type=int, outer=(4)]
+
+# Columns used by both projection and on condition, left join.
+opt
+SELECT b.*, a.x, a.y FROM t.b LEFT JOIN t.a ON b.x=a.x AND a.y<5
+----
+left-join
+ ├── columns: x:1(int!null) z:2(int) x:3(int) y:4(int)
+ ├── scan
+ │    └── columns: b.x:1(int!null) b.z:2(int)
+ ├── scan
+ │    └── columns: a.x:3(int!null) a.y:4(int)
+ └── and [type=bool, outer=(1,3,4)]
+      ├── eq [type=bool, outer=(1,3)]
+      │    ├── variable: b.x [type=int, outer=(1)]
+      │    └── variable: a.x [type=int, outer=(3)]
+      └── lt [type=bool, outer=(4)]
+           ├── variable: a.y [type=int, outer=(4)]
+           └── const: 5 [type=int]
+
+# Columns only used by on condition, right join
+opt
+SELECT b.* FROM t.b RIGHT JOIN t.a ON b.x=a.x
+----
+project
+ ├── columns: x:1(int) z:2(int)
+ ├── right-join
+ │    ├── columns: b.x:1(int) b.z:2(int) a.x:3(int!null)
+ │    ├── scan
+ │    │    └── columns: b.x:1(int!null) b.z:2(int)
+ │    ├── scan
+ │    │    └── columns: a.x:3(int!null)
+ │    └── eq [type=bool, outer=(1,3)]
+ │         ├── variable: b.x [type=int, outer=(1)]
+ │         └── variable: a.x [type=int, outer=(3)]
+ └── projections [outer=(1,2)]
+      ├── variable: b.x [type=int, outer=(1)]
+      └── variable: b.z [type=int, outer=(2)]
+
+# Columns needed only by projection, full join.
+opt
+SELECT b.*, a.x+1 FROM t.b FULL JOIN t.a ON True
+----
+project
+ ├── columns: x:1(int) z:2(int) column7:7(int)
+ ├── full-join
+ │    ├── columns: b.x:1(int) b.z:2(int) a.x:3(int)
+ │    ├── scan
+ │    │    └── columns: b.x:1(int!null) b.z:2(int)
+ │    ├── scan
+ │    │    └── columns: a.x:3(int!null)
+ │    └── true [type=bool]
+ └── projections [outer=(1-3)]
+      ├── variable: b.x [type=int, outer=(1)]
+      ├── variable: b.z [type=int, outer=(2)]
+      └── plus [type=int, outer=(3)]
+           ├── variable: a.x [type=int, outer=(3)]
+           └── const: 1 [type=int]
+
+# No columns needed from right side of join.
+opt
+SELECT b.* FROM t.b, t.a
+----
+inner-join
+ ├── columns: x:1(int!null) z:2(int)
+ ├── scan
+ │    └── columns: b.x:1(int!null) b.z:2(int)
+ ├── scan
+ └── true [type=bool]
+
+# Computed columns.
+opt
+SELECT b.*, a.x+1, a.y/2 FROM t.b INNER JOIN t.a ON b.x=a.x*a.x AND a.s||'o'='foo'
+----
+project
+ ├── columns: x:1(int!null) z:2(int) column7:7(int) column8:8(decimal)
+ ├── inner-join
+ │    ├── columns: b.x:1(int!null) b.z:2(int) a.x:3(int!null) a.y:4(int) a.s:6(string)
+ │    ├── scan
+ │    │    └── columns: b.x:1(int!null) b.z:2(int)
+ │    ├── scan
+ │    │    └── columns: a.x:3(int!null) a.y:4(int) a.s:6(string)
+ │    └── and [type=bool, outer=(1,3,6)]
+ │         ├── eq [type=bool, outer=(1,3)]
+ │         │    ├── variable: b.x [type=int, outer=(1)]
+ │         │    └── mult [type=int, outer=(3)]
+ │         │         ├── variable: a.x [type=int, outer=(3)]
+ │         │         └── variable: a.x [type=int, outer=(3)]
+ │         └── eq [type=bool, outer=(6)]
+ │              ├── concat [type=string, outer=(6)]
+ │              │    ├── variable: a.s [type=string, outer=(6)]
+ │              │    └── const: 'o' [type=string]
+ │              └── const: 'foo' [type=string]
+ └── projections [outer=(1-4)]
+      ├── variable: b.x [type=int, outer=(1)]
+      ├── variable: b.z [type=int, outer=(2)]
+      ├── plus [type=int, outer=(3)]
+      │    ├── variable: a.x [type=int, outer=(3)]
+      │    └── const: 1 [type=int]
+      └── div [type=decimal, outer=(4)]
+           ├── variable: a.y [type=int, outer=(4)]
+           └── const: 2 [type=int]
+
+# Join that is nested in another join.
+opt
+SELECT a.x, b.*
+FROM b
+INNER JOIN
+(
+    SELECT * FROM a NATURAL JOIN b
+) a
+ON a.y < b.z
+----
+project
+ ├── columns: x:3(int!null) x:1(int!null) z:2(int)
+ ├── inner-join
+ │    ├── columns: b.x:1(int!null) b.z:2(int) a.x:3(int!null) a.y:4(int)
+ │    ├── scan
+ │    │    └── columns: b.x:1(int!null) b.z:2(int)
+ │    ├── project
+ │    │    ├── columns: a.x:3(int!null) a.y:4(int)
+ │    │    ├── inner-join
+ │    │    │    ├── columns: a.x:3(int!null) a.y:4(int) b.x:7(int!null)
+ │    │    │    ├── scan
+ │    │    │    │    └── columns: a.x:3(int!null) a.y:4(int)
+ │    │    │    ├── scan
+ │    │    │    │    └── columns: b.x:7(int!null)
+ │    │    │    └── eq [type=bool, outer=(3,7)]
+ │    │    │         ├── variable: a.x [type=int, outer=(3)]
+ │    │    │         └── variable: b.x [type=int, outer=(7)]
+ │    │    └── projections [outer=(3,4)]
+ │    │         ├── variable: a.x [type=int, outer=(3)]
+ │    │         └── variable: a.y [type=int, outer=(4)]
+ │    └── lt [type=bool, outer=(2,4)]
+ │         ├── variable: a.y [type=int, outer=(4)]
+ │         └── variable: b.z [type=int, outer=(2)]
+ └── projections [outer=(1-3)]
+      ├── variable: a.x [type=int, outer=(3)]
+      ├── variable: b.x [type=int, outer=(1)]
+      └── variable: b.z [type=int, outer=(2)]
+
+# --------------------------------------------------
+# FilterUnusedJoinLeftCols + FilterUnusedJoinRightCols
+# --------------------------------------------------
+
+# Columns not needed by either side of join.
+opt
+SELECT 1 FROM a,b
+----
+project
+ ├── columns: column7:7(int)
+ ├── inner-join
+ │    ├── scan
+ │    ├── scan
+ │    └── true [type=bool]
+ └── projections
+      └── const: 1 [type=int]
+
+# Subset of columns needed by each side of join.
+opt
+SELECT a.x, b.x, a.x+b.x FROM a LEFT JOIN b ON a.x=b.x
+----
+project
+ ├── columns: x:1(int!null) x:5(int) column7:7(int)
+ ├── left-join
+ │    ├── columns: a.x:1(int!null) b.x:5(int)
+ │    ├── scan
+ │    │    └── columns: a.x:1(int!null)
+ │    ├── scan
+ │    │    └── columns: b.x:5(int!null)
+ │    └── eq [type=bool, outer=(1,5)]
+ │         ├── variable: a.x [type=int, outer=(1)]
+ │         └── variable: b.x [type=int, outer=(5)]
+ └── projections [outer=(1,5)]
+      ├── variable: a.x [type=int, outer=(1)]
+      ├── variable: b.x [type=int, outer=(5)]
+      └── plus [type=int, outer=(1,5)]
+           ├── variable: a.x [type=int, outer=(1)]
+           └── variable: b.x [type=int, outer=(5)]
+
+# --------------------------------------------------
+# FilterUnusedAggCols
+# --------------------------------------------------
+
+# Discard all aggregates.
+opt
+SELECT x FROM (SELECT x, SUM(y), MIN(s||'foo') FROM a GROUP BY x) a
+----
+group-by
+ ├── columns: x:1(int!null)
+ ├── grouping columns: a.x:1(int!null)
+ ├── scan
+ │    └── columns: a.x:1(int!null)
+ └── aggregations
+
+# Discard subset of aggregates.
+opt
+SELECT x, sumy FROM (SELECT SUM(y) sumy, x, MIN(s||'foo') FROM a GROUP BY x) a
+----
+group-by
+ ├── columns: x:1(int!null) sumy:5(decimal)
+ ├── grouping columns: a.x:1(int!null)
+ ├── scan
+ │    └── columns: a.x:1(int!null) a.y:2(int)
+ └── aggregations [outer=(2)]
+      └── function: sum [type=decimal, outer=(2)]
+           └── variable: a.y [type=int, outer=(2)]
+
+# No aggregates to discard.
+opt
+SELECT 1 FROM (SELECT x FROM a GROUP BY x) a
+----
+project
+ ├── columns: column5:5(int)
+ ├── group-by
+ │    ├── columns: a.x:1(int!null)
+ │    ├── grouping columns: a.x:1(int!null)
+ │    ├── scan
+ │    │    └── columns: a.x:1(int!null)
+ │    └── aggregations
+ └── projections
+      └── const: 1 [type=int]
+
+# --------------------------------------------------
+# FilterUnusedGroupByCols
+# --------------------------------------------------
+
+# Columns used by grouping or aggregation, but not both.
+opt
+SELECT x, SUM(y) FROM a GROUP BY x
+----
+group-by
+ ├── columns: x:1(int!null) column5:5(decimal)
+ ├── grouping columns: a.x:1(int!null)
+ ├── scan
+ │    └── columns: a.x:1(int!null) a.y:2(int)
+ └── aggregations [outer=(2)]
+      └── function: sum [type=decimal, outer=(2)]
+           └── variable: a.y [type=int, outer=(2)]
+
+# Columns used by both grouping and aggregation.
+opt
+SELECT AVG(x+y), x, y FROM a GROUP BY x, y
+----
+group-by
+ ├── columns: column6:6(decimal) x:1(int!null) y:2(int)
+ ├── grouping columns: a.x:1(int!null) a.y:2(int)
+ ├── project
+ │    ├── columns: a.x:1(int!null) a.y:2(int) column5:5(int)
+ │    ├── scan
+ │    │    └── columns: a.x:1(int!null) a.y:2(int)
+ │    └── projections [outer=(1,2)]
+ │         ├── variable: a.x [type=int, outer=(1)]
+ │         ├── variable: a.y [type=int, outer=(2)]
+ │         └── plus [type=int, outer=(1,2)]
+ │              ├── variable: a.x [type=int, outer=(1)]
+ │              └── variable: a.y [type=int, outer=(2)]
+ └── aggregations [outer=(5)]
+      └── function: avg [type=decimal, outer=(5)]
+           └── variable: column5 [type=int, outer=(5)]
+
+# Columns used only by aggregation, no grouping columns.
+opt
+SELECT MIN(y), MAX(x), MAX(x) FROM a
+----
+group-by
+ ├── columns: column5:5(int) column6:6(int) column6:6(int)
+ ├── scan
+ │    └── columns: a.x:1(int!null) a.y:2(int)
+ └── aggregations [outer=(1,2)]
+      ├── function: min [type=int, outer=(2)]
+      │    └── variable: a.y [type=int, outer=(2)]
+      └── function: max [type=int, outer=(1)]
+           └── variable: a.x [type=int, outer=(1)]
+
+# Columns used only by groupings, no aggregation columns.
+opt
+SELECT x, y+1 FROM a GROUP BY y, x
+----
+project
+ ├── columns: x:1(int!null) column5:5(int)
+ ├── group-by
+ │    ├── columns: a.x:1(int!null) a.y:2(int)
+ │    ├── grouping columns: a.x:1(int!null) a.y:2(int)
+ │    ├── scan
+ │    │    └── columns: a.x:1(int!null) a.y:2(int)
+ │    └── aggregations
+ └── projections [outer=(1,2)]
+      ├── variable: a.x [type=int, outer=(1)]
+      └── plus [type=int, outer=(2)]
+           ├── variable: a.y [type=int, outer=(2)]
+           └── const: 1 [type=int]
+
+# Groupby a groupby.
+opt
+SELECT MIN(sm), y FROM (SELECT s, y, SUM(x) sm, AVG(x) av FROM a GROUP BY y, s) a GROUP BY y
+----
+group-by
+ ├── columns: column7:7(decimal) y:2(int)
+ ├── grouping columns: a.y:2(int)
+ ├── project
+ │    ├── columns: a.y:2(int) sm:5(decimal)
+ │    ├── group-by
+ │    │    ├── columns: a.y:2(int) a.s:4(string) sm:5(decimal)
+ │    │    ├── grouping columns: a.y:2(int) a.s:4(string)
+ │    │    ├── scan
+ │    │    │    └── columns: a.x:1(int!null) a.y:2(int) a.s:4(string)
+ │    │    └── aggregations [outer=(1)]
+ │    │         └── function: sum [type=decimal, outer=(1)]
+ │    │              └── variable: a.x [type=int, outer=(1)]
+ │    └── projections [outer=(2,5)]
+ │         ├── variable: a.y [type=int, outer=(2)]
+ │         └── variable: sm [type=decimal, outer=(5)]
+ └── aggregations [outer=(5)]
+      └── function: min [type=decimal, outer=(5)]
+           └── variable: sm [type=decimal, outer=(5)]
+
+# --------------------------------------------------
+# FilterUnusedValueCols
+# --------------------------------------------------
+
+# Discard all but first Values column.
+opt
+SELECT column1 FROM (VALUES (1, 2), (3, 4)) a
+----
+values
+ ├── columns: column1:1(int)
+ ├── tuple [type=tuple{int}]
+ │    └── const: 1 [type=int]
+ └── tuple [type=tuple{int}]
+      └── const: 3 [type=int]
+
+# Discard all but middle Values column.
+opt
+SELECT column2 FROM (VALUES (1, 2, 3), (4, 5, 6)) a
+----
+values
+ ├── columns: column2:2(int)
+ ├── tuple [type=tuple{int}]
+ │    └── const: 2 [type=int]
+ └── tuple [type=tuple{int}]
+      └── const: 5 [type=int]
+
+# Discard all but last Values column.
+opt
+SELECT column3 FROM (VALUES ('foo', 'bar', 'baz'), ('apple', 'banana', 'cherry')) a
+----
+values
+ ├── columns: column3:3(string)
+ ├── tuple [type=tuple{string}]
+ │    └── const: 'baz' [type=string]
+ └── tuple [type=tuple{string}]
+      └── const: 'cherry' [type=string]
+
+# Discard all Values columns.
+opt
+SELECT 1 FROM (VALUES ('foo', 'bar', 'baz'), ('apple', 'banana', 'cherry')) a
+----
+project
+ ├── columns: column4:4(int)
+ ├── values
+ │    ├── tuple [type=tuple{}]
+ │    └── tuple [type=tuple{}]
+ └── projections
+      └── const: 1 [type=int]
+
+# --------------------------------------------------
+# FilterUnused - multiple combined operators
+# --------------------------------------------------
+
+opt
+SELECT a.x, b.z FROM a INNER JOIN b ON a.x=b.x WHERE a.y < 5
+----
+project
+ ├── columns: x:1(int!null) z:6(int)
+ ├── select
+ │    ├── columns: a.x:1(int!null) a.y:2(int) b.z:6(int)
+ │    ├── project
+ │    │    ├── columns: a.x:1(int!null) a.y:2(int) b.z:6(int)
+ │    │    ├── inner-join
+ │    │    │    ├── columns: a.x:1(int!null) a.y:2(int) b.x:5(int!null) b.z:6(int)
+ │    │    │    ├── scan
+ │    │    │    │    └── columns: a.x:1(int!null) a.y:2(int)
+ │    │    │    ├── scan
+ │    │    │    │    └── columns: b.x:5(int!null) b.z:6(int)
+ │    │    │    └── eq [type=bool, outer=(1,5)]
+ │    │    │         ├── variable: a.x [type=int, outer=(1)]
+ │    │    │         └── variable: b.x [type=int, outer=(5)]
+ │    │    └── projections [outer=(1,2,6)]
+ │    │         ├── variable: a.x [type=int, outer=(1)]
+ │    │         ├── variable: a.y [type=int, outer=(2)]
+ │    │         └── variable: b.z [type=int, outer=(6)]
+ │    └── lt [type=bool, outer=(2)]
+ │         ├── variable: a.y [type=int, outer=(2)]
+ │         └── const: 5 [type=int]
+ └── projections [outer=(1,6)]
+      ├── variable: a.x [type=int, outer=(1)]
+      └── variable: b.z [type=int, outer=(6)]
+
+opt
+SELECT x FROM (SELECT x, MIN(s) FROM a GROUP BY x HAVING SUM(y) > 5)
+----
+project
+ ├── columns: x:1(int!null)
+ ├── select
+ │    ├── columns: a.x:1(int!null) column5:5(decimal)
+ │    ├── group-by
+ │    │    ├── columns: a.x:1(int!null) column5:5(decimal)
+ │    │    ├── grouping columns: a.x:1(int!null)
+ │    │    ├── scan
+ │    │    │    └── columns: a.x:1(int!null) a.y:2(int)
+ │    │    └── aggregations [outer=(2)]
+ │    │         └── function: sum [type=decimal, outer=(2)]
+ │    │              └── variable: a.y [type=int, outer=(2)]
+ │    └── gt [type=bool, outer=(5)]
+ │         ├── variable: column5 [type=decimal, outer=(5)]
+ │         └── const: 5 [type=decimal]
  └── projections [outer=(1)]
       └── variable: a.x [type=int, outer=(1)]

--- a/pkg/sql/opt/xform/testdata/rules/scalar
+++ b/pkg/sql/opt/xform/testdata/rules/scalar
@@ -34,7 +34,7 @@ FROM a
 project
  ├── columns: column7:7(bool) column8:8(bool) column9:9(bool) column10:10(bool) column11:11(int) column12:12(int) column13:13(int) column14:14(int) column15:15(int)
  ├── scan
- │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb) a.arr:6(int[])
+ │    └── columns: a.k:1(int!null) a.i:2(int)
  └── projections [outer=(1,2)]
       ├── eq [type=bool, outer=(1,2)]
       │    ├── variable: a.k [type=int, outer=(1)]
@@ -102,7 +102,7 @@ FROM a
 project
  ├── columns: column7:7(bool) column8:8(bool) column9:9(bool) column10:10(bool) column11:11(float) column12:12(int) column13:13(int) column14:14(int) column15:15(int)
  ├── scan
- │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb) a.arr:6(int[])
+ │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float)
  └── projections [outer=(1-3)]
       ├── eq [type=bool, outer=(1,2)]
       │    ├── plus [type=int, outer=(1,2)]
@@ -172,7 +172,7 @@ SELECT COALESCE(i) FROM a
 project
  ├── columns: column7:7(int)
  ├── scan
- │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb) a.arr:6(int[])
+ │    └── columns: a.i:2(int)
  └── projections [outer=(2)]
       └── variable: a.i [type=int, outer=(2)]
 
@@ -185,7 +185,6 @@ SELECT COALESCE(NULL) FROM a
 project
  ├── columns: column7:7(unknown)
  ├── scan
- │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb) a.arr:6(int[])
  └── projections
       └── null [type=unknown]
 
@@ -195,7 +194,6 @@ SELECT COALESCE(NULL, 'foo', s) FROM a
 project
  ├── columns: column7:7(string)
  ├── scan
- │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb) a.arr:6(int[])
  └── projections
       └── const: 'foo' [type=string]
 
@@ -205,7 +203,7 @@ SELECT COALESCE(NULL, NULL, s, s || 'foo') FROM a
 project
  ├── columns: column7:7(string)
  ├── scan
- │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb) a.arr:6(int[])
+ │    └── columns: a.s:4(string)
  └── projections [outer=(4)]
       └── coalesce [type=string, outer=(4)]
            ├── variable: a.s [type=string, outer=(4)]
@@ -220,7 +218,7 @@ SELECT COALESCE(i, NULL, NULL) FROM a
 project
  ├── columns: column7:7(int)
  ├── scan
- │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb) a.arr:6(int[])
+ │    └── columns: a.i:2(int)
  └── projections [outer=(2)]
       └── coalesce [type=int, outer=(2)]
            ├── variable: a.i [type=int, outer=(2)]
@@ -236,7 +234,7 @@ SELECT i::int, arr::int[], '[1, 2]'::json::json, null::string::int FROM a
 project
  ├── columns: column7:7(int) column8:8(int[]) column9:9(jsonb) column10:10(int)
  ├── scan
- │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb) a.arr:6(int[])
+ │    └── columns: a.i:2(int) a.arr:6(int[])
  └── projections [outer=(2,6)]
       ├── variable: a.i [type=int, outer=(2)]
       ├── variable: a.arr [type=int[], outer=(6)]
@@ -250,7 +248,7 @@ SELECT i::float, arr::decimal[], s::json::json FROM a
 project
  ├── columns: column7:7(float) column8:8(decimal[]) column9:9(jsonb)
  ├── scan
- │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb) a.arr:6(int[])
+ │    └── columns: a.i:2(int) a.s:4(string) a.arr:6(int[])
  └── projections [outer=(2,4,6)]
       ├── cast: float [type=float, outer=(2)]
       │    └── variable: a.i [type=int, outer=(2)]
@@ -282,7 +280,6 @@ SELECT +null::int, -null::int, ~null::int FROM a
 project
  ├── columns: column7:7(int) column8:8(int) column9:9(int)
  ├── scan
- │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb) a.arr:6(int[])
  └── projections
       ├── null [type=int]
       ├── null [type=int]
@@ -310,7 +307,7 @@ FROM a
 project
  ├── columns: column7:7(int) column8:8(int) column9:9(decimal) column10:10(decimal) column11:11(float) column12:12(float) column13:13(int) column14:14(int) column15:15(jsonb) column16:16(jsonb) column17:17(decimal[]) column18:18(string[]) column19:19(decimal[]) column20:20(float[])
  ├── scan
- │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb) a.arr:6(int[])
+ │    └── columns: a.i:2(int) a.arr:6(int[])
  └── projections [outer=(2,6)]
       ├── null [type=int]
       ├── null [type=int]
@@ -348,7 +345,6 @@ SELECT null IN (i), null NOT IN (s) FROM a
 project
  ├── columns: column7:7(bool) column8:8(bool)
  ├── scan
- │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb) a.arr:6(int[])
  └── projections
       ├── null [type=bool]
       └── null [type=bool]
@@ -362,7 +358,6 @@ SELECT i IN (null, null), k NOT IN (1 * null, null::int, 1 < null) FROM a
 project
  ├── columns: column7:7(bool) column8:8(bool)
  ├── scan
- │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb) a.arr:6(int[])
  └── projections
       ├── null [type=bool]
       └── null [type=bool]
@@ -376,7 +371,7 @@ SELECT i IN (2, 1, 1, null, 3, null, 2, 3.0) FROM a
 project
  ├── columns: column7:7(bool)
  ├── scan
- │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb) a.arr:6(int[])
+ │    └── columns: a.i:2(int)
  └── projections [outer=(2)]
       └── in [type=bool, outer=(2)]
            ├── variable: a.i [type=int, outer=(2)]
@@ -392,7 +387,7 @@ SELECT s NOT IN ('foo', s || 'foo', 'bar', length(s)::string, NULL) FROM a
 project
  ├── columns: column7:7(bool)
  ├── scan
- │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb) a.arr:6(int[])
+ │    └── columns: a.s:4(string)
  └── projections [outer=(4)]
       └── not-in [type=bool, outer=(4)]
            ├── variable: a.s [type=string, outer=(4)]

--- a/pkg/sql/opt/xform/typing.go
+++ b/pkg/sql/opt/xform/typing.go
@@ -161,9 +161,9 @@ func typeAsBinary(ev ExprView) types.T {
 }
 
 // typeFunction returns the type of a function expression by extracting it from
-// the function's private field, which is an instance of opt.FuncDef.
+// the function's private field, which is an instance of opt.FuncOpDef.
 func typeFunction(ev ExprView) types.T {
-	return ev.Private().(opt.FuncDef).Type
+	return ev.Private().(opt.FuncOpDef).Type
 }
 
 // typeAsAny returns types.Any for an operator that never has its type used.

--- a/pkg/sql/opt_exec_engine.go
+++ b/pkg/sql/opt_exec_engine.go
@@ -137,17 +137,14 @@ func (ee *execEngine) ConstructValues(
 }
 
 // ConstructScan is part of the exec.Factory interface.
-func (ee *execEngine) ConstructScan(table opt.Table) (exec.Node, error) {
+func (ee *execEngine) ConstructScan(
+	table opt.Table, cols exec.ColumnOrdinalSet,
+) (exec.Node, error) {
 	desc := table.(*optTable).desc
-
-	columns := make([]tree.ColumnID, len(desc.Columns))
-	for i := range columns {
-		columns[i] = tree.ColumnID(desc.Columns[i].ID)
-	}
 	// Create a scanNode.
 	scan := ee.planner.Scan()
 	if err := scan.initTable(
-		context.TODO(), ee.planner, desc, nil /* hints */, publicColumns, columns,
+		context.TODO(), ee.planner, desc, nil /* hints */, publicColumns, nil, /* wantedColumns */
 	); err != nil {
 		return nil, err
 	}
@@ -155,6 +152,16 @@ func (ee *execEngine) ConstructScan(table opt.Table) (exec.Node, error) {
 	scan.spans, err = unconstrainedSpans(desc, &desc.PrimaryIndex)
 	if err != nil {
 		return nil, err
+	}
+	scan.valNeededForCol = cols.Copy()
+	l := cols.Len()
+	if l != len(desc.Columns) {
+		// Only a subset of columns should be projected.
+		ordinals := make([]exec.ColumnOrdinal, 0, l)
+		cols.ForEach(func(ord int) {
+			ordinals = append(ordinals, exec.ColumnOrdinal(ord))
+		})
+		return ee.ConstructSimpleProject(scan, ordinals, nil)
 	}
 	return scan, nil
 }


### PR DESCRIPTION
Add multiple new patterns to the optimizer that work together to
remove unused columns from scans, values, projection lists, and
aggregations lists. The patterns determine whether a column is unused
by consulting the OuterCols logical property. If unused columns are
found, then the patterns will either filter existing lists, or else
will create a new Project operator that filters the columns.

In order to make debugging the optimizer easier, this PR adds a new
"optsteps" test command that will print out the expression tree after
each optimizer rule is applied, so that it's possible to see the
steps that resulted in the output.

Release note: None