### PR TITLE
build: don't strip release binaries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -147,27 +147,26 @@ else ifeq ($(TYPE),release-linux-gnu)
 # this toolchain's libstdc++ version is quite recent and must be statically
 # linked to avoid depending on the target's available libstdc++.
 XHOST_TRIPLE := x86_64-unknown-linux-gnu
-override LINKFLAGS += -s -w -extldflags "-static-libgcc -static-libstdc++"
+override LINKFLAGS += -extldflags "-static-libgcc -static-libstdc++"
 override SUFFIX := $(SUFFIX)-linux-2.6.32-gnu-amd64
 BUILD_TYPE := release
 else ifeq ($(TYPE),release-linux-musl)
 BUILD_TYPE := release
 XHOST_TRIPLE := x86_64-unknown-linux-musl
-override LINKFLAGS += -s -w -extldflags "-static"
+override LINKFLAGS += -extldflags "-static"
 override SUFFIX := $(SUFFIX)-linux-2.6.32-musl-amd64
 else ifeq ($(TYPE),release-darwin)
 XGOOS := darwin
 export CGO_ENABLED := 1
 XHOST_TRIPLE := x86_64-apple-darwin13
 override SUFFIX := $(SUFFIX)-darwin-10.9-amd64
-override LINKFLAGS += -s -w
 BUILD_TYPE := release
 else ifeq ($(TYPE),release-windows)
 XGOOS := windows
 export CGO_ENABLED := 1
 XHOST_TRIPLE := x86_64-w64-mingw32
 override SUFFIX := $(SUFFIX)-windows-6.2-amd64
-override LINKFLAGS += -s -w -extldflags "-static"
+override LINKFLAGS += -extldflags "-static"
 BUILD_TYPE := release
 else
 $(error unknown build type $(TYPE))


### PR DESCRIPTION
Stop stripping release binaries. This nearly doubles their size (55MiB
-> 110MiB), but it makes backtraces and pprof profiles substantially
more useful.

Note that we currently build our C/C++ dependencies with `-g1`, which is
enough debug information for symbolized backtraces but not enough debug
information to fully support a debugger (e.g. local variable
information).

Release note (build note): Release binaries are now built with enough
debug information to produce useful CPU profiles and backtraces.