### PR TITLE
cherrypick-2.0: ui: remove freestanding node list page

### DIFF
--- a/pkg/ui/src/index.tsx
+++ b/pkg/ui/src/index.tsx
@@ -38,7 +38,6 @@ import Raft from "src/views/devtools/containers/raft";
 import RaftRanges from "src/views/devtools/containers/raftRanges";
 import RaftMessages from "src/views/devtools/containers/raftMessages";
 import NodeGraphs from "src/views/cluster/containers/nodeGraphs";
-import NodesOverview from "src/views/cluster/containers/nodesOverview";
 import NodeOverview from "src/views/cluster/containers/nodeOverview";
 import NodeLogs from "src/views/cluster/containers/nodeLogs";
 import JobsPage from "src/views/jobs";
@@ -86,11 +85,8 @@ ReactDOM.render(
         </Route>
 
         { /* node details */ }
-        <Route path="nodes">
-          <IndexRoute component={ NodesOverview } />
-        </Route>
         <Route path="node">
-          <IndexRedirect to="/nodes" />
+          <IndexRedirect to="/overview/list" />
           <Route path={ `:${nodeIDAttr}` }>
             <IndexRoute component={ NodeOverview } />
             <Route path="logs" component={ NodeLogs } />
@@ -159,13 +155,16 @@ ReactDOM.render(
             to={ `/metrics/:${dashboardNameAttr}/node/:${nodeIDAttr}` }
           />
           <Route path="nodes">
-            <IndexRedirect to="/nodes" />
+            <IndexRedirect to="/overview/list" />
             <Route path={`:${nodeIDAttr}`}>
               <IndexRedirect to={ `/node/:${nodeIDAttr}` } />
               <Redirect from="logs" to={ `/node/:${nodeIDAttr}/logs` } />
             </Route>
           </Route>
           <Redirect from="events" to="/events" />
+        </Route>
+        <Route path="nodes">
+          <IndexRedirect to="/overview/list" />
         </Route>
 
         { /* 404 */ }

--- a/pkg/ui/src/views/cluster/containers/nodeGraphs/summaryBar.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodeGraphs/summaryBar.tsx
@@ -39,7 +39,7 @@ function ClusterNodeTotals (props: ClusterSummaryProps) {
   return (
     <SummaryStat
       title={
-        <span>Total Nodes <Link to="/nodes">View nodes list</Link></span>
+        <span>Total Nodes <Link to="/overview/list">View nodes list</Link></span>
       }
       value={nodeCounts.total}
     >

--- a/pkg/ui/src/views/cluster/containers/nodesOverview/index.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodesOverview/index.tsx
@@ -379,16 +379,4 @@ const NodesMainConnected = connect(
   },
 )(NodesMain);
 
-/**
- * Renders the main content of the nodes page, which is primarily a data table
- * of all nodes.
- */
-function NodesPage() {
-  return (
-    <div>
-      <NodesMainConnected />
-    </div>
-  );
-}
-
-export { NodesPage as default, NodesMainConnected as NodesOverview };
+export { NodesMainConnected as NodesOverview };


### PR DESCRIPTION
Since the node list now appears on the cluster overview, we should
prefer that page to the freestanding node list page.

Fixes: #23759
Release note: None

A cherry-pick of #24706
cc: @cockroachdb/release @vilterp 