### PR TITLE
roachtest: improve ergonomics of test.Status

### DIFF
--- a/pkg/cmd/roachtest/backup.go
+++ b/pkg/cmd/roachtest/backup.go
@@ -28,7 +28,7 @@ func init() {
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			nodes := c.nodes
 
-			c.status(`downloading store dumps`)
+			t.Status(`downloading store dumps`)
 			var wg sync.WaitGroup
 			for node := 1; node <= nodes; node++ {
 				node := c.Node(node)
@@ -48,7 +48,7 @@ func init() {
 			c.Start(ctx)
 			m := newMonitor(ctx, c)
 			m.Go(func(ctx context.Context) error {
-				c.status(`running 2tb backup`)
+				t.Status(`running backup`)
 				c.Run(ctx, c.Node(1), `./cockroach sql --insecure -e "
 				BACKUP bank.bank TO 'gs://cockroachdb-backup-testing/`+c.name+`'"`)
 				return nil

--- a/pkg/cmd/roachtest/import.go
+++ b/pkg/cmd/roachtest/import.go
@@ -68,7 +68,7 @@ func init() {
 				if _, err := conn.Exec(`create database csv`); err != nil {
 					t.Fatal(err)
 				}
-				c.status(`running import`)
+				t.Status(`running import`)
 				if _, err := conn.Exec(`
 				IMPORT TABLE csv.lineitem
 				CREATE USING 'gs://cockroach-fixtures/tpch-csv/schema/lineitem.sql'

--- a/pkg/cmd/roachtest/restore.go
+++ b/pkg/cmd/roachtest/restore.go
@@ -28,8 +28,8 @@ func init() {
 			c.Start(ctx)
 			m := newMonitor(ctx, c)
 			m.Go(func(ctx context.Context) error {
+				t.Status(`running restore`)
 				c.Run(ctx, c.Node(1), `./cockroach sql --insecure -e "CREATE DATABASE restore2tb"`)
-				c.status(`running 2tb restore`)
 				// TODO(dan): It'd be nice if we could keep track over time of how
 				// long this next line took.
 				c.Run(ctx, c.Node(1), `./cockroach sql --insecure -e "

--- a/pkg/cmd/roachtest/test.go
+++ b/pkg/cmd/roachtest/test.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/petermattis/goid"
 )
 
 var (
@@ -56,8 +57,9 @@ type testSpec struct {
 }
 
 type registry struct {
-	m   map[string]*test
-	out io.Writer
+	m              map[string]*test
+	out            io.Writer
+	statusInterval time.Duration
 }
 
 func (r *registry) Add(spec testSpec) {
@@ -134,7 +136,6 @@ func (r *registry) Run(filter []string) int {
 			t := tests[i]
 			sem <- struct{}{}
 			fmt.Fprintf(r.out, "=== RUN   %s\n", t.Name())
-			t.Status("starting")
 			status.Lock()
 			status.running[t] = struct{}{}
 			status.Unlock()
@@ -160,7 +161,10 @@ func (r *registry) Run(filter []string) int {
 	}()
 
 	// Periodically output test status to give an indication of progress.
-	ticker := time.NewTicker(time.Minute)
+	if r.statusInterval == 0 {
+		r.statusInterval = time.Minute
+	}
+	ticker := time.NewTicker(r.statusInterval)
 	defer ticker.Stop()
 
 	// Shut down test clusters when interrupted (for example CTRL+C).
@@ -193,18 +197,56 @@ func (r *registry) Run(filter []string) int {
 			for _, t := range runningTests {
 				t.mu.Lock()
 				done := t.mu.done
-				status := t.mu.status
-				statusTime := t.mu.statusTime
-				statusProgress := t.mu.statusProgress
+				var status map[int64]testStatus
+				if !done {
+					status = make(map[int64]testStatus, len(t.mu.status))
+					for k, v := range t.mu.status {
+						status[k] = v
+					}
+					if len(status) == 0 {
+						// If we have no other status messages display this unknown state.
+						status[0] = testStatus{
+							msg:  "???",
+							time: timeutil.Now(),
+						}
+					}
+				}
 				t.mu.Unlock()
 				if !done {
-					duration := timeutil.Now().Sub(statusTime)
-					progStr := ""
-					if statusProgress > 0 {
-						progStr = fmt.Sprintf("%.1f%%|", 100*statusProgress)
+					ids := make([]int64, 0, len(status))
+					for id := range status {
+						ids = append(ids, id)
 					}
-					fmt.Fprintf(&buf, "[%4d] %s: %s (%s%s)\n", i, t.Name(), status,
-						progStr, time.Duration(duration.Seconds()+0.5)*time.Second)
+					sort.Slice(ids, func(i, j int) bool {
+						// Force the goroutine ID for the main test goroutine to sort to
+						// the front. NB: goroutine IDs are not monotonically increasing
+						// because each thread has a small cache of IDs for allocation.
+						if ids[j] == t.runnerID {
+							return false
+						}
+						if ids[i] == t.runnerID {
+							return true
+						}
+						return ids[i] < ids[j]
+					})
+
+					fmt.Fprintf(&buf, "[%4d] %s: ", i, t.Name())
+
+					for j := range ids {
+						s := status[ids[j]]
+						duration := timeutil.Now().Sub(s.time)
+						progStr := ""
+						if s.progress > 0 {
+							progStr = fmt.Sprintf("%.1f%%|", 100*s.progress)
+						}
+						if j > 0 {
+							buf.WriteString(", ")
+						}
+						fmt.Fprintf(&buf, "%s (%s%s)", s.msg, progStr,
+							time.Duration(duration.Seconds()+0.5)*time.Second)
+					}
+
+					fmt.Fprintf(&buf, "\n")
 				}
 			}
 			fmt.Fprint(r.out, buf.String())
@@ -216,19 +258,24 @@ func (r *registry) Run(filter []string) int {
 	}
 }
 
+type testStatus struct {
+	msg      string
+	time     time.Time
+	progress float64
+}
+
 type test struct {
-	spec   *testSpec
-	runner string
-	start  time.Time
-	end    time.Time
-	mu     struct {
+	spec     *testSpec
+	runner   string
+	runnerID int64
+	start    time.Time
+	end      time.Time
+	mu       struct {
 		syncutil.RWMutex
-		done           bool
-		failed         bool
-		status         string
-		statusTime     time.Time
-		statusProgress float64
-		output         []byte
+		done   bool
+		failed bool
+		status map[int64]testStatus
+		output []byte
 	}
 }
 
@@ -236,18 +283,62 @@ func (t *test) Name() string {
 	return t.spec.Name
 }
 
-func (t *test) Status(args ...interface{}) {
+func (t *test) status(id int64, args ...interface{}) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
-	t.mu.status = strings.SplitN(fmt.Sprint(args...), "\n", 2)[0]
-	t.mu.statusTime = timeutil.Now()
-	t.mu.statusProgress = 0
+
+	if t.mu.status == nil {
+		t.mu.status = make(map[int64]testStatus)
+	}
+	if len(args) == 0 {
+		delete(t.mu.status, id)
+		return
+	}
+	t.mu.status[id] = testStatus{
+		msg:  fmt.Sprint(args...),
+		time: timeutil.Now(),
+	}
 }
 
-func (t *test) Progress(frac float64) {
+// Status sets the main status message for the test. When called from the main
+// test goroutine (i.e. the goroutine on which testSpec.Run is invoked), this
+// is equivalent to calling WorkerStatus. If no arguments are specified, the
+// status message is erased.
+func (t *test) Status(args ...interface{}) {
+	t.status(t.runnerID, args...)
+}
+
+// WorkerStatus sets the status message for a worker goroutine associated with
+// the test. The status message should be cleared before the goroutine exits by
+// calling WorkerStatus with no arguments.
+func (t *test) WorkerStatus(args ...interface{}) {
+	t.status(goid.Get(), args...)
+}
+
+func (t *test) progress(id int64, frac float64) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
-	t.mu.statusProgress = frac
+
+	if t.mu.status == nil {
+		t.mu.status = make(map[int64]testStatus)
+	}
+	status := t.mu.status[id]
+	status.progress = frac
+	t.mu.status[id] = status
+}
+
+// Progress sets the progress (a fraction in the range [0,1]) associated with
+// the main test status messasge. When called from the main test goroutine
+// (i.e. the goroutine on which testSpec.Run is invoked), this is equivalent to
+// calling WorkerProgress.
+func (t *test) Progress(frac float64) {
+	t.progress(t.runnerID, frac)
+}
+
+// WorkerProgress sets the progress (a fraction in the range [0,1]) associated
+// with the a worker status messasge.
+func (t *test) WorkerProgress(frac float64) {
+	t.progress(goid.Get(), frac)
 }
 
 func (t *test) Fatal(args ...interface{}) {
@@ -335,6 +426,7 @@ func (t *test) run(out io.Writer, done func(failed bool)) {
 
 	go func() {
 		t.runner = callerName()
+		t.runnerID = goid.Get()
 
 		defer func() {
 			t.end = timeutil.Now()

--- a/pkg/cmd/roachtest/test_test.go
+++ b/pkg/cmd/roachtest/test_test.go
@@ -16,9 +16,16 @@
 package main
 
 import (
+	"bytes"
 	"context"
+	"fmt"
 	"io/ioutil"
+	"regexp"
+	"sync"
 	"testing"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 )
 
 func TestRegistryRun(t *testing.T) {
@@ -52,5 +59,108 @@ func TestRegistryRun(t *testing.T) {
 				t.Fatalf("expected %d, but found %d", c.expected, code)
 			}
 		})
+	}
+}
+
+type syncedBuffer struct {
+	mu  syncutil.Mutex
+	buf bytes.Buffer
+}
+
+func (b *syncedBuffer) Write(p []byte) (n int, err error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *syncedBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
+}
+
+func TestRegistryStatus(t *testing.T) {
+	var buf syncedBuffer
+	waitingRE := regexp.MustCompile(`(?m)^.*status: waiting.*worker?.*worker?.*$`)
+	cleaningUpRE := regexp.MustCompile(`(?m)^.*status: cleaning up \(.*\)$`)
+
+	r := &registry{
+		m:              make(map[string]*test),
+		out:            &buf,
+		statusInterval: 20 * time.Millisecond,
+	}
+	r.Add(testSpec{
+		Name: `status`,
+		Run: func(ctx context.Context, t *test, c *cluster) {
+			t.Status("waiting")
+			var wg sync.WaitGroup
+			for i := 0; i < 2; i++ {
+				wg.Add(1)
+				go func(i int) {
+					defer wg.Done()
+					t.WorkerStatus("worker", i)
+					defer t.WorkerStatus()
+					for i := 0.0; i < 1.0; i += 0.01 {
+						t.WorkerProgress(i)
+						time.Sleep(r.statusInterval)
+						if waitingRE.MatchString(buf.String()) {
+							break
+						}
+					}
+				}(i)
+			}
+			wg.Wait()
+			t.Status("cleaning up")
+			for i := 0.0; i < 1.0; i += 0.01 {
+				t.Progress(i)
+				time.Sleep(r.statusInterval)
+				if cleaningUpRE.MatchString(buf.String()) {
+					break
+				}
+			}
+		},
+	})
+	r.Run([]string{"status"})
+
+	status := buf.String()
+	if !waitingRE.MatchString(status) {
+		t.Fatalf("unable to find \"waiting\" status:\n%s", status)
+	}
+	if !cleaningUpRE.MatchString(status) {
+		t.Fatalf("unable to find \"cleaning up\" status:\n%s", status)
+	}
+	if testing.Verbose() {
+		fmt.Println(status)
+	}
+}
+
+func TestRegistryStatusUnknown(t *testing.T) {
+	var buf syncedBuffer
+	unknownRE := regexp.MustCompile(`(?m)^.*status: \?\?\? \(.*\)$`)
+
+	r := &registry{
+		m:              make(map[string]*test),
+		out:            &buf,
+		statusInterval: 20 * time.Millisecond,
+	}
+	r.Add(testSpec{
+		Name: `status`,
+		Run: func(ctx context.Context, t *test, c *cluster) {
+			for i := 0; i < 100; i++ {
+				time.Sleep(r.statusInterval)
+				if unknownRE.MatchString(buf.String()) {
+					break
+				}
+			}
+		},
+	})
+	r.Run([]string{"status"})
+
+	status := buf.String()
+	if !unknownRE.MatchString(status) {
+		t.Fatalf("unable to find \"waiting\" status:\n%s", status)
+	}
+	if testing.Verbose() {
+		fmt.Println(status)
 	}
 }


### PR DESCRIPTION
Extend `test.Status` so that it tracks status messages
per-goroutine. `test.Status` is now a wrapper around `test.WorkerStatus`
which sets the status for the main test goroutine. When status for
multiple goroutines is present in a test the messages are displayed in
goroutine order. For example:

```
[   1] status: waiting (0s), worker0 (0s), worker1 (0s)
[   2] status: waiting (0s), worker0 (0s), worker1 (0s)
[   3] status: waiting (0s)
[   4] status: cleaning up (0s)
[   5] status: cleaning up (0s)
```

Fixes #23336

Release note: None