### PR TITLE
opt: plan index joins for non-covering indexes

### DIFF
--- a/pkg/sql/opt/memo/expr_view.go
+++ b/pkg/sql/opt/memo/expr_view.go
@@ -331,6 +331,11 @@ func (ev ExprView) formatRelational(tp treeprinter.Node, flags ExprFmtFlags) {
 		if def.HardLimit > 0 {
 			tp.Childf("limit: %d", def.HardLimit)
 		}
+
+	case opt.LookupJoinOp:
+		def := ev.Private().(*LookupJoinDef)
+		tableID := def.Table
+		tp.Childf("table: %s", ev.Metadata().Table(tableID).TabName())
 	}
 
 	if !flags.HasFlags(ExprFmtHideOuterCols) && !logProps.Relational.OuterCols.Empty() {

--- a/pkg/sql/opt/memo/memo_format.go
+++ b/pkg/sql/opt/memo/memo_format.go
@@ -263,6 +263,9 @@ func (f exprFormatter) formatPrivate(private interface{}) {
 		case opt.ColumnID:
 			fmt.Fprintf(f.buf, " %s", f.mem.metadata.ColumnLabel(t))
 
+		case *LookupJoinDef:
+			fmt.Fprintf(f.buf, " %s,cols=%s", f.mem.metadata.Table(t.Table).TabName(), t.Cols)
+
 		case opt.ColSet, opt.ColList:
 			// Don't show anything, because it's mostly redundant.
 
@@ -283,6 +286,9 @@ func (f exprFormatter) formatScanPrivate(def *ScanOpDef, short bool) {
 
 	// Add additional fields when short=false.
 	if !short {
+		if tab.ColumnCount() != def.Cols.Len() {
+			fmt.Fprintf(f.buf, ",cols=%s", def.Cols)
+		}
 		if def.Constraint != nil {
 			fmt.Fprintf(f.buf, ",constrained")
 		}

--- a/pkg/sql/opt/memo/private_defs.go
+++ b/pkg/sql/opt/memo/private_defs.go
@@ -39,6 +39,19 @@ func (f FuncOpDef) String() string {
 	return f.Name
 }
 
+// LookupJoinDef defines the value of the Def private field of the LookupJoin
+// operator.
+type LookupJoinDef struct {
+	// Table identifies the table do to lookups in. The primary index is
+	// currently the only index used.
+	Table opt.TableID
+
+	// Cols is the set of columns the index join outputs. The set of columns
+	// which must be retrieved from the primary index is thus Cols minus the set
+	// of columns provided by the input.
+	Cols opt.ColSet
+}
+
 // ScanOpDef defines the value of the Def private field of the Scan operator.
 type ScanOpDef struct {
 	// Table identifies the table to scan. It is an id that can be passed to
@@ -64,19 +77,6 @@ type ScanOpDef struct {
 	// if more are available. If its value is zero, then the limit is
 	// unknown, and the scan should return all available rows.
 	HardLimit int64
-}
-
-// AltIndexHasCols returns true if the given alternate index on the table
-// contains the columns projected by the scan operator. This means that the
-// alternate index can be scanned instead.
-func (s *ScanOpDef) AltIndexHasCols(md *opt.Metadata, altIndex int) bool {
-	index := md.Table(s.Table).Index(altIndex)
-	var indexCols opt.ColSet
-	for col := 0; col < index.ColumnCount(); col++ {
-		ord := index.Column(col).Ordinal
-		indexCols.Add(int(md.TableColumn(s.Table, ord)))
-	}
-	return s.Cols.SubsetOf(indexCols)
 }
 
 // CanProvideOrdering returns true if the scan operator returns rows that

--- a/pkg/sql/opt/memo/private_defs_test.go
+++ b/pkg/sql/opt/memo/private_defs_test.go
@@ -20,49 +20,22 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/testutils"
-	"github.com/cockroachdb/cockroach/pkg/util"
 )
 
-func TestAltIndexHasCols(t *testing.T) {
-	cat := createDefsCatalog(t)
-	md := opt.NewMetadata()
-	a := md.AddTable(cat.Table("a"))
-
-	// INDEX (i, k)
-	altIndex1 := 1
-	// INDEX (s DESC) STORING(f)
-	altIndex2 := 2
-
-	k := int(md.TableColumn(a, 0))
-	i := int(md.TableColumn(a, 1))
-	s := int(md.TableColumn(a, 2))
-
-	test := func(def *memo.ScanOpDef, altIndex int, expected bool) {
-		t.Helper()
-		if def.AltIndexHasCols(md, altIndex) != expected {
-			t.Errorf("expected %v, got %v", expected, !expected)
-		}
-	}
-
-	def := &memo.ScanOpDef{Table: a, Index: opt.PrimaryIndex, Cols: util.MakeFastIntSet(k, i)}
-	test(def, altIndex1, true)
-	test(def, altIndex2, false)
-
-	def = &memo.ScanOpDef{Table: a, Index: opt.PrimaryIndex, Cols: util.MakeFastIntSet(k)}
-	test(def, altIndex1, true)
-	test(def, altIndex2, true)
-
-	def = &memo.ScanOpDef{Table: a, Index: opt.PrimaryIndex, Cols: util.MakeFastIntSet(s)}
-	test(def, altIndex1, false)
-	test(def, altIndex2, true)
-
-	def = &memo.ScanOpDef{Table: a, Index: opt.PrimaryIndex, Cols: util.MakeFastIntSet(k, i, s)}
-	test(def, altIndex1, false)
-	test(def, altIndex2, false)
-}
-
 func TestCanProvideOrdering(t *testing.T) {
-	cat := createDefsCatalog(t)
+	cat := testutils.NewTestCatalog()
+	testutils.ExecuteTestDDL(
+		t,
+		"CREATE TABLE a ("+
+			"k INT PRIMARY KEY, "+
+			"i INT, "+
+			"s STRING, "+
+			"f FLOAT, "+
+			"INDEX (i, k), "+
+			"INDEX (s DESC) STORING(f))",
+		cat,
+	)
+
 	md := opt.NewMetadata()
 	a := md.AddTable(cat.Table("a"))
 
@@ -100,20 +73,4 @@ func TestCanProvideOrdering(t *testing.T) {
 	// Index contains storing column.
 	test(def, memo.Ordering{-s, k, f}, true)
 	test(def, memo.Ordering{-s, k, i}, false)
-}
-
-func createDefsCatalog(t *testing.T) *testutils.TestCatalog {
-	cat := testutils.NewTestCatalog()
-	testutils.ExecuteTestDDL(
-		t,
-		"CREATE TABLE a ("+
-			"k INT PRIMARY KEY, "+
-			"i INT, "+
-			"s STRING, "+
-			"f FLOAT, "+
-			"INDEX (i, k), "+
-			"INDEX (s DESC) STORING(f))",
-		cat,
-	)
-	return cat
 }

--- a/pkg/sql/opt/memo/private_storage.go
+++ b/pkg/sql/opt/memo/private_storage.go
@@ -186,6 +186,23 @@ func (ps *privateStorage) internScanOpDef(def *ScanOpDef) PrivateID {
 	return ps.addValue(privateKey{iface: typ, str: ps.keyBuf.String()}, def)
 }
 
+// internLookupJoinDef adds the given value to storage and returns an id that
+// can later be used to retrieve the value by calling the lookup method. If the
+// value has been previously added to storage, then internLookupJoinDef always
+// returns the same private id that was returned from the previous call.
+func (ps *privateStorage) internLookupJoinDef(def *LookupJoinDef) PrivateID {
+	// The below code is carefully constructed to not allocate in the case where
+	// the value is already in the map. Be careful when modifying.
+	ps.keyBuf.Reset()
+	ps.keyBuf.writeUvarint(uint64(def.Table))
+	ps.keyBuf.writeColSet(def.Cols)
+	typ := (*LookupJoinDef)(nil)
+	if id, ok := ps.privatesMap[privateKey{iface: typ, str: ps.keyBuf.String()}]; ok {
+		return id
+	}
+	return ps.addValue(privateKey{iface: typ, str: ps.keyBuf.String()}, def)
+}
+
 // internSetOpColMap adds the given value to storage and returns an id that can
 // later be used to retrieve the value by calling the lookup method. If the
 // value has been previously added to storage, then internSetOpColMap always

--- a/pkg/sql/opt/memo/private_storage_test.go
+++ b/pkg/sql/opt/memo/private_storage_test.go
@@ -300,6 +300,7 @@ func BenchmarkPrivateStorage(b *testing.B) {
 		Overload: &builtins.Builtins["concat"][0],
 	}
 	scanOpDef := &ScanOpDef{Table: 1, Index: 2, Cols: colSet}
+	indexJoinDef := &LookupJoinDef{Table: 1, Cols: colSet}
 	setOpColMap := &SetOpColMap{Left: colList, Right: colList, Out: colList}
 	datum := tree.NewDInt(1)
 	typ := types.Int
@@ -312,6 +313,7 @@ func BenchmarkPrivateStorage(b *testing.B) {
 		ps.internOrdering(ordering)
 		ps.internFuncOpDef(funcOpDef)
 		ps.internScanOpDef(scanOpDef)
+		ps.internLookupJoinDef(indexJoinDef)
 		ps.internSetOpColMap(setOpColMap)
 		ps.internDatum(datum)
 		ps.internType(typ)

--- a/pkg/sql/opt/memo/testdata/memo
+++ b/pkg/sql/opt/memo/testdata/memo
@@ -181,9 +181,9 @@ memo (optimized)
  │    └── ""
  │         ├── best: (select G12 G13)
  │         └── cost: 1100.00
- ├── G10: (scan b)
+ ├── G10: (scan b,cols=(3))
  │    └── ""
- │         ├── best: (scan b)
+ │         ├── best: (scan b,cols=(3))
  │         └── cost: 1000.00
  ├── G11: (filters G14)
  ├── G12: (scan a)

--- a/pkg/sql/opt/metadata.go
+++ b/pkg/sql/opt/metadata.go
@@ -105,6 +105,21 @@ func (md *Metadata) NumColumns() int {
 	return len(md.cols) - 1
 }
 
+// IndexColumns returns the set of columns in the given index.
+// TODO(justin): cache this value in the table metadata.
+func (md *Metadata) IndexColumns(tableID TableID, indexOrdinal int) ColSet {
+	tab := md.Table(tableID)
+	index := tab.Index(indexOrdinal)
+
+	var indexCols ColSet
+	for i := 0; i < index.ColumnCount(); i++ {
+		ord := index.Column(i).Ordinal
+		indexCols.Add(int(md.TableColumn(tableID, ord)))
+	}
+
+	return indexCols
+}
+
 // ColumnLabel returns the label of the given column. It is used for pretty-
 // printing and debugging.
 func (md *Metadata) ColumnLabel(id ColumnID) string {

--- a/pkg/sql/opt/norm/testdata/combo
+++ b/pkg/sql/opt/norm/testdata/combo
@@ -281,11 +281,85 @@ FilterUnusedJoinRightCols
     └── projections [outer=(4)]
          └── variable: a.s [type=string, outer=(4)]
 --------------------------------------------------------------------------------
-GenerateIndexScans (no changes)
+GenerateIndexScans (higher cost)
 --------------------------------------------------------------------------------
+   project
+    ├── columns: s:4(string)
+    ├── inner-join
+    │    ├── columns: a.x:1(int!null) a.s:4(string) b.x:6(int!null)
+    │    ├── project
+    │    │    ├── columns: a.x:1(int!null) a.s:4(string)
+    │    │    ├── keys: (1)
+    │    │    ├── select
+    │    │    │    ├── columns: a.x:1(int!null) a.i:2(int) a.s:4(string)
+    │    │    │    ├── keys: (1)
+  - │    │    │    ├── scan a
+  + │    │    │    ├── lookup-join
+    │    │    │    │    ├── columns: a.x:1(int!null) a.i:2(int) a.s:4(string)
+  - │    │    │    │    └── keys: (1)
+  + │    │    │    │    ├── table: a
+  + │    │    │    │    ├── keys: (1)
+  + │    │    │    │    └── scan a@secondary
+  + │    │    │    │         ├── columns: a.x:1(int!null) a.s:4(string)
+  + │    │    │    │         └── keys: (1)
+    │    │    │    └── filters [type=bool, outer=(2)]
+    │    │    │         └── eq [type=bool, outer=(2)]
+    │    │    │              ├── variable: a.i [type=int, outer=(2)]
+    │    │    │              └── minus [type=int]
+    │    │    │                   ├── const: 10 [type=int]
+    │    │    │                   └── const: 1 [type=int]
+    │    │    └── projections [outer=(1,4)]
+    │    │         ├── variable: a.x [type=int, outer=(1)]
+    │    │         └── variable: a.s [type=string, outer=(4)]
+    │    ├── scan b
+    │    │    ├── columns: b.x:6(int!null)
+    │    │    └── keys: (6)
+    │    └── filters [type=bool, outer=(1,6)]
+    │         └── eq [type=bool, outer=(1,6)]
+    │              ├── variable: a.x [type=int, outer=(1)]
+    │              └── variable: b.x [type=int, outer=(6)]
+    └── projections [outer=(4)]
+         └── variable: a.s [type=string, outer=(4)]
 --------------------------------------------------------------------------------
-ConstrainScan (no changes)
+ConstrainScan (higher cost)
 --------------------------------------------------------------------------------
+   project
+    ├── columns: s:4(string)
+    ├── inner-join
+    │    ├── columns: a.x:1(int!null) a.s:4(string) b.x:6(int!null)
+    │    ├── project
+    │    │    ├── columns: a.x:1(int!null) a.s:4(string)
+    │    │    ├── keys: (1)
+    │    │    ├── select
+    │    │    │    ├── columns: a.x:1(int!null) a.i:2(int) a.s:4(string)
+    │    │    │    ├── keys: (1)
+  - │    │    │    ├── lookup-join
+  + │    │    │    ├── scan a
+    │    │    │    │    ├── columns: a.x:1(int!null) a.i:2(int) a.s:4(string)
+  - │    │    │    │    ├── table: a
+  - │    │    │    │    ├── keys: (1)
+  - │    │    │    │    └── scan a@secondary
+  - │    │    │    │         ├── columns: a.x:1(int!null) a.s:4(string)
+  - │    │    │    │         └── keys: (1)
+  + │    │    │    │    └── keys: (1)
+    │    │    │    └── filters [type=bool, outer=(2)]
+    │    │    │         └── eq [type=bool, outer=(2)]
+    │    │    │              ├── variable: a.i [type=int, outer=(2)]
+    │    │    │              └── minus [type=int]
+    │    │    │                   ├── const: 10 [type=int]
+    │    │    │                   └── const: 1 [type=int]
+    │    │    └── projections [outer=(1,4)]
+    │    │         ├── variable: a.x [type=int, outer=(1)]
+    │    │         └── variable: a.s [type=string, outer=(4)]
+    │    ├── scan b
+    │    │    ├── columns: b.x:6(int!null)
+    │    │    └── keys: (6)
+    │    └── filters [type=bool, outer=(1,6)]
+    │         └── eq [type=bool, outer=(1,6)]
+    │              ├── variable: a.x [type=int, outer=(1)]
+    │              └── variable: b.x [type=int, outer=(6)]
+    └── projections [outer=(4)]
+         └── variable: a.s [type=string, outer=(4)]
 --------------------------------------------------------------------------------
 GenerateIndexScans (no changes)
 --------------------------------------------------------------------------------
@@ -1152,11 +1226,105 @@ PushLimitIntoProject
   +           ├── variable: a.i [type=int, outer=(2)]
   +           └── const: 1 [type=int]
 --------------------------------------------------------------------------------
-GenerateIndexScans (no changes)
+GenerateIndexScans (higher cost)
 --------------------------------------------------------------------------------
+   project
+    ├── columns: i:2(int) column8:8(int)
+    ├── ordering: +2
+    ├── limit
+    │    ├── columns: a.i:2(int)
+    │    ├── ordering: +2
+    │    ├── offset
+    │    │    ├── columns: a.i:2(int)
+    │    │    ├── ordering: +2
+    │    │    ├── sort
+    │    │    │    ├── columns: a.i:2(int)
+    │    │    │    ├── ordering: +2
+    │    │    │    └── project
+    │    │    │         ├── columns: a.i:2(int)
+    │    │    │         ├── select
+    │    │    │         │    ├── columns: a.x:1(int) a.i:2(int) b.x:6(int)
+    │    │    │         │    ├── full-join
+    │    │    │         │    │    ├── columns: a.x:1(int) a.i:2(int) b.x:6(int)
+  - │    │    │         │    │    ├── scan a
+  + │    │    │         │    │    ├── lookup-join
+    │    │    │         │    │    │    ├── columns: a.x:1(int!null) a.i:2(int)
+  - │    │    │         │    │    │    └── keys: (1)
+  + │    │    │         │    │    │    ├── table: a
+  + │    │    │         │    │    │    ├── keys: (1)
+  + │    │    │         │    │    │    └── scan a@secondary
+  + │    │    │         │    │    │         ├── columns: a.x:1(int!null)
+  + │    │    │         │    │    │         └── keys: (1)
+    │    │    │         │    │    ├── scan b
+    │    │    │         │    │    │    ├── columns: b.x:6(int!null)
+    │    │    │         │    │    │    └── keys: (6)
+    │    │    │         │    │    └── filters [type=bool, outer=(1,6)]
+    │    │    │         │    │         └── eq [type=bool, outer=(1,6)]
+    │    │    │         │    │              ├── variable: a.x [type=int, outer=(1)]
+    │    │    │         │    │              └── variable: b.x [type=int, outer=(6)]
+    │    │    │         │    └── filters [type=bool, outer=(2), constraints=(/2: [/10 - /10]; tight)]
+    │    │    │         │         └── eq [type=bool, outer=(2), constraints=(/2: [/10 - /10]; tight)]
+    │    │    │         │              ├── variable: a.i [type=int, outer=(2)]
+    │    │    │         │              └── const: 10 [type=int]
+    │    │    │         └── projections [outer=(2)]
+    │    │    │              └── variable: a.i [type=int, outer=(2)]
+    │    │    └── const: 1 [type=int]
+    │    └── const: 5 [type=int]
+    └── projections [outer=(2)]
+         ├── variable: a.i [type=int, outer=(2)]
+         └── plus [type=int, outer=(2)]
+              ├── variable: a.i [type=int, outer=(2)]
+              └── const: 1 [type=int]
 --------------------------------------------------------------------------------
-GenerateIndexScans (no changes)
+GenerateIndexScans (higher cost)
 --------------------------------------------------------------------------------
+   project
+    ├── columns: i:2(int) column8:8(int)
+    ├── ordering: +2
+    ├── limit
+    │    ├── columns: a.i:2(int)
+    │    ├── ordering: +2
+    │    ├── offset
+    │    │    ├── columns: a.i:2(int)
+    │    │    ├── ordering: +2
+    │    │    ├── sort
+    │    │    │    ├── columns: a.i:2(int)
+    │    │    │    ├── ordering: +2
+    │    │    │    └── project
+    │    │    │         ├── columns: a.i:2(int)
+    │    │    │         ├── select
+    │    │    │         │    ├── columns: a.x:1(int) a.i:2(int) b.x:6(int)
+    │    │    │         │    ├── full-join
+    │    │    │         │    │    ├── columns: a.x:1(int) a.i:2(int) b.x:6(int)
+  - │    │    │         │    │    ├── lookup-join
+  + │    │    │         │    │    ├── scan a
+    │    │    │         │    │    │    ├── columns: a.x:1(int!null) a.i:2(int)
+  - │    │    │         │    │    │    ├── table: a
+  - │    │    │         │    │    │    ├── keys: (1)
+  - │    │    │         │    │    │    └── scan a@secondary
+  - │    │    │         │    │    │         ├── columns: a.x:1(int!null)
+  - │    │    │         │    │    │         └── keys: (1)
+  + │    │    │         │    │    │    └── keys: (1)
+    │    │    │         │    │    ├── scan b
+    │    │    │         │    │    │    ├── columns: b.x:6(int!null)
+    │    │    │         │    │    │    └── keys: (6)
+    │    │    │         │    │    └── filters [type=bool, outer=(1,6)]
+    │    │    │         │    │         └── eq [type=bool, outer=(1,6)]
+    │    │    │         │    │              ├── variable: a.x [type=int, outer=(1)]
+    │    │    │         │    │              └── variable: b.x [type=int, outer=(6)]
+    │    │    │         │    └── filters [type=bool, outer=(2), constraints=(/2: [/10 - /10]; tight)]
+    │    │    │         │         └── eq [type=bool, outer=(2), constraints=(/2: [/10 - /10]; tight)]
+    │    │    │         │              ├── variable: a.i [type=int, outer=(2)]
+    │    │    │         │              └── const: 10 [type=int]
+    │    │    │         └── projections [outer=(2)]
+    │    │    │              └── variable: a.i [type=int, outer=(2)]
+    │    │    └── const: 1 [type=int]
+    │    └── const: 5 [type=int]
+    └── projections [outer=(2)]
+         ├── variable: a.i [type=int, outer=(2)]
+         └── plus [type=int, outer=(2)]
+              ├── variable: a.i [type=int, outer=(2)]
+              └── const: 1 [type=int]
 ================================================================================
 Final best expression
   Cost: 14500.00
@@ -1970,11 +2138,47 @@ DecorrelateJoin
               ├── variable: b.z [type=int, outer=(7)]
               └── variable: a.i [type=int, outer=(2)]
 --------------------------------------------------------------------------------
-GenerateIndexScans (no changes)
+GenerateIndexScans (higher cost)
 --------------------------------------------------------------------------------
+   semi-join
+    ├── columns: x:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
+  - ├── scan a
+  + ├── lookup-join
+    │    ├── columns: a.x:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
+  - │    └── keys: (1) weak(3,4)
+  + │    ├── table: a
+  + │    ├── keys: (1) weak(3,4)
+  + │    └── scan a@secondary
+  + │         ├── columns: a.x:1(int!null) a.f:3(float) a.s:4(string) a.j:5(jsonb)
+  + │         └── keys: (1) weak(3,4)
+    ├── scan b
+    │    ├── columns: b.x:6(int!null) b.z:7(int)
+    │    └── keys: (6)
+    └── filters [type=bool, outer=(2,7)]
+         └── eq [type=bool, outer=(2,7)]
+              ├── variable: b.z [type=int, outer=(7)]
+              └── variable: a.i [type=int, outer=(2)]
 --------------------------------------------------------------------------------
-GenerateIndexScans (no changes)
+GenerateIndexScans (higher cost)
 --------------------------------------------------------------------------------
+   semi-join
+    ├── columns: x:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
+  - ├── lookup-join
+  + ├── scan a
+    │    ├── columns: a.x:1(int!null) a.i:2(int) a.f:3(float) a.s:4(string) a.j:5(jsonb)
+  - │    ├── table: a
+  - │    ├── keys: (1) weak(3,4)
+  - │    └── scan a@secondary
+  - │         ├── columns: a.x:1(int!null) a.f:3(float) a.s:4(string) a.j:5(jsonb)
+  - │         └── keys: (1) weak(3,4)
+  + │    └── keys: (1) weak(3,4)
+    ├── scan b
+    │    ├── columns: b.x:6(int!null) b.z:7(int)
+    │    └── keys: (6)
+    └── filters [type=bool, outer=(2,7)]
+         └── eq [type=bool, outer=(2,7)]
+              ├── variable: b.z [type=int, outer=(7)]
+              └── variable: a.i [type=int, outer=(2)]
 ================================================================================
 Final best expression
   Cost: 2000.00

--- a/pkg/sql/opt/ops/relational.opt
+++ b/pkg/sql/opt/ops/relational.opt
@@ -114,6 +114,13 @@ define AntiJoin {
     On    Expr
 }
 
+# LookupJoin represents a join between an input expression and an index.
+[Relational]
+define LookupJoin {
+    Input Expr
+    Def LookupJoinDef
+}
+
 # InnerJoinApply has the same join semantics as InnerJoin. However, unlike
 # InnerJoin, it allows the right input to refer to columns projected by the
 # left input.

--- a/pkg/sql/opt/optgen/cmd/optgen/utils.go
+++ b/pkg/sql/opt/optgen/cmd/optgen/utils.go
@@ -56,6 +56,8 @@ func mapPrivateType(typ string) string {
 		return "*memo.FuncOpDef"
 	case "ScanOpDef":
 		return "*memo.ScanOpDef"
+	case "LookupJoinDef":
+		return "*memo.LookupJoinDef"
 	case "SetOpColMap":
 		return "*memo.SetOpColMap"
 	case "Datum":

--- a/pkg/sql/opt/xform/coster.go
+++ b/pkg/sql/opt/xform/coster.go
@@ -70,6 +70,10 @@ func (c *coster) ComputeCost(candidate *memo.BestExpr, props *memo.LogicalProps)
 	case opt.ValuesOp:
 		return c.computeValuesCost(candidate, props)
 
+	case opt.LookupJoinOp:
+		// TODO(justin): remove this once we can execbuild index joins.
+		return 1000000000000
+
 	default:
 		// By default, cost of parent is sum of child costs.
 		return c.computeChildrenCost(candidate)

--- a/pkg/sql/opt/xform/testdata/physprops/ordering
+++ b/pkg/sql/opt/xform/testdata/physprops/ordering
@@ -202,12 +202,12 @@ memo (optimized)
  │         ├── best: (select G4="[ordering: +1,-2]" G5)
  │         └── cost: 1100.00
  ├── G3: (projections G10 G6 G9)
- ├── G4: (scan a)
+ ├── G4: (scan a,cols=(1,2))
  │    ├── ""
- │    │    ├── best: (scan a)
+ │    │    ├── best: (scan a,cols=(1,2))
  │    │    └── cost: 1000.00
  │    └── "[ordering: +1,-2]"
- │         ├── best: (scan a)
+ │         ├── best: (scan a,cols=(1,2))
  │         └── cost: 1000.00
  ├── G5: (filters G7)
  ├── G6: (minus G9 G8)
@@ -256,9 +256,9 @@ memo (optimized)
  │         ├── best: (sort G2)
  │         └── cost: 1125.00
  ├── G3: (projections G9 G6)
- ├── G4: (scan a)
+ ├── G4: (scan a,cols=(1-3))
  │    ├── ""
- │    │    ├── best: (scan a)
+ │    │    ├── best: (scan a,cols=(1-3))
  │    │    └── cost: 1000.00
  │    └── "[ordering: +2]"
  │         ├── best: (sort G4)

--- a/pkg/sql/opt/xform/testdata/rules/limit
+++ b/pkg/sql/opt/xform/testdata/rules/limit
@@ -109,18 +109,18 @@ memo
 SELECT s FROM a WHERE s='foo' LIMIT 1
 ----
 memo (optimized)
- ├── G1: (limit G2 G3 ) (scan a@s_idx,constrained,lim=1) (scan a@si_idx,constrained,lim=1)
+ ├── G1: (limit G2 G3 ) (scan a@s_idx,cols=(4),constrained,lim=1) (scan a@si_idx,cols=(4),constrained,lim=1)
  │    └── "[presentation: s:4]"
- │         ├── best: (scan a@s_idx,constrained,lim=1)
+ │         ├── best: (scan a@s_idx,cols=(4),constrained,lim=1)
  │         └── cost: 1.00
- ├── G2: (select G4 G5) (scan a@s_idx,constrained) (scan a@si_idx,constrained)
+ ├── G2: (select G4 G5) (scan a@s_idx,cols=(4),constrained) (scan a@si_idx,cols=(4),constrained)
  │    └── ""
- │         ├── best: (scan a@s_idx,constrained)
+ │         ├── best: (scan a@s_idx,cols=(4),constrained)
  │         └── cost: 100.00
  ├── G3: (const 1)
- ├── G4: (scan a) (scan a@s_idx) (scan a@si_idx)
+ ├── G4: (scan a,cols=(4)) (scan a@s_idx,cols=(4)) (scan a@si_idx,cols=(4))
  │    └── ""
- │         ├── best: (scan a)
+ │         ├── best: (scan a,cols=(4))
  │         └── cost: 1000.00
  ├── G5: (filters G6)
  ├── G6: (eq G7 G8)

--- a/pkg/sql/opt/xform/testdata/rules/scan
+++ b/pkg/sql/opt/xform/testdata/rules/scan
@@ -46,13 +46,113 @@ memo
 SELECT s, i, f FROM a ORDER BY s, k, i
 ----
 memo (optimized)
- └── G1: (scan a) (scan a@s_idx)
-      ├── "[presentation: s:4,i:2,f:3] [ordering: +4,+1,+2]"
-      │    ├── best: (scan a@s_idx)
+ ├── G1: (scan a,cols=(1-4)) (scan a@s_idx,cols=(1-4)) (lookup-join G2 a,cols=(1-4))
+ │    ├── "[presentation: s:4,i:2,f:3] [ordering: +4,+1,+2]"
+ │    │    ├── best: (scan a@s_idx,cols=(1-4))
+ │    │    └── cost: 1000.00
+ │    └── ""
+ │         ├── best: (scan a,cols=(1-4))
+ │         └── cost: 1000.00
+ └── G2: (scan a@si_idx,cols=(1,2,4))
+      ├── ""
+      │    ├── best: (scan a@si_idx,cols=(1,2,4))
       │    └── cost: 1000.00
+      └── "[ordering: +4,+1,+2]"
+           ├── best: (sort G2)
+           └── cost: 1250.00
+
+memo
+SELECT s, i, f FROM a ORDER BY f
+----
+memo (optimized)
+ ├── G1: (scan a,cols=(2-4)) (scan a@s_idx,cols=(2-4)) (lookup-join G2 a,cols=(2-4))
+ │    ├── "[presentation: s:4,i:2,f:3] [ordering: +3]"
+ │    │    ├── best: (sort G1)
+ │    │    └── cost: 1250.00
+ │    └── ""
+ │         ├── best: (scan a,cols=(2-4))
+ │         └── cost: 1000.00
+ └── G2: (scan a@si_idx,cols=(1,2,4))
       └── ""
-           ├── best: (scan a)
+           ├── best: (scan a@si_idx,cols=(1,2,4))
            └── cost: 1000.00
+
+memo
+SELECT s, i, f FROM a ORDER BY s DESC, i
+----
+memo (optimized)
+ ├── G1: (scan a,cols=(2-4)) (scan a@s_idx,cols=(2-4)) (lookup-join G2 a,cols=(2-4))
+ │    ├── "[presentation: s:4,i:2,f:3] [ordering: -4,+2]"
+ │    │    ├── best: (sort G1)
+ │    │    └── cost: 1250.00
+ │    └── ""
+ │         ├── best: (scan a,cols=(2-4))
+ │         └── cost: 1000.00
+ └── G2: (scan a@si_idx,cols=(1,2,4))
+      ├── ""
+      │    ├── best: (scan a@si_idx,cols=(1,2,4))
+      │    └── cost: 1000.00
+      └── "[ordering: -4,+2]"
+           ├── best: (scan a@si_idx,cols=(1,2,4))
+           └── cost: 1000.00
+
+exec-ddl
+CREATE TABLE abc (
+  a INT,
+  b INT,
+  c INT,
+  d CHAR,
+  PRIMARY KEY (a, b, c),
+  UNIQUE INDEX bc (b, c),
+  INDEX ba (b, a),
+  FAMILY (a, b, c),
+  FAMILY (d)
+)
+----
+TABLE abc
+ ├── a int not null
+ ├── b int not null
+ ├── c int not null
+ ├── d string
+ ├── INDEX primary
+ │    ├── a int not null
+ │    ├── b int not null
+ │    └── c int not null
+ ├── INDEX bc
+ │    ├── b int not null
+ │    ├── c int not null
+ │    └── a int not null (storing)
+ └── INDEX ba
+      ├── b int not null
+      ├── a int not null
+      └── c int not null
+
+memo
+SELECT d FROM abc ORDER BY LOWER(d)
+----
+memo (optimized)
+ ├── G1: (project G2 G3)
+ │    ├── "[presentation: d:4] [ordering: +5]"
+ │    │    ├── best: (sort G1)
+ │    │    └── cost: 1250.00
+ │    └── ""
+ │         ├── best: (project G2 G3)
+ │         └── cost: 1000.00
+ ├── G2: (scan abc,cols=(4)) (lookup-join G4 abc,cols=(4)) (lookup-join G5 abc,cols=(4))
+ │    └── ""
+ │         ├── best: (scan abc,cols=(4))
+ │         └── cost: 1000.00
+ ├── G3: (projections G7 G6)
+ ├── G4: (scan abc@bc,cols=(1-3))
+ │    └── ""
+ │         ├── best: (scan abc@bc,cols=(1-3))
+ │         └── cost: 1000.00
+ ├── G5: (scan abc@ba,cols=(1-3))
+ │    └── ""
+ │         ├── best: (scan abc@ba,cols=(1-3))
+ │         └── cost: 1000.00
+ ├── G6: (function G7 lower)
+ └── G7: (variable abc.d)
 
 # Scan of primary index is lowest cost.
 opt
@@ -67,13 +167,20 @@ memo
 SELECT s, i, f FROM a ORDER BY k, i, s
 ----
 memo (optimized)
- └── G1: (scan a) (scan a@s_idx)
-      ├── "[presentation: s:4,i:2,f:3] [ordering: +1,+2,+4]"
-      │    ├── best: (scan a)
+ ├── G1: (scan a,cols=(1-4)) (scan a@s_idx,cols=(1-4)) (lookup-join G2 a,cols=(1-4))
+ │    ├── "[presentation: s:4,i:2,f:3] [ordering: +1,+2,+4]"
+ │    │    ├── best: (scan a,cols=(1-4))
+ │    │    └── cost: 1000.00
+ │    └── ""
+ │         ├── best: (scan a,cols=(1-4))
+ │         └── cost: 1000.00
+ └── G2: (scan a@si_idx,cols=(1,2,4))
+      ├── ""
+      │    ├── best: (scan a@si_idx,cols=(1,2,4))
       │    └── cost: 1000.00
-      └── ""
-           ├── best: (scan a)
-           └── cost: 1000.00
+      └── "[ordering: +1,+2,+4]"
+           ├── best: (sort G2)
+           └── cost: 1250.00
 
 # Secondary index has right order, but is not covering.
 opt
@@ -89,12 +196,19 @@ memo
 SELECT s, j FROM a ORDER BY s
 ----
 memo (optimized)
- └── G1: (scan a) (scan a@si_idx)
-      ├── "[presentation: s:4,j:5] [ordering: +4]"
-      │    ├── best: (sort G1)
-      │    └── cost: 1250.00
-      └── ""
-           ├── best: (scan a)
+ ├── G1: (scan a,cols=(4,5)) (lookup-join G2 a,cols=(4,5)) (scan a@si_idx,cols=(4,5))
+ │    ├── "[presentation: s:4,j:5] [ordering: +4]"
+ │    │    ├── best: (sort G1)
+ │    │    └── cost: 1250.00
+ │    └── ""
+ │         ├── best: (scan a,cols=(4,5))
+ │         └── cost: 1000.00
+ └── G2: (scan a@s_idx,cols=(1,4))
+      ├── ""
+      │    ├── best: (scan a@s_idx,cols=(1,4))
+      │    └── cost: 1000.00
+      └── "[ordering: +4]"
+           ├── best: (scan a@s_idx,cols=(1,4))
            └── cost: 1000.00
 
 # Consider three different indexes, and pick index with multiple keys.
@@ -110,12 +224,12 @@ memo
 SELECT i, k FROM a ORDER BY s DESC, i, k
 ----
 memo (optimized)
- └── G1: (scan a) (scan a@s_idx) (scan a@si_idx)
+ └── G1: (scan a,cols=(1,2,4)) (scan a@s_idx,cols=(1,2,4)) (scan a@si_idx,cols=(1,2,4))
       ├── "[presentation: i:2,k:1] [ordering: -4,+2,+1]"
-      │    ├── best: (scan a@si_idx)
+      │    ├── best: (scan a@si_idx,cols=(1,2,4))
       │    └── cost: 1000.00
       └── ""
-           ├── best: (scan a)
+           ├── best: (scan a,cols=(1,2,4))
            └── cost: 1000.00
 
 memo
@@ -126,14 +240,14 @@ memo (optimized)
  │    └── "[presentation: i:2,k:1]"
  │         ├── best: (project G2 G3)
  │         └── cost: 100.00
- ├── G2: (select G4 G5) (scan a@s_idx,constrained) (scan a@si_idx,constrained)
+ ├── G2: (select G4 G5) (scan a@s_idx,cols=(1,2,4),constrained) (scan a@si_idx,cols=(1,2,4),constrained)
  │    └── ""
- │         ├── best: (scan a@s_idx,constrained)
+ │         ├── best: (scan a@s_idx,cols=(1,2,4),constrained)
  │         └── cost: 100.00
  ├── G3: (projections G6 G7)
- ├── G4: (scan a) (scan a@s_idx) (scan a@si_idx)
+ ├── G4: (scan a,cols=(1,2,4)) (scan a@s_idx,cols=(1,2,4)) (scan a@si_idx,cols=(1,2,4))
  │    └── ""
- │         ├── best: (scan a)
+ │         ├── best: (scan a,cols=(1,2,4))
  │         └── cost: 1000.00
  ├── G5: (filters G8)
  ├── G6: (variable a.i)

--- a/pkg/sql/opt/xform/testdata/rules/select
+++ b/pkg/sql/opt/xform/testdata/rules/select
@@ -39,13 +39,13 @@ memo
 SELECT k FROM a WHERE k = 1
 ----
 memo (optimized)
- ├── G1: (select G2 G3) (scan a,constrained)
+ ├── G1: (select G2 G3) (scan a,cols=(1),constrained)
  │    └── "[presentation: k:1]"
- │         ├── best: (scan a,constrained)
+ │         ├── best: (scan a,cols=(1),constrained)
  │         └── cost: 100.00
- ├── G2: (scan a) (scan a@u) (scan a@v)
+ ├── G2: (scan a,cols=(1)) (scan a@u,cols=(1)) (scan a@v,cols=(1))
  │    └── ""
- │         ├── best: (scan a)
+ │         ├── best: (scan a,cols=(1))
  │         └── cost: 1000.00
  ├── G3: (filters G4)
  ├── G4: (eq G5 G6)
@@ -73,14 +73,14 @@ memo (optimized)
  │    └── "[presentation: k:1]"
  │         ├── best: (project G2 G3)
  │         └── cost: 100.00
- ├── G2: (select G4 G5) (scan a@v,constrained)
+ ├── G2: (select G4 G5) (scan a@v,cols=(1,3),constrained)
  │    └── ""
- │         ├── best: (scan a@v,constrained)
+ │         ├── best: (scan a@v,cols=(1,3),constrained)
  │         └── cost: 100.00
  ├── G3: (projections G6)
- ├── G4: (scan a) (scan a@u) (scan a@v)
+ ├── G4: (scan a,cols=(1,3)) (scan a@u,cols=(1,3)) (scan a@v,cols=(1,3))
  │    └── ""
- │         ├── best: (scan a)
+ │         ├── best: (scan a,cols=(1,3))
  │         └── cost: 1000.00
  ├── G5: (filters G7)
  ├── G6: (variable a.k)
@@ -109,19 +109,19 @@ memo (optimized)
  │    └── "[presentation: k:1]"
  │         ├── best: (project G2 G3)
  │         └── cost: 100.00
- ├── G2: (select G4 G5) (select G6 G7) (scan a@u,constrained)
+ ├── G2: (select G4 G5) (select G6 G7) (scan a@u,cols=(1,2),constrained)
  │    └── ""
- │         ├── best: (scan a@u,constrained)
+ │         ├── best: (scan a@u,cols=(1,2),constrained)
  │         └── cost: 100.00
  ├── G3: (projections G10)
- ├── G4: (scan a) (scan a@u) (scan a@v)
+ ├── G4: (scan a,cols=(1,2)) (scan a@u,cols=(1,2)) (scan a@v,cols=(1,2))
  │    └── ""
- │         ├── best: (scan a)
+ │         ├── best: (scan a,cols=(1,2))
  │         └── cost: 1000.00
  ├── G5: (filters G9 G8)
- ├── G6: (scan a,constrained)
+ ├── G6: (scan a,cols=(1,2),constrained)
  │    └── ""
- │         ├── best: (scan a,constrained)
+ │         ├── best: (scan a,cols=(1,2),constrained)
  │         └── cost: 100.00
  ├── G7: (filters G9)
  ├── G8: (eq G10 G11)
@@ -167,14 +167,14 @@ memo (optimized)
  │         ├── best: (select G6 G7)
  │         └── cost: 110.00
  ├── G3: (projections G12)
- ├── G4: (scan a) (scan a@u) (scan a@v)
+ ├── G4: (scan a,cols=(1,2)) (scan a@u,cols=(1,2)) (scan a@v,cols=(1,2))
  │    └── ""
- │         ├── best: (scan a)
+ │         ├── best: (scan a,cols=(1,2))
  │         └── cost: 1000.00
  ├── G5: (filters G8 G9)
- ├── G6: (scan a@u,constrained)
+ ├── G6: (scan a@u,cols=(1,2),constrained)
  │    └── ""
- │         ├── best: (scan a@u,constrained)
+ │         ├── best: (scan a@u,cols=(1,2),constrained)
  │         └── cost: 100.00
  ├── G7: (filters G9)
  ├── G8: (eq G13 G11)


### PR DESCRIPTION
This commit introduces the ability to explore index scans which are not
covering the requested columns, and use an index join to add in the
columns which are required.

It does not yet support execbuilding such plans, however, and they're
given infinite cost so they don't get planned.

This is also a good bit less general than the full machinery of planning lookup joins. 

Release note: None