### PR TITLE
backport-2.0: build: GH label changes

### DIFF
--- a/build/teamcity-post-failures.py
+++ b/build/teamcity-post-failures.py
@@ -110,7 +110,7 @@ The following tests appear to have failed:
 
 Please assign, take a look and update the issue accordingly.
 '''.format(build_id, ''.join(t[1] for t in failed_tests)),
-        'labels': ['test-failure', 'Robot'],
+        'labels': ['C-test-failure', 'O-robot'],
         'milestone': get_probable_milestone(),
     }
 

--- a/pkg/cmd/github-post/main.go
+++ b/pkg/cmd/github-post/main.go
@@ -46,7 +46,7 @@ const tagsEnv = "TAGS"
 const goFlagsEnv = "GOFLAGS"
 const cockroachPkgPrefix = "github.com/cockroachdb/cockroach/pkg/"
 
-var issueLabels = []string{"Robot", "test-failure"}
+var issueLabels = []string{"O-robot", "C-test-failure"}
 
 // Based on the following observed API response:
 //


### PR DESCRIPTION
Backport 1/1 commits from #25050.

/cc @cockroachdb/release

---

- Robot -> O-robot
- test-failure -> C-test-failure

@benesch do we need to backport this for it to work on other branches?

Release note: None
