### PR TITLE
engine: pass rocksdb perf stats back to go

### DIFF
--- a/c-deps/libroach/db.h
+++ b/c-deps/libroach/db.h
@@ -71,4 +71,17 @@ std::string EncodeKey(DBKey k);
 MVCCStatsResult MVCCComputeStatsInternal(::rocksdb::Iterator* const iter_rep, DBKey start,
                                          DBKey end, int64_t now_nanos);
 
+// ScopedStats wraps an iterator and, if that iterator has the stats
+// member populated, aggregates a subset of the RocksDB perf counters
+// into it (while the ScopedStats is live).
+class ScopedStats {
+ public:
+  ScopedStats(DBIterator*);
+  ~ScopedStats();
+
+ private:
+  DBIterator* const iter_;
+  uint64_t internal_delete_skipped_count_base_;
+};
+
 }  // namespace cockroach

--- a/c-deps/libroach/include/libroach.h
+++ b/c-deps/libroach/include/libroach.h
@@ -175,17 +175,34 @@ DBEngine* DBNewBatch(DBEngine* db, bool writeOnly);
 // the user-key prefix of the key supplied to DBIterSeek() to restrict
 // which sstables are searched, but iteration (using Next) over keys
 // without the same user-key prefix will not work correctly (keys may
-// be skipped). It is the callers responsibility to call
-// DBIterDestroy().
-DBIterator* DBNewIter(DBEngine* db, bool prefix);
+// be skipped). When stats is true, the iterator will collect RocksDB
+// performance counters which can be retrieved via `DBIterStats`.
+//
+// It is the caller's responsibility to call DBIterDestroy().
+DBIterator* DBNewIter(DBEngine* db, bool prefix, bool stats);
 
-DBIterator* DBNewTimeBoundIter(DBEngine* db, DBTimestamp min_ts, DBTimestamp max_ts);
+DBIterator* DBNewTimeBoundIter(DBEngine* db, DBTimestamp min_ts, DBTimestamp max_ts,
+                               bool with_stats);
 
 // Destroys an iterator, freeing up any associated memory.
 void DBIterDestroy(DBIterator* iter);
 
 // Positions the iterator at the first key that is >= "key".
 DBIterState DBIterSeek(DBIterator* iter, DBKey key);
+
+typedef struct {
+  uint64_t internal_delete_skipped_count;
+  // the number of SSTables touched (only for time bound iterators).
+  // This field is populated from the table filter, not from the
+  // RocksDB perf counters.
+  //
+  // TODO(tschottdorf): populate this field for all iterators.
+  uint64_t timebound_num_ssts;
+  // New fields added here must also be added in various other places;
+  // just grep the repo for internal_delete_skipped_count. Sorry.
+} IteratorStats;
+
+IteratorStats DBIterStats(DBIterator* iter);
 
 // Positions the iterator at the first key in the database.
 DBIterState DBIterSeekToFirst(DBIterator* iter);

--- a/c-deps/libroach/iterator.h
+++ b/c-deps/libroach/iterator.h
@@ -29,4 +29,5 @@ struct DBIterator {
   std::unique_ptr<rocksdb::Iterator> rep;
   std::unique_ptr<cockroach::chunkedBuffer> kvs;
   std::unique_ptr<rocksdb::WriteBatch> intents;
+  std::unique_ptr<IteratorStats> stats;
 };

--- a/c-deps/libroach/mvcc.cc
+++ b/c-deps/libroach/mvcc.cc
@@ -292,6 +292,7 @@ DBScanResults MVCCGet(DBIterator* iter, DBSlice key, DBTimestamp timestamp, DBTx
   // don't retrieve a key different than the start key. This is a bit
   // of a hack.
   const DBSlice end = {0, 0};
+  ScopedStats scoped_iter(iter);
   mvccForwardScanner scanner(iter, key, end, timestamp, 0 /* max_keys */, txn, consistent,
                              tombstones);
   return scanner.get();
@@ -300,6 +301,7 @@ DBScanResults MVCCGet(DBIterator* iter, DBSlice key, DBTimestamp timestamp, DBTx
 DBScanResults MVCCScan(DBIterator* iter, DBSlice start, DBSlice end, DBTimestamp timestamp,
                        int64_t max_keys, DBTxn txn, bool consistent, bool reverse,
                        bool tombstones) {
+  ScopedStats scoped_iter(iter);
   if (reverse) {
     mvccReverseScanner scanner(iter, end, start, timestamp, max_keys, txn, consistent, tombstones);
     return scanner.scan();

--- a/pkg/ccl/storageccl/engineccl/bench_test.go
+++ b/pkg/ccl/storageccl/engineccl/bench_test.go
@@ -173,7 +173,7 @@ func BenchmarkTimeBoundIterate(b *testing.B) {
 			})
 			b.Run("TimeBoundIterator", func(b *testing.B) {
 				runIterate(b, loadFactor, func(e engine.Engine, startTime, endTime hlc.Timestamp) engine.Iterator {
-					return e.NewTimeBoundIterator(startTime, endTime)
+					return e.NewTimeBoundIterator(startTime, endTime, false)
 				})
 			})
 		})

--- a/pkg/ccl/storageccl/engineccl/mvcc.go
+++ b/pkg/ccl/storageccl/engineccl/mvcc.go
@@ -66,7 +66,9 @@ func NewMVCCIncrementalIterator(
 		// interval into the fully-inclusive [start, end] interval that
 		// NewTimeBoundIterator expects. This is strictly a performance
 		// optimization; omitting the call would still return correct results.
-		iter:      e.NewTimeBoundIterator(startTime.Next(), endTime),
+		//
+		// TODO(tschottdorf): plumb withStats in when needed.
+		iter:      e.NewTimeBoundIterator(startTime.Next(), endTime, false /* withStats */),
 		startTime: startTime,
 		endTime:   endTime,
 	}

--- a/pkg/sql/logictest/testdata/logic_test/show_trace
+++ b/pkg/sql/logictest/testdata/logic_test/show_trace
@@ -825,3 +825,11 @@ SELECT message FROM [SHOW TRACE FOR SESSION] WHERE message LIKE e'%1 CPut, 1 Beg
 ----
 r1: sending batch 1 CPut, 1 BeginTxn, 1 EndTxn to (n1,s1):1
 1 CPut, 1 BeginTxn, 1 EndTxn
+
+statement ok
+CREATE TABLE t.enginestats(k INT PRIMARY KEY, v INT)
+
+query T
+SELECT message FROM [ SHOW TRACE FOR SELECT * FROM t.enginestats ] WHERE message LIKE '%InternalDelete%'
+----
+engine stats: {InternalDeleteSkippedCount:0 TimeBoundNumSSTs:0}

--- a/pkg/storage/batcheval/cmd_refresh_range.go
+++ b/pkg/storage/batcheval/cmd_refresh_range.go
@@ -44,7 +44,7 @@ func RefreshRange(
 
 	// Use a time-bounded iterator to avoid unnecessarily iterating over
 	// older data.
-	iter := batch.NewTimeBoundIterator(h.Txn.OrigTimestamp, h.Txn.Timestamp)
+	iter := batch.NewTimeBoundIterator(h.Txn.OrigTimestamp, h.Txn.Timestamp, false)
 	defer iter.Close()
 	// Iterate over values until we discover any value written at or
 	// after the original timestamp, but before or at the current

--- a/pkg/storage/batcheval/cmd_resolve_intent_range.go
+++ b/pkg/storage/batcheval/cmd_resolve_intent_range.go
@@ -56,7 +56,7 @@ func ResolveIntentRange(
 	// Use a time-bounded iterator as an optimization if indicated.
 	var iterAndBuf engine.IterAndBuf
 	if args.MinTimestamp != (hlc.Timestamp{}) {
-		iter := batch.NewTimeBoundIterator(args.MinTimestamp, args.IntentTxn.Timestamp)
+		iter := batch.NewTimeBoundIterator(args.MinTimestamp, args.IntentTxn.Timestamp, false)
 		iterAndBuf = engine.GetBufUsingIter(iter)
 	} else {
 		iterAndBuf = engine.GetIterAndBuf(batch)

--- a/pkg/storage/engine/batch_test.go
+++ b/pkg/storage/engine/batch_test.go
@@ -175,7 +175,7 @@ func TestReadOnlyBasics(t *testing.T) {
 		func() { _, _, _, _ = b.GetProto(a, getVal) },
 		func() { _ = b.Iterate(a, a, func(MVCCKeyValue) (bool, error) { return true, nil }) },
 		func() { b.NewIterator(IterOptions{}).Close() },
-		func() { b.NewTimeBoundIterator(hlc.Timestamp{}, hlc.Timestamp{}).Close() },
+		func() { b.NewTimeBoundIterator(hlc.Timestamp{}, hlc.Timestamp{}, false).Close() },
 	}
 	defer func() {
 		b.Close()

--- a/pkg/storage/engine/rocksdb_iter_stats_test.go
+++ b/pkg/storage/engine/rocksdb_iter_stats_test.go
@@ -1,0 +1,107 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package engine
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+)
+
+func TestIterStats(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	db := setupMVCCInMemRocksDB(t, "test_iter_stats")
+	defer db.Close()
+
+	k := MakeMVCCMetadataKey(roachpb.Key("foo"))
+	if err := db.Put(k, []byte("abc")); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := db.Clear(k); err != nil {
+		t.Fatal(err)
+	}
+
+	batch := db.NewBatch()
+	defer batch.Close()
+
+	testCases := []Iterator{
+		db.NewIterator(IterOptions{WithStats: true}),
+		db.NewTimeBoundIterator(hlc.Timestamp{}, hlc.Timestamp{WallTime: 999}, true /* withStats */),
+		batch.NewIterator(IterOptions{WithStats: true}),
+		batch.NewTimeBoundIterator(hlc.Timestamp{}, hlc.Timestamp{WallTime: 999}, true /* withStats */),
+	}
+
+	defer func() {
+		for _, iter := range testCases {
+			iter.Close()
+		}
+	}()
+
+	for _, iter := range testCases {
+		t.Run("", func(t *testing.T) {
+			// Seeking past the tombstone manually counts it.
+			for i := 0; i < 10; i++ {
+				iter.Seek(NilKey)
+				iter.Seek(MVCCKeyMax)
+				stats := iter.Stats()
+				if e, a := i+1, stats.InternalDeleteSkippedCount; a != e {
+					t.Errorf("expected internal delete skipped count of %d, not %d", e, a)
+				}
+			}
+			// Scanning a key range containing the tombstone sees it.
+			for i := 0; i < 10; i++ {
+				if _, _, _, err := iter.MVCCScan(
+					roachpb.KeyMin, roachpb.KeyMax, 0, hlc.Timestamp{}, nil, true, false, false,
+				); err != nil {
+					t.Fatal(err)
+				}
+				stats := iter.Stats()
+				if e, a := i+11, stats.InternalDeleteSkippedCount; a != e {
+					t.Errorf("expected internal delete skipped count of %d, not %d", e, a)
+				}
+			}
+
+			// Getting the key with the tombstone sees it.
+			for i := 0; i < 10; i++ {
+				if _, _, err := iter.MVCCGet(
+					k.Key, hlc.Timestamp{}, nil, true, false,
+				); err != nil {
+					t.Fatal(err)
+				}
+				stats := iter.Stats()
+				if e, a := i+21, stats.InternalDeleteSkippedCount; a != e {
+					t.Errorf("expected internal delete skipped count of %d, not %d", e, a)
+				}
+			}
+			// Getting KeyMax doesn't see it.
+			for i := 0; i < 10; i++ {
+				if _, _, err := iter.MVCCGet(
+					roachpb.KeyMax, hlc.Timestamp{}, nil, true, false,
+				); err != nil {
+					t.Fatal(err)
+				}
+				stats := iter.Stats()
+				if e, a := 30, stats.InternalDeleteSkippedCount; a != e {
+					t.Errorf("expected internal delete skipped count of %d, not %d", e, a)
+				}
+			}
+
+		})
+	}
+}

--- a/pkg/storage/replica_command.go
+++ b/pkg/storage/replica_command.go
@@ -495,7 +495,7 @@ func resolveLocalIntents(
 	}
 
 	min, max := txn.InclusiveTimeBounds()
-	iter := batch.NewTimeBoundIterator(min, max)
+	iter := batch.NewTimeBoundIterator(min, max, false)
 	iterAndBuf := engine.GetBufUsingIter(iter)
 	defer iterAndBuf.Cleanup()
 

--- a/pkg/storage/spanset/batch.go
+++ b/pkg/storage/spanset/batch.go
@@ -47,6 +47,11 @@ func NewIterator(iter engine.Iterator, spans *SpanSet) *Iterator {
 	}
 }
 
+// Stats is part of the engine.Iterator interface.
+func (s *Iterator) Stats() engine.IteratorStats {
+	return s.i.Stats()
+}
+
 // Close is part of the engine.Iterator interface.
 func (s *Iterator) Close() {
 	s.i.Close()
@@ -232,8 +237,10 @@ func (s spanSetReader) NewIterator(opts engine.IterOptions) engine.Iterator {
 	return &Iterator{s.r.NewIterator(opts), s.spans, nil, false}
 }
 
-func (s spanSetReader) NewTimeBoundIterator(start, end hlc.Timestamp) engine.Iterator {
-	return &Iterator{s.r.NewTimeBoundIterator(start, end), s.spans, nil, false}
+func (s spanSetReader) NewTimeBoundIterator(
+	start, end hlc.Timestamp, withStats bool,
+) engine.Iterator {
+	return &Iterator{s.r.NewTimeBoundIterator(start, end, withStats), s.spans, nil, false}
 }
 
 type spanSetWriter struct {


### PR DESCRIPTION
Being able to see RocksDB-level perf counters in slow read operations
can be helpful to diagnose issues such as #17229. Being able to see
I/O slowness at the RocksDB level should be helpful to diagnose disk
bottlenecking.

This commit optionally enables collection of (a currently singleton
subset) RocksDB performance counters on a per-iterator basis but
makes it straightforward to add anything from the IO or PerfContext.

Note that the RocksDB perf counters use TLS (thread-local storage).
Iterators are usually created and used from goroutines, so they are not
tied to a thread. To avoid this, the iterator holds a struct into which
it accumulates the collected counters for each operation that takes
place in C++. Compared to the overhead of crossing the cgo barrier in
the first place, the added two conditionals seem negligible (and the
branch predictor should do a good job on them).

As a first cut, it prints the number of skipped RocksDB tombstones
into the trace for scan operations.

Was was tempted to make this event log automatic upon closing the
iterator, but this would require passing a `context.Context` into
`(Iterator).Close` as well as `NewIterator` which seemed potentially
controversial.

Release note: None