### PR TITLE
sql: add the ability to access a column from the results of an SRF

### DIFF
--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -1284,6 +1284,8 @@ d_expr ::=
 	| a_expr_const
 	| '@' iconst64
 	| 'PLACEHOLDER'
+	| '(' a_expr ')' '.' '*'
+	| '(' a_expr ')' '.' unrestricted_name
 	| '(' a_expr ')'
 	| func_expr
 	| select_with_parens

--- a/pkg/sql/data_source.go
+++ b/pkg/sql/data_source.go
@@ -98,42 +98,6 @@ func (p *planner) getVirtualDataSource(
 	}, nil
 }
 
-// getDataSourceAsOneColumn builds a planDataSource from a data source
-// clause and ensures that it returns one column. If the plan would
-// return zero or more than one column, the columns are grouped into
-// a tuple. This is needed for SRF substitution (e.g. `SELECT
-// pg_get_keywords()`).
-func (p *planner) getDataSourceAsOneColumn(
-	ctx context.Context, src *tree.FuncExpr,
-) (planDataSource, error) {
-	ds, err := p.getDataSource(ctx, src, nil, publicColumns)
-	if err != nil {
-		return ds, err
-	}
-	if len(ds.info.SourceColumns) == 1 {
-		return ds, nil
-	}
-
-	// Zero or more than one column: make a tuple.
-
-	// We use the name of the function to determine the name of the
-	// rendered column.
-	fd, err := src.Func.Resolve(p.SessionData().SearchPath)
-	if err != nil {
-		return planDataSource{}, err
-	}
-	newPlan, err := p.makeTupleRender(ctx, ds, fd.Name)
-	if err != nil {
-		return planDataSource{}, err
-	}
-
-	tn := tree.MakeUnqualifiedTableName(tree.Name(fd.Name))
-	return planDataSource{
-		info: sqlbase.NewSourceInfoForSingleTable(tn, planColumns(newPlan)),
-		plan: newPlan,
-	}, nil
-}
-
 // getDataSource builds a planDataSource from a single data source clause
 // (TableExpr) in a SelectClause.
 func (p *planner) getDataSource(
@@ -164,7 +128,7 @@ func (p *planner) getDataSource(
 		return p.getPlanForDesc(ctx, desc, tn, hints, colCfg)
 
 	case *tree.FuncExpr:
-		return p.getGeneratorPlan(ctx, t)
+		return p.getGeneratorPlan(ctx, t, sqlbase.AnonymousTable)
 
 	case *tree.Subquery:
 		return p.getSubqueryPlan(ctx, sqlbase.AnonymousTable, t.Select, nil)
@@ -447,13 +411,15 @@ func (p *planner) getSubqueryPlan(
 	}, nil
 }
 
-func (p *planner) getGeneratorPlan(ctx context.Context, t *tree.FuncExpr) (planDataSource, error) {
+func (p *planner) getGeneratorPlan(
+	ctx context.Context, t *tree.FuncExpr, srcName tree.TableName,
+) (planDataSource, error) {
 	plan, err := p.makeGenerator(ctx, t)
 	if err != nil {
 		return planDataSource{}, err
 	}
 	return planDataSource{
-		info: sqlbase.NewSourceInfoForSingleTable(sqlbase.AnonymousTable, planColumns(plan)),
+		info: sqlbase.NewSourceInfoForSingleTable(srcName, planColumns(plan)),
 		plan: plan,
 	}, nil
 }

--- a/pkg/sql/distinct.go
+++ b/pkg/sql/distinct.go
@@ -174,7 +174,6 @@ func (p *planner) distinct(
 			source:     src,
 			sourceInfo: sqlbase.MakeMultiSourceInfo(src.info),
 		}
-		postRender.ivarHelper = tree.MakeIndexedVarHelper(postRender, len(src.info.SourceColumns))
 		if err := p.initTargets(ctx, postRender, tree.SelectExprs{
 			tree.SelectExpr{
 				Expr: tree.StarExpr(),

--- a/pkg/sql/logictest/testdata/logic_test/generators
+++ b/pkg/sql/logictest/testdata/logic_test/generators
@@ -1,5 +1,7 @@
 # LogicTest: default parallel-stmts distsql distsql-metadata
 
+subtest generate_series
+
 query I colnames
 SELECT * FROM GENERATE_SERIES(1, 3)
 ----
@@ -26,9 +28,10 @@ generate_series
 2017-11-11 01:00:00 +0000 +0000
 2017-11-11 00:00:00 +0000 +0000
 
-query T
+query T colnames
 SELECT * FROM GENERATE_SERIES('2017-11-11 00:00:00'::TIMESTAMP, '2017-11-11 03:00:00'::TIMESTAMP, '-1 hour')
 ----
+generate_series
 
 query TTT
 EXPLAIN SELECT * FROM GENERATE_SERIES(1, 3)
@@ -52,23 +55,26 @@ join            ·     ·
  ├── generator  ·     ·
  └── generator  ·     ·
 
-query I
+query I colnames
 SELECT * FROM GENERATE_SERIES(3, 1, -1)
 ----
+generate_series
 3
 2
 1
 
-query I
+query I colnames
 SELECT * FROM GENERATE_SERIES(3, 1)
 ----
+generate_series
 
 query error step cannot be 0
 SELECT * FROM GENERATE_SERIES(1, 3, 0)
 
-query I
+query I colnames
 SELECT * FROM PG_CATALOG.GENERATE_SERIES(1, 3)
 ----
+generate_series
 1
 2
 3
@@ -106,22 +112,29 @@ EXPLAIN SELECT GENERATE_SERIES(1, 3)
 ----
 generator  ·  ·
 
-query II colnames
-SELECT GENERATE_SERIES(1, 2), GENERATE_SERIES(3, 4)
-----
-generate_series             generate_series
-1                           3
-1                           4
-2                           3
-2                           4
+subtest multiple_SRFs
+# See #20511
 
-query TTT
+# query II colnames
+# SELECT GENERATE_SERIES(1, 2), GENERATE_SERIES(3, 4)
+# ----
+# generate_series             generate_series
+# 1                           3
+# 2                           4
+
+query error pq: unimplemented: cannot use multiple set-returning functions in a single SELECT clause: "generate_series\(3, 4\)"
+SELECT GENERATE_SERIES(1, 2), GENERATE_SERIES(3, 4)
+
+# query TTT
+# EXPLAIN SELECT GENERATE_SERIES(1, 2), GENERATE_SERIES(1, 2)
+# ----
+# join            ·     ·
+# │              type  cross
+# ├── generator  ·     ·
+# └── generator  ·     ·
+
+query error pq: unimplemented: cannot use multiple set-returning functions in a single SELECT clause: "generate_series\(1, 2\)"
 EXPLAIN SELECT GENERATE_SERIES(1, 2), GENERATE_SERIES(1, 2)
-----
-join            ·     ·
- │              type  cross
- ├── generator  ·     ·
- └── generator  ·     ·
 
 statement ok
 CREATE TABLE t (a string)
@@ -138,107 +151,128 @@ INSERT INTO u VALUES ('bird')
 # The following two queries should have the same result. This exercises the
 # transformation that moves generator expressions in render positions to cross
 # joins.
-query TTII
+# query TTII colnames
+# SELECT t.*, u.*, generate_series(1,2), generate_series(3, 4) FROM t, u
+# ----
+# a    b     generate_series generate_series
+# cat  bird  1               3
+# cat  bird  2               4
+
+query error pq: unimplemented: cannot use multiple set-returning functions in a single SELECT clause: "generate_series\(3, 4\)"
 SELECT t.*, u.*, generate_series(1,2), generate_series(3, 4) FROM t, u
-----
-cat  bird  1  3
-cat  bird  1  4
-cat  bird  2  3
-cat  bird  2  4
 
-query TTT
+# query TTT
+# EXPLAIN(EXPRS) SELECT t.*, u.*, generate_series(1,2), generate_series(3, 4) FROM t, u
+# ----
+# render                    ·         ·
+# │                        render 0  a
+# │                        render 1  b
+# │                        render 2  generate_series
+# │                        render 3  generate_series
+# └── join                 ·         ·
+#      │                   type      cross
+#      ├── join            ·         ·
+#      │    │              type      cross
+#      │    ├── join       ·         ·
+#      │    │    │         type      cross
+#      │    │    ├── scan  ·         ·
+#      │    │    │         table     t@primary
+#      │    │    │         spans     ALL
+#      │    │    └── scan  ·         ·
+#      │    │              table     u@primary
+#      │    │              spans     ALL
+#      │    └── generator  ·         ·
+#      │                   expr      generate_series(1, 2)
+#      └── generator       ·         ·
+#·                         expr      generate_series(3, 4)
+
+query error pq: unimplemented: cannot use multiple set-returning functions in a single SELECT clause: "generate_series\(3, 4\)"
 EXPLAIN(EXPRS) SELECT t.*, u.*, generate_series(1,2), generate_series(3, 4) FROM t, u
-----
-render                    ·         ·
- │                        render 0  a
- │                        render 1  b
- │                        render 2  generate_series
- │                        render 3  generate_series
- └── join                 ·         ·
-      │                   type      cross
-      ├── join            ·         ·
-      │    │              type      cross
-      │    ├── join       ·         ·
-      │    │    │         type      cross
-      │    │    ├── scan  ·         ·
-      │    │    │         table     t@primary
-      │    │    │         spans     ALL
-      │    │    └── scan  ·         ·
-      │    │              table     u@primary
-      │    │              spans     ALL
-      │    └── generator  ·         ·
-      │                   expr      generate_series(1, 2)
-      └── generator       ·         ·
-·                         expr      generate_series(3, 4)
 
-query TTII
+query TTII colnames
 SELECT t.*, u.*, a.*, b.* FROM t, u, generate_series(1, 2) AS a, generate_series(3, 4) AS b
 ----
+a    b     a  b
 cat  bird  1  3
 cat  bird  1  4
 cat  bird  2  3
 cat  bird  2  4
 
-query I
+query I colnames
 SELECT 3 + x FROM generate_series(1,2) AS a(x)
 ----
+3 + x
 4
 5
-
 
 query I colnames
 SELECT 3 + generate_series(1,2)
 ----
-3 + generate_series(1, 2)
+3 + generate_series.generate_series
 4
 5
 
-query I
+query I colnames
 SELECT 3 + (3 * generate_series(1,3))
 ----
+3 + (3 * generate_series.generate_series)
 6
 9
 12
 
-query I
+subtest unnest
+
+query I colnames
 SELECT * from unnest(ARRAY[1,2])
 ----
+unnest
 1
 2
 
-query IT
-SELECT unnest(ARRAY[1,2]), unnest(ARRAY['a', 'b'])
-----
-1  a
-1  b
-2  a
-2  b
+# Also see #20511
+# query IT colnames
+# SELECT unnest(ARRAY[1,2]), unnest(ARRAY['a', 'b'])
+# ----
+# unnest unnest
+# 1      a
+# 2      b
 
-query I
+query error pq: unimplemented: cannot use multiple set-returning functions in a single SELECT clause: "unnest\(ARRAY\['a', 'b'\]\)"
+SELECT unnest(ARRAY[1,2]), unnest(ARRAY['a', 'b'])
+
+query I colnames
 SELECT unnest(ARRAY[3,4]) - 2
 ----
+unnest.unnest - 2
 1
 2
 
-query II
-SELECT 1 + generate_series(0, 1), unnest(ARRAY[2, 4]) - 1
-----
-1  1
-1  3
-2  1
-2  3
+# Again #20511
+# query II colnames
+# SELECT 1 + generate_series(0, 1), unnest(ARRAY[2, 4]) - 1
+# ----
+# generate_series unnest - 1
+# 1               1
+# 2               3
 
-query I
+query error pq: unimplemented: cannot use multiple set-returning functions in a single SELECT clause: "unnest\(ARRAY\[2, 4\]\)"
+SELECT 1 + generate_series(0, 1), unnest(ARRAY[2, 4]) - 1
+
+query I colnames
 SELECT ascii(unnest(ARRAY['a', 'b', 'c']));
 ----
+ascii
 97
 98
 99
 
-query error pq: cannot specify two set-returning functions in the same SELECT expression
+subtest nested_SRF
+# See #20511
+
+query error pq: unimplemented: cannot use multiple set-returning functions in a single SELECT clause: "generate_series\(generate_series.generate_series, 3\)"
 SELECT generate_series(generate_series(1, 3), 3)
 
-query error pq: cannot specify two set-returning functions in the same SELECT expression
+query error pq: unimplemented: cannot use multiple set-returning functions in a single SELECT clause: "generate_series\(1, 3\)"
 SELECT generate_series(1, 3) + generate_series(1, 3)
 
 query error pq: column name "generate_series" not found
@@ -247,23 +281,28 @@ SELECT generate_series(1, 3) FROM t WHERE generate_series > 3
 # Regressions for #15900: ensure that null parameters to generate_series don't
 # cause issues.
 
-query T
+query T colnames
 SELECT * from generate_series(1, (select * from generate_series(1, 0)))
 ----
+generate_series
 
 # The following query is designed to produce a null array argument to unnest
 # in a way that the type system can't detect before evaluation.
-query T
-SELECT unnest((select current_schemas((select isnan((select round(3.4, (select generate_series(1, 0)))))))));
+query T colnames
+SELECT unnest((SELECT current_schemas((SELECT isnan((SELECT round(3.4, (SELECT generate_series(1, 0)))))))));
 ----
+unnest
 
 # Regression for #18021.
-query I
+query I colnames
 SELECT GENERATE_SERIES(9223372036854775807::int, -9223372036854775807::int, -9223372036854775807::int)
 ----
+generate_series
 9223372036854775807
 0
 -9223372036854775807
+
+subtest pg_get_keywords
 
 # pg_get_keywords for compatibility (#10291)
 query TTT colnames
@@ -286,14 +325,16 @@ a  b  word  catcode  catdesc
 query TTT colnames
 SELECT 'a', pg_get_keywords(), 'c' LIMIT 1
 ----
-'a'  pg_get_keywords              'c'
-a    ('abort','U','unreserved')  c
+'a'  (pg_get_keywords.word, pg_get_keywords.catcode, pg_get_keywords.catdesc)  'c'
+a    ('abort','U','unreserved')                                                c
 
 query TTT colnames
 SELECT 'a', pg_get_keywords() b, 'c' LIMIT 1
 ----
-'a'  b                            'c'
+'a'  b                           'c'
 a    ('abort','U','unreserved')  c
+
+subtest unary_table
 
 query TTT colnames
 SELECT 'a', crdb_internal.unary_table() b, 'c' LIMIT 1
@@ -301,12 +342,16 @@ SELECT 'a', crdb_internal.unary_table() b, 'c' LIMIT 1
 'a'  b   'c'
 a    ()  c
 
+subtest upper
+
 # Regular scalar functions can be used as functions too. #22312
 query T colnames
 SELECT * FROM upper('abc')
 ----
 upper
 ABC
+
+subtest current_schema
 
 query TI colnames
 SELECT * FROM current_schema() WITH ORDINALITY AS a(b)
@@ -328,82 +373,191 @@ SELECT information_schema._pg_expandarray(ARRAY[])
 query error pq: information_schema\._pg_expandarray\(\): cannot determine type of empty array\. Consider annotating with the desired type, for example ARRAY\[\]:::int\[\]
 SELECT * FROM information_schema._pg_expandarray(ARRAY[])
 
-query I
+query I colnames
 SELECT information_schema._pg_expandarray(ARRAY[]:::int[])
 ----
+ ("information_schema._pg_expandarray".x, "information_schema._pg_expandarray".n)
 
-query II
+query II colnames
 SELECT * FROM information_schema._pg_expandarray(ARRAY[]:::int[])
 ----
+x  n
 
-query T
+query T colnames
 SELECT information_schema._pg_expandarray(ARRAY[100])
 ----
+("information_schema._pg_expandarray".x, "information_schema._pg_expandarray".n)
 (100,1)
 
-query II
+query II colnames
 SELECT * FROM information_schema._pg_expandarray(ARRAY[100])
 ----
+x   n
 100 1
 
-query T
+query T colnames
 SELECT information_schema._pg_expandarray(ARRAY[2, 1])
 ----
+("information_schema._pg_expandarray".x, "information_schema._pg_expandarray".n)
 (2,1)
 (1,2)
 
-query II
+query II colnames
 SELECT * FROM information_schema._pg_expandarray(ARRAY[2, 1])
 ----
+x n
 2 1
 1 2
 
-query T
+query T colnames
 SELECT information_schema._pg_expandarray(ARRAY[3, 2, 1])
 ----
+("information_schema._pg_expandarray".x, "information_schema._pg_expandarray".n)
 (3,1)
 (2,2)
 (1,3)
 
-query II
+query II colnames
 SELECT * FROM information_schema._pg_expandarray(ARRAY[3, 2, 1])
 ----
+x n
 3 1
 2 2
 1 3
 
-query T
+query T colnames
 SELECT information_schema._pg_expandarray(ARRAY['a'])
 ----
+("information_schema._pg_expandarray".x, "information_schema._pg_expandarray".n)
 ('a',1)
 
-query TI
+query TI colnames
 SELECT * FROM information_schema._pg_expandarray(ARRAY['a'])
 ----
+x n
 a 1
 
-query T
+query T colnames
 SELECT information_schema._pg_expandarray(ARRAY['b', 'a'])
 ----
+("information_schema._pg_expandarray".x, "information_schema._pg_expandarray".n)
 ('b',1)
 ('a',2)
 
-query TI
+query TI colnames
 SELECT * FROM information_schema._pg_expandarray(ARRAY['b', 'a'])
 ----
+x n
 b 1
 a 2
 
-query T
+query T colnames
 SELECT information_schema._pg_expandarray(ARRAY['c', 'b', 'a'])
 ----
+("information_schema._pg_expandarray".x, "information_schema._pg_expandarray".n)
 ('c',1)
 ('b',2)
 ('a',3)
 
-query TI
+query TI colnames
 SELECT * FROM information_schema._pg_expandarray(ARRAY['c', 'b', 'a'])
 ----
+x n
 c 1
 b 2
 a 3
+
+subtest srf_accessor
+
+query error pq: unimplemented: access to field in composite expression: "1"
+SELECT (1).*
+
+query error pq: unimplemented: access to field in composite expression: "1"
+SELECT (1).x
+
+query error pq: unimplemented: access to field in composite expression: "'a'"
+SELECT ('a').*
+
+query error pq: unimplemented: access to field in composite expression: "'a'"
+SELECT ('a').x
+
+query error pq: unnest\(\): cannot determine type of empty array. Consider annotating with the desired type, for example ARRAY\[\]:::int\[\]
+SELECT (unnest(ARRAY[])).*
+
+query I colnames
+SELECT (unnest(ARRAY[]:::INT[])).*
+----
+unnest
+
+query TI colnames
+SELECT (information_schema._pg_expandarray(ARRAY['c', 'b', 'a'])).*
+----
+x  n
+c  1
+b  2
+a  3
+
+query T colnames
+SELECT (information_schema._pg_expandarray(ARRAY['c', 'b', 'a'])).x
+----
+x
+c
+b
+a
+
+query I colnames
+SELECT (information_schema._pg_expandarray(ARRAY['c', 'b', 'a'])).n
+----
+n
+1
+2
+3
+
+query error pq: column name "information_schema._pg_expandarray.other" not found
+SELECT (information_schema._pg_expandarray(ARRAY['c', 'b', 'a'])).other
+
+query T colnames
+SELECT temp.x from information_schema._pg_expandarray(array['c','b','a']) AS temp;
+----
+x
+c
+b
+a
+
+query I colnames
+SELECT temp.n from information_schema._pg_expandarray(array['c','b','a']) AS temp;
+----
+n
+1
+2
+3
+
+query error pq: column name "temp.other" not found
+SELECT temp.other from information_schema._pg_expandarray(array['c','b','a']) AS temp;
+
+query TI colnames
+SELECT temp.* from information_schema._pg_expandarray(array['c','b','a']) AS temp;
+----
+x n
+c 1
+b 2
+a 3
+
+query TI colnames
+SELECT * from information_schema._pg_expandarray(array['c','b','a']) AS temp;
+----
+x n
+c 1
+b 2
+a 3
+
+subtest 24866
+
+# TODO(bram): #24866
+# query I colnames
+# SELECT (i.keys).n FROM (SELECT information_schema._pg_expandarray(ARRAY[3,2,1]) AS keys) AS i;
+# ----
+# n
+# 3
+# 2
+# 1

--- a/pkg/sql/parser/parse_test.go
+++ b/pkg/sql/parser/parse_test.go
@@ -805,6 +805,13 @@ func TestParse(t *testing.T) {
 		{`SELECT * FROM [123 AS t]@[456]`},
 		{`SELECT * FROM [123 AS t]@{FORCE_INDEX=[456],NO_INDEX_JOIN}`},
 
+		{`SELECT (1 + 2).*`},
+		{`SELECT (1 + 2).col`},
+		{`SELECT (abc.def).col`},
+		{`SELECT (i.keys).col`},
+		{`SELECT (i.keys).*`},
+		{`SELECT (ARRAY['a', 'b', 'c']).name`},
+
 		{`TABLE a`}, // Shorthand for: SELECT * FROM a; used e.g. in CREATE VIEW v AS TABLE t
 		{`TABLE [123 AS a]`},
 
@@ -1783,13 +1790,6 @@ ALTER TABLE t RENAME TO t[TRUE]
 `,
 		},
 		{
-			`SELECT (1 + 2).*`,
-			`syntax error at or near "."
-SELECT (1 + 2).*
-              ^
-`,
-		},
-		{
 			`TABLE abc[TRUE]`,
 			`syntax error at or near "["
 TABLE abc[TRUE]
@@ -1802,13 +1802,6 @@ TABLE abc[TRUE]
 UPDATE kv SET k[0] = 9
                ^
 HINT: try \h UPDATE`,
-		},
-		{
-			`SELECT (ARRAY['a', 'b', 'c']).name`,
-			`syntax error at or near "."
-SELECT (ARRAY['a', 'b', 'c']).name
-                             ^
-`,
 		},
 		{
 			`SELECT (0) FROM y[array[]]`,
@@ -1928,7 +1921,7 @@ HINT: try \h RESTORE`,
 	for _, d := range testData {
 		_, err := Parse(d.sql)
 		if err == nil {
-			t.Errorf("expected error, got nil")
+			t.Errorf("expected error, got nil for:\n%s", d.sql)
 			continue
 		}
 		msg := err.Error()

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -6610,6 +6610,14 @@ d_expr:
     $$.val = tree.NewPlaceholder($1)
   }
 // TODO(knz/jordan): extend this for compound types. See explanation above.
+| '(' a_expr ')' '.' '*'
+  {
+    $$.val = &tree.ColumnAccessExpr{Expr: $2.expr(), Star: true }
+  }
+| '(' a_expr ')' '.' unrestricted_name
+  {
+    $$.val = &tree.ColumnAccessExpr{Expr: $2.expr(), ColName: $5 }
+  }
 | '(' a_expr ')'
   {
     $$.val = &tree.ParenExpr{Expr: $2.expr()}

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -3371,6 +3371,12 @@ func (expr *CollateExpr) Eval(ctx *EvalContext) (Datum, error) {
 }
 
 // Eval implements the TypedExpr interface.
+func (expr *ColumnAccessExpr) Eval(ctx *EvalContext) (Datum, error) {
+	return nil, pgerror.NewErrorf(pgerror.CodeInternalError,
+		"programmer error: column access expressions must be replaced before evaluation")
+}
+
+// Eval implements the TypedExpr interface.
 func (expr *CoalesceExpr) Eval(ctx *EvalContext) (Datum, error) {
 	for _, e := range expr.Exprs {
 		d, err := e.(TypedExpr).Eval(ctx)

--- a/pkg/sql/sem/tree/name_part.go
+++ b/pkg/sql/sem/tree/name_part.go
@@ -189,7 +189,13 @@ func (u *UnresolvedName) String() string { return AsString(u) }
 
 // NewUnresolvedName constructs an UnresolvedName from some strings.
 func NewUnresolvedName(args ...string) *UnresolvedName {
-	n := &UnresolvedName{NumParts: len(args)}
+	n := MakeUnresolvedName(args...)
+	return &n
+}
+
+// MakeUnresolvedName constructs an UnresolvedName from some strings.
+func MakeUnresolvedName(args ...string) UnresolvedName {
+	n := UnresolvedName{NumParts: len(args)}
 	for i := 0; i < len(args); i++ {
 		n.Parts[i] = args[len(args)-1-i]
 	}

--- a/pkg/sql/sem/tree/type_check.go
+++ b/pkg/sql/sem/tree/type_check.go
@@ -389,6 +389,12 @@ func (expr *CollateExpr) TypeCheck(ctx *SemaContext, desired types.T) (TypedExpr
 }
 
 // TypeCheck implements the Expr interface.
+func (expr *ColumnAccessExpr) TypeCheck(ctx *SemaContext, desired types.T) (TypedExpr, error) {
+	return nil, pgerror.NewErrorf(pgerror.CodeInternalError,
+		"programmer error: column access expressions must be replaced before type checking")
+}
+
+// TypeCheck implements the Expr interface.
 func (expr *CoalesceExpr) TypeCheck(ctx *SemaContext, desired types.T) (TypedExpr, error) {
 	typedSubExprs, retType, err := TypeCheckSameTypedExprs(ctx, desired, expr.Exprs...)
 	if err != nil {
@@ -1607,7 +1613,7 @@ type placeholderAnnotationVisitor struct {
 	placeholders map[string]annotationState
 }
 
-// annotationState holds the state of an unreseolved type annotation for a given placeholder.
+// annotationState holds the state of an unresolved type annotation for a given placeholder.
 type annotationState struct {
 	sawAssertion   bool // marks if the placeholder has been subject to at least one type assetion
 	shouldAnnotate bool // marks if the placeholder should be annotated with the type typ

--- a/pkg/sql/sem/tree/walk.go
+++ b/pkg/sql/sem/tree/walk.go
@@ -148,6 +148,17 @@ func (expr *CollateExpr) Walk(v Visitor) Expr {
 	return expr
 }
 
+// Walk implements the Expr interface.
+func (expr *ColumnAccessExpr) Walk(v Visitor) Expr {
+	e, changed := WalkExpr(v, expr.Expr)
+	if changed {
+		exprCopy := *expr
+		exprCopy.Expr = e
+		return &exprCopy
+	}
+	return expr
+}
+
 // CopyNode makes a copy of this Expr without recursing in any child Exprs.
 func (expr *CoalesceExpr) CopyNode() *CoalesceExpr {
 	exprCopy := *expr


### PR DESCRIPTION
 sql: add the ability to access a column from the results of an SRF

To be compatible with postgres, specifically to be able to handle #16971
correctly. There is a need to be able to access the results of a Set Returning
Function (SRF) using a `.` accessor.

This commit does 3 things.
Firstly, it adds the appropriate grammer.

Secondly, it rewrites the rewriteSRF function to handle named column accessors
correctly.

Before this change, the only way to decompose an SRF into columns was to set it
it as the data source in the FROM clause, like so:
```sql
SELECT * FROM information_schema._pg_expandarray(ARRAY['c', 'b', 'a']);
+---+---+
| x | n |
+---+---+
| c | 1 |
| b | 2 |
| a | 3 |
+---+---+

SELECT x FROM information_schema._pg_expandarray(ARRAY['c', 'b', 'a']);
+---+
| x |
+---+
| c |
| b |
| a |
+---+

SELECT n FROM information_schema._pg_expandarray(ARRAY['c', 'b', 'a']);
+---+
| n |
+---+
| 1 |
| 2 |
| 3 |
+---+
```

With this commit, the following are now valid syntax:

```sql
SELECT (information_schema._pg_expandarray(ARRAY['c', 'b', 'a'])).*;
+---+---+
| x | n |
+---+---+
| c | 1 |
| b | 2 |
| a | 3 |
+---+---+

SELECT (information_schema._pg_expandarray(ARRAY['c', 'b', 'a'])).x;
+---+
| x |
+---+
| c |
| b |
| a |
+---+

SELECT (information_schema._pg_expandarray(ARRAY['c', 'b', 'a'])).n;
+---+
| n |
+---+
| 1 |
| 2 |
| 3 |
+---+
```

Thirdly, this changes the behaviour of the resulting columns from SRFs. If
there is more than one named element in the resulting tuple, the column for the
tuple will now be named for all elements:
```sql
SELECT information_schema._pg_expandarray(ARRAY[3, 2, 1])
```

Will produce a tuple column like named
`("information_schema._pg_expandarray".x, "information_schema._pg_expandarray".n)`.

The bahaviour does deviate from postgres, which simply names the column after
the name of the function, in this case `_pg_expandarray`.

Here's another example of this difference:

```sql
SELECT 'a', pg_get_keywords(), 'c' LIMIT 1;

In Postgres:
 ?column? |   pg_get_keywords    | ?column?
----------+----------------------+----------
 a        | (abort,U,unreserved) | c

In Cockroach:
+-----+--------------------------------+-----+
| 'a' |     (pg_get_keywords.word,     | 'c' |
|     |    pg_get_keywords.catcode,    |     |
|     |    pg_get_keywords.catdesc)    |     |
+-----+--------------------------------+-----+
| a   | ('abort','U','unreserved')     | c   |
+-----+--------------------------------+-----+
```

Release note (sql change): Set Returning Functions (SRF) can now be accessed
using `(SRF).x` where `x` is the name of a column returned form the SRF or a
 `*`. For example,
`SELECT (information_schema._pg_expandarray(ARRAY['c', 'b', 'a'])).x` and
`SELECT (information_schema._pg_expandarray(ARRAY['c', 'b', 'a'])).*` are both
now valid syntax.
Also, the naming of the resulting columns from SRFs has been updated to provide
more information about the resulting tuple.

Co-authored-by: Raphael 'kena' Poss <knz@cockroachlabs.com>