### PR TITLE
roachtest: rename splits tests

### DIFF
--- a/pkg/cmd/roachtest/kv.go
+++ b/pkg/cmd/roachtest/kv.go
@@ -59,7 +59,7 @@ func init() {
 
 func init() {
 	tests.Add(testSpec{
-		Name:  "splits/nodes=3",
+		Name:  "kv/splits/nodes=3",
 		Nodes: nodes(4),
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			nodes := c.nodes - 1

--- a/pkg/cmd/roachtest/large_range.go
+++ b/pkg/cmd/roachtest/large_range.go
@@ -38,10 +38,10 @@ func init() {
 	const numNodes = 3
 
 	tests.Add(testSpec{
-		Name:  fmt.Sprintf("splits/size=%s,nodes=%d", bytesStr(size), numNodes),
+		Name:  fmt.Sprintf("largerange/splits/size=%s,nodes=%d", bytesStr(size), numNodes),
 		Nodes: nodes(numNodes),
 		Run: func(ctx context.Context, t *test, c *cluster) {
-			runSplit(ctx, t, c, size)
+			runLargeRangeSplits(ctx, t, c, size)
 		},
 	})
 }
@@ -54,7 +54,7 @@ func bytesStr(size uint64) string {
 // so by setting the max range size to a huge number before populating the
 // table. It then drops the range size back down to normal and watches as
 // the large range splits apart.
-func runSplit(ctx context.Context, t *test, c *cluster, size int) {
+func runLargeRangeSplits(ctx context.Context, t *test, c *cluster, size int) {
 	// payload is the size of the payload column for each row in the Bank
 	// table.
 	const payload = 100


### PR DESCRIPTION
I noticed that we had two different tests with almost identical
names - `splits/nodes=3` and `splits/size=10GiB,nodes=3`. The former
runs `kv` with the splits option and the latter creates a huge range
and lets it split. To help differentiate these tests, this change
renames them to `kv/splits/nodes=3` and
`largerange/splits/size=10GiB,nodes=3`, respectively.

Note that both of these names are under the 41 character size limit
enforced by GCE (taking into account the teamcity username).

Release note: None