### PR TITLE
roachtest: Use roachprod run instead of roachprod ssh

### DIFF
--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -679,7 +679,7 @@ func (c *cluster) RunWithBuffer(
 		return nil, err
 	}
 	return execCmdWithBuffer(ctx, l,
-		append([]string{"roachprod", "ssh", c.makeNodes(node), "--"}, args...)...)
+		append([]string{"roachprod", "run", c.makeNodes(node), "--"}, args...)...)
 }
 
 // pgURL returns the Postgres endpoint for the specified node. It accepts a flag


### PR DESCRIPTION
This was meant to go in bb97461a45 but it was left out because of a
bad rebase.

This is needed by the jepsen tests, which use roachprod run for parallelism.

Release note: None