### PR TITLE
sql: eval RHS in inverted index normalization

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/inverted_index
+++ b/pkg/sql/logictest/testdata/logic_test/inverted_index
@@ -267,6 +267,14 @@ SELECT * from d where b @>'{"a": "b"}' ORDER BY a;
 7  {"a": "b", "c": "d"}
 
 statement ok
+PREPARE query (STRING, STRING) AS SELECT * from d where b->$1 = $2 ORDER BY a
+
+query IT
+EXECUTE query ('a', '"b"')
+----
+7  {"a": "b", "c": "d"}
+
+statement ok
 DELETE from d WHERE a=6;
 
 query IT
@@ -737,7 +745,6 @@ DROP TABLE del_cascade_test
 
 statement ok
 UPDATE update_test SET (i,j)  = (5, '{"a":"b", "a":"b"}') WHERE i = 1;
-
 
 query IT
 SELECT * from update_cascade_test ORDER BY update_cascade;

--- a/pkg/sql/sem/tree/normalize.go
+++ b/pkg/sql/sem/tree/normalize.go
@@ -434,8 +434,13 @@ func (expr *ComparisonExpr) normalize(v *NormalizeVisitor) TypedExpr {
 					break
 				}
 
+				rhs, err := expr.TypedRight().Eval(v.ctx)
+				if err != nil {
+					break
+				}
+
 				j := json.NewObjectBuilder(1)
-				j.Add(string(*str.(*DString)), expr.Right.(*DJSON).JSON)
+				j.Add(string(*str.(*DString)), rhs.(*DJSON).JSON)
 
 				dj, err := MakeDJSON(j.Build())
 				if err != nil {


### PR DESCRIPTION
Fixes #24545.

Going to cherry-pick this to 2.0.1.

Release note (bug fix): Fixed a panic around inverted index queries
using the -> operator.