### PR TITLE
sql: add tests regarding all datum types

### DIFF
--- a/pkg/sql/coltypes/invariants_test.go
+++ b/pkg/sql/coltypes/invariants_test.go
@@ -1,0 +1,37 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package coltypes
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
+)
+
+func TestCanConvertBetweenDatumTypeAndColumnType(t *testing.T) {
+	for _, typ := range types.AnyNonArray {
+		coltyp, err := DatumTypeToColumnType(typ)
+		if err != nil {
+			t.Errorf("can't convert %s to a column type", typ)
+		}
+
+		// This panics in the event of an unhandled type.
+		resultTyp := CastTargetToDatumType(coltyp)
+
+		if !resultTyp.Equivalent(typ) {
+			t.Errorf("expected %s to equal %s", resultTyp, typ)
+		}
+	}
+}

--- a/pkg/sql/pgwire/types_test.go
+++ b/pkg/sql/pgwire/types_test.go
@@ -17,6 +17,7 @@ package pgwire
 import (
 	"bytes"
 	"context"
+	"math/rand"
 	"reflect"
 	"testing"
 	"time"
@@ -28,8 +29,10 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgwirebase"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 )
 
 // The assertions in this test should also be caught by the integration tests on
@@ -136,6 +139,39 @@ func TestIntArrayRoundTrip(t *testing.T) {
 	defer evalCtx.Stop(context.Background())
 	if got.Compare(evalCtx, d) != 0 {
 		t.Fatalf("expected %s, got %s", d, got)
+	}
+}
+
+func TestCanWriteAllDatums(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	rng := rand.New(rand.NewSource(timeutil.Now().Unix()))
+
+	for _, typ := range types.AnyNonArray {
+		buf := newWriteBuffer(nil /* bytecount */)
+
+		semtyp, err := sqlbase.DatumTypeToColumnSemanticType(typ)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		for i := 0; i < 10; i++ {
+			d := sqlbase.RandDatum(rng, sqlbase.ColumnType{SemanticType: semtyp}, true)
+
+			buf.writeTextDatum(context.Background(), d, time.UTC)
+			if buf.err != nil {
+				t.Fatalf("got %s while attempting to write datum %s as text", buf.err, d)
+			}
+
+			// TODO(justin): #24525.
+			if typ == types.Interval {
+				continue
+			}
+			buf.writeBinaryDatum(context.Background(), d, time.UTC)
+			if buf.err != nil {
+				t.Fatalf("got %s while attempting to write datum %s as binary", buf.err, d)
+			}
+		}
 	}
 }
 

--- a/pkg/sql/sem/builtins/builtins_test.go
+++ b/pkg/sql/sem/builtins/builtins_test.go
@@ -165,3 +165,13 @@ func TestEscapeFormatRandom(t *testing.T) {
 		}
 	}
 }
+
+func TestAllTypesAsJSON(t *testing.T) {
+	for _, typ := range types.AnyNonArray {
+		d := tree.SampleDatum(typ)
+		_, err := AsJSON(d)
+		if err != nil {
+			t.Errorf("couldn't convert %s to JSON: %s", d, err)
+		}
+	}
+}

--- a/pkg/sql/sem/tree/datum_invariants_test.go
+++ b/pkg/sql/sem/tree/datum_invariants_test.go
@@ -1,0 +1,37 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package tree
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
+)
+
+func TestAllTypesCastableToString(t *testing.T) {
+	for _, typ := range types.AnyNonArray {
+		if !isCastDeepValid(typ, types.String) {
+			t.Errorf("%s is not castable to STRING, all types should be", typ)
+		}
+	}
+}
+
+func TestAllTypesCastableFromString(t *testing.T) {
+	for _, typ := range types.AnyNonArray {
+		if !isCastDeepValid(types.String, typ) {
+			t.Errorf("%s is not castable from STRING, all types should be", typ)
+		}
+	}
+}

--- a/pkg/sql/sem/tree/testutils.go
+++ b/pkg/sql/sem/tree/testutils.go
@@ -14,7 +14,14 @@
 
 package tree
 
-import "github.com/cockroachdb/cockroach/pkg/sql/sem/types"
+import (
+	"fmt"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
+	"github.com/cockroachdb/cockroach/pkg/util/timeofday"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+)
 
 // presetTypesForTesting is a mapping of qualified names to types that can be mocked out
 // for tests to allow the qualified names to be type checked without throwing an error.
@@ -25,5 +32,53 @@ func MockNameTypes(types map[string]types.T) func() {
 	presetTypesForTesting = types
 	return func() {
 		presetTypesForTesting = nil
+	}
+}
+
+// SampleDatum is intended to be a more lightweight version of RandDatum for
+// when you just need one consistent example of a datum.
+func SampleDatum(t types.T) Datum {
+	switch t {
+	case types.Bool:
+		return MakeDBool(true)
+	case types.Int:
+		return NewDInt(123)
+	case types.Float:
+		f := DFloat(123.456)
+		return &f
+	case types.Decimal:
+		d := &DDecimal{}
+		d.Decimal.SetExponent(6)
+		// int64(rng.Uint64()) to get negative numbers, too
+		d.Decimal.SetCoefficient(3)
+		return d
+	case types.String:
+		return NewDString("Carl")
+	case types.Bytes:
+		return NewDBytes("Princess")
+	case types.Date:
+		return NewDDate(123123)
+	case types.Time:
+		return MakeDTime(timeofday.FromInt(789))
+	case types.Timestamp:
+		return MakeDTimestamp(timeutil.Unix(123, 123), time.Second)
+	case types.TimestampTZ:
+		return MakeDTimestampTZ(timeutil.Unix(123, 123), time.Second)
+	case types.Interval:
+		i, _ := ParseDInterval("1h1m1s")
+		return i
+	case types.UUID:
+		u, _ := ParseDUuidFromString("3189ad07-52f2-4d60-83e8-4a8347fef718")
+		return u
+	case types.INet:
+		i, _ := ParseDIPAddrFromINetString("127.0.0.1")
+		return i
+	case types.JSON:
+		j, _ := ParseDJSON(`{"a": "b"}`)
+		return j
+	case types.Oid:
+		return NewDOid(DInt(1009))
+	default:
+		panic(fmt.Sprintf("SampleDatum not implemented for %s", t))
 	}
 }

--- a/pkg/sql/sem/types/invariants_test.go
+++ b/pkg/sql/sem/types/invariants_test.go
@@ -1,0 +1,33 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package types
+
+import (
+	"testing"
+
+	"github.com/lib/pq/oid"
+)
+
+func TestArraysHaveOids(t *testing.T) {
+	for _, typ := range AnyNonArray {
+		if !IsValidArrayElementType(typ) {
+			continue
+		}
+
+		if (TArray{Typ: typ}).Oid() == oid.Oid(0) {
+			t.Errorf("%s[] does not have a valid OID", typ)
+		}
+	}
+}

--- a/pkg/sql/sqlbase/structured_test.go
+++ b/pkg/sql/sqlbase/structured_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
@@ -1345,5 +1346,16 @@ func TestKeysPerRow(t *testing.T) {
 				t.Errorf("expected %d keys got %d", test.expected, keys)
 			}
 		})
+	}
+}
+
+func TestDatumTypeToColumnSemanticType(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	for _, typ := range types.AnyNonArray {
+		_, err := DatumTypeToColumnSemanticType(typ)
+		if err != nil {
+			t.Errorf("couldn't get semantic type: %s", err)
+		}
 	}
 }


### PR DESCRIPTION
This commit adds a couple guardrails around adding a new Datum type
(suggestions for more welcome) by using types.AnyNonArray to check that
a handful of important switch statements are exhaustive.

Release note: None