### PR TITLE
testutils: Update RPC error matcher for #22658

### DIFF
--- a/pkg/testutils/error.go
+++ b/pkg/testutils/error.go
@@ -60,10 +60,16 @@ func IsPError(pErr *roachpb.Error, re string) bool {
 // itself. This can occur when a node is restarting or is unstable in
 // some other way. Note that retryable errors may occur event in cases
 // where the SQL execution ran to completion.
+//
+// TODO(bdarnell): Why are RPC errors in this list? These should
+// generally be retried on the server side or transformed into
+// ambiguous result errors ("connection reset/refused" are needed for
+// the pgwire connection, but anything RPC-related should be handled
+// within the cluster).
 func IsSQLRetryableError(err error) bool {
 	// Don't forget to update the corresponding test when making adjustments
 	// here.
-	return IsError(err, "(connection reset by peer|connection refused|failed to send RPC|EOF|result is ambiguous)")
+	return IsError(err, "(connection reset by peer|connection refused|failed to send RPC|rpc error: code = Unavailable|EOF|result is ambiguous)")
 }
 
 // Caller returns filename and line number info for the specified stack


### PR DESCRIPTION
Acceptance tests are (infrequently) failing with this message, when it
looks like this test has historically swallowed RPC errors here. I'm
not sure that's completely correct, but this change should restore the
test to its previous level of reliability.



Release note: None