### PR TITLE
distsqlrun: remove unnecessary uglifying of errors in tableReader

### DIFF
--- a/pkg/sql/distsqlrun/tablereader.go
+++ b/pkg/sql/distsqlrun/tablereader.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
-	"github.com/cockroachdb/cockroach/pkg/sql/scrub"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -247,14 +246,12 @@ func (tr *tableReader) Next() (sqlbase.EncDatumRow, *ProducerMetadata) {
 
 	for {
 		row, meta := tr.input.Next()
-		var err error
+
 		if meta != nil {
-			err = meta.Err
+			return nil, meta
 		}
-		if row == nil || err != nil {
-			// This was the last-row or an error was encountered, annotate the
-			// metadata with misplanned ranges and trace data.
-			return nil, tr.producerMeta(scrub.UnwrapScrubError(err))
+		if row == nil {
+			return nil, tr.producerMeta(nil /* err */)
 		}
 
 		outRow, status, err := tr.out.ProcessRow(tr.ctx, row)


### PR DESCRIPTION
I assume this was left over from when tableReader and scrubTableReader
were sharing that code.

Release note: None