### PR TITLE
server: Simplify RangeProblems logic in status server

### DIFF
--- a/pkg/server/status.go
+++ b/pkg/server/status.go
@@ -1018,10 +1018,10 @@ func (s *statusServer) Ranges(
 				WritesPerSecond:  rep.WritesPerSecond(),
 			},
 			Problems: serverpb.RangeProblems{
-				Unavailable:          metrics.RangeCounter && metrics.Unavailable,
+				Unavailable:          metrics.Unavailable,
 				LeaderNotLeaseHolder: metrics.Leader && metrics.LeaseValid && !metrics.Leaseholder,
 				NoRaftLeader:         !storage.HasRaftLeader(raftStatus) && !metrics.Quiescent,
-				Underreplicated:      metrics.Leader && metrics.Underreplicated,
+				Underreplicated:      metrics.Underreplicated,
 				NoLease:              metrics.Leader && !metrics.LeaseValid && !metrics.Quiescent,
 			},
 			CmdQLocal:   serverpb.CommandQueueMetrics(metrics.CmdQMetricsLocal),


### PR DESCRIPTION
The code that calculates the number of unavailable and underreplicated
ranges already does its best to only count a range as
unavailable/underreplicated on one of its replicas. Doing the same here
can lead to it getting out of sync with the code in core. #23409 changed
the code there to make RangeCounter responsible for counting
underreplicated ranges, not Leader, so this made the node's metrics
different from its response to this Status API.

Alternatively I could change the Underreplicated field to require
metrics.RangeCounter instead of metrics.Leader, but this protects us
from future changes as long as the core code abides by the current
contract that only one replica per range should report these statuses.

Release note: None

----------

This was making the debug pages of my buggy cluster in #24023 say that tons of ranges were unavailable but not underreplicated, which doesn't make any real sense.