### PR TITLE
*: centralize cross-platform signal handling

### DIFF
--- a/pkg/cli/start.go
+++ b/pkg/cli/start.go
@@ -752,17 +752,15 @@ func runStart(cmd *cobra.Command, args []string) error {
 		// encoded as 128+signal number.
 		//
 		// Also, on Unix, os.Signal is syscall.Signal and it's convertible to int.
-		returnErr = &cliError{
+		return &cliError{
 			exitCode: 128 + int(sig.(syscall.Signal)),
 			severity: log.Severity_ERROR,
 			cause: errors.Errorf(
 				"received signal '%s' during shutdown, initiating hard shutdown%s", sig, hardShutdownHint),
 		}
-		// NB: we do not return here to go through log.Flush below.
 
 	case <-time.After(time.Minute):
-		returnErr = errors.Errorf("time limit reached, initiating hard shutdown%s", hardShutdownHint)
-		// NB: we do not return here to go through log.Flush below.
+		return errors.Errorf("time limit reached, initiating hard shutdown%s", hardShutdownHint)
 
 	case <-stopper.IsStopped():
 		const msgDone = "server drained and shutdown completed"

--- a/pkg/cli/start.go
+++ b/pkg/cli/start.go
@@ -29,7 +29,6 @@ import (
 	"runtime"
 	"runtime/pprof"
 	"strings"
-	"syscall"
 	"text/tabwriter"
 	"time"
 
@@ -55,6 +54,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log/logflags"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+	"github.com/cockroachdb/cockroach/pkg/util/sysutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 )
 
@@ -395,7 +395,7 @@ func runStart(cmd *cobra.Command, args []string) error {
 	// the buffers in the signal handler below. If we started capturing
 	// signals later, some startup logging might be lost.
 	signalCh := make(chan os.Signal, 1)
-	signal.Notify(signalCh, syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT)
+	signal.Notify(signalCh, drainSignals...)
 
 	// Set up a tracing span for the start process.  We want any logging
 	// happening beyond this point to be accounted to this start
@@ -747,17 +747,11 @@ func runStart(cmd *cobra.Command, args []string) error {
 	select {
 	case sig := <-signalCh:
 		// This new signal is not welcome, as it interferes with the graceful
-		// shutdown process. On Unix, a signal that was not handled gracefully by
-		// the application should be visible to other processes as an exit code
-		// encoded as 128+signal number.
-		//
-		// Also, on Unix, os.Signal is syscall.Signal and it's convertible to int.
-		return &cliError{
-			exitCode: 128 + int(sig.(syscall.Signal)),
-			severity: log.Severity_ERROR,
-			cause: errors.Errorf(
-				"received signal '%s' during shutdown, initiating hard shutdown%s", sig, hardShutdownHint),
-		}
+		// shutdown process.
+		log.Shout(ctx, log.Severity_ERROR, fmt.Sprintf(
+			"received signal '%s' during shutdown, initiating hard shutdown%s", sig, hardShutdownHint))
+		handleSignalDuringShutdown(sig)
+		panic("unreachable")
 
 	case <-time.After(time.Minute):
 		return errors.Errorf("time limit reached, initiating hard shutdown%s", hardShutdownHint)
@@ -786,8 +780,7 @@ func reportConfiguration(ctx context.Context) {
 	// running as root in a multi-user environment, or using different
 	// uid/gid across runs in the same data directory. To determine
 	// this, it's easier if the information appears in the log file.
-	log.Infof(ctx, "process identity: uid %d euid %d gid %d egid %d",
-		syscall.Getuid(), syscall.Geteuid(), syscall.Getgid(), syscall.Getegid())
+	log.Infof(ctx, "process identity: %s", sysutil.ProcessIdentity())
 }
 
 func maybeWarnMemorySizes(ctx context.Context) {

--- a/pkg/cli/synctest/synctest.go
+++ b/pkg/cli/synctest/synctest.go
@@ -23,7 +23,6 @@ import (
 	"os/signal"
 	"sync"
 	"sync/atomic"
-	"syscall"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
@@ -31,6 +30,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+	"github.com/cockroachdb/cockroach/pkg/util/sysutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/codahale/hdrhistogram"
 	"github.com/pkg/errors"
@@ -164,17 +164,17 @@ func Run(opts Options) error {
 	defer ticker.Stop()
 
 	done := make(chan os.Signal, 3)
-	signal.Notify(done, syscall.SIGINT, syscall.SIGTERM)
+	signal.Notify(done, os.Interrupt)
 
 	go func() {
 		wg.Wait()
-		done <- syscall.Signal(0)
+		done <- sysutil.Signal(0)
 	}()
 
 	if opts.Duration > 0 {
 		go func() {
 			time.Sleep(opts.Duration)
-			done <- syscall.Signal(0)
+			done <- sysutil.Signal(0)
 		}()
 	}
 

--- a/pkg/security/certs_rotation_test.go
+++ b/pkg/security/certs_rotation_test.go
@@ -22,15 +22,16 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
-	"syscall"
 	"testing"
+
+	"github.com/pkg/errors"
+	"golang.org/x/sys/unix"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
-	"github.com/pkg/errors"
 )
 
 // TestRotateCerts tests certs rotation in the server.
@@ -125,7 +126,7 @@ func TestRotateCerts(t *testing.T) {
 	}
 
 	t.Log("issuing SIGHUP")
-	if err := syscall.Kill(syscall.Getpid(), syscall.SIGHUP); err != nil {
+	if err := unix.Kill(unix.Getpid(), unix.SIGHUP); err != nil {
 		t.Fatal(err)
 	}
 
@@ -173,7 +174,7 @@ func TestRotateCerts(t *testing.T) {
 	}
 
 	t.Log("issuing SIGHUP")
-	if err := syscall.Kill(syscall.Getpid(), syscall.SIGHUP); err != nil {
+	if err := unix.Kill(unix.Getpid(), unix.SIGHUP); err != nil {
 		t.Fatal(err)
 	}
 

--- a/pkg/testutils/lint/lint_test.go
+++ b/pkg/testutils/lint/lint_test.go
@@ -777,6 +777,7 @@ func TestLint(t *testing.T) {
 			"github.com/golang/protobuf/proto": "github.com/gogo/protobuf/proto",
 			"github.com/satori/go.uuid":        "util/uuid",
 			"golang.org/x/sync/singleflight":   "github.com/cockroachdb/cockroach/pkg/util/syncutil/singleflight",
+			"syscall":                          "sysutil",
 		}
 
 		// grepBuf creates a grep string that matches any forbidden import pkgs.
@@ -827,7 +828,7 @@ func TestLint(t *testing.T) {
 			stream.Grep(`^`+settingsPkgPrefix+`: | `+grepBuf.String()),
 			stream.GrepNot(`cockroach/pkg/cmd/`),
 			stream.GrepNot(`cockroach/pkg/testutils/lint: log$`),
-			stream.GrepNot(`cockroach/pkg/(cli|security): syscall$`),
+			stream.GrepNot(`cockroach/pkg/util/sysutil: syscall$`),
 			stream.GrepNot(`cockroach/pkg/(base|security|util/(log|randutil|stop)): log$`),
 			stream.GrepNot(`cockroach/pkg/(server/serverpb|ts/tspb): github\.com/golang/protobuf/proto$`),
 			stream.GrepNot(`cockroach/pkg/util/caller: path$`),

--- a/pkg/util/log/clog.go
+++ b/pkg/util/log/clog.go
@@ -27,7 +27,6 @@ import (
 	stdLog "log"
 	"math"
 	"os"
-	"os/signal"
 	"path/filepath"
 	"regexp"
 	"runtime"
@@ -35,13 +34,13 @@ import (
 	"strconv"
 	"strings"
 	"sync/atomic"
-	"syscall"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/build"
 	"github.com/cockroachdb/cockroach/pkg/util/caller"
 	"github.com/cockroachdb/cockroach/pkg/util/color"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+	"github.com/cockroachdb/cockroach/pkg/util/sysutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/petermattis/goid"
 )
@@ -595,10 +594,8 @@ func init() {
 
 // signalFlusher flushes the log(s) every time SIGHUP is received.
 func signalFlusher() {
-	flushCh := make(chan os.Signal, 1)
-	signal.Notify(flushCh, syscall.SIGHUP)
-
-	for sig := range flushCh {
+	ch := sysutil.RefreshSignaledChan()
+	for sig := range ch {
 		Infof(context.Background(), "%s received, flushing logs", sig)
 		Flush()
 	}

--- a/pkg/util/log/crash_reporting.go
+++ b/pkg/util/log/crash_reporting.go
@@ -22,7 +22,6 @@ import (
 	"runtime"
 	"runtime/debug"
 	"strings"
-	"syscall"
 	"time"
 
 	raven "github.com/getsentry/raven-go"
@@ -33,6 +32,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/caller"
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
+	"github.com/cockroachdb/cockroach/pkg/util/sysutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 )
 
@@ -307,7 +307,7 @@ func Redact(r interface{}) string {
 		switch t := r.(error).(type) {
 		case runtime.Error:
 			return typAnd(t, t.Error())
-		case syscall.Errno:
+		case sysutil.Errno:
 			return typAnd(t, t.Error())
 		case *os.SyscallError:
 			s := Redact(t.Err)

--- a/pkg/util/log/crash_reporting_unix_test.go
+++ b/pkg/util/log/crash_reporting_unix_test.go
@@ -12,22 +12,19 @@
 // implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
-package cli
+// +build !windows
+
+package log
 
 import (
 	"os"
+
+	"golang.org/x/sys/unix"
 )
 
-// drainSignals are the signals that will cause the server to drain and exit.
-var drainSignals = []os.Signal{os.Interrupt}
-
-func handleSignalDuringShutdown(os.Signal) {
-	// Windows doesn't indicate whether a process exited due to a signal in the
-	// exit code, so we don't need to do anything but exit with a failing code.
-	// The error message has already been printed.
-	os.Exit(1)
-}
-
-func maybeRerunBackground() (bool, error) {
-	return false, nil
+func init() {
+	safeErrorTestCases = append(safeErrorTestCases, safeErrorTestCase{
+		format: "", rs: []interface{}{os.NewSyscallError("write", unix.ENOSPC)},
+		expErr: "?:0: *os.SyscallError: write: syscall.Errno: no space left on device",
+	})
 }

--- a/pkg/util/sysutil/sysutil.go
+++ b/pkg/util/sysutil/sysutil.go
@@ -1,0 +1,57 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package sysutil is a cross-platform compatibility layer on top of package
+// syscall. It exposes APIs for common operations that require package syscall
+// and re-exports several symbols from package syscall that are known to be
+// safe. Using package syscall directly from other packages is forbidden.
+package sysutil
+
+import (
+	"os"
+	"os/exec"
+	"os/signal"
+	"syscall"
+)
+
+// Signal is syscall.Signal.
+type Signal = syscall.Signal
+
+// Errno is syscall.Errno.
+type Errno = syscall.Errno
+
+// ExitStatus returns the exit status contained within an exec.ExitError.
+func ExitStatus(err *exec.ExitError) int {
+	// err.Sys() is of type syscall.WaitStatus on all supported platforms.
+	// syscall.WaitStatus has a different type on Windows, but that type has an
+	// ExitStatus method with an identical signature, so no need for conditional
+	// compilation.
+	return err.Sys().(syscall.WaitStatus).ExitStatus()
+}
+
+const refreshSignal = syscall.SIGHUP
+
+// RefreshSignaledChan returns a channel that will receive an os.Signal whenever
+// the process receives a "refresh" signal (currently SIGHUP). A refresh signal
+// indicates that the user wants to apply nondisruptive updates, like reloading
+// certificates and flushing log files.
+//
+// On Windows, the returned channel will never receive any values, as Windows
+// does not support signals. Consider exposing a refresh trigger through other
+// means if Windows support is important.
+func RefreshSignaledChan() <-chan os.Signal {
+	ch := make(chan os.Signal, 1)
+	signal.Notify(ch, refreshSignal)
+	return ch
+}

--- a/pkg/util/sysutil/sysutil_test.go
+++ b/pkg/util/sysutil/sysutil_test.go
@@ -1,0 +1,35 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sysutil
+
+import (
+	"os/exec"
+	"testing"
+)
+
+func TestExitStatus(t *testing.T) {
+	cmd := exec.Command("sh", "-c", "exit 42")
+	err := cmd.Run()
+	if err == nil {
+		t.Fatalf("%s did not return error", cmd.Args)
+	}
+	exitErr, ok := err.(*exec.ExitError)
+	if !ok {
+		t.Fatalf("%s returned error of type %T, but expected *exec.ExitError", cmd.Args, err)
+	}
+	if status := ExitStatus(exitErr); status != 42 {
+		t.Fatalf("expected exit status 42, but got %d", status)
+	}
+}

--- a/pkg/util/sysutil/sysutil_unix.go
+++ b/pkg/util/sysutil/sysutil_unix.go
@@ -1,0 +1,30 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !windows
+
+package sysutil
+
+import (
+	"fmt"
+
+	"golang.org/x/sys/unix"
+)
+
+// ProcessIdentity returns a string describing the user and group that this
+// process is running as.
+func ProcessIdentity() string {
+	return fmt.Sprintf("uid %d euid %d gid %d egid %d",
+		unix.Getuid(), unix.Geteuid(), unix.Getgid(), unix.Getegid())
+}

--- a/pkg/util/sysutil/sysutil_unix_test.go
+++ b/pkg/util/sysutil/sysutil_unix_test.go
@@ -1,0 +1,42 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !windows
+
+package sysutil
+
+import (
+	"testing"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+func TestRefreshSignaledChan(t *testing.T) {
+	ch := RefreshSignaledChan()
+
+	if err := unix.Kill(unix.Getpid(), refreshSignal); err != nil {
+		t.Error(err)
+		return
+	}
+
+	select {
+	case sig := <-ch:
+		if refreshSignal != sig {
+			t.Fatalf("expected signal %s, but got %s", refreshSignal, sig)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out while waiting for refresh signal")
+	}
+}

--- a/pkg/util/sysutil/sysutil_windows.go
+++ b/pkg/util/sysutil/sysutil_windows.go
@@ -1,0 +1,32 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build windows
+
+package sysutil
+
+import (
+	"fmt"
+	"os/user"
+)
+
+// ProcessIdentity returns a string describing the user and group that this
+// process is running as.
+func ProcessIdentity() string {
+	u, err := user.Current()
+	if err != nil {
+		return "<unknown>"
+	}
+	return fmt.Sprintf("uid %s, gid %s", u.Uid, u.Gid)
+}


### PR DESCRIPTION
Go's story around cross-platform signal handling is weak. The syscall
package sometimes defines compatibility shims, but not always. For
example, on Windows, neither SIGTERM nor SIGUSR1 exists, yet Go provides
syscall.SIGTERM and not syscall.SIGUSR1. Our Windows build was recently
broken because of an unchecked usage of syscall.SIGUSR1 (2b91e0f).

Introduce a sysutil package to serve as a compatibility layer. sysutil
provides consistent cross-platform shims for all signals we care about.

sysutil also allows us to lint against usage of the syscall package
elsewhere in the codebase. Direct usage of syscall usually indicates
code that will fail to compile on Windows. The few syscall symbols that
are known to work cross-platform, or at least to fail gracefully on
unsupported platforms, are re-exported in the sysutil package. (A
similar lint rule used to exist, but was inadvertently dropped by
254457c.)

Unix-specific code is still allowed to import golang.org/x/sys/unix, but
hopefully the import path makes it a obvious that such code needs to be
protected with a "!windows" build tag. Ideally we'd lint for this, too,
but writing such a lint rule is challenging.

Release note: None

/cc @bdarnell you might want to have a look too.