### PR TITLE
opt/constraint: convert exclusive boundaries to inclusive

### DIFF
--- a/pkg/sql/opt/constraint/constraint_set_test.go
+++ b/pkg/sql/opt/constraint/constraint_set_test.go
@@ -22,7 +22,7 @@ import (
 )
 
 func TestConstraintSetIntersect(t *testing.T) {
-	keyCtx := testKeyContext()
+	keyCtx := testKeyContext(1, 2)
 	evalCtx := keyCtx.EvalCtx
 
 	test := func(cs *Set, expected string) {
@@ -127,7 +127,7 @@ func TestConstraintSetIntersect(t *testing.T) {
 }
 
 func TestConstraintSetUnion(t *testing.T) {
-	keyCtx := testKeyContext()
+	keyCtx := testKeyContext(1, 2)
 	evalCtx := keyCtx.EvalCtx
 	data := newSpanTestData(keyCtx)
 

--- a/pkg/sql/opt/constraint/constraint_test.go
+++ b/pkg/sql/opt/constraint/constraint_test.go
@@ -197,7 +197,7 @@ func newConstraintTestData(evalCtx *tree.EvalContext) *constraintTestData {
 	key60 := MakeKey(tree.NewDInt(60))
 	key70 := MakeKey(tree.NewDInt(70))
 
-	keyCtx := testKeyContext()
+	keyCtx := testKeyContext(1, 2)
 
 	cherry := MakeCompositeKey(tree.NewDString("cherry"), tree.DBoolTrue)
 	mango := MakeCompositeKey(tree.NewDString("mango"), tree.DBoolFalse)

--- a/pkg/sql/opt/physical_props.go
+++ b/pkg/sql/opt/physical_props.go
@@ -192,6 +192,11 @@ func (c OrderingColumn) Index() ColumnIndex {
 	return ColumnIndex(c)
 }
 
+// Ascending returns true if the ordering on this column is ascending.
+func (c OrderingColumn) Ascending() bool {
+	return c > 0
+}
+
 // Descending returns true if the ordering on this column is descending.
 func (c OrderingColumn) Descending() bool {
 	return c < 0


### PR DESCRIPTION
Add `Span.PreferInclusive` which tries to adjust the span keys to be
inclusive (when possible); e.g. `(/1 - ] -> [/2 - ]`. Inclusive spans
are preferred because they can be "refined" with constraints on more
columns.

To help implement this, we add Key.Next/Prev methods.

Release note: None