### PR TITLE
*: remove unnecessary import aliases

### DIFF
--- a/pkg/config/zone_yaml.go
+++ b/pkg/config/zone_yaml.go
@@ -15,7 +15,7 @@
 package config
 
 import (
-	fmt "fmt"
+	"fmt"
 	"runtime/debug"
 	"sort"
 	"strings"

--- a/pkg/util/fast_int_map_test.go
+++ b/pkg/util/fast_int_map_test.go
@@ -15,7 +15,7 @@
 package util
 
 import (
-	fmt "fmt"
+	"fmt"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"


### PR DESCRIPTION
Goimports sometimes adds the "fmt" import as `fmt "fmt"`. Not sure why
this happens, but it's unnecessary.

Release note: None