### PR TITLE
opt: Rename TableIndex to TableID and ColumnIndex to ColumnID

### DIFF
--- a/pkg/sql/opt/catalog.go
+++ b/pkg/sql/opt/catalog.go
@@ -132,18 +132,18 @@ type Catalog interface {
 
 // FormatCatalogTable nicely formats a catalog table using a treeprinter for
 // debugging and testing.
-func FormatCatalogTable(tbl Table, tp treeprinter.Node) {
-	child := tp.Childf("TABLE %s", tbl.TabName())
+func FormatCatalogTable(tab Table, tp treeprinter.Node) {
+	child := tp.Childf("TABLE %s", tab.TabName())
 
 	var buf bytes.Buffer
-	for i := 0; i < tbl.ColumnCount(); i++ {
+	for i := 0; i < tab.ColumnCount(); i++ {
 		buf.Reset()
-		formatColumn(tbl.Column(i), &buf)
+		formatColumn(tab.Column(i), &buf)
 		child.Child(buf.String())
 	}
 
-	for i := 0; i < tbl.IndexCount(); i++ {
-		formatCatalogIndex(tbl.Index(i), child)
+	for i := 0; i < tab.IndexCount(); i++ {
+		formatCatalogIndex(tab.Index(i), child)
 	}
 }
 

--- a/pkg/sql/opt/constraint/columns.go
+++ b/pkg/sql/opt/constraint/columns.go
@@ -28,9 +28,9 @@ import (
 // values on that column (in other words, inverts the result of any Datum
 // comparisons on that column).
 type Columns struct {
-	// firstCol holds the first column index and otherCols hold any indexes
-	// beyond the first. These are separated in order to optimize for the common
-	// case of a single-column constraint.
+	// firstCol holds the first column id and otherCols hold any ids beyond the
+	// first. These are separated in order to optimize for the common case of a
+	// single-column constraint.
 	firstCol  opt.OrderingColumn
 	otherCols []opt.OrderingColumn
 }

--- a/pkg/sql/opt/exec/execbuilder/builder_test.go
+++ b/pkg/sql/opt/exec/execbuilder/builder_test.go
@@ -231,13 +231,13 @@ func TestBuild(t *testing.T) {
 
 					parts := strings.Split(d.Input, ".")
 					name := tree.NewTableName(tree.Name(parts[0]), tree.Name(parts[1]))
-					tbl, err := eng.Catalog().FindTable(context.Background(), name)
+					tab, err := eng.Catalog().FindTable(context.Background(), name)
 					if err != nil {
 						d.Fatalf(t, "Catalog: %v", err)
 					}
 
 					tp := treeprinter.New()
-					opt.FormatCatalogTable(tbl, tp)
+					opt.FormatCatalogTable(tab, tp)
 					return tp.String()
 
 				default:

--- a/pkg/sql/opt/exec/execbuilder/scalar_builder.go
+++ b/pkg/sql/opt/exec/execbuilder/scalar_builder.go
@@ -26,8 +26,8 @@ import (
 type buildScalarCtx struct {
 	ivh tree.IndexedVarHelper
 
-	// ivarMap is a map from opt.ColumnIndex to the index of an IndexedVar.
-	// If a ColumnIndex is not in the map, it cannot appear in the expression.
+	// ivarMap is a map from opt.ColumnID to the index of an IndexedVar.
+	// If a ColumnID is not in the map, it cannot appear in the expression.
 	ivarMap opt.ColMap
 }
 
@@ -87,12 +87,12 @@ func (b *Builder) buildNull(ctx *buildScalarCtx, ev memo.ExprView) tree.TypedExp
 }
 
 func (b *Builder) buildVariable(ctx *buildScalarCtx, ev memo.ExprView) tree.TypedExpr {
-	colIndex := ev.Private().(opt.ColumnIndex)
-	idx, ok := ctx.ivarMap.Get(int(colIndex))
+	colID := ev.Private().(opt.ColumnID)
+	idx, ok := ctx.ivarMap.Get(int(colID))
 	if !ok {
-		panic(fmt.Sprintf("cannot map variable %d to an indexed var", colIndex))
+		panic(fmt.Sprintf("cannot map variable %d to an indexed var", colID))
 	}
-	return ctx.ivh.IndexedVarWithType(idx, ev.Metadata().ColumnType(colIndex))
+	return ctx.ivh.IndexedVarWithType(idx, ev.Metadata().ColumnType(colID))
 }
 
 func (b *Builder) buildTuple(ctx *buildScalarCtx, ev memo.ExprView) tree.TypedExpr {

--- a/pkg/sql/opt/idxconstraint/index_constraints.go
+++ b/pkg/sql/opt/idxconstraint/index_constraints.go
@@ -1151,5 +1151,5 @@ func (ic *Instance) RemainingFilter() memo.GroupID {
 // isIndexColumn returns true if ev is an indexed var that corresponds
 // to index column <offset>.
 func (c *indexConstraintCtx) isIndexColumn(ev memo.ExprView, index int) bool {
-	return ev.Operator() == opt.VariableOp && ev.Private().(opt.ColumnIndex) == c.colInfos[index].VarIdx
+	return ev.Operator() == opt.VariableOp && ev.Private().(opt.ColumnID) == c.colInfos[index].VarID
 }

--- a/pkg/sql/opt/idxconstraint/index_constraints_test.go
+++ b/pkg/sql/opt/idxconstraint/index_constraints_test.go
@@ -282,15 +282,15 @@ func parseIndexColumns(indexVarTypes []types.T, colStrs []string) ([]IndexColumn
 		if fields[0][0] != '@' {
 			return nil, fmt.Errorf("index column must start with @<index>")
 		}
-		idx, err := strconv.Atoi(fields[0][1:])
+		id, err := strconv.Atoi(fields[0][1:])
 		if err != nil {
 			return nil, err
 		}
-		if idx < 1 || idx > len(indexVarTypes) {
-			return nil, fmt.Errorf("invalid index var @%d", idx)
+		if id < 1 || id > len(indexVarTypes) {
+			return nil, fmt.Errorf("invalid index var @%d", id)
 		}
-		res[i].VarIdx = opt.ColumnIndex(idx)
-		res[i].Typ = indexVarTypes[res[i].VarIdx-1]
+		res[i].VarID = opt.ColumnID(id)
+		res[i].Typ = indexVarTypes[res[i].VarID-1]
 		res[i].Direction = encoding.Ascending
 		res[i].Nullable = true
 		fields = fields[1:]

--- a/pkg/sql/opt/idxconstraint/spans.go
+++ b/pkg/sql/opt/idxconstraint/spans.go
@@ -167,8 +167,8 @@ func ExactPrefix(spans LogicalSpans, evalCtx *tree.EvalContext) int {
 // IndexColumnInfo encompasses the information for index columns, needed for
 // index constraints.
 type IndexColumnInfo struct {
-	// VarIdx identifies the indexed var that corresponds to this column.
-	VarIdx    opt.ColumnIndex
+	// VarID identifies the indexed var that corresponds to this column.
+	VarID     opt.ColumnID
 	Typ       types.T
 	Direction encoding.Direction
 	// Nullable should be set to false if this column cannot store NULLs; used

--- a/pkg/sql/opt/memo/expr.og.go
+++ b/pkg/sql/opt/memo/expr.og.go
@@ -1941,7 +1941,7 @@ func (e *Expr) AsSubquery() *SubqueryExpr {
 }
 
 // VariableExpr is the typed scalar value of a column in the query. The private
-// field is a Metadata.ColumnIndex that references the column by index.
+// field is a Metadata.ColumnID that references the column by index.
 type VariableExpr Expr
 
 func MakeVariableExpr(col PrivateID) VariableExpr {

--- a/pkg/sql/opt/memo/expr_view.go
+++ b/pkg/sql/opt/memo/expr_view.go
@@ -240,8 +240,8 @@ func (ev ExprView) formatRelational(tp treeprinter.Node, flags ExprFmtFlags) {
 
 	switch ev.Operator() {
 	case opt.ScanOp:
-		tblIndex := ev.Private().(*ScanOpDef).Table
-		fmt.Fprintf(&buf, " %s", ev.Metadata().Table(tblIndex).TabName())
+		tabID := ev.Private().(*ScanOpDef).Table
+		fmt.Fprintf(&buf, " %s", ev.Metadata().Table(tabID).TabName())
 	}
 
 	logProps := ev.Logical()
@@ -273,7 +273,7 @@ func (ev ExprView) formatRelational(tp treeprinter.Node, flags ExprFmtFlags) {
 			logProps.FormatColList("columns:", colMap.Out, ev.Metadata(), tp)
 
 		default:
-			// Fall back to writing output columns in column index order, with
+			// Fall back to writing output columns in column id order, with
 			// best guess label.
 			logProps.FormatColSet("columns:", logProps.Relational.OutputCols, ev.Metadata(), tp)
 		}
@@ -360,8 +360,8 @@ func (ev ExprView) formatScalar(tp treeprinter.Node, flags ExprFmtFlags) {
 func (ev ExprView) formatPrivate(buf *bytes.Buffer, private interface{}) {
 	switch ev.op {
 	case opt.VariableOp:
-		colIndex := private.(opt.ColumnIndex)
-		private = ev.mem.metadata.ColumnLabel(colIndex)
+		id := private.(opt.ColumnID)
+		private = ev.mem.metadata.ColumnLabel(id)
 
 	case opt.NullOp:
 		// Private is redundant with logical type property.
@@ -385,7 +385,7 @@ func (ev ExprView) formatPresentation(presentation Presentation, tp treeprinter.
 	var buf bytes.Buffer
 	buf.WriteString("columns:")
 	for _, col := range presentation {
-		logProps.FormatCol(col.Label, col.Index, ev.Metadata(), &buf)
+		logProps.FormatCol(col.Label, col.ID, ev.Metadata(), &buf)
 	}
 	tp.Child(buf.String())
 }

--- a/pkg/sql/opt/memo/logical_props.go
+++ b/pkg/sql/opt/memo/logical_props.go
@@ -135,7 +135,7 @@ func (p *LogicalProps) FormatColSet(
 		var buf bytes.Buffer
 		buf.WriteString(heading)
 		colSet.ForEach(func(i int) {
-			p.FormatCol("", opt.ColumnIndex(i), md, &buf)
+			p.FormatCol("", opt.ColumnID(i), md, &buf)
 		})
 		tp.Child(buf.String())
 	}
@@ -165,19 +165,19 @@ func (p *LogicalProps) FormatColList(
 // If a label is given, then it is used. Otherwise, a "best effort" label is
 // used from query metadata.
 func (p *LogicalProps) FormatCol(
-	label string, index opt.ColumnIndex, md *opt.Metadata, buf *bytes.Buffer,
+	label string, id opt.ColumnID, md *opt.Metadata, buf *bytes.Buffer,
 ) {
 	if label == "" {
-		label = md.ColumnLabel(index)
+		label = md.ColumnLabel(id)
 	}
-	typ := md.ColumnType(index)
+	typ := md.ColumnType(id)
 	buf.WriteByte(' ')
 	buf.WriteString(label)
 	buf.WriteByte(':')
-	fmt.Fprintf(buf, "%d", index)
+	fmt.Fprintf(buf, "%d", id)
 	buf.WriteByte('(')
 	buf.WriteString(typ.String())
-	if p.Relational.NotNullCols.Contains(int(index)) {
+	if p.Relational.NotNullCols.Contains(int(id)) {
 		buf.WriteString("!null")
 	}
 	buf.WriteByte(')')

--- a/pkg/sql/opt/memo/logical_props_factory.go
+++ b/pkg/sql/opt/memo/logical_props_factory.go
@@ -79,17 +79,17 @@ func (f logicalPropsFactory) constructScanProps(ev ExprView) LogicalProps {
 
 	md := ev.Metadata()
 	def := ev.Private().(*ScanOpDef)
-	tbl := md.Table(def.Table)
+	tab := md.Table(def.Table)
 
 	// Scan output columns are stored in the definition.
 	props.Relational.OutputCols = def.Cols
 
 	// Initialize not-NULL columns from the table schema.
-	for i := 0; i < tbl.ColumnCount(); i++ {
-		if !tbl.Column(i).IsNullable() {
-			colIndex := md.TableColumn(def.Table, i)
-			if def.Cols.Contains(int(colIndex)) {
-				props.Relational.NotNullCols.Add(int(colIndex))
+	for i := 0; i < tab.ColumnCount(); i++ {
+		if !tab.Column(i).IsNullable() {
+			colID := md.TableColumn(def.Table, i)
+			if def.Cols.Contains(int(colID)) {
+				props.Relational.NotNullCols.Add(int(colID))
 			}
 		}
 	}
@@ -267,7 +267,7 @@ func (f logicalPropsFactory) constructScalarProps(ev ExprView) LogicalProps {
 	switch ev.Operator() {
 	case opt.VariableOp:
 		// Variable introduces outer column.
-		props.Scalar.OuterCols.Add(int(ev.Private().(opt.ColumnIndex)))
+		props.Scalar.OuterCols.Add(int(ev.Private().(opt.ColumnID)))
 		return props
 	}
 

--- a/pkg/sql/opt/memo/logical_props_factory_test.go
+++ b/pkg/sql/opt/memo/logical_props_factory_test.go
@@ -70,10 +70,10 @@ func TestLogicalJoinProps(t *testing.T) {
 	joinFunc(opt.AntiJoinApplyOp, "a.x:1(int!null) a.y:2(int)\n")
 }
 
-func constructScanOpDef(md *opt.Metadata, tblIndex opt.TableIndex) *memo.ScanOpDef {
-	def := memo.ScanOpDef{Table: tblIndex}
-	for i := 0; i < md.Table(tblIndex).ColumnCount(); i++ {
-		def.Cols.Add(int(md.TableColumn(tblIndex, i)))
+func constructScanOpDef(md *opt.Metadata, tabID opt.TableID) *memo.ScanOpDef {
+	def := memo.ScanOpDef{Table: tabID}
+	for i := 0; i < md.Table(tabID).ColumnCount(); i++ {
+		def.Cols.Add(int(md.TableColumn(tabID, i)))
 	}
 	return &def
 }

--- a/pkg/sql/opt/memo/memo.go
+++ b/pkg/sql/opt/memo/memo.go
@@ -440,7 +440,7 @@ func (m *Memo) formatPrivate(private interface{}, buf *bytes.Buffer) {
 		case nil:
 		case *ScanOpDef:
 			fmt.Fprintf(buf, " %s", m.metadata.Table(t.Table).TabName())
-		case opt.ColumnIndex:
+		case opt.ColumnID:
 			fmt.Fprintf(buf, " %s", m.metadata.ColumnLabel(t))
 		case *opt.ColSet, *opt.ColMap, *opt.ColList:
 			// Don't show anything, because it's mostly redundant.

--- a/pkg/sql/opt/memo/physical_props.go
+++ b/pkg/sql/opt/memo/physical_props.go
@@ -148,13 +148,12 @@ func (p Presentation) format(buf *bytes.Buffer) {
 		if i > 0 {
 			buf.WriteString(",")
 		}
-
-		fmt.Fprintf(buf, "%s:%d", col.Label, col.Index)
+		fmt.Fprintf(buf, "%s:%d", col.Label, col.ID)
 	}
 }
 
 // Ordering defines the order of rows provided or required by an operator. A
-// negative value indicates descending order on the column index "-(value)".
+// negative value indicates descending order on the column id "-(value)".
 type Ordering []opt.OrderingColumn
 
 // Defined is true if a particular row ordering is required or provided.
@@ -178,7 +177,7 @@ func (o Ordering) format(buf *bytes.Buffer) {
 		} else {
 			buf.WriteByte('+')
 		}
-		fmt.Fprintf(buf, "%d", col.Index())
+		fmt.Fprintf(buf, "%d", col.ID())
 	}
 }
 

--- a/pkg/sql/opt/memo/physical_props_test.go
+++ b/pkg/sql/opt/memo/physical_props_test.go
@@ -32,8 +32,8 @@ func TestPhysicalProps(t *testing.T) {
 
 	// Presentation props.
 	presentation := memo.Presentation{
-		opt.LabeledColumn{Label: "a", Index: 1},
-		opt.LabeledColumn{Label: "b", Index: 2},
+		opt.LabeledColumn{Label: "a", ID: 1},
+		opt.LabeledColumn{Label: "b", ID: 2},
 	}
 	props = &memo.PhysicalProps{Presentation: presentation}
 	testPhysicalProps(t, props, "p:a:1,b:2")

--- a/pkg/sql/opt/memo/private_defs.go
+++ b/pkg/sql/opt/memo/private_defs.go
@@ -42,7 +42,7 @@ func (f FuncOpDef) String() string {
 type ScanOpDef struct {
 	// Table identifies the table to scan. It is an index that can be passed to
 	// the Metadata.Table method in order to fetch optbase.Table metadata.
-	Table opt.TableIndex
+	Table opt.TableID
 
 	// Cols specifies the set of columns that the scan operator projects. This
 	// may be a subset of the columns that the table contains.

--- a/pkg/sql/opt/memo/typing.go
+++ b/pkg/sql/opt/memo/typing.go
@@ -118,12 +118,12 @@ func init() {
 }
 
 // typeVariable returns the type of a variable expression, which is stored in
-// the query metadata and acessed by column index.
+// the query metadata and accessed by column id.
 func typeVariable(ev ExprView) types.T {
-	colIndex := ev.Private().(opt.ColumnIndex)
-	typ := ev.Metadata().ColumnType(colIndex)
+	colID := ev.Private().(opt.ColumnID)
+	typ := ev.Metadata().ColumnType(colID)
 	if typ == nil {
-		panic(fmt.Sprintf("column %d does not have type", colIndex))
+		panic(fmt.Sprintf("column %d does not have type", colID))
 	}
 	return typ
 }

--- a/pkg/sql/opt/metadata_column.go
+++ b/pkg/sql/opt/metadata_column.go
@@ -18,50 +18,50 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util"
 )
 
-// ColumnIndex uniquely identifies the usage of a column within the scope of a
-// query. ColumnIndex 0 is reserved to mean "unknown column". See the comment
-// for Metadata for more details.
-type ColumnIndex int32
+// ColumnID uniquely identifies the usage of a column within the scope of a
+// query. ColumnID 0 is reserved to mean "unknown column". See the comment for
+// Metadata for more details.
+type ColumnID int32
 
-// ColSet efficiently stores an unordered set of column indexes.
+// ColSet efficiently stores an unordered set of column ids.
 type ColSet = util.FastIntSet
 
-// ColList is a list of column indexes.
+// ColList is a list of column ids.
 //
 // TODO(radu): perhaps implement a FastIntList with the same "small"
 // representation as FastIntMap but with a slice for large cases.
-type ColList = []ColumnIndex
+type ColList = []ColumnID
 
-// ColMap provides a 1:1 mapping from one column index to another. It is used
-// by operators that need to match columns from its inputs.
+// ColMap provides a 1:1 mapping from one column id to another. It is used by
+// operators that need to match columns from its inputs.
 type ColMap = util.FastIntMap
 
-// LabeledColumn specifies the label and index of a column.
+// LabeledColumn specifies the label and id of a column.
 type LabeledColumn struct {
 	Label string
-	Index ColumnIndex
+	ID    ColumnID
 }
 
-// OrderingColumn is the ColumnIndex for a column that is part of an ordering,
+// OrderingColumn is the ColumnID for a column that is part of an ordering,
 // except that it can be negated to indicate a descending ordering on that
 // column.
 type OrderingColumn int32
 
-// MakeOrderingColumn initializes an ordering column with a ColumnIndex and a
-// flag indicating whether the direction is descending.
-func MakeOrderingColumn(index ColumnIndex, descending bool) OrderingColumn {
+// MakeOrderingColumn initializes an ordering column with a ColumnID and a flag
+// indicating whether the direction is descending.
+func MakeOrderingColumn(id ColumnID, descending bool) OrderingColumn {
 	if descending {
-		return OrderingColumn(-index)
+		return OrderingColumn(-id)
 	}
-	return OrderingColumn(index)
+	return OrderingColumn(id)
 }
 
-// Index returns the ColumnIndex for this OrderingColumn.
-func (c OrderingColumn) Index() ColumnIndex {
+// ID returns the ColumnID for this OrderingColumn.
+func (c OrderingColumn) ID() ColumnID {
 	if c < 0 {
-		return ColumnIndex(-c)
+		return ColumnID(-c)
 	}
-	return ColumnIndex(c)
+	return ColumnID(c)
 }
 
 // Ascending returns true if the ordering on this column is ascending.
@@ -74,7 +74,7 @@ func (c OrderingColumn) Descending() bool {
 	return c < 0
 }
 
-// ColListToSet converts a column index list to a column index set.
+// ColListToSet converts a column id list to a column id set.
 func ColListToSet(colList ColList) ColSet {
 	var r ColSet
 	for _, col := range colList {

--- a/pkg/sql/opt/metadata_test.go
+++ b/pkg/sql/opt/metadata_test.go
@@ -26,17 +26,17 @@ func TestMetadataColumns(t *testing.T) {
 	md := opt.NewMetadata()
 
 	// Add standalone column.
-	colIndex := md.AddColumn("alias", types.Int)
-	if colIndex != 1 {
-		t.Fatalf("unexpected column index: %d", colIndex)
+	colID := md.AddColumn("alias", types.Int)
+	if colID != 1 {
+		t.Fatalf("unexpected column id: %d", colID)
 	}
 
-	label := md.ColumnLabel(colIndex)
+	label := md.ColumnLabel(colID)
 	if label != "alias" {
 		t.Fatalf("unexpected column label: %s", label)
 	}
 
-	typ := md.ColumnType(colIndex)
+	typ := md.ColumnType(colID)
 	if typ != types.Int {
 		t.Fatalf("unexpected column type: %s", typ)
 	}
@@ -46,17 +46,17 @@ func TestMetadataColumns(t *testing.T) {
 	}
 
 	// Add another column.
-	colIndex = md.AddColumn("alias2", types.String)
-	if colIndex != 2 {
-		t.Fatalf("unexpected column index: %d", colIndex)
+	colID = md.AddColumn("alias2", types.String)
+	if colID != 2 {
+		t.Fatalf("unexpected column id: %d", colID)
 	}
 
-	label = md.ColumnLabel(colIndex)
+	label = md.ColumnLabel(colID)
 	if label != "alias2" {
 		t.Fatalf("unexpected column label: %s", label)
 	}
 
-	typ = md.ColumnType(colIndex)
+	typ = md.ColumnType(colID)
 	if typ != types.String {
 		t.Fatalf("unexpected column type: %s", typ)
 	}
@@ -75,22 +75,22 @@ func TestMetadataTables(t *testing.T) {
 	y := &testutils.TestColumn{Name: "y"}
 	a.Columns = append(a.Columns, x, y)
 
-	tblIndex := md.AddTable(a)
-	if tblIndex != 1 {
-		t.Fatalf("unexpected table index: %d", tblIndex)
+	tabID := md.AddTable(a)
+	if tabID != 1 {
+		t.Fatalf("unexpected table id: %d", tabID)
 	}
 
-	tbl := md.Table(tblIndex)
-	if tbl != a {
+	tab := md.Table(tabID)
+	if tab != a {
 		t.Fatal("table didn't match table added to metadata")
 	}
 
-	colIndex := md.TableColumn(tblIndex, 0)
-	if colIndex != 1 {
-		t.Fatalf("unexpected column index: %d", colIndex)
+	colID := md.TableColumn(tabID, 0)
+	if colID != 1 {
+		t.Fatalf("unexpected column id: %d", colID)
 	}
 
-	label := md.ColumnLabel(colIndex)
+	label := md.ColumnLabel(colID)
 	if label != "a.x" {
 		t.Fatalf("unexpected column label: %s", label)
 	}
@@ -99,12 +99,12 @@ func TestMetadataTables(t *testing.T) {
 	b := &testutils.TestTable{}
 	b.Columns = append(b.Columns, &testutils.TestColumn{Name: "x"})
 
-	tblIndex = md.AddTable(b)
-	if tblIndex != 3 {
-		t.Fatalf("unexpected table index: %d", tblIndex)
+	tabID = md.AddTable(b)
+	if tabID != 3 {
+		t.Fatalf("unexpected table id: %d", tabID)
 	}
 
-	label = md.ColumnLabel(md.TableColumn(tblIndex, 0))
+	label = md.ColumnLabel(md.TableColumn(tabID, 0))
 	if label != "x" {
 		t.Fatalf("unexpected column label: %s", label)
 	}

--- a/pkg/sql/opt/operator.og.go
+++ b/pkg/sql/opt/operator.og.go
@@ -190,7 +190,7 @@ const (
 	SubqueryOp
 
 	// VariableOp is the typed scalar value of a column in the query. The private
-	// field is a Metadata.ColumnIndex that references the column by index.
+	// field is a Metadata.ColumnID that references the column by index.
 	VariableOp
 
 	// ConstOp is a typed scalar constant value. The private field is a tree.Datum

--- a/pkg/sql/opt/ops/scalar.opt
+++ b/pkg/sql/opt/ops/scalar.opt
@@ -14,10 +14,10 @@ define Subquery {
 }
 
 # Variable is the typed scalar value of a column in the query. The private
-# field is a Metadata.ColumnIndex that references the column by index.
+# field is a Metadata.ColumnID that references the column by index.
 [Scalar]
 define Variable {
-    Col ColumnIndex
+    Col ColumnID
 }
 
 # Const is a typed scalar constant value. The private field is a tree.Datum

--- a/pkg/sql/opt/optbuilder/column_props.go
+++ b/pkg/sql/opt/optbuilder/column_props.go
@@ -37,9 +37,9 @@ type columnProps struct {
 	table tree.TableName
 	typ   types.T
 
-	// index is an identifier for this column, which is unique across all the
+	// id is an identifier for this column, which is unique across all the
 	// columns in the query.
-	index  opt.ColumnIndex
+	id     opt.ColumnID
 	hidden bool
 
 	// expr is the expression that this column refers to, if any. expr is nil if

--- a/pkg/sql/opt/optbuilder/distinct.go
+++ b/pkg/sql/opt/optbuilder/distinct.go
@@ -49,7 +49,7 @@ func (b *Builder) buildDistinct(
 	// Distinct is equivalent to group by without any aggregations.
 	var groupCols opt.ColSet
 	for i := range byCols {
-		groupCols.Add(int(byCols[i].index))
+		groupCols.Add(int(byCols[i].id))
 		outScope.cols = append(outScope.cols, byCols[i])
 	}
 

--- a/pkg/sql/opt/optbuilder/groupby.go
+++ b/pkg/sql/opt/optbuilder/groupby.go
@@ -108,7 +108,7 @@ type groupby struct {
 	//                \   /                 a GROUP BY expression
 	//  5.          Build v/(k+v) [v] <- error - build is complete and varsUsed
 	//                                   is not empty
-	varsUsed []opt.ColumnIndex
+	varsUsed []opt.ColumnID
 }
 
 // aggregateInfo stores information about an aggregation function call.
@@ -215,9 +215,9 @@ func (b *Builder) buildAggregation(
 	for i, agg := range aggInfos {
 		argList := make([]memo.GroupID, len(agg.args))
 		for j := range agg.args {
-			colIndex := argCols[0].index
+			colID := argCols[0].id
 			argCols = argCols[1:]
-			argList[j] = b.factory.ConstructVariable(b.factory.InternPrivate(colIndex))
+			argList[j] = b.factory.ConstructVariable(b.factory.InternPrivate(colID))
 		}
 		aggExprs[i] = b.factory.ConstructFunction(
 			b.factory.InternList(argList),
@@ -228,7 +228,7 @@ func (b *Builder) buildAggregation(
 	aggList := b.constructList(opt.AggregationsOp, aggExprs, aggOutScope.getAggregateCols())
 	var groupingColSet opt.ColSet
 	for i := range groupings {
-		groupingColSet.Add(int(aggInScope.cols[i].index))
+		groupingColSet.Add(int(aggInScope.cols[i].id))
 	}
 	outGroup = b.factory.ConstructGroupBy(outGroup, aggList, b.factory.InternPrivate(&groupingColSet))
 
@@ -402,7 +402,7 @@ func (b *Builder) buildAggregateFunction(
 	}
 
 	// Replace the function call with a reference to the column.
-	return b.factory.ConstructVariable(b.factory.InternPrivate(col.index)), col
+	return b.factory.ConstructVariable(b.factory.InternPrivate(col.id)), col
 }
 
 func isAggregate(def *tree.FunctionDefinition) bool {

--- a/pkg/sql/opt/optbuilder/orderby.go
+++ b/pkg/sql/opt/optbuilder/orderby.go
@@ -147,7 +147,7 @@ func (b *Builder) buildOrdering(
 	// Add the new columns to the ordering.
 	for i := start; i < len(orderByScope.cols); i++ {
 		col := opt.MakeOrderingColumn(
-			orderByScope.cols[i].index,
+			orderByScope.cols[i].id,
 			order.Direction == tree.Descending,
 		)
 		orderByScope.ordering = append(orderByScope.ordering, col)
@@ -177,7 +177,7 @@ func (b *Builder) buildOrderByProject(
 		col := &orderByScope.cols[i]
 
 		// Only append order by columns that aren't already present.
-		if findColByIndex(outScope.cols, col.index) == nil {
+		if findColByIndex(outScope.cols, col.id) == nil {
 			outScope.cols = append(outScope.cols, *col)
 			outScope.cols[len(outScope.cols)-1].hidden = true
 			combined = append(combined, orderByProjections[i])

--- a/pkg/sql/opt/optbuilder/project.go
+++ b/pkg/sql/opt/optbuilder/project.go
@@ -131,10 +131,10 @@ func (b *Builder) buildScalarProjection(
 func (b *Builder) buildVariableProjection(
 	col *columnProps, label string, inScope, outScope *scope,
 ) memo.GroupID {
-	if inScope.inGroupingContext() && !inScope.groupby.inAgg && !inScope.groupby.aggInScope.hasColumn(col.index) {
+	if inScope.inGroupingContext() && !inScope.groupby.inAgg && !inScope.groupby.aggInScope.hasColumn(col.id) {
 		panic(groupingError(col.String()))
 	}
-	out := b.factory.ConstructVariable(b.factory.InternPrivate(col.index))
+	out := b.factory.ConstructVariable(b.factory.InternPrivate(col.id))
 	outScope.cols = append(outScope.cols, *col)
 
 	// Update the column name with the alias if it exists, and mark the column
@@ -186,14 +186,14 @@ func (b *Builder) buildDefaultScalarProjection(
 
 		if col := inScope.findGrouping(group); col != nil {
 			// The column already exists, so use that instead.
-			col = &b.colMap[col.index]
+			col = &b.colMap[col.id]
 			if label != "" {
 				col.name = tree.Name(label)
 			}
 			outScope.cols = append(outScope.cols, *col)
 
 			// Replace the expression with a reference to the column.
-			return b.factory.ConstructVariable(b.factory.InternPrivate(col.index))
+			return b.factory.ConstructVariable(b.factory.InternPrivate(col.id))
 		}
 	}
 

--- a/pkg/sql/opt/optbuilder/scalar.go
+++ b/pkg/sql/opt/optbuilder/scalar.go
@@ -90,10 +90,10 @@ func (b *Builder) buildScalar(scalar tree.TypedExpr, inScope *scope) (out memo.G
 	varsUsedIn := len(inScope.groupby.varsUsed)
 	switch t := scalar.(type) {
 	case *columnProps:
-		if inGroupingContext && !inScope.groupby.aggInScope.hasColumn(t.index) {
-			inScope.groupby.varsUsed = append(inScope.groupby.varsUsed, t.index)
+		if inGroupingContext && !inScope.groupby.aggInScope.hasColumn(t.id) {
+			inScope.groupby.varsUsed = append(inScope.groupby.varsUsed, t.id)
 		}
-		return b.factory.ConstructVariable(b.factory.InternPrivate(t.index))
+		return b.factory.ConstructVariable(b.factory.InternPrivate(t.id))
 
 	case *tree.AndExpr:
 		left := b.buildScalar(t.TypedLeft(), inScope)
@@ -187,7 +187,7 @@ func (b *Builder) buildScalar(scalar tree.TypedExpr, inScope *scope) (out memo.G
 		if t.Idx < 0 || t.Idx >= len(inScope.cols) {
 			panic(errorf("invalid column ordinal @%d", t.Idx))
 		}
-		out = b.factory.ConstructVariable(b.factory.InternPrivate(inScope.cols[t.Idx].index))
+		out = b.factory.ConstructVariable(b.factory.InternPrivate(inScope.cols[t.Idx].id))
 		// TODO(rytaft): Do we need to update varsUsed here?
 
 	case *tree.NotExpr:

--- a/pkg/sql/opt/optbuilder/scope.go
+++ b/pkg/sql/opt/optbuilder/scope.go
@@ -86,12 +86,12 @@ func (s *scope) resolveType(expr tree.Expr, desired types.T) tree.TypedExpr {
 	return texpr
 }
 
-// hasColumn returns true if the given column index is found within this scope.
-func (s *scope) hasColumn(index opt.ColumnIndex) bool {
+// hasColumn returns true if the given column id is found within this scope.
+func (s *scope) hasColumn(id opt.ColumnID) bool {
 	for curr := s; curr != nil; curr = curr.parent {
 		for i := range curr.cols {
 			col := &curr.cols[i]
-			if col.index == index {
+			if col.id == id {
 				return true
 			}
 		}
@@ -107,7 +107,7 @@ func (s *scope) hasSameColumns(other *scope) bool {
 		return false
 	}
 	for i := range s.cols {
-		if s.cols[i].index != other.cols[i].index {
+		if s.cols[i].id != other.cols[i].id {
 			return false
 		}
 	}
@@ -276,13 +276,13 @@ func (s *scope) FindSourceProvidingColumn(
 			)
 		}
 		if candidateFromAnonSource != nil {
-			return &candidateFromAnonSource.table, candidateFromAnonSource, int(candidateFromAnonSource.index), nil
+			return &candidateFromAnonSource.table, candidateFromAnonSource, int(candidateFromAnonSource.id), nil
 		}
 
 		// Else if a single named source exists with a matching non-hidden column,
 		// use that.
 		if candidateWithPrefix != nil && !moreThanOneCandidateWithPrefix {
-			return &candidateWithPrefix.table, candidateWithPrefix, int(candidateWithPrefix.index), nil
+			return &candidateWithPrefix.table, candidateWithPrefix, int(candidateWithPrefix.id), nil
 		}
 		if moreThanOneCandidateWithPrefix || moreThanOneHiddenCandidate {
 			return nil, nil, -1, s.newAmbiguousColumnError(
@@ -293,7 +293,7 @@ func (s *scope) FindSourceProvidingColumn(
 		// One last option: if a single source exists with a matching hidden
 		// column, use that.
 		if hiddenCandidate != nil {
-			return &hiddenCandidate.table, hiddenCandidate, int(hiddenCandidate.index), nil
+			return &hiddenCandidate.table, hiddenCandidate, int(hiddenCandidate.id), nil
 		}
 	}
 

--- a/pkg/sql/opt/optbuilder/util.go
+++ b/pkg/sql/opt/optbuilder/util.go
@@ -113,12 +113,12 @@ func (b *Builder) synthesizeColumn(
 	}
 
 	name := tree.Name(label)
-	colIndex := b.factory.Metadata().AddColumn(label, typ)
+	colID := b.factory.Metadata().AddColumn(label, typ)
 	col := columnProps{
 		origName: name,
 		name:     name,
 		typ:      typ,
-		index:    colIndex,
+		id:       colID,
 		expr:     expr,
 	}
 	b.colMap = append(b.colMap, col)
@@ -133,7 +133,7 @@ func (b *Builder) constructList(
 ) memo.GroupID {
 	colList := make(opt.ColList, len(cols))
 	for i := range cols {
-		colList[i] = cols[i].index
+		colList[i] = cols[i].id
 	}
 
 	list := b.factory.InternList(items)
@@ -153,8 +153,8 @@ func (b *Builder) constructList(
 // verifies it refers to a valid target in the SELECT list, and returns the
 // corresponding column index. For example:
 //    SELECT a from T ORDER by 1
-// Here "1" refers to the first item in the SELECT list, "a". The returned index
-// is 0.
+// Here "1" refers to the first item in the SELECT list, "a". The returned
+// index is 0.
 func colIndex(numOriginalCols int, expr tree.Expr, context string) int {
 	ord := int64(-1)
 	switch i := expr.(type) {
@@ -280,15 +280,15 @@ func symbolicExprStr(expr tree.Expr) string {
 func colsToColList(cols []columnProps) opt.ColList {
 	colList := make(opt.ColList, len(cols))
 	for i := range cols {
-		colList[i] = cols[i].index
+		colList[i] = cols[i].id
 	}
 	return colList
 }
 
-func findColByIndex(cols []columnProps, colIndex opt.ColumnIndex) *columnProps {
+func findColByIndex(cols []columnProps, id opt.ColumnID) *columnProps {
 	for i := range cols {
 		col := &cols[i]
-		if col.index == colIndex {
+		if col.id == id {
 			return col
 		}
 	}
@@ -300,7 +300,7 @@ func makePresentation(cols []columnProps) memo.Presentation {
 	presentation := make(memo.Presentation, len(cols))
 	for i := range cols {
 		col := &cols[i]
-		presentation[i] = opt.LabeledColumn{Label: string(col.name), Index: col.index}
+		presentation[i] = opt.LabeledColumn{Label: string(col.name), ID: col.id}
 	}
 	return presentation
 }

--- a/pkg/sql/opt/optgen/cmd/optgen/testdata/factory
+++ b/pkg/sql/opt/optgen/cmd/optgen/testdata/factory
@@ -409,7 +409,7 @@ define Func {
 }
 
 define Variable {
-    Col ColumnIndex
+    Col ColumnID
 }
 
 [Concat, Normalize]

--- a/pkg/sql/opt/testutils/create_table.go
+++ b/pkg/sql/opt/testutils/create_table.go
@@ -41,24 +41,24 @@ func (tc *TestCatalog) CreateTable(stmt *tree.CreateTable) *TestTable {
 	}
 
 	// Add the columns and primary index (if there is one defined).
-	tbl := &TestTable{Name: tn.Table()}
+	tab := &TestTable{Name: tn.Table()}
 	for _, def := range stmt.Defs {
 		switch def := def.(type) {
 		case *tree.ColumnTableDef:
-			tbl.addColumn(def)
+			tab.addColumn(def)
 
 		case *tree.UniqueConstraintTableDef:
 			if def.PrimaryKey {
-				tbl.addIndex(&def.IndexTableDef, primaryIndex)
+				tab.addIndex(&def.IndexTableDef, primaryIndex)
 			}
 		}
 	}
 
 	// If there is no primary index, add the hidden rowid column.
-	if len(tbl.Indexes) == 0 {
+	if len(tab.Indexes) == 0 {
 		rowid := &TestColumn{Name: "rowid", Type: types.Int, Hidden: true}
-		tbl.Columns = append(tbl.Columns, rowid)
-		tbl.addPrimaryColumnIndex(rowid)
+		tab.Columns = append(tab.Columns, rowid)
+		tab.addPrimaryColumnIndex(rowid)
 	}
 
 	// Search for other relevant definitions.
@@ -66,11 +66,11 @@ func (tc *TestCatalog) CreateTable(stmt *tree.CreateTable) *TestTable {
 		switch def := def.(type) {
 		case *tree.UniqueConstraintTableDef:
 			if !def.PrimaryKey {
-				tbl.addIndex(&def.IndexTableDef, uniqueIndex)
+				tab.addIndex(&def.IndexTableDef, uniqueIndex)
 			}
 
 		case *tree.IndexTableDef:
-			tbl.addIndex(def, nonUniqueIndex)
+			tab.addIndex(def, nonUniqueIndex)
 		}
 		// TODO(rytaft): In the future we will likely want to check for unique
 		// constraints, indexes, and foreign key constraints to determine
@@ -78,9 +78,9 @@ func (tc *TestCatalog) CreateTable(stmt *tree.CreateTable) *TestTable {
 	}
 
 	// Add the new table to the catalog.
-	tc.AddTable(tbl)
+	tc.AddTable(tab)
 
-	return tbl
+	return tab
 }
 
 func (tt *TestTable) addColumn(def *tree.ColumnTableDef) {

--- a/pkg/sql/opt/testutils/test_catalog.go
+++ b/pkg/sql/opt/testutils/test_catalog.go
@@ -52,8 +52,8 @@ func (tc *TestCatalog) Table(name string) *TestTable {
 }
 
 // AddTable adds the given test table to the catalog.
-func (tc *TestCatalog) AddTable(tbl *TestTable) {
-	tc.tables[tbl.Name] = tbl
+func (tc *TestCatalog) AddTable(tab *TestTable) {
+	tc.tables[tab.Name] = tab
 }
 
 // TestTable implements the opt.Table interface for testing purposes.

--- a/pkg/sql/opt/testutils/utils.go
+++ b/pkg/sql/opt/testutils/utils.go
@@ -74,8 +74,8 @@ func ExecuteTestDDL(tb testing.TB, sql string, catalog *TestCatalog) string {
 
 	switch stmt := stmt.(type) {
 	case *tree.CreateTable:
-		tbl := catalog.CreateTable(stmt)
-		return tbl.String()
+		tab := catalog.CreateTable(stmt)
+		return tab.String()
 
 	default:
 		tb.Fatalf("expected CREATE TABLE statement but found: %v", stmt)

--- a/pkg/sql/opt/xform/factory.go
+++ b/pkg/sql/opt/xform/factory.go
@@ -348,7 +348,7 @@ func (f *Factory) neededColsGroupBy(aggs memo.GroupID, groupingCols memo.Private
 func (f *Factory) neededColsLimit(projections memo.GroupID, ordering memo.PrivateID) opt.ColSet {
 	colSet := f.outerCols(projections).Copy()
 	for _, col := range *f.mem.LookupPrivate(ordering).(*memo.Ordering) {
-		colSet.Add(int(col.Index()))
+		colSet.Add(int(col.ID()))
 	}
 	return colSet
 }
@@ -409,9 +409,9 @@ func (f *Factory) filterUnusedColumns(target memo.GroupID, neededCols opt.ColSet
 	default:
 		// Construct new variable groups for each output column that's needed.
 		colSet.ForEach(func(i int) {
-			v := f.ConstructVariable(f.InternPrivate(opt.ColumnIndex(i)))
+			v := f.ConstructVariable(f.InternPrivate(opt.ColumnID(i)))
 			groupList = append(groupList, v)
-			colList = append(colList, opt.ColumnIndex(i))
+			colList = append(colList, opt.ColumnID(i))
 		})
 	}
 
@@ -452,11 +452,11 @@ func (f *Factory) filterUnusedValuesColumns(
 	newRows := make([]memo.GroupID, 0, len(existingRows))
 
 	// Create new list of columns that only contains needed columns.
-	for _, colIndex := range existingCols {
-		if !neededCols.Contains(int(colIndex)) {
+	for _, colID := range existingCols {
+		if !neededCols.Contains(int(colID)) {
 			continue
 		}
-		newCols = append(newCols, colIndex)
+		newCols = append(newCols, colID)
 	}
 
 	// newElems is used to store tuple values, and can be allocated once and

--- a/pkg/sql/opt/xform/factory.og.go
+++ b/pkg/sql/opt/xform/factory.og.go
@@ -1322,7 +1322,7 @@ func (_f *Factory) ConstructSubquery(
 
 // ConstructVariable constructs an expression for the Variable operator.
 // Variable is the typed scalar value of a column in the query. The private
-// field is a Metadata.ColumnIndex that references the column by index.
+// field is a Metadata.ColumnID that references the column by index.
 func (_f *Factory) ConstructVariable(
 	col memo.PrivateID,
 ) memo.GroupID {

--- a/pkg/sql/opt/xform/physical_props_factory.go
+++ b/pkg/sql/opt/xform/physical_props_factory.go
@@ -116,8 +116,8 @@ func (f physicalPropsFactory) canProvideOrdering(eid memo.ExprID, required memo.
 
 		for i := 0; i < cnt; i++ {
 			primaryCol := primary.Column(i)
-			colIndex := f.mem.Metadata().TableColumn(def.Table, primaryCol.Ordinal)
-			orderingCol := opt.MakeOrderingColumn(colIndex, primaryCol.Descending)
+			colID := f.mem.Metadata().TableColumn(def.Table, primaryCol.Ordinal)
+			orderingCol := opt.MakeOrderingColumn(colID, primaryCol.Descending)
 			if orderingCol != required[i] {
 				return false
 			}

--- a/pkg/sql/opt_catalog.go
+++ b/pkg/sql/opt_catalog.go
@@ -150,7 +150,7 @@ func (ot *optTable) lookupColumnOrdinal(colID sqlbase.ColumnID) int {
 // optIndex is a wrapper around sqlbase.IndexDescriptor that caches some
 // commonly accessed information and keeps a reference to the table wrapper.
 type optIndex struct {
-	tbl           *optTable
+	tab           *optTable
 	desc          *sqlbase.IndexDescriptor
 	numCols       int
 	numUniqueCols int
@@ -158,15 +158,15 @@ type optIndex struct {
 
 var _ opt.Index = &optIndex{}
 
-func newOptIndex(tbl *optTable, desc *sqlbase.IndexDescriptor) *optIndex {
+func newOptIndex(tab *optTable, desc *sqlbase.IndexDescriptor) *optIndex {
 	oi := &optIndex{}
-	oi.init(tbl, desc)
+	oi.init(tab, desc)
 	return oi
 }
 
 // init allows the optIndex wrapper to be inlined.
-func (oi *optIndex) init(tbl *optTable, desc *sqlbase.IndexDescriptor) {
-	oi.tbl = tbl
+func (oi *optIndex) init(tab *optTable, desc *sqlbase.IndexDescriptor) {
+	oi.tab = tab
 	oi.desc = desc
 	oi.numCols = len(desc.ColumnIDs) + len(desc.ExtraColumnIDs) + len(desc.StoreColumnIDs)
 
@@ -196,9 +196,9 @@ func (oi *optIndex) UniqueColumnCount() int {
 func (oi *optIndex) Column(i int) opt.IndexColumn {
 	length := len(oi.desc.ColumnIDs)
 	if i < length {
-		ord := oi.tbl.lookupColumnOrdinal(oi.desc.ColumnIDs[i])
+		ord := oi.tab.lookupColumnOrdinal(oi.desc.ColumnIDs[i])
 		return opt.IndexColumn{
-			Column:     oi.tbl.Column(ord),
+			Column:     oi.tab.Column(ord),
 			Ordinal:    ord,
 			Descending: oi.desc.ColumnDirections[i] == sqlbase.IndexDescriptor_DESC,
 		}
@@ -207,11 +207,11 @@ func (oi *optIndex) Column(i int) opt.IndexColumn {
 	i -= length
 	length = len(oi.desc.ExtraColumnIDs)
 	if i < length {
-		ord := oi.tbl.lookupColumnOrdinal(oi.desc.ExtraColumnIDs[i])
-		return opt.IndexColumn{Column: oi.tbl.Column(ord), Ordinal: ord}
+		ord := oi.tab.lookupColumnOrdinal(oi.desc.ExtraColumnIDs[i])
+		return opt.IndexColumn{Column: oi.tab.Column(ord), Ordinal: ord}
 	}
 
 	i -= length
-	ord := oi.tbl.lookupColumnOrdinal(oi.desc.StoreColumnIDs[i])
-	return opt.IndexColumn{Column: oi.tbl.Column(ord), Ordinal: ord}
+	ord := oi.tab.lookupColumnOrdinal(oi.desc.StoreColumnIDs[i])
+	return opt.IndexColumn{Column: oi.tab.Column(ord), Ordinal: ord}
 }

--- a/pkg/sql/opt_index_selection.go
+++ b/pkg/sql/opt_index_selection.go
@@ -463,7 +463,7 @@ func (v *indexInfo) makeIndexConstraints(
 
 		colDesc := &v.desc.Columns[idx]
 		colInfos = append(colInfos, idxconstraint.IndexColumnInfo{
-			VarIdx:    opt.ColumnIndex(idx + 1),
+			VarID:     opt.ColumnID(idx + 1),
 			Typ:       colDesc.Type.ToDatumType(),
 			Direction: dir,
 			Nullable:  colDesc.Nullable,


### PR DESCRIPTION
As we add index selection to the optimizer, it is becoming
increasingly confusing to have opt.Table, opt.Index, and
opt.TableIndex. The word "Index" is too overloaded. So this PR
renames opt.TableIndex to opt.TableID and opt.ColumnIndex to
opt.ColumnID.

Release note: None