### PR TITLE
build: fix make ui-maintainer-clean && make ui-lint cycle

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1062,7 +1062,7 @@ WEBPACK_DASHBOARD  := ./opt/node_modules/.bin/webpack-dashboard
 ui-generate: $(UI_ROOT)/distccl/bindata.go
 
 .PHONY: ui-lint
-ui-lint: $(UI_PROTOS)
+ui-lint: $(YARN_INSTALLED_TARGET) $(UI_PROTOS)
 	$(NODE_RUN) -C $(UI_ROOT) $(STYLINT) -c .stylintrc styl
 	$(NODE_RUN) -C $(UI_ROOT) $(TSLINT) -c tslint.json -p tsconfig.json --type-check
 	@# TODO(benesch): Invoke tslint just once when palantir/tslint#2827 is fixed.


### PR DESCRIPTION
At some point the ui-lint target got out of sync with the dependencies
needed for it to run.  This ensures that the linters are installed
before trying to invoke them.

Release note: None