### PR TITLE
server: require web login if an env var is set

### DIFF
--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -68,9 +68,8 @@ const (
 	TempDirPrefix = "cockroach-temp"
 	// TempDirsRecordFilename is the filename for the record file
 	// that keeps track of the paths of the temporary directories created.
-	TempDirsRecordFilename                = "temp-dirs-record.txt"
-	defaultEventLogEnabled                = true
-	defaultEnableWebSessionAuthentication = false
+	TempDirsRecordFilename = "temp-dirs-record.txt"
+	defaultEventLogEnabled = true
 
 	maximumMaxClockOffset = 5 * time.Second
 
@@ -376,6 +375,8 @@ func MakeConfig(ctx context.Context, st *cluster.Settings) Config {
 		panic(err)
 	}
 
+	requireWebLogin := envutil.EnvOrDefaultBool("COCKROACH_EXPERIMENTAL_REQUIRE_WEB_LOGIN", false)
+
 	cfg := Config{
 		Config:                         new(base.Config),
 		MaxOffset:                      MaxOffsetType(base.DefaultMaxClockOffset),
@@ -386,7 +387,7 @@ func MakeConfig(ctx context.Context, st *cluster.Settings) Config {
 		ScanInterval:                   defaultScanInterval,
 		ScanMaxIdleTime:                defaultScanMaxIdleTime,
 		EventLogEnabled:                defaultEventLogEnabled,
-		EnableWebSessionAuthentication: defaultEnableWebSessionAuthentication,
+		EnableWebSessionAuthentication: requireWebLogin,
 		Stores: base.StoreSpecList{
 			Specs: []base.StoreSpec{storeSpec},
 		},


### PR DESCRIPTION
This PR introduces the temporary environment variable `COCKROACH_EXPERIMENTAL_REQUIRE_WEB_LOGIN ` to enable testing login functionality before a fully functional login/logout UI is merged. Supersedes #24944, which hardcoded this.

Once we have a functional login/logout UI, we will probably hardcode this variable to true, so that login will always be required when the cluster is in secure mode.

Before this change:
- Admin server endpoints don't care whether there is a logged-in user or not, even in secure mode; they always run as the root user (#8767)
- There is no way to log in — the `/_auth/v1/login` endpoint 404s

After this change:
- secure mode
    - with env var `COCKROACH_EXPERIMENTAL_REQUIRE_WEB_LOGIN=true`:
        - Admin server endpoints require _some user_ to be logged in, although they still run queries (e.g. against `crdb_internal`) as the root user.
        - `/_auth/v1/login` is exposed, allowing clients such as the admin UI to log in.
    - else:
        - no auth (same as before)
- insecure mode
    - no auth (same as before)