### PR TITLE
build, ui: introduce `make watch-secure`; unbreak `make watch` insecure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1134,11 +1134,15 @@ $(UI_ROOT)/yarn.opt.installed:
 	$(NODE_RUN) -C $(UI_ROOT)/opt yarn install
 	touch $@
 
+.PHONY: ui-watch-secure
+ui-watch-secure: override WEBPACK_DEV_SERVER_FLAGS += --https
+ui-watch-secure: export TARGET ?= https://localhost:8080/
+
 .PHONY: ui-watch
-ui-watch: export TARGET ?= https://localhost:8080
-ui-watch: PORT := 3000
-ui-watch: $(UI_DLLS) $(UI_ROOT)/yarn.opt.installed
-	cd $(UI_ROOT) && $(WEBPACK_DASHBOARD) -- $(WEBPACK_DEV_SERVER) --config webpack.ccl.js --port $(PORT) --https
+ui-watch: export TARGET ?= http://localhost:8080
+ui-watch ui-watch-secure: PORT := 3000
+ui-watch ui-watch-secure: $(UI_DLLS) $(UI_ROOT)/yarn.opt.installed
+	cd $(UI_ROOT) && $(WEBPACK_DASHBOARD) -- $(WEBPACK_DEV_SERVER) --config webpack.ccl.js --port $(PORT) $(WEBPACK_DEV_SERVER_FLAGS)
 
 .PHONY: ui-clean
 ui-clean: ## Remove build artifacts.

--- a/pkg/ui/README.md
+++ b/pkg/ui/README.md
@@ -47,6 +47,14 @@ $ make watch TARGET=<target-cluster-http-uri>
 
 then navigate to `http://localhost:3000` to access the UI.
 
+To proxy to a cluster started up in secure mode, use:
+
+```shell
+$ make watch-secure TARGET=<target-cluster-https-uri>
+```
+
+then navigate to `https://localhost:3000` to access the UI.
+
 While the proxy is running, any changes you make in the `src` directory will
 trigger an automatic recompilation of the UI. This recompilation should be much
 faster than a cold compile—usually less than one second—as Webpack can reuse


### PR DESCRIPTION
With this change, you can use `make watch` for an insecure cluster and `make watch-secure` for a secure cluster when cd'd into `pkg/ui`.

Follow up to #25052

Release note: None