### PR TITLE
sql: fix crash in OUTER JOIN with null VALUES

### DIFF
--- a/pkg/sql/join.go
+++ b/pkg/sql/join.go
@@ -292,7 +292,12 @@ func (p *planner) makeJoin(
 				return planDataSource{}, err
 			}
 		}
-		r.addRenderColumn(expr, symbolicExprStr(expr), left.info.SourceColumns[leftCol])
+		// Issue #23609: the type of the left side might be NULL; so use the type of
+		// the IFNULL expression instead of the type of the left source column.
+		r.addRenderColumn(expr, symbolicExprStr(expr), sqlbase.ResultColumn{
+			Name: left.info.SourceColumns[leftCol].Name,
+			Typ:  expr.ResolvedType(),
+		})
 	}
 	for i, c := range left.info.SourceColumns {
 		if remapped[i] != -1 {

--- a/pkg/sql/join_predicate.go
+++ b/pkg/sql/join_predicate.go
@@ -113,7 +113,8 @@ func (p *joinPredicate) tryAddEqualityFilter(
 	}
 
 	if !lhs.ResolvedType().Equivalent(rhs.ResolvedType()) {
-		// We can't have equality columns of different types (#22519).
+		// Issue #22519: we can't have two equality columns of mismatched types
+		// because the hash-joiner assumes the encodings are the same.
 		return false
 	}
 

--- a/pkg/sql/logictest/testdata/logic_test/join
+++ b/pkg/sql/logictest/testdata/logic_test/join
@@ -2345,3 +2345,34 @@ NULL  44    51
 NULL  NULL  52
 NULL  42    53
 NULL  45    45
+
+# Regression test for #23609: make sure that the type of the merged column
+# is int (not unknown).
+query TT colnames
+SELECT "Type", "Columns" FROM [EXPLAIN (TYPES)
+  SELECT column1, column1+1
+  FROM
+    (SELECT * FROM
+      (VALUES (NULL, NULL)) AS t
+        NATURAL FULL OUTER JOIN
+      (VALUES (1, 1)) AS u)]
+WHERE "Type" != ''
+----
+Type    Columns
+render  (column1 int, "column1 + 1" int)
+render  (column1 int, column2[omitted] int)
+render  (column1 int, column2[omitted] int, column1[hidden,omitted] unknown, column2[hidden,omitted] unknown, column1[hidden,omitted] int, column2[hidden,omitted] int)
+join    (column1 unknown, column2[omitted] unknown, column1 int, column2[omitted] int)
+values  (column1 unknown, column2 unknown)
+values  (column1 int, column2 int)
+
+query II rowsort
+SELECT column1, column1+1
+FROM
+  (SELECT * FROM
+    (VALUES (NULL, NULL)) AS t
+      NATURAL FULL OUTER JOIN
+    (VALUES (1, 1)) AS u)
+----
+1     2
+NULL  NULL


### PR DESCRIPTION
For outer joins, we have merged columns `IFNULL(left.x, right.x)`. We
were setting the type of this column as the type of `left.x`; however
it is possible that one side's type is null/unknown. This resulted in
a `invalid datum type given: int, expected unknown` crash in some
cases. In other cases, the query worked, but the planning process
incorrectly assumed that the result is constant (because of the
unknown type which accepts only NULL values).

The fix is to use the resolved type of the `IFNULL` expression.

Release note (bug fix): Fixed crashes or incorrect results when
combining an OUTER JOIN with a VALUES clause that contains only NULL
values on a column (or other subqueries which result in a NULL
column).

Fixes #23609.