### PR TITLE
sql/jobs: don't print the stack in errors on jobs adoption

### DIFF
--- a/pkg/sql/jobs/registry.go
+++ b/pkg/sql/jobs/registry.go
@@ -216,7 +216,7 @@ func (r *Registry) Start(
 			select {
 			case <-time.After(adoptInterval):
 				if err := r.maybeAdoptJob(ctx, nl); err != nil {
-					log.Errorf(ctx, "error while adopting jobs: %+v", err)
+					log.Errorf(ctx, "error while adopting jobs: %s", err)
 				}
 			case <-stopper.ShouldStop():
 				return


### PR DESCRIPTION
The query for adopting jobs runs even after the server starts draining
(but before the stopper is stopped). After the server is draining, if it
gets far enough with the draining, it can fail in various ways. For
example, if it starts using DistSQL (which I'm trying to do in another
change), it gets an error from an internal "flowRegistry". This patch
makes the error being printed not have a stack trace.
The bigger issue is that we should stop adopting when we're draining;
that's not addressed here.

Release note: None