### PR TITLE
cherry-pick 2.0: sql: gate sql features on cluster version

### DIFF
--- a/pkg/acceptance/version_upgrade_test.go
+++ b/pkg/acceptance/version_upgrade_test.go
@@ -109,6 +109,38 @@ func (bv binaryVersionUpgrade) checkNode(
 	}
 }
 
+type feature struct {
+	name              string
+	minAllowedVersion string
+	query             string
+}
+
+func testFeature(ctx context.Context, t *testing.T, c cluster.Cluster, f feature, cv string) {
+	db := makePGClient(t, c.PGUrl(ctx, 0 /* nodeId */))
+	defer db.Close()
+
+	minAllowedVersion, err := roachpb.ParseVersion(f.minAllowedVersion)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	actualVersion, err := roachpb.ParseVersion(cv)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = db.Exec(f.query)
+	if actualVersion.Less(minAllowedVersion) {
+		if err == nil {
+			t.Fatalf("expected %s to fail on cluster version %s", f.name, cv)
+		}
+	} else {
+		if err != nil {
+			t.Fatalf("expected %s to succeed on cluster version %s, got %s", f.name, cv, err)
+		}
+	}
+}
+
 // clusterVersionUpgrade performs a cluster version upgrade to its version.
 // It waits until all nodes have seen the upgraded cluster version.
 type clusterVersionUpgrade string
@@ -196,6 +228,31 @@ func testVersionUpgrade(ctx context.Context, t *testing.T, cfg cluster.TestConfi
 		clusterVersionUpgrade(clusterversion.BinaryServerVersion.String()),
 	}
 
+	features := []feature{
+		{
+			name:              "JSONB",
+			minAllowedVersion: "2.0-0",
+			query: `
+			CREATE DATABASE IF NOT EXISTS test;
+			CREATE TABLE test.t (j JSONB);
+			DROP TABLE test.t;`,
+		}, {
+			name:              "Sequences",
+			minAllowedVersion: "2.0-0",
+			query: `
+			CREATE DATABASE IF NOT EXISTS test;
+			CREATE SEQUENCE test.test_sequence;
+			DROP SEQUENCE test.test_sequence;`,
+		}, {
+			name:              "Computed Columns",
+			minAllowedVersion: "2.0-0",
+			query: `
+			CREATE DATABASE IF NOT EXISTS test;
+			CREATE TABLE test.t (x INT AS (3) STORED);
+			DROP TABLE test.t;`,
+		},
+	}
+
 	if len(cfg.Nodes) > 3 {
 		cfg.Nodes = cfg.Nodes[:3]
 	}
@@ -212,5 +269,10 @@ func testVersionUpgrade(ctx context.Context, t *testing.T, cfg cluster.TestConfi
 	for _, step := range steps {
 		t.Log(step.name())
 		step.run(ctx, t, c)
+		if s, ok := step.(clusterVersionUpgrade); ok {
+			for _, feature := range features {
+				testFeature(ctx, t, c, feature, string(s))
+			}
+		}
 	}
 }

--- a/pkg/ccl/backupccl/restore.go
+++ b/pkg/ccl/backupccl/restore.go
@@ -831,6 +831,7 @@ func WriteTableDescs(
 	databases []*sqlbase.DatabaseDescriptor,
 	tables []*sqlbase.TableDescriptor,
 	user string,
+	settings *cluster.Settings,
 ) error {
 	ctx, span := tracing.ChildSpan(ctx, "WriteTableDescs")
 	defer tracing.FinishSpan(span)
@@ -871,7 +872,7 @@ func WriteTableDescs(
 		}
 
 		for _, table := range tables {
-			if err := table.Validate(ctx, txn); err != nil {
+			if err := table.Validate(ctx, txn, settings); err != nil {
 				return errors.Wrapf(err, "validate table %d", table.ID)
 			}
 		}
@@ -1356,7 +1357,7 @@ func (r *restoreResumer) OnSuccess(ctx context.Context, txn *client.Txn, job *jo
 	// Write the new TableDescriptors and flip the namespace entries over to
 	// them. After this call, any queries on a table will be served by the newly
 	// restored data.
-	if err := WriteTableDescs(ctx, txn, r.databases, r.tables, job.Record.Username); err != nil {
+	if err := WriteTableDescs(ctx, txn, r.databases, r.tables, job.Record.Username, r.settings); err != nil {
 		return errors.Wrapf(err, "restoring %d TableDescriptors", len(r.tables))
 	}
 

--- a/pkg/ccl/importccl/csv.go
+++ b/pkg/ccl/importccl/csv.go
@@ -1743,7 +1743,7 @@ func (r *importResumer) OnSuccess(ctx context.Context, txn *client.Txn, job *job
 		// Write the new TableDescriptors and flip the namespace entries over to
 		// them. After this call, any queries on a table will be served by the newly
 		// imported data.
-		if err := backupccl.WriteTableDescs(ctx, txn, nil, []*sqlbase.TableDescriptor{details.Desc}, job.Record.Username); err != nil {
+		if err := backupccl.WriteTableDescs(ctx, txn, nil, []*sqlbase.TableDescriptor{details.Desc}, job.Record.Username, r.settings); err != nil {
 			return errors.Wrapf(err, "creating table %q", details.Desc.Name)
 		}
 	}

--- a/pkg/ccl/partitionccl/partition_test.go
+++ b/pkg/ccl/partitionccl/partition_test.go
@@ -129,7 +129,7 @@ func (t *partitioningTest) parse() error {
 		if err != nil {
 			return err
 		}
-		if err := t.parsed.tableDesc.ValidateTable(); err != nil {
+		if err := t.parsed.tableDesc.ValidateTable(st); err != nil {
 			return err
 		}
 	}

--- a/pkg/settings/cluster/settings.go
+++ b/pkg/settings/cluster/settings.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
@@ -139,6 +140,13 @@ func (ecv *ExposedClusterVersion) Version() ClusterVersion {
 	return v
 }
 
+// HasBeenInitialized returns whether the cluster version has been initialized
+// yet and if Version can be safely called.
+func (ecv *ExposedClusterVersion) HasBeenInitialized() bool {
+	v := *ecv.baseVersion.Load().(*ClusterVersion)
+	return v != ClusterVersion{}
+}
+
 // BootstrapVersion returns the version a newly initialized cluster should have.
 func (ecv *ExposedClusterVersion) BootstrapVersion() ClusterVersion {
 	return ClusterVersion{
@@ -169,6 +177,20 @@ func (ecv *ExposedClusterVersion) IsActive(versionKey VersionKey) bool {
 // permanently available (i.e. cannot be downgraded away).
 func (ecv *ExposedClusterVersion) IsMinSupported(versionKey VersionKey) bool {
 	return ecv.Version().IsMinSupported(versionKey)
+}
+
+// CheckVersion is like IsMinSupported but returns an appropriate error in the
+// case of a cluster version which is too low.
+func (ecv *ExposedClusterVersion) CheckVersion(versionKey VersionKey, feature string) error {
+	if !ecv.Version().IsMinSupported(versionKey) {
+		return pgerror.NewErrorf(
+			pgerror.CodeFeatureNotSupportedError,
+			"cluster version does not support %s (>= %s required)",
+			feature,
+			VersionByKey(versionKey).String(),
+		)
+	}
+	return nil
 }
 
 // MakeTestingClusterSettings returns a Settings object that has had its version

--- a/pkg/sql/create_sequence.go
+++ b/pkg/sql/create_sequence.go
@@ -80,7 +80,7 @@ func (n *createSequenceNode) startExec(params runParams) error {
 		return err
 	}
 
-	if err = desc.ValidateTable(); err != nil {
+	if err = desc.ValidateTable(params.EvalContext().Settings); err != nil {
 		return err
 	}
 
@@ -99,7 +99,7 @@ func (n *createSequenceNode) startExec(params runParams) error {
 	if desc.Adding() {
 		params.p.notifySchemaChange(&desc, sqlbase.InvalidMutationID)
 	}
-	if err := desc.Validate(params.ctx, params.p.txn); err != nil {
+	if err := desc.Validate(params.ctx, params.p.txn, params.extendedEvalCtx.Settings); err != nil {
 		return err
 	}
 
@@ -175,5 +175,5 @@ func (n *createSequenceNode) makeSequenceTableDesc(
 	}
 	desc.SequenceOpts = opts
 
-	return desc, desc.ValidateTable()
+	return desc, desc.ValidateTable(params.EvalContext().Settings)
 }

--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -152,7 +152,7 @@ func (n *createTableNode) startExec(params runParams) error {
 	// We need to validate again after adding the FKs.
 	// Only validate the table because backreferences aren't created yet.
 	// Everything is validated below.
-	if err := desc.ValidateTable(); err != nil {
+	if err := desc.ValidateTable(params.EvalContext().Settings); err != nil {
 		return err
 	}
 
@@ -177,7 +177,7 @@ func (n *createTableNode) startExec(params runParams) error {
 		}
 	}
 
-	if err := desc.Validate(params.ctx, params.p.txn); err != nil {
+	if err := desc.Validate(params.ctx, params.p.txn, params.EvalContext().Settings); err != nil {
 		return err
 	}
 
@@ -666,7 +666,7 @@ func (p *planner) saveNonmutationAndNotify(ctx context.Context, td *sqlbase.Tabl
 	if err := td.SetUpVersion(); err != nil {
 		return err
 	}
-	if err := td.ValidateTable(); err != nil {
+	if err := td.ValidateTable(p.EvalContext().Settings); err != nil {
 		return err
 	}
 	if err := p.writeTableDesc(ctx, td); err != nil {

--- a/pkg/sql/create_view.go
+++ b/pkg/sql/create_view.go
@@ -146,7 +146,7 @@ func (n *createViewNode) startExec(params runParams) error {
 		return err
 	}
 
-	if err = desc.ValidateTable(); err != nil {
+	if err = desc.ValidateTable(params.EvalContext().Settings); err != nil {
 		return err
 	}
 
@@ -179,7 +179,7 @@ func (n *createViewNode) startExec(params runParams) error {
 	if desc.Adding() {
 		params.p.notifySchemaChange(&desc, sqlbase.InvalidMutationID)
 	}
-	if err := desc.Validate(params.ctx, params.p.txn); err != nil {
+	if err := desc.Validate(params.ctx, params.p.txn, params.EvalContext().Settings); err != nil {
 		return err
 	}
 

--- a/pkg/sql/descriptor.go
+++ b/pkg/sql/descriptor.go
@@ -191,7 +191,7 @@ func getDescriptorByID(
 		}
 		table.MaybeFillInDescriptor()
 
-		if err := table.Validate(ctx, txn); err != nil {
+		if err := table.Validate(ctx, txn, nil /* clusterVersion */); err != nil {
 			return err
 		}
 		*t = *table

--- a/pkg/sql/descriptor_mutation_test.go
+++ b/pkg/sql/descriptor_mutation_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
@@ -85,7 +86,7 @@ func (mt mutationTest) makeMutationsActive() {
 		}
 	}
 	mt.tableDesc.Mutations = nil
-	if err := mt.tableDesc.ValidateTable(); err != nil {
+	if err := mt.tableDesc.ValidateTable(cluster.MakeTestingClusterSettings()); err != nil {
 		mt.Fatal(err)
 	}
 	if err := mt.kvDB.Put(
@@ -140,7 +141,7 @@ func (mt mutationTest) writeMutation(m sqlbase.DescriptorMutation) {
 		}
 	}
 	mt.tableDesc.Mutations = append(mt.tableDesc.Mutations, m)
-	if err := mt.tableDesc.ValidateTable(); err != nil {
+	if err := mt.tableDesc.ValidateTable(cluster.MakeTestingClusterSettings()); err != nil {
 		mt.Fatal(err)
 	}
 	if err := mt.kvDB.Put(
@@ -347,21 +348,21 @@ CREATE INDEX allidx ON t.test (k, v);
 	// Check that a mutation can only be inserted with an explicit mutation state, and direction.
 	tableDesc = mTest.tableDesc
 	tableDesc.Mutations = []sqlbase.DescriptorMutation{{}}
-	if err := tableDesc.ValidateTable(); !testutils.IsError(err, "mutation in state UNKNOWN, direction NONE, and no column/index descriptor") {
+	if err := tableDesc.ValidateTable(cluster.MakeTestingClusterSettings()); !testutils.IsError(err, "mutation in state UNKNOWN, direction NONE, and no column/index descriptor") {
 		t.Fatal(err)
 	}
 	tableDesc.Mutations = []sqlbase.DescriptorMutation{{Descriptor_: &sqlbase.DescriptorMutation_Column{Column: &tableDesc.Columns[len(tableDesc.Columns)-1]}}}
 	tableDesc.Columns = tableDesc.Columns[:len(tableDesc.Columns)-1]
-	if err := tableDesc.ValidateTable(); !testutils.IsError(err, `mutation in state UNKNOWN, direction NONE, col "i", id 3`) {
+	if err := tableDesc.ValidateTable(cluster.MakeTestingClusterSettings()); !testutils.IsError(err, `mutation in state UNKNOWN, direction NONE, col "i", id 3`) {
 		t.Fatal(err)
 	}
 	tableDesc.Mutations[0].State = sqlbase.DescriptorMutation_DELETE_ONLY
-	if err := tableDesc.ValidateTable(); !testutils.IsError(err, `mutation in state DELETE_ONLY, direction NONE, col "i", id 3`) {
+	if err := tableDesc.ValidateTable(cluster.MakeTestingClusterSettings()); !testutils.IsError(err, `mutation in state DELETE_ONLY, direction NONE, col "i", id 3`) {
 		t.Fatal(err)
 	}
 	tableDesc.Mutations[0].State = sqlbase.DescriptorMutation_UNKNOWN
 	tableDesc.Mutations[0].Direction = sqlbase.DescriptorMutation_DROP
-	if err := tableDesc.ValidateTable(); !testutils.IsError(err, `mutation in state UNKNOWN, direction DROP, col "i", id 3`) {
+	if err := tableDesc.ValidateTable(cluster.MakeTestingClusterSettings()); !testutils.IsError(err, `mutation in state UNKNOWN, direction DROP, col "i", id 3`) {
 		t.Fatal(err)
 	}
 }
@@ -524,7 +525,7 @@ CREATE TABLE t.test (k CHAR PRIMARY KEY, v CHAR, INDEX foo (v));
 	tableDesc = mTest.tableDesc
 	tableDesc.Mutations = []sqlbase.DescriptorMutation{{Descriptor_: &sqlbase.DescriptorMutation_Index{Index: &tableDesc.Indexes[len(tableDesc.Indexes)-1]}}}
 	tableDesc.Indexes = tableDesc.Indexes[:len(tableDesc.Indexes)-1]
-	if err := tableDesc.ValidateTable(); !testutils.IsError(err, "mutation in state UNKNOWN, direction NONE, index foo, id 2") {
+	if err := tableDesc.ValidateTable(cluster.MakeTestingClusterSettings()); !testutils.IsError(err, "mutation in state UNKNOWN, direction NONE, index foo, id 2") {
 		t.Fatal(err)
 	}
 }

--- a/pkg/sql/drop_index.go
+++ b/pkg/sql/drop_index.go
@@ -214,7 +214,7 @@ func (p *planner) dropIndexByName(
 		return fmt.Errorf("index %q in the middle of being added, try again later", idxName)
 	}
 
-	if err := tableDesc.Validate(ctx, p.txn); err != nil {
+	if err := tableDesc.Validate(ctx, p.txn, p.EvalContext().Settings); err != nil {
 		return err
 	}
 	mutationID, err := p.createSchemaChangeJob(ctx, tableDesc, jobDesc)

--- a/pkg/sql/grant_revoke.go
+++ b/pkg/sql/grant_revoke.go
@@ -98,7 +98,7 @@ func (p *planner) changePrivileges(
 			}
 
 		case *sqlbase.TableDescriptor:
-			if err := d.Validate(ctx, p.txn); err != nil {
+			if err := d.Validate(ctx, p.txn, p.EvalContext().Settings); err != nil {
 				return nil, err
 			}
 			if err := d.SetUpVersion(); err != nil {

--- a/pkg/sql/lease.go
+++ b/pkg/sql/lease.go
@@ -166,7 +166,7 @@ func (s LeaseStore) acquire(
 
 		// ValidateTable instead of Validate, even though we have a txn available,
 		// so we don't block reads waiting for this table version.
-		if err := table.ValidateTable(); err != nil {
+		if err := table.ValidateTable(s.execCfg.Settings); err != nil {
 			return err
 		}
 
@@ -351,7 +351,7 @@ func (s LeaseStore) Publish(
 			tableDesc.ModificationTime = modTime
 			log.Infof(ctx, "publish: descID=%d (%s) version=%d mtime=%s",
 				tableDesc.ID, tableDesc.Name, tableDesc.Version, modTime.GoTime())
-			if err := tableDesc.ValidateTable(); err != nil {
+			if err := tableDesc.ValidateTable(s.execCfg.Settings); err != nil {
 				return err
 			}
 
@@ -1504,7 +1504,7 @@ func (m *LeaseManager) RefreshLeases(s *stop.Stopper, db *client.DB, g *gossip.G
 					case *sqlbase.Descriptor_Table:
 						table := union.Table
 						table.MaybeFillInDescriptor()
-						if err := table.ValidateTable(); err != nil {
+						if err := table.ValidateTable(m.execCfg.Settings); err != nil {
 							log.Errorf(ctx, "%s: received invalid table descriptor: %v", kv.Key, table)
 							return
 						}

--- a/pkg/sql/rename_column.go
+++ b/pkg/sql/rename_column.go
@@ -144,7 +144,7 @@ func (p *planner) RenameColumn(ctx context.Context, n *tree.RenameColumn) (planN
 	}
 
 	descKey := sqlbase.MakeDescMetadataKey(tableDesc.GetID())
-	if err := tableDesc.Validate(ctx, p.txn); err != nil {
+	if err := tableDesc.Validate(ctx, p.txn, p.EvalContext().Settings); err != nil {
 		return nil, err
 	}
 	if err := p.txn.Put(ctx, descKey, sqlbase.WrapDescriptor(tableDesc)); err != nil {

--- a/pkg/sql/rename_index.go
+++ b/pkg/sql/rename_index.go
@@ -83,7 +83,7 @@ func (p *planner) RenameIndex(ctx context.Context, n *tree.RenameIndex) (planNod
 		return nil, err
 	}
 	descKey := sqlbase.MakeDescMetadataKey(tableDesc.GetID())
-	if err := tableDesc.Validate(ctx, p.txn); err != nil {
+	if err := tableDesc.Validate(ctx, p.txn, p.EvalContext().Settings); err != nil {
 		return nil, err
 	}
 	if err := p.txn.Put(ctx, descKey, sqlbase.WrapDescriptor(tableDesc)); err != nil {

--- a/pkg/sql/rename_table.go
+++ b/pkg/sql/rename_table.go
@@ -115,7 +115,7 @@ func (p *planner) RenameTable(ctx context.Context, n *tree.RenameTable) (planNod
 	descKey := sqlbase.MakeDescMetadataKey(tableDesc.GetID())
 	newTbKey := tableKey{targetDbDesc.ID, newTn.Table()}.Key()
 
-	if err := tableDesc.Validate(ctx, p.txn); err != nil {
+	if err := tableDesc.Validate(ctx, p.txn, p.EvalContext().Settings); err != nil {
 		return nil, err
 	}
 

--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -1064,7 +1064,7 @@ func (s *SchemaChangeManager) Start(stopper *stop.Stopper) {
 					case *sqlbase.Descriptor_Table:
 						table := union.Table
 						table.MaybeFillInDescriptor()
-						if err := table.ValidateTable(); err != nil {
+						if err := table.ValidateTable(s.execCfg.Settings); err != nil {
 							log.Errorf(ctx, "%s: received invalid table descriptor: %v: %s", kv.Key, table, err)
 							return
 						}

--- a/pkg/sql/sqlbase/structured.go
+++ b/pkg/sql/sqlbase/structured.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/optbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
@@ -597,7 +598,7 @@ func (desc *TableDescriptor) AllocateIDs() error {
 	if desc.ID == 0 {
 		desc.ID = keys.MaxReservedDescID + 1
 	}
-	err := desc.ValidateTable()
+	err := desc.ValidateTable(nil)
 	desc.ID = savedID
 	return err
 }
@@ -870,8 +871,10 @@ func (desc *TableDescriptor) allocateColumnFamilyIDs(columnNames map[string]Colu
 
 // Validate validates that the table descriptor is well formed. Checks include
 // both single table and cross table invariants.
-func (desc *TableDescriptor) Validate(ctx context.Context, txn *client.Txn) error {
-	err := desc.ValidateTable()
+func (desc *TableDescriptor) Validate(
+	ctx context.Context, txn *client.Txn, st *cluster.Settings,
+) error {
+	err := desc.ValidateTable(st)
 	if err != nil {
 		return err
 	}
@@ -1023,7 +1026,8 @@ func (desc *TableDescriptor) validateCrossReferences(ctx context.Context, txn *c
 // names and index names are unique and verifying that column IDs and index IDs
 // are consistent. Use Validate to validate that cross-table references are
 // correct.
-func (desc *TableDescriptor) ValidateTable() error {
+// If version is supplied, the descriptor is checked for version incompatibilities.
+func (desc *TableDescriptor) ValidateTable(st *cluster.Settings) error {
 	if err := validateName(desc.Name, "table"); err != nil {
 		return err
 	}
@@ -1037,6 +1041,12 @@ func (desc *TableDescriptor) ValidateTable() error {
 	}
 
 	if desc.IsSequence() {
+		if st != nil && st.Version.HasBeenInitialized() {
+			if err := st.Version.CheckVersion(cluster.Version2_0, "sequences"); err != nil {
+				return err
+			}
+		}
+
 		return nil
 	}
 
@@ -1099,6 +1109,19 @@ func (desc *TableDescriptor) ValidateTable() error {
 		if column.ID >= desc.NextColumnID {
 			return fmt.Errorf("column %q invalid ID (%d) >= next column ID (%d)",
 				column.Name, column.ID, desc.NextColumnID)
+		}
+	}
+
+	if st != nil && st.Version.HasBeenInitialized() {
+		if !st.Version.IsMinSupported(cluster.Version2_0) {
+			for _, def := range desc.Columns {
+				if def.Type.SemanticType == ColumnType_JSON {
+					return errors.New("cluster version does not support JSONB (>= 2.0 required)")
+				}
+				if def.ComputeExpr != nil {
+					return errors.New("cluster version does not support computed columns (>= 2.0 required)")
+				}
+			}
 		}
 	}
 

--- a/pkg/sql/sqlbase/structured_test.go
+++ b/pkg/sql/sqlbase/structured_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
@@ -614,7 +615,7 @@ func TestValidateTableDesc(t *testing.T) {
 			}},
 	}
 	for i, d := range testData {
-		if err := d.desc.ValidateTable(); err == nil {
+		if err := d.desc.ValidateTable(cluster.MakeTestingClusterSettings()); err == nil {
 			t.Errorf("%d: expected \"%s\", but found success: %+v", i, d.err, d.desc)
 		} else if d.err != err.Error() {
 			t.Errorf("%d: expected \"%s\", but found \"%+v\"", i, d.err, err)

--- a/pkg/sql/table_test.go
+++ b/pkg/sql/table_test.go
@@ -19,6 +19,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -273,7 +274,7 @@ func TestPrimaryKeyUnspecified(t *testing.T) {
 	}
 	desc.PrimaryIndex = sqlbase.IndexDescriptor{}
 
-	err = desc.ValidateTable()
+	err = desc.ValidateTable(cluster.MakeTestingClusterSettings())
 	if !testutils.IsError(err, sqlbase.ErrMissingPrimaryKey.Error()) {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/pkg/sqlmigrations/migrations.go
+++ b/pkg/sqlmigrations/migrations.go
@@ -900,7 +900,7 @@ func upgradeDescsWithFn(
 							// days, while upgrading to a new version can take as little as a
 							// few minutes.
 							table.UpVersion = true
-							if err := table.Validate(ctx, txn); err != nil {
+							if err := table.Validate(ctx, txn, nil); err != nil {
 								return err
 							}
 


### PR DESCRIPTION
Fixes #22843.

I couldn't find an appropriate pg error code for these so I just used
the internal error one. David says "Feature Not Supported" will report
to the reg cluster which is not ideal.

It's sufficient to test clusters which are fully upgraded to a version,
because if a cluster version is upgraded past the acceptable version for
some node in the cluster, said node will just crash.

Release note (sql change): SQL features introduced in version 2.0 cannot
be used in clusters which are not upgraded fully to 2.0.

cc @cockroachdb/release 