### PR TITLE
storage: fix multiTestContext.addStore race

### DIFF
--- a/pkg/storage/client_test.go
+++ b/pkg/storage/client_test.go
@@ -831,7 +831,7 @@ func (m *multiTestContext) addStore(idx int) {
 		ch: make(chan struct{}),
 	}
 	m.nodeLivenesses[idx].StartHeartbeat(ctx, stopper, func(ctx context.Context) {
-		now := m.clocks[idx].Now()
+		now := clock.Now()
 		if err := store.WriteLastUpTimestamp(ctx, now); err != nil {
 			log.Warning(ctx, err)
 		}


### PR DESCRIPTION
Fixes #24201.
Fixes #24310.

The race was caused by an index into a slice of `*hlc.Clock`s while
the slice was concurrently being appended to. This change gets around
this by avoiding the offending retrieval from the slice, instead
capturing the correct clock in the closure that can be called
concurrently with the rest of test startup.

Release note: None