### PR TITLE
opt/optbuilder: add more tests for ORDER BY

### DIFF
--- a/pkg/sql/opt/optbuilder/testdata/aggregate
+++ b/pkg/sql/opt/optbuilder/testdata/aggregate
@@ -720,6 +720,78 @@ SELECT COUNT(k, v) FROM t.kv
 error: unknown signature: count(int, int)
 
 build
+SELECT v, COUNT(k) FROM kv GROUP BY v ORDER BY v
+----
+sort
+ ├── columns: v:2(int) column5:5(int)
+ ├── ordering: +2
+ └── group-by
+      ├── columns: kv.v:2(int) column5:5(int)
+      ├── grouping columns: kv.v:2(int)
+      ├── project
+      │    ├── columns: kv.v:2(int) kv.k:1(int!null)
+      │    ├── scan
+      │    │    └── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string)
+      │    └── projections [outer=(1,2)]
+      │         ├── variable: kv.v [type=int, outer=(2)]
+      │         └── variable: kv.k [type=int, outer=(1)]
+      └── aggregations [outer=(1)]
+           └── function: count [type=int, outer=(1)]
+                └── variable: kv.k [type=int, outer=(1)]
+
+build
+SELECT v, COUNT(k) FROM kv GROUP BY v ORDER BY v DESC
+----
+sort
+ ├── columns: v:2(int) column5:5(int)
+ ├── ordering: -2
+ └── group-by
+      ├── columns: kv.v:2(int) column5:5(int)
+      ├── grouping columns: kv.v:2(int)
+      ├── project
+      │    ├── columns: kv.v:2(int) kv.k:1(int!null)
+      │    ├── scan
+      │    │    └── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string)
+      │    └── projections [outer=(1,2)]
+      │         ├── variable: kv.v [type=int, outer=(2)]
+      │         └── variable: kv.k [type=int, outer=(1)]
+      └── aggregations [outer=(1)]
+           └── function: count [type=int, outer=(1)]
+                └── variable: kv.k [type=int, outer=(1)]
+
+# TODO(rytaft): This is a bug. This query is valid.
+build
+SELECT v, COUNT(k) FROM kv GROUP BY v ORDER BY COUNT(k) DESC
+----
+error: column name "k" not found
+
+# TODO(rytaft): This is a bug. This query is valid.
+build
+SELECT v, COUNT(k) FROM kv GROUP BY v ORDER BY v-COUNT(k)
+----
+error: column name "k" not found
+
+build
+SELECT v, COUNT(k) FROM kv GROUP BY v ORDER BY 1 DESC
+----
+sort
+ ├── columns: v:2(int) column5:5(int)
+ ├── ordering: -2
+ └── group-by
+      ├── columns: kv.v:2(int) column5:5(int)
+      ├── grouping columns: kv.v:2(int)
+      ├── project
+      │    ├── columns: kv.v:2(int) kv.k:1(int!null)
+      │    ├── scan
+      │    │    └── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string)
+      │    └── projections [outer=(1,2)]
+      │         ├── variable: kv.v [type=int, outer=(2)]
+      │         └── variable: kv.k [type=int, outer=(1)]
+      └── aggregations [outer=(1)]
+           └── function: count [type=int, outer=(1)]
+                └── variable: kv.k [type=int, outer=(1)]
+
+build
 SELECT COUNT(*), COUNT(k), COUNT(kv.v) FROM t.kv
 ----
 group-by
@@ -871,6 +943,24 @@ group-by
       │    └── variable: kv.v [type=int, outer=(2)]
       └── function: max [type=int, outer=(2)]
            └── variable: kv.v [type=int, outer=(2)]
+
+build
+SELECT ARRAY_AGG(k), ARRAY_AGG(s) FROM (SELECT k, s FROM kv ORDER BY k)
+----
+group-by
+ ├── columns: column5:5(int[]) column6:6(string[])
+ ├── project
+ │    ├── columns: kv.k:1(int!null) kv.s:4(string)
+ │    ├── scan
+ │    │    └── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string)
+ │    └── projections [outer=(1,4)]
+ │         ├── variable: kv.k [type=int, outer=(1)]
+ │         └── variable: kv.s [type=string, outer=(4)]
+ └── aggregations [outer=(1,4)]
+      ├── function: array_agg [type=int[], outer=(1)]
+      │    └── variable: kv.k [type=int, outer=(1)]
+      └── function: array_agg [type=string[], outer=(4)]
+           └── variable: kv.s [type=string, outer=(4)]
 
 build
 SELECT array_agg(s) FROM t.kv WHERE s IS NULL
@@ -1609,6 +1699,52 @@ project
       └── variable: column7 [type=int, outer=(7)]
 
 build
+SELECT TO_HEX(XOR_AGG(a)), b, XOR_AGG(c) FROM xor_bytes GROUP BY b ORDER BY b
+----
+project
+ ├── columns: column6:6(string) b:2(int) column7:7(int)
+ ├── ordering: +2
+ ├── sort
+ │    ├── columns: xor_bytes.b:2(int) column5:5(bytes) column7:7(int)
+ │    ├── ordering: +2
+ │    └── group-by
+ │         ├── columns: xor_bytes.b:2(int) column5:5(bytes) column7:7(int)
+ │         ├── grouping columns: xor_bytes.b:2(int)
+ │         ├── project
+ │         │    ├── columns: xor_bytes.b:2(int) xor_bytes.a:1(bytes) xor_bytes.c:3(int)
+ │         │    ├── scan
+ │         │    │    └── columns: xor_bytes.a:1(bytes) xor_bytes.b:2(int) xor_bytes.c:3(int) xor_bytes.rowid:4(int!null)
+ │         │    └── projections [outer=(1-3)]
+ │         │         ├── variable: xor_bytes.b [type=int, outer=(2)]
+ │         │         ├── variable: xor_bytes.a [type=bytes, outer=(1)]
+ │         │         └── variable: xor_bytes.c [type=int, outer=(3)]
+ │         └── aggregations [outer=(1,3)]
+ │              ├── function: xor_agg [type=bytes, outer=(1)]
+ │              │    └── variable: xor_bytes.a [type=bytes, outer=(1)]
+ │              └── function: xor_agg [type=int, outer=(3)]
+ │                   └── variable: xor_bytes.c [type=int, outer=(3)]
+ └── projections [outer=(2,5,7)]
+      ├── function: to_hex [type=string, outer=(5)]
+      │    └── variable: column5 [type=bytes, outer=(5)]
+      ├── variable: xor_bytes.b [type=int, outer=(2)]
+      └── variable: column7 [type=int, outer=(7)]
+
+build
+SELECT XOR_AGG(i) FROM (VALUES (b'\x01'), (b'\x01\x01')) AS a(i)
+----
+group-by
+ ├── columns: column2:2(bytes)
+ ├── values
+ │    ├── columns: column1:1(bytes)
+ │    ├── tuple [type=tuple{bytes}]
+ │    │    └── const: '\x01' [type=bytes]
+ │    └── tuple [type=tuple{bytes}]
+ │         └── const: '\x0101' [type=bytes]
+ └── aggregations [outer=(1)]
+      └── function: xor_agg [type=bytes, outer=(1)]
+           └── variable: column1 [type=bytes, outer=(1)]
+
+build
 SELECT MAX(true), MIN(true)
 ----
 group-by
@@ -1625,6 +1761,66 @@ group-by
       │    └── variable: column1 [type=bool, outer=(1)]
       └── function: min [type=bool, outer=(3)]
            └── variable: column3 [type=bool, outer=(3)]
+
+build
+SELECT CONCAT_AGG(s) FROM (SELECT s FROM kv ORDER BY k)
+----
+group-by
+ ├── columns: column5:5(string)
+ ├── project
+ │    ├── columns: kv.s:4(string)
+ │    ├── project
+ │    │    ├── columns: kv.s:4(string) kv.k:1(int!null)
+ │    │    ├── scan
+ │    │    │    └── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string)
+ │    │    └── projections [outer=(1,4)]
+ │    │         ├── variable: kv.s [type=string, outer=(4)]
+ │    │         └── variable: kv.k [type=int, outer=(1)]
+ │    └── projections [outer=(4)]
+ │         └── variable: kv.s [type=string, outer=(4)]
+ └── aggregations [outer=(4)]
+      └── function: concat_agg [type=string, outer=(4)]
+           └── variable: kv.s [type=string, outer=(4)]
+
+build
+SELECT JSON_AGG(s) FROM (SELECT s FROM kv ORDER BY k)
+----
+group-by
+ ├── columns: column5:5(jsonb)
+ ├── project
+ │    ├── columns: kv.s:4(string)
+ │    ├── project
+ │    │    ├── columns: kv.s:4(string) kv.k:1(int!null)
+ │    │    ├── scan
+ │    │    │    └── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string)
+ │    │    └── projections [outer=(1,4)]
+ │    │         ├── variable: kv.s [type=string, outer=(4)]
+ │    │         └── variable: kv.k [type=int, outer=(1)]
+ │    └── projections [outer=(4)]
+ │         └── variable: kv.s [type=string, outer=(4)]
+ └── aggregations [outer=(4)]
+      └── function: json_agg [type=jsonb, outer=(4)]
+           └── variable: kv.s [type=string, outer=(4)]
+
+build
+SELECT JSONB_AGG(s) FROM (SELECT s FROM kv ORDER BY k)
+----
+group-by
+ ├── columns: column5:5(jsonb)
+ ├── project
+ │    ├── columns: kv.s:4(string)
+ │    ├── project
+ │    │    ├── columns: kv.s:4(string) kv.k:1(int!null)
+ │    │    ├── scan
+ │    │    │    └── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string)
+ │    │    └── projections [outer=(1,4)]
+ │    │         ├── variable: kv.s [type=string, outer=(4)]
+ │    │         └── variable: kv.k [type=int, outer=(1)]
+ │    └── projections [outer=(4)]
+ │         └── variable: kv.s [type=string, outer=(4)]
+ └── aggregations [outer=(4)]
+      └── function: jsonb_agg [type=jsonb, outer=(4)]
+           └── variable: kv.s [type=string, outer=(4)]
 
 exec-ddl
 CREATE TABLE t.ab (
@@ -1703,6 +1899,24 @@ project
       └── tuple [type=tuple{int, int}, outer=(1,2)]
            ├── variable: ab.b [type=int, outer=(2)]
            └── variable: ab.a [type=int, outer=(1)]
+
+# TODO(rytaft): This is a bug. This query is valid.
+build
+SELECT v, COUNT(k) FROM kv GROUP BY v ORDER BY COUNT(k)
+----
+error: column name "k" not found
+
+# TODO(rytaft): This is a bug. This query is valid.
+build
+SELECT v, COUNT(*) FROM kv GROUP BY v ORDER BY COUNT(*)
+----
+error: aggregate function is not allowed in this context
+
+# TODO(rytaft): This is a bug. This query is valid.
+build
+SELECT v, COUNT(1) FROM kv GROUP BY v ORDER BY COUNT(1)
+----
+error: aggregate function is not allowed in this context
 
 build
 SELECT (k+v)/(v+w) FROM t.kv GROUP BY k+v, v+w;

--- a/pkg/sql/opt/optbuilder/testdata/distinct
+++ b/pkg/sql/opt/optbuilder/testdata/distinct
@@ -72,6 +72,75 @@ project
       └── variable: xyz.y [type=int, outer=(2)]
 
 build
+SELECT DISTINCT y, z FROM xyz ORDER BY z
+----
+sort
+ ├── columns: y:2(int) z:3(float)
+ ├── ordering: +3
+ └── group-by
+      ├── columns: xyz.y:2(int) xyz.z:3(float)
+      ├── grouping columns: xyz.y:2(int) xyz.z:3(float)
+      ├── scan
+      │    └── columns: xyz.x:1(int!null) xyz.y:2(int) xyz.z:3(float)
+      └── aggregations
+
+build
+SELECT DISTINCT y, z FROM xyz ORDER BY y
+----
+sort
+ ├── columns: y:2(int) z:3(float)
+ ├── ordering: +2
+ └── group-by
+      ├── columns: xyz.y:2(int) xyz.z:3(float)
+      ├── grouping columns: xyz.y:2(int) xyz.z:3(float)
+      ├── scan
+      │    └── columns: xyz.x:1(int!null) xyz.y:2(int) xyz.z:3(float)
+      └── aggregations
+
+build
+SELECT DISTINCT y, z FROM xyz ORDER BY y, z
+----
+sort
+ ├── columns: y:2(int) z:3(float)
+ ├── ordering: +2,+3
+ └── group-by
+      ├── columns: xyz.y:2(int) xyz.z:3(float)
+      ├── grouping columns: xyz.y:2(int) xyz.z:3(float)
+      ├── scan
+      │    └── columns: xyz.x:1(int!null) xyz.y:2(int) xyz.z:3(float)
+      └── aggregations
+
+# TODO(rytaft): This is a bug. This query is valid.
+build
+SELECT DISTINCT y + z FROM xyz ORDER by (y + z)
+----
+error: unsupported binary operator: <int> + <float>
+
+# TODO(rytaft): This is a bug. This query is valid.
+build
+SELECT DISTINCT y + z FROM xyz ORDER BY y + z
+----
+error: unsupported binary operator: <int> + <float>
+
+# TODO(rytaft): This query causes an error in Postgres, but it is supported by
+# CockroachDB with the semantics:
+#   SELECT y AS w FROM t GROUP BY y ORDER BY min(z);
+# We may decide to support this later, but for now this should cause an error.
+# TODO(rytaft): Improve this error message to be more descriptive. E.g., the
+# Postgres error message is "for SELECT DISTINCT, ORDER BY expressions must
+# appear in select list".
+build
+SELECT DISTINCT y AS w FROM xyz ORDER by z
+----
+error: column name "z" not found
+
+# TODO(rytaft): This is a bug. This query is valid.
+build
+SELECT DISTINCT y AS w FROM xyz ORDER by y
+----
+error: column name "y" not found
+
+build
 SELECT DISTINCT (y,z) FROM t.xyz
 ----
 group-by
@@ -242,3 +311,41 @@ group-by
  │         │    └── variable: xyz.y [type=int, outer=(2)]
  │         └── const: 3 [type=int]
  └── aggregations
+
+exec-ddl
+CREATE TABLE abcd (
+  a INT,
+  b INT,
+  c INT,
+  d INT NOT NULL,
+  PRIMARY KEY (a, b, c),
+  UNIQUE INDEX (d, b)
+)
+----
+TABLE abcd
+ ├── a int not null
+ ├── b int not null
+ ├── c int not null
+ ├── d int not null
+ ├── INDEX primary
+ │    ├── a int not null
+ │    ├── b int not null
+ │    └── c int not null
+ └── INDEX secondary
+      ├── d int not null
+      ├── b int not null
+      ├── a int not null (storing)
+      └── c int not null (storing)
+
+build
+SELECT DISTINCT 1, d, b FROM abcd ORDER BY d, b
+----
+sort
+ ├── columns: column5:5(int) d:4(int!null) b:2(int!null)
+ ├── ordering: +4,+2
+ └── group-by
+      ├── columns: abcd.b:2(int!null) abcd.d:4(int!null) column5:5(int)
+      ├── grouping columns: abcd.b:2(int!null) abcd.d:4(int!null) column5:5(int)
+      ├── scan
+      │    └── columns: abcd.a:1(int!null) abcd.b:2(int!null) abcd.c:3(int!null) abcd.d:4(int!null)
+      └── aggregations

--- a/pkg/sql/opt/optbuilder/testdata/join
+++ b/pkg/sql/opt/optbuilder/testdata/join
@@ -84,19 +84,23 @@ project
       └── variable: onecolumn.x [type=int, outer=(3)]
 
 build
-SELECT * FROM onecolumn AS a JOIN onecolumn as b USING(x)
+SELECT * FROM onecolumn AS a JOIN onecolumn as b USING(x) ORDER BY x
 ----
 project
  ├── columns: x:1(int)
- ├── inner-join
+ ├── ordering: +1
+ ├── sort
  │    ├── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null) onecolumn.x:3(int) onecolumn.rowid:4(int!null)
- │    ├── scan
- │    │    └── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null)
- │    ├── scan
- │    │    └── columns: onecolumn.x:3(int) onecolumn.rowid:4(int!null)
- │    └── eq [type=bool, outer=(1,3)]
- │         ├── variable: onecolumn.x [type=int, outer=(1)]
- │         └── variable: onecolumn.x [type=int, outer=(3)]
+ │    ├── ordering: +1
+ │    └── inner-join
+ │         ├── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null) onecolumn.x:3(int) onecolumn.rowid:4(int!null)
+ │         ├── scan
+ │         │    └── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null)
+ │         ├── scan
+ │         │    └── columns: onecolumn.x:3(int) onecolumn.rowid:4(int!null)
+ │         └── eq [type=bool, outer=(1,3)]
+ │              ├── variable: onecolumn.x [type=int, outer=(1)]
+ │              └── variable: onecolumn.x [type=int, outer=(3)]
  └── projections [outer=(1)]
       └── variable: onecolumn.x [type=int, outer=(1)]
 
@@ -136,21 +140,48 @@ project
       └── variable: onecolumn.x [type=int, outer=(3)]
 
 build
-SELECT * FROM onecolumn AS a LEFT OUTER JOIN onecolumn AS b USING(x)
+SELECT * FROM onecolumn AS a LEFT OUTER JOIN onecolumn AS b USING(x) ORDER BY x
 ----
 project
  ├── columns: x:1(int)
- ├── left-join
+ ├── ordering: +1
+ ├── sort
  │    ├── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null) onecolumn.x:3(int) onecolumn.rowid:4(int)
- │    ├── scan
- │    │    └── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null)
- │    ├── scan
- │    │    └── columns: onecolumn.x:3(int) onecolumn.rowid:4(int!null)
- │    └── eq [type=bool, outer=(1,3)]
- │         ├── variable: onecolumn.x [type=int, outer=(1)]
- │         └── variable: onecolumn.x [type=int, outer=(3)]
+ │    ├── ordering: +1
+ │    └── left-join
+ │         ├── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null) onecolumn.x:3(int) onecolumn.rowid:4(int)
+ │         ├── scan
+ │         │    └── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null)
+ │         ├── scan
+ │         │    └── columns: onecolumn.x:3(int) onecolumn.rowid:4(int!null)
+ │         └── eq [type=bool, outer=(1,3)]
+ │              ├── variable: onecolumn.x [type=int, outer=(1)]
+ │              └── variable: onecolumn.x [type=int, outer=(3)]
  └── projections [outer=(1)]
       └── variable: onecolumn.x [type=int, outer=(1)]
+
+# Check that ORDER BY chokes on ambiguity if no table less columns
+# were introduced by USING. (#12239)
+# TODO(rytaft): This is a bug. This query is invalid.
+build
+SELECT * FROM onecolumn AS a, onecolumn AS b ORDER BY x
+----
+project
+ ├── columns: x:1(int) x:3(int)
+ ├── ordering: +1
+ ├── sort
+ │    ├── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null) onecolumn.x:3(int) onecolumn.rowid:4(int!null)
+ │    ├── ordering: +1
+ │    └── inner-join
+ │         ├── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null) onecolumn.x:3(int) onecolumn.rowid:4(int!null)
+ │         ├── scan
+ │         │    └── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null)
+ │         ├── scan
+ │         │    └── columns: onecolumn.x:3(int) onecolumn.rowid:4(int!null)
+ │         └── true [type=bool]
+ └── projections [outer=(1,3)]
+      ├── variable: onecolumn.x [type=int, outer=(1)]
+      └── variable: onecolumn.x [type=int, outer=(3)]
 
 build
 SELECT * FROM onecolumn AS a NATURAL LEFT OUTER JOIN onecolumn AS b
@@ -188,19 +219,23 @@ project
       └── variable: onecolumn.x [type=int, outer=(3)]
 
 build
-SELECT * FROM onecolumn AS a RIGHT OUTER JOIN onecolumn AS b USING(x)
+SELECT * FROM onecolumn AS a RIGHT OUTER JOIN onecolumn AS b USING(x) ORDER BY x
 ----
 project
  ├── columns: x:3(int)
- ├── right-join
+ ├── ordering: +3
+ ├── sort
  │    ├── columns: onecolumn.x:1(int) onecolumn.rowid:2(int) onecolumn.x:3(int) onecolumn.rowid:4(int!null)
- │    ├── scan
- │    │    └── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null)
- │    ├── scan
- │    │    └── columns: onecolumn.x:3(int) onecolumn.rowid:4(int!null)
- │    └── eq [type=bool, outer=(1,3)]
- │         ├── variable: onecolumn.x [type=int, outer=(1)]
- │         └── variable: onecolumn.x [type=int, outer=(3)]
+ │    ├── ordering: +3
+ │    └── right-join
+ │         ├── columns: onecolumn.x:1(int) onecolumn.rowid:2(int) onecolumn.x:3(int) onecolumn.rowid:4(int!null)
+ │         ├── scan
+ │         │    └── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null)
+ │         ├── scan
+ │         │    └── columns: onecolumn.x:3(int) onecolumn.rowid:4(int!null)
+ │         └── eq [type=bool, outer=(1,3)]
+ │              ├── variable: onecolumn.x [type=int, outer=(1)]
+ │              └── variable: onecolumn.x [type=int, outer=(3)]
  └── projections [outer=(3)]
       └── variable: onecolumn.x [type=int, outer=(3)]
 
@@ -256,107 +291,130 @@ TABLE othercolumn
       └── rowid int not null (hidden)
 
 build
-SELECT * FROM onecolumn AS a FULL OUTER JOIN othercolumn AS b ON a.x = b.x
+SELECT * FROM onecolumn AS a FULL OUTER JOIN othercolumn AS b ON a.x = b.x ORDER BY a.x,b.x
 ----
 project
  ├── columns: x:1(int) x:3(int)
- ├── full-join
+ ├── ordering: +1,+3
+ ├── sort
  │    ├── columns: onecolumn.x:1(int) onecolumn.rowid:2(int) othercolumn.x:3(int) othercolumn.rowid:4(int)
- │    ├── scan
- │    │    └── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null)
- │    ├── scan
- │    │    └── columns: othercolumn.x:3(int) othercolumn.rowid:4(int!null)
- │    └── eq [type=bool, outer=(1,3)]
- │         ├── variable: onecolumn.x [type=int, outer=(1)]
- │         └── variable: othercolumn.x [type=int, outer=(3)]
+ │    ├── ordering: +1,+3
+ │    └── full-join
+ │         ├── columns: onecolumn.x:1(int) onecolumn.rowid:2(int) othercolumn.x:3(int) othercolumn.rowid:4(int)
+ │         ├── scan
+ │         │    └── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null)
+ │         ├── scan
+ │         │    └── columns: othercolumn.x:3(int) othercolumn.rowid:4(int!null)
+ │         └── eq [type=bool, outer=(1,3)]
+ │              ├── variable: onecolumn.x [type=int, outer=(1)]
+ │              └── variable: othercolumn.x [type=int, outer=(3)]
  └── projections [outer=(1,3)]
       ├── variable: onecolumn.x [type=int, outer=(1)]
       └── variable: othercolumn.x [type=int, outer=(3)]
 
 build
-SELECT * FROM onecolumn AS a FULL OUTER JOIN othercolumn AS b USING(x)
+SELECT * FROM onecolumn AS a FULL OUTER JOIN othercolumn AS b USING(x) ORDER BY x
 ----
 project
  ├── columns: x:5(int)
- ├── project
- │    ├── columns: x:5(int) onecolumn.x:1(int) onecolumn.rowid:2(int) othercolumn.x:3(int) othercolumn.rowid:4(int)
- │    ├── full-join
- │    │    ├── columns: onecolumn.x:1(int) onecolumn.rowid:2(int) othercolumn.x:3(int) othercolumn.rowid:4(int)
- │    │    ├── scan
- │    │    │    └── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null)
- │    │    ├── scan
- │    │    │    └── columns: othercolumn.x:3(int) othercolumn.rowid:4(int!null)
- │    │    └── eq [type=bool, outer=(1,3)]
- │    │         ├── variable: onecolumn.x [type=int, outer=(1)]
- │    │         └── variable: othercolumn.x [type=int, outer=(3)]
- │    └── projections [outer=(1-4)]
- │         ├── coalesce [type=int, outer=(1,3)]
- │         │    ├── variable: onecolumn.x [type=int, outer=(1)]
- │         │    └── variable: othercolumn.x [type=int, outer=(3)]
- │         ├── variable: onecolumn.x [type=int, outer=(1)]
- │         ├── variable: onecolumn.rowid [type=int, outer=(2)]
- │         ├── variable: othercolumn.x [type=int, outer=(3)]
- │         └── variable: othercolumn.rowid [type=int, outer=(4)]
+ ├── ordering: +5
+ ├── sort
+ │    ├── columns: onecolumn.x:1(int) onecolumn.rowid:2(int) othercolumn.x:3(int) othercolumn.rowid:4(int) x:5(int)
+ │    ├── ordering: +5
+ │    └── project
+ │         ├── columns: x:5(int) onecolumn.x:1(int) onecolumn.rowid:2(int) othercolumn.x:3(int) othercolumn.rowid:4(int)
+ │         ├── full-join
+ │         │    ├── columns: onecolumn.x:1(int) onecolumn.rowid:2(int) othercolumn.x:3(int) othercolumn.rowid:4(int)
+ │         │    ├── scan
+ │         │    │    └── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null)
+ │         │    ├── scan
+ │         │    │    └── columns: othercolumn.x:3(int) othercolumn.rowid:4(int!null)
+ │         │    └── eq [type=bool, outer=(1,3)]
+ │         │         ├── variable: onecolumn.x [type=int, outer=(1)]
+ │         │         └── variable: othercolumn.x [type=int, outer=(3)]
+ │         └── projections [outer=(1-4)]
+ │              ├── coalesce [type=int, outer=(1,3)]
+ │              │    ├── variable: onecolumn.x [type=int, outer=(1)]
+ │              │    └── variable: othercolumn.x [type=int, outer=(3)]
+ │              ├── variable: onecolumn.x [type=int, outer=(1)]
+ │              ├── variable: onecolumn.rowid [type=int, outer=(2)]
+ │              ├── variable: othercolumn.x [type=int, outer=(3)]
+ │              └── variable: othercolumn.rowid [type=int, outer=(4)]
  └── projections [outer=(5)]
       └── variable: x [type=int, outer=(5)]
 
 # Check that the source columns can be selected separately from the
 # USING column (#12033).
 build
-SELECT x AS s, a.x, b.x FROM onecolumn AS a FULL OUTER JOIN othercolumn AS b USING(x)
+SELECT x AS s, a.x, b.x FROM onecolumn AS a FULL OUTER JOIN othercolumn AS b USING(x) ORDER BY s
 ----
 project
  ├── columns: s:5(int) x:1(int) x:3(int)
- ├── project
- │    ├── columns: x:5(int) onecolumn.x:1(int) onecolumn.rowid:2(int) othercolumn.x:3(int) othercolumn.rowid:4(int)
- │    ├── full-join
- │    │    ├── columns: onecolumn.x:1(int) onecolumn.rowid:2(int) othercolumn.x:3(int) othercolumn.rowid:4(int)
- │    │    ├── scan
- │    │    │    └── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null)
- │    │    ├── scan
- │    │    │    └── columns: othercolumn.x:3(int) othercolumn.rowid:4(int!null)
- │    │    └── eq [type=bool, outer=(1,3)]
- │    │         ├── variable: onecolumn.x [type=int, outer=(1)]
- │    │         └── variable: othercolumn.x [type=int, outer=(3)]
- │    └── projections [outer=(1-4)]
- │         ├── coalesce [type=int, outer=(1,3)]
- │         │    ├── variable: onecolumn.x [type=int, outer=(1)]
- │         │    └── variable: othercolumn.x [type=int, outer=(3)]
- │         ├── variable: onecolumn.x [type=int, outer=(1)]
- │         ├── variable: onecolumn.rowid [type=int, outer=(2)]
- │         ├── variable: othercolumn.x [type=int, outer=(3)]
- │         └── variable: othercolumn.rowid [type=int, outer=(4)]
+ ├── ordering: +5
+ ├── sort
+ │    ├── columns: onecolumn.x:1(int) onecolumn.rowid:2(int) othercolumn.x:3(int) othercolumn.rowid:4(int) x:5(int)
+ │    ├── ordering: +5
+ │    └── project
+ │         ├── columns: x:5(int) onecolumn.x:1(int) onecolumn.rowid:2(int) othercolumn.x:3(int) othercolumn.rowid:4(int)
+ │         ├── full-join
+ │         │    ├── columns: onecolumn.x:1(int) onecolumn.rowid:2(int) othercolumn.x:3(int) othercolumn.rowid:4(int)
+ │         │    ├── scan
+ │         │    │    └── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null)
+ │         │    ├── scan
+ │         │    │    └── columns: othercolumn.x:3(int) othercolumn.rowid:4(int!null)
+ │         │    └── eq [type=bool, outer=(1,3)]
+ │         │         ├── variable: onecolumn.x [type=int, outer=(1)]
+ │         │         └── variable: othercolumn.x [type=int, outer=(3)]
+ │         └── projections [outer=(1-4)]
+ │              ├── coalesce [type=int, outer=(1,3)]
+ │              │    ├── variable: onecolumn.x [type=int, outer=(1)]
+ │              │    └── variable: othercolumn.x [type=int, outer=(3)]
+ │              ├── variable: onecolumn.x [type=int, outer=(1)]
+ │              ├── variable: onecolumn.rowid [type=int, outer=(2)]
+ │              ├── variable: othercolumn.x [type=int, outer=(3)]
+ │              └── variable: othercolumn.rowid [type=int, outer=(4)]
  └── projections [outer=(1,3,5)]
       ├── variable: x [type=int, outer=(5)]
       ├── variable: onecolumn.x [type=int, outer=(1)]
       └── variable: othercolumn.x [type=int, outer=(3)]
 
 build
-SELECT * FROM onecolumn AS a NATURAL FULL OUTER JOIN othercolumn AS b
+SELECT * FROM onecolumn AS a NATURAL FULL OUTER JOIN othercolumn AS b ORDER BY x
 ----
 project
  ├── columns: x:5(int)
- ├── project
- │    ├── columns: x:5(int) onecolumn.x:1(int) onecolumn.rowid:2(int) othercolumn.x:3(int) othercolumn.rowid:4(int)
- │    ├── full-join
- │    │    ├── columns: onecolumn.x:1(int) onecolumn.rowid:2(int) othercolumn.x:3(int) othercolumn.rowid:4(int)
- │    │    ├── scan
- │    │    │    └── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null)
- │    │    ├── scan
- │    │    │    └── columns: othercolumn.x:3(int) othercolumn.rowid:4(int!null)
- │    │    └── eq [type=bool, outer=(1,3)]
- │    │         ├── variable: onecolumn.x [type=int, outer=(1)]
- │    │         └── variable: othercolumn.x [type=int, outer=(3)]
- │    └── projections [outer=(1-4)]
- │         ├── coalesce [type=int, outer=(1,3)]
- │         │    ├── variable: onecolumn.x [type=int, outer=(1)]
- │         │    └── variable: othercolumn.x [type=int, outer=(3)]
- │         ├── variable: onecolumn.x [type=int, outer=(1)]
- │         ├── variable: onecolumn.rowid [type=int, outer=(2)]
- │         ├── variable: othercolumn.x [type=int, outer=(3)]
- │         └── variable: othercolumn.rowid [type=int, outer=(4)]
+ ├── ordering: +5
+ ├── sort
+ │    ├── columns: onecolumn.x:1(int) onecolumn.rowid:2(int) othercolumn.x:3(int) othercolumn.rowid:4(int) x:5(int)
+ │    ├── ordering: +5
+ │    └── project
+ │         ├── columns: x:5(int) onecolumn.x:1(int) onecolumn.rowid:2(int) othercolumn.x:3(int) othercolumn.rowid:4(int)
+ │         ├── full-join
+ │         │    ├── columns: onecolumn.x:1(int) onecolumn.rowid:2(int) othercolumn.x:3(int) othercolumn.rowid:4(int)
+ │         │    ├── scan
+ │         │    │    └── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null)
+ │         │    ├── scan
+ │         │    │    └── columns: othercolumn.x:3(int) othercolumn.rowid:4(int!null)
+ │         │    └── eq [type=bool, outer=(1,3)]
+ │         │         ├── variable: onecolumn.x [type=int, outer=(1)]
+ │         │         └── variable: othercolumn.x [type=int, outer=(3)]
+ │         └── projections [outer=(1-4)]
+ │              ├── coalesce [type=int, outer=(1,3)]
+ │              │    ├── variable: onecolumn.x [type=int, outer=(1)]
+ │              │    └── variable: othercolumn.x [type=int, outer=(3)]
+ │              ├── variable: onecolumn.x [type=int, outer=(1)]
+ │              ├── variable: onecolumn.rowid [type=int, outer=(2)]
+ │              ├── variable: othercolumn.x [type=int, outer=(3)]
+ │              └── variable: othercolumn.rowid [type=int, outer=(4)]
  └── projections [outer=(5)]
       └── variable: x [type=int, outer=(5)]
+
+# TODO(rytaft): LIMIT not yet supported.
+# Check that a limit on the JOIN's result do not cause rows from the
+# JOIN operands to become invisible to the JOIN.
+#build
+#SELECT * FROM (SELECT x FROM onecolumn ORDER BY x DESC) NATURAL JOIN (VALUES (42)) AS v(x) LIMIT 1
+#----
 
 exec-ddl
 CREATE TABLE empty (x INT)
@@ -470,37 +528,45 @@ project
       └── variable: empty.x [type=int, outer=(1)]
 
 build
-SELECT * FROM onecolumn AS a(x) LEFT OUTER JOIN empty AS b(y) ON a.x = b.y
+SELECT * FROM onecolumn AS a(x) LEFT OUTER JOIN empty AS b(y) ON a.x = b.y ORDER BY a.x
 ----
 project
  ├── columns: x:1(int) y:3(int)
- ├── left-join
+ ├── ordering: +1
+ ├── sort
  │    ├── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null) empty.x:3(int) empty.rowid:4(int)
- │    ├── scan
- │    │    └── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null)
- │    ├── scan
- │    │    └── columns: empty.x:3(int) empty.rowid:4(int!null)
- │    └── eq [type=bool, outer=(1,3)]
- │         ├── variable: onecolumn.x [type=int, outer=(1)]
- │         └── variable: empty.x [type=int, outer=(3)]
+ │    ├── ordering: +1
+ │    └── left-join
+ │         ├── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null) empty.x:3(int) empty.rowid:4(int)
+ │         ├── scan
+ │         │    └── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null)
+ │         ├── scan
+ │         │    └── columns: empty.x:3(int) empty.rowid:4(int!null)
+ │         └── eq [type=bool, outer=(1,3)]
+ │              ├── variable: onecolumn.x [type=int, outer=(1)]
+ │              └── variable: empty.x [type=int, outer=(3)]
  └── projections [outer=(1,3)]
       ├── variable: onecolumn.x [type=int, outer=(1)]
       └── variable: empty.x [type=int, outer=(3)]
 
 build
-SELECT * FROM onecolumn AS a LEFT OUTER JOIN empty AS b USING(x)
+SELECT * FROM onecolumn AS a LEFT OUTER JOIN empty AS b USING(x) ORDER BY x
 ----
 project
  ├── columns: x:1(int)
- ├── left-join
+ ├── ordering: +1
+ ├── sort
  │    ├── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null) empty.x:3(int) empty.rowid:4(int)
- │    ├── scan
- │    │    └── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null)
- │    ├── scan
- │    │    └── columns: empty.x:3(int) empty.rowid:4(int!null)
- │    └── eq [type=bool, outer=(1,3)]
- │         ├── variable: onecolumn.x [type=int, outer=(1)]
- │         └── variable: empty.x [type=int, outer=(3)]
+ │    ├── ordering: +1
+ │    └── left-join
+ │         ├── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null) empty.x:3(int) empty.rowid:4(int)
+ │         ├── scan
+ │         │    └── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null)
+ │         ├── scan
+ │         │    └── columns: empty.x:3(int) empty.rowid:4(int!null)
+ │         └── eq [type=bool, outer=(1,3)]
+ │              ├── variable: onecolumn.x [type=int, outer=(1)]
+ │              └── variable: empty.x [type=int, outer=(3)]
  └── projections [outer=(1)]
       └── variable: onecolumn.x [type=int, outer=(1)]
 
@@ -575,92 +641,108 @@ project
       └── variable: empty.x [type=int, outer=(3)]
 
 build
-SELECT * FROM empty AS a(x) FULL OUTER JOIN onecolumn AS b(y) ON a.x = b.y
+SELECT * FROM empty AS a(x) FULL OUTER JOIN onecolumn AS b(y) ON a.x = b.y ORDER BY b.y
 ----
 project
  ├── columns: x:1(int) y:3(int)
- ├── full-join
+ ├── ordering: +3
+ ├── sort
  │    ├── columns: empty.x:1(int) empty.rowid:2(int) onecolumn.x:3(int) onecolumn.rowid:4(int)
- │    ├── scan
- │    │    └── columns: empty.x:1(int) empty.rowid:2(int!null)
- │    ├── scan
- │    │    └── columns: onecolumn.x:3(int) onecolumn.rowid:4(int!null)
- │    └── eq [type=bool, outer=(1,3)]
- │         ├── variable: empty.x [type=int, outer=(1)]
- │         └── variable: onecolumn.x [type=int, outer=(3)]
+ │    ├── ordering: +3
+ │    └── full-join
+ │         ├── columns: empty.x:1(int) empty.rowid:2(int) onecolumn.x:3(int) onecolumn.rowid:4(int)
+ │         ├── scan
+ │         │    └── columns: empty.x:1(int) empty.rowid:2(int!null)
+ │         ├── scan
+ │         │    └── columns: onecolumn.x:3(int) onecolumn.rowid:4(int!null)
+ │         └── eq [type=bool, outer=(1,3)]
+ │              ├── variable: empty.x [type=int, outer=(1)]
+ │              └── variable: onecolumn.x [type=int, outer=(3)]
  └── projections [outer=(1,3)]
       ├── variable: empty.x [type=int, outer=(1)]
       └── variable: onecolumn.x [type=int, outer=(3)]
 
 build
-SELECT * FROM empty AS a FULL OUTER JOIN onecolumn AS b USING(x)
+SELECT * FROM empty AS a FULL OUTER JOIN onecolumn AS b USING(x) ORDER BY x
 ----
 project
  ├── columns: x:5(int)
- ├── project
- │    ├── columns: x:5(int) empty.x:1(int) empty.rowid:2(int) onecolumn.x:3(int) onecolumn.rowid:4(int)
- │    ├── full-join
- │    │    ├── columns: empty.x:1(int) empty.rowid:2(int) onecolumn.x:3(int) onecolumn.rowid:4(int)
- │    │    ├── scan
- │    │    │    └── columns: empty.x:1(int) empty.rowid:2(int!null)
- │    │    ├── scan
- │    │    │    └── columns: onecolumn.x:3(int) onecolumn.rowid:4(int!null)
- │    │    └── eq [type=bool, outer=(1,3)]
- │    │         ├── variable: empty.x [type=int, outer=(1)]
- │    │         └── variable: onecolumn.x [type=int, outer=(3)]
- │    └── projections [outer=(1-4)]
- │         ├── coalesce [type=int, outer=(1,3)]
- │         │    ├── variable: empty.x [type=int, outer=(1)]
- │         │    └── variable: onecolumn.x [type=int, outer=(3)]
- │         ├── variable: empty.x [type=int, outer=(1)]
- │         ├── variable: empty.rowid [type=int, outer=(2)]
- │         ├── variable: onecolumn.x [type=int, outer=(3)]
- │         └── variable: onecolumn.rowid [type=int, outer=(4)]
+ ├── ordering: +5
+ ├── sort
+ │    ├── columns: empty.x:1(int) empty.rowid:2(int) onecolumn.x:3(int) onecolumn.rowid:4(int) x:5(int)
+ │    ├── ordering: +5
+ │    └── project
+ │         ├── columns: x:5(int) empty.x:1(int) empty.rowid:2(int) onecolumn.x:3(int) onecolumn.rowid:4(int)
+ │         ├── full-join
+ │         │    ├── columns: empty.x:1(int) empty.rowid:2(int) onecolumn.x:3(int) onecolumn.rowid:4(int)
+ │         │    ├── scan
+ │         │    │    └── columns: empty.x:1(int) empty.rowid:2(int!null)
+ │         │    ├── scan
+ │         │    │    └── columns: onecolumn.x:3(int) onecolumn.rowid:4(int!null)
+ │         │    └── eq [type=bool, outer=(1,3)]
+ │         │         ├── variable: empty.x [type=int, outer=(1)]
+ │         │         └── variable: onecolumn.x [type=int, outer=(3)]
+ │         └── projections [outer=(1-4)]
+ │              ├── coalesce [type=int, outer=(1,3)]
+ │              │    ├── variable: empty.x [type=int, outer=(1)]
+ │              │    └── variable: onecolumn.x [type=int, outer=(3)]
+ │              ├── variable: empty.x [type=int, outer=(1)]
+ │              ├── variable: empty.rowid [type=int, outer=(2)]
+ │              ├── variable: onecolumn.x [type=int, outer=(3)]
+ │              └── variable: onecolumn.rowid [type=int, outer=(4)]
  └── projections [outer=(5)]
       └── variable: x [type=int, outer=(5)]
 
 build
-SELECT * FROM onecolumn AS a(x) FULL OUTER JOIN empty AS b(y) ON a.x = b.y
+SELECT * FROM onecolumn AS a(x) FULL OUTER JOIN empty AS b(y) ON a.x = b.y ORDER BY a.x
 ----
 project
  ├── columns: x:1(int) y:3(int)
- ├── full-join
+ ├── ordering: +1
+ ├── sort
  │    ├── columns: onecolumn.x:1(int) onecolumn.rowid:2(int) empty.x:3(int) empty.rowid:4(int)
- │    ├── scan
- │    │    └── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null)
- │    ├── scan
- │    │    └── columns: empty.x:3(int) empty.rowid:4(int!null)
- │    └── eq [type=bool, outer=(1,3)]
- │         ├── variable: onecolumn.x [type=int, outer=(1)]
- │         └── variable: empty.x [type=int, outer=(3)]
+ │    ├── ordering: +1
+ │    └── full-join
+ │         ├── columns: onecolumn.x:1(int) onecolumn.rowid:2(int) empty.x:3(int) empty.rowid:4(int)
+ │         ├── scan
+ │         │    └── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null)
+ │         ├── scan
+ │         │    └── columns: empty.x:3(int) empty.rowid:4(int!null)
+ │         └── eq [type=bool, outer=(1,3)]
+ │              ├── variable: onecolumn.x [type=int, outer=(1)]
+ │              └── variable: empty.x [type=int, outer=(3)]
  └── projections [outer=(1,3)]
       ├── variable: onecolumn.x [type=int, outer=(1)]
       └── variable: empty.x [type=int, outer=(3)]
 
 build
-SELECT * FROM onecolumn AS a FULL OUTER JOIN empty AS b USING(x)
+SELECT * FROM onecolumn AS a FULL OUTER JOIN empty AS b USING(x) ORDER BY x
 ----
 project
  ├── columns: x:5(int)
- ├── project
- │    ├── columns: x:5(int) onecolumn.x:1(int) onecolumn.rowid:2(int) empty.x:3(int) empty.rowid:4(int)
- │    ├── full-join
- │    │    ├── columns: onecolumn.x:1(int) onecolumn.rowid:2(int) empty.x:3(int) empty.rowid:4(int)
- │    │    ├── scan
- │    │    │    └── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null)
- │    │    ├── scan
- │    │    │    └── columns: empty.x:3(int) empty.rowid:4(int!null)
- │    │    └── eq [type=bool, outer=(1,3)]
- │    │         ├── variable: onecolumn.x [type=int, outer=(1)]
- │    │         └── variable: empty.x [type=int, outer=(3)]
- │    └── projections [outer=(1-4)]
- │         ├── coalesce [type=int, outer=(1,3)]
- │         │    ├── variable: onecolumn.x [type=int, outer=(1)]
- │         │    └── variable: empty.x [type=int, outer=(3)]
- │         ├── variable: onecolumn.x [type=int, outer=(1)]
- │         ├── variable: onecolumn.rowid [type=int, outer=(2)]
- │         ├── variable: empty.x [type=int, outer=(3)]
- │         └── variable: empty.rowid [type=int, outer=(4)]
+ ├── ordering: +5
+ ├── sort
+ │    ├── columns: onecolumn.x:1(int) onecolumn.rowid:2(int) empty.x:3(int) empty.rowid:4(int) x:5(int)
+ │    ├── ordering: +5
+ │    └── project
+ │         ├── columns: x:5(int) onecolumn.x:1(int) onecolumn.rowid:2(int) empty.x:3(int) empty.rowid:4(int)
+ │         ├── full-join
+ │         │    ├── columns: onecolumn.x:1(int) onecolumn.rowid:2(int) empty.x:3(int) empty.rowid:4(int)
+ │         │    ├── scan
+ │         │    │    └── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null)
+ │         │    ├── scan
+ │         │    │    └── columns: empty.x:3(int) empty.rowid:4(int!null)
+ │         │    └── eq [type=bool, outer=(1,3)]
+ │         │         ├── variable: onecolumn.x [type=int, outer=(1)]
+ │         │         └── variable: empty.x [type=int, outer=(3)]
+ │         └── projections [outer=(1-4)]
+ │              ├── coalesce [type=int, outer=(1,3)]
+ │              │    ├── variable: onecolumn.x [type=int, outer=(1)]
+ │              │    └── variable: empty.x [type=int, outer=(3)]
+ │              ├── variable: onecolumn.x [type=int, outer=(1)]
+ │              ├── variable: onecolumn.rowid [type=int, outer=(2)]
+ │              ├── variable: empty.x [type=int, outer=(3)]
+ │              └── variable: empty.rowid [type=int, outer=(4)]
  └── projections [outer=(5)]
       └── variable: x [type=int, outer=(5)]
 
@@ -970,38 +1052,46 @@ project
       └── variable: b.b [type=bool, outer=(4)]
 
 build
-SELECT * FROM a RIGHT OUTER JOIN b ON a.i = b.i
+SELECT * FROM a RIGHT OUTER JOIN b ON a.i = b.i ORDER BY b.i, b.b
 ----
 project
  ├── columns: i:1(int) i:3(int) b:4(bool)
- ├── right-join
+ ├── ordering: +3,+4
+ ├── sort
  │    ├── columns: a.i:1(int) a.rowid:2(int) b.i:3(int) b.b:4(bool) b.rowid:5(int!null)
- │    ├── scan
- │    │    └── columns: a.i:1(int) a.rowid:2(int!null)
- │    ├── scan
- │    │    └── columns: b.i:3(int) b.b:4(bool) b.rowid:5(int!null)
- │    └── eq [type=bool, outer=(1,3)]
- │         ├── variable: a.i [type=int, outer=(1)]
- │         └── variable: b.i [type=int, outer=(3)]
+ │    ├── ordering: +3,+4
+ │    └── right-join
+ │         ├── columns: a.i:1(int) a.rowid:2(int) b.i:3(int) b.b:4(bool) b.rowid:5(int!null)
+ │         ├── scan
+ │         │    └── columns: a.i:1(int) a.rowid:2(int!null)
+ │         ├── scan
+ │         │    └── columns: b.i:3(int) b.b:4(bool) b.rowid:5(int!null)
+ │         └── eq [type=bool, outer=(1,3)]
+ │              ├── variable: a.i [type=int, outer=(1)]
+ │              └── variable: b.i [type=int, outer=(3)]
  └── projections [outer=(1,3,4)]
       ├── variable: a.i [type=int, outer=(1)]
       ├── variable: b.i [type=int, outer=(3)]
       └── variable: b.b [type=bool, outer=(4)]
 
 build
-SELECT * FROM a FULL OUTER JOIN b ON a.i = b.i
+SELECT * FROM a FULL OUTER JOIN b ON a.i = b.i ORDER BY b.i, b.b
 ----
 project
  ├── columns: i:1(int) i:3(int) b:4(bool)
- ├── full-join
+ ├── ordering: +3,+4
+ ├── sort
  │    ├── columns: a.i:1(int) a.rowid:2(int) b.i:3(int) b.b:4(bool) b.rowid:5(int)
- │    ├── scan
- │    │    └── columns: a.i:1(int) a.rowid:2(int!null)
- │    ├── scan
- │    │    └── columns: b.i:3(int) b.b:4(bool) b.rowid:5(int!null)
- │    └── eq [type=bool, outer=(1,3)]
- │         ├── variable: a.i [type=int, outer=(1)]
- │         └── variable: b.i [type=int, outer=(3)]
+ │    ├── ordering: +3,+4
+ │    └── full-join
+ │         ├── columns: a.i:1(int) a.rowid:2(int) b.i:3(int) b.b:4(bool) b.rowid:5(int)
+ │         ├── scan
+ │         │    └── columns: a.i:1(int) a.rowid:2(int!null)
+ │         ├── scan
+ │         │    └── columns: b.i:3(int) b.b:4(bool) b.rowid:5(int!null)
+ │         └── eq [type=bool, outer=(1,3)]
+ │              ├── variable: a.i [type=int, outer=(1)]
+ │              └── variable: b.i [type=int, outer=(3)]
  └── projections [outer=(1,3,4)]
       ├── variable: a.i [type=int, outer=(1)]
       ├── variable: b.i [type=int, outer=(3)]
@@ -1009,23 +1099,27 @@ project
 
 # Full outer join with filter predicate
 build
-SELECT * FROM a FULL OUTER JOIN b ON (a.i = b.i and a.i>2)
+SELECT * FROM a FULL OUTER JOIN b ON (a.i = b.i and a.i>2) ORDER BY a.i, b.i
 ----
 project
  ├── columns: i:1(int) i:3(int) b:4(bool)
- ├── full-join
+ ├── ordering: +1,+3
+ ├── sort
  │    ├── columns: a.i:1(int) a.rowid:2(int) b.i:3(int) b.b:4(bool) b.rowid:5(int)
- │    ├── scan
- │    │    └── columns: a.i:1(int) a.rowid:2(int!null)
- │    ├── scan
- │    │    └── columns: b.i:3(int) b.b:4(bool) b.rowid:5(int!null)
- │    └── and [type=bool, outer=(1,3)]
- │         ├── eq [type=bool, outer=(1,3)]
- │         │    ├── variable: a.i [type=int, outer=(1)]
- │         │    └── variable: b.i [type=int, outer=(3)]
- │         └── gt [type=bool, outer=(1)]
- │              ├── variable: a.i [type=int, outer=(1)]
- │              └── const: 2 [type=int]
+ │    ├── ordering: +1,+3
+ │    └── full-join
+ │         ├── columns: a.i:1(int) a.rowid:2(int) b.i:3(int) b.b:4(bool) b.rowid:5(int)
+ │         ├── scan
+ │         │    └── columns: a.i:1(int) a.rowid:2(int!null)
+ │         ├── scan
+ │         │    └── columns: b.i:3(int) b.b:4(bool) b.rowid:5(int!null)
+ │         └── and [type=bool, outer=(1,3)]
+ │              ├── eq [type=bool, outer=(1,3)]
+ │              │    ├── variable: a.i [type=int, outer=(1)]
+ │              │    └── variable: b.i [type=int, outer=(3)]
+ │              └── gt [type=bool, outer=(1)]
+ │                   ├── variable: a.i [type=int, outer=(1)]
+ │                   └── const: 2 [type=int]
  └── projections [outer=(1,3,4)]
       ├── variable: a.i [type=int, outer=(1)]
       ├── variable: b.i [type=int, outer=(3)]
@@ -1033,35 +1127,39 @@ project
 
 # Check column orders and names.
 build
-SELECT * FROM (onecolumn CROSS JOIN twocolumn JOIN onecolumn AS a(b) ON a.b=twocolumn.x JOIN twocolumn AS c(d,e) ON a.b=c.d AND c.d=onecolumn.x)
+SELECT * FROM (onecolumn CROSS JOIN twocolumn JOIN onecolumn AS a(b) ON a.b=twocolumn.x JOIN twocolumn AS c(d,e) ON a.b=c.d AND c.d=onecolumn.x) ORDER BY 1
 ----
 project
  ├── columns: x:1(int) x:3(int) y:4(int) b:6(int) d:8(int) e:9(int)
- ├── inner-join
+ ├── ordering: +1
+ ├── sort
  │    ├── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null) twocolumn.x:3(int) twocolumn.y:4(int) twocolumn.rowid:5(int!null) onecolumn.x:6(int) onecolumn.rowid:7(int!null) twocolumn.x:8(int) twocolumn.y:9(int) twocolumn.rowid:10(int!null)
- │    ├── inner-join
- │    │    ├── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null) twocolumn.x:3(int) twocolumn.y:4(int) twocolumn.rowid:5(int!null) onecolumn.x:6(int) onecolumn.rowid:7(int!null)
- │    │    ├── inner-join
- │    │    │    ├── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null) twocolumn.x:3(int) twocolumn.y:4(int) twocolumn.rowid:5(int!null)
- │    │    │    ├── scan
- │    │    │    │    └── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null)
- │    │    │    ├── scan
- │    │    │    │    └── columns: twocolumn.x:3(int) twocolumn.y:4(int) twocolumn.rowid:5(int!null)
- │    │    │    └── true [type=bool]
- │    │    ├── scan
- │    │    │    └── columns: onecolumn.x:6(int) onecolumn.rowid:7(int!null)
- │    │    └── eq [type=bool, outer=(3,6)]
- │    │         ├── variable: onecolumn.x [type=int, outer=(6)]
- │    │         └── variable: twocolumn.x [type=int, outer=(3)]
- │    ├── scan
- │    │    └── columns: twocolumn.x:8(int) twocolumn.y:9(int) twocolumn.rowid:10(int!null)
- │    └── and [type=bool, outer=(1,6,8)]
- │         ├── eq [type=bool, outer=(6,8)]
- │         │    ├── variable: onecolumn.x [type=int, outer=(6)]
- │         │    └── variable: twocolumn.x [type=int, outer=(8)]
- │         └── eq [type=bool, outer=(1,8)]
- │              ├── variable: twocolumn.x [type=int, outer=(8)]
- │              └── variable: onecolumn.x [type=int, outer=(1)]
+ │    ├── ordering: +1
+ │    └── inner-join
+ │         ├── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null) twocolumn.x:3(int) twocolumn.y:4(int) twocolumn.rowid:5(int!null) onecolumn.x:6(int) onecolumn.rowid:7(int!null) twocolumn.x:8(int) twocolumn.y:9(int) twocolumn.rowid:10(int!null)
+ │         ├── inner-join
+ │         │    ├── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null) twocolumn.x:3(int) twocolumn.y:4(int) twocolumn.rowid:5(int!null) onecolumn.x:6(int) onecolumn.rowid:7(int!null)
+ │         │    ├── inner-join
+ │         │    │    ├── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null) twocolumn.x:3(int) twocolumn.y:4(int) twocolumn.rowid:5(int!null)
+ │         │    │    ├── scan
+ │         │    │    │    └── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null)
+ │         │    │    ├── scan
+ │         │    │    │    └── columns: twocolumn.x:3(int) twocolumn.y:4(int) twocolumn.rowid:5(int!null)
+ │         │    │    └── true [type=bool]
+ │         │    ├── scan
+ │         │    │    └── columns: onecolumn.x:6(int) onecolumn.rowid:7(int!null)
+ │         │    └── eq [type=bool, outer=(3,6)]
+ │         │         ├── variable: onecolumn.x [type=int, outer=(6)]
+ │         │         └── variable: twocolumn.x [type=int, outer=(3)]
+ │         ├── scan
+ │         │    └── columns: twocolumn.x:8(int) twocolumn.y:9(int) twocolumn.rowid:10(int!null)
+ │         └── and [type=bool, outer=(1,6,8)]
+ │              ├── eq [type=bool, outer=(6,8)]
+ │              │    ├── variable: onecolumn.x [type=int, outer=(6)]
+ │              │    └── variable: twocolumn.x [type=int, outer=(8)]
+ │              └── eq [type=bool, outer=(1,8)]
+ │                   ├── variable: twocolumn.x [type=int, outer=(8)]
+ │                   └── variable: onecolumn.x [type=int, outer=(1)]
  └── projections [outer=(1,3,4,6,8,9)]
       ├── variable: onecolumn.x [type=int, outer=(1)]
       ├── variable: twocolumn.x [type=int, outer=(3)]
@@ -1095,26 +1193,30 @@ project
 
 # Check that a single column can have multiple table aliases.
 build
-SELECT * FROM (twocolumn AS a JOIN twocolumn AS b USING(x) JOIN twocolumn AS c USING(x))
+SELECT * FROM (twocolumn AS a JOIN twocolumn AS b USING(x) JOIN twocolumn AS c USING(x)) ORDER BY x
 ----
 project
  ├── columns: x:1(int) y:2(int) y:5(int) y:8(int)
- ├── inner-join
+ ├── ordering: +1
+ ├── sort
  │    ├── columns: twocolumn.x:1(int) twocolumn.y:2(int) twocolumn.rowid:3(int!null) twocolumn.x:4(int) twocolumn.y:5(int) twocolumn.rowid:6(int!null) twocolumn.x:7(int) twocolumn.y:8(int) twocolumn.rowid:9(int!null)
- │    ├── inner-join
- │    │    ├── columns: twocolumn.x:1(int) twocolumn.y:2(int) twocolumn.rowid:3(int!null) twocolumn.x:4(int) twocolumn.y:5(int) twocolumn.rowid:6(int!null)
- │    │    ├── scan
- │    │    │    └── columns: twocolumn.x:1(int) twocolumn.y:2(int) twocolumn.rowid:3(int!null)
- │    │    ├── scan
- │    │    │    └── columns: twocolumn.x:4(int) twocolumn.y:5(int) twocolumn.rowid:6(int!null)
- │    │    └── eq [type=bool, outer=(1,4)]
- │    │         ├── variable: twocolumn.x [type=int, outer=(1)]
- │    │         └── variable: twocolumn.x [type=int, outer=(4)]
- │    ├── scan
- │    │    └── columns: twocolumn.x:7(int) twocolumn.y:8(int) twocolumn.rowid:9(int!null)
- │    └── eq [type=bool, outer=(1,7)]
- │         ├── variable: twocolumn.x [type=int, outer=(1)]
- │         └── variable: twocolumn.x [type=int, outer=(7)]
+ │    ├── ordering: +1
+ │    └── inner-join
+ │         ├── columns: twocolumn.x:1(int) twocolumn.y:2(int) twocolumn.rowid:3(int!null) twocolumn.x:4(int) twocolumn.y:5(int) twocolumn.rowid:6(int!null) twocolumn.x:7(int) twocolumn.y:8(int) twocolumn.rowid:9(int!null)
+ │         ├── inner-join
+ │         │    ├── columns: twocolumn.x:1(int) twocolumn.y:2(int) twocolumn.rowid:3(int!null) twocolumn.x:4(int) twocolumn.y:5(int) twocolumn.rowid:6(int!null)
+ │         │    ├── scan
+ │         │    │    └── columns: twocolumn.x:1(int) twocolumn.y:2(int) twocolumn.rowid:3(int!null)
+ │         │    ├── scan
+ │         │    │    └── columns: twocolumn.x:4(int) twocolumn.y:5(int) twocolumn.rowid:6(int!null)
+ │         │    └── eq [type=bool, outer=(1,4)]
+ │         │         ├── variable: twocolumn.x [type=int, outer=(1)]
+ │         │         └── variable: twocolumn.x [type=int, outer=(4)]
+ │         ├── scan
+ │         │    └── columns: twocolumn.x:7(int) twocolumn.y:8(int) twocolumn.rowid:9(int!null)
+ │         └── eq [type=bool, outer=(1,7)]
+ │              ├── variable: twocolumn.x [type=int, outer=(1)]
+ │              └── variable: twocolumn.x [type=int, outer=(7)]
  └── projections [outer=(1,2,5,8)]
       ├── variable: twocolumn.x [type=int, outer=(1)]
       ├── variable: twocolumn.y [type=int, outer=(2)]
@@ -1122,26 +1224,30 @@ project
       └── variable: twocolumn.y [type=int, outer=(8)]
 
 build
-SELECT a.x AS s, b.x, c.x, a.y, b.y, c.y FROM (twocolumn AS a JOIN twocolumn AS b USING(x) JOIN twocolumn AS c USING(x))
+SELECT a.x AS s, b.x, c.x, a.y, b.y, c.y FROM (twocolumn AS a JOIN twocolumn AS b USING(x) JOIN twocolumn AS c USING(x)) ORDER BY s
 ----
 project
  ├── columns: s:1(int) x:4(int) x:7(int) y:2(int) y:5(int) y:8(int)
- ├── inner-join
+ ├── ordering: +1
+ ├── sort
  │    ├── columns: twocolumn.x:1(int) twocolumn.y:2(int) twocolumn.rowid:3(int!null) twocolumn.x:4(int) twocolumn.y:5(int) twocolumn.rowid:6(int!null) twocolumn.x:7(int) twocolumn.y:8(int) twocolumn.rowid:9(int!null)
- │    ├── inner-join
- │    │    ├── columns: twocolumn.x:1(int) twocolumn.y:2(int) twocolumn.rowid:3(int!null) twocolumn.x:4(int) twocolumn.y:5(int) twocolumn.rowid:6(int!null)
- │    │    ├── scan
- │    │    │    └── columns: twocolumn.x:1(int) twocolumn.y:2(int) twocolumn.rowid:3(int!null)
- │    │    ├── scan
- │    │    │    └── columns: twocolumn.x:4(int) twocolumn.y:5(int) twocolumn.rowid:6(int!null)
- │    │    └── eq [type=bool, outer=(1,4)]
- │    │         ├── variable: twocolumn.x [type=int, outer=(1)]
- │    │         └── variable: twocolumn.x [type=int, outer=(4)]
- │    ├── scan
- │    │    └── columns: twocolumn.x:7(int) twocolumn.y:8(int) twocolumn.rowid:9(int!null)
- │    └── eq [type=bool, outer=(1,7)]
- │         ├── variable: twocolumn.x [type=int, outer=(1)]
- │         └── variable: twocolumn.x [type=int, outer=(7)]
+ │    ├── ordering: +1
+ │    └── inner-join
+ │         ├── columns: twocolumn.x:1(int) twocolumn.y:2(int) twocolumn.rowid:3(int!null) twocolumn.x:4(int) twocolumn.y:5(int) twocolumn.rowid:6(int!null) twocolumn.x:7(int) twocolumn.y:8(int) twocolumn.rowid:9(int!null)
+ │         ├── inner-join
+ │         │    ├── columns: twocolumn.x:1(int) twocolumn.y:2(int) twocolumn.rowid:3(int!null) twocolumn.x:4(int) twocolumn.y:5(int) twocolumn.rowid:6(int!null)
+ │         │    ├── scan
+ │         │    │    └── columns: twocolumn.x:1(int) twocolumn.y:2(int) twocolumn.rowid:3(int!null)
+ │         │    ├── scan
+ │         │    │    └── columns: twocolumn.x:4(int) twocolumn.y:5(int) twocolumn.rowid:6(int!null)
+ │         │    └── eq [type=bool, outer=(1,4)]
+ │         │         ├── variable: twocolumn.x [type=int, outer=(1)]
+ │         │         └── variable: twocolumn.x [type=int, outer=(4)]
+ │         ├── scan
+ │         │    └── columns: twocolumn.x:7(int) twocolumn.y:8(int) twocolumn.rowid:9(int!null)
+ │         └── eq [type=bool, outer=(1,7)]
+ │              ├── variable: twocolumn.x [type=int, outer=(1)]
+ │              └── variable: twocolumn.x [type=int, outer=(7)]
  └── projections [outer=(1,2,4,5,7,8)]
       ├── variable: twocolumn.x [type=int, outer=(1)]
       ├── variable: twocolumn.x [type=int, outer=(4)]
@@ -1319,6 +1425,42 @@ project
  │         └── variable: twocolumn.y [type=int, outer=(5)]
  └── projections [outer=(1)]
       └── variable: twocolumn.x [type=int, outer=(1)]
+
+build
+SELECT * FROM (SELECT * FROM (VALUES (9, 1), (8, 2)) AS a (u, k) ORDER BY k)
+  INNER JOIN (VALUES (1, 1), (2, 2)) AS b (k, w) USING (k) ORDER BY u
+----
+project
+ ├── columns: k:2(int) u:1(int) w:4(int)
+ ├── ordering: +1
+ ├── sort
+ │    ├── columns: column1:1(int) column2:2(int) column1:3(int) column2:4(int)
+ │    ├── ordering: +1
+ │    └── inner-join
+ │         ├── columns: column1:1(int) column2:2(int) column1:3(int) column2:4(int)
+ │         ├── values
+ │         │    ├── columns: column1:1(int) column2:2(int)
+ │         │    ├── tuple [type=tuple{int, int}]
+ │         │    │    ├── const: 9 [type=int]
+ │         │    │    └── const: 1 [type=int]
+ │         │    └── tuple [type=tuple{int, int}]
+ │         │         ├── const: 8 [type=int]
+ │         │         └── const: 2 [type=int]
+ │         ├── values
+ │         │    ├── columns: column1:3(int) column2:4(int)
+ │         │    ├── tuple [type=tuple{int, int}]
+ │         │    │    ├── const: 1 [type=int]
+ │         │    │    └── const: 1 [type=int]
+ │         │    └── tuple [type=tuple{int, int}]
+ │         │         ├── const: 2 [type=int]
+ │         │         └── const: 2 [type=int]
+ │         └── eq [type=bool, outer=(2,3)]
+ │              ├── variable: column2 [type=int, outer=(2)]
+ │              └── variable: column1 [type=int, outer=(3)]
+ └── projections [outer=(1,2,4)]
+      ├── variable: column2 [type=int, outer=(2)]
+      ├── variable: column1 [type=int, outer=(1)]
+      └── variable: column2 [type=int, outer=(4)]
 
 # Tests for filter propagation through joins.
 
@@ -2488,7 +2630,7 @@ right-join
 # Test OUTER joins that are run in the distSQL merge joiner
 
 build
-SELECT * FROM (SELECT * FROM xyu) AS xyu LEFT OUTER JOIN (SELECT * FROM xyv) AS xyv USING(x, y) WHERE x > 2
+SELECT * FROM (SELECT * FROM xyu ORDER BY x, y) AS xyu LEFT OUTER JOIN (SELECT * FROM xyv ORDER BY x, y) AS xyv USING(x, y) WHERE x > 2
 ----
 project
  ├── columns: x:1(int!null) y:2(int!null) u:3(int!null) v:6(int)
@@ -2517,7 +2659,7 @@ project
       └── variable: xyv.v [type=int, outer=(6)]
 
 build
-SELECT * FROM (SELECT * FROM xyu) AS xyu RIGHT OUTER JOIN (SELECT * FROM xyv) AS xyv USING(x, y) WHERE x > 2
+SELECT * FROM (SELECT * FROM xyu ORDER BY x, y) AS xyu RIGHT OUTER JOIN (SELECT * FROM xyv ORDER BY x, y) AS xyv USING(x, y) WHERE x > 2
 ----
 project
  ├── columns: x:4(int!null) y:5(int!null) u:3(int) v:6(int!null)
@@ -2546,7 +2688,7 @@ project
       └── variable: xyv.v [type=int, outer=(6)]
 
 build
-SELECT * FROM (SELECT * FROM xyu) AS xyu FULL OUTER JOIN (SELECT * FROM xyv) AS xyv USING(x, y) WHERE x > 2
+SELECT * FROM (SELECT * FROM xyu ORDER BY x, y) AS xyu FULL OUTER JOIN (SELECT * FROM xyv ORDER BY x, y) AS xyv USING(x, y) WHERE x > 2
 ----
 project
  ├── columns: x:7(int) y:8(int) u:3(int) v:6(int)
@@ -2590,7 +2732,7 @@ project
       └── variable: xyv.v [type=int, outer=(6)]
 
 build
-SELECT * FROM (SELECT * FROM xyu) AS xyu LEFT OUTER JOIN (SELECT * FROM xyv) AS xyv ON xyu.x = xyv.x AND xyu.y = xyv.y AND xyu.x = 1 AND xyu.y < 10
+SELECT * FROM (SELECT * FROM xyu ORDER BY x, y) AS xyu LEFT OUTER JOIN (SELECT * FROM xyv ORDER BY x, y) AS xyv ON xyu.x = xyv.x AND xyu.y = xyv.y AND xyu.x = 1 AND xyu.y < 10
 ----
 left-join
  ├── columns: x:1(int!null) y:2(int!null) u:3(int!null) x:4(int) y:5(int) v:6(int)
@@ -2615,7 +2757,7 @@ left-join
            └── const: 10 [type=int]
 
 build
-SELECT * FROM xyu RIGHT OUTER JOIN (SELECT * FROM xyv) AS xyv ON xyu.x = xyv.x AND xyu.y = xyv.y AND xyu.x = 1 AND xyu.y < 10
+SELECT * FROM xyu RIGHT OUTER JOIN (SELECT * FROM xyv ORDER BY x, y) AS xyv ON xyu.x = xyv.x AND xyu.y = xyv.y AND xyu.x = 1 AND xyu.y < 10
 ----
 right-join
  ├── columns: x:1(int) y:2(int) u:3(int) x:4(int!null) y:5(int!null) v:6(int!null)

--- a/pkg/sql/opt/optbuilder/testdata/select
+++ b/pkg/sql/opt/optbuilder/testdata/select
@@ -330,6 +330,50 @@ project
       └── variable: kw.from [type=int, outer=(1)]
 
 exec-ddl
+CREATE TABLE xyzw (
+  x INT PRIMARY KEY,
+  y INT,
+  z INT,
+  w INT,
+  INDEX foo (z, y)
+)
+----
+TABLE xyzw
+ ├── x int not null
+ ├── y int
+ ├── z int
+ ├── w int
+ ├── INDEX primary
+ │    └── x int not null
+ └── INDEX foo
+      ├── z int
+      ├── y int
+      └── x int not null
+
+build
+SELECT * FROM xyzw ORDER BY 1
+----
+scan
+ ├── columns: x:1(int!null) y:2(int) z:3(int) w:4(int)
+ └── ordering: +1
+
+build
+SELECT * FROM xyzw ORDER BY x
+----
+scan
+ ├── columns: x:1(int!null) y:2(int) z:3(int) w:4(int)
+ └── ordering: +1
+
+build
+SELECT * FROM xyzw ORDER BY y
+----
+sort
+ ├── columns: x:1(int!null) y:2(int) z:3(int) w:4(int)
+ ├── ordering: +2
+ └── scan
+      └── columns: xyzw.x:1(int!null) xyzw.y:2(int) xyzw.z:3(int) xyzw.w:4(int)
+
+exec-ddl
 CREATE TABLE boolean_table (
   id INTEGER PRIMARY KEY NOT NULL,
   value BOOLEAN

--- a/pkg/sql/opt/optbuilder/testdata/union
+++ b/pkg/sql/opt/optbuilder/testdata/union
@@ -204,22 +204,88 @@ union
            ├── const: 1 [type=int]
            └── const: 1 [type=int]
 
+build
+(VALUES (1), (1), (1), (2), (2) UNION ALL VALUES (1), (3), (1)) ORDER BY 1 DESC
+----
+sort
+ ├── columns: column1:3(int)
+ ├── ordering: -3
+ └── union-all
+      ├── columns: column1:3(int)
+      ├── left columns: column1:1(int)
+      ├── right columns: column1:2(int)
+      ├── values
+      │    ├── columns: column1:1(int)
+      │    ├── tuple [type=tuple{int}]
+      │    │    └── const: 1 [type=int]
+      │    ├── tuple [type=tuple{int}]
+      │    │    └── const: 1 [type=int]
+      │    ├── tuple [type=tuple{int}]
+      │    │    └── const: 1 [type=int]
+      │    ├── tuple [type=tuple{int}]
+      │    │    └── const: 2 [type=int]
+      │    └── tuple [type=tuple{int}]
+      │         └── const: 2 [type=int]
+      └── values
+           ├── columns: column1:2(int)
+           ├── tuple [type=tuple{int}]
+           │    └── const: 1 [type=int]
+           ├── tuple [type=tuple{int}]
+           │    └── const: 3 [type=int]
+           └── tuple [type=tuple{int}]
+                └── const: 1 [type=int]
+
+# The ORDER BY applies to the UNION, not the last VALUES.
+build
+VALUES (1), (1), (1), (2), (2) UNION ALL VALUES (1), (3), (1) ORDER BY 1 DESC
+----
+sort
+ ├── columns: column1:3(int)
+ ├── ordering: -3
+ └── union-all
+      ├── columns: column1:3(int)
+      ├── left columns: column1:1(int)
+      ├── right columns: column1:2(int)
+      ├── values
+      │    ├── columns: column1:1(int)
+      │    ├── tuple [type=tuple{int}]
+      │    │    └── const: 1 [type=int]
+      │    ├── tuple [type=tuple{int}]
+      │    │    └── const: 1 [type=int]
+      │    ├── tuple [type=tuple{int}]
+      │    │    └── const: 1 [type=int]
+      │    ├── tuple [type=tuple{int}]
+      │    │    └── const: 2 [type=int]
+      │    └── tuple [type=tuple{int}]
+      │         └── const: 2 [type=int]
+      └── values
+           ├── columns: column1:2(int)
+           ├── tuple [type=tuple{int}]
+           │    └── const: 1 [type=int]
+           ├── tuple [type=tuple{int}]
+           │    └── const: 3 [type=int]
+           └── tuple [type=tuple{int}]
+                └── const: 1 [type=int]
+
 # UNION with NULL columns in operands works.
 build
-VALUES (NULL) UNION ALL VALUES (1)
+VALUES (NULL) UNION ALL VALUES (1) ORDER BY 1
 ----
-union-all
+sort
  ├── columns: column1:3(int)
- ├── left columns: column1:1(unknown)
- ├── right columns: column1:2(int)
- ├── values
- │    ├── columns: column1:1(unknown)
- │    └── tuple [type=tuple{unknown}]
- │         └── null [type=unknown]
- └── values
-      ├── columns: column1:2(int)
-      └── tuple [type=tuple{int}]
-           └── const: 1 [type=int]
+ ├── ordering: +3
+ └── union-all
+      ├── columns: column1:3(int)
+      ├── left columns: column1:1(unknown)
+      ├── right columns: column1:2(int)
+      ├── values
+      │    ├── columns: column1:1(unknown)
+      │    └── tuple [type=tuple{unknown}]
+      │         └── null [type=unknown]
+      └── values
+           ├── columns: column1:2(int)
+           └── tuple [type=tuple{int}]
+                └── const: 1 [type=int]
 
 build
 VALUES (NULL) UNION ALL VALUES (NULL)
@@ -487,6 +553,73 @@ except-all
            └── variable: uniontest.v [type=int, outer=(5)]
 
 build
+(SELECT v FROM uniontest WHERE k = 1 UNION ALL SELECT v FROM uniontest WHERE k = 2) ORDER BY 1 DESC
+----
+sort
+ ├── columns: v:7(int)
+ ├── ordering: -7
+ └── union-all
+      ├── columns: v:7(int)
+      ├── left columns: uniontest.v:2(int)
+      ├── right columns: uniontest.v:5(int)
+      ├── project
+      │    ├── columns: uniontest.v:2(int)
+      │    ├── select
+      │    │    ├── columns: uniontest.k:1(int) uniontest.v:2(int) uniontest.rowid:3(int!null)
+      │    │    ├── scan
+      │    │    │    └── columns: uniontest.k:1(int) uniontest.v:2(int) uniontest.rowid:3(int!null)
+      │    │    └── eq [type=bool, outer=(1)]
+      │    │         ├── variable: uniontest.k [type=int, outer=(1)]
+      │    │         └── const: 1 [type=int]
+      │    └── projections [outer=(2)]
+      │         └── variable: uniontest.v [type=int, outer=(2)]
+      └── project
+           ├── columns: uniontest.v:5(int)
+           ├── select
+           │    ├── columns: uniontest.k:4(int) uniontest.v:5(int) uniontest.rowid:6(int!null)
+           │    ├── scan
+           │    │    └── columns: uniontest.k:4(int) uniontest.v:5(int) uniontest.rowid:6(int!null)
+           │    └── eq [type=bool, outer=(4)]
+           │         ├── variable: uniontest.k [type=int, outer=(4)]
+           │         └── const: 2 [type=int]
+           └── projections [outer=(5)]
+                └── variable: uniontest.v [type=int, outer=(5)]
+
+# The ORDER BY applies to the UNION, not the last SELECT.
+build
+SELECT v FROM uniontest WHERE k = 1 UNION ALL SELECT v FROM uniontest WHERE k = 2 ORDER BY 1 DESC
+----
+sort
+ ├── columns: v:7(int)
+ ├── ordering: -7
+ └── union-all
+      ├── columns: v:7(int)
+      ├── left columns: uniontest.v:2(int)
+      ├── right columns: uniontest.v:5(int)
+      ├── project
+      │    ├── columns: uniontest.v:2(int)
+      │    ├── select
+      │    │    ├── columns: uniontest.k:1(int) uniontest.v:2(int) uniontest.rowid:3(int!null)
+      │    │    ├── scan
+      │    │    │    └── columns: uniontest.k:1(int) uniontest.v:2(int) uniontest.rowid:3(int!null)
+      │    │    └── eq [type=bool, outer=(1)]
+      │    │         ├── variable: uniontest.k [type=int, outer=(1)]
+      │    │         └── const: 1 [type=int]
+      │    └── projections [outer=(2)]
+      │         └── variable: uniontest.v [type=int, outer=(2)]
+      └── project
+           ├── columns: uniontest.v:5(int)
+           ├── select
+           │    ├── columns: uniontest.k:4(int) uniontest.v:5(int) uniontest.rowid:6(int!null)
+           │    ├── scan
+           │    │    └── columns: uniontest.k:4(int) uniontest.v:5(int) uniontest.rowid:6(int!null)
+           │    └── eq [type=bool, outer=(4)]
+           │         ├── variable: uniontest.k [type=int, outer=(4)]
+           │         └── const: 2 [type=int]
+           └── projections [outer=(5)]
+                └── variable: uniontest.v [type=int, outer=(5)]
+
+build
 SELECT v FROM uniontest UNION SELECT k FROM uniontest
 ----
 union
@@ -606,25 +739,11 @@ SELECT 1 EXCEPT SELECT '3'
 ----
 error: EXCEPT types int and string cannot be matched
 
+# TODO(rytaft): Error message should be `pgcode 42703 column "z" does not exist`
 build
-SELECT 1 UNION SELECT 3
+SELECT 1 UNION SELECT 3 ORDER BY z
 ----
-union
- ├── columns: column1:3(int)
- ├── left columns: column1:1(int)
- ├── right columns: column2:2(int)
- ├── project
- │    ├── columns: column1:1(int)
- │    ├── values
- │    │    └── tuple [type=tuple{}]
- │    └── projections
- │         └── const: 1 [type=int]
- └── project
-      ├── columns: column2:2(int)
-      ├── values
-      │    └── tuple [type=tuple{}]
-      └── projections
-           └── const: 3 [type=int]
+error: column name "z" not found
 
 build
 SELECT ARRAY[1] UNION ALL SELECT ARRAY['foo']

--- a/pkg/sql/opt/optbuilder/testdata/values
+++ b/pkg/sql/opt/optbuilder/testdata/values
@@ -28,18 +28,27 @@ VALUES (1), (2, 3)
 error: VALUES lists must all be the same length, expected 1 columns, found 2
 
 build
-VALUES (1), (1), (2), (3)
+VALUES (1), (1), (2), (3) ORDER BY 1 DESC
 ----
-values
+sort
  ├── columns: column1:1(int)
- ├── tuple [type=tuple{int}]
- │    └── const: 1 [type=int]
- ├── tuple [type=tuple{int}]
- │    └── const: 1 [type=int]
- ├── tuple [type=tuple{int}]
- │    └── const: 2 [type=int]
- └── tuple [type=tuple{int}]
-      └── const: 3 [type=int]
+ ├── ordering: -1
+ └── values
+      ├── columns: column1:1(int)
+      ├── tuple [type=tuple{int}]
+      │    └── const: 1 [type=int]
+      ├── tuple [type=tuple{int}]
+      │    └── const: 1 [type=int]
+      ├── tuple [type=tuple{int}]
+      │    └── const: 2 [type=int]
+      └── tuple [type=tuple{int}]
+           └── const: 3 [type=int]
+
+# TODO(rytaft): Error message should be `pgcode 42703 column "z" does not exist`
+build
+VALUES (1), (1), (2), (3) ORDER BY z
+----
+error: column name "z" not found
 
 build
 VALUES ('this', 'is', 'a', 'test'), (1, 2, 3, 4)

--- a/pkg/sql/opt/optbuilder/testdata/where
+++ b/pkg/sql/opt/optbuilder/testdata/where
@@ -1,0 +1,250 @@
+# tests adapted from logictest -- where
+
+exec-ddl
+CREATE TABLE kv (
+  k INT PRIMARY KEY,
+  v INT
+)
+----
+TABLE kv
+ ├── k int not null
+ ├── v int
+ └── INDEX primary
+      └── k int not null
+
+exec-ddl
+CREATE TABLE kvString (
+  k STRING PRIMARY KEY,
+  v STRING
+)
+----
+TABLE kvstring
+ ├── k string not null
+ ├── v string
+ └── INDEX primary
+      └── k string not null
+
+build
+SELECT * FROM kv WHERE k IN (1, 3)
+----
+select
+ ├── columns: k:1(int!null) v:2(int)
+ ├── scan
+ │    └── columns: kv.k:1(int!null) kv.v:2(int)
+ └── in [type=bool, outer=(1)]
+      ├── variable: kv.k [type=int, outer=(1)]
+      └── tuple [type=tuple{int, int}]
+           ├── const: 1 [type=int]
+           └── const: 3 [type=int]
+
+build
+SELECT * FROM kv WHERE v IN (6)
+----
+select
+ ├── columns: k:1(int!null) v:2(int)
+ ├── scan
+ │    └── columns: kv.k:1(int!null) kv.v:2(int)
+ └── in [type=bool, outer=(2)]
+      ├── variable: kv.v [type=int, outer=(2)]
+      └── tuple [type=tuple{int}]
+           └── const: 6 [type=int]
+
+# TODO(rytaft) subqueries not yet implemented.
+#build
+#SELECT * FROM kv WHERE k IN (SELECT k FROM kv)
+#----
+#
+#build
+#SELECT * FROM kv WHERE (k,v) IN (SELECT * FROM kv)
+#----
+
+build
+SELECT * FROM kv WHERE nonexistent = 1
+----
+error: column name "nonexistent" not found
+
+build
+SELECT 'hello' LIKE v FROM kvString WHERE k LIKE 'like%' ORDER BY k
+----
+project
+ ├── columns: column3:3(bool)
+ ├── ordering: +1
+ ├── select
+ │    ├── columns: kvstring.k:1(string!null) kvstring.v:2(string)
+ │    ├── ordering: +1
+ │    ├── scan
+ │    │    ├── columns: kvstring.k:1(string!null) kvstring.v:2(string)
+ │    │    └── ordering: +1
+ │    └── like [type=bool, outer=(1)]
+ │         ├── variable: kvstring.k [type=string, outer=(1)]
+ │         └── const: 'like%' [type=string]
+ └── projections [outer=(1,2)]
+      ├── like [type=bool, outer=(2)]
+      │    ├── const: 'hello' [type=string]
+      │    └── variable: kvstring.v [type=string, outer=(2)]
+      └── variable: kvstring.k [type=string, outer=(1)]
+
+build
+SELECT 'hello' SIMILAR TO v FROM kvString WHERE k SIMILAR TO 'like[1-2]' ORDER BY k
+----
+project
+ ├── columns: column3:3(bool)
+ ├── ordering: +1
+ ├── select
+ │    ├── columns: kvstring.k:1(string!null) kvstring.v:2(string)
+ │    ├── ordering: +1
+ │    ├── scan
+ │    │    ├── columns: kvstring.k:1(string!null) kvstring.v:2(string)
+ │    │    └── ordering: +1
+ │    └── similar-to [type=bool, outer=(1)]
+ │         ├── variable: kvstring.k [type=string, outer=(1)]
+ │         └── const: 'like[1-2]' [type=string]
+ └── projections [outer=(1,2)]
+      ├── similar-to [type=bool, outer=(2)]
+      │    ├── const: 'hello' [type=string]
+      │    └── variable: kvstring.v [type=string, outer=(2)]
+      └── variable: kvstring.k [type=string, outer=(1)]
+
+build
+SELECT 'hello' ~ replace(v, '%', '.*') FROM kvString WHERE k ~ 'like[1-2]' ORDER BY k
+----
+project
+ ├── columns: column3:3(bool)
+ ├── ordering: +1
+ ├── select
+ │    ├── columns: kvstring.k:1(string!null) kvstring.v:2(string)
+ │    ├── ordering: +1
+ │    ├── scan
+ │    │    ├── columns: kvstring.k:1(string!null) kvstring.v:2(string)
+ │    │    └── ordering: +1
+ │    └── reg-match [type=bool, outer=(1)]
+ │         ├── variable: kvstring.k [type=string, outer=(1)]
+ │         └── const: 'like[1-2]' [type=string]
+ └── projections [outer=(1,2)]
+      ├── reg-match [type=bool, outer=(2)]
+      │    ├── const: 'hello' [type=string]
+      │    └── function: replace [type=string, outer=(2)]
+      │         ├── variable: kvstring.v [type=string, outer=(2)]
+      │         ├── const: '%' [type=string]
+      │         └── const: '.*' [type=string]
+      └── variable: kvstring.k [type=string, outer=(1)]
+
+# Test mixed type tuple comparison.
+
+build
+SELECT * FROM kv WHERE k IN (1, 5.0, 9)
+----
+select
+ ├── columns: k:1(int!null) v:2(int)
+ ├── scan
+ │    └── columns: kv.k:1(int!null) kv.v:2(int)
+ └── in [type=bool, outer=(1)]
+      ├── variable: kv.k [type=int, outer=(1)]
+      └── tuple [type=tuple{int, int, int}]
+           ├── const: 1 [type=int]
+           ├── const: 5 [type=int]
+           └── const: 9 [type=int]
+
+# Regression tests for #22670.
+exec-ddl
+CREATE TABLE ab (a INT, b INT)
+----
+TABLE ab
+ ├── a int
+ ├── b int
+ ├── rowid int not null (hidden)
+ └── INDEX primary
+      └── rowid int not null (hidden)
+
+build
+SELECT * FROM ab WHERE a IN (1, 3, 4)
+----
+project
+ ├── columns: a:1(int) b:2(int)
+ ├── select
+ │    ├── columns: ab.a:1(int) ab.b:2(int) ab.rowid:3(int!null)
+ │    ├── scan
+ │    │    └── columns: ab.a:1(int) ab.b:2(int) ab.rowid:3(int!null)
+ │    └── in [type=bool, outer=(1)]
+ │         ├── variable: ab.a [type=int, outer=(1)]
+ │         └── tuple [type=tuple{int, int, int}]
+ │              ├── const: 1 [type=int]
+ │              ├── const: 3 [type=int]
+ │              └── const: 4 [type=int]
+ └── projections [outer=(1,2)]
+      ├── variable: ab.a [type=int, outer=(1)]
+      └── variable: ab.b [type=int, outer=(2)]
+
+build
+SELECT * FROM ab WHERE a IN (1, 3, 4, NULL)
+----
+project
+ ├── columns: a:1(int) b:2(int)
+ ├── select
+ │    ├── columns: ab.a:1(int) ab.b:2(int) ab.rowid:3(int!null)
+ │    ├── scan
+ │    │    └── columns: ab.a:1(int) ab.b:2(int) ab.rowid:3(int!null)
+ │    └── in [type=bool, outer=(1)]
+ │         ├── variable: ab.a [type=int, outer=(1)]
+ │         └── tuple [type=tuple{int, int, int, unknown}]
+ │              ├── const: 1 [type=int]
+ │              ├── const: 3 [type=int]
+ │              ├── const: 4 [type=int]
+ │              └── null [type=unknown]
+ └── projections [outer=(1,2)]
+      ├── variable: ab.a [type=int, outer=(1)]
+      └── variable: ab.b [type=int, outer=(2)]
+
+build
+SELECT * FROM ab WHERE (a, b) IN ((1, 10), (3, 30), (4, 40))
+----
+project
+ ├── columns: a:1(int) b:2(int)
+ ├── select
+ │    ├── columns: ab.a:1(int) ab.b:2(int) ab.rowid:3(int!null)
+ │    ├── scan
+ │    │    └── columns: ab.a:1(int) ab.b:2(int) ab.rowid:3(int!null)
+ │    └── in [type=bool, outer=(1,2)]
+ │         ├── tuple [type=tuple{int, int}, outer=(1,2)]
+ │         │    ├── variable: ab.a [type=int, outer=(1)]
+ │         │    └── variable: ab.b [type=int, outer=(2)]
+ │         └── tuple [type=tuple{tuple{int, int}, tuple{int, int}, tuple{int, int}}]
+ │              ├── tuple [type=tuple{int, int}]
+ │              │    ├── const: 1 [type=int]
+ │              │    └── const: 10 [type=int]
+ │              ├── tuple [type=tuple{int, int}]
+ │              │    ├── const: 3 [type=int]
+ │              │    └── const: 30 [type=int]
+ │              └── tuple [type=tuple{int, int}]
+ │                   ├── const: 4 [type=int]
+ │                   └── const: 40 [type=int]
+ └── projections [outer=(1,2)]
+      ├── variable: ab.a [type=int, outer=(1)]
+      └── variable: ab.b [type=int, outer=(2)]
+
+build
+SELECT * FROM ab WHERE (a, b) IN ((1, 10), (4, NULL), (NULL, 50))
+----
+project
+ ├── columns: a:1(int) b:2(int)
+ ├── select
+ │    ├── columns: ab.a:1(int) ab.b:2(int) ab.rowid:3(int!null)
+ │    ├── scan
+ │    │    └── columns: ab.a:1(int) ab.b:2(int) ab.rowid:3(int!null)
+ │    └── in [type=bool, outer=(1,2)]
+ │         ├── tuple [type=tuple{int, int}, outer=(1,2)]
+ │         │    ├── variable: ab.a [type=int, outer=(1)]
+ │         │    └── variable: ab.b [type=int, outer=(2)]
+ │         └── tuple [type=tuple{tuple{int, int}, tuple{int, unknown}, tuple{unknown, int}}]
+ │              ├── tuple [type=tuple{int, int}]
+ │              │    ├── const: 1 [type=int]
+ │              │    └── const: 10 [type=int]
+ │              ├── tuple [type=tuple{int, unknown}]
+ │              │    ├── const: 4 [type=int]
+ │              │    └── null [type=unknown]
+ │              └── tuple [type=tuple{unknown, int}]
+ │                   ├── null [type=unknown]
+ │                   └── const: 50 [type=int]
+ └── projections [outer=(1,2)]
+      ├── variable: ab.a [type=int, outer=(1)]
+      └── variable: ab.b [type=int, outer=(2)]


### PR DESCRIPTION
This commit adds a number of tests from logictests
to the optbuilder tests that were not previously supported
because they contain ORDER BY. The purpose of these additional
tests is to test the way that ORDER BY interacts with other
SQL operators such as Aggregations, Joins, and Distinct.

These tests also uncovered several bugs which will be
addressed in a separate PR. In particular:

- It should be possible to order by an aggregate that is
  part of the SELECT list. Currently, valid queries such as
  `SELECT v, COUNT(k) FROM kv GROUP BY v ORDER BY COUNT(k)`
  are causing an error.
- Attempting to order by a column that is present in two
  joined tables should fail with an ambiguity error if
  not combined with USING or NATURAL JOIN. Currently, invalid
  queries such as
  `SELECT * FROM onecolumn AS a, onecolumn AS b ORDER BY x`
  are not causing an error when they should.
- There is an "unsupported binary operator" error when
  attempting to order by the sum of two columns of types int
  and float.
- Ordering by the original column name of an aliased column
  in a DISTINCT query is causing an error. For example:
  `SELECT DISTINCT y AS w FROM xyz ORDER by y`
- Ordering by a column that does not exist should throw an
  error with pgcode 42703.

Release note: None