### PR TITLE
workload/tpcc: use explicit primary key in tpcc.history

### DIFF
--- a/pkg/workload/csv.go
+++ b/pkg/workload/csv.go
@@ -75,6 +75,8 @@ func datumToCSVString(datum interface{}) string {
 	switch t := datum.(type) {
 	case int:
 		return strconv.Itoa(t)
+	case int64:
+		return fmt.Sprint(t)
 	case float64:
 		return strconv.FormatFloat(t, 'f', -1, 64)
 	case string:

--- a/pkg/workload/tpcc/ddls.go
+++ b/pkg/workload/tpcc/ddls.go
@@ -69,6 +69,7 @@ const (
 	tpccCustomerSchemaInterleave = ` interleave in parent district (c_w_id, c_d_id)`
 	// No PK necessary for this table.
 	tpccHistorySchema = `(
+		rowid    uuid PRIMARY KEY DEFAULT gen_random_uuid(),
 		h_c_id   integer,
 		h_c_d_id integer,
 		h_c_w_id integer,

--- a/pkg/workload/tpcc/generate.go
+++ b/pkg/workload/tpcc/generate.go
@@ -18,6 +18,8 @@ package tpcc
 import (
 	"math/rand"
 	"strconv"
+
+	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 )
 
 // These constants are all set by the spec - they're not knobs. Don't change
@@ -188,12 +190,13 @@ func (w *tpcc) tpccHistoryInitialRow(rowIdx int) []interface{} {
 	rng := w.rngPool.Get().(*rand.Rand)
 	defer w.rngPool.Put(rng)
 
+	rowID := uuid.MakeV4().String()
 	cID := (rowIdx % numCustomersPerDistrict) + 1
 	dID := ((rowIdx / numCustomersPerDistrict) % numDistrictsPerWarehouse) + 1
 	wID := (rowIdx / numCustomersPerWarehouse)
 
 	return []interface{}{
-		cID, dID, wID, dID, wID, w.nowString, 10.00, randAString(rng, 12, 24),
+		rowID, cID, dID, wID, dID, wID, w.nowString, 10.00, randAString(rng, 12, 24),
 	}
 }
 

--- a/pkg/workload/tpcc/tpcc.go
+++ b/pkg/workload/tpcc/tpcc.go
@@ -67,7 +67,7 @@ var tpccMeta = workload.Meta{
 	Name: `tpcc`,
 	Description: `TPC-C simulates a transaction processing workload` +
 		` using a rich schema of multiple tables`,
-	Version: `1.0.0`,
+	Version: `2.0.0`,
 	New: func() workload.Generator {
 		g := &tpcc{}
 		g.flags.FlagSet = pflag.NewFlagSet(`tpcc`, pflag.ContinueOnError)


### PR DESCRIPTION
Use an explicit primary key in tpcc.history which is identical to the
implicit one. When generating fixture data, fill in the rowid using a
random 63-bit integer rather than relying on sequential values generated
during import. This matches the rowid generation used by the `tpcc` load
generator.

Fixes #23544

Release note: None