### PR TITLE
optbuilder: Fix bugs in ORDER BY and DISTINCT

### DIFF
--- a/pkg/sql/opt/optbuilder/builder.go
+++ b/pkg/sql/opt/optbuilder/builder.go
@@ -134,10 +134,10 @@ func errorf(format string, a ...interface{}) builderError {
 // buildPhysicalProps construct a set of required physical properties from the
 // given scope.
 func (b *Builder) buildPhysicalProps(scope *scope) *memo.PhysicalProps {
-	if scope.presentation == nil {
-		scope.presentation = makePresentation(scope.cols)
+	if scope.physicalProps.Presentation == nil {
+		scope.physicalProps.Presentation = makePresentation(scope.cols)
 	}
-	return &memo.PhysicalProps{Presentation: scope.presentation, Ordering: scope.ordering}
+	return &scope.physicalProps
 }
 
 // buildStmt builds a set of memo groups that represent the given SQL

--- a/pkg/sql/opt/optbuilder/groupby.go
+++ b/pkg/sql/opt/optbuilder/groupby.go
@@ -146,7 +146,7 @@ func (b *Builder) hasAggregates(selects tree.SelectExprs) bool {
 //  - the group with the aggregation operator and the corresponding scope
 //  - post-projections with corresponding scope.
 func (b *Builder) buildAggregation(
-	sel *tree.SelectClause, fromGroup memo.GroupID, fromScope *scope,
+	sel *tree.SelectClause, orderBy tree.OrderBy, fromGroup memo.GroupID, fromScope *scope,
 ) (outGroup memo.GroupID, outScope *scope, projections []memo.GroupID, projectionsScope *scope) {
 	// We use two scopes:
 	//   - aggInScope contains columns that are used as input by the
@@ -202,6 +202,10 @@ func (b *Builder) buildAggregation(
 	// function that refers to variables in fromScope, buildAggregateFunction is
 	// called which adds columns to the aggInScope and aggOutScope.
 	projections = b.buildProjectionList(sel.Exprs, fromScope, projectionsScope)
+
+	// Any additional columns or aggregates in the ORDER BY clause (if it exists)
+	// will be added here.
+	projections = b.buildOrderBy(orderBy, fromGroup, projections, fromScope, projectionsScope)
 
 	aggInfos := aggOutScope.groupby.aggs
 

--- a/pkg/sql/opt/optbuilder/limit.go
+++ b/pkg/sql/opt/optbuilder/limit.go
@@ -31,7 +31,7 @@ func (b *Builder) buildLimit(
 ) (out memo.GroupID, outScope *scope) {
 	out, outScope = in, inScope
 
-	ordering := inScope.ordering
+	ordering := inScope.physicalProps.Ordering
 	orderingPrivID := b.factory.InternOrdering(ordering)
 
 	if limit.Offset != nil {

--- a/pkg/sql/opt/optbuilder/orderby.go
+++ b/pkg/sql/opt/optbuilder/orderby.go
@@ -33,24 +33,24 @@ import (
 // The `c` column must be retained in the projection (and the presentation
 // property then omits it).
 //
-// buildOrderBy builds a projection combining the projected columns and
-// order by columns (only if it's not a "pass through" projection), and sets
-// the ordering and presentation properties on the output scope. These
-// properties later become part of the required physical properties returned
-// by Build.
+// buildOrderBy returns a list of memo groups that combines projected columns
+// from the SELECT list (the projections parameter) and any ORDER BY columns
+// that are not already present in the SELECT list. buildOrderBy adds any new
+// ORDER BY columns to the projectionsScope and sets the ordering and
+// presentation properties on the projectionsScope. These properties later
+// become part of the required physical properties returned by Build.
 func (b *Builder) buildOrderBy(
 	orderBy tree.OrderBy,
 	in memo.GroupID,
 	projections []memo.GroupID,
-	inScope,
-	projectionsScope *scope,
-) (out memo.GroupID, outScope *scope) {
+	inScope, projectionsScope *scope,
+) []memo.GroupID {
 	if orderBy == nil {
-		return in, nil
+		return projections
 	}
 
 	orderByScope := inScope.push()
-	orderByScope.ordering = make(memo.Ordering, 0, len(orderBy))
+	orderByScope.physicalProps.Ordering = make(memo.Ordering, 0, len(orderBy))
 	orderByProjections := make([]memo.GroupID, 0, len(orderBy))
 
 	// TODO(rytaft): rewrite ORDER BY if it uses ORDER BY INDEX tbl@idx or
@@ -62,11 +62,7 @@ func (b *Builder) buildOrderBy(
 		)
 	}
 
-	out, outScope = b.buildOrderByProject(
-		in, projections, orderByProjections, inScope, projectionsScope, orderByScope,
-	)
-	return out, outScope
-
+	return b.buildOrderByProject(projections, orderByProjections, projectionsScope, orderByScope)
 }
 
 // buildOrdering sets up the projection(s) of a single ORDER BY argument.
@@ -150,52 +146,35 @@ func (b *Builder) buildOrdering(
 			orderByScope.cols[i].id,
 			order.Direction == tree.Descending,
 		)
-		orderByScope.ordering = append(orderByScope.ordering, col)
+		orderByScope.physicalProps.Ordering = append(orderByScope.physicalProps.Ordering, col)
 	}
 
 	return projections
 }
 
-// buildOrderByProject builds a projection that combines projected
-// columns from a SELECT list and ORDER BY columns.
-// If the combined set of output columns matches the set of input columns,
-// buildOrderByProject simply returns the input -- it does not construct
-// a "pass through" projection.
+// buildOrderByProject returns a list of memo groups that combines projections
+// and any items from orderByProjections that are not already present in
+// projections. buildOrderByProject adds any new ORDER BY columns to the
+// projectionsScope and sets the ordering and presentation properties on the
+// projectionsScope. These properties later become part of the required
+// physical properties returned by Build.
 func (b *Builder) buildOrderByProject(
-	in memo.GroupID,
-	projections, orderByProjections []memo.GroupID,
-	inScope, projectionsScope, orderByScope *scope,
-) (out memo.GroupID, outScope *scope) {
-	outScope = inScope.replace()
-
-	outScope.cols = make([]columnProps, 0, len(projectionsScope.cols)+len(orderByScope.cols))
-	outScope.appendColumns(projectionsScope)
-	combined := make([]memo.GroupID, 0, len(projectionsScope.cols)+len(orderByScope.cols))
-	combined = append(combined, projections...)
-
+	projections, orderByProjections []memo.GroupID, projectionsScope, orderByScope *scope,
+) []memo.GroupID {
 	for i := range orderByScope.cols {
 		col := &orderByScope.cols[i]
 
 		// Only append order by columns that aren't already present.
-		if findColByIndex(outScope.cols, col.id) == nil {
-			outScope.cols = append(outScope.cols, *col)
-			outScope.cols[len(outScope.cols)-1].hidden = true
-			combined = append(combined, orderByProjections[i])
+		if findColByIndex(projectionsScope.cols, col.id) == nil {
+			projectionsScope.cols = append(projectionsScope.cols, *col)
+			projectionsScope.cols[len(projectionsScope.cols)-1].hidden = true
+			projections = append(projections, orderByProjections[i])
 		}
 	}
 
-	outScope.ordering = orderByScope.ordering
-	outScope.presentation = makePresentation(projectionsScope.cols)
-
-	if outScope.hasSameColumns(inScope) {
-		// All order by and projection columns were already present, so no need to
-		// construct the projection expression.
-		return in, outScope
-	}
-
-	p := b.constructList(opt.ProjectionsOp, combined, outScope.cols)
-	out = b.factory.ConstructProject(in, p)
-	return out, outScope
+	projectionsScope.physicalProps.Ordering = orderByScope.physicalProps.Ordering
+	projectionsScope.physicalProps.Presentation = makePresentation(projectionsScope.cols)
+	return projections
 }
 
 func ensureColumnOrderable(e tree.TypedExpr) {

--- a/pkg/sql/opt/optbuilder/testdata/aggregate
+++ b/pkg/sql/opt/optbuilder/testdata/aggregate
@@ -825,17 +825,73 @@ sort
            └── function: count [type=int]
                 └── variable: kv.k [type=int]
 
-# TODO(rytaft): This is a bug. This query is valid.
 build
 SELECT v, COUNT(k) FROM kv GROUP BY v ORDER BY COUNT(k) DESC
 ----
-error: column name "k" not found
+sort
+ ├── columns: v:2(int) column5:5(int)
+ ├── ordering: -5
+ └── group-by
+      ├── columns: kv.v:2(int) column5:5(int)
+      ├── grouping columns: kv.v:2(int)
+      ├── project
+      │    ├── columns: kv.v:2(int) kv.k:1(int!null)
+      │    ├── scan kv
+      │    │    └── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string)
+      │    └── projections
+      │         ├── variable: kv.v [type=int]
+      │         └── variable: kv.k [type=int]
+      └── aggregations
+           └── function: count [type=int]
+                └── variable: kv.k [type=int]
 
-# TODO(rytaft): This is a bug. This query is valid.
 build
 SELECT v, COUNT(k) FROM kv GROUP BY v ORDER BY v-COUNT(k)
 ----
-error: column name "k" not found
+sort
+ ├── columns: v:2(int) column5:5(int)
+ ├── ordering: +6
+ └── project
+      ├── columns: kv.v:2(int) column5:5(int) column6:6(int)
+      ├── group-by
+      │    ├── columns: kv.v:2(int) column5:5(int)
+      │    ├── grouping columns: kv.v:2(int)
+      │    ├── project
+      │    │    ├── columns: kv.v:2(int) kv.k:1(int!null)
+      │    │    ├── scan kv
+      │    │    │    └── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string)
+      │    │    └── projections
+      │    │         ├── variable: kv.v [type=int]
+      │    │         └── variable: kv.k [type=int]
+      │    └── aggregations
+      │         └── function: count [type=int]
+      │              └── variable: kv.k [type=int]
+      └── projections
+           ├── variable: kv.v [type=int]
+           ├── variable: column5 [type=int]
+           └── minus [type=int]
+                ├── variable: kv.v [type=int]
+                └── variable: column5 [type=int]
+
+build
+SELECT v FROM kv GROUP BY v ORDER BY SUM(k)
+----
+sort
+ ├── columns: v:2(int)
+ ├── ordering: +5
+ └── group-by
+      ├── columns: kv.v:2(int) column5:5(decimal)
+      ├── grouping columns: kv.v:2(int)
+      ├── project
+      │    ├── columns: kv.v:2(int) kv.k:1(int!null)
+      │    ├── scan kv
+      │    │    └── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string)
+      │    └── projections
+      │         ├── variable: kv.v [type=int]
+      │         └── variable: kv.k [type=int]
+      └── aggregations
+           └── function: sum [type=decimal]
+                └── variable: kv.k [type=int]
 
 build
 SELECT v, COUNT(k) FROM kv GROUP BY v ORDER BY 1 DESC
@@ -1985,23 +2041,63 @@ project
            ├── variable: ab.b [type=int]
            └── variable: ab.a [type=int]
 
-# TODO(rytaft): This is a bug. This query is valid.
 build
 SELECT v, COUNT(k) FROM kv GROUP BY v ORDER BY COUNT(k)
 ----
-error: column name "k" not found
+sort
+ ├── columns: v:2(int) column5:5(int)
+ ├── ordering: +5
+ └── group-by
+      ├── columns: kv.v:2(int) column5:5(int)
+      ├── grouping columns: kv.v:2(int)
+      ├── project
+      │    ├── columns: kv.v:2(int) kv.k:1(int!null)
+      │    ├── scan kv
+      │    │    └── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string)
+      │    └── projections
+      │         ├── variable: kv.v [type=int]
+      │         └── variable: kv.k [type=int]
+      └── aggregations
+           └── function: count [type=int]
+                └── variable: kv.k [type=int]
 
-# TODO(rytaft): This is a bug. This query is valid.
 build
 SELECT v, COUNT(*) FROM kv GROUP BY v ORDER BY COUNT(*)
 ----
-error: aggregate function is not allowed in this context
+sort
+ ├── columns: v:2(int) column5:5(int)
+ ├── ordering: +5
+ └── group-by
+      ├── columns: kv.v:2(int) column5:5(int)
+      ├── grouping columns: kv.v:2(int)
+      ├── project
+      │    ├── columns: kv.v:2(int)
+      │    ├── scan kv
+      │    │    └── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string)
+      │    └── projections
+      │         └── variable: kv.v [type=int]
+      └── aggregations
+           └── function: count_rows [type=int]
 
-# TODO(rytaft): This is a bug. This query is valid.
 build
 SELECT v, COUNT(1) FROM kv GROUP BY v ORDER BY COUNT(1)
 ----
-error: aggregate function is not allowed in this context
+sort
+ ├── columns: v:2(int) column6:6(int)
+ ├── ordering: +6
+ └── group-by
+      ├── columns: kv.v:2(int) column6:6(int)
+      ├── grouping columns: kv.v:2(int)
+      ├── project
+      │    ├── columns: kv.v:2(int) column5:5(int)
+      │    ├── scan kv
+      │    │    └── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string)
+      │    └── projections
+      │         ├── variable: kv.v [type=int]
+      │         └── const: 1 [type=int]
+      └── aggregations
+           └── function: count [type=int]
+                └── variable: column5 [type=int]
 
 build
 SELECT (k+v)/(v+w) FROM t.kv GROUP BY k+v, v+w;

--- a/pkg/sql/opt/optbuilder/testdata/distinct
+++ b/pkg/sql/opt/optbuilder/testdata/distinct
@@ -80,8 +80,13 @@ sort
  └── group-by
       ├── columns: xyz.y:2(int) xyz.z:3(float)
       ├── grouping columns: xyz.y:2(int) xyz.z:3(float)
-      ├── scan xyz
-      │    └── columns: xyz.x:1(int!null) xyz.y:2(int) xyz.z:3(float)
+      ├── project
+      │    ├── columns: xyz.y:2(int) xyz.z:3(float)
+      │    ├── scan xyz
+      │    │    └── columns: xyz.x:1(int!null) xyz.y:2(int) xyz.z:3(float)
+      │    └── projections
+      │         ├── variable: xyz.y [type=int]
+      │         └── variable: xyz.z [type=float]
       └── aggregations
 
 build
@@ -93,8 +98,13 @@ sort
  └── group-by
       ├── columns: xyz.y:2(int) xyz.z:3(float)
       ├── grouping columns: xyz.y:2(int) xyz.z:3(float)
-      ├── scan xyz
-      │    └── columns: xyz.x:1(int!null) xyz.y:2(int) xyz.z:3(float)
+      ├── project
+      │    ├── columns: xyz.y:2(int) xyz.z:3(float)
+      │    ├── scan xyz
+      │    │    └── columns: xyz.x:1(int!null) xyz.y:2(int) xyz.z:3(float)
+      │    └── projections
+      │         ├── variable: xyz.y [type=int]
+      │         └── variable: xyz.z [type=float]
       └── aggregations
 
 build
@@ -106,8 +116,13 @@ sort
  └── group-by
       ├── columns: xyz.y:2(int) xyz.z:3(float)
       ├── grouping columns: xyz.y:2(int) xyz.z:3(float)
-      ├── scan xyz
-      │    └── columns: xyz.x:1(int!null) xyz.y:2(int) xyz.z:3(float)
+      ├── project
+      │    ├── columns: xyz.y:2(int) xyz.z:3(float)
+      │    ├── scan xyz
+      │    │    └── columns: xyz.x:1(int!null) xyz.y:2(int) xyz.z:3(float)
+      │    └── projections
+      │         ├── variable: xyz.y [type=int]
+      │         └── variable: xyz.z [type=float]
       └── aggregations
 
 # TODO(rytaft): This is a bug. This query is valid.
@@ -126,19 +141,27 @@ error: unsupported binary operator: <int> + <float>
 # CockroachDB with the semantics:
 #   SELECT y AS w FROM t GROUP BY y ORDER BY min(z);
 # We may decide to support this later, but for now this should cause an error.
-# TODO(rytaft): Improve this error message to be more descriptive. E.g., the
-# Postgres error message is "for SELECT DISTINCT, ORDER BY expressions must
-# appear in select list".
 build
 SELECT DISTINCT y AS w FROM xyz ORDER by z
 ----
-error: column name "z" not found
+error: for SELECT DISTINCT, ORDER BY expressions must appear in select list
 
-# TODO(rytaft): This is a bug. This query is valid.
 build
 SELECT DISTINCT y AS w FROM xyz ORDER by y
 ----
-error: column name "y" not found
+sort
+ ├── columns: w:2(int)
+ ├── ordering: +2
+ └── group-by
+      ├── columns: xyz.y:2(int)
+      ├── grouping columns: xyz.y:2(int)
+      ├── project
+      │    ├── columns: xyz.y:2(int)
+      │    ├── scan xyz
+      │    │    └── columns: xyz.x:1(int!null) xyz.y:2(int) xyz.z:3(float)
+      │    └── projections
+      │         └── variable: xyz.y [type=int]
+      └── aggregations
 
 build
 SELECT DISTINCT (y,z) FROM t.xyz
@@ -346,6 +369,12 @@ sort
  └── group-by
       ├── columns: abcd.b:2(int!null) abcd.d:4(int!null) column5:5(int)
       ├── grouping columns: abcd.b:2(int!null) abcd.d:4(int!null) column5:5(int)
-      ├── scan abcd
-      │    └── columns: abcd.a:1(int!null) abcd.b:2(int!null) abcd.c:3(int!null) abcd.d:4(int!null)
+      ├── project
+      │    ├── columns: column5:5(int) abcd.d:4(int!null) abcd.b:2(int!null)
+      │    ├── scan abcd
+      │    │    └── columns: abcd.a:1(int!null) abcd.b:2(int!null) abcd.c:3(int!null) abcd.d:4(int!null)
+      │    └── projections
+      │         ├── const: 1 [type=int]
+      │         ├── variable: abcd.d [type=int]
+      │         └── variable: abcd.b [type=int]
       └── aggregations

--- a/pkg/sql/opt/optbuilder/testdata/limit
+++ b/pkg/sql/opt/optbuilder/testdata/limit
@@ -177,8 +177,12 @@ limit
  │    └── group-by
  │         ├── columns: t.v:2(int)
  │         ├── grouping columns: t.v:2(int)
- │         ├── scan t
- │         │    └── columns: t.k:1(int!null) t.v:2(int) t.w:3(int)
+ │         ├── project
+ │         │    ├── columns: t.v:2(int)
+ │         │    ├── scan t
+ │         │    │    └── columns: t.k:1(int!null) t.v:2(int) t.w:3(int)
+ │         │    └── projections
+ │         │         └── variable: t.v [type=int]
  │         └── aggregations
  └── const: 10 [type=int]
 

--- a/pkg/sql/opt/optbuilder/testdata/orderby
+++ b/pkg/sql/opt/optbuilder/testdata/orderby
@@ -103,13 +103,10 @@ sort
 # CockroachDB with the semantics:
 #   SELECT c FROM t GROUP BY c ORDER BY max(b) DESC;
 # We may decide to support this later, but for now this should cause an error.
-# TODO(rytaft): Improve this error message to be more descriptive. E.g., the
-# Postgres error message is "for SELECT DISTINCT, ORDER BY expressions must
-# appear in select list".
 build
 SELECT DISTINCT c FROM t ORDER BY b DESC
 ----
-error: column name "b" not found
+error: for SELECT DISTINCT, ORDER BY expressions must appear in select list
 
 build
 SELECT a AS foo, b FROM t ORDER BY foo DESC

--- a/pkg/sql/opt/optbuilder/util.go
+++ b/pkg/sql/opt/optbuilder/util.go
@@ -298,10 +298,12 @@ func findColByIndex(cols []columnProps, id opt.ColumnID) *columnProps {
 }
 
 func makePresentation(cols []columnProps) memo.Presentation {
-	presentation := make(memo.Presentation, len(cols))
+	presentation := make(memo.Presentation, 0, len(cols))
 	for i := range cols {
 		col := &cols[i]
-		presentation[i] = opt.LabeledColumn{Label: string(col.name), ID: col.id}
+		if !col.hidden {
+			presentation = append(presentation, opt.LabeledColumn{Label: string(col.name), ID: col.id})
+		}
 	}
 	return presentation
 }


### PR DESCRIPTION
This commit fixes several bugs in the optbuilder related to
building `ORDER BY` and `DISTINCT` queries.

1. Queries in which the `ORDER BY` clause contained aggregate
   functions were previously causing an error. This commit
   fixes that problem by including the `ORDER BY` columns in
   the columns passed to `buildAggregation`.
2. `DISTINCT` queries containing an `ORDER BY` did not build
   correctly. This commit fixes that problem by reversing
   the order in which the `ORDER BY` and `DISTINCT` are built.
3. This commit improves the cryptic error message that was
   being returned for queries containing `SELECT DISTINCT` in
   which the `ORDER BY` columns were not in the select list.
   Now the error message matches the message returned by
   Postgres.

Release note: None