### PR TITLE
tscache: use larger IntervalSkl pageSize in benchmarks

### DIFF
--- a/pkg/storage/tscache/interval_skl_test.go
+++ b/pkg/storage/tscache/interval_skl_test.go
@@ -1170,7 +1170,7 @@ func BenchmarkIntervalSklAdd(b *testing.B) {
 	const txnID = "123"
 
 	clock := hlc.NewClock(hlc.UnixNano, time.Millisecond)
-	s := newIntervalSkl(clock, MinRetentionWindow, TestSklPageSize, makeMetrics())
+	s := newIntervalSkl(clock, MinRetentionWindow, defaultSklPageSize, makeMetrics())
 	rng := rand.New(rand.NewSource(timeutil.Now().UnixNano()))
 
 	size := 1
@@ -1195,7 +1195,7 @@ func BenchmarkIntervalSklAddAndLookup(b *testing.B) {
 	const txnID = "123"
 
 	clock := hlc.NewClock(hlc.UnixNano, time.Millisecond)
-	s := newIntervalSkl(clock, MinRetentionWindow, TestSklPageSize, makeMetrics())
+	s := newIntervalSkl(clock, MinRetentionWindow, defaultSklPageSize, makeMetrics())
 	rng := rand.New(rand.NewSource(timeutil.Now().UnixNano()))
 
 	for i := 0; i < data; i++ {


### PR DESCRIPTION
This was hurting benchmark performance and making the results
less realistic.

Release note: None