### PR TITLE
distsql,stringarena: Speed up distinct processor with Arena.UnsafeReset()

### DIFF
--- a/pkg/sql/distsqlrun/distinct_test.go
+++ b/pkg/sql/distsqlrun/distinct_test.go
@@ -171,7 +171,7 @@ func TestDistinct(t *testing.T) {
 	}
 }
 
-func BenchmarkDistinct(b *testing.B) {
+func benchmarkDistinct(b *testing.B, useOrdering bool) {
 	const numCols = 1
 	const numRows = 1000
 
@@ -188,6 +188,9 @@ func BenchmarkDistinct(b *testing.B) {
 	spec := &DistinctSpec{
 		DistinctColumns: []uint32{0},
 	}
+	if useOrdering {
+		spec.OrderedColumns = []uint32{0}
+	}
 	post := &PostProcessSpec{}
 	input := NewRepeatableRowSource(oneIntCol, makeIntRows(numRows, numCols))
 
@@ -202,4 +205,12 @@ func BenchmarkDistinct(b *testing.B) {
 		input.Reset()
 	}
 	b.StopTimer()
+}
+
+func BenchmarkOrderedDistinct(b *testing.B) {
+	benchmarkDistinct(b, true /* useOrdering */)
+}
+
+func BenchmarkUnorderedDistinct(b *testing.B) {
+	benchmarkDistinct(b, false /* useOrdering */)
 }


### PR DESCRIPTION
Add a stringarena.Arena.Reset() method, which sets the allocation's
length to zero. This is useful in cases where we know that all the
strings on a string arena will never be reused, but we expect to still
need the memory allocated by the arena. The distinct processor in
DistSQL has this allocation pattern when OrderedColumns are specified,
so it now takes advantage of Reset.

Also add a new benchmark to measure the results of the change.

Benchmark Before:
```
BenchmarkOrderedDistinct-8     	    2000	    726214 ns/op	  11.02 MB/s
```
Benchmark After:
```
BenchmarkOrderedDistinct-8     	    5000	    327526 ns/op	  24.43 MB/s
```
Release note (performance improvement): Improve performance of DISTINCT
queries with orderings.