### PR TITLE
cli: use Cobra's positional argument validation

### DIFF
--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -81,6 +81,7 @@ var versionCmd = &cobra.Command{
 	Long: `
 Output build version information.
 `,
+	Args: cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		info := build.GetInfo()
 		tw := tabwriter.NewWriter(os.Stdout, 2, 1, 2, ' ', 0)

--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -2061,17 +2061,19 @@ func TestJunkPositionalArguments(t *testing.T) {
 	defer c.cleanup()
 
 	for i, test := range []string{
-		"start junk",
-		"sql junk",
-		"gen man junk",
-		"gen autocomplete junk",
-		"gen example-data intro junk",
+		"start",
+		"sql",
+		"gen man",
+		"gen autocomplete",
+		"gen example-data intro",
 	} {
-		out, err := c.RunWithCapture(test)
+		const junk = "junk"
+		line := test + " " + junk
+		out, err := c.RunWithCapture(line)
 		if err != nil {
 			t.Fatal(errors.Wrap(err, strconv.Itoa(i)))
 		}
-		exp := test + "\ninvalid arguments\n"
+		exp := fmt.Sprintf("%s\nunknown command %q for \"cockroach %s\"\n", line, junk, test)
 		if exp != out {
 			t.Errorf("expected:\n%s\ngot:\n%s", exp, out)
 		}

--- a/pkg/cli/debug.go
+++ b/pkg/cli/debug.go
@@ -55,7 +55,7 @@ import (
 )
 
 var debugKeysCmd = &cobra.Command{
-	Use:   "keys [directory]",
+	Use:   "keys <directory>",
 	Short: "dump all the keys in a store",
 	Long: `
 Pretty-prints all keys in a store.
@@ -153,7 +153,7 @@ func runDebugKeys(cmd *cobra.Command, args []string) error {
 }
 
 var debugRangeDataCmd = &cobra.Command{
-	Use:   "range-data [directory] [range id]",
+	Use:   "range-data <directory> <range id>",
 	Short: "dump all the data in a range",
 	Long: `
 Pretty-prints all keys and values in a range. By default, includes unreplicated
@@ -202,7 +202,7 @@ func runDebugRangeData(cmd *cobra.Command, args []string) error {
 }
 
 var debugRangeDescriptorsCmd = &cobra.Command{
-	Use:   "range-descriptors [directory]",
+	Use:   "range-descriptors <directory>",
 	Short: "print all range descriptors in a store",
 	Long: `
 Prints all range descriptors in a store with a history of changes.
@@ -457,7 +457,7 @@ Decode a hexadecimal-encoded key and pretty-print it. For example:
 }
 
 var debugRaftLogCmd = &cobra.Command{
-	Use:   "raft-log [directory] [range id]",
+	Use:   "raft-log <directory> <range id>",
 	Short: "print the raft log for a range",
 	Long: `
 Prints all log entries in a store for the given range.
@@ -538,7 +538,7 @@ func runDebugRaftLog(cmd *cobra.Command, args []string) error {
 }
 
 var debugGCCmd = &cobra.Command{
-	Use:   "estimate-gc [directory] [range id]",
+	Use:   "estimate-gc <directory> [range id]",
 	Short: "find out what a GC run would do",
 	Long: `
 Sets up (but does not run) a GC collection cycle, giving insight into how much
@@ -624,7 +624,7 @@ func runDebugGCCmd(cmd *cobra.Command, args []string) error {
 }
 
 var debugCheckStoreCmd = &cobra.Command{
-	Use:   "check-store [directory]",
+	Use:   "check-store <directory>",
 	Short: "consistency check for a single store",
 	Long: `
 Perform local consistency checks of a single store.
@@ -800,7 +800,7 @@ Output environment variables that influence configuration.
 }
 
 var debugCompactCmd = &cobra.Command{
-	Use:   "compact [directory]",
+	Use:   "compact <directory>",
 	Short: "compact the sstables in a store",
 	Long: `
 Compact the sstables in a store.
@@ -841,7 +841,7 @@ func runDebugCompact(cmd *cobra.Command, args []string) error {
 }
 
 var debugSSTablesCmd = &cobra.Command{
-	Use:   "sstables [directory]",
+	Use:   "sstables <directory>",
 	Short: "list the sstables in a store",
 	Long: `
 
@@ -882,7 +882,7 @@ func runDebugSSTables(cmd *cobra.Command, args []string) error {
 }
 
 var debugGossipValuesCmd = &cobra.Command{
-	Use:   "gossip-values [directory]",
+	Use:   "gossip-values <directory>",
 	Short: "dump all the values in a node's gossip instance",
 	Long: `
 Pretty-prints the values in a node's gossip instance.

--- a/pkg/cli/demo.go
+++ b/pkg/cli/demo.go
@@ -34,6 +34,7 @@ Start an in-memory, standalone, single-node CockroachDB instance, and open an
 interactive SQL prompt to it.
 `,
 	Example: `  cockroach demo`,
+	Args:    cobra.NoArgs,
 	RunE:    MaybeShoutError(MaybeDecorateGRPCError(runDemo)),
 }
 

--- a/pkg/cli/dump.go
+++ b/pkg/cli/dump.go
@@ -41,14 +41,11 @@ var dumpCmd = &cobra.Command{
 Dump SQL tables of a cockroach database. If the table name
 is omitted, dump all tables in the database.
 `,
+	Args: cobra.MinimumNArgs(1),
 	RunE: MaybeDecorateGRPCError(runDump),
 }
 
 func runDump(cmd *cobra.Command, args []string) error {
-	if len(args) < 1 {
-		return usageAndError(cmd)
-	}
-
 	conn, err := getPasswordAndMakeSQLClient("cockroach dump")
 	if err != nil {
 		return err

--- a/pkg/cli/error.go
+++ b/pkg/cli/error.go
@@ -111,10 +111,3 @@ func MaybeShoutError(
 		return err
 	}
 }
-
-func usageAndError(cmd *cobra.Command) error {
-	if err := cmd.Usage(); err != nil {
-		return err
-	}
-	return errors.New("invalid arguments")
-}

--- a/pkg/cli/examples.go
+++ b/pkg/cli/examples.go
@@ -41,10 +41,8 @@ func init() {
 		genExampleCmd := &cobra.Command{
 			Use:   meta.Name,
 			Short: meta.Description,
+			Args:  cobra.NoArgs,
 			RunE: func(cmd *cobra.Command, args []string) error {
-				if len(args) > 0 {
-					return usageAndError(cmd)
-				}
 				runGenExamplesCmd(gen)
 				return nil
 			},

--- a/pkg/cli/gen.go
+++ b/pkg/cli/gen.go
@@ -35,14 +35,11 @@ By default, this places man pages into the "man/man1" directory under the curren
 Use "--path=PATH" to override the output directory. For example, to install man pages globally on
 many Unix-like systems, use "--path=/usr/local/share/man/man1".
 `,
+	Args: cobra.NoArgs,
 	RunE: MaybeDecorateGRPCError(runGenManCmd),
 }
 
 func runGenManCmd(cmd *cobra.Command, args []string) error {
-	if len(args) > 0 {
-		return usageAndError(cmd)
-	}
-
 	info := build.GetInfo()
 	header := &doc.GenManHeader{
 		Section: "1",
@@ -90,13 +87,11 @@ override the file location.
 Note that for the generated file to work on OS X, you'll need to install Homebrew's bash-completion
 package (or an equivalent) and follow the post-install instructions.
 `,
+	Args: cobra.NoArgs,
 	RunE: MaybeDecorateGRPCError(runGenAutocompleteCmd),
 }
 
 func runGenAutocompleteCmd(cmd *cobra.Command, args []string) error {
-	if len(args) > 0 {
-		return usageAndError(cmd)
-	}
 	if err := cmd.Root().GenBashCompletionFile(autoCompletePath); err != nil {
 		return err
 	}

--- a/pkg/cli/haproxy.go
+++ b/pkg/cli/haproxy.go
@@ -45,6 +45,7 @@ The addresses used are those advertized by the nodes themselves. Make sure hapro
 can resolve the hostnames in the configuration file, either by using full-qualified names, or
 running haproxy in the same network.
 `,
+	Args: cobra.NoArgs,
 	RunE: MaybeDecorateGRPCError(runGenHAProxyCmd),
 }
 
@@ -84,10 +85,6 @@ func nodeStatusesToNodeInfos(statuses []status.NodeStatus) []haProxyNodeInfo {
 }
 
 func runGenHAProxyCmd(cmd *cobra.Command, args []string) error {
-	if len(args) > 0 {
-		return usageAndError(cmd)
-	}
-
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 

--- a/pkg/cli/init.go
+++ b/pkg/cli/init.go
@@ -38,6 +38,7 @@ must appear in the --join flags of other nodes.
 A node started without the --join flag initializes itself as a
 single-node cluster, so the init command is not used in that case.
 `,
+	Args: cobra.NoArgs,
 	RunE: MaybeShoutError(MaybeDecorateGRPCError(runInit)),
 }
 

--- a/pkg/cli/node.go
+++ b/pkg/cli/node.go
@@ -102,7 +102,7 @@ var statusNodesColumnHeadersForDecommission = []string{
 }
 
 var statusNodeCmd = &cobra.Command{
-	Use:   "status <optional node ID>",
+	Use:   "status [<node id>]",
 	Short: "shows the status of a node or all nodes",
 	Long: `
 	If a node ID is specified, this will show the status for the corresponding node. If no node ID
@@ -307,7 +307,7 @@ var decommissionNodesColumnHeaders = []string{
 }
 
 var decommissionNodeCmd = &cobra.Command{
-	Use:   "decommission [<nodeID1> <nodeID2> ...]",
+	Use:   "decommission <node id 1> [<node id 2> ...]",
 	Short: "decommissions the node(s)",
 	Long: `
 Marks the nodes with the supplied IDs as decommissioning.
@@ -429,7 +429,7 @@ func decommissionResponseValueToRows(
 }
 
 var recommissionNodeCmd = &cobra.Command{
-	Use:   "recommission [<nodeID1> <nodeID2> ...]",
+	Use:   "recommission <node id 1> [<node id 2> ...]",
 	Short: "recommissions the node(s)",
 	Long: `
 For the nodes with the supplied IDs, resets the decommissioning states.

--- a/pkg/cli/node.go
+++ b/pkg/cli/node.go
@@ -49,14 +49,11 @@ var lsNodesCmd = &cobra.Command{
 Display the node IDs for all active (that is, running and not decommissioned) members of the cluster.
 To retrieve the IDs for inactive members, see 'node status --decommission'.
 	`,
+	Args: cobra.NoArgs,
 	RunE: MaybeDecorateGRPCError(runLsNodes),
 }
 
 func runLsNodes(cmd *cobra.Command, args []string) error {
-	if len(args) != 0 {
-		return usageAndError(cmd)
-	}
-
 	const showDecommissioned = false
 	nodeStatuses, _, err := runStatusNodeInner(showDecommissioned, nil)
 	if err != nil {
@@ -111,6 +108,7 @@ var statusNodeCmd = &cobra.Command{
 	If a node ID is specified, this will show the status for the corresponding node. If no node ID
 	is specified, this will display the status for all nodes in the cluster.
 	`,
+	Args: cobra.MaximumNArgs(1),
 	RunE: MaybeDecorateGRPCError(runStatusNode),
 }
 
@@ -314,6 +312,7 @@ var decommissionNodeCmd = &cobra.Command{
 	Long: `
 Marks the nodes with the supplied IDs as decommissioning.
 This will cause leases and replicas to be removed from these nodes.`,
+	Args: cobra.MinimumNArgs(1),
 	RunE: MaybeDecorateGRPCError(runDecommissionNode),
 }
 
@@ -330,10 +329,6 @@ func parseNodeIDs(strNodeIDs []string) ([]roachpb.NodeID, error) {
 }
 
 func runDecommissionNode(cmd *cobra.Command, args []string) error {
-	if len(args) == 0 {
-		return usageAndError(cmd)
-	}
-
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -434,13 +429,14 @@ func decommissionResponseValueToRows(
 }
 
 var recommissionNodeCmd = &cobra.Command{
-	Use:   "recommission [<node ID>]+",
+	Use:   "recommission [<nodeID1> <nodeID2> ...]",
 	Short: "recommissions the node(s)",
 	Long: `
 For the nodes with the supplied IDs, resets the decommissioning states.
 The target nodes must be restarted, at which point the change will take
 effect and the nodes will participate in the cluster as regular nodes.
 	`,
+	Args: cobra.MinimumNArgs(1),
 	RunE: MaybeDecorateGRPCError(runRecommissionNode),
 }
 
@@ -450,10 +446,6 @@ func printDecommissionStatus(resp serverpb.DecommissionStatusResponse) error {
 }
 
 func runRecommissionNode(cmd *cobra.Command, args []string) error {
-	if len(args) == 0 {
-		return usageAndError(cmd)
-	}
-
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 

--- a/pkg/cli/sql.go
+++ b/pkg/cli/sql.go
@@ -59,6 +59,7 @@ var sqlShellCmd = &cobra.Command{
 	Long: `
 Open a sql shell running against a cockroach database.
 `,
+	Args: cobra.NoArgs,
 	RunE: MaybeDecorateGRPCError(runTerm),
 }
 
@@ -1140,10 +1141,6 @@ func runStatements(conn *sqlConn, stmts []string) error {
 }
 
 func runTerm(cmd *cobra.Command, args []string) error {
-	if len(args) > 0 {
-		return usageAndError(cmd)
-	}
-
 	// We don't consider sessions interactives unless we have a
 	// serious hunch they are. For now, only `cockroach sql` *without*
 	// `-e` has the ability to input from a (presumably) human user,

--- a/pkg/cli/start.go
+++ b/pkg/cli/start.go
@@ -78,6 +78,7 @@ uninitialized, specify the --join flag to point to any healthy node
 (or list of nodes) already part of the cluster.
 `,
 	Example: `  cockroach start --insecure --store=attrs=ssd,path=/mnt/ssd1 [--join=host:port,[host:port]]`,
+	Args:    cobra.NoArgs,
 	RunE:    MaybeShoutError(MaybeDecorateGRPCError(runStart)),
 }
 
@@ -371,10 +372,6 @@ func initTempStorageConfig(
 // of other active nodes used to join this node to the cockroach
 // cluster, if this is its first time connecting.
 func runStart(cmd *cobra.Command, args []string) error {
-	if len(args) > 0 {
-		return usageAndError(cmd)
-	}
-
 	tBegin := timeutil.Now()
 
 	// First things first: if the user wants background processing,
@@ -999,6 +996,7 @@ Shutdown the server. The first stage is drain, where any new requests
 will be ignored by the server. When all extant requests have been
 completed, the server exits.
 `,
+	Args: cobra.NoArgs,
 	RunE: MaybeDecorateGRPCError(runQuit),
 }
 
@@ -1071,10 +1069,6 @@ type errTryHardShutdown struct{ error }
 
 // runQuit accesses the quit shutdown path.
 func runQuit(cmd *cobra.Command, args []string) (err error) {
-	if len(args) != 0 {
-		return usageAndError(cmd)
-	}
-
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 

--- a/pkg/cli/user.go
+++ b/pkg/cli/user.go
@@ -31,13 +31,11 @@ var getUserCmd = &cobra.Command{
 	Long: `
 Fetches and displays the user for <username>.
 `,
+	Args: cobra.ExactArgs(1),
 	RunE: MaybeDecorateGRPCError(runGetUser),
 }
 
 func runGetUser(cmd *cobra.Command, args []string) error {
-	if len(args) != 1 {
-		return usageAndError(cmd)
-	}
 	conn, err := getPasswordAndMakeSQLClient("cockroach user")
 	if err != nil {
 		return err
@@ -60,13 +58,11 @@ var lsUsersCmd = &cobra.Command{
 	Long: `
 List all users.
 `,
+	Args: cobra.NoArgs,
 	RunE: MaybeDecorateGRPCError(runLsUsers),
 }
 
 func runLsUsers(cmd *cobra.Command, args []string) error {
-	if len(args) > 0 {
-		return usageAndError(cmd)
-	}
 	conn, err := getPasswordAndMakeSQLClient("cockroach user")
 	if err != nil {
 		return err
@@ -83,13 +79,11 @@ var rmUserCmd = &cobra.Command{
 	Long: `
 Remove an existing user by username.
 `,
+	Args: cobra.ExactArgs(1),
 	RunE: MaybeDecorateGRPCError(runRmUser),
 }
 
 func runRmUser(cmd *cobra.Command, args []string) error {
-	if len(args) != 1 {
-		return usageAndError(cmd)
-	}
 	conn, err := getPasswordAndMakeSQLClient("cockroach user")
 	if err != nil {
 		return err
@@ -117,6 +111,7 @@ Valid usernames contain 1 to 63 alphanumeric characters. They must
 begin with either a letter or an underscore. Subsequent characters
 may be letters, numbers, or underscores.
 `,
+	Args: cobra.ExactArgs(1),
 	RunE: MaybeDecorateGRPCError(runSetUser),
 }
 
@@ -125,9 +120,6 @@ may be letters, numbers, or underscores.
 // TODO(marc): once we have more fields in the user, we will need
 // to allow changing just some of them (eg: change email, but leave password).
 func runSetUser(cmd *cobra.Command, args []string) error {
-	if len(args) != 1 {
-		return usageAndError(cmd)
-	}
 	pwdString := ""
 	if password {
 		var err error

--- a/pkg/cli/zip.go
+++ b/pkg/cli/zip.go
@@ -30,7 +30,7 @@ import (
 )
 
 var debugZipCmd = &cobra.Command{
-	Use:   "zip [file]",
+	Use:   "zip <file>",
 	Short: "gather cluster debug data into a zip file",
 	Long: `
 

--- a/pkg/cli/zip.go
+++ b/pkg/cli/zip.go
@@ -42,6 +42,7 @@ Retrieval of per-node details (status, stack traces, range status) requires the
 node to be live and operating properly. Retrieval of SQL data requires the
 cluster to be live.
 `,
+	Args: cobra.ExactArgs(1),
 	RunE: MaybeDecorateGRPCError(runDebugZip),
 }
 
@@ -103,10 +104,6 @@ func runDebugZip(cmd *cobra.Command, args []string) error {
 		schemaPrefix = base + "/schema"
 		settingsName = base + "/settings"
 	)
-
-	if len(args) != 1 {
-		return usageAndError(cmd)
-	}
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/pkg/cli/zone.go
+++ b/pkg/cli/zone.go
@@ -72,16 +72,13 @@ var getZoneCmd = &cobra.Command{
 Fetches and displays the zone configuration for the specified database or
 table.
 `,
+	Args: cobra.ExactArgs(1),
 	RunE: MaybeDecorateGRPCError(runGetZone),
 }
 
 // runGetZone retrieves the zone config for a given object id,
 // and if present, outputs its YAML representation.
 func runGetZone(cmd *cobra.Command, args []string) error {
-	if len(args) != 1 {
-		return usageAndError(cmd)
-	}
-
 	zs, err := config.ParseCLIZoneSpecifier(args[0])
 	if err != nil {
 		return err
@@ -128,13 +125,11 @@ var lsZonesCmd = &cobra.Command{
 	Long: `
 List zone configs.
 `,
+	Args: cobra.NoArgs,
 	RunE: MaybeDecorateGRPCError(runLsZones),
 }
 
 func runLsZones(cmd *cobra.Command, args []string) error {
-	if len(args) > 0 {
-		return usageAndError(cmd)
-	}
 	conn, err := getPasswordAndMakeSQLClient("cockroach zone")
 	if err != nil {
 		return err
@@ -169,14 +164,11 @@ var rmZoneCmd = &cobra.Command{
 	Long: `
 Remove an existing zone config for the specified database or table.
 `,
+	Args: cobra.ExactArgs(1),
 	RunE: MaybeDecorateGRPCError(runRmZone),
 }
 
 func runRmZone(cmd *cobra.Command, args []string) error {
-	if len(args) != 1 {
-		return usageAndError(cmd)
-	}
-
 	conn, err := getPasswordAndMakeSQLClient("cockroach zone")
 	if err != nil {
 		return err
@@ -225,6 +217,7 @@ EOF
 Note that the specified zone config is merged with the existing zone config for
 the database or table.
 `,
+	Args: cobra.ExactArgs(1),
 	RunE: MaybeDecorateGRPCError(runSetZone),
 }
 
@@ -250,10 +243,6 @@ func readZoneConfig() (conf []byte, err error) {
 // runSetZone parses the yaml input file, converts it to proto, and inserts it
 // in the system.zones table.
 func runSetZone(cmd *cobra.Command, args []string) error {
-	if len(args) != 1 {
-		return usageAndError(cmd)
-	}
-
 	conn, err := getPasswordAndMakeSQLClient("cockroach zone")
 	if err != nil {
 		return err

--- a/pkg/security/certs.go
+++ b/pkg/security/certs.go
@@ -185,10 +185,6 @@ func CreateNodePair(
 		return errors.New("the path to the certs directory is required")
 	}
 
-	if len(hosts) == 0 {
-		return errors.Errorf("no hosts specified. Need at least one")
-	}
-
 	// The certificate manager expands the env for the certs directory.
 	// For consistency, we need to do this for the key as well.
 	caKeyPath = os.ExpandEnv(caKeyPath)


### PR DESCRIPTION
Positional argument validation was added to spf13/cobra in
spf13/cobra#284, but our cli still
relies on custom validation in each of the "run" functions.
This validation is unstandardized and overly permissive in
certain cases. This change fixes this by replacing our custom
logic with validation expressed using Cobra's `PositionalArgs`
validators.

Release note: None