### PR TITLE
ui: change "Bytes" to "Used Capacity" in nodes table

### DIFF
--- a/pkg/ui/src/views/cluster/containers/nodesOverview/index.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodesOverview/index.tsx
@@ -118,9 +118,9 @@ class LiveNodeList extends React.Component<NodeCategoryListProps, {}> {
               },
               sort: (ns) => ns.started_at,
             },
-            // Bytes - displays the total persisted bytes maintained by the node.
+            // Used Capacity - displays the total persisted bytes maintained by the node.
             {
-              title: "Bytes",
+              title: "Used Capacity",
               cell: (ns) => Bytes(BytesUsed(ns)),
               sort: (ns) => BytesUsed(ns),
             },


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/7341/38834376-4cd0ea18-4196-11e8-9388-1798eaff1d60.png)

After:
![image](https://user-images.githubusercontent.com/7341/38834361-43218d88-4196-11e8-9440-d2e9b24229b6.png)

Note that this now matches where it says "used capacity" in the cluster overview.

Release note (admin ui change): change label "bytes" to "used capacity" in nodes table