### PR TITLE
sql: do not allow full scans of inverted indexes

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/inverted_index
+++ b/pkg/sql/logictest/testdata/logic_test/inverted_index
@@ -495,6 +495,9 @@ INSERT INTO users (user_profile) VALUES  ('{"first_name": "Lola", "last_name": "
 statement ok
 CREATE INVERTED INDEX dogs on users(user_profile);
 
+statement error index "dogs" is inverted and cannot be used for this query
+SELECT COUNT(*) FROM users@dogs
+
 query T
 SELECT user_profile from users where user_profile @> '{"first_name":"Lola"}';
 ----


### PR DESCRIPTION
Fixes #23936.

Release note (bug fix): Inverted indexes can no longer be hinted
for inappropriate queries.