### PR TITLE
tscache: add kv.timestamp_cache.page_size cluster setting

### DIFF
--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -90,7 +90,7 @@ func makeTestConfig(st *cluster.Settings) Config {
 	cfg.HTTPAddr = util.TestAddr.String()
 	// Set standard user for intra-cluster traffic.
 	cfg.User = security.NodeUser
-	cfg.TimestampCachePageSize = tscache.TestSklPageSize
+	cfg.TimestampCachePageSize = tscache.TestSklPageSize()
 
 	// Enable web session authentication.
 	cfg.EnableWebSessionAuthentication = true

--- a/pkg/storage/tscache/cache.go
+++ b/pkg/storage/tscache/cache.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
@@ -85,11 +86,11 @@ type Cache interface {
 
 // New returns a new timestamp cache with the supplied hybrid clock. If the
 // pageSize is provided, it will override the default page size.
-func New(clock *hlc.Clock, pageSize uint32, metrics Metrics) Cache {
+func New(st *cluster.Settings, clock *hlc.Clock, metrics Metrics) Cache {
 	if envutil.EnvOrDefaultBool("COCKROACH_USE_TREE_TSCACHE", false) {
 		return newTreeImpl(clock)
 	}
-	return newSklImpl(clock, pageSize, metrics)
+	return newSklImpl(st, clock, metrics)
 }
 
 // cacheValue combines a timestamp with an optional txnID. It is shared between

--- a/pkg/storage/tscache/cache_test.go
+++ b/pkg/storage/tscache/cache_test.go
@@ -685,6 +685,7 @@ func BenchmarkTimestampCacheInsertion(b *testing.B) {
 	clock := hlc.NewClock(manual.UnixNano, time.Nanosecond)
 	tc := New(clock, 0, MakeMetrics())
 
+	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		cdTS := clock.Now()
 		tc.Add(roachpb.Key("c"), roachpb.Key("d"), cdTS, noTxnID, true)

--- a/pkg/storage/tscache/cache_test.go
+++ b/pkg/storage/tscache/cache_test.go
@@ -28,6 +28,7 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
@@ -38,7 +39,11 @@ import (
 
 var cacheImplConstrs = []func(clock *hlc.Clock) Cache{
 	func(clock *hlc.Clock) Cache { return newTreeImpl(clock) },
-	func(clock *hlc.Clock) Cache { return newSklImpl(clock, TestSklPageSize, MakeMetrics()) },
+	func(clock *hlc.Clock) Cache {
+		st := cluster.MakeTestingClusterSettings()
+		SklPageSize.Override(&st.SV, int64(TestSklPageSize()))
+		return newSklImpl(st, clock, MakeMetrics())
+	},
 }
 
 func forEachCacheImpl(
@@ -463,7 +468,7 @@ func TestTimestampCacheLargeKeys(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	forEachCacheImpl(t, func(t *testing.T, tc Cache, clock *hlc.Clock, manual *hlc.ManualClock) {
-		keyStart := roachpb.Key(make([]byte, 5*TestSklPageSize))
+		keyStart := roachpb.Key(make([]byte, 5*TestSklPageSize()))
 		keyEnd := keyStart.Next()
 		ts1 := clock.Now()
 		txn1 := uuid.MakeV4()
@@ -681,9 +686,10 @@ func identicalAndRatcheted(
 }
 
 func BenchmarkTimestampCacheInsertion(b *testing.B) {
+	st := cluster.MakeTestingClusterSettings()
 	manual := hlc.NewManualClock(123)
 	clock := hlc.NewClock(manual.UnixNano, time.Nanosecond)
-	tc := New(clock, 0, MakeMetrics())
+	tc := New(st, clock, MakeMetrics())
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {

--- a/pkg/storage/tscache/interval_skl_test.go
+++ b/pkg/storage/tscache/interval_skl_test.go
@@ -1176,11 +1176,16 @@ func BenchmarkIntervalSklAdd(b *testing.B) {
 	size := 1
 	for i := 0; i < 9; i++ {
 		b.Run(fmt.Sprintf("size_%d", size), func(b *testing.B) {
+			froms, tos := make([][]byte, b.N), make([][]byte, b.N)
 			for iter := 0; iter < b.N; iter++ {
 				rnd := int64(rng.Int31n(max))
-				from := []byte(fmt.Sprintf("%020d", rnd))
-				to := []byte(fmt.Sprintf("%020d", rnd+int64(size-1)))
-				s.AddRange(from, to, 0, makeVal(clock.Now(), txnID))
+				froms[iter] = []byte(fmt.Sprintf("%020d", rnd))
+				tos[iter] = []byte(fmt.Sprintf("%020d", rnd+int64(size-1)))
+			}
+
+			b.ResetTimer()
+			for iter := 0; iter < b.N; iter++ {
+				s.AddRange(froms[iter], tos[iter], 0, makeVal(clock.Now(), txnID))
 			}
 		})
 

--- a/pkg/testutils/localtestcluster/local_test_cluster.go
+++ b/pkg/testutils/localtestcluster/local_test_cluster.go
@@ -147,7 +147,7 @@ func (ltc *LocalTestCluster) Start(t testing.TB, baseCtx *base.Config, initFacto
 		/* deterministic */ false,
 	)
 	cfg.Transport = transport
-	cfg.TimestampCachePageSize = tscache.TestSklPageSize
+	cfg.TimestampCachePageSize = tscache.TestSklPageSize()
 	ltc.Store = storage.NewStore(cfg, ltc.Eng, nodeDesc)
 	ctx := context.TODO()
 


### PR DESCRIPTION
Fixes #17531.

Release note (general change): Added a new cluster setting to
control the size of the timestamp cache.