### PR TITLE
cherrypick-1.1: server: Use remote_debugging setting to restrict all access to keys

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -383,6 +383,7 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 	s.admin = newAdminServer(s)
 	s.status = newStatusServer(
 		s.cfg.AmbientCtx,
+		st,
 		s.cfg.Config,
 		s.admin,
 		s.db,

--- a/pkg/server/status_test.go
+++ b/pkg/server/status_test.go
@@ -21,6 +21,7 @@ import (
 	"reflect"
 	"regexp"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -709,5 +710,116 @@ func TestRangeResponse(t *testing.T) {
 
 	if len(info.LeaseHistory) == 0 {
 		t.Error("expected at least one lease history entry")
+	}
+}
+
+func TestRemoteDebugModeSetting(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	s, db, _ := serverutils.StartServer(t, base.TestServerArgs{
+		StoreSpecs: []base.StoreSpec{
+			base.DefaultTestStoreSpec,
+			base.DefaultTestStoreSpec,
+			base.DefaultTestStoreSpec,
+		},
+	})
+	ts := s.(*TestServer)
+	defer ts.Stopper().Stop(context.TODO())
+
+	if _, err := db.Exec(`SET CLUSTER SETTING server.remote_debugging.mode = 'off'`); err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify that the remote debugging mode is respected for HTTP requests.
+	// This needs to be wrapped in SucceedsSoon because settings changes have to
+	// propagate through gossip and thus don't always take effect immediately.
+	testutils.SucceedsSoon(t, func() error {
+		for _, tc := range []struct {
+			path     string
+			response proto.Message
+		}{
+			{"gossip/local", &gossip.InfoStatus{}},
+			{"allocator/node/local", &serverpb.AllocatorResponse{}},
+			{"allocator/range/1", &serverpb.AllocatorResponse{}},
+			{"logs/local", &serverpb.LogEntriesResponse{}},
+			{"logfiles/local/cockroach.log", &serverpb.LogEntriesResponse{}},
+			{"local_sessions", &serverpb.ListSessionsResponse{}},
+			{"sessions", &serverpb.ListSessionsResponse{}},
+		} {
+			err := getStatusJSONProto(ts, tc.path, tc.response)
+			if !testutils.IsError(err, "403 Forbidden") {
+				return fmt.Errorf("expected '403 Forbidden' error, but %q returned %+v: %v",
+					tc.path, tc.response, err)
+			}
+		}
+		return nil
+	})
+
+	// But not for grpc requests. The fact that the above gets an error but these
+	// don't indicate that the grpc gateway is correctly adding the necessary
+	// metadata for differentiating between the two (and that we're correctly
+	// interpreting said metadata).
+	rootConfig := testutils.NewTestBaseContext(security.RootUser)
+	rpcContext := rpc.NewContext(
+		log.AmbientContext{Tracer: ts.ClusterSettings().Tracer}, rootConfig, ts.Clock(), ts.Stopper())
+	url := ts.ServingAddr()
+	conn, err := rpcContext.GRPCDial(url)
+	if err != nil {
+		t.Fatal(err)
+	}
+	client := serverpb.NewStatusClient(conn)
+	ctx := context.Background()
+	if _, err := client.Gossip(ctx, &serverpb.GossipRequest{}); err != nil {
+		t.Error(err)
+	}
+	if _, err := client.Allocator(ctx, &serverpb.AllocatorRequest{}); err != nil {
+		t.Error(err)
+	}
+	if _, err := client.Allocator(ctx, &serverpb.AllocatorRequest{}); err != nil {
+		t.Error(err)
+	}
+	if _, err := client.AllocatorRange(ctx, &serverpb.AllocatorRangeRequest{}); err != nil {
+		t.Error(err)
+	}
+	if _, err := client.Logs(ctx, &serverpb.LogsRequest{}); err != nil {
+		t.Error(err)
+	}
+	if _, err := client.ListLocalSessions(ctx, &serverpb.ListSessionsRequest{}); err != nil {
+		t.Error(err)
+	}
+	if _, err := client.ListSessions(ctx, &serverpb.ListSessionsRequest{}); err != nil {
+		t.Error(err)
+	}
+
+	// Check that keys are properly omitted from the Ranges and RangeLog endpoints.
+	var rangesResp serverpb.RangesResponse
+	if err := getStatusJSONProto(ts, "ranges/local", &rangesResp); err != nil {
+		t.Fatal(err)
+	}
+	if len(rangesResp.Ranges) == 0 {
+		t.Errorf("didn't get any ranges")
+	}
+	for _, ri := range rangesResp.Ranges {
+		if ri.Span.StartKey != omittedKeyStr || ri.Span.EndKey != omittedKeyStr ||
+			ri.State.ReplicaState.Desc.StartKey != nil || ri.State.ReplicaState.Desc.EndKey != nil {
+			t.Errorf("unexpected key value found in RangeInfo: %+v", ri)
+		}
+	}
+
+	var rangelogResp serverpb.RangeLogResponse
+	if err := getAdminJSONProto(ts, "rangelog", &rangelogResp); err != nil {
+		t.Fatal(err)
+	}
+	if len(rangelogResp.Events) == 0 {
+		t.Errorf("didn't get any Events")
+	}
+	for _, event := range rangelogResp.Events {
+		if event.Event.Info.NewDesc.StartKey != nil || event.Event.Info.NewDesc.EndKey != nil ||
+			event.Event.Info.UpdatedDesc.StartKey != nil || event.Event.Info.UpdatedDesc.EndKey != nil {
+			t.Errorf("unexpected key value found in rangelog event: %+v", event)
+		}
+		if strings.Contains(event.PrettyInfo.NewDesc, "Min-System") ||
+			strings.Contains(event.PrettyInfo.UpdatedDesc, "Min-System") {
+			t.Errorf("unexpected key value found in rangelog event info: %+v", event.PrettyInfo)
+		}
 	}
 }


### PR DESCRIPTION
Keys can potentially contain sensitive information, so lock down or
strip any debug endpoints that contain range start/end keys in
accordance with the server.remote_debugging.mode setting and where the
request originated.

This intentionally only applies the filtering for HTTP requests: gRPC
requests should be allowed through since they're already properly
authenticated by certificates in secure clusters.

Fixes #23555

Release note (admin ui change): More debug pages are now locked down by
the server.remote_debugging.mode cluster setting.

----------

Cherrypicks #23851 in slightly modified form (to fix merge conflicts) onto release-1.1.