### PR TITLE
log improvements + deflake test + add missing test

### DIFF
--- a/pkg/cli/interactive_tests/common.tcl
+++ b/pkg/cli/interactive_tests/common.tcl
@@ -107,6 +107,18 @@ proc stop_server {argv} {
     report "END STOP SERVER"
 }
 
+proc rotate_server_logs {} {
+    report "BEGIN ROTATE LOGS"
+    system "kill -USR2 `cat server_pid` 2>/dev/null"
+    report "END ROTATE LOGS"
+}
+
+proc flush_server_logs {} {
+    report "BEGIN FLUSH LOGS"
+    system "kill -USR1 `cat server_pid` 2>/dev/null"
+    report "END FLUSH LOGS"
+}
+
 proc force_stop_server {argv} {
     report "BEGIN FORCE STOP SERVER"
     system "$argv quit & sleep 1; if kill -CONT `cat server_pid` 2>/dev/null; then kill -TERM `cat server_pid`; sleep 1; if kill -CONT `cat server_pid` 2>/dev/null; then kill -KILL `cat server_pid`; fi; fi"

--- a/pkg/cli/interactive_tests/test_audit_log.tcl
+++ b/pkg/cli/interactive_tests/test_audit_log.tcl
@@ -43,14 +43,10 @@ end_test
 
 # force rotate the logs: the test below must not see the
 # log entries that were already generated above.
-force_stop_server $argv
-start_server $argv
+rotate_server_logs
 
-send "\r"
-eexpect "opening new connection"
-eexpect root@
-send "\r"
-eexpect "t>"
+# Check the log indeed is empty
+system "if grep -q helloworld $logfile; then false; fi"
 
 start_test "Check that audit removal is logged too"
 send "ALTER TABLE helloworld EXPERIMENTAL_AUDIT SET OFF;\r"

--- a/pkg/cli/interactive_tests/test_exec_log.tcl
+++ b/pkg/cli/interactive_tests/test_exec_log.tcl
@@ -1,0 +1,48 @@
+#! /usr/bin/env expect -f
+
+source [file join [file dirname $argv0] common.tcl]
+
+start_server $argv
+
+spawn $argv sql
+eexpect root@
+
+set logfile logs/db/logs/cockroach-sql-exec.log
+
+start_test "Check that the exec log is not created by default"
+system "if test -e $logfile; then false; fi"
+end_test
+
+start_test "Check that the exec log is created after enabled"
+send "SET CLUSTER SETTING sql.trace.log_statement_execute = TRUE;\r"
+eexpect root@
+system "test -e $logfile"
+end_test
+
+start_test "Check that statements get logged to the exec log but stop logging when disabled"
+send "SELECT 'helloworld';\r"
+eexpect root@
+
+# Errors must be logged too
+send "SELECT nonexistent;\r"
+eexpect "column name"
+eexpect "nonexistent"
+eexpect "not found"
+eexpect root@
+
+# Check logging after disable
+send "SET CLUSTER SETTING sql.trace.log_statement_execute = FALSE;\r"
+eexpect root@
+send "SELECT 'lovely';\r"
+eexpect root@
+
+flush_server_logs
+
+# Now check the items are there in the log file.
+system "grep -q helloworld $logfile"
+system "grep -q nonexistent $logfile"
+system "if grep -q lovely $logfile; then false; fi"
+
+end_test
+
+stop_server $argv

--- a/pkg/cli/interactive_tests/test_rotate_flush.tcl
+++ b/pkg/cli/interactive_tests/test_rotate_flush.tcl
@@ -1,0 +1,24 @@
+#! /usr/bin/env expect -f
+
+source [file join [file dirname $argv0] common.tcl]
+
+set logfile logs/db/logs/cockroach.log
+
+start_server $argv
+
+start_test "Check that SIGUSR1 says it flushes the log"
+flush_server_logs
+system "grep 'signal.*received, flushing logs' $logfile"
+end_test
+
+start_test "Check that SIGUSR2 flushes and rotates the logs"
+rotate_server_logs
+# The log have been rotated so the flush/rotate messages should not be there any more.
+system "if grep 'signal.*received, flushing logs' $logfile; then false; fi"
+system "if grep 'signal.*received, rotating logs' $logfile; then false; fi"
+# However they must be in the directory in some previous log file.
+system "grep 'signal.*received, flushing logs' logs/db/logs/*.log"
+system "grep 'signal.*received, rotating logs' logs/db/logs/*.log"
+end_test
+
+stop_server $argv


### PR DESCRIPTION
### util/log: make SIGUSR1 and SIGUSR2 flush and rotate the logs

It is common while developing system administration tools and in tests
to need to flush the log files and rotate them. Prior to this patch,
there was no way to do this in CockroachDB short of restarting the
server.

Release note (general change): a CockroachDB process will now flush
its logs upon receiving `SIGUSR1` and rotate the log files upon
receiving `SIGUSR2`. This is aimed to simplify the automation of
process monitoring, test and backup tools.

###  cli/interactive_tests: deflake the audit log test

Prior to this patch, the test required a server restart to rotate the
logs. This in turn could cause the SQL lease on the table to not be
properly released, which would cause the test to hang after the
restart.

This patch fixes that by using a signal to rotate the logs instead.

Fixes #23714.

### sql: add the missing tests for the execution log

I forgot to add the tests for the exec log to my previous commit "sql:
enhance statement logging".

Here they are.