### PR TITLE
backport-2.0: cli: fix specification of fractional units

### DIFF
--- a/pkg/cli/flags_test.go
+++ b/pkg/cli/flags_test.go
@@ -81,33 +81,44 @@ func TestSQLMemoryPoolFlagValue(t *testing.T) {
 	// Avoid leaking configuration changes after the test ends.
 	defer initCLIDefaults()
 
-	// Check absolute values.
 	f := StartCmd.Flags()
-	args := []string{"--max-sql-memory", "100MB"}
-	if err := f.Parse(args); err != nil {
-		t.Fatal(err)
+
+	// Check absolute values.
+	testCases := []struct {
+		value    string
+		expected int64
+	}{
+		{"100MB", 100 * 1000 * 1000},
+		{".5GiB", 512 * 1024 * 1024},
+		{"1.3", 1},
+	}
+	for _, c := range testCases {
+		args := []string{"--max-sql-memory", c.value}
+		if err := f.Parse(args); err != nil {
+			t.Fatal(err)
+		}
+		if c.expected != serverCfg.SQLMemoryPoolSize {
+			t.Errorf("expected %d, but got %d", c.expected, serverCfg.SQLMemoryPoolSize)
+		}
 	}
 
-	const expectedSQLMemSize = 100 * 1000 * 1000
-	if expectedSQLMemSize != serverCfg.SQLMemoryPoolSize {
-		t.Errorf("expected %d, but got %d", expectedSQLMemSize, serverCfg.SQLMemoryPoolSize)
-	}
+	for _, c := range []string{".30", "0.3"} {
+		args := []string{"--max-sql-memory", c}
+		if err := f.Parse(args); err != nil {
+			t.Fatal(err)
+		}
 
-	args = []string{"--max-sql-memory", ".30"}
-	if err := f.Parse(args); err != nil {
-		t.Fatal(err)
-	}
-
-	// Check fractional values.
-	maxMem, err := server.GetTotalMemory(context.TODO())
-	if err != nil {
-		t.Logf("total memory unknown: %v", err)
-		return
-	}
-	expectedLow := (maxMem * 28) / 100
-	expectedHigh := (maxMem * 32) / 100
-	if serverCfg.SQLMemoryPoolSize < expectedLow || serverCfg.SQLMemoryPoolSize > expectedHigh {
-		t.Errorf("expected %d-%d, but got %d", expectedLow, expectedHigh, serverCfg.SQLMemoryPoolSize)
+		// Check fractional values.
+		maxMem, err := server.GetTotalMemory(context.TODO())
+		if err != nil {
+			t.Logf("total memory unknown: %v", err)
+			return
+		}
+		expectedLow := (maxMem * 28) / 100
+		expectedHigh := (maxMem * 32) / 100
+		if serverCfg.SQLMemoryPoolSize < expectedLow || serverCfg.SQLMemoryPoolSize > expectedHigh {
+			t.Errorf("expected %d-%d, but got %d", expectedLow, expectedHigh, serverCfg.SQLMemoryPoolSize)
+		}
 	}
 }
 

--- a/pkg/cli/flags_util.go
+++ b/pkg/cli/flags_util.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"regexp"
 	"strconv"
 	"strings"
 
@@ -369,10 +370,12 @@ func newBytesOrPercentageValue(
 	}
 }
 
+var fractionRE = regexp.MustCompile(`^0?\.[0-9]+$`)
+
 // Set implements the pflags.Flag interface.
 func (b *bytesOrPercentageValue) Set(s string) error {
 	b.origVal = s
-	if strings.HasSuffix(s, "%") || strings.Contains(s, ".") {
+	if strings.HasSuffix(s, "%") || fractionRE.MatchString(s) {
 		multiplier := 100.0
 		if s[len(s)-1] == '%' {
 			// We have a percentage.


### PR DESCRIPTION
Backport 1/1 commits from #24381.

/cc @cockroachdb/release

---

Fix specifying fractional units (e.g. `0.5GiB`) by only interpeting a
fraction as unit-less if it lies in the range `[0, 1)` and does not have
a suffix.

Fixes #24379

Release note (cli change): Fix specification of fractional
units (e.g. 0.5GiB) for the --cache and --sql-max-memory flags.
