### PR TITLE
opt: clean up idxconstraint interface

### DIFF
--- a/pkg/sql/opt/optbuilder/builder_test.go
+++ b/pkg/sql/opt/optbuilder/builder_test.go
@@ -127,17 +127,14 @@ func TestBuilder(t *testing.T) {
 					semaCtx := tree.MakeSemaContext(false /* privileged */)
 					evalCtx := tree.MakeTestingEvalContext(cluster.MakeTestingClusterSettings())
 
-					varNames := make([]string, len(varTypes))
-					for i := range varNames {
-						varNames[i] = fmt.Sprintf("@%d", i+1)
+					o := xform.NewOptimizer(&evalCtx)
+					for i, typ := range varTypes {
+						o.Memo().Metadata().AddColumn(fmt.Sprintf("@%d", i+1), typ)
 					}
 					// Disable normalization rules: we want the tests to check the result
 					// of the build process.
-					o := xform.NewOptimizer(&evalCtx)
 					o.MaxSteps = xform.OptimizeNone
-					b := optbuilder.NewScalar(
-						ctx, &semaCtx, &evalCtx, o.Factory(), varNames, varTypes,
-					)
+					b := optbuilder.NewScalar(ctx, &semaCtx, &evalCtx, o.Factory())
 					b.AllowUnsupportedExpr = allowUnsupportedExpr
 					group, err := b.Build(typedExpr)
 					if err != nil {

--- a/pkg/sql/opt/optbuilder/scalar.go
+++ b/pkg/sql/opt/optbuilder/scalar.go
@@ -17,6 +17,7 @@ package optbuilder
 import (
 	"context"
 
+	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/xform"
 
@@ -189,7 +190,7 @@ func (b *Builder) buildScalar(scalar tree.TypedExpr, inScope *scope) (out memo.G
 
 	case *tree.IndexedVar:
 		if t.Idx < 0 || t.Idx >= len(inScope.cols) {
-			panic(errorf("invalid column ordinal @%d", t.Idx))
+			panic(errorf("invalid column ordinal @%d", t.Idx+1))
 		}
 		out = b.factory.ConstructVariable(b.factory.InternPrivate(inScope.cols[t.Idx].id))
 		// TODO(rytaft): Do we need to update varsUsed here?
@@ -374,30 +375,37 @@ type ScalarBuilder struct {
 	scope scope
 }
 
-// NewScalar creates a new ScalarBuilder. The provided columns are accessible
+// NewScalar creates a new ScalarBuilder. The columns in the metadata are accessible
 // from scalar expressions via IndexedVars.
-// columnNames and columnTypes must have the same length.
 func NewScalar(
-	ctx context.Context,
-	semaCtx *tree.SemaContext,
-	evalCtx *tree.EvalContext,
-	factory *xform.Factory,
-	columnNames []string,
-	columnTypes []types.T,
+	ctx context.Context, semaCtx *tree.SemaContext, evalCtx *tree.EvalContext, factory *xform.Factory,
 ) *ScalarBuilder {
+	md := factory.Metadata()
 	sb := &ScalarBuilder{
 		Builder: Builder{
 			factory: factory,
-			colMap:  make([]columnProps, 1),
+			colMap:  make([]columnProps, 1, 1+md.NumColumns()),
 			ctx:     ctx,
 			semaCtx: semaCtx,
 			evalCtx: evalCtx,
 		},
 	}
 	sb.scope.builder = &sb.Builder
-	for i := range columnNames {
-		sb.synthesizeColumn(&sb.scope, columnNames[i], columnTypes[i], nil)
+
+	// Put all the columns in the current scope.
+	sb.scope.cols = make([]columnProps, 0, md.NumColumns())
+	for colID := opt.ColumnID(1); int(colID) <= md.NumColumns(); colID++ {
+		name := tree.Name(md.ColumnLabel(colID))
+		col := columnProps{
+			origName: name,
+			name:     name,
+			typ:      md.ColumnType(colID),
+			id:       colID,
+		}
+		sb.colMap = append(sb.colMap, col)
+		sb.scope.cols = append(sb.scope.cols, col)
 	}
+
 	return sb
 }
 


### PR DESCRIPTION
The index constraints code uses a one-off `IndexColumnInfo` structure
for information on the columns. Cleaning up the interface to use the
`Metadata`, plus an additional `notNullCols` set.

As a consequence, we no longer pass column names and types to the
`ScalarBuilder` (instead, we set them up in the metadata).

Release note: None