### PR TITLE
sql: add some missing pg_type entries for anyelt

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -758,6 +758,7 @@ oid   typname       typnamespace  typowner  typlen  typbyval  typtype
 2205  regclass      3572887043    NULL      8       true      b
 2206  regtype       3572887043    NULL      8       true      b
 2249  record        3572887043    NULL      0       true      b
+2277  anyarray      3572887043    NULL      -1      false     b
 2283  anyelement    3572887043    NULL      -1      false     b
 2950  uuid          3572887043    NULL      16      true      b
 2951  _uuid         3572887043    NULL      -1      false     b
@@ -813,7 +814,8 @@ oid   typname       typcategory  typispreferred  typisdefined  typdelim  typreli
 2205  regclass      N            false           true          ,         0         0        0
 2206  regtype       N            false           true          ,         0         0        0
 2249  record        P            false           true          ,         0         0        0
-2283  anyelement    P            false           true          ,         0         0        0
+2277  anyarray      A            false           true          ,         0         2283     0
+2283  anyelement    P            false           true          ,         0         0        2277
 2950  uuid          U            false           true          ,         0         0        2951
 2951  _uuid         A            false           true          ,         0         2950     0
 3802  jsonb         U            false           true          ,         0         0        0
@@ -868,6 +870,7 @@ oid   typname       typinput        typoutput        typreceive        typsend  
 2205  regclass      regclassin      regclassout      regclassrecv      regclasssend      0         0          0
 2206  regtype       regtypein       regtypeout       regtyperecv       regtypesend       0         0          0
 2249  record        record_in       record_out       record_recv       record_send       0         0          0
+2277  anyarray      array_in        array_out        array_recv        array_send        0         0          0
 2283  anyelement    anyelement_in   anyelement_out   anyelement_recv   anyelement_send   0         0          0
 2950  uuid          uuid_in         uuid_out         uuid_recv         uuid_send         0         0          0
 2951  _uuid         array_in        array_out        array_recv        array_send        0         0          0
@@ -923,6 +926,7 @@ oid   typname       typalign  typstorage  typnotnull  typbasetype  typtypmod
 2205  regclass      NULL      NULL        false       0            -1
 2206  regtype       NULL      NULL        false       0            -1
 2249  record        NULL      NULL        false       0            -1
+2277  anyarray      NULL      NULL        false       0            -1
 2283  anyelement    NULL      NULL        false       0            -1
 2950  uuid          NULL      NULL        false       0            -1
 2951  _uuid         NULL      NULL        false       0            -1
@@ -978,6 +982,7 @@ oid   typname       typndims  typcollation  typdefaultbin  typdefault  typacl
 2205  regclass      0         0             NULL           NULL        NULL
 2206  regtype       0         0             NULL           NULL        NULL
 2249  record        0         0             NULL           NULL        NULL
+2277  anyarray      0         1661428263    NULL           NULL        NULL
 2283  anyelement    0         0             NULL           NULL        NULL
 2950  uuid          0         0             NULL           NULL        NULL
 2951  _uuid         0         0             NULL           NULL        NULL

--- a/pkg/sql/sem/types/oid.go
+++ b/pkg/sql/sem/types/oid.go
@@ -64,6 +64,7 @@ var (
 // the map directly.
 var OidToType = map[oid.Oid]T{
 	oid.T_anyelement:   Any,
+	oid.T_anyarray:     TArray{Any},
 	oid.T_bool:         Bool,
 	oid.T__bool:        TArray{Bool},
 	oid.T_bytea:        Bytes,
@@ -131,6 +132,7 @@ var aliasedOidToName = map[oid.Oid]string{
 	oid.T_varchar:    "varchar",
 	oid.T_numeric:    "numeric",
 	oid.T_record:     "record",
+	oid.T_anyarray:   "anyarray",
 	oid.T__int2:      "_int2",
 	oid.T__int4:      "_int4",
 	oid.T__int8:      "_int8",
@@ -155,6 +157,7 @@ var aliasedOidToName = map[oid.Oid]string{
 
 // oidToArrayOid maps scalar type Oids to their corresponding array type Oid.
 var oidToArrayOid = map[oid.Oid]oid.Oid{
+	oid.T_anyelement:  oid.T_anyarray,
 	oid.T_bool:        oid.T__bool,
 	oid.T_bytea:       oid.T__bytea,
 	oid.T_name:        oid.T__name,


### PR DESCRIPTION
Previously, we exported the `anyelement` type in `pg_type` without
correctly exporting the corresponding `anyarray` type, which has
`anyelement` as its element. This is required for `sqlsmith` and
improves general compatibility.

Release note: None