### PR TITLE
roachtest: add --debug flag that preserves cluster on failure

### DIFF
--- a/pkg/cmd/roachtest/main.go
+++ b/pkg/cmd/roachtest/main.go
@@ -54,6 +54,8 @@ func main() {
 	rootCmd.AddCommand(runCmd)
 
 	runCmd.Flags().BoolVarP(
+		&debug, "debug", "d", debug, "don't wipe and destroy cluster if test fails")
+	runCmd.Flags().BoolVarP(
 		&dryrun, "dry-run", "n", dryrun, "dry run (don't run tests)")
 	runCmd.Flags().BoolVarP(
 		&local, "local", "l", local, "run tests locally")

--- a/pkg/cmd/roachtest/test.go
+++ b/pkg/cmd/roachtest/test.go
@@ -36,6 +36,7 @@ import (
 var (
 	tests       = &registry{m: make(map[string]*test), out: os.Stdout}
 	parallelism = 10
+	debug       = false
 	dryrun      = false
 )
 
@@ -366,7 +367,13 @@ func (t *test) run(out io.Writer, done func(failed bool)) {
 		if !dryrun {
 			ctx := context.Background()
 			c := newCluster(ctx, t, t.spec.Nodes)
-			defer c.Destroy(ctx)
+			defer func() {
+				if !debug || !t.Failed() {
+					c.Destroy(ctx)
+				} else {
+					c.l.printf("not destroying cluster to allow debugging\n")
+				}
+			}()
 			t.spec.Run(ctx, t, c)
 		}
 	}()


### PR DESCRIPTION
Release note: None