### PR TITLE
cli: Truncate haproxy.cfg file before overwriting it

### DIFF
--- a/pkg/cli/haproxy.go
+++ b/pkg/cli/haproxy.go
@@ -112,7 +112,7 @@ func runGenHAProxyCmd(cmd *cobra.Command, args []string) error {
 	var f *os.File
 	if haProxyPath == "-" {
 		w = os.Stdout
-	} else if f, err = os.OpenFile(haProxyPath, os.O_RDWR|os.O_CREATE, 0755); err != nil {
+	} else if f, err = os.OpenFile(haProxyPath, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0755); err != nil {
 		return err
 	} else {
 		w = f


### PR DESCRIPTION
Fixes #24330

Release note (cli change,bug fix): If an haproxy.cfg file already exists
in the current directory when `gen haproxy` is run, it now gets fully
overwritten instead of potentially resulting in an unusable config.

Candidate for cherry-picking. To v2.0.1, if not v2.0.0 (@bdarnell).