### PR TITLE
server: Improve locking in metric/status recorder

### DIFF
--- a/pkg/util/metric/prometheus_exporter.go
+++ b/pkg/util/metric/prometheus_exporter.go
@@ -68,18 +68,16 @@ func (pm *PrometheusExporter) findOrCreateFamily(
 // call. It creates new families as needed.
 func (pm *PrometheusExporter) ScrapeRegistry(registry *Registry) {
 	labels := registry.getLabels()
-	for _, metric := range registry.tracked {
-		metric.Inspect(func(v interface{}) {
-			if prom, ok := v.(PrometheusExportable); ok {
-				m := prom.ToPrometheusMetric()
-				// Set registry and metric labels.
-				m.Label = append(labels, prom.GetLabels()...)
+	registry.Each(func(_ string, v interface{}) {
+		if prom, ok := v.(PrometheusExportable); ok {
+			m := prom.ToPrometheusMetric()
+			// Set registry and metric labels.
+			m.Label = append(labels, prom.GetLabels()...)
 
-				family := pm.findOrCreateFamily(prom)
-				family.Metric = append(family.Metric, m)
-			}
-		})
-	}
+			family := pm.findOrCreateFamily(prom)
+			family.Metric = append(family.Metric, m)
+		}
+	})
 }
 
 // PrintAsText writes all metrics in the families map to the io.Writer in


### PR DESCRIPTION
When a store slows down, the WriteStatusSummary call can block for very
long periods of time because it calls down into Store.Descriptor, which
walks over all of its replicas. This avoids blocking important endpoints
like the one for Prometheus metrics (/_status/vars).

Inspired by the major slowdown on omega after dropping a table that was
many hundreds of gigabytes, and seeing alerts that Prometheus thought
the server was down even though it was actually still running.

Release note (admin ui change): Improve responsiveness of Prometheus
metrics endpoint on very overloaded nodes.