### PR TITLE
sql: trigger table lease renewal in ID lookup path

### DIFF
--- a/pkg/sql/lease_test.go
+++ b/pkg/sql/lease_test.go
@@ -1003,28 +1003,40 @@ func TestLeaseRenewedAutomatically(testingT *testing.T) {
 	params.LeaseManagerConfig.TableDescriptorLeaseRenewalTimeout =
 		params.LeaseManagerConfig.TableDescriptorLeaseDuration
 
+	ctx := context.Background()
 	t := newLeaseTest(testingT, params)
 	defer t.cleanup()
 
 	if _, err := t.db.Exec(`
 CREATE DATABASE t;
-CREATE TABLE t.test (k CHAR PRIMARY KEY, v CHAR);
+CREATE TABLE t.test1 (k CHAR PRIMARY KEY, v CHAR);
+CREATE TABLE t.test2 ();
 `); err != nil {
 		t.Fatal(err)
 	}
 
-	tableDesc := sqlbase.GetTableDescriptor(t.kvDB, "t", "test")
-	dbID := tableDesc.ParentID
-	tableName := tableDesc.Name
+	test2Desc := sqlbase.GetTableDescriptor(t.kvDB, "t", "test2")
+	dbID := test2Desc.ParentID
 
-	// Acquire the first lease.
-	ts, e1, err := t.node(1).AcquireByName(context.TODO(), t.server.Clock().Now(), dbID, tableName)
+	// Acquire a lease on test1 by name.
+	ts1, eo1, err := t.node(1).AcquireByName(ctx, t.server.Clock().Now(), dbID, "test1")
 	if err != nil {
 		t.Fatal(err)
-	} else if err := t.release(1, ts); err != nil {
+	} else if err := t.release(1, ts1); err != nil {
 		t.Fatal(err)
 	} else if count := atomic.LoadInt32(&testAcquiredCount); count != 1 {
 		t.Fatalf("expected 1 lease to be acquired, but acquired %d times",
+			count)
+	}
+
+	// Acquire a lease on test2 by ID.
+	ts2, eo2, err := t.node(1).Acquire(ctx, t.server.Clock().Now(), test2Desc.ID)
+	if err != nil {
+		t.Fatal(err)
+	} else if err := t.release(1, ts2); err != nil {
+		t.Fatal(err)
+	} else if count := atomic.LoadInt32(&testAcquiredCount); count != 2 {
+		t.Fatalf("expected 2 leases to be acquired, but acquired %d times",
 			count)
 	}
 
@@ -1032,15 +1044,15 @@ CREATE TABLE t.test (k CHAR PRIMARY KEY, v CHAR);
 	atomic.StoreInt32(&testAcquisitionBlockCount, 0)
 
 	testutils.SucceedsSoon(t, func() error {
-		// Acquire another lease. At first this will be the same lease, but
-		// eventually we will asynchronously renew a lease and our acquire will get
-		// a newer lease.
-		ts, e2, err := t.node(1).AcquireByName(context.TODO(), t.server.Clock().Now(), dbID, tableName)
+		// Acquire another lease by name on test1. At first this will be the
+		// same lease, but eventually we will asynchronously renew a lease and
+		// our acquire will get a newer lease.
+		ts1, en1, err := t.node(1).AcquireByName(ctx, t.server.Clock().Now(), dbID, "test1")
 		if err != nil {
 			t.Fatal(err)
 		}
 		defer func() {
-			if err := t.release(1, ts); err != nil {
+			if err := t.release(1, ts1); err != nil {
 				t.Fatal(err)
 			}
 		}()
@@ -1048,15 +1060,42 @@ CREATE TABLE t.test (k CHAR PRIMARY KEY, v CHAR);
 		// We check for the new expiry time because if our past acquire triggered
 		// the background renewal, the next lease we get will be the result of the
 		// background renewal.
-		if e2.WallTime <= e1.WallTime {
+		if en1.WallTime <= eo1.WallTime {
 			return errors.Errorf("expected new lease expiration (%s) to be after old lease expiration (%s)",
-				e2, e1)
+				en1, eo1)
 		} else if count := atomic.LoadInt32(&testAcquiredCount); count < 2 {
 			return errors.Errorf("expected at least 2 leases to be acquired, but acquired %d times",
 				count)
 		} else if blockCount := atomic.LoadInt32(&testAcquisitionBlockCount); blockCount > 0 {
 			t.Fatalf("expected repeated lease acquisition to not block, but blockCount is: %d", blockCount)
 		}
+
+		// Acquire another lease by ID on test2. At first this will be the same
+		// lease, but eventually we will asynchronously renew a lease and our
+		// acquire will get a newer lease.
+		ts2, en2, err := t.node(1).Acquire(ctx, t.server.Clock().Now(), test2Desc.ID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer func() {
+			if err := t.release(1, ts2); err != nil {
+				t.Fatal(err)
+			}
+		}()
+
+		// We check for the new expiry time because if our past acquire triggered
+		// the background renewal, the next lease we get will be the result of the
+		// background renewal.
+		if en2.WallTime <= eo2.WallTime {
+			return errors.Errorf("expected new lease expiration (%s) to be after old lease expiration (%s)",
+				en2, eo2)
+		} else if count := atomic.LoadInt32(&testAcquiredCount); count < 3 {
+			return errors.Errorf("expected at least 3 leases to be acquired, but acquired %d times",
+				count)
+		} else if blockCount := atomic.LoadInt32(&testAcquisitionBlockCount); blockCount > 0 {
+			t.Fatalf("expected repeated lease acquisition to not block, but blockCount is: %d", blockCount)
+		}
+
 		return nil
 	})
 }


### PR DESCRIPTION
When acquiring a lease on a table by name, we check to make sure the
table lease isn't expiring soon. If it is, we queue an asynchronous
lease renewal; this asynchronous renewal is crucial in avoiding
"transaction deadline exceeded" errors.

Teach the lease manager to perform the same check when acquiring table
descriptors by ID, as it's possible to construct workloads that only
ever trigger lease acquisitions by ID [0].

[0]: https://github.com/cockroachdb/cockroach/issues/18684#issuecomment-373852730

Release note: None

Fix #18684.

@jordanlewis @petermattis are either of you guys able to qualify this patch on one of your tpcc 10k runs?