### PR TITLE
sql: support semi and anti join in joinNode

### DIFF
--- a/pkg/sql/distsqlrun/processors.pb.go
+++ b/pkg/sql/distsqlrun/processors.pb.go
@@ -488,6 +488,9 @@ func (*DistinctSpec) Descriptor() ([]byte, []int) { return fileDescriptorProcess
 // input has N columns and the right input has M columns, the first N columns
 // contain values from the left side and the following M columns contain values
 // from the right side.
+//
+// In the case of semi-join and anti-join, the processor core outputs only the
+// left columns.
 type MergeJoinerSpec struct {
 	// The streams must be ordered according to the columns that have equality
 	// constraints. The first column of the left ordering is constrained to be
@@ -537,6 +540,9 @@ func (*MergeJoinerSpec) Descriptor() ([]byte, []int) { return fileDescriptorProc
 // contain values from the right side. If merged columns are present, they
 // occupy first E positions followed by N values from the left side and M values
 // from the right side.
+//
+// In the case of semi-join and anti-join, the processor core outputs only the
+// left columns.
 type HashJoinerSpec struct {
 	// The join constraints certain columns from the left stream to equal
 	// corresponding columns on the right stream. These must have the same length.

--- a/pkg/sql/distsqlrun/processors.proto
+++ b/pkg/sql/distsqlrun/processors.proto
@@ -286,6 +286,9 @@ message DistinctSpec {
 // input has N columns and the right input has M columns, the first N columns
 // contain values from the left side and the following M columns contain values
 // from the right side.
+//
+// In the case of semi-join and anti-join, the processor core outputs only the
+// left columns.
 message MergeJoinerSpec {
   // The streams must be ordered according to the columns that have equality
   // constraints. The first column of the left ordering is constrained to be
@@ -333,6 +336,9 @@ message MergeJoinerSpec {
 // contain values from the right side. If merged columns are present, they
 // occupy first E positions followed by N values from the left side and M values
 // from the right side.
+//
+// In the case of semi-join and anti-join, the processor core outputs only the
+// left columns.
 message HashJoinerSpec {
   // The join constraints certain columns from the left stream to equal
   // corresponding columns on the right stream. These must have the same length.

--- a/pkg/sql/join.go
+++ b/pkg/sql/join.go
@@ -378,6 +378,7 @@ type joinRun struct {
 
 	// emptyRight contain tuples of NULL values to use on the right for left and
 	// full outer joins when the on condition fails.
+	// This is also used for semi and anti joins, in which case it is always nil.
 	emptyRight tree.Datums
 
 	// emptyLeft contains tuples of NULL values to use on the left for right and
@@ -458,7 +459,9 @@ func (n *joinNode) Next(params runParams) (res bool, err error) {
 		return false, nil
 	}
 
-	wantUnmatchedLeft := n.joinType == sqlbase.LeftOuterJoin || n.joinType == sqlbase.FullOuterJoin
+	wantUnmatchedLeft := n.joinType == sqlbase.LeftOuterJoin ||
+		n.joinType == sqlbase.FullOuterJoin ||
+		n.joinType == sqlbase.LeftAntiJoin
 	wantUnmatchedRight := n.joinType == sqlbase.RightOuterJoin || n.joinType == sqlbase.FullOuterJoin
 
 	if len(n.run.buckets.Buckets()) == 0 {
@@ -489,9 +492,9 @@ func (n *joinNode) Next(params runParams) (res bool, err error) {
 			return false, err
 		}
 
-		// We make the explicit check for whether or not lrow contained a NULL
-		// tuple. The reasoning here is because of the way we expect NULL
-		// equality checks to behave (i.e. NULL != NULL) and the fact that we
+		// We make the explicit check for whether or not lrow contained a NULL value
+		// on an equality column. The reasoning here is because of the way we expect
+		// NULL equality checks to behave (i.e. NULL != NULL) and the fact that we
 		// use the encoding of any given row as key into our bucket. Thus if we
 		// encountered a NULL row when building the hashmap we have to store in
 		// order to use it for RIGHT OUTER joins but if we encounter another
@@ -568,7 +571,7 @@ func (n *joinNode) Next(params runParams) (res bool, err error) {
 		// on condition, if the on condition passes we add it to the buffer.
 		foundMatch := false
 		for idx, rrow := range b.Rows() {
-			passesOnCond, err := n.pred.eval(params.EvalContext(), n.run.output, lrow, rrow)
+			passesOnCond, err := n.pred.eval(params.EvalContext(), lrow, rrow)
 			if err != nil {
 				return false, err
 			}
@@ -577,8 +580,18 @@ func (n *joinNode) Next(params runParams) (res bool, err error) {
 				continue
 			}
 			foundMatch = true
+			if n.joinType == sqlbase.JoinType_LEFT_ANTI {
+				// For anti-join, we want to output the left rows that don't have a
+				// match. Since we found a match, we can skip this row.
+				break
+			}
 
-			n.pred.prepareRow(n.run.output, lrow, rrow)
+			if n.joinType == sqlbase.JoinType_LEFT_SEMI {
+				// Semi-joins only output the left row.
+				n.pred.prepareRow(n.run.output, lrow, nil)
+			} else {
+				n.pred.prepareRow(n.run.output, lrow, rrow)
+			}
 			if wantUnmatchedRight {
 				// Mark the row as seen if we need to retrieve the rows
 				// without matches for right or full joins later.
@@ -587,11 +600,16 @@ func (n *joinNode) Next(params runParams) (res bool, err error) {
 			if _, err := n.run.buffer.AddRow(params.ctx, n.run.output); err != nil {
 				return false, err
 			}
+			if n.joinType == sqlbase.JoinType_LEFT_SEMI {
+				// For semi-joins, we only output the left row once, even if it matches
+				// multiple rows.
+				break
+			}
 		}
 		if !foundMatch && wantUnmatchedLeft {
 			// If none of the rows matched the on condition and we are computing a
-			// left or full outer join, we need to add a row with an empty
-			// right side.
+			// left outer, full outer, or anti join, we need to add a row with an
+			// empty right side.
 			n.pred.prepareRow(n.run.output, lrow, n.run.emptyRight)
 			if _, err := n.run.buffer.AddRow(params.ctx, n.run.output); err != nil {
 				return false, err

--- a/pkg/sql/join_predicate.go
+++ b/pkg/sql/join_predicate.go
@@ -51,11 +51,14 @@ type joinPredicate struct {
 	// we need an IndexedVarHelper, the DataSourceInfo, a row buffer
 	// and the expression itself.
 	iVarHelper tree.IndexedVarHelper
-	info       *sqlbase.DataSourceInfo
 	curRow     tree.Datums
 	// The ON condition that needs to be evaluated (in addition to the
 	// equality columns).
 	onCond tree.TypedExpr
+
+	leftInfo  *sqlbase.DataSourceInfo
+	rightInfo *sqlbase.DataSourceInfo
+	info      *sqlbase.DataSourceInfo
 
 	// This struct must be allocated on the heap and its location stay
 	// stable after construction because it implements
@@ -131,13 +134,19 @@ func (p *joinPredicate) tryAddEqualityFilter(
 func makePredicate(
 	joinType sqlbase.JoinType, left, right *sqlbase.DataSourceInfo, usingColumns []usingColumn,
 ) (*joinPredicate, error) {
+	// For anti and semi joins, the right columns are omitted from the output (but
+	// they must be available internally for the ON condition evaluation).
+	omitRightColumns := joinType == sqlbase.JoinType_LEFT_SEMI || joinType == sqlbase.JoinType_LEFT_ANTI
+
 	// Prepare the metadata for the result columns.
 	// The structure of the join data source results is like this:
 	// - all the left columns,
-	// - then all the right columns,
+	// - then all the right columns (except for anti/semi join).
 	columns := make(sqlbase.ResultColumns, 0, len(left.SourceColumns)+len(right.SourceColumns))
 	columns = append(columns, left.SourceColumns...)
-	columns = append(columns, right.SourceColumns...)
+	if !omitRightColumns {
+		columns = append(columns, right.SourceColumns...)
+	}
 
 	// Compute the mappings from table aliases to column sets from
 	// both sides into a new alias-columnset mapping for the result
@@ -158,7 +167,9 @@ func makePredicate(
 		}
 	}
 	collectAliases(left.SourceAliases, 0)
-	collectAliases(right.SourceAliases, len(left.SourceColumns))
+	if !omitRightColumns {
+		collectAliases(right.SourceAliases, len(left.SourceColumns))
+	}
 	if !anonymousCols.Empty() {
 		aliases = append(aliases, sqlbase.SourceAlias{
 			Name:      sqlbase.AnonymousTable,
@@ -170,6 +181,8 @@ func makePredicate(
 		joinType:     joinType,
 		numLeftCols:  len(left.SourceColumns),
 		numRightCols: len(right.SourceColumns),
+		leftInfo:     left,
+		rightInfo:    right,
 		info: &sqlbase.DataSourceInfo{
 			SourceColumns: columns,
 			SourceAliases: aliases,
@@ -178,7 +191,8 @@ func makePredicate(
 	// We must initialize the indexed var helper in all cases, even when
 	// there is no on condition, so that getNeededColumns() does not get
 	// confused.
-	pred.iVarHelper = tree.MakeIndexedVarHelper(pred, len(columns))
+	pred.curRow = make(tree.Datums, len(left.SourceColumns)+len(right.SourceColumns))
+	pred.iVarHelper = tree.MakeIndexedVarHelper(pred, len(pred.curRow))
 
 	// Prepare the arrays populated below.
 	pred.leftEqualityIndices = make([]int, 0, len(usingColumns))
@@ -229,12 +243,18 @@ func (p *joinPredicate) IndexedVarEval(idx int, ctx *tree.EvalContext) (tree.Dat
 
 // IndexedVarResolvedType implements the tree.IndexedVarContainer interface.
 func (p *joinPredicate) IndexedVarResolvedType(idx int) types.T {
-	return p.info.SourceColumns[idx].Typ
+	if idx < p.numLeftCols {
+		return p.leftInfo.SourceColumns[idx].Typ
+	}
+	return p.rightInfo.SourceColumns[idx-p.numLeftCols].Typ
 }
 
 // IndexedVarNodeFormatter implements the tree.IndexedVarContainer interface.
 func (p *joinPredicate) IndexedVarNodeFormatter(idx int) tree.NodeFormatter {
-	return p.info.NodeFormatter(idx)
+	if idx < p.numLeftCols {
+		return p.leftInfo.NodeFormatter(idx)
+	}
+	return p.rightInfo.NodeFormatter(idx - p.numLeftCols)
 }
 
 // eval for joinPredicate runs the on condition across the columns that do
@@ -242,11 +262,8 @@ func (p *joinPredicate) IndexedVarNodeFormatter(idx int) tree.NodeFormatter {
 // in the join algorithm already).
 // Returns true if there is no on condition or the on condition accepts the
 // row.
-func (p *joinPredicate) eval(
-	ctx *tree.EvalContext, result, leftRow, rightRow tree.Datums,
-) (bool, error) {
+func (p *joinPredicate) eval(ctx *tree.EvalContext, leftRow, rightRow tree.Datums) (bool, error) {
 	if p.onCond != nil {
-		p.curRow = result
 		copy(p.curRow[:len(leftRow)], leftRow)
 		copy(p.curRow[len(leftRow):], rightRow)
 		ctx.PushIVarContainer(p.iVarHelper.Container())

--- a/pkg/sql/join_test.go
+++ b/pkg/sql/join_test.go
@@ -17,10 +17,12 @@ package sql
 import (
 	"context"
 	"fmt"
+	"reflect"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
@@ -38,6 +40,10 @@ func newTestScanNode(kvDB *client.DB, tableName string) (*scanNode, error) {
 		return nil, err
 	}
 	scan.initOrdering(0 /* exactPrefix */, p.EvalContext())
+	scan.spans, err = spansFromConstraint(desc, &desc.PrimaryIndex, nil /* constraint */)
+	if err != nil {
+		return nil, err
+	}
 	return scan, nil
 }
 
@@ -118,5 +124,187 @@ func TestInterleavedNodes(t *testing.T) {
 			// Rerun the same subtests but flip the tables
 			tc.table1, tc.table2 = tc.table2, tc.table1
 		}
+	}
+}
+
+func TestSemiAntiJoin(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	ctx := context.TODO()
+	s, sqlDB, kvDB := serverutils.StartServer(t, base.TestServerArgs{})
+	defer s.Stopper().Stop(ctx)
+
+	sqlutils.CreateTestInterleavedHierarchy(t, sqlDB)
+	sqlutils.CreateTable(
+		t, sqlDB, "t1", "a INT PRIMARY KEY, b INT, c INT", 10,
+		sqlutils.ToRowFn(
+			sqlutils.RowIdxFn,
+			func(row int) tree.Datum {
+				return tree.NewDInt(tree.DInt(row * row))
+			},
+			func(row int) tree.Datum {
+				return tree.NewDInt(tree.DInt(row * row * row))
+			},
+		),
+	)
+	sqlutils.CreateTable(
+		t, sqlDB, "t2", "a INT PRIMARY KEY, b INT", 10,
+		sqlutils.ToRowFn(
+			func(row int) tree.Datum {
+				return tree.NewDInt(tree.DInt(row + 5))
+			},
+			func(row int) tree.Datum {
+				return tree.NewDInt(tree.DInt((row - 5) * (row - 5)))
+			},
+		),
+	)
+	testCases := []struct {
+		typ         sqlbase.JoinType
+		left, right string
+		using       tree.NameList
+		expected    []string
+	}{
+		{ // 0
+			typ:   sqlbase.JoinType_LEFT_SEMI,
+			left:  "t1",
+			right: "t2",
+			using: tree.NameList{"a"},
+			expected: []string{
+				"[6 36 216]",
+				"[7 49 343]",
+				"[8 64 512]",
+				"[9 81 729]",
+				"[10 100 1000]",
+			},
+		},
+		{ // 1
+			typ:   sqlbase.JoinType_LEFT_ANTI,
+			left:  "t1",
+			right: "t2",
+			using: tree.NameList{"a"},
+			expected: []string{
+				"[1 1 1]",
+				"[2 4 8]",
+				"[3 9 27]",
+				"[4 16 64]",
+				"[5 25 125]",
+			},
+		},
+		{ // 2
+			typ:   sqlbase.JoinType_LEFT_SEMI,
+			left:  "t1",
+			right: "t2",
+			using: tree.NameList{"b"},
+			expected: []string{
+				"[1 1 1]",
+				"[2 4 8]",
+				"[3 9 27]",
+				"[4 16 64]",
+				"[5 25 125]",
+			},
+		},
+		{ // 3
+			typ:   sqlbase.JoinType_LEFT_ANTI,
+			left:  "t1",
+			right: "t2",
+			using: tree.NameList{"b"},
+			expected: []string{
+				"[6 36 216]",
+				"[7 49 343]",
+				"[8 64 512]",
+				"[9 81 729]",
+				"[10 100 1000]",
+			},
+		},
+		{ // 4
+			typ:   sqlbase.JoinType_LEFT_SEMI,
+			left:  "t2",
+			right: "t1",
+			using: tree.NameList{"a"},
+			expected: []string{
+				"[6 16]",
+				"[7 9]",
+				"[8 4]",
+				"[9 1]",
+				"[10 0]",
+			},
+		},
+		{ // 5
+			typ:   sqlbase.JoinType_LEFT_ANTI,
+			left:  "t2",
+			right: "t1",
+			using: tree.NameList{"a"},
+			expected: []string{
+				"[11 1]",
+				"[12 4]",
+				"[13 9]",
+				"[14 16]",
+				"[15 25]",
+			},
+		},
+	}
+
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+			err := kvDB.Txn(ctx, func(ctx context.Context, txn *client.Txn) error {
+				left, err := newTestScanNode(kvDB, tc.left)
+				if err != nil {
+					return err
+				}
+				right, err := newTestScanNode(kvDB, tc.right)
+				if err != nil {
+					return err
+				}
+
+				p, cleanup := newInternalPlanner(
+					"", txn, "root", &MemoryMetrics{},
+					s.InternalExecutor().(*InternalExecutor).ExecCfg,
+				)
+				defer cleanup()
+				leftSrc := planDataSource{
+					plan: left,
+					info: &sqlbase.DataSourceInfo{SourceColumns: planColumns(left)},
+				}
+				rightSrc := planDataSource{
+					plan: right,
+					info: &sqlbase.DataSourceInfo{SourceColumns: planColumns(right)},
+				}
+				pred, _, err := p.makeJoinPredicate(
+					ctx, leftSrc.info, rightSrc.info, tc.typ,
+					&tree.UsingJoinCond{Cols: tc.using},
+				)
+				if err != nil {
+					return err
+				}
+				join := p.makeJoinNode(planDataSource{plan: left}, planDataSource{plan: right}, pred)
+				params := runParams{
+					ctx:             ctx,
+					extendedEvalCtx: p.ExtendedEvalContext(),
+					p:               p,
+				}
+				defer join.Close(ctx)
+				if err := startPlan(params, join); err != nil {
+					return err
+				}
+				var res []string
+				for {
+					ok, err := join.Next(params)
+					if err != nil {
+						return err
+					}
+					if !ok {
+						break
+					}
+					res = append(res, fmt.Sprintf("%v", join.Values()))
+				}
+				if !reflect.DeepEqual(res, tc.expected) {
+					t.Errorf("expected:\n%v\n got:\n%v", tc.expected, res)
+				}
+				return nil
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+		})
 	}
 }

--- a/pkg/sql/opt/exec/execbuilder/builder_test.go
+++ b/pkg/sql/opt/exec/execbuilder/builder_test.go
@@ -38,7 +38,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/treeprinter"
 )
 
-// TestBuilder runs data-driven testcases of the form
+// TestExecBuild runs data-driven testcases of the form
 //
 //   <command> [<args]...
 //   <SQL statement>
@@ -73,7 +73,7 @@ import (
 //
 //    Prints information about a table, retrieved through the Catalog interface.
 //
-func TestBuild(t *testing.T) {
+func TestExecBuild(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	datadriven.Walk(t, "testdata", func(t *testing.T, path string) {

--- a/pkg/sql/opt/exec/execbuilder/testdata/join
+++ b/pkg/sql/opt/exec/execbuilder/testdata/join
@@ -216,3 +216,89 @@ x:int  y:int  x:int  z:int
 1      10     NULL   NULL
 2      20     2      200
 3      30     NULL   NULL
+
+# TODO(radu): we create another table because we have some name resolution bugs
+# when two tables have the same column name and we use both columns in the EXISTS
+# condition.
+exec-raw
+CREATE TABLE c (u INT PRIMARY KEY, v INT);
+INSERT INTO c VALUES (2, 200), (3, 300), (4, 400)
+----
+
+exec-explain
+SELECT * FROM a WHERE EXISTS(SELECT * FROM c WHERE x = u)
+----
+join       0  join  ·         ·          (x, y)  ·
+ │         0  ·     type      semi       ·       ·
+ │         0  ·     equality  (x) = (u)  ·       ·
+ ├── scan  1  scan  ·         ·          (x, y)  ·
+ │         1  ·     table     a@primary  ·       ·
+ │         1  ·     spans     ALL        ·       ·
+ └── scan  1  scan  ·         ·          (u, v)  ·
+·          1  ·     table     c@primary  ·       ·
+·          1  ·     spans     ALL        ·       ·
+
+exec
+SELECT * FROM a WHERE EXISTS(SELECT * FROM c WHERE x = u)
+----
+x:int  y:int
+2      20
+3      30
+
+exec-explain
+SELECT * FROM a WHERE EXISTS(SELECT * FROM c WHERE x-1 = u)
+----
+join       0  join  ·      ·            (x, y)  ·
+ │         0  ·     type   semi         ·       ·
+ │         0  ·     pred   u = (x - 1)  ·       ·
+ ├── scan  1  scan  ·      ·            (x, y)  ·
+ │         1  ·     table  a@primary    ·       ·
+ │         1  ·     spans  ALL          ·       ·
+ └── scan  1  scan  ·      ·            (u, v)  ·
+·          1  ·     table  c@primary    ·       ·
+·          1  ·     spans  ALL          ·       ·
+
+exec
+SELECT * FROM a WHERE EXISTS(SELECT * FROM c WHERE x-1 = u)
+----
+x:int  y:int
+3      30
+
+exec-explain
+SELECT * FROM a WHERE NOT EXISTS(SELECT * FROM c WHERE x = u)
+----
+join       0  join  ·         ·          (x, y)  ·
+ │         0  ·     type      anti       ·       ·
+ │         0  ·     equality  (x) = (u)  ·       ·
+ ├── scan  1  scan  ·         ·          (x, y)  ·
+ │         1  ·     table     a@primary  ·       ·
+ │         1  ·     spans     ALL        ·       ·
+ └── scan  1  scan  ·         ·          (u, v)  ·
+·          1  ·     table     c@primary  ·       ·
+·          1  ·     spans     ALL        ·       ·
+
+exec
+SELECT * FROM a WHERE NOT EXISTS(SELECT * FROM c WHERE x = u)
+----
+x:int  y:int
+1      10
+
+exec-explain
+SELECT * FROM a WHERE NOT EXISTS(SELECT * FROM c WHERE x-1 = u)
+----
+join       0  join  ·      ·            (x, y)  ·
+ │         0  ·     type   anti         ·       ·
+ │         0  ·     pred   u = (x - 1)  ·       ·
+ ├── scan  1  scan  ·      ·            (x, y)  ·
+ │         1  ·     table  a@primary    ·       ·
+ │         1  ·     spans  ALL          ·       ·
+ └── scan  1  scan  ·      ·            (u, v)  ·
+·          1  ·     table  c@primary    ·       ·
+·          1  ·     spans  ALL          ·       ·
+
+exec
+SELECT * FROM a WHERE NOT EXISTS(SELECT * FROM c WHERE x-1 = u)
+----
+x:int  y:int
+1      10
+2      20

--- a/pkg/sql/plan.go
+++ b/pkg/sql/plan.go
@@ -73,7 +73,7 @@ type planMaker interface {
 var _ planMaker = &planner{}
 
 // runParams is a struct containing all parameters passed to planNode.Next() and
-// planNode.Start().
+// startPlan.
 type runParams struct {
 	// context.Context for this method call.
 	ctx context.Context

--- a/pkg/sql/walk.go
+++ b/pkg/sql/walk.go
@@ -188,6 +188,10 @@ func (v *planVisitor) visit(plan planNode) {
 				jType = "right outer"
 			case sqlbase.FullOuterJoin:
 				jType = "full outer"
+			case sqlbase.LeftSemiJoin:
+				jType = "semi"
+			case sqlbase.LeftAntiJoin:
+				jType = "anti"
 			}
 			v.observer.attr(name, "type", jType)
 


### PR DESCRIPTION
The distsql processors support semi and anti join; however, the
optimizer doesn't yet play well with distsql; and when it will, it
initially won't generate distsql plans directly.

Adding support for semi and anti join in the joinNode. This will also
allow us to generate distsql plans for these joins from an
intermediary planNode tree.

Release note: None