### PR TITLE
Makefile: work around symlink bug in Go toolchain

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -239,7 +239,13 @@ export PATH := $(abspath bin):$(PATH)
 # Setting the SHELL variable to a value other than the default (/bin/sh)
 # is one way to do this globally.
 # http://stackoverflow.com/questions/8941110/how-i-could-add-dir-to-path-in-makefile/13468229#13468229
-export SHELL := $(shell which bash)
+#
+# We also force the PWD environment variable to $(CURDIR), which ensures that
+# any programs invoked by Make see a physical CWD without any symlinks. The Go
+# toolchain does not support symlinks well (for one example, see
+# https://github.com/golang/go/issues/24359). This may be fixed when GOPATH is
+# deprecated, so revisit whether this workaround is necessary then.
+export SHELL := env PWD=$(CURDIR) bash
 ifeq ($(SHELL),)
 $(error bash is required)
 endif


### PR DESCRIPTION
Build info injected via linker flags, like the Git commit SHA, is
dropped on the floor when building from a symlink (e.g., ~/roach ->
~/go/src/cockroachdb/cockroach). This issue was filed upstream
(golang/go#24359), but the Go team refused to fix it. Luckily, we can
work around it by teaching Make to resolve any symlinks in the CWD.

Release note (build change): Build metadata, like the commit SHA and build
time, is properly injected into the binary when using Go 1.10 and building from
a symlink.