### PR TITLE
sql: Fix deadlock in schema changes with retriable errors

### DIFF
--- a/pkg/sql/executor.go
+++ b/pkg/sql/executor.go
@@ -865,10 +865,12 @@ func (e *Executor) execParsed(
 			txnState.finishSQLTxn(session)
 		}
 
-		// If the txn is not in an "open" state any more, exec the schema changes.
-		// They'll short-circuit themselves if the mutation that queued them has
-		// been rolled back from the table descriptor.
-		if !txnState.TxnIsOpen() {
+		// If we're no longer in a transaction, exec the schema changes.
+		// They'll short-circuit themselves if the mutation that queued
+		// them has been rolled back from the table descriptor. (It's
+		// important that this condition match the one used to call
+		// finishSQLTxn above:
+		if txnState.State() == NoTxn {
 			blockOpt := blockForDBCacheUpdate
 			if err != nil {
 				blockOpt = dontBlockForDBCacheUpdate

--- a/pkg/sql/logictest/testdata/logic_test/schema_change_retry
+++ b/pkg/sql/logictest/testdata/logic_test/schema_change_retry
@@ -1,0 +1,54 @@
+# LogicTest: default parallel-stmts distsql
+
+# This test reproduces https://github.com/cockroachdb/cockroach/issues/23979
+
+# Schema changes that experienced retriable errors in RELEASE
+# SAVEPOINT would previously deadlock.
+
+statement ok
+BEGIN
+
+statement ok
+SAVEPOINT cockroach_restart
+
+statement ok
+CREATE TABLE t (x INT PRIMARY KEY, y INT);
+
+# It doesn't matter that we're creating the table and index in the
+# same transaction, but it does matter that the index creation is not
+# the first thing in the transaction (since it would trigger a
+# server-side retry if it were).
+statement ok
+CREATE INDEX y_idx ON t (y);
+
+# Trigger a retriable error by running a scan as another user (high
+# priority ensures that we don't block in this test).
+user testuser
+
+statement ok
+BEGIN TRANSACTION PRIORITY HIGH
+
+statement ok
+SHOW TABLES
+
+user root
+
+# In the original bug, we'd deadlock inside RELEASE SAVEPOINT
+query error TransactionRetryError
+RELEASE SAVEPOINT cockroach_restart
+
+# After restarting, everything's back to normal.
+statement ok
+SAVEPOINT cockroach_restart
+
+statement ok
+CREATE TABLE t (x INT PRIMARY KEY, y INT);
+
+statement ok
+CREATE INDEX y_idx ON t (y);
+
+statement ok
+RELEASE SAVEPOINT cockroach_restart
+
+statement ok
+COMMIT


### PR DESCRIPTION
Previously a transaction heartbeat loop would be kept alive while
running schema change operations on the same goroutine, leading to
deadlock.

This forward-ports #23981 from release-1.1. The main purpose of this
change is to add the test to the master branch; the executor change
itself is (nearly) dead code in this branch.

Fixes #23979