### PR TITLE
sql: introduce the LATERAL keyword and mark it as unimplemented

### DIFF
--- a/pkg/sql/parser/parse_test.go
+++ b/pkg/sql/parser/parse_test.go
@@ -1809,6 +1809,20 @@ UPDATE foo SET a.b = 1
                  ^
 HINT: See: https://github.com/cockroachdb/cockroach/issues/8318`,
 		},
+		{
+			`SELECT * FROM ab, LATERAL (SELECT * FROM kv)`,
+			`unimplemented at or near "EOF"
+SELECT * FROM ab, LATERAL (SELECT * FROM kv)
+                                            ^
+HINT: See: https://github.com/cockroachdb/cockroach/issues/24560`,
+		},
+		{
+			`SELECT * FROM ab, LATERAL foo(a)`,
+			`unimplemented at or near "EOF"
+SELECT * FROM ab, LATERAL foo(a)
+                                ^
+HINT: See: https://github.com/cockroachdb/cockroach/issues/24560`,
+		},
 	}
 	for _, d := range testData {
 		_, err := Parse(d.sql)

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -5127,15 +5127,19 @@ table_ref:
   {
     $$.val = &tree.AliasedTableExpr{Expr: &tree.FuncExpr{Func: $1.resolvableFuncRefFromName(), Exprs: $3.exprs()}, Ordinality: $5.bool(), As: $6.aliasClause() }
   }
+| LATERAL func_name '(' opt_expr_list ')' opt_ordinality opt_alias_clause { return unimplementedWithIssue(sqllex, 24560) }
 | func_name '(' error { return helpWithFunction(sqllex, $1.resolvableFuncRefFromName()) }
+| LATERAL func_name '(' error { return helpWithFunction(sqllex, $2.resolvableFuncRefFromName()) }
 | special_function opt_ordinality opt_alias_clause
   {
       $$.val = &tree.AliasedTableExpr{Expr: $1.expr().(tree.TableExpr), Ordinality: $2.bool(), As: $3.aliasClause() }
   }
+| LATERAL special_function opt_ordinality opt_alias_clause { return unimplementedWithIssue(sqllex, 24560) }
 | select_with_parens opt_ordinality opt_alias_clause
   {
     $$.val = &tree.AliasedTableExpr{Expr: &tree.Subquery{Select: $1.selectStmt()}, Ordinality: $2.bool(), As: $3.aliasClause() }
   }
+| LATERAL select_with_parens opt_ordinality opt_alias_clause { return unimplementedWithIssue(sqllex, 24560) }
 | joined_table
   {
     $$.val = $1.tblExpr()


### PR DESCRIPTION
CockroachDB aims to implement lateral joins. Until then, recognize
the syntax and link the error message to the appropriate support
issue.

This incidentally motivates keeping the keyword "reserved" in the
grammar.

Release note: None

Informs #24489.
Refers to #24560.
cc @petermattis 