### PR TITLE
build, ui: make webpack dev server use HTTPS, proxy auth endpoint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1129,10 +1129,10 @@ $(UI_ROOT)/yarn.opt.installed:
 	touch $@
 
 .PHONY: ui-watch
-ui-watch: export TARGET ?= http://localhost:8080
+ui-watch: export TARGET ?= https://localhost:8080
 ui-watch: PORT := 3000
 ui-watch: $(UI_DLLS) $(UI_ROOT)/yarn.opt.installed
-	cd $(UI_ROOT) && $(WEBPACK_DASHBOARD) -- $(WEBPACK_DEV_SERVER) --config webpack.ccl.js --port $(PORT)
+	cd $(UI_ROOT) && $(WEBPACK_DASHBOARD) -- $(WEBPACK_DEV_SERVER) --config webpack.ccl.js --port $(PORT) --https
 
 .PHONY: ui-clean
 ui-clean: ## Remove build artifacts.

--- a/pkg/ui/webpack.app.js
+++ b/pkg/ui/webpack.app.js
@@ -128,7 +128,7 @@ module.exports = (distDir, ...additionalRoots) => ({
   devServer: {
     contentBase: path.join(__dirname, distDir),
     proxy: [{
-      context: ["/_admin", "/_status", "/ts"],
+      context: ["/_admin", "/_status", "/ts", "/_auth"],
       secure: false,
       target: process.env.TARGET,
     }],


### PR DESCRIPTION
If WDS isn't running HTTPS and proxying to an HTTPS URL on Cockroach, Cockroach sometimes tries to redirect the client to use HTTPS, creating a redirect loop.

Also, make `make watch` proxy requests to `_auth`, since we're now using that for login work.

Release note: None