### PR TITLE
workload: fix `./workload init kv`

### DIFF
--- a/pkg/workload/workload.go
+++ b/pkg/workload/workload.go
@@ -285,7 +285,9 @@ func Setup(
 
 	var size int64
 	for _, table := range tables {
-		if table.InitialRows.Batch == nil {
+		if table.InitialRows.NumBatches == 0 {
+			continue
+		} else if table.InitialRows.Batch == nil {
 			return 0, errors.Errorf(
 				`initial data is not supported for workload %s`, gen.Meta().Name)
 		}


### PR DESCRIPTION
We only want to return the "unsupported" error if a table has non-zero
rows and it doesn't have a function for computing them (currently only
tpch). This is a regression in #24914.

Release note: None