### PR TITLE
cherrypick-2.0: ui: Remove Decommissioned nodes from Dropdown

### DIFF
--- a/pkg/ui/src/redux/nodes.ts
+++ b/pkg/ui/src/redux/nodes.ts
@@ -211,19 +211,25 @@ export function nodeCapacityStats(n: NodeStatus$Properties): CapacityStats {
   };
 }
 
-export function getDisplayName(node: NodeStatus$Properties) {
-  return `${node.desc.address.address_field} (n${node.desc.node_id})`;
+export function getDisplayName(node: NodeStatus$Properties, livenessStatus = LivenessStatus.LIVE) {
+  const decommissionedString = livenessStatus === LivenessStatus.DECOMMISSIONED
+    ? "[decommissioned] "
+    : "";
+  return `${decommissionedString}${node.desc.address.address_field} (n${node.desc.node_id})`;
 }
 
 // nodeDisplayNameByIDSelector provides a unique, human-readable display name
 // for each node.
 export const nodeDisplayNameByIDSelector = createSelector(
   nodeStatusesSelector,
-  (nodeStatuses) => {
+  livenessStatusByNodeIDSelector,
+  (nodeStatuses, livenessStatusByNodeID) => {
     const result: {[key: string]: string} = {};
     if (!_.isEmpty(nodeStatuses)) {
       nodeStatuses.forEach(ns => {
-        result[ns.desc.node_id] = getDisplayName(ns);
+        result[ns.desc.node_id] = getDisplayName(
+          ns, livenessStatusByNodeID[ns.desc.node_id],
+        );
       });
     }
     return result;

--- a/pkg/ui/src/views/reports/containers/customgraph/index.tsx
+++ b/pkg/ui/src/views/reports/containers/customgraph/index.tsx
@@ -42,12 +42,16 @@ class CustomGraph extends React.Component<CustomGraphProps & WithRouterProps> {
     (summary: NodesSummary) => summary.nodeDisplayNameByID,
     (nodeStatuses, nodeDisplayNameByID): DropdownOption[] => {
       const base = [{value: "", label: "Cluster"}];
-      return base.concat(_.map(nodeStatuses, (ns) => {
-        return {
-          value: ns.desc.node_id.toString(),
-          label: nodeDisplayNameByID[ns.desc.node_id],
-        };
-      }));
+      return base.concat(_.chain(nodeStatuses)
+        .map(ns => {
+          return {
+            value: ns.desc.node_id.toString(),
+            label: nodeDisplayNameByID[ns.desc.node_id],
+          };
+        })
+        .sortBy(value => _.startsWith(value.label, "[decommissioned]"))
+        .value(),
+      );
     },
   );
 


### PR DESCRIPTION
Decommissioned nodes no longer appear in the "Select node" dropdown on
the metrics page. The nodes still appear in the nodes list, and data for
the nodes is still graphed, but they will no longer clutter the
dropdown.

In the case that a user needs to see this data explicitly,
decommissioned nodes still appear on the Custom Graph debug page as an
available source - in this dropdown, they now have "[decommissioned]"
appended to their display name and are sorted to the end of the
dropdown.

Fixes #23110

Release note (admin ui): Decommissioned nodes no longer appear in the
node selection dropdown on the Metrics page.