### PR TITLE
storage: change sideloadStorage.PutIfNotExist to Put

### DIFF
--- a/pkg/storage/helpers_test.go
+++ b/pkg/storage/helpers_test.go
@@ -382,7 +382,7 @@ const (
 func (r *Replica) PutBogusSideloadedData() {
 	r.raftMu.Lock()
 	defer r.raftMu.Unlock()
-	if err := r.raftMu.sideloaded.PutIfNotExists(context.Background(), sideloadBogusIndex, sideloadBogusTerm, []byte("bogus")); err != nil {
+	if err := r.raftMu.sideloaded.Put(context.Background(), sideloadBogusIndex, sideloadBogusTerm, []byte("bogus")); err != nil {
 		panic(err)
 	}
 }

--- a/pkg/storage/replica_sideload.go
+++ b/pkg/storage/replica_sideload.go
@@ -34,8 +34,8 @@ type sideloadStorage interface {
 	// exist.
 	Dir() string
 	// Writes the given contents to the file specified by the given index and
-	// term. Does not perform the write if the file exists.
-	PutIfNotExists(_ context.Context, index, term uint64, contents []byte) error
+	// term. Overwrites the file if it already exists.
+	Put(_ context.Context, index, term uint64, contents []byte) error
 	// Load the file at the given index and term. Return errSideloadedFileNotFound when no
 	// such file is present.
 	Get(_ context.Context, index, term uint64) ([]byte, error)
@@ -151,7 +151,7 @@ func maybeSideloadEntriesImpl(
 
 			ent.Data = encodeRaftCommandV2(cmdID, data)
 			log.Eventf(ctx, "writing payload at index=%d term=%d", ent.Index, ent.Term)
-			if err = sideloaded.PutIfNotExists(ctx, ent.Index, ent.Term, dataToSideload); err != nil {
+			if err = sideloaded.Put(ctx, ent.Index, ent.Term, dataToSideload); err != nil {
 				return nil, 0, err
 			}
 			sideloadedEntriesSize += int64(len(dataToSideload))

--- a/pkg/storage/replica_sideload_disk.go
+++ b/pkg/storage/replica_sideload_disk.go
@@ -68,18 +68,10 @@ func (ss *diskSideloadStorage) Dir() string {
 	return ss.dir
 }
 
-func (ss *diskSideloadStorage) PutIfNotExists(
-	ctx context.Context, index, term uint64, contents []byte,
-) error {
+func (ss *diskSideloadStorage) Put(ctx context.Context, index, term uint64, contents []byte) error {
 	filename := ss.filename(ctx, index, term)
-	if _, err := os.Stat(filename); err == nil {
-		// File exists.
-		return nil
-	} else if !os.IsNotExist(err) {
-		return err
-	}
-	// File does not exist yet. There's a chance the whole path is missing (for
-	// example after Clear()), in which case handle that transparently.
+	// There's a chance the whole path is missing (for example after Clear()),
+	// in which case handle that transparently.
 	for {
 		// Use 0644 since that's what RocksDB uses:
 		// https://github.com/facebook/rocksdb/blob/56656e12d67d8a63f1e4c4214da9feeec2bd442b/env/env_posix.cc#L171

--- a/pkg/storage/replica_sideload_inmem.go
+++ b/pkg/storage/replica_sideload_inmem.go
@@ -61,13 +61,8 @@ func (ss *inMemSideloadStorage) Dir() string {
 	panic("unsupported")
 }
 
-func (ss *inMemSideloadStorage) PutIfNotExists(
-	_ context.Context, index, term uint64, contents []byte,
-) error {
+func (ss *inMemSideloadStorage) Put(_ context.Context, index, term uint64, contents []byte) error {
 	key := ss.key(index, term)
-	if _, ok := ss.m[key]; ok {
-		return nil
-	}
 	ss.m[key] = contents
 	return nil
 }


### PR DESCRIPTION
Fixes #24025.

This commit changes the semantics of `sideloadStorage.PutIfNotExist` to
overwrite the file if it already exists instead of no-oping. In doing
so, it changes the methods name to `sideloadStorage.Put`. This ensures
that if a call to `PutIfNotExist` fails midway through, a future retry
will retry the file write instead of noticing that a file exists and
short-circuiting.

I confirmed that this fixes #24025 by putting a TPC-C 1k restore under heavy
chaos and setting `setting kv.bulk_sst.sync_size` to 16kb. Without this change,
the crash from #24025 consistently occurred after only a few minutes. With
this change, I never saw the crash and the restores always eventually succeeded.

Release note: None