### PR TITLE
cherrypick 2.0: sql, client: auto-retry pushed txns that can't be refreshed 

### DIFF
--- a/pkg/sql/logictest/logic.go
+++ b/pkg/sql/logictest/logic.go
@@ -814,10 +814,8 @@ func (t *logicTest) setUser(user string) func() {
 
 	addr := t.cluster.Server(t.nodeIdx).ServingAddr()
 	pgURL, cleanupFunc := sqlutils.PGUrl(t.t, addr, "TestLogic", url.User(user))
-	// Connect to the test database by default, to match the default test
-	// connection (which creates and uses that database).
-	urlStr := pgURL.String() + "&database=test"
-	db, err := gosql.Open("postgres", urlStr)
+	pgURL.Path = "test"
+	db, err := gosql.Open("postgres", pgURL.String())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -853,6 +851,7 @@ func (t *logicTest) setup(cfg testClusterConfig) {
 					AssertFuncExprReturnTypes:   true,
 				},
 			},
+			UseDatabase: "test",
 		},
 		// For distributed SQL tests, we use the fake span resolver; it doesn't
 		// matter where the data really is.
@@ -922,7 +921,6 @@ func (t *logicTest) setup(cfg testClusterConfig) {
 
 	if _, err := t.db.Exec(`
 CREATE DATABASE test;
-SET DATABASE = test;
 `); err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/sql/logictest/testdata/logic_test/alter_table
+++ b/pkg/sql/logictest/testdata/logic_test/alter_table
@@ -594,6 +594,11 @@ INSERT INTO privs VALUES (1)
 
 user testuser
 
+query T
+SHOW DATABASE
+----
+test
+
 statement error user testuser does not have CREATE privilege on relation privs
 ALTER TABLE privs ADD c INT
 

--- a/pkg/sql/logictest/testdata/logic_test/pgoidtype
+++ b/pkg/sql/logictest/testdata/logic_test/pgoidtype
@@ -221,17 +221,20 @@ user root
 statement ok
 CREATE DATABASE otherdb
 
-statement ok
-SET DATABASE = otherdb
-
 ## a non-root user can't get the OID of a table from a different database
 
 user testuser
+
+statement ok
+SET DATABASE = otherdb
 
 query error pgcode 42P01 relation "a" does not exist
 SELECT 'a'::regclass
 
 user root
+
+statement ok
+SET DATABASE = otherdb
 
 statement ok
 CREATE TABLE a (id INT PRIMARY KEY, foo STRING)

--- a/pkg/sql/logictest/testdata/logic_test/show_trace
+++ b/pkg/sql/logictest/testdata/logic_test/show_trace
@@ -12,18 +12,18 @@ SET tracing = on; BEGIN; SELECT 1; COMMIT; SELECT 2; SET tracing = off;
 query ITT
 SELECT span, message, operation FROM [SHOW TRACE FOR SESSION] WHERE message LIKE '%SPAN START%' OR message LIKE '%pos%executing%';
 ----
-0  === SPAN START: sql txn ===                           sql txn
-1  === SPAN START: session recording ===                 session recording
-1  [NoTxn pos:6] executing ExecStmt: BEGIN TRANSACTION   session recording
-2  === SPAN START: sql txn ===                           sql txn
-2  [Open pos:7] executing ExecStmt: SELECT 1             sql txn
-2  [Open pos:8] executing ExecStmt: COMMIT TRANSACTION   sql txn
-1  [NoTxn pos:9] executing ExecStmt: SELECT 2            session recording
-3  === SPAN START: sql txn ===                           sql txn
-3  [Open pos:9] executing ExecStmt: SELECT 2             sql txn
-1  [NoTxn pos:10] executing ExecStmt: SET tracing = off  session recording
-4  === SPAN START: sql txn ===                           sql txn
-4  [Open pos:10] executing ExecStmt: SET tracing = off   sql txn
+0  === SPAN START: sql txn ===                          sql txn
+1  === SPAN START: session recording ===                session recording
+1  [NoTxn pos:5] executing ExecStmt: BEGIN TRANSACTION  session recording
+2  === SPAN START: sql txn ===                          sql txn
+2  [Open pos:6] executing ExecStmt: SELECT 1            sql txn
+2  [Open pos:7] executing ExecStmt: COMMIT TRANSACTION  sql txn
+1  [NoTxn pos:8] executing ExecStmt: SELECT 2           session recording
+3  === SPAN START: sql txn ===                          sql txn
+3  [Open pos:8] executing ExecStmt: SELECT 2            sql txn
+1  [NoTxn pos:9] executing ExecStmt: SET tracing = off  session recording
+4  === SPAN START: sql txn ===                          sql txn
+4  [Open pos:9] executing ExecStmt: SET tracing = off   sql txn
 
 # Same, with SHOW TRACE FOR.
 # This also tests that sub-spans are reported properly.

--- a/pkg/sql/logictest/testdata/logic_test/txn
+++ b/pkg/sql/logictest/testdata/logic_test/txn
@@ -494,6 +494,10 @@ snapshot
 statement ok
 COMMIT
 
+# restore default
+statement ok
+SET DEFAULT_TRANSACTION_ISOLATION TO 'SERIALIZABLE'
+
 # SHOW TRANSACTION STATUS
 
 query T
@@ -977,3 +981,7 @@ SELECT CRDB_INTERNAL.FORCE_RETRY('1s':::INTERVAL)
 
 statement ok
 ROLLBACK
+
+# restore the default
+statement ok
+SET default_transaction_read_only = false

--- a/pkg/sql/logictest/testdata/logic_test/txn_retry
+++ b/pkg/sql/logictest/testdata/logic_test/txn_retry
@@ -1,0 +1,37 @@
+# LogicTest: default
+
+# Check that we auto-retry pushed transactions which can't be refreshed - if
+# they're pushed while we can still auto-retry them.
+subtest autoretry-on-push-first-batch
+
+statement ok
+CREATE TABLE test_retry (
+  k INT PRIMARY KEY
+)
+
+statement ok
+GRANT ALL ON test_retry TO testuser
+
+# Start a txn (and fix a timestamp).
+statement ok
+BEGIN
+
+# On a different connection, do a read at a higher timestamp.
+#
+# We use dont_inherit_database, as otherwise we'd run some statements under the
+# hood that break the auto-retry that we'll need later.
+user testuser dont_inherit_database
+
+statement ok
+SELECT * FROM test.test_retry
+
+user root dont_inherit_database
+
+# Run a cluster_logical_timestamp(), so that the transaction "observes its
+# commit timestamp" and so can't be refreshed, and the do an insert that will
+# cause the txn to be pushed.
+statement ok
+SELECT cluster_logical_timestamp(); INSERT INTO test_retry VALUES (1);
+
+statement ok
+COMMIT

--- a/pkg/sql/logictest/testdata/logic_test/txn_retry
+++ b/pkg/sql/logictest/testdata/logic_test/txn_retry
@@ -17,15 +17,12 @@ statement ok
 BEGIN
 
 # On a different connection, do a read at a higher timestamp.
-#
-# We use dont_inherit_database, as otherwise we'd run some statements under the
-# hood that break the auto-retry that we'll need later.
-user testuser dont_inherit_database
+user testuser
 
 statement ok
 SELECT * FROM test.test_retry
 
-user root dont_inherit_database
+user root
 
 # Run a cluster_logical_timestamp(), so that the transaction "observes its
 # commit timestamp" and so can't be refreshed, and the do an insert that will


### PR DESCRIPTION
Cherry-pick #24031 and also pull in #24049

#24031 reads: 
sql, client: auto-retry pushed txns that can't be refreshed 
if it's still possible for the SQL connExecutor to retry them (i.e.
we haven't sent results to the client for the respective txn yet).

This patch re-introduces code we used to have, but was deleted in #21140.
The motivation for deleting the code was that retriable errors were
supposed to be rarer because of the "read refreshing" mechanism, but
that mechanism doesn't apply to transactions that "observe their commit
timestamp". A txn can observe its timestamp by calling
cluster_logical_timestamp(), or in other ways. In particular, schema
change txns always observe their ts.

Fixes #22933

Release note: Retriable errors on schema change operations are less
likely to be returned to clients; more operations are retried
internally.
aff3bd7
