### PR TITLE
jobs: Allow leniency before stealing work

### DIFF
--- a/pkg/ccl/importccl/csv_test.go
+++ b/pkg/ccl/importccl/csv_test.go
@@ -21,6 +21,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
@@ -1135,8 +1137,9 @@ func TestImportControlJob(t *testing.T) {
 	})
 }
 
-// TestImportLiveness tests that a node liveness increment during IMPORT
-// correctly resumes.
+// TestImportLivenessWithRestart tests that a node liveness transition
+// during IMPORT correctly resumes after the node executing the job
+// becomes non-live (from the perspective of the jobs registry).
 //
 // Its actual purpose is to address the second bug listed in #22924 about
 // the addsstable arguments not in request range. The theory was that the
@@ -1145,7 +1148,7 @@ func TestImportControlJob(t *testing.T) {
 // error. However this does not appear to be the case, as running many stress
 // iterations with differing constants (rows, sstsize, kv.import.batch_size)
 // was not able to fail in the way listed by the second bug.
-func TestImportLiveness(t *testing.T) {
+func TestImportLivenessWithRestart(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	defer func(oldInterval time.Duration) {
@@ -1206,12 +1209,21 @@ func TestImportLiveness(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
-	// Fetch the new job ID since we know it's running now.
+	// Fetch the new job ID and lease since we know it's running now.
 	var jobID int64
-	sqlDB.QueryRow(t, `SELECT id FROM system.jobs ORDER BY created DESC LIMIT 1`).Scan(&jobID)
+	originalLease := &jobs.Payload{}
+	{
+		var expectedLeaseBytes []byte
+		sqlDB.QueryRow(
+			t, `SELECT id, payload FROM system.jobs ORDER BY created DESC LIMIT 1`,
+		).Scan(&jobID, &expectedLeaseBytes)
+		if err := protoutil.Unmarshal(expectedLeaseBytes, originalLease); err != nil {
+			t.Fatal(err)
+		}
+	}
 
-	// addsstable is done, now tick liveness and wait for it to cancel the import.
-	nl.FakeIncrementEpoch(1)
+	// addsstable is done, make the node non-live and wait for cancellation
+	nl.FakeSetExpiration(1, hlc.MinTimestamp)
 	// Wait for the registry cancel loop to run and cancel the job.
 	<-nl.SelfCalledCh
 	<-nl.SelfCalledCh
@@ -1220,7 +1232,123 @@ func TestImportLiveness(t *testing.T) {
 	if !testutils.IsError(err, "job .*: node liveness error") {
 		t.Fatalf("unexpected: %v", err)
 	}
+	// Make the node live again
+	nl.FakeSetExpiration(1, hlc.MaxTimestamp)
 	// The registry should now adopt the job and resume it.
+	if err := jobutils.WaitForJob(sqlDB.DB, jobID); err != nil {
+		t.Fatal(err)
+	}
+	// Verify that the job lease was updated
+	rescheduledLease := &jobs.Payload{}
+	{
+		var actualLeaseBytes []byte
+		sqlDB.QueryRow(
+			t, `SELECT payload FROM system.jobs WHERE id = $1`, jobID,
+		).Scan(&actualLeaseBytes)
+		if err := protoutil.Unmarshal(actualLeaseBytes, rescheduledLease); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if rescheduledLease.ModifiedMicros <= originalLease.ModifiedMicros {
+		t.Fatalf("expecting rescheduled job to have a later modification time: %d vs %d",
+			rescheduledLease.StartedMicros, originalLease.StartedMicros)
+	}
+}
+
+// TestImportLivenessWithLeniency tests that a temporary node liveness
+// transition during IMPORT doesn't cancel the job, but allows the
+// owning node to continue processing.
+func TestImportLivenessWithLeniency(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	defer func(oldInterval time.Duration) {
+		jobs.DefaultAdoptInterval = oldInterval
+	}(jobs.DefaultAdoptInterval)
+	jobs.DefaultAdoptInterval = 100 * time.Millisecond
+	jobs.DefaultCancelInterval = 100 * time.Millisecond
+
+	const nodes = 1
+	nl := jobs.NewFakeNodeLiveness(nodes)
+	serverArgs := base.TestServerArgs{
+		Knobs: base.TestingKnobs{
+			RegistryLiveness: nl,
+		},
+	}
+
+	var allowResponse chan struct{}
+	params := base.TestClusterArgs{ServerArgs: serverArgs}
+	params.ServerArgs.Knobs.Store = &storage.StoreTestingKnobs{
+		TestingResponseFilter: jobutils.BulkOpResponseFilter(&allowResponse),
+	}
+
+	ctx := context.Background()
+	tc := testcluster.StartTestCluster(t, nodes, params)
+	defer tc.Stopper().Stop(ctx)
+	sqlDB := sqlutils.MakeSQLRunner(tc.Conns[0])
+
+	// Prevent hung HTTP connections in leaktest.
+	sqlDB.Exec(t, `SET CLUSTER SETTING cloudstorage.timeout = '3s'`)
+	// We want to know exactly how much leniency is configured.
+	sqlDB.Exec(t, `SET CLUSTER SETTING jobs.registry.leniency = '1m'`)
+	sqlDB.Exec(t, `SET CLUSTER SETTING kv.import.batch_size = '300B'`)
+	sqlDB.Exec(t, `CREATE DATABASE liveness`)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		const rows = 5000
+		if r.Method == "GET" {
+			for i := 0; i < rows; i++ {
+				fmt.Fprintln(w, i)
+			}
+		}
+	}))
+	defer srv.Close()
+
+	const query = `IMPORT TABLE liveness.t (i INT PRIMARY KEY) CSV DATA ($1) WITH sstsize = '500B'`
+
+	// Start an IMPORT and wait until it's done one addsstable.
+	allowResponse = make(chan struct{})
+	errCh := make(chan error)
+	go func() {
+		_, err := sqlDB.DB.Exec(query, srv.URL)
+		errCh <- err
+	}()
+	// Allow many, but not all, addsstables to complete.
+	for i := 0; i < 50; i++ {
+		select {
+		case allowResponse <- struct{}{}:
+		case err := <-errCh:
+			t.Fatal(err)
+		}
+	}
+	// Fetch the new job ID and lease since we know it's running now.
+	var jobID int64
+	originalLease := &jobs.Payload{}
+	{
+		var expectedLeaseBytes []byte
+		sqlDB.QueryRow(
+			t, `SELECT id, payload FROM system.jobs ORDER BY created DESC LIMIT 1`,
+		).Scan(&jobID, &expectedLeaseBytes)
+		if err := protoutil.Unmarshal(expectedLeaseBytes, originalLease); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// addsstable is done, make the node slightly tardy.
+	nl.FakeSetExpiration(1, hlc.Timestamp{
+		WallTime: hlc.UnixNano() - (15 * time.Second).Nanoseconds(),
+	})
+
+	// Wait for the registry cancel loop to run and cancel the job.
+	<-nl.SelfCalledCh
+	<-nl.SelfCalledCh
+	close(allowResponse)
+
+	// Verify that the client didn't see anything amiss.
+	if err := <-errCh; err != nil {
+		t.Fatalf("import job should have completed: %s", err)
+	}
+
+	// The job should have completed normally.
 	if err := jobutils.WaitForJob(sqlDB.DB, jobID); err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/sql/jobs/registry.go
+++ b/pkg/sql/jobs/registry.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/pkg/errors"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
@@ -34,7 +35,17 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 )
 
-var nodeLivenessLogLimiter = log.Every(5 * time.Second)
+const defaultLeniencySetting = 60 * time.Second
+
+var (
+	nodeLivenessLogLimiter = log.Every(5 * time.Second)
+	// LeniencySetting is the amount of time to defer any attempts to
+	// reschedule a job.  Visible for testing.
+	LeniencySetting = settings.RegisterDurationSetting(
+		"jobs.registry.leniency",
+		"the amount of time to defer any attempts to reschedule a job",
+		defaultLeniencySetting)
+)
 
 // NodeLiveness is the subset of storage.NodeLiveness's interface needed
 // by Registry.
@@ -44,6 +55,30 @@ type NodeLiveness interface {
 }
 
 // Registry creates Jobs and manages their leases and cancelation.
+//
+// Job information is stored in the `system.jobs` table.  Each node will
+// poll this table and establish a lease on any claimed job. Registry
+// calculates its own liveness for a node based on the expiration time
+// of the underlying node-liveness lease.  This is because we want to
+// allow jobs assigned to temporarily non-live (i.e. saturated) nodes to
+// continue without being canceled.
+//
+// When a lease has been determined to be stale, a node may attempt to
+// claim the relevant job. Thus, a Registry must occasionally
+// re-validate its own leases to ensure that another node has not stolen
+// the work and cancel the local job if so.
+//
+// Prior versions of Registry used the node's epoch value to determine
+// whether or not a job should be stolen.  The current implementation
+// uses a time-based approach, where a node's last reported expiration
+// timestamp is used to calculate a liveness value for the purpose
+// of job scheduling.
+//
+// Mixed-version operation between epoch- and time-based nodes works
+// since we still publish epoch information in the leases for time-based
+// nodes.  From the perspective of a time-based node, an epoch-based
+// node simply behaves as though its leniency period is 0. Epoch-based
+// nodes will see time-based nodes delay the act of stealing a job.
 type Registry struct {
 	ac       log.AmbientContext
 	db       *client.DB
@@ -55,6 +90,9 @@ type Registry struct {
 
 	mu struct {
 		syncutil.Mutex
+		// epoch is present to support older nodes that are not using
+		// the timestamp-based approach to determine when to steal jobs.
+		// TODO: Remove this and deprecate Lease.Epoch proto field
 		epoch int64
 		// jobs holds a map from job id to its context cancel func. This should
 		// be populated with jobs that are currently being run (and owned) by
@@ -106,6 +144,21 @@ func MakeRegistry(
 	r.mu.epoch = 1
 	r.mu.jobs = make(map[int64]context.CancelFunc)
 	return r
+}
+
+// lenientNow returns the timestamp after which we should attempt
+// to steal a job from a node whose liveness is failing.  This allows
+// jobs coordinated by a node which is temporarily saturated to continue.
+func (r *Registry) lenientNow() hlc.Timestamp {
+	// We see this in tests.
+	var offset time.Duration
+	if r.settings == cluster.NoSettings {
+		offset = defaultLeniencySetting
+	} else {
+		offset = LeniencySetting.Get(&r.settings.SV)
+	}
+
+	return r.clock.Now().Add(-offset.Nanoseconds(), 0)
 }
 
 // makeCtx returns a new context from r's ambient context and an associated
@@ -241,18 +294,10 @@ func (r *Registry) maybeCancelJobs(ctx context.Context, nl NodeLiveness) {
 
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	// TODO(benesch): this logic is correct but too aggressive. Jobs created
-	// immediately after a liveness failure but before we've updated our cached
-	// epoch will be unnecessarily canceled.
-	//
-	// Additionally consider handling the case where our locally-cached liveness
-	// record is expired, but a non-expired liveness record has, in fact, been
-	// successfully persisted. Rather than canceling all jobs immediately, we
-	// could instead wait to see if we managed a successful heartbeat at the
-	// current epoch. The additional complexity this requires is not clearly
-	// worthwhile.
-	sameEpoch := liveness.Epoch == r.mu.epoch
-	if !sameEpoch || !liveness.IsLive(r.clock.Now(), r.clock.MaxOffset()) {
+	// If we haven't persisted a liveness record within the leniency
+	// interval, we'll cancel all of our jobs.
+	if !liveness.IsLive(r.lenientNow(), r.clock.MaxOffset()) {
+		log.Warning(ctx, "canceling all jobs due to liveness failure")
 		r.cancelAll(ctx)
 		r.mu.epoch = liveness.Epoch
 	}
@@ -432,7 +477,6 @@ func (r *Registry) maybeAdoptJob(ctx context.Context, nl NodeLiveness) error {
 
 	type nodeStatus struct {
 		isLive bool
-		epoch  int64
 	}
 	nodeStatusMap := map[roachpb.NodeID]*nodeStatus{
 		// 0 is not a valid node ID, but we treat it as an always-dead node so that
@@ -440,11 +484,24 @@ func (r *Registry) maybeAdoptJob(ctx context.Context, nl NodeLiveness) error {
 		0: {isLive: false},
 	}
 	{
-		now, maxOffset := r.clock.Now(), r.clock.MaxOffset()
+		// We subtract the leniency interval here to artificially
+		// widen the range of times over which the job registry will
+		// consider the node to be alive.  We rely on the fact that
+		// only a live node updates its own expiration.  Thus, the
+		// expiration time can be used as a reasonable measure of
+		// when the node was last seen.
+		now, maxOffset := r.lenientNow(), r.clock.MaxOffset()
 		for _, liveness := range nl.GetLivenesses() {
 			nodeStatusMap[liveness.NodeID] = &nodeStatus{
 				isLive: liveness.IsLive(now, maxOffset),
-				epoch:  liveness.Epoch,
+			}
+
+			// Don't try to start any more jobs unless we're really live,
+			// otherwise we'd just immediately cancel them.
+			if liveness.NodeID == r.nodeID.Get() {
+				if !liveness.IsLive(r.clock.Now(), maxOffset) {
+					return nil
+				}
 			}
 		}
 	}
@@ -484,6 +541,10 @@ func (r *Registry) maybeAdoptJob(ctx context.Context, nl NodeLiveness) error {
 			// overcautiously cancel all jobs due to e.g. a slow heartbeat response.
 			// If that heartbeat managed to successfully extend the liveness lease,
 			// we'll have stopped running jobs on which we still had valid leases.
+			//
+			// This path also takes care of the case where a node adopts a job
+			// and is then restarted; the node will attempt to restart
+			// any previously-leased job.
 			needsResume = !running
 		} else {
 			// If we are currently running a job that another node has the lease on,
@@ -499,7 +560,7 @@ func (r *Registry) maybeAdoptJob(ctx context.Context, nl NodeLiveness) error {
 					*id, payload.Lease.NodeID)
 				continue
 			}
-			needsResume = nodeStatus.epoch > payload.Lease.Epoch || !nodeStatus.isLive
+			needsResume = !nodeStatus.isLive
 		}
 
 		if !needsResume {

--- a/pkg/sql/jobs/registry_external_test.go
+++ b/pkg/sql/jobs/registry_external_test.go
@@ -75,6 +75,9 @@ func TestRegistryResumeExpiredLease(t *testing.T) {
 	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
 	defer s.Stopper().Stop(ctx)
 
+	// Disable leniency for instant expiration
+	jobs.LeniencySetting.Override(&s.ClusterSettings().SV, 0)
+
 	db := s.DB()
 	ex := &sql.InternalExecutor{ExecCfg: s.InternalExecutor().(*sql.InternalExecutor).ExecCfg}
 	clock := hlc.NewClock(hlc.UnixNano, time.Nanosecond)
@@ -85,7 +88,7 @@ func TestRegistryResumeExpiredLease(t *testing.T) {
 
 		nodeID := &base.NodeIDContainer{}
 		nodeID.Reset(id)
-		r := jobs.MakeRegistry(log.AmbientContext{}, clock, db, ex, nodeID, cluster.NoSettings, jobs.FakePHS)
+		r := jobs.MakeRegistry(log.AmbientContext{}, clock, db, ex, nodeID, s.ClusterSettings(), jobs.FakePHS)
 		if err := r.Start(ctx, s.Stopper(), nodeLiveness, cancelInterval, adoptInterval); err != nil {
 			t.Fatal(err)
 		}
@@ -180,13 +183,27 @@ func TestRegistryResumeExpiredLease(t *testing.T) {
 		return nil
 	})
 
+	// We want to verify that simply incrementing the epoch does not
+	// result in the job being rescheduled.
 	nodeLiveness.FakeIncrementEpoch(3)
+	drainAdoptionLoop()
+	select {
+	case <-resumeCalled:
+		t.Fatal("Incrementing an epoch should not reschedule a job")
+	default:
+	}
+
+	// When we reset the liveness of the node, though, we should get
+	// a reschedule.
+	nodeLiveness.FakeSetExpiration(3, hlc.MinTimestamp)
+	drainAdoptionLoop()
 	<-resumeCalled
 	close(done)
+
 	testutils.SucceedsSoon(t, func() error {
 		lock.Lock()
 		defer lock.Unlock()
-		if e, a := 2, resumeCounts[jobMap[3]]; e > a {
+		if e, a := 1, resumeCounts[jobMap[3]]; e > a {
 			return errors.Errorf("expected resumeCount to be > %d, but got %d", e, a)
 		}
 		if e, a := 1, resumeCounts[jobMap[2]]; e > a {
@@ -197,7 +214,7 @@ func TestRegistryResumeExpiredLease(t *testing.T) {
 			count += ct
 		}
 
-		if e, a := 5, count; e > a {
+		if e, a := 4, count; e > a {
 			return errors.Errorf("expected total jobs to be > %d, but got %d", e, a)
 		}
 		return nil

--- a/pkg/sql/jobs/registry_test.go
+++ b/pkg/sql/jobs/registry_test.go
@@ -42,7 +42,9 @@ func TestRegistryCancelation(t *testing.T) {
 
 	var db *client.DB
 	var ex sqlutil.InternalExecutor
-	clock := hlc.NewClock(hlc.UnixNano, time.Nanosecond)
+	// Insulate this test from wall time.
+	mClock := hlc.NewManualClock(hlc.UnixNano())
+	clock := hlc.NewClock(mClock.UnixNano, time.Nanosecond)
 	registry := MakeRegistry(log.AmbientContext{}, clock, db, ex, FakeNodeID, cluster.NoSettings, FakePHS)
 
 	const nodeCount = 1
@@ -67,58 +69,104 @@ func TestRegistryCancelation(t *testing.T) {
 	}
 
 	cancelCount := 0
-
-	register := func(id int64) {
-		registry.register(id, func() { cancelCount++ })
-	}
-	unregister := func(id int64) {
-		registry.unregister(id)
-	}
-
+	didRegister := false
+	jobID := int64(1)
 	const nodeID = roachpb.NodeID(1)
 
-	// Jobs that complete while the node is live should be canceled once.
-	register(1)
-	wait()
-	unregister(1)
-	wait()
-	if e, a := 1, cancelCount; e != a {
-		t.Fatalf("expected cancelCount of %d, but got %d", e, a)
+	register := func() {
+		didRegister = true
+		jobID++
+		registry.register(jobID, func() { cancelCount++ })
+	}
+	unregister := func() {
+		registry.unregister(jobID)
+		didRegister = false
+	}
+	expectCancel := func(expect bool) {
+		t.Helper()
+
+		wait()
+		var e int
+		if expect {
+			e = 1
+		}
+		if a := cancelCount; e != a {
+			t.Errorf("expected cancelCount of %d, but got %d", e, a)
+		}
+	}
+	check := func(fn func()) {
+		fn()
+		if didRegister {
+			unregister()
+			wait()
+		}
+		cancelCount = 0
+	}
+	// inWindow slews the expiration time of the node's expiration.
+	inWindow := func(in bool) {
+		nanos := -defaultLeniencySetting.Nanoseconds()
+		if in {
+			nanos = nanos / 2
+		} else {
+			nanos = nanos * 2
+		}
+		nodeLiveness.FakeSetExpiration(nodeID, clock.Now().Add(nanos, 0))
 	}
 
-	// Jobs that are in-progress when the liveness epoch is incremented should be
-	// canceled.
-	register(2)
-	nodeLiveness.FakeIncrementEpoch(nodeID)
-	wait()
-	if e, a := 2, cancelCount; e != a {
-		t.Fatalf("expected cancelCount of %d, but got %d", e, a)
-	}
+	// Jobs that complete while the node is live should be canceled once.
+	check(func() {
+		register()
+		expectCancel(false)
+		unregister()
+		expectCancel(true)
+	})
+
+	// Jobs that are in-progress when the liveness epoch is incremented
+	// should not be canceled.
+	check(func() {
+		register()
+		nodeLiveness.FakeIncrementEpoch(nodeID)
+		expectCancel(false)
+		unregister()
+		expectCancel(true)
+	})
 
 	// Jobs started in the new epoch that complete while the new epoch is live
 	// should be canceled once.
-	register(3)
-	wait()
-	unregister(3)
-	wait()
-	if e, a := 3, cancelCount; e != a {
-		t.Fatalf("expected cancelCount of %d, but got %d", e, a)
-	}
+	check(func() {
+		register()
+		expectCancel(false)
+		unregister()
+		expectCancel(true)
+	})
 
-	// Jobs that are in-progress when the liveness lease expires should be
-	// canceled.
-	register(4)
-	nodeLiveness.FakeSetExpiration(nodeID, hlc.MinTimestamp)
-	wait()
-	if e, a := 4, cancelCount; e != a {
-		t.Fatalf("expected cancelCount of %d, but got %d", e, a)
-	}
+	// Jobs **alive** within the leniency period should not be canceled.
+	check(func() {
+		register()
+		inWindow(true)
+		expectCancel(false)
+		unregister()
+		expectCancel(true)
+	})
 
-	// Jobs that are started while the liveness lease is expired should be
-	// canceled.
-	register(5)
-	wait()
-	if e, a := 5, cancelCount; e != a {
-		t.Fatalf("expected cancelCount of %d, but got %d", e, a)
-	}
+	// Jobs **started** within the leniency period should not be canceled.
+	check(func() {
+		inWindow(true)
+		register()
+		expectCancel(false)
+	})
+
+	// Jobs **alive** outside of the leniency period should be canceled.
+	check(func() {
+		register()
+		inWindow(false)
+		expectCancel(true)
+	})
+
+	// Jobs **started** outside of the leniency period should be canceled.
+	check(func() {
+		inWindow(false)
+		register()
+		expectCancel(true)
+	})
 }


### PR DESCRIPTION
This change allows a degree of leniency between the time the executing node's
liveness expires and when another node will steal the job.  This allows
long-running jobs, such as import, to survive temporary node saturation on the
coordinating node.

Resolves: #23831

Release note (enterprise change): A new cluster setting,
jobs.registry.leniency, is added to allow long-running import jobs to survive
temporary node saturation.