### PR TITLE
distsqlrun: add benchmarks for distsql infrastructure

### DIFF
--- a/pkg/sql/distsqlrun/stream_data_test.go
+++ b/pkg/sql/distsqlrun/stream_data_test.go
@@ -143,3 +143,50 @@ func TestEmptyStreamEncodeDecode(t *testing.T) {
 		t.Errorf("received bogus row %v %v", row, meta)
 	}
 }
+
+func BenchmarkStreamEncoder(b *testing.B) {
+	numRows := 1 << 16
+
+	for _, numCols := range []int{1, 4, 16, 64} {
+		b.Run(fmt.Sprintf("rows=%d,cols=%d", numRows, numCols), func(b *testing.B) {
+			b.SetBytes(int64(numRows * numCols * 8))
+			cols := makeIntCols(numCols)
+			input := NewRepeatableRowSource(cols, makeIntRows(numRows, numCols))
+
+			b.ResetTimer()
+			ctx := context.Background()
+
+			for i := 0; i < b.N; i++ {
+				b.StopTimer()
+				input.Reset()
+				// Reset the EncDatums' encoded bytes cache.
+				for _, row := range input.rows {
+					for j := range row {
+						row[j] = sqlbase.EncDatum{
+							Datum: row[j].Datum,
+						}
+					}
+				}
+				var se StreamEncoder
+				se.init(cols)
+				b.StartTimer()
+
+				// Add rows to the StreamEncoder until the input source is exhausted.
+				// "Flush" every outboxBufRows.
+				for j := 0; ; j++ {
+					row, _ := input.Next()
+					if row == nil {
+						break
+					}
+					if err := se.AddRow(row); err != nil {
+						b.Fatal(err)
+					}
+					if j%outboxBufRows == 0 {
+						// ignore output
+						se.FormMessage(ctx)
+					}
+				}
+			}
+		})
+	}
+}

--- a/pkg/sql/distsqlrun/utils_test.go
+++ b/pkg/sql/distsqlrun/utils_test.go
@@ -133,6 +133,14 @@ var oneIntCol = []sqlbase.ColumnType{intType}
 var twoIntCols = []sqlbase.ColumnType{intType, intType}
 var threeIntCols = []sqlbase.ColumnType{intType, intType, intType}
 
+func makeIntCols(numCols int) []sqlbase.ColumnType {
+	ret := make([]sqlbase.ColumnType, numCols)
+	for i := 0; i < numCols; i++ {
+		ret[i] = intType
+	}
+	return ret
+}
+
 func intEncDatum(i int) sqlbase.EncDatum {
 	return sqlbase.EncDatum{Datum: tree.NewDInt(tree.DInt(i))}
 }


### PR DESCRIPTION
For #24690 - this completes all of them except for the outbox (and `RowChannel` which was already benchmarked).

```
BenchmarkRouter/BY_RANGE/outputs=2-8                  30          35692346 ns/op          29.38 MB/s
BenchmarkRouter/BY_RANGE/outputs=4-8                  30          34937864 ns/op          60.03 MB/s
BenchmarkRouter/BY_RANGE/outputs=8-8                  30          35112627 ns/op         119.45 MB/s
BenchmarkRouter/BY_HASH/outputs=2-8                  100          19840820 ns/op          52.85 MB/s
BenchmarkRouter/BY_HASH/outputs=4-8                  100          18774629 ns/op         111.70 MB/s
BenchmarkRouter/BY_HASH/outputs=8-8                   50          27249006 ns/op         153.93 MB/s
BenchmarkRouter/MIRROR/outputs=2-8                    30          34873995 ns/op          30.07 MB/s
BenchmarkRouter/MIRROR/outputs=4-8                    20          59782584 ns/op          35.08 MB/s
BenchmarkRouter/MIRROR/outputs=8-8                    10         153532931 ns/op          27.32 MB/s
```

```
BenchmarkMultiplexedRowChannel/senders=2-8                   500           2841863 ns/op          56.30 MB/s
BenchmarkMultiplexedRowChannel/senders=4-8                   100          10030833 ns/op          31.90 MB/s
BenchmarkMultiplexedRowChannel/senders=8-8                    50          32353212 ns/op          19.78 MB/s
```

```
BenchmarkStreamEncoder/cols=1-8                      500           3074456 ns/op         170.53 MB/s
BenchmarkStreamEncoder/cols=4-8                      200           8792420 ns/op         238.52 MB/s
BenchmarkStreamEncoder/cols=16-8                      50          34338533 ns/op         244.29 MB/s
BenchmarkStreamEncoder/cols=64-8                      10         131163270 ns/op         255.82 MB/s
```

```
BenchmarkStreamDecoder/cols=1-8                  1000000              1058 ns/op         120.92 MB/s
BenchmarkStreamDecoder/cols=4-8                   500000              2792 ns/op         183.32 MB/s
BenchmarkStreamDecoder/cols=16-8                  200000              9592 ns/op         213.50 MB/s
BenchmarkStreamDecoder/cols=64-8                   50000             35636 ns/op         229.88 MB/s
```