### PR TITLE
backport-2.0: cli: don't leak iterator in `debug range-data`

### DIFF
--- a/pkg/cli/debug.go
+++ b/pkg/cli/debug.go
@@ -189,6 +189,7 @@ func runDebugRangeData(cmd *cobra.Command, args []string) error {
 	}
 
 	iter := rditer.NewReplicaDataIterator(&desc, db, debugCtx.replicated)
+	defer iter.Close()
 	for ; ; iter.Next() {
 		if ok, err := iter.Valid(); err != nil {
 			return err


### PR DESCRIPTION
Backport 1/1 commits from #24038.

/cc @cockroachdb/release

---

Before this change, `debug range-data` would panic with the
message: `1 leaked iterators`. This has been an issue since
5b38855.

Release note: None
