### PR TITLE
sqlbase: Add nil BatchResponse check to kvfetcher

### DIFF
--- a/pkg/sql/sqlbase/kvfetcher.go
+++ b/pkg/sql/sqlbase/kvfetcher.go
@@ -300,7 +300,11 @@ func (f *txnKVFetcher) fetch(ctx context.Context) error {
 	if err != nil {
 		return err.GoError()
 	}
-	f.responses = br.Responses
+	if br != nil {
+		f.responses = br.Responses
+	} else {
+		f.responses = nil
+	}
 
 	// Set end to true until disproved.
 	f.fetchEnd = true


### PR DESCRIPTION
A nil BatchResponse from txn.Send() is a legitimate value which
indicates that the batches are empty. Handle this case to avoid a nil
pointer dereference.

Release note: None