### PR TITLE
opt: add rules to push negation through And/Or; build RangeCond

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/scalar
+++ b/pkg/sql/opt/exec/execbuilder/testdata/scalar
@@ -95,11 +95,11 @@ render     0  render  ·         ·          (column8)                          
 exec-explain
 SELECT NOT (a > 5 AND b >= 10) FROM t.t
 ----
-render     0  render  ·         ·                            (column8)                          ·
- │         0  ·       render 0  NOT ((a > 5) AND (b >= 10))  ·                                  ·
- └── scan  1  scan    ·         ·                            (a, b, c, d, j, s, rowid[hidden])  ·
-·          1  ·       table     t@primary                    ·                                  ·
-·          1  ·       spans     ALL                          ·                                  ·
+render     0  render  ·         ·                     (column8)                          ·
+ │         0  ·       render 0  (a <= 5) OR (b < 10)  ·                                  ·
+ └── scan  1  scan    ·         ·                     (a, b, c, d, j, s, rowid[hidden])  ·
+·          1  ·       table     t@primary             ·                                  ·
+·          1  ·       spans     ALL                   ·                                  ·
 
 exec-explain
 SELECT (a >= 5 AND b <= 10) OR (a <= 10 AND c > 5) FROM t.t
@@ -113,11 +113,11 @@ render     0  render  ·         ·                                             
 exec-explain
 SELECT NOT (a >= 5 OR b <= 10) AND NOT (c >= 10) FROM t.t
 ----
-render     0  render  ·         ·                                           (column8)                          ·
- │         0  ·       render 0  (NOT ((a >= 5) OR (b <= 10))) AND (c < 10)  ·                                  ·
- └── scan  1  scan    ·         ·                                           (a, b, c, d, j, s, rowid[hidden])  ·
-·          1  ·       table     t@primary                                   ·                                  ·
-·          1  ·       spans     ALL                                         ·                                  ·
+render     0  render  ·         ·                                    (column8)                          ·
+ │         0  ·       render 0  ((a < 5) AND (b > 10)) AND (c < 10)  ·                                  ·
+ └── scan  1  scan    ·         ·                                    (a, b, c, d, j, s, rowid[hidden])  ·
+·          1  ·       table     t@primary                            ·                                  ·
+·          1  ·       spans     ALL                                  ·                                  ·
 
 
 exec-explain

--- a/pkg/sql/opt/exec/execbuilder/testdata/scalar
+++ b/pkg/sql/opt/exec/execbuilder/testdata/scalar
@@ -415,3 +415,43 @@ column4:int
 4
 6
 NULL
+
+exec-explain
+SELECT a FROM t.t WHERE a BETWEEN b AND d
+----
+render          0  render  ·         ·                      (a)                                ·
+ │              0  ·       render 0  a                      ·                                  ·
+ └── filter     1  filter  ·         ·                      (a, b, c, d, j, s, rowid[hidden])  ·
+      │         1  ·       filter    (a >= b) AND (a <= d)  ·                                  ·
+      └── scan  2  scan    ·         ·                      (a, b, c, d, j, s, rowid[hidden])  ·
+·               2  ·       table     t@primary              ·                                  ·
+·               2  ·       spans     ALL                    ·                                  ·
+
+exec-explain
+SELECT a FROM t.t WHERE a NOT BETWEEN b AND d
+----
+render          0  render  ·         ·                   (a)                                ·
+ │              0  ·       render 0  a                   ·                                  ·
+ └── filter     1  filter  ·         ·                   (a, b, c, d, j, s, rowid[hidden])  ·
+      │         1  ·       filter    (a < b) OR (a > d)  ·                                  ·
+      └── scan  2  scan    ·         ·                   (a, b, c, d, j, s, rowid[hidden])  ·
+·               2  ·       table     t@primary           ·                                  ·
+·               2  ·       spans     ALL                 ·                                  ·
+
+exec-explain
+SELECT a BETWEEN SYMMETRIC b AND d FROM t.t
+----
+render     0  render  ·         ·                                                   (column8)                          ·
+ │         0  ·       render 0  ((a >= b) AND (a <= d)) OR ((a >= d) AND (a <= b))  ·                                  ·
+ └── scan  1  scan    ·         ·                                                   (a, b, c, d, j, s, rowid[hidden])  ·
+·          1  ·       table     t@primary                                           ·                                  ·
+·          1  ·       spans     ALL                                                 ·                                  ·
+
+exec-explain
+SELECT a NOT BETWEEN SYMMETRIC b AND d FROM t.t
+----
+render     0  render  ·         ·                                              (column8)                          ·
+ │         0  ·       render 0  ((a < b) OR (a > d)) AND ((a < d) OR (a > b))  ·                                  ·
+ └── scan  1  scan    ·         ·                                              (a, b, c, d, j, s, rowid[hidden])  ·
+·          1  ·       table     t@primary                                      ·                                  ·
+·          1  ·       spans     ALL                                            ·                                  ·

--- a/pkg/sql/opt/optbuilder/builder_test.go
+++ b/pkg/sql/opt/optbuilder/builder_test.go
@@ -124,6 +124,8 @@ func TestBuilder(t *testing.T) {
 						d.Fatalf(t, "%v", err)
 					}
 
+					// Disable normalization rules: we want the tests to check the result
+					// of the build process.
 					o := xform.NewOptimizer(&evalCtx, xform.OptimizeNone)
 					b := New(ctx, &semaCtx, &evalCtx, catalog, o.Factory(), stmt)
 					b.AllowUnsupportedExpr = allowUnsupportedExpr
@@ -144,6 +146,8 @@ func TestBuilder(t *testing.T) {
 					for i := range varNames {
 						varNames[i] = fmt.Sprintf("@%d", i+1)
 					}
+					// Disable normalization rules: we want the tests to check the result
+					// of the build process.
 					o := xform.NewOptimizer(&evalCtx, xform.OptimizeNone)
 					b := NewScalar(ctx, &semaCtx, &evalCtx, o.Factory(), varNames, varTypes)
 					b.AllowUnsupportedExpr = allowUnsupportedExpr

--- a/pkg/sql/opt/optbuilder/testdata/scalar
+++ b/pkg/sql/opt/optbuilder/testdata/scalar
@@ -367,6 +367,188 @@ case [type=int, outer=(1)]
  │    └── const: 1 [type=int]
  └── null [type=unknown]
 
+build-scalar vars=(int)
+@1 BETWEEN 1 AND 4
+----
+and [type=bool, outer=(1)]
+ ├── ge [type=bool, outer=(1)]
+ │    ├── variable: @1 [type=int, outer=(1)]
+ │    └── const: 1 [type=int]
+ └── le [type=bool, outer=(1)]
+      ├── variable: @1 [type=int, outer=(1)]
+      └── const: 4 [type=int]
+
+build-scalar vars=(int)
+@1 NOT BETWEEN 1 AND 4
+----
+not [type=bool, outer=(1)]
+ └── and [type=bool, outer=(1)]
+      ├── ge [type=bool, outer=(1)]
+      │    ├── variable: @1 [type=int, outer=(1)]
+      │    └── const: 1 [type=int]
+      └── le [type=bool, outer=(1)]
+           ├── variable: @1 [type=int, outer=(1)]
+           └── const: 4 [type=int]
+
+build-scalar vars=(int)
+@1 BETWEEN SYMMETRIC 1 AND 4
+----
+or [type=bool, outer=(1)]
+ ├── and [type=bool, outer=(1)]
+ │    ├── ge [type=bool, outer=(1)]
+ │    │    ├── variable: @1 [type=int, outer=(1)]
+ │    │    └── const: 1 [type=int]
+ │    └── le [type=bool, outer=(1)]
+ │         ├── variable: @1 [type=int, outer=(1)]
+ │         └── const: 4 [type=int]
+ └── and [type=bool, outer=(1)]
+      ├── ge [type=bool, outer=(1)]
+      │    ├── variable: @1 [type=int, outer=(1)]
+      │    └── const: 4 [type=int]
+      └── le [type=bool, outer=(1)]
+           ├── variable: @1 [type=int, outer=(1)]
+           └── const: 1 [type=int]
+
+build-scalar vars=(int)
+@1 NOT BETWEEN SYMMETRIC 1 AND 4
+----
+not [type=bool, outer=(1)]
+ └── or [type=bool, outer=(1)]
+      ├── and [type=bool, outer=(1)]
+      │    ├── ge [type=bool, outer=(1)]
+      │    │    ├── variable: @1 [type=int, outer=(1)]
+      │    │    └── const: 1 [type=int]
+      │    └── le [type=bool, outer=(1)]
+      │         ├── variable: @1 [type=int, outer=(1)]
+      │         └── const: 4 [type=int]
+      └── and [type=bool, outer=(1)]
+           ├── ge [type=bool, outer=(1)]
+           │    ├── variable: @1 [type=int, outer=(1)]
+           │    └── const: 4 [type=int]
+           └── le [type=bool, outer=(1)]
+                ├── variable: @1 [type=int, outer=(1)]
+                └── const: 1 [type=int]
+
+build-scalar vars=(int, int, int)
+@1 BETWEEN @2 AND @3
+----
+and [type=bool, outer=(1-3)]
+ ├── ge [type=bool, outer=(1,2)]
+ │    ├── variable: @1 [type=int, outer=(1)]
+ │    └── variable: @2 [type=int, outer=(2)]
+ └── le [type=bool, outer=(1,3)]
+      ├── variable: @1 [type=int, outer=(1)]
+      └── variable: @3 [type=int, outer=(3)]
+
+build-scalar vars=(int, int, int)
+(@1 + @2) BETWEEN (@2 + @3) AND (@3 + @1)
+----
+and [type=bool, outer=(1-3)]
+ ├── ge [type=bool, outer=(1-3)]
+ │    ├── plus [type=int, outer=(1,2)]
+ │    │    ├── variable: @1 [type=int, outer=(1)]
+ │    │    └── variable: @2 [type=int, outer=(2)]
+ │    └── plus [type=int, outer=(2,3)]
+ │         ├── variable: @2 [type=int, outer=(2)]
+ │         └── variable: @3 [type=int, outer=(3)]
+ └── le [type=bool, outer=(1-3)]
+      ├── plus [type=int, outer=(1,2)]
+      │    ├── variable: @1 [type=int, outer=(1)]
+      │    └── variable: @2 [type=int, outer=(2)]
+      └── plus [type=int, outer=(1,3)]
+           ├── variable: @3 [type=int, outer=(3)]
+           └── variable: @1 [type=int, outer=(1)]
+
+build-scalar vars=(int, int, int)
+(@1 + @2) BETWEEN SYMMETRIC (@2 + @3) AND (@3 + @1)
+----
+or [type=bool, outer=(1-3)]
+ ├── and [type=bool, outer=(1-3)]
+ │    ├── ge [type=bool, outer=(1-3)]
+ │    │    ├── plus [type=int, outer=(1,2)]
+ │    │    │    ├── variable: @1 [type=int, outer=(1)]
+ │    │    │    └── variable: @2 [type=int, outer=(2)]
+ │    │    └── plus [type=int, outer=(2,3)]
+ │    │         ├── variable: @2 [type=int, outer=(2)]
+ │    │         └── variable: @3 [type=int, outer=(3)]
+ │    └── le [type=bool, outer=(1-3)]
+ │         ├── plus [type=int, outer=(1,2)]
+ │         │    ├── variable: @1 [type=int, outer=(1)]
+ │         │    └── variable: @2 [type=int, outer=(2)]
+ │         └── plus [type=int, outer=(1,3)]
+ │              ├── variable: @3 [type=int, outer=(3)]
+ │              └── variable: @1 [type=int, outer=(1)]
+ └── and [type=bool, outer=(1-3)]
+      ├── ge [type=bool, outer=(1-3)]
+      │    ├── plus [type=int, outer=(1,2)]
+      │    │    ├── variable: @1 [type=int, outer=(1)]
+      │    │    └── variable: @2 [type=int, outer=(2)]
+      │    └── plus [type=int, outer=(1,3)]
+      │         ├── variable: @3 [type=int, outer=(3)]
+      │         └── variable: @1 [type=int, outer=(1)]
+      └── le [type=bool, outer=(1-3)]
+           ├── plus [type=int, outer=(1,2)]
+           │    ├── variable: @1 [type=int, outer=(1)]
+           │    └── variable: @2 [type=int, outer=(2)]
+           └── plus [type=int, outer=(2,3)]
+                ├── variable: @2 [type=int, outer=(2)]
+                └── variable: @3 [type=int, outer=(3)]
+
+build-scalar vars=(int, int, int)
+(@1, @2) BETWEEN (1, 2) AND (3, 4)
+----
+and [type=bool, outer=(1,2)]
+ ├── ge [type=bool, outer=(1,2)]
+ │    ├── tuple [type=tuple{int, int}, outer=(1,2)]
+ │    │    ├── variable: @1 [type=int, outer=(1)]
+ │    │    └── variable: @2 [type=int, outer=(2)]
+ │    └── tuple [type=tuple{int, int}]
+ │         ├── const: 1 [type=int]
+ │         └── const: 2 [type=int]
+ └── le [type=bool, outer=(1,2)]
+      ├── tuple [type=tuple{int, int}, outer=(1,2)]
+      │    ├── variable: @1 [type=int, outer=(1)]
+      │    └── variable: @2 [type=int, outer=(2)]
+      └── tuple [type=tuple{int, int}]
+           ├── const: 3 [type=int]
+           └── const: 4 [type=int]
+
+build-scalar vars=(int, int, int)
+(@1, @2) NOT BETWEEN SYMMETRIC (1, 2) AND (3, 4)
+----
+not [type=bool, outer=(1,2)]
+ └── or [type=bool, outer=(1,2)]
+      ├── and [type=bool, outer=(1,2)]
+      │    ├── ge [type=bool, outer=(1,2)]
+      │    │    ├── tuple [type=tuple{int, int}, outer=(1,2)]
+      │    │    │    ├── variable: @1 [type=int, outer=(1)]
+      │    │    │    └── variable: @2 [type=int, outer=(2)]
+      │    │    └── tuple [type=tuple{int, int}]
+      │    │         ├── const: 1 [type=int]
+      │    │         └── const: 2 [type=int]
+      │    └── le [type=bool, outer=(1,2)]
+      │         ├── tuple [type=tuple{int, int}, outer=(1,2)]
+      │         │    ├── variable: @1 [type=int, outer=(1)]
+      │         │    └── variable: @2 [type=int, outer=(2)]
+      │         └── tuple [type=tuple{int, int}]
+      │              ├── const: 3 [type=int]
+      │              └── const: 4 [type=int]
+      └── and [type=bool, outer=(1,2)]
+           ├── ge [type=bool, outer=(1,2)]
+           │    ├── tuple [type=tuple{int, int}, outer=(1,2)]
+           │    │    ├── variable: @1 [type=int, outer=(1)]
+           │    │    └── variable: @2 [type=int, outer=(2)]
+           │    └── tuple [type=tuple{int, int}]
+           │         ├── const: 3 [type=int]
+           │         └── const: 4 [type=int]
+           └── le [type=bool, outer=(1,2)]
+                ├── tuple [type=tuple{int, int}, outer=(1,2)]
+                │    ├── variable: @1 [type=int, outer=(1)]
+                │    └── variable: @2 [type=int, outer=(2)]
+                └── tuple [type=tuple{int, int}]
+                     ├── const: 1 [type=int]
+                     └── const: 2 [type=int]
+
 build-scalar vars=(json) allow-unsupported
 @1->>'a' = 'b'
 ----

--- a/pkg/sql/opt/xform/factory.go
+++ b/pkg/sql/opt/xform/factory.go
@@ -358,6 +358,16 @@ func (f *factory) simplifyOr(conditions opt.ListID) opt.GroupID {
 	return f.ConstructOr(f.mem.internList(list))
 }
 
+// negateConditions negates the given conditions and puts them in a new list.
+func (f *factory) negateConditions(conditions opt.ListID) opt.ListID {
+	list := f.mem.lookupList(conditions)
+	negCond := make([]opt.GroupID, len(list))
+	for i := range list {
+		negCond[i] = f.ConstructNot(list[i])
+	}
+	return f.mem.internList(negCond)
+}
+
 // negateComparison negates a comparison op like:
 //   a.x = 5
 // to:

--- a/pkg/sql/opt/xform/factory.og.go
+++ b/pkg/sql/opt/xform/factory.og.go
@@ -407,6 +407,30 @@ func (_f *factory) ConstructNot(
 		}
 	}
 
+	// [NegateAnd]
+	{
+		_and := _f.mem.lookupNormExpr(input).asAnd()
+		if _and != nil {
+			conditions := _and.conditions()
+			_f.reportOptimization()
+			_group = _f.ConstructOr(_f.negateConditions(conditions))
+			_f.mem.addAltFingerprint(_notExpr.fingerprint(), _group)
+			return _group
+		}
+	}
+
+	// [NegateOr]
+	{
+		_or := _f.mem.lookupNormExpr(input).asOr()
+		if _or != nil {
+			conditions := _or.conditions()
+			_f.reportOptimization()
+			_group = _f.ConstructAnd(_f.negateConditions(conditions))
+			_f.mem.addAltFingerprint(_notExpr.fingerprint(), _group)
+			return _group
+		}
+	}
+
 	return _f.onConstruct(_f.mem.memoizeNormExpr(memoExpr(_notExpr)))
 }
 

--- a/pkg/sql/opt/xform/rules/bool.opt
+++ b/pkg/sql/opt/xform/rules/bool.opt
@@ -79,3 +79,17 @@ $item
 # EliminateNot discards a doubled Not operator.
 [EliminateNot, Normalize]
 (Not (Not $input:*)) => $input
+
+# NegateAnd converts the negation of a conjunction into a disjunction of
+# negations.
+[NegateAnd, Normalize]
+(Not (And $conditions:*))
+=>
+(Or (NegateConditions $conditions))
+
+# NegateOr converts the negation of a disjunction into a conjunction of
+# negations.
+[NegateOr, Normalize]
+(Not (Or $conditions:*))
+=>
+(And (NegateConditions $conditions))

--- a/pkg/sql/opt/xform/testdata/rules/bool
+++ b/pkg/sql/opt/xform/testdata/rules/bool
@@ -412,3 +412,142 @@ select
  └── contains [type=bool, outer=(5)]
       ├── const: '[1, 2]' [type=jsonb]
       └── variable: a.j [type=jsonb, outer=(5)]
+
+# --------------------------------------------------
+# NegateAnd + NegateComparison
+# --------------------------------------------------
+opt
+SELECT * FROM a WHERE NOT (k >= i AND i < f)
+----
+select
+ ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
+ ├── scan
+ │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
+ └── or [type=bool, outer=(1-3)]
+      ├── lt [type=bool, outer=(1,2)]
+      │    ├── variable: a.k [type=int, outer=(1)]
+      │    └── variable: a.i [type=int, outer=(2)]
+      └── ge [type=bool, outer=(2,3)]
+           ├── variable: a.i [type=int, outer=(2)]
+           └── variable: a.f [type=float, outer=(3)]
+
+opt
+SELECT * FROM a WHERE NOT (k >= i AND i < f AND (i > 5 AND i < 10 AND f > 1))
+----
+select
+ ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
+ ├── scan
+ │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
+ └── or [type=bool, outer=(1-3)]
+      ├── lt [type=bool, outer=(1,2)]
+      │    ├── variable: a.k [type=int, outer=(1)]
+      │    └── variable: a.i [type=int, outer=(2)]
+      ├── ge [type=bool, outer=(2,3)]
+      │    ├── variable: a.i [type=int, outer=(2)]
+      │    └── variable: a.f [type=float, outer=(3)]
+      ├── le [type=bool, outer=(2)]
+      │    ├── variable: a.i [type=int, outer=(2)]
+      │    └── const: 5 [type=int]
+      ├── ge [type=bool, outer=(2)]
+      │    ├── variable: a.i [type=int, outer=(2)]
+      │    └── const: 10 [type=int]
+      └── le [type=bool, outer=(3)]
+           ├── variable: a.f [type=float, outer=(3)]
+           └── const: 1.0 [type=float]
+
+
+# --------------------------------------------------
+# NegateOr + NegateComparison
+# --------------------------------------------------
+opt
+SELECT * FROM a WHERE NOT (k >= i OR i < f OR k + i < f)
+----
+select
+ ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
+ ├── scan
+ │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
+ └── and [type=bool, outer=(1-3)]
+      ├── lt [type=bool, outer=(1,2)]
+      │    ├── variable: a.k [type=int, outer=(1)]
+      │    └── variable: a.i [type=int, outer=(2)]
+      ├── ge [type=bool, outer=(2,3)]
+      │    ├── variable: a.i [type=int, outer=(2)]
+      │    └── variable: a.f [type=float, outer=(3)]
+      └── le [type=bool, outer=(1-3)]
+           ├── variable: a.f [type=float, outer=(3)]
+           └── plus [type=int, outer=(1,2)]
+                ├── variable: a.k [type=int, outer=(1)]
+                └── variable: a.i [type=int, outer=(2)]
+
+opt
+SELECT * FROM a WHERE NOT (k >= i OR i < f OR (i > 5 OR i < 10 OR f > 1))
+----
+select
+ ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
+ ├── scan
+ │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
+ └── and [type=bool, outer=(1-3)]
+      ├── lt [type=bool, outer=(1,2)]
+      │    ├── variable: a.k [type=int, outer=(1)]
+      │    └── variable: a.i [type=int, outer=(2)]
+      ├── ge [type=bool, outer=(2,3)]
+      │    ├── variable: a.i [type=int, outer=(2)]
+      │    └── variable: a.f [type=float, outer=(3)]
+      ├── le [type=bool, outer=(2)]
+      │    ├── variable: a.i [type=int, outer=(2)]
+      │    └── const: 5 [type=int]
+      ├── ge [type=bool, outer=(2)]
+      │    ├── variable: a.i [type=int, outer=(2)]
+      │    └── const: 10 [type=int]
+      └── le [type=bool, outer=(3)]
+           ├── variable: a.f [type=float, outer=(3)]
+           └── const: 1.0 [type=float]
+
+# --------------------------------------------------
+# NegateAnd + NegateOr + NegateComparison
+# --------------------------------------------------
+opt
+SELECT * FROM a WHERE NOT ((k >= i OR i < f) AND (i > 5 OR f > 1))
+----
+select
+ ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
+ ├── scan
+ │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
+ └── or [type=bool, outer=(1-3)]
+      ├── and [type=bool, outer=(1-3)]
+      │    ├── lt [type=bool, outer=(1,2)]
+      │    │    ├── variable: a.k [type=int, outer=(1)]
+      │    │    └── variable: a.i [type=int, outer=(2)]
+      │    └── ge [type=bool, outer=(2,3)]
+      │         ├── variable: a.i [type=int, outer=(2)]
+      │         └── variable: a.f [type=float, outer=(3)]
+      └── and [type=bool, outer=(2,3)]
+           ├── le [type=bool, outer=(2)]
+           │    ├── variable: a.i [type=int, outer=(2)]
+           │    └── const: 5 [type=int]
+           └── le [type=bool, outer=(3)]
+                ├── variable: a.f [type=float, outer=(3)]
+                └── const: 1.0 [type=float]
+
+opt
+SELECT * FROM a WHERE NOT ((k >= i AND i < f) OR (i > 5 AND f > 1))
+----
+select
+ ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
+ ├── scan
+ │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
+ └── and [type=bool, outer=(1-3)]
+      ├── or [type=bool, outer=(1-3)]
+      │    ├── lt [type=bool, outer=(1,2)]
+      │    │    ├── variable: a.k [type=int, outer=(1)]
+      │    │    └── variable: a.i [type=int, outer=(2)]
+      │    └── ge [type=bool, outer=(2,3)]
+      │         ├── variable: a.i [type=int, outer=(2)]
+      │         └── variable: a.f [type=float, outer=(3)]
+      └── or [type=bool, outer=(2,3)]
+           ├── le [type=bool, outer=(2)]
+           │    ├── variable: a.i [type=int, outer=(2)]
+           │    └── const: 5 [type=int]
+           └── le [type=bool, outer=(3)]
+                ├── variable: a.f [type=float, outer=(3)]
+                └── const: 1.0 [type=float]

--- a/pkg/testutils/lint/lint_test.go
+++ b/pkg/testutils/lint/lint_test.go
@@ -734,6 +734,7 @@ func TestLint(t *testing.T) {
 			}),
 			stream.GrepNot(`declaration of "?(pE|e)rr"? shadows`),
 			stream.GrepNot(`\.pb\.gw\.go:[0-9]+: declaration of "?ctx"? shadows`),
+			stream.GrepNot(`\.og\.go:[0-9]+: declaration of ".*" shadows`),
 		), func(s string) {
 			t.Error(s)
 		}); err != nil {


### PR DESCRIPTION
#### opt: add rules to push negation through And/Or

Normalization rules to convert:
```
NOT (a AND b) -> (NOT a) OR (NOT b)
NOT (a OR b)  -> (NOT a) AND (NOT b)
```

Release note: None

#### opt: build RangeCond

Support for `BETWEEN` syntax. We don't add an operator, but directly
construct the equivalent expression.

Note that the current planner does the same normalization.
Unfortunately this normalization is problematic if the expressions
have side-effects. Leaving that as a TODO for now.

Release note: None
