### PR TITLE
storage: cap RocksDB background jobs

### DIFF
--- a/pkg/storage/raft_log_queue.go
+++ b/pkg/storage/raft_log_queue.go
@@ -44,6 +44,9 @@ const (
 	// when Raft log truncation usually occurs when using the number of entries
 	// as the sole criteria.
 	RaftLogQueueStaleSize = 64 << 10
+	// Allow a limited number of Raft log truncations to be processed
+	// concurrently.
+	raftLogQueueConcurrency = 4
 )
 
 // raftLogMaxSize limits the maximum size of the Raft log.
@@ -65,6 +68,7 @@ func newRaftLogQueue(store *Store, db *client.DB, gossip *gossip.Gossip) *raftLo
 		"raftlog", rlq, store, gossip,
 		queueConfig{
 			maxSize:              defaultQueueMaxSize,
+			maxConcurrency:       raftLogQueueConcurrency,
 			needsLease:           false,
 			needsSystemConfig:    false,
 			acceptsUnsplitRanges: true,


### PR DESCRIPTION
Cap the number of RocksDB background at 4. Allowing NumCPU background
jobs could lead to short periods of excessive CPU usage performing
RocksDB compactions. Should probably make this configurable.

Increase the concurrency of Raft log truncations from 1 to 4. A value
of 1 wasn't adequately keeping up with Raft log truncations which made
some of the truncations larger in size (we have to truncate the entire
log whenever a truncation is performed) leading to small latency spikes.

Release note: None