### PR TITLE
distsql: lookup join internal columns fix

### DIFF
--- a/pkg/sql/distsqlrun/processors.proto
+++ b/pkg/sql/distsqlrun/processors.proto
@@ -201,20 +201,23 @@ message TableReaderSpec {
 // performs KV operations to retrieve specific rows that correspond to the
 // values in the input stream (join by lookup).
 //
-// The "internal columns" of a JoinReader (see ProcessorSpec) are either the
-// columns of the table or the concatenation of the columns of the input stream
-// with the table columns, depending on the lookup columns specified.
-// Internally, only the values for the columns needed by the post-processing
-// stage are be populated.
+// The "internal columns" of a JoinReader (see ProcessorSpec) depend on whether
+// it is an index join or a lookup join.
+// For an index join: the internal columns are the columns of the table (right
+// side) of the index join.
+// For a lookup join: the internal columns are the input stream columns (left
+// side) concattenated with the needed columns from the table (right side) of
+// the join. This includes relevant outputted columns, or columns needed for
+// the onExpr.
 //
 // Example:
-// Input stream columns: | a | b |              Table columns: | c |
+// Input stream columns: | a | b |              Table columns: | c | d | e |
 // 
-// If performing a lookup join on a = c (lookup columns are [0, 2]):
-//        Internal columns: | a | b | c |
+// If performing a lookup join on a = c (lookup columns is [0]), outputting a, b, c, e:
+//        Internal columns: | a | c | e |
 // 
-// If performing an index join (lookup columns is []):
-//        Internal columns: | c |
+// If performing an index join (where a = c and b = d) (lookup columns is []):
+//        Internal columns: | c | d | e |
 message JoinReaderSpec {
   optional sqlbase.TableDescriptor table = 1 [(gogoproto.nullable) = false];
 
@@ -247,7 +250,7 @@ message JoinReaderSpec {
   // join is: [-1, -1, 2, -1, 3], the internal columns would be columns 3 and
   // 5. But when an index lookup is done, the entire right side is returned.
   // The index map tells the processor which columns it should select. In the
-  // example the indexMap would be [2, 3].
+  // example the indexMap would be [2, 4].
   repeated uint32 index_map = 5 [packed = true];
 }
 

--- a/pkg/sql/logictest/testdata/logic_test/lookup_join
+++ b/pkg/sql/logictest/testdata/logic_test/lookup_join
@@ -243,6 +243,20 @@ SELECT "URL" FROM [EXPLAIN (DISTSQL) SELECT * FROM authors INNER JOIN books ON b
 ----
 https://cockroachdb.github.io/distsqlplan/decode.html?eJyUkTFrwzAQhff-CvHmK8ROsggKmgopJSkhW_Gg2EeqxtEZSYaW4P9ebA9NCnHbUe_ue--hO8NLxWt74gj9igyEJQpCE6TkGCX08ri0qj6gZwTnmzb1ckEoJTD0GcmlmqGxlntpQKg4WVcPSx1B2vSNxGQPDD3v6MI2m7bd2X3NW7YVhytzNMGdbPg0tk1vfVfCpk1amYxMjlvR2X-in8T5qeS9yLHPfRY5to16F-eVeK1MDsKjqxMHrcxCPahMa71a7646kpmTWZBZ3iybX5X95fu3HBvxkf90gVlXELg68HjiKG0o-SVIOcSMz83ADULFMY3T-fhY-XHUF7yEs0k4n4bzSXj2Ay66u68AAAD__9tr5dM=
 
+# Regression test for #24401
+statement ok
+CREATE TABLE players (id DECIMAL PRIMARY KEY, name STRING, team INT)
+
+statement ok
+INSERT INTO players VALUES (1.0, 'ready', 0), (2.0, 'another player', 0), (3.2, 'third', 1)
+
+query B rowsort
+SELECT p1.team = p2.team FROM players p1 JOIN players p2 ON p1.id = p2.id
+----
+true
+true
+true
+
 
 statement ok
 SET experimental_force_lookup_join = false;


### PR DESCRIPTION
Fixes #24401, by modifying the internal columns of lookup joins to only
use needed columns, as specified from the right side's
planToStreamColMap via the lookup join's index map.

Release note: None