### PR TITLE
distsqlrun: add SetBytes to distsql benchmarks

### DIFF
--- a/pkg/sql/distsqlrun/hashjoiner_test.go
+++ b/pkg/sql/distsqlrun/hashjoiner_test.go
@@ -1439,7 +1439,7 @@ func BenchmarkHashJoiner(b *testing.B) {
 					rows := makeIntRows(numRows, numCols)
 					leftInput := NewRepeatableRowSource(oneIntCol, rows)
 					rightInput := NewRepeatableRowSource(oneIntCol, rows)
-					b.SetBytes(int64(8 * numRows * numCols))
+					b.SetBytes(int64(8 * numRows * numCols * 2))
 					b.ResetTimer()
 					for i := 0; i < b.N; i++ {
 						// TODO(asubiotto): Get rid of uncleared state between

--- a/pkg/sql/distsqlrun/mergejoiner_test.go
+++ b/pkg/sql/distsqlrun/mergejoiner_test.go
@@ -858,7 +858,7 @@ func BenchmarkMergeJoiner(b *testing.B) {
 			rows := makeIntRows(inputSize, numCols)
 			leftInput := NewRepeatableRowSource(oneIntCol, rows)
 			rightInput := NewRepeatableRowSource(oneIntCol, rows)
-			b.SetBytes(int64(8 * inputSize * numCols))
+			b.SetBytes(int64(8 * inputSize * numCols * 2))
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
 				m, err := newMergeJoiner(flowCtx, spec, leftInput, rightInput, post, disposer)

--- a/pkg/sql/distsqlrun/sorter_test.go
+++ b/pkg/sql/distsqlrun/sorter_test.go
@@ -392,6 +392,7 @@ func BenchmarkSortAll(b *testing.B) {
 			if err != nil {
 				b.Fatal(err)
 			}
+			b.SetBytes(int64(inputSize * 8))
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
 				s.Run(context.Background(), nil /* wg */)
@@ -445,6 +446,7 @@ func BenchmarkSortLimit(b *testing.B) {
 				if err != nil {
 					b.Fatal(err)
 				}
+				b.SetBytes(int64(inputSize * 8))
 				b.ResetTimer()
 				for i := 0; i < b.N; i++ {
 					s.Run(context.Background(), nil /* wg */)

--- a/pkg/sql/distsqlrun/tablereader_test.go
+++ b/pkg/sql/distsqlrun/tablereader_test.go
@@ -294,10 +294,12 @@ func BenchmarkTableReader(b *testing.B) {
 	s, sqlDB, kvDB := serverutils.StartServer(b, base.TestServerArgs{})
 	defer s.Stopper().Stop(context.Background())
 
+	const numRows = 10000
+	const numCols = 2
 	sqlutils.CreateTable(
 		b, sqlDB, "t",
 		"k INT PRIMARY KEY, v INT",
-		10000,
+		numRows,
 		sqlutils.ToRowFn(sqlutils.RowIdxFn, sqlutils.RowModuloFn(42)),
 	)
 
@@ -316,6 +318,7 @@ func BenchmarkTableReader(b *testing.B) {
 		Spans: []TableReaderSpan{{Span: tableDesc.PrimaryIndexSpan()}},
 	}
 	post := PostProcessSpec{}
+	b.SetBytes(numRows * numCols * 8)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		tr, err := newTableReader(&flowCtx, &spec, &post, nil /* output */)


### PR DESCRIPTION
And fix the ones for hash and merge joiner, which were halving the
actual input size.

Release note: None