### PR TITLE
ui: unbreak cluster viz by removing extraneous div in Loading

### DIFF
--- a/pkg/ui/src/views/reports/containers/network/index.tsx
+++ b/pkg/ui/src/views/reports/containers/network/index.tsx
@@ -443,8 +443,10 @@ class Network extends React.Component<NetworkProps, {}> {
           className="loading-image loading-image__spinner-left loading-image__spinner-left__padded"
           image={spinner}
         >
-          <NodeFilterList nodeIDs={filters.nodeIDs} localityRegex={filters.localityRegex} />
-          {this.renderContent(nodesSummary, filters)}
+          <div>
+            <NodeFilterList nodeIDs={filters.nodeIDs} localityRegex={filters.localityRegex} />
+            {this.renderContent(nodesSummary, filters)}
+          </div>
         </Loading>
       </div>
     );

--- a/pkg/ui/src/views/shared/components/loading/index.tsx
+++ b/pkg/ui/src/views/shared/components/loading/index.tsx
@@ -18,13 +18,12 @@ export default function Loading(props: LoadingProps) {
   if (props.loading) {
     return <div className={props.className} style={image} />;
   }
-  // The wrapper <div> in the return clause is required so that this component
-  // can take a list of elements instead of only a single one.
-  // This is fixed in react 16, see:
-  // https://reactjs.org/blog/2017/11/28/react-v16.2.0-fragment-support.html
-  return (
-    <div>
-      {props.children}
-    </div>
-  );
+
+  // This throws an error if more than one child is passed.
+  // Unfortunately the error seems to get eaten by some try/catch
+  // above this, but leaving it here to at least signal intent.
+  // Also unfortunately it's unclear how to enforce this invariant
+  // with the type system, since the `children` argument matches
+  // both one node and multiple nodes.
+  return React.Children.only(props.children);
 }


### PR DESCRIPTION
Unfortunately, the cluster viz styles are brittle enough that the change in #23844 which introduced an additional `<div>` as a child of the `<Loading>` component broke them, causing the node map to have zero width and height.

Would be nice to make those less brittle, but in the short term this commit enforces that only one child is passed to the Loading component, and moves the container div to the Network page (which motivated the multi-child case).

I've verified that both the network page and cluster viz work on this page, but could use another set of eyes so we don't break cluster viz again. (not to mention, could use perceptual diffs :P)

Release note: None