### PR TITLE
Makefile: properly track dependencies of binaries

### DIFF
--- a/build/variables.mk
+++ b/build/variables.mk
@@ -99,8 +99,8 @@ define VALID_VARS
   PROTOBUF_DIR
   PROTOBUF_PATH
   PROTOBUF_SRC_DIR
+  PROTOBUF_TARGETS
   PROTOC_DIR
-  PROTOC_PLUGIN
   PROTO_MAPPINGS
   RACETIMEOUT
   ROCKSDB_DIR
@@ -147,6 +147,8 @@ define VALID_VARS
   bindir
   cyan
   go-version-check
+  langgen-package
+  optgen-package
   prefix
   space
   term-reset


### PR DESCRIPTION
Previously, Make assumed that every standalone binary was stored in
pkg/cmd/BINARYNAME and had no dependencies on other packages. This
heuristic worked for simple packages, like bin/returncheck, but not for
more complex packages, like bin/workload, which depends on several other
packages. Changing a file in a transitive dependency, like
pkg/ccl/workload, would confusingly not trigger a rebuild.

Stop trying to compute dependencies in the Makefile and instead always
call `go install`. This pushes all dependency tracking to Go, and, since
the introduction of the package cache in Go 1.10, is reasonably fast.

To keep things speedy, as `go install` isn't entirely free, make
installation of binaries lazy. We don't install bin/protoc-gen-gogoroach
unless protobufs are out of date, for example. Similarly for docgen,
optgen, and langgen.

Finally, add a missing dependency on protobufs to bin/workload.

Release note: None

Fix #23826.