### PR TITLE
cherrypick-2.0: sql: only reuse a render if the types match

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/array
+++ b/pkg/sql/logictest/testdata/logic_test/array
@@ -1085,3 +1085,11 @@ query T
 SELECT STRING_TO_ARRAY('foofoofoofoo', 'foo', 'foo')
 ----
 {"","","","",""}
+
+# Regression test for #23429.
+
+statement ok
+CREATE TABLE x (a STRING[], b INT[])
+
+statement ok
+UPDATE x SET a = ARRAY[], b = ARRAY[]

--- a/pkg/sql/targets.go
+++ b/pkg/sql/targets.go
@@ -116,7 +116,7 @@ func (s *renderNode) addOrReuseRender(
 		// already so that comparison occurs after replacing column names
 		// to IndexedVars.
 		for j := range s.render {
-			if s.isRenderEquivalent(exprStr, j) {
+			if s.isRenderEquivalent(exprStr, j) && s.render[j].ResolvedType() == col.Typ {
 				return j
 			}
 		}


### PR DESCRIPTION
Picks #23465.
Fixes #23429.

The problem here was that since we use string equality to determine if
two expressions are "equivalent", two empty arrays of different types
would be considered to be equal. This change fixes that by requiring
that the types are the same before reusing a render.

Release note: Fixed a bug where expressions could be mistakenly
considered equal, despite their types being different.

cc @cockroachdb/release 