### PR TITLE
distsqlrun: make the tableReader not ask its input for one too many rows

### DIFF
--- a/pkg/sql/distsqlrun/processors.go
+++ b/pkg/sql/distsqlrun/processors.go
@@ -349,6 +349,15 @@ func (h *ProcOutputHelper) ProcessRow(
 	return outRow, NeedMoreRows, nil
 }
 
+// LimitSatisfied returns true if sufficient rows have been processed (and have
+// passed the filter).
+//
+// TODO(andrei): This method should go away once we make ProcessRow able to
+// return a row and a status at the same time.
+func (h *ProcOutputHelper) LimitSatisfied() bool {
+	return h.rowIdx >= h.maxRowIdx
+}
+
 // Close signals to the output that there will be no more rows.
 func (h *ProcOutputHelper) Close() {
 	h.output.ProducerDone()

--- a/pkg/sql/distsqlrun/tablereader.go
+++ b/pkg/sql/distsqlrun/tablereader.go
@@ -258,6 +258,13 @@ func (tr *tableReader) Next() (sqlbase.EncDatumRow, *ProducerMetadata) {
 	}
 
 	for {
+		// Check whether calling input.Next() is necessary. Nobody else does this,
+		// but in the case of the TableReader calling Next() on a RowFetcher and one
+		// too many times and causing it run do another Scan is real bad.
+		if tr.out.LimitSatisfied() {
+			return nil, tr.producerMeta(nil /* err */)
+		}
+
 		row, meta := tr.input.Next()
 
 		if meta != nil {

--- a/pkg/sql/distsqlrun/tablereader_test.go
+++ b/pkg/sql/distsqlrun/tablereader_test.go
@@ -16,6 +16,8 @@ package distsqlrun
 
 import (
 	"context"
+	"fmt"
+	"regexp"
 	"sort"
 	"testing"
 
@@ -30,6 +32,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/tracing"
+	opentracing "github.com/opentracing/opentracing-go"
 )
 
 func TestTableReader(t *testing.T) {
@@ -287,7 +291,101 @@ ALTER TABLE t TESTING_RELOCATE VALUES (ARRAY[2], 1), (ARRAY[1], 2), (ARRAY[3], 3
 	})
 }
 
+// Test that a scan with a limit doesn't touch more ranges than necessary (i.e.
+// we properly set the limit on the underlying RowFetcher/KVFetcher).
+func TestLimitScans(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	s, sqlDB, kvDB := serverutils.StartServer(t, base.TestServerArgs{
+		UseDatabase: "test",
+	})
+	defer s.Stopper().Stop(context.Background())
+
+	sqlutils.CreateTable(t, sqlDB, "t",
+		"num INT PRIMARY KEY",
+		100, /* numRows */
+		sqlutils.ToRowFn(sqlutils.RowIdxFn))
+
+	if _, err := sqlDB.Exec("ALTER TABLE t SPLIT AT VALUES (5)"); err != nil {
+		t.Fatal(err)
+	}
+
+	tableDesc := sqlbase.GetTableDescriptor(kvDB, "test", "t")
+
+	evalCtx := tree.MakeTestingEvalContext(s.ClusterSettings())
+	defer evalCtx.Stop(context.Background())
+	flowCtx := FlowCtx{
+		EvalCtx:  evalCtx,
+		Settings: s.ClusterSettings(),
+		txn:      client.NewTxn(kvDB, s.NodeID(), client.RootTxn),
+		nodeID:   s.NodeID(),
+	}
+	spec := TableReaderSpec{
+		Table: *tableDesc,
+		Spans: []TableReaderSpan{{Span: tableDesc.PrimaryIndexSpan()}},
+	}
+	// We're going to ask for 3 rows, all contained in the first range.
+	post := PostProcessSpec{Limit: 3}
+
+	tr, err := newTableReader(&flowCtx, &spec, &post, nil /* output */)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Now we're going to run the tableReader and trace it.
+	tracer := tracing.NewTracer()
+	sp := tracer.StartSpan("root", tracing.Recordable)
+	tracing.StartRecording(sp, tracing.SnowballRecording)
+	ctx := opentracing.ContextWithSpan(context.Background(), sp)
+
+	tr.Start(ctx)
+	rows := 0
+	for {
+		row, meta := tr.Next()
+		if row != nil {
+			rows++
+		}
+
+		// Simulate what the DistSQLReceiver does and ingest the trace.
+		if meta != nil && len(meta.TraceData) > 0 {
+			if err := tracing.ImportRemoteSpans(sp, meta.TraceData); err != nil {
+				t.Fatal(err)
+			}
+		}
+
+		if row == nil && meta == nil {
+			break
+		}
+	}
+	if rows != 3 {
+		t.Fatalf("expected 3 rows, got: %d", rows)
+	}
+
+	// We're now going to count how many distinct scans we've done. This regex is
+	// specific so that we don't count range resolving requests, and we dedupe
+	// scans from the same key as the DistSender retries scans when it detects
+	// splits.
+	re := regexp.MustCompile(fmt.Sprintf(`querying next range at /Table/%d/1(\S.*)?`, tableDesc.ID))
+	spans := tracing.GetRecording(sp)
+	ranges := make(map[string]struct{})
+	for _, span := range spans {
+		for _, l := range span.Logs {
+			for _, f := range l.Fields {
+				match := re.FindStringSubmatch(f.Value)
+				if match == nil {
+					continue
+				}
+				ranges[match[1]] = struct{}{}
+			}
+		}
+	}
+	if len(ranges) != 1 {
+		t.Fatalf("expected one ranges scanned, got: %d (%+v)", len(ranges), ranges)
+	}
+}
+
 func BenchmarkTableReader(b *testing.B) {
+	defer leaktest.AfterTest(b)()
 	logScope := log.Scope(b)
 	defer logScope.Close(b)
 


### PR DESCRIPTION
When a tableReader was configured with a limit of, say, 10, we were only
finding out from its ProcOutputHelper that the limit was satisfied when
we were requesting a 11'th row. That had bad consequences, as the extra
row necessary was causing the underlying RowFetcher do to an extra scan
(10 times larger than the first scan).
The proper fix is for ProcOutputHelper.ProcessRow() to be able to both
return a processed row and to tell us that no further rows are necessary
at once. That's a larger change, though; upcoming. This here patch is a
simpler patch specific to the tableReader.

Fixes #24304

Release note: Some selects with limits no longer need a 2nd low-level
scan, resulting in much faster execution.