### PR TITLE
log: log the cluster ID in new log files

### DIFF
--- a/pkg/cli/interactive_tests/test_log_config_msg.tcl
+++ b/pkg/cli/interactive_tests/test_log_config_msg.tcl
@@ -1,0 +1,12 @@
+#! /usr/bin/env expect -f
+
+source [file join [file dirname $argv0] common.tcl]
+
+# Make a server with a tiny log buffer so as to force frequent log rotation.
+system "mkfifo pid_fifo || true; $argv start --insecure --pid-file=pid_fifo --background -s=path=logs/db --log-file-max-size=2k >>logs/expect-cmd.log 2>&1 & cat pid_fifo > server_pid"
+
+start_test "Check that the cluster ID is reported at the start of new log files."
+system "grep '\\\[config\\\] clusterID:' logs/db/logs/cockroach.log"
+end_test
+
+stop_server $argv

--- a/pkg/cli/start.go
+++ b/pkg/cli/start.go
@@ -586,7 +586,12 @@ func runStart(cmd *cobra.Command, args []string) error {
 			} else {
 				fmt.Fprintf(tw, "status:\trestarted pre-existing node\n")
 			}
-			fmt.Fprintf(tw, "clusterID:\t%s\n", s.ClusterID())
+
+			// Remember the cluster ID for log file rotation.
+			clusterID := s.ClusterID().String()
+			log.SetClusterID(clusterID)
+			fmt.Fprintf(tw, "clusterID:\t%s\n", clusterID)
+
 			fmt.Fprintf(tw, "nodeID:\t%d\n", nodeID)
 			if err := tw.Flush(); err != nil {
 				return err

--- a/pkg/util/log/clog.go
+++ b/pkg/util/log/clog.go
@@ -696,6 +696,10 @@ type loggingT struct {
 	fatalCh   chan struct{} // closed on fatal error
 
 	interceptor atomic.Value // InterceptorFn
+
+	// The Cluster ID is reported on every new log file so as to ease the correlation
+	// of panic reports with self-reported log files.
+	clusterID string
 }
 
 // buffer holds a byte Buffer for reuse. The zero value is ready for use.
@@ -706,6 +710,18 @@ type buffer struct {
 }
 
 var logging loggingT
+
+// SetClusterID stores the Cluster ID for further reference.
+func SetClusterID(clusterID string) {
+	logging.mu.Lock()
+	defer logging.mu.Unlock()
+
+	if logging.clusterID != "" {
+		panic("clusterID already set")
+	}
+
+	logging.clusterID = clusterID
+}
 
 // setVState sets a consistent state for V logging.
 // l.mu is held.
@@ -1039,16 +1055,22 @@ func (sb *syncBuffer) rotateFile(now time.Time) error {
 
 	sb.Writer = bufio.NewWriterSize(sb.file, bufferSize)
 
-	f, l, _ := caller.Lookup(1)
-	for _, msg := range []string{
+	messages := make([]string, 0, 6)
+	messages = append(messages,
 		fmt.Sprintf("[config] file created at: %s\n", now.Format("2006/01/02 15:04:05")),
 		fmt.Sprintf("[config] running on machine: %s\n", host),
 		fmt.Sprintf("[config] binary: %s\n", build.GetInfo().Short()),
 		fmt.Sprintf("[config] arguments: %s\n", os.Args),
-		// Including a non-ascii character in the first 1024 bytes of the log helps
-		// viewers that attempt to guess the character encoding.
-		fmt.Sprintf("line format: [IWEF]yymmdd hh:mm:ss.uuuuuu goid file:line msg utf8=\u2713\n"),
-	} {
+	)
+	if sb.logger.clusterID != "" {
+		messages = append(messages, fmt.Sprintf("[config] clusterID: %s\n", sb.logger.clusterID))
+	}
+	// Including a non-ascii character in the first 1024 bytes of the log helps
+	// viewers that attempt to guess the character encoding.
+	messages = append(messages, fmt.Sprintf("line format: [IWEF]yymmdd hh:mm:ss.uuuuuu goid file:line msg utf8=\u2713\n"))
+
+	f, l, _ := caller.Lookup(1)
+	for _, msg := range messages {
 		buf := formatLogEntry(Entry{
 			Severity:  Severity_INFO,
 			Time:      now.UnixNano(),


### PR DESCRIPTION
Fixes #24395.

The CONTRIBUTING guide suggest including the `[config]` lines with
error reports in new issues. This patch ensures these lines now
include the cluster ID. This is aimed to ease the correlation of
manual issue reports with auto-generated crash reports.

Release note (general change): The header of new log files generated
by `cockroach start` will now include the cluster ID once it has been
determined.