### PR TITLE
ui: clusterviz: fix flicker on location data refresh

### DIFF
--- a/pkg/ui/karma.conf.js
+++ b/pkg/ui/karma.conf.js
@@ -13,6 +13,14 @@ module.exports = function(config) {
     // base path that will be used to resolve all patterns (eg. files, exclude)
     basePath: "",
 
+    // redirect `console.log`s in test code to Karma's stdout.
+    // This is the default behavior in Karma 2.0; so we can remove when we upgrade.
+    browserConsoleLogOptions: {
+      format: "%b %T: %m",
+      level: "log",
+      terminal: true,
+    },
+
     // start these browsers
     // available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
     browsers: ["jsdom"],

--- a/pkg/ui/src/redux/locations.spec.ts
+++ b/pkg/ui/src/redux/locations.spec.ts
@@ -62,22 +62,31 @@ describe("selectLocations", function() {
     assert.deepEqual(selectLocations(state), []);
   });
 
-  it("returns an empty array if location data is invalid", function() {
-    const state = {
-      cachedData: {
-        locations: {
-          data: protos.cockroach.server.serverpb.LocationsResponse.fromObject({
-            locations: [
-              {},
-            ],
-          }),
-          inFlight: false,
-          valid: false,
-        },
-      },
-    };
+  // Data must still be returned while the state is invalid to avoid
+  // flickering while the data is being refreshed.
+  it("returns location data if it exists but is invalid", function() {
+    const locationData = [{
+      locality_key: "city",
+      locality_value: "nyc",
+      latitude: 123,
+      longitude: 456,
+    }];
+    const state = makeStateWithLocations(locationData);
+    state.cachedData.locations.valid = false;
 
-    assert.deepEqual(selectLocations(state), []);
+    assert.deepEqual(
+      selectLocations(state).map(climbOutOfTheMorass),
+      locationData,
+    );
+  });
+
+  it("returns an empty array if location data is null", function() {
+    const state = makeStateWithLocations(null);
+
+    assert.deepEqual(
+      selectLocations(state).map(climbOutOfTheMorass),
+      [],
+    );
   });
 
   it("returns location data if valid", function() {

--- a/pkg/ui/src/redux/locations.ts
+++ b/pkg/ui/src/redux/locations.ts
@@ -14,7 +14,7 @@ export function selectLocationsRequestStatus(state: LocationState) {
 }
 
 export function selectLocations(state: LocationState) {
-  if (!state.cachedData.locations.valid) {
+  if (!state.cachedData.locations.data) {
     return [];
   }
 


### PR DESCRIPTION
Refreshing location data would cause the node map to switch to circle layout for the duration of the request, causing a flicker. This is because the location selector bailed out if the cached reducer state was invalid. Changed it to bail out only if the data doesn't exist.

This flicker was harder to notice because the location data was only refreshed once every ten minutes. I changed it to be every ten seconds like the rest of the reducers. This may be overkill most of the time, but is also nice when setting up your config.

Release note (admin ui change): Fix another flicker in the cluster viz as data was being reloaded.