### PR TITLE
opt: Combine PrimaryIndex and SecondaryIndexes in opt.Table

### DIFF
--- a/pkg/sql/opt/testutils/test_catalog.go
+++ b/pkg/sql/opt/testutils/test_catalog.go
@@ -58,10 +58,9 @@ func (tc *TestCatalog) AddTable(tbl *TestTable) {
 
 // TestTable implements the opt.Table interface for testing purposes.
 type TestTable struct {
-	Name             string
-	Columns          []*TestColumn
-	PrimaryIndex     *TestIndex
-	SecondaryIndexes []*TestIndex
+	Name    string
+	Columns []*TestColumn
+	Indexes []*TestIndex
 }
 
 var _ opt.Table = &TestTable{}
@@ -87,19 +86,14 @@ func (tt *TestTable) Column(i int) opt.Column {
 	return tt.Columns[i]
 }
 
-// Primary is part of the opt.Table interface.
-func (tt *TestTable) Primary() opt.Index {
-	return tt.PrimaryIndex
+// IndexCount is part of the opt.Table interface.
+func (tt *TestTable) IndexCount() int {
+	return len(tt.Indexes)
 }
 
-// SecondaryCount is part of the opt.Table interface.
-func (tt *TestTable) SecondaryCount() int {
-	return len(tt.SecondaryIndexes)
-}
-
-// Secondary is part of the opt.Table interface.
-func (tt *TestTable) Secondary(i int) opt.Index {
-	return tt.SecondaryIndexes[i]
+// Index is part of the opt.Table interface.
+func (tt *TestTable) Index(i int) opt.Index {
+	return tt.Indexes[i]
 }
 
 // FindOrdinal returns the ordinal of the column with the given name.
@@ -119,7 +113,10 @@ type TestIndex struct {
 
 	// Unique is the number of columns that make up the unique key for the
 	// index. The columns are always a non-empty prefix of the Columns
-	// collection, so Unique is > 0 and < len(Columns). Note that
+	// collection, so Unique is > 0 and < len(Columns). Note that this is even
+	// true for indexes that were not declared as unique, since primary key
+	// columns will be implicitly added to the index in order to ensure it is
+	// always unique.
 	Unique int
 }
 

--- a/pkg/sql/opt/xform/physical_props_factory.go
+++ b/pkg/sql/opt/xform/physical_props_factory.go
@@ -102,7 +102,7 @@ func (f physicalPropsFactory) canProvideOrdering(eid memo.ExprID, required memo.
 	case opt.ScanOp:
 		// Scan naturally orders according to the primary index.
 		def := mexpr.Private(f.mem).(*memo.ScanOpDef)
-		primary := f.mem.Metadata().Table(def.Table).Primary()
+		primary := f.mem.Metadata().Table(def.Table).Index(opt.PrimaryIndex)
 
 		// The scan can provide the required ordering in either of these cases:
 		// 1. The required columns are a prefix of the primary index columns.

--- a/pkg/sql/opt_catalog.go
+++ b/pkg/sql/opt_catalog.go
@@ -107,19 +107,21 @@ func (ot *optTable) Column(i int) opt.Column {
 	return &ot.desc.Columns[i]
 }
 
-// Primary is part of the opt.Table interface.
-func (ot *optTable) Primary() opt.Index {
-	return &ot.primary
+// IndexCount is part of the opt.Table interface.
+func (ot *optTable) IndexCount() int {
+	// Primary index is always present, so count is always >= 1.
+	return 1 + len(ot.desc.Indexes)
 }
 
-// SecondaryCount is part of the opt.Table interface.
-func (ot *optTable) SecondaryCount() int {
-	return len(ot.desc.Indexes)
-}
+// Index is part of the opt.Table interface.
+func (ot *optTable) Index(i int) opt.Index {
+	// Primary index is always 0th index.
+	if i == opt.PrimaryIndex {
+		return &ot.primary
+	}
 
-// Secondary is part of the opt.Table interface.
-func (ot *optTable) Secondary(i int) opt.Index {
-	desc := &ot.desc.Indexes[i]
+	// Bias i to account for lack of primary index in Indexes slice.
+	desc := &ot.desc.Indexes[i-1]
 
 	// Check to see if there's already a wrapper for this index descriptor.
 	if ot.wrappers == nil {


### PR DESCRIPTION
Before, we had separate methods to fetch metadata for the primary index
vs. the secondary indexes. This means that code that needs to enumerate
all indexes needs to special-case the primary index. This PR combines
all indexes into a single Index collection so that they're more
convenient to access for upcoming index selection PR's.

Release note: None