### PR TITLE
scripts: fix release note script for bors

### DIFF
--- a/scripts/release-notes.py
+++ b/scripts/release-notes.py
@@ -471,10 +471,10 @@ print()
 ## Print the Contributors section.
 print("### Contributors")
 print()
-print("This release includes %d merged PRs by %s author%s." %
-      (len(allprs),
+print("This release includes %d merged PR%s by %s author%s." %
+      (len(allprs), len(allprs) != 1 and "s" or "",
        len(individual_authors), (len(individual_authors) != 1 and "s" or ""),
-      ), end=' ')
+      ), end='')
 
 ext_contributors = individual_authors - crdb_folk
 
@@ -483,7 +483,7 @@ if len(ext_contributors) > 0:
     # # Note: CRDB folk can be first-time contributors too, so
     # # not part of the if ext_contributors above.
     if len(firsttime_contributors) > 0:
-        print("We would like to thank the following contributors from the CockroachDB community, with special thanks to first-time contributors ", end='')
+        print(" We would like to thank the following contributors from the CockroachDB community, with special thanks to first-time contributors ", end='')
         for i, n in enumerate(firsttime_contributors):
             if i > 0 and i < len(firsttime_contributors)-1:
                 print(', ', end='')
@@ -492,11 +492,13 @@ if len(ext_contributors) > 0:
             print(n, end='')
         print('.')
     else:
-        print("We would like to thank the following contributors from the CockroachDB community:")
+        print(" We would like to thank the following contributors from the CockroachDB community:")
         print()
     for a in ext_contributors:
         print("-", a)
+else:
     print()
+print()
 
 ## Print the per-author contribution list.
 if not hidepercontributor:

--- a/scripts/release-notes.py
+++ b/scripts/release-notes.py
@@ -211,8 +211,19 @@ hidedownloads = options.hide_downloads
 repo = Repo('.')
 heads = repo.heads
 
-firstCommit = repo.commit(options.from_commit)
-commit = repo.commit(options.until_commit)
+try:
+    firstCommit = repo.commit(options.from_commit)
+except:
+    print("Unable to find the first commit of the range.", file=sys.stderr)
+    print("No ref named %s." % options.from_commit, file=sys.stderr)
+    exit(0)
+
+try:
+    commit = repo.commit(options.until_commit)
+except:
+    print("Unable to find the last commit of the range.", file=sys.stderr)
+    print("No ref named %s." % options.until_commit, file=sys.stderr)
+    exit(0)
 
 if commit == firstCommit:
     print("Commit range is empty!", file=sys.stderr)
@@ -224,7 +235,16 @@ if commit == firstCommit:
     print("Note: the first commit is excluded. Use e.g.: --from <prev-release-tag> --until <new-release-candidate-sha>", file=sys.stderr)
     exit(0)
 
-# TODO(couchand): check here that pull_ref_prefix is valid
+# Check that pull_ref_prefix is valid
+testrefname = "%s/1" % pull_ref_prefix
+try:
+    repo.commit(testrefname)
+except:
+    print("Unable to find pull request refs at %s." % pull_ref_prefix, file=sys.stderr)
+    print("Is your repo set up to fetch them?  Try adding", file=sys.stderr)
+    print("  fetch = +refs/pull/*/head:%s/*" % pull_ref_prefix, file=sys.stderr)
+    print("to the GitHub remote section of .git/config.", file=sys.stderr)
+    exit(0)
 
 ### Reading data from repository ###
 

--- a/scripts/release-notes.py
+++ b/scripts/release-notes.py
@@ -57,6 +57,7 @@ author_aliases = {
     'rytaft': "Rebecca Taft",
     'songhao': "Song Hao",
     'solongordon': "Solon Gordon",
+    'Amruta': "Amruta Ranade",
 }
 
 # FIXME(knz): This too.
@@ -71,6 +72,7 @@ crdb_folk = set([
     "Andy Woods",
     "Arjun Narayan",
     "Ben Darnell",
+    "Bob Vawter",
     "Bram Gruneir",
     "Daniel Harrison",
     "David Taylor",
@@ -81,6 +83,7 @@ crdb_folk = set([
     "Jordan Lewis",
     "Justin Jaffray",
     "Kuan Luo",
+    "Lauren Hirata",
     "Marc Berhault",
     "Masha Schneider",
     "Matt Jibson",
@@ -100,6 +103,7 @@ crdb_folk = set([
     "Spencer Kimball",
     "Tamir Duberstein",
     "Tobias Schottdorf",
+    "Victor Chen",
     "Vivek Menezes",
 ])
 

--- a/scripts/release-notes.py
+++ b/scripts/release-notes.py
@@ -176,8 +176,6 @@ relnote = re.compile(r'(?:^|[\n\r])[rR]elease [nN]otes? *(?:' + form1 + '|' + fo
 # Merge pull request #XXXXX from ...      <- GitHub merges
 # Merge #XXXXX #XXXXX #XXXXX              <- Bors merges
 merge_numbers = re.compile(r'^Merge( pull request)?(?P<numbers>( #[0-9]+)+)')
-# TODO(couchand): handle this:
-# <some PR title/commit message> (#XXXXX) <- GitHub squash merges
 
 ### Initialization / option parsing ###
 


### PR DESCRIPTION
Since Bors merges with a slightly different message and a
significantly different strategy compared to GitHub, the
pattern matching and logic for the release notes script
was broken by the introduction of the Bors workflow.  This
fixes the script to account for the various merge types.

Merged PRs are now found by git ref.  This requires that
you configure your local repo to pull the PR refs from
GitHub.  To do this, add a line like:

    fetch = +refs/pull/*/head:refs/pull/origin/*

to the GitHub remote section of .git/config, then run
`git fetch -a` to pull them down.

Fixes: #24418
Release note: None