### PR TITLE
cherry-pick 2.0: distsqlrun: generate TxnCoordMeta in processors that weren't doing it

### DIFF
--- a/pkg/ccl/importccl/csv.go
+++ b/pkg/ccl/importccl/csv.go
@@ -1398,7 +1398,7 @@ func (cp *readCSVProcessor) Run(wg *sync.WaitGroup) {
 		return nil
 	})
 	if err := group.Wait(); err != nil {
-		distsqlrun.DrainAndClose(ctx, cp.output, err)
+		distsqlrun.DrainAndClose(ctx, cp.output, err, func(context.Context) {} /* pushTrailingMeta */)
 		return
 	}
 
@@ -1653,7 +1653,8 @@ func (sp *sstWriter) Run(wg *sync.WaitGroup) {
 		}
 		return nil
 	}()
-	distsqlrun.DrainAndClose(ctx, sp.output, err, sp.input)
+	distsqlrun.DrainAndClose(
+		ctx, sp.output, err, func(context.Context) {} /* pushTrailingMeta */, sp.input)
 }
 
 type importResumer struct {

--- a/pkg/internal/client/txn.go
+++ b/pkg/internal/client/txn.go
@@ -1243,3 +1243,8 @@ func (txn *Txn) IsSerializablePushAndRefreshNotPossible() bool {
 	return txn.Proto().Isolation == enginepb.SERIALIZABLE &&
 		isTxnPushed && txn.mu.Proto.OrigTimestampWasObserved
 }
+
+// Type returns the transaction's type.
+func (txn *Txn) Type() TxnType {
+	return txn.typ
+}

--- a/pkg/sql/distsqlrun/interleaved_reader_joiner.go
+++ b/pkg/sql/distsqlrun/interleaved_reader_joiner.go
@@ -397,6 +397,7 @@ func (irj *interleavedReaderJoiner) Run(wg *sync.WaitGroup) {
 
 	irj.sendMisplannedRangesMetadata(ctx)
 	sendTraceData(ctx, irj.out.output)
+	sendTxnCoordMetaMaybe(irj.flowCtx.txn, irj.out.output)
 	irj.out.Close()
 }
 

--- a/pkg/sql/distsqlrun/tablereader.go
+++ b/pkg/sql/distsqlrun/tablereader.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/pkg/errors"
 
+	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/scrub"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
@@ -158,9 +159,11 @@ func (tr *tableReader) producerMeta(err error) *ProducerMetadata {
 		if traceData != nil {
 			tr.trailingMetadata = append(tr.trailingMetadata, ProducerMetadata{TraceData: traceData})
 		}
-		txnMeta := tr.flowCtx.txn.GetTxnCoordMeta()
-		if txnMeta.Txn.ID != (uuid.UUID{}) {
-			tr.trailingMetadata = append(tr.trailingMetadata, ProducerMetadata{TxnMeta: &txnMeta})
+		if tr.flowCtx.txn.Type() == client.LeafTxn {
+			txnMeta := tr.flowCtx.txn.GetTxnCoordMeta()
+			if txnMeta.Txn.ID != (uuid.UUID{}) {
+				tr.trailingMetadata = append(tr.trailingMetadata, ProducerMetadata{TxnMeta: &txnMeta})
+			}
 		}
 		tr.close()
 	}


### PR DESCRIPTION
Cherry-pick of #24414

Every processor that uses the flow's txn needs to send metadata about
its reads to the root client.Txn/TxnCoordSender. The most critical thing
in that metadata is the read spans. Only the TableReader was doing it,
but more processors need to.

Fixes #24385

Release note: Fix a possible problem with transactions performing joins doing inconsistent reads.

cc @cockroachdb/release 