### PR TITLE
server: skip TestAdminApiReplicaMatrix

### DIFF
--- a/pkg/server/admin_test.go
+++ b/pkg/server/admin_test.go
@@ -1315,6 +1315,9 @@ func TestAdminAPIFullRangeLog(t *testing.T) {
 
 func TestAdminAPIReplicaMatrix(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+
+	t.Skip("#24802")
+
 	testCluster := serverutils.StartTestCluster(t, 3, base.TestClusterArgs{})
 	defer testCluster.Stopper().Stop(context.Background())
 


### PR DESCRIPTION
Until I figure out how to deflake it (sometimes fails under stress).

Seems like somehow the ids of the tables created in this test are not fully deterministic, and sometimes their ranges don't replicate to all three nodes within the 45s window of `succeedsSoon`.

It might be ok just to make the test less stringent, since the UI this powers doesn't really care what the IDs are or whether the replicas have fully rebalanced. Maybe just assert that the table ids match up with zone config ids, and some replicas are seen.

Fixes #24800
Touches #24802

Release note: None