### PR TITLE
sql: avoid context-insensitive retry loop in SHOW CLUSTER SETTING

### DIFF
--- a/pkg/sql/show_cluster_setting.go
+++ b/pkg/sql/show_cluster_setting.go
@@ -19,7 +19,6 @@ import (
 	"context"
 	"fmt"
 	"strings"
-	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
 	"github.com/pkg/errors"
@@ -42,7 +41,8 @@ func (p *planner) showStateMachineSetting(
 	// immediately while at the same time guaranteeing that a node reporting a certain version has
 	// also processed the corresponding Gossip update (which is important as only then does the node
 	// update its persisted state; see #22796).
-	if err := retry.ForDuration(10*time.Second, func() error {
+	const maxAttempts = 10
+	if err := retry.WithMaxAttempts(ctx, retry.Options{}, maxAttempts, func() error {
 		datums, err := p.queryRow(ctx, "SELECT value FROM system.settings WHERE name = $1", name)
 		if err != nil {
 			return err

--- a/pkg/util/retry/retry.go
+++ b/pkg/util/retry/retry.go
@@ -166,6 +166,12 @@ func WithMaxAttempts(ctx context.Context, opts Options, n int, fn func() error) 
 // without error, or the given duration has elapsed. The function is invoked
 // immediately at first and then successively with an exponential backoff
 // starting at 1ns and ending at the specified duration.
+//
+// This function is DEPRECATED! Please use one of the other functions in this
+// package that takes context cancellation into account.
+//
+// TODO(benesch): remove this function and port its callers to a context-
+// sensitive API.
 func ForDuration(duration time.Duration, fn func() error) error {
 	deadline := timeutil.Now().Add(duration)
 	var lastErr error


### PR DESCRIPTION
The implementation of SHOW CLUSTER SETTING for state-machine settings,
like the cluster version setting, uses a retry loop that is insensitive
to context cancellation. This can block node shutdown for up to ten
seconds since the shutdown signal is ignored for the full retry
duration. Notably, this breaks some acceptance tests that expect servers
to shut down within five seconds after the quit command returns.

Also add a note about the dangers of retry.ForDuration.

Release note: None