### PR TITLE
ts: Move memory-related Query params to a struct

### DIFF
--- a/pkg/storage/ts_maintenance_queue_test.go
+++ b/pkg/storage/ts_maintenance_queue_test.go
@@ -290,8 +290,16 @@ func TestTimeSeriesMaintenanceQueueServer(t *testing.T) {
 	)
 	memMon.Start(context.TODO(), nil /* pool */, mon.MakeStandaloneBudget(math.MaxInt64))
 	defer memMon.Stop(context.TODO())
-	acc := memMon.MakeBoundAccount()
-	defer acc.Close(context.TODO())
+	memContext := ts.MakeQueryMemoryContext(
+		&memMon,
+		&memMon,
+		ts.QueryMemoryOptions{
+			BudgetBytes:             math.MaxInt64,
+			EstimatedSources:        1,
+			InterpolationLimitNanos: 0,
+		},
+	)
+	defer memContext.Close(context.TODO())
 
 	// getDatapoints queries all datapoints in the series from the beginning
 	// of time to a point in the near future.
@@ -303,9 +311,7 @@ func TestTimeSeriesMaintenanceQueueServer(t *testing.T) {
 			ts.Resolution10s.SampleDuration(),
 			0,
 			now+ts.Resolution10s.SlabDuration(),
-			0,
-			&acc,
-			&memMon,
+			memContext,
 		)
 		return dps, err
 	}

--- a/pkg/ts/db_test.go
+++ b/pkg/ts/db_test.go
@@ -284,6 +284,18 @@ func (tm *testModel) prune(nowNanos int64, timeSeries ...timeSeriesResolutionInf
 	}
 }
 
+func (tm *testModel) makeMemoryContext(interpolationLimitNanos int64) QueryMemoryContext {
+	return MakeQueryMemoryContext(
+		tm.workerMemMonitor,
+		tm.resultMemMonitor,
+		QueryMemoryOptions{
+			BudgetBytes:             tm.queryMemoryBudget,
+			EstimatedSources:        tm.model.UniqueSourceCount(),
+			InterpolationLimitNanos: interpolationLimitNanos,
+		},
+	)
+}
+
 // modelDataSource is used to create a mock DataSource. It returns a
 // deterministic set of data to GetTimeSeriesData, storing the returned data in
 // the model whenever GetTimeSeriesData is called. Data is returned until all

--- a/pkg/ts/memory.go
+++ b/pkg/ts/memory.go
@@ -1,0 +1,109 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package ts
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"unsafe"
+
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/ts/tspb"
+	"github.com/cockroachdb/cockroach/pkg/util/mon"
+)
+
+// Compute the size of various structures to use when tracking memory usage.
+var (
+	sizeOfDataSpan       = int64(unsafe.Sizeof(dataSpan{}))
+	sizeOfCalibratedData = int64(unsafe.Sizeof(calibratedData{}))
+	sizeOfTimeSeriesData = int64(unsafe.Sizeof(roachpb.InternalTimeSeriesData{}))
+	sizeOfSample         = int64(unsafe.Sizeof(roachpb.InternalTimeSeriesSample{}))
+	sizeOfDataPoint      = int64(unsafe.Sizeof(tspb.TimeSeriesDatapoint{}))
+)
+
+// QueryMemoryOptions represents the adjustable options of a QueryMemoryContext.
+type QueryMemoryOptions struct {
+	BudgetBytes             int64
+	EstimatedSources        int64
+	InterpolationLimitNanos int64
+}
+
+// QueryMemoryContext encapsulates the memory-related parameters of a time
+// series query. These same parameters are often repeated across numerous
+// queries.
+type QueryMemoryContext struct {
+	workerMonitor *mon.BytesMonitor
+	resultAccount *mon.BoundAccount
+	QueryMemoryOptions
+}
+
+// MakeQueryMemoryContext constructs a new query memory context from the
+// given parameters.
+func MakeQueryMemoryContext(
+	workerMonitor, resultMonitor *mon.BytesMonitor, opts QueryMemoryOptions,
+) QueryMemoryContext {
+	resultAccount := resultMonitor.MakeBoundAccount()
+	return QueryMemoryContext{
+		workerMonitor:      workerMonitor,
+		resultAccount:      &resultAccount,
+		QueryMemoryOptions: opts,
+	}
+}
+
+// Close closes any resources held by the queryMemoryContext.
+func (qmc QueryMemoryContext) Close(ctx context.Context) {
+	if qmc.resultAccount != nil {
+		qmc.resultAccount.Close(ctx)
+	}
+}
+
+// GetMaxTimespan computes the longest timespan that can be safely queried while
+// remaining within the given memory budget. Inputs are the resolution of data
+// being queried, the budget, the estimated number of sources, and the
+// interpolation limit being used for the query.
+func (qmc QueryMemoryContext) GetMaxTimespan(r Resolution) (int64, error) {
+	slabDuration := r.SlabDuration()
+
+	// Size of slab is the size of a completely full data slab for the supplied
+	// data resolution.
+	sizeOfSlab := sizeOfTimeSeriesData + (slabDuration/r.SampleDuration())*sizeOfSample
+
+	// InterpolationBuffer is the number of slabs outside of the query range
+	// needed to satisfy the interpolation limit. Extra slabs may be queried
+	// on both sides of the target range.
+	interpolationBufferOneSide :=
+		int64(math.Ceil(float64(qmc.InterpolationLimitNanos) / float64(slabDuration)))
+
+	interpolationBuffer := interpolationBufferOneSide * 2
+
+	// If the (interpolation buffer timespan - interpolation limit) is less than
+	// half of a slab, then it is possible for one additional slab to be queried
+	// that would not have otherwise been queried. This can occur when the queried
+	// timespan does not start on an even slab boundary.
+	if (interpolationBufferOneSide*slabDuration)-qmc.InterpolationLimitNanos < slabDuration/2 {
+		interpolationBuffer++
+	}
+
+	// The number of slabs that can be queried safely is perSeriesMem/sizeOfSlab,
+	// less the interpolation buffer.
+	perSourceMem := qmc.BudgetBytes / qmc.EstimatedSources
+	numSlabs := perSourceMem/sizeOfSlab - interpolationBuffer
+	if numSlabs <= 0 {
+		return 0, fmt.Errorf("insufficient memory budget to attempt query")
+	}
+
+	return numSlabs * slabDuration, nil
+}

--- a/pkg/ts/memory_test.go
+++ b/pkg/ts/memory_test.go
@@ -1,0 +1,163 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package ts
+
+import (
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+)
+
+func TestGetMaxTimespan(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	for _, tc := range []struct {
+		r                   Resolution
+		opts                QueryMemoryOptions
+		expectedTimespan    int64
+		expectedErrorString string
+	}{
+		// Simplest case: One series, room for exactly one hour of query (need two
+		// slabs of memory budget, as queried time span may stagger across two
+		// slabs)
+		{
+			Resolution10s,
+			QueryMemoryOptions{
+				BudgetBytes:             2 * (sizeOfTimeSeriesData + sizeOfTimeSeriesData*360),
+				EstimatedSources:        1,
+				InterpolationLimitNanos: 0,
+			},
+			(1 * time.Hour).Nanoseconds(),
+			"",
+		},
+		// Not enough room for to make query.
+		{
+			Resolution10s,
+			QueryMemoryOptions{
+				BudgetBytes:             sizeOfTimeSeriesData + sizeOfTimeSeriesData*360,
+				EstimatedSources:        1,
+				InterpolationLimitNanos: 0,
+			},
+			0,
+			"insufficient",
+		},
+		// Not enough room because of multiple sources.
+		{
+			Resolution10s,
+			QueryMemoryOptions{
+				BudgetBytes:             2 * (sizeOfTimeSeriesData + sizeOfTimeSeriesData*360),
+				EstimatedSources:        2,
+				InterpolationLimitNanos: 0,
+			},
+			0,
+			"insufficient",
+		},
+		// 6 sources, room for 1 hour.
+		{
+			Resolution10s,
+			QueryMemoryOptions{
+				BudgetBytes:             12 * (sizeOfTimeSeriesData + sizeOfTimeSeriesData*360),
+				EstimatedSources:        6,
+				InterpolationLimitNanos: 0,
+			},
+			(1 * time.Hour).Nanoseconds(),
+			"",
+		},
+		// 6 sources, room for 2 hours.
+		{
+			Resolution10s,
+			QueryMemoryOptions{
+				BudgetBytes:             18 * (sizeOfTimeSeriesData + sizeOfTimeSeriesData*360),
+				EstimatedSources:        6,
+				InterpolationLimitNanos: 0,
+			},
+			(2 * time.Hour).Nanoseconds(),
+			"",
+		},
+		// Not enough room due to interpolation buffer.
+		{
+			Resolution10s,
+			QueryMemoryOptions{
+				BudgetBytes:             12 * (sizeOfTimeSeriesData + sizeOfTimeSeriesData*360),
+				EstimatedSources:        6,
+				InterpolationLimitNanos: 1,
+			},
+			0,
+			"insufficient",
+		},
+		// Sufficient room even with interpolation buffer.
+		{
+			Resolution10s,
+			QueryMemoryOptions{
+				BudgetBytes:             18 * (sizeOfTimeSeriesData + sizeOfTimeSeriesData*360),
+				EstimatedSources:        6,
+				InterpolationLimitNanos: 1,
+			},
+			(1 * time.Hour).Nanoseconds(),
+			"",
+		},
+		// Insufficient room for interpolation buffer (due to straddling)
+		{
+			Resolution10s,
+			QueryMemoryOptions{
+				BudgetBytes:             18 * (sizeOfTimeSeriesData + sizeOfTimeSeriesData*360),
+				EstimatedSources:        6,
+				InterpolationLimitNanos: int64(float64(Resolution10s.SlabDuration()) * 0.75),
+			},
+			0,
+			"insufficient",
+		},
+		// Sufficient room even with interpolation buffer.
+		{
+			Resolution10s,
+			QueryMemoryOptions{
+				BudgetBytes:             24 * (sizeOfTimeSeriesData + sizeOfTimeSeriesData*360),
+				EstimatedSources:        6,
+				InterpolationLimitNanos: int64(float64(Resolution10s.SlabDuration()) * 0.75),
+			},
+			(1 * time.Hour).Nanoseconds(),
+			"",
+		},
+		// 1ns test resolution.
+		{
+			resolution1ns,
+			QueryMemoryOptions{
+				BudgetBytes:             3 * (sizeOfTimeSeriesData + sizeOfTimeSeriesData*10),
+				EstimatedSources:        1,
+				InterpolationLimitNanos: 1,
+			},
+			10,
+			"",
+		},
+	} {
+		t.Run("", func(t *testing.T) {
+			mem := QueryMemoryContext{
+				QueryMemoryOptions: tc.opts,
+			}
+			actual, err := mem.GetMaxTimespan(tc.r)
+			if !testutils.IsError(err, tc.expectedErrorString) {
+				t.Fatalf("got error %s, wanted error matching %s", err, tc.expectedErrorString)
+			}
+			if tc.expectedErrorString == "" {
+				return
+			}
+			if a, e := actual, tc.expectedTimespan; a != e {
+				t.Fatalf("got max timespan %d, wanted %d", a, e)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Memory-related parameters for the DB.Query() method are now grouped into
a struct QueryMemoryContext. Methods related specifically to memory
management should be associated with this structure as much as possible
going forward.

Release note: None