### PR TITLE
workloadccl: Skip flaky TestSetup

### DIFF
--- a/pkg/ccl/workloadccl/workload_test.go
+++ b/pkg/ccl/workloadccl/workload_test.go
@@ -23,6 +23,7 @@ import (
 
 func TestSetup(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	t.Skip("#24655")
 
 	get := func(name string) workload.Meta {
 		meta, err := workload.Get(name)


### PR DESCRIPTION
Release note: None

Touches #24655. This has been failing almost every night for the last two weeks.