### PR TITLE
sql: fix inverted index queries

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/inverted_index
+++ b/pkg/sql/logictest/testdata/logic_test/inverted_index
@@ -147,6 +147,9 @@ INSERT INTO d VALUES(18, '[]')
 statement ok
 INSERT INTO d VALUES (29,  NULL)
 
+statement ok
+INSERT INTO d VALUES (30,  '{"a": []}')
+
 query TITTTTT
 EXPLAIN (VERBOSE) SELECT * from d where b @>'{"a": "b"}'
 ----
@@ -322,6 +325,7 @@ SELECT * from d where b @> '{}' ORDER BY a;
 8   {"a": {"b": true}}
 9   {"a": {"b": false}}
 17  {}
+30  {"a": []}
 
 query IT
 SELECT * from d where b @> '[]' ORDER BY a;
@@ -416,14 +420,24 @@ SELECT * from d where b @> '{"a": [{}]}' ORDER BY a;
 ----
 25  {"a": [{}]}
 
+
+query IT
+SELECT * from d where b @> '{"a": []}' ORDER BY a;
+----
+25  {"a": [{}]}
+30  {"a": []}
+
 query IT
 SELECT * from d where b @> '[{}]' ORDER BY a;
 ----
+16  [{"a": {"b": [1, [2]]}}, "d"]
+20  [{"a": "a"}, {"a": "a"}]
 26  [[], {}]
 
 query IT
 SELECT * from d where b @> '[[]]' ORDER BY a;
 ----
+21  [[[["a"]]], [[["a"]]]]
 26  [[], {}]
 
 statement ok
@@ -480,6 +494,35 @@ SELECT * from d where b @> 'null' ORDER BY a;
 ----
 11  null
 27  [true, false, null, 1.23, "a"]
+
+query IT
+SELECT * from d where b @> '{"a": {}}' ORDER BY a;
+----
+3  {"a": {"b": "c"}}
+4  {"a": {"b": [1]}}
+5  {"a": {"b": [1, [2]]}}
+8  {"a": {"b": true}}
+9  {"a": {"b": false}}
+
+query IT
+SELECT * from d where b @> '{"a": []}' ORDER BY a;
+----
+25  {"a": [{}]}
+30  {"a": []}
+
+query TTT
+EXPLAIN SELECT * from d where b @> '{"a": []}' ORDER BY a;
+----
+scan  ·      ·
+·     table  d@primary
+·     spans  ALL
+
+query TTT
+EXPLAIN SELECT * from d where b @> '{"a": {}}' ORDER BY a;
+----
+scan  ·      ·
+·     table  d@primary
+·     spans  ALL
 
 statement ok
 CREATE TABLE users (

--- a/pkg/sql/opt/idxconstraint/index_constraints.go
+++ b/pkg/sql/opt/idxconstraint/index_constraints.go
@@ -15,6 +15,7 @@
 package idxconstraint
 
 import (
+	"context"
 	"fmt"
 	"regexp"
 	"strings"
@@ -25,6 +26,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/cockroach/pkg/util/json"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 )
 
 // makeEqSpan returns a span that constrains a column to a single value.
@@ -860,11 +862,16 @@ func (c *indexConstraintCtx) makeInvertedIndexSpansForExpr(
 
 		switch rd.Type() {
 		case json.ArrayJSONType, json.ObjectJSONType:
-			// We want to have a full index scan for an empty json array or object on the RHS of @>.
-			if rd.Len() < 1 {
+			// We want to have a full index scan if the RHS contains either [] or {}.
+			hasContainerLeaf, err := rd.HasContainerLeaf()
+			if err != nil {
+				log.Errorf(context.TODO(), "unexpected JSON error: %v", err)
 				return nil, false, false
 			}
 
+			if hasContainerLeaf {
+				return nil, false, false
+			}
 			return LogicalSpans{c.makeEqSpan(xform.ExtractConstDatum(rhs))}, true, true
 		default:
 			// If we find a scalar on the right side of the @> operator it means that we need to find

--- a/pkg/sql/opt_index_selection.go
+++ b/pkg/sql/opt_index_selection.go
@@ -568,12 +568,6 @@ func encodeLogicalKey(
 				)
 				return nil, err
 			}
-			if len(keys) < 1 {
-				err := pgerror.NewError(
-					pgerror.CodeInternalError, "can't look up empty JSON",
-				)
-				return nil, err
-			}
 			key = keys[0]
 		} else {
 			key, err = sqlbase.EncodeTableKey(key, val, dir)

--- a/pkg/util/json/encoded.go
+++ b/pkg/util/json/encoded.go
@@ -702,6 +702,15 @@ func (j *jsonEncoded) encodeInvertedIndexKeys(b []byte) ([][]byte, error) {
 	return decoded.encodeInvertedIndexKeys(b)
 }
 
+// HasContainerLeaf implements the JSON interface.
+func (j *jsonEncoded) HasContainerLeaf() (bool, error) {
+	decoded, err := j.decode()
+	if err != nil {
+		return false, err
+	}
+	return decoded.HasContainerLeaf()
+}
+
 // preprocessForContains implements the JSON interface.
 func (j *jsonEncoded) preprocessForContains() (containsable, error) {
 	if dec := j.alreadyDecoded(); dec != nil {

--- a/pkg/util/json/json.go
+++ b/pkg/util/json/json.go
@@ -146,6 +146,10 @@ type JSON interface {
 	// Len returns the number of outermost elements in the JSON document if it is an object or an array.
 	// Otherwise, Len returns 0.
 	Len() int
+
+	// HasContainerLeaf returns whether this document contains in it somewhere
+	// either the empty array or the empty object.
+	HasContainerLeaf() (bool, error)
 }
 
 type jsonTrue struct{}
@@ -1522,3 +1526,41 @@ func (j jsonTrue) doRemovePath([]string) (JSON, bool, error)   { return j, false
 func (j jsonFalse) doRemovePath([]string) (JSON, bool, error)  { return j, false, nil }
 func (j jsonString) doRemovePath([]string) (JSON, bool, error) { return j, false, nil }
 func (j jsonNumber) doRemovePath([]string) (JSON, bool, error) { return j, false, nil }
+
+func (j jsonObject) HasContainerLeaf() (bool, error) {
+	if j.Len() == 0 {
+		return true, nil
+	}
+	for _, c := range j {
+		child, err := c.v.HasContainerLeaf()
+		if err != nil {
+			return false, err
+		}
+		if child {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func (j jsonArray) HasContainerLeaf() (bool, error) {
+	if j.Len() == 0 {
+		return true, nil
+	}
+	for _, c := range j {
+		child, err := c.HasContainerLeaf()
+		if err != nil {
+			return false, err
+		}
+		if child {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func (j jsonNull) HasContainerLeaf() (bool, error)   { return false, nil }
+func (j jsonTrue) HasContainerLeaf() (bool, error)   { return false, nil }
+func (j jsonFalse) HasContainerLeaf() (bool, error)  { return false, nil }
+func (j jsonString) HasContainerLeaf() (bool, error) { return false, nil }
+func (j jsonNumber) HasContainerLeaf() (bool, error) { return false, nil }

--- a/pkg/util/json/json_test.go
+++ b/pkg/util/json/json_test.go
@@ -1630,6 +1630,46 @@ func TestPretty(t *testing.T) {
 	}
 }
 
+func TestHasContainerLeaf(t *testing.T) {
+	cases := []struct {
+		input    string
+		expected bool
+	}{
+		{`true`, false},
+		{`false`, false},
+		{`1`, false},
+		{`[]`, true},
+		{`{}`, true},
+		{`{"a": 1}`, false},
+		{`{"a": {"b": 3}, "x": "y", "c": []}`, true},
+		{`{"a": {"b": 3}, "c": [], "x": "y"}`, true},
+		{`{"a": {}}`, true},
+		{`{"a": []}`, true},
+		{`[]`, true},
+		{`[[]]`, true},
+		{`[1, 2, 3, []]`, true},
+		{`[1, 2, [], 3]`, true},
+		{`[[], 1, 2, 3]`, true},
+		{`[1, 2, 3]`, false},
+		{`[[1, 2, 3]]`, false},
+		{`[[1, 2], 3]`, false},
+		{`[1, 2, 3, [4]]`, false},
+	}
+
+	for _, tc := range cases {
+		j := jsonTestShorthand(tc.input)
+		runDecodedAndEncoded(t, tc.input, j, func(t *testing.T, j JSON) {
+			result, err := j.HasContainerLeaf()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if result != tc.expected {
+				t.Fatalf("expected:\n%v\ngot:\n%v\n", tc.expected, result)
+			}
+		})
+	}
+}
+
 func BenchmarkBuildJSONObject(b *testing.B) {
 	for _, objectSize := range []int{1, 10, 100, 1000, 10000, 100000} {
 		keys := make([]string, objectSize)


### PR DESCRIPTION
We need to do a full table scan whenever we are querying by containment
of a document that has an empty object or array in it, not just those at
the top level.

Fixes #23819.

Release note (bug fix): Fixed a bug where some inverted index queries
could return incorrect results.