### PR TITLE
build: test that Bors blocks failing builds from merging

### DIFF
--- a/pkg/testutils/fail_test.go
+++ b/pkg/testutils/fail_test.go
@@ -1,0 +1,23 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package testutils
+
+import (
+	"testing"
+)
+
+func TestBorsBlocksMergeOnFailure(t *testing.T) {
+	t.Fatalf("this always fails, to verify that Bors is sane")
+}


### PR DESCRIPTION
This commit should not actually be merged.  If it gets merged, it means
there's something wrong with our Bors configuration.

Release note: None