### PR TITLE
storage: Maintain a separate set of unquiesced replicas

### DIFF
--- a/pkg/storage/replica_test.go
+++ b/pkg/storage/replica_test.go
@@ -9922,3 +9922,77 @@ func TestReplicaMigrateRangeAppliedStateKey(t *testing.T) {
 	// in-memory and on-disk ReplicaStates are not diverging.
 	assertMigrationComplete(t, true)
 }
+
+func TestReplicaShouldCampaignOnWake(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	const storeID = roachpb.StoreID(1)
+
+	myLease := roachpb.Lease{
+		Replica: roachpb.ReplicaDescriptor{
+			StoreID: storeID,
+		},
+	}
+	otherLease := roachpb.Lease{
+		Replica: roachpb.ReplicaDescriptor{
+			StoreID: roachpb.StoreID(2),
+		},
+	}
+
+	followerWithoutLeader := raft.Status{
+		SoftState: raft.SoftState{
+			RaftState: raft.StateFollower,
+			Lead:      0,
+		},
+	}
+	followerWithLeader := raft.Status{
+		SoftState: raft.SoftState{
+			RaftState: raft.StateFollower,
+			Lead:      1,
+		},
+	}
+	candidate := raft.Status{
+		SoftState: raft.SoftState{
+			RaftState: raft.StateCandidate,
+			Lead:      0,
+		},
+	}
+	leader := raft.Status{
+		SoftState: raft.SoftState{
+			RaftState: raft.StateLeader,
+			Lead:      1,
+		},
+	}
+
+	tests := []struct {
+		leaseStatus LeaseStatus
+		lease       roachpb.Lease
+		raftStatus  raft.Status
+		exp         bool
+	}{
+		{LeaseStatus{State: LeaseState_VALID}, myLease, followerWithoutLeader, true},
+		{LeaseStatus{State: LeaseState_VALID}, otherLease, followerWithoutLeader, false},
+		{LeaseStatus{State: LeaseState_VALID}, myLease, followerWithLeader, false},
+		{LeaseStatus{State: LeaseState_VALID}, otherLease, followerWithLeader, false},
+		{LeaseStatus{State: LeaseState_VALID}, myLease, candidate, false},
+		{LeaseStatus{State: LeaseState_VALID}, otherLease, candidate, false},
+		{LeaseStatus{State: LeaseState_VALID}, myLease, leader, false},
+		{LeaseStatus{State: LeaseState_VALID}, otherLease, leader, false},
+
+		{LeaseStatus{State: LeaseState_EXPIRED}, myLease, followerWithoutLeader, true},
+		{LeaseStatus{State: LeaseState_EXPIRED}, otherLease, followerWithoutLeader, true},
+		{LeaseStatus{State: LeaseState_EXPIRED}, myLease, followerWithLeader, false},
+		{LeaseStatus{State: LeaseState_EXPIRED}, otherLease, followerWithLeader, false},
+		{LeaseStatus{State: LeaseState_EXPIRED}, myLease, candidate, false},
+		{LeaseStatus{State: LeaseState_EXPIRED}, otherLease, candidate, false},
+		{LeaseStatus{State: LeaseState_EXPIRED}, myLease, leader, false},
+		{LeaseStatus{State: LeaseState_EXPIRED}, otherLease, leader, false},
+	}
+
+	for i, test := range tests {
+		v := shouldCampaignOnWake(test.leaseStatus, test.lease, storeID, test.raftStatus)
+		if v != test.exp {
+			t.Errorf("%d: expected %v but got %v", i, test.exp, v)
+		}
+	}
+}

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -100,9 +100,6 @@ var changeTypeInternalToRaft = map[roachpb.ReplicaChangeType]raftpb.ConfChangeTy
 var storeSchedulerConcurrency = envutil.EnvOrDefaultInt(
 	"COCKROACH_SCHEDULER_CONCURRENCY", 8*runtime.NumCPU())
 
-var enableTickQuiesced = envutil.EnvOrDefaultBool(
-	"COCKROACH_ENABLE_TICK_QUIESCED", false)
-
 // bulkIOWriteLimit is defined here because it is used by BulkIOWriteLimiter.
 var bulkIOWriteLimit = settings.RegisterByteSizeSetting(
 	"kv.bulk_io_write.max_rate",
@@ -3612,7 +3609,7 @@ func (s *Store) raftTickLoop(ctx context.Context) {
 				// Replica on the store which cascades into Raft elections and more
 				// disruption. Replica.maybeTickQuiesced only grabs short-duration
 				// locks and not locks that are held during disk I/O.
-				if !(*Replica)(v).maybeTickQuiesced() {
+				if !(*Replica)(v).needsTick() {
 					rangeIDs = append(rangeIDs, roachpb.RangeID(k))
 				}
 				return true

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -3621,7 +3621,7 @@ func (s *Store) raftTickLoop(ctx context.Context) {
 				// then a single bad/slow Replica can disrupt tick processing for every
 				// Replica on the store which cascades into Raft elections and more
 				// disruption.
-				rangeIDs = append(rangeIDs, roachpb.RangeID(k))
+				rangeIDs = append(rangeIDs, k)
 			}
 			s.unquiescedReplicas.Unlock()
 

--- a/pkg/util/syncutil/int_map.go
+++ b/pkg/util/syncutil/int_map.go
@@ -23,6 +23,9 @@ import (
 // comparable or worse performance and worse type safety than an ordinary
 // map paired with a read-write mutex.
 //
+// Nil values are not supported; to use an IntMap as a set store a
+// dummy non-nil pointer instead of nil.
+//
 // The zero Map is valid and empty.
 //
 // A Map must not be copied after first use.


### PR DESCRIPTION
This means that idle replicas no longer have a per-tick CPU cost,
which is one of the bottlenecks limiting the amount of data we can
handle per store.

Fixes #17609

Release note (performance improvement): Reduced CPU overhead of idle
ranges


The first five commits are from #24920; that PR should be merged and tested in isolation first. 