### PR TITLE
distsqlrun: fix tableReader ctx

### DIFF
--- a/pkg/sql/distsqlrun/tablereader.go
+++ b/pkg/sql/distsqlrun/tablereader.go
@@ -225,13 +225,13 @@ func (tr *tableReader) producerMeta(err error) *ProducerMetadata {
 
 // Start is part of the RowSource interface.
 func (tr *tableReader) Start(ctx context.Context) context.Context {
-	ctx = tr.startInternal(ctx, tableReaderProcName)
 	if sp := opentracing.SpanFromContext(ctx); sp != nil && tracing.IsRecording(sp) {
 		isc := NewInputStatCollector(tr.input, "tableReader input")
 		tr.stats = append(tr.stats, isc)
 		tr.input = isc
 	}
-	return tr.input.Start(ctx)
+	tr.input.Start(ctx)
+	return tr.startInternal(ctx, tableReaderProcName)
 }
 
 // Next is part of the RowSource interface.


### PR DESCRIPTION
The recent #24529 made a change: it switched to starting the tr's input
using the tr's ctx, instead of the ctx passed to tr.Start(). I think the
change was inadvertent. It diverges from the pattern used by every other
processor that implements RowSource: a proc's ctx is not supposed to be
used by other procs - e.g. it would lead to contradictory logging tags.
In this particular case of the tableReader, perhaps this is not the
worst thing in the world: the tr's input is not a generic rowSource, it
is precisely a RowFetcher (wrapped in layers and layers). So maybe it's
not so bad for the RowFetcher in particular to use a tr's ctx. But now
we've also introduced the InputStatCollector as a possible input, so
we're really pretending that the tr is just like any other proc with an
input. So, I went for uniformity.

Release note: None