### PR TITLE
distsql: eagerly realize that processor limits have been satisfied

### DIFF
--- a/pkg/sql/distsqlrun/interleaved_reader_joiner.go
+++ b/pkg/sql/distsqlrun/interleaved_reader_joiner.go
@@ -260,7 +260,8 @@ func (irj *interleavedReaderJoiner) Run(ctx context.Context, wg *sync.WaitGroup)
 		return
 	}
 
-	for {
+	ok := true
+	for ok {
 		row, desc, index, err := irj.fetcher.NextRow(ctx)
 		if err != nil || row == nil {
 			if err != nil {
@@ -291,11 +292,10 @@ func (irj *interleavedReaderJoiner) Run(ctx context.Context, wg *sync.WaitGroup)
 		}
 
 		// We post-process the intermediate row from either table.
-		tableRow, consumerStatus, err := tInfo.post.ProcessRow(ctx, row)
-		if err != nil || consumerStatus != NeedMoreRows {
-			if err != nil {
-				irj.out.output.Push(nil /* row */, &ProducerMetadata{Err: err})
-			}
+		var tableRow sqlbase.EncDatumRow
+		tableRow, ok, err = tInfo.post.ProcessRow(ctx, row)
+		if err != nil {
+			irj.out.output.Push(nil /* row */, &ProducerMetadata{Err: err})
 			break
 		}
 
@@ -360,7 +360,7 @@ func (irj *interleavedReaderJoiner) Run(ctx context.Context, wg *sync.WaitGroup)
 				break
 			}
 			if renderedRow != nil {
-				consumerStatus, err = irj.out.EmitRow(ctx, renderedRow)
+				consumerStatus, err := irj.out.EmitRow(ctx, renderedRow)
 				if err != nil || consumerStatus != NeedMoreRows {
 					if err != nil {
 						irj.out.output.Push(nil /* row */, &ProducerMetadata{Err: err})

--- a/pkg/sql/distsqlrun/tablereader.go
+++ b/pkg/sql/distsqlrun/tablereader.go
@@ -242,14 +242,6 @@ func (tr *tableReader) Start(ctx context.Context) context.Context {
 // Next is part of the RowSource interface.
 func (tr *tableReader) Next() (sqlbase.EncDatumRow, *ProducerMetadata) {
 	for tr.state == stateRunning {
-		// Check whether calling input.Next() is necessary. Nobody else does this,
-		// but in the case of the TableReader calling Next() on a RowFetcher and one
-		// too many times and causing it run do another Scan is real bad.
-		if tr.out.LimitSatisfied() {
-			tr.moveToDraining(nil /* err */)
-			break
-		}
-
 		row, meta := tr.input.Next()
 
 		if meta != nil {


### PR DESCRIPTION
Processors commonly use ProcOutputHelper.ProcessRow() to do filtering
and projections on an output row. That method also deals with enforcing
the processor's limit. Before this patch, it was unable to tell the
processor that, at the same time, an output row has been produced and
the limit has been reached. Instead, a processor would only find out
about the fact that the limit has been reached when trying to process
the next row. Except that, in order to get to the point where it'd
process a next row, a processor would generally need to consume more
from its inputs - causing them to do an arbitrary amount of extra work.

The most egregious manifestation of this problem was seen in #24304 -
the tableReader was configured with the expected limit, which was
plumbed down to the first scan. Trying to get one extra row meant doing
a whole other scan. The tableReader's problem in particular was
addressed in #24790 through a bit of a hack.

This patch removes said hack and solves the general problem by making
ProcessRow() return both a row and a drain signal at the same time.
A lot of prep work for this was done in #24651, which made it so that
there's very few callers to ProcOutputHelper.ProcessRow(). The majority
of callers go through processorBase.processorRowHelper(), which absorbs
the contract change.

A proof for this change is the test added in #24790 asserting that the
tableReader doesn't do the extra scan, which now works with no
tableReader specific code.

Release note: None