### PR TITLE
opt: wire up table statistics

### DIFF
--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -78,6 +78,8 @@ const (
 	recommendedNetworkFileDescriptors = 5000
 
 	defaultConnResultsBufferBytes = 16 << 10 // 16 KiB
+
+	defaultSQLTableStatCacheSize = 256
 )
 
 var productionSettingsWebpage = fmt.Sprintf(
@@ -167,6 +169,10 @@ type Config struct {
 
 	// SQLAuditLogDirName is the target directory name for SQL audit logs.
 	SQLAuditLogDirName *log.DirName
+
+	// SQLTableStatCacheSize is the size (number of tables) of the table
+	// statistics cache.
+	SQLTableStatCacheSize int
 
 	// Parsed values.
 
@@ -376,6 +382,7 @@ func MakeConfig(ctx context.Context, st *cluster.Settings) Config {
 		Settings:                       st,
 		CacheSize:                      DefaultCacheSize,
 		SQLMemoryPoolSize:              defaultSQLMemoryPoolSize,
+		SQLTableStatCacheSize:          defaultSQLTableStatCacheSize,
 		ScanInterval:                   defaultScanInterval,
 		ScanMaxIdleTime:                defaultScanMaxIdleTime,
 		EventLogEnabled:                defaultEventLogEnabled,

--- a/pkg/sql/executor.go
+++ b/pkg/sql/executor.go
@@ -46,6 +46,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/pkg/sql/stats"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/duration"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
@@ -266,6 +267,7 @@ type ExecutorConfig struct {
 	JobRegistry     *jobs.Registry
 	VirtualSchemas  *VirtualSchemaHolder
 	DistSQLPlanner  *DistSQLPlanner
+	TableStatsCache *stats.TableStatisticsCache
 	ExecLogger      *log.SecondaryLogger
 	AuditLogger     *log.SecondaryLogger
 

--- a/pkg/sql/opt/catalog.go
+++ b/pkg/sql/opt/catalog.go
@@ -124,10 +124,6 @@ type TableStatistic interface {
 	// any column in the statistic.
 	NullCount() uint64
 
-	// HasHistogram returns whether a histogram is available for this statistic.
-	// Only single-column statistics can have histograms.
-	HasHistogram() bool
-
 	// TODO(radu): add Histogram().
 }
 

--- a/pkg/sql/opt/exec/execbuilder/testdata/stats
+++ b/pkg/sql/opt/exec/execbuilder/testdata/stats
@@ -1,0 +1,49 @@
+# Tests that verify we retrieve the stats correctly.
+
+exec-raw
+CREATE DATABASE t
+----
+
+exec-raw
+CREATE TABLE t.a (u INT, v INT, INDEX (u) STORING (v), INDEX (v) STORING (u));
+INSERT INTO t.a VALUES (1, 1), (1, 2), (1, 3), (1, 4), (2, 4), (2, 5), (2, 6), (2, 7)
+----
+
+build
+SELECT * FROM t.a
+----
+project
+ ├── columns: u:1(int) v:2(int)
+ ├── stats: [rows=1000]
+ ├── cost: 1000.00
+ ├── scan a
+ │    ├── columns: a.u:1(int) a.v:2(int) a.rowid:3(int!null)
+ │    ├── stats: [rows=1000]
+ │    ├── cost: 1000.00
+ │    └── keys: (3)
+ └── projections [outer=(1,2)]
+      ├── variable: a.u [type=int, outer=(1)]
+      └── variable: a.v [type=int, outer=(2)]
+
+exec-raw
+CREATE STATISTICS u ON u FROM t.a
+----
+
+build
+SELECT * FROM t.a
+----
+project
+ ├── columns: u:1(int) v:2(int)
+ ├── stats: [rows=8]
+ ├── cost: 8.00
+ ├── scan a
+ │    ├── columns: a.u:1(int) a.v:2(int) a.rowid:3(int!null)
+ │    ├── stats: [rows=8]
+ │    ├── cost: 8.00
+ │    └── keys: (3)
+ └── projections [outer=(1,2)]
+      ├── variable: a.u [type=int, outer=(1)]
+      └── variable: a.v [type=int, outer=(2)]
+
+# TODO(radu): once we use cardinality, verify we choose the index with the
+# smaller cardinality (for a WHERE condition on both columns).

--- a/pkg/sql/opt/testutils/test_catalog.go
+++ b/pkg/sql/opt/testutils/test_catalog.go
@@ -222,8 +222,3 @@ func (ts *TestTableStat) DistinctCount() uint64 {
 func (ts *TestTableStat) NullCount() uint64 {
 	return ts.js.NullCount
 }
-
-// HasHistogram is part of the opt.TableStatistic interface.
-func (ts *TestTableStat) HasHistogram() bool {
-	return len(ts.js.HistogramBuckets) > 0
-}

--- a/pkg/sql/opt_catalog.go
+++ b/pkg/sql/opt_catalog.go
@@ -16,10 +16,12 @@ package sql
 
 import (
 	"context"
+	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/pkg/sql/stats"
 )
 
 // optCatalog implements the opt.Catalog interface over the SchemaResolver
@@ -30,6 +32,8 @@ type optCatalog struct {
 	// resolver needs to be set via a call to init before calling other methods.
 	resolver SchemaResolver
 
+	statsCache *stats.TableStatisticsCache
+
 	// wrappers is a cache of table wrappers that's used to satisfy repeated
 	// calls to the FindTable method for the same table.
 	wrappers map[*sqlbase.TableDescriptor]*optTable
@@ -38,8 +42,9 @@ type optCatalog struct {
 var _ opt.Catalog = &optCatalog{}
 
 // init allows the optCatalog wrapper to be inlined.
-func (oc *optCatalog) init(resolver SchemaResolver) {
+func (oc *optCatalog) init(statsCache *stats.TableStatisticsCache, resolver SchemaResolver) {
 	oc.resolver = resolver
+	oc.statsCache = statsCache
 }
 
 // FindTable is part of the opt.Catalog interface.
@@ -55,7 +60,7 @@ func (oc *optCatalog) FindTable(ctx context.Context, name *tree.TableName) (opt.
 	}
 	wrapper, ok := oc.wrappers[desc]
 	if !ok {
-		wrapper = newOptTable(desc)
+		wrapper = newOptTable(oc.statsCache, desc)
 		oc.wrappers[desc] = wrapper
 	}
 	return wrapper, nil
@@ -69,6 +74,12 @@ type optTable struct {
 	// primary is the inlined wrapper for the table's primary index.
 	primary optIndex
 
+	statsCache *stats.TableStatisticsCache
+
+	// stats is nil until StatisticCount is called. After that it will not be nil,
+	// even when there are no statistics.
+	stats []optTableStat
+
 	// colMap is a mapping from unique ColumnID to column ordinal within the
 	// table. This is a common lookup that needs to be fast.
 	colMap map[sqlbase.ColumnID]int
@@ -80,16 +91,17 @@ type optTable struct {
 
 var _ opt.Table = &optTable{}
 
-func newOptTable(desc *sqlbase.TableDescriptor) *optTable {
+func newOptTable(statsCache *stats.TableStatisticsCache, desc *sqlbase.TableDescriptor) *optTable {
 	ot := &optTable{}
-	ot.init(desc)
+	ot.init(statsCache, desc)
 	return ot
 }
 
 // init allows the optTable wrapper to be inlined.
-func (ot *optTable) init(desc *sqlbase.TableDescriptor) {
+func (ot *optTable) init(statsCache *stats.TableStatisticsCache, desc *sqlbase.TableDescriptor) {
 	ot.desc = desc
 	ot.primary.init(ot, &desc.PrimaryIndex)
+	ot.statsCache = statsCache
 }
 
 // TabName is part of the opt.Table interface.
@@ -137,25 +149,48 @@ func (ot *optTable) Index(i int) opt.Index {
 
 // StatisticCount is part of the opt.Table interface.
 func (ot *optTable) StatisticCount() int {
-	// TODO(radu): implement this.
-	return 0
+	if ot.stats != nil {
+		return len(ot.stats)
+	}
+	stats, err := ot.statsCache.GetTableStats(context.TODO(), ot.desc.ID)
+	if err != nil {
+		// Ignore any error. We still want to be able to run queries even if we lose
+		// access to the statistics table.
+		// TODO(radu): at least log the error.
+		ot.stats = make([]optTableStat, 0)
+		return 0
+	}
+	ot.stats = make([]optTableStat, len(stats))
+	n := 0
+	for i := range stats {
+		// We skip any stats that have columns that don't exist in
+		// the table anymore.
+		if ot.stats[n].init(ot, stats[i]) {
+			n++
+		}
+	}
+	ot.stats = ot.stats[:n]
+	return n
 }
 
 // Statistic is part of the opt.Table interface.
 func (ot *optTable) Statistic(i int) opt.TableStatistic {
-	// TODO(radu): implement this.
-	panic("unimplemented")
+	return &ot.stats[i]
 }
 
-// lookupColumnOrdinal returns the ordinal of the column with the given ID. A
-// cache makes the lookup O(1).
-func (ot *optTable) lookupColumnOrdinal(colID sqlbase.ColumnID) int {
+func (ot *optTable) ensureColMap() {
 	if ot.colMap == nil {
 		ot.colMap = make(map[sqlbase.ColumnID]int, len(ot.desc.Columns))
 		for i := range ot.desc.Columns {
 			ot.colMap[ot.desc.Columns[i].ID] = i
 		}
 	}
+}
+
+// lookupColumnOrdinal returns the ordinal of the column with the given ID. A
+// cache makes the lookup O(1).
+func (ot *optTable) lookupColumnOrdinal(colID sqlbase.ColumnID) int {
+	ot.ensureColMap()
 	return ot.colMap[colID]
 }
 
@@ -226,4 +261,63 @@ func (oi *optIndex) Column(i int) opt.IndexColumn {
 	i -= length
 	ord := oi.tab.lookupColumnOrdinal(oi.desc.StoreColumnIDs[i])
 	return opt.IndexColumn{Column: oi.tab.Column(ord), Ordinal: ord}
+}
+
+type optTableStat struct {
+	createdAt      time.Time
+	columnOrdinals []int
+	rowCount       uint64
+	distinctCount  uint64
+	nullCount      uint64
+}
+
+var _ opt.TableStatistic = &optTableStat{}
+
+func (os *optTableStat) init(tab *optTable, stat *stats.TableStatistic) (ok bool) {
+	os.createdAt = stat.CreatedAt
+	os.rowCount = stat.RowCount
+	os.distinctCount = stat.DistinctCount
+	os.nullCount = stat.NullCount
+	os.columnOrdinals = make([]int, len(stat.ColumnIDs))
+	tab.ensureColMap()
+	for i, c := range stat.ColumnIDs {
+		var ok bool
+		os.columnOrdinals[i], ok = tab.colMap[c]
+		if !ok {
+			// Column not in table (this is possible if the column was removed since
+			// the statistic was calculated).
+			return false
+		}
+	}
+	return true
+}
+
+// CreatedAt is part of the opt.TableStatistic interface.
+func (os *optTableStat) CreatedAt() time.Time {
+	return os.createdAt
+}
+
+// ColumnCount is part of the opt.TableStatistic interface.
+func (os *optTableStat) ColumnCount() int {
+	return len(os.columnOrdinals)
+}
+
+// ColumnOrdinal is part of the opt.TableStatistic interface.
+func (os *optTableStat) ColumnOrdinal(i int) int {
+	return os.columnOrdinals[i]
+}
+
+// RowCount is part of the opt.TableStatistic interface.
+func (os *optTableStat) RowCount() uint64 {
+	return os.rowCount
+}
+
+// DistinctCount is part of the opt.TableStatistic interface.
+func (os *optTableStat) DistinctCount() uint64 {
+	return os.distinctCount
+}
+
+// NullCount is part of the opt.TableStatistic interface.
+func (os *optTableStat) NullCount() uint64 {
+	return os.nullCount
 }

--- a/pkg/sql/opt_exec_engine.go
+++ b/pkg/sql/opt_exec_engine.go
@@ -52,7 +52,7 @@ var _ exec.TestEngine = &execEngine{}
 
 func newExecEngine(p *planner, cleanup func()) *execEngine {
 	ee := &execEngine{planner: p, cleanup: cleanup}
-	ee.catalog.init(p)
+	ee.catalog.init(p.execCfg.TableStatsCache, p)
 	return ee
 }
 


### PR DESCRIPTION
Setting up the statistics cache in the `ExecutorConfig` and
implementing the statistics part of the catalog.

Release note: None