### PR TITLE
sql: verify column uniqueness in FKs during ADD COLUMN

### DIFF
--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -607,6 +607,26 @@ func resolveFK(
 	} else {
 		target.PrimaryIndex.ReferencedBy = append(target.PrimaryIndex.ReferencedBy, backref)
 	}
+
+	// Multiple FKs from the same column would potentially result in ambiguous or
+	// unexpected behavior with conflicting CASCADE/RESTRICT/etc behaviors.
+	colsInFKs := make(map[sqlbase.ColumnID]struct{})
+	for _, idx := range tbl.Indexes {
+		if idx.ForeignKey.IsSet() {
+			numCols := len(idx.ColumnIDs)
+			if idx.ForeignKey.SharedPrefixLen > 0 {
+				numCols = int(idx.ForeignKey.SharedPrefixLen)
+			}
+			for i := 0; i < numCols; i++ {
+				if _, ok := colsInFKs[idx.ColumnIDs[i]]; ok {
+					return pgerror.NewErrorf(pgerror.CodeInvalidForeignKeyError,
+						"column %q cannot be used by multiple foreign key constraints", idx.ColumnNames[i])
+				}
+				colsInFKs[idx.ColumnIDs[i]] = struct{}{}
+			}
+		}
+	}
+
 	return nil
 }
 
@@ -1223,25 +1243,6 @@ func MakeTableDesc(
 			}
 		default:
 			return desc, errors.Errorf("unsupported table def: %T", def)
-		}
-	}
-
-	// Multiple FKs from the same column would potentially result in ambiguous or
-	// unexpected behavior with conflicting CASCADE/RESTRICT/etc behaviors.
-	colsInFKs := make(map[sqlbase.ColumnID]struct{})
-	for _, idx := range desc.Indexes {
-		if idx.ForeignKey.IsSet() {
-			numCols := len(idx.ColumnIDs)
-			if idx.ForeignKey.SharedPrefixLen > 0 {
-				numCols = int(idx.ForeignKey.SharedPrefixLen)
-			}
-			for i := 0; i < numCols; i++ {
-				if _, ok := colsInFKs[idx.ColumnIDs[i]]; ok {
-					return desc, fmt.Errorf(
-						"column %q cannot be used by multiple foreign key constraints", idx.ColumnNames[i])
-				}
-				colsInFKs[idx.ColumnIDs[i]] = struct{}{}
-			}
 		}
 	}
 

--- a/pkg/sql/logictest/testdata/logic_test/fk
+++ b/pkg/sql/logictest/testdata/logic_test/fk
@@ -1312,3 +1312,17 @@ CREATE TABLE no_default_table (
 # Clean up after the test.
 statement ok
 DROP TABLE a;
+
+subtest 24664
+
+statement ok
+CREATE TABLE t (a INT, b INT, UNIQUE INDEX (a), UNIQUE INDEX (a, b))
+
+statement ok
+ALTER TABLE t ADD FOREIGN KEY (a) REFERENCES t (a)
+
+statement error column "a" cannot be used by multiple foreign key constraints
+ALTER TABLE t ADD FOREIGN KEY (a, b) REFERENCES t (a, b)
+
+statement ok
+DROP TABLE t


### PR DESCRIPTION
Move a check to a place common to CREATE TABLE and ALTER TABLE.

Fixes #24664

Release note (bug fix): correctly verify columns can only by
referencing by a single foreign key. Existing tables with a column
that is used by multiple foreign key constraints should be manually
changed to have at most one foreign key per column.