### PR TITLE
cli: run `node status` and `node ls` commands through SQL

### DIFF
--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -1836,9 +1836,7 @@ func TestCLITimeout(t *testing.T) {
 		}
 
 		const exp = `node status 1 --timeout 1ns
-operation timed out.
-
-context deadline exceeded
+pq: query execution canceled due to statement timeout
 `
 		if out != exp {
 			err := errors.Errorf("unexpected output:\n%q\nwanted:\n%q", out, exp)

--- a/pkg/cli/context.go
+++ b/pkg/cli/context.go
@@ -151,13 +151,6 @@ type cliContext struct {
 // Defaults set by InitCLIDefaults() above.
 var cliCtx = cliContext{Config: baseCfg}
 
-func cmdTimeoutContext(ctx context.Context) (context.Context, func()) {
-	if cliCtx.cmdTimeout != 0 {
-		return context.WithTimeout(ctx, cliCtx.cmdTimeout)
-	}
-	return context.WithCancel(ctx)
-}
-
 // sqlCtx captures the command-line parameters of the `sql` command.
 // Defaults set by InitCLIDefaults() above.
 var sqlCtx = struct {


### PR DESCRIPTION
Earlier `node status` command used to hit statusServer api endpoint and `node ls`
internally called `node status`.

After this commit, `node status` and `node ls` commands will internally query various tables in
crdb_internal and format the result.

Closes #20713.

Release note: None