### PR TITLE
sql: ensure uniquness of pg_proc oids

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -1360,7 +1360,7 @@ FROM pg_proc p
 JOIN pg_type t ON t.typinput = p.oid
 WHERE t.typname = '_int4'
 ----
-2590763490  array_in  array_in
+639449980  array_in  array_in
 
 ## #16285
 ## int2vectors should be 0-indexed
@@ -1368,6 +1368,11 @@ query I
 SELECT COUNT(*) FROM pg_catalog.pg_index WHERE indkey[0] IS NULL;
 ----
 0
+
+## Ensure no two builtins have the same oid.
+query I
+SELECT c FROM (SELECT oid, COUNT(*) as c FROM pg_catalog.pg_proc GROUP BY oid) WHERE c > 1
+----
 
 ## TODO(masha): #16769
 #statement ok

--- a/pkg/sql/logictest/testdata/logic_test/pgoidtype
+++ b/pkg/sql/logictest/testdata/logic_test/pgoidtype
@@ -85,7 +85,7 @@ WHERE relname = 'pg_constraint'
 query OOOO
 SELECT 'upper'::REGPROC, 'upper'::REGPROCEDURE, 'pg_catalog.upper'::REGPROCEDURE, 'upper'::REGPROC::OID
 ----
-upper  upper  upper  1736923753
+upper  upper  upper  2896429946
 
 query error invalid function name
 SELECT 'invalid.more.pg_catalog.upper'::REGPROCEDURE
@@ -93,7 +93,7 @@ SELECT 'invalid.more.pg_catalog.upper'::REGPROCEDURE
 query OOO
 SELECT 'upper(int)'::REGPROC, 'upper(int)'::REGPROCEDURE, 'upper(int)'::REGPROC::OID
 ----
-upper  upper  1736923753
+upper  upper  2896429946
 
 query error unknown function: blah\(\)
 SELECT 'blah(ignored, ignored)'::REGPROC, 'blah(ignored, ignored)'::REGPROCEDURE

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -2198,6 +2198,7 @@ func (h oidHasher) BuiltinOid(name string, builtin *tree.Builtin) *tree.DOid {
 	h.writeTypeTag(functionTypeTag)
 	h.writeStr(name)
 	h.writeStr(builtin.Types.String())
+	h.writeStr(builtin.FixedReturnType().String())
 	return h.getOid()
 }
 


### PR DESCRIPTION
Previously, the algorithm used to determine the OID of a builtin in
`pg_proc` failed to take into account that more than one overload can
have the same name and type signature due to the "preferred" flag. This
PR takes that flag into account to ensure that those builtins have
unique OIDs as well.

Release note (bug fix): Make sure that all builtins have a unique
Postgres OID for compatibility.