### PR TITLE
cherrypick-1.1: storage: Disallow sync intent resolution in loadSystemConfig

### DIFF
--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -5440,7 +5440,10 @@ func (r *Replica) loadSystemConfig(ctx context.Context) (config.SystemConfig, er
 		// There were intents, so what we read may not be consistent. Attempt
 		// to nudge the intents in case they're expired; next time around we'll
 		// hopefully have more luck.
-		if err := r.store.intentResolver.processIntentsAsync(ctx, r, intents, true /* allowSync */); err != nil {
+		// This is called from handleLocalEvalResult (with raftMu locked),
+		// so disallow synchronous processing (which blocks that mutex for
+		// too long and is a potential deadlock).
+		if err := r.store.intentResolver.processIntentsAsync(ctx, r, intents, false /* allowSync */); err != nil {
 			log.Warning(ctx, err)
 		}
 		return config.SystemConfig{}, errSystemConfigIntent


### PR DESCRIPTION
Cherry-picks #23282 to release-1.1

This holds raftMu on the system config range for too long,
and in extreme cases can lead to deadlock.

Fixes #23254

Release note (bug fix): Fixed a deadlock when tables are rapidly
created or dropped.