### PR TITLE
opt: test infrastructure improvements and cleanup

### DIFF
--- a/pkg/sql/opt/memo/logical_props_factory_test.go
+++ b/pkg/sql/opt/memo/logical_props_factory_test.go
@@ -28,7 +28,7 @@ import (
 )
 
 func TestLogicalPropsFactory(t *testing.T) {
-	runDataDrivenTest(t, "testdata/logprops/*", memo.ExprFmtHideCost)
+	runDataDrivenTest(t, "testdata/logprops/", memo.ExprFmtHideCost)
 }
 
 // Test joins that cannot yet be tested using SQL syntax + optimizer.

--- a/pkg/sql/opt/memo/memo_test.go
+++ b/pkg/sql/opt/memo/memo_test.go
@@ -15,7 +15,6 @@
 package memo_test
 
 import (
-	"path/filepath"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
@@ -34,15 +33,13 @@ func TestMemo(t *testing.T) {
 //   <expected results>
 //
 // See OptTester.Handle for supported commands.
-func runDataDrivenTest(t *testing.T, testdataGlob string, fmtFlags memo.ExprFmtFlags) {
-	for _, path := range testutils.GetTestFiles(t, testdataGlob) {
+func runDataDrivenTest(t *testing.T, path string, fmtFlags memo.ExprFmtFlags) {
+	datadriven.Walk(t, path, func(t *testing.T, path string) {
 		catalog := testutils.NewTestCatalog()
-		t.Run(filepath.Base(path), func(t *testing.T) {
-			datadriven.RunTest(t, path, func(d *datadriven.TestData) string {
-				tester := testutils.NewOptTester(catalog, d.Input)
-				tester.Flags.Format = fmtFlags
-				return tester.RunCommand(t, d)
-			})
+		datadriven.RunTest(t, path, func(d *datadriven.TestData) string {
+			tester := testutils.NewOptTester(catalog, d.Input)
+			tester.Flags.Format = fmtFlags
+			return tester.RunCommand(t, d)
 		})
-	}
+	})
 }

--- a/pkg/sql/opt/memo/memo_test.go
+++ b/pkg/sql/opt/memo/memo_test.go
@@ -33,63 +33,15 @@ func TestMemo(t *testing.T) {
 //   ----
 //   <expected results>
 //
-// The supported commands are:
-//
-//  - exec-ddl
-//
-//    Runs a SQL DDL statement to build the test catalog. Only a small number
-//    of DDL statements are supported, and those not fully.
-//
-//  - build
-//
-//    Builds an expression tree from a SQL query and outputs it without any
-//    optimizations applied to it.
-//
-//  - opt
-//
-//    Builds an expression tree from a SQL query, fully optimizes it using the
-//    memo, and then outputs the lowest cost tree.
-//
-//  - memo
-//
-//    Builds an expression tree from a SQL query, fully optimizes it using the
-//    memo, and then outputs the memo containing the forest of trees.
-//
-func runDataDrivenTest(t *testing.T, testdataGlob string, flags memo.ExprFmtFlags) {
+// See OptTester.Handle for supported commands.
+func runDataDrivenTest(t *testing.T, testdataGlob string, fmtFlags memo.ExprFmtFlags) {
 	for _, path := range testutils.GetTestFiles(t, testdataGlob) {
 		catalog := testutils.NewTestCatalog()
 		t.Run(filepath.Base(path), func(t *testing.T) {
 			datadriven.RunTest(t, path, func(d *datadriven.TestData) string {
 				tester := testutils.NewOptTester(catalog, d.Input)
-				switch d.Cmd {
-				case "exec-ddl":
-					return testutils.ExecuteTestDDL(t, d.Input, catalog)
-
-				case "build":
-					ev, err := tester.OptBuild()
-					if err != nil {
-						d.Fatalf(t, "%v", err)
-					}
-					return ev.FormatString(flags)
-
-				case "opt":
-					ev, err := tester.Optimize()
-					if err != nil {
-						d.Fatalf(t, "%v", err)
-					}
-					return ev.FormatString(flags)
-
-				case "memo":
-					result, err := tester.Memo()
-					if err != nil {
-						d.Fatalf(t, "%v", err)
-					}
-					return result
-
-				default:
-					d.Fatalf(t, "unsupported command: %s", d.Cmd)
-					return ""
-				}
+				tester.Flags.Format = fmtFlags
+				return tester.RunCommand(t, d)
 			})
 		})
 	}

--- a/pkg/sql/opt/norm/norm_test.go
+++ b/pkg/sql/opt/norm/norm_test.go
@@ -34,32 +34,7 @@ import (
 //   ----
 //   <expected results>
 //
-// The supported commands are:
-//
-//  - exec-ddl
-//
-//    Runs a SQL DDL statement to build the test catalog. Only a small number
-//    of DDL statements are supported, and those not fully.
-//
-//  - build
-//
-//    Builds an expression tree from a SQL query and outputs it without any
-//    optimizations applied to it.
-//
-//  - opt
-//
-//    Builds an expression tree from a SQL query, fully optimizes it using the
-//    memo, and then outputs the lowest cost tree.
-//
-//  - optsteps
-//
-//    Outputs the lowest cost tree for each step in optimization using the
-//    standard unified diff format. Used for debugging the optimizer.
-//
-//  - memo
-//
-//    Builds an expression tree from a SQL query, fully optimizes it using the
-//    memo, and then outputs the memo containing the forest of trees.
+// See OptTester.Handle for supported commands.
 //
 // Rules files can be run separately like this:
 //   make test PKG=./pkg/sql/opt/norm TESTS="TestRules/bool"
@@ -74,42 +49,8 @@ func TestNormRules(t *testing.T) {
 		t.Run(filepath.Base(path), func(t *testing.T) {
 			datadriven.RunTest(t, path, func(d *datadriven.TestData) string {
 				tester := testutils.NewOptTester(catalog, d.Input)
-				switch d.Cmd {
-				case "exec-ddl":
-					return testutils.ExecuteTestDDL(t, d.Input, catalog)
-
-				case "build":
-					ev, err := tester.OptBuild()
-					if err != nil {
-						d.Fatalf(t, "%v", err)
-					}
-					return ev.FormatString(fmtFlags)
-
-				case "opt":
-					ev, err := tester.Optimize()
-					if err != nil {
-						d.Fatalf(t, "%v", err)
-					}
-					return ev.FormatString(fmtFlags)
-
-				case "optsteps":
-					result, err := tester.OptSteps(fmtFlags, testing.Verbose())
-					if err != nil {
-						d.Fatalf(t, "%v", err)
-					}
-					return result
-
-				case "memo":
-					result, err := tester.Memo()
-					if err != nil {
-						d.Fatalf(t, "%v", err)
-					}
-					return result
-
-				default:
-					d.Fatalf(t, "unsupported command: %s", d.Cmd)
-					return ""
-				}
+				tester.Flags.Format = fmtFlags
+				return tester.RunCommand(t, d)
 			})
 		})
 	}

--- a/pkg/sql/opt/norm/norm_test.go
+++ b/pkg/sql/opt/norm/norm_test.go
@@ -15,7 +15,6 @@
 package norm_test
 
 import (
-	"path/filepath"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
@@ -41,19 +40,16 @@ import (
 //   make test PKG=./pkg/sql/opt/norm TESTS="TestRules/comp"
 //   ...
 func TestNormRules(t *testing.T) {
-	const testdataGlob = "testdata/*"
 	const fmtFlags = memo.ExprFmtHideStats | memo.ExprFmtHideCost
 
-	for _, path := range testutils.GetTestFiles(t, testdataGlob) {
+	datadriven.Walk(t, "testdata", func(t *testing.T, path string) {
 		catalog := testutils.NewTestCatalog()
-		t.Run(filepath.Base(path), func(t *testing.T) {
-			datadriven.RunTest(t, path, func(d *datadriven.TestData) string {
-				tester := testutils.NewOptTester(catalog, d.Input)
-				tester.Flags.Format = fmtFlags
-				return tester.RunCommand(t, d)
-			})
+		datadriven.RunTest(t, path, func(d *datadriven.TestData) string {
+			tester := testutils.NewOptTester(catalog, d.Input)
+			tester.Flags.Format = fmtFlags
+			return tester.RunCommand(t, d)
 		})
-	}
+	})
 }
 
 // Test the FoldNullInEmpty rule. Can't create empty tuple on right side of

--- a/pkg/sql/opt/optbuilder/builder_test.go
+++ b/pkg/sql/opt/optbuilder/builder_test.go
@@ -14,42 +14,6 @@
 
 package optbuilder_test
 
-// This file is home to TestBuilder, which is similar to the logic tests, except it
-// is used for optimizer builder-specific testcases.
-//
-// Each testfile contains testcases of the form
-//   <command> [<args>]...
-//   <SQL statement or expression>
-//   ----
-//   <expected results>
-//
-// The supported commands are:
-//
-//  - build
-//
-//    Builds a memo structure from a SQL query and outputs a representation
-//    of the "expression view" of the memo structure.
-//
-//  - build-scalar
-//
-//    Builds a memo structure from a SQL scalar expression and outputs a
-//    representation of the "expression view" of the memo structure.
-//
-//  - exec-ddl
-//
-//    Parses a CREATE TABLE statement, creates a test table, and adds the
-//    table to the catalog.
-//
-// The supported args are:
-//
-//  - vars=(type1,type2,...)
-//
-//    Information about IndexedVar columns.
-//
-//  - allow-unsupported
-//
-//    Allows building unsupported scalar expressions into UnsupportedExprOp.
-
 import (
 	"context"
 	"flag"
@@ -75,6 +39,26 @@ var (
 	testDataGlob = flag.String("d", "testdata/[^.]*", "test data glob")
 )
 
+// TestBuilder runs data-driven testcases of the form
+//   <command> [<args>]...
+//   <SQL statement or expression>
+//   ----
+//   <expected results>
+//
+// See OptTester.Handle for supported commands. In addition to those, we
+// support:
+//
+//  - build-scalar [args]
+//
+//    Builds a memo structure from a SQL scalar expression and outputs a
+//    representation of the "expression view" of the memo structure.
+//
+//    The supported args (in addition to the ones supported by OptTester:
+//
+//      - vars=(type1,type2,...)
+//
+//        Information about IndexedVar columns.
+//
 func TestBuilder(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
@@ -85,8 +69,10 @@ func TestBuilder(t *testing.T) {
 			datadriven.RunTest(t, path, func(d *datadriven.TestData) string {
 				var varTypes []types.T
 				var iVarHelper tree.IndexedVarHelper
-				var allowUnsupportedExpr bool
 				var err error
+
+				tester := testutils.NewOptTester(catalog, d.Input)
+				tester.Flags.Format = memo.ExprFmtHideAll
 
 				for _, arg := range d.CmdArgs {
 					key, vals := arg.Key, arg.Vals
@@ -99,24 +85,14 @@ func TestBuilder(t *testing.T) {
 
 						iVarHelper = tree.MakeTypesOnlyIndexedVarHelper(varTypes)
 
-					case "allow-unsupported":
-						allowUnsupportedExpr = true
-
 					default:
-						d.Fatalf(t, "unknown argument: %s", key)
+						if err := tester.Flags.Set(arg); err != nil {
+							d.Fatalf(t, "%s", err)
+						}
 					}
 				}
 
 				switch d.Cmd {
-				case "build":
-					tester := testutils.NewOptTester(catalog, d.Input)
-					tester.AllowUnsupportedExpr = allowUnsupportedExpr
-					ev, err := tester.OptBuild()
-					if err != nil {
-						return fmt.Sprintf("error: %s\n", strings.TrimSpace(err.Error()))
-					}
-					return ev.FormatString(memo.ExprFmtHideAll)
-
 				case "build-scalar":
 					typedExpr, err := testutils.ParseScalarExpr(d.Input, iVarHelper.Container())
 					if err != nil {
@@ -135,7 +111,7 @@ func TestBuilder(t *testing.T) {
 					// of the build process.
 					o.DisableOptimizations()
 					b := optbuilder.NewScalar(ctx, &semaCtx, &evalCtx, o.Factory())
-					b.AllowUnsupportedExpr = allowUnsupportedExpr
+					b.AllowUnsupportedExpr = tester.Flags.AllowUnsupportedExpr
 					group, err := b.Build(typedExpr)
 					if err != nil {
 						return fmt.Sprintf("error: %s\n", strings.TrimSpace(err.Error()))
@@ -143,12 +119,8 @@ func TestBuilder(t *testing.T) {
 					exprView := o.Optimize(group, &memo.PhysicalProps{})
 					return exprView.FormatString(memo.ExprFmtHideAll)
 
-				case "exec-ddl":
-					return testutils.ExecuteTestDDL(t, d.Input, catalog)
-
 				default:
-					d.Fatalf(t, "unsupported command: %s", d.Cmd)
-					return ""
+					return tester.RunCommand(t, d)
 				}
 			})
 		})

--- a/pkg/sql/opt/testutils/opt_tester.go
+++ b/pkg/sql/opt/testutils/opt_tester.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"testing"
 
 	"github.com/pmezard/go-difflib/difflib"
 
@@ -33,6 +34,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/pkg/testutils/datadriven"
 )
 
 // OptTester is a helper for testing the various optimizer components. It
@@ -46,16 +48,26 @@ import (
 //
 // The OptTester is used by tests in various sub-packages of the opt package.
 type OptTester struct {
+	Flags OptTesterFlags
+
 	catalog opt.Catalog
 	sql     string
 	ctx     context.Context
 	semaCtx tree.SemaContext
 	evalCtx tree.EvalContext
+}
 
-	// AllowUnsupportedExpr is a control knob: if set, when building a scalar,
-	// the optbuilder takes any TypedExpr node that it doesn't recognize and
-	// wraps that expression in an UnsupportedExpr node. This is temporary; it
-	// is used for interfacing with the old planning code.
+// OptTesterFlags are control knobs for tests. Note that specific testcases can
+// override these defaults.
+type OptTesterFlags struct {
+	// Format controls the output detail of build / opt/ optsteps
+	// directives.
+	Format memo.ExprFmtFlags
+
+	// AllowUnsupportedExpr if set: when building a scalar, the optbuilder takes
+	// any TypedExpr node that it doesn't recognize and wraps that expression in
+	// an UnsupportedExpr node. This is temporary; it is used for interfacing with
+	// the old planning code.
 	AllowUnsupportedExpr bool
 }
 
@@ -69,6 +81,126 @@ func NewOptTester(catalog opt.Catalog, sql string) *OptTester {
 		semaCtx: tree.MakeSemaContext(false /* privileged */),
 		evalCtx: tree.MakeTestingEvalContext(cluster.MakeTestingClusterSettings()),
 	}
+}
+
+// RunCommand implements commands that are used by most tests:
+//
+//  - exec-ddl
+//
+//    Runs a SQL DDL statement to build the test catalog. Only a small number
+//    of DDL statements are supported, and those not fully. This is only
+//    available when using a TestCatalog.
+//
+//  - build [flags]
+//
+//    Builds an expression tree from a SQL query and outputs it without any
+//    optimizations applied to it.
+//
+//  - opt [flags]
+//
+//    Builds an expression tree from a SQL query, fully optimizes it using the
+//    memo, and then outputs the lowest cost tree.
+//
+//  - optsteps [flags]
+//
+//    Outputs the lowest cost tree for each step in optimization using the
+//    standard unified diff format. Used for debugging the optimizer.
+//
+//  - memo [flags]
+//
+//    Builds an expression tree from a SQL query, fully optimizes it using the
+//    memo, and then outputs the memo containing the forest of trees.
+//
+// Supported flags:
+//
+//  - format: controls the formatting of expressions for build, opt, and
+//    optsteps commands. Possible values: show-all, hide-all, or any combination
+//    of hide-cost, hide-stats, hide-constraints. Example:
+//      build format={hide-cost,hide-stats}
+//
+//  - allow-unsupported: wrap unsupported expressions in UnsupportedOp.
+//
+func (e *OptTester) RunCommand(tb testing.TB, d *datadriven.TestData) string {
+	// Allow testcases to override the flags.
+	for _, a := range d.CmdArgs {
+		if err := e.Flags.Set(a); err != nil {
+			d.Fatalf(tb, "%s", err)
+		}
+	}
+
+	switch d.Cmd {
+	case "exec-ddl":
+		testCatalog, ok := e.catalog.(*TestCatalog)
+		if !ok {
+			tb.Fatal("exec-ddl can only be used with TestCatalog")
+		}
+		return ExecuteTestDDL(tb, d.Input, testCatalog)
+
+	case "build":
+		ev, err := e.OptBuild()
+		if err != nil {
+			return fmt.Sprintf("error: %s\n", strings.TrimSpace(err.Error()))
+		}
+		return ev.FormatString(e.Flags.Format)
+
+	case "opt":
+		ev, err := e.Optimize()
+		if err != nil {
+			d.Fatalf(tb, "%v", err)
+		}
+		return ev.FormatString(e.Flags.Format)
+
+	case "optsteps":
+		result, err := e.OptSteps(testing.Verbose())
+		if err != nil {
+			d.Fatalf(tb, "%v", err)
+		}
+		return result
+
+	case "memo":
+		result, err := e.Memo()
+		if err != nil {
+			d.Fatalf(tb, "%v", err)
+		}
+		return result
+
+	default:
+		d.Fatalf(tb, "unsupported command: %s", d.Cmd)
+		return ""
+	}
+}
+
+// Set parses an argument that refers to a flag. See OptTester.Handle for
+// supported flags.
+func (f *OptTesterFlags) Set(arg datadriven.CmdArg) error {
+	switch arg.Key {
+	case "format":
+		f.Format = 0
+		if len(arg.Vals) == 0 {
+			return fmt.Errorf("format flag requires value(s)")
+		}
+		for _, v := range arg.Vals {
+			m := map[string]memo.ExprFmtFlags{
+				"show-all":         memo.ExprFmtShowAll,
+				"hide-all":         memo.ExprFmtHideAll,
+				"hide-stats":       memo.ExprFmtHideStats,
+				"hide-cost":        memo.ExprFmtHideCost,
+				"hide-constraints": memo.ExprFmtHideConstraints,
+			}
+			if val, ok := m[v]; ok {
+				f.Format |= val
+			} else {
+				return fmt.Errorf("unknown format value %s", v)
+			}
+		}
+
+	case "allow-unsupported":
+		f.AllowUnsupportedExpr = true
+
+	default:
+		return fmt.Errorf("unknown argument: %s", arg.Key)
+	}
+	return nil
 }
 
 // OptBuild constructs an opt expression tree for the SQL query, with no
@@ -100,7 +232,7 @@ func (e *OptTester) Memo() (string, error) {
 // OptSteps returns a string that shows each optimization step using the
 // standard unified diff format. It is used for debugging the optimizer.
 // If verbose is true, each step is also printed on stdout.
-func (e *OptTester) OptSteps(fmtFlags memo.ExprFmtFlags, verbose bool) (string, error) {
+func (e *OptTester) OptSteps(verbose bool) (string, error) {
 	var buf bytes.Buffer
 	var prev, next string
 	if verbose {
@@ -139,7 +271,7 @@ func (e *OptTester) OptSteps(fmtFlags memo.ExprFmtFlags, verbose bool) (string, 
 			return "", err
 		}
 
-		next = o.Optimize(root, required).FormatString(fmtFlags)
+		next = o.Optimize(root, required).FormatString(e.Flags.Format)
 		if steps != 0 {
 			// All steps were not used, so must be done.
 			break
@@ -231,7 +363,7 @@ func (e *OptTester) buildExpr(
 	}
 
 	b := optbuilder.New(e.ctx, &e.semaCtx, &e.evalCtx, e.catalog, factory, stmt)
-	b.AllowUnsupportedExpr = e.AllowUnsupportedExpr
+	b.AllowUnsupportedExpr = e.Flags.AllowUnsupportedExpr
 	return b.Build()
 }
 

--- a/pkg/sql/opt/testutils/utils.go
+++ b/pkg/sql/opt/testutils/utils.go
@@ -94,3 +94,5 @@ func GetTestFiles(tb testing.TB, testdataGlob string) []string {
 	}
 	return paths
 }
+
+var _ = GetTestFiles

--- a/pkg/sql/opt/xform/optimizer_test.go
+++ b/pkg/sql/opt/xform/optimizer_test.go
@@ -15,7 +15,6 @@
 package xform_test
 
 import (
-	"path/filepath"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
@@ -28,7 +27,7 @@ import (
 //   make test PKG=./pkg/sql/opt/xform TESTS="TestCoster/scan"
 //   ...
 func TestCoster(t *testing.T) {
-	runDataDrivenTest(t, "testdata/coster/*", memo.ExprFmtShowAll)
+	runDataDrivenTest(t, "testdata/coster/", memo.ExprFmtShowAll)
 }
 
 // TestPhysicalPropsFactory files can be run separately like this:
@@ -36,7 +35,7 @@ func TestCoster(t *testing.T) {
 //   make test PKG=./pkg/sql/opt/xform TESTS="TestPhysicalPropsFactory/presentation"
 //   ...
 func TestPhysicalPropsFactory(t *testing.T) {
-	runDataDrivenTest(t, "testdata/physprops/*", memo.ExprFmtHideAll)
+	runDataDrivenTest(t, "testdata/physprops/", memo.ExprFmtHideAll)
 }
 
 // TestRules files can be run separately like this:
@@ -44,7 +43,7 @@ func TestPhysicalPropsFactory(t *testing.T) {
 //   make test PKG=./pkg/sql/opt/xform TESTS="TestRules/select"
 //   ...
 func TestRules(t *testing.T) {
-	runDataDrivenTest(t, "testdata/rules/*", memo.ExprFmtHideStats|memo.ExprFmtHideCost)
+	runDataDrivenTest(t, "testdata/rules/", memo.ExprFmtHideStats|memo.ExprFmtHideCost)
 }
 
 // runDataDrivenTest runs data-driven testcases of the form
@@ -54,15 +53,13 @@ func TestRules(t *testing.T) {
 //   <expected results>
 //
 // See OptTester.Handle for supported commands.
-func runDataDrivenTest(t *testing.T, testdataGlob string, fmtFlags memo.ExprFmtFlags) {
-	for _, path := range testutils.GetTestFiles(t, testdataGlob) {
+func runDataDrivenTest(t *testing.T, path string, fmtFlags memo.ExprFmtFlags) {
+	datadriven.Walk(t, path, func(t *testing.T, path string) {
 		catalog := testutils.NewTestCatalog()
-		t.Run(filepath.Base(path), func(t *testing.T) {
-			datadriven.RunTest(t, path, func(d *datadriven.TestData) string {
-				tester := testutils.NewOptTester(catalog, d.Input)
-				tester.Flags.Format = fmtFlags
-				return tester.RunCommand(t, d)
-			})
+		datadriven.RunTest(t, path, func(d *datadriven.TestData) string {
+			tester := testutils.NewOptTester(catalog, d.Input)
+			tester.Flags.Format = fmtFlags
+			return tester.RunCommand(t, d)
 		})
-	}
+	})
 }

--- a/pkg/sql/opt/xform/optimizer_test.go
+++ b/pkg/sql/opt/xform/optimizer_test.go
@@ -53,75 +53,15 @@ func TestRules(t *testing.T) {
 //   ----
 //   <expected results>
 //
-// The supported commands are:
-//
-//  - exec-ddl
-//
-//    Runs a SQL DDL statement to build the test catalog. Only a small number
-//    of DDL statements are supported, and those not fully.
-//
-//  - build
-//
-//    Builds an expression tree from a SQL query and outputs it without any
-//    optimizations applied to it.
-//
-//  - opt
-//
-//    Builds an expression tree from a SQL query, fully optimizes it using the
-//    memo, and then outputs the lowest cost tree.
-//
-//  - optsteps
-//
-//    Outputs the lowest cost tree for each step in optimization using the
-//    standard unified diff format. Used for debugging the optimizer.
-//
-//  - memo
-//
-//    Builds an expression tree from a SQL query, fully optimizes it using the
-//    memo, and then outputs the memo containing the forest of trees.
-//
+// See OptTester.Handle for supported commands.
 func runDataDrivenTest(t *testing.T, testdataGlob string, fmtFlags memo.ExprFmtFlags) {
 	for _, path := range testutils.GetTestFiles(t, testdataGlob) {
 		catalog := testutils.NewTestCatalog()
 		t.Run(filepath.Base(path), func(t *testing.T) {
 			datadriven.RunTest(t, path, func(d *datadriven.TestData) string {
 				tester := testutils.NewOptTester(catalog, d.Input)
-				switch d.Cmd {
-				case "exec-ddl":
-					return testutils.ExecuteTestDDL(t, d.Input, catalog)
-
-				case "build":
-					ev, err := tester.OptBuild()
-					if err != nil {
-						d.Fatalf(t, "%v", err)
-					}
-					return ev.FormatString(fmtFlags)
-
-				case "opt":
-					ev, err := tester.Optimize()
-					if err != nil {
-						d.Fatalf(t, "%v", err)
-					}
-					return ev.FormatString(fmtFlags)
-
-				case "optsteps":
-					result, err := tester.OptSteps(fmtFlags, testing.Verbose())
-					if err != nil {
-						d.Fatalf(t, "%v", err)
-					}
-					return result
-
-				case "memo":
-					result, err := tester.Memo()
-					if err != nil {
-						d.Fatalf(t, "%v", err)
-					}
-					return result
-
-				default:
-					d.Fatalf(t, "unsupported command: %s", d.Cmd)
-					return ""
-				}
+				tester.Flags.Format = fmtFlags
+				return tester.RunCommand(t, d)
 			})
 		})
 	}

--- a/pkg/testutils/datadriven/datadriven.go
+++ b/pkg/testutils/datadriven/datadriven.go
@@ -144,9 +144,9 @@ func (arg *CmdArg) String() string {
 
 // Fatalf wraps a fatal testing error with test file position information, so
 // that it's easy to locate the source of the error.
-func (td TestData) Fatalf(t *testing.T, format string, args ...interface{}) {
-	t.Helper()
-	t.Fatalf("%s: %s", td.Pos, fmt.Sprintf(format, args...))
+func (td TestData) Fatalf(tb testing.TB, format string, args ...interface{}) {
+	tb.Helper()
+	tb.Fatalf("%s: %s", td.Pos, fmt.Sprintf(format, args...))
 }
 
 func hasBlankLine(s string) bool {

--- a/pkg/testutils/datadriven/test_data_reader.go
+++ b/pkg/testutils/datadriven/test_data_reader.go
@@ -185,7 +185,7 @@ func (r *testDataReader) emit(s string) {
 	}
 }
 
-var splitDirectivesRE = regexp.MustCompile(`^ *[a-zA-Z0-9_,-\.]+(|=[a-zA-Z0-9_@]+|=\([^)]*\))( |$)`)
+var splitDirectivesRE = regexp.MustCompile(`^ *[a-zA-Z0-9_,-\.]+(|=[-a-zA-Z0-9_@]+|=\([^)]*\))( |$)`)
 
 // splits a directive line into tokens, where each token is
 // either:


### PR DESCRIPTION
#### opt: move more common code in OptTester

Move the handling of the shared commands (build, opt, optsteps, memo)
into OptTester. We now support tweaking the format on a
testcase-by-testcase basis; this could be useful during debugging, and
we could also add it to all testcases in files like
`memo/testdata/typing` instead of changing the default for each test
file).

Release note: None

#### datadriven, opt: facility to walk hierarchies of test files

Walk goes through all the files in a subdirectory, creating subtests
that mirror the file hierarchy. A function is called for each file,
similar to how t.Run() works.

Release note: None
