### PR TITLE
workload/kv: fix key generation

### DIFF
--- a/pkg/workload/kv/kv.go
+++ b/pkg/workload/kv/kv.go
@@ -167,6 +167,7 @@ func (w *kv) Ops(urls []string, reg *workload.HistogramRegistry) (workload.Query
 	}
 
 	ql := workload.QueryLoad{SQLDatabase: sqlDatabase}
+	seq := &sequence{config: w, val: w.writeSeq}
 	for i := 0; i < w.connFlags.Concurrency; i++ {
 		op := kvOp{
 			config:    w,
@@ -175,7 +176,6 @@ func (w *kv) Ops(urls []string, reg *workload.HistogramRegistry) (workload.Query
 			readStmt:  readStmt,
 			writeStmt: writeStmt,
 		}
-		seq := &sequence{config: w, val: w.writeSeq}
 		if w.sequential {
 			op.g = newSequentialGenerator(seq)
 		} else {
@@ -258,7 +258,7 @@ type hashGenerator struct {
 func newHashGenerator(seq *sequence) *hashGenerator {
 	return &hashGenerator{
 		seq:    seq,
-		random: rand.New(rand.NewSource(seq.config.seed)),
+		random: rand.New(rand.NewSource(timeutil.Now().UnixNano())),
 		hasher: sha1.New(),
 	}
 }
@@ -296,7 +296,7 @@ type sequentialGenerator struct {
 func newSequentialGenerator(seq *sequence) *sequentialGenerator {
 	return &sequentialGenerator{
 		seq:    seq,
-		random: rand.New(rand.NewSource(seq.config.seed)),
+		random: rand.New(rand.NewSource(timeutil.Now().UnixNano())),
 	}
 }
 


### PR DESCRIPTION
kv was performing significantly worse than the loadgen version due to
contention between workers. Each worker was using a sequence with the
same seed, which led to them all trying to write to the same keys. I
changed this to have the workers share a single sequence (like loadgen
does) and also updated a couple RNGs to use random seeds.

Release note: None