### PR TITLE
cherrypick-2.0: ui: update labels for Snapshots chart on Replication dashboard

### DIFF
--- a/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/replication.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/replication.tsx
@@ -90,8 +90,8 @@ export default function (props: GraphDashboardProps) {
     <LineGraph title="Snapshots" sources={storeSources}>
       <Axis label="snapshots">
         <Metric name="cr.store.range.snapshots.generated" title="Generated" nonNegativeRate />
-        <Metric name="cr.store.range.snapshots.normal-applied" title="Normal-applied" nonNegativeRate />
-        <Metric name="cr.store.range.snapshots.preemptive-applied" title="Preemptive-applied" nonNegativeRate />
+        <Metric name="cr.store.range.snapshots.normal-applied" title="Applied (Raft-initiated)" nonNegativeRate />
+        <Metric name="cr.store.range.snapshots.preemptive-applied" title="Applied (Preemptive)" nonNegativeRate />
         <Metric name="cr.store.replicas.reserved" title="Reserved" nonNegativeRate />
       </Axis>
     </LineGraph>,


### PR DESCRIPTION
Since snapshots that we had labeled "normal" are actually rare, this PR updates
the label to be more specific: Raft-initiated vs. Preemptive.

Fixes: #23592
Release note (admin ui change): Update the labels for the Snapshots chart on
the Replication dashboard to be more specific.

A cherry-pick of #23729 

cc @cockroachdb/release @BramGruneir 