### PR TITLE
opt: Push down filter conditions

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/join
+++ b/pkg/sql/opt/exec/execbuilder/testdata/join
@@ -35,20 +35,18 @@ x:int  y:int  x:int  z:int
 3      30     3      300
 3      30     4      400
 
-# We don't yet push the filter into the join.
 exec-explain
 SELECT * FROM t.a, t.b WHERE a.x = b.x
 ----
-filter          0  filter  ·       ·          (x, y, x, z)  ·
- │              0  ·       filter  x = x      ·             ·
- └── join       1  join    ·       ·          (x, y, x, z)  ·
-      │         1  ·       type    cross      ·             ·
-      ├── scan  2  scan    ·       ·          (x, y)        ·
-      │         2  ·       table   a@primary  ·             ·
-      │         2  ·       spans   ALL        ·             ·
-      └── scan  2  scan    ·       ·          (x, z)        ·
-·               2  ·       table   b@primary  ·             ·
-·               2  ·       spans   ALL        ·             ·
+join       0  join  ·         ·          (x, y, x, z)  ·
+ │         0  ·     type      inner      ·             ·
+ │         0  ·     equality  (x) = (x)  ·             ·
+ ├── scan  1  scan  ·         ·          (x, y)        ·
+ │         1  ·     table     a@primary  ·             ·
+ │         1  ·     spans     ALL        ·             ·
+ └── scan  1  scan  ·         ·          (x, z)        ·
+·          1  ·     table     b@primary  ·             ·
+·          1  ·     spans     ALL        ·             ·
 
 exec
 SELECT * FROM t.a, t.b WHERE a.x = b.x
@@ -172,3 +170,53 @@ x:int  y:int  z:int
 2      20     200
 3      30     300
 4      NULL   400
+
+# Select filters are pushed through join, down to scans.
+exec-explain
+SELECT * FROM t.a, t.b WHERE y > 10 AND z < 400
+----
+join            0  join    ·       ·          (x, y, x, z)  ·
+ │              0  ·       type    cross      ·             ·
+ ├── filter     1  filter  ·       ·          (x, y)        ·
+ │    │         1  ·       filter  y > 10     ·             ·
+ │    └── scan  2  scan    ·       ·          (x, y)        ·
+ │              2  ·       table   a@primary  ·             ·
+ │              2  ·       spans   ALL        ·             ·
+ └── filter     1  filter  ·       ·          (x, z)        ·
+      │         1  ·       filter  z < 400    ·             ·
+      └── scan  2  scan    ·       ·          (x, z)        ·
+·               2  ·       table   b@primary  ·             ·
+·               2  ·       spans   ALL        ·             ·
+
+exec
+SELECT * FROM t.a, t.b WHERE y > 10 AND z < 400
+----
+x:int  y:int  x:int  z:int
+2      20     2      200
+2      20     3      300
+3      30     2      200
+3      30     3      300
+
+# Join filter is pushed through join, down to scan.
+exec-explain
+SELECT * FROM t.a LEFT JOIN t.b ON a.x=b.x AND z < 300
+----
+join            0  join    ·         ·           (x, y, x, z)  ·
+ │              0  ·       type      left outer  ·             ·
+ │              0  ·       equality  (x) = (x)   ·             ·
+ ├── scan       1  scan    ·         ·           (x, y)        ·
+ │              1  ·       table     a@primary   ·             ·
+ │              1  ·       spans     ALL         ·             ·
+ └── filter     1  filter  ·         ·           (x, z)        ·
+      │         1  ·       filter    z < 300     ·             ·
+      └── scan  2  scan    ·         ·           (x, z)        ·
+·               2  ·       table     b@primary   ·             ·
+·               2  ·       spans     ALL         ·             ·
+
+exec
+SELECT * FROM t.a LEFT JOIN t.b ON a.x=b.x AND z < 300
+----
+x:int  y:int  x:int  z:int
+1      10     NULL   NULL
+2      20     2      200
+3      30     NULL   NULL

--- a/pkg/sql/opt/xform/rules/citations.md
+++ b/pkg/sql/opt/xform/rules/citations.md
@@ -1,0 +1,12 @@
+This file contains citations for papers that contain the relational identities
+upon which the transformation rules are based. Some rules contain a "Citations"
+line which references one or more entries in this list of citations, in which
+further information, and in some cases proofs, can be found.
+
+[1] Galindo-Legaria, C.A. & Rosenthal, Arnon. (1997).
+    Outerjoin Simplification and Reordering for Query Optimization.
+    ACM Trans. Database Syst.. 22. 43-73. 10.1145/244810.244812.
+    https://www.researchgate.net/publication/220225172_Outerjoin_Simplification_and_Reordering_for_Query_Optimization
+
+[2] M. M. Joshi and C. A. Galindo-Legaria. Properties of the GroupBy/Aggregate
+    relational operator. Technical report, Microsoft, 2001. MSR-TR-2001-13.

--- a/pkg/sql/opt/xform/rules/join.opt
+++ b/pkg/sql/opt/xform/rules/join.opt
@@ -36,3 +36,51 @@
     $right
     (Filters [ $filter ])
 )
+
+# PushDownJoinLeft pushes Join filter conditions into the left side of the
+# join. This is possible in the case of InnerJoin and RightJoin, as long as the
+# condition has no dependencies on the right side of the join. Left and Full
+# joins are not eligible, since filtering left rows will change the number of
+# rows in the result for those types of joins:
+#
+#   -- A row with nulls on the right side is returned for a.x=1, a.y=2, b.x=1.
+#   SELECT * FROM a LEFT JOIN b ON a.x=b.x AND a.y < 0
+#
+#   -- But if the filter is incorrectly pushed down, then no row is returned.
+#   SELECT * FROM (SELECT * FROM a WHERE a.y < 0) a LEFT JOIN b ON a.x=b.x
+#
+# Citations: [1]
+[PushDownJoinLeft]
+(InnerJoin | InnerJoinApply | RightJoin | RightJoinApply
+    $left:*
+    $right:*
+    $on:(Filters $list:[ ... $condition:* & ^(IsCorrelated $condition $right) ... ])
+)
+=>
+((OpName)
+    (Select
+        $left
+        (Filters (ExtractUncorrelatedConditions $list $right))
+    )
+    $right
+    (Filters (ExtractCorrelatedConditions $list $right))
+)
+
+# PushDownJoinRight is symmetric with PushDownJoinLeft. It pushes Join filter
+# conditions into the right side of the join rather than into the left side.
+# See that rule's comments for more details.
+[PushDownJoinRight]
+(InnerJoin | InnerJoinApply | LeftJoin | LeftJoinApply
+    $left:*
+    $right:*
+    $on:(Filters $list:[ ... $condition:* & ^(IsCorrelated $condition $left) ... ])
+)
+=>
+((OpName)
+    $left
+    (Select
+        $right
+        (Filters (ExtractUncorrelatedConditions $list $left))
+    )
+    (Filters (ExtractCorrelatedConditions $list $left))
+)

--- a/pkg/sql/opt/xform/rules/select.opt
+++ b/pkg/sql/opt/xform/rules/select.opt
@@ -38,3 +38,140 @@
 # filter is always true.
 [EliminateSelect, Normalize]
 (Select $input:* (True)) => $input
+
+# MergeSelects combines two nested Select operators into a single Select that
+# ANDs the filter conditions of the two Selects.
+[MergeSelects]
+(Select
+    (Select
+        $input:*
+        $innerFilter:*
+    )
+    $filter:*
+)
+=>
+(Select
+    $input
+    (ConcatFilters $innerFilter $filter)
+)
+
+# PushDownSelectJoinLeft pushes Select filter conditions into the left side of
+# an input Join. This is possible in the case of InnerJoin and LeftJoin, as
+# long as the condition has no dependencies on the right side of the join.
+# Right and Full joins are not eligible, since attempting to filter left rows
+# would just result in NULL left rows instead.
+#
+#   -- No row is returned for a.x=1, a.y=2, b.x=1, since the WHERE excludes it.
+#   SELECT * FROM a RIGHT JOIN b ON a.x=b.x WHERE a.y < 0
+#
+#   -- But if the filter is incorrectly pushed down in RIGHT/FULL JOIN case,
+#   -- then a row containing null values on the left side is returned.
+#   SELECT * FROM (SELECT * FROM a WHERE a.y < 0) a RIGHT JOIN b ON a.x=b.x
+#
+# Citations: [1]
+[PushDownSelectJoinLeft]
+(Select
+    $input:(InnerJoin | InnerJoinApply | LeftJoin | LeftJoinApply
+        $left:*
+        $right:*
+        $on:*
+    )
+    $filter:(Filters $list:[ ... $condition:* & ^(IsCorrelated $condition $right) ... ])
+)
+=>
+(Select
+    ((OpName $input)
+        (Select
+            $left
+            (Filters (ExtractUncorrelatedConditions $list $right))
+        )
+        $right
+        $on
+    )
+    (Filters (ExtractCorrelatedConditions $list $right))
+)
+
+# PushDownSelectJoinRight is symmetric with PushdownSelectJoinLeft. It pushes
+# Select filter conditions into the right side of an input Join rather than
+# into the left side. See that rule's comments for more details.
+[PushDownSelectJoinRight]
+(Select
+    $input:(InnerJoin | InnerJoinApply | RightJoin | RightJoinApply
+        $left:*
+        $right:*
+        $on:*
+    )
+    $filter:(Filters $list:[ ... $condition:* & ^(IsCorrelated $condition $left) ... ])
+)
+=>
+(Select
+    ((OpName $input)
+        $left
+        (Select
+            $right
+            (Filters (ExtractUncorrelatedConditions $list $left))
+        )
+        $on
+    )
+    (Filters (ExtractCorrelatedConditions $list $left))
+)
+
+# MergeSelectInnerJoin merges a Select operator with an InnerJoin input by
+# AND'ing the filter conditions of each and creating a new InnerJoin with that
+# On condition. This is only safe to do with InnerJoin in the general case
+# where the conditions could filter either left or right rows. The special case
+# where a condition filters only one or the other is already taken care of by
+# the PushDownSelectJoin rules.
+# NOTE: Keep this rule ordered after the PushDownSelectJoin rules, for
+#       performance reasons. It's better to push down below the join in a
+#       single step, when possible.
+[MergeSelectInnerJoin]
+(Select
+    $input:(InnerJoin | InnerJoinApply
+        $left:*
+        $right:*
+        $on:*
+    )
+    $filter:*
+)
+=>
+((OpName $input)
+    $left
+    $right
+    (ConcatFilters $on $filter)
+)
+
+# PushDownSelectGroupBy pushes a Select condition below a GroupBy in the case
+# where it does not reference any of the aggregation columns. This only works
+# if there are grouping columns. Otherwise, this is an instance of the "scalar"
+# GroupBy, which returns only one row, and which exhibits different behavior if
+# the input is empty:
+#   SELECT MAX(y) FROM a
+#
+# If "a" is empty, this returns a single row containing a null value. This is
+# different behavior than a GroupBy with grouping columns, which would return
+# the empty set for a similar query:
+#   SELECT MAX(y) FROM a GROUP BY x
+#
+# Citations: [2]
+[PushDownSelectGroupBy]
+(Select
+    (GroupBy
+        $input:*
+        $aggregations:*
+        $groupingCols:* & ^(EmptyGroupingCols $groupingCols)
+    )
+    (Filters $list:[ ... $condition:* & ^(IsCorrelated $condition $aggregations) ... ])
+)
+=>
+(Select
+    (GroupBy
+        (Select
+            $input
+            (Filters (ExtractUncorrelatedConditions $list $aggregations))
+        )
+        $aggregations
+        $groupingCols
+    )
+    (Filters (ExtractCorrelatedConditions $list $aggregations))
+)

--- a/pkg/sql/opt/xform/testdata/rules/join
+++ b/pkg/sql/opt/xform/testdata/rules/join
@@ -23,7 +23,7 @@ TABLE b
 # EnsureJoinFiltersAnd
 # --------------------------------------------------
 opt
-SELECT * FROM a INNER JOIN b ON a.x=b.x AND b.z<10
+SELECT * FROM a INNER JOIN b ON a.x=b.x AND b.z<a.i
 ----
 inner-join
  ├── columns: x:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb) x:6(int!null) z:7(int)
@@ -31,13 +31,13 @@ inner-join
  │    └── columns: a.x:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
  ├── scan
  │    └── columns: b.x:6(int!null) b.z:7(int)
- └── filters [type=bool, outer=(1,6,7)]
+ └── filters [type=bool, outer=(1,2,6,7)]
       ├── eq [type=bool, outer=(1,6)]
       │    ├── variable: a.x [type=int, outer=(1)]
       │    └── variable: b.x [type=int, outer=(6)]
-      └── lt [type=bool, outer=(7)]
+      └── lt [type=bool, outer=(2,7)]
            ├── variable: b.z [type=int, outer=(7)]
-           └── const: 10 [type=int]
+           └── variable: a.i [type=int, outer=(2)]
 
 # --------------------------------------------------
 # EnsureJoinFilters
@@ -73,3 +73,196 @@ inner-join
            └── lt [type=bool, outer=(7)]
                 ├── variable: b.z [type=int, outer=(7)]
                 └── const: 10 [type=int]
+
+# --------------------------------------------------
+# PushDownJoinLeft
+# --------------------------------------------------
+opt
+SELECT * FROM a INNER JOIN b ON a.x=b.x AND a.s='foo'
+----
+inner-join
+ ├── columns: x:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb) x:6(int!null) z:7(int)
+ ├── select
+ │    ├── columns: a.x:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
+ │    ├── scan
+ │    │    └── columns: a.x:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
+ │    └── filters [type=bool, outer=(4)]
+ │         └── eq [type=bool, outer=(4)]
+ │              ├── variable: a.s [type=string, outer=(4)]
+ │              └── const: 'foo' [type=string]
+ ├── scan
+ │    └── columns: b.x:6(int!null) b.z:7(int)
+ └── filters [type=bool, outer=(1,6)]
+      └── eq [type=bool, outer=(1,6)]
+           ├── variable: a.x [type=int, outer=(1)]
+           └── variable: b.x [type=int, outer=(6)]
+
+opt
+SELECT * FROM a RIGHT JOIN b ON (a.i<0 OR a.i>10) AND b.z=1 AND a.s='foo' AND a.x=b.x
+----
+right-join
+ ├── columns: x:1(int) i:2(int) f:3(float) s:4(string) j:5(jsonb) x:6(int!null) z:7(int)
+ ├── select
+ │    ├── columns: a.x:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
+ │    ├── scan
+ │    │    └── columns: a.x:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
+ │    └── filters [type=bool, outer=(2,4)]
+ │         ├── or [type=bool, outer=(2)]
+ │         │    ├── lt [type=bool, outer=(2)]
+ │         │    │    ├── variable: a.i [type=int, outer=(2)]
+ │         │    │    └── const: 0 [type=int]
+ │         │    └── gt [type=bool, outer=(2)]
+ │         │         ├── variable: a.i [type=int, outer=(2)]
+ │         │         └── const: 10 [type=int]
+ │         └── eq [type=bool, outer=(4)]
+ │              ├── variable: a.s [type=string, outer=(4)]
+ │              └── const: 'foo' [type=string]
+ ├── scan
+ │    └── columns: b.x:6(int!null) b.z:7(int)
+ └── filters [type=bool, outer=(1,6,7)]
+      ├── eq [type=bool, outer=(7)]
+      │    ├── variable: b.z [type=int, outer=(7)]
+      │    └── const: 1 [type=int]
+      └── eq [type=bool, outer=(1,6)]
+           ├── variable: a.x [type=int, outer=(1)]
+           └── variable: b.x [type=int, outer=(6)]
+
+# LEFT JOIN should not push down conditions to left side of join.
+opt
+SELECT * FROM a LEFT JOIN b ON a.x=b.x AND a.i=1
+----
+left-join
+ ├── columns: x:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb) x:6(int) z:7(int)
+ ├── scan
+ │    └── columns: a.x:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
+ ├── scan
+ │    └── columns: b.x:6(int!null) b.z:7(int)
+ └── filters [type=bool, outer=(1,2,6)]
+      ├── eq [type=bool, outer=(1,6)]
+      │    ├── variable: a.x [type=int, outer=(1)]
+      │    └── variable: b.x [type=int, outer=(6)]
+      └── eq [type=bool, outer=(2)]
+           ├── variable: a.i [type=int, outer=(2)]
+           └── const: 1 [type=int]
+
+# --------------------------------------------------
+# PushDownJoinRight
+# --------------------------------------------------
+opt
+SELECT * FROM b INNER JOIN a ON b.x=a.x AND a.s='foo'
+----
+inner-join
+ ├── columns: x:1(int!null) z:2(int) x:3(int!null) i:4(int) f:5(float) s:6(string) j:7(jsonb)
+ ├── scan
+ │    └── columns: b.x:1(int!null) b.z:2(int)
+ ├── select
+ │    ├── columns: a.x:3(int!null) a.i:4(int) a.f:5(float) a.s:6(string) a.j:7(jsonb)
+ │    ├── scan
+ │    │    └── columns: a.x:3(int!null) a.i:4(int) a.f:5(float) a.s:6(string) a.j:7(jsonb)
+ │    └── filters [type=bool, outer=(6)]
+ │         └── eq [type=bool, outer=(6)]
+ │              ├── variable: a.s [type=string, outer=(6)]
+ │              └── const: 'foo' [type=string]
+ └── filters [type=bool, outer=(1,3)]
+      └── eq [type=bool, outer=(1,3)]
+           ├── variable: b.x [type=int, outer=(1)]
+           └── variable: a.x [type=int, outer=(3)]
+
+opt
+SELECT * FROM b LEFT JOIN a ON (a.i<0 OR a.i>10) AND b.z=1 AND a.s='foo' AND b.x=a.x
+----
+left-join
+ ├── columns: x:1(int!null) z:2(int) x:3(int) i:4(int) f:5(float) s:6(string) j:7(jsonb)
+ ├── scan
+ │    └── columns: b.x:1(int!null) b.z:2(int)
+ ├── select
+ │    ├── columns: a.x:3(int!null) a.i:4(int) a.f:5(float) a.s:6(string) a.j:7(jsonb)
+ │    ├── scan
+ │    │    └── columns: a.x:3(int!null) a.i:4(int) a.f:5(float) a.s:6(string) a.j:7(jsonb)
+ │    └── filters [type=bool, outer=(4,6)]
+ │         ├── or [type=bool, outer=(4)]
+ │         │    ├── lt [type=bool, outer=(4)]
+ │         │    │    ├── variable: a.i [type=int, outer=(4)]
+ │         │    │    └── const: 0 [type=int]
+ │         │    └── gt [type=bool, outer=(4)]
+ │         │         ├── variable: a.i [type=int, outer=(4)]
+ │         │         └── const: 10 [type=int]
+ │         └── eq [type=bool, outer=(6)]
+ │              ├── variable: a.s [type=string, outer=(6)]
+ │              └── const: 'foo' [type=string]
+ └── filters [type=bool, outer=(1-3)]
+      ├── eq [type=bool, outer=(2)]
+      │    ├── variable: b.z [type=int, outer=(2)]
+      │    └── const: 1 [type=int]
+      └── eq [type=bool, outer=(1,3)]
+           ├── variable: b.x [type=int, outer=(1)]
+           └── variable: a.x [type=int, outer=(3)]
+
+# RIGHT JOIN should not push down conditions to right side of join.
+opt
+SELECT * FROM b RIGHT JOIN a ON b.x=a.x AND a.i=1
+----
+right-join
+ ├── columns: x:1(int) z:2(int) x:3(int!null) i:4(int) f:5(float) s:6(string) j:7(jsonb)
+ ├── scan
+ │    └── columns: b.x:1(int!null) b.z:2(int)
+ ├── scan
+ │    └── columns: a.x:3(int!null) a.i:4(int) a.f:5(float) a.s:6(string) a.j:7(jsonb)
+ └── filters [type=bool, outer=(1,3,4)]
+      ├── eq [type=bool, outer=(1,3)]
+      │    ├── variable: b.x [type=int, outer=(1)]
+      │    └── variable: a.x [type=int, outer=(3)]
+      └── eq [type=bool, outer=(4)]
+           ├── variable: a.i [type=int, outer=(4)]
+           └── const: 1 [type=int]
+
+# --------------------------------------------------
+# PushDownJoinLeft + PushDownJoinRight
+# --------------------------------------------------
+
+opt
+SELECT * FROM a INNER JOIN b ON a.x=b.x AND a.i=1 AND b.z=1
+----
+inner-join
+ ├── columns: x:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb) x:6(int!null) z:7(int)
+ ├── select
+ │    ├── columns: a.x:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
+ │    ├── scan
+ │    │    └── columns: a.x:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
+ │    └── filters [type=bool, outer=(2)]
+ │         └── eq [type=bool, outer=(2)]
+ │              ├── variable: a.i [type=int, outer=(2)]
+ │              └── const: 1 [type=int]
+ ├── select
+ │    ├── columns: b.x:6(int!null) b.z:7(int)
+ │    ├── scan
+ │    │    └── columns: b.x:6(int!null) b.z:7(int)
+ │    └── filters [type=bool, outer=(7)]
+ │         └── eq [type=bool, outer=(7)]
+ │              ├── variable: b.z [type=int, outer=(7)]
+ │              └── const: 1 [type=int]
+ └── filters [type=bool, outer=(1,6)]
+      └── eq [type=bool, outer=(1,6)]
+           ├── variable: a.x [type=int, outer=(1)]
+           └── variable: b.x [type=int, outer=(6)]
+
+# FULL JOIN should not push down conditions to either side of join.
+opt
+SELECT * FROM a FULL JOIN b ON a.x=b.x AND a.i=1 AND b.z=1
+----
+full-join
+ ├── columns: x:1(int) i:2(int) f:3(float) s:4(string) j:5(jsonb) x:6(int) z:7(int)
+ ├── scan
+ │    └── columns: a.x:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
+ ├── scan
+ │    └── columns: b.x:6(int!null) b.z:7(int)
+ └── filters [type=bool, outer=(1,2,6,7)]
+      ├── eq [type=bool, outer=(1,6)]
+      │    ├── variable: a.x [type=int, outer=(1)]
+      │    └── variable: b.x [type=int, outer=(6)]
+      ├── eq [type=bool, outer=(2)]
+      │    ├── variable: a.i [type=int, outer=(2)]
+      │    └── const: 1 [type=int]
+      └── eq [type=bool, outer=(7)]
+           ├── variable: b.z [type=int, outer=(7)]
+           └── const: 1 [type=int]

--- a/pkg/sql/opt/xform/testdata/rules/project
+++ b/pkg/sql/opt/xform/testdata/rules/project
@@ -259,14 +259,14 @@ project
 
 # Select nested in select.
 opt
-SELECT y FROM (SELECT * FROM a WHERE x = 5) a2 WHERE y::float = f
+SELECT y FROM (SELECT x, y, s, f+1.0 f FROM a WHERE x = 5) a2 WHERE y::float = f
 ----
 project
  ├── columns: y:2(int)
  ├── select
- │    ├── columns: a.y:2(int) a.f:3(float)
+ │    ├── columns: a.y:2(int) f:5(float)
  │    ├── project
- │    │    ├── columns: a.y:2(int) a.f:3(float)
+ │    │    ├── columns: a.y:2(int) f:5(float)
  │    │    ├── select
  │    │    │    ├── columns: a.x:1(int!null) a.y:2(int) a.f:3(float)
  │    │    │    ├── scan
@@ -277,10 +277,12 @@ project
  │    │    │              └── const: 5 [type=int]
  │    │    └── projections [outer=(2,3)]
  │    │         ├── variable: a.y [type=int, outer=(2)]
- │    │         └── variable: a.f [type=float, outer=(3)]
- │    └── filters [type=bool, outer=(2,3)]
- │         └── eq [type=bool, outer=(2,3)]
- │              ├── variable: a.f [type=float, outer=(3)]
+ │    │         └── plus [type=float, outer=(3)]
+ │    │              ├── variable: a.f [type=float, outer=(3)]
+ │    │              └── const: 1.0 [type=float]
+ │    └── filters [type=bool, outer=(2,5)]
+ │         └── eq [type=bool, outer=(2,5)]
+ │              ├── variable: f [type=float, outer=(5)]
  │              └── cast: float [type=float, outer=(2)]
  │                   └── variable: a.y [type=int, outer=(2)]
  └── projections [outer=(2)]
@@ -387,22 +389,30 @@ SELECT a.x+1, a.y/2, b.* FROM t.a INNER JOIN t.b ON a.x*a.x=b.x AND a.s||'o'='fo
 project
  ├── columns: column7:7(int) column8:8(decimal) x:5(int!null) z:6(int)
  ├── inner-join
- │    ├── columns: a.x:1(int!null) a.y:2(int) a.s:4(string) b.x:5(int!null) b.z:6(int)
- │    ├── scan
- │    │    └── columns: a.x:1(int!null) a.y:2(int) a.s:4(string)
+ │    ├── columns: a.x:1(int!null) a.y:2(int) b.x:5(int!null) b.z:6(int)
+ │    ├── project
+ │    │    ├── columns: a.x:1(int!null) a.y:2(int)
+ │    │    ├── select
+ │    │    │    ├── columns: a.x:1(int!null) a.y:2(int) a.s:4(string)
+ │    │    │    ├── scan
+ │    │    │    │    └── columns: a.x:1(int!null) a.y:2(int) a.s:4(string)
+ │    │    │    └── filters [type=bool, outer=(4)]
+ │    │    │         └── eq [type=bool, outer=(4)]
+ │    │    │              ├── concat [type=string, outer=(4)]
+ │    │    │              │    ├── variable: a.s [type=string, outer=(4)]
+ │    │    │              │    └── const: 'o' [type=string]
+ │    │    │              └── const: 'foo' [type=string]
+ │    │    └── projections [outer=(1,2)]
+ │    │         ├── variable: a.x [type=int, outer=(1)]
+ │    │         └── variable: a.y [type=int, outer=(2)]
  │    ├── scan
  │    │    └── columns: b.x:5(int!null) b.z:6(int)
- │    └── filters [type=bool, outer=(1,4,5)]
- │         ├── eq [type=bool, outer=(1,5)]
- │         │    ├── variable: b.x [type=int, outer=(5)]
- │         │    └── mult [type=int, outer=(1)]
- │         │         ├── variable: a.x [type=int, outer=(1)]
- │         │         └── variable: a.x [type=int, outer=(1)]
- │         └── eq [type=bool, outer=(4)]
- │              ├── concat [type=string, outer=(4)]
- │              │    ├── variable: a.s [type=string, outer=(4)]
- │              │    └── const: 'o' [type=string]
- │              └── const: 'foo' [type=string]
+ │    └── filters [type=bool, outer=(1,5)]
+ │         └── eq [type=bool, outer=(1,5)]
+ │              ├── variable: b.x [type=int, outer=(5)]
+ │              └── mult [type=int, outer=(1)]
+ │                   ├── variable: a.x [type=int, outer=(1)]
+ │                   └── variable: a.x [type=int, outer=(1)]
  └── projections [outer=(1,2,5,6)]
       ├── plus [type=int, outer=(1)]
       │    ├── variable: a.x [type=int, outer=(1)]
@@ -480,7 +490,7 @@ project
 
 # Columns used by both projection and on condition, left join.
 opt
-SELECT b.*, a.x, a.y FROM t.b LEFT JOIN t.a ON b.x=a.x AND a.y<5
+SELECT b.*, a.x, a.y FROM t.b LEFT JOIN t.a ON b.x=a.x AND a.y<b.x
 ----
 left-join
  ├── columns: x:1(int!null) z:2(int) x:3(int) y:4(int)
@@ -492,9 +502,9 @@ left-join
       ├── eq [type=bool, outer=(1,3)]
       │    ├── variable: b.x [type=int, outer=(1)]
       │    └── variable: a.x [type=int, outer=(3)]
-      └── lt [type=bool, outer=(4)]
+      └── lt [type=bool, outer=(1,4)]
            ├── variable: a.y [type=int, outer=(4)]
-           └── const: 5 [type=int]
+           └── variable: b.x [type=int, outer=(1)]
 
 # Columns only used by on condition, right join
 opt
@@ -554,22 +564,30 @@ SELECT b.*, a.x+1, a.y/2 FROM t.b INNER JOIN t.a ON b.x=a.x*a.x AND a.s||'o'='fo
 project
  ├── columns: x:1(int!null) z:2(int) column7:7(int) column8:8(decimal)
  ├── inner-join
- │    ├── columns: b.x:1(int!null) b.z:2(int) a.x:3(int!null) a.y:4(int) a.s:6(string)
+ │    ├── columns: b.x:1(int!null) b.z:2(int) a.x:3(int!null) a.y:4(int)
  │    ├── scan
  │    │    └── columns: b.x:1(int!null) b.z:2(int)
- │    ├── scan
- │    │    └── columns: a.x:3(int!null) a.y:4(int) a.s:6(string)
- │    └── filters [type=bool, outer=(1,3,6)]
- │         ├── eq [type=bool, outer=(1,3)]
- │         │    ├── variable: b.x [type=int, outer=(1)]
- │         │    └── mult [type=int, outer=(3)]
- │         │         ├── variable: a.x [type=int, outer=(3)]
- │         │         └── variable: a.x [type=int, outer=(3)]
- │         └── eq [type=bool, outer=(6)]
- │              ├── concat [type=string, outer=(6)]
- │              │    ├── variable: a.s [type=string, outer=(6)]
- │              │    └── const: 'o' [type=string]
- │              └── const: 'foo' [type=string]
+ │    ├── project
+ │    │    ├── columns: a.x:3(int!null) a.y:4(int)
+ │    │    ├── select
+ │    │    │    ├── columns: a.x:3(int!null) a.y:4(int) a.s:6(string)
+ │    │    │    ├── scan
+ │    │    │    │    └── columns: a.x:3(int!null) a.y:4(int) a.s:6(string)
+ │    │    │    └── filters [type=bool, outer=(6)]
+ │    │    │         └── eq [type=bool, outer=(6)]
+ │    │    │              ├── concat [type=string, outer=(6)]
+ │    │    │              │    ├── variable: a.s [type=string, outer=(6)]
+ │    │    │              │    └── const: 'o' [type=string]
+ │    │    │              └── const: 'foo' [type=string]
+ │    │    └── projections [outer=(3,4)]
+ │    │         ├── variable: a.x [type=int, outer=(3)]
+ │    │         └── variable: a.y [type=int, outer=(4)]
+ │    └── filters [type=bool, outer=(1,3)]
+ │         └── eq [type=bool, outer=(1,3)]
+ │              ├── variable: b.x [type=int, outer=(1)]
+ │              └── mult [type=int, outer=(3)]
+ │                   ├── variable: a.x [type=int, outer=(3)]
+ │                   └── variable: a.x [type=int, outer=(3)]
  └── projections [outer=(1-4)]
       ├── variable: b.x [type=int, outer=(1)]
       ├── variable: b.z [type=int, outer=(2)]
@@ -855,28 +873,26 @@ SELECT a.x, b.z FROM a INNER JOIN b ON a.x=b.x WHERE a.y < 5
 ----
 project
  ├── columns: x:1(int!null) z:6(int)
- ├── select
- │    ├── columns: a.x:1(int!null) a.y:2(int) b.z:6(int)
+ ├── inner-join
+ │    ├── columns: a.x:1(int!null) b.x:5(int!null) b.z:6(int)
  │    ├── project
- │    │    ├── columns: a.x:1(int!null) a.y:2(int) b.z:6(int)
- │    │    ├── inner-join
- │    │    │    ├── columns: a.x:1(int!null) a.y:2(int) b.x:5(int!null) b.z:6(int)
+ │    │    ├── columns: a.x:1(int!null)
+ │    │    ├── select
+ │    │    │    ├── columns: a.x:1(int!null) a.y:2(int)
  │    │    │    ├── scan
  │    │    │    │    └── columns: a.x:1(int!null) a.y:2(int)
- │    │    │    ├── scan
- │    │    │    │    └── columns: b.x:5(int!null) b.z:6(int)
- │    │    │    └── filters [type=bool, outer=(1,5)]
- │    │    │         └── eq [type=bool, outer=(1,5)]
- │    │    │              ├── variable: a.x [type=int, outer=(1)]
- │    │    │              └── variable: b.x [type=int, outer=(5)]
- │    │    └── projections [outer=(1,2,6)]
- │    │         ├── variable: a.x [type=int, outer=(1)]
- │    │         ├── variable: a.y [type=int, outer=(2)]
- │    │         └── variable: b.z [type=int, outer=(6)]
- │    └── filters [type=bool, outer=(2)]
- │         └── lt [type=bool, outer=(2)]
- │              ├── variable: a.y [type=int, outer=(2)]
- │              └── const: 5 [type=int]
+ │    │    │    └── filters [type=bool, outer=(2)]
+ │    │    │         └── lt [type=bool, outer=(2)]
+ │    │    │              ├── variable: a.y [type=int, outer=(2)]
+ │    │    │              └── const: 5 [type=int]
+ │    │    └── projections [outer=(1)]
+ │    │         └── variable: a.x [type=int, outer=(1)]
+ │    ├── scan
+ │    │    └── columns: b.x:5(int!null) b.z:6(int)
+ │    └── filters [type=bool, outer=(1,5)]
+ │         └── eq [type=bool, outer=(1,5)]
+ │              ├── variable: a.x [type=int, outer=(1)]
+ │              └── variable: b.x [type=int, outer=(5)]
  └── projections [outer=(1,6)]
       ├── variable: a.x [type=int, outer=(1)]
       └── variable: b.z [type=int, outer=(6)]

--- a/pkg/sql/opt/xform/testdata/rules/select
+++ b/pkg/sql/opt/xform/testdata/rules/select
@@ -10,6 +10,15 @@ TABLE a
  └── INDEX primary
       └── k int not null
 
+exec-ddl
+CREATE TABLE t.b (x INT PRIMARY KEY, y INT)
+----
+TABLE b
+ ├── x int not null
+ ├── y int
+ └── INDEX primary
+      └── x int not null
+
 # --------------------------------------------------
 # EnsureSelectFiltersAnd
 # --------------------------------------------------
@@ -83,3 +92,538 @@ SELECT * FROM a WHERE True
 ----
 scan
  └── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
+
+# --------------------------------------------------
+# MergeSelects
+# --------------------------------------------------
+opt
+SELECT * FROM (SELECT * FROM a WHERE False) WHERE s='foo'
+----
+select
+ ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
+ ├── scan
+ │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
+ └── false [type=bool]
+
+opt
+SELECT * FROM (SELECT * FROM a WHERE i=1) WHERE False
+----
+select
+ ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
+ ├── scan
+ │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
+ └── false [type=bool]
+
+opt
+SELECT * FROM (SELECT * FROM a WHERE i=1) WHERE False
+----
+select
+ ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
+ ├── scan
+ │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
+ └── false [type=bool]
+
+opt
+SELECT * FROM (SELECT * FROM a WHERE i<5) WHERE s='foo'
+----
+select
+ ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
+ ├── scan
+ │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
+ └── filters [type=bool, outer=(2,4)]
+      ├── lt [type=bool, outer=(2)]
+      │    ├── variable: a.i [type=int, outer=(2)]
+      │    └── const: 5 [type=int]
+      └── eq [type=bool, outer=(4)]
+           ├── variable: a.s [type=string, outer=(4)]
+           └── const: 'foo' [type=string]
+
+opt
+SELECT * FROM (SELECT * FROM a WHERE i>1 AND i<10) WHERE s='foo' OR k=5
+----
+select
+ ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
+ ├── scan
+ │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
+ └── filters [type=bool, outer=(1,2,4)]
+      ├── gt [type=bool, outer=(2)]
+      │    ├── variable: a.i [type=int, outer=(2)]
+      │    └── const: 1 [type=int]
+      ├── lt [type=bool, outer=(2)]
+      │    ├── variable: a.i [type=int, outer=(2)]
+      │    └── const: 10 [type=int]
+      └── or [type=bool, outer=(1,4)]
+           ├── eq [type=bool, outer=(4)]
+           │    ├── variable: a.s [type=string, outer=(4)]
+           │    └── const: 'foo' [type=string]
+           └── eq [type=bool, outer=(1)]
+                ├── variable: a.k [type=int, outer=(1)]
+                └── const: 5 [type=int]
+
+# --------------------------------------------------
+# PushdownSelectJoinLeft
+# --------------------------------------------------
+opt
+SELECT * FROM a INNER JOIN b ON a.k=b.x WHERE a.f=1.1
+----
+inner-join
+ ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb) x:6(int!null) y:7(int)
+ ├── select
+ │    ├── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
+ │    ├── scan
+ │    │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
+ │    └── filters [type=bool, outer=(3)]
+ │         └── eq [type=bool, outer=(3)]
+ │              ├── variable: a.f [type=float, outer=(3)]
+ │              └── const: 1.1 [type=float]
+ ├── scan
+ │    └── columns: b.x:6(int!null) b.y:7(int)
+ └── filters [type=bool, outer=(1,6)]
+      └── eq [type=bool, outer=(1,6)]
+           ├── variable: a.k [type=int, outer=(1)]
+           └── variable: b.x [type=int, outer=(6)]
+
+opt
+SELECT * FROM a LEFT JOIN b ON a.k=b.x WHERE a.f=1.1 AND a.i<b.y AND (a.s='foo' OR a.s='bar')
+----
+select
+ ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb) x:6(int) y:7(int)
+ ├── left-join
+ │    ├── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb) b.x:6(int) b.y:7(int)
+ │    ├── select
+ │    │    ├── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
+ │    │    ├── scan
+ │    │    │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
+ │    │    └── filters [type=bool, outer=(3,4)]
+ │    │         ├── eq [type=bool, outer=(3)]
+ │    │         │    ├── variable: a.f [type=float, outer=(3)]
+ │    │         │    └── const: 1.1 [type=float]
+ │    │         └── or [type=bool, outer=(4)]
+ │    │              ├── eq [type=bool, outer=(4)]
+ │    │              │    ├── variable: a.s [type=string, outer=(4)]
+ │    │              │    └── const: 'foo' [type=string]
+ │    │              └── eq [type=bool, outer=(4)]
+ │    │                   ├── variable: a.s [type=string, outer=(4)]
+ │    │                   └── const: 'bar' [type=string]
+ │    ├── scan
+ │    │    └── columns: b.x:6(int!null) b.y:7(int)
+ │    └── filters [type=bool, outer=(1,6)]
+ │         └── eq [type=bool, outer=(1,6)]
+ │              ├── variable: a.k [type=int, outer=(1)]
+ │              └── variable: b.x [type=int, outer=(6)]
+ └── filters [type=bool, outer=(2,7)]
+      └── lt [type=bool, outer=(2,7)]
+           ├── variable: a.i [type=int, outer=(2)]
+           └── variable: b.y [type=int, outer=(7)]
+
+# Pushdown constant condition.
+opt
+SELECT * FROM a INNER JOIN b ON True WHERE a.i=100 AND now()>'2000-01-01T1:00:00'
+----
+inner-join
+ ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb) x:6(int!null) y:7(int)
+ ├── select
+ │    ├── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
+ │    ├── scan
+ │    │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
+ │    └── filters [type=bool, outer=(2)]
+ │         ├── eq [type=bool, outer=(2)]
+ │         │    ├── variable: a.i [type=int, outer=(2)]
+ │         │    └── const: 100 [type=int]
+ │         └── gt [type=bool]
+ │              ├── function: now [type=timestamptz]
+ │              └── const: '2000-01-01 01:00:00+00:00' [type=timestamptz]
+ ├── scan
+ │    └── columns: b.x:6(int!null) b.y:7(int)
+ └── true [type=bool]
+
+# Don't push down conditions in case of RIGHT JOIN.
+opt
+SELECT * FROM a RIGHT JOIN b ON a.k=b.x WHERE a.i=100
+----
+select
+ ├── columns: k:1(int) i:2(int) f:3(float) s:4(string) j:5(jsonb) x:6(int!null) y:7(int)
+ ├── right-join
+ │    ├── columns: a.k:1(int) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb) b.x:6(int!null) b.y:7(int)
+ │    ├── scan
+ │    │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
+ │    ├── scan
+ │    │    └── columns: b.x:6(int!null) b.y:7(int)
+ │    └── filters [type=bool, outer=(1,6)]
+ │         └── eq [type=bool, outer=(1,6)]
+ │              ├── variable: a.k [type=int, outer=(1)]
+ │              └── variable: b.x [type=int, outer=(6)]
+ └── filters [type=bool, outer=(2)]
+      └── eq [type=bool, outer=(2)]
+           ├── variable: a.i [type=int, outer=(2)]
+           └── const: 100 [type=int]
+
+# Don't push down conditions in case of FULL JOIN.
+opt
+SELECT * FROM a FULL JOIN b ON a.k=b.x WHERE a.i=100
+----
+select
+ ├── columns: k:1(int) i:2(int) f:3(float) s:4(string) j:5(jsonb) x:6(int) y:7(int)
+ ├── full-join
+ │    ├── columns: a.k:1(int) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb) b.x:6(int) b.y:7(int)
+ │    ├── scan
+ │    │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
+ │    ├── scan
+ │    │    └── columns: b.x:6(int!null) b.y:7(int)
+ │    └── filters [type=bool, outer=(1,6)]
+ │         └── eq [type=bool, outer=(1,6)]
+ │              ├── variable: a.k [type=int, outer=(1)]
+ │              └── variable: b.x [type=int, outer=(6)]
+ └── filters [type=bool, outer=(2)]
+      └── eq [type=bool, outer=(2)]
+           ├── variable: a.i [type=int, outer=(2)]
+           └── const: 100 [type=int]
+
+# --------------------------------------------------
+# PushdownSelectJoinRight
+# --------------------------------------------------
+opt
+SELECT * FROM b INNER JOIN a ON b.x=a.k WHERE a.f=1.1
+----
+inner-join
+ ├── columns: x:1(int!null) y:2(int) k:3(int!null) i:4(int) f:5(float) s:6(string) j:7(jsonb)
+ ├── scan
+ │    └── columns: b.x:1(int!null) b.y:2(int)
+ ├── select
+ │    ├── columns: a.k:3(int!null) a.i:4(int) a.f:5(float) a.s:6(string) a.j:7(jsonb)
+ │    ├── scan
+ │    │    └── columns: a.k:3(int!null) a.i:4(int) a.f:5(float) a.s:6(string) a.j:7(jsonb)
+ │    └── filters [type=bool, outer=(5)]
+ │         └── eq [type=bool, outer=(5)]
+ │              ├── variable: a.f [type=float, outer=(5)]
+ │              └── const: 1.1 [type=float]
+ └── filters [type=bool, outer=(1,3)]
+      └── eq [type=bool, outer=(1,3)]
+           ├── variable: b.x [type=int, outer=(1)]
+           └── variable: a.k [type=int, outer=(3)]
+
+opt
+SELECT * FROM b RIGHT JOIN a ON b.x=a.k WHERE a.f=1.1 AND a.i<b.y AND (a.s='foo' OR a.s='bar')
+----
+select
+ ├── columns: x:1(int) y:2(int) k:3(int!null) i:4(int) f:5(float) s:6(string) j:7(jsonb)
+ ├── right-join
+ │    ├── columns: b.x:1(int) b.y:2(int) a.k:3(int!null) a.i:4(int) a.f:5(float) a.s:6(string) a.j:7(jsonb)
+ │    ├── scan
+ │    │    └── columns: b.x:1(int!null) b.y:2(int)
+ │    ├── select
+ │    │    ├── columns: a.k:3(int!null) a.i:4(int) a.f:5(float) a.s:6(string) a.j:7(jsonb)
+ │    │    ├── scan
+ │    │    │    └── columns: a.k:3(int!null) a.i:4(int) a.f:5(float) a.s:6(string) a.j:7(jsonb)
+ │    │    └── filters [type=bool, outer=(5,6)]
+ │    │         ├── eq [type=bool, outer=(5)]
+ │    │         │    ├── variable: a.f [type=float, outer=(5)]
+ │    │         │    └── const: 1.1 [type=float]
+ │    │         └── or [type=bool, outer=(6)]
+ │    │              ├── eq [type=bool, outer=(6)]
+ │    │              │    ├── variable: a.s [type=string, outer=(6)]
+ │    │              │    └── const: 'foo' [type=string]
+ │    │              └── eq [type=bool, outer=(6)]
+ │    │                   ├── variable: a.s [type=string, outer=(6)]
+ │    │                   └── const: 'bar' [type=string]
+ │    └── filters [type=bool, outer=(1,3)]
+ │         └── eq [type=bool, outer=(1,3)]
+ │              ├── variable: b.x [type=int, outer=(1)]
+ │              └── variable: a.k [type=int, outer=(3)]
+ └── filters [type=bool, outer=(2,4)]
+      └── lt [type=bool, outer=(2,4)]
+           ├── variable: a.i [type=int, outer=(4)]
+           └── variable: b.y [type=int, outer=(2)]
+
+# Don't push down conditions in case of LEFT JOIN.
+opt
+SELECT * FROM b LEFT JOIN a ON a.k=b.x WHERE a.i=100
+----
+select
+ ├── columns: x:1(int!null) y:2(int) k:3(int) i:4(int) f:5(float) s:6(string) j:7(jsonb)
+ ├── left-join
+ │    ├── columns: b.x:1(int!null) b.y:2(int) a.k:3(int) a.i:4(int) a.f:5(float) a.s:6(string) a.j:7(jsonb)
+ │    ├── scan
+ │    │    └── columns: b.x:1(int!null) b.y:2(int)
+ │    ├── scan
+ │    │    └── columns: a.k:3(int!null) a.i:4(int) a.f:5(float) a.s:6(string) a.j:7(jsonb)
+ │    └── filters [type=bool, outer=(1,3)]
+ │         └── eq [type=bool, outer=(1,3)]
+ │              ├── variable: a.k [type=int, outer=(3)]
+ │              └── variable: b.x [type=int, outer=(1)]
+ └── filters [type=bool, outer=(4)]
+      └── eq [type=bool, outer=(4)]
+           ├── variable: a.i [type=int, outer=(4)]
+           └── const: 100 [type=int]
+
+# Don't push down conditions in case of FULL JOIN.
+opt
+SELECT * FROM b FULL JOIN a ON a.k=b.x WHERE a.i=100
+----
+select
+ ├── columns: x:1(int) y:2(int) k:3(int) i:4(int) f:5(float) s:6(string) j:7(jsonb)
+ ├── full-join
+ │    ├── columns: b.x:1(int) b.y:2(int) a.k:3(int) a.i:4(int) a.f:5(float) a.s:6(string) a.j:7(jsonb)
+ │    ├── scan
+ │    │    └── columns: b.x:1(int!null) b.y:2(int)
+ │    ├── scan
+ │    │    └── columns: a.k:3(int!null) a.i:4(int) a.f:5(float) a.s:6(string) a.j:7(jsonb)
+ │    └── filters [type=bool, outer=(1,3)]
+ │         └── eq [type=bool, outer=(1,3)]
+ │              ├── variable: a.k [type=int, outer=(3)]
+ │              └── variable: b.x [type=int, outer=(1)]
+ └── filters [type=bool, outer=(4)]
+      └── eq [type=bool, outer=(4)]
+           ├── variable: a.i [type=int, outer=(4)]
+           └── const: 100 [type=int]
+
+# --------------------------------------------------
+# MergeSelectInnerJoin
+# --------------------------------------------------
+opt
+SELECT * FROM a, b WHERE a.k=b.x AND (a.s='foo' OR b.y<100)
+----
+inner-join
+ ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb) x:6(int!null) y:7(int)
+ ├── scan
+ │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
+ ├── scan
+ │    └── columns: b.x:6(int!null) b.y:7(int)
+ └── filters [type=bool, outer=(1,4,6,7)]
+      ├── eq [type=bool, outer=(1,6)]
+      │    ├── variable: a.k [type=int, outer=(1)]
+      │    └── variable: b.x [type=int, outer=(6)]
+      └── or [type=bool, outer=(4,7)]
+           ├── eq [type=bool, outer=(4)]
+           │    ├── variable: a.s [type=string, outer=(4)]
+           │    └── const: 'foo' [type=string]
+           └── lt [type=bool, outer=(7)]
+                ├── variable: b.y [type=int, outer=(7)]
+                └── const: 100 [type=int]
+
+opt
+SELECT * FROM a INNER JOIN b ON a.k=b.x WHERE (a.s='foo' OR b.y<100)
+----
+inner-join
+ ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb) x:6(int!null) y:7(int)
+ ├── scan
+ │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
+ ├── scan
+ │    └── columns: b.x:6(int!null) b.y:7(int)
+ └── filters [type=bool, outer=(1,4,6,7)]
+      ├── eq [type=bool, outer=(1,6)]
+      │    ├── variable: a.k [type=int, outer=(1)]
+      │    └── variable: b.x [type=int, outer=(6)]
+      └── or [type=bool, outer=(4,7)]
+           ├── eq [type=bool, outer=(4)]
+           │    ├── variable: a.s [type=string, outer=(4)]
+           │    └── const: 'foo' [type=string]
+           └── lt [type=bool, outer=(7)]
+                ├── variable: b.y [type=int, outer=(7)]
+                └── const: 100 [type=int]
+
+opt
+SELECT * FROM a INNER JOIN b ON a.k=b.x WHERE False
+----
+inner-join
+ ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb) x:6(int!null) y:7(int)
+ ├── scan
+ │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
+ ├── scan
+ │    └── columns: b.x:6(int!null) b.y:7(int)
+ └── false [type=bool]
+
+# Don't merge with LEFT JOIN.
+opt
+SELECT * FROM a LEFT JOIN b ON True WHERE a.k=b.x
+----
+select
+ ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb) x:6(int) y:7(int)
+ ├── left-join
+ │    ├── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb) b.x:6(int) b.y:7(int)
+ │    ├── scan
+ │    │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
+ │    ├── scan
+ │    │    └── columns: b.x:6(int!null) b.y:7(int)
+ │    └── true [type=bool]
+ └── filters [type=bool, outer=(1,6)]
+      └── eq [type=bool, outer=(1,6)]
+           ├── variable: a.k [type=int, outer=(1)]
+           └── variable: b.x [type=int, outer=(6)]
+
+# Don't merge with RIGHT JOIN.
+opt
+SELECT * FROM a RIGHT JOIN b ON True WHERE a.k=b.x
+----
+select
+ ├── columns: k:1(int) i:2(int) f:3(float) s:4(string) j:5(jsonb) x:6(int!null) y:7(int)
+ ├── right-join
+ │    ├── columns: a.k:1(int) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb) b.x:6(int!null) b.y:7(int)
+ │    ├── scan
+ │    │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
+ │    ├── scan
+ │    │    └── columns: b.x:6(int!null) b.y:7(int)
+ │    └── true [type=bool]
+ └── filters [type=bool, outer=(1,6)]
+      └── eq [type=bool, outer=(1,6)]
+           ├── variable: a.k [type=int, outer=(1)]
+           └── variable: b.x [type=int, outer=(6)]
+
+# Don't merge with FULL JOIN.
+opt
+SELECT * FROM a FULL JOIN b ON True WHERE a.k=b.x
+----
+select
+ ├── columns: k:1(int) i:2(int) f:3(float) s:4(string) j:5(jsonb) x:6(int) y:7(int)
+ ├── full-join
+ │    ├── columns: a.k:1(int) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb) b.x:6(int) b.y:7(int)
+ │    ├── scan
+ │    │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
+ │    ├── scan
+ │    │    └── columns: b.x:6(int!null) b.y:7(int)
+ │    └── true [type=bool]
+ └── filters [type=bool, outer=(1,6)]
+      └── eq [type=bool, outer=(1,6)]
+           ├── variable: a.k [type=int, outer=(1)]
+           └── variable: b.x [type=int, outer=(6)]
+
+# --------------------------------------------------
+# PushdownSelectJoinLeft + PushdownSelectJoinRight + MergeSelectInnerJoin
+# --------------------------------------------------
+opt
+SELECT * FROM a INNER JOIN b ON a.k=b.x WHERE a.f=1.1 AND s='foo' AND b.y=10 AND a.i<b.y
+----
+inner-join
+ ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb) x:6(int!null) y:7(int)
+ ├── select
+ │    ├── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
+ │    ├── scan
+ │    │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
+ │    └── filters [type=bool, outer=(3,4)]
+ │         ├── eq [type=bool, outer=(3)]
+ │         │    ├── variable: a.f [type=float, outer=(3)]
+ │         │    └── const: 1.1 [type=float]
+ │         └── eq [type=bool, outer=(4)]
+ │              ├── variable: a.s [type=string, outer=(4)]
+ │              └── const: 'foo' [type=string]
+ ├── select
+ │    ├── columns: b.x:6(int!null) b.y:7(int)
+ │    ├── scan
+ │    │    └── columns: b.x:6(int!null) b.y:7(int)
+ │    └── filters [type=bool, outer=(7)]
+ │         └── eq [type=bool, outer=(7)]
+ │              ├── variable: b.y [type=int, outer=(7)]
+ │              └── const: 10 [type=int]
+ └── filters [type=bool, outer=(1,2,6,7)]
+      ├── eq [type=bool, outer=(1,6)]
+      │    ├── variable: a.k [type=int, outer=(1)]
+      │    └── variable: b.x [type=int, outer=(6)]
+      └── lt [type=bool, outer=(2,7)]
+           ├── variable: a.i [type=int, outer=(2)]
+           └── variable: b.y [type=int, outer=(7)]
+
+opt
+SELECT * FROM a, b WHERE a.i=100 AND now()>'2000-01-01T1:00:00' AND b.x=a.k
+----
+inner-join
+ ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb) x:6(int!null) y:7(int)
+ ├── select
+ │    ├── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
+ │    ├── scan
+ │    │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
+ │    └── filters [type=bool, outer=(2)]
+ │         ├── eq [type=bool, outer=(2)]
+ │         │    ├── variable: a.i [type=int, outer=(2)]
+ │         │    └── const: 100 [type=int]
+ │         └── gt [type=bool]
+ │              ├── function: now [type=timestamptz]
+ │              └── const: '2000-01-01 01:00:00+00:00' [type=timestamptz]
+ ├── scan
+ │    └── columns: b.x:6(int!null) b.y:7(int)
+ └── filters [type=bool, outer=(1,6)]
+      └── eq [type=bool, outer=(1,6)]
+           ├── variable: b.x [type=int, outer=(6)]
+           └── variable: a.k [type=int, outer=(1)]
+
+# --------------------------------------------------
+# PushDownSelectGroupBy
+# --------------------------------------------------
+
+# Push down into GroupBy with aggregations.
+opt
+SELECT * FROM (SELECT i, COUNT(*) FROM a GROUP BY i) a WHERE i=1
+----
+group-by
+ ├── columns: i:2(int) column6:6(int)
+ ├── grouping columns: a.i:2(int)
+ ├── select
+ │    ├── columns: a.i:2(int)
+ │    ├── scan
+ │    │    └── columns: a.i:2(int)
+ │    └── filters [type=bool, outer=(2)]
+ │         └── eq [type=bool, outer=(2)]
+ │              ├── variable: a.i [type=int, outer=(2)]
+ │              └── const: 1 [type=int]
+ └── aggregations
+      └── function: count_rows [type=int]
+
+# Push down into GroupBy with no aggregations.
+opt
+SELECT * FROM (SELECT i FROM a GROUP BY i) a WHERE i=1
+----
+group-by
+ ├── columns: i:2(int)
+ ├── grouping columns: a.i:2(int)
+ ├── select
+ │    ├── columns: a.i:2(int)
+ │    ├── scan
+ │    │    └── columns: a.i:2(int)
+ │    └── filters [type=bool, outer=(2)]
+ │         └── eq [type=bool, outer=(2)]
+ │              ├── variable: a.i [type=int, outer=(2)]
+ │              └── const: 1 [type=int]
+ └── aggregations
+
+# Push down only conditions that do not depend on aggregations.
+opt
+SELECT * FROM (SELECT k, i, MAX(s) m FROM a GROUP BY k, i) a WHERE i=k AND m='foo'
+----
+select
+ ├── columns: k:1(int!null) i:2(int) m:6(string)
+ ├── group-by
+ │    ├── columns: a.k:1(int!null) a.i:2(int) m:6(string)
+ │    ├── grouping columns: a.k:1(int!null) a.i:2(int)
+ │    ├── select
+ │    │    ├── columns: a.k:1(int!null) a.i:2(int) a.s:4(string)
+ │    │    ├── scan
+ │    │    │    └── columns: a.k:1(int!null) a.i:2(int) a.s:4(string)
+ │    │    └── filters [type=bool, outer=(1,2)]
+ │    │         └── eq [type=bool, outer=(1,2)]
+ │    │              ├── variable: a.i [type=int, outer=(2)]
+ │    │              └── variable: a.k [type=int, outer=(1)]
+ │    └── aggregations [outer=(4)]
+ │         └── function: max [type=string, outer=(4)]
+ │              └── variable: a.s [type=string, outer=(4)]
+ └── filters [type=bool, outer=(6)]
+      └── eq [type=bool, outer=(6)]
+           ├── variable: m [type=string, outer=(6)]
+           └── const: 'foo' [type=string]
+
+# Do *not* push down into scalar GroupBy.
+opt
+SELECT * FROM (SELECT COUNT(*) c FROM a) a WHERE now()<'2000-01-01T10:00:00' AND c=0
+----
+select
+ ├── columns: c:6(int)
+ ├── group-by
+ │    ├── columns: c:6(int)
+ │    ├── scan
+ │    └── aggregations
+ │         └── function: count_rows [type=int]
+ └── filters [type=bool, outer=(6)]
+      ├── lt [type=bool]
+      │    ├── function: now [type=timestamptz]
+      │    └── const: '2000-01-01 10:00:00+00:00' [type=timestamptz]
+      └── eq [type=bool, outer=(6)]
+           ├── variable: c [type=int, outer=(6)]
+           └── const: 0 [type=int]


### PR DESCRIPTION
This PR adds multiple patterns that try to push filters down lower in
the expression tree. This is generally desirable, since it means fewer
rows to process at the higher levels. Filters can be pushed down into
a variety of operators. This PR does not handle every possible push
down opportunity, but does handle the most common cases.

Release note: None