### PR TITLE
ui, sql: fix display of "database dropped" event.

### DIFF
--- a/pkg/sql/drop_database.go
+++ b/pkg/sql/drop_database.go
@@ -172,10 +172,10 @@ func (n *dropDatabaseNode) startExec(params runParams) error {
 		int32(n.dbDesc.ID),
 		int32(params.extendedEvalCtx.NodeID),
 		struct {
-			DatabaseName          string
-			Statement             string
-			User                  string
-			DroppedTablesAndViews []string
+			DatabaseName         string
+			Statement            string
+			User                 string
+			DroppedSchemaObjects []string
 		}{n.n.Name.String(), n.n.String(), p.SessionData().User, tbNameStrings},
 	)
 }

--- a/pkg/sql/logictest/testdata/logic_test/event_log
+++ b/pkg/sql/logictest/testdata/logic_test/event_log
@@ -292,7 +292,7 @@ DROP DATABASE IF EXISTS othereventlogtest CASCADE
 # verify event is there, and cascading table drops are logged.
 
 query IIT
-SELECT "targetID", "reportingID", info::JSONB->>'DroppedTablesAndViews'
+SELECT "targetID", "reportingID", info::JSONB->>'DroppedSchemaObjects'
 FROM system.eventlog
 WHERE "eventType" = 'drop_database'
   AND info::JSONB->>'Statement' LIKE 'DROP DATABASE eventlogtest%'
@@ -300,7 +300,7 @@ WHERE "eventType" = 'drop_database'
 53 1 ["eventlogtest.public.anothertesttable", "eventlogtest.public.testtable"]
 
 query IIT
-SELECT "targetID", "reportingID", info::JSONB->>'DroppedTablesAndViews'
+SELECT "targetID", "reportingID", info::JSONB->>'DroppedSchemaObjects'
 FROM system.eventlog
 WHERE "eventType" = 'drop_database'
   AND info::JSONB->>'Statement' LIKE 'DROP DATABASE IF EXISTS othereventlogtest%'

--- a/pkg/ui/src/util/events.spec.ts
+++ b/pkg/ui/src/util/events.spec.ts
@@ -1,0 +1,37 @@
+import { assert } from "chai";
+import { EventInfo, getDroppedObjectsText } from "src/util/events";
+
+describe("getDroppedObjectsText", function() {
+
+  // The key indicating which objects were dropped in a DROP_DATABASE event has been
+  // renamed multiple times, creating bugs (e.g. #18523). This test won't fail if the
+  // key is renamed again on the Go side, but it at least tests that we can handle all
+  // existing versions.
+  it("returns a sentence for all versions of the dropped objects key", function() {
+    const commonProperties: EventInfo = {
+      User: "root",
+      DatabaseName: "foo",
+    };
+    const versions: EventInfo[] = [
+      {
+        ...commonProperties,
+        DroppedTables: ["foo", "bar"],
+      },
+      {
+        ...commonProperties,
+        DroppedTablesAndViews: ["foo", "bar"],
+      },
+      {
+        ...commonProperties,
+        DroppedSchemaObjects: ["foo", "bar"],
+      },
+    ];
+
+    const expected = "2 schema objects were dropped: foo, bar";
+
+    versions.forEach((eventInfoVersion) => {
+      assert.equal(expected, getDroppedObjectsText(eventInfoVersion));
+    });
+  });
+
+});


### PR DESCRIPTION
The DROP_DATABASE event in `system.eventlog`  was changed from having the key `DroppedTables` to having the key `DroppedTablesAndViews`. The corresponding UI code which displays the dropped tables was not changed, creating bug #18523.

This commit fixes #18523 by renaming the key to `DroppedSchemaObjects`, both in the event and in the UI code. The term "Schema Objects" accounts for the existence of sequences in addition to views and tables.

Q: is it worth adding a migration to change old events from `DroppedTablesAndViews` to `DroppedSchemaObjects`? I'm leaning toward no, since (a) it doesn't look like we added a migration when we renamed `DroppedTables` to `DroppedTablesAndViews`, and (b) without the migration, you'll still see the "drop database" event in the UI, just not the table names (but they'll be in `system.eventlog` under the old key).

Release note (admin ui change): display the names of dropped schema objects on `DROP DATABASE ... CASCADE`