### PR TITLE
roachtest: deflake splits/nodes=3 test

### DIFF
--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -320,7 +320,15 @@ type nodeCPUOption int
 func (o nodeCPUOption) apply(spec *nodeSpec) {
 	spec.CPUs = int(o)
 	if !local && clusterName != "local" {
-		spec.MachineType = fmt.Sprintf("--gce-machine-type=n1-highcpu-%d", spec.CPUs)
+		// TODO(peter): This is awkward: below 16 cpus, use n1-standard so that the
+		// machines have a decent amount of RAM. We could use customer machine
+		// configurations, but the rules for the amount of RAM per CPU need to be
+		// determined (you can't request any arbitrary amount of RAM).
+		if spec.CPUs < 16 {
+			spec.MachineType = fmt.Sprintf("--gce-machine-type=n1-standard-%d", spec.CPUs)
+		} else {
+			spec.MachineType = fmt.Sprintf("--gce-machine-type=n1-highcpu-%d", spec.CPUs)
+		}
 	}
 }
 


### PR DESCRIPTION
Ensure that machines have an adequate amount of RAM by default. A recent
change to node specification switched roachtest from using n1-standard
machines to n1-highcpu machines. This makes sense when the number of
CPUs is high. For the default 4 cpu machines used by tests, an
n1-highcpu-4 machine only has 3.6 GiB of RAM. This too is adequate for
most tests, but the splits/nodes=3 test uses quite a bit of RAM. Switch
back to using n1-standard machine types when the number of CPUs
requested is less than 16.

Fixes #23953

Release note: None