### PR TITLE
optbuilder: fix panic for subqueries in WHERE clause

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/subquery
+++ b/pkg/sql/logictest/testdata/logic_test/subquery
@@ -512,3 +512,16 @@ root                 ·          ·
            └── scan  ·          ·
 ·                    table      tab4@primary
 ·                    spans      ALL
+
+statement ok
+CREATE TABLE a (a INT PRIMARY KEY)
+
+# Regression test for #24171.
+query I
+SELECT * FROM  a WHERE CAST(COALESCE((SELECT 'a' FROM crdb_internal.zones LIMIT 1 OFFSET 5), (SELECT 'b' FROM pg_catalog.pg_trigger)) AS BYTEA) <= 'a'
+----
+
+# Regression test for #24170.
+query I
+SELECT * FROM a WHERE CAST(COALESCE((SELECT 'a'), (SELECT 'a')) AS bytea) < 'a'
+----

--- a/pkg/sql/opt/optbuilder/scope.go
+++ b/pkg/sql/opt/optbuilder/scope.go
@@ -484,6 +484,11 @@ func (s *scope) VisitPre(expr tree.Expr) (recurse bool, newExpr tree.Expr) {
 		}
 
 	case *tree.ArrayFlatten:
+		if s.builder.AllowUnsupportedExpr {
+			// TODO(rytaft): Temporary fix for #24171 and #24170.
+			break
+		}
+
 		// TODO(peter): the ARRAY flatten operator requires a single column from
 		// the subquery.
 		if sub, ok := t.Subquery.(*tree.Subquery); ok {
@@ -491,6 +496,11 @@ func (s *scope) VisitPre(expr tree.Expr) (recurse bool, newExpr tree.Expr) {
 		}
 
 	case *tree.ComparisonExpr:
+		if s.builder.AllowUnsupportedExpr {
+			// TODO(rytaft): Temporary fix for #24171 and #24170.
+			break
+		}
+
 		switch t.Operator {
 		case tree.In, tree.NotIn, tree.Any, tree.Some, tree.All:
 			if sub, ok := t.Right.(*tree.Subquery); ok {
@@ -499,6 +509,11 @@ func (s *scope) VisitPre(expr tree.Expr) (recurse bool, newExpr tree.Expr) {
 		}
 
 	case *tree.Subquery:
+		if s.builder.AllowUnsupportedExpr {
+			// TODO(rytaft): Temporary fix for #24171 and #24170.
+			break
+		}
+
 		if t.Exists {
 			expr = s.replaceSubquery(t, true /* multi-row */, -1 /* desired-columns */)
 		} else {


### PR DESCRIPTION
This is a temporary fix for a panic that was happening during query
execution for queries with one or more subqueries in the WHERE
clause. The panic was due to the fact that subqueries are now supported
in the optbuilder of the optimizer, but they are not not yet supported
in the execbuilder of the optimizer. Since the index selection code relies
on parity between the optbuilder and execbuilder, this caused the panic.

The longer-term fix will require implementing subqueries in the
execbuilder. It will also require updates to our code for building scalar
expressions. For example, `ScalarBuilder` will probably need to take a
`catalog` argument. We'll also likely need to update our testing
infrastructure to handle subqueries in scalar expressions since
`ParseScalarExpr` does not infer the type of subqueries.

Fixes #24170
Fixes #24171

cc @andy-kimball, @RaduBerinde, @jordanlewis 

Release note: None