### PR TITLE
sql: ensure that errors in SHOW SYNTAX results get recorded

### DIFF
--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -915,7 +915,9 @@ func (ex *connExecutor) runShowSyntax(
 		func(ctx context.Context, field, msg string) error {
 			commErr = res.AddRow(ctx, tree.Datums{tree.NewDString(field), tree.NewDString(msg)})
 			return nil
-		}); err != nil {
+		},
+		ex.server.recordError, /* reportErr */
+	); err != nil {
 		res.SetError(err)
 	}
 	return commErr

--- a/pkg/sql/err_count_test.go
+++ b/pkg/sql/err_count_test.go
@@ -1,0 +1,71 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package sql_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/server"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
+	"github.com/cockroachdb/cockroach/pkg/sql/tests"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+)
+
+func TestErrorCounts(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	params, _ := tests.CreateTestServerParams()
+	s, db, _ := serverutils.StartServer(t, params)
+	defer s.Stopper().Stop(context.TODO())
+
+	sqlServer := s.(*server.TestServer).PGServer().SQLServer
+
+	codes := make(map[string]int64)
+	unimplemented := make(map[string]int64)
+
+	sqlServer.FillErrorCounts(codes, unimplemented)
+	count1 := codes[pgerror.CodeSyntaxError]
+
+	_, err := db.Query("SELECT 1+")
+	if err == nil {
+		t.Fatal("expected error, got no error")
+	}
+
+	sqlServer.FillErrorCounts(codes, unimplemented)
+	count2 := codes[pgerror.CodeSyntaxError]
+
+	if count2-count1 != 1 {
+		t.Fatalf("expected 1 syntax error, got %d", count2-count1)
+	}
+
+	rows, err := db.Query(`SHOW SYNTAX 'SELECT 1+'`)
+	if err != nil {
+		t.Fatalf("%+v", err)
+	}
+	for rows.Next() {
+		// Do nothing. SHOW SYNTAX itself is tested elsewhere.
+		// We just check the counts below.
+	}
+	rows.Close()
+
+	sqlServer.FillErrorCounts(codes, unimplemented)
+	count3 := codes[pgerror.CodeSyntaxError]
+
+	if count3-count2 != 1 {
+		t.Fatalf("expected 1 syntax error, got %d", count3-count2)
+	}
+}

--- a/pkg/sql/executor.go
+++ b/pkg/sql/executor.go
@@ -1357,7 +1357,9 @@ func runObserverStatement(session *Session, res StatementResult, stmt Statement)
 		if err := runShowSyntax(session.Ctx(), sqlStmt.Statement,
 			func(ctx context.Context, field, msg string) error {
 				return res.AddRow(ctx, tree.Datums{tree.NewDString(field), tree.NewDString(msg)})
-			}); err != nil {
+			},
+			nil, /* reportErr */
+		); err != nil {
 			return err
 		}
 


### PR DESCRIPTION
Fixes  #24432.
Requested by @awoods187 

SHOW SYNTAX translates parse errors into valid results towards
clients. However we want these errors to be collected for stats
reporting too. This patch changes the logic to ensure that a
translated error gets captured.

Note that only SHOW SYNTAX statements at the top level of a query are
handled in this way (and the errors collected), which is the most
common case and incidentally the case used by `cockroach sql` to do
client-side checking of statements during interactive sessions. If
SHOW SYNTAX is used as a data source (e.g. `SELECT * FROM [SHOW SYNTAX
...]`), the mechanism does not kick in. This is because the
infrastructure necessary for error collection is not easily available
on this code path. This can be extended later if need arises.


Release note (sql change): Errors detected by `SHOW SYNTAX` are now
tracked internally like other SQL errors.