### PR TITLE
publish-artifacts: build and upload workload binaries

### DIFF
--- a/pkg/cmd/publish-artifacts/main.go
+++ b/pkg/cmd/publish-artifacts/main.go
@@ -213,7 +213,7 @@ func main() {
 				continue
 			}
 
-			buildOne(svc, o)
+			buildOneCockroach(svc, o)
 		}
 	}
 }
@@ -258,9 +258,9 @@ func buildArchive(svc s3putter, o opts) {
 	}
 }
 
-func buildOne(svc s3putter, o opts) {
+func buildOneCockroach(svc s3putter, o opts) {
 	defer func() {
-		log.Printf("done building: %s", pretty.Sprint(o))
+		log.Printf("done building cockroach: %s", pretty.Sprint(o))
 	}()
 
 	{


### PR DESCRIPTION
As promised!

Binaries will be uploaded to https://edge-binaries.cockroachdb.com/cockroach/workload.LATEST, where LATEST can be replaced with a recent SHA from master.