### PR TITLE
build: add bors.toml

### DIFF
--- a/bors.toml
+++ b/bors.toml
@@ -1,0 +1,6 @@
+status = [
+  "GitHub CI (Cockroach)"
+]
+block_labels = [
+  "do-not-merge"
+]


### PR DESCRIPTION
Teaches Bors to wait for a successful build on TeamCity before merging approved PRs to master.

Contributes to #22499
Release note (build change): Begin using Bors to automate merging PRs to master.