### PR TITLE
sql: refactor the creation of sql MemMetrics

### DIFF
--- a/pkg/sql/pgwire/conn.go
+++ b/pkg/sql/pgwire/conn.go
@@ -1225,7 +1225,7 @@ func (c *conn) handleAuthentication(ctx context.Context, insecure bool) error {
 	// Check that the requested user exists and retrieve the hashed
 	// password in case password authentication is needed.
 	exists, hashedPassword, err := sql.GetUserHashedPassword(
-		ctx, c.execCfg, c.metrics.internalMemMetrics, c.sessionArgs.User,
+		ctx, c.execCfg, &c.metrics.SQLMemMetrics, c.sessionArgs.User,
 	)
 	if err != nil {
 		return sendError(err)

--- a/pkg/sql/pgwire/conn_test.go
+++ b/pkg/sql/pgwire/conn_test.go
@@ -317,7 +317,7 @@ func waitForClientConn(ln net.Listener) (*conn, error) {
 		return nil, err
 	}
 
-	metrics := makeServerMetrics(nil /* internalMemMetrics */, metric.TestSampleInterval)
+	metrics := makeServerMetrics(sql.MemoryMetrics{} /* sqlMemMetrics */, metric.TestSampleInterval)
 	pgwireConn := newConn(conn, sql.SessionArgs{}, &metrics, &sql.ExecutorConfig{})
 	return pgwireConn, nil
 }

--- a/pkg/sql/pgwire/server.go
+++ b/pkg/sql/pgwire/server.go
@@ -121,20 +121,17 @@ type ServerMetrics struct {
 	Conns          *metric.Gauge
 	ConnMemMetrics sql.MemoryMetrics
 	SQLMemMetrics  sql.MemoryMetrics
-
-	internalMemMetrics *sql.MemoryMetrics
 }
 
 func makeServerMetrics(
-	internalMemMetrics *sql.MemoryMetrics, histogramWindow time.Duration,
+	sqlMemMetrics sql.MemoryMetrics, histogramWindow time.Duration,
 ) ServerMetrics {
 	return ServerMetrics{
-		BytesInCount:       metric.NewCounter(MetaBytesIn),
-		BytesOutCount:      metric.NewCounter(MetaBytesOut),
-		Conns:              metric.NewGauge(MetaConns),
-		ConnMemMetrics:     sql.MakeMemMetrics("conns", histogramWindow),
-		SQLMemMetrics:      sql.MakeMemMetrics("client", histogramWindow),
-		internalMemMetrics: internalMemMetrics,
+		BytesInCount:   metric.NewCounter(MetaBytesIn),
+		BytesOutCount:  metric.NewCounter(MetaBytesOut),
+		Conns:          metric.NewGauge(MetaConns),
+		ConnMemMetrics: sql.MakeMemMetrics("conns", histogramWindow),
+		SQLMemMetrics:  sqlMemMetrics,
 	}
 }
 
@@ -156,7 +153,7 @@ func MakeServer(
 	cfg *base.Config,
 	st *cluster.Settings,
 	executor *sql.Executor,
-	internalMemMetrics *sql.MemoryMetrics,
+	sqlMemMetrics sql.MemoryMetrics,
 	parentMemoryMonitor *mon.BytesMonitor,
 	histogramWindow time.Duration,
 	executorConfig *sql.ExecutorConfig,
@@ -166,7 +163,7 @@ func MakeServer(
 		cfg:        cfg,
 		execCfg:    executorConfig,
 		executor:   executor,
-		metrics:    makeServerMetrics(internalMemMetrics, histogramWindow),
+		metrics:    makeServerMetrics(sqlMemMetrics, histogramWindow),
 	}
 	server.sqlMemoryPool = mon.MakeMonitor("sql",
 		mon.MemoryResource,

--- a/pkg/sql/pgwire/v3.go
+++ b/pkg/sql/pgwire/v3.go
@@ -268,7 +268,7 @@ func (c *v3Conn) handleAuthentication(ctx context.Context, insecure bool) error 
 	// Check that the requested user exists and retrieve the hashed
 	// password in case password authentication is needed.
 	exists, hashedPassword, err := sql.GetUserHashedPassword(
-		ctx, c.executor.Cfg(), c.metrics.internalMemMetrics, c.sessionArgs.User,
+		ctx, c.executor.Cfg(), &c.metrics.SQLMemMetrics, c.sessionArgs.User,
 	)
 	if err != nil {
 		return c.sendError(err)

--- a/pkg/sql/pgwire/v3_test.go
+++ b/pkg/sql/pgwire/v3_test.go
@@ -37,7 +37,7 @@ import (
 )
 
 func makeTestV3Conn(c net.Conn) v3Conn {
-	metrics := makeServerMetrics(nil, metric.TestSampleInterval)
+	metrics := makeServerMetrics(sql.MemoryMetrics{} /* sqlMemMetrics */, metric.TestSampleInterval)
 	st := cluster.MakeTestingClusterSettings()
 	mon := mon.MakeUnlimitedMonitor(
 		context.Background(), "test", mon.MemoryResource, nil, nil, 1000, st,


### PR DESCRIPTION
Lift the creation of the SQL mem metrics from pgwire.Server to
server.Server. This is in preparation of a next commit where those
metrics will be fed to the distsqlrun.Server too, to be used for
internal executors created by that fella - we want "internal queries"
run on behalf of distsql flows to contribute to the sql memory metrics.
Also this groups the creation of all these metrics - sql,internal,admin
to one place, which is nice.

This patch tangentially switches some sql session authentication code
from using the "internal" memtrics to using the "sql" ones. This sounds
better to me, and also simplifies the pgwire.Server's metrics.

Release note: None