### PR TITLE
server: add a crdb_internal.force_diagnostics_report helper

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -817,6 +817,15 @@ Compatible elements: hour, minute, second, millisecond, microsecond.</p>
 </span></td></tr></tbody>
 </table>
 
+### Testing and Debugging Functions
+
+<table>
+<thead><tr><th>Function &rarr; Returns</th><th>Description</th></tr></thead>
+<tbody>
+<tr><td><code>crdb_internal.force_diagnostic_report() &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>This function is used only by CockroachDB’s developers for testing purposes.</p>
+</span></td></tr></tbody>
+</table>
+
 ### Compatibility Functions
 
 <table>

--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -791,19 +791,7 @@ Compatible elements: hour, minute, second, millisecond, microsecond.</p>
 </span></td></tr>
 <tr><td><code>crdb_internal.cluster_id() &rarr; <a href="uuid.html">uuid</a></code></td><td><span class="funcdesc"><p>Returns the cluster ID.</p>
 </span></td></tr>
-<tr><td><code>crdb_internal.force_error(errorCode: <a href="string.html">string</a>, msg: <a href="string.html">string</a>) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>This function is used only by CockroachDB’s developers for testing purposes.</p>
-</span></td></tr>
-<tr><td><code>crdb_internal.force_log_fatal(msg: <a href="string.html">string</a>) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>This function is used only by CockroachDB’s developers for testing purposes.</p>
-</span></td></tr>
-<tr><td><code>crdb_internal.force_panic(msg: <a href="string.html">string</a>) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>This function is used only by CockroachDB’s developers for testing purposes.</p>
-</span></td></tr>
-<tr><td><code>crdb_internal.force_retry(val: <a href="interval.html">interval</a>) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>This function is used only by CockroachDB’s developers for testing purposes.</p>
-</span></td></tr>
-<tr><td><code>crdb_internal.no_constant_folding(input: anyelement) &rarr; anyelement</code></td><td><span class="funcdesc"><p>This function is used only by CockroachDB’s developers for testing purposes.</p>
-</span></td></tr>
 <tr><td><code>crdb_internal.node_executable_version() &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Returns the version of CockroachDB this node is running.</p>
-</span></td></tr>
-<tr><td><code>crdb_internal.set_vmodule(vmodule_string: <a href="string.html">string</a>) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>This function is used for internal debugging purposes. Incorrect use can severely impact performance.</p>
 </span></td></tr>
 <tr><td><code>current_database() &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Returns the current database.</p>
 </span></td></tr>
@@ -823,6 +811,18 @@ Compatible elements: hour, minute, second, millisecond, microsecond.</p>
 <thead><tr><th>Function &rarr; Returns</th><th>Description</th></tr></thead>
 <tbody>
 <tr><td><code>crdb_internal.force_diagnostic_report() &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>This function is used only by CockroachDB’s developers for testing purposes.</p>
+</span></td></tr>
+<tr><td><code>crdb_internal.force_error(errorCode: <a href="string.html">string</a>, msg: <a href="string.html">string</a>) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>This function is used only by CockroachDB’s developers for testing purposes.</p>
+</span></td></tr>
+<tr><td><code>crdb_internal.force_log_fatal(msg: <a href="string.html">string</a>) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>This function is used only by CockroachDB’s developers for testing purposes.</p>
+</span></td></tr>
+<tr><td><code>crdb_internal.force_panic(msg: <a href="string.html">string</a>) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>This function is used only by CockroachDB’s developers for testing purposes.</p>
+</span></td></tr>
+<tr><td><code>crdb_internal.force_retry(val: <a href="interval.html">interval</a>) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>This function is used only by CockroachDB’s developers for testing purposes.</p>
+</span></td></tr>
+<tr><td><code>crdb_internal.no_constant_folding(input: anyelement) &rarr; anyelement</code></td><td><span class="funcdesc"><p>This function is used only by CockroachDB’s developers for testing purposes.</p>
+</span></td></tr>
+<tr><td><code>crdb_internal.set_vmodule(vmodule_string: <a href="string.html">string</a>) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>This function is used for internal debugging purposes. Incorrect use can severely impact performance.</p>
 </span></td></tr></tbody>
 </table>
 

--- a/pkg/cli/start.go
+++ b/pkg/cli/start.go
@@ -538,7 +538,7 @@ func runStart(cmd *cobra.Command, args []string) error {
 			// We don't do this in (*server.Server).Start() because we don't want it
 			// in tests.
 			if !envutil.EnvOrDefaultBool("COCKROACH_SKIP_UPDATE_CHECK", false) {
-				s.PeriodicallyCheckForUpdates()
+				s.PeriodicallyCheckForUpdates(ctx)
 			}
 
 			// Now inform the user that the server is running and tell the

--- a/pkg/server/updates.go
+++ b/pkg/server/updates.go
@@ -39,6 +39,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/server/diagnosticspb"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/sql"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/builtins"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
@@ -49,6 +50,10 @@ import (
 
 const baseUpdatesURL = `https://register.cockroachdb.com/api/clusters/updates`
 const baseReportingURL = `https://register.cockroachdb.com/api/clusters/report`
+
+var (
+	errReportingDisabled = errors.New("diagnostic reporting disabled")
+)
 
 var updatesURL, reportingURL *url.URL
 
@@ -99,9 +104,21 @@ type versionInfo struct {
 
 // PeriodicallyCheckForUpdates starts a background worker that periodically
 // phones home to check for updates and report usage.
-func (s *Server) PeriodicallyCheckForUpdates() {
-	s.stopper.RunWorker(context.TODO(), func(ctx context.Context) {
-		startup := timeutil.Now()
+func (s *Server) PeriodicallyCheckForUpdates(ctx context.Context) {
+	startup := timeutil.Now()
+
+	builtins.ExternalFuncImpls["crdb_internal.force_diagnostic_report"] = func(
+		ctx *tree.EvalContext, _ tree.Datums,
+	) (tree.Datum, error) {
+		now := timeutil.Now()
+		_, err := s.maybeReportDiagnostics(ctx.Ctx(), now, now.Add(-1*time.Second), now.Sub(startup))
+		if err != nil {
+			return nil, err
+		}
+		return tree.NewDString("OK"), nil
+	}
+
+	s.stopper.RunWorker(ctx, func(ctx context.Context) {
 		nextUpdateCheck := startup
 		nextDiagnosticReport := startup
 
@@ -111,8 +128,9 @@ func (s *Server) PeriodicallyCheckForUpdates() {
 			now := timeutil.Now()
 			runningTime := now.Sub(startup)
 
-			nextUpdateCheck = s.maybeCheckForUpdates(now, nextUpdateCheck, runningTime)
-			nextDiagnosticReport = s.maybeReportDiagnostics(ctx, now, nextDiagnosticReport, runningTime)
+			nextUpdateCheck = s.maybeCheckForUpdates(ctx, now, nextUpdateCheck, runningTime)
+			// maybeReportDiagnostics logs its err internally so it can be ignored.
+			nextDiagnosticReport, _ = s.maybeReportDiagnostics(ctx, now, nextDiagnosticReport, runningTime)
 
 			sooner := nextUpdateCheck
 			if nextDiagnosticReport.Before(sooner) {
@@ -133,7 +151,7 @@ func (s *Server) PeriodicallyCheckForUpdates() {
 // maybeCheckForUpdates determines if it is time to check for updates and does
 // so if it is, before returning the time at which the next check be done.
 func (s *Server) maybeCheckForUpdates(
-	now, scheduled time.Time, runningTime time.Duration,
+	ctx context.Context, now, scheduled time.Time, runningTime time.Duration,
 ) time.Time {
 	if scheduled.After(now) {
 		return scheduled
@@ -147,7 +165,7 @@ func (s *Server) maybeCheckForUpdates(
 
 	// checkForUpdates handles its own errors, but it returns a bool indicating if
 	// it succeeded, so we can schedule a re-attempt if it did not.
-	if succeeded := s.checkForUpdates(runningTime); !succeeded {
+	if succeeded := s.checkForUpdates(ctx, runningTime); !succeeded {
 		return now.Add(updateCheckRetryFrequency)
 	}
 
@@ -188,11 +206,11 @@ func addInfoToURL(ctx context.Context, url *url.URL, s *Server, runningTime time
 // and logs messages if it finds them, as well as if it encounters any errors.
 // The returned boolean indicates if the check succeeded (and thus does not need
 // to be re-attempted by the scheduler after a retry-interval).
-func (s *Server) checkForUpdates(runningTime time.Duration) bool {
+func (s *Server) checkForUpdates(ctx context.Context, runningTime time.Duration) bool {
 	if updatesURL == nil {
 		return true // don't bother with asking for retry -- we'll never succeed.
 	}
-	ctx, span := s.AnnotateCtxWithSpan(context.Background(), "checkForUpdates")
+	ctx, span := s.AnnotateCtxWithSpan(ctx, "checkForUpdates")
 	defer span.Finish()
 
 	addInfoToURL(ctx, updatesURL, s, runningTime)
@@ -235,18 +253,31 @@ func (s *Server) checkForUpdates(runningTime time.Duration) bool {
 	return true
 }
 
+// maybeReportDiagnostics checks if it is time to report and does so if enabled
+// (flushing stats either way to avoid unbounded growth). Returns a time after
+// which it would like to be called again when used in the background reporting
+// loop, as well as an already logged error for use by manual callers.
 func (s *Server) maybeReportDiagnostics(
 	ctx context.Context, now, scheduled time.Time, running time.Duration,
-) time.Time {
+) (time.Time, error) {
 	if scheduled.After(now) {
-		return scheduled
+		return scheduled, errReportingDisabled
 	}
 
 	// TODO(dt): we should allow tuning the reset and report intervals separately.
 	// Consider something like rand.Float() > resetFreq/reportFreq here to sample
 	// stat reset periods for reporting.
+	var result error
 	if log.DiagnosticsReportingEnabled.Get(&s.st.SV) {
-		s.reportDiagnostics(running)
+		result = s.reportDiagnostics(ctx, running)
+		// The report generation helper logs internal errors as warnings on its own,
+		// so here we mostly only expect network errors -- which may be common in
+		// firewalled production environments so avoid spamming logs about them.
+		if result != nil && log.V(2) {
+			log.Warning(ctx, result)
+		}
+	} else {
+		result = errReportingDisabled
 	}
 	if !s.cfg.UseLegacyConnHandling {
 		s.pgServer.SQLServer.ResetStatementStats(ctx)
@@ -256,7 +287,7 @@ func (s *Server) maybeReportDiagnostics(
 		s.sqlExecutor.ResetErrorCounts()
 	}
 
-	return scheduled.Add(diagnosticReportFrequency.Get(&s.st.SV))
+	return scheduled.Add(diagnosticReportFrequency.Get(&s.st.SV)), result
 }
 
 func (s *Server) getReportingInfo(ctx context.Context) *diagnosticspb.DiagnosticReport {
@@ -382,36 +413,33 @@ func anonymizeZoneConfig(dst *config.ZoneConfig, src config.ZoneConfig, secret s
 	}
 }
 
-func (s *Server) reportDiagnostics(runningTime time.Duration) {
+func (s *Server) reportDiagnostics(ctx context.Context, runningTime time.Duration) error {
 	if reportingURL == nil {
-		return
+		return errReportingDisabled
 	}
-	ctx, span := s.AnnotateCtxWithSpan(context.Background(), "usageReport")
+	ctx, span := s.AnnotateCtxWithSpan(ctx, "usageReport")
 	defer span.Finish()
 
 	b, err := protoutil.Marshal(s.getReportingInfo(ctx))
 	if err != nil {
-		log.Warning(ctx, err)
-		return
+		return errors.Wrap(err, "gathering report info")
 	}
 
 	addInfoToURL(ctx, reportingURL, s, runningTime)
+	log.Eventf(ctx, "sending anonymized diagnostics report to %s", updatesURL.String())
 	res, err := http.Post(reportingURL.String(), "application/x-protobuf", bytes.NewReader(b))
 	if err != nil {
-		if log.V(2) {
-			// This is probably going to be relatively common in production
-			// environments where network access is usually curtailed.
-			log.Warning(ctx, "failed to report node usage metrics: ", err)
-		}
-		return
+		return errors.Wrap(err, "reporting node usage metrics")
 	}
 	defer res.Body.Close()
 
 	if res.StatusCode != http.StatusOK {
 		b, err := ioutil.ReadAll(res.Body)
-		log.Warningf(ctx, "failed to report node usage metrics: status: %s, body: %s, "+
-			"error: %v", res.Status, b, err)
+		return errors.Errorf(
+			"reporting node usage metrics: status: %s, body: %s, error: %v", res.Status, b, err,
+		)
 	}
+	return nil
 }
 
 func (s *Server) collectSchemaInfo(ctx context.Context) ([]sqlbase.TableDescriptor, error) {

--- a/pkg/server/updates_test.go
+++ b/pkg/server/updates_test.go
@@ -63,7 +63,7 @@ func TestCheckVersion(t *testing.T) {
 	defer stubURL(&updatesURL, r.url)()
 
 	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
-	s.(*TestServer).checkForUpdates(time.Minute)
+	s.(*TestServer).checkForUpdates(ctx, time.Minute)
 	r.Close()
 	s.Stopper().Stop(ctx)
 
@@ -96,7 +96,7 @@ func TestCheckVersion(t *testing.T) {
 		// ensure nil, which happens when an empty env override URL is used, does not
 		// cause a crash. We've deferred a cleanup of the original pointer above.
 		updatesURL = nil
-		s.(*TestServer).checkForUpdates(time.Minute)
+		s.(*TestServer).checkForUpdates(ctx, time.Minute)
 	})
 }
 
@@ -265,7 +265,9 @@ func TestReportUsage(t *testing.T) {
 		expectedUsageReports++
 
 		node := ts.node.recorder.GetStatusSummary(ctx)
-		ts.reportDiagnostics(0)
+		if err := ts.reportDiagnostics(ctx, 0); err != nil {
+			t.Fatal(err)
+		}
 
 		keyCounts := make(map[roachpb.StoreID]int64)
 		rangeCounts := make(map[roachpb.StoreID]int64)

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -1321,7 +1321,7 @@ CockroachDB supports the following flags:
 			Fn: func(ctx *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
 				return ctx.GetClusterTimestamp(), nil
 			},
-			Info: "This function is used only by CockroachDB's developers for testing purposes.",
+			Info: testingHelperDesc,
 		},
 	},
 
@@ -2337,8 +2337,8 @@ CockroachDB supports the following flags:
 				}
 				return nil, pgerror.NewError(errCode, msg)
 			},
-			Category: categorySystemInfo,
-			Info:     "This function is used only by CockroachDB's developers for testing purposes.",
+			Category: categoryTesting,
+			Info:     testingHelperDesc,
 		},
 	},
 
@@ -2352,8 +2352,8 @@ CockroachDB supports the following flags:
 				msg := string(*args[0].(*tree.DString))
 				panic(msg)
 			},
-			Category: categorySystemInfo,
-			Info:     "This function is used only by CockroachDB's developers for testing purposes.",
+			Category: categoryTesting,
+			Info:     testingHelperDesc,
 		},
 	},
 
@@ -2368,8 +2368,8 @@ CockroachDB supports the following flags:
 				log.Fatal(ctx.Ctx(), msg)
 				return nil, nil
 			},
-			Category: categorySystemInfo,
-			Info:     "This function is used only by CockroachDB's developers for testing purposes.",
+			Category: categoryTesting,
+			Info:     testingHelperDesc,
 		},
 	},
 
@@ -2394,8 +2394,8 @@ CockroachDB supports the following flags:
 				}
 				return tree.DZero, nil
 			},
-			Category: categorySystemInfo,
-			Info:     "This function is used only by CockroachDB's developers for testing purposes.",
+			Category: categoryTesting,
+			Info:     testingHelperDesc,
 		},
 	},
 
@@ -2425,8 +2425,8 @@ CockroachDB supports the following flags:
 			Fn: func(_ *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
 				return args[0], nil
 			},
-			Category: categorySystemInfo,
-			Info:     "This function is used only by CockroachDB's developers for testing purposes.",
+			Category: categoryTesting,
+			Info:     testingHelperDesc,
 		},
 	},
 
@@ -2439,7 +2439,7 @@ CockroachDB supports the following flags:
 			Fn: func(ctx *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
 				return tree.DZero, log.SetVModule(string(*args[0].(*tree.DString)))
 			},
-			Category: categorySystemInfo,
+			Category: categoryTesting,
 			Info: "This function is used for internal debugging purposes. " +
 				"Incorrect use can severely impact performance.",
 		},


### PR DESCRIPTION
For easier end-to-end testing of our reporting setup, it is nice to skip scheduling loop and trigger a rerpot attempt directly. Note that the attempted report is the same as if the normal loop had triggered it, e.g. it still checks if reporting is enabled and flushes the accumulated stats (to avoid double counting in next report). Requires super-user.

Release note: none.