### PR TITLE
libroach: support atomic multi-SST ingestion

### DIFF
--- a/c-deps/libroach/include/libroach.h
+++ b/c-deps/libroach/include/libroach.h
@@ -324,14 +324,14 @@ DBSSTable* DBGetSSTables(DBEngine* db, int* n);
 // proto.
 DBString DBGetUserProperties(DBEngine* db);
 
-// Bulk adds the file at the given path to a database. See the RocksDB
-// documentation on `IngestExternalFile` for the various restrictions on what
-// can be added. If move_file is true, the file will be moved instead of copied.
-// If allow_file_modification is false, RocksDB will return an error if it would
-// have tried to modify the file's sequence number rather than editing the file
-// in place.
-DBStatus DBIngestExternalFile(DBEngine* db, DBSlice path, bool move_file,
-                              bool allow_file_modification);
+// Bulk adds the files at the given paths to a database, all atomically. See the
+// RocksDB documentation on `IngestExternalFile` for the various restrictions on
+// what can be added. If move_files is true, the files will be moved instead of
+// copied. If allow_file_modifications is false, RocksDB will return an error if
+// it would have tried to modify any of the files' sequence numbers rather than
+// editing the files in place.
+DBStatus DBIngestExternalFiles(DBEngine* db, char** paths, size_t len, bool move_files,
+                               bool allow_file_modifications);
 
 typedef struct DBSstFileWriter DBSstFileWriter;
 

--- a/pkg/ccl/storageccl/add_sstable_test.go
+++ b/pkg/ccl/storageccl/add_sstable_test.go
@@ -368,7 +368,7 @@ func TestAddSSTableMVCCStats(t *testing.T) {
 		if err := e.WriteFile(filename, sstBytes); err != nil {
 			t.Fatalf("%+v", err)
 		}
-		if err := e.IngestExternalFile(ctx, filename, true /* modify the sst */); err != nil {
+		if err := e.IngestExternalFiles(ctx, []string{filename}, true /* modify the sst */); err != nil {
 			t.Fatalf("%+v", err)
 		}
 

--- a/pkg/storage/engine/engine.go
+++ b/pkg/storage/engine/engine.go
@@ -270,12 +270,12 @@ type Engine interface {
 	// by invoking Close(). Note that snapshots must not be used after the
 	// original engine has been stopped.
 	NewSnapshot() Reader
-	// IngestExternalFile links a file into the RocksDB log-structured
-	// merge-tree. May modify the file (including the underlying file in
-	// the case of hard-links) if allowFileModification is passed as
-	// well. See additional comments in db.cc's IngestExternalFile
-	// explaining modification behavior.
-	IngestExternalFile(ctx context.Context, path string, allowFileModification bool) error
+	// IngestExternalFiles atomically links a slice of files into the RocksDB
+	// log-structured merge-tree. May modify the files (including the underlying
+	// file in the case of hard-links) if allowFileModifications is passed as
+	// well. See additional comments in db.cc's IngestExternalFile explaining
+	// modification behavior.
+	IngestExternalFiles(ctx context.Context, paths []string, allowFileModifications bool) error
 	// ApproximateDiskBytes returns an approximation of the on-disk size for the given key span.
 	ApproximateDiskBytes(from, to roachpb.Key) (uint64, error)
 	// CompactRange ensures that the specified range of key value pairs is

--- a/pkg/storage/replica_proposal.go
+++ b/pkg/storage/replica_proposal.go
@@ -367,7 +367,7 @@ func addSSTablePreApply(
 			// pass it the path in the sideload store as it deletes the passed path on
 			// success.
 			if linkErr := os.Link(path, ingestPath); linkErr == nil {
-				ingestErr := eng.IngestExternalFile(ctx, ingestPath, noModify)
+				ingestErr := eng.IngestExternalFiles(ctx, []string{ingestPath}, noModify)
 				if ingestErr == nil {
 					// Adding without modification succeeded, no copy necessary.
 					log.Eventf(ctx, "ingested SSTable at index %d, term %d: %s", index, term, ingestPath)
@@ -408,7 +408,7 @@ func addSSTablePreApply(
 		copied = true
 	}
 
-	if err := eng.IngestExternalFile(ctx, path, modify); err != nil {
+	if err := eng.IngestExternalFiles(ctx, []string{path}, modify); err != nil {
 		log.Fatalf(ctx, "while ingesting %s: %s", path, err)
 	}
 	log.Eventf(ctx, "ingested SSTable at index %d, term %d: %s", index, term, path)


### PR DESCRIPTION
This is needed by #16954.

This change adds support for passing multiple file paths to
`rocksdb::DB::IngestExternalFile`. This is required by #16954
because passing all of the paths together instead of one-by-one
allows them to be ingested atomically.

Release note: None