### PR TITLE
sql: make ROLE a non-reserved keyword

### DIFF
--- a/docs/generated/sql/bnf/backup.bnf
+++ b/docs/generated/sql/bnf/backup.bnf
@@ -1,37 +1,13 @@
 backup_stmt ::=
-	'BACKUP' table_pattern ( ( ',' table_pattern ) )* 'TO' string_or_placeholder as_of_clause 'INCREMENTAL FROM' full_backup_location ( | ',' incremental_backup_location ( ',' incremental_backup_location )* ) 'WITH' kv_option_list
-	| 'BACKUP' table_pattern ( ( ',' table_pattern ) )* 'TO' string_or_placeholder as_of_clause 'INCREMENTAL FROM' full_backup_location ( | ',' incremental_backup_location ( ',' incremental_backup_location )* ) 
-	| 'BACKUP' table_pattern ( ( ',' table_pattern ) )* 'TO' string_or_placeholder as_of_clause 'INCREMENTAL FROM' full_backup_location ( | ',' incremental_backup_location ( ',' incremental_backup_location )* ) 
-	| 'BACKUP' table_pattern ( ( ',' table_pattern ) )* 'TO' string_or_placeholder as_of_clause  'WITH' kv_option_list
-	| 'BACKUP' table_pattern ( ( ',' table_pattern ) )* 'TO' string_or_placeholder as_of_clause  
-	| 'BACKUP' table_pattern ( ( ',' table_pattern ) )* 'TO' string_or_placeholder as_of_clause  
-	| 'BACKUP' table_pattern ( ( ',' table_pattern ) )* 'TO' string_or_placeholder  'INCREMENTAL FROM' full_backup_location ( | ',' incremental_backup_location ( ',' incremental_backup_location )* ) 'WITH' kv_option_list
-	| 'BACKUP' table_pattern ( ( ',' table_pattern ) )* 'TO' string_or_placeholder  'INCREMENTAL FROM' full_backup_location ( | ',' incremental_backup_location ( ',' incremental_backup_location )* ) 
-	| 'BACKUP' table_pattern ( ( ',' table_pattern ) )* 'TO' string_or_placeholder  'INCREMENTAL FROM' full_backup_location ( | ',' incremental_backup_location ( ',' incremental_backup_location )* ) 
-	| 'BACKUP' table_pattern ( ( ',' table_pattern ) )* 'TO' string_or_placeholder   'WITH' kv_option_list
-	| 'BACKUP' table_pattern ( ( ',' table_pattern ) )* 'TO' string_or_placeholder   
-	| 'BACKUP' table_pattern ( ( ',' table_pattern ) )* 'TO' string_or_placeholder   
-	| 'BACKUP' 'TABLE' table_pattern ( ( ',' table_pattern ) )* 'TO' string_or_placeholder as_of_clause 'INCREMENTAL FROM' full_backup_location ( | ',' incremental_backup_location ( ',' incremental_backup_location )* ) 'WITH' kv_option_list
-	| 'BACKUP' 'TABLE' table_pattern ( ( ',' table_pattern ) )* 'TO' string_or_placeholder as_of_clause 'INCREMENTAL FROM' full_backup_location ( | ',' incremental_backup_location ( ',' incremental_backup_location )* ) 
-	| 'BACKUP' 'TABLE' table_pattern ( ( ',' table_pattern ) )* 'TO' string_or_placeholder as_of_clause 'INCREMENTAL FROM' full_backup_location ( | ',' incremental_backup_location ( ',' incremental_backup_location )* ) 
-	| 'BACKUP' 'TABLE' table_pattern ( ( ',' table_pattern ) )* 'TO' string_or_placeholder as_of_clause  'WITH' kv_option_list
-	| 'BACKUP' 'TABLE' table_pattern ( ( ',' table_pattern ) )* 'TO' string_or_placeholder as_of_clause  
-	| 'BACKUP' 'TABLE' table_pattern ( ( ',' table_pattern ) )* 'TO' string_or_placeholder as_of_clause  
-	| 'BACKUP' 'TABLE' table_pattern ( ( ',' table_pattern ) )* 'TO' string_or_placeholder  'INCREMENTAL FROM' full_backup_location ( | ',' incremental_backup_location ( ',' incremental_backup_location )* ) 'WITH' kv_option_list
-	| 'BACKUP' 'TABLE' table_pattern ( ( ',' table_pattern ) )* 'TO' string_or_placeholder  'INCREMENTAL FROM' full_backup_location ( | ',' incremental_backup_location ( ',' incremental_backup_location )* ) 
-	| 'BACKUP' 'TABLE' table_pattern ( ( ',' table_pattern ) )* 'TO' string_or_placeholder  'INCREMENTAL FROM' full_backup_location ( | ',' incremental_backup_location ( ',' incremental_backup_location )* ) 
-	| 'BACKUP' 'TABLE' table_pattern ( ( ',' table_pattern ) )* 'TO' string_or_placeholder   'WITH' kv_option_list
-	| 'BACKUP' 'TABLE' table_pattern ( ( ',' table_pattern ) )* 'TO' string_or_placeholder   
-	| 'BACKUP' 'TABLE' table_pattern ( ( ',' table_pattern ) )* 'TO' string_or_placeholder   
-	| 'BACKUP' 'DATABASE' name ( ( ',' name ) )* 'TO' string_or_placeholder as_of_clause 'INCREMENTAL FROM' full_backup_location ( | ',' incremental_backup_location ( ',' incremental_backup_location )* ) 'WITH' kv_option_list
-	| 'BACKUP' 'DATABASE' name ( ( ',' name ) )* 'TO' string_or_placeholder as_of_clause 'INCREMENTAL FROM' full_backup_location ( | ',' incremental_backup_location ( ',' incremental_backup_location )* ) 
-	| 'BACKUP' 'DATABASE' name ( ( ',' name ) )* 'TO' string_or_placeholder as_of_clause 'INCREMENTAL FROM' full_backup_location ( | ',' incremental_backup_location ( ',' incremental_backup_location )* ) 
-	| 'BACKUP' 'DATABASE' name ( ( ',' name ) )* 'TO' string_or_placeholder as_of_clause  'WITH' kv_option_list
-	| 'BACKUP' 'DATABASE' name ( ( ',' name ) )* 'TO' string_or_placeholder as_of_clause  
-	| 'BACKUP' 'DATABASE' name ( ( ',' name ) )* 'TO' string_or_placeholder as_of_clause  
-	| 'BACKUP' 'DATABASE' name ( ( ',' name ) )* 'TO' string_or_placeholder  'INCREMENTAL FROM' full_backup_location ( | ',' incremental_backup_location ( ',' incremental_backup_location )* ) 'WITH' kv_option_list
-	| 'BACKUP' 'DATABASE' name ( ( ',' name ) )* 'TO' string_or_placeholder  'INCREMENTAL FROM' full_backup_location ( | ',' incremental_backup_location ( ',' incremental_backup_location )* ) 
-	| 'BACKUP' 'DATABASE' name ( ( ',' name ) )* 'TO' string_or_placeholder  'INCREMENTAL FROM' full_backup_location ( | ',' incremental_backup_location ( ',' incremental_backup_location )* ) 
-	| 'BACKUP' 'DATABASE' name ( ( ',' name ) )* 'TO' string_or_placeholder   'WITH' kv_option_list
-	| 'BACKUP' 'DATABASE' name ( ( ',' name ) )* 'TO' string_or_placeholder   
-	| 'BACKUP' 'DATABASE' name ( ( ',' name ) )* 'TO' string_or_placeholder   
+	'BACKUP' ( ( 'TABLE' | ) table_pattern ( ( ',' table_pattern ) )* | 'DATABASE' database_name ( ( ',' database_name ) )* ) 'TO' string_or_placeholder as_of_clause 'INCREMENTAL FROM' full_backup_location ( | ',' incremental_backup_location ( ',' incremental_backup_location )* ) 'WITH' kv_option_list
+	| 'BACKUP' ( ( 'TABLE' | ) table_pattern ( ( ',' table_pattern ) )* | 'DATABASE' database_name ( ( ',' database_name ) )* ) 'TO' string_or_placeholder as_of_clause 'INCREMENTAL FROM' full_backup_location ( | ',' incremental_backup_location ( ',' incremental_backup_location )* ) 
+	| 'BACKUP' ( ( 'TABLE' | ) table_pattern ( ( ',' table_pattern ) )* | 'DATABASE' database_name ( ( ',' database_name ) )* ) 'TO' string_or_placeholder as_of_clause 'INCREMENTAL FROM' full_backup_location ( | ',' incremental_backup_location ( ',' incremental_backup_location )* ) 
+	| 'BACKUP' ( ( 'TABLE' | ) table_pattern ( ( ',' table_pattern ) )* | 'DATABASE' database_name ( ( ',' database_name ) )* ) 'TO' string_or_placeholder as_of_clause  'WITH' kv_option_list
+	| 'BACKUP' ( ( 'TABLE' | ) table_pattern ( ( ',' table_pattern ) )* | 'DATABASE' database_name ( ( ',' database_name ) )* ) 'TO' string_or_placeholder as_of_clause  
+	| 'BACKUP' ( ( 'TABLE' | ) table_pattern ( ( ',' table_pattern ) )* | 'DATABASE' database_name ( ( ',' database_name ) )* ) 'TO' string_or_placeholder as_of_clause  
+	| 'BACKUP' ( ( 'TABLE' | ) table_pattern ( ( ',' table_pattern ) )* | 'DATABASE' database_name ( ( ',' database_name ) )* ) 'TO' string_or_placeholder  'INCREMENTAL FROM' full_backup_location ( | ',' incremental_backup_location ( ',' incremental_backup_location )* ) 'WITH' kv_option_list
+	| 'BACKUP' ( ( 'TABLE' | ) table_pattern ( ( ',' table_pattern ) )* | 'DATABASE' database_name ( ( ',' database_name ) )* ) 'TO' string_or_placeholder  'INCREMENTAL FROM' full_backup_location ( | ',' incremental_backup_location ( ',' incremental_backup_location )* ) 
+	| 'BACKUP' ( ( 'TABLE' | ) table_pattern ( ( ',' table_pattern ) )* | 'DATABASE' database_name ( ( ',' database_name ) )* ) 'TO' string_or_placeholder  'INCREMENTAL FROM' full_backup_location ( | ',' incremental_backup_location ( ',' incremental_backup_location )* ) 
+	| 'BACKUP' ( ( 'TABLE' | ) table_pattern ( ( ',' table_pattern ) )* | 'DATABASE' database_name ( ( ',' database_name ) )* ) 'TO' string_or_placeholder   'WITH' kv_option_list
+	| 'BACKUP' ( ( 'TABLE' | ) table_pattern ( ( ',' table_pattern ) )* | 'DATABASE' database_name ( ( ',' database_name ) )* ) 'TO' string_or_placeholder   
+	| 'BACKUP' ( ( 'TABLE' | ) table_pattern ( ( ',' table_pattern ) )* | 'DATABASE' database_name ( ( ',' database_name ) )* ) 'TO' string_or_placeholder   

--- a/docs/generated/sql/bnf/grant_privileges.bnf
+++ b/docs/generated/sql/bnf/grant_privileges.bnf
@@ -1,4 +1,4 @@
 grant_stmt ::=
-	'GRANT' ( 'ALL' | ( ( ( 'CREATE' | 'GRANT' | 'SELECT' | 'DROP' | 'INSERT' | 'DELETE' | 'UPDATE' ) ) ( ( ',' ( 'CREATE' | 'GRANT' | 'SELECT' | 'DROP' | 'INSERT' | 'DELETE' | 'UPDATE' ) ) )* ) ) 'ON' ( ( ( table_name ) ( ( ',' table_name ) )* ) | 'TABLE' ( ( table_name ) ( ( ',' table_name ) )* ) | 'DATABASE' ( ( database_name ) ( ( ',' database_name ) )* ) ) 'TO' ( ( user_name ) ( ( ',' user_name ) )* )
+	'GRANT' ( 'ALL' | ( ( ( 'CREATE' | 'GRANT' | 'SELECT' | 'DROP' | 'INSERT' | 'DELETE' | 'UPDATE' ) ) ( ( ',' ( 'CREATE' | 'GRANT' | 'SELECT' | 'DROP' | 'INSERT' | 'DELETE' | 'UPDATE' ) ) )* ) ) 'ON' ( ( 'TABLE' | ) table_pattern ( ( ',' table_pattern ) )* | 'DATABASE' database_name ( ( ',' database_name ) )* ) 'TO' ( ( user_name ) ( ( ',' user_name ) )* )
 	
 	 

--- a/docs/generated/sql/bnf/restore.bnf
+++ b/docs/generated/sql/bnf/restore.bnf
@@ -1,13 +1,7 @@
 restore_stmt ::=
-	'RESTORE' table_pattern ( ( ',' table_pattern ) )* 'FROM' full_backup_location ( | incremental_backup_location ( ',' incremental_backup_location )*) 'WITH' kv_option_list
-	| 'RESTORE' table_pattern ( ( ',' table_pattern ) )* 'FROM' full_backup_location ( | incremental_backup_location ( ',' incremental_backup_location )*) 'WITH OPTIONS' '(' kv_option_list ')'
-	| 'RESTORE' table_pattern ( ( ',' table_pattern ) )* 'FROM' full_backup_location ( | incremental_backup_location ( ',' incremental_backup_location )*) 
-	| 'RESTORE' 'TABLE' table_pattern ( ( ',' table_pattern ) )* 'FROM' full_backup_location ( | incremental_backup_location ( ',' incremental_backup_location )*) 'WITH' kv_option_list
-	| 'RESTORE' 'TABLE' table_pattern ( ( ',' table_pattern ) )* 'FROM' full_backup_location ( | incremental_backup_location ( ',' incremental_backup_location )*) 'WITH OPTIONS' '(' kv_option_list ')'
-	| 'RESTORE' 'TABLE' table_pattern ( ( ',' table_pattern ) )* 'FROM' full_backup_location ( | incremental_backup_location ( ',' incremental_backup_location )*) 
-	| 'RESTORE' table_pattern ( ( ',' table_pattern ) )* 'FROM' full_backup_location ( | incremental_backup_location ( ',' incremental_backup_location )*) as_of_clause 'WITH' kv_option_list
-	| 'RESTORE' table_pattern ( ( ',' table_pattern ) )* 'FROM' full_backup_location ( | incremental_backup_location ( ',' incremental_backup_location )*) as_of_clause 'WITH OPTIONS' '(' kv_option_list ')'
-	| 'RESTORE' table_pattern ( ( ',' table_pattern ) )* 'FROM' full_backup_location ( | incremental_backup_location ( ',' incremental_backup_location )*) as_of_clause 
-	| 'RESTORE' 'TABLE' table_pattern ( ( ',' table_pattern ) )* 'FROM' full_backup_location ( | incremental_backup_location ( ',' incremental_backup_location )*) as_of_clause 'WITH' kv_option_list
-	| 'RESTORE' 'TABLE' table_pattern ( ( ',' table_pattern ) )* 'FROM' full_backup_location ( | incremental_backup_location ( ',' incremental_backup_location )*) as_of_clause 'WITH OPTIONS' '(' kv_option_list ')'
-	| 'RESTORE' 'TABLE' table_pattern ( ( ',' table_pattern ) )* 'FROM' full_backup_location ( | incremental_backup_location ( ',' incremental_backup_location )*) as_of_clause 
+	'RESTORE' ( ( 'TABLE' | ) table_pattern ( ( ',' table_pattern ) )* | 'DATABASE' database_name ( ( ',' database_name ) )* ) 'FROM' full_backup_location ( | incremental_backup_location ( ',' incremental_backup_location )*) 'WITH' kv_option_list
+	| 'RESTORE' ( ( 'TABLE' | ) table_pattern ( ( ',' table_pattern ) )* | 'DATABASE' database_name ( ( ',' database_name ) )* ) 'FROM' full_backup_location ( | incremental_backup_location ( ',' incremental_backup_location )*) 'WITH OPTIONS' '(' kv_option_list ')'
+	| 'RESTORE' ( ( 'TABLE' | ) table_pattern ( ( ',' table_pattern ) )* | 'DATABASE' database_name ( ( ',' database_name ) )* ) 'FROM' full_backup_location ( | incremental_backup_location ( ',' incremental_backup_location )*) 
+	| 'RESTORE' ( ( 'TABLE' | ) table_pattern ( ( ',' table_pattern ) )* | 'DATABASE' database_name ( ( ',' database_name ) )* ) 'FROM' full_backup_location ( | incremental_backup_location ( ',' incremental_backup_location )*) as_of_clause 'WITH' kv_option_list
+	| 'RESTORE' ( ( 'TABLE' | ) table_pattern ( ( ',' table_pattern ) )* | 'DATABASE' database_name ( ( ',' database_name ) )* ) 'FROM' full_backup_location ( | incremental_backup_location ( ',' incremental_backup_location )*) as_of_clause 'WITH OPTIONS' '(' kv_option_list ')'
+	| 'RESTORE' ( ( 'TABLE' | ) table_pattern ( ( ',' table_pattern ) )* | 'DATABASE' database_name ( ( ',' database_name ) )* ) 'FROM' full_backup_location ( | incremental_backup_location ( ',' incremental_backup_location )*) as_of_clause 

--- a/docs/generated/sql/bnf/revoke_privileges.bnf
+++ b/docs/generated/sql/bnf/revoke_privileges.bnf
@@ -1,4 +1,4 @@
 revoke_stmt ::=
-	'REVOKE' ( 'ALL' | ( ( ( 'CREATE' | 'GRANT' | 'SELECT' | 'DROP' | 'INSERT' | 'DELETE' | 'UPDATE' ) ) ( ( ',' ( 'CREATE' | 'GRANT' | 'SELECT' | 'DROP' | 'INSERT' | 'DELETE' | 'UPDATE' ) ) )* ) ) 'ON' ( ( ( table_name ) ( ( ',' table_name ) )* ) | 'TABLE' ( ( table_name ) ( ( ',' table_name ) )* ) | 'DATABASE' ( ( database_name ) ( ( ',' database_name ) )* ) ) 'FROM' ( ( user_name ) ( ( ',' user_name ) )* )
+	'REVOKE' ( 'ALL' | ( ( ( 'CREATE' | 'GRANT' | 'SELECT' | 'DROP' | 'INSERT' | 'DELETE' | 'UPDATE' ) ) ( ( ',' ( 'CREATE' | 'GRANT' | 'SELECT' | 'DROP' | 'INSERT' | 'DELETE' | 'UPDATE' ) ) )* ) ) 'ON' ( ( 'TABLE' | ) table_pattern ( ( ',' table_pattern ) )* | 'DATABASE' database_name ( ( ',' database_name ) )* ) 'FROM' ( ( user_name ) ( ( ',' user_name ) )* )
 	
 	

--- a/docs/generated/sql/bnf/show_grants_stmt.bnf
+++ b/docs/generated/sql/bnf/show_grants_stmt.bnf
@@ -1,13 +1,5 @@
 show_grants_stmt ::=
-	'SHOW' 'GRANTS' 'ON' 'ROLE' role_name ( ( ',' role_name ) )* 'FOR' user_name ( ( ',' user_name ) )*
-	| 'SHOW' 'GRANTS' 'ON' 'ROLE' role_name ( ( ',' role_name ) )* 
-	| 'SHOW' 'GRANTS' 'ON' 'ROLE'  'FOR' user_name ( ( ',' user_name ) )*
-	| 'SHOW' 'GRANTS' 'ON' 'ROLE'  
-	| 'SHOW' 'GRANTS' 'ON' table_name ( ( ',' table_name ) )* 'FOR' user_name ( ( ',' user_name ) )*
-	| 'SHOW' 'GRANTS' 'ON' table_name ( ( ',' table_name ) )* 
-	| 'SHOW' 'GRANTS' 'ON' 'TABLE' table_name ( ( ',' table_name ) )* 'FOR' user_name ( ( ',' user_name ) )*
-	| 'SHOW' 'GRANTS' 'ON' 'TABLE' table_name ( ( ',' table_name ) )* 
-	| 'SHOW' 'GRANTS' 'ON' 'DATABASE' database_name ( ( ',' database_name ) )* 'FOR' user_name ( ( ',' user_name ) )*
-	| 'SHOW' 'GRANTS' 'ON' 'DATABASE' database_name ( ( ',' database_name ) )* 
+	'SHOW' 'GRANTS' 'ON' ( 'ROLE' | 'ROLE' name ( ',' name ) )* | ( 'TABLE' | ) table_pattern ( ( ',' table_pattern ) )* | 'DATABASE' database_name ( ( ',' database_name ) )* ) 'FOR' user_name ( ( ',' user_name ) )*
+	| 'SHOW' 'GRANTS' 'ON' ( 'ROLE' | 'ROLE' name ( ',' name ) )* | ( 'TABLE' | ) table_pattern ( ( ',' table_pattern ) )* | 'DATABASE' database_name ( ( ',' database_name ) )* ) 
 	| 'SHOW' 'GRANTS'  'FOR' user_name ( ( ',' user_name ) )*
 	| 'SHOW' 'GRANTS'  

--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -187,7 +187,11 @@ alter_user_stmt ::=
 	alter_user_password_stmt
 
 targets ::=
-	table_pattern_list
+	'identifier'
+	| col_name_keyword
+	| unreserved_keyword
+	| complex_table_pattern
+	| table_pattern ',' table_pattern_list
 	| 'TABLE' table_pattern_list
 	| 'DATABASE' name_list
 
@@ -446,8 +450,7 @@ show_databases_stmt ::=
 	'SHOW' 'DATABASES'
 
 show_grants_stmt ::=
-	'SHOW' 'GRANTS' 'ON' 'ROLE' opt_name_list for_grantee_clause
-	| 'SHOW' 'GRANTS' on_privilege_target_clause for_grantee_clause
+	'SHOW' 'GRANTS' opt_on_targets_roles for_grantee_clause
 
 show_histogram_stmt ::=
 	'SHOW' 'HISTOGRAM' 'ICONST'
@@ -554,52 +557,48 @@ alter_user_password_stmt ::=
 	'ALTER' 'USER' string_or_placeholder 'WITH' 'PASSWORD' string_or_placeholder
 	| 'ALTER' 'USER' 'IF' 'EXISTS' string_or_placeholder 'WITH' 'PASSWORD' string_or_placeholder
 
-table_pattern_list ::=
-	( table_pattern ) ( ( ',' table_pattern ) )*
-
-non_reserved_word_or_sconst ::=
-	non_reserved_word
-	| 'SCONST'
-
-kv_option_list ::=
-	( kv_option ) ( ( ',' kv_option ) )*
-
-db_object_name ::=
-	name
-	| name '.' unrestricted_name
-	| name '.' unrestricted_name '.' unrestricted_name
-
-opt_password ::=
-	opt_with 'PASSWORD' string_or_placeholder
-	| 
-
-create_database_stmt ::=
-	'CREATE' 'DATABASE' database_name opt_with opt_template_clause opt_encoding_clause opt_lc_collate_clause opt_lc_ctype_clause
-	| 'CREATE' 'DATABASE' 'IF' 'NOT' 'EXISTS' database_name opt_with opt_template_clause opt_encoding_clause opt_lc_collate_clause opt_lc_ctype_clause
-
-create_index_stmt ::=
-	'CREATE' opt_unique 'INDEX' opt_index_name 'ON' table_name opt_using_gin '(' index_params ')' opt_storing opt_interleave opt_partition_by
-	| 'CREATE' opt_unique 'INDEX' 'IF' 'NOT' 'EXISTS' index_name 'ON' table_name opt_using_gin '(' index_params ')' opt_storing opt_interleave opt_partition_by
-	| 'CREATE' 'INVERTED' 'INDEX' opt_index_name 'ON' table_name '(' index_params ')'
-	| 'CREATE' 'INVERTED' 'INDEX' 'IF' 'NOT' 'EXISTS' index_name 'ON' table_name '(' index_params ')'
-
-create_table_stmt ::=
-	'CREATE' 'TABLE' table_name '(' opt_table_elem_list ')' opt_interleave opt_partition_by
-	| 'CREATE' 'TABLE' 'IF' 'NOT' 'EXISTS' table_name '(' opt_table_elem_list ')' opt_interleave opt_partition_by
-
-create_table_as_stmt ::=
-	'CREATE' 'TABLE' table_name opt_column_list 'AS' select_stmt
-	| 'CREATE' 'TABLE' 'IF' 'NOT' 'EXISTS' table_name opt_column_list 'AS' select_stmt
-
-create_view_stmt ::=
-	'CREATE' 'VIEW' view_name opt_column_list 'AS' select_stmt
-
-create_sequence_stmt ::=
-	'CREATE' 'SEQUENCE' sequence_name opt_sequence_option_list
-	| 'CREATE' 'SEQUENCE' 'IF' 'NOT' 'EXISTS' sequence_name opt_sequence_option_list
-
-statistics_name ::=
-	name
+col_name_keyword ::=
+	'ANNOTATE_TYPE'
+	| 'BETWEEN'
+	| 'BIGINT'
+	| 'BIT'
+	| 'BOOLEAN'
+	| 'CHAR'
+	| 'CHARACTER'
+	| 'CHARACTERISTICS'
+	| 'COALESCE'
+	| 'DEC'
+	| 'DECIMAL'
+	| 'EXISTS'
+	| 'EXTRACT'
+	| 'EXTRACT_DURATION'
+	| 'FLOAT'
+	| 'GREATEST'
+	| 'GROUPING'
+	| 'IF'
+	| 'IFNULL'
+	| 'INT'
+	| 'INTEGER'
+	| 'INTERVAL'
+	| 'LEAST'
+	| 'NULLIF'
+	| 'NUMERIC'
+	| 'OUT'
+	| 'OVERLAY'
+	| 'POSITION'
+	| 'PRECISION'
+	| 'REAL'
+	| 'ROW'
+	| 'SMALLINT'
+	| 'SUBSTRING'
+	| 'TIME'
+	| 'TIMESTAMP'
+	| 'TREAT'
+	| 'TRIM'
+	| 'VALUES'
+	| 'VARCHAR'
+	| 'VIRTUAL'
+	| 'WORK'
 
 unreserved_keyword ::=
 	'ABORT'
@@ -744,6 +743,7 @@ unreserved_keyword ::=
 	| 'RESTRICT'
 	| 'RESUME'
 	| 'REVOKE'
+	| 'ROLE'
 	| 'ROLES'
 	| 'ROLLBACK'
 	| 'ROLLUP'
@@ -814,48 +814,61 @@ unreserved_keyword ::=
 	| 'YEAR'
 	| 'ZONE'
 
-col_name_keyword ::=
-	'ANNOTATE_TYPE'
-	| 'BETWEEN'
-	| 'BIGINT'
-	| 'BIT'
-	| 'BOOLEAN'
-	| 'CHAR'
-	| 'CHARACTER'
-	| 'CHARACTERISTICS'
-	| 'COALESCE'
-	| 'DEC'
-	| 'DECIMAL'
-	| 'EXISTS'
-	| 'EXTRACT'
-	| 'EXTRACT_DURATION'
-	| 'FLOAT'
-	| 'GREATEST'
-	| 'GROUPING'
-	| 'IF'
-	| 'IFNULL'
-	| 'INT'
-	| 'INTEGER'
-	| 'INTERVAL'
-	| 'LEAST'
-	| 'NULLIF'
-	| 'NUMERIC'
-	| 'OUT'
-	| 'OVERLAY'
-	| 'POSITION'
-	| 'PRECISION'
-	| 'REAL'
-	| 'ROW'
-	| 'SMALLINT'
-	| 'SUBSTRING'
-	| 'TIME'
-	| 'TIMESTAMP'
-	| 'TREAT'
-	| 'TRIM'
-	| 'VALUES'
-	| 'VARCHAR'
-	| 'VIRTUAL'
-	| 'WORK'
+complex_table_pattern ::=
+	complex_db_object_name
+	| name '.' unrestricted_name '.' '*'
+	| name '.' '*'
+	| '*'
+
+table_pattern ::=
+	simple_db_object_name
+	| complex_table_pattern
+
+table_pattern_list ::=
+	( table_pattern ) ( ( ',' table_pattern ) )*
+
+non_reserved_word_or_sconst ::=
+	non_reserved_word
+	| 'SCONST'
+
+kv_option_list ::=
+	( kv_option ) ( ( ',' kv_option ) )*
+
+db_object_name ::=
+	simple_db_object_name
+	| complex_db_object_name
+
+opt_password ::=
+	opt_with 'PASSWORD' string_or_placeholder
+	| 
+
+create_database_stmt ::=
+	'CREATE' 'DATABASE' database_name opt_with opt_template_clause opt_encoding_clause opt_lc_collate_clause opt_lc_ctype_clause
+	| 'CREATE' 'DATABASE' 'IF' 'NOT' 'EXISTS' database_name opt_with opt_template_clause opt_encoding_clause opt_lc_collate_clause opt_lc_ctype_clause
+
+create_index_stmt ::=
+	'CREATE' opt_unique 'INDEX' opt_index_name 'ON' table_name opt_using_gin '(' index_params ')' opt_storing opt_interleave opt_partition_by
+	| 'CREATE' opt_unique 'INDEX' 'IF' 'NOT' 'EXISTS' index_name 'ON' table_name opt_using_gin '(' index_params ')' opt_storing opt_interleave opt_partition_by
+	| 'CREATE' 'INVERTED' 'INDEX' opt_index_name 'ON' table_name '(' index_params ')'
+	| 'CREATE' 'INVERTED' 'INDEX' 'IF' 'NOT' 'EXISTS' index_name 'ON' table_name '(' index_params ')'
+
+create_table_stmt ::=
+	'CREATE' 'TABLE' table_name '(' opt_table_elem_list ')' opt_interleave opt_partition_by
+	| 'CREATE' 'TABLE' 'IF' 'NOT' 'EXISTS' table_name '(' opt_table_elem_list ')' opt_interleave opt_partition_by
+
+create_table_as_stmt ::=
+	'CREATE' 'TABLE' table_name opt_column_list 'AS' select_stmt
+	| 'CREATE' 'TABLE' 'IF' 'NOT' 'EXISTS' table_name opt_column_list 'AS' select_stmt
+
+create_view_stmt ::=
+	'CREATE' 'VIEW' view_name opt_column_list 'AS' select_stmt
+
+create_sequence_stmt ::=
+	'CREATE' 'SEQUENCE' sequence_name opt_sequence_option_list
+	| 'CREATE' 'SEQUENCE' 'IF' 'NOT' 'EXISTS' sequence_name opt_sequence_option_list
+
+statistics_name ::=
+	name
 
 with_clause ::=
 	'WITH' cte_list
@@ -1026,16 +1039,12 @@ view_name ::=
 sequence_name ::=
 	db_object_name
 
-opt_name_list ::=
-	name_list
+opt_on_targets_roles ::=
+	'ON' targets_roles
 	| 
 
 for_grantee_clause ::=
 	'FOR' name_list
-	| 
-
-on_privilege_target_clause ::=
-	'ON' targets
 	| 
 
 opt_compact ::=
@@ -1112,11 +1121,19 @@ alter_sequence_options_stmt ::=
 alter_rename_database_stmt ::=
 	'ALTER' 'DATABASE' database_name 'RENAME' 'TO' database_name
 
-table_pattern ::=
-	db_object_name
-	| name '.' unrestricted_name '.' '*'
-	| name '.' '*'
-	| '*'
+complex_db_object_name ::=
+	name '.' unrestricted_name
+	| name '.' unrestricted_name '.' unrestricted_name
+
+unrestricted_name ::=
+	'identifier'
+	| unreserved_keyword
+	| col_name_keyword
+	| type_func_name_keyword
+	| reserved_keyword
+
+simple_db_object_name ::=
+	name
 
 non_reserved_word ::=
 	'identifier'
@@ -1129,13 +1146,6 @@ kv_option ::=
 	| name
 	| 'SCONST' '=' string_or_placeholder
 	| 'SCONST'
-
-unrestricted_name ::=
-	'identifier'
-	| unreserved_keyword
-	| col_name_keyword
-	| type_func_name_keyword
-	| reserved_keyword
 
 opt_with ::=
 	'WITH'
@@ -1367,6 +1377,10 @@ opt_comma ::=
 	','
 	| 
 
+targets_roles ::=
+	'ROLE' name_list
+	| targets
+
 single_set_clause ::=
 	column_name '=' a_expr
 
@@ -1477,7 +1491,6 @@ reserved_keyword ::=
 	| 'PRIMARY'
 	| 'REFERENCES'
 	| 'RETURNING'
-	| 'ROLE'
 	| 'SELECT'
 	| 'SESSION_USER'
 	| 'SOME'

--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -470,11 +470,11 @@ func TestBackupRestoreSystemJobs(t *testing.T) {
 	sqlDB.Exec(t, `BACKUP DATABASE data TO $1`, fullDir)
 	sqlDB.Exec(t, `SET DATABASE = data`)
 
-	sqlDB.Exec(t, `BACKUP bank TO $1 INCREMENTAL FROM $2`, incDir, fullDir)
+	sqlDB.Exec(t, `BACKUP TABLE bank TO $1 INCREMENTAL FROM $2`, incDir, fullDir)
 	if err := jobutils.VerifySystemJob(t, sqlDB, baseNumJobs+1, jobs.TypeBackup, jobs.Record{
 		Username: security.RootUser,
 		Description: fmt.Sprintf(
-			`BACKUP bank TO '%s' INCREMENTAL FROM '%s'`,
+			`BACKUP TABLE bank TO '%s' INCREMENTAL FROM '%s'`,
 			sanitizedIncDir, sanitizedFullDir,
 		),
 		DescriptorIDs: sqlbase.IDs{
@@ -485,11 +485,11 @@ func TestBackupRestoreSystemJobs(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	sqlDB.Exec(t, `RESTORE bank FROM $1, $2 WITH OPTIONS ('into_db'='restoredb')`, fullDir, incDir)
+	sqlDB.Exec(t, `RESTORE TABLE bank FROM $1, $2 WITH OPTIONS ('into_db'='restoredb')`, fullDir, incDir)
 	if err := jobutils.VerifySystemJob(t, sqlDB, baseNumJobs+2, jobs.TypeRestore, jobs.Record{
 		Username: security.RootUser,
 		Description: fmt.Sprintf(
-			`RESTORE bank FROM '%s', '%s' WITH into_db = 'restoredb'`,
+			`RESTORE TABLE bank FROM '%s', '%s' WITH into_db = 'restoredb'`,
 			sanitizedFullDir, sanitizedIncDir,
 		),
 		DescriptorIDs: sqlbase.IDs{
@@ -907,8 +907,8 @@ func TestBackupRestoreControlJob(t *testing.T) {
 		}
 
 		for i, query := range []string{
-			`BACKUP orig_fkdb.fk TO $1`,
-			`RESTORE orig_fkdb.fk FROM $1 WITH OPTIONS ('skip_missing_foreign_keys', 'into_db'='restore_fkdb')`,
+			`BACKUP TABLE orig_fkdb.fk TO $1`,
+			`RESTORE TABLE orig_fkdb.fk FROM $1 WITH OPTIONS ('skip_missing_foreign_keys', 'into_db'='restore_fkdb')`,
 		} {
 			jobID, err := jobutils.RunJob(t, sqlDB, &allowResponse, []string{"PAUSE"}, query, foreignDir)
 			if !testutils.IsError(err, "job paused") {
@@ -932,7 +932,7 @@ func TestBackupRestoreControlJob(t *testing.T) {
 
 		for i, query := range []string{
 			`BACKUP DATABASE data TO $1`,
-			`RESTORE data.* FROM $1 WITH OPTIONS ('into_db'='pause')`,
+			`RESTORE TABLE data.* FROM $1 WITH OPTIONS ('into_db'='pause')`,
 		} {
 			ops := []string{"PAUSE", "RESUME", "PAUSE"}
 			jobID, err := jobutils.RunJob(t, sqlDB, &allowResponse, ops, query, pauseDir)
@@ -961,7 +961,7 @@ func TestBackupRestoreControlJob(t *testing.T) {
 
 		for i, query := range []string{
 			`BACKUP DATABASE data TO $1`,
-			`RESTORE data.* FROM $1 WITH OPTIONS ('into_db'='cancel')`,
+			`RESTORE TABLE data.* FROM $1 WITH OPTIONS ('into_db'='cancel')`,
 		} {
 			if _, err := jobutils.RunJob(
 				t, sqlDB, &allowResponse, []string{"cancel"}, query, cancelDir,

--- a/pkg/ccl/backupccl/restore.go
+++ b/pkg/ccl/backupccl/restore.go
@@ -141,7 +141,7 @@ func selectTargets(
 		}
 	}
 	if !seenTable {
-		return nil, nil, errors.Errorf("no tables found: %s", &targets)
+		return nil, nil, errors.Errorf("no tables found: %s", tree.ErrString(&targets))
 	}
 
 	if lastBackupDesc.FormatVersion >= BackupFormatDescriptorTrackingVersion {

--- a/pkg/sql/parser/parse_test.go
+++ b/pkg/sql/parser/parse_test.go
@@ -383,8 +383,8 @@ func TestParse(t *testing.T) {
 		// Tables are the default, but can also be specified with
 		// GRANT x ON TABLE y. However, the stringer does not output TABLE.
 		{`SHOW GRANTS`},
-		{`SHOW GRANTS ON foo`},
-		{`SHOW GRANTS ON foo, db.foo`},
+		{`SHOW GRANTS ON TABLE foo`},
+		{`SHOW GRANTS ON TABLE foo, db.foo`},
 		{`SHOW GRANTS ON DATABASE foo, bar`},
 		{`SHOW GRANTS ON DATABASE foo FOR bar`},
 		{`SHOW GRANTS FOR bar, baz`},
@@ -441,8 +441,8 @@ func TestParse(t *testing.T) {
 
 		// Tables are the default, but can also be specified with
 		// GRANT x ON TABLE y. However, the stringer does not output TABLE.
-		{`GRANT SELECT ON foo TO root`},
-		{`GRANT SELECT, DELETE, UPDATE ON foo, db.foo TO root, bar`},
+		{`GRANT SELECT ON TABLE foo TO root`},
+		{`GRANT SELECT, DELETE, UPDATE ON TABLE foo, db.foo TO root, bar`},
 		{`GRANT DROP ON DATABASE foo TO root`},
 		{`GRANT ALL ON DATABASE foo TO root, test`},
 		{`GRANT SELECT, INSERT ON DATABASE bar TO foo, bar, baz`},
@@ -453,8 +453,8 @@ func TestParse(t *testing.T) {
 
 		// Tables are the default, but can also be specified with
 		// REVOKE x ON TABLE y. However, the stringer does not output TABLE.
-		{`REVOKE SELECT ON foo FROM root`},
-		{`REVOKE UPDATE, DELETE ON foo, db.foo FROM root, bar`},
+		{`REVOKE SELECT ON TABLE foo FROM root`},
+		{`REVOKE UPDATE, DELETE ON TABLE foo, db.foo FROM root, bar`},
 		{`REVOKE INSERT ON DATABASE foo FROM root`},
 		{`REVOKE ALL ON DATABASE foo FROM root, test`},
 		{`REVOKE SELECT, INSERT ON DATABASE bar FROM foo, bar, baz`},
@@ -927,33 +927,33 @@ func TestParse(t *testing.T) {
 		{`EXPERIMENTAL SCRUB TABLE x WITH OPTIONS PHYSICAL, INDEX (index_name), CONSTRAINT (cst_name)`},
 		{`EXPERIMENTAL SCRUB TABLE x WITH OPTIONS PHYSICAL, INDEX ALL, CONSTRAINT ALL`},
 
-		{`BACKUP foo TO 'bar'`},
-		{`BACKUP foo.foo, baz.baz TO 'bar'`},
+		{`BACKUP TABLE foo TO 'bar'`},
+		{`BACKUP TABLE foo.foo, baz.baz TO 'bar'`},
 		{`SHOW BACKUP 'bar'`},
-		{`BACKUP foo TO 'bar' AS OF SYSTEM TIME '1' INCREMENTAL FROM 'baz'`},
-		{`BACKUP foo TO $1 INCREMENTAL FROM 'bar', $2, 'baz'`},
+		{`BACKUP TABLE foo TO 'bar' AS OF SYSTEM TIME '1' INCREMENTAL FROM 'baz'`},
+		{`BACKUP TABLE foo TO $1 INCREMENTAL FROM 'bar', $2, 'baz'`},
 		{`BACKUP DATABASE foo TO 'bar'`},
 		{`BACKUP DATABASE foo, baz TO 'bar'`},
 		{`BACKUP DATABASE foo TO 'bar' AS OF SYSTEM TIME '1' INCREMENTAL FROM 'baz'`},
-		{`RESTORE foo FROM 'bar'`},
-		{`RESTORE foo FROM $1`},
-		{`RESTORE foo FROM $1, $2, 'bar'`},
-		{`RESTORE foo, baz FROM 'bar'`},
-		{`RESTORE foo, baz FROM 'bar' AS OF SYSTEM TIME '1'`},
+		{`RESTORE TABLE foo FROM 'bar'`},
+		{`RESTORE TABLE foo FROM $1`},
+		{`RESTORE TABLE foo FROM $1, $2, 'bar'`},
+		{`RESTORE TABLE foo, baz FROM 'bar'`},
+		{`RESTORE TABLE foo, baz FROM 'bar' AS OF SYSTEM TIME '1'`},
 		{`RESTORE DATABASE foo FROM 'bar'`},
 		{`RESTORE DATABASE foo, baz FROM 'bar'`},
 		{`RESTORE DATABASE foo, baz FROM 'bar' AS OF SYSTEM TIME '1'`},
-		{`BACKUP foo TO 'bar' WITH key1, key2 = 'value'`},
-		{`RESTORE foo FROM 'bar' WITH key1, key2 = 'value'`},
+		{`BACKUP TABLE foo TO 'bar' WITH key1, key2 = 'value'`},
+		{`RESTORE TABLE foo FROM 'bar' WITH key1, key2 = 'value'`},
 		{`IMPORT TABLE foo CREATE USING 'nodelocal:///some/file' CSV DATA ('path/to/some/file', $1) WITH temp = 'path/to/temp'`},
 		{`IMPORT TABLE foo (id INT PRIMARY KEY, email STRING, age INT) CSV DATA ('path/to/some/file', $1) WITH temp = 'path/to/temp'`},
 		{`IMPORT TABLE foo (id INT, email STRING, age INT) CSV DATA ('path/to/some/file', $1) WITH comma = ',', "nullif" = 'n/a', temp = $2`},
 		{`SET ROW (1, true, NULL)`},
 
-		{`CREATE EXPERIMENTAL_CHANGEFEED EMIT foo TO kafka`},
-		{`CREATE EXPERIMENTAL_CHANGEFEED EMIT foo TO kafka WITH topic_prefix = 'bar'`},
+		{`CREATE EXPERIMENTAL_CHANGEFEED EMIT TABLE foo TO kafka`},
+		{`CREATE EXPERIMENTAL_CHANGEFEED EMIT TABLE foo TO kafka WITH topic_prefix = 'bar'`},
 		{`CREATE EXPERIMENTAL_CHANGEFEED EMIT DATABASE foo TO kafka`},
-		{`CREATE EXPERIMENTAL_CHANGEFEED EMIT foo TO kafka AS OF SYSTEM TIME '1'`},
+		{`CREATE EXPERIMENTAL_CHANGEFEED EMIT TABLE foo TO kafka AS OF SYSTEM TIME '1'`},
 
 		// Regression for #15926
 		{`SELECT * FROM ((t1 NATURAL JOIN t2 WITH ORDINALITY AS o1)) WITH ORDINALITY AS o2`},
@@ -1283,8 +1283,8 @@ func TestParse2(t *testing.T) {
 		{`RESTORE DATABASE foo FROM bar`,
 			`RESTORE DATABASE foo FROM 'bar'`},
 
-		{`CREATE EXPERIMENTAL_CHANGEFEED EMIT TABLE foo TO kafka`,
-			`CREATE EXPERIMENTAL_CHANGEFEED EMIT foo TO kafka`},
+		{`CREATE EXPERIMENTAL_CHANGEFEED EMIT foo TO kafka`,
+			`CREATE EXPERIMENTAL_CHANGEFEED EMIT TABLE foo TO kafka`},
 
 		{`SHOW ALL CLUSTER SETTINGS`, `SHOW CLUSTER SETTING all`},
 
@@ -1321,6 +1321,57 @@ func TestParse2(t *testing.T) {
 		{`ALTER USER foo WITH PASSWORD bar`,
 			`ALTER USER 'foo' WITH PASSWORD 'bar'`},
 
+		// Alternative forms for table patterns.
+
+		{`SHOW GRANTS ON foo`,
+			`SHOW GRANTS ON TABLE foo`},
+		{`SHOW GRANTS ON foo, db.foo`,
+			`SHOW GRANTS ON TABLE foo, db.foo`},
+		{`BACKUP foo TO 'bar'`,
+			`BACKUP TABLE foo TO 'bar'`},
+		{`BACKUP foo.foo, baz.baz TO 'bar'`,
+			`BACKUP TABLE foo.foo, baz.baz TO 'bar'`},
+		{`BACKUP foo TO 'bar' AS OF SYSTEM TIME '1' INCREMENTAL FROM 'baz'`,
+			`BACKUP TABLE foo TO 'bar' AS OF SYSTEM TIME '1' INCREMENTAL FROM 'baz'`},
+		{`BACKUP foo TO $1 INCREMENTAL FROM 'bar', $2, 'baz'`,
+			`BACKUP TABLE foo TO $1 INCREMENTAL FROM 'bar', $2, 'baz'`},
+		// Tables named "role" are handled specially to support SHOW GRANTS ON ROLE,
+		// but that special handling should not impact BACKUP.
+		{`BACKUP role TO 'bar'`,
+			`BACKUP TABLE role TO 'bar'`},
+		{`RESTORE foo FROM 'bar'`,
+			`RESTORE TABLE foo FROM 'bar'`},
+		{`RESTORE foo FROM $1`,
+			`RESTORE TABLE foo FROM $1`},
+		{`RESTORE foo FROM $1, $2, 'bar'`,
+			`RESTORE TABLE foo FROM $1, $2, 'bar'`},
+		{`RESTORE foo, baz FROM 'bar'`,
+			`RESTORE TABLE foo, baz FROM 'bar'`},
+		{`RESTORE foo, baz FROM 'bar' AS OF SYSTEM TIME '1'`,
+			`RESTORE TABLE foo, baz FROM 'bar' AS OF SYSTEM TIME '1'`},
+		{`BACKUP foo TO 'bar' WITH key1, key2 = 'value'`,
+			`BACKUP TABLE foo TO 'bar' WITH key1, key2 = 'value'`},
+		{`RESTORE foo FROM 'bar' WITH key1, key2 = 'value'`,
+			`RESTORE TABLE foo FROM 'bar' WITH key1, key2 = 'value'`},
+
+		{`CREATE EXPERIMENTAL_CHANGEFEED EMIT foo TO kafka`,
+			`CREATE EXPERIMENTAL_CHANGEFEED EMIT TABLE foo TO kafka`},
+
+		{`GRANT SELECT ON foo TO root`,
+			`GRANT SELECT ON TABLE foo TO root`},
+		{`GRANT SELECT, DELETE, UPDATE ON foo, db.foo TO root, bar`,
+			`GRANT SELECT, DELETE, UPDATE ON TABLE foo, db.foo TO root, bar`},
+		// Tables named "role" are handled specially to support SHOW GRANTS ON ROLE,
+		// but that special handling should not impact GRANT.
+		{`GRANT SELECT ON role TO root`,
+			`GRANT SELECT ON TABLE role TO root`},
+		{`REVOKE SELECT ON foo FROM root`,
+			`REVOKE SELECT ON TABLE foo FROM root`},
+		{`REVOKE UPDATE, DELETE ON foo, db.foo FROM root, bar`,
+			`REVOKE UPDATE, DELETE ON TABLE foo, db.foo FROM root, bar`},
+
+		// RBAC-related statements.
+
 		{`CREATE ROLE foo`,
 			`CREATE ROLE 'foo'`},
 		{`CREATE ROLE IF NOT EXISTS foo`,
@@ -1329,6 +1380,18 @@ func TestParse2(t *testing.T) {
 			`DROP ROLE 'foo', 'bar'`},
 		{`DROP ROLE IF EXISTS foo, bar`,
 			`DROP ROLE IF EXISTS 'foo', 'bar'`},
+
+		// Clarify the ambiguity between "ON ROLE" (RBAC) and "ON ROLE"
+		// (regular table named "role").
+		{`SHOW GRANTS ON role`, `SHOW GRANTS ON ROLE`},
+		{`SHOW GRANTS ON "role"`, `SHOW GRANTS ON TABLE role`},
+		{`SHOW GRANTS ON role foo`, `SHOW GRANTS ON ROLE foo`},
+		{`SHOW GRANTS ON role, foo`, `SHOW GRANTS ON TABLE role, foo`},
+		{`SHOW GRANTS ON role foo, bar`, `SHOW GRANTS ON ROLE foo, bar`},
+		{`SHOW GRANTS ON "role", foo`, `SHOW GRANTS ON TABLE role, foo`},
+		{`SHOW GRANTS ON "role".foo`, `SHOW GRANTS ON TABLE role.foo`},
+		{`SHOW GRANTS ON role.foo`, `SHOW GRANTS ON TABLE role.foo`},
+		{`SHOW GRANTS ON role.*`, `SHOW GRANTS ON TABLE role.*`},
 
 		{
 			`CREATE TABLE a (b INT, FOREIGN KEY (b) REFERENCES other ON UPDATE NO ACTION ON DELETE NO ACTION)`,
@@ -1822,6 +1885,36 @@ HINT: See: https://github.com/cockroachdb/cockroach/issues/24560`,
 SELECT * FROM ab, LATERAL foo(a)
                                 ^
 HINT: See: https://github.com/cockroachdb/cockroach/issues/24560`,
+		},
+		// Ensure that the support for ON ROLE <namelist> doesn't leak
+		// where it should not be recognized.
+		{
+			`GRANT SELECT ON ROLE foo, bar TO blix`,
+			`syntax error at or near "foo"
+GRANT SELECT ON ROLE foo, bar TO blix
+                     ^
+HINT: try \h GRANT`,
+		},
+		{
+			`REVOKE SELECT ON ROLE foo, bar FROM blix`,
+			`syntax error at or near "foo"
+REVOKE SELECT ON ROLE foo, bar FROM blix
+                      ^
+HINT: try \h REVOKE`,
+		},
+		{
+			`BACKUP ROLE foo, bar TO 'baz'`,
+			`syntax error at or near "foo"
+BACKUP ROLE foo, bar TO 'baz'
+            ^
+HINT: try \h BACKUP`,
+		},
+		{
+			`RESTORE ROLE foo, bar FROM 'baz'`,
+			`syntax error at or near "foo"
+RESTORE ROLE foo, bar FROM 'baz'
+             ^
+HINT: try \h RESTORE`,
 		},
 	}
 	for _, d := range testData {

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -752,8 +752,8 @@ func newNameFromStr(s string) *tree.Name {
 
 %type <str> database_name index_name opt_index_name column_name insert_column_item statistics_name window_name
 %type <str> family_name opt_family_name table_alias_name constraint_name target_name zone_name partition_name collation_name
-%type <*tree.UnresolvedName> table_name sequence_name view_name db_object_name
-%type <*tree.UnresolvedName> table_pattern
+%type <*tree.UnresolvedName> table_name sequence_name view_name db_object_name simple_db_object_name complex_db_object_name 
+%type <*tree.UnresolvedName> table_pattern complex_table_pattern
 %type <*tree.UnresolvedName> column_path prefixed_column_path column_path_with_star
 %type <tree.TableExpr> insert_target
 
@@ -780,7 +780,7 @@ func newNameFromStr(s string) *tree.Name {
 %type <tree.OrderBy> sort_clause opt_sort_clause
 %type <[]*tree.Order> sortby_list
 %type <tree.IndexElemList> index_params
-%type <tree.NameList> name_list opt_name_list privilege_list
+%type <tree.NameList> name_list privilege_list
 %type <[]int32> opt_array_bounds
 %type <*tree.From> from_clause update_from_clause
 %type <tree.TableExprs> from_list
@@ -925,8 +925,8 @@ func newNameFromStr(s string) *tree.Name {
 
 %type <[]tree.ColumnID> opt_tableref_col_list tableref_col_list
 
-%type <tree.TargetList>    targets
-%type <*tree.TargetList> on_privilege_target_clause
+%type <tree.TargetList>    targets targets_roles
+%type <*tree.TargetList>   opt_on_targets_roles
 %type <tree.NameList>       for_grantee_clause
 %type <privilege.List> privileges
 %type <tree.AuditMode> audit_mode
@@ -2190,20 +2190,6 @@ revoke_stmt:
   }
 | REVOKE error // SHOW HELP: REVOKE
 
-targets:
-  table_pattern_list
-  {
-    $$.val = tree.TargetList{Tables: $1.tablePatterns()}
-  }
-| TABLE table_pattern_list
-  {
-    $$.val = tree.TargetList{Tables: $2.tablePatterns()}
-  }
-|  DATABASE name_list
-  {
-    $$.val = tree.TargetList{Databases: $2.nameList()}
-  }
-
 // ALL is always by itself.
 privileges:
   ALL
@@ -2780,14 +2766,14 @@ show_databases_stmt:
 //
 // %SeeAlso: WEBDOCS/show-grants.html
 show_grants_stmt:
-  SHOW GRANTS ON ROLE opt_name_list for_grantee_clause
+  SHOW GRANTS opt_on_targets_roles for_grantee_clause
   {
-    $$.val = &tree.ShowRoleGrants{Roles: $5.nameList(), Grantees: $6.nameList()}
-  }
-|
-  SHOW GRANTS on_privilege_target_clause for_grantee_clause
-  {
-    $$.val = &tree.ShowGrants{Targets: $3.targetListPtr(), Grantees: $4.nameList()}
+    lst := $3.targetListPtr()
+    if lst != nil && lst.ForRoles {
+      $$.val = &tree.ShowRoleGrants{Roles: lst.Roles, Grantees: $4.nameList()}
+    } else {
+      $$.val = &tree.ShowGrants{Targets: lst, Grantees: $4.nameList()}
+    }
   }
 | SHOW GRANTS error // SHOW HELP: SHOW GRANTS
 
@@ -3103,8 +3089,8 @@ show_testing_stmt:
     $$.val = &tree.ShowFingerprints{Table: $5.newNormalizableTableNameFromUnresolvedName()}
   }
 
-on_privilege_target_clause:
-  ON targets
+opt_on_targets_roles:
+  ON targets_roles
   {
     tmp := $2.targetList()
     $$.val = &tmp
@@ -3113,6 +3099,196 @@ on_privilege_target_clause:
   {
     $$.val = (*tree.TargetList)(nil)
   }
+
+// targets is a non-terminal for a list of privilege targets, either a
+// list of databases or a list of tables.
+//
+// This rule is complex and cannot be decomposed as a tree of
+// non-terminals because it must resolve syntax ambiguities in the
+// SHOW GRANTS ON ROLE statement. It was constructed as follows.
+//
+// 1. Start with the desired definition of targets:
+//
+//    targets ::=
+//        table_pattern_list
+//        TABLE table_pattern_list
+//        DATABASE name_list
+//
+// 2. Now we must disambiguate the first rule "table_pattern_list"
+//    between one that recognizes ROLE and one that recognizes
+//    <some table pattern list>". So first, inline the definition of
+//    table_pattern_list.
+//
+//    targets ::=
+//        table_pattern                          # <- here
+//        table_pattern_list ',' table_pattern   # <- here
+//        TABLE table_pattern_list
+//        DATABASE name_list
+//
+// 3. We now must disambiguate the "ROLE" inside the prefix "table_pattern".
+//    However having "table_pattern_list" as prefix is cumbersome, so swap it.
+//
+//    targets ::=
+//        table_pattern
+//        table_pattern ',' table_pattern_list   # <- here
+//        TABLE table_pattern_list
+//        DATABASE name_list
+//
+// 4. The rule that has table_pattern followed by a comma is now
+//    non-problematic, because it will never match "ROLE" followed
+//    by an optional name list (neither "ROLE;" nor "ROLE <ident>"
+//    would match). We just need to focus on the first one "table_pattern".
+//    This needs to tweak "table_pattern".
+//
+//    Here we could inline table_pattern but now we don't have to any
+//    more, we just need to create a variant of it which is
+//    unambiguous with a single ROLE keyword. That is, we need a
+//    table_pattern which cannot contain a single name. We do
+//    this as follows.
+//
+//    targets ::=
+//        complex_table_pattern                  # <- here
+//        table_pattern ',' table_pattern_list
+//        TABLE table_pattern_list
+//        DATABASE name_list
+//    complex_table_pattern ::=
+//        name '.' unrestricted_name
+//        name '.' unrestricted_name '.' unrestricted_name
+//        name '.' unrestricted_name '.' '*'
+//        name '.' '*'
+//        '*'
+//
+// 5. At this point the rule cannot start with a simple identifier any
+//    more, keyword or not. But more importantly, any token sequence
+//    that starts with ROLE cannot be matched by any of these remaining
+//    rules. This means that the prefix is now free to use, without
+//    ambiguity. We do this as follows, to gain a syntax rule for "ROLE
+//    <namelist>". (We'll handle a ROLE with no name list below.)
+//
+//    targets ::=
+//        ROLE name_list                        # <- here
+//        complex_table_pattern
+//        table_pattern ',' table_pattern_list
+//        TABLE table_pattern_list
+//        DATABASE name_list
+//
+// 6. Now on to the finishing touches. First we'd like to regain the
+//    ability to use "<tablename>" when the table name is a simple
+//    identifier. This is done as follows:
+//
+//    targets ::=
+//        ROLE name_list
+//        name                                  # <- here
+//        complex_table_pattern
+//        table_pattern ',' table_pattern_list
+//        TABLE table_pattern_list
+//        DATABASE name_list
+//
+// 7. Then, we want to recognize "ROLE" without any subsequent name
+//    list. This requires some care: we can't add "ROLE" to the set of
+//    rules above, because "name" would then overlap. To disambiguate,
+//    we must first inline "name" as follows:
+//
+//    targets ::=
+//        ROLE name_list
+//        IDENT                    # <- here, always <table>
+//        col_name_keyword         # <- here, always <table>
+//        unreserved_keyword       # <- here, either ROLE or <table>
+//        complex_table_pattern
+//        table_pattern ',' table_pattern_list
+//        TABLE table_pattern_list
+//        DATABASE name_list
+//
+// 8. And now the rule is sufficiently simple that we can disambiguate
+//    in the action, like this:
+//
+//    targets ::=
+//        ...
+//        unreserved_keyword {
+//             if $1 == "role" { /* handle ROLE */ }
+//             else { /* handle ON <tablename> */ }
+//        }
+//        ...
+//
+//   (but see the comment on the action of this sub-rule below for
+//   more nuance.)
+//
+// Tada!
+targets:
+  IDENT
+  {
+    $$.val = tree.TargetList{Tables: tree.TablePatterns{&tree.UnresolvedName{NumParts:1, Parts: tree.NameParts{$1}}}}
+  }
+| col_name_keyword
+  {
+    $$.val = tree.TargetList{Tables: tree.TablePatterns{&tree.UnresolvedName{NumParts:1, Parts: tree.NameParts{$1}}}}
+  }
+| unreserved_keyword
+  {
+    // This sub-rule is meant to support both ROLE and other keywords
+    // used as table name without the TABLE prefix. The keyword ROLE
+    // here can have two meanings:
+    //
+    // - for all statements except SHOW GRANTS, it must be interpreted
+    //   as a plain table name.
+    // - for SHOW GRANTS specifically, it must be handled as an ON ROLE
+    //   specifier without a name list (the rule with a name list is separate,
+    //   see above).
+    //
+    // Yet we want to use a single "targets" non-terminal for all
+    // statements that use targets, to share the code. This action
+    // achieves this as follows:
+    //
+    // - for all statements (including SHOW GRANTS), it populates the
+    //   Tables list in TargetList{} with the given name. This will
+    //   include the given keyword as table pattern in all cases,
+    //   including when the keyword was ROLE.
+    //
+    // - if ROLE was specified, it remembers this fact in the ForRoles
+    //   field.  This distinguishes `ON ROLE` (where "role" is
+    //   specified as keyword), which triggers the special case in
+    //   SHOW GRANTS, from `ON "role"` (where "role" is specified as
+    //   identifier), which is always handled as a table name.
+    //
+    //   Both `ON ROLE` and `ON "role"` populate the Tables list in the same way,
+    //   so that other statements than SHOW GRANTS don't observe any difference.
+    //
+    // Arguably this code is a bit too clever. Future work should aim
+    // to remove the special casing of SHOW GRANTS altogether instead
+    // of increasing (or attempting to modify) the grey magic occurring
+    // here.
+    $$.val = tree.TargetList{
+      Tables: tree.TablePatterns{&tree.UnresolvedName{NumParts:1, Parts: tree.NameParts{$1}}},
+      ForRoles: $1 == "role", // backdoor for "SHOW GRANTS ON ROLE" (no name list)
+    }
+  }
+| complex_table_pattern
+  {
+    $$.val = tree.TargetList{Tables: tree.TablePatterns{$1.unresolvedName()}}
+  }
+| table_pattern ',' table_pattern_list
+  {
+    remainderPats := $3.tablePatterns()
+    $$.val = tree.TargetList{Tables: append(tree.TablePatterns{$1.unresolvedName()}, remainderPats...)}
+  }
+| TABLE table_pattern_list
+  {
+    $$.val = tree.TargetList{Tables: $2.tablePatterns()}
+  }
+| DATABASE name_list
+  {
+    $$.val = tree.TargetList{Databases: $2.nameList()}
+  }
+
+// target_roles is the variant of targets which recognizes ON ROLES
+// with a name list. This cannot be included in targets directly
+// because some statements must not recognize this syntax.
+targets_roles:
+  ROLE name_list
+  {
+     $$.val = tree.TargetList{ForRoles: true, Roles: $2.nameList()}
+  }
+| targets
 
 for_grantee_clause:
   FOR name_list
@@ -7132,18 +7308,24 @@ table_name_with_index:
 //   <schema>.*
 //   *
 table_pattern:
-  db_object_name
+  simple_db_object_name
+| complex_table_pattern
+
+// complex_table_pattern is the part of table_pattern which recognizes
+// every pattern not composed of a single identifier.
+complex_table_pattern:
+  complex_db_object_name
 | name '.' unrestricted_name '.' '*'
   {
-    $$.val = &tree.UnresolvedName{Star: true, NumParts: 3, Parts: tree.NameParts{"", $3, $1}}
+     $$.val = &tree.UnresolvedName{Star: true, NumParts: 3, Parts: tree.NameParts{"", $3, $1}}
   }
 | name '.' '*'
   {
-    $$.val = &tree.UnresolvedName{Star: true, NumParts: 2, Parts: tree.NameParts{"", $1}}
+     $$.val = &tree.UnresolvedName{Star: true, NumParts: 2, Parts: tree.NameParts{"", $1}}
   }
 | '*'
   {
-    $$.val = &tree.UnresolvedName{Star: true, NumParts: 1}
+     $$.val = &tree.UnresolvedName{Star: true, NumParts: 1}
   }
 
 name_list:
@@ -7154,16 +7336,6 @@ name_list:
 | name_list ',' name
   {
     $$.val = append($1.nameList(), tree.Name($3))
-  }
-
-opt_name_list:
-  name_list
-  {
-    $$.val = $1.nameList()
-  }
-| /* EMPTY */
-  {
-    $$.val = tree.NameList(nil)
   }
 
 // Constants
@@ -7401,11 +7573,23 @@ func_name:
 // <schema>.<table>
 // <catalog/db>.<schema>.<table>
 db_object_name:
+  simple_db_object_name
+| complex_db_object_name
+
+// simple_db_object_name is the part of db_object_name that recognizes
+// simple identifiers.
+simple_db_object_name:
   name
   {
     $$.val = &tree.UnresolvedName{NumParts:1, Parts: tree.NameParts{$1}}
   }
-| name '.' unrestricted_name
+
+// complex_db_object_name is the part of db_object_name that recognizes
+// composite names (not simple identifiers).
+// It is split away from db_object_name in order to enable the definition
+// of table_pattern.
+complex_db_object_name:
+  name '.' unrestricted_name
   {
     $$.val = &tree.UnresolvedName{NumParts:2, Parts: tree.NameParts{$3,$1}}
   }
@@ -7619,6 +7803,7 @@ unreserved_keyword:
 | RESTRICT
 | RESUME
 | REVOKE
+| ROLE
 | ROLES
 | ROLLBACK
 | ROLLUP
@@ -7840,7 +8025,6 @@ reserved_keyword:
 | PRIMARY
 | REFERENCES
 | RETURNING
-| ROLE
 | SELECT
 | SESSION_USER
 | SOME

--- a/pkg/sql/sem/tree/format_test.go
+++ b/pkg/sql/sem/tree/format_test.go
@@ -56,7 +56,7 @@ func TestFormatStatement(t *testing.T) {
 		{`SHOW CREATE TABLE foo`, tree.FmtAnonymize,
 			`SHOW CREATE TABLE _`},
 		{`GRANT SELECT ON bar TO foo`, tree.FmtAnonymize,
-			`GRANT SELECT ON _ TO _`},
+			`GRANT SELECT ON TABLE _ TO _`},
 
 		{`SELECT 1+COALESCE(NULL, 'a', x)-ARRAY[3.14]`, tree.FmtHideConstants,
 			`SELECT (_ + COALESCE(_, _, x)) - ARRAY[_]`},

--- a/pkg/sql/sem/tree/grant.go
+++ b/pkg/sql/sem/tree/grant.go
@@ -39,6 +39,12 @@ type Grant struct {
 type TargetList struct {
 	Databases NameList
 	Tables    TablePatterns
+
+	// ForRoles and Roles are used internally in the parser and not used
+	// in the AST. Therefore they do not participate in pretty-printing,
+	// etc.
+	ForRoles bool
+	Roles    NameList
 }
 
 // Format implements the NodeFormatter interface.
@@ -47,6 +53,7 @@ func (tl *TargetList) Format(ctx *FmtCtx) {
 		ctx.WriteString("DATABASE ")
 		ctx.FormatNode(&tl.Databases)
 	} else {
+		ctx.WriteString("TABLE ")
 		ctx.FormatNode(&tl.Tables)
 	}
 }


### PR DESCRIPTION
Fixes #24489.
Alternative to #24581.

When support for role-based access control was added, the ROLE
identifier became a reserved keyword. This breaks existing apps and
databases which use the word "role" to name databases, tables or
columns, which as experience shows seems to be a pretty common occurence.

This change un-breaks the existing apps and databases by making the
keyword non-reserved again. This change avoids redefinition of the
syntax of the SHOW GRANTS ON ROLE statement, at the cost of a
non-trivial, poorly maintainable and gross hack to the SQL grammar.

Release note (sql change, bug fix): the word "ROLE" is not a reserved
keyword any more, which (re-)enables database and apps using that name
for databases, tables and columns.