### PR TITLE
server: do not crash if diagnostics loop panics

### DIFF
--- a/pkg/cli/start.go
+++ b/pkg/cli/start.go
@@ -535,7 +535,7 @@ func runStart(cmd *cobra.Command, args []string) error {
 			// We don't do this in (*server.Server).Start() because we don't want it
 			// in tests.
 			if !envutil.EnvOrDefaultBool("COCKROACH_SKIP_UPDATE_CHECK", false) {
-				s.PeriodicallyCheckForUpdates()
+				s.PeriodicallyCheckForUpdates(ctx)
 			}
 
 			// Now inform the user that the server is running and tell the

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -555,6 +555,7 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 	if s.cfg.UseLegacyConnHandling {
 		s.registry.AddMetricStruct(s.sqlExecutor)
 	}
+	s.PeriodicallyClearStmtStats(ctx)
 
 	s.pgServer = pgwire.MakeServer(
 		s.cfg.AmbientCtx,

--- a/pkg/server/updates.go
+++ b/pkg/server/updates.go
@@ -101,6 +101,7 @@ type versionInfo struct {
 // phones home to check for updates and report usage.
 func (s *Server) PeriodicallyCheckForUpdates(ctx context.Context) {
 	s.stopper.RunWorker(ctx, func(ctx context.Context) {
+		defer log.RecoverAndReportNonfatalPanic(ctx, &s.st.SV)
 		startup := timeutil.Now()
 		nextUpdateCheck := startup
 		nextDiagnosticReport := startup

--- a/pkg/server/updates_test.go
+++ b/pkg/server/updates_test.go
@@ -63,7 +63,7 @@ func TestCheckVersion(t *testing.T) {
 	defer stubURL(&updatesURL, r.url)()
 
 	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
-	s.(*TestServer).checkForUpdates(time.Minute)
+	s.(*TestServer).checkForUpdates(ctx, time.Minute)
 	r.Close()
 	s.Stopper().Stop(ctx)
 
@@ -96,7 +96,7 @@ func TestCheckVersion(t *testing.T) {
 		// ensure nil, which happens when an empty env override URL is used, does not
 		// cause a crash. We've deferred a cleanup of the original pointer above.
 		updatesURL = nil
-		s.(*TestServer).checkForUpdates(time.Minute)
+		s.(*TestServer).checkForUpdates(ctx, time.Minute)
 	})
 }
 
@@ -265,7 +265,7 @@ func TestReportUsage(t *testing.T) {
 		expectedUsageReports++
 
 		node := ts.node.recorder.GetStatusSummary(ctx)
-		ts.reportDiagnostics(0)
+		ts.reportDiagnostics(ctx, 0)
 
 		keyCounts := make(map[roachpb.StoreID]int64)
 		rangeCounts := make(map[roachpb.StoreID]int64)

--- a/pkg/util/log/crash_reporting.go
+++ b/pkg/util/log/crash_reporting.go
@@ -101,6 +101,23 @@ func RecoverAndReportPanic(ctx context.Context, sv *settings.Values) {
 	}
 }
 
+// RecoverAndReportNonfatalPanic is an alternative RecoverAndReportPanic that
+// does not re-panic in Release builds.
+func RecoverAndReportNonfatalPanic(ctx context.Context, sv *settings.Values) {
+	if r := recover(); r != nil {
+		// The call stack here is usually:
+		// - ReportPanic
+		// - RecoverAndReport
+		// - panic.go
+		// - panic()
+		// so ReportPanic should pop four frames.
+		ReportPanic(ctx, sv, r, 4)
+		if !build.IsRelease() || PanicOnAssertions.Get(sv) {
+			panic(r)
+		}
+	}
+}
+
 // SafeMessager is implemented by objects which have a way of representing
 // themselves suitably redacted for anonymized reporting.
 type SafeMessager interface {


### PR DESCRIPTION
Losing diagnostics is a bummer for us (cockroach labs), but shouldn't cause a disruption for a user (unless they've overridden the diagnostics endpoint and are running an on-prem collector).

The one caveat is that the diagnostics loop is usually charged with periodically clearing the stmt stats stats that could otherwise grow unbounded -- so if we allow that loop to crash, we need a fallback that ensures they still get discarded (error counts counted by the fixed set of error/feature codes and are thus not unbounded).