### PR TITLE
sql: use a reusable name resolution algo for star expansions

### DIFF
--- a/pkg/sql/data_source.go
+++ b/pkg/sql/data_source.go
@@ -506,18 +506,10 @@ func expandStar(
 			}
 		}
 	case *tree.AllColumnsSelector:
-		tn, err := tree.NormalizeTableName(&sel.TableName)
-		if err != nil {
-			return nil, nil, err
-		}
 		resolver := sqlbase.ColumnResolver{Sources: src}
-		numRes, _, _, err := resolver.FindSourceMatchingName(ctx, tn)
+		_, _, err := sel.Resolve(ctx, &resolver)
 		if err != nil {
 			return nil, nil, err
-		}
-		if numRes == tree.NoResults {
-			return nil, nil, pgerror.NewErrorf(pgerror.CodeUndefinedColumnError,
-				"no data source named %q", tree.ErrString(&tn))
 		}
 		ds := src[resolver.ResolverState.SrcIdx]
 		colSet := ds.SourceAliases[resolver.ResolverState.ColSetIdx].ColumnSet

--- a/pkg/sql/logictest/testdata/logic_test/insert
+++ b/pkg/sql/logictest/testdata/logic_test/insert
@@ -511,7 +511,7 @@ INSERT INTO return AS r VALUES (5, 6)
 statement ok
 INSERT INTO return VALUES (5, 6) RETURNING test.return.a
 
-statement error no data source named "x"
+statement error no data source matches pattern: x.\*
 INSERT INTO return VALUES (1, 2) RETURNING x.*[1]
 
 statement error column name "x" not found

--- a/pkg/sql/logictest/testdata/logic_test/select
+++ b/pkg/sql/logictest/testdata/logic_test/select
@@ -139,7 +139,28 @@ SELECT kv.* FROM kv
 ----
 a NULL
 
-query error no data source named "foo"
+# Regression tests for #24169
+query TT
+SELECT test.kv.* FROM kv
+----
+a NULL
+
+query TT
+SELECT test.public.kv.* FROM kv
+----
+a NULL
+
+query TT
+SELECT test.public.kv.* FROM test.kv
+----
+a NULL
+
+query TT
+SELECT test.kv.* FROM test.public.kv
+----
+a NULL
+
+query error no data source matches pattern: foo.\*
 SELECT foo.* FROM kv
 
 query error cannot use "\*" without a FROM clause
@@ -156,7 +177,7 @@ SELECT 1, * FROM nocols
 query error "kv.*" cannot be aliased
 SELECT kv.* AS foo FROM kv
 
-query error no data source named "bar.kv"
+query error no data source matches pattern: bar.kv.\*
 SELECT bar.kv.* FROM kv
 
 # Don't panic with invalid names (#8024)

--- a/pkg/sql/opt/optbuilder/testdata/select
+++ b/pkg/sql/opt/optbuilder/testdata/select
@@ -250,7 +250,7 @@ project
 build
 SELECT foo.* FROM kv
 ----
-error: no data source named "foo"
+error: no data source matches pattern: foo.*
 
 build
 SELECT *
@@ -265,7 +265,7 @@ error: "kv.*" cannot be aliased
 build
 SELECT bar.kv.* FROM kv
 ----
-error: no data source named "bar.kv"
+error: no data source matches pattern: bar.kv.*
 
 # Don't panic with invalid names (#8024)
 build

--- a/pkg/sql/opt/optbuilder/util.go
+++ b/pkg/sql/opt/optbuilder/util.go
@@ -35,20 +35,10 @@ func (b *Builder) expandStar(expr tree.Expr, inScope *scope) (exprs []tree.Typed
 
 	switch t := expr.(type) {
 	case *tree.AllColumnsSelector:
-		tn, err := tree.NormalizeTableName(&t.TableName)
+		src, _, err := t.Resolve(b.ctx, inScope)
 		if err != nil {
 			panic(builderError{err})
 		}
-
-		numRes, src, _, err := inScope.FindSourceMatchingName(b.ctx, tn)
-		if err != nil {
-			panic(builderError{err})
-		}
-		if numRes == tree.NoResults {
-			panic(builderError{pgerror.NewErrorf(pgerror.CodeUndefinedColumnError,
-				"no data source named %q", tree.ErrString(&tn))})
-		}
-
 		for i := range inScope.cols {
 			col := inScope.cols[i]
 			if col.table == *src && !col.hidden {


### PR DESCRIPTION
Fixes #24169.

A previous patch has added a reusable name resolution mechanism which
encapsulates all the special cases supported CockroachDB into a single
code path. This covers both the resolution of object names and column
names.

Prior to this patch however, the expansion of qualified stars was
using a separate code path. This proved to be incorrect/insufficient
however, because one of the special cases of name resolution should
apply to star expansion too and the separate code path did not contain
the special case.

To solve this problem, this patch abstracts the resolution of
qualified stars in a common algorithm alongside the others (in
`sem/name_resolution.go`) and ensures it is used where applicable.

Release note (bug fix): CockroachDB now again allows to use a simply
qualified table name in qualified stars (e.g., `SELECT mydb.kv.* FROM
kv`), for compatibility with CockroachDB v1.x.