### PR TITLE
roachtest: Use roachprod run instead of roachprod ssh, take 2

### DIFF
--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -654,7 +654,7 @@ func (c *cluster) RunL(ctx context.Context, l *logger, node nodeListOption, args
 		return err
 	}
 	return execCmd(ctx, l,
-		append([]string{"roachprod", "ssh", c.makeNodes(node), "--"}, args...)...)
+		append([]string{"roachprod", "run", c.makeNodes(node), "--"}, args...)...)
 }
 
 // preRunChecks runs checks to see if it makes sense to run a command.


### PR DESCRIPTION
There were two uses of roachprod ssh and my previous attempt at this
only fixed one.

Release note: None