### PR TITLE
sql: add flag to control unwanted columns in scanNode

### DIFF
--- a/pkg/sql/data_source.go
+++ b/pkg/sql/data_source.go
@@ -355,7 +355,7 @@ func (p *planner) getPlanForDesc(
 
 	// This name designates a real table.
 	scan := p.Scan()
-	if err := scan.initTable(ctx, p, desc, hints, scanVisibility, wantedColumns); err != nil {
+	if err := scan.initTable(ctx, p, desc, hints, scanVisibility, wantedColumns, true /* addUnwantedAsHidden */); err != nil {
 		return planDataSource{}, err
 	}
 

--- a/pkg/sql/distsql_plan_stats.go
+++ b/pkg/sql/distsql_plan_stats.go
@@ -36,7 +36,12 @@ func (dsp *DistSQLPlanner) createStatsPlan(
 ) (physicalPlan, error) {
 	// Create the table readers; for this we initialize a dummy scanNode.
 	scan := scanNode{desc: desc}
-	err := scan.initDescDefaults(nil /* planDependencies */, publicColumns, nil /* wantedColumns */)
+	err := scan.initDescDefaults(
+		nil, /* planDependencies */
+		publicColumns,
+		nil,   /* wantedColumns */
+		false, /* addUnwantedAsHidden */
+	)
 	if err != nil {
 		return physicalPlan{}, err
 	}

--- a/pkg/sql/index_join.go
+++ b/pkg/sql/index_join.go
@@ -108,7 +108,12 @@ func (p *planner) makeIndexJoin(
 	table := p.Scan()
 	table.desc = origScan.desc
 	// Note: initDescDefaults can only error out if its 3rd argument is not nil.
-	_ = table.initDescDefaults(p.curPlan.deps, origScan.scanVisibility, nil /* wantedColumns */)
+	_ = table.initDescDefaults(
+		p.curPlan.deps,
+		origScan.scanVisibility,
+		nil,   /* wantedColumns */
+		false, /* addUnwantedAsHidden */
+	)
 	table.initOrdering(0 /* exactPrefix */, p.EvalContext())
 	table.disableBatchLimit()
 

--- a/pkg/sql/join_test.go
+++ b/pkg/sql/join_test.go
@@ -33,7 +33,7 @@ func newTestScanNode(kvDB *client.DB, tableName string) (*scanNode, error) {
 	p := planner{}
 	scan := p.Scan()
 	scan.desc = desc
-	err := scan.initDescDefaults(p.curPlan.deps, publicColumns, nil)
+	err := scan.initDescDefaults(p.curPlan.deps, publicColumns, nil, false /* addUnwantedAsHidden */)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/opt_exec_engine.go
+++ b/pkg/sql/opt_exec_engine.go
@@ -145,7 +145,9 @@ func (ee *execEngine) ConstructScan(table optbase.Table) (exec.Node, error) {
 	// Create a scanNode.
 	scan := ee.planner.Scan()
 	if err := scan.initTable(
-		context.TODO(), ee.planner, desc, nil /* hints */, publicColumns, columns,
+		context.TODO(), ee.planner, desc, nil /* hints */, publicColumns,
+		columns,
+		false, /* addUnwantedAsHidden */
 	); err != nil {
 		return nil, err
 	}

--- a/pkg/sql/scrub_physical.go
+++ b/pkg/sql/scrub_physical.go
@@ -110,7 +110,10 @@ func (o *physicalCheckOperation) Start(params runParams) error {
 	scan := params.p.Scan()
 	scan.run.isCheck = true
 	if err := scan.initTable(
-		ctx, params.p, o.tableDesc, indexHints, publicColumns, columnIDs,
+		ctx, params.p, o.tableDesc, indexHints,
+		publicColumns,
+		columnIDs,
+		true, /* addUnwantedAsHidden */
 	); err != nil {
 		return err
 	}

--- a/pkg/sql/select_name_resolution_test.go
+++ b/pkg/sql/select_name_resolution_test.go
@@ -27,7 +27,7 @@ func testInitDummySelectNode(p *planner, desc *sqlbase.TableDescriptor) *renderN
 	scan := &scanNode{}
 	scan.desc = desc
 	// Note: scan.initDescDefaults only returns an error if its 2nd argument is not nil.
-	_ = scan.initDescDefaults(p.curPlan.deps, publicColumns, nil)
+	_ = scan.initDescDefaults(p.curPlan.deps, publicColumns, nil, false /* addUnwantedAsHidden */)
 
 	sel := &renderNode{}
 	sel.source.plan = scan


### PR DESCRIPTION
Normally the "schema" of the scanNode includes all the columns in the
table (even if we don't produce values for all columns).

A mode where we specify a set of `wantedColumns` upfront was added to
help with some view-related issues. But even when this is set, the
unwanted columns are still added at the end of the column list, as
hidden columns.

Execution from the optimizer would benefit from passing
`wantedColumns` but without having the unwanted columns appended.
Adding a flag to this effect.

I will file an issue to investigate cleaning this up. It's not clear
that the unwanted columns are useful for anything (even though table
scrub code seems to depend on it).

Release note: None

CC @andy-kimball 