### PR TITLE
.github: add admin-ui-prs as owner for pkg/server

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -13,7 +13,7 @@
 /pkg/kv/                     @cockroachdb/core-prs
 /pkg/roachpb/                @cockroachdb/core-prs
 /pkg/rpc/                    @cockroachdb/core-prs
-/pkg/server/                 @cockroachdb/core-prs
+/pkg/server/                 @cockroachdb/core-prs @cockroachdb/admin-ui-prs
 /pkg/storage/                @cockroachdb/core-prs
 /pkg/migration/              @cockroachdb/core-prs
 /pkg/sqlmigrations           @cockroachdb/core-prs @cockroachdb/sql-wiring-prs


### PR DESCRIPTION
Adds the @cockroachdb/admin-ui-prs team to CODEOWNERS for the server package.