### PR TITLE
roachpb: enforce checksum optionality, add Value.EqualData method

### DIFF
--- a/pkg/config/system.go
+++ b/pkg/config/system.go
@@ -53,7 +53,7 @@ func (s SystemConfig) Equal(other SystemConfig) bool {
 			return false
 		}
 		leftVal, rightVal := leftKV.Value, rightKV.Value
-		if !bytes.Equal(leftVal.RawBytes, rightVal.RawBytes) {
+		if !leftVal.EqualData(rightVal) {
 			return false
 		}
 		if leftVal.Timestamp != rightVal.Timestamp {

--- a/pkg/gossip/util.go
+++ b/pkg/gossip/util.go
@@ -83,7 +83,7 @@ func (df *SystemConfigDeltaFilter) ForModified(
 				// Deleted key.
 				lastIdx++
 			case 0:
-				if !bytes.Equal(newKV.Value.RawBytes, oldKV.Value.RawBytes) {
+				if !newKV.Value.EqualData(oldKV.Value) {
 					// Modified value.
 					fn(newKV)
 				}

--- a/pkg/roachpb/data.go
+++ b/pkg/roachpb/data.go
@@ -326,6 +326,18 @@ func (v Value) dataBytes() []byte {
 	return v.RawBytes[headerSize:]
 }
 
+// EqualData returns a boolean reporting whether the receiver and the parameter
+// have equivalent byte values. This check ignores the optional checksum field
+// in the Values' byte slices, returning only whether the Values have the same
+// tag and encoded data.
+//
+// This method should be used whenever the raw bytes of two Values are being
+// compared instead of comparing the RawBytes slices directly because it ignores
+// the checksum header, which is optional.
+func (v Value) EqualData(o Value) bool {
+	return bytes.Equal(v.RawBytes[checksumSize:], o.RawBytes[checksumSize:])
+}
+
 // SetBytes sets the bytes and tag field of the receiver and clears the checksum.
 func (v *Value) SetBytes(b []byte) {
 	v.RawBytes = make([]byte, headerSize+len(b))

--- a/pkg/roachpb/data_test.go
+++ b/pkg/roachpb/data_test.go
@@ -210,6 +210,71 @@ func TestIsPrev(t *testing.T) {
 	}
 }
 
+func TestValueDataEquals(t *testing.T) {
+	strVal := func(s string) *Value {
+		var v Value
+		v.SetString(s)
+		return &v
+	}
+
+	a := strVal("val1")
+
+	b := strVal("val1")
+	b.InitChecksum([]byte("key1"))
+
+	c := strVal("val1")
+	c.InitChecksum([]byte("key2"))
+
+	// Different values.
+	d := strVal("val2")
+
+	e := strVal("val2")
+	e.InitChecksum([]byte("key1"))
+
+	// Different tags.
+	f := strVal("val1")
+	f.setTag(ValueType_INT)
+
+	g := strVal("val1")
+	g.setTag(ValueType_INT)
+	g.InitChecksum([]byte("key1"))
+
+	for i, tc := range []struct {
+		v1, v2 *Value
+		eq     bool
+	}{
+		{v1: a, v2: b, eq: true},
+		{v1: a, v2: c, eq: true},
+		{v1: a, v2: d, eq: false},
+		{v1: a, v2: e, eq: false},
+		{v1: a, v2: f, eq: false},
+		{v1: a, v2: g, eq: false},
+		{v1: b, v2: c, eq: true},
+		{v1: b, v2: d, eq: false},
+		{v1: b, v2: e, eq: false},
+		{v1: b, v2: f, eq: false},
+		{v1: b, v2: g, eq: false},
+		{v1: c, v2: d, eq: false},
+		{v1: c, v2: e, eq: false},
+		{v1: c, v2: f, eq: false},
+		{v1: c, v2: g, eq: false},
+		{v1: d, v2: e, eq: true},
+		{v1: d, v2: f, eq: false},
+		{v1: d, v2: g, eq: false},
+		{v1: e, v2: f, eq: false},
+		{v1: e, v2: g, eq: false},
+		{v1: f, v2: g, eq: true},
+	} {
+		if tc.eq != tc.v1.EqualData(*tc.v2) {
+			t.Errorf("%d: wanted eq=%t", i, tc.eq)
+		}
+		// Test symmetry.
+		if tc.eq != tc.v2.EqualData(*tc.v1) {
+			t.Errorf("%d: wanted eq=%t", i, tc.eq)
+		}
+	}
+}
+
 func TestValueChecksumEmpty(t *testing.T) {
 	k := []byte("key")
 	v := Value{}

--- a/pkg/sql/sqlbase/rowfetcher.go
+++ b/pkg/sql/sqlbase/rowfetcher.go
@@ -1090,10 +1090,10 @@ func (rf *RowFetcher) checkSecondaryIndexDatumEncodings(ctx context.Context) err
 			return scrub.WrapError(scrub.IndexKeyDecodingError, errors.Errorf(
 				"secondary index key failed to round-trip encode. expected %#v, got: %#v",
 				rf.rowReadyTable.lastKV.Key, indexEntry.Key))
-		} else if !bytes.Equal(indexEntry.Value.RawBytes[4:], table.lastKV.Value.RawBytes[4:]) {
+		} else if !indexEntry.Value.EqualData(table.lastKV.Value) {
 			return scrub.WrapError(scrub.IndexValueDecodingError, errors.Errorf(
 				"secondary index value failed to round-trip encode. expected %#v, got: %#v",
-				rf.rowReadyTable.lastKV.Value.RawBytes[4:], indexEntry.Value.RawBytes[4:]))
+				rf.rowReadyTable.lastKV.Value, indexEntry.Value))
 		}
 	}
 	return nil

--- a/pkg/sql/sqlbase/rowwriter.go
+++ b/pkg/sql/sqlbase/rowwriter.go
@@ -866,7 +866,7 @@ func (ru *RowUpdater) UpdateRow(
 				log.VEventf(ctx, 2, "Del %s", keys.PrettyPrint(ru.Helper.secIndexValDirs[i], oldSecondaryIndexEntry.Key))
 			}
 			batch.Del(oldSecondaryIndexEntry.Key)
-		} else if !bytes.Equal(newSecondaryIndexEntry.Value.RawBytes, oldSecondaryIndexEntry.Value.RawBytes) {
+		} else if !newSecondaryIndexEntry.Value.EqualData(oldSecondaryIndexEntry.Value) {
 			expValue = &oldSecondaryIndexEntry.Value
 		} else {
 			continue

--- a/pkg/storage/engine/mvcc.go
+++ b/pkg/storage/engine/mvcc.go
@@ -1460,7 +1460,7 @@ func mvccConditionalPutUsingIter(
 		func(existVal *roachpb.Value) ([]byte, error) {
 			if expValPresent, existValPresent := expVal != nil, existVal.IsPresent(); expValPresent && existValPresent {
 				// Every type flows through here, so we can't use the typed getters.
-				if !bytes.Equal(expVal.RawBytes, existVal.RawBytes) {
+				if !expVal.EqualData(*existVal) {
 					return nil, &roachpb.ConditionFailedError{
 						ActualValue: existVal.ShallowClone(),
 					}
@@ -1531,7 +1531,7 @@ func mvccInitPutUsingIter(
 				return nil, &roachpb.ConditionFailedError{ActualValue: existVal.ShallowClone()}
 			}
 			if existVal.IsPresent() {
-				if !bytes.Equal(value.RawBytes, existVal.RawBytes) {
+				if !value.EqualData(*existVal) {
 					return nil, &roachpb.ConditionFailedError{
 						ActualValue: existVal.ShallowClone(),
 					}


### PR DESCRIPTION
Fixes #23984.
Fixes #22636.

In #22636 we noticed that conditional puts were not respecting the fact
that Value checksums are meant to be optional. This is because they include
checksums when performing the equality check between expected and existing
values. This caused serious issues and forced us to roll back 75cbeb8.
This was unfortunate, but the damage was contained. It demonstrated that
we need to be very careful about changing checksums on values.

Later, we found in #23984 that a path somewhere in IMPORT was forgetting
to set checksums on Values. This was causing SQL operations at a much later
time to fail for the same reason that 75cbeb8 caused issues. This bug will
be fixed in a different change, but the fact that it exists shows how
fragile the current approach is because despite the intention, checksums
are absolutely not optional.

This change addresses both of these problems by making checksums optional,
as they were intended to be. CPut and InitPut no longer compare the checksums
of the expected and existing values. Instead, they call into a new `EqualData`
method, which ignores the checksum header when comparing byte values.

This is a bit higher risk than most of the changes we've been accepting at
this stage of the release cycle, but it would be really nice to get this
change in to 2.0 so that we can stay on track with the timeline proposed
in https://github.com/cockroachdb/cockroach/issues/22636#issuecomment-365323962
(although I'm not positive that the last step of the timeline is correct
because I don't think we can rely on the "baked in" protection with such
a low-level change). It will also save anyone who has used IMPORT already
and hit #22636.

This change should be safe from beneath Raft inconsistency for the same
reason that 75cbeb8 was safe. All CPuts beneath Raft are still careful
to set checksums, so we should not see any divergence in Raft state
because of this error handling change.

After this change, the only uses of `bytes.Equal(v1.RawBytes, v2.RawBytes)`
are in tests and the `value.Equal` method. There may be an argument for
making even `value.Equal` ignore the checksum header, although it isn't
used outside of other `proto.Equal` methods.
```
Nathans-MacBook-Pro:cockroach$ grep -lRE 'bytes\.Equal\(.*\.RawBytes,*,.*\.RawBytes,*\)' pkg
pkg/roachpb/data.pb.go
pkg/storage/engine/mvcc_test.go
```

Release note: None