### PR TITLE
cherry-pick 2.0: sql: fix inverted index queries

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/inverted_index
+++ b/pkg/sql/logictest/testdata/logic_test/inverted_index
@@ -150,6 +150,9 @@ INSERT INTO d VALUES (29,  NULL)
 statement ok
 INSERT INTO d VALUES (30,  '{"a": {"b": "c", "d": "e"}, "f": "g"}')
 
+statement ok
+INSERT INTO d VALUES (31,  '{"a": []}')
+
 query TITTTTT
 EXPLAIN (VERBOSE) SELECT * from d where b @>'{"a": "b"}'
 ----
@@ -326,6 +329,7 @@ SELECT * from d where b @> '{}' ORDER BY a;
 9   {"a": {"b": false}}
 17  {}
 30  {"a": {"b": "c", "d": "e"}, "f": "g"}
+31  {"a": []}
 
 query IT
 SELECT * from d where b @> '[]' ORDER BY a;
@@ -420,14 +424,24 @@ SELECT * from d where b @> '{"a": [{}]}' ORDER BY a;
 ----
 25  {"a": [{}]}
 
+
+query IT
+SELECT * from d where b @> '{"a": []}' ORDER BY a;
+----
+25  {"a": [{}]}
+31  {"a": []}
+
 query IT
 SELECT * from d where b @> '[{}]' ORDER BY a;
 ----
+16  [{"a": {"b": [1, [2]]}}, "d"]
+20  [{"a": "a"}, {"a": "a"}]
 26  [[], {}]
 
 query IT
 SELECT * from d where b @> '[[]]' ORDER BY a;
 ----
+21  [[[["a"]]], [[["a"]]]]
 26  [[], {}]
 
 statement ok
@@ -561,6 +575,36 @@ index-join  0  index-join  ·       ·                                          
  └── scan   1  scan        ·       ·                                                        (a, b)           ·
 ·           1  ·           table   d@primary                                                ·                ·
 ·           1  ·           filter  b @> '["d"]'                                             ·                ·
+
+query IT
+SELECT * from d where b @> '{"a": {}}' ORDER BY a;
+----
+3  {"a": {"b": "c"}}
+4  {"a": {"b": [1]}}
+5  {"a": {"b": [1, [2]]}}
+8  {"a": {"b": true}}
+9  {"a": {"b": false}}
+30 {"a": {"b": "c", "d": "e"}, "f": "g"}
+
+query IT
+SELECT * from d where b @> '{"a": []}' ORDER BY a;
+----
+25  {"a": [{}]}
+31  {"a": []}
+
+query TTT
+EXPLAIN SELECT * from d where b @> '{"a": []}' ORDER BY a;
+----
+scan  ·      ·
+·     table  d@primary
+·     spans  ALL
+
+query TTT
+EXPLAIN SELECT * from d where b @> '{"a": {}}' ORDER BY a;
+----
+scan  ·      ·
+·     table  d@primary
+·     spans  ALL
 
 statement ok
 CREATE TABLE users (

--- a/pkg/sql/opt_index_selection.go
+++ b/pkg/sql/opt_index_selection.go
@@ -560,12 +560,6 @@ func encodeLogicalKey(
 				)
 				return nil, err
 			}
-			if len(keys) < 1 {
-				err := pgerror.NewError(
-					pgerror.CodeInternalError, "can't look up empty JSON",
-				)
-				return nil, err
-			}
 			key = keys[0]
 		} else {
 			key, err = sqlbase.EncodeTableKey(key, val, dir)

--- a/pkg/util/json/encoded.go
+++ b/pkg/util/json/encoded.go
@@ -710,6 +710,15 @@ func (j *jsonEncoded) allPaths() ([]JSON, error) {
 	return decoded.allPaths()
 }
 
+// HasContainerLeaf implements the JSON interface.
+func (j *jsonEncoded) HasContainerLeaf() (bool, error) {
+	decoded, err := j.decode()
+	if err != nil {
+		return false, err
+	}
+	return decoded.HasContainerLeaf()
+}
+
 // preprocessForContains implements the JSON interface.
 func (j *jsonEncoded) preprocessForContains() (containsable, error) {
 	if dec := j.alreadyDecoded(); dec != nil {

--- a/pkg/util/json/json.go
+++ b/pkg/util/json/json.go
@@ -151,6 +151,10 @@ type JSON interface {
 	// Len returns the number of outermost elements in the JSON document if it is an object or an array.
 	// Otherwise, Len returns 0.
 	Len() int
+
+	// HasContainerLeaf returns whether this document contains in it somewhere
+	// either the empty array or the empty object.
+	HasContainerLeaf() (bool, error)
 }
 
 type jsonTrue struct{}
@@ -1588,3 +1592,41 @@ func (j jsonTrue) doRemovePath([]string) (JSON, bool, error)   { return j, false
 func (j jsonFalse) doRemovePath([]string) (JSON, bool, error)  { return j, false, nil }
 func (j jsonString) doRemovePath([]string) (JSON, bool, error) { return j, false, nil }
 func (j jsonNumber) doRemovePath([]string) (JSON, bool, error) { return j, false, nil }
+
+func (j jsonObject) HasContainerLeaf() (bool, error) {
+	if j.Len() == 0 {
+		return true, nil
+	}
+	for _, c := range j {
+		child, err := c.v.HasContainerLeaf()
+		if err != nil {
+			return false, err
+		}
+		if child {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func (j jsonArray) HasContainerLeaf() (bool, error) {
+	if j.Len() == 0 {
+		return true, nil
+	}
+	for _, c := range j {
+		child, err := c.HasContainerLeaf()
+		if err != nil {
+			return false, err
+		}
+		if child {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func (j jsonNull) HasContainerLeaf() (bool, error)   { return false, nil }
+func (j jsonTrue) HasContainerLeaf() (bool, error)   { return false, nil }
+func (j jsonFalse) HasContainerLeaf() (bool, error)  { return false, nil }
+func (j jsonString) HasContainerLeaf() (bool, error) { return false, nil }
+func (j jsonNumber) HasContainerLeaf() (bool, error) { return false, nil }

--- a/pkg/util/json/json_test.go
+++ b/pkg/util/json/json_test.go
@@ -1684,6 +1684,46 @@ func TestPretty(t *testing.T) {
 	}
 }
 
+func TestHasContainerLeaf(t *testing.T) {
+	cases := []struct {
+		input    string
+		expected bool
+	}{
+		{`true`, false},
+		{`false`, false},
+		{`1`, false},
+		{`[]`, true},
+		{`{}`, true},
+		{`{"a": 1}`, false},
+		{`{"a": {"b": 3}, "x": "y", "c": []}`, true},
+		{`{"a": {"b": 3}, "c": [], "x": "y"}`, true},
+		{`{"a": {}}`, true},
+		{`{"a": []}`, true},
+		{`[]`, true},
+		{`[[]]`, true},
+		{`[1, 2, 3, []]`, true},
+		{`[1, 2, [], 3]`, true},
+		{`[[], 1, 2, 3]`, true},
+		{`[1, 2, 3]`, false},
+		{`[[1, 2, 3]]`, false},
+		{`[[1, 2], 3]`, false},
+		{`[1, 2, 3, [4]]`, false},
+	}
+
+	for _, tc := range cases {
+		j := jsonTestShorthand(tc.input)
+		runDecodedAndEncoded(t, tc.input, j, func(t *testing.T, j JSON) {
+			result, err := j.HasContainerLeaf()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if result != tc.expected {
+				t.Fatalf("expected:\n%v\ngot:\n%v\n", tc.expected, result)
+			}
+		})
+	}
+}
+
 func BenchmarkBuildJSONObject(b *testing.B) {
 	for _, objectSize := range []int{1, 10, 100, 1000, 10000, 100000} {
 		keys := make([]string, objectSize)


### PR DESCRIPTION
We need to do a full table scan whenever we are querying by containment
of a document that has an empty object or array in it, not just those at
the top level.

Fixes #23819.

Release note (bug fix): Fixed a bug where some inverted index queries
could return incorrect results.

cc @cockroachdb/release 