### PR TITLE
opt: support for stats in Catalog and INJECT in exec-ddl

### DIFF
--- a/pkg/sql/opt/memo/testdata/logprops/scan
+++ b/pkg/sql/opt/memo/testdata/logprops/scan
@@ -82,3 +82,44 @@ SELECT d FROM a
 scan a
  ├── columns: d:4(decimal!null)
  └── stats: [rows=1000]
+
+exec-ddl
+ALTER TABLE a INJECT STATISTICS '[
+  {
+    "columns": ["x"],
+    "created_at": "2018-01-01 1:00:00.00000+00:00",
+    "row_count": 2000
+  }
+]'
+----
+
+build
+SELECT * FROM a
+----
+scan a
+ ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null)
+ ├── stats: [rows=2000]
+ └── keys: (1) weak(3,4)
+
+exec-ddl
+ALTER TABLE a INJECT STATISTICS '[
+  {
+    "columns": ["x"],
+    "created_at": "2018-01-01 1:00:00.00000+00:00",
+    "row_count": 2000
+  },
+  {
+    "columns": ["y"],
+    "created_at": "2018-01-01 2:00:00.00000+00:00",
+    "row_count": 3000
+  }
+]'
+----
+
+build
+SELECT * FROM a
+----
+scan a
+ ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null)
+ ├── stats: [rows=3000]
+ └── keys: (1) weak(3,4)

--- a/pkg/sql/opt/testutils/alter_table.go
+++ b/pkg/sql/opt/testutils/alter_table.go
@@ -1,0 +1,88 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package testutils
+
+import (
+	gojson "encoding/json"
+	"fmt"
+
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
+	"github.com/cockroachdb/cockroach/pkg/sql/stats"
+)
+
+// AlterTable is a partial implementation of the ALTER TABLE statement.
+//
+// Supported commands:
+//  - INJECT STATISTICS: imports table statistics from a JSON object.
+//
+func (tc *TestCatalog) AlterTable(stmt *tree.AlterTable) {
+	tn, err := stmt.Table.Normalize()
+	if err != nil {
+		panic(err)
+	}
+
+	table, ok := tc.tables[tn.Table()]
+	if !ok {
+		panic(fmt.Sprintf("cannot find table %s", tn.Table()))
+	}
+
+	for _, cmd := range stmt.Cmds {
+		switch t := cmd.(type) {
+		case *tree.AlterTableInjectStats:
+			injectTableStats(table, t.Stats)
+
+		default:
+			panic(fmt.Sprintf("unsupported ALTER TABLE command %T", t))
+		}
+	}
+}
+
+// injectTableStats sets the table statistics as specified by a JSON object.
+func injectTableStats(tt *TestTable, statsExpr tree.Expr) {
+	semaCtx := tree.MakeSemaContext(false /* privileged */)
+	evalCtx := tree.MakeTestingEvalContext(cluster.MakeTestingClusterSettings())
+	typedExpr, err := tree.TypeCheckAndRequire(
+		statsExpr, &semaCtx, types.JSON, "INJECT STATISTICS",
+	)
+	if err != nil {
+		panic(err)
+	}
+	val, err := typedExpr.Eval(&evalCtx)
+	if err != nil {
+		panic(err)
+	}
+
+	if val == tree.DNull {
+		panic("statistics cannot be NULL")
+	}
+	jsonStr := val.(*tree.DJSON).JSON.String()
+	var stats []stats.JSONStatistic
+	if err := gojson.Unmarshal([]byte(jsonStr), &stats); err != nil {
+		panic(err)
+	}
+	tt.Stats = make([]*TestTableStat, len(stats))
+	for i := range stats {
+		tt.Stats[i] = &TestTableStat{js: stats[i], tt: tt}
+	}
+	// Call ColumnOrdinal on all possible columns to assert that
+	// the column names are valid.
+	for _, ts := range tt.Stats {
+		for i := 0; i < ts.ColumnCount(); i++ {
+			ts.ColumnOrdinal(i)
+		}
+	}
+}

--- a/pkg/sql/opt/testutils/utils.go
+++ b/pkg/sql/opt/testutils/utils.go
@@ -77,6 +77,10 @@ func ExecuteTestDDL(tb testing.TB, sql string, catalog *TestCatalog) string {
 		tab := catalog.CreateTable(stmt)
 		return tab.String()
 
+	case *tree.AlterTable:
+		catalog.AlterTable(stmt)
+		return ""
+
 	default:
 		tb.Fatalf("expected CREATE TABLE statement but found: %v", stmt)
 		return ""

--- a/pkg/sql/opt_catalog.go
+++ b/pkg/sql/opt_catalog.go
@@ -135,6 +135,18 @@ func (ot *optTable) Index(i int) opt.Index {
 	return wrapper
 }
 
+// StatisticCount is part of the opt.Table interface.
+func (ot *optTable) StatisticCount() int {
+	// TODO(radu): implement this.
+	return 0
+}
+
+// Statistic is part of the opt.Table interface.
+func (ot *optTable) Statistic(i int) opt.TableStatistic {
+	// TODO(radu): implement this.
+	panic("unimplemented")
+}
+
 // lookupColumnOrdinal returns the ordinal of the column with the given ID. A
 // cache makes the lookup O(1).
 func (ot *optTable) lookupColumnOrdinal(colID sqlbase.ColumnID) int {


### PR DESCRIPTION
Adding support for table statistic in the Catalog interface. Wiring up
the basic row count estimate to the reported statistics.

Implementing the new interfaces in TestCatalog and adding `exec-ddl`
support for `ALTER TABLE INJECT STATISTICS`.

Release note: None