### PR TITLE
sql: reduce UX surprise with DROP DATABASE and ALTER DATABASE RENAME

### DIFF
--- a/pkg/sql/drop_database.go
+++ b/pkg/sql/drop_database.go
@@ -47,6 +47,10 @@ func (p *planner) DropDatabase(ctx context.Context, n *tree.DropDatabase) (planN
 		return nil, errEmptyDatabaseName
 	}
 
+	if string(n.Name) == p.SessionData().Database && p.SessionData().SafeUpdates {
+		return nil, pgerror.NewDangerousStatementErrorf("DROP DATABASE on current database")
+	}
+
 	// Check that the database exists.
 	var dbDesc *DatabaseDescriptor
 	var err error

--- a/pkg/sql/logictest/testdata/logic_test/drop_database
+++ b/pkg/sql/logictest/testdata/logic_test/drop_database
@@ -210,6 +210,9 @@ CREATE DATABASE foo; CREATE TABLE foo.bar(x INT);
 statement ok
 SET sql_safe_updates = TRUE;
 
+statement error DROP DATABASE on current database
+DROP DATABASE test
+
 statement error DROP DATABASE on non-empty database without explicit CASCADE
 DROP DATABASE foo
 

--- a/pkg/sql/logictest/testdata/logic_test/rename_database
+++ b/pkg/sql/logictest/testdata/logic_test/rename_database
@@ -36,7 +36,14 @@ SELECT * FROM kv
 7 8
 
 statement ok
+SET sql_safe_updates = TRUE;
+
+statement error RENAME DATABASE on current database
 ALTER DATABASE test RENAME TO u
+
+statement ok
+SET sql_safe_updates = FALSE;
+ ALTER DATABASE test RENAME TO u
 
 statement error pgcode 42P01 relation "kv" does not exist
 SELECT * FROM kv


### PR DESCRIPTION
Fixes  #23661. cc @dianasaur323 

Prior to this patch, a user logged into the CLI shell and taking a
database name's away while it is set as "current database", either via
DROP DATABASE or ALTER DATABASE RENAME, would cause the subsequent
prompt refresh and possibly further statements to fail, due to an
inexistent current database.

This behavior is arguably surprising and raises the question for
unsuspecting/beginner users: why does the thing let me do something
that breaks everything afterwards?

This patch enhances the issue by preventing DROP or ALTER DATABASE
RENAME if the name taken away is set as current database, when
`sql_safe_updates` is set. (It is set for interactive sessions with
`cockroach sql`).

The following alternatives were explored but eventually dismissed:

- prevent DROP or ALTER DATABASE RENAME altogether on the current
  database. This is unfriendly to client apps which may expect "DROP
  DATABASE" followed immediately by "CREATE DATABASE" to keep the
  session valid.

- allow DROP and ALTER DATABASE RENAME but silently change the current
  database to empty (or some other valid value, like "system"). This
  is unfriendly to client apps which only set the current database via
  a URL path and expect the setting to remain stable.

Release note (sql change): `DROP DATABASE` and `ALTER DATABASE RENAME`
now prevent the removal of a database name if that database is set as
the current database (`SET database` / `USE`) and the session setting
`sql_safe_updates` is also set.