### PR TITLE
cherrypick-2.0: sql: enforce minimum privileges for "admin" role.

### DIFF
--- a/pkg/sql/descriptor.go
+++ b/pkg/sql/descriptor.go
@@ -189,12 +189,8 @@ func getDescriptorByID(
 		if table == nil {
 			return errors.Errorf("%q is not a table", desc.String())
 		}
-		table.MaybeUpgradeFormatVersion()
-		// TODO(dan): Write the upgraded TableDescriptor back to kv. This will break
-		// the ability to use a previous version of cockroach with the on-disk data,
-		// but it's worth it to avoid having to do the upgrade every time the
-		// descriptor is fetched. Our current test for this enforces compatibility
-		// backward and forward, so that'll have to be extended before this is done.
+		table.MaybeFillInDescriptor()
+
 		if err := table.Validate(ctx, txn); err != nil {
 			return err
 		}
@@ -204,6 +200,9 @@ func getDescriptorByID(
 		if database == nil {
 			return errors.Errorf("%q is not a database", desc.String())
 		}
+
+		database.Privileges.MaybeFixPrivileges(id)
+
 		if err := database.Validate(); err != nil {
 			return err
 		}

--- a/pkg/sql/lease.go
+++ b/pkg/sql/lease.go
@@ -155,7 +155,7 @@ func (s LeaseStore) acquire(
 		if err := filterTableState(tableDesc); err != nil {
 			return err
 		}
-		tableDesc.MaybeUpgradeFormatVersion()
+		tableDesc.MaybeFillInDescriptor()
 		// Once the descriptor is set it is immutable and care must be taken
 		// to not modify it.
 		table = &tableVersionState{
@@ -1487,7 +1487,7 @@ func (m *LeaseManager) RefreshLeases(s *stop.Stopper, db *client.DB, g *gossip.G
 					switch union := descriptor.Union.(type) {
 					case *sqlbase.Descriptor_Table:
 						table := union.Table
-						table.MaybeUpgradeFormatVersion()
+						table.MaybeFillInDescriptor()
 						if err := table.ValidateTable(); err != nil {
 							log.Errorf(ctx, "%s: received invalid table descriptor: %v", kv.Key, table)
 							return

--- a/pkg/sql/logictest/testdata/logic_test/grant_database
+++ b/pkg/sql/logictest/testdata/logic_test/grant_database
@@ -16,8 +16,11 @@ a         pg_catalog          root   ALL
 a         public              admin  ALL
 a         public              root   ALL
 
-statement error user root does not have ALL privileges
+statement error user root must have exactly ALL privileges on system object with ID=.*
 REVOKE SELECT ON DATABASE a FROM root
+
+statement error user admin must have exactly ALL privileges on system object with ID=.*
+REVOKE SELECT ON DATABASE a FROM admin
 
 statement ok
 CREATE USER readwrite

--- a/pkg/sql/logictest/testdata/logic_test/system
+++ b/pkg/sql/logictest/testdata/logic_test/system
@@ -353,21 +353,20 @@ ALTER DATABASE system RENAME TO not_system
 statement error user root does not have DROP privilege on database system
 DROP DATABASE system
 
-# Non-root users can only have privileges that root has on system objects.
-# root only has GRANT, SELECT on system database.
-statement error user testuser must not have ALL privileges on this system object
+# Users cannot exceed allowed privileges on system objects.
+statement error user testuser must not have ALL privileges on system object with ID=.*
 GRANT ALL ON DATABASE system TO testuser
 
-statement error user testuser must not have INSERT privileges on this system object
+statement error user testuser must not have INSERT privileges on system object with ID=.*
 GRANT GRANT, SELECT, INSERT ON DATABASE system TO testuser
 
 statement ok
 GRANT GRANT, SELECT ON DATABASE system TO testuser
 
-statement error user testuser must not have ALL privileges on this system object
+statement error user testuser must not have ALL privileges on system object with ID=.*
 GRANT ALL ON system.namespace TO testuser
 
-statement error user testuser must not have INSERT privileges on this system object
+statement error user testuser must not have INSERT privileges on system object with ID=.*
 GRANT GRANT, SELECT, INSERT ON system.namespace TO testuser
 
 statement ok
@@ -376,43 +375,77 @@ GRANT GRANT, SELECT ON system.namespace TO testuser
 statement ok
 GRANT SELECT ON system.descriptor TO testuser
 
-statement error user root must have exactly {GRANT, SELECT} privileges on this system object
+# Superusers must have exactly the allowed privileges.
+statement error user root must have exactly GRANT, SELECT privileges on system object with ID=.*
 GRANT ALL ON DATABASE system TO root
 
-statement error user root must have exactly {GRANT, SELECT} privileges on this system object
+statement error user root must have exactly GRANT, SELECT privileges on system object with ID=.*
 GRANT DELETE, INSERT ON DATABASE system TO root
 
-statement error user root must have exactly {GRANT, SELECT} privileges on this system object
+statement error user root must have exactly GRANT, SELECT privileges on system object with ID=.*
 GRANT ALL ON system.namespace TO root
 
-statement error user root must have exactly {GRANT, SELECT} privileges on this system object
+statement error user root must have exactly GRANT, SELECT privileges on system object with ID=.*
 GRANT DELETE, INSERT ON system.descriptor TO root
 
-statement error user root must have exactly {GRANT, SELECT} privileges on this system object
+statement error user root must have exactly GRANT, SELECT privileges on system object with ID=.*
 GRANT ALL ON system.descriptor TO root
 
-statement error user root must have exactly {GRANT, SELECT} privileges on this system object
+statement error user root must have exactly GRANT, SELECT privileges on system object with ID=.*
 REVOKE GRANT ON DATABASE system FROM root
 
-statement error user root must have exactly {GRANT, SELECT} privileges on this system object
+statement error user root must have exactly GRANT, SELECT privileges on system object with ID=.*
 REVOKE GRANT ON system.namespace FROM root
 
 statement error user root does not have privileges
 REVOKE ALL ON system.namespace FROM root
 
-# Some tables (we test system.lease here) allow multiple privilege sets for
-# backwards compatibility, but still enforce that no user has more privileges
-# than root.
-statement error user testuser must not have ALL privileges on this system object
+statement error user admin must have exactly GRANT, SELECT privileges on system object with ID=.*
+GRANT ALL ON DATABASE system TO admin
+
+statement error user admin must have exactly GRANT, SELECT privileges on system object with ID=.*
+GRANT DELETE, INSERT ON DATABASE system TO admin
+
+statement error user admin must have exactly GRANT, SELECT privileges on system object with ID=.*
+GRANT ALL ON system.namespace TO admin
+
+statement error user admin must have exactly GRANT, SELECT privileges on system object with ID=.*
+GRANT DELETE, INSERT ON system.descriptor TO admin
+
+statement error user admin must have exactly GRANT, SELECT privileges on system object with ID=.*
+GRANT ALL ON system.descriptor TO admin
+
+statement error user admin must have exactly GRANT, SELECT privileges on system object with ID=.*
+REVOKE GRANT ON DATABASE system FROM admin
+
+statement error user admin must have exactly GRANT, SELECT privileges on system object with ID=.*
+REVOKE GRANT ON system.namespace FROM admin
+
+statement error user admin does not have privileges
+REVOKE ALL ON system.namespace FROM admin
+
+# Some tables (we test system.lease here) used to allow multiple privilege sets for
+# backwards compatibility, and superusers were allowed very wide privileges.
+# We make sure this is no longer the case.
+statement error user testuser must not have ALL privileges on system object with ID=.*
 GRANT ALL ON system.lease TO testuser
 
-statement error user root must have exactly {GRANT, SELECT, INSERT, DELETE, UPDATE} or {ALL} privileges on this system object
+statement error user root must have exactly GRANT, SELECT, INSERT, DELETE, UPDATE privileges on system object with ID=.*
 GRANT CREATE on system.lease to root
 
-statement ok
+statement error user admin must have exactly GRANT, SELECT, INSERT, DELETE, UPDATE privileges on system object with ID=.*
+GRANT CREATE on system.lease to admin
+
+statement error user testuser must not have CREATE privileges on system object with ID=.*
+GRANT CREATE on system.lease to testuser
+
+statement error user root must have exactly GRANT, SELECT, INSERT, DELETE, UPDATE privileges on system object with ID=.*
 GRANT ALL ON system.lease TO root
 
-statement ok
+statement error user admin must have exactly GRANT, SELECT, INSERT, DELETE, UPDATE privileges on system object with ID=.*
+GRANT ALL ON system.lease TO admin
+
+statement error user testuser must not have ALL privileges on system object with ID=.*
 GRANT ALL ON system.lease TO testuser
 
 # NB: the "order by" is necessary or this test is flaky under DistSQL.

--- a/pkg/sql/privilege/privilege.go
+++ b/pkg/sql/privilege/privilege.go
@@ -16,7 +16,6 @@ package privilege
 
 import (
 	"bytes"
-	"fmt"
 	"sort"
 	"strings"
 
@@ -165,33 +164,4 @@ func ListFromStrings(strs []string) (List, error) {
 		ret[i] = k
 	}
 	return ret, nil
-}
-
-// Lists is a list of privilege lists
-type Lists []List
-
-// Contains returns whether the list of privilege lists contains exactly the
-// privilege list represented by bitfield m. This intentionally treats ALL and
-// {CREATE, ..., UPDATE} as distinct privilege lists.
-func (pls Lists) Contains(m uint32) bool {
-	for _, pl := range pls {
-		if pl.ToBitField() == m {
-			return true
-		}
-	}
-	return false
-}
-
-// String stringifies each constituent list of privileges, groups each inside of
-// {} braces, and joins them with " or ".
-//
-// Examples:
-//   {{SELECT}}.String() -> "{SELECT}"
-//   {{SELECT}, {SELECT, GRANT}}.String() -> "{SELECT} or {SELECT, GRANT}"
-func (pls Lists) String() string {
-	ret := make([]string, len(pls))
-	for i, pl := range pls {
-		ret[i] = fmt.Sprintf("{%s}", pl)
-	}
-	return strings.Join(ret, " or ")
 }

--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -1063,7 +1063,7 @@ func (s *SchemaChangeManager) Start(stopper *stop.Stopper) {
 					switch union := descriptor.Union.(type) {
 					case *sqlbase.Descriptor_Table:
 						table := union.Table
-						table.MaybeUpgradeFormatVersion()
+						table.MaybeFillInDescriptor()
 						if err := table.ValidateTable(); err != nil {
 							log.Errorf(ctx, "%s: received invalid table descriptor: %v: %s", kv.Key, table, err)
 							return

--- a/pkg/sql/sqlbase/privilege.go
+++ b/pkg/sql/sqlbase/privilege.go
@@ -181,44 +181,115 @@ func (p *PrivilegeDescriptor) Revoke(user string, privList privilege.List) {
 	}
 }
 
+// MaybeFixPrivileges fixes the privilege descriptor if needed, including:
+// * adding default privileges for the "admin" role
+// * fixing default privileges for the "root" user
+// * fixing maximum privileges for users.
+// Returns true if the privilege descriptor was modified.
+func (p *PrivilegeDescriptor) MaybeFixPrivileges(id ID) bool {
+	allowedPrivilegesBits := privilege.ALL.Mask()
+	if IsReservedID(id) {
+		// System databases and tables have custom maximum allowed privileges.
+		allowedPrivilegesBits = SystemAllowedPrivileges[id].ToBitField()
+	}
+
+	var modified bool
+
+	fixSuperUser := func(user string) {
+		privs := p.findOrCreateUser(user)
+		if privs.Privileges != allowedPrivilegesBits {
+			privs.Privileges = allowedPrivilegesBits
+			modified = true
+		}
+	}
+
+	// Check "root" user and "admin" role.
+	fixSuperUser(security.RootUser)
+	fixSuperUser(AdminRole)
+
+	if isPrivilegeSet(allowedPrivilegesBits, privilege.ALL) {
+		// ALL privileges allowed, we can skip regular users.
+		return modified
+	}
+
+	for i := range p.Users {
+		// Users is a slice of values, we need pointers to make them mutable.
+		u := &p.Users[i]
+		if u.User == security.RootUser || u.User == AdminRole {
+			// we've already checked super users.
+			continue
+		}
+
+		if (u.Privileges &^ allowedPrivilegesBits) != 0 {
+			// User has disallowed privileges: bitwise AND with allowed privileges.
+			u.Privileges &= allowedPrivilegesBits
+			modified = true
+		}
+	}
+
+	return modified
+}
+
 // Validate is called when writing a database or table descriptor.
 // It takes the descriptor ID which is used to determine if
 // it belongs to a system descriptor, in which case the maximum
 // set of allowed privileges is looked up and applied.
-// TODO(mberhault): we'll need to enforce minimum privileges
-// for the admin role as well, but we can't until migrations are done.
 func (p PrivilegeDescriptor) Validate(id ID) error {
-	rootPriv, ok := p.findUser(security.RootUser)
-	if !ok {
-		return fmt.Errorf("user %s does not have privileges", security.RootUser)
-	}
+	allowedPrivileges := privilege.List{privilege.ALL}
 	if IsReservedID(id) {
-		// System databases and tables have custom maximum allowed privileges.
-		allowedPrivileges, ok := SystemAllowedPrivileges[id]
+		var ok bool
+		allowedPrivileges, ok = SystemAllowedPrivileges[id]
 		if !ok {
 			return fmt.Errorf("no allowed privileges found for system object with ID=%d", id)
 		}
-
-		// The root user must match one of the allowed privilege sets exactly.
-		if !allowedPrivileges.Contains(rootPriv.Privileges) {
-			return fmt.Errorf("user %s must have exactly %s privileges on this system object",
-				security.RootUser, allowedPrivileges)
-		}
-
-		// For all users, no other privileges must be granted.
-		if !isPrivilegeSet(rootPriv.Privileges, privilege.ALL) {
-			for _, u := range p.Users {
-				if remaining := u.Privileges &^ rootPriv.Privileges; remaining != 0 {
-					return fmt.Errorf("user %s must not have %s privileges on this system object",
-						u.User, privilege.ListFromBitField(remaining))
-				}
-			}
-		}
-	} else if !isPrivilegeSet(rootPriv.Privileges, privilege.ALL) {
-		// Non-system databases and tables must preserve ALL
-		// privileges for the root user.
-		return fmt.Errorf("user %s does not have ALL privileges", security.RootUser)
 	}
+
+	// Check "root" user.
+	if err := p.validateRequiredSuperuser(id, allowedPrivileges, security.RootUser); err != nil {
+		return err
+	}
+
+	// We expect an "admin" role. Check that it has desired superuser permissions.
+	if err := p.validateRequiredSuperuser(id, allowedPrivileges, AdminRole); err != nil {
+		return err
+	}
+
+	allowedPrivilegesBits := allowedPrivileges.ToBitField()
+	if isPrivilegeSet(allowedPrivilegesBits, privilege.ALL) {
+		// ALL privileges allowed, we can skip regular users.
+		return nil
+	}
+
+	// For all non-super users, privileges must not exceed the allowed privileges.
+	for _, u := range p.Users {
+		if u.User == security.RootUser || u.User == AdminRole {
+			// We've already checked super users.
+			continue
+		}
+
+		if remaining := u.Privileges &^ allowedPrivilegesBits; remaining != 0 {
+			return fmt.Errorf("user %s must not have %s privileges on system object with ID=%d",
+				u.User, privilege.ListFromBitField(remaining), id)
+		}
+	}
+
+	return nil
+}
+
+func (p PrivilegeDescriptor) validateRequiredSuperuser(
+	id ID, allowedPrivileges privilege.List, user string,
+) error {
+	superPriv, ok := p.findUser(user)
+	if !ok {
+		return fmt.Errorf("user %s does not have privileges", user)
+	}
+
+	// The super users must match the allowed privilege set exactly.
+	if superPriv.Privileges != allowedPrivileges.ToBitField() {
+		return fmt.Errorf("user %s must have exactly %s privileges on system object with ID=%d",
+			user, allowedPrivileges, id)
+	}
+
 	return nil
 }
 

--- a/pkg/sql/sqlbase/privilege_test.go
+++ b/pkg/sql/sqlbase/privilege_test.go
@@ -231,46 +231,46 @@ func TestSystemPrivilegeValidate(t *testing.T) {
 	if _, exists := SystemAllowedPrivileges[id]; exists {
 		t.Fatalf("system object with maximum id %d already exists--is the reserved id space full?", id)
 	}
-	SystemAllowedPrivileges[id] = privilege.Lists{
-		{privilege.SELECT},
-		{privilege.SELECT, privilege.GRANT},
-		{privilege.ALL},
+	SystemAllowedPrivileges[id] = privilege.List{
+		privilege.SELECT,
+		privilege.GRANT,
 	}
 	defer delete(SystemAllowedPrivileges, id)
 
-	fooNoGrantPrivilegeErr := "user foo must not have GRANT privileges on this system object"
-	rootWrongPrivilegesErr := "user root must have exactly {SELECT} or {SELECT, GRANT} or {ALL} " +
-		"privileges on this system object"
+	rootWrongPrivilegesErr := "user root must have exactly SELECT, GRANT " +
+		"privileges on system object with ID=.*"
+	adminWrongPrivilegesErr := "user admin must have exactly SELECT, GRANT " +
+		"privileges on system object with ID=.*"
 
 	{
 		// Valid: root user has one of the allowable privilege sets.
-		descriptor := NewPrivilegeDescriptor(security.RootUser, privilege.List{privilege.SELECT})
+		descriptor := NewCustomSuperuserPrivilegeDescriptor(
+			privilege.List{privilege.SELECT, privilege.GRANT},
+		)
 		if err := descriptor.Validate(id); err != nil {
 			t.Fatal(err)
 		}
 
-		// Valid: foo has the same privileges as root.
+		// Valid: foo has a subset of the allowed privileges.
 		descriptor.Grant("foo", privilege.List{privilege.SELECT})
 		if err := descriptor.Validate(id); err != nil {
 			t.Fatal(err)
 		}
 
-		// Invalid: foo has more privileges than root.
+		// Valid: foo has exactly the allowed privileges.
 		descriptor.Grant("foo", privilege.List{privilege.GRANT})
-		if err := descriptor.Validate(id); !testutils.IsError(err, fooNoGrantPrivilegeErr) {
-			t.Fatalf("expected err=%s, got err=%v", fooNoGrantPrivilegeErr, err)
+		if err := descriptor.Validate(id); err != nil {
+			t.Fatal(err)
 		}
 	}
 
 	{
-		// Valid: root user has a different allowable privilege set.
-		descriptor := NewPrivilegeDescriptor(security.RootUser,
-			privilege.List{privilege.SELECT, privilege.GRANT})
-		if err := descriptor.Validate(id); err != nil {
-			t.Fatal(err)
-		}
+		// Valid: root has exactly the allowed privileges.
+		descriptor := NewCustomSuperuserPrivilegeDescriptor(
+			privilege.List{privilege.SELECT, privilege.GRANT},
+		)
 
-		// Valid: foo has less privileges than root.
+		// Valid: foo has a subset of the allowed privileges.
 		descriptor.Grant("foo", privilege.List{privilege.GRANT})
 		if err := descriptor.Validate(id); err != nil {
 			t.Fatal(err)
@@ -291,14 +291,22 @@ func TestSystemPrivilegeValidate(t *testing.T) {
 
 	{
 		// Invalid: root has a non-allowable privilege set.
-		descriptor := NewPrivilegeDescriptor(security.RootUser, privilege.List{privilege.UPDATE})
+		descriptor := NewCustomSuperuserPrivilegeDescriptor(privilege.List{privilege.UPDATE})
 		if err := descriptor.Validate(id); !testutils.IsError(err, rootWrongPrivilegesErr) {
 			t.Fatalf("expected err=%s, got err=%v", rootWrongPrivilegesErr, err)
 		}
 
-		// Valid: root's invalid privileges are revoked and replaced with allowable privileges.
+		// Invalid: root's invalid privileges are revoked and replaced with allowable privileges,
+		// but admin is still wrong.
 		descriptor.Revoke(security.RootUser, privilege.List{privilege.UPDATE})
-		descriptor.Grant(security.RootUser, privilege.List{privilege.ALL})
+		descriptor.Grant(security.RootUser, privilege.List{privilege.SELECT, privilege.GRANT})
+		if err := descriptor.Validate(id); !testutils.IsError(err, adminWrongPrivilegesErr) {
+			t.Fatalf("expected err=%s, got err=%v", adminWrongPrivilegesErr, err)
+		}
+
+		// Valid: admin's invalid privileges are revoked and replaced with allowable privileges.
+		descriptor.Revoke(AdminRole, privilege.List{privilege.UPDATE})
+		descriptor.Grant(AdminRole, privilege.List{privilege.SELECT, privilege.GRANT})
 		if err := descriptor.Validate(id); err != nil {
 			t.Fatal(err)
 		}
@@ -308,13 +316,152 @@ func TestSystemPrivilegeValidate(t *testing.T) {
 		if err := descriptor.Validate(id); err != nil {
 			t.Fatal(err)
 		}
+	}
+}
 
-		// TODO(marc): validate fails here because we do not aggregate
-		// privileges into ALL when all are set.
-		descriptor.Revoke(security.RootUser, privilege.List{privilege.SELECT})
-		descriptor.Grant(security.RootUser, privilege.List{privilege.SELECT})
-		if err := descriptor.Validate(id); !testutils.IsError(err, rootWrongPrivilegesErr) {
-			t.Fatalf("expected err=%s, got err=%v", rootWrongPrivilegesErr, err)
+func TestFixPrivileges(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	// Use a non-system ID.
+	userID := ID(keys.MaxReservedDescID + 1)
+	userPrivs := privilege.List{privilege.ALL}
+
+	// And create an entry for a fake system table.
+	systemID := ID(keys.MaxReservedDescID)
+	if _, exists := SystemAllowedPrivileges[systemID]; exists {
+		t.Fatalf("system object with maximum id %d already exists--is the reserved id space full?", systemID)
+	}
+	systemPrivs := privilege.List{
+		privilege.SELECT,
+		privilege.GRANT,
+	}
+	SystemAllowedPrivileges[systemID] = systemPrivs
+	defer delete(SystemAllowedPrivileges, systemID)
+
+	type userPrivileges map[string]privilege.List
+
+	testCases := []struct {
+		id       ID
+		input    userPrivileges
+		modified bool
+		output   userPrivileges
+	}{
+		{
+			// Empty privileges for system ID.
+			systemID,
+			userPrivileges{},
+			true,
+			userPrivileges{
+				security.RootUser: systemPrivs,
+				AdminRole:         systemPrivs,
+			},
+		},
+		{
+			// Valid requirements for system ID.
+			systemID,
+			userPrivileges{
+				security.RootUser: systemPrivs,
+				AdminRole:         systemPrivs,
+				"foo":             privilege.List{privilege.SELECT},
+				"bar":             privilege.List{privilege.GRANT},
+				"baz":             privilege.List{privilege.SELECT, privilege.GRANT},
+			},
+			false,
+			userPrivileges{
+				security.RootUser: systemPrivs,
+				AdminRole:         systemPrivs,
+				"foo":             privilege.List{privilege.SELECT},
+				"bar":             privilege.List{privilege.GRANT},
+				"baz":             privilege.List{privilege.SELECT, privilege.GRANT},
+			},
+		},
+		{
+			// Too many privileges for system ID.
+			systemID,
+			userPrivileges{
+				security.RootUser: privilege.List{privilege.ALL},
+				AdminRole:         privilege.List{privilege.ALL},
+				"foo":             privilege.List{privilege.ALL},
+				"bar":             privilege.List{privilege.SELECT, privilege.UPDATE},
+			},
+			true,
+			userPrivileges{
+				security.RootUser: systemPrivs,
+				AdminRole:         systemPrivs,
+				"foo":             privilege.List{},
+				"bar":             privilege.List{privilege.SELECT},
+			},
+		},
+		{
+			// Empty privileges for non-system ID.
+			userID,
+			userPrivileges{},
+			true,
+			userPrivileges{
+				security.RootUser: userPrivs,
+				AdminRole:         userPrivs,
+			},
+		},
+		{
+			// Valid requirements for non-system ID.
+			userID,
+			userPrivileges{
+				security.RootUser: userPrivs,
+				AdminRole:         userPrivs,
+				"foo":             privilege.List{privilege.SELECT},
+				"bar":             privilege.List{privilege.GRANT},
+				"baz":             privilege.List{privilege.SELECT, privilege.GRANT},
+			},
+			false,
+			userPrivileges{
+				security.RootUser: userPrivs,
+				AdminRole:         userPrivs,
+				"foo":             privilege.List{privilege.SELECT},
+				"bar":             privilege.List{privilege.GRANT},
+				"baz":             privilege.List{privilege.SELECT, privilege.GRANT},
+			},
+		},
+		{
+			// All privileges are allowed for non-system ID, but we need super users.
+			userID,
+			userPrivileges{
+				"foo": privilege.List{privilege.ALL},
+				"bar": privilege.List{privilege.UPDATE},
+			},
+			true,
+			userPrivileges{
+				security.RootUser: privilege.List{privilege.ALL},
+				AdminRole:         privilege.List{privilege.ALL},
+				"foo":             privilege.List{privilege.ALL},
+				"bar":             privilege.List{privilege.UPDATE},
+			},
+		},
+	}
+
+	for num, testCase := range testCases {
+		desc := &PrivilegeDescriptor{}
+		for u, p := range testCase.input {
+			desc.Grant(u, p)
+		}
+
+		if a, e := desc.MaybeFixPrivileges(testCase.id), testCase.modified; a != e {
+			t.Errorf("#%d: expected modified=%t, got modified=%t", num, e, a)
+			continue
+		}
+
+		if a, e := len(desc.Users), len(testCase.output); a != e {
+			t.Errorf("#%d: expected %d users (%v), got %d (%v)", num, e, testCase.output, a, desc.Users)
+			continue
+		}
+
+		for u, p := range testCase.output {
+			outputUser, ok := desc.findUser(u)
+			if !ok {
+				t.Fatalf("#%d: expected user %s in output, but not found (%v)", num, u, desc.Users)
+			}
+			if a, e := privilege.ListFromBitField(outputUser.Privileges), p; a.ToBitField() != e.ToBitField() {
+				t.Errorf("#%d: user %s: expected privileges %v, got %v", num, u, e, a)
+			}
 		}
 	}
 }

--- a/pkg/sql/sqlbase/structured_test.go
+++ b/pkg/sql/sqlbase/structured_test.go
@@ -1250,7 +1250,7 @@ func TestMaybeUpgradeFormatVersion(t *testing.T) {
 	}
 	for i, test := range tests {
 		desc := test.desc
-		upgraded := desc.MaybeUpgradeFormatVersion()
+		upgraded := desc.maybeUpgradeFormatVersion()
 		if upgraded != test.expUpgrade {
 			t.Fatalf("%d: expected upgraded=%t, but got upgraded=%t", i, test.expUpgrade, upgraded)
 		}

--- a/pkg/sqlmigrations/migrations.go
+++ b/pkg/sqlmigrations/migrations.go
@@ -30,7 +30,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql"
-	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
@@ -146,13 +145,8 @@ var backwardCompatibleMigrations = []migrationDescriptor{
 		doesBackfill: true,
 	},
 	{
-		// Introduced in v2.0.
-		// TODO(benesch): bake this migration into v2.1.
-		//
-		// This is separated from the previous migration as we don't want to re-run
-		// addRoles if this part fails.
-		name:   "grant superuser privileges on all objects to the admin role",
-		workFn: grantAdminPrivileges,
+		// Introduced in v2.0, replaced by "ensure admin role privileges in all descriptors"
+		name: "grant superuser privileges on all objects to the admin role",
 	},
 	{
 		// Introduced in v2.0.
@@ -184,6 +178,13 @@ var backwardCompatibleMigrations = []migrationDescriptor{
 		// Introduced in v2.0.
 		name:   "initialize cluster.secret",
 		workFn: initializeClusterSecret,
+	},
+	{
+		// Introduced in v2.0.
+		// TODO(benesch): bake this migration into v2.1, but create a new migration
+		// with the same function to catch any tables written in a mixed-version setting.
+		name:   "ensure admin role privileges in all descriptors",
+		workFn: ensureMaxPrivileges,
 	},
 }
 
@@ -782,66 +783,6 @@ func addRoles(ctx context.Context, r runner) error {
 	return err
 }
 
-func grantAdminPrivileges(ctx context.Context, r runner) error {
-	// System tables can only be modified by a privileged internal user.
-	session := r.newRootSession(ctx)
-	defer session.Finish(r.sqlExecutor)
-
-	// Give the admin role permissions on all databases and tables.
-	err := r.db.Txn(ctx, func(ctx context.Context, txn *client.Txn) error {
-		descriptors, descErr := sql.GetAllDescriptors(ctx, txn)
-		if descErr != nil {
-			return descErr
-		}
-
-		for _, desc := range descriptors {
-			// Lookup desired privileges:
-			var desiredPrivs privilege.List
-
-			descID := desc.GetID()
-			if sqlbase.IsReservedID(descID) {
-				// System databases and tables have custom maximum allowed privileges.
-				systemPrivs, ok := sqlbase.SystemAllowedPrivileges[descID]
-				if !ok || len(systemPrivs) == 0 {
-					return fmt.Errorf("no allowed privileges found for system object with ID=%d", descID)
-				}
-				desiredPrivs = systemPrivs[0]
-			} else {
-				// Non-system object: fall back on default superuser privileges.
-				desiredPrivs = sqlbase.DefaultSuperuserPrivileges
-			}
-
-			// Grant privileges to the admin role.
-			desc.GetPrivileges().Grant(sqlbase.AdminRole, desiredPrivs)
-
-			// Validate descriptors.
-			switch d := desc.(type) {
-			case *sqlbase.DatabaseDescriptor:
-				if err := d.Validate(); err != nil {
-					return err
-				}
-			case *sqlbase.TableDescriptor:
-				_ = d.MaybeUpgradeFormatVersion()
-				if err := d.Validate(ctx, txn); err != nil {
-					return err
-				}
-			}
-		}
-
-		// Now update the descriptors transactionally.
-		b := txn.NewBatch()
-		for _, descriptor := range descriptors {
-			descKey := sqlbase.MakeDescMetadataKey(descriptor.GetID())
-			b.Put(descKey, sqlbase.WrapDescriptor(descriptor))
-		}
-		if err := txn.SetSystemConfigTrigger(); err != nil {
-			return err
-		}
-		return txn.Run(ctx, b)
-	})
-	return err
-}
-
 func addRootToAdminRole(ctx context.Context, r runner) error {
 	// System tables can only be modified by a privileged internal user.
 	session := r.newRootSession(ctx)
@@ -876,20 +817,38 @@ func addRootToAdminRole(ctx context.Context, r runner) error {
 //
 // TODO(benesch): Remove this migration in v2.1.
 func upgradeTableDescsToInterleavedFormatVersion(ctx context.Context, r runner) error {
-	return upgradeTableDescsWithFn(ctx, r, func(desc *sqlbase.TableDescriptor) (bool, error) {
-		return desc.MaybeUpgradeFormatVersion(), nil
-	})
+	tableDescFn := func(desc *sqlbase.TableDescriptor) (bool, error) {
+		return desc.MaybeFillInDescriptor(), nil
+	}
+	return upgradeDescsWithFn(ctx, r, tableDescFn, nil)
 }
 
-var upgradeTableDescBatchSize int64 = 50
+// ensureMaxPrivileges ensures that all descriptors have privileges
+// for the admin role, and that root and user privileges do not exceed
+// the allowed privileges.
+//
+// TODO(mberhault): Remove this migration in v2.1.
+func ensureMaxPrivileges(ctx context.Context, r runner) error {
+	tableDescFn := func(desc *sqlbase.TableDescriptor) (bool, error) {
+		return desc.Privileges.MaybeFixPrivileges(desc.ID), nil
+	}
+	databaseDescFn := func(desc *sqlbase.DatabaseDescriptor) (bool, error) {
+		return desc.Privileges.MaybeFixPrivileges(desc.ID), nil
+	}
+	return upgradeDescsWithFn(ctx, r, tableDescFn, databaseDescFn)
+}
 
-// upgradeTableDescsWithFn runs the provided upgrade function on each table
-// descriptor, persisting any upgrades if the function indicates that the
+var upgradeDescBatchSize int64 = 50
+
+// upgradeTableDescsWithFn runs the provided upgrade functions on each table
+// and database descriptor, persisting any upgrades if the function indicates that the
 // descriptor was changed.
-func upgradeTableDescsWithFn(
+// Upgrade functions may be nil to perform nothing for the corresponding descriptor type.
+func upgradeDescsWithFn(
 	ctx context.Context,
 	r runner,
-	upgradeFn func(desc *sqlbase.TableDescriptor) (upgraded bool, err error),
+	upgradeTableDescFn func(desc *sqlbase.TableDescriptor) (upgraded bool, err error),
+	upgradeDatabaseDescFn func(desc *sqlbase.DatabaseDescriptor) (upgraded bool, err error),
 ) error {
 	session := r.newRootSession(ctx)
 	defer session.Finish(r.sqlExecutor)
@@ -904,7 +863,7 @@ func upgradeTableDescsWithFn(
 		// descriptors using InterleavedFormatVersion. We need only upgrade the
 		// ancient table descriptors written by versions before beta-20161013.
 		if err := r.db.Txn(ctx, func(ctx context.Context, txn *client.Txn) error {
-			kvs, err := txn.Scan(ctx, startKey, endKey, upgradeTableDescBatchSize)
+			kvs, err := txn.Scan(ctx, startKey, endKey, upgradeDescBatchSize)
 			if err != nil {
 				return err
 			}
@@ -920,27 +879,49 @@ func upgradeTableDescsWithFn(
 				if err := kv.ValueProto(&sqlDesc); err != nil {
 					return err
 				}
-				if table := sqlDesc.GetTable(); table != nil {
-					if upgraded, err := upgradeFn(table); err != nil {
-						return err
-					} else if upgraded {
-						// Though SetUpVersion typically bails out if the table is being
-						// dropped, it's safe to ignore the DROP state here and
-						// unconditionally set UpVersion. For proof, see
-						// TestDropTableWhileUpgradingFormat.
-						//
-						// In fact, it's of the utmost importance that this migration
-						// upgrades every last old-format table descriptor, including those
-						// that are dropping. Otherwise, the user could upgrade to a version
-						// without support for reading the old format before the drop
-						// completes, leaving a broken table descriptor and the table's
-						// remaining data around forever. This isn't just a theoretical
-						// concern: consider that dropping a large table can take several
-						// days, while upgrading to a new version can take as little as a
-						// few minutes.
-						table.UpVersion = true
-						b.Put(kv.Key, sqlbase.WrapDescriptor(table))
+				switch t := sqlDesc.Union.(type) {
+				case *sqlbase.Descriptor_Table:
+					if table := sqlDesc.GetTable(); table != nil && upgradeTableDescFn != nil {
+						if upgraded, err := upgradeTableDescFn(table); err != nil {
+							return err
+						} else if upgraded {
+							// Though SetUpVersion typically bails out if the table is being
+							// dropped, it's safe to ignore the DROP state here and
+							// unconditionally set UpVersion. For proof, see
+							// TestDropTableWhileUpgradingFormat.
+							//
+							// In fact, it's of the utmost importance that this migration
+							// upgrades every last old-format table descriptor, including those
+							// that are dropping. Otherwise, the user could upgrade to a version
+							// without support for reading the old format before the drop
+							// completes, leaving a broken table descriptor and the table's
+							// remaining data around forever. This isn't just a theoretical
+							// concern: consider that dropping a large table can take several
+							// days, while upgrading to a new version can take as little as a
+							// few minutes.
+							table.UpVersion = true
+							if err := table.Validate(ctx, txn); err != nil {
+								return err
+							}
+
+							b.Put(kv.Key, sqlbase.WrapDescriptor(table))
+						}
 					}
+				case *sqlbase.Descriptor_Database:
+					if database := sqlDesc.GetDatabase(); database != nil && upgradeDatabaseDescFn != nil {
+						if upgraded, err := upgradeDatabaseDescFn(database); err != nil {
+							return err
+						} else if upgraded {
+							if err := database.Validate(); err != nil {
+								return err
+							}
+
+							b.Put(kv.Key, sqlbase.WrapDescriptor(database))
+						}
+					}
+
+				default:
+					return errors.Errorf("Descriptor.Union has unexpected type %T", t)
 				}
 			}
 			if err := txn.SetSystemConfigTrigger(); err != nil {


### PR DESCRIPTION
This fixes an issue caught during QA: #21872

Also changed:
* validate used to enforce "no more privileges than root", this was
incorrect and should just be "must have no more than allowed privileges"
* switched to using the "upgrade descriptor" migration helper
* dropped the "multiple allowed privileges" in favor of just one

Release note (bug fix): enforce minimum privileges for "admin" role.