### PR TITLE
opt: build LIMIT/OFFSET

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/orderby
+++ b/pkg/sql/opt/exec/execbuilder/testdata/orderby
@@ -89,25 +89,26 @@ a:int
 2
 1
 
-exec-explain
-SELECT a, b FROM t ORDER BY b LIMIT 2
-----
-sort            0  sort    ·         ·          (a, b)     +b
- │              0  ·       order     +b         ·          ·
- └── render     1  render  ·         ·          (a, b)     ·
-      │         1  ·       render 0  a          ·          ·
-      │         1  ·       render 1  b          ·          ·
-      └── scan  2  scan    ·         ·          (a, b, c)  ·
-·               2  ·       table     t@primary  ·          ·
-·               2  ·       spans     ALL        ·          ·
-
-exec
-SELECT a, b FROM t ORDER BY b DESC LIMIT 2
-----
-a:int  b:int
-1      9
-2      8
-3      7
+# TODO(radu): LIMIT not supported.
+#exec-explain
+#SELECT a, b FROM t ORDER BY b LIMIT 2
+#----
+#sort            0  sort    ·         ·          (a, b)     +b
+# │              0  ·       order     +b         ·          ·
+# └── render     1  render  ·         ·          (a, b)     ·
+#      │         1  ·       render 0  a          ·          ·
+#      │         1  ·       render 1  b          ·          ·
+#      └── scan  2  scan    ·         ·          (a, b, c)  ·
+#·               2  ·       table     t@primary  ·          ·
+#·               2  ·       spans     ALL        ·          ·
+#
+#exec
+#SELECT a, b FROM t ORDER BY b DESC LIMIT 2
+#----
+#a:int  b:int
+#1      9
+#2      8
+#3      7
 
 # TODO(radu): this does not work. Unclear if we want to support it or not.
 #exec-explain
@@ -277,25 +278,26 @@ a:int
 4
 5
 
-exec
-(((SELECT a FROM t))) ORDER BY a DESC LIMIT 4
-----
-a:int
-5
-4
-3
-2
-1
-
-exec
-(((SELECT a FROM t ORDER BY a DESC LIMIT 4)))
-----
-a:int
-5
-4
-3
-2
-1
+# TODO(radu): LIMIT not supported.
+#exec
+#(((SELECT a FROM t))) ORDER BY a DESC LIMIT 4
+#----
+#a:int
+#5
+#4
+#3
+#2
+#1
+#
+#exec
+#(((SELECT a FROM t ORDER BY a DESC LIMIT 4)))
+#----
+#a:int
+#5
+#4
+#3
+#2
+#1
 
 # TODO(radu): functions as tables not yet implemented
 #exec

--- a/pkg/sql/opt/factory.og.go
+++ b/pkg/sql/opt/factory.og.go
@@ -466,4 +466,16 @@ type Factory interface {
 	// of the ExceptAll with the output columns. See the comment above
 	// opt.SetOpColMap for more details.
 	ConstructExceptAll(left GroupID, right GroupID, colMap PrivateID) GroupID
+
+	// ConstructLimit constructs an expression for the Limit operator.
+	// Limit returns a limited subset of the results in the input relation.
+	// The limit expression is a scalar value; the operator returns at most this many
+	// rows. The private field is an *opt.Ordering which indicates the desired
+	// row ordering (the first rows with respect to this ordering are returned).
+	ConstructLimit(input GroupID, limit GroupID, ordering PrivateID) GroupID
+
+	// ConstructOffset constructs an expression for the Offset operator.
+	// Offset filters out the first Offset rows of the input relation; used in
+	// conjunction with Limit.
+	ConstructOffset(input GroupID, offset GroupID, ordering PrivateID) GroupID
 }

--- a/pkg/sql/opt/operator.og.go
+++ b/pkg/sql/opt/operator.og.go
@@ -365,6 +365,16 @@ const (
 	// opt.SetOpColMap for more details.
 	ExceptAllOp
 
+	// LimitOp returns a limited subset of the results in the input relation.
+	// The limit expression is a scalar value; the operator returns at most this many
+	// rows. The private field is an *opt.Ordering which indicates the desired
+	// row ordering (the first rows with respect to this ordering are returned).
+	LimitOp
+
+	// OffsetOp filters out the first Offset rows of the input relation; used in
+	// conjunction with Limit.
+	OffsetOp
+
 	// ------------------------------------------------------------
 	// Enforcer Operators
 	// ------------------------------------------------------------
@@ -380,9 +390,9 @@ const (
 	NumOperators
 )
 
-const opNames = "unknownsubqueryvariableconstnulltruefalseplaceholdertupleprojectionsaggregationsexistsfiltersandornoteqltgtlegeneinnot-inlikenot-likei-likenot-i-likesimilar-tonot-similar-toreg-matchnot-reg-matchreg-i-matchnot-reg-i-matchisis-notcontainsbitandbitorbitxorplusminusmultdivfloor-divmodpowconcatl-shiftr-shiftfetch-valfetch-textfetch-val-pathfetch-text-pathunary-minusunary-complementcastcasewhenfunctioncoalesceunsupported-exprscanvaluesselectprojectinner-joinleft-joinright-joinfull-joinsemi-joinanti-joininner-join-applyleft-join-applyright-join-applyfull-join-applysemi-join-applyanti-join-applygroup-byunionintersectexceptunion-allintersect-allexcept-allsort"
+const opNames = "unknownsubqueryvariableconstnulltruefalseplaceholdertupleprojectionsaggregationsexistsfiltersandornoteqltgtlegeneinnot-inlikenot-likei-likenot-i-likesimilar-tonot-similar-toreg-matchnot-reg-matchreg-i-matchnot-reg-i-matchisis-notcontainsbitandbitorbitxorplusminusmultdivfloor-divmodpowconcatl-shiftr-shiftfetch-valfetch-textfetch-val-pathfetch-text-pathunary-minusunary-complementcastcasewhenfunctioncoalesceunsupported-exprscanvaluesselectprojectinner-joinleft-joinright-joinfull-joinsemi-joinanti-joininner-join-applyleft-join-applyright-join-applyfull-join-applysemi-join-applyanti-join-applygroup-byunionintersectexceptunion-allintersect-allexcept-alllimitoffsetsort"
 
-var opIndexes = [...]uint32{0, 7, 15, 23, 28, 32, 36, 41, 52, 57, 68, 80, 86, 93, 96, 98, 101, 103, 105, 107, 109, 111, 113, 115, 121, 125, 133, 139, 149, 159, 173, 182, 195, 206, 221, 223, 229, 237, 243, 248, 254, 258, 263, 267, 270, 279, 282, 285, 291, 298, 305, 314, 324, 338, 353, 364, 380, 384, 388, 392, 400, 408, 424, 428, 434, 440, 447, 457, 466, 476, 485, 494, 503, 519, 534, 550, 565, 580, 595, 603, 608, 617, 623, 632, 645, 655, 659}
+var opIndexes = [...]uint32{0, 7, 15, 23, 28, 32, 36, 41, 52, 57, 68, 80, 86, 93, 96, 98, 101, 103, 105, 107, 109, 111, 113, 115, 121, 125, 133, 139, 149, 159, 173, 182, 195, 206, 221, 223, 229, 237, 243, 248, 254, 258, 263, 267, 270, 279, 282, 285, 291, 298, 305, 314, 324, 338, 353, 364, 380, 384, 388, 392, 400, 408, 424, 428, 434, 440, 447, 457, 466, 476, 485, 494, 503, 519, 534, 550, 565, 580, 595, 603, 608, 617, 623, 632, 645, 655, 660, 666, 670}
 
 var ScalarOperators = [...]Operator{
 	SubqueryOp,
@@ -537,6 +547,8 @@ var RelationalOperators = [...]Operator{
 	UnionAllOp,
 	IntersectAllOp,
 	ExceptAllOp,
+	LimitOp,
+	OffsetOp,
 }
 
 var JoinOperators = [...]Operator{

--- a/pkg/sql/opt/ops/relational.opt
+++ b/pkg/sql/opt/ops/relational.opt
@@ -193,8 +193,8 @@ define Union {
 # opt.SetOpColMap for more details.
 [Relational]
 define Intersect {
-    Left  Expr
-    Right Expr
+    Left   Expr
+    Right  Expr
     ColMap SetOpColMap
 }
 
@@ -206,8 +206,8 @@ define Intersect {
 # for more details.
 [Relational]
 define Except {
-    Left  Expr
-    Right Expr
+    Left   Expr
+    Right  Expr
     ColMap SetOpColMap
 }
 
@@ -254,8 +254,8 @@ define UnionAll {
 # opt.SetOpColMap for more details.
 [Relational]
 define IntersectAll {
-    Left  Expr
-    Right Expr
+    Left   Expr
+    Right  Expr
     ColMap SetOpColMap
 }
 
@@ -279,7 +279,27 @@ define IntersectAll {
 # opt.SetOpColMap for more details.
 [Relational]
 define ExceptAll {
-    Left  Expr
-    Right Expr
+    Left   Expr
+    Right  Expr
     ColMap SetOpColMap
+}
+
+# Limit returns a limited subset of the results in the input relation.
+# The limit expression is a scalar value; the operator returns at most this many
+# rows. The private field is an *opt.Ordering which indicates the desired
+# row ordering (the first rows with respect to this ordering are returned).
+[Relational]
+define Limit {
+    Input    Expr
+    Limit    Expr
+    Ordering Ordering
+}
+
+# Offset filters out the first Offset rows of the input relation; used in
+# conjunction with Limit.
+[Relational]
+define Offset {
+    Input    Expr
+    Offset   Expr
+    Ordering Ordering
 }

--- a/pkg/sql/opt/optbuilder/limit.go
+++ b/pkg/sql/opt/optbuilder/limit.go
@@ -1,0 +1,48 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package optbuilder
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/sql/opt"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
+)
+
+// buildLimit adds Limit and Offset operators according to the Limit clause.
+//
+// parentScope is the scope for the LIMIT/OFFSET expressions; this is not the
+// same as inScope, because statements like:
+//   SELECT k FROM kv LIMIT k
+// are not valid.
+func (b *Builder) buildLimit(
+	limit *tree.Limit, parentScope *scope, in opt.GroupID, inScope *scope,
+) (out opt.GroupID, outScope *scope) {
+	out, outScope = in, inScope
+
+	ordering := inScope.ordering
+	orderingPrivID := b.factory.InternPrivate(&ordering)
+
+	if limit.Offset != nil {
+		texpr := parentScope.resolveType(limit.Offset, types.Int)
+		offset := b.buildScalar(texpr, parentScope)
+		out = b.factory.ConstructOffset(out, offset, orderingPrivID)
+	}
+	if limit.Count != nil {
+		texpr := parentScope.resolveType(limit.Count, types.Int)
+		limit := b.buildScalar(texpr, parentScope)
+		out = b.factory.ConstructLimit(out, limit, orderingPrivID)
+	}
+	return out, outScope
+}

--- a/pkg/sql/opt/optbuilder/select.go
+++ b/pkg/sql/opt/optbuilder/select.go
@@ -182,8 +182,11 @@ func (b *Builder) buildSelect(
 		out, outScope = b.buildOrderBy(orderBy, out, projections, outScope, projectionsScope)
 	}
 
+	if stmt.Limit != nil {
+		out, outScope = b.buildLimit(stmt.Limit, inScope, out, outScope)
+	}
+
 	// TODO(rytaft): Support FILTER expression.
-	// TODO(peter): stmt.Limit
 	return out, outScope
 }
 
@@ -192,7 +195,6 @@ func (b *Builder) buildSelect(
 // select clause in order to handle ORDER BY scoping rules. ORDER BY can sort
 // results using columns from the FROM/GROUP BY clause and/or from the
 // projection list.
-// TODO(rytaft): Add support for ORDER BY, DISTINCT and HAVING.
 //
 // See Builder.buildStmt for a description of the remaining input and
 // return values.

--- a/pkg/sql/opt/optbuilder/testdata/limit
+++ b/pkg/sql/opt/optbuilder/testdata/limit
@@ -1,0 +1,204 @@
+# tests adapted from logictest -- limit
+
+exec-ddl
+CREATE TABLE t (k INT PRIMARY KEY, v INT, w INT, INDEX(v))
+----
+TABLE t
+ ├── k int not null
+ ├── v int
+ ├── w int
+ ├── INDEX primary
+ │    └── k int not null
+ └── INDEX secondary
+      ├── v int
+      └── k int not null
+
+build
+SELECT k, v FROM t ORDER BY k LIMIT 5
+----
+limit
+ ├── columns: k:1(int!null) v:2(int)
+ ├── ordering: +1
+ ├── project
+ │    ├── columns: t.k:1(int!null) t.v:2(int)
+ │    ├── ordering: +1
+ │    ├── scan
+ │    │    ├── columns: t.k:1(int!null) t.v:2(int) t.w:3(int)
+ │    │    └── ordering: +1
+ │    └── projections [outer=(1,2)]
+ │         ├── variable: t.k [type=int, outer=(1)]
+ │         └── variable: t.v [type=int, outer=(2)]
+ └── const: 5 [type=int]
+
+build
+SELECT k, v FROM t ORDER BY v FETCH FIRST 5 ROWS ONLY
+----
+limit
+ ├── columns: k:1(int!null) v:2(int)
+ ├── ordering: +2
+ ├── project
+ │    ├── columns: t.k:1(int!null) t.v:2(int)
+ │    ├── ordering: +2
+ │    ├── sort
+ │    │    ├── columns: t.k:1(int!null) t.v:2(int) t.w:3(int)
+ │    │    ├── ordering: +2
+ │    │    └── scan
+ │    │         └── columns: t.k:1(int!null) t.v:2(int) t.w:3(int)
+ │    └── projections [outer=(1,2)]
+ │         ├── variable: t.k [type=int, outer=(1)]
+ │         └── variable: t.v [type=int, outer=(2)]
+ └── const: 5 [type=int]
+
+build
+SELECT k, v FROM t LIMIT (1+2)
+----
+limit
+ ├── columns: k:1(int!null) v:2(int)
+ ├── project
+ │    ├── columns: t.k:1(int!null) t.v:2(int)
+ │    ├── scan
+ │    │    └── columns: t.k:1(int!null) t.v:2(int) t.w:3(int)
+ │    └── projections [outer=(1,2)]
+ │         ├── variable: t.k [type=int, outer=(1)]
+ │         └── variable: t.v [type=int, outer=(2)]
+ └── const: 3 [type=int]
+
+build
+SELECT k FROM t ORDER BY k FETCH FIRST ROW ONLY
+----
+limit
+ ├── columns: k:1(int!null)
+ ├── ordering: +1
+ ├── project
+ │    ├── columns: t.k:1(int!null)
+ │    ├── ordering: +1
+ │    ├── scan
+ │    │    ├── columns: t.k:1(int!null) t.v:2(int) t.w:3(int)
+ │    │    └── ordering: +1
+ │    └── projections [outer=(1)]
+ │         └── variable: t.k [type=int, outer=(1)]
+ └── const: 1 [type=int]
+
+build
+SELECT k FROM t ORDER BY k OFFSET 3 ROWS FETCH NEXT ROW ONLY
+----
+limit
+ ├── columns: k:1(int!null)
+ ├── ordering: +1
+ ├── offset
+ │    ├── columns: t.k:1(int!null)
+ │    ├── ordering: +1
+ │    ├── project
+ │    │    ├── columns: t.k:1(int!null)
+ │    │    ├── ordering: +1
+ │    │    ├── scan
+ │    │    │    ├── columns: t.k:1(int!null) t.v:2(int) t.w:3(int)
+ │    │    │    └── ordering: +1
+ │    │    └── projections [outer=(1)]
+ │    │         └── variable: t.k [type=int, outer=(1)]
+ │    └── const: 3 [type=int]
+ └── const: 1 [type=int]
+
+build
+SELECT k, v FROM t ORDER BY k OFFSET 5
+----
+offset
+ ├── columns: k:1(int!null) v:2(int)
+ ├── ordering: +1
+ ├── project
+ │    ├── columns: t.k:1(int!null) t.v:2(int)
+ │    ├── ordering: +1
+ │    ├── scan
+ │    │    ├── columns: t.k:1(int!null) t.v:2(int) t.w:3(int)
+ │    │    └── ordering: +1
+ │    └── projections [outer=(1,2)]
+ │         ├── variable: t.k [type=int, outer=(1)]
+ │         └── variable: t.v [type=int, outer=(2)]
+ └── const: 5 [type=int]
+
+build
+SELECT k FROM t ORDER BY k FETCH FIRST (1+1) ROWS ONLY
+----
+limit
+ ├── columns: k:1(int!null)
+ ├── ordering: +1
+ ├── project
+ │    ├── columns: t.k:1(int!null)
+ │    ├── ordering: +1
+ │    ├── scan
+ │    │    ├── columns: t.k:1(int!null) t.v:2(int) t.w:3(int)
+ │    │    └── ordering: +1
+ │    └── projections [outer=(1)]
+ │         └── variable: t.k [type=int, outer=(1)]
+ └── const: 2 [type=int]
+
+build
+SELECT k FROM T LIMIT k
+----
+error: column name "k" not found
+
+build
+SELECT k FROM T LIMIT v
+----
+error: column name "v" not found
+
+build
+SELECT SUM(w) FROM t GROUP BY k, v ORDER BY v DESC LIMIT 10
+----
+limit
+ ├── columns: column4:4(decimal)
+ ├── ordering: -2
+ ├── project
+ │    ├── columns: column4:4(decimal) t.v:2(int)
+ │    ├── ordering: -2
+ │    ├── sort
+ │    │    ├── columns: t.k:1(int!null) t.v:2(int) column4:4(decimal)
+ │    │    ├── ordering: -2
+ │    │    └── group-by
+ │    │         ├── columns: t.k:1(int!null) t.v:2(int) column4:4(decimal)
+ │    │         ├── grouping columns: t.k:1(int!null) t.v:2(int)
+ │    │         ├── scan
+ │    │         │    └── columns: t.k:1(int!null) t.v:2(int) t.w:3(int)
+ │    │         └── aggregations [outer=(3)]
+ │    │              └── function: sum [type=decimal, outer=(3)]
+ │    │                   └── variable: t.w [type=int, outer=(3)]
+ │    └── projections [outer=(2,4)]
+ │         ├── variable: column4 [type=decimal, outer=(4)]
+ │         └── variable: t.v [type=int, outer=(2)]
+ └── const: 10 [type=int]
+
+build
+SELECT DISTINCT v FROM T ORDER BY v LIMIT 10
+----
+limit
+ ├── columns: v:2(int)
+ ├── ordering: +2
+ ├── sort
+ │    ├── columns: t.v:2(int)
+ │    ├── ordering: +2
+ │    └── group-by
+ │         ├── columns: t.v:2(int)
+ │         ├── grouping columns: t.v:2(int)
+ │         ├── scan
+ │         │    └── columns: t.k:1(int!null) t.v:2(int) t.w:3(int)
+ │         └── aggregations
+ └── const: 10 [type=int]
+
+build
+VALUES (1,1), (2,2) ORDER BY 1 LIMIT 1
+----
+limit
+ ├── columns: column1:1(int) column2:2(int)
+ ├── ordering: +1
+ ├── sort
+ │    ├── columns: column1:1(int) column2:2(int)
+ │    ├── ordering: +1
+ │    └── values
+ │         ├── columns: column1:1(int) column2:2(int)
+ │         ├── tuple [type=tuple{int, int}]
+ │         │    ├── const: 1 [type=int]
+ │         │    └── const: 1 [type=int]
+ │         └── tuple [type=tuple{int, int}]
+ │              ├── const: 2 [type=int]
+ │              └── const: 2 [type=int]
+ └── const: 1 [type=int]

--- a/pkg/sql/opt/physical_props.go
+++ b/pkg/sql/opt/physical_props.go
@@ -115,6 +115,11 @@ func (p *PhysicalProps) String() string {
 	return p.Fingerprint()
 }
 
+// Equals returns true if the two physical properties are identical.
+func (p *PhysicalProps) Equals(rhs *PhysicalProps) bool {
+	return p.Presentation.Equals(rhs.Presentation) && p.Ordering.Equals(rhs.Ordering)
+}
+
 // Presentation specifies the naming, membership (including duplicates), and
 // order of result columns that are required of or provided by an operator.
 // While it cannot add unique columns, Presentation can rename, reorder,
@@ -128,15 +133,15 @@ func (p Presentation) Defined() bool {
 	return p != nil
 }
 
-// Provides returns true iff this presentation exactly matches the given
+// Equals returns true iff this presentation exactly matches the given
 // presentation.
-func (p Presentation) Provides(required Presentation) bool {
-	if len(p) != len(required) {
+func (p Presentation) Equals(rhs Presentation) bool {
+	if len(p) != len(rhs) {
 		return false
 	}
 
 	for i := 0; i < len(p); i++ {
-		if p[i] != required[i] {
+		if p[i] != rhs[i] {
 			return false
 		}
 	}
@@ -229,6 +234,20 @@ func (o Ordering) Provides(required Ordering) bool {
 
 	for i := range required {
 		if o[i] != required[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// Equals returns true if the two orderings are identical.
+func (o Ordering) Equals(rhs Ordering) bool {
+	if len(o) != len(rhs) {
+		return false
+	}
+
+	for i := range o {
+		if o[i] != rhs[i] {
 			return false
 		}
 	}

--- a/pkg/sql/opt/physical_props_test.go
+++ b/pkg/sql/opt/physical_props_test.go
@@ -41,12 +41,12 @@ func TestPhysicalProps(t *testing.T) {
 		t.Error("presentation should be defined")
 	}
 
-	if !presentation.Provides(presentation) {
-		t.Error("presentation should provide itself")
+	if !presentation.Equals(presentation) {
+		t.Error("presentation should equal itself")
 	}
 
-	if presentation.Provides(opt.Presentation{}) {
-		t.Error("presentation should not provide the empty presentation")
+	if presentation.Equals(opt.Presentation{}) {
+		t.Error("presentation should not equal the empty presentation")
 	}
 
 	// Add Ordering props.
@@ -72,6 +72,18 @@ func TestPhysicalProps(t *testing.T) {
 
 	if !ordering.Provides(opt.Ordering{}) {
 		t.Error("ordering should provide the empty ordering")
+	}
+
+	if !ordering.Equals(ordering) {
+		t.Error("ordering should be equal with itself")
+	}
+
+	if ordering.Equals(opt.Ordering{}) {
+		t.Error("ordering should not equal the empty ordering")
+	}
+
+	if (opt.Ordering{}).Equals(ordering) {
+		t.Error("empty ordering should not equal ordering")
 	}
 }
 


### PR DESCRIPTION
Support for Limit and Offset. We use two operators because we can't
have three children and a private in a single operator; use of offset
should be relatively rare and we should be able to coalesce the
operators at execbuild time.

Release note: None