### PR TITLE
roachpb: fix error in resume reason while combining ResponseHeaders

### DIFF
--- a/pkg/kv/dist_sender.go
+++ b/pkg/kv/dist_sender.go
@@ -795,7 +795,7 @@ func (ds *DistSender) divideAndSendBatchToRanges(
 				pErr.UpdateTxn(br.Txn)
 			}
 			// If this is a write batch with any successful responses, but
-			// we're ultimately returning an error, wrap the error with an
+			// we're ultimately returning an error, wrap the error with a
 			// MixedSuccessError.
 			if hadSuccess && ba.IsWrite() {
 				pErr = roachpb.NewError(&roachpb.MixedSuccessError{Wrapped: pErr})

--- a/pkg/roachpb/api.go
+++ b/pkg/roachpb/api.go
@@ -236,6 +236,7 @@ func (rh *ResponseHeader) combine(otherRH ResponseHeader) error {
 		panic(fmt.Sprintf("combining %+v with %+v", rh.ResumeSpan, otherRH.ResumeSpan))
 	}
 	rh.ResumeSpan = otherRH.ResumeSpan
+	rh.ResumeReason = otherRH.ResumeReason
 	rh.NumKeys += otherRH.NumKeys
 	rh.RangeInfos = append(rh.RangeInfos, otherRH.RangeInfos...)
 	return nil


### PR DESCRIPTION
This doesn't include a unittest because I could simply not figure out
how the problem is still possible given the current code. However,
the fix in this PR does address a problem in the combination of responses
which prevented the `ResumeReason` from being properly combined.
There are plenty of unittests already in `kv/dist_sender_server_test.go`
which exercise this code path, and demonstrate also that while this bug
has existed for a long time, the code in `kv/dist_sender.go`, specifically
in `fillSkippedResponses`, papers over the problem by resetting the
`ResumeReason` appropriately.

Because the fix is so suggestive, I'm going to tentatively close the
issue reported by sentry. If it crops up again, we can reopen.

Fixes #22370

Release note: None