### PR TITLE
build: decrease roachtest parallelism

### DIFF
--- a/build/roachtest-nightly.sh
+++ b/build/roachtest-nightly.sh
@@ -44,7 +44,8 @@ run bin/roachtest run \
   --slack-token "${SLACK_TOKEN}" \
   --cockroach "$PWD/cockroach-linux-2.6.32-gnu-amd64" \
   --workload "$PWD/bin/workload" \
-  --artifacts "$artifacts"
+  --artifacts "$artifacts" \
+  --parallelism 5
 if_tc tc_end_block "Run roachtest"
 
 if_tc tc_start_block "Upload artifacts"


### PR DESCRIPTION
While we're waiting for more quota, we might as well stop trying to run
so many clusters in parallel.

Release note: None