### PR TITLE
sql, client: auto-retry pushed txns that can't be refreshed

### DIFF
--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -372,6 +372,29 @@ func (ex *connExecutor) execStmtInOpenState(
 		if err := res.Err(); err != nil {
 			return makeErrEvent(err)
 		}
+
+		txn := ex.state.mu.txn
+		if !os.ImplicitTxn.Get() && txn.IsSerializablePushAndRefreshNotPossible() {
+			rc, canAutoRetry := ex.getRewindTxnCapability()
+			if canAutoRetry {
+				ev := eventRetriableErr{
+					IsCommit:     fsm.FromBool(isCommit(stmt.AST)),
+					CanAutoRetry: fsm.FromBool(canAutoRetry),
+				}
+				txn.Proto().Restart(0 /* userPriority */, 0 /* upgradePriority */, ex.server.cfg.Clock.Now())
+				payload := eventRetriableErrPayload{
+					err: roachpb.NewHandledRetryableTxnError(
+						"serializable transaction timestamp pushed (detected by connExecutor)",
+						txn.ID(),
+						// No updated transaction required; we've already manually updated our
+						// client.Txn.
+						roachpb.Transaction{},
+					),
+					rewCap: rc,
+				}
+				return ev, payload, nil
+			}
+		}
 	}
 
 	// No event was generated.

--- a/pkg/sql/logictest/testdata/logic_test/alter_table
+++ b/pkg/sql/logictest/testdata/logic_test/alter_table
@@ -594,6 +594,11 @@ INSERT INTO privs VALUES (1)
 
 user testuser
 
+query T
+SHOW DATABASE
+----
+test
+
 statement error user testuser does not have CREATE privilege on relation privs
 ALTER TABLE privs ADD c INT
 

--- a/pkg/sql/logictest/testdata/logic_test/pgoidtype
+++ b/pkg/sql/logictest/testdata/logic_test/pgoidtype
@@ -221,17 +221,20 @@ user root
 statement ok
 CREATE DATABASE otherdb
 
-statement ok
-SET DATABASE = otherdb
-
 ## a non-root user can't get the OID of a table from a different database
 
 user testuser
+
+statement ok
+SET DATABASE = otherdb
 
 query error pgcode 42P01 relation "a" does not exist
 SELECT 'a'::regclass
 
 user root
+
+statement ok
+SET DATABASE = otherdb
 
 statement ok
 CREATE TABLE a (id INT PRIMARY KEY, foo STRING)

--- a/pkg/sql/logictest/testdata/logic_test/txn
+++ b/pkg/sql/logictest/testdata/logic_test/txn
@@ -494,6 +494,10 @@ snapshot
 statement ok
 COMMIT
 
+# restore default
+statement ok
+SET DEFAULT_TRANSACTION_ISOLATION TO 'SERIALIZABLE'
+
 # SHOW TRANSACTION STATUS
 
 query T
@@ -977,3 +981,7 @@ SELECT CRDB_INTERNAL.FORCE_RETRY('1s':::INTERVAL)
 
 statement ok
 ROLLBACK
+
+# restore the default
+statement ok
+SET default_transaction_read_only = false

--- a/pkg/sql/logictest/testdata/logic_test/txn_retry
+++ b/pkg/sql/logictest/testdata/logic_test/txn_retry
@@ -1,0 +1,37 @@
+# LogicTest: default
+
+# Check that we auto-retry pushed transactions which can't be refreshed - if
+# they're pushed while we can still auto-retry them.
+subtest autoretry-on-push-first-batch
+
+statement ok
+CREATE TABLE test_retry (
+  k INT PRIMARY KEY
+)
+
+statement ok
+GRANT ALL ON test_retry TO testuser
+
+# Start a txn (and fix a timestamp).
+statement ok
+BEGIN
+
+# On a different connection, do a read at a higher timestamp.
+#
+# We use dont_inherit_database, as otherwise we'd run some statements under the
+# hood that break the auto-retry that we'll need later.
+user testuser dont_inherit_database
+
+statement ok
+SELECT * FROM test.test_retry
+
+user root dont_inherit_database
+
+# Run a cluster_logical_timestamp(), so that the transaction "observes its
+# commit timestamp" and so can't be refreshed, and the do an insert that will
+# cause the txn to be pushed.
+statement ok
+SELECT cluster_logical_timestamp(); INSERT INTO test_retry VALUES (1);
+
+statement ok
+COMMIT


### PR DESCRIPTION
... if it's still possible for the SQL connExecutor to retry them (i.e.
we haven't sent results to the client for the respective txn yet).

This patch re-introduces code we used to have, but was deleted in #21140.
The motivation for deleting the code was that retriable errors were
supposed to be rarer because of the "read refreshing" mechanism, but
that mechanism doesn't apply to transactions that "observe their commit
timestamp". A txn can observe its timestamp by calling
cluster_logical_timestamp(), or in other ways. In particular, schema
change txns always observe their ts.

Fixes #22933

Release note: Retriable errors on schema change operations are less
likely to be returned to clients; more operations are retried
internally.