### PR TITLE
cherry-pick 2.0: sql: use a reusable name resolution algo for star expansions

### DIFF
--- a/pkg/sql/data_source.go
+++ b/pkg/sql/data_source.go
@@ -506,18 +506,10 @@ func expandStar(
 			}
 		}
 	case *tree.AllColumnsSelector:
-		tn, err := tree.NormalizeTableName(&sel.TableName)
-		if err != nil {
-			return nil, nil, err
-		}
 		resolver := sqlbase.ColumnResolver{Sources: src}
-		numRes, _, _, err := resolver.FindSourceMatchingName(ctx, tn)
+		_, _, err := sel.Resolve(ctx, &resolver)
 		if err != nil {
 			return nil, nil, err
-		}
-		if numRes == tree.NoResults {
-			return nil, nil, pgerror.NewErrorf(pgerror.CodeUndefinedColumnError,
-				"no data source named %q", tree.ErrString(&tn))
 		}
 		ds := src[resolver.ResolverState.SrcIdx]
 		colSet := ds.SourceAliases[resolver.ResolverState.ColSetIdx].ColumnSet

--- a/pkg/sql/logictest/testdata/logic_test/insert
+++ b/pkg/sql/logictest/testdata/logic_test/insert
@@ -511,7 +511,7 @@ INSERT INTO return AS r VALUES (5, 6)
 statement ok
 INSERT INTO return VALUES (5, 6) RETURNING test.return.a
 
-statement error no data source named "x"
+statement error no data source matches pattern: x.\*
 INSERT INTO return VALUES (1, 2) RETURNING x.*[1]
 
 statement error column name "x" not found

--- a/pkg/sql/logictest/testdata/logic_test/select
+++ b/pkg/sql/logictest/testdata/logic_test/select
@@ -139,7 +139,28 @@ SELECT kv.* FROM kv
 ----
 a NULL
 
-query error no data source named "foo"
+# Regression tests for #24169
+query TT
+SELECT test.kv.* FROM kv
+----
+a NULL
+
+query TT
+SELECT test.public.kv.* FROM kv
+----
+a NULL
+
+query TT
+SELECT test.public.kv.* FROM test.kv
+----
+a NULL
+
+query TT
+SELECT test.kv.* FROM test.public.kv
+----
+a NULL
+
+query error no data source matches pattern: foo.\*
 SELECT foo.* FROM kv
 
 query error cannot use "\*" without a FROM clause
@@ -156,7 +177,7 @@ SELECT 1, * FROM nocols
 query error "kv.*" cannot be aliased
 SELECT kv.* AS foo FROM kv
 
-query error no data source named "bar.kv"
+query error no data source matches pattern: bar.kv.\*
 SELECT bar.kv.* FROM kv
 
 # Don't panic with invalid names (#8024)


### PR DESCRIPTION
Picks #24811.
cc @cockroachdb/release 