### PR TITLE
ui: highlight sidebar links for nested pages

### DIFF
--- a/pkg/ui/src/views/app/components/layoutSidebar/index.tsx
+++ b/pkg/ui/src/views/app/components/layoutSidebar/index.tsx
@@ -1,4 +1,7 @@
+import classNames from "classnames";
+import _ from "lodash";
 import React from "react";
+import PropTypes from "prop-types";
 import { Link } from "react-router";
 import { cockroachIcon } from "src/views/shared/components/icons";
 import { trustIcon } from "src/util/trust";
@@ -12,6 +15,7 @@ interface IconLinkProps {
   icon?: string;
   title?: string;
   to: string;
+  activeFor?: string | string[];
   onlyActiveOnIndex?: boolean;
   className?: string;
 }
@@ -26,11 +30,29 @@ class IconLink extends React.Component<IconLinkProps, {}> {
     onlyActiveOnIndex: false,
   };
 
+  static contextTypes = {
+    router: PropTypes.object,
+  };
+
   render() {
-    const { icon, title, to, onlyActiveOnIndex, className } = this.props;
+    const { icon, title, to, activeFor, onlyActiveOnIndex, className } = this.props;
+
+    let isActive = false;
+    if (!_.isNil(activeFor)) {
+      const router = this.context.router;
+      const options = typeof activeFor === "string" ? [activeFor] : activeFor;
+      isActive = _.some(options, (opt) => router.isActive(opt, onlyActiveOnIndex));
+    }
+    const classOverrides = classNames({ active: isActive });
+
     return (
       <li className={className} >
-        <Link to={to} activeClassName="active" onlyActiveOnIndex={onlyActiveOnIndex}>
+        <Link
+          to={to}
+          activeClassName="active"
+          onlyActiveOnIndex={onlyActiveOnIndex}
+          className={classOverrides}
+        >
           <div className="image-container"
                dangerouslySetInnerHTML={trustIcon(icon)}/>
           <div>{title}</div>
@@ -49,10 +71,10 @@ export default class extends React.Component<{}, {}> {
   render() {
     return <nav className="navigation-bar">
       <ul className="navigation-bar__list">
-        <IconLink to="/overview" icon={homeIcon} title="Overview" />
+        <IconLink to="/overview" icon={homeIcon} title="Overview" activeFor="/node" />
         <IconLink to="/metrics" icon={metricsIcon} title="Metrics" />
-        <IconLink to="/databases" icon={databasesIcon} title="Databases"/>
-        <IconLink to="/jobs" icon={jobsIcon} title="Jobs"/>
+        <IconLink to="/databases" icon={databasesIcon} title="Databases" activeFor="/database" />
+        <IconLink to="/jobs" icon={jobsIcon} title="Jobs" />
       </ul>
       <ul className="navigation-bar__list navigation-bar__list--bottom">
         <IconLink to="/" icon={cockroachIcon} className="cockroach" />

--- a/pkg/ui/src/views/app/components/layoutSidebar/index.tsx
+++ b/pkg/ui/src/views/app/components/layoutSidebar/index.tsx
@@ -12,11 +12,10 @@ import databasesIcon from "!!raw-loader!assets/databases.svg";
 import jobsIcon from "!!raw-loader!assets/jobs.svg";
 
 interface IconLinkProps {
-  icon?: string;
+  icon: string;
   title?: string;
   to: string;
   activeFor?: string | string[];
-  onlyActiveOnIndex?: boolean;
   className?: string;
 }
 
@@ -27,7 +26,6 @@ interface IconLinkProps {
 class IconLink extends React.Component<IconLinkProps, {}> {
   static defaultProps = {
     className: "normal",
-    onlyActiveOnIndex: false,
   };
 
   static contextTypes = {
@@ -35,13 +33,13 @@ class IconLink extends React.Component<IconLinkProps, {}> {
   };
 
   render() {
-    const { icon, title, to, activeFor, onlyActiveOnIndex, className } = this.props;
+    const { icon, title, to, activeFor, className } = this.props;
 
     let isActive = false;
     if (!_.isNil(activeFor)) {
       const router = this.context.router;
       const options = typeof activeFor === "string" ? [activeFor] : activeFor;
-      isActive = _.some(options, (opt) => router.isActive(opt, onlyActiveOnIndex));
+      isActive = _.some(options, (opt) => router.isActive(opt, false));
     }
     const classOverrides = classNames({ active: isActive });
 
@@ -50,7 +48,6 @@ class IconLink extends React.Component<IconLinkProps, {}> {
         <Link
           to={to}
           activeClassName="active"
-          onlyActiveOnIndex={onlyActiveOnIndex}
           className={classOverrides}
         >
           <div className="image-container"

--- a/pkg/ui/src/views/app/components/layoutSidebar/index.tsx
+++ b/pkg/ui/src/views/app/components/layoutSidebar/index.tsx
@@ -24,8 +24,9 @@ interface IconLinkProps {
  * a string title.
  */
 class IconLink extends React.Component<IconLinkProps, {}> {
-  static defaultProps = {
+  static defaultProps: Partial<IconLinkProps> = {
     className: "normal",
+    activeFor: [],
   };
 
   static contextTypes = {
@@ -35,20 +36,14 @@ class IconLink extends React.Component<IconLinkProps, {}> {
   render() {
     const { icon, title, to, activeFor, className } = this.props;
 
-    let isActive = false;
-    if (!_.isNil(activeFor)) {
-      const router = this.context.router;
-      const options = typeof activeFor === "string" ? [activeFor] : activeFor;
-      isActive = _.some(options, (opt) => router.isActive(opt, false));
-    }
-    const classOverrides = classNames({ active: isActive });
-
+    const router = this.context.router;
+    const linkRoutes = [to].concat(activeFor);
+    const isActive = _.some(linkRoutes, (route) => router.isActive(route, false));
     return (
       <li className={className} >
         <Link
           to={to}
-          activeClassName="active"
-          className={classOverrides}
+          className={classNames({ active: isActive })}
         >
           <div className="image-container"
                dangerouslySetInnerHTML={trustIcon(icon)}/>


### PR DESCRIPTION
The route reorganization broke one of react-router's assumptions: that
logically nested pages are always on strictly-nested routes.  This
fixes the sidebar link highlighting for nested pages whose route
doesn't start with the exact route the link is going to.

Fixes: #24069
Release note: None

<img width="344" alt="screen shot 2018-04-11 at 3 46 24 pm" src="https://user-images.githubusercontent.com/793969/38639723-1a4ef4e4-3da0-11e8-98c9-d83ac070d7b0.png">
