### PR TITLE
[WIP] sql/parse: unreserve ROLE as a keyword

### DIFF
--- a/docs/generated/sql/bnf/create_index_stmt.bnf
+++ b/docs/generated/sql/bnf/create_index_stmt.bnf
@@ -1,37 +1,37 @@
 create_index_stmt ::=
-	'CREATE' 'UNIQUE' 'INDEX' opt_index_name 'ON' table_name  '(' column_name 'ASC' ( ( ',' ( column_name ( 'ASC' | 'DESC' |  ) ) ) )* ')' 'COVERING' '(' name_list ')' opt_interleave opt_partition_by
-	| 'CREATE' 'UNIQUE' 'INDEX' opt_index_name 'ON' table_name  '(' column_name 'ASC' ( ( ',' ( column_name ( 'ASC' | 'DESC' |  ) ) ) )* ')' 'STORING' '(' name_list ')' opt_interleave opt_partition_by
-	| 'CREATE' 'UNIQUE' 'INDEX' opt_index_name 'ON' table_name  '(' column_name 'ASC' ( ( ',' ( column_name ( 'ASC' | 'DESC' |  ) ) ) )* ')'  opt_interleave opt_partition_by
-	| 'CREATE' 'UNIQUE' 'INDEX' opt_index_name 'ON' table_name  '(' column_name 'DESC' ( ( ',' ( column_name ( 'ASC' | 'DESC' |  ) ) ) )* ')' 'COVERING' '(' name_list ')' opt_interleave opt_partition_by
-	| 'CREATE' 'UNIQUE' 'INDEX' opt_index_name 'ON' table_name  '(' column_name 'DESC' ( ( ',' ( column_name ( 'ASC' | 'DESC' |  ) ) ) )* ')' 'STORING' '(' name_list ')' opt_interleave opt_partition_by
-	| 'CREATE' 'UNIQUE' 'INDEX' opt_index_name 'ON' table_name  '(' column_name 'DESC' ( ( ',' ( column_name ( 'ASC' | 'DESC' |  ) ) ) )* ')'  opt_interleave opt_partition_by
-	| 'CREATE' 'UNIQUE' 'INDEX' opt_index_name 'ON' table_name  '(' column_name  ( ( ',' ( column_name ( 'ASC' | 'DESC' |  ) ) ) )* ')' 'COVERING' '(' name_list ')' opt_interleave opt_partition_by
-	| 'CREATE' 'UNIQUE' 'INDEX' opt_index_name 'ON' table_name  '(' column_name  ( ( ',' ( column_name ( 'ASC' | 'DESC' |  ) ) ) )* ')' 'STORING' '(' name_list ')' opt_interleave opt_partition_by
-	| 'CREATE' 'UNIQUE' 'INDEX' opt_index_name 'ON' table_name  '(' column_name  ( ( ',' ( column_name ( 'ASC' | 'DESC' |  ) ) ) )* ')'  opt_interleave opt_partition_by
-	| 'CREATE'  'INDEX' opt_index_name 'ON' table_name  '(' column_name 'ASC' ( ( ',' ( column_name ( 'ASC' | 'DESC' |  ) ) ) )* ')' 'COVERING' '(' name_list ')' opt_interleave opt_partition_by
-	| 'CREATE'  'INDEX' opt_index_name 'ON' table_name  '(' column_name 'ASC' ( ( ',' ( column_name ( 'ASC' | 'DESC' |  ) ) ) )* ')' 'STORING' '(' name_list ')' opt_interleave opt_partition_by
-	| 'CREATE'  'INDEX' opt_index_name 'ON' table_name  '(' column_name 'ASC' ( ( ',' ( column_name ( 'ASC' | 'DESC' |  ) ) ) )* ')'  opt_interleave opt_partition_by
-	| 'CREATE'  'INDEX' opt_index_name 'ON' table_name  '(' column_name 'DESC' ( ( ',' ( column_name ( 'ASC' | 'DESC' |  ) ) ) )* ')' 'COVERING' '(' name_list ')' opt_interleave opt_partition_by
-	| 'CREATE'  'INDEX' opt_index_name 'ON' table_name  '(' column_name 'DESC' ( ( ',' ( column_name ( 'ASC' | 'DESC' |  ) ) ) )* ')' 'STORING' '(' name_list ')' opt_interleave opt_partition_by
-	| 'CREATE'  'INDEX' opt_index_name 'ON' table_name  '(' column_name 'DESC' ( ( ',' ( column_name ( 'ASC' | 'DESC' |  ) ) ) )* ')'  opt_interleave opt_partition_by
-	| 'CREATE'  'INDEX' opt_index_name 'ON' table_name  '(' column_name  ( ( ',' ( column_name ( 'ASC' | 'DESC' |  ) ) ) )* ')' 'COVERING' '(' name_list ')' opt_interleave opt_partition_by
-	| 'CREATE'  'INDEX' opt_index_name 'ON' table_name  '(' column_name  ( ( ',' ( column_name ( 'ASC' | 'DESC' |  ) ) ) )* ')' 'STORING' '(' name_list ')' opt_interleave opt_partition_by
-	| 'CREATE'  'INDEX' opt_index_name 'ON' table_name  '(' column_name  ( ( ',' ( column_name ( 'ASC' | 'DESC' |  ) ) ) )* ')'  opt_interleave opt_partition_by
-	| 'CREATE' 'UNIQUE' 'INDEX' 'IF' 'NOT' 'EXISTS' index_name 'ON' table_name  '(' column_name 'ASC' ( ( ',' ( column_name ( 'ASC' | 'DESC' |  ) ) ) )* ')' 'COVERING' '(' name_list ')' opt_interleave opt_partition_by
-	| 'CREATE' 'UNIQUE' 'INDEX' 'IF' 'NOT' 'EXISTS' index_name 'ON' table_name  '(' column_name 'ASC' ( ( ',' ( column_name ( 'ASC' | 'DESC' |  ) ) ) )* ')' 'STORING' '(' name_list ')' opt_interleave opt_partition_by
-	| 'CREATE' 'UNIQUE' 'INDEX' 'IF' 'NOT' 'EXISTS' index_name 'ON' table_name  '(' column_name 'ASC' ( ( ',' ( column_name ( 'ASC' | 'DESC' |  ) ) ) )* ')'  opt_interleave opt_partition_by
-	| 'CREATE' 'UNIQUE' 'INDEX' 'IF' 'NOT' 'EXISTS' index_name 'ON' table_name  '(' column_name 'DESC' ( ( ',' ( column_name ( 'ASC' | 'DESC' |  ) ) ) )* ')' 'COVERING' '(' name_list ')' opt_interleave opt_partition_by
-	| 'CREATE' 'UNIQUE' 'INDEX' 'IF' 'NOT' 'EXISTS' index_name 'ON' table_name  '(' column_name 'DESC' ( ( ',' ( column_name ( 'ASC' | 'DESC' |  ) ) ) )* ')' 'STORING' '(' name_list ')' opt_interleave opt_partition_by
-	| 'CREATE' 'UNIQUE' 'INDEX' 'IF' 'NOT' 'EXISTS' index_name 'ON' table_name  '(' column_name 'DESC' ( ( ',' ( column_name ( 'ASC' | 'DESC' |  ) ) ) )* ')'  opt_interleave opt_partition_by
-	| 'CREATE' 'UNIQUE' 'INDEX' 'IF' 'NOT' 'EXISTS' index_name 'ON' table_name  '(' column_name  ( ( ',' ( column_name ( 'ASC' | 'DESC' |  ) ) ) )* ')' 'COVERING' '(' name_list ')' opt_interleave opt_partition_by
-	| 'CREATE' 'UNIQUE' 'INDEX' 'IF' 'NOT' 'EXISTS' index_name 'ON' table_name  '(' column_name  ( ( ',' ( column_name ( 'ASC' | 'DESC' |  ) ) ) )* ')' 'STORING' '(' name_list ')' opt_interleave opt_partition_by
-	| 'CREATE' 'UNIQUE' 'INDEX' 'IF' 'NOT' 'EXISTS' index_name 'ON' table_name  '(' column_name  ( ( ',' ( column_name ( 'ASC' | 'DESC' |  ) ) ) )* ')'  opt_interleave opt_partition_by
-	| 'CREATE'  'INDEX' 'IF' 'NOT' 'EXISTS' index_name 'ON' table_name  '(' column_name 'ASC' ( ( ',' ( column_name ( 'ASC' | 'DESC' |  ) ) ) )* ')' 'COVERING' '(' name_list ')' opt_interleave opt_partition_by
-	| 'CREATE'  'INDEX' 'IF' 'NOT' 'EXISTS' index_name 'ON' table_name  '(' column_name 'ASC' ( ( ',' ( column_name ( 'ASC' | 'DESC' |  ) ) ) )* ')' 'STORING' '(' name_list ')' opt_interleave opt_partition_by
-	| 'CREATE'  'INDEX' 'IF' 'NOT' 'EXISTS' index_name 'ON' table_name  '(' column_name 'ASC' ( ( ',' ( column_name ( 'ASC' | 'DESC' |  ) ) ) )* ')'  opt_interleave opt_partition_by
-	| 'CREATE'  'INDEX' 'IF' 'NOT' 'EXISTS' index_name 'ON' table_name  '(' column_name 'DESC' ( ( ',' ( column_name ( 'ASC' | 'DESC' |  ) ) ) )* ')' 'COVERING' '(' name_list ')' opt_interleave opt_partition_by
-	| 'CREATE'  'INDEX' 'IF' 'NOT' 'EXISTS' index_name 'ON' table_name  '(' column_name 'DESC' ( ( ',' ( column_name ( 'ASC' | 'DESC' |  ) ) ) )* ')' 'STORING' '(' name_list ')' opt_interleave opt_partition_by
-	| 'CREATE'  'INDEX' 'IF' 'NOT' 'EXISTS' index_name 'ON' table_name  '(' column_name 'DESC' ( ( ',' ( column_name ( 'ASC' | 'DESC' |  ) ) ) )* ')'  opt_interleave opt_partition_by
-	| 'CREATE'  'INDEX' 'IF' 'NOT' 'EXISTS' index_name 'ON' table_name  '(' column_name  ( ( ',' ( column_name ( 'ASC' | 'DESC' |  ) ) ) )* ')' 'COVERING' '(' name_list ')' opt_interleave opt_partition_by
-	| 'CREATE'  'INDEX' 'IF' 'NOT' 'EXISTS' index_name 'ON' table_name  '(' column_name  ( ( ',' ( column_name ( 'ASC' | 'DESC' |  ) ) ) )* ')' 'STORING' '(' name_list ')' opt_interleave opt_partition_by
-	| 'CREATE'  'INDEX' 'IF' 'NOT' 'EXISTS' index_name 'ON' table_name  '(' column_name  ( ( ',' ( column_name ( 'ASC' | 'DESC' |  ) ) ) )* ')'  opt_interleave opt_partition_by
+	'CREATE' 'UNIQUE' 'INDEX' opt_index_name on table_name  '(' column_name 'ASC' ( ( ',' ( column_name ( 'ASC' | 'DESC' |  ) ) ) )* ')' 'COVERING' '(' name_list ')' opt_interleave opt_partition_by
+	| 'CREATE' 'UNIQUE' 'INDEX' opt_index_name on table_name  '(' column_name 'ASC' ( ( ',' ( column_name ( 'ASC' | 'DESC' |  ) ) ) )* ')' 'STORING' '(' name_list ')' opt_interleave opt_partition_by
+	| 'CREATE' 'UNIQUE' 'INDEX' opt_index_name on table_name  '(' column_name 'ASC' ( ( ',' ( column_name ( 'ASC' | 'DESC' |  ) ) ) )* ')'  opt_interleave opt_partition_by
+	| 'CREATE' 'UNIQUE' 'INDEX' opt_index_name on table_name  '(' column_name 'DESC' ( ( ',' ( column_name ( 'ASC' | 'DESC' |  ) ) ) )* ')' 'COVERING' '(' name_list ')' opt_interleave opt_partition_by
+	| 'CREATE' 'UNIQUE' 'INDEX' opt_index_name on table_name  '(' column_name 'DESC' ( ( ',' ( column_name ( 'ASC' | 'DESC' |  ) ) ) )* ')' 'STORING' '(' name_list ')' opt_interleave opt_partition_by
+	| 'CREATE' 'UNIQUE' 'INDEX' opt_index_name on table_name  '(' column_name 'DESC' ( ( ',' ( column_name ( 'ASC' | 'DESC' |  ) ) ) )* ')'  opt_interleave opt_partition_by
+	| 'CREATE' 'UNIQUE' 'INDEX' opt_index_name on table_name  '(' column_name  ( ( ',' ( column_name ( 'ASC' | 'DESC' |  ) ) ) )* ')' 'COVERING' '(' name_list ')' opt_interleave opt_partition_by
+	| 'CREATE' 'UNIQUE' 'INDEX' opt_index_name on table_name  '(' column_name  ( ( ',' ( column_name ( 'ASC' | 'DESC' |  ) ) ) )* ')' 'STORING' '(' name_list ')' opt_interleave opt_partition_by
+	| 'CREATE' 'UNIQUE' 'INDEX' opt_index_name on table_name  '(' column_name  ( ( ',' ( column_name ( 'ASC' | 'DESC' |  ) ) ) )* ')'  opt_interleave opt_partition_by
+	| 'CREATE'  'INDEX' opt_index_name on table_name  '(' column_name 'ASC' ( ( ',' ( column_name ( 'ASC' | 'DESC' |  ) ) ) )* ')' 'COVERING' '(' name_list ')' opt_interleave opt_partition_by
+	| 'CREATE'  'INDEX' opt_index_name on table_name  '(' column_name 'ASC' ( ( ',' ( column_name ( 'ASC' | 'DESC' |  ) ) ) )* ')' 'STORING' '(' name_list ')' opt_interleave opt_partition_by
+	| 'CREATE'  'INDEX' opt_index_name on table_name  '(' column_name 'ASC' ( ( ',' ( column_name ( 'ASC' | 'DESC' |  ) ) ) )* ')'  opt_interleave opt_partition_by
+	| 'CREATE'  'INDEX' opt_index_name on table_name  '(' column_name 'DESC' ( ( ',' ( column_name ( 'ASC' | 'DESC' |  ) ) ) )* ')' 'COVERING' '(' name_list ')' opt_interleave opt_partition_by
+	| 'CREATE'  'INDEX' opt_index_name on table_name  '(' column_name 'DESC' ( ( ',' ( column_name ( 'ASC' | 'DESC' |  ) ) ) )* ')' 'STORING' '(' name_list ')' opt_interleave opt_partition_by
+	| 'CREATE'  'INDEX' opt_index_name on table_name  '(' column_name 'DESC' ( ( ',' ( column_name ( 'ASC' | 'DESC' |  ) ) ) )* ')'  opt_interleave opt_partition_by
+	| 'CREATE'  'INDEX' opt_index_name on table_name  '(' column_name  ( ( ',' ( column_name ( 'ASC' | 'DESC' |  ) ) ) )* ')' 'COVERING' '(' name_list ')' opt_interleave opt_partition_by
+	| 'CREATE'  'INDEX' opt_index_name on table_name  '(' column_name  ( ( ',' ( column_name ( 'ASC' | 'DESC' |  ) ) ) )* ')' 'STORING' '(' name_list ')' opt_interleave opt_partition_by
+	| 'CREATE'  'INDEX' opt_index_name on table_name  '(' column_name  ( ( ',' ( column_name ( 'ASC' | 'DESC' |  ) ) ) )* ')'  opt_interleave opt_partition_by
+	| 'CREATE' 'UNIQUE' 'INDEX' 'IF' 'NOT' 'EXISTS' index_name on table_name  '(' column_name 'ASC' ( ( ',' ( column_name ( 'ASC' | 'DESC' |  ) ) ) )* ')' 'COVERING' '(' name_list ')' opt_interleave opt_partition_by
+	| 'CREATE' 'UNIQUE' 'INDEX' 'IF' 'NOT' 'EXISTS' index_name on table_name  '(' column_name 'ASC' ( ( ',' ( column_name ( 'ASC' | 'DESC' |  ) ) ) )* ')' 'STORING' '(' name_list ')' opt_interleave opt_partition_by
+	| 'CREATE' 'UNIQUE' 'INDEX' 'IF' 'NOT' 'EXISTS' index_name on table_name  '(' column_name 'ASC' ( ( ',' ( column_name ( 'ASC' | 'DESC' |  ) ) ) )* ')'  opt_interleave opt_partition_by
+	| 'CREATE' 'UNIQUE' 'INDEX' 'IF' 'NOT' 'EXISTS' index_name on table_name  '(' column_name 'DESC' ( ( ',' ( column_name ( 'ASC' | 'DESC' |  ) ) ) )* ')' 'COVERING' '(' name_list ')' opt_interleave opt_partition_by
+	| 'CREATE' 'UNIQUE' 'INDEX' 'IF' 'NOT' 'EXISTS' index_name on table_name  '(' column_name 'DESC' ( ( ',' ( column_name ( 'ASC' | 'DESC' |  ) ) ) )* ')' 'STORING' '(' name_list ')' opt_interleave opt_partition_by
+	| 'CREATE' 'UNIQUE' 'INDEX' 'IF' 'NOT' 'EXISTS' index_name on table_name  '(' column_name 'DESC' ( ( ',' ( column_name ( 'ASC' | 'DESC' |  ) ) ) )* ')'  opt_interleave opt_partition_by
+	| 'CREATE' 'UNIQUE' 'INDEX' 'IF' 'NOT' 'EXISTS' index_name on table_name  '(' column_name  ( ( ',' ( column_name ( 'ASC' | 'DESC' |  ) ) ) )* ')' 'COVERING' '(' name_list ')' opt_interleave opt_partition_by
+	| 'CREATE' 'UNIQUE' 'INDEX' 'IF' 'NOT' 'EXISTS' index_name on table_name  '(' column_name  ( ( ',' ( column_name ( 'ASC' | 'DESC' |  ) ) ) )* ')' 'STORING' '(' name_list ')' opt_interleave opt_partition_by
+	| 'CREATE' 'UNIQUE' 'INDEX' 'IF' 'NOT' 'EXISTS' index_name on table_name  '(' column_name  ( ( ',' ( column_name ( 'ASC' | 'DESC' |  ) ) ) )* ')'  opt_interleave opt_partition_by
+	| 'CREATE'  'INDEX' 'IF' 'NOT' 'EXISTS' index_name on table_name  '(' column_name 'ASC' ( ( ',' ( column_name ( 'ASC' | 'DESC' |  ) ) ) )* ')' 'COVERING' '(' name_list ')' opt_interleave opt_partition_by
+	| 'CREATE'  'INDEX' 'IF' 'NOT' 'EXISTS' index_name on table_name  '(' column_name 'ASC' ( ( ',' ( column_name ( 'ASC' | 'DESC' |  ) ) ) )* ')' 'STORING' '(' name_list ')' opt_interleave opt_partition_by
+	| 'CREATE'  'INDEX' 'IF' 'NOT' 'EXISTS' index_name on table_name  '(' column_name 'ASC' ( ( ',' ( column_name ( 'ASC' | 'DESC' |  ) ) ) )* ')'  opt_interleave opt_partition_by
+	| 'CREATE'  'INDEX' 'IF' 'NOT' 'EXISTS' index_name on table_name  '(' column_name 'DESC' ( ( ',' ( column_name ( 'ASC' | 'DESC' |  ) ) ) )* ')' 'COVERING' '(' name_list ')' opt_interleave opt_partition_by
+	| 'CREATE'  'INDEX' 'IF' 'NOT' 'EXISTS' index_name on table_name  '(' column_name 'DESC' ( ( ',' ( column_name ( 'ASC' | 'DESC' |  ) ) ) )* ')' 'STORING' '(' name_list ')' opt_interleave opt_partition_by
+	| 'CREATE'  'INDEX' 'IF' 'NOT' 'EXISTS' index_name on table_name  '(' column_name 'DESC' ( ( ',' ( column_name ( 'ASC' | 'DESC' |  ) ) ) )* ')'  opt_interleave opt_partition_by
+	| 'CREATE'  'INDEX' 'IF' 'NOT' 'EXISTS' index_name on table_name  '(' column_name  ( ( ',' ( column_name ( 'ASC' | 'DESC' |  ) ) ) )* ')' 'COVERING' '(' name_list ')' opt_interleave opt_partition_by
+	| 'CREATE'  'INDEX' 'IF' 'NOT' 'EXISTS' index_name on table_name  '(' column_name  ( ( ',' ( column_name ( 'ASC' | 'DESC' |  ) ) ) )* ')' 'STORING' '(' name_list ')' opt_interleave opt_partition_by
+	| 'CREATE'  'INDEX' 'IF' 'NOT' 'EXISTS' index_name on table_name  '(' column_name  ( ( ',' ( column_name ( 'ASC' | 'DESC' |  ) ) ) )* ')'  opt_interleave opt_partition_by

--- a/docs/generated/sql/bnf/create_inverted_index_stmt.bnf
+++ b/docs/generated/sql/bnf/create_inverted_index_stmt.bnf
@@ -1,7 +1,7 @@
 create_index_stmt ::=
-	'CREATE' 'INVERTED' 'INDEX' opt_index_name 'ON' table_name '(' column_name 'ASC' ( ( ',' ( column_name ( 'ASC' | 'DESC' |  ) ) ) )* ')'
-	| 'CREATE' 'INVERTED' 'INDEX' opt_index_name 'ON' table_name '(' column_name 'DESC' ( ( ',' ( column_name ( 'ASC' | 'DESC' |  ) ) ) )* ')'
-	| 'CREATE' 'INVERTED' 'INDEX' opt_index_name 'ON' table_name '(' column_name  ( ( ',' ( column_name ( 'ASC' | 'DESC' |  ) ) ) )* ')'
-	| 'CREATE' 'INVERTED' 'INDEX' 'IF' 'NOT' 'EXISTS' index_name 'ON' table_name '(' column_name 'ASC' ( ( ',' ( column_name ( 'ASC' | 'DESC' |  ) ) ) )* ')'
-	| 'CREATE' 'INVERTED' 'INDEX' 'IF' 'NOT' 'EXISTS' index_name 'ON' table_name '(' column_name 'DESC' ( ( ',' ( column_name ( 'ASC' | 'DESC' |  ) ) ) )* ')'
-	| 'CREATE' 'INVERTED' 'INDEX' 'IF' 'NOT' 'EXISTS' index_name 'ON' table_name '(' column_name  ( ( ',' ( column_name ( 'ASC' | 'DESC' |  ) ) ) )* ')'
+	'CREATE' 'INVERTED' 'INDEX' opt_index_name on table_name '(' column_name 'ASC' ( ( ',' ( column_name ( 'ASC' | 'DESC' |  ) ) ) )* ')'
+	| 'CREATE' 'INVERTED' 'INDEX' opt_index_name on table_name '(' column_name 'DESC' ( ( ',' ( column_name ( 'ASC' | 'DESC' |  ) ) ) )* ')'
+	| 'CREATE' 'INVERTED' 'INDEX' opt_index_name on table_name '(' column_name  ( ( ',' ( column_name ( 'ASC' | 'DESC' |  ) ) ) )* ')'
+	| 'CREATE' 'INVERTED' 'INDEX' 'IF' 'NOT' 'EXISTS' index_name on table_name '(' column_name 'ASC' ( ( ',' ( column_name ( 'ASC' | 'DESC' |  ) ) ) )* ')'
+	| 'CREATE' 'INVERTED' 'INDEX' 'IF' 'NOT' 'EXISTS' index_name on table_name '(' column_name 'DESC' ( ( ',' ( column_name ( 'ASC' | 'DESC' |  ) ) ) )* ')'
+	| 'CREATE' 'INVERTED' 'INDEX' 'IF' 'NOT' 'EXISTS' index_name on table_name '(' column_name  ( ( ',' ( column_name ( 'ASC' | 'DESC' |  ) ) ) )* ')'

--- a/docs/generated/sql/bnf/grant_privileges.bnf
+++ b/docs/generated/sql/bnf/grant_privileges.bnf
@@ -1,4 +1,4 @@
 grant_stmt ::=
-	'GRANT' ( 'ALL' | ( ( ( 'CREATE' | 'GRANT' | 'SELECT' | 'DROP' | 'INSERT' | 'DELETE' | 'UPDATE' ) ) ( ( ',' ( 'CREATE' | 'GRANT' | 'SELECT' | 'DROP' | 'INSERT' | 'DELETE' | 'UPDATE' ) ) )* ) ) 'ON' ( ( ( table_name ) ( ( ',' table_name ) )* ) | 'TABLE' ( ( table_name ) ( ( ',' table_name ) )* ) | 'DATABASE' ( ( database_name ) ( ( ',' database_name ) )* ) ) 'TO' ( ( user_name ) ( ( ',' user_name ) )* )
+	'GRANT' ( 'ALL' | ( ( ( 'CREATE' | 'GRANT' | 'SELECT' | 'DROP' | 'INSERT' | 'DELETE' | 'UPDATE' ) ) ( ( ',' ( 'CREATE' | 'GRANT' | 'SELECT' | 'DROP' | 'INSERT' | 'DELETE' | 'UPDATE' ) ) )* ) ) on ( ( ( table_name ) ( ( ',' table_name ) )* ) | 'TABLE' ( ( table_name ) ( ( ',' table_name ) )* ) | 'DATABASE' ( ( database_name ) ( ( ',' database_name ) )* ) ) 'TO' ( ( user_name ) ( ( ',' user_name ) )* )
 	
 	 

--- a/docs/generated/sql/bnf/grant_roles.bnf
+++ b/docs/generated/sql/bnf/grant_roles.bnf
@@ -1,2 +1,1 @@
 grant_stmt ::=
-	'GRANT' ( role_name ) ( ( ',' role_name ) )* 'TO' ( user_name ) ( ( ',' user_name ) )*

--- a/docs/generated/sql/bnf/joined_table.bnf
+++ b/docs/generated/sql/bnf/joined_table.bnf
@@ -1,7 +1,7 @@
 joined_table ::=
 	'(' joined_table ')'
 	| table_ref 'CROSS' 'JOIN' table_ref
-	| table_ref ( 'FULL' ( 'OUTER' |  ) | 'LEFT' ( 'OUTER' |  ) | 'RIGHT' ( 'OUTER' |  ) | 'INNER' ) 'JOIN' table_ref ( 'USING' '(' ( ( name ) ( ( ',' name ) )* ) ')' | 'ON' a_expr )
-	| table_ref 'JOIN' table_ref ( 'USING' '(' ( ( name ) ( ( ',' name ) )* ) ')' | 'ON' a_expr )
+	| table_ref ( 'FULL' ( 'OUTER' |  ) | 'LEFT' ( 'OUTER' |  ) | 'RIGHT' ( 'OUTER' |  ) | 'INNER' ) 'JOIN' table_ref ( 'USING' '(' ( ( name ) ( ( ',' name ) )* ) ')' | on a_expr )
+	| table_ref 'JOIN' table_ref ( 'USING' '(' ( ( name ) ( ( ',' name ) )* ) ')' | on a_expr )
 	| table_ref 'NATURAL' ( 'FULL' ( 'OUTER' |  ) | 'LEFT' ( 'OUTER' |  ) | 'RIGHT' ( 'OUTER' |  ) | 'INNER' ) 'JOIN' table_ref
 	| table_ref 'NATURAL' 'JOIN' table_ref

--- a/docs/generated/sql/bnf/revoke_privileges.bnf
+++ b/docs/generated/sql/bnf/revoke_privileges.bnf
@@ -1,4 +1,4 @@
 revoke_stmt ::=
-	'REVOKE' ( 'ALL' | ( ( ( 'CREATE' | 'GRANT' | 'SELECT' | 'DROP' | 'INSERT' | 'DELETE' | 'UPDATE' ) ) ( ( ',' ( 'CREATE' | 'GRANT' | 'SELECT' | 'DROP' | 'INSERT' | 'DELETE' | 'UPDATE' ) ) )* ) ) 'ON' ( ( ( table_name ) ( ( ',' table_name ) )* ) | 'TABLE' ( ( table_name ) ( ( ',' table_name ) )* ) | 'DATABASE' ( ( database_name ) ( ( ',' database_name ) )* ) ) 'FROM' ( ( user_name ) ( ( ',' user_name ) )* )
+	'REVOKE' ( 'ALL' | ( ( ( 'CREATE' | 'GRANT' | 'SELECT' | 'DROP' | 'INSERT' | 'DELETE' | 'UPDATE' ) ) ( ( ',' ( 'CREATE' | 'GRANT' | 'SELECT' | 'DROP' | 'INSERT' | 'DELETE' | 'UPDATE' ) ) )* ) ) on ( ( ( table_name ) ( ( ',' table_name ) )* ) | 'TABLE' ( ( table_name ) ( ( ',' table_name ) )* ) | 'DATABASE' ( ( database_name ) ( ( ',' database_name ) )* ) ) 'FROM' ( ( user_name ) ( ( ',' user_name ) )* )
 	
 	

--- a/docs/generated/sql/bnf/revoke_roles.bnf
+++ b/docs/generated/sql/bnf/revoke_roles.bnf
@@ -1,2 +1,1 @@
 revoke_stmt ::=
-	'REVOKE' ( role_name ) ( ( ',' role_name ) )* 'FROM' ( user_name ) ( ( ',' user_name ) )*

--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -84,7 +84,7 @@ explain_stmt ::=
 	| 'EXPLAIN' '(' explain_option_list ')' explainable_stmt
 
 grant_stmt ::=
-	'GRANT' privileges 'ON' targets 'TO' name_list
+	'GRANT' privileges on targets 'TO' name_list
 	| 'GRANT' privilege_list 'TO' name_list
 	| 'GRANT' privilege_list 'TO' name_list 'WITH' 'ADMIN' 'OPTION'
 
@@ -110,7 +110,7 @@ resume_stmt ::=
 	'RESUME' 'JOB' a_expr
 
 revoke_stmt ::=
-	'REVOKE' privileges 'ON' targets 'FROM' name_list
+	'REVOKE' privileges on targets 'FROM' name_list
 	| 'REVOKE' privilege_list 'FROM' name_list
 	| 'REVOKE' 'ADMIN' 'OPTION' 'FOR' privilege_list 'FROM' name_list
 
@@ -243,7 +243,7 @@ create_ddl_stmt ::=
 	| create_sequence_stmt
 
 create_stats_stmt ::=
-	'CREATE' 'STATISTICS' statistics_name 'ON' name_list 'FROM' table_name
+	'CREATE' 'STATISTICS' statistics_name on name_list 'FROM' table_name
 
 name ::=
 	'identifier'
@@ -312,6 +312,10 @@ explain_option_list ::=
 privileges ::=
 	'ALL'
 	| privilege_list
+
+on ::=
+	'ON'
+	| 'ON'
 
 name_list ::=
 	( name ) ( ( ',' name ) )*
@@ -578,10 +582,10 @@ create_database_stmt ::=
 	| 'CREATE' 'DATABASE' 'IF' 'NOT' 'EXISTS' database_name opt_with opt_template_clause opt_encoding_clause opt_lc_collate_clause opt_lc_ctype_clause
 
 create_index_stmt ::=
-	'CREATE' opt_unique 'INDEX' opt_index_name 'ON' table_name opt_using_gin '(' index_params ')' opt_storing opt_interleave opt_partition_by
-	| 'CREATE' opt_unique 'INDEX' 'IF' 'NOT' 'EXISTS' index_name 'ON' table_name opt_using_gin '(' index_params ')' opt_storing opt_interleave opt_partition_by
-	| 'CREATE' 'INVERTED' 'INDEX' opt_index_name 'ON' table_name '(' index_params ')'
-	| 'CREATE' 'INVERTED' 'INDEX' 'IF' 'NOT' 'EXISTS' index_name 'ON' table_name '(' index_params ')'
+	'CREATE' opt_unique 'INDEX' opt_index_name on table_name opt_using_gin '(' index_params ')' opt_storing opt_interleave opt_partition_by
+	| 'CREATE' opt_unique 'INDEX' 'IF' 'NOT' 'EXISTS' index_name on table_name opt_using_gin '(' index_params ')' opt_storing opt_interleave opt_partition_by
+	| 'CREATE' 'INVERTED' 'INDEX' opt_index_name on table_name '(' index_params ')'
+	| 'CREATE' 'INVERTED' 'INDEX' 'IF' 'NOT' 'EXISTS' index_name on table_name '(' index_params ')'
 
 create_table_stmt ::=
 	'CREATE' 'TABLE' table_name '(' opt_table_elem_list ')' opt_interleave opt_partition_by
@@ -744,6 +748,7 @@ unreserved_keyword ::=
 	| 'RESTRICT'
 	| 'RESUME'
 	| 'REVOKE'
+	| 'ROLE'
 	| 'ROLES'
 	| 'ROLLBACK'
 	| 'ROLLUP'
@@ -1018,7 +1023,7 @@ transaction_mode_list ::=
 
 var_value ::=
 	a_expr
-	| 'ON'
+	| on
 
 view_name ::=
 	table_name
@@ -1477,7 +1482,6 @@ reserved_keyword ::=
 	| 'PRIMARY'
 	| 'REFERENCES'
 	| 'RETURNING'
-	| 'ROLE'
 	| 'SELECT'
 	| 'SESSION_USER'
 	| 'SOME'
@@ -2003,7 +2007,7 @@ join_type ::=
 
 join_qual ::=
 	'USING' '(' name_list ')'
-	| 'ON' a_expr
+	| on a_expr
 
 partition ::=
 	'PARTITION' partition_name

--- a/pkg/sql/lex/predicates.go
+++ b/pkg/sql/lex/predicates.go
@@ -50,6 +50,7 @@ var lookaheadKeywords = map[string]struct{}{
 	"like":       {},
 	"of":         {},
 	"ordinality": {},
+	"role":       {},
 	"similar":    {},
 	"time":       {},
 }

--- a/pkg/sql/parser/parse_test.go
+++ b/pkg/sql/parser/parse_test.go
@@ -384,6 +384,7 @@ func TestParse(t *testing.T) {
 		// GRANT x ON TABLE y. However, the stringer does not output TABLE.
 		{`SHOW GRANTS`},
 		{`SHOW GRANTS ON foo`},
+		{`SHOW GRANTS ON "role"`},
 		{`SHOW GRANTS ON foo, db.foo`},
 		{`SHOW GRANTS ON DATABASE foo, bar`},
 		{`SHOW GRANTS ON DATABASE foo FOR bar`},
@@ -991,6 +992,7 @@ func TestParse2(t *testing.T) {
 		{`CREATE TABLE a (UNIQUE INDEX (b) PARTITION BY LIST (c) (PARTITION d VALUES IN (1)))`,
 			`CREATE TABLE a (UNIQUE (b) PARTITION BY LIST (c) (PARTITION d VALUES IN (1)))`},
 		{`CREATE INDEX ON a (b) COVERING (c)`, `CREATE INDEX ON a (b) STORING (c)`},
+		{`CREATE INDEX ON role (b)`, `CREATE INDEX ON "role" (b)`},
 
 		{`SELECT TIMESTAMP WITHOUT TIME ZONE 'foo'`, `SELECT TIMESTAMP 'foo'`},
 		{`SELECT CAST('foo' AS TIMESTAMP WITHOUT TIME ZONE)`, `SELECT CAST('foo' AS TIMESTAMP)`},

--- a/pkg/sql/parser/scan.go
+++ b/pkg/sql/parser/scan.go
@@ -101,7 +101,7 @@ func (s *Scanner) Lex(lval *sqlSymType) int {
 	}
 
 	switch lval.id {
-	case NOT, NULLS, WITH, AS:
+	case AS, NOT, NULLS, ON, WITH:
 	default:
 		s.lastTok = *lval
 		return lval.id
@@ -110,17 +110,27 @@ func (s *Scanner) Lex(lval *sqlSymType) int {
 	s.nextTok = &s.tokBuf
 	s.scan(s.nextTok)
 
-	// If you update these cases, update lookaheadKeywords below.
+	// If you add additional cases here, don't forget to add the corresponding
+	// case to the switch earlier in this method. Also, update lex.lookupKeywords
+	// so the keyword (when used as an identifier) is appropriately quoted when
+	// formatted.
 	switch lval.id {
 	case AS:
 		switch s.nextTok.id {
 		case OF:
 			lval.id = AS_LA
 		}
+
 	case NOT:
 		switch s.nextTok.id {
 		case BETWEEN, IN, LIKE, ILIKE, SIMILAR:
 			lval.id = NOT_LA
+		}
+
+	case ON:
+		switch s.nextTok.id {
+		case ROLE:
+			lval.id = ON_LA
 		}
 
 	case WITH:

--- a/pkg/sql/parser/scan_test.go
+++ b/pkg/sql/parser/scan_test.go
@@ -94,6 +94,8 @@ func TestScanner(t *testing.T) {
 		{`WITH`, []int{WITH}},
 		{`WITH TIME`, []int{WITH_LA, TIME}},
 		{`WITH ORDINALITY`, []int{WITH_LA, ORDINALITY}},
+		{`ON`, []int{ON}},
+		{`ON ROLE`, []int{ON_LA, ROLE}},
 		{`1`, []int{ICONST}},
 		{`0xa`, []int{ICONST}},
 		{`x'2F'`, []int{BCONST}},


### PR DESCRIPTION
Use scanner lookahead to allow `SHOW GRANTS ON ROLE` despite `ROLE` not
being a reserved keyword. The user will have to type `SHOW GRANTS ON
"role"` in order to show the grants for a database named `role`.

TODO: `SHOW GRANTS ON "role"` does not round-trip properly and is output
as `SHOW GRANTS ON role`.

Fixes #24489

Release note (sql change): permit ROLE to be used as an unrestricted
name again.