### PR TITLE
roachtest: do not hang on panic

### DIFF
--- a/pkg/cmd/roachtest/test.go
+++ b/pkg/cmd/roachtest/test.go
@@ -340,7 +340,10 @@ func (t *test) run(out io.Writer, done func(failed bool)) {
 			t.end = timeutil.Now()
 
 			if err := recover(); err != nil {
-				t.Fatal(err)
+				t.mu.Lock()
+				t.mu.failed = true
+				t.mu.output = append(t.mu.output, t.decorate(fmt.Sprint(err))...)
+				t.mu.Unlock()
 			}
 
 			t.mu.Lock()


### PR DESCRIPTION
Which is what previously happened, thanks to the call to t.Fatal
which in turn called runtime.Goexit. We need to call `done` here
so that the caller has their WaitGroup signaled.

Release note: None