### PR TITLE
roachtest: fix running tests locally

### DIFF
--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -316,7 +316,9 @@ type nodeSpec struct {
 
 func (s *nodeSpec) args() []string {
 	var args []string
-	args = append(args, s.MachineType)
+	if s.MachineType != "" {
+		args = append(args, s.MachineType)
+	}
 	if s.Geo {
 		args = append(args, "--geo")
 	}


### PR DESCRIPTION
`roachtest run -l` was broken because we were adding an extra empty
argument to the command line for tests which don't specifying a
machine-type (i.e. nearly all tests).

Release note: None