### PR TITLE
cli: bump the libedit dep and fix linking isues

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,7 @@ new engineers.
        work due to https://gcc.gnu.org/bugzilla/show_bug.cgi?id=48891
      - The standard C/C++ development headers on your system.
      - On GNU/Linux, the terminfo development libraries, which may be
-       part of a ncurses development package (e.g. `libtinfo-dev` on
+       part of a ncurses development package (e.g. `libncurses-dev` on
        Debian/Ubuntu, but `ncurses-devel` on CentOS).
      - A Go environment with a recent 64-bit version of the toolchain. Note that
        the Makefile enforces the specific version required, as it is updated

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -697,8 +697,8 @@
     "unix",
     "unix/sigtramp",
   ]
-  revision = "92ff7be0fe45ff74fdea05fcbcaef25467f19779"
-  version = "v1.6.4"
+  revision = "69b759d6ff84df6bbd39846dae3670625cc0361b"
+  version = "v1.7"
 
 [[projects]]
   branch = "master"
@@ -1235,6 +1235,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "b468a68dc5e8ba7c498994d66a80fbe0ef7fccd7206a39fd03c407a116663161"
+  inputs-digest = "81eaf42becb4e2ce3bdcd0a5caddcce6d8e6aacce40a875788b55546db5eae44"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/build/bootstrap/bootstrap-debian.sh
+++ b/build/bootstrap/bootstrap-debian.sh
@@ -18,7 +18,7 @@ sudo apt-get install -y --no-install-recommends \
   cmake \
   ccache \
   docker.io \
-  libtinfo-dev \
+  libncurses-dev \
   git \
   nodejs \
   yarn

--- a/build/builder.sh
+++ b/build/builder.sh
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 image=cockroachdb/builder
-version=20180330-210116
+version=20180405-182035
 
 function init() {
   docker build --tag="${image}" "$(dirname "${0}")/builder"

--- a/build/builder/Dockerfile
+++ b/build/builder/Dockerfile
@@ -40,7 +40,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     make \
     patch \
     texinfo \
-    xz-utils
+    xz-utils \
+ && apt-get clean
 
 RUN mkdir crosstool-ng \
  && curl -fsSL http://crosstool-ng.org/download/crosstool-ng/crosstool-ng-1.23.0.tar.xz | tar --strip-components=1 -C crosstool-ng -xJ \
@@ -60,7 +61,7 @@ RUN mkdir src \
  && mkdir build && (cd build && DEFCONFIG=../aarch64-unknown-linux-gnueabi.defconfig /usr/local/ct-ng/bin/ct-ng defconfig && /usr/local/ct-ng/bin/ct-ng build) && rm -rf build \
  && rm -rf src
 
-# Build & install libtinfo (terminfo) for the linux targets (x86 and arm).
+# Build & install the terminfo lib (incl. in ncurses) for the linux targets (x86 and arm).
 # (on BSD or BSD-derived like macOS it's already built-in; on windows we don't need it.)
 #
 # The patch is needed to work around a bug in Debian mawk, see
@@ -90,7 +91,7 @@ RUN mkdir ncurses \
        ../configure --prefix=/x-tools/x86_64-unknown-linux-musl/x86_64-unknown-linux-musl/sysroot/usr \
          --host=x86_64-unknown-linux-musl \
          $(cat /ncurses.conf) --without-shared --without-dlsym \
-    && (cd ncurses && make all && make install.tinfo)) \
+    && (cd ncurses && make all && make install)) \
  && mkdir build-x86_64-unknown-linux-gnu \
  && (cd build-x86_64-unknown-linux-gnu \
     && CC=/x-tools/x86_64-unknown-linux-gnu/bin/x86_64-unknown-linux-gnu-cc \
@@ -98,7 +99,7 @@ RUN mkdir ncurses \
        ../configure --prefix=/x-tools/x86_64-unknown-linux-gnu/x86_64-unknown-linux-gnu/sysroot/usr \
          --host=x86_64-unknown-linux-gnu \
          $(cat /ncurses.conf) \
-    && (cd ncurses && make all && make install.tinfo)) \
+    && (cd ncurses && make all && make install)) \
  && mkdir build-aarch64-unknown-linux-gnueabi \
  && (cd build-aarch64-unknown-linux-gnueabi \
     && CC=/x-tools/aarch64-unknown-linux-gnueabi/bin/aarch64-unknown-linux-gnueabi-cc \
@@ -106,7 +107,7 @@ RUN mkdir ncurses \
        ../configure --prefix=/x-tools/aarch64-unknown-linux-gnueabi/aarch64-unknown-linux-gnueabi/sysroot/usr \
          --host=aarch64-unknown-linux-gnueabi \
          $(cat /ncurses.conf) \
-    && (cd ncurses && make all && make install.tinfo)) \
+    && (cd ncurses && make all && make install)) \
  && cd .. \
  && rm -rf ncurses ncurses.conf ncurses.patch
 

--- a/build/builder/ncurses.conf
+++ b/build/builder/ncurses.conf
@@ -16,6 +16,5 @@
 --with-default-terminfo-dir=/etc/terminfo
 --with-terminfo-dirs=/etc/terminfo:/lib/terminfo:/usr/share/terminfo
 --with-ticlib=tic
---with-termlib=tinfo
 --without-versioned-syms
 --with-xterm-kbs=del

--- a/build/verify-archive.sh
+++ b/build/verify-archive.sh
@@ -9,7 +9,7 @@
 set -euo pipefail
 
 apt-get update
-apt-get install -y autoconf cmake libtinfo-dev
+apt-get install -y autoconf cmake libncurses-dev
 
 workdir=$(mktemp -d)
 tar xzf cockroach.src.tgz -C "$workdir"

--- a/pkg/cmd/publish-artifacts/main.go
+++ b/pkg/cmd/publish-artifacts/main.go
@@ -67,6 +67,7 @@ var libsRe = func() *regexp.Regexp {
 		regexp.QuoteMeta("libpthread.so."),
 		regexp.QuoteMeta("libdl.so."),
 		regexp.QuoteMeta("libtinfo.so."),
+		regexp.QuoteMeta("libncurses.so."),
 		regexp.QuoteMeta("libm.so."),
 		regexp.QuoteMeta("libc.so."),
 		strings.Replace(regexp.QuoteMeta("ld-linux-ARCH.so."), "ARCH", ".*", -1),


### PR DESCRIPTION
Prior to this patch, the underlying `go-libedit` dependency would set
LDFLAGS to link on linux against libtinfo, mistakenly assuming that
this would cause the resulting Go binary to only use the subset of
whatever tinfo implementation on linux system dedicated to terminal
access.

The mistake is that there is no such thing -- there is no standad
standalone libtinfo on linux, and on most linux system it is either
a symlink to libncurses, or doesn't exist at all!

This patch corrects the issue by upgrading to the newest go-libedit
code which links against libncurses instead, which is guaranteed to
exist (it's been part of the Linux Standard Base forever).

The builder docker image is upgraded accordingly.

Release note (general change): Prevent execution errors reporting a
missing `libtinfo.so.5` on linux systems.

Fixes #24492.
