### PR TITLE
workload/ycsb: improve key generation logic

### DIFF
--- a/pkg/workload/ycsb/zipfgenerator.go
+++ b/pkg/workload/ycsb/zipfgenerator.go
@@ -28,6 +28,13 @@ import (
 	"github.com/pkg/errors"
 )
 
+const (
+	// See https://github.com/brianfrankcooper/YCSB/blob/f886c1e7988f8f4965cb88a1fe2f6bad2c61b56d/core/src/main/java/com/yahoo/ycsb/generator/ScrambledZipfianGenerator.java#L33-L35
+	defaultIMax  = 10000000000
+	defaultTheta = 0.99
+	defaultZetaN = 26.46902820178302
+)
+
 // ZipfGenerator is a random number generator that generates draws from a Zipf
 // distribution. Unlike rand.Zipf, this generator supports incrementing the
 // imax parameter without performing an expensive recomputation of the
@@ -111,6 +118,11 @@ func computeZetaIncrementally(oldIMax, iMax uint64, theta float64, sum float64) 
 // The function zeta computes the value
 // zeta(n, theta) = (1/1)^theta + (1/2)^theta + (1/3)^theta + ... + (1/n)^theta
 func computeZetaFromScratch(n uint64, theta float64) (float64, error) {
+	if n == defaultIMax && theta == defaultTheta {
+		// Precomputed value, borrowed from ScrambledZipfianGenerator.java. (This is
+		// quite slow to calculate from scratch due to the large n value.)
+		return defaultZetaN, nil
+	}
 	zeta, err := computeZetaIncrementally(0, n, theta, 0.0)
 	if err != nil {
 		return zeta, errors.Errorf("could not compute zeta: %s", err)


### PR DESCRIPTION
Our YCSB row key generation logic was not quite matching the spec and
official implementation. We were sampling from a Zipfian distribution
with a max value equal to the number of rows. But the spec says to use a
distribution with a very large max value, and then hash and mod the
sampled value. This discrepancy was actually causing our key
distribution to be more skewed and therefore to have more contention and
worse performance. After this change, performance appears to be on par
with the official runner.

I also changed the keys from ints to strings to be more consistent with
the official runner.

Release note: None