### PR TITLE
storage: Simplify raft automatic campaigning after PreVote

### DIFF
--- a/pkg/server/node.go
+++ b/pkg/server/node.go
@@ -412,14 +412,6 @@ func (n *Node) start(
 		return err
 	}
 
-	if n.initialBoot {
-		// The cluster was just bootstrapped by this node, explicitly notify the
-		// stores that they were bootstrapped.
-		for _, s := range stores {
-			s.NotifyBootstrapped()
-		}
-	}
-
 	if err := n.startStores(ctx, stores, n.stopper); err != nil {
 		return err
 	}

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -3911,28 +3911,11 @@ func (r *Replica) tick() (bool, error) {
 	if r.mu.quiescent {
 		// While a replica is quiesced we still advance its logical clock.
 		//
-		// When CheckQuorum is used (currently when !enablePreVote), this is
-		// necessary to avoid a scenario where the leader quiesces and a follower
-		// does not. The follower calls an election but the election fails because
-		// the leader and other follower believe that no time in the current term
-		// has passed. The Raft group is then in a state where one member has a
-		// term that is advanced which will then cause subsequent heartbeats from
-		// the existing leader to be rejected in a way that the leader will step
-		// down. This situation is caused by an interaction between quiescence and
-		// the Raft CheckQuorum feature which relies on the logical clock ticking
-		// at roughly the same rate on all members of the group.
-		//
-		// By ticking the logical clock (incrementing an integer) we avoid this
-		// situation. If one of the followers does not quiesce it will call an
-		// election but the election will succeed. Note that while we expect such
-		// elections from quiesced followers to be extremely rare, it is very
-		// difficult to completely eliminate them so we want to minimize the
-		// disruption when they do occur.
-		//
-		// Without CheckQuorum, the call to TickQuiesced is less critical,
-		// but still improves our responsiveness to node failures by
-		// priming the replica to start an election immediately upon
-		// unquiescing, instead of waiting for a full election timeout.
+		// Since we no longer use CheckQuorum, the call to TickQuiesced is
+		// less critical, but still improves our responsiveness to node
+		// failures by priming the replica to start an election
+		// immediately upon unquiescing, instead of waiting for a full
+		// election timeout.
 		//
 		// Enabling TickQuiesced slightly increases the rate of contested
 		// elections. Deployments with high inter-node latency and skewed

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -541,13 +541,6 @@ func (r *Replica) withRaftGroupLocked(
 		return nil
 	}
 
-	if shouldCampaignOnCreation {
-		// Special handling of idle replicas: we campaign their Raft group upon
-		// creation if we gossiped our store descriptor more than the election
-		// timeout in the past.
-		shouldCampaignOnCreation = (r.mu.internalRaftGroup == nil) && r.store.canCampaignIdleReplica()
-	}
-
 	ctx := r.AnnotateCtx(context.TODO())
 
 	if r.mu.internalRaftGroup == nil {

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -101,7 +101,7 @@ var storeSchedulerConcurrency = envutil.EnvOrDefaultInt(
 	"COCKROACH_SCHEDULER_CONCURRENCY", 8*runtime.NumCPU())
 
 var enableTickQuiesced = envutil.EnvOrDefaultBool(
-	"COCKROACH_ENABLE_TICK_QUIESCED", true)
+	"COCKROACH_ENABLE_TICK_QUIESCED", false)
 
 // bulkIOWriteLimit is defined here because it is used by BulkIOWriteLimiter.
 var bulkIOWriteLimit = settings.RegisterByteSizeSetting(

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -100,9 +100,6 @@ var changeTypeInternalToRaft = map[roachpb.ReplicaChangeType]raftpb.ConfChangeTy
 var storeSchedulerConcurrency = envutil.EnvOrDefaultInt(
 	"COCKROACH_SCHEDULER_CONCURRENCY", 8*runtime.NumCPU())
 
-var enablePreVote = envutil.EnvOrDefaultBool(
-	"COCKROACH_ENABLE_PREVOTE", true)
-
 var enableTickQuiesced = envutil.EnvOrDefaultBool(
 	"COCKROACH_ENABLE_TICK_QUIESCED", true)
 
@@ -175,12 +172,7 @@ func newRaftConfig(
 		Storage:       strg,
 		Logger:        logger,
 
-		// TODO(bdarnell): PreVote and CheckQuorum are two ways of
-		// achieving the same thing. PreVote is more compatible with
-		// quiesced ranges, so we want to switch to it once we've worked
-		// out the bugs.
-		PreVote:     enablePreVote,
-		CheckQuorum: !enablePreVote,
+		PreVote: true,
 
 		// MaxSizePerMsg controls how many Raft log entries the leader will send to
 		// followers in a single MsgApp.

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -397,11 +397,6 @@ type Store struct {
 	nodeDesc     *roachpb.NodeDescriptor
 	initComplete sync.WaitGroup // Signaled by async init tasks
 
-	idleReplicaElectionTime struct {
-		syncutil.Mutex
-		at time.Time
-	}
-
 	// Semaphore to limit concurrent non-empty snapshot application and replica
 	// data destruction.
 	snapshotApplySem chan struct{}
@@ -1543,36 +1538,7 @@ func (s *Store) GossipStore(ctx context.Context) error {
 	// Unique gossip key per store.
 	gossipStoreKey := gossip.MakeStoreKey(storeDesc.StoreID)
 	// Gossip store descriptor.
-	if err := s.cfg.Gossip.AddInfoProto(gossipStoreKey, storeDesc, gossip.StoreTTL); err != nil {
-		return err
-	}
-	// Once we have gossiped the store descriptor the first time, other nodes
-	// will know that this node has restarted and will start sending Raft
-	// heartbeats for active ranges. We compute the time in the future where a
-	// replica on this store which receives a command for an idle range can
-	// campaign the associated Raft group immediately instead of waiting for the
-	// normal Raft election timeout.
-	//
-	// Note that computing this timestamp here is conservative. We really care
-	// that the node descriptor has been gossiped as that is how remote nodes
-	// locate this one to send Raft messages. The initialization sequence is:
-	//   1. gossip node descriptor
-	//   2. wait for gossip to be connected
-	//   3. gossip store descriptors (where we're at here)
-	s.idleReplicaElectionTime.Lock()
-	if s.idleReplicaElectionTime.at == (time.Time{}) {
-		// Raft uses a randomized election timeout in the range
-		// [electionTimeout,2*electionTimeout]. Using the lower bound here means
-		// that elections are somewhat more likely to be contested (assuming
-		// traffic is distributed evenly across a cluster that is restarted
-		// simultaneously). That's OK; it just adds a network round trip or two to
-		// the process since a contested election just restarts the clock to where
-		// it would have been anyway if we weren't doing idle replica campaigning.
-		electionTimeout := s.cfg.RaftTickInterval * time.Duration(s.cfg.RaftElectionTimeoutTicks)
-		s.idleReplicaElectionTime.at = s.Clock().PhysicalTime().Add(electionTimeout)
-	}
-	s.idleReplicaElectionTime.Unlock()
-	return nil
+	return s.cfg.Gossip.AddInfoProto(gossipStoreKey, storeDesc, gossip.StoreTTL)
 }
 
 type capacityChangeEvent int
@@ -1611,15 +1577,6 @@ func (s *Store) recordNewWritesPerSecond(newVal float64) {
 	if newVal < oldVal*.5 || newVal > oldVal*1.5 {
 		s.asyncGossipStore(context.TODO(), "writes-per-second change")
 	}
-}
-
-func (s *Store) canCampaignIdleReplica() bool {
-	s.idleReplicaElectionTime.Lock()
-	defer s.idleReplicaElectionTime.Unlock()
-	if s.idleReplicaElectionTime.at == (time.Time{}) {
-		return false
-	}
-	return !s.Clock().PhysicalTime().Before(s.idleReplicaElectionTime.at)
 }
 
 // GossipDeadReplicas broadcasts the store's dead replicas on the gossip
@@ -1674,7 +1631,6 @@ func (s *Store) Bootstrap(
 		return errors.Wrap(err, "persisting bootstrap data")
 	}
 
-	s.NotifyBootstrapped()
 	return nil
 }
 
@@ -1793,14 +1749,6 @@ func checkEngineEmpty(ctx context.Context, eng engine.Engine) error {
 		return errors.Errorf("engine belongs to store %s, contains %s", ident, keyVals)
 	}
 	return nil
-}
-
-// NotifyBootstrapped tells the store that it was bootstrapped and allows idle
-// replicas to campaign immediately. This primarily affects tests.
-func (s *Store) NotifyBootstrapped() {
-	s.idleReplicaElectionTime.Lock()
-	s.idleReplicaElectionTime.at = s.Clock().PhysicalTime()
-	s.idleReplicaElectionTime.Unlock()
 }
 
 // GetReplica fetches a replica by Range ID. Returns an error if no replica is found.


### PR DESCRIPTION
Before we implemented PreVote, we had various heuristics to decide when we should ask raft to campaign (bypassing the usual timeout). Since PreVote has reduced the cost of raft elections (by ensuring that a node that calls for an election it can't win doesn't disrupt its peers), we can get by with simpler logic. 

In addition to simplifying the logic, this PR introduces a new campaign trigger when a range unquiesces. This is a prerequisite for getting rid of the TickQuiesced hack (which is disabled by default in this PR and will be removed in a future one). 

Fixes #18365