### PR TITLE
client: set OrigTimestampWasObserved for AS OF SYSTEM TIME queries

### DIFF
--- a/pkg/internal/client/txn.go
+++ b/pkg/internal/client/txn.go
@@ -1187,13 +1187,8 @@ func (txn *Txn) SetFixedTimestamp(ctx context.Context, ts hlc.Timestamp) {
 	txn.mu.Proto.Timestamp = ts
 	txn.mu.Proto.OrigTimestamp = ts
 	txn.mu.Proto.MaxTimestamp = ts
+	txn.mu.Proto.OrigTimestampWasObserved = true
 	txn.mu.Unlock()
-	// The deadline-checking code checks that the `Timestamp` field of the proto
-	// hasn't exceeded the deadline. Since we set the Timestamp field each retry,
-	// it won't ever exceed the deadline, and thus setting the deadline here is
-	// not strictly needed. However, it doesn't do anything incorrect and it will
-	// possibly find problems if things change in the future, so it is left in.
-	txn.UpdateDeadlineMaybe(ctx, ts)
 }
 
 // GenerateForcedRetryableError returns a HandledRetryableTxnError that will


### PR DESCRIPTION
this eliminates the need to set the deadline for such queries.
I'd like to us eventually move to a model where we never need to set
a deadline for a transaction.

Release note: None