### PR TITLE
roachtest: use correct database in backup test

### DIFF
--- a/pkg/cmd/roachtest/backup.go
+++ b/pkg/cmd/roachtest/backup.go
@@ -39,7 +39,7 @@ func init() {
 					path := fmt.Sprintf(`gs://cockroach-fixtures/workload/bank/`+
 						`version=1.0.0,payload-bytes=10240,ranges=0,rows=65104166,seed=1/`+
 						`stores=%d/%d/*`, nodes, node)
-					c.Run(ctx, node, `gsutil -m cp -r `+path+` /mnt/data1/cockroach`)
+					c.Run(ctx, node, `gsutil -m -q cp -r `+path+` /mnt/data1/cockroach`)
 				}()
 			}
 			wg.Wait()

--- a/pkg/cmd/roachtest/backup.go
+++ b/pkg/cmd/roachtest/backup.go
@@ -50,7 +50,7 @@ func init() {
 			m.Go(func(ctx context.Context) error {
 				c.status(`running 2tb backup`)
 				c.Run(ctx, 1, `./cockroach sql --insecure -e "
-				BACKUP workload.bank TO 'gs://cockroachdb-backup-testing/`+c.name+`'"`)
+				BACKUP bank.bank TO 'gs://cockroachdb-backup-testing/`+c.name+`'"`)
 				return nil
 			})
 			m.Wait()


### PR DESCRIPTION
Some day, someone will have to explain to me why workload uses a
different database name every time I look at it.

Release note: None