### PR TITLE
optbuilder: refactor scope and column_props

### DIFF
--- a/pkg/sql/opt/optbuilder/builder.go
+++ b/pkg/sql/opt/optbuilder/builder.go
@@ -63,7 +63,7 @@ type Builder struct {
 	catalog opt.Catalog
 
 	// Skip index 0 in order to reserve it to indicate the "unknown" column.
-	colMap []columnProps
+	colMap []scopeColumn
 }
 
 // New creates a new Builder structure initialized with the given
@@ -79,7 +79,7 @@ func New(
 	return &Builder{
 		factory: factory,
 		stmt:    stmt,
-		colMap:  make([]columnProps, 1),
+		colMap:  make([]scopeColumn, 1),
 		ctx:     ctx,
 		semaCtx: semaCtx,
 		evalCtx: evalCtx,
@@ -111,8 +111,8 @@ func (b *Builder) Build() (root memo.GroupID, required *memo.PhysicalProps, err 
 		}
 	}()
 
-	out, outScope := b.buildStmt(b.stmt, &scope{builder: b})
-	root = out
+	outScope := b.buildStmt(b.stmt, &scope{builder: b})
+	root = outScope.group
 	required = b.buildPhysicalProps(outScope)
 	return root, required, nil
 }
@@ -143,21 +143,20 @@ func (b *Builder) buildPhysicalProps(scope *scope) *memo.PhysicalProps {
 // buildStmt builds a set of memo groups that represent the given SQL
 // statement.
 //
-// NOTE: The following description of the inScope parameter and return values
-//       applies for all buildXXX() functions in this directory.
+// NOTE: The following descriptions of the inScope parameter and outScope
+//       return value apply for all buildXXX() functions in this directory.
+//       Note that some buildXXX() functions pass outScope as a parameter
+//       rather than a return value so its scopeColumns can be built up
+//       incrementally across several function calls.
 //
 // inScope   This parameter contains the name bindings that are visible for this
 //           statement/expression (e.g., passed in from an enclosing statement).
 //
-// out       This return value corresponds to the top-level memo group ID for
-//           this statement/expression.
-//
 // outScope  This return value contains the newly bound variables that will be
 //           visible to enclosing statements, as well as a pointer to any
-//           "parent" scope that is still visible.
-func (b *Builder) buildStmt(
-	stmt tree.Statement, inScope *scope,
-) (out memo.GroupID, outScope *scope) {
+//           "parent" scope that is still visible. The top-level memo group ID
+//           for the built statement/expression is returned in outScope.group.
+func (b *Builder) buildStmt(stmt tree.Statement, inScope *scope) (outScope *scope) {
 	// NB: The case statements are sorted lexicographically.
 	switch stmt := stmt.(type) {
 	case *tree.ParenSelect:

--- a/pkg/sql/opt/optbuilder/distinct.go
+++ b/pkg/sql/opt/optbuilder/distinct.go
@@ -16,23 +16,17 @@ package optbuilder
 
 import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
-	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
 )
 
 // buildDistinct builds a set of memo groups that represent a DISTINCT
-// expression.
-//
-// in        contains the memo group ID of the input expression.
-// distinct  is true if this is a DISTINCT expression. If distinct is false,
-//           we just return `in, inScope`.
+// expression if distinct is true. If distinct is false, we just return
+// `inScope`.
 //
 // See Builder.buildStmt for a description of the remaining input and
 // return values.
-func (b *Builder) buildDistinct(
-	in memo.GroupID, distinct bool, inScope *scope,
-) (out memo.GroupID, outScope *scope) {
+func (b *Builder) buildDistinct(distinct bool, inScope *scope) (outScope *scope) {
 	if !distinct {
-		return in, inScope
+		return inScope
 	}
 
 	outScope = inScope.replace()
@@ -58,6 +52,9 @@ func (b *Builder) buildDistinct(
 		}
 	}
 
-	aggList := b.constructList(opt.AggregationsOp, nil, nil)
-	return b.factory.ConstructGroupBy(in, aggList, b.factory.InternColSet(groupCols)), outScope
+	aggList := b.constructList(opt.AggregationsOp, nil)
+	outScope.group = b.factory.ConstructGroupBy(
+		inScope.group, aggList, b.factory.InternColSet(groupCols),
+	)
+	return outScope
 }

--- a/pkg/sql/opt/optbuilder/limit.go
+++ b/pkg/sql/opt/optbuilder/limit.go
@@ -15,7 +15,6 @@
 package optbuilder
 
 import (
-	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
 )
@@ -26,11 +25,7 @@ import (
 // same as inScope, because statements like:
 //   SELECT k FROM kv LIMIT k
 // are not valid.
-func (b *Builder) buildLimit(
-	limit *tree.Limit, parentScope *scope, in memo.GroupID, inScope *scope,
-) (out memo.GroupID, outScope *scope) {
-	out, outScope = in, inScope
-
+func (b *Builder) buildLimit(limit *tree.Limit, parentScope, inScope *scope) {
 	ordering := inScope.physicalProps.Ordering
 	orderingPrivID := b.factory.InternOrdering(ordering)
 
@@ -39,14 +34,13 @@ func (b *Builder) buildLimit(
 		b.assertNoAggregationOrWindowing(limit.Offset, op)
 		texpr := parentScope.resolveAndRequireType(limit.Offset, types.Int, op)
 		offset := b.buildScalar(texpr, parentScope)
-		out = b.factory.ConstructOffset(out, offset, orderingPrivID)
+		inScope.group = b.factory.ConstructOffset(inScope.group, offset, orderingPrivID)
 	}
 	if limit.Count != nil {
 		op := "LIMIT"
 		b.assertNoAggregationOrWindowing(limit.Count, op)
 		texpr := parentScope.resolveAndRequireType(limit.Count, types.Int, op)
 		limit := b.buildScalar(texpr, parentScope)
-		out = b.factory.ConstructLimit(out, limit, orderingPrivID)
+		inScope.group = b.factory.ConstructLimit(inScope.group, limit, orderingPrivID)
 	}
-	return out, outScope
 }

--- a/pkg/sql/opt/optbuilder/scope.go
+++ b/pkg/sql/opt/optbuilder/scope.go
@@ -35,9 +35,12 @@ import (
 type scope struct {
 	builder       *Builder
 	parent        *scope
-	cols          []columnProps
+	cols          []scopeColumn
 	groupby       groupby
 	physicalProps memo.PhysicalProps
+
+	// group is the memo.GroupID of the relational operator built with this scope.
+	group memo.GroupID
 
 	// Desired number of columns for subqueries found during name resolution and
 	// type checking. This only applies to the top-level subqueries that are
@@ -78,7 +81,7 @@ func (s *scope) appendColumns(src *scope) {
 
 // appendColumn adds a new column to the scope with an optional new label.
 // It returns a pointer to the new column.
-func (s *scope) appendColumn(col *columnProps, label string) *columnProps {
+func (s *scope) appendColumn(col *scopeColumn, label string) *scopeColumn {
 	s.cols = append(s.cols, *col)
 	newCol := &s.cols[len(s.cols)-1]
 	if label != "" {
@@ -191,7 +194,7 @@ func (s *scope) removeHiddenCols() {
 
 // findExistingCol finds the given expression among the bound variables
 // in this scope. Returns nil if the expression is not found.
-func (s *scope) findExistingCol(expr tree.TypedExpr) *columnProps {
+func (s *scope) findExistingCol(expr tree.TypedExpr) *scopeColumn {
 	exprStr := symbolicExprStr(expr)
 	for i := range s.cols {
 		col := &s.cols[i]
@@ -205,7 +208,7 @@ func (s *scope) findExistingCol(expr tree.TypedExpr) *columnProps {
 
 // getAggregateCols returns the columns in this scope corresponding
 // to aggregate functions.
-func (s *scope) getAggregateCols() []columnProps {
+func (s *scope) getAggregateCols() []scopeColumn {
 	// Aggregates are always clustered at the end of the column list, in the
 	// same order as s.groupby.aggs.
 	return s.cols[len(s.cols)-len(s.groupby.aggs):]
@@ -213,7 +216,7 @@ func (s *scope) getAggregateCols() []columnProps {
 
 // findAggregate finds the given aggregate among the bound variables
 // in this scope. Returns nil if the aggregate is not found.
-func (s *scope) findAggregate(agg aggregateInfo) *columnProps {
+func (s *scope) findAggregate(agg aggregateInfo) *scopeColumn {
 	for i, a := range s.groupby.aggs {
 		// Find an existing aggregate that has the same function and the same
 		// arguments.
@@ -238,7 +241,7 @@ func (s *scope) findAggregate(agg aggregateInfo) *columnProps {
 
 // findGrouping finds the given grouping expression among the bound variables
 // in the groupingsScope. Returns nil if the grouping is not found.
-func (s *scope) findGrouping(grouping memo.GroupID) *columnProps {
+func (s *scope) findGrouping(grouping memo.GroupID) *scopeColumn {
 	for i, g := range s.groupby.groupings {
 		if g == grouping {
 			// Grouping already exists, so return information about the
@@ -284,7 +287,7 @@ func (s *scope) endAggFunc() {
 
 // scope implements the tree.Visitor interface so that it can walk through
 // a tree.Expr tree, perform name resolution, and replace unresolved column
-// names with a columnProps. The info stored in columnProps is necessary for
+// names with a scopeColumn. The info stored in scopeColumn is necessary for
 // Builder.buildScalar to construct a "variable" memo expression.
 var _ tree.Visitor = &scope{}
 
@@ -292,18 +295,18 @@ var _ tree.Visitor = &scope{}
 func (*scope) ColumnSourceMeta() {}
 
 // ColumnSourceMeta implements the tree.ColumnSourceMeta interface.
-func (*columnProps) ColumnSourceMeta() {}
+func (*scopeColumn) ColumnSourceMeta() {}
 
 // ColumnResolutionResult implements the tree.ColumnResolutionResult interface.
-func (*columnProps) ColumnResolutionResult() {}
+func (*scopeColumn) ColumnResolutionResult() {}
 
 // FindSourceProvidingColumn is part of the tree.ColumnItemResolver interface.
 func (s *scope) FindSourceProvidingColumn(
 	_ context.Context, colName tree.Name,
 ) (prefix *tree.TableName, srcMeta tree.ColumnSourceMeta, colHint int, err error) {
-	var candidateFromAnonSource *columnProps
-	var candidateWithPrefix *columnProps
-	var hiddenCandidate *columnProps
+	var candidateFromAnonSource *scopeColumn
+	var candidateWithPrefix *scopeColumn
+	var hiddenCandidate *scopeColumn
 	var moreThanOneCandidateFromAnonSource bool
 	var moreThanOneCandidateWithPrefix bool
 	var moreThanOneHiddenCandidate bool
@@ -442,7 +445,7 @@ func (s *scope) Resolve(
 ) (tree.ColumnResolutionResult, error) {
 	if colHint >= 0 {
 		// Column was found by FindSourceProvidingColumn above.
-		return srcMeta.(*columnProps), nil
+		return srcMeta.(*scopeColumn), nil
 	}
 
 	// Otherwise, a table is known but not the column yet.
@@ -499,7 +502,7 @@ func (s *scope) VisitPre(expr tree.Expr) (recurse bool, newExpr tree.Expr) {
 		if err != nil {
 			panic(builderError{err})
 		}
-		return false, colI.(*columnProps)
+		return false, colI.(*scopeColumn)
 
 	case *tree.FuncExpr:
 		def, err := t.Func.Resolve(s.builder.semaCtx.SearchPath)
@@ -598,7 +601,7 @@ func (s *scope) VisitPre(expr tree.Expr) (recurse bool, newExpr tree.Expr) {
 // number of columns and is used when the normal type checking machinery will
 // verify that the correct number of columns is returned.
 func (s *scope) replaceSubquery(sub *tree.Subquery, multiRow bool, desiredColumns int) *subquery {
-	out, outScope := s.builder.buildStmt(sub.Select, s)
+	outScope := s.builder.buildStmt(sub.Select, s)
 	if desiredColumns > 0 && len(outScope.cols) != desiredColumns {
 		n := len(outScope.cols)
 		switch desiredColumns {
@@ -611,7 +614,7 @@ func (s *scope) replaceSubquery(sub *tree.Subquery, multiRow bool, desiredColumn
 
 	return &subquery{
 		cols:     outScope.cols,
-		out:      out,
+		group:    outScope.group,
 		multiRow: multiRow,
 		exists:   sub.Exists,
 	}

--- a/pkg/sql/opt/optbuilder/values.go
+++ b/pkg/sql/opt/optbuilder/values.go
@@ -27,9 +27,7 @@ import (
 //
 // See Builder.buildStmt for a description of the remaining input and
 // return values.
-func (b *Builder) buildValuesClause(
-	values *tree.ValuesClause, inScope *scope,
-) (out memo.GroupID, outScope *scope) {
+func (b *Builder) buildValuesClause(values *tree.ValuesClause, inScope *scope) (outScope *scope) {
 	var numCols int
 	if len(values.Tuples) > 0 {
 		numCols = len(values.Tuples[0].Exprs)
@@ -73,10 +71,12 @@ func (b *Builder) buildValuesClause(
 	for i := 0; i < numCols; i++ {
 		// The column names for VALUES are column1, column2, etc.
 		label := fmt.Sprintf("column%d", i+1)
-		b.synthesizeColumn(outScope, label, colTypes[i], nil)
+		b.synthesizeColumn(outScope, label, colTypes[i], nil, 0 /* group */)
 	}
 
 	colList := colsToColList(outScope.cols)
-	out = b.factory.ConstructValues(b.factory.InternList(rows), b.factory.InternColList(colList))
-	return out, outScope
+	outScope.group = b.factory.ConstructValues(
+		b.factory.InternList(rows), b.factory.InternColList(colList),
+	)
+	return outScope
 }


### PR DESCRIPTION
This commit contains a minor refactoring of the `scope.go` and
`column_props.go` files in optbuilder. The main changes are:
- `column_props.go` is renamed to `scope_column.go`, and the
  `columnProps` struct is therefore renamed to `scopeColumn`. This
  name better explains the function of the struct: it represents
  a bound variable in a particular scope created as part of the
  build process.
- Both `scopeColumn` and `scope` have a new `group` field, which
  contains the memo group ID of the scalar or relational expression
  in the current scope after it has been added to the memo.

These changes allow some amount of simplification in other parts
of the builder code. Most notably, buildXXX functions no longer
need to return `(out memo.GroupID, outScope *scope)`. They can simply
return `(outScope *scope)`, since the memo group ID is already
contained in `outScope.group`.

Release note: None