### PR TITLE
sql: avoid an unnecessary call to Datum.Eval()

### DIFF
--- a/pkg/sql/insert.go
+++ b/pkg/sql/insert.go
@@ -507,7 +507,7 @@ type rowIndexedVarContainer struct {
 func (r *rowIndexedVarContainer) IndexedVarEval(
 	idx int, ctx *tree.EvalContext,
 ) (tree.Datum, error) {
-	return r.curSourceRow[r.mapping[r.cols[idx].ID]].Eval(ctx)
+	return r.curSourceRow[r.mapping[r.cols[idx].ID]], nil
 }
 
 func (r *rowIndexedVarContainer) IndexedVarResolvedType(idx int) types.T {


### PR DESCRIPTION
Release note: none