### PR TITLE
server: set login cookie's path to /

### DIFF
--- a/pkg/server/authentication.go
+++ b/pkg/server/authentication.go
@@ -356,6 +356,7 @@ func encodeSessionCookie(sessionCookie *serverpb.SessionCookie) (*http.Cookie, e
 	return &http.Cookie{
 		Name:     sessionCookieName,
 		Value:    base64.StdEncoding.EncodeToString(cookieValueBytes),
+		Path:     "/",
 		HttpOnly: true,
 		Secure:   true,
 	}, nil


### PR DESCRIPTION
Otherwise the browser saves it with a path of /_auth/v1/login, and only sends the cookie to the login endpoint. With a path of /, the browser sends the cookie to all endpoints.

Release note: None