### PR TITLE
workloadccl: don't require database to exist during `fixtures make`

### DIFF
--- a/pkg/ccl/workloadccl/fixture.go
+++ b/pkg/ccl/workloadccl/fixture.go
@@ -339,7 +339,9 @@ func MakeFixture(
 				startRow, endRow := 0, table.InitialRowCount
 				return c.groupWriteCSVs(gCtx, tableCSVPathsCh, table, startRow, endRow)
 			}
-			const numNodesQuery = `SELECT COUNT(node_id) FROM crdb_internal.gossip_liveness`
+			// Specify an explicit empty prefix for crdb_internal to avoid an error if
+			// the database we're connected to does not exist.
+			const numNodesQuery = `SELECT COUNT(node_id) FROM "".crdb_internal.gossip_liveness`
 			var numNodes int
 			if err := sqlDB.QueryRow(numNodesQuery).Scan(&numNodes); err != nil {
 				return err


### PR DESCRIPTION
Release note: None