### PR TITLE
build: teach Bors about the CLA check

### DIFF
--- a/bors.toml
+++ b/bors.toml
@@ -1,6 +1,9 @@
 status = [
   "GitHub CI (Cockroach)"
 ]
+pr_status = [
+  "license/cla"
+]
 block_labels = [
   "do-not-merge"
 ]


### PR DESCRIPTION
When introducing Bors in #24100, I only thought to include the TeamCity build
status, but since we require the license check for regular, GitHub-initiated
merges, this was a regression.  This change corrects that, adding the CLA to
the list of statuses to check.

Release note: None