### PR TITLE
workload/tpcc: explictly mark expensive_checks flag as RuntimeOnly

### DIFF
--- a/pkg/workload/tpcc/tpcc.go
+++ b/pkg/workload/tpcc/tpcc.go
@@ -103,7 +103,7 @@ var tpccMeta = workload.Meta{
 			`split`:            {RuntimeOnly: true},
 			`wait`:             {RuntimeOnly: true},
 			`workers`:          {RuntimeOnly: true},
-			`expensive-checks`: {CheckConsistencyOnly: true},
+			`expensive-checks`: {RuntimeOnly: true, CheckConsistencyOnly: true},
 		}
 
 		g.flags.Int64Var(&g.seed, `seed`, 1, `Random number generator seed`)

--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -55,8 +55,7 @@ type FlagMeta struct {
 	// impact on the behavior of any Tables in this workload.
 	RuntimeOnly bool
 	// CheckConsistencyOnly is expected to be true only if the corresponding
-	// flag only has an effect on the CheckConsistency hook. Setting
-	// CheckConsistencyOnly to true also implies true for RuntimeOnly.
+	// flag only has an effect on the CheckConsistency hook.
 	CheckConsistencyOnly bool
 }
 


### PR DESCRIPTION
I originally thought it would be easier if CheckConsistencyOnly implied
RuntimeOnly, but this has already caused a bug (fixture load was
incorrectly including the flag when constructing the path). Reverse this
decision.

Release note: None