### PR TITLE
release-2.0: reset forgotten planner fields

### DIFF
--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -1625,6 +1625,8 @@ func (ex *connExecutor) resetPlanner(
 	p.autoCommit = false
 	p.isPreparing = false
 	p.asOfSystemTime = false
+	p.avoidCachedDescriptors = false
+	p.revealNewDescriptors = false
 }
 
 // txnStateTransitionsApplyWrapper is a wrapper on top of Machine built with the


### PR DESCRIPTION
Cherry-pick of #25004

Some planner weren't being reset between statements. Not sure what the
consequences were.

Release note: None

cc @cockroachdb/release 