### PR TITLE
kubernetes: Fix secure/insecure channel naming mismatch

### DIFF
--- a/cloud/kubernetes/cockroachdb-statefulset-secure.yaml
+++ b/cloud/kubernetes/cockroachdb-statefulset-secure.yaml
@@ -204,7 +204,7 @@ spec:
           mountPath: /cockroach/cockroach-certs
         env:
         - name: COCKROACH_CHANNEL
-          value: kubernetes-insecure
+          value: kubernetes-secure
         command:
           - "/bin/bash"
           - "-ecx"

--- a/cloud/kubernetes/cockroachdb-statefulset.yaml
+++ b/cloud/kubernetes/cockroachdb-statefulset.yaml
@@ -104,7 +104,7 @@ spec:
           mountPath: /cockroach/cockroach-data
         env:
         - name: COCKROACH_CHANNEL
-          value: kubernetes-secure
+          value: kubernetes-insecure
         command:
           - "/bin/bash"
           - "-ecx"


### PR DESCRIPTION
The fact that the file without a special suffix is the insecure one
never fails to trick me.

Release note: None