### PR TITLE
storage: remove rg1 helper

### DIFF
--- a/pkg/storage/addressing_test.go
+++ b/pkg/storage/addressing_test.go
@@ -143,7 +143,7 @@ func TestUpdateRangeAddressing(t *testing.T) {
 		// intents, otherwise the MVCCScan that the test does below fails.
 		tcsf := kv.NewTxnCoordSenderFactory(
 			log.AmbientContext{Tracer: st.Tracer}, st,
-			store.testSender(), store.cfg.Clock,
+			store.TestSender(), store.cfg.Clock,
 			false, stopper, kv.MakeTxnMetrics(time.Second),
 		)
 		db := client.NewDB(tcsf, store.cfg.Clock)

--- a/pkg/storage/client_merge_test.go
+++ b/pkg/storage/client_merge_test.go
@@ -48,7 +48,7 @@ func createSplitRanges(
 	store *storage.Store,
 ) (*roachpb.RangeDescriptor, *roachpb.RangeDescriptor, *roachpb.Error) {
 	args := adminSplitArgs(roachpb.Key("b"))
-	if _, err := client.SendWrapped(context.Background(), rg1(store), args); err != nil {
+	if _, err := client.SendWrapped(context.Background(), store.TestSender(), args); err != nil {
 		return nil, nil, err
 	}
 
@@ -77,7 +77,7 @@ func TestStoreRangeMergeTwoEmptyRanges(t *testing.T) {
 
 	// Merge the b range back into the a range.
 	args := adminMergeArgs(roachpb.KeyMin)
-	_, err := client.SendWrapped(context.Background(), rg1(store), args)
+	_, err := client.SendWrapped(context.Background(), store.TestSender(), args)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -110,7 +110,7 @@ func TestStoreRangeMergeMetadataCleanup(t *testing.T) {
 
 	// Write some values left of the proposed split key.
 	pArgs := putArgs([]byte("aaa"), content)
-	if _, err := client.SendWrapped(context.Background(), rg1(store), pArgs); err != nil {
+	if _, err := client.SendWrapped(context.Background(), store.TestSender(), pArgs); err != nil {
 		t.Fatal(err)
 	}
 
@@ -129,7 +129,7 @@ func TestStoreRangeMergeMetadataCleanup(t *testing.T) {
 
 	// Write some values right of the split key.
 	pArgs = putArgs([]byte("ccc"), content)
-	if _, err := client.SendWrappedWith(context.Background(), rg1(store), roachpb.Header{
+	if _, err := client.SendWrappedWith(context.Background(), store.TestSender(), roachpb.Header{
 		RangeID: bDesc.RangeID,
 	}, pArgs); err != nil {
 		t.Fatal(err)
@@ -137,7 +137,7 @@ func TestStoreRangeMergeMetadataCleanup(t *testing.T) {
 
 	// Merge the b range back into the a range.
 	args := adminMergeArgs(roachpb.KeyMin)
-	if _, err := client.SendWrapped(context.Background(), rg1(store), args); err != nil {
+	if _, err := client.SendWrapped(context.Background(), store.TestSender(), args); err != nil {
 		t.Fatal(err)
 	}
 
@@ -190,11 +190,11 @@ func TestStoreRangeMergeWithData(t *testing.T) {
 
 	// Write some values left and right of the proposed split key.
 	pArgs := putArgs([]byte("aaa"), content)
-	if _, err := client.SendWrapped(context.Background(), rg1(store), pArgs); err != nil {
+	if _, err := client.SendWrapped(context.Background(), store.TestSender(), pArgs); err != nil {
 		t.Fatal(err)
 	}
 	pArgs = putArgs([]byte("ccc"), content)
-	if _, err := client.SendWrappedWith(context.Background(), rg1(store), roachpb.Header{
+	if _, err := client.SendWrappedWith(context.Background(), store.TestSender(), roachpb.Header{
 		RangeID: bDesc.RangeID,
 	}, pArgs); err != nil {
 		t.Fatal(err)
@@ -202,7 +202,7 @@ func TestStoreRangeMergeWithData(t *testing.T) {
 
 	// Confirm the values are there.
 	gArgs := getArgs([]byte("aaa"))
-	if reply, err := client.SendWrapped(context.Background(), rg1(store), gArgs); err != nil {
+	if reply, err := client.SendWrapped(context.Background(), store.TestSender(), gArgs); err != nil {
 		t.Fatal(err)
 	} else if replyBytes, err := reply.(*roachpb.GetResponse).Value.GetBytes(); err != nil {
 		t.Fatal(err)
@@ -210,7 +210,7 @@ func TestStoreRangeMergeWithData(t *testing.T) {
 		t.Fatalf("actual value %q did not match expected value %q", replyBytes, content)
 	}
 	gArgs = getArgs([]byte("ccc"))
-	if reply, err := client.SendWrappedWith(context.Background(), rg1(store), roachpb.Header{
+	if reply, err := client.SendWrappedWith(context.Background(), store.TestSender(), roachpb.Header{
 		RangeID: bDesc.RangeID,
 	}, gArgs); err != nil {
 		t.Fatal(err)
@@ -222,7 +222,7 @@ func TestStoreRangeMergeWithData(t *testing.T) {
 
 	// Merge the b range back into the a range.
 	args := adminMergeArgs(roachpb.KeyMin)
-	if _, err := client.SendWrapped(context.Background(), rg1(store), args); err != nil {
+	if _, err := client.SendWrapped(context.Background(), store.TestSender(), args); err != nil {
 		t.Fatal(err)
 	}
 
@@ -251,7 +251,7 @@ func TestStoreRangeMergeWithData(t *testing.T) {
 
 	// Try to get values from after the merge.
 	gArgs = getArgs([]byte("aaa"))
-	if reply, err := client.SendWrapped(context.Background(), rg1(store), gArgs); err != nil {
+	if reply, err := client.SendWrapped(context.Background(), store.TestSender(), gArgs); err != nil {
 		t.Fatal(err)
 	} else if replyBytes, err := reply.(*roachpb.GetResponse).Value.GetBytes(); err != nil {
 		t.Fatal(err)
@@ -259,7 +259,7 @@ func TestStoreRangeMergeWithData(t *testing.T) {
 		t.Fatalf("actual value %q did not match expected value %q", replyBytes, content)
 	}
 	gArgs = getArgs([]byte("ccc"))
-	if reply, err := client.SendWrappedWith(context.Background(), rg1(store), roachpb.Header{
+	if reply, err := client.SendWrappedWith(context.Background(), store.TestSender(), roachpb.Header{
 		RangeID: rangeB.RangeID,
 	}, gArgs); err != nil {
 		t.Fatal(err)
@@ -271,11 +271,11 @@ func TestStoreRangeMergeWithData(t *testing.T) {
 
 	// Put new values after the merge on both sides.
 	pArgs = putArgs([]byte("aaaa"), content)
-	if _, err := client.SendWrapped(context.Background(), rg1(store), pArgs); err != nil {
+	if _, err := client.SendWrapped(context.Background(), store.TestSender(), pArgs); err != nil {
 		t.Fatal(err)
 	}
 	pArgs = putArgs([]byte("cccc"), content)
-	if _, err := client.SendWrappedWith(context.Background(), rg1(store), roachpb.Header{
+	if _, err := client.SendWrappedWith(context.Background(), store.TestSender(), roachpb.Header{
 		RangeID: rangeB.RangeID,
 	}, pArgs); err != nil {
 		t.Fatal(err)
@@ -283,7 +283,7 @@ func TestStoreRangeMergeWithData(t *testing.T) {
 
 	// Try to get the newly placed values.
 	gArgs = getArgs([]byte("aaaa"))
-	if reply, err := client.SendWrapped(context.Background(), rg1(store), gArgs); err != nil {
+	if reply, err := client.SendWrapped(context.Background(), store.TestSender(), gArgs); err != nil {
 		t.Fatal(err)
 	} else if replyBytes, err := reply.(*roachpb.GetResponse).Value.GetBytes(); err != nil {
 		t.Fatal(err)
@@ -291,7 +291,7 @@ func TestStoreRangeMergeWithData(t *testing.T) {
 		t.Fatalf("actual value %q did not match expected value %q", replyBytes, content)
 	}
 	gArgs = getArgs([]byte("cccc"))
-	if reply, err := client.SendWrapped(context.Background(), rg1(store), gArgs); err != nil {
+	if reply, err := client.SendWrapped(context.Background(), store.TestSender(), gArgs); err != nil {
 		t.Fatal(err)
 	} else if replyBytes, err := reply.(*roachpb.GetResponse).Value.GetBytes(); err != nil {
 		t.Fatal(err)
@@ -312,7 +312,7 @@ func TestStoreRangeMergeLastRange(t *testing.T) {
 
 	// Merge last range.
 	args := adminMergeArgs(roachpb.KeyMin)
-	if _, pErr := client.SendWrapped(context.Background(), rg1(store), args); !testutils.IsPError(pErr, "cannot merge final range") {
+	if _, pErr := client.SendWrapped(context.Background(), store.TestSender(), args); !testutils.IsPError(pErr, "cannot merge final range") {
 		t.Fatalf("expected 'cannot merge final range' error; got %s", pErr)
 	}
 }
@@ -329,11 +329,11 @@ func TestStoreRangeMergeNonCollocated(t *testing.T) {
 
 	// Split into 3 ranges
 	argsSplit := adminSplitArgs(roachpb.Key("d"))
-	if _, pErr := client.SendWrapped(context.Background(), rg1(store), argsSplit); pErr != nil {
+	if _, pErr := client.SendWrapped(context.Background(), store.TestSender(), argsSplit); pErr != nil {
 		t.Fatalf("Can't split range %s", pErr)
 	}
 	argsSplit = adminSplitArgs(roachpb.Key("b"))
-	if _, pErr := client.SendWrapped(context.Background(), rg1(store), argsSplit); pErr != nil {
+	if _, pErr := client.SendWrapped(context.Background(), store.TestSender(), argsSplit); pErr != nil {
 		t.Fatalf("Can't split range %s", pErr)
 	}
 
@@ -414,7 +414,7 @@ func TestStoreRangeMergeStats(t *testing.T) {
 
 	// Merge the b range back into the a range.
 	args := adminMergeArgs(roachpb.KeyMin)
-	if _, err := client.SendWrapped(ctx, rg1(store), args); err != nil {
+	if _, err := client.SendWrapped(ctx, store.TestSender(), args); err != nil {
 		t.Fatal(err)
 	}
 	replMerged := store.LookupReplica(aDesc.StartKey, nil)
@@ -442,7 +442,7 @@ func BenchmarkStoreRangeMerge(b *testing.B) {
 
 	// Perform initial split of ranges.
 	sArgs := adminSplitArgs(roachpb.Key("b"))
-	if _, err := client.SendWrapped(context.Background(), rg1(store), sArgs); err != nil {
+	if _, err := client.SendWrapped(context.Background(), store.TestSender(), sArgs); err != nil {
 		b.Fatal(err)
 	}
 
@@ -459,13 +459,13 @@ func BenchmarkStoreRangeMerge(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		// Merge the ranges.
 		b.StartTimer()
-		if _, err := client.SendWrapped(context.Background(), rg1(store), mArgs); err != nil {
+		if _, err := client.SendWrapped(context.Background(), store.TestSender(), mArgs); err != nil {
 			b.Fatal(err)
 		}
 
 		// Split the range.
 		b.StopTimer()
-		if _, err := client.SendWrapped(context.Background(), rg1(store), sArgs); err != nil {
+		if _, err := client.SendWrapped(context.Background(), store.TestSender(), sArgs); err != nil {
 			b.Fatal(err)
 		}
 	}

--- a/pkg/storage/client_metrics_test.go
+++ b/pkg/storage/client_metrics_test.go
@@ -176,7 +176,7 @@ func TestStoreMetrics(t *testing.T) {
 
 	// Perform a split, which has special metrics handling.
 	splitArgs := adminSplitArgs(roachpb.Key("m"))
-	if _, err := client.SendWrapped(context.Background(), rg1(mtc.stores[0]), splitArgs); err != nil {
+	if _, err := client.SendWrapped(context.Background(), mtc.stores[0].TestSender(), splitArgs); err != nil {
 		t.Fatal(err)
 	}
 

--- a/pkg/storage/client_raft_log_queue_test.go
+++ b/pkg/storage/client_raft_log_queue_test.go
@@ -53,7 +53,7 @@ func TestRaftLogQueue(t *testing.T) {
 
 	// Write a single value to ensure we have a leader.
 	pArgs := putArgs([]byte("key"), []byte("value"))
-	if _, err := client.SendWrapped(context.Background(), rg1(mtc.stores[0]), pArgs); err != nil {
+	if _, err := client.SendWrapped(context.Background(), mtc.stores[0].TestSender(), pArgs); err != nil {
 		t.Fatal(err)
 	}
 
@@ -77,7 +77,7 @@ func TestRaftLogQueue(t *testing.T) {
 	value := bytes.Repeat([]byte("a"), 1000) // 1KB
 	for size := int64(0); size < 2*maxBytes; size += int64(len(value)) {
 		pArgs = putArgs([]byte(fmt.Sprintf("key-%d", size)), value)
-		if _, err := client.SendWrapped(context.Background(), rg1(mtc.stores[0]), pArgs); err != nil {
+		if _, err := client.SendWrapped(context.Background(), mtc.stores[0].TestSender(), pArgs); err != nil {
 			t.Fatal(err)
 		}
 	}

--- a/pkg/storage/client_test.go
+++ b/pkg/storage/client_test.go
@@ -67,19 +67,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 )
 
-// rg1 returns a wrapping sender that changes all requests to range 0 to
-// requests to range 1.
-// This function is DEPRECATED. Send your requests to the right range by
-// properly initializing the request header.
-func rg1(s *storage.Store) client.Sender {
-	return client.Wrap(s, func(ba roachpb.BatchRequest) roachpb.BatchRequest {
-		if ba.RangeID == 0 {
-			ba.RangeID = 1
-		}
-		return ba
-	})
-}
-
 // createTestStore creates a test store using an in-memory
 // engine.
 func createTestStore(t testing.TB, stopper *stop.Stopper) (*storage.Store, *hlc.ManualClock) {

--- a/pkg/storage/consistency_queue_test.go
+++ b/pkg/storage/consistency_queue_test.go
@@ -84,7 +84,7 @@ func TestCheckConsistencyMultiStore(t *testing.T) {
 
 	// Write something to the DB.
 	putArgs := putArgs([]byte("a"), []byte("b"))
-	if _, err := client.SendWrapped(context.Background(), rg1(mtc.stores[0]), putArgs); err != nil {
+	if _, err := client.SendWrapped(context.Background(), mtc.stores[0].TestSender(), putArgs); err != nil {
 		t.Fatal(err)
 	}
 
@@ -96,7 +96,7 @@ func TestCheckConsistencyMultiStore(t *testing.T) {
 			EndKey: []byte("aa"),
 		},
 	}
-	if _, err := client.SendWrappedWith(context.Background(), rg1(mtc.stores[0]), roachpb.Header{
+	if _, err := client.SendWrappedWith(context.Background(), mtc.stores[0].TestSender(), roachpb.Header{
 		Timestamp: mtc.stores[0].Clock().Now(),
 	}, &checkArgs); err != nil {
 		t.Fatal(err)
@@ -146,11 +146,11 @@ func TestCheckConsistencyInconsistent(t *testing.T) {
 
 	// Write something to the DB.
 	pArgs := putArgs([]byte("a"), []byte("b"))
-	if _, err := client.SendWrapped(context.Background(), rg1(mtc.stores[0]), pArgs); err != nil {
+	if _, err := client.SendWrapped(context.Background(), mtc.stores[0].TestSender(), pArgs); err != nil {
 		t.Fatal(err)
 	}
 	pArgs = putArgs([]byte("c"), []byte("d"))
-	if _, err := client.SendWrapped(context.Background(), rg1(mtc.stores[0]), pArgs); err != nil {
+	if _, err := client.SendWrapped(context.Background(), mtc.stores[0].TestSender(), pArgs); err != nil {
 		t.Fatal(err)
 	}
 
@@ -172,7 +172,7 @@ func TestCheckConsistencyInconsistent(t *testing.T) {
 			EndKey: []byte("z"),
 		},
 	}
-	if _, err := client.SendWrapped(context.Background(), rg1(mtc.stores[0]), &checkArgs); err != nil {
+	if _, err := client.SendWrapped(context.Background(), mtc.stores[0].TestSender(), &checkArgs); err != nil {
 		t.Fatal(err)
 	}
 	select {

--- a/pkg/storage/raft_log_queue_test.go
+++ b/pkg/storage/raft_log_queue_test.go
@@ -178,7 +178,7 @@ func TestGetTruncatableIndexes(t *testing.T) {
 	for i := 0; i < RaftLogQueueStaleThreshold+1; i++ {
 		key := roachpb.Key(fmt.Sprintf("key%02d", i))
 		args := putArgs(key, []byte(fmt.Sprintf("value%02d", i)))
-		if _, err := client.SendWrapped(context.Background(), store.testSender(), &args); err != nil {
+		if _, err := client.SendWrapped(context.Background(), store.TestSender(), &args); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -290,7 +290,7 @@ func TestProactiveRaftLogTruncate(t *testing.T) {
 			for i := 0; i < c.count; i++ {
 				key := roachpb.Key(fmt.Sprintf("key%02d", i))
 				args := putArgs(key, []byte(fmt.Sprintf("%s%02d", strings.Repeat("v", c.valueSize), i)))
-				if _, err := client.SendWrapped(ctx, store.testSender(), &args); err != nil {
+				if _, err := client.SendWrapped(ctx, store.TestSender(), &args); err != nil {
 					t.Fatal(err)
 				}
 			}

--- a/pkg/storage/replica_test.go
+++ b/pkg/storage/replica_test.go
@@ -7949,7 +7949,7 @@ func checkValue(ctx context.Context, tc *testContext, key []byte, expectedVal []
 	// Note: sending through the store, not directly through the replica, for
 	// intent resolution to kick in. Use max user priority to ensure we push
 	// any residual intent.
-	resp, pErr := client.SendWrappedWith(ctx, tc.store.testSender(), roachpb.Header{
+	resp, pErr := client.SendWrappedWith(ctx, tc.store.TestSender(), roachpb.Header{
 		UserPriority: roachpb.MaxUserPriority,
 	}, &gArgs)
 	if pErr != nil {


### PR DESCRIPTION
One other refactor I was considering was introducing a test-only `store.SendToRange(roachpb.RangeID, roachpb.Request)` method as more readable shorthand for `client.SendWrappedWith(store, roachpb.Header{RangeID: ...}, args)`. I found it super confusing when first reading these storage tests that some requests could use `client.SendWrapped` while others had to use `client.SendWrappedWith` with some header nonsense. 

Making everything consistent seemed like a useful first step, though.

---

For convenience, many of our storage tests generate requests with a zero
RangeID, relying on a test sender to rewrite RangeID=0 to RangeID=1. For
reasons I can't discern, external tests create this rewriting sender
using the "rg1" helper function, while internal tests use
Store.testSender.

Export Store.testSender so it can be used by both internal and external
tests. Because it's located in a test file, it is still not part of
Store's public interface.

Release note: None