### PR TITLE
cherrypick-2.0: storage: Fix nil pointer exception in rebalance target selection

### DIFF
--- a/pkg/storage/allocator_scorer.go
+++ b/pkg/storage/allocator_scorer.go
@@ -787,6 +787,9 @@ func bestRebalanceTarget(
 			continue
 		}
 		target := option.candidates.selectGood(randGen)
+		if target == nil {
+			continue
+		}
 		existing := option.existingCandidates[len(option.existingCandidates)-1]
 		if betterRebalanceTarget(target, &existing, bestTarget, &replaces) == target {
 			bestIdx = i


### PR DESCRIPTION
We could panic if there was a rebalance candidate that was

* Invalid or had a full disk
* Better than an existing replica (which, in turn, must have been
  invalid or had a full disk)
* The best candidate remaining in the list of candidates when
  bestRebalanceTargets was called.

These sets of conditions are most likely when new constraints have been
set on a range that make one or more of its existing replicas invalid.

Fixes #23796

Release note (bug fix): Fix rare nil pointer exception in rebalance
target selection.

--------

Cherry-picks #23804 to release-2.0