### PR TITLE
backport-2.0: ui: Auto-zoom map to fit visible content

### DIFF
--- a/pkg/ui/ccl/src/views/clusterviz/containers/map/mapLayout.tsx
+++ b/pkg/ui/ccl/src/views/clusterviz/containers/map/mapLayout.tsx
@@ -9,8 +9,8 @@
 import _ from "lodash";
 import * as d3 from "d3";
 import React from "react";
-import { createSelector } from "reselect";
 
+import * as protos from "src/js/protos";
 import { LocalityTree } from "src/redux/localities";
 import { LocationTree } from "src/redux/locations";
 import { getChildLocalities } from "src/util/localities";
@@ -31,14 +31,9 @@ interface MapLayoutProps {
   viewportSize: [number, number];
 }
 
-interface LocalityLocation {
-  locality: LocalityTree;
-  location: any;
-}
-
 interface MapLayoutState {
   zoomTransform: ZoomTransformer;
-  prevLocalityLocations: LocalityLocation[];
+  prevLocations: protos.cockroach.server.serverpb.LocationsResponse.Location$Properties[];
 }
 
 export class MapLayout extends React.Component<MapLayoutProps, MapLayoutState> {
@@ -46,26 +41,8 @@ export class MapLayout extends React.Component<MapLayoutProps, MapLayoutState> {
   zoom: d3.behavior.Zoom<any>;
   maxLatitude = 80;
 
-  localityLocations = createSelector(
-    (props: MapLayoutProps) => props.localityTree,
-    (props: MapLayoutProps) => props.locationTree,
-    (localityTree, locationTree) => {
-      return _.map(getChildLocalities(localityTree), locality => {
-        const location = findOrCalculateLocation(locationTree, locality);
-        return {
-          locality,
-          location,
-        };
-      });
-    },
-  );
-
   constructor(props: MapLayoutProps) {
     super(props);
-
-    // Create a new zoom behavior and apply it to the svg element.
-    this.zoom = d3.behavior.zoom()
-      .on("zoom", this.onZoom);
 
     // Compute zoomable area bounds based on the default mercator projection.
     const projection = d3.geo.mercator();
@@ -78,80 +55,109 @@ export class MapLayout extends React.Component<MapLayoutProps, MapLayoutState> {
       botRight[1] - topLeft[1],
     );
 
-    // Set initial zoom state.
     const zoomTransform = new ZoomTransformer(bounds, props.viewportSize);
-    this.updateZoomState(zoomTransform);
     this.state = {
       zoomTransform,
-      prevLocalityLocations: [],
+      prevLocations: [],
     };
+
+    // Create a new zoom behavior and apply it to the svg element.
+    this.zoom = d3.behavior.zoom()
+      .on("zoom", this.onZoom);
+
+    // Set initial zoom state.
+    this.updateZoom(zoomTransform);
   }
 
-  updateZoomState(zt: ZoomTransformer) {
+  // updateZoom programmatically requests zoom transition to the target
+  // specified by the provided ZoomTransformer. If 'animate' is true, this
+  // transition is animated; otherwise, the transition is instant. Note that the
+  // non-animated updates must still go through a d3 transition of 0 duration,
+  // or else the next animated zoom will not have the correct initial state - it
+  // establishes the starting point of future animations.
+  //
+  // During the transition, d3 will repeatedly call the 'onZoom' method with the
+  // appropriate translations for the animation; that is the point where this
+  // component will actually be re-rendered.
+  updateZoom(zt: ZoomTransformer, animate = false) {
     const minScale = zt.minScale();
 
-    // Update both the d3 zoom behavior and the local state.
     this.zoom
       .scaleExtent([minScale, minScale * 10])
-      .size(zt.viewportSize())
-      .scale(zt.scale())
-      .translate(zt.translate());
+      .size(zt.viewportSize());
+
+    // Update both the d3 zoom behavior and the local state.
+    d3.select(this.gEl)
+      .transition()
+      .duration(animate ? 750 : 0)
+      .call(this.zoom
+        .scale(zt.scale())
+        .translate(zt.translate())
+        .event);
   }
 
+  // onZoom is called by d3 whenever the zoom needs to be updated. We apply
+  // the translations from d3 to our react-land zoomTransform state, causing
+  // the component to re-render with the new zoom.
   onZoom = () => {
     const zoomTransform = this.state.zoomTransform.withScaleAndTranslate(
       this.zoom.scale(), this.zoom.translate(),
     );
-    this.updateZoomState(zoomTransform);
     this.setState({ zoomTransform });
   }
 
   // rezoomToLocalities is called to properly re-zoom the map to display all
-  // localities.
-  rezoomToLocalities() {
-    const { prevLocalityLocations } = this.state;
-    const localityLocations = this.localityLocations(this.props);
+  // localities. Should be supplied with the current ZoomTransformer setting.
+  rezoomToLocalities(zoomTransform: ZoomTransformer) {
+    const { prevLocations } = this.state;
+    const { localityTree, locationTree } = this.props;
+    const locations = _.map(
+      getChildLocalities(localityTree), l => findOrCalculateLocation(locationTree, l),
+    );
 
-    // Deep comparison to previous locality set. If anything has changed, this
-    // indicates that the user has navigated to a different level of the
+    // Deep comparison to previous location set. If any locations have changed,
+    // this indicates that the user has navigated to a different level of the
     // locality tree OR that new data has been added to the currently visible
     // locality.
-    if (_.isEqual(localityLocations, prevLocalityLocations)) {
+    if (_.isEqual(locations, prevLocations)) {
       return;
     }
 
+    // Compute a new zoom based on the new set of localities.
     const projection = d3.geo.mercator();
-    const boxes = localityLocations.map(localityLocation => {
-      const { location } = localityLocation;
+    const boxes = locations.map(location => {
       const center = projection([location.longitude, location.latitude]);
 
-      // Create a 100 unit box centered on each locality. This is an arbitrary
-      // size in order to reserve enough space to display each locality.
+      // Create a 100 unit box centered on each mapped location. This is an
+      // arbitrary size in order to reserve enough space to display each
+      // location.
       return new Box(center[0] - 50, center[1] - 50, 100, 100);
     });
-    const zoomTransform = this.state.zoomTransform.zoomedToBox(Box.boundingBox(...boxes));
-    this.updateZoomState(zoomTransform);
+    zoomTransform = zoomTransform.zoomedToBox(Box.boundingBox(...boxes));
     this.setState({
-      zoomTransform,
-      prevLocalityLocations: localityLocations,
+      prevLocations: locations,
     });
+
+    this.updateZoom(zoomTransform, !_.isEmpty(prevLocations));
   }
 
   componentDidMount() {
     d3.select(this.gEl).call(this.zoom);
-    this.rezoomToLocalities();
+    this.rezoomToLocalities(this.state.zoomTransform);
   }
 
   componentWillReceiveProps(props: MapLayoutProps) {
     const zoomTransform = this.state.zoomTransform.withViewportSize(props.viewportSize);
-    this.updateZoomState(zoomTransform);
-    this.setState({ zoomTransform });
-    this.rezoomToLocalities();
+    this.setState({
+      zoomTransform,
+    });
+    this.rezoomToLocalities(zoomTransform);
   }
 
   renderChildLocalities(projection: d3.geo.Projection) {
-    return this.localityLocations(this.props).map((localityLocation) => {
-      const { locality, location } = localityLocation;
+    const { localityTree, locationTree } = this.props;
+    return _.map(getChildLocalities(localityTree), locality => {
+      const location = findOrCalculateLocation(locationTree, locality);
       const center = projection([location.longitude, location.latitude]);
 
       return (


### PR DESCRIPTION
The cluster map now auto-zooms to the set of visible information
whenever the user navigates to a new locality, or whenever new locality
information becomes available for the locality currently being viewed.

Fixes #23513

Release note: None