### PR TITLE
cherry-pick 2.0: sql: add ResultColumns to zeroNode to fix crash

### DIFF
--- a/pkg/ccl/roleccl/role.go
+++ b/pkg/ccl/roleccl/role.go
@@ -183,7 +183,7 @@ func grantRolePlanHook(
 		}
 	}
 
-	return &sql.ZeroNode{}, nil
+	return sql.NewZeroNode(nil /* columns */), nil
 }
 
 func revokeRolePlanHook(
@@ -277,7 +277,7 @@ func revokeRolePlanHook(
 		}
 	}
 
-	return &sql.ZeroNode{}, nil
+	return sql.NewZeroNode(nil /* columns */), nil
 }
 
 func init() {

--- a/pkg/sql/alter_sequence.go
+++ b/pkg/sql/alter_sequence.go
@@ -44,7 +44,7 @@ func (p *planner) AlterSequence(ctx context.Context, n *tree.AlterSequence) (pla
 		return nil, err
 	}
 	if seqDesc == nil {
-		return &zeroNode{}, nil
+		return newZeroNode(nil /* columns */), nil
 	}
 
 	if err := p.CheckPrivilege(ctx, seqDesc, privilege.CREATE); err != nil {

--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -53,7 +53,7 @@ func (p *planner) AlterTable(ctx context.Context, n *tree.AlterTable) (planNode,
 		return nil, err
 	}
 	if tableDesc == nil {
-		return &zeroNode{}, nil
+		return newZeroNode(nil /* columns */), nil
 	}
 
 	if err := p.CheckPrivilege(ctx, tableDesc, privilege.CREATE); err != nil {

--- a/pkg/sql/deallocate.go
+++ b/pkg/sql/deallocate.go
@@ -32,5 +32,5 @@ func (p *planner) Deallocate(ctx context.Context, s *tree.Deallocate) (planNode,
 				"prepared statement %q does not exist", s.Name)
 		}
 	}
-	return &zeroNode{}, nil
+	return newZeroNode(nil /* columns */), nil
 }

--- a/pkg/sql/discard.go
+++ b/pkg/sql/discard.go
@@ -46,5 +46,5 @@ func (p *planner) Discard(ctx context.Context, s *tree.Discard) (planNode, error
 		return nil, pgerror.NewErrorf(pgerror.CodeInternalError,
 			"unknown mode for DISCARD: %d", s.Mode)
 	}
-	return &zeroNode{}, nil
+	return newZeroNode(nil /* columns */), nil
 }

--- a/pkg/sql/drop_database.go
+++ b/pkg/sql/drop_database.go
@@ -58,7 +58,7 @@ func (p *planner) DropDatabase(ctx context.Context, n *tree.DropDatabase) (planN
 	}
 	if dbDesc == nil {
 		// IfExists was specified and database was not found.
-		return &zeroNode{}, nil
+		return newZeroNode(nil /* columns */), nil
 	}
 
 	if err := p.CheckPrivilege(ctx, dbDesc, privilege.DROP); err != nil {

--- a/pkg/sql/drop_sequence.go
+++ b/pkg/sql/drop_sequence.go
@@ -51,7 +51,7 @@ func (p *planner) DropSequence(ctx context.Context, n *tree.DropSequence) (planN
 	}
 
 	if len(td) == 0 {
-		return &zeroNode{}, nil
+		return newZeroNode(nil /* columns */), nil
 	}
 
 	return &dropSequenceNode{

--- a/pkg/sql/drop_table.go
+++ b/pkg/sql/drop_table.go
@@ -94,7 +94,7 @@ func (p *planner) DropTable(ctx context.Context, n *tree.DropTable) (planNode, e
 	}
 
 	if len(td) == 0 {
-		return &zeroNode{}, nil
+		return newZeroNode(nil /* columns */), nil
 	}
 	return &dropTableNode{n: n, td: td}, nil
 }

--- a/pkg/sql/drop_view.go
+++ b/pkg/sql/drop_view.go
@@ -71,7 +71,7 @@ func (p *planner) DropView(ctx context.Context, n *tree.DropView) (planNode, err
 	}
 
 	if len(td) == 0 {
-		return &zeroNode{}, nil
+		return newZeroNode(nil /* columns */), nil
 	}
 	return &dropViewNode{n: n, td: td}, nil
 }

--- a/pkg/sql/grant_revoke.go
+++ b/pkg/sql/grant_revoke.go
@@ -117,5 +117,5 @@ func (p *planner) changePrivileges(
 	if err := p.txn.Run(ctx, b); err != nil {
 		return nil, err
 	}
-	return &zeroNode{}, nil
+	return newZeroNode(nil /* columns */), nil
 }

--- a/pkg/sql/logictest/testdata/logic_test/join
+++ b/pkg/sql/logictest/testdata/logic_test/join
@@ -2336,3 +2336,12 @@ SELECT * FROM foo JOIN bar USING (a, b) WHERE foo.c = bar.c AND foo.d = bar.d
 1  1  1  1  1  1
 2  2  2  2  2  2
 3  3  3  3  3  3
+
+# Regression test for 23664.
+query III rowsort
+SELECT * FROM onecolumn AS a(x) RIGHT JOIN twocolumn ON false
+----
+NULL  44    51
+NULL  NULL  52
+NULL  42    53
+NULL  45    45

--- a/pkg/sql/logictest/testdata/logic_test/select_index
+++ b/pkg/sql/logictest/testdata/logic_test/select_index
@@ -195,8 +195,7 @@ SELECT message FROM [SHOW KV TRACE FOR SELECT * FROM t WHERE a > 1 AND b > 'b']
 query TTT
 EXPLAIN SELECT * FROM t WHERE a > 1 AND a < 2
 ----
-render       ·  ·
- └── norows  ·  ·
+norows  ·  ·
 
 query T
 SELECT message FROM [SHOW KV TRACE FOR SELECT * FROM t WHERE a = 1 AND 'a' < b AND 'c' > b]
@@ -314,20 +313,17 @@ output row: [3 4]
 query TTT
 EXPLAIN SELECT * FROM t WHERE a = 1 AND false
 ----
-render       ·  ·
- └── norows  ·  ·
+norows  ·  ·
 
 query TTT
 EXPLAIN SELECT * FROM t WHERE a = 1 AND NULL
 ----
-render       ·  ·
- └── norows  ·  ·
+norows  ·  ·
 
 query TTT
 EXPLAIN SELECT * FROM t WHERE a = NULL AND a != NULL
 ----
-render       ·  ·
- └── norows  ·  ·
+norows  ·  ·
 
 # Make sure that mixed type comparison operations are not used
 # for selecting indexes.

--- a/pkg/sql/opt_index_selection.go
+++ b/pkg/sql/opt_index_selection.go
@@ -139,7 +139,7 @@ func (p *planner) selectIndex(
 			if spans, ok := c.ic.Spans(); ok && len(spans) == 0 {
 				// No spans (i.e. the filter is always false). Note that if a filter
 				// results in no constraints, ok would be false.
-				return &zeroNode{}, nil
+				return newZeroNode(s.resultColumns), nil
 			}
 		}
 	}
@@ -205,7 +205,7 @@ func (p *planner) selectIndex(
 
 	if len(s.spans) == 0 {
 		// There are no spans to scan.
-		return &zeroNode{}, nil
+		return newZeroNode(s.resultColumns), nil
 	}
 
 	s.origFilter = s.filter

--- a/pkg/sql/parallel_stmts_test.go
+++ b/pkg/sql/parallel_stmts_test.go
@@ -31,7 +31,7 @@ import (
 )
 
 func newPlanNode() planNode {
-	return &zeroNode{}
+	return newZeroNode(nil /* columns */)
 }
 
 // assertLen asserts the number of plans in the ParallelizeQueue.

--- a/pkg/sql/plan_columns.go
+++ b/pkg/sql/plan_columns.go
@@ -77,6 +77,8 @@ func getPlanColumns(plan planNode, mut bool) sqlbase.ResultColumns {
 		return n.run.values.columns
 	case *showTraceNode:
 		return n.columns
+	case *zeroNode:
+		return n.columns
 
 	// Nodes with a fixed schema.
 	case *scrubNode:

--- a/pkg/sql/rename_column.go
+++ b/pkg/sql/rename_column.go
@@ -47,7 +47,7 @@ func (p *planner) RenameColumn(ctx context.Context, n *tree.RenameColumn) (planN
 		return nil, err
 	}
 	if tableDesc == nil {
-		return &zeroNode{}, nil
+		return newZeroNode(nil /* columns */), nil
 	}
 
 	if err := p.CheckPrivilege(ctx, tableDesc, privilege.CREATE); err != nil {
@@ -79,7 +79,7 @@ func (p *planner) RenameColumn(ctx context.Context, n *tree.RenameColumn) (planN
 
 	if n.Name == n.NewName {
 		// Noop.
-		return &zeroNode{}, nil
+		return newZeroNode(nil /* columns */), nil
 	}
 
 	if _, _, err := tableDesc.FindColumnByName(n.NewName); err == nil {
@@ -158,5 +158,5 @@ func (p *planner) RenameColumn(ctx context.Context, n *tree.RenameColumn) (planN
 	//	return nil, err
 	// }
 	p.notifySchemaChange(tableDesc, sqlbase.InvalidMutationID)
-	return &zeroNode{}, nil
+	return newZeroNode(nil /* columns */), nil
 }

--- a/pkg/sql/rename_database.go
+++ b/pkg/sql/rename_database.go
@@ -52,7 +52,7 @@ func (p *planner) RenameDatabase(ctx context.Context, n *tree.RenameDatabase) (p
 
 	if n.Name == n.NewName {
 		// Noop.
-		return &zeroNode{}, nil
+		return newZeroNode(nil /* columns */), nil
 	}
 
 	// Check if any views depend on tables in the database. Because our views
@@ -106,5 +106,5 @@ func (p *planner) RenameDatabase(ctx context.Context, n *tree.RenameDatabase) (p
 	if err := p.renameDatabase(ctx, dbDesc, string(n.NewName)); err != nil {
 		return nil, err
 	}
-	return &zeroNode{}, nil
+	return newZeroNode(nil /* columns */), nil
 }

--- a/pkg/sql/rename_index.go
+++ b/pkg/sql/rename_index.go
@@ -46,7 +46,7 @@ func (p *planner) RenameIndex(ctx context.Context, n *tree.RenameIndex) (planNod
 	if err != nil {
 		if n.IfExists {
 			// Noop.
-			return &zeroNode{}, nil
+			return newZeroNode(nil /* columns */), nil
 		}
 		// Index does not exist, but we want it to: error out.
 		return nil, err
@@ -70,7 +70,7 @@ func (p *planner) RenameIndex(ctx context.Context, n *tree.RenameIndex) (planNod
 
 	if n.Index.Index == n.NewName {
 		// Noop.
-		return &zeroNode{}, nil
+		return newZeroNode(nil /* columns */), nil
 	}
 
 	if _, _, err := tableDesc.FindIndexByName(string(n.NewName)); err == nil {
@@ -98,5 +98,5 @@ func (p *planner) RenameIndex(ctx context.Context, n *tree.RenameIndex) (planNod
 	//	return nil, err
 	// }
 	p.notifySchemaChange(tableDesc, sqlbase.InvalidMutationID)
-	return &zeroNode{}, nil
+	return newZeroNode(nil /* columns */), nil
 }

--- a/pkg/sql/rename_table.go
+++ b/pkg/sql/rename_table.go
@@ -59,7 +59,7 @@ func (p *planner) RenameTable(ctx context.Context, n *tree.RenameTable) (planNod
 	}
 	if tableDesc == nil {
 		// Noop.
-		return &zeroNode{}, nil
+		return newZeroNode(nil /* columns */), nil
 	}
 
 	if tableDesc.State != sqlbase.TableDescriptor_PUBLIC {
@@ -106,7 +106,7 @@ func (p *planner) RenameTable(ctx context.Context, n *tree.RenameTable) (planNod
 		oldTn.Schema() == newTn.Schema() &&
 		oldTn.Table() == newTn.Table() {
 		// Noop.
-		return &zeroNode{}, nil
+		return newZeroNode(nil /* columns */), nil
 	}
 
 	tableDesc.SetName(newTn.Table())
@@ -153,7 +153,7 @@ func (p *planner) RenameTable(ctx context.Context, n *tree.RenameTable) (planNod
 	}
 	p.notifySchemaChange(tableDesc, sqlbase.InvalidMutationID)
 
-	return &zeroNode{}, nil
+	return newZeroNode(nil /* columns */), nil
 }
 
 // TODO(a-robinson): Support renaming objects depended on by views once we have

--- a/pkg/sql/set_default_isolation.go
+++ b/pkg/sql/set_default_isolation.go
@@ -51,5 +51,5 @@ func (p *planner) SetSessionCharacteristics(n *tree.SetSessionCharacteristics) (
 		return nil, pgerror.Unimplemented("default transaction priority",
 			"unsupported session default: transaction priority")
 	}
-	return &zeroNode{}, nil
+	return newZeroNode(nil /* columns */), nil
 }

--- a/pkg/sql/set_transaction.go
+++ b/pkg/sql/set_transaction.go
@@ -20,5 +20,5 @@ import (
 
 // SetTransaction sets a transaction's isolation level
 func (p *planner) SetTransaction(n *tree.SetTransaction) (planNode, error) {
-	return &zeroNode{}, p.extendedEvalCtx.TxnModesSetter.setTransactionModes(n.Modes)
+	return newZeroNode(nil /* columns */), p.extendedEvalCtx.TxnModesSetter.setTransactionModes(n.Modes)
 }

--- a/pkg/sql/truncate.go
+++ b/pkg/sql/truncate.go
@@ -108,7 +108,7 @@ func (p *planner) Truncate(ctx context.Context, n *tree.Truncate) (planNode, err
 		}
 	}
 
-	return &zeroNode{}, nil
+	return newZeroNode(nil /* columns */), nil
 }
 
 // truncateTable truncates the data of a table in a single transaction. It

--- a/pkg/sql/zero.go
+++ b/pkg/sql/zero.go
@@ -18,21 +18,23 @@ import (
 	"context"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 )
-
-// ZeroNode is the exported alias for zeroNode. Used by CCL.
-type ZeroNode = zeroNode
 
 // zeroNode is a planNode with no columns and no rows and is used for nodes that
 // have no results. (e.g. a table for which the filtering condition has a
-// contradiction)
+// contradiction).
 type zeroNode struct {
-	// We use planNodes as map keys, and zero-size structs are optimized to all
-	// point to the same location in memory. As a result, unless we include some
-	// field in this struct every zeroNode will have the same identity.
-	// In particular, the parallelization detector maps planNodes to go channels
-	// which this causes problems for (see TestParallelizeQueueNoDependencies).
-	_ interface{}
+	columns sqlbase.ResultColumns
+}
+
+func newZeroNode(columns sqlbase.ResultColumns) *zeroNode {
+	return &zeroNode{columns: columns}
+}
+
+// NewZeroNode is the exported version of makeZeroNode. Used by CCL.
+func NewZeroNode(columns sqlbase.ResultColumns) PlanNode {
+	return newZeroNode(columns)
 }
 
 func (z *zeroNode) Next(runParams) (bool, error) { return false, nil }

--- a/pkg/testutils/lint/lint_test.go
+++ b/pkg/testutils/lint/lint_test.go
@@ -947,6 +947,7 @@ func TestLint(t *testing.T) {
 				filter,
 				// _fsm.go files are allowed to dot-import the util/fsm package.
 				stream.GrepNot("_fsm.go.*should not use dot imports"),
+				stream.GrepNot("sql/.*exported func .* returns unexported type sql.planNode"),
 			), func(s string) {
 				t.Error(s)
 			}); err != nil {


### PR DESCRIPTION
In most contexts, `zeroNode` is used when the statement returns
nothing (no columns). However, it is also used to replace a `scanNode`
when index selection knows that there won't be any useful results. In
this case, the node must still present the same `planColumns` as the
`scanNode`.

Fixes #23664.

Release note: None

Cherry-pick of #23696. CC @cockroachdb/release 