### PR TITLE
log: Execute exitFunc before returning log.Fatal

### DIFF
--- a/pkg/util/log/clog.go
+++ b/pkg/util/log/clog.go
@@ -797,12 +797,17 @@ func (l *loggingT) outputLogEntry(s Severity, file string, line int, msg string)
 		// https://github.com/cockroachdb/cockroach/issues/23119
 		fatalTrigger = make(chan struct{})
 		exitFunc := l.exitFunc
+		exitCalled := make(chan struct{})
+		defer func() {
+			<-exitCalled
+		}()
 		go func() {
 			select {
 			case <-time.After(10 * time.Second):
 			case <-fatalTrigger:
 			}
 			exitFunc(255) // C++ uses -1, which is silly because it's anded with 255 anyway.
+			close(exitCalled)
 		}()
 	} else if l.traceLocation.isSet() {
 		if l.traceLocation.match(file, line) {


### PR DESCRIPTION
exitFunc is being executed asynchronously based on closing
of a channel. This makes executing a few statements after log.Fatal
possible. This change blocks till exitFunc is called before returning
from log.Fatal

Release note: none