### PR TITLE
storage: queue requests to push txn / resolve intents on single keys

### DIFF
--- a/pkg/storage/batcheval/cmd_push_txn.go
+++ b/pkg/storage/batcheval/cmd_push_txn.go
@@ -205,8 +205,8 @@ func PushTxn(
 		if !pusherWins {
 			s = "failed to push"
 		}
-		log.Infof(ctx, "%s "+s+" %s: %s (pushee last active: %s)",
-			args.PusherTxn.Short(), args.PusheeTxn.Short(),
+		log.Infof(ctx, "%s "+s+" (push type=%s) %s: %s (pushee last active: %s)",
+			args.PusherTxn.Short(), args.PushType, args.PusheeTxn.Short(),
 			reason, reply.PusheeTxn.LastActive())
 	}
 

--- a/pkg/storage/intent_resolver.go
+++ b/pkg/storage/intent_resolver.go
@@ -16,6 +16,7 @@
 package storage
 
 import (
+	"container/list"
 	"context"
 	"sort"
 	"time"
@@ -58,12 +59,308 @@ const (
 	intentResolverBatchSize = 100
 )
 
+type pusher struct {
+	txn      *roachpb.Transaction
+	waitCh   chan *enginepb.TxnMeta
+	detectCh chan struct{}
+}
+
+func newPusher(txn *roachpb.Transaction) *pusher {
+	p := &pusher{
+		txn:    txn,
+		waitCh: make(chan *enginepb.TxnMeta, 1),
+	}
+	if p.activeTxn() {
+		p.detectCh = make(chan struct{}, 1)
+		// Signal the channel in order to begin dependency cycle detection.
+		p.detectCh <- struct{}{}
+	}
+	return p
+}
+
+func (p *pusher) activeTxn() bool {
+	return p.txn != nil && p.txn.Key != nil
+}
+
+type contendedKey struct {
+	ll *list.List
+	// lastTxnMeta is the most recent txn to own the intent. Active
+	// transactions in the contention queue for this intent must push
+	// this txn record in order to detect dependency cycles.
+	lastTxnMeta *enginepb.TxnMeta
+}
+
+func newContendedKey() *contendedKey {
+	return &contendedKey{
+		ll: list.New(),
+	}
+}
+
+// setLastTxnMeta sets the most recent txn meta and sends to all
+// pushers w/ active txns still in the queue to push, to guarantee
+// detection of dependency cycles.
+func (ck *contendedKey) setLastTxnMeta(txnMeta *enginepb.TxnMeta) {
+	ck.lastTxnMeta = txnMeta
+	if txnMeta == nil {
+		return
+	}
+	for e := ck.ll.Front(); e != nil; e = e.Next() {
+		p := e.Value.(*pusher)
+		if p.detectCh != nil {
+			select {
+			case p.detectCh <- struct{}{}:
+			default:
+			}
+		}
+	}
+}
+
+// contentionQueue handles contention on keys with conflicting intents
+// by forming queues of "pushers" which are requests that experienced
+// a WriteIntentError. There is a queue for each key with one or more
+// pushers. Queues are complicated by the difference between pushers
+// with writing transactions (i.e. they may have a transaction record
+// which can be pushed) and non-writing transactions (e.g.,
+// non-transactional requests, and read-only transactions).
+//
+// Queues are linked lists, with each element containing a transaction
+// (can be nil), and a wait channel. The wait channel is closed when
+// the request is dequeued and run to completion, whether to success
+// or failure. Pushers wait on the most recent pusher in the queue to
+// complete. However, pushers with an active transaction (i.e., txns
+// with a non-nil key) must send a PushTxn RPC. This is necessary in
+// order to properly detect dependency cycles.
+type contentionQueue struct {
+	// keys is a map from key to a linked list of pusher instances,
+	// ordered as a FIFO queue.
+	store *Store
+	mu    struct {
+		syncutil.Mutex
+		keys map[string]*contendedKey
+	}
+}
+
+func newContentionQueue(store *Store) *contentionQueue {
+	cq := &contentionQueue{
+		store: store,
+	}
+	cq.mu.keys = map[string]*contendedKey{}
+	return cq
+}
+
+func txnID(txn *roachpb.Transaction) string {
+	if txn == nil {
+		return "nil txn"
+	}
+	return txn.ID.Short()
+}
+
+// add adds the intent specified in the supplied wiErr to the
+// contention queue. This may block the current goroutine if the
+// pusher has no transaction or the transaction is not yet writing
+// (i.e. read-only or hasn't successfully executed BeginTxn).
+//
+// Note that the supplied wiErr write intent error must have only a
+// single intent (len(wiErr.Intents) == 1).
+//
+// Returns a cleanup function to be invoked by the caller after the
+// original request completes, a possibly updated WriteIntentError and
+// a bool indicating whether the intent resolver should regard the
+// original push / resolve as no longer applicable and skip those
+// steps to retry the original request that generated the
+// WriteIntentError. The cleanup function takes two arguments, a
+// newWIErr, non-nil in case the re-executed request experienced
+// another write intent error and could not complete; and
+// newIntentTxn, nil if the re-executed request left no intent, and
+// non-nil if it did.
+func (cq *contentionQueue) add(
+	ctx context.Context, wiErr *roachpb.WriteIntentError, h roachpb.Header,
+) (
+	func(newWIErr *roachpb.WriteIntentError, newIntentTxn *enginepb.TxnMeta),
+	*roachpb.WriteIntentError,
+	bool,
+) {
+	if len(wiErr.Intents) != 1 {
+		log.Fatalf(ctx, "write intent error must contain only a single intent: %s", wiErr)
+	}
+	intent := wiErr.Intents[0]
+	key := string(intent.Span.Key)
+	curPusher := newPusher(h.Txn)
+	log.VEventf(ctx, 3, "adding %s to contention queue on intent %s @%s", txnID(h.Txn), intent.Key, intent.Txn.ID.Short())
+
+	// Consider prior pushers in reverse arrival order to build queue
+	// by waiting on the most recent overlapping pusher.
+	var waitCh chan *enginepb.TxnMeta
+	var curElement *list.Element
+
+	cq.mu.Lock()
+	contended, ok := cq.mu.keys[key]
+	if !ok {
+		contended = newContendedKey()
+		contended.setLastTxnMeta(&intent.Txn)
+		cq.mu.keys[key] = contended
+	} else if contended.lastTxnMeta == nil || contended.lastTxnMeta.ID != intent.Txn.ID {
+		contended.setLastTxnMeta(&intent.Txn)
+	}
+
+	// Get the prior pusher to wait on.
+	if e := contended.ll.Back(); e != nil {
+		p := e.Value.(*pusher)
+		waitCh = p.waitCh
+		log.VEventf(ctx, 3, "%s waiting on %s", txnID(curPusher.txn), txnID(p.txn))
+	}
+
+	// Append the current pusher to the queue.
+	curElement = contended.ll.PushBack(curPusher)
+	cq.mu.Unlock()
+
+	// Delay before pushing in order to detect dependency cycles.
+	const dependencyCyclePushDelay = 100 * time.Millisecond
+
+	// Wait on prior pusher, if applicable.
+	var done bool
+	if waitCh != nil {
+		var detectCh chan struct{}
+		var detectReady <-chan time.Time
+		// If the current pusher has an active txn, we need to push the
+		// transaction which owns the intent to detect dependency cycles.
+		// To avoid unnecessary push traffic, insert a delay by
+		// instantiating the detectReady, which sets detectCh when it
+		// fires. When detectCh receives, it sends a push to the most
+		// recent txn to own the intent.
+		if curPusher.detectCh != nil {
+			detectReady = time.After(dependencyCyclePushDelay)
+		}
+
+	Loop:
+		for {
+			select {
+			case txnMeta, ok := <-waitCh:
+				if !ok {
+					log.Fatalf(ctx, "the wait channel of a prior pusher was used twice (pusher=%s)", txnMeta)
+				}
+				// If the prior pusher wrote an intent, push it instead by
+				// creating a copy of the WriteIntentError with updated txn.
+				if txnMeta != nil {
+					log.VEventf(ctx, 3, "%s exiting contention queue to push %s", txnID(curPusher.txn), txnMeta.ID.Short())
+					wiErrCopy := *wiErr
+					wiErrCopy.Intents = []roachpb.Intent{
+						{
+							Span:   intent.Span,
+							Txn:    *txnMeta,
+							Status: roachpb.PENDING,
+						},
+					}
+					wiErr = &wiErrCopy
+				} else {
+					// No intent was left by the prior pusher; don't push, go
+					// immediately to retrying the conflicted request.
+					log.VEventf(ctx, 3, "%s exiting contention queue to proceed", txnID(curPusher.txn))
+					done = true
+				}
+				break Loop
+
+			case <-ctx.Done():
+				// The pusher's context is done. Return without pushing.
+				done = true
+				break Loop
+
+			case <-detectReady:
+				// When the detect timer fires, set detectCh and loop.
+				log.VEventf(ctx, 3, "%s cycle detection is ready", txnID(curPusher.txn))
+				detectCh = curPusher.detectCh
+
+			case <-detectCh:
+				cq.mu.Lock()
+				frontOfQueue := curElement == contended.ll.Front()
+				pusheeTxn := contended.lastTxnMeta
+				cq.mu.Unlock()
+				// If we're at the start of the queue, or there's no pushee
+				// transaction (the previous pusher didn't leave an intent),
+				// loop and wait for the wait channel to signal.
+				if frontOfQueue {
+					log.VEventf(ctx, 3, "%s at front of queue; breaking from loop", txnID(curPusher.txn))
+					break Loop
+				} else if pusheeTxn == nil {
+					log.VEventf(ctx, 3, "%s cycle detection skipped because there is no txn to push", txnID(curPusher.txn))
+					detectCh = nil
+					detectReady = time.After(dependencyCyclePushDelay)
+					continue
+				}
+				pushReq := &roachpb.PushTxnRequest{
+					RequestHeader: roachpb.RequestHeader{
+						Key: pusheeTxn.Key,
+					},
+					PusherTxn: getPusherTxn(h),
+					PusheeTxn: *pusheeTxn,
+					PushTo:    h.Timestamp,
+					Now:       cq.store.Clock().Now(),
+					PushType:  roachpb.PUSH_ABORT,
+				}
+				b := &client.Batch{}
+				b.AddRawRequest(pushReq)
+				log.VEventf(ctx, 3, "%s pushing %s to detect dependency cycles", txnID(curPusher.txn), pusheeTxn.ID.Short())
+				if err := cq.store.db.Run(ctx, b); err != nil {
+					log.VErrEventf(ctx, 2, "while waiting in push contention queue to push %s: %s", pusheeTxn.ID.Short(), b.MustPErr())
+					done = true // done=true to avoid uselessly trying to push and resolve
+					break Loop
+				}
+				// Note that this pusher may have aborted the pushee, but it
+				// should still wait on the previous pusher's wait channel.
+				detectCh = nil
+				detectReady = time.After(dependencyCyclePushDelay)
+			}
+		}
+	}
+
+	return func(newWIErr *roachpb.WriteIntentError, newIntentTxn *enginepb.TxnMeta) {
+		if newWIErr == nil {
+			log.VEventf(ctx, 3, "%s finished, leaving intent? %t (owned by %s)", txnID(curPusher.txn), newIntentTxn != nil, newIntentTxn)
+		} else {
+			log.VEventf(ctx, 3, "%s encountered another write intent error %s", txnID(curPusher.txn), newWIErr)
+		}
+		cq.mu.Lock()
+		// If the current element isn't the front, it's being removed
+		// because its context was canceled. Swap the wait channel with
+		// the previous element.
+		if curElement != contended.ll.Front() {
+			prevPusher := curElement.Prev().Value.(*pusher)
+			if waitCh != nil && prevPusher.waitCh != waitCh {
+				log.Fatalf(ctx, "expected previous pusher's wait channel to be the one current pusher waited on")
+			}
+			prevPusher.waitCh, curPusher.waitCh = curPusher.waitCh, prevPusher.waitCh
+		}
+		// If the pusher re-executed its request and encountered another
+		// write intent error, check if it's for the same intent; if so,
+		// we can set the newIntentTxn to match the new intent.
+		if newWIErr != nil && len(newWIErr.Intents) == 1 &&
+			len(newWIErr.Intents[0].EndKey) == 0 && newWIErr.Intents[0].Key.Equal(intent.Key) {
+			newIntentTxn = &newWIErr.Intents[0].Txn
+		}
+		contended.ll.Remove(curElement)
+		if contended.ll.Len() == 0 {
+			delete(cq.mu.keys, key)
+		} else if newIntentTxn != nil {
+			contended.setLastTxnMeta(newIntentTxn)
+		} else if newWIErr != nil {
+			// Note that we don't update last txn meta unless we know for
+			// sure the txn which has written the most recent intent to the
+			// contended key (i.e. newWIErr != nil).
+			contended.setLastTxnMeta(nil)
+		}
+		curPusher.waitCh <- newIntentTxn
+		close(curPusher.waitCh)
+		cq.mu.Unlock()
+	}, wiErr, done
+}
+
 // intentResolver manages the process of pushing transactions and
 // resolving intents.
 type intentResolver struct {
 	store *Store
 
-	sem chan struct{} // Semaphore to limit async goroutines.
+	sem         chan struct{}    // Semaphore to limit async goroutines.
+	contentionQ *contentionQueue // manages contention on individual keys
 
 	mu struct {
 		syncutil.Mutex
@@ -78,8 +375,9 @@ type intentResolver struct {
 
 func newIntentResolver(store *Store, taskLimit int) *intentResolver {
 	ir := &intentResolver{
-		store: store,
-		sem:   make(chan struct{}, taskLimit),
+		store:       store,
+		sem:         make(chan struct{}, taskLimit),
+		contentionQ: newContentionQueue(store),
 	}
 	ir.mu.inFlightPushes = map[uuid.UUID]int{}
 	ir.mu.inFlightTxnCleanups = map[uuid.UUID]struct{}{}
@@ -88,29 +386,46 @@ func newIntentResolver(store *Store, taskLimit int) *intentResolver {
 
 // processWriteIntentError tries to push the conflicting
 // transaction(s) responsible for the given WriteIntentError, and to
-// resolve those intents if possible. Returns a new error to be used
-// in place of the original.
+// resolve those intents if possible. Returns a cleanup function and
+// potentially a new error to be used in place of the original. The
+// cleanup function should be invoked by the caller after the request
+// which experienced the conflict has completed with a parameter
+// specifying a transaction in the event that the request left its own
+// intent.
 func (ir *intentResolver) processWriteIntentError(
 	ctx context.Context,
 	wiPErr *roachpb.Error,
 	args roachpb.Request,
 	h roachpb.Header,
 	pushType roachpb.PushTxnType,
-) *roachpb.Error {
+) (func(newWIErr *roachpb.WriteIntentError, newIntentTxn *enginepb.TxnMeta), *roachpb.Error) {
 	wiErr, ok := wiPErr.GetDetail().(*roachpb.WriteIntentError)
 	if !ok {
-		return roachpb.NewErrorf("not a WriteIntentError: %v", wiPErr)
+		return nil, roachpb.NewErrorf("not a WriteIntentError: %v", wiPErr)
 	}
 
 	if log.V(6) {
 		log.Infof(ctx, "resolving write intent %s", wiErr)
 	}
 
+	// Possibly queue this processing if the write intent error is for a
+	// single intent affecting a unitary key.
+	var cleanup func(*roachpb.WriteIntentError, *enginepb.TxnMeta)
+	if len(wiErr.Intents) == 1 && len(wiErr.Intents[0].Span.EndKey) == 0 {
+		var done bool
+		// Note that the write intent error may be mutated here in the event
+		// that this pusher is queued to wait for a different transaction
+		// instead.
+		if cleanup, wiErr, done = ir.contentionQ.add(ctx, wiErr, h); done {
+			return cleanup, nil
+		}
+	}
+
 	resolveIntents, pErr := ir.maybePushTransactions(
 		ctx, wiErr.Intents, h, pushType, false, /* skipIfInFlight */
 	)
 	if pErr != nil {
-		return pErr
+		return cleanup, pErr
 	}
 
 	// We always poison due to limitations of the API: not poisoning equals
@@ -125,10 +440,24 @@ func (ir *intentResolver) processWriteIntentError(
 	// poison.
 	if err := ir.resolveIntents(ctx, resolveIntents,
 		ResolveOptions{Wait: false, Poison: true}); err != nil {
-		return roachpb.NewError(err)
+		return cleanup, roachpb.NewError(err)
 	}
 
-	return nil
+	return cleanup, nil
+}
+
+func getPusherTxn(h roachpb.Header) roachpb.Transaction {
+	// If the txn is nil, we communicate a priority by sending an empty
+	// txn with only the priority set. This is official usage of PushTxn.
+	txn := h.Txn
+	if txn == nil {
+		txn = &roachpb.Transaction{
+			TxnMeta: enginepb.TxnMeta{
+				Priority: roachpb.MakePriority(h.UserPriority),
+			},
+		}
+	}
+	return *txn
 }
 
 // maybePushTransactions tries to push the conflicting transaction(s)
@@ -164,23 +493,12 @@ func (ir *intentResolver) maybePushTransactions(
 ) ([]roachpb.Intent, *roachpb.Error) {
 	now := ir.store.Clock().Now()
 
-	partialPusherTxn := h.Txn
-	// If there's no pusher, we communicate a priority by sending an empty
-	// txn with only the priority set. This is official usage of PushTxn.
-	if partialPusherTxn == nil {
-		partialPusherTxn = &roachpb.Transaction{
-			TxnMeta: enginepb.TxnMeta{
-				Priority: roachpb.MakePriority(h.UserPriority),
-			},
-		}
-	}
-
 	// Split intents into those we need to push and those which are good to
 	// resolve.
 	ir.mu.Lock()
 	// TODO(tschottdorf): can optimize this and use same underlying slice.
 	var pushIntents []roachpb.Intent
-	cleanupPushIntentsLocked := func() {
+	cleanupInFlightPushesLocked := func() {
 		for _, intent := range pushIntents {
 			ir.mu.inFlightPushes[intent.Txn.ID]--
 			if ir.mu.inFlightPushes[intent.Txn.ID] == 0 {
@@ -195,7 +513,7 @@ func (ir *intentResolver) maybePushTransactions(
 			// because the transaction is already finalized.
 			// This shouldn't happen as all intents created are in
 			// the PENDING status.
-			cleanupPushIntentsLocked()
+			cleanupInFlightPushesLocked()
 			ir.mu.Unlock()
 			return nil, roachpb.NewErrorf("unexpected %s intent: %+v", intent.Status, intent)
 		}
@@ -228,7 +546,7 @@ func (ir *intentResolver) maybePushTransactions(
 			RequestHeader: roachpb.RequestHeader{
 				Key: pushTxn.Key,
 			},
-			PusherTxn: *partialPusherTxn,
+			PusherTxn: getPusherTxn(h),
 			PusheeTxn: pushTxn,
 			PushTo:    h.Timestamp,
 			// The timestamp is used by PushTxn for figuring out whether the
@@ -247,7 +565,7 @@ func (ir *intentResolver) maybePushTransactions(
 		pErr = b.MustPErr()
 	}
 	ir.mu.Lock()
-	cleanupPushIntentsLocked()
+	cleanupInFlightPushesLocked()
 	ir.mu.Unlock()
 	if pErr != nil {
 		return nil, pErr

--- a/pkg/storage/intent_resolver_test.go
+++ b/pkg/storage/intent_resolver_test.go
@@ -17,12 +17,17 @@ package storage
 
 import (
 	"context"
+	"sync"
 	"testing"
+	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
+	"github.com/pkg/errors"
 )
 
 // TestPushTransactionsWithNonPendingIntent verifies that maybePushTransactions
@@ -48,7 +53,224 @@ func TestPushTransactionsWithNonPendingIntent(t *testing.T) {
 			t.Errorf("expected error on aborted/resolved intent, but got %s", pErr)
 		}
 		if cnt := len(tc.store.intentResolver.mu.inFlightPushes); cnt != 0 {
-			t.Errorf("expected no inflight pushe refcount map entries, found %d", cnt)
+			t.Errorf("expected no inflight pushes refcount map entries, found %d", cnt)
 		}
+	}
+}
+
+func beginTransaction(
+	t *testing.T, store *Store, pri roachpb.UserPriority, key roachpb.Key, putKey bool,
+) *roachpb.Transaction {
+	txn := newTransaction("test", key, pri, enginepb.SERIALIZABLE, store.Clock())
+
+	var ba roachpb.BatchRequest
+	bt, header := beginTxnArgs(key, txn)
+	ba.Header = header
+	ba.Add(&bt)
+	assignSeqNumsForReqs(txn, &bt)
+	if putKey {
+		put := putArgs(key, []byte("value"))
+		ba.Add(&put)
+		assignSeqNumsForReqs(txn, &put)
+	}
+	br, pErr := store.TestSender().Send(context.Background(), ba)
+	if pErr != nil {
+		t.Fatal(pErr)
+	}
+	txn = br.Txn
+
+	return txn
+}
+
+// TestContendedIntent verifies that multiple transactions, some actively
+// writing and others read-only, are queued if processing write intent
+// errors on a contended key. The test verifies the expected ordering in
+// the queue.
+func TestContendedIntent(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	stopper := stop.NewStopper()
+	defer stopper.Stop(context.TODO())
+	store, _ := createTestStore(t, stopper)
+	ctx, cancel := context.WithCancel(context.Background())
+
+	key := roachpb.Key("a")
+	span := roachpb.Span{Key: key}
+	origTxn := beginTransaction(t, store, 1, key, true /* putKey */)
+
+	roTxn1 := newTransaction("test", key, 1, enginepb.SERIALIZABLE, store.Clock())
+	roTxn2 := newTransaction("test", key, 1, enginepb.SERIALIZABLE, store.Clock())
+	roTxn3 := newTransaction("test", key, 1, enginepb.SERIALIZABLE, store.Clock())
+	rwTxn1 := beginTransaction(t, store, 1, roachpb.Key("b"), true /* putKey */)
+	rwTxn2 := beginTransaction(t, store, 1, roachpb.Key("c"), true /* putKey */)
+
+	testCases := []struct {
+		pusher  *roachpb.Transaction
+		expTxns []*roachpb.Transaction
+	}{
+		// First establish a chain of three read-only txns.
+		{pusher: roTxn1, expTxns: []*roachpb.Transaction{roTxn1}},
+		{pusher: roTxn2, expTxns: []*roachpb.Transaction{roTxn1, roTxn2}},
+		{pusher: roTxn3, expTxns: []*roachpb.Transaction{roTxn1, roTxn2, roTxn3}},
+		// Now, verify that a writing txn is inserted at the end of the queue.
+		{pusher: rwTxn1, expTxns: []*roachpb.Transaction{roTxn1, roTxn2, roTxn3, rwTxn1}},
+		// And a second writing txn is inserted after it.
+		{pusher: rwTxn2, expTxns: []*roachpb.Transaction{roTxn1, roTxn2, roTxn3, rwTxn1, rwTxn2}},
+	}
+
+	var wg sync.WaitGroup
+	ir := store.intentResolver
+	for _, tc := range testCases {
+		t.Run("", func(t *testing.T) {
+			wiErr := &roachpb.WriteIntentError{Intents: []roachpb.Intent{{Txn: origTxn.TxnMeta, Span: span}}}
+			h := roachpb.Header{Txn: tc.pusher}
+			wg.Add(1)
+			go func() {
+				_, pErr := ir.processWriteIntentError(ctx, roachpb.NewError(wiErr), nil, h, roachpb.PUSH_ABORT)
+				if pErr != nil && !testutils.IsPError(pErr, "context canceled") {
+					panic(pErr)
+				}
+				wg.Done()
+			}()
+			testutils.SucceedsSoon(t, func() error {
+				ir.contentionQ.mu.Lock()
+				defer ir.contentionQ.mu.Unlock()
+				contended, ok := ir.contentionQ.mu.keys[string(key)]
+				if !ok {
+					return errors.Errorf("key not contended")
+				}
+				if lc, let := contended.ll.Len(), len(tc.expTxns); lc != let {
+					return errors.Errorf("expected len %d; got %d", let, lc)
+				}
+				var idx int
+				for e := contended.ll.Front(); e != nil; e = e.Next() {
+					p := e.Value.(*pusher)
+					if p.txn != tc.expTxns[idx] {
+						return errors.Errorf("expected txn %s at index %d; got %s", tc.expTxns[idx], idx, p.txn)
+					}
+					idx++
+				}
+				return nil
+			})
+		})
+	}
+
+	// Free up all waiters to complete the test.
+	cancel()
+	wg.Wait()
+}
+
+// TestContendedIntentWithDependencyCycle verifies that a queue of
+// writers on a contended key, each pushing the prior writer, will
+// still notice a dependency cycle. In this case, txn3 writes "a",
+// then txn1 writes "b" and "a", then txn2 writes "b", then txn3
+// writes "b". The deadlock is broken by an aborted transaction.
+//
+// Additional non-transactional reads on the same contended key are
+// inserted to verify they do not interfere with writing transactions
+// always pushing to ensure the dependency cycle can be detected.
+func TestContendedIntentWithDependencyCycle(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	stopper := stop.NewStopper()
+	defer stopper.Stop(context.TODO())
+	store, _ := createTestStore(t, stopper)
+	ctx := context.Background()
+
+	keyA := roachpb.Key("a")
+	keyB := roachpb.Key("b")
+	spanA := roachpb.Span{Key: keyA}
+	spanB := roachpb.Span{Key: keyB}
+
+	// Create the three transactions; at this point, none of them have
+	// conflicts. Txn1 has written "b", Txn3 has written "a".
+	txn1 := beginTransaction(t, store, -3, keyB, true /* putKey */)
+	txn2 := beginTransaction(t, store, -2, keyB, false /* putKey */)
+	txn3 := beginTransaction(t, store, -1, keyA, true /* putKey */)
+
+	// Send txn1 put, followed by an end transaction.
+	txnCh1 := make(chan error, 1)
+	go func() {
+		put := putArgs(keyA, []byte("value"))
+		assignSeqNumsForReqs(txn1, &put)
+		if _, pErr := client.SendWrappedWith(ctx, store.TestSender(), roachpb.Header{Txn: txn1}, &put); pErr != nil {
+			txnCh1 <- pErr.GoError()
+			return
+		}
+		et, _ := endTxnArgs(txn1, true)
+		et.IntentSpans = []roachpb.Span{spanA, spanB}
+		et.NoRefreshSpans = true
+		assignSeqNumsForReqs(txn1, &et)
+		_, pErr := client.SendWrappedWith(ctx, store.TestSender(), roachpb.Header{Txn: txn1}, &et)
+		txnCh1 <- pErr.GoError()
+	}()
+
+	// Send a non-transactional read to keyB. This adds an early waiter
+	// to the intent resolver on keyB which txn2 must skip in order to
+	// properly register itself as a dependency by pushing txn1.
+	readCh1 := make(chan error, 1)
+	go func() {
+		get := getArgs(keyB)
+		_, pErr := client.SendWrapped(ctx, store.TestSender(), &get)
+		readCh1 <- pErr.GoError()
+	}()
+
+	// Send txn2 put, followed by an end transaction.
+	txnCh2 := make(chan error, 1)
+	go func() {
+		put := putArgs(keyB, []byte("value"))
+		assignSeqNumsForReqs(txn2, &put)
+		repl, pErr := client.SendWrappedWith(ctx, store.TestSender(), roachpb.Header{Txn: txn2}, &put)
+		if pErr != nil {
+			txnCh2 <- pErr.GoError()
+			return
+		}
+		txn2Copy := *repl.Header().Txn
+		txn2 = &txn2Copy
+		et, _ := endTxnArgs(txn2, true)
+		et.IntentSpans = []roachpb.Span{spanB}
+		et.NoRefreshSpans = true
+		assignSeqNumsForReqs(txn2, &et)
+		_, pErr = client.SendWrappedWith(ctx, store.TestSender(), roachpb.Header{Txn: txn2}, &et)
+		txnCh2 <- pErr.GoError()
+	}()
+
+	// Send another non-transactional read to keyB to add a waiter in
+	// between txn2 and txn3. Txn3 must wait on txn2, instead of getting
+	// queued behind this reader, in order to establish the dependency cycle.
+	readCh2 := make(chan error, 1)
+	go func() {
+		get := getArgs(keyB)
+		_, pErr := client.SendWrapped(ctx, store.TestSender(), &get)
+		readCh2 <- pErr.GoError()
+	}()
+
+	// Send txn3. Pause for 10ms to make it more likely that we have a
+	// dependency cycle of length 3, although we don't mind testing
+	// either way.
+	time.Sleep(10 * time.Millisecond)
+	txnCh3 := make(chan error, 1)
+	go func() {
+		put := putArgs(keyB, []byte("value"))
+		assignSeqNumsForReqs(txn3, &put)
+		_, pErr := client.SendWrappedWith(ctx, store.TestSender(), roachpb.Header{Txn: txn3}, &put)
+		txnCh3 <- pErr.GoError()
+	}()
+
+	// The third transaction will always be aborted.
+	err := <-txnCh3
+	if _, ok := err.(*roachpb.UnhandledRetryableError); !ok {
+		t.Fatalf("expected transaction aborted error; got %T", err)
+	}
+	if err := <-txnCh1; err != nil {
+		t.Fatal(err)
+	}
+	if err := <-txnCh2; err != nil {
+		t.Fatal(err)
+	}
+	if err := <-readCh1; err != nil {
+		t.Fatal(err)
+	}
+	if err := <-readCh2; err != nil {
+		t.Fatal(err)
 	}
 }

--- a/pkg/storage/txnwait/txnqueue.go
+++ b/pkg/storage/txnwait/txnqueue.go
@@ -278,6 +278,7 @@ func (q *Queue) UpdateTxn(ctx context.Context, txn *roachpb.Transaction) {
 		q.mu.Unlock()
 		return
 	}
+
 	pending, ok := q.mu.txns[txn.ID]
 	if !ok {
 		q.mu.Unlock()
@@ -433,6 +434,10 @@ func (q *Queue) MaybeWaitForPush(
 	var queryPusherCh <-chan *roachpb.Transaction // accepts updates to the pusher txn
 	var queryPusherErrCh <-chan *roachpb.Error    // accepts errors querying the pusher txn
 	var readyCh chan struct{}                     // signaled when pusher txn should be queried
+
+	// Query the pusher if it's a valid transaction which already [may]
+	// have a transaction record (note that key being non-nil does not
+	// guarantee a txn record has been successfully written yet).
 	if req.PusherTxn.ID != uuid.Nil && req.PusherTxn.Key != nil {
 		// Create a context which will be canceled once this call completes.
 		// This ensures that the goroutine created to query the pusher txn

--- a/pkg/util/interval/interval.go
+++ b/pkg/util/interval/interval.go
@@ -140,7 +140,7 @@ func Compare(a, b Interface) int {
 	}
 }
 
-// Equal returns a boolean indicating whethter the given Interfaces are equal to each other. If
+// Equal returns a boolean indicating whether the given Interfaces are equal to each other. If
 // "Equal(a, b) == true", "a.Range().End == b.Range().End" must hold. Otherwise, the interval tree
 // behavior is undefined. "Equal(a, b) == true" is equivalent to "Compare(a, b) == 0". But the
 // former has measurably better performance than the latter. So Equal should be used when only


### PR DESCRIPTION
Previously, high contention on a single key would cause every thread to
push the same conflicting transaction then resolve the same intent in
parallel. This is inefficient as only one pusher needs to succeed, and
only one resolver needs to resolve the intent, and then only one writer
should proceed while the other readers/writers should in turn wait on
the previous writer by pushing its transaction. This effectively
serializes the conflicting reader/writers.
    
One complication is that all pushers which may have a valid, writing
transaction (i.e., `Transaction.Key != nil`), must push either the
conflicting transaction or another transaction already pushing that
transaction. This allows dependency cycles to be discovered.

Fixes #20448 