### PR TITLE
cli: add a decode-key command

### DIFF
--- a/pkg/cli/debug.go
+++ b/pkg/cli/debug.go
@@ -18,6 +18,7 @@ package cli
 import (
 	"bytes"
 	"context"
+	"encoding/hex"
 	"fmt"
 	"os"
 	"sort"
@@ -435,6 +436,31 @@ func runDebugRangeDescriptors(cmd *cobra.Command, args []string) error {
 	end := engine.MakeMVCCMetadataKey(keys.LocalRangeMax)
 
 	return db.Iterate(start, end, printRangeDescriptor)
+}
+
+var debugDecodeKeyCmd = &cobra.Command{
+	Use:   "decode-key",
+	Short: "decode <key>",
+	Long: `
+Decode a hexadecimal-encoded key and pretty-print it. For example:
+
+	$ decode-key BB89F902ADB43000151C2D1ED07DE6C009
+	/Table/51/1/44938288/1521140384.514565824,0
+`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		for _, arg := range args {
+			b, err := hex.DecodeString(arg)
+			if err != nil {
+				return err
+			}
+			k, err := engine.DecodeKey(b)
+			if err != nil {
+				return err
+			}
+			fmt.Println(k)
+		}
+		return nil
+	},
 }
 
 var debugRaftLogCmd = &cobra.Command{
@@ -1030,6 +1056,7 @@ var debugCmds = []*cobra.Command{
 	debugKeysCmd,
 	debugRangeDataCmd,
 	debugRangeDescriptorsCmd,
+	debugDecodeKeyCmd,
 	debugRaftLogCmd,
 	debugGCCmd,
 	debugCheckStoreCmd,


### PR DESCRIPTION
Add a CLI command that takes a hex-encoded key and pretty-prints it.
This is useful when looking at a raw SST dump with tools that don't
understand Cockroach's key encoding.

@bdarnell we don't already have this, do we? I realize teaching `sst_dump` to pretty-print keys might ultimately prove more useful, but I've wanted a dead simple pretty-printer like this on more than one occasion.

Release note: None