### PR TITLE
opt/constraint: remove Span.immutable

### DIFF
--- a/pkg/sql/opt/constraint/constraint.go
+++ b/pkg/sql/opt/constraint/constraint.go
@@ -116,7 +116,7 @@ func (c *Constraint) UnionWith(evalCtx *tree.EvalContext, other *Constraint) {
 		//   merge with [/30 - /40]: [/1 - /40]
 		//   merge with [/40 - /50]: [/1 - /50]
 		//
-		mergeSpan := left.Get(leftIndex).Copy()
+		mergeSpan := *left.Get(leftIndex)
 		leftIndex++
 		for {
 			// Note that Span.TryUnionWith returns false for a different reason
@@ -185,7 +185,7 @@ func (c *Constraint) IntersectWith(evalCtx *tree.EvalContext, other *Constraint)
 			continue
 		}
 
-		mergeSpan := left.Get(leftIndex).Copy()
+		mergeSpan := *left.Get(leftIndex)
 		if !mergeSpan.TryIntersectWith(&keyCtx, right.Get(rightIndex)) {
 			leftIndex++
 			continue
@@ -284,7 +284,7 @@ func (c *Constraint) CutFirstColumn(evalCtx *tree.EvalContext) {
 	keyCtx := MakeKeyContext(&c.Columns, evalCtx)
 	result := MakeSpans(c.Spans.Count())
 	for i := 0; i < c.Spans.Count(); i++ {
-		sp := c.Spans.Get(i).Copy()
+		sp := *c.Spans.Get(i)
 		sp.start = sp.start.CutFront(1)
 		sp.end = sp.end.CutFront(1)
 		result.Append(&sp)

--- a/pkg/sql/opt/constraint/spans.go
+++ b/pkg/sql/opt/constraint/spans.go
@@ -44,7 +44,7 @@ func MakeSpans(capacity int) Spans {
 // SingleSpan creates Spans containing a single span.
 func SingleSpan(sp *Span) Spans {
 	return Spans{
-		firstSpan: sp.Copy(),
+		firstSpan: *sp,
 		numSpans:  1,
 	}
 }
@@ -68,9 +68,9 @@ func (s *Spans) Append(sp *Span) {
 		panic("mutation disallowed")
 	}
 	if s.numSpans == 0 {
-		s.firstSpan = sp.Copy()
+		s.firstSpan = *sp
 	} else {
-		s.otherSpans = append(s.otherSpans, sp.Copy())
+		s.otherSpans = append(s.otherSpans, *sp)
 	}
 	s.numSpans++
 }
@@ -106,12 +106,6 @@ func (s Spans) String() string {
 // the Spans structure or any Span returned by Get.
 func (s *Spans) makeImmutable() {
 	s.immutable = true
-	if s.numSpans > 0 {
-		s.firstSpan.makeImmutable()
-		for i := range s.otherSpans {
-			s.otherSpans[i].makeImmutable()
-		}
-	}
 }
 
 // sortedAndMerged returns true if the collection of spans is strictly


### PR DESCRIPTION
The immutable flag is designed to prevent a certain class of bugs, but
it causes overhead, mostly from the extra copies caused by `Copy()`.
Removing this mechanism (in practice, it didn't help catch any bugs so
far).

Release note: None