### PR TITLE
backport-2.0: storage: Treat "precandidates" the same as "candidates" in replica GC

### DIFF
--- a/pkg/storage/replica_gc_queue.go
+++ b/pkg/storage/replica_gc_queue.go
@@ -135,7 +135,8 @@ func (rgcq *replicaGCQueue) shouldQueue(
 
 	var isCandidate bool
 	if raftStatus := repl.RaftStatus(); raftStatus != nil {
-		isCandidate = (raftStatus.SoftState.RaftState == raft.StateCandidate)
+		isCandidate = (raftStatus.SoftState.RaftState == raft.StateCandidate ||
+			raftStatus.SoftState.RaftState == raft.StatePreCandidate)
 	} else {
 		// If a replica doesn't have an active raft group, we should check whether
 		// we're decommissioning. If so, we should process the replica because it

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -3450,6 +3450,25 @@ func (s *Store) HandleRaftResponse(ctx context.Context, resp *RaftMessageRespons
 			} else {
 				log.Infof(ctx, "added to replica GC queue (peer suggestion)")
 			}
+		case *roachpb.RaftGroupDeletedError:
+			if replErr != nil {
+				// RangeNotFoundErrors are expected here; nothing else is.
+				if _, ok := replErr.(*roachpb.RangeNotFoundError); !ok {
+					log.Error(ctx, replErr)
+				}
+				return nil
+			}
+
+			// If the replica is talking to a replica that's been deleted, it must be
+			// out of date. While this may just mean it's slightly behind, it can
+			// also mean that it is so far behind it no longer knows where any of the
+			// other replicas are (#23994). Add it to the replica GC queue to do a
+			// proper check.
+			if _, err := s.replicaGCQueue.Add(repl, replicaGCPriorityDefault); err != nil {
+				log.Errorf(ctx, "unable to add to replica GC queue: %s", err)
+			} else {
+				log.Infof(ctx, "added to replica GC queue (contacted deleted peer)")
+			}
 		case *roachpb.StoreNotFoundError:
 			log.Warningf(ctx, "raft error: node %d claims to not contain store %d for replica %s: %s",
 				resp.FromReplica.NodeID, resp.FromReplica.StoreID, resp.FromReplica, val)


### PR DESCRIPTION
Backport 2/2 commits from #23995.

/cc @cockroachdb/release

---

We have long had code that relied on eagerly adding to the GC queue
replicas that are in the raft candidate state because it's often a
sign that the replica is no longer a part of the range. Now that
pre-vote is enabled, we need to do the same for the precandidate
state to ensure that replicas are GCed in a timely fashion.

Release note (bug fix): garbage collect old replicas in a more timely
fashion after a node has been offline for a long time (this bug only
exists in recent v2.0 alpha/beta releases, not in v1.1).

Fixes #23994, assuming this works in practice on the cluster involved there. @jordanlewis it looks like you're running a custom build there, otherwise I'd try this myself on the node in question. Can you try applying this patch to your branch and restarting jordan-tpcc-new:13 with it?

It'd be nice to also add a higher-level test for this situation of a node coming back online after being declared dead and the replicas for a range having been moved around the cluster. It's not going to be a simple test, though.
