### PR TITLE
sql, opt: incorporate projection into scanNode

### DIFF
--- a/pkg/sql/distsql_plan_stats.go
+++ b/pkg/sql/distsql_plan_stats.go
@@ -36,7 +36,7 @@ func (dsp *DistSQLPlanner) createStatsPlan(
 ) (physicalPlan, error) {
 	// Create the table readers; for this we initialize a dummy scanNode.
 	scan := scanNode{desc: desc}
-	err := scan.initDescDefaults(nil /* planDependencies */, publicColumns, nil /* wantedColumns */)
+	err := scan.initDescDefaults(nil /* planDependencies */, publicColumnsCfg)
 	if err != nil {
 		return physicalPlan{}, err
 	}

--- a/pkg/sql/join_test.go
+++ b/pkg/sql/join_test.go
@@ -33,7 +33,7 @@ func newTestScanNode(kvDB *client.DB, tableName string) (*scanNode, error) {
 	p := planner{}
 	scan := p.Scan()
 	scan.desc = desc
-	err := scan.initDescDefaults(p.curPlan.deps, publicColumns, nil)
+	err := scan.initDescDefaults(p.curPlan.deps, publicColumnsCfg)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/logictest/testdata/logic_test/dependencies
+++ b/pkg/sql/logictest/testdata/logic_test/dependencies
@@ -127,7 +127,7 @@ CREATE SEQUENCE blog_posts_id_seq
 statement ok
 CREATE TABLE blog_posts (id INT PRIMARY KEY DEFAULT nextval('blog_posts_id_seq'), title text)
 
-query ITIIITITT colnames rowsort
+query ITIIITITT colnames
 SELECT * FROM crdb_internal.backward_dependencies WHERE descriptor_name LIKE 'blog_posts'
 ----
 descriptor_id  descriptor_name  index_id  column_id  dependson_id  dependson_type  dependson_index_id  dependson_name  dependson_details
@@ -138,3 +138,36 @@ SELECT * FROM crdb_internal.forward_dependencies WHERE descriptor_name LIKE 'blo
 ----
 descriptor_id  descriptor_name    index_id  dependedonby_id  dependedonby_type  dependedonby_index_id  dependedonby_name  dependedonby_details
 63             blog_posts_id_seq  NULL      64               sequence           0                      NULL               Columns: [0]
+
+# Verify that we report a dependency on a column that is being mutated.
+  #CREATE VIEW v AS WITH a AS (UPDATE kv SET v = 444 RETURNING k) SELECT k FROM a;
+statement ok
+CREATE TABLE kv (k INT PRIMARY KEY, v INT);
+BEGIN;
+  ALTER TABLE kv ADD COLUMN z INT DEFAULT 123;
+  CREATE VIEW v AS SELECT k FROM [UPDATE kv SET v = 444 WHERE k > 0 RETURNING k];
+COMMIT
+
+# The view should contain column z.
+query TITTTTT colnames
+EXPLAIN (VERBOSE) SELECT * FROM v
+----
+Tree            Level  Type    Field        Description       Columns           Ordering
+update          0      update  ·            ·                 (k)               ·
+ │              0      ·       table        kv                ·                 ·
+ │              0      ·       set          v                 ·                 ·
+ │              0      ·       returning 0  test.public.kv.k  ·                 ·
+ └── render     1      render  ·            ·                 (k, v, z, "444")  "444"=CONST; k!=NULL; key(k)
+      │         1      ·       render 0     test.public.kv.k  ·                 ·
+      │         1      ·       render 1     test.public.kv.v  ·                 ·
+      │         1      ·       render 2     test.public.kv.z  ·                 ·
+      │         1      ·       render 3     444               ·                 ·
+      └── scan  2      scan    ·            ·                 (k, v, z)         k!=NULL; key(k)
+·               2      ·       table        kv@primary        ·                 ·
+·               2      ·       spans        /1-               ·                 ·
+
+query ITIITITT colnames
+SELECT * FROM crdb_internal.forward_dependencies WHERE descriptor_name = 'kv'
+----
+descriptor_id  descriptor_name  index_id  dependedonby_id  dependedonby_type  dependedonby_index_id  dependedonby_name  dependedonby_details
+65             kv               NULL      66               view               0                      NULL               Columns: [1 2 3]

--- a/pkg/sql/opt/exec/execbuilder/testdata/aggregate
+++ b/pkg/sql/opt/exec/execbuilder/testdata/aggregate
@@ -12,34 +12,33 @@ CREATE TABLE kv (
 exec-explain
 SELECT MIN(1), MAX(1), COUNT(1), SUM_INT(1), AVG(1), SUM(1), STDDEV(1), VARIANCE(1), BOOL_AND(true), BOOL_AND(false), XOR_AGG(b'\x01') FROM kv
 ----
-group                0  group   ·             ·                   (column6, column8, column10, column12, column14, column16, column18, column20, column22, column24, column26)  ·
- │                   0  ·       aggregate 0   min(column5)        ·                                                                                                             ·
- │                   0  ·       aggregate 1   max(column7)        ·                                                                                                             ·
- │                   0  ·       aggregate 2   count(column9)      ·                                                                                                             ·
- │                   0  ·       aggregate 3   sum_int(column11)   ·                                                                                                             ·
- │                   0  ·       aggregate 4   avg(column13)       ·                                                                                                             ·
- │                   0  ·       aggregate 5   sum(column15)       ·                                                                                                             ·
- │                   0  ·       aggregate 6   stddev(column17)    ·                                                                                                             ·
- │                   0  ·       aggregate 7   variance(column19)  ·                                                                                                             ·
- │                   0  ·       aggregate 8   bool_and(column21)  ·                                                                                                             ·
- │                   0  ·       aggregate 9   bool_and(column23)  ·                                                                                                             ·
- │                   0  ·       aggregate 10  xor_agg(column25)   ·                                                                                                             ·
- └── render          1  render  ·             ·                   (column5, column7, column9, column11, column13, column15, column17, column19, column21, column23, column25)   ·
-      │              1  ·       render 0      1                   ·                                                                                                             ·
-      │              1  ·       render 1      1                   ·                                                                                                             ·
-      │              1  ·       render 2      1                   ·                                                                                                             ·
-      │              1  ·       render 3      1                   ·                                                                                                             ·
-      │              1  ·       render 4      1                   ·                                                                                                             ·
-      │              1  ·       render 5      1                   ·                                                                                                             ·
-      │              1  ·       render 6      1                   ·                                                                                                             ·
-      │              1  ·       render 7      1                   ·                                                                                                             ·
-      │              1  ·       render 8      true                ·                                                                                                             ·
-      │              1  ·       render 9      false               ·                                                                                                             ·
-      │              1  ·       render 10     '\x01'              ·                                                                                                             ·
-      └── render     2  render  ·             ·                   ()                                                                                                            ·
-           └── scan  3  scan    ·             ·                   (k, v, w, s)                                                                                                  ·
-·                    3  ·       table         kv@primary          ·                                                                                                             ·
-·                    3  ·       spans         ALL                 ·                                                                                                             ·
+group           0  group   ·             ·                   (column6, column8, column10, column12, column14, column16, column18, column20, column22, column24, column26)  ·
+ │              0  ·       aggregate 0   min(column5)        ·                                                                                                             ·
+ │              0  ·       aggregate 1   max(column7)        ·                                                                                                             ·
+ │              0  ·       aggregate 2   count(column9)      ·                                                                                                             ·
+ │              0  ·       aggregate 3   sum_int(column11)   ·                                                                                                             ·
+ │              0  ·       aggregate 4   avg(column13)       ·                                                                                                             ·
+ │              0  ·       aggregate 5   sum(column15)       ·                                                                                                             ·
+ │              0  ·       aggregate 6   stddev(column17)    ·                                                                                                             ·
+ │              0  ·       aggregate 7   variance(column19)  ·                                                                                                             ·
+ │              0  ·       aggregate 8   bool_and(column21)  ·                                                                                                             ·
+ │              0  ·       aggregate 9   bool_and(column23)  ·                                                                                                             ·
+ │              0  ·       aggregate 10  xor_agg(column25)   ·                                                                                                             ·
+ └── render     1  render  ·             ·                   (column5, column7, column9, column11, column13, column15, column17, column19, column21, column23, column25)   ·
+      │         1  ·       render 0      1                   ·                                                                                                             ·
+      │         1  ·       render 1      1                   ·                                                                                                             ·
+      │         1  ·       render 2      1                   ·                                                                                                             ·
+      │         1  ·       render 3      1                   ·                                                                                                             ·
+      │         1  ·       render 4      1                   ·                                                                                                             ·
+      │         1  ·       render 5      1                   ·                                                                                                             ·
+      │         1  ·       render 6      1                   ·                                                                                                             ·
+      │         1  ·       render 7      1                   ·                                                                                                             ·
+      │         1  ·       render 8      true                ·                                                                                                             ·
+      │         1  ·       render 9      false               ·                                                                                                             ·
+      │         1  ·       render 10     '\x01'              ·                                                                                                             ·
+      └── scan  2  scan    ·             ·                   ()                                                                                                            ·
+·               2  ·       table         kv@primary          ·                                                                                                             ·
+·               2  ·       spans         ALL                 ·                                                                                                             ·
 
 exec
 SELECT MIN(1), MAX(1), COUNT(1), SUM_INT(1), AVG(1), SUM(1), STDDEV(1), VARIANCE(1), BOOL_AND(true), BOOL_AND(false), XOR_AGG(b'\x01') FROM kv
@@ -69,36 +68,33 @@ NULL
 exec-explain
 SELECT MIN(v), MAX(v), COUNT(v), SUM_INT(1), AVG(v), SUM(v), STDDEV(v), VARIANCE(v), BOOL_AND(v = 1), BOOL_AND(v = 1), XOR_AGG(s::bytes) FROM kv
 ----
-group                0  group   ·             ·                   (column5, column6, column7, column9, column10, column11, column12, column13, column15, column17, column19)  ·
- │                   0  ·       aggregate 0   min(kv.v)           ·                                                                                                           ·
- │                   0  ·       aggregate 1   max(kv.v)           ·                                                                                                           ·
- │                   0  ·       aggregate 2   count(kv.v)         ·                                                                                                           ·
- │                   0  ·       aggregate 3   sum_int(column8)    ·                                                                                                           ·
- │                   0  ·       aggregate 4   avg(kv.v)           ·                                                                                                           ·
- │                   0  ·       aggregate 5   sum(kv.v)           ·                                                                                                           ·
- │                   0  ·       aggregate 6   stddev(kv.v)        ·                                                                                                           ·
- │                   0  ·       aggregate 7   variance(kv.v)      ·                                                                                                           ·
- │                   0  ·       aggregate 8   bool_and(column14)  ·                                                                                                           ·
- │                   0  ·       aggregate 9   bool_and(column16)  ·                                                                                                           ·
- │                   0  ·       aggregate 10  xor_agg(column18)   ·                                                                                                           ·
- └── render          1  render  ·             ·                   ("kv.v", "kv.v", "kv.v", column8, "kv.v", "kv.v", "kv.v", "kv.v", column14, column16, column18)             ·
-      │              1  ·       render 0      v                   ·                                                                                                           ·
-      │              1  ·       render 1      v                   ·                                                                                                           ·
-      │              1  ·       render 2      v                   ·                                                                                                           ·
-      │              1  ·       render 3      1                   ·                                                                                                           ·
-      │              1  ·       render 4      v                   ·                                                                                                           ·
-      │              1  ·       render 5      v                   ·                                                                                                           ·
-      │              1  ·       render 6      v                   ·                                                                                                           ·
-      │              1  ·       render 7      v                   ·                                                                                                           ·
-      │              1  ·       render 8      v = 1               ·                                                                                                           ·
-      │              1  ·       render 9      v = 1               ·                                                                                                           ·
-      │              1  ·       render 10     s::BYTES            ·                                                                                                           ·
-      └── render     2  render  ·             ·                   (v, s)                                                                                                      ·
-           │         2  ·       render 0      v                   ·                                                                                                           ·
-           │         2  ·       render 1      s                   ·                                                                                                           ·
-           └── scan  3  scan    ·             ·                   (k, v, w, s)                                                                                                ·
-·                    3  ·       table         kv@primary          ·                                                                                                           ·
-·                    3  ·       spans         ALL                 ·                                                                                                           ·
+group           0  group   ·             ·                   (column5, column6, column7, column9, column10, column11, column12, column13, column15, column17, column19)  ·
+ │              0  ·       aggregate 0   min(kv.v)           ·                                                                                                           ·
+ │              0  ·       aggregate 1   max(kv.v)           ·                                                                                                           ·
+ │              0  ·       aggregate 2   count(kv.v)         ·                                                                                                           ·
+ │              0  ·       aggregate 3   sum_int(column8)    ·                                                                                                           ·
+ │              0  ·       aggregate 4   avg(kv.v)           ·                                                                                                           ·
+ │              0  ·       aggregate 5   sum(kv.v)           ·                                                                                                           ·
+ │              0  ·       aggregate 6   stddev(kv.v)        ·                                                                                                           ·
+ │              0  ·       aggregate 7   variance(kv.v)      ·                                                                                                           ·
+ │              0  ·       aggregate 8   bool_and(column14)  ·                                                                                                           ·
+ │              0  ·       aggregate 9   bool_and(column16)  ·                                                                                                           ·
+ │              0  ·       aggregate 10  xor_agg(column18)   ·                                                                                                           ·
+ └── render     1  render  ·             ·                   ("kv.v", "kv.v", "kv.v", column8, "kv.v", "kv.v", "kv.v", "kv.v", column14, column16, column18)             ·
+      │         1  ·       render 0      v                   ·                                                                                                           ·
+      │         1  ·       render 1      v                   ·                                                                                                           ·
+      │         1  ·       render 2      v                   ·                                                                                                           ·
+      │         1  ·       render 3      1                   ·                                                                                                           ·
+      │         1  ·       render 4      v                   ·                                                                                                           ·
+      │         1  ·       render 5      v                   ·                                                                                                           ·
+      │         1  ·       render 6      v                   ·                                                                                                           ·
+      │         1  ·       render 7      v                   ·                                                                                                           ·
+      │         1  ·       render 8      v = 1               ·                                                                                                           ·
+      │         1  ·       render 9      v = 1               ·                                                                                                           ·
+      │         1  ·       render 10     s::BYTES            ·                                                                                                           ·
+      └── scan  2  scan    ·             ·                   (v, s)                                                                                                      ·
+·               2  ·       table         kv@primary          ·                                                                                                           ·
+·               2  ·       spans         ALL                 ·                                                                                                           ·
 
 exec
 SELECT MIN(v), MAX(v), COUNT(v), SUM_INT(1), AVG(v), SUM(v), STDDEV(v), VARIANCE(v), BOOL_AND(v = 1), BOOL_AND(v = 1), XOR_AGG(s::bytes) FROM kv
@@ -328,18 +324,16 @@ column5:int  k:int
 exec-explain
 SELECT COUNT(*), k FROM kv GROUP BY 2
 ----
-render               0  render  ·            ·             (column5, k)  ·
- │                   0  ·       render 0     agg0          ·             ·
- │                   0  ·       render 1     k             ·             ·
- └── group           1  group   ·            ·             (k, agg0)     ·
-      │              1  ·       aggregate 0  k             ·             ·
-      │              1  ·       aggregate 1  count_rows()  ·             ·
-      │              1  ·       group by     @1            ·             ·
-      └── render     2  render  ·            ·             (k)           ·
-           │         2  ·       render 0     k             ·             ·
-           └── scan  3  scan    ·            ·             (k, v, w, s)  ·
-·                    3  ·       table        kv@primary    ·             ·
-·                    3  ·       spans        ALL           ·             ·
+render          0  render  ·            ·             (column5, k)  ·
+ │              0  ·       render 0     agg0          ·             ·
+ │              0  ·       render 1     k             ·             ·
+ └── group      1  group   ·            ·             (k, agg0)     ·
+      │         1  ·       aggregate 0  k             ·             ·
+      │         1  ·       aggregate 1  count_rows()  ·             ·
+      │         1  ·       group by     @1            ·             ·
+      └── scan  2  scan    ·            ·             (k)           ·
+·               2  ·       table        kv@primary    ·             ·
+·               2  ·       spans        ALL           ·             ·
 
 # GROUP BY specified using column index works.
 exec rowsort
@@ -411,21 +405,18 @@ column5:int  column6:string
 exec-explain
 SELECT COUNT(*), k+v FROM kv GROUP BY k+v
 ----
-render                    0  render  ·            ·             (column6, column5)  ·
- │                        0  ·       render 0     agg0          ·                   ·
- │                        0  ·       render 1     column5       ·                   ·
- └── group                1  group   ·            ·             (column5, agg0)     ·
-      │                   1  ·       aggregate 0  column5       ·                   ·
-      │                   1  ·       aggregate 1  count_rows()  ·                   ·
-      │                   1  ·       group by     @1            ·                   ·
-      └── render          2  render  ·            ·             (column5)           ·
-           │              2  ·       render 0     k + v         ·                   ·
-           └── render     3  render  ·            ·             (k, v)              ·
-                │         3  ·       render 0     k             ·                   ·
-                │         3  ·       render 1     v             ·                   ·
-                └── scan  4  scan    ·            ·             (k, v, w, s)        ·
-·                         4  ·       table        kv@primary    ·                   ·
-·                         4  ·       spans        ALL           ·                   ·
+render               0  render  ·            ·             (column6, column5)  ·
+ │                   0  ·       render 0     agg0          ·                   ·
+ │                   0  ·       render 1     column5       ·                   ·
+ └── group           1  group   ·            ·             (column5, agg0)     ·
+      │              1  ·       aggregate 0  column5       ·                   ·
+      │              1  ·       aggregate 1  count_rows()  ·                   ·
+      │              1  ·       group by     @1            ·                   ·
+      └── render     2  render  ·            ·             (column5)           ·
+           │         2  ·       render 0     k + v         ·                   ·
+           └── scan  3  scan    ·            ·             (k, v)              ·
+·                    3  ·       table        kv@primary    ·                   ·
+·                    3  ·       spans        ALL           ·                   ·
 
 exec rowsort
 SELECT COUNT(*), k+v FROM kv GROUP BY k+v
@@ -442,20 +433,17 @@ column6:int  column5:int
 exec-explain
 SELECT COUNT(*), k+v FROM kv GROUP BY k, v
 ----
-render               0  render  ·            ·             (column5, column6)  ·
- │                   0  ·       render 0     agg0          ·                   ·
- │                   0  ·       render 1     k + v         ·                   ·
- └── group           1  group   ·            ·             (k, v, agg0)        ·
-      │              1  ·       aggregate 0  k             ·                   ·
-      │              1  ·       aggregate 1  v             ·                   ·
-      │              1  ·       aggregate 2  count_rows()  ·                   ·
-      │              1  ·       group by     @1-@2         ·                   ·
-      └── render     2  render  ·            ·             (k, v)              ·
-           │         2  ·       render 0     k             ·                   ·
-           │         2  ·       render 1     v             ·                   ·
-           └── scan  3  scan    ·            ·             (k, v, w, s)        ·
-·                    3  ·       table        kv@primary    ·                   ·
-·                    3  ·       spans        ALL           ·                   ·
+render          0  render  ·            ·             (column5, column6)  ·
+ │              0  ·       render 0     agg0          ·                   ·
+ │              0  ·       render 1     k + v         ·                   ·
+ └── group      1  group   ·            ·             (k, v, agg0)        ·
+      │         1  ·       aggregate 0  k             ·                   ·
+      │         1  ·       aggregate 1  v             ·                   ·
+      │         1  ·       aggregate 2  count_rows()  ·                   ·
+      │         1  ·       group by     @1-@2         ·                   ·
+      └── scan  2  scan    ·            ·             (k, v)              ·
+·               2  ·       table        kv@primary    ·                   ·
+·               2  ·       spans        ALL           ·                   ·
 
 exec rowsort
 SELECT COUNT(*), k+v FROM kv GROUP BY k, v
@@ -705,26 +693,22 @@ column7:decimal
 exec-explain
 SELECT COUNT(k) FROM kv
 ----
-group           0  group   ·            ·           (column5)     ·
- │              0  ·       aggregate 0  count(k)    ·             ·
- └── render     1  render  ·            ·           (k)           ·
-      │         1  ·       render 0     k           ·             ·
-      └── scan  2  scan    ·            ·           (k, v, w, s)  ·
-·               2  ·       table        kv@primary  ·             ·
-·               2  ·       spans        ALL         ·             ·
+group      0  group  ·            ·           (column5)  ·
+ │         0  ·      aggregate 0  count(k)    ·          ·
+ └── scan  1  scan   ·            ·           (k)        ·
+·          1  ·      table        kv@primary  ·          ·
+·          1  ·      spans        ALL         ·          ·
 
 exec-explain
 SELECT COUNT(k), SUM(k), MAX(k) FROM kv
 ----
-group           0  group   ·            ·           (column5, column6, column7)  ·
- │              0  ·       aggregate 0  count(k)    ·                            ·
- │              0  ·       aggregate 1  sum(k)      ·                            ·
- │              0  ·       aggregate 2  max(k)      ·                            ·
- └── render     1  render  ·            ·           (k)                          ·
-      │         1  ·       render 0     k           ·                            ·
-      └── scan  2  scan    ·            ·           (k, v, w, s)                 ·
-·               2  ·       table        kv@primary  ·                            ·
-·               2  ·       spans        ALL         ·                            ·
+group      0  group  ·            ·           (column5, column6, column7)  ·
+ │         0  ·      aggregate 0  count(k)    ·                            ·
+ │         0  ·      aggregate 1  sum(k)      ·                            ·
+ │         0  ·      aggregate 2  max(k)      ·                            ·
+ └── scan  1  scan   ·            ·           (k)                          ·
+·          1  ·      table        kv@primary  ·                            ·
+·          1  ·      spans        ALL         ·                            ·
 
 exec-raw
 CREATE TABLE abc (
@@ -742,13 +726,11 @@ INSERT INTO abc VALUES ('one', 1.5, true, 5::decimal), ('two', 2.0, false, 1.1::
 exec-explain
 SELECT MIN(a) FROM abc
 ----
-group           0  group   ·            ·            (column5)     ·
- │              0  ·       aggregate 0  min(a)       ·             ·
- └── render     1  render  ·            ·            (a)           ·
-      │         1  ·       render 0     a            ·             ·
-      └── scan  2  scan    ·            ·            (a, b, c, d)  ·
-·               2  ·       table        abc@primary  ·             ·
-·               2  ·       spans        ALL          ·             ·
+group      0  group  ·            ·            (column5)  ·
+ │         0  ·      aggregate 0  min(a)       ·          ·
+ └── scan  1  scan   ·            ·            (a)        ·
+·          1  ·      table        abc@primary  ·          ·
+·          1  ·      spans        ALL          ·          ·
 
 exec
 SELECT MIN(a), MIN(b), MIN(c), MIN(d) FROM abc
@@ -811,13 +793,11 @@ column4:int
 exec-explain
 SELECT MIN(x) FROM xyz
 ----
-group           0  group   ·            ·            (column4)  ·
- │              0  ·       aggregate 0  min(x)       ·          ·
- └── render     1  render  ·            ·            (x)        ·
-      │         1  ·       render 0     x            ·          ·
-      └── scan  2  scan    ·            ·            (x, y, z)  ·
-·               2  ·       table        xyz@primary  ·          ·
-·               2  ·       spans        ALL          ·          ·
+group      0  group  ·            ·            (column4)  ·
+ │         0  ·      aggregate 0  min(x)       ·          ·
+ └── scan  1  scan   ·            ·            (x)        ·
+·          1  ·      table        xyz@primary  ·          ·
+·          1  ·      spans        ALL          ·          ·
 
 exec
 SELECT MIN(x) FROM xyz WHERE x in (0, 4, 7)
@@ -829,15 +809,13 @@ column4:int
 exec-explain
 SELECT MIN(x) FROM xyz WHERE x in (0, 4, 7)
 ----
-group                0  group   ·            ·               (column4)  ·
- │                   0  ·       aggregate 0  min(x)          ·          ·
- └── filter          1  filter  ·            ·               (x)        ·
-      │              1  ·       filter       x IN (0, 4, 7)  ·          ·
-      └── render     2  render  ·            ·               (x)        ·
-           │         2  ·       render 0     x               ·          ·
-           └── scan  3  scan    ·            ·               (x, y, z)  ·
-·                    3  ·       table        xyz@primary     ·          ·
-·                    3  ·       spans        ALL             ·          ·
+group           0  group   ·            ·               (column4)  ·
+ │              0  ·       aggregate 0  min(x)          ·          ·
+ └── filter     1  filter  ·            ·               (x)        ·
+      │         1  ·       filter       x IN (0, 4, 7)  ·          ·
+      └── scan  2  scan    ·            ·               (x)        ·
+·               2  ·       table        xyz@primary     ·          ·
+·               2  ·       spans        ALL             ·          ·
 
 exec
 SELECT MAX(x) FROM xyz
@@ -849,13 +827,11 @@ column4:int
 exec-explain
 SELECT MAX(x) FROM xyz
 ----
-group           0  group   ·            ·            (column4)  ·
- │              0  ·       aggregate 0  max(x)       ·          ·
- └── render     1  render  ·            ·            (x)        ·
-      │         1  ·       render 0     x            ·          ·
-      └── scan  2  scan    ·            ·            (x, y, z)  ·
-·               2  ·       table        xyz@primary  ·          ·
-·               2  ·       spans        ALL          ·          ·
+group      0  group  ·            ·            (column4)  ·
+ │         0  ·      aggregate 0  max(x)       ·          ·
+ └── scan  1  scan   ·            ·            (x)        ·
+·          1  ·      table        xyz@primary  ·          ·
+·          1  ·      spans        ALL          ·          ·
 
 exec
 SELECT MIN(y) FROM xyz WHERE x = 1
@@ -866,18 +842,15 @@ column4:int
 exec-explain
 SELECT MIN(y) FROM xyz WHERE x = 1
 ----
-group                     0  group   ·            ·            (column4)  ·
- │                        0  ·       aggregate 0  min(xyz.y)   ·          ·
- └── render               1  render  ·            ·            ("xyz.y")  ·
-      │                   1  ·       render 0     y            ·          ·
-      └── filter          2  filter  ·            ·            (x, y)     ·
-           │              2  ·       filter       x = 1        ·          ·
-           └── render     3  render  ·            ·            (x, y)     ·
-                │         3  ·       render 0     x            ·          ·
-                │         3  ·       render 1     y            ·          ·
-                └── scan  4  scan    ·            ·            (x, y, z)  ·
-·                         4  ·       table        xyz@primary  ·          ·
-·                         4  ·       spans        ALL          ·          ·
+group                0  group   ·            ·            (column4)  ·
+ │                   0  ·       aggregate 0  min(xyz.y)   ·          ·
+ └── render          1  render  ·            ·            ("xyz.y")  ·
+      │              1  ·       render 0     y            ·          ·
+      └── filter     2  filter  ·            ·            (x, y)     ·
+           │         2  ·       filter       x = 1        ·          ·
+           └── scan  3  scan    ·            ·            (x, y)     ·
+·                    3  ·       table        xyz@primary  ·          ·
+·                    3  ·       spans        ALL          ·          ·
 
 exec
 SELECT MAX(y) FROM xyz WHERE x = 1
@@ -888,18 +861,15 @@ column4:int
 exec-explain
 SELECT MAX(y) FROM xyz WHERE x = 1
 ----
-group                     0  group   ·            ·            (column4)  ·
- │                        0  ·       aggregate 0  max(xyz.y)   ·          ·
- └── render               1  render  ·            ·            ("xyz.y")  ·
-      │                   1  ·       render 0     y            ·          ·
-      └── filter          2  filter  ·            ·            (x, y)     ·
-           │              2  ·       filter       x = 1        ·          ·
-           └── render     3  render  ·            ·            (x, y)     ·
-                │         3  ·       render 0     x            ·          ·
-                │         3  ·       render 1     y            ·          ·
-                └── scan  4  scan    ·            ·            (x, y, z)  ·
-·                         4  ·       table        xyz@primary  ·          ·
-·                         4  ·       spans        ALL          ·          ·
+group                0  group   ·            ·            (column4)  ·
+ │                   0  ·       aggregate 0  max(xyz.y)   ·          ·
+ └── render          1  render  ·            ·            ("xyz.y")  ·
+      │              1  ·       render 0     y            ·          ·
+      └── filter     2  filter  ·            ·            (x, y)     ·
+           │         2  ·       filter       x = 1        ·          ·
+           └── scan  3  scan    ·            ·            (x, y)     ·
+·                    3  ·       table        xyz@primary  ·          ·
+·                    3  ·       spans        ALL          ·          ·
 
 exec
 SELECT MIN(y) FROM xyz WHERE x = 7
@@ -910,18 +880,15 @@ NULL
 exec-explain
 SELECT MIN(y) FROM xyz WHERE x = 7
 ----
-group                     0  group   ·            ·            (column4)  ·
- │                        0  ·       aggregate 0  min(xyz.y)   ·          ·
- └── render               1  render  ·            ·            ("xyz.y")  ·
-      │                   1  ·       render 0     y            ·          ·
-      └── filter          2  filter  ·            ·            (x, y)     ·
-           │              2  ·       filter       x = 7        ·          ·
-           └── render     3  render  ·            ·            (x, y)     ·
-                │         3  ·       render 0     x            ·          ·
-                │         3  ·       render 1     y            ·          ·
-                └── scan  4  scan    ·            ·            (x, y, z)  ·
-·                         4  ·       table        xyz@primary  ·          ·
-·                         4  ·       spans        ALL          ·          ·
+group                0  group   ·            ·            (column4)  ·
+ │                   0  ·       aggregate 0  min(xyz.y)   ·          ·
+ └── render          1  render  ·            ·            ("xyz.y")  ·
+      │              1  ·       render 0     y            ·          ·
+      └── filter     2  filter  ·            ·            (x, y)     ·
+           │         2  ·       filter       x = 7        ·          ·
+           └── scan  3  scan    ·            ·            (x, y)     ·
+·                    3  ·       table        xyz@primary  ·          ·
+·                    3  ·       spans        ALL          ·          ·
 
 exec
 SELECT MAX(y) FROM xyz WHERE x = 7
@@ -932,18 +899,15 @@ NULL
 exec-explain
 SELECT MAX(y) FROM xyz WHERE x = 7
 ----
-group                     0  group   ·            ·            (column4)  ·
- │                        0  ·       aggregate 0  max(xyz.y)   ·          ·
- └── render               1  render  ·            ·            ("xyz.y")  ·
-      │                   1  ·       render 0     y            ·          ·
-      └── filter          2  filter  ·            ·            (x, y)     ·
-           │              2  ·       filter       x = 7        ·          ·
-           └── render     3  render  ·            ·            (x, y)     ·
-                │         3  ·       render 0     x            ·          ·
-                │         3  ·       render 1     y            ·          ·
-                └── scan  4  scan    ·            ·            (x, y, z)  ·
-·                         4  ·       table        xyz@primary  ·          ·
-·                         4  ·       spans        ALL          ·          ·
+group                0  group   ·            ·            (column4)  ·
+ │                   0  ·       aggregate 0  max(xyz.y)   ·          ·
+ └── render          1  render  ·            ·            ("xyz.y")  ·
+      │              1  ·       render 0     y            ·          ·
+      └── filter     2  filter  ·            ·            (x, y)     ·
+           │         2  ·       filter       x = 7        ·          ·
+           └── scan  3  scan    ·            ·            (x, y)     ·
+·                    3  ·       table        xyz@primary  ·          ·
+·                    3  ·       spans        ALL          ·          ·
 
 exec
 SELECT MIN(x) FROM xyz WHERE (y, z) = (2, 3.0)
@@ -1006,15 +970,13 @@ NULL
 exec-explain
 SELECT VARIANCE(x) FROM xyz WHERE x = 1
 ----
-group                0  group   ·            ·            (column4)  ·
- │                   0  ·       aggregate 0  variance(x)  ·          ·
- └── filter          1  filter  ·            ·            (x)        ·
-      │              1  ·       filter       x = 1        ·          ·
-      └── render     2  render  ·            ·            (x)        ·
-           │         2  ·       render 0     x            ·          ·
-           └── scan  3  scan    ·            ·            (x, y, z)  ·
-·                    3  ·       table        xyz@primary  ·          ·
-·                    3  ·       spans        ALL          ·          ·
+group           0  group   ·            ·            (column4)  ·
+ │              0  ·       aggregate 0  variance(x)  ·          ·
+ └── filter     1  filter  ·            ·            (x)        ·
+      │         1  ·       filter       x = 1        ·          ·
+      └── scan  2  scan    ·            ·            (x)        ·
+·               2  ·       table        xyz@primary  ·          ·
+·               2  ·       spans        ALL          ·          ·
 
 exec
 SELECT STDDEV(x), STDDEV(y::decimal), round(STDDEV(z), 14) FROM xyz
@@ -1347,26 +1309,24 @@ column5:int
 exec-explain
 SELECT SUM(abc.d) FROM kv JOIN abc ON kv.k >= abc.d GROUP BY kv.*;
 ----
-render                    0  render  ·            ·            (column9)           ·
- │                        0  ·       render 0     agg0         ·                   ·
- └── group                1  group   ·            ·            (k, v, w, s, agg0)  ·
-      │                   1  ·       aggregate 0  k            ·                   ·
-      │                   1  ·       aggregate 1  v            ·                   ·
-      │                   1  ·       aggregate 2  w            ·                   ·
-      │                   1  ·       aggregate 3  s            ·                   ·
-      │                   1  ·       aggregate 4  sum(d)       ·                   ·
-      │                   1  ·       group by     @1-@4        ·                   ·
-      └── join            2  join    ·            ·            (k, v, w, s, d)     ·
-           │              2  ·       type         inner        ·                   ·
-           │              2  ·       pred         k >= d       ·                   ·
-           ├── scan       3  scan    ·            ·            (k, v, w, s)        ·
-           │              3  ·       table        kv@primary   ·                   ·
-           │              3  ·       spans        ALL          ·                   ·
-           └── render     3  render  ·            ·            (d)                 ·
-                │         3  ·       render 0     d            ·                   ·
-                └── scan  4  scan    ·            ·            (a, b, c, d)        ·
-·                         4  ·       table        abc@primary  ·                   ·
-·                         4  ·       spans        ALL          ·                   ·
+render               0  render  ·            ·            (column9)           ·
+ │                   0  ·       render 0     agg0         ·                   ·
+ └── group           1  group   ·            ·            (k, v, w, s, agg0)  ·
+      │              1  ·       aggregate 0  k            ·                   ·
+      │              1  ·       aggregate 1  v            ·                   ·
+      │              1  ·       aggregate 2  w            ·                   ·
+      │              1  ·       aggregate 3  s            ·                   ·
+      │              1  ·       aggregate 4  sum(d)       ·                   ·
+      │              1  ·       group by     @1-@4        ·                   ·
+      └── join       2  join    ·            ·            (k, v, w, s, d)     ·
+           │         2  ·       type         inner        ·                   ·
+           │         2  ·       pred         k >= d       ·                   ·
+           ├── scan  3  scan    ·            ·            (k, v, w, s)        ·
+           │         3  ·       table        kv@primary   ·                   ·
+           │         3  ·       spans        ALL          ·                   ·
+           └── scan  3  scan    ·            ·            (d)                 ·
+·                    3  ·       table        abc@primary  ·                   ·
+·                    3  ·       spans        ALL          ·                   ·
 
 exec rowsort
 SELECT SUM(abc.d) FROM kv JOIN abc ON kv.k >= abc.d GROUP BY kv.*;
@@ -1545,23 +1505,20 @@ d               (4, 3)
 exec-explain
 SELECT MIN(y), (b, a) FROM ab, xy GROUP BY (x, (a, b))
 ----
-render                    0  render  ·            ·           (column6, column7)     ·
- │                        0  ·       render 0     agg0        ·                      ·
- │                        0  ·       render 1     (b, a)      ·                      ·
- └── group                1  group   ·            ·           (a, b, x, agg0)        ·
-      │                   1  ·       aggregate 0  a           ·                      ·
-      │                   1  ·       aggregate 1  b           ·                      ·
-      │                   1  ·       aggregate 2  x           ·                      ·
-      │                   1  ·       aggregate 3  min(y)      ·                      ·
-      │                   1  ·       group by     @1-@3       ·                      ·
-      └── join            2  join    ·            ·           (a, b, x, y)           ·
-           │              2  ·       type         cross       ·                      ·
-           ├── scan       3  scan    ·            ·           (a, b)                 ·
-           │              3  ·       table        ab@primary  ·                      ·
-           │              3  ·       spans        ALL         ·                      ·
-           └── render     3  render  ·            ·           (x, y)                 ·
-                │         3  ·       render 0     x           ·                      ·
-                │         3  ·       render 1     y           ·                      ·
-                └── scan  4  scan    ·            ·           (x, y, rowid[hidden])  ·
-·                         4  ·       table        xy@primary  ·                      ·
-·                         4  ·       spans        ALL         ·                      ·
+render               0  render  ·            ·           (column6, column7)  ·
+ │                   0  ·       render 0     agg0        ·                   ·
+ │                   0  ·       render 1     (b, a)      ·                   ·
+ └── group           1  group   ·            ·           (a, b, x, agg0)     ·
+      │              1  ·       aggregate 0  a           ·                   ·
+      │              1  ·       aggregate 1  b           ·                   ·
+      │              1  ·       aggregate 2  x           ·                   ·
+      │              1  ·       aggregate 3  min(y)      ·                   ·
+      │              1  ·       group by     @1-@3       ·                   ·
+      └── join       2  join    ·            ·           (a, b, x, y)        ·
+           │         2  ·       type         cross       ·                   ·
+           ├── scan  3  scan    ·            ·           (a, b)              ·
+           │         3  ·       table        ab@primary  ·                   ·
+           │         3  ·       spans        ALL         ·                   ·
+           └── scan  3  scan    ·            ·           (x, y)              ·
+·                    3  ·       table        xy@primary  ·                   ·
+·                    3  ·       spans        ALL         ·                   ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/limit
+++ b/pkg/sql/opt/exec/execbuilder/testdata/limit
@@ -6,14 +6,11 @@ INSERT INTO t VALUES (1, 1, 1), (2, -4, 8), (3, 9, 27), (4, -16, 94), (5, 25, 12
 exec-explain
 SELECT k, v FROM t ORDER BY k LIMIT 5
 ----
-limit           0  limit   ·         ·          (k, v)     ·
- │              0  ·       count     5          ·          ·
- └── render     1  render  ·         ·          (k, v)     ·
-      │         1  ·       render 0  k          ·          ·
-      │         1  ·       render 1  v          ·          ·
-      └── scan  2  scan    ·         ·          (k, v, w)  ·
-·               2  ·       table     t@primary  ·          ·
-·               2  ·       spans     ALL        ·          ·
+limit      0  limit  ·      ·          (k, v)  ·
+ │         0  ·      count  5          ·       ·
+ └── scan  1  scan   ·      ·          (k, v)  ·
+·          1  ·      table  t@primary  ·       ·
+·          1  ·      spans  ALL        ·       ·
 
 exec
 SELECT k, v FROM t ORDER BY k LIMIT 5
@@ -28,14 +25,11 @@ k:int  v:int
 exec-explain
 SELECT k, v FROM t ORDER BY k OFFSET 5
 ----
-limit           0  limit   ·         ·          (k, v)     ·
- │              0  ·       offset    5          ·          ·
- └── render     1  render  ·         ·          (k, v)     ·
-      │         1  ·       render 0  k          ·          ·
-      │         1  ·       render 1  v          ·          ·
-      └── scan  2  scan    ·         ·          (k, v, w)  ·
-·               2  ·       table     t@primary  ·          ·
-·               2  ·       spans     ALL        ·          ·
+limit      0  limit  ·       ·          (k, v)  ·
+ │         0  ·      offset  5          ·       ·
+ └── scan  1  scan   ·       ·          (k, v)  ·
+·          1  ·      table   t@primary  ·       ·
+·          1  ·      spans   ALL        ·       ·
 
 exec
 SELECT k, v FROM t ORDER BY k OFFSET 5
@@ -46,17 +40,14 @@ k:int  v:int
 exec-explain
 SELECT k, v FROM t ORDER BY v LIMIT (1+4) OFFSET 1
 ----
-limit                0  limit   ·         ·          (k, v)     +v
- │                   0  ·       count     5          ·          ·
- │                   0  ·       offset    1          ·          ·
- └── sort            1  sort    ·         ·          (k, v)     +v
-      │              1  ·       order     +v         ·          ·
-      └── render     2  render  ·         ·          (k, v)     ·
-           │         2  ·       render 0  k          ·          ·
-           │         2  ·       render 1  v          ·          ·
-           └── scan  3  scan    ·         ·          (k, v, w)  ·
-·                    3  ·       table     t@primary  ·          ·
-·                    3  ·       spans     ALL        ·          ·
+limit           0  limit  ·       ·          (k, v)  +v
+ │              0  ·      count   5          ·       ·
+ │              0  ·      offset  1          ·       ·
+ └── sort       1  sort   ·       ·          (k, v)  +v
+      │         1  ·      order   +v         ·       ·
+      └── scan  2  scan   ·       ·          (k, v)  ·
+·               2  ·      table   t@primary  ·       ·
+·               2  ·      spans   ALL        ·       ·
 
 exec
 SELECT k, v FROM t ORDER BY v LIMIT (1+4) OFFSET 1
@@ -103,18 +94,15 @@ column4:decimal
 exec-explain
 SELECT k FROM (SELECT k, v FROM t ORDER BY v LIMIT 4)
 ----
-render                    0  render  ·         ·          (k)        ·
- │                        0  ·       render 0  k          ·          ·
- └── limit                1  limit   ·         ·          (k, v)     +v
-      │                   1  ·       count     4          ·          ·
-      └── sort            2  sort    ·         ·          (k, v)     +v
-           │              2  ·       order     +v         ·          ·
-           └── render     3  render  ·         ·          (k, v)     ·
-                │         3  ·       render 0  k          ·          ·
-                │         3  ·       render 1  v          ·          ·
-                └── scan  4  scan    ·         ·          (k, v, w)  ·
-·                         4  ·       table     t@primary  ·          ·
-·                         4  ·       spans     ALL        ·          ·
+render               0  render  ·         ·          (k)     ·
+ │                   0  ·       render 0  k          ·       ·
+ └── limit           1  limit   ·         ·          (k, v)  +v
+      │              1  ·       count     4          ·       ·
+      └── sort       2  sort    ·         ·          (k, v)  +v
+           │         2  ·       order     +v         ·       ·
+           └── scan  3  scan    ·         ·          (k, v)  ·
+·                    3  ·       table     t@primary  ·       ·
+·                    3  ·       spans     ALL        ·       ·
 
 exec
 SELECT k FROM (SELECT k, v FROM t ORDER BY v LIMIT 4)
@@ -128,18 +116,15 @@ k:int
 exec-explain
 SELECT k FROM (SELECT k, v, w FROM t ORDER BY v LIMIT 4)
 ----
-render                    0  render  ·         ·          (k)        ·
- │                        0  ·       render 0  k          ·          ·
- └── limit                1  limit   ·         ·          (k, v)     +v
-      │                   1  ·       count     4          ·          ·
-      └── sort            2  sort    ·         ·          (k, v)     +v
-           │              2  ·       order     +v         ·          ·
-           └── render     3  render  ·         ·          (k, v)     ·
-                │         3  ·       render 0  k          ·          ·
-                │         3  ·       render 1  v          ·          ·
-                └── scan  4  scan    ·         ·          (k, v, w)  ·
-·                         4  ·       table     t@primary  ·          ·
-·                         4  ·       spans     ALL        ·          ·
+render               0  render  ·         ·          (k)     ·
+ │                   0  ·       render 0  k          ·       ·
+ └── limit           1  limit   ·         ·          (k, v)  +v
+      │              1  ·       count     4          ·       ·
+      └── sort       2  sort    ·         ·          (k, v)  +v
+           │         2  ·       order     +v         ·       ·
+           └── scan  3  scan    ·         ·          (k, v)  ·
+·                    3  ·       table     t@primary  ·       ·
+·                    3  ·       spans     ALL        ·       ·
 
 exec
 SELECT k FROM (SELECT k, v, w FROM t ORDER BY v LIMIT 4)

--- a/pkg/sql/opt/exec/execbuilder/testdata/orderby
+++ b/pkg/sql/opt/exec/execbuilder/testdata/orderby
@@ -24,13 +24,11 @@ true
 exec-explain
 SELECT c FROM t ORDER BY c
 ----
-sort            0  sort    ·         ·          (c)        +c
- │              0  ·       order     +c         ·          ·
- └── render     1  render  ·         ·          (c)        ·
-      │         1  ·       render 0  c          ·          ·
-      └── scan  2  scan    ·         ·          (a, b, c)  ·
-·               2  ·       table     t@primary  ·          ·
-·               2  ·       spans     ALL        ·          ·
+sort       0  sort  ·      ·          (c)  +c
+ │         0  ·     order  +c         ·    ·
+ └── scan  1  scan  ·      ·          (c)  ·
+·          1  ·     table  t@primary  ·    ·
+·          1  ·     spans  ALL        ·    ·
 
 exec
 SELECT c FROM t ORDER BY c DESC
@@ -51,14 +49,11 @@ a:int  b:int
 exec-explain
 SELECT a, b FROM t ORDER BY b
 ----
-sort            0  sort    ·         ·          (a, b)     +b
- │              0  ·       order     +b         ·          ·
- └── render     1  render  ·         ·          (a, b)     ·
-      │         1  ·       render 0  a          ·          ·
-      │         1  ·       render 1  b          ·          ·
-      └── scan  2  scan    ·         ·          (a, b, c)  ·
-·               2  ·       table     t@primary  ·          ·
-·               2  ·       spans     ALL        ·          ·
+sort       0  sort  ·      ·          (a, b)  +b
+ │         0  ·     order  +b         ·       ·
+ └── scan  1  scan  ·      ·          (a, b)  ·
+·          1  ·     table  t@primary  ·       ·
+·          1  ·     spans  ALL        ·       ·
 
 exec
 SELECT a, b FROM t ORDER BY b DESC
@@ -71,14 +66,11 @@ a:int  b:int
 exec-explain
 SELECT a, b FROM t ORDER BY b DESC
 ----
-sort            0  sort    ·         ·          (a, b)     -b
- │              0  ·       order     -b         ·          ·
- └── render     1  render  ·         ·          (a, b)     ·
-      │         1  ·       render 0  a          ·          ·
-      │         1  ·       render 1  b          ·          ·
-      └── scan  2  scan    ·         ·          (a, b, c)  ·
-·               2  ·       table     t@primary  ·          ·
-·               2  ·       spans     ALL        ·          ·
+sort       0  sort  ·      ·          (a, b)  -b
+ │         0  ·     order  -b         ·       ·
+ └── scan  1  scan  ·      ·          (a, b)  ·
+·          1  ·     table  t@primary  ·       ·
+·          1  ·     spans  ALL        ·       ·
 
 
 exec
@@ -92,16 +84,13 @@ a:int
 exec-explain
 SELECT a, b FROM t ORDER BY b LIMIT 2
 ----
-limit                0  limit   ·         ·          (a, b)     +b
- │                   0  ·       count     2          ·          ·
- └── sort            1  sort    ·         ·          (a, b)     +b
-      │              1  ·       order     +b         ·          ·
-      └── render     2  render  ·         ·          (a, b)     ·
-           │         2  ·       render 0  a          ·          ·
-           │         2  ·       render 1  b          ·          ·
-           └── scan  3  scan    ·         ·          (a, b, c)  ·
-·                    3  ·       table     t@primary  ·          ·
-·                    3  ·       spans     ALL        ·          ·
+limit           0  limit  ·      ·          (a, b)  +b
+ │              0  ·      count  2          ·       ·
+ └── sort       1  sort   ·      ·          (a, b)  +b
+      │         1  ·      order  +b         ·       ·
+      └── scan  2  scan   ·      ·          (a, b)  ·
+·               2  ·      table  t@primary  ·       ·
+·               2  ·      spans  ALL        ·       ·
 
 exec
 SELECT a, b FROM t ORDER BY b DESC LIMIT 2
@@ -144,58 +133,46 @@ b:int
 exec-explain
 SELECT b FROM t ORDER BY a DESC
 ----
-render               0  render  ·         ·          (b)        ·
- │                   0  ·       render 0  b          ·          ·
- └── sort            1  sort    ·         ·          (a, b)     -a
-      │              1  ·       order     -a         ·          ·
-      └── render     2  render  ·         ·          (a, b)     ·
-           │         2  ·       render 0  a          ·          ·
-           │         2  ·       render 1  b          ·          ·
-           └── scan  3  scan    ·         ·          (a, b, c)  ·
-·                    3  ·       table     t@primary  ·          ·
-·                    3  ·       spans     ALL        ·          ·
+render          0  render  ·         ·          (b)     ·
+ │              0  ·       render 0  b          ·       ·
+ └── sort       1  sort    ·         ·          (a, b)  -a
+      │         1  ·       order     -a         ·       ·
+      └── scan  2  scan    ·         ·          (a, b)  ·
+·               2  ·       table     t@primary  ·       ·
+·               2  ·       spans     ALL        ·       ·
 
 exec-explain
 SELECT b FROM t ORDER BY a LIMIT 1
 ----
-render               0  render  ·         ·          (b)        ·
- │                   0  ·       render 0  b          ·          ·
- └── limit           1  limit   ·         ·          (a, b)     ·
-      │              1  ·       count     1          ·          ·
-      └── render     2  render  ·         ·          (a, b)     ·
-           │         2  ·       render 0  a          ·          ·
-           │         2  ·       render 1  b          ·          ·
-           └── scan  3  scan    ·         ·          (a, b, c)  ·
-·                    3  ·       table     t@primary  ·          ·
-·                    3  ·       spans     ALL        ·          ·
+render          0  render  ·         ·          (b)     ·
+ │              0  ·       render 0  b          ·       ·
+ └── limit      1  limit   ·         ·          (a, b)  ·
+      │         1  ·       count     1          ·       ·
+      └── scan  2  scan    ·         ·          (a, b)  ·
+·               2  ·       table     t@primary  ·       ·
+·               2  ·       spans     ALL        ·       ·
 
 exec-explain
 SELECT b FROM t ORDER BY a DESC, b ASC
 ----
-render               0  render  ·         ·          (b)        ·
- │                   0  ·       render 0  b          ·          ·
- └── sort            1  sort    ·         ·          (a, b)     -a,+b
-      │              1  ·       order     -a,+b      ·          ·
-      └── render     2  render  ·         ·          (a, b)     ·
-           │         2  ·       render 0  a          ·          ·
-           │         2  ·       render 1  b          ·          ·
-           └── scan  3  scan    ·         ·          (a, b, c)  ·
-·                    3  ·       table     t@primary  ·          ·
-·                    3  ·       spans     ALL        ·          ·
+render          0  render  ·         ·          (b)     ·
+ │              0  ·       render 0  b          ·       ·
+ └── sort       1  sort    ·         ·          (a, b)  -a,+b
+      │         1  ·       order     -a,+b      ·       ·
+      └── scan  2  scan    ·         ·          (a, b)  ·
+·               2  ·       table     t@primary  ·       ·
+·               2  ·       spans     ALL        ·       ·
 
 exec-explain
 SELECT b FROM t ORDER BY a DESC, b DESC
 ----
-render               0  render  ·         ·          (b)        ·
- │                   0  ·       render 0  b          ·          ·
- └── sort            1  sort    ·         ·          (a, b)     -a,-b
-      │              1  ·       order     -a,-b      ·          ·
-      └── render     2  render  ·         ·          (a, b)     ·
-           │         2  ·       render 0  a          ·          ·
-           │         2  ·       render 1  b          ·          ·
-           └── scan  3  scan    ·         ·          (a, b, c)  ·
-·                    3  ·       table     t@primary  ·          ·
-·                    3  ·       spans     ALL        ·          ·
+render          0  render  ·         ·          (b)     ·
+ │              0  ·       render 0  b          ·       ·
+ └── sort       1  sort    ·         ·          (a, b)  -a,-b
+      │         1  ·       order     -a,-b      ·       ·
+      └── scan  2  scan    ·         ·          (a, b)  ·
+·               2  ·       table     t@primary  ·       ·
+·               2  ·       spans     ALL        ·       ·
 
 exec-explain
 SELECT * FROM t ORDER BY (b, t.*)
@@ -377,49 +354,43 @@ render               0  render  ·         ·              (a, b, c)            
 exec-explain
 SELECT b+2 FROM t ORDER BY b+2
 ----
-render                    0  render  ·         ·          (column4)           ·
- │                        0  ·       render 0  column4    ·                   ·
- └── sort                 1  sort    ·         ·          (column4, column5)  +column5
-      │                   1  ·       order     +column5   ·                   ·
-      └── render          2  render  ·         ·          (column4, column5)  ·
-           │              2  ·       render 0  b + 2      ·                   ·
-           │              2  ·       render 1  b + 2      ·                   ·
-           └── render     3  render  ·         ·          (b)                 ·
-                │         3  ·       render 0  b          ·                   ·
-                └── scan  4  scan    ·         ·          (a, b, c)           ·
-·                         4  ·       table     t@primary  ·                   ·
-·                         4  ·       spans     ALL        ·                   ·
+render               0  render  ·         ·          (column4)           ·
+ │                   0  ·       render 0  column4    ·                   ·
+ └── sort            1  sort    ·         ·          (column4, column5)  +column5
+      │              1  ·       order     +column5   ·                   ·
+      └── render     2  render  ·         ·          (column4, column5)  ·
+           │         2  ·       render 0  b + 2      ·                   ·
+           │         2  ·       render 1  b + 2      ·                   ·
+           └── scan  3  scan    ·         ·          (b)                 ·
+·                    3  ·       table     t@primary  ·                   ·
+·                    3  ·       spans     ALL        ·                   ·
 
 # Check that the sort picks up a renamed render properly.
 exec-explain
 SELECT b+2 AS y FROM t ORDER BY y
 ----
-sort                 0  sort    ·         ·          (y)        +y
- │                   0  ·       order     +y         ·          ·
- └── render          1  render  ·         ·          (y)        ·
-      │              1  ·       render 0  b + 2      ·          ·
-      └── render     2  render  ·         ·          (b)        ·
-           │         2  ·       render 0  b          ·          ·
-           └── scan  3  scan    ·         ·          (a, b, c)  ·
-·                    3  ·       table     t@primary  ·          ·
-·                    3  ·       spans     ALL        ·          ·
+sort            0  sort    ·         ·          (y)  +y
+ │              0  ·       order     +y         ·    ·
+ └── render     1  render  ·         ·          (y)  ·
+      │         1  ·       render 0  b + 2      ·    ·
+      └── scan  2  scan    ·         ·          (b)  ·
+·               2  ·       table     t@primary  ·    ·
+·               2  ·       spans     ALL        ·    ·
 
 # Check that the sort reuses a render behind a rename properly.
 exec-explain
 SELECT b+2 AS y FROM t ORDER BY b+2
 ----
-render                    0  render  ·         ·          (y)           ·
- │                        0  ·       render 0  y          ·             ·
- └── sort                 1  sort    ·         ·          (y, column5)  +column5
-      │                   1  ·       order     +column5   ·             ·
-      └── render          2  render  ·         ·          (y, column5)  ·
-           │              2  ·       render 0  b + 2      ·             ·
-           │              2  ·       render 1  b + 2      ·             ·
-           └── render     3  render  ·         ·          (b)           ·
-                │         3  ·       render 0  b          ·             ·
-                └── scan  4  scan    ·         ·          (a, b, c)     ·
-·                         4  ·       table     t@primary  ·             ·
-·                         4  ·       spans     ALL        ·             ·
+render               0  render  ·         ·          (y)           ·
+ │                   0  ·       render 0  y          ·             ·
+ └── sort            1  sort    ·         ·          (y, column5)  +column5
+      │              1  ·       order     +column5   ·             ·
+      └── render     2  render  ·         ·          (y, column5)  ·
+           │         2  ·       render 0  b + 2      ·             ·
+           │         2  ·       render 1  b + 2      ·             ·
+           └── scan  3  scan    ·         ·          (b)           ·
+·                    3  ·       table     t@primary  ·             ·
+·                    3  ·       spans     ALL        ·             ·
 
 exec-raw
 CREATE TABLE abc (
@@ -504,14 +475,11 @@ a:int  b:int  c:int  d:string
 exec-explain
 SELECT a, b FROM abc ORDER BY b, a
 ----
-sort            0  sort    ·         ·            (a, b)        +b,+a
- │              0  ·       order     +b,+a        ·             ·
- └── render     1  render  ·         ·            (a, b)        ·
-      │         1  ·       render 0  a            ·             ·
-      │         1  ·       render 1  b            ·             ·
-      └── scan  2  scan    ·         ·            (a, b, c, d)  ·
-·               2  ·       table     abc@primary  ·             ·
-·               2  ·       spans     ALL          ·             ·
+sort       0  sort  ·      ·            (a, b)  +b,+a
+ │         0  ·     order  +b,+a        ·       ·
+ └── scan  1  scan  ·      ·            (a, b)  ·
+·          1  ·     table  abc@primary  ·       ·
+·          1  ·     spans  ALL          ·       ·
 
 exec
 SELECT a, b FROM abc ORDER BY b, a
@@ -532,15 +500,11 @@ a:int  b:int
 exec-explain
 SELECT a, b, c FROM abc ORDER BY b, a, c
 ----
-sort            0  sort    ·         ·            (a, b, c)     +b,+a,+c
- │              0  ·       order     +b,+a,+c     ·             ·
- └── render     1  render  ·         ·            (a, b, c)     ·
-      │         1  ·       render 0  a            ·             ·
-      │         1  ·       render 1  b            ·             ·
-      │         1  ·       render 2  c            ·             ·
-      └── scan  2  scan    ·         ·            (a, b, c, d)  ·
-·               2  ·       table     abc@primary  ·             ·
-·               2  ·       spans     ALL          ·             ·
+sort       0  sort  ·      ·            (a, b, c)  +b,+a,+c
+ │         0  ·     order  +b,+a,+c     ·          ·
+ └── scan  1  scan  ·      ·            (a, b, c)  ·
+·          1  ·     table  abc@primary  ·          ·
+·          1  ·     spans  ALL          ·          ·
 
 exec
 SELECT a, b, c FROM abc ORDER BY b, a, c
@@ -608,18 +572,14 @@ a:int  b:int  c:int  d:string
 exec-explain
 SELECT a, b FROM abc ORDER BY b, c
 ----
-render               0  render  ·         ·            (a, b)        ·
- │                   0  ·       render 0  a            ·             ·
- │                   0  ·       render 1  b            ·             ·
- └── sort            1  sort    ·         ·            (a, b, c)     +b,+c
-      │              1  ·       order     +b,+c        ·             ·
-      └── render     2  render  ·         ·            (a, b, c)     ·
-           │         2  ·       render 0  a            ·             ·
-           │         2  ·       render 1  b            ·             ·
-           │         2  ·       render 2  c            ·             ·
-           └── scan  3  scan    ·         ·            (a, b, c, d)  ·
-·                    3  ·       table     abc@primary  ·             ·
-·                    3  ·       spans     ALL          ·             ·
+render          0  render  ·         ·            (a, b)     ·
+ │              0  ·       render 0  a            ·          ·
+ │              0  ·       render 1  b            ·          ·
+ └── sort       1  sort    ·         ·            (a, b, c)  +b,+c
+      │         1  ·       order     +b,+c        ·          ·
+      └── scan  2  scan    ·         ·            (a, b, c)  ·
+·               2  ·       table     abc@primary  ·          ·
+·               2  ·       spans     ALL          ·          ·
 
 exec
 SELECT a, b FROM abc ORDER BY b, c
@@ -638,18 +598,14 @@ a:int  b:int
 exec-explain
 SELECT a, b FROM abc ORDER BY c, b
 ----
-render               0  render  ·         ·            (a, b)        ·
- │                   0  ·       render 0  a            ·             ·
- │                   0  ·       render 1  b            ·             ·
- └── sort            1  sort    ·         ·            (a, b, c)     +c,+b
-      │              1  ·       order     +c,+b        ·             ·
-      └── render     2  render  ·         ·            (a, b, c)     ·
-           │         2  ·       render 0  a            ·             ·
-           │         2  ·       render 1  b            ·             ·
-           │         2  ·       render 2  c            ·             ·
-           └── scan  3  scan    ·         ·            (a, b, c, d)  ·
-·                    3  ·       table     abc@primary  ·             ·
-·                    3  ·       spans     ALL          ·             ·
+render          0  render  ·         ·            (a, b)     ·
+ │              0  ·       render 0  a            ·          ·
+ │              0  ·       render 1  b            ·          ·
+ └── sort       1  sort    ·         ·            (a, b, c)  +c,+b
+      │         1  ·       order     +c,+b        ·          ·
+      └── scan  2  scan    ·         ·            (a, b, c)  ·
+·               2  ·       table     abc@primary  ·          ·
+·               2  ·       spans     ALL          ·          ·
 
 exec
 SELECT a, b FROM abc ORDER BY c, b
@@ -668,18 +624,14 @@ a:int  b:int
 exec-explain
 SELECT a, b FROM abc ORDER BY b, c, a
 ----
-render               0  render  ·         ·            (a, b)        ·
- │                   0  ·       render 0  a            ·             ·
- │                   0  ·       render 1  b            ·             ·
- └── sort            1  sort    ·         ·            (a, b, c)     +b,+c,+a
-      │              1  ·       order     +b,+c,+a     ·             ·
-      └── render     2  render  ·         ·            (a, b, c)     ·
-           │         2  ·       render 0  a            ·             ·
-           │         2  ·       render 1  b            ·             ·
-           │         2  ·       render 2  c            ·             ·
-           └── scan  3  scan    ·         ·            (a, b, c, d)  ·
-·                    3  ·       table     abc@primary  ·             ·
-·                    3  ·       spans     ALL          ·             ·
+render          0  render  ·         ·            (a, b)     ·
+ │              0  ·       render 0  a            ·          ·
+ │              0  ·       render 1  b            ·          ·
+ └── sort       1  sort    ·         ·            (a, b, c)  +b,+c,+a
+      │         1  ·       order     +b,+c,+a     ·          ·
+      └── scan  2  scan    ·         ·            (a, b, c)  ·
+·               2  ·       table     abc@primary  ·          ·
+·               2  ·       spans     ALL          ·          ·
 
 exec
 SELECT a, b FROM abc ORDER BY b, c, a
@@ -698,18 +650,14 @@ a:int  b:int
 exec-explain
 SELECT a, b FROM abc ORDER BY b, c, a DESC
 ----
-render               0  render  ·         ·            (a, b)        ·
- │                   0  ·       render 0  a            ·             ·
- │                   0  ·       render 1  b            ·             ·
- └── sort            1  sort    ·         ·            (a, b, c)     +b,+c,-a
-      │              1  ·       order     +b,+c,-a     ·             ·
-      └── render     2  render  ·         ·            (a, b, c)     ·
-           │         2  ·       render 0  a            ·             ·
-           │         2  ·       render 1  b            ·             ·
-           │         2  ·       render 2  c            ·             ·
-           └── scan  3  scan    ·         ·            (a, b, c, d)  ·
-·                    3  ·       table     abc@primary  ·             ·
-·                    3  ·       spans     ALL          ·             ·
+render          0  render  ·         ·            (a, b)     ·
+ │              0  ·       render 0  a            ·          ·
+ │              0  ·       render 1  b            ·          ·
+ └── sort       1  sort    ·         ·            (a, b, c)  +b,+c,-a
+      │         1  ·       order     +b,+c,-a     ·          ·
+      └── scan  2  scan    ·         ·            (a, b, c)  ·
+·               2  ·       table     abc@primary  ·          ·
+·               2  ·       spans     ALL          ·          ·
 
 exec
 SELECT a, b FROM abc ORDER BY b, c, a DESC
@@ -728,13 +676,11 @@ a:int  b:int
 exec-explain
 SELECT a FROM abc ORDER BY a DESC
 ----
-sort            0  sort    ·         ·            (a)           -a
- │              0  ·       order     -a           ·             ·
- └── render     1  render  ·         ·            (a)           ·
-      │         1  ·       render 0  a            ·             ·
-      └── scan  2  scan    ·         ·            (a, b, c, d)  ·
-·               2  ·       table     abc@primary  ·             ·
-·               2  ·       spans     ALL          ·             ·
+sort       0  sort  ·      ·            (a)  -a
+ │         0  ·     order  -a           ·    ·
+ └── scan  1  scan  ·      ·            (a)  ·
+·          1  ·     table  abc@primary  ·    ·
+·          1  ·     spans  ALL          ·    ·
 
 exec
 SELECT a FROM abc ORDER BY a DESC
@@ -764,54 +710,44 @@ a:int
 exec-explain
 SELECT c FROM abc WHERE b = 2 ORDER BY c
 ----
-render                    0  render  ·         ·            (c)           ·
- │                        0  ·       render 0  c            ·             ·
- └── filter               1  filter  ·         ·            (b, c)        ·
-      │                   1  ·       filter    b = 2        ·             ·
-      └── sort            2  sort    ·         ·            (b, c)        +c
-           │              2  ·       order     +c           ·             ·
-           └── render     3  render  ·         ·            (b, c)        ·
-                │         3  ·       render 0  b            ·             ·
-                │         3  ·       render 1  c            ·             ·
-                └── scan  4  scan    ·         ·            (a, b, c, d)  ·
-·                         4  ·       table     abc@primary  ·             ·
-·                         4  ·       spans     ALL          ·             ·
+render               0  render  ·         ·            (c)     ·
+ │                   0  ·       render 0  c            ·       ·
+ └── filter          1  filter  ·         ·            (b, c)  ·
+      │              1  ·       filter    b = 2        ·       ·
+      └── sort       2  sort    ·         ·            (b, c)  +c
+           │         2  ·       order     +c           ·       ·
+           └── scan  3  scan    ·         ·            (b, c)  ·
+·                    3  ·       table     abc@primary  ·       ·
+·                    3  ·       spans     ALL          ·       ·
 
 exec-explain
 SELECT c FROM abc WHERE b = 2 ORDER BY c DESC
 ----
-render                    0  render  ·         ·            (c)           ·
- │                        0  ·       render 0  c            ·             ·
- └── filter               1  filter  ·         ·            (b, c)        ·
-      │                   1  ·       filter    b = 2        ·             ·
-      └── sort            2  sort    ·         ·            (b, c)        -c
-           │              2  ·       order     -c           ·             ·
-           └── render     3  render  ·         ·            (b, c)        ·
-                │         3  ·       render 0  b            ·             ·
-                │         3  ·       render 1  c            ·             ·
-                └── scan  4  scan    ·         ·            (a, b, c, d)  ·
-·                         4  ·       table     abc@primary  ·             ·
-·                         4  ·       spans     ALL          ·             ·
+render               0  render  ·         ·            (c)     ·
+ │                   0  ·       render 0  c            ·       ·
+ └── filter          1  filter  ·         ·            (b, c)  ·
+      │              1  ·       filter    b = 2        ·       ·
+      └── sort       2  sort    ·         ·            (b, c)  -c
+           │         2  ·       order     -c           ·       ·
+           └── scan  3  scan    ·         ·            (b, c)  ·
+·                    3  ·       table     abc@primary  ·       ·
+·                    3  ·       spans     ALL          ·       ·
 
 # Verify that the ordering of the primary index is still used for the outer sort.
 exec-explain
 SELECT * FROM (SELECT b, c FROM abc WHERE a=1 ORDER BY a,b) ORDER BY b,c
 ----
-render                    0  render  ·         ·            (b, c, a)     ·
- │                        0  ·       render 0  b            ·             ·
- │                        0  ·       render 1  c            ·             ·
- │                        0  ·       render 2  a            ·             ·
- └── filter               1  filter  ·         ·            (a, b, c)     ·
-      │                   1  ·       filter    a = 1        ·             ·
-      └── sort            2  sort    ·         ·            (a, b, c)     +b,+c
-           │              2  ·       order     +b,+c        ·             ·
-           └── render     3  render  ·         ·            (a, b, c)     ·
-                │         3  ·       render 0  a            ·             ·
-                │         3  ·       render 1  b            ·             ·
-                │         3  ·       render 2  c            ·             ·
-                └── scan  4  scan    ·         ·            (a, b, c, d)  ·
-·                         4  ·       table     abc@primary  ·             ·
-·                         4  ·       spans     ALL          ·             ·
+render               0  render  ·         ·            (b, c, a)  ·
+ │                   0  ·       render 0  b            ·          ·
+ │                   0  ·       render 1  c            ·          ·
+ │                   0  ·       render 2  a            ·          ·
+ └── filter          1  filter  ·         ·            (a, b, c)  ·
+      │              1  ·       filter    a = 1        ·          ·
+      └── sort       2  sort    ·         ·            (a, b, c)  +b,+c
+           │         2  ·       order     +b,+c        ·          ·
+           └── scan  3  scan    ·         ·            (a, b, c)  ·
+·                    3  ·       table     abc@primary  ·          ·
+·                    3  ·       spans     ALL          ·          ·
 
 exec-raw
 CREATE TABLE bar (id INT PRIMARY KEY, baz STRING, UNIQUE INDEX i_bar (baz))
@@ -882,62 +818,46 @@ column5:int
 exec-explain
 SELECT a, b, c FROM abcd@abc WHERE (a, b) = (1, 4) ORDER BY c
 ----
-filter               0  filter  ·         ·                    (a, b, c)     ·
- │                   0  ·       filter    (a = 1) AND (b = 4)  ·             ·
- └── sort            1  sort    ·         ·                    (a, b, c)     +c
-      │              1  ·       order     +c                   ·             ·
-      └── render     2  render  ·         ·                    (a, b, c)     ·
-           │         2  ·       render 0  a                    ·             ·
-           │         2  ·       render 1  b                    ·             ·
-           │         2  ·       render 2  c                    ·             ·
-           └── scan  3  scan    ·         ·                    (a, b, c, d)  ·
-·                    3  ·       table     abcd@primary         ·             ·
-·                    3  ·       spans     ALL                  ·             ·
+filter          0  filter  ·       ·                    (a, b, c)  ·
+ │              0  ·       filter  (a = 1) AND (b = 4)  ·          ·
+ └── sort       1  sort    ·       ·                    (a, b, c)  +c
+      │         1  ·       order   +c                   ·          ·
+      └── scan  2  scan    ·       ·                    (a, b, c)  ·
+·               2  ·       table   abcd@primary         ·          ·
+·               2  ·       spans   ALL                  ·          ·
 
 exec-explain
 SELECT a, b, c FROM abcd@abc WHERE (a, b) = (1, 4) ORDER BY c, b, a
 ----
-filter               0  filter  ·         ·                    (a, b, c)     ·
- │                   0  ·       filter    (a = 1) AND (b = 4)  ·             ·
- └── sort            1  sort    ·         ·                    (a, b, c)     +c,+b,+a
-      │              1  ·       order     +c,+b,+a             ·             ·
-      └── render     2  render  ·         ·                    (a, b, c)     ·
-           │         2  ·       render 0  a                    ·             ·
-           │         2  ·       render 1  b                    ·             ·
-           │         2  ·       render 2  c                    ·             ·
-           └── scan  3  scan    ·         ·                    (a, b, c, d)  ·
-·                    3  ·       table     abcd@primary         ·             ·
-·                    3  ·       spans     ALL                  ·             ·
+filter          0  filter  ·       ·                    (a, b, c)  ·
+ │              0  ·       filter  (a = 1) AND (b = 4)  ·          ·
+ └── sort       1  sort    ·       ·                    (a, b, c)  +c,+b,+a
+      │         1  ·       order   +c,+b,+a             ·          ·
+      └── scan  2  scan    ·       ·                    (a, b, c)  ·
+·               2  ·       table   abcd@primary         ·          ·
+·               2  ·       spans   ALL                  ·          ·
 
 exec-explain
 SELECT a, b, c FROM abcd@abc WHERE (a, b) = (1, 4) ORDER BY b, a, c
 ----
-filter               0  filter  ·         ·                    (a, b, c)     ·
- │                   0  ·       filter    (a = 1) AND (b = 4)  ·             ·
- └── sort            1  sort    ·         ·                    (a, b, c)     +b,+a,+c
-      │              1  ·       order     +b,+a,+c             ·             ·
-      └── render     2  render  ·         ·                    (a, b, c)     ·
-           │         2  ·       render 0  a                    ·             ·
-           │         2  ·       render 1  b                    ·             ·
-           │         2  ·       render 2  c                    ·             ·
-           └── scan  3  scan    ·         ·                    (a, b, c, d)  ·
-·                    3  ·       table     abcd@primary         ·             ·
-·                    3  ·       spans     ALL                  ·             ·
+filter          0  filter  ·       ·                    (a, b, c)  ·
+ │              0  ·       filter  (a = 1) AND (b = 4)  ·          ·
+ └── sort       1  sort    ·       ·                    (a, b, c)  +b,+a,+c
+      │         1  ·       order   +b,+a,+c             ·          ·
+      └── scan  2  scan    ·       ·                    (a, b, c)  ·
+·               2  ·       table   abcd@primary         ·          ·
+·               2  ·       spans   ALL                  ·          ·
 
 exec-explain
 SELECT a, b, c FROM abcd@abc WHERE (a, b) = (1, 4) ORDER BY b, c, a
 ----
-filter               0  filter  ·         ·                    (a, b, c)     ·
- │                   0  ·       filter    (a = 1) AND (b = 4)  ·             ·
- └── sort            1  sort    ·         ·                    (a, b, c)     +b,+c,+a
-      │              1  ·       order     +b,+c,+a             ·             ·
-      └── render     2  render  ·         ·                    (a, b, c)     ·
-           │         2  ·       render 0  a                    ·             ·
-           │         2  ·       render 1  b                    ·             ·
-           │         2  ·       render 2  c                    ·             ·
-           └── scan  3  scan    ·         ·                    (a, b, c, d)  ·
-·                    3  ·       table     abcd@primary         ·             ·
-·                    3  ·       spans     ALL                  ·             ·
+filter          0  filter  ·       ·                    (a, b, c)  ·
+ │              0  ·       filter  (a = 1) AND (b = 4)  ·          ·
+ └── sort       1  sort    ·       ·                    (a, b, c)  +b,+c,+a
+      │         1  ·       order   +b,+c,+a             ·          ·
+      └── scan  2  scan    ·       ·                    (a, b, c)  ·
+·               2  ·       table   abcd@primary         ·          ·
+·               2  ·       spans   ALL                  ·          ·
 
 exec-raw
 CREATE TABLE nan (id INT PRIMARY KEY, x REAL)
@@ -1052,21 +972,17 @@ CREATE TABLE uvwxyz (
 exec-explain
 SELECT * FROM (SELECT y, w, x FROM uvwxyz WHERE y = 1 ORDER BY w) ORDER BY w, x
 ----
-render                    0  render  ·         ·               (y, w, x)                          ·
- │                        0  ·       render 0  y               ·                                  ·
- │                        0  ·       render 1  w               ·                                  ·
- │                        0  ·       render 2  x               ·                                  ·
- └── filter               1  filter  ·         ·               (w, x, y)                          ·
-      │                   1  ·       filter    y = 1           ·                                  ·
-      └── sort            2  sort    ·         ·               (w, x, y)                          +w,+x
-           │              2  ·       order     +w,+x           ·                                  ·
-           └── render     3  render  ·         ·               (w, x, y)                          ·
-                │         3  ·       render 0  w               ·                                  ·
-                │         3  ·       render 1  x               ·                                  ·
-                │         3  ·       render 2  y               ·                                  ·
-                └── scan  4  scan    ·         ·               (u, v, w, x, y, z, rowid[hidden])  ·
-·                         4  ·       table     uvwxyz@primary  ·                                  ·
-·                         4  ·       spans     ALL             ·                                  ·
+render               0  render  ·         ·               (y, w, x)  ·
+ │                   0  ·       render 0  y               ·          ·
+ │                   0  ·       render 1  w               ·          ·
+ │                   0  ·       render 2  x               ·          ·
+ └── filter          1  filter  ·         ·               (w, x, y)  ·
+      │              1  ·       filter    y = 1           ·          ·
+      └── sort       2  sort    ·         ·               (w, x, y)  +w,+x
+           │         2  ·       order     +w,+x           ·          ·
+           └── scan  3  scan    ·         ·               (w, x, y)  ·
+·                    3  ·       table     uvwxyz@primary  ·          ·
+·                    3  ·       spans     ALL             ·          ·
 
 exec-raw
 CREATE TABLE blocks (

--- a/pkg/sql/opt/exec/execbuilder/testdata/project
+++ b/pkg/sql/opt/exec/execbuilder/testdata/project
@@ -61,13 +61,11 @@ x:int  y:int
 exec-explain
 SELECT x + 1 FROM t.a
 ----
-render          0  render  ·         ·          (column3)  ·
- │              0  ·       render 0  x + 1      ·          ·
- └── render     1  render  ·         ·          (x)        ·
-      │         1  ·       render 0  x          ·          ·
-      └── scan  2  scan    ·         ·          (x, y)     ·
-·               2  ·       table     a@primary  ·          ·
-·               2  ·       spans     ALL        ·          ·
+render     0  render  ·         ·          (column3)  ·
+ │         0  ·       render 0  x + 1      ·          ·
+ └── scan  1  scan    ·         ·          (x)        ·
+·          1  ·       table     a@primary  ·          ·
+·          1  ·       spans     ALL        ·          ·
 
 exec
 SELECT x + 1 FROM t.a
@@ -166,12 +164,9 @@ INSERT INTO t.b VALUES (1, 10), (2, 20), (3, 30)
 exec-explain
 SELECT * FROM t.b
 ----
-render     0  render  ·         ·          (x, y)                 ·
- │         0  ·       render 0  x          ·                      ·
- │         0  ·       render 1  y          ·                      ·
- └── scan  1  scan    ·         ·          (x, y, rowid[hidden])  ·
-·          1  ·       table     b@primary  ·                      ·
-·          1  ·       spans     ALL        ·                      ·
+scan  0  scan  ·      ·          (x, y)  ·
+·     0  ·     table  b@primary  ·       ·
+·     0  ·     spans  ALL        ·       ·
 
 exec
 SELECT * FROM t.b
@@ -184,16 +179,13 @@ x:int  y:int
 exec-explain
 SELECT x FROM t.b WHERE rowid > 0
 ----
-render               0  render  ·         ·          (x)                    ·
- │                   0  ·       render 0  x          ·                      ·
- └── filter          1  filter  ·         ·          (x, rowid)             ·
-      │              1  ·       filter    rowid > 0  ·                      ·
-      └── render     2  render  ·         ·          (x, rowid)             ·
-           │         2  ·       render 0  x          ·                      ·
-           │         2  ·       render 1  rowid      ·                      ·
-           └── scan  3  scan    ·         ·          (x, y, rowid[hidden])  ·
-·                    3  ·       table     b@primary  ·                      ·
-·                    3  ·       spans     ALL        ·                      ·
+render          0  render  ·         ·          (x)                 ·
+ │              0  ·       render 0  x          ·                   ·
+ └── filter     1  filter  ·         ·          (x, rowid[hidden])  ·
+      │         1  ·       filter    rowid > 0  ·                   ·
+      └── scan  2  scan    ·         ·          (x, rowid[hidden])  ·
+·               2  ·       table     b@primary  ·                   ·
+·               2  ·       spans     ALL        ·                   ·
 
 exec
 SELECT x FROM t.b WHERE rowid > 0
@@ -219,12 +211,11 @@ TABLE nocols
 exec-explain
 SELECT 1, * FROM t.nocols
 ----
-render          0  render  ·         ·               (column2)        ·
- │              0  ·       render 0  1               ·                ·
- └── render     1  render  ·         ·               ()               ·
-      └── scan  2  scan    ·         ·               (rowid[hidden])  ·
-·               2  ·       table     nocols@primary  ·                ·
-·               2  ·       spans     ALL             ·                ·
+render     0  render  ·         ·               (column2)  ·
+ │         0  ·       render 0  1               ·          ·
+ └── scan  1  scan    ·         ·               ()         ·
+·          1  ·       table     nocols@primary  ·          ·
+·          1  ·       spans     ALL             ·          ·
 
 exec
 SELECT 1, * FROM t.nocols

--- a/pkg/sql/opt/exec/execbuilder/testdata/scalar
+++ b/pkg/sql/opt/exec/execbuilder/testdata/scalar
@@ -50,334 +50,255 @@ render       0  render  ·         ·                 (column1)  ·
 exec-explain
 SELECT 1 + 2 FROM t.t
 ----
-render          0  render  ·         ·          (column8)                          ·
- │              0  ·       render 0  3          ·                                  ·
- └── render     1  render  ·         ·          ()                                 ·
-      └── scan  2  scan    ·         ·          (a, b, c, d, j, s, rowid[hidden])  ·
-·               2  ·       table     t@primary  ·                                  ·
-·               2  ·       spans     ALL        ·                                  ·
+render     0  render  ·         ·          (column8)  ·
+ │         0  ·       render 0  3          ·          ·
+ └── scan  1  scan    ·         ·          ()         ·
+·          1  ·       table     t@primary  ·          ·
+·          1  ·       spans     ALL        ·          ·
 
 exec-explain
 SELECT a + 2 FROM t.t
 ----
-render          0  render  ·         ·          (column8)                          ·
- │              0  ·       render 0  a + 2      ·                                  ·
- └── render     1  render  ·         ·          (a)                                ·
-      │         1  ·       render 0  a          ·                                  ·
-      └── scan  2  scan    ·         ·          (a, b, c, d, j, s, rowid[hidden])  ·
-·               2  ·       table     t@primary  ·                                  ·
-·               2  ·       spans     ALL        ·                                  ·
+render     0  render  ·         ·          (column8)  ·
+ │         0  ·       render 0  a + 2      ·          ·
+ └── scan  1  scan    ·         ·          (a)        ·
+·          1  ·       table     t@primary  ·          ·
+·          1  ·       spans     ALL        ·          ·
 
 exec-explain
 SELECT a >= 5 AND b <= 10 AND c < 4 FROM t.t
 ----
-render          0  render  ·         ·                                     (column8)                          ·
- │              0  ·       render 0  ((a >= 5) AND (b <= 10)) AND (c < 4)  ·                                  ·
- └── render     1  render  ·         ·                                     (a, b, c)                          ·
-      │         1  ·       render 0  a                                     ·                                  ·
-      │         1  ·       render 1  b                                     ·                                  ·
-      │         1  ·       render 2  c                                     ·                                  ·
-      └── scan  2  scan    ·         ·                                     (a, b, c, d, j, s, rowid[hidden])  ·
-·               2  ·       table     t@primary                             ·                                  ·
-·               2  ·       spans     ALL                                   ·                                  ·
+render     0  render  ·         ·                                     (column8)  ·
+ │         0  ·       render 0  ((a >= 5) AND (b <= 10)) AND (c < 4)  ·          ·
+ └── scan  1  scan    ·         ·                                     (a, b, c)  ·
+·          1  ·       table     t@primary                             ·          ·
+·          1  ·       spans     ALL                                   ·          ·
 
 exec-explain
 SELECT a >= 5 OR b <= 10 OR c < 4  FROM t.t
 ----
-render          0  render  ·         ·                                   (column8)                          ·
- │              0  ·       render 0  ((a >= 5) OR (b <= 10)) OR (c < 4)  ·                                  ·
- └── render     1  render  ·         ·                                   (a, b, c)                          ·
-      │         1  ·       render 0  a                                   ·                                  ·
-      │         1  ·       render 1  b                                   ·                                  ·
-      │         1  ·       render 2  c                                   ·                                  ·
-      └── scan  2  scan    ·         ·                                   (a, b, c, d, j, s, rowid[hidden])  ·
-·               2  ·       table     t@primary                           ·                                  ·
-·               2  ·       spans     ALL                                 ·                                  ·
+render     0  render  ·         ·                                   (column8)  ·
+ │         0  ·       render 0  ((a >= 5) OR (b <= 10)) OR (c < 4)  ·          ·
+ └── scan  1  scan    ·         ·                                   (a, b, c)  ·
+·          1  ·       table     t@primary                           ·          ·
+·          1  ·       spans     ALL                                 ·          ·
 
 exec-explain
 SELECT NOT (a = 5) FROM t.t
 ----
-render          0  render  ·         ·          (column8)                          ·
- │              0  ·       render 0  a != 5     ·                                  ·
- └── render     1  render  ·         ·          (a)                                ·
-      │         1  ·       render 0  a          ·                                  ·
-      └── scan  2  scan    ·         ·          (a, b, c, d, j, s, rowid[hidden])  ·
-·               2  ·       table     t@primary  ·                                  ·
-·               2  ·       spans     ALL        ·                                  ·
+render     0  render  ·         ·          (column8)  ·
+ │         0  ·       render 0  a != 5     ·          ·
+ └── scan  1  scan    ·         ·          (a)        ·
+·          1  ·       table     t@primary  ·          ·
+·          1  ·       spans     ALL        ·          ·
 
 exec-explain
 SELECT NOT (a > 5 AND b >= 10) FROM t.t
 ----
-render          0  render  ·         ·                     (column8)                          ·
- │              0  ·       render 0  (a <= 5) OR (b < 10)  ·                                  ·
- └── render     1  render  ·         ·                     (a, b)                             ·
-      │         1  ·       render 0  a                     ·                                  ·
-      │         1  ·       render 1  b                     ·                                  ·
-      └── scan  2  scan    ·         ·                     (a, b, c, d, j, s, rowid[hidden])  ·
-·               2  ·       table     t@primary             ·                                  ·
-·               2  ·       spans     ALL                   ·                                  ·
+render     0  render  ·         ·                     (column8)  ·
+ │         0  ·       render 0  (a <= 5) OR (b < 10)  ·          ·
+ └── scan  1  scan    ·         ·                     (a, b)     ·
+·          1  ·       table     t@primary             ·          ·
+·          1  ·       spans     ALL                   ·          ·
 
 exec-explain
 SELECT (a >= 5 AND b <= 10) OR (a <= 10 AND c > 5) FROM t.t
 ----
-render          0  render  ·         ·                                                    (column8)                          ·
- │              0  ·       render 0  ((a >= 5) AND (b <= 10)) OR ((a <= 10) AND (c > 5))  ·                                  ·
- └── render     1  render  ·         ·                                                    (a, b, c)                          ·
-      │         1  ·       render 0  a                                                    ·                                  ·
-      │         1  ·       render 1  b                                                    ·                                  ·
-      │         1  ·       render 2  c                                                    ·                                  ·
-      └── scan  2  scan    ·         ·                                                    (a, b, c, d, j, s, rowid[hidden])  ·
-·               2  ·       table     t@primary                                            ·                                  ·
-·               2  ·       spans     ALL                                                  ·                                  ·
+render     0  render  ·         ·                                                    (column8)  ·
+ │         0  ·       render 0  ((a >= 5) AND (b <= 10)) OR ((a <= 10) AND (c > 5))  ·          ·
+ └── scan  1  scan    ·         ·                                                    (a, b, c)  ·
+·          1  ·       table     t@primary                                            ·          ·
+·          1  ·       spans     ALL                                                  ·          ·
 
 exec-explain
 SELECT NOT (a >= 5 OR b <= 10) AND NOT (c >= 10) FROM t.t
 ----
-render          0  render  ·         ·                                    (column8)                          ·
- │              0  ·       render 0  ((a < 5) AND (b > 10)) AND (c < 10)  ·                                  ·
- └── render     1  render  ·         ·                                    (a, b, c)                          ·
-      │         1  ·       render 0  a                                    ·                                  ·
-      │         1  ·       render 1  b                                    ·                                  ·
-      │         1  ·       render 2  c                                    ·                                  ·
-      └── scan  2  scan    ·         ·                                    (a, b, c, d, j, s, rowid[hidden])  ·
-·               2  ·       table     t@primary                            ·                                  ·
-·               2  ·       spans     ALL                                  ·                                  ·
+render     0  render  ·         ·                                    (column8)  ·
+ │         0  ·       render 0  ((a < 5) AND (b > 10)) AND (c < 10)  ·          ·
+ └── scan  1  scan    ·         ·                                    (a, b, c)  ·
+·          1  ·       table     t@primary                            ·          ·
+·          1  ·       spans     ALL                                  ·          ·
 
 exec-explain
 SELECT (a, b) = (1, 2)  FROM t.t
 ----
-render          0  render  ·         ·                    (column8)                          ·
- │              0  ·       render 0  (a = 1) AND (b = 2)  ·                                  ·
- └── render     1  render  ·         ·                    (a, b)                             ·
-      │         1  ·       render 0  a                    ·                                  ·
-      │         1  ·       render 1  b                    ·                                  ·
-      └── scan  2  scan    ·         ·                    (a, b, c, d, j, s, rowid[hidden])  ·
-·               2  ·       table     t@primary            ·                                  ·
-·               2  ·       spans     ALL                  ·                                  ·
+render     0  render  ·         ·                    (column8)  ·
+ │         0  ·       render 0  (a = 1) AND (b = 2)  ·          ·
+ └── scan  1  scan    ·         ·                    (a, b)     ·
+·          1  ·       table     t@primary            ·          ·
+·          1  ·       spans     ALL                  ·          ·
 
 exec-explain
 SELECT a IN (1, 2) FROM t.t
 ----
-render          0  render  ·         ·            (column8)                          ·
- │              0  ·       render 0  a IN (1, 2)  ·                                  ·
- └── render     1  render  ·         ·            (a)                                ·
-      │         1  ·       render 0  a            ·                                  ·
-      └── scan  2  scan    ·         ·            (a, b, c, d, j, s, rowid[hidden])  ·
-·               2  ·       table     t@primary    ·                                  ·
-·               2  ·       spans     ALL          ·                                  ·
+render     0  render  ·         ·            (column8)  ·
+ │         0  ·       render 0  a IN (1, 2)  ·          ·
+ └── scan  1  scan    ·         ·            (a)        ·
+·          1  ·       table     t@primary    ·          ·
+·          1  ·       spans     ALL          ·          ·
 
 exec-explain
 SELECT (a, b) IN ((1, 2), (3, 4)) FROM t.t
 ----
-render          0  render  ·         ·                           (column8)                          ·
- │              0  ·       render 0  (a, b) IN ((1, 2), (3, 4))  ·                                  ·
- └── render     1  render  ·         ·                           (a, b)                             ·
-      │         1  ·       render 0  a                           ·                                  ·
-      │         1  ·       render 1  b                           ·                                  ·
-      └── scan  2  scan    ·         ·                           (a, b, c, d, j, s, rowid[hidden])  ·
-·               2  ·       table     t@primary                   ·                                  ·
-·               2  ·       spans     ALL                         ·                                  ·
+render     0  render  ·         ·                           (column8)  ·
+ │         0  ·       render 0  (a, b) IN ((1, 2), (3, 4))  ·          ·
+ └── scan  1  scan    ·         ·                           (a, b)     ·
+·          1  ·       table     t@primary                   ·          ·
+·          1  ·       spans     ALL                         ·          ·
 
 exec-explain
 SELECT (a, b + c, 5 + d * 2) = (b+c, 8, a - c)  FROM t.t
 ----
-render          0  render  ·         ·                                                                (column8)                          ·
- │              0  ·       render 0  ((a = (b + c)) AND ((b + c) = 8)) AND (((d * 2) + 5) = (a - c))  ·                                  ·
- └── render     1  render  ·         ·                                                                (a, b, c, d)                       ·
-      │         1  ·       render 0  a                                                                ·                                  ·
-      │         1  ·       render 1  b                                                                ·                                  ·
-      │         1  ·       render 2  c                                                                ·                                  ·
-      │         1  ·       render 3  d                                                                ·                                  ·
-      └── scan  2  scan    ·         ·                                                                (a, b, c, d, j, s, rowid[hidden])  ·
-·               2  ·       table     t@primary                                                        ·                                  ·
-·               2  ·       spans     ALL                                                              ·                                  ·
+render     0  render  ·         ·                                                                (column8)     ·
+ │         0  ·       render 0  ((a = (b + c)) AND ((b + c) = 8)) AND (((d * 2) + 5) = (a - c))  ·             ·
+ └── scan  1  scan    ·         ·                                                                (a, b, c, d)  ·
+·          1  ·       table     t@primary                                                        ·             ·
+·          1  ·       spans     ALL                                                              ·             ·
 
 exec-explain
 SELECT ((a, b), (c, d)) = ((1, 2), (3, 4))  FROM t.t
 ----
-render          0  render  ·         ·                                                (column8)                          ·
- │              0  ·       render 0  (((a = 1) AND (b = 2)) AND (c = 3)) AND (d = 4)  ·                                  ·
- └── render     1  render  ·         ·                                                (a, b, c, d)                       ·
-      │         1  ·       render 0  a                                                ·                                  ·
-      │         1  ·       render 1  b                                                ·                                  ·
-      │         1  ·       render 2  c                                                ·                                  ·
-      │         1  ·       render 3  d                                                ·                                  ·
-      └── scan  2  scan    ·         ·                                                (a, b, c, d, j, s, rowid[hidden])  ·
-·               2  ·       table     t@primary                                        ·                                  ·
-·               2  ·       spans     ALL                                              ·                                  ·
+render     0  render  ·         ·                                                (column8)     ·
+ │         0  ·       render 0  (((a = 1) AND (b = 2)) AND (c = 3)) AND (d = 4)  ·             ·
+ └── scan  1  scan    ·         ·                                                (a, b, c, d)  ·
+·          1  ·       table     t@primary                                        ·             ·
+·          1  ·       spans     ALL                                              ·             ·
 
 exec-explain
 SELECT (a, (b, 'a'), (c, 'b', 5)) = (9, (a+c, s), (5, s, a)) FROM t.t
 ----
-render          0  render  ·         ·                                                                                      (column8)                          ·
- │              0  ·       render 0  (((((a = 9) AND (b = (a + c))) AND (s = 'a')) AND (c = 5)) AND (s = 'b')) AND (a = 5)  ·                                  ·
- └── render     1  render  ·         ·                                                                                      (a, b, c, s)                       ·
-      │         1  ·       render 0  a                                                                                      ·                                  ·
-      │         1  ·       render 1  b                                                                                      ·                                  ·
-      │         1  ·       render 2  c                                                                                      ·                                  ·
-      │         1  ·       render 3  s                                                                                      ·                                  ·
-      └── scan  2  scan    ·         ·                                                                                      (a, b, c, d, j, s, rowid[hidden])  ·
-·               2  ·       table     t@primary                                                                              ·                                  ·
-·               2  ·       spans     ALL                                                                                    ·                                  ·
+render     0  render  ·         ·                                                                                      (column8)     ·
+ │         0  ·       render 0  (((((a = 9) AND (b = (a + c))) AND (s = 'a')) AND (c = 5)) AND (s = 'b')) AND (a = 5)  ·             ·
+ └── scan  1  scan    ·         ·                                                                                      (a, b, c, s)  ·
+·          1  ·       table     t@primary                                                                              ·             ·
+·          1  ·       spans     ALL                                                                                    ·             ·
 
 exec-explain
 SELECT a IS NULL FROM t.t
 ----
-render          0  render  ·         ·          (column8)                          ·
- │              0  ·       render 0  a IS NULL  ·                                  ·
- └── render     1  render  ·         ·          (a)                                ·
-      │         1  ·       render 0  a          ·                                  ·
-      └── scan  2  scan    ·         ·          (a, b, c, d, j, s, rowid[hidden])  ·
-·               2  ·       table     t@primary  ·                                  ·
-·               2  ·       spans     ALL        ·                                  ·
+render     0  render  ·         ·          (column8)  ·
+ │         0  ·       render 0  a IS NULL  ·          ·
+ └── scan  1  scan    ·         ·          (a)        ·
+·          1  ·       table     t@primary  ·          ·
+·          1  ·       spans     ALL        ·          ·
 
 exec-explain
 SELECT a IS NOT DISTINCT FROM NULL FROM t.t
 ----
-render          0  render  ·         ·          (column8)                          ·
- │              0  ·       render 0  a IS NULL  ·                                  ·
- └── render     1  render  ·         ·          (a)                                ·
-      │         1  ·       render 0  a          ·                                  ·
-      └── scan  2  scan    ·         ·          (a, b, c, d, j, s, rowid[hidden])  ·
-·               2  ·       table     t@primary  ·                                  ·
-·               2  ·       spans     ALL        ·                                  ·
+render     0  render  ·         ·          (column8)  ·
+ │         0  ·       render 0  a IS NULL  ·          ·
+ └── scan  1  scan    ·         ·          (a)        ·
+·          1  ·       table     t@primary  ·          ·
+·          1  ·       spans     ALL        ·          ·
 
 exec-explain
 SELECT a IS NOT DISTINCT FROM b FROM t.t
 ----
-render          0  render  ·         ·                         (column8)                          ·
- │              0  ·       render 0  a IS NOT DISTINCT FROM b  ·                                  ·
- └── render     1  render  ·         ·                         (a, b)                             ·
-      │         1  ·       render 0  a                         ·                                  ·
-      │         1  ·       render 1  b                         ·                                  ·
-      └── scan  2  scan    ·         ·                         (a, b, c, d, j, s, rowid[hidden])  ·
-·               2  ·       table     t@primary                 ·                                  ·
-·               2  ·       spans     ALL                       ·                                  ·
+render     0  render  ·         ·                         (column8)  ·
+ │         0  ·       render 0  a IS NOT DISTINCT FROM b  ·          ·
+ └── scan  1  scan    ·         ·                         (a, b)     ·
+·          1  ·       table     t@primary                 ·          ·
+·          1  ·       spans     ALL                       ·          ·
 
 exec-explain
 SELECT a IS NOT NULL FROM t.t
 ----
-render          0  render  ·         ·              (column8)                          ·
- │              0  ·       render 0  a IS NOT NULL  ·                                  ·
- └── render     1  render  ·         ·              (a)                                ·
-      │         1  ·       render 0  a              ·                                  ·
-      └── scan  2  scan    ·         ·              (a, b, c, d, j, s, rowid[hidden])  ·
-·               2  ·       table     t@primary      ·                                  ·
-·               2  ·       spans     ALL            ·                                  ·
+render     0  render  ·         ·              (column8)  ·
+ │         0  ·       render 0  a IS NOT NULL  ·          ·
+ └── scan  1  scan    ·         ·              (a)        ·
+·          1  ·       table     t@primary      ·          ·
+·          1  ·       spans     ALL            ·          ·
 
 exec-explain
 SELECT a IS DISTINCT FROM NULL FROM t.t
 ----
-render          0  render  ·         ·              (column8)                          ·
- │              0  ·       render 0  a IS NOT NULL  ·                                  ·
- └── render     1  render  ·         ·              (a)                                ·
-      │         1  ·       render 0  a              ·                                  ·
-      └── scan  2  scan    ·         ·              (a, b, c, d, j, s, rowid[hidden])  ·
-·               2  ·       table     t@primary      ·                                  ·
-·               2  ·       spans     ALL            ·                                  ·
+render     0  render  ·         ·              (column8)  ·
+ │         0  ·       render 0  a IS NOT NULL  ·          ·
+ └── scan  1  scan    ·         ·              (a)        ·
+·          1  ·       table     t@primary      ·          ·
+·          1  ·       spans     ALL            ·          ·
 
 exec-explain
 SELECT a IS DISTINCT FROM b FROM t.t
 ----
-render          0  render  ·         ·                     (column8)                          ·
- │              0  ·       render 0  a IS DISTINCT FROM b  ·                                  ·
- └── render     1  render  ·         ·                     (a, b)                             ·
-      │         1  ·       render 0  a                     ·                                  ·
-      │         1  ·       render 1  b                     ·                                  ·
-      └── scan  2  scan    ·         ·                     (a, b, c, d, j, s, rowid[hidden])  ·
-·               2  ·       table     t@primary             ·                                  ·
-·               2  ·       spans     ALL                   ·                                  ·
+render     0  render  ·         ·                     (column8)  ·
+ │         0  ·       render 0  a IS DISTINCT FROM b  ·          ·
+ └── scan  1  scan    ·         ·                     (a, b)     ·
+·          1  ·       table     t@primary             ·          ·
+·          1  ·       spans     ALL                   ·          ·
 
 exec-explain
 SELECT +a + (-b) FROM t.t
 ----
-render          0  render  ·         ·          (column8)                          ·
- │              0  ·       render 0  a + (-b)   ·                                  ·
- └── render     1  render  ·         ·          (a, b)                             ·
-      │         1  ·       render 0  a          ·                                  ·
-      │         1  ·       render 1  b          ·                                  ·
-      └── scan  2  scan    ·         ·          (a, b, c, d, j, s, rowid[hidden])  ·
-·               2  ·       table     t@primary  ·                                  ·
-·               2  ·       spans     ALL        ·                                  ·
+render     0  render  ·         ·          (column8)  ·
+ │         0  ·       render 0  a + (-b)   ·          ·
+ └── scan  1  scan    ·         ·          (a, b)     ·
+·          1  ·       table     t@primary  ·          ·
+·          1  ·       spans     ALL        ·          ·
 
 exec-explain
 SELECT CASE a WHEN 1 THEN 2 WHEN 2 THEN 3 ELSE 4 END FROM t.t
 ----
-render          0  render  ·         ·                                              (column8)                          ·
- │              0  ·       render 0  CASE a WHEN 1 THEN 2 WHEN 2 THEN 3 ELSE 4 END  ·                                  ·
- └── render     1  render  ·         ·                                              (a)                                ·
-      │         1  ·       render 0  a                                              ·                                  ·
-      └── scan  2  scan    ·         ·                                              (a, b, c, d, j, s, rowid[hidden])  ·
-·               2  ·       table     t@primary                                      ·                                  ·
-·               2  ·       spans     ALL                                            ·                                  ·
+render     0  render  ·         ·                                              (column8)  ·
+ │         0  ·       render 0  CASE a WHEN 1 THEN 2 WHEN 2 THEN 3 ELSE 4 END  ·          ·
+ └── scan  1  scan    ·         ·                                              (a)        ·
+·          1  ·       table     t@primary                                      ·          ·
+·          1  ·       spans     ALL                                            ·          ·
 
 exec-explain
 SELECT CASE WHEN a = 2 THEN 1 ELSE 2 END FROM t.t
 ----
-render          0  render  ·         ·                                  (column8)                          ·
- │              0  ·       render 0  CASE WHEN a = 2 THEN 1 ELSE 2 END  ·                                  ·
- └── render     1  render  ·         ·                                  (a)                                ·
-      │         1  ·       render 0  a                                  ·                                  ·
-      └── scan  2  scan    ·         ·                                  (a, b, c, d, j, s, rowid[hidden])  ·
-·               2  ·       table     t@primary                          ·                                  ·
-·               2  ·       spans     ALL                                ·                                  ·
+render     0  render  ·         ·                                  (column8)  ·
+ │         0  ·       render 0  CASE WHEN a = 2 THEN 1 ELSE 2 END  ·          ·
+ └── scan  1  scan    ·         ·                                  (a)        ·
+·          1  ·       table     t@primary                          ·          ·
+·          1  ·       spans     ALL                                ·          ·
 
 exec-explain
 SELECT CASE a + 3 WHEN 5 * b THEN 1 % b WHEN 6 THEN 2 ELSE -1 END FROM t.t
 ----
-render          0  render  ·         ·                                                           (column8)                          ·
- │              0  ·       render 0  CASE a + 3 WHEN b * 5 THEN 1 % b WHEN 6 THEN 2 ELSE -1 END  ·                                  ·
- └── render     1  render  ·         ·                                                           (a, b)                             ·
-      │         1  ·       render 0  a                                                           ·                                  ·
-      │         1  ·       render 1  b                                                           ·                                  ·
-      └── scan  2  scan    ·         ·                                                           (a, b, c, d, j, s, rowid[hidden])  ·
-·               2  ·       table     t@primary                                                   ·                                  ·
-·               2  ·       spans     ALL                                                         ·                                  ·
+render     0  render  ·         ·                                                           (column8)  ·
+ │         0  ·       render 0  CASE a + 3 WHEN b * 5 THEN 1 % b WHEN 6 THEN 2 ELSE -1 END  ·          ·
+ └── scan  1  scan    ·         ·                                                           (a, b)     ·
+·          1  ·       table     t@primary                                                   ·          ·
+·          1  ·       spans     ALL                                                         ·          ·
 
 # Tests for CASE with no ELSE statement
 exec-explain
 SELECT CASE WHEN a = 2 THEN 1 END FROM t.t
 ----
-render          0  render  ·         ·                           (column8)                          ·
- │              0  ·       render 0  CASE WHEN a = 2 THEN 1 END  ·                                  ·
- └── render     1  render  ·         ·                           (a)                                ·
-      │         1  ·       render 0  a                           ·                                  ·
-      └── scan  2  scan    ·         ·                           (a, b, c, d, j, s, rowid[hidden])  ·
-·               2  ·       table     t@primary                   ·                                  ·
-·               2  ·       spans     ALL                         ·                                  ·
+render     0  render  ·         ·                           (column8)  ·
+ │         0  ·       render 0  CASE WHEN a = 2 THEN 1 END  ·          ·
+ └── scan  1  scan    ·         ·                           (a)        ·
+·          1  ·       table     t@primary                   ·          ·
+·          1  ·       spans     ALL                         ·          ·
 
 exec-explain
 SELECT CASE a WHEN 2 THEN 1 END FROM t.t
 ----
-render          0  render  ·         ·                         (column8)                          ·
- │              0  ·       render 0  CASE a WHEN 2 THEN 1 END  ·                                  ·
- └── render     1  render  ·         ·                         (a)                                ·
-      │         1  ·       render 0  a                         ·                                  ·
-      └── scan  2  scan    ·         ·                         (a, b, c, d, j, s, rowid[hidden])  ·
-·               2  ·       table     t@primary                 ·                                  ·
-·               2  ·       spans     ALL                       ·                                  ·
+render     0  render  ·         ·                         (column8)  ·
+ │         0  ·       render 0  CASE a WHEN 2 THEN 1 END  ·          ·
+ └── scan  1  scan    ·         ·                         (a)        ·
+·          1  ·       table     t@primary                 ·          ·
+·          1  ·       spans     ALL                       ·          ·
 
 exec-explain allow-unsupported
 SELECT a FROM t.t WHERE a IS OF (INT)
 ----
-filter          0  filter  ·         ·                         (a)                                ·
- │              0  ·       filter    t.public.t.a IS OF (INT)  ·                                  ·
- └── render     1  render  ·         ·                         (a)                                ·
-      │         1  ·       render 0  a                         ·                                  ·
-      └── scan  2  scan    ·         ·                         (a, b, c, d, j, s, rowid[hidden])  ·
-·               2  ·       table     t@primary                 ·                                  ·
-·               2  ·       spans     ALL                       ·                                  ·
+filter     0  filter  ·       ·                         (a)  ·
+ │         0  ·       filter  t.public.t.a IS OF (INT)  ·    ·
+ └── scan  1  scan    ·       ·                         (a)  ·
+·          1  ·       table   t@primary                 ·    ·
+·          1  ·       spans   ALL                       ·    ·
 
 exec-explain
 SELECT LENGTH(s) FROM t.t
 ----
-render          0  render  ·         ·          (column8)                          ·
- │              0  ·       render 0  length(s)  ·                                  ·
- └── render     1  render  ·         ·          (s)                                ·
-      │         1  ·       render 0  s          ·                                  ·
-      └── scan  2  scan    ·         ·          (a, b, c, d, j, s, rowid[hidden])  ·
-·               2  ·       table     t@primary  ·                                  ·
-·               2  ·       spans     ALL        ·                                  ·
+render     0  render  ·         ·          (column8)  ·
+ │         0  ·       render 0  length(s)  ·          ·
+ └── scan  1  scan    ·         ·          (s)        ·
+·          1  ·       table     t@primary  ·          ·
+·          1  ·       spans     ALL        ·          ·
 
 # Verify that the built function can be executed.
 exec-raw
@@ -396,50 +317,39 @@ column3:int
 exec-explain
 SELECT j @> '{"a": 1}' FROM t.t
 ----
-render          0  render  ·         ·                (column8)                          ·
- │              0  ·       render 0  j @> '{"a": 1}'  ·                                  ·
- └── render     1  render  ·         ·                (j)                                ·
-      │         1  ·       render 0  j                ·                                  ·
-      └── scan  2  scan    ·         ·                (a, b, c, d, j, s, rowid[hidden])  ·
-·               2  ·       table     t@primary        ·                                  ·
-·               2  ·       spans     ALL              ·                                  ·
+render     0  render  ·         ·                (column8)  ·
+ │         0  ·       render 0  j @> '{"a": 1}'  ·          ·
+ └── scan  1  scan    ·         ·                (j)        ·
+·          1  ·       table     t@primary        ·          ·
+·          1  ·       spans     ALL              ·          ·
 
 exec-explain
 SELECT '{"a": 1}' <@ j FROM t.t
 ----
-render          0  render  ·         ·                (column8)                          ·
- │              0  ·       render 0  j @> '{"a": 1}'  ·                                  ·
- └── render     1  render  ·         ·                (j)                                ·
-      │         1  ·       render 0  j                ·                                  ·
-      └── scan  2  scan    ·         ·                (a, b, c, d, j, s, rowid[hidden])  ·
-·               2  ·       table     t@primary        ·                                  ·
-·               2  ·       spans     ALL              ·                                  ·
+render     0  render  ·         ·                (column8)  ·
+ │         0  ·       render 0  j @> '{"a": 1}'  ·          ·
+ └── scan  1  scan    ·         ·                (j)        ·
+·          1  ·       table     t@primary        ·          ·
+·          1  ·       spans     ALL              ·          ·
 
 exec-explain
 SELECT CAST(a AS string), b::float FROM t.t
 ----
-render          0  render  ·         ·          (column8, column9)                 ·
- │              0  ·       render 0  a::STRING  ·                                  ·
- │              0  ·       render 1  b::FLOAT   ·                                  ·
- └── render     1  render  ·         ·          (a, b)                             ·
-      │         1  ·       render 0  a          ·                                  ·
-      │         1  ·       render 1  b          ·                                  ·
-      └── scan  2  scan    ·         ·          (a, b, c, d, j, s, rowid[hidden])  ·
-·               2  ·       table     t@primary  ·                                  ·
-·               2  ·       spans     ALL        ·                                  ·
+render     0  render  ·         ·          (column8, column9)  ·
+ │         0  ·       render 0  a::STRING  ·                   ·
+ │         0  ·       render 1  b::FLOAT   ·                   ·
+ └── scan  1  scan    ·         ·          (a, b)              ·
+·          1  ·       table     t@primary  ·                   ·
+·          1  ·       spans     ALL        ·                   ·
 
 exec-explain
 SELECT CAST(a + b + c AS string) FROM t.t
 ----
-render          0  render  ·         ·                      (column8)                          ·
- │              0  ·       render 0  (c + (a + b))::STRING  ·                                  ·
- └── render     1  render  ·         ·                      (a, b, c)                          ·
-      │         1  ·       render 0  a                      ·                                  ·
-      │         1  ·       render 1  b                      ·                                  ·
-      │         1  ·       render 2  c                      ·                                  ·
-      └── scan  2  scan    ·         ·                      (a, b, c, d, j, s, rowid[hidden])  ·
-·               2  ·       table     t@primary              ·                                  ·
-·               2  ·       spans     ALL                    ·                                  ·
+render     0  render  ·         ·                      (column8)  ·
+ │         0  ·       render 0  (c + (a + b))::STRING  ·          ·
+ └── scan  1  scan    ·         ·                      (a, b, c)  ·
+·          1  ·       table     t@primary              ·          ·
+·          1  ·       spans     ALL                    ·          ·
 
 exec
 SELECT LENGTH(s)::float, s FROM t.str
@@ -506,55 +416,39 @@ NULL
 exec-explain
 SELECT a FROM t.t WHERE a BETWEEN b AND d
 ----
-render               0  render  ·         ·                      (a)                                ·
- │                   0  ·       render 0  a                      ·                                  ·
- └── filter          1  filter  ·         ·                      (a, b, d)                          ·
-      │              1  ·       filter    (a >= b) AND (a <= d)  ·                                  ·
-      └── render     2  render  ·         ·                      (a, b, d)                          ·
-           │         2  ·       render 0  a                      ·                                  ·
-           │         2  ·       render 1  b                      ·                                  ·
-           │         2  ·       render 2  d                      ·                                  ·
-           └── scan  3  scan    ·         ·                      (a, b, c, d, j, s, rowid[hidden])  ·
-·                    3  ·       table     t@primary              ·                                  ·
-·                    3  ·       spans     ALL                    ·                                  ·
+render          0  render  ·         ·                      (a)        ·
+ │              0  ·       render 0  a                      ·          ·
+ └── filter     1  filter  ·         ·                      (a, b, d)  ·
+      │         1  ·       filter    (a >= b) AND (a <= d)  ·          ·
+      └── scan  2  scan    ·         ·                      (a, b, d)  ·
+·               2  ·       table     t@primary              ·          ·
+·               2  ·       spans     ALL                    ·          ·
 
 exec-explain
 SELECT a FROM t.t WHERE a NOT BETWEEN b AND d
 ----
-render               0  render  ·         ·                   (a)                                ·
- │                   0  ·       render 0  a                   ·                                  ·
- └── filter          1  filter  ·         ·                   (a, b, d)                          ·
-      │              1  ·       filter    (a < b) OR (a > d)  ·                                  ·
-      └── render     2  render  ·         ·                   (a, b, d)                          ·
-           │         2  ·       render 0  a                   ·                                  ·
-           │         2  ·       render 1  b                   ·                                  ·
-           │         2  ·       render 2  d                   ·                                  ·
-           └── scan  3  scan    ·         ·                   (a, b, c, d, j, s, rowid[hidden])  ·
-·                    3  ·       table     t@primary           ·                                  ·
-·                    3  ·       spans     ALL                 ·                                  ·
+render          0  render  ·         ·                   (a)        ·
+ │              0  ·       render 0  a                   ·          ·
+ └── filter     1  filter  ·         ·                   (a, b, d)  ·
+      │         1  ·       filter    (a < b) OR (a > d)  ·          ·
+      └── scan  2  scan    ·         ·                   (a, b, d)  ·
+·               2  ·       table     t@primary           ·          ·
+·               2  ·       spans     ALL                 ·          ·
 
 exec-explain
 SELECT a BETWEEN SYMMETRIC b AND d FROM t.t
 ----
-render          0  render  ·         ·                                                   (column8)                          ·
- │              0  ·       render 0  ((a >= b) AND (a <= d)) OR ((a >= d) AND (a <= b))  ·                                  ·
- └── render     1  render  ·         ·                                                   (a, b, d)                          ·
-      │         1  ·       render 0  a                                                   ·                                  ·
-      │         1  ·       render 1  b                                                   ·                                  ·
-      │         1  ·       render 2  d                                                   ·                                  ·
-      └── scan  2  scan    ·         ·                                                   (a, b, c, d, j, s, rowid[hidden])  ·
-·               2  ·       table     t@primary                                           ·                                  ·
-·               2  ·       spans     ALL                                                 ·                                  ·
+render     0  render  ·         ·                                                   (column8)  ·
+ │         0  ·       render 0  ((a >= b) AND (a <= d)) OR ((a >= d) AND (a <= b))  ·          ·
+ └── scan  1  scan    ·         ·                                                   (a, b, d)  ·
+·          1  ·       table     t@primary                                           ·          ·
+·          1  ·       spans     ALL                                                 ·          ·
 
 exec-explain
 SELECT a NOT BETWEEN SYMMETRIC b AND d FROM t.t
 ----
-render          0  render  ·         ·                                              (column8)                          ·
- │              0  ·       render 0  ((a < b) OR (a > d)) AND ((a < d) OR (a > b))  ·                                  ·
- └── render     1  render  ·         ·                                              (a, b, d)                          ·
-      │         1  ·       render 0  a                                              ·                                  ·
-      │         1  ·       render 1  b                                              ·                                  ·
-      │         1  ·       render 2  d                                              ·                                  ·
-      └── scan  2  scan    ·         ·                                              (a, b, c, d, j, s, rowid[hidden])  ·
-·               2  ·       table     t@primary                                      ·                                  ·
-·               2  ·       spans     ALL                                            ·                                  ·
+render     0  render  ·         ·                                              (column8)  ·
+ │         0  ·       render 0  ((a < b) OR (a > d)) AND ((a < d) OR (a > b))  ·          ·
+ └── scan  1  scan    ·         ·                                              (a, b, d)  ·
+·          1  ·       table     t@primary                                      ·          ·
+·          1  ·       spans     ALL                                            ·          ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/scan
+++ b/pkg/sql/opt/exec/execbuilder/testdata/scan
@@ -38,15 +38,12 @@ scan a
 exec-explain
 SELECT s, x FROM t.a
 ----
-render          0  render  ·         ·          (s, x)     ·
- │              0  ·       render 0  s          ·          ·
- │              0  ·       render 1  x          ·          ·
- └── render     1  render  ·         ·          (x, s)     ·
-      │         1  ·       render 0  x          ·          ·
-      │         1  ·       render 1  s          ·          ·
-      └── scan  2  scan    ·         ·          (x, y, s)  ·
-·               2  ·       table     a@primary  ·          ·
-·               2  ·       spans     ALL        ·          ·
+render     0  render  ·         ·          (s, x)  ·
+ │         0  ·       render 0  s          ·       ·
+ │         0  ·       render 1  x          ·       ·
+ └── scan  1  scan    ·         ·          (x, s)  ·
+·          1  ·       table     a@primary  ·       ·
+·          1  ·       spans     ALL        ·       ·
 
 exec
 SELECT s, x FROM t.a
@@ -79,12 +76,9 @@ cherry    3
 exec-explain
 SELECT s, x FROM t.b
 ----
-render          0  render  ·         ·          (s, x)                    ·
- │              0  ·       render 0  s          ·                         ·
- │              0  ·       render 1  x          ·                         ·
- └── render     1  render  ·         ·          (x, s)                    ·
-      │         1  ·       render 0  x          ·                         ·
-      │         1  ·       render 1  s          ·                         ·
-      └── scan  2  scan    ·         ·          (x, y, s, rowid[hidden])  ·
-·               2  ·       table     b@primary  ·                         ·
-·               2  ·       spans     ALL        ·                         ·
+render     0  render  ·         ·          (s, x)  ·
+ │         0  ·       render 0  s          ·       ·
+ │         0  ·       render 1  x          ·       ·
+ └── scan  1  scan    ·         ·          (x, s)  ·
+·          1  ·       table     b@primary  ·       ·
+·          1  ·       spans     ALL        ·       ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/union
+++ b/pkg/sql/opt/exec/execbuilder/testdata/union
@@ -223,32 +223,24 @@ v:int
 exec-explain
 SELECT v FROM t.uniontest UNION SELECT k FROM t.uniontest
 ----
-union           0  union   ·         ·                  (v)                    ·
- ├── render     1  render  ·         ·                  (k)                    ·
- │    │         1  ·       render 0  k                  ·                      ·
- │    └── scan  2  scan    ·         ·                  (k, v, rowid[hidden])  ·
- │              2  ·       table     uniontest@primary  ·                      ·
- │              2  ·       spans     ALL                ·                      ·
- └── render     1  render  ·         ·                  (v)                    ·
-      │         1  ·       render 0  v                  ·                      ·
-      └── scan  2  scan    ·         ·                  (k, v, rowid[hidden])  ·
-·               2  ·       table     uniontest@primary  ·                      ·
-·               2  ·       spans     ALL                ·                      ·
+union      0  union  ·      ·                  (v)  ·
+ ├── scan  1  scan   ·      ·                  (k)  ·
+ │         1  ·      table  uniontest@primary  ·    ·
+ │         1  ·      spans  ALL                ·    ·
+ └── scan  1  scan   ·      ·                  (v)  ·
+·          1  ·      table  uniontest@primary  ·    ·
+·          1  ·      spans  ALL                ·    ·
 
 exec-explain
 SELECT v FROM t.uniontest UNION ALL SELECT k FROM t.uniontest
 ----
-append          0  append  ·         ·                  (v)                    ·
- ├── render     1  render  ·         ·                  (k)                    ·
- │    │         1  ·       render 0  k                  ·                      ·
- │    └── scan  2  scan    ·         ·                  (k, v, rowid[hidden])  ·
- │              2  ·       table     uniontest@primary  ·                      ·
- │              2  ·       spans     ALL                ·                      ·
- └── render     1  render  ·         ·                  (v)                    ·
-      │         1  ·       render 0  v                  ·                      ·
-      └── scan  2  scan    ·         ·                  (k, v, rowid[hidden])  ·
-·               2  ·       table     uniontest@primary  ·                      ·
-·               2  ·       spans     ALL                ·                      ·
+append     0  append  ·      ·                  (v)  ·
+ ├── scan  1  scan    ·      ·                  (k)  ·
+ │         1  ·       table  uniontest@primary  ·    ·
+ │         1  ·       spans  ALL                ·    ·
+ └── scan  1  scan    ·      ·                  (v)  ·
+·          1  ·       table  uniontest@primary  ·    ·
+·          1  ·       spans  ALL                ·    ·
 
 exec
 SELECT * FROM (SELECT * FROM (VALUES (1)) a LEFT JOIN (VALUES (1) UNION VALUES (2)) b on a.column1 = b.column1);

--- a/pkg/sql/opt_decompose_test.go
+++ b/pkg/sql/opt_decompose_test.go
@@ -62,7 +62,7 @@ func testTableDesc() *sqlbase.TableDescriptor {
 
 func makeSelectNode(t *testing.T, p *planner) *renderNode {
 	desc := testTableDesc()
-	sel := testInitDummySelectNode(p, desc)
+	sel := testInitDummySelectNode(t, p, desc)
 	if err := desc.AllocateIDs(); err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/sql/opt_exec_engine.go
+++ b/pkg/sql/opt_exec_engine.go
@@ -145,7 +145,7 @@ func (ee *execEngine) ConstructScan(
 	// Create a scanNode.
 	scan := ee.planner.Scan()
 	if err := scan.initTable(
-		context.TODO(), ee.planner, desc, nil /* hints */, publicColumns, nil, /* wantedColumns */
+		context.TODO(), ee.planner, desc, nil /* hints */, publicColumnsCfg,
 	); err != nil {
 		return nil, err
 	}

--- a/pkg/sql/opt_index_selection.go
+++ b/pkg/sql/opt_index_selection.go
@@ -253,7 +253,10 @@ func (p *planner) selectIndex(
 		// Note: makeIndexJoin destroys s and returns a new index scan
 		// node. The filter in that node may be different from the
 		// original table filter.
-		plan, s = p.makeIndexJoin(s, c.exactPrefix)
+		plan, s, err = p.makeIndexJoin(s, c.exactPrefix)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	if log.V(3) {

--- a/pkg/sql/scan.go
+++ b/pkg/sql/scan.go
@@ -422,7 +422,9 @@ func (n *scanNode) initDescDefaults(planDeps planDependencies, colCfg scanColumn
 		n.colIdxMap[c.ID] = i
 	}
 	n.valNeededForCol = util.FastIntSet{}
-	n.valNeededForCol.AddRange(0, len(n.cols)-1)
+	if len(n.cols) > 0 {
+		n.valNeededForCol.AddRange(0, len(n.cols)-1)
+	}
 	n.run.row = make([]tree.Datum, len(n.cols))
 	n.filterVars = tree.MakeIndexedVarHelper(n, len(n.cols))
 	return nil

--- a/pkg/sql/scrub_physical.go
+++ b/pkg/sql/scrub_physical.go
@@ -109,9 +109,8 @@ func (o *physicalCheckOperation) Start(params runParams) error {
 	}
 	scan := params.p.Scan()
 	scan.run.isCheck = true
-	if err := scan.initTable(
-		ctx, params.p, o.tableDesc, indexHints, publicColumns, columnIDs,
-	); err != nil {
+	colCfg := scanColumnsConfig{wantedColumns: columnIDs, addUnwantedAsHidden: true}
+	if err := scan.initTable(ctx, params.p, o.tableDesc, indexHints, colCfg); err != nil {
 		return err
 	}
 	plan := planNode(scan)

--- a/pkg/sql/select_name_resolution_test.go
+++ b/pkg/sql/select_name_resolution_test.go
@@ -23,11 +23,12 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 )
 
-func testInitDummySelectNode(p *planner, desc *sqlbase.TableDescriptor) *renderNode {
+func testInitDummySelectNode(t *testing.T, p *planner, desc *sqlbase.TableDescriptor) *renderNode {
 	scan := &scanNode{}
 	scan.desc = desc
-	// Note: scan.initDescDefaults only returns an error if its 2nd argument is not nil.
-	_ = scan.initDescDefaults(p.curPlan.deps, publicColumns, nil)
+	if err := scan.initDescDefaults(p.curPlan.deps, publicColumnsCfg); err != nil {
+		t.Fatal(err)
+	}
 
 	sel := &renderNode{}
 	sel.source.plan = scan
@@ -52,7 +53,7 @@ func TestRetryResolveNames(t *testing.T) {
 
 	desc := testTableDesc()
 	p := makeTestPlanner()
-	s := testInitDummySelectNode(p, desc)
+	s := testInitDummySelectNode(t, p, desc)
 	if err := desc.AllocateIDs(); err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
#### sql: consolidate configuration knobs for scanNode columns

We have `scanVisibility` and `wantedColumns` knobs for setting up the
scanNode columns. In addition, we would like to control whether
unwanted columns are also added as hidden. Consolidating all these
knobs in a single structure.

This cleanup also fixes an oversight: mutation columns are now
reported as plan dependencies.

Release note: None

#### sql: fix scanNode issues when we don't include all the PK columns

Fixing a few minor issues with scanNode/rowFetcher for the case where
our schema doesn't contain all PK columns. Also a minor fix to a scrub
error message (it was showing the wrong values).

Release note: None

#### opt/exec: incorporate projection into the scan

We are now able to set up the scanNode to output only the columns we
want (even no columns).

Release note: None

CC @knz, @jordanlewis for the first two commits
CC @andy-kimball for the third commit