### PR TITLE
importccl: require hex-encoded byte literals in IMPORT

### DIFF
--- a/pkg/ccl/importccl/csv.go
+++ b/pkg/ccl/importccl/csv.go
@@ -367,7 +367,6 @@ func convertRecord(
 	const kvBatchSize = 1000
 	padding := 2 * (len(tableDesc.Indexes) + len(tableDesc.Families))
 	visibleCols := tableDesc.VisibleColumns()
-	cenv := &tree.CollationEnvironment{}
 
 	ri, err := sqlbase.MakeRowInserter(nil /* txn */, tableDesc, nil, /* fkTables */
 		tableDesc.Columns, false /* checkFKs */, &sqlbase.DatumAlloc{})
@@ -417,7 +416,8 @@ func convertRecord(
 				if nullif != nil && v == *nullif {
 					datums[i] = tree.DNull
 				} else {
-					datums[i], err = parser.ParseStringAs(col.Type.ToDatumType(), v, &evalCtx, cenv)
+					var err error
+					datums[i], err = tree.ParseDatumStringAs(col.Type.ToDatumType(), v, &evalCtx)
 					if err != nil {
 						return errors.Wrapf(err, "%s: row %d: parse %q as %s", batch.file, rowNum, col.Name, col.Type.SQLString())
 					}

--- a/pkg/ccl/importccl/csv_test.go
+++ b/pkg/ccl/importccl/csv_test.go
@@ -132,6 +132,27 @@ d
 				`SELECT count(*) from d.t`: {{"1"}},
 			},
 		},
+		{
+			name:   "good bytes encoding",
+			create: `b bytes`,
+			csv: `\x0143
+0143`,
+			query: map[string][][]string{
+				`SELECT * from d.t`: {{"\x01C"}, {"0143"}},
+			},
+		},
+		{
+			name:   "invalid byte",
+			create: `b bytes`,
+			csv:    `\x0g`,
+			err:    "invalid byte",
+		},
+		{
+			name:   "bad bytes length",
+			create: `b bytes`,
+			csv:    `\x0`,
+			err:    "odd length hex string",
+		},
 	}
 
 	var csvString string

--- a/pkg/sql/copy.go
+++ b/pkg/sql/copy.go
@@ -24,7 +24,6 @@ import (
 	"unsafe"
 
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
-	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgwirebase"
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -75,9 +74,6 @@ type copyMachine struct {
 	// parsing. Is it not correcly initialized with timestamps, transactions and
 	// other things that statements more generally need.
 	parsingEvalCtx *tree.EvalContext
-	// collationEnv is needed only when creating collated strings. Using a common
-	// environment allows for some expensive work to only be done once.
-	collationEnv tree.CollationEnvironment
 }
 
 // newCopyMachine creates a new copyMachine.
@@ -363,7 +359,7 @@ func (c *copyMachine) addRow(ctx context.Context, line []byte) error {
 				return err
 			}
 		}
-		d, err := parser.ParseStringAs(c.resultColumns[i].Typ, s, c.parsingEvalCtx, &c.collationEnv)
+		d, err := tree.ParseStringAs(c.resultColumns[i].Typ, s, c.parsingEvalCtx)
 		if err != nil {
 			return err
 		}

--- a/pkg/sql/sem/tree/constant.go
+++ b/pkg/sql/sem/tree/constant.go
@@ -20,7 +20,6 @@ import (
 	"go/token"
 	"math"
 	"strings"
-	"time"
 	"unicode/utf8"
 
 	"github.com/pkg/errors"
@@ -464,39 +463,17 @@ func (expr *StrVal) ResolveAsType(ctx *SemaContext, typ types.T) (Datum, error) 
 			expr.resBytes = *s
 		}
 		return &expr.resBytes, err
-	case types.Bool:
-		return ParseDBool(expr.s)
-	case types.Int:
-		return ParseDInt(expr.s)
-	case types.Float:
-		return ParseDFloat(expr.s)
-	case types.Decimal:
-		return ParseDDecimal(expr.s)
-	case types.Date:
-		return ParseDDate(expr.s, ctx.getLocation())
-	case types.Time:
-		return ParseDTime(expr.s)
-	case types.TimeTZ:
-		return ParseDTimeTZ(expr.s, ctx.getLocation())
-	case types.INet:
-		return ParseDIPAddrFromINetString(expr.s)
-	case types.JSON:
-		return ParseDJSON(expr.s)
-	case types.Timestamp:
-		return ParseDTimestamp(expr.s, time.Microsecond)
-	case types.TimestampTZ:
-		return ParseDTimestampTZ(expr.s, ctx.getLocation(), time.Microsecond)
-	case types.Interval:
-		return ParseDInterval(expr.s)
 	case types.UUID:
 		if expr.bytesEsc {
 			return ParseDUuidFromBytes([]byte(expr.s))
 		}
-		return ParseDUuidFromString(expr.s)
-	default:
+	}
+	datum, err := parseStringAs(typ, expr.s, ctx)
+	if datum == nil && err == nil {
 		return nil, pgerror.NewErrorf(pgerror.CodeInternalError,
 			"could not resolve %T %v into a %T", expr, expr, typ)
 	}
+	return datum, err
 }
 
 type constantFolderVisitor struct{}

--- a/pkg/sql/sem/tree/datum.go
+++ b/pkg/sql/sem/tree/datum.go
@@ -919,7 +919,9 @@ func (*DString) AmbiguousFormat() bool { return true }
 // Format implements the NodeFormatter interface.
 func (d *DString) Format(ctx *FmtCtx) {
 	buf, f := ctx.Buffer, ctx.flags
-	if f.HasFlags(fmtWithinArray) {
+	if f.HasFlags(fmtUnicodeStrings) {
+		buf.WriteString(string(*d))
+	} else if f.HasFlags(fmtWithinArray) {
 		lex.EncodeSQLStringInsideArray(buf, string(*d))
 	} else {
 		lex.EncodeSQLStringWithFlags(buf, string(*d), f.EncodeFlags())
@@ -2407,6 +2409,10 @@ func (d *DJSON) Format(ctx *FmtCtx) {
 	// TODO(justin): ideally the JSON string encoder should know it needs to
 	// escape things to be inside SQL strings in order to avoid this allocation.
 	s := d.JSON.String()
+	if ctx.flags.HasFlags(fmtUnicodeStrings) {
+		ctx.Buffer.WriteString(s)
+		return
+	}
 	lex.EncodeSQLStringWithFlags(ctx.Buffer, s, ctx.flags.EncodeFlags())
 }
 

--- a/pkg/sql/sem/tree/format.go
+++ b/pkg/sql/sem/tree/format.go
@@ -93,6 +93,9 @@ const (
 	// fmtSymbolicVars indicates that IndexedVars must be pretty-printed
 	// using numeric notation (@123).
 	fmtSymbolicVars
+
+	// fmtUnicodeStrings prints strings and JSON in their unicode representation.
+	fmtUnicodeStrings
 )
 
 // Composite/derived flag definitions follow.
@@ -123,6 +126,10 @@ const (
 	//    can otherwise be formatted to the same string: (for example the
 	//    DDecimal 1 and the DInt 1).
 	FmtCheckEquivalence FmtFlags = fmtSymbolicVars | fmtDisambiguateDatumTypes
+
+	// FmtParseDatums, if set, formats datums such that they can be round-tripped
+	// with their associated Parse func.
+	FmtParseDatums FmtFlags = FmtBareStrings | fmtUnicodeStrings
 )
 
 // FmtCtx is suitable for passing to Format() methods.

--- a/pkg/sql/sem/tree/parse_string.go
+++ b/pkg/sql/sem/tree/parse_string.go
@@ -1,0 +1,109 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package tree
+
+import (
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/coltypes"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
+)
+
+// ParseStringAs reads s as type t. If t is Bytes or String, s is returned
+// unchanged. Otherwise s is parsed with the given type's Parse func.
+func ParseStringAs(t types.T, s string, evalCtx *EvalContext) (Datum, error) {
+	var d Datum
+	var err error
+	switch t {
+	case types.Bytes:
+		d = NewDBytes(DBytes(s))
+	default:
+		switch t := t.(type) {
+		case types.TArray:
+			typ, err := coltypes.DatumTypeToColumnType(t.Typ)
+			if err != nil {
+				return nil, err
+			}
+			d, err = ParseDArrayFromString(evalCtx, s, typ)
+			if err != nil {
+				return nil, err
+			}
+		case types.TCollatedString:
+			d = NewDCollatedString(s, t.Locale, &evalCtx.collationEnv)
+		default:
+			d, err = parseStringAs(t, s, evalCtx)
+			if d == nil && err == nil {
+				return nil, pgerror.NewErrorf(pgerror.CodeInternalError, "unknown type %s (%T)", t, t)
+			}
+		}
+	}
+	return d, err
+}
+
+// ParseDatumStringAs parses s as type t. This function is guaranteed to
+// round-trip when printing a Datum with FmtParseDatums.
+func ParseDatumStringAs(t types.T, s string, evalCtx *EvalContext) (Datum, error) {
+	switch t {
+	case types.Bytes:
+		return ParseDByte(s, true)
+	default:
+		return ParseStringAs(t, s, evalCtx)
+	}
+}
+
+type locationContext interface {
+	GetLocation() *time.Location
+}
+
+var _ locationContext = &EvalContext{}
+var _ locationContext = &SemaContext{}
+
+// parseStringAs parses s as type t for simple types. Bytes, arrays, collated
+// strings are not handled. nil, nil is returned if t is not a supported type.
+func parseStringAs(t types.T, s string, ctx locationContext) (Datum, error) {
+	switch t {
+	case types.Bool:
+		return ParseDBool(s)
+	case types.Date:
+		return ParseDDate(s, ctx.GetLocation())
+	case types.Decimal:
+		return ParseDDecimal(s)
+	case types.Float:
+		return ParseDFloat(s)
+	case types.INet:
+		return ParseDIPAddrFromINetString(s)
+	case types.Int:
+		return ParseDInt(s)
+	case types.Interval:
+		return ParseDInterval(s)
+	case types.JSON:
+		return ParseDJSON(s)
+	case types.String:
+		return NewDString(s), nil
+	case types.Time:
+		return ParseDTime(s)
+	case types.TimeTZ:
+		return ParseDTimeTZ(s, ctx.GetLocation())
+	case types.Timestamp:
+		return ParseDTimestamp(s, time.Microsecond)
+	case types.TimestampTZ:
+		return ParseDTimestampTZ(s, ctx.GetLocation(), time.Microsecond)
+	case types.UUID:
+		return ParseDUuidFromString(s)
+	default:
+		return nil, nil
+	}
+}

--- a/pkg/sql/sem/tree/parse_string_test.go
+++ b/pkg/sql/sem/tree/parse_string_test.go
@@ -1,0 +1,141 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package tree
+
+import (
+	"fmt"
+	"math"
+	"strconv"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
+	"github.com/cockroachdb/cockroach/pkg/util/uuid"
+)
+
+// TestParseDatumStringAs tests that datums are roundtrippable between
+// printing with FmtParseDatums and ParseDatumStringAs.
+func TestParseDatumStringAs(t *testing.T) {
+	tests := map[types.T][]string{
+		types.Bool: {
+			"true",
+			"false",
+		},
+		types.Bytes: {
+			`\x`,
+			`\x00`,
+			`\xff`,
+			`\xffff`,
+			fmt.Sprintf(`\x%x`, "abc"),
+		},
+		types.Date: {
+			"2001-01-01",
+		},
+		types.Decimal: {
+			"0.0",
+			"-0.0",
+			"1.0",
+			"-1.0",
+			strconv.FormatFloat(math.MaxFloat64, 'G', -1, 64),
+			strconv.FormatFloat(math.SmallestNonzeroFloat64, 'G', -1, 64),
+			strconv.FormatFloat(-math.MaxFloat64, 'G', -1, 64),
+			strconv.FormatFloat(-math.SmallestNonzeroFloat64, 'G', -1, 64),
+			"1E+1000",
+			"1E-1000",
+			"Infinity",
+			"-Infinity",
+			"NaN",
+		},
+		types.Float: {
+			"0.0",
+			"-0.0",
+			"1.0",
+			"-1.0",
+			strconv.FormatFloat(math.MaxFloat64, 'g', -1, 64),
+			strconv.FormatFloat(math.SmallestNonzeroFloat64, 'g', -1, 64),
+			strconv.FormatFloat(-math.MaxFloat64, 'g', -1, 64),
+			strconv.FormatFloat(-math.SmallestNonzeroFloat64, 'g', -1, 64),
+			"+Inf",
+			"-Inf",
+			"NaN",
+		},
+		types.INet: {
+			"127.0.0.1",
+		},
+		types.Int: {
+			"1",
+			"0",
+			"-1",
+			strconv.Itoa(math.MaxInt64),
+			strconv.Itoa(math.MinInt64),
+		},
+		types.Interval: {
+			"1h",
+			"-1m",
+			"2y3mon",
+		},
+		types.JSON: {
+			"{}",
+			"[]",
+			"null",
+			"1",
+			"1.0",
+			`""`,
+		},
+		types.String: {
+			"",
+			"abc",
+			"abc\x00",
+		},
+		types.Time: {
+			"01:02:03",
+			"02:03:04.123456",
+		},
+		types.TimeTZ: {
+			"01:02:03+00:00",
+			"02:03:04.123456+00:00",
+		},
+		types.Timestamp: {
+			"2001-01-01 01:02:03+00:00",
+			"2001-01-01 02:03:04.123456+00:00",
+		},
+		types.TimestampTZ: {
+			"2001-01-01 01:02:03+00:00",
+			"2001-01-01 02:03:04.123456+00:00",
+		},
+		types.UUID: {
+			uuid.MakeV4().String(),
+		},
+	}
+	evalCtx := NewTestingEvalContext(nil)
+	for typ, exprs := range tests {
+		t.Run(typ.String(), func(t *testing.T) {
+			for _, s := range exprs {
+				t.Run(fmt.Sprintf("%q", s), func(t *testing.T) {
+					d, err := ParseDatumStringAs(typ, s, evalCtx)
+					if err != nil {
+						t.Fatal(err)
+					}
+					if d.ResolvedType() != typ {
+						t.Fatalf("unexpected type: %s", d.ResolvedType())
+					}
+					ds := AsStringWithFlags(d, FmtParseDatums)
+					if s != ds {
+						t.Fatalf("unexpected string: %q, expected: %q", ds, s)
+					}
+				})
+			}
+		})
+	}
+}

--- a/pkg/sql/sem/tree/type_check.go
+++ b/pkg/sql/sem/tree/type_check.go
@@ -72,7 +72,7 @@ func (sc *SemaContext) isUnresolvedPlaceholder(expr Expr) bool {
 }
 
 // GetLocation returns the session timezone.
-func (sc *SemaContext) getLocation() *time.Location {
+func (sc *SemaContext) GetLocation() *time.Location {
 	if sc == nil || sc.Location == nil || *sc.Location == nil {
 		return time.UTC
 	}

--- a/pkg/sql/stats/json.go
+++ b/pkg/sql/stats/json.go
@@ -112,10 +112,9 @@ func (js *JSONStatistic) GetHistogram(evalCtx *tree.EvalContext) (*HistogramData
 		return nil, err
 	}
 	h.Buckets = make([]HistogramData_Bucket, len(js.HistogramBuckets))
-	var collationEnv tree.CollationEnvironment
 	for i := range h.Buckets {
 		hb := &js.HistogramBuckets[i]
-		upperVal, err := parser.ParseStringAs(datumType, hb.UpperBound, evalCtx, &collationEnv)
+		upperVal, err := tree.ParseStringAs(datumType, hb.UpperBound, evalCtx)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Previously there was no way to get BYTES columns in IMPORT because
the CSV spec doesn't support non-unicode runes (or at least the
Go CSV reader doesn't). Change it to support our hex-encoded byte
literal format. This is the same format as used when a bytes column
is converted to a string.

Unfortunately this doesn't help with parsing our CSV-output mode in
the CLI because that uses Go's %q from the fmt package, which prints
visible chars if they exist. We can fix the CLI in a later change.

As part of this change, do a large refactor around
parser.ParseStringAs. IMPORT, COPY, and StrVal.ResolveAsType all
share some similar code that takes a string and converts it into a
Datum. Each, though, has a different need about what to do with strings
and bytes. Refactor the functionality into some reusable functions.

We can also remove the creation of unneeded collation envs since
the unexported member of the evalContext is now available in the
tree package.

For IMPORT specifically, we also add a new FmtFlag:
FmtParseDatums. This flag will cause Datums to print such that they
can be parsed by the ParseDatumStringAs function. Although IMPORT is
the only user of this function now, the upcoming EXPORT statement
will use this flag to guarantee that IMPORT is able to correctly
parse anything it produces.

Fixes #24841

Release note (sql change): IMPORT now supports hex-encoded byte
literals for BYTES columns.