### PR TITLE
vendor: Upgrade Azure client code.

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -16,9 +16,12 @@
 
 [[projects]]
   name = "github.com/Azure/azure-sdk-for-go"
-  packages = ["storage"]
-  revision = "509eea43b93cec2f3f17acbe2578ef58703923f8"
-  version = "v11.1.1-beta"
+  packages = [
+    "storage",
+    "version",
+  ]
+  revision = "e67cd39e942c417ae5e9ae1165f778d9fe8996e0"
+  version = "v14.5.0"
 
 [[projects]]
   branch = "master"
@@ -37,8 +40,8 @@
     "autorest/azure",
     "autorest/date",
   ]
-  revision = "e90eb98af76c8cf5684aa79ecc8abce90afe484a"
-  version = "v9.2.0"
+  revision = "0ae36a9e544696de46fdadb7b0d5fb38af48c063"
+  version = "v10.2.0"
 
 [[projects]]
   branch = "parse-constraints-with-dash-in-pre"
@@ -740,6 +743,12 @@
   version = "v0.15.0"
 
 [[projects]]
+  name = "github.com/marstr/guid"
+  packages = ["."]
+  revision = "8bd9a64bf37eb297b492a4101fb28e80ac0b290f"
+  version = "v1.1.0"
+
+[[projects]]
   name = "github.com/marusama/semaphore"
   packages = ["."]
   revision = "567f17206eaa3f28bd73e209620e2abaa65d7405"
@@ -952,12 +961,6 @@
   packages = ["."]
   revision = "f58768cc1a7a7e77a3bd49e98cdd21419399b6a3"
   version = "v1.2.0"
-
-[[projects]]
-  name = "github.com/satori/uuid"
-  packages = ["."]
-  revision = "879c5887cd475cd7864858769793b2ceb0d44feb"
-  version = "v1.1.0"
 
 [[projects]]
   branch = "master"
@@ -1229,6 +1232,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "8bda46b35139d318b4fda9ba890f573323a93a9343efc84052094710c1ba59ec"
+  inputs-digest = "b468a68dc5e8ba7c498994d66a80fbe0ef7fccd7206a39fd03c407a116663161"
   solver-name = "gps-cdcl"
   solver-version = 1


### PR DESCRIPTION
This upgrades the Azure sdk to v14.5.0 and the associated go-autorest support
library to 10.2.0.

The associated vendor commit is at:
https://github.com/cockroachdb/vendored/commit/7b6d381e31118df7e68464ea4c331c0a07516a51

Resolves #24060

Release note: None