### PR TITLE
optbuilder: Fix bug with column visibility

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/orderby
+++ b/pkg/sql/opt/exec/execbuilder/testdata/orderby
@@ -737,10 +737,9 @@ sort                 0  sort    ·         ·            (c)     -c
 exec-explain
 SELECT * FROM (SELECT b, c FROM abc WHERE a=1 ORDER BY a,b) ORDER BY b,c
 ----
-render               0  render  ·         ·            (b, c, a)  ·
+render               0  render  ·         ·            (b, c)     ·
  │                   0  ·       render 0  b            ·          ·
  │                   0  ·       render 1  c            ·          ·
- │                   0  ·       render 2  a            ·          ·
  └── sort            1  sort    ·         ·            (a, b, c)  +b,+c
       │              1  ·       order     +b,+c        ·          ·
       └── filter     2  filter  ·         ·            (a, b, c)  ·
@@ -877,7 +876,7 @@ NaN
 1.0
 
 exec-explain
-SELECT * FROM (SELECT * FROM (VALUES ('a'), ('b'), ('c')) AS c(x) ORDER BY x)
+SELECT * FROM (VALUES ('a'), ('b'), ('c')) AS c(x) ORDER BY x
 ----
 sort         0  sort    ·              ·                 (x)  +x
  │           0  ·       order          +x                ·    ·
@@ -886,6 +885,15 @@ sort         0  sort    ·              ·                 (x)  +x
 ·            1  ·       row 0, expr 0  'a'               ·    ·
 ·            1  ·       row 1, expr 0  'b'               ·    ·
 ·            1  ·       row 2, expr 0  'c'               ·    ·
+
+exec-explain
+SELECT * FROM (SELECT * FROM (VALUES ('a'), ('b'), ('c')) AS c(x) ORDER BY x)
+----
+values  0  values  ·              ·                 (x)  ·
+·       0  ·       size           1 column, 3 rows  ·    ·
+·       0  ·       row 0, expr 0  'a'               ·    ·
+·       0  ·       row 1, expr 0  'b'               ·    ·
+·       0  ·       row 2, expr 0  'c'               ·    ·
 
 # TODO(radu): ordinality not supported
 #exec-explain
@@ -903,26 +911,25 @@ sort         0  sort    ·              ·                 (x)  +x
 # └── ordinality   ·      ·
 #      └── values  ·      ·
 #·                 size   1 column, 3 rows
-
-exec-explain
-SELECT * FROM (SELECT * FROM (VALUES ('a'), ('b'), ('c')) AS c(x)) WITH ORDINALITY
-----
-values  0  values  ·              ·                 (x)  ·
-·       0  ·       size           1 column, 3 rows  ·    ·
-·       0  ·       row 0, expr 0  'a'               ·    ·
-·       0  ·       row 1, expr 0  'b'               ·    ·
-·       0  ·       row 2, expr 0  'c'               ·    ·
-
-exec-explain
-SELECT * FROM (SELECT * FROM (VALUES ('a'), ('b'), ('c')) AS c(x) ORDER BY x) WITH ORDINALITY
-----
-sort         0  sort    ·              ·                 (x)  +x
- │           0  ·       order          +x                ·    ·
- └── values  1  values  ·              ·                 (x)  ·
-·            1  ·       size           1 column, 3 rows  ·    ·
-·            1  ·       row 0, expr 0  'a'               ·    ·
-·            1  ·       row 1, expr 0  'b'               ·    ·
-·            1  ·       row 2, expr 0  'c'               ·    ·
+#
+# Once ordinality is supported these test cases should have a sort node.
+#exec-explain
+#SELECT * FROM (SELECT * FROM (VALUES ('a'), ('b'), ('c')) AS c(x)) WITH ORDINALITY
+#----
+#values  0  values  ·              ·                 (x)  ·
+#·       0  ·       size           1 column, 3 rows  ·    ·
+#·       0  ·       row 0, expr 0  'a'               ·    ·
+#·       0  ·       row 1, expr 0  'b'               ·    ·
+#·       0  ·       row 2, expr 0  'c'               ·    ·
+#
+#exec-explain
+#SELECT * FROM (SELECT * FROM (VALUES ('a'), ('b'), ('c')) AS c(x) ORDER BY x) WITH ORDINALITY
+#----
+#values  0  values  ·              ·                 (x)  ·
+#·       0  ·       size           1 column, 3 rows  ·    ·
+#·       0  ·       row 0, expr 0  'a'               ·    ·
+#·       0  ·       row 1, expr 0  'b'               ·    ·
+#·       0  ·       row 2, expr 0  'c'               ·    ·
 
 # TODO(radu): DML statements not supported yet.
 ## Check that the ordering of the source does not propagate blindly to RETURNING.

--- a/pkg/sql/opt/optbuilder/scope.go
+++ b/pkg/sql/opt/optbuilder/scope.go
@@ -114,6 +114,20 @@ func (s *scope) hasSameColumns(other *scope) bool {
 	return true
 }
 
+// removeHiddenCols removes hidden columns from the scope.
+func (s *scope) removeHiddenCols() {
+	n := 0
+	for i := range s.cols {
+		if !s.cols[i].hidden {
+			if n != i {
+				s.cols[n] = s.cols[i]
+			}
+			n++
+		}
+	}
+	s.cols = s.cols[:n]
+}
+
 // getAggregateCols returns the columns in this scope corresponding
 // to aggregate functions.
 func (s *scope) getAggregateCols() []columnProps {

--- a/pkg/sql/opt/optbuilder/testdata/aggregate
+++ b/pkg/sql/opt/optbuilder/testdata/aggregate
@@ -1767,16 +1767,12 @@ SELECT CONCAT_AGG(s) FROM (SELECT s FROM kv ORDER BY k)
 group-by
  ├── columns: column5:5(string)
  ├── project
- │    ├── columns: kv.s:4(string)
- │    ├── project
- │    │    ├── columns: kv.s:4(string) kv.k:1(int!null)
- │    │    ├── scan kv
- │    │    │    └── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string)
- │    │    └── projections
- │    │         ├── variable: kv.s [type=string]
- │    │         └── variable: kv.k [type=int]
+ │    ├── columns: kv.s:4(string) kv.k:1(int!null)
+ │    ├── scan kv
+ │    │    └── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string)
  │    └── projections
- │         └── variable: kv.s [type=string]
+ │         ├── variable: kv.s [type=string]
+ │         └── variable: kv.k [type=int]
  └── aggregations
       └── function: concat_agg [type=string]
            └── variable: kv.s [type=string]
@@ -1787,16 +1783,12 @@ SELECT JSON_AGG(s) FROM (SELECT s FROM kv ORDER BY k)
 group-by
  ├── columns: column5:5(jsonb)
  ├── project
- │    ├── columns: kv.s:4(string)
- │    ├── project
- │    │    ├── columns: kv.s:4(string) kv.k:1(int!null)
- │    │    ├── scan kv
- │    │    │    └── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string)
- │    │    └── projections
- │    │         ├── variable: kv.s [type=string]
- │    │         └── variable: kv.k [type=int]
+ │    ├── columns: kv.s:4(string) kv.k:1(int!null)
+ │    ├── scan kv
+ │    │    └── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string)
  │    └── projections
- │         └── variable: kv.s [type=string]
+ │         ├── variable: kv.s [type=string]
+ │         └── variable: kv.k [type=int]
  └── aggregations
       └── function: json_agg [type=jsonb]
            └── variable: kv.s [type=string]
@@ -1807,16 +1799,12 @@ SELECT JSONB_AGG(s) FROM (SELECT s FROM kv ORDER BY k)
 group-by
  ├── columns: column5:5(jsonb)
  ├── project
- │    ├── columns: kv.s:4(string)
- │    ├── project
- │    │    ├── columns: kv.s:4(string) kv.k:1(int!null)
- │    │    ├── scan kv
- │    │    │    └── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string)
- │    │    └── projections
- │    │         ├── variable: kv.s [type=string]
- │    │         └── variable: kv.k [type=int]
+ │    ├── columns: kv.s:4(string) kv.k:1(int!null)
+ │    ├── scan kv
+ │    │    └── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string)
  │    └── projections
- │         └── variable: kv.s [type=string]
+ │         ├── variable: kv.s [type=string]
+ │         └── variable: kv.k [type=int]
  └── aggregations
       └── function: jsonb_agg [type=jsonb]
            └── variable: kv.s [type=string]

--- a/pkg/sql/opt/optbuilder/testdata/orderby
+++ b/pkg/sql/opt/optbuilder/testdata/orderby
@@ -627,7 +627,7 @@ project
            └── variable: abcd.d [type=int]
 
 build
-SELECT * FROM (SELECT * FROM (VALUES ('a'), ('b'), ('c')) AS c(x) ORDER BY x)
+SELECT * FROM (VALUES ('a'), ('b'), ('c')) AS c(x) ORDER BY x
 ----
 sort
  ├── columns: x:1(string)
@@ -640,6 +640,18 @@ sort
       │    └── const: 'b' [type=string]
       └── tuple [type=tuple{string}]
            └── const: 'c' [type=string]
+
+build
+SELECT * FROM (SELECT * FROM (VALUES ('a'), ('b'), ('c')) AS c(x) ORDER BY x)
+----
+values
+ ├── columns: x:1(string)
+ ├── tuple [type=tuple{string}]
+ │    └── const: 'a' [type=string]
+ ├── tuple [type=tuple{string}]
+ │    └── const: 'b' [type=string]
+ └── tuple [type=tuple{string}]
+      └── const: 'c' [type=string]
 
 exec-ddl
 CREATE TABLE blocks (

--- a/pkg/sql/opt/optbuilder/testdata/project
+++ b/pkg/sql/opt/optbuilder/testdata/project
@@ -201,6 +201,27 @@ SELECT rowid FROM b, c
 error: column reference "rowid" is ambiguous (candidates: b.rowid, c.rowid)
 
 build
+SELECT x, y, rowid FROM c WHERE rowid > 0
+----
+select
+ ├── columns: x:1(int) y:2(float) rowid:3(int!null)
+ ├── scan c
+ │    └── columns: c.x:1(int) c.y:2(float) c.rowid:3(int!null)
+ └── gt [type=bool]
+      ├── variable: c.rowid [type=int]
+      └── const: 0 [type=int]
+
+build
+SELECT r FROM (SELECT x, y, rowid AS r FROM c)
+----
+project
+ ├── columns: r:3(int!null)
+ ├── scan c
+ │    └── columns: c.x:1(int) c.y:2(float) c.rowid:3(int!null)
+ └── projections
+      └── variable: c.rowid [type=int]
+
+build
 SELECT rowid::string FROM b
 ----
 project
@@ -220,3 +241,28 @@ build
 SELECT CAST(x AS int[]) FROM b
 ----
 error: invalid cast: int -> INT[]
+
+exec-ddl
+CREATE TABLE abc (a INT PRIMARY KEY, b INT, c INT)
+----
+TABLE abc
+ ├── a int not null
+ ├── b int
+ ├── c int
+ └── INDEX primary
+      └── a int not null
+
+build
+SELECT c FROM (SELECT a FROM abc)
+----
+error: column name "c" not found
+
+build
+SELECT c FROM (SELECT a FROM abc ORDER BY c)
+----
+error: column name "c" not found
+
+build
+SELECT c FROM (SELECT a, b FROM abc ORDER BY c)
+----
+error: column name "c" not found


### PR DESCRIPTION
Before this fix, invalid queries such as
```
  SELECT c FROM (SELECT a FROM abc)
```
were (incorrectly) not causing an error in the optbuilder.
This commit fixes the problem by ensuring that FROM columns are
not visible outside of the subquery unless they are included
in the SELECT list.

There is an additional complexity for subqueries
with an order by clause such as
```
  SELECT c FROM (SELECT a FROM abc ORDER BY c)
```
Since column c is included in the subquery projection, it must be
hidden and removed from the scope before the names in the outer
query are resolved.

Release note: None