### PR TITLE
kv: fill-in ResumeReason for backwards compatibility

### DIFF
--- a/pkg/roachpb/api.pb.go
+++ b/pkg/roachpb/api.pb.go
@@ -389,8 +389,9 @@ type ResponseHeader struct {
 	ResumeSpan *Span `protobuf:"bytes,4,opt,name=resume_span,json=resumeSpan" json:"resume_span,omitempty"`
 	// When resume_span is populated, this specifies the reason why the operation
 	// wasn't completed and needs to be resumed.
-	// This field appeared in v1.2. Responses from storage coming from older
-	// servers will not contain it, but the DistSender always fills it in.
+	// This field appeared in v2.0. Responses from storage coming from older
+	// servers will not contain it, but the conversion from a BatchResponse to a
+	// client.Result always fills it in.
 	ResumeReason ResponseHeader_ResumeReason `protobuf:"varint,7,opt,name=resume_reason,json=resumeReason,proto3,enum=cockroach.roachpb.ResponseHeader_ResumeReason" json:"resume_reason,omitempty"`
 	// The number of keys operated on.
 	NumKeys int64 `protobuf:"varint,5,opt,name=num_keys,json=numKeys,proto3" json:"num_keys,omitempty"`

--- a/pkg/roachpb/api.proto
+++ b/pkg/roachpb/api.proto
@@ -82,8 +82,9 @@ message ResponseHeader {
   Span resume_span = 4;
   // When resume_span is populated, this specifies the reason why the operation
   // wasn't completed and needs to be resumed.
-  // This field appeared in v1.2. Responses from storage coming from older
-  // servers will not contain it, but the DistSender always fills it in.
+  // This field appeared in v2.0. Responses from storage coming from older
+  // servers will not contain it, but the conversion from a BatchResponse to a
+  // client.Result always fills it in.
   ResumeReason resume_reason = 7;
 
   // The number of keys operated on.


### PR DESCRIPTION
The DistSender is supposed to fill-in a response's ResumeReason field in
cases where old nodes don't. It was failing to do so when taking a
particular fast-path, resulting in panics for responses that had a
ResumeSpan but were missing a ResumeReason.

Fixes #22370

Release note: Fix a crash while performing rolling-restarts.