### PR TITLE
backport-2.0: backupccl: fix progress tracking in restore

### DIFF
--- a/pkg/ccl/backupccl/backup_cloud_test.go
+++ b/pkg/ccl/backupccl/backup_cloud_test.go
@@ -16,14 +16,15 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws/credentials"
+
 	"github.com/cockroachdb/cockroach/pkg/ccl/storageccl"
-	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql"
+	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 )
 
-func initNone(_ *cluster.Settings) {}
+func initNone(_ *testcluster.TestCluster) {}
 
 // The tests in this file talk to remote APIs which require credentials.
 // To run these tests, you need to supply credentials via env vars (the tests


### PR DESCRIPTION
Backport 1/1 commits from #24083.

/cc @cockroachdb/release

---

The job low watermark assumes the that the key in the i'th importSpan can be
assumed done if requestsCompleted for all values <= i are true. Therefore it is
essential that that if we're marking the i'th completed we are actually the same
span -- this isn't always trivially true due to re-ordering during scatter.

In practice, this could cause the low-water-mark to be incorrectly set s.t. on
resume, ranges would be skipped that had not been completed, manifesting as missing
data in tables restored if the restore was paused and resumed or encountered a node-
liveness error that caused an internal resume.

Fixes #23977.

Release note (enterprise change): Fix issue in RESTORE that could lead to missing rows if the RESTORE was interrupted.
