### PR TITLE
backport-2.0: sql: unwrap datums in pg privilege builtins

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/privilege_builtins
+++ b/pkg/sql/logictest/testdata/logic_test/privilege_builtins
@@ -39,6 +39,14 @@ SELECT has_any_column_privilege(12345, 'SELECT'),
 NULL  NULL  NULL  NULL
 
 query BBBB
+SELECT has_any_column_privilege(12345::OID::REGCLASS, 'SELECT'),
+       has_any_column_privilege(12345::OID::REGCLASS, 'INSERT'),
+       has_any_column_privilege(12345::OID::REGCLASS, 'UPDATE'),
+       has_any_column_privilege(12345::OID::REGCLASS, 'REFERENCES')
+----
+NULL  NULL  NULL  NULL
+
+query BBBB
 SELECT has_any_column_privilege((SELECT oid FROM pg_class WHERE relname = 'pg_type'), 'SELECT'),
        has_any_column_privilege((SELECT oid FROM pg_class WHERE relname = 'pg_type'), 'INSERT'),
        has_any_column_privilege((SELECT oid FROM pg_class WHERE relname = 'pg_type'), 'UPDATE'),
@@ -81,6 +89,15 @@ SELECT has_any_column_privilege('t', 'SELECT WITH GRANT OPTION'),
        has_any_column_privilege('t', 'UPDATE WITH GRANT OPTION'),
        has_any_column_privilege('t', 'REFERENCES WITH GRANT OPTION'),
        has_any_column_privilege('t', 'SELECT WITH GRANT OPTION, INSERT WITH GRANT OPTION, UPDATE WITH GRANT OPTION')
+----
+true  true  true  true  true
+
+query BBBBB
+SELECT has_any_column_privilege('t'::Name, 'SELECT'),
+       has_any_column_privilege('t'::Name, 'INSERT'),
+       has_any_column_privilege('t'::Name, 'UPDATE'),
+       has_any_column_privilege('t'::Name, 'REFERENCES'),
+       has_any_column_privilege('t'::Name, 'SELECT, INSERT, UPDATE')
 ----
 true  true  true  true  true
 
@@ -255,6 +272,15 @@ SELECT has_column_privilege('t', 'a', 'SELECT WITH GRANT OPTION'),
 ----
 true  true  true  true  true
 
+query BBBBB
+SELECT has_column_privilege('t'::Name, 'a'::Name, 'SELECT WITH GRANT OPTION'),
+       has_column_privilege('t'::Name, 'a'::Name, 'INSERT WITH GRANT OPTION'),
+       has_column_privilege('t'::Name, 'a'::Name, 'UPDATE WITH GRANT OPTION'),
+       has_column_privilege('t'::Name, 'a'::Name, 'REFERENCES WITH GRANT OPTION'),
+       has_column_privilege('t'::Name, 'a'::Name, 'SELECT WITH GRANT OPTION, INSERT WITH GRANT OPTION, UPDATE WITH GRANT OPTION')
+----
+true  true  true  true  true
+
 query error pgcode 22023 unrecognized privilege type: "USAGE"
 SELECT has_column_privilege('t', 'a', 'USAGE')
 
@@ -336,6 +362,15 @@ SELECT has_database_privilege('test', 'CREATE WITH GRANT OPTION'),
 ----
 true  true  true  true  true
 
+query BBBBB
+SELECT has_database_privilege('test'::Name, 'CREATE'),
+       has_database_privilege('test'::Name, 'CONNECT'),
+       has_database_privilege('test'::Name, 'TEMPORARY'),
+       has_database_privilege('test'::Name, 'TEMP'),
+       has_database_privilege('test'::Name, 'CREATE, CONNECT')
+----
+true  true  true  true  true
+
 query error pgcode 22023 unrecognized privilege type: "UPDATE"
 SELECT has_database_privilege('test', 'UPDATE')
 
@@ -375,6 +410,9 @@ true
 
 query error pgcode 42704 foreign-data wrapper 'does_not_exist' does not exist
 SELECT has_foreign_data_wrapper_privilege('does_not_exist', 'USAGE')
+
+query error pgcode 42704 foreign-data wrapper 'does_not_exist' does not exist
+SELECT has_foreign_data_wrapper_privilege('does_not_exist'::Name, 'USAGE')
 
 query B
 SELECT has_foreign_data_wrapper_privilege(12345, 'USAGE WITH GRANT OPTION')
@@ -429,6 +467,11 @@ SELECT has_function_privilege('cos(float)', 'EXECUTE WITH GRANT OPTION')
 ----
 true
 
+query B
+SELECT has_function_privilege('version'::Name, 'EXECUTE')
+----
+true
+
 query error pgcode 22023 unrecognized privilege type: "UPDATE"
 SELECT has_function_privilege('acos(float)', 'UPDATE')
 
@@ -458,6 +501,9 @@ NULL
 
 query error pgcode 42704 language 'does_not_exist' does not exist
 SELECT has_language_privilege('does_not_exist', 'USAGE')
+
+query error pgcode 42704 language 'does_not_exist' does not exist
+SELECT has_language_privilege('does_not_exist'::Name, 'USAGE')
 
 query B
 SELECT has_language_privilege(12345, 'USAGE WITH GRANT OPTION')
@@ -522,6 +568,13 @@ SELECT has_schema_privilege('public', 'CREATE WITH GRANT OPTION'),
 ----
 true  true  true
 
+query BBB
+SELECT has_schema_privilege('public'::Name, 'CREATE'),
+       has_schema_privilege('public'::Name, 'USAGE'),
+       has_schema_privilege('public'::Name, 'CREATE, USAGE')
+----
+true  true  true
+
 query error pgcode 22023 unrecognized privilege type: "UPDATE"
 SELECT has_schema_privilege('public', 'UPDATE')
 
@@ -582,6 +635,13 @@ SELECT has_sequence_privilege('seq', 'USAGE WITH GRANT OPTION'),
 ----
 true  true  true
 
+query BBB
+SELECT has_sequence_privilege('seq'::Name, 'USAGE'),
+       has_sequence_privilege('seq'::Name, 'SELECT'),
+       has_sequence_privilege('seq'::Name, 'UPDATE')
+----
+true  true  true
+
 query error pgcode 22023 unrecognized privilege type: "DELETE"
 SELECT has_sequence_privilege('seq', 'DELETE')
 
@@ -633,6 +693,9 @@ true
 
 query error pgcode 42704 server 'does_not_exist' does not exist
 SELECT has_server_privilege('does_not_exist', 'USAGE')
+
+query error pgcode 42704 server 'does_not_exist' does not exist
+SELECT has_server_privilege('does_not_exist'::Name, 'USAGE')
 
 query B
 SELECT has_server_privilege(12345, 'USAGE WITH GRANT OPTION')
@@ -731,6 +794,19 @@ SELECT has_table_privilege('t', 'SELECT WITH GRANT OPTION'),
 ----
 true  true  true  true  true  true  true  true  true
 
+query BBBBBBBBB
+SELECT has_table_privilege('t'::Name, 'SELECT'),
+       has_table_privilege('t'::Name, 'INSERT'),
+       has_table_privilege('t'::Name, 'UPDATE'),
+       has_table_privilege('t'::Name, 'DELETE'),
+       has_table_privilege('t'::Name, 'TRUNCATE'),
+       has_table_privilege('t'::Name, 'REFERENCES'),
+       has_table_privilege('t'::Name, 'TRIGGER'),
+       has_table_privilege('t'::Name, 'SELECT, INSERT, UPDATE'),
+       has_table_privilege('t'::Name, 'SELECT, TRUNCATE')
+----
+true  true  true  true  true  true  true  true  true
+
 # has_table_privilege works with sequences as well.
 query BBBBBBBBB
 SELECT has_table_privilege('seq', 'SELECT'),
@@ -806,6 +882,11 @@ SELECT has_tablespace_privilege('pg_default', 'CREATE WITH GRANT OPTION')
 ----
 true
 
+query B
+SELECT has_tablespace_privilege('pg_default'::Name, 'CREATE')
+----
+true
+
 query error pgcode 22023 unrecognized privilege type: "CREATE    WITH GRANT OPTION"
 SELECT has_tablespace_privilege('pg_default', 'CREATE    WITH GRANT OPTION')
 
@@ -846,6 +927,11 @@ true
 
 query B
 SELECT has_type_privilege('decimal(18,2)', 'USAGE WITH GRANT OPTION')
+----
+true
+
+query B
+SELECT has_type_privilege('int'::Name, 'USAGE')
 ----
 true
 

--- a/pkg/sql/sem/builtins/pg_builtins.go
+++ b/pkg/sql/sem/builtins/pg_builtins.go
@@ -280,8 +280,8 @@ func makePGPrivilegeInquiryDef(
 }
 
 // getNameForArg determines the object name for the specified argument, which
-// should be either a STRING or an OID. If the object is not found, the returned
-// string will be empty.
+// should be either an unwrapped STRING or an OID. If the object is not found,
+// the returned string will be empty.
 func getNameForArg(ctx *tree.EvalContext, arg tree.Datum, pgTable, pgCol string) (string, error) {
 	var query string
 	switch t := arg.(type) {
@@ -290,7 +290,7 @@ func getNameForArg(ctx *tree.EvalContext, arg tree.Datum, pgTable, pgCol string)
 	case *tree.DOid:
 		query = fmt.Sprintf("SELECT %s FROM pg_catalog.%s WHERE oid = $1 LIMIT 1", pgCol, pgTable)
 	default:
-		log.Fatalf(ctx.Ctx(), "expected arg type %T", t)
+		log.Fatalf(ctx.Ctx(), "unexpected arg type %T", t)
 	}
 	r, err := ctx.Planner.QueryRow(ctx.Ctx(), query, arg)
 	if err != nil || r == nil {
@@ -300,8 +300,8 @@ func getNameForArg(ctx *tree.EvalContext, arg tree.Datum, pgTable, pgCol string)
 }
 
 // getTableNameForArg determines the qualified table name for the specified
-// argument, which should be either a STRING or an OID. If the table is not
-// found, the returned pointer will be nil.
+// argument, which should be either an unwrapped STRING or an OID. If the table
+// is not found, the returned pointer will be nil.
 func getTableNameForArg(ctx *tree.EvalContext, arg tree.Datum) (*tree.TableName, error) {
 	switch t := arg.(type) {
 	case *tree.DString:
@@ -333,7 +333,7 @@ func getTableNameForArg(ctx *tree.EvalContext, arg tree.Datum) (*tree.TableName,
 		tn := tree.MakeTableNameWithSchema(db, schema, table)
 		return &tn, nil
 	default:
-		log.Fatalf(ctx.Ctx(), "expected arg type %T", t)
+		log.Fatalf(ctx.Ctx(), "unexpected arg type %T", t)
 	}
 	return nil, nil
 }
@@ -716,7 +716,8 @@ FROM pg_catalog.pg_sequence WHERE seqrelid=$1`, args[0])
 		"any column of table",
 		argTypeOpts{{"table", strOrOidTypes}},
 		func(ctx *tree.EvalContext, args tree.Datums, user string) (tree.Datum, error) {
-			tn, err := getTableNameForArg(ctx, args[0])
+			tableArg := tree.UnwrapDatum(ctx, args[0])
+			tn, err := getTableNameForArg(ctx, tableArg)
 			if err != nil {
 				return nil, err
 			}
@@ -768,7 +769,8 @@ FROM pg_catalog.pg_sequence WHERE seqrelid=$1`, args[0])
 		"column",
 		argTypeOpts{{"table", strOrOidTypes}, {"column", []types.T{types.String, types.Int}}},
 		func(ctx *tree.EvalContext, args tree.Datums, user string) (tree.Datum, error) {
-			tn, err := getTableNameForArg(ctx, args[0])
+			tableArg := tree.UnwrapDatum(ctx, args[0])
+			tn, err := getTableNameForArg(ctx, tableArg)
 			if err != nil {
 				return nil, err
 			}
@@ -785,7 +787,8 @@ FROM pg_catalog.pg_sequence WHERE seqrelid=$1`, args[0])
 
 				// Verify that the column exists in the table.
 				var colPred string
-				switch t := args[1].(type) {
+				colArg := tree.UnwrapDatum(ctx, args[1])
+				switch t := colArg.(type) {
 				case *tree.DString:
 					colPred = "column_name = $1"
 				case *tree.DInt:
@@ -796,11 +799,11 @@ FROM pg_catalog.pg_sequence WHERE seqrelid=$1`, args[0])
 
 				if r, err := ctx.Planner.QueryRow(ctx.Ctx(), fmt.Sprintf(`
 					SELECT column_name FROM information_schema.columns
-					WHERE %s AND %s`, pred, colPred), args[1]); err != nil {
+					WHERE %s AND %s`, pred, colPred), colArg); err != nil {
 					return nil, err
 				} else if r == nil {
 					return nil, pgerror.NewErrorf(pgerror.CodeUndefinedColumnError,
-						"column %s of relation %s does not exist", args[1], args[0])
+						"column %s of relation %s does not exist", colArg, tableArg)
 				}
 			}
 
@@ -840,16 +843,17 @@ FROM pg_catalog.pg_sequence WHERE seqrelid=$1`, args[0])
 		"database",
 		argTypeOpts{{"database", strOrOidTypes}},
 		func(ctx *tree.EvalContext, args tree.Datums, user string) (tree.Datum, error) {
-			db, err := getNameForArg(ctx, args[0], "pg_database", "datname")
+			dbArg := tree.UnwrapDatum(ctx, args[0])
+			db, err := getNameForArg(ctx, dbArg, "pg_database", "datname")
 			if err != nil {
 				return nil, err
 			}
 			retNull := false
 			if db == "" {
-				switch args[0].(type) {
+				switch dbArg.(type) {
 				case *tree.DString:
 					return nil, pgerror.NewErrorf(pgerror.CodeInvalidCatalogNameError,
-						"database %s does not exist", args[0])
+						"database %s does not exist", dbArg)
 				case *tree.DOid:
 					// Postgres returns NULL if no matching language is found
 					// when given an OID.
@@ -894,15 +898,16 @@ FROM pg_catalog.pg_sequence WHERE seqrelid=$1`, args[0])
 		"foreign-data wrapper",
 		argTypeOpts{{"fdw", strOrOidTypes}},
 		func(ctx *tree.EvalContext, args tree.Datums, user string) (tree.Datum, error) {
-			fdw, err := getNameForArg(ctx, args[0], "pg_foreign_data_wrapper", "fdwname")
+			fdwArg := tree.UnwrapDatum(ctx, args[0])
+			fdw, err := getNameForArg(ctx, fdwArg, "pg_foreign_data_wrapper", "fdwname")
 			if err != nil {
 				return nil, err
 			}
 			if fdw == "" {
-				switch args[0].(type) {
+				switch fdwArg.(type) {
 				case *tree.DString:
 					return nil, pgerror.NewErrorf(pgerror.CodeUndefinedObjectError,
-						"foreign-data wrapper %s does not exist", args[0])
+						"foreign-data wrapper %s does not exist", fdwArg)
 				case *tree.DOid:
 					// Unlike most of the functions, Postgres does not return
 					// NULL when an OID does not match.
@@ -921,10 +926,11 @@ FROM pg_catalog.pg_sequence WHERE seqrelid=$1`, args[0])
 		"function",
 		argTypeOpts{{"function", strOrOidTypes}},
 		func(ctx *tree.EvalContext, args tree.Datums, user string) (tree.Datum, error) {
+			oidArg := tree.UnwrapDatum(ctx, args[0])
 			// When specifying a function by a text string rather than by OID,
 			// the allowed input is the same as for the regprocedure data type.
 			var oid tree.Datum
-			switch t := args[0].(type) {
+			switch t := oidArg.(type) {
 			case *tree.DString:
 				var err error
 				oid, err = tree.PerformCast(ctx, t, coltypes.RegProcedure)
@@ -961,16 +967,17 @@ FROM pg_catalog.pg_sequence WHERE seqrelid=$1`, args[0])
 		"language",
 		argTypeOpts{{"language", strOrOidTypes}},
 		func(ctx *tree.EvalContext, args tree.Datums, user string) (tree.Datum, error) {
-			lang, err := getNameForArg(ctx, args[0], "pg_language", "lanname")
+			langArg := tree.UnwrapDatum(ctx, args[0])
+			lang, err := getNameForArg(ctx, langArg, "pg_language", "lanname")
 			if err != nil {
 				return nil, err
 			}
 			retNull := false
 			if lang == "" {
-				switch args[0].(type) {
+				switch langArg.(type) {
 				case *tree.DString:
 					return nil, pgerror.NewErrorf(pgerror.CodeUndefinedObjectError,
-						"language %s does not exist", args[0])
+						"language %s does not exist", langArg)
 				case *tree.DOid:
 					// Postgres returns NULL if no matching language is found
 					// when given an OID.
@@ -993,16 +1000,17 @@ FROM pg_catalog.pg_sequence WHERE seqrelid=$1`, args[0])
 		"schema",
 		argTypeOpts{{"schema", strOrOidTypes}},
 		func(ctx *tree.EvalContext, args tree.Datums, user string) (tree.Datum, error) {
-			schema, err := getNameForArg(ctx, args[0], "pg_namespace", "nspname")
+			schemaArg := tree.UnwrapDatum(ctx, args[0])
+			schema, err := getNameForArg(ctx, schemaArg, "pg_namespace", "nspname")
 			if err != nil {
 				return nil, err
 			}
 			retNull := false
 			if schema == "" {
-				switch args[0].(type) {
+				switch schemaArg.(type) {
 				case *tree.DString:
 					return nil, pgerror.NewErrorf(pgerror.CodeInvalidSchemaNameError,
-						"schema %s does not exist", args[0])
+						"schema %s does not exist", schemaArg)
 				case *tree.DOid:
 					// Postgres returns NULL if no matching schema is found
 					// when given an OID.
@@ -1038,7 +1046,8 @@ FROM pg_catalog.pg_sequence WHERE seqrelid=$1`, args[0])
 		"sequence",
 		argTypeOpts{{"sequence", strOrOidTypes}},
 		func(ctx *tree.EvalContext, args tree.Datums, user string) (tree.Datum, error) {
-			tn, err := getTableNameForArg(ctx, args[0])
+			seqArg := tree.UnwrapDatum(ctx, args[0])
+			tn, err := getTableNameForArg(ctx, seqArg)
 			if err != nil {
 				return nil, err
 			}
@@ -1057,7 +1066,7 @@ FROM pg_catalog.pg_sequence WHERE seqrelid=$1`, args[0])
 					return nil, err
 				} else if r == nil {
 					return nil, pgerror.NewErrorf(pgerror.CodeWrongObjectTypeError,
-						"%s is not a sequence", args[0])
+						"%s is not a sequence", seqArg)
 				}
 
 				pred = fmt.Sprintf(
@@ -1094,15 +1103,16 @@ FROM pg_catalog.pg_sequence WHERE seqrelid=$1`, args[0])
 		"foreign server",
 		argTypeOpts{{"server", strOrOidTypes}},
 		func(ctx *tree.EvalContext, args tree.Datums, user string) (tree.Datum, error) {
-			server, err := getNameForArg(ctx, args[0], "pg_foreign_server", "srvname")
+			serverArg := tree.UnwrapDatum(ctx, args[0])
+			server, err := getNameForArg(ctx, serverArg, "pg_foreign_server", "srvname")
 			if err != nil {
 				return nil, err
 			}
 			if server == "" {
-				switch args[0].(type) {
+				switch serverArg.(type) {
 				case *tree.DString:
 					return nil, pgerror.NewErrorf(pgerror.CodeUndefinedObjectError,
-						"server %s does not exist", args[0])
+						"server %s does not exist", serverArg)
 				case *tree.DOid:
 					// Unlike most of the functions, Postgres does not return
 					// NULL when an OID does not match.
@@ -1121,7 +1131,8 @@ FROM pg_catalog.pg_sequence WHERE seqrelid=$1`, args[0])
 		"table",
 		argTypeOpts{{"table", strOrOidTypes}},
 		func(ctx *tree.EvalContext, args tree.Datums, user string) (tree.Datum, error) {
-			tn, err := getTableNameForArg(ctx, args[0])
+			tableArg := tree.UnwrapDatum(ctx, args[0])
+			tn, err := getTableNameForArg(ctx, tableArg)
 			if err != nil {
 				return nil, err
 			}
@@ -1194,15 +1205,16 @@ FROM pg_catalog.pg_sequence WHERE seqrelid=$1`, args[0])
 		"tablespace",
 		argTypeOpts{{"tablespace", strOrOidTypes}},
 		func(ctx *tree.EvalContext, args tree.Datums, user string) (tree.Datum, error) {
-			tablespace, err := getNameForArg(ctx, args[0], "pg_tablespace", "spcname")
+			tablespaceArg := tree.UnwrapDatum(ctx, args[0])
+			tablespace, err := getNameForArg(ctx, tablespaceArg, "pg_tablespace", "spcname")
 			if err != nil {
 				return nil, err
 			}
 			if tablespace == "" {
-				switch args[0].(type) {
+				switch tablespaceArg.(type) {
 				case *tree.DString:
 					return nil, pgerror.NewErrorf(pgerror.CodeUndefinedObjectError,
-						"tablespace %s does not exist", args[0])
+						"tablespace %s does not exist", tablespaceArg)
 				case *tree.DOid:
 					// Unlike most of the functions, Postgres does not return
 					// NULL when an OID does not match.
@@ -1221,10 +1233,11 @@ FROM pg_catalog.pg_sequence WHERE seqrelid=$1`, args[0])
 		"type",
 		argTypeOpts{{"type", strOrOidTypes}},
 		func(ctx *tree.EvalContext, args tree.Datums, user string) (tree.Datum, error) {
+			oidArg := tree.UnwrapDatum(ctx, args[0])
 			// When specifying a type by a text string rather than by OID, the
 			// allowed input is the same as for the regtype data type.
 			var oid tree.Datum
-			switch t := args[0].(type) {
+			switch t := oidArg.(type) {
 			case *tree.DString:
 				var err error
 				oid, err = tree.PerformCast(ctx, t, coltypes.RegType)


### PR DESCRIPTION
Backport 1/1 commits from #24252.

Waiting for 2.0.1 cherry-picks to begin.

/cc @cockroachdb/release

---

Fixes #24249.

Release note (bug fix): Fixes a bug where passing a Name type to
has_database_privilege would cause a panic.
