### PR TITLE
optbuilder: fix bug with subquery in WHERE clause

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/subquery
+++ b/pkg/sql/logictest/testdata/logic_test/subquery
@@ -525,3 +525,14 @@ SELECT * FROM  a WHERE CAST(COALESCE((SELECT 'a' FROM crdb_internal.zones LIMIT 
 query I
 SELECT * FROM a WHERE CAST(COALESCE((SELECT 'a'), (SELECT 'a')) AS bytea) < 'a'
 ----
+
+statement ok
+CREATE TABLE test (a INT PRIMARY KEY)
+
+statement ok
+CREATE TABLE test2(b INT PRIMARY KEY)
+
+# Regression test for #24225.
+query I
+SELECT * FROM test2 WHERE 0 = CASE WHEN true THEN (SELECT a FROM test LIMIT 1) ELSE 10 END
+----

--- a/pkg/sql/opt/optbuilder/scope.go
+++ b/pkg/sql/opt/optbuilder/scope.go
@@ -510,8 +510,8 @@ func (s *scope) VisitPre(expr tree.Expr) (recurse bool, newExpr tree.Expr) {
 
 	case *tree.Subquery:
 		if s.builder.AllowUnsupportedExpr {
-			// TODO(rytaft): Temporary fix for #24171 and #24170.
-			break
+			// TODO(rytaft): Temporary fix for #24171, #24170 and #24225.
+			return false, expr
 		}
 
 		if t.Exists {


### PR DESCRIPTION
This commit fixes a bug that was occuring when there was
a subquery inside another scalar expression in a WHERE clause.
Since the scalar builder attempts to resolve the type of each
scalar sub-expression, it was attempting to resolve the type
of the subquery as well. As part of the type resolution, the
builder walks through the query tree in scope.go and attempts
to resolve all names in each subtree. This commit prevents the
builder from walking into tree.Subquery expressions when
AllowUnsupportedExpr is true. Instead, it just passes the entire
tree.Subquery through as an unsupported expression.

Fixes #24225 

cc @jordanlewis 

Release note: None