### PR TITLE
Towards more robust import/export IO

### DIFF
--- a/pkg/util/contextutil/check.go
+++ b/pkg/util/contextutil/check.go
@@ -1,0 +1,206 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package contextutil
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+)
+
+// CheckContext is returned by WithCheck() and allows the Checker to
+// be set lazily in the case where it cannot be constructed until
+// after the context has been created.
+type CheckContext interface {
+	context.Context
+	SetChecker(Checker)
+}
+
+// Checker is a function that returns a sampled value and whether or not
+// that value was acceptable.  It is valid to return nil for the sampled
+// value if retrieving them from a TooManyChecksFailedError isn't
+// required.
+type Checker func() (interface{}, bool)
+
+type checkContext struct {
+	context.Context
+	checker     Checker
+	err         error
+	errHook     func(error *TooManyChecksFailedError) error
+	maxFailures int
+	period      time.Duration
+}
+
+// Err implements the context.Context interface.  We use this to inject
+// our own error into a caller.
+func (c *checkContext) Err() error {
+	if c.err != nil {
+		return c.err
+	}
+	return c.Context.Err()
+}
+
+// SetChecker allows the checker to be replaced or set lazily when
+// the Checker cannot be created until after the context is created.
+func (c *checkContext) SetChecker(checker Checker) {
+	c.checker = checker
+}
+
+var defaultCheckContext = checkContext{
+	errHook:     func(e *TooManyChecksFailedError) error { return e },
+	maxFailures: 1,
+	period:      time.Minute,
+}
+
+// An Option is used to configure the Context created by WithCheck.
+type Option func(*checkContext)
+
+// OptionChecker sets the Checker that will be used by WithCheck.
+func OptionChecker(checker Checker) Option {
+	if checker == nil {
+		panic("checker must not be nil")
+	}
+	return func(ctx *checkContext) {
+		ctx.checker = checker
+	}
+}
+
+// OptionErrorHook allows a custom error to be injected into the context
+// when it has been canceled.
+func OptionErrorHook(hook func(error *TooManyChecksFailedError) error) Option {
+	if hook == nil {
+		panic("hook must not be nil")
+	}
+	return func(ctx *checkContext) {
+		ctx.errHook = hook
+	}
+}
+
+// OptionMaxFailures sets the maximum number of consecutive check
+// failures before the context will be canceled.
+func OptionMaxFailures(max int) Option {
+	if max <= 0 {
+		panic("maxFailures must be > 0")
+	}
+	return func(ctx *checkContext) {
+		ctx.maxFailures = max
+	}
+}
+
+// OptionPeriod sets how often the check function will be called.
+func OptionPeriod(period time.Duration) Option {
+	if period <= 0 {
+		panic("period must be > 0")
+	}
+	return func(ctx *checkContext) {
+		ctx.period = period
+	}
+}
+
+// TooManyChecksFailedError provides more details about why a context
+// was canceled.
+type TooManyChecksFailedError struct {
+	// The most recent samples.
+	Samples []interface{}
+}
+
+// Error implements the error interface.
+func (e *TooManyChecksFailedError) Error() string {
+	return fmt.Sprintf("too many checks failed: %s", e.Samples)
+}
+
+// WithCheck constructs a child context that will be canceled
+// when the given checker fails more than maxFailures consecutive
+// checks.
+//
+// Callers must either provide OptionChecker() or call
+// CheckContext.SetChecker() before the check runs, or a warning
+// will be logged and the check will be considered to have failed.
+//
+// If the check fails for maxFailures consecutive periods, the returned
+// Context will be canceled and its Err() will return a
+// TooManyChecksFailedError, which can be examined for the offending
+// sampled values.
+func WithCheck(parent context.Context, options ...Option) (CheckContext, context.CancelFunc) {
+	// Use baked-in cancellation mechanism and start up a goroutine
+	// to call the user-provided check logic.  We wrap the cancellable
+	// context in our own shim so that we can inject a custom error
+	// if the context is canceled due to check failures.
+	cancelCtx, cancel := context.WithCancel(parent)
+
+	ctx := defaultCheckContext
+	ctx.Context = cancelCtx
+	for _, opt := range options {
+		opt(&ctx)
+	}
+
+	go func() {
+		samples := make([]interface{}, 0, ctx.maxFailures)
+		// Start with a full collection of health credits.
+		health := ctx.maxFailures
+
+		// Timer to wake up for each check period.
+		timer := timeutil.NewTimer()
+		defer timer.Stop()
+
+		for {
+			timer.Reset(ctx.period)
+			select {
+			case <-ctx.Done():
+				return
+			case <-timer.C:
+				// Set per docs on Timer.
+				timer.Read = true
+
+				// Invoke user logic.
+				var sample interface{}
+				var ok bool
+				checker := ctx.checker
+				if checker == nil {
+					log.Warning(&ctx, "no checker has been configured")
+					ok = false
+				} else {
+					sample, ok = checker()
+				}
+
+				// Collect only maxFailures samples.
+				if len(samples) == ctx.maxFailures {
+					samples = append(samples[1:len(samples):ctx.maxFailures], sample)
+				} else {
+					samples = append(samples, sample)
+				}
+
+				switch {
+				case !ok:
+					// Decrement health and cancel if we're out of credits.
+					health--
+					if health == 0 {
+						ctx.err = ctx.errHook(&TooManyChecksFailedError{samples})
+						cancel()
+						return
+					}
+				case health < ctx.maxFailures:
+					// Increment health if it's below the cap.
+					health++
+				}
+			}
+		}
+	}()
+
+	return &ctx, cancel
+}

--- a/pkg/util/contextutil/check_test.go
+++ b/pkg/util/contextutil/check_test.go
@@ -1,0 +1,153 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package contextutil
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+)
+
+func TestCancels(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	const maxFailures = 10
+	const okChecks = 5
+
+	counter := 0
+	// Use a Checker that becomes false after a few iterations.
+	ctx, cancel := WithCheck(context.Background(),
+		OptionChecker(
+			func() (interface{}, bool) {
+				counter++
+				return counter, counter <= okChecks
+			}),
+		OptionMaxFailures(maxFailures),
+		OptionPeriod(time.Nanosecond),
+	)
+
+	<-ctx.Done()
+
+	// Verify call count.
+	if counter != maxFailures+okChecks {
+		t.Fatalf("expected counter == %d, got %d", maxFailures+okChecks, counter)
+	}
+
+	switch err := ctx.Err().(type) {
+	case *TooManyChecksFailedError:
+		if maxFailures != len(err.Samples) {
+			t.Fatalf("expecting %d samples, saw %d", maxFailures, len(err.Samples))
+		}
+		for idx, sample := range err.Samples {
+			a, ok := sample.(int)
+			if !ok {
+				t.Fatalf("sample %d could not be cast to int", a)
+			}
+			e := idx + okChecks + 1
+			if a != e {
+				t.Fatalf("expecting sample %d == %d at index %d", a, e, idx)
+			}
+		}
+	default:
+		t.Fatal("unexpected error returned:", err)
+	}
+
+	// Ensure no-op behavior is ok.
+	cancel()
+}
+
+func TestExplicitCancel(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	child, childCancel := WithCheck(
+		context.Background(), OptionPeriod(time.Hour))
+
+	// Ensure that this doesn't blow up on no-op cancellation.
+	childCancel()
+	<-child.Done()
+	if child.Err() != context.Canceled {
+		t.Fatal("unexpected error from child context:", child.Err())
+	}
+}
+
+func TestParentCancel(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	parent, parentCancel := context.WithCancel(context.Background())
+	child, childCancel := WithCheck(parent, OptionPeriod(time.Hour))
+
+	parentCancel()
+
+	<-child.Done()
+	if child.Err() != context.Canceled {
+		t.Fatal("unexpected error from child context:", child.Err())
+	}
+
+	// Ensure that this doesn't blow up on no-op cancellation.
+	childCancel()
+	<-child.Done()
+	if child.Err() != context.Canceled {
+		t.Fatal("unexpected error from child context:", child.Err())
+	}
+}
+
+// This creates a context that will execute the checker once a minute
+// and allow up to five consecutive failures before canceling
+// the context.
+func ExampleWithCheck_eager() {
+	ctx, cancel := WithCheck(context.Background(),
+		OptionChecker(
+			func() (interface{}, bool) {
+				return "arbitrary sample value", true // If sample is OK
+			}),
+		OptionMaxFailures(5),
+		OptionPeriod(1*time.Minute),
+	)
+	// You'll want to handle explicit cancellation.
+	defer cancel()
+
+	// Then do something with the Context.
+	<-ctx.Done()
+}
+
+// This shows how the Checker can be set after the Context has been
+// created.  This is useful for cases like starting an IO operation,
+// where you might not be able to determine the rate until after
+// the context must be created.
+func ExampleWithCheck_lazy() {
+	ctx, cancel := WithCheck(context.Background(),
+		OptionMaxFailures(5),
+		OptionPeriod(1*time.Minute),
+	)
+	// You'll want to handle explicit cancellation.
+	defer cancel()
+
+	server := startServer(ctx)
+
+	ctx.SetChecker(func() (interface{}, bool) {
+		return nil, server.isHealthy()
+	})
+
+	// The wait for things to complete.
+	<-ctx.Done()
+}
+
+func startServer(_ context.Context) interface {
+	isHealthy() bool
+} {
+	return nil
+}

--- a/pkg/util/rate/counter.go
+++ b/pkg/util/rate/counter.go
@@ -1,0 +1,119 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package rate
+
+import (
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/util/metric"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+)
+
+// Counter can be used to compute a live rate at which a count of events
+// is occurring.  The zero value of a Counter is ready to use.
+//
+// Internally, it uses an EWMA that will automatically
+// decay over one minute.  The value of the counter can be permanently
+// frozen to preserve its value once no new events are expected.
+type Counter struct {
+	mu struct {
+		syncutil.Mutex
+		// frozen saves the last-known rate.Value() since it will decay
+		// over time.
+		frozen Rate
+		// Use EWMA, and allow it to be discarded once frozen.
+		rate  *metric.Rate
+		ready bool
+	}
+}
+
+var _ Rater = &Counter{}
+
+// Add a number of events to the counter.  This method will be a no-op
+// if the Counter has been frozen.
+func (c *Counter) Add(count int) {
+	c.mu.Lock()
+	switch {
+	case !c.mu.ready:
+		c.mu.ready = true
+		c.mu.rate = metric.NewRate(time.Minute)
+		fallthrough
+	case c.mu.rate != nil:
+		c.mu.rate.Add(float64(count))
+	}
+	c.mu.Unlock()
+}
+
+// Freeze the rate in the counter.  Once this method is called,
+// it is still safe to call Add(), however no updates will occur.
+func (c *Counter) Freeze() {
+	c.mu.Lock()
+	if c.mu.rate != nil {
+		c.mu.frozen = NewRate(c.mu.rate.Value(), time.Second)
+		c.mu.rate = nil
+		c.mu.ready = true
+	}
+	c.mu.Unlock()
+}
+
+// IsFrozen indicates if freeze() has been called.
+func (c *Counter) IsFrozen() (ret bool) {
+	c.mu.Lock()
+	ret = c.mu.ready && c.mu.rate == nil
+	c.mu.Unlock()
+	return
+}
+
+// Rate returns the live or frozen rate of events.
+func (c *Counter) Rate() (ret Rate) {
+	c.mu.Lock()
+	if c.mu.rate != nil {
+		ret = NewRate(c.mu.rate.Value(), time.Second)
+	} else {
+		ret = c.mu.frozen
+	}
+	c.mu.Unlock()
+	return
+}
+
+// Reset returns the Counter to its zero-value.
+func (c *Counter) Reset() {
+	c.mu.Lock()
+	c.mu.frozen = 0
+	c.mu.rate = metric.NewRate(time.Minute)
+	c.mu.ready = true
+	c.mu.Unlock()
+}
+
+// String shows counts / sec.
+func (c *Counter) String() string {
+	return c.Rate().String()
+}
+
+// NewChannelRater constructs a Rater that will receive counts
+// from the given channel.  The rate will be frozen once
+// the channel is closed.
+func NewChannelRater(ch <-chan int) Rater {
+	ctr := &Counter{}
+
+	go func() {
+		for count := range ch {
+			ctr.Add(count)
+		}
+		ctr.Freeze()
+	}()
+
+	return ctr
+}

--- a/pkg/util/rate/counter_test.go
+++ b/pkg/util/rate/counter_test.go
@@ -1,0 +1,67 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package rate
+
+import (
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+)
+
+func TestCounter(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	var ctr Counter
+	// Add values until we see a rate.
+	for ctr.Rate() == 0 {
+		ctr.Add(1024)
+		time.Sleep(100 * time.Microsecond)
+	}
+
+	snapshot := ctr.Rate()
+
+	// Now wait until we see some decay.
+	for snapshot == ctr.Rate() {
+		time.Sleep(100 * time.Microsecond)
+	}
+
+	ctr.Freeze()
+	if !ctr.IsFrozen() {
+		t.Error("should have been frozen")
+	}
+
+	ctr.Reset()
+	if ctr.Rate() != 0 {
+		t.Error("expected 0 rate")
+	}
+	if ctr.IsFrozen() {
+		t.Error("expected to be unfrozen")
+	}
+}
+
+func TestChannelCounter(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	ch := make(chan int)
+	defer close(ch)
+
+	ctr := NewChannelRater(ch)
+	// Add values until we see a rate.
+	for ctr.Rate() == 0 {
+		ch <- 1024
+		time.Sleep(100 * time.Microsecond)
+	}
+}

--- a/pkg/util/rate/io/closer.go
+++ b/pkg/util/rate/io/closer.go
@@ -1,0 +1,44 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+// Package io provides a number of wrappers around standard io types
+// which can report their IO rates.
+package io
+
+import (
+	"io"
+
+	"github.com/cockroachdb/cockroach/pkg/util/rate"
+)
+
+type closer struct {
+	ctr      *rate.Counter
+	delegate io.Closer
+	onClose  []func()
+}
+
+// newCloser is a composition constructor.
+func newCloser(ctr *rate.Counter, c io.Closer, onClose []func()) *closer {
+	return &closer{ctr: ctr, delegate: c, onClose: onClose}
+}
+
+// Close implements io.Closer and will freeze the counter.
+func (c *closer) Close() (err error) {
+	err = c.delegate.Close()
+	c.ctr.Freeze()
+	for _, fn := range c.onClose {
+		fn()
+	}
+	return err
+}

--- a/pkg/util/rate/io/iorate_test.go
+++ b/pkg/util/rate/io/iorate_test.go
@@ -1,0 +1,90 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package io
+
+import (
+	"io"
+	"io/ioutil"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+)
+
+// These functions are just trivial delegates to code tested below.
+var _ = NewWriter(nil)
+var _ = NewReader(nil)
+
+func TestReadWrite(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	f, err := ioutil.TempFile("", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	name := f.Name()
+
+	// Write some data to the file until we see a rate.
+	{
+		w := NewWriteCloser(f)
+		var _ io.WriteCloser = w
+
+		for w.Rate() == 0 {
+			if _, err := w.Write(make([]byte, 1024*1024)); err != nil {
+				t.Fatal(err)
+			}
+			time.Sleep(100 * time.Microsecond)
+		}
+		if err := w.Close(); err != nil {
+			t.Fatal(err)
+		}
+		if !w.w.ctr.IsFrozen() {
+			t.Fatal("should have been frozen")
+		}
+	}
+
+	// Read data until we see rate data.
+	{
+		f, err := os.Open(name)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		rc := NewReadCloser(f)
+		var _ io.ReadCloser = rc
+
+		buf := make([]byte, 1024)
+		for rc.Rate() == 0 {
+			if _, err := rc.Read(buf); err != nil {
+				if err == io.EOF {
+					t.Fatal("did not see rate before hitting EOF")
+				}
+				t.Fatal(err)
+			}
+			time.Sleep(100 * time.Microsecond)
+		}
+		if err := rc.Close(); err != nil {
+			t.Fatal(err)
+		}
+		if !rc.r.ctr.IsFrozen() {
+			t.Fatal("should have been frozen")
+		}
+	}
+
+	if err := os.Remove(name); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/pkg/util/rate/io/reader.go
+++ b/pkg/util/rate/io/reader.go
@@ -1,0 +1,137 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package io
+
+import (
+	"io"
+
+	"github.com/cockroachdb/cockroach/pkg/util/rate"
+)
+
+// Reader wraps an io.Reader and provides an associated IO rate.
+// The rate will be frozen when the underlying reader returns io.EOF.
+type Reader struct {
+	ctr      *rate.Counter
+	delegate io.Reader
+}
+
+var _ io.Reader = &Reader{}
+var _ rate.Rater = &Reader{}
+
+// Composition constructor.
+func newReader(ctr *rate.Counter, r io.Reader) *Reader {
+	return &Reader{
+		ctr:      ctr,
+		delegate: r,
+	}
+}
+
+// NewReader constructs a new iorate.Reader around an io.Reader,
+// sampling the observed IO rate over a one-minute interval.
+func NewReader(r io.Reader) *Reader {
+	return newReader(&rate.Counter{}, r)
+}
+
+// Rate returns the current IO rate in bytes / second if the Read()
+// has not yet returned an error (including io.EOF), or the last known
+// rate when an error was returned.
+func (r *Reader) Rate() rate.Rate {
+	return r.ctr.Rate()
+}
+
+// Read implements the io.Reader interface.
+func (r *Reader) Read(p []byte) (int, error) {
+	count, err := r.delegate.Read(p)
+	if err == nil {
+		r.ctr.Add(count)
+	} else {
+		r.ctr.Freeze()
+	}
+	return count, err
+}
+
+// ReadCloser wraps an io.ReadCloser and provides an associated IO rate.
+// The rate will be frozen when the underlying reader returns an EOF
+// or if Close is called.
+type ReadCloser struct {
+	r *Reader
+	c *closer
+}
+
+var _ io.ReadCloser = &ReadCloser{}
+var _ rate.Rater = &ReadCloser{}
+
+// NewReadCloser wraps an io.ReadCloser to provide an IO rate, with
+// optional callbacks when Close() is called.
+func NewReadCloser(rc io.ReadCloser, onClose ...func()) *ReadCloser {
+	var base rate.Counter
+	return &ReadCloser{
+		r: newReader(&base, rc),
+		c: newCloser(&base, rc, onClose),
+	}
+}
+
+// Rate returns the current IO rate if the Read()
+// has not yet returned an error (including io.EOF), or the last known
+// rate when an error was returned or when Close() was called.
+func (r *ReadCloser) Rate() rate.Rate {
+	return r.r.Rate()
+}
+
+// Read implements the io.Reader interface.
+func (r *ReadCloser) Read(p []byte) (int, error) {
+	return r.r.Read(p)
+}
+
+// Close implements the io.Closer interface.  It will freeze the rate
+// associated with the ReadCloser.
+func (r *ReadCloser) Close() error {
+	return r.c.Close()
+}
+
+// ReadSeeker wraps an io.ReadSeeker and provides an associated IO rate.
+// The rate will be frozen when the reader returns an EOF.
+type ReadSeeker struct {
+	r *Reader
+	s io.Seeker
+}
+
+var _ io.ReadSeeker = &ReadSeeker{}
+var _ rate.Rater = &ReadSeeker{}
+
+// NewReadSeeker wraps an io.ReadSeeker to provide an IO rate.
+func NewReadSeeker(rs io.ReadSeeker) *ReadSeeker {
+	return &ReadSeeker{
+		r: newReader(&rate.Counter{}, rs),
+		s: rs,
+	}
+}
+
+// Rate returns the current IO rate in bytes / second if the Read()
+// has not yet returned an error (including io.EOF), or the last known
+// rate when an error was returned.
+func (r *ReadSeeker) Rate() rate.Rate {
+	return r.r.Rate()
+}
+
+// Read implements the io.Reader interface.
+func (r *ReadSeeker) Read(p []byte) (int, error) {
+	return r.r.Read(p)
+}
+
+// Seek implements the io.Seeker interface.
+func (r *ReadSeeker) Seek(offset int64, whence int) (int64, error) {
+	return r.s.Seek(offset, whence)
+}

--- a/pkg/util/rate/io/writer.go
+++ b/pkg/util/rate/io/writer.go
@@ -1,0 +1,105 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package io
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/cockroachdb/cockroach/pkg/util/rate"
+)
+
+// Writer wraps an io.Writer and provides an associated IO rate.
+// The rate will be frozen if the underlying writer returns a
+// write error.
+type Writer struct {
+	ctr *rate.Counter
+	w   io.Writer
+}
+
+var _ io.Writer = &Writer{}
+var _ rate.Rater = &Writer{}
+
+// Composition constructor.
+func newWriter(ctr *rate.Counter, w io.Writer) *Writer {
+	return &Writer{ctr: ctr, w: w}
+}
+
+// NewWriter constructs a new iorate.Writer around an io.Writer,
+// sampling the observed IO rate over a one-minute interval.
+func NewWriter(w io.Writer) *Writer {
+	return newWriter(&rate.Counter{}, w)
+}
+
+// Rate returns the rate at which bytes are being written.  The value
+// returned here will always decay, since there is no way to know
+// when to freeze the value.
+func (r *Writer) Rate() rate.Rate {
+	return r.ctr.Rate()
+}
+
+// Write implements the io.Writer interface.
+func (r *Writer) Write(p []byte) (int, error) {
+	count, err := r.w.Write(p)
+	if err == nil {
+		r.ctr.Add(count)
+	} else {
+		r.ctr.Freeze()
+	}
+	return count, err
+}
+
+// String returns the rates over the configured timescales.
+func (r *Writer) String() string {
+	return fmt.Sprintf("%.2f bytes / sec", r.Rate())
+}
+
+// WriteCloser wraps an io.WriteCloser and provides an associated IO
+// rate.  The rate will be frozen if the underlying Writer returns an
+// error or Close() is called.
+type WriteCloser struct {
+	c *closer
+	w *Writer
+}
+
+var _ io.WriteCloser = &WriteCloser{}
+var _ rate.Rater = &WriteCloser{}
+
+// NewWriteCloser constructs a new iorate.WriteCloser around an
+// io.WriteCloser, with optional callbacks when Close() is called.
+func NewWriteCloser(wc io.WriteCloser, onClose ...func()) *WriteCloser {
+	var base rate.Counter
+	return &WriteCloser{
+		c: newCloser(&base, wc, onClose),
+		w: newWriter(&base, wc),
+	}
+}
+
+// Close implements the io.Closer interface.  Calling this method will
+// freeze the Rate associated with the WriteCloser.
+func (w *WriteCloser) Close() error {
+	return w.c.Close()
+}
+
+// Rate returns the rate at which bytes are being written, or the last
+// known value when the writer was closed.
+func (w *WriteCloser) Rate() rate.Rate {
+	return w.w.Rate()
+}
+
+// Write implements the io.Writer interface.
+func (w *WriteCloser) Write(p []byte) (int, error) {
+	return w.w.Write(p)
+}

--- a/pkg/util/rate/rate.go
+++ b/pkg/util/rate/rate.go
@@ -1,0 +1,58 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+// Package rate provides a variety of utility types and methods for
+// describing activities per units of time.
+package rate
+
+import (
+	"fmt"
+	"time"
+)
+
+// Rate represents a value per unit of time.  Internally, this is
+// normalized to units / second, but prefer using the Per()
+// function to convert a Rate back to a numeric type.
+type Rate float64
+
+// NewRate constructs a rate of values per time period.
+func NewRate(count float64, period time.Duration) Rate {
+	if period == time.Second {
+		return Rate(count)
+	}
+
+	return Rate(count / period.Seconds())
+}
+
+// Per converts the Rate to units per specified time period.
+func (r Rate) Per(d time.Duration) float64 {
+	if d == time.Second {
+		return float64(r)
+	}
+	return float64(r) * (float64(d.Nanoseconds()) / float64(time.Second.Nanoseconds()))
+}
+
+// Rate implements the Rater interface, since a Rate can vend itself.
+func (r Rate) Rate() Rate {
+	return r
+}
+
+func (r Rate) String() string {
+	return fmt.Sprintf("%.2f per second", r)
+}
+
+// Rater describes a type which can provide a Rate.
+type Rater interface {
+	Rate() Rate
+}

--- a/pkg/util/rate/rate_test.go
+++ b/pkg/util/rate/rate_test.go
@@ -1,0 +1,35 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package rate
+
+import (
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+)
+
+func TestRateMath(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	r := NewRate(1, time.Minute)
+	if r.Per(time.Hour) != 60 {
+		t.Errorf("expecting %f, got %f", 60.0, r.Per(time.Hour))
+	}
+
+	if NewRate(1, time.Hour) >= NewRate(1, time.Second) {
+		t.Errorf("comparison incorrect")
+	}
+}

--- a/pkg/util/rate/stall.go
+++ b/pkg/util/rate/stall.go
@@ -1,0 +1,158 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package rate
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/util/contextutil"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+)
+
+var defaultConfig = config{
+	checkPeriod: time.Minute,
+	minRate:     NewRate(1, time.Minute),
+	maxFailures: 1,
+}
+
+type config struct {
+	context.Context
+	checkPeriod time.Duration
+	maxFailures int
+	minRate     Rate
+	rater       Rater
+	warnFn      func()
+}
+
+// SetRater implements the StallContext interface.
+func (c *config) SetRater(r Rater) {
+	c.rater = r
+}
+
+// A StallDetectedError will be returned from a context created by
+// WithStallPrevention when a stall has been detected.
+type StallDetectedError struct {
+	Actual Rate
+	Min    Rate
+}
+
+func (e *StallDetectedError) Error() string {
+	return fmt.Sprintf("work has stalled: %s < %s", e.Actual, e.Min)
+}
+
+// Option is used to configure the behavior of WithStallPrevention.
+type Option func(config *config)
+
+// OptionCheckPeriod controls how often the current rate is checked
+// before canceling the context.  This value should be chosen relative
+// to the expected duration of the task.
+func OptionCheckPeriod(period time.Duration) Option {
+	return func(cfg *config) {
+		cfg.checkPeriod = period
+	}
+}
+
+// OptionMaxFailures controls how many consecutive check periods the
+// observed rate is below the minimum rate before the context will
+// be canceled.
+func OptionMaxFailures(maxFailures int) Option {
+	return func(cfg *config) {
+		cfg.maxFailures = maxFailures
+	}
+}
+
+// OptionMinRate sets the minimum rate at which events must occur.
+func OptionMinRate(rate Rate) Option {
+	return func(cfg *config) {
+		cfg.minRate = rate
+	}
+}
+
+// OptionRater sets the source of the Rates that will be used.
+func OptionRater(rater Rater) Option {
+	return func(cfg *config) {
+		cfg.rater = rater
+	}
+}
+
+// OptionWarnFunction provides a callback to be invoked when the rate
+// has dropped below the minimum (e.g. to provide extra logging).
+func OptionWarnFunction(fn func()) Option {
+	return func(cfg *config) {
+		cfg.warnFn = fn
+	}
+}
+
+// StallContext is a specialization of Context that allows the Rater
+// to be set lazily.  This is used when the context must be created
+// before it's possible to calculate rate information.
+type StallContext interface {
+	context.Context
+	// SetRater is used to set or replace the Rater associated with the
+	// context.  This may be called safely at any time.
+	SetRater(r Rater)
+}
+
+// WithStallPrevention constructs a child context that will be canceled
+// when a rate drops below a certain threshold.
+//
+// Note that in order to enable cancellation, a Rater must be provided,
+// either through OptionRater() or by calling StallContext.SetRater().
+// The latter way is useful when the context must be created before
+// it is possible to determine a rate (e.g. cancelable IO operations).
+//
+// If the check period expires without a Rater having been provided,
+// a warning will be logged and the rate will be considered to be 0.
+func WithStallPrevention(
+	parent context.Context, options ...Option,
+) (StallContext, context.CancelFunc) {
+	cfg := defaultConfig
+	for _, opt := range options {
+		opt(&cfg)
+	}
+	var cancel context.CancelFunc
+	cfg.Context, cancel = contextutil.WithCheck(parent,
+		// Just do the rate comparison.
+		contextutil.OptionChecker(
+			func() (interface{}, bool) {
+				maybeRater := cfg.rater
+				if maybeRater == nil {
+					log.Warning(parent, "no Rater has been set")
+					return 0, false
+				}
+				rate := maybeRater.Rate()
+				ok := rate >= cfg.minRate
+				if !ok && cfg.warnFn != nil {
+					cfg.warnFn()
+				}
+				return rate, ok
+			}),
+		// Inject a more obvious error type.
+		contextutil.OptionErrorHook(func(error *contextutil.TooManyChecksFailedError) error {
+			ret := &StallDetectedError{
+				Actual: error.Samples[len(error.Samples)-1].(Rate),
+				Min:    cfg.minRate,
+			}
+			return ret
+		}),
+		// Passthrough options.
+		contextutil.OptionMaxFailures(cfg.maxFailures),
+		contextutil.OptionPeriod(cfg.checkPeriod),
+	)
+
+	return &cfg, cancel
+}

--- a/pkg/util/rate/stall_test.go
+++ b/pkg/util/rate/stall_test.go
@@ -1,0 +1,55 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package rate
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+)
+
+func TestStallPrevention(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	// Construct a counter and add enough values to exceed the threshold.
+	const threshold = 100
+	var ctr Counter
+	ctr.Add(threshold)
+
+	// Construct a context that will be canceled once the counter
+	// rate decays before the minimum rate.
+	ctx, cancel := WithStallPrevention(context.Background(),
+		OptionCheckPeriod(time.Second),
+		OptionMaxFailures(2),
+		OptionMinRate(NewRate(threshold-1, time.Second)),
+		OptionRater(&ctr),
+	)
+	defer cancel()
+
+	// Now, wait for the context to be canceled or time out.
+	select {
+	case <-ctx.Done():
+		switch err := ctx.Err().(type) {
+		case *StallDetectedError:
+			// OK
+		default:
+			t.Error("unexpected ctx.Err()", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Error("context was not canceled in time")
+	}
+}


### PR DESCRIPTION
The attached pull requests contains a series of commits that will support #23859, which I'm interpreting as "be able to detect when we're going much too slowly".

The first two commits are utility code, to add a new Context type that will cancel if an arbitrary health-check fails.  The second builds on this with a rate-based Context and some wrappers around basic IO interfaces to be able to capture their throughput.

The last two changes update the csv import code and the ExportStorage code to detect a stall in the overall process and stalls at the stream level.  A test is specifically added for an HTTP import target which doesn't actually produce any data, but simply hangs.