### PR TITLE
sql: enhance the error message when a target name is invalid

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/table
+++ b/pkg/sql/logictest/testdata/logic_test/table
@@ -3,7 +3,7 @@
 statement ok
 SET DATABASE = ""
 
-statement error invalid target name: "a"
+statement error no schema has been selected to create "a" in
 CREATE TABLE a (id INT PRIMARY KEY)
 
 statement error invalid table name: test.""

--- a/pkg/sql/resolver.go
+++ b/pkg/sql/resolver.go
@@ -151,8 +151,9 @@ func ResolveTargetObject(
 		return nil, err
 	}
 	if !found {
-		return nil, pgerror.NewErrorf(pgerror.CodeInvalidNameError,
-			"invalid target name: %q", tree.ErrString(tn))
+		return nil, pgerror.NewErrorf(pgerror.CodeInvalidSchemaNameError,
+			"no schema has been selected to create %q in",
+			tree.ErrString(tn)).SetHintf("verify that the current database and search_path are valid")
 	}
 	if tn.Schema() != tree.PublicSchema {
 		return nil, pgerror.NewErrorf(pgerror.CodeInvalidNameError,


### PR DESCRIPTION
Fixes #24056.

If there's no valid db or schema, CockroachDB would print "invalid
target name" which is a bit cryptic and non-actionable. This patch
enhances this.

Before:

```
root@:26257/> create table a (a int primary key);
pq: invalid target name: "a"
```

After:

```
root@:26257/> create table a (a int primary key);
pq: no schema has been selected to create "a" in
HINT: check the current database and search_path are valid
```

The text "no schema has been selected to create in" is taken over from
PostgreSQL which uses it in the same situation.

Release note (sql change): the error message produced upon object
creation when there is no current database selected or only invalid
schemas in `search_path` is now improved.