### PR TITLE
cli: fully support self and cyclic references in dump

### DIFF
--- a/pkg/cli/dump_test.go
+++ b/pkg/cli/dump_test.go
@@ -82,18 +82,14 @@ func TestDumpData(t *testing.T) {
 			}
 			if d.Cmd == "dump" && d.Input != "noroundtrip" {
 				if s != d.Expected {
-					d.Fatalf(t, "unexpected: %s\nexpected: %s", s, d.Expected)
+					return s
 				}
 
-				if out, err := c.RunWithCaptureArgs([]string{"sql", "-e", "drop database if exists tmp; create database tmp"}); err != nil {
-					d.Fatalf(t, "%v", err)
-				} else {
-					t.Log(out)
-				}
+				c.RunWithArgs([]string{"sql", "-e", "drop database if exists tmp; create database tmp"})
 				if out, err := c.RunWithCaptureArgs([]string{"sql", "-d", "tmp", "-e", s}); err != nil {
 					d.Fatalf(t, "%v", err)
 				} else {
-					t.Log(out)
+					t.Logf("executed SQL: %s\nresult: %s", s, out)
 				}
 				args[1] = "tmp"
 				roundtrip, err := c.RunWithCaptureArgs(args)
@@ -101,7 +97,7 @@ func TestDumpData(t *testing.T) {
 					d.Fatalf(t, "%v", err)
 				}
 				if roundtrip != s {
-					d.Fatalf(t, "unexpected: %s", roundtrip)
+					d.Fatalf(t, "roundtrip results unexpected: %s, expected: %s", roundtrip, s)
 				}
 			}
 			return s

--- a/pkg/cli/testdata/dump/reference_cycle
+++ b/pkg/cli/testdata/dump/reference_cycle
@@ -1,35 +1,94 @@
-# Test dumping in the presence of cycles.
-# This used to crash before with stack overflow due to an infinite loop before:
-# https://github.com/cockroachdb/cockroach/pull/20255
+# Test that a cycle between two tables is handled correctly.
 
 sql
 CREATE DATABASE d;
-CREATE TABLE d.t (
-	PRIMARY KEY (id),
-	FOREIGN KEY (next_id) REFERENCES d.t(id),
-	id INT,
-	next_id INT
+USE d;
+CREATE TABLE loop_a (
+  id INT PRIMARY KEY
+ ,b_id INT
+ ,INDEX(b_id)
 );
-INSERT INTO d.t VALUES (
-	1,
-	NULL
-);
-----
-INSERT 1
 
-dump d t
+CREATE TABLE loop_b (
+  id INT PRIMARY KEY
+ ,a_id INT REFERENCES loop_a ON DELETE CASCADE
+);
+
+ALTER TABLE loop_a ADD CONSTRAINT b_id_delete_constraint
+  FOREIGN KEY (b_id) REFERENCES loop_b (id) ON DELETE CASCADE;
+
+INSERT INTO loop_a (id, b_id) VALUES (1, NULL);
+INSERT INTO loop_b (id, a_id) VALUES (1, 1);
+INSERT INTO loop_a (id, b_id) VALUES (2, 1);
+INSERT INTO loop_b (id, a_id) VALUES (2, 2);
+INSERT INTO loop_a (id, b_id) VALUES (3, 2);
+INSERT INTO loop_b (id, a_id) VALUES (3, 3);
+UPDATE loop_a SET b_id = 3 WHERE id = 1;
+----
+UPDATE 1
+
+dump d
 ----
 ----
-CREATE TABLE t (
+CREATE TABLE loop_b (
 	id INT NOT NULL,
-	next_id INT NULL,
+	a_id INT NULL,
 	CONSTRAINT "primary" PRIMARY KEY (id ASC),
-	CONSTRAINT fk_next_id_ref_t FOREIGN KEY (next_id) REFERENCES t (id),
-	INDEX t_auto_index_fk_next_id_ref_t (next_id ASC),
-	FAMILY "primary" (id, next_id)
+	INDEX loop_b_auto_index_fk_a_id_ref_loop_a (a_id ASC),
+	FAMILY "primary" (id, a_id)
 );
 
-INSERT INTO t (id, next_id) VALUES
-	(1, NULL);
+CREATE TABLE loop_a (
+	id INT NOT NULL,
+	b_id INT NULL,
+	CONSTRAINT "primary" PRIMARY KEY (id ASC),
+	INDEX loop_a_b_id_idx (b_id ASC),
+	FAMILY "primary" (id, b_id)
+);
+
+INSERT INTO loop_b (id, a_id) VALUES
+	(1, 1),
+	(2, 2),
+	(3, 3);
+
+INSERT INTO loop_a (id, b_id) VALUES
+	(1, 3),
+	(2, 1),
+	(3, 2);
+
+ALTER TABLE loop_b ADD CONSTRAINT fk_a_id_ref_loop_a FOREIGN KEY (a_id) REFERENCES loop_a (id) ON DELETE CASCADE;
+ALTER TABLE loop_a ADD CONSTRAINT b_id_delete_constraint FOREIGN KEY (b_id) REFERENCES loop_b (id) ON DELETE CASCADE;
+
+-- Validate foreign key constraints. These can fail if there was unvalidated data during the dump.
+ALTER TABLE loop_b VALIDATE CONSTRAINT fk_a_id_ref_loop_a;
+ALTER TABLE loop_a VALIDATE CONSTRAINT b_id_delete_constraint;
+----
+----
+
+dump d --dump-mode=schema
+----
+----
+CREATE TABLE loop_b (
+	id INT NOT NULL,
+	a_id INT NULL,
+	CONSTRAINT "primary" PRIMARY KEY (id ASC),
+	INDEX loop_b_auto_index_fk_a_id_ref_loop_a (a_id ASC),
+	FAMILY "primary" (id, a_id)
+);
+
+CREATE TABLE loop_a (
+	id INT NOT NULL,
+	b_id INT NULL,
+	CONSTRAINT "primary" PRIMARY KEY (id ASC),
+	INDEX loop_a_b_id_idx (b_id ASC),
+	FAMILY "primary" (id, b_id)
+);
+
+ALTER TABLE loop_b ADD CONSTRAINT fk_a_id_ref_loop_a FOREIGN KEY (a_id) REFERENCES loop_a (id) ON DELETE CASCADE;
+ALTER TABLE loop_a ADD CONSTRAINT b_id_delete_constraint FOREIGN KEY (b_id) REFERENCES loop_b (id) ON DELETE CASCADE;
+
+-- Validate foreign key constraints. These can fail if there was unvalidated data during the dump.
+ALTER TABLE loop_b VALIDATE CONSTRAINT fk_a_id_ref_loop_a;
+ALTER TABLE loop_a VALIDATE CONSTRAINT b_id_delete_constraint;
 ----
 ----

--- a/pkg/cli/testdata/dump/reference_order
+++ b/pkg/cli/testdata/dump/reference_order
@@ -43,7 +43,6 @@ CREATE TABLE b (
 
 CREATE TABLE a (
 	i INT NULL,
-	CONSTRAINT fk_i_ref_b FOREIGN KEY (i) REFERENCES b (i),
 	INDEX a_auto_index_fk_i_ref_b (i ASC),
 	FAMILY "primary" (i, rowid)
 );
@@ -64,7 +63,6 @@ CREATE TABLE f (
 	i INT NOT NULL,
 	g INT NULL,
 	CONSTRAINT "primary" PRIMARY KEY (i ASC),
-	CONSTRAINT fk_g_ref_g FOREIGN KEY (g) REFERENCES g (i),
 	INDEX f_auto_index_fk_g_ref_g (g ASC),
 	FAMILY "primary" (i, g)
 );
@@ -74,16 +72,13 @@ CREATE TABLE d (
 	e INT NULL,
 	f INT NULL,
 	CONSTRAINT "primary" PRIMARY KEY (i ASC),
-	CONSTRAINT fk_e_ref_e FOREIGN KEY (e) REFERENCES e (i),
 	INDEX d_auto_index_fk_e_ref_e (e ASC),
-	CONSTRAINT fk_f_ref_f FOREIGN KEY (f) REFERENCES f (i),
 	INDEX d_auto_index_fk_f_ref_f (f ASC),
 	FAMILY "primary" (i, e, f)
 );
 
 CREATE TABLE c (
 	i INT NULL,
-	CONSTRAINT fk_i_ref_d FOREIGN KEY (i) REFERENCES d (i),
 	INDEX c_auto_index_fk_i_ref_d (i ASC),
 	FAMILY "primary" (i, rowid)
 );
@@ -123,6 +118,19 @@ SELECT setval('s', 3, false);
 INSERT INTO s_tbl (id, v) VALUES
 	(1, 10),
 	(2, 11);
+
+ALTER TABLE a ADD CONSTRAINT fk_i_ref_b FOREIGN KEY (i) REFERENCES b (i);
+ALTER TABLE f ADD CONSTRAINT fk_g_ref_g FOREIGN KEY (g) REFERENCES g (i);
+ALTER TABLE d ADD CONSTRAINT fk_e_ref_e FOREIGN KEY (e) REFERENCES e (i);
+ALTER TABLE d ADD CONSTRAINT fk_f_ref_f FOREIGN KEY (f) REFERENCES f (i);
+ALTER TABLE c ADD CONSTRAINT fk_i_ref_d FOREIGN KEY (i) REFERENCES d (i);
+
+-- Validate foreign key constraints. These can fail if there was unvalidated data during the dump.
+ALTER TABLE a VALIDATE CONSTRAINT fk_i_ref_b;
+ALTER TABLE f VALIDATE CONSTRAINT fk_g_ref_g;
+ALTER TABLE d VALIDATE CONSTRAINT fk_e_ref_e;
+ALTER TABLE d VALIDATE CONSTRAINT fk_f_ref_f;
+ALTER TABLE c VALIDATE CONSTRAINT fk_i_ref_d;
 ----
 ----
 
@@ -144,9 +152,7 @@ CREATE TABLE d (
 	e INT NULL,
 	f INT NULL,
 	CONSTRAINT "primary" PRIMARY KEY (i ASC),
-	CONSTRAINT fk_e_ref_e FOREIGN KEY (e) REFERENCES e (i),
 	INDEX d_auto_index_fk_e_ref_e (e ASC),
-	CONSTRAINT fk_f_ref_f FOREIGN KEY (f) REFERENCES f (i),
 	INDEX d_auto_index_fk_f_ref_f (f ASC),
 	FAMILY "primary" (i, e, f)
 );
@@ -156,5 +162,12 @@ INSERT INTO e (i) VALUES
 
 INSERT INTO d (i, e, f) VALUES
 	(1, 1, 1);
+
+ALTER TABLE d ADD CONSTRAINT fk_e_ref_e FOREIGN KEY (e) REFERENCES e (i);
+ALTER TABLE d ADD CONSTRAINT fk_f_ref_f FOREIGN KEY (f) REFERENCES f (i);
+
+-- Validate foreign key constraints. These can fail if there was unvalidated data during the dump.
+ALTER TABLE d VALIDATE CONSTRAINT fk_e_ref_e;
+ALTER TABLE d VALIDATE CONSTRAINT fk_f_ref_f;
 ----
 ----

--- a/pkg/cli/testdata/dump/reference_self
+++ b/pkg/cli/testdata/dump/reference_self
@@ -1,0 +1,127 @@
+# Test dumping in the presence of cycles.
+# This used to crash before with stack overflow due to an infinite loop before:
+# https://github.com/cockroachdb/cockroach/pull/20255
+
+sql
+CREATE DATABASE d;
+CREATE TABLE d.t (
+	PRIMARY KEY (id),
+	FOREIGN KEY (next_id) REFERENCES d.t(id),
+	id INT,
+	next_id INT
+);
+INSERT INTO d.t VALUES (
+	1,
+	NULL
+);
+----
+INSERT 1
+
+dump d t
+----
+----
+CREATE TABLE t (
+	id INT NOT NULL,
+	next_id INT NULL,
+	CONSTRAINT "primary" PRIMARY KEY (id ASC),
+	INDEX t_auto_index_fk_next_id_ref_t (next_id ASC),
+	FAMILY "primary" (id, next_id)
+);
+
+INSERT INTO t (id, next_id) VALUES
+	(1, NULL);
+
+ALTER TABLE t ADD CONSTRAINT fk_next_id_ref_t FOREIGN KEY (next_id) REFERENCES t (id);
+
+-- Validate foreign key constraints. These can fail if there was unvalidated data during the dump.
+ALTER TABLE t VALIDATE CONSTRAINT fk_next_id_ref_t;
+----
+----
+
+# Now make a reference forces the dump to add the FKs after the data has been inserted.
+
+sql
+UPDATE d.t SET next_id = 1
+----
+UPDATE 1
+
+dump d t
+----
+----
+CREATE TABLE t (
+	id INT NOT NULL,
+	next_id INT NULL,
+	CONSTRAINT "primary" PRIMARY KEY (id ASC),
+	INDEX t_auto_index_fk_next_id_ref_t (next_id ASC),
+	FAMILY "primary" (id, next_id)
+);
+
+INSERT INTO t (id, next_id) VALUES
+	(1, 1);
+
+ALTER TABLE t ADD CONSTRAINT fk_next_id_ref_t FOREIGN KEY (next_id) REFERENCES t (id);
+
+-- Validate foreign key constraints. These can fail if there was unvalidated data during the dump.
+ALTER TABLE t VALIDATE CONSTRAINT fk_next_id_ref_t;
+----
+----
+
+# Make some weirdo identifiers and the second FK.
+
+sql
+ALTER TABLE d.t RENAME COLUMN next_id TO "'";
+ALTER TABLE d.t RENAME TO d."table";
+----
+RENAME TABLE
+
+dump d table
+----
+----
+CREATE TABLE "table" (
+	id INT NOT NULL,
+	"'" INT NULL,
+	CONSTRAINT "primary" PRIMARY KEY (id ASC),
+	INDEX t_auto_index_fk_next_id_ref_t ("'" ASC),
+	FAMILY "primary" (id, "'")
+);
+
+INSERT INTO "table" (id, "'") VALUES
+	(1, 1);
+
+ALTER TABLE "table" ADD CONSTRAINT fk_next_id_ref_t FOREIGN KEY ("'") REFERENCES "table" (id);
+
+-- Validate foreign key constraints. These can fail if there was unvalidated data during the dump.
+ALTER TABLE "table" VALIDATE CONSTRAINT fk_next_id_ref_t;
+----
+----
+
+# Dumping only the schema doesn't need to use the ALTER TABLE FK stuff.
+
+dump d --dump-mode=schema
+----
+----
+CREATE TABLE "table" (
+	id INT NOT NULL,
+	"'" INT NULL,
+	CONSTRAINT "primary" PRIMARY KEY (id ASC),
+	INDEX t_auto_index_fk_next_id_ref_t ("'" ASC),
+	FAMILY "primary" (id, "'")
+);
+
+ALTER TABLE "table" ADD CONSTRAINT fk_next_id_ref_t FOREIGN KEY ("'") REFERENCES "table" (id);
+
+-- Validate foreign key constraints. These can fail if there was unvalidated data during the dump.
+ALTER TABLE "table" VALIDATE CONSTRAINT fk_next_id_ref_t;
+----
+----
+# Dumping only the data shouldn't have the ALTER stuff either.
+
+dump d --dump-mode=data
+noroundtrip
+----
+----
+
+INSERT INTO "table" (id, "'") VALUES
+	(1, 1);
+----
+----

--- a/pkg/sql/logictest/testdata/logic_test/crdb_internal
+++ b/pkg/sql/logictest/testdata/logic_test/crdb_internal
@@ -161,10 +161,10 @@ SELECT * FROM crdb_internal.builtin_functions WHERE function = ''
 ----
 function  signature  category  details
 
-query ITTITTTT colnames
+query ITTITTTTTTT colnames
 SELECT * FROM crdb_internal.create_statements WHERE database_name = ''
 ----
-database_id  database_name  schema_name descriptor_id  descriptor_type  descriptor_name  create_statement  state
+database_id  database_name  schema_name  descriptor_id  descriptor_type  descriptor_name  create_statement  state  create_nofks  alter_statements  validate_statements
 
 query ITITTBTB colnames
 SELECT * FROM crdb_internal.table_columns WHERE descriptor_name = ''

--- a/pkg/sql/logictest/testdata/logic_test/create_statements
+++ b/pkg/sql/logictest/testdata/logic_test/create_statements
@@ -1,0 +1,37 @@
+# LogicTest: default parallel-stmts distsql
+
+statement ok
+CREATE TABLE t (a INT REFERENCES t)
+
+statement ok
+CREATE TABLE v ("'" INT REFERENCES t, s STRING UNIQUE REFERENCES v (s))
+
+query TTTT colnames
+SELECT create_statement, create_nofks, alter_statements, validate_statements FROM crdb_internal.create_statements WHERE database_name = 'test'
+----
+create_statement  create_nofks  alter_statements  validate_statements
+CREATE TABLE t (
+   a INT NULL,
+   CONSTRAINT fk_a_ref_t FOREIGN KEY (a) REFERENCES t (rowid),
+   INDEX t_auto_index_fk_a_ref_t (a ASC),
+   FAMILY "primary" (a, rowid)
+)  CREATE TABLE t (
+   a INT NULL,
+   INDEX t_auto_index_fk_a_ref_t (a ASC),
+   FAMILY "primary" (a, rowid)
+)  {"ALTER TABLE t ADD CONSTRAINT fk_a_ref_t FOREIGN KEY (a) REFERENCES t (rowid)"}  {"ALTER TABLE t VALIDATE CONSTRAINT fk_a_ref_t"}
+CREATE TABLE v (
+   "'" INT NULL,
+   s STRING NULL,
+   CONSTRAINT fk_s_ref_v FOREIGN KEY (s) REFERENCES v (s),
+   UNIQUE INDEX v_s_key (s ASC),
+   CONSTRAINT "fk_'_ref_t" FOREIGN KEY ("'") REFERENCES t (rowid),
+   INDEX "v_auto_index_fk_'_ref_t" ("'" ASC),
+   FAMILY "primary" ("'", s, rowid)
+)  CREATE TABLE v (
+   "'" INT NULL,
+   s STRING NULL,
+   UNIQUE INDEX v_s_key (s ASC),
+   INDEX "v_auto_index_fk_'_ref_t" ("'" ASC),
+   FAMILY "primary" ("'", s, rowid)
+)  {"ALTER TABLE v ADD CONSTRAINT fk_s_ref_v FOREIGN KEY (s) REFERENCES v (s)","ALTER TABLE v ADD CONSTRAINT \"fk_'_ref_t\" FOREIGN KEY (\"'\") REFERENCES t (rowid)"}  {"ALTER TABLE v VALIDATE CONSTRAINT fk_s_ref_v","ALTER TABLE v VALIDATE CONSTRAINT \"fk_'_ref_t\""}

--- a/pkg/sql/logictest/testdata/logic_test/explain
+++ b/pkg/sql/logictest/testdata/logic_test/explain
@@ -230,7 +230,7 @@ sort                                       ·            ·
                      ├── render            ·            ·
                      │    └── filter       ·            ·
                      │         └── values  ·            ·
-                     │                     size         17 columns, 741 rows
+                     │                     size         17 columns, 744 rows
                      └── render            ·            ·
                           └── filter       ·            ·
                                └── values  ·            ·

--- a/pkg/sql/logictest/testdata/logic_test/sequences
+++ b/pkg/sql/logictest/testdata/logic_test/sequences
@@ -118,11 +118,11 @@ CREATE SEQUENCE ignored_options_test CACHE 1 NO CYCLE
 statement ok
 CREATE SEQUENCE show_create_test
 
-query ITTITTTT colnames
+query ITTITTTTTTT colnames
 SELECT * FROM crdb_internal.create_statements WHERE descriptor_name = 'show_create_test'
 ----
-database_id  database_name  schema_name  descriptor_id  descriptor_type  descriptor_name   create_statement                                                                              state
-50           test           public       64             sequence         show_create_test  CREATE SEQUENCE show_create_test MINVALUE 1 MAXVALUE 9223372036854775807 INCREMENT 1 START 1  PUBLIC
+database_id  database_name  schema_name  descriptor_id  descriptor_type  descriptor_name   create_statement                                                                              state   create_nofks                                                                                  alter_statements  validate_statements
+50           test           public       64             sequence         show_create_test  CREATE SEQUENCE show_create_test MINVALUE 1 MAXVALUE 9223372036854775807 INCREMENT 1 START 1  PUBLIC  CREATE SEQUENCE show_create_test MINVALUE 1 MAXVALUE 9223372036854775807 INCREMENT 1 START 1  {}                {}
 
 query TT colnames
 SHOW CREATE SEQUENCE show_create_test

--- a/pkg/sql/show_create.go
+++ b/pkg/sql/show_create.go
@@ -185,6 +185,7 @@ func (p *planner) showCreateTable(
 	dbPrefix string,
 	desc *sqlbase.TableDescriptor,
 	lCtx *internalLookupCtx,
+	ignoreFKs bool,
 ) (string, error) {
 	a := &sqlbase.DatumAlloc{}
 
@@ -214,7 +215,7 @@ func (p *planner) showCreateTable(
 	allIdx := append(desc.Indexes, desc.PrimaryIndex)
 	for i := range allIdx {
 		idx := &allIdx[i]
-		if fk := &idx.ForeignKey; fk.IsSet() {
+		if fk := &idx.ForeignKey; fk.IsSet() && !ignoreFKs {
 			f.WriteString(",\n\tCONSTRAINT ")
 			f.FormatNameP(&fk.Name)
 			f.WriteString(" ")


### PR DESCRIPTION
In the case of a self or cyclic FK dependency, dump used to create
SQL that was not loadable due to out-of-order dependencies. In order
to fix all cases of this, remove FKs from create statements and move
them to ALTERs below.

In addition, we want to attempt to validate the constraints. They may
or may not have been validated during the time of the dump. These
validations can thus fail. However if they do, a user hopefully is
aware of the reason and can deal with the fallout. And the schema
and data are correct at that time anyway, so they can at least proceed.

This is done by adding new columns to crdb_internal.create_statetments.

Fixes #20254

Release note (cli change): fully support self and cyclic foreign key
references in dump.