### PR TITLE
opt: execute SortOp

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/optimizer
+++ b/pkg/sql/logictest/testdata/logic_test/optimizer
@@ -18,8 +18,12 @@ query II
 3  30
 
 # Select
-query error pq: building execution for non-relational operator sort
-SELECT * FROM test.t ORDER BY t.k+1
+query II
+SELECT * FROM test.t ORDER BY 1-t.k
+----
+3  30
+2  20
+1  10
 
 # SelectClause
 query II

--- a/pkg/sql/opt/exec/execbuilder/builder.go
+++ b/pkg/sql/opt/exec/execbuilder/builder.go
@@ -42,7 +42,7 @@ func (b *Builder) Build() (exec.Node, error) {
 }
 
 func (b *Builder) build(ev xform.ExprView) (exec.Node, error) {
-	if !ev.IsRelational() {
+	if !ev.IsRelational() && !ev.IsEnforcer() {
 		return nil, errors.Errorf("building execution for non-relational operator %s", ev.Operator())
 	}
 	plan, err := b.buildRelational(ev)

--- a/pkg/sql/opt/exec/execbuilder/testdata/orderby
+++ b/pkg/sql/opt/exec/execbuilder/testdata/orderby
@@ -1,0 +1,1092 @@
+# tests adapted from logictest -- order_by
+
+exec-raw
+CREATE DATABASE t;
+CREATE TABLE t (
+  a INT PRIMARY KEY,
+  b INT,
+  c BOOLEAN
+)
+----
+
+exec-raw
+INSERT INTO t VALUES (1, 9, true), (2, 8, false), (3, 7, NULL)
+----
+
+exec
+SELECT c FROM t ORDER BY c
+----
+c:bool
+NULL
+false
+true
+
+exec-explain
+SELECT c FROM t ORDER BY c
+----
+sort            0  sort    ·         ·          (c)        +c
+ │              0  ·       order     +c         ·          ·
+ └── render     1  render  ·         ·          (c)        ·
+      │         1  ·       render 0  c          ·          ·
+      └── scan  2  scan    ·         ·          (a, b, c)  ·
+·               2  ·       table     t@primary  ·          ·
+·               2  ·       spans     ALL        ·          ·
+
+exec
+SELECT c FROM t ORDER BY c DESC
+----
+c:bool
+true
+false
+NULL
+
+exec
+SELECT a, b FROM t ORDER BY b
+----
+a:int  b:int
+3      7
+2      8
+1      9
+
+exec-explain
+SELECT a, b FROM t ORDER BY b
+----
+sort            0  sort    ·         ·          (a, b)     +b
+ │              0  ·       order     +b         ·          ·
+ └── render     1  render  ·         ·          (a, b)     ·
+      │         1  ·       render 0  a          ·          ·
+      │         1  ·       render 1  b          ·          ·
+      └── scan  2  scan    ·         ·          (a, b, c)  ·
+·               2  ·       table     t@primary  ·          ·
+·               2  ·       spans     ALL        ·          ·
+
+exec
+SELECT a, b FROM t ORDER BY b DESC
+----
+a:int  b:int
+1      9
+2      8
+3      7
+
+exec-explain
+SELECT a, b FROM t ORDER BY b DESC
+----
+sort            0  sort    ·         ·          (a, b)     -b
+ │              0  ·       order     -b         ·          ·
+ └── render     1  render  ·         ·          (a, b)     ·
+      │         1  ·       render 0  a          ·          ·
+      │         1  ·       render 1  b          ·          ·
+      └── scan  2  scan    ·         ·          (a, b, c)  ·
+·               2  ·       table     t@primary  ·          ·
+·               2  ·       spans     ALL        ·          ·
+
+
+exec
+SELECT a FROM t ORDER BY 1 DESC
+----
+a:int
+3
+2
+1
+
+exec-explain
+SELECT a, b FROM t ORDER BY b LIMIT 2
+----
+sort            0  sort    ·         ·          (a, b)     +b
+ │              0  ·       order     +b         ·          ·
+ └── render     1  render  ·         ·          (a, b)     ·
+      │         1  ·       render 0  a          ·          ·
+      │         1  ·       render 1  b          ·          ·
+      └── scan  2  scan    ·         ·          (a, b, c)  ·
+·               2  ·       table     t@primary  ·          ·
+·               2  ·       spans     ALL        ·          ·
+
+exec
+SELECT a, b FROM t ORDER BY b DESC LIMIT 2
+----
+a:int  b:int
+1      9
+2      8
+3      7
+
+# TODO(radu): this does not work. Unclear if we want to support it or not.
+#exec-explain
+#SELECT DISTINCT c FROM t ORDER BY b LIMIT 2
+#----
+#limit                     0  limit     ·         ·                (c)                 weak-key(c)
+# │                        0  ·         count     2                ·                   ·
+# └── distinct             1  distinct  ·         ·                (c)                 weak-key(c)
+#      └── sort            2  sort      ·         ·                (c)                 ·
+#           │              2  ·         order     +b               ·                   ·
+#           │              2  ·         strategy  iterative        ·                   ·
+#           └── render     3  render    ·         ·                (c, b)              ·
+#                │         3  ·         render 0  test.public.t.c  ·                   ·
+#                │         3  ·         render 1  test.public.t.b  ·                   ·
+#                └── scan  4  scan      ·         ·                (a[omitted], b, c)  a!=NULL; key(a)
+#·                         4  ·         table     t@primary        ·                   ·
+#·                         4  ·         spans     ALL              ·                   ·
+#
+#exec
+#SELECT DISTINCT c FROM t ORDER BY b DESC LIMIT 2
+#----
+#true
+#false
+#
+#exec
+#SELECT b FROM t ORDER BY a DESC
+#----
+#7
+#8
+#9
+#
+#exec-explain
+#SELECT b FROM t ORDER BY a DESC
+#----
+#nosort             ·      ·
+# │                 order  -a
+# └── render        ·      ·
+#      └── revscan  ·      ·
+#·                  table  t@primary
+#·                  spans  ALL
+
+# TODO(radu): LIMIT not yet supported.
+## Check that LIMIT propagates past nosort nodes.
+#exec-explain
+#SELECT b FROM t ORDER BY a LIMIT 1
+#----
+#limit                ·      ·
+# └── nosort          ·      ·
+#      │              order  +a
+#      └── render     ·      ·
+#           └── scan  ·      ·
+#·                    table  t@primary
+#·                    spans  ALL
+#·                    limit  1
+
+exec-explain
+SELECT b FROM t ORDER BY a DESC, b ASC
+----
+render               0  render  ·         ·          (b)        ·
+ │                   0  ·       render 0  b          ·          ·
+ └── sort            1  sort    ·         ·          (a, b)     -a,+b
+      │              1  ·       order     -a,+b      ·          ·
+      └── render     2  render  ·         ·          (a, b)     ·
+           │         2  ·       render 0  a          ·          ·
+           │         2  ·       render 1  b          ·          ·
+           └── scan  3  scan    ·         ·          (a, b, c)  ·
+·                    3  ·       table     t@primary  ·          ·
+·                    3  ·       spans     ALL        ·          ·
+
+exec-explain
+SELECT b FROM t ORDER BY a DESC, b DESC
+----
+render               0  render  ·         ·          (b)        ·
+ │                   0  ·       render 0  b          ·          ·
+ └── sort            1  sort    ·         ·          (a, b)     -a,-b
+      │              1  ·       order     -a,-b      ·          ·
+      └── render     2  render  ·         ·          (a, b)     ·
+           │         2  ·       render 0  a          ·          ·
+           │         2  ·       render 1  b          ·          ·
+           └── scan  3  scan    ·         ·          (a, b, c)  ·
+·                    3  ·       table     t@primary  ·          ·
+·                    3  ·       spans     ALL        ·          ·
+
+exec-explain
+SELECT * FROM t ORDER BY (b, t.*)
+----
+sort       0  sort  ·      ·          (a, b, c)  +b,+a,+c
+ │         0  ·     order  +b,+a,+c   ·          ·
+ └── scan  1  scan  ·      ·          (a, b, c)  ·
+·          1  ·     table  t@primary  ·          ·
+·          1  ·     spans  ALL        ·          ·
+
+exec-explain
+SELECT * FROM t ORDER BY (b, a), c
+----
+sort       0  sort  ·      ·          (a, b, c)  +b,+a,+c
+ │         0  ·     order  +b,+a,+c   ·          ·
+ └── scan  1  scan  ·      ·          (a, b, c)  ·
+·          1  ·     table  t@primary  ·          ·
+·          1  ·     spans  ALL        ·          ·
+
+exec-explain
+SELECT * FROM t ORDER BY b, (a, c)
+----
+sort       0  sort  ·      ·          (a, b, c)  +b,+a,+c
+ │         0  ·     order  +b,+a,+c   ·          ·
+ └── scan  1  scan  ·      ·          (a, b, c)  ·
+·          1  ·     table  t@primary  ·          ·
+·          1  ·     spans  ALL        ·          ·
+
+exec-explain
+SELECT * FROM t ORDER BY (b, (a, c))
+----
+sort       0  sort  ·      ·          (a, b, c)  +b,+a,+c
+ │         0  ·     order  +b,+a,+c   ·          ·
+ └── scan  1  scan  ·      ·          (a, b, c)  ·
+·          1  ·     table  t@primary  ·          ·
+·          1  ·     spans  ALL        ·          ·
+
+exec-raw
+INSERT INTO t VALUES (4, 7), (5, 7)
+----
+
+exec
+SELECT a, b FROM t WHERE b = 7 ORDER BY b, a
+----
+a:int  b:int
+3      7
+4      7
+5      7
+
+exec
+SELECT a, b FROM t ORDER BY b, a DESC
+----
+a:int  b:int
+5      7
+4      7
+3      7
+2      8
+1      9
+
+exec
+SELECT a, b, a+b AS ab FROM t WHERE b = 7 ORDER BY ab DESC, a
+----
+a:int  b:int  ab:int
+5      7      12
+4      7      11
+3      7      10
+
+exec
+SELECT a FROM t ORDER BY a+b DESC, a
+----
+a:int
+5
+4
+1
+2
+3
+
+exec
+SELECT a FROM t ORDER BY (((a)))
+----
+a:int
+1
+2
+3
+4
+5
+
+exec
+(((SELECT a FROM t))) ORDER BY a DESC LIMIT 4
+----
+a:int
+5
+4
+3
+2
+1
+
+exec
+(((SELECT a FROM t ORDER BY a DESC LIMIT 4)))
+----
+a:int
+5
+4
+3
+2
+1
+
+# TODO(radu): functions as tables not yet implemented
+#exec
+#SELECT GENERATE_SERIES, ARRAY[GENERATE_SERIES] FROM GENERATE_SERIES(1, 1) ORDER BY 1
+#----
+#1 {1}
+#
+#exec
+#SELECT GENERATE_SERIES, ARRAY[GENERATE_SERIES] FROM GENERATE_SERIES(1, 1) ORDER BY GENERATE_SERIES
+#----
+#1 {1}
+#
+#exec
+#SELECT GENERATE_SERIES, ARRAY[GENERATE_SERIES] FROM GENERATE_SERIES(1, 1) ORDER BY -GENERATE_SERIES
+#----
+#1 {1}
+
+
+# Check that sort is skipped if the ORDER BY clause is constant.
+# TODO(radu): we don't optimize constant columns yet.
+exec-explain
+SELECT * FROM t ORDER BY 1+2
+----
+render               0  render  ·         ·          (a, b, c)                       ·
+ │                   0  ·       render 0  "t.a"      ·                               ·
+ │                   0  ·       render 1  "t.b"      ·                               ·
+ │                   0  ·       render 2  "t.c"      ·                               ·
+ └── sort            1  sort    ·         ·          ("t.a", "t.b", "t.c", column4)  +column4
+      │              1  ·       order     +column4   ·                               ·
+      └── render     2  render  ·         ·          ("t.a", "t.b", "t.c", column4)  ·
+           │         2  ·       render 0  a          ·                               ·
+           │         2  ·       render 1  b          ·                               ·
+           │         2  ·       render 2  c          ·                               ·
+           │         2  ·       render 3  3          ·                               ·
+           └── scan  3  scan    ·         ·          (a, b, c)                       ·
+·                    3  ·       table     t@primary  ·                               ·
+·                    3  ·       spans     ALL        ·                               ·
+
+exec-explain
+SELECT 1, * FROM t ORDER BY 1
+----
+sort            0  sort    ·         ·          (column4, a, b, c)  +column4
+ │              0  ·       order     +column4   ·                   ·
+ └── render     1  render  ·         ·          (column4, a, b, c)  ·
+      │         1  ·       render 0  1          ·                   ·
+      │         1  ·       render 1  a          ·                   ·
+      │         1  ·       render 2  b          ·                   ·
+      │         1  ·       render 3  c          ·                   ·
+      └── scan  2  scan    ·         ·          (a, b, c)           ·
+·               2  ·       table     t@primary  ·                   ·
+·               2  ·       spans     ALL        ·                   ·
+
+exec-explain
+SELECT * FROM t ORDER BY length('abc')
+----
+render               0  render  ·         ·              (a, b, c)                       ·
+ │                   0  ·       render 0  "t.a"          ·                               ·
+ │                   0  ·       render 1  "t.b"          ·                               ·
+ │                   0  ·       render 2  "t.c"          ·                               ·
+ └── sort            1  sort    ·         ·              ("t.a", "t.b", "t.c", column4)  +column4
+      │              1  ·       order     +column4       ·                               ·
+      └── render     2  render  ·         ·              ("t.a", "t.b", "t.c", column4)  ·
+           │         2  ·       render 0  a              ·                               ·
+           │         2  ·       render 1  b              ·                               ·
+           │         2  ·       render 2  c              ·                               ·
+           │         2  ·       render 3  length('abc')  ·                               ·
+           └── scan  3  scan    ·         ·              (a, b, c)                       ·
+·                    3  ·       table     t@primary      ·                               ·
+·                    3  ·       spans     ALL            ·                               ·
+
+# Check that the sort key reuses the existing render.
+exec-explain
+SELECT b+2 FROM t ORDER BY b+2
+----
+render                    0  render  ·         ·          (column4)           ·
+ │                        0  ·       render 0  column4    ·                   ·
+ └── sort                 1  sort    ·         ·          (column4, column5)  +column5
+      │                   1  ·       order     +column5   ·                   ·
+      └── render          2  render  ·         ·          (column4, column5)  ·
+           │              2  ·       render 0  b + 2      ·                   ·
+           │              2  ·       render 1  b + 2      ·                   ·
+           └── render     3  render  ·         ·          (b)                 ·
+                │         3  ·       render 0  b          ·                   ·
+                └── scan  4  scan    ·         ·          (a, b, c)           ·
+·                         4  ·       table     t@primary  ·                   ·
+·                         4  ·       spans     ALL        ·                   ·
+
+# Check that the sort picks up a renamed render properly.
+exec-explain
+SELECT b+2 AS y FROM t ORDER BY y
+----
+sort                 0  sort    ·         ·          (y)        +y
+ │                   0  ·       order     +y         ·          ·
+ └── render          1  render  ·         ·          (y)        ·
+      │              1  ·       render 0  b + 2      ·          ·
+      └── render     2  render  ·         ·          (b)        ·
+           │         2  ·       render 0  b          ·          ·
+           └── scan  3  scan    ·         ·          (a, b, c)  ·
+·                    3  ·       table     t@primary  ·          ·
+·                    3  ·       spans     ALL        ·          ·
+
+# Check that the sort reuses a render behind a rename properly.
+exec-explain
+SELECT b+2 AS y FROM t ORDER BY b+2
+----
+render                    0  render  ·         ·          (y)           ·
+ │                        0  ·       render 0  y          ·             ·
+ └── sort                 1  sort    ·         ·          (y, column5)  +column5
+      │                   1  ·       order     +column5   ·             ·
+      └── render          2  render  ·         ·          (y, column5)  ·
+           │              2  ·       render 0  b + 2      ·             ·
+           │              2  ·       render 1  b + 2      ·             ·
+           └── render     3  render  ·         ·          (b)           ·
+                │         3  ·       render 0  b          ·             ·
+                └── scan  4  scan    ·         ·          (a, b, c)     ·
+·                         4  ·       table     t@primary  ·             ·
+·                         4  ·       spans     ALL        ·             ·
+
+exec-raw
+CREATE TABLE abc (
+  a INT,
+  b INT,
+  c INT,
+  d CHAR,
+  PRIMARY KEY (a, b, c),
+  UNIQUE INDEX bc (b, c),
+  INDEX ba (b, a),
+  FAMILY (a, b, c),
+  FAMILY (d)
+)
+----
+
+exec-raw
+INSERT INTO abc
+SELECT x, (x-1)*3 + y, 4 - x, to_english((x-1)*3+y)
+FROM
+  GENERATE_SERIES(1, 3) AS x(x),
+  GENERATE_SERIES(1, 3) AS y(y)
+----
+
+exec
+SELECT d FROM abc ORDER BY LOWER(d)
+----
+d:string
+eight
+five
+four
+nine
+one
+seven
+six
+three
+two
+
+exec-explain
+SELECT * FROM abc ORDER BY a
+----
+scan  0  scan  ·      ·            (a, b, c, d)  ·
+·     0  ·     table  abc@primary  ·             ·
+·     0  ·     spans  ALL          ·             ·
+
+exec partialsort=(1)
+SELECT * FROM abc ORDER BY a
+----
+a:int  b:int  c:int  d:string
+1      1      3      one
+1      2      3      two
+1      3      3      three
+2      4      2      four
+2      5      2      five
+2      6      2      six
+3      7      1      seven
+3      8      1      eight
+3      9      1      nine
+
+exec-explain
+SELECT * FROM abc ORDER BY a, c
+----
+sort       0  sort  ·      ·            (a, b, c, d)  +a,+c
+ │         0  ·     order  +a,+c        ·             ·
+ └── scan  1  scan  ·      ·            (a, b, c, d)  ·
+·          1  ·     table  abc@primary  ·             ·
+·          1  ·     spans  ALL          ·             ·
+
+exec partialsort=(1,3)
+SELECT * FROM abc ORDER BY a, c
+----
+a:int  b:int  c:int  d:string
+1      1      3      one
+1      2      3      two
+1      3      3      three
+2      4      2      four
+2      5      2      five
+2      6      2      six
+3      7      1      seven
+3      8      1      eight
+3      9      1      nine
+
+exec-explain
+SELECT a, b FROM abc ORDER BY b, a
+----
+sort            0  sort    ·         ·            (a, b)        +b,+a
+ │              0  ·       order     +b,+a        ·             ·
+ └── render     1  render  ·         ·            (a, b)        ·
+      │         1  ·       render 0  a            ·             ·
+      │         1  ·       render 1  b            ·             ·
+      └── scan  2  scan    ·         ·            (a, b, c, d)  ·
+·               2  ·       table     abc@primary  ·             ·
+·               2  ·       spans     ALL          ·             ·
+
+exec
+SELECT a, b FROM abc ORDER BY b, a
+----
+a:int  b:int
+1      1
+1      2
+1      3
+2      4
+2      5
+2      6
+3      7
+3      8
+3      9
+
+# The non-unique index ba includes column c (required to make the keys unique)
+# so the results will already be sorted.
+exec-explain
+SELECT a, b, c FROM abc ORDER BY b, a, c
+----
+sort            0  sort    ·         ·            (a, b, c)     +b,+a,+c
+ │              0  ·       order     +b,+a,+c     ·             ·
+ └── render     1  render  ·         ·            (a, b, c)     ·
+      │         1  ·       render 0  a            ·             ·
+      │         1  ·       render 1  b            ·             ·
+      │         1  ·       render 2  c            ·             ·
+      └── scan  2  scan    ·         ·            (a, b, c, d)  ·
+·               2  ·       table     abc@primary  ·             ·
+·               2  ·       spans     ALL          ·             ·
+
+exec
+SELECT a, b, c FROM abc ORDER BY b, a, c
+----
+a:int  b:int  c:int
+1      1      3
+1      2      3
+1      3      3
+2      4      2
+2      5      2
+2      6      2
+3      7      1
+3      8      1
+3      9      1
+
+# We use the WHERE condition to force the use of index ba.
+exec-explain
+SELECT a, b, c FROM abc WHERE b > 4 ORDER BY b, a, d
+----
+render               0  render  ·         ·            (a, b, c)     ·
+ │                   0  ·       render 0  a            ·             ·
+ │                   0  ·       render 1  b            ·             ·
+ │                   0  ·       render 2  c            ·             ·
+ └── filter          1  filter  ·         ·            (a, b, c, d)  ·
+      │              1  ·       filter    b > 4        ·             ·
+      └── sort       2  sort    ·         ·            (a, b, c, d)  +b,+a,+d
+           │         2  ·       order     +b,+a,+d     ·             ·
+           └── scan  3  scan    ·         ·            (a, b, c, d)  ·
+·                    3  ·       table     abc@primary  ·             ·
+·                    3  ·       spans     ALL          ·             ·
+
+exec
+SELECT a, b, c FROM abc WHERE b > 4 ORDER BY b, a, d
+----
+a:int  b:int  c:int
+2      5      2
+2      6      2
+3      7      1
+3      8      1
+3      9      1
+
+# We cannot have rows with identical values for a,b,c so we don't need to
+# sort for d.
+exec-explain
+SELECT a, b, c, d FROM abc WHERE b > 4 ORDER BY b, a, c, d
+----
+filter          0  filter  ·       ·            (a, b, c, d)  ·
+ │              0  ·       filter  b > 4        ·             ·
+ └── sort       1  sort    ·       ·            (a, b, c, d)  +b,+a,+c,+d
+      │         1  ·       order   +b,+a,+c,+d  ·             ·
+      └── scan  2  scan    ·       ·            (a, b, c, d)  ·
+·               2  ·       table   abc@primary  ·             ·
+·               2  ·       spans   ALL          ·             ·
+
+exec
+SELECT a, b, c, d FROM abc WHERE b > 4 ORDER BY b, a, c, d
+----
+a:int  b:int  c:int  d:string
+2      5      2      five
+2      6      2      six
+3      7      1      seven
+3      8      1      eight
+3      9      1      nine
+
+exec-explain
+SELECT a, b FROM abc ORDER BY b, c
+----
+render               0  render  ·         ·            (a, b)        ·
+ │                   0  ·       render 0  a            ·             ·
+ │                   0  ·       render 1  b            ·             ·
+ └── sort            1  sort    ·         ·            (a, b, c)     +b,+c
+      │              1  ·       order     +b,+c        ·             ·
+      └── render     2  render  ·         ·            (a, b, c)     ·
+           │         2  ·       render 0  a            ·             ·
+           │         2  ·       render 1  b            ·             ·
+           │         2  ·       render 2  c            ·             ·
+           └── scan  3  scan    ·         ·            (a, b, c, d)  ·
+·                    3  ·       table     abc@primary  ·             ·
+·                    3  ·       spans     ALL          ·             ·
+
+exec
+SELECT a, b FROM abc ORDER BY b, c
+----
+a:int  b:int
+1      1
+1      2
+1      3
+2      4
+2      5
+2      6
+3      7
+3      8
+3      9
+
+exec-explain
+SELECT a, b FROM abc ORDER BY c, b
+----
+render               0  render  ·         ·            (a, b)        ·
+ │                   0  ·       render 0  a            ·             ·
+ │                   0  ·       render 1  b            ·             ·
+ └── sort            1  sort    ·         ·            (a, b, c)     +c,+b
+      │              1  ·       order     +c,+b        ·             ·
+      └── render     2  render  ·         ·            (a, b, c)     ·
+           │         2  ·       render 0  a            ·             ·
+           │         2  ·       render 1  b            ·             ·
+           │         2  ·       render 2  c            ·             ·
+           └── scan  3  scan    ·         ·            (a, b, c, d)  ·
+·                    3  ·       table     abc@primary  ·             ·
+·                    3  ·       spans     ALL          ·             ·
+
+exec
+SELECT a, b FROM abc ORDER BY c, b
+----
+a:int  b:int
+3      7
+3      8
+3      9
+2      4
+2      5
+2      6
+1      1
+1      2
+1      3
+
+exec-explain
+SELECT a, b FROM abc ORDER BY b, c, a
+----
+render               0  render  ·         ·            (a, b)        ·
+ │                   0  ·       render 0  a            ·             ·
+ │                   0  ·       render 1  b            ·             ·
+ └── sort            1  sort    ·         ·            (a, b, c)     +b,+c,+a
+      │              1  ·       order     +b,+c,+a     ·             ·
+      └── render     2  render  ·         ·            (a, b, c)     ·
+           │         2  ·       render 0  a            ·             ·
+           │         2  ·       render 1  b            ·             ·
+           │         2  ·       render 2  c            ·             ·
+           └── scan  3  scan    ·         ·            (a, b, c, d)  ·
+·                    3  ·       table     abc@primary  ·             ·
+·                    3  ·       spans     ALL          ·             ·
+
+exec
+SELECT a, b FROM abc ORDER BY b, c, a
+----
+a:int  b:int
+1      1
+1      2
+1      3
+2      4
+2      5
+2      6
+3      7
+3      8
+3      9
+
+exec-explain
+SELECT a, b FROM abc ORDER BY b, c, a DESC
+----
+render               0  render  ·         ·            (a, b)        ·
+ │                   0  ·       render 0  a            ·             ·
+ │                   0  ·       render 1  b            ·             ·
+ └── sort            1  sort    ·         ·            (a, b, c)     +b,+c,-a
+      │              1  ·       order     +b,+c,-a     ·             ·
+      └── render     2  render  ·         ·            (a, b, c)     ·
+           │         2  ·       render 0  a            ·             ·
+           │         2  ·       render 1  b            ·             ·
+           │         2  ·       render 2  c            ·             ·
+           └── scan  3  scan    ·         ·            (a, b, c, d)  ·
+·                    3  ·       table     abc@primary  ·             ·
+·                    3  ·       spans     ALL          ·             ·
+
+exec
+SELECT a, b FROM abc ORDER BY b, c, a DESC
+----
+a:int  b:int
+1      1
+1      2
+1      3
+2      4
+2      5
+2      6
+3      7
+3      8
+3      9
+
+exec-explain
+SELECT a FROM abc ORDER BY a DESC
+----
+sort            0  sort    ·         ·            (a)           -a
+ │              0  ·       order     -a           ·             ·
+ └── render     1  render  ·         ·            (a)           ·
+      │         1  ·       render 0  a            ·             ·
+      └── scan  2  scan    ·         ·            (a, b, c, d)  ·
+·               2  ·       table     abc@primary  ·             ·
+·               2  ·       spans     ALL          ·             ·
+
+exec
+SELECT a FROM abc ORDER BY a DESC
+----
+a:int
+3
+3
+3
+2
+2
+2
+1
+1
+1
+
+# TODO(radu): LIMIT not supported.
+# exec
+# SELECT a FROM abc ORDER BY a DESC LIMIT 1
+# ----
+# a:int
+# 
+# exec
+# SELECT a FROM abc ORDER BY a DESC OFFSET 1
+# ----
+# a:int
+
+exec-explain
+SELECT c FROM abc WHERE b = 2 ORDER BY c
+----
+render                    0  render  ·         ·            (c)           ·
+ │                        0  ·       render 0  c            ·             ·
+ └── filter               1  filter  ·         ·            (b, c)        ·
+      │                   1  ·       filter    b = 2        ·             ·
+      └── sort            2  sort    ·         ·            (b, c)        +c
+           │              2  ·       order     +c           ·             ·
+           └── render     3  render  ·         ·            (b, c)        ·
+                │         3  ·       render 0  b            ·             ·
+                │         3  ·       render 1  c            ·             ·
+                └── scan  4  scan    ·         ·            (a, b, c, d)  ·
+·                         4  ·       table     abc@primary  ·             ·
+·                         4  ·       spans     ALL          ·             ·
+
+exec-explain
+SELECT c FROM abc WHERE b = 2 ORDER BY c DESC
+----
+render                    0  render  ·         ·            (c)           ·
+ │                        0  ·       render 0  c            ·             ·
+ └── filter               1  filter  ·         ·            (b, c)        ·
+      │                   1  ·       filter    b = 2        ·             ·
+      └── sort            2  sort    ·         ·            (b, c)        -c
+           │              2  ·       order     -c           ·             ·
+           └── render     3  render  ·         ·            (b, c)        ·
+                │         3  ·       render 0  b            ·             ·
+                │         3  ·       render 1  c            ·             ·
+                └── scan  4  scan    ·         ·            (a, b, c, d)  ·
+·                         4  ·       table     abc@primary  ·             ·
+·                         4  ·       spans     ALL          ·             ·
+
+# Verify that the ordering of the primary index is still used for the outer sort.
+exec-explain
+SELECT * FROM (SELECT b, c FROM abc WHERE a=1 ORDER BY a,b) ORDER BY b,c
+----
+render                    0  render  ·         ·            (b, c, a)     ·
+ │                        0  ·       render 0  b            ·             ·
+ │                        0  ·       render 1  c            ·             ·
+ │                        0  ·       render 2  a            ·             ·
+ └── filter               1  filter  ·         ·            (a, b, c)     ·
+      │                   1  ·       filter    a = 1        ·             ·
+      └── sort            2  sort    ·         ·            (a, b, c)     +b,+c
+           │              2  ·       order     +b,+c        ·             ·
+           └── render     3  render  ·         ·            (a, b, c)     ·
+                │         3  ·       render 0  a            ·             ·
+                │         3  ·       render 1  b            ·             ·
+                │         3  ·       render 2  c            ·             ·
+                └── scan  4  scan    ·         ·            (a, b, c, d)  ·
+·                         4  ·       table     abc@primary  ·             ·
+·                         4  ·       spans     ALL          ·             ·
+
+exec-raw
+CREATE TABLE bar (id INT PRIMARY KEY, baz STRING, UNIQUE INDEX i_bar (baz))
+----
+
+exec-raw
+INSERT INTO bar VALUES (0, NULL), (1, NULL)
+----
+
+exec-explain
+SELECT * FROM bar ORDER BY baz, id
+----
+sort       0  sort  ·      ·            (id, baz)  +baz,+id
+ │         0  ·     order  +baz,+id     ·          ·
+ └── scan  1  scan  ·      ·            (id, baz)  ·
+·          1  ·     table  bar@primary  ·          ·
+·          1  ·     spans  ALL          ·          ·
+
+# Here rowsort is needed because the ORDER BY clause does not guarantee any
+# relative ordering between rows where baz is NULL. As we see above, because
+# this is a unique index, the ordering `+baz,+id` is deemed equivalent to just
+# `+baz`.
+exec
+SELECT * FROM bar ORDER BY baz, id
+----
+id:int  baz:string
+0       NULL
+1       NULL
+
+exec-raw
+CREATE TABLE abcd (
+  a INT PRIMARY KEY,
+  b INT,
+  c INT,
+  d INT,
+  INDEX abc (a, b, c)
+)
+----
+
+exec-raw
+INSERT INTO abcd VALUES (1, 4, 2, 3), (2, 3, 4, 1), (3, 2, 1, 2), (4, 4, 1, 1)
+----
+
+# Verify that render expressions after sorts perform correctly. We need the
+# rowsort as we're attempting to force a RENDER expression after the first
+# ORDER BY, to ensure it renders correctly, but the outer query doesn't
+# guarantee that it will preserve the order.
+
+exec rowsort
+SELECT a+b FROM (SELECT * FROM abcd ORDER BY d)
+----
+column5:int
+5
+5
+5
+8
+
+exec rowsort
+SELECT b+d FROM (SELECT * FROM abcd ORDER BY a,d)
+----
+column5:int
+4
+4
+5
+7
+
+# The following tests verify we recognize that sorting is not necessary
+exec-explain
+SELECT a, b, c FROM abcd@abc WHERE (a, b) = (1, 4) ORDER BY c
+----
+filter               0  filter  ·         ·                    (a, b, c)     ·
+ │                   0  ·       filter    (a = 1) AND (b = 4)  ·             ·
+ └── sort            1  sort    ·         ·                    (a, b, c)     +c
+      │              1  ·       order     +c                   ·             ·
+      └── render     2  render  ·         ·                    (a, b, c)     ·
+           │         2  ·       render 0  a                    ·             ·
+           │         2  ·       render 1  b                    ·             ·
+           │         2  ·       render 2  c                    ·             ·
+           └── scan  3  scan    ·         ·                    (a, b, c, d)  ·
+·                    3  ·       table     abcd@primary         ·             ·
+·                    3  ·       spans     ALL                  ·             ·
+
+exec-explain
+SELECT a, b, c FROM abcd@abc WHERE (a, b) = (1, 4) ORDER BY c, b, a
+----
+filter               0  filter  ·         ·                    (a, b, c)     ·
+ │                   0  ·       filter    (a = 1) AND (b = 4)  ·             ·
+ └── sort            1  sort    ·         ·                    (a, b, c)     +c,+b,+a
+      │              1  ·       order     +c,+b,+a             ·             ·
+      └── render     2  render  ·         ·                    (a, b, c)     ·
+           │         2  ·       render 0  a                    ·             ·
+           │         2  ·       render 1  b                    ·             ·
+           │         2  ·       render 2  c                    ·             ·
+           └── scan  3  scan    ·         ·                    (a, b, c, d)  ·
+·                    3  ·       table     abcd@primary         ·             ·
+·                    3  ·       spans     ALL                  ·             ·
+
+exec-explain
+SELECT a, b, c FROM abcd@abc WHERE (a, b) = (1, 4) ORDER BY b, a, c
+----
+filter               0  filter  ·         ·                    (a, b, c)     ·
+ │                   0  ·       filter    (a = 1) AND (b = 4)  ·             ·
+ └── sort            1  sort    ·         ·                    (a, b, c)     +b,+a,+c
+      │              1  ·       order     +b,+a,+c             ·             ·
+      └── render     2  render  ·         ·                    (a, b, c)     ·
+           │         2  ·       render 0  a                    ·             ·
+           │         2  ·       render 1  b                    ·             ·
+           │         2  ·       render 2  c                    ·             ·
+           └── scan  3  scan    ·         ·                    (a, b, c, d)  ·
+·                    3  ·       table     abcd@primary         ·             ·
+·                    3  ·       spans     ALL                  ·             ·
+
+exec-explain
+SELECT a, b, c FROM abcd@abc WHERE (a, b) = (1, 4) ORDER BY b, c, a
+----
+filter               0  filter  ·         ·                    (a, b, c)     ·
+ │                   0  ·       filter    (a = 1) AND (b = 4)  ·             ·
+ └── sort            1  sort    ·         ·                    (a, b, c)     +b,+c,+a
+      │              1  ·       order     +b,+c,+a             ·             ·
+      └── render     2  render  ·         ·                    (a, b, c)     ·
+           │         2  ·       render 0  a                    ·             ·
+           │         2  ·       render 1  b                    ·             ·
+           │         2  ·       render 2  c                    ·             ·
+           └── scan  3  scan    ·         ·                    (a, b, c, d)  ·
+·                    3  ·       table     abcd@primary         ·             ·
+·                    3  ·       spans     ALL                  ·             ·
+
+exec-raw
+CREATE TABLE nan (id INT PRIMARY KEY, x REAL)
+----
+
+exec-raw
+INSERT INTO nan VALUES (1, 0/0), (2, -1), (3, 1), (4, 0/0)
+----
+
+exec
+SELECT x FROM nan ORDER BY x
+----
+x:float
+NaN
+NaN
+-1.0
+1.0
+
+exec-explain
+SELECT * FROM (SELECT * FROM (VALUES ('a'), ('b'), ('c')) AS c(x) ORDER BY x)
+----
+sort         0  sort    ·              ·                 (x)  +x
+ │           0  ·       order          +x                ·    ·
+ └── values  1  values  ·              ·                 (x)  ·
+·            1  ·       size           1 column, 3 rows  ·    ·
+·            1  ·       row 0, expr 0  'a'               ·    ·
+·            1  ·       row 1, expr 0  'b'               ·    ·
+·            1  ·       row 2, expr 0  'c'               ·    ·
+
+# TODO(radu): ordinality not supported
+#exec-explain
+#SELECT * FROM (VALUES ('a'), ('b'), ('c')) WITH ORDINALITY ORDER BY ordinality ASC
+#----
+#ordinality   ·     ·
+# └── values  ·     ·
+#·            size  1 column, 3 rows
+#
+#exec-explain
+#SELECT * FROM (VALUES ('a'), ('b'), ('c')) WITH ORDINALITY ORDER BY ordinality DESC
+#----
+#sort              ·      ·
+# │                order  -"ordinality"
+# └── ordinality   ·      ·
+#      └── values  ·      ·
+#·                 size   1 column, 3 rows
+
+exec-explain
+SELECT * FROM (SELECT * FROM (VALUES ('a'), ('b'), ('c')) AS c(x)) WITH ORDINALITY
+----
+values  0  values  ·              ·                 (x)  ·
+·       0  ·       size           1 column, 3 rows  ·    ·
+·       0  ·       row 0, expr 0  'a'               ·    ·
+·       0  ·       row 1, expr 0  'b'               ·    ·
+·       0  ·       row 2, expr 0  'c'               ·    ·
+
+exec-explain
+SELECT * FROM (SELECT * FROM (VALUES ('a'), ('b'), ('c')) AS c(x) ORDER BY x) WITH ORDINALITY
+----
+sort         0  sort    ·              ·                 (x)  +x
+ │           0  ·       order          +x                ·    ·
+ └── values  1  values  ·              ·                 (x)  ·
+·            1  ·       size           1 column, 3 rows  ·    ·
+·            1  ·       row 0, expr 0  'a'               ·    ·
+·            1  ·       row 1, expr 0  'b'               ·    ·
+·            1  ·       row 2, expr 0  'c'               ·    ·
+
+# TODO(radu): DML statements not supported yet.
+## Check that the ordering of the source does not propagate blindly to RETURNING.
+#exec-explain
+#INSERT INTO t(a, b) SELECT * FROM (SELECT 1 AS x, 2 AS y) ORDER BY x RETURNING b
+#----
+#insert              0  insert    ·     ·        (b)     ·
+# │                  0  ·         into  t(a, b)  ·       ·
+# └── render         1  render    ·     ·        (x, y)  x=CONST; y=CONST
+#      └── emptyrow  2  emptyrow  ·     ·        ()      ·
+#
+#exec-explain
+#DELETE FROM t WHERE a = 3 RETURNING b
+#----
+#delete     0  delete  ·      ·          (b)        ·
+# │         0  ·       from   t          ·          ·
+# └── scan  1  scan    ·      ·          (a, b, c)  a=CONST; key()
+#·          1  ·       table  t@primary  ·          ·
+#·          1  ·       spans  /3-/3/#    ·          ·
+#
+#exec-explain
+#UPDATE t SET c = TRUE RETURNING b
+#----
+#update          0  update  ·      ·          (b)                ·
+# │              0  ·       table  t          ·                  ·
+# │              0  ·       set    c          ·                  ·
+# └── render     1  render  ·      ·          (a, b, c, "true")  "true"=CONST; a!=NULL; key(a)
+#      └── scan  2  scan    ·      ·          (a, b, c)          a!=NULL; key(a)
+#·               2  ·       table  t@primary  ·                  ·
+#·               2  ·       spans  ALL        ·                  ·
+
+exec-raw
+CREATE TABLE uvwxyz (
+  u INT,
+  v INT,
+  w INT,
+  x INT,
+  y INT,
+  z INT,
+  INDEX ywxz (y, w, x, z, u, v),
+  INDEX ywz (y, w, z, x)
+)
+----
+
+# Verify that the outer ordering is propagated to index selection and we choose
+# the index that avoids any sorting.
+exec-explain
+SELECT * FROM (SELECT y, w, x FROM uvwxyz WHERE y = 1 ORDER BY w) ORDER BY w, x
+----
+render                    0  render  ·         ·               (y, w, x)                          ·
+ │                        0  ·       render 0  y               ·                                  ·
+ │                        0  ·       render 1  w               ·                                  ·
+ │                        0  ·       render 2  x               ·                                  ·
+ └── filter               1  filter  ·         ·               (w, x, y)                          ·
+      │                   1  ·       filter    y = 1           ·                                  ·
+      └── sort            2  sort    ·         ·               (w, x, y)                          +w,+x
+           │              2  ·       order     +w,+x           ·                                  ·
+           └── render     3  render  ·         ·               (w, x, y)                          ·
+                │         3  ·       render 0  w               ·                                  ·
+                │         3  ·       render 1  x               ·                                  ·
+                │         3  ·       render 2  y               ·                                  ·
+                └── scan  4  scan    ·         ·               (u, v, w, x, y, z, rowid[hidden])  ·
+·                         4  ·       table     uvwxyz@primary  ·                                  ·
+·                         4  ·       spans     ALL             ·                                  ·
+
+exec-raw
+CREATE TABLE blocks (
+  block_id  INT,
+  writer_id STRING,
+  block_num INT,
+  raw_bytes BYTES,
+  PRIMARY KEY (block_id, writer_id, block_num)
+)
+----
+
+# TODO(radu): LIMIT not supported yet.
+## Test that ordering goes "through" a renderNode that has a duplicate render of
+## an order-by column (#13696).
+#exec-explain
+#SELECT block_id,writer_id,block_num,block_id FROM blocks ORDER BY block_id, writer_id, block_num LIMIT 1
+#----
+#render          0  render  ·         ·                   (block_id, writer_id, block_num, block_id)                                      ·
+# │              0  ·       render 0  "blocks.block_id"   ·                                                                               ·
+# │              0  ·       render 1  "blocks.writer_id"  ·                                                                               ·
+# │              0  ·       render 2  "blocks.block_num"  ·                                                                               ·
+# │              0  ·       render 3  "blocks.block_id"   ·                                                                               ·
+# └── render     1  render  ·         ·                   ("blocks.block_id", "blocks.writer_id", "blocks.block_num", "blocks.block_id")  ·
+#      │         1  ·       render 0  block_id            ·                                                                               ·
+#      │         1  ·       render 1  writer_id           ·                                                                               ·
+#      │         1  ·       render 2  block_num           ·                                                                               ·
+#      │         1  ·       render 3  block_id            ·                                                                               ·
+#      └── scan  2  scan    ·         ·                   (block_id, writer_id, block_num, raw_bytes)                                     ·
+#·               2  ·       table     blocks@primary      ·                                                                               ·
+#·               2  ·       spans     ALL                 ·                                                                               ·

--- a/pkg/sql/opt/exec/factory.go
+++ b/pkg/sql/opt/exec/factory.go
@@ -75,6 +75,10 @@ type Factory interface {
 	// nodes must have the same number of columns.
 	ConstructSetOp(typ tree.UnionType, all bool, left, right Node) (Node, error)
 
+	// ConstructSort returns a node that performs a resorting of the rows produced
+	// by the input node.
+	ConstructSort(input Node, ordering sqlbase.ColumnOrdering) (Node, error)
+
 	// RenameColumns modifies the column names of a node.
 	RenameColumns(input Node, colNames []string) (Node, error)
 }

--- a/pkg/sql/opt/optbuilder/orderby.go
+++ b/pkg/sql/opt/optbuilder/orderby.go
@@ -52,8 +52,9 @@ func (b *Builder) buildOrderBy(
 	// ORDER BY PRIMARY KEY syntax.
 
 	for i := range orderBy {
-		p := b.buildOrdering(orderBy[i], orderByProjections, inScope, projectionsScope, orderByScope)
-		orderByProjections = append(orderByProjections, p...)
+		orderByProjections = b.buildOrdering(
+			orderBy[i], orderByProjections, inScope, projectionsScope, orderByScope,
+		)
 	}
 
 	out, outScope = b.buildOrderByProject(
@@ -63,6 +64,11 @@ func (b *Builder) buildOrderBy(
 
 }
 
+// buildOrdering sets up the projection(s) of a single ORDER BY argument.
+// Typically this is a single column, with the exception of *.
+//
+// The projections are appended to the projections slice (and the resulting
+// slice is returned). Corresponding columns are added to the orderByScope.
 func (b *Builder) buildOrdering(
 	order *tree.Order, projections []opt.GroupID, inScope, projectionsScope, orderByScope *scope,
 ) []opt.GroupID {
@@ -124,7 +130,7 @@ func (b *Builder) buildOrdering(
 	}
 
 	// Build each of the ORDER BY columns. As a side effect, this will append new
-	// columns to the end of outScope.cols.
+	// columns to the end of orderByScope.cols.
 	start := len(orderByScope.cols)
 	for _, e := range exprs {
 		// Ensure we can order on the given column.

--- a/pkg/sql/opt/optbuilder/testdata/orderby
+++ b/pkg/sql/opt/optbuilder/testdata/orderby
@@ -692,3 +692,67 @@ project
       ├── variable: blocks.writer_id [type=string, outer=(2)]
       ├── variable: blocks.block_num [type=int, outer=(3)]
       └── variable: blocks.block_id [type=int, outer=(1)]
+
+exec-ddl
+CREATE TABLE abcd (
+  a INT PRIMARY KEY,
+  b INT,
+  c INT,
+  d INT
+)
+----
+TABLE abcd
+ ├── a int not null
+ ├── b int
+ ├── c int
+ ├── d int
+ └── INDEX primary
+      └── a int not null
+
+build
+SELECT a, b FROM abcd ORDER BY b, c
+----
+project
+ ├── columns: a:1(int!null) b:2(int)
+ ├── ordering: +2,+3
+ ├── sort
+ │    ├── columns: abcd.a:1(int!null) abcd.b:2(int) abcd.c:3(int) abcd.d:4(int)
+ │    ├── ordering: +2,+3
+ │    └── scan
+ │         └── columns: abcd.a:1(int!null) abcd.b:2(int) abcd.c:3(int) abcd.d:4(int)
+ └── projections [outer=(1-3)]
+      ├── variable: abcd.a [type=int, outer=(1)]
+      ├── variable: abcd.b [type=int, outer=(2)]
+      └── variable: abcd.c [type=int, outer=(3)]
+
+build
+SELECT a FROM abcd ORDER BY b, c
+----
+project
+ ├── columns: a:1(int!null)
+ ├── ordering: +2,+3
+ ├── sort
+ │    ├── columns: abcd.a:1(int!null) abcd.b:2(int) abcd.c:3(int) abcd.d:4(int)
+ │    ├── ordering: +2,+3
+ │    └── scan
+ │         └── columns: abcd.a:1(int!null) abcd.b:2(int) abcd.c:3(int) abcd.d:4(int)
+ └── projections [outer=(1-3)]
+      ├── variable: abcd.a [type=int, outer=(1)]
+      ├── variable: abcd.b [type=int, outer=(2)]
+      └── variable: abcd.c [type=int, outer=(3)]
+
+build
+SELECT a FROM abcd ORDER BY a, b, c
+----
+project
+ ├── columns: a:1(int!null)
+ ├── ordering: +1,+2,+3
+ ├── sort
+ │    ├── columns: abcd.a:1(int!null) abcd.b:2(int) abcd.c:3(int) abcd.d:4(int)
+ │    ├── ordering: +1,+2,+3
+ │    └── scan
+ │         └── columns: abcd.a:1(int!null) abcd.b:2(int) abcd.c:3(int) abcd.d:4(int)
+ └── projections [outer=(1-3)]
+      ├── variable: abcd.a [type=int, outer=(1)]
+      ├── variable: abcd.b [type=int, outer=(2)]
+      └── variable: abcd.c [type=int, outer=(3)]

--- a/pkg/sql/opt/xform/physical_props_factory.go
+++ b/pkg/sql/opt/xform/physical_props_factory.go
@@ -132,32 +132,33 @@ func (f physicalPropsFactory) constructChildProps(ev ExprView, nth int) opt.Phys
 
 	parentProps := ev.Physical()
 
-	var childProps opt.PhysicalProps
+	childProps := *parentProps
 	var changed bool
 
 	// Presentation property is provided by all the relational operators, so
 	// don't add it to childProps.
-	if parentProps.Presentation.Defined() {
+	if childProps.Presentation.Defined() {
+		childProps.Presentation = nil
 		changed = true
 	}
 
 	// Check for operators that might pass through the ordering property to
 	// input.
-	if parentProps.Ordering.Defined() {
+	if childProps.Ordering.Defined() {
 		switch ev.Operator() {
 		case opt.SelectOp, opt.ProjectOp:
 			if nth == 0 {
-				childProps.Ordering = parentProps.Ordering
 				break
 			}
 			fallthrough
 
 		default:
+			childProps.Ordering = nil
 			changed = true
 		}
 	}
 
-	// If properties haven't changed, then don't need to re-intern them.
+	// If properties haven't changed, no need to re-intern them.
 	if !changed {
 		return ev.required
 	}

--- a/pkg/sql/opt_exec_engine.go
+++ b/pkg/sql/opt_exec_engine.go
@@ -347,3 +347,17 @@ func (ee *execEngine) ConstructSetOp(
 ) (exec.Node, error) {
 	return ee.planner.newUnionNode(typ, all, left.(planNode), right.(planNode))
 }
+
+// ConstructSort is part of the exec.Factory interface.
+func (ee *execEngine) ConstructSort(
+	input exec.Node, ordering sqlbase.ColumnOrdering,
+) (exec.Node, error) {
+	plan := input.(planNode)
+	inputColumns := planColumns(plan)
+	return &sortNode{
+		plan:     plan,
+		columns:  inputColumns,
+		ordering: ordering,
+		needSort: true,
+	}, nil
+}


### PR DESCRIPTION
#### opt: fix ORDER BY build problem

Fixing a bug when building `ORDER BY` which causes incorrect
projections.

Release note: None

#### opt: support for partialsort in execbuilder tests

Support partial sorting of rows for queries which guarantee a partial,
but not total order.

Release note: None

#### opt: execute SortOp

Support `SortOp` in the `execbuilder`.

Release note: None