### PR TITLE
sqlbase: Fix spurious lint error

### DIFF
--- a/pkg/sql/sqlbase/errors.go
+++ b/pkg/sql/sqlbase/errors.go
@@ -233,7 +233,7 @@ func NewStatementCompletionUnknownError(err error) error {
 	return pgerror.NewErrorf(pgerror.CodeStatementCompletionUnknownError, err.Error())
 }
 
-var queryCanceledError error = pgerror.NewErrorf(
+var queryCanceledError = pgerror.NewErrorf(
 	pgerror.CodeQueryCanceledError, "query execution canceled")
 
 // NewQueryCanceledError creates a query cancellation error.


### PR DESCRIPTION
The release-2.0 build failed over the weekend with what looks like a spurious,
if arguably correct, error in the linter.  A similar change was made in the
master branch in commit bc5014b0.

Resolves #24572

Release note: None