### PR TITLE
sql: allow sub-plans in hook-created plans

### DIFF
--- a/pkg/sql/expand_plan.go
+++ b/pkg/sql/expand_plan.go
@@ -315,6 +315,12 @@ func doExpandPlan(
 	case *zeroNode:
 	case *unaryNode:
 	case *hookFnNode:
+		for i := range n.subplans {
+			n.subplans[i], err = doExpandPlan(ctx, p, noParams, n.subplans[i])
+			if err != nil {
+				break
+			}
+		}
 	case *valueGenerator:
 	case *sequenceSelectNode:
 	case *setVarNode:

--- a/pkg/sql/logictest/main_test.go
+++ b/pkg/sql/logictest/main_test.go
@@ -15,45 +15,19 @@
 package logictest
 
 import (
-	"context"
 	"os"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/security/securitytest"
 	"github.com/cockroachdb/cockroach/pkg/server"
-	"github.com/cockroachdb/cockroach/pkg/sql"
-	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
-	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
-	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	_ "github.com/cockroachdb/cockroach/pkg/sql/tests"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 )
 
 //go:generate ../../util/leaktest/add-leaktest.sh *_test.go
-
-// Add a placeholder implementation to test the plan hook. It accepts statements
-// of the form `SHOW planhook` and returns a single row with the string value
-// 'planhook'.
-func init() {
-	testingPlanHook := func(
-		_ context.Context, stmt tree.Statement, state sql.PlanHookState,
-	) (func(context.Context, chan<- tree.Datums) error, sqlbase.ResultColumns, error) {
-		show, ok := stmt.(*tree.ShowVar)
-		if !ok || show.Name != "planhook" {
-			return nil, nil, nil
-		}
-		header := sqlbase.ResultColumns{
-			{Name: "value", Typ: types.String},
-		}
-		return func(_ context.Context, resultsCh chan<- tree.Datums) error {
-			resultsCh <- tree.Datums{tree.NewDString(show.Name)}
-			return nil
-		}, header, nil
-	}
-	sql.AddPlanHook(testingPlanHook)
-}
 
 func TestMain(m *testing.M) {
 	security.SetAssetLoader(securitytest.EmbeddedAssets)

--- a/pkg/sql/plan.go
+++ b/pkg/sql/plan.go
@@ -523,10 +523,10 @@ func (p *planner) maybePlanHook(ctx context.Context, stmt tree.Statement) (planN
 	// upcoming IR work will provide unique numeric type tags, which will
 	// elegantly solve this.
 	for _, planHook := range planHooks {
-		if fn, header, err := planHook(ctx, stmt, p); err != nil {
+		if fn, header, subplans, err := planHook(ctx, stmt, p); err != nil {
 			return nil, err
 		} else if fn != nil {
-			return &hookFnNode{f: fn, header: header}, nil
+			return &hookFnNode{f: fn, header: header, subplans: subplans}, nil
 		}
 	}
 	for _, planHook := range wrappedPlanHooks {


### PR DESCRIPTION
Plan hooks intercept certain statements and return their own plans for
them instead of allowing the usual sql planner to plan them. Their
planning returns a function that can then be called at execution time to
produce rows. However hooks are wholly responsible for planning these
statements -- the normal sql planner does not examine/plan any parts of
a statement once it is intercepted by a hook.

Furthermore, we do not want planning logic to jump back and forth across
the `sql` package boundry, so the sql package does not export many of
the helpers and methods required for planning the statements for which
is is responsible.

Previously this made it difficult for a statement handled by a hook plan
to include any sub-statements/clauses that would usually be handled by
normal planning -- the hook's plan creation was could not reuse any of the
`sql` planning logic.

This changes `planHookFn` to return a list of sub-plans when called to
do its initial planning.

The hook’s execution function is then passed a similar list of sub-plans
when called. These are the transformed versions of the ones returned by
the hook's intial planing, but prepared for execution by the usual logic
in sql.

Release note: none.