### PR TITLE
debug: remove limit on logspy duration

### DIFF
--- a/pkg/server/debug/logspy.go
+++ b/pkg/server/debug/logspy.go
@@ -87,8 +87,8 @@ func (d durationAsString) String() string {
 }
 
 const (
-	logSpyDefaultDuration = durationAsString(10 * time.Second)
-	logSpyMaxDuration     = durationAsString(time.Minute)
+	logSpyDefaultDuration = durationAsString(5 * time.Second)
+	logSpyMaxCount        = 10000
 	logSpyDefaultCount    = 1000
 	logSpyChanCap         = 4096
 )
@@ -115,17 +115,16 @@ func logSpyOptionsFromValues(values url.Values) (logSpyOptions, error) {
 		return logSpyOptions{}, err
 	}
 	if opts.Duration == 0 {
-		if opts.Count > 0 {
-			opts.Duration = logSpyMaxDuration
-		} else {
-			opts.Duration = logSpyDefaultDuration
-		}
-	} else if opts.Duration > logSpyMaxDuration {
-		return logSpyOptions{}, errors.Errorf("duration %s is too large (limit is %s)", opts.Duration, logSpyMaxDuration)
+		opts.Duration = logSpyDefaultDuration
 	}
 
 	if opts.Count == 0 {
 		opts.Count = logSpyDefaultCount
+	} else if opts.Count > logSpyMaxCount {
+		return logSpyOptions{}, errors.Errorf(
+			"count %d is too large (limit is %d); consider restricting your filter",
+			opts.Count, logSpyMaxCount,
+		)
 	}
 	return opts, nil
 }

--- a/pkg/server/debug/logspy_test.go
+++ b/pkg/server/debug/logspy_test.go
@@ -64,22 +64,11 @@ func TestDebugLogSpyOptions(t *testing.T) {
 			},
 		},
 		{
-			// When a count is given but no duration, default the duration to the
-			// maximum allowed.
+			// Can't stream out too much at once.
 			vals: map[string][]string{
-				"Count": {"1"},
+				"Count": {strconv.Itoa(2 * logSpyMaxCount)},
 			},
-			expOpts: logSpyOptions{
-				Count:    1,
-				Duration: logSpyMaxDuration,
-			},
-		},
-		{
-			// Can't spy for too long.
-			vals: map[string][]string{
-				"Duration": {(2 * logSpyMaxDuration).String()},
-			},
-			expErr: regexp.QuoteMeta(`duration 2m0s is too large (limit is 1m0s)`),
+			expErr: (`count .* is too large .limit is .*.`),
 		},
 		// Various parse errors.
 		{


### PR DESCRIPTION
Note to self: backport this to release-2.0.

Fixes #24998.

Release note: None