### PR TITLE
workload/tpcc: forward port everything

### DIFF
--- a/pkg/workload/tpcc/audit.go
+++ b/pkg/workload/tpcc/audit.go
@@ -1,0 +1,65 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+
+package tpcc
+
+import (
+	"fmt"
+	"sync/atomic"
+
+	"github.com/pkg/errors"
+)
+
+// auditor maintains statistics about TPC-C input data and runs distribution
+// checks, as specified in Clause 9.2 of the TPC-C spec.
+type auditor struct {
+	newOrderTransactions uint64
+	newOrderRollbacks    uint64
+}
+
+// runChecks runs the audit checks and prints warnings to stdout for those that
+// fail.
+func (a *auditor) runChecks() {
+	type check struct {
+		name string
+		f    func(a *auditor) error
+	}
+	checks := []check{
+		{"9.2.2.5.1", check92251},
+	}
+	for _, check := range checks {
+		result := check.f(a)
+		if result != nil {
+			fmt.Println(errors.Wrapf(result, "WARN: Failed audit check %s", check.name))
+		}
+	}
+}
+
+func check92251(a *auditor) error {
+	// At least 0.9% and at most 1.1% of the New-Order transactions roll back as a
+	// result of an unused item number.
+	orders := atomic.LoadUint64(&a.newOrderTransactions)
+	if orders < 10000 {
+		// Not enough orders to be statistically significant.
+		return nil
+	}
+	rollbacks := atomic.LoadUint64(&a.newOrderRollbacks)
+	rollbackPct := 100 * float64(rollbacks) / float64(orders)
+	if rollbackPct < 0.9 || rollbackPct > 1.1 {
+		return errors.Errorf(
+			"new order rollback percent %.1f is not between allowed bounds [0.9, 1.1]", rollbackPct)
+	}
+	return nil
+}

--- a/pkg/workload/tpcc/ddls.go
+++ b/pkg/workload/tpcc/ddls.go
@@ -14,6 +14,15 @@
 
 package tpcc
 
+import (
+	gosql "database/sql"
+	"encoding/binary"
+	"fmt"
+	"math"
+
+	"github.com/cockroachdb/cockroach/pkg/util/uuid"
+)
+
 const (
 	tpccWarehouseSchema = `(
 		w_id        integer   not null primary key,
@@ -148,3 +157,62 @@ const (
 	)`
 	tpccOrderLineSchemaInterleave = ` interleave in parent "order" (ol_w_id, ol_d_id, ol_o_id)`
 )
+
+// NB: Since we always split at the same points (specific warehouse IDs and
+// item IDs), splitting is idempotent.
+func splitTables(db *gosql.DB, warehouses int) {
+	// Split district and warehouse tables every 10 warehouses.
+	const warehousesPerRange = 10
+	for i := warehousesPerRange; i < warehouses; i += warehousesPerRange {
+		sql := fmt.Sprintf("ALTER TABLE warehouse SPLIT AT VALUES (%d)", i)
+		if _, err := db.Exec(sql); err != nil {
+			panic(fmt.Sprintf("Couldn't exec %s: %s\n", sql, err))
+		}
+		sql = fmt.Sprintf("ALTER TABLE district SPLIT AT VALUES (%d, 0)", i)
+		if _, err := db.Exec(sql); err != nil {
+			panic(fmt.Sprintf("Couldn't exec %s: %s\n", sql, err))
+		}
+	}
+
+	// Split the item table every 100 items.
+	const itemsPerRange = 100
+	for i := itemsPerRange; i < numItems; i += itemsPerRange {
+		sql := fmt.Sprintf("ALTER TABLE item SPLIT AT VALUES (%d)", i)
+		if _, err := db.Exec(sql); err != nil {
+			panic(fmt.Sprintf("Couldn't exec %s: %s\n", sql, err))
+		}
+	}
+
+	// Split the history table into 1000 ranges.
+	const maxVal = math.MaxUint64
+	const valsPerRange uint64 = maxVal / 1000
+	for i := 1; i < 100; i++ {
+		var u uuid.UUID
+		binary.BigEndian.PutUint64(u.GetBytes()[:], uint64(i)*valsPerRange)
+		sql := fmt.Sprintf("ALTER TABLE history SPLIT AT VALUES ('%s')", u.String())
+		if _, err := db.Exec(sql); err != nil {
+			panic(fmt.Sprintf("Couldn't exec %s: %s\n", sql, err))
+		}
+	}
+}
+
+func scatterRanges(db *gosql.DB) {
+	tables := []string{
+		`customer`,
+		`district`,
+		`history`,
+		`item`,
+		`new_order`,
+		`"order"`,
+		`order_line`,
+		`stock`,
+		`warehouse`,
+	}
+
+	for _, table := range tables {
+		sql := fmt.Sprintf(`ALTER TABLE %s SCATTER`, table)
+		if _, err := db.Exec(sql); err != nil {
+			panic(fmt.Sprintf("Couldn't exec %s: %s\n", sql, err))
+		}
+	}
+}

--- a/pkg/workload/tpcc/delivery.go
+++ b/pkg/workload/tpcc/delivery.go
@@ -21,8 +21,12 @@ import (
 
 	"context"
 
+	"fmt"
+	"strings"
+
 	"github.com/cockroachdb/cockroach-go/crdb"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/pkg/errors"
 )
 
 // 2.7 The Delivery Transaction
@@ -42,92 +46,127 @@ import (
 
 type delivery struct{}
 
-var _ tpccTx = newOrder{}
+var _ tpccTx = delivery{}
 
-func (del delivery) run(_ *tpcc, db *gosql.DB, wID int) (interface{}, error) {
-	oCarrierID := rand.Intn(10) + 1
+func (del delivery) run(config *tpcc, db *gosql.DB, wID int) (interface{}, error) {
+	rng := rand.New(rand.NewSource(timeutil.Now().UnixNano()))
+
+	oCarrierID := rng.Intn(10) + 1
 	olDeliveryD := timeutil.Now()
 
 	err := crdb.ExecuteTx(
 		context.Background(),
 		db,
-		&gosql.TxOptions{Isolation: gosql.LevelSerializable},
+		config.txOpts,
 		func(tx *gosql.Tx) error {
-			getNewOrder, err := tx.Prepare(`
-			SELECT no_o_id
-			FROM new_order
-			WHERE no_w_id = $1 AND no_d_id = $2
-			ORDER BY no_o_id ASC
-			LIMIT 1`)
-			if err != nil {
-				return err
-			}
-			delNewOrder, err := tx.Prepare(`
-			DELETE FROM new_order
-			WHERE no_w_id = $1 AND no_d_id = $2 AND no_o_id = $3`)
-			if err != nil {
-				return err
-			}
-			updateOrder, err := tx.Prepare(`
-			UPDATE "order"
-			SET o_carrier_id = $1
-			WHERE o_w_id = $2 AND o_d_id = $3 AND o_id = $4
-			RETURNING o_c_id`)
-			if err != nil {
-				return err
-			}
-			updateOrderLine, err := tx.Prepare(`
-			UPDATE order_line
-			SET ol_delivery_d = $1
-			WHERE ol_w_id = $2 AND ol_d_id = $3 AND ol_o_id = $4`)
-			if err != nil {
-				return err
-			}
-			sumOrderLine, err := tx.Prepare(`
-			SELECT SUM(ol_amount) FROM order_line
-			WHERE ol_w_id = $1 AND ol_d_id = $2 AND ol_o_id = $3`)
-			if err != nil {
-				return err
-			}
-			updateCustomer, err := tx.Prepare(`
-			UPDATE customer
-			SET (c_balance, c_delivery_cnt) =
-				(c_Balance + $1, c_delivery_cnt + 1)
-			WHERE c_w_id = $2 AND c_d_id = $3 AND c_id = $4`)
-			if err != nil {
-				return err
-			}
-
 			// 2.7.4.2. For each district:
+			dIDoIDPairs := make(map[int]int)
+			dIDolTotalPairs := make(map[int]float64)
 			for dID := 1; dID <= 10; dID++ {
 				var oID int
-				if err := getNewOrder.QueryRow(wID, dID).Scan(&oID); err != nil {
+				if err := tx.QueryRow(fmt.Sprintf(`
+					SELECT no_o_id
+					FROM new_order
+					WHERE no_w_id = %d AND no_d_id = %d
+					ORDER BY no_o_id ASC
+					LIMIT 1`,
+					wID, dID)).Scan(&oID); err != nil {
 					// If no matching order is found, the delivery of this order is skipped.
 					if err != gosql.ErrNoRows {
 						return err
 					}
 					continue
 				}
-				if _, err := delNewOrder.Exec(wID, dID, oID); err != nil {
-					return err
-				}
-				var oCID int
-				if err := updateOrder.QueryRow(oCarrierID, wID, dID, oID).Scan(&oCID); err != nil {
-					return err
-				}
-				if _, err := updateOrderLine.Exec(olDeliveryD, wID, dID, oID); err != nil {
-					return err
-				}
+				dIDoIDPairs[dID] = oID
+
 				var olTotal float64
-				if err := sumOrderLine.QueryRow(wID, dID, oID).Scan(&olTotal); err != nil {
+				if err := tx.QueryRow(fmt.Sprintf(`
+						SELECT SUM(ol_amount) FROM order_line
+						WHERE ol_w_id = %d AND ol_d_id = %d AND ol_o_id = %d`,
+					wID, dID, oID)).Scan(&olTotal); err != nil {
 					return err
 				}
-				if _, err := updateCustomer.Exec(olTotal, wID, dID, oID); err != nil {
-					return err
-				}
+				dIDolTotalPairs[dID] = olTotal
 			}
-			return nil
-		},
-	)
+			dIDoIDPairsStr := makeInTuples(dIDoIDPairs)
+
+			rows, err := tx.Query(fmt.Sprintf(`
+					UPDATE "order"
+					SET o_carrier_id = %d
+					WHERE o_w_id = %d AND (o_d_id, o_id) IN (%s)
+					RETURNING o_d_id, o_c_id`,
+				oCarrierID, wID, dIDoIDPairsStr))
+			if err != nil {
+				return err
+			}
+			dIDcIDPairs := make(map[int]int)
+			for rows.Next() {
+				var dID, oCID int
+				if err := rows.Scan(&dID, &oCID); err != nil {
+					rows.Close()
+					return err
+				}
+				dIDcIDPairs[dID] = oCID
+			}
+			if err := rows.Err(); err != nil {
+				return err
+			}
+			rows.Close()
+
+			if err := checkSameKeys(dIDoIDPairs, dIDcIDPairs); err != nil {
+				return err
+			}
+			dIDcIDPairsStr := makeInTuples(dIDcIDPairs)
+			dIDToOlTotalStr := makeWhereCases(dIDolTotalPairs)
+
+			if _, err := tx.Exec(fmt.Sprintf(`
+				UPDATE customer
+				SET c_delivery_cnt = c_delivery_cnt + 1,
+					c_balance = c_balance + CASE c_d_id %s END
+				WHERE c_w_id = %d AND (c_d_id, c_id) IN (%s)`,
+				dIDToOlTotalStr, wID, dIDcIDPairsStr)); err != nil {
+				return err
+			}
+			if _, err := tx.Exec(fmt.Sprintf(`
+				DELETE FROM new_order
+				WHERE no_w_id = %d AND (no_d_id, no_o_id) IN (%s)`,
+				wID, dIDoIDPairsStr)); err != nil {
+				return err
+			}
+			_, err = tx.Exec(fmt.Sprintf(`
+				UPDATE order_line
+				SET ol_delivery_d = '%s'
+				WHERE ol_w_id = %d AND (ol_d_id, ol_o_id) IN (%s)`,
+				olDeliveryD.Format("2006-01-02 15:04:05"), wID, dIDoIDPairsStr))
+			return err
+		})
 	return nil, err
+}
+
+func makeInTuples(pairs map[int]int) string {
+	tupleStrs := make([]string, 0, len(pairs))
+	for k, v := range pairs {
+		tupleStrs = append(tupleStrs, fmt.Sprintf("(%d, %d)", k, v))
+	}
+	return strings.Join(tupleStrs, ", ")
+}
+
+func makeWhereCases(cases map[int]float64) string {
+	casesStrs := make([]string, 0, len(cases))
+	for k, v := range cases {
+		casesStrs = append(casesStrs, fmt.Sprintf("WHEN %d THEN %f", k, v))
+	}
+	return strings.Join(casesStrs, " ")
+}
+
+func checkSameKeys(a, b map[int]int) error {
+	if len(a) != len(b) {
+		return errors.Errorf("different number of keys")
+	}
+	for k := range a {
+		if _, ok := b[k]; !ok {
+			return errors.Errorf("missing key %v", k)
+		}
+	}
+	return nil
 }

--- a/pkg/workload/tpcc/new_order.go
+++ b/pkg/workload/tpcc/new_order.go
@@ -19,10 +19,13 @@ import (
 	gosql "database/sql"
 	"fmt"
 	"math/rand"
+	"sort"
 	"strings"
 	"time"
 
 	"context"
+
+	"sync/atomic"
 
 	"github.com/cockroachdb/cockroach-go/crdb"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
@@ -43,6 +46,7 @@ import (
 type orderItem struct {
 	olSupplyWID  int    // supplying warehouse id
 	olIID        int    // item id
+	olNumber     int    // item number in order
 	iName        string // item name
 	olQuantity   int    // order quantity
 	brandGeneric string
@@ -78,6 +82,8 @@ type newOrder struct{}
 var _ tpccTx = newOrder{}
 
 func (n newOrder) run(config *tpcc, db *gosql.DB, wID int) (interface{}, error) {
+	atomic.AddUint64(&config.auditor.newOrderTransactions, 1)
+
 	rng := rand.New(rand.NewSource(timeutil.Now().UnixNano()))
 
 	d := newOrderData{
@@ -88,6 +94,11 @@ func (n newOrder) run(config *tpcc, db *gosql.DB, wID int) (interface{}, error) 
 	}
 	d.items = make([]orderItem, d.oOlCnt)
 
+	// itemIDs tracks the item ids in the order so that we can prevent adding
+	// multiple items with the same ID. This would not make sense because each
+	// orderItem already tracks a quantity that can be larger than 1.
+	itemIDs := make(map[int]struct{})
+
 	// 2.4.1.4: A fixed 1% of the New-Order transactions are chosen at random to
 	// simulate user data entry errors and exercise the performance of rolling
 	// back update transactions.
@@ -97,6 +108,7 @@ func (n newOrder) run(config *tpcc, db *gosql.DB, wID int) (interface{}, error) 
 	allLocal := 1
 	for i := 0; i < d.oOlCnt; i++ {
 		item := orderItem{
+			olNumber: i + 1,
 			// 2.4.1.5.3: order has a quantity [1..10]
 			olQuantity: rand.Intn(10) + 1,
 		}
@@ -105,7 +117,14 @@ func (n newOrder) run(config *tpcc, db *gosql.DB, wID int) (interface{}, error) 
 		if rollback && i == d.oOlCnt-1 {
 			item.olIID = -1
 		} else {
-			item.olIID = randItemID(rng)
+			// Loop until we find a unique item ID.
+			for {
+				item.olIID = randItemID(rng)
+				if _, ok := itemIDs[item.olIID]; !ok {
+					itemIDs[item.olIID] = struct{}{}
+					break
+				}
+			}
 		}
 		// 2.4.1.5.2: 1% of the time, an item is supplied from a remote warehouse.
 		item.remoteWarehouse = rand.Intn(100) == 0
@@ -118,127 +137,222 @@ func (n newOrder) run(config *tpcc, db *gosql.DB, wID int) (interface{}, error) 
 		d.items[i] = item
 	}
 
+	// Sort the items in the same order that we will require from batch select queries.
+	sort.Slice(d.items, func(i, j int) bool {
+		return d.items[i].olIID < d.items[j].olIID
+	})
+
 	d.oEntryD = timeutil.Now()
 
 	err := crdb.ExecuteTx(
 		context.Background(),
 		db,
-		&gosql.TxOptions{Isolation: gosql.LevelSerializable},
+		config.txOpts,
 		func(tx *gosql.Tx) error {
+			// Select the district tax rate and next available order number, bumping it.
+			var dNextOID int
+			if err := tx.QueryRow(fmt.Sprintf(`
+				UPDATE district
+				SET d_next_o_id = d_next_o_id + 1
+				WHERE d_w_id = %[1]d AND d_id = %[2]d
+				RETURNING d_tax, d_next_o_id`,
+				d.wID, d.dID),
+			).Scan(&d.dTax, &dNextOID); err != nil {
+				return err
+			}
+			d.oID = dNextOID - 1
+
 			// Select the warehouse tax rate.
-			if err := tx.QueryRow(
-				`SELECT w_tax FROM warehouse WHERE w_id = $1`,
-				wID,
+			if err := tx.QueryRow(fmt.Sprintf(`
+				SELECT w_tax FROM warehouse WHERE w_id = %[1]d`,
+				wID),
 			).Scan(&d.wTax); err != nil {
 				return err
 			}
 
-			// Select the district tax rate and next available order number, bumping it.
-			var dNextOID int
-			if err := tx.QueryRow(`
-				UPDATE district
-				SET d_next_o_id = d_next_o_id + 1
-				WHERE d_w_id = $1 AND d_id = $2
-				RETURNING d_tax, d_next_o_id`,
-				d.wID, d.dID,
-			).Scan(&d.dTax, &dNextOID); err != nil {
-				return err
-			}
-
-			d.oID = dNextOID - 1
-
 			// Select the customer's discount, last name and credit.
-			if err := tx.QueryRow(`
+			if err := tx.QueryRow(fmt.Sprintf(`
 				SELECT c_discount, c_last, c_credit
 				FROM customer
-				WHERE c_w_id = $1 AND c_d_id = $2 AND c_id = $3`,
-				d.wID, d.dID, d.cID,
+				WHERE c_w_id = %[1]d AND c_d_id = %[2]d AND c_id = %[3]d`,
+				d.wID, d.dID, d.cID),
 			).Scan(&d.cDiscount, &d.cLast, &d.cCredit); err != nil {
 				return err
 			}
 
-			// Insert row into the orders and new orders table.
-			if _, err := tx.Exec(`
-				INSERT INTO "order" (o_id, o_d_id, o_w_id, o_c_id, o_entry_d, o_ol_cnt, o_all_local)
-				VALUES ($1, $2, $3, $4, $5, $6, $7)`,
-				d.oID, d.dID, d.wID, d.cID, d.oEntryD, d.oOlCnt, allLocal); err != nil {
-				return err
-			}
-			if _, err := tx.Exec(`
-				INSERT INTO new_order (no_o_id, no_d_id, no_w_id)
-				VALUES ($1, $2, $3)`,
-				d.oID, d.dID, d.wID); err != nil {
-				return err
-			}
-
-			selectItem, err := tx.Prepare(`SELECT i_price, i_name, i_data FROM item WHERE i_id=$1`)
-			if err != nil {
-				return err
-			}
-			updateStock, err := tx.Prepare(fmt.Sprintf(`
-			UPDATE stock
-			SET (s_quantity, s_ytd, s_order_cnt, s_remote_cnt) =
-				(CASE s_quantity >= $1 + 10 WHEN true THEN s_quantity-$1 ELSE (s_quantity-$1)+91 END,
-				 s_ytd + $1,
-				 s_order_cnt + 1,
-				 s_remote_cnt + (CASE $2::bool WHEN true THEN 1 ELSE 0 END))
-			WHERE s_i_id=$3 AND s_w_id=$4
-			RETURNING s_dist_%02d, s_data`, d.dID))
-			if err != nil {
-				return err
-			}
-			insertOrderLine, err := tx.Prepare(`
-			INSERT INTO order_line(ol_o_id, ol_d_id, ol_w_id, ol_number, ol_i_id, ol_supply_w_id, ol_quantity, ol_amount, ol_dist_info)
-			VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)`)
-			if err != nil {
-				return err
-			}
-
-			var iData string
 			// 2.4.2.2: For each o_ol_cnt item in the order, query the relevant item
 			// row, update the stock row to account for the order, and insert a new
 			// line into the order_line table to reflect the item on the order.
+			itemIDs := make([]string, d.oOlCnt)
 			for i, item := range d.items {
-				if err := selectItem.QueryRow(item.olIID).Scan(&item.iPrice, &item.iName, &iData); err != nil {
-					if rollback && item.olIID < 0 {
+				itemIDs[i] = fmt.Sprint(item.olIID)
+			}
+			rows, err := tx.Query(fmt.Sprintf(`
+				SELECT i_price, i_name, i_data
+				FROM item
+				WHERE i_id IN (%[1]s)
+				ORDER BY i_id`,
+				strings.Join(itemIDs, ", ")),
+			)
+			if err != nil {
+				return err
+			}
+			iDatas := make([]string, d.oOlCnt)
+			for i := range d.items {
+				item := &d.items[i]
+				iData := &iDatas[i]
+
+				if !rows.Next() {
+					if rollback {
 						// 2.4.2.3: roll back when we're expecting a rollback due to
 						// simulated user error (invalid item id) and we actually
 						// can't find the item. The spec requires us to actually go
 						// to the database for this, even though we know earlier
 						// that the item has an invalid number.
+						atomic.AddUint64(&config.auditor.newOrderRollbacks, 1)
 						return errSimulated
 					}
+					return errors.New("missing item row")
+				}
+
+				err = rows.Scan(&item.iPrice, &item.iName, iData)
+				if err != nil {
+					rows.Close()
+					return err
+				}
+			}
+			if rows.Next() {
+				return errors.New("extra item row")
+			}
+			if err := rows.Err(); err != nil {
+				return err
+			}
+			rows.Close()
+
+			stockIDs := make([]string, d.oOlCnt)
+			for i, item := range d.items {
+				stockIDs[i] = fmt.Sprintf("(%d, %d)", item.olIID, item.olSupplyWID)
+			}
+			rows, err = tx.Query(fmt.Sprintf(`
+				SELECT s_quantity, s_ytd, s_order_cnt, s_remote_cnt, s_data, s_dist_%02[1]d
+				FROM stock
+				WHERE (s_i_id, s_w_id) IN (%[2]s)
+				ORDER BY s_i_id`,
+				d.dID, strings.Join(stockIDs, ", ")),
+			)
+			if err != nil {
+				return err
+			}
+			distInfos := make([]string, d.oOlCnt)
+			sQuantityUpdateCases := make([]string, d.oOlCnt)
+			sYtdUpdateCases := make([]string, d.oOlCnt)
+			sOrderCntUpdateCases := make([]string, d.oOlCnt)
+			sRemoteCntUpdateCases := make([]string, d.oOlCnt)
+			for i := range d.items {
+				item := &d.items[i]
+
+				if !rows.Next() {
+					return errors.New("missing stock row")
+				}
+
+				var sQuantity, sYtd, sOrderCnt, sRemoteCnt int
+				var sData string
+				err = rows.Scan(&sQuantity, &sYtd, &sOrderCnt, &sRemoteCnt, &sData, &distInfos[i])
+				if err != nil {
+					rows.Close()
 					return err
 				}
 
-				var distInfo, sData string
-				if err := updateStock.QueryRow(
-					item.olQuantity, item.remoteWarehouse, item.olIID, item.olSupplyWID,
-				).Scan(&distInfo, &sData); err != nil {
-					return err
-				}
-				if strings.Contains(sData, originalString) && strings.Contains(iData, originalString) {
+				if strings.Contains(sData, originalString) && strings.Contains(iDatas[i], originalString) {
 					item.brandGeneric = "B"
 				} else {
 					item.brandGeneric = "G"
 				}
 
+				newSQuantity := sQuantity - item.olQuantity
+				if sQuantity < item.olQuantity+10 {
+					newSQuantity += 91
+				}
+
+				newSRemoteCnt := sRemoteCnt
+				if item.remoteWarehouse {
+					newSRemoteCnt++
+				}
+
+				sQuantityUpdateCases[i] = fmt.Sprintf("WHEN %s THEN %d", stockIDs[i], newSQuantity)
+				sYtdUpdateCases[i] = fmt.Sprintf("WHEN %s THEN %d", stockIDs[i], sYtd+item.olQuantity)
+				sOrderCntUpdateCases[i] = fmt.Sprintf("WHEN %s THEN %d", stockIDs[i], sOrderCnt+1)
+				sRemoteCntUpdateCases[i] = fmt.Sprintf("WHEN %s THEN %d", stockIDs[i], newSRemoteCnt)
+			}
+			if rows.Next() {
+				return errors.New("extra stock row")
+			}
+			if err := rows.Err(); err != nil {
+				return err
+			}
+			rows.Close()
+
+			// Insert row into the orders and new orders table.
+			if _, err := tx.Exec(fmt.Sprintf(`
+				INSERT INTO "order" (o_id, o_d_id, o_w_id, o_c_id, o_entry_d, o_ol_cnt, o_all_local)
+				VALUES (%[1]d, %[2]d, %[3]d, %[4]d, '%[5]s', %[6]d, %[7]d)`,
+				d.oID, d.dID, d.wID, d.cID, d.oEntryD.Format("2006-01-02 15:04:05"),
+				d.oOlCnt, allLocal),
+			); err != nil {
+				return err
+			}
+			if _, err := tx.Exec(fmt.Sprintf(`
+				INSERT INTO new_order (no_o_id, no_d_id, no_w_id) 
+				VALUES (%[1]d, %[2]d, %[3]d)`,
+				d.oID, d.dID, d.wID)); err != nil {
+				return err
+			}
+
+			// Update the stock table for each item.
+			if _, err := tx.Exec(fmt.Sprintf(`
+				UPDATE stock
+				SET
+					s_quantity = CASE (s_i_id, s_w_id) %[1]s ELSE crdb_internal.force_error('', 'unknown case') END,
+					s_ytd = CASE (s_i_id, s_w_id) %[2]s END,
+					s_order_cnt = CASE (s_i_id, s_w_id) %[3]s END,
+					s_remote_cnt = CASE (s_i_id, s_w_id) %[4]s END
+				WHERE (s_i_id, s_w_id) IN (%[5]s)`,
+				strings.Join(sQuantityUpdateCases, " "),
+				strings.Join(sYtdUpdateCases, " "),
+				strings.Join(sOrderCntUpdateCases, " "),
+				strings.Join(sRemoteCntUpdateCases, " "),
+				strings.Join(stockIDs, ", ")),
+			); err != nil {
+				return err
+			}
+
+			// Insert a new order line for each item in the order.
+			olValsStrings := make([]string, d.oOlCnt)
+			for i := range d.items {
+				item := &d.items[i]
 				item.olAmount = float64(item.olQuantity) * item.iPrice
 				d.totalAmount += item.olAmount
-				if _, err := insertOrderLine.Exec(
-					d.oID, // ol_o_id
-					d.dID,
-					d.wID,
-					i+1, // ol_number is a counter over the items in the order.
-					item.olIID,
-					item.olSupplyWID,
-					item.olQuantity,
-					item.olAmount,
-					distInfo, // ol_dist_info is set to the contents of s_dist_xx
-				); err != nil {
-					return err
-				}
+
+				olValsStrings[i] = fmt.Sprintf("(%d,%d,%d,%d,%d,%d,%d,%f,'%s')",
+					d.oID,            // ol_o_id
+					d.dID,            // ol_d_id
+					d.wID,            // ol_w_id
+					item.olNumber,    // ol_number
+					item.olIID,       // ol_i_id
+					item.olSupplyWID, // ol_supply_w_id
+					item.olQuantity,  // ol_quantity
+					item.olAmount,    // ol_amount
+					distInfos[i],     // ol_dist_info
+				)
 			}
+			if _, err := tx.Exec(fmt.Sprintf(`
+				INSERT INTO order_line(ol_o_id, ol_d_id, ol_w_id, ol_number, ol_i_id, ol_supply_w_id, ol_quantity, ol_amount, ol_dist_info)
+				VALUES %s`,
+				strings.Join(olValsStrings, ", ")),
+			); err != nil {
+				return err
+			}
+
 			// 2.4.2.2: total_amount = sum(OL_AMOUNT) * (1 - C_DISCOUNT) * (1 + W_TAX + D_TAX)
 			d.totalAmount *= (1 - d.cDiscount) * (1 + d.wTax + d.dTax)
 
@@ -248,4 +362,5 @@ func (n newOrder) run(config *tpcc, db *gosql.DB, wID int) (interface{}, error) 
 		return d, nil
 	}
 	return d, err
+
 }

--- a/pkg/workload/tpcc/partition.go
+++ b/pkg/workload/tpcc/partition.go
@@ -1,0 +1,331 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+
+package tpcc
+
+import (
+	"bytes"
+	gosql "database/sql"
+	"encoding/binary"
+	"fmt"
+	"math"
+
+	"github.com/cockroachdb/cockroach/pkg/util/uuid"
+)
+
+func configureZone(db *gosql.DB, table, partition string, constraint int) {
+	sql := fmt.Sprintf(
+		`ALTER PARTITION %s OF TABLE %s EXPERIMENTAL CONFIGURE ZONE 'constraints: [+rack=%d]'`,
+		partition, table, constraint)
+	if _, err := db.Exec(sql); err != nil {
+		panic(fmt.Sprintf("Couldn't exec %s: %s\n", sql, err))
+	}
+}
+
+func partitionWarehouse(db *gosql.DB, wIDs []int, partitions int) {
+	var buf bytes.Buffer
+	buf.WriteString("ALTER TABLE warehouse PARTITION BY RANGE (w_id) (\n")
+	for i := 0; i < partitions; i++ {
+		fmt.Fprintf(&buf, "  PARTITION p%d VALUES FROM (%d) to (%d)", i, wIDs[i], wIDs[i+1])
+		if i+1 < partitions {
+			buf.WriteString(",")
+		}
+		buf.WriteString("\n")
+	}
+	buf.WriteString(")\n")
+	if _, err := db.Exec(buf.String()); err != nil {
+		panic(fmt.Sprintf("Couldn't exec %s: %s\n", buf.String(), err))
+	}
+
+	for i := 0; i < partitions; i++ {
+		configureZone(db, "warehouse", fmt.Sprintf("p%d", i), i)
+	}
+}
+
+func partitionDistrict(db *gosql.DB, wIDs []int, partitions int) {
+	var buf bytes.Buffer
+	buf.WriteString("ALTER TABLE district PARTITION BY RANGE (d_w_id) (\n")
+	for i := 0; i < partitions; i++ {
+		fmt.Fprintf(&buf, "  PARTITION p%d VALUES FROM (%d) to (%d)", i, wIDs[i], wIDs[i+1])
+		if i+1 < partitions {
+			buf.WriteString(",")
+		}
+		buf.WriteString("\n")
+	}
+	buf.WriteString(")\n")
+	if _, err := db.Exec(buf.String()); err != nil {
+		panic(fmt.Sprintf("Couldn't exec %s: %s\n", buf.String(), err))
+	}
+
+	for i := 0; i < partitions; i++ {
+		configureZone(db, "district", fmt.Sprintf("p%d", i), i)
+	}
+}
+
+func partitionNewOrder(db *gosql.DB, wIDs []int, partitions int) {
+	var buf bytes.Buffer
+	buf.WriteString("ALTER TABLE new_order PARTITION BY RANGE (no_w_id) (\n")
+	for i := 0; i < partitions; i++ {
+		fmt.Fprintf(&buf, "  PARTITION p%d VALUES FROM (%d) to (%d)", i, wIDs[i], wIDs[i+1])
+		if i+1 < partitions {
+			buf.WriteString(",")
+		}
+		buf.WriteString("\n")
+	}
+	buf.WriteString(")\n")
+	if _, err := db.Exec(buf.String()); err != nil {
+		panic(fmt.Sprintf("Couldn't exec %s: %s\n", buf.String(), err))
+	}
+
+	for i := 0; i < partitions; i++ {
+		configureZone(db, "new_order", fmt.Sprintf("p%d", i), i)
+	}
+}
+
+func partitionOrder(db *gosql.DB, wIDs []int, partitions int) {
+	targets := []string{
+		`TABLE "order"`,
+		`INDEX "order"@order_idx`,
+		`INDEX "order"@order_o_w_id_o_d_id_o_c_id_idx`,
+	}
+
+	for j, target := range targets {
+		var buf bytes.Buffer
+		fmt.Fprintf(&buf, "ALTER %s PARTITION BY RANGE (o_w_id) (\n", target)
+		for i := 0; i < partitions; i++ {
+			fmt.Fprintf(&buf, "  PARTITION p%d_%d VALUES FROM (%d) to (%d)", j, i, wIDs[i], wIDs[i+1])
+			if i+1 < partitions {
+				buf.WriteString(",")
+			}
+			buf.WriteString("\n")
+		}
+		buf.WriteString(")\n")
+		if _, err := db.Exec(buf.String()); err != nil {
+			panic(fmt.Sprintf("Couldn't exec %s: %s\n", buf.String(), err))
+		}
+	}
+
+	for i := 0; i < partitions; i++ {
+		for j := range targets {
+			configureZone(db, `"order"`, fmt.Sprintf("p%d_%d", j, i), i)
+		}
+	}
+}
+
+func partitionOrderLine(db *gosql.DB, wIDs []int, partitions int) {
+	data := []struct {
+		target string
+		column string
+	}{
+		{`TABLE order_line`, `ol_w_id`},
+		{`INDEX order_line@order_line_fk`, `ol_supply_w_id`},
+	}
+
+	for j, d := range data {
+		var buf bytes.Buffer
+		fmt.Fprintf(&buf, "ALTER %s PARTITION BY RANGE (%s) (\n", d.target, d.column)
+		for i := 0; i < partitions; i++ {
+			fmt.Fprintf(&buf, "  PARTITION p%d_%d VALUES FROM (%d) to (%d)", j, i, wIDs[i], wIDs[i+1])
+			if i+1 < partitions {
+				buf.WriteString(",")
+			}
+			buf.WriteString("\n")
+		}
+		buf.WriteString(")\n")
+		if _, err := db.Exec(buf.String()); err != nil {
+			panic(fmt.Sprintf("Couldn't exec %s: %s\n", buf.String(), err))
+		}
+	}
+
+	for i := 0; i < partitions; i++ {
+		for j := range data {
+			configureZone(db, `order_line`, fmt.Sprintf("p%d_%d", j, i), i)
+		}
+	}
+}
+
+func partitionStock(db *gosql.DB, wIDs []int, partitions int) {
+	var buf bytes.Buffer
+	buf.WriteString("ALTER TABLE stock PARTITION BY RANGE (s_w_id) (\n")
+	for i := 0; i < partitions; i++ {
+		fmt.Fprintf(&buf, "  PARTITION p%d VALUES FROM (%d) to (%d)", i, wIDs[i], wIDs[i+1])
+		if i+1 < partitions {
+			buf.WriteString(",")
+		}
+		buf.WriteString("\n")
+	}
+	buf.WriteString(")\n")
+	if _, err := db.Exec(buf.String()); err != nil {
+		panic(fmt.Sprintf("Couldn't exec %s: %s\n", buf.String(), err))
+	}
+
+	// TODO(peter): remove duplication with partitionItem().
+	const nItems = 100000
+	iIDs := make([]int, partitions+1)
+	for i := 0; i < partitions; i++ {
+		iIDs[i] = i * (nItems / partitions)
+	}
+	iIDs[partitions] = nItems
+
+	buf.Reset()
+	buf.WriteString("ALTER INDEX stock@stock_s_i_id_idx PARTITION BY RANGE (s_i_id) (\n")
+	for i := 0; i < partitions; i++ {
+		fmt.Fprintf(&buf, "  PARTITION p1_%d VALUES FROM (%d) to (%d)", i, iIDs[i], iIDs[i+1])
+		if i+1 < partitions {
+			buf.WriteString(",")
+		}
+		buf.WriteString("\n")
+	}
+	buf.WriteString(")\n")
+	if _, err := db.Exec(buf.String()); err != nil {
+		panic(fmt.Sprintf("Couldn't exec %s: %s\n", buf.String(), err))
+	}
+
+	for i := 0; i < partitions; i++ {
+		configureZone(db, "stock", fmt.Sprintf("p%d", i), i)
+		configureZone(db, "stock", fmt.Sprintf("p1_%d", i), i)
+	}
+}
+
+func partitionCustomer(db *gosql.DB, wIDs []int, partitions int) {
+	targets := []string{
+		`TABLE customer`,
+		`INDEX customer@customer_idx`,
+	}
+
+	for j, target := range targets {
+		var buf bytes.Buffer
+		fmt.Fprintf(&buf, "ALTER %s PARTITION BY RANGE (c_w_id) (\n", target)
+		for i := 0; i < partitions; i++ {
+			fmt.Fprintf(&buf, "  PARTITION p%d_%d VALUES FROM (%d) to (%d)", j, i, wIDs[i], wIDs[i+1])
+			if i+1 < partitions {
+				buf.WriteString(",")
+			}
+			buf.WriteString("\n")
+		}
+		buf.WriteString(")\n")
+		if _, err := db.Exec(buf.String()); err != nil {
+			panic(fmt.Sprintf("Couldn't exec %s: %s\n", buf.String(), err))
+		}
+	}
+
+	for i := 0; i < partitions; i++ {
+		for j := range targets {
+			configureZone(db, `customer`, fmt.Sprintf("p%d_%d", j, i), i)
+		}
+	}
+}
+
+func partitionHistory(db *gosql.DB, wIDs []int, partitions int) {
+	const maxVal = math.MaxUint64
+	rowids := make([]uuid.UUID, partitions+1)
+	for i := 0; i < partitions; i++ {
+		// We're splitting the UUID rowid column evenly into N partitions. The
+		// column is sorted lexicographically on the bytes of the UUID which means
+		// we should put the partitioning values at the front of the UUID.
+		binary.BigEndian.PutUint64(rowids[i].GetBytes()[:], uint64(i)*(maxVal/uint64(partitions)))
+	}
+	rowids[partitions], _ = uuid.FromString("ffffffff-ffff-ffff-ffff-ffffffffffff")
+
+	var buf bytes.Buffer
+	buf.WriteString("ALTER TABLE history PARTITION BY RANGE (rowid) (\n")
+	for i := 0; i < partitions; i++ {
+		fmt.Fprintf(&buf, "  PARTITION p%d VALUES FROM ('%s') to ('%s')", i, rowids[i], rowids[i+1])
+		if i+1 < partitions {
+			buf.WriteString(",")
+		}
+		buf.WriteString("\n")
+	}
+	buf.WriteString(")\n")
+	if _, err := db.Exec(buf.String()); err != nil {
+		panic(fmt.Sprintf("Couldn't exec %s: %s\n", buf.String(), err))
+	}
+
+	data := []struct {
+		target string
+		column string
+	}{
+		{`INDEX history@history_h_w_id_h_d_id_idx`, `h_w_id`},
+		{`INDEX history@history_h_c_w_id_h_c_d_id_h_c_id_idx`, `h_c_w_id`},
+	}
+
+	for j, d := range data {
+		var buf bytes.Buffer
+		fmt.Fprintf(&buf, "ALTER %s PARTITION BY RANGE (%s) (\n", d.target, d.column)
+		for i := 0; i < partitions; i++ {
+			fmt.Fprintf(&buf, "  PARTITION p%d_%d VALUES FROM (%d) to (%d)", j, i, wIDs[i], wIDs[i+1])
+			if i+1 < partitions {
+				buf.WriteString(",")
+			}
+			buf.WriteString("\n")
+		}
+		buf.WriteString(")\n")
+		if _, err := db.Exec(buf.String()); err != nil {
+			panic(fmt.Sprintf("Couldn't exec %s: %s\n", buf.String(), err))
+		}
+	}
+
+	for i := 0; i < partitions; i++ {
+		configureZone(db, `history`, fmt.Sprintf("p%d", i), i)
+		for j := range data {
+			configureZone(db, `history`, fmt.Sprintf("p%d_%d", j, i), i)
+		}
+	}
+}
+
+func partitionItem(db *gosql.DB, partitions int) {
+	const nItems = 100000
+	iIDs := make([]int, partitions+1)
+	for i := 0; i < partitions; i++ {
+		iIDs[i] = i * (nItems / partitions)
+	}
+	iIDs[partitions] = nItems
+
+	var buf bytes.Buffer
+	buf.WriteString("ALTER TABLE item PARTITION BY RANGE (i_id) (\n")
+	for i := 0; i < partitions; i++ {
+		fmt.Fprintf(&buf, "  PARTITION p%d VALUES FROM (%d) to (%d)", i, iIDs[i], iIDs[i+1])
+		if i+1 < partitions {
+			buf.WriteString(",")
+		}
+		buf.WriteString("\n")
+	}
+	buf.WriteString(")\n")
+	if _, err := db.Exec(buf.String()); err != nil {
+		panic(fmt.Sprintf("Couldn't exec %s: %s\n", buf.String(), err))
+	}
+
+	for i := 0; i < partitions; i++ {
+		configureZone(db, "item", fmt.Sprintf("p%d", i), i)
+	}
+}
+
+func partitionTables(db *gosql.DB, warehouses, partitions int) {
+	wIDs := make([]int, partitions+1)
+	for i := 0; i < partitions; i++ {
+		wIDs[i] = i * (warehouses / partitions)
+	}
+	wIDs[partitions] = warehouses
+
+	partitionWarehouse(db, wIDs, partitions)
+	partitionDistrict(db, wIDs, partitions)
+	partitionNewOrder(db, wIDs, partitions)
+	partitionOrder(db, wIDs, partitions)
+	partitionOrderLine(db, wIDs, partitions)
+	partitionStock(db, wIDs, partitions)
+	partitionCustomer(db, wIDs, partitions)
+	partitionHistory(db, wIDs, partitions)
+	partitionItem(db, partitions)
+}

--- a/pkg/workload/tpcc/random.go
+++ b/pkg/workload/tpcc/random.go
@@ -106,7 +106,7 @@ func randTax(rng *rand.Rand) float64 {
 // randInt returns a number within [min, max] inclusive.
 // See 2.1.4.
 func randInt(rng *rand.Rand, min, max int) int {
-	return rng.Intn(max-min) + min
+	return rng.Intn(max-min+1) + min
 }
 
 // See 4.3.2.3.

--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -97,6 +97,9 @@ type Hooks struct {
 	// loaded. It called after restoring a fixture. This, for example, is where
 	// creating foreign keys should go.
 	PostLoad func(*gosql.DB) error
+	// PostRun is called after workload run has ended. This is where any post-run
+	// special printing or validation can be done.
+	PostRun func() error
 }
 
 // Meta is used to register a Generator at init time and holds meta information
@@ -141,7 +144,7 @@ type Table struct {
 type QueryLoad struct {
 	SQLDatabase string
 
-	// WorkerFns one function per worker. It is to be called once per unit of
+	// WorkerFns is one function per worker. It is to be called once per unit of
 	// work to be done.
 	WorkerFns []func(context.Context) error
 


### PR DESCRIPTION
This is my attempt at forward porting all of the progress except for the checks in loadgen/tpcc to workload.

The commits are roughly named - I'll squash them further after the review, but it's probably easier to keep them like this for the review.

@danhhz 2 main things for you to look at - a new `-ramp` global argument, and a new `PostRun` member of the `Hooks` struct.

Also, keep an eye out for the `-split` arg. I see that there's a workload specific split thing, but I'm not sure if that covers the way `tpcc`'s split works.