### PR TITLE
[DNM] server: require web login by default in secure mode

### DIFF
--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -70,7 +70,7 @@ const (
 	// that keeps track of the paths of the temporary directories created.
 	TempDirsRecordFilename                = "temp-dirs-record.txt"
 	defaultEventLogEnabled                = true
-	defaultEnableWebSessionAuthentication = false
+	defaultEnableWebSessionAuthentication = true
 
 	maximumMaxClockOffset = 5 * time.Second
 


### PR DESCRIPTION
_Note: this change or something like it is required for web login to work, but shouldn't be merged before a UI login screen exists._

Before this change:
- Admin server endpoints don't care whether there is a logged-in user or not, even in secure mode; they always run as the root user (#8767)
- There is no way to log in — the `/_auth/v1/login` endpoint 404s

After this change:
- Admin server endpoints require _some user_ to be logged in, although they still run queries (e.g. against `crdb_internal`) as the root user.
- `/_auth/v1/login` is exposed, allowing clients such as the admin UI to log in.

UX note: some users might want a cluster which is in secure mode but doesn't require web login. To support that, we'd need to introduce a new cluster setting, e.g. `disable_web_login`. *do not merge this* until we've made that decision.

Implementation note: Flipping this boolean causes the authentication mux to be installed on the server when in secure mode, which (a) handles the login endpoint and (b) checks requests to the admin and status servers for a valid session. Here's where it's installed: https://github.com/cockroachdb/cockroach/blob/75d44eb05b7c60dc6d9a7a284e9b3c56529d57d2/pkg/server/server.go#L1181-L1184