### PR TITLE
backport-2.0: sql: verify column uniqueness in FKs during ADD COLUMN

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/fk
+++ b/pkg/sql/logictest/testdata/logic_test/fk
@@ -1315,3 +1315,17 @@ CREATE TABLE no_default_table (
 # Clean up after the test.
 statement ok
 DROP TABLE a;
+
+subtest 24664
+
+statement ok
+CREATE TABLE t (a INT, b INT, UNIQUE INDEX (a), UNIQUE INDEX (a, b))
+
+statement ok
+ALTER TABLE t ADD FOREIGN KEY (a) REFERENCES t (a)
+
+statement error column "a" cannot be used by multiple foreign key constraints
+ALTER TABLE t ADD FOREIGN KEY (a, b) REFERENCES t (a, b)
+
+statement ok
+DROP TABLE t


### PR DESCRIPTION
Backport 1/1 commits from #25060.

/cc @cockroachdb/release

---

Move a check to a place common to CREATE TABLE and ALTER TABLE.

Fixes #24664

Release note (bug fix): correctly verify columns can only by
referencing by a single foreign key. Existing tables with a column
that is used by multiple foreign key constraints should be manually
changed to have at most one foreign key per column.
