### PR TITLE
server: embed the pprof ui

### DIFF
--- a/pkg/server/debug/pprofui/fakeflags.go
+++ b/pkg/server/debug/pprofui/fakeflags.go
@@ -1,0 +1,45 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package pprofui
+
+import "github.com/spf13/pflag"
+
+// pprofFlags is a wrapper to satisfy pprof's client flag interface.
+// That interface is satisfied by what the standard flag package
+// offers, with some tweaks. In this package, we just want to specify
+// the command line args directly; pprofFlags lets us do that
+// essentially by mocking out `os.Args`. `pprof` will register all of
+// its flags via this struct, and then they get populated from `args`
+// below.
+type pprofFlags struct {
+	args []string // passed to Parse()
+	*pflag.FlagSet
+}
+
+func (pprofFlags) ExtraUsage() string {
+	return ""
+}
+
+func (f pprofFlags) StringList(o, d, c string) *[]*string {
+	return &[]*string{f.String(o, d, c)}
+}
+
+func (f pprofFlags) Parse(usage func()) []string {
+	f.FlagSet.Usage = usage
+	if err := f.FlagSet.Parse(f.args); err != nil {
+		panic(err)
+	}
+	return f.FlagSet.Args()
+}

--- a/pkg/server/debug/pprofui/response_writer.go
+++ b/pkg/server/debug/pprofui/response_writer.go
@@ -1,0 +1,42 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package pprofui
+
+import (
+	"io"
+	"net/http"
+)
+
+// responseBridge is a helper for fetching from the pprof profile handlers.
+// Their interface wants a http.ResponseWriter, so we give it one. The writes
+// are passed through to an `io.Writer` of our choosing.
+type responseBridge struct {
+	target     io.Writer
+	statusCode int
+}
+
+var _ http.ResponseWriter = &responseBridge{}
+
+func (r *responseBridge) Header() http.Header {
+	return http.Header{}
+}
+
+func (r *responseBridge) Write(b []byte) (int, error) {
+	return r.target.Write(b)
+}
+
+func (r *responseBridge) WriteHeader(statusCode int) {
+	r.statusCode = statusCode
+}

--- a/pkg/server/debug/pprofui/server.go
+++ b/pkg/server/debug/pprofui/server.go
@@ -1,0 +1,211 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package pprofui
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/pprof"
+	"net/url"
+	"path"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	runtimepprof "runtime/pprof"
+
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+	"github.com/google/pprof/driver"
+	"github.com/google/pprof/profile"
+	"github.com/pkg/errors"
+	"github.com/spf13/pflag"
+)
+
+// A Server serves up the pprof web ui. A request to /<profiletype>
+// generates a profile of the desired type and redirects to the UI for
+// it at /<profiletype>/<id>. Valid profile types at the time of
+// writing include `profile` (cpu), `goroutine`, `threadcreate`,
+// `heap`, `block`, and `mutex`.
+type Server struct {
+	storage      Storage
+	profileSem   syncutil.Mutex
+	profileTypes map[string]http.HandlerFunc
+}
+
+// NewServer creates a new Server backed by the supplied Storage.
+func NewServer(storage Storage) *Server {
+	s := &Server{
+		storage: storage,
+	}
+
+	s.profileTypes = map[string]http.HandlerFunc{
+		// The CPU profile endpoint is special in that the handler actually blocks
+		// for a predetermined duration (recording the profile in the meantime).
+		// It is not included in `runtimepprof.Profiles` below.
+		"profile": func(w http.ResponseWriter, r *http.Request) {
+			const profileDurationSeconds = 5
+			r.Form = make(url.Values)
+			r.Form.Set("seconds", strconv.Itoa(profileDurationSeconds))
+			s.profileSem.Lock()
+			defer s.profileSem.Unlock()
+			pprof.Profile(w, r)
+		},
+	}
+
+	// Register the endpoints for heap, block, threadcreate, etc.
+	for _, p := range runtimepprof.Profiles() {
+		p := p // copy
+		s.profileTypes[p.Name()] = func(w http.ResponseWriter, r *http.Request) {
+			if err := p.WriteTo(w, 0 /* debug */); err != nil {
+				w.WriteHeader(http.StatusInternalServerError)
+				_, _ = w.Write([]byte(err.Error()))
+			}
+		}
+	}
+
+	return s
+}
+
+// parsePath turns /profile/123/flamegraph/banana into (profile, 123, /flamegraph/banana).
+func (s *Server) parsePath(reqPath string) (profType string, id string, remainingPath string) {
+	parts := strings.Split(path.Clean(reqPath), "/")
+	if parts[0] == "" {
+		// The path was absolute (the typical case), pretend it was
+		// relative (to this handler's root).
+		parts = parts[1:]
+	}
+	switch len(parts) {
+	case 0:
+		return "", "", "/"
+	case 1:
+		return parts[0], "", "/"
+	default:
+		return parts[0], parts[1], "/" + strings.Join(parts[2:], "/")
+	}
+}
+
+func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	profileName, id, remainingPath := s.parsePath(r.URL.Path)
+
+	if profileName == "" {
+		// TODO(tschottdorf): serve an overview page.
+		var names []string
+		for name := range s.profileTypes {
+			names = append(names, name)
+		}
+		sort.Strings(names)
+		msg := fmt.Sprintf("Try %s for one of %s", path.Join(r.RequestURI, "<profileName>"), strings.Join(names, ", "))
+		http.Error(w, msg, http.StatusNotFound)
+		return
+	}
+
+	if id != "" {
+		// Catch nonexistent IDs early or pprof will do a worse job at
+		// giving an informative error.
+		if err := s.storage.Get(id, func(io.Reader) error { return nil }); err != nil {
+			msg := fmt.Sprintf("profile for id %s not found: %s", id, err)
+			http.Error(w, msg, http.StatusNotFound)
+			return
+		}
+
+		server := func(args *driver.HTTPServerArgs) error {
+			handler, ok := args.Handlers[remainingPath]
+			if !ok {
+				return errors.Errorf("unknown endpoint %s", remainingPath)
+			}
+			handler.ServeHTTP(w, r)
+			return nil
+		}
+
+		storageFetcher := func(_ string, _, _ time.Duration) (*profile.Profile, string, error) {
+			var p *profile.Profile
+			if err := s.storage.Get(id, func(reader io.Reader) error {
+				var err error
+				p, err = profile.Parse(reader)
+				return err
+			}); err != nil {
+				return nil, "", err
+			}
+			return p, "", nil
+		}
+
+		// Invoke the (library version) of `pprof` with a number of stubs.
+		// Specifically, we pass a fake FlagSet that plumbs through the
+		// given args, a UI that logs any errors pprof may emit, a fetcher
+		// that simply reads the profile we downloaded earlier, and a
+		// HTTPServer that pprof will pass the web ui handlers to at the
+		// end (and we let it handle this client request).
+		if err := driver.PProf(&driver.Options{
+			Flagset: &pprofFlags{
+				FlagSet: pflag.NewFlagSet("pprof", pflag.ExitOnError),
+				args: []string{
+					"--symbolize", "none",
+					"--http", "localhost:0",
+					"", // we inject our own target
+				},
+			},
+			UI:         &fakeUI{},
+			Fetch:      fetcherFn(storageFetcher),
+			HTTPServer: server,
+		}); err != nil {
+			_, _ = w.Write([]byte(err.Error()))
+		}
+
+		return
+	}
+
+	// Create and save new profile, then redirect client to corresponding ui URL.
+
+	id = s.storage.ID()
+
+	fetchHandler, ok := s.profileTypes[profileName]
+	if !ok {
+		_, _ = w.Write([]byte(fmt.Sprintf("unknown profile type %s", profileName)))
+		return
+	}
+
+	if err := s.storage.Store(id, func(w io.Writer) error {
+		req, err := http.NewRequest("GET", "/unused", bytes.NewReader(nil))
+		if err != nil {
+			return err
+		}
+		rw := &responseBridge{target: w}
+
+		fetchHandler(rw, req)
+
+		if rw.statusCode != http.StatusOK && rw.statusCode != 0 {
+			return errors.Errorf("unexpected status: %d", rw.statusCode)
+		}
+		return nil
+	}); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	// NB: direct straight to the flamegraph. This is because `pprof`
+	// shells out to `dot` for the default landing page and thus works
+	// only on hosts that have graphviz installed. You can still navigate
+	// to the dot page from there.
+	http.Redirect(w, r, r.RequestURI+"/"+id+"/flamegraph", http.StatusTemporaryRedirect)
+}
+
+type fetcherFn func(_ string, _, _ time.Duration) (*profile.Profile, string, error)
+
+func (f fetcherFn) Fetch(s string, d, t time.Duration) (*profile.Profile, string, error) {
+	return f(s, d, t)
+}

--- a/pkg/server/debug/pprofui/server_test.go
+++ b/pkg/server/debug/pprofui/server_test.go
@@ -1,0 +1,62 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package pprofui
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestServer(t *testing.T) {
+	storage := NewMemStorage(1, 0)
+	s := NewServer(storage)
+
+	for i := 0; i < 3; i++ {
+		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+			r := httptest.NewRequest("GET", "/heap/", nil)
+			w := httptest.NewRecorder()
+			s.ServeHTTP(w, r)
+
+			if a, e := w.Code, http.StatusTemporaryRedirect; a != e {
+				t.Fatalf("expected status code %d, got %d", e, a)
+			}
+
+			loc := w.Result().Header.Get("Location")
+
+			if a, e := loc, fmt.Sprintf("/heap/%d/flamegraph", i+1); a != e {
+				t.Fatalf("expected location header %s, but got %s", e, a)
+			}
+
+			r = httptest.NewRequest("GET", loc, nil)
+			w = httptest.NewRecorder()
+
+			s.ServeHTTP(w, r)
+
+			if a, e := w.Code, http.StatusOK; a != e {
+				t.Fatalf("expected status code %d, got %d", e, a)
+			}
+
+			if a, e := w.Body.String(), "pprof</a></h1>"; !strings.Contains(a, e) {
+				t.Fatalf("body does not contain %q: %v", e, a)
+			}
+		})
+		if a, e := len(storage.mu.records), 1; a != e {
+			t.Fatalf("storage did not expunge records; have %d instead of %d", a, e)
+		}
+	}
+}

--- a/pkg/server/debug/pprofui/storage.go
+++ b/pkg/server/debug/pprofui/storage.go
@@ -1,0 +1,30 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package pprofui
+
+import (
+	"io"
+)
+
+// Storage exposes the methods for storing and accessing profiles.
+type Storage interface {
+	// ID generates a unique ID for use in Store.
+	ID() string
+	// Store invokes the passed-in closure with a writer that stores its input.
+	Store(id string, write func(io.Writer) error) error
+	// Get invokes the passed-in closure with a reader for the data at the given id.
+	// An error is returned when no data is found.
+	Get(id string, read func(io.Reader) error) error
+}

--- a/pkg/server/debug/pprofui/storage_mem.go
+++ b/pkg/server/debug/pprofui/storage_mem.go
@@ -1,0 +1,104 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package pprofui
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"sort"
+	"sync/atomic"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/pkg/errors"
+)
+
+type record struct {
+	id string
+	t  time.Time
+	b  []byte
+}
+
+// A MemStorage is a Storage implementation that holds recent profiles in memory.
+type MemStorage struct {
+	mu struct {
+		syncutil.Mutex
+		records []record // sorted by record.t
+	}
+	idGen        int32         // accessed atomically
+	keepDuration time.Duration // zero for disabled
+	keepNumber   int           // zero for disabled
+}
+
+var _ Storage = &MemStorage{}
+
+// NewMemStorage creates a MemStorage that retains the most recent n records
+// as long as they are less than d old.
+//
+// Records are dropped only when there is activity (i.e. an old record will
+// only be dropped the next time the storage is accessed).
+func NewMemStorage(n int, d time.Duration) *MemStorage {
+	return &MemStorage{
+		keepNumber:   n,
+		keepDuration: d,
+	}
+}
+
+// ID implements Storage.
+func (s *MemStorage) ID() string {
+	return fmt.Sprint(atomic.AddInt32(&s.idGen, 1))
+}
+
+func (s *MemStorage) cleanLocked() {
+	if l, m := len(s.mu.records), s.keepNumber; l > m && m != 0 {
+		s.mu.records = append([]record(nil), s.mu.records[l-m:]...)
+	}
+	now := timeutil.Now()
+	if pos := sort.Search(len(s.mu.records), func(i int) bool {
+		return s.mu.records[i].t.Add(s.keepDuration).After(now)
+	}); pos < len(s.mu.records) && s.keepDuration != 0 {
+		s.mu.records = append([]record(nil), s.mu.records[pos:]...)
+	}
+}
+
+// Store implements Storage.
+func (s *MemStorage) Store(id string, write func(io.Writer) error) error {
+	var b bytes.Buffer
+	if err := write(&b); err != nil {
+		return err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.mu.records = append(s.mu.records, record{id: id, t: timeutil.Now(), b: b.Bytes()})
+	sort.Slice(s.mu.records, func(i, j int) bool {
+		return s.mu.records[i].t.Before(s.mu.records[j].t)
+	})
+	s.cleanLocked()
+	return nil
+}
+
+// Get implements Storage.
+func (s *MemStorage) Get(id string, read func(io.Reader) error) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, v := range s.mu.records {
+		if v.id == id {
+			return read(bytes.NewReader(v.b))
+		}
+	}
+	return errors.Errorf("profile not found; it may have expired")
+}

--- a/pkg/server/debug/pprofui/ui.go
+++ b/pkg/server/debug/pprofui/ui.go
@@ -1,0 +1,52 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package pprofui
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+)
+
+func pprofCtx(ctx context.Context) context.Context {
+	return log.WithLogTag(ctx, "pprof", nil)
+}
+
+// fakeUI implements pprof's driver.UI.
+type fakeUI struct{}
+
+func (*fakeUI) ReadLine(prompt string) (string, error) { return "", io.EOF }
+
+func (*fakeUI) Print(args ...interface{}) {
+	msg := fmt.Sprint(args...)
+	log.InfofDepth(pprofCtx(context.Background()), 1, "%s", msg)
+}
+
+func (*fakeUI) PrintErr(args ...interface{}) {
+	msg := fmt.Sprint(args...)
+	log.WarningfDepth(pprofCtx(context.Background()), 1, "%s", msg)
+}
+
+func (*fakeUI) IsTerminal() bool {
+	return false
+}
+
+func (*fakeUI) WantBrowser() bool {
+	return false
+}
+
+func (*fakeUI) SetAutoComplete(complete func(string) string) {}

--- a/pkg/server/debug/server.go
+++ b/pkg/server/debug/server.go
@@ -25,6 +25,7 @@ import (
 
 	// Register the net/trace endpoint with http.DefaultServeMux.
 
+	"github.com/cockroachdb/cockroach/pkg/server/debug/pprofui"
 	"golang.org/x/net/trace"
 	"google.golang.org/grpc/metadata"
 
@@ -121,11 +122,15 @@ func NewServer(st *cluster.Settings) *Server {
 	}
 	mux.HandleFunc("/debug/logspy", spy.handleDebugLogSpy)
 
+	ps := pprofui.NewServer(pprofui.NewMemStorage(1, 0))
+	mux.Handle("/debug/pprof/ui/", http.StripPrefix("/debug/pprof/ui", ps))
+
 	return &Server{
 		st:  st,
 		mux: mux,
 		spy: spy,
 	}
+
 }
 
 // ServeHTTP serves various tools under the /debug endpoint. It restricts access

--- a/pkg/testutils/lint/lint_test.go
+++ b/pkg/testutils/lint/lint_test.go
@@ -830,6 +830,7 @@ func TestLint(t *testing.T) {
 			stream.GrepNot(`cockroach/pkg/(cli|security): syscall$`),
 			stream.GrepNot(`cockroach/pkg/(base|security|util/(log|randutil|stop)): log$`),
 			stream.GrepNot(`cockroach/pkg/(server/serverpb|ts/tspb): github\.com/golang/protobuf/proto$`),
+			stream.GrepNot(`cockroach/pkg/server/debug/pprofui: path$`),
 			stream.GrepNot(`cockroach/pkg/util/caller: path$`),
 			stream.GrepNot(`cockroach/pkg/ccl/storageccl: path$`),
 			stream.GrepNot(`cockroach/pkg/ccl/workloadccl: path$`),

--- a/pkg/ui/src/views/reports/containers/debug/index.tsx
+++ b/pkg/ui/src/views/reports/containers/debug/index.tsx
@@ -121,13 +121,18 @@ export default function Debug() {
           <DebugTableLink name="Active Tasks" url="/debug/stopper" />
         </DebugTableRow>
         <DebugTableRow title="pprof">
-          <DebugTableLink name="Heap" url="/debug/pprof/heap?debug=1" />
-          <DebugTableLink name="Profile" url="/debug/pprof/profile?debug=1" />
-          <DebugTableLink name="Block" url="/debug/pprof/block?debug=1" />
-          <DebugTableLink name="Trace" url="/debug/pprof/trace?debug=1" />
-          <DebugTableLink name="Thread Create" url="/debug/pprof/threadcreate?debug=1" />
-          <DebugTableLink name="Goroutines" url="/debug/pprof/goroutine?debug=1" />
-          <DebugTableLink name="All Goroutines" url="/debug/pprof/goroutine?debug=2" />
+          <DebugTableLink name="Heap (UI)" url="/debug/pprof/ui/heap/" />
+          <DebugTableLink name="Heap (raw)" url="/debug/pprof/heap?debug=1" />
+          <DebugTableLink name="Profile (UI)" url="/debug/pprof/ui/profile/" />
+          <DebugTableLink name="Profile (raw)" url="/debug/pprof/profile?debug=1" />
+          <DebugTableLink name="Block (UI)" url="/debug/pprof/ui/block/" />
+          <DebugTableLink name="Block (raw)" url="/debug/pprof/block?debug=1" />
+          <DebugTableLink name="Thread Create (UI)" url="/debug/pprof/ui/threadcreate/" />
+          <DebugTableLink name="Thread Create (raw)" url="/debug/pprof/threadcreate?debug=1" />
+          <DebugTableLink name="Goroutines (UI)" url="/debug/pprof/ui/goroutine/" />
+          <DebugTableLink name="Goroutines (raw)" url="/debug/pprof/goroutine?debug=1" />
+          <DebugTableLink name="All Goroutines (raw)" url="/debug/pprof/goroutine?debug=2" />
+          <DebugTableLink name="Trace (raw)" url="/debug/pprof/trace?debug=1" />
         </DebugTableRow>
       </DebugTable>
       <DebugTable heading="Raw Status Endpoints (JSON)">


### PR DESCRIPTION
Now that pprof has a web ui, we can just embed it into the running
server directly.

It turns out that for the most part, pprof has the right abstractions
built in, and so the code for this came out fairly clean. I needed a
few upstream modifications which are currently pending; it's looking
good that they'll be merged:

https://github.com/google/pprof/pulls/tschottdorf

Release note: None