### PR TITLE
cherrypick-2.0: ui: Add link to settings endpoint from main debug page

### DIFF
--- a/pkg/ui/src/views/reports/containers/debug/index.tsx
+++ b/pkg/ui/src/views/reports/containers/debug/index.tsx
@@ -188,6 +188,7 @@ export default function Debug() {
           <DebugTableLink name="All Sessions" url="/_status/sessions" />
         </DebugTableRow>
         <DebugTableRow title="Cluster Wide">
+          <DebugTableLink name="Cluster Settings" url="/_admin/v1/settings" />
           <DebugTableLink name="Raft" url="/_status/raft" />
           <DebugTableLink
             name="Range"


### PR DESCRIPTION
Release note: None

Cherry-picks #23925 to release-2.0. Touches #23923.