### PR TITLE
backport-2.0: storage: perform SpanSet assertions on read-only requests

### DIFF
--- a/pkg/storage/spanset/batch.go
+++ b/pkg/storage/spanset/batch.go
@@ -307,6 +307,12 @@ func makeSpanSetReadWriter(rw engine.ReadWriter, spans *SpanSet) spanSetReadWrit
 	}
 }
 
+// NewReadWriter returns an engine.ReadWriter that asserts access of the
+// underlying ReadWriter against the given SpanSet.
+func NewReadWriter(rw engine.ReadWriter, spans *SpanSet) engine.ReadWriter {
+	return makeSpanSetReadWriter(rw, spans)
+}
+
 type spanSetBatch struct {
 	spanSetReadWriter
 	b     engine.Batch

--- a/pkg/storage/spanset/spanset.go
+++ b/pkg/storage/spanset/spanset.go
@@ -114,9 +114,6 @@ func (ss *SpanSet) CheckAllowed(access SpanAccess, span roachpb.Span) error {
 	}
 	for ac := access; ac < NumSpanAccess; ac++ {
 		for _, s := range ss.spans[ac][scope] {
-			if s.Key.Equal(keys.LocalMax) && s.EndKey.Equal(roachpb.KeyMax) {
-				continue
-			}
 			if s.Contains(span) {
 				return nil
 			}


### PR DESCRIPTION
Backport 1/1 commits from #23997.

/cc @cockroachdb/release

---

Before this change, we only performed SpanSet assertions on read-write
requests. This was a pretty huge oversight and is what allowed #23944 to
slip in. This change fixes this by adding an `engine.ReadWriter` spanset
variant and using it for read-only requests while in race mode.

It is currently blocked on #23996 and the revival of #18579. This is actually
good news, as it means that no other spanset violations have crept in while
this assertion was missing. 

First commit is from #23996.

Release note: None
