### PR TITLE
storage: merge replica.evaluateProposal and replica.evaluateProposalInner

### DIFF
--- a/pkg/storage/batcheval/result/result.go
+++ b/pkg/storage/batcheval/result/result.go
@@ -30,13 +30,6 @@ import (
 // the proposing node may die before the local results are processed,
 // so any side effects here are only best-effort.
 type LocalResult struct {
-	// The error resulting from the proposal. Most failing proposals will
-	// fail-fast, i.e. will return an error to the client above Raft. However,
-	// some proposals need to commit data even on error, and in that case we
-	// treat the proposal like a successful one, except that the error stored
-	// here will be sent to the client when the associated batch commits. In
-	// the common case, this field is nil.
-	Err   *roachpb.Error
 	Reply *roachpb.BatchResponse
 
 	// Intents stores any intents encountered but not conflicted with.

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -2928,13 +2928,6 @@ func (r *Replica) requestToProposal(
 // while still handling LocalEvalResult.
 //
 // Replica.mu must not be held.
-//
-// TODO(tschottdorf): the setting of WriteTooOld does not work. With
-// proposer-evaluated KV, TestStoreResolveWriteIntentPushOnRead fails in the
-// SNAPSHOT case since the transactional write in that test *always* catches
-// a WriteTooOldError. With proposer-evaluated KV disabled the same happens,
-// but the resulting WriteTooOld flag on the transaction is lost, letting the
-// test pass erroneously.
 func (r *Replica) evaluateProposal(
 	ctx context.Context, idKey storagebase.CmdIDKey, ba roachpb.BatchRequest, spans *spanset.SpanSet,
 ) (*result.Result, *roachpb.Error) {

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -5137,10 +5137,6 @@ func (r *Replica) applyRaftCommand(
 func (r *Replica) evaluateProposalInner(
 	ctx context.Context, idKey storagebase.CmdIDKey, ba roachpb.BatchRequest, spans *spanset.SpanSet,
 ) result.Result {
-	// Keep track of original txn Writing state to sanitize txn
-	// reported with any error except TransactionRetryError.
-	wasWriting := ba.Txn != nil && ba.Txn.Writing
-
 	// Evaluate the commands. If this returns without an error, the batch should
 	// be committed.
 	var result result.Result
@@ -5177,7 +5173,7 @@ func (r *Replica) evaluateProposalInner(
 				log.Fatalf(ctx, "error had a txn but batch is non-transactional. Err txn: %s", txn)
 			}
 			if txn.ID == ba.Txn.ID {
-				txn.Writing = wasWriting
+				txn.Writing = ba.Txn.Writing
 			}
 		}
 		return result

--- a/pkg/storage/replica_proposal.go
+++ b/pkg/storage/replica_proposal.go
@@ -708,18 +708,10 @@ func (r *Replica) handleReplicatedEvalResult(
 }
 
 func (r *Replica) handleLocalEvalResult(ctx context.Context, lResult result.LocalResult) {
-	// Enqueue failed push transactions on the txnWaitQueue.
-	if !r.store.cfg.DontRetryPushTxnFailures {
-		if tpErr, ok := lResult.Err.GetDetail().(*roachpb.TransactionPushError); ok {
-			r.txnWaitQueue.Enqueue(&tpErr.PusheeTxn)
-		}
-	}
-
 	// Fields for which no action is taken in this method are zeroed so that
 	// they don't trigger an assertion at the end of the method (which checks
 	// that all fields were handled).
 	{
-		lResult.Err = nil
 		lResult.Reply = nil
 	}
 

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -2828,11 +2828,12 @@ func (s *Store) Send(
 
 		// Handle push txn failures and write intent conflicts locally and
 		// retry. Other errors are returned to caller.
-		switch pErr.GetDetail().(type) {
+		switch t := pErr.GetDetail().(type) {
 		case *roachpb.TransactionPushError:
 			// On a transaction push error, retry immediately if doing so will
-			// enqueue into the txnWaitQueue in order to await further updates to the
-			// unpushed txn's status.
+			// enqueue into the txnWaitQueue in order to await further updates to
+			// the unpushed txn's status. We check ShouldPushImmediately to avoid
+			// retrying non-queueable PushTxnRequests (see #18191).
 			dontRetry := s.cfg.DontRetryPushTxnFailures
 			if !dontRetry && ba.IsSinglePushTxnRequest() {
 				pushReq := ba.Requests[0].GetInner().(*roachpb.PushTxnRequest)
@@ -2847,7 +2848,11 @@ func (s *Store) Send(
 				}
 				return nil, pErr
 			}
-			pErr = nil // retry command
+
+			// Enqueue unsuccessfully pushed transaction on the txnWaitQueue and
+			// retry the command.
+			repl.txnWaitQueue.Enqueue(&t.PusheeTxn)
+			pErr = nil
 
 		case *roachpb.WriteIntentError:
 			// Process and resolve write intent error. We do this here because

--- a/pkg/storage/store_test.go
+++ b/pkg/storage/store_test.go
@@ -1505,11 +1505,6 @@ func TestStoreResolveWriteIntentRollback(t *testing.T) {
 // TestStoreResolveWriteIntentPushOnRead verifies that resolving a write intent
 // for a read will push the timestamp. On failure to push, verify a write
 // intent error is returned with !Resolvable.
-//
-// TODO(tschottdorf): this test (but likely a lot of others) always need to
-// manually update the transaction for each received response, or they behave
-// like real clients aren't allowed to (for instance, dropping WriteTooOld
-// flags or timestamp bumps).
 func TestStoreResolveWriteIntentPushOnRead(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	storeCfg := TestStoreConfig(nil)
@@ -1555,15 +1550,8 @@ func TestStoreResolveWriteIntentPushOnRead(t *testing.T) {
 		{
 			_, btH := beginTxnArgs(key, pushee)
 			args := putArgs(key, []byte("value2"))
-			if reply, pErr := maybeWrapWithBeginTransaction(context.Background(), store.testSender(), btH, &args); pErr != nil {
+			if _, pErr := maybeWrapWithBeginTransaction(context.Background(), store.testSender(), btH, &args); pErr != nil {
 				t.Fatal(pErr)
-			} else {
-				pushee.Update(reply.(*roachpb.PutResponse).Txn)
-				if pushee.WriteTooOld {
-					// See test comment for the TODO mentioned below.
-					t.Logf("%d: unsetting WriteTooOld flag as a hack to keep this test passing; should address the TODO", i)
-					pushee.WriteTooOld = false
-				}
 			}
 		}
 


### PR DESCRIPTION
This change includes a series of cleanup that eventually ends in the merging of `replica.evaluateProposal` and `replica.evaluateProposalInner`. Along the way, it addresses a number of TODOs that have been around since the beginning of proposer-evaluated KV.

I've made a number of attempts at this change, and each time I threw it away because it became difficult to convince myself that I wasn't clobbering any desired behavior. To address this, I've split the PR into a series of equivalent refactors. The one exception to this is that all errors now "fail fast", because #21140 removed the cases where a proposal would result in an error but still want to propose in order to lie down intents.

This is all a precursor to cleanly addressing https://github.com/cockroachdb/cockroach/issues/23942.