### PR TITLE
storage: Init UseVersion to minSupportedVersion, not serverVersion

### DIFF
--- a/pkg/storage/stores_test.go
+++ b/pkg/storage/stores_test.go
@@ -435,6 +435,21 @@ func TestStoresClusterVersionWriteSynthesize(t *testing.T) {
 	}
 
 	ls0 := makeStores()
+
+	// If there are no stores, default to minSupportedVersion
+	// (VersionBase in this test)
+	if initialCV, err := ls0.SynthesizeClusterVersion(ctx); err != nil {
+		t.Fatal(err)
+	} else {
+		expCV := cluster.ClusterVersion{
+			MinimumVersion: cluster.VersionByKey(cluster.VersionBase),
+			UseVersion:     cluster.VersionByKey(cluster.VersionBase),
+		}
+		if !reflect.DeepEqual(initialCV, expCV) {
+			t.Fatalf("expected %+v; got %+v", expCV, initialCV)
+		}
+	}
+
 	ls0.AddStore(stores[0])
 
 	versionA := roachpb.Version{Major: 1, Minor: 0, Unstable: 1} // 1.0-1


### PR DESCRIPTION
If there are no initialized stores, we must initialize UseVersion to
our minimum version so we can join a cluster running any version
compatible with our binary.

Fixes #24229

Release note (bug fix): Brand-new nodes running CockroachDB 2.0 can
now join clusters that contain nodes running version 1.1.