### PR TITLE
[wip] Fix ordering of golang protobuf dependencies in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -989,7 +989,9 @@ CPP_SOURCES_CCL := $(subst $(PKG_ROOT),$(CPP_PROTO_CCL_ROOT),$(CPP_PROTOS_CCL:%.
 
 UI_PROTOS := $(UI_JS) $(UI_TS)
 
-$(GO_PROTOS_TARGET): $(PROTOC) $(GO_PROTOS) $(GOGOPROTO_PROTO) $(BOOTSTRAP_TARGET) | bin/protoc-gen-gogoroach
+$(GOGOPROTO_PROTO): $(GO_PROTOS)
+
+$(GO_PROTOS_TARGET): $(PROTOC) $(GOGOPROTO_PROTO) $(BOOTSTRAP_TARGET) | bin/protoc-gen-gogoroach
 	$(FIND_RELEVANT) -type f -name '*.pb.go' -exec rm {} +
 	set -e; for dir in $(sort $(dir $(GO_PROTOS))); do \
 	  build/werror.sh $(PROTOC) -I$(PKG_ROOT):$(GOGO_PROTOBUF_PATH):$(PROTOBUF_PATH):$(COREOS_PATH):$(GRPC_GATEWAY_GOOGLEAPIS_PATH) --gogoroach_out=$(PROTO_MAPPINGS),plugins=grpc,import_prefix=github.com/cockroachdb/cockroach/pkg/:$(PKG_ROOT) $$dir/*.proto; \


### PR DESCRIPTION
Running the initial `make` after project checkout with parallelization (`make -j14`)
results in an error due to an incomplete dependency chain in the golang
protobuf imports:

```
mqudsi@mysql ~/g/s/g/c/cockroach> gmake -j14
GOPATH set to /usr/home/mqudsi/go
git submodule update --init
Cloning into '/usr/home/mqudsi/go/src/github.com/cockroachdb/cockroach/c-deps/cryptopp'...
build/node-run.sh -C ./pkg/ui yarn install
gmake: *** No rule to make target 'vendor/github.com/gogo/protobuf/gogoproto/gogo.proto', needed by 'bin/.go_protobuf_sources'.  Stop.
gmake: *** Waiting for unfinished jobs....
yarn install v1.5.1
[1/5] Validating package.json...
[2/5] Resolving packages...
^Cgmake: *** [Makefile:388: bin/.submodules-initialized] Interrupt
gmake: *** [Makefile:338: pkg/ui/yarn.installed] Interrupt
```

Resolved by splitting the protobuff dependencies into an additional rule to introduce ordering.

However, there is still another problem that I haven't been able to pin down. After this patch and starting again with a clean checkout and running a parallel build, the following occurs:

```
...
build/node-run.sh -C ./pkg/ui/node_modules/protobufjs/cli yarn install
yarn install v1.5.1
[1/4] Resolving packages...
success Already up-to-date.
Done in 0.18s.
rm -rf ./pkg/ui/node_modules/@types/node
touch pkg/ui/yarn.installed
# Add comment recognized by reviewable.
echo '// GENERATED FILE DO NOT EDIT' > pkg/ui/src/js/protos.js
build/node-run.sh ./pkg/ui/node_modules/.bin/pbjs -t static-module -w es6 --strict-long --keep-case --path ./pkg --path ./vendor/github.com/gogo/protobuf --path ./vendor/github.com/coreos --path ./vendor/github.com/grpc-ecosystem/grpc-gateway/third_party/googleapis ./pkg/server/serverpb/admin.proto ./pkg/server/serverpb/status.proto ./pkg/server/serverpb/authentication.proto ./pkg/ts/tspb/timeseries.proto >> pkg/ui/src/js/protos.js
/usr/home/mqudsi/go/src/github.com/cockroachdb/cockroach/pkg/ui/node_modules/protobufjs/cli/pbjs.js:229
            throw err;
            ^

Error: no such Type or Enum 'raftpb.HardState' in Type .cockroach.server.serverpb.RaftState
    at Type.lookupTypeOrEnum (/usr/home/mqudsi/go/src/github.com/cockroachdb/cockroach/pkg/ui/node_modules/protobufjs/src/namespace.js:382:15)
    at Field.resolve (/usr/home/mqudsi/go/src/github.com/cockroachdb/cockroach/pkg/ui/node_modules/protobufjs/src/field.js:248:94)
    at Type.resolveAll (/usr/home/mqudsi/go/src/github.com/cockroachdb/cockroach/pkg/ui/node_modules/protobufjs/src/type.js:255:21)
    at Namespace.resolveAll (/usr/home/mqudsi/go/src/github.com/cockroachdb/cockroach/pkg/ui/node_modules/protobufjs/src/namespace.js:286:25)
    at Namespace.resolveAll (/usr/home/mqudsi/go/src/github.com/cockroachdb/cockroach/pkg/ui/node_modules/protobufjs/src/namespace.js:286:25)
    at Namespace.resolveAll (/usr/home/mqudsi/go/src/github.com/cockroachdb/cockroach/pkg/ui/node_modules/protobufjs/src/namespace.js:286:25)
    at Root.resolveAll (/usr/home/mqudsi/go/src/github.com/cockroachdb/cockroach/pkg/ui/node_modules/protobufjs/src/namespace.js:286:25)
    at Root.resolveAll (/usr/home/mqudsi/go/src/github.com/cockroachdb/cockroach/pkg/ui/node_modules/protobufjs/src/root.js:246:43)
    at Object.main (/usr/home/mqudsi/go/src/github.com/cockroachdb/cockroach/pkg/ui/node_modules/protobufjs/cli/pbjs.js:220:48)
    at Object.<anonymous> (/usr/home/mqudsi/go/src/github.com/cockroachdb/cockroach/pkg/ui/node_modules/protobufjs/bin/pbjs:4:16)
gmake: *** [Makefile:1041: pkg/ui/src/js/protos.js] Error 1
gmake: *** Deleting file 'pkg/ui/src/js/protos.js'
gmake: *** Waiting for unfinished jobs....
Cloning into '/usr/home/mqudsi/go/src/github.com/cockroachdb/cockroach/c-deps/protobuf'...
Cloning into '/usr/home/mqudsi/go/src/github.com/cockroachdb/cockroach/c-deps/rocksdb'...
```

This time, I did not abort Make, but I let it finish then re-ran it and the problem went away. I'm not sure which rule generates the raft js dependencies, but that needs to be added to prevent this error.