### PR TITLE
cherry-pick 2.0: sql: don't use outer transaction when querying role memberships.

### DIFF
--- a/pkg/ccl/roleccl/role.go
+++ b/pkg/ccl/roleccl/role.go
@@ -161,10 +161,9 @@ func grantRolePlanHook(
 	var rowsAffected int
 	for _, r := range grant.Roles {
 		for _, m := range grant.Members {
-			affected, err := internalExecutor.ExecuteStatementInTransaction(
+			affected, err := internalExecutor.ExecuteStatement(
 				ctx,
 				"grant-role",
-				p.Txn(),
 				memberStmt,
 				r, m, grant.AdminOption,
 			)
@@ -255,10 +254,9 @@ func revokeRolePlanHook(
 					"user %s cannot be removed from role %s or lose the ADMIN OPTION",
 					security.RootUser, sqlbase.AdminRole)
 			}
-			affected, err := internalExecutor.ExecuteStatementInTransaction(
+			affected, err := internalExecutor.ExecuteStatement(
 				ctx,
 				"revoke-role",
-				p.Txn(),
 				memberStmt,
 				r, m,
 			)

--- a/pkg/sql/authorization.go
+++ b/pkg/sql/authorization.go
@@ -219,7 +219,7 @@ func (p *planner) MemberOfWithAdminOption(
 
 // resolveMemberOfWithAdminOption performs the actual recursive role membership lookup.
 // TODO(mberhault): this is the naive way and performs a full lookup for each user,
-// we could save detailed memberships (as opposed to fully expanded) and reuser them
+// we could save detailed memberships (as opposed to fully expanded) and reuse them
 // across users. We may then want to lookup more than just this user.
 func (p *planner) resolveMemberOfWithAdminOption(
 	ctx context.Context, member string,
@@ -228,9 +228,7 @@ func (p *planner) resolveMemberOfWithAdminOption(
 
 	// Keep track of members we looked up.
 	visited := map[string]struct{}{}
-
 	toVisit := []string{member}
-
 	lookupRolesStmt := `SELECT "role", "isAdmin" FROM system.role_members WHERE "member" = $1`
 
 	internalExecutor := InternalExecutor{ExecCfg: p.ExecCfg()}
@@ -244,10 +242,9 @@ func (p *planner) resolveMemberOfWithAdminOption(
 		}
 		visited[m] = struct{}{}
 
-		rows, _ /* cols */, err := internalExecutor.QueryRowsInTransaction(
+		rows, _ /* cols */, err := internalExecutor.QueryRows(
 			ctx,
 			"expand-roles",
-			p.Txn(),
 			lookupRolesStmt,
 			m,
 		)

--- a/pkg/sql/internal.go
+++ b/pkg/sql/internal.go
@@ -127,6 +127,21 @@ func (ie *InternalExecutor) GetTableSpan(
 	return roachpb.Span{Key: tableStartKey, EndKey: tableEndKey}, nil
 }
 
+// ExecuteStatement is like ExecuteStatementInTransaction, except that it runs
+// a transaction internally.
+// Statements are currently executed as the root user with the system database as current database.
+func (ie InternalExecutor) ExecuteStatement(
+	ctx context.Context, opName string, statement string, qargs ...interface{},
+) (int, error) {
+	var numAffected int
+	err := ie.ExecCfg.DB.Txn(ctx, func(ctx context.Context, txn *client.Txn) error {
+		var err error
+		numAffected, err = ie.ExecuteStatementInTransaction(ctx, opName, txn, statement, qargs...)
+		return err
+	})
+	return numAffected, err
+}
+
 func (ie *InternalExecutor) initSession(p *planner) {
 	p.extendedEvalCtx.NodeID = ie.ExecCfg.LeaseManager.LeaseStore.execCfg.NodeID.Get()
 	p.extendedEvalCtx.Tables.leaseMgr = ie.ExecCfg.LeaseManager


### PR DESCRIPTION
Release note (sql change): don't use outer transaction for role memberships
manipulation.