### PR TITLE
keys,roachpb: add some high-level documentation

### DIFF
--- a/pkg/keys/constants.go
+++ b/pkg/keys/constants.go
@@ -20,6 +20,9 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 )
 
+// For a high-level overview of the keyspace layout, see the package comment in
+// doc.go.
+
 // These constants are single bytes for performance. They allow single-byte
 // comparisons which are considerably faster than bytes.HasPrefix.
 const (
@@ -36,27 +39,7 @@ const (
 //
 // Note: preserve group-wise ordering when adding new constants.
 var (
-	// localPrefix is the prefix for keys which hold data local to a
-	// RocksDB instance, such as store and range-specific metadata which
-	// must not pollute the user key space, but must be collocated with
-	// the store and/or ranges which they refer to. Storing this
-	// information in the normal system keyspace would place the data on
-	// an arbitrary set of stores, with no guarantee of collocation.
-	// Local data includes store metadata, range metadata, abort
-	// cache values, transaction records, range-spanning binary tree
-	// node pointers, and message queues.
-	//
-	// The local key prefix has been deliberately chosen to sort before
-	// the SystemPrefix, because these local keys are not addressable
-	// via the meta range addressing indexes.
-	//
-	// Some local data are not replicated, such as the store's 'ident'
-	// record. Most local data are replicated, such as AbortSpan
-	// entries and transaction rows, but are not addressable as normal
-	// MVCC values as part of transactions. Finally, some local data are
-	// stored as MVCC values and are addressable as part of distributed
-	// transactions, such as range metadata, range-spanning binary tree
-	// node pointers, and message queues.
+	// localPrefix is the prefix for all local keys.
 	localPrefix = roachpb.Key{localPrefixByte}
 	// LocalMax is the end of the local key range. It is itself a global
 	// key.

--- a/pkg/keys/doc.go
+++ b/pkg/keys/doc.go
@@ -1,0 +1,108 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+// Package keys manages the construction of keys for CockroachDB's key-value
+// layer.
+//
+// The keys package is necessarily tightly coupled to the storage package. In
+// theory, it is oblivious to higher levels of the stack. In practice, it
+// exposes several functions that blur abstraction boundaries to break
+// dependency cycles. For example, EnsureSafeSplitKey knows far too much about
+// how to decode SQL keys.
+//
+// This is the ten-thousand foot view of the keyspace:
+//
+//    +----------+
+//    | (empty)  | /Min
+//    | \x01...  | /Local
+//    | \x02...  | /Meta1    ----+
+//    | \x03...  | /Meta2        |
+//    | \x04...  | /System       |
+//    |          |               |
+//    | ...      |               |
+//    |          |               | global keys
+//    | \x89...  | /Table/1      |
+//    | \x8a...  | /Table/2      |
+//    |          |               |
+//    | ...      |               |
+//    |          |               |
+//    | \xff\xff | /Max      ----+
+//    +----------+
+//
+// When keys are pretty printed, the logical name to the right of the table is
+// shown instead of the raw byte sequence.
+//
+// Non-local key types (i.e., meta1, meta2, system, and SQL keys) are
+// collectively referred to as "global" keys. The empty key (/Min) is a special
+// case. No data is stored there, but it is used as the start key of the first
+// range descriptor and as the starting point for some scans, in which case it
+// acts like a global key.
+//
+// Key addressing
+//
+// The keyspace is divided into contiguous, non-overlapping chunks called
+// "ranges." A range is defined by its start and end keys. For example, a range
+// might span from [/Table/1, /Table/2), where the lower bound is inclusive and
+// the upper bound is exclusive. Any key that begins with /Table/1, like
+// /Table/1/SomePrimaryKeyValue..., would belong to this range. Range boundaries
+// are always global keys.
+//
+// Local keys are special. They do not belong to the range they would naturally
+// sort into. Instead, they have an "address" that is used to determine which
+// range they sort into. For example, the key /Local/Range/Table/1 would
+// naturally sort into the range [/Min, /System), but its address is /Table/1,
+// so it actually belongs to a range like [/Table1, /Table/2). Note that not
+// every local key has an address.
+//
+// Global keys have an address too, but the address is simply the key itself.
+//
+// To retrieve a key's address, use the Addr function.
+//
+// Local keys
+//
+// Local keys hold data local to a RocksDB instance, such as store- and
+// range-specific metadata which must not pollute the user key space, but must
+// be collocated with the store and/or ranges which they refer to. Storing this
+// information in the global keyspace would place the data on an arbitrary set
+// of stores, with no guarantee of collocation. Local data includes store
+// metadata, range metadata, abort cache values and transaction records.
+//
+// The local key prefix was chosen arbitrarily. Local keys would work just as
+// well with a different prefix, like 0xff, or even with a suffix.
+//
+// There are four kinds of local keys.
+//
+//   - Store local keys contain metadata about an individual store. They are
+//     unreplicated and unaddressable. The typical example is the store 'ident'
+//     record.
+//
+//   - Unreplicated range-ID local keys contain metadata that pertains to just
+//     one replica of a range. They are unreplicated and unaddressable. The
+//     typical example is the Raft log.
+//
+//   - Replicated range-ID local keys store metadata that pertains to a range as
+//     a whole. Though they are replicated, they are unaddressable. Typical
+//     examples are MVCC stats and the abort span.
+//
+//   - Range local keys also store metadata that pertains to a range as a whole.
+//     They are replicated and addressable. Typical examples are the local
+//     range descriptor and transaction records.
+//
+// Deciding between replicated range-ID local keys and (replicated) range local
+// keys is not entirely straightforward, as the two key types serve similar
+// purposes. Note that only addressable keys, like range local keys, can be the
+// target of KV operations. Unaddressable keys, like range-ID local keys, can
+// only be written as a side-effect of other KV operations. This often makes the
+// choice between the two clear.
+package keys

--- a/pkg/keys/printer.go
+++ b/pkg/keys/printer.go
@@ -566,38 +566,38 @@ func prettyPrintInternal(valDirs []encoding.Direction, key roachpb.Key, quoteRaw
 
 // PrettyPrint prints the key in a human readable format:
 //
-// Key's Format                                   Key's Value
-// /Local/...                                        "\x01"+...
-// 		/Store/...                                     "\x01s"+...
-//		/RangeID/...                                   "\x01s"+[rangeid]
-//			/[rangeid]/AbortSpan/[id]                   "\x01s"+[rangeid]+"abc-"+[id]
-//			/[rangeid]/Lease						                 "\x01s"+[rangeid]+"rfll"
-//			/[rangeid]/RaftTombstone                     "\x01s"+[rangeid]+"rftb"
-//			/[rangeid]/RaftHardState						         "\x01s"+[rangeid]+"rfth"
-//			/[rangeid]/RaftAppliedIndex						       "\x01s"+[rangeid]+"rfta"
-//			/[rangeid]/RaftLog/logIndex:[logIndex]       "\x01s"+[rangeid]+"rftl"+[logIndex]
-//			/[rangeid]/RaftTruncatedState                "\x01s"+[rangeid]+"rftt"
-//			/[rangeid]/RaftLastIndex                     "\x01s"+[rangeid]+"rfti"
-//			/[rangeid]/RangeLastReplicaGCTimestamp       "\x01s"+[rangeid]+"rlrt"
-//			/[rangeid]/RangeLastVerificationTimestamp    "\x01s"+[rangeid]+"rlvt"
-//			/[rangeid]/RangeStats                        "\x01s"+[rangeid]+"stat"
-//		/Range/...                                     "\x01k"+...
-//			[key]/RangeDescriptor                        "\x01k"+[key]+"rdsc"
-//			[key]/Transaction/[id]	                     "\x01k"+[key]+"txn-"+[txn-id]
-//			[key]/QueueLastProcessed/[queue]             "\x01k"+[key]+"qlpt"+[queue]
-// /Local/Max                                        "\x02"
+//   Key format                                        Key value
+//   /Local/...                                        "\x01"+...
+//      /Store/...                                     "\x01s"+...
+//      /RangeID/...                                   "\x01s"+[rangeid]
+//        /[rangeid]/AbortSpan/[id]                    "\x01s"+[rangeid]+"abc-"+[id]
+//        /[rangeid]/Lease                             "\x01s"+[rangeid]+"rfll"
+//        /[rangeid]/RaftTombstone                     "\x01s"+[rangeid]+"rftb"
+//        /[rangeid]/RaftHardState                     "\x01s"+[rangeid]+"rfth"
+//        /[rangeid]/RaftAppliedIndex                  "\x01s"+[rangeid]+"rfta"
+//        /[rangeid]/RaftLog/logIndex:[logIndex]       "\x01s"+[rangeid]+"rftl"+[logIndex]
+//        /[rangeid]/RaftTruncatedState                "\x01s"+[rangeid]+"rftt"
+//        /[rangeid]/RaftLastIndex                     "\x01s"+[rangeid]+"rfti"
+//        /[rangeid]/RangeLastReplicaGCTimestamp       "\x01s"+[rangeid]+"rlrt"
+//        /[rangeid]/RangeLastVerificationTimestamp    "\x01s"+[rangeid]+"rlvt"
+//        /[rangeid]/RangeStats                        "\x01s"+[rangeid]+"stat"
+//      /Range/...                                     "\x01k"+...
+//        [key]/RangeDescriptor                        "\x01k"+[key]+"rdsc"
+//        [key]/Transaction/[id]                       "\x01k"+[key]+"txn-"+[txn-id]
+//        [key]/QueueLastProcessed/[queue]             "\x01k"+[key]+"qlpt"+[queue]
+//   /Local/Max                                        "\x02"
 //
-// /Meta1/[key]                                      "\x02"+[key]
-// /Meta2/[key]                                      "\x03"+[key]
-// /System/...                                       "\x04"
-//		/NodeLiveness/[key]                            "\x04\0x00liveness-"+[key]
-//		/StatusNode/[key]                              "\x04status-node-"+[key]
-// /System/Max                                       "\x05"
+//   /Meta1/[key]                                      "\x02"+[key]
+//   /Meta2/[key]                                      "\x03"+[key]
+//   /System/...                                       "\x04"
+//      /NodeLiveness/[key]                            "\x04\0x00liveness-"+[key]
+//      /StatusNode/[key]                              "\x04status-node-"+[key]
+//   /System/Max                                       "\x05"
 //
-// /Table/[key]                                      [key]
+//   /Table/[key]                                      [key]
 //
-// /Min                                              ""
-// /Max                                              "\xff\xff"
+//   /Min                                              ""
+//   /Max                                              "\xff\xff"
 //
 // valDirs correspond to the encoding direction of each encoded value in key.
 // For example, table keys could have column values encoded in ascending or

--- a/pkg/roachpb/data.go
+++ b/pkg/roachpb/data.go
@@ -71,12 +71,15 @@ var (
 
 // RKey denotes a Key whose local addressing has been accounted for.
 // A key can be transformed to an RKey by keys.Addr().
+//
+// RKey stands for "resolved key," as in a key whose address has been resolved.
 type RKey Key
 
 // AsRawKey returns the RKey as a Key. This is to be used only in select
 // situations in which an RKey is known to not contain a wrapped locally-
-// addressed Key. Whenever the Key which created the RKey is still available,
-// it should be used instead.
+// addressed Key. That is, it must only be used when the original Key was not a
+// local key. Whenever the Key which created the RKey is still available, it
+// should be used instead.
 func (rk RKey) AsRawKey() Key {
 	return Key(rk)
 }


### PR DESCRIPTION
Add some high-level documentation that explains our keyspace to package
keys's godoc. Also explain what roachpb.RKey probably stands for.

Release note: None