### PR TITLE
distsql: add log.Scope to BenchmarkTableReader

### DIFF
--- a/pkg/sql/distsqlrun/tablereader_test.go
+++ b/pkg/sql/distsqlrun/tablereader_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 )
 
 func TestTableReader(t *testing.T) {
@@ -279,6 +280,9 @@ ALTER TABLE t TESTING_RELOCATE VALUES (ARRAY[2], 1), (ARRAY[1], 2), (ARRAY[3], 3
 }
 
 func BenchmarkTableReader(b *testing.B) {
+	logScope := log.Scope(b)
+	defer logScope.Close(b)
+
 	s, sqlDB, kvDB := serverutils.StartServer(b, base.TestServerArgs{})
 	defer s.Stopper().Stop(context.Background())
 


### PR DESCRIPTION
To avoid stderr output messing with the benchmark output.

Release note: None