### PR TITLE
DNM distsqlrun: propagate metadata in sorter

### DIFF
--- a/pkg/sql/distsqlrun/sorter.go
+++ b/pkg/sql/distsqlrun/sorter.go
@@ -340,7 +340,9 @@ func (s *sortAllProcessor) producerMeta(err error) *ProducerMetadata {
 			meta = &ProducerMetadata{TraceData: trace}
 		}
 		s.close()
-		return meta
+		if meta != nil {
+			return meta
+		}
 	}
 	if len(s.meta) > 0 {
 		meta := &s.meta[0]
@@ -495,7 +497,9 @@ func (s *sortTopKProcessor) producerMeta(err error) *ProducerMetadata {
 			meta = &ProducerMetadata{TraceData: trace}
 		}
 		s.close()
-		return meta
+		if meta != nil {
+			return meta
+		}
 	}
 	if len(s.meta) > 0 {
 		meta := &s.meta[0]
@@ -678,7 +682,9 @@ func (s *sortChunksProcessor) producerMeta(err error) *ProducerMetadata {
 			meta = &ProducerMetadata{TraceData: trace}
 		}
 		s.close()
-		return meta
+		if meta != nil {
+			return meta
+		}
 	}
 	if len(s.meta) > 0 {
 		meta := &s.meta[0]


### PR DESCRIPTION
If the sorter closed itself without encountering any trace metadata,
it could return nil, nil, which would indicate to the consumer not to
call Next() again, and thus its trailing metadata would never be
drained.

Release note: None