### PR TITLE
sql: fix arrays when OID wrapping required

### DIFF
--- a/pkg/sql/sqlbase/structured.go
+++ b/pkg/sql/sqlbase/structured.go
@@ -2277,7 +2277,10 @@ func DatumTypeToColumnSemanticType(ptyp types.T) (ColumnType_SemanticType, error
 		if ptyp.FamilyEqual(types.FamCollatedString) {
 			return ColumnType_COLLATEDSTRING, nil
 		}
-		return -1, pgerror.NewErrorf(pgerror.CodeFeatureNotSupportedError, "unsupported result type: %s", ptyp)
+		if wrapper, ok := ptyp.(types.TOidWrapper); ok {
+			return DatumTypeToColumnSemanticType(wrapper.T)
+		}
+		return -1, pgerror.NewErrorf(pgerror.CodeFeatureNotSupportedError, "unsupported result type: %s, %T, %+v", ptyp, ptyp, ptyp)
 	}
 }
 

--- a/pkg/sql/sqlbase/table.go
+++ b/pkg/sql/sqlbase/table.go
@@ -1922,7 +1922,9 @@ func encodeArray(d *tree.DArray, scratch []byte) ([]byte, error) {
 		return scratch, err
 	}
 	scratch = scratch[0:0]
-	elementType, err := parserTypeToEncodingType(d.ParamTyp)
+	unwrapped := types.UnwrapType(d.ParamTyp)
+	elementType, err := parserTypeToEncodingType(unwrapped)
+
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Fixes #24055.

This was breaking arrays with Npgsql.

🔬🐶 on the C# stuff.

Release note (bug fix): Fixed a bug involving Npgsql and array values.