### PR TITLE
cherry-pick-2.0: ui: jobs page: fix overflowing description text

### DIFF
--- a/pkg/ui/src/views/shared/components/expandableString/expandable.styl
+++ b/pkg/ui/src/views/shared/components/expandableString/expandable.styl
@@ -8,6 +8,9 @@
   justify-content space-between
   align-items center
 
+  .expandable__long
+    width 95%
+
   .expandable__icon
     flex 0 0 auto
     padding-left 10px

--- a/pkg/ui/src/views/shared/components/expandableString/index.tsx
+++ b/pkg/ui/src/views/shared/components/expandableString/index.tsx
@@ -50,14 +50,14 @@ export class ExpandableString extends React.Component<ExpandableStringProps, Exp
 
     const neverCollapse = _.isNil(short) && long.length <= truncateLength + 2;
     if (neverCollapse) {
-      return <span>{ this.props.long }</span>;
+      return <span className="expandable__long">{ this.props.long }</span>;
     }
 
     const { expanded } = this.state;
     const icon = expanded ? collapseIcon : expandIcon;
     return (
       <div className="expandable" onClick={ this.onClick }>
-        { this.renderText(expanded) }
+        <span className="expandable__long">{ this.renderText(expanded) }</span>
         <span className="expandable__icon" dangerouslySetInnerHTML={ trustIcon(icon) } />
       </div>
     );


### PR DESCRIPTION
Cherry-pick of #23687

Fixes #23679.

Release note (admin ui change): fix text that was overflowing past the table cell boundaries on the jobs page.

cc @cockroachdb/release 