### PR TITLE
ui: timeseries: add per-node CPU and memory usage charts

### DIFF
--- a/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/runtime.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/runtime.tsx
@@ -17,6 +17,41 @@ export default function (props: GraphDashboardProps) {
     </LineGraph>,
 
     <LineGraph
+      title="CPU Time (per-node)"
+      sources={nodeSources}
+      tooltip={`CPU usage per node, in CPU seconds per second. E.g. if a node has four
+        cores all at 100%, the value will be 4.`}
+    >
+      <Axis units={AxisUnits.Count} label="cpu seconds / second">
+        {
+          _.map(nodeIDs, (nid) => {
+            return (
+              <Metric
+                name="cr.node.sys.cpu.user.percent"
+                title={nodeDisplayName(nodesSummary, nid)}
+                sources={[nid]}
+              />
+            );
+          })
+        }
+      </Axis>
+    </LineGraph>,
+
+    <LineGraph
+      title="CPU Time (aggregated)"
+      sources={nodeSources}
+      tooltip={
+        `The amount of CPU time used by CockroachDB (User)
+           and system-level operations (Sys) ${tooltipSelection}.`
+      }
+    >
+      <Axis units={AxisUnits.Duration} label="cpu time">
+        <Metric name="cr.node.sys.cpu.user.ns" title="User CPU Time" nonNegativeRate />
+        <Metric name="cr.node.sys.cpu.sys.ns" title="Sys CPU Time" nonNegativeRate />
+      </Axis>
+    </LineGraph>,
+
+    <LineGraph
       title="Memory Usage"
       sources={nodeSources}
       tooltip={(
@@ -84,20 +119,6 @@ export default function (props: GraphDashboardProps) {
     >
       <Axis units={AxisUnits.Duration} label="pause time">
         <Metric name="cr.node.sys.gc.pause.ns" title="GC Pause Time" nonNegativeRate />
-      </Axis>
-    </LineGraph>,
-
-    <LineGraph
-      title="CPU Time"
-      sources={nodeSources}
-      tooltip={
-        `The amount of CPU time used by CockroachDB (User)
-           and system-level operations (Sys) ${tooltipSelection}.`
-      }
-    >
-      <Axis units={AxisUnits.Duration} label="cpu time">
-        <Metric name="cr.node.sys.cpu.user.ns" title="User CPU Time" nonNegativeRate />
-        <Metric name="cr.node.sys.cpu.sys.ns" title="Sys CPU Time" nonNegativeRate />
       </Axis>
     </LineGraph>,
 

--- a/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/runtime.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/runtime.tsx
@@ -52,7 +52,27 @@ export default function (props: GraphDashboardProps) {
     </LineGraph>,
 
     <LineGraph
-      title="Memory Usage"
+      title="Memory Usage (per-node RSS)"
+      sources={nodeSources}
+      tooltip={`Per-node Resident Set Size.`}
+    >
+      <Axis units={AxisUnits.Bytes} label="memory usage">
+        {
+          _.map(nodeIDs, (nid) => {
+            return (
+              <Metric
+                name="cr.node.sys.rss"
+                title={nodeDisplayName(nodesSummary, nid)}
+                sources={[nid]}
+              />
+            );
+          })
+        }
+      </Axis>
+    </LineGraph>,
+
+    <LineGraph
+      title="Memory Usage (aggregated)"
       sources={nodeSources}
       tooltip={(
         <div>


### PR DESCRIPTION
In #23379, @petermattis asked for the ability to switch from aggregated to per-node charts, to see what nodes are overloaded. That would be a fairly general change to our TS code; in the meantime it seems useful to at least be able to see per-node CPU and memory to get a basic sense of what nodes are overloaded.

### Before:
CPU time aggregated across the cluster:
![image](https://user-images.githubusercontent.com/7341/37295035-8d462ffa-25ed-11e8-8034-4ac6ed56107b.png)
Memory usage by type, but not by node:
![image](https://user-images.githubusercontent.com/7341/37295042-9157a344-25ed-11e8-8ce2-f126c2a35d46.png)

### After:
- Add per-node CPU time and per-node memory
![image](https://user-images.githubusercontent.com/7341/37298773-b14f9706-25f7-11e8-8ad7-e516047941fe.png)