### PR TITLE
cherrypick-2.0: importccl: set roachpb.Value checksums when creating data

### DIFF
--- a/pkg/ccl/importccl/csv.go
+++ b/pkg/ccl/importccl/csv.go
@@ -652,6 +652,7 @@ func convertRecord(
 			if err := ri.InsertRow(
 				ctx,
 				inserter(func(kv roachpb.KeyValue) {
+					kv.Value.InitChecksum(kv.Key)
 					kvBatch = append(kvBatch, kv)
 				}),
 				row,


### PR DESCRIPTION
IMPORT was not setting value checksums when generating KV pairs from
CSV rows. This results in CPuts on, for example, secondary indexes
failing because the checksum doesn't match.

Fixes #23984

Release note (bug fix): correctly generate on-disk checksums during
IMPORT. If there is existing data created by IMPORT that cannot
be recreated by this fixed version of IMPORT, use `cockroach dump`
to rewrite any affected tables.