### PR TITLE
opt: Fix flaky test

### DIFF
--- a/pkg/sql/opt/memo/private_storage_test.go
+++ b/pkg/sql/opt/memo/private_storage_test.go
@@ -272,7 +272,7 @@ func TestPrivateStorageAllocations(t *testing.T) {
 	datum := tree.NewDInt(1)
 	typ := types.Int
 
-	result := testutils.TestNoMallocs(func() {
+	testutils.TestNoMallocs(t, func() {
 		ps.internColumnID(colID)
 		ps.internColSet(colSet)
 		ps.internColList(colList)
@@ -284,10 +284,6 @@ func TestPrivateStorageAllocations(t *testing.T) {
 		ps.internType(typ)
 		ps.internTypedExpr(datum)
 	})
-
-	if !result {
-		t.Errorf("intern methods should not allocate after initial add")
-	}
 }
 
 func BenchmarkPrivateStorage(b *testing.B) {


### PR DESCRIPTION
Update the TestNoMallocs to use the SucceedsSoon method in order
to repeatedly retry until zero memory allocations are detected.

Release note: None