### PR TITLE
workload/tpcc: improve output

### DIFF
--- a/pkg/cmd/workload/run.go
+++ b/pkg/cmd/workload/run.go
@@ -335,7 +335,7 @@ func runRun(gen workload.Generator, urls []string, dbName string) error {
 
 			if h, ok := gen.(workload.Hookser); ok {
 				if h.Hooks().PostRun != nil {
-					if err := h.Hooks().PostRun(); err != nil {
+					if err := h.Hooks().PostRun(start); err != nil {
 						fmt.Printf("failed post-run hook: %v\n", err)
 					}
 				}

--- a/pkg/workload/histogram.go
+++ b/pkg/workload/histogram.go
@@ -206,12 +206,12 @@ func (w *Histograms) Get(name string) *NamedHistogram {
 type HistogramTick struct {
 	// Name is the name given to the histograms represented by this tick.
 	Name string
-	// Hist is the merged result of the represented histgrams for this tick.
+	// Hist is the merged result of the represented histograms for this tick.
 	Hist *hdrhistogram.Histogram
-	// Cumulative is the merged result of the represented histgrams for all
+	// Cumulative is the merged result of the represented histograms for all
 	// time.
 	Cumulative *hdrhistogram.Histogram
-	// Ops is the total number of `Record` calls for all represented histgrams.
+	// Ops is the total number of `Record` calls for all represented histograms.
 	Ops int64
 	// LastOps is the value of Ops for the last tick.
 	LastOps int64

--- a/pkg/workload/tpcc/tpcc.go
+++ b/pkg/workload/tpcc/tpcc.go
@@ -22,6 +22,9 @@ import (
 	"net/url"
 	"sync"
 
+	"fmt"
+	"time"
+
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
@@ -49,6 +52,8 @@ type tpcc struct {
 	deck []int
 
 	auditor *auditor
+
+	reg *workload.HistogramRegistry
 
 	split   bool
 	scatter bool
@@ -176,8 +181,29 @@ func (w *tpcc) Hooks() workload.Hooks {
 			}
 			return nil
 		},
-		PostRun: func() error {
+		PostRun: func(start time.Time) error {
 			w.auditor.runChecks()
+			const totalHeader = "\n_elapsed_______tpmC____efc__avg(ms)__p50(ms)__p90(ms)__p95(ms)__p99(ms)_pMax(ms)"
+			fmt.Println(totalHeader)
+			startElapsed := timeutil.Since(start)
+
+			const newOrderName = `newOrder`
+			w.reg.Tick(func(t workload.HistogramTick) {
+				if newOrderName == t.Name {
+					tpmC := float64(t.Ops) / startElapsed.Seconds() * 60
+					fmt.Printf("%7.1fs %10.1f %5.1f%% %8.1f %8.1f %8.1f %8.1f %8.1f %8.1f\n",
+						startElapsed.Seconds(),
+						tpmC,
+						100*tpmC/(12.86*float64(w.warehouses)),
+						time.Duration(t.Cumulative.Mean()).Seconds()*1000,
+						time.Duration(t.Cumulative.ValueAtQuantile(50)).Seconds()*1000,
+						time.Duration(t.Cumulative.ValueAtQuantile(90)).Seconds()*1000,
+						time.Duration(t.Cumulative.ValueAtQuantile(95)).Seconds()*1000,
+						time.Duration(t.Cumulative.ValueAtQuantile(99)).Seconds()*1000,
+						time.Duration(t.Cumulative.ValueAtQuantile(100)).Seconds()*1000,
+					)
+				}
+			})
 			return nil
 		},
 		CheckConsistency: func(ctx context.Context, db *gosql.DB) error {
@@ -332,6 +358,8 @@ func (w *tpcc) Ops(urls []string, reg *workload.HistogramRegistry) (workload.Que
 		}
 	}
 
+	w.reg = reg
+
 	ql := workload.QueryLoad{SQLDatabase: sqlDatabase}
 	for workerIdx := 0; workerIdx < w.workers; workerIdx++ {
 		warehouse := workerIdx % w.warehouses
@@ -352,11 +380,6 @@ func (w *tpcc) Ops(urls []string, reg *workload.HistogramRegistry) (workload.Que
 		copy(worker.deckPerm, w.deck)
 
 		ql.WorkerFns = append(ql.WorkerFns, worker.run)
-	}
-	if w.doWaits {
-		// TODO(dan): doWaits is currently our catch-all for "run this to spec".
-		// It should probably be renamed to match.
-		ql.ResultHist = `newOrder`
 	}
 	return ql, nil
 }

--- a/pkg/workload/tpcc/tpcc.go
+++ b/pkg/workload/tpcc/tpcc.go
@@ -381,5 +381,9 @@ func (w *tpcc) Ops(urls []string, reg *workload.HistogramRegistry) (workload.Que
 
 		ql.WorkerFns = append(ql.WorkerFns, worker.run)
 	}
+	// Preregister all of the histograms so they always print.
+	for _, tx := range allTxs {
+		reg.GetHandle().Get(tx.name)
+	}
 	return ql, nil
 }

--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -101,9 +101,9 @@ type Hooks struct {
 	// loaded. It called after restoring a fixture. This, for example, is where
 	// creating foreign keys should go.
 	PostLoad func(*gosql.DB) error
-	// PostRun is called after workload run has ended. This is where any post-run
-	// special printing or validation can be done.
-	PostRun func() error
+	// PostRun is called after workload run has ended, with the start time of the
+	// run. This is where any post-run special printing or validation can be done.
+	PostRun func(time.Time) error
 	// CheckConsistency is called to run generator-specific consistency checks.
 	// These are expected to pass after the initial data load as well as after
 	// running queryload.


### PR DESCRIPTION
- print tpmC at the end, with efficiency percent
- preregister all txn types so they always print during histogram output