### PR TITLE
roachtest: allow test registration to use flags

### DIFF
--- a/pkg/cmd/roachtest/allocator.go
+++ b/pkg/cmd/roachtest/allocator.go
@@ -26,7 +26,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-func init() {
+func registerAllocator(r *registry) {
 	runAllocator := func(ctx context.Context, t *test, c *cluster, start int, maxStdDev float64) {
 		const fixturePath = `gs://cockroach-fixtures/workload/tpch/scalefactor=10/backup`
 		c.Put(ctx, cockroach, "./cockroach")
@@ -75,14 +75,14 @@ func init() {
 		m.Wait()
 	}
 
-	tests.Add(testSpec{
+	r.Add(testSpec{
 		Name:  `upreplicate/1to3`,
 		Nodes: nodes(3),
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			runAllocator(ctx, t, c, 1, 10.0)
 		},
 	})
-	tests.Add(testSpec{
+	r.Add(testSpec{
 		Name:  `rebalance/3to5`,
 		Nodes: nodes(5),
 		Run: func(ctx context.Context, t *test, c *cluster) {

--- a/pkg/cmd/roachtest/backup.go
+++ b/pkg/cmd/roachtest/backup.go
@@ -21,8 +21,8 @@ import (
 	"sync"
 )
 
-func init() {
-	tests.Add(testSpec{
+func registerBackup(r *registry) {
+	r.Add(testSpec{
 		Name:  `backup2TB`,
 		Nodes: nodes(10),
 		Run: func(ctx context.Context, t *test, c *cluster) {

--- a/pkg/cmd/roachtest/cancel.go
+++ b/pkg/cmd/roachtest/cancel.go
@@ -37,7 +37,7 @@ import (
 //
 // Once DistSQL queries provide more testing knobs, these tests can likely be
 // replaced with unit tests.
-func init() {
+func registerCancel(r *registry) {
 	runCancel := func(ctx context.Context, t *test, c *cluster,
 		queries []string, warehouses int, useDistsql bool) {
 		c.Put(ctx, cockroach, "./cockroach", c.All())
@@ -116,7 +116,7 @@ func init() {
 		`SELECT ol_number, sum(s_quantity) FROM tpcc.stock JOIN tpcc.order_line ON s_i_id=ol_i_id WHERE ol_number > 10 GROUP BY ol_number ORDER BY ol_number`,
 	}
 
-	tests.Add(testSpec{
+	r.Add(testSpec{
 		Name:  fmt.Sprintf("cancel/tpcc/distsql/w=%d,nodes=%d", warehouses, numNodes),
 		Nodes: nodes(numNodes),
 		Run: func(ctx context.Context, t *test, c *cluster) {
@@ -124,7 +124,7 @@ func init() {
 		},
 	})
 
-	tests.Add(testSpec{
+	r.Add(testSpec{
 		Name:  fmt.Sprintf("cancel/tpcc/local/w=%d,nodes=%d", warehouses, numNodes),
 		Nodes: nodes(numNodes),
 		Run: func(ctx context.Context, t *test, c *cluster) {

--- a/pkg/cmd/roachtest/copy.go
+++ b/pkg/cmd/roachtest/copy.go
@@ -26,7 +26,7 @@ import (
 	"github.com/cockroachdb/cockroach-go/crdb"
 )
 
-func init() {
+func registerCopy(r *registry) {
 	// This test imports a fully-populated Bank table. It then creates an empty
 	// Bank schema. Finally, it performs a series of `INSERT ... SELECT ...`
 	// statements to copy all data from the first table into the second table.
@@ -138,7 +138,7 @@ func init() {
 
 	for _, inTxn := range []bool{true, false} {
 		inTxn := inTxn
-		tests.Add(testSpec{
+		r.Add(testSpec{
 			Name:  fmt.Sprintf("copy/bank/rows=%d,nodes=%d,txn=%t", rows, numNodes, inTxn),
 			Nodes: nodes(numNodes),
 			Run: func(ctx context.Context, t *test, c *cluster) {

--- a/pkg/cmd/roachtest/decommission.go
+++ b/pkg/cmd/roachtest/decommission.go
@@ -175,11 +175,11 @@ func runDecommission(t *test, c *cluster, nodes int, duration time.Duration) {
 	}
 }
 
-func init() {
+func registerDecommission(r *registry) {
 	const numNodes = 4
 	duration := time.Hour
 
-	tests.Add(testSpec{
+	r.Add(testSpec{
 		Name:  fmt.Sprintf("decommission/nodes=%d/duration=%s", numNodes, duration),
 		Nodes: nodes(numNodes),
 		Run: func(ctx context.Context, t *test, c *cluster) {

--- a/pkg/cmd/roachtest/drop.go
+++ b/pkg/cmd/roachtest/drop.go
@@ -27,7 +27,7 @@ import (
 	_ "github.com/lib/pq"
 )
 
-func init() {
+func registerDrop(r *registry) {
 	// TODO(tschottdorf): rearrange all tests so that their synopses are available
 	// via godoc and (some variation on) `roachtest run <testname> --help`.
 
@@ -158,7 +158,7 @@ gc:
 	// 1GB
 	initDiskSpace := int(1E9)
 
-	tests.Add(testSpec{
+	r.Add(testSpec{
 		Name:  fmt.Sprintf("drop/tpcc/w=%d,nodes=%d", warehouses, numNodes),
 		Nodes: nodes(numNodes),
 		Run: func(ctx context.Context, t *test, c *cluster) {

--- a/pkg/cmd/roachtest/import.go
+++ b/pkg/cmd/roachtest/import.go
@@ -24,7 +24,7 @@ const (
 	gcsTestBucket = `cockroach-tmp`
 )
 
-func init() {
+func registerImportTPCC(r *registry) {
 	runImportTPCC := func(ctx context.Context, t *test, c *cluster, warehouses int) {
 		c.Put(ctx, cockroach, "./cockroach")
 		c.Put(ctx, workload, "./workload")
@@ -47,7 +47,7 @@ func init() {
 
 	const warehouses = 1000
 	const numNodes = 4
-	tests.Add(testSpec{
+	r.Add(testSpec{
 		Name:  fmt.Sprintf("import/tpcc/warehouses=%d/nodes=%d", warehouses, numNodes),
 		Nodes: nodes(numNodes),
 		Run: func(ctx context.Context, t *test, c *cluster) {
@@ -56,9 +56,9 @@ func init() {
 	})
 }
 
-func init() {
+func registerImportTPCH(r *registry) {
 	for _, n := range []int{4, 8} {
-		tests.Add(testSpec{
+		r.Add(testSpec{
 			Name:  fmt.Sprintf(`import/tpch/nodes=%d`, n),
 			Nodes: nodes(n),
 			Run: func(ctx context.Context, t *test, c *cluster) {

--- a/pkg/cmd/roachtest/jepsen.go
+++ b/pkg/cmd/roachtest/jepsen.go
@@ -218,8 +218,8 @@ cd jepsen/cockroachdb && set -eo pipefail && \
 	}
 }
 
-func init() {
-	tests.Add(testSpec{
+func registerJepsen(r *registry) {
+	r.Add(testSpec{
 		Name:  "jepsen",
 		Nodes: nodes(6),
 		Run:   runJepsen,

--- a/pkg/cmd/roachtest/kv.go
+++ b/pkg/cmd/roachtest/kv.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 )
 
-func init() {
+func registerKV(r *registry) {
 	runKV := func(ctx context.Context, t *test, c *cluster, percent int) {
 		nodes := c.nodes - 1
 		c.Put(ctx, cockroach, "./cockroach", c.Range(1, nodes))
@@ -46,7 +46,7 @@ func init() {
 	for _, p := range []int{0, 95} {
 		p := p
 		for _, n := range []int{1, 3} {
-			tests.Add(testSpec{
+			r.Add(testSpec{
 				Name:  fmt.Sprintf("kv%d/nodes=%d", p, n),
 				Nodes: nodes(n + 1),
 				Run: func(ctx context.Context, t *test, c *cluster) {
@@ -57,8 +57,8 @@ func init() {
 	}
 }
 
-func init() {
-	tests.Add(testSpec{
+func registerKVSplits(r *registry) {
+	r.Add(testSpec{
 		Name:  "kv/splits/nodes=3",
 		Nodes: nodes(4),
 		Run: func(ctx context.Context, t *test, c *cluster) {
@@ -85,7 +85,7 @@ func init() {
 	})
 }
 
-func init() {
+func registerKVScalability(r *registry) {
 	runScalability := func(ctx context.Context, t *test, c *cluster, percent int) {
 		nodes := c.nodes - 1
 
@@ -128,7 +128,7 @@ func init() {
 	if false {
 		for _, p := range []int{0, 95} {
 			p := p
-			tests.Add(testSpec{
+			r.Add(testSpec{
 				Name:  fmt.Sprintf("kv%d/scale/nodes=6", p),
 				Nodes: nodes(7, cpu(8)),
 				Run: func(ctx context.Context, t *test, c *cluster) {

--- a/pkg/cmd/roachtest/large_range.go
+++ b/pkg/cmd/roachtest/large_range.go
@@ -27,7 +27,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-func init() {
+func registerLargeRange(r *registry) {
 	const size = 10 << 30 // 10 GB
 	// TODO(nvanbenschoten): Snapshots currently hold the entirety of a range in
 	// memory on the receiving side. This is dangerous when we grow a range to
@@ -37,7 +37,7 @@ func init() {
 	// splitting the single large range also triggers rebalancing.
 	const numNodes = 3
 
-	tests.Add(testSpec{
+	r.Add(testSpec{
 		Name:  fmt.Sprintf("largerange/splits/size=%s,nodes=%d", bytesStr(size), numNodes),
 		Nodes: nodes(numNodes),
 		Run: func(ctx context.Context, t *test, c *cluster) {

--- a/pkg/cmd/roachtest/main.go
+++ b/pkg/cmd/roachtest/main.go
@@ -18,7 +18,6 @@ package main
 import (
 	"fmt"
 	"os"
-	"strings"
 
 	"github.com/spf13/cobra"
 )
@@ -38,7 +37,7 @@ func main() {
 		Short: "run automated tests on cockroach cluster\n",
 		Long: `Run automated tests on existing or ephemeral cockroach clusters.
 
-	` + strings.Join(allTests(), "\n\t") + `
+Use 'roachtest run -n' to see a list of all tests.
 `,
 		RunE: func(_ *cobra.Command, args []string) error {
 			if clusterName != "" && local {
@@ -46,7 +45,10 @@ func main() {
 			}
 
 			initBinaries()
-			os.Exit(tests.Run(args))
+
+			r := newRegistry()
+			registerTests(r)
+			os.Exit(r.Run(args))
 			return nil
 		},
 	}

--- a/pkg/cmd/roachtest/registry.go
+++ b/pkg/cmd/roachtest/registry.go
@@ -1,0 +1,42 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+
+package main
+
+func registerTests(r *registry) {
+	// Helpful shell pipeline to generate the list below:
+	//
+	// grep -h -E 'func register[^(]+\(.*registry\) {' *.go | grep -E -o 'register[^(]+' | grep -v '^registerTests$' | sort | awk '{printf "\t%s(r)\n", $0}'
+
+	registerAllocator(r)
+	registerBackup(r)
+	registerCancel(r)
+	registerCopy(r)
+	registerDecommission(r)
+	registerDrop(r)
+	registerImportTPCC(r)
+	registerImportTPCH(r)
+	registerJepsen(r)
+	registerKV(r)
+	registerKVScalability(r)
+	registerKVSplits(r)
+	registerLargeRange(r)
+	registerRestore(r)
+	registerRoachmart(r)
+	registerScaleData(r)
+	registerSchemaChange(r)
+	registerTPCC(r)
+	registerVersion(r)
+}

--- a/pkg/cmd/roachtest/restore.go
+++ b/pkg/cmd/roachtest/restore.go
@@ -19,8 +19,8 @@ import (
 	"context"
 )
 
-func init() {
-	tests.Add(testSpec{
+func registerRestore(r *registry) {
+	r.Add(testSpec{
 		Name:  `restore2TB`,
 		Nodes: nodes(10),
 		Run: func(ctx context.Context, t *test, c *cluster) {

--- a/pkg/cmd/roachtest/roachmart.go
+++ b/pkg/cmd/roachtest/roachmart.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 )
 
-func init() {
+func registerRoachmart(r *registry) {
 	runRoachmart := func(ctx context.Context, t *test, c *cluster, partition bool) {
 		c.Put(ctx, cockroach, "./cockroach")
 		c.Put(ctx, workload, "./workload")
@@ -73,7 +73,7 @@ func init() {
 
 	for _, v := range []bool{true, false} {
 		v := v
-		tests.Add(testSpec{
+		r.Add(testSpec{
 			Name:  fmt.Sprintf("roachmart/partition=%v", v),
 			Nodes: nodes(9, geo()),
 			Run: func(ctx context.Context, t *test, c *cluster) {

--- a/pkg/cmd/roachtest/scaledata.go
+++ b/pkg/cmd/roachtest/scaledata.go
@@ -26,7 +26,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/binfetcher"
 )
 
-func init() {
+func registerScaleData(r *registry) {
 	// apps is a suite of Sqlapp applications designed to be used to check the
 	// consistency of a database under load. Each Sqlapp application launches a
 	// set of workers who perform database operations while another worker
@@ -46,7 +46,7 @@ func init() {
 		app, flags := app, flags // copy loop iterator vars
 		const duration = 10 * time.Minute
 		for _, n := range []int{3, 6} {
-			tests.Add(testSpec{
+			r.Add(testSpec{
 				Name:  fmt.Sprintf("scaledata/%s/nodes=%d", app, n),
 				Nodes: nodes(n + 1),
 				Run: func(ctx context.Context, t *test, c *cluster) {

--- a/pkg/cmd/roachtest/schemachange.go
+++ b/pkg/cmd/roachtest/schemachange.go
@@ -25,8 +25,8 @@ import (
 	"github.com/pkg/errors"
 )
 
-func init() {
-	tests.Add(testSpec{
+func registerSchemaChange(r *registry) {
+	r.Add(testSpec{
 		Name:  `schemachange`,
 		Nodes: nodes(5),
 		Run: func(ctx context.Context, t *test, c *cluster) {

--- a/pkg/cmd/roachtest/test.go
+++ b/pkg/cmd/roachtest/test.go
@@ -36,20 +36,10 @@ import (
 )
 
 var (
-	tests       = &registry{m: make(map[string]*test), out: os.Stdout}
 	parallelism = 10
 	debug       = false
 	dryrun      = false
 )
-
-func allTests() []string {
-	t := tests.List(nil)
-	r := make([]string, len(t))
-	for i := range t {
-		r[i] = t[i].Name()
-	}
-	return r
-}
 
 type testSpec struct {
 	Name string
@@ -62,6 +52,10 @@ type registry struct {
 	m              map[string]*test
 	out            io.Writer
 	statusInterval time.Duration
+}
+
+func newRegistry() *registry {
+	return &registry{m: make(map[string]*test), out: os.Stdout}
 }
 
 func (r *registry) Add(spec testSpec) {

--- a/pkg/cmd/roachtest/tpcc.go
+++ b/pkg/cmd/roachtest/tpcc.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 )
 
-func init() {
+func registerTPCC(r *registry) {
 	runTPCC := func(ctx context.Context, t *test, c *cluster, warehouses int, extra string) {
 		nodes := c.nodes - 1
 
@@ -42,14 +42,14 @@ func init() {
 		m.Wait()
 	}
 
-	tests.Add(testSpec{
+	r.Add(testSpec{
 		Name:  "tpcc/w=1/nodes=3",
 		Nodes: nodes(4),
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			runTPCC(ctx, t, c, 1, " --wait=false")
 		},
 	})
-	tests.Add(testSpec{
+	r.Add(testSpec{
 		Name:  "tpmc/w=1/nodes=3",
 		Nodes: nodes(4),
 		Run: func(ctx context.Context, t *test, c *cluster) {

--- a/pkg/cmd/roachtest/version.go
+++ b/pkg/cmd/roachtest/version.go
@@ -30,7 +30,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/binfetcher"
 )
 
-func init() {
+func registerVersion(r *registry) {
 	runVersion := func(ctx context.Context, t *test, c *cluster, version string) {
 		nodes := c.nodes - 1
 		goos := ifLocal(runtime.GOOS, "linux")
@@ -209,7 +209,7 @@ func init() {
 
 	const version = "v1.1.5"
 	for _, n := range []int{3, 5} {
-		tests.Add(testSpec{
+		r.Add(testSpec{
 			Name:  fmt.Sprintf("version/mixedWith=%s/nodes=%d", version, n),
 			Nodes: nodes(n + 1),
 			Run: func(ctx context.Context, t *test, c *cluster) {


### PR DESCRIPTION
Add a central `registerTests` function to register tests just before
execution. This allows tests registration to utilize command line
flags. `registerTests` is automatically constructed by looking for
global functions with the signature `register*(*registry)`.

Fixes #24461

Release note: None