### PR TITLE
workloadccl/allccl: skip tpcc validation test under testshort and testrace

### DIFF
--- a/pkg/ccl/workloadccl/allccl/all_test.go
+++ b/pkg/ccl/workloadccl/allccl/all_test.go
@@ -19,6 +19,7 @@ import (
 	_ "github.com/cockroachdb/cockroach/pkg/ccl"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
+	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/workload"
 )
@@ -54,6 +55,10 @@ func TestAllRegisteredWorkloadsValidate(t *testing.T) {
 		}
 
 		t.Run(meta.Name, func(t *testing.T) {
+			if meta.Name == `tpcc` && (testing.Short() || util.RaceEnabled) {
+				t.Skip(`tpcc loads a lot of data`)
+			}
+
 			ctx := context.Background()
 			s, db, _ := serverutils.StartServer(t, base.TestServerArgs{
 				UseDatabase: "d",


### PR DESCRIPTION
It loads a lot of data and so it takes too long to run under short or
race tests. Cutting the data down would make the test uninteresting
since the whole point of the test is to check that the validation
function agrees with the initial data generation, so just skip it in
these cases.

Closes #24660 #24659

Release note: None