### PR TITLE
opt: improve optsteps output

### DIFF
--- a/pkg/sql/opt/xform/testdata/rules/combo
+++ b/pkg/sql/opt/xform/testdata/rules/combo
@@ -25,241 +25,243 @@ TABLE b
 optsteps
 SELECT s FROM a INNER JOIN b ON a.x=b.x AND i+1=10
 ----
-project
- ├── columns: s:4(string)
- ├── inner-join
- │    ├── columns: a.x:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb) b.x:6(int!null) b.z:7(int)
- │    ├── scan a
- │    │    └── columns: a.x:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
- │    ├── scan b
- │    │    └── columns: b.x:6(int!null) b.z:7(int)
- │    └── and [type=bool, outer=(1,2,6)]
- │         ├── eq [type=bool, outer=(1,6)]
- │         │    ├── variable: a.x [type=int, outer=(1)]
- │         │    └── variable: b.x [type=int, outer=(6)]
- │         └── eq [type=bool, outer=(2)]
- │              ├── plus [type=int, outer=(2)]
- │              │    ├── variable: a.i [type=int, outer=(2)]
- │              │    └── const: 1 [type=int]
- │              └── const: 10 [type=int]
- └── projections [outer=(4)]
-      └── variable: a.s [type=string, outer=(4)]
---- 
-+++ NormalizeCmpPlusConst
-@@ -1,20 +1,20 @@
- project
-  ├── columns: s:4(string)
-  ├── inner-join
-  │    ├── columns: a.x:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb) b.x:6(int!null) b.z:7(int)
-  │    ├── scan a
-  │    │    └── columns: a.x:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
-  │    ├── scan b
-  │    │    └── columns: b.x:6(int!null) b.z:7(int)
-  │    └── and [type=bool, outer=(1,2,6)]
-  │         ├── eq [type=bool, outer=(1,6)]
-  │         │    ├── variable: a.x [type=int, outer=(1)]
-  │         │    └── variable: b.x [type=int, outer=(6)]
-  │         └── eq [type=bool, outer=(2)]
-- │              ├── plus [type=int, outer=(2)]
-- │              │    ├── variable: a.i [type=int, outer=(2)]
-- │              │    └── const: 1 [type=int]
-- │              └── const: 10 [type=int]
-+ │              ├── variable: a.i [type=int, outer=(2)]
-+ │              └── minus [type=int]
-+ │                   ├── const: 10 [type=int]
-+ │                   └── const: 1 [type=int]
-  └── projections [outer=(4)]
-       └── variable: a.s [type=string, outer=(4)]
---- 
-+++ EnsureJoinFiltersAnd
-@@ -1,20 +1,20 @@
- project
-  ├── columns: s:4(string)
-  ├── inner-join
-  │    ├── columns: a.x:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb) b.x:6(int!null) b.z:7(int)
-  │    ├── scan a
-  │    │    └── columns: a.x:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
-  │    ├── scan b
-  │    │    └── columns: b.x:6(int!null) b.z:7(int)
-- │    └── and [type=bool, outer=(1,2,6)]
-+ │    └── filters [type=bool, outer=(1,2,6)]
-  │         ├── eq [type=bool, outer=(1,6)]
-  │         │    ├── variable: a.x [type=int, outer=(1)]
-  │         │    └── variable: b.x [type=int, outer=(6)]
-  │         └── eq [type=bool, outer=(2)]
-  │              ├── variable: a.i [type=int, outer=(2)]
-  │              └── minus [type=int]
-  │                   ├── const: 10 [type=int]
-  │                   └── const: 1 [type=int]
-  └── projections [outer=(4)]
-       └── variable: a.s [type=string, outer=(4)]
---- 
-+++ PushDownJoinLeft
-@@ -1,20 +1,23 @@
- project
-  ├── columns: s:4(string)
-  ├── inner-join
-  │    ├── columns: a.x:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb) b.x:6(int!null) b.z:7(int)
-- │    ├── scan a
-- │    │    └── columns: a.x:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
-+ │    ├── select
-+ │    │    ├── columns: a.x:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
-+ │    │    ├── scan a
-+ │    │    │    └── columns: a.x:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
-+ │    │    └── filters [type=bool, outer=(2)]
-+ │    │         └── eq [type=bool, outer=(2)]
-+ │    │              ├── variable: a.i [type=int, outer=(2)]
-+ │    │              └── minus [type=int]
-+ │    │                   ├── const: 10 [type=int]
-+ │    │                   └── const: 1 [type=int]
-  │    ├── scan b
-  │    │    └── columns: b.x:6(int!null) b.z:7(int)
-- │    └── filters [type=bool, outer=(1,2,6)]
-- │         ├── eq [type=bool, outer=(1,6)]
-- │         │    ├── variable: a.x [type=int, outer=(1)]
-- │         │    └── variable: b.x [type=int, outer=(6)]
-- │         └── eq [type=bool, outer=(2)]
-- │              ├── variable: a.i [type=int, outer=(2)]
-- │              └── minus [type=int]
-- │                   ├── const: 10 [type=int]
-- │                   └── const: 1 [type=int]
-+ │    └── filters [type=bool, outer=(1,6)]
-+ │         └── eq [type=bool, outer=(1,6)]
-+ │              ├── variable: a.x [type=int, outer=(1)]
-+ │              └── variable: b.x [type=int, outer=(6)]
-  └── projections [outer=(4)]
-       └── variable: a.s [type=string, outer=(4)]
---- 
-+++ FilterUnusedJoinLeftCols
-@@ -1,23 +1,28 @@
- project
-  ├── columns: s:4(string)
-  ├── inner-join
-- │    ├── columns: a.x:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb) b.x:6(int!null) b.z:7(int)
-- │    ├── select
-- │    │    ├── columns: a.x:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
-- │    │    ├── scan a
-- │    │    │    └── columns: a.x:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
-- │    │    └── filters [type=bool, outer=(2)]
-- │    │         └── eq [type=bool, outer=(2)]
-- │    │              ├── variable: a.i [type=int, outer=(2)]
-- │    │              └── minus [type=int]
-- │    │                   ├── const: 10 [type=int]
-- │    │                   └── const: 1 [type=int]
-+ │    ├── columns: a.x:1(int!null) a.s:4(string) b.x:6(int!null) b.z:7(int)
-+ │    ├── project
-+ │    │    ├── columns: a.x:1(int!null) a.s:4(string)
-+ │    │    ├── select
-+ │    │    │    ├── columns: a.x:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
-+ │    │    │    ├── scan a
-+ │    │    │    │    └── columns: a.x:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
-+ │    │    │    └── filters [type=bool, outer=(2)]
-+ │    │    │         └── eq [type=bool, outer=(2)]
-+ │    │    │              ├── variable: a.i [type=int, outer=(2)]
-+ │    │    │              └── minus [type=int]
-+ │    │    │                   ├── const: 10 [type=int]
-+ │    │    │                   └── const: 1 [type=int]
-+ │    │    └── projections [outer=(1,4)]
-+ │    │         ├── variable: a.x [type=int, outer=(1)]
-+ │    │         └── variable: a.s [type=string, outer=(4)]
-  │    ├── scan b
-  │    │    └── columns: b.x:6(int!null) b.z:7(int)
-  │    └── filters [type=bool, outer=(1,6)]
-  │         └── eq [type=bool, outer=(1,6)]
-  │              ├── variable: a.x [type=int, outer=(1)]
-  │              └── variable: b.x [type=int, outer=(6)]
-  └── projections [outer=(4)]
-       └── variable: a.s [type=string, outer=(4)]
---- 
-+++ FilterUnusedSelectCols
-@@ -1,28 +1,28 @@
- project
-  ├── columns: s:4(string)
-  ├── inner-join
-  │    ├── columns: a.x:1(int!null) a.s:4(string) b.x:6(int!null) b.z:7(int)
-  │    ├── project
-  │    │    ├── columns: a.x:1(int!null) a.s:4(string)
-  │    │    ├── select
-- │    │    │    ├── columns: a.x:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
-+ │    │    │    ├── columns: a.x:1(int!null) a.i:2(int) a.s:4(string)
-  │    │    │    ├── scan a
-- │    │    │    │    └── columns: a.x:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
-+ │    │    │    │    └── columns: a.x:1(int!null) a.i:2(int) a.s:4(string)
-  │    │    │    └── filters [type=bool, outer=(2)]
-  │    │    │         └── eq [type=bool, outer=(2)]
-  │    │    │              ├── variable: a.i [type=int, outer=(2)]
-  │    │    │              └── minus [type=int]
-  │    │    │                   ├── const: 10 [type=int]
-  │    │    │                   └── const: 1 [type=int]
-  │    │    └── projections [outer=(1,4)]
-  │    │         ├── variable: a.x [type=int, outer=(1)]
-  │    │         └── variable: a.s [type=string, outer=(4)]
-  │    ├── scan b
-  │    │    └── columns: b.x:6(int!null) b.z:7(int)
-  │    └── filters [type=bool, outer=(1,6)]
-  │         └── eq [type=bool, outer=(1,6)]
-  │              ├── variable: a.x [type=int, outer=(1)]
-  │              └── variable: b.x [type=int, outer=(6)]
-  └── projections [outer=(4)]
-       └── variable: a.s [type=string, outer=(4)]
---- 
-+++ FilterUnusedJoinRightCols
-@@ -1,28 +1,28 @@
- project
-  ├── columns: s:4(string)
-  ├── inner-join
-- │    ├── columns: a.x:1(int!null) a.s:4(string) b.x:6(int!null) b.z:7(int)
-+ │    ├── columns: a.x:1(int!null) a.s:4(string) b.x:6(int!null)
-  │    ├── project
-  │    │    ├── columns: a.x:1(int!null) a.s:4(string)
-  │    │    ├── select
-  │    │    │    ├── columns: a.x:1(int!null) a.i:2(int) a.s:4(string)
-  │    │    │    ├── scan a
-  │    │    │    │    └── columns: a.x:1(int!null) a.i:2(int) a.s:4(string)
-  │    │    │    └── filters [type=bool, outer=(2)]
-  │    │    │         └── eq [type=bool, outer=(2)]
-  │    │    │              ├── variable: a.i [type=int, outer=(2)]
-  │    │    │              └── minus [type=int]
-  │    │    │                   ├── const: 10 [type=int]
-  │    │    │                   └── const: 1 [type=int]
-  │    │    └── projections [outer=(1,4)]
-  │    │         ├── variable: a.x [type=int, outer=(1)]
-  │    │         └── variable: a.s [type=string, outer=(4)]
-  │    ├── scan b
-- │    │    └── columns: b.x:6(int!null) b.z:7(int)
-+ │    │    └── columns: b.x:6(int!null)
-  │    └── filters [type=bool, outer=(1,6)]
-  │         └── eq [type=bool, outer=(1,6)]
-  │              ├── variable: a.x [type=int, outer=(1)]
-  │              └── variable: b.x [type=int, outer=(6)]
-  └── projections [outer=(4)]
-       └── variable: a.s [type=string, outer=(4)]
----
-+++
-project
- ├── columns: s:4(string)
- ├── inner-join
- │    ├── columns: a.x:1(int!null) a.s:4(string) b.x:6(int!null)
- │    ├── project
- │    │    ├── columns: a.x:1(int!null) a.s:4(string)
- │    │    ├── select
- │    │    │    ├── columns: a.x:1(int!null) a.i:2(int) a.s:4(string)
- │    │    │    ├── scan a
- │    │    │    │    └── columns: a.x:1(int!null) a.i:2(int) a.s:4(string)
- │    │    │    └── filters [type=bool, outer=(2)]
- │    │    │         └── eq [type=bool, outer=(2)]
- │    │    │              ├── variable: a.i [type=int, outer=(2)]
- │    │    │              └── minus [type=int]
- │    │    │                   ├── const: 10 [type=int]
- │    │    │                   └── const: 1 [type=int]
- │    │    └── projections [outer=(1,4)]
- │    │         ├── variable: a.x [type=int, outer=(1)]
- │    │         └── variable: a.s [type=string, outer=(4)]
- │    ├── scan b
- │    │    └── columns: b.x:6(int!null)
- │    └── filters [type=bool, outer=(1,6)]
- │         └── eq [type=bool, outer=(1,6)]
- │              ├── variable: a.x [type=int, outer=(1)]
- │              └── variable: b.x [type=int, outer=(6)]
- └── projections [outer=(4)]
-      └── variable: a.s [type=string, outer=(4)]
+----
+*** Initial expr:
+  project
+   ├── columns: s:4(string)
+   ├── inner-join
+   │    ├── columns: a.x:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb) b.x:6(int!null) b.z:7(int)
+   │    ├── scan a
+   │    │    └── columns: a.x:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
+   │    ├── scan b
+   │    │    └── columns: b.x:6(int!null) b.z:7(int)
+   │    └── and [type=bool, outer=(1,2,6)]
+   │         ├── eq [type=bool, outer=(1,6)]
+   │         │    ├── variable: a.x [type=int, outer=(1)]
+   │         │    └── variable: b.x [type=int, outer=(6)]
+   │         └── eq [type=bool, outer=(2)]
+   │              ├── plus [type=int, outer=(2)]
+   │              │    ├── variable: a.i [type=int, outer=(2)]
+   │              │    └── const: 1 [type=int]
+   │              └── const: 10 [type=int]
+   └── projections [outer=(4)]
+        └── variable: a.s [type=string, outer=(4)]
+
+*** NormalizeCmpPlusConst applied; best expr changed:
+   project
+    ├── columns: s:4(string)
+    ├── inner-join
+    │    ├── columns: a.x:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb) b.x:6(int!null) b.z:7(int)
+    │    ├── scan a
+    │    │    └── columns: a.x:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
+    │    ├── scan b
+    │    │    └── columns: b.x:6(int!null) b.z:7(int)
+    │    └── and [type=bool, outer=(1,2,6)]
+    │         ├── eq [type=bool, outer=(1,6)]
+    │         │    ├── variable: a.x [type=int, outer=(1)]
+    │         │    └── variable: b.x [type=int, outer=(6)]
+    │         └── eq [type=bool, outer=(2)]
+  - │              ├── plus [type=int, outer=(2)]
+  - │              │    ├── variable: a.i [type=int, outer=(2)]
+  - │              │    └── const: 1 [type=int]
+  - │              └── const: 10 [type=int]
+  + │              ├── variable: a.i [type=int, outer=(2)]
+  + │              └── minus [type=int]
+  + │                   ├── const: 10 [type=int]
+  + │                   └── const: 1 [type=int]
+    └── projections [outer=(4)]
+         └── variable: a.s [type=string, outer=(4)]
+
+*** EnsureJoinFiltersAnd applied; best expr changed:
+   project
+    ├── columns: s:4(string)
+    ├── inner-join
+    │    ├── columns: a.x:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb) b.x:6(int!null) b.z:7(int)
+    │    ├── scan a
+    │    │    └── columns: a.x:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
+    │    ├── scan b
+    │    │    └── columns: b.x:6(int!null) b.z:7(int)
+  - │    └── and [type=bool, outer=(1,2,6)]
+  + │    └── filters [type=bool, outer=(1,2,6)]
+    │         ├── eq [type=bool, outer=(1,6)]
+    │         │    ├── variable: a.x [type=int, outer=(1)]
+    │         │    └── variable: b.x [type=int, outer=(6)]
+    │         └── eq [type=bool, outer=(2)]
+    │              ├── variable: a.i [type=int, outer=(2)]
+    │              └── minus [type=int]
+    │                   ├── const: 10 [type=int]
+    │                   └── const: 1 [type=int]
+    └── projections [outer=(4)]
+         └── variable: a.s [type=string, outer=(4)]
+
+*** PushDownJoinLeft applied; best expr changed:
+   project
+    ├── columns: s:4(string)
+    ├── inner-join
+    │    ├── columns: a.x:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb) b.x:6(int!null) b.z:7(int)
+  - │    ├── scan a
+  - │    │    └── columns: a.x:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
+  + │    ├── select
+  + │    │    ├── columns: a.x:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
+  + │    │    ├── scan a
+  + │    │    │    └── columns: a.x:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
+  + │    │    └── filters [type=bool, outer=(2)]
+  + │    │         └── eq [type=bool, outer=(2)]
+  + │    │              ├── variable: a.i [type=int, outer=(2)]
+  + │    │              └── minus [type=int]
+  + │    │                   ├── const: 10 [type=int]
+  + │    │                   └── const: 1 [type=int]
+    │    ├── scan b
+    │    │    └── columns: b.x:6(int!null) b.z:7(int)
+  - │    └── filters [type=bool, outer=(1,2,6)]
+  - │         ├── eq [type=bool, outer=(1,6)]
+  - │         │    ├── variable: a.x [type=int, outer=(1)]
+  - │         │    └── variable: b.x [type=int, outer=(6)]
+  - │         └── eq [type=bool, outer=(2)]
+  - │              ├── variable: a.i [type=int, outer=(2)]
+  - │              └── minus [type=int]
+  - │                   ├── const: 10 [type=int]
+  - │                   └── const: 1 [type=int]
+  + │    └── filters [type=bool, outer=(1,6)]
+  + │         └── eq [type=bool, outer=(1,6)]
+  + │              ├── variable: a.x [type=int, outer=(1)]
+  + │              └── variable: b.x [type=int, outer=(6)]
+    └── projections [outer=(4)]
+         └── variable: a.s [type=string, outer=(4)]
+
+*** FilterUnusedJoinLeftCols applied; best expr changed:
+   project
+    ├── columns: s:4(string)
+    ├── inner-join
+  - │    ├── columns: a.x:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb) b.x:6(int!null) b.z:7(int)
+  - │    ├── select
+  - │    │    ├── columns: a.x:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
+  - │    │    ├── scan a
+  - │    │    │    └── columns: a.x:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
+  - │    │    └── filters [type=bool, outer=(2)]
+  - │    │         └── eq [type=bool, outer=(2)]
+  - │    │              ├── variable: a.i [type=int, outer=(2)]
+  - │    │              └── minus [type=int]
+  - │    │                   ├── const: 10 [type=int]
+  - │    │                   └── const: 1 [type=int]
+  + │    ├── columns: a.x:1(int!null) a.s:4(string) b.x:6(int!null) b.z:7(int)
+  + │    ├── project
+  + │    │    ├── columns: a.x:1(int!null) a.s:4(string)
+  + │    │    ├── select
+  + │    │    │    ├── columns: a.x:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
+  + │    │    │    ├── scan a
+  + │    │    │    │    └── columns: a.x:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
+  + │    │    │    └── filters [type=bool, outer=(2)]
+  + │    │    │         └── eq [type=bool, outer=(2)]
+  + │    │    │              ├── variable: a.i [type=int, outer=(2)]
+  + │    │    │              └── minus [type=int]
+  + │    │    │                   ├── const: 10 [type=int]
+  + │    │    │                   └── const: 1 [type=int]
+  + │    │    └── projections [outer=(1,4)]
+  + │    │         ├── variable: a.x [type=int, outer=(1)]
+  + │    │         └── variable: a.s [type=string, outer=(4)]
+    │    ├── scan b
+    │    │    └── columns: b.x:6(int!null) b.z:7(int)
+    │    └── filters [type=bool, outer=(1,6)]
+    │         └── eq [type=bool, outer=(1,6)]
+    │              ├── variable: a.x [type=int, outer=(1)]
+    │              └── variable: b.x [type=int, outer=(6)]
+    └── projections [outer=(4)]
+         └── variable: a.s [type=string, outer=(4)]
+
+*** FilterUnusedSelectCols applied; best expr changed:
+   project
+    ├── columns: s:4(string)
+    ├── inner-join
+    │    ├── columns: a.x:1(int!null) a.s:4(string) b.x:6(int!null) b.z:7(int)
+    │    ├── project
+    │    │    ├── columns: a.x:1(int!null) a.s:4(string)
+    │    │    ├── select
+  - │    │    │    ├── columns: a.x:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
+  + │    │    │    ├── columns: a.x:1(int!null) a.i:2(int) a.s:4(string)
+    │    │    │    ├── scan a
+  - │    │    │    │    └── columns: a.x:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
+  + │    │    │    │    └── columns: a.x:1(int!null) a.i:2(int) a.s:4(string)
+    │    │    │    └── filters [type=bool, outer=(2)]
+    │    │    │         └── eq [type=bool, outer=(2)]
+    │    │    │              ├── variable: a.i [type=int, outer=(2)]
+    │    │    │              └── minus [type=int]
+    │    │    │                   ├── const: 10 [type=int]
+    │    │    │                   └── const: 1 [type=int]
+    │    │    └── projections [outer=(1,4)]
+    │    │         ├── variable: a.x [type=int, outer=(1)]
+    │    │         └── variable: a.s [type=string, outer=(4)]
+    │    ├── scan b
+    │    │    └── columns: b.x:6(int!null) b.z:7(int)
+    │    └── filters [type=bool, outer=(1,6)]
+    │         └── eq [type=bool, outer=(1,6)]
+    │              ├── variable: a.x [type=int, outer=(1)]
+    │              └── variable: b.x [type=int, outer=(6)]
+    └── projections [outer=(4)]
+         └── variable: a.s [type=string, outer=(4)]
+
+*** FilterUnusedJoinRightCols applied; best expr changed:
+   project
+    ├── columns: s:4(string)
+    ├── inner-join
+  - │    ├── columns: a.x:1(int!null) a.s:4(string) b.x:6(int!null) b.z:7(int)
+  + │    ├── columns: a.x:1(int!null) a.s:4(string) b.x:6(int!null)
+    │    ├── project
+    │    │    ├── columns: a.x:1(int!null) a.s:4(string)
+    │    │    ├── select
+    │    │    │    ├── columns: a.x:1(int!null) a.i:2(int) a.s:4(string)
+    │    │    │    ├── scan a
+    │    │    │    │    └── columns: a.x:1(int!null) a.i:2(int) a.s:4(string)
+    │    │    │    └── filters [type=bool, outer=(2)]
+    │    │    │         └── eq [type=bool, outer=(2)]
+    │    │    │              ├── variable: a.i [type=int, outer=(2)]
+    │    │    │              └── minus [type=int]
+    │    │    │                   ├── const: 10 [type=int]
+    │    │    │                   └── const: 1 [type=int]
+    │    │    └── projections [outer=(1,4)]
+    │    │         ├── variable: a.x [type=int, outer=(1)]
+    │    │         └── variable: a.s [type=string, outer=(4)]
+    │    ├── scan b
+  - │    │    └── columns: b.x:6(int!null) b.z:7(int)
+  + │    │    └── columns: b.x:6(int!null)
+    │    └── filters [type=bool, outer=(1,6)]
+    │         └── eq [type=bool, outer=(1,6)]
+    │              ├── variable: a.x [type=int, outer=(1)]
+    │              └── variable: b.x [type=int, outer=(6)]
+    └── projections [outer=(4)]
+         └── variable: a.s [type=string, outer=(4)]
+
+*** GenerateIndexScans applied; best expr unchanged.
+
+*** GenerateIndexScans applied; best expr unchanged.
+
+*** Final best expr:
+  project
+   ├── columns: s:4(string)
+   ├── inner-join
+   │    ├── columns: a.x:1(int!null) a.s:4(string) b.x:6(int!null)
+   │    ├── project
+   │    │    ├── columns: a.x:1(int!null) a.s:4(string)
+   │    │    ├── select
+   │    │    │    ├── columns: a.x:1(int!null) a.i:2(int) a.s:4(string)
+   │    │    │    ├── scan a
+   │    │    │    │    └── columns: a.x:1(int!null) a.i:2(int) a.s:4(string)
+   │    │    │    └── filters [type=bool, outer=(2)]
+   │    │    │         └── eq [type=bool, outer=(2)]
+   │    │    │              ├── variable: a.i [type=int, outer=(2)]
+   │    │    │              └── minus [type=int]
+   │    │    │                   ├── const: 10 [type=int]
+   │    │    │                   └── const: 1 [type=int]
+   │    │    └── projections [outer=(1,4)]
+   │    │         ├── variable: a.x [type=int, outer=(1)]
+   │    │         └── variable: a.s [type=string, outer=(4)]
+   │    ├── scan b
+   │    │    └── columns: b.x:6(int!null)
+   │    └── filters [type=bool, outer=(1,6)]
+   │         └── eq [type=bool, outer=(1,6)]
+   │              ├── variable: a.x [type=int, outer=(1)]
+   │              └── variable: b.x [type=int, outer=(6)]
+   └── projections [outer=(4)]
+        └── variable: a.s [type=string, outer=(4)]
+----
+----


### PR DESCRIPTION
I got confused about how optsteps interacts with exploration. The
optsteps output only changes when the best expression for the entire
query changes; when a rule is applied that doesn't affect the best
expression, there is no report of that rule being applied.

This change makes the following improvements:
 - we trim the diff header to avoid the --- +++ delimiters
 - we indent the initial and final expressions and the diffs
 - when the expression doesn't change, we still show the rule that was
   applied
 - we are more explicit about what's happening; we label the initial
   and final expressions and each step shows "best expr changed" or
   "best expr unchanged".

Release note: None