### PR TITLE
sql: implement pg_operator

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -1254,6 +1254,14 @@ query OOIIIIIB
 SELECT * FROM pg_catalog.pg_sequence
 ----
 
+## pg_catalog.pg_operator
+
+query OTOOTBBOOOOOOOO colnames
+SELECT * FROM pg_catalog.pg_operator where oprname='+' and oprleft='float8'::regtype
+----
+oid         oprname  oprnamespace  oprowner  oprkind  oprcanmerge  oprcanhash  oprleft  oprright  oprresult  oprcom  oprnegate  oprcode  oprrest  oprjoin
+3695865198  +        3572887043    NULL      b        false        false       701      701       701        NULL    NULL       NULL     NULL     NULL
+
 # Verify proper functionality of system information functions.
 
 query TT

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -1924,6 +1924,21 @@ var CmpOps = map[ComparisonOperator]cmpOpOverload{
 	},
 }
 
+// This map contains the inverses for operators in the CmpOps map that have
+// inverses.
+var cmpOpsInverse map[ComparisonOperator]ComparisonOperator
+
+func init() {
+	cmpOpsInverse = make(map[ComparisonOperator]ComparisonOperator)
+	for cmpOpIdx := range comparisonOpName {
+		cmpOp := ComparisonOperator(cmpOpIdx)
+		newOp, _, _, _, _ := foldComparisonExpr(cmpOp, DNull, DNull)
+		if newOp != cmpOp {
+			cmpOpsInverse[newOp] = cmpOp
+		}
+	}
+}
+
 func boolFromCmp(cmp int, op ComparisonOperator) *DBool {
 	switch op {
 	case EQ, IsNotDistinctFrom:

--- a/pkg/sql/sem/tree/expr.go
+++ b/pkg/sql/sem/tree/expr.go
@@ -366,6 +366,13 @@ func (i ComparisonOperator) String() string {
 	return comparisonOpName[i]
 }
 
+// Inverse returns the inverse of this comparison operator if it exists. The
+// second return value is true if it exists, and false otherwise.
+func (i ComparisonOperator) Inverse() (ComparisonOperator, bool) {
+	inverse, ok := cmpOpsInverse[i]
+	return inverse, ok
+}
+
 // hasSubOperator returns if the ComparisonOperator is used with a sub-operator.
 func (i ComparisonOperator) hasSubOperator() bool {
 	switch i {

--- a/pkg/sql/sem/tree/overload.go
+++ b/pkg/sql/sem/tree/overload.go
@@ -33,6 +33,12 @@ type overloadImpl interface {
 	preferred() bool
 }
 
+// GetParamsAndReturnType gets the parameters and return type of an
+// overloadImpl.
+func GetParamsAndReturnType(impl overloadImpl) (TypeList, ReturnTyper) {
+	return impl.params(), impl.returnType()
+}
+
 // TypeList is a list of types representing a function parameter list.
 type TypeList interface {
 	// match checks if all types in the TypeList match the corresponding elements in types.


### PR DESCRIPTION
Needed for sqlsmith, which uses the pg_operator table to pick operators
to use based on datatype.

Release note: None