### PR TITLE
Makefile: express bin/workload's dependency on generated code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1234,3 +1234,5 @@ unsafe-clean: maintainer-clean unsafe-clean-c-deps
 .SECONDEXPANSION:
 bin/%: $$(shell find $(PKG_ROOT)/cmd/$$*) | $(SUBMODULES_TARGET)
 	@$(GO_INSTALL) -v $(PKG_ROOT)/cmd/$*
+
+bin/workload: $(SQLPARSER_TARGETS)

--- a/build/roachtest-nightly.sh
+++ b/build/roachtest-nightly.sh
@@ -42,9 +42,9 @@ run go get -u -v github.com/cockroachdb/roachprod
 run git -C "$(go env GOPATH)/src/github.com/cockroachdb/roachprod" rev-parse HEAD
 if_tc tc_end_block "Install roachprod"
 
-if_tc tc_start_block "Compile Workload"
+if_tc tc_start_block "Compile workload and roachtest"
 run make bin/roachtest bin/workload
-if_tc tc_end_block "Compile Workload"
+if_tc tc_end_block "Compile workload and roachtest"
 
 if_tc tc_start_block "Run roachtest"
 chmod +x "$PWD/cockroach-linux-2.6.32-gnu-amd64"

--- a/build/roachtest-nightly.sh
+++ b/build/roachtest-nightly.sh
@@ -47,6 +47,7 @@ run make bin/roachtest bin/workload
 if_tc tc_end_block "Compile Workload"
 
 if_tc tc_start_block "Run roachtest"
+chmod +x "$PWD/cockroach-linux-2.6.32-gnu-amd64"
 run bin/roachtest run \
   --cluster-id "${TC_BUILD_ID}" \
   --slack-token "${SLACK_TOKEN}" \


### PR DESCRIPTION
bin/workload needs pkg/sql/lex's code to be generated. This went
unnoticed because it's not typical to run `make bin/workload` before
running `make build`.

Release note: None