### PR TITLE
scripts: Allow 'destroy' as an alias for 'delete'

### DIFF
--- a/scripts/azworker.sh
+++ b/scripts/azworker.sh
@@ -86,7 +86,7 @@ case ${1-} in
   stop)
     az vm deallocate -g "${RG}" -n "${NAME}"
     ;;
-  delete)
+  delete|destroy)
     # The straightforward thing to do would be to first delete the VM, then
     # check if there are any virtual machines left in the group. However, the
     # deleted VM doesn't disappear right away from the listing. So we instead

--- a/scripts/gceworker.sh
+++ b/scripts/gceworker.sh
@@ -45,7 +45,7 @@ case "${cmd}" in
     stop)
     gcloud compute instances stop "${NAME}"
     ;;
-    delete)
+    delete|destroy)
     gcloud compute instances delete "${NAME}"
     ;;
     ssh)


### PR DESCRIPTION
"Destroy" feels like the more natural verb for this action to me (it's
also used for this purpose in roachprod). Every time I recreate a
worker VM I run `destroy` first, see it fail, and have to rerun with
`delete`.

Release note: None