### PR TITLE
sql, server: fix periodic resetting of stmt stats

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -579,7 +579,6 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 	if s.cfg.UseLegacyConnHandling {
 		s.registry.AddMetricStruct(s.sqlExecutor)
 	}
-	s.PeriodicallyClearStmtStats(ctx)
 
 	s.pgServer = pgwire.MakeServer(
 		s.cfg.AmbientCtx,

--- a/pkg/server/updates_test.go
+++ b/pkg/server/updates_test.go
@@ -132,8 +132,6 @@ func TestReportUsage(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	ts.sqlExecutor.ResetStatementStats(ctx)
-
 	const elemName = "somestring"
 	if _, err := db.Exec(fmt.Sprintf(`CREATE DATABASE %s`, elemName)); err != nil {
 		t.Fatal(err)

--- a/pkg/sql/app_stats.go
+++ b/pkg/sql/app_stats.go
@@ -348,19 +348,6 @@ func HashForReporting(secret, appName string) string {
 	return hex.EncodeToString(hash.Sum(nil)[:4])
 }
 
-// ResetStatementStats resets the executor's collected statement statistics.
-func (e *Executor) ResetStatementStats(ctx context.Context) {
-	e.sqlStats.resetStats(ctx)
-}
-
-// LasStatementStatReset returns the time the stmt stats were last rest.
-func (e *Executor) LasStatementStatReset() time.Time {
-	e.sqlStats.Lock()
-	last := e.sqlStats.lastReset
-	e.sqlStats.Unlock()
-	return last
-}
-
 // FillErrorCounts fills the passed map with the executor's current
 // counts of how often individual unimplemented features have been encountered.
 func (e *Executor) FillErrorCounts(codes, unimplemented map[string]int64) {


### PR DESCRIPTION
Addressing own comments from #24511: we have a loop resetting some stats
but it's resetting the wrong ones - the ones on the old Executor,
unused. It should be resetting the sql.Server stats.
Also moved the resetting code from server.Server to sql.Server, where
it belongs.

Release note: None