### PR TITLE
cherrypick-2.0: cli: Don't fail `zone ls` on zones from deleted tables/partitions

### DIFF
--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -461,6 +461,13 @@ func Example_zone() {
 	c.Run("zone rm .timeseries")
 	c.Run("zone set system.jobs@primary --file=./testdata/zone_attrs.yaml")
 	c.Run("zone set system --file=./testdata/zone_attrs_advanced.yaml")
+	c.RunWithArgs([]string{"sql", "-e", "create database t; create table t.f (x int, y int)"})
+	c.Run("zone set t --file=./testdata/zone_range_max_bytes.yaml")
+	c.Run("zone ls")
+	c.Run("zone set t.f --file=./testdata/zone_range_max_bytes.yaml")
+	c.Run("zone ls")
+	c.RunWithArgs([]string{"sql", "-e", "drop database t cascade"})
+	c.Run("zone ls")
 
 	// Output:
 	// zone ls
@@ -643,6 +650,39 @@ func Example_zone() {
 	// num_replicas: 3
 	// constraints: {'+us-east-1a,+ssd': 1, +us-east-1b: 1}
 	// experimental_lease_preferences: [[+us-east1b], [+us-east-1a]]
+	// sql -e create database t; create table t.f (x int, y int)
+	// CREATE TABLE
+	// zone set t --file=./testdata/zone_range_max_bytes.yaml
+	// range_min_bytes: 1048576
+	// range_max_bytes: 134217728
+	// gc:
+	//   ttlseconds: 90000
+	// num_replicas: 3
+	// constraints: []
+	// zone ls
+	// .default
+	// system
+	// system.jobs
+	// t
+	// zone set t.f --file=./testdata/zone_range_max_bytes.yaml
+	// range_min_bytes: 1048576
+	// range_max_bytes: 134217728
+	// gc:
+	//   ttlseconds: 90000
+	// num_replicas: 3
+	// constraints: []
+	// zone ls
+	// .default
+	// system
+	// system.jobs
+	// t
+	// t.f
+	// sql -e drop database t cascade
+	// DROP DATABASE
+	// zone ls
+	// .default
+	// system
+	// system.jobs
 }
 
 func Example_sql() {

--- a/pkg/cli/zone.go
+++ b/pkg/cli/zone.go
@@ -47,6 +47,14 @@ func queryZoneSpecifiers(conn *sqlConn) ([]string, error) {
 			return nil, err
 		}
 
+		if vals[0] == nil {
+			// Zone configs for deleted tables and partitions are left around until
+			// their table descriptors are deleted, which happens after the
+			// configured GC TTL duration. Such zones have no cli_specifier and
+			// shouldn't be displayed.
+			continue
+		}
+
 		s, ok := vals[0].(string)
 		if !ok {
 			return nil, fmt.Errorf("unexpected value: %T", vals[0])


### PR DESCRIPTION
Cherrypicks #24178 to release-2.0. It fixes a broken CLI command with approximately zero risk.

------------------

This continues displaying them in the output of `SHOW EXPERIMENTAL ZONE
CONFIGURATIONS`, but it still makes some sense there given that the zone
configs are still in use, they just aren't addressable.

Fixes #24154

Release note (bug fix): Fix a crash in `cockroach zone ls` that would
happen if a table with a zone config on it had been deleted but not yet
garbage collected. (this was broken in v2.0 alphas, not in v1.1)