### PR TITLE
sql: stop SQLRunner from swallowing query errors

### DIFF
--- a/pkg/testutils/sqlutils/main_test.go
+++ b/pkg/testutils/sqlutils/main_test.go
@@ -1,0 +1,31 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package sqlutils_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/security"
+	"github.com/cockroachdb/cockroach/pkg/security/securitytest"
+	"github.com/cockroachdb/cockroach/pkg/server"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
+)
+
+func TestMain(m *testing.M) {
+	security.SetAssetLoader(securitytest.EmbeddedAssets)
+	randutil.SeedForTests()
+	serverutils.InitTestServerFactory(server.TestServerFactory)
+	serverutils.InitTestClusterFactory(testcluster.TestClusterFactory)
+	os.Exit(m.Run())
+}
+
+//go:generate ../../util/leaktest/add-leaktest.sh *_test.go

--- a/pkg/testutils/sqlutils/sql_runner.go
+++ b/pkg/testutils/sqlutils/sql_runner.go
@@ -132,6 +132,9 @@ func RowsToStrMatrix(rows *gosql.Rows) ([][]string, error) {
 		}
 		res = append(res, row)
 	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
 	return res, nil
 }
 

--- a/pkg/testutils/sqlutils/sql_runner_test.go
+++ b/pkg/testutils/sqlutils/sql_runner_test.go
@@ -1,0 +1,45 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package sqlutils_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+)
+
+// Test that the RowsToStrMatrix doesn't swallow errors.
+func TestRowsToStrMatrixError(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	s, db, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	defer s.Stopper().Stop(context.TODO())
+
+	// We'll run a query that only fails after returning some rows, so that the
+	// error is discovered by RowsToStrMatrix below.
+	rows, err := db.Query(
+		"select generate_series(1,10) union all select crdb_internal.force_error('00000', 'testing error')")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := sqlutils.RowsToStrMatrix(rows); !testutils.IsError(err, "testing error") {
+		t.Fatalf("expected 'testing error', got: %v", err)
+	}
+}

--- a/pkg/testutils/sqlutils/table_gen_test.go
+++ b/pkg/testutils/sqlutils/table_gen_test.go
@@ -17,9 +17,12 @@ package sqlutils
 import (
 	"bytes"
 	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 )
 
 func TestIntToEnglish(t *testing.T) {
+	defer leaktest.AfterTest(t)()
 	testCases := []struct {
 		val int
 		exp string
@@ -41,6 +44,7 @@ func TestIntToEnglish(t *testing.T) {
 }
 
 func TestGenValues(t *testing.T) {
+	defer leaktest.AfterTest(t)()
 	var buf bytes.Buffer
 	genValues(&buf, 7, 11, ToRowFn(RowIdxFn, RowModuloFn(3), RowEnglishFn))
 	expected := `(7,1,'seven'),(8,2,'eight'),(9,0,'nine'),(10,1,'one-zero'),(11,2,'one-one')`


### PR DESCRIPTION
Release note: None