### PR TITLE
cherrypick-2.0: ui: Move Clock Offset graph to runtime dashboard and display per node

### DIFF
--- a/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/distributed.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/distributed.tsx
@@ -122,13 +122,5 @@ export default function (props: GraphDashboardProps) {
       </Axis>
     </LineGraph>,
 
-    <LineGraph title="Clock Offset" sources={nodeSources}
-    tooltip={`Mean and Standard deviation of the clock offset across the cluster`}>
-      <Axis label="offset" units={AxisUnits.Duration}>
-        <Metric name="cr.node.clock-offset.meannanos" title="Mean" />
-        <Metric name="cr.node.clock-offset.stddevnanos" title="Standard Deviation" />
-      </Axis>
-    </LineGraph>,
-
   ];
 }

--- a/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/runtime.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/runtime.tsx
@@ -1,12 +1,13 @@
 import React from "react";
+import _ from "lodash";
 
 import { LineGraph } from "src/views/cluster/components/linegraph";
 import { Metric, Axis, AxisUnits } from "src/views/shared/components/metricQuery";
 
-import { GraphDashboardProps } from "./dashboardUtils";
+import { GraphDashboardProps, nodeDisplayName, storeIDsForNode } from "./dashboardUtils";
 
 export default function (props: GraphDashboardProps) {
-  const { nodeSources, tooltipSelection } = props;
+  const { nodeIDs, nodesSummary, nodeSources, tooltipSelection } = props;
 
   return [
     <LineGraph title="Live Node Count" tooltip="The number of live nodes in the cluster.">
@@ -97,6 +98,25 @@ export default function (props: GraphDashboardProps) {
       <Axis units={AxisUnits.Duration} label="cpu time">
         <Metric name="cr.node.sys.cpu.user.ns" title="User CPU Time" nonNegativeRate />
         <Metric name="cr.node.sys.cpu.sys.ns" title="Sys CPU Time" nonNegativeRate />
+      </Axis>
+    </LineGraph>,
+
+    <LineGraph
+      title="Clock Offset"
+      sources={nodeSources}
+      tooltip={`Mean clock offset of each node against the rest of the cluster.`}
+    >
+      <Axis label="offset" units={AxisUnits.Duration}>
+        {
+          _.map(nodeIDs, (nid) => (
+            <Metric
+              key={nid}
+              name="cr.node.clock-offset.meannanos"
+              title={nodeDisplayName(nodesSummary, nid)}
+              sources={storeIDsForNode(nodesSummary, nid)}
+            />
+          ))
+        }
       </Axis>
     </LineGraph>,
   ];


### PR DESCRIPTION
Since the Distributed dashboard isn't currently a place for metrics of
interest to end users.

Also, aggregating the offsets and standard deviations together using a
SUM aggregator was basically meaningless. This metric makes the most
sense on a per-node basis.

Touches https://github.com/cockroachdb/docs/issues/2664

Release note (admin ui change): Moved the Clock Offset graph from the
Distributed dashboard to the Runtime dashboard, and display each node's
clock offset independently rather than aggregating them together.

-------------------

Cherrypicks #23618 to release-2.0