### PR TITLE
backport-2.0: sql: fix out-of-bounds access on mismatched INSERTs

### DIFF
--- a/pkg/sql/insert.go
+++ b/pkg/sql/insert.go
@@ -191,11 +191,11 @@ func (p *planner) Insert(
 		// If the insert source was not a VALUES clause, then we have not
 		// already verified the expression length.
 		numExprs := len(planColumns(rows))
-		if numExprs > maxInsertIdx {
-			return nil, cannotWriteToComputedColError(cols[maxInsertIdx])
-		}
 		if err := checkNumExprs(numExprs, numInputColumns, n.Columns != nil); err != nil {
 			return nil, err
+		}
+		if numExprs > maxInsertIdx {
+			return nil, cannotWriteToComputedColError(cols[maxInsertIdx])
 		}
 	}
 

--- a/pkg/sql/logictest/testdata/logic_test/insert
+++ b/pkg/sql/logictest/testdata/logic_test/insert
@@ -388,6 +388,17 @@ SELECT v, k FROM kv5@a
 NULL a
 
 statement error INSERT has more expressions than target columns, 3 expressions for 2 targets
+INSERT INTO kv SELECT 'a', 'b', 'c'
+
+statement error INSERT has more expressions than target columns, 2 expressions for 1 targets
+INSERT INTO kv (k) SELECT 'a', 'b'
+
+statement error INSERT has more target columns than expressions, 1 expressions for 2 targets
+INSERT INTO kv5 (k, v) SELECT 'a'
+
+# INSERT ... VALUES take a separate code path from INSERT ... SELECT.
+
+statement error INSERT has more expressions than target columns, 3 expressions for 2 targets
 INSERT INTO kv VALUES ('a', 'b', 'c')
 
 statement error INSERT has more expressions than target columns, 2 expressions for 1 targets


### PR DESCRIPTION
Backports 1/1 commits from #23637.
		
/cc @cockroachdb/release"

---

Fix a panic while executing queries like

    INSERT INTO (c1) ... SELECT c1, c2

where the number of columns in the data source does not match the number
of columns targeted for insertion. Our existing coverage of mismatched
INSERTS was limited to INSERT INTO ... VALUES, which takes a different
code path.

Fix #23635.

Release note (bug fix): Fix a panic when executing `INSERT INTO ...
SELECT` queries where the number of columns targeted for insertion does
not match the number of columns returned by the SELECT.