### PR TITLE
opt: generate constraints for boolean scalars

### DIFF
--- a/pkg/sql/opt/constraint/constraint_set.go
+++ b/pkg/sql/opt/constraint/constraint_set.go
@@ -15,8 +15,7 @@
 package constraint
 
 import (
-	"bytes"
-	"fmt"
+	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 )
@@ -285,17 +284,20 @@ func (s *Set) undoAllocConstraint() {
 
 func (s *Set) String() string {
 	if s.IsUnconstrained() {
-		return "unconstrained\n"
+		return "unconstrained"
 	}
 	if s == Contradiction {
-		return "contradiction\n"
+		return "contradiction"
 	}
 
-	var buf bytes.Buffer
+	var b strings.Builder
 	for i := 0; i < s.Length(); i++ {
-		fmt.Fprintf(&buf, "%s\n", s.Constraint(i))
+		if i > 0 {
+			b.WriteString("; ")
+		}
+		b.WriteString(s.Constraint(i).String())
 	}
-	return buf.String()
+	return b.String()
 }
 
 // compareConstraintsByCols orders constraints by the indexes of their columns,

--- a/pkg/sql/opt/constraint/constraint_set_test.go
+++ b/pkg/sql/opt/constraint/constraint_set_test.go
@@ -29,7 +29,7 @@ func TestConstraintSetIntersect(t *testing.T) {
 	test := func(cs *Set, expected string) {
 		t.Helper()
 		if cs.String() != expected {
-			t.Errorf("\nexpected:\n%vactual:\n%v", expected, cs.String())
+			t.Errorf("\nexpected:\n%v\nactual:\n%v", expected, cs.String())
 		}
 	}
 
@@ -40,93 +40,93 @@ func TestConstraintSetIntersect(t *testing.T) {
 	var c Constraint
 	c.InitSingleSpan(kc1, &data.spGt20)
 	gt20 := SingleConstraint(&c)
-	test(gt20, "/1: (/20 - ]\n")
+	test(gt20, "/1: (/20 - ]")
 
 	// @1 <= 40
 	le40 := SingleSpanConstraint(kc1, &data.spLe40)
-	test(le40, "/1: [ - /40]\n")
+	test(le40, "/1: [ - /40]")
 
 	// @1 > 20 AND @1 <= 40
 	range2040 := gt20.Intersect(evalCtx, le40)
-	test(range2040, "/1: (/20 - /40]\n")
+	test(range2040, "/1: (/20 - /40]")
 	range2040 = le40.Intersect(evalCtx, gt20)
-	test(range2040, "/1: (/20 - /40]\n")
+	test(range2040, "/1: (/20 - /40]")
 
 	// Include constraint on multiple columns.
 	// (@1, @2) >= (10, 15)
 	gt1015 := SingleSpanConstraint(kc12, &data.spGe1015)
-	test(gt1015, "/1/2: [/10/15 - ]\n")
+	test(gt1015, "/1/2: [/10/15 - ]")
 
 	// (@1, @2) >= (10, 15) AND @1 <= 40
 	multi2 := le40.Intersect(evalCtx, gt1015)
 	test(multi2, ""+
-		"/1: [ - /40]\n"+
-		"/1/2: [/10/15 - ]\n")
+		"/1: [ - /40]; "+
+		"/1/2: [/10/15 - ]")
 
 	multi2 = gt1015.Intersect(evalCtx, le40)
 	test(multi2, ""+
-		"/1: [ - /40]\n"+
-		"/1/2: [/10/15 - ]\n")
+		"/1: [ - /40]; "+
+		"/1/2: [/10/15 - ]")
 
 	// (@1, @2) >= (10, 15) AND @1 <= 40 AND @2 < 80
 	lt80 := SingleSpanConstraint(kc2, &data.spLt80)
 	multi3 := lt80.Intersect(evalCtx, multi2)
 	test(multi3, ""+
-		"/1: [ - /40]\n"+
-		"/1/2: [/10/15 - ]\n"+
-		"/2: [ - /80)\n")
+		"/1: [ - /40]; "+
+		"/1/2: [/10/15 - ]; "+
+		"/2: [ - /80)")
 
 	multi3 = multi2.Intersect(evalCtx, lt80)
 	test(multi3, ""+
-		"/1: [ - /40]\n"+
-		"/1/2: [/10/15 - ]\n"+
-		"/2: [ - /80)\n")
+		"/1: [ - /40]; "+
+		"/1/2: [/10/15 - ]; "+
+		"/2: [ - /80)")
 
 	// Mismatched number of constraints in each set.
 	eq10 := SingleSpanConstraint(kc1, &data.spEq10)
 	mismatched := eq10.Intersect(evalCtx, multi3)
 	test(mismatched, ""+
-		"/1: [/10 - /10]\n"+
-		"/1/2: [/10/15 - ]\n"+
-		"/2: [ - /80)\n")
+		"/1: [/10 - /10]; "+
+		"/1/2: [/10/15 - ]; "+
+		"/2: [ - /80)")
 
 	mismatched = multi3.Intersect(evalCtx, eq10)
 	test(mismatched, ""+
-		"/1: [/10 - /10]\n"+
-		"/1/2: [/10/15 - ]\n"+
-		"/2: [ - /80)\n")
+		"/1: [/10 - /10]; "+
+		"/1/2: [/10/15 - ]; "+
+		"/2: [ - /80)")
 
 	// Multiple intersecting constraints on different columns.
 	diffCols := eq10.Intersect(evalCtx, SingleSpanConstraint(kc2, &data.spGt20))
 	res := diffCols.Intersect(evalCtx, multi3)
 	test(res, ""+
-		"/1: [/10 - /10]\n"+
-		"/1/2: [/10/15 - ]\n"+
-		"/2: (/20 - /80)\n")
+		"/1: [/10 - /10]; "+
+		"/1/2: [/10/15 - ]; "+
+		"/2: (/20 - /80)")
 
 	res = multi3.Intersect(evalCtx, diffCols)
 	test(res, ""+
-		"/1: [/10 - /10]\n"+
-		"/1/2: [/10/15 - ]\n"+
-		"/2: (/20 - /80)\n")
+		"/1: [/10 - /10]; "+
+		"/1/2: [/10/15 - ]; "+
+		"/2: (/20 - /80)")
 
 	// Intersection results in Contradiction.
 	res = eq10.Intersect(evalCtx, gt20)
-	test(res, "contradiction\n")
+	test(res, "contradiction")
 	res = gt20.Intersect(evalCtx, eq10)
-	test(res, "contradiction\n")
+	test(res, "contradiction")
 
 	// Intersect with Unconstrained (identity op).
 	res = range2040.Intersect(evalCtx, Unconstrained)
-	test(res, "/1: (/20 - /40]\n")
+	test(res, "/1: (/20 - /40]")
 	res = Unconstrained.Intersect(evalCtx, range2040)
-	test(res, "/1: (/20 - /40]\n")
+	test(res, "/1: (/20 - /40]")
 
 	// Intersect with Contradiction (always contradiction).
 	res = eq10.Intersect(evalCtx, Contradiction)
-	test(res, "contradiction\n")
+	test(res, "contradiction")
 	res = Contradiction.Intersect(evalCtx, eq10)
-	test(res, "contradiction\n")
+	test(res, "contradiction")
 }
 
 func TestConstraintSetUnion(t *testing.T) {
@@ -146,39 +146,39 @@ func TestConstraintSetUnion(t *testing.T) {
 	// Simple OR case.
 	// @1 > 20
 	gt20 := SingleSpanConstraint(kc1, &data.spGt20)
-	test(gt20, "/1: (/20 - ]\n")
+	test(gt20, "/1: (/20 - ]")
 
 	// @1 = 10
 	eq10 := SingleSpanConstraint(kc1, &data.spEq10)
-	test(eq10, "/1: [/10 - /10]\n")
+	test(eq10, "/1: [/10 - /10]")
 
 	// @1 > 20 OR @1 = 10
 	gt20eq10 := gt20.Union(evalCtx, eq10)
-	test(gt20eq10, "/1: [/10 - /10] (/20 - ]\n")
+	test(gt20eq10, "/1: [/10 - /10] (/20 - ]")
 	gt20eq10 = eq10.Union(evalCtx, gt20)
-	test(gt20eq10, "/1: [/10 - /10] (/20 - ]\n")
+	test(gt20eq10, "/1: [/10 - /10] (/20 - ]")
 
 	// Combine constraints that result in full span and unconstrained result.
 	// @1 > 20 OR @1 = 10 OR @1 <= 40
 	le40 := SingleSpanConstraint(kc1, &data.spLe40)
 	res := gt20eq10.Union(evalCtx, le40)
-	test(res, "unconstrained\n")
+	test(res, "unconstrained")
 	res = le40.Union(evalCtx, gt20eq10)
-	test(res, "unconstrained\n")
+	test(res, "unconstrained")
 
 	// Include constraint on multiple columns and union with itself.
 	// (@1, @2) >= (10, 15)
 	gt1015 := SingleSpanConstraint(kc12, &data.spGe1015)
 	res = gt1015.Union(evalCtx, gt1015)
-	test(res, "/1/2: [/10/15 - ]\n")
+	test(res, "/1/2: [/10/15 - ]")
 
 	// Union incompatible constraints (both are discarded).
 	// (@1, @2) >= (10, 15) OR @2 < 80
 	lt80 := SingleSpanConstraint(kc2, &data.spLt80)
 	res = gt1015.Union(evalCtx, lt80)
-	test(res, "unconstrained\n")
+	test(res, "unconstrained")
 	res = lt80.Union(evalCtx, gt1015)
-	test(res, "unconstrained\n")
+	test(res, "unconstrained")
 
 	// Union two sets with multiple and differing numbers of constraints.
 	// ((@1, @2) >= (10, 15) AND @2 < 80 AND @1 > 20) OR (@1 = 10 AND @2 = 80)
@@ -190,12 +190,12 @@ func TestConstraintSetUnion(t *testing.T) {
 
 	res = multi3.Union(evalCtx, multi2)
 	test(res, ""+
-		"/1: [/10 - /10] (/20 - ]\n"+
-		"/2: [ - /80]\n")
+		"/1: [/10 - /10] (/20 - ]; "+
+		"/2: [ - /80]")
 	res = multi2.Union(evalCtx, multi3)
 	test(res, ""+
-		"/1: [/10 - /10] (/20 - ]\n"+
-		"/2: [ - /80]\n")
+		"/1: [/10 - /10] (/20 - ]; "+
+		"/2: [ - /80]")
 
 	// Do same as previous, but in different order so that discarded constraint
 	// is at end of list rather than beginning.
@@ -205,24 +205,24 @@ func TestConstraintSetUnion(t *testing.T) {
 
 	res = multi3.Union(evalCtx, multi2)
 	test(res, ""+
-		"/1: [/10 - /10] (/20 - ]\n"+
-		"/2: [ - /80]\n")
+		"/1: [/10 - /10] (/20 - ]; "+
+		"/2: [ - /80]")
 	res = multi2.Union(evalCtx, multi3)
 	test(res, ""+
-		"/1: [/10 - /10] (/20 - ]\n"+
-		"/2: [ - /80]\n")
+		"/1: [/10 - /10] (/20 - ]; "+
+		"/2: [ - /80]")
 
 	// Union with Unconstrained (always unconstrained).
 	res = gt20.Union(evalCtx, Unconstrained)
-	test(res, "unconstrained\n")
+	test(res, "unconstrained")
 	res = Unconstrained.Union(evalCtx, gt20)
-	test(res, "unconstrained\n")
+	test(res, "unconstrained")
 
 	// Union with Contradiction (identity op).
 	res = eq10.Union(evalCtx, Contradiction)
-	test(res, "/1: [/10 - /10]\n")
+	test(res, "/1: [/10 - /10]")
 	res = Contradiction.Union(evalCtx, eq10)
-	test(res, "/1: [/10 - /10]\n")
+	test(res, "/1: [/10 - /10]")
 }
 
 type spanTestData struct {

--- a/pkg/sql/opt/memo/constraint_builder.go
+++ b/pkg/sql/opt/memo/constraint_builder.go
@@ -1,0 +1,148 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package memo
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/sql/opt"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/constraint"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
+)
+
+// Convenience aliases to avoid the constraint prefix everywhere.
+const includeBoundary = constraint.IncludeBoundary
+const excludeBoundary = constraint.ExcludeBoundary
+
+var emptyKey = constraint.EmptyKey
+var unconstrained = constraint.Unconstrained
+
+// constraintsBuilder is used to create constraints (constraint.Set) from
+// boolean scalar expressions. The constraints are stored in the logical
+// properties; in certain cases, they become constraints for relational
+// operators (e.g. Select). They can also be used to transfer over conditions
+// between the two sides of a join.
+//
+// A constraint is "tight" if it is exactly equivalent to the expression. A
+// constraint that is not tight is weaker than the expression.
+type constraintsBuilder struct {
+	md      *opt.Metadata
+	evalCtx *tree.EvalContext
+}
+
+func (cb *constraintsBuilder) buildSingleColumnConstraint(
+	col opt.ColumnID, op opt.Operator, val ExprView,
+) (_ *constraint.Set, tight bool) {
+	// TODO(radu): handle IN
+
+	if val.IsConstValue() {
+		return cb.buildSingleColumnConstraintConst(col, op, ExtractConstDatum(val))
+	}
+
+	// TODO(radu): try to deduce a not-NULL constraint.
+
+	return unconstrained, false
+}
+
+func (cb *constraintsBuilder) buildSingleColumnConstraintConst(
+	col opt.ColumnID, op opt.Operator, datum tree.Datum,
+) (_ *constraint.Set, tight bool) {
+	if !cb.verifyType(col, datum.ResolvedType()) {
+		return unconstrained, false
+	}
+	if datum == tree.DNull {
+		// TODO(radu): handle NULL datum
+		return unconstrained, false
+	}
+
+	switch op {
+	case opt.EqOp, opt.IsOp:
+		return cb.eqSpan(col, datum), true
+
+	case opt.LtOp, opt.GtOp, opt.LeOp, opt.GeOp:
+		startKey, startBoundary := constraint.MakeKey(tree.DNull), excludeBoundary
+		endKey, endBoundary := emptyKey, includeBoundary
+		k := constraint.MakeKey(datum)
+		switch op {
+		case opt.LtOp:
+			endKey, endBoundary = k, excludeBoundary
+		case opt.LeOp:
+			endKey, endBoundary = k, includeBoundary
+		case opt.GtOp:
+			startKey, startBoundary = k, excludeBoundary
+		case opt.GeOp:
+			startKey, startBoundary = k, includeBoundary
+		}
+
+		return cb.singleSpan(col, startKey, startBoundary, endKey, endBoundary), true
+
+		// TODO(radu): handle other ops.
+	}
+	return unconstrained, false
+}
+
+func (cb *constraintsBuilder) buildConstraints(ev ExprView) (_ *constraint.Set, tight bool) {
+	// TODO(radu): handle const bool value.
+
+	switch ev.Operator() {
+	case opt.AndOp, opt.FiltersOp:
+		c, tight := cb.buildConstraints(ev.Child(0))
+		for i := 1; i < ev.ChildCount(); i++ {
+			ci, tighti := cb.buildConstraints(ev.Child(i))
+			c = c.Intersect(cb.evalCtx, ci)
+			tight = tight && tighti
+		}
+		return c, tight
+	}
+
+	if ev.ChildCount() < 2 {
+		return unconstrained, false
+	}
+
+	child0, child1 := ev.Child(0), ev.Child(1)
+	// Check for an operation where the left-hand side is an
+	// indexed var for this column.
+	if child0.Operator() == opt.VariableOp {
+		return cb.buildSingleColumnConstraint(child0.Private().(opt.ColumnID), ev.Operator(), child1)
+	}
+	return unconstrained, false
+}
+
+func (cb *constraintsBuilder) singleSpan(
+	col opt.ColumnID,
+	start constraint.Key,
+	startBoundary constraint.SpanBoundary,
+	end constraint.Key,
+	endBoundary constraint.SpanBoundary,
+) *constraint.Set {
+	var span constraint.Span
+	span.Init(start, startBoundary, end, endBoundary)
+	keyCtx := constraint.KeyContext{EvalCtx: cb.evalCtx}
+	keyCtx.Columns.InitSingle(opt.MakeOrderingColumn(col, false /* descending */))
+	span.PreferInclusive(&keyCtx)
+	return constraint.SingleSpanConstraint(&keyCtx, &span)
+}
+
+// eqSpan constrains a column to a single value (which can be DNull).
+func (cb *constraintsBuilder) eqSpan(col opt.ColumnID, value tree.Datum) *constraint.Set {
+	key := constraint.MakeKey(value)
+	return cb.singleSpan(col, key, includeBoundary, key, includeBoundary)
+}
+
+// verifyType checks that the type of column matches the given type. We disallow
+// mixed-type comparisons because if they become index constraints, we would
+// generate incorrect encodings (#4313).
+func (cb *constraintsBuilder) verifyType(col opt.ColumnID, typ types.T) bool {
+	return typ == types.Unknown || cb.md.ColumnType(col).Equivalent(typ)
+}

--- a/pkg/sql/opt/memo/logical_props.go
+++ b/pkg/sql/opt/memo/logical_props.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/constraint"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
 	"github.com/cockroachdb/cockroach/pkg/util/treeprinter"
 )
@@ -115,6 +116,16 @@ type ScalarProps struct {
 	// b.y columns are not outer columns on the EXISTS expression, they *are*
 	// outer columns on the inner WHERE condition.
 	OuterCols opt.ColSet
+
+	// Constraints is the set of constraints deduced from a boolean expression.
+	// For the expression to be true, all constraints in the set must be
+	// satisfied. Unset for non-boolean scalars.
+	Constraints *constraint.Set
+
+	// TightConstraints is true if the expression is exactly equivalent to the
+	// constraints. If it is false, the constraints are weaker than the
+	// expression.
+	TightConstraints bool
 }
 
 // OuterCols is a helper method that returns either the relational or scalar

--- a/pkg/sql/opt/memo/testdata/logprops/constraints
+++ b/pkg/sql/opt/memo/testdata/logprops/constraints
@@ -1,0 +1,238 @@
+exec-ddl
+CREATE TABLE a (x INT PRIMARY KEY, y INT)
+----
+TABLE a
+ ├── x int not null
+ ├── y int
+ └── INDEX primary
+      └── x int not null
+
+exec-ddl
+CREATE TABLE kuv (k INT PRIMARY KEY, u FLOAT, v STRING)
+----
+TABLE kuv
+ ├── k int not null
+ ├── u float
+ ├── v string
+ └── INDEX primary
+      └── k int not null
+
+opt
+SELECT * FROM a WHERE x > 1
+----
+select
+ ├── columns: x:1(int!null) y:2(int)
+ ├── stats: [rows=100]
+ ├── scan a
+ │    ├── columns: a.x:1(int!null) a.y:2(int)
+ │    └── stats: [rows=1000]
+ └── filters [type=bool, outer=(1), constraints=(/1: [/2 - ]; tight)]
+      └── gt [type=bool, outer=(1), constraints=(/1: [/2 - ]; tight)]
+           ├── variable: a.x [type=int, outer=(1)]
+           └── const: 1 [type=int]
+
+opt
+SELECT * FROM a WHERE x >= 1
+----
+select
+ ├── columns: x:1(int!null) y:2(int)
+ ├── stats: [rows=100]
+ ├── scan a
+ │    ├── columns: a.x:1(int!null) a.y:2(int)
+ │    └── stats: [rows=1000]
+ └── filters [type=bool, outer=(1), constraints=(/1: [/1 - ]; tight)]
+      └── ge [type=bool, outer=(1), constraints=(/1: [/1 - ]; tight)]
+           ├── variable: a.x [type=int, outer=(1)]
+           └── const: 1 [type=int]
+
+opt
+SELECT * FROM a WHERE x < 1
+----
+select
+ ├── columns: x:1(int!null) y:2(int)
+ ├── stats: [rows=100]
+ ├── scan a
+ │    ├── columns: a.x:1(int!null) a.y:2(int)
+ │    └── stats: [rows=1000]
+ └── filters [type=bool, outer=(1), constraints=(/1: (/NULL - /0]; tight)]
+      └── lt [type=bool, outer=(1), constraints=(/1: (/NULL - /0]; tight)]
+           ├── variable: a.x [type=int, outer=(1)]
+           └── const: 1 [type=int]
+
+opt
+SELECT * FROM a WHERE x <= 1
+----
+select
+ ├── columns: x:1(int!null) y:2(int)
+ ├── stats: [rows=100]
+ ├── scan a
+ │    ├── columns: a.x:1(int!null) a.y:2(int)
+ │    └── stats: [rows=1000]
+ └── filters [type=bool, outer=(1), constraints=(/1: (/NULL - /1]; tight)]
+      └── le [type=bool, outer=(1), constraints=(/1: (/NULL - /1]; tight)]
+           ├── variable: a.x [type=int, outer=(1)]
+           └── const: 1 [type=int]
+
+opt
+SELECT * FROM a WHERE x = 1
+----
+select
+ ├── columns: x:1(int!null) y:2(int)
+ ├── stats: [rows=100]
+ ├── scan a
+ │    ├── columns: a.x:1(int!null) a.y:2(int)
+ │    └── stats: [rows=1000]
+ └── filters [type=bool, outer=(1), constraints=(/1: [/1 - /1]; tight)]
+      └── eq [type=bool, outer=(1), constraints=(/1: [/1 - /1]; tight)]
+           ├── variable: a.x [type=int, outer=(1)]
+           └── const: 1 [type=int]
+
+opt
+SELECT * FROM a WHERE x > 1 AND x < 5
+----
+select
+ ├── columns: x:1(int!null) y:2(int)
+ ├── stats: [rows=100]
+ ├── scan a
+ │    ├── columns: a.x:1(int!null) a.y:2(int)
+ │    └── stats: [rows=1000]
+ └── filters [type=bool, outer=(1), constraints=(/1: [/2 - /4]; tight)]
+      ├── gt [type=bool, outer=(1), constraints=(/1: [/2 - ]; tight)]
+      │    ├── variable: a.x [type=int, outer=(1)]
+      │    └── const: 1 [type=int]
+      └── lt [type=bool, outer=(1), constraints=(/1: (/NULL - /4]; tight)]
+           ├── variable: a.x [type=int, outer=(1)]
+           └── const: 5 [type=int]
+
+opt
+SELECT * FROM a WHERE x = 1 AND y = 5
+----
+select
+ ├── columns: x:1(int!null) y:2(int)
+ ├── stats: [rows=100]
+ ├── scan a
+ │    ├── columns: a.x:1(int!null) a.y:2(int)
+ │    └── stats: [rows=1000]
+ └── filters [type=bool, outer=(1,2), constraints=(/1: [/1 - /1]; /2: [/5 - /5]; tight)]
+      ├── eq [type=bool, outer=(1), constraints=(/1: [/1 - /1]; tight)]
+      │    ├── variable: a.x [type=int, outer=(1)]
+      │    └── const: 1 [type=int]
+      └── eq [type=bool, outer=(2), constraints=(/2: [/5 - /5]; tight)]
+           ├── variable: a.y [type=int, outer=(2)]
+           └── const: 5 [type=int]
+
+opt
+SELECT * FROM a WHERE x > 1 AND x < 5 AND y >= 7 AND y <= 9
+----
+select
+ ├── columns: x:1(int!null) y:2(int)
+ ├── stats: [rows=100]
+ ├── scan a
+ │    ├── columns: a.x:1(int!null) a.y:2(int)
+ │    └── stats: [rows=1000]
+ └── filters [type=bool, outer=(1,2), constraints=(/1: [/2 - /4]; /2: [/7 - /9]; tight)]
+      ├── gt [type=bool, outer=(1), constraints=(/1: [/2 - ]; tight)]
+      │    ├── variable: a.x [type=int, outer=(1)]
+      │    └── const: 1 [type=int]
+      ├── lt [type=bool, outer=(1), constraints=(/1: (/NULL - /4]; tight)]
+      │    ├── variable: a.x [type=int, outer=(1)]
+      │    └── const: 5 [type=int]
+      ├── ge [type=bool, outer=(2), constraints=(/2: [/7 - ]; tight)]
+      │    ├── variable: a.y [type=int, outer=(2)]
+      │    └── const: 7 [type=int]
+      └── le [type=bool, outer=(2), constraints=(/2: (/NULL - /9]; tight)]
+           ├── variable: a.y [type=int, outer=(2)]
+           └── const: 9 [type=int]
+
+# Verify the resulting constraints are not tight.
+opt
+SELECT * FROM a WHERE x > 1 AND x < 5 AND x + y = 5
+----
+select
+ ├── columns: x:1(int!null) y:2(int)
+ ├── stats: [rows=100]
+ ├── scan a
+ │    ├── columns: a.x:1(int!null) a.y:2(int)
+ │    └── stats: [rows=1000]
+ └── filters [type=bool, outer=(1,2), constraints=(/1: [/2 - /4])]
+      ├── gt [type=bool, outer=(1), constraints=(/1: [/2 - ]; tight)]
+      │    ├── variable: a.x [type=int, outer=(1)]
+      │    └── const: 1 [type=int]
+      ├── lt [type=bool, outer=(1), constraints=(/1: (/NULL - /4]; tight)]
+      │    ├── variable: a.x [type=int, outer=(1)]
+      │    └── const: 5 [type=int]
+      └── eq [type=bool, outer=(1,2)]
+           ├── plus [type=int, outer=(1,2)]
+           │    ├── variable: a.x [type=int, outer=(1)]
+           │    └── variable: a.y [type=int, outer=(2)]
+           └── const: 5 [type=int]
+
+opt
+SELECT * FROM a WHERE x > 1 AND x + y >= 5 AND x + y <= 7
+----
+select
+ ├── columns: x:1(int!null) y:2(int)
+ ├── stats: [rows=100]
+ ├── scan a
+ │    ├── columns: a.x:1(int!null) a.y:2(int)
+ │    └── stats: [rows=1000]
+ └── filters [type=bool, outer=(1,2), constraints=(/1: [/2 - ])]
+      ├── gt [type=bool, outer=(1), constraints=(/1: [/2 - ]; tight)]
+      │    ├── variable: a.x [type=int, outer=(1)]
+      │    └── const: 1 [type=int]
+      ├── ge [type=bool, outer=(1,2)]
+      │    ├── plus [type=int, outer=(1,2)]
+      │    │    ├── variable: a.x [type=int, outer=(1)]
+      │    │    └── variable: a.y [type=int, outer=(2)]
+      │    └── const: 5 [type=int]
+      └── le [type=bool, outer=(1,2)]
+           ├── plus [type=int, outer=(1,2)]
+           │    ├── variable: a.x [type=int, outer=(1)]
+           │    └── variable: a.y [type=int, outer=(2)]
+           └── const: 7 [type=int]
+
+# Verify that we ignore mixed-type comparisons.
+opt
+SELECT * FROM a WHERE x > 1.0
+----
+select
+ ├── columns: x:1(int!null) y:2(int)
+ ├── stats: [rows=100]
+ ├── scan a
+ │    ├── columns: a.x:1(int!null) a.y:2(int)
+ │    └── stats: [rows=1000]
+ └── filters [type=bool, outer=(1), constraints=(/1: [/2 - ]; tight)]
+      └── gt [type=bool, outer=(1), constraints=(/1: [/2 - ]; tight)]
+           ├── variable: a.x [type=int, outer=(1)]
+           └── const: 1 [type=int]
+
+opt
+SELECT * FROM kuv WHERE u > 1::INT
+----
+select
+ ├── columns: k:1(int!null) u:2(float) v:3(string)
+ ├── stats: [rows=100]
+ ├── scan kuv
+ │    ├── columns: kuv.k:1(int!null) kuv.u:2(float) kuv.v:3(string)
+ │    └── stats: [rows=1000]
+ └── filters [type=bool, outer=(2)]
+      └── gt [type=bool, outer=(2)]
+           ├── variable: kuv.u [type=float, outer=(2)]
+           └── const: 1 [type=int]
+
+opt
+SELECT * FROM kuv WHERE v <= 'foo' AND v >= 'bar'
+----
+select
+ ├── columns: k:1(int!null) u:2(float) v:3(string)
+ ├── stats: [rows=100]
+ ├── scan kuv
+ │    ├── columns: kuv.k:1(int!null) kuv.u:2(float) kuv.v:3(string)
+ │    └── stats: [rows=1000]
+ └── filters [type=bool, outer=(3), constraints=(/3: [/'bar' - /'foo']; tight)]
+      ├── le [type=bool, outer=(3), constraints=(/3: (/NULL - /'foo']; tight)]
+      │    ├── variable: kuv.v [type=string, outer=(3)]
+      │    └── const: 'foo' [type=string]
+      └── ge [type=bool, outer=(3), constraints=(/3: [/'bar' - ]; tight)]
+           ├── variable: kuv.v [type=string, outer=(3)]
+           └── const: 'bar' [type=string]

--- a/pkg/sql/opt/memo/testdata/logprops/scalar
+++ b/pkg/sql/opt/memo/testdata/logprops/scalar
@@ -26,7 +26,7 @@ select
  ├── scan a
  │    ├── columns: a.x:1(int!null) a.y:2(int)
  │    └── stats: [rows=1000]
- └── lt [type=bool, outer=(1)]
+ └── lt [type=bool, outer=(1), constraints=(/1: (/NULL - /4]; tight)]
       ├── variable: a.x [type=int, outer=(1)]
       └── const: 5 [type=int]
 

--- a/pkg/sql/opt/memo/testdata/logprops/select
+++ b/pkg/sql/opt/memo/testdata/logprops/select
@@ -26,7 +26,7 @@ select
  ├── scan a
  │    ├── columns: a.x:1(int!null) a.y:2(int)
  │    └── stats: [rows=1000]
- └── eq [type=bool, outer=(1)]
+ └── eq [type=bool, outer=(1), constraints=(/1: [/1 - /1]; tight)]
       ├── variable: a.x [type=int, outer=(1)]
       └── const: 1 [type=int]
 

--- a/pkg/sql/opt/memo/testdata/logprops/set
+++ b/pkg/sql/opt/memo/testdata/logprops/set
@@ -65,7 +65,7 @@ intersect
       │    ├── scan b
       │    │    ├── columns: b.x:3(int) b.z:4(int!null) b.rowid:5(int!null)
       │    │    └── stats: [rows=1000]
-      │    └── eq [type=bool, outer=(3)]
+      │    └── eq [type=bool, outer=(3), constraints=(/3: [/1 - /1]; tight)]
       │         ├── variable: b.x [type=int, outer=(3)]
       │         └── const: 1 [type=int]
       └── projections [outer=(3-5)]
@@ -103,7 +103,7 @@ except
       │    │    ├── scan b
       │    │    │    ├── columns: b.x:3(int) b.z:4(int!null) b.rowid:5(int!null)
       │    │    │    └── stats: [rows=1000]
-      │    │    └── eq [type=bool, outer=(3)]
+      │    │    └── eq [type=bool, outer=(3), constraints=(/3: [/1 - /1]; tight)]
       │    │         ├── variable: b.x [type=int, outer=(3)]
       │    │         └── const: 1 [type=int]
       │    └── projections [outer=(3,4)]

--- a/pkg/sql/opt/memo/testdata/memo
+++ b/pkg/sql/opt/memo/testdata/memo
@@ -54,8 +54,8 @@ limit
  │         │    │    │    ├── stats: [rows=1000]
  │         │    │    │    └── cost: 1000.00
  │         │    │    └── true [type=bool]
- │         │    └── and [type=bool, outer=(1-3)]
- │         │         ├── eq [type=bool, outer=(2)]
+ │         │    └── and [type=bool, outer=(1-3), constraints=(/2: [/1 - /1])]
+ │         │         ├── eq [type=bool, outer=(2), constraints=(/2: [/1 - /1]; tight)]
  │         │         │    ├── variable: a.y [type=int, outer=(2)]
  │         │         │    └── const: 1 [type=int]
  │         │         └── eq [type=bool, outer=(1,3)]
@@ -103,8 +103,8 @@ limit
  │         │    │    │    ├── columns: a.x:1(int!null) a.y:2(int)
  │         │    │    │    ├── stats: [rows=1000]
  │         │    │    │    └── cost: 1000.00
- │         │    │    └── filters [type=bool, outer=(2)]
- │         │    │         └── eq [type=bool, outer=(2)]
+ │         │    │    └── filters [type=bool, outer=(2), constraints=(/2: [/1 - /1]; tight)]
+ │         │    │         └── eq [type=bool, outer=(2), constraints=(/2: [/1 - /1]; tight)]
  │         │    │              ├── variable: a.y [type=int, outer=(2)]
  │         │    │              └── const: 1 [type=int]
  │         │    ├── scan b

--- a/pkg/sql/opt/optgen/cmd/optgen/factory_gen.go
+++ b/pkg/sql/opt/optgen/cmd/optgen/factory_gen.go
@@ -113,7 +113,7 @@ func (g *factoryGen) genConstructFuncs() {
 		g.w.unnest("}\n\n")
 
 		g.w.nestIndent("if !_f.o.allowOptimizations() {\n")
-		g.w.writeIndent("return _f.mem.MemoizeNormExpr(memo.Expr(%s))\n", varName)
+		g.w.writeIndent("return _f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(%s))\n", varName)
 		g.w.unnest("}\n\n")
 
 		// Only include normalization rules for the current define.
@@ -125,7 +125,7 @@ func (g *factoryGen) genConstructFuncs() {
 			g.w.newline()
 		}
 
-		g.w.writeIndent("return _f.onConstruct(_f.mem.MemoizeNormExpr(memo.Expr(%s)))\n", varName)
+		g.w.writeIndent("return _f.onConstruct(_f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(%s)))\n", varName)
 		g.w.unnest("}\n\n")
 	}
 }

--- a/pkg/sql/opt/optgen/cmd/optgen/testdata/factory
+++ b/pkg/sql/opt/optgen/cmd/optgen/testdata/factory
@@ -51,10 +51,10 @@ func (_f *Factory) ConstructNot(
 	}
 
 	if !_f.o.allowOptimizations() {
-		return _f.mem.MemoizeNormExpr(memo.Expr(_notExpr))
+		return _f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_notExpr))
 	}
 
-	return _f.onConstruct(_f.mem.MemoizeNormExpr(memo.Expr(_notExpr)))
+	return _f.onConstruct(_f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_notExpr)))
 }
 
 // ConstructFuncCall constructs an expression for the FuncCall operator.
@@ -70,10 +70,10 @@ func (_f *Factory) ConstructFuncCall(
 	}
 
 	if !_f.o.allowOptimizations() {
-		return _f.mem.MemoizeNormExpr(memo.Expr(_funcCallExpr))
+		return _f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_funcCallExpr))
 	}
 
-	return _f.onConstruct(_f.mem.MemoizeNormExpr(memo.Expr(_funcCallExpr)))
+	return _f.onConstruct(_f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_funcCallExpr)))
 }
 
 type dynConstructLookupFunc func(f *Factory, operands DynamicOperands) memo.GroupID
@@ -140,7 +140,7 @@ func (_f *Factory) ConstructInnerJoin(
 	}
 
 	if !_f.o.allowOptimizations() {
-		return _f.mem.MemoizeNormExpr(memo.Expr(_innerJoinExpr))
+		return _f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_innerJoinExpr))
 	}
 
 	// [CommuteJoin]
@@ -156,7 +156,7 @@ func (_f *Factory) ConstructInnerJoin(
 		return _group
 	}
 
-	return _f.onConstruct(_f.mem.MemoizeNormExpr(memo.Expr(_innerJoinExpr)))
+	return _f.onConstruct(_f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_innerJoinExpr)))
 }
 
 type dynConstructLookupFunc func(f *Factory, operands DynamicOperands) memo.GroupID
@@ -256,7 +256,7 @@ func (_f *Factory) ConstructEq(
 	}
 
 	if !_f.o.allowOptimizations() {
-		return _f.mem.MemoizeNormExpr(memo.Expr(_eqExpr))
+		return _f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_eqExpr))
 	}
 
 	// [NormalizeVarPlus]
@@ -286,7 +286,7 @@ func (_f *Factory) ConstructEq(
 		}
 	}
 
-	return _f.onConstruct(_f.mem.MemoizeNormExpr(memo.Expr(_eqExpr)))
+	return _f.onConstruct(_f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_eqExpr)))
 }
 
 // ConstructLt constructs an expression for the Lt operator.
@@ -301,7 +301,7 @@ func (_f *Factory) ConstructLt(
 	}
 
 	if !_f.o.allowOptimizations() {
-		return _f.mem.MemoizeNormExpr(memo.Expr(_ltExpr))
+		return _f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_ltExpr))
 	}
 
 	// [NormalizeVarPlus]
@@ -331,7 +331,7 @@ func (_f *Factory) ConstructLt(
 		}
 	}
 
-	return _f.onConstruct(_f.mem.MemoizeNormExpr(memo.Expr(_ltExpr)))
+	return _f.onConstruct(_f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_ltExpr)))
 }
 
 // ConstructPlus constructs an expression for the Plus operator.
@@ -346,10 +346,10 @@ func (_f *Factory) ConstructPlus(
 	}
 
 	if !_f.o.allowOptimizations() {
-		return _f.mem.MemoizeNormExpr(memo.Expr(_plusExpr))
+		return _f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_plusExpr))
 	}
 
-	return _f.onConstruct(_f.mem.MemoizeNormExpr(memo.Expr(_plusExpr)))
+	return _f.onConstruct(_f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_plusExpr)))
 }
 
 // ConstructMinus constructs an expression for the Minus operator.
@@ -364,10 +364,10 @@ func (_f *Factory) ConstructMinus(
 	}
 
 	if !_f.o.allowOptimizations() {
-		return _f.mem.MemoizeNormExpr(memo.Expr(_minusExpr))
+		return _f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_minusExpr))
 	}
 
-	return _f.onConstruct(_f.mem.MemoizeNormExpr(memo.Expr(_minusExpr)))
+	return _f.onConstruct(_f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_minusExpr)))
 }
 
 // ConstructConst constructs an expression for the Const operator.
@@ -381,10 +381,10 @@ func (_f *Factory) ConstructConst(
 	}
 
 	if !_f.o.allowOptimizations() {
-		return _f.mem.MemoizeNormExpr(memo.Expr(_constExpr))
+		return _f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_constExpr))
 	}
 
-	return _f.onConstruct(_f.mem.MemoizeNormExpr(memo.Expr(_constExpr)))
+	return _f.onConstruct(_f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_constExpr)))
 }
 
 type dynConstructLookupFunc func(f *Factory, operands DynamicOperands) memo.GroupID
@@ -489,7 +489,7 @@ func (_f *Factory) ConstructFunc(
 	}
 
 	if !_f.o.allowOptimizations() {
-		return _f.mem.MemoizeNormExpr(memo.Expr(_funcExpr))
+		return _f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_funcExpr))
 	}
 
 	// [Concat]
@@ -513,7 +513,7 @@ func (_f *Factory) ConstructFunc(
 		}
 	}
 
-	return _f.onConstruct(_f.mem.MemoizeNormExpr(memo.Expr(_funcExpr)))
+	return _f.onConstruct(_f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_funcExpr)))
 }
 
 // ConstructVariable constructs an expression for the Variable operator.
@@ -527,10 +527,10 @@ func (_f *Factory) ConstructVariable(
 	}
 
 	if !_f.o.allowOptimizations() {
-		return _f.mem.MemoizeNormExpr(memo.Expr(_variableExpr))
+		return _f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_variableExpr))
 	}
 
-	return _f.onConstruct(_f.mem.MemoizeNormExpr(memo.Expr(_variableExpr)))
+	return _f.onConstruct(_f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_variableExpr)))
 }
 
 type dynConstructLookupFunc func(f *Factory, operands DynamicOperands) memo.GroupID
@@ -626,7 +626,7 @@ func (_f *Factory) ConstructSelect(
 	}
 
 	if !_f.o.allowOptimizations() {
-		return _f.mem.MemoizeNormExpr(memo.Expr(_selectExpr))
+		return _f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_selectExpr))
 	}
 
 	// [Test]
@@ -665,7 +665,7 @@ func (_f *Factory) ConstructSelect(
 		}
 	}
 
-	return _f.onConstruct(_f.mem.MemoizeNormExpr(memo.Expr(_selectExpr)))
+	return _f.onConstruct(_f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_selectExpr)))
 }
 
 // ConstructInnerJoin constructs an expression for the InnerJoin operator.
@@ -680,10 +680,10 @@ func (_f *Factory) ConstructInnerJoin(
 	}
 
 	if !_f.o.allowOptimizations() {
-		return _f.mem.MemoizeNormExpr(memo.Expr(_innerJoinExpr))
+		return _f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_innerJoinExpr))
 	}
 
-	return _f.onConstruct(_f.mem.MemoizeNormExpr(memo.Expr(_innerJoinExpr)))
+	return _f.onConstruct(_f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_innerJoinExpr)))
 }
 
 // ConstructFullJoin constructs an expression for the FullJoin operator.
@@ -698,10 +698,10 @@ func (_f *Factory) ConstructFullJoin(
 	}
 
 	if !_f.o.allowOptimizations() {
-		return _f.mem.MemoizeNormExpr(memo.Expr(_fullJoinExpr))
+		return _f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_fullJoinExpr))
 	}
 
-	return _f.onConstruct(_f.mem.MemoizeNormExpr(memo.Expr(_fullJoinExpr)))
+	return _f.onConstruct(_f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_fullJoinExpr)))
 }
 
 // ConstructUnion constructs an expression for the Union operator.
@@ -716,10 +716,10 @@ func (_f *Factory) ConstructUnion(
 	}
 
 	if !_f.o.allowOptimizations() {
-		return _f.mem.MemoizeNormExpr(memo.Expr(_unionExpr))
+		return _f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_unionExpr))
 	}
 
-	return _f.onConstruct(_f.mem.MemoizeNormExpr(memo.Expr(_unionExpr)))
+	return _f.onConstruct(_f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_unionExpr)))
 }
 
 // ConstructAnd constructs an expression for the And operator.
@@ -734,10 +734,10 @@ func (_f *Factory) ConstructAnd(
 	}
 
 	if !_f.o.allowOptimizations() {
-		return _f.mem.MemoizeNormExpr(memo.Expr(_andExpr))
+		return _f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_andExpr))
 	}
 
-	return _f.onConstruct(_f.mem.MemoizeNormExpr(memo.Expr(_andExpr)))
+	return _f.onConstruct(_f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_andExpr)))
 }
 
 type dynConstructLookupFunc func(f *Factory, operands DynamicOperands) memo.GroupID
@@ -831,7 +831,7 @@ func (_f *Factory) ConstructList(
 	}
 
 	if !_f.o.allowOptimizations() {
-		return _f.mem.MemoizeNormExpr(memo.Expr(_listExpr))
+		return _f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_listExpr))
 	}
 
 	// [List]
@@ -872,7 +872,7 @@ func (_f *Factory) ConstructList(
 		}
 	}
 
-	return _f.onConstruct(_f.mem.MemoizeNormExpr(memo.Expr(_listExpr)))
+	return _f.onConstruct(_f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_listExpr)))
 }
 
 type dynConstructLookupFunc func(f *Factory, operands DynamicOperands) memo.GroupID
@@ -938,7 +938,7 @@ func (_f *Factory) ConstructJoin(
 	}
 
 	if !_f.o.allowOptimizations() {
-		return _f.mem.MemoizeNormExpr(memo.Expr(_joinExpr))
+		return _f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_joinExpr))
 	}
 
 	// [ConstructList]
@@ -949,7 +949,7 @@ func (_f *Factory) ConstructJoin(
 		return _group
 	}
 
-	return _f.onConstruct(_f.mem.MemoizeNormExpr(memo.Expr(_joinExpr)))
+	return _f.onConstruct(_f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_joinExpr)))
 }
 
 type dynConstructLookupFunc func(f *Factory, operands DynamicOperands) memo.GroupID
@@ -1018,10 +1018,10 @@ func (_f *Factory) ConstructList(
 	}
 
 	if !_f.o.allowOptimizations() {
-		return _f.mem.MemoizeNormExpr(memo.Expr(_listExpr))
+		return _f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_listExpr))
 	}
 
-	return _f.onConstruct(_f.mem.MemoizeNormExpr(memo.Expr(_listExpr)))
+	return _f.onConstruct(_f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_listExpr)))
 }
 
 // ConstructOp constructs an expression for the Op operator.
@@ -1036,7 +1036,7 @@ func (_f *Factory) ConstructOp(
 	}
 
 	if !_f.o.allowOptimizations() {
-		return _f.mem.MemoizeNormExpr(memo.Expr(_opExpr))
+		return _f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_opExpr))
 	}
 
 	// [ListNot]
@@ -1060,7 +1060,7 @@ func (_f *Factory) ConstructOp(
 		}
 	}
 
-	return _f.onConstruct(_f.mem.MemoizeNormExpr(memo.Expr(_opExpr)))
+	return _f.onConstruct(_f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_opExpr)))
 }
 
 type dynConstructLookupFunc func(f *Factory, operands DynamicOperands) memo.GroupID
@@ -1146,7 +1146,7 @@ func (_f *Factory) ConstructEq(
 	}
 
 	if !_f.o.allowOptimizations() {
-		return _f.mem.MemoizeNormExpr(memo.Expr(_eqExpr))
+		return _f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_eqExpr))
 	}
 
 	// [Constant]
@@ -1180,7 +1180,7 @@ func (_f *Factory) ConstructEq(
 		}
 	}
 
-	return _f.onConstruct(_f.mem.MemoizeNormExpr(memo.Expr(_eqExpr)))
+	return _f.onConstruct(_f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_eqExpr)))
 }
 
 // ConstructNe constructs an expression for the Ne operator.
@@ -1195,7 +1195,7 @@ func (_f *Factory) ConstructNe(
 	}
 
 	if !_f.o.allowOptimizations() {
-		return _f.mem.MemoizeNormExpr(memo.Expr(_neExpr))
+		return _f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_neExpr))
 	}
 
 	// [Dynamic]
@@ -1229,7 +1229,7 @@ func (_f *Factory) ConstructNe(
 		}
 	}
 
-	return _f.onConstruct(_f.mem.MemoizeNormExpr(memo.Expr(_neExpr)))
+	return _f.onConstruct(_f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_neExpr)))
 }
 
 type dynConstructLookupFunc func(f *Factory, operands DynamicOperands) memo.GroupID
@@ -1310,7 +1310,7 @@ func (_f *Factory) ConstructPlus(
 	}
 
 	if !_f.o.allowOptimizations() {
-		return _f.mem.MemoizeNormExpr(memo.Expr(_plusExpr))
+		return _f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_plusExpr))
 	}
 
 	// [Fold]
@@ -1326,7 +1326,7 @@ func (_f *Factory) ConstructPlus(
 		}
 	}
 
-	return _f.onConstruct(_f.mem.MemoizeNormExpr(memo.Expr(_plusExpr)))
+	return _f.onConstruct(_f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_plusExpr)))
 }
 
 // ConstructMinus constructs an expression for the Minus operator.
@@ -1341,7 +1341,7 @@ func (_f *Factory) ConstructMinus(
 	}
 
 	if !_f.o.allowOptimizations() {
-		return _f.mem.MemoizeNormExpr(memo.Expr(_minusExpr))
+		return _f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_minusExpr))
 	}
 
 	// [Fold]
@@ -1357,7 +1357,7 @@ func (_f *Factory) ConstructMinus(
 		}
 	}
 
-	return _f.onConstruct(_f.mem.MemoizeNormExpr(memo.Expr(_minusExpr)))
+	return _f.onConstruct(_f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_minusExpr)))
 }
 
 // ConstructNull constructs an expression for the Null operator.
@@ -1369,10 +1369,10 @@ func (_f *Factory) ConstructNull() memo.GroupID {
 	}
 
 	if !_f.o.allowOptimizations() {
-		return _f.mem.MemoizeNormExpr(memo.Expr(_nullExpr))
+		return _f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_nullExpr))
 	}
 
-	return _f.onConstruct(_f.mem.MemoizeNormExpr(memo.Expr(_nullExpr)))
+	return _f.onConstruct(_f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_nullExpr)))
 }
 
 type dynConstructLookupFunc func(f *Factory, operands DynamicOperands) memo.GroupID
@@ -1463,10 +1463,10 @@ func (_f *Factory) ConstructLt(
 	}
 
 	if !_f.o.allowOptimizations() {
-		return _f.mem.MemoizeNormExpr(memo.Expr(_ltExpr))
+		return _f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_ltExpr))
 	}
 
-	return _f.onConstruct(_f.mem.MemoizeNormExpr(memo.Expr(_ltExpr)))
+	return _f.onConstruct(_f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_ltExpr)))
 }
 
 // ConstructGt constructs an expression for the Gt operator.
@@ -1481,10 +1481,10 @@ func (_f *Factory) ConstructGt(
 	}
 
 	if !_f.o.allowOptimizations() {
-		return _f.mem.MemoizeNormExpr(memo.Expr(_gtExpr))
+		return _f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_gtExpr))
 	}
 
-	return _f.onConstruct(_f.mem.MemoizeNormExpr(memo.Expr(_gtExpr)))
+	return _f.onConstruct(_f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_gtExpr)))
 }
 
 // ConstructContains constructs an expression for the Contains operator.
@@ -1499,10 +1499,10 @@ func (_f *Factory) ConstructContains(
 	}
 
 	if !_f.o.allowOptimizations() {
-		return _f.mem.MemoizeNormExpr(memo.Expr(_containsExpr))
+		return _f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_containsExpr))
 	}
 
-	return _f.onConstruct(_f.mem.MemoizeNormExpr(memo.Expr(_containsExpr)))
+	return _f.onConstruct(_f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_containsExpr)))
 }
 
 // ConstructNot constructs an expression for the Not operator.
@@ -1516,7 +1516,7 @@ func (_f *Factory) ConstructNot(
 	}
 
 	if !_f.o.allowOptimizations() {
-		return _f.mem.MemoizeNormExpr(memo.Expr(_notExpr))
+		return _f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_notExpr))
 	}
 
 	// [Invert]
@@ -1537,7 +1537,7 @@ func (_f *Factory) ConstructNot(
 		}
 	}
 
-	return _f.onConstruct(_f.mem.MemoizeNormExpr(memo.Expr(_notExpr)))
+	return _f.onConstruct(_f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_notExpr)))
 }
 
 type dynConstructLookupFunc func(f *Factory, operands DynamicOperands) memo.GroupID

--- a/pkg/sql/opt/xform/factory.og.go
+++ b/pkg/sql/opt/xform/factory.og.go
@@ -94,10 +94,10 @@ func (_f *Factory) ConstructScan(
 	}
 
 	if !_f.o.allowOptimizations() {
-		return _f.mem.MemoizeNormExpr(memo.Expr(_scanExpr))
+		return _f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_scanExpr))
 	}
 
-	return _f.onConstruct(_f.mem.MemoizeNormExpr(memo.Expr(_scanExpr)))
+	return _f.onConstruct(_f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_scanExpr)))
 }
 
 // ConstructValues constructs an expression for the Values operator.
@@ -121,10 +121,10 @@ func (_f *Factory) ConstructValues(
 	}
 
 	if !_f.o.allowOptimizations() {
-		return _f.mem.MemoizeNormExpr(memo.Expr(_valuesExpr))
+		return _f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_valuesExpr))
 	}
 
-	return _f.onConstruct(_f.mem.MemoizeNormExpr(memo.Expr(_valuesExpr)))
+	return _f.onConstruct(_f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_valuesExpr)))
 }
 
 // ConstructSelect constructs an expression for the Select operator.
@@ -144,7 +144,7 @@ func (_f *Factory) ConstructSelect(
 	}
 
 	if !_f.o.allowOptimizations() {
-		return _f.mem.MemoizeNormExpr(memo.Expr(_selectExpr))
+		return _f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_selectExpr))
 	}
 
 	// [EnsureSelectFiltersAnd]
@@ -347,7 +347,7 @@ func (_f *Factory) ConstructSelect(
 		}
 	}
 
-	return _f.onConstruct(_f.mem.MemoizeNormExpr(memo.Expr(_selectExpr)))
+	return _f.onConstruct(_f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_selectExpr)))
 }
 
 // ConstructProject constructs an expression for the Project operator.
@@ -367,7 +367,7 @@ func (_f *Factory) ConstructProject(
 	}
 
 	if !_f.o.allowOptimizations() {
-		return _f.mem.MemoizeNormExpr(memo.Expr(_projectExpr))
+		return _f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_projectExpr))
 	}
 
 	// [EliminateProject]
@@ -575,7 +575,7 @@ func (_f *Factory) ConstructProject(
 		}
 	}
 
-	return _f.onConstruct(_f.mem.MemoizeNormExpr(memo.Expr(_projectExpr)))
+	return _f.onConstruct(_f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_projectExpr)))
 }
 
 // ConstructInnerJoin constructs an expression for the InnerJoin operator.
@@ -596,7 +596,7 @@ func (_f *Factory) ConstructInnerJoin(
 	}
 
 	if !_f.o.allowOptimizations() {
-		return _f.mem.MemoizeNormExpr(memo.Expr(_innerJoinExpr))
+		return _f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_innerJoinExpr))
 	}
 
 	// [EnsureJoinFiltersAnd]
@@ -691,7 +691,7 @@ func (_f *Factory) ConstructInnerJoin(
 		}
 	}
 
-	return _f.onConstruct(_f.mem.MemoizeNormExpr(memo.Expr(_innerJoinExpr)))
+	return _f.onConstruct(_f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_innerJoinExpr)))
 }
 
 // ConstructLeftJoin constructs an expression for the LeftJoin operator.
@@ -707,7 +707,7 @@ func (_f *Factory) ConstructLeftJoin(
 	}
 
 	if !_f.o.allowOptimizations() {
-		return _f.mem.MemoizeNormExpr(memo.Expr(_leftJoinExpr))
+		return _f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_leftJoinExpr))
 	}
 
 	// [EnsureJoinFiltersAnd]
@@ -774,7 +774,7 @@ func (_f *Factory) ConstructLeftJoin(
 		}
 	}
 
-	return _f.onConstruct(_f.mem.MemoizeNormExpr(memo.Expr(_leftJoinExpr)))
+	return _f.onConstruct(_f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_leftJoinExpr)))
 }
 
 // ConstructRightJoin constructs an expression for the RightJoin operator.
@@ -790,7 +790,7 @@ func (_f *Factory) ConstructRightJoin(
 	}
 
 	if !_f.o.allowOptimizations() {
-		return _f.mem.MemoizeNormExpr(memo.Expr(_rightJoinExpr))
+		return _f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_rightJoinExpr))
 	}
 
 	// [EnsureJoinFiltersAnd]
@@ -857,7 +857,7 @@ func (_f *Factory) ConstructRightJoin(
 		}
 	}
 
-	return _f.onConstruct(_f.mem.MemoizeNormExpr(memo.Expr(_rightJoinExpr)))
+	return _f.onConstruct(_f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_rightJoinExpr)))
 }
 
 // ConstructFullJoin constructs an expression for the FullJoin operator.
@@ -873,7 +873,7 @@ func (_f *Factory) ConstructFullJoin(
 	}
 
 	if !_f.o.allowOptimizations() {
-		return _f.mem.MemoizeNormExpr(memo.Expr(_fullJoinExpr))
+		return _f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_fullJoinExpr))
 	}
 
 	// [EnsureJoinFiltersAnd]
@@ -912,7 +912,7 @@ func (_f *Factory) ConstructFullJoin(
 		}
 	}
 
-	return _f.onConstruct(_f.mem.MemoizeNormExpr(memo.Expr(_fullJoinExpr)))
+	return _f.onConstruct(_f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_fullJoinExpr)))
 }
 
 // ConstructSemiJoin constructs an expression for the SemiJoin operator.
@@ -928,7 +928,7 @@ func (_f *Factory) ConstructSemiJoin(
 	}
 
 	if !_f.o.allowOptimizations() {
-		return _f.mem.MemoizeNormExpr(memo.Expr(_semiJoinExpr))
+		return _f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_semiJoinExpr))
 	}
 
 	// [EnsureJoinFiltersAnd]
@@ -967,7 +967,7 @@ func (_f *Factory) ConstructSemiJoin(
 		}
 	}
 
-	return _f.onConstruct(_f.mem.MemoizeNormExpr(memo.Expr(_semiJoinExpr)))
+	return _f.onConstruct(_f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_semiJoinExpr)))
 }
 
 // ConstructAntiJoin constructs an expression for the AntiJoin operator.
@@ -983,7 +983,7 @@ func (_f *Factory) ConstructAntiJoin(
 	}
 
 	if !_f.o.allowOptimizations() {
-		return _f.mem.MemoizeNormExpr(memo.Expr(_antiJoinExpr))
+		return _f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_antiJoinExpr))
 	}
 
 	// [EnsureJoinFiltersAnd]
@@ -1022,7 +1022,7 @@ func (_f *Factory) ConstructAntiJoin(
 		}
 	}
 
-	return _f.onConstruct(_f.mem.MemoizeNormExpr(memo.Expr(_antiJoinExpr)))
+	return _f.onConstruct(_f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_antiJoinExpr)))
 }
 
 // ConstructInnerJoinApply constructs an expression for the InnerJoinApply operator.
@@ -1041,7 +1041,7 @@ func (_f *Factory) ConstructInnerJoinApply(
 	}
 
 	if !_f.o.allowOptimizations() {
-		return _f.mem.MemoizeNormExpr(memo.Expr(_innerJoinApplyExpr))
+		return _f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_innerJoinApplyExpr))
 	}
 
 	// [EnsureJoinFiltersAnd]
@@ -1136,7 +1136,7 @@ func (_f *Factory) ConstructInnerJoinApply(
 		}
 	}
 
-	return _f.onConstruct(_f.mem.MemoizeNormExpr(memo.Expr(_innerJoinApplyExpr)))
+	return _f.onConstruct(_f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_innerJoinApplyExpr)))
 }
 
 // ConstructLeftJoinApply constructs an expression for the LeftJoinApply operator.
@@ -1152,7 +1152,7 @@ func (_f *Factory) ConstructLeftJoinApply(
 	}
 
 	if !_f.o.allowOptimizations() {
-		return _f.mem.MemoizeNormExpr(memo.Expr(_leftJoinApplyExpr))
+		return _f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_leftJoinApplyExpr))
 	}
 
 	// [EnsureJoinFiltersAnd]
@@ -1219,7 +1219,7 @@ func (_f *Factory) ConstructLeftJoinApply(
 		}
 	}
 
-	return _f.onConstruct(_f.mem.MemoizeNormExpr(memo.Expr(_leftJoinApplyExpr)))
+	return _f.onConstruct(_f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_leftJoinApplyExpr)))
 }
 
 // ConstructRightJoinApply constructs an expression for the RightJoinApply operator.
@@ -1235,7 +1235,7 @@ func (_f *Factory) ConstructRightJoinApply(
 	}
 
 	if !_f.o.allowOptimizations() {
-		return _f.mem.MemoizeNormExpr(memo.Expr(_rightJoinApplyExpr))
+		return _f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_rightJoinApplyExpr))
 	}
 
 	// [EnsureJoinFiltersAnd]
@@ -1302,7 +1302,7 @@ func (_f *Factory) ConstructRightJoinApply(
 		}
 	}
 
-	return _f.onConstruct(_f.mem.MemoizeNormExpr(memo.Expr(_rightJoinApplyExpr)))
+	return _f.onConstruct(_f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_rightJoinApplyExpr)))
 }
 
 // ConstructFullJoinApply constructs an expression for the FullJoinApply operator.
@@ -1318,7 +1318,7 @@ func (_f *Factory) ConstructFullJoinApply(
 	}
 
 	if !_f.o.allowOptimizations() {
-		return _f.mem.MemoizeNormExpr(memo.Expr(_fullJoinApplyExpr))
+		return _f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_fullJoinApplyExpr))
 	}
 
 	// [EnsureJoinFiltersAnd]
@@ -1357,7 +1357,7 @@ func (_f *Factory) ConstructFullJoinApply(
 		}
 	}
 
-	return _f.onConstruct(_f.mem.MemoizeNormExpr(memo.Expr(_fullJoinApplyExpr)))
+	return _f.onConstruct(_f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_fullJoinApplyExpr)))
 }
 
 // ConstructSemiJoinApply constructs an expression for the SemiJoinApply operator.
@@ -1373,7 +1373,7 @@ func (_f *Factory) ConstructSemiJoinApply(
 	}
 
 	if !_f.o.allowOptimizations() {
-		return _f.mem.MemoizeNormExpr(memo.Expr(_semiJoinApplyExpr))
+		return _f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_semiJoinApplyExpr))
 	}
 
 	// [EnsureJoinFiltersAnd]
@@ -1412,7 +1412,7 @@ func (_f *Factory) ConstructSemiJoinApply(
 		}
 	}
 
-	return _f.onConstruct(_f.mem.MemoizeNormExpr(memo.Expr(_semiJoinApplyExpr)))
+	return _f.onConstruct(_f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_semiJoinApplyExpr)))
 }
 
 // ConstructAntiJoinApply constructs an expression for the AntiJoinApply operator.
@@ -1428,7 +1428,7 @@ func (_f *Factory) ConstructAntiJoinApply(
 	}
 
 	if !_f.o.allowOptimizations() {
-		return _f.mem.MemoizeNormExpr(memo.Expr(_antiJoinApplyExpr))
+		return _f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_antiJoinApplyExpr))
 	}
 
 	// [EnsureJoinFiltersAnd]
@@ -1467,7 +1467,7 @@ func (_f *Factory) ConstructAntiJoinApply(
 		}
 	}
 
-	return _f.onConstruct(_f.mem.MemoizeNormExpr(memo.Expr(_antiJoinApplyExpr)))
+	return _f.onConstruct(_f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_antiJoinApplyExpr)))
 }
 
 // ConstructGroupBy constructs an expression for the GroupBy operator.
@@ -1488,7 +1488,7 @@ func (_f *Factory) ConstructGroupBy(
 	}
 
 	if !_f.o.allowOptimizations() {
-		return _f.mem.MemoizeNormExpr(memo.Expr(_groupByExpr))
+		return _f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_groupByExpr))
 	}
 
 	// [FilterUnusedGroupByCols]
@@ -1505,7 +1505,7 @@ func (_f *Factory) ConstructGroupBy(
 		}
 	}
 
-	return _f.onConstruct(_f.mem.MemoizeNormExpr(memo.Expr(_groupByExpr)))
+	return _f.onConstruct(_f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_groupByExpr)))
 }
 
 // ConstructUnion constructs an expression for the Union operator.
@@ -1526,10 +1526,10 @@ func (_f *Factory) ConstructUnion(
 	}
 
 	if !_f.o.allowOptimizations() {
-		return _f.mem.MemoizeNormExpr(memo.Expr(_unionExpr))
+		return _f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_unionExpr))
 	}
 
-	return _f.onConstruct(_f.mem.MemoizeNormExpr(memo.Expr(_unionExpr)))
+	return _f.onConstruct(_f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_unionExpr)))
 }
 
 // ConstructIntersect constructs an expression for the Intersect operator.
@@ -1552,10 +1552,10 @@ func (_f *Factory) ConstructIntersect(
 	}
 
 	if !_f.o.allowOptimizations() {
-		return _f.mem.MemoizeNormExpr(memo.Expr(_intersectExpr))
+		return _f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_intersectExpr))
 	}
 
-	return _f.onConstruct(_f.mem.MemoizeNormExpr(memo.Expr(_intersectExpr)))
+	return _f.onConstruct(_f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_intersectExpr)))
 }
 
 // ConstructExcept constructs an expression for the Except operator.
@@ -1577,10 +1577,10 @@ func (_f *Factory) ConstructExcept(
 	}
 
 	if !_f.o.allowOptimizations() {
-		return _f.mem.MemoizeNormExpr(memo.Expr(_exceptExpr))
+		return _f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_exceptExpr))
 	}
 
-	return _f.onConstruct(_f.mem.MemoizeNormExpr(memo.Expr(_exceptExpr)))
+	return _f.onConstruct(_f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_exceptExpr)))
 }
 
 // ConstructUnionAll constructs an expression for the UnionAll operator.
@@ -1612,10 +1612,10 @@ func (_f *Factory) ConstructUnionAll(
 	}
 
 	if !_f.o.allowOptimizations() {
-		return _f.mem.MemoizeNormExpr(memo.Expr(_unionAllExpr))
+		return _f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_unionAllExpr))
 	}
 
-	return _f.onConstruct(_f.mem.MemoizeNormExpr(memo.Expr(_unionAllExpr)))
+	return _f.onConstruct(_f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_unionAllExpr)))
 }
 
 // ConstructIntersectAll constructs an expression for the IntersectAll operator.
@@ -1649,10 +1649,10 @@ func (_f *Factory) ConstructIntersectAll(
 	}
 
 	if !_f.o.allowOptimizations() {
-		return _f.mem.MemoizeNormExpr(memo.Expr(_intersectAllExpr))
+		return _f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_intersectAllExpr))
 	}
 
-	return _f.onConstruct(_f.mem.MemoizeNormExpr(memo.Expr(_intersectAllExpr)))
+	return _f.onConstruct(_f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_intersectAllExpr)))
 }
 
 // ConstructExceptAll constructs an expression for the ExceptAll operator.
@@ -1686,10 +1686,10 @@ func (_f *Factory) ConstructExceptAll(
 	}
 
 	if !_f.o.allowOptimizations() {
-		return _f.mem.MemoizeNormExpr(memo.Expr(_exceptAllExpr))
+		return _f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_exceptAllExpr))
 	}
 
-	return _f.onConstruct(_f.mem.MemoizeNormExpr(memo.Expr(_exceptAllExpr)))
+	return _f.onConstruct(_f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_exceptAllExpr)))
 }
 
 // ConstructLimit constructs an expression for the Limit operator.
@@ -1709,10 +1709,10 @@ func (_f *Factory) ConstructLimit(
 	}
 
 	if !_f.o.allowOptimizations() {
-		return _f.mem.MemoizeNormExpr(memo.Expr(_limitExpr))
+		return _f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_limitExpr))
 	}
 
-	return _f.onConstruct(_f.mem.MemoizeNormExpr(memo.Expr(_limitExpr)))
+	return _f.onConstruct(_f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_limitExpr)))
 }
 
 // ConstructOffset constructs an expression for the Offset operator.
@@ -1730,10 +1730,10 @@ func (_f *Factory) ConstructOffset(
 	}
 
 	if !_f.o.allowOptimizations() {
-		return _f.mem.MemoizeNormExpr(memo.Expr(_offsetExpr))
+		return _f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_offsetExpr))
 	}
 
-	return _f.onConstruct(_f.mem.MemoizeNormExpr(memo.Expr(_offsetExpr)))
+	return _f.onConstruct(_f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_offsetExpr)))
 }
 
 // ConstructMax1Row constructs an expression for the Max1Row operator.
@@ -1750,10 +1750,10 @@ func (_f *Factory) ConstructMax1Row(
 	}
 
 	if !_f.o.allowOptimizations() {
-		return _f.mem.MemoizeNormExpr(memo.Expr(_max1RowExpr))
+		return _f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_max1RowExpr))
 	}
 
-	return _f.onConstruct(_f.mem.MemoizeNormExpr(memo.Expr(_max1RowExpr)))
+	return _f.onConstruct(_f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_max1RowExpr)))
 }
 
 // ConstructSubquery constructs an expression for the Subquery operator.
@@ -1810,10 +1810,10 @@ func (_f *Factory) ConstructSubquery(
 	}
 
 	if !_f.o.allowOptimizations() {
-		return _f.mem.MemoizeNormExpr(memo.Expr(_subqueryExpr))
+		return _f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_subqueryExpr))
 	}
 
-	return _f.onConstruct(_f.mem.MemoizeNormExpr(memo.Expr(_subqueryExpr)))
+	return _f.onConstruct(_f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_subqueryExpr)))
 }
 
 // ConstructAny constructs an expression for the Any operator.
@@ -1836,10 +1836,10 @@ func (_f *Factory) ConstructAny(
 	}
 
 	if !_f.o.allowOptimizations() {
-		return _f.mem.MemoizeNormExpr(memo.Expr(_anyExpr))
+		return _f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_anyExpr))
 	}
 
-	return _f.onConstruct(_f.mem.MemoizeNormExpr(memo.Expr(_anyExpr)))
+	return _f.onConstruct(_f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_anyExpr)))
 }
 
 // ConstructVariable constructs an expression for the Variable operator.
@@ -1855,10 +1855,10 @@ func (_f *Factory) ConstructVariable(
 	}
 
 	if !_f.o.allowOptimizations() {
-		return _f.mem.MemoizeNormExpr(memo.Expr(_variableExpr))
+		return _f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_variableExpr))
 	}
 
-	return _f.onConstruct(_f.mem.MemoizeNormExpr(memo.Expr(_variableExpr)))
+	return _f.onConstruct(_f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_variableExpr)))
 }
 
 // ConstructConst constructs an expression for the Const operator.
@@ -1874,10 +1874,10 @@ func (_f *Factory) ConstructConst(
 	}
 
 	if !_f.o.allowOptimizations() {
-		return _f.mem.MemoizeNormExpr(memo.Expr(_constExpr))
+		return _f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_constExpr))
 	}
 
-	return _f.onConstruct(_f.mem.MemoizeNormExpr(memo.Expr(_constExpr)))
+	return _f.onConstruct(_f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_constExpr)))
 }
 
 // ConstructNull constructs an expression for the Null operator.
@@ -1907,10 +1907,10 @@ func (_f *Factory) ConstructNull(
 	}
 
 	if !_f.o.allowOptimizations() {
-		return _f.mem.MemoizeNormExpr(memo.Expr(_nullExpr))
+		return _f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_nullExpr))
 	}
 
-	return _f.onConstruct(_f.mem.MemoizeNormExpr(memo.Expr(_nullExpr)))
+	return _f.onConstruct(_f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_nullExpr)))
 }
 
 // ConstructTrue constructs an expression for the True operator.
@@ -1925,10 +1925,10 @@ func (_f *Factory) ConstructTrue() memo.GroupID {
 	}
 
 	if !_f.o.allowOptimizations() {
-		return _f.mem.MemoizeNormExpr(memo.Expr(_trueExpr))
+		return _f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_trueExpr))
 	}
 
-	return _f.onConstruct(_f.mem.MemoizeNormExpr(memo.Expr(_trueExpr)))
+	return _f.onConstruct(_f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_trueExpr)))
 }
 
 // ConstructFalse constructs an expression for the False operator.
@@ -1943,10 +1943,10 @@ func (_f *Factory) ConstructFalse() memo.GroupID {
 	}
 
 	if !_f.o.allowOptimizations() {
-		return _f.mem.MemoizeNormExpr(memo.Expr(_falseExpr))
+		return _f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_falseExpr))
 	}
 
-	return _f.onConstruct(_f.mem.MemoizeNormExpr(memo.Expr(_falseExpr)))
+	return _f.onConstruct(_f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_falseExpr)))
 }
 
 // ConstructPlaceholder constructs an expression for the Placeholder operator.
@@ -1960,10 +1960,10 @@ func (_f *Factory) ConstructPlaceholder(
 	}
 
 	if !_f.o.allowOptimizations() {
-		return _f.mem.MemoizeNormExpr(memo.Expr(_placeholderExpr))
+		return _f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_placeholderExpr))
 	}
 
-	return _f.onConstruct(_f.mem.MemoizeNormExpr(memo.Expr(_placeholderExpr)))
+	return _f.onConstruct(_f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_placeholderExpr)))
 }
 
 // ConstructTuple constructs an expression for the Tuple operator.
@@ -1977,10 +1977,10 @@ func (_f *Factory) ConstructTuple(
 	}
 
 	if !_f.o.allowOptimizations() {
-		return _f.mem.MemoizeNormExpr(memo.Expr(_tupleExpr))
+		return _f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_tupleExpr))
 	}
 
-	return _f.onConstruct(_f.mem.MemoizeNormExpr(memo.Expr(_tupleExpr)))
+	return _f.onConstruct(_f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_tupleExpr)))
 }
 
 // ConstructProjections constructs an expression for the Projections operator.
@@ -1999,10 +1999,10 @@ func (_f *Factory) ConstructProjections(
 	}
 
 	if !_f.o.allowOptimizations() {
-		return _f.mem.MemoizeNormExpr(memo.Expr(_projectionsExpr))
+		return _f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_projectionsExpr))
 	}
 
-	return _f.onConstruct(_f.mem.MemoizeNormExpr(memo.Expr(_projectionsExpr)))
+	return _f.onConstruct(_f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_projectionsExpr)))
 }
 
 // ConstructAggregations constructs an expression for the Aggregations operator.
@@ -2021,10 +2021,10 @@ func (_f *Factory) ConstructAggregations(
 	}
 
 	if !_f.o.allowOptimizations() {
-		return _f.mem.MemoizeNormExpr(memo.Expr(_aggregationsExpr))
+		return _f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_aggregationsExpr))
 	}
 
-	return _f.onConstruct(_f.mem.MemoizeNormExpr(memo.Expr(_aggregationsExpr)))
+	return _f.onConstruct(_f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_aggregationsExpr)))
 }
 
 // ConstructExists constructs an expression for the Exists operator.
@@ -2038,10 +2038,10 @@ func (_f *Factory) ConstructExists(
 	}
 
 	if !_f.o.allowOptimizations() {
-		return _f.mem.MemoizeNormExpr(memo.Expr(_existsExpr))
+		return _f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_existsExpr))
 	}
 
-	return _f.onConstruct(_f.mem.MemoizeNormExpr(memo.Expr(_existsExpr)))
+	return _f.onConstruct(_f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_existsExpr)))
 }
 
 // ConstructFilters constructs an expression for the Filters operator.
@@ -2066,7 +2066,7 @@ func (_f *Factory) ConstructFilters(
 	}
 
 	if !_f.o.allowOptimizations() {
-		return _f.mem.MemoizeNormExpr(memo.Expr(_filtersExpr))
+		return _f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_filtersExpr))
 	}
 
 	// [EliminateEmptyAnd]
@@ -2092,7 +2092,7 @@ func (_f *Factory) ConstructFilters(
 		}
 	}
 
-	return _f.onConstruct(_f.mem.MemoizeNormExpr(memo.Expr(_filtersExpr)))
+	return _f.onConstruct(_f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_filtersExpr)))
 }
 
 // ConstructAnd constructs an expression for the And operator.
@@ -2109,7 +2109,7 @@ func (_f *Factory) ConstructAnd(
 	}
 
 	if !_f.o.allowOptimizations() {
-		return _f.mem.MemoizeNormExpr(memo.Expr(_andExpr))
+		return _f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_andExpr))
 	}
 
 	// [EliminateEmptyAnd]
@@ -2165,7 +2165,7 @@ func (_f *Factory) ConstructAnd(
 		}
 	}
 
-	return _f.onConstruct(_f.mem.MemoizeNormExpr(memo.Expr(_andExpr)))
+	return _f.onConstruct(_f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_andExpr)))
 }
 
 // ConstructOr constructs an expression for the Or operator.
@@ -2182,7 +2182,7 @@ func (_f *Factory) ConstructOr(
 	}
 
 	if !_f.o.allowOptimizations() {
-		return _f.mem.MemoizeNormExpr(memo.Expr(_orExpr))
+		return _f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_orExpr))
 	}
 
 	// [EliminateEmptyOr]
@@ -2238,7 +2238,7 @@ func (_f *Factory) ConstructOr(
 		}
 	}
 
-	return _f.onConstruct(_f.mem.MemoizeNormExpr(memo.Expr(_orExpr)))
+	return _f.onConstruct(_f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_orExpr)))
 }
 
 // ConstructNot constructs an expression for the Not operator.
@@ -2254,7 +2254,7 @@ func (_f *Factory) ConstructNot(
 	}
 
 	if !_f.o.allowOptimizations() {
-		return _f.mem.MemoizeNormExpr(memo.Expr(_notExpr))
+		return _f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_notExpr))
 	}
 
 	// [NegateComparison]
@@ -2313,7 +2313,7 @@ func (_f *Factory) ConstructNot(
 		}
 	}
 
-	return _f.onConstruct(_f.mem.MemoizeNormExpr(memo.Expr(_notExpr)))
+	return _f.onConstruct(_f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_notExpr)))
 }
 
 // ConstructEq constructs an expression for the Eq operator.
@@ -2328,7 +2328,7 @@ func (_f *Factory) ConstructEq(
 	}
 
 	if !_f.o.allowOptimizations() {
-		return _f.mem.MemoizeNormExpr(memo.Expr(_eqExpr))
+		return _f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_eqExpr))
 	}
 
 	// [NormalizeCmpPlusConst]
@@ -2486,7 +2486,7 @@ func (_f *Factory) ConstructEq(
 		}
 	}
 
-	return _f.onConstruct(_f.mem.MemoizeNormExpr(memo.Expr(_eqExpr)))
+	return _f.onConstruct(_f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_eqExpr)))
 }
 
 // ConstructLt constructs an expression for the Lt operator.
@@ -2501,7 +2501,7 @@ func (_f *Factory) ConstructLt(
 	}
 
 	if !_f.o.allowOptimizations() {
-		return _f.mem.MemoizeNormExpr(memo.Expr(_ltExpr))
+		return _f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_ltExpr))
 	}
 
 	// [CommuteVarInequality]
@@ -2637,7 +2637,7 @@ func (_f *Factory) ConstructLt(
 		}
 	}
 
-	return _f.onConstruct(_f.mem.MemoizeNormExpr(memo.Expr(_ltExpr)))
+	return _f.onConstruct(_f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_ltExpr)))
 }
 
 // ConstructGt constructs an expression for the Gt operator.
@@ -2652,7 +2652,7 @@ func (_f *Factory) ConstructGt(
 	}
 
 	if !_f.o.allowOptimizations() {
-		return _f.mem.MemoizeNormExpr(memo.Expr(_gtExpr))
+		return _f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_gtExpr))
 	}
 
 	// [CommuteVarInequality]
@@ -2788,7 +2788,7 @@ func (_f *Factory) ConstructGt(
 		}
 	}
 
-	return _f.onConstruct(_f.mem.MemoizeNormExpr(memo.Expr(_gtExpr)))
+	return _f.onConstruct(_f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_gtExpr)))
 }
 
 // ConstructLe constructs an expression for the Le operator.
@@ -2803,7 +2803,7 @@ func (_f *Factory) ConstructLe(
 	}
 
 	if !_f.o.allowOptimizations() {
-		return _f.mem.MemoizeNormExpr(memo.Expr(_leExpr))
+		return _f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_leExpr))
 	}
 
 	// [CommuteVarInequality]
@@ -2939,7 +2939,7 @@ func (_f *Factory) ConstructLe(
 		}
 	}
 
-	return _f.onConstruct(_f.mem.MemoizeNormExpr(memo.Expr(_leExpr)))
+	return _f.onConstruct(_f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_leExpr)))
 }
 
 // ConstructGe constructs an expression for the Ge operator.
@@ -2954,7 +2954,7 @@ func (_f *Factory) ConstructGe(
 	}
 
 	if !_f.o.allowOptimizations() {
-		return _f.mem.MemoizeNormExpr(memo.Expr(_geExpr))
+		return _f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_geExpr))
 	}
 
 	// [CommuteVarInequality]
@@ -3090,7 +3090,7 @@ func (_f *Factory) ConstructGe(
 		}
 	}
 
-	return _f.onConstruct(_f.mem.MemoizeNormExpr(memo.Expr(_geExpr)))
+	return _f.onConstruct(_f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_geExpr)))
 }
 
 // ConstructNe constructs an expression for the Ne operator.
@@ -3105,7 +3105,7 @@ func (_f *Factory) ConstructNe(
 	}
 
 	if !_f.o.allowOptimizations() {
-		return _f.mem.MemoizeNormExpr(memo.Expr(_neExpr))
+		return _f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_neExpr))
 	}
 
 	// [FoldNullComparisonLeft]
@@ -3166,7 +3166,7 @@ func (_f *Factory) ConstructNe(
 		}
 	}
 
-	return _f.onConstruct(_f.mem.MemoizeNormExpr(memo.Expr(_neExpr)))
+	return _f.onConstruct(_f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_neExpr)))
 }
 
 // ConstructIn constructs an expression for the In operator.
@@ -3181,7 +3181,7 @@ func (_f *Factory) ConstructIn(
 	}
 
 	if !_f.o.allowOptimizations() {
-		return _f.mem.MemoizeNormExpr(memo.Expr(_inExpr))
+		return _f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_inExpr))
 	}
 
 	// [FoldNullInNonEmpty]
@@ -3256,7 +3256,7 @@ func (_f *Factory) ConstructIn(
 		}
 	}
 
-	return _f.onConstruct(_f.mem.MemoizeNormExpr(memo.Expr(_inExpr)))
+	return _f.onConstruct(_f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_inExpr)))
 }
 
 // ConstructNotIn constructs an expression for the NotIn operator.
@@ -3271,7 +3271,7 @@ func (_f *Factory) ConstructNotIn(
 	}
 
 	if !_f.o.allowOptimizations() {
-		return _f.mem.MemoizeNormExpr(memo.Expr(_notInExpr))
+		return _f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_notInExpr))
 	}
 
 	// [FoldNullInNonEmpty]
@@ -3346,7 +3346,7 @@ func (_f *Factory) ConstructNotIn(
 		}
 	}
 
-	return _f.onConstruct(_f.mem.MemoizeNormExpr(memo.Expr(_notInExpr)))
+	return _f.onConstruct(_f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_notInExpr)))
 }
 
 // ConstructLike constructs an expression for the Like operator.
@@ -3361,7 +3361,7 @@ func (_f *Factory) ConstructLike(
 	}
 
 	if !_f.o.allowOptimizations() {
-		return _f.mem.MemoizeNormExpr(memo.Expr(_likeExpr))
+		return _f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_likeExpr))
 	}
 
 	// [FoldNullComparisonLeft]
@@ -3390,7 +3390,7 @@ func (_f *Factory) ConstructLike(
 		}
 	}
 
-	return _f.onConstruct(_f.mem.MemoizeNormExpr(memo.Expr(_likeExpr)))
+	return _f.onConstruct(_f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_likeExpr)))
 }
 
 // ConstructNotLike constructs an expression for the NotLike operator.
@@ -3405,7 +3405,7 @@ func (_f *Factory) ConstructNotLike(
 	}
 
 	if !_f.o.allowOptimizations() {
-		return _f.mem.MemoizeNormExpr(memo.Expr(_notLikeExpr))
+		return _f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_notLikeExpr))
 	}
 
 	// [FoldNullComparisonLeft]
@@ -3434,7 +3434,7 @@ func (_f *Factory) ConstructNotLike(
 		}
 	}
 
-	return _f.onConstruct(_f.mem.MemoizeNormExpr(memo.Expr(_notLikeExpr)))
+	return _f.onConstruct(_f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_notLikeExpr)))
 }
 
 // ConstructILike constructs an expression for the ILike operator.
@@ -3449,7 +3449,7 @@ func (_f *Factory) ConstructILike(
 	}
 
 	if !_f.o.allowOptimizations() {
-		return _f.mem.MemoizeNormExpr(memo.Expr(_iLikeExpr))
+		return _f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_iLikeExpr))
 	}
 
 	// [FoldNullComparisonLeft]
@@ -3478,7 +3478,7 @@ func (_f *Factory) ConstructILike(
 		}
 	}
 
-	return _f.onConstruct(_f.mem.MemoizeNormExpr(memo.Expr(_iLikeExpr)))
+	return _f.onConstruct(_f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_iLikeExpr)))
 }
 
 // ConstructNotILike constructs an expression for the NotILike operator.
@@ -3493,7 +3493,7 @@ func (_f *Factory) ConstructNotILike(
 	}
 
 	if !_f.o.allowOptimizations() {
-		return _f.mem.MemoizeNormExpr(memo.Expr(_notILikeExpr))
+		return _f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_notILikeExpr))
 	}
 
 	// [FoldNullComparisonLeft]
@@ -3522,7 +3522,7 @@ func (_f *Factory) ConstructNotILike(
 		}
 	}
 
-	return _f.onConstruct(_f.mem.MemoizeNormExpr(memo.Expr(_notILikeExpr)))
+	return _f.onConstruct(_f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_notILikeExpr)))
 }
 
 // ConstructSimilarTo constructs an expression for the SimilarTo operator.
@@ -3537,7 +3537,7 @@ func (_f *Factory) ConstructSimilarTo(
 	}
 
 	if !_f.o.allowOptimizations() {
-		return _f.mem.MemoizeNormExpr(memo.Expr(_similarToExpr))
+		return _f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_similarToExpr))
 	}
 
 	// [FoldNullComparisonLeft]
@@ -3566,7 +3566,7 @@ func (_f *Factory) ConstructSimilarTo(
 		}
 	}
 
-	return _f.onConstruct(_f.mem.MemoizeNormExpr(memo.Expr(_similarToExpr)))
+	return _f.onConstruct(_f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_similarToExpr)))
 }
 
 // ConstructNotSimilarTo constructs an expression for the NotSimilarTo operator.
@@ -3581,7 +3581,7 @@ func (_f *Factory) ConstructNotSimilarTo(
 	}
 
 	if !_f.o.allowOptimizations() {
-		return _f.mem.MemoizeNormExpr(memo.Expr(_notSimilarToExpr))
+		return _f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_notSimilarToExpr))
 	}
 
 	// [FoldNullComparisonLeft]
@@ -3610,7 +3610,7 @@ func (_f *Factory) ConstructNotSimilarTo(
 		}
 	}
 
-	return _f.onConstruct(_f.mem.MemoizeNormExpr(memo.Expr(_notSimilarToExpr)))
+	return _f.onConstruct(_f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_notSimilarToExpr)))
 }
 
 // ConstructRegMatch constructs an expression for the RegMatch operator.
@@ -3625,7 +3625,7 @@ func (_f *Factory) ConstructRegMatch(
 	}
 
 	if !_f.o.allowOptimizations() {
-		return _f.mem.MemoizeNormExpr(memo.Expr(_regMatchExpr))
+		return _f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_regMatchExpr))
 	}
 
 	// [FoldNullComparisonLeft]
@@ -3654,7 +3654,7 @@ func (_f *Factory) ConstructRegMatch(
 		}
 	}
 
-	return _f.onConstruct(_f.mem.MemoizeNormExpr(memo.Expr(_regMatchExpr)))
+	return _f.onConstruct(_f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_regMatchExpr)))
 }
 
 // ConstructNotRegMatch constructs an expression for the NotRegMatch operator.
@@ -3669,7 +3669,7 @@ func (_f *Factory) ConstructNotRegMatch(
 	}
 
 	if !_f.o.allowOptimizations() {
-		return _f.mem.MemoizeNormExpr(memo.Expr(_notRegMatchExpr))
+		return _f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_notRegMatchExpr))
 	}
 
 	// [FoldNullComparisonLeft]
@@ -3698,7 +3698,7 @@ func (_f *Factory) ConstructNotRegMatch(
 		}
 	}
 
-	return _f.onConstruct(_f.mem.MemoizeNormExpr(memo.Expr(_notRegMatchExpr)))
+	return _f.onConstruct(_f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_notRegMatchExpr)))
 }
 
 // ConstructRegIMatch constructs an expression for the RegIMatch operator.
@@ -3713,7 +3713,7 @@ func (_f *Factory) ConstructRegIMatch(
 	}
 
 	if !_f.o.allowOptimizations() {
-		return _f.mem.MemoizeNormExpr(memo.Expr(_regIMatchExpr))
+		return _f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_regIMatchExpr))
 	}
 
 	// [FoldNullComparisonLeft]
@@ -3742,7 +3742,7 @@ func (_f *Factory) ConstructRegIMatch(
 		}
 	}
 
-	return _f.onConstruct(_f.mem.MemoizeNormExpr(memo.Expr(_regIMatchExpr)))
+	return _f.onConstruct(_f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_regIMatchExpr)))
 }
 
 // ConstructNotRegIMatch constructs an expression for the NotRegIMatch operator.
@@ -3757,7 +3757,7 @@ func (_f *Factory) ConstructNotRegIMatch(
 	}
 
 	if !_f.o.allowOptimizations() {
-		return _f.mem.MemoizeNormExpr(memo.Expr(_notRegIMatchExpr))
+		return _f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_notRegIMatchExpr))
 	}
 
 	// [FoldNullComparisonLeft]
@@ -3786,7 +3786,7 @@ func (_f *Factory) ConstructNotRegIMatch(
 		}
 	}
 
-	return _f.onConstruct(_f.mem.MemoizeNormExpr(memo.Expr(_notRegIMatchExpr)))
+	return _f.onConstruct(_f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_notRegIMatchExpr)))
 }
 
 // ConstructIs constructs an expression for the Is operator.
@@ -3801,7 +3801,7 @@ func (_f *Factory) ConstructIs(
 	}
 
 	if !_f.o.allowOptimizations() {
-		return _f.mem.MemoizeNormExpr(memo.Expr(_isExpr))
+		return _f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_isExpr))
 	}
 
 	// [CommuteVar]
@@ -3836,7 +3836,7 @@ func (_f *Factory) ConstructIs(
 		}
 	}
 
-	return _f.onConstruct(_f.mem.MemoizeNormExpr(memo.Expr(_isExpr)))
+	return _f.onConstruct(_f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_isExpr)))
 }
 
 // ConstructIsNot constructs an expression for the IsNot operator.
@@ -3851,7 +3851,7 @@ func (_f *Factory) ConstructIsNot(
 	}
 
 	if !_f.o.allowOptimizations() {
-		return _f.mem.MemoizeNormExpr(memo.Expr(_isNotExpr))
+		return _f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_isNotExpr))
 	}
 
 	// [CommuteVar]
@@ -3886,7 +3886,7 @@ func (_f *Factory) ConstructIsNot(
 		}
 	}
 
-	return _f.onConstruct(_f.mem.MemoizeNormExpr(memo.Expr(_isNotExpr)))
+	return _f.onConstruct(_f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_isNotExpr)))
 }
 
 // ConstructContains constructs an expression for the Contains operator.
@@ -3901,10 +3901,10 @@ func (_f *Factory) ConstructContains(
 	}
 
 	if !_f.o.allowOptimizations() {
-		return _f.mem.MemoizeNormExpr(memo.Expr(_containsExpr))
+		return _f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_containsExpr))
 	}
 
-	return _f.onConstruct(_f.mem.MemoizeNormExpr(memo.Expr(_containsExpr)))
+	return _f.onConstruct(_f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_containsExpr)))
 }
 
 // ConstructBitand constructs an expression for the Bitand operator.
@@ -3919,7 +3919,7 @@ func (_f *Factory) ConstructBitand(
 	}
 
 	if !_f.o.allowOptimizations() {
-		return _f.mem.MemoizeNormExpr(memo.Expr(_bitandExpr))
+		return _f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_bitandExpr))
 	}
 
 	// [CommuteVar]
@@ -3980,7 +3980,7 @@ func (_f *Factory) ConstructBitand(
 		}
 	}
 
-	return _f.onConstruct(_f.mem.MemoizeNormExpr(memo.Expr(_bitandExpr)))
+	return _f.onConstruct(_f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_bitandExpr)))
 }
 
 // ConstructBitor constructs an expression for the Bitor operator.
@@ -3995,7 +3995,7 @@ func (_f *Factory) ConstructBitor(
 	}
 
 	if !_f.o.allowOptimizations() {
-		return _f.mem.MemoizeNormExpr(memo.Expr(_bitorExpr))
+		return _f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_bitorExpr))
 	}
 
 	// [CommuteVar]
@@ -4056,7 +4056,7 @@ func (_f *Factory) ConstructBitor(
 		}
 	}
 
-	return _f.onConstruct(_f.mem.MemoizeNormExpr(memo.Expr(_bitorExpr)))
+	return _f.onConstruct(_f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_bitorExpr)))
 }
 
 // ConstructBitxor constructs an expression for the Bitxor operator.
@@ -4071,7 +4071,7 @@ func (_f *Factory) ConstructBitxor(
 	}
 
 	if !_f.o.allowOptimizations() {
-		return _f.mem.MemoizeNormExpr(memo.Expr(_bitxorExpr))
+		return _f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_bitxorExpr))
 	}
 
 	// [CommuteVar]
@@ -4132,7 +4132,7 @@ func (_f *Factory) ConstructBitxor(
 		}
 	}
 
-	return _f.onConstruct(_f.mem.MemoizeNormExpr(memo.Expr(_bitxorExpr)))
+	return _f.onConstruct(_f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_bitxorExpr)))
 }
 
 // ConstructPlus constructs an expression for the Plus operator.
@@ -4147,7 +4147,7 @@ func (_f *Factory) ConstructPlus(
 	}
 
 	if !_f.o.allowOptimizations() {
-		return _f.mem.MemoizeNormExpr(memo.Expr(_plusExpr))
+		return _f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_plusExpr))
 	}
 
 	// [FoldPlusZero]
@@ -4234,7 +4234,7 @@ func (_f *Factory) ConstructPlus(
 		}
 	}
 
-	return _f.onConstruct(_f.mem.MemoizeNormExpr(memo.Expr(_plusExpr)))
+	return _f.onConstruct(_f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_plusExpr)))
 }
 
 // ConstructMinus constructs an expression for the Minus operator.
@@ -4249,7 +4249,7 @@ func (_f *Factory) ConstructMinus(
 	}
 
 	if !_f.o.allowOptimizations() {
-		return _f.mem.MemoizeNormExpr(memo.Expr(_minusExpr))
+		return _f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_minusExpr))
 	}
 
 	// [FoldMinusZero]
@@ -4291,7 +4291,7 @@ func (_f *Factory) ConstructMinus(
 		}
 	}
 
-	return _f.onConstruct(_f.mem.MemoizeNormExpr(memo.Expr(_minusExpr)))
+	return _f.onConstruct(_f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_minusExpr)))
 }
 
 // ConstructMult constructs an expression for the Mult operator.
@@ -4306,7 +4306,7 @@ func (_f *Factory) ConstructMult(
 	}
 
 	if !_f.o.allowOptimizations() {
-		return _f.mem.MemoizeNormExpr(memo.Expr(_multExpr))
+		return _f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_multExpr))
 	}
 
 	// [FoldMultOne]
@@ -4393,7 +4393,7 @@ func (_f *Factory) ConstructMult(
 		}
 	}
 
-	return _f.onConstruct(_f.mem.MemoizeNormExpr(memo.Expr(_multExpr)))
+	return _f.onConstruct(_f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_multExpr)))
 }
 
 // ConstructDiv constructs an expression for the Div operator.
@@ -4408,7 +4408,7 @@ func (_f *Factory) ConstructDiv(
 	}
 
 	if !_f.o.allowOptimizations() {
-		return _f.mem.MemoizeNormExpr(memo.Expr(_divExpr))
+		return _f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_divExpr))
 	}
 
 	// [FoldDivOne]
@@ -4450,7 +4450,7 @@ func (_f *Factory) ConstructDiv(
 		}
 	}
 
-	return _f.onConstruct(_f.mem.MemoizeNormExpr(memo.Expr(_divExpr)))
+	return _f.onConstruct(_f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_divExpr)))
 }
 
 // ConstructFloorDiv constructs an expression for the FloorDiv operator.
@@ -4465,7 +4465,7 @@ func (_f *Factory) ConstructFloorDiv(
 	}
 
 	if !_f.o.allowOptimizations() {
-		return _f.mem.MemoizeNormExpr(memo.Expr(_floorDivExpr))
+		return _f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_floorDivExpr))
 	}
 
 	// [FoldDivOne]
@@ -4507,7 +4507,7 @@ func (_f *Factory) ConstructFloorDiv(
 		}
 	}
 
-	return _f.onConstruct(_f.mem.MemoizeNormExpr(memo.Expr(_floorDivExpr)))
+	return _f.onConstruct(_f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_floorDivExpr)))
 }
 
 // ConstructMod constructs an expression for the Mod operator.
@@ -4522,7 +4522,7 @@ func (_f *Factory) ConstructMod(
 	}
 
 	if !_f.o.allowOptimizations() {
-		return _f.mem.MemoizeNormExpr(memo.Expr(_modExpr))
+		return _f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_modExpr))
 	}
 
 	// [FoldNullBinaryLeft]
@@ -4551,7 +4551,7 @@ func (_f *Factory) ConstructMod(
 		}
 	}
 
-	return _f.onConstruct(_f.mem.MemoizeNormExpr(memo.Expr(_modExpr)))
+	return _f.onConstruct(_f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_modExpr)))
 }
 
 // ConstructPow constructs an expression for the Pow operator.
@@ -4566,7 +4566,7 @@ func (_f *Factory) ConstructPow(
 	}
 
 	if !_f.o.allowOptimizations() {
-		return _f.mem.MemoizeNormExpr(memo.Expr(_powExpr))
+		return _f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_powExpr))
 	}
 
 	// [FoldNullBinaryLeft]
@@ -4595,7 +4595,7 @@ func (_f *Factory) ConstructPow(
 		}
 	}
 
-	return _f.onConstruct(_f.mem.MemoizeNormExpr(memo.Expr(_powExpr)))
+	return _f.onConstruct(_f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_powExpr)))
 }
 
 // ConstructConcat constructs an expression for the Concat operator.
@@ -4610,7 +4610,7 @@ func (_f *Factory) ConstructConcat(
 	}
 
 	if !_f.o.allowOptimizations() {
-		return _f.mem.MemoizeNormExpr(memo.Expr(_concatExpr))
+		return _f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_concatExpr))
 	}
 
 	// [FoldNullBinaryLeft]
@@ -4639,7 +4639,7 @@ func (_f *Factory) ConstructConcat(
 		}
 	}
 
-	return _f.onConstruct(_f.mem.MemoizeNormExpr(memo.Expr(_concatExpr)))
+	return _f.onConstruct(_f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_concatExpr)))
 }
 
 // ConstructLShift constructs an expression for the LShift operator.
@@ -4654,7 +4654,7 @@ func (_f *Factory) ConstructLShift(
 	}
 
 	if !_f.o.allowOptimizations() {
-		return _f.mem.MemoizeNormExpr(memo.Expr(_lShiftExpr))
+		return _f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_lShiftExpr))
 	}
 
 	// [FoldNullBinaryLeft]
@@ -4683,7 +4683,7 @@ func (_f *Factory) ConstructLShift(
 		}
 	}
 
-	return _f.onConstruct(_f.mem.MemoizeNormExpr(memo.Expr(_lShiftExpr)))
+	return _f.onConstruct(_f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_lShiftExpr)))
 }
 
 // ConstructRShift constructs an expression for the RShift operator.
@@ -4698,7 +4698,7 @@ func (_f *Factory) ConstructRShift(
 	}
 
 	if !_f.o.allowOptimizations() {
-		return _f.mem.MemoizeNormExpr(memo.Expr(_rShiftExpr))
+		return _f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_rShiftExpr))
 	}
 
 	// [FoldNullBinaryLeft]
@@ -4727,7 +4727,7 @@ func (_f *Factory) ConstructRShift(
 		}
 	}
 
-	return _f.onConstruct(_f.mem.MemoizeNormExpr(memo.Expr(_rShiftExpr)))
+	return _f.onConstruct(_f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_rShiftExpr)))
 }
 
 // ConstructFetchVal constructs an expression for the FetchVal operator.
@@ -4742,7 +4742,7 @@ func (_f *Factory) ConstructFetchVal(
 	}
 
 	if !_f.o.allowOptimizations() {
-		return _f.mem.MemoizeNormExpr(memo.Expr(_fetchValExpr))
+		return _f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_fetchValExpr))
 	}
 
 	// [FoldNullBinaryLeft]
@@ -4775,7 +4775,7 @@ func (_f *Factory) ConstructFetchVal(
 		}
 	}
 
-	return _f.onConstruct(_f.mem.MemoizeNormExpr(memo.Expr(_fetchValExpr)))
+	return _f.onConstruct(_f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_fetchValExpr)))
 }
 
 // ConstructFetchText constructs an expression for the FetchText operator.
@@ -4790,7 +4790,7 @@ func (_f *Factory) ConstructFetchText(
 	}
 
 	if !_f.o.allowOptimizations() {
-		return _f.mem.MemoizeNormExpr(memo.Expr(_fetchTextExpr))
+		return _f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_fetchTextExpr))
 	}
 
 	// [FoldNullBinaryLeft]
@@ -4823,7 +4823,7 @@ func (_f *Factory) ConstructFetchText(
 		}
 	}
 
-	return _f.onConstruct(_f.mem.MemoizeNormExpr(memo.Expr(_fetchTextExpr)))
+	return _f.onConstruct(_f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_fetchTextExpr)))
 }
 
 // ConstructFetchValPath constructs an expression for the FetchValPath operator.
@@ -4838,7 +4838,7 @@ func (_f *Factory) ConstructFetchValPath(
 	}
 
 	if !_f.o.allowOptimizations() {
-		return _f.mem.MemoizeNormExpr(memo.Expr(_fetchValPathExpr))
+		return _f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_fetchValPathExpr))
 	}
 
 	// [FoldNullBinaryLeft]
@@ -4871,7 +4871,7 @@ func (_f *Factory) ConstructFetchValPath(
 		}
 	}
 
-	return _f.onConstruct(_f.mem.MemoizeNormExpr(memo.Expr(_fetchValPathExpr)))
+	return _f.onConstruct(_f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_fetchValPathExpr)))
 }
 
 // ConstructFetchTextPath constructs an expression for the FetchTextPath operator.
@@ -4886,7 +4886,7 @@ func (_f *Factory) ConstructFetchTextPath(
 	}
 
 	if !_f.o.allowOptimizations() {
-		return _f.mem.MemoizeNormExpr(memo.Expr(_fetchTextPathExpr))
+		return _f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_fetchTextPathExpr))
 	}
 
 	// [FoldNullBinaryLeft]
@@ -4919,7 +4919,7 @@ func (_f *Factory) ConstructFetchTextPath(
 		}
 	}
 
-	return _f.onConstruct(_f.mem.MemoizeNormExpr(memo.Expr(_fetchTextPathExpr)))
+	return _f.onConstruct(_f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_fetchTextPathExpr)))
 }
 
 // ConstructUnaryMinus constructs an expression for the UnaryMinus operator.
@@ -4933,7 +4933,7 @@ func (_f *Factory) ConstructUnaryMinus(
 	}
 
 	if !_f.o.allowOptimizations() {
-		return _f.mem.MemoizeNormExpr(memo.Expr(_unaryMinusExpr))
+		return _f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_unaryMinusExpr))
 	}
 
 	// [InvertMinus]
@@ -4977,7 +4977,7 @@ func (_f *Factory) ConstructUnaryMinus(
 		}
 	}
 
-	return _f.onConstruct(_f.mem.MemoizeNormExpr(memo.Expr(_unaryMinusExpr)))
+	return _f.onConstruct(_f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_unaryMinusExpr)))
 }
 
 // ConstructUnaryComplement constructs an expression for the UnaryComplement operator.
@@ -4991,7 +4991,7 @@ func (_f *Factory) ConstructUnaryComplement(
 	}
 
 	if !_f.o.allowOptimizations() {
-		return _f.mem.MemoizeNormExpr(memo.Expr(_unaryComplementExpr))
+		return _f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_unaryComplementExpr))
 	}
 
 	// [FoldNullUnary]
@@ -5005,7 +5005,7 @@ func (_f *Factory) ConstructUnaryComplement(
 		}
 	}
 
-	return _f.onConstruct(_f.mem.MemoizeNormExpr(memo.Expr(_unaryComplementExpr)))
+	return _f.onConstruct(_f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_unaryComplementExpr)))
 }
 
 // ConstructCast constructs an expression for the Cast operator.
@@ -5020,7 +5020,7 @@ func (_f *Factory) ConstructCast(
 	}
 
 	if !_f.o.allowOptimizations() {
-		return _f.mem.MemoizeNormExpr(memo.Expr(_castExpr))
+		return _f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_castExpr))
 	}
 
 	// [EliminateCast]
@@ -5046,7 +5046,7 @@ func (_f *Factory) ConstructCast(
 		}
 	}
 
-	return _f.onConstruct(_f.mem.MemoizeNormExpr(memo.Expr(_castExpr)))
+	return _f.onConstruct(_f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_castExpr)))
 }
 
 // ConstructCase constructs an expression for the Case operator.
@@ -5077,10 +5077,10 @@ func (_f *Factory) ConstructCase(
 	}
 
 	if !_f.o.allowOptimizations() {
-		return _f.mem.MemoizeNormExpr(memo.Expr(_caseExpr))
+		return _f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_caseExpr))
 	}
 
-	return _f.onConstruct(_f.mem.MemoizeNormExpr(memo.Expr(_caseExpr)))
+	return _f.onConstruct(_f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_caseExpr)))
 }
 
 // ConstructWhen constructs an expression for the When operator.
@@ -5098,10 +5098,10 @@ func (_f *Factory) ConstructWhen(
 	}
 
 	if !_f.o.allowOptimizations() {
-		return _f.mem.MemoizeNormExpr(memo.Expr(_whenExpr))
+		return _f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_whenExpr))
 	}
 
-	return _f.onConstruct(_f.mem.MemoizeNormExpr(memo.Expr(_whenExpr)))
+	return _f.onConstruct(_f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_whenExpr)))
 }
 
 // ConstructFunction constructs an expression for the Function operator.
@@ -5119,10 +5119,10 @@ func (_f *Factory) ConstructFunction(
 	}
 
 	if !_f.o.allowOptimizations() {
-		return _f.mem.MemoizeNormExpr(memo.Expr(_functionExpr))
+		return _f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_functionExpr))
 	}
 
-	return _f.onConstruct(_f.mem.MemoizeNormExpr(memo.Expr(_functionExpr)))
+	return _f.onConstruct(_f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_functionExpr)))
 }
 
 // ConstructCoalesce constructs an expression for the Coalesce operator.
@@ -5136,7 +5136,7 @@ func (_f *Factory) ConstructCoalesce(
 	}
 
 	if !_f.o.allowOptimizations() {
-		return _f.mem.MemoizeNormExpr(memo.Expr(_coalesceExpr))
+		return _f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_coalesceExpr))
 	}
 
 	// [EliminateCoalesce]
@@ -5165,7 +5165,7 @@ func (_f *Factory) ConstructCoalesce(
 		}
 	}
 
-	return _f.onConstruct(_f.mem.MemoizeNormExpr(memo.Expr(_coalesceExpr)))
+	return _f.onConstruct(_f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_coalesceExpr)))
 }
 
 // ConstructUnsupportedExpr constructs an expression for the UnsupportedExpr operator.
@@ -5181,10 +5181,10 @@ func (_f *Factory) ConstructUnsupportedExpr(
 	}
 
 	if !_f.o.allowOptimizations() {
-		return _f.mem.MemoizeNormExpr(memo.Expr(_unsupportedExprExpr))
+		return _f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_unsupportedExprExpr))
 	}
 
-	return _f.onConstruct(_f.mem.MemoizeNormExpr(memo.Expr(_unsupportedExprExpr)))
+	return _f.onConstruct(_f.mem.MemoizeNormExpr(_f.evalCtx, memo.Expr(_unsupportedExprExpr)))
 }
 
 type dynConstructLookupFunc func(f *Factory, operands DynamicOperands) memo.GroupID

--- a/pkg/sql/opt/xform/testdata/coster/join
+++ b/pkg/sql/opt/xform/testdata/coster/join
@@ -38,8 +38,8 @@ inner-join
  │    │    │    ├── columns: a.k:1(int!null) a.d:4(decimal!null)
  │    │    │    ├── stats: [rows=1000]
  │    │    │    └── cost: 1000.00
- │    │    └── filters [type=bool, outer=(4)]
- │    │         └── eq [type=bool, outer=(4)]
+ │    │    └── filters [type=bool, outer=(4), constraints=(/4: [/1.0 - /1.0]; tight)]
+ │    │         └── eq [type=bool, outer=(4), constraints=(/4: [/1.0 - /1.0]; tight)]
  │    │              ├── variable: a.d [type=decimal, outer=(4)]
  │    │              └── const: 1.0 [type=decimal]
  │    └── projections [outer=(1)]

--- a/pkg/sql/opt/xform/testdata/rules/bool
+++ b/pkg/sql/opt/xform/testdata/rules/bool
@@ -50,11 +50,11 @@ select
  ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
  ├── scan a
  │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
- └── filters [type=bool, outer=(2,4)]
-      ├── eq [type=bool, outer=(2)]
+ └── filters [type=bool, outer=(2,4), constraints=(/2: [/5 - /5]; /4: (/NULL - /'foo'); tight)]
+      ├── eq [type=bool, outer=(2), constraints=(/2: [/5 - /5]; tight)]
       │    ├── variable: a.i [type=int, outer=(2)]
       │    └── const: 5 [type=int]
-      └── lt [type=bool, outer=(4)]
+      └── lt [type=bool, outer=(4), constraints=(/4: (/NULL - /'foo'); tight)]
            ├── variable: a.s [type=string, outer=(4)]
            └── const: 'foo' [type=string]
 
@@ -89,8 +89,8 @@ select
  ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
  ├── scan a
  │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
- └── filters [type=bool, outer=(1)]
-      └── eq [type=bool, outer=(1)]
+ └── filters [type=bool, outer=(1), constraints=(/1: [/1 - /1]; tight)]
+      └── eq [type=bool, outer=(1), constraints=(/1: [/1 - /1]; tight)]
            ├── variable: a.k [type=int, outer=(1)]
            └── const: 1 [type=int]
 
@@ -101,11 +101,11 @@ select
  ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
  ├── scan a
  │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
- └── filters [type=bool, outer=(1,2)]
-      ├── eq [type=bool, outer=(1)]
+ └── filters [type=bool, outer=(1,2), constraints=(/1: [/1 - /1]; /2: [/2 - /2]; tight)]
+      ├── eq [type=bool, outer=(1), constraints=(/1: [/1 - /1]; tight)]
       │    ├── variable: a.k [type=int, outer=(1)]
       │    └── const: 1 [type=int]
-      └── eq [type=bool, outer=(2)]
+      └── eq [type=bool, outer=(2), constraints=(/2: [/2 - /2]; tight)]
            ├── variable: a.i [type=int, outer=(2)]
            └── const: 2 [type=int]
 
@@ -124,17 +124,17 @@ select
  ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
  ├── scan a
  │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
- └── filters [type=bool, outer=(1,3,4)]
-      ├── gt [type=bool, outer=(1)]
+ └── filters [type=bool, outer=(1,3,4), constraints=(/1: [/2 - /4]; /3: [/3.5 - /3.5]; /4: [/'foo' - /'foo']; tight)]
+      ├── gt [type=bool, outer=(1), constraints=(/1: [/2 - ]; tight)]
       │    ├── variable: a.k [type=int, outer=(1)]
       │    └── const: 1 [type=int]
-      ├── lt [type=bool, outer=(1)]
+      ├── lt [type=bool, outer=(1), constraints=(/1: (/NULL - /4]; tight)]
       │    ├── variable: a.k [type=int, outer=(1)]
       │    └── const: 5 [type=int]
-      ├── eq [type=bool, outer=(3)]
+      ├── eq [type=bool, outer=(3), constraints=(/3: [/3.5 - /3.5]; tight)]
       │    ├── variable: a.f [type=float, outer=(3)]
       │    └── const: 3.5 [type=float]
-      └── eq [type=bool, outer=(4)]
+      └── eq [type=bool, outer=(4), constraints=(/4: [/'foo' - /'foo']; tight)]
            ├── variable: a.s [type=string, outer=(4)]
            └── const: 'foo' [type=string]
 
@@ -163,8 +163,8 @@ select
  ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
  ├── scan a
  │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
- └── filters [type=bool, outer=(1)]
-      └── eq [type=bool, outer=(1)]
+ └── filters [type=bool, outer=(1), constraints=(/1: [/1 - /1]; tight)]
+      └── eq [type=bool, outer=(1), constraints=(/1: [/1 - /1]; tight)]
            ├── variable: a.k [type=int, outer=(1)]
            └── const: 1 [type=int]
 
@@ -177,10 +177,10 @@ select
  │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
  └── filters [type=bool, outer=(1,2)]
       └── or [type=bool, outer=(1,2)]
-           ├── eq [type=bool, outer=(1)]
+           ├── eq [type=bool, outer=(1), constraints=(/1: [/1 - /1]; tight)]
            │    ├── variable: a.k [type=int, outer=(1)]
            │    └── const: 1 [type=int]
-           └── eq [type=bool, outer=(2)]
+           └── eq [type=bool, outer=(2), constraints=(/2: [/2 - /2]; tight)]
                 ├── variable: a.i [type=int, outer=(2)]
                 └── const: 2 [type=int]
 
@@ -204,16 +204,16 @@ select
  │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
  └── filters [type=bool, outer=(1-4)]
       └── or [type=bool, outer=(1-4)]
-           ├── eq [type=bool, outer=(1)]
+           ├── eq [type=bool, outer=(1), constraints=(/1: [/1 - /1]; tight)]
            │    ├── variable: a.k [type=int, outer=(1)]
            │    └── const: 1 [type=int]
-           ├── eq [type=bool, outer=(2)]
+           ├── eq [type=bool, outer=(2), constraints=(/2: [/2 - /2]; tight)]
            │    ├── variable: a.i [type=int, outer=(2)]
            │    └── const: 2 [type=int]
-           ├── eq [type=bool, outer=(3)]
+           ├── eq [type=bool, outer=(3), constraints=(/3: [/3.5 - /3.5]; tight)]
            │    ├── variable: a.f [type=float, outer=(3)]
            │    └── const: 3.5 [type=float]
-           └── eq [type=bool, outer=(4)]
+           └── eq [type=bool, outer=(4), constraints=(/4: [/'foo' - /'foo']; tight)]
                 ├── variable: a.s [type=string, outer=(4)]
                 └── const: 'foo' [type=string]
 
@@ -227,11 +227,11 @@ select
  ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
  ├── scan a
  │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
- └── filters [type=bool, outer=(1)]
-      ├── eq [type=bool, outer=(1)]
+ └── filters [type=bool, outer=(1), constraints=(contradiction; tight)]
+      ├── eq [type=bool, outer=(1), constraints=(/1: [/1 - /1]; tight)]
       │    ├── variable: a.k [type=int, outer=(1)]
       │    └── const: 1 [type=int]
-      └── eq [type=bool, outer=(1)]
+      └── eq [type=bool, outer=(1), constraints=(/1: [/2 - /2]; tight)]
            ├── variable: a.k [type=int, outer=(1)]
            └── const: 2 [type=int]
 
@@ -243,18 +243,18 @@ select
  ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
  ├── scan a
  │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
- └── filters [type=bool, outer=(1-4)]
+ └── filters [type=bool, outer=(1-4), constraints=(/4: [/'foo' - /'foo'])]
       ├── or [type=bool, outer=(1-3)]
-      │    ├── eq [type=bool, outer=(1)]
+      │    ├── eq [type=bool, outer=(1), constraints=(/1: [/1 - /1]; tight)]
       │    │    ├── variable: a.k [type=int, outer=(1)]
       │    │    └── const: 1 [type=int]
-      │    ├── eq [type=bool, outer=(2)]
+      │    ├── eq [type=bool, outer=(2), constraints=(/2: [/2 - /2]; tight)]
       │    │    ├── variable: a.i [type=int, outer=(2)]
       │    │    └── const: 2 [type=int]
-      │    └── eq [type=bool, outer=(3)]
+      │    └── eq [type=bool, outer=(3), constraints=(/3: [/3.5 - /3.5]; tight)]
       │         ├── variable: a.f [type=float, outer=(3)]
       │         └── const: 3.5 [type=float]
-      ├── eq [type=bool, outer=(4)]
+      ├── eq [type=bool, outer=(4), constraints=(/4: [/'foo' - /'foo']; tight)]
       │    ├── variable: a.s [type=string, outer=(4)]
       │    └── const: 'foo' [type=string]
       └── ne [type=bool, outer=(4)]
@@ -334,9 +334,9 @@ select
  └── filters [type=bool, outer=(1)]
       └── or [type=bool, outer=(1)]
            ├── null [type=unknown]
-           └── and [type=bool, outer=(1)]
+           └── and [type=bool, outer=(1), constraints=(/1: [/1 - /1])]
                 ├── null [type=unknown]
-                └── eq [type=bool, outer=(1)]
+                └── eq [type=bool, outer=(1), constraints=(/1: [/1 - /1]; tight)]
                      ├── variable: a.k [type=int, outer=(1)]
                      └── const: 1 [type=int]
 
@@ -352,23 +352,23 @@ select
  ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
  ├── scan a
  │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
- └── filters [type=bool, outer=(2)]
+ └── filters [type=bool, outer=(2), constraints=(contradiction)]
       ├── ne [type=bool, outer=(2)]
       │    ├── variable: a.i [type=int, outer=(2)]
       │    └── const: 1 [type=int]
-      ├── eq [type=bool, outer=(2)]
+      ├── eq [type=bool, outer=(2), constraints=(/2: [/1 - /1]; tight)]
       │    ├── variable: a.i [type=int, outer=(2)]
       │    └── const: 1 [type=int]
-      ├── le [type=bool, outer=(2)]
+      ├── le [type=bool, outer=(2), constraints=(/2: (/NULL - /1]; tight)]
       │    ├── variable: a.i [type=int, outer=(2)]
       │    └── const: 1 [type=int]
-      ├── lt [type=bool, outer=(2)]
+      ├── lt [type=bool, outer=(2), constraints=(/2: (/NULL - /0]; tight)]
       │    ├── variable: a.i [type=int, outer=(2)]
       │    └── const: 1 [type=int]
-      ├── ge [type=bool, outer=(2)]
+      ├── ge [type=bool, outer=(2), constraints=(/2: [/1 - ]; tight)]
       │    ├── variable: a.i [type=int, outer=(2)]
       │    └── const: 1 [type=int]
-      └── gt [type=bool, outer=(2)]
+      └── gt [type=bool, outer=(2), constraints=(/2: [/2 - ]; tight)]
            ├── variable: a.i [type=int, outer=(2)]
            └── const: 1 [type=int]
 
@@ -529,13 +529,13 @@ select
            ├── ge [type=bool, outer=(2,3)]
            │    ├── variable: a.i [type=int, outer=(2)]
            │    └── variable: a.f [type=float, outer=(3)]
-           ├── le [type=bool, outer=(2)]
+           ├── le [type=bool, outer=(2), constraints=(/2: (/NULL - /5]; tight)]
            │    ├── variable: a.i [type=int, outer=(2)]
            │    └── const: 5 [type=int]
-           ├── ge [type=bool, outer=(2)]
+           ├── ge [type=bool, outer=(2), constraints=(/2: [/10 - ]; tight)]
            │    ├── variable: a.i [type=int, outer=(2)]
            │    └── const: 10 [type=int]
-           └── le [type=bool, outer=(3)]
+           └── le [type=bool, outer=(3), constraints=(/3: (/NULL - /1.0]; tight)]
                 ├── variable: a.f [type=float, outer=(3)]
                 └── const: 1.0 [type=float]
 
@@ -570,20 +570,20 @@ select
  ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
  ├── scan a
  │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
- └── filters [type=bool, outer=(1-3)]
+ └── filters [type=bool, outer=(1-3), constraints=(contradiction)]
       ├── lt [type=bool, outer=(1,2)]
       │    ├── variable: a.k [type=int, outer=(1)]
       │    └── variable: a.i [type=int, outer=(2)]
       ├── ge [type=bool, outer=(2,3)]
       │    ├── variable: a.i [type=int, outer=(2)]
       │    └── variable: a.f [type=float, outer=(3)]
-      ├── le [type=bool, outer=(2)]
+      ├── le [type=bool, outer=(2), constraints=(/2: (/NULL - /5]; tight)]
       │    ├── variable: a.i [type=int, outer=(2)]
       │    └── const: 5 [type=int]
-      ├── ge [type=bool, outer=(2)]
+      ├── ge [type=bool, outer=(2), constraints=(/2: [/10 - ]; tight)]
       │    ├── variable: a.i [type=int, outer=(2)]
       │    └── const: 10 [type=int]
-      └── le [type=bool, outer=(3)]
+      └── le [type=bool, outer=(3), constraints=(/3: (/NULL - /1.0]; tight)]
            ├── variable: a.f [type=float, outer=(3)]
            └── const: 1.0 [type=float]
 
@@ -606,11 +606,11 @@ select
            │    └── ge [type=bool, outer=(2,3)]
            │         ├── variable: a.i [type=int, outer=(2)]
            │         └── variable: a.f [type=float, outer=(3)]
-           └── and [type=bool, outer=(2,3)]
-                ├── le [type=bool, outer=(2)]
+           └── and [type=bool, outer=(2,3), constraints=(/2: (/NULL - /5]; /3: (/NULL - /1.0]; tight)]
+                ├── le [type=bool, outer=(2), constraints=(/2: (/NULL - /5]; tight)]
                 │    ├── variable: a.i [type=int, outer=(2)]
                 │    └── const: 5 [type=int]
-                └── le [type=bool, outer=(3)]
+                └── le [type=bool, outer=(3), constraints=(/3: (/NULL - /1.0]; tight)]
                      ├── variable: a.f [type=float, outer=(3)]
                      └── const: 1.0 [type=float]
 
@@ -630,9 +630,9 @@ select
       │         ├── variable: a.i [type=int, outer=(2)]
       │         └── variable: a.f [type=float, outer=(3)]
       └── or [type=bool, outer=(2,3)]
-           ├── le [type=bool, outer=(2)]
+           ├── le [type=bool, outer=(2), constraints=(/2: (/NULL - /5]; tight)]
            │    ├── variable: a.i [type=int, outer=(2)]
            │    └── const: 5 [type=int]
-           └── le [type=bool, outer=(3)]
+           └── le [type=bool, outer=(3), constraints=(/3: (/NULL - /1.0]; tight)]
                 ├── variable: a.f [type=float, outer=(3)]
                 └── const: 1.0 [type=float]

--- a/pkg/sql/opt/xform/testdata/rules/comp
+++ b/pkg/sql/opt/xform/testdata/rules/comp
@@ -55,7 +55,7 @@ select
  ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
  ├── scan a
  │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
- └── filters [type=bool, outer=(1,2,4)]
+ └── filters [type=bool, outer=(1,2,4), constraints=(/2: (/NULL - /4]; /4: (/NULL - /'foo'])]
       ├── gt [type=bool, outer=(1,2)]
       │    ├── plus [type=int, outer=(1,2)]
       │    │    ├── variable: a.i [type=int, outer=(2)]
@@ -70,10 +70,10 @@ select
       │    │    └── const: 2 [type=int]
       │    └── function: length [type=int]
       │         └── const: 'bar' [type=string]
-      ├── lt [type=bool, outer=(2)]
+      ├── lt [type=bool, outer=(2), constraints=(/2: (/NULL - /4]; tight)]
       │    ├── variable: a.i [type=int, outer=(2)]
       │    └── const: 5 [type=int]
-      └── le [type=bool, outer=(4)]
+      └── le [type=bool, outer=(4), constraints=(/4: (/NULL - /'foo']; tight)]
            ├── variable: a.s [type=string, outer=(4)]
            └── const: 'foo' [type=string]
 
@@ -288,14 +288,14 @@ select
  ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
  ├── scan a
  │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
- └── filters [type=bool, outer=(2-4)]
-      ├── eq [type=bool, outer=(2)]
+ └── filters [type=bool, outer=(2-4), constraints=(/2: [/1 - /1]; /3: [/3.5 - /3.5]; /4: [/'foo' - /'foo']; tight)]
+      ├── eq [type=bool, outer=(2), constraints=(/2: [/1 - /1]; tight)]
       │    ├── variable: a.i [type=int, outer=(2)]
       │    └── const: 1 [type=int]
-      ├── eq [type=bool, outer=(3)]
+      ├── eq [type=bool, outer=(3), constraints=(/3: [/3.5 - /3.5]; tight)]
       │    ├── variable: a.f [type=float, outer=(3)]
       │    └── const: 3.5 [type=float]
-      └── eq [type=bool, outer=(4)]
+      └── eq [type=bool, outer=(4), constraints=(/4: [/'foo' - /'foo']; tight)]
            ├── variable: a.s [type=string, outer=(4)]
            └── const: 'foo' [type=string]
 
@@ -311,14 +311,14 @@ select
  ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
  ├── scan a
  │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
- └── filters [type=bool, outer=(1,2,4)]
-      ├── eq [type=bool, outer=(1)]
+ └── filters [type=bool, outer=(1,2,4), constraints=(/1: [/1 - /1]; /2: [/2 - /2]; /4: [/'foo' - /'foo']; tight)]
+      ├── eq [type=bool, outer=(1), constraints=(/1: [/1 - /1]; tight)]
       │    ├── variable: a.k [type=int, outer=(1)]
       │    └── const: 1 [type=int]
-      ├── eq [type=bool, outer=(2)]
+      ├── eq [type=bool, outer=(2), constraints=(/2: [/2 - /2]; tight)]
       │    ├── variable: a.i [type=int, outer=(2)]
       │    └── const: 2 [type=int]
-      └── eq [type=bool, outer=(4)]
+      └── eq [type=bool, outer=(4), constraints=(/4: [/'foo' - /'foo']; tight)]
            ├── variable: a.s [type=string, outer=(4)]
            └── const: 'foo' [type=string]
 

--- a/pkg/sql/opt/xform/testdata/rules/join
+++ b/pkg/sql/opt/xform/testdata/rules/join
@@ -67,10 +67,10 @@ inner-join
  │    └── columns: b.x:6(int!null) b.z:7(int)
  └── filters [type=bool, outer=(4,7)]
       └── or [type=bool, outer=(4,7)]
-           ├── eq [type=bool, outer=(4)]
+           ├── eq [type=bool, outer=(4), constraints=(/4: [/'foo' - /'foo']; tight)]
            │    ├── variable: a.s [type=string, outer=(4)]
            │    └── const: 'foo' [type=string]
-           └── lt [type=bool, outer=(7)]
+           └── lt [type=bool, outer=(7), constraints=(/7: (/NULL - /9]; tight)]
                 ├── variable: b.z [type=int, outer=(7)]
                 └── const: 10 [type=int]
 
@@ -86,8 +86,8 @@ inner-join
  │    ├── columns: a.x:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
  │    ├── scan a
  │    │    └── columns: a.x:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
- │    └── filters [type=bool, outer=(4)]
- │         └── eq [type=bool, outer=(4)]
+ │    └── filters [type=bool, outer=(4), constraints=(/4: [/'foo' - /'foo']; tight)]
+ │         └── eq [type=bool, outer=(4), constraints=(/4: [/'foo' - /'foo']; tight)]
  │              ├── variable: a.s [type=string, outer=(4)]
  │              └── const: 'foo' [type=string]
  ├── scan b
@@ -106,21 +106,21 @@ right-join
  │    ├── columns: a.x:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
  │    ├── scan a
  │    │    └── columns: a.x:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
- │    └── filters [type=bool, outer=(2,4)]
+ │    └── filters [type=bool, outer=(2,4), constraints=(/4: [/'foo' - /'foo'])]
  │         ├── or [type=bool, outer=(2)]
- │         │    ├── lt [type=bool, outer=(2)]
+ │         │    ├── lt [type=bool, outer=(2), constraints=(/2: (/NULL - /-1]; tight)]
  │         │    │    ├── variable: a.i [type=int, outer=(2)]
  │         │    │    └── const: 0 [type=int]
- │         │    └── gt [type=bool, outer=(2)]
+ │         │    └── gt [type=bool, outer=(2), constraints=(/2: [/11 - ]; tight)]
  │         │         ├── variable: a.i [type=int, outer=(2)]
  │         │         └── const: 10 [type=int]
- │         └── eq [type=bool, outer=(4)]
+ │         └── eq [type=bool, outer=(4), constraints=(/4: [/'foo' - /'foo']; tight)]
  │              ├── variable: a.s [type=string, outer=(4)]
  │              └── const: 'foo' [type=string]
  ├── scan b
  │    └── columns: b.x:6(int!null) b.z:7(int)
- └── filters [type=bool, outer=(1,6,7)]
-      ├── eq [type=bool, outer=(7)]
+ └── filters [type=bool, outer=(1,6,7), constraints=(/7: [/1 - /1])]
+      ├── eq [type=bool, outer=(7), constraints=(/7: [/1 - /1]; tight)]
       │    ├── variable: b.z [type=int, outer=(7)]
       │    └── const: 1 [type=int]
       └── eq [type=bool, outer=(1,6)]
@@ -137,11 +137,11 @@ left-join
  │    └── columns: a.x:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
  ├── scan b
  │    └── columns: b.x:6(int!null) b.z:7(int)
- └── filters [type=bool, outer=(1,2,6)]
+ └── filters [type=bool, outer=(1,2,6), constraints=(/2: [/1 - /1])]
       ├── eq [type=bool, outer=(1,6)]
       │    ├── variable: a.x [type=int, outer=(1)]
       │    └── variable: b.x [type=int, outer=(6)]
-      └── eq [type=bool, outer=(2)]
+      └── eq [type=bool, outer=(2), constraints=(/2: [/1 - /1]; tight)]
            ├── variable: a.i [type=int, outer=(2)]
            └── const: 1 [type=int]
 
@@ -159,8 +159,8 @@ inner-join
  │    ├── columns: a.x:3(int!null) a.i:4(int) a.f:5(float) a.s:6(string) a.j:7(jsonb)
  │    ├── scan a
  │    │    └── columns: a.x:3(int!null) a.i:4(int) a.f:5(float) a.s:6(string) a.j:7(jsonb)
- │    └── filters [type=bool, outer=(6)]
- │         └── eq [type=bool, outer=(6)]
+ │    └── filters [type=bool, outer=(6), constraints=(/6: [/'foo' - /'foo']; tight)]
+ │         └── eq [type=bool, outer=(6), constraints=(/6: [/'foo' - /'foo']; tight)]
  │              ├── variable: a.s [type=string, outer=(6)]
  │              └── const: 'foo' [type=string]
  └── filters [type=bool, outer=(1,3)]
@@ -179,19 +179,19 @@ left-join
  │    ├── columns: a.x:3(int!null) a.i:4(int) a.f:5(float) a.s:6(string) a.j:7(jsonb)
  │    ├── scan a
  │    │    └── columns: a.x:3(int!null) a.i:4(int) a.f:5(float) a.s:6(string) a.j:7(jsonb)
- │    └── filters [type=bool, outer=(4,6)]
+ │    └── filters [type=bool, outer=(4,6), constraints=(/6: [/'foo' - /'foo'])]
  │         ├── or [type=bool, outer=(4)]
- │         │    ├── lt [type=bool, outer=(4)]
+ │         │    ├── lt [type=bool, outer=(4), constraints=(/4: (/NULL - /-1]; tight)]
  │         │    │    ├── variable: a.i [type=int, outer=(4)]
  │         │    │    └── const: 0 [type=int]
- │         │    └── gt [type=bool, outer=(4)]
+ │         │    └── gt [type=bool, outer=(4), constraints=(/4: [/11 - ]; tight)]
  │         │         ├── variable: a.i [type=int, outer=(4)]
  │         │         └── const: 10 [type=int]
- │         └── eq [type=bool, outer=(6)]
+ │         └── eq [type=bool, outer=(6), constraints=(/6: [/'foo' - /'foo']; tight)]
  │              ├── variable: a.s [type=string, outer=(6)]
  │              └── const: 'foo' [type=string]
- └── filters [type=bool, outer=(1-3)]
-      ├── eq [type=bool, outer=(2)]
+ └── filters [type=bool, outer=(1-3), constraints=(/2: [/1 - /1])]
+      ├── eq [type=bool, outer=(2), constraints=(/2: [/1 - /1]; tight)]
       │    ├── variable: b.z [type=int, outer=(2)]
       │    └── const: 1 [type=int]
       └── eq [type=bool, outer=(1,3)]
@@ -208,11 +208,11 @@ right-join
  │    └── columns: b.x:1(int!null) b.z:2(int)
  ├── scan a
  │    └── columns: a.x:3(int!null) a.i:4(int) a.f:5(float) a.s:6(string) a.j:7(jsonb)
- └── filters [type=bool, outer=(1,3,4)]
+ └── filters [type=bool, outer=(1,3,4), constraints=(/4: [/1 - /1])]
       ├── eq [type=bool, outer=(1,3)]
       │    ├── variable: b.x [type=int, outer=(1)]
       │    └── variable: a.x [type=int, outer=(3)]
-      └── eq [type=bool, outer=(4)]
+      └── eq [type=bool, outer=(4), constraints=(/4: [/1 - /1]; tight)]
            ├── variable: a.i [type=int, outer=(4)]
            └── const: 1 [type=int]
 
@@ -229,16 +229,16 @@ inner-join
  │    ├── columns: a.x:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
  │    ├── scan a
  │    │    └── columns: a.x:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
- │    └── filters [type=bool, outer=(2)]
- │         └── eq [type=bool, outer=(2)]
+ │    └── filters [type=bool, outer=(2), constraints=(/2: [/1 - /1]; tight)]
+ │         └── eq [type=bool, outer=(2), constraints=(/2: [/1 - /1]; tight)]
  │              ├── variable: a.i [type=int, outer=(2)]
  │              └── const: 1 [type=int]
  ├── select
  │    ├── columns: b.x:6(int!null) b.z:7(int)
  │    ├── scan b
  │    │    └── columns: b.x:6(int!null) b.z:7(int)
- │    └── filters [type=bool, outer=(7)]
- │         └── eq [type=bool, outer=(7)]
+ │    └── filters [type=bool, outer=(7), constraints=(/7: [/1 - /1]; tight)]
+ │         └── eq [type=bool, outer=(7), constraints=(/7: [/1 - /1]; tight)]
  │              ├── variable: b.z [type=int, outer=(7)]
  │              └── const: 1 [type=int]
  └── filters [type=bool, outer=(1,6)]
@@ -256,13 +256,13 @@ full-join
  │    └── columns: a.x:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
  ├── scan b
  │    └── columns: b.x:6(int!null) b.z:7(int)
- └── filters [type=bool, outer=(1,2,6,7)]
+ └── filters [type=bool, outer=(1,2,6,7), constraints=(/2: [/1 - /1]; /7: [/1 - /1])]
       ├── eq [type=bool, outer=(1,6)]
       │    ├── variable: a.x [type=int, outer=(1)]
       │    └── variable: b.x [type=int, outer=(6)]
-      ├── eq [type=bool, outer=(2)]
+      ├── eq [type=bool, outer=(2), constraints=(/2: [/1 - /1]; tight)]
       │    ├── variable: a.i [type=int, outer=(2)]
       │    └── const: 1 [type=int]
-      └── eq [type=bool, outer=(7)]
+      └── eq [type=bool, outer=(7), constraints=(/7: [/1 - /1]; tight)]
            ├── variable: b.z [type=int, outer=(7)]
            └── const: 1 [type=int]

--- a/pkg/sql/opt/xform/testdata/rules/project
+++ b/pkg/sql/opt/xform/testdata/rules/project
@@ -190,8 +190,8 @@ project
  │    ├── columns: a.x:1(int!null) a.y:2(int)
  │    ├── scan a
  │    │    └── columns: a.x:1(int!null) a.y:2(int)
- │    └── filters [type=bool, outer=(2)]
- │         └── lt [type=bool, outer=(2)]
+ │    └── filters [type=bool, outer=(2), constraints=(/2: (/NULL - /4]; tight)]
+ │         └── lt [type=bool, outer=(2), constraints=(/2: (/NULL - /4]; tight)]
  │              ├── variable: a.y [type=int, outer=(2)]
  │              └── const: 5 [type=int]
  └── projections [outer=(1)]
@@ -205,11 +205,11 @@ select
  ├── columns: x:1(int!null) y:2(int)
  ├── scan a
  │    └── columns: a.x:1(int!null) a.y:2(int)
- └── filters [type=bool, outer=(1,2)]
-      ├── eq [type=bool, outer=(1)]
+ └── filters [type=bool, outer=(1,2), constraints=(/1: [/1 - /1]; /2: (/NULL - /4]; tight)]
+      ├── eq [type=bool, outer=(1), constraints=(/1: [/1 - /1]; tight)]
       │    ├── variable: a.x [type=int, outer=(1)]
       │    └── const: 1 [type=int]
-      └── lt [type=bool, outer=(2)]
+      └── lt [type=bool, outer=(2), constraints=(/2: (/NULL - /4]; tight)]
            ├── variable: a.y [type=int, outer=(2)]
            └── const: 5 [type=int]
 
@@ -271,8 +271,8 @@ project
  │    │    │    ├── columns: a.x:1(int!null) a.y:2(int) a.f:3(float)
  │    │    │    ├── scan a
  │    │    │    │    └── columns: a.x:1(int!null) a.y:2(int) a.f:3(float)
- │    │    │    └── filters [type=bool, outer=(1)]
- │    │    │         └── eq [type=bool, outer=(1)]
+ │    │    │    └── filters [type=bool, outer=(1), constraints=(/1: [/5 - /5]; tight)]
+ │    │    │         └── eq [type=bool, outer=(1), constraints=(/1: [/5 - /5]; tight)]
  │    │    │              ├── variable: a.x [type=int, outer=(1)]
  │    │    │              └── const: 5 [type=int]
  │    │    └── projections [outer=(2,3)]
@@ -489,11 +489,11 @@ left-join
  │    └── columns: a.x:1(int!null) a.y:2(int)
  ├── scan b
  │    └── columns: b.x:5(int!null) b.z:6(int)
- └── filters [type=bool, outer=(1,2,5)]
+ └── filters [type=bool, outer=(1,2,5), constraints=(/2: (/NULL - /4])]
       ├── eq [type=bool, outer=(1,5)]
       │    ├── variable: a.x [type=int, outer=(1)]
       │    └── variable: b.x [type=int, outer=(5)]
-      └── lt [type=bool, outer=(2)]
+      └── lt [type=bool, outer=(2), constraints=(/2: (/NULL - /4]; tight)]
            ├── variable: a.y [type=int, outer=(2)]
            └── const: 5 [type=int]
 
@@ -1047,8 +1047,8 @@ project
  │    │    │    ├── columns: a.x:1(int!null) a.y:2(int)
  │    │    │    ├── scan a
  │    │    │    │    └── columns: a.x:1(int!null) a.y:2(int)
- │    │    │    └── filters [type=bool, outer=(2)]
- │    │    │         └── lt [type=bool, outer=(2)]
+ │    │    │    └── filters [type=bool, outer=(2), constraints=(/2: (/NULL - /4]; tight)]
+ │    │    │         └── lt [type=bool, outer=(2), constraints=(/2: (/NULL - /4]; tight)]
  │    │    │              ├── variable: a.y [type=int, outer=(2)]
  │    │    │              └── const: 5 [type=int]
  │    │    └── projections [outer=(1)]
@@ -1078,8 +1078,8 @@ project
  │    │    └── aggregations [outer=(2)]
  │    │         └── function: sum [type=decimal, outer=(2)]
  │    │              └── variable: a.y [type=int, outer=(2)]
- │    └── filters [type=bool, outer=(5)]
- │         └── gt [type=bool, outer=(5)]
+ │    └── filters [type=bool, outer=(5), constraints=(/5: (/5 - ]; tight)]
+ │         └── gt [type=bool, outer=(5), constraints=(/5: (/5 - ]; tight)]
  │              ├── variable: column5 [type=decimal, outer=(5)]
  │              └── const: 5 [type=decimal]
  └── projections [outer=(1)]

--- a/pkg/sql/opt/xform/testdata/rules/select
+++ b/pkg/sql/opt/xform/testdata/rules/select
@@ -29,11 +29,11 @@ select
  ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
  ├── scan a
  │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
- └── filters [type=bool, outer=(2,4)]
-      ├── eq [type=bool, outer=(2)]
+ └── filters [type=bool, outer=(2,4), constraints=(/2: [/5 - /5]; /4: (/NULL - /'foo'); tight)]
+      ├── eq [type=bool, outer=(2), constraints=(/2: [/5 - /5]; tight)]
       │    ├── variable: a.i [type=int, outer=(2)]
       │    └── const: 5 [type=int]
-      └── lt [type=bool, outer=(4)]
+      └── lt [type=bool, outer=(4), constraints=(/4: (/NULL - /'foo'); tight)]
            ├── variable: a.s [type=string, outer=(4)]
            └── const: 'foo' [type=string]
 
@@ -47,8 +47,8 @@ select
  ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
  ├── scan a
  │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
- └── filters [type=bool, outer=(2)]
-      └── lt [type=bool, outer=(2)]
+ └── filters [type=bool, outer=(2), constraints=(/2: (/NULL - /4]; tight)]
+      └── lt [type=bool, outer=(2), constraints=(/2: (/NULL - /4]; tight)]
            ├── variable: a.i [type=int, outer=(2)]
            └── const: 5 [type=int]
 
@@ -61,10 +61,10 @@ select
  │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
  └── filters [type=bool, outer=(2,4)]
       └── or [type=bool, outer=(2,4)]
-           ├── lt [type=bool, outer=(2)]
+           ├── lt [type=bool, outer=(2), constraints=(/2: (/NULL - /4]; tight)]
            │    ├── variable: a.i [type=int, outer=(2)]
            │    └── const: 5 [type=int]
-           └── eq [type=bool, outer=(4)]
+           └── eq [type=bool, outer=(4), constraints=(/4: [/'foo' - /'foo']; tight)]
                 ├── variable: a.s [type=string, outer=(4)]
                 └── const: 'foo' [type=string]
 
@@ -130,11 +130,11 @@ select
  ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
  ├── scan a
  │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
- └── filters [type=bool, outer=(2,4)]
-      ├── lt [type=bool, outer=(2)]
+ └── filters [type=bool, outer=(2,4), constraints=(/2: (/NULL - /4]; /4: [/'foo' - /'foo']; tight)]
+      ├── lt [type=bool, outer=(2), constraints=(/2: (/NULL - /4]; tight)]
       │    ├── variable: a.i [type=int, outer=(2)]
       │    └── const: 5 [type=int]
-      └── eq [type=bool, outer=(4)]
+      └── eq [type=bool, outer=(4), constraints=(/4: [/'foo' - /'foo']; tight)]
            ├── variable: a.s [type=string, outer=(4)]
            └── const: 'foo' [type=string]
 
@@ -145,18 +145,18 @@ select
  ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
  ├── scan a
  │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
- └── filters [type=bool, outer=(1,2,4)]
-      ├── gt [type=bool, outer=(2)]
+ └── filters [type=bool, outer=(1,2,4), constraints=(/2: [/2 - /9])]
+      ├── gt [type=bool, outer=(2), constraints=(/2: [/2 - ]; tight)]
       │    ├── variable: a.i [type=int, outer=(2)]
       │    └── const: 1 [type=int]
-      ├── lt [type=bool, outer=(2)]
+      ├── lt [type=bool, outer=(2), constraints=(/2: (/NULL - /9]; tight)]
       │    ├── variable: a.i [type=int, outer=(2)]
       │    └── const: 10 [type=int]
       └── or [type=bool, outer=(1,4)]
-           ├── eq [type=bool, outer=(4)]
+           ├── eq [type=bool, outer=(4), constraints=(/4: [/'foo' - /'foo']; tight)]
            │    ├── variable: a.s [type=string, outer=(4)]
            │    └── const: 'foo' [type=string]
-           └── eq [type=bool, outer=(1)]
+           └── eq [type=bool, outer=(1), constraints=(/1: [/5 - /5]; tight)]
                 ├── variable: a.k [type=int, outer=(1)]
                 └── const: 5 [type=int]
 
@@ -172,8 +172,8 @@ inner-join
  │    ├── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
  │    ├── scan a
  │    │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
- │    └── filters [type=bool, outer=(3)]
- │         └── eq [type=bool, outer=(3)]
+ │    └── filters [type=bool, outer=(3), constraints=(/3: [/1.1 - /1.1]; tight)]
+ │         └── eq [type=bool, outer=(3), constraints=(/3: [/1.1 - /1.1]; tight)]
  │              ├── variable: a.f [type=float, outer=(3)]
  │              └── const: 1.1 [type=float]
  ├── scan b
@@ -194,15 +194,15 @@ select
  │    │    ├── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
  │    │    ├── scan a
  │    │    │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
- │    │    └── filters [type=bool, outer=(3,4)]
- │    │         ├── eq [type=bool, outer=(3)]
+ │    │    └── filters [type=bool, outer=(3,4), constraints=(/3: [/1.1 - /1.1])]
+ │    │         ├── eq [type=bool, outer=(3), constraints=(/3: [/1.1 - /1.1]; tight)]
  │    │         │    ├── variable: a.f [type=float, outer=(3)]
  │    │         │    └── const: 1.1 [type=float]
  │    │         └── or [type=bool, outer=(4)]
- │    │              ├── eq [type=bool, outer=(4)]
+ │    │              ├── eq [type=bool, outer=(4), constraints=(/4: [/'foo' - /'foo']; tight)]
  │    │              │    ├── variable: a.s [type=string, outer=(4)]
  │    │              │    └── const: 'foo' [type=string]
- │    │              └── eq [type=bool, outer=(4)]
+ │    │              └── eq [type=bool, outer=(4), constraints=(/4: [/'bar' - /'bar']; tight)]
  │    │                   ├── variable: a.s [type=string, outer=(4)]
  │    │                   └── const: 'bar' [type=string]
  │    ├── scan b
@@ -226,8 +226,8 @@ inner-join
  │    ├── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
  │    ├── scan a
  │    │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
- │    └── filters [type=bool, outer=(2)]
- │         ├── eq [type=bool, outer=(2)]
+ │    └── filters [type=bool, outer=(2), constraints=(/2: [/100 - /100])]
+ │         ├── eq [type=bool, outer=(2), constraints=(/2: [/100 - /100]; tight)]
  │         │    ├── variable: a.i [type=int, outer=(2)]
  │         │    └── const: 100 [type=int]
  │         └── gt [type=bool]
@@ -253,8 +253,8 @@ select
  │         └── eq [type=bool, outer=(1,6)]
  │              ├── variable: a.k [type=int, outer=(1)]
  │              └── variable: b.x [type=int, outer=(6)]
- └── filters [type=bool, outer=(2)]
-      └── eq [type=bool, outer=(2)]
+ └── filters [type=bool, outer=(2), constraints=(/2: [/100 - /100]; tight)]
+      └── eq [type=bool, outer=(2), constraints=(/2: [/100 - /100]; tight)]
            ├── variable: a.i [type=int, outer=(2)]
            └── const: 100 [type=int]
 
@@ -274,8 +274,8 @@ select
  │         └── eq [type=bool, outer=(1,6)]
  │              ├── variable: a.k [type=int, outer=(1)]
  │              └── variable: b.x [type=int, outer=(6)]
- └── filters [type=bool, outer=(2)]
-      └── eq [type=bool, outer=(2)]
+ └── filters [type=bool, outer=(2), constraints=(/2: [/100 - /100]; tight)]
+      └── eq [type=bool, outer=(2), constraints=(/2: [/100 - /100]; tight)]
            ├── variable: a.i [type=int, outer=(2)]
            └── const: 100 [type=int]
 
@@ -293,8 +293,8 @@ inner-join
  │    ├── columns: a.k:3(int!null) a.i:4(int) a.f:5(float) a.s:6(string) a.j:7(jsonb)
  │    ├── scan a
  │    │    └── columns: a.k:3(int!null) a.i:4(int) a.f:5(float) a.s:6(string) a.j:7(jsonb)
- │    └── filters [type=bool, outer=(5)]
- │         └── eq [type=bool, outer=(5)]
+ │    └── filters [type=bool, outer=(5), constraints=(/5: [/1.1 - /1.1]; tight)]
+ │         └── eq [type=bool, outer=(5), constraints=(/5: [/1.1 - /1.1]; tight)]
  │              ├── variable: a.f [type=float, outer=(5)]
  │              └── const: 1.1 [type=float]
  └── filters [type=bool, outer=(1,3)]
@@ -315,15 +315,15 @@ select
  │    │    ├── columns: a.k:3(int!null) a.i:4(int) a.f:5(float) a.s:6(string) a.j:7(jsonb)
  │    │    ├── scan a
  │    │    │    └── columns: a.k:3(int!null) a.i:4(int) a.f:5(float) a.s:6(string) a.j:7(jsonb)
- │    │    └── filters [type=bool, outer=(5,6)]
- │    │         ├── eq [type=bool, outer=(5)]
+ │    │    └── filters [type=bool, outer=(5,6), constraints=(/5: [/1.1 - /1.1])]
+ │    │         ├── eq [type=bool, outer=(5), constraints=(/5: [/1.1 - /1.1]; tight)]
  │    │         │    ├── variable: a.f [type=float, outer=(5)]
  │    │         │    └── const: 1.1 [type=float]
  │    │         └── or [type=bool, outer=(6)]
- │    │              ├── eq [type=bool, outer=(6)]
+ │    │              ├── eq [type=bool, outer=(6), constraints=(/6: [/'foo' - /'foo']; tight)]
  │    │              │    ├── variable: a.s [type=string, outer=(6)]
  │    │              │    └── const: 'foo' [type=string]
- │    │              └── eq [type=bool, outer=(6)]
+ │    │              └── eq [type=bool, outer=(6), constraints=(/6: [/'bar' - /'bar']; tight)]
  │    │                   ├── variable: a.s [type=string, outer=(6)]
  │    │                   └── const: 'bar' [type=string]
  │    └── filters [type=bool, outer=(1,3)]
@@ -351,8 +351,8 @@ select
  │         └── eq [type=bool, outer=(1,3)]
  │              ├── variable: a.k [type=int, outer=(3)]
  │              └── variable: b.x [type=int, outer=(1)]
- └── filters [type=bool, outer=(4)]
-      └── eq [type=bool, outer=(4)]
+ └── filters [type=bool, outer=(4), constraints=(/4: [/100 - /100]; tight)]
+      └── eq [type=bool, outer=(4), constraints=(/4: [/100 - /100]; tight)]
            ├── variable: a.i [type=int, outer=(4)]
            └── const: 100 [type=int]
 
@@ -372,8 +372,8 @@ select
  │         └── eq [type=bool, outer=(1,3)]
  │              ├── variable: a.k [type=int, outer=(3)]
  │              └── variable: b.x [type=int, outer=(1)]
- └── filters [type=bool, outer=(4)]
-      └── eq [type=bool, outer=(4)]
+ └── filters [type=bool, outer=(4), constraints=(/4: [/100 - /100]; tight)]
+      └── eq [type=bool, outer=(4), constraints=(/4: [/100 - /100]; tight)]
            ├── variable: a.i [type=int, outer=(4)]
            └── const: 100 [type=int]
 
@@ -394,10 +394,10 @@ inner-join
       │    ├── variable: a.k [type=int, outer=(1)]
       │    └── variable: b.x [type=int, outer=(6)]
       └── or [type=bool, outer=(4,7)]
-           ├── eq [type=bool, outer=(4)]
+           ├── eq [type=bool, outer=(4), constraints=(/4: [/'foo' - /'foo']; tight)]
            │    ├── variable: a.s [type=string, outer=(4)]
            │    └── const: 'foo' [type=string]
-           └── lt [type=bool, outer=(7)]
+           └── lt [type=bool, outer=(7), constraints=(/7: (/NULL - /99]; tight)]
                 ├── variable: b.y [type=int, outer=(7)]
                 └── const: 100 [type=int]
 
@@ -415,10 +415,10 @@ inner-join
       │    ├── variable: a.k [type=int, outer=(1)]
       │    └── variable: b.x [type=int, outer=(6)]
       └── or [type=bool, outer=(4,7)]
-           ├── eq [type=bool, outer=(4)]
+           ├── eq [type=bool, outer=(4), constraints=(/4: [/'foo' - /'foo']; tight)]
            │    ├── variable: a.s [type=string, outer=(4)]
            │    └── const: 'foo' [type=string]
-           └── lt [type=bool, outer=(7)]
+           └── lt [type=bool, outer=(7), constraints=(/7: (/NULL - /99]; tight)]
                 ├── variable: b.y [type=int, outer=(7)]
                 └── const: 100 [type=int]
 
@@ -499,19 +499,19 @@ inner-join
  │    ├── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
  │    ├── scan a
  │    │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
- │    └── filters [type=bool, outer=(3,4)]
- │         ├── eq [type=bool, outer=(3)]
+ │    └── filters [type=bool, outer=(3,4), constraints=(/3: [/1.1 - /1.1]; /4: [/'foo' - /'foo']; tight)]
+ │         ├── eq [type=bool, outer=(3), constraints=(/3: [/1.1 - /1.1]; tight)]
  │         │    ├── variable: a.f [type=float, outer=(3)]
  │         │    └── const: 1.1 [type=float]
- │         └── eq [type=bool, outer=(4)]
+ │         └── eq [type=bool, outer=(4), constraints=(/4: [/'foo' - /'foo']; tight)]
  │              ├── variable: a.s [type=string, outer=(4)]
  │              └── const: 'foo' [type=string]
  ├── select
  │    ├── columns: b.x:6(int!null) b.y:7(int)
  │    ├── scan b
  │    │    └── columns: b.x:6(int!null) b.y:7(int)
- │    └── filters [type=bool, outer=(7)]
- │         └── eq [type=bool, outer=(7)]
+ │    └── filters [type=bool, outer=(7), constraints=(/7: [/10 - /10]; tight)]
+ │         └── eq [type=bool, outer=(7), constraints=(/7: [/10 - /10]; tight)]
  │              ├── variable: b.y [type=int, outer=(7)]
  │              └── const: 10 [type=int]
  └── filters [type=bool, outer=(1,2,6,7)]
@@ -531,8 +531,8 @@ inner-join
  │    ├── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
  │    ├── scan a
  │    │    └── columns: a.k:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
- │    └── filters [type=bool, outer=(2)]
- │         ├── eq [type=bool, outer=(2)]
+ │    └── filters [type=bool, outer=(2), constraints=(/2: [/100 - /100])]
+ │         ├── eq [type=bool, outer=(2), constraints=(/2: [/100 - /100]; tight)]
  │         │    ├── variable: a.i [type=int, outer=(2)]
  │         │    └── const: 100 [type=int]
  │         └── gt [type=bool]
@@ -560,8 +560,8 @@ group-by
  │    ├── columns: a.i:2(int)
  │    ├── scan a
  │    │    └── columns: a.i:2(int)
- │    └── filters [type=bool, outer=(2)]
- │         └── eq [type=bool, outer=(2)]
+ │    └── filters [type=bool, outer=(2), constraints=(/2: [/1 - /1]; tight)]
+ │         └── eq [type=bool, outer=(2), constraints=(/2: [/1 - /1]; tight)]
  │              ├── variable: a.i [type=int, outer=(2)]
  │              └── const: 1 [type=int]
  └── aggregations
@@ -578,8 +578,8 @@ group-by
  │    ├── columns: a.i:2(int)
  │    ├── scan a
  │    │    └── columns: a.i:2(int)
- │    └── filters [type=bool, outer=(2)]
- │         └── eq [type=bool, outer=(2)]
+ │    └── filters [type=bool, outer=(2), constraints=(/2: [/1 - /1]; tight)]
+ │         └── eq [type=bool, outer=(2), constraints=(/2: [/1 - /1]; tight)]
  │              ├── variable: a.i [type=int, outer=(2)]
  │              └── const: 1 [type=int]
  └── aggregations
@@ -604,8 +604,8 @@ select
  │    └── aggregations [outer=(4)]
  │         └── function: max [type=string, outer=(4)]
  │              └── variable: a.s [type=string, outer=(4)]
- └── filters [type=bool, outer=(6)]
-      └── eq [type=bool, outer=(6)]
+ └── filters [type=bool, outer=(6), constraints=(/6: [/'foo' - /'foo']; tight)]
+      └── eq [type=bool, outer=(6), constraints=(/6: [/'foo' - /'foo']; tight)]
            ├── variable: m [type=string, outer=(6)]
            └── const: 'foo' [type=string]
 
@@ -620,10 +620,10 @@ select
  │    ├── scan a
  │    └── aggregations
  │         └── function: count_rows [type=int]
- └── filters [type=bool, outer=(6)]
+ └── filters [type=bool, outer=(6), constraints=(/6: [/0 - /0])]
       ├── lt [type=bool]
       │    ├── function: now [type=timestamptz]
       │    └── const: '2000-01-01 10:00:00+00:00' [type=timestamptz]
-      └── eq [type=bool, outer=(6)]
+      └── eq [type=bool, outer=(6), constraints=(/6: [/0 - /0]; tight)]
            ├── variable: c [type=int, outer=(6)]
            └── const: 0 [type=int]


### PR DESCRIPTION
Very basic constraint generation for boolean scalars; only simple
comparisons are supported so far. The code will be extended to support
more expressions in follow-up PRs. In addition, the index selection
code will try to make use of these constraints instead of re-deriving
them.

Release note: None