### PR TITLE
workload/tpcc: add audit check 9.2.2.5.2

### DIFF
--- a/pkg/workload/tpcc/audit.go
+++ b/pkg/workload/tpcc/audit.go
@@ -17,16 +17,31 @@ package tpcc
 
 import (
 	"fmt"
+	"math"
 	"sync/atomic"
 
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/pkg/errors"
+)
+
+const (
+	minSignificantOrders = 10000
 )
 
 // auditor maintains statistics about TPC-C input data and runs distribution
 // checks, as specified in Clause 9.2 of the TPC-C spec.
 type auditor struct {
+	syncutil.Mutex
+
 	newOrderTransactions uint64
 	newOrderRollbacks    uint64
+
+	// map from order-lines count to the number of orders with that count
+	orderLinesFreq map[int]uint64
+}
+
+func newAuditor() *auditor {
+	return &auditor{orderLinesFreq: make(map[int]uint64)}
 }
 
 // runChecks runs the audit checks and prints warnings to stdout for those that
@@ -38,6 +53,7 @@ func (a *auditor) runChecks() {
 	}
 	checks := []check{
 		{"9.2.2.5.1", check92251},
+		{"9.2.2.5.2", check92252},
 	}
 	for _, check := range checks {
 		result := check.f(a)
@@ -51,7 +67,7 @@ func check92251(a *auditor) error {
 	// At least 0.9% and at most 1.1% of the New-Order transactions roll back as a
 	// result of an unused item number.
 	orders := atomic.LoadUint64(&a.newOrderTransactions)
-	if orders < 10000 {
+	if orders < minSignificantOrders {
 		// Not enough orders to be statistically significant.
 		return nil
 	}
@@ -60,6 +76,44 @@ func check92251(a *auditor) error {
 	if rollbackPct < 0.9 || rollbackPct > 1.1 {
 		return errors.Errorf(
 			"new order rollback percent %.1f is not between allowed bounds [0.9, 1.1]", rollbackPct)
+	}
+	return nil
+}
+
+func check92252(a *auditor) error {
+	// The average number of order-lines per order is in the range of 9.5 to 10.5
+	// and the number of order-lines is uniformly distributed from 5 to 15 for the
+	// New-Order transactions that are submitted to the SUT during the measurement
+	// interval.
+	a.Lock()
+	defer a.Unlock()
+
+	var orders, orderLines uint64
+	for i := 5; i <= 15; i++ {
+		freq := a.orderLinesFreq[i]
+		orders += freq
+		orderLines += freq * uint64(i)
+	}
+	if orders < minSignificantOrders {
+		return nil
+	}
+
+	avg := float64(orderLines) / float64(orders)
+	if avg < 9.5 || avg > 10.5 {
+		return errors.Errorf(
+			"average order-lines count %.1f is not between allowed bounds [9.5, 10.5]", avg)
+	}
+
+	expectedPct := 100.0 / 11 // uniformly distributed across 11 possible values
+	tolerance := 1.0          // allow 1 percent deviation from expected
+	for i := 5; i <= 15; i++ {
+		freq := a.orderLinesFreq[i]
+		pct := 100 * float64(freq) / float64(orders)
+		if math.Abs(expectedPct-pct) > tolerance {
+			return errors.Errorf(
+				"order-lines count should be uniformly distributed from 5 to 15, but it was %d for "+
+					"%.1f percent of orders", i, pct)
+		}
 	}
 	return nil
 }

--- a/pkg/workload/tpcc/new_order.go
+++ b/pkg/workload/tpcc/new_order.go
@@ -94,6 +94,10 @@ func (n newOrder) run(config *tpcc, db *gosql.DB, wID int) (interface{}, error) 
 	}
 	d.items = make([]orderItem, d.oOlCnt)
 
+	config.auditor.Lock()
+	config.auditor.orderLinesFreq[d.oOlCnt]++
+	config.auditor.Unlock()
+
 	// itemIDs tracks the item ids in the order so that we can prevent adding
 	// multiple items with the same ID. This would not make sense because each
 	// orderItem already tracks a quantity that can be larger than 1.

--- a/pkg/workload/tpcc/tpcc.go
+++ b/pkg/workload/tpcc/tpcc.go
@@ -127,7 +127,7 @@ var tpccMeta = workload.Meta{
 		g.flags.BoolVar(&g.serializable, `serializable`, false, `Force serializable mode`)
 		g.flags.BoolVar(&g.split, `split`, false, `Split tables`)
 
-		g.auditor = &auditor{}
+		g.auditor = newAuditor()
 
 		g.flags.BoolVar(&g.expensiveChecks, `expensive-checks`, false, `Run expensive checks`)
 		return g


### PR DESCRIPTION
Added an audit check for order-line distribution.

Release note: None