### PR TITLE
backport-2.0: server: fix /debug/stopper endpoint

### DIFF
--- a/pkg/server/debug/server.go
+++ b/pkg/server/debug/server.go
@@ -25,12 +25,14 @@ import (
 
 	"golang.org/x/net/trace"
 
-	"github.com/cockroachdb/cockroach/pkg/settings"
-	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
-	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/pkg/errors"
 	"github.com/rcrowley/go-metrics"
 	"github.com/rcrowley/go-metrics/exp"
+
+	"github.com/cockroachdb/cockroach/pkg/settings"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/stop"
 )
 
 var origTraceAuthRequest = trace.AuthRequest
@@ -106,6 +108,9 @@ func NewServer(st *cluster.Settings) *Server {
 	mux.Handle("/debug/metrics", exp.ExpHandler(metrics.DefaultRegistry))
 	// Also register /debug/vars (even though /debug/metrics is better).
 	mux.Handle("/debug/vars", expvar.Handler())
+
+	// Register the stopper endpoint, which lists all active tasks.
+	mux.HandleFunc("/debug/stopper", stop.HandleDebug)
 
 	// Set up the log spy, a tool that allows inspecting filtered logs at high
 	// verbosity.

--- a/pkg/util/stop/stopper.go
+++ b/pkg/util/stop/stopper.go
@@ -64,7 +64,8 @@ var trackedStoppers struct {
 	stoppers []*Stopper
 }
 
-func handleDebug(w http.ResponseWriter, r *http.Request) {
+// HandleDebug responds with the list of stopper tasks actively running.
+func HandleDebug(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
 	trackedStoppers.Lock()
 	defer trackedStoppers.Unlock()
@@ -73,10 +74,6 @@ func handleDebug(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintf(w, "%p: %d tasks\n%s", s, s.mu.numTasks, s.runningTasksLocked())
 		s.mu.Unlock()
 	}
-}
-
-func init() {
-	http.Handle("/debug/stopper", http.HandlerFunc(handleDebug))
 }
 
 // Closer is an interface for objects to attach to the stopper to


### PR DESCRIPTION
Backport 1/1 commits from #23886.

/cc @cockroachdb/release

---

This has been broken since 64c101dc, maybe longer.

Release note: None
