### PR TITLE
backport-2.0: sql: do not allow full scans of inverted indexes

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/inverted_index
+++ b/pkg/sql/logictest/testdata/logic_test/inverted_index
@@ -576,6 +576,9 @@ INSERT INTO users (user_profile) VALUES  ('{"first_name": "Lola", "last_name": "
 statement ok
 CREATE INVERTED INDEX dogs on users(user_profile);
 
+statement error index "dogs" is inverted and cannot be used for this query
+SELECT COUNT(*) FROM users@dogs
+
 query T
 SELECT user_profile from users where user_profile @> '{"first_name":"Lola"}';
 ----

--- a/pkg/sql/opt_index_selection.go
+++ b/pkg/sql/opt_index_selection.go
@@ -144,14 +144,33 @@ func (p *planner) selectIndex(
 		}
 	}
 
+	// Remove any inverted indexes that don't generate any spans, a full-scan of
+	// an inverted index is always invalid.
+	for i := 0; i < len(candidates); {
+		spans, ok := candidates[i].ic.Spans()
+		if candidates[i].index.Type == sqlbase.IndexDescriptor_INVERTED && (!ok || len(spans) == 0) {
+			candidates[i] = candidates[len(candidates)-1]
+			candidates = candidates[:len(candidates)-1]
+		} else {
+			i++
+		}
+	}
+
+	if len(candidates) == 0 {
+		// The primary index is never inverted. So the only way this can happen is
+		// if we had a specified index.
+		if s.specifiedIndex == nil {
+			panic("no non-inverted indexes")
+		}
+		return nil, fmt.Errorf("index \"%s\" is inverted and cannot be used for this query",
+			s.specifiedIndex.Name)
+	}
+
 	if s.noIndexJoin {
 		// Eliminate non-covering indexes. We do this after the check above for
-		// constant false filter. We're also removing inverted indexes that don't
-		// generate spans.
+		// constant false filter.
 		for i := 0; i < len(candidates); {
-			spans, ok := candidates[i].ic.Spans()
-			if !candidates[i].covering ||
-				(candidates[i].index.Type == sqlbase.IndexDescriptor_INVERTED && (!ok || len(spans) == 0)) {
+			if !candidates[i].covering {
 				candidates[i] = candidates[len(candidates)-1]
 				candidates = candidates[:len(candidates)-1]
 			} else {


### PR DESCRIPTION
Backport 1/1 commits from #23973.

/cc @cockroachdb/release

---

Fixes #23936.

Release note (bug fix): Inverted indexes can no longer be hinted
for inappropriate queries.
