### PR TITLE
wip: kv: evict leaseholder on RPC error

### DIFF
--- a/pkg/cmd/roachtest/test.go
+++ b/pkg/cmd/roachtest/test.go
@@ -340,7 +340,10 @@ func (t *test) run(out io.Writer, done func(failed bool)) {
 			t.end = timeutil.Now()
 
 			if err := recover(); err != nil {
-				t.Fatal(err)
+				t.mu.Lock()
+				t.mu.failed = true
+				t.mu.output = append(t.mu.output, t.decorate(fmt.Sprint(err))...)
+				t.mu.Unlock()
 			}
 
 			t.mu.Lock()


### PR DESCRIPTION
This addresses a situation in which we would not evict a stale
leaseholder for a long time. Consider the replica [s1,s2,s3] and
s1 is down but is the cached leaseholder, while s2 is the actual lease
holder. The RPC layer will try s1, get an RPC error, try s2 and succeed.
Since there is no NotLeaseHolderError involved, the cache would not get
updated, and so every request pays the overhead of trying s1 first.

WIP because needs testing.

Touches #23601.

Release note (bug fix): Improve request routing during node outages.