### PR TITLE
Makefile: further improve GOPATH detection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -201,7 +201,10 @@ UI_ROOT        := $(PKG_ROOT)/ui
 SQLPARSER_ROOT := $(PKG_ROOT)/sql/parser
 
 # Ensure we have an unambiguous GOPATH.
-GOPATH := $(shell $(GO) env GOPATH)
+GOPATH := $(realpath $(shell $(GO) env GOPATH))
+ifeq ($(strip $(GOPATH)),)
+$(error GOPATH is not set and could not be automatically determined, build cannot continue)
+endif
 
 ifneq "$(or $(findstring :,$(GOPATH)),$(findstring ;,$(GOPATH)))" ""
 $(error GOPATHs with multiple entries are not supported)


### PR DESCRIPTION
Squash of #24387.

Closes #24387.

---

It is necessary to use `realpath` to get the real GOPATH, as symlinks
may be in play. For instance, on FreeBSD `/home` is symlinked to
`/usr/home/`, but the former is often used. If `realpath` isn't used,
the string-based prefix matching will incorrectly claim that CWD is not
a child of GOPATH.

Additionally, if `go env GOPATH` does not return a workable value, that
means there is something wrong with the golang deployment and it is
unsafe to assume the value of GOPATH and attempt to proceed. Error out
with a message about GOPATH resolution if `go env GOPATH` does not come
back with a good value.

Release note (build change): None