### PR TITLE
importccl: add test for node liveness blips

### DIFF
--- a/pkg/base/testing_knobs.go
+++ b/pkg/base/testing_knobs.go
@@ -31,4 +31,5 @@ type TestingKnobs struct {
 	SQLMigrationManager ModuleTestingKnobs
 	DistSQL             ModuleTestingKnobs
 	SQLEvalContext      ModuleTestingKnobs
+	RegistryLiveness    ModuleTestingKnobs
 }

--- a/pkg/ccl/importccl/csv_test.go
+++ b/pkg/ccl/importccl/csv_test.go
@@ -1028,15 +1028,12 @@ func BenchmarkConvertRecord(b *testing.B) {
 func TestImportControlJob(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	dir, cleanup := testutils.TempDir(t)
-	defer cleanup()
-
 	defer func(oldInterval time.Duration) {
 		jobs.DefaultAdoptInterval = oldInterval
 	}(jobs.DefaultAdoptInterval)
 	jobs.DefaultAdoptInterval = 100 * time.Millisecond
 
-	serverArgs := base.TestServerArgs{ExternalIODir: dir}
+	var serverArgs base.TestServerArgs
 	// Disable external processing of mutations so that the final check of
 	// crdb_internal.tables is guaranteed to not be cleaned up. Although this
 	// was never observed by a stress test, it is here for safety.
@@ -1058,7 +1055,7 @@ func TestImportControlJob(t *testing.T) {
 	sqlDB := sqlutils.MakeSQLRunner(tc.Conns[0])
 	sqlDB.Exec(t, `CREATE DATABASE data`)
 
-	t.Run("cancel import", func(t *testing.T) {
+	t.Run("cancel", func(t *testing.T) {
 		sqlDB.Exec(t, `CREATE DATABASE cancelimport`)
 
 		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -1085,7 +1082,7 @@ func TestImportControlJob(t *testing.T) {
 		sqlDB.Exec(t, query)
 	})
 
-	t.Run("pause import", func(t *testing.T) {
+	t.Run("pause", func(t *testing.T) {
 		// Test that IMPORT can be paused and resumed. This test also attempts to
 		// only pause the job after it has begun splitting ranges. When the job
 		// is resumed, if the sampling phase is re-run, the splits points will
@@ -1130,4 +1127,94 @@ func TestImportControlJob(t *testing.T) {
 			sqlDB.QueryStr(t, `SELECT * FROM generate_series(0, $1)`, count-1),
 		)
 	})
+}
+
+// TestImportLiveness tests that a node liveness increment during IMPORT
+// correctly resumes.
+//
+// Its actual purpose is to address the second bug listed in #22924 about
+// the addsstable arguments not in request range. The theory was that the
+// restart in that issue was caused by node liveness and that the work
+// already performed (the splits and addsstables) somehow caused the second
+// error. However this does not appear to be the case, as running many stress
+// iterations with differing constants (rows, sstsize, kv.import.batch_size)
+// was not able to fail in the way listed by the second bug.
+func TestImportLiveness(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	defer func(oldInterval time.Duration) {
+		jobs.DefaultAdoptInterval = oldInterval
+	}(jobs.DefaultAdoptInterval)
+	jobs.DefaultAdoptInterval = 100 * time.Millisecond
+
+	const nodes = 1
+	nl := jobs.NewFakeNodeLiveness(nodes)
+	serverArgs := base.TestServerArgs{
+		Knobs: base.TestingKnobs{
+			RegistryLiveness: nl,
+		},
+	}
+
+	var allowResponse chan struct{}
+	params := base.TestClusterArgs{ServerArgs: serverArgs}
+	params.ServerArgs.Knobs.Store = &storage.StoreTestingKnobs{
+		TestingResponseFilter: jobutils.BulkOpResponseFilter(&allowResponse),
+	}
+
+	ctx := context.Background()
+	tc := testcluster.StartTestCluster(t, nodes, params)
+	defer tc.Stopper().Stop(ctx)
+	sqlDB := sqlutils.MakeSQLRunner(tc.Conns[0])
+
+	sqlDB.Exec(t, `SET CLUSTER SETTING kv.import.batch_size = '300B'`)
+	sqlDB.Exec(t, `CREATE DATABASE liveness`)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		const rows = 5000
+		if r.Method == "GET" {
+			for i := 0; i < rows; i++ {
+				fmt.Fprintln(w, i)
+			}
+		}
+	}))
+	defer srv.Close()
+
+	const query = `IMPORT TABLE liveness.t (i INT PRIMARY KEY) CSV DATA ($1) WITH sstsize = '500B'`
+
+	// Start an IMPORT and wait until it's done one addsstable.
+	allowResponse = make(chan struct{})
+	errCh := make(chan error)
+	go func() {
+		_, err := sqlDB.DB.Exec(query, srv.URL)
+		errCh <- err
+	}()
+	// Allow many, but not all, addsstables to complete.
+	for i := 0; i < 50; i++ {
+		select {
+		case allowResponse <- struct{}{}:
+		case err := <-errCh:
+			t.Fatal(err)
+		}
+	}
+	// Fetch the new job ID since we know it's running now.
+	var jobID int64
+	sqlDB.QueryRow(t, `SELECT id FROM system.jobs ORDER BY created DESC LIMIT 1`).Scan(&jobID)
+
+	// addsstable is done, now tick liveness and wait for it to cancel the import.
+	nl.FakeIncrementEpoch(1)
+	// Wait for the registry cancel loop to run, otherwise the job can sometimes succeed.
+	time.Sleep(jobs.DefaultCancelInterval)
+	close(allowResponse)
+	err := <-errCh
+	// Expect the odd double context canceled error. The first is from the node
+	// liveness causing the job registry to cancel the job. The second is from
+	// the job registry failing to cancel the job because the context has been
+	// canceled.
+	if !testutils.IsError(err, "could not mark job .* as failed: context canceled: context canceled") {
+		t.Fatalf("unexpected: %v", err)
+	}
+	// The registry should now adopt the job and resume it.
+	if err := jobutils.WaitForJob(sqlDB.DB, jobID); err != nil {
+		t.Fatal(err)
+	}
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1236,10 +1236,16 @@ If problems persist, please see ` + base.DocsURL("cluster-setup-troubleshooting.
 		}
 	})
 
-	if err := s.jobRegistry.Start(
-		ctx, s.stopper, s.nodeLiveness, jobs.DefaultCancelInterval, jobs.DefaultAdoptInterval,
-	); err != nil {
-		return err
+	{
+		var regLiveness jobs.NodeLiveness = s.nodeLiveness
+		if testingLiveness := s.cfg.TestingKnobs.RegistryLiveness; testingLiveness != nil {
+			regLiveness = testingLiveness.(*jobs.FakeNodeLiveness)
+		}
+		if err := s.jobRegistry.Start(
+			ctx, s.stopper, regLiveness, jobs.DefaultCancelInterval, jobs.DefaultAdoptInterval,
+		); err != nil {
+			return err
+		}
 	}
 
 	// Before serving SQL requests, we have to make sure the database is

--- a/pkg/sql/jobs/helpers.go
+++ b/pkg/sql/jobs/helpers.go
@@ -1,0 +1,108 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package jobs
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/storage"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+)
+
+// FakeNodeID is a dummy node ID for use in tests. It always stores 1.
+var FakeNodeID = func() *base.NodeIDContainer {
+	nodeID := base.NodeIDContainer{}
+	nodeID.Reset(1)
+	return &nodeID
+}()
+
+// FakeNodeLiveness allows simulating liveness failures without the full
+// storage.NodeLiveness machinery.
+type FakeNodeLiveness struct {
+	mu struct {
+		syncutil.Mutex
+		livenessMap map[roachpb.NodeID]*storage.Liveness
+	}
+
+	// A non-blocking send is performed over these channels when the corresponding
+	// method is called.
+	SelfCalledCh          chan struct{}
+	GetLivenessesCalledCh chan struct{}
+}
+
+// NewFakeNodeLiveness initializes a new NodeLiveness with nodeCount live nodes.
+func NewFakeNodeLiveness(nodeCount int) *FakeNodeLiveness {
+	nl := &FakeNodeLiveness{
+		SelfCalledCh:          make(chan struct{}),
+		GetLivenessesCalledCh: make(chan struct{}),
+	}
+	nl.mu.livenessMap = make(map[roachpb.NodeID]*storage.Liveness)
+	for i := 0; i < nodeCount; i++ {
+		nodeID := roachpb.NodeID(i + 1)
+		nl.mu.livenessMap[nodeID] = &storage.Liveness{
+			Epoch:      1,
+			Expiration: hlc.LegacyTimestamp(hlc.MaxTimestamp),
+			NodeID:     nodeID,
+		}
+	}
+	return nl
+}
+
+// ModuleTestingKnobs implements base.ModuleTestingKnobs.
+func (*FakeNodeLiveness) ModuleTestingKnobs() {}
+
+// Self implements the implicit storage.NodeLiveness interface. It uses NodeID
+// as the node ID. On every call, a nonblocking send is performed over nl.ch to
+// allow tests to execute a callback.
+func (nl *FakeNodeLiveness) Self() (*storage.Liveness, error) {
+	select {
+	case nl.SelfCalledCh <- struct{}{}:
+	default:
+	}
+	nl.mu.Lock()
+	defer nl.mu.Unlock()
+	selfCopy := *nl.mu.livenessMap[FakeNodeID.Get()]
+	return &selfCopy, nil
+}
+
+// GetLivenesses implements the implicit storage.NodeLiveness interface.
+func (nl *FakeNodeLiveness) GetLivenesses() (out []storage.Liveness) {
+	select {
+	case nl.GetLivenessesCalledCh <- struct{}{}:
+	default:
+	}
+	nl.mu.Lock()
+	defer nl.mu.Unlock()
+	for _, liveness := range nl.mu.livenessMap {
+		out = append(out, *liveness)
+	}
+	return out
+}
+
+// FakeIncrementEpoch increments the epoch for the node with the specified ID.
+func (nl *FakeNodeLiveness) FakeIncrementEpoch(id roachpb.NodeID) {
+	nl.mu.Lock()
+	defer nl.mu.Unlock()
+	nl.mu.livenessMap[id].Epoch++
+}
+
+// FakeSetExpiration sets the expiration time of the liveness for the node with
+// the specified ID to ts.
+func (nl *FakeNodeLiveness) FakeSetExpiration(id roachpb.NodeID, ts hlc.Timestamp) {
+	nl.mu.Lock()
+	defer nl.mu.Unlock()
+	nl.mu.livenessMap[id].Expiration = hlc.LegacyTimestamp(ts)
+}

--- a/pkg/sql/jobs/helpers_test.go
+++ b/pkg/sql/jobs/helpers_test.go
@@ -17,102 +17,13 @@ package jobs
 import (
 	"context"
 
-	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
-	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
-	"github.com/cockroachdb/cockroach/pkg/storage"
-	"github.com/cockroachdb/cockroach/pkg/util/hlc"
-	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 )
 
 func ResetResumeHooks() func() {
 	oldResumeHooks := resumeHooks
 	return func() { resumeHooks = oldResumeHooks }
-}
-
-// FakeNodeID is a dummy node ID for use in tests. It always stores 1.
-var FakeNodeID = func() *base.NodeIDContainer {
-	nodeID := base.NodeIDContainer{}
-	nodeID.Reset(1)
-	return &nodeID
-}()
-
-// FakeNodeLiveness allows simulating liveness failures without the full
-// storage.NodeLiveness machinery.
-type FakeNodeLiveness struct {
-	clock *hlc.Clock
-	mu    struct {
-		syncutil.Mutex
-		livenessMap map[roachpb.NodeID]*storage.Liveness
-	}
-
-	// A non-blocking send is performed over these channels when the corresponding
-	// method is called.
-	SelfCalledCh          chan struct{}
-	GetLivenessesCalledCh chan struct{}
-}
-
-// NewFakeNodeLiveness initializes a new NodeLiveness with nodeCount live nodes.
-func NewFakeNodeLiveness(clock *hlc.Clock, nodeCount int) *FakeNodeLiveness {
-	nl := &FakeNodeLiveness{
-		clock:                 clock,
-		SelfCalledCh:          make(chan struct{}),
-		GetLivenessesCalledCh: make(chan struct{}),
-	}
-	nl.mu.livenessMap = make(map[roachpb.NodeID]*storage.Liveness)
-	for i := 0; i < nodeCount; i++ {
-		nodeID := roachpb.NodeID(i + 1)
-		nl.mu.livenessMap[nodeID] = &storage.Liveness{
-			Epoch:      1,
-			Expiration: hlc.LegacyTimestamp(hlc.MaxTimestamp),
-			NodeID:     nodeID,
-		}
-	}
-	return nl
-}
-
-// Self implements the implicit storage.NodeLiveness interface. It uses NodeID
-// as the node ID. On every call, a nonblocking send is performed over nl.ch to
-// allow tests to execute a callback.
-func (nl *FakeNodeLiveness) Self() (*storage.Liveness, error) {
-	select {
-	case nl.SelfCalledCh <- struct{}{}:
-	default:
-	}
-	nl.mu.Lock()
-	defer nl.mu.Unlock()
-	selfCopy := *nl.mu.livenessMap[FakeNodeID.Get()]
-	return &selfCopy, nil
-}
-
-// GetLivenesses implements the implicit storage.NodeLiveness interface.
-func (nl *FakeNodeLiveness) GetLivenesses() (out []storage.Liveness) {
-	select {
-	case nl.GetLivenessesCalledCh <- struct{}{}:
-	default:
-	}
-	nl.mu.Lock()
-	defer nl.mu.Unlock()
-	for _, liveness := range nl.mu.livenessMap {
-		out = append(out, *liveness)
-	}
-	return out
-}
-
-// FakeIncrementEpoch increments the epoch for the node with the specified ID.
-func (nl *FakeNodeLiveness) FakeIncrementEpoch(id roachpb.NodeID) {
-	nl.mu.Lock()
-	defer nl.mu.Unlock()
-	nl.mu.livenessMap[id].Epoch++
-}
-
-// FakeSetExpiration sets the expiration time of the liveness for the node with
-// the specified ID to ts.
-func (nl *FakeNodeLiveness) FakeSetExpiration(id roachpb.NodeID, ts hlc.Timestamp) {
-	nl.mu.Lock()
-	defer nl.mu.Unlock()
-	nl.mu.livenessMap[id].Expiration = hlc.LegacyTimestamp(ts)
 }
 
 // FakeResumer calls optional callbacks during the job lifecycle.

--- a/pkg/sql/jobs/registry.go
+++ b/pkg/sql/jobs/registry.go
@@ -36,9 +36,9 @@ import (
 
 var nodeLivenessLogLimiter = log.Every(5 * time.Second)
 
-// nodeLiveness is the subset of storage.NodeLiveness's interface needed
+// NodeLiveness is the subset of storage.NodeLiveness's interface needed
 // by Registry.
-type nodeLiveness interface {
+type NodeLiveness interface {
 	Self() (*storage.Liveness, error)
 	GetLivenesses() []storage.Liveness
 }
@@ -193,7 +193,7 @@ var DefaultAdoptInterval = 30 * time.Second
 func (r *Registry) Start(
 	ctx context.Context,
 	stopper *stop.Stopper,
-	nl nodeLiveness,
+	nl NodeLiveness,
 	cancelInterval, adoptInterval time.Duration,
 ) error {
 	// Calling maybeCancelJobs once at the start ensures we have an up-to-date
@@ -226,7 +226,7 @@ func (r *Registry) Start(
 	return nil
 }
 
-func (r *Registry) maybeCancelJobs(ctx context.Context, nl nodeLiveness) {
+func (r *Registry) maybeCancelJobs(ctx context.Context, nl NodeLiveness) {
 	liveness, err := nl.Self()
 	if err != nil {
 		if nodeLivenessLogLimiter.ShouldLog() {
@@ -411,7 +411,7 @@ func AddResumeHook(fn ResumeHookFn) {
 	resumeHooks = append(resumeHooks, fn)
 }
 
-func (r *Registry) maybeAdoptJob(ctx context.Context, nl nodeLiveness) error {
+func (r *Registry) maybeAdoptJob(ctx context.Context, nl NodeLiveness) error {
 	var rows []tree.Datums
 	if err := r.db.Txn(ctx, func(ctx context.Context, txn *client.Txn) error {
 		var err error

--- a/pkg/sql/jobs/registry_external_test.go
+++ b/pkg/sql/jobs/registry_external_test.go
@@ -78,7 +78,7 @@ func TestRegistryResumeExpiredLease(t *testing.T) {
 	db := s.DB()
 	ex := &sql.InternalExecutor{ExecCfg: s.InternalExecutor().(*sql.InternalExecutor).ExecCfg}
 	clock := hlc.NewClock(hlc.UnixNano, time.Nanosecond)
-	nodeLiveness := jobs.NewFakeNodeLiveness(clock, 4)
+	nodeLiveness := jobs.NewFakeNodeLiveness(4)
 	newRegistry := func(id roachpb.NodeID) *jobs.Registry {
 		const cancelInterval = time.Duration(math.MaxInt64)
 		const adoptInterval = time.Nanosecond

--- a/pkg/sql/jobs/registry_test.go
+++ b/pkg/sql/jobs/registry_test.go
@@ -46,7 +46,7 @@ func TestRegistryCancelation(t *testing.T) {
 	registry := MakeRegistry(log.AmbientContext{}, clock, db, ex, FakeNodeID, cluster.NoSettings, FakePHS)
 
 	const nodeCount = 1
-	nodeLiveness := NewFakeNodeLiveness(clock, nodeCount)
+	nodeLiveness := NewFakeNodeLiveness(nodeCount)
 
 	const cancelInterval = time.Nanosecond
 	const adoptInterval = time.Duration(math.MaxInt64)


### PR DESCRIPTION
Add a testing knob for the job registry node liveness. Simplify and
remove unused stuff in TestImportControlJob. Remove an unused argument
from FakeNodeLiveness.

Release note: None