### PR TITLE
distsqlrun: refactoring binge around processor startup

### DIFF
--- a/pkg/ccl/importccl/csv.go
+++ b/pkg/ccl/importccl/csv.go
@@ -1065,8 +1065,8 @@ func (cp *readCSVProcessor) OutputTypes() []sqlbase.ColumnType {
 	return csvOutputTypes
 }
 
-func (cp *readCSVProcessor) Run(wg *sync.WaitGroup) {
-	ctx, span := tracing.ChildSpan(cp.flowCtx.Ctx, "readCSVProcessor")
+func (cp *readCSVProcessor) Run(ctx context.Context, wg *sync.WaitGroup) {
+	ctx, span := tracing.ChildSpan(ctx, "readCSVProcessor")
 	defer tracing.FinishSpan(span)
 
 	if wg != nil {
@@ -1244,13 +1244,15 @@ func (sp *sstWriter) OutputTypes() []sqlbase.ColumnType {
 	return sstOutputTypes
 }
 
-func (sp *sstWriter) Run(wg *sync.WaitGroup) {
-	ctx, span := tracing.ChildSpan(sp.flowCtx.Ctx, "sstWriter")
-	defer tracing.FinishSpan(span)
-
+func (sp *sstWriter) Run(ctx context.Context, wg *sync.WaitGroup) {
 	if wg != nil {
 		defer wg.Done()
 	}
+
+	sp.input.Start(ctx)
+
+	ctx, span := tracing.ChildSpan(ctx, "sstWriter")
+	defer tracing.FinishSpan(span)
 
 	err := func() error {
 		job, err := sp.registry.LoadJob(ctx, sp.progress.JobID)

--- a/pkg/sql/distsqlrun/aggregator_test.go
+++ b/pkg/sql/distsqlrun/aggregator_test.go
@@ -354,7 +354,6 @@ func TestAggregator(t *testing.T) {
 			evalCtx := tree.MakeTestingEvalContext(st)
 			defer evalCtx.Stop(context.Background())
 			flowCtx := FlowCtx{
-				Ctx:      context.Background(),
 				Settings: st,
 				EvalCtx:  evalCtx,
 			}
@@ -364,7 +363,7 @@ func TestAggregator(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			ag.Run(nil)
+			ag.Run(context.Background(), nil /* wg */)
 
 			var expected []string
 			for _, row := range c.expected {
@@ -415,7 +414,6 @@ func BenchmarkAggregation(b *testing.B) {
 	defer evalCtx.Stop(ctx)
 
 	flowCtx := &FlowCtx{
-		Ctx:      ctx,
 		Settings: st,
 		EvalCtx:  evalCtx,
 	}
@@ -441,7 +439,7 @@ func BenchmarkAggregation(b *testing.B) {
 				if err != nil {
 					b.Fatal(err)
 				}
-				d.Run(nil)
+				d.Run(context.TODO(), nil)
 				input.Reset()
 			}
 			b.StopTimer()
@@ -459,7 +457,6 @@ func BenchmarkGrouping(b *testing.B) {
 	defer evalCtx.Stop(ctx)
 
 	flowCtx := &FlowCtx{
-		Ctx:      ctx,
 		Settings: st,
 		EvalCtx:  evalCtx,
 	}
@@ -477,7 +474,7 @@ func BenchmarkGrouping(b *testing.B) {
 		if err != nil {
 			b.Fatal(err)
 		}
-		d.Run(nil)
+		d.Run(context.Background(), nil /* wg */)
 		input.Reset()
 	}
 	b.StopTimer()

--- a/pkg/sql/distsqlrun/backfiller.go
+++ b/pkg/sql/distsqlrun/backfiller.go
@@ -70,20 +70,15 @@ func (*backfiller) OutputTypes() []sqlbase.ColumnType {
 	return nil
 }
 
-// Run is part of the processor interface.
-func (b *backfiller) Run(wg *sync.WaitGroup) {
-	if wg != nil {
-		defer wg.Done()
-	}
-
+// Run is part of the Processor interface.
+func (b *backfiller) Run(ctx context.Context, wg *sync.WaitGroup) {
 	opName := fmt.Sprintf("%sBackfiller", b.name)
-	ctx := log.WithLogTagInt(b.flowCtx.Ctx, opName, int(b.spec.Table.ID))
+	ctx = log.WithLogTagInt(ctx, opName, int(b.spec.Table.ID))
 	ctx, span := processorSpan(ctx, opName)
 	defer tracing.FinishSpan(span)
 
-	log.VEventf(ctx, 1, "starting")
-	if log.V(1) {
-		defer log.Infof(ctx, "exiting")
+	if wg != nil {
+		defer wg.Done()
 	}
 
 	if err := b.mainLoop(ctx); err != nil {

--- a/pkg/sql/distsqlrun/base_test.go
+++ b/pkg/sql/distsqlrun/base_test.go
@@ -31,18 +31,21 @@ import (
 func TestRunDrain(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
+	ctx := context.Background()
+
 	// A source with no rows and 2 ProducerMetadata messages.
 	src := &RowChannel{}
 	src.InitWithBufSize(nil, 10)
 	src.Push(nil /* row */, &ProducerMetadata{Err: fmt.Errorf("test")})
 	src.Push(nil /* row */, nil /* meta */)
+	src.Start(ctx)
 
 	// A receiver that is marked as done consuming rows so that Run will
 	// immediately move from forwarding rows and metadata to draining metadata.
 	buf := &RowBuffer{}
 	buf.ConsumerDone()
 
-	Run(context.Background(), src, buf)
+	Run(ctx, src, buf)
 
 	if src.consumerStatus != DrainRequested {
 		t.Fatalf("expected DrainRequested, but found %d", src.consumerStatus)

--- a/pkg/sql/distsqlrun/distinct_test.go
+++ b/pkg/sql/distsqlrun/distinct_test.go
@@ -119,7 +119,6 @@ func TestDistinct(t *testing.T) {
 			evalCtx := tree.MakeTestingEvalContext(st)
 			defer evalCtx.Stop(context.Background())
 			flowCtx := FlowCtx{
-				Ctx:      context.Background(),
 				Settings: st,
 				EvalCtx:  evalCtx,
 			}
@@ -129,7 +128,7 @@ func TestDistinct(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			d.Run(nil)
+			d.Run(context.Background(), nil /* wg */)
 			if !out.ProducerClosed {
 				t.Fatalf("output RowReceiver not closed")
 			}
@@ -158,7 +157,6 @@ func benchmarkDistinct(b *testing.B, orderedColumns []uint32) {
 	defer evalCtx.Stop(ctx)
 
 	flowCtx := &FlowCtx{
-		Ctx:      ctx,
 		Settings: st,
 		EvalCtx:  evalCtx,
 	}
@@ -179,7 +177,7 @@ func benchmarkDistinct(b *testing.B, orderedColumns []uint32) {
 				if err != nil {
 					b.Fatal(err)
 				}
-				d.Run(nil)
+				d.Run(context.Background(), nil /* wg */)
 				input.Reset()
 			}
 		})

--- a/pkg/sql/distsqlrun/flow_registry_test.go
+++ b/pkg/sql/distsqlrun/flow_registry_test.go
@@ -375,7 +375,6 @@ func TestFlowRegistryDrain(t *testing.T) {
 	reg := makeFlowRegistry(roachpb.NodeID(0))
 
 	flow := &Flow{}
-	flow.Ctx = ctx
 	id := FlowID{uuid.MakeV4()}
 	registerFlow := func(t *testing.T, id FlowID) {
 		t.Helper()

--- a/pkg/sql/distsqlrun/hashjoiner_test.go
+++ b/pkg/sql/distsqlrun/hashjoiner_test.go
@@ -919,7 +919,6 @@ func TestHashJoiner(t *testing.T) {
 				rightInput := NewRowBuffer(c.rightTypes, c.rightInput, RowBufferArgs{})
 				out := &RowBuffer{}
 				flowCtx := FlowCtx{
-					Ctx:         ctx,
 					Settings:    st,
 					EvalCtx:     evalCtx,
 					TempStorage: tempEngine,
@@ -933,7 +932,7 @@ func TestHashJoiner(t *testing.T) {
 				outTypes := h.OutputTypes()
 				setup(h)
 				h.forcedStoredSide = &side
-				h.Run(nil)
+				h.Run(context.Background(), nil /* wg */)
 
 				if !out.ProducerClosed {
 					return errors.New("output RowReceiver not closed")
@@ -1089,7 +1088,6 @@ func TestHashJoinerError(t *testing.T) {
 			rightInput := NewRowBuffer(c.rightTypes, c.rightInput, RowBufferArgs{})
 			out := &RowBuffer{}
 			flowCtx := FlowCtx{
-				Ctx:         ctx,
 				Settings:    st,
 				EvalCtx:     evalCtx,
 				TempStorage: tempEngine,
@@ -1103,7 +1101,7 @@ func TestHashJoinerError(t *testing.T) {
 			}
 			outTypes := h.OutputTypes()
 			setup(h)
-			h.Run(nil)
+			h.Run(context.Background(), nil /* wg */)
 
 			if !out.ProducerClosed {
 				return errors.New("output RowReceiver not closed")
@@ -1224,7 +1222,6 @@ func TestHashJoinerDrain(t *testing.T) {
 	ctx := context.Background()
 	defer evalCtx.Stop(ctx)
 	flowCtx := FlowCtx{
-		Ctx:      ctx,
 		Settings: settings,
 		EvalCtx:  evalCtx,
 	}
@@ -1240,7 +1237,7 @@ func TestHashJoinerDrain(t *testing.T) {
 	h.initialBufferSize = 0
 
 	out.ConsumerDone()
-	h.Run(nil)
+	h.Run(context.Background(), nil /* wg */)
 
 	if !out.ProducerClosed {
 		t.Fatalf("output RowReceiver not closed")
@@ -1348,7 +1345,6 @@ func TestHashJoinerDrainAfterBuildPhaseError(t *testing.T) {
 	evalCtx := tree.MakeTestingEvalContext(st)
 	defer evalCtx.Stop(context.Background())
 	flowCtx := FlowCtx{
-		Ctx:      context.Background(),
 		Settings: st,
 		EvalCtx:  evalCtx,
 	}
@@ -1361,7 +1357,7 @@ func TestHashJoinerDrainAfterBuildPhaseError(t *testing.T) {
 	// Disable initial buffering. We always store the right stream in this case.
 	h.initialBufferSize = 0
 
-	h.Run(nil)
+	h.Run(context.Background(), nil /* wg */)
 
 	if !out.ProducerClosed {
 		t.Fatalf("output RowReceiver not closed")
@@ -1397,7 +1393,6 @@ func BenchmarkHashJoiner(b *testing.B) {
 	evalCtx := tree.MakeTestingEvalContext(st)
 	defer evalCtx.Stop(ctx)
 	flowCtx := &FlowCtx{
-		Ctx:      ctx,
 		Settings: st,
 		EvalCtx:  evalCtx,
 	}
@@ -1425,7 +1420,7 @@ func BenchmarkHashJoiner(b *testing.B) {
 				if err != nil {
 					b.Fatal(err)
 				}
-				h.Run(nil)
+				h.Run(context.Background(), nil /* wg */)
 				leftInput.Reset()
 				rightInput.Reset()
 			}

--- a/pkg/sql/distsqlrun/inbound.go
+++ b/pkg/sql/distsqlrun/inbound.go
@@ -120,7 +120,7 @@ func processInboundStreamHelper(
 	// Check for context cancellation while reading from the stream on another
 	// goroutine.
 	select {
-	case <-f.Ctx.Done():
+	case <-f.ctxDone:
 		return sqlbase.QueryCanceledError
 	case err := <-errChan:
 		return err

--- a/pkg/sql/distsqlrun/input_sync.go
+++ b/pkg/sql/distsqlrun/input_sync.go
@@ -259,6 +259,14 @@ func (s *orderedSynchronizer) drainSources() {
 	}
 }
 
+// Start is part of the RowSource interface.
+func (s *orderedSynchronizer) Start(ctx context.Context) context.Context {
+	for _, src := range s.sources {
+		src.src.Start(ctx)
+	}
+	return ctx
+}
+
 // Next is part of the RowSource interface.
 func (s *orderedSynchronizer) Next() (sqlbase.EncDatumRow, *ProducerMetadata) {
 	if s.state == notInitialized {

--- a/pkg/sql/distsqlrun/input_sync_test.go
+++ b/pkg/sql/distsqlrun/input_sync_test.go
@@ -119,6 +119,7 @@ func TestOrderedSync(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
+		src.Start(context.Background())
 		var retRows sqlbase.EncDatumRows
 		for {
 			row, meta := src.Next()

--- a/pkg/sql/distsqlrun/interleaved_reader_joiner_test.go
+++ b/pkg/sql/distsqlrun/interleaved_reader_joiner_test.go
@@ -397,7 +397,6 @@ func TestInterleavedReaderJoiner(t *testing.T) {
 			evalCtx := tree.MakeTestingEvalContext(s.ClusterSettings())
 			defer evalCtx.Stop(context.Background())
 			flowCtx := FlowCtx{
-				Ctx:      context.Background(),
 				EvalCtx:  evalCtx,
 				Settings: s.ClusterSettings(),
 				// Run in a RootTxn so that there's no txn metadata produced.
@@ -410,7 +409,7 @@ func TestInterleavedReaderJoiner(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			irj.Run(nil)
+			irj.Run(context.Background(), nil /* wg */)
 			if !out.ProducerClosed {
 				t.Fatalf("output RowReceiver not closed")
 			}
@@ -581,7 +580,6 @@ func TestInterleavedReaderJoinerTrailingMetadata(t *testing.T) {
 	defer sp.Finish()
 
 	flowCtx := FlowCtx{
-		Ctx:      ctx,
 		EvalCtx:  evalCtx,
 		Settings: s.ClusterSettings(),
 		// Run in a LeafTxn so that txn metadata is produced.
@@ -610,7 +608,7 @@ func TestInterleavedReaderJoinerTrailingMetadata(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	irj.Run(nil)
+	irj.Run(ctx, nil /* wg */)
 	if !out.ProducerClosed {
 		t.Fatalf("output RowReceiver not closed")
 	}

--- a/pkg/sql/distsqlrun/joinerbase.go
+++ b/pkg/sql/distsqlrun/joinerbase.go
@@ -109,11 +109,10 @@ func (jb *joinerBase) init(
 	}
 	outputTypes := condTypes[:outputSize]
 
-	evalCtx := flowCtx.NewEvalCtx()
-	if err := jb.onCond.init(onExpr, condTypes, evalCtx); err != nil {
+	if err := jb.processorBase.init(post, outputTypes, flowCtx, output); err != nil {
 		return err
 	}
-	return jb.processorBase.init(post, outputTypes, flowCtx, evalCtx, output)
+	return jb.onCond.init(onExpr, condTypes, jb.evalCtx)
 }
 
 type joinSide uint8

--- a/pkg/sql/distsqlrun/joinreader.go
+++ b/pkg/sql/distsqlrun/joinreader.go
@@ -69,6 +69,8 @@ type joinReader struct {
 
 var _ Processor = &joinReader{}
 
+const joinReaderProcName = "join reader"
+
 func newJoinReader(
 	flowCtx *FlowCtx,
 	spec *JoinReaderSpec,
@@ -402,14 +404,14 @@ func (jr *joinReader) indexLookup(
 }
 
 // Run is part of the processor interface.
-func (jr *joinReader) Run(wg *sync.WaitGroup) {
+func (jr *joinReader) Run(ctx context.Context, wg *sync.WaitGroup) {
 	if wg != nil {
 		defer wg.Done()
 	}
 
-	ctx := log.WithLogTagInt(jr.flowCtx.Ctx, "JoinReader", int(jr.desc.ID))
-	ctx, span := processorSpan(ctx, "join reader")
-	defer tracing.FinishSpan(span)
+	jr.input.Start(ctx)
+	ctx = jr.startInternal(ctx, joinReaderProcName)
+	defer tracing.FinishSpan(jr.span)
 
 	err := jr.mainLoop(ctx)
 	if err != nil {

--- a/pkg/sql/distsqlrun/joinreader_test.go
+++ b/pkg/sql/distsqlrun/joinreader_test.go
@@ -180,7 +180,6 @@ func TestJoinReader(t *testing.T) {
 			evalCtx := tree.MakeTestingEvalContext(st)
 			defer evalCtx.Stop(context.Background())
 			flowCtx := FlowCtx{
-				Ctx:      context.Background(),
 				EvalCtx:  evalCtx,
 				Settings: st,
 				txn:      client.NewTxn(s.DB(), s.NodeID(), client.RootTxn),
@@ -208,7 +207,7 @@ func TestJoinReader(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			jr.Run(nil)
+			jr.Run(context.Background(), nil /* wg */)
 
 			if !in.Done {
 				t.Fatal("joinReader didn't consume all the rows")
@@ -263,7 +262,6 @@ func TestJoinReaderDrain(t *testing.T) {
 	defer sp.Finish()
 
 	flowCtx := FlowCtx{
-		Ctx:      ctx,
 		EvalCtx:  evalCtx,
 		Settings: s.ClusterSettings(),
 		txn:      client.NewTxn(s.DB(), s.NodeID(), client.LeafTxn),
@@ -283,7 +281,7 @@ func TestJoinReaderDrain(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		jr.Run(nil)
+		jr.Run(ctx, nil /* wg */)
 	})
 
 	// ConsumerDone verifies that the producer drains properly by checking that
@@ -302,7 +300,7 @@ func TestJoinReaderDrain(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		jr.Run(nil)
+		jr.Run(ctx, nil /* wg */)
 		row, meta := out.Next()
 		if row != nil {
 			t.Fatalf("row was pushed unexpectedly: %s", row.String(oneIntCol))

--- a/pkg/sql/distsqlrun/mergejoiner_test.go
+++ b/pkg/sql/distsqlrun/mergejoiner_test.go
@@ -702,7 +702,6 @@ func TestMergeJoiner(t *testing.T) {
 			evalCtx := tree.MakeTestingEvalContext(st)
 			defer evalCtx.Stop(context.Background())
 			flowCtx := FlowCtx{
-				Ctx:      context.Background(),
 				Settings: st,
 				EvalCtx:  evalCtx,
 			}
@@ -713,7 +712,7 @@ func TestMergeJoiner(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			m.Run(nil /* wg */)
+			m.Run(context.Background(), nil /* wg */)
 
 			if !out.ProducerClosed {
 				t.Fatalf("output RowReceiver not closed")
@@ -810,7 +809,6 @@ func TestConsumerClosed(t *testing.T) {
 			evalCtx := tree.MakeTestingEvalContext(st)
 			defer evalCtx.Stop(context.Background())
 			flowCtx := FlowCtx{
-				Ctx:      context.Background(),
 				Settings: st,
 				EvalCtx:  evalCtx,
 			}
@@ -820,7 +818,7 @@ func TestConsumerClosed(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			m.Run(nil /* wg */)
+			m.Run(context.Background(), nil /* wg */)
 
 			if !out.ProducerClosed {
 				t.Fatalf("output RowReceiver not closed")
@@ -835,7 +833,6 @@ func BenchmarkMergeJoiner(b *testing.B) {
 	evalCtx := tree.MakeTestingEvalContext(st)
 	defer evalCtx.Stop(ctx)
 	flowCtx := &FlowCtx{
-		Ctx:      ctx,
 		Settings: st,
 		EvalCtx:  evalCtx,
 	}
@@ -868,7 +865,7 @@ func BenchmarkMergeJoiner(b *testing.B) {
 				if err != nil {
 					b.Fatal(err)
 				}
-				m.Run(nil)
+				m.Run(context.Background(), nil /* wg */)
 				leftInput.Reset()
 				rightInput.Reset()
 			}

--- a/pkg/sql/distsqlrun/noop_test.go
+++ b/pkg/sql/distsqlrun/noop_test.go
@@ -33,7 +33,6 @@ func BenchmarkNoop(b *testing.B) {
 	defer evalCtx.Stop(ctx)
 
 	flowCtx := &FlowCtx{
-		Ctx:      ctx,
 		Settings: st,
 		EvalCtx:  evalCtx,
 	}
@@ -54,7 +53,7 @@ func BenchmarkNoop(b *testing.B) {
 				if err != nil {
 					b.Fatal(err)
 				}
-				d.Run(nil)
+				d.Run(context.Background(), nil /* wg */)
 				input.Reset()
 			}
 		})

--- a/pkg/sql/distsqlrun/processors_test.go
+++ b/pkg/sql/distsqlrun/processors_test.go
@@ -400,7 +400,6 @@ func TestProcessorBaseContext(t *testing.T) {
 
 	runTest := func(t *testing.T, f func(noop *noopProcessor)) {
 		flowCtx := &FlowCtx{
-			Ctx:      ctx,
 			Settings: st,
 			EvalCtx:  tree.MakeTestingEvalContext(st),
 		}
@@ -411,10 +410,11 @@ func TestProcessorBaseContext(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
+		noop.Start(ctx)
 
-		// The context should be valid before Next is called in case ConsumerDone
-		// or ConsumerClosed are called without calling Next.j
-		if noop.ctx != ctx {
+		// The context should be valid after Start but before Next is called in case
+		// ConsumerDone or ConsumerClosed are called without calling Next.
+		if noop.ctx == nil {
 			t.Fatalf("processorBase.ctx not initialized")
 		}
 		f(noop)

--- a/pkg/sql/distsqlrun/sample_aggregator_test.go
+++ b/pkg/sql/distsqlrun/sample_aggregator_test.go
@@ -43,7 +43,6 @@ func TestSampleAggregator(t *testing.T) {
 	evalCtx := tree.MakeTestingEvalContext(st)
 	defer evalCtx.Stop(context.Background())
 	flowCtx := FlowCtx{
-		Ctx:      context.Background(),
 		Settings: st,
 		EvalCtx:  evalCtx,
 		clientDB: kvDB,
@@ -111,7 +110,7 @@ func TestSampleAggregator(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		p.Run(nil /* wg */)
+		p.Run(context.Background(), nil /* wg */)
 	}
 	// Randomly interleave the output rows from the samplers into a single buffer.
 	samplerResults := NewRowBuffer(samplerOutTypes, nil /* rows */, RowBufferArgs{})
@@ -138,7 +137,7 @@ func TestSampleAggregator(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	agg.Run(nil /* wg */)
+	agg.Run(context.Background(), nil /* wg */)
 	// Make sure there was no error.
 	finalOut.GetRowsNoMeta(t)
 	r := sqlutils.MakeSQLRunner(sqlDB)

--- a/pkg/sql/distsqlrun/sampler_test.go
+++ b/pkg/sql/distsqlrun/sampler_test.go
@@ -48,7 +48,6 @@ func runSampler(t *testing.T, numRows, numSamples int) []int {
 	evalCtx := tree.MakeTestingEvalContext(st)
 	defer evalCtx.Stop(context.Background())
 	flowCtx := FlowCtx{
-		Ctx:      context.Background(),
 		Settings: st,
 		EvalCtx:  evalCtx,
 	}
@@ -58,7 +57,7 @@ func runSampler(t *testing.T, numRows, numSamples int) []int {
 	if err != nil {
 		t.Fatal(err)
 	}
-	p.Run(nil)
+	p.Run(context.Background(), nil /* wg */)
 
 	// Verify we have numSamples distinct rows.
 	res := make([]int, 0, numSamples)
@@ -154,7 +153,6 @@ func TestSamplerSketch(t *testing.T) {
 	evalCtx := tree.MakeTestingEvalContext(st)
 	defer evalCtx.Stop(context.Background())
 	flowCtx := FlowCtx{
-		Ctx:      context.Background(),
 		Settings: st,
 		EvalCtx:  evalCtx,
 	}
@@ -176,7 +174,7 @@ func TestSamplerSketch(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	p.Run(nil)
+	p.Run(context.Background(), nil /* wg */)
 
 	rows = out.GetRowsNoMeta(t)
 	// We expect one sampled row and two sketch rows.

--- a/pkg/sql/distsqlrun/stream_group_accumulator.go
+++ b/pkg/sql/distsqlrun/stream_group_accumulator.go
@@ -15,6 +15,8 @@
 package distsqlrun
 
 import (
+	"context"
+
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/pkg/errors"
@@ -48,6 +50,10 @@ func makeStreamGroupAccumulator(
 		types:    src.OutputTypes(),
 		ordering: ordering,
 	}
+}
+
+func (s *streamGroupAccumulator) start(ctx context.Context) {
+	s.src.Start(ctx)
 }
 
 // nextGroup returns the next group from the inputs. The returned slice is not safe

--- a/pkg/sql/distsqlrun/stream_merger.go
+++ b/pkg/sql/distsqlrun/stream_merger.go
@@ -15,6 +15,8 @@
 package distsqlrun
 
 import (
+	"context"
+
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
@@ -35,6 +37,11 @@ type streamMerger struct {
 	// during SCRUB secondary index checks.
 	nullEquality bool
 	datumAlloc   sqlbase.DatumAlloc
+}
+
+func (sm *streamMerger) start(ctx context.Context) {
+	sm.left.start(ctx)
+	sm.right.start(ctx)
 }
 
 // NextBatch returns a set of rows from the left stream and a set of rows from

--- a/pkg/sql/distsqlrun/utils_test.go
+++ b/pkg/sql/distsqlrun/utils_test.go
@@ -62,6 +62,9 @@ func (r *RepeatableRowSource) OutputTypes() []sqlbase.ColumnType {
 	return r.types
 }
 
+// Start is part of the RowSource interface.
+func (r *RepeatableRowSource) Start(ctx context.Context) context.Context { return ctx }
+
 // Next is part of the RowSource interface.
 func (r *RepeatableRowSource) Next() (sqlbase.EncDatumRow, *ProducerMetadata) {
 	// If we've emitted all rows, signal that we have reached the end.

--- a/pkg/sql/distsqlrun/values_test.go
+++ b/pkg/sql/distsqlrun/values_test.go
@@ -72,7 +72,6 @@ func TestValues(t *testing.T) {
 					out := &RowBuffer{}
 					st := cluster.MakeTestingClusterSettings()
 					flowCtx := FlowCtx{
-						Ctx:      context.Background(),
 						Settings: st,
 					}
 
@@ -80,7 +79,7 @@ func TestValues(t *testing.T) {
 					if err != nil {
 						t.Fatal(err)
 					}
-					v.Run(nil)
+					v.Run(context.Background(), nil)
 					if !out.ProducerClosed {
 						t.Fatalf("output RowReceiver not closed")
 					}

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -2238,20 +2238,29 @@ type SequenceOperators interface {
 }
 
 // CtxProvider is anything that can return a Context.
+//
+// TODO(andrei): I think this whole CtxProvider business might not be needed any
+// more. I think it was needed back in the day to indirect dereferencing a
+// context to a session, whose context used to change willy-nilly when entering
+// and exiting a transaction. More recently, the points where that context
+// changes are clear; uses of an EvalContext don't straddle context changes, so
+// we should bind EvalCtx.Ctx to a context.Context directly.
 type CtxProvider interface {
 	// Ctx returns this provider's context.
 	Ctx() context.Context
 }
 
-// backgroundCtxProvider returns the background context.
-type backgroundCtxProvider struct{}
-
-// Ctx implements CtxProvider.
-func (s backgroundCtxProvider) Ctx() context.Context {
-	return context.Background()
+// FixedCtxProvider returns a given Context.
+type FixedCtxProvider struct {
+	context.Context
 }
 
-var _ CtxProvider = backgroundCtxProvider{}
+// Ctx implements CtxProvider.
+func (s FixedCtxProvider) Ctx() context.Context {
+	return s.Context
+}
+
+var _ CtxProvider = FixedCtxProvider{}
 
 // EvalContextTestingKnobs contains test knobs.
 type EvalContextTestingKnobs struct {
@@ -2385,7 +2394,7 @@ func MakeTestingEvalContext(st *cluster.Settings) EvalContext {
 	)
 	monitor.Start(context.Background(), nil /* pool */, mon.MakeStandaloneBudget(math.MaxInt64))
 	ctx.Mon = &monitor
-	ctx.CtxProvider = backgroundCtxProvider{}
+	ctx.CtxProvider = FixedCtxProvider{context.TODO()}
 	acc := monitor.MakeBoundAccount()
 	ctx.ActiveMemAcc = &acc
 	now := timeutil.Now()


### PR DESCRIPTION
Introduced a RowSource.Start() method so that processors have a uniform
way of initializing, aided by processorBase.startInternal(). A bunch of
them had a maybeStart() method called continuously from Next().
Also got rid of flowCtx.ctx since it was very confusing and wrongly used
in a few places - each processor was supposed to override it. Replaced
by contexts passed to Start/Run.
Also centralized the forking of the evalCtx by each processor in the
startup.

This is in preparation of processors getting help for having a trailing
metadata draining stage.

Release note: none