### PR TITLE
execbuilder: add errors to scalar build functions

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/builder.go
+++ b/pkg/sql/opt/exec/execbuilder/builder.go
@@ -49,14 +49,12 @@ func (b *Builder) build(ev memo.ExprView) (exec.Node, error) {
 	if err != nil {
 		return nil, err
 	}
-	// TODO(radu): plan.outputCols will be used to apply a final projection.
-	// TODO(radu): check physical props for final presentation.
 	return plan.root, err
 }
 
 // BuildScalar converts a scalar expression to a TypedExpr. Variables are mapped
 // according to the IndexedVarHelper.
-func (b *Builder) BuildScalar(ivh *tree.IndexedVarHelper) tree.TypedExpr {
+func (b *Builder) BuildScalar(ivh *tree.IndexedVarHelper) (tree.TypedExpr, error) {
 	ctx := buildScalarCtx{ivh: *ivh}
 	for i := 0; i < ivh.NumVars(); i++ {
 		ctx.ivarMap.Set(i+1, i)

--- a/pkg/sql/opt/idxconstraint/index_constraints_test.go
+++ b/pkg/sql/opt/idxconstraint/index_constraints_test.go
@@ -161,7 +161,10 @@ func TestIndexConstraints(t *testing.T) {
 				remEv := memo.MakeNormExprView(f.Memo(), remainingFilter)
 				if remEv.Operator() != opt.TrueOp {
 					execBld := execbuilder.New(nil /* execFactory */, remEv)
-					expr := execBld.BuildScalar(&iVarHelper)
+					expr, err := execBld.BuildScalar(&iVarHelper)
+					if err != nil {
+						return fmt.Sprintf("error: %v\n", err)
+					}
 					fmt.Fprintf(&buf, "Remaining filter: %s\n", expr)
 				}
 				return buf.String()

--- a/pkg/sql/opt_index_selection.go
+++ b/pkg/sql/opt_index_selection.go
@@ -250,7 +250,10 @@ func (p *planner) selectIndex(
 			s.filter = nil
 		} else {
 			execBld := execbuilder.New(nil /* execFactory */, remEv)
-			s.filter = execBld.BuildScalar(&s.filterVars)
+			s.filter, err = execBld.BuildScalar(&s.filterVars)
+			if err != nil {
+				return nil, err
+			}
 		}
 	}
 	s.filterVars.Rebind(s.filter, true, false)


### PR DESCRIPTION
The scalar build functions don't return errors. This made the code
simple, but we had to resort to panics in a few places. Now the
surface area of errors is about to increase significantly because of
subqueries.

Changing the functions to return errors, consistent with the
relational build code.

Release note: None

---

This is just something I ran across while working on subqueries; I decided to split it off since it's pretty noisy diff-wise.