### PR TITLE
sql: split the code for UPSERT from the INSERT code

### DIFF
--- a/pkg/sql/copy.go
+++ b/pkg/sql/copy.go
@@ -114,7 +114,8 @@ func newCopyMachine(
 	if err != nil {
 		return nil, err
 	}
-	cols, err := c.p.processColumns(en.tableDesc, n.Columns)
+	cols, err := c.p.processColumns(en.tableDesc, n.Columns,
+		true /* ensureColumns */, false /* allowMutations */)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -394,7 +394,7 @@ func (dsp *DistSQLPlanner) checkSupportForNode(node planNode) (distRecommendatio
 	case *createStatsNode:
 		return shouldDistribute, nil
 
-	case *insertNode, *updateNode, *deleteNode:
+	case *insertNode, *updateNode, *deleteNode, *upsertNode:
 		// This is a potential hot path.
 		return 0, mutationsNotSupportedError
 

--- a/pkg/sql/expand_plan.go
+++ b/pkg/sql/expand_plan.go
@@ -68,6 +68,9 @@ func doExpandPlan(
 	case *insertNode:
 		n.run.rows, err = doExpandPlan(ctx, p, noParams, n.run.rows)
 
+	case *upsertNode:
+		n.run.rows, err = doExpandPlan(ctx, p, noParams, n.run.rows)
+
 	case *deleteNode:
 		n.run.rows, err = doExpandPlan(ctx, p, noParams, n.run.rows)
 
@@ -476,6 +479,9 @@ func (p *planner) simplifyOrderings(plan planNode, usefulOrdering sqlbase.Column
 		n.run.rows = p.simplifyOrderings(n.run.rows, nil)
 
 	case *insertNode:
+		n.run.rows = p.simplifyOrderings(n.run.rows, nil)
+
+	case *upsertNode:
 		n.run.rows = p.simplifyOrderings(n.run.rows, nil)
 
 	case *deleteNode:

--- a/pkg/sql/insert.go
+++ b/pkg/sql/insert.go
@@ -39,23 +39,16 @@ var tableInserterPool = sync.Pool{
 	},
 }
 
-var tableUpserterPool = sync.Pool{
-	New: func() interface{} {
-		return &tableUpserter{}
-	},
-}
-
 type insertNode struct {
 	// The following fields are populated during makePlan.
 	editNodeBase
 	defaultExprs []tree.TypedExpr
 	computeExprs []tree.TypedExpr
-	n            *tree.Insert
 	checkHelper  *sqlbase.CheckHelper
 
 	insertCols   []sqlbase.ColumnDescriptor
 	computedCols []sqlbase.ColumnDescriptor
-	tw           tableWriter
+	tw           tableInserter
 
 	run insertRun
 
@@ -88,15 +81,9 @@ func (p *planner) Insert(
 	if err != nil {
 		return nil, err
 	}
-	isUpsertReturning := false
-	if n.OnConflict != nil {
-		if !n.OnConflict.DoNothing {
-			if err := p.CheckPrivilege(ctx, en.tableDesc, privilege.UPDATE); err != nil {
-				return nil, err
-			}
-		}
-		if _, ok := n.Returning.(*tree.ReturningExprs); ok {
-			isUpsertReturning = true
+	if n.OnConflict != nil && !n.OnConflict.DoNothing {
+		if err := p.CheckPrivilege(ctx, en.tableDesc, privilege.UPDATE); err != nil {
+			return nil, err
 		}
 	}
 
@@ -222,96 +209,46 @@ func (p *planner) Insert(
 		return nil, err
 	}
 
-	var tw tableWriter
-	if n.OnConflict == nil {
-		ti := tableInserterPool.Get().(*tableInserter)
-		*ti = tableInserter{ri: ri}
-		tw = ti
-	} else {
-		updateExprs, conflictIndex, err := upsertExprsAndIndex(en.tableDesc, *n.OnConflict, ri.InsertCols)
-		if err != nil {
-			return nil, err
-		}
-
-		if n.OnConflict.DoNothing {
-			// TODO(dan): Postgres allows ON CONFLICT DO NOTHING without specifying a
-			// conflict index, which means do nothing on any conflict. Support this if
-			// someone needs it.
-			tu := tableUpserterPool.Get().(*tableUpserter)
-			*tu = tableUpserter{
-				ri:            ri,
-				conflictIndex: *conflictIndex,
-				alloc:         &p.alloc,
-				collectRows:   isUpsertReturning,
-			}
-			tw = tu
-		} else {
-			names, err := p.namesForExprs(updateExprs)
-			if err != nil {
-				return nil, err
-			}
-			// Also include columns that are inactive because they should be
-			// updated.
-			updateCols := make([]sqlbase.ColumnDescriptor, len(names))
-			for i, n := range names {
-				col, _, err := en.tableDesc.FindColumnByName(n)
-				if err != nil {
-					return nil, err
-				}
-				updateCols[i] = col
-			}
-
-			// We also need to include any computed columns in the set of UpdateCols.
-			// They can't have been set explicitly so there's no chance of
-			// double-including a computed column.
-
-			// TODO(justin): we should size updateCols appropriately beforehand,
-			// but we'd need to know how many computed columns there are (and it
-			// would be more complicated if we only updated computed columns when
-			// necessary).
-			updateCols = append(updateCols, computedCols...)
-
-			helper, err := p.makeUpsertHelper(
-				ctx, tn, en.tableDesc, ri.InsertCols, updateCols, updateExprs, computeExprs, conflictIndex, n.OnConflict.Where,
-			)
-			if err != nil {
-				return nil, err
-			}
-
-			tu := tableUpserterPool.Get().(*tableUpserter)
-			*tu = tableUpserter{
-				ri:            ri,
-				alloc:         &p.alloc,
-				collectRows:   isUpsertReturning,
-				anyComputed:   len(computeExprs) >= 0,
-				fkTables:      fkTables,
-				updateCols:    updateCols,
-				conflictIndex: *conflictIndex,
-				evaler:        helper,
-				isUpsertAlias: n.OnConflict.IsUpsertAlias(),
-			}
-			tw = tu
-		}
+	if n.OnConflict != nil {
+		return p.newUpsertNode(
+			ctx, n, en, ri, tn, alias, rows,
+			defaultExprs, computeExprs, computedCols, fkTables, desiredTypes)
 	}
+	return newInsertNode(
+		ctx, n, en, ri, alias, rows, defaultExprs, computeExprs, computedCols,
+		fkTables[en.tableDesc.ID].CheckHelper, desiredTypes)
+}
 
+func newInsertNode(
+	ctx context.Context,
+	n *tree.Insert,
+	en editNodeBase,
+	ri sqlbase.RowInserter,
+	alias *tree.TableName,
+	rows planNode,
+	defaultExprs []tree.TypedExpr,
+	computeExprs []tree.TypedExpr,
+	computedCols []sqlbase.ColumnDescriptor,
+	checkHelper *sqlbase.CheckHelper,
+	desiredTypes []types.T,
+) (planNode, error) {
 	in := insertNodePool.Get().(*insertNode)
 	*in = insertNode{
-		n:            n,
 		editNodeBase: en,
 		defaultExprs: defaultExprs,
 		computeExprs: computeExprs,
 		insertCols:   ri.InsertCols,
 		computedCols: computedCols,
-		tw:           tw,
+		tw:           tableInserter{ri: ri},
 		run: insertRun{
 			insertColIDtoRowIndex: ri.InsertColIDtoRowIndex,
-			isUpsertReturning:     isUpsertReturning,
 		},
-		checkHelper: fkTables[en.tableDesc.ID].CheckHelper,
+		checkHelper: checkHelper,
 	}
 
 	if err := in.run.initEditNode(
-		ctx, &in.editNodeBase, rows, in.tw, alias, n.Returning, desiredTypes); err != nil {
+		ctx, &in.editNodeBase, rows, &in.tw, alias, n.Returning, desiredTypes); err != nil {
+		in.Close(ctx)
 		return nil, err
 	}
 
@@ -323,14 +260,10 @@ type insertRun struct {
 	// The following fields are populated during Start().
 	editNodeRun
 
-	isUpsertReturning     bool
 	insertColIDtoRowIndex map[sqlbase.ColumnID]int
 
 	rowIdxToRetIdx []int
 	rowTemplate    tree.Datums
-
-	doneUpserting bool
-	rowsUpserted  *sqlbase.RowContainer
 }
 
 func (n *insertNode) startExec(params runParams) error {
@@ -365,34 +298,10 @@ func (n *insertNode) startExec(params runParams) error {
 	return n.run.tw.init(params.p.txn, params.EvalContext())
 }
 
-func (n *insertNode) Next(params runParams) (bool, error) {
-	if n.run.isUpsertReturning {
-		hasRows, err := n.drain(params)
-		if hasRows {
-			n.run.resultRow = n.run.rowsUpserted.At(0)
-			n.run.rowsUpserted.PopFirst()
-		}
-		return hasRows, err
-	}
-
-	return n.internalNext(params)
-}
-
 func (n *insertNode) Close(ctx context.Context) {
 	n.tw.close(ctx)
-	n.run.rows.Close(ctx)
-	n.run.rows = nil
-	if n.run.rowsUpserted != nil {
-		n.run.rowsUpserted.Close(ctx)
-		n.run.rowsUpserted = nil
-	}
-	switch t := n.tw.(type) {
-	case *tableInserter:
-		*t = tableInserter{}
-		tableInserterPool.Put(t)
-	case *tableUpserter:
-		*t = tableUpserter{}
-		tableUpserterPool.Put(t)
+	if n.run.rows != nil {
+		n.run.rows.Close(ctx)
 	}
 	*n = insertNode{}
 	insertNodePool.Put(n)
@@ -402,52 +311,17 @@ func (n *insertNode) Values() tree.Datums {
 	return n.run.resultRow
 }
 
-// Because TableUpserter batches the upserts, we need to completely drain the
-// source and handle all the rows before returning from the first call to Next,
-// so that we can return an upserted row from each call to Values.
-func (n *insertNode) drain(params runParams) (bool, error) {
-	for !n.run.doneUpserting {
-		_, err := n.internalNext(params)
+func (n *insertNode) Next(params runParams) (bool, error) {
+	if err := params.p.cancelChecker.Check(); err != nil {
+		return false, err
+	}
+	if next, err := n.run.rows.Next(params); !next {
 		if err != nil {
 			return false, err
 		}
-	}
-	hasRows := n.run.rowsUpserted.Len() > 0
-	return hasRows, nil
-}
-
-func (n *insertNode) internalNext(params runParams) (bool, error) {
-	if next, err := n.run.rows.Next(params); !next {
-		if err == nil {
-			if err := params.p.cancelChecker.Check(); err != nil {
-				return false, err
-			}
-			// We're done. Finish the batch.
-			rows, err := n.tw.finalize(
-				params.ctx, n.autoCommit, params.extendedEvalCtx.Tracing.KVTracingEnabled())
-			if err != nil {
-				return false, err
-			}
-
-			if n.run.isUpsertReturning {
-				n.run.rowsUpserted = sqlbase.NewRowContainer(
-					params.EvalContext().Mon.MakeBoundAccount(),
-					sqlbase.ColTypeInfoFromResCols(n.rh.columns),
-					rows.Len(),
-				)
-				for i := 0; i < rows.Len(); i++ {
-					cooked, err := n.rh.cookResultRow(rows.At(i))
-					if err != nil {
-						return false, err
-					}
-					_, err = n.run.rowsUpserted.AddRow(params.ctx, cooked)
-					if err != nil {
-						return false, err
-					}
-				}
-				n.run.doneUpserting = true
-			}
-		}
+		// We're done. Finish the batch.
+		_, err := n.tw.finalize(
+			params.ctx, n.autoCommit, params.extendedEvalCtx.Tracing.KVTracingEnabled())
 		return false, err
 	}
 
@@ -477,12 +351,9 @@ func (n *insertNode) internalNext(params runParams) (bool, error) {
 		return false, err
 	}
 
-	// Handle regular INSERT ... RETURNING without ON CONFLICT clause
-	if !n.run.isUpsertReturning {
-		if n.run.rowTemplate != nil {
-			for i, val := range rowVals {
-				n.run.rowTemplate[n.run.rowIdxToRetIdx[i]] = val
-			}
+	if n.run.rowTemplate != nil {
+		for i, val := range rowVals {
+			n.run.rowTemplate[n.run.rowIdxToRetIdx[i]] = val
 		}
 
 		resultRow, err := n.rh.cookResultRow(n.run.rowTemplate)
@@ -752,10 +623,6 @@ func checkNumExprs(numExprs, numCols int, specifiedTargets bool) error {
 			more, less, numExprs, numCols)
 	}
 	return nil
-}
-
-func (n *insertNode) isUpsert() bool {
-	return n.n.OnConflict != nil
 }
 
 // enableAutoCommit is part of the autoCommitNode interface.

--- a/pkg/sql/logictest/testdata/logic_test/show_trace
+++ b/pkg/sql/logictest/testdata/logic_test/show_trace
@@ -219,21 +219,23 @@ SELECT span, operation, message FROM [SHOW KV TRACE FOR SESSION]
 5  dist sender  querying next range at /Table/52/1/1/0
 5  dist sender  r1: sending batch 1 Put, 1 BeginTxn, 1 EndTxn to (n1,s1):1
 
-# We use SHOW KV TRACE FOR <stmt> here to reveal how the error shows up.
+statement error duplicate key value
+set tracing=kv;
+UPSERT INTO t.kv(k, v) VALUES (2,2)
+
 query ITT
-SELECT span, operation, message FROM [SHOW KV TRACE FOR UPSERT INTO t.kv(k, v) VALUES (2,2)]
+set tracing=off;
+SELECT span, operation, message FROM [SHOW KV TRACE FOR SESSION]
 ----
-2  consuming rows  output row: []
-0  sql txn         Scan /Table/52/1/{2-3}
-3  dist sender     querying next range at /Table/52/1/2
-3  dist sender     r1: sending batch 1 Scan to (n1,s1):1
-0  sql txn         fetched: /kv/primary/2/v -> /3
-0  sql txn         Put /Table/52/1/2/0 -> /TUPLE/2:2:Int/2
-0  sql txn         Del /Table/52/2/3/0
-0  sql txn         CPut /Table/52/2/2/0 -> /BYTES/Š
-5  dist sender     querying next range at /Table/52/1/2/0
-5  dist sender     r1: sending batch 1 Put, 1 CPut, 1 Del, 1 BeginTxn to (n1,s1):1
-2  consuming rows  execution failed: duplicate key value (v)=(2) violates unique constraint "woo"
+2  sql txn      Scan /Table/52/1/{2-3}
+3  dist sender  querying next range at /Table/52/1/2
+3  dist sender  r1: sending batch 1 Scan to (n1,s1):1
+2  sql txn      fetched: /kv/primary/2/v -> /3
+2  sql txn      Put /Table/52/1/2/0 -> /TUPLE/2:2:Int/2
+2  sql txn      Del /Table/52/2/3/0
+2  sql txn      CPut /Table/52/2/2/0 -> /BYTES/Š
+5  dist sender  querying next range at /Table/52/1/2/0
+5  dist sender  r1: sending batch 1 Put, 1 CPut, 1 Del, 1 BeginTxn, 1 EndTxn to (n1,s1):1
 
 query ITT
 SET tracing=kv;

--- a/pkg/sql/logictest/testdata/logic_test/upsert
+++ b/pkg/sql/logictest/testdata/logic_test/upsert
@@ -16,6 +16,9 @@ SELECT * FROM kv ORDER BY (k, v)
 2 2
 3 3
 
+statement error multiple assignments to the same column
+INSERT INTO kv VALUES (4, 4), (2, 5), (6, 6) ON CONFLICT (k) DO UPDATE SET v = 1, v = 1
+
 statement ok
 INSERT INTO kv VALUES (4, 4), (2, 5), (6, 6) ON CONFLICT (k) DO UPDATE SET v = excluded.v
 
@@ -37,6 +40,7 @@ INSERT INTO kv VALUES (4, 10) ON CONFLICT DO UPDATE SET v = kv.v + 20
 statement error duplicate key value \(k\)=\(3\) violates unique constraint "primary"
 INSERT INTO kv VALUES (2, 10) ON CONFLICT (k) DO UPDATE SET k = 3, v = 10
 
+# Until #23660 is fixed.
 statement error UPSERT/ON CONFLICT DO UPDATE command cannot affect row a second time
 UPSERT INTO kv VALUES (10, 10), (10, 11)
 
@@ -49,17 +53,21 @@ INSERT INTO kv VALUES (13, 13), (7, 8) ON CONFLICT (k) DO NOTHING
 statement error there is no unique or exclusion constraint matching the ON CONFLICT specification
 INSERT INTO kv VALUES (13, 13), (7, 8) ON CONFLICT DO NOTHING
 
+# Until #23660 is fixed.
+statement error UPSERT/ON CONFLICT DO UPDATE command cannot affect row a second time
+INSERT INTO kv VALUES (14, 14), (14, 15) ON CONFLICT (k) DO UPDATE SET v = excluded.v + 1
+
 query II
 SELECT * FROM kv ORDER BY (k, v)
 ----
-1 32
-2 5
-3 8
-4 24
-6 6
-7 7
-11 12
-13 13
+1   32
+2   5
+3   8
+4   24
+6   6
+7   7
+11  12
+13  13
 
 query II
 INSERT INTO kv VALUES (10, 10), (11, 11) ON CONFLICT (k) DO UPDATE SET v = excluded.v RETURNING *
@@ -159,6 +167,7 @@ CREATE TABLE excluded (a INT PRIMARY KEY, b INT)
 statement error ambiguous source name: "excluded"
 INSERT INTO excluded VALUES (1, 1) ON CONFLICT (a) DO UPDATE SET b = excluded.b
 
+# Also test the statement is rejected on the fast path.
 statement error ambiguous source name: "excluded"
 UPSERT INTO excluded VALUES (1, 1)
 
@@ -298,17 +307,11 @@ SELECT * FROM issue_14052_2;
 ----
 1  UPDATED  1  2
 
-# Make sure the fast path isn't taken (repeating a column in the ON CONFLICT clause doesn't do anything)
-statement ok
+statement error multiple assignments to the same column
 INSERT INTO issue_14052_2 (id, name, createdAt, updatedAt) VALUES
   (1, 'FOO', 3, 3)
 ON CONFLICT (id) DO UPDATE
   SET id = excluded.id, name = excluded.name, name = excluded.name, name = excluded.name
-
-query ITII
-SELECT * FROM issue_14052_2;
-----
-1  FOO  1  2
 
 # Make sure the fast path isn't taken (all clauses in the set must be of the form x = excluded.x)
 statement ok
@@ -369,7 +372,6 @@ EXPLAIN (PLAN,EXPRS) UPSERT INTO kv TABLE kv ORDER BY v DESC
 ----
 upsert          ·       ·
  │              into    kv(k, v)
- │              eval 0  v
  └── sort       ·       ·
       │         order   -v
       └── scan  ·       ·

--- a/pkg/sql/logictest/testdata/logic_test/upsert
+++ b/pkg/sql/logictest/testdata/logic_test/upsert
@@ -363,3 +363,15 @@ SELECT * FROM issue_17339 ORDER BY a;
 ----
 1 0
 2 1
+
+query TTT
+EXPLAIN (PLAN,EXPRS) UPSERT INTO kv TABLE kv ORDER BY v DESC
+----
+upsert          ·       ·
+ │              into    kv(k, v)
+ │              eval 0  v
+ └── sort       ·       ·
+      │         order   -v
+      └── scan  ·       ·
+·               table   kv@primary
+·               spans   ALL

--- a/pkg/sql/opt_filters.go
+++ b/pkg/sql/opt_filters.go
@@ -271,6 +271,11 @@ func (p *planner) propagateFilters(
 			return plan, extraFilter, err
 		}
 
+	case *upsertNode:
+		if n.run.rows, err = p.triggerFilterPropagation(ctx, n.run.rows); err != nil {
+			return plan, extraFilter, err
+		}
+
 	case *updateNode:
 		if n.run.rows, err = p.triggerFilterPropagation(ctx, n.run.rows); err != nil {
 			return plan, extraFilter, err

--- a/pkg/sql/opt_limits.go
+++ b/pkg/sql/opt_limits.go
@@ -142,6 +142,8 @@ func (p *planner) applyLimit(plan planNode, numRows int64, soft bool) {
 		p.setUnlimited(n.run.rows)
 	case *insertNode:
 		p.setUnlimited(n.run.rows)
+	case *upsertNode:
+		p.setUnlimited(n.run.rows)
 	case *createTableNode:
 		if n.sourcePlan != nil {
 			p.applyLimit(n.sourcePlan, numRows, soft)

--- a/pkg/sql/opt_needed.go
+++ b/pkg/sql/opt_needed.go
@@ -185,6 +185,12 @@ func setNeededColumns(plan planNode, needed []bool) {
 		// foreign key relations and that are not needed for RETURNING.
 		setNeededColumns(n.run.rows, allColumns(n.run.rows))
 
+	case *upsertNode:
+		// TODO(knz): This can be optimized by omitting the columns that
+		// are not part of the primary key, do not participate in
+		// foreign key relations and that are not needed for RETURNING.
+		setNeededColumns(n.run.rows, allColumns(n.run.rows))
+
 	case *splitNode:
 		setNeededColumns(n.rows, allColumns(n.rows))
 

--- a/pkg/sql/plan.go
+++ b/pkg/sql/plan.go
@@ -197,18 +197,20 @@ var _ planNode = &sortNode{}
 var _ planNode = &splitNode{}
 var _ planNode = &unionNode{}
 var _ planNode = &updateNode{}
+var _ planNode = &upsertNode{}
 var _ planNode = &valueGenerator{}
 var _ planNode = &valuesNode{}
 var _ planNode = &windowNode{}
 var _ planNode = &CreateUserNode{}
 var _ planNode = &DropUserNode{}
 
+var _ planNodeFastPath = &CreateUserNode{}
+var _ planNodeFastPath = &DropUserNode{}
 var _ planNodeFastPath = &alterUserSetPasswordNode{}
 var _ planNodeFastPath = &createTableNode{}
-var _ planNodeFastPath = &CreateUserNode{}
 var _ planNodeFastPath = &deleteNode{}
-var _ planNodeFastPath = &DropUserNode{}
 var _ planNodeFastPath = &setZoneConfigNode{}
+var _ planNodeFastPath = &upsertNode{}
 
 // planTop is the struct that collects the properties
 // of an entire plan.

--- a/pkg/sql/plan_columns.go
+++ b/pkg/sql/plan_columns.go
@@ -107,6 +107,8 @@ func getPlanColumns(plan planNode, mut bool) sqlbase.ResultColumns {
 		return n.rh.columns
 	case *updateNode:
 		return n.rh.columns
+	case *upsertNode:
+		return n.rh.columns
 
 	// Nodes that have the same schema as their source or their
 	// valueNode helper.

--- a/pkg/sql/plan_physical_props.go
+++ b/pkg/sql/plan_physical_props.go
@@ -53,8 +53,15 @@ func planPhysicalProps(plan planNode) physicalProps {
 		// TODO(knz): RETURNING is ordered by the PK.
 	case *deleteNode:
 		// TODO(knz): RETURNING is ordered by the PK.
-	case *updateNode:
-		// TODO(knz): RETURNING is ordered by the PK.
+	case *updateNode, *upsertNode:
+		// After an update, the original order may have been destroyed.
+		// For example, if the PK is updated by a SET expression.
+		// So we can't assume any ordering.
+		//
+		// TODO(knz/radu): this can be refined by an analysis which
+		// determines whether the columns that participate in the ordering
+		// of the source are being updated. If they are not, the source
+		// ordering can be propagated.
 
 	case *scanNode:
 		return n.props

--- a/pkg/sql/plan_spans.go
+++ b/pkg/sql/plan_spans.go
@@ -45,13 +45,15 @@ func collectSpans(params runParams, plan planNode) (reads, writes roachpb.Spans,
 	case *updateNode:
 		return editNodeSpans(params, &n.run.editNodeRun)
 	case *insertNode:
-		if v, ok := n.run.editNodeRun.rows.(*valuesNode); ok && !n.isUpsert() {
+		if v, ok := n.run.editNodeRun.rows.(*valuesNode); ok {
 			// subqueries, even within valuesNodes, can be arbitrarily complex,
 			// so we can't run the valuesNode ahead of time if they are present.
 			if v.isConst {
 				return insertNodeWithValuesSpans(params, n, v)
 			}
 		}
+		return editNodeSpans(params, &n.run.editNodeRun)
+	case *upsertNode:
 		return editNodeSpans(params, &n.run.editNodeRun)
 	case *deleteNode:
 		return editNodeSpans(params, &n.run.editNodeRun)

--- a/pkg/sql/tablewriter.go
+++ b/pkg/sql/tablewriter.go
@@ -259,7 +259,7 @@ type tableUpserter struct {
 
 	// These are set for ON CONFLICT DO UPDATE, but not for DO NOTHING
 	updateCols []sqlbase.ColumnDescriptor
-	evaler     tableUpsertEvaler
+	evaler     *upsertHelper
 
 	// Set by init.
 	txn                   *client.Txn
@@ -407,9 +407,8 @@ func (tu *tableUpserter) row(
 		return nil, err
 	}
 
-	_, err := tu.insertRows.AddRow(ctx, row)
 	// TODO(dan): If len(tu.insertRows) > some threshold, call flush().
-	return nil, err
+	return tu.insertRows.AddRow(ctx, row)
 }
 
 // flush commits to tu.txn any rows batched up in tu.insertRows.

--- a/pkg/sql/tablewriter.go
+++ b/pkg/sql/tablewriter.go
@@ -219,9 +219,10 @@ type tableUpsertEvaler interface {
 	// should really be defined as those needed in distributed sql leaf nodes,
 	// which will necessarily include expr evaluation.
 
-	// eval returns the values for the update case of an upsert, given the row
-	// that would have been inserted and the existing (conflicting) values.
-	eval(insertRow tree.Datums, existingRow tree.Datums) (tree.Datums, error)
+	// eval populates into resultRow the values for the update case of
+	// an upsert, given the row that would have been inserted and the
+	// existing (conflicting) values.
+	eval(insertRow, existingRow, resultRow tree.Datums) (tree.Datums, error)
 
 	// evalComputedCols evaluates the computed columns for this upsert using the
 	// values in updatedRow and appends the results, in order, to appendTo,
@@ -235,31 +236,46 @@ type tableUpsertEvaler interface {
 
 // tableUpserter handles writing kvs and forming table rows for upserts.
 //
-// There are two distinct "modes" that tableUpserter can use, one of which is
-// selected during `init`. In the general mode, rows are batched up from calls
-// to `row` and upserted using `flush`, which uses 1 or 2 `client.Batch`s from
-// the init'd txn to fetch the existing (conflicting) values, followed by one
-// more `client.Batch` with the appropriate inserts and updates. In this case,
-// all necessary `client.Batch`s are created and run within the lifetime of
-// `flush`.
+// There are two distinct "modes" that tableUpserter can use, one of
+// which is selected by newUpsertNode(). In the general mode, rows to
+// be inserted are batched up from calls to `row` and then the upsert
+// is processed using finalize(). The other mode is the fast
+// path. See fastTableUpserter below.
 //
-// The other mode is the fast path. If certain conditions are met (no secondary
-// indexes, all table values being inserted, update expressions of the form `SET
-// a = excluded.a`) then the upsert can be done in one `client.Batch` and using
-// only `Put`s. In this case, the single batch is created during `init`,
-// operated on during `row`, and run during `finalize`. This is the same model
-// as the other `tableFoo`s, which are more simple than upsert.
+// In the general mode, the insert rows are accumulated in insertRows.
+// Then during finalize(), the final upsert processing occurs. This
+// uses 1 or 2 `client.Batch`s from the init'd txn to fetch the
+// existing (conflicting) values, followed by one more `client.Batch`
+// with the appropriate inserts and updates. In this case, all
+// necessary `client.Batch`s are created and run within the lifetime
+// of `finalize`.
+//
 type tableUpserter struct {
-	ri            sqlbase.RowInserter
+	ri sqlbase.RowInserter
+
+	// insertRows are the rows produced by the insertion data source.
+	// These are accumulated while iterating on the insertion data source.
+	insertRows sqlbase.RowContainer
+
+	// updateCols indicates which columns need an update during a
+	// conflict.  There is one entry per column descriptors in the
+	// table. However only the entries identified in the conflict clause
+	// of the original statement will be populated, to disambiguate
+	// columns that need an update from those that don't.
+	updateCols []sqlbase.ColumnDescriptor
+
 	conflictIndex sqlbase.IndexDescriptor
-	isUpsertAlias bool
 	alloc         *sqlbase.DatumAlloc
 	collectRows   bool
 	anyComputed   bool
 
 	// These are set for ON CONFLICT DO UPDATE, but not for DO NOTHING
-	updateCols []sqlbase.ColumnDescriptor
-	evaler     *upsertHelper
+	evaler *upsertHelper
+
+	// updateValues is the temporary buffer for rows computed by
+	// evaler.eval(). It is reused from one row to the next to limit
+	// allocations.
+	updateValues tree.Datums
 
 	// Set by init.
 	txn                   *client.Txn
@@ -271,15 +287,10 @@ type tableUpserter struct {
 	fetchColIDtoRowIndex  map[sqlbase.ColumnID]int
 	fetcher               sqlbase.RowFetcher
 
-	// Used for the fast path.
-	fastPathBatch *client.Batch
-	fastPathKeys  map[string]struct{}
-
-	// Batched up in run/flush.
-	insertRows sqlbase.RowContainer
-
 	// Rows returned if collectRows is true.
 	rowsUpserted *sqlbase.RowContainer
+	// rowTemplate is used to prepare rows to add to rowsUpserted.
+	rowTemplate tree.Datums
 
 	// For allocation avoidance.
 	indexKeyPrefix []byte
@@ -302,28 +313,19 @@ func (tu *tableUpserter) init(txn *client.Txn, evalCtx *tree.EvalContext) error 
 		tu.evalCtx.Mon.MakeBoundAccount(), sqlbase.ColTypeInfoFromColDescs(tu.ri.InsertCols), 0,
 	)
 
-	// TODO(dan): The fast path is currently only enabled when the UPSERT alias
-	// is explicitly selected by the user. It's possible to fast path some
-	// queries of the form INSERT ... ON CONFLICT, but the utility is low and
-	// there are lots of edge cases (that caused real correctness bugs #13437
-	// #13962). As a result, we've decided to remove this until after 1.0 and
-	// re-enable it then. See #14482.
-	enableFastPath := tu.isUpsertAlias &&
-		// Tables with secondary indexes are not eligible for fast path (it
-		// would be easy to add the new secondary index entry but we can't clean
-		// up the old one without the previous values).
-		len(tableDesc.Indexes) == 0 &&
-		// When adding or removing a column in a schema change (mutation), the user
-		// can't specify it, which means we need to do a lookup and so we can't use
-		// the fast path. When adding or removing an index, same result, so the fast
-		// path is disabled during all mutations.
-		len(tableDesc.Mutations) == 0 &&
-		// For the fast path, all columns must be specified in the insert.
-		len(tu.ri.InsertCols) == len(tableDesc.Columns)
-	if enableFastPath {
-		tu.fastPathBatch = tu.txn.NewBatch()
-		tu.fastPathKeys = make(map[string]struct{})
-		return nil
+	if tu.collectRows {
+		tu.rowsUpserted = sqlbase.NewRowContainer(
+			tu.evalCtx.Mon.MakeBoundAccount(),
+			sqlbase.ColTypeInfoFromColDescs(tableDesc.Columns),
+			tu.insertRows.Len(),
+		)
+
+		// In some cases (e.g. `INSERT INTO t (a) ...`) rowVals does not contain
+		// all the table columns. We need to pass values for all table columns
+		// to rh, in the correct order; we will use rowTemplate for this. We
+		// also need a table that maps row indices to rowTemplate indices to
+		// fill in the row values; any absent values will be NULLs.
+		tu.rowTemplate = make(tree.Datums, len(tableDesc.Columns))
 	}
 
 	// TODO(dan): This could be made tighter, just the rows needed for the ON
@@ -385,59 +387,18 @@ func (tu *tableUpserter) init(txn *client.Txn, evalCtx *tree.EvalContext) error 
 func (tu *tableUpserter) row(
 	ctx context.Context, row tree.Datums, traceKV bool,
 ) (tree.Datums, error) {
-	if tu.fastPathBatch != nil {
-		tableDesc := tu.tableDesc()
-		primaryKey, _, err := sqlbase.EncodeIndexKey(
-			tableDesc, &tableDesc.PrimaryIndex, tu.ri.InsertColIDtoRowIndex, row, tu.indexKeyPrefix)
-		if err != nil {
-			return nil, err
-		}
-		if _, ok := tu.fastPathKeys[string(primaryKey)]; ok {
-			return nil, fmt.Errorf("UPSERT/ON CONFLICT DO UPDATE command cannot affect row a second time")
-		}
-		tu.fastPathKeys[string(primaryKey)] = struct{}{}
-		err = tu.ri.InsertRow(ctx, tu.fastPathBatch, row, true, sqlbase.CheckFKs, traceKV)
-		if err != nil {
-			return nil, err
-		}
-
-		if tu.collectRows {
-			_, err = tu.insertRows.AddRow(ctx, row)
-		}
-		return nil, err
-	}
-
 	// TODO(dan): If len(tu.insertRows) > some threshold, call flush().
 	return tu.insertRows.AddRow(ctx, row)
 }
 
-// flush commits to tu.txn any rows batched up in tu.insertRows.
-func (tu *tableUpserter) flush(
+// finalize commits to tu.txn any rows batched up in tu.insertRows.
+func (tu *tableUpserter) finalize(
 	ctx context.Context, autoCommit autoCommitOpt, traceKV bool,
 ) (*sqlbase.RowContainer, error) {
 	tableDesc := tu.tableDesc()
 	existingRows, err := tu.fetchExisting(ctx, traceKV)
 	if err != nil {
 		return nil, err
-	}
-
-	var rowTemplate tree.Datums
-	if tu.collectRows {
-		tu.rowsUpserted = sqlbase.NewRowContainer(
-			tu.evalCtx.Mon.MakeBoundAccount(),
-			sqlbase.ColTypeInfoFromColDescs(tableDesc.Columns),
-			tu.insertRows.Len(),
-		)
-
-		// In some cases (e.g. `INSERT INTO t (a) ...`) rowVals does not contain
-		// all the table columns. We need to pass values for all table columns
-		// to rh, in the correct order; we will use rowTemplate for this. We
-		// also need a table that maps row indices to rowTemplate indices to
-		// fill in the row values; any absent values will be NULLs.
-		rowTemplate = make(tree.Datums, len(tableDesc.Columns))
-		for i := range rowTemplate {
-			rowTemplate[i] = tree.DNull
-		}
 	}
 
 	colIDToRetIndex := map[sqlbase.ColumnID]int{}
@@ -462,69 +423,91 @@ func (tu *tableUpserter) flush(
 			}
 
 			if tu.collectRows {
+				// Pre-fill with NULLs.
+				for i := range tu.rowTemplate {
+					tu.rowTemplate[i] = tree.DNull
+				}
+				// Fill the other values from insertRow.
 				for i, val := range insertRow {
-					rowTemplate[rowIdxToRetIdx[i]] = val
+					tu.rowTemplate[rowIdxToRetIdx[i]] = val
 				}
 
-				_, err = tu.rowsUpserted.AddRow(ctx, rowTemplate)
+				_, err = tu.rowsUpserted.AddRow(ctx, tu.rowTemplate)
 				if err != nil {
 					return nil, err
 				}
 			}
 		} else {
-			// If len(tu.updateCols) == 0, then we're in the DO NOTHING case.
-			if len(tu.updateCols) > 0 {
-				existingValues := existingRow[:len(tu.ru.FetchCols)]
-				shouldUpdate, err := tu.evaler.shouldUpdate(insertRow, existingValues)
+			if len(tu.updateCols) == 0 {
+				// If len(tu.updateCols) == 0, then we're in the DO NOTHING case.
+				// There is no update to be done.
+				continue
+			}
+
+			// Check the ON CONFLICT DO UPDATE WHERE ... clause.
+			existingValues := existingRow[:len(tu.ru.FetchCols)]
+			shouldUpdate, err := tu.evaler.shouldUpdate(insertRow, existingValues)
+			if err != nil {
+				return nil, err
+			}
+			if !shouldUpdate {
+				// WHERE tells us there is nothing to do. Stop here.
+				continue
+			}
+
+			// Process the UPDATE ON CONFLICT.
+
+			// First compute all the updates via SET (or the pseudo-SET generated
+			// for UPSERT statements).
+			updateValues, err := tu.evaler.eval(insertRow, existingValues, tu.updateValues)
+			if err != nil {
+				return nil, err
+			}
+
+			// Now (re-)compute computed columns. This appends the computed
+			// columns at the end of updateValues.
+			//
+			// TODO(justin): We're currently wasteful here: we construct the
+			// result row *twice* because we need it once to evaluate any computed
+			// columns and again to actually perform the update. we need to find a
+			// way to reuse it. I'm not sure right now how best to factor this -
+			// suggestions welcome.
+			if tu.anyComputed {
+				newValues := make([]tree.Datum, len(existingValues))
+				copy(newValues, existingValues)
+				for i, updateValue := range updateValues {
+					newValues[tu.ru.FetchColIDtoRowIndex[tu.ru.UpdateCols[i].ID]] = updateValue
+				}
+
+				// Now that we have a complete row except for its computed columns,
+				// since the computed columns are at the end of the update row, we
+				// must evaluate the computed columns and add the results to the end
+				// of updateValues.
+				updateValues, err = tu.evaler.evalComputedCols(newValues, updateValues)
 				if err != nil {
 					return nil, err
-				}
-
-				if !shouldUpdate {
-					continue
-				}
-
-				updateValues, err := tu.evaler.eval(insertRow, existingValues)
-				if err != nil {
-					return nil, err
-				}
-
-				// TODO(justin): We're currently wasteful here: we construct the
-				// result row *twice* because we need it once to evaluate any computed
-				// columns and again to actually perform the update. we need to find a
-				// way to reuse it. I'm not sure right now how best to factor this -
-				// suggestions welcome.
-				if tu.anyComputed {
-					newValues := make([]tree.Datum, len(existingValues))
-					copy(newValues, existingValues)
-					for i, updateValue := range updateValues {
-						newValues[tu.ru.FetchColIDtoRowIndex[tu.ru.UpdateCols[i].ID]] = updateValue
-					}
-
-					// Now that we have a complete row except for its computed columns,
-					// since the computed columns are at the end of the update row, we
-					// must evaluate the computed columns and add the results to the end
-					// of updateValues.
-					updateValues, err = tu.evaler.evalComputedCols(newValues, updateValues)
-					if err != nil {
-						return nil, err
-					}
-				}
-
-				updatedRow, err := tu.ru.UpdateRow(
-					ctx, b, existingValues, updateValues, sqlbase.CheckFKs, traceKV,
-				)
-				if err != nil {
-					return nil, err
-				}
-
-				if tu.collectRows {
-					_, err = tu.rowsUpserted.AddRow(ctx, updatedRow)
-					if err != nil {
-						return nil, err
-					}
 				}
 			}
+
+			// Queue the update in KV. This also returns an "update row"
+			// containing the updated values for every column in the
+			// table. This is useful for RETURNING, which we collect below.
+			updatedRow, err := tu.ru.UpdateRow(
+				ctx, b, existingValues, updateValues, sqlbase.CheckFKs, traceKV,
+			)
+			if err != nil {
+				return nil, err
+			}
+
+			if tu.collectRows {
+				_, err = tu.rowsUpserted.AddRow(ctx, updatedRow)
+				if err != nil {
+					return nil, err
+				}
+			}
+
+			// Keep the slice for reuse.
+			tu.updateValues = updateValues[:0]
 		}
 	}
 
@@ -667,36 +650,6 @@ func (tu *tableUpserter) fetchExisting(ctx context.Context, traceKV bool) ([]tre
 	return rows, nil
 }
 
-// finalize is part of the tableWriter interface.
-func (tu *tableUpserter) finalize(
-	ctx context.Context, autoCommit autoCommitOpt, traceKV bool,
-) (*sqlbase.RowContainer, error) {
-	if tu.fastPathBatch != nil {
-		if autoCommit == autoCommitEnabled {
-			// An auto-txn can commit the transaction with the batch. This is an
-			// optimization to avoid an extra round-trip to the transaction
-			// coordinator.
-			err := tu.txn.CommitInBatch(ctx, tu.fastPathBatch)
-			if err != nil {
-				return nil, err
-			}
-			if tu.collectRows {
-				return &tu.insertRows, nil
-			}
-			return nil, nil
-		}
-		err := tu.txn.Run(ctx, tu.fastPathBatch)
-		if err != nil {
-			return nil, err
-		}
-		if tu.collectRows {
-			return &tu.insertRows, nil
-		}
-		return nil, nil
-	}
-	return tu.flush(ctx, autoCommit, traceKV)
-}
-
 func (tu *tableUpserter) tableDesc() *sqlbase.TableDescriptor {
 	return tu.ri.Helper.TableDesc
 }
@@ -709,6 +662,122 @@ func (tu *tableUpserter) close(ctx context.Context) {
 	tu.insertRows.Close(ctx)
 	if tu.rowsUpserted != nil {
 		tu.rowsUpserted.Close(ctx)
+	}
+}
+
+// fastTableUpserter implements the fast path for an upsert. See
+// tableUpserter above for the general case.
+//
+// If certain conditions are met (no secondary indexes, all table
+// values being inserted, update expressions of the form `SET a =
+// excluded.a`) then the upsert can be done in one `client.Batch` and
+// using only `Put`s. In this case, the single batch is created during
+// `init`, operated on during `row`, and run during `finalize`. This
+// is the same model as the other `tableFoo`s, which are more simple
+// than upsert.
+type fastTableUpserter struct {
+	ri sqlbase.RowInserter
+
+	// collectRows indicates whether the upserted rows should be
+	// collected in the row container.
+	collectRows  bool
+	upsertedRows *sqlbase.RowContainer
+
+	// fastPathKeys and indexKeyPrefix are used to detect that no
+	// duplicate row is being upserted.
+	fastPathKeys   map[string]struct{}
+	indexKeyPrefix []byte
+
+	// Set by init.
+	txn     *client.Txn
+	evalCtx *tree.EvalContext
+
+	// Used for the fast path.
+	fastPathBatch *client.Batch
+}
+
+func (tu *fastTableUpserter) walkExprs(_ func(_ string, _ int, _ tree.TypedExpr)) {}
+
+// init is part of the tableWriter interface.
+func (tu *fastTableUpserter) init(txn *client.Txn, evalCtx *tree.EvalContext) error {
+	tableDesc := tu.tableDesc()
+
+	tu.txn = txn
+	tu.evalCtx = evalCtx
+	tu.indexKeyPrefix = sqlbase.MakeIndexKeyPrefix(tableDesc, tableDesc.PrimaryIndex.ID)
+
+	if tu.collectRows {
+		tu.upsertedRows = sqlbase.NewRowContainer(
+			tu.evalCtx.Mon.MakeBoundAccount(), sqlbase.ColTypeInfoFromColDescs(tu.ri.InsertCols), 0,
+		)
+	}
+
+	tu.fastPathKeys = make(map[string]struct{})
+	tu.fastPathBatch = tu.txn.NewBatch()
+	return nil
+}
+
+// row is part of the tableWriter interface.
+func (tu *fastTableUpserter) row(
+	ctx context.Context, row tree.Datums, traceKV bool,
+) (tree.Datums, error) {
+	tableDesc := tu.tableDesc()
+
+	// Verify we are not upserting a duplicate.
+	primaryKey, _, err := sqlbase.EncodeIndexKey(
+		tableDesc, &tableDesc.PrimaryIndex, tu.ri.InsertColIDtoRowIndex, row, tu.indexKeyPrefix)
+	if err != nil {
+		return nil, err
+	}
+	if _, ok := tu.fastPathKeys[string(primaryKey)]; ok {
+		return nil, fmt.Errorf("UPSERT/ON CONFLICT DO UPDATE command cannot affect row a second time")
+	}
+	tu.fastPathKeys[string(primaryKey)] = struct{}{}
+
+	// Use the fast path, ignore conflicts.
+	if err := tu.ri.InsertRow(
+		ctx, tu.fastPathBatch, row, true /* ignoreConflicts */, sqlbase.CheckFKs, traceKV); err != nil {
+		return nil, err
+	}
+
+	if tu.collectRows {
+		_, err = tu.upsertedRows.AddRow(ctx, row)
+	}
+	return nil, err
+}
+
+// finalize is part of the tableWriter interface.
+func (tu *fastTableUpserter) finalize(
+	ctx context.Context, autoCommit autoCommitOpt, traceKV bool,
+) (*sqlbase.RowContainer, error) {
+	if autoCommit == autoCommitEnabled {
+		// An auto-txn can commit the transaction with the batch. This is an
+		// optimization to avoid an extra round-trip to the transaction
+		// coordinator.
+		if err := tu.txn.CommitInBatch(ctx, tu.fastPathBatch); err != nil {
+			return nil, err
+		}
+	} else {
+		if err := tu.txn.Run(ctx, tu.fastPathBatch); err != nil {
+			return nil, err
+		}
+	}
+
+	return tu.upsertedRows, nil
+}
+
+func (tu *fastTableUpserter) fkSpanCollector() sqlbase.FkSpanCollector {
+	return tu.ri.Fks
+}
+
+func (tu *fastTableUpserter) tableDesc() *sqlbase.TableDescriptor {
+	return tu.ri.Helper.TableDesc
+}
+
+func (tu *fastTableUpserter) close(ctx context.Context) {
+	if tu.upsertedRows != nil {
+		tu.upsertedRows.Close(ctx)
+		tu.upsertedRows = nil
 	}
 }
 

--- a/pkg/sql/update.go
+++ b/pkg/sql/update.go
@@ -99,7 +99,8 @@ func (p *planner) Update(
 		return nil, err
 	}
 
-	updateCols, err := p.processColumns(en.tableDesc, names)
+	updateCols, err := p.processColumns(en.tableDesc, names,
+		true /* ensureColumns */, false /* allowMutations */)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/upsert.go
+++ b/pkg/sql/upsert.go
@@ -17,12 +17,305 @@ package sql
 import (
 	"context"
 	"fmt"
+	"sync"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/util"
 )
+
+var upsertNodePool = sync.Pool{
+	New: func() interface{} {
+		return &upsertNode{}
+	},
+}
+
+type upsertNode struct {
+	// The following fields are populated during makePlan.
+	editNodeBase
+	defaultExprs []tree.TypedExpr
+	computeExprs []tree.TypedExpr
+	checkHelper  *sqlbase.CheckHelper
+
+	insertCols   []sqlbase.ColumnDescriptor
+	computedCols []sqlbase.ColumnDescriptor
+	tw           tableWriter
+
+	run upsertRun
+
+	autoCommit autoCommitOpt
+}
+
+// upsertNode implements the autoCommitNode interface.
+var _ autoCommitNode = &upsertNode{}
+
+func (p *planner) newUpsertNode(
+	ctx context.Context,
+	n *tree.Insert,
+	en editNodeBase,
+	ri sqlbase.RowInserter,
+	tn, alias *tree.TableName,
+	rows planNode,
+	defaultExprs []tree.TypedExpr,
+	computeExprs []tree.TypedExpr,
+	computedCols []sqlbase.ColumnDescriptor,
+	fkTables sqlbase.TableLookupsByID,
+	desiredTypes []types.T,
+) (res planNode, err error) {
+	updateExprs, conflictIndex, err := upsertExprsAndIndex(en.tableDesc, *n.OnConflict, ri.InsertCols)
+	if err != nil {
+		return nil, err
+	}
+
+	needRows := false
+	if _, ok := n.Returning.(*tree.ReturningExprs); ok {
+		needRows = true
+	}
+
+	un := upsertNodePool.Get().(*upsertNode)
+	*un = upsertNode{
+		editNodeBase: en,
+		defaultExprs: defaultExprs,
+		computeExprs: computeExprs,
+		insertCols:   ri.InsertCols,
+		computedCols: computedCols,
+		run: upsertRun{
+			insertColIDtoRowIndex: ri.InsertColIDtoRowIndex,
+		},
+		checkHelper: fkTables[en.tableDesc.ID].CheckHelper,
+	}
+	defer func() {
+		if err != nil {
+			un.Close(ctx)
+		}
+	}()
+
+	if n.OnConflict.DoNothing {
+		// TODO(dan): Postgres allows ON CONFLICT DO NOTHING without specifying a
+		// conflict index, which means do nothing on any conflict. Support this if
+		// someone needs it.
+		un.tw = &tableUpserter{
+			ri:            ri,
+			conflictIndex: *conflictIndex,
+			collectRows:   needRows,
+			alloc:         &p.alloc,
+		}
+	} else {
+		names, err := p.namesForExprs(updateExprs)
+		if err != nil {
+			return nil, err
+		}
+		// Also include columns that are inactive because they should be
+		// updated.
+		updateCols := make([]sqlbase.ColumnDescriptor, len(names))
+		for i, n := range names {
+			col, _, err := en.tableDesc.FindColumnByName(n)
+			if err != nil {
+				return nil, err
+			}
+			updateCols[i] = col
+		}
+
+		// We also need to include any computed columns in the set of UpdateCols.
+		// They can't have been set explicitly so there's no chance of
+		// double-including a computed column.
+
+		// TODO(justin): we should size updateCols appropriately beforehand,
+		// but we'd need to know how many computed columns there are (and it
+		// would be more complicated if we only updated computed columns when
+		// necessary).
+		updateCols = append(updateCols, computedCols...)
+
+		helper, err := p.newUpsertHelper(
+			ctx, tn, en.tableDesc, ri.InsertCols, updateCols, updateExprs, computeExprs, conflictIndex, n.OnConflict.Where,
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		un.tw = &tableUpserter{
+			ri:            ri,
+			alloc:         &p.alloc,
+			anyComputed:   len(computeExprs) >= 0,
+			fkTables:      fkTables,
+			updateCols:    updateCols,
+			conflictIndex: *conflictIndex,
+			collectRows:   needRows,
+			evaler:        helper,
+			isUpsertAlias: n.OnConflict.IsUpsertAlias(),
+		}
+	}
+
+	if err := un.run.initEditNode(
+		ctx, &un.editNodeBase, rows, un.tw, alias, n.Returning, desiredTypes); err != nil {
+		return nil, err
+	}
+
+	return un, nil
+}
+
+func (n *upsertNode) Close(ctx context.Context) {
+	if n.tw != nil {
+		n.tw.close(ctx)
+	}
+	if n.run.rows != nil {
+		n.run.rows.Close(ctx)
+	}
+	if n.run.rowsUpserted != nil {
+		n.run.rowsUpserted.Close(ctx)
+		n.run.rowsUpserted = nil
+	}
+	*n = upsertNode{}
+	upsertNodePool.Put(n)
+}
+
+// upsertRun contains the run-time state of upsertNode during local execution.
+type upsertRun struct {
+	// The following fields are populated during Start().
+	editNodeRun
+
+	insertColIDtoRowIndex map[sqlbase.ColumnID]int
+
+	rowIdxToRetIdx []int
+	rowTemplate    tree.Datums
+
+	rowsUpserted *sqlbase.RowContainer
+
+	numRows   int
+	curRowIdx int
+}
+
+func (n *upsertNode) startExec(params runParams) error {
+	if n.rh.exprs != nil {
+		// In some cases (e.g. `INSERT INTO t (a) ...`) rowVals does not contain all the table
+		// columns. We need to pass values for all table columns to rh, in the correct order; we
+		// will use rowTemplate for this. We also need a table that maps row indices to rowTemplate indices
+		// to fill in the row values; any absent values will be NULLs.
+		n.run.rowTemplate = make(tree.Datums, len(n.tableDesc.Columns))
+		for i := range n.run.rowTemplate {
+			n.run.rowTemplate[i] = tree.DNull
+		}
+
+		colIDToRetIndex := map[sqlbase.ColumnID]int{}
+		for i, col := range n.tableDesc.Columns {
+			colIDToRetIndex[col.ID] = i
+		}
+
+		n.run.rowIdxToRetIdx = make([]int, len(n.insertCols))
+		for i, col := range n.insertCols {
+			n.run.rowIdxToRetIdx[i] = colIDToRetIndex[col.ID]
+		}
+
+		n.run.rowsUpserted = sqlbase.NewRowContainer(
+			params.EvalContext().Mon.MakeBoundAccount(),
+			sqlbase.ColTypeInfoFromResCols(n.rh.columns),
+			0,
+		)
+	}
+
+	if err := n.run.startEditNode(params, &n.editNodeBase); err != nil {
+		return err
+	}
+
+	if err := n.run.tw.init(params.p.txn, params.EvalContext()); err != nil {
+		return err
+	}
+
+	// Do all the work upfront.
+	for {
+		next, err := n.internalNext(params)
+		if err != nil {
+			return err
+		}
+		if !next {
+			break
+		}
+	}
+	// Initialize the current row index for the first call to Next().
+	n.run.curRowIdx = -1
+	return nil
+}
+
+func (n *upsertNode) FastPathResults() (int, bool) {
+	if n.run.rowsUpserted != nil {
+		return 0, false
+	}
+	return n.run.numRows, true
+}
+
+func (n *upsertNode) Next(params runParams) (bool, error) {
+	if n.run.rowsUpserted == nil {
+		return false, nil
+	}
+	n.run.curRowIdx++
+	return n.run.curRowIdx < n.run.rowsUpserted.Len(), nil
+}
+
+func (n *upsertNode) internalNext(params runParams) (bool, error) {
+	if err := params.p.cancelChecker.Check(); err != nil {
+		return false, err
+	}
+	if next, err := n.run.rows.Next(params); !next {
+		if err != nil {
+			return false, err
+		}
+		// We're done. Finish the batch.
+		rows, err := n.tw.finalize(
+			params.ctx, n.autoCommit, params.extendedEvalCtx.Tracing.KVTracingEnabled())
+		if err != nil {
+			return false, err
+		}
+
+		if n.run.rowsUpserted != nil {
+			for i := 0; i < rows.Len(); i++ {
+				cooked, err := n.rh.cookResultRow(rows.At(i))
+				if err != nil {
+					return false, err
+				}
+				_, err = n.run.rowsUpserted.AddRow(params.ctx, cooked)
+				if err != nil {
+					return false, err
+				}
+			}
+		}
+		return false, nil
+	}
+
+	n.run.numRows++
+	rowVals, err := GenerateInsertRow(
+		n.defaultExprs,
+		n.computeExprs,
+		n.run.insertColIDtoRowIndex,
+		n.insertCols,
+		n.computedCols,
+		*params.EvalContext(),
+		n.tableDesc,
+		n.run.rows.Values(),
+	)
+	if err != nil {
+		return false, err
+	}
+
+	if err := n.checkHelper.LoadRow(n.run.insertColIDtoRowIndex, rowVals, false); err != nil {
+		return false, err
+	}
+	if err := n.checkHelper.Check(params.EvalContext()); err != nil {
+		return false, err
+	}
+
+	_, err = n.tw.row(params.ctx, rowVals, params.extendedEvalCtx.Tracing.KVTracingEnabled())
+	return err == nil, err
+}
+
+func (n *upsertNode) Values() tree.Datums {
+	return n.run.rowsUpserted.At(n.run.curRowIdx)
+}
+
+// enableAutoCommit is part of the autoCommitNode interface.
+func (n *upsertNode) enableAutoCommit() {
+	n.autoCommit = autoCommitEnabled
+}
 
 // upsertExcludedTable is the name of a synthetic table used in an upsert's set
 // expressions to refer to the values that would be inserted for a row if it
@@ -82,7 +375,7 @@ func (uh *upsertHelper) IndexedVarNodeFormatter(idx int) tree.NodeFormatter {
 	return uh.sourceInfo.NodeFormatter(idx)
 }
 
-func (p *planner) makeUpsertHelper(
+func (p *planner) newUpsertHelper(
 	ctx context.Context,
 	tn *tree.TableName,
 	tableDesc *sqlbase.TableDescriptor,

--- a/pkg/sql/upsert.go
+++ b/pkg/sql/upsert.go
@@ -63,16 +63,21 @@ func (p *planner) newUpsertNode(
 	fkTables sqlbase.TableLookupsByID,
 	desiredTypes []types.T,
 ) (res planNode, err error) {
+	// Extract the index that will detect upsert conflicts
+	// (conflictIndex) and the assignment expressions to use when
+	// conflicts are detected (updateExprs).
 	updateExprs, conflictIndex, err := upsertExprsAndIndex(en.tableDesc, *n.OnConflict, ri.InsertCols)
 	if err != nil {
 		return nil, err
 	}
 
+	// needRows determines whether we need to accumulate result rows.
 	needRows := false
 	if _, ok := n.Returning.(*tree.ReturningExprs); ok {
 		needRows = true
 	}
 
+	// Instantiate the upsert node.
 	un := upsertNodePool.Get().(*upsertNode)
 	*un = upsertNode{
 		editNodeBase: en,
@@ -86,6 +91,9 @@ func (p *planner) newUpsertNode(
 		checkHelper: fkTables[en.tableDesc.ID].CheckHelper,
 	}
 	defer func() {
+		// If anything below fails, we don't want to leak
+		// resources. Ensure the thing is always closed and put back to
+		// its alloc pool.
 		if err != nil {
 			un.Close(ctx)
 		}
@@ -102,51 +110,96 @@ func (p *planner) newUpsertNode(
 			alloc:         &p.alloc,
 		}
 	} else {
+		// We're going to work on allocating an upsertHelper here, even
+		// though it might end up not being used below in this fast
+		// path. This is because this also performs a semantic check, that
+		// the upsert column references are not ambiguous (in particular,
+		// this rejects attempts to upsert into a table called "excluded"
+		// without an AS clause).
+
+		// Determine which columns are updated by the RHS of INSERT
+		// ... ON CONFLICT DO UPDATE, or the non-PK columns in an
+		// UPSERT.
 		names, err := p.namesForExprs(updateExprs)
 		if err != nil {
 			return nil, err
 		}
-		// Also include columns that are inactive because they should be
-		// updated.
-		updateCols := make([]sqlbase.ColumnDescriptor, len(names))
-		for i, n := range names {
-			col, _, err := en.tableDesc.FindColumnByName(n)
-			if err != nil {
-				return nil, err
-			}
-			updateCols[i] = col
+
+		// We use ensureColumns = false in processColumns, because
+		// updateCols may be legitimately empty (when there is no DO
+		// UPDATE clause). We set allowMutations because we need
+		// to populate all columns even those that are being added.
+		updateCols, err := p.processColumns(en.tableDesc, names,
+			false /* ensureColumns */, true /* allowMutations */)
+		if err != nil {
+			return nil, err
 		}
 
 		// We also need to include any computed columns in the set of UpdateCols.
 		// They can't have been set explicitly so there's no chance of
 		// double-including a computed column.
-
-		// TODO(justin): we should size updateCols appropriately beforehand,
-		// but we'd need to know how many computed columns there are (and it
-		// would be more complicated if we only updated computed columns when
-		// necessary).
 		updateCols = append(updateCols, computedCols...)
 
+		// Instantiate the helper that will take over the evaluation of
+		// SQL expressions. As described above, this also performs a
+		// semantic check, so it cannot be skipped on the fast path below.
 		helper, err := p.newUpsertHelper(
-			ctx, tn, en.tableDesc, ri.InsertCols, updateCols, updateExprs, computeExprs, conflictIndex, n.OnConflict.Where,
+			ctx, tn, en.tableDesc,
+			ri.InsertCols,
+			updateCols,
+			updateExprs,
+			computeExprs,
+			conflictIndex,
+			n.OnConflict.Where,
 		)
 		if err != nil {
 			return nil, err
 		}
 
-		un.tw = &tableUpserter{
-			ri:            ri,
-			alloc:         &p.alloc,
-			anyComputed:   len(computeExprs) >= 0,
-			fkTables:      fkTables,
-			updateCols:    updateCols,
-			conflictIndex: *conflictIndex,
-			collectRows:   needRows,
-			evaler:        helper,
-			isUpsertAlias: n.OnConflict.IsUpsertAlias(),
+		// Determine whether to use the fast path or the slow path.
+		// TODO(dan): The fast path is currently only enabled when the UPSERT alias
+		// is explicitly selected by the user. It's possible to fast path some
+		// queries of the form INSERT ... ON CONFLICT, but the utility is low and
+		// there are lots of edge cases (that caused real correctness bugs #13437
+		// #13962). As a result, we've decided to remove this until after 1.0 and
+		// re-enable it then. See #14482.
+		enableFastPath := n.OnConflict.IsUpsertAlias() &&
+			// Tables with secondary indexes are not eligible for fast path (it
+			// would be easy to add the new secondary index entry but we can't clean
+			// up the old one without the previous values).
+			len(en.tableDesc.Indexes) == 0 &&
+			// When adding or removing a column in a schema change (mutation), the user
+			// can't specify it, which means we need to do a lookup and so we can't use
+			// the fast path. When adding or removing an index, same result, so the fast
+			// path is disabled during all mutations.
+			len(en.tableDesc.Mutations) == 0 &&
+			// For the fast path, all columns must be specified in the insert.
+			len(ri.InsertCols) == len(en.tableDesc.Columns)
+
+		if enableFastPath {
+			// We then use the super-simple, super-fast writer. There's not
+			// much else to prepare.
+			un.tw = &fastTableUpserter{
+				ri:          ri,
+				collectRows: needRows,
+			}
+		} else {
+			// General/slow path.
+			un.tw = &tableUpserter{
+				ri:            ri,
+				alloc:         &p.alloc,
+				anyComputed:   len(computeExprs) >= 0,
+				fkTables:      fkTables,
+				updateCols:    updateCols,
+				conflictIndex: *conflictIndex,
+				collectRows:   needRows,
+				evaler:        helper,
+			}
 		}
 	}
 
+	// Common initialization in any case, includes setting up the
+	// returning helper.
 	if err := un.run.initEditNode(
 		ctx, &un.editNodeBase, rows, un.tw, alias, n.Returning, desiredTypes); err != nil {
 		return nil, err
@@ -323,20 +376,66 @@ func (n *upsertNode) enableAutoCommit() {
 // Example: `INSERT INTO kv VALUES (1, 2) ON CONFLICT (k) DO UPDATE SET v = excluded.v`
 var upsertExcludedTable = tree.MakeUnqualifiedTableName("excluded")
 
+// upsertHelper is the helper struct in charge of evaluating SQL
+// expression during an UPSERT. Its main responsibilities are:
+//
+// - eval(): compute the UPDATE statements given the previous and new values,
+//   for INSERT ... ON CONFLICT DO UPDATE SET ...
+//
+// - evalComputedCols(): evaluate and add the computed columns
+//   to the current upserted row.
+//
+// - shouldUpdate(): evaluates the WHERE clause of an ON CONFLICT
+//   ... DO UPDATE clause.
+//
+// See the tableUpsertEvaler interface definition in tablewriter.go.
 type upsertHelper struct {
-	p                  *planner
-	evalExprs          []tree.TypedExpr
-	whereExpr          tree.TypedExpr
-	sourceInfo         *sqlbase.DataSourceInfo
+	// p is used to provide an evalContext.
+	p *planner
+
+	// evalExprs contains the individual columns of SET RHS in an ON
+	// CONFLICT DO UPDATE clause.
+	// This decomposes tuple assignments, e.g. DO UPDATE SET (a,b) = (x,y)
+	// into their individual expressions, in this case x, y.
+	//
+	// Its entries correspond 1-to-1 to the columns in
+	// tableUpserter.updateCols.
+	//
+	// This is the main input for eval().
+	evalExprs []tree.TypedExpr
+
+	// whereExpr is the RHS of an ON CONFLICT DO UPDATE SET ... WHERE <expr>.
+	// This is the main input for shouldUpdate().
+	whereExpr tree.TypedExpr
+
+	// sourceInfo describes the columns provided by the table being
+	// upserted into.
+	sourceInfo *sqlbase.DataSourceInfo
+	// excludedSourceInfo describes the columns provided by the values
+	// being upserted. This may be fewer columns than the
+	// table, for example:
+	// INSERT INTO kv(k) VALUES (3) ON CONFLICT(k) DO UPDATE SET v = excluded.v;
+	//        invalid, value v is not part of the source in VALUES   ^^^^^^^^^^
 	excludedSourceInfo *sqlbase.DataSourceInfo
-	curSourceRow       tree.Datums
-	curExcludedRow     tree.Datums
 
-	ivarHelper *tree.IndexedVarHelper
+	// curSourceRow buffers the current values from the table during
+	// an upsert conflict. Used as input when evaluating
+	// evalExprs and whereExpr.
+	curSourceRow tree.Datums
+	// curExcludedRow buffers the current values being upserted
+	// during an upsert conflict. Used as input when evaluating
+	// evalExprs and whereExpr.
+	curExcludedRow tree.Datums
 
-	ccIvarContainer *rowIndexedVarContainer
-	ccIvarHelper    *tree.IndexedVarHelper
-	computeExprs    []tree.TypedExpr
+	// computeExprs is the list of expressions to (re-)compute computed
+	// columns.
+	// This is the main input for evalComputedCols().
+	computeExprs []tree.TypedExpr
+
+	// ccIvarContainer buffers the current values after the upsert
+	// conflict resolution, to serve as input while evaluating
+	// computeExprs.
+	ccIvarContainer rowIndexedVarContainer
 
 	// This struct must be allocated on the heap and its location stay
 	// stable after construction because it implements
@@ -375,6 +474,12 @@ func (uh *upsertHelper) IndexedVarNodeFormatter(idx int) tree.NodeFormatter {
 	return uh.sourceInfo.NodeFormatter(idx)
 }
 
+// newUpsertHelper instantiates an upsertHelper based on the extracted
+// metadata.
+// It needs to prepare three things:
+// - the RHS expressions of UPDATE SET ... (evalExprs)
+// - the UPDATE WHERE clause, if any (whereExpr)
+// - the computed expressions, if any (computeExprs).
 func (p *planner) newUpsertHelper(
 	ctx context.Context,
 	tn *tree.TableName,
@@ -386,12 +491,29 @@ func (p *planner) newUpsertHelper(
 	upsertConflictIndex *sqlbase.IndexDescriptor,
 	whereClause *tree.Where,
 ) (*upsertHelper, error) {
+	// Extract the parsed default expressions for every updated
+	// column. This populates nil for every entry in updateCols which
+	// has no default.
 	defaultExprs, err := sqlbase.MakeDefaultExprs(
 		updateCols, &p.txCtx, p.EvalContext())
 	if err != nil {
 		return nil, err
 	}
 
+	// Flatten any tuple assignment in the UPDATE SET clause(s).
+	//
+	// For example, if we have two tuple assignments like SET (a,b) =
+	// (c,d), (x,y) = (u,v), we turn this into four expressions
+	// [c,d,u,v] in untupledExprs.
+	//
+	// If any of the RHS expressions is the special DEFAULT keyword,
+	// we substitute the default expression computed above.
+	//
+	// This works because the LHS of each SET clause has already been
+	// untupled by the caller, so that for the example above updateCols
+	// contains the metadata for [a,b,c,d] already, so there's always
+	// exactly one entry in defaultExprs for the untuplification to
+	// find.
 	untupledExprs := make(tree.Exprs, 0, len(updateExprs))
 	i := 0
 	for _, updateExpr := range updateExprs {
@@ -410,51 +532,75 @@ func (p *planner) newUpsertHelper(
 		}
 	}
 
-	sourceInfo := sqlbase.NewSourceInfoForSingleTable(
+	// At this point, the entries in updateCols and untupledExprs match
+	// 1-to-1.
+
+	// Start preparing the helper.
+	//
+	// We need to allocate early because the ivarHelper below needs a
+	// heap reference to inject in the resolved indexed vars.
+	helper := &upsertHelper{p: p, computeExprs: computeExprs}
+
+	// Now on to analyze the evalExprs and the whereExpr.  These can
+	// refer to both the original table and the upserted values, so they
+	// need a double dataSourceInfo.
+
+	// sourceInfo describes the columns provided by the table.
+	helper.sourceInfo = sqlbase.NewSourceInfoForSingleTable(
 		*tn, sqlbase.ResultColumnsFromColDescs(tableDesc.Columns),
 	)
-	excludedSourceInfo := sqlbase.NewSourceInfoForSingleTable(
+	// excludedSourceInfo describes the columns provided by the
+	// insert/upsert data source. This will be used to resolve
+	// expressions of the form `excluded.x`, which refer to the values
+	// coming from the data source.
+	helper.excludedSourceInfo = sqlbase.NewSourceInfoForSingleTable(
 		upsertExcludedTable, sqlbase.ResultColumnsFromColDescs(insertCols),
 	)
 
-	helper := &upsertHelper{
-		p:                  p,
-		sourceInfo:         sourceInfo,
-		excludedSourceInfo: excludedSourceInfo,
-	}
+	// Name resolution needs a multi-source which knows both about the
+	// table being upsert into which contains values pre-upsert, and a
+	// pseudo-table "excluded" which will contain values from the upsert
+	// data source.
+	sources := sqlbase.MultiSourceInfo{helper.sourceInfo, helper.excludedSourceInfo}
 
-	var evalExprs []tree.TypedExpr
-	ivarHelper := tree.MakeIndexedVarHelper(helper, len(sourceInfo.SourceColumns)+len(excludedSourceInfo.SourceColumns))
-	sources := sqlbase.MultiSourceInfo{sourceInfo, excludedSourceInfo}
+	// Prepare the ivarHelper which connects the indexed vars
+	// back to this helper.
+	ivarHelper := tree.MakeIndexedVarHelper(helper,
+		len(helper.sourceInfo.SourceColumns)+len(helper.excludedSourceInfo.SourceColumns))
+
+	// Start with evalExprs, which will contain all the RHS expressions
+	// of UPDATE SET clauses. Again, evalExprs will contain one entry
+	// per column in updateCols and untupledExprs.
+	helper.evalExprs = make([]tree.TypedExpr, len(untupledExprs))
 	for i, expr := range untupledExprs {
-		typ := updateCols[i].Type.ToDatumType()
-		normExpr, err := p.analyzeExpr(ctx, expr, sources, ivarHelper, typ, true, "ON CONFLICT")
+		// Analyze the expression.
+
+		// We require the type from the column descriptor.
+		desiredType := updateCols[i].Type.ToDatumType()
+
+		// Resolve names, type and normalize.
+		normExpr, err := p.analyzeExpr(
+			ctx, expr, sources, ivarHelper, desiredType, true /* requireType */, "ON CONFLICT")
 		if err != nil {
 			return nil, err
 		}
-		evalExprs = append(evalExprs, normExpr)
-	}
-	helper.ivarHelper = &ivarHelper
-	helper.evalExprs = evalExprs
 
-	// We need this IVarContainer to be able to evaluate the computed columns for each row.
-	// Since we just have the entire row, this is just the identity mapping.
-	mapping := make(map[sqlbase.ColumnID]int)
-	for i, c := range tableDesc.Columns {
-		mapping[c.ID] = i
-	}
-	helper.ccIvarContainer = &rowIndexedVarContainer{
-		cols:    tableDesc.Columns,
-		mapping: mapping,
-	}
-	ccIvarHelper := tree.MakeIndexedVarHelper(helper.ccIvarContainer, len(sourceInfo.SourceColumns))
-	helper.ccIvarHelper = &ccIvarHelper
-	helper.computeExprs = computeExprs
+		// Make sure there are no aggregation/window functions in the
+		// expression (after subqueries have been expanded).
+		if err := p.txCtx.AssertNoAggregationOrWindowing(
+			normExpr, "ON CONFLICT", p.SessionData().SearchPath,
+		); err != nil {
+			return nil, err
+		}
 
+		helper.evalExprs[i] = normExpr
+	}
+
+	// If there's a conflict WHERE clause, analyze it.
 	if whereClause != nil {
+		// Resolve names, type and normalize.
 		whereExpr, err := p.analyzeExpr(
-			ctx, whereClause.Expr, sources, ivarHelper, types.Bool, true /* requireType */, "WHERE",
-		)
+			ctx, whereClause.Expr, sources, ivarHelper, types.Bool, true /* requireType */, "WHERE")
 		if err != nil {
 			return nil, err
 		}
@@ -462,12 +608,26 @@ func (p *planner) newUpsertHelper(
 		// Make sure there are no aggregation/window functions in the filter
 		// (after subqueries have been expanded).
 		if err := p.txCtx.AssertNoAggregationOrWindowing(
-			whereExpr, "WHERE", p.SessionData().SearchPath,
+			whereExpr, "ON CONFLICT...WHERE", p.SessionData().SearchPath,
 		); err != nil {
 			return nil, err
 		}
 
 		helper.whereExpr = whereExpr
+	}
+
+	// To (re-)compute computed columns, we use a 1-row buffer with an
+	// IVarContainer interface (a rowIndexedVarContainer).
+	//
+	// This will use the layout from the table columns. The mapping from
+	// column IDs to row datum positions is straightforward.
+	mapping := make(map[sqlbase.ColumnID]int)
+	for i, c := range tableDesc.Columns {
+		mapping[c.ID] = i
+	}
+	helper.ccIvarContainer = rowIndexedVarContainer{
+		cols:    tableDesc.Columns,
+		mapping: mapping,
 	}
 
 	return helper, nil
@@ -481,22 +641,23 @@ func (uh *upsertHelper) walkExprs(walk func(desc string, index int, expr tree.Ty
 
 // eval returns the values for the update case of an upsert, given the row
 // that would have been inserted and the existing (conflicting) values.
-func (uh *upsertHelper) eval(insertRow tree.Datums, existingRow tree.Datums) (tree.Datums, error) {
+func (uh *upsertHelper) eval(insertRow, existingRow, resultRow tree.Datums) (tree.Datums, error) {
+	// Buffer the rows.
 	uh.curSourceRow = existingRow
 	uh.curExcludedRow = insertRow
 
-	var err error
-	ret := make([]tree.Datum, len(uh.evalExprs))
-	uh.p.extendedEvalCtx.PushIVarContainer(uh.ivarHelper.Container())
-	defer func() { uh.p.extendedEvalCtx.PopIVarContainer() }()
-	for i, evalExpr := range uh.evalExprs {
-		ret[i], err = evalExpr.Eval(uh.p.EvalContext())
+	// Evaluate the update expressions.
+	uh.p.EvalContext().PushIVarContainer(uh)
+	defer func() { uh.p.EvalContext().PopIVarContainer() }()
+	for _, evalExpr := range uh.evalExprs {
+		res, err := evalExpr.Eval(uh.p.EvalContext())
 		if err != nil {
 			return nil, err
 		}
+		resultRow = append(resultRow, res)
 	}
 
-	return ret, nil
+	return resultRow, nil
 }
 
 // evalComputedCols handles after we've figured out the values of all regular
@@ -505,9 +666,12 @@ func (uh *upsertHelper) eval(insertRow tree.Datums, existingRow tree.Datums) (tr
 func (uh *upsertHelper) evalComputedCols(
 	updatedRow tree.Datums, appendTo tree.Datums,
 ) (tree.Datums, error) {
+	// Buffer the row.
 	uh.ccIvarContainer.curSourceRow = updatedRow
-	uh.p.EvalContext().IVarContainer = uh.ccIvarContainer
-	defer func() { uh.p.EvalContext().IVarContainer = nil }()
+
+	// Evaluate the computed columns.
+	uh.p.EvalContext().PushIVarContainer(&uh.ccIvarContainer)
+	defer func() { uh.p.EvalContext().PopIVarContainer() }()
 	for i := range uh.computeExprs {
 		res, err := uh.computeExprs[i].Eval(uh.p.EvalContext())
 		if err != nil {
@@ -521,11 +685,13 @@ func (uh *upsertHelper) evalComputedCols(
 // shouldUpdate returns the result of evaluating the WHERE clause of the
 // ON CONFLICT ... DO UPDATE clause.
 func (uh *upsertHelper) shouldUpdate(insertRow tree.Datums, existingRow tree.Datums) (bool, error) {
+	// Buffer the rows.
 	uh.curSourceRow = existingRow
 	uh.curExcludedRow = insertRow
 
-	uh.p.extendedEvalCtx.PushIVarContainer(uh.ivarHelper.Container())
-	defer func() { uh.p.extendedEvalCtx.PopIVarContainer() }()
+	// Evaluate the predicate.
+	uh.p.EvalContext().PushIVarContainer(uh)
+	defer func() { uh.p.EvalContext().PopIVarContainer() }()
 	return sqlbase.RunFilter(uh.whereExpr, uh.p.EvalContext())
 }
 
@@ -537,6 +703,9 @@ func upsertExprsAndIndex(
 	insertCols []sqlbase.ColumnDescriptor,
 ) (tree.UpdateExprs, *sqlbase.IndexDescriptor, error) {
 	if onConflict.IsUpsertAlias() {
+		// Construct a fake set of UPDATE SET expressions. This enables sharing
+		// the same implementation for UPSERT and INSERT ... ON CONFLICT DO UPDATE.
+
 		// The UPSERT syntactic sugar is the same as the longhand specifying the
 		// primary index as the conflict index and SET expressions for the columns
 		// in insertCols minus any columns in the conflict index. Example:
@@ -547,12 +716,17 @@ func upsertExprsAndIndex(
 		for _, colID := range conflictIndex.ColumnIDs {
 			indexColSet[colID] = struct{}{}
 		}
+
 		updateExprs := make(tree.UpdateExprs, 0, len(insertCols))
 		for _, c := range insertCols {
 			if c.ComputeExpr != nil {
+				// Computed columns must not appear in the pseudo-SET
+				// expression.
 				continue
 			}
 			if _, ok := indexColSet[c.ID]; ok {
+				// If the column is part of the PK, there is no need for a
+				// pseudo-assignment.
 				continue
 			}
 			n := tree.Name(c.Name)
@@ -561,6 +735,8 @@ func upsertExprsAndIndex(
 		}
 		return updateExprs, conflictIndex, nil
 	}
+
+	// General case: INSERT with an ON CONFLICT clause.
 
 	indexMatch := func(index sqlbase.IndexDescriptor) bool {
 		if !index.Unique {

--- a/pkg/sql/walk.go
+++ b/pkg/sql/walk.go
@@ -377,6 +377,34 @@ func (v *planVisitor) visit(plan planNode) {
 			for i, rexpr := range n.rh.exprs {
 				v.expr(name, "returning", i, rexpr)
 			}
+		}
+		v.visit(n.run.rows)
+
+	case *upsertNode:
+		if v.observer.attr != nil {
+			var buf bytes.Buffer
+			buf.WriteString(n.tableDesc.Name)
+			buf.WriteByte('(')
+			for i, col := range n.insertCols {
+				if i > 0 {
+					buf.WriteString(", ")
+				}
+				buf.WriteString(col.Name)
+			}
+			buf.WriteByte(')')
+			v.observer.attr(name, "into", buf.String())
+		}
+
+		if v.observer.expr != nil {
+			for i, dexpr := range n.defaultExprs {
+				v.expr(name, "default", i, dexpr)
+			}
+			for i, cexpr := range n.checkHelper.Exprs {
+				v.expr(name, "check", i, cexpr)
+			}
+			for i, rexpr := range n.rh.exprs {
+				v.expr(name, "returning", i, rexpr)
+			}
 			n.tw.walkExprs(func(d string, i int, e tree.TypedExpr) {
 				v.expr(name, d, i, e)
 			})
@@ -574,6 +602,7 @@ var planNodeNames = map[reflect.Type]string{
 	reflect.TypeOf(&splitNode{}):                "split",
 	reflect.TypeOf(&unionNode{}):                "union",
 	reflect.TypeOf(&updateNode{}):               "update",
+	reflect.TypeOf(&upsertNode{}):               "upsert",
 	reflect.TypeOf(&valueGenerator{}):           "generator",
 	reflect.TypeOf(&valuesNode{}):               "values",
 	reflect.TypeOf(&windowNode{}):               "window",


### PR DESCRIPTION
Commits split away from #23373 (fixing #23156 and related bugs) to ease reviewing.

Fixes #23672.
Fixes #23674.
