### PR TITLE
sql: fix ALTER INDEX RENAME on primary index

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/rename_index
+++ b/pkg/sql/logictest/testdata/logic_test/rename_index
@@ -91,3 +91,7 @@ ALTER INDEX users@ufo RENAME TO foo
 
 statement ok
 ALTER INDEX users@rar RENAME TO bar
+
+# Regression test for #24774
+statement ok
+ALTER INDEX users@"primary" RENAME TO pk

--- a/pkg/sql/rename_index.go
+++ b/pkg/sql/rename_index.go
@@ -77,7 +77,9 @@ func (p *planner) RenameIndex(ctx context.Context, n *tree.RenameIndex) (planNod
 		return nil, fmt.Errorf("index name %q already exists", string(n.NewName))
 	}
 
-	tableDesc.RenameIndexDescriptor(idx, string(n.NewName))
+	if err := tableDesc.RenameIndexDescriptor(idx, string(n.NewName)); err != nil {
+		return nil, err
+	}
 
 	if err := tableDesc.SetUpVersion(); err != nil {
 		return nil, err

--- a/pkg/sql/sqlbase/structured.go
+++ b/pkg/sql/sqlbase/structured.go
@@ -1896,21 +1896,25 @@ func (desc *TableDescriptor) FindIndexByName(name string) (IndexDescriptor, bool
 }
 
 // RenameIndexDescriptor renames an index descriptor.
-func (desc *TableDescriptor) RenameIndexDescriptor(index IndexDescriptor, name string) {
+func (desc *TableDescriptor) RenameIndexDescriptor(index IndexDescriptor, name string) error {
 	id := index.ID
+	if id == desc.PrimaryIndex.ID {
+		desc.PrimaryIndex.Name = name
+		return nil
+	}
 	for i := range desc.Indexes {
 		if desc.Indexes[i].ID == id {
 			desc.Indexes[i].Name = name
-			return
+			return nil
 		}
 	}
 	for _, m := range desc.Mutations {
 		if idx := m.GetIndex(); idx != nil && idx.ID == id {
 			idx.Name = name
-			return
+			return nil
 		}
 	}
-	panic(fmt.Sprintf("index with id = %d does not exist", id))
+	return fmt.Errorf("index with id = %d does not exist", id)
 }
 
 // FindIndexByID finds an index (active or inactive) with the specified ID.


### PR DESCRIPTION
Fixes #24774.

ALTER INDEX ... RENAME would crash if issued on the primary index.

Release note (bug fix): `ALTER INDEX ... RENAME` can now be used on
the primary index.