### PR TITLE
distsql: Add ordered aggregator specialization

### DIFF
--- a/pkg/sql/distsqlrun/aggregator.go
+++ b/pkg/sql/distsqlrun/aggregator.go
@@ -90,14 +90,15 @@ func (af aggregateFuncs) close(ctx context.Context) {
 	}
 }
 
-// aggregator is the processor core type that does "aggregation" in the SQL
-// sense. It groups rows and computes an aggregate for each group. The group is
-// configured using the group key and the aggregator can be configured with one
-// or more aggregation functions, as defined in the AggregatorSpec_Func enum.
+// aggregatorBase is the foundation of the processor core type that does
+// "aggregation" in the SQL sense. It groups rows and computes an aggregate for
+// each group. The group is configured using the group key and the aggregator
+// can be configured with one or more aggregation functions, as defined in the
+// AggregatorSpec_Func enum.
 //
-// aggregator's output schema is comprised of what is specified by the
+// aggregatorBase's output schema is comprised of what is specified by the
 // accompanying SELECT expressions.
-type aggregator struct {
+type aggregatorBase struct {
 	processorBase
 
 	// runningState represents the state of the aggregator. This is in addition to
@@ -117,11 +118,6 @@ type aggregator struct {
 	orderedGroupCols columns
 	aggregations     []AggregatorSpec_Aggregation
 
-	// buckets is used during the accumulation phase to track the bucket keys
-	// that have been seen. After accumulation, the keys are extracted into
-	// bucketsIter for iteration.
-	buckets          map[string]aggregateFuncs
-	bucketsIter      []string
 	lastOrdGroupCols sqlbase.EncDatumRow
 	arena            stringarena.Arena
 	row              sqlbase.EncDatumRow
@@ -130,10 +126,103 @@ type aggregator struct {
 	cancelChecker *sqlbase.CancelChecker
 }
 
-var _ Processor = &aggregator{}
-var _ RowSource = &aggregator{}
+// init initializes the aggregatorBase.
+//
+// trailingMetaCallback is passed as part of procStateOpts; the inputs to drain
+// are in aggregatorBase.
+func (ag *aggregatorBase) init(
+	flowCtx *FlowCtx,
+	spec *AggregatorSpec,
+	input RowSource,
+	post *PostProcessSpec,
+	output RowReceiver,
+	trailingMetaCallback func() []ProducerMetadata,
+) error {
+	ag.input = input
+	ag.groupCols = spec.GroupCols
+	ag.orderedGroupCols = spec.OrderedGroupCols
+	ag.aggregations = spec.Aggregations
+	ag.funcs = make([]*aggregateFuncHolder, len(spec.Aggregations))
+	ag.outputTypes = make([]sqlbase.ColumnType, len(spec.Aggregations))
+	ag.row = make(sqlbase.EncDatumRow, len(spec.Aggregations))
+	ag.bucketsAcc = flowCtx.EvalCtx.Mon.MakeBoundAccount()
+	ag.arena = stringarena.Make(&ag.bucketsAcc)
 
-const aggregatorProcName = "aggregator"
+	// Loop over the select expressions and extract any aggregate functions --
+	// non-aggregation functions are replaced with parser.NewIdentAggregate,
+	// (which just returns the last value added to them for a bucket) to provide
+	// grouped-by values for each bucket.  ag.funcs is updated to contain all
+	// the functions which need to be fed values.
+	ag.inputTypes = input.OutputTypes()
+	for i, aggInfo := range spec.Aggregations {
+		if aggInfo.FilterColIdx != nil {
+			col := *aggInfo.FilterColIdx
+			if col >= uint32(len(ag.inputTypes)) {
+				return errors.Errorf("FilterColIdx out of range (%d)", col)
+			}
+			t := ag.inputTypes[col].SemanticType
+			if t != sqlbase.ColumnType_BOOL && t != sqlbase.ColumnType_NULL {
+				return errors.Errorf(
+					"filter column %d must be of boolean type, not %s", *aggInfo.FilterColIdx, t,
+				)
+			}
+		}
+		argTypes := make([]sqlbase.ColumnType, len(aggInfo.ColIdx))
+		for i, c := range aggInfo.ColIdx {
+			if c >= uint32(len(ag.inputTypes)) {
+				return errors.Errorf("ColIdx out of range (%d)", aggInfo.ColIdx)
+			}
+			argTypes[i] = ag.inputTypes[c]
+		}
+		aggConstructor, retType, err := GetAggregateInfo(aggInfo.Func, argTypes...)
+		if err != nil {
+			return err
+		}
+
+		ag.funcs[i] = ag.newAggregateFuncHolder(aggConstructor)
+		if aggInfo.Distinct {
+			ag.funcs[i].seen = make(map[string]struct{})
+		}
+
+		ag.outputTypes[i] = retType
+	}
+
+	return ag.processorBase.init(post, ag.outputTypes, flowCtx, output, procStateOpts{
+		inputsToDrain:        []RowSource{ag.input},
+		trailingMetaCallback: trailingMetaCallback,
+	})
+}
+
+// hashAggregator is a specialization of aggregatorBase that must keep track of
+// multiple grouping buckets at a time.
+type hashAggregator struct {
+	aggregatorBase
+
+	// buckets is used during the accumulation phase to track the bucket keys
+	// that have been seen. After accumulation, the keys are extracted into
+	// bucketsIter for iteration.
+	buckets     map[string]aggregateFuncs
+	bucketsIter []string
+}
+
+// orderedAggregator is a specialization of aggregatorBase that only needs to
+// keep track of a single grouping bucket at a time.
+type orderedAggregator struct {
+	aggregatorBase
+
+	// bucket is used during the accumulation phase to aggregate results.
+	bucket aggregateFuncs
+}
+
+var _ Processor = &hashAggregator{}
+var _ RowSource = &hashAggregator{}
+
+const hashAggregatorProcName = "hash aggregator"
+
+var _ Processor = &orderedAggregator{}
+var _ RowSource = &orderedAggregator{}
+
+const orderedAggregatorProcName = "ordered aggregator"
 
 // aggregatorState represents the state of the processor.
 type aggregatorState int
@@ -154,69 +243,48 @@ func newAggregator(
 	input RowSource,
 	post *PostProcessSpec,
 	output RowReceiver,
-) (*aggregator, error) {
-	ag := &aggregator{
-		input:            input,
-		groupCols:        spec.GroupCols,
-		orderedGroupCols: spec.OrderedGroupCols,
-		aggregations:     spec.Aggregations,
-		buckets:          make(map[string]aggregateFuncs),
-		funcs:            make([]*aggregateFuncHolder, len(spec.Aggregations)),
-		outputTypes:      make([]sqlbase.ColumnType, len(spec.Aggregations)),
-		row:              make(sqlbase.EncDatumRow, len(spec.Aggregations)),
-		bucketsAcc:       flowCtx.EvalCtx.Mon.MakeBoundAccount(),
+) (Processor, error) {
+	if len(spec.OrderedGroupCols) == len(spec.GroupCols) {
+		return newOrderedAggregator(flowCtx, spec, input, post, output)
 	}
-	ag.arena = stringarena.Make(&ag.bucketsAcc)
 
-	// Loop over the select expressions and extract any aggregate functions --
-	// non-aggregation functions are replaced with parser.NewIdentAggregate,
-	// (which just returns the last value added to them for a bucket) to provide
-	// grouped-by values for each bucket.  ag.funcs is updated to contain all
-	// the functions which need to be fed values.
-	ag.inputTypes = input.OutputTypes()
-	for i, aggInfo := range spec.Aggregations {
-		if aggInfo.FilterColIdx != nil {
-			col := *aggInfo.FilterColIdx
-			if col >= uint32(len(ag.inputTypes)) {
-				return nil, errors.Errorf("FilterColIdx out of range (%d)", col)
-			}
-			t := ag.inputTypes[col].SemanticType
-			if t != sqlbase.ColumnType_BOOL && t != sqlbase.ColumnType_NULL {
-				return nil, errors.Errorf(
-					"filter column %d must be of boolean type, not %s", *aggInfo.FilterColIdx, t,
-				)
-			}
-		}
-		argTypes := make([]sqlbase.ColumnType, len(aggInfo.ColIdx))
-		for i, c := range aggInfo.ColIdx {
-			if c >= uint32(len(ag.inputTypes)) {
-				return nil, errors.Errorf("ColIdx out of range (%d)", aggInfo.ColIdx)
-			}
-			argTypes[i] = ag.inputTypes[c]
-		}
-		aggConstructor, retType, err := GetAggregateInfo(aggInfo.Func, argTypes...)
-		if err != nil {
-			return nil, err
-		}
+	ag := &hashAggregator{buckets: make(map[string]aggregateFuncs)}
 
-		ag.funcs[i] = ag.newAggregateFuncHolder(aggConstructor)
-		if aggInfo.Distinct {
-			ag.funcs[i].seen = make(map[string]struct{})
-		}
-
-		ag.outputTypes[i] = retType
-	}
 	if err := ag.init(
-		post,
-		ag.outputTypes,
 		flowCtx,
+		spec,
+		input,
+		post,
 		output,
-		procStateOpts{
-			inputsToDrain: []RowSource{ag.input},
-			trailingMetaCallback: func() []ProducerMetadata {
-				ag.close()
-				return nil
-			},
+		func() []ProducerMetadata {
+			ag.close()
+			return nil
+		},
+	); err != nil {
+		return nil, err
+	}
+
+	return ag, nil
+}
+
+func newOrderedAggregator(
+	flowCtx *FlowCtx,
+	spec *AggregatorSpec,
+	input RowSource,
+	post *PostProcessSpec,
+	output RowReceiver,
+) (*orderedAggregator, error) {
+	ag := &orderedAggregator{}
+
+	if err := ag.init(
+		flowCtx,
+		spec,
+		input,
+		post,
+		output,
+		func() []ProducerMetadata {
+			ag.close()
+			return nil
 		},
 	); err != nil {
 		return nil, err
@@ -226,16 +294,25 @@ func newAggregator(
 }
 
 // Start is part of the RowSource interface.
-func (ag *aggregator) Start(ctx context.Context) context.Context {
+func (ag *hashAggregator) Start(ctx context.Context) context.Context {
+	return ag.start(ctx, hashAggregatorProcName)
+}
+
+// Start is part of the RowSource interface.
+func (ag *orderedAggregator) Start(ctx context.Context) context.Context {
+	return ag.start(ctx, orderedAggregatorProcName)
+}
+
+func (ag *aggregatorBase) start(ctx context.Context, procName string) context.Context {
 	ag.input.Start(ctx)
-	ctx = ag.startInternal(ctx, aggregatorProcName)
+	ctx = ag.startInternal(ctx, procName)
 	ag.cancelChecker = sqlbase.NewCancelChecker(ctx)
 	ag.runningState = aggAccumulating
 	return ctx
 }
 
 // Run is part of the Processor interface.
-func (ag *aggregator) Run(ctx context.Context, wg *sync.WaitGroup) {
+func (ag *hashAggregator) Run(ctx context.Context, wg *sync.WaitGroup) {
 	if ag.out.output == nil {
 		panic("aggregator output not initialized for emitting rows")
 	}
@@ -247,7 +324,20 @@ func (ag *aggregator) Run(ctx context.Context, wg *sync.WaitGroup) {
 	}
 }
 
-func (ag *aggregator) close() {
+// Run is part of the Processor interface.
+func (ag *orderedAggregator) Run(ctx context.Context, wg *sync.WaitGroup) {
+	if ag.out.output == nil {
+		panic("aggregator output not initialized for emitting rows")
+	}
+
+	ctx = ag.Start(ctx)
+	Run(ctx, ag, ag.out.output)
+	if wg != nil {
+		wg.Done()
+	}
+}
+
+func (ag *hashAggregator) close() {
 	if ag.internalClose() {
 		log.VEventf(ag.ctx, 2, "exiting aggregator")
 		ag.bucketsAcc.Close(ag.ctx)
@@ -257,10 +347,20 @@ func (ag *aggregator) close() {
 	}
 }
 
+func (ag *orderedAggregator) close() {
+	if ag.internalClose() {
+		log.VEventf(ag.ctx, 2, "exiting aggregator")
+		ag.bucketsAcc.Close(ag.ctx)
+		if ag.bucket != nil {
+			ag.bucket.close(ag.ctx)
+		}
+	}
+}
+
 // matchLastOrdGroupCols takes a row and matches it with the row stored by
 // lastOrdGroupCols. It returns true if the two rows are equal on the grouping
 // columns, and false otherwise.
-func (ag *aggregator) matchLastOrdGroupCols(row sqlbase.EncDatumRow) (bool, error) {
+func (ag *aggregatorBase) matchLastOrdGroupCols(row sqlbase.EncDatumRow) (bool, error) {
 	for _, colIdx := range ag.orderedGroupCols {
 		res, err := ag.lastOrdGroupCols[colIdx].Compare(
 			&ag.inputTypes[colIdx], &ag.datumAlloc, &ag.flowCtx.EvalCtx, &row[colIdx],
@@ -276,7 +376,7 @@ func (ag *aggregator) matchLastOrdGroupCols(row sqlbase.EncDatumRow) (bool, erro
 // into intermediary aggregate results. If it encounters metadata, the metadata
 // is immediately returned. Subsequent calls of this function will resume row
 // accumulation.
-func (ag *aggregator) accumulateRows() (aggregatorState, sqlbase.EncDatumRow, *ProducerMetadata) {
+func (ag *hashAggregator) accumulateRows() (aggregatorState, sqlbase.EncDatumRow, *ProducerMetadata) {
 	for {
 		row, meta := ag.input.Next()
 		if meta != nil {
@@ -331,11 +431,91 @@ func (ag *aggregator) accumulateRows() (aggregatorState, sqlbase.EncDatumRow, *P
 	return aggEmittingRows, nil, nil
 }
 
+// accumulateRows continually reads rows from the input and accumulates them
+// into intermediary aggregate results. If it encounters metadata, the metadata
+// is immediately returned. Subsequent calls of this function will resume row
+// accumulation.
+func (ag *orderedAggregator) accumulateRows() (aggregatorState, sqlbase.EncDatumRow, *ProducerMetadata) {
+	for {
+		row, meta := ag.input.Next()
+		if meta != nil {
+			if meta.Err != nil {
+				ag.moveToDraining(nil /* err */)
+				return aggStateUnknown, nil, meta
+			}
+			return aggAccumulating, nil, meta
+		}
+		if row == nil {
+			log.VEvent(ag.ctx, 1, "accumulation complete")
+			ag.inputDone = true
+			break
+		}
+
+		if ag.lastOrdGroupCols == nil {
+			ag.lastOrdGroupCols = row
+		} else {
+			matched, err := ag.matchLastOrdGroupCols(row)
+			if err != nil {
+				ag.moveToDraining(err)
+				return aggStateUnknown, nil, nil
+			}
+			if !matched {
+				ag.lastOrdGroupCols = row
+				break
+			}
+		}
+		if err := ag.accumulateRow(row); err != nil {
+			ag.moveToDraining(err)
+			return aggStateUnknown, nil, nil
+		}
+	}
+
+	// Queries like `SELECT MAX(n) FROM t` expect a row of NULLs if nothing was
+	// aggregated.
+	if ag.bucket == nil && len(ag.groupCols) == 0 {
+		var err error
+		ag.bucket, err = ag.createAggregateFuncs()
+		if err != nil {
+			ag.moveToDraining(err)
+			return aggStateUnknown, nil, nil
+		}
+	}
+
+	// Transition to aggEmittingRows, and let it generate the next row/meta.
+	return aggEmittingRows, nil, nil
+}
+
+func (ag *aggregatorBase) getAggResults(
+	bucket aggregateFuncs,
+) (aggregatorState, sqlbase.EncDatumRow, *ProducerMetadata) {
+	for i, b := range bucket {
+		result, err := b.Result()
+		if err != nil {
+			ag.moveToDraining(err)
+			return aggStateUnknown, nil, nil
+		}
+		if result == nil {
+			// We can't encode nil into an EncDatum, so we represent it with DNull.
+			result = tree.DNull
+		}
+		ag.row[i] = sqlbase.DatumToEncDatum(ag.outputTypes[i], result)
+	}
+	bucket.close(ag.ctx)
+
+	if outRow := ag.processRowHelper(ag.row); outRow != nil {
+		return aggEmittingRows, outRow, nil
+	}
+	// We might have switched to draining, we might not have. In case we
+	// haven't, aggEmittingRows is accurate. If we have, it will be ignored by
+	// the caller.
+	return aggEmittingRows, nil, nil
+}
+
 // emitRow constructs an output row from an accumulated bucket and returns it.
 //
 // emitRow() might move to stateDraining. It might also not return a row if the
 // ProcOutputHelper filtered a the current row out.
-func (ag *aggregator) emitRow() (aggregatorState, sqlbase.EncDatumRow, *ProducerMetadata) {
+func (ag *hashAggregator) emitRow() (aggregatorState, sqlbase.EncDatumRow, *ProducerMetadata) {
 	if len(ag.bucketsIter) == 0 {
 		// We've exhausted all of the aggregation buckets.
 		if ag.inputDone {
@@ -349,9 +529,6 @@ func (ag *aggregator) emitRow() (aggregatorState, sqlbase.EncDatumRow, *Producer
 		// the columns specified by ag.orderedGroupCols, so we need to continue
 		// accumulating the remaining rows.
 
-		for _, funcs := range ag.buckets {
-			funcs.close(ag.ctx)
-		}
 		if err := ag.arena.UnsafeReset(ag.ctx); err != nil {
 			ag.moveToDraining(err)
 			return aggStateUnknown, nil, nil
@@ -375,31 +552,74 @@ func (ag *aggregator) emitRow() (aggregatorState, sqlbase.EncDatumRow, *Producer
 	bucket := ag.bucketsIter[0]
 	ag.bucketsIter = ag.bucketsIter[1:]
 
-	for i, b := range ag.buckets[bucket] {
-		result, err := b.Result()
-		if err != nil {
+	return ag.getAggResults(ag.buckets[bucket])
+}
+
+// emitRow constructs an output row from an accumulated bucket and returns it.
+//
+// emitRow() might move to stateDraining. It might also not return a row if the
+// ProcOutputHelper filtered a the current row out.
+func (ag *orderedAggregator) emitRow() (aggregatorState, sqlbase.EncDatumRow, *ProducerMetadata) {
+	if ag.bucket == nil {
+		// We've exhausted all of the aggregation buckets.
+		if ag.inputDone {
+			// The input has been fully consumed. Transition to draining so that we
+			// emit any metadata that we've produced.
+			ag.moveToDraining(nil /* err */)
+			return aggStateUnknown, nil, nil
+		}
+
+		// We've only consumed part of the input where the rows are equal over
+		// the columns specified by ag.orderedGroupCols, so we need to continue
+		// accumulating the remaining rows.
+
+		if err := ag.arena.UnsafeReset(ag.ctx); err != nil {
 			ag.moveToDraining(err)
 			return aggStateUnknown, nil, nil
 		}
-		if result == nil {
-			// Special case useful when this is a local stage of a distributed
-			// aggregation.
-			result = tree.DNull
+		for _, f := range ag.funcs {
+			if f.seen != nil {
+				f.seen = make(map[string]struct{})
+			}
 		}
-		ag.row[i] = sqlbase.DatumToEncDatum(ag.outputTypes[i], result)
+
+		if err := ag.accumulateRow(ag.lastOrdGroupCols); err != nil {
+			ag.moveToDraining(err)
+			return aggStateUnknown, nil, nil
+		}
+
+		return aggAccumulating, nil, nil
 	}
 
-	if outRow := ag.processRowHelper(ag.row); outRow != nil {
-		return aggEmittingRows, outRow, nil
-	}
-	// We might have switched to draining, we might not have. In case we
-	// haven't, aggEmittingRows is accurate. If we have, it will be ignored by
-	// the caller.
-	return aggEmittingRows, nil, nil
+	bucket := ag.bucket
+	ag.bucket = nil
+	return ag.getAggResults(bucket)
 }
 
 // Next is part of the RowSource interface.
-func (ag *aggregator) Next() (sqlbase.EncDatumRow, *ProducerMetadata) {
+func (ag *hashAggregator) Next() (sqlbase.EncDatumRow, *ProducerMetadata) {
+	for ag.state == stateRunning {
+		var row sqlbase.EncDatumRow
+		var meta *ProducerMetadata
+		switch ag.runningState {
+		case aggAccumulating:
+			ag.runningState, row, meta = ag.accumulateRows()
+		case aggEmittingRows:
+			ag.runningState, row, meta = ag.emitRow()
+		default:
+			log.Fatalf(ag.ctx, "unsupported state: %d", ag.runningState)
+		}
+
+		if row == nil && meta == nil {
+			continue
+		}
+		return row, meta
+	}
+	return nil, ag.drainHelper()
+}
+
+// Next is part of the RowSource interface.
+func (ag *orderedAggregator) Next() (sqlbase.EncDatumRow, *ProducerMetadata) {
 	for ag.state == stateRunning {
 		var row sqlbase.EncDatumRow
 		var meta *ProducerMetadata
@@ -421,43 +641,25 @@ func (ag *aggregator) Next() (sqlbase.EncDatumRow, *ProducerMetadata) {
 }
 
 // ConsumerDone is part of the RowSource interface.
-func (ag *aggregator) ConsumerDone() {
+func (ag *aggregatorBase) ConsumerDone() {
 	ag.moveToDraining(nil /* err */)
 }
 
 // ConsumerClosed is part of the RowSource interface.
-func (ag *aggregator) ConsumerClosed() {
+func (ag *hashAggregator) ConsumerClosed() {
 	// The consumer is done, Next() will not be called again.
 	ag.close()
 }
 
-// accumulateRow accumulates a single row, returning an error if accumulation
-// failed for any reason.
-func (ag *aggregator) accumulateRow(row sqlbase.EncDatumRow) error {
-	if err := ag.cancelChecker.Check(); err != nil {
-		return err
-	}
-	// The encoding computed here determines which bucket the non-grouping
-	// datums are accumulated to.
-	encoded, err := ag.encode(ag.scratch, row)
-	if err != nil {
-		return err
-	}
-	ag.scratch = encoded[:0]
+// ConsumerClosed is part of the RowSource interface.
+func (ag *orderedAggregator) ConsumerClosed() {
+	// The consumer is done, Next() will not be called again.
+	ag.close()
+}
 
-	bucket, ok := ag.buckets[string(encoded)]
-	if !ok {
-		s, err := ag.arena.AllocBytes(ag.ctx, encoded)
-		if err != nil {
-			return err
-		}
-		bucket, err = ag.createAggregateFuncs()
-		if err != nil {
-			return err
-		}
-		ag.buckets[s] = bucket
-	}
-
+func (ag *aggregatorBase) accumulateRowIntoBucket(
+	row sqlbase.EncDatumRow, groupKey []byte, bucket aggregateFuncs,
+) error {
 	// Feed the func holders for this bucket the non-grouping datums.
 	for i, a := range ag.aggregations {
 		if a.FilterColIdx != nil {
@@ -493,7 +695,7 @@ func (ag *aggregator) accumulateRow(row sqlbase.EncDatumRow) error {
 			otherArgs[j-1] = row[c].Datum
 		}
 
-		canAdd, err := ag.funcs[i].canAdd(ag.ctx, encoded, firstArg, otherArgs)
+		canAdd, err := ag.funcs[i].canAdd(ag.ctx, groupKey, firstArg, otherArgs)
 		if err != nil {
 			return err
 		}
@@ -507,16 +709,65 @@ func (ag *aggregator) accumulateRow(row sqlbase.EncDatumRow) error {
 	return nil
 }
 
+// accumulateRow accumulates a single row, returning an error if accumulation
+// failed for any reason.
+func (ag *hashAggregator) accumulateRow(row sqlbase.EncDatumRow) error {
+	if err := ag.cancelChecker.Check(); err != nil {
+		return err
+	}
+
+	// The encoding computed here determines which bucket the non-grouping
+	// datums are accumulated to.
+	encoded, err := ag.encode(ag.scratch, row)
+	if err != nil {
+		return err
+	}
+	ag.scratch = encoded[:0]
+
+	bucket, ok := ag.buckets[string(encoded)]
+	if !ok {
+		s, err := ag.arena.AllocBytes(ag.ctx, encoded)
+		if err != nil {
+			return err
+		}
+		bucket, err = ag.createAggregateFuncs()
+		if err != nil {
+			return err
+		}
+		ag.buckets[s] = bucket
+	}
+
+	return ag.accumulateRowIntoBucket(row, encoded, bucket)
+}
+
+// accumulateRow accumulates a single row, returning an error if accumulation
+// failed for any reason.
+func (ag *orderedAggregator) accumulateRow(row sqlbase.EncDatumRow) error {
+	if err := ag.cancelChecker.Check(); err != nil {
+		return err
+	}
+
+	if ag.bucket == nil {
+		var err error
+		ag.bucket, err = ag.createAggregateFuncs()
+		if err != nil {
+			return err
+		}
+	}
+
+	return ag.accumulateRowIntoBucket(row, nil /* groupKey */, ag.bucket)
+}
+
 type aggregateFuncHolder struct {
 	create func(*tree.EvalContext) tree.AggregateFunc
-	group  *aggregator
+	group  *aggregatorBase
 	seen   map[string]struct{}
 	arena  *stringarena.Arena
 }
 
 const sizeOfAggregateFunc = int64(unsafe.Sizeof(tree.AggregateFunc(nil)))
 
-func (ag *aggregator) newAggregateFuncHolder(
+func (ag *aggregatorBase) newAggregateFuncHolder(
 	create func(*tree.EvalContext) tree.AggregateFunc,
 ) *aggregateFuncHolder {
 	return &aggregateFuncHolder{
@@ -527,16 +778,16 @@ func (ag *aggregator) newAggregateFuncHolder(
 }
 
 func (a *aggregateFuncHolder) canAdd(
-	ctx context.Context, bucket []byte, firstArg tree.Datum, otherArgs tree.Datums,
+	ctx context.Context, encodingPrefix []byte, firstArg tree.Datum, otherArgs tree.Datums,
 ) (bool, error) {
 	if a.seen != nil {
-		encoded, err := sqlbase.EncodeDatum(bucket, firstArg)
+		encoded, err := sqlbase.EncodeDatum(encodingPrefix, firstArg)
 		if err != nil {
 			return false, err
 		}
 		// Encode additional arguments if necessary.
 		if otherArgs != nil {
-			encoded, err = sqlbase.EncodeDatums(bucket, otherArgs)
+			encoded, err = sqlbase.EncodeDatums(encoded, otherArgs)
 			if err != nil {
 				return false, err
 			}
@@ -558,7 +809,7 @@ func (a *aggregateFuncHolder) canAdd(
 
 // encode returns the encoding for the grouping columns, this is then used as
 // our group key to determine which bucket to add to.
-func (ag *aggregator) encode(
+func (ag *aggregatorBase) encode(
 	appendTo []byte, row sqlbase.EncDatumRow,
 ) (encoding []byte, err error) {
 	for _, colIdx := range ag.groupCols {
@@ -571,7 +822,7 @@ func (ag *aggregator) encode(
 	return appendTo, nil
 }
 
-func (ag *aggregator) createAggregateFuncs() (aggregateFuncs, error) {
+func (ag *aggregatorBase) createAggregateFuncs() (aggregateFuncs, error) {
 	bucket := make(aggregateFuncs, len(ag.funcs))
 	for i, f := range ag.funcs {
 		// TODO(radu): we should account for the size of impl (this needs to be done

--- a/pkg/sql/distsqlrun/processors.go
+++ b/pkg/sql/distsqlrun/processors.go
@@ -713,8 +713,8 @@ func (pb *processorBase) OutputTypes() []sqlbase.ColumnType {
 }
 
 var procNameToLogTag = map[string]string{
-	aggregatorProcName:              "agg",
 	distinctProcName:                "distinct",
+	hashAggregatorProcName:          "hashAgg",
 	hashJoinerProcName:              "hashJoiner",
 	interleavedReaderJoinerProcName: "interleaveReaderJoiner",
 	joinReaderProcName:              "joinReader",
@@ -722,6 +722,7 @@ var procNameToLogTag = map[string]string{
 	metadataTestReceiverProcName:    "metaReceiver",
 	metadataTestSenderProcName:      "metaSender",
 	noopProcName:                    "noop",
+	orderedAggregatorProcName:       "orderedAgg",
 	samplerProcName:                 "sampler",
 	scrubTableReaderProcName:        "scrub",
 	sortAllProcName:                 "sortAll",


### PR DESCRIPTION
If there is an ordering on all the grouping columns, there is no need to
create a map of buckets; instead, only one bucket needs to be maintained
at a time. The new orderedAggregator processor does this, which
significantly speeds up fully ordered grouping column scenarios.

Release note: None