### PR TITLE
sql: clarify the error message upon access to vtable with no db

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/namespace
+++ b/pkg/sql/logictest/testdata/logic_test/namespace
@@ -52,7 +52,7 @@ SELECT x FROM pg_type
 
 # Leave database, check name resolves to default.
 # The expected error can only occur on the virtual pg_type, not the physical one.
-query error no database specified
+query error cannot access virtual schema in anonymous database
 SET DATABASE = ''; SELECT * FROM pg_type
 
 # Go to different database, check name still resolves to default.

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -1324,29 +1324,29 @@ user root
 statement ok
 SET DATABASE = ''
 
-query error no database specified
+query error cannot access virtual schema in anonymous database
 SELECT tablename FROM pg_catalog.pg_tables WHERE schemaname='public' ORDER BY 1
 
-query error no database specified
+query error cannot access virtual schema in anonymous database
 SELECT viewname FROM pg_catalog.pg_views WHERE schemaname='public' ORDER BY 1
 
-query error no database specified
+query error cannot access virtual schema in anonymous database
 SELECT relname FROM pg_catalog.pg_class c
 JOIN pg_catalog.pg_namespace n ON c.relnamespace = n.oid
 WHERE nspname='public'
 
-query error no database specified
+query error cannot access virtual schema in anonymous database
 SELECT conname FROM pg_catalog.pg_constraint con
 JOIN pg_catalog.pg_namespace n ON con.connamespace = n.oid
 WHERE n.nspname = 'public'
 
-query error no database specified
+query error cannot access virtual schema in anonymous database
 SELECT COUNT(*) FROM pg_catalog.pg_depend
 
-query error no database specified
+query error cannot access virtual schema in anonymous database
 select 'upper'::REGPROC;
 
-query error no database specified
+query error cannot access virtual schema in anonymous database
 select 'system.namespace'::regclass
 
 statement ok


### PR DESCRIPTION
Fixes #23958.

Prior to this patch:

```
root@:26257/> select * from pg_catalog.pg_class;
pq: no database specified
```

After:

```
root@:26257/> select * from pg_catalog.pg_class;
pq: cannot access virtual schema in anonymous database
HINT: verify that the current database is set
```

Release note (sql change): the error message produced upon accessing a
virtual schema with no database prefix (e.g. when `database` is not
set) is now clarified.