### PR TITLE
backport-2.0:  sql: drop correct zone configs when altering an index partitioning

### DIFF
--- a/pkg/ccl/partitionccl/partition_test.go
+++ b/pkg/ccl/partitionccl/partition_test.go
@@ -1303,7 +1303,7 @@ func TestRepartitioning(t *testing.T) {
 					if err != nil {
 						t.Fatal(err)
 					}
-					if tn.Table() != test.new.parsed.tableName || zs.Partition == "" {
+					if tn.Table() != test.new.parsed.tableDesc.Name || zs.Partition == "" {
 						// Ignore zone configs that do not target a partition of this table.
 						continue
 					}

--- a/pkg/ccl/partitionccl/partition_test.go
+++ b/pkg/ccl/partitionccl/partition_test.go
@@ -78,6 +78,8 @@ type partitioningTest struct {
 
 	// The following are all filled in by `parse()`.
 	parsed struct {
+		parsed bool
+
 		// tableName is `name` but escaped for use in SQL.
 		tableName string
 
@@ -103,6 +105,10 @@ type repartitioningTest struct {
 
 // parse fills in the various fields of `partitioningTest.parsed`.
 func (t *partitioningTest) parse() error {
+	if t.parsed.parsed {
+		return nil
+	}
+
 	t.parsed.tableName = tree.NameStringP(&t.name)
 	t.parsed.createStmt = fmt.Sprintf(t.schema, t.parsed.tableName)
 
@@ -179,6 +185,7 @@ func (t *partitioningTest) parse() error {
 		t.parsed.subzones = append(t.parsed.subzones, subzone)
 	}
 	t.parsed.zoneConfigStmts = zoneConfigStmts.String()
+	t.parsed.parsed = true
 
 	return nil
 }

--- a/pkg/sql/alter_index.go
+++ b/pkg/sql/alter_index.go
@@ -72,8 +72,8 @@ func (n *alterIndexNode) startExec(params runParams) error {
 			)
 			err = deleteRemovedPartitionZoneConfigs(
 				params.ctx, params.p.txn,
-				n.tableDesc, &n.tableDesc.PrimaryIndex,
-				&n.tableDesc.PrimaryIndex.Partitioning, &partitioning,
+				n.tableDesc, n.indexDesc,
+				&n.indexDesc.Partitioning, &partitioning,
 				params.extendedEvalCtx.ExecCfg,
 			)
 			if err != nil {


### PR DESCRIPTION
Backports 3/3 commits from #23559.
		
/cc @cockroachdb/release"

---

ALTER INDEX ... PARTITION BY ... would incorrectly drop zone configs for
partitions of a table's primary key due to copypasta. Errors of this
kind are now properly caught by TestRepartitioning since e573238.