### PR TITLE
roachtest: remove sqlapp from scaledata test name

### DIFF
--- a/pkg/cmd/roachtest/scaledata.go
+++ b/pkg/cmd/roachtest/scaledata.go
@@ -47,7 +47,7 @@ func init() {
 		const duration = 10 * time.Minute
 		for _, n := range []int{3, 6} {
 			tests.Add(testSpec{
-				Name:  fmt.Sprintf("scaledata/sqlapp/%s/nodes=%d", app, n),
+				Name:  fmt.Sprintf("scaledata/%s/nodes=%d", app, n),
 				Nodes: nodes(n + 1),
 				Run: func(ctx context.Context, t *test, c *cluster) {
 					runSqlapp(ctx, t, c, app, flags, duration)


### PR DESCRIPTION
This was kicking the name over the GCE name size limit.

Release note: None