### PR TITLE
build,cmd/roachtest: allow specification of the zone(s) to run in

### DIFF
--- a/build/roachtest-nightly.sh
+++ b/build/roachtest-nightly.sh
@@ -53,6 +53,7 @@ run bin/roachtest run \
   --cockroach "$PWD/cockroach-linux-2.6.32-gnu-amd64" \
   --workload "$PWD/bin/workload" \
   --artifacts "$artifacts" \
+  --zones "us-central1-b,us-west1-b,europe-west2-b" \
   --parallelism 5
 if_tc tc_end_block "Run roachtest"
 

--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -51,6 +51,7 @@ var (
 	clusterID   string
 	clusterWipe bool
 	username    = os.Getenv("ROACHPROD_USER")
+	zones       string
 )
 
 func ifLocal(trueVal, falseVal string) string {
@@ -326,6 +327,9 @@ func newCluster(ctx context.Context, t testI, nodes int, args ...interface{}) *c
 		sargs := []string{"roachprod", "create", c.name, "-n", fmt.Sprint(nodes)}
 		for _, arg := range args {
 			sargs = append(sargs, fmt.Sprint(arg))
+		}
+		if zones != "" {
+			sargs = append(sargs, "--gce-zones="+zones)
 		}
 
 		c.status("creating cluster")

--- a/pkg/cmd/roachtest/main.go
+++ b/pkg/cmd/roachtest/main.go
@@ -76,6 +76,8 @@ func main() {
 		&workload, "workload", "", "path to workload binary to use")
 	runCmd.Flags().StringVar(
 		&slackToken, "slack-token", "", "Slack bot token")
+	runCmd.Flags().StringVar(
+		&zones, "zones", "", "Zones for the cluster (use roachprod defaults if empty)")
 
 	if err := rootCmd.Execute(); err != nil {
 		// Cobra has already printed the error message.


### PR DESCRIPTION
Add a `--zones` flag which passes through to `roachprod create`. This
allows changing the default zones to run in. Change the roachtest
nightlies to use `us-central1-b` instead of `us-east1-b`.

Release note: None