### PR TITLE
util/log: ensure that also the first log file contains the cluster ID

### DIFF
--- a/pkg/cli/interactive_tests/test_log_config_msg.tcl
+++ b/pkg/cli/interactive_tests/test_log_config_msg.tcl
@@ -2,6 +2,14 @@
 
 source [file join [file dirname $argv0] common.tcl]
 
+start_server $argv
+
+start_test "Check that the cluster ID is reported at the start of the first log file."
+system "grep '\\\[config\\\] clusterID:' logs/db/logs/cockroach.log"
+end_test
+
+stop_server $argv
+
 # Make a server with a tiny log buffer so as to force frequent log rotation.
 system "mkfifo pid_fifo || true; $argv start --insecure --pid-file=pid_fifo --background -s=path=logs/db --log-file-max-size=2k >>logs/expect-cmd.log 2>&1 & cat pid_fifo > server_pid"
 

--- a/pkg/util/log/clog.go
+++ b/pkg/util/log/clog.go
@@ -713,6 +713,14 @@ var logging loggingT
 
 // SetClusterID stores the Cluster ID for further reference.
 func SetClusterID(clusterID string) {
+	// Ensure that the clusterID is logged with the same format as for
+	// new log files, even on the first log file. This ensures that grep
+	// will always find it.
+	file, line, _ := caller.Lookup(1)
+	logging.outputLogEntry(Severity_INFO, file, line,
+		fmt.Sprintf("[config] clusterID: %s", clusterID))
+
+	// Perform the change proper.
 	logging.mu.Lock()
 	defer logging.mu.Unlock()
 


### PR DESCRIPTION
Requested by @bdarnell in https://github.com/cockroachdb/cockroach/pull/24926#issuecomment-383617517.

This ensures that `grep '\[config\]'
cockroach.log` finds it, even on the first log file.

Release note (general change): The cluster ID is also reported with
tag `[config]` in the first log file, not only when log files are
rotated.