### PR TITLE
log: report errors grouped by release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -712,7 +712,8 @@ $(COCKROACH) build buildoss buildshort go-install gotestdashi generate lint lint
 	-X "github.com/cockroachdb/cockroach/pkg/build.utcTime=$(shell date -u '+%Y/%m/%d %H:%M:%S')" \
 	-X "github.com/cockroachdb/cockroach/pkg/build.rev=$(shell cat .buildinfo/rev)" \
 	-X "github.com/cockroachdb/cockroach/pkg/build.cgoTargetTriple=$(TARGET_TRIPLE)" \
-	$(if $(BUILDCHANNEL),-X "github.com/cockroachdb/cockroach/pkg/build.channel=$(BUILDCHANNEL)")
+	$(if $(BUILDCHANNEL),-X "github.com/cockroachdb/cockroach/pkg/build.channel=$(BUILDCHANNEL)") \
+	$(if $(BUILD_TAGGED_RELEASE),-X "github.com/cockroachdb/cockroach/pkg/util/log.crashReportEnv=$(shell cat .buildinfo/tag)")
 
 # Note: We pass `-v` to `go build` and `go test -i` so that warnings
 # from the linker aren't suppressed. The usage of `-v` also shows when

--- a/pkg/cmd/publish-artifacts/main.go
+++ b/pkg/cmd/publish-artifacts/main.go
@@ -263,6 +263,9 @@ func buildOne(svc s3putter, o opts) {
 		args = append(args, fmt.Sprintf("%s=%s", "SUFFIX", o.Suffix))
 		args = append(args, fmt.Sprintf("%s=%s", "TAGS", o.Tags))
 		args = append(args, fmt.Sprintf("%s=%s", "BUILDCHANNEL", "official-binary"))
+		if *isRelease {
+			args = append(args, fmt.Sprintf("%s=%s", "BUILD_TAGGED_RELEASE", "true"))
+		}
 		cmd := exec.Command("make", args...)
 		cmd.Dir = o.PkgDir
 		cmd.Stdout = os.Stdout

--- a/pkg/util/log/crash_reporting.go
+++ b/pkg/util/log/crash_reporting.go
@@ -37,6 +37,9 @@ import (
 )
 
 var (
+	// crashReportEnv controls the version reported in crash reports
+	crashReportEnv = "development"
+
 	// DiagnosticsReportingEnabled wraps "diagnostics.reporting.enabled".
 	//
 	// "diagnostics.reporting.enabled" enables reporting of metrics related to a
@@ -223,7 +226,7 @@ func SetupCrashReporter(ctx context.Context, cmd string) {
 	}
 	info := build.GetInfo()
 	raven.SetRelease(info.Tag)
-	raven.SetEnvironment(info.Type)
+	raven.SetEnvironment(crashReportEnv)
 	raven.SetTagsContext(map[string]string{
 		"cmd":          cmd,
 		"platform":     info.Platform,


### PR DESCRIPTION
our error collection has some tools that make it easier to filter by the
reported enviorment -- with optons like 'production' or 'staging' being
an expected use-case. This populates that field with our release -- e.g.
v2.0-beta-20180512, optionally appending '-dev' for builds other than
those generated explictly for our published releases. Combined with
recent changes to only report from 'official' builds (#23623), this
means essentially that it would only be the master build nightlies that
report as -dev.

Release note: none.