### PR TITLE
server: skip null config zones in diagnostic report

### DIFF
--- a/pkg/server/updates.go
+++ b/pkg/server/updates.go
@@ -320,11 +320,14 @@ func (s *Server) getReportingInfo(ctx context.Context) *diagnosticspb.Diagnostic
 		info.ZoneConfigs = make(map[int64]config.ZoneConfig)
 		for _, row := range datums {
 			id := int64(tree.MustBeDInt(row[0]))
-			configProto := []byte(*(row[1].(*tree.DBytes)))
 			var zone config.ZoneConfig
-			if err := protoutil.Unmarshal(configProto, &zone); err != nil {
-				log.Warningf(ctx, "unable to parse zone config %d: %v", id, err)
+			if bytes, ok := row[1].(*tree.DBytes); !ok {
 				continue
+			} else {
+				if err := protoutil.Unmarshal([]byte(*bytes), &zone); err != nil {
+					log.Warningf(ctx, "unable to parse zone config %d: %v", id, err)
+					continue
+				}
 			}
 			var anonymizedZone config.ZoneConfig
 			anonymizeZoneConfig(&anonymizedZone, zone, secret)

--- a/pkg/server/updates_test.go
+++ b/pkg/server/updates_test.go
@@ -161,6 +161,9 @@ func TestReportUsage(t *testing.T) {
 			t.Fatalf("error applying zone config %q to %q: %v", cmd.config, cmd.resource, err)
 		}
 	}
+	if _, err := db.Exec(`INSERT INTO system.zones (id, config) VALUES (10000, null)`); err != nil {
+		t.Fatal(err)
+	}
 
 	if _, err := db.Exec(
 		fmt.Sprintf(`CREATE TABLE %[1]s.%[1]s (%[1]s INT CONSTRAINT %[1]s CHECK (%[1]s > 1))`, elemName),
@@ -496,7 +499,7 @@ func TestReportUsage(t *testing.T) {
 		}
 	}
 
-	if expected, actual := 15, len(r.last.SqlStats); expected != actual {
+	if expected, actual := 16, len(r.last.SqlStats); expected != actual {
 		t.Fatalf("expected %d queries in stats report, got %d :\n %v", expected, actual, r.last.SqlStats)
 	}
 
@@ -516,6 +519,7 @@ func TestReportUsage(t *testing.T) {
 			`CREATE TABLE _ (_ INT PRIMARY KEY, _ INT, INDEX (_) INTERLEAVE IN PARENT _ (_))`,
 			`INSERT INTO _ VALUES (length($1::STRING))`,
 			`INSERT INTO _ VALUES (_)`,
+			`INSERT INTO _(_, _) VALUES (_, _)`,
 			`SELECT * FROM _ WHERE (_ = length($1::STRING)) OR (_ = $2)`,
 			`SELECT * FROM _ WHERE (_ = _) AND (_ = _)`,
 			`SELECT _ / $1`,


### PR DESCRIPTION
Fixes #24499.

This is intended for back port to 2.0 as well /cc @cockroachdb/release 