### PR TITLE
backport-2.0: server: avoid spurious warning

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1517,7 +1517,16 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set(httputil.ContentEncodingHeader, httputil.GzipEncoding)
 		gzw := newGzipResponseWriter(w)
 		defer func() {
-			if err := gzw.Close(); err != nil {
+			// Certain requests must not have a body, yet closing the gzip writer will
+			// attempt to write the gzip header. Avoid logging a warning in this case.
+			// This is notably triggered by:
+			//
+			// curl -H 'Accept-Encoding: gzip' \
+			// 	    -H 'If-Modified-Since: Thu, 29 Mar 2018 22:36:32 GMT' \
+			//      -v http://localhost:8080/favicon.ico > /dev/null
+			//
+			// which results in a 304 Not Modified.
+			if err := gzw.Close(); err != http.ErrBodyNotAllowed {
 				ctx := s.AnnotateCtx(r.Context())
 				log.Warningf(ctx, "error closing gzip response writer: %v", err)
 			}


### PR DESCRIPTION
Backport 1/1 commits from #24367.

/cc @cockroachdb/release

---

When a gzip-encoded http request returns a response code that
does not allow a body, closing the gzip writer will fail.

Avoid a spurious warning in that case.

Release note: None
