### PR TITLE
[wip] sql: fix panic in lastval()

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/sequences
+++ b/pkg/sql/logictest/testdata/logic_test/sequences
@@ -1,9 +1,20 @@
 # LogicTest: default distsql parallel-stmts
 
+# Test selecting lastval() before nextval has been called, and FROM a table.
+
+statement ok
+CREATE TABLE a (a INT PRIMARY KEY)
+
+statement ok
+INSERT INTO a VALUES(1)
+
+statement error pq: lastval\(\): lastval is not yet defined in this session
+SELECT lastval() FROM a
+
 # see also files `drop_sequence`, `alter_sequence`, `rename_sequence`
 
 # USING THE `lastval` FUNCTION
-# (at the top because it requires a session in which `lastval` has never been called)
+# (at the top because it requires a session in which `nextval` has never been called)
 
 statement ok
 SET DATABASE = test
@@ -122,7 +133,7 @@ query ITTITTTT colnames
 SELECT * FROM crdb_internal.create_statements WHERE descriptor_name = 'show_create_test'
 ----
 database_id  database_name  schema_name  descriptor_id  descriptor_type  descriptor_name   create_statement                                                                              state
-50           test           public       64             sequence         show_create_test  CREATE SEQUENCE show_create_test MINVALUE 1 MAXVALUE 9223372036854775807 INCREMENT 1 START 1  PUBLIC
+50           test           public       65             sequence         show_create_test  CREATE SEQUENCE show_create_test MINVALUE 1 MAXVALUE 9223372036854775807 INCREMENT 1 START 1  PUBLIC
 
 query TT colnames
 SHOW CREATE SEQUENCE show_create_test


### PR DESCRIPTION
Currently this PR just contains a logic test which repros the bug, #23808

Release note: None