### PR TITLE
.gitignore: ignore workload binary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ artifacts
 # cockroach-data, cockroach{,.race}-{darwin,linux,windows}-*
 /cockroach*
 /certs
+pkg/cmd/workload/workload
 # make stress, acceptance produce stress.test, acceptance.test
 *.test*
 


### PR DESCRIPTION
I keep accidentally adding the binary to other PRs.