### PR TITLE
gceworker: add ip subcommand

### DIFF
--- a/scripts/gceworker.sh
+++ b/scripts/gceworker.sh
@@ -51,6 +51,9 @@ case "${cmd}" in
     ssh)
     retry gcloud compute ssh "${NAME}" --ssh-flag="-A" "$@"
     ;;
+    ip)
+    gcloud compute instances describe --format="value(networkInterfaces[0].accessConfigs[0].natIP)" "${NAME}"
+    ;;
     sync)
     if ! hash unison 2>/dev/null; then
       echo 'unison not found (on macOS, run `brew install unison`)' >&2


### PR DESCRIPTION
Add an ip subcommand to scripts/gceworker.sh which prints the public IP
of the GCE worker.

Release note: None