### PR TITLE
sql: bake 2.0 migrations into 2.1.

### DIFF
--- a/pkg/acceptance/testdata/Dockerfile
+++ b/pkg/acceptance/testdata/Dockerfile
@@ -31,10 +31,8 @@ RUN apt-get update \
 # The forward reference version is the oldest version from which we support
 # upgrading. The bidirectional reference version is the oldest version that we
 # support upgrading from and downgrading to.
-#
-# v1.1.0 has the wrong cluster version, so we need v1.1.1.
-ENV FORWARD_REFERENCE_VERSION="v1.1.1"
-ENV BIDIRECTIONAL_REFERENCE_VERSION="v1.1.1"
+ENV FORWARD_REFERENCE_VERSION="v2.0.0"
+ENV BIDIRECTIONAL_REFERENCE_VERSION="v2.0.0"
 RUN mkdir /opt/forward-reference-version /opt/bidirectional-reference-version \
  && curl -fsSL https://binaries.cockroachdb.com/cockroach-${FORWARD_REFERENCE_VERSION}.linux-amd64.tgz \
     | tar xz -C /opt/forward-reference-version --strip-components=1 \

--- a/pkg/acceptance/util_docker.go
+++ b/pkg/acceptance/util_docker.go
@@ -62,7 +62,7 @@ func testDockerSuccess(ctx context.Context, t *testing.T, name string, cmd []str
 const (
 	// Iterating against a locally built version of the docker image can be done
 	// by changing acceptanceImage to the hash of the container.
-	acceptanceImage = "docker.io/cockroachdb/acceptance:20180321-163009"
+	acceptanceImage = "docker.io/cockroachdb/acceptance:20180416-090309"
 )
 
 func testDocker(

--- a/pkg/acceptance/version_upgrade_test.go
+++ b/pkg/acceptance/version_upgrade_test.go
@@ -220,11 +220,15 @@ func testVersionUpgrade(ctx context.Context, t *testing.T, cfg cluster.TestConfi
 		binaryVersionUpgrade("v1.1.0"),
 		clusterVersionUpgrade("1.0"),
 		clusterVersionUpgrade("1.0-3"),
+
 		binaryVersionUpgrade("v1.1.1"),
 		clusterVersionUpgrade("1.1"),
-		binaryVersionUpgrade(sourceVersion),
+
+		binaryVersionUpgrade("v2.0.0"),
 		clusterVersionUpgrade("1.1-6"),
 		clusterVersionUpgrade("2.0"),
+
+		binaryVersionUpgrade(sourceVersion),
 		clusterVersionUpgrade(clusterversion.BinaryServerVersion.String()),
 	}
 

--- a/pkg/sql/sqlbase/privilege.go
+++ b/pkg/sql/sqlbase/privilege.go
@@ -78,12 +78,6 @@ func (p *PrivilegeDescriptor) removeUser(user string) {
 	p.Users = append(p.Users[:idx], p.Users[idx+1:]...)
 }
 
-// NewCustomRootPrivilegeDescriptor returns a privilege descriptor for the root user
-// and specified privileges.
-func NewCustomRootPrivilegeDescriptor(priv privilege.List) *PrivilegeDescriptor {
-	return NewPrivilegeDescriptor(security.RootUser, priv)
-}
-
 // NewCustomSuperuserPrivilegeDescriptor returns a privilege descriptor for the root user
 // and the admin role with specified privileges.
 func NewCustomSuperuserPrivilegeDescriptor(priv privilege.List) *PrivilegeDescriptor {

--- a/pkg/sql/sqlbase/system.go
+++ b/pkg/sql/sqlbase/system.go
@@ -247,7 +247,7 @@ var (
 		Name: "system",
 		ID:   keys.SystemDatabaseID,
 		// Assign max privileges to root user.
-		Privileges: NewCustomRootPrivilegeDescriptor(SystemAllowedPrivileges[keys.SystemDatabaseID]),
+		Privileges: NewCustomSuperuserPrivilegeDescriptor(SystemAllowedPrivileges[keys.SystemDatabaseID]),
 	}
 
 	// NamespaceTable is the descriptor for the namespace table.
@@ -276,7 +276,7 @@ var (
 			ColumnIDs:        []ColumnID{1, 2},
 		},
 		NextIndexID:    2,
-		Privileges:     NewCustomRootPrivilegeDescriptor(SystemAllowedPrivileges[keys.NamespaceTableID]),
+		Privileges:     NewCustomSuperuserPrivilegeDescriptor(SystemAllowedPrivileges[keys.NamespaceTableID]),
 		FormatVersion:  InterleavedFormatVersion,
 		NextMutationID: 1,
 	}
@@ -285,7 +285,7 @@ var (
 	DescriptorTable = TableDescriptor{
 		Name:       "descriptor",
 		ID:         keys.DescriptorTableID,
-		Privileges: NewCustomRootPrivilegeDescriptor(SystemAllowedPrivileges[keys.DescriptorTableID]),
+		Privileges: NewCustomSuperuserPrivilegeDescriptor(SystemAllowedPrivileges[keys.DescriptorTableID]),
 		ParentID:   keys.SystemDatabaseID,
 		Version:    1,
 		Columns: []ColumnDescriptor{
@@ -322,7 +322,7 @@ var (
 		PrimaryIndex:   pk("username"),
 		NextFamilyID:   3,
 		NextIndexID:    2,
-		Privileges:     NewCustomRootPrivilegeDescriptor(SystemAllowedPrivileges[keys.UsersTableID]),
+		Privileges:     NewCustomSuperuserPrivilegeDescriptor(SystemAllowedPrivileges[keys.UsersTableID]),
 		FormatVersion:  InterleavedFormatVersion,
 		NextMutationID: 1,
 	}
@@ -352,7 +352,7 @@ var (
 		},
 		NextFamilyID:   3,
 		NextIndexID:    2,
-		Privileges:     NewCustomRootPrivilegeDescriptor(SystemAllowedPrivileges[keys.ZonesTableID]),
+		Privileges:     NewCustomSuperuserPrivilegeDescriptor(SystemAllowedPrivileges[keys.ZonesTableID]),
 		FormatVersion:  InterleavedFormatVersion,
 		NextMutationID: 1,
 	}
@@ -380,7 +380,7 @@ var (
 		NextFamilyID:   1,
 		PrimaryIndex:   pk("name"),
 		NextIndexID:    2,
-		Privileges:     NewCustomRootPrivilegeDescriptor(SystemAllowedPrivileges[keys.SettingsTableID]),
+		Privileges:     NewCustomSuperuserPrivilegeDescriptor(SystemAllowedPrivileges[keys.SettingsTableID]),
 		FormatVersion:  InterleavedFormatVersion,
 		NextMutationID: 1,
 	}
@@ -418,7 +418,7 @@ var (
 		},
 		NextFamilyID:   1,
 		NextIndexID:    2,
-		Privileges:     NewCustomRootPrivilegeDescriptor(SystemAllowedPrivileges[keys.LeaseTableID]),
+		Privileges:     NewCustomSuperuserPrivilegeDescriptor(SystemAllowedPrivileges[keys.LeaseTableID]),
 		FormatVersion:  InterleavedFormatVersion,
 		NextMutationID: 1,
 	}
@@ -457,7 +457,7 @@ var (
 		},
 		NextFamilyID:   6,
 		NextIndexID:    2,
-		Privileges:     NewCustomRootPrivilegeDescriptor(SystemAllowedPrivileges[keys.EventLogTableID]),
+		Privileges:     NewCustomSuperuserPrivilegeDescriptor(SystemAllowedPrivileges[keys.EventLogTableID]),
 		FormatVersion:  InterleavedFormatVersion,
 		NextMutationID: 1,
 	}
@@ -498,7 +498,7 @@ var (
 		},
 		NextFamilyID:   7,
 		NextIndexID:    2,
-		Privileges:     NewCustomRootPrivilegeDescriptor(SystemAllowedPrivileges[keys.RangeEventTableID]),
+		Privileges:     NewCustomSuperuserPrivilegeDescriptor(SystemAllowedPrivileges[keys.RangeEventTableID]),
 		FormatVersion:  InterleavedFormatVersion,
 		NextMutationID: 1,
 	}
@@ -523,7 +523,7 @@ var (
 		NextFamilyID:   4,
 		PrimaryIndex:   pk("key"),
 		NextIndexID:    2,
-		Privileges:     NewCustomRootPrivilegeDescriptor(SystemAllowedPrivileges[keys.UITableID]),
+		Privileges:     NewCustomSuperuserPrivilegeDescriptor(SystemAllowedPrivileges[keys.UITableID]),
 		FormatVersion:  InterleavedFormatVersion,
 		NextMutationID: 1,
 	}
@@ -565,7 +565,7 @@ var (
 			},
 		},
 		NextIndexID:    3,
-		Privileges:     NewCustomRootPrivilegeDescriptor(SystemAllowedPrivileges[keys.JobsTableID]),
+		Privileges:     NewCustomSuperuserPrivilegeDescriptor(SystemAllowedPrivileges[keys.JobsTableID]),
 		FormatVersion:  InterleavedFormatVersion,
 		NextMutationID: 1,
 	}
@@ -627,7 +627,7 @@ var (
 			},
 		},
 		NextIndexID:    4,
-		Privileges:     NewCustomRootPrivilegeDescriptor(SystemAllowedPrivileges[keys.WebSessionsTableID]),
+		Privileges:     NewCustomSuperuserPrivilegeDescriptor(SystemAllowedPrivileges[keys.WebSessionsTableID]),
 		NextMutationID: 1,
 		FormatVersion:  3,
 	}
@@ -678,7 +678,7 @@ var (
 			ColumnIDs:        []ColumnID{1, 2},
 		},
 		NextIndexID:    2,
-		Privileges:     NewCustomRootPrivilegeDescriptor(SystemAllowedPrivileges[keys.TableStatisticsTableID]),
+		Privileges:     NewCustomSuperuserPrivilegeDescriptor(SystemAllowedPrivileges[keys.TableStatisticsTableID]),
 		FormatVersion:  InterleavedFormatVersion,
 		NextMutationID: 1,
 	}
@@ -720,7 +720,7 @@ var (
 			ColumnIDs:        []ColumnID{1, 2},
 		},
 		NextIndexID:    2,
-		Privileges:     NewCustomRootPrivilegeDescriptor(SystemAllowedPrivileges[keys.LocationsTableID]),
+		Privileges:     NewCustomSuperuserPrivilegeDescriptor(SystemAllowedPrivileges[keys.LocationsTableID]),
 		FormatVersion:  InterleavedFormatVersion,
 		NextMutationID: 1,
 	}
@@ -787,13 +787,6 @@ var (
 		FormatVersion:  InterleavedFormatVersion,
 		NextMutationID: 1,
 	}
-
-//***************************************************************************
-// WARNING: any tables added after LocationsTable must use:
-//   Privileges: NewCustomSuperuserPrivilegeDescriptor(...)
-// instead of
-//   Privileges: NewCustomRootPrivilegeDescriptor(...)
-//***************************************************************************
 )
 
 // Create the key/value pair for the default zone config entry.

--- a/pkg/sql/sqlbase/system.go
+++ b/pkg/sql/sqlbase/system.go
@@ -832,6 +832,11 @@ func addSystemDatabaseToSchema(target *MetadataSchema) {
 	target.AddDescriptor(keys.SystemDatabaseID, &SettingsTable)
 	target.AddDescriptor(keys.SystemDatabaseID, &WebSessionsTable)
 
+	// Tables introduced in 2.0, added here for 2.1.
+	target.AddDescriptor(keys.SystemDatabaseID, &TableStatisticsTable)
+	target.AddDescriptor(keys.SystemDatabaseID, &LocationsTable)
+	target.AddDescriptor(keys.SystemDatabaseID, &RoleMembersTable)
+
 	// Adding a new system table? Don't add it to the metadata schema yet!
 	//
 	// The first release to contain the system table must add the system table

--- a/pkg/sql/tests/system_table_test.go
+++ b/pkg/sql/tests/system_table_test.go
@@ -103,26 +103,23 @@ func TestSystemTableLiterals(t *testing.T) {
 		id     sqlbase.ID
 		schema string
 		pkg    sqlbase.TableDescriptor
-		// Starting with the RoleMembers table, all newly created tables have two sets of privileges:
-		// one for "root", another for "admin". Previous tables get them through a migration.
-		hasAdmin bool
 	}
 
 	for _, test := range []testcase{
-		{keys.NamespaceTableID, sqlbase.NamespaceTableSchema, sqlbase.NamespaceTable, false},
-		{keys.DescriptorTableID, sqlbase.DescriptorTableSchema, sqlbase.DescriptorTable, false},
-		{keys.UsersTableID, sqlbase.UsersTableSchema, sqlbase.UsersTable, false},
-		{keys.ZonesTableID, sqlbase.ZonesTableSchema, sqlbase.ZonesTable, false},
-		{keys.LeaseTableID, sqlbase.LeaseTableSchema, sqlbase.LeaseTable, false},
-		{keys.EventLogTableID, sqlbase.EventLogTableSchema, sqlbase.EventLogTable, false},
-		{keys.RangeEventTableID, sqlbase.RangeEventTableSchema, sqlbase.RangeEventTable, false},
-		{keys.UITableID, sqlbase.UITableSchema, sqlbase.UITable, false},
-		{keys.JobsTableID, sqlbase.JobsTableSchema, sqlbase.JobsTable, false},
-		{keys.SettingsTableID, sqlbase.SettingsTableSchema, sqlbase.SettingsTable, false},
-		{keys.WebSessionsTableID, sqlbase.WebSessionsTableSchema, sqlbase.WebSessionsTable, false},
-		{keys.TableStatisticsTableID, sqlbase.TableStatisticsTableSchema, sqlbase.TableStatisticsTable, false},
-		{keys.LocationsTableID, sqlbase.LocationsTableSchema, sqlbase.LocationsTable, false},
-		{keys.RoleMembersTableID, sqlbase.RoleMembersTableSchema, sqlbase.RoleMembersTable, true},
+		{keys.NamespaceTableID, sqlbase.NamespaceTableSchema, sqlbase.NamespaceTable},
+		{keys.DescriptorTableID, sqlbase.DescriptorTableSchema, sqlbase.DescriptorTable},
+		{keys.UsersTableID, sqlbase.UsersTableSchema, sqlbase.UsersTable},
+		{keys.ZonesTableID, sqlbase.ZonesTableSchema, sqlbase.ZonesTable},
+		{keys.LeaseTableID, sqlbase.LeaseTableSchema, sqlbase.LeaseTable},
+		{keys.EventLogTableID, sqlbase.EventLogTableSchema, sqlbase.EventLogTable},
+		{keys.RangeEventTableID, sqlbase.RangeEventTableSchema, sqlbase.RangeEventTable},
+		{keys.UITableID, sqlbase.UITableSchema, sqlbase.UITable},
+		{keys.JobsTableID, sqlbase.JobsTableSchema, sqlbase.JobsTable},
+		{keys.SettingsTableID, sqlbase.SettingsTableSchema, sqlbase.SettingsTable},
+		{keys.WebSessionsTableID, sqlbase.WebSessionsTableSchema, sqlbase.WebSessionsTable},
+		{keys.TableStatisticsTableID, sqlbase.TableStatisticsTableSchema, sqlbase.TableStatisticsTable},
+		{keys.LocationsTableID, sqlbase.LocationsTableSchema, sqlbase.LocationsTable},
+		{keys.RoleMembersTableID, sqlbase.RoleMembersTableSchema, sqlbase.RoleMembersTable},
 	} {
 		// Always create tables with "admin" privileges included, or CreateTestTableDescriptor fails.
 		privs := sqlbase.NewCustomSuperuserPrivilegeDescriptor(sqlbase.SystemAllowedPrivileges[test.id])
@@ -135,11 +132,6 @@ func TestSystemTableLiterals(t *testing.T) {
 		)
 		if err != nil {
 			t.Fatalf("test: %+v, err: %v", test, err)
-		}
-		// Privileges for the admin user get automatically added in CreateTestTableDescriptor,
-		// we need to remove them for tables that only get it through migrations.
-		if !test.hasAdmin {
-			gen.Privileges = sqlbase.NewCustomRootPrivilegeDescriptor(sqlbase.SystemAllowedPrivileges[test.id])
 		}
 
 		if !proto.Equal(&test.pkg, &gen) {

--- a/pkg/sqlmigrations/migrations.go
+++ b/pkg/sqlmigrations/migrations.go
@@ -172,9 +172,12 @@ var backwardCompatibleMigrations = []migrationDescriptor{
 	},
 	{
 		// Introduced in v2.0.
-		// TODO(mberhault): bake this migration into v2.1, but create a new migration
-		// with the same function to catch any tables written in a mixed-version setting.
-		name:   "ensure admin role privileges in all descriptors",
+		name: "ensure admin role privileges in all descriptors",
+	},
+	{
+		// Introduced in v2.1, repeat of 2.0 migration to catch mixed-version issues.
+		// TODO(mberhault): bake into v2.2.
+		name:   "ensure admin role privileges in all descriptors, again",
 		workFn: ensureMaxPrivileges,
 	},
 }

--- a/pkg/sqlmigrations/migrations.go
+++ b/pkg/sqlmigrations/migrations.go
@@ -105,11 +105,8 @@ var backwardCompatibleMigrations = []migrationDescriptor{
 		workFn: disableNetTrace,
 	},
 	{
-		// Introduced in v2.0.
-		// TODO(benesch): bake this migration into v2.1.
-		name:             "create system.table_statistics table",
-		workFn:           createTableStatisticsTable,
-		newDescriptorIDs: []sqlbase.ID{keys.TableStatisticsTableID},
+		// Introduced in v2.0. Baked into v2.1.
+		name: "create system.table_statistics table",
 	},
 	{
 		// Introduced in v2.0.
@@ -118,11 +115,8 @@ var backwardCompatibleMigrations = []migrationDescriptor{
 		workFn: addRootUser,
 	},
 	{
-		// Introduced in v2.0.
-		// TODO(benesch): bake this migration into v2.1.
-		name:             "create system.locations table",
-		workFn:           createLocationsTable,
-		newDescriptorIDs: []sqlbase.ID{keys.LocationsTableID},
+		// Introduced in v2.0. Baked into v2.1.
+		name: "create system.locations table",
 	},
 	{
 		// Introduced in v2.0.
@@ -131,11 +125,8 @@ var backwardCompatibleMigrations = []migrationDescriptor{
 		workFn: addDefaultMetaAndLivenessZoneConfigs,
 	},
 	{
-		// Introduced in v2.0.
-		// TODO(benesch): bake this migration into v2.1.
-		name:             "create system.role_members table",
-		workFn:           createRoleMembersTable,
-		newDescriptorIDs: []sqlbase.ID{keys.RoleMembersTableID},
+		// Introduced in v2.0. Baked into v2.1.
+		name: "create system.role_members table",
 	},
 	{
 		// Introduced in v2.0.
@@ -465,18 +456,6 @@ func getCompletedMigrations(ctx context.Context, db db) (map[string]struct{}, er
 
 func migrationKey(migration migrationDescriptor) roachpb.Key {
 	return append(keys.MigrationPrefix, roachpb.RKey(migration.name)...)
-}
-
-func createTableStatisticsTable(ctx context.Context, r runner) error {
-	return createSystemTable(ctx, r, sqlbase.TableStatisticsTable)
-}
-
-func createLocationsTable(ctx context.Context, r runner) error {
-	return createSystemTable(ctx, r, sqlbase.LocationsTable)
-}
-
-func createRoleMembersTable(ctx context.Context, r runner) error {
-	return createSystemTable(ctx, r, sqlbase.RoleMembersTable)
 }
 
 func createSystemTable(ctx context.Context, r runner, desc sqlbase.TableDescriptor) error {

--- a/pkg/sqlmigrations/migrations.go
+++ b/pkg/sqlmigrations/migrations.go
@@ -146,10 +146,8 @@ var backwardCompatibleMigrations = []migrationDescriptor{
 		workFn: addRootToAdminRole,
 	},
 	{
-		// Introduced in v2.0.
-		// TODO(benesch): bake this migration into v2.1.
-		name:   "upgrade table descs to interleaved format version",
-		workFn: upgradeTableDescsToInterleavedFormatVersion,
+		// Introduced in v2.0. Repeated in v2.1 below.
+		name: "upgrade table descs to interleaved format version",
 	},
 	{
 		// Introduced in v2.0 alphas then folded into `retiredSettings`.
@@ -171,13 +169,19 @@ var backwardCompatibleMigrations = []migrationDescriptor{
 		workFn: initializeClusterSecret,
 	},
 	{
-		// Introduced in v2.0.
+		// Introduced in v2.0. Repeated in v2.1 below.
 		name: "ensure admin role privileges in all descriptors",
 	},
 	{
 		// Introduced in v2.1, repeat of 2.0 migration to catch mixed-version issues.
 		// TODO(mberhault): bake into v2.2.
-		name:   "ensure admin role privileges in all descriptors, again",
+		name:   "repeat: upgrade table descs to interleaved format version",
+		workFn: upgradeTableDescsToInterleavedFormatVersion,
+	},
+	{
+		// Introduced in v2.1, repeat of 2.0 migration to catch mixed-version issues.
+		// TODO(mberhault): bake into v2.2.
+		name:   "repeat: ensure admin role privileges in all descriptors",
 		workFn: ensureMaxPrivileges,
 	},
 }

--- a/pkg/sqlmigrations/migrations_test.go
+++ b/pkg/sqlmigrations/migrations_test.go
@@ -719,7 +719,7 @@ func TestUpgradeTableDescsToInterleavedFormatVersionMigration(t *testing.T) {
 	mt := makeMigrationTest(ctx, t)
 	defer mt.close(ctx)
 
-	migration := mt.pop(t, "upgrade table descs to interleaved format version")
+	migration := mt.pop(t, "repeat: upgrade table descs to interleaved format version")
 	mt.start(t, base.TestServerArgs{
 		Knobs: base.TestingKnobs{
 			SQLSchemaChanger: &sql.SchemaChangerTestingKnobs{


### PR DESCRIPTION
Bake some of the 2.0 migrations into 2.1. Others are repeated, and yet others are still to be done.
Tweak version tests to properly run 2.0 before 2.1.