### PR TITLE
backport-2.0: sql: unreserve VIRTUAL and WORK keywords

### DIFF
--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -845,6 +845,8 @@ col_name_keyword ::=
 	| 'UUID'
 	| 'VALUES'
 	| 'VARCHAR'
+	| 'VIRTUAL'
+	| 'WORK'
 
 with_clause ::=
 	'WITH' cte_list
@@ -1483,12 +1485,10 @@ reserved_keyword ::=
 	| 'USING'
 	| 'VARIADIC'
 	| 'VIEW'
-	| 'VIRTUAL'
 	| 'WHEN'
 	| 'WHERE'
 	| 'WINDOW'
 	| 'WITH'
-	| 'WORK'
 
 opt_equal ::=
 	'='

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -7673,6 +7673,8 @@ col_name_keyword:
 | UUID
 | VALUES
 | VARCHAR
+| VIRTUAL
+| WORK
 
 // Type/function identifier --- keywords that can be type or function names.
 //
@@ -7790,11 +7792,9 @@ reserved_keyword:
 | USING
 | VARIADIC
 | VIEW
-| VIRTUAL
 | WHEN
 | WHERE
 | WINDOW
 | WITH
-| WORK
 
 %%


### PR DESCRIPTION
Backport 1/1 commits from #24491.

/cc @cockroachdb/release

---

These shouldn't have been moved into the reserved keyword section.

I'll cherry-pick this into `release-2.0`.

Release note (sql change): permit VIRTUAL and WORK to be used as
unrestricted names again.
