### PR TITLE
ui: fix capacity math bug

### DIFF
--- a/pkg/ui/src/redux/nodes.ts
+++ b/pkg/ui/src/redux/nodes.ts
@@ -181,7 +181,7 @@ export function sumNodeStats(
 
         result.capacityUsed += used;
         result.capacityAvailable += available;
-        result.capacityUsable = usable;
+        result.capacityUsable += usable;
         result.capacityTotal += n.metrics[MetricConstants.capacity];
         result.usedBytes += BytesUsed(n);
         result.usedMem += n.metrics[MetricConstants.rss];


### PR DESCRIPTION
Introduced in #23438. Fixes part of #23669.

Release note (admin ui change): Fix a bug in which usable capacity of nodes was not added up correctly.