### PR TITLE
ui: cluster overview layout tweaks

### DIFF
--- a/pkg/ui/ccl/src/views/clusterviz/containers/map/nodeList.tsx
+++ b/pkg/ui/ccl/src/views/clusterviz/containers/map/nodeList.tsx
@@ -28,11 +28,11 @@ export default class NodeList extends React.Component<RouterState & { router: In
       <div
         style={{
           width: "100%",
+          height: "100%",
           display: "flex",
           flexDirection: "column",
           overflow: "hidden",
           background: "white",
-          paddingBottom: 24,
         }}
         className="clusterviz"
       >
@@ -52,7 +52,14 @@ export default class NodeList extends React.Component<RouterState & { router: In
             />
           </div>
         </div>
-        <NodesOverview />
+        <div style={{
+          paddingBottom: 24,
+          width: "100%",
+          height: "100%",
+          overflow: "auto",
+        }}>
+          <NodesOverview />
+        </div>
       </div>
     );
   }

--- a/pkg/ui/src/routes/visualization.tsx
+++ b/pkg/ui/src/routes/visualization.tsx
@@ -7,7 +7,12 @@ import ClusterOverview from "src/views/cluster/containers/clusterOverview";
 class NodesWrapper extends React.Component<{}, {}> {
   render() {
     return (
-      <div style={{ marginTop: 12 }}>
+      <div style={{
+        paddingTop: 12,
+        width: "100%",
+        height: "100%",
+        overflow: "auto",
+      }}>
         <NodesOverview />
       </div>
     );

--- a/pkg/ui/src/views/cluster/containers/clusterOverview/cluster.styl
+++ b/pkg/ui/src/views/cluster/containers/clusterOverview/cluster.styl
@@ -107,6 +107,7 @@
       line-height 64px
       color $link-color
       white-space nowrap
+      padding-right 12px
 
       &.warning
         color $warning-color

--- a/pkg/ui/src/views/cluster/containers/clusterOverview/cluster.styl
+++ b/pkg/ui/src/views/cluster/containers/clusterOverview/cluster.styl
@@ -16,10 +16,7 @@
 .cluster-overview
   .cluster-summary
     background-color white
-    padding-top 24px
-    padding-bottom 24px
-    padding-left 24px
-    padding-right 24px
+    padding 24px
     margin-top 0
     margin-left 24px
     margin-right 24px
@@ -31,12 +28,31 @@
     grid-template-rows repeat(3, auto)
     grid-template-areas "cap-t cap-t cap-t cap-t . live-t live-t live-t . rep-t rep-t rep-t" "cap-m cap-c cap-c cap-c . live-a live-b live-c . rep-a rep-b rep-c" "cap-a1 cap-a2 cap-a3 cap-a4 . live-1 live-2 live-3 . rep-1 rep-2 rep-3"
 
+    @media screen and (max-width: 960px)
+      padding 18px 14px 10px
+      align-items center
+      grid-template-columns 4fr 5fr 4fr 3fr 5fr 4fr
+      grid-template-rows repeat(4, auto)
+      grid-template-areas "cap-t cap-t live-t live-t rep-t rep-t" "cap-m2 cap-m live-1 live-a rep-1 rep-a" "cap-a1 cap-a2 live-2 live-b rep-2 rep-b" "cap-a3 cap-a4 live-3 live-c rep-3 rep-c"
+
+    @media screen and (min-width: 1400px)
+      grid-template-columns 100px 135px 100px 135px 1fr 100px 100px 100px 1fr 100px 168px 100px
+
     .capacity-usage
       &.cluster-summary__title
           grid-area cap-t
 
       &.cluster-summary__chart
           grid-area cap-c
+
+          @media screen and (max-width: 960px)
+            display none
+
+      &.cluster-summary__label.storage-percent
+          grid-area cap-m2
+
+          @media screen and (min-width: 960px)
+            display none
 
       &.cluster-summary__metric.storage-percent
           grid-area cap-m
@@ -102,12 +118,33 @@
       font-size 20px
       margin-bottom 20px
 
+      @media screen and (max-width: 960px)
+        margin-bottom 10px
+        font-size 14px
+        line-height 14px
+
+      @media screen and (min-width: 960px) and (max-width: 1400px)
+        font-size 18px
+
     &__metric
       font-size 30px
-      line-height 64px
+      font-weight bold
       color $link-color
       white-space nowrap
       padding-right 12px
+
+      @media screen and (max-width: 960px)
+        font-size 22px
+
+      @media screen and (min-width: 960px) and (max-width: 1400px)
+        font-size 28px
+        line-height 54px
+
+      @media screen and (min-width: 1400px)
+        line-height 64px
+
+      @media screen and (min-width: 1720px)
+        font-size 36px
 
       &.warning
         color $warning-color
@@ -116,17 +153,36 @@
         color $alert-color
 
       &.storage-used, &.storage-usable
-        font-size 18px
-        line-height 21px
+        @media screen and (min-width: 960px) and (max-width: 1400px)
+          font-size 14px
+          line-height 16px
+
+        @media screen and (min-width: 1400px) and (max-width: 1720px)
+          font-size 18px
+          line-height 20px
+
+        @media screen and (min-width: 1720px)
+          font-size 22px
+          line-height 24px
 
     &__label
       font-size 12px
       font-weight 500
       line-height 18px
-      padding-top 10px
       text-transform uppercase
       color $tooltip-color
       letter-spacing 2px
+
+      @media screen and (max-width: 960px)
+        margin-top 5px
+        margin-bottom 5px
+
+      @media screen and (max-width: 1400px)
+        font-size 10px
+        line-height 14px
+
+      @media screen and (min-width: 960px)
+        padding-top 10px
 
   .capacity-usage.cluster-summary__chart
     align-self start
@@ -136,7 +192,10 @@
       position absolute
       shape-rendering crispEdges
       margin-left -20px
-      margin-top 10px
+      margin-top 8px
+
+      @media screen and (max-width: 1400px)
+        margin-top 4px
 
     .axis path
       fill none

--- a/pkg/ui/src/views/cluster/containers/clusterOverview/index.tsx
+++ b/pkg/ui/src/views/cluster/containers/clusterOverview/index.tsx
@@ -30,6 +30,7 @@ function renderCapacityUsage(props: CapacityUsageProps) {
   const usedPercentage = usableCapacity !== 0 ? usedCapacity / usableCapacity : 0;
   return [
     <h3 className="capacity-usage cluster-summary__title">Capacity Usage</h3>,
+    <div className="capacity-usage cluster-summary__label storage-percent">Used<br />Percent</div>,
     <div className="capacity-usage cluster-summary__metric storage-percent">{ formatPercentage(usedPercentage) }</div>,
     <div className="capacity-usage cluster-summary__chart">
       <CapacityChart used={usedCapacity} usable={usableCapacity} />


### PR DESCRIPTION
Some tweaks to the cluster overview layout for narrow and wide screens, as well as better handling when the metrics have many-digit numbers.

<img width="767" alt="screen shot 2018-04-17 at 1 35 41 pm" src="https://user-images.githubusercontent.com/793969/38886599-6f3704ee-4244-11e8-9ff9-bdf476176566.png">
<img width="1021" alt="screen shot 2018-04-17 at 1 35 57 pm" src="https://user-images.githubusercontent.com/793969/38886600-6f5bec50-4244-11e8-9ace-9cf88cc3ddd1.png">
<img width="1438" alt="screen shot 2018-04-17 at 1 36 18 pm" src="https://user-images.githubusercontent.com/793969/38886601-6f7d2af0-4244-11e8-8e9d-d228cc72a4c4.png">
<img width="1920" alt="screen shot 2018-04-17 at 1 36 33 pm" src="https://user-images.githubusercontent.com/793969/38886602-6fa30b80-4244-11e8-9e7e-7f49b343e1f7.png">

Avoiding collision:
<img width="195" alt="screen shot 2018-04-16 at 5 48 37 pm" src="https://user-images.githubusercontent.com/793969/38837026-6fcebeb6-419e-11e8-914b-4cb12efc365b.png">

Fixes: #23669
Fixes: #24158
Fixes: #24844
