### PR TITLE
sql: support 'base64' args for encode/decode

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -624,9 +624,9 @@ Compatible elements: hour, minute, second, millisecond, microsecond.</p>
 <tr><td><code>concat_ws(<a href="string.html">string</a>...) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Uses the first argument as a separator between the concatenation of the subsequent arguments.</p>
 <p>For example <code>concat_ws('!','wow','great')</code> returns <code>wow!great</code>.</p>
 </span></td></tr>
-<tr><td><code>decode(text: <a href="string.html">string</a>, format: <a href="string.html">string</a>) &rarr; <a href="bytes.html">bytes</a></code></td><td><span class="funcdesc"><p>Decodes <code>data</code> as the format specified by <code>format</code> (only “hex” and “escape” are supported).</p>
+<tr><td><code>decode(text: <a href="string.html">string</a>, format: <a href="string.html">string</a>) &rarr; <a href="bytes.html">bytes</a></code></td><td><span class="funcdesc"><p>Decodes <code>data</code> as the format specified by <code>format</code> (only “hex”, “escape”, and “base64” are supported).</p>
 </span></td></tr>
-<tr><td><code>encode(data: <a href="bytes.html">bytes</a>, format: <a href="string.html">string</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Encodes <code>data</code> in the text format specified by <code>format</code> (only “hex” and “escape” are supported).</p>
+<tr><td><code>encode(data: <a href="bytes.html">bytes</a>, format: <a href="string.html">string</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Encodes <code>data</code> in the text format specified by <code>format</code> (only “hex”, “escape”, and “base64” are supported).</p>
 </span></td></tr>
 <tr><td><code>from_ip(val: <a href="bytes.html">bytes</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Converts the byte string representation of an IP to its character string representation.</p>
 </span></td></tr>

--- a/pkg/sql/logictest/testdata/logic_test/builtin_function
+++ b/pkg/sql/logictest/testdata/logic_test/builtin_function
@@ -1361,6 +1361,30 @@ SELECT DECODE('123\000456', 'escape')::STRING
 ----
 \x31323300343536
 
+query TT
+SELECT ENCODE('abc', 'base64'), DECODE('YWJj', 'base64')
+----
+YWJj abc
+
+query T
+SELECT DECODE('padded==', 'base64')::STRING
+----
+\xa5a75d79
+
+query T
+SELECT DECODE('padded1=', 'base64')::STRING
+----
+\xa5a75d79dd
+
+query error illegal base64 data at input byte 4
+SELECT DECODE('invalid', 'base64')
+
+query error only 'hex', 'escape', and 'base64' formats are supported for ENCODE
+SELECT ENCODE('abc', 'fake')
+
+query error only 'hex', 'escape', and 'base64' formats are supported for DECODE
+SELECT DECODE('abc', 'fake')
+
 query T
 SELECT FROM_IP(b'\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xff\xff\x01\x02\x03\x04')
 ----

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -20,6 +20,7 @@ import (
 	"crypto/sha1"
 	"crypto/sha256"
 	"crypto/sha512"
+	"encoding/base64"
 	"encoding/hex"
 	"fmt"
 	"hash"
@@ -580,11 +581,14 @@ var Builtins = map[string][]tree.Builtin{
 					return tree.NewDString(buf.String()), nil
 				case "escape":
 					return tree.NewDString(encodeEscape([]byte(data))), nil
+				case "base64":
+					enc := base64.StdEncoding.EncodeToString([]byte(data))
+					return tree.NewDString(enc), nil
 				default:
-					return nil, pgerror.NewError(pgerror.CodeInvalidParameterValueError, "only 'hex' and 'escape' formats are supported for ENCODE")
+					return nil, pgerror.NewError(pgerror.CodeInvalidParameterValueError, "only 'hex', 'escape', and 'base64' formats are supported for ENCODE")
 				}
 			},
-			Info: "Encodes `data` in the text format specified by `format` (only \"hex\" and \"escape\" are supported).",
+			Info: "Encodes `data` in the text format specified by `format` (only \"hex\", \"escape\", and \"base64\" are supported).",
 		},
 	},
 
@@ -607,11 +611,17 @@ var Builtins = map[string][]tree.Builtin{
 						return nil, err
 					}
 					return tree.NewDBytes(tree.DBytes(decoded)), nil
+				case "base64":
+					decoded, err := base64.StdEncoding.DecodeString(data)
+					if err != nil {
+						return nil, err
+					}
+					return tree.NewDBytes(tree.DBytes(decoded)), nil
 				default:
-					return nil, pgerror.NewError(pgerror.CodeInvalidParameterValueError, "only 'hex' and 'escape' formats are supported for DECODE")
+					return nil, pgerror.NewError(pgerror.CodeInvalidParameterValueError, "only 'hex', 'escape', and 'base64' formats are supported for DECODE")
 				}
 			},
-			Info: "Decodes `data` as the format specified by `format` (only \"hex\" and \"escape\" are supported).",
+			Info: "Decodes `data` as the format specified by `format` (only \"hex\", \"escape\", and \"base64\" are supported).",
 		},
 	},
 


### PR DESCRIPTION
Release note (sql change): Add 'base64' option to the encode/decode
builtins.