### PR TITLE
roachtest: add Sqlapp consistency check tests

### DIFF
--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -22,6 +22,7 @@ import (
 	gosql "database/sql"
 	"fmt"
 	"io"
+	"net/url"
 	"os"
 	"os/exec"
 	"os/user"
@@ -681,11 +682,18 @@ func (c *cluster) RunWithBuffer(
 		append([]string{"roachprod", "ssh", c.makeNodes(node), "--"}, args...)...)
 }
 
-// PGUrl returns the Postgres endpoint for the specified node.
-func (c *cluster) PGUrl(ctx context.Context, node int) string {
-	cmd := exec.CommandContext(
-		ctx, `roachprod`, `pgurl`, `--external`, c.makeNodes(c.Node(node)),
-	)
+// pgURL returns the Postgres endpoint for the specified node. It accepts a flag
+// specifying whether the URL should include the node's internal or external IP
+// address. In general, inter-cluster communication and should use internal IPs
+// and communication from a test driver to nodes in a cluster should use
+// external IPs.
+func (c *cluster) pgURL(ctx context.Context, node int, external bool) string {
+	args := []string{`pgurl`}
+	if external {
+		args = append(args, `--external`)
+	}
+	args = append(args, c.makeNodes(c.Node(node)))
+	cmd := exec.CommandContext(ctx, `roachprod`, args...)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		fmt.Println(strings.Join(cmd.Args, ` `))
@@ -694,9 +702,42 @@ func (c *cluster) PGUrl(ctx context.Context, node int) string {
 	return strings.Trim(string(output), "' \n")
 }
 
+// InternalPGUrl returns the internal Postgres endpoint for the specified node.
+func (c *cluster) InternalPGUrl(ctx context.Context, node int) string {
+	return c.pgURL(ctx, node, false /* external */)
+}
+
+// ExternalPGUrl returns the external Postgres endpoint for the specified node.
+func (c *cluster) ExternalPGUrl(ctx context.Context, node int) string {
+	return c.pgURL(ctx, node, true /* external */)
+}
+
+func urlToIP(c *cluster, pgURL string) string {
+	u, err := url.Parse(pgURL)
+	if err != nil {
+		c.t.Fatal(err)
+	}
+	return u.Host
+}
+
+// InternalIP returns the internal IP address in the form host:port for the
+// specified node.
+func (c *cluster) InternalIP(ctx context.Context, node int) string {
+	return urlToIP(c, c.InternalPGUrl(ctx, node))
+}
+
+// ExternalIP returns the external IP address in the form host:port for the
+// specified node.
+func (c *cluster) ExternalIP(ctx context.Context, node int) string {
+	return urlToIP(c, c.ExternalPGUrl(ctx, node))
+}
+
+// Silence unused warning.
+var _ = (&cluster{}).ExternalIP
+
 // Conn returns a SQL connection to the specified node.
 func (c *cluster) Conn(ctx context.Context, node int) *gosql.DB {
-	url := c.PGUrl(ctx, node)
+	url := c.ExternalPGUrl(ctx, node)
 	db, err := gosql.Open("postgres", url)
 	if err != nil {
 		c.t.Fatal(err)

--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -634,7 +634,7 @@ func (c *cluster) Wipe(ctx context.Context, opts ...option) {
 	}
 }
 
-// Run a command on the specified node
+// Run a command on the specified node.
 func (c *cluster) Run(ctx context.Context, node nodeListOption, args ...string) {
 	err := c.RunL(ctx, c.l, node, args...)
 	if err != nil {

--- a/pkg/cmd/roachtest/decommission.go
+++ b/pkg/cmd/roachtest/decommission.go
@@ -19,7 +19,6 @@ import (
 	"context"
 	"fmt"
 	"io/ioutil"
-	"net/url"
 	"os"
 	"strconv"
 	"time"
@@ -141,11 +140,7 @@ func runDecommission(t *test, c *cluster, nodes int, duration time.Duration) {
 			if err := c.RunE(ctx, c.Node(node), "rm -rf {store-dir}"); err != nil {
 				return err
 			}
-			u, err := url.Parse(c.PGUrl(ctx, nodes))
-			if err != nil {
-				t.Fatal(err)
-			}
-			c.Start(ctx, c.Node(node), startArgs("-a", "--join "+u.Host))
+			c.Start(ctx, c.Node(node), startArgs("-a", "--join "+c.InternalIP(ctx, nodes)))
 			t.Status("sleeping")
 			select {
 			case <-ctx.Done():

--- a/pkg/cmd/roachtest/scaledata.go
+++ b/pkg/cmd/roachtest/scaledata.go
@@ -19,7 +19,6 @@ import (
 	"context"
 	"fmt"
 	"io/ioutil"
-	"net/url"
 	"runtime"
 	"strings"
 	"time"
@@ -85,12 +84,7 @@ func runSqlapp(ctx context.Context, t *test, c *cluster, app, flags string, dur 
 	// comma-separated list of node IP addresses with optional port specifiers.
 	var addrs []string
 	for i := 1; i <= roachNodeCount; i++ {
-		urlStr := c.PGUrl(ctx, i)
-		url, err := url.Parse(urlStr)
-		if err != nil {
-			t.Fatal(err)
-		}
-		addrs = append(addrs, url.Host)
+		addrs = append(addrs, c.InternalIP(ctx, i))
 	}
 	addrStr := strings.Join(addrs, ",")
 

--- a/pkg/cmd/roachtest/scaledata.go
+++ b/pkg/cmd/roachtest/scaledata.go
@@ -1,0 +1,127 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"net/url"
+	"runtime"
+	"strings"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/util/binfetcher"
+)
+
+func init() {
+	// apps is a suite of Sqlapp applications designed to be used to check the
+	// consistency of a database under load. Each Sqlapp application launches a
+	// set of workers who perform database operations while another worker
+	// periodically checks invariants to capture any inconsistencies. The
+	// application suite has been pulled from:
+	// github.com/scaledata/rksql/tree/master/src/go/src/rubrik/sqlapp
+	//
+	// The map provides a mapping between application name and command-line
+	// flags unique to that application.
+	apps := map[string]string{
+		"distributed_semaphore": "",
+		"filesystem_simulator":  "",
+		"jobcoordinator":        "--num_jobs_per_worker=8 --job_period_scale_millis=100",
+	}
+
+	for app, flags := range apps {
+		app, flags := app, flags // copy loop iterator vars
+		const duration = 10 * time.Minute
+		for _, n := range []int{3, 6} {
+			tests.Add(testSpec{
+				Name:  fmt.Sprintf("scaledata/sqlapp/%s/nodes=%d", app, n),
+				Nodes: nodes(n + 1),
+				Run: func(ctx context.Context, t *test, c *cluster) {
+					runSqlapp(ctx, t, c, app, flags, duration)
+				},
+			})
+		}
+	}
+}
+
+func runSqlapp(ctx context.Context, t *test, c *cluster, app, flags string, dur time.Duration) {
+	roachNodeCount := c.nodes - 1
+	roachNodes := c.Range(1, roachNodeCount)
+	appNode := c.Node(c.nodes)
+
+	if local && runtime.GOOS != "linux" {
+		t.Fatalf("must run on linux os, found %s", runtime.GOOS)
+	}
+	b, err := binfetcher.Download(ctx, binfetcher.Options{
+		Component: "rubrik",
+		Binary:    app,
+		Version:   "LATEST",
+		GOOS:      "linux",
+		GOARCH:    "amd64",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	c.Put(ctx, b, app, appNode)
+	c.Put(ctx, cockroach, "./cockroach", roachNodes)
+	c.Start(ctx, roachNodes)
+
+	// Sqlapps each take a `--cockroach_ip_addresses_csv` flag, which is a
+	// comma-separated list of node IP addresses with optional port specifiers.
+	var addrs []string
+	for i := 1; i <= roachNodeCount; i++ {
+		urlStr := c.PGUrl(ctx, i)
+		url, err := url.Parse(urlStr)
+		if err != nil {
+			t.Fatal(err)
+		}
+		addrs = append(addrs, url.Host)
+	}
+	addrStr := strings.Join(addrs, ",")
+
+	m := newMonitor(ctx, c, roachNodes)
+	m.Go(func(ctx context.Context) error {
+		// Sqlapp logs are very noisy - so noisy that if not directed to /dev/null
+		// they often have the effect of slowing down the test so much that it
+		// fails. To get around this we create a new logger that writes to an
+		// artifacts file but does not output to stdout or stderr.
+		sqlappL, err := newLogger(c.l.name, "sqlapp", "", ioutil.Discard, ioutil.Discard)
+		if err != nil {
+			return err
+		}
+
+		t.Status("installing schema")
+		err = c.RunL(ctx, sqlappL, appNode, fmt.Sprintf("./%s --install_schema "+
+			"--cockroach_ip_addresses_csv='%s' %s", app, addrStr, flags))
+		if err != nil {
+			return err
+		}
+
+		// TODO(nvanbenschoten): We are currently running these consistency
+		// checks in the most basic case where are nodes in the Cockroach
+		// cluster are healthy and able to communicate. We should also run them
+		// in a chaos environment, which could introduce network partitions,
+		// node and service restarts, ENOSPACE, clock issues, etc.
+		t.Status("running consistency checker")
+		const workers = 16
+		return c.RunL(ctx, sqlappL, appNode, fmt.Sprintf("./%s  --duration_secs=%d "+
+			"--num_workers=%d --cockroach_ip_addresses_csv='%s' %s",
+			app, int(dur.Seconds()), workers, addrStr, flags))
+	})
+	m.Wait()
+}

--- a/pkg/util/binfetcher/binfetcher.go
+++ b/pkg/util/binfetcher/binfetcher.go
@@ -165,7 +165,6 @@ func Download(ctx context.Context, opts Options) (string, error) {
 	}
 
 	log.Infof(ctx, "downloading %s to %s", opts.URL.String(), destFileName)
-
 	resp, err := http.Get(opts.URL.String())
 	if err != nil {
 		return "", err
@@ -174,6 +173,9 @@ func Download(ctx context.Context, opts Options) (string, error) {
 	if resp.StatusCode != 200 {
 		body, _ := ioutil.ReadAll(resp.Body)
 		return "", errors.Errorf("unexpected HTTP response from %s: %d\n%s", opts.URL.String(), resp.StatusCode, body)
+	}
+	if opts.Version == "LATEST" {
+		log.Infof(ctx, "LATEST redirected to %s", resp.Request.URL.String())
 	}
 
 	destFile, err := os.Create(destFileName)


### PR DESCRIPTION
Fixes cockroachlabs/rubrik#19.

This change adds a series of roachtests that run the Sqlapp consistency
check suite. This suite consists of three applications:
- distributed_semaphore
- filesystem_simulator
- jobworker/jobcoordinator

Each application was designed to be used to check the consistency of a
database under load. They each launch a set of workers who perform database
operations while another worker periodically checks invariants to capture
any inconsistencies. The apps have been pulled from
https://github.com/scaledata/rksql/tree/master/src/go/src/rubrik/sqlapp.

I have a script similar to `loadgen/teamcity-push.sh` that compiles and
uploads all binaries from https://github.com/scaledata/rksql into s3 under
the `cockroach` bucket and the `rubrik` folder. I'm not sure where that
should live.

This PR works on pre-built binaries that include the changes proposed in
https://github.com/scaledata/rksql/pull/1.

Release note: None