### PR TITLE
opt: exec builder support for Limit/Offset

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/builder_test.go
+++ b/pkg/sql/opt/exec/execbuilder/builder_test.go
@@ -29,12 +29,13 @@ package execbuilder
 //
 //    Runs a SQL statement against the database (not through the execbuilder).
 //
-//  - build
+//  - opt
 //
 //    Builds a memo structure from a SQL query and outputs a representation of
-//    the "expression view" of the memo structure. Note: tests for the build
-//    process belong in the optbuilder tests; this is here only to have the
-//    expression view in the testfiles (for documentation).
+//    the "expression view" of the memo structure, after normalization.
+//    Note: tests for the build process belong in the optbuilder tests; this is
+//    here only to have the expression view in the testfiles (for
+//    documentation).
 //
 //  - exec
 //
@@ -162,7 +163,7 @@ func TestBuild(t *testing.T) {
 					}
 					return ""
 
-				case "build", "exec", "exec-explain":
+				case "opt", "exec", "exec-explain":
 					// Parse the SQL.
 					stmt, err := parser.ParseOne(d.Input)
 					if err != nil {
@@ -184,7 +185,7 @@ func TestBuild(t *testing.T) {
 					}
 					ev := o.Optimize(root, props)
 
-					if d.Cmd == "build" {
+					if d.Cmd == "opt" {
 						return ev.String()
 					}
 

--- a/pkg/sql/opt/exec/execbuilder/testdata/aggregate
+++ b/pkg/sql/opt/exec/execbuilder/testdata/aggregate
@@ -599,25 +599,28 @@ SELECT COUNT((k, v)) FROM kv
 column6:int
 6
 
-#exec
-#SELECT COUNT(DISTINCT (k, v)) FROM kv
-#----
-#6
-#
-#exec
-#SELECT COUNT(DISTINCT (k, (v))) FROM kv
-#----
-#6
+exec
+SELECT COUNT(DISTINCT (k, v)) FROM kv
+----
+column6:int
+6
 
-#TODO(radu): LIMIT not supported.
-#exec
-#SELECT COUNT((k, v)) FROM kv LIMIT 1
-#----
-#6
-#
-#exec
-#SELECT COUNT((k, v)) FROM kv OFFSET 1
-#----
+exec
+SELECT COUNT(DISTINCT (k, (v))) FROM kv
+----
+column6:int
+6
+
+exec
+SELECT COUNT((k, v)) FROM kv LIMIT 1
+----
+column6:int
+6
+
+exec
+SELECT COUNT((k, v)) FROM kv OFFSET 1
+----
+column6:int
 
 exec
 SELECT COUNT(k)+COUNT(kv.v) FROM kv

--- a/pkg/sql/opt/exec/execbuilder/testdata/limit
+++ b/pkg/sql/opt/exec/execbuilder/testdata/limit
@@ -99,3 +99,28 @@ column4:decimal
 8
 94
 216
+
+exec-explain
+SELECT k FROM (SELECT k, v FROM t ORDER BY v LIMIT 4)
+----
+render                    0  render  ·         ·          (k)        ·
+ │                        0  ·       render 0  k          ·          ·
+ └── limit                1  limit   ·         ·          (k, v)     +v
+      │                   1  ·       count     4          ·          ·
+      └── sort            2  sort    ·         ·          (k, v)     +v
+           │              2  ·       order     +v         ·          ·
+           └── render     3  render  ·         ·          (k, v)     ·
+                │         3  ·       render 0  k          ·          ·
+                │         3  ·       render 1  v          ·          ·
+                └── scan  4  scan    ·         ·          (k, v, w)  ·
+·                         4  ·       table     t@primary  ·          ·
+·                         4  ·       spans     ALL        ·          ·
+
+exec
+SELECT k FROM (SELECT k, v FROM t ORDER BY v LIMIT 4)
+----
+k:int
+6
+4
+2
+1

--- a/pkg/sql/opt/exec/execbuilder/testdata/limit
+++ b/pkg/sql/opt/exec/execbuilder/testdata/limit
@@ -1,0 +1,101 @@
+exec-raw
+CREATE TABLE t (k INT PRIMARY KEY, v INT, w INT, INDEX(v));
+INSERT INTO t VALUES (1, 1, 1), (2, -4, 8), (3, 9, 27), (4, -16, 94), (5, 25, 125), (6, -36, 216)
+----
+
+exec-explain
+SELECT k, v FROM t ORDER BY k LIMIT 5
+----
+limit           0  limit   ·         ·          (k, v)     ·
+ │              0  ·       count     5          ·          ·
+ └── render     1  render  ·         ·          (k, v)     ·
+      │         1  ·       render 0  k          ·          ·
+      │         1  ·       render 1  v          ·          ·
+      └── scan  2  scan    ·         ·          (k, v, w)  ·
+·               2  ·       table     t@primary  ·          ·
+·               2  ·       spans     ALL        ·          ·
+
+exec
+SELECT k, v FROM t ORDER BY k LIMIT 5
+----
+k:int  v:int
+1      1
+2      -4
+3      9
+4      -16
+5      25
+
+exec-explain
+SELECT k, v FROM t ORDER BY k OFFSET 5
+----
+limit           0  limit   ·         ·          (k, v)     ·
+ │              0  ·       offset    5          ·          ·
+ └── render     1  render  ·         ·          (k, v)     ·
+      │         1  ·       render 0  k          ·          ·
+      │         1  ·       render 1  v          ·          ·
+      └── scan  2  scan    ·         ·          (k, v, w)  ·
+·               2  ·       table     t@primary  ·          ·
+·               2  ·       spans     ALL        ·          ·
+
+exec
+SELECT k, v FROM t ORDER BY k OFFSET 5
+----
+k:int  v:int
+6      -36
+
+exec-explain
+SELECT k, v FROM t ORDER BY v LIMIT (1+4) OFFSET 1
+----
+limit                0  limit   ·         ·          (k, v)     +v
+ │                   0  ·       count     5          ·          ·
+ │                   0  ·       offset    1          ·          ·
+ └── sort            1  sort    ·         ·          (k, v)     +v
+      │              1  ·       order     +v         ·          ·
+      └── render     2  render  ·         ·          (k, v)     ·
+           │         2  ·       render 0  k          ·          ·
+           │         2  ·       render 1  v          ·          ·
+           └── scan  3  scan    ·         ·          (k, v, w)  ·
+·                    3  ·       table     t@primary  ·          ·
+·                    3  ·       spans     ALL        ·          ·
+
+exec
+SELECT k, v FROM t ORDER BY v LIMIT (1+4) OFFSET 1
+----
+k:int  v:int
+4      -16
+2      -4
+1      1
+3      9
+5      25
+
+exec-explain
+SELECT SUM(w) FROM t GROUP BY k, v ORDER BY v DESC LIMIT 10
+----
+render                         0  render  ·            ·          (column4)         ·
+ │                             0  ·       render 0     column4    ·                 ·
+ └── limit                     1  limit   ·            ·          (column4, "t.v")  ·
+      │                        1  ·       count        10         ·                 ·
+      └── render               2  render  ·            ·          (column4, "t.v")  ·
+           │                   2  ·       render 0     agg0       ·                 ·
+           │                   2  ·       render 1     v          ·                 ·
+           └── sort            3  sort    ·            ·          (k, v, agg0)      -v
+                │              3  ·       order        -v         ·                 ·
+                └── group      4  group   ·            ·          (k, v, agg0)      ·
+                     │         4  ·       aggregate 0  k          ·                 ·
+                     │         4  ·       aggregate 1  v          ·                 ·
+                     │         4  ·       aggregate 2  sum(w)     ·                 ·
+                     │         4  ·       group by     @1-@2      ·                 ·
+                     └── scan  5  scan    ·            ·          (k, v, w)         ·
+·                              5  ·       table        t@primary  ·                 ·
+·                              5  ·       spans        ALL        ·                 ·
+
+exec
+SELECT SUM(w) FROM t GROUP BY k, v ORDER BY v DESC LIMIT 10
+----
+column4:decimal
+125
+27
+1
+8
+94
+216

--- a/pkg/sql/opt/exec/execbuilder/testdata/orderby
+++ b/pkg/sql/opt/exec/execbuilder/testdata/orderby
@@ -89,26 +89,26 @@ a:int
 2
 1
 
-# TODO(radu): LIMIT not supported.
-#exec-explain
-#SELECT a, b FROM t ORDER BY b LIMIT 2
-#----
-#sort            0  sort    ·         ·          (a, b)     +b
-# │              0  ·       order     +b         ·          ·
-# └── render     1  render  ·         ·          (a, b)     ·
-#      │         1  ·       render 0  a          ·          ·
-#      │         1  ·       render 1  b          ·          ·
-#      └── scan  2  scan    ·         ·          (a, b, c)  ·
-#·               2  ·       table     t@primary  ·          ·
-#·               2  ·       spans     ALL        ·          ·
-#
-#exec
-#SELECT a, b FROM t ORDER BY b DESC LIMIT 2
-#----
-#a:int  b:int
-#1      9
-#2      8
-#3      7
+exec-explain
+SELECT a, b FROM t ORDER BY b LIMIT 2
+----
+limit                0  limit   ·         ·          (a, b)     +b
+ │                   0  ·       count     2          ·          ·
+ └── sort            1  sort    ·         ·          (a, b)     +b
+      │              1  ·       order     +b         ·          ·
+      └── render     2  render  ·         ·          (a, b)     ·
+           │         2  ·       render 0  a          ·          ·
+           │         2  ·       render 1  b          ·          ·
+           └── scan  3  scan    ·         ·          (a, b, c)  ·
+·                    3  ·       table     t@primary  ·          ·
+·                    3  ·       spans     ALL        ·          ·
+
+exec
+SELECT a, b FROM t ORDER BY b DESC LIMIT 2
+----
+a:int  b:int
+1      9
+2      8
 
 # TODO(radu): this does not work. Unclear if we want to support it or not.
 #exec-explain
@@ -132,37 +132,42 @@ a:int
 #----
 #true
 #false
-#
-#exec
-#SELECT b FROM t ORDER BY a DESC
-#----
-#7
-#8
-#9
-#
-#exec-explain
-#SELECT b FROM t ORDER BY a DESC
-#----
-#nosort             ·      ·
-# │                 order  -a
-# └── render        ·      ·
-#      └── revscan  ·      ·
-#·                  table  t@primary
-#·                  spans  ALL
 
-# TODO(radu): LIMIT not yet supported.
-## Check that LIMIT propagates past nosort nodes.
-#exec-explain
-#SELECT b FROM t ORDER BY a LIMIT 1
-#----
-#limit                ·      ·
-# └── nosort          ·      ·
-#      │              order  +a
-#      └── render     ·      ·
-#           └── scan  ·      ·
-#·                    table  t@primary
-#·                    spans  ALL
-#·                    limit  1
+exec
+SELECT b FROM t ORDER BY a DESC
+----
+b:int
+7
+8
+9
+
+exec-explain
+SELECT b FROM t ORDER BY a DESC
+----
+render               0  render  ·         ·          (b)        ·
+ │                   0  ·       render 0  b          ·          ·
+ └── sort            1  sort    ·         ·          (a, b)     -a
+      │              1  ·       order     -a         ·          ·
+      └── render     2  render  ·         ·          (a, b)     ·
+           │         2  ·       render 0  a          ·          ·
+           │         2  ·       render 1  b          ·          ·
+           └── scan  3  scan    ·         ·          (a, b, c)  ·
+·                    3  ·       table     t@primary  ·          ·
+·                    3  ·       spans     ALL        ·          ·
+
+exec-explain
+SELECT b FROM t ORDER BY a LIMIT 1
+----
+render               0  render  ·         ·          (b)        ·
+ │                   0  ·       render 0  b          ·          ·
+ └── limit           1  limit   ·         ·          (a, b)     ·
+      │              1  ·       count     1          ·          ·
+      └── render     2  render  ·         ·          (a, b)     ·
+           │         2  ·       render 0  a          ·          ·
+           │         2  ·       render 1  b          ·          ·
+           └── scan  3  scan    ·         ·          (a, b, c)  ·
+·                    3  ·       table     t@primary  ·          ·
+·                    3  ·       spans     ALL        ·          ·
 
 exec-explain
 SELECT b FROM t ORDER BY a DESC, b ASC

--- a/pkg/sql/opt/exec/execbuilder/testdata/scan
+++ b/pkg/sql/opt/exec/execbuilder/testdata/scan
@@ -7,7 +7,7 @@ CREATE TABLE t.a (x INT PRIMARY KEY, y FLOAT, s STRING);
 INSERT INTO t.a VALUES (1, 1.0, 'apple'), (2, 2.0, 'banana'), (3, 3.0, 'cherry')
 ----
 
-build
+opt
 SELECT * FROM t.a
 ----
 scan
@@ -29,7 +29,7 @@ x:int  y:float  s:string
 3      3.0      cherry
 
 # Test projecting subset of table columns.
-build
+opt
 SELECT s, x FROM t.a
 ----
 scan
@@ -62,7 +62,7 @@ CREATE TABLE t.b (x INT, y INT, s STRING);
 INSERT INTO t.b VALUES (1, 10, 'apple'), (2, 20, 'banana'), (3, 30, 'cherry')
 ----
 
-build
+opt
 SELECT s, x FROM t.b
 ----
 scan

--- a/pkg/sql/opt/exec/execbuilder/testdata/union
+++ b/pkg/sql/opt/exec/execbuilder/testdata/union
@@ -58,32 +58,63 @@ column1:int  column2:int
 2            1
 3            4
 
-# TODO(radu): ORDER BY not supported yet.
-#exec
-#(VALUES (1), (1), (1), (2), (2) UNION ALL VALUES (1), (3), (1)) ORDER BY 1 DESC LIMIT 2
-#----
-#3
-#2
-#
-## The ORDER BY and LIMIT apply to the UNION, not the last VALUES.
-#exec
-#VALUES (1), (1), (1), (2), (2) UNION ALL VALUES (1), (3), (1) ORDER BY 1 DESC LIMIT 2
-#----
-#3
-#2
-#
-## UNION with NULL columns in operands works.
-#exec
-#VALUES (1) UNION ALL VALUES (NULL) ORDER BY 1
-#----
-#NULL
-#1
-#
-#exec
-#VALUES (NULL) UNION ALL VALUES (1) ORDER BY 1
-#----
-#NULL
-#1
+opt
+(VALUES (1), (1), (1), (2), (2) UNION ALL VALUES (1), (3), (1)) ORDER BY 1 DESC LIMIT 2
+----
+limit
+ ├── columns: column1:3(int)
+ ├── ordering: -3
+ ├── sort
+ │    ├── columns: column1:3(int)
+ │    ├── ordering: -3
+ │    └── union-all
+ │         ├── columns: column1:3(int)
+ │         ├── left columns: column1:1(int)
+ │         ├── right columns: column1:2(int)
+ │         ├── values
+ │         │    ├── columns: column1:1(int)
+ │         │    ├── tuple [type=tuple{int}]
+ │         │    │    └── const: 1 [type=int]
+ │         │    ├── tuple [type=tuple{int}]
+ │         │    │    └── const: 1 [type=int]
+ │         │    ├── tuple [type=tuple{int}]
+ │         │    │    └── const: 1 [type=int]
+ │         │    ├── tuple [type=tuple{int}]
+ │         │    │    └── const: 2 [type=int]
+ │         │    └── tuple [type=tuple{int}]
+ │         │         └── const: 2 [type=int]
+ │         └── values
+ │              ├── columns: column1:2(int)
+ │              ├── tuple [type=tuple{int}]
+ │              │    └── const: 1 [type=int]
+ │              ├── tuple [type=tuple{int}]
+ │              │    └── const: 3 [type=int]
+ │              └── tuple [type=tuple{int}]
+ │                   └── const: 1 [type=int]
+ └── const: 2 [type=int]
+
+# The ORDER BY and LIMIT apply to the UNION, not the last VALUES.
+exec
+VALUES (1), (1), (1), (2), (2) UNION ALL VALUES (1), (3), (1) ORDER BY 1 DESC LIMIT 2
+----
+column1:int
+3
+2
+
+# UNION with NULL columns in operands works.
+exec
+VALUES (1) UNION ALL VALUES (NULL) ORDER BY 1
+----
+column1:int
+NULL
+1
+
+exec
+VALUES (NULL) UNION ALL VALUES (1) ORDER BY 1
+----
+column1:int
+NULL
+1
 
 exec
 VALUES (NULL) UNION ALL VALUES (NULL)
@@ -174,19 +205,20 @@ v:int
 2
 2
 
-# TODO(radu): ORDER BY, LIMIT not supported yet.
-#exec
-#(SELECT v FROM t.uniontest WHERE k = 1 UNION ALL SELECT v FROM t.uniontest WHERE k = 2) ORDER BY 1 DESC LIMIT 2
-#----
-#3
-#2
-#
-## The ORDER BY and LIMIT apply to the UNION, not the last SELECT.
-#exec
-#SELECT v FROM t.uniontest WHERE k = 1 UNION ALL SELECT v FROM t.uniontest WHERE k = 2 ORDER BY 1 DESC LIMIT 2
-#----
-#3
-#2
+exec
+(SELECT v FROM t.uniontest WHERE k = 1 UNION ALL SELECT v FROM t.uniontest WHERE k = 2) ORDER BY 1 DESC LIMIT 2
+----
+v:int
+3
+2
+
+# The ORDER BY and LIMIT apply to the UNION, not the last SELECT.
+exec
+SELECT v FROM t.uniontest WHERE k = 1 UNION ALL SELECT v FROM t.uniontest WHERE k = 2 ORDER BY 1 DESC LIMIT 2
+----
+v:int
+3
+2
 
 exec-explain
 SELECT v FROM t.uniontest UNION SELECT k FROM t.uniontest

--- a/pkg/sql/opt/exec/factory.go
+++ b/pkg/sql/opt/exec/factory.go
@@ -79,6 +79,11 @@ type Factory interface {
 	// by the input node.
 	ConstructSort(input Node, ordering sqlbase.ColumnOrdering) (Node, error)
 
+	// ConstructLimit returns a node that implements LIMIT and/or OFFSET on the
+	// results of the given node. If only an offset is desired, limit should be
+	// math.MaxInt64.
+	ConstructLimit(input Node, limit int64, offset int64) (Node, error)
+
 	// RenameColumns modifies the column names of a node.
 	RenameColumns(input Node, colNames []string) (Node, error)
 }

--- a/pkg/sql/opt/optbuilder/select.go
+++ b/pkg/sql/opt/optbuilder/select.go
@@ -144,6 +144,7 @@ func (b *Builder) buildSelect(
 ) (out opt.GroupID, outScope *scope) {
 	wrapped := stmt.Select
 	orderBy := stmt.OrderBy
+	limit := stmt.Limit
 
 	for s, ok := wrapped.(*tree.ParenSelect); ok; s, ok = wrapped.(*tree.ParenSelect) {
 		stmt = s.Select
@@ -153,6 +154,7 @@ func (b *Builder) buildSelect(
 				panic(errorf("multiple ORDER BY clauses not allowed"))
 			}
 			orderBy = stmt.OrderBy
+			limit = stmt.Limit
 		}
 	}
 
@@ -182,8 +184,8 @@ func (b *Builder) buildSelect(
 		out, outScope = b.buildOrderBy(orderBy, out, projections, outScope, projectionsScope)
 	}
 
-	if stmt.Limit != nil {
-		out, outScope = b.buildLimit(stmt.Limit, inScope, out, outScope)
+	if limit != nil {
+		out, outScope = b.buildLimit(limit, inScope, out, outScope)
 	}
 
 	// TODO(rytaft): Support FILTER expression.

--- a/pkg/sql/opt/optbuilder/testdata/limit
+++ b/pkg/sql/opt/optbuilder/testdata/limit
@@ -202,3 +202,74 @@ limit
  │              ├── const: 2 [type=int]
  │              └── const: 2 [type=int]
  └── const: 1 [type=int]
+
+build
+(VALUES (1), (1), (1), (2), (2) UNION ALL VALUES (1), (3), (1)) ORDER BY 1 DESC LIMIT 2
+----
+limit
+ ├── columns: column1:3(int)
+ ├── ordering: -3
+ ├── sort
+ │    ├── columns: column1:3(int)
+ │    ├── ordering: -3
+ │    └── union-all
+ │         ├── columns: column1:3(int)
+ │         ├── left columns: column1:1(int)
+ │         ├── right columns: column1:2(int)
+ │         ├── values
+ │         │    ├── columns: column1:1(int)
+ │         │    ├── tuple [type=tuple{int}]
+ │         │    │    └── const: 1 [type=int]
+ │         │    ├── tuple [type=tuple{int}]
+ │         │    │    └── const: 1 [type=int]
+ │         │    ├── tuple [type=tuple{int}]
+ │         │    │    └── const: 1 [type=int]
+ │         │    ├── tuple [type=tuple{int}]
+ │         │    │    └── const: 2 [type=int]
+ │         │    └── tuple [type=tuple{int}]
+ │         │         └── const: 2 [type=int]
+ │         └── values
+ │              ├── columns: column1:2(int)
+ │              ├── tuple [type=tuple{int}]
+ │              │    └── const: 1 [type=int]
+ │              ├── tuple [type=tuple{int}]
+ │              │    └── const: 3 [type=int]
+ │              └── tuple [type=tuple{int}]
+ │                   └── const: 1 [type=int]
+ └── const: 2 [type=int]
+
+# The ORDER BY and LIMIT apply to the UNION, not the last VALUES.
+build
+VALUES (1), (1), (1), (2), (2) UNION ALL VALUES (1), (3), (1) ORDER BY 1 DESC LIMIT 2
+----
+limit
+ ├── columns: column1:3(int)
+ ├── ordering: -3
+ ├── sort
+ │    ├── columns: column1:3(int)
+ │    ├── ordering: -3
+ │    └── union-all
+ │         ├── columns: column1:3(int)
+ │         ├── left columns: column1:1(int)
+ │         ├── right columns: column1:2(int)
+ │         ├── values
+ │         │    ├── columns: column1:1(int)
+ │         │    ├── tuple [type=tuple{int}]
+ │         │    │    └── const: 1 [type=int]
+ │         │    ├── tuple [type=tuple{int}]
+ │         │    │    └── const: 1 [type=int]
+ │         │    ├── tuple [type=tuple{int}]
+ │         │    │    └── const: 1 [type=int]
+ │         │    ├── tuple [type=tuple{int}]
+ │         │    │    └── const: 2 [type=int]
+ │         │    └── tuple [type=tuple{int}]
+ │         │         └── const: 2 [type=int]
+ │         └── values
+ │              ├── columns: column1:2(int)
+ │              ├── tuple [type=tuple{int}]
+ │              │    └── const: 1 [type=int]
+ │              ├── tuple [type=tuple{int}]
+ │              │    └── const: 3 [type=int]
+ │              └── tuple [type=tuple{int}]
+ │                   └── const: 1 [type=int]
+ └── const: 2 [type=int]

--- a/pkg/sql/opt/optbuilder/testdata/limit
+++ b/pkg/sql/opt/optbuilder/testdata/limit
@@ -273,3 +273,25 @@ limit
  │              └── tuple [type=tuple{int}]
  │                   └── const: 1 [type=int]
  └── const: 2 [type=int]
+
+build
+SELECT k FROM (SELECT k, v FROM t ORDER BY v LIMIT 10)
+----
+project
+ ├── columns: k:1(int!null)
+ ├── limit
+ │    ├── columns: t.k:1(int!null) t.v:2(int)
+ │    ├── project
+ │    │    ├── columns: t.k:1(int!null) t.v:2(int)
+ │    │    ├── ordering: +2
+ │    │    ├── sort
+ │    │    │    ├── columns: t.k:1(int!null) t.v:2(int) t.w:3(int)
+ │    │    │    ├── ordering: +2
+ │    │    │    └── scan
+ │    │    │         └── columns: t.k:1(int!null) t.v:2(int) t.w:3(int)
+ │    │    └── projections [outer=(1,2)]
+ │    │         ├── variable: t.k [type=int, outer=(1)]
+ │    │         └── variable: t.v [type=int, outer=(2)]
+ │    └── const: 10 [type=int]
+ └── projections [outer=(1)]
+      └── variable: t.k [type=int, outer=(1)]

--- a/pkg/sql/opt/xform/physical_props_factory.go
+++ b/pkg/sql/opt/xform/physical_props_factory.go
@@ -127,12 +127,14 @@ func (f physicalPropsFactory) canProvideOrdering(ev ExprView, required opt.Order
 // but provides any presentation requirement. This method is heavily called
 // during ExprView traversal, so performance is important.
 func (f physicalPropsFactory) constructChildProps(ev ExprView, nth int) opt.PhysicalPropsID {
-	// Fast path taken in common case when no properties are required of parent;
-	// in that case, no properties are required of children. This will change in
-	// the future when certain operators like MergeJoin require input properties
-	// from their children regardless of what's required of them.
 	if ev.required == opt.MinPhysPropsID {
-		return opt.MinPhysPropsID
+		switch ev.Operator() {
+		case opt.LimitOp, opt.OffsetOp:
+		default:
+			// Fast path taken in common case when no properties are required of
+			// parent and the operator itself does not require any properties.
+			return opt.MinPhysPropsID
+		}
 	}
 
 	parentProps := ev.Physical()


### PR DESCRIPTION
#### opt: fix limit build issue

We weren't handling the case when the select is behind parens.

Release note: None

#### opt: exec builder support for Limit/Offset

Also renaming `build` directive to `opt` in the execbuilder test, for
consistency with other tests.

Release note: None

#### opt: fix child physical properties of limit

We were accidentally requiring no properties of the Limit/Offset input
if there is no requirement on the Limit/Offset itself.

Release note: None