### PR TITLE
security: validate certificate fields at load time.

### DIFF
--- a/pkg/security/certificate_loader_test.go
+++ b/pkg/security/certificate_loader_test.go
@@ -19,9 +19,11 @@ import (
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/x509"
+	"crypto/x509/pkix"
 	"encoding/pem"
 	"errors"
 	"io/ioutil"
+	"math/big"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -32,6 +34,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/security/securitytest"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 )
 
 func TestLoadEmbeddedCerts(t *testing.T) {
@@ -72,37 +75,59 @@ func countLoadedCertificates(certsDir string) (int, error) {
 	return len(cl.Certificates()), nil
 }
 
-// Generate a valid x509 CA certificate. Returns the x509 certificate and the
-// PEM-encoded contents (suitable to write to a .crt file).
-func makeTestCACert() (*x509.Certificate, []byte, error) {
+// Generate a x509 cert with specific fields.
+func makeTestCert(
+	t *testing.T, commonName string, keyUsage x509.KeyUsage, extUsages []x509.ExtKeyUsage,
+) []byte {
+	// Make smallest rsa key possible: not saved.
 	key, err := rsa.GenerateKey(rand.Reader, 512)
 	if err != nil {
-		return nil, nil, err
+		t.Fatalf("error on GenerateKey for CN=%s: %v", commonName, err)
 	}
 
-	certBytes, err := security.GenerateCA(key, time.Hour*48)
-	if err != nil {
-		return nil, nil, err
+	// Specify the smallest possible set of fields.
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject: pkix.Name{
+			CommonName: commonName,
+		},
+		NotBefore: timeutil.Now().Add(-time.Hour),
+		NotAfter:  timeutil.Now().Add(time.Hour),
+		KeyUsage:  keyUsage,
 	}
 
-	x509Cert, err := x509.ParseCertificate(certBytes)
+	template.ExtKeyUsage = extUsages
+
+	certBytes, err := x509.CreateCertificate(rand.Reader, template, template, key.Public(), key)
 	if err != nil {
-		return nil, nil, err
+		t.Fatalf("error on CreateCertificate for CN=%s: %v", commonName, err)
 	}
 
 	certBlock := &pem.Block{Type: "CERTIFICATE", Bytes: certBytes}
-	return x509Cert, pem.EncodeToMemory(certBlock), nil
+	return pem.EncodeToMemory(certBlock)
 }
 
 func TestNamingScheme(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	// Make a valid x509 certificate. We don't use it here, but we do need something that
-	// parses as a valid pem-encoded x509 certificate.
-	x509Cert, certContents, err := makeTestCACert()
-	if err != nil {
-		t.Fatal(err)
-	}
+	fullKeyUsage := x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature
+	// Build a few certificates. These are barebones since we only need to check our custom validation,
+	// not chain verification.
+	caCert := makeTestCert(t, "", 0, nil)
+
+	goodNodeCert := makeTestCert(t, "node", fullKeyUsage, []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth})
+	badUserNodeCert := makeTestCert(t, "notnode", fullKeyUsage, []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth})
+	noServerAuthNodeCert := makeTestCert(t, "node", fullKeyUsage, []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth})
+	noClientAuthNodeCert := makeTestCert(t, "node", fullKeyUsage, []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth})
+	noAuthNodeCert := makeTestCert(t, "node", fullKeyUsage, nil)
+	noEnciphermentNodeCert := makeTestCert(t, "node", x509.KeyUsageDigitalSignature, []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth})
+	noSignatureNodeCert := makeTestCert(t, "node", x509.KeyUsageKeyEncipherment, []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth})
+
+	goodRootCert := makeTestCert(t, "root", fullKeyUsage, []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth})
+	notRootCert := makeTestCert(t, "notroot", fullKeyUsage, []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth})
+	noClientAuthRootCert := makeTestCert(t, "root", fullKeyUsage, nil)
+	noEnciphermentRootCert := makeTestCert(t, "root", x509.KeyUsageDigitalSignature, []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth})
+	noSignatureRootCert := makeTestCert(t, "root", x509.KeyUsageKeyEncipherment, []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth})
 
 	// Do not use embedded certs.
 	security.ResetAssetLoader()
@@ -168,12 +193,12 @@ func TestNamingScheme(t *testing.T) {
 		{
 			// Test proper names, but no key files, only the CA cert should be loaded without error.
 			files: []testFile{
-				{"ca.crt", 0777, certContents},
-				{"node.crt", 0777, certContents},
-				{"client.root.crt", 0777, certContents},
+				{"ca.crt", 0777, caCert},
+				{"node.crt", 0777, goodNodeCert},
+				{"client.root.crt", 0777, goodRootCert},
 			},
 			certs: []security.CertInfo{
-				{FileUsage: security.CAPem, Filename: "ca.crt", FileContents: certContents},
+				{FileUsage: security.CAPem, Filename: "ca.crt", FileContents: caCert},
 				{FileUsage: security.ClientPem, Filename: "client.root.crt", Name: "root",
 					Error: errors.New(".* no such file or directory")},
 				{FileUsage: security.NodePem, Filename: "node.crt",
@@ -184,15 +209,15 @@ func TestNamingScheme(t *testing.T) {
 			// Key files, but wrong permissions.
 			// We don't load CA keys here, so permissions for them don't matter.
 			files: []testFile{
-				{"ca.crt", 0777, certContents},
+				{"ca.crt", 0777, caCert},
 				{"ca.key", 0777, []byte{}},
-				{"node.crt", 0777, certContents},
+				{"node.crt", 0777, goodNodeCert},
 				{"node.key", 0704, []byte{}},
-				{"client.root.crt", 0777, certContents},
+				{"client.root.crt", 0777, goodRootCert},
 				{"client.root.key", 0740, []byte{}},
 			},
 			certs: []security.CertInfo{
-				{FileUsage: security.CAPem, Filename: "ca.crt", FileContents: certContents},
+				{FileUsage: security.CAPem, Filename: "ca.crt", FileContents: caCert},
 				{FileUsage: security.ClientPem, Filename: "client.root.crt", Name: "root",
 					Error: errors.New(".* exceeds -rwx------")},
 				{FileUsage: security.NodePem, Filename: "node.crt",
@@ -207,52 +232,134 @@ func TestNamingScheme(t *testing.T) {
 				{"ca.key", 0777, []byte{}},
 				{"node.crt", 0777, []byte("foo")},
 				{"node.key", 0700, []byte{}},
-				{"client.root.crt", 0777, append(certContents, []byte("-----BEGIN CERTIFICATE-----\n-----END CERTIFICATE-----")...)},
+				{"client.root.crt", 0777, append(goodRootCert, []byte("-----BEGIN CERTIFICATE-----\n-----END CERTIFICATE-----")...)},
 				{"client.root.key", 0700, []byte{}},
 			},
 			certs: []security.CertInfo{
 				{FileUsage: security.CAPem, Filename: "ca.crt",
 					Error: errors.New("empty certificate file: ca.crt")},
 				{FileUsage: security.ClientPem, Filename: "client.root.crt", Name: "root",
-					Error: errors.New("failed to parse certificate at position 1 in file client.root.crt")},
+					Error: errors.New("failed to parse certificate 1 in file client.root.crt")},
 				{FileUsage: security.NodePem, Filename: "node.crt",
 					Error: errors.New("no certificates found in node.crt")},
 			},
 		},
 		{
+			// Bad CommonName.
+			files: []testFile{
+				{"node.crt", 0777, badUserNodeCert},
+				{"node.key", 0700, []byte{}},
+				{"client.root.crt", 0777, notRootCert},
+				{"client.root.key", 0700, []byte{}},
+			},
+			certs: []security.CertInfo{
+				{FileUsage: security.ClientPem, Filename: "client.root.crt", Name: "root",
+					Error: errors.New("client certificate has Subject \"CN=notroot\", expected \"CN=root")},
+				{FileUsage: security.NodePem, Filename: "node.crt",
+					Error: errors.New("node certificate has Subject \"CN=notnode\", expected \"CN=node")},
+			},
+		},
+		{
+			// No ServerAuth key usage.
+			files: []testFile{
+				{"node.crt", 0777, noServerAuthNodeCert},
+				{"node.key", 0700, []byte{}},
+			},
+			certs: []security.CertInfo{
+				{FileUsage: security.NodePem, Filename: "node.crt",
+					Error: errors.New("node certificate extended key usages: ServerAuth=false, ClientAuth=true, but both are needed")},
+			},
+		},
+		{
+			// No ClientAuth key usage.
+			files: []testFile{
+				{"node.crt", 0777, noClientAuthNodeCert},
+				{"node.key", 0700, []byte{}},
+				{"client.root.crt", 0777, noClientAuthRootCert},
+				{"client.root.key", 0700, []byte{}},
+			},
+			certs: []security.CertInfo{
+				{FileUsage: security.ClientPem, Filename: "client.root.crt", Name: "root",
+					Error: errors.New("client certificate does not have ClientAuth extended key usage")},
+				{FileUsage: security.NodePem, Filename: "node.crt",
+					Error: errors.New("node certificate extended key usages: ServerAuth=true, ClientAuth=false, but both are needed")},
+			},
+		},
+		{
+			// No auth key usage.
+			files: []testFile{
+				{"node.crt", 0777, noAuthNodeCert},
+				{"node.key", 0700, []byte{}},
+			},
+			certs: []security.CertInfo{
+				{FileUsage: security.NodePem, Filename: "node.crt",
+					Error: errors.New("node certificate extended key usages: ServerAuth=false, ClientAuth=false, but both are needed")},
+			},
+		},
+		{
+			// No KeyEncipherment key usage.
+			files: []testFile{
+				{"node.crt", 0777, noEnciphermentNodeCert},
+				{"node.key", 0700, []byte{}},
+				{"client.root.crt", 0777, noEnciphermentRootCert},
+				{"client.root.key", 0700, []byte{}},
+			},
+			certs: []security.CertInfo{
+				{FileUsage: security.NodePem, Filename: "client.root.crt",
+					Error: errors.New("client certificate key usages: KeyEncipherment=false, DigitalSignature=true, but both are needed")},
+				{FileUsage: security.NodePem, Filename: "node.crt",
+					Error: errors.New("node certificate key usages: KeyEncipherment=false, DigitalSignature=true, but both are needed")},
+			},
+		},
+		{
+			// No DigitalSignature key usage.
+			files: []testFile{
+				{"node.crt", 0777, noSignatureNodeCert},
+				{"node.key", 0700, []byte{}},
+				{"client.root.crt", 0777, noSignatureRootCert},
+				{"client.root.key", 0700, []byte{}},
+			},
+			certs: []security.CertInfo{
+				{FileUsage: security.NodePem, Filename: "client.root.crt",
+					Error: errors.New("client certificate key usages: KeyEncipherment=true, DigitalSignature=false, but both are needed")},
+				{FileUsage: security.NodePem, Filename: "node.crt",
+					Error: errors.New("node certificate key usages: KeyEncipherment=true, DigitalSignature=false, but both are needed")},
+			},
+		},
+		{
 			// Everything loads.
 			files: []testFile{
-				{"ca.crt", 0777, certContents},
+				{"ca.crt", 0777, caCert},
 				{"ca.key", 0700, []byte("ca.key")},
-				{"node.crt", 0777, certContents},
+				{"node.crt", 0777, goodNodeCert},
 				{"node.key", 0700, []byte("node.key")},
-				{"client.root.crt", 0777, certContents},
+				{"client.root.crt", 0777, goodRootCert},
 				{"client.root.key", 0700, []byte("client.root.key")},
 			},
 			certs: []security.CertInfo{
-				{FileUsage: security.CAPem, Filename: "ca.crt", FileContents: certContents},
+				{FileUsage: security.CAPem, Filename: "ca.crt", FileContents: caCert},
 				{FileUsage: security.ClientPem, Filename: "client.root.crt", KeyFilename: "client.root.key",
-					Name: "root", FileContents: certContents, KeyFileContents: []byte("client.root.key")},
+					Name: "root", FileContents: goodRootCert, KeyFileContents: []byte("client.root.key")},
 				{FileUsage: security.NodePem, Filename: "node.crt", KeyFilename: "node.key",
-					FileContents: certContents, KeyFileContents: []byte("node.key")},
+					FileContents: goodNodeCert, KeyFileContents: []byte("node.key")},
 			},
 		},
 		{
 			// Bad key permissions, but skip permissions checks.
 			files: []testFile{
-				{"ca.crt", 0777, certContents},
+				{"ca.crt", 0777, caCert},
 				{"ca.key", 0777, []byte("ca.key")},
-				{"node.crt", 0777, certContents},
+				{"node.crt", 0777, goodNodeCert},
 				{"node.key", 0777, []byte("node.key")},
-				{"client.root.crt", 0777, certContents},
+				{"client.root.crt", 0777, goodRootCert},
 				{"client.root.key", 0777, []byte("client.root.key")},
 			},
 			certs: []security.CertInfo{
-				{FileUsage: security.CAPem, Filename: "ca.crt", FileContents: certContents},
+				{FileUsage: security.CAPem, Filename: "ca.crt", FileContents: caCert},
 				{FileUsage: security.ClientPem, Filename: "client.root.crt", KeyFilename: "client.root.key",
-					Name: "root", FileContents: certContents, KeyFileContents: []byte("client.root.key")},
+					Name: "root", FileContents: goodRootCert, KeyFileContents: []byte("client.root.key")},
 				{FileUsage: security.NodePem, Filename: "node.crt", KeyFilename: "node.key",
-					FileContents: certContents, KeyFileContents: []byte("node.key")},
+					FileContents: goodNodeCert, KeyFileContents: []byte("node.key")},
 			},
 			skipChecks: true,
 		},
@@ -296,7 +403,7 @@ func TestNamingScheme(t *testing.T) {
 				}
 			} else {
 				if !testutils.IsError(actual.Error, expected.Error.Error()) {
-					t.Errorf("#%d: mismatched error, expected: %+v, got %+v", testNum, expected, actual)
+					t.Errorf("#%d: mismatched error, expected: %+v, got %+v", testNum, expected.Error, actual.Error)
 				}
 				continue
 			}
@@ -316,14 +423,6 @@ func TestNamingScheme(t *testing.T) {
 				}
 				if a, e := len(actual.ParsedCertificates), 1; a != e {
 					t.Errorf("#%d: expected %d certificates, found: %d", testNum, e, a)
-					continue
-				}
-				if a, e := actual.ParsedCertificates[0], x509Cert; !bytes.Equal(a.Raw, e.Raw) {
-					t.Errorf("#%d: mismatched certificate: %+v vs %+v", testNum, a, e)
-					continue
-				}
-				if a, e := actual.ExpirationTime, x509Cert.NotAfter; a != e {
-					t.Errorf("#%d: mismatched expiration: %s vs %s", testNum, a, e)
 					continue
 				}
 			}


### PR DESCRIPTION
Enforce the following fields when loading certificates:
* CommonName: `node` for node certs; user from filename for client certs
* KeyUsage: KeyEncipherment and DigitalSignature both required
* ExtendedKeyUsage: server/client auth (both for node)

This will make bad certificates (usually created with something other
than `cockroach cert`) print an error at startup (and exit) rather than failing in
obscure ways later.

Fixes #24632.

Release note (security): stricter certificate validation