### PR TITLE
roachpb: update comment on orig_timestamp

### DIFF
--- a/pkg/roachpb/data.proto
+++ b/pkg/roachpb/data.proto
@@ -239,22 +239,22 @@ message Transaction {
   util.hlc.Timestamp last_heartbeat = 5 [(gogoproto.nullable) = false];
   // The original timestamp at which the transaction started. For serializable
   // transactions, if the timestamp drifts from the original timestamp, the
-  // transaction will retry.
+  // transaction will retry unless we manage to "refresh the reads" - see
+  // refreshed_timestamp.
   //
-  // This timestamp is the one at which all transactions will read. It is also,
-  // surprisingly, the timestamp at which transactions will provisionally
-  // _write_ (i.e. intents are written at this orig_timestamp and, after commit,
-  // when the intents are resolved, their timestamps are bumped to the to the
-  // commit timestamp).
+  // This timestamp is the one at which all transactions will read, unless
+  // refreshed_timestamp is set. It is also, surprisingly, the timestamp at
+  // which transactions will provisionally _write_ (i.e. intents are written at
+  // this orig_timestamp and, after commit, when the intents are resolved,
+  // their timestamps are bumped to the to the commit timestamp), if
+  // refreshed_timestamp isn't set.
   // This is ultimately because of correctness concerns around SNAPSHOT
-  // transactions.  Note first that for SERIALIZABLE transactions, the original
-  // and commit timestamps must not diverge, and so an intent which may be
-  // committed is always written when both timestamps coincide.
+  // transactions.
   //
-  // For a SNAPSHOT transaction however, this is not the case. Intuitively,
-  // one could think that the timestamp at which intents should be written
-  // should be the provisional commit timestamp, and while this is morally
-  // true, consider the following scenario, where txn1 is a SNAPSHOT txn:
+  // Intuitively, one could think that the timestamp at which intents should be
+  // written should be the provisional commit timestamp, and while this is
+  // morally true, consider the following scenario, where txn1 is a SNAPSHOT
+  // txn:
   //
   // - txn1 at orig_timestamp=5 reads key1: (value) 1.
   // - txn1 writes elsewhere, has its commit timestamp increased to 20.
@@ -288,9 +288,11 @@ message Transaction {
   util.hlc.Timestamp max_timestamp = 7 [(gogoproto.nullable) = false];
   // The refreshed timestamp is the timestamp at which the transaction
   // can commit without necessitating a serializable restart. This
-  // value is forwarded to the transaction's current timestamp if the
-  // transaction coordinator is able to refresh all refreshable spans
-  // encountered during the course of the txn.
+  // value is forwarded to the transaction's current timestamp (meta.timestamp)
+  // if the transaction coordinator is able to refresh all refreshable spans
+  // encountered during the course of the txn. If set, this take precedence
+  // over orig_timestamp and is the timestamp at which the transaction both
+  // reads and writes going forward.
   util.hlc.Timestamp refreshed_timestamp = 15 [(gogoproto.nullable) = false];
   // A list of <NodeID, timestamp> pairs. The list maps NodeIDs to timestamps
   // as observed from their local clock during this transaction. The purpose of


### PR DESCRIPTION
... to account for the addition of the refreshed_timestamp.

Release note: None