### PR TITLE
ui: remove link to cluster settings API endpoint

### DIFF
--- a/pkg/ui/src/views/reports/containers/debug/index.tsx
+++ b/pkg/ui/src/views/reports/containers/debug/index.tsx
@@ -196,7 +196,6 @@ export default function Debug() {
           <DebugTableLink name="All Sessions" url="/_status/sessions" />
         </DebugTableRow>
         <DebugTableRow title="Cluster Wide">
-          <DebugTableLink name="Cluster Settings" url="/_admin/v1/settings" />
           <DebugTableLink name="Raft" url="/_status/raft" />
           <DebugTableLink
             name="Range"


### PR DESCRIPTION
@a-robinson added this link to the raw cluster settings endpoint recently (I approved it). 5 days later, @BramGruneir added an HTML page displaying the same information, and we forgot to remove this link.

Release note: None