### PR TITLE
cherrypick-2.0: sql: use a spool operator to fix the correctness of CTE mutations

### DIFF
--- a/pkg/sql/delete.go
+++ b/pkg/sql/delete.go
@@ -196,6 +196,9 @@ func (d *deleteNode) Values() tree.Datums {
 	return d.run.resultRow
 }
 
+// requireSpool implements the planNodeRequireSpool interface.
+func (d *deleteNode) requireSpool() {}
+
 func (d *deleteNode) Close(ctx context.Context) {
 	d.run.rows.Close(ctx)
 	d.tw.close(ctx)

--- a/pkg/sql/insert.go
+++ b/pkg/sql/insert.go
@@ -299,6 +299,9 @@ func (n *insertNode) startExec(params runParams) error {
 	return n.run.tw.init(params.p.txn, params.EvalContext())
 }
 
+// requireSpool implements the planNodeRequireSpool interface.
+func (n *insertNode) requireSpool() {}
+
 func (n *insertNode) Close(ctx context.Context) {
 	n.tw.close(ctx)
 	if n.run.rows != nil {

--- a/pkg/sql/logictest/testdata/logic_test/spool
+++ b/pkg/sql/logictest/testdata/logic_test/spool
@@ -8,12 +8,13 @@ query TTT
 EXPLAIN WITH a AS (INSERT INTO t VALUES (2) RETURNING x)
         SELECT * FROM a LIMIT 1
 ----
-limit                  ·     ·
- └── spool             ·     ·
-      └── insert       ·     ·
-           │           into  t(x)
-           └── values  ·     ·
-·                      size  1 column, 1 row
+limit                  ·      ·
+ └── spool             ·      ·
+      │                limit  1
+      └── insert       ·      ·
+           │           into   t(x)
+           └── values  ·      ·
+·                      size   1 column, 1 row
 
 query TTT
 EXPLAIN WITH a AS (DELETE FROM t RETURNING x)
@@ -21,6 +22,7 @@ EXPLAIN WITH a AS (DELETE FROM t RETURNING x)
 ----
 limit                ·      ·
  └── spool           ·      ·
+      │              limit  1
       └── delete     ·      ·
            │         from   t
            └── scan  ·      ·
@@ -34,6 +36,7 @@ EXPLAIN WITH a AS (UPDATE t SET x = x + 1 RETURNING x)
 ----
 limit                     ·      ·
  └── spool                ·      ·
+      │                   limit  1
       └── update          ·      ·
            │              table  t
            │              set    x
@@ -57,18 +60,20 @@ limit             ·     ·
 query TTT
 EXPLAIN SELECT * FROM [INSERT INTO t VALUES (2) RETURNING x] LIMIT 1
 ----
-limit                  ·     ·
- └── spool             ·     ·
-      └── insert       ·     ·
-           │           into  t(x)
-           └── values  ·     ·
-·                      size  1 column, 1 row
+limit                  ·      ·
+ └── spool             ·      ·
+      │                limit  1
+      └── insert       ·      ·
+           │           into   t(x)
+           └── values  ·      ·
+·                      size   1 column, 1 row
 
 query TTT
 EXPLAIN SELECT * FROM [DELETE FROM t RETURNING x] LIMIT 1
 ----
 limit                ·      ·
  └── spool           ·      ·
+      │              limit  1
       └── delete     ·      ·
            │         from   t
            └── scan  ·      ·
@@ -80,6 +85,7 @@ EXPLAIN SELECT * FROM [UPDATE t SET x = x + 1 RETURNING x] LIMIT 1
 ----
 limit                     ·      ·
  └── spool                ·      ·
+      │                   limit  1
       └── update          ·      ·
            │              table  t
            │              set    x
@@ -130,15 +136,16 @@ EXPLAIN WITH a AS (INSERT INTO t VALUES(2) RETURNING x),
              b AS (INSERT INTO t SELECT x+1 FROM a RETURNING x)
         SELECT * FROM b LIMIT 1
 ----
-limit                            ·     ·
- └── spool                       ·     ·
-      └── insert                 ·     ·
-           │                     into  t(x)
-           └── render            ·     ·
-                └── insert       ·     ·
-                     │           into  t(x)
-                     └── values  ·     ·
-·                                size  1 column, 1 row
+limit                            ·      ·
+ └── spool                       ·      ·
+      │                          limit  1
+      └── insert                 ·      ·
+           │                     into   t(x)
+           └── render            ·      ·
+                └── insert       ·      ·
+                     │           into   t(x)
+                     └── values  ·      ·
+·                                size   1 column, 1 row
 
 # Check that no spool is inserted if a top-level render is elided.
 query TTT

--- a/pkg/sql/logictest/testdata/logic_test/spool
+++ b/pkg/sql/logictest/testdata/logic_test/spool
@@ -1,0 +1,164 @@
+# LogicTest: default
+
+statement ok
+CREATE TABLE t(x INT PRIMARY KEY); INSERT INTO t VALUES(1);
+
+# Check that if a mutation uses further processing, a spool is added.
+query TTT
+EXPLAIN WITH a AS (INSERT INTO t VALUES (2) RETURNING x)
+        SELECT * FROM a LIMIT 1
+----
+limit                  ·     ·
+ └── spool             ·     ·
+      └── insert       ·     ·
+           │           into  t(x)
+           └── values  ·     ·
+·                      size  1 column, 1 row
+
+query TTT
+EXPLAIN WITH a AS (DELETE FROM t RETURNING x)
+        SELECT * FROM a LIMIT 1
+----
+limit                ·      ·
+ └── spool           ·      ·
+      └── delete     ·      ·
+           │         from   t
+           └── scan  ·      ·
+·                    table  t@primary
+·                    spans  ALL
+
+
+query TTT
+EXPLAIN WITH a AS (UPDATE t SET x = x + 1 RETURNING x)
+        SELECT * FROM a LIMIT 1
+----
+limit                     ·      ·
+ └── spool                ·      ·
+      └── update          ·      ·
+           │              table  t
+           │              set    x
+           └── render     ·      ·
+                └── scan  ·      ·
+·                         table  t@primary
+·                         spans  ALL
+
+# Upsert is special, it doesn't need a spool.
+query TTT
+EXPLAIN WITH a AS (UPSERT INTO t VALUES (2) RETURNING x)
+        SELECT * FROM a LIMIT 1
+----
+limit             ·     ·
+ └── upsert       ·     ·
+      │           into  t(x)
+      └── values  ·     ·
+·                 size  1 column, 1 row
+
+# Ditto all mutations, with the statement source syntax.
+query TTT
+EXPLAIN SELECT * FROM [INSERT INTO t VALUES (2) RETURNING x] LIMIT 1
+----
+limit                  ·     ·
+ └── spool             ·     ·
+      └── insert       ·     ·
+           │           into  t(x)
+           └── values  ·     ·
+·                      size  1 column, 1 row
+
+query TTT
+EXPLAIN SELECT * FROM [DELETE FROM t RETURNING x] LIMIT 1
+----
+limit                ·      ·
+ └── spool           ·      ·
+      └── delete     ·      ·
+           │         from   t
+           └── scan  ·      ·
+·                    table  t@primary
+·                    spans  ALL
+
+query TTT
+EXPLAIN SELECT * FROM [UPDATE t SET x = x + 1 RETURNING x] LIMIT 1
+----
+limit                     ·      ·
+ └── spool                ·      ·
+      └── update          ·      ·
+           │              table  t
+           │              set    x
+           └── render     ·      ·
+                └── scan  ·      ·
+·                         table  t@primary
+·                         spans  ALL
+
+query TTT
+EXPLAIN SELECT * FROM [UPSERT INTO t VALUES (2) RETURNING x] LIMIT 1
+----
+limit             ·     ·
+ └── upsert       ·     ·
+      │           into  t(x)
+      └── values  ·     ·
+·                 size  1 column, 1 row
+
+# Check that a spool is also inserted for other processings than LIMIT.
+query TTT
+EXPLAIN SELECT * FROM [INSERT INTO t VALUES (2) RETURNING x] ORDER BY x
+----
+sort                   ·      ·
+ │                     order  +x
+ └── spool             ·      ·
+      └── insert       ·      ·
+           │           into   t(x)
+           └── values  ·      ·
+·                      size   1 column, 1 row
+
+query TTT
+EXPLAIN SELECT * FROM [INSERT INTO t VALUES (2) RETURNING x], t
+----
+join                   ·      ·
+ │                     type   cross
+ ├── spool             ·      ·
+ │    └── insert       ·      ·
+ │         │           into   t(x)
+ │         └── values  ·      ·
+ │                     size   1 column, 1 row
+ └── scan              ·      ·
+·                      table  t@primary
+·                      spans  ALL
+
+# Check that if a spool is already added at some level, then it is not added
+# again at levels below.
+query TTT
+EXPLAIN WITH a AS (INSERT INTO t VALUES(2) RETURNING x),
+             b AS (INSERT INTO t SELECT x+1 FROM a RETURNING x)
+        SELECT * FROM b LIMIT 1
+----
+limit                            ·     ·
+ └── spool                       ·     ·
+      └── insert                 ·     ·
+           │                     into  t(x)
+           └── render            ·     ·
+                └── insert       ·     ·
+                     │           into  t(x)
+                     └── values  ·     ·
+·                                size  1 column, 1 row
+
+# Check that no spool is inserted if a top-level render is elided.
+query TTT
+EXPLAIN SELECT * FROM [INSERT INTO t VALUES (2) RETURNING x]
+----
+insert       ·     ·
+ │           into  t(x)
+ └── values  ·     ·
+·            size  1 column, 1 row
+
+# Check that no spool is used for a top-level INSERT, but
+# sub-INSERTs still get a spool.
+query TTT
+EXPLAIN INSERT INTO t SELECT x+1 FROM [INSERT INTO t VALUES(2) RETURNING x]
+----
+insert                      ·     ·
+ │                          into  t(x)
+ └── render                 ·     ·
+      └── spool             ·     ·
+           └── insert       ·     ·
+                │           into  t(x)
+                └── values  ·     ·
+·                           size  1 column, 1 row

--- a/pkg/sql/logictest/testdata/logic_test/statement_source
+++ b/pkg/sql/logictest/testdata/logic_test/statement_source
@@ -8,3 +8,65 @@ SELECT 1 FROM [INSERT INTO a VALUES (1, 2)]
 
 query error statement source "DELETE FROM a" does not return any columns
 SELECT 1 FROM [DELETE FROM a]
+
+query II
+SELECT @1, a+b FROM [INSERT INTO a VALUES (1,2) RETURNING b,a]
+----
+2 3
+
+# Check that LIMIT does not apply to mutation statements
+query II
+  WITH a AS (INSERT INTO a VALUES (2,3), (3,4) RETURNING a,b)
+SELECT * FROM a LIMIT 0
+----
+
+query II
+SELECT * FROM [INSERT INTO a VALUES (4,5), (5,6) RETURNING a,b] LIMIT 0
+----
+
+query II
+  WITH a AS (UPSERT INTO a VALUES (2,3), (6,7) RETURNING a,b)
+SELECT * FROM a LIMIT 0
+----
+
+query II
+SELECT * FROM [UPSERT INTO a VALUES (4,5), (7,8) RETURNING a,b] LIMIT 0
+----
+
+
+query II
+  WITH a AS (UPDATE a SET a = -a WHERE b % 2 = 1 RETURNING a,b)
+SELECT * FROM a LIMIT 0
+----
+
+query II
+SELECT * FROM [UPDATE a SET a = a*100 WHERE b < 3 RETURNING a,b] LIMIT 0
+----
+
+query II
+SELECT * FROM a ORDER BY b
+----
+100  2
+-2   3
+3    4
+-4   5
+5    6
+-6   7
+7    8
+
+query II
+  WITH a AS (DELETE FROM a WHERE b IN (4,5) RETURNING a,b)
+SELECT * FROM a LIMIT 0
+----
+
+query II
+SELECT * FROM [DELETE FROM a WHERE b IN (6,7) RETURNING a,b] LIMIT 0
+----
+
+
+query II
+SELECT * FROM a ORDER BY b
+----
+100  2
+-2   3
+7    8

--- a/pkg/sql/opt_filters.go
+++ b/pkg/sql/opt_filters.go
@@ -254,6 +254,11 @@ func (p *planner) propagateFilters(
 			return plan, extraFilter, err
 		}
 
+	case *spoolNode:
+		if n.source, err = p.triggerFilterPropagation(ctx, n.source); err != nil {
+			return plan, extraFilter, err
+		}
+
 	case *createTableNode:
 		if n.n.As() {
 			if n.sourcePlan, err = p.triggerFilterPropagation(ctx, n.sourcePlan); err != nil {

--- a/pkg/sql/opt_limits.go
+++ b/pkg/sql/opt_limits.go
@@ -131,6 +131,9 @@ func (p *planner) applyLimit(plan planNode, numRows int64, soft bool) {
 	case *ordinalityNode:
 		p.applyLimit(n.source, numRows, soft)
 
+	case *spoolNode:
+		p.setUnlimited(n.source)
+
 	case *delayedNode:
 		if n.plan != nil {
 			p.applyLimit(n.plan, numRows, soft)

--- a/pkg/sql/opt_limits.go
+++ b/pkg/sql/opt_limits.go
@@ -132,7 +132,10 @@ func (p *planner) applyLimit(plan planNode, numRows int64, soft bool) {
 		p.applyLimit(n.source, numRows, soft)
 
 	case *spoolNode:
-		p.setUnlimited(n.source)
+		if !soft {
+			n.hardLimit = numRows
+		}
+		p.applyLimit(n.source, numRows, soft)
 
 	case *delayedNode:
 		if n.plan != nil {
@@ -140,12 +143,24 @@ func (p *planner) applyLimit(plan planNode, numRows int64, soft bool) {
 		}
 
 	case *deleteNode:
+		// A limit does not propagate into a mutation. When there is a
+		// surrounding query, the mutation must run to completion even if
+		// the surrounding query only uses parts of its results.
 		p.setUnlimited(n.run.rows)
 	case *updateNode:
+		// A limit does not propagate into a mutation. When there is a
+		// surrounding query, the mutation must run to completion even if
+		// the surrounding query only uses parts of its results.
 		p.setUnlimited(n.run.rows)
 	case *insertNode:
+		// A limit does not propagate into a mutation. When there is a
+		// surrounding query, the mutation must run to completion even if
+		// the surrounding query only uses parts of its results.
 		p.setUnlimited(n.run.rows)
 	case *upsertNode:
+		// A limit does not propagate into a mutation. When there is a
+		// surrounding query, the mutation must run to completion even if
+		// the surrounding query only uses parts of its results.
 		p.setUnlimited(n.run.rows)
 	case *createTableNode:
 		if n.sourcePlan != nil {

--- a/pkg/sql/opt_needed.go
+++ b/pkg/sql/opt_needed.go
@@ -48,6 +48,9 @@ func setNeededColumns(plan planNode, needed []bool) {
 	case *limitNode:
 		setNeededColumns(n.plan, needed)
 
+	case *spoolNode:
+		setNeededColumns(n.source, needed)
+
 	case *indexJoinNode:
 		// Currently all the needed result columns are provided by the
 		// table sub-source; from the index sub-source we only need the PK

--- a/pkg/sql/plan.go
+++ b/pkg/sql/plan.go
@@ -212,6 +212,34 @@ var _ planNodeFastPath = &deleteNode{}
 var _ planNodeFastPath = &setZoneConfigNode{}
 var _ planNodeFastPath = &upsertNode{}
 
+// planNodeRequireSpool serves as marker for nodes whose parent must
+// ensure that the node is fully run to completion (and the results
+// spooled) during the start phase. This is currently implemented by
+// all mutation statements except for upsert.
+type planNodeRequireSpool interface {
+	requireSpool()
+}
+
+var _ planNodeRequireSpool = &insertNode{}
+var _ planNodeRequireSpool = &deleteNode{}
+var _ planNodeRequireSpool = &updateNode{}
+
+// planNodeSpool serves as marker for nodes that can perform all their
+// execution during the start phase. This is different from the "fast
+// path" interface because a node that performs all its execution
+// during the start phase might still have some result rows and thus
+// not implement the fast path.
+//
+// This interface exists for the following optimization: nodes
+// that require spooling but are the children of a spooled node
+// do not require the introduction of an explicit spool.
+type planNodeSpooled interface {
+	spooled()
+}
+
+var _ planNodeSpooled = &upsertNode{}
+var _ planNodeSpooled = &spoolNode{}
+
 // planTop is the struct that collects the properties
 // of an entire plan.
 // Note: some additional per-statement state is also stored in
@@ -448,6 +476,13 @@ type autoCommitNode interface {
 	// interface).
 	enableAutoCommit()
 }
+
+var _ autoCommitNode = &createTableNode{}
+var _ autoCommitNode = &delayedNode{}
+var _ autoCommitNode = &deleteNode{}
+var _ autoCommitNode = &insertNode{}
+var _ autoCommitNode = &updateNode{}
+var _ autoCommitNode = &upsertNode{}
 
 // startExec calls startExec() on each planNode that supports
 // execStartable using a depth-first, post-order traversal.

--- a/pkg/sql/plan_columns.go
+++ b/pkg/sql/plan_columns.go
@@ -122,6 +122,8 @@ func getPlanColumns(plan planNode, mut bool) sqlbase.ResultColumns {
 		return getPlanColumns(n.table, mut)
 	case *limitNode:
 		return getPlanColumns(n.plan, mut)
+	case *spoolNode:
+		return getPlanColumns(n.source, mut)
 	}
 
 	// Every other node has no columns in their results.

--- a/pkg/sql/plan_physical_props.go
+++ b/pkg/sql/plan_physical_props.go
@@ -33,6 +33,8 @@ func planPhysicalProps(plan planNode) physicalProps {
 		return planPhysicalProps(n.run.results)
 	case *limitNode:
 		return planPhysicalProps(n.plan)
+	case *spoolNode:
+		return planPhysicalProps(n.source)
 	case *indexJoinNode:
 		return planPhysicalProps(n.index)
 

--- a/pkg/sql/plan_spans.go
+++ b/pkg/sql/plan_spans.go
@@ -70,6 +70,8 @@ func collectSpans(params runParams, plan planNode) (reads, writes roachpb.Spans,
 		return collectSpans(params, n.plan)
 	case *limitNode:
 		return collectSpans(params, n.plan)
+	case *spoolNode:
+		return collectSpans(params, n.source)
 	case *sortNode:
 		return collectSpans(params, n.plan)
 	case *groupNode:

--- a/pkg/sql/spool.go
+++ b/pkg/sql/spool.go
@@ -1,0 +1,110 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package sql
+
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+)
+
+// spoolNode ensures that a child planNode is executed to completion
+// during the start phase. The results, if any, are collected. The
+// child node is guaranteed to run to completion.
+type spoolNode struct {
+	source    planNode
+	rows      *sqlbase.RowContainer
+	curRowIdx int
+}
+
+func (p *planner) makeSpool(source planNode) planNode {
+	return &spoolNode{source: source}
+}
+
+// startExec implements the execStartable interface.
+func (s *spoolNode) startExec(params runParams) error {
+	// If FastPathResults() on the source indicates that the results are
+	// already available (2nd value true), then the computation is
+	// already done at start time and spooling is unnecessary.
+	if f, ok := s.source.(planNodeFastPath); ok {
+		_, done := f.FastPathResults()
+		if done {
+			return nil
+		}
+	}
+
+	s.rows = sqlbase.NewRowContainer(
+		params.EvalContext().Mon.MakeBoundAccount(),
+		sqlbase.ColTypeInfoFromResCols(planColumns(s.source)),
+		0, /* rowCapacity */
+	)
+
+	// Accumulate all the rows. This also guarantees execution of the
+	// child node to completion, even if Next() is not called for every
+	// row.
+	for {
+		next, err := s.source.Next(params)
+		if err != nil {
+			return err
+		}
+		if !next {
+			break
+		}
+		if _, err := s.rows.AddRow(params.ctx, s.source.Values()); err != nil {
+			return err
+		}
+	}
+	s.curRowIdx = -1
+	return nil
+}
+
+// FastPathResults implements the planNodeFastPath interface.
+func (s *spoolNode) FastPathResults() (int, bool) {
+	// If the source implements the fast path interface, let it report
+	// its status through. This lets e.g. the fast path of a DELETE or
+	// an UPSERT report that they have finished its computing already,
+	// so the calls to Next() on the spool itself can also be elided.
+	// If FastPathResults() on the source says the fast path is unavailable,
+	// then startExec() on the spool will also notice that and
+	// spooling will occur as expected.
+	if f, ok := s.source.(planNodeFastPath); ok {
+		return f.FastPathResults()
+	}
+	return 0, false
+}
+
+// spooled implements the planNodeSpooled interface.
+func (s *spoolNode) spooled() {}
+
+// Next is part of the planNode interface.
+func (s *spoolNode) Next(params runParams) (bool, error) {
+	s.curRowIdx++
+	return s.curRowIdx < s.rows.Len(), nil
+}
+
+// Values is part of the planNode interface.
+func (s *spoolNode) Values() tree.Datums {
+	return s.rows.At(s.curRowIdx)
+}
+
+// Close is part of the planNode interface.
+func (s *spoolNode) Close(ctx context.Context) {
+	s.source.Close(ctx)
+	if s.rows != nil {
+		s.rows.Close(ctx)
+		s.rows = nil
+	}
+}

--- a/pkg/sql/spool.go
+++ b/pkg/sql/spool.go
@@ -24,9 +24,12 @@ import (
 // spoolNode ensures that a child planNode is executed to completion
 // during the start phase. The results, if any, are collected. The
 // child node is guaranteed to run to completion.
+// If hardLimit is set, only that number of rows is collected, but
+// the child node is still run to completion.
 type spoolNode struct {
 	source    planNode
 	rows      *sqlbase.RowContainer
+	hardLimit int64
 	curRowIdx int
 }
 
@@ -52,9 +55,9 @@ func (s *spoolNode) startExec(params runParams) error {
 		0, /* rowCapacity */
 	)
 
-	// Accumulate all the rows. This also guarantees execution of the
-	// child node to completion, even if Next() is not called for every
-	// row.
+	// Accumulate all the rows up to the hardLimit, if any.
+	// This also guarantees execution of the child node to completion,
+	// even if Next() on the spool itself is not called for every row.
 	for {
 		next, err := s.source.Next(params)
 		if err != nil {
@@ -63,8 +66,10 @@ func (s *spoolNode) startExec(params runParams) error {
 		if !next {
 			break
 		}
-		if _, err := s.rows.AddRow(params.ctx, s.source.Values()); err != nil {
-			return err
+		if s.hardLimit == 0 || int64(s.rows.Len()) < s.hardLimit {
+			if _, err := s.rows.AddRow(params.ctx, s.source.Values()); err != nil {
+				return err
+			}
 		}
 	}
 	s.curRowIdx = -1

--- a/pkg/sql/update.go
+++ b/pkg/sql/update.go
@@ -401,6 +401,9 @@ func (u *updateNode) Values() tree.Datums {
 	return u.run.resultRow
 }
 
+// requireSpool implements the planNodeRequireSpool interface.
+func (u *updateNode) requireSpool() {}
+
 func (u *updateNode) Close(ctx context.Context) {
 	u.run.rows.Close(ctx)
 	u.tw.close(ctx)

--- a/pkg/sql/upsert.go
+++ b/pkg/sql/upsert.go
@@ -290,6 +290,9 @@ func (n *upsertNode) startExec(params runParams) error {
 	return nil
 }
 
+// spooled implements the planNodeSpooled interface.
+func (n *upsertNode) spooled() {}
+
 func (n *upsertNode) FastPathResults() (int, bool) {
 	if n.run.rowsUpserted != nil {
 		return 0, false

--- a/pkg/sql/walk.go
+++ b/pkg/sql/walk.go
@@ -449,6 +449,9 @@ func (v *planVisitor) visit(plan planNode) {
 	case *ordinalityNode:
 		v.visit(n.source)
 
+	case *spoolNode:
+		v.visit(n.source)
+
 	case *showTraceNode:
 		v.visit(n.plan)
 
@@ -564,6 +567,7 @@ var planNodeNames = map[reflect.Type]string{
 	reflect.TypeOf(&showFingerprintsNode{}):     "showFingerprints",
 	reflect.TypeOf(&sortNode{}):                 "sort",
 	reflect.TypeOf(&splitNode{}):                "split",
+	reflect.TypeOf(&spoolNode{}):                "spool",
 	reflect.TypeOf(&unionNode{}):                "union",
 	reflect.TypeOf(&updateNode{}):               "update",
 	reflect.TypeOf(&upsertNode{}):               "upsert",

--- a/pkg/sql/walk.go
+++ b/pkg/sql/walk.go
@@ -450,6 +450,9 @@ func (v *planVisitor) visit(plan planNode) {
 		v.visit(n.source)
 
 	case *spoolNode:
+		if n.hardLimit > 0 && v.observer.attr != nil {
+			v.observer.attr(name, "limit", fmt.Sprintf("%d", n.hardLimit))
+		}
 		v.visit(n.source)
 
 	case *showTraceNode:


### PR DESCRIPTION
Picks #23824.

cc @cockroachdb/release 