### PR TITLE
workload/tpcc: add audit check 9.2.2.5.3

### DIFF
--- a/pkg/workload/tpcc/audit.go
+++ b/pkg/workload/tpcc/audit.go
@@ -21,7 +21,6 @@ import (
 	"sync/atomic"
 
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
-	"github.com/pkg/errors"
 )
 
 const (
@@ -33,15 +32,39 @@ const (
 type auditor struct {
 	syncutil.Mutex
 
+	warehouses int
+
 	newOrderTransactions uint64
 	newOrderRollbacks    uint64
 
 	// map from order-lines count to the number of orders with that count
-	orderLinesFreq map[int]uint64
+	orderLinesFreq  map[int]uint64
+	totalOrderLines uint64
+
+	remoteWarehouseFreq map[int]uint64
 }
 
-func newAuditor() *auditor {
-	return &auditor{orderLinesFreq: make(map[int]uint64)}
+func newAuditor(warehouses int) *auditor {
+	return &auditor{
+		warehouses:          warehouses,
+		orderLinesFreq:      make(map[int]uint64),
+		remoteWarehouseFreq: make(map[int]uint64),
+	}
+}
+
+type auditResult struct {
+	status      string // PASS, FAIL, or SKIP
+	description string
+}
+
+var passResult = auditResult{status: "PASS"}
+
+func newFailResult(format string, args ...interface{}) auditResult {
+	return auditResult{"FAIL", fmt.Sprintf(format, args...)}
+}
+
+func newSkipResult(format string, args ...interface{}) auditResult {
+	return auditResult{"SKIP", fmt.Sprintf(format, args...)}
 }
 
 // runChecks runs the audit checks and prints warnings to stdout for those that
@@ -49,38 +72,41 @@ func newAuditor() *auditor {
 func (a *auditor) runChecks() {
 	type check struct {
 		name string
-		f    func(a *auditor) error
+		f    func(a *auditor) auditResult
 	}
 	checks := []check{
 		{"9.2.2.5.1", check92251},
 		{"9.2.2.5.2", check92252},
+		{"9.2.2.5.3", check92253},
 	}
 	for _, check := range checks {
 		result := check.f(a)
-		if result != nil {
-			fmt.Println(errors.Wrapf(result, "WARN: Failed audit check %s", check.name))
+		msg := fmt.Sprintf("Audit check %s: %s", check.name, result.status)
+		if result.description == "" {
+			fmt.Println(msg)
+		} else {
+			fmt.Println(msg + ": " + result.description)
 		}
 	}
 }
 
-func check92251(a *auditor) error {
+func check92251(a *auditor) auditResult {
 	// At least 0.9% and at most 1.1% of the New-Order transactions roll back as a
 	// result of an unused item number.
 	orders := atomic.LoadUint64(&a.newOrderTransactions)
 	if orders < minSignificantOrders {
-		// Not enough orders to be statistically significant.
-		return nil
+		return newSkipResult("not enough orders to be statistically significant")
 	}
 	rollbacks := atomic.LoadUint64(&a.newOrderRollbacks)
 	rollbackPct := 100 * float64(rollbacks) / float64(orders)
 	if rollbackPct < 0.9 || rollbackPct > 1.1 {
-		return errors.Errorf(
+		return newFailResult(
 			"new order rollback percent %.1f is not between allowed bounds [0.9, 1.1]", rollbackPct)
 	}
-	return nil
+	return passResult
 }
 
-func check92252(a *auditor) error {
+func check92252(a *auditor) auditResult {
 	// The average number of order-lines per order is in the range of 9.5 to 10.5
 	// and the number of order-lines is uniformly distributed from 5 to 15 for the
 	// New-Order transactions that are submitted to the SUT during the measurement
@@ -88,19 +114,13 @@ func check92252(a *auditor) error {
 	a.Lock()
 	defer a.Unlock()
 
-	var orders, orderLines uint64
-	for i := 5; i <= 15; i++ {
-		freq := a.orderLinesFreq[i]
-		orders += freq
-		orderLines += freq * uint64(i)
-	}
-	if orders < minSignificantOrders {
-		return nil
+	if a.newOrderTransactions < minSignificantOrders {
+		return newSkipResult("not enough orders to be statistically significant")
 	}
 
-	avg := float64(orderLines) / float64(orders)
+	avg := float64(a.totalOrderLines) / float64(a.newOrderTransactions)
 	if avg < 9.5 || avg > 10.5 {
-		return errors.Errorf(
+		return newFailResult(
 			"average order-lines count %.1f is not between allowed bounds [9.5, 10.5]", avg)
 	}
 
@@ -108,12 +128,52 @@ func check92252(a *auditor) error {
 	tolerance := 1.0          // allow 1 percent deviation from expected
 	for i := 5; i <= 15; i++ {
 		freq := a.orderLinesFreq[i]
-		pct := 100 * float64(freq) / float64(orders)
+		pct := 100 * float64(freq) / float64(a.newOrderTransactions)
 		if math.Abs(expectedPct-pct) > tolerance {
-			return errors.Errorf(
-				"order-lines count should be uniformly distributed from 5 to 15, but it was %d for "+
-					"%.1f percent of orders", i, pct)
+			return newFailResult(
+				"order-lines count should be uniformly distributed from 5 to 15, but it was %d for %.1f "+
+					"percent of orders", i, pct)
 		}
 	}
-	return nil
+	return passResult
+}
+
+func check92253(a *auditor) auditResult {
+	// The number of remote order-lines is at least 0.95% and at most 1.05% of the
+	// number of order-lines that are filled in by the New-Order transactions that
+	// are submitted to the SUT during the measurement interval, and the remote
+	// warehouse numbers are uniformly distributed within the range of active
+	// warehouses.
+	a.Lock()
+	defer a.Unlock()
+
+	if a.newOrderTransactions < minSignificantOrders {
+		return newSkipResult("not enough orders to be statistically significant")
+	}
+
+	var remoteOrderLines uint64
+	for _, freq := range a.remoteWarehouseFreq {
+		remoteOrderLines += freq
+	}
+	remotePct := 100 * float64(remoteOrderLines) / float64(a.totalOrderLines)
+	if remotePct < 0.95 || remotePct > 1.05 {
+		return newFailResult(
+			"remote order-line percent %.1f is not between allowed bounds [0.95, 1.05]", remotePct)
+	}
+
+	// In the absence of a more sophisticated distribution check like a
+	// chi-squared test, check each warehouse is used as a remote warehouse at
+	// least once. We need the number of remote order-lines to be at least 15
+	// times the number of warehouses (experimentally determined) to have this
+	// expectation.
+	if remoteOrderLines < 15*uint64(a.warehouses) {
+		return newSkipResult("insufficient data for remote warehouse distribution check")
+	}
+	for i := 0; i < a.warehouses; i++ {
+		if _, ok := a.remoteWarehouseFreq[i]; !ok {
+			return newFailResult("no remote order-lines for warehouses %d", i)
+		}
+	}
+
+	return passResult
 }

--- a/pkg/workload/tpcc/tpcc.go
+++ b/pkg/workload/tpcc/tpcc.go
@@ -127,8 +127,6 @@ var tpccMeta = workload.Meta{
 		g.flags.BoolVar(&g.serializable, `serializable`, false, `Force serializable mode`)
 		g.flags.BoolVar(&g.split, `split`, false, `Split tables`)
 
-		g.auditor = newAuditor()
-
 		g.flags.BoolVar(&g.expensiveChecks, `expensive-checks`, false, `Run expensive checks`)
 		return g
 	},
@@ -159,6 +157,8 @@ func (w *tpcc) Hooks() workload.Hooks {
 			if w.serializable {
 				w.txOpts = &gosql.TxOptions{Isolation: gosql.LevelSerializable}
 			}
+
+			w.auditor = newAuditor(w.warehouses)
 
 			return initializeMix(w)
 		},


### PR DESCRIPTION
Added an audit check for remote order-lines frequency and distribution.
Also fixed a minor related bug where the local warehouse might be
randomly chosen when a remote one was called for.

Release note: None