### PR TITLE
build: publish debug information for release binaries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -147,27 +147,26 @@ else ifeq ($(TYPE),release-linux-gnu)
 # this toolchain's libstdc++ version is quite recent and must be statically
 # linked to avoid depending on the target's available libstdc++.
 XHOST_TRIPLE := x86_64-unknown-linux-gnu
-override LINKFLAGS += -s -w -extldflags "-static-libgcc -static-libstdc++"
+override LINKFLAGS += -extldflags "-static-libgcc -static-libstdc++"
 override SUFFIX := $(SUFFIX)-linux-2.6.32-gnu-amd64
 BUILD_TYPE := release
 else ifeq ($(TYPE),release-linux-musl)
 BUILD_TYPE := release
 XHOST_TRIPLE := x86_64-unknown-linux-musl
-override LINKFLAGS += -s -w -extldflags "-static"
+override LINKFLAGS += -extldflags "-static"
 override SUFFIX := $(SUFFIX)-linux-2.6.32-musl-amd64
 else ifeq ($(TYPE),release-darwin)
 XGOOS := darwin
 export CGO_ENABLED := 1
 XHOST_TRIPLE := x86_64-apple-darwin13
 override SUFFIX := $(SUFFIX)-darwin-10.9-amd64
-override LINKFLAGS += -s -w
 BUILD_TYPE := release
 else ifeq ($(TYPE),release-windows)
 XGOOS := windows
 export CGO_ENABLED := 1
 XHOST_TRIPLE := x86_64-w64-mingw32
 override SUFFIX := $(SUFFIX)-windows-6.2-amd64
-override LINKFLAGS += -s -w -extldflags "-static"
+override LINKFLAGS += -extldflags "-static"
 BUILD_TYPE := release
 else
 $(error unknown build type $(TYPE))
@@ -734,7 +733,10 @@ $(COCKROACH) build buildoss buildshort go-install gotestdashi generate lint lint
 build: ## Build the CockroachDB binary.
 buildoss: ## Build the CockroachDB binary without any CCL-licensed code.
 $(COCKROACH) build buildoss buildshort go-install:
-	 $(XGO) $(BUILDMODE) -v $(GOFLAGS) -tags '$(TAGS)' -ldflags '$(LINKFLAGS)' $(BUILDTARGET)
+	$(XGO) $(BUILDMODE) -v $(GOFLAGS) -tags '$(TAGS)' -ldflags '$(LINKFLAGS)' $(BUILDTARGET)
+ifeq "$(BUILD_TYPE)" "release"
+	build/strip.sh $(COCKROACH) $(TARGET_TRIPLE)
+endif
 
 .PHONY: install
 install: ## Install the CockroachDB binary.

--- a/build/strip.sh
+++ b/build/strip.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+# Strip a binary after extracting its debug symbols.
+#
+# Usage: build/strip.sh [BINARY] [TARGET-TRIPLE]
+
+binary=$1
+triple=${2-}
+
+if [[ "$triple" ]]; then
+  triple+=-
+fi
+
+have_objcopy=false
+if command -v "${triple}objcopy" &> /dev/null; then
+  have_objcopy=true
+fi
+
+# Create a copy of the binary with only debug symbols. If objcopy doesn't exist
+# (e.g. on macOS), fall back to copying the whole binary.
+if "$have_objcopy"; then
+  "${triple}objcopy" --only-keep-debug "$1" "$1.dbg"
+else
+  cp "$1" "$1.dbg"
+fi
+
+# Strip the original binary.
+"${triple}strip" "$1"
+
+# If possible, indicate in the stripped binary where debug information lives.
+if "$have_objcopy"; then
+  "${triple}objcopy" --add-gnu-debuglink="$1.dbg" "$1"
+fi


### PR DESCRIPTION
@tschottdorf could you check that this works with your new PProf UI? No rush.

---

Work some objcopy magic to produce a ".dbg" file that includes debug
information for every cockroach release binary. This keeps the release binaries
trim while allowing them to be profiled and symbolized if necessary.

Symbolizing using the ".dbg" file requires running 'pprof' directly, instead of
'go tool pprof'. Add a 'cockroach debug pprof' command, since we're already
vendoring pprof, to save folks from needing to manually install 'pprof'.

Release note (build change): Debug symbols are now published alongside release
binaries. Users wishing to profile a release binary can download the
appropriate ".dbg" file and place it in the same directory as the cockroach
binary, where it will be automatically used by 'cockroach debug pprof' to
symbolize profiles.