### PR TITLE
backport-2.0: sql: don't reuse planner in QueryRow

### DIFF
--- a/pkg/sql/internal.go
+++ b/pkg/sql/internal.go
@@ -61,7 +61,7 @@ func (ie *InternalExecutor) QueryRowInTransaction(
 		opName, txn, security.RootUser, ie.ExecCfg.LeaseManager.memMetrics, ie.ExecCfg)
 	defer cleanup()
 	ie.initSession(p)
-	return p.QueryRow(ctx, statement, qargs...)
+	return p.queryRow(ctx, statement, qargs...)
 }
 
 // QueryRowsInTransaction executes the supplied SQL statement as part of the

--- a/pkg/sql/lease.go
+++ b/pkg/sql/lease.go
@@ -405,7 +405,7 @@ func (s LeaseStore) countLeases(
 		defer cleanup()
 		const countLeases = `SELECT COUNT(version) FROM system.lease ` +
 			`WHERE "descID" = $1 AND version = $2 AND expiration > $3`
-		values, err := p.QueryRow(ctx, countLeases, descID, int(version), expiration)
+		values, err := p.queryRow(ctx, countLeases, descID, int(version), expiration)
 		if err != nil {
 			return err
 		}

--- a/pkg/sql/logictest/testdata/logic_test/pgoidtype
+++ b/pkg/sql/logictest/testdata/logic_test/pgoidtype
@@ -285,3 +285,10 @@ SELECT * FROM o WHERE a <= 4
 ----
 1
 4
+
+# Regression test for #23652.
+
+query B
+SELECT NOT (prorettype::regtype::text = 'foo') AND proretset FROM pg_proc WHERE proretset=false LIMIT 1
+----
+false

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -260,6 +260,8 @@ func newInternalPlanner(
 		txn, ts /* txnTimestamp */, ts, /* stmtTimestamp */
 		nil /* reCache */, s.statsCollector())
 
+	p.extendedEvalCtx.MemMetrics = memMetrics
+	p.extendedEvalCtx.ExecCfg = execCfg
 	p.extendedEvalCtx.Placeholders = &p.semaCtx.Placeholders
 	p.extendedEvalCtx.Tables = &s.tables
 
@@ -368,6 +370,16 @@ func (p *planner) ResolveTableName(ctx context.Context, tn *tree.TableName) erro
 
 // QueryRow implements the parser.EvalPlanner interface.
 func (p *planner) QueryRow(
+	ctx context.Context, sql string, args ...interface{},
+) (tree.Datums, error) {
+	origP := p
+	p, cleanup := newInternalPlanner("query rows", p.Txn(), p.User(), p.ExtendedEvalContext().MemMetrics, p.ExecCfg())
+	defer cleanup()
+	*p.SessionData() = *origP.SessionData()
+	return p.queryRow(ctx, sql, args...)
+}
+
+func (p *planner) queryRow(
 	ctx context.Context, sql string, args ...interface{},
 ) (tree.Datums, error) {
 	rows, _ /* cols */, err := p.queryRows(ctx, sql, args...)

--- a/pkg/sql/show_cluster_setting.go
+++ b/pkg/sql/show_cluster_setting.go
@@ -43,7 +43,7 @@ func (p *planner) showStateMachineSetting(
 	// also processed the corresponding Gossip update (which is important as only then does the node
 	// update its persisted state; see #22796).
 	if err := retry.ForDuration(10*time.Second, func() error {
-		datums, err := p.QueryRow(ctx, "SELECT value FROM system.settings WHERE name = $1", name)
+		datums, err := p.queryRow(ctx, "SELECT value FROM system.settings WHERE name = $1", name)
 		if err != nil {
 			return err
 		}

--- a/pkg/sql/show_fingerprints.go
+++ b/pkg/sql/show_fingerprints.go
@@ -153,7 +153,7 @@ func (n *showFingerprintsNode) Next(params runParams) (bool, error) {
 	  FROM [%d AS t]@{FORCE_INDEX=[%d],NO_INDEX_JOIN}
 	`, strings.Join(cols, `,`), n.tableDesc.ID, index.ID)
 
-	fingerprintCols, err := params.p.QueryRow(params.ctx, sql)
+	fingerprintCols, err := params.p.queryRow(params.ctx, sql)
 	if err != nil {
 		return false, err
 	}

--- a/pkg/sql/user.go
+++ b/pkg/sql/user.go
@@ -43,7 +43,7 @@ func GetUserHashedPassword(
 		defer cleanup()
 		const getHashedPassword = `SELECT "hashedPassword" FROM system.users ` +
 			`WHERE username=$1 AND "isRole" = false`
-		values, err := p.QueryRow(ctx, getHashedPassword, normalizedUsername)
+		values, err := p.queryRow(ctx, getHashedPassword, normalizedUsername)
 		if err != nil {
 			return errors.Errorf("error looking up user %s", normalizedUsername)
 		}


### PR DESCRIPTION
Backport 1/1 commits from #23692.

/cc @cockroachdb/release

---

Previously, EvalPlanner.QueryRow would try to reuse its input planner.
This is a horrible idea, as planners are single-use and reusing one will
break it.

Fixes #23652.

Release note: None
