### PR TITLE
opt/exec: simplify factory primitives

### DIFF
--- a/pkg/sql/opt/exec/factory.go
+++ b/pkg/sql/opt/exec/factory.go
@@ -72,6 +72,9 @@ type Factory interface {
 	// operation (either the ALL or the DISTINCT version). The left and right
 	// nodes must have the same number of columns.
 	ConstructSetOp(typ tree.UnionType, all bool, left, right Node) (Node, error)
+
+	// RenameColumns modifies the column names of a node.
+	RenameColumns(input Node, colNames []string) (Node, error)
 }
 
 // ColumnOrdinal is the 0-based ordinal index of a column produced by a Node.


### PR DESCRIPTION
Some of the projection primitives have some "intelligence" built-in
(e.g. rename columns instead of projecting when possible). Ideally we
want the factory to be just a shim and have all the intelligence in
the execbuilder.

This change moves out the identity detection for projections into the
execbuilder, using a new RenameColumns primitive.

Release note: None