### PR TITLE
cherrypick-2.0: server: Use remote_debugging setting to restrict all access to keys

### DIFF
--- a/pkg/server/debug/server.go
+++ b/pkg/server/debug/server.go
@@ -15,8 +15,10 @@
 package debug
 
 import (
+	"context"
 	"expvar"
 	"fmt"
+	"net"
 	"net/http"
 	"net/http/pprof"
 	"strings"
@@ -24,6 +26,7 @@ import (
 	// Register the net/trace endpoint with http.DefaultServeMux.
 
 	"golang.org/x/net/trace"
+	"google.golang.org/grpc/metadata"
 
 	"github.com/pkg/errors"
 	"github.com/rcrowley/go-metrics"
@@ -35,11 +38,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 )
 
-var origTraceAuthRequest = trace.AuthRequest
-
 func init() {
-	// Disable the net/trace auth handler. We saved it (in origTraceAuthRequest)
-	// and will consult it as appropriate.
+	// Disable the net/trace auth handler.
 	trace.AuthRequest = func(r *http.Request) (allowed, sensitive bool) {
 		return true, true
 	}
@@ -60,7 +60,9 @@ const (
 // Endpoint is the entry point under which the debug tools are housed.
 const Endpoint = "/debug/"
 
-var debugRemote = settings.RegisterValidatedStringSetting(
+// DebugRemote controls which clients are allowed to access certain
+// confidential debug pages, such as those served under the /debug/ prefix.
+var DebugRemote = settings.RegisterValidatedStringSetting(
 	"server.remote_debugging.mode",
 	"set to enable remote debugging, localhost-only or disable (any, local, off)",
 	"local",
@@ -141,18 +143,55 @@ func (ds *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 // authRequest restricts access to /debug/*.
 func (ds *Server) authRequest(r *http.Request) bool {
-	allow, _ := origTraceAuthRequest(r)
+	return authRequest(r.RemoteAddr, ds.st)
+}
 
-	switch RemoteMode(strings.ToLower(debugRemote.Get(&ds.st.SV))) {
+// authRequest restricts access according to the DebugRemote setting.
+func authRequest(remoteAddr string, st *cluster.Settings) bool {
+	switch RemoteMode(strings.ToLower(DebugRemote.Get(&st.SV))) {
 	case RemoteAny:
-		allow = true
+		return true
 	case RemoteLocal:
-		// Default behavior of trace.AuthRequest.
-		break
+		return isLocalhost(remoteAddr)
 	default:
-		allow = false
+		return false
 	}
-	return allow
+}
+
+// isLocalhost returns true if the remoteAddr represents a client talking to
+// us via localhost.
+func isLocalhost(remoteAddr string) bool {
+	// RemoteAddr is commonly in the form "IP" or "IP:port".
+	// If it is in the form "IP:port", split off the port.
+	host, _, err := net.SplitHostPort(remoteAddr)
+	if err != nil {
+		host = remoteAddr
+	}
+	switch host {
+	case "localhost", "127.0.0.1", "::1":
+		return true
+	default:
+		return false
+	}
+}
+
+// GatewayRemoteAllowed returns whether a request that has been passed through
+// the grpc gateway should be allowed accessed to privileged debugging
+// information. Because this function assumes the presence of a context field
+// populated by the grpc gateway, it's not applicable for other uses.
+func GatewayRemoteAllowed(ctx context.Context, st *cluster.Settings) bool {
+	md, ok := metadata.FromIncomingContext(ctx)
+	if !ok {
+		// This should only happen for direct grpc connections, which are allowed.
+		return true
+	}
+	peerAddr, ok := md["x-forwarded-for"]
+	if !ok || len(peerAddr) == 0 {
+		// This should only happen for direct grpc connections, which are allowed.
+		return true
+	}
+
+	return authRequest(peerAddr[0], st)
 }
 
 func handleLanding(w http.ResponseWriter, r *http.Request) {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -444,6 +444,7 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 	s.admin = newAdminServer(s, &sqlExecutor)
 	s.status = newStatusServer(
 		s.cfg.AmbientCtx,
+		st,
 		s.cfg.Config,
 		s.admin,
 		s.db,

--- a/pkg/server/status.go
+++ b/pkg/server/status.go
@@ -37,6 +37,7 @@ import (
 	"github.com/pkg/errors"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
 	grpcstatus "google.golang.org/grpc/status"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
@@ -48,8 +49,10 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/rpc"
 	"github.com/cockroachdb/cockroach/pkg/security"
+	"github.com/cockroachdb/cockroach/pkg/server/debug"
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
 	"github.com/cockroachdb/cockroach/pkg/server/status"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/util/httputil"
@@ -79,20 +82,39 @@ const (
 	// maxConcurrentRequests is the maximum number of RPC fan-out requests
 	// that will be made at any point of time.
 	maxConcurrentRequests = 100
+
+	// omittedKeyStr is the string returned in place of a key when keys aren't
+	// permitted in responses.
+	omittedKeyStr = "omitted (due to the 'server.remote_debugging.mode' setting)"
 )
 
-// Pattern for local used when determining the node ID.
-var localRE = regexp.MustCompile(`(?i)local`)
+var (
+	// Pattern for local used when determining the node ID.
+	localRE = regexp.MustCompile(`(?i)local`)
+
+	// Error used to convey that remote debugging is needs to be enabled for an
+	// endpoint to be usable.
+	remoteDebuggingErr = grpcstatus.Error(
+		codes.PermissionDenied, "not allowed (due to the 'server.remote_debugging.mode' setting)")
+)
 
 type metricMarshaler interface {
 	json.Marshaler
 	PrintAsText(io.Writer) error
 }
 
+func propagateGatewayMetadata(ctx context.Context) context.Context {
+	if md, ok := metadata.FromIncomingContext(ctx); ok {
+		return metadata.NewOutgoingContext(ctx, md)
+	}
+	return ctx
+}
+
 // A statusServer provides a RESTful status API.
 type statusServer struct {
 	log.AmbientContext
 
+	st              *cluster.Settings
 	cfg             *base.Config
 	admin           *adminServer
 	db              *client.DB
@@ -108,6 +130,7 @@ type statusServer struct {
 // newStatusServer allocates and returns a statusServer.
 func newStatusServer(
 	ambient log.AmbientContext,
+	st *cluster.Settings,
 	cfg *base.Config,
 	adminServer *adminServer,
 	db *client.DB,
@@ -122,6 +145,7 @@ func newStatusServer(
 	ambient.AddLogTag("status", nil)
 	server := &statusServer{
 		AmbientContext:  ambient,
+		st:              st,
 		cfg:             cfg,
 		admin:           adminServer,
 		db:              db,
@@ -183,6 +207,11 @@ func (s *statusServer) dialNode(
 func (s *statusServer) Gossip(
 	ctx context.Context, req *serverpb.GossipRequest,
 ) (*gossip.InfoStatus, error) {
+	if !debug.GatewayRemoteAllowed(ctx, s.st) {
+		return nil, remoteDebuggingErr
+	}
+
+	ctx = propagateGatewayMetadata(ctx)
 	ctx = s.AnnotateCtx(ctx)
 	nodeID, local, err := s.parseNodeID(req.NodeId)
 	if err != nil {
@@ -204,6 +233,13 @@ func (s *statusServer) Gossip(
 func (s *statusServer) Allocator(
 	ctx context.Context, req *serverpb.AllocatorRequest,
 ) (*serverpb.AllocatorResponse, error) {
+	// TODO(a-robinson): It'd be nice to allow this endpoint and just avoid
+	// logging range start/end keys in the simulated allocator runs.
+	if !debug.GatewayRemoteAllowed(ctx, s.st) {
+		return nil, remoteDebuggingErr
+	}
+
+	ctx = propagateGatewayMetadata(ctx)
 	ctx = s.AnnotateCtx(ctx)
 	nodeID, local, err := s.parseNodeID(req.NodeId)
 	if err != nil {
@@ -305,6 +341,13 @@ func recordedSpansToAllocatorEvents(
 func (s *statusServer) AllocatorRange(
 	ctx context.Context, req *serverpb.AllocatorRangeRequest,
 ) (*serverpb.AllocatorRangeResponse, error) {
+	// TODO(a-robinson): It'd be nice to allow this endpoint and just avoid
+	// logging range start/end keys in the simulated allocator runs.
+	if !debug.GatewayRemoteAllowed(ctx, s.st) {
+		return nil, remoteDebuggingErr
+	}
+
+	ctx = propagateGatewayMetadata(ctx)
 	ctx = s.AnnotateCtx(ctx)
 	nodeCtx, cancel := context.WithTimeout(ctx, base.NetworkTimeout)
 	defer cancel()
@@ -388,6 +431,7 @@ func (s *statusServer) AllocatorRange(
 func (s *statusServer) Certificates(
 	ctx context.Context, req *serverpb.CertificatesRequest,
 ) (*serverpb.CertificatesResponse, error) {
+	ctx = propagateGatewayMetadata(ctx)
 	ctx = s.AnnotateCtx(ctx)
 	nodeID, local, err := s.parseNodeID(req.NodeId)
 	if err != nil {
@@ -497,6 +541,7 @@ func extractCertFields(contents []byte, details *serverpb.CertificateDetails) er
 func (s *statusServer) Details(
 	ctx context.Context, req *serverpb.DetailsRequest,
 ) (*serverpb.DetailsResponse, error) {
+	ctx = propagateGatewayMetadata(ctx)
 	ctx = s.AnnotateCtx(ctx)
 	nodeID, local, err := s.parseNodeID(req.NodeId)
 	if err != nil {
@@ -544,6 +589,7 @@ func (s *statusServer) Details(
 func (s *statusServer) LogFilesList(
 	ctx context.Context, req *serverpb.LogFilesListRequest,
 ) (*serverpb.LogFilesListResponse, error) {
+	ctx = propagateGatewayMetadata(ctx)
 	ctx = s.AnnotateCtx(ctx)
 	nodeID, local, err := s.parseNodeID(req.NodeId)
 	if err != nil {
@@ -568,6 +614,11 @@ func (s *statusServer) LogFilesList(
 func (s *statusServer) LogFile(
 	ctx context.Context, req *serverpb.LogFileRequest,
 ) (*serverpb.LogEntriesResponse, error) {
+	if !debug.GatewayRemoteAllowed(ctx, s.st) {
+		return nil, remoteDebuggingErr
+	}
+
+	ctx = propagateGatewayMetadata(ctx)
 	ctx = s.AnnotateCtx(ctx)
 	nodeID, local, err := s.parseNodeID(req.NodeId)
 	if err != nil {
@@ -638,6 +689,11 @@ func parseInt64WithDefault(s string, defaultValue int64) (int64, error) {
 func (s *statusServer) Logs(
 	ctx context.Context, req *serverpb.LogsRequest,
 ) (*serverpb.LogEntriesResponse, error) {
+	if !debug.GatewayRemoteAllowed(ctx, s.st) {
+		return nil, remoteDebuggingErr
+	}
+
+	ctx = propagateGatewayMetadata(ctx)
 	ctx = s.AnnotateCtx(ctx)
 	nodeID, local, err := s.parseNodeID(req.NodeId)
 	if err != nil {
@@ -699,6 +755,7 @@ func (s *statusServer) Logs(
 func (s *statusServer) Stacks(
 	ctx context.Context, req *serverpb.StacksRequest,
 ) (*serverpb.JSONResponse, error) {
+	ctx = propagateGatewayMetadata(ctx)
 	ctx = s.AnnotateCtx(ctx)
 	nodeID, local, err := s.parseNodeID(req.NodeId)
 	if err != nil {
@@ -768,6 +825,7 @@ func (s *statusServer) Profile(
 func (s *statusServer) Nodes(
 	ctx context.Context, req *serverpb.NodesRequest,
 ) (*serverpb.NodesResponse, error) {
+	ctx = propagateGatewayMetadata(ctx)
 	ctx = s.AnnotateCtx(ctx)
 	startKey := keys.StatusNodePrefix
 	endKey := startKey.PrefixEnd()
@@ -796,6 +854,7 @@ func (s *statusServer) Nodes(
 func (s *statusServer) Node(
 	ctx context.Context, req *serverpb.NodeRequest,
 ) (*status.NodeStatus, error) {
+	ctx = propagateGatewayMetadata(ctx)
 	ctx = s.AnnotateCtx(ctx)
 	nodeID, _, err := s.parseNodeID(req.NodeId)
 	if err != nil {
@@ -823,6 +882,7 @@ func (s *statusServer) Node(
 func (s *statusServer) Metrics(
 	ctx context.Context, req *serverpb.MetricsRequest,
 ) (*serverpb.JSONResponse, error) {
+	ctx = propagateGatewayMetadata(ctx)
 	ctx = s.AnnotateCtx(ctx)
 	nodeID, local, err := s.parseNodeID(req.NodeId)
 	if err != nil {
@@ -843,6 +903,7 @@ func (s *statusServer) Metrics(
 func (s *statusServer) RaftDebug(
 	ctx context.Context, req *serverpb.RaftDebugRequest,
 ) (*serverpb.RaftDebugResponse, error) {
+	ctx = propagateGatewayMetadata(ctx)
 	ctx = s.AnnotateCtx(ctx)
 	nodes, err := s.Nodes(ctx, nil)
 	if err != nil {
@@ -949,6 +1010,7 @@ func (s *statusServer) handleVars(w http.ResponseWriter, r *http.Request) {
 func (s *statusServer) Ranges(
 	ctx context.Context, req *serverpb.RangesRequest,
 ) (*serverpb.RangesResponse, error) {
+	ctx = propagateGatewayMetadata(ctx)
 	ctx = s.AnnotateCtx(ctx)
 	nodeID, local, err := s.parseNodeID(req.NodeId)
 	if err != nil {
@@ -997,19 +1059,31 @@ func (s *statusServer) Ranges(
 		return state
 	}
 
+	includeRawKeys := debug.GatewayRemoteAllowed(ctx, s.st)
+
 	constructRangeInfo := func(
 		desc roachpb.RangeDescriptor, rep *storage.Replica, storeID roachpb.StoreID, metrics storage.ReplicaMetrics,
 	) serverpb.RangeInfo {
 		raftStatus := rep.RaftStatus()
 		raftState := convertRaftStatus(raftStatus)
 		leaseHistory := rep.GetLeaseHistory()
+		var span serverpb.PrettySpan
+		if includeRawKeys {
+			span.StartKey = desc.StartKey.String()
+			span.EndKey = desc.EndKey.String()
+		} else {
+			span.StartKey = omittedKeyStr
+			span.EndKey = omittedKeyStr
+		}
+		state := rep.State()
+		if !includeRawKeys {
+			state.ReplicaState.Desc.StartKey = nil
+			state.ReplicaState.Desc.EndKey = nil
+		}
 		return serverpb.RangeInfo{
-			Span: serverpb.PrettySpan{
-				StartKey: desc.StartKey.String(),
-				EndKey:   desc.EndKey.String(),
-			},
+			Span:          span,
 			RaftState:     raftState,
-			State:         rep.State(),
+			State:         state,
 			SourceNodeID:  nodeID,
 			SourceStoreID: storeID,
 			LeaseHistory:  leaseHistory,
@@ -1096,6 +1170,7 @@ func (s *statusServer) Ranges(
 func (s *statusServer) Range(
 	ctx context.Context, req *serverpb.RangeRequest,
 ) (*serverpb.RangeResponse, error) {
+	ctx = propagateGatewayMetadata(ctx)
 	ctx = s.AnnotateCtx(ctx)
 	response := &serverpb.RangeResponse{
 		RangeID:           roachpb.RangeID(req.RangeId),
@@ -1190,6 +1265,11 @@ func (s *statusServer) CommandQueue(
 func (s *statusServer) ListLocalSessions(
 	ctx context.Context, req *serverpb.ListSessionsRequest,
 ) (*serverpb.ListSessionsResponse, error) {
+	ctx = propagateGatewayMetadata(ctx)
+	if !debug.GatewayRemoteAllowed(ctx, s.st) {
+		return nil, remoteDebuggingErr
+	}
+
 	registry := s.sessionRegistry
 
 	sessions := registry.SerializeAll()
@@ -1211,6 +1291,11 @@ func (s *statusServer) ListLocalSessions(
 func (s *statusServer) ListSessions(
 	ctx context.Context, req *serverpb.ListSessionsRequest,
 ) (*serverpb.ListSessionsResponse, error) {
+	ctx = propagateGatewayMetadata(ctx)
+	if !debug.GatewayRemoteAllowed(ctx, s.st) {
+		return nil, remoteDebuggingErr
+	}
+
 	ctx = s.AnnotateCtx(ctx)
 	nodes, err := s.Nodes(ctx, nil)
 	if err != nil {
@@ -1292,6 +1377,7 @@ func (s *statusServer) ListSessions(
 func (s *statusServer) CancelQuery(
 	ctx context.Context, req *serverpb.CancelQueryRequest,
 ) (*serverpb.CancelQueryResponse, error) {
+	ctx = propagateGatewayMetadata(ctx)
 	ctx = s.AnnotateCtx(ctx)
 	nodeID, local, err := s.parseNodeID(req.NodeId)
 
@@ -1323,6 +1409,7 @@ func (s *statusServer) CancelQuery(
 func (s *statusServer) SpanStats(
 	ctx context.Context, req *serverpb.SpanStatsRequest,
 ) (*serverpb.SpanStatsResponse, error) {
+	ctx = propagateGatewayMetadata(ctx)
 	ctx = s.AnnotateCtx(ctx)
 	nodeID, local, err := s.parseNodeID(req.NodeID)
 	if err != nil {

--- a/pkg/server/status_test.go
+++ b/pkg/server/status_test.go
@@ -21,6 +21,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -715,5 +716,117 @@ func TestRangeResponse(t *testing.T) {
 
 	if len(info.LeaseHistory) == 0 {
 		t.Error("expected at least one lease history entry")
+	}
+}
+
+func TestRemoteDebugModeSetting(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	s, db, _ := serverutils.StartServer(t, base.TestServerArgs{
+		StoreSpecs: []base.StoreSpec{
+			base.DefaultTestStoreSpec,
+			base.DefaultTestStoreSpec,
+			base.DefaultTestStoreSpec,
+		},
+	})
+	ts := s.(*TestServer)
+	defer ts.Stopper().Stop(context.TODO())
+
+	if _, err := db.Exec(`SET CLUSTER SETTING server.remote_debugging.mode = 'off'`); err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify that the remote debugging mode is respected for HTTP requests.
+	// This needs to be wrapped in SucceedsSoon because settings changes have to
+	// propagate through gossip and thus don't always take effect immediately.
+	testutils.SucceedsSoon(t, func() error {
+		for _, tc := range []struct {
+			path     string
+			response protoutil.Message
+		}{
+			{"gossip/local", &gossip.InfoStatus{}},
+			{"allocator/node/local", &serverpb.AllocatorResponse{}},
+			{"allocator/range/1", &serverpb.AllocatorResponse{}},
+			{"logs/local", &serverpb.LogEntriesResponse{}},
+			{"logfiles/local/cockroach.log", &serverpb.LogEntriesResponse{}},
+			{"local_sessions", &serverpb.ListSessionsResponse{}},
+			{"sessions", &serverpb.ListSessionsResponse{}},
+		} {
+			err := getStatusJSONProto(ts, tc.path, tc.response)
+			if !testutils.IsError(err, "403 Forbidden") {
+				return fmt.Errorf("expected '403 Forbidden' error, but %q returned %+v: %v",
+					tc.path, tc.response, err)
+			}
+		}
+		return nil
+	})
+
+	// But not for grpc requests. The fact that the above gets an error but these
+	// don't indicate that the grpc gateway is correctly adding the necessary
+	// metadata for differentiating between the two (and that we're correctly
+	// interpreting said metadata).
+	rootConfig := testutils.NewTestBaseContext(security.RootUser)
+	rpcContext := rpc.NewContext(
+		log.AmbientContext{Tracer: ts.ClusterSettings().Tracer}, rootConfig, ts.Clock(), ts.Stopper(),
+		&ts.ClusterSettings().Version)
+	url := ts.ServingAddr()
+	conn, err := rpcContext.GRPCDial(url).Connect(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	client := serverpb.NewStatusClient(conn)
+	ctx := context.Background()
+	if _, err := client.Gossip(ctx, &serverpb.GossipRequest{}); err != nil {
+		t.Error(err)
+	}
+	if _, err := client.Allocator(ctx, &serverpb.AllocatorRequest{}); err != nil {
+		t.Error(err)
+	}
+	if _, err := client.Allocator(ctx, &serverpb.AllocatorRequest{}); err != nil {
+		t.Error(err)
+	}
+	if _, err := client.AllocatorRange(ctx, &serverpb.AllocatorRangeRequest{}); err != nil {
+		t.Error(err)
+	}
+	if _, err := client.Logs(ctx, &serverpb.LogsRequest{}); err != nil {
+		t.Error(err)
+	}
+	if _, err := client.ListLocalSessions(ctx, &serverpb.ListSessionsRequest{}); err != nil {
+		t.Error(err)
+	}
+	if _, err := client.ListSessions(ctx, &serverpb.ListSessionsRequest{}); err != nil {
+		t.Error(err)
+	}
+
+	// Check that keys are properly omitted from the Ranges and RangeLog endpoints.
+	var rangesResp serverpb.RangesResponse
+	if err := getStatusJSONProto(ts, "ranges/local", &rangesResp); err != nil {
+		t.Fatal(err)
+	}
+	if len(rangesResp.Ranges) == 0 {
+		t.Errorf("didn't get any ranges")
+	}
+	for _, ri := range rangesResp.Ranges {
+		if ri.Span.StartKey != omittedKeyStr || ri.Span.EndKey != omittedKeyStr ||
+			ri.State.ReplicaState.Desc.StartKey != nil || ri.State.ReplicaState.Desc.EndKey != nil {
+			t.Errorf("unexpected key value found in RangeInfo: %+v", ri)
+		}
+	}
+
+	var rangelogResp serverpb.RangeLogResponse
+	if err := getAdminJSONProto(ts, "rangelog", &rangelogResp); err != nil {
+		t.Fatal(err)
+	}
+	if len(rangelogResp.Events) == 0 {
+		t.Errorf("didn't get any Events")
+	}
+	for _, event := range rangelogResp.Events {
+		if event.Event.Info.NewDesc.StartKey != nil || event.Event.Info.NewDesc.EndKey != nil ||
+			event.Event.Info.UpdatedDesc.StartKey != nil || event.Event.Info.UpdatedDesc.EndKey != nil {
+			t.Errorf("unexpected key value found in rangelog event: %+v", event)
+		}
+		if strings.Contains(event.PrettyInfo.NewDesc, "Min-System") ||
+			strings.Contains(event.PrettyInfo.UpdatedDesc, "Min-System") {
+			t.Errorf("unexpected key value found in rangelog event info: %+v", event.PrettyInfo)
+		}
 	}
 }


### PR DESCRIPTION
Keys can potentially contain sensitive information, so lock down or
strip any debug endpoints that contain range start/end keys in
accordance with the server.remote_debugging.mode setting and where the
request originated.

This intentionally only applies the filtering for HTTP requests: gRPC
requests should be allowed through since they're already properly
authenticated by certificates in secure clusters.

Fixes #23555

Release note (admin ui change): More debug pages are now locked down by
the server.remote_debugging.mode cluster setting.

----------

Cherrypicks #23851 to release-2.0