### PR TITLE
storage: improve use of observed tstamps to limit uncertainty restarts

### DIFF
--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -2765,9 +2765,9 @@ func (s *Store) Send(
 		// updating the top end of our uncertainty timestamp would lead to a
 		// restart (at least in the absence of a prior observed timestamp from
 		// this node, in which case the following is a no-op).
-		if now.Less(ba.Txn.MaxTimestamp) {
+		if _, ok := ba.Txn.GetObservedTimestamp(ba.Replica.NodeID); !ok {
 			shallowTxn := *ba.Txn
-			shallowTxn.MaxTimestamp.Backward(now)
+			shallowTxn.UpdateObservedTimestamp(ba.Replica.NodeID, now)
 			ba.Txn = &shallowTxn
 		}
 	}

--- a/pkg/storage/stores.go
+++ b/pkg/storage/stores.go
@@ -189,28 +189,6 @@ func (ls *Stores) Send(
 		return nil, roachpb.NewError(err)
 	}
 
-	if ba.Txn != nil {
-		// For calls that read data within a txn, we keep track of timestamps
-		// observed from the various participating nodes' HLC clocks. If we have
-		// a timestamp on file for this Node which is smaller than MaxTimestamp,
-		// we can lower MaxTimestamp accordingly. If MaxTimestamp drops below
-		// OrigTimestamp, we effectively can't see uncertainty restarts any
-		// more.
-		// Note that it's not an issue if MaxTimestamp propagates back out to
-		// the client via a returned Transaction update - when updating a Txn
-		// from another, the larger MaxTimestamp wins.
-		if maxTS, ok := ba.Txn.GetObservedTimestamp(ba.Replica.NodeID); ok && maxTS.Less(ba.Txn.MaxTimestamp) {
-			// Copy-on-write to protect others we might be sharing the Txn with.
-			shallowTxn := *ba.Txn
-			// The uncertainty window is [OrigTimestamp, maxTS), so if that window
-			// is empty, there won't be any uncertainty restarts.
-			if !ba.Txn.OrigTimestamp.Less(maxTS) {
-				log.Event(ctx, "read has no clock uncertainty")
-			}
-			shallowTxn.MaxTimestamp.Backward(maxTS)
-			ba.Txn = &shallowTxn
-		}
-	}
 	br, pErr := store.Send(ctx, ba)
 	if br != nil && br.Error != nil {
 		panic(roachpb.ErrorUnexpectedlySet(store, br))


### PR DESCRIPTION
This change relocates the logic for using observed timestamps to affect
a transaction's `MaxTimestamp` field in order to avoid uncertainty
restarts. This was previously done in `storage.Stores.Send`, but is now
moved to `storage.Replica.executeReadOnlyBatch` and
`storage.Replica.tryExecuteWriteBatch` in order to use information from
the replica's lease to avoiding failing to read a value written in
absolute time before the txn started, but at a higher timestamp than
the timestamp observed at the node which now owns the replica lease.

Fixes #23749

Release note: None