### PR TITLE
ts: Factor Query Time Parameters into Struct

### DIFF
--- a/pkg/storage/ts_maintenance_queue_test.go
+++ b/pkg/storage/ts_maintenance_queue_test.go
@@ -308,9 +308,11 @@ func TestTimeSeriesMaintenanceQueueServer(t *testing.T) {
 			context.TODO(),
 			tspb.Query{Name: seriesName},
 			ts.Resolution10s,
-			ts.Resolution10s.SampleDuration(),
-			0,
-			now+ts.Resolution10s.SlabDuration(),
+			ts.QueryTimespan{
+				SampleDurationNanos: ts.Resolution10s.SampleDuration(),
+				StartNanos:          0,
+				EndNanos:            now + ts.Resolution10s.SlabDuration(),
+			},
 			memContext,
 		)
 		return dps, err

--- a/pkg/ts/db_test.go
+++ b/pkg/ts/db_test.go
@@ -313,14 +313,13 @@ func (tm *testModelRunner) assertQuery(
 
 	memContext := tm.makeMemoryContext(interpolationLimit)
 	defer memContext.Close(context.TODO())
+	timespan := QueryTimespan{
+		StartNanos:          start,
+		EndNanos:            end,
+		SampleDurationNanos: sampleDuration,
+	}
 	actualDatapoints, actualSources, err := tm.DB.QueryMemoryConstrained(
-		context.TODO(),
-		q,
-		r,
-		sampleDuration,
-		start,
-		end,
-		memContext,
+		context.TODO(), q, r, timespan, memContext,
 	)
 	if err != nil {
 		tm.t.Fatal(err)

--- a/pkg/ts/server.go
+++ b/pkg/ts/server.go
@@ -212,6 +212,12 @@ func (s *Server) Query(
 		}
 	}()
 
+	timespan := QueryTimespan{
+		StartNanos:          request.StartNanos,
+		EndNanos:            request.EndNanos,
+		SampleDurationNanos: sampleNanos,
+	}
+
 	// Start a task which is itself responsible for starting per-query worker
 	// tasks. This is needed because RunLimitedAsyncTask can block; in the
 	// case where a single request has more queries than the semaphore limit,
@@ -253,9 +259,7 @@ func (s *Server) Query(
 						ctx,
 						query,
 						Resolution10s,
-						sampleNanos,
-						request.StartNanos,
-						request.EndNanos,
+						timespan,
 						memContexts[queryIdx],
 					)
 					if err == nil {

--- a/pkg/ts/timespan.go
+++ b/pkg/ts/timespan.go
@@ -1,0 +1,88 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package ts
+
+import "fmt"
+
+// QueryTimespan describes the time range information for a query - the start
+// and end bounds of the query, along with the requested duration of individual
+// samples to be returned. Methods of this structure are mutating.
+type QueryTimespan struct {
+	StartNanos          int64
+	EndNanos            int64
+	SampleDurationNanos int64
+}
+
+// width returns the width of the timespan: the distance between its start and
+// and end bounds.
+func (qt *QueryTimespan) width() int64 {
+	return qt.EndNanos - qt.StartNanos
+}
+
+// slideForward modifies the timespan so that it has the same width, but
+// startNanos is moved to endNanos - in effect, sliding the timespan forward to
+// the next "window" with the same width.
+func (qt *QueryTimespan) slideForward() {
+	w := qt.width()
+	qt.StartNanos += w
+	qt.EndNanos += w
+}
+
+// expand modifies the timespan so that its width is expanded *on each side*
+// by the supplied size; the resulting width will be (2 * size) larger than the
+// original width.
+func (qt *QueryTimespan) expand(size int64) {
+	qt.StartNanos -= size
+	qt.EndNanos += size
+}
+
+// normalize modifies startNanos and endNanos so that they are exact multiples
+// of the sampleDuration. Values are modified by subtraction.
+func (qt *QueryTimespan) normalize() {
+	qt.StartNanos -= qt.StartNanos % qt.SampleDurationNanos
+	qt.EndNanos -= qt.EndNanos % qt.SampleDurationNanos
+}
+
+// verifyBounds returns an error if the bounds of this QueryTimespan are
+// incorrect; currently, this only occurs if the width is negative.
+func (qt *QueryTimespan) verifyBounds() error {
+	if qt.StartNanos > qt.EndNanos {
+		return fmt.Errorf("startNanos %d was later than endNanos %d", qt.StartNanos, qt.EndNanos)
+	}
+	return nil
+}
+
+// verifyDiskResolution returns an error if this timespan is not suitable for
+// querying the supplied disk resolution.
+func (qt *QueryTimespan) verifyDiskResolution(diskResolution Resolution) error {
+	resolutionSampleDuration := diskResolution.SampleDuration()
+	// Verify that sampleDuration is a multiple of
+	// diskResolution.SampleDuration().
+	if qt.SampleDurationNanos < resolutionSampleDuration {
+		return fmt.Errorf(
+			"sampleDuration %d was not less that queryResolution.SampleDuration %d",
+			qt.SampleDurationNanos,
+			resolutionSampleDuration,
+		)
+	}
+	if qt.SampleDurationNanos%resolutionSampleDuration != 0 {
+		return fmt.Errorf(
+			"sampleDuration %d is not a multiple of queryResolution.SampleDuration %d",
+			qt.SampleDurationNanos,
+			resolutionSampleDuration,
+		)
+	}
+	return nil
+}


### PR DESCRIPTION
Moves time parameters of a query (start, end, sample duration) into a
struct. Several utility methods that were previously inlined and
repeated have been added to this structure to make code elsewhere more
understandable.

Release Note: None