### PR TITLE
storage/keys: improve documentation around Meta1KeyMax special-case

### DIFF
--- a/c-deps/libroach/keys.h
+++ b/c-deps/libroach/keys.h
@@ -11,6 +11,7 @@ const rocksdb::Slice kMeta2KeyMax("\x03\xff\xff", 3);
 const std::vector<std::pair<rocksdb::Slice, rocksdb::Slice> > kSortedNoSplitSpans = {
   std::make_pair(rocksdb::Slice("\x88", 1), rocksdb::Slice("\x93", 1)),
   std::make_pair(rocksdb::Slice("\x04\x00\x6c\x69\x76\x65\x6e\x65\x73\x73\x2d", 11), rocksdb::Slice("\x04\x00\x6c\x69\x76\x65\x6e\x65\x73\x73\x2e", 11)),
+  std::make_pair(rocksdb::Slice("\x03\xff\xff", 3), rocksdb::Slice("\x04", 1)),
   std::make_pair(rocksdb::Slice("", 0), rocksdb::Slice("\x03", 1)),
 };
 const std::vector<std::pair<rocksdb::Slice, rocksdb::Slice> > kSortedNoSplitSpansWithoutMeta2Splits = {

--- a/pkg/keys/spans.go
+++ b/pkg/keys/spans.go
@@ -19,8 +19,20 @@ import "github.com/cockroachdb/cockroach/pkg/roachpb"
 //go:generate go run gen_cpp_keys.go
 
 var (
-	// Meta1Span holds all first level addressing.
+	// Meta1Span holds all first level addressing records.
 	Meta1Span = roachpb.Span{Key: roachpb.KeyMin, EndKey: Meta2Prefix}
+
+	// Meta2MaxSpan begins at key Meta2KeyMax with the last entry in the second
+	// level addressing keyspace. The rest of the span is always empty. We cannot
+	// split at this starting key or between it and MetaMax.
+	// - The first condition is explained and enforced in libroach/mvcc.cc.
+	// - The second condition is necessary because a split between Meta2KeyMax
+	//   and MetaMax would conflict with the use of Meta1KeyMax to hold the
+	//   descriptor for the range that spans the meta2/userspace boundary (see
+	//   case 3a in rangeAddressing). If splits were allowed in this span then
+	//   the descriptor for the ranges ending in this span would be stored AFTER
+	//   Meta1KeyMax, which would allow meta1 to get out of order.
+	Meta2MaxSpan = roachpb.Span{Key: Meta2KeyMax, EndKey: MetaMax}
 
 	// MetaSpan holds all the addressing records.
 	MetaSpan = roachpb.Span{Key: roachpb.KeyMin, EndKey: MetaMax}
@@ -33,9 +45,10 @@ var (
 
 	// NoSplitSpans describes the ranges that should never be split.
 	// Meta1Span: needed to find other ranges.
+	// Meta2MaxSpan: between meta and system ranges.
 	// NodeLivenessSpan: liveness information on nodes in the cluster.
 	// SystemConfigSpan: system objects which will be gossiped.
-	NoSplitSpans = []roachpb.Span{Meta1Span, NodeLivenessSpan, SystemConfigSpan}
+	NoSplitSpans = []roachpb.Span{Meta1Span, Meta2MaxSpan, NodeLivenessSpan, SystemConfigSpan}
 
 	// NoSplitSpansWithoutMeta2Splits describes the ranges that were never
 	// to be split before we supported meta2 splits.

--- a/pkg/kv/range_cache_test.go
+++ b/pkg/kv/range_cache_test.go
@@ -964,11 +964,11 @@ func TestRangeCacheEvictMetaDescriptors(t *testing.T) {
 	}
 	meta2RightDesc := roachpb.RangeDescriptor{
 		StartKey: meta2LeftDesc.EndKey,
-		EndKey:   keys.MustAddr(keys.Meta2KeyMax.Next()),
+		EndKey:   keys.RangeMetaKey(roachpb.RKey("zzz")).Next(),
 	}
 	restDesc := roachpb.RangeDescriptor{
 		StartKey: meta2RightDesc.EndKey,
-		EndKey:   roachpb.RKeyMax,
+		EndKey:   roachpb.RKey("zzz"),
 	}
 
 	testCases := []struct {

--- a/pkg/storage/client_split_test.go
+++ b/pkg/storage/client_split_test.go
@@ -85,6 +85,7 @@ func TestStoreRangeSplitAtIllegalKeys(t *testing.T) {
 		testutils.MakeKey(keys.Meta1Prefix, []byte("a")),
 		testutils.MakeKey(keys.Meta1Prefix, roachpb.RKeyMax),
 		keys.Meta2KeyMax,
+		testutils.MakeKey(keys.Meta2KeyMax, []byte("a")),
 		keys.MakeTablePrefix(10 /* system descriptor ID */),
 	} {
 		args := adminSplitArgs(key)


### PR DESCRIPTION
Closes #18998.

The concern about 3 levels of descriptor indirection raised in #18998
was a result of me not understanding how we store range descriptors
for ranges that span meta2 and userspace keys. It turns out that
starting all the way back in #134 we began writing *two* meta records
for ranges that span the meta2 and userspace keys. This allows us
to avoid the indirection issue because it ensures that
`[Meta1Prefix,Meta1KeyMax]` contains descriptors spanning the entire
meta2 range. This change improves the documentation describing this
subtle special-case.

The change also correct the explanation about why we can't allow
splits at `Meta2KeyMax`. If we were to allow splits at this key,
the role of `Meta1KeyMax` would be overloaded and we would end up
overwriting range descriptors, preventing range lookups from working
properly. This was fixed in #1206, but had never been properly
documented.

Release note: None