### PR TITLE
opt: add non-correlated subqueries to builder

### DIFF
--- a/pkg/sql/opt/memo/typing.go
+++ b/pkg/sql/opt/memo/typing.go
@@ -93,11 +93,13 @@ func init() {
 		opt.ProjectionsOp:     typeAsAny,
 		opt.AggregationsOp:    typeAsAny,
 		opt.ExistsOp:          typeAsBool,
+		opt.AnyOp:             typeAsBool,
 		opt.FunctionOp:        typeFunction,
 		opt.CoalesceOp:        typeCoalesce,
 		opt.CaseOp:            typeCase,
 		opt.WhenOp:            typeWhen,
 		opt.CastOp:            typeAsPrivate,
+		opt.SubqueryOp:        typeSubquery,
 	}
 
 	for _, op := range opt.BooleanOperators {
@@ -221,6 +223,12 @@ func typeWhen(ev ExprView) types.T {
 // which is an instance of types.T.
 func typeAsPrivate(ev ExprView) types.T {
 	return ev.Private().(types.T)
+}
+
+// typeSubquery returns the type of a subquery, which is equal to the type of
+// its second child, the Projection field.
+func typeSubquery(ev ExprView) types.T {
+	return ev.Child(1).Logical().Scalar.Type
 }
 
 // overload encapsulates information about a binary operator overload, to be

--- a/pkg/sql/opt/ops/scalar.opt
+++ b/pkg/sql/opt/ops/scalar.opt
@@ -7,10 +7,61 @@
 # Scalar - All operators in this file are marked with the Scalar tag, so they
 #          can be easily distinguished from Relational and Enforcer operators.
 
+# Subquery is a subquery in a single-row context such as
+# `SELECT 1 = (SELECT 1)` or `SELECT (1, 'a') = (SELECT 1, 'a')`.
+# In a single-row context, the outer query is only valid if the subquery
+# returns at most one row.
+#
+# Subqueries in a multi-row context such as
+# `SELECT 1 IN (SELECT c FROM t)` or `SELECT (1, 'a') IN (SELECT 1, 'a')`
+# can be transformed to a single row context using the Any operator. (Note that
+# this is different from the SQL ANY operator. See the comment above the Any
+# operator for more details.)
+#
+# We use the following transformations:
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+# `<var> IN (<subquery>)`
+#    ==> `Any(SELECT <var> = x FROM (<subquery>) AS q(x))`
+#
+# `<var> NOT IN (<subquery>)`
+#    ==> `NOT Any(SELECT <var> = x FROM (<subquery>) AS q(x))`
+#
+# `<var> <comp> {SOME|ANY}(<subquery>)`
+#    ==> `Any(SELECT <var> <comp> x FROM (<subquery>) AS q(x))`
+#
+# `<var> <comp> ALL(<subquery>)`
+#    ==> `NOT Any(SELECT NOT(<var> <comp> x) FROM (<subquery>) AS q(x))`
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+#
+# The Input field contains the subquery itself, and the Projection field
+# contains a single column representing the output of the subquery. For
+# example, `(SELECT 1, 'a')` would be represented by the following structure:
+#
+# (Subquery
+#   (Project (Values (Tuple)) (Projections (Tuple (Const 1) (Const 'a'))))
+#   (Variable 3)
+# )
+#
+# Here Variable 3 refers to the projection from the Input,
+# (Tuple (Const 1) (Const 'a')).
 [Scalar]
 define Subquery {
     Input      Expr
     Projection Expr
+}
+
+# Any is a special operator that does not exist in SQL. However, it is very
+# similar to the SQL ANY, and can be converted to the SQL ANY operator using
+# the following transformation:
+#  `Any(<subquery>)` ==> `True = ANY(<subquery>)`
+#
+# Any expects the subquery to return a single boolean column. The semantics
+# are equivalent to the SQL ANY expression above on the right: Any returns true
+# if any of the values returned by the subquery are true, else returns NULL
+# if any of the values are NULL, else returns false.
+[Scalar]
+define Any {
+    Input Expr
 }
 
 # Variable is the typed scalar value of a column in the query. The private
@@ -389,7 +440,7 @@ define Cast {
 #
 # The Case operator evaluates <Input> (if not provided, Input is set to True),
 # then picks the WHEN branch where <condval> is equal to
-# <cond>, then evaluates and returns the corresponding THEN expression. If no
+# <Input>, then evaluates and returns the corresponding THEN expression. If no
 # WHEN branch matches, the ELSE expression is evaluated and returned, if any.
 # Otherwise, NULL is returned.
 #

--- a/pkg/sql/opt/optbuilder/subquery.go
+++ b/pkg/sql/opt/optbuilder/subquery.go
@@ -1,0 +1,292 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package optbuilder
+
+import (
+	"fmt"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/opt"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
+)
+
+// subquery represents a subquery expression in an expression tree
+// after it has been type-checked and added to the memo.
+type subquery struct {
+	// cols contains the output columns of the subquery.
+	cols []columnProps
+
+	// out is the top level memo GroupID of the subquery.
+	out memo.GroupID
+
+	// Is the subquery in a multi-row or single-row context?
+	multiRow bool
+
+	// typ is the lazily resolved type of the subquery.
+	typ types.T
+
+	// Is this an EXISTS statement?
+	exists bool
+}
+
+// String is part of the tree.Expr interface.
+func (s *subquery) String() string {
+	return "subquery.String: unimplemented"
+}
+
+// Format is part of the tree.Expr interface.
+func (s *subquery) Format(ctx *tree.FmtCtx) {
+}
+
+// Walk is part of the tree.Expr interface.
+func (s *subquery) Walk(v tree.Visitor) tree.Expr {
+	return s
+}
+
+// TypeCheck is part of the tree.Expr interface.
+func (s *subquery) TypeCheck(_ *tree.SemaContext, desired types.T) (tree.TypedExpr, error) {
+	if s.typ != nil {
+		return s, nil
+	}
+
+	// The typing for subqueries is complex, but regular.
+	//
+	// * If the subquery is part of an EXISTS statement:
+	//
+	//   The type of the subquery is always "bool".
+	//
+	// * If the subquery is used in a single-row context:
+	//
+	//   - If the subquery returns a single column with type "U", the type of the
+	//     subquery is the type of the column "U". For example:
+	//
+	//       SELECT 1 = (SELECT 1)
+	//
+	//     The type of the subquery is "int".
+	//
+	//   - If the subquery returns multiple columns, the type of the subquery is
+	//     "tuple{C}" where "C" expands to all of the types of the columns of the
+	//     subquery. For example:
+	//
+	//       SELECT (1, 'a') = (SELECT 1, 'a')
+	//
+	//     The type of the subquery is "tuple{int,string}"
+	//
+	// * If the subquery is used in a multi-row context:
+	//
+	//   - If the subquery returns a single column with type "U", the type of the
+	//     subquery is the singleton tuple of type "U": "tuple{U}". For example:
+	//
+	//       SELECT 1 IN (SELECT 1)
+	//
+	//     The type of the subquery's columns is "int" and the type of the
+	//     subquery is "tuple{int}".
+	//
+	//   - If the subquery returns multiple columns, the type of the subquery is
+	//     "tuple{tuple{C}}" where "C expands to all of the types of the columns
+	//     of the subquery. For example:
+	//
+	//       SELECT (1, 'a') IN (SELECT 1, 'a')
+	//
+	//     The types of the subquery's columns are "int" and "string". These are
+	//     wrapped into "tuple{int,string}" to form the row type. And these are
+	//     wrapped again to form the subquery type "tuple{tuple{int,string}}".
+	//
+	// Note that these rules produce a somewhat surprising equivalence:
+	//
+	//   SELECT (SELECT 1, 2) = (SELECT (1, 2))
+	//
+	// A subquery which returns a single column tuple is equivalent to a subquery
+	// which returns the elements of the tuple as individual columns. While
+	// surprising, this is necessary for regularity and in order to handle:
+	//
+	//   SELECT 1 IN (SELECT 1)
+	//
+	// Without that auto-unwrapping of single-column subqueries, this query would
+	// type check as "<int> IN <tuple{tuple{int}}>" which would fail.
+
+	if s.exists {
+		s.typ = types.Bool
+		return s, nil
+	}
+
+	if len(s.cols) == 1 {
+		s.typ = s.cols[0].typ
+	} else {
+		t := make(types.TTuple, len(s.cols))
+		for i := range s.cols {
+			t[i] = s.cols[i].typ
+		}
+		s.typ = t
+	}
+
+	if s.multiRow {
+		// The subquery is in a multi-row context. For example:
+		//
+		//   SELECT 1 IN (SELECT * FROM t)
+		//
+		// Wrap the type in a tuple.
+		//
+		// TODO(peter): Using a tuple type to represent a multi-row subquery works
+		// with the current type checking code, but seems semantically incorrect. A
+		// tuple represents a fixed number of elements. Instead, we should either
+		// be using the table type (TTable) or introduce a new vtuple type.
+		s.typ = types.TTuple{s.typ}
+	}
+
+	return s, nil
+}
+
+// ResolvedType is part of the tree.TypedExpr interface.
+func (s *subquery) ResolvedType() types.T {
+	return s.typ
+}
+
+// Eval is part of the tree.TypedExpr interface.
+func (s *subquery) Eval(_ *tree.EvalContext) (tree.Datum, error) {
+	panic("subquery must be replaced before evaluation")
+}
+
+// buildSubqueryProjection ensures that a subquery returns exactly one column.
+// If the original subquery has more than one column, buildSubqueryProjection
+// wraps it in a projection which has a single tuple column containing all the
+// original columns: tuple{col1, col2...}.
+func (b *Builder) buildSubqueryProjection(
+	s *subquery, inScope *scope,
+) (out memo.GroupID, outScope *scope) {
+	out = s.out
+	outScope = inScope.replace()
+
+	switch len(s.cols) {
+	case 0:
+		panic("subquery returned 0 columns")
+
+	case 1:
+		outScope.cols = append(outScope.cols, s.cols[0])
+
+	default:
+		// Wrap the subquery in a projection with a single column.
+		// col1, col2... from the subquery becomes tuple{col1, col2...} in the
+		// projection.
+		cols := make(tree.TypedExprs, len(s.cols))
+		colGroups := make([]memo.GroupID, len(s.cols))
+		for i := range s.cols {
+			cols[i] = &s.cols[i]
+			colGroups[i] = b.factory.ConstructVariable(b.factory.InternPrivate(s.cols[i].id))
+		}
+
+		texpr := tree.NewTypedTuple(cols)
+		col := b.synthesizeColumn(outScope, "", texpr.ResolvedType(), texpr)
+		tup := b.factory.ConstructTuple(b.factory.InternList(colGroups))
+		p := b.constructList(opt.ProjectionsOp, []memo.GroupID{tup}, []columnProps{*col})
+		out = b.factory.ConstructProject(out, p)
+	}
+
+	return out, outScope
+}
+
+// buildSingleRowSubquery builds a set of memo groups that represent the given
+// subquery. This function should only be called for subqueries in a single-row
+// context, such as `SELECT (1, 'a') = (SELECT 1, 'a')`.
+//
+// See Builder.buildStmt for a description of the remaining input and
+// return values.
+func (b *Builder) buildSingleRowSubquery(
+	s *subquery, inScope *scope,
+) (out memo.GroupID, outScope *scope) {
+	if s.exists {
+		return b.factory.ConstructExists(s.out), inScope
+	}
+
+	out, outScope = b.buildSubqueryProjection(s, inScope)
+	v := b.factory.ConstructVariable(b.factory.InternPrivate(outScope.cols[0].id))
+	out = b.factory.ConstructSubquery(out, v)
+	return out, outScope
+}
+
+// buildMultiRowSubquery transforms a multi-row subquery into a single-row
+// subquery for IN, NOT IN, ANY, SOME and ALL expressions. Then it builds a set
+// of memo groups that represent the transformed expression.
+//
+// It performs the transformation using the Any operator. Any is a special
+// operator that does not exist in SQL. However, it is very similar to the
+// SQL ANY, and can be converted to the SQL ANY operator using the following
+// transformation:
+// `Any(<subquery>)` ==> `True = ANY(<subquery>)`
+//
+// The semantics are equivalent to the expression on the right: Any returns
+// true if any of the values returned by the subquery are true, else returns
+// NULL if any of the values are NULL, else returns false.
+//
+// We use the following transformations:
+// <var> IN (<subquery>)
+//   ==> Any(SELECT <var> = x FROM (<subquery>) AS q(x))
+//
+// <var> NOT IN (<subquery>)`
+//   ==> NOT Any(SELECT <var> = x FROM (<subquery>) AS q(x))
+//
+// <var> <comp> {SOME|ANY}(<subquery>)
+//   ==> Any(SELECT <var> <comp> x FROM (<subquery>) AS q(x))
+//
+// <var> <comp> ALL(<subquery>)
+//   ==> NOT Any(SELECT NOT(<var> <comp> x) FROM (<subquery>) AS q(x))
+//
+func (b *Builder) buildMultiRowSubquery(
+	c *tree.ComparisonExpr, inScope *scope,
+) (out memo.GroupID, outScope *scope) {
+	out, outScope = b.buildSubqueryProjection(c.Right.(*subquery), inScope)
+
+	leftExpr := c.TypedLeft()
+	rightExpr := &outScope.cols[0]
+	outScope = outScope.replace()
+
+	var texpr tree.TypedExpr
+	switch c.Operator {
+	case tree.In, tree.NotIn:
+		// <var> = x
+		texpr = tree.NewTypedComparisonExpr(tree.EQ, leftExpr, rightExpr)
+
+	case tree.Any, tree.Some, tree.All:
+		// <var> <comp> x
+		texpr = tree.NewTypedComparisonExpr(c.SubOperator, leftExpr, rightExpr)
+		if c.Operator == tree.All {
+			// NOT(<var> <comp> x)
+			texpr = tree.NewTypedNotExpr(texpr)
+		}
+
+	default:
+		panic(fmt.Errorf("transformSubquery called with operator %v", c.Operator))
+	}
+
+	// Construct the inner boolean projection.
+	comp := b.buildScalar(texpr, outScope)
+	col := b.synthesizeColumn(outScope, "", texpr.ResolvedType(), texpr)
+	p := b.constructList(opt.ProjectionsOp, []memo.GroupID{comp}, []columnProps{*col})
+	out = b.factory.ConstructProject(out, p)
+
+	// Construct the outer Any(...) operator.
+	out = b.factory.ConstructAny(out)
+	switch c.Operator {
+	case tree.NotIn, tree.All:
+		// NOT Any(...)
+		out = b.factory.ConstructNot(out)
+	}
+
+	return out, outScope
+}
+
+var _ tree.Expr = &subquery{}
+var _ tree.TypedExpr = &subquery{}

--- a/pkg/sql/opt/optbuilder/testdata/join
+++ b/pkg/sql/opt/optbuilder/testdata/join
@@ -1,11 +1,5 @@
-# LogicTest: default parallel-stmts distsql distsql-disk
+# tests adapted from logictest -- join
 
-# The join condition logic is tricky to get right with NULL
-# values. Simple implementations can deal well with NULLs on the first
-# or last row but fail to handle them in the middle. So the test table
-# must contain at least 3 rows with a null in the middle. This test
-# table also contains the pair 44/42 so that a test with a non-trivial
-# ON condition can be written.
 exec-ddl
 CREATE TABLE onecolumn (x INT)
 ----
@@ -3328,38 +3322,39 @@ project
  └── projections
       └── variable: k [type=int]
 
-# TODO(rytaft): This test case will fail until we implement subquery
-# replacement.
-# build
-# select * from (select 1 as k), (select 2 as k) where 1 in (select k from kv)
-# ----
-# select
-#  ├── columns: k:int:null:1 k:int:null:2
-#  ├── inner-join
-#  │    ├── columns: k:int:null:1 k:int:null:2
-#  │    ├── project
-#  │    │    ├── columns: k:int:null:1
-#  │    │    ├── values
-#  │    │    │    └── tuple [type=tuple{}]
-#  │    │    └── projections
-#  │    │         └── const: 1 [type=int]
-#  │    ├── project
-#  │    │    ├── columns: k:int:null:2
-#  │    │    ├── values
-#  │    │    │    └── tuple [type=tuple{}]
-#  │    │    └── projections
-#  │    │         └── const: 2 [type=int]
-#  │    └── true [type=bool]
-#  └── in [type=bool]
-#       ├── const: 1 [type=int]
-#       └── subquery [type=unknown]
-#            ├── project
-#            │    ├── columns: kv.k:int:3
-#            │    ├── scan
-#            │    │    └── columns: kv.k:int:3 kv.v:int:null:4 kv.w:int:null:5 kv.s:string:null:6
-#            │    └── projections
-#            │         └── variable: kv.k [type=int]
-#            └── variable: kv.k [type=int]
+build
+select * from (select 1 as k), (select 2 as k) where 1 in (select k from kv)
+----
+select
+ ├── columns: k:1(int) k:2(int)
+ ├── inner-join
+ │    ├── columns: k:1(int) k:2(int)
+ │    ├── project
+ │    │    ├── columns: k:1(int)
+ │    │    ├── values
+ │    │    │    └── tuple [type=tuple{}]
+ │    │    └── projections
+ │    │         └── const: 1 [type=int]
+ │    ├── project
+ │    │    ├── columns: k:2(int)
+ │    │    ├── values
+ │    │    │    └── tuple [type=tuple{}]
+ │    │    └── projections
+ │    │         └── const: 2 [type=int]
+ │    └── true [type=bool]
+ └── any [type=bool]
+      └── project
+           ├── columns: column7:7(bool)
+           ├── project
+           │    ├── columns: kv.k:3(int!null)
+           │    ├── scan kv
+           │    │    └── columns: kv.k:3(int!null) kv.v:4(int) kv.w:5(int) kv.s:6(string)
+           │    └── projections
+           │         └── variable: kv.k [type=int]
+           └── projections
+                └── eq [type=bool]
+                     ├── const: 1 [type=int]
+                     └── variable: kv.k [type=int]
 
 # Test natural outer join when the left side has unknown type
 build

--- a/pkg/sql/opt/optbuilder/testdata/subquery
+++ b/pkg/sql/opt/optbuilder/testdata/subquery
@@ -1,0 +1,1438 @@
+# tests adapted from logictest -- subquery
+
+# Tests for subqueries (SELECT statements which are part of a bigger statement).
+
+build
+SELECT (SELECT 1)
+----
+project
+ ├── columns: column2:2(int)
+ ├── values
+ │    └── tuple [type=tuple{}]
+ └── projections
+      └── subquery [type=int]
+           ├── project
+           │    ├── columns: column1:1(int)
+           │    ├── values
+           │    │    └── tuple [type=tuple{}]
+           │    └── projections
+           │         └── const: 1 [type=int]
+           └── variable: column1 [type=int]
+
+build
+SELECT 1 IN (SELECT 1)
+----
+project
+ ├── columns: column3:3(bool)
+ ├── values
+ │    └── tuple [type=tuple{}]
+ └── projections
+      └── any [type=bool]
+           └── project
+                ├── columns: column2:2(bool)
+                ├── project
+                │    ├── columns: column1:1(int)
+                │    ├── values
+                │    │    └── tuple [type=tuple{}]
+                │    └── projections
+                │         └── const: 1 [type=int]
+                └── projections
+                     └── eq [type=bool]
+                          ├── const: 1 [type=int]
+                          └── variable: column1 [type=int]
+
+build
+SELECT 1 IN ((((SELECT 1))))
+----
+project
+ ├── columns: column3:3(bool)
+ ├── values
+ │    └── tuple [type=tuple{}]
+ └── projections
+      └── any [type=bool]
+           └── project
+                ├── columns: column2:2(bool)
+                ├── project
+                │    ├── columns: column1:1(int)
+                │    ├── values
+                │    │    └── tuple [type=tuple{}]
+                │    └── projections
+                │         └── const: 1 [type=int]
+                └── projections
+                     └── eq [type=bool]
+                          ├── const: 1 [type=int]
+                          └── variable: column1 [type=int]
+
+build
+SELECT ARRAY(((((VALUES (1), (2))))))[2]
+----
+error: not yet implemented: scalar expr: *tree.IndirectionExpr
+
+build
+SELECT 1 + (SELECT 1)
+----
+project
+ ├── columns: column2:2(int)
+ ├── values
+ │    └── tuple [type=tuple{}]
+ └── projections
+      └── plus [type=int]
+           ├── const: 1 [type=int]
+           └── subquery [type=int]
+                ├── project
+                │    ├── columns: column1:1(int)
+                │    ├── values
+                │    │    └── tuple [type=tuple{}]
+                │    └── projections
+                │         └── const: 1 [type=int]
+                └── variable: column1 [type=int]
+
+build
+SELECT 1 + (SELECT 1, 2)
+----
+error: unsupported binary operator: <int> + <tuple{int, int}>
+
+build
+SELECT (1, 2, 3) IN (SELECT 1, 2, 3)
+----
+project
+ ├── columns: column6:6(bool)
+ ├── values
+ │    └── tuple [type=tuple{}]
+ └── projections
+      └── any [type=bool]
+           └── project
+                ├── columns: column5:5(bool)
+                ├── project
+                │    ├── columns: column4:4(tuple{int, int, int})
+                │    ├── project
+                │    │    ├── columns: column1:1(int) column2:2(int) column3:3(int)
+                │    │    ├── values
+                │    │    │    └── tuple [type=tuple{}]
+                │    │    └── projections
+                │    │         ├── const: 1 [type=int]
+                │    │         ├── const: 2 [type=int]
+                │    │         └── const: 3 [type=int]
+                │    └── projections
+                │         └── tuple [type=tuple{int, int, int}]
+                │              ├── variable: column1 [type=int]
+                │              ├── variable: column2 [type=int]
+                │              └── variable: column3 [type=int]
+                └── projections
+                     └── eq [type=bool]
+                          ├── tuple [type=tuple{int, int, int}]
+                          │    ├── const: 1 [type=int]
+                          │    ├── const: 2 [type=int]
+                          │    └── const: 3 [type=int]
+                          └── variable: column4 [type=tuple{int, int, int}]
+
+build
+SELECT (1, 2, 3) = (SELECT 1, 2, 3)
+----
+project
+ ├── columns: column5:5(bool)
+ ├── values
+ │    └── tuple [type=tuple{}]
+ └── projections
+      └── eq [type=bool]
+           ├── tuple [type=tuple{int, int, int}]
+           │    ├── const: 1 [type=int]
+           │    ├── const: 2 [type=int]
+           │    └── const: 3 [type=int]
+           └── subquery [type=tuple{int, int, int}]
+                ├── project
+                │    ├── columns: column4:4(tuple{int, int, int})
+                │    ├── project
+                │    │    ├── columns: column1:1(int) column2:2(int) column3:3(int)
+                │    │    ├── values
+                │    │    │    └── tuple [type=tuple{}]
+                │    │    └── projections
+                │    │         ├── const: 1 [type=int]
+                │    │         ├── const: 2 [type=int]
+                │    │         └── const: 3 [type=int]
+                │    └── projections
+                │         └── tuple [type=tuple{int, int, int}]
+                │              ├── variable: column1 [type=int]
+                │              ├── variable: column2 [type=int]
+                │              └── variable: column3 [type=int]
+                └── variable: column4 [type=tuple{int, int, int}]
+
+build
+SELECT (1, 2, 3) != (SELECT 1, 2, 3)
+----
+project
+ ├── columns: column5:5(bool)
+ ├── values
+ │    └── tuple [type=tuple{}]
+ └── projections
+      └── ne [type=bool]
+           ├── tuple [type=tuple{int, int, int}]
+           │    ├── const: 1 [type=int]
+           │    ├── const: 2 [type=int]
+           │    └── const: 3 [type=int]
+           └── subquery [type=tuple{int, int, int}]
+                ├── project
+                │    ├── columns: column4:4(tuple{int, int, int})
+                │    ├── project
+                │    │    ├── columns: column1:1(int) column2:2(int) column3:3(int)
+                │    │    ├── values
+                │    │    │    └── tuple [type=tuple{}]
+                │    │    └── projections
+                │    │         ├── const: 1 [type=int]
+                │    │         ├── const: 2 [type=int]
+                │    │         └── const: 3 [type=int]
+                │    └── projections
+                │         └── tuple [type=tuple{int, int, int}]
+                │              ├── variable: column1 [type=int]
+                │              ├── variable: column2 [type=int]
+                │              └── variable: column3 [type=int]
+                └── variable: column4 [type=tuple{int, int, int}]
+
+build
+SELECT (SELECT 1, 2, 3) = (SELECT 1, 2, 3)
+----
+project
+ ├── columns: column9:9(bool)
+ ├── values
+ │    └── tuple [type=tuple{}]
+ └── projections
+      └── eq [type=bool]
+           ├── subquery [type=tuple{int, int, int}]
+           │    ├── project
+           │    │    ├── columns: column7:7(tuple{int, int, int})
+           │    │    ├── project
+           │    │    │    ├── columns: column1:1(int) column2:2(int) column3:3(int)
+           │    │    │    ├── values
+           │    │    │    │    └── tuple [type=tuple{}]
+           │    │    │    └── projections
+           │    │    │         ├── const: 1 [type=int]
+           │    │    │         ├── const: 2 [type=int]
+           │    │    │         └── const: 3 [type=int]
+           │    │    └── projections
+           │    │         └── tuple [type=tuple{int, int, int}]
+           │    │              ├── variable: column1 [type=int]
+           │    │              ├── variable: column2 [type=int]
+           │    │              └── variable: column3 [type=int]
+           │    └── variable: column7 [type=tuple{int, int, int}]
+           └── subquery [type=tuple{int, int, int}]
+                ├── project
+                │    ├── columns: column8:8(tuple{int, int, int})
+                │    ├── project
+                │    │    ├── columns: column4:4(int) column5:5(int) column6:6(int)
+                │    │    ├── values
+                │    │    │    └── tuple [type=tuple{}]
+                │    │    └── projections
+                │    │         ├── const: 1 [type=int]
+                │    │         ├── const: 2 [type=int]
+                │    │         └── const: 3 [type=int]
+                │    └── projections
+                │         └── tuple [type=tuple{int, int, int}]
+                │              ├── variable: column4 [type=int]
+                │              ├── variable: column5 [type=int]
+                │              └── variable: column6 [type=int]
+                └── variable: column8 [type=tuple{int, int, int}]
+
+build
+SELECT (SELECT 1) IN (SELECT 1)
+----
+project
+ ├── columns: column4:4(bool)
+ ├── values
+ │    └── tuple [type=tuple{}]
+ └── projections
+      └── any [type=bool]
+           └── project
+                ├── columns: column3:3(bool)
+                ├── project
+                │    ├── columns: column1:1(int)
+                │    ├── values
+                │    │    └── tuple [type=tuple{}]
+                │    └── projections
+                │         └── const: 1 [type=int]
+                └── projections
+                     └── eq [type=bool]
+                          ├── subquery [type=int]
+                          │    ├── project
+                          │    │    ├── columns: column2:2(int)
+                          │    │    ├── values
+                          │    │    │    └── tuple [type=tuple{}]
+                          │    │    └── projections
+                          │    │         └── const: 1 [type=int]
+                          │    └── variable: column2 [type=int]
+                          └── variable: column1 [type=int]
+
+build
+SELECT (SELECT 1) IN (1)
+----
+project
+ ├── columns: column2:2(bool)
+ ├── values
+ │    └── tuple [type=tuple{}]
+ └── projections
+      └── in [type=bool]
+           ├── subquery [type=int]
+           │    ├── project
+           │    │    ├── columns: column1:1(int)
+           │    │    ├── values
+           │    │    │    └── tuple [type=tuple{}]
+           │    │    └── projections
+           │    │         └── const: 1 [type=int]
+           │    └── variable: column1 [type=int]
+           └── tuple [type=tuple{int}]
+                └── const: 1 [type=int]
+
+# NB: Cockroach has different behavior from Postgres on a few esoteric
+# subqueries. The Cockroach behavior seems more sensical and
+# supporting the specific Postgres behavior appears onerous. Fingers
+# crossed this doesn't bite us down the road.
+
+# Postgres cannot handle this query (but MySQL can), even though it
+# seems sensical:
+#   ERROR:  subquery must return only one column
+#   LINE 1: select (select 1, 2) IN (select 1, 2);
+#                  ^
+build
+SELECT (SELECT 1, 2) IN (SELECT 1, 2)
+----
+project
+ ├── columns: column8:8(bool)
+ ├── values
+ │    └── tuple [type=tuple{}]
+ └── projections
+      └── any [type=bool]
+           └── project
+                ├── columns: column7:7(bool)
+                ├── project
+                │    ├── columns: column5:5(tuple{int, int})
+                │    ├── project
+                │    │    ├── columns: column1:1(int) column2:2(int)
+                │    │    ├── values
+                │    │    │    └── tuple [type=tuple{}]
+                │    │    └── projections
+                │    │         ├── const: 1 [type=int]
+                │    │         └── const: 2 [type=int]
+                │    └── projections
+                │         └── tuple [type=tuple{int, int}]
+                │              ├── variable: column1 [type=int]
+                │              └── variable: column2 [type=int]
+                └── projections
+                     └── eq [type=bool]
+                          ├── subquery [type=tuple{int, int}]
+                          │    ├── project
+                          │    │    ├── columns: column6:6(tuple{int, int})
+                          │    │    ├── project
+                          │    │    │    ├── columns: column3:3(int) column4:4(int)
+                          │    │    │    ├── values
+                          │    │    │    │    └── tuple [type=tuple{}]
+                          │    │    │    └── projections
+                          │    │    │         ├── const: 1 [type=int]
+                          │    │    │         └── const: 2 [type=int]
+                          │    │    └── projections
+                          │    │         └── tuple [type=tuple{int, int}]
+                          │    │              ├── variable: column3 [type=int]
+                          │    │              └── variable: column4 [type=int]
+                          │    └── variable: column6 [type=tuple{int, int}]
+                          └── variable: column5 [type=tuple{int, int}]
+
+# Postgres cannot handle this query, even though it seems sensical:
+#   ERROR:  subquery must return only one column
+#   LINE 1: select (select 1, 2) IN ((1, 2));
+#                  ^
+build
+SELECT (SELECT 1, 2) IN ((1, 2))
+----
+project
+ ├── columns: column4:4(bool)
+ ├── values
+ │    └── tuple [type=tuple{}]
+ └── projections
+      └── in [type=bool]
+           ├── subquery [type=tuple{int, int}]
+           │    ├── project
+           │    │    ├── columns: column3:3(tuple{int, int})
+           │    │    ├── project
+           │    │    │    ├── columns: column1:1(int) column2:2(int)
+           │    │    │    ├── values
+           │    │    │    │    └── tuple [type=tuple{}]
+           │    │    │    └── projections
+           │    │    │         ├── const: 1 [type=int]
+           │    │    │         └── const: 2 [type=int]
+           │    │    └── projections
+           │    │         └── tuple [type=tuple{int, int}]
+           │    │              ├── variable: column1 [type=int]
+           │    │              └── variable: column2 [type=int]
+           │    └── variable: column3 [type=tuple{int, int}]
+           └── tuple [type=tuple{tuple{int, int}}]
+                └── tuple [type=tuple{int, int}]
+                     ├── const: 1 [type=int]
+                     └── const: 2 [type=int]
+
+# Postgres cannot handle this query, even though it seems sensical:
+#   ERROR:  subquery has too many columns
+#   LINE 1: select (select (1, 2)) IN (select 1, 2);
+#                                  ^
+build
+SELECT (SELECT (1, 2)) IN (SELECT 1, 2)
+----
+project
+ ├── columns: column6:6(bool)
+ ├── values
+ │    └── tuple [type=tuple{}]
+ └── projections
+      └── any [type=bool]
+           └── project
+                ├── columns: column5:5(bool)
+                ├── project
+                │    ├── columns: column4:4(tuple{int, int})
+                │    ├── project
+                │    │    ├── columns: column1:1(int) column2:2(int)
+                │    │    ├── values
+                │    │    │    └── tuple [type=tuple{}]
+                │    │    └── projections
+                │    │         ├── const: 1 [type=int]
+                │    │         └── const: 2 [type=int]
+                │    └── projections
+                │         └── tuple [type=tuple{int, int}]
+                │              ├── variable: column1 [type=int]
+                │              └── variable: column2 [type=int]
+                └── projections
+                     └── eq [type=bool]
+                          ├── subquery [type=tuple{int, int}]
+                          │    ├── project
+                          │    │    ├── columns: column3:3(tuple{int, int})
+                          │    │    ├── values
+                          │    │    │    └── tuple [type=tuple{}]
+                          │    │    └── projections
+                          │    │         └── tuple [type=tuple{int, int}]
+                          │    │              ├── const: 1 [type=int]
+                          │    │              └── const: 2 [type=int]
+                          │    └── variable: column3 [type=tuple{int, int}]
+                          └── variable: column4 [type=tuple{int, int}]
+
+build
+SELECT (SELECT (1, 2)) IN ((1, 2))
+----
+project
+ ├── columns: column2:2(bool)
+ ├── values
+ │    └── tuple [type=tuple{}]
+ └── projections
+      └── in [type=bool]
+           ├── subquery [type=tuple{int, int}]
+           │    ├── project
+           │    │    ├── columns: column1:1(tuple{int, int})
+           │    │    ├── values
+           │    │    │    └── tuple [type=tuple{}]
+           │    │    └── projections
+           │    │         └── tuple [type=tuple{int, int}]
+           │    │              ├── const: 1 [type=int]
+           │    │              └── const: 2 [type=int]
+           │    └── variable: column1 [type=tuple{int, int}]
+           └── tuple [type=tuple{tuple{int, int}}]
+                └── tuple [type=tuple{int, int}]
+                     ├── const: 1 [type=int]
+                     └── const: 2 [type=int]
+
+# Postgres cannot handle this query, even though it seems sensical:
+#   ERROR:  subquery must return only one column
+#   LINE 1: select (select 1, 2) in (select (1, 2));
+#                  ^
+build
+SELECT (SELECT 1, 2) IN (SELECT (1, 2))
+----
+project
+ ├── columns: column6:6(bool)
+ ├── values
+ │    └── tuple [type=tuple{}]
+ └── projections
+      └── any [type=bool]
+           └── project
+                ├── columns: column5:5(bool)
+                ├── project
+                │    ├── columns: column1:1(tuple{int, int})
+                │    ├── values
+                │    │    └── tuple [type=tuple{}]
+                │    └── projections
+                │         └── tuple [type=tuple{int, int}]
+                │              ├── const: 1 [type=int]
+                │              └── const: 2 [type=int]
+                └── projections
+                     └── eq [type=bool]
+                          ├── subquery [type=tuple{int, int}]
+                          │    ├── project
+                          │    │    ├── columns: column4:4(tuple{int, int})
+                          │    │    ├── project
+                          │    │    │    ├── columns: column2:2(int) column3:3(int)
+                          │    │    │    ├── values
+                          │    │    │    │    └── tuple [type=tuple{}]
+                          │    │    │    └── projections
+                          │    │    │         ├── const: 1 [type=int]
+                          │    │    │         └── const: 2 [type=int]
+                          │    │    └── projections
+                          │    │         └── tuple [type=tuple{int, int}]
+                          │    │              ├── variable: column2 [type=int]
+                          │    │              └── variable: column3 [type=int]
+                          │    └── variable: column4 [type=tuple{int, int}]
+                          └── variable: column1 [type=tuple{int, int}]
+
+build
+SELECT (SELECT (1, 2)) IN (SELECT (1, 2))
+----
+project
+ ├── columns: column4:4(bool)
+ ├── values
+ │    └── tuple [type=tuple{}]
+ └── projections
+      └── any [type=bool]
+           └── project
+                ├── columns: column3:3(bool)
+                ├── project
+                │    ├── columns: column1:1(tuple{int, int})
+                │    ├── values
+                │    │    └── tuple [type=tuple{}]
+                │    └── projections
+                │         └── tuple [type=tuple{int, int}]
+                │              ├── const: 1 [type=int]
+                │              └── const: 2 [type=int]
+                └── projections
+                     └── eq [type=bool]
+                          ├── subquery [type=tuple{int, int}]
+                          │    ├── project
+                          │    │    ├── columns: column2:2(tuple{int, int})
+                          │    │    ├── values
+                          │    │    │    └── tuple [type=tuple{}]
+                          │    │    └── projections
+                          │    │         └── tuple [type=tuple{int, int}]
+                          │    │              ├── const: 1 [type=int]
+                          │    │              └── const: 2 [type=int]
+                          │    └── variable: column2 [type=tuple{int, int}]
+                          └── variable: column1 [type=tuple{int, int}]
+
+build
+SELECT 1 = ANY(SELECT 1)
+----
+project
+ ├── columns: column3:3(bool)
+ ├── values
+ │    └── tuple [type=tuple{}]
+ └── projections
+      └── any [type=bool]
+           └── project
+                ├── columns: column2:2(bool)
+                ├── project
+                │    ├── columns: column1:1(int)
+                │    ├── values
+                │    │    └── tuple [type=tuple{}]
+                │    └── projections
+                │         └── const: 1 [type=int]
+                └── projections
+                     └── eq [type=bool]
+                          ├── const: 1 [type=int]
+                          └── variable: column1 [type=int]
+
+build
+SELECT (1, 2) = ANY(SELECT 1, 2)
+----
+project
+ ├── columns: column5:5(bool)
+ ├── values
+ │    └── tuple [type=tuple{}]
+ └── projections
+      └── any [type=bool]
+           └── project
+                ├── columns: column4:4(bool)
+                ├── project
+                │    ├── columns: column3:3(tuple{int, int})
+                │    ├── project
+                │    │    ├── columns: column1:1(int) column2:2(int)
+                │    │    ├── values
+                │    │    │    └── tuple [type=tuple{}]
+                │    │    └── projections
+                │    │         ├── const: 1 [type=int]
+                │    │         └── const: 2 [type=int]
+                │    └── projections
+                │         └── tuple [type=tuple{int, int}]
+                │              ├── variable: column1 [type=int]
+                │              └── variable: column2 [type=int]
+                └── projections
+                     └── eq [type=bool]
+                          ├── tuple [type=tuple{int, int}]
+                          │    ├── const: 1 [type=int]
+                          │    └── const: 2 [type=int]
+                          └── variable: column3 [type=tuple{int, int}]
+
+build
+SELECT 1 = SOME(SELECT 1)
+----
+project
+ ├── columns: column3:3(bool)
+ ├── values
+ │    └── tuple [type=tuple{}]
+ └── projections
+      └── any [type=bool]
+           └── project
+                ├── columns: column2:2(bool)
+                ├── project
+                │    ├── columns: column1:1(int)
+                │    ├── values
+                │    │    └── tuple [type=tuple{}]
+                │    └── projections
+                │         └── const: 1 [type=int]
+                └── projections
+                     └── eq [type=bool]
+                          ├── const: 1 [type=int]
+                          └── variable: column1 [type=int]
+
+build
+SELECT (1, 2) = SOME(SELECT 1, 2)
+----
+project
+ ├── columns: column5:5(bool)
+ ├── values
+ │    └── tuple [type=tuple{}]
+ └── projections
+      └── any [type=bool]
+           └── project
+                ├── columns: column4:4(bool)
+                ├── project
+                │    ├── columns: column3:3(tuple{int, int})
+                │    ├── project
+                │    │    ├── columns: column1:1(int) column2:2(int)
+                │    │    ├── values
+                │    │    │    └── tuple [type=tuple{}]
+                │    │    └── projections
+                │    │         ├── const: 1 [type=int]
+                │    │         └── const: 2 [type=int]
+                │    └── projections
+                │         └── tuple [type=tuple{int, int}]
+                │              ├── variable: column1 [type=int]
+                │              └── variable: column2 [type=int]
+                └── projections
+                     └── eq [type=bool]
+                          ├── tuple [type=tuple{int, int}]
+                          │    ├── const: 1 [type=int]
+                          │    └── const: 2 [type=int]
+                          └── variable: column3 [type=tuple{int, int}]
+
+build
+SELECT 1 = ALL(SELECT 1)
+----
+project
+ ├── columns: column3:3(bool)
+ ├── values
+ │    └── tuple [type=tuple{}]
+ └── projections
+      └── not [type=bool]
+           └── any [type=bool]
+                └── project
+                     ├── columns: column2:2(bool)
+                     ├── project
+                     │    ├── columns: column1:1(int)
+                     │    ├── values
+                     │    │    └── tuple [type=tuple{}]
+                     │    └── projections
+                     │         └── const: 1 [type=int]
+                     └── projections
+                          └── not [type=bool]
+                               └── eq [type=bool]
+                                    ├── const: 1 [type=int]
+                                    └── variable: column1 [type=int]
+
+build
+SELECT (1, 2) = ALL(SELECT 1, 2)
+----
+project
+ ├── columns: column5:5(bool)
+ ├── values
+ │    └── tuple [type=tuple{}]
+ └── projections
+      └── not [type=bool]
+           └── any [type=bool]
+                └── project
+                     ├── columns: column4:4(bool)
+                     ├── project
+                     │    ├── columns: column3:3(tuple{int, int})
+                     │    ├── project
+                     │    │    ├── columns: column1:1(int) column2:2(int)
+                     │    │    ├── values
+                     │    │    │    └── tuple [type=tuple{}]
+                     │    │    └── projections
+                     │    │         ├── const: 1 [type=int]
+                     │    │         └── const: 2 [type=int]
+                     │    └── projections
+                     │         └── tuple [type=tuple{int, int}]
+                     │              ├── variable: column1 [type=int]
+                     │              └── variable: column2 [type=int]
+                     └── projections
+                          └── not [type=bool]
+                               └── eq [type=bool]
+                                    ├── tuple [type=tuple{int, int}]
+                                    │    ├── const: 1 [type=int]
+                                    │    └── const: 2 [type=int]
+                                    └── variable: column3 [type=tuple{int, int}]
+
+build
+SELECT (SELECT 1, 2)
+----
+error: subquery must return only one column, found 2
+
+build
+SELECT 1 IN (SELECT 1, 2)
+----
+error: unsupported comparison operator: <int> IN <tuple{tuple{int, int}}>
+
+build
+SELECT (1, 2) IN (SELECT 1)
+----
+error: unsupported comparison operator: <tuple{int, int}> IN <tuple{int}>
+
+exec-ddl
+CREATE TABLE abc (a INT PRIMARY KEY, b INT, c INT)
+----
+TABLE abc
+ ├── a int not null
+ ├── b int
+ ├── c int
+ └── INDEX primary
+      └── a int not null
+
+build
+SELECT (1, 2) IN (SELECT * FROM abc)
+----
+error: unsupported comparison operator: <tuple{int, int}> IN <tuple{tuple{int, int, int}}>
+
+build
+SELECT (1, 2) IN (SELECT a, b FROM abc)
+----
+project
+ ├── columns: column6:6(bool)
+ ├── values
+ │    └── tuple [type=tuple{}]
+ └── projections
+      └── any [type=bool]
+           └── project
+                ├── columns: column5:5(bool)
+                ├── project
+                │    ├── columns: column4:4(tuple{int, int})
+                │    ├── project
+                │    │    ├── columns: abc.a:1(int!null) abc.b:2(int)
+                │    │    ├── scan abc
+                │    │    │    └── columns: abc.a:1(int!null) abc.b:2(int) abc.c:3(int)
+                │    │    └── projections
+                │    │         ├── variable: abc.a [type=int]
+                │    │         └── variable: abc.b [type=int]
+                │    └── projections
+                │         └── tuple [type=tuple{int, int}]
+                │              ├── variable: abc.a [type=int]
+                │              └── variable: abc.b [type=int]
+                └── projections
+                     └── eq [type=bool]
+                          ├── tuple [type=tuple{int, int}]
+                          │    ├── const: 1 [type=int]
+                          │    └── const: 2 [type=int]
+                          └── variable: column4 [type=tuple{int, int}]
+
+build
+SELECT (1, 2) IN (SELECT a, b FROM abc WHERE false)
+----
+project
+ ├── columns: column6:6(bool)
+ ├── values
+ │    └── tuple [type=tuple{}]
+ └── projections
+      └── any [type=bool]
+           └── project
+                ├── columns: column5:5(bool)
+                ├── project
+                │    ├── columns: column4:4(tuple{int, int})
+                │    ├── project
+                │    │    ├── columns: abc.a:1(int!null) abc.b:2(int)
+                │    │    ├── select
+                │    │    │    ├── columns: abc.a:1(int!null) abc.b:2(int) abc.c:3(int)
+                │    │    │    ├── scan abc
+                │    │    │    │    └── columns: abc.a:1(int!null) abc.b:2(int) abc.c:3(int)
+                │    │    │    └── false [type=bool]
+                │    │    └── projections
+                │    │         ├── variable: abc.a [type=int]
+                │    │         └── variable: abc.b [type=int]
+                │    └── projections
+                │         └── tuple [type=tuple{int, int}]
+                │              ├── variable: abc.a [type=int]
+                │              └── variable: abc.b [type=int]
+                └── projections
+                     └── eq [type=bool]
+                          ├── tuple [type=tuple{int, int}]
+                          │    ├── const: 1 [type=int]
+                          │    └── const: 2 [type=int]
+                          └── variable: column4 [type=tuple{int, int}]
+
+build
+SELECT (SELECT * FROM abc)
+----
+error: subquery must return only one column, found 3
+
+build
+SELECT (SELECT a FROM abc)
+----
+project
+ ├── columns: column4:4(int)
+ ├── values
+ │    └── tuple [type=tuple{}]
+ └── projections
+      └── subquery [type=int]
+           ├── project
+           │    ├── columns: abc.a:1(int!null)
+           │    ├── scan abc
+           │    │    └── columns: abc.a:1(int!null) abc.b:2(int) abc.c:3(int)
+           │    └── projections
+           │         └── variable: abc.a [type=int]
+           └── variable: abc.a [type=int]
+
+build
+SELECT EXISTS (SELECT a FROM abc)
+----
+project
+ ├── columns: column4:4(bool)
+ ├── values
+ │    └── tuple [type=tuple{}]
+ └── projections
+      └── exists [type=bool]
+           └── project
+                ├── columns: abc.a:1(int!null)
+                ├── scan abc
+                │    └── columns: abc.a:1(int!null) abc.b:2(int) abc.c:3(int)
+                └── projections
+                     └── variable: abc.a [type=int]
+
+build
+SELECT (SELECT a FROM abc WHERE false)
+----
+project
+ ├── columns: column4:4(int)
+ ├── values
+ │    └── tuple [type=tuple{}]
+ └── projections
+      └── subquery [type=int]
+           ├── project
+           │    ├── columns: abc.a:1(int!null)
+           │    ├── select
+           │    │    ├── columns: abc.a:1(int!null) abc.b:2(int) abc.c:3(int)
+           │    │    ├── scan abc
+           │    │    │    └── columns: abc.a:1(int!null) abc.b:2(int) abc.c:3(int)
+           │    │    └── false [type=bool]
+           │    └── projections
+           │         └── variable: abc.a [type=int]
+           └── variable: abc.a [type=int]
+
+build
+VALUES (1, (SELECT (2)))
+----
+values
+ ├── columns: column1:2(int) column2:3(int)
+ └── tuple [type=tuple{int, int}]
+      ├── const: 1 [type=int]
+      └── subquery [type=int]
+           ├── project
+           │    ├── columns: column1:1(int)
+           │    ├── values
+           │    │    └── tuple [type=tuple{}]
+           │    └── projections
+           │         └── const: 2 [type=int]
+           └── variable: column1 [type=int]
+
+build
+SELECT * FROM abc WHERE a = 7
+----
+select
+ ├── columns: a:1(int!null) b:2(int) c:3(int)
+ ├── scan abc
+ │    └── columns: abc.a:1(int!null) abc.b:2(int) abc.c:3(int)
+ └── eq [type=bool]
+      ├── variable: abc.a [type=int]
+      └── const: 7 [type=int]
+
+exec-ddl
+CREATE TABLE xyz (x INT PRIMARY KEY, y INT, z INT)
+----
+TABLE xyz
+ ├── x int not null
+ ├── y int
+ ├── z int
+ └── INDEX primary
+      └── x int not null
+
+build
+SELECT * FROM xyz
+----
+scan xyz
+ └── columns: x:1(int!null) y:2(int) z:3(int)
+
+build
+SELECT 1 IN (SELECT x FROM xyz ORDER BY x DESC)
+----
+project
+ ├── columns: column5:5(bool)
+ ├── values
+ │    └── tuple [type=tuple{}]
+ └── projections
+      └── any [type=bool]
+           └── project
+                ├── columns: column4:4(bool)
+                ├── project
+                │    ├── columns: xyz.x:1(int!null)
+                │    ├── scan xyz
+                │    │    └── columns: xyz.x:1(int!null) xyz.y:2(int) xyz.z:3(int)
+                │    └── projections
+                │         └── variable: xyz.x [type=int]
+                └── projections
+                     └── eq [type=bool]
+                          ├── const: 1 [type=int]
+                          └── variable: xyz.x [type=int]
+
+build
+SELECT * FROM xyz WHERE x = (SELECT MIN(x) FROM xyz)
+----
+select
+ ├── columns: x:1(int!null) y:2(int) z:3(int)
+ ├── scan xyz
+ │    └── columns: xyz.x:1(int!null) xyz.y:2(int) xyz.z:3(int)
+ └── eq [type=bool]
+      ├── variable: xyz.x [type=int]
+      └── subquery [type=int]
+           ├── group-by
+           │    ├── columns: column7:7(int)
+           │    ├── project
+           │    │    ├── columns: xyz.x:4(int!null)
+           │    │    ├── scan xyz
+           │    │    │    └── columns: xyz.x:4(int!null) xyz.y:5(int) xyz.z:6(int)
+           │    │    └── projections
+           │    │         └── variable: xyz.x [type=int]
+           │    └── aggregations
+           │         └── function: min [type=int]
+           │              └── variable: xyz.x [type=int]
+           └── variable: column7 [type=int]
+
+build
+SELECT * FROM xyz WHERE x = (SELECT MAX(x) FROM xyz)
+----
+select
+ ├── columns: x:1(int!null) y:2(int) z:3(int)
+ ├── scan xyz
+ │    └── columns: xyz.x:1(int!null) xyz.y:2(int) xyz.z:3(int)
+ └── eq [type=bool]
+      ├── variable: xyz.x [type=int]
+      └── subquery [type=int]
+           ├── group-by
+           │    ├── columns: column7:7(int)
+           │    ├── project
+           │    │    ├── columns: xyz.x:4(int!null)
+           │    │    ├── scan xyz
+           │    │    │    └── columns: xyz.x:4(int!null) xyz.y:5(int) xyz.z:6(int)
+           │    │    └── projections
+           │    │         └── variable: xyz.x [type=int]
+           │    └── aggregations
+           │         └── function: max [type=int]
+           │              └── variable: xyz.x [type=int]
+           └── variable: column7 [type=int]
+
+exec-ddl
+CREATE TABLE kv (k INT PRIMARY KEY, v STRING)
+----
+TABLE kv
+ ├── k int not null
+ ├── v string
+ └── INDEX primary
+      └── k int not null
+
+build
+SELECT * FROM kv WHERE k = (SELECT k FROM kv WHERE (k, v) = (1, 'one'))
+----
+select
+ ├── columns: k:1(int!null) v:2(string)
+ ├── scan kv
+ │    └── columns: kv.k:1(int!null) kv.v:2(string)
+ └── eq [type=bool]
+      ├── variable: kv.k [type=int]
+      └── subquery [type=int]
+           ├── project
+           │    ├── columns: kv.k:3(int!null)
+           │    ├── select
+           │    │    ├── columns: kv.k:3(int!null) kv.v:4(string)
+           │    │    ├── scan kv
+           │    │    │    └── columns: kv.k:3(int!null) kv.v:4(string)
+           │    │    └── eq [type=bool]
+           │    │         ├── tuple [type=tuple{int, string}]
+           │    │         │    ├── variable: kv.k [type=int]
+           │    │         │    └── variable: kv.v [type=string]
+           │    │         └── tuple [type=tuple{int, string}]
+           │    │              ├── const: 1 [type=int]
+           │    │              └── const: 'one' [type=string]
+           │    └── projections
+           │         └── variable: kv.k [type=int]
+           └── variable: kv.k [type=int]
+
+build
+SELECT EXISTS(SELECT 1 FROM kv AS x WHERE x.k = 1)
+----
+project
+ ├── columns: column4:4(bool)
+ ├── values
+ │    └── tuple [type=tuple{}]
+ └── projections
+      └── exists [type=bool]
+           └── project
+                ├── columns: column3:3(int)
+                ├── select
+                │    ├── columns: kv.k:1(int!null) kv.v:2(string)
+                │    ├── scan kv
+                │    │    └── columns: kv.k:1(int!null) kv.v:2(string)
+                │    └── eq [type=bool]
+                │         ├── variable: kv.k [type=int]
+                │         └── const: 1 [type=int]
+                └── projections
+                     └── const: 1 [type=int]
+
+build
+SELECT EXISTS(SELECT 1 FROM kv WHERE k = 2)
+----
+project
+ ├── columns: column4:4(bool)
+ ├── values
+ │    └── tuple [type=tuple{}]
+ └── projections
+      └── exists [type=bool]
+           └── project
+                ├── columns: column3:3(int)
+                ├── select
+                │    ├── columns: kv.k:1(int!null) kv.v:2(string)
+                │    ├── scan kv
+                │    │    └── columns: kv.k:1(int!null) kv.v:2(string)
+                │    └── eq [type=bool]
+                │         ├── variable: kv.k [type=int]
+                │         └── const: 2 [type=int]
+                └── projections
+                     └── const: 1 [type=int]
+
+
+# Tests for subquery in the FROM part of a SELECT
+
+build
+SELECT * FROM (VALUES (1, 2)) AS foo
+----
+values
+ ├── columns: column1:1(int) column2:2(int)
+ └── tuple [type=tuple{int, int}]
+      ├── const: 1 [type=int]
+      └── const: 2 [type=int]
+
+build
+SELECT * FROM (VALUES (1, 2))
+----
+values
+ ├── columns: column1:1(int) column2:2(int)
+ └── tuple [type=tuple{int, int}]
+      ├── const: 1 [type=int]
+      └── const: 2 [type=int]
+
+build
+SELECT * FROM (VALUES (1, 'one'), (2, 'two'), (3, 'three')) AS foo
+----
+values
+ ├── columns: column1:1(int) column2:2(string)
+ ├── tuple [type=tuple{int, string}]
+ │    ├── const: 1 [type=int]
+ │    └── const: 'one' [type=string]
+ ├── tuple [type=tuple{int, string}]
+ │    ├── const: 2 [type=int]
+ │    └── const: 'two' [type=string]
+ └── tuple [type=tuple{int, string}]
+      ├── const: 3 [type=int]
+      └── const: 'three' [type=string]
+
+build
+SELECT * FROM (VALUES (1, 2, 3), (4, 5, 6)) AS foo
+----
+values
+ ├── columns: column1:1(int) column2:2(int) column3:3(int)
+ ├── tuple [type=tuple{int, int, int}]
+ │    ├── const: 1 [type=int]
+ │    ├── const: 2 [type=int]
+ │    └── const: 3 [type=int]
+ └── tuple [type=tuple{int, int, int}]
+      ├── const: 4 [type=int]
+      ├── const: 5 [type=int]
+      └── const: 6 [type=int]
+
+build
+SELECT * FROM (VALUES (1, 2, 3), (4, 5, 6)) AS foo (foo1, foo2, foo3)
+----
+values
+ ├── columns: foo1:1(int) foo2:2(int) foo3:3(int)
+ ├── tuple [type=tuple{int, int, int}]
+ │    ├── const: 1 [type=int]
+ │    ├── const: 2 [type=int]
+ │    └── const: 3 [type=int]
+ └── tuple [type=tuple{int, int, int}]
+      ├── const: 4 [type=int]
+      ├── const: 5 [type=int]
+      └── const: 6 [type=int]
+
+build
+SELECT * FROM (VALUES (1, 2, 3), (4, 5, 6)) AS foo (foo1, foo2)
+----
+values
+ ├── columns: foo1:1(int) foo2:2(int) column3:3(int)
+ ├── tuple [type=tuple{int, int, int}]
+ │    ├── const: 1 [type=int]
+ │    ├── const: 2 [type=int]
+ │    └── const: 3 [type=int]
+ └── tuple [type=tuple{int, int, int}]
+      ├── const: 4 [type=int]
+      ├── const: 5 [type=int]
+      └── const: 6 [type=int]
+
+build
+SELECT * FROM (SELECT * FROM xyz) AS foo WHERE x < 7
+----
+select
+ ├── columns: x:1(int!null) y:2(int) z:3(int)
+ ├── scan xyz
+ │    └── columns: xyz.x:1(int!null) xyz.y:2(int) xyz.z:3(int)
+ └── lt [type=bool]
+      ├── variable: xyz.x [type=int]
+      └── const: 7 [type=int]
+
+build
+SELECT * FROM (SELECT * FROM xyz) AS foo (foo1) WHERE foo1 < 7
+----
+select
+ ├── columns: foo1:1(int!null) y:2(int) z:3(int)
+ ├── scan xyz
+ │    └── columns: xyz.x:1(int!null) xyz.y:2(int) xyz.z:3(int)
+ └── lt [type=bool]
+      ├── variable: xyz.x [type=int]
+      └── const: 7 [type=int]
+
+build
+SELECT * FROM (SELECT * FROM xyz AS moo (moo1, moo2, moo3)) as foo (foo1) WHERE foo1 < 7
+----
+select
+ ├── columns: foo1:1(int!null) moo2:2(int) moo3:3(int)
+ ├── scan xyz
+ │    └── columns: xyz.x:1(int!null) xyz.y:2(int) xyz.z:3(int)
+ └── lt [type=bool]
+      ├── variable: xyz.x [type=int]
+      └── const: 7 [type=int]
+
+# TODO(rytaft): moo1 should be foo1
+build
+SELECT * FROM (SELECT * FROM xyz AS moo (moo1, moo2, moo3) ORDER BY moo1) as foo (foo1) WHERE foo1 < 7
+----
+select
+ ├── columns: foo1:1(int!null) moo2:2(int) moo3:3(int)
+ ├── scan xyz
+ │    └── columns: xyz.x:1(int!null) xyz.y:2(int) xyz.z:3(int)
+ └── lt [type=bool]
+      ├── variable: xyz.x [type=int]
+      └── const: 7 [type=int]
+
+build
+SELECT * FROM (SELECT * FROM xyz AS moo (moo1, moo2, moo3) ORDER BY moo1) as foo (foo1) WHERE foo1 < 7 ORDER BY moo2 DESC
+----
+sort
+ ├── columns: foo1:1(int!null) moo2:2(int) moo3:3(int)
+ ├── ordering: -2
+ └── select
+      ├── columns: xyz.x:1(int!null) xyz.y:2(int) xyz.z:3(int)
+      ├── scan xyz
+      │    └── columns: xyz.x:1(int!null) xyz.y:2(int) xyz.z:3(int)
+      └── lt [type=bool]
+           ├── variable: xyz.x [type=int]
+           └── const: 7 [type=int]
+
+build
+SELECT * FROM (SELECT * FROM (VALUES (1, 2, 3), (4, 5, 6)) AS moo (moo1, moo2, moo3) WHERE moo1 = 4) as foo (foo1)
+----
+select
+ ├── columns: foo1:1(int) moo2:2(int) moo3:3(int)
+ ├── values
+ │    ├── columns: column1:1(int) column2:2(int) column3:3(int)
+ │    ├── tuple [type=tuple{int, int, int}]
+ │    │    ├── const: 1 [type=int]
+ │    │    ├── const: 2 [type=int]
+ │    │    └── const: 3 [type=int]
+ │    └── tuple [type=tuple{int, int, int}]
+ │         ├── const: 4 [type=int]
+ │         ├── const: 5 [type=int]
+ │         └── const: 6 [type=int]
+ └── eq [type=bool]
+      ├── variable: column1 [type=int]
+      └── const: 4 [type=int]
+
+build
+SELECT * FROM (SELECT * FROM (VALUES (1, 8, 8), (3, 1, 1), (2, 4, 4)) AS moo (moo1, moo2, moo3) ORDER BY moo2) as foo (foo1) ORDER BY foo1
+----
+sort
+ ├── columns: foo1:1(int) moo2:2(int) moo3:3(int)
+ ├── ordering: +1
+ └── values
+      ├── columns: column1:1(int) column2:2(int) column3:3(int)
+      ├── tuple [type=tuple{int, int, int}]
+      │    ├── const: 1 [type=int]
+      │    ├── const: 8 [type=int]
+      │    └── const: 8 [type=int]
+      ├── tuple [type=tuple{int, int, int}]
+      │    ├── const: 3 [type=int]
+      │    ├── const: 1 [type=int]
+      │    └── const: 1 [type=int]
+      └── tuple [type=tuple{int, int, int}]
+           ├── const: 2 [type=int]
+           ├── const: 4 [type=int]
+           └── const: 4 [type=int]
+
+build
+SELECT a, b FROM (VALUES (1, 2, 3), (3, 4, 7), (5, 6, 10)) AS foo (a, b, c) WHERE a + b = c
+----
+project
+ ├── columns: a:1(int) b:2(int)
+ ├── select
+ │    ├── columns: column1:1(int) column2:2(int) column3:3(int)
+ │    ├── values
+ │    │    ├── columns: column1:1(int) column2:2(int) column3:3(int)
+ │    │    ├── tuple [type=tuple{int, int, int}]
+ │    │    │    ├── const: 1 [type=int]
+ │    │    │    ├── const: 2 [type=int]
+ │    │    │    └── const: 3 [type=int]
+ │    │    ├── tuple [type=tuple{int, int, int}]
+ │    │    │    ├── const: 3 [type=int]
+ │    │    │    ├── const: 4 [type=int]
+ │    │    │    └── const: 7 [type=int]
+ │    │    └── tuple [type=tuple{int, int, int}]
+ │    │         ├── const: 5 [type=int]
+ │    │         ├── const: 6 [type=int]
+ │    │         └── const: 10 [type=int]
+ │    └── eq [type=bool]
+ │         ├── plus [type=int]
+ │         │    ├── variable: column1 [type=int]
+ │         │    └── variable: column2 [type=int]
+ │         └── variable: column3 [type=int]
+ └── projections
+      ├── variable: column1 [type=int]
+      └── variable: column2 [type=int]
+
+build
+SELECT foo.a FROM (VALUES (1), (2), (3)) AS foo (a)
+----
+values
+ ├── columns: a:1(int)
+ ├── tuple [type=tuple{int}]
+ │    └── const: 1 [type=int]
+ ├── tuple [type=tuple{int}]
+ │    └── const: 2 [type=int]
+ └── tuple [type=tuple{int}]
+      └── const: 3 [type=int]
+
+build
+SELECT foo.a, a, column2, foo.column2 FROM (VALUES (1, 'one'), (2, 'two'), (3, 'three')) AS foo (a)
+----
+project
+ ├── columns: a:1(int) a:1(int) column2:2(string) column2:2(string)
+ ├── values
+ │    ├── columns: column1:1(int) column2:2(string)
+ │    ├── tuple [type=tuple{int, string}]
+ │    │    ├── const: 1 [type=int]
+ │    │    └── const: 'one' [type=string]
+ │    ├── tuple [type=tuple{int, string}]
+ │    │    ├── const: 2 [type=int]
+ │    │    └── const: 'two' [type=string]
+ │    └── tuple [type=tuple{int, string}]
+ │         ├── const: 3 [type=int]
+ │         └── const: 'three' [type=string]
+ └── projections
+      ├── variable: column1 [type=int]
+      ├── variable: column1 [type=int]
+      ├── variable: column2 [type=string]
+      └── variable: column2 [type=string]
+
+build
+SELECT x FROM xyz WHERE x IN (SELECT x FROM xyz WHERE x = 7)
+----
+project
+ ├── columns: x:1(int!null)
+ ├── select
+ │    ├── columns: xyz.x:1(int!null) xyz.y:2(int) xyz.z:3(int)
+ │    ├── scan xyz
+ │    │    └── columns: xyz.x:1(int!null) xyz.y:2(int) xyz.z:3(int)
+ │    └── any [type=bool]
+ │         └── project
+ │              ├── columns: column7:7(bool)
+ │              ├── project
+ │              │    ├── columns: xyz.x:4(int!null)
+ │              │    ├── select
+ │              │    │    ├── columns: xyz.x:4(int!null) xyz.y:5(int) xyz.z:6(int)
+ │              │    │    ├── scan xyz
+ │              │    │    │    └── columns: xyz.x:4(int!null) xyz.y:5(int) xyz.z:6(int)
+ │              │    │    └── eq [type=bool]
+ │              │    │         ├── variable: xyz.x [type=int]
+ │              │    │         └── const: 7 [type=int]
+ │              │    └── projections
+ │              │         └── variable: xyz.x [type=int]
+ │              └── projections
+ │                   └── eq [type=bool]
+ │                        ├── variable: xyz.x [type=int]
+ │                        └── variable: xyz.x [type=int]
+ └── projections
+      └── variable: xyz.x [type=int]
+
+build
+SELECT x FROM xyz WHERE x = 7 LIMIT (SELECT x FROM xyz WHERE x = 1)
+----
+limit
+ ├── columns: x:1(int!null)
+ ├── project
+ │    ├── columns: xyz.x:1(int!null)
+ │    ├── select
+ │    │    ├── columns: xyz.x:1(int!null) xyz.y:2(int) xyz.z:3(int)
+ │    │    ├── scan xyz
+ │    │    │    └── columns: xyz.x:1(int!null) xyz.y:2(int) xyz.z:3(int)
+ │    │    └── eq [type=bool]
+ │    │         ├── variable: xyz.x [type=int]
+ │    │         └── const: 7 [type=int]
+ │    └── projections
+ │         └── variable: xyz.x [type=int]
+ └── subquery [type=int]
+      ├── project
+      │    ├── columns: xyz.x:4(int!null)
+      │    ├── select
+      │    │    ├── columns: xyz.x:4(int!null) xyz.y:5(int) xyz.z:6(int)
+      │    │    ├── scan xyz
+      │    │    │    └── columns: xyz.x:4(int!null) xyz.y:5(int) xyz.z:6(int)
+      │    │    └── eq [type=bool]
+      │    │         ├── variable: xyz.x [type=int]
+      │    │         └── const: 1 [type=int]
+      │    └── projections
+      │         └── variable: xyz.x [type=int]
+      └── variable: xyz.x [type=int]
+
+build
+SELECT x FROM xyz ORDER BY x OFFSET (SELECT x FROM xyz WHERE x = 1)
+----
+offset
+ ├── columns: x:1(int!null)
+ ├── ordering: +1
+ ├── project
+ │    ├── columns: xyz.x:1(int!null)
+ │    ├── ordering: +1
+ │    ├── scan xyz
+ │    │    ├── columns: xyz.x:1(int!null) xyz.y:2(int) xyz.z:3(int)
+ │    │    └── ordering: +1
+ │    └── projections
+ │         └── variable: xyz.x [type=int]
+ └── subquery [type=int]
+      ├── project
+      │    ├── columns: xyz.x:4(int!null)
+      │    ├── select
+      │    │    ├── columns: xyz.x:4(int!null) xyz.y:5(int) xyz.z:6(int)
+      │    │    ├── scan xyz
+      │    │    │    └── columns: xyz.x:4(int!null) xyz.y:5(int) xyz.z:6(int)
+      │    │    └── eq [type=bool]
+      │    │         ├── variable: xyz.x [type=int]
+      │    │         └── const: 1 [type=int]
+      │    └── projections
+      │         └── variable: xyz.x [type=int]
+      └── variable: xyz.x [type=int]
+
+# check that residual filters are not expanded twice
+build
+SELECT x FROM xyz WHERE x IN (SELECT x FROM xyz)
+----
+project
+ ├── columns: x:1(int!null)
+ ├── select
+ │    ├── columns: xyz.x:1(int!null) xyz.y:2(int) xyz.z:3(int)
+ │    ├── scan xyz
+ │    │    └── columns: xyz.x:1(int!null) xyz.y:2(int) xyz.z:3(int)
+ │    └── any [type=bool]
+ │         └── project
+ │              ├── columns: column7:7(bool)
+ │              ├── project
+ │              │    ├── columns: xyz.x:4(int!null)
+ │              │    ├── scan xyz
+ │              │    │    └── columns: xyz.x:4(int!null) xyz.y:5(int) xyz.z:6(int)
+ │              │    └── projections
+ │              │         └── variable: xyz.x [type=int]
+ │              └── projections
+ │                   └── eq [type=bool]
+ │                        ├── variable: xyz.x [type=int]
+ │                        └── variable: xyz.x [type=int]
+ └── projections
+      └── variable: xyz.x [type=int]
+
+# This test checks that the double sub-query plan expansion caused by a
+# sub-expression being shared by two or more plan nodes does not
+# panic.
+exec-ddl
+CREATE TABLE tab4 (col0 INTEGER, col1 FLOAT, col3 INTEGER, col4 FLOAT, INDEX idx_tab4_0 (col4,col0))
+----
+TABLE tab4
+ ├── col0 int
+ ├── col1 float
+ ├── col3 int
+ ├── col4 float
+ ├── rowid int not null (hidden)
+ ├── INDEX primary
+ │    └── rowid int not null (hidden)
+ └── INDEX idx_tab4_0
+      ├── col4 float
+      ├── col0 int
+      └── rowid int not null (hidden)
+
+build
+SELECT col0 FROM tab4 WHERE (col0 <= 0 AND col4 <= 5.38) OR (col4 IN (SELECT col1 FROM tab4 WHERE col1 > 8.27)) AND (col3 <= 5 AND (col3 BETWEEN 7 AND 9))
+----
+project
+ ├── columns: col0:1(int)
+ ├── select
+ │    ├── columns: tab4.col0:1(int) tab4.col1:2(float) tab4.col3:3(int) tab4.col4:4(float) tab4.rowid:5(int!null)
+ │    ├── scan tab4
+ │    │    └── columns: tab4.col0:1(int) tab4.col1:2(float) tab4.col3:3(int) tab4.col4:4(float) tab4.rowid:5(int!null)
+ │    └── or [type=bool]
+ │         ├── and [type=bool]
+ │         │    ├── le [type=bool]
+ │         │    │    ├── variable: tab4.col0 [type=int]
+ │         │    │    └── const: 0 [type=int]
+ │         │    └── le [type=bool]
+ │         │         ├── variable: tab4.col4 [type=float]
+ │         │         └── const: 5.38 [type=float]
+ │         └── and [type=bool]
+ │              ├── any [type=bool]
+ │              │    └── project
+ │              │         ├── columns: column11:11(bool)
+ │              │         ├── project
+ │              │         │    ├── columns: tab4.col1:7(float)
+ │              │         │    ├── select
+ │              │         │    │    ├── columns: tab4.col0:6(int) tab4.col1:7(float) tab4.col3:8(int) tab4.col4:9(float) tab4.rowid:10(int!null)
+ │              │         │    │    ├── scan tab4
+ │              │         │    │    │    └── columns: tab4.col0:6(int) tab4.col1:7(float) tab4.col3:8(int) tab4.col4:9(float) tab4.rowid:10(int!null)
+ │              │         │    │    └── gt [type=bool]
+ │              │         │    │         ├── variable: tab4.col1 [type=float]
+ │              │         │    │         └── const: 8.27 [type=float]
+ │              │         │    └── projections
+ │              │         │         └── variable: tab4.col1 [type=float]
+ │              │         └── projections
+ │              │              └── eq [type=bool]
+ │              │                   ├── variable: tab4.col4 [type=float]
+ │              │                   └── variable: tab4.col1 [type=float]
+ │              └── and [type=bool]
+ │                   ├── le [type=bool]
+ │                   │    ├── variable: tab4.col3 [type=int]
+ │                   │    └── const: 5 [type=int]
+ │                   └── and [type=bool]
+ │                        ├── ge [type=bool]
+ │                        │    ├── variable: tab4.col3 [type=int]
+ │                        │    └── const: 7 [type=int]
+ │                        └── le [type=bool]
+ │                             ├── variable: tab4.col3 [type=int]
+ │                             └── const: 9 [type=int]
+ └── projections
+      └── variable: tab4.col0 [type=int]


### PR DESCRIPTION
This commit adds support for building non-correlated subqueries
in the optbuilder. Similar to the way the existing planner works,
the optbuilder extracts subqueries from the AST and replaces them with
typed, annotated subquery structs. These subquery structs contain the
following fields:
```
type subquery struct {
  // cols contains the output columns of the subquery.
  cols []columnProps

  // out is the top level memo GroupID of the subquery.
  out  memo.GroupID

  // Is the subquery in a multi-row or single-row context?
  multiRow bool

  // typ is the lazily resolved type of the subquery.
  typ types.T

  // Is this an EXISTS statement?
  exists bool
}
```
When a `subquery` struct is encountered during the build process, it is
built in the memo as an `opt.SubqueryOp` if `multiRow` is true, or an
`opt.SingleRowSubqueryOp` if `multiRow` is false.

This code is based on code originally written as part of the
opttoy project.

Release note: None