### PR TITLE
ui: change the error case from "no lease" to "invalid lease"

### DIFF
--- a/pkg/ui/src/views/reports/containers/problemRanges/connectionsTable.tsx
+++ b/pkg/ui/src/views/reports/containers/problemRanges/connectionsTable.tsx
@@ -28,7 +28,7 @@ const connectionTableColumns: ConnectionTableColumn[] = [
   },
   { title: "Unavailable", extract: (problem) => problem.unavailable_range_ids.length },
   { title: "No Raft Leader", extract: (problem) => problem.no_raft_leader_range_ids.length },
-  { title: "No Lease", extract: (problem) => problem.no_lease_range_ids.length },
+  { title: "Invalid Lease", extract: (problem) => problem.no_lease_range_ids.length },
   {
     title: "Raft Leader but not Lease Holder",
     extract: (problem) => problem.raft_leader_not_lease_holder_range_ids.length,

--- a/pkg/ui/src/views/reports/containers/problemRanges/connectionsTable.tsx
+++ b/pkg/ui/src/views/reports/containers/problemRanges/connectionsTable.tsx
@@ -4,6 +4,7 @@ import React from "react";
 import { Link } from "react-router";
 
 import * as protos from "src/js/protos";
+import { CachedDataReducerState } from "src/redux/cachedDataReducer";
 
 interface ConnectionTableColumn {
   title: string;
@@ -14,7 +15,7 @@ interface ConnectionTableColumn {
 }
 
 interface ConnectionsTableProps {
-  problemRanges: protos.cockroach.server.serverpb.ProblemRangesResponse;
+  problemRanges: CachedDataReducerState<protos.cockroach.server.serverpb.ProblemRangesResponse>;
 }
 
 const connectionTableColumns: ConnectionTableColumn[] = [
@@ -52,16 +53,20 @@ const connectionTableColumns: ConnectionTableColumn[] = [
 
 export default function ConnectionsTable(props: ConnectionsTableProps) {
   const { problemRanges } = props;
-  if (_.isNil(problemRanges)) {
+  // lastError is already handled by ProblemRanges component.
+  if (_.isNil(problemRanges) ||
+    _.isNil(problemRanges.data) ||
+    !_.isNil(problemRanges.lastError)) {
     return null;
   }
-  const ids = _.chain(_.keys(problemRanges.problems_by_node_id))
+  const { data } = problemRanges;
+  const ids = _.chain(_.keys(data.problems_by_node_id))
     .map(id => parseInt(id, 10))
     .sortBy(id => id)
     .value();
   return (
     <div>
-      <h2>Connections (via Node {problemRanges.node_id})</h2>
+      <h2>Connections (via Node {data.node_id})</h2>
       <table className="connections-table">
         <tbody>
           <tr className="connections-table__row connections-table__row--header">
@@ -75,7 +80,7 @@ export default function ConnectionsTable(props: ConnectionsTableProps) {
           </tr>
           {
             _.map(ids, id => {
-              const rowProblems = problemRanges.problems_by_node_id[id];
+              const rowProblems = data.problems_by_node_id[id];
               const rowClassName = classNames({
                 "connections-table__row": true,
                 "connections-table__row--warning": !_.isEmpty(rowProblems.error_message),

--- a/pkg/ui/src/views/reports/containers/problemRanges/index.tsx
+++ b/pkg/ui/src/views/reports/containers/problemRanges/index.tsx
@@ -157,7 +157,7 @@ class ProblemRanges extends React.Component<ProblemRangesProps, {}> {
           extract={(problem) => problem.no_raft_leader_range_ids}
         />
         <ProblemRangeList
-          name="No Lease"
+          name="Invalid Lease"
           problems={problems}
           extract={(problem) => problem.no_lease_range_ids}
         />

--- a/pkg/ui/src/views/reports/containers/problemRanges/index.tsx
+++ b/pkg/ui/src/views/reports/containers/problemRanges/index.tsx
@@ -6,21 +6,27 @@ import { Link, RouterState } from "react-router";
 
 import * as protos from "src/js/protos";
 import { problemRangesRequestKey, refreshProblemRanges } from "src/redux/apiReducers";
+import { CachedDataReducerState } from "src/redux/cachedDataReducer";
 import { AdminUIState } from "src/redux/state";
 import { nodeIDAttr } from "src/util/constants";
 import { FixLong } from "src/util/fixLong";
 import ConnectionsTable from "src/views/reports/containers/problemRanges/connectionsTable";
+import Loading from "src/views/shared/components/loading";
 
-type ProblemRangesResponse = protos.cockroach.server.serverpb.ProblemRangesResponse;
+import spinner from "assets/spinner.gif";
+
 type NodeProblems$Properties = protos.cockroach.server.serverpb.ProblemRangesResponse.NodeProblems$Properties;
 
 interface ProblemRangesOwnProps {
-  problemRanges: ProblemRangesResponse;
-  lastError: Error;
+  problemRanges: CachedDataReducerState<protos.cockroach.server.serverpb.ProblemRangesResponse>;
   refreshProblemRanges: typeof refreshProblemRanges;
 }
 
 type ProblemRangesProps = ProblemRangesOwnProps & RouterState;
+
+function isLoading(state: CachedDataReducerState<any>) {
+  return _.isNil(state) || (_.isNil(state.data) && _.isNil(state.lastError));
+}
 
 function ProblemRangeList(props: {
   name: string,
@@ -85,67 +91,57 @@ class ProblemRanges extends React.Component<ProblemRangesProps, {}> {
     }
   }
 
-  render() {
+  renderReportBody() {
     const { problemRanges } = this.props;
-    if (!_.isNil(this.props.lastError)) {
-      let errorText: string;
-      if (_.isEmpty(this.props.params[nodeIDAttr])) {
-        errorText = `Error loading Problem Ranges on the Cluster`;
-      } else {
-        errorText = `Error loading Problem Range for node n${this.props.params[nodeIDAttr]}`;
-      }
-      return (
-        <div className="section">
-          <h1>Problem Ranges Report</h1>
-          <h2>{errorText}</h2>
-        </div>
-      );
-    }
-    if (!problemRanges) {
-      return (
-        <div className="section">
-          <h1>Problem Ranges Report</h1>
-          <h2>Loading cluster status...</h2>
-        </div>
-      );
+    if (isLoading(this.props.problemRanges)) {
+      return null;
     }
 
-    let titleText = "Problem Ranges for ";
-    const validIDs = _.keys(_.pickBy(problemRanges.problems_by_node_id, problems => {
+    if (!_.isNil(problemRanges.lastError)) {
+      if (_.isEmpty(this.props.params[nodeIDAttr])) {
+        return (
+          <div>
+            <h2>Error loading Problem Ranges for the Cluster</h2>
+            {problemRanges.lastError.toString()}
+          </div>
+        );
+      } else {
+        return (
+          <div>
+            <h2>Error loading Problem Ranges for node n{this.props.params[nodeIDAttr]}</h2>
+            {problemRanges.lastError.toString()}
+          </div>
+        );
+      }
+    }
+
+    const { data } = problemRanges;
+
+    const validIDs = _.keys(_.pickBy(data.problems_by_node_id, problems => {
       return _.isEmpty(problems.error_message);
     }));
-
-    switch (validIDs.length) {
-      case 0:
-        if (_.isEmpty(this.props.params[nodeIDAttr])) {
-          titleText = `No nodes returned any results`;
-        } else {
-          titleText = `No results for node n${this.props.params[nodeIDAttr]}`;
-        }
-        break;
-      case 1:
-        const singleNodeID = _.keys(problemRanges.problems_by_node_id)[0];
-        titleText = `Problem Ranges on Node n${singleNodeID}`;
-        break;
-      default:
-        titleText = "Problem Ranges on the Cluster";
-    }
-
     if (validIDs.length === 0) {
-      return (
-        <div className="section">
-          <h1>Problem Ranges Report</h1>
-          <h2>{titleText}</h2>
-          <ConnectionsTable problemRanges={problemRanges} />
-        </div>
-      );
+      if (_.isEmpty(this.props.params[nodeIDAttr])) {
+        return <h2>No nodes returned any results</h2>;
+      } else {
+        return <h2>No results reported for node n{this.props.params[nodeIDAttr]}</h2>;
+      }
     }
 
-    const problems = _.values(problemRanges.problems_by_node_id);
+    let titleText: string; // = "Problem Ranges for ";
+    if (validIDs.length === 1) {
+      const singleNodeID = _.keys(data.problems_by_node_id)[0];
+      titleText = `Problem Ranges on Node n${singleNodeID}`;
+    } else {
+      titleText = "Problem Ranges on the Cluster";
+    }
+
+    const problems = _.values(data.problems_by_node_id);
     return (
-      <div className="section">
-        <h1>Problem Ranges Report</h1>
-        <h2>{titleText}</h2>
+      <div>
+        <h2>
+          {titleText}
+        </h2>
         <ProblemRangeList
           name="Unavailable"
           problems={problems}
@@ -171,7 +167,24 @@ class ProblemRanges extends React.Component<ProblemRangesProps, {}> {
           problems={problems}
           extract={(problem) => problem.underreplicated_range_ids}
         />
-        <ConnectionsTable problemRanges={problemRanges} />
+      </div>
+    );
+  }
+
+  render() {
+    return (
+      <div className="section">
+        <h1>Problem Ranges Report</h1>
+        <Loading
+          loading={isLoading(this.props.problemRanges)}
+          className="loading-image loading-image__spinner-left loading-image__spinner-left__padded"
+          image={spinner}
+        >
+          <div>
+            {this.renderReportBody()}
+            <ConnectionsTable problemRanges={this.props.problemRanges} />
+          </div>
+        </Loading>
       </div>
     );
   }
@@ -181,8 +194,7 @@ export default connect(
   (state: AdminUIState, props: ProblemRangesProps) => {
     const nodeIDKey = problemRangesRequestKey(problemRangeRequestFromProps(props));
     return {
-      problemRanges: state.cachedData.problemRanges[nodeIDKey] && state.cachedData.problemRanges[nodeIDKey].data,
-      lastError: state.cachedData.problemRanges[nodeIDKey] && state.cachedData.problemRanges[nodeIDKey].lastError,
+      problemRanges: state.cachedData.problemRanges[nodeIDKey],
     };
   },
   {

--- a/pkg/ui/src/views/reports/containers/range/rangeTable.tsx
+++ b/pkg/ui/src/views/reports/containers/range/rangeTable.tsx
@@ -175,7 +175,7 @@ export default class RangeTable extends React.Component<RangeTableProps, {}> {
   ): RangeTableCellContent {
     let results: string[] = [];
     if (problems.no_lease) {
-      results = _.concat(results, "No Lease");
+      results = _.concat(results, "Invalid Lease");
     }
     if (problems.leader_not_lease_holder) {
       results = _.concat(results, "Leader is Not Lease holder");


### PR DESCRIPTION
The first commit does the rename which addresses #18055.

While I was in there, it seemed appropriate to also fix-up the problem ranges page which clearly needed some love.  There's now a loading spinner and errors are displayed and handled better.
The second commit does this.