### PR TITLE
sql: handle inverted index queries involving NULL

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/inverted_index
+++ b/pkg/sql/logictest/testdata/logic_test/inverted_index
@@ -156,6 +156,14 @@ INSERT INTO d VALUES (31,  '{"a": []}')
 statement ok
 INSERT INTO d VALUES (32,  '{"a": [1, 2, 3, 4]}')
 
+query IT
+SELECT * from d where b @> (NULL::JSON) ORDER BY a;
+----
+ 
+query IT
+SELECT * from d where b @> NULL ORDER BY a;
+----
+
 query TITTTTT
 EXPLAIN (VERBOSE) SELECT * from d where b @>'{"a": "b"}'
 ----

--- a/pkg/sql/opt/index_constraints.go
+++ b/pkg/sql/opt/index_constraints.go
@@ -834,6 +834,12 @@ func (c *indexConstraintCtx) makeInvertedIndexSpansForExpr(
 		}
 
 		rightDatum := rhs.private.(tree.Datum)
+
+		// NULL is never contained, return no spans.
+		if rightDatum == tree.DNull {
+			return LogicalSpans{}, true, true
+		}
+
 		rd := rightDatum.(*tree.DJSON).JSON
 
 		switch rd.Type() {


### PR DESCRIPTION
Please note this commit is directly against the 2.0 branch as the index
constraint code has changed significantly. The equivalent PR for the
master version is #24251.

Release note (bug fix): Fix a panic involving inverted index queries
over NULL.