### PR TITLE
kubernetes: Bump version of k8s-request-cert init container

### DIFF
--- a/cloud/kubernetes/cockroachdb-statefulset-secure.yaml
+++ b/cloud/kubernetes/cockroachdb-statefulset-secure.yaml
@@ -161,7 +161,7 @@ spec:
       # In addition to the node certificate and key, the init-certs entrypoint will symlink
       # the cluster CA to the certs directory.
       - name: init-certs
-        image: cockroachdb/cockroach-k8s-request-cert:0.2
+        image: cockroachdb/cockroach-k8s-request-cert:0.3
         imagePullPolicy: IfNotPresent
         command:
         - "/bin/ash"


### PR DESCRIPTION
Includes https://github.com/cockroachdb/k8s/pull/12 to avoid choking if the ca.crt symlink already exists

Release note: None