### PR TITLE
backport-2.0: server: redact settings values from api endpoint

### DIFF
--- a/pkg/server/admin.go
+++ b/pkg/server/admin.go
@@ -1018,7 +1018,7 @@ func (s *adminServer) Settings(
 		}
 		resp.KeyValues[k] = serverpb.SettingsResponse_Value{
 			Type:        v.Typ(),
-			Value:       v.String(&s.server.st.SV),
+			Value:       settings.SanitizedValue(k, &s.server.st.SV),
 			Description: v.Description(),
 		}
 	}

--- a/pkg/server/admin_test.go
+++ b/pkg/server/admin_test.go
@@ -846,8 +846,14 @@ func TestAdminAPISettings(t *testing.T) {
 		}
 		typ := ref.Typ()
 
-		if ref.String(&st.SV) != v.Value {
-			t.Errorf("%s: expected value %s, got %s", k, ref, v.Value)
+		if typ == "s" && k != "version" {
+			if v.Value != "<redacted>" && v.Value != "" {
+				t.Errorf("%s: expected redacted value for %v, got %s", k, ref, v.Value)
+			}
+		} else {
+			if ref.String(&st.SV) != v.Value {
+				t.Errorf("%s: expected value %v, got %s", k, ref, v.Value)
+			}
 		}
 
 		if desc := ref.Description(); desc != v.Description {

--- a/pkg/server/updates_test.go
+++ b/pkg/server/updates_test.go
@@ -404,13 +404,13 @@ func TestReportUsage(t *testing.T) {
 		t.Fatalf("expected %d changed settings, got %d: %v", expected, actual, r.last.AlteredSettings)
 	}
 	for key, expected := range map[string]string{
-		"cluster.organization":                     "<non-default>",
+		"cluster.organization":                     "<redacted>",
 		"diagnostics.reporting.enabled":            "true",
 		"diagnostics.reporting.send_crash_reports": "false",
 		"server.time_until_store_dead":             "20s",
 		"trace.debug.enable":                       "false",
 		"version":                                  "2.0",
-		"cluster.secret":                           "<non-default>",
+		"cluster.secret":                           "<redacted>",
 	} {
 		if got, ok := r.last.AlteredSettings[key]; !ok {
 			t.Fatalf("expected report of altered setting %q", key)

--- a/pkg/settings/registry.go
+++ b/pkg/settings/registry.go
@@ -69,3 +69,41 @@ func Lookup(name string) (Setting, bool) {
 	v, ok := Registry[name]
 	return v, ok
 }
+
+// safeToReportSettings are the names of settings which we want reported with
+// their values, regardless of their type -- usually only numeric/duration/bool
+// settings are reported to avoid including potentially sensitive info that may
+// appear in strings or byte/proto/statemachine settings.
+var safeToReportSettings = map[string]struct{}{
+	"version": {},
+}
+
+// SanitizedValue returns a string representation of the value for settings
+// types the are not considered sensitive (numbers, bools, etc) or
+// <redacted> for those with values could store sensitive things (i.e. strings).
+func SanitizedValue(name string, values *Values) string {
+	if setting, ok := Lookup(name); ok {
+		if _, ok := safeToReportSettings[name]; ok {
+			return setting.String(values)
+		}
+		// for settings with types that can't be sensitive, report values.
+		switch setting.(type) {
+		case *IntSetting,
+			*FloatSetting,
+			*ByteSizeSetting,
+			*DurationSetting,
+			*BoolSetting,
+			*EnumSetting:
+			return setting.String(values)
+		case *StringSetting:
+			if setting.String(values) == "" {
+				return ""
+			}
+			return "<redacted>"
+		default:
+			return "<redacted>"
+		}
+	} else {
+		return "<unknown>"
+	}
+}


### PR DESCRIPTION
Backport 1/1 commits from #24044.

/cc @cockroachdb/release

---

Given that `SHOW ALL CLUSTER SETTINGS` requires super-user, and
generally that settings values are considered potentially sensitive,
this endpoint should not return raw values to non-root users (which we
have to assume is everyone until we have auth).

However assume that non-string settings are safe to share and indeed we
already include them in the diagnostics reporting, so we can reuse that
redaction logic here to make this endpoint safe to expose as-is.

Fixes #24028.

Release note (bug fix): redact string settings values in debug API responses.
