### PR TITLE
cherry-pick 2.0: sql: fix double-call to res.SetErr() on network error 

### DIFF
--- a/pkg/base/test_server_args.go
+++ b/pkg/base/test_server_args.go
@@ -103,6 +103,11 @@ type TestServerArgs struct {
 	// If set, web session authentication will be disabled, even if the server
 	// is running in secure mode.
 	DisableWebSessionAuthentication bool
+
+	// ConnResultsBufferBytes is the size of the buffer in which each connection
+	// accumulates results set. Results are flushed to the network when this
+	// buffer overflows.
+	ConnResultsBufferBytes int
 }
 
 // TestClusterArgs contains the parameters one can set when creating a test

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -77,7 +77,7 @@ const (
 	minimumNetworkFileDescriptors     = 256
 	recommendedNetworkFileDescriptors = 5000
 
-	defaultConnResultsBufferBytes = 16 << 10
+	defaultConnResultsBufferBytes = 16 << 10 // 16 KiB
 )
 
 var productionSettingsWebpage = fmt.Sprintf(

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -76,6 +76,8 @@ const (
 
 	minimumNetworkFileDescriptors     = 256
 	recommendedNetworkFileDescriptors = 5000
+
+	defaultConnResultsBufferBytes = 16 << 10
 )
 
 var productionSettingsWebpage = fmt.Sprintf(
@@ -241,6 +243,11 @@ type Config struct {
 	// deleted.
 	UseLegacyConnHandling bool
 
+	// ConnResultsBufferBytes is the size of the buffer in which each connection
+	// accumulates results set. Results are flushed to the network when this
+	// buffer overflows.
+	ConnResultsBufferBytes int
+
 	enginesCreated bool
 }
 
@@ -378,6 +385,7 @@ func MakeConfig(ctx context.Context, st *cluster.Settings) Config {
 		},
 		TempStorageConfig: base.TempStorageConfigFromEnv(
 			ctx, st, storeSpec, "" /* parentDir */, base.DefaultTempStorageMaxSizeBytes),
+		ConnResultsBufferBytes: defaultConnResultsBufferBytes,
 	}
 	cfg.AmbientCtx.Tracer = st.Tracer
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -516,9 +516,11 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 			s.distSender,
 			s.gossip,
 			s.stopper,
-			sqlExecutorTestingKnobs.DistSQLPlannerKnobs),
-		ExecLogger:  log.NewSecondaryLogger(nil, "sql-exec", true /*enableGc*/, false /*forceSyncWrites*/),
-		AuditLogger: log.NewSecondaryLogger(s.cfg.SQLAuditLogDirName, "sql-audit", true /*enableGc*/, true /*forceSyncWrites*/),
+			sqlExecutorTestingKnobs.DistSQLPlannerKnobs,
+		),
+		ExecLogger:             log.NewSecondaryLogger(nil, "sql-exec", true /*enableGc*/, false /*forceSyncWrites*/),
+		AuditLogger:            log.NewSecondaryLogger(s.cfg.SQLAuditLogDirName, "sql-audit", true /*enableGc*/, true /*forceSyncWrites*/),
+		ConnResultsBufferBytes: s.cfg.ConnResultsBufferBytes,
 	}
 
 	if sqlSchemaChangerTestingKnobs := s.cfg.TestingKnobs.SQLSchemaChanger; sqlSchemaChangerTestingKnobs != nil {

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -203,6 +203,10 @@ func makeTestConfigFromParams(params base.TestServerArgs) Config {
 	}
 	cfg.TestingKnobs.Store.(*storage.StoreTestingKnobs).SkipMinSizeCheck = true
 
+	if params.ConnResultsBufferBytes != 0 {
+		cfg.ConnResultsBufferBytes = params.ConnResultsBufferBytes
+	}
+
 	return cfg
 }
 

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -553,7 +553,6 @@ func (ex *connExecutor) dispatchToExecutionEngine(
 	}
 	planner.statsCollector.PhaseTimes()[plannerEndExecStmt] = timeutil.Now()
 	if err != nil {
-		res.SetError(err)
 		return err
 	}
 	recordStatementSummary(
@@ -570,6 +569,7 @@ func (ex *connExecutor) dispatchToExecutionEngine(
 // execWithLocalEngine runs a plan using the local (non-distributed) SQL
 // engine.
 // If an error is returned, the connection needs to stop processing queries.
+// Such errors are also written to res.
 // Query execution errors are written to res; they are not returned.
 func (ex *connExecutor) execWithLocalEngine(
 	ctx context.Context, planner *planner, stmtType tree.StatementType, res RestrictedCommandResult,
@@ -611,6 +611,7 @@ func (ex *connExecutor) execWithLocalEngine(
 			return commErr
 		})
 		if commErr != nil {
+			res.SetError(commErr)
 			return commErr
 		}
 		if queryErr != nil {

--- a/pkg/sql/executor.go
+++ b/pkg/sql/executor.go
@@ -279,6 +279,11 @@ type ExecutorConfig struct {
 	// Caches updated by DistSQL.
 	RangeDescriptorCache *kv.RangeDescriptorCache
 	LeaseHolderCache     *kv.LeaseHolderCache
+
+	// ConnResultsBufferBytes is the size of the buffer in which each connection
+	// accumulates results set. Results are flushed to the network when this
+	// buffer overflows.
+	ConnResultsBufferBytes int
 }
 
 // Organization returns the value of cluster.organization.

--- a/pkg/sql/pgwire/conn.go
+++ b/pkg/sql/pgwire/conn.go
@@ -1047,7 +1047,7 @@ func (c *conn) Flush(pos sql.CmdPos) error {
 // maybeFlush flushes the buffer to the network connection if it exceeded
 // connResultsBufferSizeBytes.
 func (c *conn) maybeFlush(pos sql.CmdPos) (bool, error) {
-	if c.writerState.buf.Len() <= connResultsBufferSizeBytes {
+	if c.writerState.buf.Len() <= c.execCfg.ConnResultsBufferBytes {
 		return false, nil
 	}
 	return true, c.Flush(pos)

--- a/pkg/sql/pgwire/v3.go
+++ b/pkg/sql/pgwire/v3.go
@@ -48,10 +48,6 @@ const (
 	authCleartextPassword int32 = 3
 )
 
-// connResultsBufferSizeBytes refers to the size of the result set which we
-// buffer into memory prior to flushing to the client.
-const connResultsBufferSizeBytes = 16 << 10
-
 // readTimeoutConn overloads net.Conn.Read by periodically calling
 // checkExitConds() and aborting the read if an error is returned.
 type readTimeoutConn struct {
@@ -1266,7 +1262,7 @@ func (c *v3Conn) flush(forceSend bool) error {
 		return nil
 	}
 
-	if forceSend || state.buf.Len() > connResultsBufferSizeBytes {
+	if forceSend || state.buf.Len() > c.executor.Cfg().ConnResultsBufferBytes {
 		state.hasSentResults = true
 		state.txnStartIdx = 0
 		if _, err := state.buf.WriteTo(c.wr); err != nil {


### PR DESCRIPTION
Cherry-pick #23753

Before this patch, when an attempt to write a query result to the
network was encountering a network error, we would call res.SetErr()
twice, which is prohibited and panicked. This happened when the DistSQL
engine was used, because execWithDistSQLEngine() was already setting the
error and some higher-level code was setting it again.
This was caused by inconsistent handling of communication errors between
the two engines - when executing with DistSQL, we would both set the
error on the result and also return it, whereas when executing with
local we would only return it, and then there was higher-level code
which set the error again. This patch makes the local execution behave
like DistSQL.

Fixes #23694

Release note: Fix a bug where closing a connection in the middle of
executing a query sometimes crashed the server.

cc @cockroachdb/release 