### PR TITLE
cherrypick-2.0: scrub locality tiers from segment analytics

### DIFF
--- a/pkg/ui/src/redux/analytics.spec.ts
+++ b/pkg/ui/src/redux/analytics.spec.ts
@@ -6,7 +6,7 @@ import { Location } from "history";
 import _ from "lodash";
 import { Store } from "redux";
 
-import { AnalyticsSync } from "./analytics";
+import { AnalyticsSync, defaultRedactions } from "./analytics";
 import { clusterReducerObj, nodesReducerObj } from "./apiReducers";
 import { AdminUIState, createAdminUIStore } from "./state";
 
@@ -129,6 +129,39 @@ describe("analytics listener", function() {
         properties: {
           path: "/test/[redacted]/path",
         },
+      });
+    });
+
+    function testRedaction(title: string, input: string, expected: string) {
+      return { title, input, expected };
+    }
+
+    ([
+      testRedaction(
+        "old database URL",
+        "/databases/database/foobar/table/baz",
+        "/databases/database/[db]/table/[tbl]",
+      ),
+      testRedaction(
+        "new database URL",
+        "/database/foobar/table/baz",
+        "/database/[db]/table/[tbl]",
+      ),
+    ]).map(function ({ title, input, expected }) {
+      it(`applies a redaction for ${title}`, function () {
+        setClusterData();
+        const sync = new AnalyticsSync(analytics, store, defaultRedactions);
+
+        sync.page({ pathname: input } as Location);
+
+        assert.isTrue(pageSpy.calledOnce);
+        assert.deepEqual(pageSpy.args[0][0], {
+          userId: clusterID,
+          name: expected,
+          properties: {
+            path: expected,
+          },
+        });
       });
     });
   });

--- a/pkg/ui/src/redux/analytics.spec.ts
+++ b/pkg/ui/src/redux/analytics.spec.ts
@@ -160,7 +160,7 @@ describe("analytics listener", function() {
       testRedaction(
         "clusterviz map multiple localities",
         "/overview/map/datacenter=us-west-1/rack=1234",
-        "/overview/map/[locality]",
+        "/overview/map/[locality]/[locality]",
       ),
     ]).map(function ({ title, input, expected }) {
       it(`applies a redaction for ${title}`, function () {

--- a/pkg/ui/src/redux/analytics.spec.ts
+++ b/pkg/ui/src/redux/analytics.spec.ts
@@ -147,6 +147,21 @@ describe("analytics listener", function() {
         "/database/foobar/table/baz",
         "/database/[db]/table/[tbl]",
       ),
+      testRedaction(
+        "clusterviz map root",
+        "/overview/map/",
+        "/overview/map/",
+      ),
+      testRedaction(
+        "clusterviz map single locality",
+        "/overview/map/datacenter=us-west-1",
+        "/overview/map/[locality]",
+      ),
+      testRedaction(
+        "clusterviz map multiple localities",
+        "/overview/map/datacenter=us-west-1/rack=1234",
+        "/overview/map/[locality]",
+      ),
     ]).map(function ({ title, input, expected }) {
       it(`applies a redaction for ${title}`, function () {
         setClusterData();

--- a/pkg/ui/src/redux/analytics.ts
+++ b/pkg/ui/src/redux/analytics.ts
@@ -26,6 +26,11 @@ export const defaultRedactions = [
         match: new RegExp("/database/.*/table/.*"),
         replace: "/database/[db]/table/[tbl]",
     },
+    // The clusterviz map page, which puts localities in the URL.
+    {
+        match: new RegExp("/overview/map(/.+)+"),
+        replace: "/overview/map/[locality]",
+    },
 ];
 
 /**

--- a/pkg/ui/src/redux/analytics.ts
+++ b/pkg/ui/src/redux/analytics.ts
@@ -28,10 +28,21 @@ export const defaultRedactions = [
     },
     // The clusterviz map page, which puts localities in the URL.
     {
-        match: new RegExp("/overview/map(/.+)+"),
-        replace: "/overview/map/[locality]",
+        match: new RegExp("/overview/map((/.+)+)"),
+        useFunction: true, // I hate TypeScript.
+        replace: function countTiers(original: string, localities: string) {
+            const tierCount = localities.match(new RegExp("/", "g")).length;
+            let redactedLocalities = "";
+            for (let i = 0; i < tierCount; i++) {
+                redactedLocalities += "/[locality]";
+            }
+            return original.replace(localities, redactedLocalities);
+        },
     },
 ];
+
+type PageTrackReplacementFunction = (match: string, ...args: any[]) => string;
+type PageTrackReplacement = string | PageTrackReplacementFunction;
 
 /**
  * A PageTrackRedaction describes a regular expression used to identify PII
@@ -41,7 +52,8 @@ export const defaultRedactions = [
  */
 interface PageTrackRedaction {
     match: RegExp;
-    replace: string;
+    replace: PageTrackReplacement;
+    useFunction?: boolean; // I hate Typescript.
 }
 
 /**
@@ -173,12 +185,25 @@ export class AnalyticsSync {
      * pushPage pushes a single "page" event to the analytics service.
      */
     private pushPage = (userID: string, location: Location) => {
+
         // Loop through redactions, if any matches return the appropriate
         // redacted string.
         let path = location.pathname;
         _.each(this.redactions, (r) => {
             if (r.match.test(location.pathname)) {
-                path = r.replace;
+
+                // Apparently TypeScript doesn't know how to dispatch functions.
+                // If there are two function overloads defined (as with
+                // String.prototype.replace), it is unable to recognize that
+                // a union of the two types can be successfully passed in as a
+                // parameter of that function.  We have to explicitly
+                // disambiguate the types for it.
+                // See https://github.com/Microsoft/TypeScript/issues/14107
+                if (r.useFunction) {
+                    path = path.replace(r.match, r.replace as PageTrackReplacementFunction);
+                } else {
+                    path = path.replace(r.match, r.replace as string);
+                }
                 return false;
             }
         });

--- a/pkg/ui/src/redux/analytics.ts
+++ b/pkg/ui/src/redux/analytics.ts
@@ -14,7 +14,7 @@ type ClusterResponse = protos.cockroach.server.serverpb.ClusterResponse$Properti
  * TODO(mrtracy): It this list becomes more extensive, it might benefit from a
  * set of tests as a double-check.
  */
-const defaultRedactions = [
+export const defaultRedactions = [
     // When viewing a specific database, the database name and table are part of
     // the URL path.
     {


### PR DESCRIPTION
A cherry-pick of #23533.

cc @cockroachdb/release @vilterp 