### PR TITLE
sql: fix qualified index name resolution

### DIFF
--- a/pkg/ccl/partitionccl/zone_test.go
+++ b/pkg/ccl/partitionccl/zone_test.go
@@ -220,11 +220,11 @@ func TestInvalidIndexPartitionSetShowZones(t *testing.T) {
 	}{
 		{
 			"ALTER INDEX foo EXPERIMENTAL CONFIGURE ZONE ''",
-			`no database specified: "foo"`,
+			`no schema has been selected to search index: "foo"`,
 		},
 		{
 			"EXPERIMENTAL SHOW ZONE CONFIGURATION FOR INDEX foo",
-			`no database specified: "foo"`,
+			`no schema has been selected to search index: "foo"`,
 		},
 		{
 			"USE system; ALTER INDEX foo EXPERIMENTAL CONFIGURE ZONE ''",

--- a/pkg/sql/logictest/testdata/logic_test/namespace
+++ b/pkg/sql/logictest/testdata/logic_test/namespace
@@ -22,7 +22,7 @@ t
 # Of course one can also list the tables in "public" by making it the
 # current database.
 statement ok
-SET DATABASE = public
+SET database = public
 
 query T
 SHOW TABLES
@@ -30,7 +30,7 @@ SHOW TABLES
 t
 
 statement ok
-SET DATABASE = test; DROP DATABASE public
+SET database = test; DROP DATABASE public
 
 # Unqualified pg_type resolves from pg_catalog.
 query T
@@ -40,7 +40,7 @@ date
 
 # Override table and check name resolves properly.
 statement ok
-SET SEARCH_PATH=public,pg_catalog
+SET search_path=public,pg_catalog
 
 statement ok
 CREATE TABLE pg_type(x INT); INSERT INTO pg_type VALUES(42)
@@ -53,23 +53,60 @@ SELECT x FROM pg_type
 # Leave database, check name resolves to default.
 # The expected error can only occur on the virtual pg_type, not the physical one.
 query error cannot access virtual schema in anonymous database
-SET DATABASE = ''; SELECT * FROM pg_type
+SET database = ''; SELECT * FROM pg_type
 
 # Go to different database, check name still resolves to default.
 query T
-CREATE DATABASE foo; SET DATABASE = foo; SELECT typname FROM pg_type WHERE typname = 'date'
+CREATE DATABASE foo; SET database = foo; SELECT typname FROM pg_type WHERE typname = 'date'
 ----
 date
 
 # Verify that pg_catalog at the beginning of the search path takes precedence.
 query T
-SET DATABASE = test; SET SEARCH_PATH = pg_catalog,public; SELECT typname FROM pg_type WHERE typname = 'date'
+SET database = test; SET search_path = pg_catalog,public; SELECT typname FROM pg_type WHERE typname = 'date'
 ----
 date
 
 # Now set the search path to the testdb, placing pg_catalog explicitly
 # at the end.
 query I
-SET SEARCH_PATH = public,pg_catalog; SELECT x FROM pg_type
+SET search_path = public,pg_catalog; SELECT x FROM pg_type
 ----
 42
+
+statement ok
+DROP TABLE pg_type; RESET search_path; SET database = test
+
+# Unqualified index name resolution.
+statement ok
+ALTER INDEX "primary" RENAME TO a_pk
+
+# Schema-qualified index name resolution.
+statement ok
+ALTER INDEX public.a_pk RENAME TO a_pk2
+
+# DB-qualified index name resolution (CRDB 1.x compat).
+statement ok
+ALTER INDEX test.a_pk2 RENAME TO a_pk3
+
+statement ok
+CREATE DATABASE public; CREATE TABLE public.public.t(a INT)
+
+# We can't see the DB "public" with DB-qualified index name resolution.
+statement error index "primary" does not exist
+ALTER INDEX public."primary" RENAME TO t_pk
+
+# But we can see it with sufficient qualification.
+statement ok
+ALTER INDEX public.public."primary" RENAME TO t_pk
+
+# If the search path is invalid, we get a special error.
+statement ok
+SET search_path = invalid
+
+statement error no schema has been selected to search index: "a_pk3"
+ALTER INDEX a_pk3 RENAME TO a_pk4
+
+# But qualification resolves the problem.
+statement ok
+ALTER INDEX public.a_pk3 RENAME TO a_pk4


### PR DESCRIPTION
Fixes #24475.
cc @nvanbenschoten 

In CockroachDB index names are relative to a table name
(e.g. `tbl@idx`) but in Postgres index names live in the schema
namespace. To offer compatibility with Postgres, CockroachDB
implements a special name resolution algorithm for index names
specified without the '@' syntax. For example, `DROP INDEX foo` will
search all tables in the current schema to find one with index name
`foo`.

Prior to this patch, CockroachDB was not able to search for a
_qualified_ index name specified without the '@' syntax. For example,
TypeORM issues `DROP INDEX public."primary"`, expecting to be able to
drop the primary index of some table in the `public` schema. This was
not recognized by CockroachDB.

This patch extends the name resolution for index names to support both
partial and complete qualification, using the same name resolution
rules as other objects.

Release note (sql change): CockroachDB now supports more ways to
specify an index name for statements that require one (e.g., `DROP
INDEX`, `ALTER INDEX ... RENAME`, etc.), in a way more compatible with
PostgreSQL.