### PR TITLE
backport-2.0: sql/jobs: improve logic during context cancelation

### DIFF
--- a/pkg/base/testing_knobs.go
+++ b/pkg/base/testing_knobs.go
@@ -31,4 +31,5 @@ type TestingKnobs struct {
 	SQLMigrationManager ModuleTestingKnobs
 	DistSQL             ModuleTestingKnobs
 	SQLEvalContext      ModuleTestingKnobs
+	RegistryLiveness    ModuleTestingKnobs
 }

--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -1028,6 +1028,101 @@ func TestBackupRestoreControlJob(t *testing.T) {
 	})
 }
 
+// TestImportLiveness tests that a node liveness increment during IMPORT
+// correctly resumes.
+//
+// Its actual purpose is to address the second bug listed in #22924 about
+// the addsstable arguments not in request range. The theory was that the
+// restart in that issue was caused by node liveness and that the work
+// already performed (the splits and addsstables) somehow caused the second
+// error. However this does not appear to be the case, as running many stress
+// iterations with differing constants (rows, sstsize, kv.import.batch_size)
+// was not able to fail in the way listed by the second bug.
+func TestImportLiveness(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	defer func(oldInterval time.Duration) {
+		jobs.DefaultAdoptInterval = oldInterval
+	}(jobs.DefaultAdoptInterval)
+	jobs.DefaultAdoptInterval = 100 * time.Millisecond
+	jobs.DefaultCancelInterval = 100 * time.Millisecond
+
+	const nodes = 1
+	nl := jobs.NewFakeNodeLiveness(nodes)
+	serverArgs := base.TestServerArgs{
+		Knobs: base.TestingKnobs{
+			RegistryLiveness: nl,
+		},
+	}
+
+	var allowResponse chan struct{}
+	params := base.TestClusterArgs{ServerArgs: serverArgs}
+	params.ServerArgs.Knobs.Store = &storage.StoreTestingKnobs{
+		TestingResponseFilter: func(ba roachpb.BatchRequest, br *roachpb.BatchResponse) *roachpb.Error {
+			for _, res := range br.Responses {
+				if res.Export != nil || res.Import != nil || res.AddSstable != nil {
+					<-allowResponse
+				}
+			}
+			return nil
+		},
+	}
+
+	ctx := context.Background()
+	tc := testcluster.StartTestCluster(t, nodes, params)
+	defer tc.Stopper().Stop(ctx)
+	sqlDB := sqlutils.MakeSQLRunner(tc.Conns[0])
+
+	// Prevent hung HTTP connections in leaktest.
+	sqlDB.Exec(t, `SET CLUSTER SETTING cloudstorage.timeout = '3s'`)
+
+	sqlDB.Exec(t, `SET CLUSTER SETTING kv.import.batch_size = '300B'`)
+	sqlDB.Exec(t, `CREATE DATABASE liveness`)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		const rows = 100
+		if r.Method == "GET" {
+			for i := 0; i < rows; i++ {
+				fmt.Fprintln(w, i)
+			}
+		}
+	}))
+	defer srv.Close()
+
+	const query = `IMPORT TABLE liveness.t (i INT PRIMARY KEY) CSV DATA ($1) WITH sstsize = '50B'`
+
+	// Start an IMPORT and wait until it's done one addsstable.
+	allowResponse = make(chan struct{})
+	errCh := make(chan error)
+	go func() {
+		_, err := sqlDB.DB.Exec(query, srv.URL)
+		errCh <- err
+	}()
+	select {
+	case allowResponse <- struct{}{}:
+	case err := <-errCh:
+		t.Fatal(err)
+	}
+	// Fetch the new job ID since we know it's running now.
+	var jobID int64
+	sqlDB.QueryRow(t, `SELECT id FROM system.jobs ORDER BY created DESC LIMIT 1`).Scan(&jobID)
+
+	// addsstable is done, now tick liveness and wait for it to cancel the import.
+	nl.FakeIncrementEpoch(1)
+	// Wait for the registry cancel loop to run and cancel the job.
+	<-nl.SelfCalledCh
+	<-nl.SelfCalledCh
+	close(allowResponse)
+	err := <-errCh
+	if !testutils.IsError(err, "job .*: node liveness error") {
+		t.Fatalf("unexpected: %v", err)
+	}
+	// The registry should now adopt the job and resume it.
+	if err := waitForJob(sqlDB.DB, jobID); err != nil {
+		t.Fatal(err)
+	}
+}
+
 // TestRestoreFailCleanup tests that a failed RESTORE is cleaned up.
 func TestRestoreFailCleanup(t *testing.T) {
 	defer leaktest.AfterTest(t)()

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1238,10 +1238,16 @@ If problems persist, please see ` + base.DocsURL("cluster-setup-troubleshooting.
 		}
 	})
 
-	if err := s.jobRegistry.Start(
-		ctx, s.stopper, s.nodeLiveness, jobs.DefaultCancelInterval, jobs.DefaultAdoptInterval,
-	); err != nil {
-		return err
+	{
+		var regLiveness jobs.NodeLiveness = s.nodeLiveness
+		if testingLiveness := s.cfg.TestingKnobs.RegistryLiveness; testingLiveness != nil {
+			regLiveness = testingLiveness.(*jobs.FakeNodeLiveness)
+		}
+		if err := s.jobRegistry.Start(
+			ctx, s.stopper, regLiveness, jobs.DefaultCancelInterval, jobs.DefaultAdoptInterval,
+		); err != nil {
+			return err
+		}
 	}
 
 	// Before serving SQL requests, we have to make sure the database is

--- a/pkg/sql/jobs/helpers.go
+++ b/pkg/sql/jobs/helpers.go
@@ -1,0 +1,108 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package jobs
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/storage"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+)
+
+// FakeNodeID is a dummy node ID for use in tests. It always stores 1.
+var FakeNodeID = func() *base.NodeIDContainer {
+	nodeID := base.NodeIDContainer{}
+	nodeID.Reset(1)
+	return &nodeID
+}()
+
+// FakeNodeLiveness allows simulating liveness failures without the full
+// storage.NodeLiveness machinery.
+type FakeNodeLiveness struct {
+	mu struct {
+		syncutil.Mutex
+		livenessMap map[roachpb.NodeID]*storage.Liveness
+	}
+
+	// A non-blocking send is performed over these channels when the corresponding
+	// method is called.
+	SelfCalledCh          chan struct{}
+	GetLivenessesCalledCh chan struct{}
+}
+
+// NewFakeNodeLiveness initializes a new NodeLiveness with nodeCount live nodes.
+func NewFakeNodeLiveness(nodeCount int) *FakeNodeLiveness {
+	nl := &FakeNodeLiveness{
+		SelfCalledCh:          make(chan struct{}),
+		GetLivenessesCalledCh: make(chan struct{}),
+	}
+	nl.mu.livenessMap = make(map[roachpb.NodeID]*storage.Liveness)
+	for i := 0; i < nodeCount; i++ {
+		nodeID := roachpb.NodeID(i + 1)
+		nl.mu.livenessMap[nodeID] = &storage.Liveness{
+			Epoch:      1,
+			Expiration: hlc.LegacyTimestamp(hlc.MaxTimestamp),
+			NodeID:     nodeID,
+		}
+	}
+	return nl
+}
+
+// ModuleTestingKnobs implements base.ModuleTestingKnobs.
+func (*FakeNodeLiveness) ModuleTestingKnobs() {}
+
+// Self implements the implicit storage.NodeLiveness interface. It uses NodeID
+// as the node ID. On every call, a nonblocking send is performed over nl.ch to
+// allow tests to execute a callback.
+func (nl *FakeNodeLiveness) Self() (*storage.Liveness, error) {
+	select {
+	case nl.SelfCalledCh <- struct{}{}:
+	default:
+	}
+	nl.mu.Lock()
+	defer nl.mu.Unlock()
+	selfCopy := *nl.mu.livenessMap[FakeNodeID.Get()]
+	return &selfCopy, nil
+}
+
+// GetLivenesses implements the implicit storage.NodeLiveness interface.
+func (nl *FakeNodeLiveness) GetLivenesses() (out []storage.Liveness) {
+	select {
+	case nl.GetLivenessesCalledCh <- struct{}{}:
+	default:
+	}
+	nl.mu.Lock()
+	defer nl.mu.Unlock()
+	for _, liveness := range nl.mu.livenessMap {
+		out = append(out, *liveness)
+	}
+	return out
+}
+
+// FakeIncrementEpoch increments the epoch for the node with the specified ID.
+func (nl *FakeNodeLiveness) FakeIncrementEpoch(id roachpb.NodeID) {
+	nl.mu.Lock()
+	defer nl.mu.Unlock()
+	nl.mu.livenessMap[id].Epoch++
+}
+
+// FakeSetExpiration sets the expiration time of the liveness for the node with
+// the specified ID to ts.
+func (nl *FakeNodeLiveness) FakeSetExpiration(id roachpb.NodeID, ts hlc.Timestamp) {
+	nl.mu.Lock()
+	defer nl.mu.Unlock()
+	nl.mu.livenessMap[id].Expiration = hlc.LegacyTimestamp(ts)
+}

--- a/pkg/sql/jobs/helpers_test.go
+++ b/pkg/sql/jobs/helpers_test.go
@@ -17,102 +17,13 @@ package jobs
 import (
 	"context"
 
-	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
-	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
-	"github.com/cockroachdb/cockroach/pkg/storage"
-	"github.com/cockroachdb/cockroach/pkg/util/hlc"
-	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 )
 
 func ResetResumeHooks() func() {
 	oldResumeHooks := resumeHooks
 	return func() { resumeHooks = oldResumeHooks }
-}
-
-// FakeNodeID is a dummy node ID for use in tests. It always stores 1.
-var FakeNodeID = func() *base.NodeIDContainer {
-	nodeID := base.NodeIDContainer{}
-	nodeID.Reset(1)
-	return &nodeID
-}()
-
-// FakeNodeLiveness allows simulating liveness failures without the full
-// storage.NodeLiveness machinery.
-type FakeNodeLiveness struct {
-	clock *hlc.Clock
-	mu    struct {
-		syncutil.Mutex
-		livenessMap map[roachpb.NodeID]*storage.Liveness
-	}
-
-	// A non-blocking send is performed over these channels when the corresponding
-	// method is called.
-	SelfCalledCh          chan struct{}
-	GetLivenessesCalledCh chan struct{}
-}
-
-// NewFakeNodeLiveness initializes a new NodeLiveness with nodeCount live nodes.
-func NewFakeNodeLiveness(clock *hlc.Clock, nodeCount int) *FakeNodeLiveness {
-	nl := &FakeNodeLiveness{
-		clock:                 clock,
-		SelfCalledCh:          make(chan struct{}),
-		GetLivenessesCalledCh: make(chan struct{}),
-	}
-	nl.mu.livenessMap = make(map[roachpb.NodeID]*storage.Liveness)
-	for i := 0; i < nodeCount; i++ {
-		nodeID := roachpb.NodeID(i + 1)
-		nl.mu.livenessMap[nodeID] = &storage.Liveness{
-			Epoch:      1,
-			Expiration: hlc.LegacyTimestamp(hlc.MaxTimestamp),
-			NodeID:     nodeID,
-		}
-	}
-	return nl
-}
-
-// Self implements the implicit storage.NodeLiveness interface. It uses NodeID
-// as the node ID. On every call, a nonblocking send is performed over nl.ch to
-// allow tests to execute a callback.
-func (nl *FakeNodeLiveness) Self() (*storage.Liveness, error) {
-	select {
-	case nl.SelfCalledCh <- struct{}{}:
-	default:
-	}
-	nl.mu.Lock()
-	defer nl.mu.Unlock()
-	selfCopy := *nl.mu.livenessMap[FakeNodeID.Get()]
-	return &selfCopy, nil
-}
-
-// GetLivenesses implements the implicit storage.NodeLiveness interface.
-func (nl *FakeNodeLiveness) GetLivenesses() (out []storage.Liveness) {
-	select {
-	case nl.GetLivenessesCalledCh <- struct{}{}:
-	default:
-	}
-	nl.mu.Lock()
-	defer nl.mu.Unlock()
-	for _, liveness := range nl.mu.livenessMap {
-		out = append(out, *liveness)
-	}
-	return out
-}
-
-// FakeIncrementEpoch increments the epoch for the node with the specified ID.
-func (nl *FakeNodeLiveness) FakeIncrementEpoch(id roachpb.NodeID) {
-	nl.mu.Lock()
-	defer nl.mu.Unlock()
-	nl.mu.livenessMap[id].Epoch++
-}
-
-// FakeSetExpiration sets the expiration time of the liveness for the node with
-// the specified ID to ts.
-func (nl *FakeNodeLiveness) FakeSetExpiration(id roachpb.NodeID, ts hlc.Timestamp) {
-	nl.mu.Lock()
-	defer nl.mu.Unlock()
-	nl.mu.livenessMap[id].Expiration = hlc.LegacyTimestamp(ts)
 }
 
 // FakeResumer calls optional callbacks during the job lifecycle.

--- a/pkg/sql/jobs/registry_external_test.go
+++ b/pkg/sql/jobs/registry_external_test.go
@@ -78,7 +78,7 @@ func TestRegistryResumeExpiredLease(t *testing.T) {
 	db := s.DB()
 	ex := &sql.InternalExecutor{ExecCfg: s.InternalExecutor().(*sql.InternalExecutor).ExecCfg}
 	clock := hlc.NewClock(hlc.UnixNano, time.Nanosecond)
-	nodeLiveness := jobs.NewFakeNodeLiveness(clock, 4)
+	nodeLiveness := jobs.NewFakeNodeLiveness(4)
 	newRegistry := func(id roachpb.NodeID) *jobs.Registry {
 		const cancelInterval = time.Duration(math.MaxInt64)
 		const adoptInterval = time.Nanosecond

--- a/pkg/sql/jobs/registry_test.go
+++ b/pkg/sql/jobs/registry_test.go
@@ -46,7 +46,7 @@ func TestRegistryCancelation(t *testing.T) {
 	registry := MakeRegistry(log.AmbientContext{}, clock, db, ex, FakeNodeID, cluster.NoSettings, FakePHS)
 
 	const nodeCount = 1
-	nodeLiveness := NewFakeNodeLiveness(clock, nodeCount)
+	nodeLiveness := NewFakeNodeLiveness(nodeCount)
 
 	const cancelInterval = time.Nanosecond
 	const adoptInterval = time.Duration(math.MaxInt64)


### PR DESCRIPTION
Add a testing knob for the job registry node liveness. Remove an
unused argument from FakeNodeLiveness.

Add a node liveness test in backupccl to verify import handles liveness
blips as expected. This includes a failed attempt to reproduce a bug.

Release note: None