### PR TITLE
parser: add EXPORT statement syntax parsing

### DIFF
--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -17,6 +17,7 @@ stmt ::=
 	| drop_stmt
 	| execute_stmt
 	| explain_stmt
+	| export_stmt
 	| grant_stmt
 	| insert_stmt
 	| import_stmt
@@ -82,6 +83,9 @@ execute_stmt ::=
 explain_stmt ::=
 	'EXPLAIN' explainable_stmt
 	| 'EXPLAIN' '(' explain_option_list ')' explainable_stmt
+
+export_stmt ::=
+	'EXPORT' 'INTO' import_data_format string_or_placeholder opt_with_options 'FROM' select_stmt
 
 grant_stmt ::=
 	'GRANT' privileges 'ON' targets 'TO' name_list
@@ -309,6 +313,9 @@ explainable_stmt ::=
 explain_option_list ::=
 	( explain_option_name ) ( ( ',' explain_option_name ) )*
 
+import_data_format ::=
+	'CSV'
+
 privileges ::=
 	'ALL'
 	| privilege_list
@@ -331,9 +338,6 @@ insert_rest ::=
 on_conflict ::=
 	'ON' 'CONFLICT' opt_conf_expr 'DO' 'UPDATE' 'SET' set_clause_list where_clause
 	| 'ON' 'CONFLICT' opt_conf_expr 'DO' 'NOTHING'
-
-import_data_format ::=
-	'CSV'
 
 string_or_placeholder_list ::=
 	( string_or_placeholder ) ( ( ',' string_or_placeholder ) )*
@@ -655,6 +659,7 @@ unreserved_keyword ::=
 	| 'EXPERIMENTAL_FINGERPRINTS'
 	| 'EXPERIMENTAL_REPLICA'
 	| 'EXPLAIN'
+	| 'EXPORT'
 	| 'FILTER'
 	| 'FIRST'
 	| 'FLOAT4'

--- a/pkg/sql/parser/help_test.go
+++ b/pkg/sql/parser/help_test.go
@@ -357,6 +357,10 @@ func TestContextualHelp(t *testing.T) {
 
 		{`IMPORT TABLE foo CREATE USING 'foo.sql' CSV DATA ('foo') ??`, `IMPORT`},
 		{`IMPORT TABLE ??`, `IMPORT`},
+
+		{`EXPORT ??`, `EXPORT`},
+		{`EXPORT INTO CSV 'a' ??`, `EXPORT`},
+		{`EXPORT INTO CSV 'a' FROM SELECT a ??`, `SELECT`},
 	}
 
 	// The following checks that the test definition above exercises all

--- a/pkg/sql/parser/parse_test.go
+++ b/pkg/sql/parser/parse_test.go
@@ -948,6 +948,10 @@ func TestParse(t *testing.T) {
 		{`IMPORT TABLE foo CREATE USING 'nodelocal:///some/file' CSV DATA ('path/to/some/file', $1) WITH temp = 'path/to/temp'`},
 		{`IMPORT TABLE foo (id INT PRIMARY KEY, email STRING, age INT) CSV DATA ('path/to/some/file', $1) WITH temp = 'path/to/temp'`},
 		{`IMPORT TABLE foo (id INT, email STRING, age INT) CSV DATA ('path/to/some/file', $1) WITH comma = ',', "nullif" = 'n/a', temp = $2`},
+		{`EXPORT INTO CSV 'a' FROM TABLE a`},
+		{`EXPORT INTO CSV 'a' FROM SELECT * FROM a`},
+		{`EXPORT INTO CSV 's3://my/path/%part%.csv' WITH delimiter = '|' FROM TABLE a`},
+		{`EXPORT INTO CSV 's3://my/path/%part%.csv' WITH delimiter = '|' FROM SELECT a, sum(b) FROM c WHERE d = 1 ORDER BY sum(b) DESC LIMIT 10`},
 		{`SET ROW (1, true, NULL)`},
 
 		{`CREATE EXPERIMENTAL_CHANGEFEED EMIT foo TO kafka`},

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -470,7 +470,7 @@ func newNameFromStr(s string) *tree.Name {
 %token <str>   EXISTS EXPERIMENTAL_CHANGEFEED EXECUTE EXPERIMENTAL
 %token <str>   EXPERIMENTAL_FINGERPRINTS EXPERIMENTAL_REPLICA
 %token <str>   EXPERIMENTAL_AUDIT
-%token <str>   EXPLAIN EXTRACT EXTRACT_DURATION
+%token <str>   EXPLAIN EXPORT EXTRACT EXTRACT_DURATION
 
 %token <str>   FALSE FAMILY FETCH FETCHVAL FETCHTEXT FETCHVAL_PATH FETCHTEXT_PATH FILTER
 %token <str>   FIRST FLOAT FLOAT4 FLOAT8 FLOORDIV FOLLOWING FOR FORCE_INDEX FOREIGN FROM FULL
@@ -650,6 +650,7 @@ func newNameFromStr(s string) *tree.Name {
 %type <tree.Statement> prepare_stmt
 %type <tree.Statement> preparable_stmt
 %type <tree.Statement> explainable_stmt
+%type <tree.Statement> export_stmt
 %type <tree.Statement> execute_stmt
 %type <tree.Statement> deallocate_stmt
 %type <tree.Statement> grant_stmt
@@ -1033,6 +1034,7 @@ stmt:
 | drop_stmt       // help texts in sub-rule
 | execute_stmt    // EXTEND WITH HELP: EXECUTE
 | explain_stmt    // EXTEND WITH HELP: EXPLAIN
+| export_stmt     // EXTEND WITH HELP: EXPORT
 | grant_stmt      // EXTEND WITH HELP: GRANT
 | insert_stmt     // EXTEND WITH HELP: INSERT
 | import_stmt     // EXTEND WITH HELP: IMPORT
@@ -1579,7 +1581,7 @@ import_data_format:
 //    distributed = '...'
 //    sstsize = '...'
 //    temp = '...'
-//    comma = '...'          [CSV-specific]
+//    delimiter = '...'      [CSV-specific]
 //    comment = '...'        [CSV-specific]
 //    nullif = '...'         [CSV-specific]
 //
@@ -1594,6 +1596,26 @@ import_stmt:
     $$.val = &tree.Import{Table: $3.normalizableTableNameFromUnresolvedName(), CreateDefs: $5.tblDefs(), FileFormat: $7, Files: $10.exprs(), Options: $12.kvOptions()}
   }
 | IMPORT error // SHOW HELP: IMPORT
+
+
+// %Help: EXPORT - export data to file in a distributed manner
+// %Category: CCL
+// %Text:
+// EXPORT <format> (<datafile> [WITH <option> [= value] [,...]]) <query>
+//
+// Formats:
+//    CSV
+//
+// Options:
+//    delimiter = '...'   [CSV-specific]
+//
+// %SeeAlso: SELECT
+export_stmt:
+  EXPORT INTO import_data_format string_or_placeholder opt_with_options FROM select_stmt
+  {
+    $$.val = &tree.Export{Query: $7.slct(), FileFormat: $3, File: $4.expr(), Options: $5.kvOptions()}
+  }
+| EXPORT error // SHOW HELP: EXPORT
 
 string_or_placeholder:
   non_reserved_word_or_sconst
@@ -7530,6 +7552,7 @@ unreserved_keyword:
 | EXPERIMENTAL_FINGERPRINTS
 | EXPERIMENTAL_REPLICA
 | EXPLAIN
+| EXPORT
 | FILTER
 | FIRST
 | FLOAT4

--- a/pkg/sql/sem/tree/export.go
+++ b/pkg/sql/sem/tree/export.go
@@ -1,0 +1,39 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package tree
+
+// Export represents a EXPORT statement.
+type Export struct {
+	Query      *Select
+	FileFormat string
+	File       Expr
+	Options    KVOptions
+}
+
+var _ Statement = &Export{}
+
+// Format implements the NodeFormatter interface.
+func (node *Export) Format(ctx *FmtCtx) {
+	ctx.WriteString("EXPORT INTO ")
+	ctx.WriteString(node.FileFormat)
+	ctx.WriteString(" ")
+	ctx.FormatNode(node.File)
+	if node.Options != nil {
+		ctx.WriteString(" WITH ")
+		ctx.FormatNode(&node.Options)
+	}
+	ctx.WriteString(" FROM ")
+	ctx.FormatNode(node.Query)
+}

--- a/pkg/sql/sem/tree/stmt.go
+++ b/pkg/sql/sem/tree/stmt.go
@@ -396,6 +396,12 @@ func (*Explain) StatementTag() string { return "EXPLAIN" }
 func (*Explain) hiddenFromStats() {}
 
 // StatementType implements the Statement interface.
+func (*Export) StatementType() StatementType { return Rows }
+
+// StatementTag returns a short string identifying the type of statement.
+func (*Export) StatementTag() string { return "EXPORT" }
+
+// StatementType implements the Statement interface.
 func (*Grant) StatementType() StatementType { return DDL }
 
 // StatementTag returns a short string identifying the type of statement.
@@ -907,6 +913,7 @@ func (n *DropSequence) String() string              { return AsString(n) }
 func (n *DropUser) String() string                  { return AsString(n) }
 func (n *Execute) String() string                   { return AsString(n) }
 func (n *Explain) String() string                   { return AsString(n) }
+func (n *Export) String() string                    { return AsString(n) }
 func (n *Grant) String() string                     { return AsString(n) }
 func (n *GrantRole) String() string                 { return AsString(n) }
 func (n *Insert) String() string                    { return AsString(n) }


### PR DESCRIPTION
Implementation to follow, but the export statement will allow exporting
arbitrary query results in CSV format to a designated storage location.

Release note: none.