### PR TITLE
sql: make `SHOW TRACE FOR <QUERY>` work with distsql

### DIFF
--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -601,11 +601,18 @@ func (ex *connExecutor) dispatchToExecutionEngine(
 	// If we use the optimizer and we are in "local" mode, don't try to
 	// distribute.
 	if !(useOptimizer && ex.sessionData.OptimizerMode == sessiondata.OptimizerLocal) {
-		useDistSQL, err = shouldUseDistSQL(
-			ctx, ex.sessionData.DistSQLMode, ex.server.cfg.DistSQLPlanner, planner)
+		ok, err := planner.prepareForDistSQLSupportCheck(ctx)
 		if err != nil {
 			res.SetError(err)
 			return nil
+		}
+		if ok {
+			useDistSQL, err = shouldUseDistSQL(
+				ctx, ex.sessionData.DistSQLMode, ex.server.cfg.DistSQLPlanner, planner.curPlan.plan)
+			if err != nil {
+				res.SetError(err)
+				return nil
+			}
 		}
 	}
 

--- a/pkg/sql/distsql_plan_csv.go
+++ b/pkg/sql/distsql_plan_csv.go
@@ -119,21 +119,22 @@ func (b *RowResultWriter) Err() error {
 // callbackResultWriter is a rowResultWriter that runs a callback function
 // on AddRow.
 type callbackResultWriter struct {
-	fn  func(ctx context.Context, row tree.Datums) error
-	err error
+	fn           func(ctx context.Context, row tree.Datums) error
+	rowsAffected int
+	err          error
 }
 
 var _ rowResultWriter = &callbackResultWriter{}
 
-// makeCallbackResultWriter creates a new callbackResultWriter.
+// newCallbackResultWriter creates a new callbackResultWriter.
 func newCallbackResultWriter(
 	fn func(ctx context.Context, row tree.Datums) error,
-) callbackResultWriter {
-	return callbackResultWriter{fn: fn}
+) *callbackResultWriter {
+	return &callbackResultWriter{fn: fn}
 }
 
-func (*callbackResultWriter) IncrementRowsAffected(n int) {
-	panic("IncrementRowsAffected not supported by callbackResultWriter")
+func (c *callbackResultWriter) IncrementRowsAffected(n int) {
+	c.rowsAffected += n
 }
 
 func (c *callbackResultWriter) AddRow(ctx context.Context, row tree.Datums) error {
@@ -496,7 +497,7 @@ func (dsp *DistSQLPlanner) loadCSVSamplingPlan(
 
 	recv := makeDistSQLReceiver(
 		ctx,
-		&rowResultWriter,
+		rowResultWriter,
 		tree.Rows,
 		nil, /* rangeCache */
 		nil, /* leaseCache */

--- a/pkg/sql/distsql_wrapper.go
+++ b/pkg/sql/distsql_wrapper.go
@@ -1,0 +1,103 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package sql
+
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/pkg/errors"
+)
+
+const distSQLWrapperBufferSize = 1024
+
+// distSQLWrapper is a planNode that runs the wrapped node through distSQL physical
+// planning and execution. The plan is assumed to be supported by distSQL.
+type distSQLWrapper struct {
+	// plan is the wrapped execution plan that will be executed in distSQL.
+	plan     planNode
+	stmtType tree.StatementType
+
+	resultWriter rowResultWriter
+	currentRow   tree.Datums
+	// resultRows is a buffered channel to which we write the distSQL results.
+	// Once the buffer fills up, the next write will block, allowing us to push
+	// back on distSQL processing and avoid running out of memory.
+	resultRows chan tree.Datums
+}
+
+// newDistSQLWrapper creates a new distSQLWrapper.
+//
+// Args:
+// plan: The wrapped execution plan to be physically planned and executed.
+// stmtType: The statement type of the statement represented by plan.
+func (p *planner) newDistSQLWrapper(plan planNode, stmtType tree.StatementType) planNode {
+	n := &distSQLWrapper{
+		plan:       plan,
+		stmtType:   stmtType,
+		resultRows: make(chan tree.Datums, distSQLWrapperBufferSize),
+	}
+	n.resultWriter = newCallbackResultWriter(func(ctx context.Context, row tree.Datums) error {
+		rowCopy := make(tree.Datums, len(row))
+		copy(rowCopy, row)
+		select {
+		case n.resultRows <- rowCopy:
+			return nil
+		case <-ctx.Done():
+			err := errors.Wrap(ctx.Err(), "context canceled while writing distSQLWrapper result")
+			n.resultWriter.SetError(err)
+			return err
+		}
+	})
+	return n
+}
+
+func (n *distSQLWrapper) startExec(params runParams) error {
+	execCfg := params.p.ExecCfg()
+	recv := makeDistSQLReceiver(
+		params.ctx,
+		n.resultWriter,
+		n.stmtType,
+		execCfg.RangeDescriptorCache,
+		execCfg.LeaseHolderCache,
+		params.p.txn,
+		func(ts hlc.Timestamp) {
+			_ = execCfg.Clock.Update(ts)
+		},
+	)
+	go func() {
+		execCfg.DistSQLPlanner.PlanAndRun(
+			params.ctx, params.p.txn, n.plan, recv, params.p.ExtendedEvalContext(),
+		)
+		close(n.resultRows)
+	}()
+	return nil
+}
+
+func (n *distSQLWrapper) Next(params runParams) (bool, error) {
+	if n.currentRow = <-n.resultRows; n.currentRow == nil {
+		return false, n.resultWriter.Err()
+	}
+	return true, nil
+}
+
+func (n *distSQLWrapper) Values() tree.Datums {
+	return n.currentRow
+}
+
+func (n *distSQLWrapper) Close(ctx context.Context) {
+	n.plan.Close(ctx)
+}

--- a/pkg/sql/expand_plan.go
+++ b/pkg/sql/expand_plan.go
@@ -139,9 +139,6 @@ func doExpandPlan(
 		explainParams := noParamsBase
 		explainParams.atTop = true
 		n.plan, err = doExpandPlan(ctx, p, explainParams, n.plan)
-		if err != nil {
-			return plan, err
-		}
 
 	case *showTraceNode:
 		// SHOW TRACE only shows the execution trace of the plan, and wants to do
@@ -149,15 +146,9 @@ func doExpandPlan(
 		showTraceParams := noParamsBase
 		showTraceParams.atTop = true
 		n.plan, err = doExpandPlan(ctx, p, showTraceParams, n.plan)
-		if err != nil {
-			return plan, err
-		}
 
 	case *showTraceReplicaNode:
 		n.plan, err = doExpandPlan(ctx, p, noParams, n.plan)
-		if err != nil {
-			return plan, err
-		}
 
 	case *explainPlanNode:
 		// EXPLAIN only shows the structure of the plan, and wants to do
@@ -677,6 +668,9 @@ func (p *planner) simplifyOrderings(plan planNode, usefulOrdering sqlbase.Column
 
 	case *serializeNode:
 		n.source = p.simplifyOrderings(n.source, nil).(batchedPlanNode)
+
+	case *distSQLWrapper:
+		n.plan = p.simplifyOrderings(n.plan, nil)
 
 	case *explainDistSQLNode:
 		n.plan = p.simplifyOrderings(n.plan, nil)

--- a/pkg/sql/expand_plan.go
+++ b/pkg/sql/expand_plan.go
@@ -146,6 +146,21 @@ func doExpandPlan(
 		showTraceParams := noParamsBase
 		showTraceParams.atTop = true
 		n.plan, err = doExpandPlan(ctx, p, showTraceParams, n.plan)
+		if err != nil {
+			return plan, err
+		}
+		// Check if we can use distSQL for the wrapped plan and this is not a kv
+		// trace. distSQL does not handle kv tracing because this option is not
+		// plumbed down to the tableReader level.
+		// TODO(asubiotto): Handle kv tracing in distSQL.
+		ok, err := p.prepareForDistSQLSupportCheck(ctx)
+		if ok && err == nil {
+			if useDistSQL, err := shouldUseDistSQL(
+				ctx, p.SessionData().DistSQLMode, p.ExecCfg().DistSQLPlanner, n.plan,
+			); useDistSQL && err == nil && !n.kvTracingEnabled {
+				n.plan = p.newDistSQLWrapper(n.plan, n.stmtType)
+			}
+		}
 
 	case *showTraceReplicaNode:
 		n.plan, err = doExpandPlan(ctx, p, noParams, n.plan)

--- a/pkg/sql/opt_filters.go
+++ b/pkg/sql/opt_filters.go
@@ -300,6 +300,11 @@ func (p *planner) propagateFilters(
 			return plan, extraFilter, err
 		}
 
+	case *distSQLWrapper:
+		if n.plan, err = p.triggerFilterPropagation(ctx, n.plan); err != nil {
+			return plan, extraFilter, err
+		}
+
 	case *explainDistSQLNode:
 		if n.plan, err = p.triggerFilterPropagation(ctx, n.plan); err != nil {
 			return plan, extraFilter, err

--- a/pkg/sql/opt_limits.go
+++ b/pkg/sql/opt_limits.go
@@ -170,6 +170,8 @@ func (p *planner) applyLimit(plan planNode, numRows int64, soft bool) {
 		if n.sourcePlan != nil {
 			p.applyLimit(n.sourcePlan, numRows, soft)
 		}
+	case *distSQLWrapper:
+		p.applyLimit(n.plan, numRows, soft)
 	case *explainDistSQLNode:
 		p.setUnlimited(n.plan)
 	case *showTraceNode:

--- a/pkg/sql/opt_needed.go
+++ b/pkg/sql/opt_needed.go
@@ -31,6 +31,9 @@ func setNeededColumns(plan planNode, needed []bool) {
 			setNeededColumns(n.sourcePlan, allColumns(n.sourcePlan))
 		}
 
+	case *distSQLWrapper:
+		setNeededColumns(n.plan, allColumns(n.plan))
+
 	case *explainDistSQLNode:
 		setNeededColumns(n.plan, allColumns(n.plan))
 

--- a/pkg/sql/plan.go
+++ b/pkg/sql/plan.go
@@ -176,6 +176,7 @@ var _ planNode = &dropViewNode{}
 var _ planNode = &dropSequenceNode{}
 var _ planNode = &zeroNode{}
 var _ planNode = &unaryNode{}
+var _ planNode = &distSQLWrapper{}
 var _ planNode = &explainDistSQLNode{}
 var _ planNode = &explainPlanNode{}
 var _ planNode = &showTraceNode{}
@@ -497,6 +498,9 @@ func startExec(params runParams, plan planNode) error {
 	o := planObserver{
 		enterNode: func(ctx context.Context, _ string, p planNode) (bool, error) {
 			switch p.(type) {
+			case *distSQLWrapper:
+				// Do not recurse: the plan is executed in distSQL.
+				return false, nil
 			case *explainPlanNode, *explainDistSQLNode:
 				// Do not recurse: we're not starting the plan if we just show its structure with EXPLAIN.
 				return false, nil

--- a/pkg/sql/plan_columns.go
+++ b/pkg/sql/plan_columns.go
@@ -124,6 +124,8 @@ func getPlanColumns(plan planNode, mut bool) sqlbase.ResultColumns {
 		return getPlanColumns(n.source, mut)
 	case *serializeNode:
 		return getPlanColumns(n.source, mut)
+	case *distSQLWrapper:
+		return getPlanColumns(n.plan, mut)
 	}
 
 	// Every other node has no columns in their results.

--- a/pkg/sql/plan_spans.go
+++ b/pkg/sql/plan_spans.go
@@ -66,6 +66,8 @@ func collectSpans(params runParams, plan planNode) (reads, writes roachpb.Spans,
 		return collectSpans(params, n.plan)
 	case *distinctNode:
 		return collectSpans(params, n.plan)
+	case *distSQLWrapper:
+		return collectSpans(params, n.plan)
 	case *explainDistSQLNode:
 		return collectSpans(params, n.plan)
 	case *explainPlanNode:

--- a/pkg/sql/walk.go
+++ b/pkg/sql/walk.go
@@ -477,6 +477,9 @@ func (v *planVisitor) visit(plan planNode) {
 			v.visit(n.plan)
 		}
 
+	case *distSQLWrapper:
+		v.visit(n.plan)
+
 	case *explainDistSQLNode:
 		v.visit(n.plan)
 
@@ -564,7 +567,7 @@ var planNodeNames = map[reflect.Type]string{
 	reflect.TypeOf(&createDatabaseNode{}):       "create database",
 	reflect.TypeOf(&createIndexNode{}):          "create index",
 	reflect.TypeOf(&createTableNode{}):          "create table",
-	reflect.TypeOf(&CreateUserNode{}):           "create user | role",
+	reflect.TypeOf(&CreateUserNode{}):           "create user/role",
 	reflect.TypeOf(&createViewNode{}):           "create view",
 	reflect.TypeOf(&createSequenceNode{}):       "create sequence",
 	reflect.TypeOf(&createStatsNode{}):          "create statistics",
@@ -576,8 +579,9 @@ var planNodeNames = map[reflect.Type]string{
 	reflect.TypeOf(&dropTableNode{}):            "drop table",
 	reflect.TypeOf(&dropViewNode{}):             "drop view",
 	reflect.TypeOf(&dropSequenceNode{}):         "drop sequence",
-	reflect.TypeOf(&DropUserNode{}):             "drop user | role",
-	reflect.TypeOf(&explainDistSQLNode{}):       "explain dist_sql",
+	reflect.TypeOf(&DropUserNode{}):             "drop user/role",
+	reflect.TypeOf(&distSQLWrapper{}):           "distsql query",
+	reflect.TypeOf(&explainDistSQLNode{}):       "explain distsql",
 	reflect.TypeOf(&explainPlanNode{}):          "explain plan",
 	reflect.TypeOf(&showTraceNode{}):            "show trace for",
 	reflect.TypeOf(&showTraceReplicaNode{}):     "show trace for",


### PR DESCRIPTION
Closes #16562

Previously, to trace distSQL queries, a user would have had to set
session tracing on and then run `SHOW TRACE FOR SESSION`, ignoring
unrelated output. The reason for this limitation is that the
`showTraceNode` wraps the plan with a bunch of distSQL-incompatible
nodes and so the whole query is run through local execution.

The second commit leverages the distSQLNode introduced in the first commit to run the distSQL-compatible subplan through distSQL.

I still have a couple of `TODO`s with some questions and would appreciate a double-check on all the stuff I added with the `distSQLNode` since I am not very familiar with the planning code.