### PR TITLE
sql: Add lpad and rpad built-in functions

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -627,6 +627,10 @@ Compatible elements: hour, minute, second, millisecond, microsecond.</p>
 </span></td></tr>
 <tr><td><code>lower(val: <a href="string.html">string</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Converts all characters in <code>val</code> to their lower-case equivalents.</p>
 </span></td></tr>
+<tr><td><code>lpad(string: <a href="string.html">string</a>, length: <a href="int.html">int</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Pads <code>string</code> to <code>length</code> by adding ’ ’ to the left of <code>string</code>.If <code>string</code> is longer than <code>length</code> it is truncated.</p>
+</span></td></tr>
+<tr><td><code>lpad(string: <a href="string.html">string</a>, length: <a href="int.html">int</a>, fill: <a href="string.html">string</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Pads <code>string</code> by adding <code>fill</code> to the left of <code>string</code> to make it <code>length</code>. If <code>string</code> is longer than <code>length</code> it is truncated.</p>
+</span></td></tr>
 <tr><td><code>ltrim(input: <a href="string.html">string</a>, trim_chars: <a href="string.html">string</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Removes any characters included in <code>trim_chars</code> from the beginning (left-hand side) of <code>input</code> (applies recursively).</p>
 <p>For example, <code>ltrim('doggie', 'od')</code> returns <code>ggie</code>.</p>
 </span></td></tr>
@@ -727,6 +731,10 @@ Compatible elements: hour, minute, second, millisecond, microsecond.</p>
 <tr><td><code>right(input: <a href="bytes.html">bytes</a>, return_set: <a href="int.html">int</a>) &rarr; <a href="bytes.html">bytes</a></code></td><td><span class="funcdesc"><p>Returns the last <code>return_set</code> bytes from <code>input</code>.</p>
 </span></td></tr>
 <tr><td><code>right(input: <a href="string.html">string</a>, return_set: <a href="int.html">int</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Returns the last <code>return_set</code> characters from <code>input</code>.</p>
+</span></td></tr>
+<tr><td><code>rpad(string: <a href="string.html">string</a>, length: <a href="int.html">int</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Pads <code>string</code> to <code>length</code> by adding ’ ’ to the right of string. If <code>string</code> is longer than <code>length</code> it is truncated.</p>
+</span></td></tr>
+<tr><td><code>rpad(string: <a href="string.html">string</a>, length: <a href="int.html">int</a>, fill: <a href="string.html">string</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Pads <code>string</code> to <code>length</code> by adding <code>fill</code> to the right of <code>string</code>. If <code>string</code> is longer than <code>length</code> it is truncated.</p>
 </span></td></tr>
 <tr><td><code>rtrim(input: <a href="string.html">string</a>, trim_chars: <a href="string.html">string</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Removes any characters included in <code>trim_chars</code> from the end (right-hand side) of <code>input</code> (applies recursively).</p>
 <p>For example, <code>rtrim('doggie', 'ei')</code> returns <code>dogg</code>.</p>

--- a/pkg/sql/logictest/testdata/logic_test/builtin_function
+++ b/pkg/sql/logictest/testdata/logic_test/builtin_function
@@ -1682,3 +1682,122 @@ query TTTT
 SELECT quote_ident('foo'), quote_ident('select'), quote_ident('int8'), quote_ident('numeric')
 ----
 foo  "select"  int8  "numeric"
+
+# lpad tests
+
+query T
+SELECT lpad('abc', 1, 'xy')
+----
+a
+
+query T
+SELECT lpad('abc', 2, 'xy')
+----
+ab
+
+query T
+SELECT lpad('abc', 3, 'xy')
+----
+abc
+
+query T
+SELECT lpad('abc', 5, 'xy')
+----
+xyabc
+
+query T
+SELECT lpad('abc', 6, 'xy')
+----
+xyxabc
+
+query T
+SELECT lpad('abc', 7, 'xy')
+----
+xyxyabc
+
+query T
+SELECT lpad('abc', 1)
+----
+a
+
+query T
+SELECT lpad('abc', 2)
+----
+ab
+
+query T
+SELECT lpad('abc', 3)
+----
+abc
+
+query T
+SELECT lpad('abc', 5)
+----
+  abc
+
+query T
+SELECT lpad('Hello, 世界', 9)
+----
+Hello, 世界
+
+query T
+SELECT lpad('Hello, 世界', 10)
+----
+ Hello, 世界
+
+query T
+SELECT lpad('Hello', 8, '世界')
+----
+世界世Hello
+
+# rpad tests
+
+query T
+SELECT rpad('abc', 1, 'xy')
+----
+a
+
+query T
+SELECT rpad('abc', 2, 'xy')
+----
+ab
+
+query T
+SELECT rpad('abc', 3, 'xy')
+----
+abc
+
+query T
+SELECT rpad('abc', 5, 'xy')
+----
+abcxy
+
+query T
+SELECT rpad('abc', 6, 'xy')
+----
+abcxyx
+
+query T
+SELECT rpad('abc', 7, 'xy')
+----
+abcxyxy
+
+query T
+SELECT rpad('abc', 1)
+----
+a
+
+query T
+SELECT rpad('abc', 2)
+----
+ab
+
+query T
+SELECT rpad('abc', 3)
+----
+abc
+
+query T
+SELECT rpad('abc', 5)
+----
+abc  

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -2446,6 +2446,61 @@ CockroachDB supports the following flags:
 				"Incorrect use can severely impact performance.",
 		},
 	},
+
+	"lpad": {
+		tree.Builtin{
+			Types:      tree.ArgTypes{{"string", types.String}, {"length", types.Int}},
+			ReturnType: tree.FixedReturnType(types.String),
+			Fn: func(_ *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
+				s := string(tree.MustBeDString(args[0]))
+				length := int(tree.MustBeDInt(args[1]))
+				return tree.NewDString(lpad(s, length, " ")), nil
+			},
+			Category: categoryString,
+			Info: "Pads `string` to `length` by adding ' ' to the left of `string`." +
+				"If `string` is longer than `length` it is truncated.",
+		},
+		tree.Builtin{
+			Types:      tree.ArgTypes{{"string", types.String}, {"length", types.Int}, {"fill", types.String}},
+			ReturnType: tree.FixedReturnType(types.String),
+			Fn: func(_ *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
+				s := string(tree.MustBeDString(args[0]))
+				length := int(tree.MustBeDInt(args[1]))
+				fill := string(tree.MustBeDString(args[2]))
+				return tree.NewDString(lpad(s, length, fill)), nil
+			},
+			Category: categoryString,
+			Info: "Pads `string` by adding `fill` to the left of `string` to make it `length`. " +
+				"If `string` is longer than `length` it is truncated.",
+		},
+	},
+	"rpad": {
+		tree.Builtin{
+			Types:      tree.ArgTypes{{"string", types.String}, {"length", types.Int}},
+			ReturnType: tree.FixedReturnType(types.String),
+			Fn: func(_ *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
+				s := string(tree.MustBeDString(args[0]))
+				length := int(tree.MustBeDInt(args[1]))
+				return tree.NewDString(rpad(s, length, " ")), nil
+			},
+			Category: categoryString,
+			Info: "Pads `string` to `length` by adding ' ' to the right of string. " +
+				"If `string` is longer than `length` it is truncated.",
+		},
+		tree.Builtin{
+			Types:      tree.ArgTypes{{"string", types.String}, {"length", types.Int}, {"fill", types.String}},
+			ReturnType: tree.FixedReturnType(types.String),
+			Fn: func(_ *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
+				s := string(tree.MustBeDString(args[0]))
+				length := int(tree.MustBeDInt(args[1]))
+				fill := string(tree.MustBeDString(args[2]))
+				return tree.NewDString(rpad(s, length, fill)), nil
+			},
+			Category: categoryString,
+			Info: "Pads `string` to `length` by adding `fill` to the right of `string`. " +
+				"If `string` is longer than `length` it is truncated.",
+		},
+	},
 }
 
 var substringImpls = []tree.Builtin{
@@ -3742,4 +3797,48 @@ func asJSONObjectKey(d tree.Datum) (string, error) {
 	default:
 		return "", pgerror.NewErrorf(pgerror.CodeInternalError, "unexpected type %T for asJSONObjectKey", d)
 	}
+}
+
+func lpad(s string, length int, fill string) string {
+	slen := utf8.RuneCountInString(s)
+	if length == slen {
+		return s
+	}
+
+	// If string is longer then length truncate it to the requested number
+	// of characters.
+	if length < slen {
+		return string([]rune(s)[:length])
+	}
+
+	var buf strings.Builder
+	fillRunes := []rune(fill)
+	for i := 0; i < length-slen; i++ {
+		buf.WriteRune(fillRunes[i%len(fillRunes)])
+	}
+	buf.WriteString(s)
+
+	return buf.String()
+}
+
+func rpad(s string, length int, fill string) string {
+	slen := utf8.RuneCountInString(s)
+	if length == slen {
+		return s
+	}
+
+	// If string is longer then length truncate it to the requested number
+	// of characters.
+	if length < slen {
+		return string([]rune(s)[:length])
+	}
+
+	var buf strings.Builder
+	buf.WriteString(s)
+	fillRunes := []rune(fill)
+	for i := 0; i < length-slen; i++ {
+		buf.WriteRune(fillRunes[i%len(fillRunes)])
+	}
+
+	return buf.String()
 }


### PR DESCRIPTION
The implementation handles multibyte characters correctly.

It's likely that this could be optimized for the more common
case where string and fill do not contain multibyte characters.

Fixes #24456

Release note (sql change): Added support for lpad and rpad string functions.