### PR TITLE
cli: sanitize the behavior of `--url` vs other options

### DIFF
--- a/pkg/base/config.go
+++ b/pkg/base/config.go
@@ -202,35 +202,38 @@ func (cfg *Config) GetCACertPath() (string, error) {
 	return cm.GetCACertPath()
 }
 
-// ClientHasValidCerts returns true if the specified client has a valid client cert and key.
-func (cfg *Config) ClientHasValidCerts(user string) bool {
-	_, _, err := cfg.GetClientCertPaths(user)
-	return err == nil
-}
-
-// PGURL returns the URL for the postgres endpoint.
-func (cfg *Config) PGURL(user *url.Userinfo) (*url.URL, error) {
-	options := url.Values{}
+// LoadSecurityOptions extends a url.Values with SSL settings suitable for
+// the given server config. It returns true if and only if the URL
+// already contained SSL config options.
+func (cfg *Config) LoadSecurityOptions(options url.Values, username string) error {
 	if cfg.Insecure {
 		options.Add("sslmode", "disable")
 	} else {
 		// Fetch CA cert. This is required.
 		caCertPath, err := cfg.GetCACertPath()
 		if err != nil {
-			return nil, didYouMeanInsecureError(err)
+			return didYouMeanInsecureError(err)
 		}
 		options.Add("sslmode", "verify-full")
 		options.Add("sslrootcert", caCertPath)
 
 		// Fetch certs, but don't fail, we may be using a password.
-		certPath, keyPath, err := cfg.GetClientCertPaths(user.Username())
+		certPath, keyPath, err := cfg.GetClientCertPaths(username)
 		if err == nil {
 			options.Add("sslcert", certPath)
 			options.Add("sslkey", keyPath)
 		}
 	}
-	options.Add("application_name", "cockroach")
+	return nil
+}
 
+// PGURL constructs a URL for the postgres endpoint, given a server
+// config. There is no default database set.
+func (cfg *Config) PGURL(user *url.Userinfo) (*url.URL, error) {
+	options := url.Values{}
+	if err := cfg.LoadSecurityOptions(options, user.Username()); err != nil {
+		return nil, err
+	}
 	return &url.URL{
 		Scheme:   "postgresql",
 		User:     user,

--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -674,7 +674,7 @@ func Example_sql() {
 	// Output:
 	// sql -e show application_name
 	// application_name
-	// cockroach
+	// cockroach sql
 	// sql -e create database t; create table t.f (x int, y int); insert into t.f values (42, 69)
 	// INSERT 1
 	// sql -e select 3 -e select * from t.f

--- a/pkg/cli/context.go
+++ b/pkg/cli/context.go
@@ -20,7 +20,6 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
-	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/server"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
@@ -75,7 +74,7 @@ func initCLIDefaults() {
 	cliCtx.showTimes = false
 	cliCtx.cmdTimeout = 0 // no timeout
 	cliCtx.sqlConnURL = ""
-	cliCtx.sqlConnUser = security.RootUser
+	cliCtx.sqlConnUser = ""
 	cliCtx.sqlConnDBName = ""
 
 	sqlCtx.execStmts = nil

--- a/pkg/cli/dump.go
+++ b/pkg/cli/dump.go
@@ -49,7 +49,7 @@ func runDump(cmd *cobra.Command, args []string) error {
 		return usageAndError(cmd)
 	}
 
-	conn, err := getPasswordAndMakeSQLClient()
+	conn, err := getPasswordAndMakeSQLClient("cockroach dump")
 	if err != nil {
 		return err
 	}

--- a/pkg/cli/interactive_tests/test_secure.tcl
+++ b/pkg/cli/interactive_tests/test_secure.tcl
@@ -71,7 +71,7 @@ end_test
 
 start_test "Check that root cannot use password."
 # Run as root but with a non-existent certs directory.
-send "$argv sql --certs-dir=non-existent-dir\r"
+send "$argv sql --url='postgresql://root@localhost:26257?sslmode=verify-full'\r"
 eexpect "Error: connections with user root must use a client certificate"
 eexpect "Failed running \"sql\""
 end_test

--- a/pkg/cli/interactive_tests/test_url_db_override.tcl
+++ b/pkg/cli/interactive_tests/test_url_db_override.tcl
@@ -1,0 +1,101 @@
+#! /usr/bin/env expect -f
+
+source [file join [file dirname $argv0] common.tcl]
+
+start_server $argv
+
+# This is run as an acceptance test to ensure that the code path
+# that opens the SQL connection by URL is exercised.
+
+system "$argv sql -e 'create database test'"
+system "$argv user set test"
+
+start_test "Check that the SSL settings come from flags is URL does not set them already."
+# Use default, sslmode is secure
+set ::env(COCKROACH_INSECURE) "false"
+
+spawn $argv sql --url "postgresql://test@localhost:26257" -e "select 1"
+eexpect "problem with CA certificate"
+eexpect eof
+
+spawn $argv sql --url "postgresql://test@localhost:26257" --insecure -e "select 1"
+eexpect "1 row"
+eexpect eof
+
+set ::env(COCKROACH_INSECURE) "true"
+end_test
+
+
+
+start_test "Check that the insecure flag does not override the sslmode if URL is already set."
+# Use default, sslmode is secure
+set ::env(COCKROACH_INSECURE) "false"
+
+spawn $argv sql --url "postgresql://test@localhost:26257?sslmode=verify-full" -e "select 1"
+eexpect "password:"
+send "\r"
+eexpect "SSL is not enabled on the server"
+eexpect eof
+
+spawn $argv sql --url "postgresql://test@localhost:26257?sslmode=verify-full" --insecure -e "select 1"
+eexpect "parameter --insecure ignored, using --url"
+eexpect "password:"
+send "\r"
+eexpect "SSL is not enabled on the server"
+eexpect eof
+
+set ::env(COCKROACH_INSECURE) "true"
+end_test
+
+
+start_test "Check that the database flag does not override the db if URL is already set."
+spawn $argv sql --url "postgresql://root@localhost:26257/system?sslmode=disable"  -e "select length(@1) as l, @1 as db from \[show database\]" --format=csv
+eexpect "l,db"
+eexpect "6,system"
+eexpect eof
+
+spawn $argv sql --url "postgresql://root@localhost:26257/system?sslmode=disable" --database test -e "select length(@1) as l, @1 as db from \[show database\]" --format=csv
+eexpect "parameter --database ignored, using --url"
+eexpect "l,db"
+eexpect "6,system"
+eexpect eof
+end_test
+
+start_test "Check that the database flag does override the database if none was present in the URL."
+# Use empty path.
+spawn $argv sql --url "postgresql://root@localhost:26257?sslmode=disable" --database system -e "select length(@1) as l, @1 as db from \[show database\]" --format=csv
+eexpect "l,db"
+eexpect "6,system"
+eexpect eof
+# Use path = /
+spawn $argv sql --url "postgresql://root@localhost:26257/?sslmode=disable" --database system -e "select length(@1) as l, @1 as db from \[show database\]" --format=csv
+eexpect "l,db"
+eexpect "6,system"
+eexpect eof
+
+end_test
+
+start_test "Check that the user flag does not override the user if URL is already set."
+spawn $argv sql --url "postgresql://test@localhost:26257?sslmode=disable" -e "select length(@1) as l, @1 as u from \[show session_user\]" --format=csv
+eexpect "l,u"
+eexpect "4,test"
+eexpect eof
+
+spawn $argv sql --url "postgresql://root@localhost:26257?sslmode=disable" --user test -e "select length(@1) as l, @1 as u from \[show session_user\]" --format=csv
+eexpect "parameter --user ignored, using --url"
+eexpect "l,u"
+eexpect "4,root"
+eexpect eof
+end_test
+
+start_test "Check that the host flag does not override the host if URL is already set."
+spawn $argv sql --url "postgresql://root@localhost:26257?sslmode=disable" --host nonexistent -e "select 1"
+expect "parameter --host ignored, using --url"
+eexpect "1 row"
+eexpect eof
+end_test
+
+
+
+stop_server $argv
+

--- a/pkg/cli/sql.go
+++ b/pkg/cli/sql.go
@@ -1157,7 +1157,7 @@ func runTerm(cmd *cobra.Command, args []string) error {
 		fmt.Print(infoMessage)
 	}
 
-	conn, err := getPasswordAndMakeSQLClient()
+	conn, err := getPasswordAndMakeSQLClient("cockroach sql")
 	if err != nil {
 		return err
 	}

--- a/pkg/cli/sql_util.go
+++ b/pkg/cli/sql_util.go
@@ -449,38 +449,148 @@ func makeSQLConn(url string) *sqlConn {
 // getPasswordAndMakeSQLClient prompts for a password if running in secure mode
 // and no certificates have been supplied.
 // Attempting to use security.RootUser without valid certificates will return an error.
-func getPasswordAndMakeSQLClient() (*sqlConn, error) {
-	if len(cliCtx.sqlConnURL) != 0 {
-		return makeSQLConn(cliCtx.sqlConnURL), nil
-	}
-	var user *url.Userinfo
-	if !baseCfg.Insecure && !baseCfg.ClientHasValidCerts(cliCtx.sqlConnUser) {
-		if cliCtx.sqlConnUser == security.RootUser {
-			return nil, errors.Errorf("connections with user %s must use a client certificate", security.RootUser)
-		}
-
-		pwd, err := security.PromptForPassword()
-		if err != nil {
-			return nil, err
-		}
-
-		user = url.UserPassword(cliCtx.sqlConnUser, pwd)
-	} else {
-		user = url.User(cliCtx.sqlConnUser)
-	}
-	return makeSQLClient(user)
+func getPasswordAndMakeSQLClient(appName string) (*sqlConn, error) {
+	return makeSQLClient(appName)
 }
 
-func makeSQLClient(user *url.Userinfo) (*sqlConn, error) {
-	sqlURL := cliCtx.sqlConnURL
-	if len(sqlURL) == 0 {
-		u, err := sqlCtx.PGURL(user)
+// makeURLFromFlags constructs a pg connection URL using the values
+// initialized by command-line flags.
+func makeURLFromFlags(userinfo *url.Userinfo) *url.URL {
+	host := serverCfg.Addr
+	if !strings.HasPrefix(cliCtx.Addr, ":") {
+		host = cliCtx.Addr
+	}
+
+	// Build the URL object.
+	return &url.URL{
+		Scheme: "postgresql",
+		Path:   cliCtx.sqlConnDBName,
+		Host:   host,
+		User:   userinfo,
+	}
+}
+
+// makeSQLClient connects to the database using the connection
+// settings set by the command-line flags. The value of --url, if any
+// is provided is used as the source of configuration; otherwise a URL
+// is constructed from the other command-line parameters.
+//
+// If --url is specified but any of the following items is _missing_
+// from the URL, the remaining command-line flags are used to "fill it
+// in":
+//
+// - the current database (--database)
+// - the user (--user)
+// - the SSL configuration (--insecure, --certs-dir, etc)
+//
+// Otherwise, if an item is present both in the URL and specified
+// otherwise, a warning is printed to indicate that the URL prevails.
+//
+// The appName given as argument is added to the URL even if --url is
+// specified, but only if the URL didn't already specify
+// application_name.
+func makeSQLClient(appName string) (*sqlConn, error) {
+	var baseURL *url.URL
+	var options url.Values
+
+	defaultUserinfo := url.User(security.RootUser)
+	if cliCtx.sqlConnUser != "" {
+		defaultUserinfo = url.User(cliCtx.sqlConnUser)
+	}
+
+	// Determine the starting point.
+	if cliCtx.sqlConnURL == "" {
+		baseURL = makeURLFromFlags(defaultUserinfo)
+		options = url.Values{}
+	} else {
+		// User-specified --url is the starting point.
+		var err error
+		baseURL, err = url.Parse(cliCtx.sqlConnURL)
 		if err != nil {
 			return nil, err
 		}
-		u.Path = cliCtx.sqlConnDBName
-		sqlURL = u.String()
+		options, err = url.ParseQuery(baseURL.RawQuery)
+		if err != nil {
+			return nil, err
+		}
+
+		// Check that any argument otherwise used to
+		// populate a URL, if --url was not specified, have
+		// not been specified if --url was.
+		if baseURL.Path != "" && cliCtx.sqlConnDBName != "" {
+			log.Warning(context.Background(), "parameter --database ignored, using --url instead")
+		}
+		if baseURL.User.Username() != "" && cliCtx.sqlConnUser != "" {
+			log.Warning(context.Background(), "parameter --user ignored, using --url instead")
+		}
+		if !strings.HasPrefix(cliCtx.Addr, ":") {
+			log.Warning(context.Background(), "parameter --host ignored, using --url instead")
+		}
+		if options.Get("sslmode") != "" && cliCtx.Insecure {
+			log.Warning(context.Background(), "parameter --insecure ignored, using --url instead")
+		}
 	}
+
+	// If there is no user in the URL already, use the one passed as
+	// command-line flag.
+	if baseURL.User.Username() == "" {
+		baseURL.User = defaultUserinfo
+	}
+
+	// If there are no SSL options yet, use the command-line flags to set them.
+	if options.Get("sslmode") == "" {
+		if err := cliCtx.LoadSecurityOptions(options, baseURL.User.Username()); err != nil {
+			return nil, err
+		}
+	}
+
+	// Insecure connections are insecure and should never see a password. Reject
+	// one that may be present in the URL already.
+	if options.Get("sslmode") == "disable" {
+		if _, pwdSet := baseURL.User.Password(); pwdSet {
+			return nil, errors.Errorf("cannot specify a password in URL with an insecure connection")
+		}
+	} else {
+		if baseURL.User.Username() == security.RootUser {
+			// Disallow password login for root.
+			if options.Get("sslcert") == "" || options.Get("sslkey") == "" {
+				return nil, errors.Errorf("connections with user %s must use a client certificate",
+					baseURL.User.Username())
+			}
+			// If we can go on (we have a certificate spec), clear the password.
+			baseURL.User = url.User(security.RootUser)
+		} else {
+			// If there's no password in the URL yet, ask for it and populate
+			// it in the URL.
+			if _, pwdSet := baseURL.User.Password(); !pwdSet {
+				pwd, err := security.PromptForPassword()
+				if err != nil {
+					return nil, err
+				}
+				baseURL.User = url.UserPassword(baseURL.User.Username(), pwd)
+			}
+		}
+	}
+
+	// If there is no database in the URL already, use the one passed as
+	// command-line flag.
+	if baseURL.Path == "" || baseURL.Path == "/" {
+		baseURL.Path = cliCtx.sqlConnDBName
+	}
+
+	// Load the application name. It's not a command-line flag, so
+	// anything already in the URL should take priority.
+	if options.Get("application_name") == "" && appName != "" {
+		options.Set("application_name", appName)
+	}
+
+	baseURL.RawQuery = options.Encode()
+	sqlURL := baseURL.String()
+
+	if log.V(2) {
+		log.Infof(context.Background(), "connecting with URL: %s", sqlURL)
+	}
+
 	return makeSQLConn(sqlURL), nil
 }
 

--- a/pkg/cli/start.go
+++ b/pkg/cli/start.go
@@ -543,7 +543,7 @@ func runStart(cmd *cobra.Command, args []string) error {
 
 			// Now inform the user that the server is running and tell the
 			// user about its run-time derived parameters.
-			pgURL, err := serverCfg.PGURL(url.User(cliCtx.sqlConnUser))
+			pgURL, err := serverCfg.PGURL(url.User(security.RootUser))
 			if err != nil {
 				return err
 			}

--- a/pkg/cli/user.go
+++ b/pkg/cli/user.go
@@ -38,7 +38,7 @@ func runGetUser(cmd *cobra.Command, args []string) error {
 	if len(args) != 1 {
 		return usageAndError(cmd)
 	}
-	conn, err := getPasswordAndMakeSQLClient()
+	conn, err := getPasswordAndMakeSQLClient("cockroach user")
 	if err != nil {
 		return err
 	}
@@ -67,7 +67,7 @@ func runLsUsers(cmd *cobra.Command, args []string) error {
 	if len(args) > 0 {
 		return usageAndError(cmd)
 	}
-	conn, err := getPasswordAndMakeSQLClient()
+	conn, err := getPasswordAndMakeSQLClient("cockroach user")
 	if err != nil {
 		return err
 	}
@@ -90,7 +90,7 @@ func runRmUser(cmd *cobra.Command, args []string) error {
 	if len(args) != 1 {
 		return usageAndError(cmd)
 	}
-	conn, err := getPasswordAndMakeSQLClient()
+	conn, err := getPasswordAndMakeSQLClient("cockroach user")
 	if err != nil {
 		return err
 	}
@@ -137,7 +137,7 @@ func runSetUser(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	conn, err := getPasswordAndMakeSQLClient()
+	conn, err := getPasswordAndMakeSQLClient("cockroach user")
 	if err != nil {
 		return err
 	}

--- a/pkg/cli/zone.go
+++ b/pkg/cli/zone.go
@@ -79,7 +79,7 @@ func runGetZone(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	conn, err := getPasswordAndMakeSQLClient()
+	conn, err := getPasswordAndMakeSQLClient("cockroach zone")
 	if err != nil {
 		return err
 	}
@@ -127,7 +127,7 @@ func runLsZones(cmd *cobra.Command, args []string) error {
 	if len(args) > 0 {
 		return usageAndError(cmd)
 	}
-	conn, err := getPasswordAndMakeSQLClient()
+	conn, err := getPasswordAndMakeSQLClient("cockroach zone")
 	if err != nil {
 		return err
 	}
@@ -169,7 +169,7 @@ func runRmZone(cmd *cobra.Command, args []string) error {
 		return usageAndError(cmd)
 	}
 
-	conn, err := getPasswordAndMakeSQLClient()
+	conn, err := getPasswordAndMakeSQLClient("cockroach zone")
 	if err != nil {
 		return err
 	}
@@ -246,7 +246,7 @@ func runSetZone(cmd *cobra.Command, args []string) error {
 		return usageAndError(cmd)
 	}
 
-	conn, err := getPasswordAndMakeSQLClient()
+	conn, err := getPasswordAndMakeSQLClient("cockroach zone")
 	if err != nil {
 		return err
 	}

--- a/pkg/sql/logictest/testdata/logic_test/crdb_internal
+++ b/pkg/sql/logictest/testdata/logic_test/crdb_internal
@@ -248,12 +248,12 @@ query ITTT colnames
 select node_id, component, field, regexp_replace(regexp_replace(value, '^\d+$', '<port>'), e':\\d+', ':<port>') as value from crdb_internal.node_runtime_info
 ----
 node_id  component  field   value
-1        DB         URL     postgresql://root@127.0.0.1:<port>?application_name=cockroach&sslcert=test_certs%2Fclient.root.crt&sslkey=test_certs%2Fclient.root.key&sslmode=verify-full&sslrootcert=test_certs%2Fca.crt
+1        DB         URL     postgresql://root@127.0.0.1:<port>?sslcert=test_certs%2Fclient.root.crt&sslkey=test_certs%2Fclient.root.key&sslmode=verify-full&sslrootcert=test_certs%2Fca.crt
 1        DB         Scheme  postgresql
 1        DB         User    root
 1        DB         Host    127.0.0.1
 1        DB         Port    <port>
-1        DB         URI     /?application_name=cockroach&sslcert=test_certs%2Fclient.root.crt&sslkey=test_certs%2Fclient.root.key&sslmode=verify-full&sslrootcert=test_certs%2Fca.crt
+1        DB         URI     /?sslcert=test_certs%2Fclient.root.crt&sslkey=test_certs%2Fclient.root.key&sslmode=verify-full&sslrootcert=test_certs%2Fca.crt
 1        UI         URL     https://127.0.0.1:<port>
 1        UI         Scheme  https
 1        UI         User    ·


### PR DESCRIPTION
Fixes #23688.
Fixes #22376.
Fixes #23739.

Prior to this patch, if `--url` is specified, that is used to open the
connection regardless of the value of `--database`, `--host`,
`--insecure`, `--port` and `--user`. The value of these flags would
only be used if `--url` is not specified.

This is surprising because if the URL specifies something and the
operator also specifies contradictory information via another
parameter, the other parameter is dropped on the floor without
warning so the operator may get a different connection behavior than
what they expected.

Also if some information is outright missing from the passed URL, it
is not possible to override it using an individual flag (e.g. to set a
current database).

This patch changes this to make `--url` "play nice" with the other
flag: a warning is reported if `--url` is specified and also one of
the other individual flags, to remind the user that `--url`
prevails. Missing items in the URL are "filled in" from other
arguments.

This behavior extends that of `psql`, which always let the URL
prevail, even if it misses information. This patch makes CockroachDB
arguably better, by informing the user about what's going on if
there's a conflict, and enabling some customization of the URL.

Incidentally, this fixes a bug where the `application_name` option was
forcefully introduced in various places where it shouldn't be present.

Release note (cli change): the client commands now reports a
warning if both `--url` is specified and some other command-line
argument that specifies the same information.

Release note (bug fix): the postgres URL reported upon `cockroach
start` again properly does not include the option `application_name`.