### PR TITLE
opt: Store root expression directly in Memo

### DIFF
--- a/pkg/sql/opt/memo/expr_view.go
+++ b/pkg/sql/opt/memo/expr_view.go
@@ -83,6 +83,10 @@ type ExprView struct {
 // groups, and so on.
 func MakeExprView(mem *Memo, best BestExprID) ExprView {
 	mgrp := mem.group(best.group)
+	if best.ordinal == normBestOrdinal {
+		// Handle MakeNormExprView case.
+		return ExprView{mem: mem, group: best.group, op: mgrp.normExpr.op, best: best.ordinal}
+	}
 	be := mgrp.bestExpr(best.ordinal)
 	return ExprView{mem: mem, group: best.group, op: be.op, best: best.ordinal}
 }
@@ -95,8 +99,7 @@ func MakeExprView(mem *Memo, best BestExprID) ExprView {
 // bestExprs have been populated). See the struct comment in factory.go for
 // more details about the normalized expression tree.
 func MakeNormExprView(mem *Memo, group GroupID) ExprView {
-	op := mem.NormExpr(group).op
-	return ExprView{mem: mem, group: group, op: op, best: normBestOrdinal}
+	return MakeExprView(mem, BestExprID{group: group, ordinal: normBestOrdinal})
 }
 
 // Operator returns the type of the expression.
@@ -180,6 +183,10 @@ func (ev ExprView) lookupBestExpr() *BestExpr {
 	return ev.mem.group(ev.group).bestExpr(ev.best)
 }
 
+func (ev ExprView) bestExprID() BestExprID {
+	return BestExprID{group: ev.group, ordinal: ev.best}
+}
+
 // --------------------------------------------------------------------
 // String representation.
 // --------------------------------------------------------------------
@@ -198,7 +205,7 @@ const (
 	ExprFmtShowAll ExprFmtFlags = 0
 
 	// ExprFmtHideOuterCols does not show outer columns in the output.
-	ExprFmtHideOuterCols ExprFmtFlags = 1 << iota
+	ExprFmtHideOuterCols ExprFmtFlags = 1 << (iota - 1)
 
 	// ExprFmtHideStats does not show statistics in the output.
 	ExprFmtHideStats

--- a/pkg/sql/opt/memo/group.go
+++ b/pkg/sql/opt/memo/group.go
@@ -70,6 +70,12 @@ func makeMemoGroup(id GroupID, norm Expr) group {
 	return group{id: id, normExpr: norm}
 }
 
+// isScalarGroup returns true if this group contains scalar expressions and not
+// relational expressions.
+func (g *group) isScalarGroup() bool {
+	return isScalarLookup[g.normExpr.op]
+}
+
 // exprCount returns the number of logically-equivalent expressions in the
 // group.
 func (g *group) exprCount() int {

--- a/pkg/sql/opt/memo/memo_test.go
+++ b/pkg/sql/opt/memo/memo_test.go
@@ -38,7 +38,7 @@ func runDataDrivenTest(t *testing.T, path string, fmtFlags memo.ExprFmtFlags) {
 		catalog := testutils.NewTestCatalog()
 		datadriven.RunTest(t, path, func(d *datadriven.TestData) string {
 			tester := testutils.NewOptTester(catalog, d.Input)
-			tester.Flags.Format = fmtFlags
+			tester.Flags.ExprFormat = fmtFlags
 			return tester.RunCommand(t, d)
 		})
 	})

--- a/pkg/sql/opt/memo/testdata/memo
+++ b/pkg/sql/opt/memo/testdata/memo
@@ -144,42 +144,52 @@ WHERE a.y=1 AND a.x::string=b.x
 ORDER BY y
 LIMIT 10
 ----
-[presentation: y:2,x:3,column5:5] [ordering: +2]
-memo
+memo (optimized)
  ├── G1: (project G2 G3)
- │    ├── "" [cost=4600.00]
- │    │    └── best: (project G2 G3)
- │    └── "[presentation: y:2,x:3,column5:5] [ordering: +2]" [cost=4600.00]
- │         └── best: (project G2="o:+2" G3)
+ │    ├── "[presentation: y:2,x:3,column5:5] [ordering: +2]"
+ │    │    ├── best: (project G2="[ordering: +2]" G3)
+ │    │    └── cost: 4600.00
+ │    └── ""
+ │         ├── best: (project G2 G3)
+ │         └── cost: 4600.00
  ├── G2: (limit G4 G5 +2)
- │    ├── "" [cost=4600.00]
- │    │    └── best: (limit G4="o:+2" G5 +2)
- │    └── "[ordering: +2]" [cost=4600.00]
- │         └── best: (limit G4="o:+2" G5 +2)
+ │    ├── ""
+ │    │    ├── best: (limit G4="[ordering: +2]" G5 +2)
+ │    │    └── cost: 4600.00
+ │    └── "[ordering: +2]"
+ │         ├── best: (limit G4="[ordering: +2]" G5 +2)
+ │         └── cost: 4600.00
  ├── G3: (projections G18 G16 G6)
  ├── G4: (project G7 G8)
- │    ├── "" [cost=2100.00]
- │    │    └── best: (project G7 G8)
- │    └── "[ordering: +2]" [cost=4600.00]
- │         └── best: (sort G4)
+ │    ├── ""
+ │    │    ├── best: (project G7 G8)
+ │    │    └── cost: 2100.00
+ │    └── "[ordering: +2]"
+ │         ├── best: (sort G4)
+ │         └── cost: 4600.00
  ├── G5: (const 10)
  ├── G6: (plus G18 G19)
  ├── G7: (inner-join G9 G10 G11)
- │    ├── "" [cost=2100.00]
- │    │    └── best: (inner-join G9 G10 G11)
- │    └── "[ordering: +2]" [cost=4600.00]
- │         └── best: (sort G7)
+ │    ├── ""
+ │    │    ├── best: (inner-join G9 G10 G11)
+ │    │    └── cost: 2100.00
+ │    └── "[ordering: +2]"
+ │         ├── best: (sort G7)
+ │         └── cost: 4600.00
  ├── G8: (projections G18 G16)
  ├── G9: (select G12 G13)
- │    └── "" [cost=1100.00]
- │         └── best: (select G12 G13)
+ │    └── ""
+ │         ├── best: (select G12 G13)
+ │         └── cost: 1100.00
  ├── G10: (scan b)
- │    └── "" [cost=1000.00]
- │         └── best: (scan b)
+ │    └── ""
+ │         ├── best: (scan b)
+ │         └── cost: 1000.00
  ├── G11: (filters G14)
  ├── G12: (scan a)
- │    └── "" [cost=1000.00]
- │         └── best: (scan a)
+ │    └── ""
+ │         ├── best: (scan a)
+ │         └── cost: 1000.00
  ├── G13: (filters G15)
  ├── G14: (eq G16 G17)
  ├── G15: (eq G18 G19)
@@ -195,18 +205,20 @@ SELECT 1, 1+z, now()::timestamp, now()::timestamptz
 FROM b
 WHERE z=1 AND concat(x, 'foo', x)=concat(x, 'foo', x)
 ----
-[presentation: column3:3,column4:4,column5:5,column6:6]
-memo
+memo (optimized)
  ├── G1: (project G2 G3)
- │    └── "[presentation: column3:3,column4:4,column5:5,column6:6]" [cost=1100.00]
- │         └── best: (project G2 G3)
+ │    └── "[presentation: column3:3,column4:4,column5:5,column6:6]"
+ │         ├── best: (project G2 G3)
+ │         └── cost: 1100.00
  ├── G2: (select G4 G5)
- │    └── "" [cost=1100.00]
- │         └── best: (select G4 G5)
+ │    └── ""
+ │         ├── best: (select G4 G5)
+ │         └── cost: 1100.00
  ├── G3: (projections G6 G7 G8 G11)
  ├── G4: (scan b)
- │    └── "" [cost=1000.00]
- │         └── best: (scan b)
+ │    └── ""
+ │         ├── best: (scan b)
+ │         └── cost: 1000.00
  ├── G5: (filters G9 G10)
  ├── G6: (const 1)
  ├── G7: (plus G12 G13)
@@ -224,22 +236,25 @@ memo
 memo
 SELECT x FROM a WHERE x = 1 AND x+y = 1
 ----
-[presentation: x:1]
-memo
+memo (optimized)
  ├── G1: (project G2 G3)
- │    └── "[presentation: x:1]" [cost=110.00]
- │         └── best: (project G2 G3)
+ │    └── "[presentation: x:1]"
+ │         ├── best: (project G2 G3)
+ │         └── cost: 110.00
  ├── G2: (select G4 G5) (select G6 G7)
- │    └── "" [cost=110.00]
- │         └── best: (select G6 G7)
+ │    └── ""
+ │         ├── best: (select G6 G7)
+ │         └── cost: 110.00
  ├── G3: (projections G12)
  ├── G4: (scan a)
- │    └── "" [cost=1000.00]
- │         └── best: (scan a)
+ │    └── ""
+ │         ├── best: (scan a)
+ │         └── cost: 1000.00
  ├── G5: (filters G8 G9)
  ├── G6: (scan a,constrained)
- │    └── "" [cost=100.00]
- │         └── best: (scan a,constrained)
+ │    └── ""
+ │         ├── best: (scan a,constrained)
+ │         └── cost: 100.00
  ├── G7: (filters G9)
  ├── G8: (eq G12 G11)
  ├── G9: (eq G10 G11)
@@ -252,10 +267,11 @@ memo raw-memo
 SELECT x FROM a WHERE x = 1 AND x+y = 1
 ----
 root: G12, [presentation: x:1]
-memo
+memo (optimized)
  ├── G1: (scan a)
- │    └── "" [cost=1000.00]
- │         └── best: (scan a)
+ │    └── ""
+ │         ├── best: (scan a)
+ │         └── cost: 1000.00
  ├── G2: (variable a.x)
  ├── G3: (const 1)
  ├── G4: (eq G2 G3)
@@ -265,14 +281,17 @@ memo
  ├── G8: (and G4 G7)
  ├── G9: (filters G4 G7)
  ├── G10: (select G1 G9) (select G15 G14)
- │    └── "" [cost=110.00]
- │         └── best: (select G15 G14)
+ │    └── ""
+ │         ├── best: (select G15 G14)
+ │         └── cost: 110.00
  ├── G11: (projections G2)
  ├── G12: (project G10 G11)
- │    └── "[presentation: x:1]" [cost=110.00]
- │         └── best: (project G10 G11)
+ │    └── "[presentation: x:1]"
+ │         ├── best: (project G10 G11)
+ │         └── cost: 110.00
  ├── G13: (true)
  ├── G14: (filters G7)
  └── G15: (scan a,constrained)
-      └── "" [cost=100.00]
-           └── best: (scan a,constrained)
+      └── ""
+           ├── best: (scan a,constrained)
+           └── cost: 100.00

--- a/pkg/sql/opt/norm/norm_test.go
+++ b/pkg/sql/opt/norm/norm_test.go
@@ -46,7 +46,7 @@ func TestNormRules(t *testing.T) {
 		catalog := testutils.NewTestCatalog()
 		datadriven.RunTest(t, path, func(d *datadriven.TestData) string {
 			tester := testutils.NewOptTester(catalog, d.Input)
-			tester.Flags.Format = fmtFlags
+			tester.Flags.ExprFormat = fmtFlags
 			return tester.RunCommand(t, d)
 		})
 	})

--- a/pkg/sql/opt/optbuilder/builder_test.go
+++ b/pkg/sql/opt/optbuilder/builder_test.go
@@ -65,7 +65,7 @@ func TestBuilder(t *testing.T) {
 			var err error
 
 			tester := testutils.NewOptTester(catalog, d.Input)
-			tester.Flags.Format = memo.ExprFmtHideAll
+			tester.Flags.ExprFormat = memo.ExprFmtHideAll
 
 			for _, arg := range d.CmdArgs {
 				key, vals := arg.Key, arg.Vals

--- a/pkg/sql/opt/xform/optimizer.go
+++ b/pkg/sql/opt/xform/optimizer.go
@@ -106,7 +106,9 @@ func (o *Optimizer) Memo() *memo.Memo {
 func (o *Optimizer) Optimize(root memo.GroupID, requiredProps *memo.PhysicalProps) memo.ExprView {
 	required := o.mem.InternPhysicalProps(requiredProps)
 	state := o.optimizeGroup(root, required)
-	return memo.MakeExprView(o.mem, state.best)
+	ev := memo.MakeExprView(o.mem, state.best)
+	o.mem.SetRoot(ev)
+	return ev
 }
 
 // optimizeGroup enumerates expression trees rooted in the given memo group and

--- a/pkg/sql/opt/xform/optimizer_test.go
+++ b/pkg/sql/opt/xform/optimizer_test.go
@@ -58,7 +58,7 @@ func runDataDrivenTest(t *testing.T, path string, fmtFlags memo.ExprFmtFlags) {
 		catalog := testutils.NewTestCatalog()
 		datadriven.RunTest(t, path, func(d *datadriven.TestData) string {
 			tester := testutils.NewOptTester(catalog, d.Input)
-			tester.Flags.Format = fmtFlags
+			tester.Flags.ExprFormat = fmtFlags
 			return tester.RunCommand(t, d)
 		})
 	})

--- a/pkg/sql/opt/xform/testdata/physprops/ordering
+++ b/pkg/sql/opt/xform/testdata/physprops/ordering
@@ -186,24 +186,29 @@ project
 memo
 SELECT y, x-1 FROM a WHERE x>y ORDER BY x, y DESC
 ----
-[presentation: y:2,column5:5] [ordering: +1,-2]
-memo
+memo (optimized)
  ├── G1: (project G2 G3)
- │    ├── "" [cost=1100.00]
- │    │    └── best: (project G2 G3)
- │    └── "[presentation: y:2,column5:5] [ordering: +1,-2]" [cost=1100.00]
- │         └── best: (project G2="o:+1,-2" G3)
+ │    ├── "[presentation: y:2,column5:5] [ordering: +1,-2]"
+ │    │    ├── best: (project G2="[ordering: +1,-2]" G3)
+ │    │    └── cost: 1100.00
+ │    └── ""
+ │         ├── best: (project G2 G3)
+ │         └── cost: 1100.00
  ├── G2: (select G4 G5)
- │    ├── "" [cost=1100.00]
- │    │    └── best: (select G4 G5)
- │    └── "[ordering: +1,-2]" [cost=1100.00]
- │         └── best: (select G4="o:+1,-2" G5)
+ │    ├── ""
+ │    │    ├── best: (select G4 G5)
+ │    │    └── cost: 1100.00
+ │    └── "[ordering: +1,-2]"
+ │         ├── best: (select G4="[ordering: +1,-2]" G5)
+ │         └── cost: 1100.00
  ├── G3: (projections G10 G6 G9)
  ├── G4: (scan a)
- │    ├── "" [cost=1000.00]
- │    │    └── best: (scan a)
- │    └── "[ordering: +1,-2]" [cost=1000.00]
- │         └── best: (scan a)
+ │    ├── ""
+ │    │    ├── best: (scan a)
+ │    │    └── cost: 1000.00
+ │    └── "[ordering: +1,-2]"
+ │         ├── best: (scan a)
+ │         └── cost: 1000.00
  ├── G5: (filters G7)
  ├── G6: (minus G9 G8)
  ├── G7: (gt G9 G10)
@@ -235,24 +240,29 @@ sort
 memo
 SELECT y, z FROM a WHERE x>y ORDER BY y
 ----
-[presentation: y:2,z:3] [ordering: +2]
-memo
+memo (optimized)
  ├── G1: (project G2 G3)
- │    ├── "" [cost=1100.00]
- │    │    └── best: (project G2 G3)
- │    └── "[presentation: y:2,z:3] [ordering: +2]" [cost=1125.00]
- │         └── best: (sort G1)
+ │    ├── "[presentation: y:2,z:3] [ordering: +2]"
+ │    │    ├── best: (sort G1)
+ │    │    └── cost: 1125.00
+ │    └── ""
+ │         ├── best: (project G2 G3)
+ │         └── cost: 1100.00
  ├── G2: (select G4 G5)
- │    ├── "" [cost=1100.00]
- │    │    └── best: (select G4 G5)
- │    └── "[ordering: +2]" [cost=1125.00]
- │         └── best: (sort G2)
+ │    ├── ""
+ │    │    ├── best: (select G4 G5)
+ │    │    └── cost: 1100.00
+ │    └── "[ordering: +2]"
+ │         ├── best: (sort G2)
+ │         └── cost: 1125.00
  ├── G3: (projections G9 G6)
  ├── G4: (scan a)
- │    ├── "" [cost=1000.00]
- │    │    └── best: (scan a)
- │    └── "[ordering: +2]" [cost=1250.00]
- │         └── best: (sort G4)
+ │    ├── ""
+ │    │    ├── best: (scan a)
+ │    │    └── cost: 1000.00
+ │    └── "[ordering: +2]"
+ │         ├── best: (sort G4)
+ │         └── cost: 1250.00
  ├── G5: (filters G7)
  ├── G6: (variable a.z)
  ├── G7: (gt G8 G9)

--- a/pkg/sql/opt/xform/testdata/rules/limit
+++ b/pkg/sql/opt/xform/testdata/rules/limit
@@ -108,18 +108,20 @@ limit
 memo
 SELECT s FROM a WHERE s='foo' LIMIT 1
 ----
-[presentation: s:4]
-memo
+memo (optimized)
  ├── G1: (limit G2 G3 ) (scan a@s_idx,constrained,lim=1) (scan a@si_idx,constrained,lim=1)
- │    └── "[presentation: s:4]" [cost=1.00]
- │         └── best: (scan a@s_idx,constrained,lim=1)
+ │    └── "[presentation: s:4]"
+ │         ├── best: (scan a@s_idx,constrained,lim=1)
+ │         └── cost: 1.00
  ├── G2: (select G4 G5) (scan a@s_idx,constrained) (scan a@si_idx,constrained)
- │    └── "" [cost=100.00]
- │         └── best: (scan a@s_idx,constrained)
+ │    └── ""
+ │         ├── best: (scan a@s_idx,constrained)
+ │         └── cost: 100.00
  ├── G3: (const 1)
  ├── G4: (scan a) (scan a@s_idx) (scan a@si_idx)
- │    └── "" [cost=1000.00]
- │         └── best: (scan a)
+ │    └── ""
+ │         ├── best: (scan a)
+ │         └── cost: 1000.00
  ├── G5: (filters G6)
  ├── G6: (eq G7 G8)
  ├── G7: (variable a.s)

--- a/pkg/sql/opt/xform/testdata/rules/scan
+++ b/pkg/sql/opt/xform/testdata/rules/scan
@@ -45,13 +45,14 @@ scan a@s_idx
 memo
 SELECT s, i, f FROM a ORDER BY s, k, i
 ----
-[presentation: s:4,i:2,f:3] [ordering: +4,+1,+2]
-memo
+memo (optimized)
  └── G1: (scan a) (scan a@s_idx)
-      ├── "" [cost=1000.00]
-      │    └── best: (scan a)
-      └── "[presentation: s:4,i:2,f:3] [ordering: +4,+1,+2]" [cost=1000.00]
-           └── best: (scan a@s_idx)
+      ├── "[presentation: s:4,i:2,f:3] [ordering: +4,+1,+2]"
+      │    ├── best: (scan a@s_idx)
+      │    └── cost: 1000.00
+      └── ""
+           ├── best: (scan a)
+           └── cost: 1000.00
 
 # Scan of primary index is lowest cost.
 opt
@@ -65,13 +66,14 @@ scan a
 memo
 SELECT s, i, f FROM a ORDER BY k, i, s
 ----
-[presentation: s:4,i:2,f:3] [ordering: +1,+2,+4]
-memo
+memo (optimized)
  └── G1: (scan a) (scan a@s_idx)
-      ├── "" [cost=1000.00]
-      │    └── best: (scan a)
-      └── "[presentation: s:4,i:2,f:3] [ordering: +1,+2,+4]" [cost=1000.00]
-           └── best: (scan a)
+      ├── "[presentation: s:4,i:2,f:3] [ordering: +1,+2,+4]"
+      │    ├── best: (scan a)
+      │    └── cost: 1000.00
+      └── ""
+           ├── best: (scan a)
+           └── cost: 1000.00
 
 # Secondary index has right order, but is not covering.
 opt
@@ -86,13 +88,14 @@ sort
 memo
 SELECT s, j FROM a ORDER BY s
 ----
-[presentation: s:4,j:5] [ordering: +4]
-memo
+memo (optimized)
  └── G1: (scan a) (scan a@si_idx)
-      ├── "" [cost=1000.00]
-      │    └── best: (scan a)
-      └── "[presentation: s:4,j:5] [ordering: +4]" [cost=1250.00]
-           └── best: (sort G1)
+      ├── "[presentation: s:4,j:5] [ordering: +4]"
+      │    ├── best: (sort G1)
+      │    └── cost: 1250.00
+      └── ""
+           ├── best: (scan a)
+           └── cost: 1000.00
 
 # Consider three different indexes, and pick index with multiple keys.
 opt
@@ -106,29 +109,32 @@ scan a@si_idx
 memo
 SELECT i, k FROM a ORDER BY s DESC, i, k
 ----
-[presentation: i:2,k:1] [ordering: -4,+2,+1]
-memo
+memo (optimized)
  └── G1: (scan a) (scan a@s_idx) (scan a@si_idx)
-      ├── "" [cost=1000.00]
-      │    └── best: (scan a)
-      └── "[presentation: i:2,k:1] [ordering: -4,+2,+1]" [cost=1000.00]
-           └── best: (scan a@si_idx)
+      ├── "[presentation: i:2,k:1] [ordering: -4,+2,+1]"
+      │    ├── best: (scan a@si_idx)
+      │    └── cost: 1000.00
+      └── ""
+           ├── best: (scan a)
+           └── cost: 1000.00
 
 memo
 SELECT i, k FROM a WHERE s >= 'foo'
 ----
-[presentation: i:2,k:1]
-memo
+memo (optimized)
  ├── G1: (project G2 G3)
- │    └── "[presentation: i:2,k:1]" [cost=100.00]
- │         └── best: (project G2 G3)
+ │    └── "[presentation: i:2,k:1]"
+ │         ├── best: (project G2 G3)
+ │         └── cost: 100.00
  ├── G2: (select G4 G5) (scan a@s_idx,constrained) (scan a@si_idx,constrained)
- │    └── "" [cost=100.00]
- │         └── best: (scan a@s_idx,constrained)
+ │    └── ""
+ │         ├── best: (scan a@s_idx,constrained)
+ │         └── cost: 100.00
  ├── G3: (projections G6 G7)
  ├── G4: (scan a) (scan a@s_idx) (scan a@si_idx)
- │    └── "" [cost=1000.00]
- │         └── best: (scan a)
+ │    └── ""
+ │         ├── best: (scan a)
+ │         └── cost: 1000.00
  ├── G5: (filters G8)
  ├── G6: (variable a.i)
  ├── G7: (variable a.k)

--- a/pkg/sql/opt/xform/testdata/rules/select
+++ b/pkg/sql/opt/xform/testdata/rules/select
@@ -38,14 +38,15 @@ scan a
 memo
 SELECT k FROM a WHERE k = 1
 ----
-[presentation: k:1]
-memo
+memo (optimized)
  ├── G1: (select G2 G3) (scan a,constrained)
- │    └── "[presentation: k:1]" [cost=100.00]
- │         └── best: (scan a,constrained)
+ │    └── "[presentation: k:1]"
+ │         ├── best: (scan a,constrained)
+ │         └── cost: 100.00
  ├── G2: (scan a) (scan a@u) (scan a@v)
- │    └── "" [cost=1000.00]
- │         └── best: (scan a)
+ │    └── ""
+ │         ├── best: (scan a)
+ │         └── cost: 1000.00
  ├── G3: (filters G4)
  ├── G4: (eq G5 G6)
  ├── G5: (variable a.k)
@@ -67,18 +68,20 @@ project
 memo
 SELECT k FROM a WHERE v > 1
 ----
-[presentation: k:1]
-memo
+memo (optimized)
  ├── G1: (project G2 G3)
- │    └── "[presentation: k:1]" [cost=100.00]
- │         └── best: (project G2 G3)
+ │    └── "[presentation: k:1]"
+ │         ├── best: (project G2 G3)
+ │         └── cost: 100.00
  ├── G2: (select G4 G5) (scan a@v,constrained)
- │    └── "" [cost=100.00]
- │         └── best: (scan a@v,constrained)
+ │    └── ""
+ │         ├── best: (scan a@v,constrained)
+ │         └── cost: 100.00
  ├── G3: (projections G6)
  ├── G4: (scan a) (scan a@u) (scan a@v)
- │    └── "" [cost=1000.00]
- │         └── best: (scan a)
+ │    └── ""
+ │         ├── best: (scan a)
+ │         └── cost: 1000.00
  ├── G5: (filters G7)
  ├── G6: (variable a.k)
  ├── G7: (gt G8 G9)
@@ -101,22 +104,25 @@ project
 memo
 SELECT k FROM a WHERE u = 1 AND k = 5
 ----
-[presentation: k:1]
-memo
+memo (optimized)
  ├── G1: (project G2 G3)
- │    └── "[presentation: k:1]" [cost=100.00]
- │         └── best: (project G2 G3)
+ │    └── "[presentation: k:1]"
+ │         ├── best: (project G2 G3)
+ │         └── cost: 100.00
  ├── G2: (select G4 G5) (select G6 G7) (scan a@u,constrained)
- │    └── "" [cost=100.00]
- │         └── best: (scan a@u,constrained)
+ │    └── ""
+ │         ├── best: (scan a@u,constrained)
+ │         └── cost: 100.00
  ├── G3: (projections G10)
  ├── G4: (scan a) (scan a@u) (scan a@v)
- │    └── "" [cost=1000.00]
- │         └── best: (scan a)
+ │    └── ""
+ │         ├── best: (scan a)
+ │         └── cost: 1000.00
  ├── G5: (filters G9 G8)
  ├── G6: (scan a,constrained)
- │    └── "" [cost=100.00]
- │         └── best: (scan a,constrained)
+ │    └── ""
+ │         ├── best: (scan a,constrained)
+ │         └── cost: 100.00
  ├── G7: (filters G9)
  ├── G8: (eq G10 G11)
  ├── G9: (eq G12 G13)
@@ -151,22 +157,25 @@ project
 memo
 SELECT k FROM a WHERE u = 1 AND k+u = 1
 ----
-[presentation: k:1]
-memo
+memo (optimized)
  ├── G1: (project G2 G3)
- │    └── "[presentation: k:1]" [cost=110.00]
- │         └── best: (project G2 G3)
+ │    └── "[presentation: k:1]"
+ │         ├── best: (project G2 G3)
+ │         └── cost: 110.00
  ├── G2: (select G4 G5) (select G6 G7)
- │    └── "" [cost=110.00]
- │         └── best: (select G6 G7)
+ │    └── ""
+ │         ├── best: (select G6 G7)
+ │         └── cost: 110.00
  ├── G3: (projections G12)
  ├── G4: (scan a) (scan a@u) (scan a@v)
- │    └── "" [cost=1000.00]
- │         └── best: (scan a)
+ │    └── ""
+ │         ├── best: (scan a)
+ │         └── cost: 1000.00
  ├── G5: (filters G8 G9)
  ├── G6: (scan a@u,constrained)
- │    └── "" [cost=100.00]
- │         └── best: (scan a@u,constrained)
+ │    └── ""
+ │         ├── best: (scan a@u,constrained)
+ │         └── cost: 100.00
  ├── G7: (filters G9)
  ├── G8: (eq G13 G11)
  ├── G9: (eq G10 G11)
@@ -198,26 +207,30 @@ project
 memo
 SELECT k FROM a WHERE u = 1 AND v = 5
 ----
-[presentation: k:1]
-memo
+memo (optimized)
  ├── G1: (project G2 G3)
- │    └── "[presentation: k:1]" [cost=110.00]
- │         └── best: (project G2 G3)
+ │    └── "[presentation: k:1]"
+ │         ├── best: (project G2 G3)
+ │         └── cost: 110.00
  ├── G2: (select G4 G5) (select G6 G7) (select G8 G9)
- │    └── "" [cost=110.00]
- │         └── best: (select G6 G7)
+ │    └── ""
+ │         ├── best: (select G6 G7)
+ │         └── cost: 110.00
  ├── G3: (projections G10)
  ├── G4: (scan a) (scan a@u) (scan a@v)
- │    └── "" [cost=1000.00]
- │         └── best: (scan a)
+ │    └── ""
+ │         ├── best: (scan a)
+ │         └── cost: 1000.00
  ├── G5: (filters G12 G11)
  ├── G6: (scan a@u,constrained)
- │    └── "" [cost=100.00]
- │         └── best: (scan a@u,constrained)
+ │    └── ""
+ │         ├── best: (scan a@u,constrained)
+ │         └── cost: 100.00
  ├── G7: (filters G11)
  ├── G8: (scan a@v,constrained)
- │    └── "" [cost=100.00]
- │         └── best: (scan a@v,constrained)
+ │    └── ""
+ │         ├── best: (scan a@v,constrained)
+ │         └── cost: 100.00
  ├── G9: (filters G12)
  ├── G10: (variable a.k)
  ├── G11: (eq G13 G14)

--- a/pkg/sql/opt_index_selection.go
+++ b/pkg/sql/opt_index_selection.go
@@ -145,7 +145,7 @@ func (p *planner) selectIndex(
 		if err != nil {
 			return nil, err
 		}
-		filterExpr := optimizer.Optimize(filterGroup, &memo.PhysicalProps{})
+		filterExpr := memo.MakeNormExprView(optimizer.Memo(), filterGroup)
 		for _, c := range candidates {
 			if err := c.makeIndexConstraints(
 				optimizer, filterExpr, p.EvalContext(),
@@ -245,7 +245,7 @@ func (p *planner) selectIndex(
 	s.origFilter = s.filter
 	if s.filter != nil {
 		remGroup := c.ic.RemainingFilter()
-		remEv := optimizer.Optimize(remGroup, &memo.PhysicalProps{})
+		remEv := memo.MakeNormExprView(optimizer.Memo(), remGroup)
 		if remEv.Operator() == opt.TrueOp {
 			s.filter = nil
 		} else {

--- a/pkg/sql/opt_index_selection_test.go
+++ b/pkg/sql/opt_index_selection_test.go
@@ -104,7 +104,7 @@ func makeSpans(
 	if err != nil {
 		t.Fatal(err)
 	}
-	filterExpr := o.Optimize(filterGroup, &memo.PhysicalProps{})
+	filterExpr := memo.MakeNormExprView(o.Memo(), filterGroup)
 	err = c.makeIndexConstraints(o, filterExpr, p.EvalContext())
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
Currently, the memo's root expression is maintained outside the memo.
There are a few cases (like printing the Memo) where having it
available in the memo would be convenient. This change sets the root
expression (defined as the root of the lowest cost expression tree)
just after optimization is complete. The memo formatting code now
uses that information directly. Future PR's will make further usage
of the root.

Release note: None