### PR TITLE
backport-2.0: sql: allow JSONB to be cast to STRING

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/json
+++ b/pkg/sql/logictest/testdata/logic_test/json
@@ -500,3 +500,13 @@ query T
 SELECT '{"foo": {"bar": 1}}'::JSONB #- ARRAY['foo', 'bar']
 ----
 {"foo": {}}
+
+query T
+SELECT '{"a": "b"}'::JSONB::STRING
+----
+{"a": "b"}
+
+query T
+SELECT CAST('{"a": "b"}'::JSONB AS STRING)
+----
+{"a": "b"}

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -2903,6 +2903,8 @@ func PerformCast(ctx *EvalContext, d Datum, t coltypes.CastTargetType) (Datum, e
 			s = buf.String()
 		case *DOid:
 			s = t.name
+		case *DJSON:
+			s = t.JSON.String()
 		}
 		switch c := t.(type) {
 		case *coltypes.TString:

--- a/pkg/sql/sem/tree/expr.go
+++ b/pkg/sql/sem/tree/expr.go
@@ -1223,7 +1223,7 @@ var (
 	decimalCastTypes = []types.T{types.Unknown, types.Bool, types.Int, types.Float, types.Decimal, types.String, types.FamCollatedString,
 		types.Timestamp, types.TimestampTZ, types.Date, types.Interval}
 	stringCastTypes = []types.T{types.Unknown, types.Bool, types.Int, types.Float, types.Decimal, types.String, types.FamCollatedString,
-		types.Bytes, types.Timestamp, types.TimestampTZ, types.Interval, types.UUID, types.Date, types.Time, types.Oid, types.INet}
+		types.Bytes, types.Timestamp, types.TimestampTZ, types.Interval, types.UUID, types.Date, types.Time, types.Oid, types.INet, types.JSON}
 	bytesCastTypes     = []types.T{types.Unknown, types.String, types.FamCollatedString, types.Bytes, types.UUID}
 	dateCastTypes      = []types.T{types.Unknown, types.String, types.FamCollatedString, types.Date, types.Timestamp, types.TimestampTZ, types.Int}
 	timeCastTypes      = []types.T{types.Unknown, types.String, types.FamCollatedString, types.Time, types.Timestamp, types.TimestampTZ, types.Interval}


### PR DESCRIPTION
Backport 1/1 commits from #24518.

/cc @cockroachdb/release

---

I plan on cherry-picking this for 2.0.1.

Release note (bug fix): JSONB values can now be cast to STRINGs.
