### PR TITLE
scripts: enhance the release note extraction script

### DIFF
--- a/githooks/commit-msg
+++ b/githooks/commit-msg
@@ -139,6 +139,11 @@ else
                 esac
             done
         fi
+	# Do some linting on the message itself.
+	msg=$(echo "$rnote" | cut -d':' -f1-)
+	if echo "$msg" | $grep -qiE ' *([cC]loses?|[fF]ix(es)?) *#[0-9]+\.? *'; then
+	    hint "don't just close or fix. Explain."
+	fi
     done
     if test -n "$informed"; then echo >&2; fi
 fi

--- a/scripts/release-notes.py
+++ b/scripts/release-notes.py
@@ -99,6 +99,7 @@ crdb_folk = set([
     "Radu Berinde",
     "Raphael 'kena' Poss",
     "Rebecca Taft",
+    "Rich Loveland",
     "Richard Wu",
     "Sean Loiselle",
     "Solon Gordon",

--- a/scripts/release-notes.py
+++ b/scripts/release-notes.py
@@ -23,6 +23,8 @@
 #   will be confused. (it will merge their work under one entry).
 # - the list of aliases below must be manually modified when
 #   contributors change their git name and/or email address.
+#
+# Note: there are unit tests in the release-notes subdirectory!
 
 import sys
 import itertools
@@ -163,11 +165,14 @@ cat_misspells = {
 norelnote = re.compile(r'^[rR]elease [nN]otes?: *[Nn]one', flags=re.M)
 # Captures :? (xxx) ?: yyy
 form1 = r':? *\((?P<cat1>[^)]*)\) *:?'
-# Captures : xxx: yyy - this must be careful not to capture too much, we just accept one word
-form2 = r': *(?P<cat2>[^ ]*) *:'
+# Captures : xxx: yyy - this must be careful not to capture too much, we just accept one or two words
+form2 = r': *(?P<cat2>[^ ]+(?: +[^ ]+)?) *:'
 # Captures : yyy - no category
 form3 = r':(?P<cat3>)'
 relnote = re.compile(r'(?:^|[\n\r])[rR]elease [nN]otes? *(?:' + form1 + '|' + form2 + '|' + form3 + r') *(?P<note>.*)$', flags=re.S)
+
+coauthor = re.compile(r'^Co-authored-by: (?P<name>[^<]*) <(?P<email>.*)>', flags=re.M)
+fixannot = re.compile(r'^([fF]ix(es|ed)?|[cC]lose(d|s)?) #', flags=re.M)
 
 ## Merge commit format ##
 
@@ -181,7 +186,7 @@ merge_numbers = re.compile(r'^Merge( pull request)?(?P<numbers>( #[0-9]+)+)')
 
 parser = OptionParser()
 parser.add_option("-k", "--sort-key", dest="sort_key", default="title",
-                  help="sort by KEY (pr, title, insertions, deletions, files, sha; default: title)", metavar="KEY")
+                  help="sort by KEY (pr, title, insertions, deletions, files, sha, date; default: title)", metavar="KEY")
 parser.add_option("-r", "--reverse", action="store_true", dest="reverse_sort", default=False,
                   help="reverse sort")
 parser.add_option("-f", "--from", dest="from_commit",
@@ -196,6 +201,8 @@ parser.add_option("--hide-per-contributor-section", action="store_true", dest="h
                   help="omit the per-contributor section")
 parser.add_option("--hide-downloads-section", action="store_true", dest="hide_downloads", default=False,
                   help="omit the email sign-up and downloads section")
+parser.add_option("--hide-header", action="store_true", dest="hide_header", default=False,
+                  help="omit the title and date header")
 
 (options, args) = parser.parse_args()
 
@@ -205,6 +212,7 @@ pull_ref_prefix = options.pull_ref_prefix
 hideshas = options.hide_shas
 hidepercontributor = options.hide_per_contributor
 hidedownloads = options.hide_downloads
+hideheader = options.hide_header
 
 repo = Repo('.')
 heads = repo.heads
@@ -246,63 +254,149 @@ except:
 
 ### Reading data from repository ###
 
+def identify_commit(commit):
+    return '%s ("%s", %s)' % (
+        commit.hexsha, commit.message.split('\n',1)[0],
+        datetime.datetime.fromtimestamp(commit.committed_date).ctime())
+
 # Is the first commit reachable from the current one?
 base = repo.merge_base(firstCommit, commit)
 if len(base) == 0:
-    print("error: %s and %s have no common ancestor" % (options.from_commit, options.until_commit), file=sys.stderr)
+    print("error: %s:%s\nand %s:%s\nhave no common ancestor" % (
+        options.from_commit, identify_commit(firstCommit),
+        options.until_commit, identify_commit(commit)), file=sys.stderr)
     exit(1)
 commonParent = base[0]
 if firstCommit != commonParent:
-    print("warning: %s is not an ancestor of %s!" % (options.from_commit, options.until_commit), file=sys.stderr)
+    print("warning: %s:%s\nis not an ancestor of %s:%s!" % (
+        options.from_commit, identify_commit(firstCommit),
+        options.until_commit, identify_commit(commit)), file=sys.stderr)
     print(file=sys.stderr)
     ageindays = int((firstCommit.committed_date - commonParent.committed_date)/86400)
     prevlen = sum((1 for x in repo.iter_commits(commonParent.hexsha + '...' + firstCommit.hexsha)))
-    print("The first common ancestor is %s," % commonParent.hexsha, file=sys.stderr)
-    print("which is %d commits older than %s and %d days older. Using that as origin." %\
-          (prevlen, options.from_commit, ageindays), file=sys.stderr)
+    print("The first common ancestor is %s" % identify_commit(commonParent), file=sys.stderr)
+    print("which is %d commits older than %s:%s\nand %d days older. Using that as origin." %\
+          (prevlen, options.from_commit, identify_commit(firstCommit), ageindays), file=sys.stderr)
     print(file=sys.stderr)
     firstCommit = commonParent
     options.from_commit = commonParent.hexsha
 
-print("Changes %s ... %s" % (firstCommit, commit), file=sys.stderr)
+print("Changes from\n%s\nuntil\n%s" % (identify_commit(firstCommit), identify_commit(commit)), file=sys.stderr)
 
 release_notes = {}
 missing_release_notes = []
 
+def collect_authors(commit):
+    authors = set()
+    author = author_aliases.get(commit.author.name, commit.author.name)
+    if author != 'GitHub':
+        authors.add(author)
+    author = author_aliases.get(commit.committer.name, commit.committer.name)
+    if author != 'GitHub':
+        authors.add(author)
+    for m in coauthor.finditer(commit.message):
+        aname = m.group('name').strip()
+        author = author_aliases.get(aname, aname)
+        authors.add(author)
+    return authors
+
+
 def extract_release_notes(pr, title, commit):
+    authors = collect_authors(commit)
     if norelnote.search(commit.message) is not None:
         # Explicitly no release note. Nothing to do.
-        return
+        # Just report the author(s).
+        return None, authors
 
-    item = {'author': (commit.author.name, commit.author.email),
-            'sha': commit.hexsha[:shamin],
+    msglines = commit.message.split('\n')
+    curnote = []
+    innote = False
+    foundnote = False
+    cat = None
+    notes = []
+    for line in msglines:
+        m = coauthor.search(line)
+        if m is not None:
+            # A Co-authored-line finishes the parsing of the commit message,
+            # because it's included at the end only.
+            break
+
+        m = fixannot.search(line)
+        if m is not None:
+            # Fix/Close etc. Ignore.
+            continue
+
+        m = relnote.search(line)
+        if m is None:
+            # Current line does not contain a release note separator.
+            # If we were already collecting a note, continue collecting it.
+            if innote:
+                curnote.append(line)
+            continue
+
+        # We have a release note boundary. If we were collecting a
+        # note already, complete it.
+        if innote:
+            notes.append((cat, curnote))
+            curnote = []
+            innote = False
+
+        # Start a new release note.
+
+        firstline = m.group('note').strip()
+        if firstline.lower() == 'none':
+            # Release note: none - there's no note yet.
+            continue
+        foundnote = True
+        innote = True
+
+        # Capitalize the first line.
+        if firstline != "":
+            firstline = firstline[0].upper() + firstline[1:]
+
+        curnote = [firstline]
+        cat = m.group('cat1')
+        if cat is None:
+            cat = m.group('cat2')
+        if cat is None:
+            cat = 'missing category'
+        # Normalize to tolerate various capitalizations.
+        cat = cat.lower()
+        # If there are multiple categories separated by commas or slashes, use the first as grouping key.
+        cat = cat.split(',', 1)[0]
+        cat = cat.split('/', 1)[0]
+        # If there is any misspell, correct it.
+        if cat in cat_misspells:
+            cat = cat_misspells[cat]
+
+    if innote:
+        notes.append((cat, curnote))
+
+    # At the end the notes will be presented in reverse order, because
+    # we explore the commits in reverse order. However within 1 commit
+    # the notes are in the correct order. So reverse them upfront here,
+    # so that the 2nd reverse gets them in the right order again.
+    for cat, note in reversed(notes):
+        completenote(commit, cat, note, authors, pr, title)
+
+    missing_item = None
+    if not foundnote:
+        # Missing release note. Keep track for later.
+        missing_item = makeitem(pr, title, commit.hexsha[:shamin], authors)
+    return missing_item, authors
+
+def makeitem(pr, prtitle, sha, authors):
+    return {'authors': ', '.join(sorted(authors)),
+            'sha': sha,
             'pr': pr,
-            'prtitle': title,
+            'title': prtitle,
             'note': None}
 
-    m = relnote.search(commit.message)
-    if m is None:
-        # Missing release note. Keep track for later.
-        missing_release_notes.append(item)
-        return
-    item['note'] = m.group('note').strip()
-    if item['note'].lower() == 'none':
-        # Someone entered 'Release note (cat): None'.
-        return
+def completenote(commit, cat, curnote, authors, pr, title):
+    notemsg = '\n'.join(curnote).strip()
+    item = makeitem(pr, title, commit.hexsha[:shamin], authors)
+    item['note'] = notemsg
 
-    cat = m.group('cat1')
-    if cat is None:
-        cat = m.group('cat2')
-    if cat is None:
-        cat = 'missing category'
-    # Normalize to tolerate various capitalizations.
-    cat = cat.lower()
-    # If there are multiple categories separated by commas or slashes, use the first as grouping key.
-    cat = cat.split(',', 1)[0]
-    cat = cat.split('/', 1)[0]
-    # If there is any misspell, correct it.
-    if cat in cat_misspells:
-        cat = cat_misspells[cat]
     # Now collect per category.
     catnotes = release_notes.get(cat, [])
     catnotes.append(item)
@@ -358,13 +452,13 @@ def spin():
 #     |/
 #     K <-- merge base
 #
-# C, E, G, H, and J will each be checked.  None of them are reachable from B,
+# C, E, G, H, and J will each be checked.  None of them are ancestors of B,
 # so they will all be visited. E will be not be counted because the message
 # starts with "Merge", so in the end C, G, H, and J will be included.
 #
 # ### back-merge from target branch
 #
-# Dev branched off F, made one commit G, merged the latest from master in E,
+# Dev branched off H, made one commit G, merged the latest F from master in E,
 # made one final commit in C, then merged the PR.
 #
 #     A <-- master
@@ -381,7 +475,7 @@ def spin():
 #     |/
 #     H <-- merge base
 #
-# C, E, F, and G will each be checked. F is reachable from B, so it will be
+# C, E, F, and G will each be checked. F is an ancestor of B, so it will be
 # excluded. E starts with "Merge", so it will not be counted. Only C and G will
 # have statistics included.
 def analyze_pr(merge, pr):
@@ -395,67 +489,86 @@ def analyze_pr(merge, pr):
     note = ''
     if m is None:
         # GitHub merge
-        note = '\n'.join(merge.message.split('\n')[2:])
+        note = merge.message.split('\n',3)[2]
     else:
         # Bors merge
         note = m.group('message')
+    note = note.strip()
 
     merge_base_result = repo.merge_base(merge.parents[0], tip)
     if len(merge_base_result) == 0:
-        print("uh-oh!  can't find merge base!  pr", pr)
+        print("uh-oh!  can't find merge base!  pr", pr, file=sys.stderr)
         exit(-1)
 
     merge_base = merge_base_result[0]
 
     commits_to_analyze = [tip]
+    seen_commits = set()
 
+    missing_items = []
     authors = set()
     ncommits = 0
     while len(commits_to_analyze) > 0:
         spin()
 
         commit = commits_to_analyze.pop(0)
+        if commit in seen_commits:
+            # We may be seeing the same commit twice if a feature branch has
+            # been forked in sub-branches. Just skip over what we've seen
+            # already.
+            continue
+        seen_commits.add(commit)
 
         if not commit.message.startswith("Merge"):
-            extract_release_notes(pr, note, commit)
-
+            missing_item, prauthors = extract_release_notes(pr, note, commit)
+            authors.update(prauthors)
             ncommits += 1
-            author = author_aliases.get(commit.author.name, commit.author.name)
-            if author != 'GitHub':
-                authors.add(author)
-            committer = author_aliases.get(commit.committer.name, commit.committer.name)
-            if committer != 'GitHub':
-                authors.add(committer)
+            if missing_item is not None:
+                missing_items.append(missing_item)
 
-        # Exclude any parents reachable from the other side of the
-        # PR merge commit.
         for parent in commit.parents:
-          if not repo.is_ancestor(parent, merge.parents[0]):
-            commits_to_analyze.append(parent)
+            if not repo.is_ancestor(parent, merge.parents[0]):
+                # We're not yet back on the main branch. Just continue digging.
+                commits_to_analyze.append(parent)
+            else:
+                # The parent is on the main branch. We're done digging.
+                # print("found merge parent, stopping. final authors", authors)
+                pass
+
+    if ncommits == len(missing_items):
+        # None of the commits found had a release note. List them.
+        for item in missing_items:
+            missing_release_notes.append(item)
 
     text = repo.git.diff(merge_base.hexsha, tip.hexsha, '--', numstat=True)
     stats = Stats._list_from_string(repo, text)
 
-    individual_authors.update(authors)
+    collect_item(pr, note, merge.hexsha[:shamin], ncommits, authors, stats.total, merge.committed_date)
 
+def collect_item(pr, prtitle, sha, ncommits, authors, stats, prts):
+    individual_authors.update(authors)
     if len(authors) == 0:
         authors.add("Unknown Author")
-
-    item = {
-        'title': note,
-        'pr': pr,
-        'sha': merge.hexsha[:shamin],
-        'ncommits': ncommits,
-        'authors': ", ".join(sorted(authors)),
-        'insertions': stats.total['insertions'],
-        'deletions': stats.total['deletions'],
-        'files': stats.total['files'],
-        'lines': stats.total['lines'],
-        }
+    item = makeitem(pr, prtitle, sha, authors)
+    item.update({'ncommits': ncommits,
+                 'insertions': stats['insertions'],
+                 'deletions': stats['deletions'],
+                 'files': stats['files'],
+                 'lines': stats['lines'],
+                 'date': datetime.date.fromtimestamp(prts).isoformat(),
+                 })
 
     history = per_group_history.get(item['authors'], [])
     history.append(item)
     per_group_history[item['authors']] = history
+
+def analyze_standalone_commit(commit):
+    # Some random out-of-branch commit. Let's not forget them.
+    authors = collect_authors(commit)
+    title = commit.message.split('\n',1)[0].strip()
+    item = makeitem('#unknown', title, commit.hexsha[:shamin], authors)
+    missing_release_notes.append(item)
+    collect_item('#unknown', title, commit.hexsha[:shamin], 1, authors, commit.stats.total, commit.committed_date)
 
 while commit != firstCommit:
     spin()
@@ -466,6 +579,8 @@ while commit != firstCommit:
         prs = numbermatch.group("numbers").strip().split(" ")
         for pr in prs:
             analyze_pr(commit, pr)
+    else:
+        analyze_standalone_commit(commit)
 
     if len(commit.parents) == 0:
         break
@@ -505,14 +620,15 @@ sys.stderr.flush()
 current_version = subprocess.check_output(["git", "describe", "--tags", options.until_commit], universal_newlines=True).strip()
 previous_version = subprocess.check_output(["git", "describe", "--tags", options.from_commit], universal_newlines=True).strip()
 
-print("---")
-print("title: What&#39;s New in", current_version)
-print("toc: false")
-print("summary: Additions and changes in CockroachDB version", current_version, "since version", previous_version)
-print("---")
-print()
-print("## " + time.strftime("%B %d, %Y"))
-print()
+if not hideheader:
+    print("---")
+    print("title: What&#39;s New in", current_version)
+    print("toc: false")
+    print("summary: Additions and changes in CockroachDB version", current_version, "since version", previous_version)
+    print("---")
+    print()
+    print("## " + time.strftime("%B %d, %Y"))
+    print()
 
 ## Print the release notes sign-up and Downloads section.
 if not hidedownloads:
@@ -561,7 +677,7 @@ for sec in relnote_sec_order:
     print("###", sectitle)
     print()
 
-    for item in r:
+    for item in reversed(r):
         print("-", item['note'].replace('\n', '\n  '), renderlinks(item))
 
     print()
@@ -588,9 +704,8 @@ if len(missing_release_notes) > 0:
     print("#### Changes without release note annotation")
     print()
     for item in missing_release_notes:
-        author = item['author'][0]
-        author = author_aliases.get(author, author)
-        print("- [%(pr)s][%(pr)s] [%(sha)s][%(sha)s] %(prtitle)s" % item, "(%s)" % author)
+        authors = item['authors']
+        print("- [%(pr)s][%(pr)s] [%(sha)s][%(sha)s] %(title)s" % item, "(%s)" % authors)
         seenshas.add(item['sha'])
         seenprs.add(item['pr'])
     print()
@@ -617,7 +732,7 @@ if len(ext_contributors) > 0:
     # # not part of the if ext_contributors above.
     if len(firsttime_contributors) > 0:
         print(" We would like to thank the following contributors from the CockroachDB community, with special thanks to first-time contributors ", end='')
-        for i, n in enumerate(firsttime_contributors):
+        for i, n in enumerate(sorted(firsttime_contributors)):
             if i > 0 and i < len(firsttime_contributors)-1:
                 print(', ', end='')
             elif i > 0:
@@ -638,9 +753,9 @@ if not hidepercontributor:
     print("### PRs merged by contributors")
     print()
     if not hideshas:
-        fmt = "  - [%(pr)-6s][%(pr)s] [%(sha)s][%(sha)s] (+%(insertions)4d -%(deletions)4d ~%(lines)4d/%(files)2d) %(title)s"
+        fmt = "  - %(date)s [%(pr)-6s][%(pr)-6s] [%(sha)s][%(sha)s] (+%(insertions)4d -%(deletions)4d ~%(lines)4d/%(files)2d) %(title)s"
     else:
-        fmt = "  - [%(pr)-6s][%(pr)s] (+%(insertions)4d -%(deletions)4d ~%(lines)4d/%(files)2d) %(title)s"
+        fmt = "  - %(date)s [%(pr)-6s][%(pr)-6s] (+%(insertions)4d -%(deletions)4d ~%(lines)4d/%(files)2d) %(title)s"
 
     for group in allgroups:
         items = per_group_history[group]
@@ -662,8 +777,8 @@ if not hidepercontributor:
     print()
 
 # Link the PRs and SHAs
-for pr in sorted(list(seenprs)):
+for pr in sorted(seenprs):
     print("[%s]: https://github.com/cockroachdb/cockroach/pull/%s" % (pr, pr[1:]))
-for sha in seenshas:
+for sha in sorted(seenshas):
     print("[%s]: https://github.com/cockroachdb/cockroach/commit/%s" % (sha, sha))
 print()

--- a/scripts/release-notes/.gitignore
+++ b/scripts/release-notes/.gitignore
@@ -1,0 +1,3 @@
+*.graph.txt
+*.notes.txt
+.git

--- a/scripts/release-notes/Makefile
+++ b/scripts/release-notes/Makefile
@@ -1,0 +1,22 @@
+TESTS := $(wildcard test*.sh)
+BASH ?= /usr/bin/env bash
+PYTHON ?= python
+NOTESCRIPT := $(PWD)/../release-notes.py
+
+all: test
+
+check: test
+
+test: $(TESTS:.sh=.test)
+
+.SUFFIXES: .test
+
+%.test: %.sh %.graph.ref.txt %.notes.ref.txt $(NOTESCRIPT)
+	@echo
+	@echo "**** Testing for $* ****"
+	@echo
+	$(BASH) $*.sh $(NOTESCRIPT)
+
+clean:
+	rm -f *.graph.txt *.notes.txt
+	rm -rf $(TESTS:.sh=)

--- a/scripts/release-notes/README.md
+++ b/scripts/release-notes/README.md
@@ -1,0 +1,21 @@
+This directory contains unit tests for the script `release-notes.py`.
+
+The provided `Makefile` runs all tests.
+
+To run a single test invoke with:
+
+```
+bash ./testN.sh $PWD/../release-notes.py
+```
+
+Optionally, set the `PYTHON` env var to the path of a python 3
+interpreter (useful e.g. if the base `python` command is not v3).
+
+If the script changes and the reference output is not accurate any
+more, you can re-generate a reference output as follows:
+
+```
+bash ./testN.sh $PWD/../release-notes.py rewrite
+```
+
+(i.e. provide one more positional argument)

--- a/scripts/release-notes/common.sh
+++ b/scripts/release-notes/common.sh
@@ -1,0 +1,101 @@
+#!/bin/sh
+
+# Initialize a test.
+function test_init() {
+    PYTHON=${PYTHON:-python}
+
+    # We fix all the git per-commit parameters so that the repo structure
+    # becomes deterministic.
+
+    date="Sun Apr 22 19:26:11 2018 +0200"
+    author="$t <$t@example.com>"
+
+    export GIT_COMMITTER_DATE=$date
+    export GIT_COMMITTER_NAME=$t
+    export GIT_COMMITTER_EMAIL=$t@example.com
+    flags=(--date="$date" --author="$author")
+
+    rm -rf $t
+    mkdir $t
+}
+
+# Initialize the repository. Tag the initial commit.
+function init_repo() {
+    git init
+    touch foo; git add foo; git commit "${flags[@]}" -m "initial"; git tag initial
+}
+
+# Perform some arbitrary change.
+# $1 = commit message.
+function make_change() {
+    git commit --allow-empty "${flags[@]}" -m "$1"
+}
+
+# Mark a branch tip as PR tip.
+# $1 = PR number.
+function tag_pr() {
+    mkdir -p .git/refs/pull/origin
+    git log --pretty=tformat:%H > .git/refs/pull/origin/$1
+}
+
+# Merge a regular branch into the current branch.
+# $1 = branch name
+function merge_branch() {
+    git merge --no-ff -m "Merge $1 into current" $1
+    git commit --amend --no-edit "${flags[@]}"
+}
+
+# Merge a PR branch into the current branch.
+# $1 = branch name
+# $2 = PR number
+# $3 = PR title
+function merge_pr() {
+    branchname=$1
+    prnum=$2
+    prtitle=$3
+    git merge --no-ff -m "Merge #$prnum
+
+$prnum: $prtitle r=foo a=bar
+
+Release note (core change): this must not be included.
+
+Co-authored-by: invisible <invisible@example.com>
+" $branchname
+    git commit --amend --no-edit "${flags[@]}"
+
+    # Make a dummy second pr just to compare the PR message.
+    git checkout -b dummypr
+    make_change "merge pr canary
+
+Release note: none
+"
+    prnum=$(expr $prnum \* 100)
+    tag_pr $prnum
+
+    git checkout master
+    git merge --no-ff -m "Merge pull request #$prnum from foo/bar
+
+$prtitle alternate format
+" dummypr
+    git commit --amend --no-edit "${flags[@]}"
+    git branch -D dummypr
+}
+
+function test_end() {
+    # Check the repo layout is correct.
+    (cd $t && git log --graph --pretty=oneline) >$t.graph.txt
+    if test -z "$rewrite"; then
+        diff -u $t.graph.txt $t.graph.ref.txt
+    else
+        mv -f $t.graph.txt $t.graph.ref.txt
+    fi
+
+    # Check the generated release notes.
+    (cd $t && $PYTHON $relnotescript --hide-header --hide-downloads-section --from initial --until master) >$t.notes.txt
+    if test -z "$rewrite"; then
+        diff -u $t.notes.txt $t.notes.ref.txt
+    else
+        mv -f $t.notes.txt $t.notes.ref.txt
+    fi
+    rm -rf $t
+}

--- a/scripts/release-notes/test1.graph.ref.txt
+++ b/scripts/release-notes/test1.graph.ref.txt
@@ -1,0 +1,10 @@
+*   884025a61241672a11272adfd5dfd71dfec465e6 Merge pull request #100 from foo/bar
+|\  
+| * 75127f3da8ebc69048085b95915d8fb65004857f merge pr canary
+|/  
+*   c95ebe8263cf5ff7261314a16db5ab24e24b874a Merge #1
+|\  
+| * 20a33aaf1a454f99c2489d814601c5b5eea5fea2 feature A
+* | e3a1f2c94ae32eb079bfa558213ed3c6de161dca master update
+|/  
+* 44620da62c54d491c3e707e844ec2c8cddd08e65 initial

--- a/scripts/release-notes/test1.notes.ref.txt
+++ b/scripts/release-notes/test1.notes.ref.txt
@@ -1,0 +1,36 @@
+### Bug Fixes
+
+- Feature A [#1][#1] [20a33aaf1][20a33aaf1]
+
+### Miscellaneous
+
+#### Changes without release note annotation
+
+- [#unknown][#unknown] [e3a1f2c94][e3a1f2c94] master update (test1)
+
+### Doc Updates
+
+Docs team: Please add these manually.
+
+### Contributors
+
+This release includes 2 merged PRs by 1 author. We would like to thank the following contributors from the CockroachDB community:
+
+- test1
+
+### PRs merged by contributors
+
+- test1:
+  - 2018-04-22 [#unknown][#unknown] [e3a1f2c94][e3a1f2c94] (+   0 -   0 ~   0/ 0) master update
+  - 2018-04-22 [#100  ][#100  ] [884025a61][884025a61] (+   0 -   0 ~   0/ 0) PR title alternate format
+  - 2018-04-22 [#1    ][#1    ] [c95ebe826][c95ebe826] (+   0 -   0 ~   0/ 0) PR title
+
+
+[#1]: https://github.com/cockroachdb/cockroach/pull/1
+[#100]: https://github.com/cockroachdb/cockroach/pull/100
+[#unknown]: https://github.com/cockroachdb/cockroach/pull/unknown
+[20a33aaf1]: https://github.com/cockroachdb/cockroach/commit/20a33aaf1
+[884025a61]: https://github.com/cockroachdb/cockroach/commit/884025a61
+[c95ebe826]: https://github.com/cockroachdb/cockroach/commit/c95ebe826
+[e3a1f2c94]: https://github.com/cockroachdb/cockroach/commit/e3a1f2c94
+

--- a/scripts/release-notes/test1.sh
+++ b/scripts/release-notes/test1.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+set -eux
+
+. common.sh
+
+t=test1
+relnotescript=${1:?}
+rewrite=${2:-}
+
+test_init
+
+(
+    cd $t
+    init_repo
+    git branch feature
+    make_change "master update"
+    git checkout feature
+    make_change "feature A
+
+Release note (bug fix): feature A
+"
+    tag_pr 1
+    git checkout master
+    merge_pr feature 1 "PR title"
+)
+
+test_end

--- a/scripts/release-notes/test2.graph.ref.txt
+++ b/scripts/release-notes/test2.graph.ref.txt
@@ -1,0 +1,15 @@
+*   e9b08c236e759dc12120cdf640bc5143e88d0dee Merge pull request #100 from foo/bar
+|\  
+| * 0d5db159f6e1d54e255d3b1bd9074b727c997057 merge pr canary
+|/  
+*   7358b462a53bbfe968b0cebd5ed5922b21456ae3 Merge #1
+|\  
+| * 52d1235ccd64beea0e599fdf54e4bb15c3048398 feature B
+| *   1e3cecb5b073ed0f4d58684ceb9061704ffbf6aa Merge master into current
+| |\  
+| |/  
+|/|   
+* | f872999e881252e140fae78678f2b78356469b2a master update
+| * beda2677429439d88714b47ac5612afa11278a39 feature A
+|/  
+* 05cdaac83b224a29e744bebf52bb92721aa1616d initial

--- a/scripts/release-notes/test2.notes.ref.txt
+++ b/scripts/release-notes/test2.notes.ref.txt
@@ -1,0 +1,38 @@
+### Bug Fixes
+
+- Feature A [#1][#1] [beda26774][beda26774]
+- Feature B [#1][#1] [52d1235cc][52d1235cc]
+
+### Miscellaneous
+
+#### Changes without release note annotation
+
+- [#unknown][#unknown] [f872999e8][f872999e8] master update (test2)
+
+### Doc Updates
+
+Docs team: Please add these manually.
+
+### Contributors
+
+This release includes 2 merged PRs by 1 author. We would like to thank the following contributors from the CockroachDB community:
+
+- test2
+
+### PRs merged by contributors
+
+- test2:
+  - 2018-04-22 [#unknown][#unknown] [f872999e8][f872999e8] (+   0 -   0 ~   0/ 0) master update
+  - 2018-04-22 [#100  ][#100  ] [e9b08c236][e9b08c236] (+   0 -   0 ~   0/ 0) PR title alternate format
+  - 2018-04-22 [#1    ][#1    ] [7358b462a][7358b462a] (+   0 -   0 ~   0/ 0) PR title (2 commits)
+
+
+[#1]: https://github.com/cockroachdb/cockroach/pull/1
+[#100]: https://github.com/cockroachdb/cockroach/pull/100
+[#unknown]: https://github.com/cockroachdb/cockroach/pull/unknown
+[52d1235cc]: https://github.com/cockroachdb/cockroach/commit/52d1235cc
+[7358b462a]: https://github.com/cockroachdb/cockroach/commit/7358b462a
+[beda26774]: https://github.com/cockroachdb/cockroach/commit/beda26774
+[e9b08c236]: https://github.com/cockroachdb/cockroach/commit/e9b08c236
+[f872999e8]: https://github.com/cockroachdb/cockroach/commit/f872999e8
+

--- a/scripts/release-notes/test2.sh
+++ b/scripts/release-notes/test2.sh
@@ -1,0 +1,34 @@
+#!/bin/sh
+set -eux
+
+. common.sh
+
+t=test2
+relnotescript=${1:?}
+rewrite=${2:-}
+
+test_init
+
+# Initialize the repo and populate it.
+(
+    cd $t
+    init_repo
+    git branch feature
+    make_change "master update"
+    git checkout feature
+    make_change "feature A
+
+Release note (bug fix): feature A
+"
+    merge_branch master
+    make_change "feature B
+
+Release note (bug fix): feature B
+"
+
+    tag_pr 1
+    git checkout master
+    merge_pr feature 1 "PR title"
+)
+
+test_end

--- a/scripts/release-notes/test3.graph.ref.txt
+++ b/scripts/release-notes/test3.graph.ref.txt
@@ -1,0 +1,16 @@
+*   b719cfe9ebf65d0859db8aae2450803de5e1183d Merge pull request #100 from foo/bar
+|\  
+| * 1e36b35c413df3aea85463bfeb807c68497757e1 merge pr canary
+|/  
+*   ef634455eb2a8d4457d4ac47ddd080c4542cee85 Merge #1
+|\  
+| * 5fc640e1739d155b373adb7b319feeaa66b967d5 feature D
+| *   8d77d570f6005f271cb645702947ab5e501dd923 Merge feature2 into current
+| |\  
+| | * 0ac9dc576f658416cf11a7b06eb85c630374ccff feature C
+| * | 93ba1ab8f65dfa8312fce3890d82be0c4e5d3261 feature B
+| |/  
+| * 6a84145e9ca9b8bf337c8ae195f0f1f68f1486c7 feature A
+* | 4f4329fdc8766d61fff96a75f24e451c2158e715 master update
+|/  
+* e82a66de5a4d9a4cb06024f0d7d3e328c175c020 initial

--- a/scripts/release-notes/test3.notes.ref.txt
+++ b/scripts/release-notes/test3.notes.ref.txt
@@ -1,0 +1,42 @@
+### Bug Fixes
+
+- Feature A [#1][#1] [6a84145e9][6a84145e9]
+- Feature C [#1][#1] [0ac9dc576][0ac9dc576]
+- Feature B [#1][#1] [93ba1ab8f][93ba1ab8f]
+- Feature D [#1][#1] [5fc640e17][5fc640e17]
+
+### Miscellaneous
+
+#### Changes without release note annotation
+
+- [#unknown][#unknown] [4f4329fdc][4f4329fdc] master update (test3)
+
+### Doc Updates
+
+Docs team: Please add these manually.
+
+### Contributors
+
+This release includes 2 merged PRs by 1 author. We would like to thank the following contributors from the CockroachDB community:
+
+- test3
+
+### PRs merged by contributors
+
+- test3:
+  - 2018-04-22 [#unknown][#unknown] [4f4329fdc][4f4329fdc] (+   0 -   0 ~   0/ 0) master update
+  - 2018-04-22 [#100  ][#100  ] [b719cfe9e][b719cfe9e] (+   0 -   0 ~   0/ 0) PR title alternate format
+  - 2018-04-22 [#1    ][#1    ] [ef634455e][ef634455e] (+   0 -   0 ~   0/ 0) PR title (4 commits)
+
+
+[#1]: https://github.com/cockroachdb/cockroach/pull/1
+[#100]: https://github.com/cockroachdb/cockroach/pull/100
+[#unknown]: https://github.com/cockroachdb/cockroach/pull/unknown
+[0ac9dc576]: https://github.com/cockroachdb/cockroach/commit/0ac9dc576
+[4f4329fdc]: https://github.com/cockroachdb/cockroach/commit/4f4329fdc
+[5fc640e17]: https://github.com/cockroachdb/cockroach/commit/5fc640e17
+[6a84145e9]: https://github.com/cockroachdb/cockroach/commit/6a84145e9
+[93ba1ab8f]: https://github.com/cockroachdb/cockroach/commit/93ba1ab8f
+[b719cfe9e]: https://github.com/cockroachdb/cockroach/commit/b719cfe9e
+[ef634455e]: https://github.com/cockroachdb/cockroach/commit/ef634455e
+

--- a/scripts/release-notes/test3.sh
+++ b/scripts/release-notes/test3.sh
@@ -1,0 +1,45 @@
+#!/bin/sh
+set -eux
+
+. common.sh
+
+t=test3
+relnotescript=${1:?}
+rewrite=${2:-}
+
+test_init
+
+(
+    cd $t
+    init_repo
+    git branch feature
+    make_change "master update"
+    git checkout feature
+    make_change "feature A
+
+Release note (bug fix): feature A
+"
+    git branch feature2
+    make_change "feature B
+
+Release note (bug fix): feature B
+"
+    git checkout feature2
+    make_change "feature C
+
+Release note (bug fix): feature C
+"
+    git checkout feature
+    merge_branch feature2
+
+    make_change "feature D
+
+Release note (bug fix): feature D
+"
+    tag_pr 1
+    git checkout master
+    merge_pr feature 1 "PR title"
+)
+
+test_end
+

--- a/scripts/release-notes/test4.graph.ref.txt
+++ b/scripts/release-notes/test4.graph.ref.txt
@@ -1,0 +1,13 @@
+*   1525c88bd9a64ce54a6bea3d3617d71e898e03d5 Merge pull request #100 from foo/bar
+|\  
+| * 2da1c450656b0019b54ef2513871d4a890893078 merge pr canary
+|/  
+*   32204525ae2035ae0bca0d908ac238bf55f007a0 Merge #1
+|\  
+| * 76bb9f090c940b7850adaf2849ec024051d4acf9 feature E
+| * 662a10125e947acf68c213140f1ba450e5350b06 feature D
+| * 170e4d8b145c937bf2105ee8fa1e773e4c255f0d feature C
+| * 8e82a68d78e68f798df6b80b35c732c8f0df0f3f feature B
+| * 2fcb5a5bd5d16c72d30044bd1d7adb305f4c16ce feature A
+|/  
+* 40ff9538554081ef30593b66d07066e003ce66a9 initial

--- a/scripts/release-notes/test4.notes.ref.txt
+++ b/scripts/release-notes/test4.notes.ref.txt
@@ -1,0 +1,43 @@
+### Bug Fixes
+
+- Feature A release note 1
+  
+  some text for note 1 [#1][#1] [2fcb5a5bd][2fcb5a5bd]
+- Feature A release note 2
+  
+  some text for note 2 [#1][#1] [2fcb5a5bd][2fcb5a5bd]
+- Feature B release note 1 [#1][#1] [8e82a68d7][8e82a68d7]
+- Feature C [#1][#1] [170e4d8b1][170e4d8b1]
+- Feature D [#1][#1] [662a10125][662a10125]
+- Feature E [#1][#1] [76bb9f090][76bb9f090]
+
+### Doc Updates
+
+Docs team: Please add these manually.
+
+### Contributors
+
+This release includes 2 merged PRs by 3 authors. We would like to thank the following contributors from the CockroachDB community, with special thanks to first-time contributors bar, and foo.
+- bar
+- foo
+- test4
+
+### PRs merged by contributors
+
+- bar, foo, test4:
+  - 2018-04-22 [#1    ][#1    ] [32204525a][32204525a] (+   0 -   0 ~   0/ 0) PR title (5 commits)
+
+- test4:
+  - 2018-04-22 [#100  ][#100  ] [1525c88bd][1525c88bd] (+   0 -   0 ~   0/ 0) PR title alternate format
+
+
+[#1]: https://github.com/cockroachdb/cockroach/pull/1
+[#100]: https://github.com/cockroachdb/cockroach/pull/100
+[1525c88bd]: https://github.com/cockroachdb/cockroach/commit/1525c88bd
+[170e4d8b1]: https://github.com/cockroachdb/cockroach/commit/170e4d8b1
+[2fcb5a5bd]: https://github.com/cockroachdb/cockroach/commit/2fcb5a5bd
+[32204525a]: https://github.com/cockroachdb/cockroach/commit/32204525a
+[662a10125]: https://github.com/cockroachdb/cockroach/commit/662a10125
+[76bb9f090]: https://github.com/cockroachdb/cockroach/commit/76bb9f090
+[8e82a68d7]: https://github.com/cockroachdb/cockroach/commit/8e82a68d7
+

--- a/scripts/release-notes/test4.sh
+++ b/scripts/release-notes/test4.sh
@@ -1,0 +1,63 @@
+#!/bin/sh
+set -eux
+
+. common.sh
+
+t=test4
+relnotescript=${1:?}
+rewrite=${2:-}
+
+test_init
+
+(
+    cd $t
+    init_repo
+    git checkout -b feature
+
+    make_change "feature A
+
+Release note (bug fix): feature A release note 1
+
+some text for note 1
+
+Release note (bug fix): feature A release note 2
+
+some text for note 2
+"
+
+    make_change "feature B
+
+Release note (bug fix, core change): feature B release note 1
+"
+
+    make_change "feature C
+
+Release note (bug fix): feature C
+
+Fixes #123124. (this should not be included in result)
+close #12313. (this neither)
+"
+
+    # See other authors.
+    make_change "feature D
+
+Release note (bug fix): feature D
+"
+    git commit --amend --date="$date" --author='foo <foo@example.com>' --no-edit --allow-empty
+
+    make_change "feature E
+
+Release note (bug fix): feature E
+
+Co-authored-by: bar <bar@example.com>
+
+trailing garbage (should be ignored)
+"
+
+    tag_pr 1
+    git checkout master
+
+    merge_pr feature 1 "PR title"
+)
+
+test_end

--- a/scripts/release-notes/test5.graph.ref.txt
+++ b/scripts/release-notes/test5.graph.ref.txt
@@ -1,0 +1,18 @@
+*   d3ba7bcec05baa02557ad0fb6ab6c621f4aeb3e7 Merge pull request #200 from foo/bar
+|\  
+| * b93d15ec72d9c1a0ebc675174fa14d86c4e12690 merge pr canary
+|/  
+*   931c78112cb45cbe7080dc01643d65523d644909 Merge #2
+|\  
+| * 8156afc96a454fc4911e5695e454747d220fac3a feature B - missing release note
+|/  
+*   cfb4c716b1f65a48e9dbfe4b7eb1211264e95567 Merge pull request #100 from foo/bar
+|\  
+| * a5db87e6ac20f5b7e99a9f9c43cf24556ce17aa8 merge pr canary
+|/  
+*   b8a9a7f703bf66e7658aaddc161d14a6e10472d6 Merge #1
+|\  
+| * ba26457bebdf32cd82b292e2c1ee0506717169c1 minor fix - no release note
+| * 07639395743b09f14c86432aa61d5429978ab793 feature A
+|/  
+* dcb8668d9b3337937b98bcc63f268c761ee66101 initial

--- a/scripts/release-notes/test5.notes.ref.txt
+++ b/scripts/release-notes/test5.notes.ref.txt
@@ -1,0 +1,40 @@
+### Bug Fixes
+
+- Feature A [#1][#1] [076393957][076393957]
+
+### Miscellaneous
+
+#### Changes without release note annotation
+
+- [#2][#2] [8156afc96][8156afc96] PR title in need of release note (test5)
+
+### Doc Updates
+
+Docs team: Please add these manually.
+
+### Contributors
+
+This release includes 4 merged PRs by 1 author. We would like to thank the following contributors from the CockroachDB community:
+
+- test5
+
+### PRs merged by contributors
+
+- test5:
+  - 2018-04-22 [#200  ][#200  ] [d3ba7bcec][d3ba7bcec] (+   0 -   0 ~   0/ 0) PR title in need of release note alternate format
+  - 2018-04-22 [#2    ][#2    ] [931c78112][931c78112] (+   0 -   0 ~   0/ 0) PR title in need of release note
+  - 2018-04-22 [#100  ][#100  ] [cfb4c716b][cfb4c716b] (+   0 -   0 ~   0/ 0) PR title alternate format
+  - 2018-04-22 [#1    ][#1    ] [b8a9a7f70][b8a9a7f70] (+   0 -   0 ~   0/ 0) PR title (2 commits)
+
+
+[#1]: https://github.com/cockroachdb/cockroach/pull/1
+[#100]: https://github.com/cockroachdb/cockroach/pull/100
+[#2]: https://github.com/cockroachdb/cockroach/pull/2
+[#200]: https://github.com/cockroachdb/cockroach/pull/200
+[076393957]: https://github.com/cockroachdb/cockroach/commit/076393957
+[8156afc96]: https://github.com/cockroachdb/cockroach/commit/8156afc96
+[931c78112]: https://github.com/cockroachdb/cockroach/commit/931c78112
+[b8a9a7f70]: https://github.com/cockroachdb/cockroach/commit/b8a9a7f70
+[cfb4c716b]: https://github.com/cockroachdb/cockroach/commit/cfb4c716b
+[d3ba7bcec]: https://github.com/cockroachdb/cockroach/commit/d3ba7bcec
+

--- a/scripts/release-notes/test5.sh
+++ b/scripts/release-notes/test5.sh
@@ -1,0 +1,34 @@
+#!/bin/sh
+set -eux
+
+. common.sh
+
+t=test5
+relnotescript=${1:?}
+rewrite=${2:-}
+
+test_init
+
+(
+    cd $t
+    init_repo
+    git checkout -b feature
+    make_change "feature A
+
+Release note (bug fix): feature A
+"
+    make_change "minor fix - no release note"
+    tag_pr 1
+    git checkout master
+    merge_pr feature 1 "PR title"
+
+    git branch -D feature
+    git checkout -b feature
+    make_change "feature B - missing release note"
+    tag_pr 2
+    git checkout master
+    merge_pr feature 2 "PR title in need of release note"
+
+)
+
+test_end

--- a/scripts/release-notes/test6.graph.ref.txt
+++ b/scripts/release-notes/test6.graph.ref.txt
@@ -1,0 +1,18 @@
+*   5105ca93f3c4cde8865f840f810f4d2b0c4e7e62 Merge pull request #200 from foo/bar
+|\  
+| * 0f4c2b0500c7fcc27e95b488bed6bb748f389cbb merge pr canary
+|/  
+*   38b0488f9b16ea35deeb82d45efde8633a4f40bf Merge #2
+|\  
+| * 97eb9fa9a4b1fbc48444bd8000b9ac8b7cfb9b87 feature B - commit 2
+| * d456d947b78edb7dbc096a9693f73bde14c41d5d feature B - commit 1
+|/  
+*   4279dfba7939245629a2d5f5faf54663efd2e005 Merge pull request #100 from foo/bar
+|\  
+| * d168a8892abcbdfa8104f20e25b83ddcd7d19d7b merge pr canary
+|/  
+*   2ae4772fb68d385ee81f3ca46596c2637f24bd65 Merge #1
+|\  
+| * 9b5c8396188688e9a43cc00fcf2b9736f0398171 feature A
+|/  
+* dacbef8585d93a7059dccbd5a52de9fb14edf54b initial

--- a/scripts/release-notes/test6.notes.ref.txt
+++ b/scripts/release-notes/test6.notes.ref.txt
@@ -1,0 +1,28 @@
+### Doc Updates
+
+Docs team: Please add these manually.
+
+### Contributors
+
+This release includes 4 merged PRs by 1 author. We would like to thank the following contributors from the CockroachDB community:
+
+- test6
+
+### PRs merged by contributors
+
+- test6:
+  - 2018-04-22 [#200  ][#200  ] [5105ca93f][5105ca93f] (+   0 -   0 ~   0/ 0) PR title 2 alternate format
+  - 2018-04-22 [#2    ][#2    ] [38b0488f9][38b0488f9] (+   0 -   0 ~   0/ 0) PR title 2 (2 commits)
+  - 2018-04-22 [#100  ][#100  ] [4279dfba7][4279dfba7] (+   0 -   0 ~   0/ 0) PR title 1 alternate format
+  - 2018-04-22 [#1    ][#1    ] [2ae4772fb][2ae4772fb] (+   0 -   0 ~   0/ 0) PR title 1
+
+
+[#1]: https://github.com/cockroachdb/cockroach/pull/1
+[#100]: https://github.com/cockroachdb/cockroach/pull/100
+[#2]: https://github.com/cockroachdb/cockroach/pull/2
+[#200]: https://github.com/cockroachdb/cockroach/pull/200
+[2ae4772fb]: https://github.com/cockroachdb/cockroach/commit/2ae4772fb
+[38b0488f9]: https://github.com/cockroachdb/cockroach/commit/38b0488f9
+[4279dfba7]: https://github.com/cockroachdb/cockroach/commit/4279dfba7
+[5105ca93f]: https://github.com/cockroachdb/cockroach/commit/5105ca93f
+

--- a/scripts/release-notes/test6.sh
+++ b/scripts/release-notes/test6.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+set -eux
+
+. common.sh
+
+t=test6
+relnotescript=${1:?}
+rewrite=${2:-}
+
+test_init
+
+(
+    cd $t
+    init_repo
+
+    git checkout -b feature1
+    make_change "feature A
+
+Release note: none
+"
+    tag_pr 1
+    git checkout master
+    merge_pr feature1 1 "PR title 1"
+
+    git checkout -b feature2
+    make_change "feature B - commit 1"
+    make_change "feature B - commit 2
+
+Release note: none
+"
+    tag_pr 2
+    git checkout master
+    merge_pr feature2 2 "PR title 2"
+)
+
+test_end


### PR DESCRIPTION
.. and add unit tests.

Fixes #24600.
Fixes #24979.

The following have been improved:

- if a PR contains multiple commits, and only some of them contain
  a release note, then the remaining commits will not be listed
  any more in the section "changes without release note".
  This aligns the behavior with what is allowed in the contributor guide.
- the script now recognizes the new Github marker "Co-authored-by" in
  commit messages.
- if a single commit contains multiple release notes, they will now be
  correctly separated into multiple entries.
- the script now finds/recognizes commits that have been committed
  to the main branch without a fork/merge.
- intermediate pulls/merges into feature branches are now properly
  handled.
- newline characters at the end of a PR title are now properly
  stripped.
- the release notes are now listed in the order they were committed,
  instead of reverse order. This makes the list more readable (the reader
  can "follow along" with the changes).

Release note: None

cc @jseldess 