### PR TITLE
roachtest: Add roachtest for clock jumps and monotonicity

### DIFF
--- a/pkg/cmd/roachtest/clock_jump_crash.go
+++ b/pkg/cmd/roachtest/clock_jump_crash.go
@@ -1,0 +1,125 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	_ "github.com/lib/pq"
+)
+
+func runClockJump(t *test, c *cluster, tc clockJumpTestCase) {
+	ctx := context.Background()
+
+	c.l.printf("Running %s\n", tc.name)
+
+	// Test with a single node so that the node does not crash due to MaxOffset
+	// violation when injecting offset
+	if c.nodes != 1 {
+		t.Fatalf("Expected num nodes to be 1, got: %d", c.nodes)
+	}
+
+	t.Status("deploying offset injector")
+	offsetInjector := newOffsetInjector(c)
+	offsetInjector.deploy(ctx)
+
+	t.Status("starting cockroach")
+	c.Put(ctx, cockroach, "./cockroach", c.All())
+	c.Start(ctx)
+
+	db := c.Conn(ctx, c.nodes)
+	defer db.Close()
+	if _, err := db.Exec(
+		fmt.Sprintf(
+			`SET CLUSTER SETTING server.clock.forward_jump_check_enabled= %v`,
+			tc.jumpCheckEnabled)); err != nil {
+		t.Fatal(err)
+	}
+
+	// Wait for Cockroach to process the above cluster setting
+	time.Sleep(10 * time.Second)
+
+	if !isAlive(db) {
+		t.Fatal("Node unexpectedly crashed")
+	}
+
+	t.Status("injecting offset")
+	defer offsetInjector.recover(ctx, c.nodes)
+	offsetInjector.offset(ctx, c.nodes, tc.offset)
+
+	t.Status("validating health")
+	aliveAfterOffset := isAlive(db)
+	if aliveAfterOffset != tc.aliveAfterOffset {
+		t.Fatalf("Expected node health %v, got %v", tc.aliveAfterOffset, aliveAfterOffset)
+	}
+}
+
+type clockJumpTestCase struct {
+	name             string
+	jumpCheckEnabled bool
+	offset           time.Duration
+	aliveAfterOffset bool
+}
+
+func registerClockJump(r *registry) {
+	const numNodes = 1
+
+	testCases := []clockJumpTestCase{
+		{
+			name:             "large_forward_jump_with_check",
+			offset:           500 * time.Millisecond,
+			jumpCheckEnabled: true,
+			aliveAfterOffset: false,
+		},
+		{
+			name:             "small_forward_jump_with_check",
+			offset:           200 * time.Millisecond,
+			jumpCheckEnabled: true,
+			aliveAfterOffset: true,
+		},
+		{
+			name:             "large_backward_jump_with_check",
+			offset:           -500 * time.Millisecond,
+			jumpCheckEnabled: true,
+			aliveAfterOffset: true,
+		},
+		{
+			name:             "large_forward_jump_without_check",
+			offset:           500 * time.Millisecond,
+			jumpCheckEnabled: false,
+			aliveAfterOffset: true,
+		},
+		{
+			name:             "large_backward_jump_without_check",
+			offset:           -500 * time.Millisecond,
+			jumpCheckEnabled: false,
+			aliveAfterOffset: true,
+		},
+	}
+
+	for i := range testCases {
+		tc := testCases[i]
+		r.Add(testSpec{
+			Name:  fmt.Sprintf("clockjump/nodes=%d/tc=%s", numNodes, tc.name),
+			Nodes: nodes(numNodes),
+			Run: func(ctx context.Context, t *test, c *cluster) {
+				runClockJump(t, c, tc)
+			},
+		})
+	}
+}

--- a/pkg/cmd/roachtest/clock_monotonic.go
+++ b/pkg/cmd/roachtest/clock_monotonic.go
@@ -1,0 +1,138 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	_ "github.com/lib/pq"
+)
+
+func runClockMonotonicity(t *test, c *cluster, tc clockMonotonicityTestCase) {
+	ctx := context.Background()
+
+	c.l.printf("Running %s\n", tc.name)
+
+	// Test with a single node so that the node does not crash due to MaxOffset
+	// violation when introducing offset
+	if c.nodes != 1 {
+		t.Fatalf("Expected num nodes to be 1, got: %d", c.nodes)
+	}
+
+	t.Status("deploying offset injector")
+	offsetInjector := newOffsetInjector(c)
+	offsetInjector.deploy(ctx)
+
+	t.Status("starting cockroach")
+	c.Put(ctx, cockroach, "./cockroach", c.All())
+	c.Start(ctx)
+
+	db := c.Conn(ctx, c.nodes)
+	defer db.Close()
+	if _, err := db.Exec(
+		fmt.Sprintf(`SET CLUSTER SETTING server.clock.persist_upper_bound_interval = '%v'`,
+			tc.persistWallTimeInterval)); err != nil {
+		t.Fatal(err)
+	}
+
+	// Wait for Cockroach to process the above cluster setting
+	time.Sleep(10 * time.Second)
+
+	if !isAlive(db) {
+		t.Fatal("Node unexpectedly crashed")
+	}
+
+	preRestartTime, err := dbUnixEpoch(db)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	defer offsetInjector.recover(ctx, c.nodes)
+
+	// Inject a clock offset after stopping a node
+	t.Status("stopping cockroach")
+	c.Stop(ctx, c.Node(c.nodes))
+	t.Status("injecting offset")
+	offsetInjector.offset(ctx, c.nodes, tc.offset)
+	t.Status("starting cockroach post offset")
+	c.Start(ctx, c.Node(c.nodes))
+
+	if !isAlive(db) {
+		t.Fatal("Node unexpectedly crashed")
+	}
+
+	postRestartTime, err := dbUnixEpoch(db)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Status("validating clock monotonicity")
+	c.l.printf("pre-restart time:  %f\n", preRestartTime)
+	c.l.printf("post-restart time: %f\n", postRestartTime)
+	difference := postRestartTime - preRestartTime
+	c.l.printf("time-difference: %v\n", time.Duration(difference*float64(time.Second)))
+
+	if tc.expectIncreasingWallTime {
+		if preRestartTime > postRestartTime {
+			t.Fatalf("Expected pre-restart time %f < post-restart time %f", preRestartTime, postRestartTime)
+		}
+	} else {
+		if preRestartTime < postRestartTime {
+			t.Fatalf("Expected pre-restart time %f > post-restart time %f", preRestartTime, postRestartTime)
+		}
+	}
+}
+
+type clockMonotonicityTestCase struct {
+	name                     string
+	persistWallTimeInterval  time.Duration
+	offset                   time.Duration
+	expectIncreasingWallTime bool
+}
+
+func registerClockMonotonicity(r *registry) {
+	const numNodes = 1
+
+	testCases := []clockMonotonicityTestCase{
+		{
+			// Without enabling the feature to persist wall time, wall time is
+			// currently non monotonic on backward clock jumps when a node is down.
+			name:                     "non_monotonic_without_persisting_walltm",
+			offset:                   -60 * time.Second,
+			persistWallTimeInterval:  0,
+			expectIncreasingWallTime: false,
+		},
+		{
+			name:                     "monotonic_with_persisting_walltm",
+			offset:                   -60 * time.Second,
+			persistWallTimeInterval:  500 * time.Millisecond,
+			expectIncreasingWallTime: true,
+		},
+	}
+
+	for i := range testCases {
+		tc := testCases[i]
+		r.Add(testSpec{
+			Name:  fmt.Sprintf("clockmonotonic/nodes=%d/tc=%s", numNodes, tc.name),
+			Nodes: nodes(numNodes),
+			Run: func(ctx context.Context, t *test, c *cluster) {
+				runClockMonotonicity(t, c, tc)
+			},
+		})
+	}
+}

--- a/pkg/cmd/roachtest/clock_util.go
+++ b/pkg/cmd/roachtest/clock_util.go
@@ -1,0 +1,94 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+
+package main
+
+import (
+	"context"
+	gosql "database/sql"
+	"fmt"
+	"time"
+)
+
+// isAlive returns whether the node queried by db is alive
+func isAlive(db *gosql.DB) bool {
+	_, err := db.Exec("SHOW DATABASES")
+	return err == nil
+}
+
+// dbUnixEpoch returns the current time in db
+func dbUnixEpoch(db *gosql.DB) (float64, error) {
+	var epoch float64
+	if err := db.QueryRow("SELECT NOW()::DECIMAL").Scan(&epoch); err != nil {
+		return 0, err
+	}
+	return epoch, nil
+}
+
+// offsetInjector is used to inject clock offsets in roachtests
+type offsetInjector struct {
+	c        *cluster
+	deployed bool
+}
+
+// deploy installs ntp and downloads / compiles bumptime used to create a clock offset
+func (oi *offsetInjector) deploy(ctx context.Context) {
+	oi.c.Install(ctx, oi.c.All(), "ntp")
+	oi.c.Run(ctx, oi.c.All(), "service ntp stop")
+	oi.c.Run(ctx, oi.c.All(), "curl -kO https://raw.githubusercontent.com/cockroachdb/jepsen/master/"+
+		"cockroachdb/resources/bumptime.c")
+	oi.c.Run(ctx, oi.c.All(), "gcc bumptime.c -o bumptime && rm bumptime.c")
+	oi.deployed = true
+}
+
+// offset injects a offset of s into the node with the given nodeID
+func (oi *offsetInjector) offset(ctx context.Context, nodeID int, s time.Duration) {
+	if !oi.deployed {
+		oi.c.t.Fatal("Offset injector must be deployed before injecting a clock offset")
+	}
+
+	oi.c.Run(
+		ctx,
+		oi.c.Node(nodeID),
+		fmt.Sprintf("./bumptime %f", float64(s)/float64(time.Millisecond)),
+	)
+}
+
+// recover force syncs time on the node with the given nodeID to recover
+// from any offsets
+func (oi *offsetInjector) recover(ctx context.Context, nodeID int) {
+	if !oi.deployed {
+		oi.c.t.Fatal("Offset injector must be deployed before recovering from clock offsets")
+	}
+
+	syncCmds := []string{
+		"service ntp stop",
+		"ntpdate -u time.google.com",
+		"service ntp start",
+	}
+	for _, cmd := range syncCmds {
+		oi.c.Run(
+			ctx,
+			oi.c.Node(nodeID),
+			cmd,
+		)
+	}
+}
+
+// newOffsetInjector creates a offsetInjector which can be used to inject
+// and recover from clock offsets
+func newOffsetInjector(c *cluster) *offsetInjector {
+	return &offsetInjector{c: c}
+}

--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -649,6 +649,15 @@ func (c *cluster) Run(ctx context.Context, node nodeListOption, args ...string) 
 	}
 }
 
+// Install a package in a node
+func (c *cluster) Install(ctx context.Context, node nodeListOption, args ...string) {
+	err := execCmd(ctx, c.l,
+		append([]string{"roachprod", "install", c.makeNodes(node), "--"}, args...)...)
+	if err != nil {
+		c.t.Fatal(err)
+	}
+}
+
 // RunE runs a command on the specified node, returning an error.
 func (c *cluster) RunE(ctx context.Context, node nodeListOption, args ...string) error {
 	return c.RunL(ctx, c.l, node, args...)

--- a/pkg/cmd/roachtest/registry.go
+++ b/pkg/cmd/roachtest/registry.go
@@ -24,6 +24,8 @@ func registerTests(r *registry) {
 	registerBackup(r)
 	registerCancel(r)
 	registerCopy(r)
+	registerClockJump(r)
+	registerClockMonotonicity(r)
 	registerDecommission(r)
 	registerDrop(r)
 	registerImportTPCC(r)


### PR DESCRIPTION
Add roachprod tests for validating the behavior of the cluster settings
`server.clock.forward_jump_check_enabled` and
`server.clock.persist_upper_bound_interval`.

With `server.clock.forward_jump_check_enabled` set a node should crash on
forward clock jumps.

With `server.clock.persist_upper_bound_interval` set a node should guarantee
monotonic wall time even in the case of a backward clock jump when the node is
down.

Closes #24820

Release note: None