### PR TITLE
opt/constraint: detect incorrect mutation of Span

### DIFF
--- a/pkg/sql/opt/constraint/constraint.go
+++ b/pkg/sql/opt/constraint/constraint.go
@@ -58,6 +58,7 @@ func (c *Constraint) init(col opt.OrderingColumn, sp *Span) {
 	}
 	c.Columns.InitSingle(col)
 	c.firstSpan = *sp
+	c.firstSpan.makeImmutable()
 }
 
 // initComposite is for package use only. External callers should call
@@ -70,6 +71,7 @@ func (c *Constraint) initComposite(cols []opt.OrderingColumn, sp *Span) {
 	}
 	c.Columns.Init(cols)
 	c.firstSpan = *sp
+	c.firstSpan.makeImmutable()
 }
 
 // SpanCount returns the total number of spans in the constraint (always at
@@ -81,6 +83,7 @@ func (c *Constraint) SpanCount() int {
 // Span returns the nth span. Together with the SpanCount method, Span allows
 // iteration over the list of spans (since there is no method to return a slice
 // of spans).
+// Mutating the returned span is not permitted.
 func (c *Constraint) Span(nth int) *Span {
 	// There's always at least one span.
 	if nth == 0 {
@@ -133,7 +136,7 @@ func (c *Constraint) tryUnionWith(evalCtx *tree.EvalContext, other *Constraint) 
 		//   merge with [/30 - /40]: [/1 - /40]
 		//   merge with [/40 - /50]: [/1 - /50]
 		//
-		mergeSpan := *left.Span(leftIndex)
+		mergeSpan := left.Span(leftIndex).Copy()
 		leftIndex++
 		for {
 			// Note that Span.TryUnionWith returns false for a different reason
@@ -171,6 +174,7 @@ func (c *Constraint) tryUnionWith(evalCtx *tree.EvalContext, other *Constraint) 
 				break
 			}
 		}
+		mergeSpan.makeImmutable()
 
 		if otherSpans == nil {
 			if !foundSpan {
@@ -219,11 +223,12 @@ func (c *Constraint) tryIntersectWith(evalCtx *tree.EvalContext, other *Constrai
 			continue
 		}
 
-		mergeSpan := *c.Span(index)
+		mergeSpan := c.Span(index).Copy()
 		if !mergeSpan.TryIntersectWith(keyCtx, other.Span(otherIndex)) {
 			index++
 			continue
 		}
+		mergeSpan.makeImmutable()
 
 		if otherSpans == nil {
 			if empty {

--- a/pkg/sql/opt/constraint/key.go
+++ b/pkg/sql/opt/constraint/key.go
@@ -29,6 +29,7 @@ var EmptyKey = Key{}
 // significant to least significant for purposes of sorting. The datum values
 // correspond to a set of columns; it is the responsibility of the calling code
 // to keep track of them.
+// Key is immutable; it cannot be changed once created.
 type Key struct {
 	// firstVal stores the first value in the key. Subsequent values are stored
 	// in otherVals. Inlining the first value avoids an extra allocation in the


### PR DESCRIPTION
Constraint assumes that the Spans it stores are never changed. To
enforce this, we set a flag which causes any mutation methods to
panic. A Copy() method returns (by value) a non-immutable copy.

Release note: None