### PR TITLE
build: rely more on Go 1.10's package cache

### DIFF
--- a/build/builder.sh
+++ b/build/builder.sh
@@ -165,19 +165,6 @@ vols="${vols} --volume=${gocache}/docker/native:/go/native${delegated_volume_mod
 mkdir -p "${gocache}"/docker/pkg
 vols="${vols} --volume=${gocache}/docker/pkg:/go/pkg${delegated_volume_mode}"
 
-# TODO(tamird,benesch): this is horrible, but we do it because we want to
-# cache stdlib artifacts and we can't mount over GOROOT. Replace with
-# `-pkgdir` when the kinks are worked out.
-for pkgdir in {darwin,windows}_amd64{,_race}; do
-  mkdir -p "${gocache}/docker/pkg/${pkgdir}"
-  vols="${vols} --volume=${gocache}/docker/pkg/${pkgdir}:/usr/local/go/pkg/${pkgdir}${delegated_volume_mode}"
-done
-# Linux supports more stuff, so it needs a separate loop.
-for pkgdir in linux_amd64{,_release-{gnu,musl}}{,_msan,_race}; do
-  mkdir -p "${gocache}/docker/pkg/${pkgdir}"
-  vols="${vols} --volume=${gocache}/docker/pkg/${pkgdir}:/usr/local/go/pkg/${pkgdir}${delegated_volume_mode}"
-done
-
 # -i causes some commands (including `git diff`) to attempt to use
 # a pager, so we override $PAGER to disable.
 


### PR DESCRIPTION
Our build system has accumulated a number of hacks to work around the
lack of a package cache pre Go 1.10. Specifically, Go used to insist
upon writing to GOROOT, and the builder image went to great lengths to
preserve any modifications to GOROOT between invocations.

In Go 1.10, Go no longer writes to GOROOT unless you specifically
request that dumb behavior with -i. So teach our build system to never
pass -i. It's no longer necessary for speed; the new package cache is
always on. This allows us to remove the builder's GOROOT preservation
code, plus some -installsuffix micromanagement of the old package
"cache".

All this wouldn't be necessary if I hadn't accidentally touched this
line [0] in #23623, but might as well clean it up now that I've
uncovered it.

[0]: https://github.com/cockroachdb/cockroach/commit/784a10d1fd040be91e71381170c29a7a003da6ab#diff-b67911656ef5d18c4ae36cb6741b7965L163

Release note: None