### PR TITLE
server: exempt healthcheck endpoint from authentication check

### DIFF
--- a/pkg/server/admin_test.go
+++ b/pkg/server/admin_test.go
@@ -1041,9 +1041,7 @@ func TestHealthAPI(t *testing.T) {
 	}
 	s.Clock().Update(hlc.Timestamp(self.Expiration).Add(1, 0))
 
-	// Health API is not accessible if the node is not accessible, because it
-	// cannot verify the authentication session.
-	expected := "401 Unauthorized"
+	expected := "503 Service Unavailable"
 	var resp serverpb.HealthResponse
 	for {
 		if err := getAdminJSONProto(s, "health", &resp); !testutils.IsError(err, expected) {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1472,6 +1472,8 @@ If problems persist, please see ` + base.DocsURL("cluster-setup-troubleshooting.
 	s.serveMode.set(modeOperational)
 
 	s.mux.Handle(adminPrefix, authHandler)
+	// Exempt the health check endpoint from authentication.
+	s.mux.Handle("/_admin/v1/health", gwMux)
 	s.mux.Handle(ts.URLPrefix, authHandler)
 	s.mux.Handle(statusPrefix, authHandler)
 	s.mux.Handle(authPrefix, gwMux)


### PR DESCRIPTION
Otherwise, you get the red "connection lost" banner until you log in.

This will have no effect until the auth mux is put on the request path (#24944).

Fixes #24942 