### PR TITLE
sql: fix inverted index queries whose root has a single child

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/inverted_index
+++ b/pkg/sql/logictest/testdata/logic_test/inverted_index
@@ -153,6 +153,9 @@ INSERT INTO d VALUES (30,  '{"a": {"b": "c", "d": "e"}, "f": "g"}')
 statement ok
 INSERT INTO d VALUES (31,  '{"a": []}')
 
+statement ok
+INSERT INTO d VALUES (32,  '{"a": [1, 2, 3, 4]}')
+
 query TITTTTT
 EXPLAIN (VERBOSE) SELECT * from d where b @>'{"a": "b"}'
 ----
@@ -330,6 +333,7 @@ SELECT * from d where b @> '{}' ORDER BY a;
 17  {}
 30  {"a": {"b": "c", "d": "e"}, "f": "g"}
 31  {"a": []}
+32  {"a": [1, 2, 3, 4]}
 
 query IT
 SELECT * from d where b @> '[]' ORDER BY a;
@@ -430,6 +434,7 @@ SELECT * from d where b @> '{"a": []}' ORDER BY a;
 ----
 25  {"a": [{}]}
 31  {"a": []}
+32  {"a": [1, 2, 3, 4]}
 
 query IT
 SELECT * from d where b @> '[{}]' ORDER BY a;
@@ -511,6 +516,11 @@ SELECT * from d where b @> '{"a": {"b": "c", "d": "e"}, "f": "g"}'
 ----
 30  {"a": {"b": "c", "d": "e"}, "f": "g"}
 
+query IT
+SELECT * from d where b @> '{"a": [1, 2, 3]}'
+----
+32  {"a": [1, 2, 3, 4]}
+
 query TITTTTT
 EXPLAIN (VERBOSE) SELECT * from d where b @> '{"a": {"b": "c"}, "f": "g"}'
 ----
@@ -591,6 +601,7 @@ SELECT * from d where b @> '{"a": []}' ORDER BY a;
 ----
 25  {"a": [{}]}
 31  {"a": []}
+32  {"a": [1, 2, 3, 4]}
 
 query TTT
 EXPLAIN SELECT * from d where b @> '{"a": []}' ORDER BY a;

--- a/pkg/sql/opt/scalar.go
+++ b/pkg/sql/opt/scalar.go
@@ -359,9 +359,6 @@ func normalizeContainsOp(e *Expr) {
 	default:
 		return
 	}
-	if dJSON.Len() == 1 {
-		return
-	}
 
 	// Normalize a contains condition on an n-path JSON value to n contains
 	// conditions on a single-path JSON value.
@@ -369,6 +366,11 @@ func normalizeContainsOp(e *Expr) {
 	if err != nil {
 		panic(fmt.Sprintf("programming error: %+v", err))
 	}
+
+	if len(paths) == 1 {
+		return
+	}
+
 	e.op = andOp
 	lhs := e.children[0]
 	e.children = make([]*Expr, len(paths))


### PR DESCRIPTION
Please note: this PR is directly against the release-2.0 branch and has no equivalent on master, since the index constraint code is significantly different there.

Previously, we were erroneously rejecting queries
which had a root with a single entry or element, but which had
multiple children overall, such as:

    SELECT * FROM t WHERE a @> '{"a": {"b": 1, "c": 2}'

or

    SELECT * FROM t WHERE a @> '[{"b": 1, "c": 2}]'

Even though we are able to service such queries.  The reason for this is
a misplaced check that attempted to avoid splitting up a query if it
only had one path, but actually avoided splitting up a query if it had
only one *child*.

cc @cockroachdb/release 

Release note (bug fix): Previously, we were erroneously rejecting
queries which had a parent with a single entry or element despite being
able to service them.