### PR TITLE
backport-2.0: backupccl: allow backup in mixed version clusters

### DIFF
--- a/pkg/ccl/backupccl/backup.go
+++ b/pkg/ccl/backupccl/backup.go
@@ -821,17 +821,7 @@ func backupPlanHook(
 			return errors.Errorf("BACKUP cannot be used inside a transaction")
 		}
 
-		// older nodes don't know about many new fields, e.g. MVCCAll and may
-		// incorrectly evaluate either an export RPC, or a resumed backup job.
-		// VersionClearRange was introduced after most of these new fields and the
-		// jobs resume refactorings, though we may still wish to bump this to 2.0
-		// when that is defined.
-		if !p.ExecCfg().Settings.Version.IsMinSupported(cluster.VersionClearRange) {
-			return errors.Errorf(
-				"running BACKUP on a 2.x node requires cluster version >= %s (",
-				cluster.VersionByKey(cluster.VersionClearRange).String(),
-			)
-		}
+		requireVersion2 := false
 
 		to, err := toFn()
 		if err != nil {
@@ -864,6 +854,7 @@ func backupPlanHook(
 		mvccFilter := MVCCFilter_Latest
 		if _, ok := opts[backupOptRevisionHistory]; ok {
 			mvccFilter = MVCCFilter_All
+			requireVersion2 = true
 		}
 
 		targetDescs, completeDBs, err := resolveTargetsToDescriptors(ctx, p, endTime, backupStmt.Targets)
@@ -993,6 +984,22 @@ func backupPlanHook(
 				return errors.Errorf("expected previous backups to cover until time %v, got %v", startTime, coveredTime)
 			}
 		}
+
+		// older nodes don't know about many new fields, e.g. MVCCAll and may
+		// incorrectly evaluate either an export RPC, or a resumed backup job.
+		if requireVersion2 && !p.ExecCfg().Settings.Version.IsMinSupported(cluster.Version2_0) {
+			return errors.Errorf(
+				"BACKUP features introduced in 2.0 requires cluster version >= %s (",
+				cluster.VersionByKey(cluster.Version2_0).String(),
+			)
+		}
+
+		// if CompleteDbs is lost by a 1.x node, FormatDescriptorTrackingVersion
+		// means that a 2.0 node will disallow `RESTORE DATABASE foo`, but `RESTORE
+		// foo.table1, foo.table2...` will still work. MVCCFilter would be
+		// mis-handled, but is disallowed above. IntroducedSpans may also be lost by
+		// a 1.x node, meaning that if 1.1 nodes may resume a backup, the limitation
+		// of requiring full backups after schema changes remains.
 
 		backupDesc := BackupDescriptor{
 			StartTime:         startTime,


### PR DESCRIPTION
Backport 1/1 commits from #24493.

/cc @cockroachdb/release

---

Our blanket restriction was too blunt: particularly if a cluster entirely
upgrades to 2.0 binaies but waits to bump the version -- our recommended
proceedure -- being unable to take backups until the version is bumped
is a serious limitation. Indeed, in that case, since all the nodes are
2.0 binaries, they actually include the updated descriptors, jobs fields
and wire messages that we were worried about being blanked by a 1.x
node, meaning that in the common, recommended case, our restirction is
disruptive and not even particularly useful.

A few specific features *must* not be used in mixed version clusters due
to particularly bad results of incorrect evaluation, like MVCC export
requests (which would silently be incorrect if handled by a 1.x node).
We should continue to check the cluster version on attempts to use those
but in general, where we do not know of serious correctness concerns, we
can probably be more permissive. We likely should continue to
*recommend* that all nodes be upgraded to 2.0 binaries before running
BACKUP, as some features like detecting schema changes or ensuring
correct target expansion may behave differently in mixed version
clusters. 

Fixes #24490

Release note (enterprise change): relax limitation on BACKUP in mixed version cluster.
