### PR TITLE
distsqlrun: don't allocate between fused processors

### DIFF
--- a/pkg/sql/distsqlrun/aggregator.go
+++ b/pkg/sql/distsqlrun/aggregator.go
@@ -112,6 +112,7 @@ type aggregatorBase struct {
 	funcs        []*aggregateFuncHolder
 	outputTypes  []sqlbase.ColumnType
 	datumAlloc   sqlbase.DatumAlloc
+	rowAlloc     sqlbase.EncDatumRowAlloc
 
 	bucketsAcc mon.BoundAccount
 
@@ -408,7 +409,7 @@ func (ag *hashAggregator) accumulateRows() (aggregatorState, sqlbase.EncDatumRow
 		}
 
 		if ag.lastOrdGroupCols == nil {
-			ag.lastOrdGroupCols = row
+			ag.lastOrdGroupCols = ag.rowAlloc.CopyRow(row)
 		} else {
 			matched, err := ag.matchLastOrdGroupCols(row)
 			if err != nil {
@@ -416,7 +417,7 @@ func (ag *hashAggregator) accumulateRows() (aggregatorState, sqlbase.EncDatumRow
 				return aggStateUnknown, nil, nil
 			}
 			if !matched {
-				ag.lastOrdGroupCols = row
+				ag.lastOrdGroupCols = ag.rowAlloc.CopyRow(row)
 				break
 			}
 		}
@@ -467,7 +468,7 @@ func (ag *orderedAggregator) accumulateRows() (aggregatorState, sqlbase.EncDatum
 		}
 
 		if ag.lastOrdGroupCols == nil {
-			ag.lastOrdGroupCols = row
+			ag.lastOrdGroupCols = ag.rowAlloc.CopyRow(row)
 		} else {
 			matched, err := ag.matchLastOrdGroupCols(row)
 			if err != nil {
@@ -475,7 +476,7 @@ func (ag *orderedAggregator) accumulateRows() (aggregatorState, sqlbase.EncDatum
 				return aggStateUnknown, nil, nil
 			}
 			if !matched {
-				ag.lastOrdGroupCols = row
+				ag.lastOrdGroupCols = ag.rowAlloc.CopyRow(row)
 				break
 			}
 		}

--- a/pkg/sql/distsqlrun/base.go
+++ b/pkg/sql/distsqlrun/base.go
@@ -64,7 +64,9 @@ type RowReceiver interface {
 	// ProducerDone() needs to be called (after draining is done, if draining was
 	// requested).
 	//
-	// The sender must not modify the row after calling this function.
+	// Unless specifically permitted by the underlying implementation, (see
+	// copyingRowReceiver, for example), the sender must not modify the row
+	// after calling this function.
 	//
 	// After DrainRequested is returned, it is expected that all future calls only
 	// carry metadata (however that is not enforced and implementations should be
@@ -112,6 +114,9 @@ type RowSource interface {
 	// values will be non-empty. Both of them can be empty when the RowSource has
 	// been exhausted - no more records are coming and any further method calls
 	// will be no-ops.
+	//
+	// EncDatumRows returned by Next() are only valid until the next call to
+	// Next(), although the EncDatums inside them stay valid forever.
 	//
 	// A ProducerMetadata record may contain an error. In that case, this
 	// interface is oblivious about the semantics: implementers may continue
@@ -207,7 +212,7 @@ func DrainAndForwardMetadata(ctx context.Context, src RowSource, dst RowReceiver
 			)
 		}
 
-		switch dst.Push(row, meta) {
+		switch dst.Push(nil /* row */, meta) {
 		case ConsumerClosed:
 			src.ConsumerClosed()
 			return
@@ -690,6 +695,18 @@ func (rb *RowBuffer) ConsumerClosed() {
 	if rb.args.OnConsumerClosed != nil {
 		rb.args.OnConsumerClosed(rb)
 	}
+}
+
+type copyingRowReceiver struct {
+	RowReceiver
+	alloc sqlbase.EncDatumRowAlloc
+}
+
+func (r *copyingRowReceiver) Push(row sqlbase.EncDatumRow, meta *ProducerMetadata) ConsumerStatus {
+	if row != nil {
+		row = r.alloc.CopyRow(row)
+	}
+	return r.RowReceiver.Push(row, meta)
 }
 
 // String implements fmt.Stringer.

--- a/pkg/sql/distsqlrun/distinct_test.go
+++ b/pkg/sql/distsqlrun/distinct_test.go
@@ -134,7 +134,7 @@ func TestDistinct(t *testing.T) {
 			}
 			var res sqlbase.EncDatumRows
 			for {
-				row := out.NextNoMeta(t)
+				row := out.NextNoMeta(t).Copy()
 				if row == nil {
 					break
 				}

--- a/pkg/sql/distsqlrun/hashjoiner.go
+++ b/pkg/sql/distsqlrun/hashjoiner.go
@@ -215,6 +215,7 @@ func (h *hashJoiner) Run(ctx context.Context, wg *sync.WaitGroup) {
 
 	bufferPhaseOom := false
 	if pgErr, ok := pgerror.GetPGCause(err); ok && pgErr.Code == pgerror.CodeOutOfMemoryError {
+		log.VEvent(ctx, 1, "buffer phase ran out of memory")
 		bufferPhaseOom = true
 	}
 
@@ -359,6 +360,7 @@ func (h *hashJoiner) bufferPhase(
 	// choose the right stream and consume it.
 	h.storedSide = rightSide
 
+	log.VEvent(ctx, 1, "buffer phase found no short stream")
 	for {
 		if err := h.cancelChecker.Check(); err != nil {
 			return nil, false, err
@@ -702,6 +704,7 @@ func (h *hashJoiner) receiveRow(
 		}
 		if !hasNull {
 			// Normal path.
+			row = h.out.rowAlloc.CopyRow(row)
 			return row, false, nil
 		}
 

--- a/pkg/sql/distsqlrun/input_sync.go
+++ b/pkg/sql/distsqlrun/input_sync.go
@@ -84,7 +84,8 @@ type orderedSynchronizer struct {
 	// err can be set by the Less function (used by the heap implementation)
 	err error
 
-	alloc sqlbase.DatumAlloc
+	alloc    sqlbase.DatumAlloc
+	rowAlloc sqlbase.EncDatumRowAlloc
 
 	// metadata is accumulated from all the sources and is passed on as soon as
 	// possible.
@@ -197,6 +198,9 @@ func (s *orderedSynchronizer) consumeMetadata(src *srcInfo, mode consumeMetadata
 			continue
 		}
 		if mode == stopOnRowOrError {
+			if row != nil {
+				row = s.rowAlloc.CopyRow(row)
+			}
 			src.row = row
 			return nil
 		}

--- a/pkg/sql/distsqlrun/interleaved_reader_joiner.go
+++ b/pkg/sql/distsqlrun/interleaved_reader_joiner.go
@@ -314,9 +314,7 @@ func (irj *interleavedReaderJoiner) Run(ctx context.Context, wg *sync.WaitGroup)
 
 			// A new ancestor row is fetched. We re-assign our reference
 			// to the most recent ancestor row.
-			// This is safe because tableRow is a newly alloc'd
-			// row.
-			irj.ancestorRow = tableRow
+			irj.ancestorRow = tInfo.post.rowAlloc.CopyRow(tableRow)
 			irj.ancestorJoined = false
 			continue
 		}

--- a/pkg/sql/distsqlrun/interleaved_reader_joiner_test.go
+++ b/pkg/sql/distsqlrun/interleaved_reader_joiner_test.go
@@ -423,7 +423,7 @@ func TestInterleavedReaderJoiner(t *testing.T) {
 				if row == nil {
 					break
 				}
-				res = append(res, row)
+				res = append(res, row.Copy())
 			}
 
 			if result := res.String(irj.OutputTypes()); result != tc.expected {

--- a/pkg/sql/distsqlrun/joinreader.go
+++ b/pkg/sql/distsqlrun/joinreader.go
@@ -339,7 +339,7 @@ func (jr *joinReader) mainLoop(ctx context.Context) error {
 				EndKey: key.PrefixEnd(),
 			}
 			if jr.isLookupJoin() {
-				rows = append(rows, row)
+				rows = append(rows, jr.out.rowAlloc.CopyRow(row))
 				if spanToRowIndices[key.String()] == nil {
 					spans = append(spans, span)
 				}

--- a/pkg/sql/distsqlrun/processors.go
+++ b/pkg/sql/distsqlrun/processors.go
@@ -62,12 +62,14 @@ type ProcOutputHelper struct {
 	// outputCols can be set.
 	outputCols []uint32
 
+	outputRow sqlbase.EncDatumRow
+
 	// outputTypes is the schema of the rows produced by the processor after
 	// post-processing (i.e. the rows that are pushed through a router).
 	//
 	// If renderExprs is set, these types correspond to the types of those
 	// expressions.
-	// If outpuCols is set, these types correspond to the types of
+	// If outputCols is set, these types correspond to the types of
 	// those columns.
 	// If neither is set, this is the internal schema of the processor.
 	outputTypes []sqlbase.ColumnType
@@ -133,6 +135,10 @@ func (h *ProcOutputHelper) Init(
 		}
 	} else {
 		h.outputTypes = types
+	}
+	if h.outputCols != nil || h.renderExprs != nil {
+		// We're rendering or projecting, so allocate an output row.
+		h.outputRow = h.rowAlloc.AllocRow(len(h.outputTypes))
 	}
 
 	h.offset = post.Offset
@@ -300,7 +306,8 @@ func (h *ProcOutputHelper) EmitRow(
 }
 
 // ProcessRow sends the invoked row through the post-processing stage and returns
-// the post-processed row.
+// the post-processed row. Results from ProcessRow aren't safe past the next call
+// to ProcessRow.
 //
 // The moreRowsOK retval is true if more rows can be processed, false if the
 // limit has been reached (if there's a limit). Upon seeing a false value, the
@@ -334,31 +341,27 @@ func (h *ProcOutputHelper) ProcessRow(
 		return nil, true, nil
 	}
 
-	var outRow sqlbase.EncDatumRow
 	if h.renderExprs != nil {
 		// Rendering.
-		outRow = h.rowAlloc.AllocRow(len(h.renderExprs))
 		for i := range h.renderExprs {
 			datum, err := h.renderExprs[i].eval(row)
 			if err != nil {
 				return nil, false, err
 			}
-			outRow[i] = sqlbase.DatumToEncDatum(h.outputTypes[i], datum)
+			h.outputRow[i] = sqlbase.DatumToEncDatum(h.outputTypes[i], datum)
 		}
 	} else if h.outputCols != nil {
 		// Projection.
-		outRow = h.rowAlloc.AllocRow(len(h.outputCols))
 		for i, col := range h.outputCols {
-			outRow[i] = row[col]
+			h.outputRow[i] = row[col]
 		}
 	} else {
 		// No rendering or projection.
-		outRow = h.rowAlloc.AllocRow(len(row))
-		copy(outRow, row)
+		return row, h.rowIdx < h.maxRowIdx, nil
 	}
 
 	// If this row satisfies the limit, the caller is told to drain.
-	return outRow, h.rowIdx < h.maxRowIdx, nil
+	return h.outputRow, h.rowIdx < h.maxRowIdx, nil
 }
 
 // Close signals to the output that there will be no more rows.

--- a/pkg/sql/distsqlrun/sampler.go
+++ b/pkg/sql/distsqlrun/sampler.go
@@ -163,6 +163,7 @@ func (s *samplerProcessor) Run(ctx context.Context, wg *sync.WaitGroup) {
 func (s *samplerProcessor) mainLoop(ctx context.Context) (earlyExit bool, _ error) {
 	rng, _ := randutil.NewPseudoRand()
 	var da sqlbase.DatumAlloc
+	var ra sqlbase.EncDatumRowAlloc
 	var buf []byte
 	for {
 		row, meta := s.input.Next()
@@ -199,6 +200,7 @@ func (s *samplerProcessor) mainLoop(ctx context.Context) (earlyExit bool, _ erro
 
 		// Use Int63 so we don't have headaches converting to DInt.
 		rank := uint64(rng.Int63())
+		row = ra.CopyRow(row)
 		s.sr.SampleRow(row, rank)
 	}
 

--- a/pkg/sql/distsqlrun/sorter.go
+++ b/pkg/sql/distsqlrun/sorter.go
@@ -519,10 +519,10 @@ type sortChunksProcessor struct {
 	rows            memRowContainer
 	rowContainerMon *mon.BytesMonitor
 	alloc           sqlbase.DatumAlloc
+	rowAlloc        sqlbase.EncDatumRowAlloc
 
 	// sortChunksProcessor accumulates rows that are equal on a prefix, until it
 	// encounters a row that is greater. It stores that greater row in nextChunkRow
-	prefix       sqlbase.EncDatumRow
 	nextChunkRow sqlbase.EncDatumRow
 }
 
@@ -563,10 +563,12 @@ func newSortChunksProcessor(
 
 // chunkCompleted is a helper function that determines if the given row shares the same
 // values for the first matchLen ordering columns with the given prefix.
-func (s *sortChunksProcessor) chunkCompleted() (bool, error) {
+func (s *sortChunksProcessor) chunkCompleted(
+	nextChunkRow, prefix sqlbase.EncDatumRow,
+) (bool, error) {
 	for _, ord := range s.ordering[:s.matchLen] {
 		col := ord.ColIdx
-		cmp, err := s.nextChunkRow[col].Compare(&s.rows.types[col], &s.alloc, s.rows.evalCtx, &s.prefix[col])
+		cmp, err := nextChunkRow[col].Compare(&s.rows.types[col], &s.alloc, s.rows.evalCtx, &prefix[col])
 		if cmp != 0 || err != nil {
 			return true, err
 		}
@@ -585,23 +587,25 @@ func (s *sortChunksProcessor) fill() (bool, error) {
 
 	var meta *ProducerMetadata
 
-	for s.nextChunkRow == nil {
-		s.nextChunkRow, meta = s.input.Next()
+	nextChunkRow := s.nextChunkRow
+	s.nextChunkRow = nil
+	for nextChunkRow == nil {
+		nextChunkRow, meta = s.input.Next()
 		if meta != nil {
 			s.trailingMeta = append(s.trailingMeta, *meta)
 			if meta.Err != nil {
 				return false, nil
 			}
 			continue
-		} else if s.nextChunkRow == nil {
+		} else if nextChunkRow == nil {
 			return false, nil
 		}
 		break
 	}
-	s.prefix = s.nextChunkRow
+	prefix := nextChunkRow
 
 	// Add the chunk
-	if err := s.rows.AddRow(ctx, s.nextChunkRow); err != nil {
+	if err := s.rows.AddRow(ctx, nextChunkRow); err != nil {
 		return false, err
 	}
 
@@ -610,26 +614,27 @@ func (s *sortChunksProcessor) fill() (bool, error) {
 	// We will accumulate rows to form a chunk such that they all share the same values
 	// as prefix for the first s.matchLen ordering columns.
 	for {
-		s.nextChunkRow, meta = s.input.Next()
+		nextChunkRow, meta = s.input.Next()
 
 		if meta != nil {
 			s.trailingMeta = append(s.trailingMeta, *meta)
 			continue
 		}
-		if s.nextChunkRow == nil {
+		if nextChunkRow == nil {
 			break
 		}
 
-		chunkCompleted, err := s.chunkCompleted()
+		chunkCompleted, err := s.chunkCompleted(nextChunkRow, prefix)
 
 		if err != nil {
 			return false, err
 		}
 		if chunkCompleted {
+			s.nextChunkRow = s.rowAlloc.CopyRow(nextChunkRow)
 			break
 		}
 
-		if err := s.rows.AddRow(ctx, s.nextChunkRow); err != nil {
+		if err := s.rows.AddRow(ctx, nextChunkRow); err != nil {
 			return false, err
 		}
 	}

--- a/pkg/sql/distsqlrun/stream_group_accumulator.go
+++ b/pkg/sql/distsqlrun/stream_group_accumulator.go
@@ -40,6 +40,8 @@ type streamGroupAccumulator struct {
 	// accumulator after the current group is returned, so the accumulator can
 	// resume later.
 	leftoverRow sqlbase.EncDatumRow
+
+	rowAlloc sqlbase.EncDatumRowAlloc
 }
 
 func makeStreamGroupAccumulator(
@@ -81,6 +83,8 @@ func (s *streamGroupAccumulator) nextGroup(
 			s.srcConsumed = true
 			return s.curGroup, nil
 		}
+
+		row = s.rowAlloc.CopyRow(row)
 
 		if len(s.curGroup) == 0 {
 			if s.curGroup == nil {

--- a/pkg/sql/distsqlrun/tablereader.go
+++ b/pkg/sql/distsqlrun/tablereader.go
@@ -136,7 +136,6 @@ func (w *rowFetcherWrapper) Next() (sqlbase.EncDatumRow, *ProducerMetadata) {
 	}
 	return row, nil
 }
-
 func (w rowFetcherWrapper) OutputTypes() []sqlbase.ColumnType { return nil }
 func (w rowFetcherWrapper) ConsumerDone()                     {}
 func (w rowFetcherWrapper) ConsumerClosed()                   {}

--- a/pkg/sql/distsqlrun/tablereader_test.go
+++ b/pkg/sql/distsqlrun/tablereader_test.go
@@ -167,7 +167,7 @@ func TestTableReader(t *testing.T) {
 					if row == nil {
 						break
 					}
-					res = append(res, row)
+					res = append(res, row.Copy())
 				}
 				if result := res.String(tr.OutputTypes()); result != c.expected {
 					t.Errorf("invalid results: %s, expected %s'", result, c.expected)

--- a/pkg/sql/sqlbase/encoded_datum.go
+++ b/pkg/sql/sqlbase/encoded_datum.go
@@ -334,6 +334,17 @@ func (r EncDatumRow) stringToBuf(types []ColumnType, a *DatumAlloc, b *bytes.Buf
 	b.WriteString("]")
 }
 
+// Copy makes a copy of this EncDatumRow. Convenient for tests. Use an
+// EncDatumRowAlloc in non-test code.
+func (r EncDatumRow) Copy() EncDatumRow {
+	if r == nil {
+		return nil
+	}
+	rCopy := make(EncDatumRow, len(r))
+	copy(rCopy, r)
+	return rCopy
+}
+
 func (r EncDatumRow) String(types []ColumnType) string {
 	var b bytes.Buffer
 	r.stringToBuf(types, &DatumAlloc{}, &b)


### PR DESCRIPTION
distsqlrun: don't allocate between fused processors

Previously, `ProcOutputHelper.ProcessRow` (and, by extension, all
`RowSource.Next` implementations) always allocated a fresh
`EncDatumRow`. This was wasteful - not every processor needs to be able
to hold a reference to the output of `RowSource.Next`.

Now, `ProcessRow` never allocates a fresh `EncDatumRow`, and the
contract of `RowSource.Next` has been changed to say that it's not valid
to hang on to a row returned by `Next` past the next call to `Next`.
Processors that need to hold on to a row from their upstreams have been
modified to make an explicit copy to achieve this safely.

Finally, a new `copyingRowReceiver` is introduced that makes a copy of
every row that is `Push`'d to it. A `copyingRowReceiver` is inserted
before every router, since routers all expect that their inputs will be
immutable. This preserves the safety of sending outputs of
`RowSource.Next`, which aren't safe to hold on to, to routers, which
expect rows that *are* safe to hold on to.

Release note: None

Fixes #22462.
Fixes #24452.