### PR TITLE
optbuilder: Fix bugs with subqueries, DISTINCT, and ORDER BY

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/aggregate
+++ b/pkg/sql/opt/exec/execbuilder/testdata/aggregate
@@ -12,39 +12,32 @@ CREATE TABLE kv (
 exec-explain
 SELECT MIN(1), MAX(1), COUNT(1), SUM_INT(1), AVG(1), SUM(1), STDDEV(1), VARIANCE(1), BOOL_AND(true), BOOL_OR(false), XOR_AGG(b'\x01') FROM kv
 ----
-group           0  group   ·             ·                   (column6, column8, column10, column12, column14, column16, column18, column20, column22, column24, column26)  ·
- │              0  ·       aggregate 0   min(column5)        ·                                                                                                             ·
- │              0  ·       aggregate 1   max(column7)        ·                                                                                                             ·
- │              0  ·       aggregate 2   count(column9)      ·                                                                                                             ·
- │              0  ·       aggregate 3   sum_int(column11)   ·                                                                                                             ·
- │              0  ·       aggregate 4   avg(column13)       ·                                                                                                             ·
- │              0  ·       aggregate 5   sum(column15)       ·                                                                                                             ·
- │              0  ·       aggregate 6   stddev(column17)    ·                                                                                                             ·
- │              0  ·       aggregate 7   variance(column19)  ·                                                                                                             ·
- │              0  ·       aggregate 8   bool_and(column21)  ·                                                                                                             ·
- │              0  ·       aggregate 9   bool_or(column23)   ·                                                                                                             ·
- │              0  ·       aggregate 10  xor_agg(column25)   ·                                                                                                             ·
- └── render     1  render  ·             ·                   (column5, column7, column9, column11, column13, column15, column17, column19, column21, column23, column25)   ·
-      │         1  ·       render 0      1                   ·                                                                                                             ·
-      │         1  ·       render 1      1                   ·                                                                                                             ·
-      │         1  ·       render 2      1                   ·                                                                                                             ·
-      │         1  ·       render 3      1                   ·                                                                                                             ·
-      │         1  ·       render 4      1                   ·                                                                                                             ·
-      │         1  ·       render 5      1                   ·                                                                                                             ·
-      │         1  ·       render 6      1                   ·                                                                                                             ·
-      │         1  ·       render 7      1                   ·                                                                                                             ·
-      │         1  ·       render 8      true                ·                                                                                                             ·
-      │         1  ·       render 9      false               ·                                                                                                             ·
-      │         1  ·       render 10     '\x01'              ·                                                                                                             ·
-      └── scan  2  scan    ·             ·                   ()                                                                                                            ·
-·               2  ·       table         kv@primary          ·                                                                                                             ·
-·               2  ·       spans         ALL                 ·                                                                                                             ·
+group           0  group   ·             ·                   (column6, column7, column8, column9, column10, column11, column12, column13, column15, column17, column19)  ·
+ │              0  ·       aggregate 0   min(column5)        ·                                                                                                           ·
+ │              0  ·       aggregate 1   max(column5)        ·                                                                                                           ·
+ │              0  ·       aggregate 2   count(column5)      ·                                                                                                           ·
+ │              0  ·       aggregate 3   sum_int(column5)    ·                                                                                                           ·
+ │              0  ·       aggregate 4   avg(column5)        ·                                                                                                           ·
+ │              0  ·       aggregate 5   sum(column5)        ·                                                                                                           ·
+ │              0  ·       aggregate 6   stddev(column5)     ·                                                                                                           ·
+ │              0  ·       aggregate 7   variance(column5)   ·                                                                                                           ·
+ │              0  ·       aggregate 8   bool_and(column14)  ·                                                                                                           ·
+ │              0  ·       aggregate 9   bool_or(column16)   ·                                                                                                           ·
+ │              0  ·       aggregate 10  xor_agg(column18)   ·                                                                                                           ·
+ └── render     1  render  ·             ·                   (column5, column14, column16, column18)                                                                     ·
+      │         1  ·       render 0      1                   ·                                                                                                           ·
+      │         1  ·       render 1      true                ·                                                                                                           ·
+      │         1  ·       render 2      false               ·                                                                                                           ·
+      │         1  ·       render 3      '\x01'              ·                                                                                                           ·
+      └── scan  2  scan    ·             ·                   ()                                                                                                          ·
+·               2  ·       table         kv@primary          ·                                                                                                           ·
+·               2  ·       spans         ALL                 ·                                                                                                           ·
 
 exec
 SELECT MIN(1), MAX(1), COUNT(1), SUM_INT(1), AVG(1), SUM(1), STDDEV(1), VARIANCE(1), BOOL_AND(true), BOOL_OR(false), XOR_AGG(b'\x01') FROM kv
 ----
-column6:int  column8:int  column10:int  column12:int  column14:decimal  column16:decimal  column18:decimal  column20:decimal  column22:bool  column24:bool  column26:bytes
-NULL         NULL         0             NULL          NULL              NULL              NULL              NULL              NULL           NULL           NULL
+column6:int  column7:int  column8:int  column9:int  column10:decimal  column11:decimal  column12:decimal  column13:decimal  column15:bool  column17:bool  column19:bytes
+NULL         NULL         0            NULL         NULL              NULL              NULL              NULL              NULL           NULL           NULL
 
 # Aggregate functions return NULL if there are no rows.
 exec
@@ -68,7 +61,7 @@ NULL
 exec-explain
 SELECT MIN(v), MAX(v), COUNT(v), SUM_INT(1), AVG(v), SUM(v), STDDEV(v), VARIANCE(v), BOOL_AND(v = 1), BOOL_AND(v = 1), XOR_AGG(s::bytes) FROM kv
 ----
-render               0  render  ·            ·                   (column5, column6, column7, column9, column10, column11, column12, column13, column15, column15, column18)  ·
+render               0  render  ·            ·                   (column5, column6, column7, column9, column10, column11, column12, column13, column15, column15, column17)  ·
  │                   0  ·       render 0     agg0                ·                                                                                                           ·
  │                   0  ·       render 1     agg1                ·                                                                                                           ·
  │                   0  ·       render 2     agg2                ·                                                                                                           ·
@@ -90,18 +83,12 @@ render               0  render  ·            ·                   (column5, col
       │              1  ·       aggregate 6  stddev(kv.v)        ·                                                                                                           ·
       │              1  ·       aggregate 7  variance(kv.v)      ·                                                                                                           ·
       │              1  ·       aggregate 8  bool_and(column14)  ·                                                                                                           ·
-      │              1  ·       aggregate 9  xor_agg(column17)   ·                                                                                                           ·
-      └── render     2  render  ·            ·                   ("kv.v", "kv.v", "kv.v", column8, "kv.v", "kv.v", "kv.v", "kv.v", column14, column17)                       ·
+      │              1  ·       aggregate 9  xor_agg(column16)   ·                                                                                                           ·
+      └── render     2  render  ·            ·                   ("kv.v", column8, column14, column16)                                                                       ·
            │         2  ·       render 0     v                   ·                                                                                                           ·
-           │         2  ·       render 1     v                   ·                                                                                                           ·
-           │         2  ·       render 2     v                   ·                                                                                                           ·
-           │         2  ·       render 3     1                   ·                                                                                                           ·
-           │         2  ·       render 4     v                   ·                                                                                                           ·
-           │         2  ·       render 5     v                   ·                                                                                                           ·
-           │         2  ·       render 6     v                   ·                                                                                                           ·
-           │         2  ·       render 7     v                   ·                                                                                                           ·
-           │         2  ·       render 8     v = 1               ·                                                                                                           ·
-           │         2  ·       render 9     s::BYTES            ·                                                                                                           ·
+           │         2  ·       render 1     1                   ·                                                                                                           ·
+           │         2  ·       render 2     v = 1               ·                                                                                                           ·
+           │         2  ·       render 3     s::BYTES            ·                                                                                                           ·
            └── scan  3  scan    ·            ·                   (v, s)                                                                                                      ·
 ·                    3  ·       table        kv@primary          ·                                                                                                           ·
 ·                    3  ·       spans        ALL                 ·                                                                                                           ·
@@ -109,7 +96,7 @@ render               0  render  ·            ·                   (column5, col
 exec
 SELECT MIN(v), MAX(v), COUNT(v), SUM_INT(1), AVG(v), SUM(v), STDDEV(v), VARIANCE(v), BOOL_AND(v = 1), BOOL_AND(v = 1), XOR_AGG(s::bytes) FROM kv
 ----
-column5:int  column6:int  column7:int  column9:int  column10:decimal  column11:decimal  column12:decimal  column13:decimal  column15:bool  column15:bool  column18:bytes
+column5:int  column6:int  column7:int  column9:int  column10:decimal  column11:decimal  column12:decimal  column13:decimal  column15:bool  column15:bool  column17:bytes
 NULL         NULL         0            NULL         NULL              NULL              NULL              NULL              NULL           NULL           NULL
 
 exec
@@ -134,57 +121,49 @@ NULL
 exec-explain
 SELECT MIN(1), COUNT(1), MAX(1), SUM_INT(1), AVG(1)::float, SUM(1), STDDEV(1), VARIANCE(1), BOOL_AND(true), BOOL_OR(true), TO_HEX(XOR_AGG(b'\x01'))
 ----
-render                 0  render  ·             ·                   (column2, column4, column6, column8, column11, column13, column15, column17, column19, column21, column24)  ·
- │                     0  ·       render 0      agg0                ·                                                                                                           ·
- │                     0  ·       render 1      agg1                ·                                                                                                           ·
- │                     0  ·       render 2      agg2                ·                                                                                                           ·
- │                     0  ·       render 3      agg3                ·                                                                                                           ·
- │                     0  ·       render 4      agg4::FLOAT         ·                                                                                                           ·
- │                     0  ·       render 5      agg5                ·                                                                                                           ·
- │                     0  ·       render 6      agg6                ·                                                                                                           ·
- │                     0  ·       render 7      agg7                ·                                                                                                           ·
- │                     0  ·       render 8      agg8                ·                                                                                                           ·
- │                     0  ·       render 9      agg9                ·                                                                                                           ·
- │                     0  ·       render 10     to_hex(agg10)       ·                                                                                                           ·
- └── group             1  group   ·             ·                   (agg0, agg1, agg2, agg3, agg4, agg5, agg6, agg7, agg8, agg9, agg10)                                         ·
-      │                1  ·       aggregate 0   min(column1)        ·                                                                                                           ·
-      │                1  ·       aggregate 1   count(column3)      ·                                                                                                           ·
-      │                1  ·       aggregate 2   max(column5)        ·                                                                                                           ·
-      │                1  ·       aggregate 3   sum_int(column7)    ·                                                                                                           ·
-      │                1  ·       aggregate 4   avg(column9)        ·                                                                                                           ·
-      │                1  ·       aggregate 5   sum(column12)       ·                                                                                                           ·
-      │                1  ·       aggregate 6   stddev(column14)    ·                                                                                                           ·
-      │                1  ·       aggregate 7   variance(column16)  ·                                                                                                           ·
-      │                1  ·       aggregate 8   bool_and(column18)  ·                                                                                                           ·
-      │                1  ·       aggregate 9   bool_or(column20)   ·                                                                                                           ·
-      │                1  ·       aggregate 10  xor_agg(column22)   ·                                                                                                           ·
-      └── render       2  render  ·             ·                   (column1, column3, column5, column7, column9, column12, column14, column16, column18, column20, column22)   ·
-           │           2  ·       render 0      1                   ·                                                                                                           ·
-           │           2  ·       render 1      1                   ·                                                                                                           ·
-           │           2  ·       render 2      1                   ·                                                                                                           ·
-           │           2  ·       render 3      1                   ·                                                                                                           ·
-           │           2  ·       render 4      1                   ·                                                                                                           ·
-           │           2  ·       render 5      1                   ·                                                                                                           ·
-           │           2  ·       render 6      1                   ·                                                                                                           ·
-           │           2  ·       render 7      1                   ·                                                                                                           ·
-           │           2  ·       render 8      true                ·                                                                                                           ·
-           │           2  ·       render 9      true                ·                                                                                                           ·
-           │           2  ·       render 10     '\x01'              ·                                                                                                           ·
-           └── values  3  values  ·             ·                   ()                                                                                                          ·
-·                      3  ·       size          0 columns, 1 row    ·                                                                                                           ·
+render                 0  render  ·             ·                   (column2, column3, column4, column5, column7, column8, column9, column10, column12, column13, column16)  ·
+ │                     0  ·       render 0      agg0                ·                                                                                                        ·
+ │                     0  ·       render 1      agg1                ·                                                                                                        ·
+ │                     0  ·       render 2      agg2                ·                                                                                                        ·
+ │                     0  ·       render 3      agg3                ·                                                                                                        ·
+ │                     0  ·       render 4      agg4::FLOAT         ·                                                                                                        ·
+ │                     0  ·       render 5      agg5                ·                                                                                                        ·
+ │                     0  ·       render 6      agg6                ·                                                                                                        ·
+ │                     0  ·       render 7      agg7                ·                                                                                                        ·
+ │                     0  ·       render 8      agg8                ·                                                                                                        ·
+ │                     0  ·       render 9      agg9                ·                                                                                                        ·
+ │                     0  ·       render 10     to_hex(agg10)       ·                                                                                                        ·
+ └── group             1  group   ·             ·                   (agg0, agg1, agg2, agg3, agg4, agg5, agg6, agg7, agg8, agg9, agg10)                                      ·
+      │                1  ·       aggregate 0   min(column1)        ·                                                                                                        ·
+      │                1  ·       aggregate 1   count(column1)      ·                                                                                                        ·
+      │                1  ·       aggregate 2   max(column1)        ·                                                                                                        ·
+      │                1  ·       aggregate 3   sum_int(column1)    ·                                                                                                        ·
+      │                1  ·       aggregate 4   avg(column1)        ·                                                                                                        ·
+      │                1  ·       aggregate 5   sum(column1)        ·                                                                                                        ·
+      │                1  ·       aggregate 6   stddev(column1)     ·                                                                                                        ·
+      │                1  ·       aggregate 7   variance(column1)   ·                                                                                                        ·
+      │                1  ·       aggregate 8   bool_and(column11)  ·                                                                                                        ·
+      │                1  ·       aggregate 9   bool_or(column11)   ·                                                                                                        ·
+      │                1  ·       aggregate 10  xor_agg(column14)   ·                                                                                                        ·
+      └── render       2  render  ·             ·                   (column1, column11, column14)                                                                            ·
+           │           2  ·       render 0      1                   ·                                                                                                        ·
+           │           2  ·       render 1      true                ·                                                                                                        ·
+           │           2  ·       render 2      '\x01'              ·                                                                                                        ·
+           └── values  3  values  ·             ·                   ()                                                                                                       ·
+·                      3  ·       size          0 columns, 1 row    ·                                                                                                        ·
 
 exec
 SELECT MIN(1), COUNT(1), MAX(1), SUM_INT(1), AVG(1)::float, SUM(1), STDDEV(1), VARIANCE(1), BOOL_AND(true), BOOL_OR(true), TO_HEX(XOR_AGG(b'\x01'))
 ----
-column2:int  column4:int  column6:int  column8:int  column11:float  column13:decimal  column15:decimal  column17:decimal  column19:bool  column21:bool  column24:string
-1            1            1            1            1.0             1                 NULL              NULL              true           true           01
+column2:int  column3:int  column4:int  column5:int  column7:float  column8:decimal  column9:decimal  column10:decimal  column12:bool  column13:bool  column16:string
+1            1            1            1            1.0            1                NULL             NULL              true           true           01
 
 # Aggregate functions triggers aggregation and computation when there is no source.
 exec
 SELECT MIN(1), COUNT(1), MAX(1), SUM_INT(1), AVG(1)::float, SUM(1), STDDEV(1), VARIANCE(1), BOOL_AND(true), BOOL_OR(true), TO_HEX(XOR_AGG(b'\x01'))
 ----
-column2:int  column4:int  column6:int  column8:int  column11:float  column13:decimal  column15:decimal  column17:decimal  column19:bool  column21:bool  column24:string
-1            1            1            1            1.0             1                 NULL              NULL              true           true           01
+column2:int  column3:int  column4:int  column5:int  column7:float  column8:decimal  column9:decimal  column10:decimal  column12:bool  column13:bool  column16:string
+1            1            1            1            1.0            1                NULL             NULL              true           true           01
 
 # Aggregate functions triggers aggregation and computation when there is no source.
 exec
@@ -282,8 +261,8 @@ INSERT INTO kv VALUES
 exec
 SELECT MIN(1), COUNT(1), MAX(1), SUM_INT(1), AVG(1)::float, SUM(1), STDDEV(1), VARIANCE(1)::float, BOOL_AND(true), BOOL_OR(true), TO_HEX(XOR_AGG(b'\x01')) FROM kv
 ----
-column6:int  column8:int  column10:int  column12:int  column15:float  column17:decimal  column19:decimal  column22:float  column24:bool  column26:bool  column29:string
-1            6            1             6             1.0             6                 0                 0.0             true           true           00
+column6:int  column7:int  column8:int  column9:int  column11:float  column12:decimal  column13:decimal  column15:float  column17:bool  column18:bool  column21:string
+1            6            1            6            1.0             6                 0                 0.0             true           true           00
 
 # Aggregate functions triggers aggregation and computation for every row even when applied to a constant.
 exec
@@ -678,8 +657,8 @@ column5:decimal  column6:decimal  column7:decimal  column8:decimal
 exec
 SELECT AVG(k::decimal), AVG(v::decimal), SUM(k::decimal), SUM(v::decimal) FROM kv
 ----
-column6:decimal  column8:decimal  column10:decimal  column12:decimal
-5                2.8              30                14
+column6:decimal  column8:decimal  column9:decimal  column10:decimal
+5                2.8              30               14
 
 #exec
 #SELECT AVG(DISTINCT k), AVG(DISTINCT v), SUM(DISTINCT k), SUM(DISTINCT v) FROM kv
@@ -1472,7 +1451,7 @@ column6:string  column7:int
 exec
 SELECT MAX(true), MIN(true)
 ----
-column2:bool  column4:bool
+column2:bool  column3:bool
 true          true
 
 exec-raw

--- a/pkg/sql/opt/exec/execbuilder/testdata/orderby
+++ b/pkg/sql/opt/exec/execbuilder/testdata/orderby
@@ -354,16 +354,13 @@ render               0  render  ·         ·              (a, b, c)            
 exec-explain
 SELECT b+2 FROM t ORDER BY b+2
 ----
-render               0  render  ·         ·          (column4)           ·
- │                   0  ·       render 0  column4    ·                   ·
- └── sort            1  sort    ·         ·          (column4, column5)  +column5
-      │              1  ·       order     +column5   ·                   ·
-      └── render     2  render  ·         ·          (column4, column5)  ·
-           │         2  ·       render 0  b + 2      ·                   ·
-           │         2  ·       render 1  b + 2      ·                   ·
-           └── scan  3  scan    ·         ·          (b)                 ·
-·                    3  ·       table     t@primary  ·                   ·
-·                    3  ·       spans     ALL        ·                   ·
+sort            0  sort    ·         ·          (column4)  +column4
+ │              0  ·       order     +column4   ·          ·
+ └── render     1  render  ·         ·          (column4)  ·
+      │         1  ·       render 0  b + 2      ·          ·
+      └── scan  2  scan    ·         ·          (b)        ·
+·               2  ·       table     t@primary  ·          ·
+·               2  ·       spans     ALL        ·          ·
 
 # Check that the sort picks up a renamed render properly.
 exec-explain
@@ -381,16 +378,13 @@ sort            0  sort    ·         ·          (y)  +y
 exec-explain
 SELECT b+2 AS y FROM t ORDER BY b+2
 ----
-render               0  render  ·         ·          (y)           ·
- │                   0  ·       render 0  y          ·             ·
- └── sort            1  sort    ·         ·          (y, column5)  +column5
-      │              1  ·       order     +column5   ·             ·
-      └── render     2  render  ·         ·          (y, column5)  ·
-           │         2  ·       render 0  b + 2      ·             ·
-           │         2  ·       render 1  b + 2      ·             ·
-           └── scan  3  scan    ·         ·          (b)           ·
-·                    3  ·       table     t@primary  ·             ·
-·                    3  ·       spans     ALL        ·             ·
+sort            0  sort    ·         ·          (y)  +y
+ │              0  ·       order     +y         ·    ·
+ └── render     1  render  ·         ·          (y)  ·
+      │         1  ·       render 0  b + 2      ·    ·
+      └── scan  2  scan    ·         ·          (b)  ·
+·               2  ·       table     t@primary  ·    ·
+·               2  ·       spans     ALL        ·    ·
 
 exec-raw
 CREATE TABLE abc (

--- a/pkg/sql/opt/memo/testdata/logprops/set
+++ b/pkg/sql/opt/memo/testdata/logprops/set
@@ -47,15 +47,14 @@ intersect
  ├── right columns: b.z:4(int) b.x:3(int) b.rowid:5(int)
  ├── stats: [rows=550]
  ├── project
- │    ├── columns: a.x:1(int!null) a.y:2(int) a.x:1(int!null)
+ │    ├── columns: a.x:1(int!null) a.y:2(int)
  │    ├── stats: [rows=1000]
  │    ├── scan a
  │    │    ├── columns: a.x:1(int!null) a.y:2(int)
  │    │    └── stats: [rows=1000]
  │    └── projections [outer=(1,2)]
  │         ├── variable: a.x [type=int, outer=(1)]
- │         ├── variable: a.y [type=int, outer=(2)]
- │         └── variable: a.x [type=int, outer=(1)]
+ │         └── variable: a.y [type=int, outer=(2)]
  └── project
       ├── columns: b.z:4(int!null) b.x:3(int) b.rowid:5(int!null)
       ├── stats: [rows=100]
@@ -82,17 +81,16 @@ except
  ├── right columns: b.x:3(int) b.z:4(int) b.z:4(int)
  ├── stats: [rows=550]
  ├── project
- │    ├── columns: a.x:1(int!null) a.x:1(int!null) a.y:2(int)
+ │    ├── columns: a.x:1(int!null) a.y:2(int)
  │    ├── stats: [rows=1000]
  │    ├── scan a
  │    │    ├── columns: a.x:1(int!null) a.y:2(int)
  │    │    └── stats: [rows=1000]
  │    └── projections [outer=(1,2)]
  │         ├── variable: a.x [type=int, outer=(1)]
- │         ├── variable: a.x [type=int, outer=(1)]
  │         └── variable: a.y [type=int, outer=(2)]
  └── project
-      ├── columns: b.x:3(int) b.z:4(int!null) b.z:4(int!null)
+      ├── columns: b.x:3(int) b.z:4(int!null)
       ├── stats: [rows=100]
       ├── project
       │    ├── columns: b.x:3(int) b.z:4(int!null)
@@ -111,5 +109,4 @@ except
       │         └── variable: b.z [type=int, outer=(4)]
       └── projections [outer=(3,4)]
            ├── variable: b.x [type=int, outer=(3)]
-           ├── variable: b.z [type=int, outer=(4)]
            └── variable: b.z [type=int, outer=(4)]

--- a/pkg/sql/opt/optbuilder/orderby.go
+++ b/pkg/sql/opt/optbuilder/orderby.go
@@ -137,6 +137,16 @@ func (b *Builder) buildOrdering(
 		// Ensure we can order on the given column.
 		ensureColumnOrderable(e)
 		scalar := b.buildScalarProjection(e, "", inScope, orderByScope)
+
+		// Use an existing projection if possible.
+		// TODO(rytaft): If we store the memo.GroupID in the column, we can avoid
+		// rebuilding the expression.
+		if col := projectionsScope.findExistingCol(e); col != nil {
+			// buildScalarProjection added a new column to the end of
+			// orderByScope.cols. Replace it with the already existing column.
+			orderByScope.cols[len(orderByScope.cols)-1] = *col
+		}
+
 		projections = append(projections, scalar)
 	}
 

--- a/pkg/sql/opt/optbuilder/scope.go
+++ b/pkg/sql/opt/optbuilder/scope.go
@@ -76,6 +76,17 @@ func (s *scope) appendColumns(src *scope) {
 	s.cols = append(s.cols, src.cols...)
 }
 
+// appendColumn adds a new column to the scope with an optional new label.
+// It returns a pointer to the new column.
+func (s *scope) appendColumn(col *columnProps, label string) *columnProps {
+	s.cols = append(s.cols, *col)
+	newCol := &s.cols[len(s.cols)-1]
+	if label != "" {
+		newCol.name = tree.Name(label)
+	}
+	return newCol
+}
+
 // walkExprTree walks the given expression and performs name resolution,
 // replaces unresolved column names with columnProps, and replaces subqueries
 // with typed subquery structs.
@@ -176,6 +187,20 @@ func (s *scope) removeHiddenCols() {
 		}
 	}
 	s.cols = s.cols[:n]
+}
+
+// findExistingCol finds the given expression among the bound variables
+// in this scope. Returns nil if the expression is not found.
+func (s *scope) findExistingCol(expr tree.TypedExpr) *columnProps {
+	exprStr := symbolicExprStr(expr)
+	for i := range s.cols {
+		col := &s.cols[i]
+		if exprStr == col.getExprStr() {
+			return col
+		}
+	}
+
+	return nil
 }
 
 // getAggregateCols returns the columns in this scope corresponding

--- a/pkg/sql/opt/optbuilder/select.go
+++ b/pkg/sql/opt/optbuilder/select.go
@@ -267,7 +267,7 @@ func (b *Builder) buildFrom(
 			b.factory.InternList(rows),
 			b.factory.InternColList(opt.ColList{}),
 		)
-		outScope = inScope
+		outScope = inScope.push()
 	} else {
 		out = left
 	}

--- a/pkg/sql/opt/optbuilder/testdata/aggregate
+++ b/pkg/sql/opt/optbuilder/testdata/aggregate
@@ -21,19 +21,12 @@ SELECT MIN(1), MAX(1), COUNT(1), SUM_INT(1), AVG(1), SUM(1), STDDEV(1),
   VARIANCE(1), BOOL_AND(true), BOOL_OR(false), XOR_AGG(b'\x01') FROM t.kv
 ----
 group-by
- ├── columns: column6:6(int) column8:8(int) column10:10(int) column12:12(int) column14:14(decimal) column16:16(decimal) column18:18(decimal) column20:20(decimal) column22:22(bool) column24:24(bool) column26:26(bytes)
+ ├── columns: column6:6(int) column7:7(int) column8:8(int) column9:9(int) column10:10(decimal) column11:11(decimal) column12:12(decimal) column13:13(decimal) column15:15(bool) column17:17(bool) column19:19(bytes)
  ├── project
- │    ├── columns: column5:5(int) column7:7(int) column9:9(int) column11:11(int) column13:13(int) column15:15(int) column17:17(int) column19:19(int) column21:21(bool) column23:23(bool) column25:25(bytes)
+ │    ├── columns: column5:5(int) column14:14(bool) column16:16(bool) column18:18(bytes)
  │    ├── scan kv
  │    │    └── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string)
  │    └── projections
- │         ├── const: 1 [type=int]
- │         ├── const: 1 [type=int]
- │         ├── const: 1 [type=int]
- │         ├── const: 1 [type=int]
- │         ├── const: 1 [type=int]
- │         ├── const: 1 [type=int]
- │         ├── const: 1 [type=int]
  │         ├── const: 1 [type=int]
  │         ├── true [type=bool]
  │         ├── false [type=bool]
@@ -42,47 +35,41 @@ group-by
       ├── function: min [type=int]
       │    └── variable: column5 [type=int]
       ├── function: max [type=int]
-      │    └── variable: column7 [type=int]
+      │    └── variable: column5 [type=int]
       ├── function: count [type=int]
-      │    └── variable: column9 [type=int]
+      │    └── variable: column5 [type=int]
       ├── function: sum_int [type=int]
-      │    └── variable: column11 [type=int]
+      │    └── variable: column5 [type=int]
       ├── function: avg [type=decimal]
-      │    └── variable: column13 [type=int]
+      │    └── variable: column5 [type=int]
       ├── function: sum [type=decimal]
-      │    └── variable: column15 [type=int]
+      │    └── variable: column5 [type=int]
       ├── function: stddev [type=decimal]
-      │    └── variable: column17 [type=int]
+      │    └── variable: column5 [type=int]
       ├── function: variance [type=decimal]
-      │    └── variable: column19 [type=int]
+      │    └── variable: column5 [type=int]
       ├── function: bool_and [type=bool]
-      │    └── variable: column21 [type=bool]
+      │    └── variable: column14 [type=bool]
       ├── function: bool_or [type=bool]
-      │    └── variable: column23 [type=bool]
+      │    └── variable: column16 [type=bool]
       └── function: xor_agg [type=bytes]
-           └── variable: column25 [type=bytes]
+           └── variable: column18 [type=bytes]
 
 build
 SELECT MIN(v), MAX(v), COUNT(v), SUM_INT(1), AVG(v), SUM(v), STDDEV(v),
   VARIANCE(v), BOOL_AND(v = 1), BOOL_AND(v = 1), XOR_AGG(s::bytes) FROM kv
 ----
 project
- ├── columns: column5:5(int) column6:6(int) column7:7(int) column9:9(int) column10:10(decimal) column11:11(decimal) column12:12(decimal) column13:13(decimal) column15:15(bool) column15:15(bool) column18:18(bytes)
+ ├── columns: column5:5(int) column6:6(int) column7:7(int) column9:9(int) column10:10(decimal) column11:11(decimal) column12:12(decimal) column13:13(decimal) column15:15(bool) column15:15(bool) column17:17(bytes)
  ├── group-by
- │    ├── columns: column5:5(int) column6:6(int) column7:7(int) column9:9(int) column10:10(decimal) column11:11(decimal) column12:12(decimal) column13:13(decimal) column15:15(bool) column18:18(bytes)
+ │    ├── columns: column5:5(int) column6:6(int) column7:7(int) column9:9(int) column10:10(decimal) column11:11(decimal) column12:12(decimal) column13:13(decimal) column15:15(bool) column17:17(bytes)
  │    ├── project
- │    │    ├── columns: kv.v:2(int) kv.v:2(int) kv.v:2(int) column8:8(int) kv.v:2(int) kv.v:2(int) kv.v:2(int) kv.v:2(int) column14:14(bool) column17:17(bytes)
+ │    │    ├── columns: kv.v:2(int) column8:8(int) column14:14(bool) column16:16(bytes)
  │    │    ├── scan kv
  │    │    │    └── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string)
  │    │    └── projections
  │    │         ├── variable: kv.v [type=int]
- │    │         ├── variable: kv.v [type=int]
- │    │         ├── variable: kv.v [type=int]
  │    │         ├── const: 1 [type=int]
- │    │         ├── variable: kv.v [type=int]
- │    │         ├── variable: kv.v [type=int]
- │    │         ├── variable: kv.v [type=int]
- │    │         ├── variable: kv.v [type=int]
  │    │         ├── eq [type=bool]
  │    │         │    ├── variable: kv.v [type=int]
  │    │         │    └── const: 1 [type=int]
@@ -108,7 +95,7 @@ project
  │         ├── function: bool_and [type=bool]
  │         │    └── variable: column14 [type=bool]
  │         └── function: xor_agg [type=bytes]
- │              └── variable: column17 [type=bytes]
+ │              └── variable: column16 [type=bytes]
  └── projections
       ├── variable: column5 [type=int]
       ├── variable: column6 [type=int]
@@ -119,71 +106,62 @@ project
       ├── variable: column12 [type=decimal]
       ├── variable: column13 [type=decimal]
       ├── variable: column15 [type=bool]
-      ├── variable: column15 [type=bool]
-      └── variable: column18 [type=bytes]
+      └── variable: column17 [type=bytes]
 
 build
 SELECT MIN(1), COUNT(1), MAX(1), SUM_INT(1), AVG(1)::float, SUM(1), STDDEV(1),
   VARIANCE(1)::float, BOOL_AND(true), BOOL_OR(true), TO_HEX(XOR_AGG(b'\x01'))
 ----
 project
- ├── columns: column2:2(int) column4:4(int) column6:6(int) column8:8(int) column11:11(float) column13:13(decimal) column15:15(decimal) column18:18(float) column20:20(bool) column22:22(bool) column25:25(string)
+ ├── columns: column2:2(int) column3:3(int) column4:4(int) column5:5(int) column7:7(float) column8:8(decimal) column9:9(decimal) column11:11(float) column13:13(bool) column14:14(bool) column17:17(string)
  ├── group-by
- │    ├── columns: column2:2(int) column4:4(int) column6:6(int) column8:8(int) column10:10(decimal) column13:13(decimal) column15:15(decimal) column17:17(decimal) column20:20(bool) column22:22(bool) column24:24(bytes)
+ │    ├── columns: column2:2(int) column3:3(int) column4:4(int) column5:5(int) column6:6(decimal) column8:8(decimal) column9:9(decimal) column10:10(decimal) column13:13(bool) column14:14(bool) column16:16(bytes)
  │    ├── project
- │    │    ├── columns: column1:1(int) column3:3(int) column5:5(int) column7:7(int) column9:9(int) column12:12(int) column14:14(int) column16:16(int) column19:19(bool) column21:21(bool) column23:23(bytes)
+ │    │    ├── columns: column1:1(int) column12:12(bool) column15:15(bytes)
  │    │    ├── values
  │    │    │    └── tuple [type=tuple{}]
  │    │    └── projections
  │    │         ├── const: 1 [type=int]
- │    │         ├── const: 1 [type=int]
- │    │         ├── const: 1 [type=int]
- │    │         ├── const: 1 [type=int]
- │    │         ├── const: 1 [type=int]
- │    │         ├── const: 1 [type=int]
- │    │         ├── const: 1 [type=int]
- │    │         ├── const: 1 [type=int]
- │    │         ├── true [type=bool]
  │    │         ├── true [type=bool]
  │    │         └── const: '\x01' [type=bytes]
  │    └── aggregations
  │         ├── function: min [type=int]
  │         │    └── variable: column1 [type=int]
  │         ├── function: count [type=int]
- │         │    └── variable: column3 [type=int]
+ │         │    └── variable: column1 [type=int]
  │         ├── function: max [type=int]
- │         │    └── variable: column5 [type=int]
+ │         │    └── variable: column1 [type=int]
  │         ├── function: sum_int [type=int]
- │         │    └── variable: column7 [type=int]
+ │         │    └── variable: column1 [type=int]
  │         ├── function: avg [type=decimal]
- │         │    └── variable: column9 [type=int]
+ │         │    └── variable: column1 [type=int]
  │         ├── function: sum [type=decimal]
- │         │    └── variable: column12 [type=int]
+ │         │    └── variable: column1 [type=int]
  │         ├── function: stddev [type=decimal]
- │         │    └── variable: column14 [type=int]
+ │         │    └── variable: column1 [type=int]
  │         ├── function: variance [type=decimal]
- │         │    └── variable: column16 [type=int]
+ │         │    └── variable: column1 [type=int]
  │         ├── function: bool_and [type=bool]
- │         │    └── variable: column19 [type=bool]
+ │         │    └── variable: column12 [type=bool]
  │         ├── function: bool_or [type=bool]
- │         │    └── variable: column21 [type=bool]
+ │         │    └── variable: column12 [type=bool]
  │         └── function: xor_agg [type=bytes]
- │              └── variable: column23 [type=bytes]
+ │              └── variable: column15 [type=bytes]
  └── projections
       ├── variable: column2 [type=int]
+      ├── variable: column3 [type=int]
       ├── variable: column4 [type=int]
-      ├── variable: column6 [type=int]
-      ├── variable: column8 [type=int]
+      ├── variable: column5 [type=int]
+      ├── cast: float [type=float]
+      │    └── variable: column6 [type=decimal]
+      ├── variable: column8 [type=decimal]
+      ├── variable: column9 [type=decimal]
       ├── cast: float [type=float]
       │    └── variable: column10 [type=decimal]
-      ├── variable: column13 [type=decimal]
-      ├── variable: column15 [type=decimal]
-      ├── cast: float [type=float]
-      │    └── variable: column17 [type=decimal]
-      ├── variable: column20 [type=bool]
-      ├── variable: column22 [type=bool]
+      ├── variable: column13 [type=bool]
+      ├── variable: column14 [type=bool]
       └── function: to_hex [type=string]
-           └── variable: column24 [type=bytes]
+           └── variable: column16 [type=bytes]
 
 build
 SELECT ARRAY_AGG(1) FROM t.kv
@@ -1042,13 +1020,11 @@ SELECT MIN(k), MAX(k), MIN(v), MAX(v) FROM t.kv
 group-by
  ├── columns: column5:5(int) column6:6(int) column7:7(int) column8:8(int)
  ├── project
- │    ├── columns: kv.k:1(int!null) kv.k:1(int!null) kv.v:2(int) kv.v:2(int)
+ │    ├── columns: kv.k:1(int!null) kv.v:2(int)
  │    ├── scan kv
  │    │    └── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string)
  │    └── projections
  │         ├── variable: kv.k [type=int]
- │         ├── variable: kv.k [type=int]
- │         ├── variable: kv.v [type=int]
  │         └── variable: kv.v [type=int]
  └── aggregations
       ├── function: min [type=int]
@@ -1066,7 +1042,7 @@ SELECT MIN(k), MAX(k), MIN(v), MAX(v) FROM t.kv WHERE k > 8
 group-by
  ├── columns: column5:5(int) column6:6(int) column7:7(int) column8:8(int)
  ├── project
- │    ├── columns: kv.k:1(int!null) kv.k:1(int!null) kv.v:2(int) kv.v:2(int)
+ │    ├── columns: kv.k:1(int!null) kv.v:2(int)
  │    ├── select
  │    │    ├── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string)
  │    │    ├── scan kv
@@ -1076,8 +1052,6 @@ group-by
  │    │         └── const: 8 [type=int]
  │    └── projections
  │         ├── variable: kv.k [type=int]
- │         ├── variable: kv.k [type=int]
- │         ├── variable: kv.v [type=int]
  │         └── variable: kv.v [type=int]
  └── aggregations
       ├── function: min [type=int]
@@ -1133,12 +1107,10 @@ SELECT AVG(k), AVG(v), SUM(k), SUM(v) FROM t.kv
 group-by
  ├── columns: column5:5(decimal) column6:6(decimal) column7:7(decimal) column8:8(decimal)
  ├── project
- │    ├── columns: kv.k:1(int!null) kv.v:2(int) kv.k:1(int!null) kv.v:2(int)
+ │    ├── columns: kv.k:1(int!null) kv.v:2(int)
  │    ├── scan kv
  │    │    └── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string)
  │    └── projections
- │         ├── variable: kv.k [type=int]
- │         ├── variable: kv.v [type=int]
  │         ├── variable: kv.k [type=int]
  │         └── variable: kv.v [type=int]
  └── aggregations
@@ -1155,16 +1127,12 @@ build
 SELECT AVG(k::decimal), AVG(v::decimal), SUM(k::decimal), SUM(v::decimal) FROM kv
 ----
 group-by
- ├── columns: column6:6(decimal) column8:8(decimal) column10:10(decimal) column12:12(decimal)
+ ├── columns: column6:6(decimal) column8:8(decimal) column9:9(decimal) column10:10(decimal)
  ├── project
- │    ├── columns: column5:5(decimal) column7:7(decimal) column9:9(decimal) column11:11(decimal)
+ │    ├── columns: column5:5(decimal) column7:7(decimal)
  │    ├── scan kv
  │    │    └── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string)
  │    └── projections
- │         ├── cast: decimal [type=decimal]
- │         │    └── variable: kv.k [type=int]
- │         ├── cast: decimal [type=decimal]
- │         │    └── variable: kv.v [type=int]
  │         ├── cast: decimal [type=decimal]
  │         │    └── variable: kv.k [type=int]
  │         └── cast: decimal [type=decimal]
@@ -1175,9 +1143,9 @@ group-by
       ├── function: avg [type=decimal]
       │    └── variable: column7 [type=decimal]
       ├── function: sum [type=decimal]
-      │    └── variable: column9 [type=decimal]
+      │    └── variable: column5 [type=decimal]
       └── function: sum [type=decimal]
-           └── variable: column11 [type=decimal]
+           └── variable: column7 [type=decimal]
 
 build
 SELECT AVG(k) * 2.0 + MAX(v)::DECIMAL FROM kv
@@ -1296,13 +1264,11 @@ SELECT AVG(b), SUM(b), AVG(d), SUM(d) FROM t.abc
 group-by
  ├── columns: column5:5(float) column6:6(float) column7:7(decimal) column8:8(decimal)
  ├── project
- │    ├── columns: abc.b:2(float) abc.b:2(float) abc.d:4(decimal) abc.d:4(decimal)
+ │    ├── columns: abc.b:2(float) abc.d:4(decimal)
  │    ├── scan abc
  │    │    └── columns: abc.a:1(string!null) abc.b:2(float) abc.c:3(bool) abc.d:4(decimal)
  │    └── projections
  │         ├── variable: abc.b [type=float]
- │         ├── variable: abc.b [type=float]
- │         ├── variable: abc.d [type=decimal]
  │         └── variable: abc.d [type=decimal]
  └── aggregations
       ├── function: avg [type=float]
@@ -1766,11 +1732,63 @@ group-by
            └── variable: column5 [type=decimal]
 
 # Ensure subqueries don't trigger aggregation.
-# TODO(rytaft): This is a bug - this query should build.
 build
 SELECT x > (SELECT avg(0)) FROM xyz LIMIT 1
 ----
-error: column "xyz.x" must appear in the GROUP BY clause or be used in an aggregate function
+limit
+ ├── columns: column6:6(bool)
+ ├── project
+ │    ├── columns: column6:6(bool)
+ │    ├── scan xyz
+ │    │    └── columns: xyz.x:1(int!null) xyz.y:2(int) xyz.z:3(float)
+ │    └── projections
+ │         └── gt [type=bool]
+ │              ├── variable: xyz.x [type=int]
+ │              └── subquery [type=decimal]
+ │                   ├── max1-row
+ │                   │    ├── columns: column5:5(decimal)
+ │                   │    └── group-by
+ │                   │         ├── columns: column5:5(decimal)
+ │                   │         ├── project
+ │                   │         │    ├── columns: column4:4(int)
+ │                   │         │    ├── values
+ │                   │         │    │    └── tuple [type=tuple{}]
+ │                   │         │    └── projections
+ │                   │         │         └── const: 0 [type=int]
+ │                   │         └── aggregations
+ │                   │              └── function: avg [type=decimal]
+ │                   │                   └── variable: column4 [type=int]
+ │                   └── variable: column5 [type=decimal]
+ └── const: 1 [type=int]
+
+build
+SELECT x > (SELECT avg(y) FROM xyz) FROM xyz LIMIT 1
+----
+limit
+ ├── columns: column8:8(bool)
+ ├── project
+ │    ├── columns: column8:8(bool)
+ │    ├── scan xyz
+ │    │    └── columns: xyz.x:1(int!null) xyz.y:2(int) xyz.z:3(float)
+ │    └── projections
+ │         └── gt [type=bool]
+ │              ├── variable: xyz.x [type=int]
+ │              └── subquery [type=decimal]
+ │                   ├── max1-row
+ │                   │    ├── columns: column7:7(decimal)
+ │                   │    └── group-by
+ │                   │         ├── columns: column7:7(decimal)
+ │                   │         ├── project
+ │                   │         │    ├── columns: xyz.y:5(int)
+ │                   │         │    ├── scan xyz
+ │                   │         │    │    └── columns: xyz.x:4(int!null) xyz.y:5(int) xyz.z:6(float)
+ │                   │         │    └── projections
+ │                   │         │         └── variable: xyz.y [type=int]
+ │                   │         └── aggregations
+ │                   │              └── function: avg [type=decimal]
+ │                   │                   └── variable: xyz.y [type=int]
+ │                   └── variable: column7 [type=decimal]
+ └── const: 1 [type=int]
 
 exec-ddl
 CREATE TABLE t.bools (b BOOL)
@@ -1787,11 +1805,10 @@ SELECT BOOL_AND(b), BOOL_OR(b) FROM t.bools
 group-by
  ├── columns: column3:3(bool) column4:4(bool)
  ├── project
- │    ├── columns: bools.b:1(bool) bools.b:1(bool)
+ │    ├── columns: bools.b:1(bool)
  │    ├── scan bools
  │    │    └── columns: bools.b:1(bool) bools.rowid:2(int!null)
  │    └── projections
- │         ├── variable: bools.b [type=bool]
  │         └── variable: bools.b [type=bool]
  └── aggregations
       ├── function: bool_and [type=bool]
@@ -1880,8 +1897,8 @@ sort
            ├── variable: xor_bytes.b [type=int]
            └── variable: column7 [type=int]
 
-# TODO(rytaft): this is a bug - should cause an error:
-# error: arguments to xor must all be the same length
+# At execution time, this query will cause the error:
+# "arguments to xor must all be the same length"
 build
 SELECT XOR_AGG(i) FROM (VALUES (b'\x01'), (b'\x01\x01')) AS a(i)
 ----
@@ -1901,19 +1918,18 @@ build
 SELECT MAX(true), MIN(true)
 ----
 group-by
- ├── columns: column2:2(bool) column4:4(bool)
+ ├── columns: column2:2(bool) column3:3(bool)
  ├── project
- │    ├── columns: column1:1(bool) column3:3(bool)
+ │    ├── columns: column1:1(bool)
  │    ├── values
  │    │    └── tuple [type=tuple{}]
  │    └── projections
- │         ├── true [type=bool]
  │         └── true [type=bool]
  └── aggregations
       ├── function: max [type=bool]
       │    └── variable: column1 [type=bool]
       └── function: min [type=bool]
-           └── variable: column3 [type=bool]
+           └── variable: column1 [type=bool]
 
 build
 SELECT CONCAT_AGG(s) FROM (SELECT s FROM kv ORDER BY k)
@@ -2613,11 +2629,10 @@ project
  │    ├── columns: kv.k:1(int!null) column5:5(int)
  │    ├── grouping columns: kv.k:1(int!null)
  │    ├── project
- │    │    ├── columns: kv.k:1(int!null) kv.k:1(int!null)
+ │    │    ├── columns: kv.k:1(int!null)
  │    │    ├── scan kv
  │    │    │    └── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string)
  │    │    └── projections
- │    │         ├── variable: kv.k [type=int]
  │    │         └── variable: kv.k [type=int]
  │    └── aggregations
  │         └── function: count_rows [type=int]
@@ -2628,24 +2643,22 @@ build
 SELECT COUNT(UPPER(s)) FROM t.kv GROUP BY UPPER(s)
 ----
 project
- ├── columns: column7:7(int)
+ ├── columns: column6:6(int)
  ├── group-by
- │    ├── columns: column5:5(string) column7:7(int)
+ │    ├── columns: column5:5(string) column6:6(int)
  │    ├── grouping columns: column5:5(string)
  │    ├── project
- │    │    ├── columns: column5:5(string) column6:6(string)
+ │    │    ├── columns: column5:5(string)
  │    │    ├── scan kv
  │    │    │    └── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string)
  │    │    └── projections
- │    │         ├── function: upper [type=string]
- │    │         │    └── variable: kv.s [type=string]
  │    │         └── function: upper [type=string]
  │    │              └── variable: kv.s [type=string]
  │    └── aggregations
  │         └── function: count [type=int]
- │              └── variable: column6 [type=string]
+ │              └── variable: column5 [type=string]
  └── projections
-      └── variable: column7 [type=int]
+      └── variable: column6 [type=int]
 
 build
 SELECT SUM(abc.d) FROM t.kv JOIN t.abc ON kv.k >= abc.d GROUP BY kv.*

--- a/pkg/sql/opt/optbuilder/testdata/distinct
+++ b/pkg/sql/opt/optbuilder/testdata/distinct
@@ -125,13 +125,44 @@ sort
       │         └── variable: xyz.z [type=float]
       └── aggregations
 
-# TODO(rytaft): This is a bug. This query is valid.
 build
-SELECT DISTINCT y + z FROM xyz ORDER by (y + z)
+SELECT DISTINCT y + x FROM xyz ORDER by (y + x)
 ----
-error: unsupported binary operator: <int> + <float>
+sort
+ ├── columns: column4:4(int)
+ ├── ordering: +4
+ └── group-by
+      ├── columns: column4:4(int)
+      ├── grouping columns: column4:4(int)
+      ├── project
+      │    ├── columns: column4:4(int)
+      │    ├── scan xyz
+      │    │    └── columns: xyz.x:1(int!null) xyz.y:2(int) xyz.z:3(float)
+      │    └── projections
+      │         └── plus [type=int]
+      │              ├── variable: xyz.y [type=int]
+      │              └── variable: xyz.x [type=int]
+      └── aggregations
 
-# TODO(rytaft): This is a bug. This query is valid.
+build
+SELECT DISTINCT y + x FROM xyz ORDER BY y + x
+----
+sort
+ ├── columns: column4:4(int)
+ ├── ordering: +4
+ └── group-by
+      ├── columns: column4:4(int)
+      ├── grouping columns: column4:4(int)
+      ├── project
+      │    ├── columns: column4:4(int)
+      │    ├── scan xyz
+      │    │    └── columns: xyz.x:1(int!null) xyz.y:2(int) xyz.z:3(float)
+      │    └── projections
+      │         └── plus [type=int]
+      │              ├── variable: xyz.y [type=int]
+      │              └── variable: xyz.x [type=int]
+      └── aggregations
+
 build
 SELECT DISTINCT y + z FROM xyz ORDER BY y + z
 ----
@@ -249,11 +280,10 @@ group-by
  │    │    ├── columns: xyz.x:1(int!null) column4:4(int)
  │    │    ├── grouping columns: xyz.x:1(int!null)
  │    │    ├── project
- │    │    │    ├── columns: xyz.x:1(int!null) xyz.x:1(int!null)
+ │    │    │    ├── columns: xyz.x:1(int!null)
  │    │    │    ├── scan xyz
  │    │    │    │    └── columns: xyz.x:1(int!null) xyz.y:2(int) xyz.z:3(float)
  │    │    │    └── projections
- │    │    │         ├── variable: xyz.x [type=int]
  │    │    │         └── variable: xyz.x [type=int]
  │    │    └── aggregations
  │    │         └── function: max [type=int]

--- a/pkg/sql/opt/optbuilder/testdata/having
+++ b/pkg/sql/opt/optbuilder/testdata/having
@@ -91,13 +91,12 @@ project
  │    ├── group-by
  │    │    ├── columns: column5:5(int) column6:6(int) column7:7(int)
  │    │    ├── project
- │    │    │    ├── columns: kv.v:2(int) kv.k:1(int!null) kv.v:2(int)
+ │    │    │    ├── columns: kv.v:2(int) kv.k:1(int!null)
  │    │    │    ├── scan kv
  │    │    │    │    └── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string)
  │    │    │    └── projections
  │    │    │         ├── variable: kv.v [type=int]
- │    │    │         ├── variable: kv.k [type=int]
- │    │    │         └── variable: kv.v [type=int]
+ │    │    │         └── variable: kv.k [type=int]
  │    │    └── aggregations
  │    │         ├── function: max [type=int]
  │    │         │    └── variable: kv.v [type=int]
@@ -186,11 +185,10 @@ project
  │    │    ├── columns: kv.v:2(int) column5:5(int)
  │    │    ├── grouping columns: kv.v:2(int)
  │    │    ├── project
- │    │    │    ├── columns: kv.v:2(int) kv.v:2(int)
+ │    │    │    ├── columns: kv.v:2(int)
  │    │    │    ├── scan kv
  │    │    │    │    └── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string)
  │    │    │    └── projections
- │    │    │         ├── variable: kv.v [type=int]
  │    │    │         └── variable: kv.v [type=int]
  │    │    └── aggregations
  │    │         └── function: max [type=int]
@@ -296,25 +294,23 @@ build
 SELECT UPPER(s), COUNT(s), COUNT(UPPER(s)) FROM t.kv GROUP BY UPPER(s) HAVING COUNT(s) > 1
 ----
 select
- ├── columns: column5:5(string) column6:6(int) column8:8(int)
+ ├── columns: column5:5(string) column6:6(int) column7:7(int)
  ├── group-by
- │    ├── columns: column5:5(string) column6:6(int) column8:8(int)
+ │    ├── columns: column5:5(string) column6:6(int) column7:7(int)
  │    ├── grouping columns: column5:5(string)
  │    ├── project
- │    │    ├── columns: column5:5(string) kv.s:4(string) column7:7(string)
+ │    │    ├── columns: column5:5(string) kv.s:4(string)
  │    │    ├── scan kv
  │    │    │    └── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string)
  │    │    └── projections
  │    │         ├── function: upper [type=string]
  │    │         │    └── variable: kv.s [type=string]
- │    │         ├── variable: kv.s [type=string]
- │    │         └── function: upper [type=string]
- │    │              └── variable: kv.s [type=string]
+ │    │         └── variable: kv.s [type=string]
  │    └── aggregations
  │         ├── function: count [type=int]
  │         │    └── variable: kv.s [type=string]
  │         └── function: count [type=int]
- │              └── variable: column7 [type=string]
+ │              └── variable: column5 [type=string]
  └── gt [type=bool]
       ├── variable: column6 [type=int]
       └── const: 1 [type=int]

--- a/pkg/sql/opt/optbuilder/testdata/join
+++ b/pkg/sql/opt/optbuilder/testdata/join
@@ -2066,7 +2066,6 @@ project
  │         └── variable: t2.x [type=int]
  └── projections
       ├── variable: t2.x [type=int]
-      ├── variable: t1.x [type=int]
       └── variable: t1.x [type=int]
 
 build
@@ -2319,7 +2318,6 @@ project
  │         └── variable: str2.s [type=collatedstring{en_u_ks_level1}]
  └── projections
       ├── variable: str1.s [type=collatedstring{en_u_ks_level1}]
-      ├── variable: str1.s [type=collatedstring{en_u_ks_level1}]
       └── variable: str2.s [type=collatedstring{en_u_ks_level1}]
 
 build
@@ -2337,7 +2335,6 @@ project
  │         ├── variable: str1.s [type=collatedstring{en_u_ks_level1}]
  │         └── variable: str2.s [type=collatedstring{en_u_ks_level1}]
  └── projections
-      ├── variable: str1.s [type=collatedstring{en_u_ks_level1}]
       ├── variable: str1.s [type=collatedstring{en_u_ks_level1}]
       └── variable: str2.s [type=collatedstring{en_u_ks_level1}]
 

--- a/pkg/sql/opt/optbuilder/testdata/orderby
+++ b/pkg/sql/opt/optbuilder/testdata/orderby
@@ -137,13 +137,12 @@ limit
  ├── columns: foo:1(int!null) foo:1(int!null)
  ├── ordering: +1
  ├── project
- │    ├── columns: t.a:1(int!null) t.a:1(int!null)
+ │    ├── columns: t.a:1(int!null)
  │    ├── ordering: +1
  │    ├── scan t
  │    │    ├── columns: t.a:1(int!null) t.b:2(int) t.c:3(bool)
  │    │    └── ordering: +1
  │    └── projections
- │         ├── variable: t.a [type=int]
  │         └── variable: t.a [type=int]
  └── const: 1 [type=int]
 
@@ -257,12 +256,11 @@ sort
  ├── columns: a:1(int!null) b:2(int) b:2(int)
  ├── ordering: +3
  └── project
-      ├── columns: t.a:1(int!null) t.b:2(int) t.b:2(int) t.c:3(bool)
+      ├── columns: t.a:1(int!null) t.b:2(int) t.c:3(bool)
       ├── scan t
       │    └── columns: t.a:1(int!null) t.b:2(int) t.c:3(bool)
       └── projections
            ├── variable: t.a [type=int]
-           ├── variable: t.b [type=int]
            ├── variable: t.b [type=int]
            └── variable: t.c [type=bool]
 
@@ -547,21 +545,17 @@ sort
            └── function: length [type=int]
                 └── const: 'abc' [type=string]
 
-# TODO(rytaft): The sort should reuse the synthesized column for b+2.
 build
 SELECT b+2 FROM t ORDER BY b+2
 ----
 sort
  ├── columns: column4:4(int)
- ├── ordering: +5
+ ├── ordering: +4
  └── project
-      ├── columns: column4:4(int) column5:5(int)
+      ├── columns: column4:4(int)
       ├── scan t
       │    └── columns: t.a:1(int!null) t.b:2(int) t.c:3(bool)
       └── projections
-           ├── plus [type=int]
-           │    ├── variable: t.b [type=int]
-           │    └── const: 2 [type=int]
            └── plus [type=int]
                 ├── variable: t.b [type=int]
                 └── const: 2 [type=int]
@@ -582,21 +576,17 @@ sort
                 ├── variable: t.b [type=int]
                 └── const: 2 [type=int]
 
-# TODO(rytaft): The sort should reuse a synthesized column even after a rename.
 build
 SELECT b+2 AS y FROM t ORDER BY b+2
 ----
 sort
  ├── columns: y:4(int)
- ├── ordering: +5
+ ├── ordering: +4
  └── project
-      ├── columns: y:4(int) column5:5(int)
+      ├── columns: y:4(int)
       ├── scan t
       │    └── columns: t.a:1(int!null) t.b:2(int) t.c:3(bool)
       └── projections
-           ├── plus [type=int]
-           │    ├── variable: t.b [type=int]
-           │    └── const: 2 [type=int]
            └── plus [type=int]
                 ├── variable: t.b [type=int]
                 └── const: 2 [type=int]
@@ -926,7 +916,7 @@ limit
  ├── columns: block_id:1(int!null) writer_id:2(string!null) block_num:3(int!null) block_id:1(int!null)
  ├── ordering: +1,+2,+3
  ├── project
- │    ├── columns: blocks.block_id:1(int!null) blocks.writer_id:2(string!null) blocks.block_num:3(int!null) blocks.block_id:1(int!null)
+ │    ├── columns: blocks.block_id:1(int!null) blocks.writer_id:2(string!null) blocks.block_num:3(int!null)
  │    ├── ordering: +1,+2,+3
  │    ├── scan blocks
  │    │    ├── columns: blocks.block_id:1(int!null) blocks.writer_id:2(string!null) blocks.block_num:3(int!null) blocks.raw_bytes:4(bytes)
@@ -934,8 +924,7 @@ limit
  │    └── projections
  │         ├── variable: blocks.block_id [type=int]
  │         ├── variable: blocks.writer_id [type=string]
- │         ├── variable: blocks.block_num [type=int]
- │         └── variable: blocks.block_id [type=int]
+ │         └── variable: blocks.block_num [type=int]
  └── const: 1 [type=int]
 
 exec-ddl

--- a/pkg/sql/opt/optbuilder/testdata/select
+++ b/pkg/sql/opt/optbuilder/testdata/select
@@ -105,9 +105,6 @@ project
  └── projections
       ├── variable: abc.a [type=int]
       ├── variable: abc.b [type=int]
-      ├── variable: abc.c [type=int]
-      ├── variable: abc.a [type=int]
-      ├── variable: abc.b [type=int]
       └── variable: abc.c [type=int]
 
 build
@@ -118,9 +115,6 @@ project
  ├── scan abc
  │    └── columns: abc.a:1(int!null) abc.b:2(int) abc.c:3(int)
  └── projections
-      ├── variable: abc.a [type=int]
-      ├── variable: abc.a [type=int]
-      ├── variable: abc.a [type=int]
       └── variable: abc.a [type=int]
 
 build
@@ -330,8 +324,6 @@ project
  ├── scan kw
  │    └── columns: kw.from:1(int!null)
  └── projections
-      ├── variable: kw.from [type=int]
-      ├── variable: kw.from [type=int]
       └── variable: kw.from [type=int]
 
 exec-ddl

--- a/pkg/sql/opt/optbuilder/testdata/subquery
+++ b/pkg/sql/opt/optbuilder/testdata/subquery
@@ -1289,8 +1289,6 @@ project
  │         └── const: 'three' [type=string]
  └── projections
       ├── variable: column1 [type=int]
-      ├── variable: column1 [type=int]
-      ├── variable: column2 [type=string]
       └── variable: column2 [type=string]
 
 build

--- a/pkg/sql/opt/optbuilder/testdata/union
+++ b/pkg/sql/opt/optbuilder/testdata/union
@@ -799,11 +799,10 @@ union
  ├── left columns: xy.x:1(string) xy.x:1(string) xy.y:2(string)
  ├── right columns: abc.a:4(string) abc.b:5(string) abc.c:6(string)
  ├── project
- │    ├── columns: xy.x:1(string!null) xy.x:1(string!null) xy.y:2(string!null)
+ │    ├── columns: xy.x:1(string!null) xy.y:2(string!null)
  │    ├── scan xy
  │    │    └── columns: xy.x:1(string!null) xy.y:2(string!null) xy.rowid:3(int!null)
  │    └── projections
- │         ├── variable: xy.x [type=string]
  │         ├── variable: xy.x [type=string]
  │         └── variable: xy.y [type=string]
  └── project

--- a/pkg/sql/opt/optbuilder/util.go
+++ b/pkg/sql/opt/optbuilder/util.go
@@ -132,12 +132,21 @@ func (b *Builder) synthesizeColumn(
 func (b *Builder) constructList(
 	op opt.Operator, items []memo.GroupID, cols []columnProps,
 ) memo.GroupID {
-	colList := make(opt.ColList, len(cols))
+	colList := make(opt.ColList, 0, len(cols))
+	itemList := make([]memo.GroupID, 0, len(cols))
+
+	// Deduplicate the lists. We only need to project each column once.
+	colSet := opt.ColSet{}
 	for i := range cols {
-		colList[i] = cols[i].id
+		id := cols[i].id
+		if !colSet.Contains(int(id)) {
+			colList = append(colList, id)
+			itemList = append(itemList, items[i])
+			colSet.Add(int(id))
+		}
 	}
 
-	list := b.factory.InternList(items)
+	list := b.factory.InternList(itemList)
 	private := b.factory.InternColList(colList)
 
 	switch op {


### PR DESCRIPTION
This commit fixes several miscellaneous issues.

1. Subqueries with aggregation and without a `FROM` clause were
   causing the outer query to incorrectly act as if it were in
   a grouping context. This commit fixes the issue by making
   sure the scope of the subquery is different than the scope
   of the outer query.
2. Queries with `DISTINCT` and `ORDER BY` in which the `ORDER BY`
   was ordering on an expression that was also part of the
   `SELECT` list were failing. This commit fixes the issue by
   reusing the existing projection for the `ORDER BY` column.
3. Several redundant columns were previously being synthesized
   for identical expressions. This commit fixes the issue by
   reusing existing columns wherever possible.

Release note: None