### PR TITLE
workload/querybench: add 2.1-sql-20 query library

### DIFF
--- a/pkg/workload/querybench/2.1-sql-20
+++ b/pkg/workload/querybench/2.1-sql-20
@@ -1,0 +1,54 @@
+-- 2.1-sql-20 is a library of significant queries for benchmarking SQL execution
+-- during the 2.1 release cycle. These are intended to be run against the TPC-H
+-- dataset.
+--
+-- To load the data:
+--   > CREATE DATABASE tpch;
+--   > RESTORE workload.* FROM 'gs://cockroach-fixtures/workload/tpch/scalefactor=1/backup' WITH into_db = 'tpch';
+--
+-- To run the queries using the querybench workload:
+--   $ workload run querybench --concurrency 1 --max-ops 20 --db tpch --query-file 2.1-sql-20
+--
+-- Table sizes:
+--   supplier:    10,000 rows
+--   customer:   150,000 rows
+--   lineitem: 6,001,215 rows
+
+-- COUNT(*)
+SELECT COUNT(*) FROM lineitem
+
+-- COUNT(*) with filter on non-indexed column
+SELECT COUNT(*) FROM lineitem WHERE l_linenumber = 1
+
+-- SELECT *
+SELECT * FROM customer
+
+-- SELECT * ordered on non-indexed, non-sorted column
+SELECT * FROM customer ORDER BY c_address
+
+-- GROUP BY with COUNT
+SELECT l_linenumber, COUNT(*) FROM lineitem GROUP BY 1 ORDER BY 1
+
+-- GROUP BY with MAX
+SELECT l_linenumber, MAX(l_quantity) FROM lineitem GROUP BY 1 ORDER BY 1
+
+-- GROUP BY with SUM
+SELECT l_linenumber, SUM(l_quantity) FROM lineitem GROUP BY 1 ORDER BY 1
+
+-- DISTINCT
+SELECT COUNT(DISTINCT l_suppkey) FROM lineitem
+
+-- Hash join
+SELECT COUNT(*) FROM lineitem JOIN supplier ON l_suppkey = s_suppkey
+
+-- Merge join
+SELECT COUNT(*) FROM lineitem@l_sk JOIN supplier@s_sk ON l_suppkey = s_suppkey
+
+-- Index join
+SELECT COUNT(c_name) FROM customer@c_ck
+
+-- Filter with expression evaluation
+SELECT COUNT(*) FROM lineitem WHERE l_discount * l_extendedprice > 10000
+
+-- Hash join with expression evaluation
+SELECT COUNT(*) FROM supplier s1 JOIN supplier s2 ON s1.s_suppkey + 1 = s2.s_suppkey

--- a/pkg/workload/querybench/query_bench.go
+++ b/pkg/workload/querybench/query_bench.go
@@ -133,7 +133,7 @@ func (g *queryBench) Ops(
 }
 
 // getQueries returns the lines of a file as a string slice. Ignores lines
-// beginning with '#'.
+// beginning with '#' or '--'.
 func getQueries(path string) ([]string, error) {
 	file, err := os.Open(path)
 	if err != nil {
@@ -145,7 +145,7 @@ func getQueries(path string) ([]string, error) {
 	var lines []string
 	for scanner.Scan() {
 		line := scanner.Text()
-		if len(line) > 0 && line[0] != '#' {
+		if len(line) > 0 && line[0] != '#' && !strings.HasPrefix(line, "--") {
 			lines = append(lines, line)
 		}
 	}


### PR DESCRIPTION
First stab at a library of queries for benchmarking SQL execution. It
runs against the TPC-H dataset and can be run via the querybench
workload.

Refers #25011

Release note: None