### PR TITLE
cherrypick-2.0: util/hlc: monotonic wall time across restarts

### DIFF
--- a/pkg/keys/constants.go
+++ b/pkg/keys/constants.go
@@ -87,6 +87,9 @@ var (
 	// is to allow a restarting node to discover approximately how long it has
 	// been down without needing to retrieve liveness records from the cluster.
 	localStoreLastUpSuffix = []byte("uptm")
+	// localHLCUpperBoundSuffix stores an upper bound to the wall time used by
+	// the HLC
+	localHLCUpperBoundSuffix = []byte("hlcu")
 	// localStoreSuggestedCompactionSuffix stores suggested compactions to
 	// be aggregated and processed on the store.
 	localStoreSuggestedCompactionSuffix = []byte("comp")

--- a/pkg/keys/keys.go
+++ b/pkg/keys/keys.go
@@ -75,6 +75,12 @@ func StoreLastUpKey() roachpb.Key {
 	return MakeStoreKey(localStoreLastUpSuffix, nil)
 }
 
+// StoreHLCUpperBoundKey returns the key for storing an upper bound to the
+// wall time used by HLC
+func StoreHLCUpperBoundKey() roachpb.Key {
+	return MakeStoreKey(localHLCUpperBoundSuffix, nil)
+}
+
 // StoreSuggestedCompactionKey returns a store-local key for a
 // suggested compaction. It combines the specified start and end keys.
 func StoreSuggestedCompactionKey(start, end roachpb.Key) roachpb.Key {

--- a/pkg/keys/keys_test.go
+++ b/pkg/keys/keys_test.go
@@ -37,6 +37,7 @@ func TestStoreKeyEncodeDecode(t *testing.T) {
 		{key: StoreGossipKey(), expSuffix: localStoreGossipSuffix, expDetail: nil},
 		{key: StoreClusterVersionKey(), expSuffix: localStoreClusterVersionSuffix, expDetail: nil},
 		{key: StoreLastUpKey(), expSuffix: localStoreLastUpSuffix, expDetail: nil},
+		{key: StoreHLCUpperBoundKey(), expSuffix: localHLCUpperBoundSuffix, expDetail: nil},
 		{
 			key:       StoreSuggestedCompactionKey(roachpb.Key("a"), roachpb.Key("z")),
 			expSuffix: localStoreSuggestedCompactionSuffix,

--- a/pkg/server/node.go
+++ b/pkg/server/node.go
@@ -468,6 +468,14 @@ func (n *Node) SetDraining(drain bool) error {
 	})
 }
 
+// SetHLCUpperBound sets the upper bound of the HLC wall time on all of the
+// node's underlying stores.
+func (n *Node) SetHLCUpperBound(ctx context.Context, hlcUpperBound int64) error {
+	return n.stores.VisitStores(func(s *storage.Store) error {
+		return s.WriteHLCUpperBound(ctx, hlcUpperBound)
+	})
+}
+
 // initStores initializes the Stores map from ID to Store. Stores are
 // added to the local sender if already bootstrapped. A bootstrapped
 // Store has a valid ident with cluster, node and Store IDs set. If

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -106,6 +106,17 @@ var (
 		"If enabled, forward clock jumps > max_offset/2 will cause a panic.",
 		false,
 	)
+
+	persistHLCUpperBoundInterval = settings.RegisterDurationSetting(
+		"server.clock.persist_upper_bound_interval",
+		"the interval between persisting the wall time upper bound of the clock. The clock "+
+			"does not generate a wall time greater than the persisted timestamp and will panic if "+
+			"it sees a wall time greater than this value. When cockroach starts, it waits for the "+
+			"wall time to catch-up till this persisted timestamp. This guarantees monotonic wall "+
+			"time across server restarts. Not setting this or setting a value of 0 disables this "+
+			"feature.",
+		0,
+	)
 )
 
 // Server is the cockroach server node.
@@ -723,6 +734,192 @@ func (s *Server) startMonitoringForwardClockJumps(ctx context.Context) {
 	log.Info(ctx, "monitoring forward clock jumps based on server.clock.forward_jump_check_enabled")
 }
 
+// ensureClockMonotonicity sleeps till the wall time reaches
+// prevHLCUpperBound. prevHLCUpperBound > 0 implies we need to guarantee HLC
+// monotonicity across server restarts. prevHLCUpperBound is the last
+// successfully persisted timestamp greater then any wall time used by the
+// server.
+//
+// If prevHLCUpperBound is 0, the function sleeps up to max offset
+func ensureClockMonotonicity(
+	ctx context.Context,
+	clock *hlc.Clock,
+	startTime time.Time,
+	prevHLCUpperBound int64,
+	sleepUntilFn func(until int64, currTime func() int64),
+) {
+	var sleepUntil int64
+	if prevHLCUpperBound != 0 {
+		// Sleep until previous HLC upper bound to ensure wall time monotonicity
+		sleepUntil = prevHLCUpperBound + 1
+	} else {
+		// Previous HLC Upper bound is not known
+		// We might have to sleep a bit to protect against this node producing non-
+		// monotonic timestamps. Before restarting, its clock might have been driven
+		// by other nodes' fast clocks, but when we restarted, we lost all this
+		// information. For example, a client might have written a value at a
+		// timestamp that's in the future of the restarted node's clock, and if we
+		// don't do something, the same client's read would not return the written
+		// value. So, we wait up to MaxOffset; we couldn't have served timestamps more
+		// than MaxOffset in the future (assuming that MaxOffset was not changed, see
+		// #9733).
+		//
+		// As an optimization for tests, we don't sleep if all the stores are brand
+		// new. In this case, the node will not serve anything anyway until it
+		// synchronizes with other nodes.
+
+		// Don't have to sleep for monotonicity when using clockless reads
+		// (nor can we, for we would sleep forever).
+		if maxOffset := clock.MaxOffset(); maxOffset != timeutil.ClocklessMaxOffset {
+			sleepUntil = startTime.UnixNano() + int64(maxOffset) + 1
+		}
+	}
+
+	currentWallTimeFn := func() int64 { /* function to report current time */
+		return clock.Now().WallTime
+	}
+	currentWallTime := currentWallTimeFn()
+	delta := time.Duration(sleepUntil - currentWallTime)
+	if delta > 0 {
+		log.Infof(
+			ctx,
+			"Sleeping till wall time %v to catches up to %v to ensure monotonicity. Delta: %v",
+			currentWallTime,
+			sleepUntil,
+			delta,
+		)
+		sleepUntilFn(sleepUntil, currentWallTimeFn)
+	}
+}
+
+// periodicallyPersistHLCUpperBound periodically persists an upper bound of
+// the HLC's wall time. The interval for persisting is read from
+// persistHLCUpperBoundIntervalCh. An interval of 0 disables persisting.
+//
+// persistHLCUpperBoundFn is used to persist the hlc upper bound, and should
+// return an error if the persist fails.
+//
+// tickerFn is used to create the ticker used for persisting
+//
+// tickCallback is called whenever a tick is processed
+func periodicallyPersistHLCUpperBound(
+	clock *hlc.Clock,
+	persistHLCUpperBoundIntervalCh chan time.Duration,
+	persistHLCUpperBoundFn func(int64) error,
+	tickerFn func(d time.Duration) *time.Ticker,
+	stopCh <-chan struct{},
+	tickCallback func(),
+) {
+	// Create a ticker which can be used in selects.
+	// This ticker is turned on / off based on persistHLCUpperBoundIntervalCh
+	ticker := tickerFn(time.Hour)
+	ticker.Stop()
+
+	// persistInterval is the interval used for persisting the
+	// an upper bound of the HLC
+	var persistInterval time.Duration
+	var ok bool
+
+	persistHLCUpperBound := func() {
+		if err := clock.RefreshHLCUpperBound(
+			persistHLCUpperBoundFn,
+			int64(persistInterval*3), /* delta to compute upper bound */
+		); err != nil {
+			log.Fatalf(
+				context.Background(),
+				"error persisting HLC upper bound: %v",
+				err,
+			)
+		}
+	}
+
+	for {
+		select {
+		case persistInterval, ok = <-persistHLCUpperBoundIntervalCh:
+			ticker.Stop()
+			if !ok {
+				return
+			}
+
+			if persistInterval > 0 {
+				ticker = tickerFn(persistInterval)
+				persistHLCUpperBound()
+				log.Info(context.Background(), "persisting HLC upper bound is enabled")
+			} else {
+				if err := clock.ResetHLCUpperBound(persistHLCUpperBoundFn); err != nil {
+					log.Fatalf(
+						context.Background(),
+						"error resetting hlc upper bound: %v",
+						err,
+					)
+				}
+				log.Info(context.Background(), "persisting HLC upper bound is disabled")
+			}
+
+		case <-ticker.C:
+			if persistInterval > 0 {
+				persistHLCUpperBound()
+			}
+
+		case <-stopCh:
+			ticker.Stop()
+			return
+		}
+
+		if tickCallback != nil {
+			tickCallback()
+		}
+	}
+}
+
+// startPersistingHLCUpperBound starts a goroutine to persist an upper bound
+// to the HLC.
+//
+// persistHLCUpperBoundFn is used to persist upper bound of the HLC, and should
+// return an error if the persist fails
+//
+// tickerFn is used to create a new ticker
+//
+// tickCallback is called whenever persistHLCUpperBoundCh or a ticker tick is
+// processed
+func (s *Server) startPersistingHLCUpperBound(
+	hlcUpperBoundExists bool,
+	persistHLCUpperBoundFn func(int64) error,
+	tickerFn func(d time.Duration) *time.Ticker,
+) {
+	persistHLCUpperBoundIntervalCh := make(chan time.Duration, 1)
+	persistHLCUpperBoundInterval.SetOnChange(&s.st.SV, func() {
+		persistHLCUpperBoundIntervalCh <- persistHLCUpperBoundInterval.Get(&s.st.SV)
+	})
+
+	if hlcUpperBoundExists {
+		// The feature to persist upper bounds to wall times is enabled.
+		// Persist a new upper bound to continue guaranteeing monotonicity
+		// Going forward the goroutine launched below will take over persisting
+		// the upper bound
+		if err := s.clock.RefreshHLCUpperBound(
+			persistHLCUpperBoundFn,
+			int64(5*time.Second),
+		); err != nil {
+			log.Fatal(context.TODO(), err)
+		}
+	}
+
+	s.stopper.RunWorker(
+		context.TODO(),
+		func(context.Context) {
+			periodicallyPersistHLCUpperBound(
+				s.clock,
+				persistHLCUpperBoundIntervalCh,
+				persistHLCUpperBoundFn,
+				tickerFn,
+				s.stopper.ShouldStop(),
+				nil, /* tick callback */
+			)
+		},
+	)
+}
+
 // Start starts the server on the specified port, starts gossip and initializes
 // the node using the engines from the server's context. This is complex since
 // it sets up the listeners and the associated port muxing, but especially since
@@ -1071,30 +1268,25 @@ If problems persist, please see ` + base.DocsURL("cluster-setup-troubleshooting.
 			msg)
 	}).Stop()
 
+	var hlcUpperBoundExists bool
 	if len(bootstrappedEngines) > 0 {
-		// We might have to sleep a bit to protect against this node producing non-
-		// monotonic timestamps. Before restarting, its clock might have been driven
-		// by other nodes' fast clocks, but when we restarted, we lost all this
-		// information. For example, a client might have written a value at a
-		// timestamp that's in the future of the restarted node's clock, and if we
-		// don't do something, the same client's read would not return the written
-		// value. So, we wait up to MaxOffset; we couldn't have served timestamps more
-		// than MaxOffset in the future (assuming that MaxOffset was not changed, see
-		// #9733).
-		//
-		// As an optimization for tests, we don't sleep if all the stores are brand
-		// new. In this case, the node will not serve anything anyway until it
-		// synchronizes with other nodes.
-		var sleepDuration time.Duration
-		// Don't have to sleep for monotonicity when using clockless reads
-		// (nor can we, for we would sleep forever).
-		if maxOffset := s.clock.MaxOffset(); maxOffset != timeutil.ClocklessMaxOffset {
-			sleepDuration = maxOffset - timeutil.Since(startTime)
+		hlcUpperBound, err := storage.ReadMaxHLCUpperBound(ctx, bootstrappedEngines)
+		if err != nil {
+			log.Fatal(ctx, err)
 		}
-		if sleepDuration > 0 {
-			log.Infof(ctx, "sleeping for %s to guarantee HLC monotonicity", sleepDuration)
-			time.Sleep(sleepDuration)
+
+		if hlcUpperBound > 0 {
+			hlcUpperBoundExists = true
 		}
+
+		ensureClockMonotonicity(
+			ctx,
+			s.clock,
+			startTime,
+			hlcUpperBound,
+			timeutil.SleepUntil,
+		)
+
 	} else if len(s.cfg.GossipBootstrapResolvers) == 0 {
 		// If the _unfiltered_ list of hosts from the --join flag is
 		// empty, then this node can bootstrap a new cluster. We disallow
@@ -1167,6 +1359,14 @@ If problems persist, please see ` + base.DocsURL("cluster-setup-troubleshooting.
 		return err
 	}
 	log.Event(ctx, "started node")
+	s.startPersistingHLCUpperBound(
+		hlcUpperBoundExists,
+		func(t int64) error { /* function to persist upper bound of HLC to all stores */
+			return s.node.SetHLCUpperBound(context.Background(), t)
+		},
+		time.NewTicker,
+	)
+
 	s.execCfg.DistSQLPlanner.SetNodeDesc(s.node.Descriptor)
 
 	// Cluster ID should have been determined by this point.

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -45,9 +45,12 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/httputil"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/gogo/protobuf/jsonpb"
 	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
 )
 
 var nodeTestBaseContext = testutils.NewNodeTestBaseContext()
@@ -663,5 +666,230 @@ func TestClusterIDMismatch(t *testing.T) {
 	expected := "conflicting store cluster IDs"
 	if !testutils.IsError(err, expected) {
 		t.Fatalf("expected %s error, got %v", expected, err)
+	}
+}
+
+func TestEnsureInitialWallTimeMonotonicity(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	testCases := []struct {
+		name              string
+		prevHLCUpperBound int64
+		clockStartTime    int64
+		checkPersist      bool
+	}{
+		{
+			name:              "lower upper bound time",
+			prevHLCUpperBound: 100,
+			clockStartTime:    1000,
+			checkPersist:      true,
+		},
+		{
+			name:              "higher upper bound time",
+			prevHLCUpperBound: 10000,
+			clockStartTime:    1000,
+			checkPersist:      true,
+		},
+		{
+			name:              "significantly higher upper bound time",
+			prevHLCUpperBound: int64(3 * time.Hour),
+			clockStartTime:    int64(1 * time.Hour),
+			checkPersist:      true,
+		},
+		{
+			name:              "equal upper bound time",
+			prevHLCUpperBound: int64(time.Hour),
+			clockStartTime:    int64(time.Hour),
+			checkPersist:      true,
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.name, func(t *testing.T) {
+			a := assert.New(t)
+
+			const maxOffset = 500 * time.Millisecond
+			m := hlc.NewManualClock(test.clockStartTime)
+			c := hlc.NewClock(m.UnixNano, maxOffset)
+
+			sleepUntilFn := func(until int64, currentTime func() int64) {
+				delta := until - currentTime()
+				if delta > 0 {
+					m.Increment(delta)
+				}
+			}
+
+			wallTime1 := c.Now().WallTime
+			if test.clockStartTime < test.prevHLCUpperBound {
+				a.True(
+					wallTime1 < test.prevHLCUpperBound,
+					fmt.Sprintf(
+						"expected wall time %d < prev upper bound %d",
+						wallTime1,
+						test.prevHLCUpperBound,
+					),
+				)
+			}
+
+			ensureClockMonotonicity(
+				context.TODO(),
+				c,
+				c.PhysicalTime(),
+				test.prevHLCUpperBound,
+				sleepUntilFn,
+			)
+
+			wallTime2 := c.Now().WallTime
+			// After ensuring monotonicity, wall time should be greater than
+			// persisted upper bound
+			a.True(
+				wallTime2 > test.prevHLCUpperBound,
+				fmt.Sprintf(
+					"expected wall time %d > prev upper bound %d",
+					wallTime2,
+					test.prevHLCUpperBound,
+				),
+			)
+		})
+	}
+}
+
+func TestPersistHLCUpperBound(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	var fatal bool
+	defer log.SetExitFunc(os.Exit)
+	log.SetExitFunc(func(r int) {
+		defer log.Flush()
+		if r != 0 {
+			fatal = true
+		}
+	})
+
+	testCases := []struct {
+		name            string
+		persistInterval time.Duration
+	}{
+		{
+			name:            "persist default delta",
+			persistInterval: 200 * time.Millisecond,
+		},
+		{
+			name:            "persist 100ms delta",
+			persistInterval: 50 * time.Millisecond,
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.name, func(t *testing.T) {
+			a := assert.New(t)
+			m := hlc.NewManualClock(int64(1))
+			c := hlc.NewClock(m.UnixNano, time.Nanosecond)
+
+			var persistErr error
+			var persistedUpperBound int64
+			var tickerDur time.Duration
+			persistUpperBoundFn := func(i int64) error {
+				if persistErr != nil {
+					return persistErr
+				}
+				persistedUpperBound = i
+				return nil
+			}
+
+			tickerCh := make(chan time.Time)
+			tickProcessedCh := make(chan struct{})
+			persistHLCUpperBoundIntervalCh := make(chan time.Duration, 1)
+			stopCh := make(chan struct{}, 1)
+			defer close(persistHLCUpperBoundIntervalCh)
+
+			go periodicallyPersistHLCUpperBound(
+				c,
+				persistHLCUpperBoundIntervalCh,
+				persistUpperBoundFn,
+				func(d time.Duration) *time.Ticker {
+					ticker := time.NewTicker(d)
+					ticker.Stop()
+					ticker.C = tickerCh
+					tickerDur = d
+					return ticker
+				},
+				stopCh,
+				func() {
+					tickProcessedCh <- struct{}{}
+				},
+			)
+
+			fatal = false
+			// persist an upper bound
+			m.Increment(100)
+			wallTime3 := c.Now().WallTime
+			persistHLCUpperBoundIntervalCh <- test.persistInterval
+			<-tickProcessedCh
+
+			a.True(
+				test.persistInterval == tickerDur,
+				fmt.Sprintf(
+					"expected persist interval %d = ticker duration %d",
+					test.persistInterval,
+					tickerDur,
+				),
+			)
+
+			// Updating persistInterval should have triggered a persist
+			firstPersist := persistedUpperBound
+			a.True(
+				persistedUpperBound > wallTime3,
+				fmt.Sprintf(
+					"expected persisted wall time %d > wall time %d",
+					persistedUpperBound,
+					wallTime3,
+				),
+			)
+			// ensure that in memory value and persisted value are same
+			a.Equal(c.WallTimeUpperBound(), persistedUpperBound)
+
+			// Increment clock by 100 and tick the timer.
+			// A persist should have happened
+			m.Increment(100)
+			tickerCh <- timeutil.Now()
+			<-tickProcessedCh
+			secondPersist := persistedUpperBound
+			a.True(
+				secondPersist == firstPersist+100,
+				fmt.Sprintf(
+					"expected persisted wall time %d to be 100 more than earlier persisted value %d",
+					secondPersist,
+					firstPersist,
+				),
+			)
+			a.Equal(c.WallTimeUpperBound(), persistedUpperBound)
+			a.False(fatal)
+			fatal = false
+
+			// After disabling persistHLCUpperBound, a value of 0 should be persisted
+			persistHLCUpperBoundIntervalCh <- 0
+			<-tickProcessedCh
+			a.Equal(
+				int64(0),
+				c.WallTimeUpperBound(),
+			)
+			a.Equal(int64(0), persistedUpperBound)
+			a.Equal(int64(0), c.WallTimeUpperBound())
+			a.False(fatal)
+			fatal = false
+
+			persistHLCUpperBoundIntervalCh <- test.persistInterval
+			<-tickProcessedCh
+			m.Increment(100)
+			tickerCh <- timeutil.Now()
+			<-tickProcessedCh
+			// If persisting fails, a fatal error is expected
+			persistErr = errors.New("test err")
+			fatal = false
+			tickerCh <- timeutil.Now()
+			<-tickProcessedCh
+			a.True(fatal)
+		})
 	}
 }

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -1702,6 +1702,64 @@ func (s *Store) ReadLastUpTimestamp(ctx context.Context) (hlc.Timestamp, error) 
 	return timestamp, nil
 }
 
+// WriteHLCUpperBound records an upper bound to the wall time of the HLC
+func (s *Store) WriteHLCUpperBound(ctx context.Context, time int64) error {
+	ctx = s.AnnotateCtx(ctx)
+	ts := hlc.Timestamp{WallTime: time}
+	batch := s.Engine().NewBatch()
+	// Write has to sync to disk to ensure HLC monotonicity across restarts
+	defer batch.Close()
+	if err := engine.MVCCPutProto(
+		ctx,
+		batch,
+		nil,
+		keys.StoreHLCUpperBoundKey(),
+		hlc.Timestamp{},
+		nil,
+		&ts,
+	); err != nil {
+		return err
+	}
+
+	if err := batch.Commit(true /* sync */); err != nil {
+		return err
+	}
+	return nil
+}
+
+// ReadHLCUpperBound returns the upper bound to the wall time of the HLC
+// If this value does not exist 0 is returned
+func ReadHLCUpperBound(ctx context.Context, e engine.Engine) (int64, error) {
+	var timestamp hlc.Timestamp
+	ok, err := engine.MVCCGetProto(
+		ctx, e, keys.StoreHLCUpperBoundKey(), hlc.Timestamp{}, true, nil, &timestamp)
+	if err != nil {
+		return 0, err
+	} else if !ok {
+		return 0, nil
+	}
+	return timestamp.WallTime, nil
+}
+
+// ReadMaxHLCUpperBound returns the maximum of the stored hlc upper bounds
+// among all the engines. This value is optionally persisted by the server and
+// it is guaranteed to be higher than any wall time used by the HLC. If this
+// value is persisted, HLC wall clock monotonicity is guaranteed across server
+// restarts
+func ReadMaxHLCUpperBound(ctx context.Context, engines []engine.Engine) (int64, error) {
+	var hlcUpperBound int64
+	for _, e := range engines {
+		engineHLCUpperBound, err := ReadHLCUpperBound(ctx, e)
+		if err != nil {
+			return 0, err
+		}
+		if engineHLCUpperBound > hlcUpperBound {
+			hlcUpperBound = engineHLCUpperBound
+		}
+	}
+	return hlcUpperBound, nil
+}
+
 func checkEngineEmpty(ctx context.Context, eng engine.Engine) error {
 	kvs, err := engine.Scan(
 		eng,

--- a/pkg/util/hlc/hlc.go
+++ b/pkg/util/hlc/hlc.go
@@ -78,6 +78,13 @@ type Clock struct {
 		// isMonitoringForwardClockJumps is a flag to ensure that only one jump monitoring
 		// goroutine is running per clock
 		isMonitoringForwardClockJumps bool
+
+		// WallTimeUpperBound is an upper bound to the HLC which has been
+		// successfully persisted.
+		// The wall time used by the HLC will always be lesser than this timestamp.
+		// If the physical time is greater than this value, it will cause a panic
+		// If this is set to 0, this validation is skipped
+		wallTimeUpperBound int64
 	}
 }
 
@@ -251,7 +258,23 @@ func (c *Clock) Now() Timestamp {
 		c.mu.timestamp.WallTime = physicalClock
 		c.mu.timestamp.Logical = 0
 	}
+
+	c.enforceWallTimeWithinBoundLocked()
 	return c.mu.timestamp
+}
+
+// enforceWallTimeWithinBoundLocked panics if the clock's wall time is greater
+// than the upper bound. The caller of this function must be holding the lock.
+func (c *Clock) enforceWallTimeWithinBoundLocked() {
+	// WallTime should not cross the upper bound (if WallTimeUpperBound is set)
+	if c.mu.wallTimeUpperBound != 0 && c.mu.timestamp.WallTime > c.mu.wallTimeUpperBound {
+		log.Fatalf(
+			context.TODO(),
+			"wall time %d is not allowed to be greater than upper bound of %d.",
+			c.mu.timestamp.WallTime,
+			c.mu.wallTimeUpperBound,
+		)
+	}
 }
 
 // PhysicalNow returns the local wall time. It corresponds to the physicalClock
@@ -325,6 +348,8 @@ func (c *Clock) updateLocked(rt Timestamp, updateIfMaxOffsetExceeded bool) (Time
 		}
 		c.mu.timestamp.Logical++
 	}
+
+	c.enforceWallTimeWithinBoundLocked()
 	return c.mu.timestamp, err
 }
 
@@ -361,4 +386,39 @@ func (c *Clock) setMonitoringClockJump() bool {
 	isMonitoring := c.mu.isMonitoringForwardClockJumps
 	c.mu.isMonitoringForwardClockJumps = true
 	return isMonitoring
+}
+
+// RefreshHLCUpperBound persists the HLC upper bound and updates the in memory
+// value if the persist succeeds. delta is used to compute the upper bound.
+func (c *Clock) RefreshHLCUpperBound(persistFn func(int64) error, delta int64) error {
+	if delta < 0 {
+		return errors.Errorf("HLC upper bound delta %d should be positive", delta)
+	}
+	return c.persistHLCUpperBound(persistFn, c.Now().WallTime+delta)
+}
+
+// ResetHLCUpperBound persists a value of 0 as the HLC upper bound which
+// disables upper bound validation
+func (c *Clock) ResetHLCUpperBound(persistFn func(int64) error) error {
+	return c.persistHLCUpperBound(persistFn, 0 /* hlcUpperBound */)
+}
+
+// RefreshHLCUpperBound persists the HLC upper bound and updates the in memory
+// value if the persist succeeds
+func (c *Clock) persistHLCUpperBound(persistFn func(int64) error, hlcUpperBound int64) error {
+	if err := persistFn(hlcUpperBound); err != nil {
+		return err
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.mu.wallTimeUpperBound = hlcUpperBound
+	return nil
+}
+
+// WallTimeUpperBound returns the in memory value of upper bound to wall time
+func (c *Clock) WallTimeUpperBound() int64 {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.mu.wallTimeUpperBound
 }

--- a/pkg/util/timeutil/time.go
+++ b/pkg/util/timeutil/time.go
@@ -52,3 +52,21 @@ func ToUnixMicros(t time.Time) int64 {
 func Unix(sec, nsec int64) time.Time {
 	return time.Unix(sec, nsec).UTC()
 }
+
+// SleepUntil sleeps until the given time. The current time is
+// refreshed every second in case there was a clock jump
+//
+// untilNanos is the target time to sleep till in epoch nanoseconds
+// currentTimeNanos is a function returning current time in epoch nanoseconds
+func SleepUntil(untilNanos int64, currentTimeNanos func() int64) {
+	for {
+		d := time.Duration(untilNanos - currentTimeNanos())
+		if d <= 0 {
+			break
+		}
+		if d > time.Second {
+			d = time.Second
+		}
+		time.Sleep(d)
+	}
+}


### PR DESCRIPTION
A cluster setting is added to periodically persist an upper bound
to the hlc in RocksDB. The HLC is guaranteed to not use a wall time
greater than the persisted value. When cockroach restarts, it waits for
the wall time to reach the persisted value before starting up.
This guarantees monotonic wall time across restarts.

Cherrypicks #23744

Release note (general change): Added cluster settings for HLC to be
monotonic across restarts