### PR TITLE
opt: Add Max1Row operator for subqueries

### DIFF
--- a/pkg/sql/opt/memo/logical_props_factory.go
+++ b/pkg/sql/opt/memo/logical_props_factory.go
@@ -67,7 +67,7 @@ func (f logicalPropsFactory) constructRelationalProps(ev ExprView) LogicalProps 
 	case opt.GroupByOp:
 		return f.constructGroupByProps(ev)
 
-	case opt.LimitOp, opt.OffsetOp:
+	case opt.LimitOp, opt.OffsetOp, opt.Max1RowOp:
 		return f.passThroughRelationalProps(ev, 0 /* childIdx */)
 	}
 

--- a/pkg/sql/opt/operator.og.go
+++ b/pkg/sql/opt/operator.og.go
@@ -182,6 +182,11 @@ const (
 	// conjunction with Limit.
 	OffsetOp
 
+	// Max1RowOp is an operator which enforces that its input must return at most one
+	// row. It is used as input to the Subquery operator. See the comment above
+	// Subquery for more details.
+	Max1RowOp
+
 	// ------------------------------------------------------------
 	// Scalar Operators
 	// ------------------------------------------------------------
@@ -212,12 +217,17 @@ const (
 	//    ==> `NOT Any(SELECT NOT(<var> <comp> x) FROM (<subquery>) AS q(x))`
 	// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 	//
-	// The Input field contains the subquery itself, and the Projection field
+	// The Input field contains the subquery itself, which should be wrapped in a
+	// Max1Row operator to enforce that the subquery can return at most one row
+	// (Max1Row may be removed by the optimizer later if it can determine statically
+	// that the subquery will always return at most one row). The Projection field
 	// contains a single column representing the output of the subquery. For
 	// example, `(SELECT 1, 'a')` would be represented by the following structure:
 	//
 	// (Subquery
-	//   (Project (Values (Tuple)) (Projections (Tuple (Const 1) (Const 'a'))))
+	//   (Max1Row
+	//     (Project (Values (Tuple)) (Projections (Tuple (Const 1) (Const 'a'))))
+	//   )
 	//   (Variable 3)
 	// )
 	//
@@ -437,9 +447,9 @@ const (
 	NumOperators
 )
 
-const opNames = "unknownsortscanvaluesselectprojectinner-joinleft-joinright-joinfull-joinsemi-joinanti-joininner-join-applyleft-join-applyright-join-applyfull-join-applysemi-join-applyanti-join-applygroup-byunionintersectexceptunion-allintersect-allexcept-alllimitoffsetsubqueryanyvariableconstnulltruefalseplaceholdertupleprojectionsaggregationsexistsfiltersandornoteqltgtlegeneinnot-inlikenot-likei-likenot-i-likesimilar-tonot-similar-toreg-matchnot-reg-matchreg-i-matchnot-reg-i-matchisis-notcontainsbitandbitorbitxorplusminusmultdivfloor-divmodpowconcatl-shiftr-shiftfetch-valfetch-textfetch-val-pathfetch-text-pathunary-minusunary-complementcastcasewhenfunctioncoalesceunsupported-expr"
+const opNames = "unknownsortscanvaluesselectprojectinner-joinleft-joinright-joinfull-joinsemi-joinanti-joininner-join-applyleft-join-applyright-join-applyfull-join-applysemi-join-applyanti-join-applygroup-byunionintersectexceptunion-allintersect-allexcept-alllimitoffsetmax1-rowsubqueryanyvariableconstnulltruefalseplaceholdertupleprojectionsaggregationsexistsfiltersandornoteqltgtlegeneinnot-inlikenot-likei-likenot-i-likesimilar-tonot-similar-toreg-matchnot-reg-matchreg-i-matchnot-reg-i-matchisis-notcontainsbitandbitorbitxorplusminusmultdivfloor-divmodpowconcatl-shiftr-shiftfetch-valfetch-textfetch-val-pathfetch-text-pathunary-minusunary-complementcastcasewhenfunctioncoalesceunsupported-expr"
 
-var opIndexes = [...]uint32{0, 7, 11, 15, 21, 27, 34, 44, 53, 63, 72, 81, 90, 106, 121, 137, 152, 167, 182, 190, 195, 204, 210, 219, 232, 242, 247, 253, 261, 264, 272, 277, 281, 285, 290, 301, 306, 317, 329, 335, 342, 345, 347, 350, 352, 354, 356, 358, 360, 362, 364, 370, 374, 382, 388, 398, 408, 422, 431, 444, 455, 470, 472, 478, 486, 492, 497, 503, 507, 512, 516, 519, 528, 531, 534, 540, 547, 554, 563, 573, 587, 602, 613, 629, 633, 637, 641, 649, 657, 673}
+var opIndexes = [...]uint32{0, 7, 11, 15, 21, 27, 34, 44, 53, 63, 72, 81, 90, 106, 121, 137, 152, 167, 182, 190, 195, 204, 210, 219, 232, 242, 247, 253, 261, 269, 272, 280, 285, 289, 293, 298, 309, 314, 325, 337, 343, 350, 353, 355, 358, 360, 362, 364, 366, 368, 370, 372, 378, 382, 390, 396, 406, 416, 430, 439, 452, 463, 478, 480, 486, 494, 500, 505, 511, 515, 520, 524, 527, 536, 539, 542, 548, 555, 562, 571, 581, 595, 610, 621, 637, 641, 645, 649, 657, 665, 681}
 
 var EnforcerOperators = [...]Operator{
 	SortOp,
@@ -471,6 +481,7 @@ var RelationalOperators = [...]Operator{
 	ExceptAllOp,
 	LimitOp,
 	OffsetOp,
+	Max1RowOp,
 }
 
 var JoinOperators = [...]Operator{

--- a/pkg/sql/opt/ops/relational.opt
+++ b/pkg/sql/opt/ops/relational.opt
@@ -302,3 +302,11 @@ define Offset {
     Offset   Expr
     Ordering Ordering
 }
+
+# Max1Row is an operator which enforces that its input must return at most one
+# row. It is used as input to the Subquery operator. See the comment above
+# Subquery for more details.
+[Relational]
+define Max1Row {
+    Input Expr
+}

--- a/pkg/sql/opt/ops/scalar.opt
+++ b/pkg/sql/opt/ops/scalar.opt
@@ -33,12 +33,17 @@
 #    ==> `NOT Any(SELECT NOT(<var> <comp> x) FROM (<subquery>) AS q(x))`
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 #
-# The Input field contains the subquery itself, and the Projection field
+# The Input field contains the subquery itself, which should be wrapped in a
+# Max1Row operator to enforce that the subquery can return at most one row
+# (Max1Row may be removed by the optimizer later if it can determine statically
+# that the subquery will always return at most one row). The Projection field
 # contains a single column representing the output of the subquery. For
 # example, `(SELECT 1, 'a')` would be represented by the following structure:
 #
 # (Subquery
-#   (Project (Values (Tuple)) (Projections (Tuple (Const 1) (Const 'a'))))
+#   (Max1Row
+#     (Project (Values (Tuple)) (Projections (Tuple (Const 1) (Const 'a'))))
+#   )
 #   (Variable 3)
 # )
 #

--- a/pkg/sql/opt/optbuilder/subquery.go
+++ b/pkg/sql/opt/optbuilder/subquery.go
@@ -213,6 +213,12 @@ func (b *Builder) buildSingleRowSubquery(
 
 	out, outScope = b.buildSubqueryProjection(s, inScope)
 	v := b.factory.ConstructVariable(b.factory.InternPrivate(outScope.cols[0].id))
+
+	// Wrap the subquery in a Max1Row operator to enforce that it should return
+	// at most one row. Max1Row may be removed by the optimizer later if it can
+	// prove statically that the subquery always returns at most one row.
+	out = b.factory.ConstructMax1Row(out)
+
 	out = b.factory.ConstructSubquery(out, v)
 	return out, outScope
 }

--- a/pkg/sql/opt/optbuilder/testdata/subquery
+++ b/pkg/sql/opt/optbuilder/testdata/subquery
@@ -11,12 +11,14 @@ project
  │    └── tuple [type=tuple{}]
  └── projections
       └── subquery [type=int]
-           ├── project
+           ├── max1-row
            │    ├── columns: column1:1(int)
-           │    ├── values
-           │    │    └── tuple [type=tuple{}]
-           │    └── projections
-           │         └── const: 1 [type=int]
+           │    └── project
+           │         ├── columns: column1:1(int)
+           │         ├── values
+           │         │    └── tuple [type=tuple{}]
+           │         └── projections
+           │              └── const: 1 [type=int]
            └── variable: column1 [type=int]
 
 build
@@ -79,12 +81,14 @@ project
       └── plus [type=int]
            ├── const: 1 [type=int]
            └── subquery [type=int]
-                ├── project
+                ├── max1-row
                 │    ├── columns: column1:1(int)
-                │    ├── values
-                │    │    └── tuple [type=tuple{}]
-                │    └── projections
-                │         └── const: 1 [type=int]
+                │    └── project
+                │         ├── columns: column1:1(int)
+                │         ├── values
+                │         │    └── tuple [type=tuple{}]
+                │         └── projections
+                │              └── const: 1 [type=int]
                 └── variable: column1 [type=int]
 
 build
@@ -140,21 +144,23 @@ project
            │    ├── const: 2 [type=int]
            │    └── const: 3 [type=int]
            └── subquery [type=tuple{int, int, int}]
-                ├── project
+                ├── max1-row
                 │    ├── columns: column4:4(tuple{int, int, int})
-                │    ├── project
-                │    │    ├── columns: column1:1(int) column2:2(int) column3:3(int)
-                │    │    ├── values
-                │    │    │    └── tuple [type=tuple{}]
-                │    │    └── projections
-                │    │         ├── const: 1 [type=int]
-                │    │         ├── const: 2 [type=int]
-                │    │         └── const: 3 [type=int]
-                │    └── projections
-                │         └── tuple [type=tuple{int, int, int}]
-                │              ├── variable: column1 [type=int]
-                │              ├── variable: column2 [type=int]
-                │              └── variable: column3 [type=int]
+                │    └── project
+                │         ├── columns: column4:4(tuple{int, int, int})
+                │         ├── project
+                │         │    ├── columns: column1:1(int) column2:2(int) column3:3(int)
+                │         │    ├── values
+                │         │    │    └── tuple [type=tuple{}]
+                │         │    └── projections
+                │         │         ├── const: 1 [type=int]
+                │         │         ├── const: 2 [type=int]
+                │         │         └── const: 3 [type=int]
+                │         └── projections
+                │              └── tuple [type=tuple{int, int, int}]
+                │                   ├── variable: column1 [type=int]
+                │                   ├── variable: column2 [type=int]
+                │                   └── variable: column3 [type=int]
                 └── variable: column4 [type=tuple{int, int, int}]
 
 build
@@ -171,21 +177,23 @@ project
            │    ├── const: 2 [type=int]
            │    └── const: 3 [type=int]
            └── subquery [type=tuple{int, int, int}]
-                ├── project
+                ├── max1-row
                 │    ├── columns: column4:4(tuple{int, int, int})
-                │    ├── project
-                │    │    ├── columns: column1:1(int) column2:2(int) column3:3(int)
-                │    │    ├── values
-                │    │    │    └── tuple [type=tuple{}]
-                │    │    └── projections
-                │    │         ├── const: 1 [type=int]
-                │    │         ├── const: 2 [type=int]
-                │    │         └── const: 3 [type=int]
-                │    └── projections
-                │         └── tuple [type=tuple{int, int, int}]
-                │              ├── variable: column1 [type=int]
-                │              ├── variable: column2 [type=int]
-                │              └── variable: column3 [type=int]
+                │    └── project
+                │         ├── columns: column4:4(tuple{int, int, int})
+                │         ├── project
+                │         │    ├── columns: column1:1(int) column2:2(int) column3:3(int)
+                │         │    ├── values
+                │         │    │    └── tuple [type=tuple{}]
+                │         │    └── projections
+                │         │         ├── const: 1 [type=int]
+                │         │         ├── const: 2 [type=int]
+                │         │         └── const: 3 [type=int]
+                │         └── projections
+                │              └── tuple [type=tuple{int, int, int}]
+                │                   ├── variable: column1 [type=int]
+                │                   ├── variable: column2 [type=int]
+                │                   └── variable: column3 [type=int]
                 └── variable: column4 [type=tuple{int, int, int}]
 
 build
@@ -198,38 +206,42 @@ project
  └── projections
       └── eq [type=bool]
            ├── subquery [type=tuple{int, int, int}]
-           │    ├── project
+           │    ├── max1-row
            │    │    ├── columns: column7:7(tuple{int, int, int})
-           │    │    ├── project
-           │    │    │    ├── columns: column1:1(int) column2:2(int) column3:3(int)
-           │    │    │    ├── values
-           │    │    │    │    └── tuple [type=tuple{}]
-           │    │    │    └── projections
-           │    │    │         ├── const: 1 [type=int]
-           │    │    │         ├── const: 2 [type=int]
-           │    │    │         └── const: 3 [type=int]
-           │    │    └── projections
-           │    │         └── tuple [type=tuple{int, int, int}]
-           │    │              ├── variable: column1 [type=int]
-           │    │              ├── variable: column2 [type=int]
-           │    │              └── variable: column3 [type=int]
+           │    │    └── project
+           │    │         ├── columns: column7:7(tuple{int, int, int})
+           │    │         ├── project
+           │    │         │    ├── columns: column1:1(int) column2:2(int) column3:3(int)
+           │    │         │    ├── values
+           │    │         │    │    └── tuple [type=tuple{}]
+           │    │         │    └── projections
+           │    │         │         ├── const: 1 [type=int]
+           │    │         │         ├── const: 2 [type=int]
+           │    │         │         └── const: 3 [type=int]
+           │    │         └── projections
+           │    │              └── tuple [type=tuple{int, int, int}]
+           │    │                   ├── variable: column1 [type=int]
+           │    │                   ├── variable: column2 [type=int]
+           │    │                   └── variable: column3 [type=int]
            │    └── variable: column7 [type=tuple{int, int, int}]
            └── subquery [type=tuple{int, int, int}]
-                ├── project
+                ├── max1-row
                 │    ├── columns: column8:8(tuple{int, int, int})
-                │    ├── project
-                │    │    ├── columns: column4:4(int) column5:5(int) column6:6(int)
-                │    │    ├── values
-                │    │    │    └── tuple [type=tuple{}]
-                │    │    └── projections
-                │    │         ├── const: 1 [type=int]
-                │    │         ├── const: 2 [type=int]
-                │    │         └── const: 3 [type=int]
-                │    └── projections
-                │         └── tuple [type=tuple{int, int, int}]
-                │              ├── variable: column4 [type=int]
-                │              ├── variable: column5 [type=int]
-                │              └── variable: column6 [type=int]
+                │    └── project
+                │         ├── columns: column8:8(tuple{int, int, int})
+                │         ├── project
+                │         │    ├── columns: column4:4(int) column5:5(int) column6:6(int)
+                │         │    ├── values
+                │         │    │    └── tuple [type=tuple{}]
+                │         │    └── projections
+                │         │         ├── const: 1 [type=int]
+                │         │         ├── const: 2 [type=int]
+                │         │         └── const: 3 [type=int]
+                │         └── projections
+                │              └── tuple [type=tuple{int, int, int}]
+                │                   ├── variable: column4 [type=int]
+                │                   ├── variable: column5 [type=int]
+                │                   └── variable: column6 [type=int]
                 └── variable: column8 [type=tuple{int, int, int}]
 
 build
@@ -252,12 +264,14 @@ project
                 └── projections
                      └── eq [type=bool]
                           ├── subquery [type=int]
-                          │    ├── project
+                          │    ├── max1-row
                           │    │    ├── columns: column2:2(int)
-                          │    │    ├── values
-                          │    │    │    └── tuple [type=tuple{}]
-                          │    │    └── projections
-                          │    │         └── const: 1 [type=int]
+                          │    │    └── project
+                          │    │         ├── columns: column2:2(int)
+                          │    │         ├── values
+                          │    │         │    └── tuple [type=tuple{}]
+                          │    │         └── projections
+                          │    │              └── const: 1 [type=int]
                           │    └── variable: column2 [type=int]
                           └── variable: column1 [type=int]
 
@@ -271,12 +285,14 @@ project
  └── projections
       └── in [type=bool]
            ├── subquery [type=int]
-           │    ├── project
+           │    ├── max1-row
            │    │    ├── columns: column1:1(int)
-           │    │    ├── values
-           │    │    │    └── tuple [type=tuple{}]
-           │    │    └── projections
-           │    │         └── const: 1 [type=int]
+           │    │    └── project
+           │    │         ├── columns: column1:1(int)
+           │    │         ├── values
+           │    │         │    └── tuple [type=tuple{}]
+           │    │         └── projections
+           │    │              └── const: 1 [type=int]
            │    └── variable: column1 [type=int]
            └── tuple [type=tuple{int}]
                 └── const: 1 [type=int]
@@ -318,19 +334,21 @@ project
                 └── projections
                      └── eq [type=bool]
                           ├── subquery [type=tuple{int, int}]
-                          │    ├── project
+                          │    ├── max1-row
                           │    │    ├── columns: column6:6(tuple{int, int})
-                          │    │    ├── project
-                          │    │    │    ├── columns: column3:3(int) column4:4(int)
-                          │    │    │    ├── values
-                          │    │    │    │    └── tuple [type=tuple{}]
-                          │    │    │    └── projections
-                          │    │    │         ├── const: 1 [type=int]
-                          │    │    │         └── const: 2 [type=int]
-                          │    │    └── projections
-                          │    │         └── tuple [type=tuple{int, int}]
-                          │    │              ├── variable: column3 [type=int]
-                          │    │              └── variable: column4 [type=int]
+                          │    │    └── project
+                          │    │         ├── columns: column6:6(tuple{int, int})
+                          │    │         ├── project
+                          │    │         │    ├── columns: column3:3(int) column4:4(int)
+                          │    │         │    ├── values
+                          │    │         │    │    └── tuple [type=tuple{}]
+                          │    │         │    └── projections
+                          │    │         │         ├── const: 1 [type=int]
+                          │    │         │         └── const: 2 [type=int]
+                          │    │         └── projections
+                          │    │              └── tuple [type=tuple{int, int}]
+                          │    │                   ├── variable: column3 [type=int]
+                          │    │                   └── variable: column4 [type=int]
                           │    └── variable: column6 [type=tuple{int, int}]
                           └── variable: column5 [type=tuple{int, int}]
 
@@ -348,19 +366,21 @@ project
  └── projections
       └── in [type=bool]
            ├── subquery [type=tuple{int, int}]
-           │    ├── project
+           │    ├── max1-row
            │    │    ├── columns: column3:3(tuple{int, int})
-           │    │    ├── project
-           │    │    │    ├── columns: column1:1(int) column2:2(int)
-           │    │    │    ├── values
-           │    │    │    │    └── tuple [type=tuple{}]
-           │    │    │    └── projections
-           │    │    │         ├── const: 1 [type=int]
-           │    │    │         └── const: 2 [type=int]
-           │    │    └── projections
-           │    │         └── tuple [type=tuple{int, int}]
-           │    │              ├── variable: column1 [type=int]
-           │    │              └── variable: column2 [type=int]
+           │    │    └── project
+           │    │         ├── columns: column3:3(tuple{int, int})
+           │    │         ├── project
+           │    │         │    ├── columns: column1:1(int) column2:2(int)
+           │    │         │    ├── values
+           │    │         │    │    └── tuple [type=tuple{}]
+           │    │         │    └── projections
+           │    │         │         ├── const: 1 [type=int]
+           │    │         │         └── const: 2 [type=int]
+           │    │         └── projections
+           │    │              └── tuple [type=tuple{int, int}]
+           │    │                   ├── variable: column1 [type=int]
+           │    │                   └── variable: column2 [type=int]
            │    └── variable: column3 [type=tuple{int, int}]
            └── tuple [type=tuple{tuple{int, int}}]
                 └── tuple [type=tuple{int, int}]
@@ -398,14 +418,16 @@ project
                 └── projections
                      └── eq [type=bool]
                           ├── subquery [type=tuple{int, int}]
-                          │    ├── project
+                          │    ├── max1-row
                           │    │    ├── columns: column3:3(tuple{int, int})
-                          │    │    ├── values
-                          │    │    │    └── tuple [type=tuple{}]
-                          │    │    └── projections
-                          │    │         └── tuple [type=tuple{int, int}]
-                          │    │              ├── const: 1 [type=int]
-                          │    │              └── const: 2 [type=int]
+                          │    │    └── project
+                          │    │         ├── columns: column3:3(tuple{int, int})
+                          │    │         ├── values
+                          │    │         │    └── tuple [type=tuple{}]
+                          │    │         └── projections
+                          │    │              └── tuple [type=tuple{int, int}]
+                          │    │                   ├── const: 1 [type=int]
+                          │    │                   └── const: 2 [type=int]
                           │    └── variable: column3 [type=tuple{int, int}]
                           └── variable: column4 [type=tuple{int, int}]
 
@@ -419,14 +441,16 @@ project
  └── projections
       └── in [type=bool]
            ├── subquery [type=tuple{int, int}]
-           │    ├── project
+           │    ├── max1-row
            │    │    ├── columns: column1:1(tuple{int, int})
-           │    │    ├── values
-           │    │    │    └── tuple [type=tuple{}]
-           │    │    └── projections
-           │    │         └── tuple [type=tuple{int, int}]
-           │    │              ├── const: 1 [type=int]
-           │    │              └── const: 2 [type=int]
+           │    │    └── project
+           │    │         ├── columns: column1:1(tuple{int, int})
+           │    │         ├── values
+           │    │         │    └── tuple [type=tuple{}]
+           │    │         └── projections
+           │    │              └── tuple [type=tuple{int, int}]
+           │    │                   ├── const: 1 [type=int]
+           │    │                   └── const: 2 [type=int]
            │    └── variable: column1 [type=tuple{int, int}]
            └── tuple [type=tuple{tuple{int, int}}]
                 └── tuple [type=tuple{int, int}]
@@ -459,19 +483,21 @@ project
                 └── projections
                      └── eq [type=bool]
                           ├── subquery [type=tuple{int, int}]
-                          │    ├── project
+                          │    ├── max1-row
                           │    │    ├── columns: column4:4(tuple{int, int})
-                          │    │    ├── project
-                          │    │    │    ├── columns: column2:2(int) column3:3(int)
-                          │    │    │    ├── values
-                          │    │    │    │    └── tuple [type=tuple{}]
-                          │    │    │    └── projections
-                          │    │    │         ├── const: 1 [type=int]
-                          │    │    │         └── const: 2 [type=int]
-                          │    │    └── projections
-                          │    │         └── tuple [type=tuple{int, int}]
-                          │    │              ├── variable: column2 [type=int]
-                          │    │              └── variable: column3 [type=int]
+                          │    │    └── project
+                          │    │         ├── columns: column4:4(tuple{int, int})
+                          │    │         ├── project
+                          │    │         │    ├── columns: column2:2(int) column3:3(int)
+                          │    │         │    ├── values
+                          │    │         │    │    └── tuple [type=tuple{}]
+                          │    │         │    └── projections
+                          │    │         │         ├── const: 1 [type=int]
+                          │    │         │         └── const: 2 [type=int]
+                          │    │         └── projections
+                          │    │              └── tuple [type=tuple{int, int}]
+                          │    │                   ├── variable: column2 [type=int]
+                          │    │                   └── variable: column3 [type=int]
                           │    └── variable: column4 [type=tuple{int, int}]
                           └── variable: column1 [type=tuple{int, int}]
 
@@ -497,14 +523,16 @@ project
                 └── projections
                      └── eq [type=bool]
                           ├── subquery [type=tuple{int, int}]
-                          │    ├── project
+                          │    ├── max1-row
                           │    │    ├── columns: column2:2(tuple{int, int})
-                          │    │    ├── values
-                          │    │    │    └── tuple [type=tuple{}]
-                          │    │    └── projections
-                          │    │         └── tuple [type=tuple{int, int}]
-                          │    │              ├── const: 1 [type=int]
-                          │    │              └── const: 2 [type=int]
+                          │    │    └── project
+                          │    │         ├── columns: column2:2(tuple{int, int})
+                          │    │         ├── values
+                          │    │         │    └── tuple [type=tuple{}]
+                          │    │         └── projections
+                          │    │              └── tuple [type=tuple{int, int}]
+                          │    │                   ├── const: 1 [type=int]
+                          │    │                   └── const: 2 [type=int]
                           │    └── variable: column2 [type=tuple{int, int}]
                           └── variable: column1 [type=tuple{int, int}]
 
@@ -780,12 +808,14 @@ project
  │    └── tuple [type=tuple{}]
  └── projections
       └── subquery [type=int]
-           ├── project
+           ├── max1-row
            │    ├── columns: abc.a:1(int!null)
-           │    ├── scan abc
-           │    │    └── columns: abc.a:1(int!null) abc.b:2(int) abc.c:3(int)
-           │    └── projections
-           │         └── variable: abc.a [type=int]
+           │    └── project
+           │         ├── columns: abc.a:1(int!null)
+           │         ├── scan abc
+           │         │    └── columns: abc.a:1(int!null) abc.b:2(int) abc.c:3(int)
+           │         └── projections
+           │              └── variable: abc.a [type=int]
            └── variable: abc.a [type=int]
 
 build
@@ -813,15 +843,17 @@ project
  │    └── tuple [type=tuple{}]
  └── projections
       └── subquery [type=int]
-           ├── project
+           ├── max1-row
            │    ├── columns: abc.a:1(int!null)
-           │    ├── select
-           │    │    ├── columns: abc.a:1(int!null) abc.b:2(int) abc.c:3(int)
-           │    │    ├── scan abc
-           │    │    │    └── columns: abc.a:1(int!null) abc.b:2(int) abc.c:3(int)
-           │    │    └── false [type=bool]
-           │    └── projections
-           │         └── variable: abc.a [type=int]
+           │    └── project
+           │         ├── columns: abc.a:1(int!null)
+           │         ├── select
+           │         │    ├── columns: abc.a:1(int!null) abc.b:2(int) abc.c:3(int)
+           │         │    ├── scan abc
+           │         │    │    └── columns: abc.a:1(int!null) abc.b:2(int) abc.c:3(int)
+           │         │    └── false [type=bool]
+           │         └── projections
+           │              └── variable: abc.a [type=int]
            └── variable: abc.a [type=int]
 
 build
@@ -832,12 +864,14 @@ values
  └── tuple [type=tuple{int, int}]
       ├── const: 1 [type=int]
       └── subquery [type=int]
-           ├── project
+           ├── max1-row
            │    ├── columns: column1:1(int)
-           │    ├── values
-           │    │    └── tuple [type=tuple{}]
-           │    └── projections
-           │         └── const: 2 [type=int]
+           │    └── project
+           │         ├── columns: column1:1(int)
+           │         ├── values
+           │         │    └── tuple [type=tuple{}]
+           │         └── projections
+           │              └── const: 2 [type=int]
            └── variable: column1 [type=int]
 
 build
@@ -899,17 +933,19 @@ select
  └── eq [type=bool]
       ├── variable: xyz.x [type=int]
       └── subquery [type=int]
-           ├── group-by
+           ├── max1-row
            │    ├── columns: column7:7(int)
-           │    ├── project
-           │    │    ├── columns: xyz.x:4(int!null)
-           │    │    ├── scan xyz
-           │    │    │    └── columns: xyz.x:4(int!null) xyz.y:5(int) xyz.z:6(int)
-           │    │    └── projections
-           │    │         └── variable: xyz.x [type=int]
-           │    └── aggregations
-           │         └── function: min [type=int]
-           │              └── variable: xyz.x [type=int]
+           │    └── group-by
+           │         ├── columns: column7:7(int)
+           │         ├── project
+           │         │    ├── columns: xyz.x:4(int!null)
+           │         │    ├── scan xyz
+           │         │    │    └── columns: xyz.x:4(int!null) xyz.y:5(int) xyz.z:6(int)
+           │         │    └── projections
+           │         │         └── variable: xyz.x [type=int]
+           │         └── aggregations
+           │              └── function: min [type=int]
+           │                   └── variable: xyz.x [type=int]
            └── variable: column7 [type=int]
 
 build
@@ -922,17 +958,19 @@ select
  └── eq [type=bool]
       ├── variable: xyz.x [type=int]
       └── subquery [type=int]
-           ├── group-by
+           ├── max1-row
            │    ├── columns: column7:7(int)
-           │    ├── project
-           │    │    ├── columns: xyz.x:4(int!null)
-           │    │    ├── scan xyz
-           │    │    │    └── columns: xyz.x:4(int!null) xyz.y:5(int) xyz.z:6(int)
-           │    │    └── projections
-           │    │         └── variable: xyz.x [type=int]
-           │    └── aggregations
-           │         └── function: max [type=int]
-           │              └── variable: xyz.x [type=int]
+           │    └── group-by
+           │         ├── columns: column7:7(int)
+           │         ├── project
+           │         │    ├── columns: xyz.x:4(int!null)
+           │         │    ├── scan xyz
+           │         │    │    └── columns: xyz.x:4(int!null) xyz.y:5(int) xyz.z:6(int)
+           │         │    └── projections
+           │         │         └── variable: xyz.x [type=int]
+           │         └── aggregations
+           │              └── function: max [type=int]
+           │                   └── variable: xyz.x [type=int]
            └── variable: column7 [type=int]
 
 exec-ddl
@@ -954,21 +992,23 @@ select
  └── eq [type=bool]
       ├── variable: kv.k [type=int]
       └── subquery [type=int]
-           ├── project
+           ├── max1-row
            │    ├── columns: kv.k:3(int!null)
-           │    ├── select
-           │    │    ├── columns: kv.k:3(int!null) kv.v:4(string)
-           │    │    ├── scan kv
-           │    │    │    └── columns: kv.k:3(int!null) kv.v:4(string)
-           │    │    └── eq [type=bool]
-           │    │         ├── tuple [type=tuple{int, string}]
-           │    │         │    ├── variable: kv.k [type=int]
-           │    │         │    └── variable: kv.v [type=string]
-           │    │         └── tuple [type=tuple{int, string}]
-           │    │              ├── const: 1 [type=int]
-           │    │              └── const: 'one' [type=string]
-           │    └── projections
-           │         └── variable: kv.k [type=int]
+           │    └── project
+           │         ├── columns: kv.k:3(int!null)
+           │         ├── select
+           │         │    ├── columns: kv.k:3(int!null) kv.v:4(string)
+           │         │    ├── scan kv
+           │         │    │    └── columns: kv.k:3(int!null) kv.v:4(string)
+           │         │    └── eq [type=bool]
+           │         │         ├── tuple [type=tuple{int, string}]
+           │         │         │    ├── variable: kv.k [type=int]
+           │         │         │    └── variable: kv.v [type=string]
+           │         │         └── tuple [type=tuple{int, string}]
+           │         │              ├── const: 1 [type=int]
+           │         │              └── const: 'one' [type=string]
+           │         └── projections
+           │              └── variable: kv.k [type=int]
            └── variable: kv.k [type=int]
 
 build
@@ -1301,17 +1341,19 @@ limit
  │    └── projections
  │         └── variable: xyz.x [type=int]
  └── subquery [type=int]
-      ├── project
+      ├── max1-row
       │    ├── columns: xyz.x:4(int!null)
-      │    ├── select
-      │    │    ├── columns: xyz.x:4(int!null) xyz.y:5(int) xyz.z:6(int)
-      │    │    ├── scan xyz
-      │    │    │    └── columns: xyz.x:4(int!null) xyz.y:5(int) xyz.z:6(int)
-      │    │    └── eq [type=bool]
-      │    │         ├── variable: xyz.x [type=int]
-      │    │         └── const: 1 [type=int]
-      │    └── projections
-      │         └── variable: xyz.x [type=int]
+      │    └── project
+      │         ├── columns: xyz.x:4(int!null)
+      │         ├── select
+      │         │    ├── columns: xyz.x:4(int!null) xyz.y:5(int) xyz.z:6(int)
+      │         │    ├── scan xyz
+      │         │    │    └── columns: xyz.x:4(int!null) xyz.y:5(int) xyz.z:6(int)
+      │         │    └── eq [type=bool]
+      │         │         ├── variable: xyz.x [type=int]
+      │         │         └── const: 1 [type=int]
+      │         └── projections
+      │              └── variable: xyz.x [type=int]
       └── variable: xyz.x [type=int]
 
 build
@@ -1329,17 +1371,19 @@ offset
  │    └── projections
  │         └── variable: xyz.x [type=int]
  └── subquery [type=int]
-      ├── project
+      ├── max1-row
       │    ├── columns: xyz.x:4(int!null)
-      │    ├── select
-      │    │    ├── columns: xyz.x:4(int!null) xyz.y:5(int) xyz.z:6(int)
-      │    │    ├── scan xyz
-      │    │    │    └── columns: xyz.x:4(int!null) xyz.y:5(int) xyz.z:6(int)
-      │    │    └── eq [type=bool]
-      │    │         ├── variable: xyz.x [type=int]
-      │    │         └── const: 1 [type=int]
-      │    └── projections
-      │         └── variable: xyz.x [type=int]
+      │    └── project
+      │         ├── columns: xyz.x:4(int!null)
+      │         ├── select
+      │         │    ├── columns: xyz.x:4(int!null) xyz.y:5(int) xyz.z:6(int)
+      │         │    ├── scan xyz
+      │         │    │    └── columns: xyz.x:4(int!null) xyz.y:5(int) xyz.z:6(int)
+      │         │    └── eq [type=bool]
+      │         │         ├── variable: xyz.x [type=int]
+      │         │         └── const: 1 [type=int]
+      │         └── projections
+      │              └── variable: xyz.x [type=int]
       └── variable: xyz.x [type=int]
 
 # check that residual filters are not expanded twice

--- a/pkg/sql/opt/xform/factory.og.go
+++ b/pkg/sql/opt/xform/factory.og.go
@@ -1301,6 +1301,26 @@ func (_f *Factory) ConstructOffset(
 	return _f.onConstruct(_f.mem.MemoizeNormExpr(memo.Expr(_offsetExpr)))
 }
 
+// ConstructMax1Row constructs an expression for the Max1Row operator.
+// Max1Row is an operator which enforces that its input must return at most one
+// row. It is used as input to the Subquery operator. See the comment above
+// Subquery for more details.
+func (_f *Factory) ConstructMax1Row(
+	input memo.GroupID,
+) memo.GroupID {
+	_max1RowExpr := memo.MakeMax1RowExpr(input)
+	_group := _f.mem.GroupByFingerprint(_max1RowExpr.Fingerprint())
+	if _group != 0 {
+		return _group
+	}
+
+	if !_f.o.allowOptimizations() {
+		return _f.mem.MemoizeNormExpr(memo.Expr(_max1RowExpr))
+	}
+
+	return _f.onConstruct(_f.mem.MemoizeNormExpr(memo.Expr(_max1RowExpr)))
+}
+
 // ConstructSubquery constructs an expression for the Subquery operator.
 // Subquery is a subquery in a single-row context such as
 // `SELECT 1 = (SELECT 1)` or `SELECT (1, 'a') = (SELECT 1, 'a')`.
@@ -1328,12 +1348,17 @@ func (_f *Factory) ConstructOffset(
 //    ==> `NOT Any(SELECT NOT(<var> <comp> x) FROM (<subquery>) AS q(x))`
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 //
-// The Input field contains the subquery itself, and the Projection field
+// The Input field contains the subquery itself, which should be wrapped in a
+// Max1Row operator to enforce that the subquery can return at most one row
+// (Max1Row may be removed by the optimizer later if it can determine statically
+// that the subquery will always return at most one row). The Projection field
 // contains a single column representing the output of the subquery. For
 // example, `(SELECT 1, 'a')` would be represented by the following structure:
 //
 // (Subquery
-//   (Project (Values (Tuple)) (Projections (Tuple (Const 1) (Const 'a'))))
+//   (Max1Row
+//     (Project (Values (Tuple)) (Projections (Tuple (Const 1) (Const 'a'))))
+//   )
 //   (Variable 3)
 // )
 //
@@ -4621,6 +4646,11 @@ func init() {
 	// OffsetOp
 	dynConstructLookup[opt.OffsetOp] = func(f *Factory, operands DynamicOperands) memo.GroupID {
 		return f.ConstructOffset(memo.GroupID(operands[0]), memo.GroupID(operands[1]), memo.PrivateID(operands[2]))
+	}
+
+	// Max1RowOp
+	dynConstructLookup[opt.Max1RowOp] = func(f *Factory, operands DynamicOperands) memo.GroupID {
+		return f.ConstructMax1Row(memo.GroupID(operands[0]))
 	}
 
 	// SubqueryOp


### PR DESCRIPTION
This commit adds a new `Max1Row` operator, which is used as input
to the `Subquery` operator to enforce that the subquery must return
at most one row. `Max1Row` may be removed by the optimizer later
(e.g., with normalization patterns) if the optimizer can determine
statically that the subquery will always return at most one row.
Removal of `Max1Row` allows other optimizations such as subquery
decorrelation to be correctly applied.

Release note: None