### PR TITLE
sql: Add one extra validation check before writing a table descriptor.

### DIFF
--- a/pkg/sql/table.go
+++ b/pkg/sql/table.go
@@ -638,6 +638,12 @@ func (p *planner) writeTableDesc(ctx context.Context, tableDesc *sqlbase.TableDe
 		return pgerror.NewErrorf(pgerror.CodeInternalError,
 			"programming error: virtual descriptors cannot be stored, found: %v", tableDesc)
 	}
+
+	if err := tableDesc.ValidateTable(p.extendedEvalCtx.Settings); err != nil {
+		return pgerror.NewErrorf(pgerror.CodeInternalError,
+			"programming error: table descriptor is not valid: %s\n%v", err, tableDesc)
+	}
+
 	p.Tables().addUncommittedTable(*tableDesc)
 
 	descKey := sqlbase.MakeDescMetadataKey(tableDesc.GetID())


### PR DESCRIPTION
Issue #21421 showed some extremely strange and broken table descriptors. This
adds one extra validation check before writing all table descriptors to the db.
While it does not address the root cause of what created the strange
descriptors, it will prevent anything like that from happening in the future.

Sadly is not possible to do a full validate call here, as checking the
cross-table references at this point fails circumstances such as self-
referenential tables and some other similar situations.

Closes #21421.

Release note: None