### PR TITLE
sql: fix USING GIN syntax location

### DIFF
--- a/docs/generated/sql/bnf/create_index_stmt.bnf
+++ b/docs/generated/sql/bnf/create_index_stmt.bnf
@@ -1,37 +1,37 @@
 create_index_stmt ::=
-	'CREATE' 'UNIQUE' 'INDEX' opt_index_name 'ON' table_name '(' column_name 'ASC' ( ( ',' ( column_name ( 'ASC' | 'DESC' |  ) ) ) )* ')' 'COVERING' '(' name_list ')' opt_interleave opt_partition_by 
-	| 'CREATE' 'UNIQUE' 'INDEX' opt_index_name 'ON' table_name '(' column_name 'ASC' ( ( ',' ( column_name ( 'ASC' | 'DESC' |  ) ) ) )* ')' 'STORING' '(' name_list ')' opt_interleave opt_partition_by 
-	| 'CREATE' 'UNIQUE' 'INDEX' opt_index_name 'ON' table_name '(' column_name 'ASC' ( ( ',' ( column_name ( 'ASC' | 'DESC' |  ) ) ) )* ')'  opt_interleave opt_partition_by 
-	| 'CREATE' 'UNIQUE' 'INDEX' opt_index_name 'ON' table_name '(' column_name 'DESC' ( ( ',' ( column_name ( 'ASC' | 'DESC' |  ) ) ) )* ')' 'COVERING' '(' name_list ')' opt_interleave opt_partition_by 
-	| 'CREATE' 'UNIQUE' 'INDEX' opt_index_name 'ON' table_name '(' column_name 'DESC' ( ( ',' ( column_name ( 'ASC' | 'DESC' |  ) ) ) )* ')' 'STORING' '(' name_list ')' opt_interleave opt_partition_by 
-	| 'CREATE' 'UNIQUE' 'INDEX' opt_index_name 'ON' table_name '(' column_name 'DESC' ( ( ',' ( column_name ( 'ASC' | 'DESC' |  ) ) ) )* ')'  opt_interleave opt_partition_by 
-	| 'CREATE' 'UNIQUE' 'INDEX' opt_index_name 'ON' table_name '(' column_name  ( ( ',' ( column_name ( 'ASC' | 'DESC' |  ) ) ) )* ')' 'COVERING' '(' name_list ')' opt_interleave opt_partition_by 
-	| 'CREATE' 'UNIQUE' 'INDEX' opt_index_name 'ON' table_name '(' column_name  ( ( ',' ( column_name ( 'ASC' | 'DESC' |  ) ) ) )* ')' 'STORING' '(' name_list ')' opt_interleave opt_partition_by 
-	| 'CREATE' 'UNIQUE' 'INDEX' opt_index_name 'ON' table_name '(' column_name  ( ( ',' ( column_name ( 'ASC' | 'DESC' |  ) ) ) )* ')'  opt_interleave opt_partition_by 
-	| 'CREATE'  'INDEX' opt_index_name 'ON' table_name '(' column_name 'ASC' ( ( ',' ( column_name ( 'ASC' | 'DESC' |  ) ) ) )* ')' 'COVERING' '(' name_list ')' opt_interleave opt_partition_by 
-	| 'CREATE'  'INDEX' opt_index_name 'ON' table_name '(' column_name 'ASC' ( ( ',' ( column_name ( 'ASC' | 'DESC' |  ) ) ) )* ')' 'STORING' '(' name_list ')' opt_interleave opt_partition_by 
-	| 'CREATE'  'INDEX' opt_index_name 'ON' table_name '(' column_name 'ASC' ( ( ',' ( column_name ( 'ASC' | 'DESC' |  ) ) ) )* ')'  opt_interleave opt_partition_by 
-	| 'CREATE'  'INDEX' opt_index_name 'ON' table_name '(' column_name 'DESC' ( ( ',' ( column_name ( 'ASC' | 'DESC' |  ) ) ) )* ')' 'COVERING' '(' name_list ')' opt_interleave opt_partition_by 
-	| 'CREATE'  'INDEX' opt_index_name 'ON' table_name '(' column_name 'DESC' ( ( ',' ( column_name ( 'ASC' | 'DESC' |  ) ) ) )* ')' 'STORING' '(' name_list ')' opt_interleave opt_partition_by 
-	| 'CREATE'  'INDEX' opt_index_name 'ON' table_name '(' column_name 'DESC' ( ( ',' ( column_name ( 'ASC' | 'DESC' |  ) ) ) )* ')'  opt_interleave opt_partition_by 
-	| 'CREATE'  'INDEX' opt_index_name 'ON' table_name '(' column_name  ( ( ',' ( column_name ( 'ASC' | 'DESC' |  ) ) ) )* ')' 'COVERING' '(' name_list ')' opt_interleave opt_partition_by 
-	| 'CREATE'  'INDEX' opt_index_name 'ON' table_name '(' column_name  ( ( ',' ( column_name ( 'ASC' | 'DESC' |  ) ) ) )* ')' 'STORING' '(' name_list ')' opt_interleave opt_partition_by 
-	| 'CREATE'  'INDEX' opt_index_name 'ON' table_name '(' column_name  ( ( ',' ( column_name ( 'ASC' | 'DESC' |  ) ) ) )* ')'  opt_interleave opt_partition_by 
-	| 'CREATE' 'UNIQUE' 'INDEX' 'IF' 'NOT' 'EXISTS' index_name 'ON' table_name '(' column_name 'ASC' ( ( ',' ( column_name ( 'ASC' | 'DESC' |  ) ) ) )* ')' 'COVERING' '(' name_list ')' opt_interleave opt_partition_by 
-	| 'CREATE' 'UNIQUE' 'INDEX' 'IF' 'NOT' 'EXISTS' index_name 'ON' table_name '(' column_name 'ASC' ( ( ',' ( column_name ( 'ASC' | 'DESC' |  ) ) ) )* ')' 'STORING' '(' name_list ')' opt_interleave opt_partition_by 
-	| 'CREATE' 'UNIQUE' 'INDEX' 'IF' 'NOT' 'EXISTS' index_name 'ON' table_name '(' column_name 'ASC' ( ( ',' ( column_name ( 'ASC' | 'DESC' |  ) ) ) )* ')'  opt_interleave opt_partition_by 
-	| 'CREATE' 'UNIQUE' 'INDEX' 'IF' 'NOT' 'EXISTS' index_name 'ON' table_name '(' column_name 'DESC' ( ( ',' ( column_name ( 'ASC' | 'DESC' |  ) ) ) )* ')' 'COVERING' '(' name_list ')' opt_interleave opt_partition_by 
-	| 'CREATE' 'UNIQUE' 'INDEX' 'IF' 'NOT' 'EXISTS' index_name 'ON' table_name '(' column_name 'DESC' ( ( ',' ( column_name ( 'ASC' | 'DESC' |  ) ) ) )* ')' 'STORING' '(' name_list ')' opt_interleave opt_partition_by 
-	| 'CREATE' 'UNIQUE' 'INDEX' 'IF' 'NOT' 'EXISTS' index_name 'ON' table_name '(' column_name 'DESC' ( ( ',' ( column_name ( 'ASC' | 'DESC' |  ) ) ) )* ')'  opt_interleave opt_partition_by 
-	| 'CREATE' 'UNIQUE' 'INDEX' 'IF' 'NOT' 'EXISTS' index_name 'ON' table_name '(' column_name  ( ( ',' ( column_name ( 'ASC' | 'DESC' |  ) ) ) )* ')' 'COVERING' '(' name_list ')' opt_interleave opt_partition_by 
-	| 'CREATE' 'UNIQUE' 'INDEX' 'IF' 'NOT' 'EXISTS' index_name 'ON' table_name '(' column_name  ( ( ',' ( column_name ( 'ASC' | 'DESC' |  ) ) ) )* ')' 'STORING' '(' name_list ')' opt_interleave opt_partition_by 
-	| 'CREATE' 'UNIQUE' 'INDEX' 'IF' 'NOT' 'EXISTS' index_name 'ON' table_name '(' column_name  ( ( ',' ( column_name ( 'ASC' | 'DESC' |  ) ) ) )* ')'  opt_interleave opt_partition_by 
-	| 'CREATE'  'INDEX' 'IF' 'NOT' 'EXISTS' index_name 'ON' table_name '(' column_name 'ASC' ( ( ',' ( column_name ( 'ASC' | 'DESC' |  ) ) ) )* ')' 'COVERING' '(' name_list ')' opt_interleave opt_partition_by 
-	| 'CREATE'  'INDEX' 'IF' 'NOT' 'EXISTS' index_name 'ON' table_name '(' column_name 'ASC' ( ( ',' ( column_name ( 'ASC' | 'DESC' |  ) ) ) )* ')' 'STORING' '(' name_list ')' opt_interleave opt_partition_by 
-	| 'CREATE'  'INDEX' 'IF' 'NOT' 'EXISTS' index_name 'ON' table_name '(' column_name 'ASC' ( ( ',' ( column_name ( 'ASC' | 'DESC' |  ) ) ) )* ')'  opt_interleave opt_partition_by 
-	| 'CREATE'  'INDEX' 'IF' 'NOT' 'EXISTS' index_name 'ON' table_name '(' column_name 'DESC' ( ( ',' ( column_name ( 'ASC' | 'DESC' |  ) ) ) )* ')' 'COVERING' '(' name_list ')' opt_interleave opt_partition_by 
-	| 'CREATE'  'INDEX' 'IF' 'NOT' 'EXISTS' index_name 'ON' table_name '(' column_name 'DESC' ( ( ',' ( column_name ( 'ASC' | 'DESC' |  ) ) ) )* ')' 'STORING' '(' name_list ')' opt_interleave opt_partition_by 
-	| 'CREATE'  'INDEX' 'IF' 'NOT' 'EXISTS' index_name 'ON' table_name '(' column_name 'DESC' ( ( ',' ( column_name ( 'ASC' | 'DESC' |  ) ) ) )* ')'  opt_interleave opt_partition_by 
-	| 'CREATE'  'INDEX' 'IF' 'NOT' 'EXISTS' index_name 'ON' table_name '(' column_name  ( ( ',' ( column_name ( 'ASC' | 'DESC' |  ) ) ) )* ')' 'COVERING' '(' name_list ')' opt_interleave opt_partition_by 
-	| 'CREATE'  'INDEX' 'IF' 'NOT' 'EXISTS' index_name 'ON' table_name '(' column_name  ( ( ',' ( column_name ( 'ASC' | 'DESC' |  ) ) ) )* ')' 'STORING' '(' name_list ')' opt_interleave opt_partition_by 
-	| 'CREATE'  'INDEX' 'IF' 'NOT' 'EXISTS' index_name 'ON' table_name '(' column_name  ( ( ',' ( column_name ( 'ASC' | 'DESC' |  ) ) ) )* ')'  opt_interleave opt_partition_by 
+	'CREATE' 'UNIQUE' 'INDEX' opt_index_name 'ON' table_name  '(' column_name 'ASC' ( ( ',' ( column_name ( 'ASC' | 'DESC' |  ) ) ) )* ')' 'COVERING' '(' name_list ')' opt_interleave opt_partition_by
+	| 'CREATE' 'UNIQUE' 'INDEX' opt_index_name 'ON' table_name  '(' column_name 'ASC' ( ( ',' ( column_name ( 'ASC' | 'DESC' |  ) ) ) )* ')' 'STORING' '(' name_list ')' opt_interleave opt_partition_by
+	| 'CREATE' 'UNIQUE' 'INDEX' opt_index_name 'ON' table_name  '(' column_name 'ASC' ( ( ',' ( column_name ( 'ASC' | 'DESC' |  ) ) ) )* ')'  opt_interleave opt_partition_by
+	| 'CREATE' 'UNIQUE' 'INDEX' opt_index_name 'ON' table_name  '(' column_name 'DESC' ( ( ',' ( column_name ( 'ASC' | 'DESC' |  ) ) ) )* ')' 'COVERING' '(' name_list ')' opt_interleave opt_partition_by
+	| 'CREATE' 'UNIQUE' 'INDEX' opt_index_name 'ON' table_name  '(' column_name 'DESC' ( ( ',' ( column_name ( 'ASC' | 'DESC' |  ) ) ) )* ')' 'STORING' '(' name_list ')' opt_interleave opt_partition_by
+	| 'CREATE' 'UNIQUE' 'INDEX' opt_index_name 'ON' table_name  '(' column_name 'DESC' ( ( ',' ( column_name ( 'ASC' | 'DESC' |  ) ) ) )* ')'  opt_interleave opt_partition_by
+	| 'CREATE' 'UNIQUE' 'INDEX' opt_index_name 'ON' table_name  '(' column_name  ( ( ',' ( column_name ( 'ASC' | 'DESC' |  ) ) ) )* ')' 'COVERING' '(' name_list ')' opt_interleave opt_partition_by
+	| 'CREATE' 'UNIQUE' 'INDEX' opt_index_name 'ON' table_name  '(' column_name  ( ( ',' ( column_name ( 'ASC' | 'DESC' |  ) ) ) )* ')' 'STORING' '(' name_list ')' opt_interleave opt_partition_by
+	| 'CREATE' 'UNIQUE' 'INDEX' opt_index_name 'ON' table_name  '(' column_name  ( ( ',' ( column_name ( 'ASC' | 'DESC' |  ) ) ) )* ')'  opt_interleave opt_partition_by
+	| 'CREATE'  'INDEX' opt_index_name 'ON' table_name  '(' column_name 'ASC' ( ( ',' ( column_name ( 'ASC' | 'DESC' |  ) ) ) )* ')' 'COVERING' '(' name_list ')' opt_interleave opt_partition_by
+	| 'CREATE'  'INDEX' opt_index_name 'ON' table_name  '(' column_name 'ASC' ( ( ',' ( column_name ( 'ASC' | 'DESC' |  ) ) ) )* ')' 'STORING' '(' name_list ')' opt_interleave opt_partition_by
+	| 'CREATE'  'INDEX' opt_index_name 'ON' table_name  '(' column_name 'ASC' ( ( ',' ( column_name ( 'ASC' | 'DESC' |  ) ) ) )* ')'  opt_interleave opt_partition_by
+	| 'CREATE'  'INDEX' opt_index_name 'ON' table_name  '(' column_name 'DESC' ( ( ',' ( column_name ( 'ASC' | 'DESC' |  ) ) ) )* ')' 'COVERING' '(' name_list ')' opt_interleave opt_partition_by
+	| 'CREATE'  'INDEX' opt_index_name 'ON' table_name  '(' column_name 'DESC' ( ( ',' ( column_name ( 'ASC' | 'DESC' |  ) ) ) )* ')' 'STORING' '(' name_list ')' opt_interleave opt_partition_by
+	| 'CREATE'  'INDEX' opt_index_name 'ON' table_name  '(' column_name 'DESC' ( ( ',' ( column_name ( 'ASC' | 'DESC' |  ) ) ) )* ')'  opt_interleave opt_partition_by
+	| 'CREATE'  'INDEX' opt_index_name 'ON' table_name  '(' column_name  ( ( ',' ( column_name ( 'ASC' | 'DESC' |  ) ) ) )* ')' 'COVERING' '(' name_list ')' opt_interleave opt_partition_by
+	| 'CREATE'  'INDEX' opt_index_name 'ON' table_name  '(' column_name  ( ( ',' ( column_name ( 'ASC' | 'DESC' |  ) ) ) )* ')' 'STORING' '(' name_list ')' opt_interleave opt_partition_by
+	| 'CREATE'  'INDEX' opt_index_name 'ON' table_name  '(' column_name  ( ( ',' ( column_name ( 'ASC' | 'DESC' |  ) ) ) )* ')'  opt_interleave opt_partition_by
+	| 'CREATE' 'UNIQUE' 'INDEX' 'IF' 'NOT' 'EXISTS' index_name 'ON' table_name  '(' column_name 'ASC' ( ( ',' ( column_name ( 'ASC' | 'DESC' |  ) ) ) )* ')' 'COVERING' '(' name_list ')' opt_interleave opt_partition_by
+	| 'CREATE' 'UNIQUE' 'INDEX' 'IF' 'NOT' 'EXISTS' index_name 'ON' table_name  '(' column_name 'ASC' ( ( ',' ( column_name ( 'ASC' | 'DESC' |  ) ) ) )* ')' 'STORING' '(' name_list ')' opt_interleave opt_partition_by
+	| 'CREATE' 'UNIQUE' 'INDEX' 'IF' 'NOT' 'EXISTS' index_name 'ON' table_name  '(' column_name 'ASC' ( ( ',' ( column_name ( 'ASC' | 'DESC' |  ) ) ) )* ')'  opt_interleave opt_partition_by
+	| 'CREATE' 'UNIQUE' 'INDEX' 'IF' 'NOT' 'EXISTS' index_name 'ON' table_name  '(' column_name 'DESC' ( ( ',' ( column_name ( 'ASC' | 'DESC' |  ) ) ) )* ')' 'COVERING' '(' name_list ')' opt_interleave opt_partition_by
+	| 'CREATE' 'UNIQUE' 'INDEX' 'IF' 'NOT' 'EXISTS' index_name 'ON' table_name  '(' column_name 'DESC' ( ( ',' ( column_name ( 'ASC' | 'DESC' |  ) ) ) )* ')' 'STORING' '(' name_list ')' opt_interleave opt_partition_by
+	| 'CREATE' 'UNIQUE' 'INDEX' 'IF' 'NOT' 'EXISTS' index_name 'ON' table_name  '(' column_name 'DESC' ( ( ',' ( column_name ( 'ASC' | 'DESC' |  ) ) ) )* ')'  opt_interleave opt_partition_by
+	| 'CREATE' 'UNIQUE' 'INDEX' 'IF' 'NOT' 'EXISTS' index_name 'ON' table_name  '(' column_name  ( ( ',' ( column_name ( 'ASC' | 'DESC' |  ) ) ) )* ')' 'COVERING' '(' name_list ')' opt_interleave opt_partition_by
+	| 'CREATE' 'UNIQUE' 'INDEX' 'IF' 'NOT' 'EXISTS' index_name 'ON' table_name  '(' column_name  ( ( ',' ( column_name ( 'ASC' | 'DESC' |  ) ) ) )* ')' 'STORING' '(' name_list ')' opt_interleave opt_partition_by
+	| 'CREATE' 'UNIQUE' 'INDEX' 'IF' 'NOT' 'EXISTS' index_name 'ON' table_name  '(' column_name  ( ( ',' ( column_name ( 'ASC' | 'DESC' |  ) ) ) )* ')'  opt_interleave opt_partition_by
+	| 'CREATE'  'INDEX' 'IF' 'NOT' 'EXISTS' index_name 'ON' table_name  '(' column_name 'ASC' ( ( ',' ( column_name ( 'ASC' | 'DESC' |  ) ) ) )* ')' 'COVERING' '(' name_list ')' opt_interleave opt_partition_by
+	| 'CREATE'  'INDEX' 'IF' 'NOT' 'EXISTS' index_name 'ON' table_name  '(' column_name 'ASC' ( ( ',' ( column_name ( 'ASC' | 'DESC' |  ) ) ) )* ')' 'STORING' '(' name_list ')' opt_interleave opt_partition_by
+	| 'CREATE'  'INDEX' 'IF' 'NOT' 'EXISTS' index_name 'ON' table_name  '(' column_name 'ASC' ( ( ',' ( column_name ( 'ASC' | 'DESC' |  ) ) ) )* ')'  opt_interleave opt_partition_by
+	| 'CREATE'  'INDEX' 'IF' 'NOT' 'EXISTS' index_name 'ON' table_name  '(' column_name 'DESC' ( ( ',' ( column_name ( 'ASC' | 'DESC' |  ) ) ) )* ')' 'COVERING' '(' name_list ')' opt_interleave opt_partition_by
+	| 'CREATE'  'INDEX' 'IF' 'NOT' 'EXISTS' index_name 'ON' table_name  '(' column_name 'DESC' ( ( ',' ( column_name ( 'ASC' | 'DESC' |  ) ) ) )* ')' 'STORING' '(' name_list ')' opt_interleave opt_partition_by
+	| 'CREATE'  'INDEX' 'IF' 'NOT' 'EXISTS' index_name 'ON' table_name  '(' column_name 'DESC' ( ( ',' ( column_name ( 'ASC' | 'DESC' |  ) ) ) )* ')'  opt_interleave opt_partition_by
+	| 'CREATE'  'INDEX' 'IF' 'NOT' 'EXISTS' index_name 'ON' table_name  '(' column_name  ( ( ',' ( column_name ( 'ASC' | 'DESC' |  ) ) ) )* ')' 'COVERING' '(' name_list ')' opt_interleave opt_partition_by
+	| 'CREATE'  'INDEX' 'IF' 'NOT' 'EXISTS' index_name 'ON' table_name  '(' column_name  ( ( ',' ( column_name ( 'ASC' | 'DESC' |  ) ) ) )* ')' 'STORING' '(' name_list ')' opt_interleave opt_partition_by
+	| 'CREATE'  'INDEX' 'IF' 'NOT' 'EXISTS' index_name 'ON' table_name  '(' column_name  ( ( ',' ( column_name ( 'ASC' | 'DESC' |  ) ) ) )* ')'  opt_interleave opt_partition_by

--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -571,8 +571,8 @@ create_database_stmt ::=
 	| 'CREATE' 'DATABASE' 'IF' 'NOT' 'EXISTS' database_name opt_with opt_template_clause opt_encoding_clause opt_lc_collate_clause opt_lc_ctype_clause
 
 create_index_stmt ::=
-	'CREATE' opt_unique 'INDEX' opt_index_name 'ON' table_name '(' index_params ')' opt_storing opt_interleave opt_partition_by opt_using_gin
-	| 'CREATE' opt_unique 'INDEX' 'IF' 'NOT' 'EXISTS' index_name 'ON' table_name '(' index_params ')' opt_storing opt_interleave opt_partition_by opt_using_gin
+	'CREATE' opt_unique 'INDEX' opt_index_name 'ON' table_name opt_using_gin '(' index_params ')' opt_storing opt_interleave opt_partition_by
+	| 'CREATE' opt_unique 'INDEX' 'IF' 'NOT' 'EXISTS' index_name 'ON' table_name opt_using_gin '(' index_params ')' opt_storing opt_interleave opt_partition_by
 	| 'CREATE' 'INVERTED' 'INDEX' opt_index_name 'ON' table_name '(' index_params ')'
 	| 'CREATE' 'INVERTED' 'INDEX' 'IF' 'NOT' 'EXISTS' index_name 'ON' table_name '(' index_params ')'
 
@@ -1152,6 +1152,10 @@ opt_unique ::=
 opt_index_name ::=
 	opt_name
 
+opt_using_gin ::=
+	'USING' 'GIN'
+	| 
+
 index_params ::=
 	( index_elem ) ( ( ',' index_elem ) )*
 
@@ -1165,10 +1169,6 @@ opt_interleave ::=
 
 opt_partition_by ::=
 	partition_by
-	| 
-
-opt_using_gin ::=
-	'USING' 'GIN'
 	| 
 
 index_name ::=

--- a/pkg/sql/logictest/testdata/logic_test/inverted_index
+++ b/pkg/sql/logictest/testdata/logic_test/inverted_index
@@ -19,7 +19,7 @@ statement error pq: column b is of type INT and thus is not indexable with an in
 CREATE INVERTED INDEX foo_inv ON t(b)
 
 statement error pq: column b is of type INT and thus is not indexable with an inverted index
-CREATE INDEX foo_inv2 ON t(b) USING GIN
+CREATE INDEX foo_inv2 ON t USING GIN (b)
 
 statement error pq: syntax error at or near "inverted"
 CREATE UNIQUE INVERTED INDEX foo_inv ON t(b)
@@ -65,18 +65,18 @@ statement ok
 CREATE TABLE t1 (id1 INT PRIMARY KEY, id2 INT, id3 INT);
 
 statement error pq: inverted indexes don't support interleaved tables
-CREATE INDEX c on t1 (id2)
+CREATE INDEX c on t1 USING GIN (id2)
    STORING (id1,id3)
-   INTERLEAVE in PARENT t1 (id2) USING GIN;
+   INTERLEAVE in PARENT t1 (id2);
 
 statement error pq: inverted indexes don't support stored columns
-CREATE INDEX c on t1 (id2) STORING (id1,id3) USING GIN;
+CREATE INDEX c on t1 USING GIN (id2) STORING (id1,id3);
 
 statement error pq: syntax error at or near "storing"
 CREATE INVERTED INDEX c on t1 (id2) STORING (id1,id3);
 
 statement error pq: inverted indexes can't be unique
-CREATE UNIQUE INDEX foo_inv2 ON t(b) USING GIN
+CREATE UNIQUE INDEX foo_inv2 ON t USING GIN (b)
 
 statement ok
 CREATE TABLE d (

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -3767,31 +3767,31 @@ create_view_stmt:
 // %SeeAlso: CREATE TABLE, SHOW INDEXES, SHOW CREATE INDEX,
 // WEBDOCS/create-index.html
 create_index_stmt:
-  CREATE opt_unique INDEX opt_index_name ON table_name '(' index_params ')' opt_storing opt_interleave opt_partition_by opt_using_gin
+  CREATE opt_unique INDEX opt_index_name ON table_name opt_using_gin '(' index_params ')' opt_storing opt_interleave opt_partition_by
   {
     $$.val = &tree.CreateIndex{
       Name:    tree.Name($4),
       Table:   $6.normalizableTableNameFromUnresolvedName(),
       Unique:  $2.bool(),
-      Columns: $8.idxElems(),
-      Storing: $10.nameList(),
-      Interleave: $11.interleave(),
-      PartitionBy: $12.partitionBy(),
-      Inverted: $13.bool(),
+      Columns: $9.idxElems(),
+      Storing: $11.nameList(),
+      Interleave: $12.interleave(),
+      PartitionBy: $13.partitionBy(),
+      Inverted: $7.bool(),
     }
   }
-| CREATE opt_unique INDEX IF NOT EXISTS index_name ON table_name '(' index_params ')' opt_storing opt_interleave opt_partition_by opt_using_gin
+| CREATE opt_unique INDEX IF NOT EXISTS index_name ON table_name opt_using_gin '(' index_params ')' opt_storing opt_interleave opt_partition_by
   {
     $$.val = &tree.CreateIndex{
       Name:        tree.Name($7),
       Table:       $9.normalizableTableNameFromUnresolvedName(),
       Unique:      $2.bool(),
       IfNotExists: true,
-      Columns:     $11.idxElems(),
-      Storing:     $13.nameList(),
-      Interleave: $14.interleave(),
-      PartitionBy: $15.partitionBy(),
-      Inverted: $16.bool(),
+      Columns:     $12.idxElems(),
+      Storing:     $14.nameList(),
+      Interleave: $15.interleave(),
+      PartitionBy: $16.partitionBy(),
+      Inverted: $10.bool(),
     }
   }
 | CREATE INVERTED INDEX opt_index_name ON table_name '(' index_params ')'


### PR DESCRIPTION
We were accepting USING GIN at the end of a statement, but it should go
in the middle.

cc @nstewart 

Release note (bug fix): Support Postgres syntax for USING GIN.