### PR TITLE
stats: invalidate table statistic caches through gossip

### DIFF
--- a/pkg/gossip/keys.go
+++ b/pkg/gossip/keys.go
@@ -80,6 +80,11 @@ const (
 	// KeyDistSQLDrainingPrefix is the key prefix for each node's DistSQL
 	// draining state.
 	KeyDistSQLDrainingPrefix = "distsql-draining"
+
+	// KeyTableStatAddedPrefix is the prefix for keys that indicate a new table
+	// statistic was computed. The statistics themselves are not stored in gossip;
+	// the keys are used to notify nodes to invalidate table statistic caches.
+	KeyTableStatAddedPrefix = "table-stat-added"
 )
 
 // MakeKey creates a canonical key under which to gossip a piece of
@@ -111,11 +116,11 @@ func IsNodeIDKey(key string) bool {
 // The key should have been constructed by MakeNodeIDKey.
 // Returns an error if the key is not of the correct type or is not parsable.
 func NodeIDFromKey(key string) (roachpb.NodeID, error) {
-	trimmedKey := strings.TrimPrefix(key, KeyNodeIDPrefix+separator)
-	if trimmedKey == key {
-		return 0, errors.Errorf("%q is not a NodeID Key", key)
+	trimmedKey, err := removePrefixFromKey(key, KeyNodeIDPrefix)
+	if err != nil {
+		return 0, err
 	}
-	nodeID, err := strconv.ParseInt(trimmedKey, 10, 64)
+	nodeID, err := strconv.ParseInt(trimmedKey, 10 /* base */, 64 /* bitSize */)
 	if err != nil {
 		return 0, errors.Wrapf(err, "failed parsing NodeID from key %q", key)
 	}
@@ -146,4 +151,36 @@ func MakeDistSQLNodeVersionKey(nodeID roachpb.NodeID) string {
 // draining state.
 func MakeDistSQLDrainingKey(nodeID roachpb.NodeID) string {
 	return MakeKey(KeyDistSQLDrainingPrefix, nodeID.String())
+}
+
+// MakeTableStatAddedKey returns the gossip key used to notify that a new
+// statistic is available for the given table.
+func MakeTableStatAddedKey(tableID uint32) string {
+	return MakeKey(KeyTableStatAddedPrefix, strconv.FormatUint(uint64(tableID), 10 /* base */))
+}
+
+// TableIDFromTableStatAddedKey attempts to extract the table ID from the
+// provided key.
+// The key should have been constructed by MakeTableStatAddedKey.
+// Returns an error if the key is not of the correct type or is not parsable.
+func TableIDFromTableStatAddedKey(key string) (uint32, error) {
+	trimmedKey, err := removePrefixFromKey(key, KeyTableStatAddedPrefix)
+	if err != nil {
+		return 0, err
+	}
+	tableID, err := strconv.ParseUint(trimmedKey, 10 /* base */, 32 /* bitSize */)
+	if err != nil {
+		return 0, errors.Wrapf(err, "failed parsing table ID from key %q", key)
+	}
+	return uint32(tableID), nil
+}
+
+// removePrefixFromKey removes the key prefix and separator and returns what's
+// left. Returns an error if the key doesn't have this prefix.
+func removePrefixFromKey(key, prefix string) (string, error) {
+	trimmedKey := strings.TrimPrefix(key, prefix+separator)
+	if trimmedKey == key {
+		return "", errors.Errorf("%q does not have expected prefix %q%s", key, prefix, separator)
+	}
+	return trimmedKey, nil
 }

--- a/pkg/sql/distsqlrun/flow.go
+++ b/pkg/sql/distsqlrun/flow.go
@@ -21,6 +21,7 @@ import (
 	opentracing "github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 
+	"github.com/cockroachdb/cockroach/pkg/gossip"
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/rpc"
@@ -70,6 +71,8 @@ type FlowCtx struct {
 	// rpcCtx is used by the Outboxes that may be present in the flow for
 	// connecting to other nodes.
 	rpcCtx *rpc.Context
+	// gossip is used by the sample aggregator to notify nodes of a new statistic.
+	gossip *gossip.Gossip
 	// The transaction in which kv operations performed by processors in the flow
 	// must be performed. Processors in the Flow will use this txn concurrently.
 	// This field is generally not nil, except for flows that don't run in a

--- a/pkg/sql/distsqlrun/sample_aggregator.go
+++ b/pkg/sql/distsqlrun/sample_aggregator.go
@@ -21,6 +21,7 @@ import (
 	"github.com/axiomhq/hyperloglog"
 	"github.com/pkg/errors"
 
+	"github.com/cockroachdb/cockroach/pkg/gossip"
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
@@ -198,7 +199,7 @@ func (s *sampleAggregator) mainLoop(ctx context.Context) (earlyExit bool, _ erro
 
 // writeResults inserts the new statistics into system.table_statistics.
 func (s *sampleAggregator) writeResults(ctx context.Context) error {
-	return s.flowCtx.clientDB.Txn(ctx, func(ctx context.Context, txn *client.Txn) error {
+	err := s.flowCtx.clientDB.Txn(ctx, func(ctx context.Context, txn *client.Txn) error {
 		for _, si := range s.sketches {
 			// histogram will be passed to the INSERT statement; we want it to be a
 			// nil interface{} if we don't generate a histogram.
@@ -262,6 +263,18 @@ func (s *sampleAggregator) writeResults(ctx context.Context) error {
 		}
 		return nil
 	})
+	if err != nil {
+		return err
+	}
+
+	// TODO(radu): perhaps use a TTL here to avoid having a key per table floating
+	// around forever (we would need the stat cache to evict old entries
+	// automatically though).
+	return s.flowCtx.gossip.AddInfo(
+		gossip.MakeTableStatAddedKey(uint32(s.tableID)),
+		nil, /* value */
+		0,   /* ttl */
+	)
 }
 
 // generateHistogram returns a histogram (on a given column) from a set of

--- a/pkg/sql/distsqlrun/sample_aggregator.go
+++ b/pkg/sql/distsqlrun/sample_aggregator.go
@@ -21,13 +21,10 @@ import (
 	"github.com/axiomhq/hyperloglog"
 	"github.com/pkg/errors"
 
-	"github.com/cockroachdb/cockroach/pkg/gossip"
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
-	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/stats"
-	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 )
 
@@ -199,11 +196,9 @@ func (s *sampleAggregator) mainLoop(ctx context.Context) (earlyExit bool, _ erro
 
 // writeResults inserts the new statistics into system.table_statistics.
 func (s *sampleAggregator) writeResults(ctx context.Context) error {
-	err := s.flowCtx.clientDB.Txn(ctx, func(ctx context.Context, txn *client.Txn) error {
+	return s.flowCtx.clientDB.Txn(ctx, func(ctx context.Context, txn *client.Txn) error {
 		for _, si := range s.sketches {
-			// histogram will be passed to the INSERT statement; we want it to be a
-			// nil interface{} if we don't generate a histogram.
-			var histogram interface{}
+			var histogram *stats.HistogramData
 			if si.spec.GenerateHistogram && len(s.sr.Get()) != 0 {
 				colIdx := int(si.spec.Columns[0])
 				typ := s.inTypes[colIdx]
@@ -219,62 +214,32 @@ func (s *sampleAggregator) writeResults(ctx context.Context) error {
 				if err != nil {
 					return err
 				}
-				histogram, err = protoutil.Marshal(&h)
-				if err != nil {
-					return err
-				}
+				histogram = &h
 			}
 
-			columnIDs := tree.NewDArray(types.Int)
-			for _, c := range si.spec.Columns {
-				if err := columnIDs.Append(tree.NewDInt(tree.DInt(int(s.sampledCols[c])))); err != nil {
-					return err
-				}
+			columnIDs := make([]sqlbase.ColumnID, len(si.spec.Columns))
+			for i, c := range si.spec.Columns {
+				columnIDs[i] = s.sampledCols[c]
 			}
 
-			var name interface{}
-			if si.spec.StatName != "" {
-				name = si.spec.StatName
-			}
-
-			if _, err := s.flowCtx.executor.ExecuteStatementInTransaction(
-				ctx, "insert-statistic", txn,
-				`INSERT INTO system.table_statistics (
-					"tableID",
-					"name",
-					"columnIDs",
-					"rowCount",
-					"distinctCount",
-					"nullCount",
-					histogram
-				) VALUES ($1, $2, $3, $4, $5, $6, $7)`,
+			if err := stats.InsertNewStat(
+				ctx,
+				s.flowCtx.gossip,
+				s.flowCtx.executor,
+				txn,
 				s.tableID,
-				name,
+				si.spec.StatName,
 				columnIDs,
 				si.numRows,
-				si.sketch.Estimate(),
+				int64(si.sketch.Estimate()),
 				si.numNulls,
 				histogram,
 			); err != nil {
 				return err
 			}
-
-			// TODO(radu): we need to clear out old stats that are superseded.
 		}
 		return nil
 	})
-	if err != nil {
-		return err
-	}
-
-	// TODO(radu): perhaps use a TTL here to avoid having a key per table floating
-	// around forever (we would need the stat cache to evict old entries
-	// automatically though).
-	return s.flowCtx.gossip.AddInfo(
-		gossip.MakeTableStatAddedKey(uint32(s.tableID)),
-		nil, /* value */
-		0,   /* ttl */
-	)
 }
 
 // generateHistogram returns a histogram (on a given column) from a set of

--- a/pkg/sql/distsqlrun/sample_aggregator_test.go
+++ b/pkg/sql/distsqlrun/sample_aggregator_test.go
@@ -46,6 +46,7 @@ func TestSampleAggregator(t *testing.T) {
 		Ctx:      context.Background(),
 		Settings: st,
 		EvalCtx:  evalCtx,
+		gossip:   server.Gossip(),
 		clientDB: kvDB,
 		executor: server.InternalExecutor().(sqlutil.InternalExecutor),
 	}

--- a/pkg/sql/distsqlrun/server.go
+++ b/pkg/sql/distsqlrun/server.go
@@ -348,8 +348,7 @@ func (ds *ServerImpl) setupFlow(
 			*req.EvalContext.SeqState.LastSeqIncremented)
 	}
 
-	// TODO(radu): we should sanity check some of these fields (especially
-	// txnProto).
+	// TODO(radu): we should sanity check some of these fields.
 	flowCtx := FlowCtx{
 		Settings:       ds.Settings,
 		AmbientContext: ds.AmbientContext,
@@ -357,6 +356,7 @@ func (ds *ServerImpl) setupFlow(
 		id:             req.Flow.FlowID,
 		EvalCtx:        evalCtx,
 		rpcCtx:         ds.RPCContext,
+		gossip:         ds.Gossip,
 		txn:            txn,
 		clientDB:       ds.DB,
 		executor:       ds.Executor,

--- a/pkg/sql/stats/gossip_invalidation_test.go
+++ b/pkg/sql/stats/gossip_invalidation_test.go
@@ -1,0 +1,84 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package stats_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlutil"
+	"github.com/cockroachdb/cockroach/pkg/sql/stats"
+	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+)
+
+// TestGossipInvalidation verifies that the cache gets invalidated automatically
+// when a new stat is generated.
+func TestGossipInvalidation(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	ctx := context.Background()
+	tc := testcluster.StartTestCluster(t, 3, base.TestClusterArgs{})
+	defer tc.Stopper().Stop(ctx)
+
+	sc := stats.NewTableStatisticsCache(
+		10, /* statsCacheSize */
+		10, /* histogramCacheSize */
+		tc.Server(0).Gossip(),
+		tc.Server(0).DB(),
+		tc.Server(0).InternalExecutor().(sqlutil.InternalExecutor),
+	)
+
+	sr0 := sqlutils.MakeSQLRunner(tc.ServerConn(0))
+	sr0.Exec(t, "CREATE DATABASE test")
+	sr0.Exec(t, "CREATE TABLE test.t (k INT PRIMARY KEY, v INT)")
+	sr0.Exec(t, "INSERT INTO test.t VALUES (1, 1), (2, 2), (3, 3)")
+
+	tableDesc := sqlbase.GetTableDescriptor(tc.Server(0).DB(), "test", "t")
+	tableID := tableDesc.ID
+
+	expectNStats := func(n int) error {
+		stats, err := sc.GetTableStats(ctx, tableID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(stats) != n {
+			return fmt.Errorf("expected %d stats, got: %v", n, stats)
+		}
+		return nil
+	}
+
+	if err := expectNStats(0); err != nil {
+		t.Fatal(err)
+	}
+	sr1 := sqlutils.MakeSQLRunner(tc.ServerConn(1))
+	sr1.Exec(t, "CREATE STATISTICS k ON k FROM test.t")
+
+	testutils.SucceedsSoon(t, func() error {
+		return expectNStats(1)
+	})
+
+	sr2 := sqlutils.MakeSQLRunner(tc.ServerConn(2))
+	sr2.Exec(t, "CREATE STATISTICS v ON v FROM test.t")
+
+	testutils.SucceedsSoon(t, func() error {
+		return expectNStats(2)
+	})
+}

--- a/pkg/sql/stats/new_stat.go
+++ b/pkg/sql/stats/new_stat.go
@@ -1,0 +1,94 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package stats
+
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/gossip"
+	"github.com/cockroachdb/cockroach/pkg/internal/client"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlutil"
+	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
+)
+
+// InsertNewStat inserts a new statistic in the system table and updates the
+// gossip key to notify the stat caches.
+func InsertNewStat(
+	ctx context.Context,
+	g *gossip.Gossip,
+	executor sqlutil.InternalExecutor,
+	txn *client.Txn,
+	tableID sqlbase.ID,
+	name string,
+	columnIDs []sqlbase.ColumnID,
+	rowCount, distinctCount, nullCount int64,
+	h *HistogramData,
+) error {
+	// We must pass a nil interface{} if we want to insert a NULL.
+	var nameVal, histogramVal interface{}
+	if name != "" {
+		nameVal = name
+	}
+	if h != nil {
+		var err error
+		histogramVal, err = protoutil.Marshal(h)
+		if err != nil {
+			return err
+		}
+	}
+
+	columnIDsVal := tree.NewDArray(types.Int)
+	for _, c := range columnIDs {
+		if err := columnIDsVal.Append(tree.NewDInt(tree.DInt(int(c)))); err != nil {
+			return err
+		}
+	}
+
+	if _, err := executor.ExecuteStatementInTransaction(
+		ctx, "insert-statistic", txn,
+		`INSERT INTO system.table_statistics (
+					"tableID",
+					"name",
+					"columnIDs",
+					"rowCount",
+					"distinctCount",
+					"nullCount",
+					histogram
+				) VALUES ($1, $2, $3, $4, $5, $6, $7)`,
+		tableID,
+		nameVal,
+		columnIDsVal,
+		rowCount,
+		distinctCount,
+		nullCount,
+		histogramVal,
+	); err != nil {
+		return err
+	}
+
+	// TODO(radu): we need to clear out old stats that are superseded.
+
+	// TODO(radu): perhaps use a TTL here to avoid having a key per table floating
+	// around forever (we would need the stat cache to evict old entries
+	// automatically though).
+	return g.AddInfo(
+		gossip.MakeTableStatAddedKey(uint32(tableID)),
+		nil, /* value */
+		0,   /* ttl */
+	)
+}

--- a/pkg/sql/stats/stats_cache_test.go
+++ b/pkg/sql/stats/stats_cache_test.go
@@ -276,7 +276,7 @@ func TestTableStatisticsCache(t *testing.T) {
 	// will result in the cache getting populated. When the stats cache size is
 	// exceeded, entries should be evicted according to the LRU policy.
 	statsCacheSize, histogramCacheSize := 2, 2
-	sc := NewTableStatisticsCache(statsCacheSize, histogramCacheSize, db, ex)
+	sc := NewTableStatisticsCache(statsCacheSize, histogramCacheSize, s.Gossip(), db, ex)
 	for _, tableID := range tableIDs {
 		if err := checkStatsForTable(ctx, sc, expectedStats[tableID], tableID); err != nil {
 			t.Fatal(err)


### PR DESCRIPTION
This change makes the TableStatisticsCache stay up-to-date
automatically: whenever we compute a stat, we gossip a "table stat
added" key for that table, which triggers an invalidation in the
cache.

In the current form, this will add a key per table when we enable
statistics automatically. A possible improvement would be to set a TTL
on these keys and change the cache to always invalidate very old
entries automatically.

Fixes #24585.

Release note: None