### PR TITLE
distsql: Some metadata propagation fixes

### DIFF
--- a/pkg/sql/distsqlrun/values.go
+++ b/pkg/sql/distsqlrun/values.go
@@ -113,7 +113,7 @@ func (v *valuesProcessor) Next() (sqlbase.EncDatumRow, *ProducerMetadata) {
 
 		if row == nil && meta == nil {
 			if len(v.data) == 0 {
-				return nil, nil
+				return nil, v.producerMeta(nil /* err */)
 			}
 			// Push a chunk of data to the stream decoder.
 			m := &ProducerMessage{}


### PR DESCRIPTION
**distsql: Always try to forward metadata from values processor**

If the input is empty, the values processor will return `nil, nil`,
which is currently fine, but will be incorrect once new, non-error
metadata types are added that must be propagated once all the canned
rows have been sent. This change makes the values processor more closely
follow the "forward all metadata" contract.

Release Note: None

----

**distsql: Forward all metadata from aggregator inputs**

If an error is encountered during the aggregator's accumulation phase,
its producer's remaining metadata would not be forwarded to the
aggregator's consumer. Now, we continue to read metadata from the
producer even after encountering an error during accumulation.

Release note: None