### PR TITLE
storage: declare correct key for QueryTxn request

### DIFF
--- a/pkg/storage/batcheval/cmd_query_txn.go
+++ b/pkg/storage/batcheval/cmd_query_txn.go
@@ -22,12 +22,20 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage/batcheval/result"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
+	"github.com/cockroachdb/cockroach/pkg/storage/spanset"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/pkg/errors"
 )
 
 func init() {
-	RegisterCommand(roachpb.QueryTxn, DefaultDeclareKeys, QueryTxn)
+	RegisterCommand(roachpb.QueryTxn, declareKeysQueryTransaction, QueryTxn)
+}
+
+func declareKeysQueryTransaction(
+	_ roachpb.RangeDescriptor, header roachpb.Header, req roachpb.Request, spans *spanset.SpanSet,
+) {
+	qr := req.(*roachpb.QueryTxnRequest)
+	spans.Add(spanset.SpanReadOnly, roachpb.Span{Key: keys.TransactionKey(qr.Txn.Key, qr.Txn.ID)})
 }
 
 // QueryTxn fetches the current state of a transaction.


### PR DESCRIPTION
Fixes #23944.

This change corrects QueryTxn so that it now correctly declares the
key that it reads from. This is important because the previous
incorrect declaration allowed for improper CommandQueue synchronization
with other requests that touch the transaction record.

There were two approaches we could take here:
- Map the requests header.Key to the correct key
- Append the txnID to header.Key

This change goes with the former approach because it does not have any
compatibility concerns and because it is consistent with what we do
for PushTxn requests.

Release note: None