### PR TITLE
opt/constraint: allow column directions

### DIFF
--- a/pkg/sql/opt/constraint/columns.go
+++ b/pkg/sql/opt/constraint/columns.go
@@ -1,0 +1,61 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package constraint
+
+import "github.com/cockroachdb/cockroach/pkg/sql/opt"
+
+// Columns identifies the columns which correspond to the values in a Key (and
+// consequently the columns of a Span or Constraint).
+//
+// The columns have directions; a descending column inverts the order of the
+// values on that column (in other words, inverts the result of any Datum
+// comparisons on that column).
+type Columns struct {
+	// firstCol holds the first column index and otherCols hold any indexes
+	// beyond the first. These are separated in order to optimize for the common
+	// case of a single-column constraint.
+	firstCol  opt.OrderingColumn
+	otherCols []opt.OrderingColumn
+}
+
+// Init initializes a Columns structure.
+func (c *Columns) Init(cols []opt.OrderingColumn) {
+	c.firstCol = cols[0]
+	c.otherCols = cols[1:]
+}
+
+// InitSingle is a more efficient version of Init for the common case of a
+// single column.
+func (c *Columns) InitSingle(col opt.OrderingColumn) {
+	c.firstCol = col
+	c.otherCols = nil
+}
+
+// Count returns the number of constrained columns (always at least one).
+func (c *Columns) Count() int {
+	// There's always at least one column.
+	return 1 + len(c.otherCols)
+}
+
+// Get returns the nth column and direction. Together with the
+// Count method, Get allows iteration over the list of constrained
+// columns (since there is no method to return a slice of columns).
+func (c *Columns) Get(nth int) opt.OrderingColumn {
+	// There's always at least one column.
+	if nth == 0 {
+		return c.firstCol
+	}
+	return c.otherCols[nth-1]
+}

--- a/pkg/sql/opt/constraint/constraint_set.go
+++ b/pkg/sql/opt/constraint/constraint_set.go
@@ -71,7 +71,7 @@ type Set struct {
 
 // NewForColumn creates a new constraint set containing a single constraint.
 // The constraint has a single column and a single span.
-func NewForColumn(col opt.ColumnIndex, sp *Span) *Set {
+func NewForColumn(col opt.OrderingColumn, sp *Span) *Set {
 	cs := &Set{length: 1}
 	cs.firstConstraint.init(col, sp)
 	return cs
@@ -79,7 +79,7 @@ func NewForColumn(col opt.ColumnIndex, sp *Span) *Set {
 
 // NewForColumns creates a new constraint set containing a single constraint.
 // The constraint has one or more columns and a single span.
-func NewForColumns(cols []opt.ColumnIndex, sp *Span) *Set {
+func NewForColumns(cols []opt.OrderingColumn, sp *Span) *Set {
 	cs := &Set{length: 1}
 	cs.firstConstraint.initComposite(cols, sp)
 	return cs
@@ -294,10 +294,10 @@ func (s *Set) String() string {
 // with column position determining significance in the sort key (most
 // significant first).
 func compareConstraintsByCols(left, right *Constraint) int {
-	leftCount := left.ColumnCount()
-	rightCount := right.ColumnCount()
+	leftCount := left.Columns.Count()
+	rightCount := right.Columns.Count()
 	for i := 0; i < leftCount && i < rightCount; i++ {
-		diff := int(left.Column(i) - right.Column(i))
+		diff := int(left.Columns.Get(i) - right.Columns.Get(i))
 		if diff != 0 {
 			return diff
 		}

--- a/pkg/sql/opt/constraint/constraint_test.go
+++ b/pkg/sql/opt/constraint/constraint_test.go
@@ -197,6 +197,8 @@ func newConstraintTestData(evalCtx *tree.EvalContext) *constraintTestData {
 	key60 := MakeKey(tree.NewDInt(60))
 	key70 := MakeKey(tree.NewDInt(70))
 
+	keyCtx := testKeyContext()
+
 	cherry := MakeCompositeKey(tree.NewDString("cherry"), tree.DBoolTrue)
 	mango := MakeCompositeKey(tree.NewDString("mango"), tree.DBoolFalse)
 	raspberry := MakeCompositeKey(tree.NewDString("raspberry"), tree.DBoolFalse)
@@ -205,44 +207,44 @@ func newConstraintTestData(evalCtx *tree.EvalContext) *constraintTestData {
 	var span Span
 
 	// [ - /10)
-	span.Set(evalCtx, EmptyKey, IncludeBoundary, key10, ExcludeBoundary)
+	span.Set(keyCtx, EmptyKey, IncludeBoundary, key10, ExcludeBoundary)
 	data.cLt10.init(1, &span)
 
 	// (/20 - ]
-	span.Set(evalCtx, key20, ExcludeBoundary, EmptyKey, IncludeBoundary)
+	span.Set(keyCtx, key20, ExcludeBoundary, EmptyKey, IncludeBoundary)
 	data.cGt20.init(1, &span)
 
 	// [/1 - /10]
-	span.Set(evalCtx, key1, IncludeBoundary, key10, IncludeBoundary)
+	span.Set(keyCtx, key1, IncludeBoundary, key10, IncludeBoundary)
 	data.c1to10.init(1, &span)
 
 	// (/5 - /25)
-	span.Set(evalCtx, key5, ExcludeBoundary, key25, ExcludeBoundary)
+	span.Set(keyCtx, key5, ExcludeBoundary, key25, ExcludeBoundary)
 	data.c5to25.init(1, &span)
 
 	// [/20 - /30)
-	span.Set(evalCtx, key20, IncludeBoundary, key30, ExcludeBoundary)
+	span.Set(keyCtx, key20, IncludeBoundary, key30, ExcludeBoundary)
 	data.c20to30.init(1, &span)
 
 	// [/30 - /40]
-	span.Set(evalCtx, key30, IncludeBoundary, key40, IncludeBoundary)
+	span.Set(keyCtx, key30, IncludeBoundary, key40, IncludeBoundary)
 	data.c30to40.init(1, &span)
 
 	// [/40 - /50]
-	span.Set(evalCtx, key40, IncludeBoundary, key50, IncludeBoundary)
+	span.Set(keyCtx, key40, IncludeBoundary, key50, IncludeBoundary)
 	data.c40to50.init(1, &span)
 
 	// (/60 - /70)
-	span.Set(evalCtx, key60, ExcludeBoundary, key70, ExcludeBoundary)
+	span.Set(keyCtx, key60, ExcludeBoundary, key70, ExcludeBoundary)
 	data.c60to70.init(1, &span)
 
 	// [/'cherry'/true - /'raspberry'/false)
-	span.Set(evalCtx, cherry, IncludeBoundary, raspberry, ExcludeBoundary)
-	data.cherryRaspberry.initComposite([]opt.ColumnIndex{1, 2}, &span)
+	span.Set(keyCtx, cherry, IncludeBoundary, raspberry, ExcludeBoundary)
+	data.cherryRaspberry.initComposite([]opt.OrderingColumn{1, 2}, &span)
 
 	// [/'mango'/false - /'strawberry']
-	span.Set(evalCtx, mango, IncludeBoundary, strawberry, IncludeBoundary)
-	data.mangoStrawberry.initComposite([]opt.ColumnIndex{1, 2}, &span)
+	span.Set(keyCtx, mango, IncludeBoundary, strawberry, IncludeBoundary)
+	data.mangoStrawberry.initComposite([]opt.OrderingColumn{1, 2}, &span)
 
 	return data
 }

--- a/pkg/sql/opt/constraint/span.go
+++ b/pkg/sql/opt/constraint/span.go
@@ -16,8 +16,6 @@ package constraint
 
 import (
 	"bytes"
-
-	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 )
 
 // SpanBoundary specifies whether a span endpoint is inclusive or exclusive of
@@ -73,11 +71,7 @@ func (sp *Span) IsUnconstrained() bool {
 //  2. Unconstrained span (should never be used in a constraint)
 //  3. Exclusive empty key boundary (use inclusive instead)
 func (sp *Span) Set(
-	evalCtx *tree.EvalContext,
-	start Key,
-	startBoundary SpanBoundary,
-	end Key,
-	endBoundary SpanBoundary,
+	keyCtx KeyContext, start Key, startBoundary SpanBoundary, end Key, endBoundary SpanBoundary,
 ) {
 	if start.IsEmpty() {
 		if end.IsEmpty() {
@@ -102,7 +96,7 @@ func (sp *Span) Set(
 	sp.endBoundary = endBoundary
 
 	// Ensure that start boundary is less than end boundary.
-	if sp.start.Compare(evalCtx, sp.end, sp.startExt(), sp.endExt()) >= 0 {
+	if sp.start.Compare(keyCtx, sp.end, sp.startExt(), sp.endExt()) >= 0 {
 		panic("span cannot be empty")
 	}
 }
@@ -132,15 +126,15 @@ func (sp *Span) Set(
 //   (/1   - /2/1)  =  /1/High   - /2/1/Low
 //   (/1   - /2/1]  =  /1/High   - /2/1/High
 //   (/1   -     ]  =  /1/High   - /High
-func (sp *Span) Compare(evalCtx *tree.EvalContext, other *Span) int {
+func (sp *Span) Compare(keyCtx KeyContext, other *Span) int {
 	// Span with lowest start boundary is less than the other.
-	if cmp := sp.CompareStarts(evalCtx, other); cmp != 0 {
+	if cmp := sp.CompareStarts(keyCtx, other); cmp != 0 {
 		return cmp
 	}
 
 	// Start boundary is same, so span with lowest end boundary is less than
 	// the other.
-	if cmp := sp.CompareEnds(evalCtx, other); cmp != 0 {
+	if cmp := sp.CompareEnds(keyCtx, other); cmp != 0 {
 		return cmp
 	}
 
@@ -152,44 +146,44 @@ func (sp *Span) Compare(evalCtx *tree.EvalContext, other *Span) int {
 // boundaries of the two spans. The result will be 0 if the spans have the same
 // start boundary, -1 if this span has a smaller start boundary than the given
 // span, or 1 if this span has a bigger start boundary than the given span.
-func (sp *Span) CompareStarts(evalCtx *tree.EvalContext, other *Span) int {
-	return sp.start.Compare(evalCtx, other.start, sp.startExt(), other.startExt())
+func (sp *Span) CompareStarts(keyCtx KeyContext, other *Span) int {
+	return sp.start.Compare(keyCtx, other.start, sp.startExt(), other.startExt())
 }
 
 // CompareEnds returns an integer indicating the ordering of the end boundaries
 // of the two spans. The result will be 0 if the spans have the same end
 // boundary, -1 if this span has a smaller end boundary than the given span, or
 // 1 if this span has a bigger end boundary than the given span.
-func (sp *Span) CompareEnds(evalCtx *tree.EvalContext, other *Span) int {
-	return sp.end.Compare(evalCtx, other.end, sp.endExt(), other.endExt())
+func (sp *Span) CompareEnds(keyCtx KeyContext, other *Span) int {
+	return sp.end.Compare(keyCtx, other.end, sp.endExt(), other.endExt())
 }
 
 // StartsAfter returns true if this span is greater than the given span and
 // does not overlap it. In other words, this span's start boundary is greater
 // or equal to the given span's end boundary.
-func (sp *Span) StartsAfter(evalCtx *tree.EvalContext, other *Span) bool {
-	return sp.start.Compare(evalCtx, other.end, sp.startExt(), other.endExt()) >= 0
+func (sp *Span) StartsAfter(keyCtx KeyContext, other *Span) bool {
+	return sp.start.Compare(keyCtx, other.end, sp.startExt(), other.endExt()) >= 0
 }
 
 // TryIntersectWith finds the overlap between this span and the given span.
 // This span is updated to only cover the range that is common to both spans.
 // If there is no overlap, then this span will not be updated, and
 // TryIntersectWith will return false.
-func (sp *Span) TryIntersectWith(evalCtx *tree.EvalContext, other *Span) bool {
-	cmpStarts := sp.CompareStarts(evalCtx, other)
+func (sp *Span) TryIntersectWith(keyCtx KeyContext, other *Span) bool {
+	cmpStarts := sp.CompareStarts(keyCtx, other)
 	if cmpStarts > 0 {
 		// If this span's start boundary is >= the other span's end boundary,
 		// then intersection is empty.
-		if sp.start.Compare(evalCtx, other.end, sp.startExt(), other.endExt()) >= 0 {
+		if sp.start.Compare(keyCtx, other.end, sp.startExt(), other.endExt()) >= 0 {
 			return false
 		}
 	}
 
-	cmpEnds := sp.CompareEnds(evalCtx, other)
+	cmpEnds := sp.CompareEnds(keyCtx, other)
 	if cmpEnds < 0 {
 		// If this span's end boundary is <= the other span's start boundary,
 		// then intersection is empty.
-		if sp.end.Compare(evalCtx, other.start, sp.endExt(), other.startExt()) <= 0 {
+		if sp.end.Compare(keyCtx, other.start, sp.endExt(), other.startExt()) <= 0 {
 			return false
 		}
 	}
@@ -216,19 +210,19 @@ func (sp *Span) TryIntersectWith(evalCtx *tree.EvalContext, other *Span) bool {
 // returns true. If the resulting span does not constrain the range [ - ], then
 // its IsUnconstrained method returns true, and it cannot be used as part of a
 // constraint.
-func (sp *Span) TryUnionWith(evalCtx *tree.EvalContext, other *Span) bool {
+func (sp *Span) TryUnionWith(keyCtx KeyContext, other *Span) bool {
 	// Determine the minimum start boundary.
-	cmpStartKeys := sp.CompareStarts(evalCtx, other)
+	cmpStartKeys := sp.CompareStarts(keyCtx, other)
 
 	var cmp int
 	if cmpStartKeys < 0 {
 		// This span is less, so see if there's any "space" after it and before
 		// the start of the other span.
-		cmp = sp.end.Compare(evalCtx, other.start, sp.endExt(), other.startExt())
+		cmp = sp.end.Compare(keyCtx, other.start, sp.endExt(), other.startExt())
 	} else if cmpStartKeys > 0 {
 		// This span is greater, so see if there's any "space" before it and
 		// after the end of the other span.
-		cmp = other.end.Compare(evalCtx, sp.start, other.endExt(), sp.startExt())
+		cmp = other.end.Compare(keyCtx, sp.start, other.endExt(), sp.startExt())
 	}
 	if cmp < 0 {
 		// There's "space" between spans, so union of these spans can't be
@@ -237,7 +231,7 @@ func (sp *Span) TryUnionWith(evalCtx *tree.EvalContext, other *Span) bool {
 	}
 
 	// Determine the maximum end boundary.
-	cmpEndKeys := sp.CompareEnds(evalCtx, other)
+	cmpEndKeys := sp.CompareEnds(keyCtx, other)
 
 	// Create the merged span.
 	if cmpStartKeys > 0 {

--- a/pkg/sql/opt/constraint/span_test.go
+++ b/pkg/sql/opt/constraint/span_test.go
@@ -17,18 +17,52 @@
 package constraint
 
 import (
+	"fmt"
 	"testing"
 
-	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 )
 
 func TestSpanSet(t *testing.T) {
-	test := func(t *testing.T, sp Span, expected string) {
-		t.Helper()
-		if sp.String() != expected {
-			t.Errorf("expected: %s, actual: %s", expected, sp.String())
-		}
+	testCases := []struct {
+		start         Key
+		startBoundary SpanBoundary
+		end           Key
+		endBoundary   SpanBoundary
+		expected      string
+	}{
+		{ // 0
+			MakeKey(tree.NewDInt(1)), IncludeBoundary,
+			MakeKey(tree.NewDInt(5)), IncludeBoundary,
+			"[/1 - /5]",
+		},
+		{ // 1
+			MakeCompositeKey(tree.NewDString("cherry"), tree.NewDInt(5)), IncludeBoundary,
+			MakeCompositeKey(tree.NewDString("mango"), tree.NewDInt(1)), ExcludeBoundary,
+			"[/'cherry'/5 - /'mango'/1)",
+		},
+		{ // 2
+			MakeCompositeKey(tree.NewDInt(5), tree.NewDInt(1)), ExcludeBoundary,
+			MakeKey(tree.NewDInt(5)), IncludeBoundary,
+			"(/5/1 - /5]",
+		},
+		{ // 3
+			MakeKey(tree.NewDInt(5)), IncludeBoundary,
+			MakeCompositeKey(tree.NewDInt(5), tree.NewDInt(1)), ExcludeBoundary,
+			"[/5 - /5/1)",
+		},
+	}
+
+	keyCtx := testKeyContext()
+
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+			var sp Span
+			sp.Set(keyCtx, tc.start, tc.startBoundary, tc.end, tc.endBoundary)
+			if sp.String() != tc.expected {
+				t.Errorf("expected: %s, actual: %s", tc.expected, sp.String())
+			}
+		})
 	}
 
 	testPanic := func(t *testing.T, fn func(), expected string) {
@@ -44,57 +78,26 @@ func TestSpanSet(t *testing.T) {
 		fn()
 	}
 
-	st := cluster.MakeTestingClusterSettings()
-	evalCtx := tree.MakeTestingEvalContext(st)
-
 	var sp Span
-	sp.Set(
-		&evalCtx,
-		MakeKey(tree.NewDInt(1)), IncludeBoundary,
-		MakeKey(tree.NewDInt(5)), IncludeBoundary,
-	)
-	test(t, sp, "[/1 - /5]")
-
-	sp.Set(
-		&evalCtx,
-		MakeCompositeKey(tree.NewDString("cherry"), tree.NewDInt(5)), IncludeBoundary,
-		MakeCompositeKey(tree.NewDString("mango"), tree.NewDInt(1)), ExcludeBoundary,
-	)
-	test(t, sp, "[/'cherry'/5 - /'mango'/1)")
-
-	sp.Set(
-		&evalCtx,
-		MakeCompositeKey(tree.NewDInt(5), tree.NewDInt(1)), ExcludeBoundary,
-		MakeKey(tree.NewDInt(5)), IncludeBoundary,
-	)
-	test(t, sp, "(/5/1 - /5]")
-
-	sp.Set(
-		&evalCtx,
-		MakeKey(tree.NewDInt(5)), IncludeBoundary,
-		MakeCompositeKey(tree.NewDInt(5), tree.NewDInt(1)), ExcludeBoundary,
-	)
-	test(t, sp, "[/5 - /5/1)")
-
 	// Try to create unconstrained span.
 	testPanic(t, func() {
-		sp.Set(&evalCtx, EmptyKey, IncludeBoundary, EmptyKey, IncludeBoundary)
+		sp.Set(keyCtx, EmptyKey, IncludeBoundary, EmptyKey, IncludeBoundary)
 	}, "unconstrained span should never be used")
 
 	// Create exclusive empty start boundary.
 	testPanic(t, func() {
-		sp.Set(&evalCtx, EmptyKey, ExcludeBoundary, MakeKey(tree.DNull), IncludeBoundary)
+		sp.Set(keyCtx, EmptyKey, ExcludeBoundary, MakeKey(tree.DNull), IncludeBoundary)
 	}, "an empty start boundary must be inclusive")
 
 	// Create exclusive empty end boundary.
 	testPanic(t, func() {
-		sp.Set(&evalCtx, MakeKey(tree.DNull), IncludeBoundary, EmptyKey, ExcludeBoundary)
+		sp.Set(keyCtx, MakeKey(tree.DNull), IncludeBoundary, EmptyKey, ExcludeBoundary)
 	}, "an empty end boundary must be inclusive")
 
 	// Try to create zero-length spans.
 	testPanic(t, func() {
 		sp.Set(
-			&evalCtx,
+			keyCtx,
 			MakeKey(tree.NewDInt(1)), IncludeBoundary,
 			MakeKey(tree.NewDInt(1)), ExcludeBoundary,
 		)
@@ -102,7 +105,7 @@ func TestSpanSet(t *testing.T) {
 
 	testPanic(t, func() {
 		sp.Set(
-			&evalCtx,
+			keyCtx,
 			MakeCompositeKey(tree.NewDString("cherry"), tree.NewDInt(5)), ExcludeBoundary,
 			MakeCompositeKey(tree.NewDString("cherry"), tree.NewDInt(5)), IncludeBoundary,
 		)
@@ -110,12 +113,12 @@ func TestSpanSet(t *testing.T) {
 
 	// Try to create spans where start boundary > end boundary.
 	testPanic(t, func() {
-		sp.Set(&evalCtx, MakeKey(tree.NewDInt(0)), IncludeBoundary, MakeKey(tree.DNull), ExcludeBoundary)
+		sp.Set(keyCtx, MakeKey(tree.NewDInt(0)), IncludeBoundary, MakeKey(tree.DNull), ExcludeBoundary)
 	}, "span cannot be empty")
 
 	testPanic(t, func() {
 		sp.Set(
-			&evalCtx,
+			keyCtx,
 			MakeCompositeKey(tree.NewDString("mango"), tree.NewDInt(1)), IncludeBoundary,
 			MakeCompositeKey(tree.NewDString("cherry"), tree.NewDInt(5)), IncludeBoundary,
 		)
@@ -123,8 +126,7 @@ func TestSpanSet(t *testing.T) {
 }
 
 func TestSpanUnconstrained(t *testing.T) {
-	st := cluster.MakeTestingClusterSettings()
-	evalCtx := tree.MakeTestingEvalContext(st)
+	keyCtx := testKeyContext()
 
 	// Test unconstrained span.
 	unconstrained := Span{}
@@ -139,7 +141,7 @@ func TestSpanUnconstrained(t *testing.T) {
 	// Test constrained span's IsUnconstrained method.
 	var sp Span
 	sp.Set(
-		&evalCtx,
+		keyCtx,
 		MakeKey(tree.NewDInt(5)), IncludeBoundary,
 		MakeKey(tree.NewDInt(5)), IncludeBoundary,
 	)
@@ -149,16 +151,15 @@ func TestSpanUnconstrained(t *testing.T) {
 }
 
 func TestSpanCompare(t *testing.T) {
-	testComp := func(t *testing.T, evalCtx *tree.EvalContext, left, right Span, expected int) {
+	keyCtx := testKeyContext()
+
+	testComp := func(t *testing.T, left, right Span, expected int) {
 		t.Helper()
-		if actual := left.Compare(evalCtx, &right); actual != expected {
+		if actual := left.Compare(keyCtx, &right); actual != expected {
 			format := "left: %s, right: %s, expected: %v, actual: %v"
 			t.Errorf(format, left.String(), right.String(), expected, actual)
 		}
 	}
-
-	st := cluster.MakeTestingClusterSettings()
-	evalCtx := tree.MakeTestingEvalContext(st)
 
 	one := MakeKey(tree.NewDInt(1))
 	two := MakeKey(tree.NewDInt(2))
@@ -168,75 +169,134 @@ func TestSpanCompare(t *testing.T) {
 	var spans [17]Span
 
 	// [ - /2)
-	spans[0].Set(&evalCtx, EmptyKey, IncludeBoundary, two, ExcludeBoundary)
+	spans[0].Set(keyCtx, EmptyKey, IncludeBoundary, two, ExcludeBoundary)
 
 	// [ - /2/1)
-	spans[1].Set(&evalCtx, EmptyKey, IncludeBoundary, twoone, ExcludeBoundary)
+	spans[1].Set(keyCtx, EmptyKey, IncludeBoundary, twoone, ExcludeBoundary)
 
 	// [ - /2/1]
-	spans[2].Set(&evalCtx, EmptyKey, IncludeBoundary, twoone, IncludeBoundary)
+	spans[2].Set(keyCtx, EmptyKey, IncludeBoundary, twoone, IncludeBoundary)
 
 	// [ - /2]
-	spans[3].Set(&evalCtx, EmptyKey, IncludeBoundary, two, IncludeBoundary)
+	spans[3].Set(keyCtx, EmptyKey, IncludeBoundary, two, IncludeBoundary)
 
 	// [ - ]
 	spans[4] = Span{}
 
 	// [/1 - /2/1)
-	spans[5].Set(&evalCtx, one, IncludeBoundary, twoone, ExcludeBoundary)
+	spans[5].Set(keyCtx, one, IncludeBoundary, twoone, ExcludeBoundary)
 
 	// [/1 - /2/1]
-	spans[6].Set(&evalCtx, one, IncludeBoundary, twoone, IncludeBoundary)
+	spans[6].Set(keyCtx, one, IncludeBoundary, twoone, IncludeBoundary)
 
 	// [/1 - ]
-	spans[7].Set(&evalCtx, one, IncludeBoundary, EmptyKey, IncludeBoundary)
+	spans[7].Set(keyCtx, one, IncludeBoundary, EmptyKey, IncludeBoundary)
 
 	// [/1/1 - /2)
-	spans[8].Set(&evalCtx, oneone, IncludeBoundary, two, ExcludeBoundary)
+	spans[8].Set(keyCtx, oneone, IncludeBoundary, two, ExcludeBoundary)
 
 	// [/1/1 - /2]
-	spans[9].Set(&evalCtx, oneone, IncludeBoundary, two, IncludeBoundary)
+	spans[9].Set(keyCtx, oneone, IncludeBoundary, two, IncludeBoundary)
 
 	// [/1/1 - ]
-	spans[10].Set(&evalCtx, oneone, IncludeBoundary, EmptyKey, IncludeBoundary)
+	spans[10].Set(keyCtx, oneone, IncludeBoundary, EmptyKey, IncludeBoundary)
 
 	// (/1/1 - /2)
-	spans[11].Set(&evalCtx, oneone, ExcludeBoundary, two, ExcludeBoundary)
+	spans[11].Set(keyCtx, oneone, ExcludeBoundary, two, ExcludeBoundary)
 
 	// (/1/1 - /2]
-	spans[12].Set(&evalCtx, oneone, ExcludeBoundary, two, IncludeBoundary)
+	spans[12].Set(keyCtx, oneone, ExcludeBoundary, two, IncludeBoundary)
 
 	// (/1/1 - ]
-	spans[13].Set(&evalCtx, oneone, ExcludeBoundary, EmptyKey, IncludeBoundary)
+	spans[13].Set(keyCtx, oneone, ExcludeBoundary, EmptyKey, IncludeBoundary)
 
 	// (/1 - /2/1)
-	spans[14].Set(&evalCtx, one, ExcludeBoundary, twoone, ExcludeBoundary)
+	spans[14].Set(keyCtx, one, ExcludeBoundary, twoone, ExcludeBoundary)
 
 	// (/1 - /2/1]
-	spans[15].Set(&evalCtx, one, ExcludeBoundary, twoone, IncludeBoundary)
+	spans[15].Set(keyCtx, one, ExcludeBoundary, twoone, IncludeBoundary)
 
 	// (/1 - ]
-	spans[16].Set(&evalCtx, one, ExcludeBoundary, EmptyKey, IncludeBoundary)
+	spans[16].Set(keyCtx, one, ExcludeBoundary, EmptyKey, IncludeBoundary)
 
 	for i := 0; i < len(spans)-1; i++ {
-		testComp(t, &evalCtx, spans[i], spans[i+1], -1)
-		testComp(t, &evalCtx, spans[i+1], spans[i], 1)
-		testComp(t, &evalCtx, spans[i], spans[i], 0)
-		testComp(t, &evalCtx, spans[i+1], spans[i+1], 0)
+		testComp(t, spans[i], spans[i+1], -1)
+		testComp(t, spans[i+1], spans[i], 1)
+		testComp(t, spans[i], spans[i], 0)
+		testComp(t, spans[i+1], spans[i+1], 0)
+	}
+
+	keyCtx.Columns.firstCol = -keyCtx.Columns.firstCol
+
+	// [ - /1)
+	spans[0].Set(keyCtx, EmptyKey, IncludeBoundary, one, ExcludeBoundary)
+
+	// [ - /1/1)
+	spans[1].Set(keyCtx, EmptyKey, IncludeBoundary, oneone, ExcludeBoundary)
+
+	// [ - /1/1]
+	spans[2].Set(keyCtx, EmptyKey, IncludeBoundary, oneone, IncludeBoundary)
+
+	// [ - /1]
+	spans[3].Set(keyCtx, EmptyKey, IncludeBoundary, one, IncludeBoundary)
+
+	// [ - ]
+	spans[4] = Span{}
+
+	// [/2 - /1/1)
+	spans[5].Set(keyCtx, two, IncludeBoundary, oneone, ExcludeBoundary)
+
+	// [/2 - /1/1]
+	spans[6].Set(keyCtx, two, IncludeBoundary, oneone, IncludeBoundary)
+
+	// [/2 - ]
+	spans[7].Set(keyCtx, two, IncludeBoundary, EmptyKey, IncludeBoundary)
+
+	// [/2/1 - /1)
+	spans[8].Set(keyCtx, twoone, IncludeBoundary, one, ExcludeBoundary)
+
+	// [/2/1 - /1]
+	spans[9].Set(keyCtx, twoone, IncludeBoundary, one, IncludeBoundary)
+
+	// [/2/1 - ]
+	spans[10].Set(keyCtx, twoone, IncludeBoundary, EmptyKey, IncludeBoundary)
+
+	// (/2/1 - /1)
+	spans[11].Set(keyCtx, twoone, ExcludeBoundary, one, ExcludeBoundary)
+
+	// (/2/1 - /1]
+	spans[12].Set(keyCtx, twoone, ExcludeBoundary, one, IncludeBoundary)
+
+	// (/2/1 - ]
+	spans[13].Set(keyCtx, twoone, ExcludeBoundary, EmptyKey, IncludeBoundary)
+
+	// (/2 - /1/1)
+	spans[14].Set(keyCtx, two, ExcludeBoundary, oneone, ExcludeBoundary)
+
+	// (/2 - /1/1]
+	spans[15].Set(keyCtx, two, ExcludeBoundary, oneone, IncludeBoundary)
+
+	// (/2 - ]
+	spans[16].Set(keyCtx, two, ExcludeBoundary, EmptyKey, IncludeBoundary)
+
+	for i := 0; i < len(spans)-1; i++ {
+		testComp(t, spans[i], spans[i+1], -1)
+		testComp(t, spans[i+1], spans[i], 1)
+		testComp(t, spans[i], spans[i], 0)
+		testComp(t, spans[i+1], spans[i+1], 0)
 	}
 }
 
 func TestSpanCompareStarts(t *testing.T) {
-	test := func(t *testing.T, evalCtx *tree.EvalContext, left, right Span, expected int) {
+	keyCtx := testKeyContext()
+
+	test := func(left, right Span, expected int) {
 		t.Helper()
-		if actual := left.CompareStarts(evalCtx, &right); actual != expected {
+		if actual := left.CompareStarts(keyCtx, &right); actual != expected {
 			format := "left: %s, right: %s, expected: %v, actual: %v"
 			t.Errorf(format, left.String(), right.String(), expected, actual)
 		}
 	}
-
-	st := cluster.MakeTestingClusterSettings()
-	evalCtx := tree.MakeTestingEvalContext(st)
 
 	one := MakeKey(tree.NewDInt(1))
 	two := MakeKey(tree.NewDInt(2))
@@ -244,29 +304,28 @@ func TestSpanCompareStarts(t *testing.T) {
 	nine := MakeKey(tree.NewDInt(9))
 
 	var onefive Span
-	onefive.Set(&evalCtx, one, IncludeBoundary, five, IncludeBoundary)
+	onefive.Set(keyCtx, one, IncludeBoundary, five, IncludeBoundary)
 	var twonine Span
-	twonine.Set(&evalCtx, two, ExcludeBoundary, nine, ExcludeBoundary)
+	twonine.Set(keyCtx, two, ExcludeBoundary, nine, ExcludeBoundary)
 
 	// Same span.
-	test(t, &evalCtx, onefive, onefive, 0)
+	test(onefive, onefive, 0)
 
 	// Different spans.
-	test(t, &evalCtx, onefive, twonine, -1)
-	test(t, &evalCtx, twonine, onefive, 1)
+	test(onefive, twonine, -1)
+	test(twonine, onefive, 1)
 }
 
 func TestSpanCompareEnds(t *testing.T) {
-	test := func(t *testing.T, evalCtx *tree.EvalContext, left, right Span, expected int) {
+	keyCtx := testKeyContext()
+
+	test := func(left, right Span, expected int) {
 		t.Helper()
-		if actual := left.CompareEnds(evalCtx, &right); actual != expected {
+		if actual := left.CompareEnds(keyCtx, &right); actual != expected {
 			format := "left: %s, right: %s, expected: %v, actual: %v"
 			t.Errorf(format, left.String(), right.String(), expected, actual)
 		}
 	}
-
-	st := cluster.MakeTestingClusterSettings()
-	evalCtx := tree.MakeTestingEvalContext(st)
 
 	one := MakeKey(tree.NewDInt(1))
 	two := MakeKey(tree.NewDInt(2))
@@ -274,65 +333,65 @@ func TestSpanCompareEnds(t *testing.T) {
 	nine := MakeKey(tree.NewDInt(9))
 
 	var onefive Span
-	onefive.Set(&evalCtx, one, IncludeBoundary, five, IncludeBoundary)
+	onefive.Set(keyCtx, one, IncludeBoundary, five, IncludeBoundary)
 	var twonine Span
-	twonine.Set(&evalCtx, two, ExcludeBoundary, nine, ExcludeBoundary)
+	twonine.Set(keyCtx, two, ExcludeBoundary, nine, ExcludeBoundary)
 
 	// Same span.
-	test(t, &evalCtx, onefive, onefive, 0)
+	test(onefive, onefive, 0)
 
 	// Different spans.
-	test(t, &evalCtx, onefive, twonine, -1)
-	test(t, &evalCtx, twonine, onefive, 1)
+	test(onefive, twonine, -1)
+	test(twonine, onefive, 1)
 }
 
 func TestSpanStartsAfter(t *testing.T) {
-	test := func(t *testing.T, evalCtx *tree.EvalContext, left, right Span, expected bool) {
+	keyCtx := testKeyContext()
+
+	test := func(left, right Span, expected bool) {
 		t.Helper()
-		if actual := left.StartsAfter(evalCtx, &right); actual != expected {
+		if actual := left.StartsAfter(keyCtx, &right); actual != expected {
 			format := "left: %s, right: %s, expected: %v, actual: %v"
 			t.Errorf(format, left.String(), right.String(), expected, actual)
 		}
 	}
-
-	st := cluster.MakeTestingClusterSettings()
-	evalCtx := tree.MakeTestingEvalContext(st)
 
 	// Same span.
 	var banana Span
 	banana.Set(
-		&evalCtx,
+		keyCtx,
 		MakeCompositeKey(tree.DNull, tree.NewDInt(100)), IncludeBoundary,
 		MakeCompositeKey(tree.NewDString("banana"), tree.NewDInt(50)), IncludeBoundary,
 	)
-	test(t, &evalCtx, banana, banana, false)
+	test(banana, banana, false)
 
 	// Right span's start equal to left span's end.
 	var cherry Span
 	cherry.Set(
-		&evalCtx,
+		keyCtx,
 		MakeCompositeKey(tree.NewDString("banana"), tree.NewDInt(50)), ExcludeBoundary,
 		MakeKey(tree.NewDString("cherry")), ExcludeBoundary,
 	)
-	test(t, &evalCtx, banana, cherry, false)
-	test(t, &evalCtx, cherry, banana, true)
+	test(banana, cherry, false)
+	test(cherry, banana, true)
 
 	// Right span's start greater than left span's end, and inverse.
 	var cherry2 Span
 	cherry2.Set(
-		&evalCtx,
+		keyCtx,
 		MakeCompositeKey(tree.NewDString("cherry"), tree.NewDInt(0)), IncludeBoundary,
 		MakeKey(tree.NewDString("mango")), ExcludeBoundary,
 	)
-	test(t, &evalCtx, cherry, cherry2, false)
-	test(t, &evalCtx, cherry2, cherry, true)
+	test(cherry, cherry2, false)
+	test(cherry2, cherry, true)
 }
 
 func TestSpanIntersect(t *testing.T) {
-	testInt := func(t *testing.T, evalCtx *tree.EvalContext, left, right Span, expected string) {
+	keyCtx := testKeyContext()
+	testInt := func(left, right Span, expected string) {
 		t.Helper()
 		sp := left
-		ok := sp.TryIntersectWith(evalCtx, &right)
+		ok := sp.TryIntersectWith(keyCtx, &right)
 
 		var actual string
 		if ok {
@@ -345,91 +404,90 @@ func TestSpanIntersect(t *testing.T) {
 		}
 	}
 
-	st := cluster.MakeTestingClusterSettings()
-	evalCtx := tree.MakeTestingEvalContext(st)
-
 	// Same span.
 	var banana Span
 	banana.Set(
-		&evalCtx,
+		keyCtx,
 		MakeCompositeKey(tree.DNull, tree.NewDInt(100)), IncludeBoundary,
 		MakeCompositeKey(tree.NewDString("banana"), tree.NewDInt(50)), IncludeBoundary,
 	)
-	testInt(t, &evalCtx, banana, banana, "[/NULL/100 - /'banana'/50]")
+	testInt(banana, banana, "[/NULL/100 - /'banana'/50]")
 
 	// One span immediately after the other.
 	var grape Span
 	grape.Set(
-		&evalCtx,
+		keyCtx,
 		MakeCompositeKey(tree.NewDString("banana"), tree.NewDInt(50)), ExcludeBoundary,
 		MakeCompositeKey(tree.NewDString("grape")), ExcludeBoundary,
 	)
-	testInt(t, &evalCtx, banana, grape, "")
-	testInt(t, &evalCtx, grape, banana, "")
+	testInt(banana, grape, "")
+	testInt(grape, banana, "")
 
 	// Partial overlap.
 	var apple Span
 	apple.Set(
-		&evalCtx,
+		keyCtx,
 		MakeCompositeKey(tree.NewDString("apple"), tree.NewDInt(200)), ExcludeBoundary,
 		MakeCompositeKey(tree.NewDString("cherry"), tree.NewDInt(300)), ExcludeBoundary,
 	)
-	testInt(t, &evalCtx, banana, apple, "(/'apple'/200 - /'banana'/50]")
-	testInt(t, &evalCtx, apple, banana, "(/'apple'/200 - /'banana'/50]")
+	testInt(banana, apple, "(/'apple'/200 - /'banana'/50]")
+	testInt(apple, banana, "(/'apple'/200 - /'banana'/50]")
 
 	// One span is subset of other.
 	var mango Span
 	mango.Set(
-		&evalCtx,
+		keyCtx,
 		MakeCompositeKey(tree.NewDString("apple"), tree.NewDInt(200)), ExcludeBoundary,
 		MakeCompositeKey(tree.NewDString("mango")), ExcludeBoundary,
 	)
-	testInt(t, &evalCtx, apple, mango, "(/'apple'/200 - /'cherry'/300)")
-	testInt(t, &evalCtx, mango, apple, "(/'apple'/200 - /'cherry'/300)")
-	testInt(t, &evalCtx, Span{}, mango, "(/'apple'/200 - /'mango')")
-	testInt(t, &evalCtx, mango, Span{}, "(/'apple'/200 - /'mango')")
+	testInt(apple, mango, "(/'apple'/200 - /'cherry'/300)")
+	testInt(mango, apple, "(/'apple'/200 - /'cherry'/300)")
+	testInt(Span{}, mango, "(/'apple'/200 - /'mango')")
+	testInt(mango, Span{}, "(/'apple'/200 - /'mango')")
 
 	// Spans are disjoint.
 	var pear Span
 	pear.Set(
-		&evalCtx,
+		keyCtx,
 		MakeCompositeKey(tree.NewDString("mango"), tree.NewDInt(0)), IncludeBoundary,
 		MakeCompositeKey(tree.NewDString("pear"), tree.NewDInt(10)), IncludeBoundary,
 	)
-	testInt(t, &evalCtx, mango, pear, "")
-	testInt(t, &evalCtx, pear, mango, "")
+	testInt(mango, pear, "")
+	testInt(pear, mango, "")
 
 	// Ensure that if TryIntersectWith results in empty set, that it does not
 	// update either span.
 	mango2 := mango
 	pear2 := pear
-	mango2.TryIntersectWith(&evalCtx, &pear2)
-	if mango2.Compare(&evalCtx, &mango) != 0 {
+	mango2.TryIntersectWith(keyCtx, &pear2)
+	if mango2.Compare(keyCtx, &mango) != 0 {
 		t.Errorf("mango2 was incorrectly updated during TryIntersectWith")
 	}
-	if pear2.Compare(&evalCtx, &pear) != 0 {
+	if pear2.Compare(keyCtx, &pear) != 0 {
 		t.Errorf("pear2 was incorrectly updated during TryIntersectWith")
 	}
 
 	// Partial overlap on second key.
 	pear2.Set(
-		&evalCtx,
+		keyCtx,
 		MakeCompositeKey(tree.NewDString("pear"), tree.NewDInt(5), tree.DNull), ExcludeBoundary,
 		MakeCompositeKey(tree.NewDString("raspberry"), tree.NewDInt(100)), IncludeBoundary,
 	)
-	testInt(t, &evalCtx, pear, pear2, "(/'pear'/5/NULL - /'pear'/10]")
-	testInt(t, &evalCtx, pear2, pear, "(/'pear'/5/NULL - /'pear'/10]")
+	testInt(pear, pear2, "(/'pear'/5/NULL - /'pear'/10]")
+	testInt(pear2, pear, "(/'pear'/5/NULL - /'pear'/10]")
 
 	// Unconstrained (uninitialized) span.
-	testInt(t, &evalCtx, banana, Span{}, "[/NULL/100 - /'banana'/50]")
-	testInt(t, &evalCtx, Span{}, banana, "[/NULL/100 - /'banana'/50]")
+	testInt(banana, Span{}, "[/NULL/100 - /'banana'/50]")
+	testInt(Span{}, banana, "[/NULL/100 - /'banana'/50]")
 }
 
 func TestSpanUnion(t *testing.T) {
-	testUnion := func(t *testing.T, evalCtx *tree.EvalContext, left, right Span, expected string) {
+	keyCtx := testKeyContext()
+
+	testUnion := func(left, right Span, expected string) {
 		t.Helper()
 		sp := left
-		ok := sp.TryUnionWith(evalCtx, &right)
+		ok := sp.TryUnionWith(keyCtx, &right)
 
 		var actual string
 		if ok {
@@ -442,72 +500,69 @@ func TestSpanUnion(t *testing.T) {
 		}
 	}
 
-	st := cluster.MakeTestingClusterSettings()
-	evalCtx := tree.MakeTestingEvalContext(st)
-
 	// Same span.
 	var banana Span
 	banana.Set(
-		&evalCtx,
+		keyCtx,
 		MakeCompositeKey(tree.DNull, tree.NewDInt(100)), IncludeBoundary,
 		MakeCompositeKey(tree.NewDString("banana"), tree.NewDInt(50)), IncludeBoundary,
 	)
-	testUnion(t, &evalCtx, banana, banana, "[/NULL/100 - /'banana'/50]")
+	testUnion(banana, banana, "[/NULL/100 - /'banana'/50]")
 
 	// Partial overlap.
 	var apple Span
 	apple.Set(
-		&evalCtx,
+		keyCtx,
 		MakeCompositeKey(tree.NewDString("apple"), tree.NewDInt(200)), ExcludeBoundary,
 		MakeCompositeKey(tree.NewDString("cherry"), tree.NewDInt(300)), ExcludeBoundary,
 	)
-	testUnion(t, &evalCtx, banana, apple, "[/NULL/100 - /'cherry'/300)")
-	testUnion(t, &evalCtx, apple, banana, "[/NULL/100 - /'cherry'/300)")
+	testUnion(banana, apple, "[/NULL/100 - /'cherry'/300)")
+	testUnion(apple, banana, "[/NULL/100 - /'cherry'/300)")
 
 	// One span is subset of other.
 	var mango Span
 	mango.Set(
-		&evalCtx,
+		keyCtx,
 		MakeCompositeKey(tree.NewDString("apple"), tree.NewDInt(200)), ExcludeBoundary,
 		MakeCompositeKey(tree.NewDString("mango")), ExcludeBoundary,
 	)
-	testUnion(t, &evalCtx, apple, mango, "(/'apple'/200 - /'mango')")
-	testUnion(t, &evalCtx, mango, apple, "(/'apple'/200 - /'mango')")
-	testUnion(t, &evalCtx, Span{}, mango, "[ - ]")
-	testUnion(t, &evalCtx, mango, Span{}, "[ - ]")
+	testUnion(apple, mango, "(/'apple'/200 - /'mango')")
+	testUnion(mango, apple, "(/'apple'/200 - /'mango')")
+	testUnion(Span{}, mango, "[ - ]")
+	testUnion(mango, Span{}, "[ - ]")
 
 	// Spans are disjoint.
 	var pear Span
 	pear.Set(
-		&evalCtx,
+		keyCtx,
 		MakeCompositeKey(tree.NewDString("mango"), tree.NewDInt(0)), IncludeBoundary,
 		MakeCompositeKey(tree.NewDString("pear"), tree.NewDInt(10)), IncludeBoundary,
 	)
-	testUnion(t, &evalCtx, mango, pear, "")
-	testUnion(t, &evalCtx, pear, mango, "")
+	testUnion(mango, pear, "")
+	testUnion(pear, mango, "")
 
 	// Ensure that if TryUnionWith fails to merge, that it does not update
 	// either span.
 	mango2 := mango
 	pear2 := pear
-	mango2.TryUnionWith(&evalCtx, &pear2)
-	if mango2.Compare(&evalCtx, &mango) != 0 {
+	mango2.TryUnionWith(keyCtx, &pear2)
+	if mango2.Compare(keyCtx, &mango) != 0 {
 		t.Errorf("mango2 was incorrectly updated during TryUnionWith")
 	}
-	if pear2.Compare(&evalCtx, &pear) != 0 {
+	if pear2.Compare(keyCtx, &pear) != 0 {
 		t.Errorf("pear2 was incorrectly updated during TryUnionWith")
 	}
 
 	// Partial overlap on second key.
 	pear2.Set(
-		&evalCtx,
+		keyCtx,
 		MakeCompositeKey(tree.NewDString("pear"), tree.NewDInt(5), tree.DNull), ExcludeBoundary,
 		MakeCompositeKey(tree.NewDString("raspberry"), tree.NewDInt(100)), IncludeBoundary,
 	)
-	testUnion(t, &evalCtx, pear, pear2, "[/'mango'/0 - /'raspberry'/100]")
-	testUnion(t, &evalCtx, pear, pear2, "[/'mango'/0 - /'raspberry'/100]")
+	testUnion(pear, pear2, "[/'mango'/0 - /'raspberry'/100]")
+	testUnion(pear, pear2, "[/'mango'/0 - /'raspberry'/100]")
 
 	// Unconstrained (uninitialized) span.
-	testUnion(t, &evalCtx, banana, Span{}, "[ - ]")
-	testUnion(t, &evalCtx, Span{}, banana, "[ - ]")
+	testUnion(banana, Span{}, "[ - ]")
+	testUnion(Span{}, banana, "[ - ]")
 }


### PR DESCRIPTION
The index constraints code will use the new primitives from the
constraints package; we need to generalize the code a bit to allow
descending indexes. We also need to export more functionality - the
index selection code will need to create Constraints.

Release note: None