### PR TITLE
optbuilder: add test cases for LIMIT and subqueries and fix LIMIT error checking

### DIFF
--- a/pkg/sql/opt/optbuilder/limit.go
+++ b/pkg/sql/opt/optbuilder/limit.go
@@ -35,12 +35,16 @@ func (b *Builder) buildLimit(
 	orderingPrivID := b.factory.InternPrivate(&ordering)
 
 	if limit.Offset != nil {
-		texpr := parentScope.resolveType(limit.Offset, types.Int)
+		op := "OFFSET"
+		b.assertNoAggregationOrWindowing(limit.Offset, op)
+		texpr := parentScope.resolveAndRequireType(limit.Offset, types.Int, op)
 		offset := b.buildScalar(texpr, parentScope)
 		out = b.factory.ConstructOffset(out, offset, orderingPrivID)
 	}
 	if limit.Count != nil {
-		texpr := parentScope.resolveType(limit.Count, types.Int)
+		op := "LIMIT"
+		b.assertNoAggregationOrWindowing(limit.Count, op)
+		texpr := parentScope.resolveAndRequireType(limit.Count, types.Int, op)
 		limit := b.buildScalar(texpr, parentScope)
 		out = b.factory.ConstructLimit(out, limit, orderingPrivID)
 	}

--- a/pkg/sql/opt/optbuilder/testdata/aggregate
+++ b/pkg/sql/opt/optbuilder/testdata/aggregate
@@ -279,6 +279,34 @@ group-by
            └── variable: column1 [type=string]
 
 build
+SELECT (SELECT COALESCE(MAX(1), 0) FROM kv)
+----
+project
+ ├── columns: column8:8(int)
+ ├── values
+ │    └── tuple [type=tuple{}]
+ └── projections
+      └── subquery [type=int]
+           ├── project
+           │    ├── columns: column7:7(int)
+           │    ├── group-by
+           │    │    ├── columns: column6:6(int)
+           │    │    ├── project
+           │    │    │    ├── columns: column5:5(int)
+           │    │    │    ├── scan kv
+           │    │    │    │    └── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string)
+           │    │    │    └── projections
+           │    │    │         └── const: 1 [type=int]
+           │    │    └── aggregations
+           │    │         └── function: max [type=int]
+           │    │              └── variable: column5 [type=int]
+           │    └── projections
+           │         └── coalesce [type=int]
+           │              ├── variable: column6 [type=int]
+           │              └── const: 0 [type=int]
+           └── variable: column7 [type=int]
+
+build
 SELECT COUNT(*), k FROM t.kv
 ----
 error: column "t.kv.k" must appear in the GROUP BY clause or be used in an aggregate function
@@ -328,6 +356,41 @@ project
  └── projections
       ├── variable: column5 [type=int]
       └── variable: kv.k [type=int]
+
+# TODO(rytaft): fix error message:
+# error: aggregate functions are not allowed in GROUP BY
+build
+SELECT * FROM kv GROUP BY v, COUNT(w)
+----
+error: aggregate function is not allowed in this context
+
+# TODO(rytaft): fix error message:
+# error: aggregate functions are not allowed in GROUP BY
+build
+SELECT COUNT(w) FROM kv GROUP BY 1
+----
+error: aggregate function is not allowed in this context
+
+# TODO(rytaft): fix error message:
+# error: aggregate functions are not allowed in LIMIT
+build
+SELECT SUM(v) FROM kv GROUP BY k LIMIT SUM(v)
+----
+error: column name "v" not found
+
+# TODO(rytaft): fix error message:
+# error: aggregate functions are not allowed in OFFSET
+build
+SELECT SUM(v) FROM kv GROUP BY k LIMIT 1 OFFSET SUM(v)
+----
+error: column name "v" not found
+
+# TODO(rytaft): fix error message:
+# error: aggregate functions are not allowed in VALUES
+build
+VALUES (99, COUNT(1))
+----
+error: aggregate function is not allowed in this context
 
 build
 SELECT COUNT(*), k FROM t.kv GROUP BY 5
@@ -830,21 +893,44 @@ group-by
            └── variable: column5 [type=tuple{int, int, int, string}]
 
 build
-SELECT COUNT((k, v)) FROM t.kv
+SELECT COUNT((k, v)) FROM t.kv LIMIT 1
 ----
-group-by
+limit
  ├── columns: column6:6(int)
- ├── project
- │    ├── columns: column5:5(tuple{int, int})
- │    ├── scan kv
- │    │    └── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string)
- │    └── projections
- │         └── tuple [type=tuple{int, int}]
- │              ├── variable: kv.k [type=int]
- │              └── variable: kv.v [type=int]
- └── aggregations
-      └── function: count [type=int]
-           └── variable: column5 [type=tuple{int, int}]
+ ├── group-by
+ │    ├── columns: column6:6(int)
+ │    ├── project
+ │    │    ├── columns: column5:5(tuple{int, int})
+ │    │    ├── scan kv
+ │    │    │    └── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string)
+ │    │    └── projections
+ │    │         └── tuple [type=tuple{int, int}]
+ │    │              ├── variable: kv.k [type=int]
+ │    │              └── variable: kv.v [type=int]
+ │    └── aggregations
+ │         └── function: count [type=int]
+ │              └── variable: column5 [type=tuple{int, int}]
+ └── const: 1 [type=int]
+
+build
+SELECT COUNT((k, v)) FROM t.kv OFFSET 1
+----
+offset
+ ├── columns: column6:6(int)
+ ├── group-by
+ │    ├── columns: column6:6(int)
+ │    ├── project
+ │    │    ├── columns: column5:5(tuple{int, int})
+ │    │    ├── scan kv
+ │    │    │    └── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string)
+ │    │    └── projections
+ │    │         └── tuple [type=tuple{int, int}]
+ │    │              ├── variable: kv.k [type=int]
+ │    │              └── variable: kv.v [type=int]
+ │    └── aggregations
+ │         └── function: count [type=int]
+ │              └── variable: column5 [type=tuple{int, int}]
+ └── const: 1 [type=int]
 
 build
 SELECT COUNT(k)+COUNT(kv.v) FROM t.kv
@@ -1620,6 +1706,13 @@ group-by
       └── function: stddev [type=decimal]
            └── variable: column5 [type=decimal]
 
+# Ensure subqueries don't trigger aggregation.
+# TODO(rytaft): This is a bug - this query should build.
+build
+SELECT x > (SELECT avg(0)) FROM xyz LIMIT 1
+----
+error: column "xyz.x" must appear in the GROUP BY clause or be used in an aggregate function
+
 exec-ddl
 CREATE TABLE t.bools (b BOOL)
 ----
@@ -1728,6 +1821,8 @@ sort
            ├── variable: xor_bytes.b [type=int]
            └── variable: column7 [type=int]
 
+# TODO(rytaft): this is a bug - should cause an error:
+# error: arguments to xor must all be the same length
 build
 SELECT XOR_AGG(i) FROM (VALUES (b'\x01'), (b'\x01\x01')) AS a(i)
 ----

--- a/pkg/sql/opt/optbuilder/testdata/aggregate
+++ b/pkg/sql/opt/optbuilder/testdata/aggregate
@@ -287,23 +287,25 @@ project
  │    └── tuple [type=tuple{}]
  └── projections
       └── subquery [type=int]
-           ├── project
+           ├── max1-row
            │    ├── columns: column7:7(int)
-           │    ├── group-by
-           │    │    ├── columns: column6:6(int)
-           │    │    ├── project
-           │    │    │    ├── columns: column5:5(int)
-           │    │    │    ├── scan kv
-           │    │    │    │    └── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string)
-           │    │    │    └── projections
-           │    │    │         └── const: 1 [type=int]
-           │    │    └── aggregations
-           │    │         └── function: max [type=int]
-           │    │              └── variable: column5 [type=int]
-           │    └── projections
-           │         └── coalesce [type=int]
-           │              ├── variable: column6 [type=int]
-           │              └── const: 0 [type=int]
+           │    └── project
+           │         ├── columns: column7:7(int)
+           │         ├── group-by
+           │         │    ├── columns: column6:6(int)
+           │         │    ├── project
+           │         │    │    ├── columns: column5:5(int)
+           │         │    │    ├── scan kv
+           │         │    │    │    └── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string)
+           │         │    │    └── projections
+           │         │    │         └── const: 1 [type=int]
+           │         │    └── aggregations
+           │         │         └── function: max [type=int]
+           │         │              └── variable: column5 [type=int]
+           │         └── projections
+           │              └── coalesce [type=int]
+           │                   ├── variable: column6 [type=int]
+           │                   └── const: 0 [type=int]
            └── variable: column7 [type=int]
 
 build
@@ -357,40 +359,30 @@ project
       ├── variable: column5 [type=int]
       └── variable: kv.k [type=int]
 
-# TODO(rytaft): fix error message:
-# error: aggregate functions are not allowed in GROUP BY
 build
 SELECT * FROM kv GROUP BY v, COUNT(w)
 ----
-error: aggregate function is not allowed in this context
+error: aggregate functions are not allowed in GROUP BY
 
-# TODO(rytaft): fix error message:
-# error: aggregate functions are not allowed in GROUP BY
 build
 SELECT COUNT(w) FROM kv GROUP BY 1
 ----
-error: aggregate function is not allowed in this context
+error: aggregate functions are not allowed in GROUP BY
 
-# TODO(rytaft): fix error message:
-# error: aggregate functions are not allowed in LIMIT
 build
 SELECT SUM(v) FROM kv GROUP BY k LIMIT SUM(v)
 ----
-error: column name "v" not found
+error: aggregate functions are not allowed in LIMIT
 
-# TODO(rytaft): fix error message:
-# error: aggregate functions are not allowed in OFFSET
 build
 SELECT SUM(v) FROM kv GROUP BY k LIMIT 1 OFFSET SUM(v)
 ----
-error: column name "v" not found
+error: aggregate functions are not allowed in OFFSET
 
-# TODO(rytaft): fix error message:
-# error: aggregate functions are not allowed in VALUES
 build
 VALUES (99, COUNT(1))
 ----
-error: aggregate function is not allowed in this context
+error: aggregate functions are not allowed in VALUES
 
 build
 SELECT COUNT(*), k FROM t.kv GROUP BY 5
@@ -672,6 +664,8 @@ project
            ├── variable: kv.k [type=int]
            └── variable: kv.v [type=int]
 
+# TODO(rytaft): don't qualify the column name in the error message differently
+# than it was qualified in the query.
 build
 SELECT COUNT(*), k+v FROM t.kv GROUP BY k
 ----
@@ -690,12 +684,12 @@ error: column "t.kv.v" must appear in the GROUP BY clause or be used in an aggre
 build
 SELECT k FROM t.kv WHERE AVG(k) > 1
 ----
-error: aggregate function is not allowed in this context
+error: aggregate functions are not allowed in WHERE
 
 build
 SELECT MAX(AVG(k)) FROM t.kv
 ----
-error: aggregate function cannot be nested within another aggregate function
+error: aggregate functions are not allowed in the argument of max()
 
 # Test case from #2761.
 build

--- a/pkg/sql/opt/optbuilder/testdata/having
+++ b/pkg/sql/opt/optbuilder/testdata/having
@@ -115,7 +115,7 @@ project
 build
 SELECT MAX(k), MIN(v) FROM t.kv HAVING MAX(MIN(v)) > 2
 ----
-error: aggregate function cannot be nested within another aggregate function
+error: aggregate functions are not allowed in the argument of max()
 
 build
 SELECT MAX(k), MIN(v) FROM t.kv HAVING k

--- a/pkg/sql/opt/optbuilder/testdata/join
+++ b/pkg/sql/opt/optbuilder/testdata/join
@@ -395,12 +395,33 @@ sort
       └── projections
            └── variable: x [type=int]
 
-# TODO(rytaft): LIMIT not yet supported.
 # Check that a limit on the JOIN's result do not cause rows from the
 # JOIN operands to become invisible to the JOIN.
-#build
-#SELECT * FROM (SELECT x FROM onecolumn ORDER BY x DESC) NATURAL JOIN (VALUES (42)) AS v(x) LIMIT 1
-#----
+build
+SELECT * FROM (SELECT x FROM onecolumn ORDER BY x DESC) NATURAL JOIN (VALUES (42)) AS v(x) LIMIT 1
+----
+limit
+ ├── columns: x:1(int)
+ ├── project
+ │    ├── columns: onecolumn.x:1(int)
+ │    ├── inner-join
+ │    │    ├── columns: onecolumn.x:1(int) column1:3(int)
+ │    │    ├── project
+ │    │    │    ├── columns: onecolumn.x:1(int)
+ │    │    │    ├── scan onecolumn
+ │    │    │    │    └── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null)
+ │    │    │    └── projections
+ │    │    │         └── variable: onecolumn.x [type=int]
+ │    │    ├── values
+ │    │    │    ├── columns: column1:3(int)
+ │    │    │    └── tuple [type=tuple{int}]
+ │    │    │         └── const: 42 [type=int]
+ │    │    └── eq [type=bool]
+ │    │         ├── variable: onecolumn.x [type=int]
+ │    │         └── variable: column1 [type=int]
+ │    └── projections
+ │         └── variable: onecolumn.x [type=int]
+ └── const: 1 [type=int]
 
 exec-ddl
 CREATE TABLE empty (x INT)
@@ -1104,45 +1125,112 @@ sort
 
 # Check column orders and names.
 build
-SELECT * FROM (onecolumn CROSS JOIN twocolumn JOIN onecolumn AS a(b) ON a.b=twocolumn.x JOIN twocolumn AS c(d,e) ON a.b=c.d AND c.d=onecolumn.x) ORDER BY 1
+SELECT * FROM (onecolumn CROSS JOIN twocolumn JOIN onecolumn AS a(b) ON a.b=twocolumn.x JOIN twocolumn AS c(d,e) ON a.b=c.d AND c.d=onecolumn.x) ORDER BY 1 LIMIT 1
 ----
-sort
+limit
  ├── columns: x:1(int) x:3(int) y:4(int) b:6(int) d:8(int) e:9(int)
  ├── ordering: +1
- └── project
-      ├── columns: onecolumn.x:1(int) twocolumn.x:3(int) twocolumn.y:4(int) onecolumn.x:6(int) twocolumn.x:8(int) twocolumn.y:9(int)
-      ├── inner-join
-      │    ├── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null) twocolumn.x:3(int) twocolumn.y:4(int) twocolumn.rowid:5(int!null) onecolumn.x:6(int) onecolumn.rowid:7(int!null) twocolumn.x:8(int) twocolumn.y:9(int) twocolumn.rowid:10(int!null)
-      │    ├── inner-join
-      │    │    ├── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null) twocolumn.x:3(int) twocolumn.y:4(int) twocolumn.rowid:5(int!null) onecolumn.x:6(int) onecolumn.rowid:7(int!null)
-      │    │    ├── inner-join
-      │    │    │    ├── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null) twocolumn.x:3(int) twocolumn.y:4(int) twocolumn.rowid:5(int!null)
-      │    │    │    ├── scan onecolumn
-      │    │    │    │    └── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null)
-      │    │    │    ├── scan twocolumn
-      │    │    │    │    └── columns: twocolumn.x:3(int) twocolumn.y:4(int) twocolumn.rowid:5(int!null)
-      │    │    │    └── true [type=bool]
-      │    │    ├── scan onecolumn
-      │    │    │    └── columns: onecolumn.x:6(int) onecolumn.rowid:7(int!null)
-      │    │    └── eq [type=bool]
-      │    │         ├── variable: onecolumn.x [type=int]
-      │    │         └── variable: twocolumn.x [type=int]
-      │    ├── scan twocolumn
-      │    │    └── columns: twocolumn.x:8(int) twocolumn.y:9(int) twocolumn.rowid:10(int!null)
-      │    └── and [type=bool]
-      │         ├── eq [type=bool]
-      │         │    ├── variable: onecolumn.x [type=int]
-      │         │    └── variable: twocolumn.x [type=int]
-      │         └── eq [type=bool]
-      │              ├── variable: twocolumn.x [type=int]
-      │              └── variable: onecolumn.x [type=int]
-      └── projections
-           ├── variable: onecolumn.x [type=int]
-           ├── variable: twocolumn.x [type=int]
-           ├── variable: twocolumn.y [type=int]
-           ├── variable: onecolumn.x [type=int]
-           ├── variable: twocolumn.x [type=int]
-           └── variable: twocolumn.y [type=int]
+ ├── sort
+ │    ├── columns: onecolumn.x:1(int) twocolumn.x:3(int) twocolumn.y:4(int) onecolumn.x:6(int) twocolumn.x:8(int) twocolumn.y:9(int)
+ │    ├── ordering: +1
+ │    └── project
+ │         ├── columns: onecolumn.x:1(int) twocolumn.x:3(int) twocolumn.y:4(int) onecolumn.x:6(int) twocolumn.x:8(int) twocolumn.y:9(int)
+ │         ├── inner-join
+ │         │    ├── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null) twocolumn.x:3(int) twocolumn.y:4(int) twocolumn.rowid:5(int!null) onecolumn.x:6(int) onecolumn.rowid:7(int!null) twocolumn.x:8(int) twocolumn.y:9(int) twocolumn.rowid:10(int!null)
+ │         │    ├── inner-join
+ │         │    │    ├── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null) twocolumn.x:3(int) twocolumn.y:4(int) twocolumn.rowid:5(int!null) onecolumn.x:6(int) onecolumn.rowid:7(int!null)
+ │         │    │    ├── inner-join
+ │         │    │    │    ├── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null) twocolumn.x:3(int) twocolumn.y:4(int) twocolumn.rowid:5(int!null)
+ │         │    │    │    ├── scan onecolumn
+ │         │    │    │    │    └── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null)
+ │         │    │    │    ├── scan twocolumn
+ │         │    │    │    │    └── columns: twocolumn.x:3(int) twocolumn.y:4(int) twocolumn.rowid:5(int!null)
+ │         │    │    │    └── true [type=bool]
+ │         │    │    ├── scan onecolumn
+ │         │    │    │    └── columns: onecolumn.x:6(int) onecolumn.rowid:7(int!null)
+ │         │    │    └── eq [type=bool]
+ │         │    │         ├── variable: onecolumn.x [type=int]
+ │         │    │         └── variable: twocolumn.x [type=int]
+ │         │    ├── scan twocolumn
+ │         │    │    └── columns: twocolumn.x:8(int) twocolumn.y:9(int) twocolumn.rowid:10(int!null)
+ │         │    └── and [type=bool]
+ │         │         ├── eq [type=bool]
+ │         │         │    ├── variable: onecolumn.x [type=int]
+ │         │         │    └── variable: twocolumn.x [type=int]
+ │         │         └── eq [type=bool]
+ │         │              ├── variable: twocolumn.x [type=int]
+ │         │              └── variable: onecolumn.x [type=int]
+ │         └── projections
+ │              ├── variable: onecolumn.x [type=int]
+ │              ├── variable: twocolumn.x [type=int]
+ │              ├── variable: twocolumn.y [type=int]
+ │              ├── variable: onecolumn.x [type=int]
+ │              ├── variable: twocolumn.x [type=int]
+ │              └── variable: twocolumn.y [type=int]
+ └── const: 1 [type=int]
+
+# Check sub-queries in ON conditions.
+build
+SELECT * FROM onecolumn JOIN twocolumn ON twocolumn.x = onecolumn.x AND onecolumn.x IN (SELECT x FROM twocolumn WHERE y >= 52)
+----
+project
+ ├── columns: x:1(int) x:3(int) y:4(int)
+ ├── inner-join
+ │    ├── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null) twocolumn.x:3(int) twocolumn.y:4(int) twocolumn.rowid:5(int!null)
+ │    ├── scan onecolumn
+ │    │    └── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null)
+ │    ├── scan twocolumn
+ │    │    └── columns: twocolumn.x:3(int) twocolumn.y:4(int) twocolumn.rowid:5(int!null)
+ │    └── and [type=bool]
+ │         ├── eq [type=bool]
+ │         │    ├── variable: twocolumn.x [type=int]
+ │         │    └── variable: onecolumn.x [type=int]
+ │         └── any [type=bool]
+ │              └── project
+ │                   ├── columns: column9:9(bool)
+ │                   ├── project
+ │                   │    ├── columns: twocolumn.x:6(int)
+ │                   │    ├── select
+ │                   │    │    ├── columns: twocolumn.x:6(int) twocolumn.y:7(int) twocolumn.rowid:8(int!null)
+ │                   │    │    ├── scan twocolumn
+ │                   │    │    │    └── columns: twocolumn.x:6(int) twocolumn.y:7(int) twocolumn.rowid:8(int!null)
+ │                   │    │    └── ge [type=bool]
+ │                   │    │         ├── variable: twocolumn.y [type=int]
+ │                   │    │         └── const: 52 [type=int]
+ │                   │    └── projections
+ │                   │         └── variable: twocolumn.x [type=int]
+ │                   └── projections
+ │                        └── eq [type=bool]
+ │                             ├── variable: onecolumn.x [type=int]
+ │                             └── variable: twocolumn.x [type=int]
+ └── projections
+      ├── variable: onecolumn.x [type=int]
+      ├── variable: twocolumn.x [type=int]
+      └── variable: twocolumn.y [type=int]
+
+# Check sub-queries as data sources.
+build
+SELECT * FROM onecolumn JOIN (VALUES (41),(42),(43)) AS a(x) USING(x)
+----
+project
+ ├── columns: x:1(int)
+ ├── inner-join
+ │    ├── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null) column1:3(int)
+ │    ├── scan onecolumn
+ │    │    └── columns: onecolumn.x:1(int) onecolumn.rowid:2(int!null)
+ │    ├── values
+ │    │    ├── columns: column1:3(int)
+ │    │    ├── tuple [type=tuple{int}]
+ │    │    │    └── const: 41 [type=int]
+ │    │    ├── tuple [type=tuple{int}]
+ │    │    │    └── const: 42 [type=int]
+ │    │    └── tuple [type=tuple{int}]
+ │    │         └── const: 43 [type=int]
+ │    └── eq [type=bool]
+ │         ├── variable: onecolumn.x [type=int]
+ │         └── variable: column1 [type=int]
+ └── projections
+      └── variable: onecolumn.x [type=int]
 
 build
 SELECT * FROM onecolumn JOIN (SELECT x + 2 AS x FROM onecolumn) USING(x)
@@ -1169,34 +1257,38 @@ project
 
 # Check that a single column can have multiple table aliases.
 build
-SELECT * FROM (twocolumn AS a JOIN twocolumn AS b USING(x) JOIN twocolumn AS c USING(x)) ORDER BY x
+SELECT * FROM (twocolumn AS a JOIN twocolumn AS b USING(x) JOIN twocolumn AS c USING(x)) ORDER BY x LIMIT 1
 ----
-sort
+limit
  ├── columns: x:1(int) y:2(int) y:5(int) y:8(int)
  ├── ordering: +1
- └── project
-      ├── columns: twocolumn.x:1(int) twocolumn.y:2(int) twocolumn.y:5(int) twocolumn.y:8(int)
-      ├── inner-join
-      │    ├── columns: twocolumn.x:1(int) twocolumn.y:2(int) twocolumn.rowid:3(int!null) twocolumn.x:4(int) twocolumn.y:5(int) twocolumn.rowid:6(int!null) twocolumn.x:7(int) twocolumn.y:8(int) twocolumn.rowid:9(int!null)
-      │    ├── inner-join
-      │    │    ├── columns: twocolumn.x:1(int) twocolumn.y:2(int) twocolumn.rowid:3(int!null) twocolumn.x:4(int) twocolumn.y:5(int) twocolumn.rowid:6(int!null)
-      │    │    ├── scan twocolumn
-      │    │    │    └── columns: twocolumn.x:1(int) twocolumn.y:2(int) twocolumn.rowid:3(int!null)
-      │    │    ├── scan twocolumn
-      │    │    │    └── columns: twocolumn.x:4(int) twocolumn.y:5(int) twocolumn.rowid:6(int!null)
-      │    │    └── eq [type=bool]
-      │    │         ├── variable: twocolumn.x [type=int]
-      │    │         └── variable: twocolumn.x [type=int]
-      │    ├── scan twocolumn
-      │    │    └── columns: twocolumn.x:7(int) twocolumn.y:8(int) twocolumn.rowid:9(int!null)
-      │    └── eq [type=bool]
-      │         ├── variable: twocolumn.x [type=int]
-      │         └── variable: twocolumn.x [type=int]
-      └── projections
-           ├── variable: twocolumn.x [type=int]
-           ├── variable: twocolumn.y [type=int]
-           ├── variable: twocolumn.y [type=int]
-           └── variable: twocolumn.y [type=int]
+ ├── sort
+ │    ├── columns: twocolumn.x:1(int) twocolumn.y:2(int) twocolumn.y:5(int) twocolumn.y:8(int)
+ │    ├── ordering: +1
+ │    └── project
+ │         ├── columns: twocolumn.x:1(int) twocolumn.y:2(int) twocolumn.y:5(int) twocolumn.y:8(int)
+ │         ├── inner-join
+ │         │    ├── columns: twocolumn.x:1(int) twocolumn.y:2(int) twocolumn.rowid:3(int!null) twocolumn.x:4(int) twocolumn.y:5(int) twocolumn.rowid:6(int!null) twocolumn.x:7(int) twocolumn.y:8(int) twocolumn.rowid:9(int!null)
+ │         │    ├── inner-join
+ │         │    │    ├── columns: twocolumn.x:1(int) twocolumn.y:2(int) twocolumn.rowid:3(int!null) twocolumn.x:4(int) twocolumn.y:5(int) twocolumn.rowid:6(int!null)
+ │         │    │    ├── scan twocolumn
+ │         │    │    │    └── columns: twocolumn.x:1(int) twocolumn.y:2(int) twocolumn.rowid:3(int!null)
+ │         │    │    ├── scan twocolumn
+ │         │    │    │    └── columns: twocolumn.x:4(int) twocolumn.y:5(int) twocolumn.rowid:6(int!null)
+ │         │    │    └── eq [type=bool]
+ │         │    │         ├── variable: twocolumn.x [type=int]
+ │         │    │         └── variable: twocolumn.x [type=int]
+ │         │    ├── scan twocolumn
+ │         │    │    └── columns: twocolumn.x:7(int) twocolumn.y:8(int) twocolumn.rowid:9(int!null)
+ │         │    └── eq [type=bool]
+ │         │         ├── variable: twocolumn.x [type=int]
+ │         │         └── variable: twocolumn.x [type=int]
+ │         └── projections
+ │              ├── variable: twocolumn.x [type=int]
+ │              ├── variable: twocolumn.y [type=int]
+ │              ├── variable: twocolumn.y [type=int]
+ │              └── variable: twocolumn.y [type=int]
+ └── const: 1 [type=int]
 
 build
 SELECT a.x AS s, b.x, c.x, a.y, b.y, c.y FROM (twocolumn AS a JOIN twocolumn AS b USING(x) JOIN twocolumn AS c USING(x)) ORDER BY s
@@ -3397,3 +3489,58 @@ project
  └── projections
       ├── variable: column1 [type=int]
       └── variable: column2 [type=int]
+
+# Regression test for #23609: make sure that the type of the merged column
+# is int (not unknown).
+build
+SELECT column1, column1+1
+FROM
+  (SELECT * FROM
+    (VALUES (NULL, NULL)) AS t
+      NATURAL FULL OUTER JOIN
+    (VALUES (1, 1)) AS u)
+----
+project
+ ├── columns: column1:5(int) column7:7(int)
+ ├── project
+ │    ├── columns: column1:5(int) column2:6(int)
+ │    ├── project
+ │    │    ├── columns: column1:5(int) column2:6(int) column1:1(unknown) column2:2(unknown) column1:3(int) column2:4(int)
+ │    │    ├── full-join
+ │    │    │    ├── columns: column1:1(unknown) column2:2(unknown) column1:3(int) column2:4(int)
+ │    │    │    ├── values
+ │    │    │    │    ├── columns: column1:1(unknown) column2:2(unknown)
+ │    │    │    │    └── tuple [type=tuple{unknown, unknown}]
+ │    │    │    │         ├── null [type=unknown]
+ │    │    │    │         └── null [type=unknown]
+ │    │    │    ├── values
+ │    │    │    │    ├── columns: column1:3(int) column2:4(int)
+ │    │    │    │    └── tuple [type=tuple{int, int}]
+ │    │    │    │         ├── const: 1 [type=int]
+ │    │    │    │         └── const: 1 [type=int]
+ │    │    │    └── and [type=bool]
+ │    │    │         ├── eq [type=bool]
+ │    │    │         │    ├── variable: column1 [type=unknown]
+ │    │    │         │    └── variable: column1 [type=int]
+ │    │    │         └── eq [type=bool]
+ │    │    │              ├── variable: column2 [type=unknown]
+ │    │    │              └── variable: column2 [type=int]
+ │    │    └── projections
+ │    │         ├── coalesce [type=int]
+ │    │         │    ├── variable: column1 [type=unknown]
+ │    │         │    └── variable: column1 [type=int]
+ │    │         ├── coalesce [type=int]
+ │    │         │    ├── variable: column2 [type=unknown]
+ │    │         │    └── variable: column2 [type=int]
+ │    │         ├── variable: column1 [type=unknown]
+ │    │         ├── variable: column2 [type=unknown]
+ │    │         ├── variable: column1 [type=int]
+ │    │         └── variable: column2 [type=int]
+ │    └── projections
+ │         ├── variable: column1 [type=int]
+ │         └── variable: column2 [type=int]
+ └── projections
+      ├── variable: column1 [type=int]
+      └── plus [type=int]
+           ├── variable: column1 [type=int]
+           └── const: 1 [type=int]

--- a/pkg/sql/opt/optbuilder/testdata/limit
+++ b/pkg/sql/opt/optbuilder/testdata/limit
@@ -292,3 +292,33 @@ project
  │    └── const: 10 [type=int]
  └── projections
       └── variable: t.k [type=int]
+
+# This kind of query can be used to work around memory usage limits. We need to
+# choose the "hard" limit of 100 over the "soft" limit of 25 (with the hard
+# limit we will only store 100 rows in the sort node). See #19677.
+build
+SELECT DISTINCT w FROM (SELECT w FROM t ORDER BY w LIMIT 100) ORDER BY w LIMIT 25
+----
+limit
+ ├── columns: w:3(int)
+ ├── ordering: +3
+ ├── sort
+ │    ├── columns: t.w:3(int)
+ │    ├── ordering: +3
+ │    └── group-by
+ │         ├── columns: t.w:3(int)
+ │         ├── grouping columns: t.w:3(int)
+ │         ├── limit
+ │         │    ├── columns: t.w:3(int)
+ │         │    ├── sort
+ │         │    │    ├── columns: t.w:3(int)
+ │         │    │    ├── ordering: +3
+ │         │    │    └── project
+ │         │    │         ├── columns: t.w:3(int)
+ │         │    │         ├── scan t
+ │         │    │         │    └── columns: t.k:1(int!null) t.v:2(int) t.w:3(int)
+ │         │    │         └── projections
+ │         │    │              └── variable: t.w [type=int]
+ │         │    └── const: 100 [type=int]
+ │         └── aggregations
+ └── const: 25 [type=int]

--- a/pkg/sql/opt/optbuilder/testdata/orderby
+++ b/pkg/sql/opt/optbuilder/testdata/orderby
@@ -69,6 +69,24 @@ sort
            └── variable: t.b [type=int]
 
 build
+SELECT a, b FROM t ORDER BY b DESC LIMIT 2
+----
+limit
+ ├── columns: a:1(int!null) b:2(int)
+ ├── ordering: -2
+ ├── sort
+ │    ├── columns: t.a:1(int!null) t.b:2(int)
+ │    ├── ordering: -2
+ │    └── project
+ │         ├── columns: t.a:1(int!null) t.b:2(int)
+ │         ├── scan t
+ │         │    └── columns: t.a:1(int!null) t.b:2(int) t.c:3(bool)
+ │         └── projections
+ │              ├── variable: t.a [type=int]
+ │              └── variable: t.b [type=int]
+ └── const: 2 [type=int]
+
+build
 SELECT a FROM t ORDER BY 1 DESC
 ----
 sort
@@ -116,17 +134,21 @@ error: ORDER BY "foo" is ambiguous
 # Check that no ambiguity is reported if the ORDER BY name refers
 # to two or more equivalent renders (special case in SQL92).
 build
-SELECT a AS foo, (a) AS foo FROM t ORDER BY foo
+SELECT a AS foo, (a) AS foo FROM t ORDER BY foo LIMIT 1
 ----
-project
+limit
  ├── columns: foo:1(int!null) foo:1(int!null)
  ├── ordering: +1
- ├── scan t
- │    ├── columns: t.a:1(int!null) t.b:2(int) t.c:3(bool)
- │    └── ordering: +1
- └── projections
-      ├── variable: t.a [type=int]
-      └── variable: t.a [type=int]
+ ├── project
+ │    ├── columns: t.a:1(int!null) t.a:1(int!null)
+ │    ├── ordering: +1
+ │    ├── scan t
+ │    │    ├── columns: t.a:1(int!null) t.b:2(int) t.c:3(bool)
+ │    │    └── ordering: +1
+ │    └── projections
+ │         ├── variable: t.a [type=int]
+ │         └── variable: t.a [type=int]
+ └── const: 1 [type=int]
 
 # Check that this orders by the aliased column b (i.e., column a), not the
 # original column b.
@@ -184,6 +206,23 @@ sort
       └── projections
            ├── variable: t.b [type=int]
            └── variable: t.a [type=int]
+
+build
+SELECT b FROM t ORDER BY a LIMIT 1
+----
+limit
+ ├── columns: b:2(int)
+ ├── ordering: +1
+ ├── project
+ │    ├── columns: t.b:2(int) t.a:1(int!null)
+ │    ├── ordering: +1
+ │    ├── scan t
+ │    │    ├── columns: t.a:1(int!null) t.b:2(int) t.c:3(bool)
+ │    │    └── ordering: +1
+ │    └── projections
+ │         ├── variable: t.b [type=int]
+ │         └── variable: t.a [type=int]
+ └── const: 1 [type=int]
 
 build
 SELECT b FROM t ORDER BY a DESC, b ASC
@@ -350,30 +389,38 @@ project
       └── variable: t.a [type=int]
 
 build
-(((SELECT a FROM t))) ORDER BY a DESC
+(((SELECT a FROM t))) ORDER BY a DESC LIMIT 4
 ----
-sort
+limit
  ├── columns: a:1(int!null)
  ├── ordering: -1
- └── project
-      ├── columns: t.a:1(int!null)
-      ├── scan t
-      │    └── columns: t.a:1(int!null) t.b:2(int) t.c:3(bool)
-      └── projections
-           └── variable: t.a [type=int]
+ ├── sort
+ │    ├── columns: t.a:1(int!null)
+ │    ├── ordering: -1
+ │    └── project
+ │         ├── columns: t.a:1(int!null)
+ │         ├── scan t
+ │         │    └── columns: t.a:1(int!null) t.b:2(int) t.c:3(bool)
+ │         └── projections
+ │              └── variable: t.a [type=int]
+ └── const: 4 [type=int]
 
 build
-(((SELECT a FROM t ORDER BY a DESC)))
+(((SELECT a FROM t ORDER BY a DESC LIMIT 4)))
 ----
-sort
+limit
  ├── columns: a:1(int!null)
  ├── ordering: -1
- └── project
-      ├── columns: t.a:1(int!null)
-      ├── scan t
-      │    └── columns: t.a:1(int!null) t.b:2(int) t.c:3(bool)
-      └── projections
-           └── variable: t.a [type=int]
+ ├── sort
+ │    ├── columns: t.a:1(int!null)
+ │    ├── ordering: -1
+ │    └── project
+ │         ├── columns: t.a:1(int!null)
+ │         ├── scan t
+ │         │    └── columns: t.a:1(int!null) t.b:2(int) t.c:3(bool)
+ │         └── projections
+ │              └── variable: t.a [type=int]
+ └── const: 4 [type=int]
 
 build
 ((SELECT a FROM t ORDER BY a)) ORDER BY a
@@ -558,6 +605,208 @@ sort
                 └── const: 2 [type=int]
 
 exec-ddl
+CREATE TABLE abc (
+  a INT,
+  b INT,
+  c INT,
+  d CHAR,
+  PRIMARY KEY (a, b, c),
+  UNIQUE INDEX bc (b, c),
+  INDEX ba (b, a),
+  FAMILY (a, b, c),
+  FAMILY (d)
+)
+----
+TABLE abc
+ ├── a int not null
+ ├── b int not null
+ ├── c int not null
+ ├── d string
+ ├── INDEX primary
+ │    ├── a int not null
+ │    ├── b int not null
+ │    └── c int not null
+ ├── INDEX bc
+ │    ├── b int not null
+ │    ├── c int not null
+ │    └── a int not null (storing)
+ └── INDEX ba
+      ├── b int not null
+      ├── a int not null
+      └── c int not null
+
+build
+SELECT d FROM abc ORDER BY LOWER(d)
+----
+sort
+ ├── columns: d:4(string)
+ ├── ordering: +5
+ └── project
+      ├── columns: abc.d:4(string) column5:5(string)
+      ├── scan abc
+      │    └── columns: abc.a:1(int!null) abc.b:2(int!null) abc.c:3(int!null) abc.d:4(string)
+      └── projections
+           ├── variable: abc.d [type=string]
+           └── function: lower [type=string]
+                └── variable: abc.d [type=string]
+
+build
+SELECT * FROM abc ORDER BY a
+----
+scan abc
+ ├── columns: a:1(int!null) b:2(int!null) c:3(int!null) d:4(string)
+ └── ordering: +1
+
+build
+SELECT a, b FROM abc ORDER BY b, a
+----
+sort
+ ├── columns: a:1(int!null) b:2(int!null)
+ ├── ordering: +2,+1
+ └── project
+      ├── columns: abc.a:1(int!null) abc.b:2(int!null)
+      ├── scan abc
+      │    └── columns: abc.a:1(int!null) abc.b:2(int!null) abc.c:3(int!null) abc.d:4(string)
+      └── projections
+           ├── variable: abc.a [type=int]
+           └── variable: abc.b [type=int]
+
+build
+SELECT a, b FROM abc ORDER BY b, c
+----
+sort
+ ├── columns: a:1(int!null) b:2(int!null)
+ ├── ordering: +2,+3
+ └── project
+      ├── columns: abc.a:1(int!null) abc.b:2(int!null) abc.c:3(int!null)
+      ├── scan abc
+      │    └── columns: abc.a:1(int!null) abc.b:2(int!null) abc.c:3(int!null) abc.d:4(string)
+      └── projections
+           ├── variable: abc.a [type=int]
+           ├── variable: abc.b [type=int]
+           └── variable: abc.c [type=int]
+
+build
+SELECT a, b FROM abc ORDER BY b, c, a DESC
+----
+sort
+ ├── columns: a:1(int!null) b:2(int!null)
+ ├── ordering: +2,+3,-1
+ └── project
+      ├── columns: abc.a:1(int!null) abc.b:2(int!null) abc.c:3(int!null)
+      ├── scan abc
+      │    └── columns: abc.a:1(int!null) abc.b:2(int!null) abc.c:3(int!null) abc.d:4(string)
+      └── projections
+           ├── variable: abc.a [type=int]
+           ├── variable: abc.b [type=int]
+           └── variable: abc.c [type=int]
+
+build
+SELECT a FROM abc ORDER BY a DESC
+----
+sort
+ ├── columns: a:1(int!null)
+ ├── ordering: -1
+ └── project
+      ├── columns: abc.a:1(int!null)
+      ├── scan abc
+      │    └── columns: abc.a:1(int!null) abc.b:2(int!null) abc.c:3(int!null) abc.d:4(string)
+      └── projections
+           └── variable: abc.a [type=int]
+
+build
+SELECT a FROM abc ORDER BY a DESC LIMIT 1
+----
+limit
+ ├── columns: a:1(int!null)
+ ├── ordering: -1
+ ├── sort
+ │    ├── columns: abc.a:1(int!null)
+ │    ├── ordering: -1
+ │    └── project
+ │         ├── columns: abc.a:1(int!null)
+ │         ├── scan abc
+ │         │    └── columns: abc.a:1(int!null) abc.b:2(int!null) abc.c:3(int!null) abc.d:4(string)
+ │         └── projections
+ │              └── variable: abc.a [type=int]
+ └── const: 1 [type=int]
+
+build
+SELECT a FROM abc ORDER BY a DESC OFFSET 1
+----
+offset
+ ├── columns: a:1(int!null)
+ ├── ordering: -1
+ ├── sort
+ │    ├── columns: abc.a:1(int!null)
+ │    ├── ordering: -1
+ │    └── project
+ │         ├── columns: abc.a:1(int!null)
+ │         ├── scan abc
+ │         │    └── columns: abc.a:1(int!null) abc.b:2(int!null) abc.c:3(int!null) abc.d:4(string)
+ │         └── projections
+ │              └── variable: abc.a [type=int]
+ └── const: 1 [type=int]
+
+build
+SELECT c FROM abc WHERE b = 2 ORDER BY c
+----
+sort
+ ├── columns: c:3(int!null)
+ ├── ordering: +3
+ └── project
+      ├── columns: abc.c:3(int!null)
+      ├── select
+      │    ├── columns: abc.a:1(int!null) abc.b:2(int!null) abc.c:3(int!null) abc.d:4(string)
+      │    ├── scan abc
+      │    │    └── columns: abc.a:1(int!null) abc.b:2(int!null) abc.c:3(int!null) abc.d:4(string)
+      │    └── eq [type=bool]
+      │         ├── variable: abc.b [type=int]
+      │         └── const: 2 [type=int]
+      └── projections
+           └── variable: abc.c [type=int]
+
+build
+SELECT c FROM abc WHERE b = 2 ORDER BY c DESC
+----
+sort
+ ├── columns: c:3(int!null)
+ ├── ordering: -3
+ └── project
+      ├── columns: abc.c:3(int!null)
+      ├── select
+      │    ├── columns: abc.a:1(int!null) abc.b:2(int!null) abc.c:3(int!null) abc.d:4(string)
+      │    ├── scan abc
+      │    │    └── columns: abc.a:1(int!null) abc.b:2(int!null) abc.c:3(int!null) abc.d:4(string)
+      │    └── eq [type=bool]
+      │         ├── variable: abc.b [type=int]
+      │         └── const: 2 [type=int]
+      └── projections
+           └── variable: abc.c [type=int]
+
+# Verify that the ordering of the primary index is still used for the outer sort.
+# TODO(rytaft): Verify that the sort node is removed before execution.
+build
+SELECT * FROM (SELECT b, c FROM abc WHERE a=1 ORDER BY a,b) ORDER BY b,c
+----
+sort
+ ├── columns: b:2(int!null) c:3(int!null)
+ ├── ordering: +2,+3
+ └── project
+      ├── columns: abc.b:2(int!null) abc.c:3(int!null) abc.a:1(int!null)
+      ├── select
+      │    ├── columns: abc.a:1(int!null) abc.b:2(int!null) abc.c:3(int!null) abc.d:4(string)
+      │    ├── scan abc
+      │    │    └── columns: abc.a:1(int!null) abc.b:2(int!null) abc.c:3(int!null) abc.d:4(string)
+      │    └── eq [type=bool]
+      │         ├── variable: abc.a [type=int]
+      │         └── const: 1 [type=int]
+      └── projections
+           ├── variable: abc.b [type=int]
+           ├── variable: abc.c [type=int]
+           └── variable: abc.a [type=int]
+
+exec-ddl
 CREATE TABLE bar (id INT PRIMARY KEY, baz STRING, UNIQUE INDEX i_bar (baz))
 ----
 TABLE bar
@@ -674,19 +923,23 @@ TABLE blocks
 
 # Regression test for #13696.
 build
-SELECT block_id,writer_id,block_num,block_id FROM blocks ORDER BY block_id, writer_id, block_num
+SELECT block_id,writer_id,block_num,block_id FROM blocks ORDER BY block_id, writer_id, block_num LIMIT 1
 ----
-project
+limit
  ├── columns: block_id:1(int!null) writer_id:2(string!null) block_num:3(int!null) block_id:1(int!null)
  ├── ordering: +1,+2,+3
- ├── scan blocks
- │    ├── columns: blocks.block_id:1(int!null) blocks.writer_id:2(string!null) blocks.block_num:3(int!null) blocks.raw_bytes:4(bytes)
- │    └── ordering: +1,+2,+3
- └── projections
-      ├── variable: blocks.block_id [type=int]
-      ├── variable: blocks.writer_id [type=string]
-      ├── variable: blocks.block_num [type=int]
-      └── variable: blocks.block_id [type=int]
+ ├── project
+ │    ├── columns: blocks.block_id:1(int!null) blocks.writer_id:2(string!null) blocks.block_num:3(int!null) blocks.block_id:1(int!null)
+ │    ├── ordering: +1,+2,+3
+ │    ├── scan blocks
+ │    │    ├── columns: blocks.block_id:1(int!null) blocks.writer_id:2(string!null) blocks.block_num:3(int!null) blocks.raw_bytes:4(bytes)
+ │    │    └── ordering: +1,+2,+3
+ │    └── projections
+ │         ├── variable: blocks.block_id [type=int]
+ │         ├── variable: blocks.writer_id [type=string]
+ │         ├── variable: blocks.block_num [type=int]
+ │         └── variable: blocks.block_id [type=int]
+ └── const: 1 [type=int]
 
 exec-ddl
 CREATE TABLE abcd (

--- a/pkg/sql/opt/optbuilder/testdata/select
+++ b/pkg/sql/opt/optbuilder/testdata/select
@@ -350,28 +350,207 @@ TABLE xyzw
       ├── y int
       └── x int not null
 
+# TODO(rytaft): Fix error message:
+# error: name "x" is not defined
 build
-SELECT * FROM xyzw ORDER BY 1
+SELECT * FROM xyzw LIMIT x
 ----
-scan xyzw
+error: column name "x" not found
+
+# TODO(rytaft): Fix error message:
+# error: name "y" is not defined
+build
+SELECT * FROM xyzw OFFSET 1 + y
+----
+error: column name "y" not found
+
+# TODO(rytaft): should be an error:
+# error: argument of LIMIT must be type int, not type decimal
+build
+SELECT * FROM xyzw LIMIT 3.3
+----
+limit
  ├── columns: x:1(int!null) y:2(int) z:3(int) w:4(int)
- └── ordering: +1
+ ├── scan xyzw
+ │    └── columns: xyzw.x:1(int!null) xyzw.y:2(int) xyzw.z:3(int) xyzw.w:4(int)
+ └── const: 3.3 [type=decimal]
 
 build
-SELECT * FROM xyzw ORDER BY x
+SELECT * FROM xyzw ORDER BY 1 LIMIT '1'
 ----
-scan xyzw
+limit
  ├── columns: x:1(int!null) y:2(int) z:3(int) w:4(int)
- └── ordering: +1
+ ├── ordering: +1
+ ├── scan xyzw
+ │    ├── columns: xyzw.x:1(int!null) xyzw.y:2(int) xyzw.z:3(int) xyzw.w:4(int)
+ │    └── ordering: +1
+ └── const: 1 [type=int]
+
+# TODO(rytaft): should be an error:
+# error: argument of OFFSET must be type int, not type decimal
+build
+SELECT * FROM xyzw OFFSET 1.5
+----
+offset
+ ├── columns: x:1(int!null) y:2(int) z:3(int) w:4(int)
+ ├── scan xyzw
+ │    └── columns: xyzw.x:1(int!null) xyzw.y:2(int) xyzw.z:3(int) xyzw.w:4(int)
+ └── const: 1.5 [type=decimal]
+
+# TODO(rytaft): should be an error:
+# error: negative value for LIMIT
+build
+SELECT * FROM xyzw LIMIT -100
+----
+limit
+ ├── columns: x:1(int!null) y:2(int) z:3(int) w:4(int)
+ ├── scan xyzw
+ │    └── columns: xyzw.x:1(int!null) xyzw.y:2(int) xyzw.z:3(int) xyzw.w:4(int)
+ └── const: -100 [type=int]
+
+# TODO(rytaft): should be an error:
+# error: negative value for OFFSET
+build
+SELECT * FROM xyzw OFFSET -100
+----
+offset
+ ├── columns: x:1(int!null) y:2(int) z:3(int) w:4(int)
+ ├── scan xyzw
+ │    └── columns: xyzw.x:1(int!null) xyzw.y:2(int) xyzw.z:3(int) xyzw.w:4(int)
+ └── const: -100 [type=int]
 
 build
-SELECT * FROM xyzw ORDER BY y
+SELECT * FROM xyzw ORDER BY x OFFSET 1 + 0.0
 ----
-sort
+offset
+ ├── columns: x:1(int!null) y:2(int) z:3(int) w:4(int)
+ ├── ordering: +1
+ ├── scan xyzw
+ │    ├── columns: xyzw.x:1(int!null) xyzw.y:2(int) xyzw.z:3(int) xyzw.w:4(int)
+ │    └── ordering: +1
+ └── const: 1 [type=int]
+
+build
+SELECT (x,y) FROM xyzw
+----
+project
+ ├── columns: column5:5(tuple{int, int})
+ ├── scan xyzw
+ │    └── columns: xyzw.x:1(int!null) xyzw.y:2(int) xyzw.z:3(int) xyzw.w:4(int)
+ └── projections
+      └── tuple [type=tuple{int, int}]
+           ├── variable: xyzw.x [type=int]
+           └── variable: xyzw.y [type=int]
+
+build
+SELECT * FROM xyzw LIMIT 0
+----
+limit
+ ├── columns: x:1(int!null) y:2(int) z:3(int) w:4(int)
+ ├── scan xyzw
+ │    └── columns: xyzw.x:1(int!null) xyzw.y:2(int) xyzw.z:3(int) xyzw.w:4(int)
+ └── const: 0 [type=int]
+
+build
+SELECT * FROM xyzw ORDER BY x LIMIT 1
+----
+limit
+ ├── columns: x:1(int!null) y:2(int) z:3(int) w:4(int)
+ ├── ordering: +1
+ ├── scan xyzw
+ │    ├── columns: xyzw.x:1(int!null) xyzw.y:2(int) xyzw.z:3(int) xyzw.w:4(int)
+ │    └── ordering: +1
+ └── const: 1 [type=int]
+
+build
+SELECT * FROM xyzw ORDER BY x LIMIT 1 OFFSET 1
+----
+limit
+ ├── columns: x:1(int!null) y:2(int) z:3(int) w:4(int)
+ ├── ordering: +1
+ ├── offset
+ │    ├── columns: xyzw.x:1(int!null) xyzw.y:2(int) xyzw.z:3(int) xyzw.w:4(int)
+ │    ├── ordering: +1
+ │    ├── scan xyzw
+ │    │    ├── columns: xyzw.x:1(int!null) xyzw.y:2(int) xyzw.z:3(int) xyzw.w:4(int)
+ │    │    └── ordering: +1
+ │    └── const: 1 [type=int]
+ └── const: 1 [type=int]
+
+build
+SELECT * FROM xyzw ORDER BY y OFFSET 1
+----
+offset
  ├── columns: x:1(int!null) y:2(int) z:3(int) w:4(int)
  ├── ordering: +2
- └── scan xyzw
-      └── columns: xyzw.x:1(int!null) xyzw.y:2(int) xyzw.z:3(int) xyzw.w:4(int)
+ ├── sort
+ │    ├── columns: xyzw.x:1(int!null) xyzw.y:2(int) xyzw.z:3(int) xyzw.w:4(int)
+ │    ├── ordering: +2
+ │    └── scan xyzw
+ │         └── columns: xyzw.x:1(int!null) xyzw.y:2(int) xyzw.z:3(int) xyzw.w:4(int)
+ └── const: 1 [type=int]
+
+build
+SELECT * FROM xyzw ORDER BY y OFFSET 1 LIMIT 1
+----
+limit
+ ├── columns: x:1(int!null) y:2(int) z:3(int) w:4(int)
+ ├── ordering: +2
+ ├── offset
+ │    ├── columns: xyzw.x:1(int!null) xyzw.y:2(int) xyzw.z:3(int) xyzw.w:4(int)
+ │    ├── ordering: +2
+ │    ├── sort
+ │    │    ├── columns: xyzw.x:1(int!null) xyzw.y:2(int) xyzw.z:3(int) xyzw.w:4(int)
+ │    │    ├── ordering: +2
+ │    │    └── scan xyzw
+ │    │         └── columns: xyzw.x:1(int!null) xyzw.y:2(int) xyzw.z:3(int) xyzw.w:4(int)
+ │    └── const: 1 [type=int]
+ └── const: 1 [type=int]
+
+build
+SELECT * FROM xyzw LIMIT (RANDOM() * 0.0)::int OFFSET (RANDOM() * 0.0)::int
+----
+limit
+ ├── columns: x:1(int!null) y:2(int) z:3(int) w:4(int)
+ ├── offset
+ │    ├── columns: xyzw.x:1(int!null) xyzw.y:2(int) xyzw.z:3(int) xyzw.w:4(int)
+ │    ├── scan xyzw
+ │    │    └── columns: xyzw.x:1(int!null) xyzw.y:2(int) xyzw.z:3(int) xyzw.w:4(int)
+ │    └── cast: int [type=int]
+ │         └── mult [type=float]
+ │              ├── function: random [type=float]
+ │              └── const: 0.0 [type=float]
+ └── cast: int [type=int]
+      └── mult [type=float]
+           ├── function: random [type=float]
+           └── const: 0.0 [type=float]
+
+# TODO(rytaft): should be an error:
+# error: multiple LIMIT clauses not allowed
+build
+((SELECT x FROM xyzw LIMIT 1)) LIMIT 1
+----
+limit
+ ├── columns: x:1(int!null)
+ ├── project
+ │    ├── columns: xyzw.x:1(int!null)
+ │    ├── scan xyzw
+ │    │    └── columns: xyzw.x:1(int!null) xyzw.y:2(int) xyzw.z:3(int) xyzw.w:4(int)
+ │    └── projections
+ │         └── variable: xyzw.x [type=int]
+ └── const: 1 [type=int]
+
+build
+SELECT * FROM (SELECT * FROM xyzw LIMIT 5) OFFSET 5
+----
+offset
+ ├── columns: x:1(int!null) y:2(int) z:3(int) w:4(int)
+ ├── limit
+ │    ├── columns: xyzw.x:1(int!null) xyzw.y:2(int) xyzw.z:3(int) xyzw.w:4(int)
+ │    ├── scan xyzw
+ │    │    └── columns: xyzw.x:1(int!null) xyzw.y:2(int) xyzw.z:3(int) xyzw.w:4(int)
+ │    └── const: 5 [type=int]
+ └── const: 5 [type=int]
 
 exec-ddl
 CREATE TABLE boolean_table (
@@ -487,6 +666,236 @@ project
                 └── tuple [type=tuple{int, int}]
                      ├── const: 1 [type=int]
                      └── const: 1 [type=int]
+
+# Tests with a tuple coming from a subquery.
+build
+SELECT NULL::int IN (SELECT * FROM (VALUES (1)) AS t(a))
+----
+project
+ ├── columns: column3:3(bool)
+ ├── values
+ │    └── tuple [type=tuple{}]
+ └── projections
+      └── any [type=bool]
+           └── project
+                ├── columns: column2:2(bool)
+                ├── values
+                │    ├── columns: column1:1(int)
+                │    └── tuple [type=tuple{int}]
+                │         └── const: 1 [type=int]
+                └── projections
+                     └── eq [type=bool]
+                          ├── cast: int [type=int]
+                          │    └── null [type=unknown]
+                          └── variable: column1 [type=int]
+
+build
+SELECT (1, NULL::int) IN (SELECT * FROM (VALUES (1, 1)) AS t(a, b))
+----
+project
+ ├── columns: column5:5(bool)
+ ├── values
+ │    └── tuple [type=tuple{}]
+ └── projections
+      └── any [type=bool]
+           └── project
+                ├── columns: column4:4(bool)
+                ├── project
+                │    ├── columns: column3:3(tuple{int, int})
+                │    ├── values
+                │    │    ├── columns: column1:1(int) column2:2(int)
+                │    │    └── tuple [type=tuple{int, int}]
+                │    │         ├── const: 1 [type=int]
+                │    │         └── const: 1 [type=int]
+                │    └── projections
+                │         └── tuple [type=tuple{int, int}]
+                │              ├── variable: column1 [type=int]
+                │              └── variable: column2 [type=int]
+                └── projections
+                     └── eq [type=bool]
+                          ├── tuple [type=tuple{int, int}]
+                          │    ├── const: 1 [type=int]
+                          │    └── cast: int [type=int]
+                          │         └── null [type=unknown]
+                          └── variable: column3 [type=tuple{int, int}]
+
+build
+SELECT NULL::int NOT IN (SELECT * FROM (VALUES (1)) AS t(a))
+----
+project
+ ├── columns: column3:3(bool)
+ ├── values
+ │    └── tuple [type=tuple{}]
+ └── projections
+      └── not [type=bool]
+           └── any [type=bool]
+                └── project
+                     ├── columns: column2:2(bool)
+                     ├── values
+                     │    ├── columns: column1:1(int)
+                     │    └── tuple [type=tuple{int}]
+                     │         └── const: 1 [type=int]
+                     └── projections
+                          └── eq [type=bool]
+                               ├── cast: int [type=int]
+                               │    └── null [type=unknown]
+                               └── variable: column1 [type=int]
+
+build
+SELECT (1, NULL::int) NOT IN (SELECT * FROM (VALUES (1, 1)) AS t(a, b))
+----
+project
+ ├── columns: column5:5(bool)
+ ├── values
+ │    └── tuple [type=tuple{}]
+ └── projections
+      └── not [type=bool]
+           └── any [type=bool]
+                └── project
+                     ├── columns: column4:4(bool)
+                     ├── project
+                     │    ├── columns: column3:3(tuple{int, int})
+                     │    ├── values
+                     │    │    ├── columns: column1:1(int) column2:2(int)
+                     │    │    └── tuple [type=tuple{int, int}]
+                     │    │         ├── const: 1 [type=int]
+                     │    │         └── const: 1 [type=int]
+                     │    └── projections
+                     │         └── tuple [type=tuple{int, int}]
+                     │              ├── variable: column1 [type=int]
+                     │              └── variable: column2 [type=int]
+                     └── projections
+                          └── eq [type=bool]
+                               ├── tuple [type=tuple{int, int}]
+                               │    ├── const: 1 [type=int]
+                               │    └── cast: int [type=int]
+                               │         └── null [type=unknown]
+                               └── variable: column3 [type=tuple{int, int}]
+
+# Tests with an empty IN tuple.
+build
+SELECT NULL::int IN (SELECT * FROM (VALUES (1)) AS t(a) WHERE a > 1)
+----
+project
+ ├── columns: column3:3(bool)
+ ├── values
+ │    └── tuple [type=tuple{}]
+ └── projections
+      └── any [type=bool]
+           └── project
+                ├── columns: column2:2(bool)
+                ├── select
+                │    ├── columns: column1:1(int)
+                │    ├── values
+                │    │    ├── columns: column1:1(int)
+                │    │    └── tuple [type=tuple{int}]
+                │    │         └── const: 1 [type=int]
+                │    └── gt [type=bool]
+                │         ├── variable: column1 [type=int]
+                │         └── const: 1 [type=int]
+                └── projections
+                     └── eq [type=bool]
+                          ├── cast: int [type=int]
+                          │    └── null [type=unknown]
+                          └── variable: column1 [type=int]
+
+build
+SELECT (1, NULL::int) IN (SELECT * FROM (VALUES (1, 1)) AS t(a, b) WHERE a > 1)
+----
+project
+ ├── columns: column5:5(bool)
+ ├── values
+ │    └── tuple [type=tuple{}]
+ └── projections
+      └── any [type=bool]
+           └── project
+                ├── columns: column4:4(bool)
+                ├── project
+                │    ├── columns: column3:3(tuple{int, int})
+                │    ├── select
+                │    │    ├── columns: column1:1(int) column2:2(int)
+                │    │    ├── values
+                │    │    │    ├── columns: column1:1(int) column2:2(int)
+                │    │    │    └── tuple [type=tuple{int, int}]
+                │    │    │         ├── const: 1 [type=int]
+                │    │    │         └── const: 1 [type=int]
+                │    │    └── gt [type=bool]
+                │    │         ├── variable: column1 [type=int]
+                │    │         └── const: 1 [type=int]
+                │    └── projections
+                │         └── tuple [type=tuple{int, int}]
+                │              ├── variable: column1 [type=int]
+                │              └── variable: column2 [type=int]
+                └── projections
+                     └── eq [type=bool]
+                          ├── tuple [type=tuple{int, int}]
+                          │    ├── const: 1 [type=int]
+                          │    └── cast: int [type=int]
+                          │         └── null [type=unknown]
+                          └── variable: column3 [type=tuple{int, int}]
+
+build
+SELECT NULL::int NOT IN (SELECT * FROM (VALUES (1)) AS t(a) WHERE a > 1)
+----
+project
+ ├── columns: column3:3(bool)
+ ├── values
+ │    └── tuple [type=tuple{}]
+ └── projections
+      └── not [type=bool]
+           └── any [type=bool]
+                └── project
+                     ├── columns: column2:2(bool)
+                     ├── select
+                     │    ├── columns: column1:1(int)
+                     │    ├── values
+                     │    │    ├── columns: column1:1(int)
+                     │    │    └── tuple [type=tuple{int}]
+                     │    │         └── const: 1 [type=int]
+                     │    └── gt [type=bool]
+                     │         ├── variable: column1 [type=int]
+                     │         └── const: 1 [type=int]
+                     └── projections
+                          └── eq [type=bool]
+                               ├── cast: int [type=int]
+                               │    └── null [type=unknown]
+                               └── variable: column1 [type=int]
+
+build
+SELECT (1, NULL::int) NOT IN (SELECT * FROM (VALUES (1, 1)) AS t(a, b) WHERE a > 1)
+----
+project
+ ├── columns: column5:5(bool)
+ ├── values
+ │    └── tuple [type=tuple{}]
+ └── projections
+      └── not [type=bool]
+           └── any [type=bool]
+                └── project
+                     ├── columns: column4:4(bool)
+                     ├── project
+                     │    ├── columns: column3:3(tuple{int, int})
+                     │    ├── select
+                     │    │    ├── columns: column1:1(int) column2:2(int)
+                     │    │    ├── values
+                     │    │    │    ├── columns: column1:1(int) column2:2(int)
+                     │    │    │    └── tuple [type=tuple{int, int}]
+                     │    │    │         ├── const: 1 [type=int]
+                     │    │    │         └── const: 1 [type=int]
+                     │    │    └── gt [type=bool]
+                     │    │         ├── variable: column1 [type=int]
+                     │    │         └── const: 1 [type=int]
+                     │    └── projections
+                     │         └── tuple [type=tuple{int, int}]
+                     │              ├── variable: column1 [type=int]
+                     │              └── variable: column2 [type=int]
+                     └── projections
+                          └── eq [type=bool]
+                               ├── tuple [type=tuple{int, int}]
+                               │    ├── const: 1 [type=int]
+                               │    └── cast: int [type=int]
+                               │         └── null [type=unknown]
+                               └── variable: column3 [type=tuple{int, int}]
 
 exec-ddl
 CREATE TABLE t.a (x INT PRIMARY KEY, y FLOAT)

--- a/pkg/sql/opt/optbuilder/testdata/select
+++ b/pkg/sql/opt/optbuilder/testdata/select
@@ -364,16 +364,10 @@ SELECT * FROM xyzw OFFSET 1 + y
 ----
 error: column name "y" not found
 
-# TODO(rytaft): should be an error:
-# error: argument of LIMIT must be type int, not type decimal
 build
 SELECT * FROM xyzw LIMIT 3.3
 ----
-limit
- ├── columns: x:1(int!null) y:2(int) z:3(int) w:4(int)
- ├── scan xyzw
- │    └── columns: xyzw.x:1(int!null) xyzw.y:2(int) xyzw.z:3(int) xyzw.w:4(int)
- └── const: 3.3 [type=decimal]
+error: argument of LIMIT must be type int, not type decimal
 
 build
 SELECT * FROM xyzw ORDER BY 1 LIMIT '1'
@@ -386,19 +380,12 @@ limit
  │    └── ordering: +1
  └── const: 1 [type=int]
 
-# TODO(rytaft): should be an error:
-# error: argument of OFFSET must be type int, not type decimal
 build
 SELECT * FROM xyzw OFFSET 1.5
 ----
-offset
- ├── columns: x:1(int!null) y:2(int) z:3(int) w:4(int)
- ├── scan xyzw
- │    └── columns: xyzw.x:1(int!null) xyzw.y:2(int) xyzw.z:3(int) xyzw.w:4(int)
- └── const: 1.5 [type=decimal]
+error: argument of OFFSET must be type int, not type decimal
 
-# TODO(rytaft): should be an error:
-# error: negative value for LIMIT
+# At execution time, this will cause the error: negative value for LIMIT
 build
 SELECT * FROM xyzw LIMIT -100
 ----
@@ -408,8 +395,7 @@ limit
  │    └── columns: xyzw.x:1(int!null) xyzw.y:2(int) xyzw.z:3(int) xyzw.w:4(int)
  └── const: -100 [type=int]
 
-# TODO(rytaft): should be an error:
-# error: negative value for OFFSET
+# At execution time, this will cause the error: negative value for OFFSET
 build
 SELECT * FROM xyzw OFFSET -100
 ----
@@ -525,20 +511,10 @@ limit
            ├── function: random [type=float]
            └── const: 0.0 [type=float]
 
-# TODO(rytaft): should be an error:
-# error: multiple LIMIT clauses not allowed
 build
 ((SELECT x FROM xyzw LIMIT 1)) LIMIT 1
 ----
-limit
- ├── columns: x:1(int!null)
- ├── project
- │    ├── columns: xyzw.x:1(int!null)
- │    ├── scan xyzw
- │    │    └── columns: xyzw.x:1(int!null) xyzw.y:2(int) xyzw.z:3(int) xyzw.w:4(int)
- │    └── projections
- │         └── variable: xyzw.x [type=int]
- └── const: 1 [type=int]
+error: multiple LIMIT clauses not allowed
 
 build
 SELECT * FROM (SELECT * FROM xyzw LIMIT 5) OFFSET 5

--- a/pkg/sql/opt/optbuilder/testdata/subquery
+++ b/pkg/sql/opt/optbuilder/testdata/subquery
@@ -1164,7 +1164,6 @@ select
       ├── variable: xyz.x [type=int]
       └── const: 7 [type=int]
 
-# TODO(rytaft): moo1 should be foo1
 build
 SELECT * FROM (SELECT * FROM xyz AS moo (moo1, moo2, moo3) ORDER BY moo1) as foo (foo1) WHERE foo1 < 7
 ----

--- a/pkg/sql/opt/optbuilder/testdata/union
+++ b/pkg/sql/opt/optbuilder/testdata/union
@@ -205,67 +205,75 @@ union
            └── const: 1 [type=int]
 
 build
-(VALUES (1), (1), (1), (2), (2) UNION ALL VALUES (1), (3), (1)) ORDER BY 1 DESC
+(VALUES (1), (1), (1), (2), (2) UNION ALL VALUES (1), (3), (1)) ORDER BY 1 DESC LIMIT 2
 ----
-sort
+limit
  ├── columns: column1:3(int)
  ├── ordering: -3
- └── union-all
-      ├── columns: column1:3(int)
-      ├── left columns: column1:1(int)
-      ├── right columns: column1:2(int)
-      ├── values
-      │    ├── columns: column1:1(int)
-      │    ├── tuple [type=tuple{int}]
-      │    │    └── const: 1 [type=int]
-      │    ├── tuple [type=tuple{int}]
-      │    │    └── const: 1 [type=int]
-      │    ├── tuple [type=tuple{int}]
-      │    │    └── const: 1 [type=int]
-      │    ├── tuple [type=tuple{int}]
-      │    │    └── const: 2 [type=int]
-      │    └── tuple [type=tuple{int}]
-      │         └── const: 2 [type=int]
-      └── values
-           ├── columns: column1:2(int)
-           ├── tuple [type=tuple{int}]
-           │    └── const: 1 [type=int]
-           ├── tuple [type=tuple{int}]
-           │    └── const: 3 [type=int]
-           └── tuple [type=tuple{int}]
-                └── const: 1 [type=int]
+ ├── sort
+ │    ├── columns: column1:3(int)
+ │    ├── ordering: -3
+ │    └── union-all
+ │         ├── columns: column1:3(int)
+ │         ├── left columns: column1:1(int)
+ │         ├── right columns: column1:2(int)
+ │         ├── values
+ │         │    ├── columns: column1:1(int)
+ │         │    ├── tuple [type=tuple{int}]
+ │         │    │    └── const: 1 [type=int]
+ │         │    ├── tuple [type=tuple{int}]
+ │         │    │    └── const: 1 [type=int]
+ │         │    ├── tuple [type=tuple{int}]
+ │         │    │    └── const: 1 [type=int]
+ │         │    ├── tuple [type=tuple{int}]
+ │         │    │    └── const: 2 [type=int]
+ │         │    └── tuple [type=tuple{int}]
+ │         │         └── const: 2 [type=int]
+ │         └── values
+ │              ├── columns: column1:2(int)
+ │              ├── tuple [type=tuple{int}]
+ │              │    └── const: 1 [type=int]
+ │              ├── tuple [type=tuple{int}]
+ │              │    └── const: 3 [type=int]
+ │              └── tuple [type=tuple{int}]
+ │                   └── const: 1 [type=int]
+ └── const: 2 [type=int]
 
-# The ORDER BY applies to the UNION, not the last VALUES.
+# The ORDER BY and LIMIT apply to the UNION, not the last VALUES.
 build
-VALUES (1), (1), (1), (2), (2) UNION ALL VALUES (1), (3), (1) ORDER BY 1 DESC
+VALUES (1), (1), (1), (2), (2) UNION ALL VALUES (1), (3), (1) ORDER BY 1 DESC LIMIT 2
 ----
-sort
+limit
  ├── columns: column1:3(int)
  ├── ordering: -3
- └── union-all
-      ├── columns: column1:3(int)
-      ├── left columns: column1:1(int)
-      ├── right columns: column1:2(int)
-      ├── values
-      │    ├── columns: column1:1(int)
-      │    ├── tuple [type=tuple{int}]
-      │    │    └── const: 1 [type=int]
-      │    ├── tuple [type=tuple{int}]
-      │    │    └── const: 1 [type=int]
-      │    ├── tuple [type=tuple{int}]
-      │    │    └── const: 1 [type=int]
-      │    ├── tuple [type=tuple{int}]
-      │    │    └── const: 2 [type=int]
-      │    └── tuple [type=tuple{int}]
-      │         └── const: 2 [type=int]
-      └── values
-           ├── columns: column1:2(int)
-           ├── tuple [type=tuple{int}]
-           │    └── const: 1 [type=int]
-           ├── tuple [type=tuple{int}]
-           │    └── const: 3 [type=int]
-           └── tuple [type=tuple{int}]
-                └── const: 1 [type=int]
+ ├── sort
+ │    ├── columns: column1:3(int)
+ │    ├── ordering: -3
+ │    └── union-all
+ │         ├── columns: column1:3(int)
+ │         ├── left columns: column1:1(int)
+ │         ├── right columns: column1:2(int)
+ │         ├── values
+ │         │    ├── columns: column1:1(int)
+ │         │    ├── tuple [type=tuple{int}]
+ │         │    │    └── const: 1 [type=int]
+ │         │    ├── tuple [type=tuple{int}]
+ │         │    │    └── const: 1 [type=int]
+ │         │    ├── tuple [type=tuple{int}]
+ │         │    │    └── const: 1 [type=int]
+ │         │    ├── tuple [type=tuple{int}]
+ │         │    │    └── const: 2 [type=int]
+ │         │    └── tuple [type=tuple{int}]
+ │         │         └── const: 2 [type=int]
+ │         └── values
+ │              ├── columns: column1:2(int)
+ │              ├── tuple [type=tuple{int}]
+ │              │    └── const: 1 [type=int]
+ │              ├── tuple [type=tuple{int}]
+ │              │    └── const: 3 [type=int]
+ │              └── tuple [type=tuple{int}]
+ │                   └── const: 1 [type=int]
+ └── const: 2 [type=int]
 
 # UNION with NULL columns in operands works.
 build
@@ -553,71 +561,79 @@ except-all
            └── variable: uniontest.v [type=int]
 
 build
-(SELECT v FROM uniontest WHERE k = 1 UNION ALL SELECT v FROM uniontest WHERE k = 2) ORDER BY 1 DESC
+(SELECT v FROM uniontest WHERE k = 1 UNION ALL SELECT v FROM uniontest WHERE k = 2) ORDER BY 1 DESC LIMIT 2
 ----
-sort
+limit
  ├── columns: v:7(int)
  ├── ordering: -7
- └── union-all
-      ├── columns: v:7(int)
-      ├── left columns: uniontest.v:2(int)
-      ├── right columns: uniontest.v:5(int)
-      ├── project
-      │    ├── columns: uniontest.v:2(int)
-      │    ├── select
-      │    │    ├── columns: uniontest.k:1(int) uniontest.v:2(int) uniontest.rowid:3(int!null)
-      │    │    ├── scan uniontest
-      │    │    │    └── columns: uniontest.k:1(int) uniontest.v:2(int) uniontest.rowid:3(int!null)
-      │    │    └── eq [type=bool]
-      │    │         ├── variable: uniontest.k [type=int]
-      │    │         └── const: 1 [type=int]
-      │    └── projections
-      │         └── variable: uniontest.v [type=int]
-      └── project
-           ├── columns: uniontest.v:5(int)
-           ├── select
-           │    ├── columns: uniontest.k:4(int) uniontest.v:5(int) uniontest.rowid:6(int!null)
-           │    ├── scan uniontest
-           │    │    └── columns: uniontest.k:4(int) uniontest.v:5(int) uniontest.rowid:6(int!null)
-           │    └── eq [type=bool]
-           │         ├── variable: uniontest.k [type=int]
-           │         └── const: 2 [type=int]
-           └── projections
-                └── variable: uniontest.v [type=int]
+ ├── sort
+ │    ├── columns: v:7(int)
+ │    ├── ordering: -7
+ │    └── union-all
+ │         ├── columns: v:7(int)
+ │         ├── left columns: uniontest.v:2(int)
+ │         ├── right columns: uniontest.v:5(int)
+ │         ├── project
+ │         │    ├── columns: uniontest.v:2(int)
+ │         │    ├── select
+ │         │    │    ├── columns: uniontest.k:1(int) uniontest.v:2(int) uniontest.rowid:3(int!null)
+ │         │    │    ├── scan uniontest
+ │         │    │    │    └── columns: uniontest.k:1(int) uniontest.v:2(int) uniontest.rowid:3(int!null)
+ │         │    │    └── eq [type=bool]
+ │         │    │         ├── variable: uniontest.k [type=int]
+ │         │    │         └── const: 1 [type=int]
+ │         │    └── projections
+ │         │         └── variable: uniontest.v [type=int]
+ │         └── project
+ │              ├── columns: uniontest.v:5(int)
+ │              ├── select
+ │              │    ├── columns: uniontest.k:4(int) uniontest.v:5(int) uniontest.rowid:6(int!null)
+ │              │    ├── scan uniontest
+ │              │    │    └── columns: uniontest.k:4(int) uniontest.v:5(int) uniontest.rowid:6(int!null)
+ │              │    └── eq [type=bool]
+ │              │         ├── variable: uniontest.k [type=int]
+ │              │         └── const: 2 [type=int]
+ │              └── projections
+ │                   └── variable: uniontest.v [type=int]
+ └── const: 2 [type=int]
 
-# The ORDER BY applies to the UNION, not the last SELECT.
+# The ORDER BY and LIMIT apply to the UNION, not the last SELECT.
 build
-SELECT v FROM uniontest WHERE k = 1 UNION ALL SELECT v FROM uniontest WHERE k = 2 ORDER BY 1 DESC
+SELECT v FROM uniontest WHERE k = 1 UNION ALL SELECT v FROM uniontest WHERE k = 2 ORDER BY 1 DESC LIMIT 2
 ----
-sort
+limit
  ├── columns: v:7(int)
  ├── ordering: -7
- └── union-all
-      ├── columns: v:7(int)
-      ├── left columns: uniontest.v:2(int)
-      ├── right columns: uniontest.v:5(int)
-      ├── project
-      │    ├── columns: uniontest.v:2(int)
-      │    ├── select
-      │    │    ├── columns: uniontest.k:1(int) uniontest.v:2(int) uniontest.rowid:3(int!null)
-      │    │    ├── scan uniontest
-      │    │    │    └── columns: uniontest.k:1(int) uniontest.v:2(int) uniontest.rowid:3(int!null)
-      │    │    └── eq [type=bool]
-      │    │         ├── variable: uniontest.k [type=int]
-      │    │         └── const: 1 [type=int]
-      │    └── projections
-      │         └── variable: uniontest.v [type=int]
-      └── project
-           ├── columns: uniontest.v:5(int)
-           ├── select
-           │    ├── columns: uniontest.k:4(int) uniontest.v:5(int) uniontest.rowid:6(int!null)
-           │    ├── scan uniontest
-           │    │    └── columns: uniontest.k:4(int) uniontest.v:5(int) uniontest.rowid:6(int!null)
-           │    └── eq [type=bool]
-           │         ├── variable: uniontest.k [type=int]
-           │         └── const: 2 [type=int]
-           └── projections
-                └── variable: uniontest.v [type=int]
+ ├── sort
+ │    ├── columns: v:7(int)
+ │    ├── ordering: -7
+ │    └── union-all
+ │         ├── columns: v:7(int)
+ │         ├── left columns: uniontest.v:2(int)
+ │         ├── right columns: uniontest.v:5(int)
+ │         ├── project
+ │         │    ├── columns: uniontest.v:2(int)
+ │         │    ├── select
+ │         │    │    ├── columns: uniontest.k:1(int) uniontest.v:2(int) uniontest.rowid:3(int!null)
+ │         │    │    ├── scan uniontest
+ │         │    │    │    └── columns: uniontest.k:1(int) uniontest.v:2(int) uniontest.rowid:3(int!null)
+ │         │    │    └── eq [type=bool]
+ │         │    │         ├── variable: uniontest.k [type=int]
+ │         │    │         └── const: 1 [type=int]
+ │         │    └── projections
+ │         │         └── variable: uniontest.v [type=int]
+ │         └── project
+ │              ├── columns: uniontest.v:5(int)
+ │              ├── select
+ │              │    ├── columns: uniontest.k:4(int) uniontest.v:5(int) uniontest.rowid:6(int!null)
+ │              │    ├── scan uniontest
+ │              │    │    └── columns: uniontest.k:4(int) uniontest.v:5(int) uniontest.rowid:6(int!null)
+ │              │    └── eq [type=bool]
+ │              │         ├── variable: uniontest.k [type=int]
+ │              │         └── const: 2 [type=int]
+ │              └── projections
+ │                   └── variable: uniontest.v [type=int]
+ └── const: 2 [type=int]
 
 build
 SELECT v FROM uniontest UNION SELECT k FROM uniontest

--- a/pkg/sql/opt/optbuilder/testdata/values
+++ b/pkg/sql/opt/optbuilder/testdata/values
@@ -163,21 +163,25 @@ values
  ├── columns: column1:3(int)
  ├── tuple [type=tuple{int}]
  │    └── subquery [type=int]
- │         ├── project
+ │         ├── max1-row
  │         │    ├── columns: column1:1(int)
- │         │    ├── values
- │         │    │    └── tuple [type=tuple{}]
- │         │    └── projections
- │         │         └── const: 1 [type=int]
+ │         │    └── project
+ │         │         ├── columns: column1:1(int)
+ │         │         ├── values
+ │         │         │    └── tuple [type=tuple{}]
+ │         │         └── projections
+ │         │              └── const: 1 [type=int]
  │         └── variable: column1 [type=int]
  └── tuple [type=tuple{int}]
       └── subquery [type=int]
-           ├── project
+           ├── max1-row
            │    ├── columns: column2:2(int)
-           │    ├── values
-           │    │    └── tuple [type=tuple{}]
-           │    └── projections
-           │         └── const: 2 [type=int]
+           │    └── project
+           │         ├── columns: column2:2(int)
+           │         ├── values
+           │         │    └── tuple [type=tuple{}]
+           │         └── projections
+           │              └── const: 2 [type=int]
            └── variable: column2 [type=int]
 
 build
@@ -189,10 +193,12 @@ values
  │    └── const: 1 [type=int]
  └── tuple [type=tuple{int}]
       └── subquery [type=int]
-           ├── project
+           ├── max1-row
            │    ├── columns: column1:1(int)
-           │    ├── values
-           │    │    └── tuple [type=tuple{}]
-           │    └── projections
-           │         └── const: 2 [type=int]
+           │    └── project
+           │         ├── columns: column1:1(int)
+           │         ├── values
+           │         │    └── tuple [type=tuple{}]
+           │         └── projections
+           │              └── const: 2 [type=int]
            └── variable: column1 [type=int]

--- a/pkg/sql/opt/optbuilder/testdata/values
+++ b/pkg/sql/opt/optbuilder/testdata/values
@@ -28,21 +28,25 @@ VALUES (1), (2, 3)
 error: VALUES lists must all be the same length, expected 1 columns, found 2
 
 build
-VALUES (1), (1), (2), (3) ORDER BY 1 DESC
+VALUES (1), (1), (2), (3) ORDER BY 1 DESC LIMIT 3
 ----
-sort
+limit
  ├── columns: column1:1(int)
  ├── ordering: -1
- └── values
-      ├── columns: column1:1(int)
-      ├── tuple [type=tuple{int}]
-      │    └── const: 1 [type=int]
-      ├── tuple [type=tuple{int}]
-      │    └── const: 1 [type=int]
-      ├── tuple [type=tuple{int}]
-      │    └── const: 2 [type=int]
-      └── tuple [type=tuple{int}]
-           └── const: 3 [type=int]
+ ├── sort
+ │    ├── columns: column1:1(int)
+ │    ├── ordering: -1
+ │    └── values
+ │         ├── columns: column1:1(int)
+ │         ├── tuple [type=tuple{int}]
+ │         │    └── const: 1 [type=int]
+ │         ├── tuple [type=tuple{int}]
+ │         │    └── const: 1 [type=int]
+ │         ├── tuple [type=tuple{int}]
+ │         │    └── const: 2 [type=int]
+ │         └── tuple [type=tuple{int}]
+ │              └── const: 3 [type=int]
+ └── const: 3 [type=int]
 
 # TODO(rytaft): Error message should be `pgcode 42703 column "z" does not exist`
 build
@@ -151,14 +155,44 @@ project
            ├── variable: column1 [type=int]
            └── variable: column2 [type=int]
 
+# subqueries can be evaluated in VALUES
+build
+VALUES ((SELECT 1)), ((SELECT 2))
+----
+values
+ ├── columns: column1:3(int)
+ ├── tuple [type=tuple{int}]
+ │    └── subquery [type=int]
+ │         ├── project
+ │         │    ├── columns: column1:1(int)
+ │         │    ├── values
+ │         │    │    └── tuple [type=tuple{}]
+ │         │    └── projections
+ │         │         └── const: 1 [type=int]
+ │         └── variable: column1 [type=int]
+ └── tuple [type=tuple{int}]
+      └── subquery [type=int]
+           ├── project
+           │    ├── columns: column2:2(int)
+           │    ├── values
+           │    │    └── tuple [type=tuple{}]
+           │    └── projections
+           │         └── const: 2 [type=int]
+           └── variable: column2 [type=int]
 
-# TODO(rytaft): uncomment these tests once subqueries are supported
-## subqueries can be evaluated in VALUES
-#build
-#VALUES ((SELECT 1)), ((SELECT 2))
-#----
-#
-## the subquery's plan must be visible in EXPLAIN
-#build
-#VALUES (1), ((SELECT 2))
-#----
+build
+VALUES (1), ((SELECT 2))
+----
+values
+ ├── columns: column1:2(int)
+ ├── tuple [type=tuple{int}]
+ │    └── const: 1 [type=int]
+ └── tuple [type=tuple{int}]
+      └── subquery [type=int]
+           ├── project
+           │    ├── columns: column1:1(int)
+           │    ├── values
+           │    │    └── tuple [type=tuple{}]
+           │    └── projections
+           │         └── const: 2 [type=int]
+           └── variable: column1 [type=int]

--- a/pkg/sql/opt/optbuilder/testdata/where
+++ b/pkg/sql/opt/optbuilder/testdata/where
@@ -49,14 +49,51 @@ select
       └── tuple [type=tuple{int}]
            └── const: 6 [type=int]
 
-# TODO(rytaft) subqueries not yet implemented.
-#build
-#SELECT * FROM kv WHERE k IN (SELECT k FROM kv)
-#----
-#
-#build
-#SELECT * FROM kv WHERE (k,v) IN (SELECT * FROM kv)
-#----
+build
+SELECT * FROM kv WHERE k IN (SELECT k FROM kv)
+----
+select
+ ├── columns: k:1(int!null) v:2(int)
+ ├── scan kv
+ │    └── columns: kv.k:1(int!null) kv.v:2(int)
+ └── any [type=bool]
+      └── project
+           ├── columns: column5:5(bool)
+           ├── project
+           │    ├── columns: kv.k:3(int!null)
+           │    ├── scan kv
+           │    │    └── columns: kv.k:3(int!null) kv.v:4(int)
+           │    └── projections
+           │         └── variable: kv.k [type=int]
+           └── projections
+                └── eq [type=bool]
+                     ├── variable: kv.k [type=int]
+                     └── variable: kv.k [type=int]
+
+build
+SELECT * FROM kv WHERE (k,v) IN (SELECT * FROM kv)
+----
+select
+ ├── columns: k:1(int!null) v:2(int)
+ ├── scan kv
+ │    └── columns: kv.k:1(int!null) kv.v:2(int)
+ └── any [type=bool]
+      └── project
+           ├── columns: column6:6(bool)
+           ├── project
+           │    ├── columns: column5:5(tuple{int, int})
+           │    ├── scan kv
+           │    │    └── columns: kv.k:3(int!null) kv.v:4(int)
+           │    └── projections
+           │         └── tuple [type=tuple{int, int}]
+           │              ├── variable: kv.k [type=int]
+           │              └── variable: kv.v [type=int]
+           └── projections
+                └── eq [type=bool]
+                     ├── tuple [type=tuple{int, int}]
+                     │    ├── variable: kv.k [type=int]
+                     │    └── variable: kv.v [type=int]
+                     └── variable: column5 [type=tuple{int, int}]
 
 build
 SELECT * FROM kv WHERE nonexistent = 1

--- a/pkg/sql/opt/optbuilder/values.go
+++ b/pkg/sql/opt/optbuilder/values.go
@@ -53,6 +53,7 @@ func (b *Builder) buildValuesClause(
 		}
 
 		for i, expr := range tuple.Exprs {
+			b.assertNoAggregationOrWindowing(expr, "VALUES")
 			texpr := inScope.resolveType(expr, types.Any)
 			typ := texpr.ResolvedType()
 			elems[i] = b.buildScalar(texpr, inScope)


### PR DESCRIPTION
This PR consists of two commits for ease of reviewing:

1. New test cases for LIMIT and subqueries.
2. Some fixes to bugs that were uncovered by the new test cases.
