### PR TITLE
importccl: set roachpb.Value checksums when creating data

### DIFF
--- a/pkg/ccl/importccl/csv.go
+++ b/pkg/ccl/importccl/csv.go
@@ -662,6 +662,7 @@ func convertRecord(
 			if err := ri.InsertRow(
 				ctx,
 				inserter(func(kv roachpb.KeyValue) {
+					kv.Value.InitChecksum(kv.Key)
 					kvBatch = append(kvBatch, kv)
 				}),
 				row,

--- a/pkg/ccl/importccl/csv_test.go
+++ b/pkg/ccl/importccl/csv_test.go
@@ -1358,3 +1358,32 @@ func TestImportLivenessWithLeniency(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+// TestImportMVCCChecksums verifies that MVCC checksums are correctly
+// computed by issuing a secondary index change that runs a CPut on the
+// index. See #23984.
+func TestImportMVCCChecksums(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	s, db, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	ctx := context.Background()
+	defer s.Stopper().Stop(ctx)
+	sqlDB := sqlutils.MakeSQLRunner(db)
+
+	sqlDB.Exec(t, `CREATE DATABASE d`)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "GET" {
+			fmt.Fprint(w, "1,1,1")
+		}
+	}))
+	defer srv.Close()
+
+	sqlDB.Exec(t, `IMPORT TABLE d.t (
+		a INT PRIMARY KEY,
+		b INT,
+		c INT,
+		INDEX (b) STORING (c)
+	) CSV DATA ($1)`, srv.URL)
+	sqlDB.Exec(t, `UPDATE d.t SET c = 2 WHERE a = 1`)
+}


### PR DESCRIPTION
IMPORT was not setting value checksums when generating KV pairs from
CSV rows. This results in CPuts on, for example, secondary indexes
failing because the checksum doesn't match.

Fixes #23984

Release note (bug fix): correctly generate on-disk checksums during
IMPORT. If there is existing data created by IMPORT that cannot
be recreated by this fixed version of IMPORT, use `cockroach dump`
to rewrite any affected tables.