### PR TITLE
sql: unreserve VIRTUAL and WORK keywords

### DIFF
--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -844,6 +844,8 @@ col_name_keyword ::=
 	| 'TRIM'
 	| 'VALUES'
 	| 'VARCHAR'
+	| 'VIRTUAL'
+	| 'WORK'
 
 with_clause ::=
 	'WITH' cte_list
@@ -1482,12 +1484,10 @@ reserved_keyword ::=
 	| 'USING'
 	| 'VARIADIC'
 	| 'VIEW'
-	| 'VIRTUAL'
 	| 'WHEN'
 	| 'WHERE'
 	| 'WINDOW'
 	| 'WITH'
-	| 'WORK'
 
 opt_equal ::=
 	'='

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -7677,6 +7677,8 @@ col_name_keyword:
 | TRIM
 | VALUES
 | VARCHAR
+| VIRTUAL
+| WORK
 
 // Type/function identifier --- keywords that can be type or function names.
 //
@@ -7794,11 +7796,9 @@ reserved_keyword:
 | USING
 | VARIADIC
 | VIEW
-| VIRTUAL
 | WHEN
 | WHERE
 | WINDOW
 | WITH
-| WORK
 
 %%


### PR DESCRIPTION
These shouldn't have been moved into the reserved keyword section.

I'll cherry-pick this into `release-2.0`.

Release note (sql change): permit VIRTUAL and WORK to be used as
unrestricted names again.