### PR TITLE
ui: add message to explain server.remote_debugging.mode error

### DIFF
--- a/pkg/ui/src/util/constants.ts
+++ b/pkg/ui/src/util/constants.ts
@@ -5,3 +5,5 @@ export const nodeIDAttr = "node_id";
 export const nodeQueryString = "node";
 export const rangeIDAttr = "range_id";
 export const tableNameAttr = "table_name";
+
+export const REMOTE_DEBUGGING_ERROR_TEXT = "This information is not available due to the current value of the 'server.remote_debugging.mode' setting.";

--- a/pkg/ui/src/views/cluster/containers/nodeLogs/index.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodeLogs/index.tsx
@@ -5,7 +5,7 @@ import { connect } from "react-redux";
 
 import * as protos from "src/js/protos";
 import { NodeStatus$Properties } from "src/util/proto";
-import { nodeIDAttr } from "src/util/constants";
+import { nodeIDAttr, REMOTE_DEBUGGING_ERROR_TEXT } from "src/util/constants";
 import { LogEntriesResponseMessage } from "src/util/api";
 import { LongToMoment } from "src/util/convert";
 import { SortableTable } from "src/views/shared/components/sortabletable";
@@ -34,10 +34,27 @@ class Logs extends React.Component<LogProps & RouterState, {}> {
   }
 
   render() {
-    let content: React.ReactNode = "No data";
     const nodeAddress = this.props.currentNode
       ? this.props.currentNode.desc.address.address_field
       : null;
+
+    // TODO(couchand): This is a really myopic way to check for this particular
+    // case, but making major changes to the CachedDataReducer or util.api seems
+    // fraught at this point.  We should revisit this soon.
+    if (this.props.logs.lastError && this.props.logs.lastError.message === "Forbidden") {
+      return (
+        <div>
+          <div className="section section--heading">
+            <h2>Logs Node { this.props.params[nodeIDAttr] } / { nodeAddress }</h2>
+          </div>
+          <section className="section">
+            { REMOTE_DEBUGGING_ERROR_TEXT }
+          </section>
+        </div>
+      );
+    }
+
+    let content: React.ReactNode = "No data";
 
     if (this.props.logs.data) {
       const logEntries = _.sortBy(this.props.logs.data.entries, (e) => e.time);

--- a/pkg/ui/src/views/reports/containers/range/allocator.tsx
+++ b/pkg/ui/src/views/reports/containers/range/allocator.tsx
@@ -3,6 +3,7 @@ import React from "react";
 
 import * as protos from "src/js/protos";
 import { CachedDataReducerState } from "src/redux/cachedDataReducer";
+import { REMOTE_DEBUGGING_ERROR_TEXT } from "src/util/constants";
 import Print from "src/views/reports/containers/range/print";
 import Loading from "src/views/shared/components/loading";
 
@@ -15,6 +16,18 @@ interface AllocatorOutputProps {
 export default class AllocatorOutput extends React.Component<AllocatorOutputProps, {}> {
   render() {
     const { allocator } = this.props;
+
+    // TODO(couchand): This is a really myopic way to check for this particular
+    // case, but making major changes to the CachedDataReducer or util.api seems
+    // fraught at this point.  We should revisit this soon.
+    if (allocator.lastError && allocator.lastError.message === "Forbidden") {
+      return (
+        <div>
+          <h2>Simulated Allocator Output</h2>
+          { REMOTE_DEBUGGING_ERROR_TEXT }
+        </div>
+      );
+    }
 
     if (allocator && !_.isNil(allocator.lastError)) {
       return (


### PR DESCRIPTION
This adds an error message to clarify why there is data missing if
server.remote_debugging.mode is not permissive enough.

Fixes: #23952
Release note: None