### PR TITLE
opt/constraint: tweak KeyContext

### DIFF
--- a/pkg/sql/opt/constraint/constraint_set_test.go
+++ b/pkg/sql/opt/constraint/constraint_set_test.go
@@ -232,7 +232,7 @@ type spanTestData struct {
 	spGe1015 Span // [/10/15 - ]
 }
 
-func newSpanTestData(keyCtx KeyContext) *spanTestData {
+func newSpanTestData(keyCtx *KeyContext) *spanTestData {
 	data := &spanTestData{}
 
 	key10 := MakeKey(tree.NewDInt(10))
@@ -263,7 +263,7 @@ func newSpanTestData(keyCtx KeyContext) *spanTestData {
 	return data
 }
 
-func testSet(keyCtx KeyContext, sp *Span) *Set {
+func testSet(keyCtx *KeyContext, sp *Span) *Set {
 	var c Constraint
 	c.Init(keyCtx, SingleSpan(sp))
 	return SingleConstraint(c)

--- a/pkg/sql/opt/constraint/key.go
+++ b/pkg/sql/opt/constraint/key.go
@@ -104,7 +104,7 @@ func (k Key) Value(nth int) tree.Datum {
 //   (/1/2 - ...] (exclusive start key): ExtendHigh: /1/2/High
 //   [... - /1/2] (inclusive end key)  : ExtendHigh: /1/2/High
 //   [... - /1/2) (exclusive end key)  : ExtendLow : /1/2/Low
-func (k Key) Compare(keyCtx KeyContext, l Key, kext, lext KeyExtension) int {
+func (k Key) Compare(keyCtx *KeyContext, l Key, kext, lext KeyExtension) int {
 	klen := k.Length()
 	llen := l.Length()
 	for i := 0; i < klen && i < llen; i++ {
@@ -172,7 +172,7 @@ func (k Key) Concat(l Key) Key {
 //   Next(/2) = /1
 //
 // The key cannot be empty.
-func (k Key) Next(keyCtx KeyContext) (_ Key, ok bool) {
+func (k Key) Next(keyCtx *KeyContext) (_ Key, ok bool) {
 	// TODO(radu): here we could do a better job: if we know the last value is the
 	// maximum possible value, we could shorten the key; for example
 	//   Next(/1/true) -> /2
@@ -205,7 +205,7 @@ func (k Key) Next(keyCtx KeyContext) (_ Key, ok bool) {
 //   Prev(/1) = /2
 //
 // If this is the minimum possible key, returns EmptyKey.
-func (k Key) Prev(keyCtx KeyContext) (_ Key, ok bool) {
+func (k Key) Prev(keyCtx *KeyContext) (_ Key, ok bool) {
 	col := k.Length() - 1
 	prevVal, ok := keyCtx.Prev(col, k.Value(col))
 	if !ok {
@@ -236,19 +236,19 @@ func (k Key) String() string {
 
 // KeyContext contains the necessary metadata for comparing Keys.
 type KeyContext struct {
-	Columns *Columns
+	Columns Columns
 	EvalCtx *tree.EvalContext
 }
 
 // MakeKeyContext initializes a KeyContext.
 func MakeKeyContext(cols *Columns, evalCtx *tree.EvalContext) KeyContext {
-	return KeyContext{Columns: cols, EvalCtx: evalCtx}
+	return KeyContext{Columns: *cols, EvalCtx: evalCtx}
 }
 
 // Compare two values for a given column.
 // Returns 0 if the values are equal, -1 if a is less than b, or 1 if b is less
 // than a.
-func (c KeyContext) Compare(colIdx int, a, b tree.Datum) int {
+func (c *KeyContext) Compare(colIdx int, a, b tree.Datum) int {
 	cmp := a.Compare(c.EvalCtx, b)
 	if c.Columns.Get(colIdx).Descending() {
 		cmp = -cmp
@@ -258,7 +258,7 @@ func (c KeyContext) Compare(colIdx int, a, b tree.Datum) int {
 
 // Next returns the next value on a given column (for discrete types like
 // integers). See Datum.Next/Prev.
-func (c KeyContext) Next(colIdx int, val tree.Datum) (_ tree.Datum, ok bool) {
+func (c *KeyContext) Next(colIdx int, val tree.Datum) (_ tree.Datum, ok bool) {
 	if c.Columns.Get(colIdx).Ascending() {
 		if val.IsMax(c.EvalCtx) {
 			return nil, false
@@ -273,7 +273,7 @@ func (c KeyContext) Next(colIdx int, val tree.Datum) (_ tree.Datum, ok bool) {
 
 // Prev returns the previous value on a given column (for discrete types like
 // integers). See Datum.Next/Prev.
-func (c KeyContext) Prev(colIdx int, val tree.Datum) (_ tree.Datum, ok bool) {
+func (c *KeyContext) Prev(colIdx int, val tree.Datum) (_ tree.Datum, ok bool) {
 	if c.Columns.Get(colIdx).Ascending() {
 		if val.IsMin(c.EvalCtx) {
 			return nil, false

--- a/pkg/sql/opt/constraint/key_test.go
+++ b/pkg/sql/opt/constraint/key_test.go
@@ -143,7 +143,7 @@ func TestKeyNextPrev(t *testing.T) {
 
 	testCases := []struct {
 		key     Key
-		keyCtx  KeyContext
+		keyCtx  *KeyContext
 		expNext string
 		expPrev string
 	}{
@@ -232,12 +232,13 @@ func testKey(t *testing.T, k Key, expected string) {
 	}
 }
 
-func testKeyContext(cols ...opt.OrderingColumn) KeyContext {
+func testKeyContext(cols ...opt.OrderingColumn) *KeyContext {
 	st := cluster.MakeTestingClusterSettings()
 	evalCtx := tree.MakeTestingEvalContext(st)
 
 	var columns Columns
 	columns.Init(cols)
 
-	return MakeKeyContext(&columns, &evalCtx)
+	keyCtx := MakeKeyContext(&columns, &evalCtx)
+	return &keyCtx
 }

--- a/pkg/sql/opt/constraint/span.go
+++ b/pkg/sql/opt/constraint/span.go
@@ -76,7 +76,7 @@ func (sp *Span) IsUnconstrained() bool {
 //  2. Unconstrained span (should never be used in a constraint)
 //  3. Exclusive empty key boundary (use inclusive instead)
 func (sp *Span) Set(
-	keyCtx KeyContext, start Key, startBoundary SpanBoundary, end Key, endBoundary SpanBoundary,
+	keyCtx *KeyContext, start Key, startBoundary SpanBoundary, end Key, endBoundary SpanBoundary,
 ) {
 	if sp.immutable {
 		panic("mutation disallowed")
@@ -134,7 +134,7 @@ func (sp *Span) Set(
 //   (/1   - /2/1)  =  /1/High   - /2/1/Low
 //   (/1   - /2/1]  =  /1/High   - /2/1/High
 //   (/1   -     ]  =  /1/High   - /High
-func (sp *Span) Compare(keyCtx KeyContext, other *Span) int {
+func (sp *Span) Compare(keyCtx *KeyContext, other *Span) int {
 	// Span with lowest start boundary is less than the other.
 	if cmp := sp.CompareStarts(keyCtx, other); cmp != 0 {
 		return cmp
@@ -154,7 +154,7 @@ func (sp *Span) Compare(keyCtx KeyContext, other *Span) int {
 // boundaries of the two spans. The result will be 0 if the spans have the same
 // start boundary, -1 if this span has a smaller start boundary than the given
 // span, or 1 if this span has a bigger start boundary than the given span.
-func (sp *Span) CompareStarts(keyCtx KeyContext, other *Span) int {
+func (sp *Span) CompareStarts(keyCtx *KeyContext, other *Span) int {
 	return sp.start.Compare(keyCtx, other.start, sp.startExt(), other.startExt())
 }
 
@@ -162,14 +162,14 @@ func (sp *Span) CompareStarts(keyCtx KeyContext, other *Span) int {
 // of the two spans. The result will be 0 if the spans have the same end
 // boundary, -1 if this span has a smaller end boundary than the given span, or
 // 1 if this span has a bigger end boundary than the given span.
-func (sp *Span) CompareEnds(keyCtx KeyContext, other *Span) int {
+func (sp *Span) CompareEnds(keyCtx *KeyContext, other *Span) int {
 	return sp.end.Compare(keyCtx, other.end, sp.endExt(), other.endExt())
 }
 
 // StartsAfter returns true if this span is greater than the given span and
 // does not overlap it. In other words, this span's start boundary is greater
 // or equal to the given span's end boundary.
-func (sp *Span) StartsAfter(keyCtx KeyContext, other *Span) bool {
+func (sp *Span) StartsAfter(keyCtx *KeyContext, other *Span) bool {
 	return sp.start.Compare(keyCtx, other.end, sp.startExt(), other.endExt()) >= 0
 }
 
@@ -177,7 +177,7 @@ func (sp *Span) StartsAfter(keyCtx KeyContext, other *Span) bool {
 // This span is updated to only cover the range that is common to both spans.
 // If there is no overlap, then this span will not be updated, and
 // TryIntersectWith will return false.
-func (sp *Span) TryIntersectWith(keyCtx KeyContext, other *Span) bool {
+func (sp *Span) TryIntersectWith(keyCtx *KeyContext, other *Span) bool {
 	if sp.immutable {
 		panic("mutation disallowed")
 	}
@@ -221,7 +221,7 @@ func (sp *Span) TryIntersectWith(keyCtx KeyContext, other *Span) bool {
 // returns true. If the resulting span does not constrain the range [ - ], then
 // its IsUnconstrained method returns true, and it cannot be used as part of a
 // constraint in a constraint set.
-func (sp *Span) TryUnionWith(keyCtx KeyContext, other *Span) bool {
+func (sp *Span) TryUnionWith(keyCtx *KeyContext, other *Span) bool {
 	if sp.immutable {
 		panic("mutation disallowed")
 	}
@@ -272,7 +272,7 @@ func (sp *Span) TryUnionWith(keyCtx KeyContext, other *Span) bool {
 //      (/foo - /qux)  =>  [/foo\x00 - /qux).
 //  - for a decimal column, we don't have either Next or Prev so we can't
 //    change anything.
-func (sp *Span) PreferInclusive(keyCtx KeyContext) {
+func (sp *Span) PreferInclusive(keyCtx *KeyContext) {
 	if sp.immutable {
 		panic("mutation disallowed")
 	}

--- a/pkg/sql/opt/constraint/spans.go
+++ b/pkg/sql/opt/constraint/spans.go
@@ -116,7 +116,7 @@ func (s *Spans) makeImmutable() {
 
 // isSortedAndUnique returns true if the collection of spans is strictly ordered
 // (see Span.Compare).
-func (s *Spans) isSortedAndUnique(keyCtx KeyContext) bool {
+func (s *Spans) isSortedAndUnique(keyCtx *KeyContext) bool {
 	for i := 1; i < s.Count(); i++ {
 		if s.Get(i-1).Compare(keyCtx, s.Get(i)) >= 0 {
 			return false
@@ -127,13 +127,13 @@ func (s *Spans) isSortedAndUnique(keyCtx KeyContext) bool {
 
 // SortAndDedup sorts the spans (according to Span.Compare) and removes any
 // duplicates.
-func (s *Spans) SortAndDedup(keyCtx KeyContext) {
+func (s *Spans) SortAndDedup(keyCtx *KeyContext) {
 	// In many cases (e.g spans generated from normalized tuples), the spans are
 	// already ordered. Check for that as a fast path.
 	if s.isSortedAndUnique(keyCtx) {
 		return
 	}
-	sort.Sort(&spanSorter{keyCtx: keyCtx, spans: s})
+	sort.Sort(&spanSorter{keyCtx: *keyCtx, spans: s})
 	n := 1
 	for i := 1; i < s.Count(); i++ {
 		curr := s.Get(i)
@@ -161,7 +161,7 @@ func (ss *spanSorter) Len() int {
 
 // Less is part of sort.Interface.
 func (ss *spanSorter) Less(i, j int) bool {
-	return ss.spans.Get(i).Compare(ss.keyCtx, ss.spans.Get(j)) < 0
+	return ss.spans.Get(i).Compare(&ss.keyCtx, ss.spans.Get(j)) < 0
 }
 
 // Swap is part of sort.Interface.


### PR DESCRIPTION
KeyContext was being passed by value and it stored a pointer to
Columns. This causes any Columns used with it to be moved to the heap.

Changing KeyContext to store a copy of Columns, and switching to
passing KeyContext by pointer. I verified that keyCtx arguments in the
constraints code don't escape.

Release note: None