### PR TITLE
roachtest: add teamcity output markers; upload artifacts

### DIFF
--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -53,6 +53,7 @@ var (
 	clusterWipe bool
 	username    = os.Getenv("ROACHPROD_USER")
 	zones       string
+	teamCity    bool
 )
 
 func ifLocal(trueVal, falseVal string) string {
@@ -489,7 +490,7 @@ func (c *cluster) Destroy(ctx context.Context) {
 
 	c.status("retrieving logs")
 	_ = execCmd(execCtx, c.l, "roachprod", "get", c.name, "logs",
-		filepath.Join(artifacts, c.t.Name(), "logs"))
+		filepath.Join(artifacts, teamCityNameEscape(c.t.Name()), "logs"))
 
 	// Only destroy the cluster if it exists in the cluster registry. The cluster
 	// may not exist if the test was interrupted and the teardown machinery is

--- a/pkg/cmd/roachtest/log.go
+++ b/pkg/cmd/roachtest/log.go
@@ -44,7 +44,7 @@ func newLogger(name, filename, prefix string, stdout, stderr io.Writer) (*logger
 		}, nil
 	}
 
-	path := filepath.Join(artifacts, name, filename)
+	path := filepath.Join(artifacts, teamCityNameEscape(name), filename)
 	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
 		return nil, err
 	}

--- a/pkg/cmd/roachtest/main.go
+++ b/pkg/cmd/roachtest/main.go
@@ -80,6 +80,8 @@ func main() {
 		&slackToken, "slack-token", "", "Slack bot token")
 	runCmd.Flags().StringVar(
 		&zones, "zones", "", "Zones for the cluster (use roachprod defaults if empty)")
+	runCmd.Flags().BoolVar(
+		&teamCity, "teamcity", false, "include teamcity-specific markers in output")
 
 	if err := rootCmd.Execute(); err != nil {
 		// Cobra has already printed the error message.


### PR DESCRIPTION
Example build: https://teamcity.cockroachdb.com/viewLog.html?tab=buildLog&buildTypeId=Cockroach_Nightlies_WorkloadNightly&buildId=590485

### Build log
With this PR, roachtest prints out a `##teamCity` marker when a test starts, fails, and finishes (success is represented as a finish without a fail). This allows TC to show:
- how long each test has been running (and record this for the "Test History" screens)
- which tests have succeeded and failed, including while the job is still running (this is also recorded in the "Test History" screens)

The status of each running test is still printed out interleaved every minute. TC has a `buildProgress` directive with a `flowId` argument which possibly could be used to group test output under each test (so it'd no longer be interleaved), but leaving that part be for now.
![image](https://user-images.githubusercontent.com/7341/38157383-717615d6-3454-11e8-8fac-5a67febad596.png)

### Artifacts grouped by test name, uploaded while build is still in progress
By default, TC only publishes artifacts once the whole job is done. It's useful to see logs for individual tests while the build is still running, since roachtest builds are so long.

Note: TC interprets commas in artifact paths in `publishArtifacts` directives as delimiting multiple paths, so I replaced `,`s with `_`s in log paths to avoid this. (Couldn't find any way of escaping commas). Hopefully that doesn't cause problems.
![image](https://user-images.githubusercontent.com/7341/38157385-7a9b50f4-3454-11e8-95a9-ebea4c15c21a.png)

TODO: check that these aren't clobbered / duplicated when the build actually finishes. (None of my test runs have finished today!)

### "Tests" tab of build screen
I think tests only show up here once they've finished.
![image](https://user-images.githubusercontent.com/7341/38157392-84a72d20-3454-11e8-8e31-d6e875258564.png)

Fixes #24313