### PR TITLE
sql: Add the builtin function _pg_expandarray()

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -989,6 +989,8 @@ Compatible elements: hour, minute, second, millisecond, microsecond.</p>
 </span></td></tr>
 <tr><td><code>has_type_privilege(user: oid, type: oid, privilege: <a href="string.html">string</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>does user have privilege for type</p>
 </span></td></tr>
+<tr><td><code>information_schema._pg_expandarray(input: anyelement[]) &rarr; anyelement</code></td><td><span class="funcdesc"><p>Returns the input array as a set of rows with an index</p>
+</span></td></tr>
 <tr><td><code>json_array_elements(input: jsonb) &rarr; setof tuple{jsonb}</code></td><td><span class="funcdesc"><p>Expands a JSON array to a set of JSON values.</p>
 </span></td></tr>
 <tr><td><code>json_array_elements_text(input: jsonb) &rarr; setof tuple{string}</code></td><td><span class="funcdesc"><p>Expands a JSON array to a set of text values.</p>

--- a/pkg/sql/logictest/testdata/logic_test/generators
+++ b/pkg/sql/logictest/testdata/logic_test/generators
@@ -313,3 +313,97 @@ SELECT * FROM current_schema() WITH ORDINALITY AS a(b)
 ----
 b      ordinality
 public 1
+
+subtest expandArray
+
+query error pq: unknown signature: information_schema._pg_expandarray()
+SELECT information_schema._pg_expandarray()
+
+query error pq: unknown signature: information_schema._pg_expandarray()
+SELECT * FROM information_schema._pg_expandarray()
+
+query error pq: information_schema\._pg_expandarray\(\): cannot determine type of empty array\. Consider annotating with the desired type, for example ARRAY\[\]:::int\[\]
+SELECT information_schema._pg_expandarray(ARRAY[])
+
+query error pq: information_schema\._pg_expandarray\(\): cannot determine type of empty array\. Consider annotating with the desired type, for example ARRAY\[\]:::int\[\]
+SELECT * FROM information_schema._pg_expandarray(ARRAY[])
+
+query I
+SELECT information_schema._pg_expandarray(ARRAY[]:::int[])
+----
+
+query II
+SELECT * FROM information_schema._pg_expandarray(ARRAY[]:::int[])
+----
+
+query T
+SELECT information_schema._pg_expandarray(ARRAY[100])
+----
+(100,1)
+
+query II
+SELECT * FROM information_schema._pg_expandarray(ARRAY[100])
+----
+100 1
+
+query T
+SELECT information_schema._pg_expandarray(ARRAY[2, 1])
+----
+(2,1)
+(1,2)
+
+query II
+SELECT * FROM information_schema._pg_expandarray(ARRAY[2, 1])
+----
+2 1
+1 2
+
+query T
+SELECT information_schema._pg_expandarray(ARRAY[3, 2, 1])
+----
+(3,1)
+(2,2)
+(1,3)
+
+query II
+SELECT * FROM information_schema._pg_expandarray(ARRAY[3, 2, 1])
+----
+3 1
+2 2
+1 3
+
+query T
+SELECT information_schema._pg_expandarray(ARRAY['a'])
+----
+('a',1)
+
+query TI
+SELECT * FROM information_schema._pg_expandarray(ARRAY['a'])
+----
+a 1
+
+query T
+SELECT information_schema._pg_expandarray(ARRAY['b', 'a'])
+----
+('b',1)
+('a',2)
+
+query TI
+SELECT * FROM information_schema._pg_expandarray(ARRAY['b', 'a'])
+----
+b 1
+a 2
+
+query T
+SELECT information_schema._pg_expandarray(ARRAY['c', 'b', 'a'])
+----
+('c',1)
+('b',2)
+('a',3)
+
+query TI
+SELECT * FROM information_schema._pg_expandarray(ARRAY['c', 'b', 'a'])
+----
+c 1
+b 2
+a 3


### PR DESCRIPTION
This adds the information_schema._pg_expandarray() function. It is needed for
compatibility with a number of ORMs. See #16971.

information_schema._pg_expandarray takes an array and returns a set of the
value and an index into the array. This is a very old function and from what I
can discern, was designed for internal use only, but was picked up by a few
ORMs. There is no real supporting documentation for the feature. The code for
it can be seen here:
https://sourcegraph.com/github.com/postgres/postgres/-/blob/src/backend/catalog/information_schema.sql#L43:17

Furthermore, if the function is a Set Retruning Function, it returns tuples
when evaluated in a scalar context:

In Postgres:

```sql
SELECT information_schema._pg_expandarray(array['i','i','o','t','b']);

 _pg_expandarray
-----------------
 (i,1)
 (i,2)
 (o,3)
 (t,4)
 (b,5)
(5 rows)
```

With this patch Cockroach now supports this directly as well:

```sql
SELECT information_schema._pg_expandarray(array['i','i','o','t','b']);

+------------------------------------+
| information_schema._pg_expandarray |
+------------------------------------+
| ('i',1)                            |
| ('i',2)                            |
| ('o',3)                            |
| ('t',4)                            |
| ('b',5)                            |
+------------------------------------+
(5 rows)
```

However, when evaluating an SRF in the `FROM` context, it should return
columns. Luckily, we already do exactly that. This is true for `unnest()` as
well as the new `_pg_expandarray`. The difference is a little subtle and I
couldn't find any good documentation on it, but this answer seems to cover it
quite well:
https://dba.stackexchange.com/questions/172463/understanding-set-returning-function-srf-in-the-select-list

In Postgres:

```sql
SELECT * FROM information_schema._pg_expandarray(array['i','i','o','t','b']);

 x | n
---+---
 i | 1
 i | 2
 o | 3
 t | 4
 b | 5
(5 rows)

```

In Cockroach:

```sql
SELECT * from information_schema._pg_expandarray(array['i','i','o','t','b']);

+---+---+
| x | n |
+---+---+
| i | 1 |
| i | 2 |
| o | 3 |
| t | 4 |
| b | 5 |
+---+---+
(5 rows)
```

Note that after froming the resulting set to a table, this function is
essentially the same as:

```sql
SELECT * from unnest(array['i','1','3','r']) with ordinality as c(x,n);

+---+---+
| x | n |
+---+---+
| i | 1 |
| 1 | 2 |
| 3 | 3 |
| r | 4 |
+---+---+
(4 rows)
```

But to retain direct compatibility with Postgres, the original SET response
needs to be maintained as well.

Part of #16971.

Release note (sql change): Added support for the
information_schema._pg_expandarray() function.