### PR TITLE
roachtest: rework test registration

### DIFF
--- a/pkg/cmd/roachtest/cancel.go
+++ b/pkg/cmd/roachtest/cancel.go
@@ -38,12 +38,8 @@ import (
 // Once DistSQL queries provide more testing knobs, these tests can likely be
 // replaced with unit tests.
 func init() {
-	runCancel := func(t *test, queries []string, warehouses, nodes int, useDistsql bool) {
-		ctx := context.Background()
-
-		c := newCluster(ctx, t, nodes)
-		defer c.Destroy(ctx)
-
+	runCancel := func(ctx context.Context, t *test, c *cluster,
+		queries []string, warehouses int, useDistsql bool) {
 		c.Put(ctx, cockroach, "./cockroach", c.All())
 		c.Put(ctx, workload, "./workload", c.All())
 		c.Start(ctx, c.All())
@@ -109,8 +105,8 @@ func init() {
 		m.Wait()
 	}
 
-	warehouses := 10
-	nodes := 3
+	const warehouses = 10
+	const numNodes = 3
 	queries := []string{
 		`SELECT * FROM tpcc.stock`,
 		`SELECT * FROM tpcc.stock WHERE s_quantity > 100`,
@@ -120,15 +116,19 @@ func init() {
 		`SELECT ol_number, sum(s_quantity) FROM tpcc.stock JOIN tpcc.order_line ON s_i_id=ol_i_id WHERE ol_number > 10 GROUP BY ol_number ORDER BY ol_number`,
 	}
 
-	tests.Add(
-		fmt.Sprintf("cancel/tpcc/distsql/w=%d,nodes=%d", warehouses, nodes),
-		func(t *test) {
-			runCancel(t, queries, warehouses, nodes, true /* useDistsql */)
-		})
+	tests.Add(testSpec{
+		Name:  fmt.Sprintf("cancel/tpcc/distsql/w=%d,nodes=%d", warehouses, numNodes),
+		Nodes: nodes(numNodes),
+		Run: func(ctx context.Context, t *test, c *cluster) {
+			runCancel(ctx, t, c, queries, warehouses, true /* useDistsql */)
+		},
+	})
 
-	tests.Add(
-		fmt.Sprintf("cancel/tpcc/local/w=%d,nodes=%d", warehouses, nodes),
-		func(t *test) {
-			runCancel(t, queries, warehouses, nodes, false /* useDistsql */)
-		})
+	tests.Add(testSpec{
+		Name:  fmt.Sprintf("cancel/tpcc/local/w=%d,nodes=%d", warehouses, numNodes),
+		Nodes: nodes(numNodes),
+		Run: func(ctx context.Context, t *test, c *cluster) {
+			runCancel(ctx, t, c, queries, warehouses, false /* useDistsql */)
+		},
+	})
 }

--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -281,6 +281,64 @@ func (n nodeListOption) String() string {
 	return buf.String()
 }
 
+type nodeSpec struct {
+	Count       int
+	CPUs        int
+	MachineType string
+	Geo         bool
+}
+
+func (s *nodeSpec) args() []string {
+	var args []string
+	args = append(args, s.MachineType)
+	if s.Geo {
+		args = append(args, "--geo")
+	}
+	return args
+}
+
+type createOption interface {
+	apply(spec *nodeSpec)
+}
+
+type nodeCPUOption int
+
+func (o nodeCPUOption) apply(spec *nodeSpec) {
+	spec.CPUs = int(o)
+	if !local && clusterName != "local" {
+		spec.MachineType = fmt.Sprintf("--gce-machine-type=n1-highcpu-%d", spec.CPUs)
+	}
+}
+
+// cpu is a node option which requests nodes with the specified number of CPUs.
+func cpu(n int) nodeCPUOption {
+	return nodeCPUOption(n)
+}
+
+type nodeGeoOption struct{}
+
+func (o nodeGeoOption) apply(spec *nodeSpec) {
+	spec.Geo = true
+}
+
+// geo is a node option which requests geo-distributed nodes.
+func geo() nodeGeoOption {
+	return nodeGeoOption{}
+}
+
+// nodes is a helper method for creating a []nodeSpec given a node count and
+// options.
+func nodes(count int, opts ...createOption) []nodeSpec {
+	spec := nodeSpec{
+		Count: count,
+	}
+	cpu(4).apply(&spec)
+	for _, o := range opts {
+		o.apply(&spec)
+	}
+	return []nodeSpec{spec}
+}
+
 // cluster provides an interface for interacting with a set of machines,
 // starting and stopping a cockroach cluster on a subset of those machines, and
 // running load generators and other operations on the machines.
@@ -300,9 +358,22 @@ type cluster struct {
 // TODO(peter): Should set the lifetime of clusters to 2x the expected test
 // duration. The default lifetime of 12h is too long for some tests and will be
 // too short for others.
-func newCluster(ctx context.Context, t testI, nodes int, args ...interface{}) *cluster {
+//
+// TODO(peter): The nodes spec should really contain a nodeSpec per node. Need
+// to figure out how to make that work with `roachprod create`. Perhaps one
+// invocation of `roachprod create` per unique node-spec. Are there guarantees
+// we're making here about the mapping of nodeSpecs to node IDs?
+func newCluster(ctx context.Context, t testI, nodes []nodeSpec) *cluster {
 	if atomic.LoadInt32(&interrupted) == 1 {
 		t.Fatal("interrupted")
+	}
+
+	switch {
+	case len(nodes) == 0:
+		return nil
+	case len(nodes) > 1:
+		// TODO(peter): Need a motivating test that has different specs per node.
+		t.Fatalf("TODO(peter): unsupported nodes spec: %v", nodes)
 	}
 
 	l, err := rootLogger(t.Name())
@@ -312,7 +383,7 @@ func newCluster(ctx context.Context, t testI, nodes int, args ...interface{}) *c
 
 	c := &cluster{
 		name:      makeClusterName(t),
-		nodes:     nodes,
+		nodes:     nodes[0].Count,
 		status:    func(...interface{}) {},
 		t:         t,
 		l:         l,
@@ -324,10 +395,8 @@ func newCluster(ctx context.Context, t testI, nodes int, args ...interface{}) *c
 	registerCluster(c)
 
 	if c.name != clusterName {
-		sargs := []string{"roachprod", "create", c.name, "-n", fmt.Sprint(nodes)}
-		for _, arg := range args {
-			sargs = append(sargs, fmt.Sprint(arg))
-		}
+		sargs := []string{"roachprod", "create", c.name, "-n", fmt.Sprint(c.nodes)}
+		sargs = append(sargs, nodes[0].args()...)
 		if zones != "" {
 			sargs = append(sargs, "--gce-zones="+zones)
 		}
@@ -376,6 +445,10 @@ func (c *cluster) Node(i int) nodeListOption {
 }
 
 func (c *cluster) Destroy(ctx context.Context) {
+	if c == nil {
+		return
+	}
+
 	c.status("retrieving logs")
 	_ = execCmd(ctx, c.l, "roachprod", "get", c.name, "logs",
 		filepath.Join(artifacts, c.t.Name(), "logs"))

--- a/pkg/cmd/roachtest/import.go
+++ b/pkg/cmd/roachtest/import.go
@@ -25,21 +25,17 @@ const (
 )
 
 func init() {
-	runImportTPCC := func(t *test, warehouses, nodes int) {
-		ctx := context.Background()
-		c := newCluster(ctx, t, nodes)
-		defer c.Destroy(ctx)
-
-		c.Put(ctx, cockroach, "./cockroach", c.Range(1, nodes))
-		c.Put(ctx, workload, "./workload", c.Range(1, nodes))
+	runImportTPCC := func(ctx context.Context, t *test, c *cluster, warehouses int) {
+		c.Put(ctx, cockroach, "./cockroach")
+		c.Put(ctx, workload, "./workload")
 		t.Status("starting csv servers")
-		c.Start(ctx, c.Range(1, nodes))
-		for node := 1; node <= nodes; node++ {
+		c.Start(ctx)
+		for node := 1; node <= c.nodes; node++ {
 			c.Run(ctx, node, `./workload csv-server --port=8081 &> logs/workload-csv-server.log < /dev/null &`)
 		}
 
 		t.Status("running workload")
-		m := newMonitor(ctx, c, c.Range(1, nodes))
+		m := newMonitor(ctx, c)
 		m.Go(func(ctx context.Context) error {
 			cmd := fmt.Sprintf(
 				`./workload fixtures make tpcc --warehouses=%d --csv-server='http://localhost:8081' `+
@@ -51,28 +47,31 @@ func init() {
 		m.Wait()
 	}
 
-	const warehouses, nodes = 1000, 4
-	tests.Add(fmt.Sprintf("import/tpcc/warehouses=%d/nodes=%d", warehouses, nodes), func(t *test) {
-		runImportTPCC(t, warehouses, nodes)
+	const warehouses = 1000
+	const numNodes = 4
+	tests.Add(testSpec{
+		Name:  fmt.Sprintf("import/tpcc/warehouses=%d/nodes=%d", warehouses, numNodes),
+		Nodes: nodes(numNodes),
+		Run: func(ctx context.Context, t *test, c *cluster) {
+			runImportTPCC(ctx, t, c, warehouses)
+		},
 	})
 }
 
 func init() {
-	for _, nodes := range []int{4, 8} {
-		nodes := nodes
-		tests.Add(fmt.Sprintf(`import/tpch/nodes=%d`, nodes), func(t *test) {
-			ctx := context.Background()
-			c := newCluster(ctx, t, nodes)
-			defer c.Destroy(ctx)
-
-			c.Put(ctx, cockroach, "./cockroach")
-			c.Start(ctx)
-			conn := c.Conn(ctx, 1)
-			if _, err := conn.Exec(`create database csv`); err != nil {
-				t.Fatal(err)
-			}
-			c.status(`running import`)
-			if _, err := conn.Exec(`
+	for _, n := range []int{4, 8} {
+		tests.Add(testSpec{
+			Name:  fmt.Sprintf(`import/tpch/nodes=%d`, n),
+			Nodes: nodes(n),
+			Run: func(ctx context.Context, t *test, c *cluster) {
+				c.Put(ctx, cockroach, "./cockroach")
+				c.Start(ctx)
+				conn := c.Conn(ctx, 1)
+				if _, err := conn.Exec(`create database csv`); err != nil {
+					t.Fatal(err)
+				}
+				c.status(`running import`)
+				if _, err := conn.Exec(`
 				IMPORT TABLE csv.lineitem
 				CREATE USING 'gs://cockroach-fixtures/tpch-csv/schema/lineitem.sql'
 				CSV DATA (
@@ -86,8 +85,9 @@ func init() {
 				'gs://cockroach-fixtures/tpch-csv/sf-100/lineitem.tbl.8'
 				) WITH  delimiter='|'
 			`); err != nil {
-				t.Fatal(err)
-			}
+					t.Fatal(err)
+				}
+			},
 		})
 	}
 }

--- a/pkg/cmd/roachtest/restore.go
+++ b/pkg/cmd/roachtest/restore.go
@@ -20,25 +20,25 @@ import (
 )
 
 func init() {
-	tests.Add(`restore2TB`, func(t *test) {
-		ctx := context.Background()
-		c := newCluster(ctx, t, 10)
-		defer c.Destroy(ctx)
-
-		c.Put(ctx, cockroach, "./cockroach")
-		c.Start(ctx)
-		m := newMonitor(ctx, c)
-		m.Go(func(ctx context.Context) error {
-			c.Run(ctx, 1, `./cockroach sql --insecure -e "CREATE DATABASE restore2tb"`)
-			c.status(`running 2tb restore`)
-			// TODO(dan): It'd be nice if we could keep track over time of how
-			// long this next line took.
-			c.Run(ctx, 1, `./cockroach sql --insecure -e "
+	tests.Add(testSpec{
+		Name:  `restore2TB`,
+		Nodes: nodes(10),
+		Run: func(ctx context.Context, t *test, c *cluster) {
+			c.Put(ctx, cockroach, "./cockroach")
+			c.Start(ctx)
+			m := newMonitor(ctx, c)
+			m.Go(func(ctx context.Context) error {
+				c.Run(ctx, 1, `./cockroach sql --insecure -e "CREATE DATABASE restore2tb"`)
+				c.status(`running 2tb restore`)
+				// TODO(dan): It'd be nice if we could keep track over time of how
+				// long this next line took.
+				c.Run(ctx, 1, `./cockroach sql --insecure -e "
 				RESTORE csv.bank FROM
 				'gs://cockroach-fixtures/workload/bank/version=1.0.0,payload-bytes=10240,ranges=0,rows=65104166,seed=1/bank'
 				WITH into_db = 'restore2tb'"`)
-			return nil
-		})
-		m.Wait()
+				return nil
+			})
+			m.Wait()
+		},
 	})
 }

--- a/pkg/cmd/roachtest/roachmart.go
+++ b/pkg/cmd/roachtest/roachmart.go
@@ -21,11 +21,7 @@ import (
 )
 
 func init() {
-	runRoachmart := func(t *test, partition bool) {
-		ctx := context.Background()
-		c := newCluster(ctx, t, 9, "--geo")
-		defer c.Destroy(ctx)
-
+	runRoachmart := func(ctx context.Context, t *test, c *cluster, partition bool) {
 		c.Put(ctx, cockroach, "./cockroach")
 		c.Put(ctx, workload, "./workload")
 		c.Start(ctx)
@@ -77,9 +73,12 @@ func init() {
 
 	for _, v := range []bool{true, false} {
 		v := v
-		tests.Add(fmt.Sprintf("roachmart/partition=%v", v),
-			func(t *test) {
-				runRoachmart(t, v)
-			})
+		tests.Add(testSpec{
+			Name:  fmt.Sprintf("roachmart/partition=%v", v),
+			Nodes: nodes(9, geo()),
+			Run: func(ctx context.Context, t *test, c *cluster) {
+				runRoachmart(ctx, t, c, v)
+			},
+		})
 	}
 }

--- a/pkg/cmd/roachtest/slack.go
+++ b/pkg/cmd/roachtest/slack.go
@@ -89,11 +89,11 @@ func postSlackReport(pass, fail map[*test]struct{}, skip int) {
 			failTests = append(failTests, t)
 		}
 		sort.Slice(failTests, func(i, j int) bool {
-			return failTests[i].name < failTests[j].name
+			return failTests[i].Name() < failTests[j].Name()
 		})
 		var failures bytes.Buffer
 		for _, t := range failTests {
-			fmt.Fprintf(&failures, "%s\n", t.name)
+			fmt.Fprintf(&failures, "%s\n", t.Name())
 		}
 
 		params.Attachments = append(params.Attachments,

--- a/pkg/cmd/roachtest/test_test.go
+++ b/pkg/cmd/roachtest/test_test.go
@@ -16,16 +16,23 @@
 package main
 
 import (
+	"context"
 	"io/ioutil"
 	"testing"
 )
 
 func TestRegistryRun(t *testing.T) {
 	r := &registry{m: make(map[string]*test), out: ioutil.Discard}
-	r.Add("pass", func(t *test) {
+	r.Add(testSpec{
+		Name: "pass",
+		Run: func(ctx context.Context, t *test, c *cluster) {
+		},
 	})
-	r.Add("fail", func(t *test) {
-		t.Fatal("failed")
+	r.Add(testSpec{
+		Name: "fail",
+		Run: func(ctx context.Context, t *test, c *cluster) {
+			t.Fatal("failed")
+		},
 	})
 
 	testCases := []struct {

--- a/pkg/cmd/roachtest/tpcc.go
+++ b/pkg/cmd/roachtest/tpcc.go
@@ -21,10 +21,8 @@ import (
 )
 
 func init() {
-	runTPCC := func(t *test, warehouses, nodes int, extra string) {
-		ctx := context.Background()
-		c := newCluster(ctx, t, nodes+1)
-		defer c.Destroy(ctx)
+	runTPCC := func(ctx context.Context, t *test, c *cluster, warehouses int, extra string) {
+		nodes := c.nodes - 1
 
 		c.Put(ctx, cockroach, "./cockroach", c.Range(1, nodes))
 		c.Put(ctx, workload, "./workload", c.Node(nodes+1))
@@ -44,10 +42,18 @@ func init() {
 		m.Wait()
 	}
 
-	tests.Add("tpcc/w=1/nodes=3", func(t *test) {
-		runTPCC(t, 1, 3, " --wait=false")
+	tests.Add(testSpec{
+		Name:  "tpcc/w=1/nodes=3",
+		Nodes: nodes(4),
+		Run: func(ctx context.Context, t *test, c *cluster) {
+			runTPCC(ctx, t, c, 1, " --wait=false")
+		},
 	})
-	tests.Add("tpmc/w=1/nodes=3", func(t *test) {
-		runTPCC(t, 1, 3, "")
+	tests.Add(testSpec{
+		Name:  "tpmc/w=1/nodes=3",
+		Nodes: nodes(4),
+		Run: func(ctx context.Context, t *test, c *cluster) {
+			runTPCC(ctx, t, c, 1, "")
+		},
 	})
 }

--- a/pkg/cmd/roachtest/version.go
+++ b/pkg/cmd/roachtest/version.go
@@ -31,11 +31,8 @@ import (
 )
 
 func init() {
-	runVersion := func(t *test, version string, nodes int) {
-		ctx := context.Background()
-		c := newCluster(ctx, t, nodes+1)
-		defer c.Destroy(ctx)
-
+	runVersion := func(ctx context.Context, t *test, c *cluster, version string) {
+		nodes := c.nodes - 1
 		goos := ifLocal(runtime.GOOS, "linux")
 
 		b, err := binfetcher.Download(ctx, binfetcher.Options{
@@ -211,11 +208,13 @@ func init() {
 	}
 
 	const version = "v1.1.5"
-	for _, nodes := range []int{3, 5} {
-		tests.Add(
-			fmt.Sprintf("version/mixedWith=%s/nodes=%d", version, nodes),
-			func(t *test) {
-				runVersion(t, version, nodes)
-			})
+	for _, n := range []int{3, 5} {
+		tests.Add(testSpec{
+			Name:  fmt.Sprintf("version/mixedWith=%s/nodes=%d", version, n),
+			Nodes: nodes(n + 1),
+			Run: func(ctx context.Context, t *test, c *cluster) {
+				runVersion(ctx, t, c, version)
+			},
+		})
 	}
 }


### PR DESCRIPTION
Added `testSpec` which holds the specification for a single test. Added
`registry.AddSpec` to add a test given a `testSpec`. In addition to a
test name and run function, `testSpec` contains a `Help`
field (currently unused) and a `Nodes` spec. This allows declarative
specification of the resources needed for a test which will allow the
test runner to better utilize resources when scheduling tests and ensure
that running tests in parallel doesn't exceed resource quotas.

Fixes #22942

Release note: None