### PR TITLE
roachtest: fix duration handling in allocator tests

### DIFF
--- a/pkg/cmd/roachtest/allocator.go
+++ b/pkg/cmd/roachtest/allocator.go
@@ -106,11 +106,7 @@ func printRebalanceStats(l *logger, db *gosql.DB) error {
 		).Scan(&rebalanceIntervalStr); err != nil {
 			return err
 		}
-		rebalanceInterval, err := time.ParseDuration(rebalanceIntervalStr)
-		if err != nil {
-			return err
-		}
-		l.printf("cluster took %s to rebalance\n", rebalanceInterval)
+		l.printf("cluster took %s to rebalance\n", rebalanceIntervalStr)
 	}
 
 	// Output # of range events that occurred. All other things being equal,
@@ -155,7 +151,7 @@ func printRebalanceStats(l *logger, db *gosql.DB) error {
 }
 
 type replicationStats struct {
-	ElapsedSinceLastEvent time.Duration
+	SecondsSinceLastEvent int64
 	EventType             string
 	RangeID               int64
 	StoreID               int64
@@ -163,8 +159,8 @@ type replicationStats struct {
 }
 
 func (s replicationStats) String() string {
-	return fmt.Sprintf("last range event: %s for range %d/store %d (%s ago)",
-		s.EventType, s.RangeID, s.StoreID, s.ElapsedSinceLastEvent)
+	return fmt.Sprintf("last range event: %s for range %d/store %d (%ds ago)",
+		s.EventType, s.RangeID, s.StoreID, s.SecondsSinceLastEvent)
 }
 
 // allocatorStats returns the duration of stability (i.e. no replication
@@ -183,10 +179,8 @@ func allocatorStats(db *gosql.DB) (s replicationStats, err error) {
 		`split`, `add`, `remove`,
 	}
 
-	q := `SELECT NOW()-timestamp, "rangeID", "storeID", "eventType" FROM system.rangelog ` +
-		`WHERE "eventType" IN ($1, $2, $3) ORDER BY timestamp DESC LIMIT 1`
-
-	var elapsedStr string
+	q := `SELECT extract_duration(seconds FROM now()-timestamp), "rangeID", "storeID", "eventType"` +
+		`FROM system.rangelog WHERE "eventType" IN ($1, $2, $3) ORDER BY timestamp DESC LIMIT 1`
 
 	row := db.QueryRow(q, eventTypes...)
 	if row == nil {
@@ -194,11 +188,7 @@ func allocatorStats(db *gosql.DB) (s replicationStats, err error) {
 		// will always have some range events.
 		return replicationStats{}, errors.New("couldn't find any range events")
 	}
-	if err := row.Scan(&elapsedStr, &s.RangeID, &s.StoreID, &s.EventType); err != nil {
-		return replicationStats{}, err
-	}
-	s.ElapsedSinceLastEvent, err = time.ParseDuration(elapsedStr)
-	if err != nil {
+	if err := row.Scan(&s.SecondsSinceLastEvent, &s.RangeID, &s.StoreID, &s.EventType); err != nil {
 		return replicationStats{}, err
 	}
 
@@ -221,7 +211,7 @@ func allocatorStats(db *gosql.DB) (s replicationStats, err error) {
 func waitForRebalance(ctx context.Context, l *logger, db *gosql.DB, maxStdDev float64) error {
 	// const statsInterval = 20 * time.Second
 	const statsInterval = 2 * time.Second
-	const stableInterval = 3 * time.Minute
+	const stableSeconds = 3 * 60
 
 	var statsTimer timeutil.Timer
 	defer statsTimer.Stop()
@@ -238,13 +228,13 @@ func waitForRebalance(ctx context.Context, l *logger, db *gosql.DB, maxStdDev fl
 			}
 
 			l.printf("%v\n", stats)
-			if stableInterval <= stats.ElapsedSinceLastEvent {
+			if stableSeconds <= stats.SecondsSinceLastEvent {
 				l.printf("replica count stddev = %f, max allowed stddev = %f\n", stats.ReplicaCountStdDev, maxStdDev)
 				if stats.ReplicaCountStdDev > maxStdDev {
 					_ = printRebalanceStats(l, db)
 					return errors.Errorf(
-						"%s elapsed without changes, but replica count standard "+
-							"deviation is %.2f (>%.2f)", stats.ElapsedSinceLastEvent,
+						"%ds elapsed without changes, but replica count standard "+
+							"deviation is %.2f (>%.2f)", stats.SecondsSinceLastEvent,
 						stats.ReplicaCountStdDev, maxStdDev)
 				}
 				return printRebalanceStats(l, db)


### PR DESCRIPTION
SQL-formatted durations are not safe to pass to `time.ParseDuration`.
The allocator tests would occasionally fail because a duration like
"-2ms-164us" is not a valid Go duration. (The negative duration is not
unexpected, due to how we handle transaction timestamps, and in fact
would be handled correctly if Go could just parse the duration.)

Sidestep the problem by using integral seconds. We don't need the full
nanosecond precision of the duration.

Release note: None