### PR TITLE
cherry-pick 2.0: distsqlrun: make the tableReader not ask its input for one too many rows

### DIFF
--- a/pkg/sql/distsqlrun/processors.go
+++ b/pkg/sql/distsqlrun/processors.go
@@ -349,6 +349,15 @@ func (h *ProcOutputHelper) ProcessRow(
 	return outRow, NeedMoreRows, nil
 }
 
+// LimitSatisfied returns true if sufficient rows have been processed (and have
+// passed the filter).
+//
+// TODO(andrei): This method should go away once we make ProcessRow able to
+// return a row and a status at the same time.
+func (h *ProcOutputHelper) LimitSatisfied() bool {
+	return h.rowIdx >= h.maxRowIdx
+}
+
 // Close signals to the output that there will be no more rows.
 func (h *ProcOutputHelper) Close() {
 	h.output.ProducerDone()


### PR DESCRIPTION
Cherry-pick #24790, cosmetically adapted.

When a tableReader was configured with a limit of, say, 10, we were only
finding out from its ProcOutputHelper that the limit was satisfied when
we were requesting a 11'th row. That had bad consequences, as the extra
row necessary was causing the underlying RowFetcher do to an extra scan
(10 times larger than the first scan).
The proper fix is for ProcOutputHelper.ProcessRow() to be able to both
return a processed row and to tell us that no further rows are necessary
at once. That's a larger change, though; upcoming. This here patch is a
simpler patch specific to the tableReader.

Fixes #24304

Release note: Some selects with limits no longer need a 2nd low-level
scan, resulting in much faster execution.

cc @cockroachdb/release 