### PR TITLE
distsql: wrap RowFetcher.NextRow() in RowSource.Next()

### DIFF
--- a/pkg/sql/distsqlrun/tablereader.go
+++ b/pkg/sql/distsqlrun/tablereader.go
@@ -19,6 +19,8 @@ import (
 
 	"github.com/pkg/errors"
 
+	"context"
+
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/scrub"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
@@ -39,6 +41,9 @@ type tableReader struct {
 	spans     roachpb.Spans
 	limitHint int64
 
+	input RowSource
+	// fetcher is the underlying RowFetcher, should only be used for
+	// initialization, call input.Next() to retrieve rows once initialized.
 	fetcher sqlbase.RowFetcher
 	alloc   sqlbase.DatumAlloc
 
@@ -57,6 +62,7 @@ func newTableReader(
 	if flowCtx.nodeID == 0 {
 		return nil, errors.Errorf("attempting to create a tableReader with uninitialized NodeID")
 	}
+
 	tr := &tableReader{
 		tableDesc: spec.Table,
 	}
@@ -87,6 +93,29 @@ func newTableReader(
 
 	return tr, nil
 }
+
+// rowFetcherWrapper is used only by a tableReader to wrap calls to
+// RowFetcher.NextRow() in a RowSource implementation.
+type rowFetcherWrapper struct {
+	ctx context.Context
+	*sqlbase.RowFetcher
+}
+
+var _ RowSource = rowFetcherWrapper{}
+
+// Next() calls NextRow() on the underlying RowFetcher. If the returned
+// ProducerMetadata is not nil, only its Err field will be set.
+func (w rowFetcherWrapper) Next() (sqlbase.EncDatumRow, *ProducerMetadata) {
+	row, _, _, err := w.NextRow(w.ctx)
+	if err != nil {
+		return row, &ProducerMetadata{Err: err}
+	}
+	return row, nil
+}
+
+func (w rowFetcherWrapper) OutputTypes() []sqlbase.ColumnType { return nil }
+func (w rowFetcherWrapper) ConsumerDone()                     {}
+func (w rowFetcherWrapper) ConsumerClosed()                   {}
 
 func initRowFetcher(
 	fetcher *sqlbase.RowFetcher,
@@ -188,6 +217,8 @@ func (tr *tableReader) Next() (sqlbase.EncDatumRow, *ProducerMetadata) {
 			log.Eventf(tr.ctx, "scan error: %s", err)
 			return nil, tr.producerMeta(err)
 		}
+
+		tr.input = rowFetcherWrapper{ctx: tr.ctx, RowFetcher: &tr.fetcher}
 	}
 
 	if tr.closed || tr.consumerStatus != NeedMoreRows {
@@ -195,9 +226,11 @@ func (tr *tableReader) Next() (sqlbase.EncDatumRow, *ProducerMetadata) {
 	}
 
 	for {
-		var row sqlbase.EncDatumRow
+		row, meta := tr.input.Next()
 		var err error
-		row, _, _, err = tr.fetcher.NextRow(tr.ctx)
+		if meta != nil {
+			err = meta.Err
+		}
 		if row == nil || err != nil {
 			// This was the last-row or an error was encountered, annotate the
 			// metadata with misplanned ranges and trace data.


### PR DESCRIPTION
This is preparatory work for stat collection. A stat object will be
inserted between a processor and its upstream RowSource data source.
To be able to collect stats this way in the tableReader,
RowFetcher.NextRow has to be wrapped in a RowSource.Next implementation.

Release note: None

Here are the benchmark differences, I'm unsure why this change offers a performance improvement:

```
BENCHES=BenchmarkTableReader PKG=./pkg/sql/distsqlrun ./scripts/bench master pstats | tee trresults
Comparing pstats (new) with master (old)

Writing to /var/folders/ry/6tnq_y2x6mn_pk6sy57jqpjw0000gn/T/tmp.qzgNP6Qe
Switching to master
+ make bench PKG=./pkg/sql/distsqlrun BENCHTIMEOUT=5m BENCHES=BenchmarkTableReader 'TESTFLAGS=-count 10 -benchmem'
Switching to pstats
+ make bench PKG=./pkg/sql/distsqlrun BENCHTIMEOUT=5m BENCHES=BenchmarkTableReader 'TESTFLAGS=-count 10 -benchmem'
name           old time/op    new time/op    delta
TableReader-8    5.58ms ± 6%    5.30ms ± 4%  -5.07%  (p=0.004 n=10+10)

name           old alloc/op   new alloc/op   delta
TableReader-8    1.95MB ± 0%    1.95MB ± 0%    ~     (p=0.315 n=10+10)

name           old allocs/op  new allocs/op  delta
TableReader-8       826 ±22%       824 ±15%    ~     (p=0.491 n=10+10)
```

The abstraction isn't as clean as I would like it to be because of the initialization necessary for the `RowFetcher` (`init` + `StartScan` in `newTableReader` and `Next()`). I would appreciate any ideas for alternative approaches.

@jordanlewis making you the reviewer until we figure out who will be reviewing my stats-related changes but feel free to re-assign.