### PR TITLE
backupccl: simplify the restore pause test

### DIFF
--- a/pkg/ccl/importccl/csv_test.go
+++ b/pkg/ccl/importccl/csv_test.go
@@ -769,7 +769,9 @@ func TestImportControlJob(t *testing.T) {
 
 		query := fmt.Sprintf(`IMPORT TABLE cancelimport.t (i INT PRIMARY KEY) CSV DATA (%s)`, csvURLs)
 
-		if _, err := jobutils.RunJob(t, sqlDB, &allowResponse, "cancel", query); !testutils.IsError(err, "job canceled") {
+		if _, err := jobutils.RunJob(
+			t, sqlDB, &allowResponse, []string{"cancel"}, query,
+		); !testutils.IsError(err, "job canceled") {
 			t.Fatalf("expected 'job canceled' error, but got %+v", err)
 		}
 		// Check that executing again succeeds. This won't work if the first import
@@ -809,7 +811,9 @@ func TestImportControlJob(t *testing.T) {
 		csvURLs := strings.Join(urls, ", ")
 		query := fmt.Sprintf(`IMPORT TABLE pauseimport.t (i INT PRIMARY KEY) CSV DATA (%s) WITH sstsize = '50B'`, csvURLs)
 
-		jobID, err := jobutils.RunJob(t, sqlDB, &allowResponse, "PAUSE", query)
+		jobID, err := jobutils.RunJob(
+			t, sqlDB, &allowResponse, []string{"PAUSE"}, query,
+		)
 		if !testutils.IsError(err, "job paused") {
 			t.Fatalf("unexpected: %v", err)
 		}


### PR DESCRIPTION
This simplifies the pause/resume test: it now requires only that the job
be paused and resumed more than once while it was making progress.
Previously the restore/pause test watched until the watermark moved to
do a pause and resume -- however with unpredictable chunk execution
order, the watermark sometimes moved too soon or late, making it flaky.

With this change, I no longer get the unepected state error or hanging,
thought I still see the usual occassional liveness failures.
