### PR TITLE
cherrypick-1.0: build: add bors.toml

### DIFF
--- a/bors.toml
+++ b/bors.toml
@@ -1,0 +1,6 @@
+status = [
+  "GitHub CI (Cockroach)"
+]
+block_labels = [
+  "do-not-merge"
+]


### PR DESCRIPTION
A cherry-pick of #24100.

Teaches Bors to wait for a successful build on TeamCity before merging
approved PRs to master, and not to merge PRs labeled do-not-merge.

Contributes to #22499
Release note (build change): Begin using Bors to automate the process of
merging PRs to master.

cc @cockroachdb/release @bdarnell @benesch 