### PR TITLE
acceptance: fix and reenable TestDockerCSharp

### DIFF
--- a/pkg/acceptance/adapter_test.go
+++ b/pkg/acceptance/adapter_test.go
@@ -42,7 +42,6 @@ func TestDockerC(t *testing.T) {
 }
 
 func TestDockerCSharp(t *testing.T) {
-	t.Skip("#22769")
 	s := log.Scope(t)
 	defer s.Close(t)
 


### PR DESCRIPTION
The name resolution overhaul (#22371) caused TestDockerCSharp to start
failing. Specifically, I suspect that Npgsql performs some query on a
table in the pg_catalog schema, which now requires the session database
to exist. There seems to be no way to prevent Npgsql from performing
this query, so simply instruct it to connect to the system database,
which is guaranteed to exist.

Also delete a test that checked the oid of the pg_catalog namespace
entry. That's changed since the test has been skipped, and seems like a
moving target. I'm not sure why we cared about the oid's value in the
first place.

Fix #22769.

Release note: None