### PR TITLE
importccl: Fix flaky TestImportLivenessWithLeniency

### DIFF
--- a/pkg/ccl/importccl/csv_test.go
+++ b/pkg/ccl/importccl/csv_test.go
@@ -1338,10 +1338,15 @@ func TestImportLivenessWithLeniency(t *testing.T) {
 		WallTime: hlc.UnixNano() - (15 * time.Second).Nanoseconds(),
 	})
 
-	// Wait for the registry cancel loop to run and cancel the job.
+	// Wait for the registry cancel loop to run and not cancel the job.
 	<-nl.SelfCalledCh
 	<-nl.SelfCalledCh
 	close(allowResponse)
+
+	// Set the node to be fully live again.  This prevents the registry
+	// from canceling all of the jobs if the test node is saturated
+	// and the import runs slowly.
+	nl.FakeSetExpiration(1, hlc.MaxTimestamp)
 
 	// Verify that the client didn't see anything amiss.
 	if err := <-errCh; err != nil {


### PR DESCRIPTION
There are intermittent test failures when the builder node appears to be
saturated and the import job takes more than one minute to complete.  The
registry detects that it has exceeded its own leniency period and cancels all
of its running jobs since the liveness data is frozen in time.  This resets the
node to be always-live once we've verified that the scheduling loop has run and
decided not to cancel the job.

Release note: None