### PR TITLE
opt: Fix various name resolution bugs in optimizer

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/join
+++ b/pkg/sql/opt/exec/execbuilder/testdata/join
@@ -1,16 +1,12 @@
 exec-raw
-CREATE DATABASE t
-----
-
-exec-raw
-CREATE TABLE t.a (x INT PRIMARY KEY, y INT);
-CREATE TABLE t.b (x INT PRIMARY KEY, z INT);
-INSERT INTO t.a VALUES (1, 10), (2, 20), (3, 30);
-INSERT INTO t.b VALUES (2, 200), (3, 300), (4, 400)
+CREATE TABLE a (x INT PRIMARY KEY, y INT);
+CREATE TABLE b (x INT PRIMARY KEY, z INT);
+INSERT INTO a VALUES (1, 10), (2, 20), (3, 30);
+INSERT INTO b VALUES (2, 200), (3, 300), (4, 400)
 ----
 
 exec-explain
-SELECT * FROM t.a, t.b
+SELECT * FROM a, b
 ----
 join       0  join  ·      ·          (x, y, x, z)  ·
  │         0  ·     type   cross      ·             ·
@@ -22,7 +18,7 @@ join       0  join  ·      ·          (x, y, x, z)  ·
 ·          1  ·     spans  ALL        ·             ·
 
 exec
-SELECT * FROM t.a, t.b
+SELECT * FROM a, b
 ----
 x:int  y:int  x:int  z:int
 1      10     2      200
@@ -36,7 +32,7 @@ x:int  y:int  x:int  z:int
 3      30     4      400
 
 exec-explain
-SELECT * FROM t.a, t.b WHERE a.x = b.x
+SELECT * FROM a, b WHERE a.x = b.x
 ----
 join       0  join  ·         ·          (x, y, x, z)  ·
  │         0  ·     type      inner      ·             ·
@@ -49,14 +45,14 @@ join       0  join  ·         ·          (x, y, x, z)  ·
 ·          1  ·     spans     ALL        ·             ·
 
 exec
-SELECT * FROM t.a, t.b WHERE a.x = b.x
+SELECT * FROM a, b WHERE a.x = b.x
 ----
 x:int  y:int  x:int  z:int
 2      20     2      200
 3      30     3      300
 
 exec-explain
-SELECT * FROM t.a INNER JOIN t.b ON a.x = b.x
+SELECT * FROM a INNER JOIN b ON a.x = b.x
 ----
 join       0  join  ·         ·          (x, y, x, z)  ·
  │         0  ·     type      inner      ·             ·
@@ -69,14 +65,14 @@ join       0  join  ·         ·          (x, y, x, z)  ·
 ·          1  ·     spans     ALL        ·             ·
 
 exec
-SELECT * FROM t.a INNER JOIN t.b ON a.x = b.x
+SELECT * FROM a INNER JOIN b ON a.x = b.x
 ----
 x:int  y:int  x:int  z:int
 2      20     2      200
 3      30     3      300
 
 exec-explain
-SELECT * FROM t.a NATURAL JOIN t.b
+SELECT * FROM a NATURAL JOIN b
 ----
 render          0  render  ·         ·          (x, y, z)     ·
  │              0  ·       render 0  x          ·             ·
@@ -93,14 +89,14 @@ render          0  render  ·         ·          (x, y, z)     ·
 ·               2  ·       spans     ALL        ·             ·
 
 exec
-SELECT * FROM t.a NATURAL JOIN t.b
+SELECT * FROM a NATURAL JOIN b
 ----
 x:int  y:int  z:int
 2      20     200
 3      30     300
 
 exec-explain
-SELECT * FROM t.a LEFT OUTER JOIN t.b ON a.x = b.x
+SELECT * FROM a LEFT OUTER JOIN b ON a.x = b.x
 ----
 join       0  join  ·         ·           (x, y, x, z)  ·
  │         0  ·     type      left outer  ·             ·
@@ -113,7 +109,7 @@ join       0  join  ·         ·           (x, y, x, z)  ·
 ·          1  ·     spans     ALL         ·             ·
 
 exec
-SELECT * FROM t.a LEFT OUTER JOIN t.b ON a.x = b.x
+SELECT * FROM a LEFT OUTER JOIN b ON a.x = b.x
 ----
 x:int  y:int  x:int  z:int
 1      10     NULL   NULL
@@ -121,7 +117,7 @@ x:int  y:int  x:int  z:int
 3      30     3      300
 
 exec-explain
-SELECT * FROM t.a NATURAL RIGHT OUTER JOIN t.b
+SELECT * FROM a NATURAL RIGHT OUTER JOIN b
 ----
 render          0  render  ·         ·            (x, y, z)     ·
  │              0  ·       render 0  x            ·             ·
@@ -138,7 +134,7 @@ render          0  render  ·         ·            (x, y, z)     ·
 ·               2  ·       spans     ALL          ·             ·
 
 exec
-SELECT * FROM t.a NATURAL RIGHT OUTER JOIN t.b
+SELECT * FROM a NATURAL RIGHT OUTER JOIN b
 ----
 x:int  y:int  z:int
 2      20     200
@@ -146,7 +142,7 @@ x:int  y:int  z:int
 4      NULL   400
 
 exec-explain
-SELECT * FROM t.a FULL OUTER JOIN t.b USING(x)
+SELECT * FROM a FULL OUTER JOIN b USING(x)
 ----
 render          0  render  ·         ·               (x, y, z)     ·
  │              0  ·       render 0  COALESCE(x, x)  ·             ·
@@ -163,7 +159,7 @@ render          0  render  ·         ·               (x, y, z)     ·
 ·               2  ·       spans     ALL             ·             ·
 
 exec
-SELECT * FROM t.a FULL OUTER JOIN t.b USING(x)
+SELECT * FROM a FULL OUTER JOIN b USING(x)
 ----
 x:int  y:int  z:int
 1      10     NULL
@@ -173,7 +169,7 @@ x:int  y:int  z:int
 
 # Select filters are pushed through join, down to scans.
 exec-explain
-SELECT * FROM t.a, t.b WHERE y > 10 AND z < 400
+SELECT * FROM a, b WHERE y > 10 AND z < 400
 ----
 join            0  join    ·       ·          (x, y, x, z)  ·
  │              0  ·       type    cross      ·             ·
@@ -189,7 +185,7 @@ join            0  join    ·       ·          (x, y, x, z)  ·
 ·               2  ·       spans   ALL        ·             ·
 
 exec
-SELECT * FROM t.a, t.b WHERE y > 10 AND z < 400
+SELECT * FROM a, b WHERE y > 10 AND z < 400
 ----
 x:int  y:int  x:int  z:int
 2      20     2      200
@@ -199,7 +195,7 @@ x:int  y:int  x:int  z:int
 
 # Join filter is pushed through join, down to scan.
 exec-explain
-SELECT * FROM t.a LEFT JOIN t.b ON a.x=b.x AND z < 300
+SELECT * FROM a LEFT JOIN b ON a.x=b.x AND z < 300
 ----
 join            0  join    ·         ·           (x, y, x, z)  ·
  │              0  ·       type      left outer  ·             ·
@@ -214,7 +210,7 @@ join            0  join    ·         ·           (x, y, x, z)  ·
 ·               2  ·       spans     ALL         ·             ·
 
 exec
-SELECT * FROM t.a LEFT JOIN t.b ON a.x=b.x AND z < 300
+SELECT * FROM a LEFT JOIN b ON a.x=b.x AND z < 300
 ----
 x:int  y:int  x:int  z:int
 1      10     NULL   NULL

--- a/pkg/sql/opt/exec/execbuilder/testdata/orderby
+++ b/pkg/sql/opt/exec/execbuilder/testdata/orderby
@@ -1,7 +1,6 @@
 # tests adapted from logictest -- order_by
 
 exec-raw
-CREATE DATABASE t;
 CREATE TABLE t (
   a INT PRIMARY KEY,
   b INT,

--- a/pkg/sql/opt/exec/execbuilder/testdata/project
+++ b/pkg/sql/opt/exec/execbuilder/testdata/project
@@ -3,29 +3,29 @@ CREATE DATABASE t
 ----
 
 exec-raw
-CREATE TABLE t.a (x INT PRIMARY KEY, y INT)
+CREATE TABLE a (x INT PRIMARY KEY, y INT)
 ----
 
 exec-raw
-INSERT INTO t.a VALUES (1, 10), (2, 20), (3, 30)
+INSERT INTO a VALUES (1, 10), (2, 20), (3, 30)
 ----
 
 exec-explain
-SELECT * FROM t.a WHERE x > 1
+SELECT * FROM a WHERE x > 1
 ----
 scan  0  scan  ·      ·          (x, y)  ·
 ·     0  ·     table  a@primary  ·       ·
 ·     0  ·     spans  /2-        ·       ·
 
 exec
-SELECT * FROM t.a WHERE x > 1
+SELECT * FROM a WHERE x > 1
 ----
 x:int  y:int
 2      20
 3      30
 
 exec-explain
-SELECT * FROM t.a WHERE y > 1
+SELECT * FROM a WHERE y > 1
 ----
 filter     0  filter  ·       ·          (x, y)  ·
  │         0  ·       filter  y > 1      ·       ·
@@ -34,7 +34,7 @@ filter     0  filter  ·       ·          (x, y)  ·
 ·          1  ·       spans   ALL        ·       ·
 
 exec
-SELECT * FROM t.a WHERE y > 1
+SELECT * FROM a WHERE y > 1
 ----
 x:int  y:int
 1      10
@@ -42,20 +42,20 @@ x:int  y:int
 3      30
 
 exec-explain
-SELECT * FROM t.a WHERE x > 1 AND x < 3
+SELECT * FROM a WHERE x > 1 AND x < 3
 ----
 scan  0  scan  ·      ·          (x, y)  ·
 ·     0  ·     table  a@primary  ·       ·
 ·     0  ·     spans  /2-/2/#    ·       ·
 
 exec
-SELECT * FROM t.a WHERE x > 1 AND x < 3
+SELECT * FROM a WHERE x > 1 AND x < 3
 ----
 x:int  y:int
 2      20
 
 exec-explain
-SELECT x + 1 FROM t.a
+SELECT x + 1 FROM a
 ----
 render     0  render  ·         ·          (column3)  ·
  │         0  ·       render 0  x + 1      ·          ·
@@ -64,7 +64,7 @@ render     0  render  ·         ·          (column3)  ·
 ·          1  ·       spans     ALL        ·          ·
 
 exec
-SELECT x + 1 FROM t.a
+SELECT x + 1 FROM a
 ----
 column3:int
 2
@@ -72,7 +72,7 @@ column3:int
 4
 
 exec-explain
-SELECT x, x + 1, y, y + 1, x + y FROM t.a
+SELECT x, x + 1, y, y + 1, x + y FROM a
 ----
 render     0  render  ·         ·          (x, column3, y, column4, column5)  ·
  │         0  ·       render 0  x          ·                                  ·
@@ -85,7 +85,7 @@ render     0  render  ·         ·          (x, column3, y, column4, column5)  
 ·          1  ·       spans     ALL        ·                                  ·
 
 exec
-SELECT x, x + 1, y, y + 1, x + y FROM t.a
+SELECT x, x + 1, y, y + 1, x + y FROM a
 ----
 x:int  column3:int  y:int  column4:int  column5:int
 1      2            10     11           11
@@ -93,7 +93,7 @@ x:int  column3:int  y:int  column4:int  column5:int
 3      4            30     31           33
 
 exec-explain
-SELECT u + v FROM (SELECT x + 3, y + 10 FROM t.a) AS foo(u, v)
+SELECT u + v FROM (SELECT x + 3, y + 10 FROM a) AS foo(u, v)
 ----
 render          0  render  ·         ·                  (column5)           ·
  │              0  ·       render 0  column3 + column4  ·                   ·
@@ -105,7 +105,7 @@ render          0  render  ·         ·                  (column5)           ·
 ·               2  ·       spans     ALL                ·                   ·
 
 exec
-SELECT u + v FROM (SELECT x + 3, y + 10 FROM t.a) AS foo(u, v)
+SELECT u + v FROM (SELECT x + 3, y + 10 FROM a) AS foo(u, v)
 ----
 column5:int
 24
@@ -113,7 +113,7 @@ column5:int
 46
 
 exec-explain
-SELECT x, x, y, x FROM t.a
+SELECT x, x, y, x FROM a
 ----
 render     0  render  ·         ·          (x, x, y, x)  ·
  │         0  ·       render 0  x          ·             ·
@@ -125,7 +125,7 @@ render     0  render  ·         ·          (x, x, y, x)  ·
 ·          1  ·       spans     ALL        ·             ·
 
 exec
-SELECT x, x, y, x FROM t.a
+SELECT x, x, y, x FROM a
 ----
 x:int  x:int  y:int  x:int
 1      1      10     1
@@ -133,7 +133,7 @@ x:int  x:int  y:int  x:int
 3      3      30     3
 
 exec-explain
-SELECT x + 1, x + y FROM t.a WHERE x + y > 20
+SELECT x + 1, x + y FROM a WHERE x + y > 20
 ----
 render          0  render  ·         ·             (column3, column4)  ·
  │              0  ·       render 0  x + 1         ·                   ·
@@ -145,27 +145,27 @@ render          0  render  ·         ·             (column3, column4)  ·
 ·               2  ·       spans     ALL           ·                   ·
 
 exec
-SELECT x + 1, x + y FROM t.a WHERE x + y > 20
+SELECT x + 1, x + y FROM a WHERE x + y > 20
 ----
 column3:int  column4:int
 3            22
 4            33
 
 exec-raw
-CREATE TABLE t.b (x INT, y INT);
-INSERT INTO t.b VALUES (1, 10), (2, 20), (3, 30)
+CREATE TABLE b (x INT, y INT);
+INSERT INTO b VALUES (1, 10), (2, 20), (3, 30)
 ----
 
 # Test with a hidden column.
 exec-explain
-SELECT * FROM t.b
+SELECT * FROM b
 ----
 scan  0  scan  ·      ·          (x, y)  ·
 ·     0  ·     table  b@primary  ·       ·
 ·     0  ·     spans  ALL        ·       ·
 
 exec
-SELECT * FROM t.b
+SELECT * FROM b
 ----
 x:int  y:int
 1      10
@@ -173,7 +173,7 @@ x:int  y:int
 3      30
 
 exec-explain
-SELECT x FROM t.b WHERE rowid > 0
+SELECT x FROM b WHERE rowid > 0
 ----
 render     0  render  ·         ·          (x)                 ·
  │         0  ·       render 0  x          ·                   ·
@@ -182,7 +182,7 @@ render     0  render  ·         ·          (x)                 ·
 ·          1  ·       spans     /1-        ·                   ·
 
 exec
-SELECT x FROM t.b WHERE rowid > 0
+SELECT x FROM b WHERE rowid > 0
 ----
 x:int
 1

--- a/pkg/sql/opt/exec/execbuilder/testdata/scalar
+++ b/pkg/sql/opt/exec/execbuilder/testdata/scalar
@@ -3,8 +3,7 @@
 # correctly.
 
 exec-raw
-CREATE DATABASE t;
-CREATE TABLE t.t (a INT, b INT, c INT, d INT, j JSONB, s STRING)
+CREATE TABLE t (a INT, b INT, c INT, d INT, j JSONB, s STRING)
 ----
 
 exec-explain
@@ -48,7 +47,7 @@ render       0  render  ·         ·                 (column1)  ·
 ·            1  ·       size      0 columns, 1 row  ·          ·
 
 exec-explain
-SELECT 1 + 2 FROM t.t
+SELECT 1 + 2 FROM t
 ----
 render     0  render  ·         ·          (column8)  ·
  │         0  ·       render 0  3          ·          ·
@@ -57,7 +56,7 @@ render     0  render  ·         ·          (column8)  ·
 ·          1  ·       spans     ALL        ·          ·
 
 exec-explain
-SELECT a + 2 FROM t.t
+SELECT a + 2 FROM t
 ----
 render     0  render  ·         ·          (column8)  ·
  │         0  ·       render 0  a + 2      ·          ·
@@ -66,7 +65,7 @@ render     0  render  ·         ·          (column8)  ·
 ·          1  ·       spans     ALL        ·          ·
 
 exec-explain
-SELECT a >= 5 AND b <= 10 AND c < 4 FROM t.t
+SELECT a >= 5 AND b <= 10 AND c < 4 FROM t
 ----
 render     0  render  ·         ·                                     (column8)  ·
  │         0  ·       render 0  ((a >= 5) AND (b <= 10)) AND (c < 4)  ·          ·
@@ -75,7 +74,7 @@ render     0  render  ·         ·                                     (column8
 ·          1  ·       spans     ALL                                   ·          ·
 
 exec-explain
-SELECT a >= 5 OR b <= 10 OR c < 4  FROM t.t
+SELECT a >= 5 OR b <= 10 OR c < 4  FROM t
 ----
 render     0  render  ·         ·                                   (column8)  ·
  │         0  ·       render 0  ((a >= 5) OR (b <= 10)) OR (c < 4)  ·          ·
@@ -84,7 +83,7 @@ render     0  render  ·         ·                                   (column8) 
 ·          1  ·       spans     ALL                                 ·          ·
 
 exec-explain
-SELECT NOT (a = 5) FROM t.t
+SELECT NOT (a = 5) FROM t
 ----
 render     0  render  ·         ·          (column8)  ·
  │         0  ·       render 0  a != 5     ·          ·
@@ -93,7 +92,7 @@ render     0  render  ·         ·          (column8)  ·
 ·          1  ·       spans     ALL        ·          ·
 
 exec-explain
-SELECT NOT (a > 5 AND b >= 10) FROM t.t
+SELECT NOT (a > 5 AND b >= 10) FROM t
 ----
 render     0  render  ·         ·                     (column8)  ·
  │         0  ·       render 0  (a <= 5) OR (b < 10)  ·          ·
@@ -102,7 +101,7 @@ render     0  render  ·         ·                     (column8)  ·
 ·          1  ·       spans     ALL                   ·          ·
 
 exec-explain
-SELECT (a >= 5 AND b <= 10) OR (a <= 10 AND c > 5) FROM t.t
+SELECT (a >= 5 AND b <= 10) OR (a <= 10 AND c > 5) FROM t
 ----
 render     0  render  ·         ·                                                    (column8)  ·
  │         0  ·       render 0  ((a >= 5) AND (b <= 10)) OR ((a <= 10) AND (c > 5))  ·          ·
@@ -111,7 +110,7 @@ render     0  render  ·         ·                                             
 ·          1  ·       spans     ALL                                                  ·          ·
 
 exec-explain
-SELECT NOT (a >= 5 OR b <= 10) AND NOT (c >= 10) FROM t.t
+SELECT NOT (a >= 5 OR b <= 10) AND NOT (c >= 10) FROM t
 ----
 render     0  render  ·         ·                                    (column8)  ·
  │         0  ·       render 0  ((a < 5) AND (b > 10)) AND (c < 10)  ·          ·
@@ -120,7 +119,7 @@ render     0  render  ·         ·                                    (column8)
 ·          1  ·       spans     ALL                                  ·          ·
 
 exec-explain
-SELECT (a, b) = (1, 2)  FROM t.t
+SELECT (a, b) = (1, 2)  FROM t
 ----
 render     0  render  ·         ·                    (column8)  ·
  │         0  ·       render 0  (a = 1) AND (b = 2)  ·          ·
@@ -129,7 +128,7 @@ render     0  render  ·         ·                    (column8)  ·
 ·          1  ·       spans     ALL                  ·          ·
 
 exec-explain
-SELECT a IN (1, 2) FROM t.t
+SELECT a IN (1, 2) FROM t
 ----
 render     0  render  ·         ·            (column8)  ·
  │         0  ·       render 0  a IN (1, 2)  ·          ·
@@ -138,7 +137,7 @@ render     0  render  ·         ·            (column8)  ·
 ·          1  ·       spans     ALL          ·          ·
 
 exec-explain
-SELECT (a, b) IN ((1, 2), (3, 4)) FROM t.t
+SELECT (a, b) IN ((1, 2), (3, 4)) FROM t
 ----
 render     0  render  ·         ·                           (column8)  ·
  │         0  ·       render 0  (a, b) IN ((1, 2), (3, 4))  ·          ·
@@ -147,7 +146,7 @@ render     0  render  ·         ·                           (column8)  ·
 ·          1  ·       spans     ALL                         ·          ·
 
 exec-explain
-SELECT (a, b + c, 5 + d * 2) = (b+c, 8, a - c)  FROM t.t
+SELECT (a, b + c, 5 + d * 2) = (b+c, 8, a - c)  FROM t
 ----
 render     0  render  ·         ·                                                                (column8)     ·
  │         0  ·       render 0  ((a = (b + c)) AND ((b + c) = 8)) AND (((d * 2) + 5) = (a - c))  ·             ·
@@ -156,7 +155,7 @@ render     0  render  ·         ·                                             
 ·          1  ·       spans     ALL                                                              ·             ·
 
 exec-explain
-SELECT ((a, b), (c, d)) = ((1, 2), (3, 4))  FROM t.t
+SELECT ((a, b), (c, d)) = ((1, 2), (3, 4))  FROM t
 ----
 render     0  render  ·         ·                                                (column8)     ·
  │         0  ·       render 0  (((a = 1) AND (b = 2)) AND (c = 3)) AND (d = 4)  ·             ·
@@ -165,7 +164,7 @@ render     0  render  ·         ·                                             
 ·          1  ·       spans     ALL                                              ·             ·
 
 exec-explain
-SELECT (a, (b, 'a'), (c, 'b', 5)) = (9, (a+c, s), (5, s, a)) FROM t.t
+SELECT (a, (b, 'a'), (c, 'b', 5)) = (9, (a+c, s), (5, s, a)) FROM t
 ----
 render     0  render  ·         ·                                                                                      (column8)     ·
  │         0  ·       render 0  (((((a = 9) AND (b = (a + c))) AND (s = 'a')) AND (c = 5)) AND (s = 'b')) AND (a = 5)  ·             ·
@@ -174,7 +173,7 @@ render     0  render  ·         ·                                             
 ·          1  ·       spans     ALL                                                                                    ·             ·
 
 exec-explain
-SELECT a IS NULL FROM t.t
+SELECT a IS NULL FROM t
 ----
 render     0  render  ·         ·          (column8)  ·
  │         0  ·       render 0  a IS NULL  ·          ·
@@ -183,7 +182,7 @@ render     0  render  ·         ·          (column8)  ·
 ·          1  ·       spans     ALL        ·          ·
 
 exec-explain
-SELECT a IS NOT DISTINCT FROM NULL FROM t.t
+SELECT a IS NOT DISTINCT FROM NULL FROM t
 ----
 render     0  render  ·         ·          (column8)  ·
  │         0  ·       render 0  a IS NULL  ·          ·
@@ -192,7 +191,7 @@ render     0  render  ·         ·          (column8)  ·
 ·          1  ·       spans     ALL        ·          ·
 
 exec-explain
-SELECT a IS NOT DISTINCT FROM b FROM t.t
+SELECT a IS NOT DISTINCT FROM b FROM t
 ----
 render     0  render  ·         ·                         (column8)  ·
  │         0  ·       render 0  a IS NOT DISTINCT FROM b  ·          ·
@@ -201,7 +200,7 @@ render     0  render  ·         ·                         (column8)  ·
 ·          1  ·       spans     ALL                       ·          ·
 
 exec-explain
-SELECT a IS NOT NULL FROM t.t
+SELECT a IS NOT NULL FROM t
 ----
 render     0  render  ·         ·              (column8)  ·
  │         0  ·       render 0  a IS NOT NULL  ·          ·
@@ -210,7 +209,7 @@ render     0  render  ·         ·              (column8)  ·
 ·          1  ·       spans     ALL            ·          ·
 
 exec-explain
-SELECT a IS DISTINCT FROM NULL FROM t.t
+SELECT a IS DISTINCT FROM NULL FROM t
 ----
 render     0  render  ·         ·              (column8)  ·
  │         0  ·       render 0  a IS NOT NULL  ·          ·
@@ -219,7 +218,7 @@ render     0  render  ·         ·              (column8)  ·
 ·          1  ·       spans     ALL            ·          ·
 
 exec-explain
-SELECT a IS DISTINCT FROM b FROM t.t
+SELECT a IS DISTINCT FROM b FROM t
 ----
 render     0  render  ·         ·                     (column8)  ·
  │         0  ·       render 0  a IS DISTINCT FROM b  ·          ·
@@ -228,7 +227,7 @@ render     0  render  ·         ·                     (column8)  ·
 ·          1  ·       spans     ALL                   ·          ·
 
 exec-explain
-SELECT +a + (-b) FROM t.t
+SELECT +a + (-b) FROM t
 ----
 render     0  render  ·         ·          (column8)  ·
  │         0  ·       render 0  a + (-b)   ·          ·
@@ -237,7 +236,7 @@ render     0  render  ·         ·          (column8)  ·
 ·          1  ·       spans     ALL        ·          ·
 
 exec-explain
-SELECT CASE a WHEN 1 THEN 2 WHEN 2 THEN 3 ELSE 4 END FROM t.t
+SELECT CASE a WHEN 1 THEN 2 WHEN 2 THEN 3 ELSE 4 END FROM t
 ----
 render     0  render  ·         ·                                              (column8)  ·
  │         0  ·       render 0  CASE a WHEN 1 THEN 2 WHEN 2 THEN 3 ELSE 4 END  ·          ·
@@ -246,7 +245,7 @@ render     0  render  ·         ·                                             
 ·          1  ·       spans     ALL                                            ·          ·
 
 exec-explain
-SELECT CASE WHEN a = 2 THEN 1 ELSE 2 END FROM t.t
+SELECT CASE WHEN a = 2 THEN 1 ELSE 2 END FROM t
 ----
 render     0  render  ·         ·                                  (column8)  ·
  │         0  ·       render 0  CASE WHEN a = 2 THEN 1 ELSE 2 END  ·          ·
@@ -255,7 +254,7 @@ render     0  render  ·         ·                                  (column8)  
 ·          1  ·       spans     ALL                                ·          ·
 
 exec-explain
-SELECT CASE a + 3 WHEN 5 * b THEN 1 % b WHEN 6 THEN 2 ELSE -1 END FROM t.t
+SELECT CASE a + 3 WHEN 5 * b THEN 1 % b WHEN 6 THEN 2 ELSE -1 END FROM t
 ----
 render     0  render  ·         ·                                                           (column8)  ·
  │         0  ·       render 0  CASE a + 3 WHEN b * 5 THEN 1 % b WHEN 6 THEN 2 ELSE -1 END  ·          ·
@@ -265,7 +264,7 @@ render     0  render  ·         ·                                             
 
 # Tests for CASE with no ELSE statement
 exec-explain
-SELECT CASE WHEN a = 2 THEN 1 END FROM t.t
+SELECT CASE WHEN a = 2 THEN 1 END FROM t
 ----
 render     0  render  ·         ·                           (column8)  ·
  │         0  ·       render 0  CASE WHEN a = 2 THEN 1 END  ·          ·
@@ -274,7 +273,7 @@ render     0  render  ·         ·                           (column8)  ·
 ·          1  ·       spans     ALL                         ·          ·
 
 exec-explain
-SELECT CASE a WHEN 2 THEN 1 END FROM t.t
+SELECT CASE a WHEN 2 THEN 1 END FROM t
 ----
 render     0  render  ·         ·                         (column8)  ·
  │         0  ·       render 0  CASE a WHEN 2 THEN 1 END  ·          ·
@@ -283,16 +282,16 @@ render     0  render  ·         ·                         (column8)  ·
 ·          1  ·       spans     ALL                       ·          ·
 
 exec-explain allow-unsupported
-SELECT a FROM t.t WHERE a IS OF (INT)
+SELECT a FROM t WHERE a IS OF (INT)
 ----
-filter     0  filter  ·       ·                         (a)  ·
- │         0  ·       filter  t.public.t.a IS OF (INT)  ·    ·
- └── scan  1  scan    ·       ·                         (a)  ·
-·          1  ·       table   t@primary                 ·    ·
-·          1  ·       spans   ALL                       ·    ·
+filter     0  filter  ·       ·                (a)  ·
+ │         0  ·       filter  t.a IS OF (INT)  ·    ·
+ └── scan  1  scan    ·       ·                (a)  ·
+·          1  ·       table   t@primary        ·    ·
+·          1  ·       spans   ALL              ·    ·
 
 exec-explain
-SELECT LENGTH(s) FROM t.t
+SELECT LENGTH(s) FROM t
 ----
 render     0  render  ·         ·          (column8)  ·
  │         0  ·       render 0  length(s)  ·          ·
@@ -302,12 +301,12 @@ render     0  render  ·         ·          (column8)  ·
 
 # Verify that the built function can be executed.
 exec-raw
-CREATE TABLE t.str (s STRING);
-INSERT INTO t.str VALUES ('a'), ('ab'), ('abc')
+CREATE TABLE str (s STRING);
+INSERT INTO str VALUES ('a'), ('ab'), ('abc')
 ----
 
 exec
-SELECT LENGTH(s) FROM t.str
+SELECT LENGTH(s) FROM str
 ----
 column3:int
 1
@@ -315,7 +314,7 @@ column3:int
 3
 
 exec-explain
-SELECT j @> '{"a": 1}' FROM t.t
+SELECT j @> '{"a": 1}' FROM t
 ----
 render     0  render  ·         ·                (column8)  ·
  │         0  ·       render 0  j @> '{"a": 1}'  ·          ·
@@ -324,7 +323,7 @@ render     0  render  ·         ·                (column8)  ·
 ·          1  ·       spans     ALL              ·          ·
 
 exec-explain
-SELECT '{"a": 1}' <@ j FROM t.t
+SELECT '{"a": 1}' <@ j FROM t
 ----
 render     0  render  ·         ·                (column8)  ·
  │         0  ·       render 0  j @> '{"a": 1}'  ·          ·
@@ -333,7 +332,7 @@ render     0  render  ·         ·                (column8)  ·
 ·          1  ·       spans     ALL              ·          ·
 
 exec-explain
-SELECT j->>'a' FROM t.t
+SELECT j->>'a' FROM t
 ----
 render     0  render  ·         ·          (column8)  ·
  │         0  ·       render 0  j->>'a'    ·          ·
@@ -342,7 +341,7 @@ render     0  render  ·         ·          (column8)  ·
 ·          1  ·       spans     ALL        ·          ·
 
 exec-explain
-SELECT j->'a' FROM t.t
+SELECT j->'a' FROM t
 ----
 render     0  render  ·         ·          (column8)  ·
  │         0  ·       render 0  j->'a'     ·          ·
@@ -351,7 +350,7 @@ render     0  render  ·         ·          (column8)  ·
 ·          1  ·       spans     ALL        ·          ·
 
 exec-explain
-SELECT j ? 'a' FROM t.t
+SELECT j ? 'a' FROM t
 ----
 render     0  render  ·         ·          (column8)  ·
  │         0  ·       render 0  j ? 'a'    ·          ·
@@ -360,7 +359,7 @@ render     0  render  ·         ·          (column8)  ·
 ·          1  ·       spans     ALL        ·          ·
 
 exec-explain
-SELECT j ?| ARRAY['a', 'b', 'c'] FROM t.t
+SELECT j ?| ARRAY['a', 'b', 'c'] FROM t
 ----
 render     0  render  ·         ·                          (column8)  ·
  │         0  ·       render 0  j ?| ARRAY['a', 'b', 'c']  ·          ·
@@ -369,7 +368,7 @@ render     0  render  ·         ·                          (column8)  ·
 ·          1  ·       spans     ALL                        ·          ·
 
 exec-explain
-SELECT j ?& ARRAY['a', 'b', 'c'] FROM t.t
+SELECT j ?& ARRAY['a', 'b', 'c'] FROM t
 ----
 render     0  render  ·         ·                          (column8)  ·
  │         0  ·       render 0  j ?& ARRAY['a', 'b', 'c']  ·          ·
@@ -378,7 +377,7 @@ render     0  render  ·         ·                          (column8)  ·
 ·          1  ·       spans     ALL                        ·          ·
 
 exec-explain
-SELECT j#>ARRAY['a'] FROM t.t
+SELECT j#>ARRAY['a'] FROM t
 ----
 render     0  render  ·         ·              (column8)  ·
  │         0  ·       render 0  j#>ARRAY['a']  ·          ·
@@ -387,7 +386,7 @@ render     0  render  ·         ·              (column8)  ·
 ·          1  ·       spans     ALL            ·          ·
 
 exec-explain
-SELECT j#>>ARRAY['a'] FROM t.t
+SELECT j#>>ARRAY['a'] FROM t
 ----
 render     0  render  ·         ·               (column8)  ·
  │         0  ·       render 0  j#>>ARRAY['a']  ·          ·
@@ -397,7 +396,7 @@ render     0  render  ·         ·               (column8)  ·
 
 
 exec-explain
-SELECT CAST(a AS string), b::float FROM t.t
+SELECT CAST(a AS string), b::float FROM t
 ----
 render     0  render  ·         ·          (column8, column9)  ·
  │         0  ·       render 0  a::STRING  ·                   ·
@@ -407,7 +406,7 @@ render     0  render  ·         ·          (column8, column9)  ·
 ·          1  ·       spans     ALL        ·                   ·
 
 exec-explain
-SELECT CAST(a + b + c AS string) FROM t.t
+SELECT CAST(a + b + c AS string) FROM t
 ----
 render     0  render  ·         ·                      (column8)  ·
  │         0  ·       render 0  (c + (a + b))::STRING  ·          ·
@@ -416,7 +415,7 @@ render     0  render  ·         ·                      (column8)  ·
 ·          1  ·       spans     ALL                    ·          ·
 
 exec
-SELECT LENGTH(s)::float, s FROM t.str
+SELECT LENGTH(s)::float, s FROM str
 ----
 column3:float  s:string
 1.0            a
@@ -478,7 +477,7 @@ column4:int
 NULL
 
 exec-explain
-SELECT a FROM t.t WHERE a BETWEEN b AND d
+SELECT a FROM t WHERE a BETWEEN b AND d
 ----
 render          0  render  ·         ·                      (a)        ·
  │              0  ·       render 0  a                      ·          ·
@@ -489,7 +488,7 @@ render          0  render  ·         ·                      (a)        ·
 ·               2  ·       spans     ALL                    ·          ·
 
 exec-explain
-SELECT a FROM t.t WHERE a NOT BETWEEN b AND d
+SELECT a FROM t WHERE a NOT BETWEEN b AND d
 ----
 render          0  render  ·         ·                   (a)        ·
  │              0  ·       render 0  a                   ·          ·
@@ -500,7 +499,7 @@ render          0  render  ·         ·                   (a)        ·
 ·               2  ·       spans     ALL                 ·          ·
 
 exec-explain
-SELECT a BETWEEN SYMMETRIC b AND d FROM t.t
+SELECT a BETWEEN SYMMETRIC b AND d FROM t
 ----
 render     0  render  ·         ·                                                   (column8)  ·
  │         0  ·       render 0  ((a >= b) AND (a <= d)) OR ((a >= d) AND (a <= b))  ·          ·
@@ -509,7 +508,7 @@ render     0  render  ·         ·                                             
 ·          1  ·       spans     ALL                                                 ·          ·
 
 exec-explain
-SELECT a NOT BETWEEN SYMMETRIC b AND d FROM t.t
+SELECT a NOT BETWEEN SYMMETRIC b AND d FROM t
 ----
 render     0  render  ·         ·                                              (column8)  ·
  │         0  ·       render 0  ((a < b) OR (a > d)) AND ((a < d) OR (a > b))  ·          ·
@@ -518,7 +517,7 @@ render     0  render  ·         ·                                             
 ·          1  ·       spans     ALL                                            ·          ·
 
 exec-explain
-SELECT ARRAY[a + 1, 2, 3] FROM t.t
+SELECT ARRAY[a + 1, 2, 3] FROM t
 ----
 render     0  render  ·         ·                   (column8)  ·
  │         0  ·       render 0  ARRAY[a + 1, 2, 3]  ·          ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/scan
+++ b/pkg/sql/opt/exec/execbuilder/testdata/scan
@@ -1,14 +1,10 @@
 exec-raw
-CREATE DATABASE t
-----
-
-exec-raw
-CREATE TABLE t.a (x INT PRIMARY KEY, y FLOAT, s STRING);
-INSERT INTO t.a VALUES (1, 1.0, 'apple'), (2, 2.0, 'banana'), (3, 3.0, 'cherry')
+CREATE TABLE a (x INT PRIMARY KEY, y FLOAT, s STRING);
+INSERT INTO a VALUES (1, 1.0, 'apple'), (2, 2.0, 'banana'), (3, 3.0, 'cherry')
 ----
 
 opt
-SELECT * FROM t.a
+SELECT * FROM a
 ----
 scan a
  ├── columns: x:1(int!null) y:2(float) s:3(string)
@@ -17,14 +13,14 @@ scan a
  └── keys: (1)
 
 exec-explain
-SELECT * FROM t.a
+SELECT * FROM a
 ----
 scan  0  scan  ·      ·          (x, y, s)  ·
 ·     0  ·     table  a@primary  ·          ·
 ·     0  ·     spans  ALL        ·          ·
 
 exec
-SELECT * FROM t.a
+SELECT * FROM a
 ----
 x:int  y:float  s:string
 1      1.0      apple
@@ -33,7 +29,7 @@ x:int  y:float  s:string
 
 # Test projecting subset of table columns.
 opt
-SELECT s, x FROM t.a
+SELECT s, x FROM a
 ----
 scan a
  ├── columns: s:3(string) x:1(int!null)
@@ -42,7 +38,7 @@ scan a
  └── keys: (1)
 
 exec-explain
-SELECT s, x FROM t.a
+SELECT s, x FROM a
 ----
 render     0  render  ·         ·          (s, x)  ·
  │         0  ·       render 0  s          ·       ·
@@ -52,7 +48,7 @@ render     0  render  ·         ·          (s, x)  ·
 ·          1  ·       spans     ALL        ·       ·
 
 exec
-SELECT s, x FROM t.a
+SELECT s, x FROM a
 ----
 s:string  x:int
 apple     1
@@ -61,12 +57,12 @@ cherry    3
 
 # Test with a hidden column.
 exec-raw
-CREATE TABLE t.b (x INT, y INT, s STRING);
-INSERT INTO t.b VALUES (1, 10, 'apple'), (2, 20, 'banana'), (3, 30, 'cherry')
+CREATE TABLE b (x INT, y INT, s STRING);
+INSERT INTO b VALUES (1, 10, 'apple'), (2, 20, 'banana'), (3, 30, 'cherry')
 ----
 
 opt
-SELECT s, x FROM t.b
+SELECT s, x FROM b
 ----
 scan b
  ├── columns: s:3(string) x:1(int)
@@ -74,7 +70,7 @@ scan b
  └── cost: 1000.00
 
 exec
-SELECT s, x FROM t.b
+SELECT s, x FROM b
 ----
 s:string  x:int
 apple     1
@@ -82,7 +78,7 @@ banana    2
 cherry    3
 
 exec-explain
-SELECT s, x FROM t.b
+SELECT s, x FROM b
 ----
 render     0  render  ·         ·          (s, x)  ·
  │         0  ·       render 0  s          ·       ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/select
+++ b/pkg/sql/opt/exec/execbuilder/testdata/select
@@ -1,28 +1,24 @@
 exec-raw
-CREATE DATABASE t
-----
-
-exec-raw
-CREATE TABLE t.a (x INT PRIMARY KEY, y INT);
-INSERT INTO t.a VALUES (1, 10), (2, 20), (3, 30)
+CREATE TABLE a (x INT PRIMARY KEY, y INT);
+INSERT INTO a VALUES (1, 10), (2, 20), (3, 30)
 ----
 
 exec-explain
-SELECT * FROM t.a WHERE x > 1
+SELECT * FROM a WHERE x > 1
 ----
 scan  0  scan  ·      ·          (x, y)  ·
 ·     0  ·     table  a@primary  ·       ·
 ·     0  ·     spans  /2-        ·       ·
 
 exec
-SELECT * FROM t.a WHERE x > 1
+SELECT * FROM a WHERE x > 1
 ----
 x:int  y:int
 2      20
 3      30
 
 exec-explain
-SELECT * FROM t.a WHERE y > 10
+SELECT * FROM a WHERE y > 10
 ----
 filter     0  filter  ·       ·          (x, y)  ·
  │         0  ·       filter  y > 10     ·       ·
@@ -31,27 +27,27 @@ filter     0  filter  ·       ·          (x, y)  ·
 ·          1  ·       spans   ALL        ·       ·
 
 exec
-SELECT * FROM t.a WHERE y > 10
+SELECT * FROM a WHERE y > 10
 ----
 x:int  y:int
 2      20
 3      30
 
 exec-explain
-SELECT * FROM t.a WHERE x > 1 AND x < 3
+SELECT * FROM a WHERE x > 1 AND x < 3
 ----
 scan  0  scan  ·      ·          (x, y)  ·
 ·     0  ·     table  a@primary  ·       ·
 ·     0  ·     spans  /2-/2/#    ·       ·
 
 exec
-SELECT * FROM t.a WHERE x > 1 AND x < 3
+SELECT * FROM a WHERE x > 1 AND x < 3
 ----
 x:int  y:int
 2      20
 
 exec-explain
-SELECT * FROM t.a WHERE x > 1 AND y < 30
+SELECT * FROM a WHERE x > 1 AND y < 30
 ----
 filter     0  filter  ·       ·          (x, y)  ·
  │         0  ·       filter  y < 30     ·       ·
@@ -60,37 +56,37 @@ filter     0  filter  ·       ·          (x, y)  ·
 ·          1  ·       spans   /2-        ·       ·
 
 exec
-SELECT * FROM t.a WHERE x > 1 AND y < 30
+SELECT * FROM a WHERE x > 1 AND y < 30
 ----
 x:int  y:int
 2      20
 
 exec-raw
-CREATE TABLE t.b (x INT, y INT);
-INSERT INTO t.b VALUES (1, 10), (2, 20), (3, 30)
+CREATE TABLE b (x INT, y INT);
+INSERT INTO b VALUES (1, 10), (2, 20), (3, 30)
 ----
 
 exec-explain
-SELECT x, y, rowid FROM t.b WHERE rowid > 0
+SELECT x, y, rowid FROM b WHERE rowid > 0
 ----
 scan  0  scan  ·      ·          (x, y, rowid[hidden])  ·
 ·     0  ·     table  b@primary  ·                      ·
 ·     0  ·     spans  /1-        ·                      ·
 
 exec-raw
-CREATE TABLE t.c (n INT PRIMARY KEY, str STRING, INDEX str(str DESC));
-INSERT INTO t.c SELECT i, to_english(i) FROM GENERATE_SERIES(1, 10) AS g(i)
+CREATE TABLE c (n INT PRIMARY KEY, str STRING, INDEX str(str DESC));
+INSERT INTO c SELECT i, to_english(i) FROM GENERATE_SERIES(1, 10) AS g(i)
 ----
 
 exec-explain
-SELECT * FROM t.c WHERE str >= 'moo'
+SELECT * FROM c WHERE str >= 'moo'
 ----
 scan  0  scan  ·      ·                  (n, str)  ·
 ·     0  ·     table  c@str              ·         ·
 ·     0  ·     spans  -/"moo"/PrefixEnd  ·         ·
 
 exec rowsort
-SELECT * FROM t.c WHERE str >= 'moo'
+SELECT * FROM c WHERE str >= 'moo'
 ----
 n:int  str:string
 1      one

--- a/pkg/sql/opt/exec/execbuilder/testdata/stats
+++ b/pkg/sql/opt/exec/execbuilder/testdata/stats
@@ -1,15 +1,11 @@
 # Tests that verify we retrieve the stats correctly.
 
 exec-raw
-CREATE DATABASE t
-----
-
-exec-raw
-CREATE TABLE t.a (u INT, v INT, INDEX (u) STORING (v), INDEX (v) STORING (u));
+CREATE TABLE a (u INT, v INT, INDEX (u) STORING (v), INDEX (v) STORING (u));
 ----
 
 build
-SELECT * FROM t.a
+SELECT * FROM a
 ----
 project
  ├── columns: u:1(int) v:2(int)
@@ -27,17 +23,17 @@ project
 # Create a new table to avoid depending on the asynchronous stat cache
 # invalidation.
 exec-raw
-CREATE TABLE t.b (u INT, v INT, INDEX (u) STORING (v), INDEX (v) STORING (u));
-INSERT INTO t.b VALUES (1, 1), (1, 2), (1, 3), (1, 4), (2, 4), (2, 5), (2, 6), (2, 7)
+CREATE TABLE b (u INT, v INT, INDEX (u) STORING (v), INDEX (v) STORING (u));
+INSERT INTO b VALUES (1, 1), (1, 2), (1, 3), (1, 4), (2, 4), (2, 5), (2, 6), (2, 7)
 ----
 
 exec-raw
-CREATE STATISTICS u ON u FROM t.b;
-CREATE STATISTICS v ON v FROM t.b
+CREATE STATISTICS u ON u FROM b;
+CREATE STATISTICS v ON v FROM b
 ----
 
 build
-SELECT * FROM t.b
+SELECT * FROM b
 ----
 project
  ├── columns: u:1(int) v:2(int)
@@ -54,7 +50,7 @@ project
 
 # Verify we scan index v which has the more selective constraint.
 opt
-SELECT * FROM t.b WHERE u = 1 AND v = 1
+SELECT * FROM b WHERE u = 1 AND v = 1
 ----
 select
  ├── columns: u:1(int) v:2(int)
@@ -71,7 +67,7 @@ select
            └── const: 1 [type=int]
 
 exec-explain
-SELECT * FROM t.b WHERE u = 1 AND v = 1
+SELECT * FROM b WHERE u = 1 AND v = 1
 ----
 filter     0  filter  ·       ·          (u, v)  ·
  │         0  ·       filter  u = 1      ·       ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/subquery
+++ b/pkg/sql/opt/exec/execbuilder/testdata/subquery
@@ -1,14 +1,10 @@
 exec-raw
-CREATE DATABASE t
-----
-
-exec-raw
-CREATE TABLE t.t (k INT PRIMARY KEY, u INT, v INT);
-INSERT INTO t.t VALUES (1, 1, 1), (2, 4, 8), (3, 9, 27), (4, 16, 64)
+CREATE TABLE t (k INT PRIMARY KEY, u INT, v INT);
+INSERT INTO t VALUES (1, 1, 1), (2, 4, 8), (3, 9, 27), (4, 16, 64)
 ----
 
 opt
-SELECT EXISTS(SELECT * FROM t.t WHERE u = k*k)
+SELECT EXISTS(SELECT * FROM t WHERE u = k*k)
 ----
 project
  ├── columns: column4:4(bool)
@@ -38,7 +34,7 @@ project
                                └── variable: t.k [type=int, outer=(1)]
 
 exec-explain
-SELECT EXISTS(SELECT * FROM t.t WHERE u = k*k)
+SELECT EXISTS(SELECT * FROM t WHERE u = k*k)
 ----
 root                 0  root      ·          ·                 (column4)  ·
  ├── render          1  render    ·          ·                 (column4)  ·
@@ -56,19 +52,19 @@ root                 0  root      ·          ·                 (column4)  ·
 ·                    3  ·         spans      ALL               ·          ·
 
 exec
-SELECT EXISTS(SELECT * FROM t.t WHERE u = k*k)
+SELECT EXISTS(SELECT * FROM t WHERE u = k*k)
 ----
 column4:bool
 true
 
 exec
-SELECT EXISTS(SELECT * FROM t.t WHERE u != k*k)
+SELECT EXISTS(SELECT * FROM t WHERE u != k*k)
 ----
 column4:bool
 false
 
 exec-explain
-SELECT * FROM t.t WHERE u = (SELECT MAX(u) FROM t.t)
+SELECT * FROM t WHERE u = (SELECT MAX(u) FROM t)
 ----
 root                 0  root      ·            ·          (k, u, v)  ·
  ├── filter          1  filter    ·            ·          (k, u, v)  ·
@@ -87,13 +83,13 @@ root                 0  root      ·            ·          (k, u, v)  ·
 ·                    3  ·         spans        ALL        ·          ·
 
 exec
-SELECT * FROM t.t WHERE u = (SELECT MAX(u) FROM t.t)
+SELECT * FROM t WHERE u = (SELECT MAX(u) FROM t)
 ----
 k:int  u:int  v:int
 4      16     64
 
 exec-explain
-SELECT * FROM t.t WHERE u = (SELECT MAX(u) FROM t.t WHERE EXISTS(SELECT * FROM t.t WHERE u=k*k))
+SELECT * FROM t WHERE u = (SELECT MAX(u) FROM t WHERE EXISTS(SELECT * FROM t WHERE u=k*k))
 ----
 root                      0  root      ·            ·                 (k, u, v)  ·
  ├── filter               1  filter    ·            ·                 (k, u, v)  ·
@@ -123,7 +119,7 @@ root                      0  root      ·            ·                 (k, u, v
 ·                         4  ·         spans        ALL               ·          ·
 
 exec
-SELECT * FROM t.t WHERE u = (SELECT MAX(u) FROM t.t WHERE EXISTS(SELECT * FROM t.t WHERE u=k*k))
+SELECT * FROM t WHERE u = (SELECT MAX(u) FROM t WHERE EXISTS(SELECT * FROM t WHERE u=k*k))
 ----
 k:int  u:int  v:int
 4      16     64

--- a/pkg/sql/opt/memo/testdata/logprops/join
+++ b/pkg/sql/opt/memo/testdata/logprops/join
@@ -122,7 +122,7 @@ project
       └── variable: uv.v [type=int, outer=(6)]
 
 build
-SELECT * FROM xysd, xysd
+SELECT * FROM xysd, xysd AS xysd
 ----
 inner-join
  ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null) x:5(int!null) y:6(int) s:7(string) d:8(decimal!null)

--- a/pkg/sql/opt/memo/testdata/stats/join
+++ b/pkg/sql/opt/memo/testdata/stats/join
@@ -162,7 +162,7 @@ project
       └── variable: b.z [type=int, outer=(6)]
 
 build
-SELECT * FROM a, a
+SELECT * FROM a, a AS a
 ----
 inner-join
  ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null) x:5(int!null) y:6(int) s:7(string) d:8(decimal!null)

--- a/pkg/sql/opt/metadata.go
+++ b/pkg/sql/opt/metadata.go
@@ -128,14 +128,25 @@ func (md *Metadata) ColumnType(id ColumnID) types.T {
 // references to the same table are assigned different table ids (e.g. in a
 // self-join query).
 func (md *Metadata) AddTable(tab Table) TableID {
+	return md.AddTableWithName(tab, "")
+}
+
+// AddTableWithName indexes a new reference to a table within the query.
+// Separate references to the same table are assigned different table ids
+// (e.g. in a self-join query). Optionally, include a table name tabName to
+// override the name in tab when creating column labels.
+func (md *Metadata) AddTableWithName(tab Table, tabName string) TableID {
 	tabID := TableID(md.NumColumns() + 1)
+	if tabName == "" {
+		tabName = string(tab.TabName())
+	}
 
 	for i := 0; i < tab.ColumnCount(); i++ {
 		col := tab.Column(i)
-		if tab.TabName() == "" {
+		if tabName == "" {
 			md.AddColumn(string(col.ColName()), col.DatumType())
 		} else {
-			md.AddColumn(fmt.Sprintf("%s.%s", tab.TabName(), col.ColName()), col.DatumType())
+			md.AddColumn(fmt.Sprintf("%s.%s", tabName, col.ColName()), col.DatumType())
 		}
 	}
 

--- a/pkg/sql/opt/metadata_test.go
+++ b/pkg/sql/opt/metadata_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/testutils"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
 	"github.com/cockroachdb/cockroach/pkg/util"
 )
@@ -72,7 +73,8 @@ func TestMetadataTables(t *testing.T) {
 	md := opt.NewMetadata()
 
 	// Add a table reference to the metadata.
-	a := &testutils.TestTable{Name: "a"}
+	a := &testutils.TestTable{}
+	a.Name = tree.MakeUnqualifiedTableName(tree.Name("a"))
 	x := &testutils.TestColumn{Name: "x"}
 	y := &testutils.TestColumn{Name: "y"}
 	a.Columns = append(a.Columns, x, y)

--- a/pkg/sql/opt/norm/testdata/project
+++ b/pkg/sql/opt/norm/testdata/project
@@ -1,5 +1,5 @@
 exec-ddl
-CREATE TABLE t.a (x INT PRIMARY KEY, y INT, f FLOAT, s STRING)
+CREATE TABLE a (x INT PRIMARY KEY, y INT, f FLOAT, s STRING)
 ----
 TABLE a
  ├── x int not null
@@ -10,7 +10,7 @@ TABLE a
       └── x int not null
 
 exec-ddl
-CREATE TABLE t.b (x INT PRIMARY KEY, z INT)
+CREATE TABLE b (x INT PRIMARY KEY, z INT)
 ----
 TABLE b
  ├── x int not null
@@ -24,7 +24,7 @@ TABLE b
 
 # Same order, same names.
 opt
-SELECT x, y FROM t.a
+SELECT x, y FROM a
 ----
 scan a
  ├── columns: x:1(int!null) y:2(int)
@@ -32,7 +32,7 @@ scan a
 
 # Different order, aliased names.
 opt
-SELECT a.y AS aliasy, a.x FROM t.a
+SELECT a.y AS aliasy, a.x FROM a
 ----
 scan a
  ├── columns: aliasy:2(int) x:1(int!null)
@@ -40,7 +40,7 @@ scan a
 
 # Reordered, duplicate, aliased columns.
 opt
-SELECT a.y AS alias1, a.x, a.y AS alias1, a.x FROM t.a
+SELECT a.y AS alias1, a.x, a.y AS alias1, a.x FROM a
 ----
 scan a
  ├── columns: alias1:2(int) x:1(int!null) alias1:2(int) x:1(int!null)
@@ -48,7 +48,7 @@ scan a
 
 # Added column (projection should not be eliminated).
 opt
-SELECT *, 1 FROM t.a
+SELECT *, 1 FROM a
 ----
 project
  ├── columns: x:1(int!null) y:2(int) f:3(float) s:4(string) column5:5(int)
@@ -95,7 +95,7 @@ project
 
 # Discard some of columns.
 opt
-SELECT x FROM (SELECT x, y+1 FROM t.a) a
+SELECT x FROM (SELECT x, y+1 FROM a) a
 ----
 scan a
  ├── columns: x:1(int!null)
@@ -103,7 +103,7 @@ scan a
 
 # Discard all columns.
 opt
-SELECT 1 FROM (SELECT y+1, x FROM t.a) a
+SELECT 1 FROM (SELECT y+1, x FROM a) a
 ----
 project
  ├── columns: column6:6(int)
@@ -113,7 +113,7 @@ project
 
 # Use column values within computed column.
 opt
-SELECT x+y FROM (SELECT y, x, s || 'foo' FROM t.a) a
+SELECT x+y FROM (SELECT y, x, s || 'foo' FROM a) a
 ----
 project
  ├── columns: column6:6(int)
@@ -169,7 +169,7 @@ project
 
 # Project subset of columns.
 opt
-SELECT x FROM t.a
+SELECT x FROM a
 ----
 scan a
  ├── columns: x:1(int!null)
@@ -177,7 +177,7 @@ scan a
 
 # Project subset of columns, some used in computed columns.
 opt
-SELECT x, x+1, y+1 FROM t.a
+SELECT x, x+1, y+1 FROM a
 ----
 project
  ├── columns: x:1(int!null) column5:5(int) column6:6(int)
@@ -196,7 +196,7 @@ project
 
 # Use columns only in computed columns.
 opt
-SELECT x+y FROM t.a
+SELECT x+y FROM a
 ----
 project
  ├── columns: column5:5(int)
@@ -210,7 +210,7 @@ project
 
 # Use no scan columns.
 opt
-SELECT 1 FROM t.a
+SELECT 1 FROM a
 ----
 project
  ├── columns: column5:5(int)
@@ -224,7 +224,7 @@ project
 
 # Columns used only by projection or filter, but not both.
 opt
-SELECT x FROM t.a WHERE y<5
+SELECT x FROM a WHERE y<5
 ----
 project
  ├── columns: x:1(int!null)
@@ -244,7 +244,7 @@ project
 
 # Columns used by both projection and filter.
 opt
-SELECT x, y FROM t.a WHERE x=1 AND y<5
+SELECT x, y FROM a WHERE x=1 AND y<5
 ----
 select
  ├── columns: x:1(int!null) y:2(int)
@@ -260,7 +260,7 @@ select
 
 # No needed select columns.
 opt
-SELECT 1 FROM t.a WHERE now()<'2000-01-01T02:00:00'::timestamp
+SELECT 1 FROM a WHERE now()<'2000-01-01T02:00:00'::timestamp
 ----
 project
  ├── columns: column5:5(int)
@@ -275,7 +275,7 @@ project
 
 # Select columns used in computed columns.
 opt
-SELECT y-1, x*x FROM t.a WHERE x+1<5 AND s||'o'='foo'
+SELECT y-1, x*x FROM a WHERE x+1<5 AND s||'o'='foo'
 ----
 project
  ├── columns: column5:5(int) column6:6(int)
@@ -366,7 +366,7 @@ project
 
 # The projection on top of Limit should trickle down and we shouldn't scan f.
 opt
-SELECT x FROM (SELECT x, y, f FROM t.a ORDER BY y LIMIT 10)
+SELECT x FROM (SELECT x, y, f FROM a ORDER BY y LIMIT 10)
 ----
 project
  ├── columns: x:1(int!null)
@@ -387,7 +387,7 @@ project
 
 # We should scan x, y, s.
 opt
-SELECT s FROM (SELECT x, y, f, s FROM t.a ORDER BY x, y LIMIT 10)
+SELECT s FROM (SELECT x, y, f, s FROM a ORDER BY x, y LIMIT 10)
 ----
 project
  ├── columns: s:4(string)
@@ -400,7 +400,7 @@ project
 
 # We should scan x, y, s.
 opt
-SELECT x, s FROM (SELECT x, y, f, s FROM t.a ORDER BY x, y LIMIT 10)
+SELECT x, s FROM (SELECT x, y, f, s FROM a ORDER BY x, y LIMIT 10)
 ----
 project
  ├── columns: x:1(int!null) s:4(string)
@@ -444,7 +444,7 @@ project
 # --------------------------------------------------
 
 opt
-SELECT x FROM (SELECT x, y, f FROM t.a ORDER BY y OFFSET 10)
+SELECT x FROM (SELECT x, y, f FROM a ORDER BY y OFFSET 10)
 ----
 project
  ├── columns: x:1(int!null)
@@ -465,7 +465,7 @@ project
 
 # We should scan x, y, s.
 opt
-SELECT s FROM (SELECT x, y, f, s FROM t.a ORDER BY x, y OFFSET 10)
+SELECT s FROM (SELECT x, y, f, s FROM a ORDER BY x, y OFFSET 10)
 ----
 project
  ├── columns: s:4(string)
@@ -482,7 +482,7 @@ project
 
 # We should scan x, y, s.
 opt
-SELECT x, s FROM (SELECT x, y, f, s FROM t.a ORDER BY x, y OFFSET 10)
+SELECT x, s FROM (SELECT x, y, f, s FROM a ORDER BY x, y OFFSET 10)
 ----
 project
  ├── columns: x:1(int!null) s:4(string)
@@ -530,7 +530,7 @@ project
 # --------------------------------------------------
 
 opt
-SELECT x FROM (SELECT x, y, f FROM t.a ORDER BY y LIMIT 10 OFFSET 10)
+SELECT x FROM (SELECT x, y, f FROM a ORDER BY y LIMIT 10 OFFSET 10)
 ----
 project
  ├── columns: x:1(int!null)
@@ -556,7 +556,7 @@ project
 
 # We should scan x, y, s.
 opt
-SELECT s FROM (SELECT x, y, f, s FROM t.a ORDER BY x, y LIMIT 10 OFFSET 10)
+SELECT s FROM (SELECT x, y, f, s FROM a ORDER BY x, y LIMIT 10 OFFSET 10)
 ----
 project
  ├── columns: s:4(string)
@@ -578,7 +578,7 @@ project
 
 # We should scan x, y, s.
 opt
-SELECT x, s FROM (SELECT x, y, f, s FROM t.a ORDER BY x, y LIMIT 10 OFFSET 10)
+SELECT x, s FROM (SELECT x, y, f, s FROM a ORDER BY x, y LIMIT 10 OFFSET 10)
 ----
 project
  ├── columns: x:1(int!null) s:4(string)
@@ -635,7 +635,7 @@ project
 
 # Columns used only by projection or on condition, but not both.
 opt
-SELECT a.y, b.* FROM t.a INNER JOIN t.b ON a.x=b.x
+SELECT a.y, b.* FROM a INNER JOIN b ON a.x=b.x
 ----
 project
  ├── columns: y:2(int) x:5(int!null) z:6(int)
@@ -658,7 +658,7 @@ project
 
 # Columns used by both projection and on condition, left join.
 opt
-SELECT a.x, a.y, b.* FROM t.a LEFT JOIN t.b ON a.x=b.x AND a.y<5
+SELECT a.x, a.y, b.* FROM a LEFT JOIN b ON a.x=b.x AND a.y<5
 ----
 left-join
  ├── columns: x:1(int!null) y:2(int) x:5(int) z:6(int)
@@ -678,7 +678,7 @@ left-join
 
 # Columns only used by on condition, right join
 opt
-SELECT b.* FROM t.a RIGHT JOIN t.b ON a.x=b.x
+SELECT b.* FROM a RIGHT JOIN b ON a.x=b.x
 ----
 project
  ├── columns: x:5(int!null) z:6(int)
@@ -700,7 +700,7 @@ project
 
 # Columns needed only by projection, full join.
 opt
-SELECT a.x+1, b.* FROM t.a FULL JOIN t.b ON True
+SELECT a.x+1, b.* FROM a FULL JOIN b ON True
 ----
 project
  ├── columns: column7:7(int) x:5(int) z:6(int)
@@ -722,7 +722,7 @@ project
 
 # No columns needed from left side of join.
 opt
-SELECT b.* FROM t.a, t.b
+SELECT b.* FROM a, b
 ----
 inner-join
  ├── columns: x:5(int!null) z:6(int)
@@ -734,7 +734,7 @@ inner-join
 
 # Computed columns.
 opt
-SELECT a.x+1, a.y/2, b.* FROM t.a INNER JOIN t.b ON a.x*a.x=b.x AND a.s||'o'='foo'
+SELECT a.x+1, a.y/2, b.* FROM a INNER JOIN b ON a.x*a.x=b.x AND a.s||'o'='foo'
 ----
 project
  ├── columns: column7:7(int) column8:8(decimal) x:5(int!null) z:6(int)
@@ -826,7 +826,7 @@ project
 
 # Columns used only by projection or on condition, but not both.
 opt
-SELECT b.*, a.y FROM t.b INNER JOIN t.a ON b.x=a.x
+SELECT b.*, a.y FROM b INNER JOIN a ON b.x=a.x
 ----
 project
  ├── columns: x:1(int!null) z:2(int) y:4(int)
@@ -849,7 +849,7 @@ project
 
 # Columns used by both projection and on condition, left join.
 opt
-SELECT b.*, a.x, a.y FROM t.b LEFT JOIN t.a ON b.x=a.x AND a.y<b.x
+SELECT b.*, a.x, a.y FROM b LEFT JOIN a ON b.x=a.x AND a.y<b.x
 ----
 left-join
  ├── columns: x:1(int!null) z:2(int) x:3(int) y:4(int)
@@ -869,7 +869,7 @@ left-join
 
 # Columns only used by on condition, right join
 opt
-SELECT b.* FROM t.b RIGHT JOIN t.a ON b.x=a.x
+SELECT b.* FROM b RIGHT JOIN a ON b.x=a.x
 ----
 project
  ├── columns: x:1(int) z:2(int)
@@ -891,7 +891,7 @@ project
 
 # Columns needed only by projection, full join.
 opt
-SELECT b.*, a.x+1 FROM t.b FULL JOIN t.a ON True
+SELECT b.*, a.x+1 FROM b FULL JOIN a ON True
 ----
 project
  ├── columns: x:1(int) z:2(int) column7:7(int)
@@ -913,7 +913,7 @@ project
 
 # No columns needed from right side of join.
 opt
-SELECT b.* FROM t.b, t.a
+SELECT b.* FROM b, a
 ----
 inner-join
  ├── columns: x:1(int!null) z:2(int)
@@ -925,7 +925,7 @@ inner-join
 
 # Computed columns.
 opt
-SELECT b.*, a.x+1, a.y/2 FROM t.b INNER JOIN t.a ON b.x=a.x*a.x AND a.s||'o'='foo'
+SELECT b.*, a.x+1, a.y/2 FROM b INNER JOIN a ON b.x=a.x*a.x AND a.s||'o'='foo'
 ----
 project
  ├── columns: x:1(int!null) z:2(int) column7:7(int) column8:8(decimal)

--- a/pkg/sql/opt/optbuilder/builder.go
+++ b/pkg/sql/opt/optbuilder/builder.go
@@ -54,6 +54,14 @@ type Builder struct {
 	// interfacing with the old planning code.
 	AllowUnsupportedExpr bool
 
+	// FmtFlags controls the way column names are formatted in test output. For
+	// example, if set to FmtAlwaysQualifyTableNames, the builder fully qualifies
+	// the table name in all column labels before adding them to the metadata.
+	// This flag allows us to test that name resolution works correctly, and
+	// avoids cluttering test output with schema and catalog names in the general
+	// case.
+	FmtFlags tree.FmtFlags
+
 	factory *norm.Factory
 	stmt    tree.Statement
 

--- a/pkg/sql/opt/optbuilder/project.go
+++ b/pkg/sql/opt/optbuilder/project.go
@@ -17,6 +17,7 @@ package optbuilder
 import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 )
 
@@ -57,7 +58,8 @@ func (b *Builder) buildProjectionList(selects tree.SelectExprs, inScope *scope, 
 func (b *Builder) buildProjection(projection tree.Expr, label string, inScope, outScope *scope) {
 	exprs := b.expandStarAndResolveType(projection, inScope)
 	if len(exprs) > 1 && label != "" {
-		panic(errorf("\"%s\" cannot be aliased", projection))
+		panic(builderError{pgerror.NewErrorf(pgerror.CodeSyntaxError,
+			"%q cannot be aliased", tree.ErrString(projection))})
 	}
 
 	for _, e := range exprs {

--- a/pkg/sql/opt/optbuilder/scope.go
+++ b/pkg/sql/opt/optbuilder/scope.go
@@ -423,11 +423,11 @@ func sourceNameMatches(srcName tree.TableName, toFind tree.TableName) bool {
 		return false
 	}
 	if toFind.ExplicitSchema {
-		if !srcName.ExplicitSchema || srcName.SchemaName != toFind.SchemaName {
+		if srcName.SchemaName != toFind.SchemaName {
 			return false
 		}
 		if toFind.ExplicitCatalog {
-			if !srcName.ExplicitCatalog || srcName.CatalogName != toFind.CatalogName {
+			if srcName.CatalogName != toFind.CatalogName {
 				return false
 			}
 		}

--- a/pkg/sql/opt/optbuilder/select.go
+++ b/pkg/sql/opt/optbuilder/select.go
@@ -71,7 +71,7 @@ func (b *Builder) buildTable(texpr tree.TableExpr, inScope *scope) (outScope *sc
 
 // renameSource applies an AS clause to the columns in scope.
 func (b *Builder) renameSource(as tree.AliasClause, scope *scope) {
-	var tableAlias tree.Name
+	var tableAlias tree.TableName
 	colAlias := as.Cols
 
 	if as.Alias != "" {
@@ -79,9 +79,9 @@ func (b *Builder) renameSource(as tree.AliasClause, scope *scope) {
 		// functions with just one column.
 
 		// If an alias was specified, use that.
-		tableAlias = as.Alias
+		tableAlias = tree.MakeUnqualifiedTableName(as.Alias)
 		for i := range scope.cols {
-			scope.cols[i].table.TableName = tableAlias
+			scope.cols[i].table = tableAlias
 		}
 	}
 
@@ -89,9 +89,10 @@ func (b *Builder) renameSource(as tree.AliasClause, scope *scope) {
 		// The column aliases can only refer to explicit columns.
 		for colIdx, aliasIdx := 0, 0; aliasIdx < len(colAlias); colIdx++ {
 			if colIdx >= len(scope.cols) {
+				srcName := tree.ErrString(&tableAlias)
 				panic(errorf(
 					"source %q has %d columns available but %d columns specified",
-					tableAlias, aliasIdx, len(colAlias)))
+					srcName, aliasIdx, len(colAlias)))
 			}
 			if scope.cols[colIdx].hidden {
 				continue
@@ -233,6 +234,9 @@ func (b *Builder) buildSelectClause(
 // See Builder.buildStmt for a description of the remaining input and
 // return values.
 func (b *Builder) buildFrom(from *tree.From, where *tree.Where, inScope *scope) (outScope *scope) {
+	var joinTables map[string]struct{}
+	colsAdded := 0
+
 	for _, table := range from.Tables {
 		tableScope := b.buildTable(table, inScope)
 
@@ -240,6 +244,18 @@ func (b *Builder) buildFrom(from *tree.From, where *tree.Where, inScope *scope) 
 			outScope = tableScope
 			continue
 		}
+
+		// Build a map of the table names in the join.
+		if joinTables == nil {
+			joinTables = make(map[string]struct{})
+		}
+		for _, col := range outScope.cols[colsAdded:] {
+			joinTables[col.table.FQString()] = exists
+		}
+		colsAdded = len(outScope.cols)
+
+		// Check that the same table name is not used multiple times.
+		b.validateJoinTableNames(joinTables, tableScope)
 
 		outScope.appendColumns(tableScope)
 		outScope.group = b.factory.ConstructInnerJoin(

--- a/pkg/sql/opt/optbuilder/select.go
+++ b/pkg/sql/opt/optbuilder/select.go
@@ -109,7 +109,8 @@ func (b *Builder) renameSource(as tree.AliasClause, scope *scope) {
 // See Builder.buildStmt for a description of the remaining input and
 // return values.
 func (b *Builder) buildScan(tab opt.Table, tn *tree.TableName, inScope *scope) (outScope *scope) {
-	tabID := b.factory.Metadata().AddTable(tab)
+	tabName := tree.AsStringWithFlags(tn, b.FmtFlags)
+	tabID := b.factory.Metadata().AddTableWithName(tab, tabName)
 	scanOpDef := memo.ScanOpDef{Table: tabID}
 
 	outScope = inScope.push()

--- a/pkg/sql/opt/optbuilder/testdata/aggregate
+++ b/pkg/sql/opt/optbuilder/testdata/aggregate
@@ -1,7 +1,7 @@
 # tests adapted from logictest -- aggregate
 
 exec-ddl
-CREATE TABLE t.kv (
+CREATE TABLE kv (
   k INT PRIMARY KEY,
   v INT,
   w INT,
@@ -18,7 +18,7 @@ TABLE kv
 
 build
 SELECT MIN(1), MAX(1), COUNT(1), SUM_INT(1), AVG(1), SUM(1), STDDEV(1),
-  VARIANCE(1), BOOL_AND(true), BOOL_OR(false), XOR_AGG(b'\x01') FROM t.kv
+  VARIANCE(1), BOOL_AND(true), BOOL_OR(false), XOR_AGG(b'\x01') FROM kv
 ----
 group-by
  ├── columns: column6:6(int) column7:7(int) column8:8(int) column9:9(int) column10:10(decimal) column11:11(decimal) column12:12(decimal) column13:13(decimal) column15:15(bool) column17:17(bool) column19:19(bytes)
@@ -164,7 +164,7 @@ project
            └── variable: column16 [type=bytes]
 
 build
-SELECT ARRAY_AGG(1) FROM t.kv
+SELECT ARRAY_AGG(1) FROM kv
 ----
 group-by
  ├── columns: column6:6(int[])
@@ -179,7 +179,7 @@ group-by
            └── variable: column5 [type=int]
 
 build
-SELECT JSON_AGG(v) FROM t.kv
+SELECT JSON_AGG(v) FROM kv
 ----
 group-by
  ├── columns: column5:5(jsonb)
@@ -210,7 +210,7 @@ group-by
 
 # Even with no aggregate functions, grouping occurs in the presence of GROUP BY.
 build
-SELECT 1 FROM t.kv GROUP BY v
+SELECT 1 FROM kv GROUP BY v
 ----
 project
  ├── columns: column5:5(int)
@@ -297,17 +297,17 @@ project
            └── variable: column7 [type=int]
 
 build
-SELECT COUNT(*), k FROM t.kv
+SELECT COUNT(*), k FROM kv
 ----
-error: column "t.public.kv.k" must appear in the GROUP BY clause or be used in an aggregate function
+error: column "kv.k" must appear in the GROUP BY clause or be used in an aggregate function
 
 build
-SELECT COUNT(*) FROM t.kv GROUP BY s < 5
+SELECT COUNT(*) FROM kv GROUP BY s < 5
 ----
 error: unsupported comparison operator: <string> < <int>
 
 build
-SELECT COUNT(*), k FROM t.kv GROUP BY k
+SELECT COUNT(*), k FROM kv GROUP BY k
 ----
 project
  ├── columns: column5:5(int) k:1(int!null)
@@ -328,7 +328,7 @@ project
 
 # GROUP BY specified using column index works.
 build
-SELECT COUNT(*), k FROM t.kv GROUP BY 2
+SELECT COUNT(*), k FROM kv GROUP BY 2
 ----
 project
  ├── columns: column5:5(int) k:1(int!null)
@@ -373,12 +373,12 @@ VALUES (99, COUNT(1))
 error: aggregate functions are not allowed in VALUES
 
 build
-SELECT COUNT(*), k FROM t.kv GROUP BY 5
+SELECT COUNT(*), k FROM kv GROUP BY 5
 ----
 error: GROUP BY position 5 is not in select list
 
 build
-SELECT COUNT(*), k FROM t.kv GROUP BY 0
+SELECT COUNT(*), k FROM kv GROUP BY 0
 ----
 error: GROUP BY position 0 is not in select list
 
@@ -389,7 +389,7 @@ error: non-integer constant in GROUP BY: 'a'
 
 # Qualifying a name in the SELECT, the GROUP BY, both or neither should not affect validation.
 build
-SELECT COUNT(*), kv.s FROM t.kv GROUP BY s
+SELECT COUNT(*), kv.s FROM kv GROUP BY s
 ----
 project
  ├── columns: column5:5(int) s:4(string)
@@ -409,7 +409,7 @@ project
       └── variable: kv.s [type=string]
 
 build
-SELECT COUNT(*), s FROM t.kv GROUP BY kv.s
+SELECT COUNT(*), s FROM kv GROUP BY kv.s
 ----
 project
  ├── columns: column5:5(int) s:4(string)
@@ -429,7 +429,7 @@ project
       └── variable: kv.s [type=string]
 
 build
-SELECT COUNT(*), kv.s FROM t.kv GROUP BY kv.s
+SELECT COUNT(*), kv.s FROM kv GROUP BY kv.s
 ----
 project
  ├── columns: column5:5(int) s:4(string)
@@ -449,7 +449,7 @@ project
       └── variable: kv.s [type=string]
 
 build
-SELECT COUNT(*), s FROM t.kv GROUP BY s
+SELECT COUNT(*), s FROM kv GROUP BY s
 ----
 project
  ├── columns: column5:5(int) s:4(string)
@@ -470,7 +470,7 @@ project
 
 # Grouping by more than one column works.
 build
-SELECT v, COUNT(*), w FROM t.kv GROUP BY v, w
+SELECT v, COUNT(*), w FROM kv GROUP BY v, w
 ----
 project
  ├── columns: v:2(int) column5:5(int) w:3(int)
@@ -493,7 +493,7 @@ project
 
 # Grouping by more than one column using column numbers works.
 build
-SELECT v, COUNT(*), w FROM t.kv GROUP BY 1, 3
+SELECT v, COUNT(*), w FROM kv GROUP BY 1, 3
 ----
 project
  ├── columns: v:2(int) column5:5(int) w:3(int)
@@ -516,7 +516,7 @@ project
 
 # Selecting and grouping on a function expression works.
 build
-SELECT COUNT(*), UPPER(s) FROM t.kv GROUP BY UPPER(s)
+SELECT COUNT(*), UPPER(s) FROM kv GROUP BY UPPER(s)
 ----
 project
  ├── columns: column6:6(int) column5:5(string)
@@ -538,7 +538,7 @@ project
 
 # Selecting and grouping on a constant works.
 build
-SELECT COUNT(*) FROM t.kv GROUP BY 1+2
+SELECT COUNT(*) FROM kv GROUP BY 1+2
 ----
 project
  ├── columns: column6:6(int)
@@ -557,7 +557,7 @@ project
       └── variable: column6 [type=int]
 
 build
-SELECT COUNT(*) FROM t.kv GROUP BY length('abc')
+SELECT COUNT(*) FROM kv GROUP BY length('abc')
 ----
 project
  ├── columns: column6:6(int)
@@ -578,7 +578,7 @@ project
 
 # Selecting a function of something which is grouped works.
 build
-SELECT COUNT(*), UPPER(s) FROM t.kv GROUP BY s
+SELECT COUNT(*), UPPER(s) FROM kv GROUP BY s
 ----
 project
  ├── columns: column5:5(int) column6:6(string)
@@ -600,13 +600,13 @@ project
 
 # Selecting a value that is not grouped, even if a function of it it, does not work.
 build
-SELECT COUNT(*), s FROM t.kv GROUP BY UPPER(s)
+SELECT COUNT(*), s FROM kv GROUP BY UPPER(s)
 ----
-error: column "t.public.kv.s" must appear in the GROUP BY clause or be used in an aggregate function
+error: column "kv.s" must appear in the GROUP BY clause or be used in an aggregate function
 
 # Selecting and grouping on a more complex expression works.
 build
-SELECT COUNT(*), k+v FROM t.kv GROUP BY k+v
+SELECT COUNT(*), k+v FROM kv GROUP BY k+v
 ----
 project
  ├── columns: column6:6(int) column5:5(int)
@@ -630,7 +630,7 @@ project
 
 # Selecting a more complex expression, made up of things which are each grouped, works.
 build
-SELECT COUNT(*), k+v FROM t.kv GROUP BY k, v
+SELECT COUNT(*), k+v FROM kv GROUP BY k, v
 ----
 project
  ├── columns: column5:5(int) column6:6(int)
@@ -655,33 +655,33 @@ project
 # TODO(rytaft): don't qualify the column name in the error message differently
 # than it was qualified in the query.
 build
-SELECT COUNT(*), k+v FROM t.kv GROUP BY k
+SELECT COUNT(*), k+v FROM kv GROUP BY k
 ----
-error: column "t.public.kv.v" must appear in the GROUP BY clause or be used in an aggregate function
+error: column "kv.v" must appear in the GROUP BY clause or be used in an aggregate function
 
 build
-SELECT COUNT(*), k+v FROM t.kv GROUP BY v
+SELECT COUNT(*), k+v FROM kv GROUP BY v
 ----
-error: column "t.public.kv.k" must appear in the GROUP BY clause or be used in an aggregate function
+error: column "kv.k" must appear in the GROUP BY clause or be used in an aggregate function
 
 build
-SELECT COUNT(*), v/(k+v) FROM t.kv GROUP BY k+v
+SELECT COUNT(*), v/(k+v) FROM kv GROUP BY k+v
 ----
-error: column "t.public.kv.v" must appear in the GROUP BY clause or be used in an aggregate function
+error: column "kv.v" must appear in the GROUP BY clause or be used in an aggregate function
 
 build
-SELECT k FROM t.kv WHERE AVG(k) > 1
+SELECT k FROM kv WHERE AVG(k) > 1
 ----
 error: aggregate functions are not allowed in WHERE
 
 build
-SELECT MAX(AVG(k)) FROM t.kv
+SELECT MAX(AVG(k)) FROM kv
 ----
 error: aggregate functions are not allowed in the argument of max()
 
 # Test case from #2761.
 build
-SELECT count(kv.k) AS count_1, kv.v + kv.w AS lx FROM t.kv GROUP BY kv.v + kv.w
+SELECT count(kv.k) AS count_1, kv.v + kv.w AS lx FROM kv GROUP BY kv.v + kv.w
 ----
 project
  ├── columns: count_1:6(int) lx:5(int)
@@ -715,7 +715,7 @@ group-by
       └── function: count_rows [type=int]
 
 build
-SELECT COUNT(k) from t.kv
+SELECT COUNT(k) from kv
 ----
 group-by
  ├── columns: column5:5(int)
@@ -745,7 +745,7 @@ group-by
            └── variable: column1 [type=int]
 
 build
-SELECT COUNT(1) from t.kv
+SELECT COUNT(1) from kv
 ----
 group-by
  ├── columns: column6:6(int)
@@ -760,7 +760,7 @@ group-by
            └── variable: column5 [type=int]
 
 build
-SELECT COUNT(k, v) FROM t.kv
+SELECT COUNT(k, v) FROM kv
 ----
 error: unknown signature: count(int, int)
 
@@ -893,7 +893,7 @@ sort
                 └── variable: kv.k [type=int]
 
 build
-SELECT COUNT(*), COUNT(k), COUNT(kv.v) FROM t.kv
+SELECT COUNT(*), COUNT(k), COUNT(kv.v) FROM kv
 ----
 group-by
  ├── columns: column5:5(int) column6:6(int) column7:7(int)
@@ -912,7 +912,7 @@ group-by
            └── variable: kv.v [type=int]
 
 build
-SELECT COUNT(kv.*) FROM t.kv
+SELECT COUNT(kv.*) FROM kv
 ----
 group-by
  ├── columns: column6:6(int)
@@ -931,7 +931,7 @@ group-by
            └── variable: column5 [type=tuple{int, int, int, string}]
 
 build
-SELECT COUNT((k, v)) FROM t.kv LIMIT 1
+SELECT COUNT((k, v)) FROM kv LIMIT 1
 ----
 limit
  ├── columns: column6:6(int)
@@ -951,7 +951,7 @@ limit
  └── const: 1 [type=int]
 
 build
-SELECT COUNT((k, v)) FROM t.kv OFFSET 1
+SELECT COUNT((k, v)) FROM kv OFFSET 1
 ----
 offset
  ├── columns: column6:6(int)
@@ -971,7 +971,7 @@ offset
  └── const: 1 [type=int]
 
 build
-SELECT COUNT(k)+COUNT(kv.v) FROM t.kv
+SELECT COUNT(k)+COUNT(kv.v) FROM kv
 ----
 project
  ├── columns: column7:7(int)
@@ -1016,7 +1016,7 @@ group-by
            └── variable: column3 [type=tuple{unknown, unknown}]
 
 build
-SELECT MIN(k), MAX(k), MIN(v), MAX(v) FROM t.kv
+SELECT MIN(k), MAX(k), MIN(v), MAX(v) FROM kv
 ----
 group-by
  ├── columns: column5:5(int) column6:6(int) column7:7(int) column8:8(int)
@@ -1038,7 +1038,7 @@ group-by
            └── variable: kv.v [type=int]
 
 build
-SELECT MIN(k), MAX(k), MIN(v), MAX(v) FROM t.kv WHERE k > 8
+SELECT MIN(k), MAX(k), MIN(v), MAX(v) FROM kv WHERE k > 8
 ----
 group-by
  ├── columns: column5:5(int) column6:6(int) column7:7(int) column8:8(int)
@@ -1083,7 +1083,7 @@ group-by
            └── variable: kv.s [type=string]
 
 build
-SELECT array_agg(s) FROM t.kv WHERE s IS NULL
+SELECT array_agg(s) FROM kv WHERE s IS NULL
 ----
 group-by
  ├── columns: column5:5(string[])
@@ -1103,7 +1103,7 @@ group-by
            └── variable: kv.s [type=string]
 
 build
-SELECT AVG(k), AVG(v), SUM(k), SUM(v) FROM t.kv
+SELECT AVG(k), AVG(v), SUM(k), SUM(v) FROM kv
 ----
 group-by
  ├── columns: column5:5(decimal) column6:6(decimal) column7:7(decimal) column8:8(decimal)
@@ -1210,7 +1210,7 @@ project
                 └── variable: column6 [type=int]
 
 exec-ddl
-CREATE TABLE t.abc (
+CREATE TABLE abc (
   a CHAR PRIMARY KEY,
   b FLOAT,
   c BOOLEAN,
@@ -1226,7 +1226,7 @@ TABLE abc
       └── a string not null
 
 build
-SELECT MIN(a), MIN(b), MIN(c), MIN(d) FROM t.abc
+SELECT MIN(a), MIN(b), MIN(c), MIN(d) FROM abc
 ----
 group-by
  ├── columns: column5:5(string) column6:6(float) column7:7(bool) column8:8(decimal)
@@ -1243,7 +1243,7 @@ group-by
            └── variable: abc.d [type=decimal]
 
 build
-SELECT MAX(a), MAX(b), MAX(c), MAX(d) FROM t.abc
+SELECT MAX(a), MAX(b), MAX(c), MAX(d) FROM abc
 ----
 group-by
  ├── columns: column5:5(string) column6:6(float) column7:7(bool) column8:8(decimal)
@@ -1260,7 +1260,7 @@ group-by
            └── variable: abc.d [type=decimal]
 
 build
-SELECT AVG(b), SUM(b), AVG(d), SUM(d) FROM t.abc
+SELECT AVG(b), SUM(b), AVG(d), SUM(d) FROM abc
 ----
 group-by
  ├── columns: column5:5(float) column6:6(float) column7:7(decimal) column8:8(decimal)
@@ -1283,7 +1283,7 @@ group-by
 
 # Verify summing of intervals
 exec-ddl
-CREATE TABLE t.intervals (
+CREATE TABLE intervals (
   a INTERVAL PRIMARY KEY
 )
 ----
@@ -1293,7 +1293,7 @@ TABLE intervals
       └── a interval not null
 
 build
-SELECT SUM(a) FROM t.intervals
+SELECT SUM(a) FROM intervals
 ----
 group-by
  ├── columns: column2:2(interval)
@@ -1304,37 +1304,37 @@ group-by
            └── variable: intervals.a [type=interval]
 
 build
-SELECT AVG(a) FROM t.abc
+SELECT AVG(a) FROM abc
 ----
 error: unknown signature: avg(string)
 
 build
-SELECT AVG(c) FROM t.abc
+SELECT AVG(c) FROM abc
 ----
 error: unknown signature: avg(bool)
 
 build
-SELECT AVG((a,c)) FROM t.abc
+SELECT AVG((a,c)) FROM abc
 ----
 error: unknown signature: avg(tuple{string, bool})
 
 build
-SELECT SUM(a) FROM t.abc
+SELECT SUM(a) FROM abc
 ----
 error: unknown signature: sum(string)
 
 build
-SELECT SUM(c) FROM t.abc
+SELECT SUM(c) FROM abc
 ----
 error: unknown signature: sum(bool)
 
 build
-SELECT SUM((a,c)) FROM t.abc
+SELECT SUM((a,c)) FROM abc
 ----
 error: unknown signature: sum(tuple{string, bool})
 
 exec-ddl
-CREATE TABLE t.xyz (
+CREATE TABLE xyz (
   x INT PRIMARY KEY,
   y INT,
   z FLOAT,
@@ -1360,7 +1360,7 @@ TABLE xyz
       └── x int not null
 
 build
-SELECT MIN(x) FROM t.xyz
+SELECT MIN(x) FROM xyz
 ----
 group-by
  ├── columns: column4:4(int)
@@ -1375,7 +1375,7 @@ group-by
            └── variable: xyz.x [type=int]
 
 build
-SELECT MIN(x) FROM t.xyz WHERE x in (0, 4, 7)
+SELECT MIN(x) FROM xyz WHERE x in (0, 4, 7)
 ----
 group-by
  ├── columns: column4:4(int)
@@ -1398,7 +1398,7 @@ group-by
            └── variable: xyz.x [type=int]
 
 build
-SELECT MAX(x) FROM t.xyz
+SELECT MAX(x) FROM xyz
 ----
 group-by
  ├── columns: column4:4(int)
@@ -1413,7 +1413,7 @@ group-by
            └── variable: xyz.x [type=int]
 
 build
-SELECT MAX(y) FROM t.xyz WHERE x = 1
+SELECT MAX(y) FROM xyz WHERE x = 1
 ----
 group-by
  ├── columns: column4:4(int)
@@ -1433,7 +1433,7 @@ group-by
            └── variable: xyz.y [type=int]
 
 build
-SELECT MIN(y) FROM t.xyz WHERE x = 7
+SELECT MIN(y) FROM xyz WHERE x = 7
 ----
 group-by
  ├── columns: column4:4(int)
@@ -1453,7 +1453,7 @@ group-by
            └── variable: xyz.y [type=int]
 
 build
-SELECT MIN(x) FROM t.xyz WHERE (y, z) = (2, 3.0)
+SELECT MIN(x) FROM xyz WHERE (y, z) = (2, 3.0)
 ----
 group-by
  ├── columns: column4:4(int)
@@ -1477,7 +1477,7 @@ group-by
            └── variable: xyz.x [type=int]
 
 build
-SELECT MAX(x) FROM t.xyz WHERE (z, y) = (3.0, 2)
+SELECT MAX(x) FROM xyz WHERE (z, y) = (3.0, 2)
 ----
 group-by
  ├── columns: column4:4(int)
@@ -1534,7 +1534,7 @@ project
            └── const: 14 [type=int]
 
 build
-SELECT VARIANCE(x) FROM t.xyz WHERE x = 10
+SELECT VARIANCE(x) FROM xyz WHERE x = 10
 ----
 group-by
  ├── columns: column4:4(decimal)
@@ -1584,7 +1584,7 @@ project
            └── const: 14 [type=int]
 
 build
-SELECT STDDEV(x) FROM t.xyz WHERE x = 1
+SELECT STDDEV(x) FROM xyz WHERE x = 1
 ----
 group-by
  ├── columns: column4:4(decimal)
@@ -1792,7 +1792,7 @@ limit
  └── const: 1 [type=int]
 
 exec-ddl
-CREATE TABLE t.bools (b BOOL)
+CREATE TABLE bools (b BOOL)
 ----
 TABLE bools
  ├── b bool
@@ -1801,7 +1801,7 @@ TABLE bools
       └── rowid int not null (hidden)
 
 build
-SELECT BOOL_AND(b), BOOL_OR(b) FROM t.bools
+SELECT BOOL_AND(b), BOOL_OR(b) FROM bools
 ----
 group-by
  ├── columns: column3:3(bool) column4:4(bool)
@@ -1820,7 +1820,7 @@ group-by
 
 # Tests with * inside GROUP BY.
 build
-SELECT 1 FROM t.kv GROUP BY kv.*;
+SELECT 1 FROM kv GROUP BY kv.*;
 ----
 project
  ├── columns: column5:5(int)
@@ -1834,7 +1834,7 @@ project
       └── const: 1 [type=int]
 
 exec-ddl
-CREATE TABLE t.xor_bytes (a bytes, b int, c int)
+CREATE TABLE xor_bytes (a bytes, b int, c int)
 ----
 TABLE xor_bytes
  ├── a bytes
@@ -1845,7 +1845,7 @@ TABLE xor_bytes
       └── rowid int not null (hidden)
 
 build
-SELECT TO_HEX(XOR_AGG(a)), XOR_AGG(c) FROM t.xor_bytes
+SELECT TO_HEX(XOR_AGG(a)), XOR_AGG(c) FROM xor_bytes
 ----
 project
  ├── columns: column6:6(string) column7:7(int)
@@ -1981,7 +1981,7 @@ group-by
            └── variable: kv.s [type=string]
 
 exec-ddl
-CREATE TABLE t.ab (
+CREATE TABLE ab (
   a INT PRIMARY KEY,
   b INT,
   FAMILY (a),
@@ -1995,7 +1995,7 @@ TABLE ab
       └── a int not null
 
 exec-ddl
-CREATE TABLE t.xy(x STRING, y STRING);
+CREATE TABLE xy(x STRING, y STRING);
 ----
 TABLE xy
  ├── x string
@@ -2006,7 +2006,7 @@ TABLE xy
 
 # Grouping and rendering tuples.
 build
-SELECT (b, a) FROM t.ab GROUP BY (b, a)
+SELECT (b, a) FROM ab GROUP BY (b, a)
 ----
 project
  ├── columns: column3:3(tuple{int, int})
@@ -2028,7 +2028,7 @@ project
 
 build
 SELECT MIN(y), (b, a)
- FROM t.ab, t.xy GROUP BY (x, (a, b))
+ FROM ab, xy GROUP BY (x, (a, b))
 ----
 project
  ├── columns: column6:6(string) column7:7(tuple{int, int})
@@ -2117,7 +2117,7 @@ sort
                 └── variable: column5 [type=int]
 
 build
-SELECT (k+v)/(v+w) FROM t.kv GROUP BY k+v, v+w;
+SELECT (k+v)/(v+w) FROM kv GROUP BY k+v, v+w;
 ----
 project
  ├── columns: column7:7(decimal)
@@ -2146,63 +2146,63 @@ project
                 └── variable: kv.w [type=int]
 
 # Check that everything still works with differently qualified names
-build
+build fully-qualify-names
 SELECT SUM(t.kv.w), t.kv.v FROM t.kv GROUP BY v, kv.k * w
 ----
 project
  ├── columns: column6:6(decimal) v:2(int)
  ├── group-by
- │    ├── columns: kv.v:2(int) column5:5(int) column6:6(decimal)
- │    ├── grouping columns: kv.v:2(int) column5:5(int)
+ │    ├── columns: t.public.kv.v:2(int) column5:5(int) column6:6(decimal)
+ │    ├── grouping columns: t.public.kv.v:2(int) column5:5(int)
  │    ├── project
- │    │    ├── columns: kv.v:2(int) column5:5(int) kv.w:3(int)
+ │    │    ├── columns: t.public.kv.v:2(int) column5:5(int) t.public.kv.w:3(int)
  │    │    ├── scan kv
- │    │    │    └── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string)
+ │    │    │    └── columns: t.public.kv.k:1(int!null) t.public.kv.v:2(int) t.public.kv.w:3(int) t.public.kv.s:4(string)
  │    │    └── projections
- │    │         ├── variable: kv.v [type=int]
+ │    │         ├── variable: t.public.kv.v [type=int]
  │    │         ├── mult [type=int]
- │    │         │    ├── variable: kv.k [type=int]
- │    │         │    └── variable: kv.w [type=int]
- │    │         └── variable: kv.w [type=int]
+ │    │         │    ├── variable: t.public.kv.k [type=int]
+ │    │         │    └── variable: t.public.kv.w [type=int]
+ │    │         └── variable: t.public.kv.w [type=int]
  │    └── aggregations
  │         └── function: sum [type=decimal]
- │              └── variable: kv.w [type=int]
+ │              └── variable: t.public.kv.w [type=int]
  └── projections
       ├── variable: column6 [type=decimal]
-      └── variable: kv.v [type=int]
+      └── variable: t.public.kv.v [type=int]
 
-build
+build fully-qualify-names
 SELECT SUM(t.kv.w), LOWER(s), t.kv.v + k * t.kv.w, t.kv.v FROM t.kv GROUP BY v, LOWER(kv.s), kv.k * w
 ----
 project
  ├── columns: column7:7(decimal) column5:5(string) column8:8(int) v:2(int)
  ├── group-by
- │    ├── columns: kv.v:2(int) column5:5(string) column6:6(int) column7:7(decimal)
- │    ├── grouping columns: kv.v:2(int) column5:5(string) column6:6(int)
+ │    ├── columns: t.public.kv.v:2(int) column5:5(string) column6:6(int) column7:7(decimal)
+ │    ├── grouping columns: t.public.kv.v:2(int) column5:5(string) column6:6(int)
  │    ├── project
- │    │    ├── columns: kv.v:2(int) column5:5(string) column6:6(int) kv.w:3(int)
+ │    │    ├── columns: t.public.kv.v:2(int) column5:5(string) column6:6(int) t.public.kv.w:3(int)
  │    │    ├── scan kv
- │    │    │    └── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string)
+ │    │    │    └── columns: t.public.kv.k:1(int!null) t.public.kv.v:2(int) t.public.kv.w:3(int) t.public.kv.s:4(string)
  │    │    └── projections
- │    │         ├── variable: kv.v [type=int]
+ │    │         ├── variable: t.public.kv.v [type=int]
  │    │         ├── function: lower [type=string]
- │    │         │    └── variable: kv.s [type=string]
+ │    │         │    └── variable: t.public.kv.s [type=string]
  │    │         ├── mult [type=int]
- │    │         │    ├── variable: kv.k [type=int]
- │    │         │    └── variable: kv.w [type=int]
- │    │         └── variable: kv.w [type=int]
+ │    │         │    ├── variable: t.public.kv.k [type=int]
+ │    │         │    └── variable: t.public.kv.w [type=int]
+ │    │         └── variable: t.public.kv.w [type=int]
  │    └── aggregations
  │         └── function: sum [type=decimal]
- │              └── variable: kv.w [type=int]
+ │              └── variable: t.public.kv.w [type=int]
  └── projections
       ├── variable: column7 [type=decimal]
       ├── variable: column5 [type=string]
       ├── plus [type=int]
-      │    ├── variable: kv.v [type=int]
+      │    ├── variable: t.public.kv.v [type=int]
       │    └── mult [type=int]
-      │         ├── variable: kv.k [type=int]
-      │         └── variable: kv.w [type=int]
-      └── variable: kv.v [type=int]
+      │         ├── variable: t.public.kv.k [type=int]
+      │         └── variable: t.public.kv.w [type=int]
+      └── variable: t.public.kv.v [type=int]
 
 # Check all the different types of scalar expressions as group by columns
 build
@@ -2641,7 +2641,7 @@ project
       └── variable: column5 [type=int]
 
 build
-SELECT COUNT(UPPER(s)) FROM t.kv GROUP BY UPPER(s)
+SELECT COUNT(UPPER(s)) FROM kv GROUP BY UPPER(s)
 ----
 project
  ├── columns: column6:6(int)
@@ -2662,7 +2662,7 @@ project
       └── variable: column6 [type=int]
 
 build
-SELECT SUM(abc.d) FROM t.kv JOIN t.abc ON kv.k >= abc.d GROUP BY kv.*
+SELECT SUM(abc.d) FROM kv JOIN abc ON kv.k >= abc.d GROUP BY kv.*
 ----
 project
  ├── columns: column9:9(decimal)

--- a/pkg/sql/opt/optbuilder/testdata/aggregate
+++ b/pkg/sql/opt/optbuilder/testdata/aggregate
@@ -299,7 +299,7 @@ project
 build
 SELECT COUNT(*), k FROM t.kv
 ----
-error: column "t.kv.k" must appear in the GROUP BY clause or be used in an aggregate function
+error: column "t.public.kv.k" must appear in the GROUP BY clause or be used in an aggregate function
 
 build
 SELECT COUNT(*) FROM t.kv GROUP BY s < 5
@@ -602,7 +602,7 @@ project
 build
 SELECT COUNT(*), s FROM t.kv GROUP BY UPPER(s)
 ----
-error: column "t.kv.s" must appear in the GROUP BY clause or be used in an aggregate function
+error: column "t.public.kv.s" must appear in the GROUP BY clause or be used in an aggregate function
 
 # Selecting and grouping on a more complex expression works.
 build
@@ -657,17 +657,17 @@ project
 build
 SELECT COUNT(*), k+v FROM t.kv GROUP BY k
 ----
-error: column "t.kv.v" must appear in the GROUP BY clause or be used in an aggregate function
+error: column "t.public.kv.v" must appear in the GROUP BY clause or be used in an aggregate function
 
 build
 SELECT COUNT(*), k+v FROM t.kv GROUP BY v
 ----
-error: column "t.kv.k" must appear in the GROUP BY clause or be used in an aggregate function
+error: column "t.public.kv.k" must appear in the GROUP BY clause or be used in an aggregate function
 
 build
 SELECT COUNT(*), v/(k+v) FROM t.kv GROUP BY k+v
 ----
-error: column "t.kv.v" must appear in the GROUP BY clause or be used in an aggregate function
+error: column "t.public.kv.v" must appear in the GROUP BY clause or be used in an aggregate function
 
 build
 SELECT k FROM t.kv WHERE AVG(k) > 1

--- a/pkg/sql/opt/optbuilder/testdata/distinct
+++ b/pkg/sql/opt/optbuilder/testdata/distinct
@@ -1,7 +1,7 @@
 # tests adapted from logictest -- aggregate and distinct
 
 exec-ddl
-CREATE TABLE t.xyz (
+CREATE TABLE xyz (
   x INT PRIMARY KEY,
   y INT,
   z FLOAT,
@@ -27,7 +27,7 @@ TABLE xyz
       └── x int not null
 
 build
-SELECT y, z FROM t.xyz
+SELECT y, z FROM xyz
 ----
 project
  ├── columns: y:2(int) z:3(float)
@@ -38,7 +38,7 @@ project
       └── variable: xyz.z [type=float]
 
 build
-SELECT DISTINCT y, z FROM t.xyz
+SELECT DISTINCT y, z FROM xyz
 ----
 group-by
  ├── columns: y:2(int) z:3(float)
@@ -53,7 +53,7 @@ group-by
  └── aggregations
 
 build
-SELECT y FROM (SELECT DISTINCT y, z FROM t.xyz)
+SELECT y FROM (SELECT DISTINCT y, z FROM xyz)
 ----
 project
  ├── columns: y:2(int)
@@ -195,7 +195,7 @@ sort
       └── aggregations
 
 build
-SELECT DISTINCT (y,z) FROM t.xyz
+SELECT DISTINCT (y,z) FROM xyz
 ----
 group-by
  ├── columns: column4:4(tuple{int, float})
@@ -211,7 +211,7 @@ group-by
  └── aggregations
 
 build
-SELECT COUNT(*) FROM (SELECT DISTINCT y FROM t.xyz)
+SELECT COUNT(*) FROM (SELECT DISTINCT y FROM xyz)
 ----
 group-by
  ├── columns: column4:4(int)
@@ -231,7 +231,7 @@ group-by
       └── function: count_rows [type=int]
 
 build
-SELECT DISTINCT x FROM t.xyz WHERE x > 0
+SELECT DISTINCT x FROM xyz WHERE x > 0
 ----
 group-by
  ├── columns: x:1(int!null)
@@ -250,7 +250,7 @@ group-by
  └── aggregations
 
 build
-SELECT DISTINCT z FROM t.xyz WHERE x > 0
+SELECT DISTINCT z FROM xyz WHERE x > 0
 ----
 group-by
  ├── columns: z:3(float)

--- a/pkg/sql/opt/optbuilder/testdata/having
+++ b/pkg/sql/opt/optbuilder/testdata/having
@@ -1,7 +1,7 @@
 # tests adapted from logictest -- aggregate
 
 exec-ddl
-CREATE TABLE t.kv (
+CREATE TABLE kv (
   k INT PRIMARY KEY,
   v INT,
   w INT,
@@ -18,7 +18,7 @@ TABLE kv
 
 # Presence of HAVING triggers aggregation, reducing results to one row (even without GROUP BY).
 build
-SELECT 3 FROM t.kv HAVING TRUE
+SELECT 3 FROM kv HAVING TRUE
 ----
 project
  ├── columns: column5:5(int)
@@ -34,7 +34,7 @@ project
       └── const: 3 [type=int]
 
 build
-SELECT s, COUNT(*) FROM t.kv GROUP BY s HAVING COUNT(*) > 1
+SELECT s, COUNT(*) FROM kv GROUP BY s HAVING COUNT(*) > 1
 ----
 select
  ├── columns: s:4(string) column5:5(int)
@@ -54,7 +54,7 @@ select
       └── const: 1 [type=int]
 
 build
-SELECT MAX(k), MIN(v) FROM t.kv HAVING MIN(v) > 2
+SELECT MAX(k), MIN(v) FROM kv HAVING MIN(v) > 2
 ----
 project
  ├── columns: column6:6(int) column5:5(int)
@@ -82,7 +82,7 @@ project
       └── variable: column5 [type=int]
 
 build
-SELECT MAX(k), MIN(v) FROM t.kv HAVING MAX(v) > 2
+SELECT MAX(k), MIN(v) FROM kv HAVING MAX(v) > 2
 ----
 project
  ├── columns: column6:6(int) column7:7(int)
@@ -112,35 +112,35 @@ project
       └── variable: column7 [type=int]
 
 build
-SELECT MAX(k), MIN(v) FROM t.kv HAVING MAX(MIN(v)) > 2
+SELECT MAX(k), MIN(v) FROM kv HAVING MAX(MIN(v)) > 2
 ----
 error: aggregate functions are not allowed in the argument of max()
 
 build
-SELECT MAX(k), MIN(v) FROM t.kv HAVING k
+SELECT MAX(k), MIN(v) FROM kv HAVING k
 ----
-error: column "t.public.kv.k" must appear in the GROUP BY clause or be used in an aggregate function
+error: column "kv.k" must appear in the GROUP BY clause or be used in an aggregate function
 
 # Expressions listed in the HAVING clause must conform to same validation as the SELECT clause (grouped or aggregated).
 build
-SELECT 3 FROM t.kv GROUP BY v HAVING k > 5
+SELECT 3 FROM kv GROUP BY v HAVING k > 5
 ----
-error: column "t.public.kv.k" must appear in the GROUP BY clause or be used in an aggregate function
+error: column "kv.k" must appear in the GROUP BY clause or be used in an aggregate function
 
 # pg has a special case for grouping on primary key, which would allow this, but we do not.
 # See http://www.postgresql.org/docs/current/static/sql-select.html#SQL-GROUPBY
 build
-SELECT 3 FROM t.kv GROUP BY k HAVING v > 2
+SELECT 3 FROM kv GROUP BY k HAVING v > 2
 ----
-error: column "t.public.kv.v" must appear in the GROUP BY clause or be used in an aggregate function
+error: column "kv.v" must appear in the GROUP BY clause or be used in an aggregate function
 
 build
-SELECT k FROM t.kv HAVING k > 7
+SELECT k FROM kv HAVING k > 7
 ----
-error: column "t.public.kv.k" must appear in the GROUP BY clause or be used in an aggregate function
+error: column "kv.k" must appear in the GROUP BY clause or be used in an aggregate function
 
 build
-SELECT count(*), k+w FROM t.kv GROUP BY k+w HAVING (k+w) > 5
+SELECT count(*), k+w FROM kv GROUP BY k+w HAVING (k+w) > 5
 ----
 project
  ├── columns: column6:6(int) column5:5(int)
@@ -169,9 +169,9 @@ project
       └── variable: column5 [type=int]
 
 build
-SELECT count(*), k+w FROM t.kv GROUP BY k+w HAVING (k+v) > 5
+SELECT count(*), k+w FROM kv GROUP BY k+w HAVING (k+v) > 5
 ----
-error: column "t.public.kv.k" must appear in the GROUP BY clause or be used in an aggregate function
+error: column "kv.k" must appear in the GROUP BY clause or be used in an aggregate function
 
 # Check that everything still works with differently qualified names
 build
@@ -257,40 +257,40 @@ project
  └── projections
       └── variable: column6 [type=decimal]
 
-build
+build fully-qualify-names
 SELECT t.kv.v FROM t.kv GROUP BY v, kv.k * w HAVING k * kv.w > 5
 ----
 project
  ├── columns: v:2(int)
  ├── select
- │    ├── columns: kv.v:2(int) column5:5(int)
+ │    ├── columns: t.public.kv.v:2(int) column5:5(int)
  │    ├── group-by
- │    │    ├── columns: kv.v:2(int) column5:5(int)
- │    │    ├── grouping columns: kv.v:2(int) column5:5(int)
+ │    │    ├── columns: t.public.kv.v:2(int) column5:5(int)
+ │    │    ├── grouping columns: t.public.kv.v:2(int) column5:5(int)
  │    │    ├── project
- │    │    │    ├── columns: kv.v:2(int) column5:5(int)
+ │    │    │    ├── columns: t.public.kv.v:2(int) column5:5(int)
  │    │    │    ├── scan kv
- │    │    │    │    └── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string)
+ │    │    │    │    └── columns: t.public.kv.k:1(int!null) t.public.kv.v:2(int) t.public.kv.w:3(int) t.public.kv.s:4(string)
  │    │    │    └── projections
- │    │    │         ├── variable: kv.v [type=int]
+ │    │    │         ├── variable: t.public.kv.v [type=int]
  │    │    │         └── mult [type=int]
- │    │    │              ├── variable: kv.k [type=int]
- │    │    │              └── variable: kv.w [type=int]
+ │    │    │              ├── variable: t.public.kv.k [type=int]
+ │    │    │              └── variable: t.public.kv.w [type=int]
  │    │    └── aggregations
  │    └── gt [type=bool]
  │         ├── mult [type=int]
- │         │    ├── variable: kv.k [type=int]
- │         │    └── variable: kv.w [type=int]
+ │         │    ├── variable: t.public.kv.k [type=int]
+ │         │    └── variable: t.public.kv.w [type=int]
  │         └── const: 5 [type=int]
  └── projections
-      └── variable: kv.v [type=int]
+      └── variable: t.public.kv.v [type=int]
 
-build
+build fully-qualify-names
 SELECT t.kv.v FROM t.kv GROUP BY v, kv.k * w HAVING w > 5
 ----
 error: column "t.public.kv.w" must appear in the GROUP BY clause or be used in an aggregate function
 
-build
+build fully-qualify-names
 SELECT UPPER(s), COUNT(s), COUNT(UPPER(s)) FROM t.kv GROUP BY UPPER(s) HAVING COUNT(s) > 1
 ----
 select
@@ -299,16 +299,16 @@ select
  │    ├── columns: column5:5(string) column6:6(int) column7:7(int)
  │    ├── grouping columns: column5:5(string)
  │    ├── project
- │    │    ├── columns: column5:5(string) kv.s:4(string)
+ │    │    ├── columns: column5:5(string) t.public.kv.s:4(string)
  │    │    ├── scan kv
- │    │    │    └── columns: kv.k:1(int!null) kv.v:2(int) kv.w:3(int) kv.s:4(string)
+ │    │    │    └── columns: t.public.kv.k:1(int!null) t.public.kv.v:2(int) t.public.kv.w:3(int) t.public.kv.s:4(string)
  │    │    └── projections
  │    │         ├── function: upper [type=string]
- │    │         │    └── variable: kv.s [type=string]
- │    │         └── variable: kv.s [type=string]
+ │    │         │    └── variable: t.public.kv.s [type=string]
+ │    │         └── variable: t.public.kv.s [type=string]
  │    └── aggregations
  │         ├── function: count [type=int]
- │         │    └── variable: kv.s [type=string]
+ │         │    └── variable: t.public.kv.s [type=string]
  │         └── function: count [type=int]
  │              └── variable: column5 [type=string]
  └── gt [type=bool]

--- a/pkg/sql/opt/optbuilder/testdata/having
+++ b/pkg/sql/opt/optbuilder/testdata/having
@@ -119,25 +119,25 @@ error: aggregate functions are not allowed in the argument of max()
 build
 SELECT MAX(k), MIN(v) FROM t.kv HAVING k
 ----
-error: column "t.kv.k" must appear in the GROUP BY clause or be used in an aggregate function
+error: column "t.public.kv.k" must appear in the GROUP BY clause or be used in an aggregate function
 
 # Expressions listed in the HAVING clause must conform to same validation as the SELECT clause (grouped or aggregated).
 build
 SELECT 3 FROM t.kv GROUP BY v HAVING k > 5
 ----
-error: column "t.kv.k" must appear in the GROUP BY clause or be used in an aggregate function
+error: column "t.public.kv.k" must appear in the GROUP BY clause or be used in an aggregate function
 
 # pg has a special case for grouping on primary key, which would allow this, but we do not.
 # See http://www.postgresql.org/docs/current/static/sql-select.html#SQL-GROUPBY
 build
 SELECT 3 FROM t.kv GROUP BY k HAVING v > 2
 ----
-error: column "t.kv.v" must appear in the GROUP BY clause or be used in an aggregate function
+error: column "t.public.kv.v" must appear in the GROUP BY clause or be used in an aggregate function
 
 build
 SELECT k FROM t.kv HAVING k > 7
 ----
-error: column "t.kv.k" must appear in the GROUP BY clause or be used in an aggregate function
+error: column "t.public.kv.k" must appear in the GROUP BY clause or be used in an aggregate function
 
 build
 SELECT count(*), k+w FROM t.kv GROUP BY k+w HAVING (k+w) > 5
@@ -171,7 +171,7 @@ project
 build
 SELECT count(*), k+w FROM t.kv GROUP BY k+w HAVING (k+v) > 5
 ----
-error: column "t.kv.k" must appear in the GROUP BY clause or be used in an aggregate function
+error: column "t.public.kv.k" must appear in the GROUP BY clause or be used in an aggregate function
 
 # Check that everything still works with differently qualified names
 build
@@ -288,7 +288,7 @@ project
 build
 SELECT t.kv.v FROM t.kv GROUP BY v, kv.k * w HAVING w > 5
 ----
-error: column "t.kv.w" must appear in the GROUP BY clause or be used in an aggregate function
+error: column "t.public.kv.w" must appear in the GROUP BY clause or be used in an aggregate function
 
 build
 SELECT UPPER(s), COUNT(s), COUNT(UPPER(s)) FROM t.kv GROUP BY UPPER(s) HAVING COUNT(s) > 1

--- a/pkg/sql/opt/optbuilder/testdata/inner-join
+++ b/pkg/sql/opt/optbuilder/testdata/inner-join
@@ -1,5 +1,5 @@
 exec-ddl
-CREATE TABLE t.a (x INT PRIMARY KEY, y FLOAT)
+CREATE TABLE a (x INT PRIMARY KEY, y FLOAT)
 ----
 TABLE a
  ├── x int not null
@@ -8,7 +8,7 @@ TABLE a
       └── x int not null
 
 exec-ddl
-CREATE TABLE t.b (x INT, y FLOAT)
+CREATE TABLE b (x INT, y FLOAT)
 ----
 TABLE b
  ├── x int
@@ -18,7 +18,7 @@ TABLE b
       └── rowid int not null (hidden)
 
 exec-ddl
-CREATE TABLE t.c (x INT, y FLOAT, z VARCHAR, CONSTRAINT fk_x_ref_a FOREIGN KEY (x) REFERENCES t.a (x))
+CREATE TABLE c (x INT, y FLOAT, z VARCHAR, CONSTRAINT fk_x_ref_a FOREIGN KEY (x) REFERENCES a (x))
 ----
 TABLE c
  ├── x int
@@ -29,7 +29,7 @@ TABLE c
       └── rowid int not null (hidden)
 
 build
-SELECT * FROM t.a, t.b
+SELECT * FROM a, b
 ----
 project
  ├── columns: x:1(int!null) y:2(float) x:3(int) y:4(float)
@@ -47,7 +47,7 @@ project
       └── variable: b.y [type=float]
 
 build
-SELECT a.x, b.y FROM t.a, t.b WHERE a.x = b.x
+SELECT a.x, b.y FROM a, b WHERE a.x = b.x
 ----
 project
  ├── columns: x:1(int!null) y:4(float)
@@ -68,7 +68,7 @@ project
       └── variable: b.y [type=float]
 
 build
-SELECT * FROM t.c, t.b, t.a WHERE c.x = a.x AND b.x = a.x
+SELECT * FROM c, b, a WHERE c.x = a.x AND b.x = a.x
 ----
 project
  ├── columns: x:1(int) y:2(float) z:3(string) x:5(int) y:6(float) x:8(int!null) y:9(float)
@@ -121,49 +121,49 @@ TABLE a
  └── INDEX primary
       └── x int not null
 
-build
+build fully-qualify-names
 SELECT a.x FROM db1.a, db2.a
 ----
 error: ambiguous source name: "a"
 
-build
+build fully-qualify-names
 SELECT x FROM a, b
 ----
 error: column reference "x" is ambiguous (candidates: a.x, b.x)
 
-build
+build fully-qualify-names
 SELECT * FROM db1.a, db2.a
 ----
 inner-join
  ├── columns: x:1(int!null) y:2(float) z:3(string) x:4(int!null) y:5(float)
  ├── scan a
- │    └── columns: a.x:1(int!null) a.y:2(float) a.z:3(string)
+ │    └── columns: db1.public.a.x:1(int!null) db1.public.a.y:2(float) db1.public.a.z:3(string)
  ├── scan a
- │    └── columns: a.x:4(int!null) a.y:5(float)
+ │    └── columns: db2.public.a.x:4(int!null) db2.public.a.y:5(float)
  └── true [type=bool]
 
-build
+build fully-qualify-names
 SELECT * FROM a, a
 ----
 error: cannot join columns from the same source name "a" (missing AS clause)
 
-build
+build fully-qualify-names
 SELECT * FROM t.a, a
 ----
 error: cannot join columns from the same source name "a" (missing AS clause)
 
-build
+build fully-qualify-names
 SELECT * FROM t.a, a AS a
 ----
 inner-join
  ├── columns: x:1(int!null) y:2(float) x:3(int!null) y:4(float)
  ├── scan a
- │    └── columns: a.x:1(int!null) a.y:2(float)
+ │    └── columns: t.public.a.x:1(int!null) t.public.a.y:2(float)
  ├── scan a
- │    └── columns: a.x:3(int!null) a.y:4(float)
+ │    └── columns: t.public.a.x:3(int!null) t.public.a.y:4(float)
  └── true [type=bool]
 
-build
+build fully-qualify-names
 SELECT a.* FROM t.a, a AS a
 ----
 error: ambiguous source name: "a"

--- a/pkg/sql/opt/optbuilder/testdata/inner-join
+++ b/pkg/sql/opt/optbuilder/testdata/inner-join
@@ -101,3 +101,69 @@ project
       ├── variable: b.y [type=float]
       ├── variable: a.x [type=int]
       └── variable: a.y [type=float]
+
+exec-ddl
+CREATE TABLE db1.a (x INT PRIMARY KEY, y FLOAT, z STRING)
+----
+TABLE a
+ ├── x int not null
+ ├── y float
+ ├── z string
+ └── INDEX primary
+      └── x int not null
+
+exec-ddl
+CREATE TABLE db2.a (x INT PRIMARY KEY, y FLOAT)
+----
+TABLE a
+ ├── x int not null
+ ├── y float
+ └── INDEX primary
+      └── x int not null
+
+build
+SELECT a.x FROM db1.a, db2.a
+----
+error: ambiguous source name: "a"
+
+build
+SELECT x FROM a, b
+----
+error: column reference "x" is ambiguous (candidates: a.x, b.x)
+
+build
+SELECT * FROM db1.a, db2.a
+----
+inner-join
+ ├── columns: x:1(int!null) y:2(float) z:3(string) x:4(int!null) y:5(float)
+ ├── scan a
+ │    └── columns: a.x:1(int!null) a.y:2(float) a.z:3(string)
+ ├── scan a
+ │    └── columns: a.x:4(int!null) a.y:5(float)
+ └── true [type=bool]
+
+build
+SELECT * FROM a, a
+----
+error: cannot join columns from the same source name "a" (missing AS clause)
+
+build
+SELECT * FROM t.a, a
+----
+error: cannot join columns from the same source name "a" (missing AS clause)
+
+build
+SELECT * FROM t.a, a AS a
+----
+inner-join
+ ├── columns: x:1(int!null) y:2(float) x:3(int!null) y:4(float)
+ ├── scan a
+ │    └── columns: a.x:1(int!null) a.y:2(float)
+ ├── scan a
+ │    └── columns: a.x:3(int!null) a.y:4(float)
+ └── true [type=bool]
+
+build
+SELECT a.* FROM t.a, a AS a
+----
+error: ambiguous source name: "a"

--- a/pkg/sql/opt/optbuilder/testdata/join
+++ b/pkg/sql/opt/optbuilder/testdata/join
@@ -1344,7 +1344,7 @@ TABLE othertype
 build
 SELECT * FROM (onecolumn AS a JOIN othertype AS b USING(x))
 ----
-error: JOIN/USING types int for left and string for right cannot be matched for column x
+error: JOIN/USING types int for left and string for right cannot be matched for column "x"
 
 build
 SELECT * FROM (onecolumn JOIN onecolumn USING(x))
@@ -1894,6 +1894,54 @@ project
 
 build
 SELECT * FROM t1 NATURAL JOIN t2
+----
+project
+ ├── columns: x:2(int) y:4(int) col1:1(int) col2:3(int) col3:6(int) col4:9(int)
+ ├── inner-join
+ │    ├── columns: t1.col1:1(int) t1.x:2(int) t1.col2:3(int) t1.y:4(int) t1.rowid:5(int!null) t2.col3:6(int) t2.y:7(int) t2.x:8(int) t2.col4:9(int) t2.rowid:10(int!null)
+ │    ├── scan t1
+ │    │    └── columns: t1.col1:1(int) t1.x:2(int) t1.col2:3(int) t1.y:4(int) t1.rowid:5(int!null)
+ │    ├── scan t2
+ │    │    └── columns: t2.col3:6(int) t2.y:7(int) t2.x:8(int) t2.col4:9(int) t2.rowid:10(int!null)
+ │    └── and [type=bool]
+ │         ├── eq [type=bool]
+ │         │    ├── variable: t1.x [type=int]
+ │         │    └── variable: t2.x [type=int]
+ │         └── eq [type=bool]
+ │              ├── variable: t1.y [type=int]
+ │              └── variable: t2.y [type=int]
+ └── projections
+      ├── variable: t1.x [type=int]
+      ├── variable: t1.y [type=int]
+      ├── variable: t1.col1 [type=int]
+      ├── variable: t1.col2 [type=int]
+      ├── variable: t2.col3 [type=int]
+      └── variable: t2.col4 [type=int]
+
+build
+SELECT x, t1.x, t2.x FROM t1 NATURAL JOIN t2
+----
+project
+ ├── columns: x:2(int) x:2(int) x:8(int)
+ ├── inner-join
+ │    ├── columns: t1.col1:1(int) t1.x:2(int) t1.col2:3(int) t1.y:4(int) t1.rowid:5(int!null) t2.col3:6(int) t2.y:7(int) t2.x:8(int) t2.col4:9(int) t2.rowid:10(int!null)
+ │    ├── scan t1
+ │    │    └── columns: t1.col1:1(int) t1.x:2(int) t1.col2:3(int) t1.y:4(int) t1.rowid:5(int!null)
+ │    ├── scan t2
+ │    │    └── columns: t2.col3:6(int) t2.y:7(int) t2.x:8(int) t2.col4:9(int) t2.rowid:10(int!null)
+ │    └── and [type=bool]
+ │         ├── eq [type=bool]
+ │         │    ├── variable: t1.x [type=int]
+ │         │    └── variable: t2.x [type=int]
+ │         └── eq [type=bool]
+ │              ├── variable: t1.y [type=int]
+ │              └── variable: t2.y [type=int]
+ └── projections
+      ├── variable: t1.x [type=int]
+      └── variable: t2.x [type=int]
+
+build
+SELECT t1.*, t2.* FROM t1 NATURAL JOIN t2
 ----
 project
  ├── columns: x:2(int) y:4(int) col1:1(int) col2:3(int) col3:6(int) col4:9(int)

--- a/pkg/sql/opt/optbuilder/testdata/project
+++ b/pkg/sql/opt/optbuilder/testdata/project
@@ -266,3 +266,27 @@ build
 SELECT c FROM (SELECT a, b FROM abc ORDER BY c)
 ----
 error: column name "c" not found
+
+build
+SELECT t.kv.k FROM abc AS kv
+----
+error: no data source matches prefix: t.kv
+
+exec-ddl
+CREATE TABLE kv (k INT PRIMARY KEY, v INT)
+----
+TABLE kv
+ ├── k int not null
+ ├── v int
+ └── INDEX primary
+      └── k int not null
+
+build
+SELECT t.kv.k FROM kv
+----
+project
+ ├── columns: k:1(int!null)
+ ├── scan kv
+ │    └── columns: kv.k:1(int!null) kv.v:2(int)
+ └── projections
+      └── variable: kv.k [type=int]

--- a/pkg/sql/opt/optbuilder/testdata/project
+++ b/pkg/sql/opt/optbuilder/testdata/project
@@ -1,5 +1,5 @@
 exec-ddl
-CREATE TABLE t.a (x INT PRIMARY KEY, y FLOAT)
+CREATE TABLE a (x INT PRIMARY KEY, y FLOAT)
 ----
 TABLE a
  ├── x int not null
@@ -8,7 +8,7 @@ TABLE a
       └── x int not null
 
 exec-ddl
-CREATE TABLE t.b (x INT, y FLOAT)
+CREATE TABLE b (x INT, y FLOAT)
 ----
 TABLE b
  ├── x int
@@ -28,7 +28,7 @@ project
       └── const: 5 [type=int]
 
 build
-SELECT a.x FROM t.a
+SELECT a.x FROM a
 ----
 project
  ├── columns: x:1(int!null)
@@ -38,13 +38,13 @@ project
       └── variable: a.x [type=int]
 
 build
-SELECT a.x, a.y FROM t.a
+SELECT a.x, a.y FROM a
 ----
 scan a
  └── columns: x:1(int!null) y:2(float)
 
 build
-SELECT a.y, a.x FROM t.a
+SELECT a.y, a.x FROM a
 ----
 project
  ├── columns: y:2(float) x:1(int!null)
@@ -55,7 +55,7 @@ project
       └── variable: a.x [type=int]
 
 build
-SELECT * FROM t.a
+SELECT * FROM a
 ----
 scan a
  └── columns: x:1(int!null) y:2(float)
@@ -63,7 +63,7 @@ scan a
 # Note that an explicit projection operator is added for table b (unlike for
 # table a) to avoid projecting the hidden rowid column.
 build
-SELECT * FROM t.b
+SELECT * FROM b
 ----
 project
  ├── columns: x:1(int) y:2(float)
@@ -74,7 +74,7 @@ project
       └── variable: b.y [type=float]
 
 build
-SELECT (a.x + 3) AS "X", false AS "Y" FROM t.a
+SELECT (a.x + 3) AS "X", false AS "Y" FROM a
 ----
 project
  ├── columns: X:3(int) Y:4(bool)
@@ -87,7 +87,7 @@ project
       └── false [type=bool]
 
 build
-SELECT *, ((x < y) OR x > 1000) FROM t.a
+SELECT *, ((x < y) OR x > 1000) FROM a
 ----
 project
  ├── columns: x:1(int!null) y:2(float) column3:3(bool)
@@ -105,7 +105,7 @@ project
                 └── const: 1000 [type=int]
 
 build
-SELECT a.*, true FROM t.a
+SELECT a.*, true FROM a
 ----
 project
  ├── columns: x:1(int!null) y:2(float) column3:3(bool)
@@ -117,7 +117,7 @@ project
       └── true [type=bool]
 
 build
-SELECT u + 1, v + 1 FROM (SELECT a.x + 3, a.y + 1.0 FROM t.a) AS foo(u, v)
+SELECT u + 1, v + 1 FROM (SELECT a.x + 3, a.y + 1.0 FROM a) AS foo(u, v)
 ----
 project
  ├── columns: column5:5(int) column6:6(float)
@@ -267,7 +267,7 @@ SELECT c FROM (SELECT a, b FROM abc ORDER BY c)
 ----
 error: column name "c" not found
 
-build
+build fully-qualify-names
 SELECT t.kv.k FROM abc AS kv
 ----
 error: no data source matches prefix: t.kv
@@ -281,12 +281,12 @@ TABLE kv
  └── INDEX primary
       └── k int not null
 
-build
+build fully-qualify-names
 SELECT t.kv.k FROM kv
 ----
 project
  ├── columns: k:1(int!null)
  ├── scan kv
- │    └── columns: kv.k:1(int!null) kv.v:2(int)
+ │    └── columns: t.public.kv.k:1(int!null) t.public.kv.v:2(int)
  └── projections
-      └── variable: kv.k [type=int]
+      └── variable: t.public.kv.k [type=int]

--- a/pkg/sql/opt/optbuilder/testdata/scalar
+++ b/pkg/sql/opt/optbuilder/testdata/scalar
@@ -574,6 +574,17 @@ not [type=bool]
                      ├── const: 1 [type=int]
                      └── const: 2 [type=int]
 
+build-scalar
+NULL
+----
+null [type=unknown]
+
+build-scalar
+NULL::int
+----
+cast: int [type=int]
+ └── null [type=unknown]
+
 build-scalar vars=(int[])
 @1 = ARRAY[1, 2, 3]
 ----

--- a/pkg/sql/opt/optbuilder/testdata/select
+++ b/pkg/sql/opt/optbuilder/testdata/select
@@ -962,3 +962,14 @@ build
 SELECT * FROM t.a WHERE (x > 10)::INT[]
 ----
 error: invalid cast: bool -> INT[]
+
+build
+SELECT * FROM t.a WHERE x = $1
+----
+select
+ ├── columns: x:1(int!null) y:2(float)
+ ├── scan a
+ │    └── columns: a.x:1(int!null) a.y:2(float)
+ └── eq [type=bool]
+      ├── variable: a.x [type=int]
+      └── placeholder: $1 [type=int]

--- a/pkg/sql/opt/optbuilder/testdata/select
+++ b/pkg/sql/opt/optbuilder/testdata/select
@@ -871,7 +871,7 @@ project
                                └── variable: column3 [type=tuple{int, int}]
 
 exec-ddl
-CREATE TABLE t.a (x INT PRIMARY KEY, y FLOAT)
+CREATE TABLE a (x INT PRIMARY KEY, y FLOAT)
 ----
 TABLE a
  ├── x int not null
@@ -880,13 +880,13 @@ TABLE a
       └── x int not null
 
 build
-SELECT * FROM t.a
+SELECT * FROM a
 ----
 scan a
  └── columns: x:1(int!null) y:2(float)
 
 build
-SELECT * FROM t.a WHERE x > 10
+SELECT * FROM a WHERE x > 10
 ----
 select
  ├── columns: x:1(int!null) y:2(float)
@@ -897,7 +897,7 @@ select
       └── const: 10 [type=int]
 
 build
-SELECT * FROM t.a WHERE (x > 10 AND (x < 20 AND x != 13))
+SELECT * FROM a WHERE (x > 10 AND (x < 20 AND x != 13))
 ----
 select
  ├── columns: x:1(int!null) y:2(float)
@@ -916,7 +916,7 @@ select
                 └── const: 13 [type=int]
 
 build
-SELECT * FROM t.a WHERE x IN (1, 2, 3)
+SELECT * FROM a WHERE x IN (1, 2, 3)
 ----
 select
  ├── columns: x:1(int!null) y:2(float)
@@ -930,13 +930,13 @@ select
            └── const: 3 [type=int]
 
 build
-SELECT * FROM t.a AS A(X, Y)
+SELECT * FROM a AS A(X, Y)
 ----
 scan a
  └── columns: x:1(int!null) y:2(float)
 
 build
-SELECT @1, @2 FROM t.a
+SELECT @1, @2 FROM a
 ----
 project
  ├── columns: column3:3(int) column4:4(float)
@@ -947,7 +947,7 @@ project
       └── variable: a.y [type=float]
 
 build
-SELECT * FROM t.a WHERE (x > 10)::bool
+SELECT * FROM a WHERE (x > 10)::bool
 ----
 select
  ├── columns: x:1(int!null) y:2(float)
@@ -959,12 +959,12 @@ select
            └── const: 10 [type=int]
 
 build
-SELECT * FROM t.a WHERE (x > 10)::INT[]
+SELECT * FROM a WHERE (x > 10)::INT[]
 ----
 error: invalid cast: bool -> INT[]
 
 build
-SELECT * FROM t.a WHERE x = $1
+SELECT * FROM a WHERE x = $1
 ----
 select
  ├── columns: x:1(int!null) y:2(float)

--- a/pkg/sql/opt/optbuilder/testdata/subquery
+++ b/pkg/sql/opt/optbuilder/testdata/subquery
@@ -856,6 +856,20 @@ project
            │              └── variable: abc.a [type=int]
            └── variable: abc.a [type=int]
 
+exec-ddl
+CREATE TABLE kv (k INT PRIMARY KEY, v INT)
+----
+TABLE kv
+ ├── k int not null
+ ├── v int
+ └── INDEX primary
+      └── k int not null
+
+build
+SELECT (SELECT abc.k FROM abc) FROM kv AS abc
+----
+error: column name "abc.k" not found
+
 build
 VALUES (1, (SELECT (2)))
 ----

--- a/pkg/sql/opt/testutils/alter_table.go
+++ b/pkg/sql/opt/testutils/alter_table.go
@@ -35,9 +35,12 @@ func (tc *TestCatalog) AlterTable(stmt *tree.AlterTable) {
 		panic(err)
 	}
 
-	table, ok := tc.tables[tn.Table()]
+	// Update the table name to include catalog and schema if not provided.
+	tc.qualifyTableName(tn)
+
+	table, ok := tc.tables[tn.FQString()]
 	if !ok {
-		panic(fmt.Sprintf("cannot find table %s", tn.Table()))
+		panic(fmt.Sprintf("cannot find table %q", tree.ErrString(tn)))
 	}
 
 	for _, cmd := range stmt.Cmds {


### PR DESCRIPTION
This commit fixes a couple of bugs in the optbuilder:

(1) The optbuilder was incorrectly allowing queries such
    as `SELECT * from a, a`. This query now throws the error:
    `cannot join columns from the same source name "a"`
    `(missing AS clause)`.

(2) The optbuilder was incorrectly causing an error for
    queries such as `SELECT t.kv.k FROM kv` when the current
    database was set to t. This is now fixed.

In order to test the fix to these bugs and add other test cases,
this commit also improves the optimizer test infrastructure to
qualify table names with the schema and catalog.

This commit also adds additional test cases identified by
@knz in a document he created describing tricky semantic
analysis functionality in CockroachDB.

Release note: None