### PR TITLE
ui: node list: more descriptive label; add column

### DIFF
--- a/pkg/ui/src/views/cluster/containers/nodesOverview/index.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodesOverview/index.tsx
@@ -118,11 +118,20 @@ class LiveNodeList extends React.Component<NodeCategoryListProps, {}> {
               },
               sort: (ns) => ns.started_at,
             },
-            // Bytes - displays the total persisted bytes maintained by the node.
+            // Stored - displays the total persisted bytes maintained by the node.
+            // "Used" would be ambiguous here, since this is only what's used for
+            // cockroach data, not the cockroach binary itself, the OS, and whatever
+            // else is using disk space.
             {
-              title: "Bytes",
+              title: "Stored",
               cell: (ns) => Bytes(BytesUsed(ns)),
               sort: (ns) => BytesUsed(ns),
+            },
+            // Capacity - displays the total hard drive capacity of this node.
+            {
+              title: "Capacity",
+              cell: (ns) => Bytes(ns.metrics[MetricConstants.capacity]),
+              sort: (ns) => ns.metrics[MetricConstants.capacity],
             },
             // Replicas - displays the total number of replicas on the node.
             {


### PR DESCRIPTION
Fixes #23680

Before:
![image](https://user-images.githubusercontent.com/7341/37230473-a8fc4408-23b5-11e8-9649-fec500a19bcd.png)

After:
![image](https://user-images.githubusercontent.com/7341/37230456-922f1d0e-23b5-11e8-9ec3-64d9248e36dc.png)

This is the best terminology I can come up with; curious if others have suggestions.

Release note (admin ui change): On node list, add "capacity" column and rename "bytes" to "stored".