### PR TITLE
opt: fix incorrect ColSet aliasing

### DIFF
--- a/pkg/sql/opt/memo/logical_props_factory.go
+++ b/pkg/sql/opt/memo/logical_props_factory.go
@@ -204,9 +204,8 @@ func (f logicalPropsFactory) constructGroupByProps(ev ExprView) LogicalProps {
 	// Output columns are the union of grouping columns with columns from the
 	// aggregate projection list.
 	groupingColSet := ev.Private().(opt.ColSet)
-	props.Relational.OutputCols = groupingColSet
 	aggColList := ev.Child(1).Private().(opt.ColList)
-	props.Relational.OutputCols.UnionWith(opt.ColListToSet(aggColList))
+	props.Relational.OutputCols = groupingColSet.Union(opt.ColListToSet(aggColList))
 
 	// Propagate not null setting from input columns that are being grouped.
 	props.Relational.NotNullCols = inputProps.NotNullCols.Copy()

--- a/pkg/sql/opt/memo/statistics_test.go
+++ b/pkg/sql/opt/memo/statistics_test.go
@@ -145,7 +145,7 @@ func TestTranslateColSet(t *testing.T) {
 		t.Helper()
 
 		actual := translateColSet(colSetIn, from, to)
-		if actual != expected {
+		if !actual.Equals(expected) {
 			t.Fatalf("\nexpected: %s\nactual  : %s", expected, actual)
 		}
 	}

--- a/pkg/sql/opt/norm/factory.go
+++ b/pkg/sql/opt/norm/factory.go
@@ -391,8 +391,7 @@ func (f *Factory) neededCols2(left, right memo.GroupID) opt.ColSet {
 
 // neededCols3 unions the set of columns needed by any of the given groups.
 func (f *Factory) neededCols3(group1, group2, group3 memo.GroupID) opt.ColSet {
-	cols := f.outerCols(group1)
-	cols.UnionWith(f.outerCols(group2))
+	cols := f.outerCols(group1).Union(f.outerCols(group2))
 	cols.UnionWith(f.outerCols(group3))
 	return cols
 }

--- a/pkg/util/fast_int_set_test.go
+++ b/pkg/util/fast_int_set_test.go
@@ -240,10 +240,12 @@ func TestFastIntSetTwoSetOps(t *testing.T) {
 
 func TestFastIntSetAddRange(t *testing.T) {
 	assertSet := func(set *FastIntSet, from, to int) {
+		t.Helper()
 		// Iterate through the set and ensure that the values
 		// it contain are the values from 'from' to 'to' (inclusively).
 		expected := from
 		set.ForEach(func(actual int) {
+			t.Helper()
 			if actual > to {
 				t.Fatalf("expected last value in FastIntSet to be %d, got %d", to, actual)
 			}


### PR DESCRIPTION
#### util: support smaller cutoff in FastIntSet

Some of the code in FastIntSet doesn't work properly if the cutoff is
set to something smaller than 64. Fixing these issues so we can root
out usage bugs by setting a very small cutoff.

Release note: None

#### opt: fix incorrect ColSet aliasing

Fixing a few occurrences of incorrectly modifying a ColSet that
someone else still has a reference to. This is only a problem in the
"large" case; the cutoff was temporarily reduced to 2 to find these
bugs.

Release note: None
