### PR TITLE
cherrypick-2.0: utilccl: improve expired license language

### DIFF
--- a/pkg/ccl/utilccl/licenseccl/license.go
+++ b/pkg/ccl/utilccl/licenseccl/license.go
@@ -72,7 +72,21 @@ func (l *License) Check(at time.Time, cluster uuid.UUID, org, feature string) er
 	// suddenly throwing errors at them.
 	if l.ValidUntilUnixSec > 0 && l.Type != License_Enterprise {
 		if expiration := timeutil.Unix(l.ValidUntilUnixSec, 0); at.After(expiration) {
-			return errors.Errorf("license expired at %s", expiration.String())
+			licensePrefix := ""
+			switch l.Type {
+			case License_NonCommercial:
+				licensePrefix = "non-commercial "
+			case License_Evaluation:
+				licensePrefix = "evaluation "
+			}
+			return errors.Errorf(
+				"Use of %s requires an enterprise license. Your %slicense expired on %s. If you're "+
+					"interested in getting a new license, please contact subscriptions@cockroachlabs.com "+
+					"and we can help you out.",
+				feature,
+				licensePrefix,
+				expiration.Format("January 2, 2006"),
+			)
 		}
 	}
 

--- a/pkg/ccl/utilccl/licenseccl/license_test.go
+++ b/pkg/ccl/utilccl/licenseccl/license_test.go
@@ -102,3 +102,17 @@ func TestBadLicenseStrings(t *testing.T) {
 		}
 	}
 }
+
+func TestExpiredLicenseLanguage(t *testing.T) {
+	lic := License{
+		Type:              License_Evaluation,
+		ValidUntilUnixSec: 1,
+	}
+	err := lic.Check(timeutil.Now(), uuid.MakeV4(), "", "RESTORE")
+	expected := "Use of RESTORE requires an enterprise license. Your evaluation license expired on " +
+		"January 1, 1970. If you're interested in getting a new license, please contact " +
+		"subscriptions@cockroachlabs.com and we can help you out."
+	if err == nil || err.Error() != expected {
+		t.Fatalf("expected err %q, got %v", expected, err)
+	}
+}


### PR DESCRIPTION
Previously when a user attempted to use an enterprise feature with an
expired license, they would get an unceremonious "license expired at
2018-03-01 17:00:00 +0000 UTC" error. I replaced this with friendlier
language from Lakshmi.

Fixes #24203

Release note: None