### PR TITLE
storage: Fix flaky time series test

### DIFF
--- a/pkg/storage/ts_maintenance_queue_test.go
+++ b/pkg/storage/ts_maintenance_queue_test.go
@@ -237,7 +237,10 @@ func TestTimeSeriesMaintenanceQueueServer(t *testing.T) {
 	// periods; this simplifies verification.
 	seriesName := "test.metric"
 	sourceName := "source1"
-	now := tsrv.Clock().PhysicalNow()
+	// "now" is five minutes in the past to avoid any sort of shenanigans with the
+	// various adjustments we make in the very-recent-past to create consistent
+	// graphs.
+	now := tsrv.Clock().PhysicalNow() - int64(5*time.Minute)
 	nearPast := now - (tsdb.PruneThreshold(ts.Resolution10s) * 2)
 	farPast := now - (tsdb.PruneThreshold(ts.Resolution10s) * 4)
 	sampleDuration := ts.Resolution10s.SampleDuration()


### PR DESCRIPTION
Fixes TestTimeSeriesMaintenanceQueueServer, a test in the storage
package to verify the time series maintenance queue.

This became flaky because this test actually tests a data point at the
current time, and this was running into random troubles in combination
with #13537

The fix is to move "now" to five minutes into the past, which tests the
same thing but avoids the special treatment of the very-near-past.

Fixes #23877

Release note: None