### PR TITLE
opt: push projections through limit/offset

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/limit
+++ b/pkg/sql/opt/exec/execbuilder/testdata/limit
@@ -124,3 +124,28 @@ k:int
 4
 2
 1
+
+exec-explain
+SELECT k FROM (SELECT k, v, w FROM t ORDER BY v LIMIT 4)
+----
+render                    0  render  ·         ·          (k)        ·
+ │                        0  ·       render 0  k          ·          ·
+ └── limit                1  limit   ·         ·          (k, v)     +v
+      │                   1  ·       count     4          ·          ·
+      └── sort            2  sort    ·         ·          (k, v)     +v
+           │              2  ·       order     +v         ·          ·
+           └── render     3  render  ·         ·          (k, v)     ·
+                │         3  ·       render 0  k          ·          ·
+                │         3  ·       render 1  v          ·          ·
+                └── scan  4  scan    ·         ·          (k, v, w)  ·
+·                         4  ·       table     t@primary  ·          ·
+·                         4  ·       spans     ALL        ·          ·
+
+exec
+SELECT k FROM (SELECT k, v, w FROM t ORDER BY v LIMIT 4)
+----
+k:int
+6
+4
+2
+1

--- a/pkg/sql/opt/xform/factory.og.go
+++ b/pkg/sql/opt/xform/factory.og.go
@@ -3411,6 +3411,38 @@ func (_f *factory) ConstructProject(
 		}
 	}
 
+	// [FilterUnusedLimitCols]
+	{
+		_limit := _f.mem.lookupNormExpr(input).asLimit()
+		if _limit != nil {
+			input := _limit.input()
+			limit := _limit.limit()
+			ordering := _limit.ordering()
+			if _f.hasUnusedColumns(input, _f.neededColsLimit(projections, ordering)) {
+				_f.reportOptimization()
+				_group = _f.ConstructProject(_f.ConstructLimit(_f.filterUnusedColumns(input, _f.neededColsLimit(projections, ordering)), limit, ordering), projections)
+				_f.mem.addAltFingerprint(_projectExpr.fingerprint(), _group)
+				return _group
+			}
+		}
+	}
+
+	// [FilterUnusedOffsetCols]
+	{
+		_offset := _f.mem.lookupNormExpr(input).asOffset()
+		if _offset != nil {
+			input := _offset.input()
+			offset := _offset.offset()
+			ordering := _offset.ordering()
+			if _f.hasUnusedColumns(input, _f.neededColsLimit(projections, ordering)) {
+				_f.reportOptimization()
+				_group = _f.ConstructProject(_f.ConstructOffset(_f.filterUnusedColumns(input, _f.neededColsLimit(projections, ordering)), offset, ordering), projections)
+				_f.mem.addAltFingerprint(_projectExpr.fingerprint(), _group)
+				return _group
+			}
+		}
+	}
+
 	// [FilterUnusedJoinLeftCols]
 	{
 		_norm := _f.mem.lookupNormExpr(input)
@@ -4160,9 +4192,9 @@ func (_f *factory) ConstructGroupBy(
 
 	// [FilterUnusedGroupByCols]
 	{
-		if _f.hasUnusedColumns(input, _f.groupByNeededCols(aggregations, groupingCols)) {
+		if _f.hasUnusedColumns(input, _f.neededColsGroupBy(aggregations, groupingCols)) {
 			_f.reportOptimization()
-			_group = _f.ConstructGroupBy(_f.filterUnusedColumns(input, _f.groupByNeededCols(aggregations, groupingCols)), aggregations, groupingCols)
+			_group = _f.ConstructGroupBy(_f.filterUnusedColumns(input, _f.neededColsGroupBy(aggregations, groupingCols)), aggregations, groupingCols)
 			_f.mem.addAltFingerprint(_groupByExpr.fingerprint(), _group)
 			return _group
 		}

--- a/pkg/sql/opt/xform/optimizer_test.go
+++ b/pkg/sql/opt/xform/optimizer_test.go
@@ -132,7 +132,7 @@ func (ot *optimizerTest) run(t *testing.T, path string) {
 			return ot.optimizeExpr(stmt, OptimizeAll).String()
 
 		case "optsteps":
-			// optstep command iteratively outputs the output from each
+			// optsteps command iteratively shows the output from each
 			// optimization step for debugging.
 			var buf bytes.Buffer
 			var prev, next string

--- a/pkg/sql/opt/xform/rules/limit.opt
+++ b/pkg/sql/opt/xform/rules/limit.opt
@@ -1,0 +1,26 @@
+# =============================================================================
+# limit.opt contains normalization rules for the Limit and Offset operators.
+# =============================================================================
+
+#[PushLimitThroughProject, Normalize]
+#(Limit
+#    (Project $input:* $projections:*)
+#    $limit:*
+#)
+#=>
+#(Project $input:* $projections:*)
+#(Project
+#    (Limit $input $limit)
+#    $projections
+#)
+#
+#[PushLimitThroughSelect, Normalize]
+#(Limit
+#    (Project $input:* $projections:*)
+#    $limit:*
+#)
+#=>
+#(Project
+#    (Limit $input $limit)
+#    $projections
+#)

--- a/pkg/sql/opt/xform/rules/project.opt
+++ b/pkg/sql/opt/xform/rules/project.opt
@@ -62,6 +62,48 @@ $input
     $projections
 )
 
+# FilterUnusedLimitCols discards Limit input columns that are never used.
+[FilterUnusedLimitCols]
+(Project
+    (Limit
+        $input:*
+        $limit:*
+        $ordering:*
+    )
+    $projections:* & (HasUnusedColumns $input (NeededColsLimit $projections $ordering))
+)
+=>
+(Project
+    (Limit
+        (FilterUnusedColumns $input (NeededColsLimit $projections $ordering))
+        $limit
+        $ordering
+    )
+    $projections
+)
+
+# FilterUnusedOffsetCols discards Offset input columns that are never used.
+# Note: this rule is separate from FilterUnusedLimitCols because we can't access
+# the ordering private if using (Limit | Offset .. ).
+[FilterUnusedOffsetCols]
+(Project
+    (Offset
+        $input:*
+        $offset:*
+        $ordering:*
+    )
+    $projections:* & (HasUnusedColumns $input (NeededColsLimit $projections $ordering))
+)
+=>
+(Project
+    (Offset
+        (FilterUnusedColumns $input (NeededColsLimit $projections $ordering))
+        $offset
+        $ordering
+    )
+    $projections
+)
+
 # FilterUnusedJoinLeftCols discards columns on the left side of a join that are
 # never used.
 [FilterUnusedJoinLeftCols]
@@ -130,11 +172,11 @@ $input
 (GroupBy
     $input:*
     $aggregations:*
-    $groupingCols:* & (HasUnusedColumns $input (GroupByNeededCols $aggregations $groupingCols))
+    $groupingCols:* & (HasUnusedColumns $input (NeededColsGroupBy $aggregations $groupingCols))
 )
 =>
 (GroupBy
-    (FilterUnusedColumns $input (GroupByNeededCols $aggregations $groupingCols))
+    (FilterUnusedColumns $input (NeededColsGroupBy $aggregations $groupingCols))
     $aggregations
     $groupingCols
 )

--- a/pkg/sql/opt/xform/testdata/rules/project
+++ b/pkg/sql/opt/xform/testdata/rules/project
@@ -289,6 +289,184 @@ project
       └── variable: a.y [type=int, outer=(2)]
 
 # --------------------------------------------------
+# FilterUnusedLimitCols
+# --------------------------------------------------
+
+# The projection on top of Limit should trickle down and we shouldn't scan f.
+opt
+SELECT x FROM (SELECT x, y, f FROM t.a ORDER BY y LIMIT 10)
+----
+project
+ ├── columns: x:1(int!null)
+ ├── limit
+ │    ├── columns: a.x:1(int!null) a.y:2(int)
+ │    ├── sort
+ │    │    ├── columns: a.x:1(int!null) a.y:2(int)
+ │    │    ├── ordering: +2
+ │    │    └── scan a
+ │    │         └── columns: a.x:1(int!null) a.y:2(int)
+ │    └── const: 10 [type=int]
+ └── projections [outer=(1)]
+      └── variable: a.x [type=int, outer=(1)]
+
+# We should scan x, y, s.
+opt
+SELECT s FROM (SELECT x, y, f, s FROM t.a ORDER BY x, y LIMIT 10)
+----
+project
+ ├── columns: s:4(string)
+ ├── limit
+ │    ├── columns: a.x:1(int!null) a.y:2(int) a.s:4(string)
+ │    ├── sort
+ │    │    ├── columns: a.x:1(int!null) a.y:2(int) a.s:4(string)
+ │    │    ├── ordering: +1,+2
+ │    │    └── scan a
+ │    │         └── columns: a.x:1(int!null) a.y:2(int) a.s:4(string)
+ │    └── const: 10 [type=int]
+ └── projections [outer=(4)]
+      └── variable: a.s [type=string, outer=(4)]
+
+# We should scan x, y, s.
+opt
+SELECT x, s FROM (SELECT x, y, f, s FROM t.a ORDER BY x, y LIMIT 10)
+----
+project
+ ├── columns: x:1(int!null) s:4(string)
+ ├── limit
+ │    ├── columns: a.x:1(int!null) a.y:2(int) a.s:4(string)
+ │    ├── sort
+ │    │    ├── columns: a.x:1(int!null) a.y:2(int) a.s:4(string)
+ │    │    ├── ordering: +1,+2
+ │    │    └── scan a
+ │    │         └── columns: a.x:1(int!null) a.y:2(int) a.s:4(string)
+ │    └── const: 10 [type=int]
+ └── projections [outer=(1,4)]
+      ├── variable: a.x [type=int, outer=(1)]
+      └── variable: a.s [type=string, outer=(4)]
+
+# --------------------------------------------------
+# FilterUnusedOffsetCols
+# --------------------------------------------------
+
+opt
+SELECT x FROM (SELECT x, y, f FROM t.a ORDER BY y OFFSET 10)
+----
+project
+ ├── columns: x:1(int!null)
+ ├── offset
+ │    ├── columns: a.x:1(int!null) a.y:2(int)
+ │    ├── sort
+ │    │    ├── columns: a.x:1(int!null) a.y:2(int)
+ │    │    ├── ordering: +2
+ │    │    └── scan a
+ │    │         └── columns: a.x:1(int!null) a.y:2(int)
+ │    └── const: 10 [type=int]
+ └── projections [outer=(1)]
+      └── variable: a.x [type=int, outer=(1)]
+
+# We should scan x, y, s.
+opt
+SELECT s FROM (SELECT x, y, f, s FROM t.a ORDER BY x, y OFFSET 10)
+----
+project
+ ├── columns: s:4(string)
+ ├── offset
+ │    ├── columns: a.x:1(int!null) a.y:2(int) a.s:4(string)
+ │    ├── sort
+ │    │    ├── columns: a.x:1(int!null) a.y:2(int) a.s:4(string)
+ │    │    ├── ordering: +1,+2
+ │    │    └── scan a
+ │    │         └── columns: a.x:1(int!null) a.y:2(int) a.s:4(string)
+ │    └── const: 10 [type=int]
+ └── projections [outer=(4)]
+      └── variable: a.s [type=string, outer=(4)]
+
+# We should scan x, y, s.
+opt
+SELECT x, s FROM (SELECT x, y, f, s FROM t.a ORDER BY x, y OFFSET 10)
+----
+project
+ ├── columns: x:1(int!null) s:4(string)
+ ├── offset
+ │    ├── columns: a.x:1(int!null) a.y:2(int) a.s:4(string)
+ │    ├── sort
+ │    │    ├── columns: a.x:1(int!null) a.y:2(int) a.s:4(string)
+ │    │    ├── ordering: +1,+2
+ │    │    └── scan a
+ │    │         └── columns: a.x:1(int!null) a.y:2(int) a.s:4(string)
+ │    └── const: 10 [type=int]
+ └── projections [outer=(1,4)]
+      ├── variable: a.x [type=int, outer=(1)]
+      └── variable: a.s [type=string, outer=(4)]
+
+# --------------------------------------------------
+# FilterUnusedLimitCols + FilterUnusedOffsetCols
+# --------------------------------------------------
+
+opt
+SELECT x FROM (SELECT x, y, f FROM t.a ORDER BY y LIMIT 10 OFFSET 10)
+----
+project
+ ├── columns: x:1(int!null)
+ ├── limit
+ │    ├── columns: a.x:1(int!null) a.y:2(int)
+ │    ├── offset
+ │    │    ├── columns: a.x:1(int!null) a.y:2(int)
+ │    │    ├── ordering: +2
+ │    │    ├── sort
+ │    │    │    ├── columns: a.x:1(int!null) a.y:2(int)
+ │    │    │    ├── ordering: +2
+ │    │    │    └── scan a
+ │    │    │         └── columns: a.x:1(int!null) a.y:2(int)
+ │    │    └── const: 10 [type=int]
+ │    └── const: 10 [type=int]
+ └── projections [outer=(1)]
+      └── variable: a.x [type=int, outer=(1)]
+
+# We should scan x, y, s.
+opt
+SELECT s FROM (SELECT x, y, f, s FROM t.a ORDER BY x, y LIMIT 10 OFFSET 10)
+----
+project
+ ├── columns: s:4(string)
+ ├── limit
+ │    ├── columns: a.x:1(int!null) a.y:2(int) a.s:4(string)
+ │    ├── offset
+ │    │    ├── columns: a.x:1(int!null) a.y:2(int) a.s:4(string)
+ │    │    ├── ordering: +1,+2
+ │    │    ├── sort
+ │    │    │    ├── columns: a.x:1(int!null) a.y:2(int) a.s:4(string)
+ │    │    │    ├── ordering: +1,+2
+ │    │    │    └── scan a
+ │    │    │         └── columns: a.x:1(int!null) a.y:2(int) a.s:4(string)
+ │    │    └── const: 10 [type=int]
+ │    └── const: 10 [type=int]
+ └── projections [outer=(4)]
+      └── variable: a.s [type=string, outer=(4)]
+
+# We should scan x, y, s.
+opt
+SELECT x, s FROM (SELECT x, y, f, s FROM t.a ORDER BY x, y LIMIT 10 OFFSET 10)
+----
+project
+ ├── columns: x:1(int!null) s:4(string)
+ ├── limit
+ │    ├── columns: a.x:1(int!null) a.y:2(int) a.s:4(string)
+ │    ├── offset
+ │    │    ├── columns: a.x:1(int!null) a.y:2(int) a.s:4(string)
+ │    │    ├── ordering: +1,+2
+ │    │    ├── sort
+ │    │    │    ├── columns: a.x:1(int!null) a.y:2(int) a.s:4(string)
+ │    │    │    ├── ordering: +1,+2
+ │    │    │    └── scan a
+ │    │    │         └── columns: a.x:1(int!null) a.y:2(int) a.s:4(string)
+ │    │    └── const: 10 [type=int]
+ │    └── const: 10 [type=int]
+ └── projections [outer=(1,4)]
+      ├── variable: a.x [type=int, outer=(1)]
+      └── variable: a.s [type=string, outer=(4)]
+
+# --------------------------------------------------
 # FilterUnusedJoinLeftCols
 # --------------------------------------------------
 


### PR DESCRIPTION
Adding rules to filter unused columns on the input of Limit/Offset.
An interesting case is when we have an Ordering on a column that is
not needed by the top projection; to handle this correctly, the
columns needed by Limit/Offset are the union of the columns needed by
the projection and the columns in the Ordering.

Release note: None