### PR TITLE
opt: add execbuilder stats test

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/stats
+++ b/pkg/sql/opt/exec/execbuilder/testdata/stats
@@ -32,7 +32,8 @@ INSERT INTO t.b VALUES (1, 1), (1, 2), (1, 3), (1, 4), (2, 4), (2, 5), (2, 6), (
 ----
 
 exec-raw
-CREATE STATISTICS u ON u FROM t.b
+CREATE STATISTICS u ON u FROM t.b;
+CREATE STATISTICS v ON v FROM t.b
 ----
 
 build
@@ -40,16 +41,40 @@ SELECT * FROM t.b
 ----
 project
  ├── columns: u:1(int) v:2(int)
- ├── stats: [rows=8, distinct(1)=2]
+ ├── stats: [rows=8, distinct(1)=2, distinct(2)=7]
  ├── cost: 8.00
  ├── scan b
  │    ├── columns: b.u:1(int) b.v:2(int) b.rowid:3(int!null)
- │    ├── stats: [rows=8, distinct(1)=2]
+ │    ├── stats: [rows=8, distinct(1)=2, distinct(2)=7]
  │    ├── cost: 8.00
  │    └── keys: (3)
  └── projections [outer=(1,2)]
       ├── variable: b.u [type=int, outer=(1)]
       └── variable: b.v [type=int, outer=(2)]
 
-# TODO(radu): once we use cardinality, verify we choose the index with the
-# smaller cardinality (for a WHERE condition on both columns).
+# Verify we scan index v which has the more selective constraint.
+opt
+SELECT * FROM t.b WHERE u = 1 AND v = 1
+----
+select
+ ├── columns: u:1(int) v:2(int)
+ ├── stats: [rows=1, distinct(1)=1, distinct(2)=1]
+ ├── cost: 1.10
+ ├── scan b@b_v_idx
+ │    ├── columns: b.u:1(int) b.v:2(int)
+ │    ├── constraint: /2/3: [/1 - /1]
+ │    ├── stats: [rows=1, distinct(1)=1, distinct(2)=1]
+ │    └── cost: 1.00
+ └── filters [type=bool, outer=(1), constraints=(/1: [/1 - /1]; tight)]
+      └── eq [type=bool, outer=(1), constraints=(/1: [/1 - /1]; tight)]
+           ├── variable: b.u [type=int, outer=(1)]
+           └── const: 1 [type=int]
+
+exec-explain
+SELECT * FROM t.b WHERE u = 1 AND v = 1
+----
+filter     0  filter  ·       ·          (u, v)  ·
+ │         0  ·       filter  u = 1      ·       ·
+ └── scan  1  scan    ·       ·          (u, v)  ·
+·          1  ·       table   b@b_v_idx  ·       ·
+·          1  ·       spans   /1-/2      ·       ·


### PR DESCRIPTION
Adding an execbuilder test that uses the new stat calculations: we are
able to choose the index with the more selective constraint (based on
cardinality).

Release note: None