### PR TITLE
Further improve GOPATH detection in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -201,7 +201,11 @@ UI_ROOT        := $(PKG_ROOT)/ui
 SQLPARSER_ROOT := $(PKG_ROOT)/sql/parser
 
 # Ensure we have an unambiguous GOPATH.
-GOPATH := $(shell $(GO) env GOPATH)
+GOPATH := $(shell readlink -f $(shell $(GO) env GOPATH))
+# GOPATH need not be explicitly set if it is the default $HOME/go
+ifeq ($(strip $(GOPATH)),)
+GOPATH := $(shell readlink -f $$HOME/go)
+endif
 
 ifneq "$(or $(findstring :,$(GOPATH)),$(findstring ;,$(GOPATH)))" ""
 $(error GOPATHs with multiple entries are not supported)

--- a/Makefile
+++ b/Makefile
@@ -201,10 +201,10 @@ UI_ROOT        := $(PKG_ROOT)/ui
 SQLPARSER_ROOT := $(PKG_ROOT)/sql/parser
 
 # Ensure we have an unambiguous GOPATH.
-GOPATH := $(shell readlink -f $(shell $(GO) env GOPATH))
+GOPATH := $(realpath $(shell $(GO) env GOPATH))
 # GOPATH need not be explicitly set if it is the default $HOME/go
 ifeq ($(strip $(GOPATH)),)
-GOPATH := $(shell readlink -f $$HOME/go)
+GOPATH := $(realpath $(shell echo $$HOME/go))
 endif
 
 ifneq "$(or $(findstring :,$(GOPATH)),$(findstring ;,$(GOPATH)))" ""

--- a/Makefile
+++ b/Makefile
@@ -202,9 +202,8 @@ SQLPARSER_ROOT := $(PKG_ROOT)/sql/parser
 
 # Ensure we have an unambiguous GOPATH.
 GOPATH := $(realpath $(shell $(GO) env GOPATH))
-# GOPATH need not be explicitly set if it is the default $HOME/go
 ifeq ($(strip $(GOPATH)),)
-GOPATH := $(realpath $(shell echo $$HOME/go))
+$(error GOPATH is not set and could not be automatically determined, build cannot continue)
 endif
 
 ifneq "$(or $(findstring :,$(GOPATH)),$(findstring ;,$(GOPATH)))" ""


### PR DESCRIPTION
In recent versions of go, GOPATH need not be explicitly set (and `go env
GOPATH` will return nothing) if using the default $HOME/go as $GOPATH.

Additionally, it is necessary to use `readlink -f` to get the real paths
of both $GOPATH and $CWD, as symlinks may be in play. For instance, on
FreeBSD `/home` is symlinked to `/usr/home/`, but the former is often
used. If `readlink` isn't used, the string-based prefix matching will
incorrectly claim that CWD is not a child of GOPATH.

This patch sets GOPATH to `$HOME/go` if GOPATH is not exported and
`$HOME/go` exists (since `readlink -f $HOME/go` will return an empty
string if its target is not found). No change in the existing behavior
is expected if the environment variable GOPATH is not blank or if it is
both blank and $HOME/go is not the GOPATH.

Release note: None