### PR TITLE
roachtest: Another attempt at collecting systemd ntp logs

### DIFF
--- a/pkg/cmd/roachtest/jepsen.go
+++ b/pkg/cmd/roachtest/jepsen.go
@@ -214,6 +214,13 @@ cd /mnt/data1/jepsen/cockroachdb && set -eo pipefail && \
 
 			if failed {
 				failures = append(failures, testCfg)
+
+				// Collect partial systemd logs to diagnose #20492
+				logf("%s: ntp status:", testCfg)
+				c.Run(ctx, workers, "sudo service ntp status")
+				logf("%s: systemd log:", testCfg)
+				c.Run(ctx, workers, "sudo journalctl -x --no-pager --unit=ntp")
+
 				logf("%s: grabbing artifacts from controller. Tail of controller log:", testCfg)
 				c.Run(ctx, controller, "tail -n 100 /mnt/data1/jepsen/cockroachdb/invoke.log")
 				cmd = exec.CommandContext(ctx, "roachprod", "run", c.makeNodes(controller),


### PR DESCRIPTION
The previous attempt wasn't returning anything interesting because I
was running it on the controller instead of the workers. Also restrict
the logs to `--unit=ntp` to reduce verbosity.

Release note: None