### PR TITLE
acceptance: clean up certificate handling in adapter tests

### DIFF
--- a/pkg/acceptance/adapter_test.go
+++ b/pkg/acceptance/adapter_test.go
@@ -45,42 +45,18 @@ func TestDockerCSharp(t *testing.T) {
 	s := log.Scope(t)
 	defer s.Close(t)
 
-	const csharp = `
-	set -euxo pipefail
-
-	cd /mnt/data/csharp
-
-	# In dotnet, to get a cert with a private key, we have to use a pfx file.
-	# See:
-	# http://www.sparxeng.com/blog/software/x-509-self-signed-certificate-for-cryptography-in-net
-	# https://stackoverflow.com/questions/808669/convert-a-cert-pem-certificate-to-a-pfx-certificate
-	openssl pkcs12 -inkey ${PGSSLKEY} -in ${PGSSLCERT} -export -out node.pfx -passout pass:
-
-	dotnet %v
-	`
-
 	ctx := context.Background()
-	testDockerSuccess(ctx, t, "csharp", []string{"/bin/bash", "-c", strings.Replace(csharp, "%v", "run", 1)})
-	testDockerFail(ctx, t, "csharp", []string{"/bin/bash", "-c", strings.Replace(csharp, "%v", "notacommand", 1)})
+	testDockerSuccess(ctx, t, "csharp", []string{"sh", "-c", "cd /mnt/data/csharp && dotnet run"})
+	testDockerFail(ctx, t, "csharp", []string{"sh", "-c", "cd /mnt/data/csharp && dotnet notacommand"})
 }
 
 func TestDockerJava(t *testing.T) {
 	s := log.Scope(t)
 	defer s.Close(t)
 
-	const java = `
-	set -e
-	cd /mnt/data/java
-	# See: https://basildoncoder.com/blog/postgresql-jdbc-client-certificates.html
-	openssl pkcs8 -topk8 -inform PEM -outform DER -in /certs/node.key -out key.pk8 -nocrypt
-
-	mvn %v -o
-	rm -rf target
-	`
-
 	ctx := context.Background()
-	testDockerSuccess(ctx, t, "java", []string{"/bin/sh", "-c", strings.Replace(java, "%v", "test", 2)})
-	testDockerFail(ctx, t, "java", []string{"/bin/sh", "-c", strings.Replace(java, "%v", "foobar", 2)})
+	testDockerSuccess(ctx, t, "java", []string{"sh", "-c", "cd /mnt/data/java && mvn -o test"})
+	testDockerFail(ctx, t, "java", []string{"sh", "-c", "cd /mnt/data/java && mvn -o foobar"})
 }
 
 func TestDockerNodeJS(t *testing.T) {

--- a/pkg/acceptance/cluster/certs.go
+++ b/pkg/acceptance/cluster/certs.go
@@ -1,0 +1,76 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package cluster
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/security"
+)
+
+const certsDir = ".localcluster.certs"
+
+// keyLen is the length (in bits) of the generated CA and node certs.
+const keyLen = 1024
+
+// GenerateCerts generates CA and client certificates and private keys to be
+// used with a cluster. It returns a function that will clean up the generated
+// files.
+func GenerateCerts(ctx context.Context) func() {
+	maybePanic(os.RemoveAll(certsDir))
+
+	maybePanic(security.CreateCAPair(
+		certsDir, filepath.Join(certsDir, security.EmbeddedCAKey),
+		keyLen, 96*time.Hour, false, false))
+
+	maybePanic(security.CreateClientPair(
+		certsDir, filepath.Join(certsDir, security.EmbeddedCAKey),
+		512, 48*time.Hour, false, security.RootUser))
+
+	// Store a copy of the client private key in PKCS#8 format, which is
+	// the only format understood by PgJDBC (Java).
+	{
+		execCmd("openssl", "pkcs8", "-topk8", "-outform", "DER", "-nocrypt",
+			"-in", filepath.Join(certsDir, "client.root.key"),
+			"-out", filepath.Join(certsDir, "client.root.pk8"))
+	}
+
+	// Store a copy of the client certificate and private key in a PKCS#12
+	// bundle, which is the only format understood by Npgsql (.NET).
+	{
+		execCmd("openssl", "pkcs12", "-export", "-password", "pass:",
+			"-in", filepath.Join(certsDir, "client.root.crt"),
+			"-inkey", filepath.Join(certsDir, "client.root.key"),
+			"-out", filepath.Join(certsDir, "client.root.pk12"))
+	}
+
+	return func() { _ = os.RemoveAll(certsDir) }
+}
+
+// GenerateCerts is only called in a file protected by a build tag. Suppress the
+// unused linter's warning.
+var _ = GenerateCerts
+
+func execCmd(args ...string) {
+	cmd := exec.Command(args[0], args[1:]...)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		panic(fmt.Sprintf("error: %s: %s\nout: %s\n", args, err, out))
+	}
+}

--- a/pkg/acceptance/testdata/csharp/Program.cs
+++ b/pkg/acceptance/testdata/csharp/Program.cs
@@ -25,7 +25,7 @@ namespace CockroachDrivers
 
         static void ProvideClientCertificatesCallback(X509CertificateCollection clientCerts)
         {
-              clientCerts.Add(new X509Certificate2("node.pfx"));
+              clientCerts.Add(new X509Certificate2("/certs/client.root.pk12"));
         }
 
         static void Simple(string connString)

--- a/pkg/acceptance/testdata/java/src/main/java/CockroachDBTest.java
+++ b/pkg/acceptance/testdata/java/src/main/java/CockroachDBTest.java
@@ -33,7 +33,7 @@ public abstract class CockroachDBTest {
         if (System.getenv("PGSSLCERT") != null) {
             DBUrl += "?ssl=true";
             DBUrl += "&sslcert=" + System.getenv("PGSSLCERT");
-            DBUrl += "&sslkey=key.pk8";
+            DBUrl += "&sslkey=/certs/client.root.pk8";
             DBUrl += "&sslrootcert=/certs/ca.crt";
             DBUrl += "&sslfactory=org.postgresql.ssl.jdbc4.LibPQFactory";
         } else {

--- a/pkg/acceptance/util_docker.go
+++ b/pkg/acceptance/util_docker.go
@@ -34,8 +34,8 @@ func defaultContainerConfig() container.Config {
 		Env: []string{
 			fmt.Sprintf("PGUSER=%s", security.RootUser),
 			fmt.Sprintf("PGPORT=%s", base.DefaultPort),
-			"PGSSLCERT=/certs/node.crt",
-			"PGSSLKEY=/certs/node.key",
+			"PGSSLCERT=/certs/client.root.crt",
+			"PGSSLKEY=/certs/client.root.key",
 		},
 		Entrypoint: []string{"autouseradd", "-u", "roach", "-C", "/home/roach", "--"},
 	}


### PR DESCRIPTION
This commit addresses several problems with how our acceptance adapter
tests used certificates:

  1. Adapters should not connect using the node certificate. This commit
     switches them to the root client certificate instead.

  2. Adapters that can't handle a PEM certificate should not be
     responsible for mucking with OpenSSL to convert the certificate
     into a format they can understand. This commit centralizes
     certificate format conversions in cluster.GenerateCerts.

  3. Docker clusters don't need to regenerate their CA or client
     certificates on every run. This commit adjusts the test harness so
     that CA and client certificates are generated once at the start of
     the test run and reused by every Docker cluster.

Release note: None