### PR TITLE
build: ensure all packages are compiled before linting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -859,6 +859,10 @@ lint: override TAGS += lint
 lint: ## Run all style checkers and linters.
 lint: | bin/returncheck
 	@if [ -t 1 ]; then echo '$(yellow)NOTE: `make lint` is very slow! Perhaps `make lintshort`?$(term-reset)'; fi
+	@# Run 'go install' to ensure we have compiled object files available for all
+	@# packages. In Go 1.10, only 'go vet' recompiles on demand. For details:
+	@# https://groups.google.com/forum/#!msg/golang-dev/qfa3mHN4ZPA/X2UzjNV1BAAJ.
+	$(XGO) install -v $(GOFLAGS) -tags '$(TAGS)' -ldflags '$(LINKFLAGS)' $(PKG)
 	$(XGO) test $(PKG_ROOT)/testutils/lint -v $(GOFLAGS) -tags '$(TAGS)' -ldflags '$(LINKFLAGS)' -run 'TestLint/$(TESTS)'
 
 .PHONY: lintshort

--- a/pkg/ccl/logictestccl/doc.go
+++ b/pkg/ccl/logictestccl/doc.go
@@ -1,0 +1,10 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+// Package logictestccl houses the SQL logic tests that test CCL features.
+package logictestccl

--- a/pkg/sql/opt/bench/doc.go
+++ b/pkg/sql/opt/bench/doc.go
@@ -1,0 +1,16 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+// Package bench houses benchmarks for the SQL optimizer.
+package bench


### PR DESCRIPTION
@mberhault @justinj this should fix the flake you guys saw in TC today!

---

We still have some linters that depend on compiled object files being
available in GOPATH/pkg. Run 'go test -i pkg/...' before running our
linters to ensure all possible object files are up-to-date.

We actually used to do this, but I prematurely removed it in 15ab56b4f
when I thought Go 1.9 had fixed these woes.

Release note: None