### PR TITLE
sql: skip documentation for SHOW EXPERIMENTAL_REPLICA TRACE

### DIFF
--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -488,7 +488,6 @@ show_trace_stmt ::=
 	| 'SHOW' opt_compact 'KV' 'TRACE' 'FOR' 'SESSION'
 	| 'SHOW' opt_compact 'TRACE' 'FOR' explainable_stmt
 	| 'SHOW' opt_compact 'KV' 'TRACE' 'FOR' explainable_stmt
-	| 'SHOW' 'EXPERIMENTAL_REPLICA' 'TRACE' 'FOR' explainable_stmt
 
 show_users_stmt ::=
 	'SHOW' 'USERS'

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -2833,6 +2833,7 @@ show_trace_stmt:
   }
 | SHOW EXPERIMENTAL_REPLICA TRACE FOR explainable_stmt
   {
+    /* SKIP DOC */
     $$.val = &tree.ShowTrace{Statement: $5.stmt(), TraceType: tree.ShowTraceReplica}
   }
 


### PR DESCRIPTION
We're not ready to document this yet.

Release note: None

Fix #23676.