### PR TITLE
sql: Add missing distsql-metadata configs to logic tests

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/create_statements
+++ b/pkg/sql/logictest/testdata/logic_test/create_statements
@@ -1,4 +1,4 @@
-# LogicTest: default parallel-stmts distsql
+# LogicTest: default parallel-stmts distsql distsql-metadata
 
 statement ok
 CREATE TABLE t (a INT REFERENCES t)

--- a/pkg/sql/logictest/testdata/logic_test/timetz
+++ b/pkg/sql/logictest/testdata/logic_test/timetz
@@ -1,4 +1,4 @@
-# LogicTest: default parallel-stmts distsql
+# LogicTest: default parallel-stmts distsql distsql-metadata
 
 # Note that the odd '0000-01-01 hh:mi:ss +0000 +0000' result format is an
 # artifact of how pq displays TIMETZs.


### PR DESCRIPTION
Two files were missing these, so they've been added now.

Release note: None