### PR TITLE
backport-2.0: acceptance: fix buglet in gossip restart test

### DIFF
--- a/pkg/acceptance/gossip_peerings_test.go
+++ b/pkg/acceptance/gossip_peerings_test.go
@@ -167,6 +167,9 @@ func testClusterConnectedAndFunctional(ctx context.Context, t *testing.T, c clus
 			t.Fatal(err)
 		}
 		if i == 0 {
+			if _, err := db.Exec("DROP DATABASE IF EXISTS test"); err != nil {
+				t.Fatal(err)
+			}
 			if _, err := db.Exec("CREATE DATABASE test"); err != nil {
 				t.Fatal(err)
 			}


### PR DESCRIPTION
Backport 1/1 commits from #24862.

/cc @cockroachdb/release

---

The test was calling a method that would try to create a database
multiple times. Drop the database if it exists in that method to allow
that.

Fixes #24814.
Fixes #24858.

Release note: None
