### PR TITLE
opt/constraint: separate out Spans, generalize constraints

### DIFF
--- a/pkg/sql/opt/constraint/columns.go
+++ b/pkg/sql/opt/constraint/columns.go
@@ -14,7 +14,12 @@
 
 package constraint
 
-import "github.com/cockroachdb/cockroach/pkg/sql/opt"
+import (
+	"fmt"
+	"strings"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/opt"
+)
 
 // Columns identifies the columns which correspond to the values in a Key (and
 // consequently the columns of a Span or Constraint).
@@ -43,6 +48,8 @@ func (c *Columns) InitSingle(col opt.OrderingColumn) {
 	c.otherCols = nil
 }
 
+var _ = (*Columns).InitSingle
+
 // Count returns the number of constrained columns (always at least one).
 func (c *Columns) Count() int {
 	// There's always at least one column.
@@ -58,4 +65,14 @@ func (c *Columns) Get(nth int) opt.OrderingColumn {
 		return c.firstCol
 	}
 	return c.otherCols[nth-1]
+}
+
+func (c Columns) String() string {
+	var b strings.Builder
+
+	for i := 0; i < c.Count(); i++ {
+		b.WriteRune('/')
+		b.WriteString(fmt.Sprintf("%d", c.Get(i)))
+	}
+	return b.String()
 }

--- a/pkg/sql/opt/constraint/span.go
+++ b/pkg/sql/opt/constraint/span.go
@@ -220,7 +220,7 @@ func (sp *Span) TryIntersectWith(keyCtx KeyContext, other *Span) bool {
 // Otherwise, this span is updated to the merged span range and TryUnionWith
 // returns true. If the resulting span does not constrain the range [ - ], then
 // its IsUnconstrained method returns true, and it cannot be used as part of a
-// constraint.
+// constraint in a constraint set.
 func (sp *Span) TryUnionWith(keyCtx KeyContext, other *Span) bool {
 	if sp.immutable {
 		panic("mutation disallowed")

--- a/pkg/sql/opt/constraint/spans.go
+++ b/pkg/sql/opt/constraint/spans.go
@@ -1,0 +1,172 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package constraint
+
+import (
+	"sort"
+	"strings"
+)
+
+// Spans is a collection of spans. There are no general requirements on the
+// contents of the spans in the structure; the caller has to make sure they make
+// sense in the respective context.
+type Spans struct {
+	// firstSpan holds the first span and otherSpans hold any spans beyond the
+	// first. These are separated in order to optimize for the common case of a
+	// single-span constraint.
+	firstSpan  Span
+	otherSpans []Span
+	numSpans   int32
+	immutable  bool
+}
+
+// MakeSpans allocates enough space to support the given amount of spans without
+// reallocation.
+func MakeSpans(capacity int) Spans {
+	if capacity <= 1 {
+		return Spans{}
+	}
+	return Spans{otherSpans: make([]Span, 0, capacity-1)}
+}
+
+// SingleSpan creates Spans containing a single span.
+func SingleSpan(sp *Span) Spans {
+	return Spans{
+		firstSpan: sp.Copy(),
+		numSpans:  1,
+	}
+}
+
+// Count returns the number of spans.
+func (s *Spans) Count() int {
+	return int(s.numSpans)
+}
+
+// Get returns the nth span.
+func (s *Spans) Get(nth int) *Span {
+	if nth == 0 && s.numSpans > 0 {
+		return &s.firstSpan
+	}
+	return &s.otherSpans[nth-1]
+}
+
+// Append adds another span (at the end).
+func (s *Spans) Append(sp *Span) {
+	if s.immutable {
+		panic("mutation disallowed")
+	}
+	if s.numSpans == 0 {
+		s.firstSpan = sp.Copy()
+	} else {
+		s.otherSpans = append(s.otherSpans, sp.Copy())
+	}
+	s.numSpans++
+}
+
+// Truncate removes all but the first newLength spans.
+func (s *Spans) Truncate(newLength int) {
+	if s.immutable {
+		panic("mutation disallowed")
+	}
+	if int32(newLength) > s.numSpans {
+		panic("can't truncate to longer length")
+	}
+	if newLength == 0 {
+		s.otherSpans = s.otherSpans[:0]
+	} else {
+		s.otherSpans = s.otherSpans[:newLength-1]
+	}
+	s.numSpans = int32(newLength)
+}
+
+func (s Spans) String() string {
+	var b strings.Builder
+	for i := 0; i < s.Count(); i++ {
+		if i > 0 {
+			b.WriteRune(' ')
+		}
+		b.WriteString(s.Get(i).String())
+	}
+	return b.String()
+}
+
+// makeImmutable causes panics in any future calls to methods that mutate either
+// the Spans structure or any Span returned by Get.
+func (s *Spans) makeImmutable() {
+	s.immutable = true
+	if s.numSpans > 0 {
+		s.firstSpan.makeImmutable()
+		for i := range s.otherSpans {
+			s.otherSpans[i].makeImmutable()
+		}
+	}
+}
+
+// isSortedAndUnique returns true if the collection of spans is strictly ordered
+// (see Span.Compare).
+func (s *Spans) isSortedAndUnique(keyCtx KeyContext) bool {
+	for i := 1; i < s.Count(); i++ {
+		if s.Get(i-1).Compare(keyCtx, s.Get(i)) >= 0 {
+			return false
+		}
+	}
+	return true
+}
+
+// SortAndDedup sorts the spans (according to Span.Compare) and removes any
+// duplicates.
+func (s *Spans) SortAndDedup(keyCtx KeyContext) {
+	// In many cases (e.g spans generated from normalized tuples), the spans are
+	// already ordered. Check for that as a fast path.
+	if s.isSortedAndUnique(keyCtx) {
+		return
+	}
+	sort.Sort(&spanSorter{keyCtx: keyCtx, spans: s})
+	n := 1
+	for i := 1; i < s.Count(); i++ {
+		curr := s.Get(i)
+		if curr.Compare(keyCtx, s.Get(n-1)) != 0 {
+			if n != i {
+				*s.Get(n) = *curr
+			}
+			n++
+		}
+	}
+	s.Truncate(n)
+}
+
+type spanSorter struct {
+	keyCtx KeyContext
+	spans  *Spans
+}
+
+var _ sort.Interface = &spanSorter{}
+
+// Len is part of sort.Interface.
+func (ss *spanSorter) Len() int {
+	return ss.spans.Count()
+}
+
+// Less is part of sort.Interface.
+func (ss *spanSorter) Less(i, j int) bool {
+	return ss.spans.Get(i).Compare(ss.keyCtx, ss.spans.Get(j)) < 0
+}
+
+// Swap is part of sort.Interface.
+func (ss *spanSorter) Swap(i, j int) {
+	si := ss.spans.Get(i)
+	sj := ss.spans.Get(j)
+	*si, *sj = *sj, *si
+}

--- a/pkg/sql/opt/constraint/spans_test.go
+++ b/pkg/sql/opt/constraint/spans_test.go
@@ -1,0 +1,68 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// This file implements data structures used by index constraints generation.
+
+package constraint
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+)
+
+func TestSpans(t *testing.T) {
+	keyCtx := testKeyContext(1)
+	var s Spans
+	check := func(exp string) {
+		if actual := s.String(); actual != exp {
+			t.Errorf("expected %s, got %s", exp, actual)
+		}
+	}
+	add := func(x int) {
+		k := MakeKey(tree.NewDInt(tree.DInt(x)))
+		var span Span
+		span.Set(keyCtx, k, IncludeBoundary, k, IncludeBoundary)
+		s.Append(&span)
+	}
+	check("")
+	add(1)
+	check("[/1 - /1]")
+	add(2)
+	check("[/1 - /1] [/2 - /2]")
+	add(3)
+	check("[/1 - /1] [/2 - /2] [/3 - /3]")
+	s.Truncate(2)
+	check("[/1 - /1] [/2 - /2]")
+	s.Truncate(1)
+	check("[/1 - /1]")
+	s.Truncate(0)
+	check("")
+
+	add(3)
+	add(1)
+	add(2)
+	add(1)
+	add(4)
+	add(3)
+	s.SortAndDedup(keyCtx)
+	check("[/1 - /1] [/2 - /2] [/3 - /3] [/4 - /4]")
+	s.SortAndDedup(keyCtx)
+	check("[/1 - /1] [/2 - /2] [/3 - /3] [/4 - /4]")
+	add(4)
+	add(5)
+	add(5)
+	s.SortAndDedup(keyCtx)
+	check("[/1 - /1] [/2 - /2] [/3 - /3] [/4 - /4] [/5 - /5]")
+}

--- a/pkg/testutils/lint/testdata/errcheck_excludes.txt
+++ b/pkg/testutils/lint/testdata/errcheck_excludes.txt
@@ -7,3 +7,7 @@
 (*os.File).Close
 (io.Closer).Close
 (net.Conn).Close
+(*strings.Builder).WriteByte
+(*strings.Builder).WriteRune
+(*strings.Builder).WriteString
+(*strings.Builder).Write


### PR DESCRIPTION
The index constraints code needs to generate a single constraint.
Using Set when you have at most one constraint is tedious. Using
Constraint is also tedious because we can't represent "contradiction"
or "unconstrained".

This change relaxes the requirements on Constraint: a Constraint can
be a contradiction (0 spans) or unconstrained (a single unconstrained
span). It is illegal to have one such Constraint inside a Set.

We also separate out the spans part from Constraint and add more
functionality.

Release note: None