### PR TITLE
sql: Add experimental zigzag join flag

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/explain
+++ b/pkg/sql/logictest/testdata/logic_test/explain
@@ -175,7 +175,7 @@ EXPLAIN SHOW DATABASE
 render            ·     ·
  └── filter       ·     ·
       └── values  ·     ·
-·                 size  2 columns, 27 rows
+·                 size  2 columns, 28 rows
 
 query TTT
 EXPLAIN SHOW TIME ZONE
@@ -183,7 +183,7 @@ EXPLAIN SHOW TIME ZONE
 render            ·     ·
  └── filter       ·     ·
       └── values  ·     ·
-·                 size  2 columns, 27 rows
+·                 size  2 columns, 28 rows
 
 query TTT
 EXPLAIN SHOW DEFAULT_TRANSACTION_ISOLATION
@@ -191,7 +191,7 @@ EXPLAIN SHOW DEFAULT_TRANSACTION_ISOLATION
 render            ·     ·
  └── filter       ·     ·
       └── values  ·     ·
-·                 size  2 columns, 27 rows
+·                 size  2 columns, 28 rows
 
 query TTT
 EXPLAIN SHOW TRANSACTION ISOLATION LEVEL
@@ -199,7 +199,7 @@ EXPLAIN SHOW TRANSACTION ISOLATION LEVEL
 render            ·     ·
  └── filter       ·     ·
       └── values  ·     ·
-·                 size  2 columns, 27 rows
+·                 size  2 columns, 28 rows
 
 query TTT
 EXPLAIN SHOW TRANSACTION PRIORITY
@@ -207,7 +207,7 @@ EXPLAIN SHOW TRANSACTION PRIORITY
 render            ·     ·
  └── filter       ·     ·
       └── values  ·     ·
-·                 size  2 columns, 27 rows
+·                 size  2 columns, 28 rows
 
 query TTT
 EXPLAIN SHOW COLUMNS FROM foo

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -1150,6 +1150,7 @@ default_transaction_isolation   serializable  NULL      NULL        NULL        
 default_transaction_read_only   off           NULL      NULL        NULL        string
 distsql                         off           NULL      NULL        NULL        string
 experimental_force_lookup_join  off           NULL      NULL        NULL        string
+experimental_force_zigzag_join  off           NULL      NULL        NULL        string
 experimental_opt                off           NULL      NULL        NULL        string
 extra_float_digits              ·             NULL      NULL        NULL        string
 intervalstyle                   postgres      NULL      NULL        NULL        string
@@ -1182,6 +1183,7 @@ default_transaction_isolation   serializable  NULL  user     NULL      serializa
 default_transaction_read_only   off           NULL  user     NULL      off           off
 distsql                         off           NULL  user     NULL      off           off
 experimental_force_lookup_join  off           NULL  user     NULL      off           off
+experimental_force_zigzag_join  off           NULL  user     NULL      off           off
 experimental_opt                off           NULL  user     NULL      off           off
 extra_float_digits              ·             NULL  user     NULL      ·             ·
 intervalstyle                   postgres      NULL  user     NULL      postgres      postgres
@@ -1214,6 +1216,7 @@ default_transaction_isolation   NULL    NULL     NULL     NULL        NULL
 default_transaction_read_only   NULL    NULL     NULL     NULL        NULL
 distsql                         NULL    NULL     NULL     NULL        NULL
 experimental_force_lookup_join  NULL    NULL     NULL     NULL        NULL
+experimental_force_zigzag_join  NULL    NULL     NULL     NULL        NULL
 experimental_opt                NULL    NULL     NULL     NULL        NULL
 extra_float_digits              NULL    NULL     NULL     NULL        NULL
 intervalstyle                   NULL    NULL     NULL     NULL        NULL

--- a/pkg/sql/logictest/testdata/logic_test/set
+++ b/pkg/sql/logictest/testdata/logic_test/set
@@ -91,6 +91,7 @@ default_transaction_isolation   serializable
 default_transaction_read_only   off
 distsql                         off
 experimental_force_lookup_join  off
+experimental_force_zigzag_join  off
 experimental_opt                off
 extra_float_digits              ·
 intervalstyle                   postgres

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -31,6 +31,7 @@ default_transaction_isolation   serializable
 default_transaction_read_only   off
 distsql                         off
 experimental_force_lookup_join  off
+experimental_force_zigzag_join  off
 experimental_opt                off
 extra_float_digits              ·
 intervalstyle                   postgres

--- a/pkg/sql/session.go
+++ b/pkg/sql/session.go
@@ -1935,6 +1935,10 @@ func (m *sessionDataMutator) SetLookupJoinEnabled(val bool) {
 	m.data.LookupJoinEnabled = val
 }
 
+func (m *sessionDataMutator) SetZigzagJoinEnabled(val bool) {
+	m.data.ZigzagJoinEnabled = val
+}
+
 func (m *sessionDataMutator) SetOptimizerMode(val sessiondata.OptimizerMode) {
 	m.data.OptimizerMode = val
 }

--- a/pkg/sql/sessiondata/session_data.go
+++ b/pkg/sql/sessiondata/session_data.go
@@ -64,6 +64,9 @@ type SessionData struct {
 	// by the session.
 	SequenceState *SequenceState
 	RemoteAddr    net.Addr
+	// ZigzagJoinEnabled indicates whether the planner should try and plan a
+	// zigzag join. Will emit a warning if a zigzag join can't be planned.
+	ZigzagJoinEnabled bool
 
 	mu struct {
 		syncutil.Mutex

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -293,6 +293,29 @@ var varGen = map[string]sessionVar{
 	},
 
 	// CockroachDB extension.
+	`experimental_force_zigzag_join`: {
+		Set: func(
+			_ context.Context, m *sessionDataMutator,
+			evalCtx *extendedEvalContext, values []tree.TypedExpr,
+		) error {
+			s, err := getSingleBool("experimental_force_zigzag_join", evalCtx, values)
+			if err != nil {
+				return err
+			}
+			m.SetZigzagJoinEnabled(bool(*s))
+
+			return nil
+		},
+		Get: func(evalCtx *extendedEvalContext) string {
+			return formatBoolAsPostgresSetting(evalCtx.SessionData.ZigzagJoinEnabled)
+		},
+		Reset: func(m *sessionDataMutator) error {
+			m.SetZigzagJoinEnabled(false)
+			return nil
+		},
+	},
+
+	// CockroachDB extension.
 	`experimental_opt`: {
 		Set: func(
 			_ context.Context, m *sessionDataMutator,


### PR DESCRIPTION
Add the flag to enable zigzag joins experimentally. This will be used by
the planner to determine whether it should attempt to plan a zigzag
join.

Release note: None