### PR TITLE
opt: add OrderingColumn type

### DIFF
--- a/pkg/sql/opt/optbuilder/orderby.go
+++ b/pkg/sql/opt/optbuilder/orderby.go
@@ -135,11 +135,11 @@ func (b *Builder) buildOrdering(
 
 	// Add the new columns to the ordering.
 	for i := start; i < len(orderByScope.cols); i++ {
-		index := orderByScope.cols[i].index
-		if order.Direction == tree.Descending {
-			index = -index
-		}
-		orderByScope.ordering = append(orderByScope.ordering, index)
+		col := opt.MakeOrderingColumn(
+			orderByScope.cols[i].index,
+			order.Direction == tree.Descending,
+		)
+		orderByScope.ordering = append(orderByScope.ordering, col)
 	}
 
 	return projections

--- a/pkg/sql/opt/physical_props_test.go
+++ b/pkg/sql/opt/physical_props_test.go
@@ -48,7 +48,7 @@ func TestPhysicalProps(t *testing.T) {
 	}
 
 	// Add Ordering props.
-	ordering := Ordering{ColumnIndex(1), ColumnIndex(5)}
+	ordering := Ordering{1, 5}
 	props.Ordering = ordering
 	testPhysicalProps(t, props, "p:a:1,b:2 o:+1,+5")
 
@@ -60,7 +60,7 @@ func TestPhysicalProps(t *testing.T) {
 		t.Error("ordering should provide itself")
 	}
 
-	if !ordering.Provides(Ordering{ColumnIndex(1)}) {
+	if !ordering.Provides(Ordering{1}) {
 		t.Error("ordering should provide the prefix ordering")
 	}
 

--- a/pkg/sql/opt/xform/physical_props_factory.go
+++ b/pkg/sql/opt/xform/physical_props_factory.go
@@ -102,11 +102,10 @@ func (f physicalPropsFactory) canProvideOrdering(ev ExprView, required opt.Order
 		ordering := make(opt.Ordering, primary.ColumnCount())
 		for i := 0; i < primary.ColumnCount(); i++ {
 			idxCol := primary.Column(i)
-			ordering[i] = ev.Metadata().TableColumn(tblIdx, idxCol.Ordinal)
-			if idxCol.Descending {
-				// Negative metadata column index indicates descending order.
-				ordering[i] = -ordering[i]
-			}
+			ordering[i] = opt.MakeOrderingColumn(
+				ev.Metadata().TableColumn(tblIdx, idxCol.Ordinal),
+				idxCol.Descending,
+			)
 		}
 
 		return ordering.Provides(required)


### PR DESCRIPTION
Negative ColumnIndex values are normally invalid. But when used in
`Ordering`, negative values indicate a descending ordering.  Make this
special case more explicit by using a different type
`ColumnIndexAndDir`.

Release note: None