### PR TITLE
makefile: add benchshort

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -801,9 +801,13 @@ bench: TESTS := -
 bench: BENCHES := .
 bench: TESTTIMEOUT := $(BENCHTIMEOUT)
 
-.PHONY: check test testshort testrace testlogic testccllogic bench
+# -benchtime=1ns runs one iteration of each benchmark. The -short flag is set so
+# that longer running benchmarks can skip themselves.
+benchshort: override TESTFLAGS += -benchtime=1ns -short
+
+.PHONY: check test testshort testrace testlogic testccllogic bench benchshort
 test: ## Run tests.
-check test testshort testrace bench: gotestdashi
+check test testshort testrace bench benchshort: gotestdashi
 	$(XGO) test $(GOFLAGS) -tags '$(TAGS)' -ldflags '$(LINKFLAGS)' -run "$(TESTS)" $(if $(BENCHES),-bench "$(BENCHES)") -timeout $(TESTTIMEOUT) $(PKG) $(TESTFLAGS)
 
 testlogic: ## Run SQL Logic Tests.


### PR DESCRIPTION
This sets the -benchtime flag to 1ns, which results in benchmarks
running for one iteration. The -short flag is also set so that
benchmarks can tell if they are being run in this short mode and
exit if one iteration of the benchmark would take too long.

The reason for this change is that we want to avoid benchmarks becoming
stale. When making a change, we should be able to quickly figure out
what benchmarks are affected and update them accordingly. Currently,
runtime issues only surface when the benchmark is run after the fact
to measure the performance impact of another change.

Future work involves modifying long-running benchmarks to observe the
-short flag and adding `benchshort` to CI once `benchshort` runs
succesfully.

Release note: None

cc @jordanlewis @danhhz 