### PR TITLE
backport-2.0: storage: re-enqueue splitQueue attempts on cput errors 

### DIFF
--- a/pkg/storage/client_split_test.go
+++ b/pkg/storage/client_split_test.go
@@ -933,84 +933,108 @@ func TestStoreRangeSplitBackpressureWrites(t *testing.T) {
 		RangeMaxBytes: maxBytes,
 	})()
 
-	var activateSplitFilter int32
-	splitKey := roachpb.RKey(keys.UserTableDataMin)
-	splitPending, blockSplits := make(chan struct{}), make(chan struct{})
-	storeCfg := storage.TestStoreConfig(nil)
-	storeCfg.TestingKnobs.TestingResponseFilter =
-		func(ba roachpb.BatchRequest, br *roachpb.BatchResponse) *roachpb.Error {
-			if atomic.LoadInt32(&activateSplitFilter) == 1 {
-				for _, req := range ba.Requests {
-					if cPut, ok := req.GetInner().(*roachpb.ConditionalPutRequest); ok {
-						if cPut.Key.Equal(keys.RangeDescriptorKey(splitKey)) {
-							splitPending <- struct{}{}
-							<-blockSplits
+	// Backpressured writes react differently depending on the result of the
+	// split request they are waiting on. If the split request succeeds or
+	// returns an expected error, the write is permitted. If the split fails
+	// due to an unexpected error, the write also fails.
+	testCases := []struct {
+		splitErr    error
+		permitWrite bool
+	}{
+		{splitErr: nil, permitWrite: true},
+		{splitErr: &roachpb.ConditionFailedError{ActualValue: &roachpb.Value{}}, permitWrite: true},
+		{splitErr: &roachpb.AmbiguousResultError{}, permitWrite: false},
+		{splitErr: errors.New("bad error"), permitWrite: false},
+	}
+	for _, tc := range testCases {
+		t.Run(fmt.Sprintf("splitErr=%v", tc.splitErr), func(t *testing.T) {
+			var activateSplitFilter int32
+			splitKey := roachpb.RKey(keys.UserTableDataMin)
+			splitPending, blockSplits := make(chan struct{}), make(chan struct{})
+			storeCfg := storage.TestStoreConfig(nil)
+			storeCfg.TestingKnobs.TestingRequestFilter =
+				func(ba roachpb.BatchRequest) *roachpb.Error {
+					for _, req := range ba.Requests {
+						if cPut, ok := req.GetInner().(*roachpb.ConditionalPutRequest); ok {
+							if cPut.Key.Equal(keys.RangeDescriptorKey(splitKey)) {
+								if atomic.CompareAndSwapInt32(&activateSplitFilter, 1, 0) {
+									splitPending <- struct{}{}
+									<-blockSplits
+									return roachpb.NewError(tc.splitErr)
+								}
+							}
 						}
 					}
+					return nil
+				}
+
+			stopper := stop.NewStopper()
+			defer stopper.Stop(context.TODO())
+			store := createTestStoreWithConfig(t, stopper, storeCfg)
+
+			if err := server.WaitForInitialSplits(store.DB()); err != nil {
+				t.Fatal(err)
+			}
+			store.SetSplitQueueActive(false)
+
+			// Split at the split key.
+			sArgs := adminSplitArgs(splitKey.AsRawKey())
+			repl := store.LookupReplica(splitKey, nil)
+			if _, pErr := client.SendWrappedWith(context.Background(), rg1(store), roachpb.Header{
+				RangeID: repl.RangeID,
+			}, sArgs); pErr != nil {
+				t.Fatal(pErr)
+			}
+
+			// Fill the new range past the point where writes should backpressure.
+			repl = store.LookupReplica(splitKey, nil)
+			fillRange(t, store, repl.RangeID, splitKey.AsRawKey(), 2*maxBytes+1)
+
+			if !repl.ShouldBackpressureWrites() {
+				t.Fatal("expected ShouldBackpressureWrites=true, found false")
+			}
+
+			// Allow the range to begin splitting and wait until it gets blocked in the
+			// response filter.
+			atomic.StoreInt32(&activateSplitFilter, 1)
+			go func() {
+				store.SetSplitQueueActive(true)
+				store.ForceSplitScanAndProcess()
+			}()
+			<-splitPending
+
+			// Send a Put request. This should be backpressured on the split, so it should
+			// not be able to succeed until we allow the split to continue.
+			writeRes := make(chan *roachpb.Error)
+			go func() {
+				// Write to the first key of the range to make sure that
+				// we don't end up on the wrong side of the split.
+				pArgs := putArgs(splitKey.AsRawKey(), []byte("test"))
+				header := roachpb.Header{RangeID: repl.RangeID}
+				_, pErr := client.SendWrappedWith(context.Background(), store, header, pArgs)
+				writeRes <- pErr
+			}()
+
+			// Make sure the write doesn't succeed yet.
+			select {
+			case pErr := <-writeRes:
+				close(blockSplits)
+				t.Fatalf("write was not blocked on split, returned err %v", pErr)
+			case <-time.After(100 * time.Millisecond):
+			}
+
+			// Let split through. Write should follow.
+			close(blockSplits)
+			if pErr := <-writeRes; tc.permitWrite {
+				if pErr != nil {
+					t.Fatalf("write returned err %v, expected success", pErr)
+				}
+			} else {
+				if !testutils.IsPError(pErr, tc.splitErr.Error()) {
+					t.Fatalf("write returned err %v, expected backpressure failure", pErr)
 				}
 			}
-			return nil
-		}
-
-	stopper := stop.NewStopper()
-	defer stopper.Stop(context.TODO())
-	store := createTestStoreWithConfig(t, stopper, storeCfg)
-
-	if err := server.WaitForInitialSplits(store.DB()); err != nil {
-		t.Fatal(err)
-	}
-	store.SetSplitQueueActive(false)
-
-	// Split at the split key.
-	sArgs := adminSplitArgs(splitKey.AsRawKey())
-	repl := store.LookupReplica(splitKey, nil)
-	if _, pErr := client.SendWrappedWith(context.Background(), rg1(store), roachpb.Header{
-		RangeID: repl.RangeID,
-	}, sArgs); pErr != nil {
-		t.Fatal(pErr)
-	}
-
-	// Fill the new range past the point where writes should backpressure.
-	repl = store.LookupReplica(splitKey, nil)
-	fillRange(t, store, repl.RangeID, splitKey.AsRawKey(), 2*maxBytes+1)
-
-	if !repl.ShouldBackpressureWrites() {
-		t.Fatal("expected ShouldBackpressureWrites=true, found false")
-	}
-
-	// Allow the range to begin splitting and wait until it gets blocked in the
-	// response filter.
-	atomic.StoreInt32(&activateSplitFilter, 1)
-	go func() {
-		store.SetSplitQueueActive(true)
-		store.ForceSplitScanAndProcess()
-	}()
-	<-splitPending
-
-	// Send a Put request. This should be backpressured on the split, so it should
-	// not be able to succeed until we allow the split to continue.
-	writeRes := make(chan *roachpb.Error)
-	go func() {
-		// Write to the first key of the range to make sure that
-		// we don't end up on the wrong side of the split.
-		pArgs := putArgs(splitKey.AsRawKey(), []byte("test"))
-		header := roachpb.Header{RangeID: repl.RangeID}
-		_, pErr := client.SendWrappedWith(context.Background(), store, header, pArgs)
-		writeRes <- pErr
-	}()
-
-	// Make sure the write doesn't succeed yet.
-	select {
-	case pErr := <-writeRes:
-		close(blockSplits)
-		t.Fatalf("write was not blocked on split, returned err %v", pErr)
-	case <-time.After(100 * time.Millisecond):
-	}
-
-	// Let split through. Write should follow.
-	close(blockSplits)
-	if pErr := <-writeRes; pErr != nil {
-		t.Fatalf("write returned err %v", pErr)
+		})
 	}
 }
 

--- a/pkg/storage/client_split_test.go
+++ b/pkg/storage/client_split_test.go
@@ -952,6 +952,7 @@ func TestStoreRangeSplitBackpressureWrites(t *testing.T) {
 			splitKey := roachpb.RKey(keys.UserTableDataMin)
 			splitPending, blockSplits := make(chan struct{}), make(chan struct{})
 			storeCfg := storage.TestStoreConfig(nil)
+			storeCfg.TestingKnobs.DisableGCQueue = true
 			storeCfg.TestingKnobs.TestingRequestFilter =
 				func(ba roachpb.BatchRequest) *roachpb.Error {
 					for _, req := range ba.Requests {

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -715,6 +715,8 @@ type StoreTestingKnobs struct {
 	// replica.TransferLease() encounters an in-progress lease extension.
 	// nextLeader is the replica that we're trying to transfer the lease to.
 	LeaseTransferBlockedOnExtensionEvent func(nextLeader roachpb.ReplicaDescriptor)
+	// DisableGCQueue disables the GC queue.
+	DisableGCQueue bool
 	// DisableReplicaGCQueue disables the replica GC queue.
 	DisableReplicaGCQueue bool
 	// DisableReplicateQueue disables the replication queue.
@@ -912,6 +914,9 @@ func NewStore(cfg StoreConfig, eng engine.Engine, nodeDesc *roachpb.NodeDescript
 		}
 	}
 
+	if cfg.TestingKnobs.DisableGCQueue {
+		s.setGCQueueActive(false)
+	}
 	if cfg.TestingKnobs.DisableReplicaGCQueue {
 		s.setReplicaGCQueueActive(false)
 	}
@@ -4524,6 +4529,9 @@ func ReadClusterVersion(ctx context.Context, reader engine.Reader) (cluster.Clus
 // The methods below can be used to control a store's queues. Stopping a queue
 // is only meant to happen in tests.
 
+func (s *Store) setGCQueueActive(active bool) {
+	s.gcQueue.SetDisabled(!active)
+}
 func (s *Store) setRaftLogQueueActive(active bool) {
 	s.raftLogQueue.SetDisabled(!active)
 }


### PR DESCRIPTION
Backport 2/2 commits from #24232.

Not targetted at 2.0. Planning to leave this PR alone until we're ready for 2.0.1 cherrypicks.

/cc @cockroachdb/release

---

Fixes #24151.
Fixes #24218.

`ConditionFailedErrors` are an expected outcome for range splits
because splits can race with other descriptor modifications. This
is why splits are retried by AdminSplit when it sees these errors.
However, until this point, the splitQueue itself did not retry when
it saw a `ConditionFailedError`.

This change fixes this by attempting to enqueue a replica whose split
attempt fails with one of these errors. This has an effect on
backpressured writes because they listen to the splitQueue's result.
Now that a cput error does not indicate failure to the splitQueue,
the backpressured writes are allowed to continue waiting on future
split attempts until eventually the range succeeds in splitting and
they are allowed through.

Release note: None
