### PR TITLE
cherrypick-2.0: server: change server.drain_max_wait to server.shutdown.query_wait

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -88,9 +88,9 @@ var (
 	// for a graceful shutdown.
 	GracefulDrainModes = []serverpb.DrainMode{serverpb.DrainMode_CLIENT, serverpb.DrainMode_LEASES}
 
-	settingDrainMaxWait = settings.RegisterDurationSetting(
-		"server.drain_max_wait",
-		"the amount of time subsystems wait for work to finish before shutting down",
+	queryWait = settings.RegisterDurationSetting(
+		"server.shutdown.query_wait",
+		"the server will wait for at least this amount of time for active queries to finish",
 		10*time.Second,
 	)
 
@@ -1389,7 +1389,7 @@ func (s *Server) doDrain(
 					return nil
 				}
 
-				drainMaxWait := settingDrainMaxWait.Get(&s.st.SV)
+				drainMaxWait := queryWait.Get(&s.st.SV)
 				if err := s.pgServer.Drain(drainMaxWait); err != nil {
 					return err
 				}


### PR DESCRIPTION
Introduces a clearer name and a clearer description of what this setting
is used for.

Release note (cli change): Change server.drain_max_wait to
server.shutdown.query_wait

------------------------

It looks like @asubiotto missed cherry-picking this into 2.0 last week as part of #23319, but I'm pretty sure we do want to include it, particularly since it's now being documented (https://github.com/cockroachdb/docs/pull/2671)