### PR TITLE
release-2.0: storage: Init UseVersion to minSupportedVersion, not serverVersion

### DIFF
--- a/pkg/storage/stores.go
+++ b/pkg/storage/stores.go
@@ -421,12 +421,9 @@ func SynthesizeClusterVersionFromEngines(
 		origin:  "(no store)",
 	}
 
-	// FIXME(tschottdorf): when we don't have anything on the stores, we need to
-	// set this to `minSupportedVersions`. It looks like currently it would be
-	// set to `v1.0` which may not even be supported.
-	// This is the case in which the node is joining an existing cluster.
+	maxPossibleVersion := roachpb.Version{Major: 999999} // sort above any real version
 	minUseVersion := originVersion{
-		Version: serverVersion,
+		Version: maxPossibleVersion,
 		origin:  "(no store)",
 	}
 
@@ -462,6 +459,14 @@ func SynthesizeClusterVersionFromEngines(
 			minUseVersion.Version = cv.UseVersion
 			minUseVersion.origin = fmt.Sprint(eng)
 		}
+	}
+
+	// If no use version was found, fall back to our
+	// minSupportedVersion. This is the case when a brand new node is
+	// joining an existing cluster (which may be on any older version
+	// this binary supports).
+	if minUseVersion.Version == maxPossibleVersion {
+		minUseVersion.Version = minSupportedVersion
 	}
 
 	cv := cluster.ClusterVersion{

--- a/pkg/storage/stores_test.go
+++ b/pkg/storage/stores_test.go
@@ -435,6 +435,21 @@ func TestStoresClusterVersionWriteSynthesize(t *testing.T) {
 	}
 
 	ls0 := makeStores()
+
+	// If there are no stores, default to minSupportedVersion
+	// (VersionBase in this test)
+	if initialCV, err := ls0.SynthesizeClusterVersion(ctx); err != nil {
+		t.Fatal(err)
+	} else {
+		expCV := cluster.ClusterVersion{
+			MinimumVersion: cluster.VersionByKey(cluster.VersionBase),
+			UseVersion:     cluster.VersionByKey(cluster.VersionBase),
+		}
+		if !reflect.DeepEqual(initialCV, expCV) {
+			t.Fatalf("expected %+v; got %+v", expCV, initialCV)
+		}
+	}
+
 	ls0.AddStore(stores[0])
 
 	versionA := roachpb.Version{Major: 1, Minor: 0, Unstable: 1} // 1.0-1


### PR DESCRIPTION
Cherry-picks #24241, intended for 2.0.1

If there are no initialized stores, we must initialize UseVersion to
our minimum version so we can join a cluster running any version
compatible with our binary.

Fixes #24229

Release note (bug fix): Brand-new nodes running CockroachDB 2.0 can
now join clusters that contain nodes running version 1.1.