### PR TITLE
opt: fix and reenable stats test

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/stats
+++ b/pkg/sql/opt/exec/execbuilder/testdata/stats
@@ -1,49 +1,55 @@
-# # Tests that verify we retrieve the stats correctly.
+# Tests that verify we retrieve the stats correctly.
 
-# exec-raw
-# CREATE DATABASE t
-# ----
+exec-raw
+CREATE DATABASE t
+----
 
-# exec-raw
-# CREATE TABLE t.a (u INT, v INT, INDEX (u) STORING (v), INDEX (v) STORING (u));
-# INSERT INTO t.a VALUES (1, 1), (1, 2), (1, 3), (1, 4), (2, 4), (2, 5), (2, 6), (2, 7)
-# ----
+exec-raw
+CREATE TABLE t.a (u INT, v INT, INDEX (u) STORING (v), INDEX (v) STORING (u));
+----
 
-# build
-# SELECT * FROM t.a
-# ----
-# project
-#  ├── columns: u:1(int) v:2(int)
-#  ├── stats: [rows=1000]
-#  ├── cost: 1000.00
-#  ├── scan a
-#  │    ├── columns: a.u:1(int) a.v:2(int) a.rowid:3(int!null)
-#  │    ├── stats: [rows=1000]
-#  │    ├── cost: 1000.00
-#  │    └── keys: (3)
-#  └── projections [outer=(1,2)]
-#       ├── variable: a.u [type=int, outer=(1)]
-#       └── variable: a.v [type=int, outer=(2)]
+build
+SELECT * FROM t.a
+----
+project
+ ├── columns: u:1(int) v:2(int)
+ ├── stats: [rows=1000]
+ ├── cost: 1000.00
+ ├── scan a
+ │    ├── columns: a.u:1(int) a.v:2(int) a.rowid:3(int!null)
+ │    ├── stats: [rows=1000]
+ │    ├── cost: 1000.00
+ │    └── keys: (3)
+ └── projections [outer=(1,2)]
+      ├── variable: a.u [type=int, outer=(1)]
+      └── variable: a.v [type=int, outer=(2)]
 
-# exec-raw
-# CREATE STATISTICS u ON u FROM t.a
-# ----
+# Create a new table to avoid depending on the asynchronous stat cache
+# invalidation.
+exec-raw
+CREATE TABLE t.b (u INT, v INT, INDEX (u) STORING (v), INDEX (v) STORING (u));
+INSERT INTO t.b VALUES (1, 1), (1, 2), (1, 3), (1, 4), (2, 4), (2, 5), (2, 6), (2, 7)
+----
 
-# build
-# SELECT * FROM t.a
-# ----
-# project
-#  ├── columns: u:1(int) v:2(int)
-#  ├── stats: [rows=8]
-#  ├── cost: 8.00
-#  ├── scan a
-#  │    ├── columns: a.u:1(int) a.v:2(int) a.rowid:3(int!null)
-#  │    ├── stats: [rows=8]
-#  │    ├── cost: 8.00
-#  │    └── keys: (3)
-#  └── projections [outer=(1,2)]
-#       ├── variable: a.u [type=int, outer=(1)]
-#       └── variable: a.v [type=int, outer=(2)]
+exec-raw
+CREATE STATISTICS u ON u FROM t.b
+----
 
-# # TODO(radu): once we use cardinality, verify we choose the index with the
-# # smaller cardinality (for a WHERE condition on both columns).
+build
+SELECT * FROM t.b
+----
+project
+ ├── columns: u:1(int) v:2(int)
+ ├── stats: [rows=8, distinct(1)=2]
+ ├── cost: 8.00
+ ├── scan b
+ │    ├── columns: b.u:1(int) b.v:2(int) b.rowid:3(int!null)
+ │    ├── stats: [rows=8, distinct(1)=2]
+ │    ├── cost: 8.00
+ │    └── keys: (3)
+ └── projections [outer=(1,2)]
+      ├── variable: b.u [type=int, outer=(1)]
+      └── variable: b.v [type=int, outer=(2)]
+
+# TODO(radu): once we use cardinality, verify we choose the index with the
+# smaller cardinality (for a WHERE condition on both columns).


### PR DESCRIPTION
The stats test was flaky because we were depending on the asynchronous
stat cache invalidation to happen by the time we expect to see the
statistic. Fixing by using a different table.

Fixes #24773.

Release note: None