### PR TITLE
sql: fill in required privileges at Validate time.

### DIFF
--- a/pkg/sql/descriptor.go
+++ b/pkg/sql/descriptor.go
@@ -202,8 +202,6 @@ func getDescriptorByID(
 			return errors.Errorf("%q is not a database", desc.String())
 		}
 
-		database.Privileges.MaybeFixPrivileges(id)
-
 		if err := database.Validate(); err != nil {
 			return err
 		}

--- a/pkg/sql/grant_revoke.go
+++ b/pkg/sql/grant_revoke.go
@@ -91,6 +91,12 @@ func (p *planner) changePrivileges(
 			changePrivilege(privileges, string(grantee))
 		}
 
+		// Validate privilege descriptors directly as the db/table level Validate
+		// may fix up the descriptor.
+		if err := privileges.Validate(descriptor.GetID()); err != nil {
+			return nil, err
+		}
+
 		switch d := descriptor.(type) {
 		case *sqlbase.DatabaseDescriptor:
 			if err := d.Validate(); err != nil {

--- a/pkg/sql/sqlbase/structured.go
+++ b/pkg/sql/sqlbase/structured.go
@@ -1161,6 +1161,11 @@ func (desc *TableDescriptor) ValidateTable(st *cluster.Settings) error {
 		}
 	}
 
+	// Fill in any incorrect privileges that may have been missed due to mixed-versions.
+	// TODO(mberhault): remove this in 2.1 (maybe 2.2) when privilege-fixing migrations have been
+	// run again and mixed-version clusters always write "good" descriptors.
+	desc.Privileges.MaybeFixPrivileges(desc.GetID())
+
 	// Validate the privilege descriptor.
 	return desc.Privileges.Validate(desc.GetID())
 }
@@ -2407,6 +2412,12 @@ func (desc *DatabaseDescriptor) Validate() error {
 	if desc.ID == 0 {
 		return fmt.Errorf("invalid database ID %d", desc.ID)
 	}
+
+	// Fill in any incorrect privileges that may have been missed due to mixed-versions.
+	// TODO(mberhault): remove this in 2.1 (maybe 2.2) when privilege-fixing migrations have been
+	// run again and mixed-version clusters always write "good" descriptors.
+	desc.Privileges.MaybeFixPrivileges(desc.GetID())
+
 	// Validate the privilege descriptor.
 	return desc.Privileges.Validate(desc.GetID())
 }

--- a/pkg/sqlmigrations/migrations.go
+++ b/pkg/sqlmigrations/migrations.go
@@ -181,7 +181,7 @@ var backwardCompatibleMigrations = []migrationDescriptor{
 	},
 	{
 		// Introduced in v2.0.
-		// TODO(benesch): bake this migration into v2.1, but create a new migration
+		// TODO(mberhault): bake this migration into v2.1, but create a new migration
 		// with the same function to catch any tables written in a mixed-version setting.
 		name:   "ensure admin role privileges in all descriptors",
 		workFn: ensureMaxPrivileges,


### PR DESCRIPTION
Fixes #24382

We now call MaybeFixPrivileges directly in Validate to avoid any cases
of missed descriptors (occurring in mixed-versions settings).
This can be removed once 2.1 has a repeated migration to fix privileges,
in which case mixed-version will be 2.0 and generate good descriptors
anyway.

We may even want to wait until 2.2 if we want guarantees that noone can
fail validation while migrations are running.

This needs to be cherry-picked into 2.0 as this affects rolling
upgrades.

Release note: sql change: always fill in minimum required privileges.