### PR TITLE
sql: make schema changes more resilient to permanent errors

### DIFF
--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -207,7 +207,7 @@ func (sc *SchemaChanger) getTableVersion(
 		return nil, err
 	}
 	if version != tableDesc.Version {
-		return nil, errors.Errorf("table version mismatch: %d, expected=%d", tableDesc.Version, version)
+		return nil, makeErrTableVersionMismatch(tableDesc.Version, version)
 	}
 	return tableDesc, nil
 }
@@ -342,7 +342,7 @@ func (sc *SchemaChanger) getMutationToBackfill(
 			return err
 		}
 		if tableDesc.Version != version {
-			return errors.Errorf("table version mismatch: %d, expected: %d", tableDesc.Version, version)
+			return makeErrTableVersionMismatch(tableDesc.Version, version)
 		}
 		if len(tableDesc.Mutations) > 0 {
 			mutationID := tableDesc.Mutations[0].MutationID
@@ -374,7 +374,7 @@ func (sc *SchemaChanger) getJobIDForMutation(
 			return err
 		}
 		if tableDesc.Version != version {
-			return errors.Errorf("table version mismatch: %d, expected: %d", tableDesc.Version, version)
+			return makeErrTableVersionMismatch(tableDesc.Version, version)
 		}
 
 		if len(tableDesc.MutationJobs) > 0 {

--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -31,6 +31,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/jobs"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
@@ -125,17 +126,68 @@ func (sc *SchemaChanger) createSchemaChangeLease() sqlbase.TableDescriptor_Schem
 		NodeID: sc.nodeID, ExpirationTime: timeutil.Now().Add(SchemaChangeLeaseDuration).UnixNano()}
 }
 
-var errExistingSchemaChangeLease = errors.New(
-	"an outstanding schema change lease exists")
-var errSchemaChangeNotFirstInLine = errors.New(
-	"schema change not first in line")
-var errNotHitGCTTLDeadline = errors.New(
-	"not hit gc ttl deadline")
+// isPermanentSchemaChangeError returns true if the error results in
+// a permanent failure of a schema change. This function is a whitelist
+// instead of a blacklist: only known safe errors are confirmed to not be
+// permanent errors. Anything unknown is assumed to be permanent.
+func isPermanentSchemaChangeError(err error) bool {
+	if err == nil {
+		return false
+	}
+	err = errors.Cause(err)
+	switch err {
+	case
+		context.Canceled,
+		context.DeadlineExceeded,
+		errExistingSchemaChangeLease,
+		errNotHitGCTTLDeadline,
+		errSchemaChangeDuringDrain,
+		errSchemaChangeNotFirstInLine:
+		return false
+	}
+	switch err := err.(type) {
+	case errTableVersionMismatch:
+		return false
+	case *pgerror.Error:
+		switch err.Code {
+		case pgerror.CodeSerializationFailureError:
+			return false
+		case pgerror.CodeInternalError:
+			if err.Message == context.DeadlineExceeded.Error() {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+var (
+	errExistingSchemaChangeLease  = errors.New("an outstanding schema change lease exists")
+	errSchemaChangeNotFirstInLine = errors.New("schema change not first in line")
+	errNotHitGCTTLDeadline        = errors.New("not hit gc ttl deadline")
+	errSchemaChangeDuringDrain    = errors.New("a schema change ran during the drain phase, re-increment")
+)
 
 func shouldLogSchemaChangeError(err error) bool {
 	return err != errExistingSchemaChangeLease &&
 		err != errSchemaChangeNotFirstInLine &&
 		err != errNotHitGCTTLDeadline
+}
+
+type errTableVersionMismatch struct {
+	version  sqlbase.DescriptorVersion
+	expected sqlbase.DescriptorVersion
+}
+
+func makeErrTableVersionMismatch(version, expected sqlbase.DescriptorVersion) error {
+	return errors.WithStack(errTableVersionMismatch{
+		version:  version,
+		expected: expected,
+	})
+}
+
+func (e errTableVersionMismatch) Error() string {
+	return fmt.Sprintf("table version mismatch: %d, expected: %d", e.version, e.expected)
 }
 
 // AcquireLease acquires a schema change lease on the table if
@@ -379,7 +431,7 @@ func (sc *SchemaChanger) drainNames(
 			// error, so that sc.exec() is reexecuted and increments the
 			// version before coming back here to correctly drain the names.
 			if desc.UpVersion {
-				return errors.Errorf("a schema change ran during the drain phase, re-increment")
+				return errSchemaChangeDuringDrain
 			}
 			// Free up the old name(s) for reuse.
 			namesToReclaim = desc.DrainingNames
@@ -502,7 +554,7 @@ func (sc *SchemaChanger) exec(
 	// Purge the mutations if the application of the mutations failed due to
 	// a permanent error. All other errors are transient errors that are
 	// resolved by retrying the backfill.
-	if sqlbase.IsPermanentSchemaChangeError(err) {
+	if isPermanentSchemaChangeError(err) {
 		if err := sc.rollbackSchemaChange(ctx, err, &lease, evalCtx); err != nil {
 			return err
 		}

--- a/pkg/sql/schema_changer_test.go
+++ b/pkg/sql/schema_changer_test.go
@@ -822,7 +822,7 @@ CREATE UNIQUE INDEX vidx ON t.test (v);
 	wg.Add(1)
 	go func() {
 		// Start schema change that eventually runs a partial backfill.
-		if _, err := sqlDB.Exec("CREATE UNIQUE INDEX bar ON t.test (v)"); err != nil {
+		if _, err := sqlDB.Exec("CREATE UNIQUE INDEX bar ON t.test (v)"); err != nil && !testutils.IsError(err, "table is being dropped") {
 			t.Error(err)
 		}
 		wg.Done()

--- a/pkg/sql/session.go
+++ b/pkg/sql/session.go
@@ -1365,7 +1365,7 @@ func (scc *schemaChangerCollection) execSchemaChanges(
 					log.Warningf(ctx, "error executing schema change: %s", err)
 				}
 				if err == sqlbase.ErrDescriptorNotFound {
-				} else if sqlbase.IsPermanentSchemaChangeError(err) {
+				} else if isPermanentSchemaChangeError(err) {
 					// All constraint violations can be reported; we report it as the result
 					// corresponding to the statement that enqueued this changer.
 					// There's some sketchiness here: we assume there's a single result

--- a/pkg/sql/sqlbase/errors.go
+++ b/pkg/sql/sqlbase/errors.go
@@ -121,25 +121,6 @@ func IsCCLRequiredError(err error) bool {
 	return errHasCode(err, CodeCCLRequired)
 }
 
-// IsPermanentSchemaChangeError returns true if the error results in
-// a permanent failure of a schema change.
-func IsPermanentSchemaChangeError(err error) bool {
-	if errHasCode(err,
-		pgerror.CodeNotNullViolationError,
-		pgerror.CodeUniqueViolationError,
-		pgerror.CodeInvalidSchemaDefinitionError,
-		CodeCCLRequired,
-	) {
-		return true
-	}
-	switch err.(type) {
-	case *roachpb.BatchTimestampBeforeGCError:
-		return true
-	default:
-		return false
-	}
-}
-
 // NewUndefinedDatabaseError creates an error that represents a missing database.
 func NewUndefinedDatabaseError(name string) error {
 	// Postgres will return an UndefinedTable error on queries that go to a "relation"


### PR DESCRIPTION
This is a partial backport of #24464. That change added an unrelated
feature that required refactoring the IsPermanentSchemaChangeError
func to be a whitelist instead of a blacklist. This means that schema
change errors now must be specifically listed as non-permanent.

The issue below is fixed now because the system will detect that
error as permanent instead of not.

Fixes #24748

Release note (bug fix): Correctly fail some kinds of schema change
errors that are stuck in a permanent loop.