### PR TITLE
storageccl: Fix tests with ENABLE_ROCKSDB_ASSERTIONS

### DIFF
--- a/build/teamcity-testlogicrace.sh
+++ b/build/teamcity-testlogicrace.sh
@@ -12,6 +12,7 @@ build/builder.sh env \
 	make testrace \
 	PKG=./pkg/sql/logictest \
 	TESTFLAGS='-v' \
+	ENABLE_ROCKSDB_ASSERTIONS=1 \
 	2>&1 \
 	| tee artifacts/testlogicrace.log \
 	| go-test-teamcity

--- a/build/teamcity-testrace.sh
+++ b/build/teamcity-testrace.sh
@@ -30,7 +30,13 @@ run build/builder.sh make -Otarget gotestdashi GOFLAGS=-race
 tc_end_block "Compile"
 
 tc_start_block "Run Go tests under race detector"
-run build/builder.sh env COCKROACH_LOGIC_TESTS_SKIP=true make testrace PKG="$pkgspec" TESTTIMEOUT=45m TESTFLAGS='-v' 2>&1 \
+run build/builder.sh env \
+    COCKROACH_LOGIC_TESTS_SKIP=true \
+    make testrace \
+    PKG="$pkgspec" \
+    TESTTIMEOUT=45m \
+    TESTFLAGS='-v' \
+    ENABLE_ROCKSDB_ASSERTIONS=1 2>&1 \
 	| tee artifacts/testrace.log \
 	| go-test-teamcity
 tc_end_block "Run Go tests under race detector"

--- a/pkg/ccl/storageccl/add_sstable_test.go
+++ b/pkg/ccl/storageccl/add_sstable_test.go
@@ -368,7 +368,7 @@ func TestAddSSTableMVCCStats(t *testing.T) {
 		if err := e.WriteFile(filename, sstBytes); err != nil {
 			t.Fatalf("%+v", err)
 		}
-		if err := e.IngestExternalFile(ctx, filename, true /* move */, true /* modify the sst */); err != nil {
+		if err := e.IngestExternalFile(ctx, filename, true /* modify the sst */); err != nil {
 			t.Fatalf("%+v", err)
 		}
 

--- a/pkg/ccl/storageccl/add_sstable_test.go
+++ b/pkg/ccl/storageccl/add_sstable_test.go
@@ -368,7 +368,7 @@ func TestAddSSTableMVCCStats(t *testing.T) {
 		if err := e.WriteFile(filename, sstBytes); err != nil {
 			t.Fatalf("%+v", err)
 		}
-		if err := e.IngestExternalFile(ctx, filename, false /* move */, true /* modify the sst */); err != nil {
+		if err := e.IngestExternalFile(ctx, filename, true /* move */, true /* modify the sst */); err != nil {
 			t.Fatalf("%+v", err)
 		}
 

--- a/pkg/ccl/storageccl/export.go
+++ b/pkg/ccl/storageccl/export.go
@@ -166,6 +166,11 @@ func evalExport(
 		// (non-incremental) and we're not exporting all versions.
 		if skipTombstones && args.StartTime.IsEmpty() && len(iter.UnsafeValue()) == 0 {
 			iter.NextKey()
+			if ok, err := iter.Valid(); err != nil {
+				return result.Result{}, err
+			} else if !ok {
+				break
+			}
 			continue
 		}
 

--- a/pkg/storage/engine/engine.go
+++ b/pkg/storage/engine/engine.go
@@ -253,12 +253,12 @@ type Engine interface {
 	// by invoking Close(). Note that snapshots must not be used after the
 	// original engine has been stopped.
 	NewSnapshot() Reader
-	// IngestExternalFile links a file into the RocksDB log-structured merge-tree.
-	// Removes the passed path on success if `move` is true. May modify the file
-	// (including the underlying file in the case of hard-links) if
-	// allowFileModification is passed as well. See additional comments in db.cc's
-	// IngestExternalFile explaining modification behavior.
-	IngestExternalFile(ctx context.Context, path string, move, allowFileModification bool) error
+	// IngestExternalFile links a file into the RocksDB log-structured
+	// merge-tree. May modify the file (including the underlying file in
+	// the case of hard-links) if allowFileModification is passed as
+	// well. See additional comments in db.cc's IngestExternalFile
+	// explaining modification behavior.
+	IngestExternalFile(ctx context.Context, path string, allowFileModification bool) error
 	// ApproximateDiskBytes returns an approximation of the on-disk size for the given key span.
 	ApproximateDiskBytes(from, to roachpb.Key) (uint64, error)
 	// CompactRange ensures that the specified range of key value pairs is

--- a/pkg/storage/engine/rocksdb.go
+++ b/pkg/storage/engine/rocksdb.go
@@ -2551,10 +2551,10 @@ func (r *RocksDB) setAuxiliaryDir(d string) error {
 
 // IngestExternalFile links a file into the RocksDB log-structured merge-tree.
 func (r *RocksDB) IngestExternalFile(
-	ctx context.Context, path string, move, allowFileModification bool,
+	ctx context.Context, path string, allowFileModification bool,
 ) error {
 	return statusToError(C.DBIngestExternalFile(
-		r.rdb, goToCSlice([]byte(path)), C._Bool(move), C._Bool(allowFileModification),
+		r.rdb, goToCSlice([]byte(path)), C._Bool(true), C._Bool(allowFileModification),
 	))
 }
 

--- a/pkg/storage/replica_proposal.go
+++ b/pkg/storage/replica_proposal.go
@@ -336,7 +336,6 @@ func addSSTablePreApply(
 		)
 	}
 
-	const move = true
 	const modify, noModify = true, false
 
 	path, err := sideloaded.Filename(ctx, index, term)
@@ -367,7 +366,7 @@ func addSSTablePreApply(
 			// pass it the path in the sideload store as it deletes the passed path on
 			// success.
 			if linkErr := os.Link(path, ingestPath); linkErr == nil {
-				ingestErr := eng.IngestExternalFile(ctx, ingestPath, move, noModify)
+				ingestErr := eng.IngestExternalFile(ctx, ingestPath, noModify)
 				if ingestErr == nil {
 					// Adding without modification succeeded, no copy necessary.
 					log.Eventf(ctx, "ingested SSTable at index %d, term %d: %s", index, term, ingestPath)
@@ -408,7 +407,7 @@ func addSSTablePreApply(
 		copied = true
 	}
 
-	if err := eng.IngestExternalFile(ctx, path, move, modify); err != nil {
+	if err := eng.IngestExternalFile(ctx, path, modify); err != nil {
 		log.Fatalf(ctx, "while ingesting %s: %s", path, err)
 	}
 	log.Eventf(ctx, "ingested SSTable at index %d, term %d: %s", index, term, path)


### PR DESCRIPTION
Updates #23754. The only thing left is the makefile magic.