### PR TITLE
distsql: fix hashjoiner benchmark

### DIFF
--- a/pkg/sql/distsqlrun/hashjoiner_test.go
+++ b/pkg/sql/distsqlrun/hashjoiner_test.go
@@ -1425,6 +1425,7 @@ func BenchmarkHashJoiner(b *testing.B) {
 
 	const numCols = 1
 	for _, spill := range []bool{true, false} {
+		flowCtx.testingKnobs.MemoryLimitBytes = 0
 		if spill {
 			flowCtx.testingKnobs.MemoryLimitBytes = 1
 		}


### PR DESCRIPTION
MemoryLimitBytes wouldn't be set to 0 on subsequent iterations so we
would always spill to disk.

Release note: None