### PR TITLE
sql: allow relative AS OF queries with a negative interval

### DIFF
--- a/pkg/sql/as_of_test.go
+++ b/pkg/sql/as_of_test.go
@@ -161,7 +161,7 @@ func TestAsOfTime(t *testing.T) {
 	}
 
 	// String values that are neither timestamps nor decimals are an error.
-	if _, err := db.Query("SELECT a FROM d.t AS OF SYSTEM TIME 'xxx'"); !testutils.IsError(err, "value is neither timestamp nor decimal") {
+	if _, err := db.Query("SELECT a FROM d.t AS OF SYSTEM TIME 'xxx'"); !testutils.IsError(err, "value is neither timestamp, decimal, nor interval") {
 		t.Fatal(err)
 	}
 

--- a/pkg/sql/logictest/testdata/logic_test/as_of
+++ b/pkg/sql/logictest/testdata/logic_test/as_of
@@ -1,0 +1,30 @@
+# LogicTest: default
+
+statement ok
+CREATE TABLE t (i INT)
+
+statement ok
+INSERT INTO t VALUES (2)
+
+# Verify strings can be parsed as intervals.
+query I
+SELECT * FROM t AS OF SYSTEM TIME '-0ns'
+----
+2
+
+query I
+SELECT * FROM t AS OF SYSTEM TIME '-1ns'
+----
+2
+
+# Verify a forced interval type works.
+query I
+SELECT * FROM t AS OF SYSTEM TIME INTERVAL '-1ns'
+----
+2
+
+statement error pq: relation "t" does not exist
+SELECT * FROM t AS OF SYSTEM TIME '-1h'
+
+statement error cannot specify timestamp in the future
+SELECT * FROM t AS OF SYSTEM TIME '10s'


### PR DESCRIPTION
Accept an interval type or a string with a valid interval. The interval
is added to the statement's statement_timestamp() time. This can be
used to run relative AOST queries without calculating the time in
the constant.

Fixes #16424

Release note: AS OF SYSTEM TIME queries now accept a negative interval
to produce a relative time from the statement's statement_timestamp()
time.