### PR TITLE
engine: remove implementation of the unused InRange function

### DIFF
--- a/c-deps/libroach/options.cc
+++ b/c-deps/libroach/options.cc
@@ -40,8 +40,6 @@ class DBPrefixExtractor : public rocksdb::SliceTransform {
   virtual rocksdb::Slice Transform(const rocksdb::Slice& src) const { return KeyPrefix(src); }
 
   virtual bool InDomain(const rocksdb::Slice& src) const { return true; }
-
-  virtual bool InRange(const rocksdb::Slice& dst) const { return Transform(dst) == dst; }
 };
 
 class DBLogger : public rocksdb::Logger {


### PR DESCRIPTION
rocksdb/slice_transform.h has:

```
// This is currently not used and remains here for backward compatibility.
virtual bool InRange(const Slice& dst) const { return false; }
```

So we should remove the implementation of InRange function.

Fixes #24822

Release note: None