### PR TITLE
distsql: fix BenchmarkTableReader

### DIFF
--- a/pkg/sql/distsqlrun/tablereader_test.go
+++ b/pkg/sql/distsqlrun/tablereader_test.go
@@ -150,10 +150,8 @@ func TestTableReader(t *testing.T) {
 					var res sqlbase.EncDatumRows
 					for {
 						row, meta := out.Next()
-						if meta != nil {
-							if meta.TxnMeta == nil {
-								t.Fatalf("unexpected metadata: %+v", meta)
-							}
+						if meta != nil && meta.TxnMeta == nil {
+							t.Fatalf("unexpected metadata: %+v", meta)
 						}
 						if row == nil {
 							break
@@ -315,7 +313,7 @@ func BenchmarkTableReader(b *testing.B) {
 		}
 		for {
 			row, meta := tr.Next()
-			if meta != nil {
+			if meta != nil && meta.TxnMeta == nil {
 				b.Fatalf("unexpected metadata: %+v", meta)
 			}
 			if row == nil {


### PR DESCRIPTION
The benchmark would panic when encountering TxnMeta metadata. Tests in
this file expect this type of metadata, so the benchmark has been
changed to mirror these.

Release note: None