### PR TITLE
backport-2.0: stopper: downgrade a spammy log message to a log event

### DIFF
--- a/pkg/util/stop/stopper.go
+++ b/pkg/util/stop/stopper.go
@@ -288,7 +288,7 @@ func (s *Stopper) RunLimitedAsyncTask(
 		if !wait {
 			return ErrThrottled
 		}
-		log.Infof(ctx, "stopper throttling task from %s due to semaphore", taskName)
+		log.Eventf(ctx, "stopper throttling task from %s due to semaphore", taskName)
 		// Retry the select without the default.
 		select {
 		case sem <- struct{}{}:


### PR DESCRIPTION
Backport 1/1 commits from #24516.

/cc @cockroachdb/release

---

Downgrade a log message about "throttling async task" to a log
event. This occurs easily for the timeseries usage of `RunLimitedAsync`
task.

Fixes #24512

Release note: None
