### PR TITLE
cherry-pick 2.0: sql: scanNode fixes

### DIFF
--- a/pkg/sql/distsql_plan_stats.go
+++ b/pkg/sql/distsql_plan_stats.go
@@ -36,7 +36,7 @@ func (dsp *DistSQLPlanner) createStatsPlan(
 ) (physicalPlan, error) {
 	// Create the table readers; for this we initialize a dummy scanNode.
 	scan := scanNode{desc: desc}
-	err := scan.initDescDefaults(nil /* planDependencies */, publicColumns, nil /* wantedColumns */)
+	err := scan.initDescDefaults(nil /* planDependencies */, publicColumnsCfg)
 	if err != nil {
 		return physicalPlan{}, err
 	}

--- a/pkg/sql/executor_opt_interface.go
+++ b/pkg/sql/executor_opt_interface.go
@@ -135,9 +135,8 @@ func (ee *execEngine) ConstructScan(table optbase.Table) (exec.Node, error) {
 	}
 	// Create a scanNode.
 	scan := ee.planner.Scan()
-	if err := scan.initTable(
-		context.TODO(), ee.planner, desc, nil /* hints */, publicColumns, columns,
-	); err != nil {
+	colCfg := scanColumnsConfig{wantedColumns: columns}
+	if err := scan.initTable(context.TODO(), ee.planner, desc, nil /* hints */, colCfg); err != nil {
 		return nil, err
 	}
 	var err error

--- a/pkg/sql/join_test.go
+++ b/pkg/sql/join_test.go
@@ -33,7 +33,7 @@ func newTestScanNode(kvDB *client.DB, tableName string) (*scanNode, error) {
 	p := planner{}
 	scan := p.Scan()
 	scan.desc = desc
-	err := scan.initDescDefaults(p.curPlan.deps, publicColumns, nil)
+	err := scan.initDescDefaults(p.curPlan.deps, publicColumnsCfg)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/logictest/testdata/logic_test/dependencies
+++ b/pkg/sql/logictest/testdata/logic_test/dependencies
@@ -127,7 +127,7 @@ CREATE SEQUENCE blog_posts_id_seq
 statement ok
 CREATE TABLE blog_posts (id INT PRIMARY KEY DEFAULT nextval('blog_posts_id_seq'), title text)
 
-query ITIIITITT colnames rowsort
+query ITIIITITT colnames
 SELECT * FROM crdb_internal.backward_dependencies WHERE descriptor_name LIKE 'blog_posts'
 ----
 descriptor_id  descriptor_name  index_id  column_id  dependson_id  dependson_type  dependson_index_id  dependson_name  dependson_details
@@ -138,3 +138,36 @@ SELECT * FROM crdb_internal.forward_dependencies WHERE descriptor_name LIKE 'blo
 ----
 descriptor_id  descriptor_name    index_id  dependedonby_id  dependedonby_type  dependedonby_index_id  dependedonby_name  dependedonby_details
 63             blog_posts_id_seq  NULL      64               sequence           0                      NULL               Columns: [0]
+
+# Verify that we report a dependency on a column that is being mutated.
+  #CREATE VIEW v AS WITH a AS (UPDATE kv SET v = 444 RETURNING k) SELECT k FROM a;
+statement ok
+CREATE TABLE kv (k INT PRIMARY KEY, v INT);
+BEGIN;
+  ALTER TABLE kv ADD COLUMN z INT DEFAULT 123;
+  CREATE VIEW v AS SELECT k FROM [UPDATE kv SET v = 444 WHERE k > 0 RETURNING k];
+COMMIT
+
+# The view should contain column z.
+query TITTTTT colnames
+EXPLAIN (VERBOSE) SELECT * FROM v
+----
+Tree            Level  Type    Field        Description       Columns           Ordering
+update          0      update  ·            ·                 (k)               ·
+ │              0      ·       table        kv                ·                 ·
+ │              0      ·       set          v                 ·                 ·
+ │              0      ·       returning 0  test.public.kv.k  ·                 ·
+ └── render     1      render  ·            ·                 (k, v, z, "444")  "444"=CONST; k!=NULL; key(k)
+      │         1      ·       render 0     test.public.kv.k  ·                 ·
+      │         1      ·       render 1     test.public.kv.v  ·                 ·
+      │         1      ·       render 2     test.public.kv.z  ·                 ·
+      │         1      ·       render 3     444               ·                 ·
+      └── scan  2      scan    ·            ·                 (k, v, z)         k!=NULL; key(k)
+·               2      ·       table        kv@primary        ·                 ·
+·               2      ·       spans        /1-               ·                 ·
+
+query ITIITITT colnames
+SELECT * FROM crdb_internal.forward_dependencies WHERE descriptor_name = 'kv'
+----
+descriptor_id  descriptor_name  index_id  dependedonby_id  dependedonby_type  dependedonby_index_id  dependedonby_name  dependedonby_details
+65             kv               NULL      66               view               0                      NULL               Columns: [1 2 3]

--- a/pkg/sql/opt_decompose_test.go
+++ b/pkg/sql/opt_decompose_test.go
@@ -62,7 +62,7 @@ func testTableDesc() *sqlbase.TableDescriptor {
 
 func makeSelectNode(t *testing.T, p *planner) *renderNode {
 	desc := testTableDesc()
-	sel := testInitDummySelectNode(p, desc)
+	sel := testInitDummySelectNode(t, p, desc)
 	if err := desc.AllocateIDs(); err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/sql/opt_index_selection.go
+++ b/pkg/sql/opt_index_selection.go
@@ -240,7 +240,10 @@ func (p *planner) selectIndex(
 		// Note: makeIndexJoin destroys s and returns a new index scan
 		// node. The filter in that node may be different from the
 		// original table filter.
-		plan, s = p.makeIndexJoin(s, c.exactPrefix)
+		plan, s, err = p.makeIndexJoin(s, c.exactPrefix)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	if log.V(3) {

--- a/pkg/sql/scan.go
+++ b/pkg/sql/scan.go
@@ -422,7 +422,9 @@ func (n *scanNode) initDescDefaults(planDeps planDependencies, colCfg scanColumn
 		n.colIdxMap[c.ID] = i
 	}
 	n.valNeededForCol = util.FastIntSet{}
-	n.valNeededForCol.AddRange(0, len(n.cols)-1)
+	if len(n.cols) > 0 {
+		n.valNeededForCol.AddRange(0, len(n.cols)-1)
+	}
 	n.run.row = make([]tree.Datum, len(n.cols))
 	n.filterVars = tree.MakeIndexedVarHelper(n, len(n.cols))
 	return nil

--- a/pkg/sql/scrub_physical.go
+++ b/pkg/sql/scrub_physical.go
@@ -109,9 +109,8 @@ func (o *physicalCheckOperation) Start(params runParams) error {
 	}
 	scan := params.p.Scan()
 	scan.run.isCheck = true
-	if err := scan.initTable(
-		ctx, params.p, o.tableDesc, indexHints, publicColumns, columnIDs,
-	); err != nil {
+	colCfg := scanColumnsConfig{wantedColumns: columnIDs, addUnwantedAsHidden: true}
+	if err := scan.initTable(ctx, params.p, o.tableDesc, indexHints, colCfg); err != nil {
 		return err
 	}
 	plan := planNode(scan)

--- a/pkg/sql/select_name_resolution_test.go
+++ b/pkg/sql/select_name_resolution_test.go
@@ -23,11 +23,12 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 )
 
-func testInitDummySelectNode(p *planner, desc *sqlbase.TableDescriptor) *renderNode {
+func testInitDummySelectNode(t *testing.T, p *planner, desc *sqlbase.TableDescriptor) *renderNode {
 	scan := &scanNode{}
 	scan.desc = desc
-	// Note: scan.initDescDefaults only returns an error if its 2nd argument is not nil.
-	_ = scan.initDescDefaults(p.curPlan.deps, publicColumns, nil)
+	if err := scan.initDescDefaults(p.curPlan.deps, publicColumnsCfg); err != nil {
+		t.Fatal(err)
+	}
 
 	sel := &renderNode{}
 	sel.source.plan = scan
@@ -52,7 +53,7 @@ func TestRetryResolveNames(t *testing.T) {
 
 	desc := testTableDesc()
 	p := makeTestPlanner()
-	s := testInitDummySelectNode(p, desc)
+	s := testInitDummySelectNode(t, p, desc)
 	if err := desc.AllocateIDs(); err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This picks the first two bug-fixing commits from #23797.

cc @cockroachdb/release 