### PR TITLE
*: crlfmt linter accidentaly excluded files

### DIFF
--- a/pkg/sql/exec_log.go
+++ b/pkg/sql/exec_log.go
@@ -98,11 +98,7 @@ func (p *planner) maybeLogStatement(ctx context.Context, lbl string, rows int, e
 }
 
 func (p *planner) maybeLogStatementInternal(
-	ctx context.Context,
-	lbl string,
-	rows int,
-	err error,
-	startTime time.Time,
+	ctx context.Context, lbl string, rows int, err error, startTime time.Time,
 ) {
 	// Note: if you find the code below crashing because p.execCfg == nil,
 	// do not add a test "if p.execCfg == nil { do nothing }" !

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -2137,7 +2137,10 @@ func (h oidHasher) TableOid(
 }
 
 func (h oidHasher) IndexOid(
-	db *sqlbase.DatabaseDescriptor, scName string, table *sqlbase.TableDescriptor, index *sqlbase.IndexDescriptor,
+	db *sqlbase.DatabaseDescriptor,
+	scName string,
+	table *sqlbase.TableDescriptor,
+	index *sqlbase.IndexDescriptor,
 ) *tree.DOid {
 	h.writeTypeTag(indexTypeTag)
 	h.writeDB(db)
@@ -2148,7 +2151,10 @@ func (h oidHasher) IndexOid(
 }
 
 func (h oidHasher) ColumnOid(
-	db *sqlbase.DatabaseDescriptor, scName string, table *sqlbase.TableDescriptor, column *sqlbase.ColumnDescriptor,
+	db *sqlbase.DatabaseDescriptor,
+	scName string,
+	table *sqlbase.TableDescriptor,
+	column *sqlbase.ColumnDescriptor,
 ) *tree.DOid {
 	h.writeTypeTag(columnTypeTag)
 	h.writeDB(db)
@@ -2173,7 +2179,10 @@ func (h oidHasher) CheckConstraintOid(
 }
 
 func (h oidHasher) PrimaryKeyConstraintOid(
-	db *sqlbase.DatabaseDescriptor, scName string, table *sqlbase.TableDescriptor, pkey *sqlbase.IndexDescriptor,
+	db *sqlbase.DatabaseDescriptor,
+	scName string,
+	table *sqlbase.TableDescriptor,
+	pkey *sqlbase.IndexDescriptor,
 ) *tree.DOid {
 	h.writeTypeTag(pKeyConstraintTypeTag)
 	h.writeDB(db)
@@ -2184,7 +2193,10 @@ func (h oidHasher) PrimaryKeyConstraintOid(
 }
 
 func (h oidHasher) ForeignKeyConstraintOid(
-	db *sqlbase.DatabaseDescriptor, scName string, table *sqlbase.TableDescriptor, fk *sqlbase.ForeignKeyReference,
+	db *sqlbase.DatabaseDescriptor,
+	scName string,
+	table *sqlbase.TableDescriptor,
+	fk *sqlbase.ForeignKeyReference,
 ) *tree.DOid {
 	h.writeTypeTag(fkConstraintTypeTag)
 	h.writeDB(db)
@@ -2195,7 +2207,10 @@ func (h oidHasher) ForeignKeyConstraintOid(
 }
 
 func (h oidHasher) UniqueConstraintOid(
-	db *sqlbase.DatabaseDescriptor, scName string, table *sqlbase.TableDescriptor, index *sqlbase.IndexDescriptor,
+	db *sqlbase.DatabaseDescriptor,
+	scName string,
+	table *sqlbase.TableDescriptor,
+	index *sqlbase.IndexDescriptor,
 ) *tree.DOid {
 	h.writeTypeTag(uniqueConstraintTypeTag)
 	h.writeDB(db)

--- a/pkg/testutils/lint/lint_test.go
+++ b/pkg/testutils/lint/lint_test.go
@@ -654,7 +654,7 @@ func TestLint(t *testing.T) {
 
 	t.Run("TestCrlfmt", func(t *testing.T) {
 		t.Parallel()
-		ignore := `\.(pb(\.gw)?)|(.og)\.go|/testdata/`
+		ignore := `\.(pb(\.gw)?)|(\.og)\.go|/testdata/`
 		cmd, stderr, filter, err := dirCmd(pkgDir, "crlfmt", "-ignore", ignore, "-tab", "2", ".")
 		if err != nil {
 			t.Fatal(err)

--- a/pkg/util/log/secondary_log.go
+++ b/pkg/util/log/secondary_log.go
@@ -45,7 +45,9 @@ var secondaryLogRegistry struct {
 // The given directory name can be either nil or empty, in which case
 // the global logger's own dirName is used; or non-nil and non-empty,
 // in which case it specifies the directory for that new logger.
-func NewSecondaryLogger(dirName *DirName, fileNamePrefix string, enableGc, forceSyncWrites bool) *SecondaryLogger {
+func NewSecondaryLogger(
+	dirName *DirName, fileNamePrefix string, enableGc, forceSyncWrites bool,
+) *SecondaryLogger {
 	logging.mu.Lock()
 	defer logging.mu.Unlock()
 	var dir string


### PR DESCRIPTION
The ignore rule for crlfmt was `(.og)`, not `(\.og)`, which made files
that had `.og` in their name for any character `.` not get linted.

This fixes the linter and the format issues.

Release note: None