### PR TITLE
opt: format memo more meaningfully

### DIFF
--- a/pkg/sql/opt/memo/expr_view.go
+++ b/pkg/sql/opt/memo/expr_view.go
@@ -246,7 +246,8 @@ func (ev ExprView) formatRelational(tp treeprinter.Node, flags ExprFmtFlags) {
 
 	switch ev.Operator() {
 	case opt.ScanOp:
-		ev.mem.formatScanPrivate(&buf, ev.Private().(*ScanOpDef), true /* short */)
+		formatter := ev.mem.makeExprFormatter(&buf)
+		formatter.formatScanPrivate(ev.Private().(*ScanOpDef), true /* short */)
 	}
 
 	var physProps *PhysicalProps
@@ -408,7 +409,8 @@ func (ev ExprView) formatScalarPrivate(buf *bytes.Buffer, private interface{}) {
 
 	if private != nil {
 		buf.WriteRune(':')
-		ev.mem.formatPrivate(buf, private)
+		formatter := ev.mem.makeExprFormatter(buf)
+		formatter.formatPrivate(private)
 	}
 }
 

--- a/pkg/sql/opt/memo/memo_format.go
+++ b/pkg/sql/opt/memo/memo_format.go
@@ -1,0 +1,269 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package memo
+
+import (
+	"bytes"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/opt"
+	"github.com/cockroachdb/cockroach/pkg/util/treeprinter"
+)
+
+type exprFormatter struct {
+	mem *Memo
+	buf *bytes.Buffer
+}
+
+type memoFormatter struct {
+	exprFormatter
+	ordering  []GroupID
+	numbering []GroupID
+}
+
+func (m *Memo) makeExprFormatter(buf *bytes.Buffer) exprFormatter {
+	return exprFormatter{
+		mem: m,
+		buf: buf,
+	}
+}
+
+func (m *Memo) makeMemoFormatter(root GroupID) memoFormatter {
+	f := memoFormatter{
+		exprFormatter: exprFormatter{
+			mem: m,
+			buf: &bytes.Buffer{},
+		},
+	}
+
+	// If a root was specified, we topological sort from it.  Otherwise, we
+	// simply print out all the groups in the order and with the names they're
+	// referred to physically. We can do this because the GroupID 0 never refers
+	// to a valid group.
+	if root != 0 {
+		f.ordering = f.sortGroups(root)
+	} else {
+		// In this case we renumber with the identity mapping, so the groups have
+		// the same numbers as they're represented with internally.
+		f.ordering = make([]GroupID, len(m.groups)-1)
+		for i := range m.groups[1:] {
+			f.ordering[i] = GroupID(i + 1)
+		}
+	}
+
+	// We renumber the groups so that they're still printed in order from 1..N.
+	f.numbering = make([]GroupID, len(m.groups))
+	for i := range f.ordering {
+		f.numbering[f.ordering[i]] = GroupID(i + 1)
+	}
+
+	return f
+}
+
+func (f memoFormatter) Format() string {
+	tp := treeprinter.New()
+	root := tp.Child("memo")
+
+	for i := range f.ordering {
+		mgrp := &f.mem.groups[f.ordering[i]]
+
+		f.buf.Reset()
+		for ord := 0; ord < mgrp.exprCount(); ord++ {
+			if ord != 0 {
+				f.buf.WriteByte(' ')
+			}
+			f.formatExpr(mgrp.expr(ExprOrdinal(ord)))
+		}
+		child := root.Childf("G%d: %s", i+1, f.buf.String())
+		f.formatBestExprSet(child, mgrp)
+	}
+
+	return tp.String()
+}
+
+func (f *memoFormatter) formatExpr(e *Expr) {
+	fmt.Fprintf(f.buf, "(%s", e.op)
+	for i := 0; i < e.ChildCount(); i++ {
+		fmt.Fprintf(f.buf, " G%d", f.numbering[e.ChildGroup(f.mem, i)])
+	}
+	f.formatPrivate(e.Private(f.mem))
+	f.buf.WriteString(")")
+}
+
+type bestExprSort struct {
+	required PhysicalPropsID
+	display  string
+	best     *BestExpr
+}
+
+func (f *memoFormatter) formatBestExprSet(tp treeprinter.Node, mgrp *group) {
+	// Sort the bestExprs by required properties.
+	cnt := mgrp.bestExprCount()
+	beSort := make([]bestExprSort, 0, cnt)
+	for i := 0; i < cnt; i++ {
+		best := mgrp.bestExpr(bestOrdinal(i))
+		beSort = append(beSort, bestExprSort{
+			required: best.required,
+			display:  f.mem.LookupPhysicalProps(best.required).String(),
+			best:     best,
+		})
+	}
+
+	sort.Slice(beSort, func(i, j int) bool {
+		return strings.Compare(beSort[i].display, beSort[j].display) < 0
+	})
+
+	for _, sort := range beSort {
+		f.buf.Reset()
+
+		// Don't show best expressions for scalar groups because they're not too
+		// interesting.
+		if !isScalarLookup[sort.best.op] {
+			child := tp.Childf("\"%s\" [cost=%.2f]", sort.display, sort.best.cost)
+			f.formatBestExpr(sort.best)
+			child.Childf("best: %s", f.buf.String())
+		}
+	}
+}
+
+func (f *memoFormatter) formatBestExpr(be *BestExpr) {
+	fmt.Fprintf(f.buf, "(%s", be.op)
+
+	for i := 0; i < be.ChildCount(); i++ {
+		bestChild := be.Child(i)
+		fmt.Fprintf(f.buf, " G%d", f.numbering[bestChild.group])
+
+		// Print properties required of the child if they are interesting.
+		required := f.mem.bestExpr(bestChild).required
+		if required != MinPhysPropsID {
+			fmt.Fprintf(f.buf, "=\"%s\"", f.mem.LookupPhysicalProps(required).Fingerprint())
+		}
+	}
+
+	f.formatPrivate(be.Private(f.mem))
+	f.buf.WriteString(")")
+}
+
+func (f *exprFormatter) formatPrivate(private interface{}) {
+	if private != nil {
+		switch t := private.(type) {
+		case nil:
+
+		case *ScanOpDef:
+			f.formatScanPrivate(t, false /* short */)
+
+		case opt.ColumnID:
+			fmt.Fprintf(f.buf, " %s", f.mem.metadata.ColumnLabel(t))
+
+		case opt.ColSet, opt.ColList:
+			// Don't show anything, because it's mostly redundant.
+
+		default:
+			fmt.Fprintf(f.buf, " %s", private)
+		}
+	}
+}
+
+func (f *exprFormatter) formatScanPrivate(def *ScanOpDef, short bool) {
+	// Don't output name of index if it's the primary index.
+	tab := f.mem.metadata.Table(def.Table)
+	if def.Index == opt.PrimaryIndex {
+		fmt.Fprintf(f.buf, " %s", tab.TabName())
+	} else {
+		fmt.Fprintf(f.buf, " %s@%s", tab.TabName(), tab.Index(def.Index).IdxName())
+	}
+
+	// Add additional fields when short=false.
+	if !short {
+		if def.Constraint != nil {
+			fmt.Fprintf(f.buf, ",constrained")
+		}
+		if def.HardLimit > 0 {
+			fmt.Fprintf(f.buf, ",lim=%d", def.HardLimit)
+		}
+	}
+}
+
+// iterDeps runs f for each child group of g.
+func (f *memoFormatter) iterDeps(g *group, fn func(GroupID)) {
+	for i := 0; i < g.exprCount(); i++ {
+		e := g.expr(ExprOrdinal(i))
+		for c := 0; c < e.ChildCount(); c++ {
+			fn(e.ChildGroup(f.mem, c))
+		}
+	}
+}
+
+// sortGroups sorts groups reachable from the root by doing a BFS topological
+// sort.
+func (f *memoFormatter) sortGroups(root GroupID) (groups []GroupID) {
+	indegrees := f.getIndegrees(root)
+
+	res := make([]GroupID, 0, len(f.mem.groups))
+	queue := []GroupID{root}
+
+	for len(queue) > 0 {
+		var next GroupID
+		next, queue = queue[0], queue[1:]
+		res = append(res, next)
+
+		// When we visit a group, we conceptually remove it from the dependency
+		// graph, so all of its dependencies have their indegree reduced by one.
+		// Any dependencies which have no more dependents can now be visited and
+		// are added to the queue.
+		f.iterDeps(&f.mem.groups[next], func(dep GroupID) {
+			indegrees[dep]--
+			if indegrees[dep] == 0 {
+				queue = append(queue, dep)
+			}
+		})
+	}
+
+	// If there remains any group with nonzero indegree, we had a cycle.
+	for i := range indegrees {
+		if indegrees[i] != 0 {
+			// TODO(justin): we should handle this case, but there's no good way to
+			// test it yet. Cross this bridge when we come to it (use raw-memo to
+			// bypass this sorting procedure if this is causing you trouble).
+			panic("memo had a cycle, use raw-memo")
+		}
+	}
+
+	return res
+}
+
+// getIndegrees returns the indegree of each group reachable from the root.
+func (f *memoFormatter) getIndegrees(root GroupID) (indegrees []int) {
+	indegrees = make([]int, len(f.mem.groups))
+	f.computeIndegrees(root, make([]bool, len(f.mem.groups)), indegrees)
+	return indegrees
+}
+
+// computedIndegrees computes the indegree (number of dependents) of each group
+// reachable from id.  It also populates reachable with true for all reachable
+// ids.
+func (f *memoFormatter) computeIndegrees(id GroupID, reachable []bool, indegrees []int) {
+	if id <= 0 || reachable[id] {
+		return
+	}
+	reachable[id] = true
+
+	f.iterDeps(&f.mem.groups[id], func(dep GroupID) {
+		indegrees[dep]++
+		f.computeIndegrees(dep, reachable, indegrees)
+	})
+}

--- a/pkg/sql/opt/memo/physical_props.go
+++ b/pkg/sql/opt/memo/physical_props.go
@@ -70,9 +70,8 @@ func (p *PhysicalProps) Defined() bool {
 	return p.Presentation.Defined() || p.Ordering.Defined()
 }
 
-// Fingerprint returns a string that uniquely describes this set of physical
-// properties. It is suitable for use as a hash key in a map.
-func (p *PhysicalProps) Fingerprint() string {
+// FormatString writes physical properties to a human-readable format.
+func (p *PhysicalProps) FormatString(verbose bool) string {
 	hasProjection := p.Presentation.Defined()
 	hasOrdering := p.Ordering.Defined()
 
@@ -84,8 +83,14 @@ func (p *PhysicalProps) Fingerprint() string {
 	var buf bytes.Buffer
 
 	if hasProjection {
-		buf.WriteString("p:")
-		p.Presentation.format(&buf)
+		if verbose {
+			buf.WriteString("[presentation: ")
+			p.Presentation.format(&buf)
+			buf.WriteByte(']')
+		} else {
+			buf.WriteString("p:")
+			p.Presentation.format(&buf)
+		}
 
 		if hasOrdering {
 			buf.WriteString(" ")
@@ -93,15 +98,27 @@ func (p *PhysicalProps) Fingerprint() string {
 	}
 
 	if hasOrdering {
-		buf.WriteString("o:")
-		p.Ordering.format(&buf)
+		if verbose {
+			buf.WriteString("[ordering: ")
+			p.Ordering.format(&buf)
+			buf.WriteByte(']')
+		} else {
+			buf.WriteString("o:")
+			p.Ordering.format(&buf)
+		}
 	}
 
 	return buf.String()
 }
 
+// Fingerprint returns a string that uniquely describes this set of physical
+// properties. It is suitable for use as a hash key in a map.
+func (p *PhysicalProps) Fingerprint() string {
+	return p.FormatString(false /* verbose */)
+}
+
 func (p *PhysicalProps) String() string {
-	return p.Fingerprint()
+	return p.FormatString(true /* verbose */)
 }
 
 // Equals returns true if the two physical properties are identical.

--- a/pkg/sql/opt/memo/testdata/memo
+++ b/pkg/sql/opt/memo/testdata/memo
@@ -144,59 +144,50 @@ WHERE a.y=1 AND a.x::string=b.x
 ORDER BY y
 LIMIT 10
 ----
-[29: "p:y:2,x:3,column5:5 o:+2"]
+[presentation: y:2,x:3,column5:5] [ordering: +2]
 memo
- ├── 29: (project 28 20)
+ ├── G1: (project G2 G3)
  │    ├── "" [cost=4600.00]
- │    │    └── best: (project 28 20)
- │    └── "p:y:2,x:3,column5:5 o:+2" [cost=4600.00]
- │         └── best: (project 28="o:+2" 20)
- ├── 28: (limit 27 24 +2)
+ │    │    └── best: (project G2 G3)
+ │    └── "[presentation: y:2,x:3,column5:5] [ordering: +2]" [cost=4600.00]
+ │         └── best: (project G2="o:+2" G3)
+ ├── G2: (limit G4 G5 +2)
  │    ├── "" [cost=4600.00]
- │    │    └── best: (limit 27="o:+2" 24 +2)
- │    └── "o:+2" [cost=4600.00]
- │         └── best: (limit 27="o:+2" 24 +2)
- ├── 27: (project 22 26)
+ │    │    └── best: (limit G4="o:+2" G5 +2)
+ │    └── "[ordering: +2]" [cost=4600.00]
+ │         └── best: (limit G4="o:+2" G5 +2)
+ ├── G3: (projections G18 G16 G6)
+ ├── G4: (project G7 G8)
  │    ├── "" [cost=2100.00]
- │    │    └── best: (project 22 26)
- │    └── "o:+2" [cost=4600.00]
- │         └── best: (sort 27)
- ├── 26: (projections 5 10)
- ├── 25: (limit 22 24 +2)
- ├── 24: (const 10)
- ├── 23: (project 22 20)
- ├── 22: (inner-join 15 21 17)
+ │    │    └── best: (project G7 G8)
+ │    └── "[ordering: +2]" [cost=4600.00]
+ │         └── best: (sort G4)
+ ├── G5: (const 10)
+ ├── G6: (plus G18 G19)
+ ├── G7: (inner-join G9 G10 G11)
  │    ├── "" [cost=2100.00]
- │    │    └── best: (inner-join 15 21 17)
- │    └── "o:+2" [cost=4600.00]
- │         └── best: (sort 22)
- ├── 21: (scan b)
+ │    │    └── best: (inner-join G9 G10 G11)
+ │    └── "[ordering: +2]" [cost=4600.00]
+ │         └── best: (sort G7)
+ ├── G8: (projections G18 G16)
+ ├── G9: (select G12 G13)
+ │    └── "" [cost=1100.00]
+ │         └── best: (select G12 G13)
+ ├── G10: (scan b)
  │    └── "" [cost=1000.00]
  │         └── best: (scan b)
- ├── 20: (projections 5 10 19)
- ├── 19: (plus 5 6)
- ├── 18: (inner-join 15 2 17)
- ├── 17: (filters 11)
- ├── 16: (inner-join 15 2 3)
- ├── 15: (select 1 14)
- │    └── "" [cost=1100.00]
- │         └── best: (select 1 14)
- ├── 14: (filters 7)
- ├── 13: (filters 7 11)
- ├── 12: (and 7 11)
- ├── 11: (eq 10 9)
- ├── 10: (variable b.x)
- ├── 9: (cast 8 string)
- ├── 8: (variable a.x)
- ├── 7: (eq 5 6)
- ├── 6: (const 1)
- ├── 5: (variable a.y)
- ├── 4: (inner-join 1 2 3)
- ├── 3: (true)
- ├── 2: (scan b)
- └── 1: (scan a)
-      └── "" [cost=1000.00]
-           └── best: (scan a)
+ ├── G11: (filters G14)
+ ├── G12: (scan a)
+ │    └── "" [cost=1000.00]
+ │         └── best: (scan a)
+ ├── G13: (filters G15)
+ ├── G14: (eq G16 G17)
+ ├── G15: (eq G18 G19)
+ ├── G16: (variable b.x)
+ ├── G17: (cast G20 string)
+ ├── G18: (variable a.y)
+ ├── G19: (const 1)
+ └── G20: (variable a.x)
 
 # Test interning of expressions.
 memo
@@ -204,28 +195,84 @@ SELECT 1, 1+z, now()::timestamp, now()::timestamptz
 FROM b
 WHERE z=1 AND concat(x, 'foo', x)=concat(x, 'foo', x)
 ----
-[17: "p:column3:3,column4:4,column5:5,column6:6"]
+[presentation: column3:3,column4:4,column5:5,column6:6]
 memo
- ├── 17: (project 11 16)
- │    └── "p:column3:3,column4:4,column5:5,column6:6" [cost=1100.00]
- │         └── best: (project 11 16)
- ├── 16: (projections 12 13 15 14)
- ├── 15: (cast 14 timestamp)
- ├── 14: (function now)
- ├── 13: (plus 2 3)
- ├── 12: (const 1)
- ├── 11: (select 1 10)
+ ├── G1: (project G2 G3)
+ │    └── "[presentation: column3:3,column4:4,column5:5,column6:6]" [cost=1100.00]
+ │         └── best: (project G2 G3)
+ ├── G2: (select G4 G5)
  │    └── "" [cost=1100.00]
- │         └── best: (select 1 10)
- ├── 10: (filters 4 8)
- ├── 9: (and 4 8)
- ├── 8: (eq 7 7)
- ├── 7: (function 5 6 5 concat)
- ├── 6: (const 'foo')
- ├── 5: (variable b.x)
- ├── 4: (eq 2 3)
- ├── 3: (const 1)
- ├── 2: (variable b.z)
- └── 1: (scan b)
-      └── "" [cost=1000.00]
-           └── best: (scan b)
+ │         └── best: (select G4 G5)
+ ├── G3: (projections G6 G7 G8 G11)
+ ├── G4: (scan b)
+ │    └── "" [cost=1000.00]
+ │         └── best: (scan b)
+ ├── G5: (filters G9 G10)
+ ├── G6: (const 1)
+ ├── G7: (plus G12 G13)
+ ├── G8: (cast G11 timestamp)
+ ├── G9: (eq G12 G13)
+ ├── G10: (eq G14 G14)
+ ├── G11: (function now)
+ ├── G12: (variable b.z)
+ ├── G13: (const 1)
+ ├── G14: (function G16 G15 G16 concat)
+ ├── G15: (const 'foo')
+ └── G16: (variable b.x)
+
+# Test topological sorting
+memo
+SELECT x FROM a WHERE x = 1 AND x+y = 1
+----
+[presentation: x:1]
+memo
+ ├── G1: (project G2 G3)
+ │    └── "[presentation: x:1]" [cost=110.00]
+ │         └── best: (project G2 G3)
+ ├── G2: (select G4 G5) (select G6 G7)
+ │    └── "" [cost=110.00]
+ │         └── best: (select G6 G7)
+ ├── G3: (projections G12)
+ ├── G4: (scan a)
+ │    └── "" [cost=1000.00]
+ │         └── best: (scan a)
+ ├── G5: (filters G8 G9)
+ ├── G6: (scan a,constrained)
+ │    └── "" [cost=100.00]
+ │         └── best: (scan a,constrained)
+ ├── G7: (filters G9)
+ ├── G8: (eq G12 G11)
+ ├── G9: (eq G10 G11)
+ ├── G10: (plus G12 G13)
+ ├── G11: (const 1)
+ ├── G12: (variable a.x)
+ └── G13: (variable a.y)
+
+memo raw-memo
+SELECT x FROM a WHERE x = 1 AND x+y = 1
+----
+root: G12, [presentation: x:1]
+memo
+ ├── G1: (scan a)
+ │    └── "" [cost=1000.00]
+ │         └── best: (scan a)
+ ├── G2: (variable a.x)
+ ├── G3: (const 1)
+ ├── G4: (eq G2 G3)
+ ├── G5: (variable a.y)
+ ├── G6: (plus G2 G5)
+ ├── G7: (eq G6 G3)
+ ├── G8: (and G4 G7)
+ ├── G9: (filters G4 G7)
+ ├── G10: (select G1 G9) (select G15 G14)
+ │    └── "" [cost=110.00]
+ │         └── best: (select G15 G14)
+ ├── G11: (projections G2)
+ ├── G12: (project G10 G11)
+ │    └── "[presentation: x:1]" [cost=110.00]
+ │         └── best: (project G10 G11)
+ ├── G13: (true)
+ ├── G14: (filters G7)
+ └── G15: (scan a,constrained)
+      └── "" [cost=100.00]
+           └── best: (scan a,constrained)

--- a/pkg/sql/opt/xform/testdata/physprops/ordering
+++ b/pkg/sql/opt/xform/testdata/physprops/ordering
@@ -186,32 +186,30 @@ project
 memo
 SELECT y, x-1 FROM a WHERE x>y ORDER BY x, y DESC
 ----
-[12: "p:y:2,column5:5 o:+1,-2"]
+[presentation: y:2,column5:5] [ordering: +1,-2]
 memo
- ├── 12: (project 11 9)
+ ├── G1: (project G2 G3)
  │    ├── "" [cost=1100.00]
- │    │    └── best: (project 11 9)
- │    └── "p:y:2,column5:5 o:+1,-2" [cost=1100.00]
- │         └── best: (project 11="o:+1,-2" 9)
- ├── 11: (select 10 5)
+ │    │    └── best: (project G2 G3)
+ │    └── "[presentation: y:2,column5:5] [ordering: +1,-2]" [cost=1100.00]
+ │         └── best: (project G2="o:+1,-2" G3)
+ ├── G2: (select G4 G5)
  │    ├── "" [cost=1100.00]
- │    │    └── best: (select 10 5)
- │    └── "o:+1,-2" [cost=1100.00]
- │         └── best: (select 10="o:+1,-2" 5)
- ├── 10: (scan a)
+ │    │    └── best: (select G4 G5)
+ │    └── "[ordering: +1,-2]" [cost=1100.00]
+ │         └── best: (select G4="o:+1,-2" G5)
+ ├── G3: (projections G10 G6 G9)
+ ├── G4: (scan a)
  │    ├── "" [cost=1000.00]
  │    │    └── best: (scan a)
- │    └── "o:+1,-2" [cost=1000.00]
+ │    └── "[ordering: +1,-2]" [cost=1000.00]
  │         └── best: (scan a)
- ├── 9: (projections 3 8 2)
- ├── 8: (minus 2 7)
- ├── 7: (const 1)
- ├── 6: (select 1 5)
- ├── 5: (filters 4)
- ├── 4: (gt 2 3)
- ├── 3: (variable a.y)
- ├── 2: (variable a.x)
- └── 1: (scan a)
+ ├── G5: (filters G7)
+ ├── G6: (minus G9 G8)
+ ├── G7: (gt G9 G10)
+ ├── G8: (const 1)
+ ├── G9: (variable a.x)
+ └── G10: (variable a.y)
 
 # Pass through ordering to scan operator that can't support it.
 opt
@@ -237,28 +235,26 @@ sort
 memo
 SELECT y, z FROM a WHERE x>y ORDER BY y
 ----
-[11: "p:y:2,z:3 o:+2"]
+[presentation: y:2,z:3] [ordering: +2]
 memo
- ├── 11: (project 10 8)
+ ├── G1: (project G2 G3)
  │    ├── "" [cost=1100.00]
- │    │    └── best: (project 10 8)
- │    └── "p:y:2,z:3 o:+2" [cost=1125.00]
- │         └── best: (sort 11)
- ├── 10: (select 9 5)
+ │    │    └── best: (project G2 G3)
+ │    └── "[presentation: y:2,z:3] [ordering: +2]" [cost=1125.00]
+ │         └── best: (sort G1)
+ ├── G2: (select G4 G5)
  │    ├── "" [cost=1100.00]
- │    │    └── best: (select 9 5)
- │    └── "o:+2" [cost=1125.00]
- │         └── best: (sort 10)
- ├── 9: (scan a)
+ │    │    └── best: (select G4 G5)
+ │    └── "[ordering: +2]" [cost=1125.00]
+ │         └── best: (sort G2)
+ ├── G3: (projections G9 G6)
+ ├── G4: (scan a)
  │    ├── "" [cost=1000.00]
  │    │    └── best: (scan a)
- │    └── "o:+2" [cost=1250.00]
- │         └── best: (sort 9)
- ├── 8: (projections 3 7)
- ├── 7: (variable a.z)
- ├── 6: (select 1 5)
- ├── 5: (filters 4)
- ├── 4: (gt 2 3)
- ├── 3: (variable a.y)
- ├── 2: (variable a.x)
- └── 1: (scan a)
+ │    └── "[ordering: +2]" [cost=1250.00]
+ │         └── best: (sort G4)
+ ├── G5: (filters G7)
+ ├── G6: (variable a.z)
+ ├── G7: (gt G8 G9)
+ ├── G8: (variable a.x)
+ └── G9: (variable a.y)

--- a/pkg/sql/opt/xform/testdata/rules/limit
+++ b/pkg/sql/opt/xform/testdata/rules/limit
@@ -108,23 +108,19 @@ limit
 memo
 SELECT s FROM a WHERE s='foo' LIMIT 1
 ----
-[11: "p:s:4"]
+[presentation: s:4]
 memo
- ├── 12: (true)
- ├── 11: (limit 9 10 ) (scan a@s_idx,constrained,lim=1) (scan a@si_idx,constrained,lim=1)
- │    └── "p:s:4" [cost=1.00]
+ ├── G1: (limit G2 G3 ) (scan a@s_idx,constrained,lim=1) (scan a@si_idx,constrained,lim=1)
+ │    └── "[presentation: s:4]" [cost=1.00]
  │         └── best: (scan a@s_idx,constrained,lim=1)
- ├── 10: (const 1)
- ├── 9: (select 8 5) (scan a@s_idx,constrained) (scan a@si_idx,constrained)
+ ├── G2: (select G4 G5) (scan a@s_idx,constrained) (scan a@si_idx,constrained)
  │    └── "" [cost=100.00]
  │         └── best: (scan a@s_idx,constrained)
- ├── 8: (scan a) (scan a@s_idx) (scan a@si_idx)
+ ├── G3: (const 1)
+ ├── G4: (scan a) (scan a@s_idx) (scan a@si_idx)
  │    └── "" [cost=1000.00]
  │         └── best: (scan a)
- ├── 7: (projections 2)
- ├── 6: (select 1 5)
- ├── 5: (filters 4)
- ├── 4: (eq 2 3)
- ├── 3: (const 'foo')
- ├── 2: (variable a.s)
- └── 1: (scan a)
+ ├── G5: (filters G6)
+ ├── G6: (eq G7 G8)
+ ├── G7: (variable a.s)
+ └── G8: (const 'foo')

--- a/pkg/sql/opt/xform/testdata/rules/scan
+++ b/pkg/sql/opt/xform/testdata/rules/scan
@@ -45,19 +45,13 @@ scan a@s_idx
 memo
 SELECT s, i, f FROM a ORDER BY s, k, i
 ----
-[7: "p:s:4,i:2,f:3 o:+4,+1,+2"]
+[presentation: s:4,i:2,f:3] [ordering: +4,+1,+2]
 memo
- ├── 7: (scan a) (scan a@s_idx)
- │    ├── "" [cost=1000.00]
- │    │    └── best: (scan a)
- │    └── "p:s:4,i:2,f:3 o:+4,+1,+2" [cost=1000.00]
- │         └── best: (scan a@s_idx)
- ├── 6: (projections 2 3 4 5)
- ├── 5: (variable a.k)
- ├── 4: (variable a.f)
- ├── 3: (variable a.i)
- ├── 2: (variable a.s)
- └── 1: (scan a)
+ └── G1: (scan a) (scan a@s_idx)
+      ├── "" [cost=1000.00]
+      │    └── best: (scan a)
+      └── "[presentation: s:4,i:2,f:3] [ordering: +4,+1,+2]" [cost=1000.00]
+           └── best: (scan a@s_idx)
 
 # Scan of primary index is lowest cost.
 opt
@@ -71,19 +65,13 @@ scan a
 memo
 SELECT s, i, f FROM a ORDER BY k, i, s
 ----
-[7: "p:s:4,i:2,f:3 o:+1,+2,+4"]
+[presentation: s:4,i:2,f:3] [ordering: +1,+2,+4]
 memo
- ├── 7: (scan a) (scan a@s_idx)
- │    ├── "" [cost=1000.00]
- │    │    └── best: (scan a)
- │    └── "p:s:4,i:2,f:3 o:+1,+2,+4" [cost=1000.00]
- │         └── best: (scan a)
- ├── 6: (projections 2 3 4 5)
- ├── 5: (variable a.k)
- ├── 4: (variable a.f)
- ├── 3: (variable a.i)
- ├── 2: (variable a.s)
- └── 1: (scan a)
+ └── G1: (scan a) (scan a@s_idx)
+      ├── "" [cost=1000.00]
+      │    └── best: (scan a)
+      └── "[presentation: s:4,i:2,f:3] [ordering: +1,+2,+4]" [cost=1000.00]
+           └── best: (scan a)
 
 # Secondary index has right order, but is not covering.
 opt
@@ -98,17 +86,13 @@ sort
 memo
 SELECT s, j FROM a ORDER BY s
 ----
-[5: "p:s:4,j:5 o:+4"]
+[presentation: s:4,j:5] [ordering: +4]
 memo
- ├── 5: (scan a) (scan a@si_idx)
- │    ├── "" [cost=1000.00]
- │    │    └── best: (scan a)
- │    └── "p:s:4,j:5 o:+4" [cost=1250.00]
- │         └── best: (sort 5)
- ├── 4: (projections 2 3)
- ├── 3: (variable a.j)
- ├── 2: (variable a.s)
- └── 1: (scan a)
+ └── G1: (scan a) (scan a@si_idx)
+      ├── "" [cost=1000.00]
+      │    └── best: (scan a)
+      └── "[presentation: s:4,j:5] [ordering: +4]" [cost=1250.00]
+           └── best: (sort G1)
 
 # Consider three different indexes, and pick index with multiple keys.
 opt
@@ -122,40 +106,32 @@ scan a@si_idx
 memo
 SELECT i, k FROM a ORDER BY s DESC, i, k
 ----
-[6: "p:i:2,k:1 o:-4,+2,+1"]
+[presentation: i:2,k:1] [ordering: -4,+2,+1]
 memo
- ├── 6: (scan a) (scan a@s_idx) (scan a@si_idx)
- │    ├── "" [cost=1000.00]
- │    │    └── best: (scan a)
- │    └── "p:i:2,k:1 o:-4,+2,+1" [cost=1000.00]
- │         └── best: (scan a@si_idx)
- ├── 5: (projections 2 3 4)
- ├── 4: (variable a.s)
- ├── 3: (variable a.k)
- ├── 2: (variable a.i)
- └── 1: (scan a)
+ └── G1: (scan a) (scan a@s_idx) (scan a@si_idx)
+      ├── "" [cost=1000.00]
+      │    └── best: (scan a)
+      └── "[presentation: i:2,k:1] [ordering: -4,+2,+1]" [cost=1000.00]
+           └── best: (scan a@si_idx)
 
 memo
 SELECT i, k FROM a WHERE s >= 'foo'
 ----
-[12: "p:i:2,k:1"]
+[presentation: i:2,k:1]
 memo
- ├── 13: (true)
- ├── 12: (project 11 9)
- │    └── "p:i:2,k:1" [cost=100.00]
- │         └── best: (project 11 9)
- ├── 11: (select 10 5) (scan a@s_idx,constrained) (scan a@si_idx,constrained)
+ ├── G1: (project G2 G3)
+ │    └── "[presentation: i:2,k:1]" [cost=100.00]
+ │         └── best: (project G2 G3)
+ ├── G2: (select G4 G5) (scan a@s_idx,constrained) (scan a@si_idx,constrained)
  │    └── "" [cost=100.00]
  │         └── best: (scan a@s_idx,constrained)
- ├── 10: (scan a) (scan a@s_idx) (scan a@si_idx)
+ ├── G3: (projections G6 G7)
+ ├── G4: (scan a) (scan a@s_idx) (scan a@si_idx)
  │    └── "" [cost=1000.00]
  │         └── best: (scan a)
- ├── 9: (projections 7 8)
- ├── 8: (variable a.k)
- ├── 7: (variable a.i)
- ├── 6: (select 1 5)
- ├── 5: (filters 4)
- ├── 4: (ge 2 3)
- ├── 3: (const 'foo')
- ├── 2: (variable a.s)
- └── 1: (scan a)
+ ├── G5: (filters G8)
+ ├── G6: (variable a.i)
+ ├── G7: (variable a.k)
+ ├── G8: (ge G9 G10)
+ ├── G9: (variable a.s)
+ └── G10: (const 'foo')

--- a/pkg/sql/opt/xform/testdata/rules/select
+++ b/pkg/sql/opt/xform/testdata/rules/select
@@ -38,22 +38,18 @@ scan a
 memo
 SELECT k FROM a WHERE k = 1
 ----
-[9: "p:k:1"]
+[presentation: k:1]
 memo
- ├── 10: (true)
- ├── 9: (select 8 5) (scan a,constrained)
- │    └── "p:k:1" [cost=100.00]
+ ├── G1: (select G2 G3) (scan a,constrained)
+ │    └── "[presentation: k:1]" [cost=100.00]
  │         └── best: (scan a,constrained)
- ├── 8: (scan a) (scan a@u) (scan a@v)
+ ├── G2: (scan a) (scan a@u) (scan a@v)
  │    └── "" [cost=1000.00]
  │         └── best: (scan a)
- ├── 7: (projections 2)
- ├── 6: (select 1 5)
- ├── 5: (filters 4)
- ├── 4: (eq 2 3)
- ├── 3: (const 1)
- ├── 2: (variable a.k)
- └── 1: (scan a)
+ ├── G3: (filters G4)
+ ├── G4: (eq G5 G6)
+ ├── G5: (variable a.k)
+ └── G6: (const 1)
 
 opt
 SELECT k FROM a WHERE v > 1
@@ -71,26 +67,23 @@ project
 memo
 SELECT k FROM a WHERE v > 1
 ----
-[11: "p:k:1"]
+[presentation: k:1]
 memo
- ├── 12: (true)
- ├── 11: (project 10 8)
- │    └── "p:k:1" [cost=100.00]
- │         └── best: (project 10 8)
- ├── 10: (select 9 5) (scan a@v,constrained)
+ ├── G1: (project G2 G3)
+ │    └── "[presentation: k:1]" [cost=100.00]
+ │         └── best: (project G2 G3)
+ ├── G2: (select G4 G5) (scan a@v,constrained)
  │    └── "" [cost=100.00]
  │         └── best: (scan a@v,constrained)
- ├── 9: (scan a) (scan a@u) (scan a@v)
+ ├── G3: (projections G6)
+ ├── G4: (scan a) (scan a@u) (scan a@v)
  │    └── "" [cost=1000.00]
  │         └── best: (scan a)
- ├── 8: (projections 7)
- ├── 7: (variable a.k)
- ├── 6: (select 1 5)
- ├── 5: (filters 4)
- ├── 4: (gt 2 3)
- ├── 3: (const 1)
- ├── 2: (variable a.v)
- └── 1: (scan a)
+ ├── G5: (filters G7)
+ ├── G6: (variable a.k)
+ ├── G7: (gt G8 G9)
+ ├── G8: (variable a.v)
+ └── G9: (const 1)
 
 opt
 SELECT k FROM a WHERE u = 1 AND k = 5
@@ -108,33 +101,29 @@ project
 memo
 SELECT k FROM a WHERE u = 1 AND k = 5
 ----
-[14: "p:k:1"]
+[presentation: k:1]
 memo
- ├── 17: (scan a,constrained)
- │    └── "" [cost=100.00]
- │         └── best: (scan a,constrained)
- ├── 16: (filters 4)
- ├── 15: (true)
- ├── 14: (project 13 11)
- │    └── "p:k:1" [cost=100.00]
- │         └── best: (project 13 11)
- ├── 13: (select 12 9) (select 17 16) (scan a@u,constrained)
+ ├── G1: (project G2 G3)
+ │    └── "[presentation: k:1]" [cost=100.00]
+ │         └── best: (project G2 G3)
+ ├── G2: (select G4 G5) (select G6 G7) (scan a@u,constrained)
  │    └── "" [cost=100.00]
  │         └── best: (scan a@u,constrained)
- ├── 12: (scan a) (scan a@u) (scan a@v)
+ ├── G3: (projections G10)
+ ├── G4: (scan a) (scan a@u) (scan a@v)
  │    └── "" [cost=1000.00]
  │         └── best: (scan a)
- ├── 11: (projections 5)
- ├── 10: (select 1 9)
- ├── 9: (filters 4 7)
- ├── 8: (and 4 7)
- ├── 7: (eq 5 6)
- ├── 6: (const 5)
- ├── 5: (variable a.k)
- ├── 4: (eq 2 3)
- ├── 3: (const 1)
- ├── 2: (variable a.u)
- └── 1: (scan a)
+ ├── G5: (filters G9 G8)
+ ├── G6: (scan a,constrained)
+ │    └── "" [cost=100.00]
+ │         └── best: (scan a,constrained)
+ ├── G7: (filters G9)
+ ├── G8: (eq G10 G11)
+ ├── G9: (eq G12 G13)
+ ├── G10: (variable a.k)
+ ├── G11: (const 5)
+ ├── G12: (variable a.u)
+ └── G13: (const 1)
 
 # Constraint + remaining filter.
 opt
@@ -162,33 +151,29 @@ project
 memo
 SELECT k FROM a WHERE u = 1 AND k+u = 1
 ----
-[14: "p:k:1"]
+[presentation: k:1]
 memo
- ├── 17: (scan a@u,constrained)
- │    └── "" [cost=100.00]
- │         └── best: (scan a@u,constrained)
- ├── 16: (filters 7)
- ├── 15: (true)
- ├── 14: (project 13 11)
- │    └── "p:k:1" [cost=110.00]
- │         └── best: (project 13 11)
- ├── 13: (select 12 9) (select 17 16)
+ ├── G1: (project G2 G3)
+ │    └── "[presentation: k:1]" [cost=110.00]
+ │         └── best: (project G2 G3)
+ ├── G2: (select G4 G5) (select G6 G7)
  │    └── "" [cost=110.00]
- │         └── best: (select 17 16)
- ├── 12: (scan a) (scan a@u) (scan a@v)
+ │         └── best: (select G6 G7)
+ ├── G3: (projections G12)
+ ├── G4: (scan a) (scan a@u) (scan a@v)
  │    └── "" [cost=1000.00]
  │         └── best: (scan a)
- ├── 11: (projections 5)
- ├── 10: (select 1 9)
- ├── 9: (filters 4 7)
- ├── 8: (and 4 7)
- ├── 7: (eq 6 3)
- ├── 6: (plus 5 2)
- ├── 5: (variable a.k)
- ├── 4: (eq 2 3)
- ├── 3: (const 1)
- ├── 2: (variable a.u)
- └── 1: (scan a)
+ ├── G5: (filters G8 G9)
+ ├── G6: (scan a@u,constrained)
+ │    └── "" [cost=100.00]
+ │         └── best: (scan a@u,constrained)
+ ├── G7: (filters G9)
+ ├── G8: (eq G13 G11)
+ ├── G9: (eq G10 G11)
+ ├── G10: (plus G12 G13)
+ ├── G11: (const 1)
+ ├── G12: (variable a.k)
+ └── G13: (variable a.u)
 
 opt
 SELECT k FROM a WHERE u = 1 AND v = 5
@@ -213,36 +198,34 @@ project
 memo
 SELECT k FROM a WHERE u = 1 AND v = 5
 ----
-[13: "p:k:1"]
+[presentation: k:1]
 memo
- ├── 18: (scan a@v,constrained)
- │    └── "" [cost=100.00]
- │         └── best: (scan a@v,constrained)
- ├── 17: (filters 4)
- ├── 16: (scan a@u,constrained)
+ ├── G1: (project G2 G3)
+ │    └── "[presentation: k:1]" [cost=110.00]
+ │         └── best: (project G2 G3)
+ ├── G2: (select G4 G5) (select G6 G7) (select G8 G9)
+ │    └── "" [cost=110.00]
+ │         └── best: (select G6 G7)
+ ├── G3: (projections G10)
+ ├── G4: (scan a) (scan a@u) (scan a@v)
+ │    └── "" [cost=1000.00]
+ │         └── best: (scan a)
+ ├── G5: (filters G12 G11)
+ ├── G6: (scan a@u,constrained)
  │    └── "" [cost=100.00]
  │         └── best: (scan a@u,constrained)
- ├── 15: (filters 7)
- ├── 14: (true)
- ├── 13: (project 10 12)
- │    └── "p:k:1" [cost=110.00]
- │         └── best: (project 10 12)
- ├── 12: (projections 11)
- ├── 11: (variable a.k)
- ├── 10: (select 1 9) (select 16 15) (select 18 17)
- │    └── "" [cost=110.00]
- │         └── best: (select 16 15)
- ├── 9: (filters 4 7)
- ├── 8: (and 4 7)
- ├── 7: (eq 5 6)
- ├── 6: (const 5)
- ├── 5: (variable a.v)
- ├── 4: (eq 2 3)
- ├── 3: (const 1)
- ├── 2: (variable a.u)
- └── 1: (scan a) (scan a@u) (scan a@v)
-      └── "" [cost=1000.00]
-           └── best: (scan a)
+ ├── G7: (filters G11)
+ ├── G8: (scan a@v,constrained)
+ │    └── "" [cost=100.00]
+ │         └── best: (scan a@v,constrained)
+ ├── G9: (filters G12)
+ ├── G10: (variable a.k)
+ ├── G11: (eq G13 G14)
+ ├── G12: (eq G15 G16)
+ ├── G13: (variable a.v)
+ ├── G14: (const 5)
+ ├── G15: (variable a.u)
+ └── G16: (const 1)
 
 # No constraint can be derived from filter (nothing should be pushed down).
 opt


### PR DESCRIPTION
Closes #24370.

This commit makes several changes to the formatting of a memo in a test:

* Groups are optionally sorted topologically from a specified root, and
  unreachable groups can optionally be omitted (both of these are
  specified by options not currently exposed, however).
* Groups are labeled with a `G` prefix, rather than a bare integer, to
  distinguish them from constants.
* Physical properties are displayed in a "verbose" mode.

Looking at the larger memos, I'm not completely sure the topological sort is a net win for readability - the children of any given group (particularly the second child of the root) can still be pretty deep, and it's harder to guess where a group will be based on its number.

Release note: None.