### PR TITLE
cherrypick-2.0: ts: Fix "dip" at end of downsampled queries

### DIFF
--- a/pkg/storage/ts_maintenance_queue_test.go
+++ b/pkg/storage/ts_maintenance_queue_test.go
@@ -237,7 +237,10 @@ func TestTimeSeriesMaintenanceQueueServer(t *testing.T) {
 	// periods; this simplifies verification.
 	seriesName := "test.metric"
 	sourceName := "source1"
-	now := tsrv.Clock().PhysicalNow()
+	// "now" is five minutes in the past to avoid any sort of shenanigans with the
+	// various adjustments we make in the very-recent-past to create consistent
+	// graphs.
+	now := tsrv.Clock().PhysicalNow() - int64(5*time.Minute)
 	nearPast := now - (tsdb.PruneThreshold(ts.Resolution10s) * 2)
 	farPast := now - (tsdb.PruneThreshold(ts.Resolution10s) * 4)
 	sampleDuration := ts.Resolution10s.SampleDuration()


### PR DESCRIPTION
Due to the curiosities of downsampling, it is possible for a query to
show a persistent "dip" for the most recent datapoint. This occurs for
downsampled datapoints which are incomplete.

For example, when querying the last hour of data, the UI downsamples to
a resolution where each data point represents 30 seconds of time. In
practical usage, this means each returned point is calculated from 3
underlying 10-second resolution samples queried from the database.
However, the most recent datapoint may be only partially complete; that
is, perhaps only 1 or 2 of the datapoints have yet been collected. In
some graphs, especially those which show rates, this can result in the
appearance of a "dip" when graphing the data.

The fix involves two adjustments:

+ Disallow queries in the future. There are no current use cases for
queries in the future, but it was not previously disallowed
specifically.
+ If the end of the query range is near the current time, we "normalize"
the end timestamp to exclude the most recent data period which may be
incomplete.

Resolves #13537

Release note: Fixed a condition where a persistent trailing dip could
appear in graphs for longer time periods.