### PR TITLE
various: change strings.Index to strings.IndexByte

### DIFF
--- a/pkg/cmd/docgen/extract/xhtml.go
+++ b/pkg/cmd/docgen/extract/xhtml.go
@@ -39,7 +39,7 @@ func XHTMLtoHTML(r io.Reader) (string, error) {
 		t := z.Token()
 		switch t.Type {
 		case html.StartTagToken, html.EndTagToken, html.SelfClosingTagToken:
-			idx := strings.Index(t.Data, ":")
+			idx := strings.IndexByte(t.Data, ':')
 			t.Data = t.Data[idx+1:]
 		}
 		var na []html.Attribute

--- a/pkg/cmd/roachtest/test.go
+++ b/pkg/cmd/roachtest/test.go
@@ -378,7 +378,7 @@ func (t *test) decorate(s string) string {
 			break
 		}
 		file := frame.File
-		if index := strings.LastIndex(file, "/"); index >= 0 {
+		if index := strings.LastIndexByte(file, '/'); index >= 0 {
 			file = file[index+1:]
 		}
 		fmt.Fprintf(buf, "%s%s:%d", sep, file, frame.Line)

--- a/pkg/cmd/urlcheck/lib/urlcheck/urlcheck.go
+++ b/pkg/cmd/urlcheck/lib/urlcheck/urlcheck.go
@@ -197,7 +197,7 @@ func getURLs(filter stream.Filter) (map[string][]string, error) {
 			// Remove punctuation after the URL.
 			match = strings.TrimRight(match, ".,;\\\">`]")
 			// Remove the HTML target.
-			n := strings.LastIndex(match, "#")
+			n := strings.LastIndexByte(match, '#')
 			if n != -1 {
 				match = match[:n]
 			}

--- a/pkg/keys/printer.go
+++ b/pkg/keys/printer.go
@@ -217,7 +217,7 @@ func localStoreKeyParse(input string) (remainder string, output roachpb.Key) {
 			return
 		}
 	}
-	slashPos := strings.Index(input[1:], "/")
+	slashPos := strings.IndexByte(input[1:], '/')
 	if slashPos < 0 {
 		slashPos = len(input)
 	}
@@ -270,7 +270,7 @@ func localRangeIDKeyParse(input string) (remainder string, key roachpb.Key) {
 	var rangeID int64
 	var err error
 	input = mustShiftSlash(input)
-	if endPos := strings.Index(input, "/"); endPos > 0 {
+	if endPos := strings.IndexByte(input, '/'); endPos > 0 {
 		rangeID, err = strconv.ParseInt(input[:endPos], 10, 64)
 		if err != nil {
 			panic(err)

--- a/pkg/kv/replica_slice_test.go
+++ b/pkg/kv/replica_slice_test.go
@@ -72,7 +72,7 @@ func addr(nid roachpb.NodeID, sid roachpb.StoreID) util.UnresolvedAddr {
 func locality(t *testing.T, locStrs []string) roachpb.Locality {
 	var locality roachpb.Locality
 	for _, l := range locStrs {
-		idx := strings.Index(l, "=")
+		idx := strings.IndexByte(l, '=')
 		if idx == -1 {
 			t.Fatalf("locality %s not specified as <key>=<value>", l)
 		}

--- a/pkg/sql/parser/scan.go
+++ b/pkg/sql/parser/scan.go
@@ -166,15 +166,15 @@ func (s *Scanner) Error(e string) {
 	}
 
 	// Find the end of the line containing the last token.
-	i := strings.Index(s.in[s.lastTok.pos:], "\n")
+	i := strings.IndexByte(s.in[s.lastTok.pos:], '\n')
 	if i == -1 {
 		i = len(s.in)
 	} else {
 		i += s.lastTok.pos
 	}
 	// Find the beginning of the line containing the last token. Note that
-	// LastIndex returns -1 if "\n" could not be found.
-	j := strings.LastIndex(s.in[:s.lastTok.pos], "\n") + 1
+	// LastIndexByte returns -1 if '\n' could not be found.
+	j := strings.LastIndexByte(s.in[:s.lastTok.pos], '\n') + 1
 	// Output everything up to and including the line containing the last token.
 	var buf bytes.Buffer
 	fmt.Fprintf(&buf, "source SQL:\n%s\n", s.in[:i])

--- a/pkg/testutils/datadriven/test_data_reader.go
+++ b/pkg/testutils/datadriven/test_data_reader.go
@@ -87,7 +87,7 @@ func (r *testDataReader) Next(t *testing.T) bool {
 		for _, arg := range fields[1:] {
 			key := arg
 			var vals []string
-			if pos := strings.Index(key, "="); pos >= 0 {
+			if pos := strings.IndexByte(key, '='); pos >= 0 {
 				key = arg[:pos]
 				val := arg[pos+1:]
 

--- a/pkg/util/log/clog.go
+++ b/pkg/util/log/clog.go
@@ -267,7 +267,7 @@ func (t *traceLocation) match(file string, line int) bool {
 	if t.line != line {
 		return false
 	}
-	if i := strings.LastIndex(file, "/"); i >= 0 {
+	if i := strings.LastIndexByte(file, '/'); i >= 0 {
 		file = file[i+1:]
 	}
 	return t.file == file
@@ -1286,7 +1286,7 @@ func (l *loggingT) setV(pc uintptr) level {
 	if strings.HasSuffix(file, ".go") {
 		file = file[:len(file)-3]
 	}
-	if slash := strings.LastIndex(file, "/"); slash >= 0 {
+	if slash := strings.LastIndexByte(file, '/'); slash >= 0 {
 		file = file[slash+1:]
 	}
 	for _, filter := range l.vmodule.filter {

--- a/pkg/util/log/file.go
+++ b/pkg/util/log/file.go
@@ -145,7 +145,7 @@ func init() {
 // shortHostname returns its argument, truncating at the first period.
 // For instance, given "www.google.com" it returns "www".
 func shortHostname(hostname string) string {
-	if i := strings.Index(hostname, "."); i >= 0 {
+	if i := strings.IndexByte(hostname, '.'); i >= 0 {
 		return hostname[:i]
 	}
 	return hostname


### PR DESCRIPTION
In various places as changed in this commit, we can easily
improve performance (measurably) by changing calls to strings.Index
or strings.LastIndex to strings.IndexByte or strings.LastIndexByte.
No functionality is changed here. Most of the code in this repository
already does it my suggested way.
Benchmarks here: https://github.com/dchenk/strings-index