### PR TITLE
cherry-pick 2.0: sql: implement encode(..., 'escape')

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -607,9 +607,9 @@ Compatible elements: hour, minute, second, millisecond, microsecond.</p>
 <tr><td><code>concat_ws(<a href="string.html">string</a>...) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Uses the first argument as a separator between the concatenation of the subsequent arguments.</p>
 <p>For example <code>concat_ws('!','wow','great')</code> returns <code>wow!great</code>.</p>
 </span></td></tr>
-<tr><td><code>decode(text: <a href="string.html">string</a>, format: <a href="string.html">string</a>) &rarr; <a href="bytes.html">bytes</a></code></td><td><span class="funcdesc"><p>Decodes <code>data</code> as the format specified by <code>format</code> (only “hex” is supported).</p>
+<tr><td><code>decode(text: <a href="string.html">string</a>, format: <a href="string.html">string</a>) &rarr; <a href="bytes.html">bytes</a></code></td><td><span class="funcdesc"><p>Decodes <code>data</code> as the format specified by <code>format</code> (only “hex” and “escape” are supported).</p>
 </span></td></tr>
-<tr><td><code>encode(data: <a href="bytes.html">bytes</a>, format: <a href="string.html">string</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Encodes <code>data</code> in the text format specified by <code>format</code> (only “hex” is supported).</p>
+<tr><td><code>encode(data: <a href="bytes.html">bytes</a>, format: <a href="string.html">string</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Encodes <code>data</code> in the text format specified by <code>format</code> (only “hex” and “escape” are supported).</p>
 </span></td></tr>
 <tr><td><code>from_ip(val: <a href="bytes.html">bytes</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Converts the byte string representation of an IP to its character string representation.</p>
 </span></td></tr>

--- a/pkg/sql/logictest/testdata/logic_test/builtin_function
+++ b/pkg/sql/logictest/testdata/logic_test/builtin_function
@@ -1335,19 +1335,25 @@ SELECT array_upper(ARRAY[ARRAY[1, 2]], 2)
 ----
 2
 
-query error only 'hex' format is supported for ENCODE
-SELECT ENCODE('abc', 'escape')
-
-query error only 'hex' format is supported for DECODE
-SELECT DECODE('abc', 'escape')
-
-query error invalid UTF-8
+query T
 SELECT ENCODE('\xa7', 'hex')
+----
+a7
 
 query TT
 SELECT ENCODE('abc', 'hex'), DECODE('616263', 'hex')
 ----
 616263 abc
+
+query T
+SELECT ENCODE(e'123\000456', 'escape')
+----
+123\000456
+
+query T
+SELECT DECODE('123\000456', 'escape')::STRING
+----
+\x31323300343536
 
 query T
 SELECT FROM_IP(b'\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xff\xff\x01\x02\x03\x04')

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -572,18 +572,19 @@ var Builtins = map[string][]tree.Builtin{
 			Types:      tree.ArgTypes{{"data", types.Bytes}, {"format", types.String}},
 			ReturnType: tree.FixedReturnType(types.String),
 			Fn: func(evalCtx *tree.EvalContext, args tree.Datums) (_ tree.Datum, err error) {
-				data, format := string(*args[0].(*tree.DBytes)), string(tree.MustBeDString(args[1]))
-				if format != "hex" {
-					return nil, pgerror.NewError(pgerror.CodeInvalidParameterValueError, "only 'hex' format is supported for ENCODE")
+				data, format := *args[0].(*tree.DBytes), string(tree.MustBeDString(args[1]))
+				switch format {
+				case "hex":
+					var buf bytes.Buffer
+					lex.HexEncodeString(&buf, string(data))
+					return tree.NewDString(buf.String()), nil
+				case "escape":
+					return tree.NewDString(encodeEscape([]byte(data))), nil
+				default:
+					return nil, pgerror.NewError(pgerror.CodeInvalidParameterValueError, "only 'hex' and 'escape' formats are supported for ENCODE")
 				}
-				if !utf8.ValidString(data) {
-					return nil, pgerror.NewError(pgerror.CodeCharacterNotInRepertoireError, "invalid UTF-8 sequence")
-				}
-				var buf bytes.Buffer
-				lex.HexEncodeString(&buf, data)
-				return tree.NewDString(buf.String()), nil
 			},
-			Info: "Encodes `data` in the text format specified by `format` (only \"hex\" is supported).",
+			Info: "Encodes `data` in the text format specified by `format` (only \"hex\" and \"escape\" are supported).",
 		},
 	},
 
@@ -593,16 +594,24 @@ var Builtins = map[string][]tree.Builtin{
 			ReturnType: tree.FixedReturnType(types.Bytes),
 			Fn: func(evalCtx *tree.EvalContext, args tree.Datums) (_ tree.Datum, err error) {
 				data, format := string(tree.MustBeDString(args[0])), string(tree.MustBeDString(args[1]))
-				if format != "hex" {
-					return nil, pgerror.NewError(pgerror.CodeInvalidParameterValueError, "only 'hex' format is supported for DECODE")
+				switch format {
+				case "hex":
+					decoded, err := hex.DecodeString(data)
+					if err != nil {
+						return nil, err
+					}
+					return tree.NewDBytes(tree.DBytes(decoded)), nil
+				case "escape":
+					decoded, err := decodeEscape(data)
+					if err != nil {
+						return nil, err
+					}
+					return tree.NewDBytes(tree.DBytes(decoded)), nil
+				default:
+					return nil, pgerror.NewError(pgerror.CodeInvalidParameterValueError, "only 'hex' and 'escape' formats are supported for DECODE")
 				}
-				decoded, err := hex.DecodeString(data)
-				if err != nil {
-					return nil, err
-				}
-				return tree.NewDBytes(tree.DBytes(decoded)), nil
 			},
-			Info: "Decodes `data` as the format specified by `format` (only \"hex\" is supported).",
+			Info: "Decodes `data` as the format specified by `format` (only \"hex\" and \"escape\" are supported).",
 		},
 	},
 
@@ -3575,6 +3584,63 @@ func stringToArray(str string, delimPtr *string, nullStr *string) (tree.Datum, e
 		}
 		if err := result.Append(next); err != nil {
 			return nil, err
+		}
+	}
+	return result, nil
+}
+
+// encodeEscape implements the encode(..., 'escape') Postgres builtin. It's
+// described "escape converts zero bytes and high-bit-set bytes to octal
+// sequences (\nnn) and doubles backslashes."
+func encodeEscape(input []byte) string {
+	var result bytes.Buffer
+	start := 0
+	for i := range input {
+		if input[i] == 0 || input[i]&128 != 0 {
+			result.Write(input[start:i])
+			start = i + 1
+			result.WriteString(fmt.Sprintf(`\%03o`, input[i]))
+		} else if input[i] == '\\' {
+			result.Write(input[start:i])
+			start = i + 1
+			result.WriteString(`\\`)
+		}
+	}
+	result.Write(input[start:])
+	return result.String()
+}
+
+var errInvalidSyntaxForDecode = pgerror.NewError(pgerror.CodeInvalidParameterValueError, "invalid syntax for decode(..., 'escape')")
+
+func isOctalDigit(c byte) bool {
+	return '0' <= c && c <= '7'
+}
+
+func decodeOctalTriplet(input string) byte {
+	return (input[0]-'0')*64 + (input[1]-'0')*8 + (input[2] - '0')
+}
+
+// decodeEscape implements the decode(..., 'escape') Postgres builtin. The
+// escape format is described as "escape converts zero bytes and high-bit-set
+// bytes to octal sequences (\nnn) and doubles backslashes."
+func decodeEscape(input string) ([]byte, error) {
+	result := make([]byte, 0, len(input))
+	for i := 0; i < len(input); i++ {
+		if input[i] == '\\' {
+			if i+1 < len(input) && input[i+1] == '\\' {
+				result = append(result, '\\')
+				i++
+			} else if i+3 < len(input) &&
+				isOctalDigit(input[i+1]) &&
+				isOctalDigit(input[i+2]) &&
+				isOctalDigit(input[i+3]) {
+				result = append(result, decodeOctalTriplet(input[i+1:i+4]))
+				i += 3
+			} else {
+				return nil, errInvalidSyntaxForDecode
+			}
+		} else {
+			result = append(result, input[i])
 		}
 	}
 	return result, nil


### PR DESCRIPTION
I thought a whole lot about whether to cherry-pick a further change that would update the string->bytes conversion, and came to the conclusion that it's a bit too far reaching. This change solves the problem we needed to solve so I think it's reasonable as the minimum cherry-pickable change.

Release note (sql change): Add 'escape' option to the encode builtin.

cc @cockroachdb/release 