### PR TITLE
opt: Intern private values

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/relational_builder.go
+++ b/pkg/sql/opt/exec/execbuilder/relational_builder.go
@@ -141,7 +141,7 @@ func (b *Builder) buildRelational(ev memo.ExprView) (execPlan, error) {
 
 func (b *Builder) buildValues(ev memo.ExprView) (execPlan, error) {
 	md := ev.Metadata()
-	cols := *ev.Private().(*opt.ColList)
+	cols := ev.Private().(opt.ColList)
 	numCols := len(cols)
 
 	rows := make([][]tree.TypedExpr, ev.ChildCount())
@@ -226,7 +226,7 @@ func (b *Builder) buildProject(ev memo.ExprView) (execPlan, error) {
 		return execPlan{}, err
 	}
 	projections := ev.Child(1)
-	colList := *projections.Private().(*opt.ColList)
+	colList := projections.Private().(opt.ColList)
 	exprs := make(tree.TypedExprs, len(colList))
 	colNames := make([]string, len(exprs))
 	ctx := input.makeBuildScalarCtx()
@@ -284,7 +284,7 @@ func (b *Builder) buildGroupBy(ev memo.ExprView) (execPlan, error) {
 	}
 	aggregations := ev.Child(1)
 	numAgg := aggregations.ChildCount()
-	groupingCols := *ev.Private().(*opt.ColSet)
+	groupingCols := ev.Private().(opt.ColSet)
 
 	groupingColIdx := make([]exec.ColumnOrdinal, 0, groupingCols.Len())
 	var ep execPlan
@@ -293,11 +293,11 @@ func (b *Builder) buildGroupBy(ev memo.ExprView) (execPlan, error) {
 		groupingColIdx = append(groupingColIdx, input.getColumnOrdinal(opt.ColumnID(i)))
 	}
 
-	aggColList := *aggregations.Private().(*opt.ColList)
+	aggColList := aggregations.Private().(opt.ColList)
 	aggInfos := make([]exec.AggInfo, numAgg)
 	for i := 0; i < numAgg; i++ {
 		fn := aggregations.Child(i)
-		funcDef := fn.Private().(memo.FuncOpDef)
+		funcDef := fn.Private().(*memo.FuncOpDef)
 
 		argIdx := make([]exec.ColumnOrdinal, fn.ChildCount())
 		for j := range argIdx {

--- a/pkg/sql/opt/exec/execbuilder/scalar_builder.go
+++ b/pkg/sql/opt/exec/execbuilder/scalar_builder.go
@@ -169,7 +169,7 @@ func (b *Builder) buildFunction(ctx *buildScalarCtx, ev memo.ExprView) tree.Type
 	for i := range exprs {
 		exprs[i] = b.buildScalar(ctx, ev.Child(i))
 	}
-	funcDef := ev.Private().(memo.FuncOpDef)
+	funcDef := ev.Private().(*memo.FuncOpDef)
 	funcRef := tree.WrapFunction(funcDef.Name)
 	return tree.NewTypedFuncExpr(
 		funcRef,

--- a/pkg/sql/opt/exec/execbuilder/testdata/aggregate
+++ b/pkg/sql/opt/exec/execbuilder/testdata/aggregate
@@ -10,7 +10,7 @@ CREATE TABLE kv (
 ----
 
 exec-explain
-SELECT MIN(1), MAX(1), COUNT(1), SUM_INT(1), AVG(1), SUM(1), STDDEV(1), VARIANCE(1), BOOL_AND(true), BOOL_AND(false), XOR_AGG(b'\x01') FROM kv
+SELECT MIN(1), MAX(1), COUNT(1), SUM_INT(1), AVG(1), SUM(1), STDDEV(1), VARIANCE(1), BOOL_AND(true), BOOL_OR(false), XOR_AGG(b'\x01') FROM kv
 ----
 group           0  group   ·             ·                   (column6, column8, column10, column12, column14, column16, column18, column20, column22, column24, column26)  ·
  │              0  ·       aggregate 0   min(column5)        ·                                                                                                             ·
@@ -22,7 +22,7 @@ group           0  group   ·             ·                   (column6, column8
  │              0  ·       aggregate 6   stddev(column17)    ·                                                                                                             ·
  │              0  ·       aggregate 7   variance(column19)  ·                                                                                                             ·
  │              0  ·       aggregate 8   bool_and(column21)  ·                                                                                                             ·
- │              0  ·       aggregate 9   bool_and(column23)  ·                                                                                                             ·
+ │              0  ·       aggregate 9   bool_or(column23)   ·                                                                                                             ·
  │              0  ·       aggregate 10  xor_agg(column25)   ·                                                                                                             ·
  └── render     1  render  ·             ·                   (column5, column7, column9, column11, column13, column15, column17, column19, column21, column23, column25)   ·
       │         1  ·       render 0      1                   ·                                                                                                             ·
@@ -41,7 +41,7 @@ group           0  group   ·             ·                   (column6, column8
 ·               2  ·       spans         ALL                 ·                                                                                                             ·
 
 exec
-SELECT MIN(1), MAX(1), COUNT(1), SUM_INT(1), AVG(1), SUM(1), STDDEV(1), VARIANCE(1), BOOL_AND(true), BOOL_AND(false), XOR_AGG(b'\x01') FROM kv
+SELECT MIN(1), MAX(1), COUNT(1), SUM_INT(1), AVG(1), SUM(1), STDDEV(1), VARIANCE(1), BOOL_AND(true), BOOL_OR(false), XOR_AGG(b'\x01') FROM kv
 ----
 column6:int  column8:int  column10:int  column12:int  column14:decimal  column16:decimal  column18:decimal  column20:decimal  column22:bool  column24:bool  column26:bytes
 NULL         NULL         0             NULL          NULL              NULL              NULL              NULL              NULL           NULL           NULL
@@ -68,38 +68,48 @@ NULL
 exec-explain
 SELECT MIN(v), MAX(v), COUNT(v), SUM_INT(1), AVG(v), SUM(v), STDDEV(v), VARIANCE(v), BOOL_AND(v = 1), BOOL_AND(v = 1), XOR_AGG(s::bytes) FROM kv
 ----
-group           0  group   ·             ·                   (column5, column6, column7, column9, column10, column11, column12, column13, column15, column17, column19)  ·
- │              0  ·       aggregate 0   min(kv.v)           ·                                                                                                           ·
- │              0  ·       aggregate 1   max(kv.v)           ·                                                                                                           ·
- │              0  ·       aggregate 2   count(kv.v)         ·                                                                                                           ·
- │              0  ·       aggregate 3   sum_int(column8)    ·                                                                                                           ·
- │              0  ·       aggregate 4   avg(kv.v)           ·                                                                                                           ·
- │              0  ·       aggregate 5   sum(kv.v)           ·                                                                                                           ·
- │              0  ·       aggregate 6   stddev(kv.v)        ·                                                                                                           ·
- │              0  ·       aggregate 7   variance(kv.v)      ·                                                                                                           ·
- │              0  ·       aggregate 8   bool_and(column14)  ·                                                                                                           ·
- │              0  ·       aggregate 9   bool_and(column16)  ·                                                                                                           ·
- │              0  ·       aggregate 10  xor_agg(column18)   ·                                                                                                           ·
- └── render     1  render  ·             ·                   ("kv.v", "kv.v", "kv.v", column8, "kv.v", "kv.v", "kv.v", "kv.v", column14, column16, column18)             ·
-      │         1  ·       render 0      v                   ·                                                                                                           ·
-      │         1  ·       render 1      v                   ·                                                                                                           ·
-      │         1  ·       render 2      v                   ·                                                                                                           ·
-      │         1  ·       render 3      1                   ·                                                                                                           ·
-      │         1  ·       render 4      v                   ·                                                                                                           ·
-      │         1  ·       render 5      v                   ·                                                                                                           ·
-      │         1  ·       render 6      v                   ·                                                                                                           ·
-      │         1  ·       render 7      v                   ·                                                                                                           ·
-      │         1  ·       render 8      v = 1               ·                                                                                                           ·
-      │         1  ·       render 9      v = 1               ·                                                                                                           ·
-      │         1  ·       render 10     s::BYTES            ·                                                                                                           ·
-      └── scan  2  scan    ·             ·                   (v, s)                                                                                                      ·
-·               2  ·       table         kv@primary          ·                                                                                                           ·
-·               2  ·       spans         ALL                 ·                                                                                                           ·
+render               0  render  ·            ·                   (column5, column6, column7, column9, column10, column11, column12, column13, column15, column15, column18)  ·
+ │                   0  ·       render 0     agg0                ·                                                                                                           ·
+ │                   0  ·       render 1     agg1                ·                                                                                                           ·
+ │                   0  ·       render 2     agg2                ·                                                                                                           ·
+ │                   0  ·       render 3     agg3                ·                                                                                                           ·
+ │                   0  ·       render 4     agg4                ·                                                                                                           ·
+ │                   0  ·       render 5     agg5                ·                                                                                                           ·
+ │                   0  ·       render 6     agg6                ·                                                                                                           ·
+ │                   0  ·       render 7     agg7                ·                                                                                                           ·
+ │                   0  ·       render 8     agg8                ·                                                                                                           ·
+ │                   0  ·       render 9     agg8                ·                                                                                                           ·
+ │                   0  ·       render 10    agg9                ·                                                                                                           ·
+ └── group           1  group   ·            ·                   (agg0, agg1, agg2, agg3, agg4, agg5, agg6, agg7, agg8, agg9)                                                ·
+      │              1  ·       aggregate 0  min(kv.v)           ·                                                                                                           ·
+      │              1  ·       aggregate 1  max(kv.v)           ·                                                                                                           ·
+      │              1  ·       aggregate 2  count(kv.v)         ·                                                                                                           ·
+      │              1  ·       aggregate 3  sum_int(column8)    ·                                                                                                           ·
+      │              1  ·       aggregate 4  avg(kv.v)           ·                                                                                                           ·
+      │              1  ·       aggregate 5  sum(kv.v)           ·                                                                                                           ·
+      │              1  ·       aggregate 6  stddev(kv.v)        ·                                                                                                           ·
+      │              1  ·       aggregate 7  variance(kv.v)      ·                                                                                                           ·
+      │              1  ·       aggregate 8  bool_and(column14)  ·                                                                                                           ·
+      │              1  ·       aggregate 9  xor_agg(column17)   ·                                                                                                           ·
+      └── render     2  render  ·            ·                   ("kv.v", "kv.v", "kv.v", column8, "kv.v", "kv.v", "kv.v", "kv.v", column14, column17)                       ·
+           │         2  ·       render 0     v                   ·                                                                                                           ·
+           │         2  ·       render 1     v                   ·                                                                                                           ·
+           │         2  ·       render 2     v                   ·                                                                                                           ·
+           │         2  ·       render 3     1                   ·                                                                                                           ·
+           │         2  ·       render 4     v                   ·                                                                                                           ·
+           │         2  ·       render 5     v                   ·                                                                                                           ·
+           │         2  ·       render 6     v                   ·                                                                                                           ·
+           │         2  ·       render 7     v                   ·                                                                                                           ·
+           │         2  ·       render 8     v = 1               ·                                                                                                           ·
+           │         2  ·       render 9     s::BYTES            ·                                                                                                           ·
+           └── scan  3  scan    ·            ·                   (v, s)                                                                                                      ·
+·                    3  ·       table        kv@primary          ·                                                                                                           ·
+·                    3  ·       spans        ALL                 ·                                                                                                           ·
 
 exec
 SELECT MIN(v), MAX(v), COUNT(v), SUM_INT(1), AVG(v), SUM(v), STDDEV(v), VARIANCE(v), BOOL_AND(v = 1), BOOL_AND(v = 1), XOR_AGG(s::bytes) FROM kv
 ----
-column5:int  column6:int  column7:int  column9:int  column10:decimal  column11:decimal  column12:decimal  column13:decimal  column15:bool  column17:bool  column19:bytes
+column5:int  column6:int  column7:int  column9:int  column10:decimal  column11:decimal  column12:decimal  column13:decimal  column15:bool  column15:bool  column18:bytes
 NULL         NULL         0            NULL         NULL              NULL              NULL              NULL              NULL           NULL           NULL
 
 exec

--- a/pkg/sql/opt/memo/expr.og.go
+++ b/pkg/sql/opt/memo/expr.og.go
@@ -4,6 +4,8 @@ package memo
 
 import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
 )
 
 var opLayoutTable = [...]opLayout{
@@ -1152,7 +1154,7 @@ func (e *Expr) AsScan() *ScanExpr {
 // the same length (same with that of Cols).
 //
 // The Cols field contains the set of column indices returned by each row
-// as a *ColList. It is legal for Cols to be empty.
+// as an opt.ColList. It is legal for Cols to be empty.
 type ValuesExpr Expr
 
 func MakeValuesExpr(rows ListID, cols PrivateID) ValuesExpr {
@@ -1874,7 +1876,7 @@ func (e *Expr) AsExceptAll() *ExceptAllExpr {
 
 // LimitExpr returns a limited subset of the results in the input relation.
 // The limit expression is a scalar value; the operator returns at most this many
-// rows. The private field is an *opt.Ordering which indicates the desired
+// rows. The private field is an opt.Ordering which indicates the desired
 // row ordering (the first rows with respect to this ordering are returned).
 type LimitExpr Expr
 
@@ -2224,7 +2226,7 @@ func (e *Expr) AsTuple() *TupleExpr {
 
 // ProjectionsExpr is a set of typed scalar expressions that will become output
 // columns for a containing Project operator. The private Cols field contains
-// the list of column indexes returned by the expression, as a *opt.ColList. It
+// the list of column indexes returned by the expression, as an opt.ColList. It
 // is not legal for Cols to be empty.
 type ProjectionsExpr Expr
 
@@ -2253,7 +2255,7 @@ func (e *Expr) AsProjections() *ProjectionsExpr {
 
 // AggregationsExpr is a set of aggregate expressions that will become output
 // columns for a containing GroupBy operator. The private Cols field contains
-// the list of column indexes returned by the expression, as a *ColList. It
+// the list of column indexes returned by the expression, as an opt.ColList. It
 // is legal for Cols to be empty.
 type AggregationsExpr Expr
 
@@ -3491,7 +3493,7 @@ func (e *Expr) AsWhen() *WhenExpr {
 }
 
 // FunctionExpr invokes a builtin SQL function like CONCAT or NOW, passing the given
-// arguments. The private field is an opt.FuncOpDef struct that provides the
+// arguments. The private field is a *opt.FuncOpDef struct that provides the
 // name of the function as well as a pointer to the builtin overload definition.
 type FunctionExpr Expr
 
@@ -3560,4 +3562,74 @@ func (e *Expr) AsUnsupportedExpr() *UnsupportedExprExpr {
 		return nil
 	}
 	return (*UnsupportedExprExpr)(e)
+}
+
+// InternScanOpDef adds the given value to the memo and returns an ID that
+// can be used for later lookup. If the same value was added previously,
+// this method is a no-op and returns the ID of the previous value.
+func (m *Memo) InternScanOpDef(val *ScanOpDef) PrivateID {
+	return m.privateStorage.internScanOpDef(val)
+}
+
+// InternColList adds the given value to the memo and returns an ID that
+// can be used for later lookup. If the same value was added previously,
+// this method is a no-op and returns the ID of the previous value.
+func (m *Memo) InternColList(val opt.ColList) PrivateID {
+	return m.privateStorage.internColList(val)
+}
+
+// InternColSet adds the given value to the memo and returns an ID that
+// can be used for later lookup. If the same value was added previously,
+// this method is a no-op and returns the ID of the previous value.
+func (m *Memo) InternColSet(val opt.ColSet) PrivateID {
+	return m.privateStorage.internColSet(val)
+}
+
+// InternSetOpColMap adds the given value to the memo and returns an ID that
+// can be used for later lookup. If the same value was added previously,
+// this method is a no-op and returns the ID of the previous value.
+func (m *Memo) InternSetOpColMap(val *SetOpColMap) PrivateID {
+	return m.privateStorage.internSetOpColMap(val)
+}
+
+// InternOrdering adds the given value to the memo and returns an ID that
+// can be used for later lookup. If the same value was added previously,
+// this method is a no-op and returns the ID of the previous value.
+func (m *Memo) InternOrdering(val Ordering) PrivateID {
+	return m.privateStorage.internOrdering(val)
+}
+
+// InternColumnID adds the given value to the memo and returns an ID that
+// can be used for later lookup. If the same value was added previously,
+// this method is a no-op and returns the ID of the previous value.
+func (m *Memo) InternColumnID(val opt.ColumnID) PrivateID {
+	return m.privateStorage.internColumnID(val)
+}
+
+// InternDatum adds the given value to the memo and returns an ID that
+// can be used for later lookup. If the same value was added previously,
+// this method is a no-op and returns the ID of the previous value.
+func (m *Memo) InternDatum(val tree.Datum) PrivateID {
+	return m.privateStorage.internDatum(val)
+}
+
+// InternType adds the given value to the memo and returns an ID that
+// can be used for later lookup. If the same value was added previously,
+// this method is a no-op and returns the ID of the previous value.
+func (m *Memo) InternType(val types.T) PrivateID {
+	return m.privateStorage.internType(val)
+}
+
+// InternTypedExpr adds the given value to the memo and returns an ID that
+// can be used for later lookup. If the same value was added previously,
+// this method is a no-op and returns the ID of the previous value.
+func (m *Memo) InternTypedExpr(val tree.TypedExpr) PrivateID {
+	return m.privateStorage.internTypedExpr(val)
+}
+
+// InternFuncOpDef adds the given value to the memo and returns an ID that
+// can be used for later lookup. If the same value was added previously,
+// this method is a no-op and returns the ID of the previous value.
+func (m *Memo) InternFuncOpDef(val *FuncOpDef) PrivateID {
+	return m.privateStorage.internFuncOpDef(val)
 }

--- a/pkg/sql/opt/memo/expr_view.go
+++ b/pkg/sql/opt/memo/expr_view.go
@@ -259,11 +259,11 @@ func (ev ExprView) formatRelational(tp treeprinter.Node, flags ExprFmtFlags) {
 		case opt.ProjectOp:
 			// Get the list of columns from the ProjectionsOp, which has the
 			// natural order.
-			colList := *ev.Child(1).Private().(*opt.ColList)
+			colList := ev.Child(1).Private().(opt.ColList)
 			logProps.FormatColList(tp, ev.Metadata(), "columns:", colList)
 
 		case opt.ValuesOp:
-			colList := *ev.Private().(*opt.ColList)
+			colList := ev.Private().(opt.ColList)
 			logProps.FormatColList(tp, ev.Metadata(), "columns:", colList)
 
 		case opt.UnionOp, opt.IntersectOp, opt.ExceptOp,
@@ -282,7 +282,7 @@ func (ev ExprView) formatRelational(tp treeprinter.Node, flags ExprFmtFlags) {
 	// Special-case handling for GroupBy private; print grouping columns in
 	// addition to full set of columns.
 	case opt.GroupByOp:
-		groupingColSet := *ev.Private().(*opt.ColSet)
+		groupingColSet := ev.Private().(opt.ColSet)
 		logProps.FormatColSet(tp, ev.Metadata(), "grouping columns:", groupingColSet)
 
 		// Special-case handling for set operators to show the left and right

--- a/pkg/sql/opt/memo/logical_props_factory.go
+++ b/pkg/sql/opt/memo/logical_props_factory.go
@@ -123,7 +123,7 @@ func (f logicalPropsFactory) constructProjectProps(ev ExprView) LogicalProps {
 	inputProps := ev.lookupChildGroup(0).logical.Relational
 
 	// Use output columns from projection list.
-	props.Relational.OutputCols = opt.ColListToSet(*ev.Child(1).Private().(*opt.ColList))
+	props.Relational.OutputCols = opt.ColListToSet(ev.Child(1).Private().(opt.ColList))
 
 	// Inherit not null columns from input.
 	props.Relational.NotNullCols = inputProps.NotNullCols
@@ -185,9 +185,9 @@ func (f logicalPropsFactory) constructGroupByProps(ev ExprView) LogicalProps {
 
 	// Output columns are the union of grouping columns with columns from the
 	// aggregate projection list.
-	groupingColSet := *ev.Private().(*opt.ColSet)
+	groupingColSet := ev.Private().(opt.ColSet)
 	props.Relational.OutputCols = groupingColSet
-	aggColList := *ev.Child(1).Private().(*opt.ColList)
+	aggColList := ev.Child(1).Private().(opt.ColList)
 	props.Relational.OutputCols.UnionWith(opt.ColListToSet(aggColList))
 
 	// Propagate not null setting from input columns that are being grouped.
@@ -246,7 +246,7 @@ func (f logicalPropsFactory) constructValuesProps(ev ExprView) LogicalProps {
 	props := LogicalProps{Relational: &RelationalProps{}}
 
 	// Use output columns that are attached to the values op.
-	props.Relational.OutputCols = opt.ColListToSet(*ev.Private().(*opt.ColList))
+	props.Relational.OutputCols = opt.ColListToSet(ev.Private().(opt.ColList))
 
 	props.Relational.Stats.RowCount = uint64(ev.ChildCount())
 

--- a/pkg/sql/opt/memo/logical_props_factory_test.go
+++ b/pkg/sql/opt/memo/logical_props_factory_test.go
@@ -46,8 +46,8 @@ func TestLogicalJoinProps(t *testing.T) {
 		t.Helper()
 
 		// (Join (Scan a) (Scan b) (True))
-		leftGroup := f.ConstructScan(f.InternPrivate(constructScanOpDef(f.Metadata(), a)))
-		rightGroup := f.ConstructScan(f.InternPrivate(constructScanOpDef(f.Metadata(), b)))
+		leftGroup := f.ConstructScan(f.InternScanOpDef(constructScanOpDef(f.Metadata(), a)))
+		rightGroup := f.ConstructScan(f.InternScanOpDef(constructScanOpDef(f.Metadata(), b)))
 		onGroup := f.ConstructTrue()
 		operands := xform.DynamicOperands{
 			xform.DynamicID(leftGroup),

--- a/pkg/sql/opt/memo/private_storage.go
+++ b/pkg/sql/opt/memo/private_storage.go
@@ -1,0 +1,289 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package memo
+
+import (
+	"bytes"
+	"encoding/binary"
+	"reflect"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/opt"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
+)
+
+// privateStorage stores private values for opt expressions. Each value is
+// interned, which means that each unique value is stored at most once. If the
+// same value is added twice to storage, the same storage is used, and the same
+// private id is returned by the intern method.
+//
+// To use privateStorage, first call the init method to initialize storage.
+// Call one of the intern method to add a private to storage and get back a
+// unique private id. Call the lookup method with an id to retrieve a previously
+// added private.
+//
+// Each different type of value needs a key derivation function, which maps
+// from the private value to a key value. The key value must be a legal Go map
+// key value, and equivalent private values must always map to the same key
+// value. For example, the key cannot contain a slice (because it's not a legal
+// Go key value) or contain a non-interned pointer (because pointers to
+// equivalent values in different memory locations do not map to the same key
+// value).
+type privateStorage struct {
+	// privatesMap maps from the interning key to the index of the private
+	// value in the privates slice. Note that PrivateID 0 is invalid in order
+	// to indicate an unknown private.
+	privatesMap map[privateKey]PrivateID
+	privates    []interface{}
+
+	// datumCtx is used to get the string representation of datum values.
+	datumCtx tree.FmtCtx
+
+	// keyBuf is temporary "scratch" storage that's used to build keys.
+	keyBuf keyBuffer
+}
+
+// privateKey is used as the key for the privates map. Different types of
+// private values can use either or both fields to construct a unique key. For
+// example, FuncOpDef values use only the iface field to store a pointer to the
+// Builtin struct. Other types, like tree.Datum, use the iface field to store
+// the reflect.Type of the value, and the str field to store its string
+// representation. The key derived for every type/value combo must be guaranteed
+// to never collide with any other.
+type privateKey struct {
+	iface interface{}
+	str   string
+}
+
+// init must be called before privateStorage can be used.
+func (ps *privateStorage) init() {
+	ps.datumCtx = tree.MakeFmtCtx(&ps.keyBuf.Buffer, tree.FmtSimple)
+	ps.privatesMap = make(map[privateKey]PrivateID)
+	ps.privates = make([]interface{}, 1)
+}
+
+// lookup returns a private value previously interned by privateStorage.
+func (ps *privateStorage) lookup(id PrivateID) interface{} {
+	return ps.privates[id]
+}
+
+// internColumnID adds the given value to storage and returns an id that can
+// later be used to retrieve the value by calling the lookup method. If the
+// value has been previously added to storage, then internColumnID always
+// returns the same private id that was returned from the previous call.
+func (ps *privateStorage) internColumnID(colID opt.ColumnID) PrivateID {
+	// The below code is carefully constructed to not allocate in the case
+	// where the value is already in the map. Be careful when modifying.
+	ps.keyBuf.Reset()
+	ps.keyBuf.writeUvarint(uint64(colID))
+	typ := (*opt.ColumnID)(nil)
+	if id, ok := ps.privatesMap[privateKey{iface: typ, str: ps.keyBuf.String()}]; ok {
+		return id
+	}
+	return ps.addValue(privateKey{iface: typ, str: ps.keyBuf.String()}, colID)
+}
+
+// internColSet adds the given value to storage and returns an id that can later
+// be used to retrieve the value by calling the lookup method. If the value has
+// been previously added to storage, then internColSet always returns the same
+// private id that was returned from the previous call.
+func (ps *privateStorage) internColSet(colSet opt.ColSet) PrivateID {
+	// The below code is carefully constructed to not allocate in the case
+	// where the value is already in the map. Be careful when modifying.
+	ps.keyBuf.Reset()
+	ps.keyBuf.writeColSet(colSet)
+	typ := (*opt.ColSet)(nil)
+	if id, ok := ps.privatesMap[privateKey{iface: typ, str: ps.keyBuf.String()}]; ok {
+		return id
+	}
+	return ps.addValue(privateKey{iface: typ, str: ps.keyBuf.String()}, colSet)
+}
+
+// internColList adds the given value to storage and returns an id that can
+// later be used to retrieve the value by calling the lookup method. If the
+// value has been previously added to storage, then internColList always returns
+// the same private id that was returned from the previous call.
+func (ps *privateStorage) internColList(colList opt.ColList) PrivateID {
+	// The below code is carefully constructed to not allocate in the case where
+	// the value is already in the map. Be careful when modifying.
+	ps.keyBuf.Reset()
+	ps.keyBuf.writeColList(colList)
+	typ := (*opt.ColList)(nil)
+	if id, ok := ps.privatesMap[privateKey{iface: typ, str: ps.keyBuf.String()}]; ok {
+		return id
+	}
+	return ps.addValue(privateKey{iface: typ, str: ps.keyBuf.String()}, colList)
+}
+
+// internOrdering adds the given value to storage and returns an id that can
+// later be used to retrieve the value by calling the lookup method. If the
+// value has been previously added to storage, then internOrdering always
+// returns the same private id that was returned from the previous call.
+func (ps *privateStorage) internOrdering(ordering Ordering) PrivateID {
+	// The below code is carefully constructed to not allocate in the case where
+	// the value is already in the map. Be careful when modifying.
+	ps.keyBuf.Reset()
+	var arr [10]byte
+	for _, col := range ordering {
+		cnt := binary.PutVarint(arr[:], int64(col))
+		ps.keyBuf.Write(arr[:cnt])
+	}
+	typ := (*Ordering)(nil)
+	if id, ok := ps.privatesMap[privateKey{iface: typ, str: ps.keyBuf.String()}]; ok {
+		return id
+	}
+	return ps.addValue(privateKey{iface: typ, str: ps.keyBuf.String()}, ordering)
+}
+
+// internFuncOpDef adds the given value to storage and returns an id that can
+// later be used to retrieve the value by calling the lookup method. If the
+// value has been previously added to storage, then internFuncOpDef always
+// returns the same private id that was returned from the previous call.
+func (ps *privateStorage) internFuncOpDef(def *FuncOpDef) PrivateID {
+	// The below code is carefully constructed to not allocate in the case where
+	// the value is already in the map. Be careful when modifying.
+	// The Overload field is already interned, because it's the address of one
+	// of the Builtin structs in the builtins package.
+	if id, ok := ps.privatesMap[privateKey{iface: def.Overload}]; ok {
+		return id
+	}
+	return ps.addValue(privateKey{iface: def.Overload}, def)
+}
+
+// internScanOpDef adds the given value to storage and returns an id that can
+// later be used to retrieve the value by calling the lookup method. If the
+// value has been previously added to storage, then internScanOpDef always
+// returns the same private id that was returned from the previous call.
+func (ps *privateStorage) internScanOpDef(def *ScanOpDef) PrivateID {
+	// The below code is carefully constructed to not allocate in the case where
+	// the value is already in the map. Be careful when modifying.
+	ps.keyBuf.Reset()
+	ps.keyBuf.writeUvarint(uint64(def.Table))
+	ps.keyBuf.writeUvarint(uint64(def.Index))
+	ps.keyBuf.writeColSet(def.Cols)
+	typ := (*ScanOpDef)(nil)
+	if id, ok := ps.privatesMap[privateKey{iface: typ, str: ps.keyBuf.String()}]; ok {
+		return id
+	}
+	return ps.addValue(privateKey{iface: typ, str: ps.keyBuf.String()}, def)
+}
+
+// internSetOpColMap adds the given value to storage and returns an id that can
+// later be used to retrieve the value by calling the lookup method. If the
+// value has been previously added to storage, then internSetOpColMap always
+// returns the same private id that was returned from the previous call.
+func (ps *privateStorage) internSetOpColMap(setOpColMap *SetOpColMap) PrivateID {
+	// The below code is carefully constructed to not allocate in the case where
+	// the value is already in the map. Be careful when modifying.
+	// Write the values of each column list. This works with no length or
+	// separator values because the lists are always the same length.
+	ps.keyBuf.Reset()
+	ps.keyBuf.writeColList(setOpColMap.Left)
+	ps.keyBuf.writeColList(setOpColMap.Right)
+	ps.keyBuf.writeColList(setOpColMap.Out)
+	typ := (*SetOpColMap)(nil)
+	if id, ok := ps.privatesMap[privateKey{iface: typ, str: ps.keyBuf.String()}]; ok {
+		return id
+	}
+	return ps.addValue(privateKey{iface: typ, str: ps.keyBuf.String()}, setOpColMap)
+}
+
+// internDatum adds the given value to storage and returns an id that can later
+// be used to retrieve the value by calling the lookup method. If the value has
+// been previously added to storage, then internDatum always returns the same
+// private id that was returned from the previous call.
+func (ps *privateStorage) internDatum(datum tree.Datum) PrivateID {
+	// The below code is carefully constructed to not allocate in the case where
+	// the value is already in the map. Be careful when modifying.
+	// Use the string representation of the datum value, and distinguish distinct
+	// values with the same representation (i.e. "1" can be a Decimal or Int)
+	// using the reflect.Type of the value.
+	ps.keyBuf.Reset()
+	datum.Format(&ps.datumCtx)
+	typ := reflect.TypeOf(datum)
+	id, ok := ps.privatesMap[privateKey{iface: typ, str: ps.keyBuf.String()}]
+	if ok {
+		return id
+	}
+	return ps.addValue(privateKey{iface: typ, str: ps.keyBuf.String()}, datum)
+}
+
+// internType adds the given value to storage and returns an id that can later
+// be used to retrieve the value by calling the lookup method. If the value has
+// been previously added to storage, then internType always returns the same
+// private id that was returned from the previous call.
+func (ps *privateStorage) internType(sqlType types.T) PrivateID {
+	// The below code is carefully constructed to not allocate in the case where
+	// the value is already in the map. Be careful when modifying.
+	// While most types.T values are valid Go map keys, several are not, such as
+	// types.TTuple. So use the string name of the type, and distinguish that
+	// from other private types by using the reflect.Type of the types.T value.
+	typ := reflect.TypeOf(sqlType)
+	if id, ok := ps.privatesMap[privateKey{iface: typ, str: sqlType.String()}]; ok {
+		return id
+	}
+	return ps.addValue(privateKey{iface: typ, str: sqlType.String()}, sqlType)
+}
+
+// internTypedExpr adds the given value to storage and returns an id that can
+// later be used to retrieve the value by calling the lookup method. If the
+// value has been previously added to storage, then internTypedExpr always
+// returns the same private id that was returned from the previous call.
+func (ps *privateStorage) internTypedExpr(expr tree.TypedExpr) PrivateID {
+	// The below code is carefully constructed to not allocate in the case where
+	// the value is already in the map. Be careful when modifying.
+	if id, ok := ps.privatesMap[privateKey{iface: expr}]; ok {
+		return id
+	}
+	return ps.addValue(privateKey{iface: expr}, expr)
+}
+
+func (ps *privateStorage) addValue(key privateKey, val interface{}) PrivateID {
+	id := PrivateID(len(ps.privates))
+	ps.privates = append(ps.privates, val)
+	ps.privatesMap[key] = id
+	return id
+}
+
+// keyBuffer wraps bytes.Buffer to provide several helper write methods.
+type keyBuffer struct {
+	bytes.Buffer
+}
+
+func (kb *keyBuffer) writeUvarint(val uint64) {
+	var arr [10]byte
+	cnt := binary.PutUvarint(arr[:], val)
+	kb.Write(arr[:cnt])
+}
+
+// writeColSet writes a series of varints, one for each column in the set, in
+// column id order.
+func (kb *keyBuffer) writeColSet(colSet opt.ColSet) {
+	var buf [10]byte
+	colSet.ForEach(func(i int) {
+		cnt := binary.PutUvarint(buf[:], uint64(i))
+		kb.Write(buf[:cnt])
+	})
+}
+
+// writeColSet writes a series of varints, one for each column in the list, in
+// list order.
+func (kb *keyBuffer) writeColList(colList opt.ColList) {
+	var buf [10]byte
+	for _, col := range colList {
+		cnt := binary.PutUvarint(buf[:], uint64(col))
+		kb.Write(buf[:cnt])
+	}
+}

--- a/pkg/sql/opt/memo/private_storage_test.go
+++ b/pkg/sql/opt/memo/private_storage_test.go
@@ -1,0 +1,324 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package memo
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/opt"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/builtins"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
+	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/util"
+)
+
+func TestInternColumnID(t *testing.T) {
+	var ps privateStorage
+	ps.init()
+
+	id1 := ps.internColumnID(opt.ColumnID(1))
+	id2 := ps.internColumnID(opt.ColumnID(1))
+	if id1 != id2 {
+		t.Errorf("same column ID didn't return same private ID")
+	}
+
+	if ps.internColumnID(opt.ColumnID(1)) == ps.internColumnID(opt.ColumnID(2)) {
+		t.Errorf("different column IDs didn't return different private IDs")
+	}
+}
+
+func TestInternColSet(t *testing.T) {
+	var ps privateStorage
+	ps.init()
+
+	test := func(left, right opt.ColSet, expected bool) {
+		t.Helper()
+		leftID := ps.internColSet(left)
+		rightID := ps.internColSet(right)
+		if (leftID == rightID) != expected {
+			t.Errorf("%v == %v, expected %v, got %v", left, right, expected, !expected)
+		}
+	}
+
+	test(util.MakeFastIntSet(), util.MakeFastIntSet(), true)
+	test(util.MakeFastIntSet(0), util.MakeFastIntSet(0), true)
+	test(util.MakeFastIntSet(0, 1, 2, 10, 63), util.MakeFastIntSet(2, 63, 1, 10, 0), true)
+	test(util.MakeFastIntSet(64, 100, 1000), util.MakeFastIntSet(1000, 100, 64), true)
+	test(util.MakeFastIntSet(1, 10, 100, 1000), util.MakeFastIntSet(10, 100, 1, 1000), true)
+	test(util.MakeFastIntSet(1), util.MakeFastIntSet(2), false)
+	test(util.MakeFastIntSet(1, 2), util.MakeFastIntSet(1, 2, 1000), false)
+}
+
+func TestInternColList(t *testing.T) {
+	var ps privateStorage
+	ps.init()
+
+	test := func(left, right opt.ColList, expected bool) {
+		t.Helper()
+		leftID := ps.internColList(left)
+		rightID := ps.internColList(right)
+		if (leftID == rightID) != expected {
+			t.Errorf("%v == %v, expected %v, got %v", left, right, expected, !expected)
+		}
+	}
+
+	test(opt.ColList{}, opt.ColList{}, true)
+	test(opt.ColList{1, 2, 3}, opt.ColList{1, 2, 3}, true)
+	test(opt.ColList{1, 10, 100}, opt.ColList{1, 10, 100}, true)
+	test(opt.ColList{1, 2, 3}, opt.ColList{1, 3, 2}, false)
+	test(opt.ColList{1, 2}, opt.ColList{1, 2, 3}, false)
+}
+
+func TestInternScanOpDef(t *testing.T) {
+	var ps privateStorage
+	ps.init()
+
+	test := func(left, right *ScanOpDef, expected bool) {
+		t.Helper()
+		leftID := ps.internScanOpDef(left)
+		rightID := ps.internScanOpDef(right)
+		if (leftID == rightID) != expected {
+			t.Errorf("%v == %v, expected %v, got %v", left, right, expected, !expected)
+		}
+	}
+
+	scanDef1 := &ScanOpDef{Table: 0, Index: 1, Cols: util.MakeFastIntSet(1, 2)}
+	scanDef2 := &ScanOpDef{Table: 0, Index: 1, Cols: util.MakeFastIntSet(2, 1)}
+	test(scanDef1, scanDef2, true)
+	scanDef3 := &ScanOpDef{Table: 1, Index: 1, Cols: util.MakeFastIntSet(1, 2)}
+	test(scanDef1, scanDef3, false)
+	scanDef4 := &ScanOpDef{Table: 1, Index: 1, Cols: util.MakeFastIntSet(1, 2, 3)}
+	test(scanDef3, scanDef4, false)
+	scanDef5 := &ScanOpDef{Table: 1, Index: 2, Cols: util.MakeFastIntSet(1, 2)}
+	test(scanDef3, scanDef5, false)
+}
+
+func TestInternFuncOpDef(t *testing.T) {
+	var ps privateStorage
+	ps.init()
+
+	test := func(left, right *FuncOpDef, expected bool) {
+		t.Helper()
+		leftID := ps.internFuncOpDef(left)
+		rightID := ps.internFuncOpDef(right)
+		if (leftID == rightID) != expected {
+			t.Errorf("%v == %v, expected %v, got %v", left, right, expected, !expected)
+		}
+	}
+
+	ttuple1 := types.TTuple{types.Int}
+	ttuple2 := types.TTuple{types.Decimal}
+	funcDef1 := &FuncOpDef{Name: "foo", Type: ttuple1, Overload: &builtins.Builtins["now"][0]}
+	funcDef2 := &FuncOpDef{Name: "bar", Type: ttuple2, Overload: &builtins.Builtins["now"][0]}
+	test(funcDef1, funcDef2, true)
+	funcDef3 := &FuncOpDef{Name: "bar", Type: ttuple2, Overload: &builtins.Builtins["now"][1]}
+	test(funcDef2, funcDef3, false)
+}
+
+func TestInternSetOpColMap(t *testing.T) {
+	var ps privateStorage
+	ps.init()
+
+	test := func(left, right *SetOpColMap, expected bool) {
+		t.Helper()
+		leftID := ps.internSetOpColMap(left)
+		rightID := ps.internSetOpColMap(right)
+		if (leftID == rightID) != expected {
+			t.Errorf("%v == %v, expected %v, got %v", left, right, expected, !expected)
+		}
+	}
+
+	list1 := opt.ColList{1, 2}
+	list2 := opt.ColList{3, 4}
+	list3 := opt.ColList{5, 6}
+	list4 := opt.ColList{1, 2}
+	list5 := opt.ColList{3, 4}
+	list6 := opt.ColList{5, 6}
+	test(&SetOpColMap{list1, list2, list3}, &SetOpColMap{list4, list5, list6}, true)
+	test(&SetOpColMap{list1, list2, list3}, &SetOpColMap{list1, list3, list2}, false)
+}
+
+func TestInternOrdering(t *testing.T) {
+	var ps privateStorage
+	ps.init()
+
+	test := func(left, right Ordering, expected bool) {
+		t.Helper()
+		leftID := ps.internOrdering(left)
+		rightID := ps.internOrdering(right)
+		if (leftID == rightID) != expected {
+			t.Errorf("%v == %v, expected %v, got %v", left, right, expected, !expected)
+		}
+	}
+
+	test(Ordering{}, Ordering{}, true)
+	test(Ordering{1, -1, 0}, Ordering{1, -1, 0}, true)
+	test(Ordering{1, -1, 0}, Ordering{-1, 1, 0}, false)
+	test(Ordering{1, -1, 0}, Ordering{-1, 0, 1}, false)
+	test(Ordering{1, 2}, Ordering{1, 2, 3}, false)
+}
+
+func TestInternDatum(t *testing.T) {
+	var ps privateStorage
+	ps.init()
+
+	test := func(left, right tree.Datum, expected bool) {
+		t.Helper()
+		leftID := ps.internDatum(left)
+		rightID := ps.internDatum(right)
+		if (leftID == rightID) != expected {
+			t.Errorf("%v == %v, expected %v, got %v", left, right, expected, !expected)
+		}
+	}
+
+	test(tree.DNull, tree.DNull, true)
+	test(tree.DBoolTrue, tree.DBoolFalse, false)
+	test(tree.NewDFloat(1.0), tree.NewDFloat(1e0), true)
+	test(tree.NewDString("foo"), tree.NewDString("foo"), true)
+
+	dec1, _ := tree.ParseDDecimal("1.0")
+	dec2, _ := tree.ParseDDecimal("1.0")
+	test(dec1, dec2, true)
+	dec3, _ := tree.ParseDDecimal("1")
+	test(dec2, dec3, false)
+	test(dec3, tree.NewDInt(1), false)
+
+	arr1 := tree.NewDArray(types.Int)
+	arr1.Array = tree.Datums{tree.NewDInt(1), tree.NewDInt(2)}
+	arr2 := tree.NewDArray(types.Int)
+	arr2.Array = tree.Datums{tree.NewDInt(1), tree.NewDInt(2)}
+	test(arr1, arr2, true)
+}
+
+func TestInternType(t *testing.T) {
+	var ps privateStorage
+	ps.init()
+
+	test := func(left, right types.T, expected bool) {
+		t.Helper()
+		leftID := ps.internType(left)
+		rightID := ps.internType(right)
+		if (leftID == rightID) != expected {
+			t.Errorf("%v == %v, expected %v, got %v", left, right, expected, !expected)
+		}
+	}
+
+	test(types.Unknown, types.Unknown, true)
+	test(types.Int, types.Int, true)
+	test(types.Timestamp, types.TimestampTZ, false)
+	test(types.AnyArray, types.TArray{Typ: types.Any}, true)
+	test(types.TArray{Typ: types.Int}, types.TArray{Typ: types.Int}, true)
+	test(types.TArray{Typ: types.Int}, types.TArray{Typ: types.Decimal}, false)
+
+	tarr1 := types.TArray{Typ: types.TTuple{types.Int, types.String}}
+	tarr2 := types.TArray{Typ: types.TTuple{types.Int, types.String}}
+	test(tarr1, tarr2, true)
+
+	test(types.TTuple{types.Int, types.Decimal}, types.TTuple{types.Decimal, types.Int}, false)
+
+	// TTable type ignores labels as part of key.
+	ttuple := types.TTuple{types.Bytes, types.JSON}
+	test(types.TTable{Cols: ttuple, Labels: []string{"a"}}, types.TTable{Cols: ttuple}, true)
+}
+
+func TestInternTypedExpr(t *testing.T) {
+	var ps privateStorage
+	ps.init()
+
+	d := tree.NewDInt(1)
+	id1 := ps.internTypedExpr(d)
+	id2 := ps.internTypedExpr(d)
+	if id1 != id2 {
+		t.Errorf("same datum instance didn't return same private ID")
+	}
+
+	id1 = ps.internTypedExpr(tree.NewDInt(1))
+	id2 = ps.internTypedExpr(tree.NewDInt(1))
+	if id1 == id2 {
+		t.Errorf("different datum instances didn't return different private IDs")
+	}
+}
+
+// Ensure that interning values that already exist does not cause unexpected
+// allocations.
+func TestPrivateStorageAllocations(t *testing.T) {
+	var ps privateStorage
+	ps.init()
+
+	colID := opt.ColumnID(1)
+	colSet := util.MakeFastIntSet(1, 2, 3)
+	colList := opt.ColList{3, 2, 1}
+	ordering := Ordering{1, -2, 3}
+	funcOpDef := &FuncOpDef{
+		Name:     "concat",
+		Type:     types.String,
+		Overload: &builtins.Builtins["concat"][0],
+	}
+	scanOpDef := &ScanOpDef{Table: 1, Index: 2, Cols: colSet}
+	setOpColMap := &SetOpColMap{Left: colList, Right: colList, Out: colList}
+	datum := tree.NewDInt(1)
+	typ := types.Int
+
+	result := testutils.TestNoMallocs(func() {
+		ps.internColumnID(colID)
+		ps.internColSet(colSet)
+		ps.internColList(colList)
+		ps.internOrdering(ordering)
+		ps.internFuncOpDef(funcOpDef)
+		ps.internScanOpDef(scanOpDef)
+		ps.internSetOpColMap(setOpColMap)
+		ps.internDatum(datum)
+		ps.internType(typ)
+		ps.internTypedExpr(datum)
+	})
+
+	if !result {
+		t.Errorf("intern methods should not allocate after initial add")
+	}
+}
+
+func BenchmarkPrivateStorage(b *testing.B) {
+	var ps privateStorage
+	ps.init()
+
+	colID := opt.ColumnID(1)
+	colSet := util.MakeFastIntSet(1, 2, 3)
+	colList := opt.ColList{3, 2, 1}
+	ordering := Ordering{1, -2, 3}
+	funcOpDef := &FuncOpDef{
+		Name:     "concat",
+		Type:     types.String,
+		Overload: &builtins.Builtins["concat"][0],
+	}
+	scanOpDef := &ScanOpDef{Table: 1, Index: 2, Cols: colSet}
+	setOpColMap := &SetOpColMap{Left: colList, Right: colList, Out: colList}
+	datum := tree.NewDInt(1)
+	typ := types.Int
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		ps.internColumnID(colID)
+		ps.internColSet(colSet)
+		ps.internColList(colList)
+		ps.internOrdering(ordering)
+		ps.internFuncOpDef(funcOpDef)
+		ps.internScanOpDef(scanOpDef)
+		ps.internSetOpColMap(setOpColMap)
+		ps.internDatum(datum)
+		ps.internType(typ)
+		ps.internTypedExpr(datum)
+	}
+}

--- a/pkg/sql/opt/memo/testdata/memo
+++ b/pkg/sql/opt/memo/testdata/memo
@@ -131,30 +131,29 @@ WHERE a.y=1 AND a.x::string=b.x
 ORDER BY y
 LIMIT 10
 ----
-[26: "p:y:2,x:3,column5:5 o:+2"]
+[25: "p:y:2,x:3,column5:5 o:+2"]
 memo
- ├── 26: (limit 24 25 +2)
+ ├── 25: (limit 23 24 +2)
  │    ├── "" [cost=4500.00]
- │    │    └── best: (limit 24="o:+2" 25 +2)
+ │    │    └── best: (limit 23="o:+2" 24 +2)
  │    └── "p:y:2,x:3,column5:5 o:+2" [cost=4500.00]
- │         └── best: (limit 24="o:+2" 25 +2)
- ├── 25: (const 10)
- ├── 24: (project 23 21)
+ │         └── best: (limit 23="o:+2" 24 +2)
+ ├── 24: (const 10)
+ ├── 23: (project 22 20)
  │    ├── "" [cost=2000.00]
- │    │    └── best: (project 23 21)
- │    └── "o:+2" [cost=4500.00]
- │         └── best: (sort 24)
- ├── 23: (inner-join 15 22 17)
- │    ├── "" [cost=2000.00]
- │    │    └── best: (inner-join 15 22 17)
+ │    │    └── best: (project 22 20)
  │    └── "o:+2" [cost=4500.00]
  │         └── best: (sort 23)
- ├── 22: (scan b)
+ ├── 22: (inner-join 15 21 17)
+ │    ├── "" [cost=2000.00]
+ │    │    └── best: (inner-join 15 21 17)
+ │    └── "o:+2" [cost=4500.00]
+ │         └── best: (sort 22)
+ ├── 21: (scan b)
  │    └── "" [cost=1000.00]
  │         └── best: (scan b)
- ├── 21: (projections 5 10 20)
- ├── 20: (plus 5 19)
- ├── 19: (const 1)
+ ├── 20: (projections 5 10 19)
+ ├── 19: (plus 5 6)
  ├── 18: (inner-join 15 2 17)
  ├── 17: (filters 11)
  ├── 16: (inner-join 15 2 3)
@@ -177,3 +176,35 @@ memo
  └── 1: (scan a)
       └── "" [cost=1000.00]
            └── best: (scan a)
+
+# Test interning of expressions.
+memo
+SELECT 1, 1+z, now()::timestamp, now()::timestamptz
+FROM b
+WHERE z=1 AND concat(x, 'foo', x)=concat(x, 'foo', x)
+----
+[17: "p:column3:3,column4:4,column5:5,column6:6"]
+memo
+ ├── 17: (project 11 16)
+ │    └── "p:column3:3,column4:4,column5:5,column6:6" [cost=1000.00]
+ │         └── best: (project 11 16)
+ ├── 16: (projections 12 13 15 14)
+ ├── 15: (cast 14 timestamp)
+ ├── 14: (function now)
+ ├── 13: (plus 2 3)
+ ├── 12: (const 1)
+ ├── 11: (select 1 10)
+ │    └── "" [cost=1000.00]
+ │         └── best: (select 1 10)
+ ├── 10: (filters 4 8)
+ ├── 9: (and 4 8)
+ ├── 8: (eq 7 7)
+ ├── 7: (function 5 6 5 concat)
+ ├── 6: (const 'foo')
+ ├── 5: (variable b.x)
+ ├── 4: (eq 2 3)
+ ├── 3: (const 1)
+ ├── 2: (variable b.z)
+ └── 1: (scan b)
+      └── "" [cost=1000.00]
+           └── best: (scan b)

--- a/pkg/sql/opt/memo/typing.go
+++ b/pkg/sql/opt/memo/typing.go
@@ -167,9 +167,9 @@ func typeAsBinary(ev ExprView) types.T {
 }
 
 // typeFunction returns the type of a function expression by extracting it from
-// the function's private field, which is an instance of opt.FuncOpDef.
+// the function's private field, which is an instance of *opt.FuncOpDef.
 func typeFunction(ev ExprView) types.T {
-	return ev.Private().(FuncOpDef).Type
+	return ev.Private().(*FuncOpDef).Type
 }
 
 // typeAsAny returns types.Any for an operator that never has its type used.

--- a/pkg/sql/opt/memo/typing_test.go
+++ b/pkg/sql/opt/memo/typing_test.go
@@ -37,13 +37,13 @@ func TestTypingJson(t *testing.T) {
 
 	// (Const <json>)
 	json, _ := tree.ParseDJSON("[1, 2]")
-	jsonGroup := f.ConstructConst(f.InternPrivate(json))
+	jsonGroup := f.ConstructConst(f.InternDatum(json))
 
 	// (Const <int>)
-	intGroup := f.ConstructConst(f.InternPrivate(tree.NewDInt(1)))
+	intGroup := f.ConstructConst(f.InternDatum(tree.NewDInt(1)))
 
 	// (Const <string-array>)
-	arrGroup := f.ConstructConst(f.InternPrivate(tree.NewDArray(types.String)))
+	arrGroup := f.ConstructConst(f.InternDatum(tree.NewDArray(types.String)))
 
 	// (FetchVal (Const <json>) (Const <int>))
 	fetchValGroup := f.ConstructFetchVal(jsonGroup, intGroup)

--- a/pkg/sql/opt/operator.og.go
+++ b/pkg/sql/opt/operator.og.go
@@ -34,7 +34,7 @@ const (
 	// the same length (same with that of Cols).
 	//
 	// The Cols field contains the set of column indices returned by each row
-	// as a *ColList. It is legal for Cols to be empty.
+	// as an opt.ColList. It is legal for Cols to be empty.
 	ValuesOp
 
 	// SelectOp filters rows from its input result set, based on the boolean filter
@@ -174,7 +174,7 @@ const (
 
 	// LimitOp returns a limited subset of the results in the input relation.
 	// The limit expression is a scalar value; the operator returns at most this many
-	// rows. The private field is an *opt.Ordering which indicates the desired
+	// rows. The private field is an opt.Ordering which indicates the desired
 	// row ordering (the first rows with respect to this ordering are returned).
 	LimitOp
 
@@ -288,13 +288,13 @@ const (
 
 	// ProjectionsOp is a set of typed scalar expressions that will become output
 	// columns for a containing Project operator. The private Cols field contains
-	// the list of column indexes returned by the expression, as a *opt.ColList. It
+	// the list of column indexes returned by the expression, as an opt.ColList. It
 	// is not legal for Cols to be empty.
 	ProjectionsOp
 
 	// AggregationsOp is a set of aggregate expressions that will become output
 	// columns for a containing GroupBy operator. The private Cols field contains
-	// the list of column indexes returned by the expression, as a *ColList. It
+	// the list of column indexes returned by the expression, as an opt.ColList. It
 	// is legal for Cols to be empty.
 	AggregationsOp
 
@@ -433,7 +433,7 @@ const (
 	WhenOp
 
 	// FunctionOp invokes a builtin SQL function like CONCAT or NOW, passing the given
-	// arguments. The private field is an opt.FuncOpDef struct that provides the
+	// arguments. The private field is a *opt.FuncOpDef struct that provides the
 	// name of the function as well as a pointer to the builtin overload definition.
 	FunctionOp
 

--- a/pkg/sql/opt/ops/relational.opt
+++ b/pkg/sql/opt/ops/relational.opt
@@ -38,7 +38,7 @@ define Scan {
 # the same length (same with that of Cols).
 #
 # The Cols field contains the set of column indices returned by each row
-# as a *ColList. It is legal for Cols to be empty.
+# as an opt.ColList. It is legal for Cols to be empty.
 [Relational]
 define Values {
     Rows ExprList
@@ -285,7 +285,7 @@ define ExceptAll {
 
 # Limit returns a limited subset of the results in the input relation.
 # The limit expression is a scalar value; the operator returns at most this many
-# rows. The private field is an *opt.Ordering which indicates the desired
+# rows. The private field is an opt.Ordering which indicates the desired
 # row ordering (the first rows with respect to this ordering are returned).
 [Relational]
 define Limit {

--- a/pkg/sql/opt/ops/scalar.opt
+++ b/pkg/sql/opt/ops/scalar.opt
@@ -120,7 +120,7 @@ define False {
 
 [Scalar]
 define Placeholder {
-    Value Interface
+    Value TypedExpr
 }
 
 [Scalar]
@@ -130,7 +130,7 @@ define Tuple {
 
 # Projections is a set of typed scalar expressions that will become output
 # columns for a containing Project operator. The private Cols field contains
-# the list of column indexes returned by the expression, as a *opt.ColList. It
+# the list of column indexes returned by the expression, as an opt.ColList. It
 # is not legal for Cols to be empty.
 [Scalar]
 define Projections {
@@ -140,7 +140,7 @@ define Projections {
 
 # Aggregations is a set of aggregate expressions that will become output
 # columns for a containing GroupBy operator. The private Cols field contains
-# the list of column indexes returned by the expression, as a *ColList. It
+# the list of column indexes returned by the expression, as an opt.ColList. It
 # is legal for Cols to be empty.
 [Scalar]
 define Aggregations {
@@ -468,7 +468,7 @@ define When {
 }
 
 # Function invokes a builtin SQL function like CONCAT or NOW, passing the given
-# arguments. The private field is an opt.FuncOpDef struct that provides the
+# arguments. The private field is a *opt.FuncOpDef struct that provides the
 # name of the function as well as a pointer to the builtin overload definition.
 [Scalar]
 define Function {

--- a/pkg/sql/opt/optbuilder/distinct.go
+++ b/pkg/sql/opt/optbuilder/distinct.go
@@ -54,5 +54,5 @@ func (b *Builder) buildDistinct(
 	}
 
 	aggList := b.constructList(opt.AggregationsOp, nil, nil)
-	return b.factory.ConstructGroupBy(in, aggList, b.factory.InternPrivate(&groupCols)), outScope
+	return b.factory.ConstructGroupBy(in, aggList, b.factory.InternColSet(groupCols)), outScope
 }

--- a/pkg/sql/opt/optbuilder/groupby.go
+++ b/pkg/sql/opt/optbuilder/groupby.go
@@ -217,11 +217,12 @@ func (b *Builder) buildAggregation(
 		for j := range agg.args {
 			colID := argCols[0].id
 			argCols = argCols[1:]
-			argList[j] = b.factory.ConstructVariable(b.factory.InternPrivate(colID))
+			argList[j] = b.factory.ConstructVariable(b.factory.InternColumnID(colID))
 		}
+		def := agg.def
 		aggExprs[i] = b.factory.ConstructFunction(
 			b.factory.InternList(argList),
-			b.factory.InternPrivate(agg.def),
+			b.factory.InternFuncOpDef(&def),
 		)
 	}
 
@@ -230,7 +231,7 @@ func (b *Builder) buildAggregation(
 	for i := range groupings {
 		groupingColSet.Add(int(aggInScope.cols[i].id))
 	}
-	outGroup = b.factory.ConstructGroupBy(outGroup, aggList, b.factory.InternPrivate(&groupingColSet))
+	outGroup = b.factory.ConstructGroupBy(outGroup, aggList, b.factory.InternColSet(groupingColSet))
 
 	// Wrap with having filter if it exists.
 	if having != 0 {
@@ -402,7 +403,7 @@ func (b *Builder) buildAggregateFunction(
 	}
 
 	// Replace the function call with a reference to the column.
-	return b.factory.ConstructVariable(b.factory.InternPrivate(col.id)), col
+	return b.factory.ConstructVariable(b.factory.InternColumnID(col.id)), col
 }
 
 func isAggregate(def *tree.FunctionDefinition) bool {

--- a/pkg/sql/opt/optbuilder/join.go
+++ b/pkg/sql/opt/optbuilder/join.go
@@ -145,7 +145,7 @@ func (b *Builder) buildUsingJoin(
 			if mergedCol, ok := mergedCols[col.id]; ok {
 				projections = append(projections, mergedCol)
 			} else {
-				v := b.factory.ConstructVariable(b.factory.InternPrivate(col.id))
+				v := b.factory.ConstructVariable(b.factory.InternColumnID(col.id))
 				projections = append(projections, v)
 			}
 		}
@@ -256,8 +256,8 @@ func (b *Builder) buildUsingJoinPredicate(
 		}
 
 		// Construct the predicate.
-		leftVar := b.factory.ConstructVariable(b.factory.InternPrivate(leftCol.id))
-		rightVar := b.factory.ConstructVariable(b.factory.InternPrivate(rightCol.id))
+		leftVar := b.factory.ConstructVariable(b.factory.InternColumnID(leftCol.id))
+		rightVar := b.factory.ConstructVariable(b.factory.InternColumnID(rightCol.id))
 		eq := b.factory.ConstructEq(leftVar, rightVar)
 		conditions = append(conditions, eq)
 

--- a/pkg/sql/opt/optbuilder/limit.go
+++ b/pkg/sql/opt/optbuilder/limit.go
@@ -32,7 +32,7 @@ func (b *Builder) buildLimit(
 	out, outScope = in, inScope
 
 	ordering := inScope.ordering
-	orderingPrivID := b.factory.InternPrivate(&ordering)
+	orderingPrivID := b.factory.InternOrdering(ordering)
 
 	if limit.Offset != nil {
 		texpr := parentScope.resolveType(limit.Offset, types.Int)

--- a/pkg/sql/opt/optbuilder/project.go
+++ b/pkg/sql/opt/optbuilder/project.go
@@ -134,7 +134,7 @@ func (b *Builder) buildVariableProjection(
 	if inScope.inGroupingContext() && !inScope.groupby.inAgg && !inScope.groupby.aggInScope.hasColumn(col.id) {
 		panic(groupingError(col.String()))
 	}
-	out := b.factory.ConstructVariable(b.factory.InternPrivate(col.id))
+	out := b.factory.ConstructVariable(b.factory.InternColumnID(col.id))
 	outScope.cols = append(outScope.cols, *col)
 
 	// Update the column name with the alias if it exists, and mark the column
@@ -193,7 +193,7 @@ func (b *Builder) buildDefaultScalarProjection(
 			outScope.cols = append(outScope.cols, *col)
 
 			// Replace the expression with a reference to the column.
-			return b.factory.ConstructVariable(b.factory.InternPrivate(col.id))
+			return b.factory.ConstructVariable(b.factory.InternColumnID(col.id))
 		}
 	}
 

--- a/pkg/sql/opt/optbuilder/select.go
+++ b/pkg/sql/opt/optbuilder/select.go
@@ -134,7 +134,7 @@ func (b *Builder) buildScan(
 		outScope.cols = append(outScope.cols, colProps)
 	}
 
-	return b.factory.ConstructScan(b.factory.InternPrivate(&scanOpDef)), outScope
+	return b.factory.ConstructScan(b.factory.InternScanOpDef(&scanOpDef)), outScope
 }
 
 // buildSelect builds a set of memo groups that represent the given select
@@ -277,7 +277,7 @@ func (b *Builder) buildFrom(
 		rows := []memo.GroupID{b.factory.ConstructTuple(b.factory.InternList(nil))}
 		out = b.factory.ConstructValues(
 			b.factory.InternList(rows),
-			b.factory.InternPrivate(&opt.ColList{}),
+			b.factory.InternColList(opt.ColList{}),
 		)
 		outScope = inScope
 	} else {

--- a/pkg/sql/opt/optbuilder/subquery.go
+++ b/pkg/sql/opt/optbuilder/subquery.go
@@ -185,7 +185,7 @@ func (b *Builder) buildSubqueryProjection(
 		colGroups := make([]memo.GroupID, len(s.cols))
 		for i := range s.cols {
 			cols[i] = &s.cols[i]
-			colGroups[i] = b.factory.ConstructVariable(b.factory.InternPrivate(s.cols[i].id))
+			colGroups[i] = b.factory.ConstructVariable(b.factory.InternColumnID(s.cols[i].id))
 		}
 
 		texpr := tree.NewTypedTuple(cols)
@@ -212,7 +212,7 @@ func (b *Builder) buildSingleRowSubquery(
 	}
 
 	out, outScope = b.buildSubqueryProjection(s, inScope)
-	v := b.factory.ConstructVariable(b.factory.InternPrivate(outScope.cols[0].id))
+	v := b.factory.ConstructVariable(b.factory.InternColumnID(outScope.cols[0].id))
 
 	// Wrap the subquery in a Max1Row operator to enforce that it should return
 	// at most one row. Max1Row may be removed by the optimizer later if it can

--- a/pkg/sql/opt/optbuilder/testdata/aggregate
+++ b/pkg/sql/opt/optbuilder/testdata/aggregate
@@ -18,7 +18,7 @@ TABLE kv
 
 build
 SELECT MIN(1), MAX(1), COUNT(1), SUM_INT(1), AVG(1), SUM(1), STDDEV(1),
-  VARIANCE(1), BOOL_AND(true), BOOL_AND(false), XOR_AGG(b'\x01') FROM t.kv
+  VARIANCE(1), BOOL_AND(true), BOOL_OR(false), XOR_AGG(b'\x01') FROM t.kv
 ----
 group-by
  ├── columns: column6:6(int) column8:8(int) column10:10(int) column12:12(int) column14:14(decimal) column16:16(decimal) column18:18(decimal) column20:20(decimal) column22:22(bool) column24:24(bool) column26:26(bytes)
@@ -57,7 +57,7 @@ group-by
       │    └── variable: column19 [type=int]
       ├── function: bool_and [type=bool]
       │    └── variable: column21 [type=bool]
-      ├── function: bool_and [type=bool]
+      ├── function: bool_or [type=bool]
       │    └── variable: column23 [type=bool]
       └── function: xor_agg [type=bytes]
            └── variable: column25 [type=bytes]
@@ -66,52 +66,61 @@ build
 SELECT MIN(v), MAX(v), COUNT(v), SUM_INT(1), AVG(v), SUM(v), STDDEV(v),
   VARIANCE(v), BOOL_AND(v = 1), BOOL_AND(v = 1), XOR_AGG(s::bytes) FROM kv
 ----
-group-by
- ├── columns: column5:5(int) column6:6(int) column7:7(int) column9:9(int) column10:10(decimal) column11:11(decimal) column12:12(decimal) column13:13(decimal) column15:15(bool) column17:17(bool) column19:19(bytes)
- ├── project
- │    ├── columns: kv.v:2(int) kv.v:2(int) kv.v:2(int) column8:8(int) kv.v:2(int) kv.v:2(int) kv.v:2(int) kv.v:2(int) column14:14(bool) column16:16(bool) column18:18(bytes)
- │    ├── scan kv
- │    │    └── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string)
- │    └── projections
- │         ├── variable: kv.v [type=int]
- │         ├── variable: kv.v [type=int]
- │         ├── variable: kv.v [type=int]
- │         ├── const: 1 [type=int]
- │         ├── variable: kv.v [type=int]
- │         ├── variable: kv.v [type=int]
- │         ├── variable: kv.v [type=int]
- │         ├── variable: kv.v [type=int]
- │         ├── eq [type=bool]
- │         │    ├── variable: kv.v [type=int]
- │         │    └── const: 1 [type=int]
- │         ├── eq [type=bool]
- │         │    ├── variable: kv.v [type=int]
- │         │    └── const: 1 [type=int]
- │         └── cast: bytes [type=bytes]
- │              └── variable: kv.s [type=string]
- └── aggregations
-      ├── function: min [type=int]
-      │    └── variable: kv.v [type=int]
-      ├── function: max [type=int]
-      │    └── variable: kv.v [type=int]
-      ├── function: count [type=int]
-      │    └── variable: kv.v [type=int]
-      ├── function: sum_int [type=int]
-      │    └── variable: column8 [type=int]
-      ├── function: avg [type=decimal]
-      │    └── variable: kv.v [type=int]
-      ├── function: sum [type=decimal]
-      │    └── variable: kv.v [type=int]
-      ├── function: stddev [type=decimal]
-      │    └── variable: kv.v [type=int]
-      ├── function: variance [type=decimal]
-      │    └── variable: kv.v [type=int]
-      ├── function: bool_and [type=bool]
-      │    └── variable: column14 [type=bool]
-      ├── function: bool_and [type=bool]
-      │    └── variable: column16 [type=bool]
-      └── function: xor_agg [type=bytes]
-           └── variable: column18 [type=bytes]
+project
+ ├── columns: column5:5(int) column6:6(int) column7:7(int) column9:9(int) column10:10(decimal) column11:11(decimal) column12:12(decimal) column13:13(decimal) column15:15(bool) column15:15(bool) column18:18(bytes)
+ ├── group-by
+ │    ├── columns: column5:5(int) column6:6(int) column7:7(int) column9:9(int) column10:10(decimal) column11:11(decimal) column12:12(decimal) column13:13(decimal) column15:15(bool) column18:18(bytes)
+ │    ├── project
+ │    │    ├── columns: kv.v:2(int) kv.v:2(int) kv.v:2(int) column8:8(int) kv.v:2(int) kv.v:2(int) kv.v:2(int) kv.v:2(int) column14:14(bool) column17:17(bytes)
+ │    │    ├── scan kv
+ │    │    │    └── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string)
+ │    │    └── projections
+ │    │         ├── variable: kv.v [type=int]
+ │    │         ├── variable: kv.v [type=int]
+ │    │         ├── variable: kv.v [type=int]
+ │    │         ├── const: 1 [type=int]
+ │    │         ├── variable: kv.v [type=int]
+ │    │         ├── variable: kv.v [type=int]
+ │    │         ├── variable: kv.v [type=int]
+ │    │         ├── variable: kv.v [type=int]
+ │    │         ├── eq [type=bool]
+ │    │         │    ├── variable: kv.v [type=int]
+ │    │         │    └── const: 1 [type=int]
+ │    │         └── cast: bytes [type=bytes]
+ │    │              └── variable: kv.s [type=string]
+ │    └── aggregations
+ │         ├── function: min [type=int]
+ │         │    └── variable: kv.v [type=int]
+ │         ├── function: max [type=int]
+ │         │    └── variable: kv.v [type=int]
+ │         ├── function: count [type=int]
+ │         │    └── variable: kv.v [type=int]
+ │         ├── function: sum_int [type=int]
+ │         │    └── variable: column8 [type=int]
+ │         ├── function: avg [type=decimal]
+ │         │    └── variable: kv.v [type=int]
+ │         ├── function: sum [type=decimal]
+ │         │    └── variable: kv.v [type=int]
+ │         ├── function: stddev [type=decimal]
+ │         │    └── variable: kv.v [type=int]
+ │         ├── function: variance [type=decimal]
+ │         │    └── variable: kv.v [type=int]
+ │         ├── function: bool_and [type=bool]
+ │         │    └── variable: column14 [type=bool]
+ │         └── function: xor_agg [type=bytes]
+ │              └── variable: column17 [type=bytes]
+ └── projections
+      ├── variable: column5 [type=int]
+      ├── variable: column6 [type=int]
+      ├── variable: column7 [type=int]
+      ├── variable: column9 [type=int]
+      ├── variable: column10 [type=decimal]
+      ├── variable: column11 [type=decimal]
+      ├── variable: column12 [type=decimal]
+      ├── variable: column13 [type=decimal]
+      ├── variable: column15 [type=bool]
+      ├── variable: column15 [type=bool]
+      └── variable: column18 [type=bytes]
 
 build
 SELECT MIN(1), COUNT(1), MAX(1), SUM_INT(1), AVG(1)::float, SUM(1), STDDEV(1),

--- a/pkg/sql/opt/optbuilder/union.go
+++ b/pkg/sql/opt/optbuilder/union.go
@@ -97,7 +97,7 @@ func (b *Builder) buildUnion(
 		newCols = leftCols
 	}
 	setOpColMap := memo.SetOpColMap{Left: leftCols, Right: rightCols, Out: newCols}
-	private := b.factory.InternPrivate(&setOpColMap)
+	private := b.factory.InternSetOpColMap(&setOpColMap)
 
 	if clause.All {
 		switch clause.Type {

--- a/pkg/sql/opt/optbuilder/util.go
+++ b/pkg/sql/opt/optbuilder/util.go
@@ -137,7 +137,7 @@ func (b *Builder) constructList(
 	}
 
 	list := b.factory.InternList(items)
-	private := b.factory.InternPrivate(&colList)
+	private := b.factory.InternColList(colList)
 
 	switch op {
 	case opt.ProjectionsOp:

--- a/pkg/sql/opt/optbuilder/values.go
+++ b/pkg/sql/opt/optbuilder/values.go
@@ -76,6 +76,6 @@ func (b *Builder) buildValuesClause(
 	}
 
 	colList := colsToColList(outScope.cols)
-	out = b.factory.ConstructValues(b.factory.InternList(rows), b.factory.InternPrivate(&colList))
+	out = b.factory.ConstructValues(b.factory.InternList(rows), b.factory.InternColList(colList))
 	return out, outScope
 }

--- a/pkg/sql/opt/optgen/cmd/optgen/exprs_gen.go
+++ b/pkg/sql/opt/optgen/cmd/optgen/exprs_gen.go
@@ -17,6 +17,7 @@ package main
 import (
 	"fmt"
 	"io"
+	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/optgen/lang"
 )
@@ -36,6 +37,8 @@ func (g *exprsGen) generate(compiled *lang.CompiledExpr, w io.Writer) {
 
 	fmt.Fprintf(g.w, "import (\n")
 	fmt.Fprintf(g.w, "  \"github.com/cockroachdb/cockroach/pkg/sql/opt\"\n")
+	fmt.Fprintf(g.w, "  \"github.com/cockroachdb/cockroach/pkg/sql/sem/tree\"\n")
+	fmt.Fprintf(g.w, "  \"github.com/cockroachdb/cockroach/pkg/sql/sem/types\"\n")
 	fmt.Fprintf(g.w, ")\n\n")
 
 	g.genLayoutTable()
@@ -46,8 +49,9 @@ func (g *exprsGen) generate(compiled *lang.CompiledExpr, w io.Writer) {
 	for _, define := range g.compiled.Defines.WithoutTag("Enforcer") {
 		g.genExprType(define)
 		g.genExprFuncs(define)
-		g.genMemoFuncs(define)
 	}
+
+	g.genMemoFuncs()
 }
 
 // genLayoutTable generates the layout table; see opLayout.
@@ -155,6 +159,7 @@ func (g *exprsGen) genExprType(define *lang.DefineExpr) {
 // genExprFuncs generates the expression's accessor functions, one for each
 // field in the type.
 func (g *exprsGen) genExprFuncs(define *lang.DefineExpr) {
+	opType := fmt.Sprintf("%sOp", define.Name)
 	exprType := fmt.Sprintf("%sExpr", define.Name)
 
 	// Generate the strongly-typed accessor methods.
@@ -181,13 +186,6 @@ func (g *exprsGen) genExprFuncs(define *lang.DefineExpr) {
 	fmt.Fprintf(g.w, "func (e *%s) Fingerprint() Fingerprint {\n", exprType)
 	fmt.Fprintf(g.w, "  return Fingerprint(*e)\n")
 	fmt.Fprintf(g.w, "}\n\n")
-}
-
-// genMemoFuncs generates conversion methods on the memo expression, one for
-// each more specialized expression type.
-func (g *exprsGen) genMemoFuncs(define *lang.DefineExpr) {
-	opType := fmt.Sprintf("%sOp", define.Name)
-	exprType := fmt.Sprintf("%sExpr", define.Name)
 
 	// Generate a conversion method from Expr to the more specialized
 	// expression type.
@@ -198,4 +196,19 @@ func (g *exprsGen) genMemoFuncs(define *lang.DefineExpr) {
 
 	fmt.Fprintf(g.w, "  return (*%s)(e)\n", exprType)
 	fmt.Fprintf(g.w, "}\n\n")
+}
+
+// genMemoFuncs generates methods on the memo.
+func (g *exprsGen) genMemoFuncs() {
+	for _, typ := range getUniquePrivateTypes(g.compiled.Defines) {
+		// Remove memo package qualifier from types.
+		goType := strings.Replace(mapPrivateType(typ), "memo.", "", -1)
+
+		fmt.Fprintf(g.w, "// Intern%s adds the given value to the memo and returns an ID that\n", typ)
+		fmt.Fprintf(g.w, "// can be used for later lookup. If the same value was added previously, \n")
+		fmt.Fprintf(g.w, "// this method is a no-op and returns the ID of the previous value.\n")
+		fmt.Fprintf(g.w, "func (m *Memo) Intern%s(val %s) PrivateID {\n", typ, goType)
+		fmt.Fprintf(g.w, "return m.privateStorage.intern%s(val)", typ)
+		fmt.Fprintf(g.w, "}\n\n")
+	}
 }

--- a/pkg/sql/opt/optgen/cmd/optgen/testdata/exprs
+++ b/pkg/sql/opt/optgen/cmd/optgen/testdata/exprs
@@ -5,7 +5,7 @@ optgen exprs test.opt
 define FuncCall {
     Name Expr
     Args ExprList
-    Def  FuncDef
+    Def  FuncOpDef
 }
 ----
 ----
@@ -15,6 +15,8 @@ package memo
 
 import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
 )
 
 var opLayoutTable = [...]opLayout{
@@ -50,6 +52,13 @@ func (e *Expr) AsFuncCall() *FuncCallExpr {
 	}
 	return (*FuncCallExpr)(e)
 }
+
+// InternFuncOpDef adds the given value to the memo and returns an ID that
+// can be used for later lookup. If the same value was added previously,
+// this method is a no-op and returns the ID of the previous value.
+func (m *Memo) InternFuncOpDef(val *FuncOpDef) PrivateID {
+	return m.privateStorage.internFuncOpDef(val)
+}
 ----
 ----
 
@@ -69,6 +78,8 @@ package memo
 
 import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
 )
 
 var opLayoutTable = [...]opLayout{

--- a/pkg/sql/opt/optgen/cmd/optgen/testdata/factory
+++ b/pkg/sql/opt/optgen/cmd/optgen/testdata/factory
@@ -11,7 +11,7 @@ define Not {
 define FuncCall {
     Name Expr
     Args ExprList
-    Def  FuncDef
+    Def  FuncOpDef
 }
 
 # This shouldn't be added to the factory.
@@ -28,7 +28,16 @@ package xform
 import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
 )
+
+// InternFuncOpDef adds the given value to the memo and returns an ID that
+// can be used for later lookup. If the same value was added previously,
+// this method is a no-op and returns the ID of the previous value.
+func (_f *Factory) InternFuncOpDef(val *memo.FuncOpDef) memo.PrivateID {
+	return _f.mem.InternFuncOpDef(val)
+}
 
 // ConstructNot constructs an expression for the Not operator.
 // Not is a negate operator.
@@ -115,6 +124,8 @@ package xform
 import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
 )
 
 // ConstructInnerJoin constructs an expression for the InnerJoin operator.
@@ -198,6 +209,7 @@ define Minus {
 }
 
 define Const {
+    Value Datum
 }
 
 [NormalizeVarPlus, Normalize]
@@ -221,7 +233,16 @@ package xform
 import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
 )
+
+// InternDatum adds the given value to the memo and returns an ID that
+// can be used for later lookup. If the same value was added previously,
+// this method is a no-op and returns the ID of the previous value.
+func (_f *Factory) InternDatum(val tree.Datum) memo.PrivateID {
+	return _f.mem.InternDatum(val)
+}
 
 // ConstructEq constructs an expression for the Eq operator.
 func (_f *Factory) ConstructEq(
@@ -350,8 +371,10 @@ func (_f *Factory) ConstructMinus(
 }
 
 // ConstructConst constructs an expression for the Const operator.
-func (_f *Factory) ConstructConst() memo.GroupID {
-	_constExpr := memo.MakeConstExpr()
+func (_f *Factory) ConstructConst(
+	value memo.PrivateID,
+) memo.GroupID {
+	_constExpr := memo.MakeConstExpr(value)
 	_group := _f.mem.GroupByFingerprint(_constExpr.Fingerprint())
 	if _group != 0 {
 		return _group
@@ -396,7 +419,7 @@ func init() {
 
 	// ConstOp
 	dynConstructLookup[opt.ConstOp] = func(f *Factory, operands DynamicOperands) memo.GroupID {
-		return f.ConstructConst()
+		return f.ConstructConst(memo.PrivateID(operands[0]))
 	}
 
 }
@@ -415,6 +438,7 @@ optgen factory test.opt
 define Func {
     Name Expr
     Args ExprList
+    Def  FuncOpDef
 }
 
 define Variable {
@@ -434,14 +458,31 @@ package xform
 import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
 )
+
+// InternFuncOpDef adds the given value to the memo and returns an ID that
+// can be used for later lookup. If the same value was added previously,
+// this method is a no-op and returns the ID of the previous value.
+func (_f *Factory) InternFuncOpDef(val *memo.FuncOpDef) memo.PrivateID {
+	return _f.mem.InternFuncOpDef(val)
+}
+
+// InternColumnID adds the given value to the memo and returns an ID that
+// can be used for later lookup. If the same value was added previously,
+// this method is a no-op and returns the ID of the previous value.
+func (_f *Factory) InternColumnID(val opt.ColumnID) memo.PrivateID {
+	return _f.mem.InternColumnID(val)
+}
 
 // ConstructFunc constructs an expression for the Func operator.
 func (_f *Factory) ConstructFunc(
 	name memo.GroupID,
 	args memo.ListID,
+	def memo.PrivateID,
 ) memo.GroupID {
-	_funcExpr := memo.MakeFuncExpr(name, args)
+	_funcExpr := memo.MakeFuncExpr(name, args, def)
 	_group := _f.mem.GroupByFingerprint(_funcExpr.Fingerprint())
 	if _group != 0 {
 		return _group
@@ -504,7 +545,7 @@ func init() {
 
 	// FuncOp
 	dynConstructLookup[opt.FuncOp] = func(f *Factory, operands DynamicOperands) memo.GroupID {
-		return f.ConstructFunc(memo.GroupID(operands[0]), operands[1].ListID())
+		return f.ConstructFunc(memo.GroupID(operands[0]), operands[1].ListID(), memo.PrivateID(operands[2]))
 	}
 
 	// VariableOp
@@ -569,6 +610,8 @@ package xform
 import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
 )
 
 // ConstructSelect constructs an expression for the Select operator.
@@ -773,6 +816,8 @@ package xform
 import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
 )
 
 // ConstructList constructs an expression for the List operator.
@@ -876,6 +921,8 @@ package xform
 import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
 )
 
 // ConstructJoin constructs an expression for the Join operator.
@@ -956,6 +1003,8 @@ package xform
 import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
 )
 
 // ConstructList constructs an expression for the List operator.
@@ -1081,6 +1130,8 @@ package xform
 import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
 )
 
 // ConstructEq constructs an expression for the Eq operator.
@@ -1243,6 +1294,8 @@ package xform
 import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
 )
 
 // ConstructPlus constructs an expression for the Plus operator.
@@ -1394,6 +1447,8 @@ package xform
 import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
 )
 
 // ConstructLt constructs an expression for the Lt operator.

--- a/pkg/sql/opt/optgen/cmd/optgen/utils.go
+++ b/pkg/sql/opt/optgen/cmd/optgen/utils.go
@@ -42,6 +42,33 @@ func mapType(typ string) string {
 	}
 }
 
+func mapPrivateType(typ string) string {
+	switch typ {
+	case "ColumnID":
+		return "opt.ColumnID"
+	case "ColSet":
+		return "opt.ColSet"
+	case "ColList":
+		return "opt.ColList"
+	case "Ordering":
+		return "memo.Ordering"
+	case "FuncOpDef":
+		return "*memo.FuncOpDef"
+	case "ScanOpDef":
+		return "*memo.ScanOpDef"
+	case "SetOpColMap":
+		return "*memo.SetOpColMap"
+	case "Datum":
+		return "tree.Datum"
+	case "Type":
+		return "types.T"
+	case "TypedExpr":
+		return "tree.TypedExpr"
+	default:
+		panic(fmt.Sprintf("unrecognized private type: %s", typ))
+	}
+}
+
 // isListType returns true if the given type is ExprList. An expression may
 // have at most one field with a list type.
 func isListType(typ string) bool {
@@ -91,6 +118,26 @@ func privateField(d *lang.DefineExpr) *lang.DefineFieldExpr {
 	}
 
 	return nil
+}
+
+// getUniquePrivateTypes returns a list of the distinct private value types used
+// in the given set of define expressions. These are used to generating methods
+// to intern private values.
+func getUniquePrivateTypes(defines lang.DefineSetExpr) []string {
+	var types []string
+	unique := make(map[lang.StringExpr]bool)
+
+	for _, define := range defines {
+		defineField := privateField(define)
+		if defineField != nil {
+			if !unique[defineField.Type] {
+				types = append(types, string(defineField.Type))
+				unique[defineField.Type] = true
+			}
+		}
+	}
+
+	return types
 }
 
 // generateDefineComments is a helper function that generates a block of

--- a/pkg/sql/opt/xform/explorer.go
+++ b/pkg/sql/opt/xform/explorer.go
@@ -251,7 +251,7 @@ func (e *explorer) generateIndexScans(scan memo.ExprID) {
 		// then construct a new Scan operator using that index.
 		if def.AltIndexHasCols(e.mem.Metadata(), i) {
 			newDef := &memo.ScanOpDef{Table: def.Table, Index: i, Cols: def.Cols}
-			indexScan := memo.MakeScanExpr(e.mem.InternPrivate(newDef))
+			indexScan := memo.MakeScanExpr(e.mem.InternScanOpDef(newDef))
 			e.mem.MemoizeDenormExpr(scan.Group, memo.Expr(indexScan))
 		}
 	}

--- a/pkg/sql/opt/xform/factory.og.go
+++ b/pkg/sql/opt/xform/factory.og.go
@@ -5,7 +5,79 @@ package xform
 import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
 )
+
+// InternScanOpDef adds the given value to the memo and returns an ID that
+// can be used for later lookup. If the same value was added previously,
+// this method is a no-op and returns the ID of the previous value.
+func (_f *Factory) InternScanOpDef(val *memo.ScanOpDef) memo.PrivateID {
+	return _f.mem.InternScanOpDef(val)
+}
+
+// InternColList adds the given value to the memo and returns an ID that
+// can be used for later lookup. If the same value was added previously,
+// this method is a no-op and returns the ID of the previous value.
+func (_f *Factory) InternColList(val opt.ColList) memo.PrivateID {
+	return _f.mem.InternColList(val)
+}
+
+// InternColSet adds the given value to the memo and returns an ID that
+// can be used for later lookup. If the same value was added previously,
+// this method is a no-op and returns the ID of the previous value.
+func (_f *Factory) InternColSet(val opt.ColSet) memo.PrivateID {
+	return _f.mem.InternColSet(val)
+}
+
+// InternSetOpColMap adds the given value to the memo and returns an ID that
+// can be used for later lookup. If the same value was added previously,
+// this method is a no-op and returns the ID of the previous value.
+func (_f *Factory) InternSetOpColMap(val *memo.SetOpColMap) memo.PrivateID {
+	return _f.mem.InternSetOpColMap(val)
+}
+
+// InternOrdering adds the given value to the memo and returns an ID that
+// can be used for later lookup. If the same value was added previously,
+// this method is a no-op and returns the ID of the previous value.
+func (_f *Factory) InternOrdering(val memo.Ordering) memo.PrivateID {
+	return _f.mem.InternOrdering(val)
+}
+
+// InternColumnID adds the given value to the memo and returns an ID that
+// can be used for later lookup. If the same value was added previously,
+// this method is a no-op and returns the ID of the previous value.
+func (_f *Factory) InternColumnID(val opt.ColumnID) memo.PrivateID {
+	return _f.mem.InternColumnID(val)
+}
+
+// InternDatum adds the given value to the memo and returns an ID that
+// can be used for later lookup. If the same value was added previously,
+// this method is a no-op and returns the ID of the previous value.
+func (_f *Factory) InternDatum(val tree.Datum) memo.PrivateID {
+	return _f.mem.InternDatum(val)
+}
+
+// InternType adds the given value to the memo and returns an ID that
+// can be used for later lookup. If the same value was added previously,
+// this method is a no-op and returns the ID of the previous value.
+func (_f *Factory) InternType(val types.T) memo.PrivateID {
+	return _f.mem.InternType(val)
+}
+
+// InternTypedExpr adds the given value to the memo and returns an ID that
+// can be used for later lookup. If the same value was added previously,
+// this method is a no-op and returns the ID of the previous value.
+func (_f *Factory) InternTypedExpr(val tree.TypedExpr) memo.PrivateID {
+	return _f.mem.InternTypedExpr(val)
+}
+
+// InternFuncOpDef adds the given value to the memo and returns an ID that
+// can be used for later lookup. If the same value was added previously,
+// this method is a no-op and returns the ID of the previous value.
+func (_f *Factory) InternFuncOpDef(val *memo.FuncOpDef) memo.PrivateID {
+	return _f.mem.InternFuncOpDef(val)
+}
 
 // ConstructScan constructs an expression for the Scan operator.
 // Scan returns a result set containing every row in the specified table, by
@@ -37,7 +109,7 @@ func (_f *Factory) ConstructScan(
 // the same length (same with that of Cols).
 //
 // The Cols field contains the set of column indices returned by each row
-// as a *ColList. It is legal for Cols to be empty.
+// as an opt.ColList. It is legal for Cols to be empty.
 func (_f *Factory) ConstructValues(
 	rows memo.ListID,
 	cols memo.PrivateID,
@@ -1623,7 +1695,7 @@ func (_f *Factory) ConstructExceptAll(
 // ConstructLimit constructs an expression for the Limit operator.
 // Limit returns a limited subset of the results in the input relation.
 // The limit expression is a scalar value; the operator returns at most this many
-// rows. The private field is an *opt.Ordering which indicates the desired
+// rows. The private field is an opt.Ordering which indicates the desired
 // row ordering (the first rows with respect to this ordering are returned).
 func (_f *Factory) ConstructLimit(
 	input memo.GroupID,
@@ -1914,7 +1986,7 @@ func (_f *Factory) ConstructTuple(
 // ConstructProjections constructs an expression for the Projections operator.
 // Projections is a set of typed scalar expressions that will become output
 // columns for a containing Project operator. The private Cols field contains
-// the list of column indexes returned by the expression, as a *opt.ColList. It
+// the list of column indexes returned by the expression, as an opt.ColList. It
 // is not legal for Cols to be empty.
 func (_f *Factory) ConstructProjections(
 	elems memo.ListID,
@@ -1936,7 +2008,7 @@ func (_f *Factory) ConstructProjections(
 // ConstructAggregations constructs an expression for the Aggregations operator.
 // Aggregations is a set of aggregate expressions that will become output
 // columns for a containing GroupBy operator. The private Cols field contains
-// the list of column indexes returned by the expression, as a *ColList. It
+// the list of column indexes returned by the expression, as an opt.ColList. It
 // is legal for Cols to be empty.
 func (_f *Factory) ConstructAggregations(
 	aggs memo.ListID,
@@ -5034,7 +5106,7 @@ func (_f *Factory) ConstructWhen(
 
 // ConstructFunction constructs an expression for the Function operator.
 // Function invokes a builtin SQL function like CONCAT or NOW, passing the given
-// arguments. The private field is an opt.FuncOpDef struct that provides the
+// arguments. The private field is a *opt.FuncOpDef struct that provides the
 // name of the function as well as a pointer to the builtin overload definition.
 func (_f *Factory) ConstructFunction(
 	args memo.ListID,

--- a/pkg/sql/opt/xform/factory_test.go
+++ b/pkg/sql/opt/xform/factory_test.go
@@ -47,8 +47,8 @@ func TestSimplifyFilters(t *testing.T) {
 	a := f.Metadata().AddTable(cat.Table("a"))
 	ax := f.Metadata().TableColumn(a, 0)
 
-	variable := f.ConstructVariable(f.InternPrivate(ax))
-	constant := f.ConstructConst(f.InternPrivate(tree.NewDInt(1)))
+	variable := f.ConstructVariable(f.InternColumnID(ax))
+	constant := f.ConstructConst(f.InternDatum(tree.NewDInt(1)))
 	eq := f.ConstructEq(variable, constant)
 
 	// Filters expression evaluates to False if any operand is False.
@@ -60,7 +60,7 @@ func TestSimplifyFilters(t *testing.T) {
 	}
 
 	// Filters expression evaluates to False if any operand is Null.
-	conditions = []memo.GroupID{f.ConstructNull(f.InternPrivate(types.Unknown)), eq, eq}
+	conditions = []memo.GroupID{f.ConstructNull(f.InternType(types.Unknown)), eq, eq}
 	result = f.ConstructFilters(f.InternList(conditions))
 	ev = o.Optimize(result, &memo.PhysicalProps{})
 	if ev.Operator() != opt.FalseOp {

--- a/pkg/sql/opt/xform/physical_props_factory.go
+++ b/pkg/sql/opt/xform/physical_props_factory.go
@@ -128,11 +128,11 @@ func (f physicalPropsFactory) canProvideOrdering(eid memo.ExprID, required memo.
 
 	case opt.LimitOp:
 		// Limit can provide the same ordering it requires of its input.
-		return f.mem.LookupPrivate(mexpr.AsLimit().Ordering()).(*memo.Ordering).Provides(required)
+		return f.mem.LookupPrivate(mexpr.AsLimit().Ordering()).(memo.Ordering).Provides(required)
 
 	case opt.OffsetOp:
 		// Offset can provide the same ordering it requires of its input.
-		return f.mem.LookupPrivate(mexpr.AsOffset().Ordering()).(*memo.Ordering).Provides(required)
+		return f.mem.LookupPrivate(mexpr.AsOffset().Ordering()).(memo.Ordering).Provides(required)
 	}
 
 	return false
@@ -182,7 +182,7 @@ func (f physicalPropsFactory) constructChildProps(
 			} else {
 				ordering = mexpr.AsOffset().Ordering()
 			}
-			childProps.Ordering = *f.mem.LookupPrivate(ordering).(*memo.Ordering)
+			childProps.Ordering = f.mem.LookupPrivate(ordering).(memo.Ordering)
 		}
 	}
 

--- a/pkg/sql/opt/xform/rules_test.go
+++ b/pkg/sql/opt/xform/rules_test.go
@@ -40,7 +40,7 @@ func TestRuleFoldNullInEmpty(t *testing.T) {
 	o := xform.NewOptimizer(&evalCtx)
 	f := o.Factory()
 
-	null := f.ConstructNull(f.InternPrivate(types.Unknown))
+	null := f.ConstructNull(f.InternType(types.Unknown))
 	empty := f.ConstructTuple(memo.EmptyList)
 	in := f.ConstructIn(null, empty)
 	ev := o.Optimize(in, &memo.PhysicalProps{})

--- a/pkg/sql/opt/xform/testdata/physprops/ordering
+++ b/pkg/sql/opt/xform/testdata/physprops/ordering
@@ -186,26 +186,25 @@ project
 memo
 SELECT y, x-1 FROM a WHERE x=1 ORDER BY x, y DESC
 ----
-[13: "p:y:2,column5:5 o:+1,-2"]
+[12: "p:y:2,column5:5 o:+1,-2"]
 memo
- ├── 13: (project 12 10)
+ ├── 12: (project 11 9)
  │    ├── "" [cost=1000.00]
- │    │    └── best: (project 12 10)
+ │    │    └── best: (project 11 9)
  │    └── "p:y:2,column5:5 o:+1,-2" [cost=1000.00]
- │         └── best: (project 12="o:+1,-2" 10)
- ├── 12: (select 11 5)
+ │         └── best: (project 11="o:+1,-2" 9)
+ ├── 11: (select 10 5)
  │    ├── "" [cost=1000.00]
- │    │    └── best: (select 11 5)
+ │    │    └── best: (select 10 5)
  │    └── "o:+1,-2" [cost=1000.00]
- │         └── best: (select 11="o:+1,-2" 5)
- ├── 11: (scan a)
+ │         └── best: (select 10="o:+1,-2" 5)
+ ├── 10: (scan a)
  │    ├── "" [cost=1000.00]
  │    │    └── best: (scan a)
  │    └── "o:+1,-2" [cost=1000.00]
  │         └── best: (scan a)
- ├── 10: (projections 7 9 2)
- ├── 9: (minus 2 8)
- ├── 8: (const 1)
+ ├── 9: (projections 7 8 2)
+ ├── 8: (minus 2 3)
  ├── 7: (variable a.y)
  ├── 6: (select 1 5)
  ├── 5: (filters 4)

--- a/pkg/testutils/mem.go
+++ b/pkg/testutils/mem.go
@@ -1,0 +1,40 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package testutils
+
+import (
+	"runtime"
+)
+
+// TestNoMallocs returns true if calling the given function results in zero
+// memory allocations. It iterates up to 100 times to combat flakiness, as
+// there might be initial "warmup" allocations, or possibly background memory
+// allocations that cause issues. The test completes successfully as soon as at
+// least one run results in 0 allocations.
+func TestNoMallocs(fn func()) bool {
+	for i := 0; i < 100; i++ {
+		var mem runtime.MemStats
+		runtime.ReadMemStats(&mem)
+		before := mem.Mallocs
+
+		fn()
+
+		runtime.ReadMemStats(&mem)
+		if mem.Mallocs-before == 0 {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
The memo has a restriction that only allows private values that can
be used as Go map key values. In addition, many of the private value
types we use have pointers that do not compare equal even if the
values to which they point are equal. This prevents effective interning,
which means extra entries in the memo, as well as blocking us from
implementing cycle detection.

This PR creates a white list of allowed private value types, and adds
key derivation code for those types. Now two values that are equivalent
are guaranteed to have the same key value. Also, this allows us to use
the most natural type for the private value, such as ColSet rather than
*ColSet.

Release note: None