### PR TITLE
sql: plumb an error in the distsql planner

### DIFF
--- a/pkg/sql/distsql_plan_join.go
+++ b/pkg/sql/distsql_plan_join.go
@@ -229,7 +229,10 @@ func (dsp *DistSQLPlanner) tryCreatePlanForInterleavedJoin(
 	}
 
 	plan.planToStreamColMap = joinToStreamColMap
-	plan.ResultTypes = getTypesForPlanResult(n, joinToStreamColMap)
+	plan.ResultTypes, err = getTypesForPlanResult(n, joinToStreamColMap)
+	if err != nil {
+		return physicalPlan{}, false, err
+	}
 
 	plan.SetMergeOrdering(dsp.convertOrdering(n.props, plan.planToStreamColMap))
 	return plan, true, nil


### PR DESCRIPTION
We got a panic inside `getTypesForPlanResult` via Sentry;
unfortunately I cannot reproduce the panic (I believe what triggers
it is the type of a placeholder passed during prepare, but we don't
have that information).

This change addresses a TODO to make this condition result in an error
instead of a panic.

Updates #24680.

Release note (bug fix): Converted a panic related to an unsupported
type to an error.