### PR TITLE
sql: improve some distsql execution errors

### DIFF
--- a/pkg/sql/distsqlrun/server.go
+++ b/pkg/sql/distsqlrun/server.go
@@ -509,8 +509,6 @@ type TestingKnobs struct {
 // ModuleTestingKnobs is part of the base.ModuleTestingKnobs interface.
 func (*TestingKnobs) ModuleTestingKnobs() {}
 
-var errEvalPlanner = errors.New("cannot backfill such evaluated expression")
-
 // Implements the tree.EvalPlanner interface by returning errors.
 type dummyEvalPlanner struct {
 }
@@ -519,32 +517,30 @@ type dummyEvalPlanner struct {
 func (ep *dummyEvalPlanner) QueryRow(
 	ctx context.Context, sql string, args ...interface{},
 ) (tree.Datums, error) {
-	return nil, errEvalPlanner
+	return nil, errors.New("QueryRow is not supported in distributed execution")
 }
 
 // Implements the tree.EvalDatabase interface.
 func (ep *dummyEvalPlanner) ParseQualifiedTableName(
 	ctx context.Context, sql string,
 ) (*tree.TableName, error) {
-	return nil, errEvalPlanner
+	return nil, errors.New("table name parsing is not supported in distributed execution")
 }
 
 // Implements the tree.EvalDatabase interface.
 func (ep *dummyEvalPlanner) ResolveTableName(ctx context.Context, tn *tree.TableName) error {
-	return errEvalPlanner
+	return errors.New("table name resolution is not supported in distributed execution")
 }
 
 // Implements the tree.EvalPlanner interface.
 func (ep *dummyEvalPlanner) ParseType(sql string) (coltypes.CastTargetType, error) {
-	return nil, errEvalPlanner
+	return nil, errors.New("column type parsing is not supported in distributed execution")
 }
 
 // Implements the tree.EvalPlanner interface.
 func (ep *dummyEvalPlanner) EvalSubquery(expr *tree.Subquery) (tree.Datum, error) {
-	return nil, errEvalPlanner
+	return nil, errors.New("subquery evaluation is not supported in distributed execution")
 }
-
-var errSequenceOperators = errors.New("cannot backfill such sequence operation")
 
 // Implements the tree.SequenceOperators interface by returning errors.
 type dummySequenceOperators struct {
@@ -554,13 +550,16 @@ type dummySequenceOperators struct {
 func (so *dummySequenceOperators) ParseQualifiedTableName(
 	ctx context.Context, sql string,
 ) (*tree.TableName, error) {
-	return nil, errSequenceOperators
+	return nil, errors.New("table name parsing is not supported in distributed execution")
 }
 
 // Implements the tree.EvalDatabase interface.
 func (so *dummySequenceOperators) ResolveTableName(ctx context.Context, tn *tree.TableName) error {
-	return errEvalPlanner
+	return errors.New("table name resolution is not supported in distributed execution")
 }
+
+var errSequenceOperators = errors.New(
+	"sequence operators are not supported in distributed execution")
 
 // Implements the tree.SequenceOperators interface.
 func (so *dummySequenceOperators) IncrementSequence(


### PR DESCRIPTION
The distsql EvalContext has a dummy EvalPlanner and SequenceOperators.
These should never get invoked since planning should avoid distsql for
queries that would require them. But if they do, due to faulty planning
(e.g. #22264), an error gets thrown, and these error messages were
somewhat cryptic. I made them more explicit.

Fixes #22264

Release note: None