### PR TITLE
sql: clean up comments for subqueries, simplify analyzeSubqueries

### DIFF
--- a/pkg/sql/analyze_expr.go
+++ b/pkg/sql/analyze_expr.go
@@ -44,18 +44,16 @@ func (p *planner) analyzeExpr(
 	// is expected. Tell this to replaceSubqueries.  (See UPDATE for a
 	// counter-example; cases where a subquery is an operand of a
 	// comparison are handled specially in the subqueryVisitor already.)
-	replaced, err := p.analyzeSubqueries(ctx, raw, 1 /* one value expected */)
+	err := p.analyzeSubqueries(ctx, raw, 1 /* one value expected */)
 	if err != nil {
 		return nil, err
 	}
 
 	// Perform optional name resolution.
-	var resolved tree.Expr
-	if sources == nil {
-		resolved = replaced
-	} else {
+	resolved := raw
+	if sources != nil {
 		var hasStar bool
-		resolved, _, hasStar, err = p.resolveNames(replaced, sources, iVarHelper)
+		resolved, _, hasStar, err = p.resolveNames(raw, sources, iVarHelper)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/sql/update.go
+++ b/pkg/sql/update.go
@@ -86,11 +86,11 @@ func (p *planner) Update(
 	setExprs := make([]*tree.UpdateExpr, len(n.Exprs))
 	for i, expr := range n.Exprs {
 		// Analyze the sub-query nodes.
-		newExpr, err := p.analyzeSubqueries(ctx, expr.Expr, len(expr.Names))
+		err := p.analyzeSubqueries(ctx, expr.Expr, len(expr.Names))
 		if err != nil {
 			return nil, err
 		}
-		setExprs[i] = &tree.UpdateExpr{Tuple: expr.Tuple, Expr: newExpr, Names: expr.Names}
+		setExprs[i] = &tree.UpdateExpr{Tuple: expr.Tuple, Expr: expr.Expr, Names: expr.Names}
 	}
 
 	// Determine which columns we're inserting into.


### PR DESCRIPTION
Correcting some stale comments which allude to replacement of
`tree.Subquery` nodes, which no longer happens. Simplifying
`analyzeSubqueries` to no longer return the "new" expression (since
it never changes).

Release note: None