### PR TITLE
storage: lower the raft-log queue timer from 50ms to 0ms

### DIFF
--- a/pkg/storage/raft_log_queue.go
+++ b/pkg/storage/raft_log_queue.go
@@ -32,10 +32,8 @@ import (
 )
 
 const (
-	// RaftLogQueueTimerDuration is the duration between truncations. This needs
-	// to be relatively short so that truncations can keep up with raft log entry
-	// creation.
-	RaftLogQueueTimerDuration = 50 * time.Millisecond
+	// raftLogQueueTimerDuration is the duration between truncations.
+	raftLogQueueTimerDuration = 0 // zero duration to process truncations greedily
 	// RaftLogQueueStaleThreshold is the minimum threshold for stale raft log
 	// entries. A stale entry is one which all replicas of the range have
 	// progressed past and thus is no longer needed and can be truncated.
@@ -273,7 +271,7 @@ func (rlq *raftLogQueue) process(ctx context.Context, r *Replica, _ config.Syste
 
 // timer returns interval between processing successive queued truncations.
 func (*raftLogQueue) timer(_ time.Duration) time.Duration {
-	return RaftLogQueueTimerDuration
+	return raftLogQueueTimerDuration
 }
 
 // purgatoryChan returns nil.


### PR DESCRIPTION
Lower the raft-log queue timer from 50ms to 0ms. This timer was forcing
an artificial delay between raft-log truncation operations which was in
turn allowing the raft-log to grow undesirably long in cluster overload
situations. When the raft-log for a range grows to large, the eventual
truncation operation can then take a prohibitively long time which leads
to a downward spiral of performance, oftentimes resulting in Raft
snapshots (which are significantly more expensive) and even further
performance degradation. There are no downsides to a zero duration
between raft-log truncations as there are other mechanisms in place to
avoid performing truncations unless they are necessary (e.g. tracking of
the raft-log size and the number of entries).

Release note (performance improvement): Improve cluster performance
during overload scenarios.