### PR TITLE
sql: permit multi-path contains exprs in inv idx queries

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/inverted_index
+++ b/pkg/sql/logictest/testdata/logic_test/inverted_index
@@ -147,6 +147,9 @@ INSERT INTO d VALUES(18, '[]')
 statement ok
 INSERT INTO d VALUES (29,  NULL)
 
+statement ok
+INSERT INTO d VALUES (30,  '{"a": {"b": "c", "d": "e"}, "f": "g"}')
+
 query TITTTTT
 EXPLAIN (VERBOSE) SELECT * from d where b @>'{"a": "b"}'
 ----
@@ -322,6 +325,7 @@ SELECT * from d where b @> '{}' ORDER BY a;
 8   {"a": {"b": true}}
 9   {"a": {"b": false}}
 17  {}
+30  {"a": {"b": "c", "d": "e"}, "f": "g"}
 
 query IT
 SELECT * from d where b @> '[]' ORDER BY a;
@@ -480,6 +484,83 @@ SELECT * from d where b @> 'null' ORDER BY a;
 ----
 11  null
 27  [true, false, null, 1.23, "a"]
+
+## Multi-path contains queries
+
+query IT
+SELECT * from d where b @> '{"a": {"b": "c"}, "f": "g"}'
+----
+30  {"a": {"b": "c", "d": "e"}, "f": "g"}
+
+query IT
+SELECT * from d where b @> '{"a": {"b": "c", "d": "e"}, "f": "g"}'
+----
+30  {"a": {"b": "c", "d": "e"}, "f": "g"}
+
+query TITTTTT
+EXPLAIN (VERBOSE) SELECT * from d where b @> '{"a": {"b": "c"}, "f": "g"}'
+----
+index-join  0  index-join  ·       ·                                    (a, b)           b=CONST; a!=NULL; key(a)
+ ├── scan   1  scan        ·       ·                                    (a, b[omitted])  b=CONST; a!=NULL; key(a)
+ │          1  ·           table   d@foo_inv                            ·                ·
+ │          1  ·           spans   /"a"/"b"/"c"-/"a"/"b"/"c"/PrefixEnd  ·                ·
+ └── scan   1  scan        ·       ·                                    (a, b)           ·
+·           1  ·           table   d@primary                            ·                ·
+·           1  ·           filter  b @> '{"f": "g"}'                    ·                ·
+
+query TITTTTT
+EXPLAIN (VERBOSE) SELECT * from d where b @> '{"a": {"b": "c", "d": "e"}, "f": "g"}'
+----
+index-join  0  index-join  ·       ·                                                   (a, b)           b=CONST; a!=NULL; key(a)
+ ├── scan   1  scan        ·       ·                                                   (a, b[omitted])  b=CONST; a!=NULL; key(a)
+ │          1  ·           table   d@foo_inv                                           ·                ·
+ │          1  ·           spans   /"a"/"b"/"c"-/"a"/"b"/"c"/PrefixEnd                 ·                ·
+ └── scan   1  scan        ·       ·                                                   (a, b)           ·
+·           1  ·           table   d@primary                                           ·                ·
+·           1  ·           filter  (b @> '{"a": {"d": "e"}}') AND (b @> '{"f": "g"}')  ·                ·
+
+query IT
+SELECT * from d where b @> '{"c": "d", "a": "b"}'
+----
+7  {"a": "b", "c": "d"}
+
+query IT
+SELECT * from d where b @> '{"c": "d", "a": "b", "f": "g"}'
+----
+
+query IT
+SELECT * from d where b @> '{"a": "b", "c": "e"}'
+----
+
+query IT
+SELECT * from d where b @> '{"a": "e", "c": "d"}'
+----
+
+query IT
+SELECT * from d where b @> '["d", {"a": {"b": [1]}}]'
+----
+16  [{"a": {"b": [1, [2]]}}, "d"]
+
+query IT
+SELECT * from d where b @> '["d", {"a": {"b": [[2]]}}]'
+----
+16  [{"a": {"b": [1, [2]]}}, "d"]
+
+query IT
+SELECT * from d where b @> '[{"a": {"b": [[2]]}}, "d"]'
+----
+16  [{"a": {"b": [1, [2]]}}, "d"]
+
+query TITTTTT
+EXPLAIN (VERBOSE) SELECT * from d where b @> '[{"a": {"b": [[2]]}}, "d"]'
+----
+index-join  0  index-join  ·       ·                                                        (a, b)           b=CONST; a!=NULL; key(a)
+ ├── scan   1  scan        ·       ·                                                        (a, b[omitted])  b=CONST; a!=NULL; key(a)
+ │          1  ·           table   d@foo_inv                                                ·                ·
+ │          1  ·           spans   /Arr/"a"/"b"/Arr/Arr/2-/Arr/"a"/"b"/Arr/Arr/2/PrefixEnd  ·                ·
+ └── scan   1  scan        ·       ·                                                        (a, b)           ·
+·           1  ·           table   d@primary                                                ·                ·
+·           1  ·           filter  b @> '["d"]'                                             ·                ·
 
 statement ok
 CREATE TABLE users (

--- a/pkg/sql/opt/scalar.go
+++ b/pkg/sql/opt/scalar.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
+	"github.com/cockroachdb/cockroach/pkg/util/json"
 	"github.com/cockroachdb/cockroach/pkg/util/treeprinter"
 )
 
@@ -54,7 +55,7 @@ func init() {
 		notRegIMatchOp:      {name: "not-regimatch"},
 		isOp:                {name: "is"},
 		isNotOp:             {name: "is-not"},
-		containsOp:          {name: "contains"},
+		containsOp:          {name: "contains", normalizeFn: normalizeContainsOp},
 		containedByOp:       {name: "contained-by", normalizeFn: normalizeContainedByOp},
 		jsonExistsOp:        {name: "exists"},
 		jsonAllExistsOp:     {name: "all-exists"},
@@ -338,6 +339,48 @@ func normalizeEqOp(e *Expr) {
 		// Note: this transformation is already performed by the TypedExpr
 		// NormalizeExpr, but we may be creating new such expressions above.
 		e.children[0], e.children[1] = rhs, lhs
+	}
+}
+
+func normalizeContainsOp(e *Expr) {
+	if e.op != containsOp {
+		panic(fmt.Sprintf("invalid call on %s", e))
+	}
+	if e.children[1].op != constOp {
+		return
+	}
+	datum := e.children[1].private.(tree.Datum)
+	dJSON, ok := datum.(*tree.DJSON)
+	if !ok {
+		return
+	}
+	switch dJSON.Type() {
+	case json.ArrayJSONType, json.ObjectJSONType:
+	default:
+		return
+	}
+	if dJSON.Len() == 1 {
+		return
+	}
+
+	// Normalize a contains condition on an n-path JSON value to n contains
+	// conditions on a single-path JSON value.
+	paths, err := json.AllPaths(dJSON.JSON)
+	if err != nil {
+		panic(fmt.Sprintf("programming error: %+v", err))
+	}
+	e.op = andOp
+	lhs := e.children[0]
+	e.children = make([]*Expr, len(paths))
+	for i := range paths {
+		e.children[i] = &Expr{
+			scalarProps: &scalarProps{typ: types.Bool},
+		}
+		rhs := &Expr{
+			scalarProps: &scalarProps{typ: types.JSON},
+		}
+		initConstExpr(rhs, tree.NewDJSON(paths[i]))
+		initBinaryExpr(e.children[i], containsOp, lhs, rhs)
 	}
 }
 

--- a/pkg/util/json/encoded.go
+++ b/pkg/util/json/encoded.go
@@ -702,6 +702,14 @@ func (j *jsonEncoded) encodeInvertedIndexKeys(b []byte) ([][]byte, error) {
 	return decoded.encodeInvertedIndexKeys(b)
 }
 
+func (j *jsonEncoded) allPaths() ([]JSON, error) {
+	decoded, err := j.decode()
+	if err != nil {
+		return nil, err
+	}
+	return decoded.allPaths()
+}
+
 // preprocessForContains implements the JSON interface.
 func (j *jsonEncoded) preprocessForContains() (containsable, error) {
 	if dec := j.alreadyDecoded(); dec != nil {

--- a/pkg/util/json/json.go
+++ b/pkg/util/json/json.go
@@ -71,9 +71,14 @@ type JSON interface {
 	// Size returns the size of the JSON document in bytes.
 	Size() uintptr
 
-	// EncodeInvertedIndexKeys takes in a key prefix and returns a slice of inverted index keys,
+	// encodeInvertedIndexKeys takes in a key prefix and returns a slice of inverted index keys,
 	// one per path through the receiver.
 	encodeInvertedIndexKeys(b []byte) ([][]byte, error)
+
+	// allPaths returns a slice of new JSON documents, each a path to a leaf
+	// through the receiver. Note that leaves include the empty object and array
+	// in addition to scalars.
+	allPaths() ([]JSON, error)
 
 	// FetchValKey implements the `->` operator for strings, returning nil if the
 	// key is not found.
@@ -738,6 +743,67 @@ func (j jsonObject) encodeInvertedIndexKeys(b []byte) ([][]byte, error) {
 		}
 	}
 	return outKeys, nil
+}
+
+// AllPaths returns a slice of new JSON documents, each a path to a leaf
+// through the input. Note that leaves include the empty object and array
+// in addition to scalars.
+func AllPaths(j JSON) ([]JSON, error) {
+	return j.allPaths()
+}
+
+func (j jsonNull) allPaths() ([]JSON, error) {
+	return []JSON{j}, nil
+}
+
+func (j jsonTrue) allPaths() ([]JSON, error) {
+	return []JSON{j}, nil
+}
+
+func (j jsonFalse) allPaths() ([]JSON, error) {
+	return []JSON{j}, nil
+}
+
+func (j jsonString) allPaths() ([]JSON, error) {
+	return []JSON{j}, nil
+}
+
+func (j jsonNumber) allPaths() ([]JSON, error) {
+	return []JSON{j}, nil
+}
+
+func (j jsonArray) allPaths() ([]JSON, error) {
+	if len(j) == 0 {
+		return []JSON{j}, nil
+	}
+	ret := make([]JSON, 0, len(j))
+	for i := range j {
+		paths, err := j[i].allPaths()
+		if err != nil {
+			return nil, err
+		}
+		for _, path := range paths {
+			ret = append(ret, jsonArray{path})
+		}
+	}
+	return ret, nil
+}
+
+func (j jsonObject) allPaths() ([]JSON, error) {
+	if len(j) == 0 {
+		return []JSON{j}, nil
+	}
+	ret := make([]JSON, 0, len(j))
+	for i := range j {
+		paths, err := j[i].v.allPaths()
+		if err != nil {
+			return nil, err
+		}
+		for _, path := range paths {
+			ret = append(ret, jsonObject{jsonKeyValuePair{k: j[i].k, v: path}})
+		}
+	}
+	return ret, nil
 }
 
 // FromDecimal returns a JSON value given a apd.Decimal.

--- a/pkg/util/json/json_test.go
+++ b/pkg/util/json/json_test.go
@@ -1521,6 +1521,60 @@ func TestJSONContains(t *testing.T) {
 	}
 }
 
+func TestAllPaths(t *testing.T) {
+	rng := rand.New(rand.NewSource(timeutil.Now().Unix()))
+
+	var countLeaves func(j JSON) int
+	countLeaves = func(j JSON) int {
+		j = j.MaybeDecode()
+		if j.isScalar() || j.Len() == 0 {
+			return 1
+		}
+		switch t := j.(type) {
+		case jsonArray:
+			ret := 0
+			for _, child := range t {
+				ret += countLeaves(child)
+			}
+			return ret
+		case jsonObject:
+			ret := 0
+			for _, kv := range t {
+				ret += countLeaves(kv.v)
+			}
+			return ret
+		default:
+			panic("Impossible case")
+		}
+	}
+
+	for i := 0; i < 1000; i++ {
+		j, err := Random(50, rng)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		allPaths, err := AllPaths(j)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		c := countLeaves(j)
+		if len(allPaths) != c {
+			t.Errorf("len(allPaths) is %d, should be %d", len(allPaths), c)
+		}
+		for _, path := range allPaths {
+			c, err := Contains(j, path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !c {
+				t.Errorf("%s should contain path %s", j, path)
+			}
+		}
+	}
+}
+
 // TestPositiveRandomJSONContains randomly generates a JSON document, generates
 // a subdocument of it, then verifies that it matches under contains.
 func TestPositiveRandomJSONContains(t *testing.T) {


### PR DESCRIPTION
Previously, contains expressions with multiple paths wouldn't work in
inverted indexes. Now, they're normalized into a conjunction of contains
expressions with a single path.

Fixes #21786 

cc @RaduBerinde I don't know how to add this to the new code - do I need to write a rewrite rule that does this normalization?

This needs more testing. The `allPaths` method should be unit tested - just pushing up for early review. Also, probably `allPaths` should be pushed to master along with a fix for the new code, and this should be a cherrypick of `allPaths` plus the backported normalization rule.

Release note: None