### PR TITLE
workload: parallelize workload init INSERT statements

### DIFF
--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -84,6 +84,7 @@ func backupRestoreTestSetupWithParams(
 
 	dir, dirCleanupFn := testutils.TempDir(t)
 	params.ServerArgs.ExternalIODir = dir
+	params.ServerArgs.UseDatabase = "data"
 	tc = testcluster.StartTestCluster(t, clusterSize, params)
 
 	for _, server := range tc.Servers {
@@ -99,9 +100,9 @@ func backupRestoreTestSetupWithParams(
 
 	sqlDB = sqlutils.MakeSQLRunner(tc.Conns[0])
 	sqlDB.Exec(t, `CREATE DATABASE data`)
-	sqlDB.Exec(t, `USE data`)
 	const insertBatchSize = 1000
-	if _, err := workload.Setup(sqlDB.DB, bankData, insertBatchSize); err != nil {
+	const concurrency = 4
+	if _, err := workload.Setup(ctx, sqlDB.DB, bankData, insertBatchSize, concurrency); err != nil {
 		t.Fatalf("%+v", err)
 	}
 	if err := bank.Split(sqlDB.DB, bankData); err != nil {

--- a/pkg/ccl/partitionccl/partition_test.go
+++ b/pkg/ccl/partitionccl/partition_test.go
@@ -1101,6 +1101,7 @@ func setupPartitioningTestCluster(ctx context.Context, t testing.TB) (*sqlutils.
 			StoreSpecs: []base.StoreSpec{
 				{InMemory: true, Attributes: roachpb.Attributes{Attrs: []string{attr}}},
 			},
+			UseDatabase: "data",
 		}
 	}
 	tcArgs := base.TestClusterArgs{ServerArgsPerNode: map[int]base.TestServerArgs{
@@ -1112,7 +1113,6 @@ func setupPartitioningTestCluster(ctx context.Context, t testing.TB) (*sqlutils.
 
 	sqlDB := sqlutils.MakeSQLRunner(tc.Conns[0])
 	sqlDB.Exec(t, `CREATE DATABASE data`)
-	sqlDB.Exec(t, `USE data`)
 
 	// Disabling store throttling vastly speeds up rebalancing.
 	sqlDB.Exec(t, `SET CLUSTER SETTING server.declined_reservation_timeout = '0s'`)
@@ -1241,7 +1241,6 @@ func TestRepartitioning(t *testing.T) {
 		t.Run(fmt.Sprintf("%s/%s", test.old.name, test.new.name), func(t *testing.T) {
 			sqlDB.Exec(t, `DROP DATABASE IF EXISTS data`)
 			sqlDB.Exec(t, `CREATE DATABASE data`)
-			sqlDB.Exec(t, `USE data`)
 
 			{
 				if err := test.old.parse(); err != nil {

--- a/pkg/ccl/utilccl/sampledataccl/bankdata_test.go
+++ b/pkg/ccl/utilccl/sampledataccl/bankdata_test.go
@@ -34,7 +34,11 @@ func TestToBackup(t *testing.T) {
 	defer dirCleanupFn()
 
 	ctx := context.Background()
-	s, db, _ := serverutils.StartServer(t, base.TestServerArgs{ExternalIODir: outerDir})
+	args := base.TestServerArgs{
+		ExternalIODir: outerDir,
+		UseDatabase:   "data",
+	}
+	s, db, _ := serverutils.StartServer(t, args)
 	defer s.Stopper().Stop(ctx)
 
 	const payloadBytes, ranges = 100, 10
@@ -57,7 +61,6 @@ func TestToBackup(t *testing.T) {
 					sqlDB := sqlutils.MakeSQLRunner(db)
 					sqlDB.Exec(t, `DROP DATABASE IF EXISTS data CASCADE`)
 					sqlDB.Exec(t, `CREATE DATABASE data`)
-					sqlDB.Exec(t, `USE data`)
 					sqlDB.Exec(t, `RESTORE data.* FROM $1`, `nodelocal:///`+dir)
 
 					var rowCount int

--- a/pkg/ccl/workloadccl/roachmartccl/roachmart.go
+++ b/pkg/ccl/workloadccl/roachmartccl/roachmart.go
@@ -153,12 +153,12 @@ func (m *roachmart) Hooks() workload.Hooks {
 
 // Tables implements the Generator interface.
 func (m *roachmart) Tables() []workload.Table {
-	rng := rand.New(rand.NewSource(m.seed))
 	users := workload.Table{
 		Name:            `users`,
 		Schema:          usersSchema,
 		InitialRowCount: m.users,
 		InitialRowFn: func(rowIdx int) []interface{} {
+			rng := rand.New(rand.NewSource(m.seed + int64(rowIdx)))
 			const emailTemplate = `user-%d@roachmart.example`
 			return []interface{}{
 				zones[rowIdx%3],                     // zone

--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -28,12 +28,14 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/lex"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/pkg/errors"
 	"github.com/spf13/pflag"
+	"golang.org/x/sync/errgroup"
 )
 
 // Generator represents one or more sql query loads and associated initial data.
@@ -218,11 +220,15 @@ func ApproxDatumSize(x interface{}) int64 {
 // The size of the loaded data is returned in bytes, suitable for use with
 // SetBytes of benchmarks. The exact definition of this is deferred to the
 // ApproxDatumSize implementation.
-func Setup(db *gosql.DB, gen Generator, batchSize int) (int64, error) {
+func Setup(
+	ctx context.Context, db *gosql.DB, gen Generator, batchSize, concurrency int,
+) (int64, error) {
 	if batchSize <= 0 {
 		batchSize = 1000
 	}
-	var insertStmtBuf bytes.Buffer
+	if concurrency < 1 {
+		concurrency = 1
+	}
 
 	tables := gen.Tables()
 	var hooks Hooks
@@ -230,10 +236,9 @@ func Setup(db *gosql.DB, gen Generator, batchSize int) (int64, error) {
 		hooks = h.Hooks()
 	}
 
-	var size int64
 	for _, table := range tables {
 		createStmt := fmt.Sprintf(`CREATE TABLE "%s" %s`, table.Name, table.Schema)
-		if _, err := db.Exec(createStmt); err != nil {
+		if _, err := db.ExecContext(ctx, createStmt); err != nil {
 			return 0, errors.Wrapf(err, "could not create table: %s", table.Name)
 		}
 	}
@@ -244,35 +249,53 @@ func Setup(db *gosql.DB, gen Generator, batchSize int) (int64, error) {
 		}
 	}
 
+	var size int64
 	for _, table := range tables {
-		for rowIdx := 0; rowIdx < table.InitialRowCount; {
-			insertStmtBuf.Reset()
-			fmt.Fprintf(&insertStmtBuf, `INSERT INTO "%s" VALUES `, table.Name)
+		rowsPerWorker := table.InitialRowCount / concurrency
+		g, gCtx := errgroup.WithContext(ctx)
+		for i := 0; i < concurrency; i++ {
+			startIdx := i * rowsPerWorker
+			endIdx := startIdx + rowsPerWorker
+			if i == concurrency-1 {
+				// Account for any rounding error in rowsPerWorker.
+				endIdx = table.InitialRowCount
+			}
+			g.Go(func() error {
+				var insertStmtBuf bytes.Buffer
+				for rowIdx := startIdx; rowIdx < endIdx; {
+					insertStmtBuf.Reset()
+					fmt.Fprintf(&insertStmtBuf, `INSERT INTO "%s" VALUES `, table.Name)
 
-			var params []interface{}
-			for batchIdx := 0; batchIdx < batchSize && rowIdx < table.InitialRowCount; batchIdx++ {
-				if batchIdx != 0 {
-					insertStmtBuf.WriteString(`,`)
-				}
-				insertStmtBuf.WriteString(`(`)
-				row := table.InitialRowFn(rowIdx)
-				for i, datum := range row {
-					size += ApproxDatumSize(datum)
-					if i != 0 {
-						insertStmtBuf.WriteString(`,`)
+					var params []interface{}
+					for batchIdx := 0; batchIdx < batchSize && rowIdx < endIdx; batchIdx++ {
+						if batchIdx != 0 {
+							insertStmtBuf.WriteString(`,`)
+						}
+						insertStmtBuf.WriteString(`(`)
+						row := table.InitialRowFn(rowIdx)
+						for i, datum := range row {
+							atomic.AddInt64(&size, ApproxDatumSize(datum))
+							if i != 0 {
+								insertStmtBuf.WriteString(`,`)
+							}
+							fmt.Fprintf(&insertStmtBuf, `$%d`, len(params)+i+1)
+						}
+						params = append(params, row...)
+						insertStmtBuf.WriteString(`)`)
+						rowIdx++
 					}
-					fmt.Fprintf(&insertStmtBuf, `$%d`, len(params)+i+1)
+					if len(params) > 0 {
+						insertStmt := insertStmtBuf.String()
+						if _, err := db.ExecContext(gCtx, insertStmt, params...); err != nil {
+							return errors.Wrapf(err, "failed insert into %s", table.Name)
+						}
+					}
 				}
-				params = append(params, row...)
-				insertStmtBuf.WriteString(`)`)
-				rowIdx++
-			}
-			if len(params) > 0 {
-				insertStmt := insertStmtBuf.String()
-				if _, err := db.Exec(insertStmt, params...); err != nil {
-					return 0, errors.Wrapf(err, "failed insert into %s", table.Name)
-				}
-			}
+				return nil
+			})
+		}
+		if err := g.Wait(); err != nil {
+			return 0, err
 		}
 	}
 

--- a/pkg/workload/workload_test.go
+++ b/pkg/workload/workload_test.go
@@ -42,13 +42,18 @@ func TestSetup(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	tests := []struct {
-		rows      int
-		batchSize int
+		rows        int
+		batchSize   int
+		concurrency int
 	}{
-		{10, 1},
-		{10, 9},
-		{10, 10},
-		{10, 100},
+		{10, 1, 1},
+		{10, 9, 1},
+		{10, 10, 1},
+		{10, 100, 1},
+		{10, 1, 4},
+		{10, 9, 4},
+		{10, 10, 4},
+		{10, 100, 4},
 	}
 
 	ctx := context.Background()
@@ -62,7 +67,7 @@ func TestSetup(t *testing.T) {
 			sqlDB.Exec(t, `DROP TABLE IF EXISTS bank`)
 
 			gen := bank.FromRows(test.rows)
-			if _, err := workload.Setup(sqlDB.DB, gen, test.batchSize); err != nil {
+			if _, err := workload.Setup(ctx, sqlDB.DB, gen, test.batchSize, test.concurrency); err != nil {
 				t.Fatalf("%+v", err)
 			}
 


### PR DESCRIPTION
`workload init` is an easy way to set up and populate a workload. It first
creates the workload schema and then begins populating each table in the
workload using batched INSERT statements.

Before this change, `workload init` performed each INSERT statement in order,
with no parallelism. This change introduces a concurrency factor into the row
insertion step, which speeds it up significantly.

With this change, #23697 is about 3 times faster.

Release note: None