### PR TITLE
sql/jobs: fix race in tests

### DIFF
--- a/pkg/sql/jobs/jobs_test.go
+++ b/pkg/sql/jobs/jobs_test.go
@@ -171,7 +171,7 @@ func TestRegistryLifecycle(t *testing.T) {
 
 	check := func(t *testing.T) {
 		t.Helper()
-		if err := retry.ForDuration(time.Second*2, func() error {
+		if err := retry.ForDuration(time.Second*5, func() error {
 			lock.Lock()
 			defer lock.Unlock()
 			if e != a {
@@ -183,8 +183,10 @@ func TestRegistryLifecycle(t *testing.T) {
 		}
 	}
 	clear := func() {
+		lock.Lock()
 		a = Counters{}
 		e = Counters{}
+		lock.Unlock()
 	}
 
 	resumeCh := make(chan error)


### PR DESCRIPTION
Add a lock to prevent the race detector from triggering.

Increase the wait time so stressrace works.

Release note: None

Fixes #24723
Fixes #24722
Fixes #24663
Fixes #24662
Fixes #24661