### PR TITLE
cli: improve debuggability of CLI tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -876,7 +876,7 @@ upload-coverage: $(BOOTSTRAP_TARGET)
 acceptance: TESTTIMEOUT := $(ACCEPTANCETIMEOUT)
 acceptance: export TESTTIMEOUT := $(TESTTIMEOUT)
 acceptance: ## Run acceptance tests.
-	@pkg/acceptance/run.sh
+	+@pkg/acceptance/run.sh
 
 .PHONY: dupl
 dupl: $(BOOTSTRAP_TARGET)

--- a/pkg/acceptance/cli_test.go
+++ b/pkg/acceptance/cli_test.go
@@ -67,6 +67,12 @@ func TestDockerCLI(t *testing.T) {
 		t.Run(testFile, func(t *testing.T) {
 			log.Infof(ctx, "-- starting tests from: %s", testFile)
 
+			// Symlink the logs directory to /logs, which is visible outside of the
+			// container and preserved if the test fails. (They don't write to /logs
+			// directly because they are often run manually outside of Docker, where
+			// /logs is unlikely to exist.)
+			cmd := "ln -s /logs logs"
+
 			// We run the expect command using `bash -c "(expect ...)"`.
 			//
 			// We cannot run `expect` directly, nor `bash -c "expect ..."`,
@@ -75,7 +81,7 @@ func TestDockerCLI(t *testing.T) {
 			// upon by the PID 1 process when they terminate, lest they
 			// remain forever in the zombie state. Unfortunately, Expect
 			// does not contain code to do this. Bash does.
-			cmd := "(expect"
+			cmd += "; (expect"
 			if log.V(2) {
 				cmd = cmd + " -d"
 			}

--- a/pkg/acceptance/cli_test.go
+++ b/pkg/acceptance/cli_test.go
@@ -57,7 +57,6 @@ func TestDockerCLI(t *testing.T) {
 		t.Fatalf("no testfiles found (%v)", testGlob)
 	}
 
-	verbose := testing.Verbose() || log.V(1)
 	for _, p := range paths {
 		testFile := filepath.Base(p)
 		testPath := filepath.Join(containerPath, testFile)
@@ -77,7 +76,7 @@ func TestDockerCLI(t *testing.T) {
 			// remain forever in the zombie state. Unfortunately, Expect
 			// does not contain code to do this. Bash does.
 			cmd := "(expect"
-			if verbose {
+			if log.V(2) {
 				cmd = cmd + " -d"
 			}
 			cmd = cmd + " -f " + testPath + " " + cluster.CockroachBinaryInContainer + ")"

--- a/pkg/cli/interactive_tests/README.md
+++ b/pkg/cli/interactive_tests/README.md
@@ -17,6 +17,10 @@ Two ways to run the tests are supported:
 
   This requires Docker. The test driver is in `acceptance/cli_test.go`.
 
+  To enable verbose debugging output, crank up the log verbosity:
+
+  `make acceptance TESTS=TestDockerCLI TESTFLAGS="-v -vmodule=cli_test=2"`
+
 - for a quick check, or manual testing while authoring a test, one can
   run the test from the current shell with:
 

--- a/pkg/cli/interactive_tests/common.tcl
+++ b/pkg/cli/interactive_tests/common.tcl
@@ -96,7 +96,7 @@ proc stop_server {argv} {
     # Trigger a normal shutdown.
     system "$argv quit"
     # If after 5 seconds the server hasn't shut down, trigger an error.
-    system "for i in `seq 1 5`; do kill -CONT `cat server_pid` 2>/dev/null || exit 0; echo still waiting; sleep 1; done; echo 'server still running?'; exit 0"
+    system "for i in `seq 1 5`; do kill -CONT `cat server_pid` 2>/dev/null || exit 0; echo still waiting; sleep 1; done; echo 'server still running?'; exit 1"
 
     report "END STOP SERVER"
 }

--- a/pkg/cli/interactive_tests/common.tcl
+++ b/pkg/cli/interactive_tests/common.tcl
@@ -2,13 +2,7 @@
 # accordingly.
 set env(TERM) vt100
 
-# If running inside docker, change the home dir to the output log dir
-# so that any HOME-derived artifacts land there.
-if {[pwd] == "/"} {
-  set ::env(HOME) "/logs"
-} else {
-  system "mkdir -p logs"
-}
+system "mkdir -p logs"
 
 # Keep the history in a test location, so as to not override the
 # developer's own history file when running out of Docker.

--- a/pkg/cli/interactive_tests/common.tcl
+++ b/pkg/cli/interactive_tests/common.tcl
@@ -88,7 +88,9 @@ proc send_eof {} {
 # in `server_pid`.
 proc start_server {argv} {
     report "BEGIN START SERVER"
-    system "mkfifo pid_fifo || true; $argv start --insecure --pid-file=pid_fifo --background -s=path=logs/db >>logs/expect-cmd.log 2>&1 & cat pid_fifo > server_pid"
+    system "mkfifo pid_fifo || true;
+            $argv start --insecure --pid-file=pid_fifo --background -s=path=logs/db >>logs/expect-cmd.log 2>&1 &
+            cat pid_fifo > server_pid"
     report "START SERVER DONE"
 }
 proc stop_server {argv} {
@@ -96,7 +98,13 @@ proc stop_server {argv} {
     # Trigger a normal shutdown.
     system "$argv quit"
     # If after 5 seconds the server hasn't shut down, trigger an error.
-    system "for i in `seq 1 5`; do kill -CONT `cat server_pid` 2>/dev/null || exit 0; echo still waiting; sleep 1; done; echo 'server still running?'; exit 1"
+    system "for i in `seq 1 5`; do
+              kill -CONT `cat server_pid` 2>/dev/null || exit 0
+              echo still waiting
+              sleep 1
+            done
+            echo 'server still running?'
+            exit 1"
 
     report "END STOP SERVER"
 }
@@ -105,12 +113,25 @@ proc flush_server_logs {} {
     report "BEGIN FLUSH LOGS"
     system "kill -HUP `cat server_pid` 2>/dev/null"
     # Wait for flush to occur.
-    system "for i in `seq 1 3`; do grep 'hangup received, flushing logs' logs/db/logs/cockroach.log && exit 0; echo still waiting; sleep 1; done; echo 'server failed to flush logs?'; exit 1"
+    system "for i in `seq 1 3`; do
+              grep 'hangup received, flushing logs' logs/db/logs/cockroach.log && exit 0;
+              echo still waiting
+              sleep 1
+            done
+            echo 'server failed to flush logs?'
+            exit 1"
     report "END FLUSH LOGS"
 }
 
 proc force_stop_server {argv} {
     report "BEGIN FORCE STOP SERVER"
-    system "$argv quit & sleep 1; if kill -CONT `cat server_pid` 2>/dev/null; then kill -TERM `cat server_pid`; sleep 1; if kill -CONT `cat server_pid` 2>/dev/null; then kill -KILL `cat server_pid`; fi; fi"
+    system "$argv quit & sleep 1
+            if kill -CONT `cat server_pid` 2>/dev/null; then
+              kill -TERM `cat server_pid`
+              sleep 1
+              if kill -CONT `cat server_pid` 2>/dev/null; then
+                kill -KILL `cat server_pid`
+              fi
+            fi"
     report "END FORCE STOP SERVER"
 }

--- a/pkg/cli/interactive_tests/common.tcl
+++ b/pkg/cli/interactive_tests/common.tcl
@@ -104,6 +104,12 @@ proc stop_server {argv} {
               sleep 1
             done
             echo 'server still running?'
+            # Send an unclean shutdown signal to trigger a stack trace dump.
+            kill -ABRT `cat server_pid`
+            # Sleep to increase the probability that the stack trace actually
+            # makes it to disk before we force-kill the process.
+            sleep 1
+            kill -KILL `cat server_pid`
             exit 1"
 
     report "END STOP SERVER"


### PR DESCRIPTION
Various fixes from debugging a failed CLI test with @windchan7. The culprit was a misbehaving retry loop that was tying up a goroutine during server quit for too long, but cascading failures in our CLI test infrastructure prevented these logs from surfacing anywhere useful.