### PR TITLE
backport-2.0: storage: crash a node if the ingestion fails in an unexpected way

### DIFF
--- a/pkg/storage/replica_proposal.go
+++ b/pkg/storage/replica_proposal.go
@@ -377,7 +377,7 @@ func addSSTablePreApply(
 					log.Fatalf(ctx, "failed to move ingest sst: %v", rmErr)
 				}
 				const seqNoMsg = "Global seqno is required, but disabled"
-				if err, ok := err.(*engine.RocksDBError); ok && !strings.Contains(err.Error(), seqNoMsg) {
+				if err, ok := ingestErr.(*engine.RocksDBError); ok && !strings.Contains(ingestErr.Error(), seqNoMsg) {
 					log.Fatalf(ctx, "while ingesting %s: %s", ingestPath, err)
 				}
 			}


### PR DESCRIPTION
Backport 1/1 commits from #25024.

/cc @cockroachdb/release

---

Fixes #24971

Release note: None

--------------

As requested by @dt, I'll let this bake on master for a week or two before merging, but I'm opening this to make sure I don't forget about it.