### PR TITLE
cherry-pick-2.0: ui: A collection of fixes for the network debugging page

### DIFF
--- a/pkg/ui/src/views/reports/components/nodeFilterList/index.tsx
+++ b/pkg/ui/src/views/reports/components/nodeFilterList/index.tsx
@@ -4,7 +4,7 @@ import React from "react";
 
 import * as protos from "src/js/protos";
 
-interface NodeFilterListProps {
+export interface NodeFilterListProps {
   nodeIDs?: Set<number>;
   localityRegex?: RegExp;
 }

--- a/pkg/ui/src/views/reports/containers/network/index.tsx
+++ b/pkg/ui/src/views/reports/containers/network/index.tsx
@@ -443,8 +443,10 @@ class Network extends React.Component<NetworkProps, {}> {
           className="loading-image loading-image__spinner-left loading-image__spinner-left__padded"
           image={spinner}
         >
-          <NodeFilterList nodeIDs={filters.nodeIDs} localityRegex={filters.localityRegex} />
-          {this.renderContent(nodesSummary, filters)}
+          <div>
+            <NodeFilterList nodeIDs={filters.nodeIDs} localityRegex={filters.localityRegex} />
+            {this.renderContent(nodesSummary, filters)}
+          </div>
         </Loading>
       </div>
     );

--- a/pkg/ui/src/views/shared/components/loading/index.tsx
+++ b/pkg/ui/src/views/shared/components/loading/index.tsx
@@ -18,5 +18,13 @@ export default function Loading(props: LoadingProps) {
   if (props.loading) {
     return <div className={props.className} style={image} />;
   }
-  return props.children as JSX.Element;
+  // The wrapper <div> in the return clause is required so that this component
+  // can take a list of elements instead of only a single one.
+  // This is fixed in react 16, see:
+  // https://reactjs.org/blog/2017/11/28/react-v16.2.0-fragment-support.html
+  return (
+    <div>
+      {props.children}
+    </div>
+  );
 }

--- a/pkg/ui/src/views/shared/components/loading/index.tsx
+++ b/pkg/ui/src/views/shared/components/loading/index.tsx
@@ -18,13 +18,12 @@ export default function Loading(props: LoadingProps) {
   if (props.loading) {
     return <div className={props.className} style={image} />;
   }
-  // The wrapper <div> in the return clause is required so that this component
-  // can take a list of elements instead of only a single one.
-  // This is fixed in react 16, see:
-  // https://reactjs.org/blog/2017/11/28/react-v16.2.0-fragment-support.html
-  return (
-    <div>
-      {props.children}
-    </div>
-  );
+
+  // This throws an error if more than one child is passed.
+  // Unfortunately the error seems to get eaten by some try/catch
+  // above this, but leaving it here to at least signal intent.
+  // Also unfortunately it's unclear how to enforce this invariant
+  // with the type system, since the `children` argument matches
+  // both one node and multiple nodes.
+  return React.Children.only(props.children);
 }

--- a/pkg/ui/styl/layout/layout.styl
+++ b/pkg/ui/styl/layout/layout.styl
@@ -179,3 +179,6 @@ div.raft-filters
     background-size 40px 40px
     min-height 40px
     width 400px
+
+    &__padded
+      padding-top 100px


### PR DESCRIPTION
cherry-pick of #23844

---

- Fix the case in which longs had no value during calculation causing the page
to not load.
- Fix latency page to only display when there is at least 2 nodes worth of
latencies to display.
- Add a loading spinner to the network diagnostics page.
- Fix the loading spinner to accept an array of children instead of just a
single child element.
- Add a new top padded style so the loading spinner is not so cramped on the
page.
- Fix a crash when a new node doesn't yet have any activity.
- Replace all not yet calculated latencies with a `?`.
- Don't display a legend if there is only one value (and hence no stddev).

Fixes #23552.

Release note (admin ui change): The network diagnositcs report will no longer
crash when the latencies are very small or on a single node cluster.