### PR TITLE
opt/constraints: add Implies and CutFirstColumn methods

### DIFF
--- a/pkg/sql/opt/constraint/columns.go
+++ b/pkg/sql/opt/constraint/columns.go
@@ -67,6 +67,19 @@ func (c *Columns) Get(nth int) opt.OrderingColumn {
 	return c.otherCols[nth-1]
 }
 
+// Equals returns true if the two lists of columns are identical.
+func (c *Columns) Equals(other *Columns) bool {
+	if c.Count() != other.Count() {
+		return false
+	}
+	for i := 0; i < c.Count(); i++ {
+		if c.Get(i) != other.Get(i) {
+			return false
+		}
+	}
+	return true
+}
+
 func (c Columns) String() string {
 	var b strings.Builder
 

--- a/pkg/sql/opt/constraint/constraint_set_test.go
+++ b/pkg/sql/opt/constraint/constraint_set_test.go
@@ -266,5 +266,5 @@ func newSpanTestData(keyCtx *KeyContext) *spanTestData {
 func testSet(keyCtx *KeyContext, sp *Span) *Set {
 	var c Constraint
 	c.Init(keyCtx, SingleSpan(sp))
-	return SingleConstraint(c)
+	return SingleConstraint(&c)
 }

--- a/pkg/sql/opt/constraint/key.go
+++ b/pkg/sql/opt/constraint/key.go
@@ -158,6 +158,22 @@ func (k Key) Concat(l Key) Key {
 	return Key{firstVal: k.firstVal, otherVals: vals}
 }
 
+// CutFront returns the key with the first numCols values removed.
+// Example:
+//   [/1/2 - /1/3].CutFront(1) = [/2 - /3]
+func (k Key) CutFront(numCols int) Key {
+	if numCols == 0 {
+		return k
+	}
+	if len(k.otherVals) < numCols {
+		return EmptyKey
+	}
+	return Key{
+		firstVal:  k.otherVals[numCols-1],
+		otherVals: k.otherVals[numCols:],
+	}
+}
+
 // Next returns the next key; this only works for discrete types like integers.
 // It is guaranteed that there are no  possible keys in the span
 //   ( key, Next(keu) ).

--- a/pkg/sql/opt/constraint/span.go
+++ b/pkg/sql/opt/constraint/span.go
@@ -62,6 +62,9 @@ type Span struct {
 	immutable bool
 }
 
+// UnconstrainedSpan is the span without any boundaries.
+var UnconstrainedSpan = Span{immutable: true}
+
 // IsUnconstrained is true if the span does not constrain the key range. Both
 // the start and end boundaries are empty. This is the default state of a Span
 // before Set is called. Unconstrained spans cannot be used in constraints,
@@ -171,6 +174,13 @@ func (sp *Span) CompareEnds(keyCtx *KeyContext, other *Span) int {
 // or equal to the given span's end boundary.
 func (sp *Span) StartsAfter(keyCtx *KeyContext, other *Span) bool {
 	return sp.start.Compare(keyCtx, other.end, sp.startExt(), other.endExt()) >= 0
+}
+
+// StartsStrictlyAfter returns true if this span is greater than the given span and
+// does not overlap or touch it. In other words, this span's start boundary is
+// strictly greater than the given span's end boundary.
+func (sp *Span) StartsStrictlyAfter(keyCtx *KeyContext, other *Span) bool {
+	return sp.start.Compare(keyCtx, other.end, sp.startExt(), other.endExt()) > 0
 }
 
 // TryIntersectWith finds the overlap between this span and the given span.

--- a/pkg/sql/opt/constraint/span_test.go
+++ b/pkg/sql/opt/constraint/span_test.go
@@ -349,11 +349,15 @@ func TestSpanCompareEnds(t *testing.T) {
 func TestSpanStartsAfter(t *testing.T) {
 	keyCtx := testKeyContext(1, 2)
 
-	test := func(left, right Span, expected bool) {
+	test := func(left, right Span, expected, expectedStrict bool) {
 		t.Helper()
 		if actual := left.StartsAfter(keyCtx, &right); actual != expected {
 			format := "left: %s, right: %s, expected: %v, actual: %v"
 			t.Errorf(format, left.String(), right.String(), expected, actual)
+		}
+		if actual := left.StartsStrictlyAfter(keyCtx, &right); actual != expectedStrict {
+			format := "left: %s, right: %s, expected: %v, actual: %v"
+			t.Errorf(format, left.String(), right.String(), expectedStrict, actual)
 		}
 	}
 
@@ -364,7 +368,7 @@ func TestSpanStartsAfter(t *testing.T) {
 		MakeCompositeKey(tree.DNull, tree.NewDInt(100)), IncludeBoundary,
 		MakeCompositeKey(tree.NewDString("banana"), tree.NewDInt(50)), IncludeBoundary,
 	)
-	test(banana, banana, false)
+	test(banana, banana, false, false)
 
 	// Right span's start equal to left span's end.
 	var cherry Span
@@ -373,8 +377,8 @@ func TestSpanStartsAfter(t *testing.T) {
 		MakeCompositeKey(tree.NewDString("banana"), tree.NewDInt(50)), ExcludeBoundary,
 		MakeKey(tree.NewDString("cherry")), ExcludeBoundary,
 	)
-	test(banana, cherry, false)
-	test(cherry, banana, true)
+	test(banana, cherry, false, false)
+	test(cherry, banana, true, false)
 
 	// Right span's start greater than left span's end, and inverse.
 	var cherry2 Span
@@ -383,8 +387,8 @@ func TestSpanStartsAfter(t *testing.T) {
 		MakeCompositeKey(tree.NewDString("cherry"), tree.NewDInt(0)), IncludeBoundary,
 		MakeKey(tree.NewDString("mango")), ExcludeBoundary,
 	)
-	test(cherry, cherry2, false)
-	test(cherry2, cherry, true)
+	test(cherry, cherry2, false, false)
+	test(cherry2, cherry, true, true)
 }
 
 func TestSpanIntersect(t *testing.T) {


### PR DESCRIPTION
Implies checks if a constraint is implied by ("included" in) another
one. Also some misc cleanup.

CutFirstColumn cuts out the first column and tries to deduce a
constraint on the remaining columns.

Both primitives are used during filter simplification after index
constraints.

Release note: None