### PR TITLE
sql: handle inverted index queries involving NULL

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/inverted_index
+++ b/pkg/sql/logictest/testdata/logic_test/inverted_index
@@ -161,6 +161,14 @@ index-join  0  index-join  ·      ·                                           
 ·           1  ·           table  d@primary                                    ·                ·
 
 query IT
+SELECT * from d where b @> NULL ORDER BY a;
+----
+
+query IT
+SELECT * from d where b @> (NULL::JSONB) ORDER BY a;
+----
+
+query IT
 SELECT * from d where b @>'{"a": "b"}' ORDER BY a;
 ----
 1  {"a": "b"}

--- a/pkg/sql/opt/idxconstraint/index_constraints.go
+++ b/pkg/sql/opt/idxconstraint/index_constraints.go
@@ -750,6 +750,12 @@ func (c *indexConstraintCtx) makeInvertedIndexSpansForExpr(
 		}
 
 		rightDatum := memo.ExtractConstDatum(rhs)
+
+		if rightDatum == tree.DNull {
+			c.contradiction(0 /* offset */, out)
+			return true
+		}
+
 		rd := rightDatum.(*tree.DJSON).JSON
 
 		switch rd.Type() {


### PR DESCRIPTION
I will plan on backporting this to 2.0.

Fixes #24244.

Release note (bug fix): inverted index queries involving NULL are now
properly handled.