### PR TITLE
opt/constraints: add Combine primitive

### DIFF
--- a/pkg/sql/opt/constraint/columns.go
+++ b/pkg/sql/opt/constraint/columns.go
@@ -80,6 +80,31 @@ func (c *Columns) Equals(other *Columns) bool {
 	return true
 }
 
+// IsStrictSuffixOf returns true if the columns in c are a strict suffix of the
+// columns in other.
+func (c *Columns) IsStrictSuffixOf(other *Columns) bool {
+	offset := other.Count() - c.Count()
+	if offset <= 0 {
+		return false
+	}
+	if c.firstCol != other.otherCols[offset-1] {
+		return false
+	}
+	// Fast path when the slices are aliased.
+	if len(c.otherCols) == 0 || &c.otherCols[0] == &other.otherCols[offset] {
+		return true
+	}
+	cmpCols := other.otherCols[offset:]
+	// Hint for the compiler to eliminate the bound check inside the loop.
+	cmpCols = cmpCols[:len(c.otherCols)]
+	for i, v := range c.otherCols {
+		if v != cmpCols[i] {
+			return false
+		}
+	}
+	return true
+}
+
 func (c Columns) String() string {
 	var b strings.Builder
 

--- a/pkg/sql/opt/constraint/utils_test.go
+++ b/pkg/sql/opt/constraint/utils_test.go
@@ -1,0 +1,117 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package constraint
+
+import (
+	"strconv"
+	"strings"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/opt"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+)
+
+// parseConstraint parses a constraint in the format of Constraint.String, e.g:
+//   "/1/2/3: [/1 - /2]".
+func parseConstraint(evalCtx *tree.EvalContext, str string) Constraint {
+	s := strings.SplitN(str, ": ", 2)
+	if len(s) != 2 {
+		panic(str)
+	}
+	var cols []opt.OrderingColumn
+	for _, v := range parsePath(s[0]) {
+		cols = append(cols, opt.OrderingColumn(v))
+	}
+	var c Constraint
+	c.Columns.Init(cols)
+	c.Spans = parseSpans(&KeyContext{Columns: c.Columns, EvalCtx: evalCtx}, s[1])
+	return c
+}
+
+// parseSpans parses a list of spans with integer values like:
+//   "[/1 - /2] [/5 - /6]".
+func parseSpans(keyCtx *KeyContext, str string) Spans {
+	if str == "" {
+		return Spans{}
+	}
+	s := strings.Split(str, " ")
+	// Each span has three pieces.
+	if len(s)%3 != 0 {
+		panic(str)
+	}
+	var result Spans
+	for i := 0; i < len(s)/3; i++ {
+		sp := parseSpan(keyCtx, strings.Join(s[i*3:i*3+3], " "))
+		result.Append(&sp)
+	}
+	return result
+}
+
+// parses a span with integer column values in the format of Span.String,
+// e.g: [/1 - /2].
+func parseSpan(keyCtx *KeyContext, str string) Span {
+	if len(str) < len("[ - ]") {
+		panic(str)
+	}
+	boundary := map[byte]SpanBoundary{
+		'[': IncludeBoundary,
+		']': IncludeBoundary,
+		'(': ExcludeBoundary,
+		')': ExcludeBoundary,
+	}
+	s, e := str[0], str[len(str)-1]
+	if (s != '[' && s != '(') || (e != ']' && e != ')') {
+		panic(str)
+	}
+	keys := strings.Split(str[1:len(str)-1], " - ")
+	if len(keys) != 2 {
+		panic(str)
+	}
+	var sp Span
+	startVals := intsToDatums(parsePath(keys[0]))
+	endVals := intsToDatums(parsePath(keys[1]))
+	sp.Set(
+		keyCtx,
+		MakeCompositeKey(startVals...), boundary[s],
+		MakeCompositeKey(endVals...), boundary[e],
+	)
+	return sp
+}
+
+func intsToDatums(vals []int) []tree.Datum {
+	r := make([]tree.Datum, len(vals))
+	for i, v := range vals {
+		r[i] = tree.NewDInt(tree.DInt(v))
+	}
+	return r
+}
+
+// parsePath parses a string like "/1/2/3" into a list of integers.
+func parsePath(str string) []int {
+	if str == "" {
+		return nil
+	}
+	if str[0] != '/' {
+		panic(str)
+	}
+	var res []int
+	for _, valStr := range strings.Split(str, "/")[1:] {
+		val, err := strconv.Atoi(valStr)
+		if err != nil {
+			panic(err)
+		}
+		res = append(res, val)
+	}
+	return res
+}


### PR DESCRIPTION
Combine takes constraints on columns `/a/b/c/d`, `/b/c/d`, `/c/d`, `/d` and
tries to make a refined constraint on `/a/b/c/d`. For example for
`a = 1 AND b > 2` we would have constraints `/a/b: [/1 - /1]` and
`/b: [/2 - ]` which we can combine into `/a/b: [/1/2 - /1]`.

Release note: None