### PR TITLE
workload: fix ycsb -splits flag

### DIFF
--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -449,6 +449,8 @@ func StringTuple(datums []interface{}) []string {
 		switch x := datum.(type) {
 		case int:
 			s[i] = strconv.Itoa(x)
+		case uint64:
+			s[i] = strconv.FormatUint(x, 10)
 		case string:
 			s[i] = lex.EscapeSQLString(x)
 		case float64:


### PR DESCRIPTION
The ycsb schema has a `uint64` key that is being split upon, so that
type needs to be supported by `StringTuple`.

Release note: None