### PR TITLE
release-2.0: ui: identify cluster to segment on load

### DIFF
--- a/pkg/ui/src/redux/analytics.ts
+++ b/pkg/ui/src/redux/analytics.ts
@@ -238,9 +238,10 @@ history.listen((location) => {
   }
   lastPageLocation = location;
   analytics.page(location);
-  analytics.identify();
 });
 
 // Record the initial page that was accessed; listen won't fire for the first
 // page loaded.
 analytics.page(history.getCurrentLocation());
+// Identify the cluster.
+analytics.identify();


### PR DESCRIPTION
Backport 1/1 commits from #24996.

/cc @cockroachdb/release

---

Fixes an issue where a bounce will never send an identify event to Segment.

Release note: None
