### PR TITLE
opt: Output name of Scan table in expression tree

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/scan
+++ b/pkg/sql/opt/exec/execbuilder/testdata/scan
@@ -10,7 +10,7 @@ INSERT INTO t.a VALUES (1, 1.0, 'apple'), (2, 2.0, 'banana'), (3, 3.0, 'cherry')
 build
 SELECT * FROM t.a
 ----
-scan
+scan a
  └── columns: x:1(int!null) y:2(float) s:3(string)
 
 exec-explain
@@ -32,7 +32,7 @@ x:int  y:float  s:string
 build
 SELECT s, x FROM t.a
 ----
-scan
+scan a
  └── columns: s:3(string) x:1(int!null)
 
 exec-explain
@@ -65,7 +65,7 @@ INSERT INTO t.b VALUES (1, 10, 'apple'), (2, 20, 'banana'), (3, 30, 'cherry')
 build
 SELECT s, x FROM t.b
 ----
-scan
+scan b
  └── columns: s:3(string) x:1(int)
 
 exec

--- a/pkg/sql/opt/optbuilder/testdata/aggregate
+++ b/pkg/sql/opt/optbuilder/testdata/aggregate
@@ -24,7 +24,7 @@ group-by
  ├── columns: column6:6(int) column8:8(int) column10:10(int) column12:12(int) column14:14(decimal) column16:16(decimal) column18:18(decimal) column20:20(decimal) column22:22(bool) column24:24(bool) column26:26(bytes)
  ├── project
  │    ├── columns: column5:5(int) column7:7(int) column9:9(int) column11:11(int) column13:13(int) column15:15(int) column17:17(int) column19:19(int) column21:21(bool) column23:23(bool) column25:25(bytes)
- │    ├── scan
+ │    ├── scan kv
  │    │    └── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string)
  │    └── projections
  │         ├── const: 1 [type=int]
@@ -70,7 +70,7 @@ group-by
  ├── columns: column5:5(int) column6:6(int) column7:7(int) column9:9(int) column10:10(decimal) column11:11(decimal) column12:12(decimal) column13:13(decimal) column15:15(bool) column17:17(bool) column19:19(bytes)
  ├── project
  │    ├── columns: kv.v:2(int) kv.v:2(int) kv.v:2(int) column8:8(int) kv.v:2(int) kv.v:2(int) kv.v:2(int) kv.v:2(int) column14:14(bool) column16:16(bool) column18:18(bytes)
- │    ├── scan
+ │    ├── scan kv
  │    │    └── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string)
  │    └── projections [outer=(2,4)]
  │         ├── variable: kv.v [type=int, outer=(2)]
@@ -183,7 +183,7 @@ group-by
  ├── columns: column6:6(int[])
  ├── project
  │    ├── columns: column5:5(int)
- │    ├── scan
+ │    ├── scan kv
  │    │    └── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string)
  │    └── projections
  │         └── const: 1 [type=int]
@@ -198,7 +198,7 @@ group-by
  ├── columns: column5:5(jsonb)
  ├── project
  │    ├── columns: kv.v:2(int)
- │    ├── scan
+ │    ├── scan kv
  │    │    └── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string)
  │    └── projections [outer=(2)]
  │         └── variable: kv.v [type=int, outer=(2)]
@@ -232,7 +232,7 @@ project
  │    ├── grouping columns: kv.v:2(int)
  │    ├── project
  │    │    ├── columns: kv.v:2(int)
- │    │    ├── scan
+ │    │    ├── scan kv
  │    │    │    └── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string)
  │    │    └── projections [outer=(2)]
  │    │         └── variable: kv.v [type=int, outer=(2)]
@@ -298,7 +298,7 @@ project
  │    ├── grouping columns: kv.k:1(int!null)
  │    ├── project
  │    │    ├── columns: kv.k:1(int!null)
- │    │    ├── scan
+ │    │    ├── scan kv
  │    │    │    └── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string)
  │    │    └── projections [outer=(1)]
  │    │         └── variable: kv.k [type=int, outer=(1)]
@@ -319,7 +319,7 @@ project
  │    ├── grouping columns: kv.k:1(int!null)
  │    ├── project
  │    │    ├── columns: kv.k:1(int!null)
- │    │    ├── scan
+ │    │    ├── scan kv
  │    │    │    └── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string)
  │    │    └── projections [outer=(1)]
  │    │         └── variable: kv.k [type=int, outer=(1)]
@@ -355,7 +355,7 @@ project
  │    ├── grouping columns: kv.s:4(string)
  │    ├── project
  │    │    ├── columns: kv.s:4(string)
- │    │    ├── scan
+ │    │    ├── scan kv
  │    │    │    └── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string)
  │    │    └── projections [outer=(4)]
  │    │         └── variable: kv.s [type=string, outer=(4)]
@@ -375,7 +375,7 @@ project
  │    ├── grouping columns: kv.s:4(string)
  │    ├── project
  │    │    ├── columns: kv.s:4(string)
- │    │    ├── scan
+ │    │    ├── scan kv
  │    │    │    └── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string)
  │    │    └── projections [outer=(4)]
  │    │         └── variable: kv.s [type=string, outer=(4)]
@@ -395,7 +395,7 @@ project
  │    ├── grouping columns: kv.s:4(string)
  │    ├── project
  │    │    ├── columns: kv.s:4(string)
- │    │    ├── scan
+ │    │    ├── scan kv
  │    │    │    └── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string)
  │    │    └── projections [outer=(4)]
  │    │         └── variable: kv.s [type=string, outer=(4)]
@@ -415,7 +415,7 @@ project
  │    ├── grouping columns: kv.s:4(string)
  │    ├── project
  │    │    ├── columns: kv.s:4(string)
- │    │    ├── scan
+ │    │    ├── scan kv
  │    │    │    └── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string)
  │    │    └── projections [outer=(4)]
  │    │         └── variable: kv.s [type=string, outer=(4)]
@@ -436,7 +436,7 @@ project
  │    ├── grouping columns: kv.v:2(int) kv.w:3(int)
  │    ├── project
  │    │    ├── columns: kv.v:2(int) kv.w:3(int)
- │    │    ├── scan
+ │    │    ├── scan kv
  │    │    │    └── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string)
  │    │    └── projections [outer=(2,3)]
  │    │         ├── variable: kv.v [type=int, outer=(2)]
@@ -459,7 +459,7 @@ project
  │    ├── grouping columns: kv.v:2(int) kv.w:3(int)
  │    ├── project
  │    │    ├── columns: kv.v:2(int) kv.w:3(int)
- │    │    ├── scan
+ │    │    ├── scan kv
  │    │    │    └── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string)
  │    │    └── projections [outer=(2,3)]
  │    │         ├── variable: kv.v [type=int, outer=(2)]
@@ -482,7 +482,7 @@ project
  │    ├── grouping columns: column5:5(string)
  │    ├── project
  │    │    ├── columns: column5:5(string)
- │    │    ├── scan
+ │    │    ├── scan kv
  │    │    │    └── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string)
  │    │    └── projections [outer=(4)]
  │    │         └── function: upper [type=string, outer=(4)]
@@ -504,7 +504,7 @@ project
  │    ├── grouping columns: column5:5(int)
  │    ├── project
  │    │    ├── columns: column5:5(int)
- │    │    ├── scan
+ │    │    ├── scan kv
  │    │    │    └── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string)
  │    │    └── projections
  │    │         └── const: 3 [type=int]
@@ -523,7 +523,7 @@ project
  │    ├── grouping columns: column5:5(int)
  │    ├── project
  │    │    ├── columns: column5:5(int)
- │    │    ├── scan
+ │    │    ├── scan kv
  │    │    │    └── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string)
  │    │    └── projections
  │    │         └── function: length [type=int]
@@ -544,7 +544,7 @@ project
  │    ├── grouping columns: kv.s:4(string)
  │    ├── project
  │    │    ├── columns: kv.s:4(string)
- │    │    ├── scan
+ │    │    ├── scan kv
  │    │    │    └── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string)
  │    │    └── projections [outer=(4)]
  │    │         └── variable: kv.s [type=string, outer=(4)]
@@ -572,7 +572,7 @@ project
  │    ├── grouping columns: column5:5(int)
  │    ├── project
  │    │    ├── columns: column5:5(int)
- │    │    ├── scan
+ │    │    ├── scan kv
  │    │    │    └── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string)
  │    │    └── projections [outer=(1,2)]
  │    │         └── plus [type=int, outer=(1,2)]
@@ -596,7 +596,7 @@ project
  │    ├── grouping columns: kv.k:1(int!null) kv.v:2(int)
  │    ├── project
  │    │    ├── columns: kv.k:1(int!null) kv.v:2(int)
- │    │    ├── scan
+ │    │    ├── scan kv
  │    │    │    └── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string)
  │    │    └── projections [outer=(1,2)]
  │    │         ├── variable: kv.k [type=int, outer=(1)]
@@ -645,7 +645,7 @@ project
  │    ├── grouping columns: column5:5(int)
  │    ├── project
  │    │    ├── columns: column5:5(int) kv.k:1(int!null)
- │    │    ├── scan
+ │    │    ├── scan kv
  │    │    │    └── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string)
  │    │    └── projections [outer=(1-3)]
  │    │         ├── plus [type=int, outer=(2,3)]
@@ -676,7 +676,7 @@ group-by
  ├── columns: column5:5(int)
  ├── project
  │    ├── columns: kv.k:1(int!null)
- │    ├── scan
+ │    ├── scan kv
  │    │    └── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string)
  │    └── projections [outer=(1)]
  │         └── variable: kv.k [type=int, outer=(1)]
@@ -706,7 +706,7 @@ group-by
  ├── columns: column6:6(int)
  ├── project
  │    ├── columns: column5:5(int)
- │    ├── scan
+ │    ├── scan kv
  │    │    └── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string)
  │    └── projections
  │         └── const: 1 [type=int]
@@ -730,7 +730,7 @@ sort
       ├── grouping columns: kv.v:2(int)
       ├── project
       │    ├── columns: kv.v:2(int) kv.k:1(int!null)
-      │    ├── scan
+      │    ├── scan kv
       │    │    └── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string)
       │    └── projections [outer=(1,2)]
       │         ├── variable: kv.v [type=int, outer=(2)]
@@ -750,7 +750,7 @@ sort
       ├── grouping columns: kv.v:2(int)
       ├── project
       │    ├── columns: kv.v:2(int) kv.k:1(int!null)
-      │    ├── scan
+      │    ├── scan kv
       │    │    └── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string)
       │    └── projections [outer=(1,2)]
       │         ├── variable: kv.v [type=int, outer=(2)]
@@ -782,7 +782,7 @@ sort
       ├── grouping columns: kv.v:2(int)
       ├── project
       │    ├── columns: kv.v:2(int) kv.k:1(int!null)
-      │    ├── scan
+      │    ├── scan kv
       │    │    └── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string)
       │    └── projections [outer=(1,2)]
       │         ├── variable: kv.v [type=int, outer=(2)]
@@ -798,7 +798,7 @@ group-by
  ├── columns: column5:5(int) column6:6(int) column7:7(int)
  ├── project
  │    ├── columns: kv.k:1(int!null) kv.v:2(int)
- │    ├── scan
+ │    ├── scan kv
  │    │    └── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string)
  │    └── projections [outer=(1,2)]
  │         ├── variable: kv.k [type=int, outer=(1)]
@@ -817,7 +817,7 @@ group-by
  ├── columns: column6:6(int)
  ├── project
  │    ├── columns: column5:5(tuple{int, int, int, string})
- │    ├── scan
+ │    ├── scan kv
  │    │    └── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string)
  │    └── projections [outer=(1-4)]
  │         └── tuple [type=tuple{int, int, int, string}, outer=(1-4)]
@@ -836,7 +836,7 @@ group-by
  ├── columns: column6:6(int)
  ├── project
  │    ├── columns: column5:5(tuple{int, int})
- │    ├── scan
+ │    ├── scan kv
  │    │    └── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string)
  │    └── projections [outer=(1,2)]
  │         └── tuple [type=tuple{int, int}, outer=(1,2)]
@@ -855,7 +855,7 @@ project
  │    ├── columns: column5:5(int) column6:6(int)
  │    ├── project
  │    │    ├── columns: kv.k:1(int!null) kv.v:2(int)
- │    │    ├── scan
+ │    │    ├── scan kv
  │    │    │    └── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string)
  │    │    └── projections [outer=(1,2)]
  │    │         ├── variable: kv.k [type=int, outer=(1)]
@@ -898,7 +898,7 @@ group-by
  ├── columns: column5:5(int) column6:6(int) column7:7(int) column8:8(int)
  ├── project
  │    ├── columns: kv.k:1(int!null) kv.k:1(int!null) kv.v:2(int) kv.v:2(int)
- │    ├── scan
+ │    ├── scan kv
  │    │    └── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string)
  │    └── projections [outer=(1,2)]
  │         ├── variable: kv.k [type=int, outer=(1)]
@@ -924,7 +924,7 @@ group-by
  │    ├── columns: kv.k:1(int!null) kv.k:1(int!null) kv.v:2(int) kv.v:2(int)
  │    ├── select
  │    │    ├── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string)
- │    │    ├── scan
+ │    │    ├── scan kv
  │    │    │    └── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string)
  │    │    └── gt [type=bool, outer=(1)]
  │    │         ├── variable: kv.k [type=int, outer=(1)]
@@ -951,7 +951,7 @@ group-by
  ├── columns: column5:5(int[]) column6:6(string[])
  ├── project
  │    ├── columns: kv.k:1(int!null) kv.s:4(string)
- │    ├── scan
+ │    ├── scan kv
  │    │    └── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string)
  │    └── projections [outer=(1,4)]
  │         ├── variable: kv.k [type=int, outer=(1)]
@@ -971,7 +971,7 @@ group-by
  │    ├── columns: kv.s:4(string)
  │    ├── select
  │    │    ├── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string)
- │    │    ├── scan
+ │    │    ├── scan kv
  │    │    │    └── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string)
  │    │    └── is [type=bool, outer=(4)]
  │    │         ├── variable: kv.s [type=string, outer=(4)]
@@ -989,7 +989,7 @@ group-by
  ├── columns: column5:5(decimal) column6:6(decimal) column7:7(decimal) column8:8(decimal)
  ├── project
  │    ├── columns: kv.k:1(int!null) kv.v:2(int) kv.k:1(int!null) kv.v:2(int)
- │    ├── scan
+ │    ├── scan kv
  │    │    └── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string)
  │    └── projections [outer=(1,2)]
  │         ├── variable: kv.k [type=int, outer=(1)]
@@ -1013,7 +1013,7 @@ group-by
  ├── columns: column6:6(decimal) column8:8(decimal) column10:10(decimal) column12:12(decimal)
  ├── project
  │    ├── columns: column5:5(decimal) column7:7(decimal) column9:9(decimal) column11:11(decimal)
- │    ├── scan
+ │    ├── scan kv
  │    │    └── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string)
  │    └── projections [outer=(1,2)]
  │         ├── cast: decimal [type=decimal, outer=(1)]
@@ -1043,7 +1043,7 @@ project
  │    ├── columns: column5:5(decimal) column6:6(int)
  │    ├── project
  │    │    ├── columns: kv.k:1(int!null) kv.v:2(int)
- │    │    ├── scan
+ │    │    ├── scan kv
  │    │    │    └── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string)
  │    │    └── projections [outer=(1,2)]
  │    │         ├── variable: kv.k [type=int, outer=(1)]
@@ -1072,7 +1072,7 @@ project
  │    │    ├── columns: kv.k:1(int!null) kv.v:2(int)
  │    │    ├── select
  │    │    │    ├── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string)
- │    │    │    ├── scan
+ │    │    │    ├── scan kv
  │    │    │    │    └── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string)
  │    │    │    └── eq [type=bool, outer=(1,3)]
  │    │    │         ├── mult [type=int, outer=(3)]
@@ -1116,7 +1116,7 @@ SELECT MIN(a), MIN(b), MIN(c), MIN(d) FROM t.abc
 ----
 group-by
  ├── columns: column5:5(string) column6:6(float) column7:7(bool) column8:8(decimal)
- ├── scan
+ ├── scan abc
  │    └── columns: abc.a:1(string!null) abc.b:2(float) abc.c:3(bool) abc.d:4(decimal)
  └── aggregations [outer=(1-4)]
       ├── function: min [type=string, outer=(1)]
@@ -1133,7 +1133,7 @@ SELECT MAX(a), MAX(b), MAX(c), MAX(d) FROM t.abc
 ----
 group-by
  ├── columns: column5:5(string) column6:6(float) column7:7(bool) column8:8(decimal)
- ├── scan
+ ├── scan abc
  │    └── columns: abc.a:1(string!null) abc.b:2(float) abc.c:3(bool) abc.d:4(decimal)
  └── aggregations [outer=(1-4)]
       ├── function: max [type=string, outer=(1)]
@@ -1152,7 +1152,7 @@ group-by
  ├── columns: column5:5(float) column6:6(float) column7:7(decimal) column8:8(decimal)
  ├── project
  │    ├── columns: abc.b:2(float) abc.b:2(float) abc.d:4(decimal) abc.d:4(decimal)
- │    ├── scan
+ │    ├── scan abc
  │    │    └── columns: abc.a:1(string!null) abc.b:2(float) abc.c:3(bool) abc.d:4(decimal)
  │    └── projections [outer=(2,4)]
  │         ├── variable: abc.b [type=float, outer=(2)]
@@ -1185,7 +1185,7 @@ SELECT SUM(a) FROM t.intervals
 ----
 group-by
  ├── columns: column2:2(interval)
- ├── scan
+ ├── scan intervals
  │    └── columns: intervals.a:1(interval!null)
  └── aggregations [outer=(1)]
       └── function: sum [type=interval, outer=(1)]
@@ -1254,7 +1254,7 @@ group-by
  ├── columns: column4:4(int)
  ├── project
  │    ├── columns: xyz.x:1(int!null)
- │    ├── scan
+ │    ├── scan xyz
  │    │    └── columns: xyz.x:1(int!null) xyz.y:2(int) xyz.z:3(float)
  │    └── projections [outer=(1)]
  │         └── variable: xyz.x [type=int, outer=(1)]
@@ -1271,7 +1271,7 @@ group-by
  │    ├── columns: xyz.x:1(int!null)
  │    ├── select
  │    │    ├── columns: xyz.x:1(int!null) xyz.y:2(int) xyz.z:3(float)
- │    │    ├── scan
+ │    │    ├── scan xyz
  │    │    │    └── columns: xyz.x:1(int!null) xyz.y:2(int) xyz.z:3(float)
  │    │    └── in [type=bool, outer=(1)]
  │    │         ├── variable: xyz.x [type=int, outer=(1)]
@@ -1292,7 +1292,7 @@ group-by
  ├── columns: column4:4(int)
  ├── project
  │    ├── columns: xyz.x:1(int!null)
- │    ├── scan
+ │    ├── scan xyz
  │    │    └── columns: xyz.x:1(int!null) xyz.y:2(int) xyz.z:3(float)
  │    └── projections [outer=(1)]
  │         └── variable: xyz.x [type=int, outer=(1)]
@@ -1309,7 +1309,7 @@ group-by
  │    ├── columns: xyz.y:2(int)
  │    ├── select
  │    │    ├── columns: xyz.x:1(int!null) xyz.y:2(int) xyz.z:3(float)
- │    │    ├── scan
+ │    │    ├── scan xyz
  │    │    │    └── columns: xyz.x:1(int!null) xyz.y:2(int) xyz.z:3(float)
  │    │    └── eq [type=bool, outer=(1)]
  │    │         ├── variable: xyz.x [type=int, outer=(1)]
@@ -1329,7 +1329,7 @@ group-by
  │    ├── columns: xyz.y:2(int)
  │    ├── select
  │    │    ├── columns: xyz.x:1(int!null) xyz.y:2(int) xyz.z:3(float)
- │    │    ├── scan
+ │    │    ├── scan xyz
  │    │    │    └── columns: xyz.x:1(int!null) xyz.y:2(int) xyz.z:3(float)
  │    │    └── eq [type=bool, outer=(1)]
  │    │         ├── variable: xyz.x [type=int, outer=(1)]
@@ -1349,7 +1349,7 @@ group-by
  │    ├── columns: xyz.x:1(int!null)
  │    ├── select
  │    │    ├── columns: xyz.x:1(int!null) xyz.y:2(int) xyz.z:3(float)
- │    │    ├── scan
+ │    │    ├── scan xyz
  │    │    │    └── columns: xyz.x:1(int!null) xyz.y:2(int) xyz.z:3(float)
  │    │    └── eq [type=bool, outer=(2,3)]
  │    │         ├── tuple [type=tuple{int, float}, outer=(2,3)]
@@ -1373,7 +1373,7 @@ group-by
  │    ├── columns: xyz.x:1(int!null)
  │    ├── select
  │    │    ├── columns: xyz.x:1(int!null) xyz.y:2(int) xyz.z:3(float)
- │    │    ├── scan
+ │    │    ├── scan xyz
  │    │    │    └── columns: xyz.x:1(int!null) xyz.y:2(int) xyz.z:3(float)
  │    │    └── eq [type=bool, outer=(2,3)]
  │    │         ├── tuple [type=tuple{float, int}, outer=(2,3)]
@@ -1400,7 +1400,7 @@ project
  │    ├── columns: column4:4(decimal) column6:6(decimal) column7:7(float)
  │    ├── project
  │    │    ├── columns: xyz.x:1(int!null) column5:5(decimal) xyz.z:3(float)
- │    │    ├── scan
+ │    │    ├── scan xyz
  │    │    │    └── columns: xyz.x:1(int!null) xyz.y:2(int) xyz.z:3(float)
  │    │    └── projections [outer=(1-3)]
  │    │         ├── variable: xyz.x [type=int, outer=(1)]
@@ -1430,7 +1430,7 @@ group-by
  │    ├── columns: xyz.x:1(int!null)
  │    ├── select
  │    │    ├── columns: xyz.x:1(int!null) xyz.y:2(int) xyz.z:3(float)
- │    │    ├── scan
+ │    │    ├── scan xyz
  │    │    │    └── columns: xyz.x:1(int!null) xyz.y:2(int) xyz.z:3(float)
  │    │    └── eq [type=bool, outer=(1)]
  │    │         ├── variable: xyz.x [type=int, outer=(1)]
@@ -1450,7 +1450,7 @@ project
  │    ├── columns: column4:4(decimal) column6:6(decimal) column7:7(float)
  │    ├── project
  │    │    ├── columns: xyz.x:1(int!null) column5:5(decimal) xyz.z:3(float)
- │    │    ├── scan
+ │    │    ├── scan xyz
  │    │    │    └── columns: xyz.x:1(int!null) xyz.y:2(int) xyz.z:3(float)
  │    │    └── projections [outer=(1-3)]
  │    │         ├── variable: xyz.x [type=int, outer=(1)]
@@ -1480,7 +1480,7 @@ group-by
  │    ├── columns: xyz.x:1(int!null)
  │    ├── select
  │    │    ├── columns: xyz.x:1(int!null) xyz.y:2(int) xyz.z:3(float)
- │    │    ├── scan
+ │    │    ├── scan xyz
  │    │    │    └── columns: xyz.x:1(int!null) xyz.y:2(int) xyz.z:3(float)
  │    │    └── eq [type=bool, outer=(1)]
  │    │         ├── variable: xyz.x [type=int, outer=(1)]
@@ -1636,7 +1636,7 @@ group-by
  ├── columns: column3:3(bool) column4:4(bool)
  ├── project
  │    ├── columns: bools.b:1(bool) bools.b:1(bool)
- │    ├── scan
+ │    ├── scan bools
  │    │    └── columns: bools.b:1(bool) bools.rowid:2(int!null)
  │    └── projections [outer=(1)]
  │         ├── variable: bools.b [type=bool, outer=(1)]
@@ -1657,7 +1657,7 @@ project
  ├── group-by
  │    ├── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string)
  │    ├── grouping columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string)
- │    ├── scan
+ │    ├── scan kv
  │    │    └── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string)
  │    └── aggregations
  └── projections
@@ -1683,7 +1683,7 @@ project
  │    ├── columns: column5:5(bytes) column7:7(int)
  │    ├── project
  │    │    ├── columns: xor_bytes.a:1(bytes) xor_bytes.c:3(int)
- │    │    ├── scan
+ │    │    ├── scan xor_bytes
  │    │    │    └── columns: xor_bytes.a:1(bytes) xor_bytes.b:2(int) xor_bytes.c:3(int) xor_bytes.rowid:4(int!null)
  │    │    └── projections [outer=(1,3)]
  │    │         ├── variable: xor_bytes.a [type=bytes, outer=(1)]
@@ -1712,7 +1712,7 @@ project
  │         ├── grouping columns: xor_bytes.b:2(int)
  │         ├── project
  │         │    ├── columns: xor_bytes.b:2(int) xor_bytes.a:1(bytes) xor_bytes.c:3(int)
- │         │    ├── scan
+ │         │    ├── scan xor_bytes
  │         │    │    └── columns: xor_bytes.a:1(bytes) xor_bytes.b:2(int) xor_bytes.c:3(int) xor_bytes.rowid:4(int!null)
  │         │    └── projections [outer=(1-3)]
  │         │         ├── variable: xor_bytes.b [type=int, outer=(2)]
@@ -1771,7 +1771,7 @@ group-by
  │    ├── columns: kv.s:4(string)
  │    ├── project
  │    │    ├── columns: kv.s:4(string) kv.k:1(int!null)
- │    │    ├── scan
+ │    │    ├── scan kv
  │    │    │    └── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string)
  │    │    └── projections [outer=(1,4)]
  │    │         ├── variable: kv.s [type=string, outer=(4)]
@@ -1791,7 +1791,7 @@ group-by
  │    ├── columns: kv.s:4(string)
  │    ├── project
  │    │    ├── columns: kv.s:4(string) kv.k:1(int!null)
- │    │    ├── scan
+ │    │    ├── scan kv
  │    │    │    └── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string)
  │    │    └── projections [outer=(1,4)]
  │    │         ├── variable: kv.s [type=string, outer=(4)]
@@ -1811,7 +1811,7 @@ group-by
  │    ├── columns: kv.s:4(string)
  │    ├── project
  │    │    ├── columns: kv.s:4(string) kv.k:1(int!null)
- │    │    ├── scan
+ │    │    ├── scan kv
  │    │    │    └── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string)
  │    │    └── projections [outer=(1,4)]
  │    │         ├── variable: kv.s [type=string, outer=(4)]
@@ -1857,7 +1857,7 @@ project
  │    ├── grouping columns: ab.a:1(int!null) ab.b:2(int)
  │    ├── project
  │    │    ├── columns: ab.b:2(int) ab.a:1(int!null)
- │    │    ├── scan
+ │    │    ├── scan ab
  │    │    │    └── columns: ab.a:1(int!null) ab.b:2(int)
  │    │    └── projections [outer=(1,2)]
  │    │         ├── variable: ab.b [type=int, outer=(2)]
@@ -1881,9 +1881,9 @@ project
  │    │    ├── columns: xy.x:3(string) ab.a:1(int!null) ab.b:2(int) xy.y:4(string)
  │    │    ├── inner-join
  │    │    │    ├── columns: ab.a:1(int!null) ab.b:2(int) xy.x:3(string) xy.y:4(string) xy.rowid:5(int!null)
- │    │    │    ├── scan
+ │    │    │    ├── scan ab
  │    │    │    │    └── columns: ab.a:1(int!null) ab.b:2(int)
- │    │    │    ├── scan
+ │    │    │    ├── scan xy
  │    │    │    │    └── columns: xy.x:3(string) xy.y:4(string) xy.rowid:5(int!null)
  │    │    │    └── true [type=bool]
  │    │    └── projections [outer=(1-4)]
@@ -1928,7 +1928,7 @@ project
  │    ├── grouping columns: column5:5(int) column6:6(int)
  │    ├── project
  │    │    ├── columns: column5:5(int) column6:6(int)
- │    │    ├── scan
+ │    │    ├── scan kv
  │    │    │    └── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string)
  │    │    └── projections [outer=(1-3)]
  │    │         ├── plus [type=int, outer=(1,2)]
@@ -1958,7 +1958,7 @@ project
  │    ├── grouping columns: kv.v:2(int) column5:5(int)
  │    ├── project
  │    │    ├── columns: kv.v:2(int) column5:5(int) kv.w:3(int)
- │    │    ├── scan
+ │    │    ├── scan kv
  │    │    │    └── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string)
  │    │    └── projections [outer=(1-3)]
  │    │         ├── variable: kv.v [type=int, outer=(2)]
@@ -1983,7 +1983,7 @@ project
  │    ├── grouping columns: kv.v:2(int) column5:5(string) column6:6(int)
  │    ├── project
  │    │    ├── columns: kv.v:2(int) column5:5(string) column6:6(int) kv.w:3(int)
- │    │    ├── scan
+ │    │    ├── scan kv
  │    │    │    └── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string)
  │    │    └── projections [outer=(1-4)]
  │    │         ├── variable: kv.v [type=int, outer=(2)]
@@ -2021,12 +2021,12 @@ project
  │    │    │    ├── columns: bools.b:1(bool) bools.rowid:2(int!null) bools.b:3(bool) bools.rowid:4(int!null) abc.a:5(string!null) abc.b:6(float) abc.c:7(bool) abc.d:8(decimal)
  │    │    │    ├── inner-join
  │    │    │    │    ├── columns: bools.b:1(bool) bools.rowid:2(int!null) bools.b:3(bool) bools.rowid:4(int!null)
- │    │    │    │    ├── scan
+ │    │    │    │    ├── scan bools
  │    │    │    │    │    └── columns: bools.b:1(bool) bools.rowid:2(int!null)
- │    │    │    │    ├── scan
+ │    │    │    │    ├── scan bools
  │    │    │    │    │    └── columns: bools.b:3(bool) bools.rowid:4(int!null)
  │    │    │    │    └── true [type=bool]
- │    │    │    ├── scan
+ │    │    │    ├── scan abc
  │    │    │    │    └── columns: abc.a:5(string!null) abc.b:6(float) abc.c:7(bool) abc.d:8(decimal)
  │    │    │    └── true [type=bool]
  │    │    └── projections [outer=(1,3,7)]
@@ -2061,12 +2061,12 @@ project
  │    │    │    ├── columns: bools.b:1(bool) bools.rowid:2(int!null) bools.b:3(bool) bools.rowid:4(int!null) abc.a:5(string!null) abc.b:6(float) abc.c:7(bool) abc.d:8(decimal)
  │    │    │    ├── inner-join
  │    │    │    │    ├── columns: bools.b:1(bool) bools.rowid:2(int!null) bools.b:3(bool) bools.rowid:4(int!null)
- │    │    │    │    ├── scan
+ │    │    │    │    ├── scan bools
  │    │    │    │    │    └── columns: bools.b:1(bool) bools.rowid:2(int!null)
- │    │    │    │    ├── scan
+ │    │    │    │    ├── scan bools
  │    │    │    │    │    └── columns: bools.b:3(bool) bools.rowid:4(int!null)
  │    │    │    │    └── true [type=bool]
- │    │    │    ├── scan
+ │    │    │    ├── scan abc
  │    │    │    │    └── columns: abc.a:5(string!null) abc.b:6(float) abc.c:7(bool) abc.d:8(decimal)
  │    │    │    └── true [type=bool]
  │    │    └── projections [outer=(1,3,7)]
@@ -2097,7 +2097,7 @@ project
  │    ├── grouping columns: kv.v:2(int) column5:5(int)
  │    ├── project
  │    │    ├── columns: column5:5(int) kv.v:2(int)
- │    │    ├── scan
+ │    │    ├── scan kv
  │    │    │    └── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string)
  │    │    └── projections [outer=(1-3)]
  │    │         ├── mod [type=int, outer=(1,3)]
@@ -2124,9 +2124,9 @@ project
  │    │    ├── columns: column9:9(string) abc.a:5(string!null)
  │    │    ├── inner-join
  │    │    │    ├── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string) abc.a:5(string!null) abc.b:6(float) abc.c:7(bool) abc.d:8(decimal)
- │    │    │    ├── scan
+ │    │    │    ├── scan kv
  │    │    │    │    └── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string)
- │    │    │    ├── scan
+ │    │    │    ├── scan abc
  │    │    │    │    └── columns: abc.a:5(string!null) abc.b:6(float) abc.c:7(bool) abc.d:8(decimal)
  │    │    │    └── true [type=bool]
  │    │    └── projections [outer=(4,5)]
@@ -2157,7 +2157,7 @@ project
  │    ├── grouping columns: kv.v:2(int) column5:5(bool)
  │    ├── project
  │    │    ├── columns: column5:5(bool) kv.v:2(int)
- │    │    ├── scan
+ │    │    ├── scan kv
  │    │    │    └── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string)
  │    │    └── projections [outer=(1-3)]
  │    │         ├── lt [type=bool, outer=(1,3)]
@@ -2201,9 +2201,9 @@ project
  │    │    ├── columns: column7:7(bool) foo.baz:5(jsonb)
  │    │    ├── inner-join
  │    │    │    ├── columns: foo.bar:1(jsonb) foo.baz:2(jsonb) foo.rowid:3(int!null) foo.bar:4(jsonb) foo.baz:5(jsonb) foo.rowid:6(int!null)
- │    │    │    ├── scan
+ │    │    │    ├── scan foo
  │    │    │    │    └── columns: foo.bar:1(jsonb) foo.baz:2(jsonb) foo.rowid:3(int!null)
- │    │    │    ├── scan
+ │    │    │    ├── scan foo
  │    │    │    │    └── columns: foo.bar:4(jsonb) foo.baz:5(jsonb) foo.rowid:6(int!null)
  │    │    │    └── true [type=bool]
  │    │    └── projections [outer=(1,5)]
@@ -2238,9 +2238,9 @@ project
  │    │    ├── columns: column7:7(bool) foo.baz:5(jsonb)
  │    │    ├── inner-join
  │    │    │    ├── columns: foo.bar:1(jsonb) foo.baz:2(jsonb) foo.rowid:3(int!null) foo.bar:4(jsonb) foo.baz:5(jsonb) foo.rowid:6(int!null)
- │    │    │    ├── scan
+ │    │    │    ├── scan foo
  │    │    │    │    └── columns: foo.bar:1(jsonb) foo.baz:2(jsonb) foo.rowid:3(int!null)
- │    │    │    ├── scan
+ │    │    │    ├── scan foo
  │    │    │    │    └── columns: foo.bar:4(jsonb) foo.baz:5(jsonb) foo.rowid:6(int!null)
  │    │    │    └── true [type=bool]
  │    │    └── projections [outer=(1,5)]
@@ -2279,9 +2279,9 @@ project
  │    │    ├── columns: column3:3(interval) column4:4(interval)
  │    │    ├── inner-join
  │    │    │    ├── columns: times.t:1(time!null) times.t:2(time!null)
- │    │    │    ├── scan
+ │    │    │    ├── scan times
  │    │    │    │    └── columns: times.t:1(time!null)
- │    │    │    ├── scan
+ │    │    │    ├── scan times
  │    │    │    │    └── columns: times.t:2(time!null)
  │    │    │    └── true [type=bool]
  │    │    └── projections [outer=(1,2)]
@@ -2315,7 +2315,7 @@ group-by
  ├── grouping columns: column3:3(bool)
  ├── project
  │    ├── columns: column3:3(bool)
- │    ├── scan
+ │    ├── scan bools
  │    │    └── columns: bools.b:1(bool) bools.rowid:2(int!null)
  │    └── projections [outer=(1)]
  │         └── not [type=bool, outer=(1)]
@@ -2337,7 +2337,7 @@ project
  │    ├── grouping columns: bools.b:1(bool)
  │    ├── project
  │    │    ├── columns: bools.b:1(bool)
- │    │    ├── scan
+ │    │    ├── scan bools
  │    │    │    └── columns: bools.b:1(bool) bools.rowid:2(int!null)
  │    │    └── projections [outer=(1)]
  │    │         └── variable: bools.b [type=bool, outer=(1)]
@@ -2356,7 +2356,7 @@ project
  │    ├── grouping columns: column5:5(int) column6:6(int)
  │    ├── project
  │    │    ├── columns: column5:5(int) column6:6(int)
- │    │    ├── scan
+ │    │    ├── scan kv
  │    │    │    └── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string)
  │    │    └── projections [outer=(1,3)]
  │    │         ├── variable: kv.k [type=int, outer=(1)]
@@ -2384,7 +2384,7 @@ project
  │    ├── grouping columns: kv.k:1(int!null) kv.w:3(int)
  │    ├── project
  │    │    ├── columns: kv.k:1(int!null) kv.w:3(int)
- │    │    ├── scan
+ │    │    ├── scan kv
  │    │    │    └── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string)
  │    │    └── projections [outer=(1,3)]
  │    │         ├── variable: kv.k [type=int, outer=(1)]
@@ -2406,7 +2406,7 @@ project
  │    ├── grouping columns: column5:5(int)
  │    ├── project
  │    │    ├── columns: column5:5(int) column6:6(int)
- │    │    ├── scan
+ │    │    ├── scan kv
  │    │    │    └── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string)
  │    │    └── projections [outer=(1,2)]
  │    │         ├── plus [type=int, outer=(1)]
@@ -2433,7 +2433,7 @@ project
  │    ├── grouping columns: kv.k:1(int!null)
  │    ├── project
  │    │    ├── columns: kv.k:1(int!null) kv.k:1(int!null)
- │    │    ├── scan
+ │    │    ├── scan kv
  │    │    │    └── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string)
  │    │    └── projections [outer=(1)]
  │    │         ├── variable: kv.k [type=int, outer=(1)]
@@ -2453,7 +2453,7 @@ project
  │    ├── grouping columns: column5:5(string)
  │    ├── project
  │    │    ├── columns: column5:5(string) column6:6(string)
- │    │    ├── scan
+ │    │    ├── scan kv
  │    │    │    └── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string)
  │    │    └── projections [outer=(4)]
  │    │         ├── function: upper [type=string, outer=(4)]
@@ -2478,9 +2478,9 @@ project
  │    │    ├── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string) abc.d:8(decimal)
  │    │    ├── inner-join
  │    │    │    ├── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string) abc.a:5(string!null) abc.b:6(float) abc.c:7(bool) abc.d:8(decimal)
- │    │    │    ├── scan
+ │    │    │    ├── scan kv
  │    │    │    │    └── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string)
- │    │    │    ├── scan
+ │    │    │    ├── scan abc
  │    │    │    │    └── columns: abc.a:5(string!null) abc.b:6(float) abc.c:7(bool) abc.d:8(decimal)
  │    │    │    └── ge [type=bool, outer=(1,8)]
  │    │    │         ├── variable: kv.k [type=int, outer=(1)]

--- a/pkg/sql/opt/optbuilder/testdata/distinct
+++ b/pkg/sql/opt/optbuilder/testdata/distinct
@@ -31,7 +31,7 @@ SELECT y, z FROM t.xyz
 ----
 project
  ├── columns: y:2(int) z:3(float)
- ├── scan
+ ├── scan xyz
  │    └── columns: xyz.x:1(int!null) xyz.y:2(int) xyz.z:3(float)
  └── projections [outer=(2,3)]
       ├── variable: xyz.y [type=int, outer=(2)]
@@ -45,7 +45,7 @@ group-by
  ├── grouping columns: xyz.y:2(int) xyz.z:3(float)
  ├── project
  │    ├── columns: xyz.y:2(int) xyz.z:3(float)
- │    ├── scan
+ │    ├── scan xyz
  │    │    └── columns: xyz.x:1(int!null) xyz.y:2(int) xyz.z:3(float)
  │    └── projections [outer=(2,3)]
  │         ├── variable: xyz.y [type=int, outer=(2)]
@@ -62,7 +62,7 @@ project
  │    ├── grouping columns: xyz.y:2(int) xyz.z:3(float)
  │    ├── project
  │    │    ├── columns: xyz.y:2(int) xyz.z:3(float)
- │    │    ├── scan
+ │    │    ├── scan xyz
  │    │    │    └── columns: xyz.x:1(int!null) xyz.y:2(int) xyz.z:3(float)
  │    │    └── projections [outer=(2,3)]
  │    │         ├── variable: xyz.y [type=int, outer=(2)]
@@ -80,7 +80,7 @@ sort
  └── group-by
       ├── columns: xyz.y:2(int) xyz.z:3(float)
       ├── grouping columns: xyz.y:2(int) xyz.z:3(float)
-      ├── scan
+      ├── scan xyz
       │    └── columns: xyz.x:1(int!null) xyz.y:2(int) xyz.z:3(float)
       └── aggregations
 
@@ -93,7 +93,7 @@ sort
  └── group-by
       ├── columns: xyz.y:2(int) xyz.z:3(float)
       ├── grouping columns: xyz.y:2(int) xyz.z:3(float)
-      ├── scan
+      ├── scan xyz
       │    └── columns: xyz.x:1(int!null) xyz.y:2(int) xyz.z:3(float)
       └── aggregations
 
@@ -106,7 +106,7 @@ sort
  └── group-by
       ├── columns: xyz.y:2(int) xyz.z:3(float)
       ├── grouping columns: xyz.y:2(int) xyz.z:3(float)
-      ├── scan
+      ├── scan xyz
       │    └── columns: xyz.x:1(int!null) xyz.y:2(int) xyz.z:3(float)
       └── aggregations
 
@@ -148,7 +148,7 @@ group-by
  ├── grouping columns: column4:4(tuple{int, float})
  ├── project
  │    ├── columns: column4:4(tuple{int, float})
- │    ├── scan
+ │    ├── scan xyz
  │    │    └── columns: xyz.x:1(int!null) xyz.y:2(int) xyz.z:3(float)
  │    └── projections [outer=(2,3)]
  │         └── tuple [type=tuple{int, float}, outer=(2,3)]
@@ -167,7 +167,7 @@ group-by
  │    │    ├── grouping columns: xyz.y:2(int)
  │    │    ├── project
  │    │    │    ├── columns: xyz.y:2(int)
- │    │    │    ├── scan
+ │    │    │    ├── scan xyz
  │    │    │    │    └── columns: xyz.x:1(int!null) xyz.y:2(int) xyz.z:3(float)
  │    │    │    └── projections [outer=(2)]
  │    │    │         └── variable: xyz.y [type=int, outer=(2)]
@@ -186,7 +186,7 @@ group-by
  │    ├── columns: xyz.x:1(int!null)
  │    ├── select
  │    │    ├── columns: xyz.x:1(int!null) xyz.y:2(int) xyz.z:3(float)
- │    │    ├── scan
+ │    │    ├── scan xyz
  │    │    │    └── columns: xyz.x:1(int!null) xyz.y:2(int) xyz.z:3(float)
  │    │    └── gt [type=bool, outer=(1)]
  │    │         ├── variable: xyz.x [type=int, outer=(1)]
@@ -205,7 +205,7 @@ group-by
  │    ├── columns: xyz.z:3(float)
  │    ├── select
  │    │    ├── columns: xyz.x:1(int!null) xyz.y:2(int) xyz.z:3(float)
- │    │    ├── scan
+ │    │    ├── scan xyz
  │    │    │    └── columns: xyz.x:1(int!null) xyz.y:2(int) xyz.z:3(float)
  │    │    └── gt [type=bool, outer=(1)]
  │    │         ├── variable: xyz.x [type=int, outer=(1)]
@@ -227,7 +227,7 @@ group-by
  │    │    ├── grouping columns: xyz.x:1(int!null)
  │    │    ├── project
  │    │    │    ├── columns: xyz.x:1(int!null) xyz.x:1(int!null)
- │    │    │    ├── scan
+ │    │    │    ├── scan xyz
  │    │    │    │    └── columns: xyz.x:1(int!null) xyz.y:2(int) xyz.z:3(float)
  │    │    │    └── projections [outer=(1)]
  │    │    │         ├── variable: xyz.x [type=int, outer=(1)]
@@ -247,7 +247,7 @@ group-by
  ├── grouping columns: column4:4(int)
  ├── project
  │    ├── columns: column4:4(int)
- │    ├── scan
+ │    ├── scan xyz
  │    │    └── columns: xyz.x:1(int!null) xyz.y:2(int) xyz.z:3(float)
  │    └── projections [outer=(1,2)]
  │         └── plus [type=int, outer=(1,2)]
@@ -263,7 +263,7 @@ group-by
  ├── grouping columns: column4:4(int)
  ├── project
  │    ├── columns: column4:4(int)
- │    ├── scan
+ │    ├── scan xyz
  │    │    └── columns: xyz.x:1(int!null) xyz.y:2(int) xyz.z:3(float)
  │    └── projections
  │         └── const: 3 [type=int]
@@ -296,7 +296,7 @@ group-by
  │    │    ├── group-by
  │    │    │    ├── columns: xyz.x:1(int!null) xyz.y:2(int) column4:4(float)
  │    │    │    ├── grouping columns: xyz.x:1(int!null) xyz.y:2(int)
- │    │    │    ├── scan
+ │    │    │    ├── scan xyz
  │    │    │    │    └── columns: xyz.x:1(int!null) xyz.y:2(int) xyz.z:3(float)
  │    │    │    └── aggregations [outer=(3)]
  │    │    │         └── function: max [type=float, outer=(3)]
@@ -346,6 +346,6 @@ sort
  └── group-by
       ├── columns: abcd.b:2(int!null) abcd.d:4(int!null) column5:5(int)
       ├── grouping columns: abcd.b:2(int!null) abcd.d:4(int!null) column5:5(int)
-      ├── scan
+      ├── scan abcd
       │    └── columns: abcd.a:1(int!null) abcd.b:2(int!null) abcd.c:3(int!null) abcd.d:4(int!null)
       └── aggregations

--- a/pkg/sql/opt/optbuilder/testdata/having
+++ b/pkg/sql/opt/optbuilder/testdata/having
@@ -25,7 +25,7 @@ project
  ├── select
  │    ├── group-by
  │    │    ├── project
- │    │    │    ├── scan
+ │    │    │    ├── scan kv
  │    │    │    │    └── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string)
  │    │    │    └── projections
  │    │    └── aggregations
@@ -43,7 +43,7 @@ select
  │    ├── grouping columns: kv.s:4(string)
  │    ├── project
  │    │    ├── columns: kv.s:4(string)
- │    │    ├── scan
+ │    │    ├── scan kv
  │    │    │    └── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string)
  │    │    └── projections [outer=(4)]
  │    │         └── variable: kv.s [type=string, outer=(4)]
@@ -64,7 +64,7 @@ project
  │    │    ├── columns: column5:5(int) column6:6(int)
  │    │    ├── project
  │    │    │    ├── columns: kv.v:2(int) kv.k:1(int!null)
- │    │    │    ├── scan
+ │    │    │    ├── scan kv
  │    │    │    │    └── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string)
  │    │    │    └── projections [outer=(1,2)]
  │    │    │         ├── variable: kv.v [type=int, outer=(2)]
@@ -92,7 +92,7 @@ project
  │    │    ├── columns: column5:5(int) column6:6(int) column7:7(int)
  │    │    ├── project
  │    │    │    ├── columns: kv.v:2(int) kv.k:1(int!null) kv.v:2(int)
- │    │    │    ├── scan
+ │    │    │    ├── scan kv
  │    │    │    │    └── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string)
  │    │    │    └── projections [outer=(1,2)]
  │    │    │         ├── variable: kv.v [type=int, outer=(2)]
@@ -152,7 +152,7 @@ project
  │    │    ├── grouping columns: column5:5(int)
  │    │    ├── project
  │    │    │    ├── columns: column5:5(int)
- │    │    │    ├── scan
+ │    │    │    ├── scan kv
  │    │    │    │    └── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string)
  │    │    │    └── projections [outer=(1,3)]
  │    │    │         └── plus [type=int, outer=(1,3)]
@@ -187,7 +187,7 @@ project
  │    │    ├── grouping columns: kv.v:2(int)
  │    │    ├── project
  │    │    │    ├── columns: kv.v:2(int) kv.v:2(int)
- │    │    │    ├── scan
+ │    │    │    ├── scan kv
  │    │    │    │    └── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string)
  │    │    │    └── projections [outer=(2)]
  │    │    │         ├── variable: kv.v [type=int, outer=(2)]
@@ -213,7 +213,7 @@ project
  │    │    ├── grouping columns: column5:5(string)
  │    │    ├── project
  │    │    │    ├── columns: column5:5(string) kv.w:3(int)
- │    │    │    ├── scan
+ │    │    │    ├── scan kv
  │    │    │    │    └── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string)
  │    │    │    └── projections [outer=(3,4)]
  │    │    │         ├── function: lower [type=string, outer=(4)]
@@ -241,7 +241,7 @@ project
  │    │    ├── grouping columns: column5:5(string)
  │    │    ├── project
  │    │    │    ├── columns: column5:5(string) kv.w:3(int)
- │    │    │    ├── scan
+ │    │    │    ├── scan kv
  │    │    │    │    └── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string)
  │    │    │    └── projections [outer=(3,4)]
  │    │    │         ├── function: lower [type=string, outer=(4)]
@@ -271,7 +271,7 @@ project
  │    │    ├── grouping columns: kv.v:2(int) column5:5(int)
  │    │    ├── project
  │    │    │    ├── columns: kv.v:2(int) column5:5(int)
- │    │    │    ├── scan
+ │    │    │    ├── scan kv
  │    │    │    │    └── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string)
  │    │    │    └── projections [outer=(1-3)]
  │    │    │         ├── variable: kv.v [type=int, outer=(2)]
@@ -302,7 +302,7 @@ select
  │    ├── grouping columns: column5:5(string)
  │    ├── project
  │    │    ├── columns: column5:5(string) kv.s:4(string) column7:7(string)
- │    │    ├── scan
+ │    │    ├── scan kv
  │    │    │    └── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string)
  │    │    └── projections [outer=(4)]
  │    │         ├── function: upper [type=string, outer=(4)]

--- a/pkg/sql/opt/optbuilder/testdata/inner-join
+++ b/pkg/sql/opt/optbuilder/testdata/inner-join
@@ -35,9 +35,9 @@ project
  ├── columns: x:1(int!null) y:2(float) x:3(int) y:4(float)
  ├── inner-join
  │    ├── columns: a.x:1(int!null) a.y:2(float) b.x:3(int) b.y:4(float) b.rowid:5(int!null)
- │    ├── scan
+ │    ├── scan a
  │    │    └── columns: a.x:1(int!null) a.y:2(float)
- │    ├── scan
+ │    ├── scan b
  │    │    └── columns: b.x:3(int) b.y:4(float) b.rowid:5(int!null)
  │    └── true [type=bool]
  └── projections [outer=(1-4)]
@@ -55,9 +55,9 @@ project
  │    ├── columns: a.x:1(int!null) a.y:2(float) b.x:3(int) b.y:4(float) b.rowid:5(int!null)
  │    ├── inner-join
  │    │    ├── columns: a.x:1(int!null) a.y:2(float) b.x:3(int) b.y:4(float) b.rowid:5(int!null)
- │    │    ├── scan
+ │    │    ├── scan a
  │    │    │    └── columns: a.x:1(int!null) a.y:2(float)
- │    │    ├── scan
+ │    │    ├── scan b
  │    │    │    └── columns: b.x:3(int) b.y:4(float) b.rowid:5(int!null)
  │    │    └── true [type=bool]
  │    └── eq [type=bool, outer=(1,3)]
@@ -78,12 +78,12 @@ project
  │    │    ├── columns: c.x:1(int) c.y:2(float) c.z:3(string) c.rowid:4(int!null) b.x:5(int) b.y:6(float) b.rowid:7(int!null) a.x:8(int!null) a.y:9(float)
  │    │    ├── inner-join
  │    │    │    ├── columns: c.x:1(int) c.y:2(float) c.z:3(string) c.rowid:4(int!null) b.x:5(int) b.y:6(float) b.rowid:7(int!null)
- │    │    │    ├── scan
+ │    │    │    ├── scan c
  │    │    │    │    └── columns: c.x:1(int) c.y:2(float) c.z:3(string) c.rowid:4(int!null)
- │    │    │    ├── scan
+ │    │    │    ├── scan b
  │    │    │    │    └── columns: b.x:5(int) b.y:6(float) b.rowid:7(int!null)
  │    │    │    └── true [type=bool]
- │    │    ├── scan
+ │    │    ├── scan a
  │    │    │    └── columns: a.x:8(int!null) a.y:9(float)
  │    │    └── true [type=bool]
  │    └── and [type=bool, outer=(1,5,8)]

--- a/pkg/sql/opt/optbuilder/testdata/join
+++ b/pkg/sql/opt/optbuilder/testdata/join
@@ -22,9 +22,9 @@ project
  ├── columns: x:1(int) y:3(int)
  ├── inner-join
  │    ├── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null) onecolumn.x:3(int) onecolumn.rowid:4(int!null)
- │    ├── scan
+ │    ├── scan onecolumn
  │    │    └── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null)
- │    ├── scan
+ │    ├── scan onecolumn
  │    │    └── columns: onecolumn.x:3(int) onecolumn.rowid:4(int!null)
  │    └── true [type=bool]
  └── projections [outer=(1,3)]
@@ -56,10 +56,10 @@ project
  │    │    │    │    └── tuple [type=tuple{}]
  │    │    │    └── projections
  │    │    │         └── const: 1 [type=int]
- │    │    ├── scan
+ │    │    ├── scan onecolumn
  │    │    │    └── columns: onecolumn.x:2(int) onecolumn.rowid:3(int!null)
  │    │    └── true [type=bool]
- │    ├── scan
+ │    ├── scan onecolumn
  │    │    └── columns: onecolumn.x:4(int) onecolumn.rowid:5(int!null)
  │    └── true [type=bool]
  └── projections [outer=(1)]
@@ -72,9 +72,9 @@ project
  ├── columns: x:1(int) y:3(int)
  ├── inner-join
  │    ├── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null) onecolumn.x:3(int) onecolumn.rowid:4(int!null)
- │    ├── scan
+ │    ├── scan onecolumn
  │    │    └── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null)
- │    ├── scan
+ │    ├── scan onecolumn
  │    │    └── columns: onecolumn.x:3(int) onecolumn.rowid:4(int!null)
  │    └── eq [type=bool, outer=(1,3)]
  │         ├── variable: onecolumn.x [type=int, outer=(1)]
@@ -94,9 +94,9 @@ project
  │    ├── ordering: +1
  │    └── inner-join
  │         ├── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null) onecolumn.x:3(int) onecolumn.rowid:4(int!null)
- │         ├── scan
+ │         ├── scan onecolumn
  │         │    └── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null)
- │         ├── scan
+ │         ├── scan onecolumn
  │         │    └── columns: onecolumn.x:3(int) onecolumn.rowid:4(int!null)
  │         └── eq [type=bool, outer=(1,3)]
  │              ├── variable: onecolumn.x [type=int, outer=(1)]
@@ -111,9 +111,9 @@ project
  ├── columns: x:1(int)
  ├── inner-join
  │    ├── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null) onecolumn.x:3(int) onecolumn.rowid:4(int!null)
- │    ├── scan
+ │    ├── scan onecolumn
  │    │    └── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null)
- │    ├── scan
+ │    ├── scan onecolumn
  │    │    └── columns: onecolumn.x:3(int) onecolumn.rowid:4(int!null)
  │    └── eq [type=bool, outer=(1,3)]
  │         ├── variable: onecolumn.x [type=int, outer=(1)]
@@ -128,9 +128,9 @@ project
  ├── columns: x:1(int) y:3(int)
  ├── left-join
  │    ├── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null) onecolumn.x:3(int) onecolumn.rowid:4(int)
- │    ├── scan
+ │    ├── scan onecolumn
  │    │    └── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null)
- │    ├── scan
+ │    ├── scan onecolumn
  │    │    └── columns: onecolumn.x:3(int) onecolumn.rowid:4(int!null)
  │    └── eq [type=bool, outer=(1,3)]
  │         ├── variable: onecolumn.x [type=int, outer=(1)]
@@ -150,9 +150,9 @@ project
  │    ├── ordering: +1
  │    └── left-join
  │         ├── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null) onecolumn.x:3(int) onecolumn.rowid:4(int)
- │         ├── scan
+ │         ├── scan onecolumn
  │         │    └── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null)
- │         ├── scan
+ │         ├── scan onecolumn
  │         │    └── columns: onecolumn.x:3(int) onecolumn.rowid:4(int!null)
  │         └── eq [type=bool, outer=(1,3)]
  │              ├── variable: onecolumn.x [type=int, outer=(1)]
@@ -174,9 +174,9 @@ project
  │    ├── ordering: +1
  │    └── inner-join
  │         ├── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null) onecolumn.x:3(int) onecolumn.rowid:4(int!null)
- │         ├── scan
+ │         ├── scan onecolumn
  │         │    └── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null)
- │         ├── scan
+ │         ├── scan onecolumn
  │         │    └── columns: onecolumn.x:3(int) onecolumn.rowid:4(int!null)
  │         └── true [type=bool]
  └── projections [outer=(1,3)]
@@ -190,9 +190,9 @@ project
  ├── columns: x:1(int)
  ├── left-join
  │    ├── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null) onecolumn.x:3(int) onecolumn.rowid:4(int)
- │    ├── scan
+ │    ├── scan onecolumn
  │    │    └── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null)
- │    ├── scan
+ │    ├── scan onecolumn
  │    │    └── columns: onecolumn.x:3(int) onecolumn.rowid:4(int!null)
  │    └── eq [type=bool, outer=(1,3)]
  │         ├── variable: onecolumn.x [type=int, outer=(1)]
@@ -207,9 +207,9 @@ project
  ├── columns: x:1(int) y:3(int)
  ├── right-join
  │    ├── columns: onecolumn.x:1(int) onecolumn.rowid:2(int) onecolumn.x:3(int) onecolumn.rowid:4(int!null)
- │    ├── scan
+ │    ├── scan onecolumn
  │    │    └── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null)
- │    ├── scan
+ │    ├── scan onecolumn
  │    │    └── columns: onecolumn.x:3(int) onecolumn.rowid:4(int!null)
  │    └── eq [type=bool, outer=(1,3)]
  │         ├── variable: onecolumn.x [type=int, outer=(1)]
@@ -229,9 +229,9 @@ project
  │    ├── ordering: +3
  │    └── right-join
  │         ├── columns: onecolumn.x:1(int) onecolumn.rowid:2(int) onecolumn.x:3(int) onecolumn.rowid:4(int!null)
- │         ├── scan
+ │         ├── scan onecolumn
  │         │    └── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null)
- │         ├── scan
+ │         ├── scan onecolumn
  │         │    └── columns: onecolumn.x:3(int) onecolumn.rowid:4(int!null)
  │         └── eq [type=bool, outer=(1,3)]
  │              ├── variable: onecolumn.x [type=int, outer=(1)]
@@ -246,9 +246,9 @@ project
  ├── columns: x:3(int)
  ├── right-join
  │    ├── columns: onecolumn.x:1(int) onecolumn.rowid:2(int) onecolumn.x:3(int) onecolumn.rowid:4(int!null)
- │    ├── scan
+ │    ├── scan onecolumn
  │    │    └── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null)
- │    ├── scan
+ │    ├── scan onecolumn
  │    │    └── columns: onecolumn.x:3(int) onecolumn.rowid:4(int!null)
  │    └── eq [type=bool, outer=(1,3)]
  │         ├── variable: onecolumn.x [type=int, outer=(1)]
@@ -272,9 +272,9 @@ project
  ├── columns: x:1(int) w:3(int)
  ├── inner-join
  │    ├── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null) onecolumn_w.w:3(int) onecolumn_w.rowid:4(int!null)
- │    ├── scan
+ │    ├── scan onecolumn
  │    │    └── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null)
- │    ├── scan
+ │    ├── scan onecolumn_w
  │    │    └── columns: onecolumn_w.w:3(int) onecolumn_w.rowid:4(int!null)
  │    └── true [type=bool]
  └── projections [outer=(1,3)]
@@ -301,9 +301,9 @@ project
  │    ├── ordering: +1,+3
  │    └── full-join
  │         ├── columns: onecolumn.x:1(int) onecolumn.rowid:2(int) othercolumn.x:3(int) othercolumn.rowid:4(int)
- │         ├── scan
+ │         ├── scan onecolumn
  │         │    └── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null)
- │         ├── scan
+ │         ├── scan othercolumn
  │         │    └── columns: othercolumn.x:3(int) othercolumn.rowid:4(int!null)
  │         └── eq [type=bool, outer=(1,3)]
  │              ├── variable: onecolumn.x [type=int, outer=(1)]
@@ -325,9 +325,9 @@ project
  │         ├── columns: x:5(int) onecolumn.x:1(int) onecolumn.rowid:2(int) othercolumn.x:3(int) othercolumn.rowid:4(int)
  │         ├── full-join
  │         │    ├── columns: onecolumn.x:1(int) onecolumn.rowid:2(int) othercolumn.x:3(int) othercolumn.rowid:4(int)
- │         │    ├── scan
+ │         │    ├── scan onecolumn
  │         │    │    └── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null)
- │         │    ├── scan
+ │         │    ├── scan othercolumn
  │         │    │    └── columns: othercolumn.x:3(int) othercolumn.rowid:4(int!null)
  │         │    └── eq [type=bool, outer=(1,3)]
  │         │         ├── variable: onecolumn.x [type=int, outer=(1)]
@@ -358,9 +358,9 @@ project
  │         ├── columns: x:5(int) onecolumn.x:1(int) onecolumn.rowid:2(int) othercolumn.x:3(int) othercolumn.rowid:4(int)
  │         ├── full-join
  │         │    ├── columns: onecolumn.x:1(int) onecolumn.rowid:2(int) othercolumn.x:3(int) othercolumn.rowid:4(int)
- │         │    ├── scan
+ │         │    ├── scan onecolumn
  │         │    │    └── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null)
- │         │    ├── scan
+ │         │    ├── scan othercolumn
  │         │    │    └── columns: othercolumn.x:3(int) othercolumn.rowid:4(int!null)
  │         │    └── eq [type=bool, outer=(1,3)]
  │         │         ├── variable: onecolumn.x [type=int, outer=(1)]
@@ -391,9 +391,9 @@ project
  │         ├── columns: x:5(int) onecolumn.x:1(int) onecolumn.rowid:2(int) othercolumn.x:3(int) othercolumn.rowid:4(int)
  │         ├── full-join
  │         │    ├── columns: onecolumn.x:1(int) onecolumn.rowid:2(int) othercolumn.x:3(int) othercolumn.rowid:4(int)
- │         │    ├── scan
+ │         │    ├── scan onecolumn
  │         │    │    └── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null)
- │         │    ├── scan
+ │         │    ├── scan othercolumn
  │         │    │    └── columns: othercolumn.x:3(int) othercolumn.rowid:4(int!null)
  │         │    └── eq [type=bool, outer=(1,3)]
  │         │         ├── variable: onecolumn.x [type=int, outer=(1)]
@@ -432,9 +432,9 @@ project
  ├── columns: x:1(int) y:3(int)
  ├── inner-join
  │    ├── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null) empty.x:3(int) empty.rowid:4(int!null)
- │    ├── scan
+ │    ├── scan onecolumn
  │    │    └── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null)
- │    ├── scan
+ │    ├── scan empty
  │    │    └── columns: empty.x:3(int) empty.rowid:4(int!null)
  │    └── true [type=bool]
  └── projections [outer=(1,3)]
@@ -448,9 +448,9 @@ project
  ├── columns: x:1(int) x:3(int)
  ├── inner-join
  │    ├── columns: empty.x:1(int) empty.rowid:2(int!null) onecolumn.x:3(int) onecolumn.rowid:4(int!null)
- │    ├── scan
+ │    ├── scan empty
  │    │    └── columns: empty.x:1(int) empty.rowid:2(int!null)
- │    ├── scan
+ │    ├── scan onecolumn
  │    │    └── columns: onecolumn.x:3(int) onecolumn.rowid:4(int!null)
  │    └── true [type=bool]
  └── projections [outer=(1,3)]
@@ -464,9 +464,9 @@ project
  ├── columns: x:1(int) y:3(int)
  ├── inner-join
  │    ├── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null) empty.x:3(int) empty.rowid:4(int!null)
- │    ├── scan
+ │    ├── scan onecolumn
  │    │    └── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null)
- │    ├── scan
+ │    ├── scan empty
  │    │    └── columns: empty.x:3(int) empty.rowid:4(int!null)
  │    └── eq [type=bool, outer=(1,3)]
  │         ├── variable: onecolumn.x [type=int, outer=(1)]
@@ -482,9 +482,9 @@ project
  ├── columns: x:1(int)
  ├── inner-join
  │    ├── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null) empty.x:3(int) empty.rowid:4(int!null)
- │    ├── scan
+ │    ├── scan onecolumn
  │    │    └── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null)
- │    ├── scan
+ │    ├── scan empty
  │    │    └── columns: empty.x:3(int) empty.rowid:4(int!null)
  │    └── eq [type=bool, outer=(1,3)]
  │         ├── variable: onecolumn.x [type=int, outer=(1)]
@@ -499,9 +499,9 @@ project
  ├── columns: x:1(int) y:3(int)
  ├── inner-join
  │    ├── columns: empty.x:1(int) empty.rowid:2(int!null) onecolumn.x:3(int) onecolumn.rowid:4(int!null)
- │    ├── scan
+ │    ├── scan empty
  │    │    └── columns: empty.x:1(int) empty.rowid:2(int!null)
- │    ├── scan
+ │    ├── scan onecolumn
  │    │    └── columns: onecolumn.x:3(int) onecolumn.rowid:4(int!null)
  │    └── eq [type=bool, outer=(1,3)]
  │         ├── variable: empty.x [type=int, outer=(1)]
@@ -517,9 +517,9 @@ project
  ├── columns: x:1(int)
  ├── inner-join
  │    ├── columns: empty.x:1(int) empty.rowid:2(int!null) onecolumn.x:3(int) onecolumn.rowid:4(int!null)
- │    ├── scan
+ │    ├── scan empty
  │    │    └── columns: empty.x:1(int) empty.rowid:2(int!null)
- │    ├── scan
+ │    ├── scan onecolumn
  │    │    └── columns: onecolumn.x:3(int) onecolumn.rowid:4(int!null)
  │    └── eq [type=bool, outer=(1,3)]
  │         ├── variable: empty.x [type=int, outer=(1)]
@@ -538,9 +538,9 @@ project
  │    ├── ordering: +1
  │    └── left-join
  │         ├── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null) empty.x:3(int) empty.rowid:4(int)
- │         ├── scan
+ │         ├── scan onecolumn
  │         │    └── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null)
- │         ├── scan
+ │         ├── scan empty
  │         │    └── columns: empty.x:3(int) empty.rowid:4(int!null)
  │         └── eq [type=bool, outer=(1,3)]
  │              ├── variable: onecolumn.x [type=int, outer=(1)]
@@ -560,9 +560,9 @@ project
  │    ├── ordering: +1
  │    └── left-join
  │         ├── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null) empty.x:3(int) empty.rowid:4(int)
- │         ├── scan
+ │         ├── scan onecolumn
  │         │    └── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null)
- │         ├── scan
+ │         ├── scan empty
  │         │    └── columns: empty.x:3(int) empty.rowid:4(int!null)
  │         └── eq [type=bool, outer=(1,3)]
  │              ├── variable: onecolumn.x [type=int, outer=(1)]
@@ -577,9 +577,9 @@ project
  ├── columns: x:1(int) y:3(int)
  ├── left-join
  │    ├── columns: empty.x:1(int) empty.rowid:2(int!null) onecolumn.x:3(int) onecolumn.rowid:4(int)
- │    ├── scan
+ │    ├── scan empty
  │    │    └── columns: empty.x:1(int) empty.rowid:2(int!null)
- │    ├── scan
+ │    ├── scan onecolumn
  │    │    └── columns: onecolumn.x:3(int) onecolumn.rowid:4(int!null)
  │    └── eq [type=bool, outer=(1,3)]
  │         ├── variable: empty.x [type=int, outer=(1)]
@@ -595,9 +595,9 @@ project
  ├── columns: x:1(int)
  ├── left-join
  │    ├── columns: empty.x:1(int) empty.rowid:2(int!null) onecolumn.x:3(int) onecolumn.rowid:4(int)
- │    ├── scan
+ │    ├── scan empty
  │    │    └── columns: empty.x:1(int) empty.rowid:2(int!null)
- │    ├── scan
+ │    ├── scan onecolumn
  │    │    └── columns: onecolumn.x:3(int) onecolumn.rowid:4(int!null)
  │    └── eq [type=bool, outer=(1,3)]
  │         ├── variable: empty.x [type=int, outer=(1)]
@@ -612,9 +612,9 @@ project
  ├── columns: x:1(int) y:3(int)
  ├── right-join
  │    ├── columns: onecolumn.x:1(int) onecolumn.rowid:2(int) empty.x:3(int) empty.rowid:4(int!null)
- │    ├── scan
+ │    ├── scan onecolumn
  │    │    └── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null)
- │    ├── scan
+ │    ├── scan empty
  │    │    └── columns: empty.x:3(int) empty.rowid:4(int!null)
  │    └── eq [type=bool, outer=(1,3)]
  │         ├── variable: onecolumn.x [type=int, outer=(1)]
@@ -630,9 +630,9 @@ project
  ├── columns: x:3(int)
  ├── right-join
  │    ├── columns: onecolumn.x:1(int) onecolumn.rowid:2(int) empty.x:3(int) empty.rowid:4(int!null)
- │    ├── scan
+ │    ├── scan onecolumn
  │    │    └── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null)
- │    ├── scan
+ │    ├── scan empty
  │    │    └── columns: empty.x:3(int) empty.rowid:4(int!null)
  │    └── eq [type=bool, outer=(1,3)]
  │         ├── variable: onecolumn.x [type=int, outer=(1)]
@@ -651,9 +651,9 @@ project
  │    ├── ordering: +3
  │    └── full-join
  │         ├── columns: empty.x:1(int) empty.rowid:2(int) onecolumn.x:3(int) onecolumn.rowid:4(int)
- │         ├── scan
+ │         ├── scan empty
  │         │    └── columns: empty.x:1(int) empty.rowid:2(int!null)
- │         ├── scan
+ │         ├── scan onecolumn
  │         │    └── columns: onecolumn.x:3(int) onecolumn.rowid:4(int!null)
  │         └── eq [type=bool, outer=(1,3)]
  │              ├── variable: empty.x [type=int, outer=(1)]
@@ -675,9 +675,9 @@ project
  │         ├── columns: x:5(int) empty.x:1(int) empty.rowid:2(int) onecolumn.x:3(int) onecolumn.rowid:4(int)
  │         ├── full-join
  │         │    ├── columns: empty.x:1(int) empty.rowid:2(int) onecolumn.x:3(int) onecolumn.rowid:4(int)
- │         │    ├── scan
+ │         │    ├── scan empty
  │         │    │    └── columns: empty.x:1(int) empty.rowid:2(int!null)
- │         │    ├── scan
+ │         │    ├── scan onecolumn
  │         │    │    └── columns: onecolumn.x:3(int) onecolumn.rowid:4(int!null)
  │         │    └── eq [type=bool, outer=(1,3)]
  │         │         ├── variable: empty.x [type=int, outer=(1)]
@@ -704,9 +704,9 @@ project
  │    ├── ordering: +1
  │    └── full-join
  │         ├── columns: onecolumn.x:1(int) onecolumn.rowid:2(int) empty.x:3(int) empty.rowid:4(int)
- │         ├── scan
+ │         ├── scan onecolumn
  │         │    └── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null)
- │         ├── scan
+ │         ├── scan empty
  │         │    └── columns: empty.x:3(int) empty.rowid:4(int!null)
  │         └── eq [type=bool, outer=(1,3)]
  │              ├── variable: onecolumn.x [type=int, outer=(1)]
@@ -728,9 +728,9 @@ project
  │         ├── columns: x:5(int) onecolumn.x:1(int) onecolumn.rowid:2(int) empty.x:3(int) empty.rowid:4(int)
  │         ├── full-join
  │         │    ├── columns: onecolumn.x:1(int) onecolumn.rowid:2(int) empty.x:3(int) empty.rowid:4(int)
- │         │    ├── scan
+ │         │    ├── scan onecolumn
  │         │    │    └── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null)
- │         │    ├── scan
+ │         │    ├── scan empty
  │         │    │    └── columns: empty.x:3(int) empty.rowid:4(int!null)
  │         │    └── eq [type=bool, outer=(1,3)]
  │         │         ├── variable: onecolumn.x [type=int, outer=(1)]
@@ -764,9 +764,9 @@ project
  ├── columns: x:1(int) y:4(int)
  ├── inner-join
  │    ├── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null) twocolumn.x:3(int) twocolumn.y:4(int) twocolumn.rowid:5(int!null)
- │    ├── scan
+ │    ├── scan onecolumn
  │    │    └── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null)
- │    ├── scan
+ │    ├── scan twocolumn
  │    │    └── columns: twocolumn.x:3(int) twocolumn.y:4(int) twocolumn.rowid:5(int!null)
  │    └── eq [type=bool, outer=(1,3)]
  │         ├── variable: onecolumn.x [type=int, outer=(1)]
@@ -782,9 +782,9 @@ project
  ├── columns: x:1(int) y:4(int)
  ├── inner-join
  │    ├── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null) twocolumn.x:3(int) twocolumn.y:4(int) twocolumn.rowid:5(int!null)
- │    ├── scan
+ │    ├── scan onecolumn
  │    │    └── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null)
- │    ├── scan
+ │    ├── scan twocolumn
  │    │    └── columns: twocolumn.x:3(int) twocolumn.y:4(int) twocolumn.rowid:5(int!null)
  │    └── eq [type=bool, outer=(1,3)]
  │         ├── variable: onecolumn.x [type=int, outer=(1)]
@@ -800,9 +800,9 @@ project
  ├── columns: x:1(int) y:2(int) x:4(int) y:5(int)
  ├── inner-join
  │    ├── columns: twocolumn.x:1(int) twocolumn.y:2(int) twocolumn.rowid:3(int!null) twocolumn.x:4(int) twocolumn.y:5(int) twocolumn.rowid:6(int!null)
- │    ├── scan
+ │    ├── scan twocolumn
  │    │    └── columns: twocolumn.x:1(int) twocolumn.y:2(int) twocolumn.rowid:3(int!null)
- │    ├── scan
+ │    ├── scan twocolumn
  │    │    └── columns: twocolumn.x:4(int) twocolumn.y:5(int) twocolumn.rowid:6(int!null)
  │    └── eq [type=bool, outer=(1,5)]
  │         ├── variable: twocolumn.x [type=int, outer=(1)]
@@ -820,9 +820,9 @@ project
  ├── columns: x:1(int) y:2(int) x:4(int) y:5(int)
  ├── inner-join
  │    ├── columns: twocolumn.x:1(int) twocolumn.y:2(int) twocolumn.rowid:3(int!null) twocolumn.x:4(int) twocolumn.y:5(int) twocolumn.rowid:6(int!null)
- │    ├── scan
+ │    ├── scan twocolumn
  │    │    └── columns: twocolumn.x:1(int) twocolumn.y:2(int) twocolumn.rowid:3(int!null)
- │    ├── scan
+ │    ├── scan twocolumn
  │    │    └── columns: twocolumn.x:4(int) twocolumn.y:5(int) twocolumn.rowid:6(int!null)
  │    └── eq [type=bool, outer=(1,2)]
  │         ├── variable: twocolumn.x [type=int, outer=(1)]
@@ -840,9 +840,9 @@ project
  ├── columns: x:1(int) x:3(int) y:4(int)
  ├── inner-join
  │    ├── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null) twocolumn.x:3(int) twocolumn.y:4(int) twocolumn.rowid:5(int!null)
- │    ├── scan
+ │    ├── scan onecolumn
  │    │    └── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null)
- │    ├── scan
+ │    ├── scan twocolumn
  │    │    └── columns: twocolumn.x:3(int) twocolumn.y:4(int) twocolumn.rowid:5(int!null)
  │    └── eq [type=bool, outer=(1,4)]
  │         ├── variable: onecolumn.x [type=int, outer=(1)]
@@ -859,9 +859,9 @@ project
  ├── columns: x:1(int) x:3(int) y:4(int)
  ├── inner-join
  │    ├── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null) twocolumn.x:3(int) twocolumn.y:4(int) twocolumn.rowid:5(int!null)
- │    ├── scan
+ │    ├── scan onecolumn
  │    │    └── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null)
- │    ├── scan
+ │    ├── scan twocolumn
  │    │    └── columns: twocolumn.x:3(int) twocolumn.y:4(int) twocolumn.rowid:5(int!null)
  │    └── eq [type=bool, outer=(1,4)]
  │         ├── variable: onecolumn.x [type=int, outer=(1)]
@@ -879,9 +879,9 @@ project
  ├── columns: x:1(int) y:2(int) x:4(int) y:5(int)
  ├── inner-join
  │    ├── columns: twocolumn.x:1(int) twocolumn.y:2(int) twocolumn.rowid:3(int!null) twocolumn.x:4(int) twocolumn.y:5(int) twocolumn.rowid:6(int!null)
- │    ├── scan
+ │    ├── scan twocolumn
  │    │    └── columns: twocolumn.x:1(int) twocolumn.y:2(int) twocolumn.rowid:3(int!null)
- │    ├── scan
+ │    ├── scan twocolumn
  │    │    └── columns: twocolumn.x:4(int) twocolumn.y:5(int) twocolumn.rowid:6(int!null)
  │    └── eq [type=bool, outer=(1)]
  │         ├── variable: twocolumn.x [type=int, outer=(1)]
@@ -899,9 +899,9 @@ project
  ├── columns: x:1(int) y:4(int)
  ├── inner-join
  │    ├── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null) twocolumn.x:3(int) twocolumn.y:4(int) twocolumn.rowid:5(int!null)
- │    ├── scan
+ │    ├── scan onecolumn
  │    │    └── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null)
- │    ├── scan
+ │    ├── scan twocolumn
  │    │    └── columns: twocolumn.x:3(int) twocolumn.y:4(int) twocolumn.rowid:5(int!null)
  │    └── and [type=bool, outer=(1,3,4)]
  │         ├── eq [type=bool, outer=(1,3)]
@@ -922,9 +922,9 @@ project
  ├── columns: x:1(int) y:4(int)
  ├── left-join
  │    ├── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null) twocolumn.x:3(int) twocolumn.y:4(int) twocolumn.rowid:5(int)
- │    ├── scan
+ │    ├── scan onecolumn
  │    │    └── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null)
- │    ├── scan
+ │    ├── scan twocolumn
  │    │    └── columns: twocolumn.x:3(int) twocolumn.y:4(int) twocolumn.rowid:5(int!null)
  │    └── and [type=bool, outer=(1,3,4)]
  │         ├── eq [type=bool, outer=(1,3)]
@@ -944,9 +944,9 @@ project
  ├── columns: x:1(int) y:4(int)
  ├── left-join
  │    ├── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null) twocolumn.x:3(int) twocolumn.y:4(int) twocolumn.rowid:5(int)
- │    ├── scan
+ │    ├── scan onecolumn
  │    │    └── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null)
- │    ├── scan
+ │    ├── scan twocolumn
  │    │    └── columns: twocolumn.x:3(int) twocolumn.y:4(int) twocolumn.rowid:5(int!null)
  │    └── and [type=bool, outer=(1,3)]
  │         ├── eq [type=bool, outer=(1,3)]
@@ -966,9 +966,9 @@ project
  ├── columns: x:1(int) y:4(int)
  ├── left-join
  │    ├── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null) twocolumn.x:3(int) twocolumn.y:4(int) twocolumn.rowid:5(int)
- │    ├── scan
+ │    ├── scan onecolumn
  │    │    └── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null)
- │    ├── scan
+ │    ├── scan twocolumn
  │    │    └── columns: twocolumn.x:3(int) twocolumn.y:4(int) twocolumn.rowid:5(int!null)
  │    └── and [type=bool, outer=(1,3)]
  │         ├── eq [type=bool, outer=(1,3)]
@@ -1020,9 +1020,9 @@ project
  ├── columns: i:1(int) i:3(int) b:4(bool)
  ├── inner-join
  │    ├── columns: a.i:1(int) a.rowid:2(int!null) b.i:3(int) b.b:4(bool) b.rowid:5(int!null)
- │    ├── scan
+ │    ├── scan a
  │    │    └── columns: a.i:1(int) a.rowid:2(int!null)
- │    ├── scan
+ │    ├── scan b
  │    │    └── columns: b.i:3(int) b.b:4(bool) b.rowid:5(int!null)
  │    └── eq [type=bool, outer=(1,3)]
  │         ├── variable: a.i [type=int, outer=(1)]
@@ -1039,9 +1039,9 @@ project
  ├── columns: i:1(int) i:3(int) b:4(bool)
  ├── left-join
  │    ├── columns: a.i:1(int) a.rowid:2(int!null) b.i:3(int) b.b:4(bool) b.rowid:5(int)
- │    ├── scan
+ │    ├── scan a
  │    │    └── columns: a.i:1(int) a.rowid:2(int!null)
- │    ├── scan
+ │    ├── scan b
  │    │    └── columns: b.i:3(int) b.b:4(bool) b.rowid:5(int!null)
  │    └── eq [type=bool, outer=(1,3)]
  │         ├── variable: a.i [type=int, outer=(1)]
@@ -1062,9 +1062,9 @@ project
  │    ├── ordering: +3,+4
  │    └── right-join
  │         ├── columns: a.i:1(int) a.rowid:2(int) b.i:3(int) b.b:4(bool) b.rowid:5(int!null)
- │         ├── scan
+ │         ├── scan a
  │         │    └── columns: a.i:1(int) a.rowid:2(int!null)
- │         ├── scan
+ │         ├── scan b
  │         │    └── columns: b.i:3(int) b.b:4(bool) b.rowid:5(int!null)
  │         └── eq [type=bool, outer=(1,3)]
  │              ├── variable: a.i [type=int, outer=(1)]
@@ -1085,9 +1085,9 @@ project
  │    ├── ordering: +3,+4
  │    └── full-join
  │         ├── columns: a.i:1(int) a.rowid:2(int) b.i:3(int) b.b:4(bool) b.rowid:5(int)
- │         ├── scan
+ │         ├── scan a
  │         │    └── columns: a.i:1(int) a.rowid:2(int!null)
- │         ├── scan
+ │         ├── scan b
  │         │    └── columns: b.i:3(int) b.b:4(bool) b.rowid:5(int!null)
  │         └── eq [type=bool, outer=(1,3)]
  │              ├── variable: a.i [type=int, outer=(1)]
@@ -1109,9 +1109,9 @@ project
  │    ├── ordering: +1,+3
  │    └── full-join
  │         ├── columns: a.i:1(int) a.rowid:2(int) b.i:3(int) b.b:4(bool) b.rowid:5(int)
- │         ├── scan
+ │         ├── scan a
  │         │    └── columns: a.i:1(int) a.rowid:2(int!null)
- │         ├── scan
+ │         ├── scan b
  │         │    └── columns: b.i:3(int) b.b:4(bool) b.rowid:5(int!null)
  │         └── and [type=bool, outer=(1,3)]
  │              ├── eq [type=bool, outer=(1,3)]
@@ -1141,17 +1141,17 @@ project
  │         │    ├── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null) twocolumn.x:3(int) twocolumn.y:4(int) twocolumn.rowid:5(int!null) onecolumn.x:6(int) onecolumn.rowid:7(int!null)
  │         │    ├── inner-join
  │         │    │    ├── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null) twocolumn.x:3(int) twocolumn.y:4(int) twocolumn.rowid:5(int!null)
- │         │    │    ├── scan
+ │         │    │    ├── scan onecolumn
  │         │    │    │    └── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null)
- │         │    │    ├── scan
+ │         │    │    ├── scan twocolumn
  │         │    │    │    └── columns: twocolumn.x:3(int) twocolumn.y:4(int) twocolumn.rowid:5(int!null)
  │         │    │    └── true [type=bool]
- │         │    ├── scan
+ │         │    ├── scan onecolumn
  │         │    │    └── columns: onecolumn.x:6(int) onecolumn.rowid:7(int!null)
  │         │    └── eq [type=bool, outer=(3,6)]
  │         │         ├── variable: onecolumn.x [type=int, outer=(6)]
  │         │         └── variable: twocolumn.x [type=int, outer=(3)]
- │         ├── scan
+ │         ├── scan twocolumn
  │         │    └── columns: twocolumn.x:8(int) twocolumn.y:9(int) twocolumn.rowid:10(int!null)
  │         └── and [type=bool, outer=(1,6,8)]
  │              ├── eq [type=bool, outer=(6,8)]
@@ -1175,11 +1175,11 @@ project
  ├── columns: x:1(int)
  ├── inner-join
  │    ├── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null) x:5(int)
- │    ├── scan
+ │    ├── scan onecolumn
  │    │    └── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null)
  │    ├── project
  │    │    ├── columns: x:5(int)
- │    │    ├── scan
+ │    │    ├── scan onecolumn
  │    │    │    └── columns: onecolumn.x:3(int) onecolumn.rowid:4(int!null)
  │    │    └── projections [outer=(3)]
  │    │         └── plus [type=int, outer=(3)]
@@ -1205,14 +1205,14 @@ project
  │         ├── columns: twocolumn.x:1(int) twocolumn.y:2(int) twocolumn.rowid:3(int!null) twocolumn.x:4(int) twocolumn.y:5(int) twocolumn.rowid:6(int!null) twocolumn.x:7(int) twocolumn.y:8(int) twocolumn.rowid:9(int!null)
  │         ├── inner-join
  │         │    ├── columns: twocolumn.x:1(int) twocolumn.y:2(int) twocolumn.rowid:3(int!null) twocolumn.x:4(int) twocolumn.y:5(int) twocolumn.rowid:6(int!null)
- │         │    ├── scan
+ │         │    ├── scan twocolumn
  │         │    │    └── columns: twocolumn.x:1(int) twocolumn.y:2(int) twocolumn.rowid:3(int!null)
- │         │    ├── scan
+ │         │    ├── scan twocolumn
  │         │    │    └── columns: twocolumn.x:4(int) twocolumn.y:5(int) twocolumn.rowid:6(int!null)
  │         │    └── eq [type=bool, outer=(1,4)]
  │         │         ├── variable: twocolumn.x [type=int, outer=(1)]
  │         │         └── variable: twocolumn.x [type=int, outer=(4)]
- │         ├── scan
+ │         ├── scan twocolumn
  │         │    └── columns: twocolumn.x:7(int) twocolumn.y:8(int) twocolumn.rowid:9(int!null)
  │         └── eq [type=bool, outer=(1,7)]
  │              ├── variable: twocolumn.x [type=int, outer=(1)]
@@ -1236,14 +1236,14 @@ project
  │         ├── columns: twocolumn.x:1(int) twocolumn.y:2(int) twocolumn.rowid:3(int!null) twocolumn.x:4(int) twocolumn.y:5(int) twocolumn.rowid:6(int!null) twocolumn.x:7(int) twocolumn.y:8(int) twocolumn.rowid:9(int!null)
  │         ├── inner-join
  │         │    ├── columns: twocolumn.x:1(int) twocolumn.y:2(int) twocolumn.rowid:3(int!null) twocolumn.x:4(int) twocolumn.y:5(int) twocolumn.rowid:6(int!null)
- │         │    ├── scan
+ │         │    ├── scan twocolumn
  │         │    │    └── columns: twocolumn.x:1(int) twocolumn.y:2(int) twocolumn.rowid:3(int!null)
- │         │    ├── scan
+ │         │    ├── scan twocolumn
  │         │    │    └── columns: twocolumn.x:4(int) twocolumn.y:5(int) twocolumn.rowid:6(int!null)
  │         │    └── eq [type=bool, outer=(1,4)]
  │         │         ├── variable: twocolumn.x [type=int, outer=(1)]
  │         │         └── variable: twocolumn.x [type=int, outer=(4)]
- │         ├── scan
+ │         ├── scan twocolumn
  │         │    └── columns: twocolumn.x:7(int) twocolumn.y:8(int) twocolumn.rowid:9(int!null)
  │         └── eq [type=bool, outer=(1,7)]
  │              ├── variable: twocolumn.x [type=int, outer=(1)]
@@ -1298,13 +1298,13 @@ inner-join
  ├── columns: x:1(int) x:3(int)
  ├── project
  │    ├── columns: onecolumn.x:1(int)
- │    ├── scan
+ │    ├── scan onecolumn
  │    │    └── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null)
  │    └── projections [outer=(1)]
  │         └── variable: onecolumn.x [type=int, outer=(1)]
  ├── project
  │    ├── columns: onecolumn.x:3(int)
- │    ├── scan
+ │    ├── scan onecolumn
  │    │    └── columns: onecolumn.x:3(int) onecolumn.rowid:4(int!null)
  │    └── projections [outer=(3)]
  │         └── variable: onecolumn.x [type=int, outer=(3)]
@@ -1320,18 +1320,18 @@ project
  │    ├── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null) othercolumn.x:3(int) othercolumn.rowid:4(int!null) onecolumn.x:5(int) onecolumn.rowid:6(int!null) othercolumn.x:7(int) othercolumn.rowid:8(int!null)
  │    ├── inner-join
  │    │    ├── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null) othercolumn.x:3(int) othercolumn.rowid:4(int!null)
- │    │    ├── scan
+ │    │    ├── scan onecolumn
  │    │    │    └── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null)
- │    │    ├── scan
+ │    │    ├── scan othercolumn
  │    │    │    └── columns: othercolumn.x:3(int) othercolumn.rowid:4(int!null)
  │    │    └── eq [type=bool, outer=(1,3)]
  │    │         ├── variable: onecolumn.x [type=int, outer=(1)]
  │    │         └── variable: othercolumn.x [type=int, outer=(3)]
  │    ├── inner-join
  │    │    ├── columns: onecolumn.x:5(int) onecolumn.rowid:6(int!null) othercolumn.x:7(int) othercolumn.rowid:8(int!null)
- │    │    ├── scan
+ │    │    ├── scan onecolumn
  │    │    │    └── columns: onecolumn.x:5(int) onecolumn.rowid:6(int!null)
- │    │    ├── scan
+ │    │    ├── scan othercolumn
  │    │    │    └── columns: othercolumn.x:7(int) othercolumn.rowid:8(int!null)
  │    │    └── eq [type=bool, outer=(5,7)]
  │    │         ├── variable: onecolumn.x [type=int, outer=(5)]
@@ -1366,9 +1366,9 @@ project
  ├── columns: x:1(int) y:5(int)
  ├── inner-join
  │    ├── columns: twocolumn.x:1(int) twocolumn.y:2(int) twocolumn.rowid:3(int!null) twocolumn.x:4(int) twocolumn.y:5(int) twocolumn.rowid:6(int!null)
- │    ├── scan
+ │    ├── scan twocolumn
  │    │    └── columns: twocolumn.x:1(int) twocolumn.y:2(int) twocolumn.rowid:3(int!null)
- │    ├── scan
+ │    ├── scan twocolumn
  │    │    └── columns: twocolumn.x:4(int) twocolumn.y:5(int) twocolumn.rowid:6(int!null)
  │    └── true [type=bool]
  └── projections [outer=(1,5)]
@@ -1382,9 +1382,9 @@ project
  ├── columns: y:5(int)
  ├── inner-join
  │    ├── columns: twocolumn.x:1(int) twocolumn.y:2(int) twocolumn.rowid:3(int!null) twocolumn.x:4(int) twocolumn.y:5(int) twocolumn.rowid:6(int!null)
- │    ├── scan
+ │    ├── scan twocolumn
  │    │    └── columns: twocolumn.x:1(int) twocolumn.y:2(int) twocolumn.rowid:3(int!null)
- │    ├── scan
+ │    ├── scan twocolumn
  │    │    └── columns: twocolumn.x:4(int) twocolumn.y:5(int) twocolumn.rowid:6(int!null)
  │    └── eq [type=bool, outer=(1,4)]
  │         ├── variable: twocolumn.x [type=int, outer=(1)]
@@ -1399,9 +1399,9 @@ project
  ├── columns: y:5(int)
  ├── inner-join
  │    ├── columns: twocolumn.x:1(int) twocolumn.y:2(int) twocolumn.rowid:3(int!null) twocolumn.x:4(int) twocolumn.y:5(int) twocolumn.rowid:6(int!null)
- │    ├── scan
+ │    ├── scan twocolumn
  │    │    └── columns: twocolumn.x:1(int) twocolumn.y:2(int) twocolumn.rowid:3(int!null)
- │    ├── scan
+ │    ├── scan twocolumn
  │    │    └── columns: twocolumn.x:4(int) twocolumn.y:5(int) twocolumn.rowid:6(int!null)
  │    └── eq [type=bool, outer=(1,4)]
  │         ├── variable: twocolumn.x [type=int, outer=(1)]
@@ -1416,9 +1416,9 @@ project
  ├── columns: x:1(int)
  ├── inner-join
  │    ├── columns: twocolumn.x:1(int) twocolumn.y:2(int) twocolumn.rowid:3(int!null) twocolumn.x:4(int) twocolumn.y:5(int) twocolumn.rowid:6(int!null)
- │    ├── scan
+ │    ├── scan twocolumn
  │    │    └── columns: twocolumn.x:1(int) twocolumn.y:2(int) twocolumn.rowid:3(int!null)
- │    ├── scan
+ │    ├── scan twocolumn
  │    │    └── columns: twocolumn.x:4(int) twocolumn.y:5(int) twocolumn.rowid:6(int!null)
  │    └── lt [type=bool, outer=(1,5)]
  │         ├── variable: twocolumn.x [type=int, outer=(1)]
@@ -1493,9 +1493,9 @@ project
  │    ├── columns: pairs.a:1(int) pairs.b:2(int) pairs.rowid:3(int!null) square.n:4(int!null) square.sq:5(int)
  │    ├── inner-join
  │    │    ├── columns: pairs.a:1(int) pairs.b:2(int) pairs.rowid:3(int!null) square.n:4(int!null) square.sq:5(int)
- │    │    ├── scan
+ │    │    ├── scan pairs
  │    │    │    └── columns: pairs.a:1(int) pairs.b:2(int) pairs.rowid:3(int!null)
- │    │    ├── scan
+ │    │    ├── scan square
  │    │    │    └── columns: square.n:4(int!null) square.sq:5(int)
  │    │    └── true [type=bool]
  │    └── eq [type=bool, outer=(2,4)]
@@ -1517,9 +1517,9 @@ project
  │    ├── columns: pairs.a:1(int) pairs.b:2(int) pairs.rowid:3(int!null) square.n:4(int!null) square.sq:5(int)
  │    ├── inner-join
  │    │    ├── columns: pairs.a:1(int) pairs.b:2(int) pairs.rowid:3(int!null) square.n:4(int!null) square.sq:5(int)
- │    │    ├── scan
+ │    │    ├── scan pairs
  │    │    │    └── columns: pairs.a:1(int) pairs.b:2(int) pairs.rowid:3(int!null)
- │    │    ├── scan
+ │    │    ├── scan square
  │    │    │    └── columns: square.n:4(int!null) square.sq:5(int)
  │    │    └── true [type=bool]
  │    └── eq [type=bool, outer=(1,2,5)]
@@ -1547,9 +1547,9 @@ project
  │    │    ├── columns: pairs.a:1(int) pairs.b:2(int) sum:6(int) square.n:4(int!null) square.sq:5(int)
  │    │    ├── inner-join
  │    │    │    ├── columns: pairs.a:1(int) pairs.b:2(int) pairs.rowid:3(int!null) square.n:4(int!null) square.sq:5(int)
- │    │    │    ├── scan
+ │    │    │    ├── scan pairs
  │    │    │    │    └── columns: pairs.a:1(int) pairs.b:2(int) pairs.rowid:3(int!null)
- │    │    │    ├── scan
+ │    │    │    ├── scan square
  │    │    │    │    └── columns: square.n:4(int!null) square.sq:5(int)
  │    │    │    └── true [type=bool]
  │    │    └── projections [outer=(1,2,4,5)]
@@ -1577,9 +1577,9 @@ project
  ├── columns: a:1(int) b:2(int) n:4(int) sq:5(int)
  ├── full-join
  │    ├── columns: pairs.a:1(int) pairs.b:2(int) pairs.rowid:3(int) square.n:4(int) square.sq:5(int)
- │    ├── scan
+ │    ├── scan pairs
  │    │    └── columns: pairs.a:1(int) pairs.b:2(int) pairs.rowid:3(int!null)
- │    ├── scan
+ │    ├── scan square
  │    │    └── columns: square.n:4(int!null) square.sq:5(int)
  │    └── eq [type=bool, outer=(1,2,5)]
  │         ├── plus [type=int, outer=(1,2)]
@@ -1601,9 +1601,9 @@ project
  │    ├── columns: pairs.a:1(int) pairs.b:2(int) pairs.rowid:3(int) square.n:4(int) square.sq:5(int)
  │    ├── full-join
  │    │    ├── columns: pairs.a:1(int) pairs.b:2(int) pairs.rowid:3(int) square.n:4(int) square.sq:5(int)
- │    │    ├── scan
+ │    │    ├── scan pairs
  │    │    │    └── columns: pairs.a:1(int) pairs.b:2(int) pairs.rowid:3(int!null)
- │    │    ├── scan
+ │    │    ├── scan square
  │    │    │    └── columns: square.n:4(int!null) square.sq:5(int)
  │    │    └── eq [type=bool, outer=(1,2,5)]
  │    │         ├── plus [type=int, outer=(1,2)]
@@ -1636,9 +1636,9 @@ select
  │    ├── columns: pairs.a:1(int) pairs.b:2(int) square.n:4(int) square.sq:5(int)
  │    ├── left-join
  │    │    ├── columns: pairs.a:1(int) pairs.b:2(int) pairs.rowid:3(int!null) square.n:4(int) square.sq:5(int)
- │    │    ├── scan
+ │    │    ├── scan pairs
  │    │    │    └── columns: pairs.a:1(int) pairs.b:2(int) pairs.rowid:3(int!null)
- │    │    ├── scan
+ │    │    ├── scan square
  │    │    │    └── columns: square.n:4(int!null) square.sq:5(int)
  │    │    └── and [type=bool, outer=(1,2,4,5)]
  │    │         ├── and [type=bool, outer=(1,2,5)]
@@ -1687,9 +1687,9 @@ select
  │    ├── columns: pairs.a:1(int) pairs.b:2(int) square.n:4(int!null) square.sq:5(int)
  │    ├── right-join
  │    │    ├── columns: pairs.a:1(int) pairs.b:2(int) pairs.rowid:3(int) square.n:4(int!null) square.sq:5(int)
- │    │    ├── scan
+ │    │    ├── scan pairs
  │    │    │    └── columns: pairs.a:1(int) pairs.b:2(int) pairs.rowid:3(int!null)
- │    │    ├── scan
+ │    │    ├── scan square
  │    │    │    └── columns: square.n:4(int!null) square.sq:5(int)
  │    │    └── and [type=bool, outer=(1,2,4,5)]
  │    │         ├── and [type=bool, outer=(1,2,5)]
@@ -1739,9 +1739,9 @@ select
  │    ├── columns: pairs.a:1(int) pairs.b:2(int) square.n:4(int!null) square.sq:5(int)
  │    ├── inner-join
  │    │    ├── columns: pairs.a:1(int) pairs.b:2(int) pairs.rowid:3(int!null) square.n:4(int!null) square.sq:5(int)
- │    │    ├── scan
+ │    │    ├── scan pairs
  │    │    │    └── columns: pairs.a:1(int) pairs.b:2(int) pairs.rowid:3(int!null)
- │    │    ├── scan
+ │    │    ├── scan square
  │    │    │    └── columns: square.n:4(int!null) square.sq:5(int)
  │    │    └── and [type=bool, outer=(1,2,4,5)]
  │    │         ├── and [type=bool, outer=(1,2,5)]
@@ -1811,9 +1811,9 @@ project
  ├── columns: x:2(int) col1:1(int) col2:3(int) y:4(int) col3:6(int) y:7(int) col4:9(int)
  ├── inner-join
  │    ├── columns: t1.col1:1(int) t1.x:2(int) t1.col2:3(int) t1.y:4(int) t1.rowid:5(int!null) t2.col3:6(int) t2.y:7(int) t2.x:8(int) t2.col4:9(int) t2.rowid:10(int!null)
- │    ├── scan
+ │    ├── scan t1
  │    │    └── columns: t1.col1:1(int) t1.x:2(int) t1.col2:3(int) t1.y:4(int) t1.rowid:5(int!null)
- │    ├── scan
+ │    ├── scan t2
  │    │    └── columns: t2.col3:6(int) t2.y:7(int) t2.x:8(int) t2.col4:9(int) t2.rowid:10(int!null)
  │    └── eq [type=bool, outer=(2,8)]
  │         ├── variable: t1.x [type=int, outer=(2)]
@@ -1834,9 +1834,9 @@ project
  ├── columns: x:2(int) y:4(int) col1:1(int) col2:3(int) col3:6(int) col4:9(int)
  ├── inner-join
  │    ├── columns: t1.col1:1(int) t1.x:2(int) t1.col2:3(int) t1.y:4(int) t1.rowid:5(int!null) t2.col3:6(int) t2.y:7(int) t2.x:8(int) t2.col4:9(int) t2.rowid:10(int!null)
- │    ├── scan
+ │    ├── scan t1
  │    │    └── columns: t1.col1:1(int) t1.x:2(int) t1.col2:3(int) t1.y:4(int) t1.rowid:5(int!null)
- │    ├── scan
+ │    ├── scan t2
  │    │    └── columns: t2.col3:6(int) t2.y:7(int) t2.x:8(int) t2.col4:9(int) t2.rowid:10(int!null)
  │    └── and [type=bool, outer=(2,4,7,8)]
  │         ├── eq [type=bool, outer=(2,8)]
@@ -1860,9 +1860,9 @@ project
  ├── columns: col1:1(int) x:2(int) col2:3(int) y:4(int) col3:6(int) y:7(int) x:8(int) col4:9(int)
  ├── inner-join
  │    ├── columns: t1.col1:1(int) t1.x:2(int) t1.col2:3(int) t1.y:4(int) t1.rowid:5(int!null) t2.col3:6(int) t2.y:7(int) t2.x:8(int) t2.col4:9(int) t2.rowid:10(int!null)
- │    ├── scan
+ │    ├── scan t1
  │    │    └── columns: t1.col1:1(int) t1.x:2(int) t1.col2:3(int) t1.y:4(int) t1.rowid:5(int!null)
- │    ├── scan
+ │    ├── scan t2
  │    │    └── columns: t2.col3:6(int) t2.y:7(int) t2.x:8(int) t2.col4:9(int) t2.rowid:10(int!null)
  │    └── eq [type=bool, outer=(2,8)]
  │         ├── variable: t2.x [type=int, outer=(8)]
@@ -1886,9 +1886,9 @@ project
  │    ├── columns: x:11(int) t1.col1:1(int) t1.x:2(int) t1.col2:3(int) t1.y:4(int) t1.rowid:5(int) t2.col3:6(int) t2.y:7(int) t2.x:8(int) t2.col4:9(int) t2.rowid:10(int)
  │    ├── full-join
  │    │    ├── columns: t1.col1:1(int) t1.x:2(int) t1.col2:3(int) t1.y:4(int) t1.rowid:5(int) t2.col3:6(int) t2.y:7(int) t2.x:8(int) t2.col4:9(int) t2.rowid:10(int)
- │    │    ├── scan
+ │    │    ├── scan t1
  │    │    │    └── columns: t1.col1:1(int) t1.x:2(int) t1.col2:3(int) t1.y:4(int) t1.rowid:5(int!null)
- │    │    ├── scan
+ │    │    ├── scan t2
  │    │    │    └── columns: t2.col3:6(int) t2.y:7(int) t2.x:8(int) t2.col4:9(int) t2.rowid:10(int!null)
  │    │    └── eq [type=bool, outer=(2,8)]
  │    │         ├── variable: t1.x [type=int, outer=(2)]
@@ -1925,9 +1925,9 @@ project
  │    ├── columns: x:11(int) y:12(int) t1.col1:1(int) t1.x:2(int) t1.col2:3(int) t1.y:4(int) t1.rowid:5(int) t2.col3:6(int) t2.y:7(int) t2.x:8(int) t2.col4:9(int) t2.rowid:10(int)
  │    ├── full-join
  │    │    ├── columns: t1.col1:1(int) t1.x:2(int) t1.col2:3(int) t1.y:4(int) t1.rowid:5(int) t2.col3:6(int) t2.y:7(int) t2.x:8(int) t2.col4:9(int) t2.rowid:10(int)
- │    │    ├── scan
+ │    │    ├── scan t1
  │    │    │    └── columns: t1.col1:1(int) t1.x:2(int) t1.col2:3(int) t1.y:4(int) t1.rowid:5(int!null)
- │    │    ├── scan
+ │    │    ├── scan t2
  │    │    │    └── columns: t2.col3:6(int) t2.y:7(int) t2.x:8(int) t2.col4:9(int) t2.rowid:10(int!null)
  │    │    └── and [type=bool, outer=(2,4,7,8)]
  │    │         ├── eq [type=bool, outer=(2,8)]
@@ -1968,9 +1968,9 @@ project
  ├── columns: col1:1(int) x:2(int) col2:3(int) y:4(int) col3:6(int) y:7(int) x:8(int) col4:9(int)
  ├── full-join
  │    ├── columns: t1.col1:1(int) t1.x:2(int) t1.col2:3(int) t1.y:4(int) t1.rowid:5(int) t2.col3:6(int) t2.y:7(int) t2.x:8(int) t2.col4:9(int) t2.rowid:10(int)
- │    ├── scan
+ │    ├── scan t1
  │    │    └── columns: t1.col1:1(int) t1.x:2(int) t1.col2:3(int) t1.y:4(int) t1.rowid:5(int!null)
- │    ├── scan
+ │    ├── scan t2
  │    │    └── columns: t2.col3:6(int) t2.y:7(int) t2.x:8(int) t2.col4:9(int) t2.rowid:10(int!null)
  │    └── eq [type=bool, outer=(2,8)]
  │         ├── variable: t1.x [type=int, outer=(2)]
@@ -1992,9 +1992,9 @@ project
  ├── columns: x:8(int) x:2(int) x:2(int)
  ├── inner-join
  │    ├── columns: t1.col1:1(int) t1.x:2(int) t1.col2:3(int) t1.y:4(int) t1.rowid:5(int!null) t2.col3:6(int) t2.y:7(int) t2.x:8(int) t2.col4:9(int) t2.rowid:10(int!null)
- │    ├── scan
+ │    ├── scan t1
  │    │    └── columns: t1.col1:1(int) t1.x:2(int) t1.col2:3(int) t1.y:4(int) t1.rowid:5(int!null)
- │    ├── scan
+ │    ├── scan t2
  │    │    └── columns: t2.col3:6(int) t2.y:7(int) t2.x:8(int) t2.col4:9(int) t2.rowid:10(int!null)
  │    └── eq [type=bool, outer=(2,8)]
  │         ├── variable: t1.x [type=int, outer=(2)]
@@ -2013,9 +2013,9 @@ project
  │    ├── columns: x:11(int) t1.col1:1(int) t1.x:2(int) t1.col2:3(int) t1.y:4(int) t1.rowid:5(int) t2.col3:6(int) t2.y:7(int) t2.x:8(int) t2.col4:9(int) t2.rowid:10(int)
  │    ├── full-join
  │    │    ├── columns: t1.col1:1(int) t1.x:2(int) t1.col2:3(int) t1.y:4(int) t1.rowid:5(int) t2.col3:6(int) t2.y:7(int) t2.x:8(int) t2.col4:9(int) t2.rowid:10(int)
- │    │    ├── scan
+ │    │    ├── scan t1
  │    │    │    └── columns: t1.col1:1(int) t1.x:2(int) t1.col2:3(int) t1.y:4(int) t1.rowid:5(int!null)
- │    │    ├── scan
+ │    │    ├── scan t2
  │    │    │    └── columns: t2.col3:6(int) t2.y:7(int) t2.x:8(int) t2.col4:9(int) t2.rowid:10(int!null)
  │    │    └── eq [type=bool, outer=(2,8)]
  │    │         ├── variable: t1.x [type=int, outer=(2)]
@@ -2047,11 +2047,11 @@ project
  ├── columns: x:2(int)
  ├── inner-join
  │    ├── columns: t1.col1:1(int) t1.x:2(int) t1.col2:3(int) t1.y:4(int) t1.rowid:5(int!null) t2.col3:6(int) t2.y:7(int) t2.x:8(int) t2.col4:9(int)
- │    ├── scan
+ │    ├── scan t1
  │    │    └── columns: t1.col1:1(int) t1.x:2(int) t1.col2:3(int) t1.y:4(int) t1.rowid:5(int!null)
  │    ├── project
  │    │    ├── columns: t2.col3:6(int) t2.y:7(int) t2.x:8(int) t2.col4:9(int)
- │    │    ├── scan
+ │    │    ├── scan t2
  │    │    │    └── columns: t2.col3:6(int) t2.y:7(int) t2.x:8(int) t2.col4:9(int) t2.rowid:10(int!null)
  │    │    └── projections [outer=(6-9)]
  │    │         ├── variable: t2.col3 [type=int, outer=(6)]
@@ -2124,9 +2124,9 @@ SELECT * FROM pkBA AS l JOIN pkBC AS r ON l.a = r.a AND l.b = r.b AND l.c = r.c
 ----
 inner-join
  ├── columns: a:1(int!null) b:2(int!null) c:3(int) d:4(int) a:5(int) b:6(int!null) c:7(int!null) d:8(int)
- ├── scan
+ ├── scan pkba
  │    └── columns: pkba.a:1(int!null) pkba.b:2(int!null) pkba.c:3(int) pkba.d:4(int)
- ├── scan
+ ├── scan pkbc
  │    └── columns: pkbc.a:5(int) pkbc.b:6(int!null) pkbc.c:7(int!null) pkbc.d:8(int)
  └── and [type=bool, outer=(1-3,5-7)]
       ├── and [type=bool, outer=(1,2,5,6)]
@@ -2147,9 +2147,9 @@ project
  ├── columns: a:1(int!null) b:2(int!null) c:3(int) d:4(int)
  ├── inner-join
  │    ├── columns: pkba.a:1(int!null) pkba.b:2(int!null) pkba.c:3(int) pkba.d:4(int) pkbad.a:5(int!null) pkbad.b:6(int!null) pkbad.c:7(int) pkbad.d:8(int!null)
- │    ├── scan
+ │    ├── scan pkba
  │    │    └── columns: pkba.a:1(int!null) pkba.b:2(int!null) pkba.c:3(int) pkba.d:4(int)
- │    ├── scan
+ │    ├── scan pkbad
  │    │    └── columns: pkbad.a:5(int!null) pkbad.b:6(int!null) pkbad.c:7(int) pkbad.d:8(int!null)
  │    └── and [type=bool, outer=(1-8)]
  │         ├── eq [type=bool, outer=(1,5)]
@@ -2177,9 +2177,9 @@ project
  ├── columns: a:1(int!null) b:2(int!null) c:3(int!null) d:4(int) d:8(int)
  ├── inner-join
  │    ├── columns: pkbac.a:1(int!null) pkbac.b:2(int!null) pkbac.c:3(int!null) pkbac.d:4(int) pkbac.a:5(int!null) pkbac.b:6(int!null) pkbac.c:7(int!null) pkbac.d:8(int)
- │    ├── scan
+ │    ├── scan pkbac
  │    │    └── columns: pkbac.a:1(int!null) pkbac.b:2(int!null) pkbac.c:3(int!null) pkbac.d:4(int)
- │    ├── scan
+ │    ├── scan pkbac
  │    │    └── columns: pkbac.a:5(int!null) pkbac.b:6(int!null) pkbac.c:7(int!null) pkbac.d:8(int)
  │    └── and [type=bool, outer=(1-3,5-7)]
  │         ├── eq [type=bool, outer=(1,5)]
@@ -2203,9 +2203,9 @@ SELECT * FROM pkBAC AS l JOIN pkBAD AS r ON l.c = r.d AND l.a = r.a AND l.b = r.
 ----
 inner-join
  ├── columns: a:1(int!null) b:2(int!null) c:3(int!null) d:4(int) a:5(int!null) b:6(int!null) c:7(int) d:8(int!null)
- ├── scan
+ ├── scan pkbac
  │    └── columns: pkbac.a:1(int!null) pkbac.b:2(int!null) pkbac.c:3(int!null) pkbac.d:4(int)
- ├── scan
+ ├── scan pkbad
  │    └── columns: pkbad.a:5(int!null) pkbad.b:6(int!null) pkbad.c:7(int) pkbad.d:8(int!null)
  └── and [type=bool, outer=(1-3,5,6,8)]
       ├── and [type=bool, outer=(1,3,5,8)]
@@ -2245,9 +2245,9 @@ project
  ├── columns: s:2(collatedstring{en_u_ks_level1}) s:2(collatedstring{en_u_ks_level1}) s:4(collatedstring{en_u_ks_level1})
  ├── inner-join
  │    ├── columns: str1.a:1(int!null) str1.s:2(collatedstring{en_u_ks_level1}) str2.a:3(int!null) str2.s:4(collatedstring{en_u_ks_level1})
- │    ├── scan
+ │    ├── scan str1
  │    │    └── columns: str1.a:1(int!null) str1.s:2(collatedstring{en_u_ks_level1})
- │    ├── scan
+ │    ├── scan str2
  │    │    └── columns: str2.a:3(int!null) str2.s:4(collatedstring{en_u_ks_level1})
  │    └── eq [type=bool, outer=(2,4)]
  │         ├── variable: str1.s [type=collatedstring{en_u_ks_level1}, outer=(2)]
@@ -2264,9 +2264,9 @@ project
  ├── columns: s:2(collatedstring{en_u_ks_level1}) s:2(collatedstring{en_u_ks_level1}) s:4(collatedstring{en_u_ks_level1})
  ├── left-join
  │    ├── columns: str1.a:1(int!null) str1.s:2(collatedstring{en_u_ks_level1}) str2.a:3(int) str2.s:4(collatedstring{en_u_ks_level1})
- │    ├── scan
+ │    ├── scan str1
  │    │    └── columns: str1.a:1(int!null) str1.s:2(collatedstring{en_u_ks_level1})
- │    ├── scan
+ │    ├── scan str2
  │    │    └── columns: str2.a:3(int!null) str2.s:4(collatedstring{en_u_ks_level1})
  │    └── eq [type=bool, outer=(2,4)]
  │         ├── variable: str1.s [type=collatedstring{en_u_ks_level1}, outer=(2)]
@@ -2285,9 +2285,9 @@ project
  │    ├── columns: s:5(collatedstring{en_u_ks_level1}) str1.a:1(int) str1.s:2(collatedstring{en_u_ks_level1}) str2.a:3(int!null) str2.s:4(collatedstring{en_u_ks_level1})
  │    ├── right-join
  │    │    ├── columns: str1.a:1(int) str1.s:2(collatedstring{en_u_ks_level1}) str2.a:3(int!null) str2.s:4(collatedstring{en_u_ks_level1})
- │    │    ├── scan
+ │    │    ├── scan str1
  │    │    │    └── columns: str1.a:1(int!null) str1.s:2(collatedstring{en_u_ks_level1})
- │    │    ├── scan
+ │    │    ├── scan str2
  │    │    │    └── columns: str2.a:3(int!null) str2.s:4(collatedstring{en_u_ks_level1})
  │    │    └── eq [type=bool, outer=(2,4)]
  │    │         ├── variable: str1.s [type=collatedstring{en_u_ks_level1}, outer=(2)]
@@ -2314,9 +2314,9 @@ project
  │    ├── columns: s:5(collatedstring{en_u_ks_level1}) str1.a:1(int) str1.s:2(collatedstring{en_u_ks_level1}) str2.a:3(int) str2.s:4(collatedstring{en_u_ks_level1})
  │    ├── full-join
  │    │    ├── columns: str1.a:1(int) str1.s:2(collatedstring{en_u_ks_level1}) str2.a:3(int) str2.s:4(collatedstring{en_u_ks_level1})
- │    │    ├── scan
+ │    │    ├── scan str1
  │    │    │    └── columns: str1.a:1(int!null) str1.s:2(collatedstring{en_u_ks_level1})
- │    │    ├── scan
+ │    │    ├── scan str2
  │    │    │    └── columns: str2.a:3(int!null) str2.s:4(collatedstring{en_u_ks_level1})
  │    │    └── eq [type=bool, outer=(2,4)]
  │    │         ├── variable: str1.s [type=collatedstring{en_u_ks_level1}, outer=(2)]
@@ -2345,9 +2345,9 @@ project
  │    ├── columns: str2.a:3(int!null) s:5(collatedstring{en_u_ks_level1}) str1.a:1(int) str1.s:2(collatedstring{en_u_ks_level1}) str2.s:4(collatedstring{en_u_ks_level1})
  │    ├── right-join
  │    │    ├── columns: str1.a:1(int) str1.s:2(collatedstring{en_u_ks_level1}) str2.a:3(int!null) str2.s:4(collatedstring{en_u_ks_level1})
- │    │    ├── scan
+ │    │    ├── scan str1
  │    │    │    └── columns: str1.a:1(int!null) str1.s:2(collatedstring{en_u_ks_level1})
- │    │    ├── scan
+ │    │    ├── scan str2
  │    │    │    └── columns: str2.a:3(int!null) str2.s:4(collatedstring{en_u_ks_level1})
  │    │    └── and [type=bool, outer=(1-4)]
  │    │         ├── eq [type=bool, outer=(1,3)]
@@ -2402,9 +2402,9 @@ project
  │    ├── columns: xyu.x:1(int!null) xyu.y:2(int!null) xyu.u:3(int!null) xyv.x:4(int!null) xyv.y:5(int!null) xyv.v:6(int!null)
  │    ├── inner-join
  │    │    ├── columns: xyu.x:1(int!null) xyu.y:2(int!null) xyu.u:3(int!null) xyv.x:4(int!null) xyv.y:5(int!null) xyv.v:6(int!null)
- │    │    ├── scan
+ │    │    ├── scan xyu
  │    │    │    └── columns: xyu.x:1(int!null) xyu.y:2(int!null) xyu.u:3(int!null)
- │    │    ├── scan
+ │    │    ├── scan xyv
  │    │    │    └── columns: xyv.x:4(int!null) xyv.y:5(int!null) xyv.v:6(int!null)
  │    │    └── and [type=bool, outer=(1,2,4,5)]
  │    │         ├── eq [type=bool, outer=(1,4)]
@@ -2431,9 +2431,9 @@ project
  │    ├── columns: xyu.x:1(int!null) xyu.y:2(int!null) xyu.u:3(int!null) xyv.x:4(int) xyv.y:5(int) xyv.v:6(int)
  │    ├── left-join
  │    │    ├── columns: xyu.x:1(int!null) xyu.y:2(int!null) xyu.u:3(int!null) xyv.x:4(int) xyv.y:5(int) xyv.v:6(int)
- │    │    ├── scan
+ │    │    ├── scan xyu
  │    │    │    └── columns: xyu.x:1(int!null) xyu.y:2(int!null) xyu.u:3(int!null)
- │    │    ├── scan
+ │    │    ├── scan xyv
  │    │    │    └── columns: xyv.x:4(int!null) xyv.y:5(int!null) xyv.v:6(int!null)
  │    │    └── and [type=bool, outer=(1,2,4,5)]
  │    │         ├── eq [type=bool, outer=(1,4)]
@@ -2460,9 +2460,9 @@ project
  │    ├── columns: xyu.x:1(int) xyu.y:2(int) xyu.u:3(int) xyv.x:4(int!null) xyv.y:5(int!null) xyv.v:6(int!null)
  │    ├── right-join
  │    │    ├── columns: xyu.x:1(int) xyu.y:2(int) xyu.u:3(int) xyv.x:4(int!null) xyv.y:5(int!null) xyv.v:6(int!null)
- │    │    ├── scan
+ │    │    ├── scan xyu
  │    │    │    └── columns: xyu.x:1(int!null) xyu.y:2(int!null) xyu.u:3(int!null)
- │    │    ├── scan
+ │    │    ├── scan xyv
  │    │    │    └── columns: xyv.x:4(int!null) xyv.y:5(int!null) xyv.v:6(int!null)
  │    │    └── and [type=bool, outer=(1,2,4,5)]
  │    │         ├── eq [type=bool, outer=(1,4)]
@@ -2491,9 +2491,9 @@ project
  │    │    ├── columns: x:7(int) y:8(int) xyu.x:1(int) xyu.y:2(int) xyu.u:3(int) xyv.x:4(int) xyv.y:5(int) xyv.v:6(int)
  │    │    ├── full-join
  │    │    │    ├── columns: xyu.x:1(int) xyu.y:2(int) xyu.u:3(int) xyv.x:4(int) xyv.y:5(int) xyv.v:6(int)
- │    │    │    ├── scan
+ │    │    │    ├── scan xyu
  │    │    │    │    └── columns: xyu.x:1(int!null) xyu.y:2(int!null) xyu.u:3(int!null)
- │    │    │    ├── scan
+ │    │    │    ├── scan xyv
  │    │    │    │    └── columns: xyv.x:4(int!null) xyv.y:5(int!null) xyv.v:6(int!null)
  │    │    │    └── and [type=bool, outer=(1,2,4,5)]
  │    │    │         ├── eq [type=bool, outer=(1,4)]
@@ -2532,9 +2532,9 @@ select
  ├── columns: x:1(int!null) y:2(int!null) u:3(int!null) x:4(int!null) y:5(int!null) v:6(int!null)
  ├── inner-join
  │    ├── columns: xyu.x:1(int!null) xyu.y:2(int!null) xyu.u:3(int!null) xyv.x:4(int!null) xyv.y:5(int!null) xyv.v:6(int!null)
- │    ├── scan
+ │    ├── scan xyu
  │    │    └── columns: xyu.x:1(int!null) xyu.y:2(int!null) xyu.u:3(int!null)
- │    ├── scan
+ │    ├── scan xyv
  │    │    └── columns: xyv.x:4(int!null) xyv.y:5(int!null) xyv.v:6(int!null)
  │    └── and [type=bool, outer=(1,2,4,5)]
  │         ├── eq [type=bool, outer=(1,4)]
@@ -2556,9 +2556,9 @@ SELECT * FROM xyu INNER JOIN xyv ON xyu.x = xyv.x AND xyu.y = xyv.y AND xyu.x = 
 ----
 inner-join
  ├── columns: x:1(int!null) y:2(int!null) u:3(int!null) x:4(int!null) y:5(int!null) v:6(int!null)
- ├── scan
+ ├── scan xyu
  │    └── columns: xyu.x:1(int!null) xyu.y:2(int!null) xyu.u:3(int!null)
- ├── scan
+ ├── scan xyv
  │    └── columns: xyv.x:4(int!null) xyv.y:5(int!null) xyv.v:6(int!null)
  └── and [type=bool, outer=(1,2,4,5)]
       ├── and [type=bool, outer=(1,2,4,5)]
@@ -2581,9 +2581,9 @@ SELECT * FROM xyu LEFT OUTER JOIN xyv ON xyu.x = xyv.x AND xyu.y = xyv.y AND xyu
 ----
 left-join
  ├── columns: x:1(int!null) y:2(int!null) u:3(int!null) x:4(int) y:5(int) v:6(int)
- ├── scan
+ ├── scan xyu
  │    └── columns: xyu.x:1(int!null) xyu.y:2(int!null) xyu.u:3(int!null)
- ├── scan
+ ├── scan xyv
  │    └── columns: xyv.x:4(int!null) xyv.y:5(int!null) xyv.v:6(int!null)
  └── and [type=bool, outer=(1,2,4,5)]
       ├── and [type=bool, outer=(1,2,4,5)]
@@ -2606,9 +2606,9 @@ SELECT * FROM xyu RIGHT OUTER JOIN xyv ON xyu.x = xyv.x AND xyu.y = xyv.y AND xy
 ----
 right-join
  ├── columns: x:1(int) y:2(int) u:3(int) x:4(int!null) y:5(int!null) v:6(int!null)
- ├── scan
+ ├── scan xyu
  │    └── columns: xyu.x:1(int!null) xyu.y:2(int!null) xyu.u:3(int!null)
- ├── scan
+ ├── scan xyv
  │    └── columns: xyv.x:4(int!null) xyv.y:5(int!null) xyv.v:6(int!null)
  └── and [type=bool, outer=(1,2,4,5)]
       ├── and [type=bool, outer=(1,2,4,5)]
@@ -2638,9 +2638,9 @@ project
  │    ├── columns: xyu.x:1(int!null) xyu.y:2(int!null) xyu.u:3(int!null) xyv.x:4(int) xyv.y:5(int) xyv.v:6(int)
  │    ├── left-join
  │    │    ├── columns: xyu.x:1(int!null) xyu.y:2(int!null) xyu.u:3(int!null) xyv.x:4(int) xyv.y:5(int) xyv.v:6(int)
- │    │    ├── scan
+ │    │    ├── scan xyu
  │    │    │    └── columns: xyu.x:1(int!null) xyu.y:2(int!null) xyu.u:3(int!null)
- │    │    ├── scan
+ │    │    ├── scan xyv
  │    │    │    └── columns: xyv.x:4(int!null) xyv.y:5(int!null) xyv.v:6(int!null)
  │    │    └── and [type=bool, outer=(1,2,4,5)]
  │    │         ├── eq [type=bool, outer=(1,4)]
@@ -2667,9 +2667,9 @@ project
  │    ├── columns: xyu.x:1(int) xyu.y:2(int) xyu.u:3(int) xyv.x:4(int!null) xyv.y:5(int!null) xyv.v:6(int!null)
  │    ├── right-join
  │    │    ├── columns: xyu.x:1(int) xyu.y:2(int) xyu.u:3(int) xyv.x:4(int!null) xyv.y:5(int!null) xyv.v:6(int!null)
- │    │    ├── scan
+ │    │    ├── scan xyu
  │    │    │    └── columns: xyu.x:1(int!null) xyu.y:2(int!null) xyu.u:3(int!null)
- │    │    ├── scan
+ │    │    ├── scan xyv
  │    │    │    └── columns: xyv.x:4(int!null) xyv.y:5(int!null) xyv.v:6(int!null)
  │    │    └── and [type=bool, outer=(1,2,4,5)]
  │    │         ├── eq [type=bool, outer=(1,4)]
@@ -2698,9 +2698,9 @@ project
  │    │    ├── columns: x:7(int) y:8(int) xyu.x:1(int) xyu.y:2(int) xyu.u:3(int) xyv.x:4(int) xyv.y:5(int) xyv.v:6(int)
  │    │    ├── full-join
  │    │    │    ├── columns: xyu.x:1(int) xyu.y:2(int) xyu.u:3(int) xyv.x:4(int) xyv.y:5(int) xyv.v:6(int)
- │    │    │    ├── scan
+ │    │    │    ├── scan xyu
  │    │    │    │    └── columns: xyu.x:1(int!null) xyu.y:2(int!null) xyu.u:3(int!null)
- │    │    │    ├── scan
+ │    │    │    ├── scan xyv
  │    │    │    │    └── columns: xyv.x:4(int!null) xyv.y:5(int!null) xyv.v:6(int!null)
  │    │    │    └── and [type=bool, outer=(1,2,4,5)]
  │    │    │         ├── eq [type=bool, outer=(1,4)]
@@ -2736,9 +2736,9 @@ SELECT * FROM (SELECT * FROM xyu ORDER BY x, y) AS xyu LEFT OUTER JOIN (SELECT *
 ----
 left-join
  ├── columns: x:1(int!null) y:2(int!null) u:3(int!null) x:4(int) y:5(int) v:6(int)
- ├── scan
+ ├── scan xyu
  │    └── columns: xyu.x:1(int!null) xyu.y:2(int!null) xyu.u:3(int!null)
- ├── scan
+ ├── scan xyv
  │    └── columns: xyv.x:4(int!null) xyv.y:5(int!null) xyv.v:6(int!null)
  └── and [type=bool, outer=(1,2,4,5)]
       ├── and [type=bool, outer=(1,2,4,5)]
@@ -2761,9 +2761,9 @@ SELECT * FROM xyu RIGHT OUTER JOIN (SELECT * FROM xyv ORDER BY x, y) AS xyv ON x
 ----
 right-join
  ├── columns: x:1(int) y:2(int) u:3(int) x:4(int!null) y:5(int!null) v:6(int!null)
- ├── scan
+ ├── scan xyu
  │    └── columns: xyu.x:1(int!null) xyu.y:2(int!null) xyu.u:3(int!null)
- ├── scan
+ ├── scan xyv
  │    └── columns: xyv.x:4(int!null) xyv.y:5(int!null) xyv.v:6(int!null)
  └── and [type=bool, outer=(1,2,4,5)]
       ├── and [type=bool, outer=(1,2,4,5)]
@@ -2791,9 +2791,9 @@ project
  │    ├── columns: xyu.x:1(int!null) xyu.y:2(int!null) xyu.u:3(int!null) xyv.x:4(int!null) xyv.y:5(int!null) xyv.v:6(int!null)
  │    ├── inner-join
  │    │    ├── columns: xyu.x:1(int!null) xyu.y:2(int!null) xyu.u:3(int!null) xyv.x:4(int!null) xyv.y:5(int!null) xyv.v:6(int!null)
- │    │    ├── scan
+ │    │    ├── scan xyu
  │    │    │    └── columns: xyu.x:1(int!null) xyu.y:2(int!null) xyu.u:3(int!null)
- │    │    ├── scan
+ │    │    ├── scan xyv
  │    │    │    └── columns: xyv.x:4(int!null) xyv.y:5(int!null) xyv.v:6(int!null)
  │    │    └── and [type=bool, outer=(1,2,4,5)]
  │    │         ├── eq [type=bool, outer=(1,4)]
@@ -2843,9 +2843,9 @@ select
  ├── columns: a:1(int!null) a:2(int)
  ├── left-join
  │    ├── columns: l.a:1(int!null) r.a:2(int)
- │    ├── scan
+ │    ├── scan l
  │    │    └── columns: l.a:1(int!null)
- │    ├── scan
+ │    ├── scan r
  │    │    └── columns: r.a:2(int!null)
  │    └── eq [type=bool, outer=(1,2)]
  │         ├── variable: l.a [type=int, outer=(1)]
@@ -2861,9 +2861,9 @@ select
  ├── columns: a:1(int) a:2(int!null)
  ├── right-join
  │    ├── columns: l.a:1(int) r.a:2(int!null)
- │    ├── scan
+ │    ├── scan l
  │    │    └── columns: l.a:1(int!null)
- │    ├── scan
+ │    ├── scan r
  │    │    └── columns: r.a:2(int!null)
  │    └── eq [type=bool, outer=(1,2)]
  │         ├── variable: l.a [type=int, outer=(1)]
@@ -2881,9 +2881,9 @@ project
  │    ├── columns: l.a:1(int!null) r.a:2(int)
  │    ├── left-join
  │    │    ├── columns: l.a:1(int!null) r.a:2(int)
- │    │    ├── scan
+ │    │    ├── scan l
  │    │    │    └── columns: l.a:1(int!null)
- │    │    ├── scan
+ │    │    ├── scan r
  │    │    │    └── columns: r.a:2(int!null)
  │    │    └── eq [type=bool, outer=(1,2)]
  │    │         ├── variable: l.a [type=int, outer=(1)]
@@ -2903,9 +2903,9 @@ project
  │    ├── columns: l.a:1(int) r.a:2(int!null)
  │    ├── right-join
  │    │    ├── columns: l.a:1(int) r.a:2(int!null)
- │    │    ├── scan
+ │    │    ├── scan l
  │    │    │    └── columns: l.a:1(int!null)
- │    │    ├── scan
+ │    │    ├── scan r
  │    │    │    └── columns: r.a:2(int!null)
  │    │    └── eq [type=bool, outer=(1,2)]
  │    │         ├── variable: l.a [type=int, outer=(1)]
@@ -2966,9 +2966,9 @@ project
  │    ├── columns: abcdef.a:1(int!null) abcdef.b:2(int!null) abcdef.c:3(int!null) abcdef.d:4(int!null) abcdef.e:5(int) abcdef.f:6(int) abg.a:7(int!null) abg.b:8(int!null) abg.g:9(int)
  │    ├── inner-join
  │    │    ├── columns: abcdef.a:1(int!null) abcdef.b:2(int!null) abcdef.c:3(int!null) abcdef.d:4(int!null) abcdef.e:5(int) abcdef.f:6(int) abg.a:7(int!null) abg.b:8(int!null) abg.g:9(int)
- │    │    ├── scan
+ │    │    ├── scan abcdef
  │    │    │    └── columns: abcdef.a:1(int!null) abcdef.b:2(int!null) abcdef.c:3(int!null) abcdef.d:4(int!null) abcdef.e:5(int) abcdef.f:6(int)
- │    │    ├── scan
+ │    │    ├── scan abg
  │    │    │    └── columns: abg.a:7(int!null) abg.b:8(int!null) abg.g:9(int)
  │    │    └── and [type=bool, outer=(1,2,7,8)]
  │    │         ├── eq [type=bool, outer=(1,7)]
@@ -3062,9 +3062,9 @@ project
  ├── columns: a:1(int) b:2(int) c:3(float) d:4(float)
  ├── inner-join
  │    ├── columns: foo.a:1(int) foo.b:2(int) foo.c:3(float) foo.d:4(float) foo.rowid:5(int!null) bar.a:6(int) bar.b:7(float) bar.c:8(float) bar.d:9(int) bar.rowid:10(int!null)
- │    ├── scan
+ │    ├── scan foo
  │    │    └── columns: foo.a:1(int) foo.b:2(int) foo.c:3(float) foo.d:4(float) foo.rowid:5(int!null)
- │    ├── scan
+ │    ├── scan bar
  │    │    └── columns: bar.a:6(int) bar.b:7(float) bar.c:8(float) bar.d:9(int) bar.rowid:10(int!null)
  │    └── and [type=bool, outer=(1-4,6-9)]
  │         ├── eq [type=bool, outer=(1,6)]
@@ -3093,9 +3093,9 @@ project
  ├── columns: b:2(int) a:1(int) c:3(float) d:4(float) a:6(int) c:8(float) d:9(int)
  ├── inner-join
  │    ├── columns: foo.a:1(int) foo.b:2(int) foo.c:3(float) foo.d:4(float) foo.rowid:5(int!null) bar.a:6(int) bar.b:7(float) bar.c:8(float) bar.d:9(int) bar.rowid:10(int!null)
- │    ├── scan
+ │    ├── scan foo
  │    │    └── columns: foo.a:1(int) foo.b:2(int) foo.c:3(float) foo.d:4(float) foo.rowid:5(int!null)
- │    ├── scan
+ │    ├── scan bar
  │    │    └── columns: bar.a:6(int) bar.b:7(float) bar.c:8(float) bar.d:9(int) bar.rowid:10(int!null)
  │    └── eq [type=bool, outer=(2,7)]
  │         ├── variable: foo.b [type=int, outer=(2)]
@@ -3117,9 +3117,9 @@ project
  ├── columns: a:1(int) b:2(int) c:3(float) d:4(float) c:8(float) d:9(int)
  ├── inner-join
  │    ├── columns: foo.a:1(int) foo.b:2(int) foo.c:3(float) foo.d:4(float) foo.rowid:5(int!null) bar.a:6(int) bar.b:7(float) bar.c:8(float) bar.d:9(int) bar.rowid:10(int!null)
- │    ├── scan
+ │    ├── scan foo
  │    │    └── columns: foo.a:1(int) foo.b:2(int) foo.c:3(float) foo.d:4(float) foo.rowid:5(int!null)
- │    ├── scan
+ │    ├── scan bar
  │    │    └── columns: bar.a:6(int) bar.b:7(float) bar.c:8(float) bar.d:9(int) bar.rowid:10(int!null)
  │    └── and [type=bool, outer=(1,2,6,7)]
  │         ├── eq [type=bool, outer=(1,6)]
@@ -3144,9 +3144,9 @@ project
  ├── columns: a:1(int) b:2(int) c:3(float) d:4(float) d:9(int)
  ├── inner-join
  │    ├── columns: foo.a:1(int) foo.b:2(int) foo.c:3(float) foo.d:4(float) foo.rowid:5(int!null) bar.a:6(int) bar.b:7(float) bar.c:8(float) bar.d:9(int) bar.rowid:10(int!null)
- │    ├── scan
+ │    ├── scan foo
  │    │    └── columns: foo.a:1(int) foo.b:2(int) foo.c:3(float) foo.d:4(float) foo.rowid:5(int!null)
- │    ├── scan
+ │    ├── scan bar
  │    │    └── columns: bar.a:6(int) bar.b:7(float) bar.c:8(float) bar.d:9(int) bar.rowid:10(int!null)
  │    └── and [type=bool, outer=(1-3,6-8)]
  │         ├── eq [type=bool, outer=(1,6)]
@@ -3173,9 +3173,9 @@ project
  ├── columns: a:1(int) b:2(int) c:3(float) d:4(float) a:6(int) b:7(float) c:8(float) d:9(int)
  ├── inner-join
  │    ├── columns: foo.a:1(int) foo.b:2(int) foo.c:3(float) foo.d:4(float) foo.rowid:5(int!null) bar.a:6(int) bar.b:7(float) bar.c:8(float) bar.d:9(int) bar.rowid:10(int!null)
- │    ├── scan
+ │    ├── scan foo
  │    │    └── columns: foo.a:1(int) foo.b:2(int) foo.c:3(float) foo.d:4(float) foo.rowid:5(int!null)
- │    ├── scan
+ │    ├── scan bar
  │    │    └── columns: bar.a:6(int) bar.b:7(float) bar.c:8(float) bar.d:9(int) bar.rowid:10(int!null)
  │    └── eq [type=bool, outer=(2,7)]
  │         ├── variable: foo.b [type=int, outer=(2)]
@@ -3198,9 +3198,9 @@ project
  ├── columns: a:1(int) b:2(int) c:3(float) d:4(float) a:6(int) b:7(float) c:8(float) d:9(int)
  ├── inner-join
  │    ├── columns: foo.a:1(int) foo.b:2(int) foo.c:3(float) foo.d:4(float) foo.rowid:5(int!null) bar.a:6(int) bar.b:7(float) bar.c:8(float) bar.d:9(int) bar.rowid:10(int!null)
- │    ├── scan
+ │    ├── scan foo
  │    │    └── columns: foo.a:1(int) foo.b:2(int) foo.c:3(float) foo.d:4(float) foo.rowid:5(int!null)
- │    ├── scan
+ │    ├── scan bar
  │    │    └── columns: bar.a:6(int) bar.b:7(float) bar.c:8(float) bar.d:9(int) bar.rowid:10(int!null)
  │    └── and [type=bool, outer=(1,2,6,7)]
  │         ├── eq [type=bool, outer=(1,6)]
@@ -3228,9 +3228,9 @@ project
  │    ├── columns: foo.a:1(int) foo.b:2(int) foo.c:3(float) foo.d:4(float) foo.rowid:5(int!null) bar.a:6(int) bar.b:7(float) bar.c:8(float) bar.d:9(int) bar.rowid:10(int!null)
  │    ├── inner-join
  │    │    ├── columns: foo.a:1(int) foo.b:2(int) foo.c:3(float) foo.d:4(float) foo.rowid:5(int!null) bar.a:6(int) bar.b:7(float) bar.c:8(float) bar.d:9(int) bar.rowid:10(int!null)
- │    │    ├── scan
+ │    │    ├── scan foo
  │    │    │    └── columns: foo.a:1(int) foo.b:2(int) foo.c:3(float) foo.d:4(float) foo.rowid:5(int!null)
- │    │    ├── scan
+ │    │    ├── scan bar
  │    │    │    └── columns: bar.a:6(int) bar.b:7(float) bar.c:8(float) bar.d:9(int) bar.rowid:10(int!null)
  │    │    └── true [type=bool]
  │    └── eq [type=bool, outer=(2,7)]
@@ -3256,9 +3256,9 @@ project
  │    ├── columns: foo.a:1(int) foo.b:2(int) foo.c:3(float) foo.d:4(float) foo.rowid:5(int!null) bar.a:6(int) bar.b:7(float) bar.c:8(float) bar.d:9(int) bar.rowid:10(int!null)
  │    ├── inner-join
  │    │    ├── columns: foo.a:1(int) foo.b:2(int) foo.c:3(float) foo.d:4(float) foo.rowid:5(int!null) bar.a:6(int) bar.b:7(float) bar.c:8(float) bar.d:9(int) bar.rowid:10(int!null)
- │    │    ├── scan
+ │    │    ├── scan foo
  │    │    │    └── columns: foo.a:1(int) foo.b:2(int) foo.c:3(float) foo.d:4(float) foo.rowid:5(int!null)
- │    │    ├── scan
+ │    │    ├── scan bar
  │    │    │    └── columns: bar.a:6(int) bar.b:7(float) bar.c:8(float) bar.d:9(int) bar.rowid:10(int!null)
  │    │    └── true [type=bool]
  │    └── and [type=bool, outer=(1,2,6,7)]
@@ -3288,9 +3288,9 @@ project
  │    ├── columns: foo.a:1(int) foo.b:2(int) foo.c:3(float) foo.d:4(float) foo.rowid:5(int!null) bar.a:6(int) bar.b:7(float) bar.c:8(float) bar.d:9(int) bar.rowid:10(int!null)
  │    ├── inner-join
  │    │    ├── columns: foo.a:1(int) foo.b:2(int) foo.c:3(float) foo.d:4(float) foo.rowid:5(int!null) bar.a:6(int) bar.b:7(float) bar.c:8(float) bar.d:9(int) bar.rowid:10(int!null)
- │    │    ├── scan
+ │    │    ├── scan foo
  │    │    │    └── columns: foo.a:1(int) foo.b:2(int) foo.c:3(float) foo.d:4(float) foo.rowid:5(int!null)
- │    │    ├── scan
+ │    │    ├── scan bar
  │    │    │    └── columns: bar.a:6(int) bar.b:7(float) bar.c:8(float) bar.d:9(int) bar.rowid:10(int!null)
  │    │    └── and [type=bool, outer=(1,2,6,7)]
  │    │         ├── eq [type=bool, outer=(1,6)]
@@ -3337,7 +3337,7 @@ project
  ├── columns: k:5(int)
  ├── inner-join
  │    ├── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string) k:5(int)
- │    ├── scan
+ │    ├── scan kv
  │    │    └── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string)
  │    ├── project
  │    │    ├── columns: k:5(int)

--- a/pkg/sql/opt/optbuilder/testdata/limit
+++ b/pkg/sql/opt/optbuilder/testdata/limit
@@ -22,7 +22,7 @@ limit
  ├── project
  │    ├── columns: t.k:1(int!null) t.v:2(int)
  │    ├── ordering: +1
- │    ├── scan
+ │    ├── scan t
  │    │    ├── columns: t.k:1(int!null) t.v:2(int) t.w:3(int)
  │    │    └── ordering: +1
  │    └── projections [outer=(1,2)]
@@ -42,7 +42,7 @@ limit
  │    ├── sort
  │    │    ├── columns: t.k:1(int!null) t.v:2(int) t.w:3(int)
  │    │    ├── ordering: +2
- │    │    └── scan
+ │    │    └── scan t
  │    │         └── columns: t.k:1(int!null) t.v:2(int) t.w:3(int)
  │    └── projections [outer=(1,2)]
  │         ├── variable: t.k [type=int, outer=(1)]
@@ -56,7 +56,7 @@ limit
  ├── columns: k:1(int!null) v:2(int)
  ├── project
  │    ├── columns: t.k:1(int!null) t.v:2(int)
- │    ├── scan
+ │    ├── scan t
  │    │    └── columns: t.k:1(int!null) t.v:2(int) t.w:3(int)
  │    └── projections [outer=(1,2)]
  │         ├── variable: t.k [type=int, outer=(1)]
@@ -72,7 +72,7 @@ limit
  ├── project
  │    ├── columns: t.k:1(int!null)
  │    ├── ordering: +1
- │    ├── scan
+ │    ├── scan t
  │    │    ├── columns: t.k:1(int!null) t.v:2(int) t.w:3(int)
  │    │    └── ordering: +1
  │    └── projections [outer=(1)]
@@ -91,7 +91,7 @@ limit
  │    ├── project
  │    │    ├── columns: t.k:1(int!null)
  │    │    ├── ordering: +1
- │    │    ├── scan
+ │    │    ├── scan t
  │    │    │    ├── columns: t.k:1(int!null) t.v:2(int) t.w:3(int)
  │    │    │    └── ordering: +1
  │    │    └── projections [outer=(1)]
@@ -108,7 +108,7 @@ offset
  ├── project
  │    ├── columns: t.k:1(int!null) t.v:2(int)
  │    ├── ordering: +1
- │    ├── scan
+ │    ├── scan t
  │    │    ├── columns: t.k:1(int!null) t.v:2(int) t.w:3(int)
  │    │    └── ordering: +1
  │    └── projections [outer=(1,2)]
@@ -125,7 +125,7 @@ limit
  ├── project
  │    ├── columns: t.k:1(int!null)
  │    ├── ordering: +1
- │    ├── scan
+ │    ├── scan t
  │    │    ├── columns: t.k:1(int!null) t.v:2(int) t.w:3(int)
  │    │    └── ordering: +1
  │    └── projections [outer=(1)]
@@ -157,7 +157,7 @@ limit
  │    │    └── group-by
  │    │         ├── columns: t.k:1(int!null) t.v:2(int) column4:4(decimal)
  │    │         ├── grouping columns: t.k:1(int!null) t.v:2(int)
- │    │         ├── scan
+ │    │         ├── scan t
  │    │         │    └── columns: t.k:1(int!null) t.v:2(int) t.w:3(int)
  │    │         └── aggregations [outer=(3)]
  │    │              └── function: sum [type=decimal, outer=(3)]
@@ -179,7 +179,7 @@ limit
  │    └── group-by
  │         ├── columns: t.v:2(int)
  │         ├── grouping columns: t.v:2(int)
- │         ├── scan
+ │         ├── scan t
  │         │    └── columns: t.k:1(int!null) t.v:2(int) t.w:3(int)
  │         └── aggregations
  └── const: 10 [type=int]

--- a/pkg/sql/opt/optbuilder/testdata/orderby
+++ b/pkg/sql/opt/optbuilder/testdata/orderby
@@ -23,7 +23,7 @@ project
  ├── sort
  │    ├── columns: t.a:1(int!null) t.b:2(int) t.c:3(bool)
  │    ├── ordering: +3
- │    └── scan
+ │    └── scan t
  │         └── columns: t.a:1(int!null) t.b:2(int) t.c:3(bool)
  └── projections [outer=(3)]
       └── variable: t.c [type=bool, outer=(3)]
@@ -37,7 +37,7 @@ project
  ├── sort
  │    ├── columns: t.a:1(int!null) t.b:2(int) t.c:3(bool)
  │    ├── ordering: -3
- │    └── scan
+ │    └── scan t
  │         └── columns: t.a:1(int!null) t.b:2(int) t.c:3(bool)
  └── projections [outer=(3)]
       └── variable: t.c [type=bool, outer=(3)]
@@ -51,7 +51,7 @@ project
  ├── sort
  │    ├── columns: t.a:1(int!null) t.b:2(int) t.c:3(bool)
  │    ├── ordering: +2
- │    └── scan
+ │    └── scan t
  │         └── columns: t.a:1(int!null) t.b:2(int) t.c:3(bool)
  └── projections [outer=(1,2)]
       ├── variable: t.a [type=int, outer=(1)]
@@ -66,7 +66,7 @@ project
  ├── sort
  │    ├── columns: t.a:1(int!null) t.b:2(int) t.c:3(bool)
  │    ├── ordering: -2
- │    └── scan
+ │    └── scan t
  │         └── columns: t.a:1(int!null) t.b:2(int) t.c:3(bool)
  └── projections [outer=(1,2)]
       ├── variable: t.a [type=int, outer=(1)]
@@ -81,7 +81,7 @@ project
  ├── sort
  │    ├── columns: t.a:1(int!null) t.b:2(int) t.c:3(bool)
  │    ├── ordering: -1
- │    └── scan
+ │    └── scan t
  │         └── columns: t.a:1(int!null) t.b:2(int) t.c:3(bool)
  └── projections [outer=(1)]
       └── variable: t.a [type=int, outer=(1)]
@@ -107,7 +107,7 @@ project
  ├── sort
  │    ├── columns: t.a:1(int!null) t.b:2(int) t.c:3(bool)
  │    ├── ordering: -1
- │    └── scan
+ │    └── scan t
  │         └── columns: t.a:1(int!null) t.b:2(int) t.c:3(bool)
  └── projections [outer=(1,2)]
       ├── variable: t.a [type=int, outer=(1)]
@@ -127,7 +127,7 @@ SELECT a AS foo, (a) AS foo FROM t ORDER BY foo
 project
  ├── columns: foo:1(int!null) foo:1(int!null)
  ├── ordering: +1
- ├── scan
+ ├── scan t
  │    ├── columns: t.a:1(int!null) t.b:2(int) t.c:3(bool)
  │    └── ordering: +1
  └── projections [outer=(1)]
@@ -142,7 +142,7 @@ SELECT a AS b, b AS c FROM t ORDER BY b
 project
  ├── columns: b:1(int!null) c:2(int)
  ├── ordering: +1
- ├── scan
+ ├── scan t
  │    ├── columns: t.a:1(int!null) t.b:2(int) t.c:3(bool)
  │    └── ordering: +1
  └── projections [outer=(1,2)]
@@ -158,7 +158,7 @@ project
  ├── sort
  │    ├── columns: t.a:1(int!null) t.b:2(int) t.c:3(bool)
  │    ├── ordering: -1
- │    └── scan
+ │    └── scan t
  │         └── columns: t.a:1(int!null) t.b:2(int) t.c:3(bool)
  └── projections [outer=(1,2)]
       ├── variable: t.a [type=int, outer=(1)]
@@ -173,7 +173,7 @@ project
  ├── sort
  │    ├── columns: t.a:1(int!null) t.b:2(int) t.c:3(bool)
  │    ├── ordering: -1
- │    └── scan
+ │    └── scan t
  │         └── columns: t.a:1(int!null) t.b:2(int) t.c:3(bool)
  └── projections [outer=(1,2)]
       ├── variable: t.a [type=int, outer=(1)]
@@ -188,7 +188,7 @@ project
  ├── sort
  │    ├── columns: t.a:1(int!null) t.b:2(int) t.c:3(bool)
  │    ├── ordering: -1
- │    └── scan
+ │    └── scan t
  │         └── columns: t.a:1(int!null) t.b:2(int) t.c:3(bool)
  └── projections [outer=(1,2)]
       ├── variable: t.b [type=int, outer=(2)]
@@ -203,7 +203,7 @@ project
  ├── sort
  │    ├── columns: t.a:1(int!null) t.b:2(int) t.c:3(bool)
  │    ├── ordering: -1,+2
- │    └── scan
+ │    └── scan t
  │         └── columns: t.a:1(int!null) t.b:2(int) t.c:3(bool)
  └── projections [outer=(1,2)]
       ├── variable: t.b [type=int, outer=(2)]
@@ -218,7 +218,7 @@ project
  ├── sort
  │    ├── columns: t.a:1(int!null) t.b:2(int) t.c:3(bool)
  │    ├── ordering: -1,-2
- │    └── scan
+ │    └── scan t
  │         └── columns: t.a:1(int!null) t.b:2(int) t.c:3(bool)
  └── projections [outer=(1,2)]
       ├── variable: t.b [type=int, outer=(2)]
@@ -234,7 +234,7 @@ project
  ├── sort
  │    ├── columns: t.a:1(int!null) t.b:2(int) t.c:3(bool)
  │    ├── ordering: +3
- │    └── scan
+ │    └── scan t
  │         └── columns: t.a:1(int!null) t.b:2(int) t.c:3(bool)
  └── projections [outer=(1-3)]
       ├── variable: t.a [type=int, outer=(1)]
@@ -248,7 +248,7 @@ SELECT * FROM t ORDER BY (b, t.*)
 sort
  ├── columns: a:1(int!null) b:2(int) c:3(bool)
  ├── ordering: +2,+1,+2,+3
- └── scan
+ └── scan t
       └── columns: t.a:1(int!null) t.b:2(int) t.c:3(bool)
 
 build
@@ -257,7 +257,7 @@ SELECT * FROM t ORDER BY (b, a), c
 sort
  ├── columns: a:1(int!null) b:2(int) c:3(bool)
  ├── ordering: +2,+1,+3
- └── scan
+ └── scan t
       └── columns: t.a:1(int!null) t.b:2(int) t.c:3(bool)
 
 build
@@ -266,7 +266,7 @@ SELECT * FROM t ORDER BY b, (a, c)
 sort
  ├── columns: a:1(int!null) b:2(int) c:3(bool)
  ├── ordering: +2,+1,+3
- └── scan
+ └── scan t
       └── columns: t.a:1(int!null) t.b:2(int) t.c:3(bool)
 
 build
@@ -275,7 +275,7 @@ SELECT * FROM t ORDER BY (b, (a, c))
 sort
  ├── columns: a:1(int!null) b:2(int) c:3(bool)
  ├── ordering: +2,+1,+3
- └── scan
+ └── scan t
       └── columns: t.a:1(int!null) t.b:2(int) t.c:3(bool)
 
 build
@@ -290,7 +290,7 @@ project
  │    ├── sort
  │    │    ├── columns: t.a:1(int!null) t.b:2(int) t.c:3(bool)
  │    │    ├── ordering: +2,+1
- │    │    └── scan
+ │    │    └── scan t
  │    │         └── columns: t.a:1(int!null) t.b:2(int) t.c:3(bool)
  │    └── eq [type=bool, outer=(2)]
  │         ├── variable: t.b [type=int, outer=(2)]
@@ -308,7 +308,7 @@ project
  ├── sort
  │    ├── columns: t.a:1(int!null) t.b:2(int) t.c:3(bool)
  │    ├── ordering: +2,-1
- │    └── scan
+ │    └── scan t
  │         └── columns: t.a:1(int!null) t.b:2(int) t.c:3(bool)
  └── projections [outer=(1,2)]
       ├── variable: t.a [type=int, outer=(1)]
@@ -324,7 +324,7 @@ sort
       ├── columns: t.a:1(int!null) t.b:2(int) ab:4(int)
       ├── select
       │    ├── columns: t.a:1(int!null) t.b:2(int) t.c:3(bool)
-      │    ├── scan
+      │    ├── scan t
       │    │    └── columns: t.a:1(int!null) t.b:2(int) t.c:3(bool)
       │    └── eq [type=bool, outer=(2)]
       │         ├── variable: t.b [type=int, outer=(2)]
@@ -344,7 +344,7 @@ sort
  ├── ordering: -4,+1
  └── project
       ├── columns: t.a:1(int!null) column4:4(int)
-      ├── scan
+      ├── scan t
       │    └── columns: t.a:1(int!null) t.b:2(int) t.c:3(bool)
       └── projections [outer=(1,2)]
            ├── variable: t.a [type=int, outer=(1)]
@@ -358,7 +358,7 @@ SELECT a FROM t ORDER BY (((a)))
 project
  ├── columns: a:1(int!null)
  ├── ordering: +1
- ├── scan
+ ├── scan t
  │    ├── columns: t.a:1(int!null) t.b:2(int) t.c:3(bool)
  │    └── ordering: +1
  └── projections [outer=(1)]
@@ -373,7 +373,7 @@ project
  ├── sort
  │    ├── columns: t.a:1(int!null) t.b:2(int) t.c:3(bool)
  │    ├── ordering: -1
- │    └── scan
+ │    └── scan t
  │         └── columns: t.a:1(int!null) t.b:2(int) t.c:3(bool)
  └── projections [outer=(1)]
       └── variable: t.a [type=int, outer=(1)]
@@ -387,7 +387,7 @@ project
  ├── sort
  │    ├── columns: t.a:1(int!null) t.b:2(int) t.c:3(bool)
  │    ├── ordering: -1
- │    └── scan
+ │    └── scan t
  │         └── columns: t.a:1(int!null) t.b:2(int) t.c:3(bool)
  └── projections [outer=(1)]
       └── variable: t.a [type=int, outer=(1)]
@@ -479,7 +479,7 @@ sort
  ├── ordering: +4
  └── project
       ├── columns: t.a:1(int!null) t.b:2(int) t.c:3(bool) column4:4(int)
-      ├── scan
+      ├── scan t
       │    └── columns: t.a:1(int!null) t.b:2(int) t.c:3(bool)
       └── projections [outer=(1-3)]
            ├── variable: t.a [type=int, outer=(1)]
@@ -495,7 +495,7 @@ sort
  ├── ordering: +4
  └── project
       ├── columns: column4:4(int) t.a:1(int!null) t.b:2(int) t.c:3(bool)
-      ├── scan
+      ├── scan t
       │    └── columns: t.a:1(int!null) t.b:2(int) t.c:3(bool)
       └── projections [outer=(1-3)]
            ├── const: 1 [type=int]
@@ -511,7 +511,7 @@ sort
  ├── ordering: +4
  └── project
       ├── columns: t.a:1(int!null) t.b:2(int) t.c:3(bool) column4:4(int)
-      ├── scan
+      ├── scan t
       │    └── columns: t.a:1(int!null) t.b:2(int) t.c:3(bool)
       └── projections [outer=(1-3)]
            ├── variable: t.a [type=int, outer=(1)]
@@ -529,7 +529,7 @@ sort
  ├── ordering: +5
  └── project
       ├── columns: column4:4(int) column5:5(int)
-      ├── scan
+      ├── scan t
       │    └── columns: t.a:1(int!null) t.b:2(int) t.c:3(bool)
       └── projections [outer=(2)]
            ├── plus [type=int, outer=(2)]
@@ -548,7 +548,7 @@ sort
  ├── ordering: +4
  └── project
       ├── columns: y:4(int)
-      ├── scan
+      ├── scan t
       │    └── columns: t.a:1(int!null) t.b:2(int) t.c:3(bool)
       └── projections [outer=(2)]
            └── plus [type=int, outer=(2)]
@@ -564,7 +564,7 @@ sort
  ├── ordering: +5
  └── project
       ├── columns: y:4(int) column5:5(int)
-      ├── scan
+      ├── scan t
       │    └── columns: t.a:1(int!null) t.b:2(int) t.c:3(bool)
       └── projections [outer=(2)]
            ├── plus [type=int, outer=(2)]
@@ -592,7 +592,7 @@ SELECT * FROM bar ORDER BY baz, id
 sort
  ├── columns: id:1(int!null) baz:2(string)
  ├── ordering: +2,+1
- └── scan
+ └── scan bar
       └── columns: bar.id:1(int!null) bar.baz:2(string)
 
 exec-ddl
@@ -624,7 +624,7 @@ SELECT a+b FROM (SELECT * FROM abcd ORDER BY d)
 ----
 project
  ├── columns: column5:5(int)
- ├── scan
+ ├── scan abcd
  │    └── columns: abcd.a:1(int!null) abcd.b:2(int) abcd.c:3(int) abcd.d:4(int)
  └── projections [outer=(1,2)]
       └── plus [type=int, outer=(1,2)]
@@ -636,7 +636,7 @@ SELECT b+d FROM (SELECT * FROM abcd ORDER BY a,d)
 ----
 project
  ├── columns: column5:5(int)
- ├── scan
+ ├── scan abcd
  │    └── columns: abcd.a:1(int!null) abcd.b:2(int) abcd.c:3(int) abcd.d:4(int)
  └── projections [outer=(2,4)]
       └── plus [type=int, outer=(2,4)]
@@ -684,7 +684,7 @@ SELECT block_id,writer_id,block_num,block_id FROM blocks ORDER BY block_id, writ
 project
  ├── columns: block_id:1(int!null) writer_id:2(string!null) block_num:3(int!null) block_id:1(int!null)
  ├── ordering: +1,+2,+3
- ├── scan
+ ├── scan blocks
  │    ├── columns: blocks.block_id:1(int!null) blocks.writer_id:2(string!null) blocks.block_num:3(int!null) blocks.raw_bytes:4(bytes)
  │    └── ordering: +1,+2,+3
  └── projections [outer=(1-3)]
@@ -718,7 +718,7 @@ project
  ├── sort
  │    ├── columns: abcd.a:1(int!null) abcd.b:2(int) abcd.c:3(int) abcd.d:4(int)
  │    ├── ordering: +2,+3
- │    └── scan
+ │    └── scan abcd
  │         └── columns: abcd.a:1(int!null) abcd.b:2(int) abcd.c:3(int) abcd.d:4(int)
  └── projections [outer=(1-3)]
       ├── variable: abcd.a [type=int, outer=(1)]
@@ -734,7 +734,7 @@ project
  ├── sort
  │    ├── columns: abcd.a:1(int!null) abcd.b:2(int) abcd.c:3(int) abcd.d:4(int)
  │    ├── ordering: +2,+3
- │    └── scan
+ │    └── scan abcd
  │         └── columns: abcd.a:1(int!null) abcd.b:2(int) abcd.c:3(int) abcd.d:4(int)
  └── projections [outer=(1-3)]
       ├── variable: abcd.a [type=int, outer=(1)]
@@ -750,7 +750,7 @@ project
  ├── sort
  │    ├── columns: abcd.a:1(int!null) abcd.b:2(int) abcd.c:3(int) abcd.d:4(int)
  │    ├── ordering: +1,+2,+3
- │    └── scan
+ │    └── scan abcd
  │         └── columns: abcd.a:1(int!null) abcd.b:2(int) abcd.c:3(int) abcd.d:4(int)
  └── projections [outer=(1-3)]
       ├── variable: abcd.a [type=int, outer=(1)]

--- a/pkg/sql/opt/optbuilder/testdata/project
+++ b/pkg/sql/opt/optbuilder/testdata/project
@@ -32,7 +32,7 @@ SELECT a.x FROM t.a
 ----
 project
  ├── columns: x:1(int!null)
- ├── scan
+ ├── scan a
  │    └── columns: a.x:1(int!null) a.y:2(float)
  └── projections [outer=(1)]
       └── variable: a.x [type=int, outer=(1)]
@@ -40,7 +40,7 @@ project
 build
 SELECT a.x, a.y FROM t.a
 ----
-scan
+scan a
  └── columns: x:1(int!null) y:2(float)
 
 build
@@ -48,7 +48,7 @@ SELECT a.y, a.x FROM t.a
 ----
 project
  ├── columns: y:2(float) x:1(int!null)
- ├── scan
+ ├── scan a
  │    └── columns: a.x:1(int!null) a.y:2(float)
  └── projections [outer=(1,2)]
       ├── variable: a.y [type=float, outer=(2)]
@@ -57,7 +57,7 @@ project
 build
 SELECT * FROM t.a
 ----
-scan
+scan a
  └── columns: x:1(int!null) y:2(float)
 
 # Note that an explicit projection operator is added for table b (unlike for
@@ -67,7 +67,7 @@ SELECT * FROM t.b
 ----
 project
  ├── columns: x:1(int) y:2(float)
- ├── scan
+ ├── scan b
  │    └── columns: b.x:1(int) b.y:2(float) b.rowid:3(int!null)
  └── projections [outer=(1,2)]
       ├── variable: b.x [type=int, outer=(1)]
@@ -78,7 +78,7 @@ SELECT (a.x + 3) AS "X", false AS "Y" FROM t.a
 ----
 project
  ├── columns: X:3(int) Y:4(bool)
- ├── scan
+ ├── scan a
  │    └── columns: a.x:1(int!null) a.y:2(float)
  └── projections [outer=(1)]
       ├── plus [type=int, outer=(1)]
@@ -91,7 +91,7 @@ SELECT *, ((x < y) OR x > 1000) FROM t.a
 ----
 project
  ├── columns: x:1(int!null) y:2(float) column3:3(bool)
- ├── scan
+ ├── scan a
  │    └── columns: a.x:1(int!null) a.y:2(float)
  └── projections [outer=(1,2)]
       ├── variable: a.x [type=int, outer=(1)]
@@ -109,7 +109,7 @@ SELECT a.*, true FROM t.a
 ----
 project
  ├── columns: x:1(int!null) y:2(float) column3:3(bool)
- ├── scan
+ ├── scan a
  │    └── columns: a.x:1(int!null) a.y:2(float)
  └── projections [outer=(1,2)]
       ├── variable: a.x [type=int, outer=(1)]
@@ -123,7 +123,7 @@ project
  ├── columns: column5:5(int) column6:6(float)
  ├── project
  │    ├── columns: column3:3(int) column4:4(float)
- │    ├── scan
+ │    ├── scan a
  │    │    └── columns: a.x:1(int!null) a.y:2(float)
  │    └── projections [outer=(1,2)]
  │         ├── plus [type=int, outer=(1)]
@@ -145,7 +145,7 @@ SELECT rowid FROM b;
 ----
 project
  ├── columns: rowid:3(int!null)
- ├── scan
+ ├── scan b
  │    └── columns: b.x:1(int) b.y:2(float) b.rowid:3(int!null)
  └── projections [outer=(3)]
       └── variable: b.rowid [type=int, outer=(3)]
@@ -160,7 +160,7 @@ SELECT rowid FROM (SELECT rowid FROM b)
 ----
 project
  ├── columns: rowid:3(int!null)
- ├── scan
+ ├── scan b
  │    └── columns: b.x:1(int) b.y:2(float) b.rowid:3(int!null)
  └── projections [outer=(3)]
       └── variable: b.rowid [type=int, outer=(3)]
@@ -170,7 +170,7 @@ SELECT q.r FROM (SELECT rowid FROM b) AS q(r)
 ----
 project
  ├── columns: r:3(int!null)
- ├── scan
+ ├── scan b
  │    └── columns: b.x:1(int) b.y:2(float) b.rowid:3(int!null)
  └── projections [outer=(3)]
       └── variable: b.rowid [type=int, outer=(3)]
@@ -180,7 +180,7 @@ SELECT r FROM (SELECT rowid FROM b) AS q(r)
 ----
 project
  ├── columns: r:3(int!null)
- ├── scan
+ ├── scan b
  │    └── columns: b.x:1(int) b.y:2(float) b.rowid:3(int!null)
  └── projections [outer=(3)]
       └── variable: b.rowid [type=int, outer=(3)]
@@ -205,7 +205,7 @@ SELECT rowid::string FROM b
 ----
 project
  ├── columns: column4:4(string)
- ├── scan
+ ├── scan b
  │    └── columns: b.x:1(int) b.y:2(float) b.rowid:3(int!null)
  └── projections [outer=(3)]
       └── cast: string [type=string, outer=(3)]

--- a/pkg/sql/opt/optbuilder/testdata/select
+++ b/pkg/sql/opt/optbuilder/testdata/select
@@ -53,7 +53,7 @@ error: could not parse "hello" as type bool: invalid bool value
 build
 SELECT * FROM abc
 ----
-scan
+scan abc
  └── columns: a:1(int!null) b:2(int) c:3(int)
 
 build
@@ -61,7 +61,7 @@ SELECT NULL, * FROM abc
 ----
 project
  ├── columns: column4:4(unknown) a:1(int!null) b:2(int) c:3(int)
- ├── scan
+ ├── scan abc
  │    └── columns: abc.a:1(int!null) abc.b:2(int) abc.c:3(int)
  └── projections [outer=(1-3)]
       ├── null [type=unknown]
@@ -74,7 +74,7 @@ project
 build
 TABLE abc
 ----
-scan
+scan abc
  └── columns: a:1(int!null) b:2(int) c:3(int)
 
 build
@@ -82,7 +82,7 @@ SELECT * FROM abc WHERE NULL
 ----
 select
  ├── columns: a:1(int!null) b:2(int) c:3(int)
- ├── scan
+ ├── scan abc
  │    └── columns: abc.a:1(int!null) abc.b:2(int) abc.c:3(int)
  └── null [type=unknown]
 
@@ -91,7 +91,7 @@ SELECT * FROM abc WHERE a = NULL
 ----
 select
  ├── columns: a:1(int!null) b:2(int) c:3(int)
- ├── scan
+ ├── scan abc
  │    └── columns: abc.a:1(int!null) abc.b:2(int) abc.c:3(int)
  └── null [type=unknown]
 
@@ -100,7 +100,7 @@ SELECT *,* FROM abc
 ----
 project
  ├── columns: a:1(int!null) b:2(int) c:3(int) a:1(int!null) b:2(int) c:3(int)
- ├── scan
+ ├── scan abc
  │    └── columns: abc.a:1(int!null) abc.b:2(int) abc.c:3(int)
  └── projections [outer=(1-3)]
       ├── variable: abc.a [type=int, outer=(1)]
@@ -115,7 +115,7 @@ SELECT a,a,a,a FROM abc
 ----
 project
  ├── columns: a:1(int!null) a:1(int!null) a:1(int!null) a:1(int!null)
- ├── scan
+ ├── scan abc
  │    └── columns: abc.a:1(int!null) abc.b:2(int) abc.c:3(int)
  └── projections [outer=(1)]
       ├── variable: abc.a [type=int, outer=(1)]
@@ -128,7 +128,7 @@ SELECT a,c FROM abc
 ----
 project
  ├── columns: a:1(int!null) c:3(int)
- ├── scan
+ ├── scan abc
  │    └── columns: abc.a:1(int!null) abc.b:2(int) abc.c:3(int)
  └── projections [outer=(1,3)]
       ├── variable: abc.a [type=int, outer=(1)]
@@ -139,7 +139,7 @@ SELECT a+b+c AS foo FROM abc
 ----
 project
  ├── columns: foo:4(int)
- ├── scan
+ ├── scan abc
  │    └── columns: abc.a:1(int!null) abc.b:2(int) abc.c:3(int)
  └── projections [outer=(1-3)]
       └── plus [type=int, outer=(1-3)]
@@ -155,7 +155,7 @@ project
  ├── columns: a:1(int!null) b:2(int)
  ├── select
  │    ├── columns: abc.a:1(int!null) abc.b:2(int) abc.c:3(int)
- │    ├── scan
+ │    ├── scan abc
  │    │    └── columns: abc.a:1(int!null) abc.b:2(int) abc.c:3(int)
  │    └── case [type=bool, outer=(1,2)]
  │         ├── true [type=bool]
@@ -187,13 +187,13 @@ TABLE kv
 build
 SELECT * FROM kv
 ----
-scan
+scan kv
  └── columns: k:1(string!null) v:2(string)
 
 build
 SELECT k,v FROM kv
 ----
-scan
+scan kv
  └── columns: k:1(string!null) v:2(string)
 
 build
@@ -201,7 +201,7 @@ SELECT v||'foo' FROM kv
 ----
 project
  ├── columns: column3:3(string)
- ├── scan
+ ├── scan kv
  │    └── columns: kv.k:1(string!null) kv.v:2(string)
  └── projections [outer=(2)]
       └── concat [type=string, outer=(2)]
@@ -213,7 +213,7 @@ SELECT LOWER(v) FROM kv
 ----
 project
  ├── columns: column3:3(string)
- ├── scan
+ ├── scan kv
  │    └── columns: kv.k:1(string!null) kv.v:2(string)
  └── projections [outer=(2)]
       └── function: lower [type=string, outer=(2)]
@@ -224,7 +224,7 @@ SELECT k FROM kv
 ----
 project
  ├── columns: k:1(string!null)
- ├── scan
+ ├── scan kv
  │    └── columns: kv.k:1(string!null) kv.v:2(string)
  └── projections [outer=(1)]
       └── variable: kv.k [type=string, outer=(1)]
@@ -232,13 +232,13 @@ project
 build
 SELECT kv.K,KV.v FROM kv
 ----
-scan
+scan kv
  └── columns: k:1(string!null) v:2(string)
 
 build
 SELECT kv.* FROM kv
 ----
-scan
+scan kv
  └── columns: k:1(string!null) v:2(string)
 
 build
@@ -246,7 +246,7 @@ SELECT (kv.*) FROM kv
 ----
 project
  ├── columns: column3:3(tuple{string, string})
- ├── scan
+ ├── scan kv
  │    └── columns: kv.k:1(string!null) kv.v:2(string)
  └── projections [outer=(1,2)]
       └── tuple [type=tuple{string, string}, outer=(1,2)]
@@ -286,7 +286,7 @@ project
  ├── columns: k:1(string!null)
  ├── select
  │    ├── columns: kv.k:1(string!null) kv.v:2(string)
- │    ├── scan
+ │    ├── scan kv
  │    │    └── columns: kv.k:1(string!null) kv.v:2(string)
  │    └── eq [type=bool, outer=(1)]
  │         ├── variable: kv.k [type=string, outer=(1)]
@@ -301,7 +301,7 @@ project
  ├── columns: v:2(string)
  ├── select
  │    ├── columns: kv.k:1(string!null) kv.v:2(string)
- │    ├── scan
+ │    ├── scan kv
  │    │    └── columns: kv.k:1(string!null) kv.v:2(string)
  │    └── eq [type=bool, outer=(1)]
  │         ├── variable: kv.k [type=string, outer=(1)]
@@ -322,7 +322,7 @@ SELECT *, "from", kw."from" FROM kw
 ----
 project
  ├── columns: from:1(int!null) from:1(int!null) from:1(int!null)
- ├── scan
+ ├── scan kw
  │    └── columns: kw.from:1(int!null)
  └── projections [outer=(1)]
       ├── variable: kw.from [type=int, outer=(1)]
@@ -353,14 +353,14 @@ TABLE xyzw
 build
 SELECT * FROM xyzw ORDER BY 1
 ----
-scan
+scan xyzw
  ├── columns: x:1(int!null) y:2(int) z:3(int) w:4(int)
  └── ordering: +1
 
 build
 SELECT * FROM xyzw ORDER BY x
 ----
-scan
+scan xyzw
  ├── columns: x:1(int!null) y:2(int) z:3(int) w:4(int)
  └── ordering: +1
 
@@ -370,7 +370,7 @@ SELECT * FROM xyzw ORDER BY y
 sort
  ├── columns: x:1(int!null) y:2(int) z:3(int) w:4(int)
  ├── ordering: +2
- └── scan
+ └── scan xyzw
       └── columns: xyzw.x:1(int!null) xyzw.y:2(int) xyzw.z:3(int) xyzw.w:4(int)
 
 exec-ddl
@@ -390,7 +390,7 @@ SELECT value FROM boolean_table
 ----
 project
  ├── columns: value:2(bool)
- ├── scan
+ ├── scan boolean_table
  │    └── columns: boolean_table.id:1(int!null) boolean_table.value:2(bool)
  └── projections [outer=(2)]
       └── variable: boolean_table.value [type=bool, outer=(2)]
@@ -415,7 +415,7 @@ SELECT 0 * b, b % 1, 0 % b from abc
 ----
 project
  ├── columns: column4:4(int) column5:5(int) column6:6(int)
- ├── scan
+ ├── scan abc
  │    └── columns: abc.a:1(int!null) abc.b:2(int) abc.c:3(int)
  └── projections [outer=(2)]
       ├── mult [type=int, outer=(2)]
@@ -500,7 +500,7 @@ TABLE a
 build
 SELECT * FROM t.a
 ----
-scan
+scan a
  └── columns: x:1(int!null) y:2(float)
 
 build
@@ -508,7 +508,7 @@ SELECT * FROM t.a WHERE x > 10
 ----
 select
  ├── columns: x:1(int!null) y:2(float)
- ├── scan
+ ├── scan a
  │    └── columns: a.x:1(int!null) a.y:2(float)
  └── gt [type=bool, outer=(1)]
       ├── variable: a.x [type=int, outer=(1)]
@@ -519,7 +519,7 @@ SELECT * FROM t.a WHERE (x > 10 AND (x < 20 AND x != 13))
 ----
 select
  ├── columns: x:1(int!null) y:2(float)
- ├── scan
+ ├── scan a
  │    └── columns: a.x:1(int!null) a.y:2(float)
  └── and [type=bool, outer=(1)]
       ├── gt [type=bool, outer=(1)]
@@ -538,7 +538,7 @@ SELECT * FROM t.a WHERE x IN (1, 2, 3)
 ----
 select
  ├── columns: x:1(int!null) y:2(float)
- ├── scan
+ ├── scan a
  │    └── columns: a.x:1(int!null) a.y:2(float)
  └── in [type=bool, outer=(1)]
       ├── variable: a.x [type=int, outer=(1)]
@@ -550,7 +550,7 @@ select
 build
 SELECT * FROM t.a AS A(X, Y)
 ----
-scan
+scan a
  └── columns: x:1(int!null) y:2(float)
 
 build
@@ -558,7 +558,7 @@ SELECT @1, @2 FROM t.a
 ----
 project
  ├── columns: column3:3(int) column4:4(float)
- ├── scan
+ ├── scan a
  │    └── columns: a.x:1(int!null) a.y:2(float)
  └── projections [outer=(1,2)]
       ├── variable: a.x [type=int, outer=(1)]
@@ -569,7 +569,7 @@ SELECT * FROM t.a WHERE (x > 10)::bool
 ----
 select
  ├── columns: x:1(int!null) y:2(float)
- ├── scan
+ ├── scan a
  │    └── columns: a.x:1(int!null) a.y:2(float)
  └── cast: bool [type=bool, outer=(1)]
       └── gt [type=bool, outer=(1)]

--- a/pkg/sql/opt/optbuilder/testdata/union
+++ b/pkg/sql/opt/optbuilder/testdata/union
@@ -383,7 +383,7 @@ union
  │    ├── columns: uniontest.v:2(int)
  │    ├── select
  │    │    ├── columns: uniontest.k:1(int) uniontest.v:2(int) uniontest.rowid:3(int!null)
- │    │    ├── scan
+ │    │    ├── scan uniontest
  │    │    │    └── columns: uniontest.k:1(int) uniontest.v:2(int) uniontest.rowid:3(int!null)
  │    │    └── eq [type=bool, outer=(1)]
  │    │         ├── variable: uniontest.k [type=int, outer=(1)]
@@ -394,7 +394,7 @@ union
       ├── columns: uniontest.v:5(int)
       ├── select
       │    ├── columns: uniontest.k:4(int) uniontest.v:5(int) uniontest.rowid:6(int!null)
-      │    ├── scan
+      │    ├── scan uniontest
       │    │    └── columns: uniontest.k:4(int) uniontest.v:5(int) uniontest.rowid:6(int!null)
       │    └── eq [type=bool, outer=(4)]
       │         ├── variable: uniontest.k [type=int, outer=(4)]
@@ -413,7 +413,7 @@ union-all
  │    ├── columns: uniontest.v:2(int)
  │    ├── select
  │    │    ├── columns: uniontest.k:1(int) uniontest.v:2(int) uniontest.rowid:3(int!null)
- │    │    ├── scan
+ │    │    ├── scan uniontest
  │    │    │    └── columns: uniontest.k:1(int) uniontest.v:2(int) uniontest.rowid:3(int!null)
  │    │    └── eq [type=bool, outer=(1)]
  │    │         ├── variable: uniontest.k [type=int, outer=(1)]
@@ -424,7 +424,7 @@ union-all
       ├── columns: uniontest.v:5(int)
       ├── select
       │    ├── columns: uniontest.k:4(int) uniontest.v:5(int) uniontest.rowid:6(int!null)
-      │    ├── scan
+      │    ├── scan uniontest
       │    │    └── columns: uniontest.k:4(int) uniontest.v:5(int) uniontest.rowid:6(int!null)
       │    └── eq [type=bool, outer=(4)]
       │         ├── variable: uniontest.k [type=int, outer=(4)]
@@ -443,7 +443,7 @@ intersect
  │    ├── columns: uniontest.v:2(int)
  │    ├── select
  │    │    ├── columns: uniontest.k:1(int) uniontest.v:2(int) uniontest.rowid:3(int!null)
- │    │    ├── scan
+ │    │    ├── scan uniontest
  │    │    │    └── columns: uniontest.k:1(int) uniontest.v:2(int) uniontest.rowid:3(int!null)
  │    │    └── eq [type=bool, outer=(1)]
  │    │         ├── variable: uniontest.k [type=int, outer=(1)]
@@ -454,7 +454,7 @@ intersect
       ├── columns: uniontest.v:5(int)
       ├── select
       │    ├── columns: uniontest.k:4(int) uniontest.v:5(int) uniontest.rowid:6(int!null)
-      │    ├── scan
+      │    ├── scan uniontest
       │    │    └── columns: uniontest.k:4(int) uniontest.v:5(int) uniontest.rowid:6(int!null)
       │    └── eq [type=bool, outer=(4)]
       │         ├── variable: uniontest.k [type=int, outer=(4)]
@@ -473,7 +473,7 @@ intersect-all
  │    ├── columns: uniontest.v:2(int)
  │    ├── select
  │    │    ├── columns: uniontest.k:1(int) uniontest.v:2(int) uniontest.rowid:3(int!null)
- │    │    ├── scan
+ │    │    ├── scan uniontest
  │    │    │    └── columns: uniontest.k:1(int) uniontest.v:2(int) uniontest.rowid:3(int!null)
  │    │    └── eq [type=bool, outer=(1)]
  │    │         ├── variable: uniontest.k [type=int, outer=(1)]
@@ -484,7 +484,7 @@ intersect-all
       ├── columns: uniontest.v:5(int)
       ├── select
       │    ├── columns: uniontest.k:4(int) uniontest.v:5(int) uniontest.rowid:6(int!null)
-      │    ├── scan
+      │    ├── scan uniontest
       │    │    └── columns: uniontest.k:4(int) uniontest.v:5(int) uniontest.rowid:6(int!null)
       │    └── eq [type=bool, outer=(4)]
       │         ├── variable: uniontest.k [type=int, outer=(4)]
@@ -503,7 +503,7 @@ except
  │    ├── columns: uniontest.v:2(int)
  │    ├── select
  │    │    ├── columns: uniontest.k:1(int) uniontest.v:2(int) uniontest.rowid:3(int!null)
- │    │    ├── scan
+ │    │    ├── scan uniontest
  │    │    │    └── columns: uniontest.k:1(int) uniontest.v:2(int) uniontest.rowid:3(int!null)
  │    │    └── eq [type=bool, outer=(1)]
  │    │         ├── variable: uniontest.k [type=int, outer=(1)]
@@ -514,7 +514,7 @@ except
       ├── columns: uniontest.v:5(int)
       ├── select
       │    ├── columns: uniontest.k:4(int) uniontest.v:5(int) uniontest.rowid:6(int!null)
-      │    ├── scan
+      │    ├── scan uniontest
       │    │    └── columns: uniontest.k:4(int) uniontest.v:5(int) uniontest.rowid:6(int!null)
       │    └── eq [type=bool, outer=(4)]
       │         ├── variable: uniontest.k [type=int, outer=(4)]
@@ -533,7 +533,7 @@ except-all
  │    ├── columns: uniontest.v:2(int)
  │    ├── select
  │    │    ├── columns: uniontest.k:1(int) uniontest.v:2(int) uniontest.rowid:3(int!null)
- │    │    ├── scan
+ │    │    ├── scan uniontest
  │    │    │    └── columns: uniontest.k:1(int) uniontest.v:2(int) uniontest.rowid:3(int!null)
  │    │    └── eq [type=bool, outer=(1)]
  │    │         ├── variable: uniontest.k [type=int, outer=(1)]
@@ -544,7 +544,7 @@ except-all
       ├── columns: uniontest.v:5(int)
       ├── select
       │    ├── columns: uniontest.k:4(int) uniontest.v:5(int) uniontest.rowid:6(int!null)
-      │    ├── scan
+      │    ├── scan uniontest
       │    │    └── columns: uniontest.k:4(int) uniontest.v:5(int) uniontest.rowid:6(int!null)
       │    └── eq [type=bool, outer=(4)]
       │         ├── variable: uniontest.k [type=int, outer=(4)]
@@ -566,7 +566,7 @@ sort
       │    ├── columns: uniontest.v:2(int)
       │    ├── select
       │    │    ├── columns: uniontest.k:1(int) uniontest.v:2(int) uniontest.rowid:3(int!null)
-      │    │    ├── scan
+      │    │    ├── scan uniontest
       │    │    │    └── columns: uniontest.k:1(int) uniontest.v:2(int) uniontest.rowid:3(int!null)
       │    │    └── eq [type=bool, outer=(1)]
       │    │         ├── variable: uniontest.k [type=int, outer=(1)]
@@ -577,7 +577,7 @@ sort
            ├── columns: uniontest.v:5(int)
            ├── select
            │    ├── columns: uniontest.k:4(int) uniontest.v:5(int) uniontest.rowid:6(int!null)
-           │    ├── scan
+           │    ├── scan uniontest
            │    │    └── columns: uniontest.k:4(int) uniontest.v:5(int) uniontest.rowid:6(int!null)
            │    └── eq [type=bool, outer=(4)]
            │         ├── variable: uniontest.k [type=int, outer=(4)]
@@ -600,7 +600,7 @@ sort
       │    ├── columns: uniontest.v:2(int)
       │    ├── select
       │    │    ├── columns: uniontest.k:1(int) uniontest.v:2(int) uniontest.rowid:3(int!null)
-      │    │    ├── scan
+      │    │    ├── scan uniontest
       │    │    │    └── columns: uniontest.k:1(int) uniontest.v:2(int) uniontest.rowid:3(int!null)
       │    │    └── eq [type=bool, outer=(1)]
       │    │         ├── variable: uniontest.k [type=int, outer=(1)]
@@ -611,7 +611,7 @@ sort
            ├── columns: uniontest.v:5(int)
            ├── select
            │    ├── columns: uniontest.k:4(int) uniontest.v:5(int) uniontest.rowid:6(int!null)
-           │    ├── scan
+           │    ├── scan uniontest
            │    │    └── columns: uniontest.k:4(int) uniontest.v:5(int) uniontest.rowid:6(int!null)
            │    └── eq [type=bool, outer=(4)]
            │         ├── variable: uniontest.k [type=int, outer=(4)]
@@ -628,13 +628,13 @@ union
  ├── right columns: uniontest.k:4(int)
  ├── project
  │    ├── columns: uniontest.v:2(int)
- │    ├── scan
+ │    ├── scan uniontest
  │    │    └── columns: uniontest.k:1(int) uniontest.v:2(int) uniontest.rowid:3(int!null)
  │    └── projections [outer=(2)]
  │         └── variable: uniontest.v [type=int, outer=(2)]
  └── project
       ├── columns: uniontest.k:4(int)
-      ├── scan
+      ├── scan uniontest
       │    └── columns: uniontest.k:4(int) uniontest.v:5(int) uniontest.rowid:6(int!null)
       └── projections [outer=(4)]
            └── variable: uniontest.k [type=int, outer=(4)]
@@ -648,13 +648,13 @@ union-all
  ├── right columns: uniontest.k:4(int)
  ├── project
  │    ├── columns: uniontest.v:2(int)
- │    ├── scan
+ │    ├── scan uniontest
  │    │    └── columns: uniontest.k:1(int) uniontest.v:2(int) uniontest.rowid:3(int!null)
  │    └── projections [outer=(2)]
  │         └── variable: uniontest.v [type=int, outer=(2)]
  └── project
       ├── columns: uniontest.k:4(int)
-      ├── scan
+      ├── scan uniontest
       │    └── columns: uniontest.k:4(int) uniontest.v:5(int) uniontest.rowid:6(int!null)
       └── projections [outer=(4)]
            └── variable: uniontest.k [type=int, outer=(4)]
@@ -784,7 +784,7 @@ union
  ├── right columns: abc.a:4(string) abc.b:5(string) abc.c:6(string)
  ├── project
  │    ├── columns: xy.x:1(string!null) xy.x:1(string!null) xy.y:2(string!null)
- │    ├── scan
+ │    ├── scan xy
  │    │    └── columns: xy.x:1(string!null) xy.y:2(string!null) xy.rowid:3(int!null)
  │    └── projections [outer=(1,2)]
  │         ├── variable: xy.x [type=string, outer=(1)]
@@ -792,7 +792,7 @@ union
  │         └── variable: xy.y [type=string, outer=(2)]
  └── project
       ├── columns: abc.a:4(string) abc.b:5(string!null) abc.c:6(string!null)
-      ├── scan
+      ├── scan abc
       │    └── columns: abc.a:4(string) abc.b:5(string!null) abc.c:6(string!null) abc.rowid:7(int!null)
       └── projections [outer=(4-6)]
            ├── variable: abc.a [type=string, outer=(4)]

--- a/pkg/sql/opt/optbuilder/testdata/where
+++ b/pkg/sql/opt/optbuilder/testdata/where
@@ -29,7 +29,7 @@ SELECT * FROM kv WHERE k IN (1, 3)
 ----
 select
  ├── columns: k:1(int!null) v:2(int)
- ├── scan
+ ├── scan kv
  │    └── columns: kv.k:1(int!null) kv.v:2(int)
  └── in [type=bool, outer=(1)]
       ├── variable: kv.k [type=int, outer=(1)]
@@ -42,7 +42,7 @@ SELECT * FROM kv WHERE v IN (6)
 ----
 select
  ├── columns: k:1(int!null) v:2(int)
- ├── scan
+ ├── scan kv
  │    └── columns: kv.k:1(int!null) kv.v:2(int)
  └── in [type=bool, outer=(2)]
       ├── variable: kv.v [type=int, outer=(2)]
@@ -72,7 +72,7 @@ project
  ├── select
  │    ├── columns: kvstring.k:1(string!null) kvstring.v:2(string)
  │    ├── ordering: +1
- │    ├── scan
+ │    ├── scan kvstring
  │    │    ├── columns: kvstring.k:1(string!null) kvstring.v:2(string)
  │    │    └── ordering: +1
  │    └── like [type=bool, outer=(1)]
@@ -93,7 +93,7 @@ project
  ├── select
  │    ├── columns: kvstring.k:1(string!null) kvstring.v:2(string)
  │    ├── ordering: +1
- │    ├── scan
+ │    ├── scan kvstring
  │    │    ├── columns: kvstring.k:1(string!null) kvstring.v:2(string)
  │    │    └── ordering: +1
  │    └── similar-to [type=bool, outer=(1)]
@@ -114,7 +114,7 @@ project
  ├── select
  │    ├── columns: kvstring.k:1(string!null) kvstring.v:2(string)
  │    ├── ordering: +1
- │    ├── scan
+ │    ├── scan kvstring
  │    │    ├── columns: kvstring.k:1(string!null) kvstring.v:2(string)
  │    │    └── ordering: +1
  │    └── reg-match [type=bool, outer=(1)]
@@ -136,7 +136,7 @@ SELECT * FROM kv WHERE k IN (1, 5.0, 9)
 ----
 select
  ├── columns: k:1(int!null) v:2(int)
- ├── scan
+ ├── scan kv
  │    └── columns: kv.k:1(int!null) kv.v:2(int)
  └── in [type=bool, outer=(1)]
       ├── variable: kv.k [type=int, outer=(1)]
@@ -163,7 +163,7 @@ project
  ├── columns: a:1(int) b:2(int)
  ├── select
  │    ├── columns: ab.a:1(int) ab.b:2(int) ab.rowid:3(int!null)
- │    ├── scan
+ │    ├── scan ab
  │    │    └── columns: ab.a:1(int) ab.b:2(int) ab.rowid:3(int!null)
  │    └── in [type=bool, outer=(1)]
  │         ├── variable: ab.a [type=int, outer=(1)]
@@ -182,7 +182,7 @@ project
  ├── columns: a:1(int) b:2(int)
  ├── select
  │    ├── columns: ab.a:1(int) ab.b:2(int) ab.rowid:3(int!null)
- │    ├── scan
+ │    ├── scan ab
  │    │    └── columns: ab.a:1(int) ab.b:2(int) ab.rowid:3(int!null)
  │    └── in [type=bool, outer=(1)]
  │         ├── variable: ab.a [type=int, outer=(1)]
@@ -202,7 +202,7 @@ project
  ├── columns: a:1(int) b:2(int)
  ├── select
  │    ├── columns: ab.a:1(int) ab.b:2(int) ab.rowid:3(int!null)
- │    ├── scan
+ │    ├── scan ab
  │    │    └── columns: ab.a:1(int) ab.b:2(int) ab.rowid:3(int!null)
  │    └── in [type=bool, outer=(1,2)]
  │         ├── tuple [type=tuple{int, int}, outer=(1,2)]
@@ -229,7 +229,7 @@ project
  ├── columns: a:1(int) b:2(int)
  ├── select
  │    ├── columns: ab.a:1(int) ab.b:2(int) ab.rowid:3(int!null)
- │    ├── scan
+ │    ├── scan ab
  │    │    └── columns: ab.a:1(int) ab.b:2(int) ab.rowid:3(int!null)
  │    └── in [type=bool, outer=(1,2)]
  │         ├── tuple [type=tuple{int, int}, outer=(1,2)]

--- a/pkg/sql/opt/xform/expr.go
+++ b/pkg/sql/opt/xform/expr.go
@@ -261,6 +261,12 @@ func (ev ExprView) formatRelational(tp treeprinter.Node) {
 
 	fmt.Fprintf(&buf, "%v", ev.op)
 
+	switch ev.Operator() {
+	case opt.ScanOp:
+		tblIndex := ev.Private().(*opt.ScanOpDef).Table
+		fmt.Fprintf(&buf, " %s", ev.Metadata().Table(tblIndex).TabName())
+	}
+
 	logProps := ev.Logical()
 	physProps := ev.Physical()
 

--- a/pkg/sql/opt/xform/testdata/logprops/groupby
+++ b/pkg/sql/opt/xform/testdata/logprops/groupby
@@ -16,7 +16,7 @@ project
  ├── group-by
  │    ├── columns: a.x:1(int!null) a.y:2(int) column4:4(float)
  │    ├── grouping columns: a.x:1(int!null) a.y:2(int)
- │    ├── scan
+ │    ├── scan a
  │    │    └── columns: a.x:1(int!null) a.y:2(int) a.z:3(float!null)
  │    └── aggregations [outer=(3)]
  │         └── function: sum [type=float, outer=(3)]

--- a/pkg/sql/opt/xform/testdata/logprops/join
+++ b/pkg/sql/opt/xform/testdata/logprops/join
@@ -22,9 +22,9 @@ SELECT *, rowid FROM a INNER JOIN b ON a.x=b.x
 ----
 inner-join
  ├── columns: x:1(int!null) y:2(int) x:3(int) z:4(int!null) rowid:5(int!null)
- ├── scan
+ ├── scan a
  │    └── columns: a.x:1(int!null) a.y:2(int)
- ├── scan
+ ├── scan b
  │    └── columns: b.x:3(int) b.z:4(int!null) b.rowid:5(int!null)
  └── eq [type=bool, outer=(1,3)]
       ├── variable: a.x [type=int, outer=(1)]
@@ -35,9 +35,9 @@ SELECT *, rowid FROM a LEFT JOIN b ON a.x=b.x
 ----
 left-join
  ├── columns: x:1(int!null) y:2(int) x:3(int) z:4(int) rowid:5(int)
- ├── scan
+ ├── scan a
  │    └── columns: a.x:1(int!null) a.y:2(int)
- ├── scan
+ ├── scan b
  │    └── columns: b.x:3(int) b.z:4(int!null) b.rowid:5(int!null)
  └── eq [type=bool, outer=(1,3)]
       ├── variable: a.x [type=int, outer=(1)]
@@ -48,9 +48,9 @@ SELECT *, rowid FROM a RIGHT JOIN b ON a.x=b.x
 ----
 right-join
  ├── columns: x:1(int) y:2(int) x:3(int) z:4(int!null) rowid:5(int!null)
- ├── scan
+ ├── scan a
  │    └── columns: a.x:1(int!null) a.y:2(int)
- ├── scan
+ ├── scan b
  │    └── columns: b.x:3(int) b.z:4(int!null) b.rowid:5(int!null)
  └── eq [type=bool, outer=(1,3)]
       ├── variable: a.x [type=int, outer=(1)]
@@ -61,9 +61,9 @@ SELECT *, rowid FROM a FULL JOIN b ON a.x=b.x
 ----
 full-join
  ├── columns: x:1(int) y:2(int) x:3(int) z:4(int) rowid:5(int)
- ├── scan
+ ├── scan a
  │    └── columns: a.x:1(int!null) a.y:2(int)
- ├── scan
+ ├── scan b
  │    └── columns: b.x:3(int) b.z:4(int!null) b.rowid:5(int!null)
  └── eq [type=bool, outer=(1,3)]
       ├── variable: a.x [type=int, outer=(1)]

--- a/pkg/sql/opt/xform/testdata/logprops/project
+++ b/pkg/sql/opt/xform/testdata/logprops/project
@@ -12,7 +12,7 @@ SELECT a.y, a.x+1, 1, a.x FROM a
 ----
 project
  ├── columns: y:2(int) column3:3(int) column4:4(int) x:1(int!null)
- ├── scan
+ ├── scan a
  │    └── columns: a.x:1(int!null) a.y:2(int)
  └── projections [outer=(1,2)]
       ├── variable: a.y [type=int, outer=(2)]

--- a/pkg/sql/opt/xform/testdata/logprops/scalar
+++ b/pkg/sql/opt/xform/testdata/logprops/scalar
@@ -22,7 +22,7 @@ SELECT * FROM a WHERE x < 5
 ----
 select
  ├── columns: x:1(int!null) y:2(int)
- ├── scan
+ ├── scan a
  │    └── columns: a.x:1(int!null) a.y:2(int)
  └── lt [type=bool, outer=(1)]
       ├── variable: a.x [type=int, outer=(1)]
@@ -35,9 +35,9 @@ project
  ├── columns: column6:6(bool) column7:7(int)
  ├── inner-join
  │    ├── columns: a.x:1(int!null) a.y:2(int) b.x:3(int) b.z:4(int!null) b.rowid:5(int!null)
- │    ├── scan
+ │    ├── scan a
  │    │    └── columns: a.x:1(int!null) a.y:2(int)
- │    ├── scan
+ │    ├── scan b
  │    │    └── columns: b.x:3(int) b.z:4(int!null) b.rowid:5(int!null)
  │    └── true [type=bool]
  └── projections [outer=(1,2,5)]

--- a/pkg/sql/opt/xform/testdata/logprops/scan
+++ b/pkg/sql/opt/xform/testdata/logprops/scan
@@ -22,7 +22,7 @@ TABLE b
 build
 SELECT * FROM a
 ----
-scan
+scan a
  └── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null)
 
 build
@@ -30,7 +30,7 @@ SELECT * FROM b
 ----
 project
  ├── columns: x:1(int) z:2(int!null)
- ├── scan
+ ├── scan b
  │    └── columns: b.x:1(int) b.z:2(int!null) b.rowid:3(int!null)
  └── projections [outer=(1,2)]
       ├── variable: b.x [type=int, outer=(1)]
@@ -40,5 +40,5 @@ project
 opt
 SELECT s, x FROM a
 ----
-scan
+scan a
  └── columns: s:3(string) x:1(int!null)

--- a/pkg/sql/opt/xform/testdata/logprops/select
+++ b/pkg/sql/opt/xform/testdata/logprops/select
@@ -22,7 +22,7 @@ SELECT * FROM a WHERE x=1
 ----
 select
  ├── columns: x:1(int!null) y:2(int)
- ├── scan
+ ├── scan a
  │    └── columns: a.x:1(int!null) a.y:2(int)
  └── eq [type=bool, outer=(1)]
       ├── variable: a.x [type=int, outer=(1)]
@@ -37,9 +37,9 @@ project
  │    ├── columns: a.x:1(int!null) a.y:2(int) b.x:3(int) b.z:4(int!null) b.rowid:5(int!null)
  │    ├── inner-join
  │    │    ├── columns: a.x:1(int!null) a.y:2(int) b.x:3(int) b.z:4(int!null) b.rowid:5(int!null)
- │    │    ├── scan
+ │    │    ├── scan a
  │    │    │    └── columns: a.x:1(int!null) a.y:2(int)
- │    │    ├── scan
+ │    │    ├── scan b
  │    │    │    └── columns: b.x:3(int) b.z:4(int!null) b.rowid:5(int!null)
  │    │    └── true [type=bool]
  │    └── eq [type=bool, outer=(1,3)]

--- a/pkg/sql/opt/xform/testdata/logprops/set
+++ b/pkg/sql/opt/xform/testdata/logprops/set
@@ -24,11 +24,11 @@ union
  ├── columns: x:6(int) y:7(int)
  ├── left columns: a.x:1(int) a.y:2(int)
  ├── right columns: b.x:3(int) b.z:4(int)
- ├── scan
+ ├── scan a
  │    └── columns: a.x:1(int!null) a.y:2(int)
  └── project
       ├── columns: b.x:3(int) b.z:4(int!null)
-      ├── scan
+      ├── scan b
       │    └── columns: b.x:3(int) b.z:4(int!null) b.rowid:5(int!null)
       └── projections [outer=(3,4)]
            ├── variable: b.x [type=int, outer=(3)]
@@ -43,7 +43,7 @@ intersect
  ├── right columns: b.z:4(int) b.x:3(int) b.rowid:5(int)
  ├── project
  │    ├── columns: a.x:1(int!null) a.y:2(int) a.x:1(int!null)
- │    ├── scan
+ │    ├── scan a
  │    │    └── columns: a.x:1(int!null) a.y:2(int)
  │    └── projections [outer=(1,2)]
  │         ├── variable: a.x [type=int, outer=(1)]
@@ -51,7 +51,7 @@ intersect
  │         └── variable: a.x [type=int, outer=(1)]
  └── project
       ├── columns: b.z:4(int!null) b.x:3(int) b.rowid:5(int!null)
-      ├── scan
+      ├── scan b
       │    └── columns: b.x:3(int) b.z:4(int!null) b.rowid:5(int!null)
       └── projections [outer=(3-5)]
            ├── variable: b.z [type=int, outer=(4)]
@@ -67,7 +67,7 @@ except
  ├── right columns: b.x:3(int) b.z:4(int) b.z:4(int)
  ├── project
  │    ├── columns: a.x:1(int!null) a.x:1(int!null) a.y:2(int)
- │    ├── scan
+ │    ├── scan a
  │    │    └── columns: a.x:1(int!null) a.y:2(int)
  │    └── projections [outer=(1,2)]
  │         ├── variable: a.x [type=int, outer=(1)]
@@ -75,7 +75,7 @@ except
  │         └── variable: a.y [type=int, outer=(2)]
  └── project
       ├── columns: b.x:3(int) b.z:4(int!null) b.z:4(int!null)
-      ├── scan
+      ├── scan b
       │    └── columns: b.x:3(int) b.z:4(int!null) b.rowid:5(int!null)
       └── projections [outer=(3,4)]
            ├── variable: b.x [type=int, outer=(3)]

--- a/pkg/sql/opt/xform/testdata/physprops/ordering
+++ b/pkg/sql/opt/xform/testdata/physprops/ordering
@@ -25,7 +25,7 @@ TABLE a
 opt
 SELECT * FROM a ORDER BY x, y DESC
 ----
-scan
+scan a
  ├── columns: x:1(int!null) y:2(float!null) z:3(decimal) s:4(string!null)
  └── ordering: +1,-2
 
@@ -33,7 +33,7 @@ scan
 opt
 SELECT * FROM a ORDER BY x
 ----
-scan
+scan a
  ├── columns: x:1(int!null) y:2(float!null) z:3(decimal) s:4(string!null)
  └── ordering: +1
 
@@ -44,7 +44,7 @@ SELECT * FROM a ORDER BY y DESC
 sort
  ├── columns: x:1(int!null) y:2(float!null) z:3(decimal) s:4(string!null)
  ├── ordering: -2
- └── scan
+ └── scan a
       └── columns: a.x:1(int!null) a.y:2(float!null) a.z:3(decimal) a.s:4(string!null)
 
 # Order by additional column (scan shouldn't be able to provide for now).
@@ -54,7 +54,7 @@ SELECT * FROM a ORDER BY x, y DESC, z
 sort
  ├── columns: x:1(int!null) y:2(float!null) z:3(decimal) s:4(string!null)
  ├── ordering: +1,-2,+3
- └── scan
+ └── scan a
       └── columns: a.x:1(int!null) a.y:2(float!null) a.z:3(decimal) a.s:4(string!null)
 
 # --------------------------------------------------
@@ -68,7 +68,7 @@ SELECT * FROM a WHERE x=1 ORDER BY x, y DESC
 select
  ├── columns: x:1(int!null) y:2(float!null) z:3(decimal) s:4(string!null)
  ├── ordering: +1,-2
- ├── scan
+ ├── scan a
  │    ├── columns: a.x:1(int!null) a.y:2(float!null) a.z:3(decimal) a.s:4(string!null)
  │    └── ordering: +1,-2
  └── filters [type=bool, outer=(1)]
@@ -86,7 +86,7 @@ select
  ├── sort
  │    ├── columns: a.x:1(int!null) a.y:2(float!null) a.z:3(decimal) a.s:4(string!null)
  │    ├── ordering: -3
- │    └── scan
+ │    └── scan a
  │         └── columns: a.x:1(int!null) a.y:2(float!null) a.z:3(decimal) a.s:4(string!null)
  └── filters [type=bool, outer=(1)]
       └── eq [type=bool, outer=(1)]
@@ -104,7 +104,7 @@ SELECT x+1, y FROM a ORDER BY x, y DESC
 project
  ├── columns: column5:5(int) y:2(float!null)
  ├── ordering: +1,-2
- ├── scan
+ ├── scan a
  │    ├── columns: a.x:1(int!null) a.y:2(float!null)
  │    └── ordering: +1,-2
  └── projections [outer=(1,2)]
@@ -124,7 +124,7 @@ project
  ├── sort
  │    ├── columns: a.x:1(int!null) a.y:2(float!null) a.z:3(decimal)
  │    ├── ordering: +1,+2
- │    └── scan
+ │    └── scan a
  │         └── columns: a.x:1(int!null) a.y:2(float!null) a.z:3(decimal)
  └── projections [outer=(1-3)]
       ├── variable: a.y [type=float, outer=(2)]
@@ -142,7 +142,7 @@ sort
  ├── ordering: +1,+5
  └── project
       ├── columns: a.x:1(int!null) one:5(int) a.y:2(float!null)
-      ├── scan
+      ├── scan a
       │    └── columns: a.x:1(int!null) a.y:2(float!null)
       └── projections [outer=(1,2)]
            ├── variable: a.x [type=int, outer=(1)]
@@ -163,7 +163,7 @@ project
  ├── select
  │    ├── columns: a.x:1(int!null) a.y:2(float!null)
  │    ├── ordering: +1,-2
- │    ├── scan
+ │    ├── scan a
  │    │    ├── columns: a.x:1(int!null) a.y:2(float!null)
  │    │    └── ordering: +1,-2
  │    └── filters [type=bool, outer=(1)]
@@ -221,7 +221,7 @@ project
  │    ├── sort
  │    │    ├── columns: a.x:1(int!null) a.y:2(float!null) a.z:3(decimal)
  │    │    ├── ordering: +2
- │    │    └── scan
+ │    │    └── scan a
  │    │         └── columns: a.x:1(int!null) a.y:2(float!null) a.z:3(decimal)
  │    └── filters [type=bool, outer=(1)]
  │         └── eq [type=bool, outer=(1)]

--- a/pkg/sql/opt/xform/testdata/physprops/presentation
+++ b/pkg/sql/opt/xform/testdata/physprops/presentation
@@ -21,7 +21,7 @@ TABLE b
 opt
 SELECT a.y, a.x, a.y y2 FROM a
 ----
-scan
+scan a
  └── columns: y:2(int) x:1(int!null) y2:2(int)
 
 # Select operator.
@@ -30,7 +30,7 @@ SELECT a.y, a.x, a.y y2 FROM a WHERE x=1
 ----
 select
  ├── columns: y:2(int) x:1(int!null) y2:2(int)
- ├── scan
+ ├── scan a
  │    └── columns: a.x:1(int!null) a.y:2(int)
  └── filters [type=bool, outer=(1)]
       └── eq [type=bool, outer=(1)]
@@ -43,7 +43,7 @@ SELECT 1+a.y AS plus, a.x FROM a
 ----
 project
  ├── columns: plus:3(int) x:1(int!null)
- ├── scan
+ ├── scan a
  │    └── columns: a.x:1(int!null) a.y:2(int)
  └── projections [outer=(1,2)]
       ├── plus [type=int, outer=(2)]
@@ -57,9 +57,9 @@ SELECT b.x, rowid, a.y, a.x, a.y y2, b.y FROM a, b
 ----
 inner-join
  ├── columns: x:3(int) rowid:5(int!null) y:2(int) x:1(int!null) y2:2(int) y:4(float)
- ├── scan
+ ├── scan a
  │    └── columns: a.x:1(int!null) a.y:2(int)
- ├── scan
+ ├── scan b
  │    └── columns: b.x:3(int) b.y:4(float) b.rowid:5(int!null)
  └── true [type=bool]
 
@@ -70,7 +70,7 @@ SELECT MAX(y), y, y, x FROM a GROUP BY a.x, a.y
 group-by
  ├── columns: column3:3(int) y:2(int) y:2(int) x:1(int!null)
  ├── grouping columns: a.x:1(int!null) a.y:2(int)
- ├── scan
+ ├── scan a
  │    └── columns: a.x:1(int!null) a.y:2(int)
  └── aggregations [outer=(2)]
       └── function: max [type=int, outer=(2)]

--- a/pkg/sql/opt/xform/testdata/rules/bool
+++ b/pkg/sql/opt/xform/testdata/rules/bool
@@ -25,7 +25,7 @@ TABLE b
 opt
 SELECT * FROM a WHERE True AND True
 ----
-scan
+scan a
  └── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
 
 # --------------------------------------------------
@@ -36,7 +36,7 @@ SELECT * FROM a WHERE False OR False
 ----
 select
  ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
- ├── scan
+ ├── scan a
  │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
  └── false [type=bool]
 
@@ -48,7 +48,7 @@ SELECT * FROM a WHERE (i=5 OR False) AND (s<'foo' AND True)
 ----
 select
  ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
- ├── scan
+ ├── scan a
  │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
  └── filters [type=bool, outer=(2,4)]
       ├── eq [type=bool, outer=(2)]
@@ -68,7 +68,7 @@ SELECT * FROM a WHERE k=1 AND False AND f=3.5
 ----
 select
  ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
- ├── scan
+ ├── scan a
  │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
  └── false [type=bool]
 
@@ -77,7 +77,7 @@ SELECT * FROM a WHERE False AND s='foo'
 ----
 select
  ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
- ├── scan
+ ├── scan a
  │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
  └── false [type=bool]
 
@@ -87,7 +87,7 @@ SELECT * FROM a WHERE true AND k=1
 ----
 select
  ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
- ├── scan
+ ├── scan a
  │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
  └── filters [type=bool, outer=(1)]
       └── eq [type=bool, outer=(1)]
@@ -99,7 +99,7 @@ SELECT * FROM a WHERE k=1 AND i=2 AND true
 ----
 select
  ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
- ├── scan
+ ├── scan a
  │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
  └── filters [type=bool, outer=(1,2)]
       ├── eq [type=bool, outer=(1)]
@@ -113,7 +113,7 @@ select
 opt
 SELECT * FROM a WHERE true AND true
 ----
-scan
+scan a
  └── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
 
 # Flatten nested And operands.
@@ -122,7 +122,7 @@ SELECT * FROM a WHERE (k>1 AND k<5) AND (f=3.5 AND s='foo')
 ----
 select
  ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
- ├── scan
+ ├── scan a
  │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
  └── filters [type=bool, outer=(1,3,4)]
       ├── gt [type=bool, outer=(1)]
@@ -146,13 +146,13 @@ select
 opt
 SELECT * FROM a WHERE k=1 OR (i=2 OR True)
 ----
-scan
+scan a
  └── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
 
 opt
 SELECT * FROM a WHERE k=1 OR True OR f=3.5
 ----
-scan
+scan a
  └── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
 
 # Discard False operands.
@@ -161,7 +161,7 @@ SELECT * FROM a WHERE false OR k=1
 ----
 select
  ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
- ├── scan
+ ├── scan a
  │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
  └── filters [type=bool, outer=(1)]
       └── eq [type=bool, outer=(1)]
@@ -173,7 +173,7 @@ SELECT * FROM a WHERE k=1 OR i=2 OR false
 ----
 select
  ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
- ├── scan
+ ├── scan a
  │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
  └── filters [type=bool, outer=(1,2)]
       └── or [type=bool, outer=(1,2)]
@@ -190,7 +190,7 @@ SELECT * FROM a WHERE false OR false
 ----
 select
  ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
- ├── scan
+ ├── scan a
  │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
  └── false [type=bool]
 
@@ -200,7 +200,7 @@ SELECT * FROM a WHERE (k=1 OR i=2) OR (f=3.5 OR s='foo')
 ----
 select
  ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
- ├── scan
+ ├── scan a
  │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
  └── filters [type=bool, outer=(1-4)]
       └── or [type=bool, outer=(1-4)]
@@ -225,7 +225,7 @@ SELECT * FROM a WHERE (k=1 OR false) AND (false OR k=2 OR false) AND true
 ----
 select
  ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
- ├── scan
+ ├── scan a
  │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
  └── filters [type=bool, outer=(1)]
       ├── eq [type=bool, outer=(1)]
@@ -241,7 +241,7 @@ SELECT * FROM a WHERE (k=1 OR (i=2 OR f=3.5)) AND (s='foo' AND s<>'bar')
 ----
 select
  ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
- ├── scan
+ ├── scan a
  │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
  └── filters [type=bool, outer=(1-4)]
       ├── or [type=bool, outer=(1-3)]
@@ -269,7 +269,7 @@ SELECT * FROM a WHERE Null
 ----
 select
  ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
- ├── scan
+ ├── scan a
  │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
  └── false [type=bool]
 
@@ -278,9 +278,9 @@ SELECT * FROM a INNER JOIN b ON NULL
 ----
 inner-join
  ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb) x:6(int!null) z:7(int)
- ├── scan
+ ├── scan a
  │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
- ├── scan
+ ├── scan b
  │    └── columns: b.x:6(int!null) b.z:7(int)
  └── false [type=bool]
 
@@ -289,7 +289,7 @@ SELECT * FROM a WHERE i=1 AND Null
 ----
 select
  ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
- ├── scan
+ ├── scan a
  │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
  └── false [type=bool]
 
@@ -301,7 +301,7 @@ SELECT * FROM a WHERE null and null
 ----
 select
  ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
- ├── scan
+ ├── scan a
  │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
  └── false [type=bool]
 
@@ -310,7 +310,7 @@ SELECT * FROM a WHERE null or null
 ----
 select
  ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
- ├── scan
+ ├── scan a
  │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
  └── false [type=bool]
 
@@ -319,7 +319,7 @@ SELECT * FROM a WHERE null or (null and null and null) or null
 ----
 select
  ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
- ├── scan
+ ├── scan a
  │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
  └── false [type=bool]
 
@@ -329,7 +329,7 @@ SELECT * FROM a WHERE null or (null and k=1)
 ----
 select
  ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
- ├── scan
+ ├── scan a
  │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
  └── filters [type=bool, outer=(1)]
       └── or [type=bool, outer=(1)]
@@ -350,7 +350,7 @@ SELECT * FROM a WHERE NOT(i=1) AND NOT(i<>1) AND NOT(i>1) AND NOT(i>=1) AND NOT(
 ----
 select
  ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
- ├── scan
+ ├── scan a
  │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
  └── filters [type=bool, outer=(2)]
       ├── ne [type=bool, outer=(2)]
@@ -380,7 +380,7 @@ WHERE NOT(i IN (1,2)) AND NOT(i NOT IN (3,4)) AND NOT(i IS NULL) AND NOT(i IS NO
 ----
 select
  ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
- ├── scan
+ ├── scan a
  │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
  └── filters [type=bool, outer=(2)]
       ├── not-in [type=bool, outer=(2)]
@@ -408,7 +408,7 @@ WHERE NOT(s LIKE 'foo') AND NOT(s NOT LIKE 'foo') AND NOT(s ILIKE 'foo') AND NOT
 ----
 select
  ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
- ├── scan
+ ├── scan a
  │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
  └── filters [type=bool, outer=(4)]
       ├── not-like [type=bool, outer=(4)]
@@ -430,7 +430,7 @@ SELECT * FROM a WHERE NOT(s SIMILAR TO 'foo') AND NOT(s NOT SIMILAR TO 'foo')
 ----
 select
  ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
- ├── scan
+ ├── scan a
  │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
  └── filters [type=bool, outer=(4)]
       ├── not-similar-to [type=bool, outer=(4)]
@@ -446,7 +446,7 @@ SELECT * FROM a WHERE NOT(s ~ 'foo') AND NOT(s !~ 'foo') AND NOT(s ~* 'foo') AND
 ----
 select
  ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
- ├── scan
+ ├── scan a
  │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
  └── filters [type=bool, outer=(4)]
       ├── not-reg-match [type=bool, outer=(4)]
@@ -468,7 +468,7 @@ SELECT * FROM a WHERE NOT('[1, 2]' @> j) AND NOT(j <@ '[3, 4]')
 ----
 select
  ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
- ├── scan
+ ├── scan a
  │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
  └── filters [type=bool, outer=(5)]
       ├── not [type=bool, outer=(5)]
@@ -488,7 +488,7 @@ SELECT * FROM a WHERE NOT(NOT('[1, 2]' @> j))
 ----
 select
  ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
- ├── scan
+ ├── scan a
  │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
  └── filters [type=bool, outer=(5)]
       └── contains [type=bool, outer=(5)]
@@ -503,7 +503,7 @@ SELECT * FROM a WHERE NOT (k >= i AND i < f)
 ----
 select
  ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
- ├── scan
+ ├── scan a
  │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
  └── filters [type=bool, outer=(1-3)]
       └── or [type=bool, outer=(1-3)]
@@ -519,7 +519,7 @@ SELECT * FROM a WHERE NOT (k >= i AND i < f AND (i > 5 AND i < 10 AND f > 1))
 ----
 select
  ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
- ├── scan
+ ├── scan a
  │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
  └── filters [type=bool, outer=(1-3)]
       └── or [type=bool, outer=(1-3)]
@@ -548,7 +548,7 @@ SELECT * FROM a WHERE NOT (k >= i OR i < f OR k + i < f)
 ----
 select
  ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
- ├── scan
+ ├── scan a
  │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
  └── filters [type=bool, outer=(1-3)]
       ├── lt [type=bool, outer=(1,2)]
@@ -568,7 +568,7 @@ SELECT * FROM a WHERE NOT (k >= i OR i < f OR (i > 5 OR i < 10 OR f > 1))
 ----
 select
  ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
- ├── scan
+ ├── scan a
  │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
  └── filters [type=bool, outer=(1-3)]
       ├── lt [type=bool, outer=(1,2)]
@@ -595,7 +595,7 @@ SELECT * FROM a WHERE NOT ((k >= i OR i < f) AND (i > 5 OR f > 1))
 ----
 select
  ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
- ├── scan
+ ├── scan a
  │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
  └── filters [type=bool, outer=(1-3)]
       └── or [type=bool, outer=(1-3)]
@@ -619,7 +619,7 @@ SELECT * FROM a WHERE NOT ((k >= i AND i < f) OR (i > 5 AND f > 1))
 ----
 select
  ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
- ├── scan
+ ├── scan a
  │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
  └── filters [type=bool, outer=(1-3)]
       ├── or [type=bool, outer=(1-3)]

--- a/pkg/sql/opt/xform/testdata/rules/comp
+++ b/pkg/sql/opt/xform/testdata/rules/comp
@@ -21,7 +21,7 @@ SELECT * FROM a WHERE 1+i<k AND k-1<=i AND i*i>k AND k/2>=i
 ----
 select
  ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
- ├── scan
+ ├── scan a
  │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
  └── filters [type=bool, outer=(1,2)]
       ├── gt [type=bool, outer=(1,2)]
@@ -53,7 +53,7 @@ SELECT * FROM a WHERE length('foo')+1<i+k AND length('bar')<=i*2 AND 5>i AND 'fo
 ----
 select
  ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
- ├── scan
+ ├── scan a
  │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
  └── filters [type=bool, outer=(1,2,4)]
       ├── gt [type=bool, outer=(1,2)]
@@ -92,7 +92,7 @@ WHERE
 ----
 select
  ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
- ├── scan
+ ├── scan a
  │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
  └── filters [type=bool, outer=(2,3)]
       ├── eq [type=bool, outer=(2)]
@@ -133,7 +133,7 @@ SELECT * FROM a WHERE s::date + '02:00:00'::time = '2000-01-01T02:00:00'::timest
 ----
 select
  ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
- ├── scan
+ ├── scan a
  │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
  └── filters [type=bool, outer=(4)]
       └── eq [type=bool, outer=(4)]
@@ -158,7 +158,7 @@ WHERE
 ----
 select
  ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
- ├── scan
+ ├── scan a
  │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
  └── filters [type=bool, outer=(2,3)]
       ├── eq [type=bool, outer=(2)]
@@ -201,7 +201,7 @@ SELECT * FROM a WHERE s::json - 1 = '[1]'::json
 ----
 select
  ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
- ├── scan
+ ├── scan a
  │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
  └── filters [type=bool, outer=(4)]
       └── eq [type=bool, outer=(4)]
@@ -226,7 +226,7 @@ WHERE
 ----
 select
  ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
- ├── scan
+ ├── scan a
  │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
  └── filters [type=bool, outer=(2,3)]
       ├── eq [type=bool, outer=(2)]
@@ -269,7 +269,7 @@ SELECT * FROM a WHERE '[1, 2]'::json - i = '[1]'
 ----
 select
  ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
- ├── scan
+ ├── scan a
  │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
  └── filters [type=bool, outer=(2)]
       └── eq [type=bool, outer=(2)]
@@ -286,7 +286,7 @@ SELECT * FROM a WHERE (i, f, s) = (1, 3.5, 'foo')
 ----
 select
  ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
- ├── scan
+ ├── scan a
  │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
  └── filters [type=bool, outer=(2-4)]
       ├── eq [type=bool, outer=(2)]
@@ -309,7 +309,7 @@ SELECT * FROM a WHERE (1, (2, 'foo')) = (k, (i, s))
 ----
 select
  ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
- ├── scan
+ ├── scan a
  │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
  └── filters [type=bool, outer=(1,2,4)]
       ├── eq [type=bool, outer=(1)]
@@ -350,6 +350,6 @@ WHERE
 ----
 select
  ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
- ├── scan
+ ├── scan a
  │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
  └── false [type=bool]

--- a/pkg/sql/opt/xform/testdata/rules/join
+++ b/pkg/sql/opt/xform/testdata/rules/join
@@ -27,9 +27,9 @@ SELECT * FROM a INNER JOIN b ON a.x=b.x AND b.z<a.i
 ----
 inner-join
  ├── columns: x:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb) x:6(int!null) z:7(int)
- ├── scan
+ ├── scan a
  │    └── columns: a.x:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
- ├── scan
+ ├── scan b
  │    └── columns: b.x:6(int!null) b.z:7(int)
  └── filters [type=bool, outer=(1,2,6,7)]
       ├── eq [type=bool, outer=(1,6)]
@@ -47,9 +47,9 @@ SELECT * FROM a INNER JOIN b ON a.x=b.x
 ----
 inner-join
  ├── columns: x:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb) x:6(int!null) z:7(int)
- ├── scan
+ ├── scan a
  │    └── columns: a.x:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
- ├── scan
+ ├── scan b
  │    └── columns: b.x:6(int!null) b.z:7(int)
  └── filters [type=bool, outer=(1,6)]
       └── eq [type=bool, outer=(1,6)]
@@ -61,9 +61,9 @@ SELECT * FROM a INNER JOIN b ON a.s='foo' OR b.z<10
 ----
 inner-join
  ├── columns: x:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb) x:6(int!null) z:7(int)
- ├── scan
+ ├── scan a
  │    └── columns: a.x:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
- ├── scan
+ ├── scan b
  │    └── columns: b.x:6(int!null) b.z:7(int)
  └── filters [type=bool, outer=(4,7)]
       └── or [type=bool, outer=(4,7)]
@@ -84,13 +84,13 @@ inner-join
  ├── columns: x:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb) x:6(int!null) z:7(int)
  ├── select
  │    ├── columns: a.x:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
- │    ├── scan
+ │    ├── scan a
  │    │    └── columns: a.x:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
  │    └── filters [type=bool, outer=(4)]
  │         └── eq [type=bool, outer=(4)]
  │              ├── variable: a.s [type=string, outer=(4)]
  │              └── const: 'foo' [type=string]
- ├── scan
+ ├── scan b
  │    └── columns: b.x:6(int!null) b.z:7(int)
  └── filters [type=bool, outer=(1,6)]
       └── eq [type=bool, outer=(1,6)]
@@ -104,7 +104,7 @@ right-join
  ├── columns: x:1(int) i:2(int) f:3(float) s:4(string) j:5(jsonb) x:6(int!null) z:7(int)
  ├── select
  │    ├── columns: a.x:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
- │    ├── scan
+ │    ├── scan a
  │    │    └── columns: a.x:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
  │    └── filters [type=bool, outer=(2,4)]
  │         ├── or [type=bool, outer=(2)]
@@ -117,7 +117,7 @@ right-join
  │         └── eq [type=bool, outer=(4)]
  │              ├── variable: a.s [type=string, outer=(4)]
  │              └── const: 'foo' [type=string]
- ├── scan
+ ├── scan b
  │    └── columns: b.x:6(int!null) b.z:7(int)
  └── filters [type=bool, outer=(1,6,7)]
       ├── eq [type=bool, outer=(7)]
@@ -133,9 +133,9 @@ SELECT * FROM a LEFT JOIN b ON a.x=b.x AND a.i=1
 ----
 left-join
  ├── columns: x:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb) x:6(int) z:7(int)
- ├── scan
+ ├── scan a
  │    └── columns: a.x:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
- ├── scan
+ ├── scan b
  │    └── columns: b.x:6(int!null) b.z:7(int)
  └── filters [type=bool, outer=(1,2,6)]
       ├── eq [type=bool, outer=(1,6)]
@@ -153,11 +153,11 @@ SELECT * FROM b INNER JOIN a ON b.x=a.x AND a.s='foo'
 ----
 inner-join
  ├── columns: x:1(int!null) z:2(int) x:3(int!null) i:4(int) f:5(float) s:6(string) j:7(jsonb)
- ├── scan
+ ├── scan b
  │    └── columns: b.x:1(int!null) b.z:2(int)
  ├── select
  │    ├── columns: a.x:3(int!null) a.i:4(int) a.f:5(float) a.s:6(string) a.j:7(jsonb)
- │    ├── scan
+ │    ├── scan a
  │    │    └── columns: a.x:3(int!null) a.i:4(int) a.f:5(float) a.s:6(string) a.j:7(jsonb)
  │    └── filters [type=bool, outer=(6)]
  │         └── eq [type=bool, outer=(6)]
@@ -173,11 +173,11 @@ SELECT * FROM b LEFT JOIN a ON (a.i<0 OR a.i>10) AND b.z=1 AND a.s='foo' AND b.x
 ----
 left-join
  ├── columns: x:1(int!null) z:2(int) x:3(int) i:4(int) f:5(float) s:6(string) j:7(jsonb)
- ├── scan
+ ├── scan b
  │    └── columns: b.x:1(int!null) b.z:2(int)
  ├── select
  │    ├── columns: a.x:3(int!null) a.i:4(int) a.f:5(float) a.s:6(string) a.j:7(jsonb)
- │    ├── scan
+ │    ├── scan a
  │    │    └── columns: a.x:3(int!null) a.i:4(int) a.f:5(float) a.s:6(string) a.j:7(jsonb)
  │    └── filters [type=bool, outer=(4,6)]
  │         ├── or [type=bool, outer=(4)]
@@ -204,9 +204,9 @@ SELECT * FROM b RIGHT JOIN a ON b.x=a.x AND a.i=1
 ----
 right-join
  ├── columns: x:1(int) z:2(int) x:3(int!null) i:4(int) f:5(float) s:6(string) j:7(jsonb)
- ├── scan
+ ├── scan b
  │    └── columns: b.x:1(int!null) b.z:2(int)
- ├── scan
+ ├── scan a
  │    └── columns: a.x:3(int!null) a.i:4(int) a.f:5(float) a.s:6(string) a.j:7(jsonb)
  └── filters [type=bool, outer=(1,3,4)]
       ├── eq [type=bool, outer=(1,3)]
@@ -227,7 +227,7 @@ inner-join
  ├── columns: x:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb) x:6(int!null) z:7(int)
  ├── select
  │    ├── columns: a.x:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
- │    ├── scan
+ │    ├── scan a
  │    │    └── columns: a.x:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
  │    └── filters [type=bool, outer=(2)]
  │         └── eq [type=bool, outer=(2)]
@@ -235,7 +235,7 @@ inner-join
  │              └── const: 1 [type=int]
  ├── select
  │    ├── columns: b.x:6(int!null) b.z:7(int)
- │    ├── scan
+ │    ├── scan b
  │    │    └── columns: b.x:6(int!null) b.z:7(int)
  │    └── filters [type=bool, outer=(7)]
  │         └── eq [type=bool, outer=(7)]
@@ -252,9 +252,9 @@ SELECT * FROM a FULL JOIN b ON a.x=b.x AND a.i=1 AND b.z=1
 ----
 full-join
  ├── columns: x:1(int) i:2(int) f:3(float) s:4(string) j:5(jsonb) x:6(int) z:7(int)
- ├── scan
+ ├── scan a
  │    └── columns: a.x:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
- ├── scan
+ ├── scan b
  │    └── columns: b.x:6(int!null) b.z:7(int)
  └── filters [type=bool, outer=(1,2,6,7)]
       ├── eq [type=bool, outer=(1,6)]

--- a/pkg/sql/opt/xform/testdata/rules/numeric
+++ b/pkg/sql/opt/xform/testdata/rules/numeric
@@ -24,7 +24,7 @@ FROM a
 ----
 project
  ├── columns: column6:6(int) column7:7(int) column8:8(float) column9:9(float) column10:10(decimal) column11:11(decimal)
- ├── scan
+ ├── scan a
  │    └── columns: a.i:2(int) a.f:3(float) a.d:4(decimal)
  └── projections [outer=(2-4)]
       ├── plus [type=int, outer=(2)]
@@ -60,7 +60,7 @@ FROM a
 ----
 project
  ├── columns: column6:6(int) column7:7(float) column8:8(decimal)
- ├── scan
+ ├── scan a
  │    └── columns: a.i:2(int) a.f:3(float) a.d:4(decimal)
  └── projections [outer=(2-4)]
       ├── plus [type=int, outer=(2)]
@@ -87,7 +87,7 @@ FROM a
 ----
 project
  ├── columns: column6:6(int) column7:7(int) column8:8(float) column9:9(float) column10:10(decimal) column11:11(decimal)
- ├── scan
+ ├── scan a
  │    └── columns: a.i:2(int) a.f:3(float) a.d:4(decimal)
  └── projections [outer=(2-4)]
       ├── plus [type=int, outer=(2)]
@@ -122,7 +122,7 @@ FROM a
 ----
 project
  ├── columns: column6:6(decimal) column7:7(float) column8:8(decimal)
- ├── scan
+ ├── scan a
  │    └── columns: a.i:2(int) a.f:3(float) a.d:4(decimal)
  └── projections [outer=(2-4)]
       ├── variable: a.i [type=int, outer=(2)]
@@ -141,7 +141,7 @@ FROM a
 ----
 project
  ├── columns: column6:6(float) column7:7(decimal) column8:8(interval)
- ├── scan
+ ├── scan a
  │    └── columns: a.i:2(int) a.f:3(float) a.d:4(decimal) a.t:5(time)
  └── projections [outer=(2-5)]
       ├── minus [type=float, outer=(3)]
@@ -162,7 +162,7 @@ SELECT -(-a.i::int) FROM a
 ----
 project
  ├── columns: column6:6(int)
- ├── scan
+ ├── scan a
  │    └── columns: a.i:2(int)
  └── projections [outer=(2)]
       └── variable: a.i [type=int, outer=(2)]

--- a/pkg/sql/opt/xform/testdata/rules/project
+++ b/pkg/sql/opt/xform/testdata/rules/project
@@ -26,21 +26,21 @@ TABLE b
 opt
 SELECT x, y FROM t.a
 ----
-scan
+scan a
  └── columns: x:1(int!null) y:2(int)
 
 # Different order, aliased names.
 opt
 SELECT a.y AS aliasy, a.x FROM t.a
 ----
-scan
+scan a
  └── columns: aliasy:2(int) x:1(int!null)
 
 # Reordered, duplicate, aliased columns.
 opt
 SELECT a.y AS alias1, a.x, a.y AS alias1, a.x FROM t.a
 ----
-scan
+scan a
  └── columns: alias1:2(int) x:1(int!null) alias1:2(int) x:1(int!null)
 
 # Added column (projection should not be eliminated).
@@ -49,7 +49,7 @@ SELECT *, 1 FROM t.a
 ----
 project
  ├── columns: x:1(int!null) y:2(int) f:3(float) s:4(string) column5:5(int)
- ├── scan
+ ├── scan a
  │    └── columns: a.x:1(int!null) a.y:2(int) a.f:3(float) a.s:4(string)
  └── projections [outer=(1-4)]
       ├── variable: a.x [type=int, outer=(1)]
@@ -66,7 +66,7 @@ project
 opt
 SELECT x FROM (SELECT x, y+1 FROM t.a) a
 ----
-scan
+scan a
  └── columns: x:1(int!null)
 
 # Discard all columns.
@@ -75,7 +75,7 @@ SELECT 1 FROM (SELECT y+1, x FROM t.a) a
 ----
 project
  ├── columns: column6:6(int)
- ├── scan
+ ├── scan a
  └── projections
       └── const: 1 [type=int]
 
@@ -85,7 +85,7 @@ SELECT x+y FROM (SELECT y, x, s || 'foo' FROM t.a) a
 ----
 project
  ├── columns: column6:6(int)
- ├── scan
+ ├── scan a
  │    └── columns: a.x:1(int!null) a.y:2(int)
  └── projections [outer=(1,2)]
       └── plus [type=int, outer=(1,2)]
@@ -98,7 +98,7 @@ SELECT l, x FROM (SELECT length(s) l, * FROM a) a
 ----
 project
  ├── columns: l:5(int) x:1(int!null)
- ├── scan
+ ├── scan a
  │    └── columns: a.x:1(int!null) a.s:4(string)
  └── projections [outer=(1,4)]
       ├── function: length [type=int, outer=(4)]
@@ -113,7 +113,7 @@ project
  ├── columns: column6:6(int) x:1(int!null)
  ├── project
  │    ├── columns: a.x:1(int!null) l:5(int)
- │    ├── scan
+ │    ├── scan a
  │    │    └── columns: a.x:1(int!null) a.s:4(string)
  │    └── projections [outer=(1,4)]
  │         ├── variable: a.x [type=int, outer=(1)]
@@ -133,7 +133,7 @@ project
 opt
 SELECT x FROM t.a
 ----
-scan
+scan a
  └── columns: x:1(int!null)
 
 # Project subset of columns, some used in computed columns.
@@ -142,7 +142,7 @@ SELECT x, x+1, y+1 FROM t.a
 ----
 project
  ├── columns: x:1(int!null) column5:5(int) column6:6(int)
- ├── scan
+ ├── scan a
  │    └── columns: a.x:1(int!null) a.y:2(int)
  └── projections [outer=(1,2)]
       ├── variable: a.x [type=int, outer=(1)]
@@ -159,7 +159,7 @@ SELECT x+y FROM t.a
 ----
 project
  ├── columns: column5:5(int)
- ├── scan
+ ├── scan a
  │    └── columns: a.x:1(int!null) a.y:2(int)
  └── projections [outer=(1,2)]
       └── plus [type=int, outer=(1,2)]
@@ -172,7 +172,7 @@ SELECT 1 FROM t.a
 ----
 project
  ├── columns: column5:5(int)
- ├── scan
+ ├── scan a
  └── projections
       └── const: 1 [type=int]
 
@@ -188,7 +188,7 @@ project
  ├── columns: x:1(int!null)
  ├── select
  │    ├── columns: a.x:1(int!null) a.y:2(int)
- │    ├── scan
+ │    ├── scan a
  │    │    └── columns: a.x:1(int!null) a.y:2(int)
  │    └── filters [type=bool, outer=(2)]
  │         └── lt [type=bool, outer=(2)]
@@ -203,7 +203,7 @@ SELECT x, y FROM t.a WHERE x=1 AND y<5
 ----
 select
  ├── columns: x:1(int!null) y:2(int)
- ├── scan
+ ├── scan a
  │    └── columns: a.x:1(int!null) a.y:2(int)
  └── filters [type=bool, outer=(1,2)]
       ├── eq [type=bool, outer=(1)]
@@ -220,7 +220,7 @@ SELECT 1 FROM t.a WHERE now()<'2000-01-01T02:00:00'::timestamp
 project
  ├── columns: column5:5(int)
  ├── select
- │    ├── scan
+ │    ├── scan a
  │    └── filters [type=bool]
  │         └── lt [type=bool]
  │              ├── function: now [type=timestamptz]
@@ -236,7 +236,7 @@ project
  ├── columns: column5:5(int) column6:6(int)
  ├── select
  │    ├── columns: a.x:1(int!null) a.y:2(int) a.s:4(string)
- │    ├── scan
+ │    ├── scan a
  │    │    └── columns: a.x:1(int!null) a.y:2(int) a.s:4(string)
  │    └── filters [type=bool, outer=(1,4)]
  │         ├── lt [type=bool, outer=(1)]
@@ -269,7 +269,7 @@ project
  │    │    ├── columns: a.y:2(int) f:5(float)
  │    │    ├── select
  │    │    │    ├── columns: a.x:1(int!null) a.y:2(int) a.f:3(float)
- │    │    │    ├── scan
+ │    │    │    ├── scan a
  │    │    │    │    └── columns: a.x:1(int!null) a.y:2(int) a.f:3(float)
  │    │    │    └── filters [type=bool, outer=(1)]
  │    │    │         └── eq [type=bool, outer=(1)]
@@ -300,9 +300,9 @@ project
  ├── columns: y:2(int) x:5(int!null) z:6(int)
  ├── inner-join
  │    ├── columns: a.x:1(int!null) a.y:2(int) b.x:5(int!null) b.z:6(int)
- │    ├── scan
+ │    ├── scan a
  │    │    └── columns: a.x:1(int!null) a.y:2(int)
- │    ├── scan
+ │    ├── scan b
  │    │    └── columns: b.x:5(int!null) b.z:6(int)
  │    └── filters [type=bool, outer=(1,5)]
  │         └── eq [type=bool, outer=(1,5)]
@@ -319,9 +319,9 @@ SELECT a.x, a.y, b.* FROM t.a LEFT JOIN t.b ON a.x=b.x AND a.y<5
 ----
 left-join
  ├── columns: x:1(int!null) y:2(int) x:5(int) z:6(int)
- ├── scan
+ ├── scan a
  │    └── columns: a.x:1(int!null) a.y:2(int)
- ├── scan
+ ├── scan b
  │    └── columns: b.x:5(int!null) b.z:6(int)
  └── filters [type=bool, outer=(1,2,5)]
       ├── eq [type=bool, outer=(1,5)]
@@ -339,9 +339,9 @@ project
  ├── columns: x:5(int!null) z:6(int)
  ├── right-join
  │    ├── columns: a.x:1(int) b.x:5(int!null) b.z:6(int)
- │    ├── scan
+ │    ├── scan a
  │    │    └── columns: a.x:1(int!null)
- │    ├── scan
+ │    ├── scan b
  │    │    └── columns: b.x:5(int!null) b.z:6(int)
  │    └── filters [type=bool, outer=(1,5)]
  │         └── eq [type=bool, outer=(1,5)]
@@ -359,9 +359,9 @@ project
  ├── columns: column7:7(int) x:5(int) z:6(int)
  ├── full-join
  │    ├── columns: a.x:1(int) b.x:5(int) b.z:6(int)
- │    ├── scan
+ │    ├── scan a
  │    │    └── columns: a.x:1(int!null)
- │    ├── scan
+ │    ├── scan b
  │    │    └── columns: b.x:5(int!null) b.z:6(int)
  │    └── true [type=bool]
  └── projections [outer=(1,5,6)]
@@ -377,8 +377,8 @@ SELECT b.* FROM t.a, t.b
 ----
 inner-join
  ├── columns: x:5(int!null) z:6(int)
- ├── scan
- ├── scan
+ ├── scan a
+ ├── scan b
  │    └── columns: b.x:5(int!null) b.z:6(int)
  └── true [type=bool]
 
@@ -394,7 +394,7 @@ project
  │    │    ├── columns: a.x:1(int!null) a.y:2(int)
  │    │    ├── select
  │    │    │    ├── columns: a.x:1(int!null) a.y:2(int) a.s:4(string)
- │    │    │    ├── scan
+ │    │    │    ├── scan a
  │    │    │    │    └── columns: a.x:1(int!null) a.y:2(int) a.s:4(string)
  │    │    │    └── filters [type=bool, outer=(4)]
  │    │    │         └── eq [type=bool, outer=(4)]
@@ -405,7 +405,7 @@ project
  │    │    └── projections [outer=(1,2)]
  │    │         ├── variable: a.x [type=int, outer=(1)]
  │    │         └── variable: a.y [type=int, outer=(2)]
- │    ├── scan
+ │    ├── scan b
  │    │    └── columns: b.x:5(int!null) b.z:6(int)
  │    └── filters [type=bool, outer=(1,5)]
  │         └── eq [type=bool, outer=(1,5)]
@@ -441,9 +441,9 @@ project
  │    │    ├── columns: a.x:1(int!null) a.y:2(int)
  │    │    ├── inner-join
  │    │    │    ├── columns: a.x:1(int!null) a.y:2(int) b.x:5(int!null)
- │    │    │    ├── scan
+ │    │    │    ├── scan a
  │    │    │    │    └── columns: a.x:1(int!null) a.y:2(int)
- │    │    │    ├── scan
+ │    │    │    ├── scan b
  │    │    │    │    └── columns: b.x:5(int!null)
  │    │    │    └── filters [type=bool, outer=(1,5)]
  │    │    │         └── eq [type=bool, outer=(1,5)]
@@ -452,7 +452,7 @@ project
  │    │    └── projections [outer=(1,2)]
  │    │         ├── variable: a.x [type=int, outer=(1)]
  │    │         └── variable: a.y [type=int, outer=(2)]
- │    ├── scan
+ │    ├── scan b
  │    │    └── columns: b.x:7(int!null) b.z:8(int)
  │    └── filters [type=bool, outer=(2,8)]
  │         └── lt [type=bool, outer=(2,8)]
@@ -475,9 +475,9 @@ project
  ├── columns: x:1(int!null) z:2(int) y:4(int)
  ├── inner-join
  │    ├── columns: b.x:1(int!null) b.z:2(int) a.x:3(int!null) a.y:4(int)
- │    ├── scan
+ │    ├── scan b
  │    │    └── columns: b.x:1(int!null) b.z:2(int)
- │    ├── scan
+ │    ├── scan a
  │    │    └── columns: a.x:3(int!null) a.y:4(int)
  │    └── filters [type=bool, outer=(1,3)]
  │         └── eq [type=bool, outer=(1,3)]
@@ -494,9 +494,9 @@ SELECT b.*, a.x, a.y FROM t.b LEFT JOIN t.a ON b.x=a.x AND a.y<b.x
 ----
 left-join
  ├── columns: x:1(int!null) z:2(int) x:3(int) y:4(int)
- ├── scan
+ ├── scan b
  │    └── columns: b.x:1(int!null) b.z:2(int)
- ├── scan
+ ├── scan a
  │    └── columns: a.x:3(int!null) a.y:4(int)
  └── filters [type=bool, outer=(1,3,4)]
       ├── eq [type=bool, outer=(1,3)]
@@ -514,9 +514,9 @@ project
  ├── columns: x:1(int) z:2(int)
  ├── right-join
  │    ├── columns: b.x:1(int) b.z:2(int) a.x:3(int!null)
- │    ├── scan
+ │    ├── scan b
  │    │    └── columns: b.x:1(int!null) b.z:2(int)
- │    ├── scan
+ │    ├── scan a
  │    │    └── columns: a.x:3(int!null)
  │    └── filters [type=bool, outer=(1,3)]
  │         └── eq [type=bool, outer=(1,3)]
@@ -534,9 +534,9 @@ project
  ├── columns: x:1(int) z:2(int) column7:7(int)
  ├── full-join
  │    ├── columns: b.x:1(int) b.z:2(int) a.x:3(int)
- │    ├── scan
+ │    ├── scan b
  │    │    └── columns: b.x:1(int!null) b.z:2(int)
- │    ├── scan
+ │    ├── scan a
  │    │    └── columns: a.x:3(int!null)
  │    └── true [type=bool]
  └── projections [outer=(1-3)]
@@ -552,9 +552,9 @@ SELECT b.* FROM t.b, t.a
 ----
 inner-join
  ├── columns: x:1(int!null) z:2(int)
- ├── scan
+ ├── scan b
  │    └── columns: b.x:1(int!null) b.z:2(int)
- ├── scan
+ ├── scan a
  └── true [type=bool]
 
 # Computed columns.
@@ -565,13 +565,13 @@ project
  ├── columns: x:1(int!null) z:2(int) column7:7(int) column8:8(decimal)
  ├── inner-join
  │    ├── columns: b.x:1(int!null) b.z:2(int) a.x:3(int!null) a.y:4(int)
- │    ├── scan
+ │    ├── scan b
  │    │    └── columns: b.x:1(int!null) b.z:2(int)
  │    ├── project
  │    │    ├── columns: a.x:3(int!null) a.y:4(int)
  │    │    ├── select
  │    │    │    ├── columns: a.x:3(int!null) a.y:4(int) a.s:6(string)
- │    │    │    ├── scan
+ │    │    │    ├── scan a
  │    │    │    │    └── columns: a.x:3(int!null) a.y:4(int) a.s:6(string)
  │    │    │    └── filters [type=bool, outer=(6)]
  │    │    │         └── eq [type=bool, outer=(6)]
@@ -612,15 +612,15 @@ project
  ├── columns: x:3(int!null) x:1(int!null) z:2(int)
  ├── inner-join
  │    ├── columns: b.x:1(int!null) b.z:2(int) a.x:3(int!null) a.y:4(int)
- │    ├── scan
+ │    ├── scan b
  │    │    └── columns: b.x:1(int!null) b.z:2(int)
  │    ├── project
  │    │    ├── columns: a.x:3(int!null) a.y:4(int)
  │    │    ├── inner-join
  │    │    │    ├── columns: a.x:3(int!null) a.y:4(int) b.x:7(int!null)
- │    │    │    ├── scan
+ │    │    │    ├── scan a
  │    │    │    │    └── columns: a.x:3(int!null) a.y:4(int)
- │    │    │    ├── scan
+ │    │    │    ├── scan b
  │    │    │    │    └── columns: b.x:7(int!null)
  │    │    │    └── filters [type=bool, outer=(3,7)]
  │    │    │         └── eq [type=bool, outer=(3,7)]
@@ -649,8 +649,8 @@ SELECT 1 FROM a,b
 project
  ├── columns: column7:7(int)
  ├── inner-join
- │    ├── scan
- │    ├── scan
+ │    ├── scan a
+ │    ├── scan b
  │    └── true [type=bool]
  └── projections
       └── const: 1 [type=int]
@@ -663,9 +663,9 @@ project
  ├── columns: x:1(int!null) x:5(int) column7:7(int)
  ├── left-join
  │    ├── columns: a.x:1(int!null) b.x:5(int)
- │    ├── scan
+ │    ├── scan a
  │    │    └── columns: a.x:1(int!null)
- │    ├── scan
+ │    ├── scan b
  │    │    └── columns: b.x:5(int!null)
  │    └── filters [type=bool, outer=(1,5)]
  │         └── eq [type=bool, outer=(1,5)]
@@ -689,7 +689,7 @@ SELECT x FROM (SELECT x, SUM(y), MIN(s||'foo') FROM a GROUP BY x) a
 group-by
  ├── columns: x:1(int!null)
  ├── grouping columns: a.x:1(int!null)
- ├── scan
+ ├── scan a
  │    └── columns: a.x:1(int!null)
  └── aggregations
 
@@ -700,7 +700,7 @@ SELECT x, sumy FROM (SELECT SUM(y) sumy, x, MIN(s||'foo') FROM a GROUP BY x) a
 group-by
  ├── columns: x:1(int!null) sumy:5(decimal)
  ├── grouping columns: a.x:1(int!null)
- ├── scan
+ ├── scan a
  │    └── columns: a.x:1(int!null) a.y:2(int)
  └── aggregations [outer=(2)]
       └── function: sum [type=decimal, outer=(2)]
@@ -715,7 +715,7 @@ project
  ├── group-by
  │    ├── columns: a.x:1(int!null)
  │    ├── grouping columns: a.x:1(int!null)
- │    ├── scan
+ │    ├── scan a
  │    │    └── columns: a.x:1(int!null)
  │    └── aggregations
  └── projections
@@ -732,7 +732,7 @@ SELECT x, SUM(y) FROM a GROUP BY x
 group-by
  ├── columns: x:1(int!null) column5:5(decimal)
  ├── grouping columns: a.x:1(int!null)
- ├── scan
+ ├── scan a
  │    └── columns: a.x:1(int!null) a.y:2(int)
  └── aggregations [outer=(2)]
       └── function: sum [type=decimal, outer=(2)]
@@ -747,7 +747,7 @@ group-by
  ├── grouping columns: a.x:1(int!null) a.y:2(int)
  ├── project
  │    ├── columns: a.x:1(int!null) a.y:2(int) column5:5(int)
- │    ├── scan
+ │    ├── scan a
  │    │    └── columns: a.x:1(int!null) a.y:2(int)
  │    └── projections [outer=(1,2)]
  │         ├── variable: a.x [type=int, outer=(1)]
@@ -765,7 +765,7 @@ SELECT MIN(y), MAX(x), MAX(x) FROM a
 ----
 group-by
  ├── columns: column5:5(int) column6:6(int) column6:6(int)
- ├── scan
+ ├── scan a
  │    └── columns: a.x:1(int!null) a.y:2(int)
  └── aggregations [outer=(1,2)]
       ├── function: min [type=int, outer=(2)]
@@ -782,7 +782,7 @@ project
  ├── group-by
  │    ├── columns: a.x:1(int!null) a.y:2(int)
  │    ├── grouping columns: a.x:1(int!null) a.y:2(int)
- │    ├── scan
+ │    ├── scan a
  │    │    └── columns: a.x:1(int!null) a.y:2(int)
  │    └── aggregations
  └── projections [outer=(1,2)]
@@ -803,7 +803,7 @@ group-by
  │    ├── group-by
  │    │    ├── columns: a.y:2(int) a.s:4(string) sm:5(decimal)
  │    │    ├── grouping columns: a.y:2(int) a.s:4(string)
- │    │    ├── scan
+ │    │    ├── scan a
  │    │    │    └── columns: a.x:1(int!null) a.y:2(int) a.s:4(string)
  │    │    └── aggregations [outer=(1)]
  │    │         └── function: sum [type=decimal, outer=(1)]
@@ -879,7 +879,7 @@ project
  │    │    ├── columns: a.x:1(int!null)
  │    │    ├── select
  │    │    │    ├── columns: a.x:1(int!null) a.y:2(int)
- │    │    │    ├── scan
+ │    │    │    ├── scan a
  │    │    │    │    └── columns: a.x:1(int!null) a.y:2(int)
  │    │    │    └── filters [type=bool, outer=(2)]
  │    │    │         └── lt [type=bool, outer=(2)]
@@ -887,7 +887,7 @@ project
  │    │    │              └── const: 5 [type=int]
  │    │    └── projections [outer=(1)]
  │    │         └── variable: a.x [type=int, outer=(1)]
- │    ├── scan
+ │    ├── scan b
  │    │    └── columns: b.x:5(int!null) b.z:6(int)
  │    └── filters [type=bool, outer=(1,5)]
  │         └── eq [type=bool, outer=(1,5)]
@@ -907,7 +907,7 @@ project
  │    ├── group-by
  │    │    ├── columns: a.x:1(int!null) column5:5(decimal)
  │    │    ├── grouping columns: a.x:1(int!null)
- │    │    ├── scan
+ │    │    ├── scan a
  │    │    │    └── columns: a.x:1(int!null) a.y:2(int)
  │    │    └── aggregations [outer=(2)]
  │    │         └── function: sum [type=decimal, outer=(2)]

--- a/pkg/sql/opt/xform/testdata/rules/scalar
+++ b/pkg/sql/opt/xform/testdata/rules/scalar
@@ -33,7 +33,7 @@ FROM a
 ----
 project
  ├── columns: column7:7(bool) column8:8(bool) column9:9(bool) column10:10(bool) column11:11(int) column12:12(int) column13:13(int) column14:14(int) column15:15(int)
- ├── scan
+ ├── scan a
  │    └── columns: a.k:1(int!null) a.i:2(int)
  └── projections [outer=(1,2)]
       ├── eq [type=bool, outer=(1,2)]
@@ -101,7 +101,7 @@ FROM a
 ----
 project
  ├── columns: column7:7(bool) column8:8(bool) column9:9(bool) column10:10(bool) column11:11(float) column12:12(int) column13:13(int) column14:14(int) column15:15(int)
- ├── scan
+ ├── scan a
  │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float)
  └── projections [outer=(1-3)]
       ├── eq [type=bool, outer=(1,2)]
@@ -171,7 +171,7 @@ SELECT COALESCE(i) FROM a
 ----
 project
  ├── columns: column7:7(int)
- ├── scan
+ ├── scan a
  │    └── columns: a.i:2(int)
  └── projections [outer=(2)]
       └── variable: a.i [type=int, outer=(2)]
@@ -184,7 +184,7 @@ SELECT COALESCE(NULL) FROM a
 ----
 project
  ├── columns: column7:7(unknown)
- ├── scan
+ ├── scan a
  └── projections
       └── null [type=unknown]
 
@@ -193,7 +193,7 @@ SELECT COALESCE(NULL, 'foo', s) FROM a
 ----
 project
  ├── columns: column7:7(string)
- ├── scan
+ ├── scan a
  └── projections
       └── const: 'foo' [type=string]
 
@@ -202,7 +202,7 @@ SELECT COALESCE(NULL, NULL, s, s || 'foo') FROM a
 ----
 project
  ├── columns: column7:7(string)
- ├── scan
+ ├── scan a
  │    └── columns: a.s:4(string)
  └── projections [outer=(4)]
       └── coalesce [type=string, outer=(4)]
@@ -217,7 +217,7 @@ SELECT COALESCE(i, NULL, NULL) FROM a
 ----
 project
  ├── columns: column7:7(int)
- ├── scan
+ ├── scan a
  │    └── columns: a.i:2(int)
  └── projections [outer=(2)]
       └── coalesce [type=int, outer=(2)]
@@ -233,7 +233,7 @@ SELECT i::int, arr::int[], '[1, 2]'::json::json, null::string::int FROM a
 ----
 project
  ├── columns: column7:7(int) column8:8(int[]) column9:9(jsonb) column10:10(int)
- ├── scan
+ ├── scan a
  │    └── columns: a.i:2(int) a.arr:6(int[])
  └── projections [outer=(2,6)]
       ├── variable: a.i [type=int, outer=(2)]
@@ -247,7 +247,7 @@ SELECT i::float, arr::decimal[], s::json::json FROM a
 ----
 project
  ├── columns: column7:7(float) column8:8(decimal[]) column9:9(jsonb)
- ├── scan
+ ├── scan a
  │    └── columns: a.i:2(int) a.s:4(string) a.arr:6(int[])
  └── projections [outer=(2,4,6)]
       ├── cast: float [type=float, outer=(2)]
@@ -279,7 +279,7 @@ SELECT +null::int, -null::int, ~null::int FROM a
 ----
 project
  ├── columns: column7:7(int) column8:8(int) column9:9(int)
- ├── scan
+ ├── scan a
  └── projections
       ├── null [type=int]
       ├── null [type=int]
@@ -306,7 +306,7 @@ FROM a
 ----
 project
  ├── columns: column7:7(int) column8:8(int) column9:9(decimal) column10:10(decimal) column11:11(float) column12:12(float) column13:13(int) column14:14(int) column15:15(jsonb) column16:16(jsonb) column17:17(decimal[]) column18:18(string[]) column19:19(decimal[]) column20:20(float[])
- ├── scan
+ ├── scan a
  │    └── columns: a.i:2(int) a.arr:6(int[])
  └── projections [outer=(2,6)]
       ├── null [type=int]
@@ -344,7 +344,7 @@ SELECT null IN (i), null NOT IN (s) FROM a
 ----
 project
  ├── columns: column7:7(bool) column8:8(bool)
- ├── scan
+ ├── scan a
  └── projections
       ├── null [type=bool]
       └── null [type=bool]
@@ -357,7 +357,7 @@ SELECT i IN (null, null), k NOT IN (1 * null, null::int, 1 < null) FROM a
 ----
 project
  ├── columns: column7:7(bool) column8:8(bool)
- ├── scan
+ ├── scan a
  └── projections
       ├── null [type=bool]
       └── null [type=bool]
@@ -370,7 +370,7 @@ SELECT i IN (2, 1, 1, null, 3, null, 2, 3.0) FROM a
 ----
 project
  ├── columns: column7:7(bool)
- ├── scan
+ ├── scan a
  │    └── columns: a.i:2(int)
  └── projections [outer=(2)]
       └── in [type=bool, outer=(2)]
@@ -386,7 +386,7 @@ SELECT s NOT IN ('foo', s || 'foo', 'bar', length(s)::string, NULL) FROM a
 ----
 project
  ├── columns: column7:7(bool)
- ├── scan
+ ├── scan a
  │    └── columns: a.s:4(string)
  └── projections [outer=(4)]
       └── not-in [type=bool, outer=(4)]

--- a/pkg/sql/opt/xform/testdata/rules/select
+++ b/pkg/sql/opt/xform/testdata/rules/select
@@ -27,7 +27,7 @@ SELECT * FROM a WHERE i=5 AND s<'foo'
 ----
 select
  ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
- ├── scan
+ ├── scan a
  │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
  └── filters [type=bool, outer=(2,4)]
       ├── eq [type=bool, outer=(2)]
@@ -45,7 +45,7 @@ SELECT * FROM a WHERE i<5
 ----
 select
  ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
- ├── scan
+ ├── scan a
  │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
  └── filters [type=bool, outer=(2)]
       └── lt [type=bool, outer=(2)]
@@ -57,7 +57,7 @@ SELECT * FROM a WHERE i<5 OR s='foo'
 ----
 select
  ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
- ├── scan
+ ├── scan a
  │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
  └── filters [type=bool, outer=(2,4)]
       └── or [type=bool, outer=(2,4)]
@@ -72,7 +72,7 @@ select
 opt
 SELECT * FROM a WHERE True
 ----
-scan
+scan a
  └── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
 
 opt
@@ -80,7 +80,7 @@ SELECT * FROM a WHERE False
 ----
 select
  ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
- ├── scan
+ ├── scan a
  │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
  └── false [type=bool]
 
@@ -90,7 +90,7 @@ select
 opt
 SELECT * FROM a WHERE True
 ----
-scan
+scan a
  └── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
 
 # --------------------------------------------------
@@ -101,7 +101,7 @@ SELECT * FROM (SELECT * FROM a WHERE False) WHERE s='foo'
 ----
 select
  ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
- ├── scan
+ ├── scan a
  │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
  └── false [type=bool]
 
@@ -110,7 +110,7 @@ SELECT * FROM (SELECT * FROM a WHERE i=1) WHERE False
 ----
 select
  ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
- ├── scan
+ ├── scan a
  │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
  └── false [type=bool]
 
@@ -119,7 +119,7 @@ SELECT * FROM (SELECT * FROM a WHERE i=1) WHERE False
 ----
 select
  ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
- ├── scan
+ ├── scan a
  │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
  └── false [type=bool]
 
@@ -128,7 +128,7 @@ SELECT * FROM (SELECT * FROM a WHERE i<5) WHERE s='foo'
 ----
 select
  ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
- ├── scan
+ ├── scan a
  │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
  └── filters [type=bool, outer=(2,4)]
       ├── lt [type=bool, outer=(2)]
@@ -143,7 +143,7 @@ SELECT * FROM (SELECT * FROM a WHERE i>1 AND i<10) WHERE s='foo' OR k=5
 ----
 select
  ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
- ├── scan
+ ├── scan a
  │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
  └── filters [type=bool, outer=(1,2,4)]
       ├── gt [type=bool, outer=(2)]
@@ -170,13 +170,13 @@ inner-join
  ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb) x:6(int!null) y:7(int)
  ├── select
  │    ├── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
- │    ├── scan
+ │    ├── scan a
  │    │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
  │    └── filters [type=bool, outer=(3)]
  │         └── eq [type=bool, outer=(3)]
  │              ├── variable: a.f [type=float, outer=(3)]
  │              └── const: 1.1 [type=float]
- ├── scan
+ ├── scan b
  │    └── columns: b.x:6(int!null) b.y:7(int)
  └── filters [type=bool, outer=(1,6)]
       └── eq [type=bool, outer=(1,6)]
@@ -192,7 +192,7 @@ select
  │    ├── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb) b.x:6(int) b.y:7(int)
  │    ├── select
  │    │    ├── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
- │    │    ├── scan
+ │    │    ├── scan a
  │    │    │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
  │    │    └── filters [type=bool, outer=(3,4)]
  │    │         ├── eq [type=bool, outer=(3)]
@@ -205,7 +205,7 @@ select
  │    │              └── eq [type=bool, outer=(4)]
  │    │                   ├── variable: a.s [type=string, outer=(4)]
  │    │                   └── const: 'bar' [type=string]
- │    ├── scan
+ │    ├── scan b
  │    │    └── columns: b.x:6(int!null) b.y:7(int)
  │    └── filters [type=bool, outer=(1,6)]
  │         └── eq [type=bool, outer=(1,6)]
@@ -224,7 +224,7 @@ inner-join
  ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb) x:6(int!null) y:7(int)
  ├── select
  │    ├── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
- │    ├── scan
+ │    ├── scan a
  │    │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
  │    └── filters [type=bool, outer=(2)]
  │         ├── eq [type=bool, outer=(2)]
@@ -233,7 +233,7 @@ inner-join
  │         └── gt [type=bool]
  │              ├── function: now [type=timestamptz]
  │              └── const: '2000-01-01 01:00:00+00:00' [type=timestamptz]
- ├── scan
+ ├── scan b
  │    └── columns: b.x:6(int!null) b.y:7(int)
  └── true [type=bool]
 
@@ -245,9 +245,9 @@ select
  ├── columns: k:1(int) i:2(int) f:3(float) s:4(string) j:5(jsonb) x:6(int!null) y:7(int)
  ├── right-join
  │    ├── columns: a.k:1(int) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb) b.x:6(int!null) b.y:7(int)
- │    ├── scan
+ │    ├── scan a
  │    │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
- │    ├── scan
+ │    ├── scan b
  │    │    └── columns: b.x:6(int!null) b.y:7(int)
  │    └── filters [type=bool, outer=(1,6)]
  │         └── eq [type=bool, outer=(1,6)]
@@ -266,9 +266,9 @@ select
  ├── columns: k:1(int) i:2(int) f:3(float) s:4(string) j:5(jsonb) x:6(int) y:7(int)
  ├── full-join
  │    ├── columns: a.k:1(int) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb) b.x:6(int) b.y:7(int)
- │    ├── scan
+ │    ├── scan a
  │    │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
- │    ├── scan
+ │    ├── scan b
  │    │    └── columns: b.x:6(int!null) b.y:7(int)
  │    └── filters [type=bool, outer=(1,6)]
  │         └── eq [type=bool, outer=(1,6)]
@@ -287,11 +287,11 @@ SELECT * FROM b INNER JOIN a ON b.x=a.k WHERE a.f=1.1
 ----
 inner-join
  ├── columns: x:1(int!null) y:2(int) k:3(int!null) i:4(int) f:5(float) s:6(string) j:7(jsonb)
- ├── scan
+ ├── scan b
  │    └── columns: b.x:1(int!null) b.y:2(int)
  ├── select
  │    ├── columns: a.k:3(int!null) a.i:4(int) a.f:5(float) a.s:6(string) a.j:7(jsonb)
- │    ├── scan
+ │    ├── scan a
  │    │    └── columns: a.k:3(int!null) a.i:4(int) a.f:5(float) a.s:6(string) a.j:7(jsonb)
  │    └── filters [type=bool, outer=(5)]
  │         └── eq [type=bool, outer=(5)]
@@ -309,11 +309,11 @@ select
  ├── columns: x:1(int) y:2(int) k:3(int!null) i:4(int) f:5(float) s:6(string) j:7(jsonb)
  ├── right-join
  │    ├── columns: b.x:1(int) b.y:2(int) a.k:3(int!null) a.i:4(int) a.f:5(float) a.s:6(string) a.j:7(jsonb)
- │    ├── scan
+ │    ├── scan b
  │    │    └── columns: b.x:1(int!null) b.y:2(int)
  │    ├── select
  │    │    ├── columns: a.k:3(int!null) a.i:4(int) a.f:5(float) a.s:6(string) a.j:7(jsonb)
- │    │    ├── scan
+ │    │    ├── scan a
  │    │    │    └── columns: a.k:3(int!null) a.i:4(int) a.f:5(float) a.s:6(string) a.j:7(jsonb)
  │    │    └── filters [type=bool, outer=(5,6)]
  │    │         ├── eq [type=bool, outer=(5)]
@@ -343,9 +343,9 @@ select
  ├── columns: x:1(int!null) y:2(int) k:3(int) i:4(int) f:5(float) s:6(string) j:7(jsonb)
  ├── left-join
  │    ├── columns: b.x:1(int!null) b.y:2(int) a.k:3(int) a.i:4(int) a.f:5(float) a.s:6(string) a.j:7(jsonb)
- │    ├── scan
+ │    ├── scan b
  │    │    └── columns: b.x:1(int!null) b.y:2(int)
- │    ├── scan
+ │    ├── scan a
  │    │    └── columns: a.k:3(int!null) a.i:4(int) a.f:5(float) a.s:6(string) a.j:7(jsonb)
  │    └── filters [type=bool, outer=(1,3)]
  │         └── eq [type=bool, outer=(1,3)]
@@ -364,9 +364,9 @@ select
  ├── columns: x:1(int) y:2(int) k:3(int) i:4(int) f:5(float) s:6(string) j:7(jsonb)
  ├── full-join
  │    ├── columns: b.x:1(int) b.y:2(int) a.k:3(int) a.i:4(int) a.f:5(float) a.s:6(string) a.j:7(jsonb)
- │    ├── scan
+ │    ├── scan b
  │    │    └── columns: b.x:1(int!null) b.y:2(int)
- │    ├── scan
+ │    ├── scan a
  │    │    └── columns: a.k:3(int!null) a.i:4(int) a.f:5(float) a.s:6(string) a.j:7(jsonb)
  │    └── filters [type=bool, outer=(1,3)]
  │         └── eq [type=bool, outer=(1,3)]
@@ -385,9 +385,9 @@ SELECT * FROM a, b WHERE a.k=b.x AND (a.s='foo' OR b.y<100)
 ----
 inner-join
  ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb) x:6(int!null) y:7(int)
- ├── scan
+ ├── scan a
  │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
- ├── scan
+ ├── scan b
  │    └── columns: b.x:6(int!null) b.y:7(int)
  └── filters [type=bool, outer=(1,4,6,7)]
       ├── eq [type=bool, outer=(1,6)]
@@ -406,9 +406,9 @@ SELECT * FROM a INNER JOIN b ON a.k=b.x WHERE (a.s='foo' OR b.y<100)
 ----
 inner-join
  ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb) x:6(int!null) y:7(int)
- ├── scan
+ ├── scan a
  │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
- ├── scan
+ ├── scan b
  │    └── columns: b.x:6(int!null) b.y:7(int)
  └── filters [type=bool, outer=(1,4,6,7)]
       ├── eq [type=bool, outer=(1,6)]
@@ -427,9 +427,9 @@ SELECT * FROM a INNER JOIN b ON a.k=b.x WHERE False
 ----
 inner-join
  ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb) x:6(int!null) y:7(int)
- ├── scan
+ ├── scan a
  │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
- ├── scan
+ ├── scan b
  │    └── columns: b.x:6(int!null) b.y:7(int)
  └── false [type=bool]
 
@@ -441,9 +441,9 @@ select
  ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb) x:6(int) y:7(int)
  ├── left-join
  │    ├── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb) b.x:6(int) b.y:7(int)
- │    ├── scan
+ │    ├── scan a
  │    │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
- │    ├── scan
+ │    ├── scan b
  │    │    └── columns: b.x:6(int!null) b.y:7(int)
  │    └── true [type=bool]
  └── filters [type=bool, outer=(1,6)]
@@ -459,9 +459,9 @@ select
  ├── columns: k:1(int) i:2(int) f:3(float) s:4(string) j:5(jsonb) x:6(int!null) y:7(int)
  ├── right-join
  │    ├── columns: a.k:1(int) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb) b.x:6(int!null) b.y:7(int)
- │    ├── scan
+ │    ├── scan a
  │    │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
- │    ├── scan
+ │    ├── scan b
  │    │    └── columns: b.x:6(int!null) b.y:7(int)
  │    └── true [type=bool]
  └── filters [type=bool, outer=(1,6)]
@@ -477,9 +477,9 @@ select
  ├── columns: k:1(int) i:2(int) f:3(float) s:4(string) j:5(jsonb) x:6(int) y:7(int)
  ├── full-join
  │    ├── columns: a.k:1(int) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb) b.x:6(int) b.y:7(int)
- │    ├── scan
+ │    ├── scan a
  │    │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
- │    ├── scan
+ │    ├── scan b
  │    │    └── columns: b.x:6(int!null) b.y:7(int)
  │    └── true [type=bool]
  └── filters [type=bool, outer=(1,6)]
@@ -497,7 +497,7 @@ inner-join
  ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb) x:6(int!null) y:7(int)
  ├── select
  │    ├── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
- │    ├── scan
+ │    ├── scan a
  │    │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
  │    └── filters [type=bool, outer=(3,4)]
  │         ├── eq [type=bool, outer=(3)]
@@ -508,7 +508,7 @@ inner-join
  │              └── const: 'foo' [type=string]
  ├── select
  │    ├── columns: b.x:6(int!null) b.y:7(int)
- │    ├── scan
+ │    ├── scan b
  │    │    └── columns: b.x:6(int!null) b.y:7(int)
  │    └── filters [type=bool, outer=(7)]
  │         └── eq [type=bool, outer=(7)]
@@ -529,7 +529,7 @@ inner-join
  ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb) x:6(int!null) y:7(int)
  ├── select
  │    ├── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
- │    ├── scan
+ │    ├── scan a
  │    │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
  │    └── filters [type=bool, outer=(2)]
  │         ├── eq [type=bool, outer=(2)]
@@ -538,7 +538,7 @@ inner-join
  │         └── gt [type=bool]
  │              ├── function: now [type=timestamptz]
  │              └── const: '2000-01-01 01:00:00+00:00' [type=timestamptz]
- ├── scan
+ ├── scan b
  │    └── columns: b.x:6(int!null) b.y:7(int)
  └── filters [type=bool, outer=(1,6)]
       └── eq [type=bool, outer=(1,6)]
@@ -558,7 +558,7 @@ group-by
  ├── grouping columns: a.i:2(int)
  ├── select
  │    ├── columns: a.i:2(int)
- │    ├── scan
+ │    ├── scan a
  │    │    └── columns: a.i:2(int)
  │    └── filters [type=bool, outer=(2)]
  │         └── eq [type=bool, outer=(2)]
@@ -576,7 +576,7 @@ group-by
  ├── grouping columns: a.i:2(int)
  ├── select
  │    ├── columns: a.i:2(int)
- │    ├── scan
+ │    ├── scan a
  │    │    └── columns: a.i:2(int)
  │    └── filters [type=bool, outer=(2)]
  │         └── eq [type=bool, outer=(2)]
@@ -595,7 +595,7 @@ select
  │    ├── grouping columns: a.k:1(int!null) a.i:2(int)
  │    ├── select
  │    │    ├── columns: a.k:1(int!null) a.i:2(int) a.s:4(string)
- │    │    ├── scan
+ │    │    ├── scan a
  │    │    │    └── columns: a.k:1(int!null) a.i:2(int) a.s:4(string)
  │    │    └── filters [type=bool, outer=(1,2)]
  │    │         └── eq [type=bool, outer=(1,2)]
@@ -617,7 +617,7 @@ select
  ├── columns: c:6(int)
  ├── group-by
  │    ├── columns: c:6(int)
- │    ├── scan
+ │    ├── scan a
  │    └── aggregations
  │         └── function: count_rows [type=int]
  └── filters [type=bool, outer=(6)]

--- a/pkg/sql/opt/xform/testdata/typing
+++ b/pkg/sql/opt/xform/testdata/typing
@@ -31,7 +31,7 @@ SELECT a.x FROM a
 ----
 project
  ├── columns: x:1(int!null)
- ├── scan
+ ├── scan a
  │    └── columns: a.x:1(int!null) a.y:2(int)
  └── projections [outer=(1)]
       └── variable: a.x [type=int, outer=(1)]
@@ -56,7 +56,7 @@ SELECT * FROM a WHERE x = $1
 ----
 select
  ├── columns: x:1(int!null) y:2(int)
- ├── scan
+ ├── scan a
  │    └── columns: a.x:1(int!null) a.y:2(int)
  └── eq [type=bool, outer=(1)]
       ├── variable: a.x [type=int, outer=(1)]
@@ -68,7 +68,7 @@ SELECT (a.x, 1.5), a.y FROM a
 ----
 project
  ├── columns: column3:3(tuple{int, decimal}) y:2(int)
- ├── scan
+ ├── scan a
  │    └── columns: a.x:1(int!null) a.y:2(int)
  └── projections [outer=(1,2)]
       ├── tuple [type=tuple{int, decimal}, outer=(1)]
@@ -82,7 +82,7 @@ SELECT * FROM a WHERE a.x = 1 AND NOT (a.y = 2 OR a.y = 3.5)
 ----
 select
  ├── columns: x:1(int!null) y:2(int)
- ├── scan
+ ├── scan a
  │    └── columns: a.x:1(int!null) a.y:2(int)
  └── and [type=bool, outer=(1,2)]
       ├── eq [type=bool, outer=(1)]
@@ -103,7 +103,7 @@ SELECT * FROM a WHERE a.x = 1 AND a.x <> 2
 ----
 select
  ├── columns: x:1(int!null) y:2(int)
- ├── scan
+ ├── scan a
  │    └── columns: a.x:1(int!null) a.y:2(int)
  └── and [type=bool, outer=(1)]
       ├── eq [type=bool, outer=(1)]
@@ -119,7 +119,7 @@ SELECT * FROM a WHERE a.x >= 1 AND a.x <= 10 AND a.y > 1 AND a.y < 10
 ----
 select
  ├── columns: x:1(int!null) y:2(int)
- ├── scan
+ ├── scan a
  │    └── columns: a.x:1(int!null) a.y:2(int)
  └── and [type=bool, outer=(1,2)]
       ├── and [type=bool, outer=(1,2)]
@@ -143,7 +143,7 @@ SELECT * FROM a WHERE a.x IN (1, 2) AND a.y NOT IN (3, 4)
 ----
 select
  ├── columns: x:1(int!null) y:2(int)
- ├── scan
+ ├── scan a
  │    └── columns: a.x:1(int!null) a.y:2(int)
  └── and [type=bool, outer=(1,2)]
       ├── in [type=bool, outer=(1)]
@@ -163,7 +163,7 @@ SELECT * FROM b WHERE b.x LIKE '%foo%' AND b.x NOT LIKE '%bar%'
 ----
 select
  ├── columns: x:1(string!null) z:2(decimal!null)
- ├── scan
+ ├── scan b
  │    └── columns: b.x:1(string!null) b.z:2(decimal!null)
  └── and [type=bool, outer=(1)]
       ├── like [type=bool, outer=(1)]
@@ -179,7 +179,7 @@ SELECT * FROM b WHERE b.x ILIKE '%foo%' AND b.x NOT ILIKE '%bar%'
 ----
 select
  ├── columns: x:1(string!null) z:2(decimal!null)
- ├── scan
+ ├── scan b
  │    └── columns: b.x:1(string!null) b.z:2(decimal!null)
  └── and [type=bool, outer=(1)]
       ├── i-like [type=bool, outer=(1)]
@@ -195,7 +195,7 @@ SELECT * FROM b WHERE b.x ~ 'foo' AND b.x !~ 'bar' AND b.x ~* 'foo' AND b.x !~* 
 ----
 select
  ├── columns: x:1(string!null) z:2(decimal!null)
- ├── scan
+ ├── scan b
  │    └── columns: b.x:1(string!null) b.z:2(decimal!null)
  └── and [type=bool, outer=(1)]
       ├── and [type=bool, outer=(1)]
@@ -219,7 +219,7 @@ SELECT * FROM a WHERE a.x IS DISTINCT FROM a.y AND a.x IS NULL
 ----
 select
  ├── columns: x:1(int!null) y:2(int)
- ├── scan
+ ├── scan a
  │    └── columns: a.x:1(int!null) a.y:2(int)
  └── and [type=bool, outer=(1,2)]
       ├── is-not [type=bool, outer=(1,2)]
@@ -235,7 +235,7 @@ SELECT a.x & a.y, a.x | a.y, a.x # a.y FROM a
 ----
 project
  ├── columns: column3:3(int) column4:4(int) column5:5(int)
- ├── scan
+ ├── scan a
  │    └── columns: a.x:1(int!null) a.y:2(int)
  └── projections [outer=(1,2)]
       ├── bitand [type=int, outer=(1,2)]
@@ -254,7 +254,7 @@ SELECT a.x + 1.5, DATE '2000-01-01' - 15, 10.10 * a.x, 1 / a.y, a.x // 1.5 FROM 
 ----
 project
  ├── columns: column3:3(decimal) column4:4(date) column5:5(decimal) column6:6(decimal) column7:7(decimal)
- ├── scan
+ ├── scan a
  │    └── columns: a.x:1(int!null) a.y:2(int)
  └── projections [outer=(1,2)]
       ├── plus [type=decimal, outer=(1)]
@@ -279,7 +279,7 @@ SELECT 100.1 % a.x, a.x ^ 2.5, a.x << 3, a.y >> 2 FROM a
 ----
 project
  ├── columns: column3:3(decimal) column4:4(decimal) column5:5(int) column6:6(int)
- ├── scan
+ ├── scan a
  │    └── columns: a.x:1(int!null) a.y:2(int)
  └── projections [outer=(1,2)]
       ├── mod [type=decimal, outer=(1)]
@@ -301,7 +301,7 @@ SELECT b.x || 'more' FROM b
 ----
 project
  ├── columns: column3:3(string)
- ├── scan
+ ├── scan b
  │    └── columns: b.x:1(string!null) b.z:2(decimal!null)
  └── projections [outer=(1)]
       └── concat [type=string, outer=(1)]
@@ -314,7 +314,7 @@ SELECT -a.y, ~a.x FROM a
 ----
 project
  ├── columns: column3:3(int) column4:4(int)
- ├── scan
+ ├── scan a
  │    └── columns: a.x:1(int!null) a.y:2(int)
  └── projections [outer=(1,2)]
       ├── unary-minus [type=int, outer=(2)]
@@ -328,7 +328,7 @@ SELECT arr || arr, arr || NULL, NULL || arr FROM unusual
 ----
 project
  ├── columns: column3:3(int[]) column4:4(int[]) column5:5(int[])
- ├── scan
+ ├── scan unusual
  │    └── columns: unusual.x:1(int!null) unusual.arr:2(int[])
  └── projections [outer=(2)]
       ├── concat [type=int[], outer=(2)]
@@ -347,7 +347,7 @@ SELECT x || arr, arr || x, x || NULL, NULL || x FROM unusual
 ----
 project
  ├── columns: column3:3(int[]) column4:4(int[]) column5:5(int[]) column6:6(int[])
- ├── scan
+ ├── scan unusual
  │    └── columns: unusual.x:1(int!null) unusual.arr:2(int[])
  └── projections [outer=(1,2)]
       ├── concat [type=int[], outer=(1,2)]


### PR DESCRIPTION
Add name of Scan table when outputting the expression tree in tests
and for debugging. This makes the output easier to understand.

Release note: None