### PR TITLE
backport-2.0: sql: stop using txn.OrigTimestamp to reset TableCollection

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/prepare
+++ b/pkg/sql/logictest/testdata/logic_test/prepare
@@ -416,3 +416,19 @@ PREPARE x21701c AS SELECT * FROM kv WHERE k IS NOT DISTINCT FROM $1
 query II
 EXECUTE x21701c(NULL)
 ----
+
+# Test that a PREPARE statement after a CREATE TABLE in the same TRANSACTION
+# doesn't hang.
+subtest 24578
+
+statement ok
+BEGIN TRANSACTION
+
+statement ok
+create table bar (id integer)
+
+statement ok
+PREPARE forbar AS insert into bar (id) VALUES (1)
+
+statement ok
+COMMIT TRANSACTION


### PR DESCRIPTION
Backport 1/1 commits from #23816.

/cc @cockroachdb/release

---

sql: Stop using txn.OrigTimestamp to reset TableCollection
We use the transaction OrigTimestamp to figure out if a
transaction is being retried, triggering a reset of
TableCollection. This logic would get triggered when
running PREPARE within a transaction, because PREPARE
uses it's own transaction and thus has a different
OrigTimestamp.

Removed this logic because transaction retries trigger
resetting the TableCollection in the new conn-executor code.

fixes #24578

Release note sql: fix PREPARE hanging when run in the same transaction
as a CREATE TABLE

possibly  related #23718 