### PR TITLE
Revert "distsqlrun: stop calling processorBase.init() twice in the joinreader"

### DIFF
--- a/pkg/sql/distsqlrun/joinreader.go
+++ b/pkg/sql/distsqlrun/joinreader.go
@@ -91,6 +91,9 @@ func newJoinReader(
 
 	types := jr.getOutputTypes()
 
+	if err := jr.processorBase.init(post, types, flowCtx, nil /* evalCtx */, output); err != nil {
+		return nil, err
+	}
 	var err error
 	jr.index, _, err = jr.desc.FindIndexByIndexIdx(int(spec.IndexIdx))
 	if err != nil {
@@ -100,19 +103,22 @@ func newJoinReader(
 	for i := 0; i < len(jr.index.ColumnIDs); i++ {
 		indexCols[i] = uint32(jr.index.ColumnIDs[i])
 	}
-	if err := jr.joinerBase.init(
-		flowCtx,
-		input.OutputTypes(),
-		jr.desc.ColumnTypes(),
-		sqlbase.InnerJoin,
-		spec.OnExpr,
-		jr.lookupCols,
-		indexCols,
-		0, /* numMergedColumns */
-		post,
-		output,
-	); err != nil {
-		return nil, err
+	if len(jr.lookupCols) > 0 {
+		err = jr.joinerBase.init(
+			flowCtx,
+			input.OutputTypes(),
+			jr.desc.ColumnTypes(),
+			sqlbase.InnerJoin,
+			spec.OnExpr,
+			jr.lookupCols,
+			indexCols,
+			0, /* numMergedColumns */
+			post,
+			output,
+		)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	_, _, err = initRowFetcher(


### PR DESCRIPTION
Revert #24457

This reverts commit ba2aee3ec01e8ea8b9340b47d2430f70d4ffc7d6.

I don't know what's wrong but this causes all sorts of mayhem with the
nightly tests. Looking.

Fixes #24501