### PR TITLE
sql: introduce SessionData.Copy

### DIFF
--- a/pkg/sql/distsqlrun/api.go
+++ b/pkg/sql/distsqlrun/api.go
@@ -25,7 +25,7 @@ func MakeEvalContext(evalCtx tree.EvalContext) EvalContext {
 		Location:           evalCtx.GetLocation().String(),
 		Database:           evalCtx.SessionData.Database,
 		User:               evalCtx.SessionData.User,
-		ApplicationName:    evalCtx.SessionData.ApplicationName(),
+		ApplicationName:    evalCtx.SessionData.ApplicationName,
 	}
 
 	// Populate the search path.

--- a/pkg/sql/distsqlrun/server.go
+++ b/pkg/sql/distsqlrun/server.go
@@ -319,10 +319,12 @@ func (ds *ServerImpl) setupFlow(
 	evalCtx := tree.EvalContext{
 		Settings: ds.ServerConfig.Settings,
 		SessionData: &sessiondata.SessionData{
-			Location:   location,
-			Database:   req.EvalContext.Database,
-			User:       req.EvalContext.User,
-			SearchPath: sessiondata.MakeSearchPath(req.EvalContext.SearchPath),
+			ApplicationName: req.EvalContext.ApplicationName,
+			Location:        location,
+			Database:        req.EvalContext.Database,
+			User:            req.EvalContext.User,
+			SearchPath:      sessiondata.MakeSearchPath(req.EvalContext.SearchPath),
+			SequenceState:   sessiondata.NewSequenceState(),
 		},
 		ClusterID:    ds.ServerConfig.ClusterID,
 		NodeID:       nodeID,
@@ -336,10 +338,8 @@ func (ds *ServerImpl) setupFlow(
 		Planner:     &dummyEvalPlanner{},
 		Sequence:    &dummySequenceOperators{},
 	}
-	evalCtx.SessionData.SetApplicationName(req.EvalContext.ApplicationName)
 	evalCtx.SetStmtTimestamp(timeutil.Unix(0 /* sec */, req.EvalContext.StmtTimestampNanos))
 	evalCtx.SetTxnTimestamp(timeutil.Unix(0 /* sec */, req.EvalContext.TxnTimestampNanos))
-	evalCtx.SessionData.SequenceState = sessiondata.NewSequenceState()
 	var haveSequences bool
 	for _, seq := range req.EvalContext.SeqState.Seqs {
 		evalCtx.SessionData.SequenceState.RecordValue(seq.SeqID, seq.LatestVal)

--- a/pkg/sql/exec_log.go
+++ b/pkg/sql/exec_log.go
@@ -119,7 +119,7 @@ func (p *planner) maybeLogStatementInternal(
 
 	// label passed as argument.
 
-	appName := s.ApplicationName()
+	appName := p.EvalContext().SessionData.ApplicationName
 
 	logTrigger := "{}"
 	if auditEventsDetected {

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -2397,9 +2397,6 @@ type EvalContext struct {
 	// Session variables. This is a read-only copy of the values owned by the
 	// Session.
 	SessionData *sessiondata.SessionData
-	// ApplicationName is a session variable, but it is not part of SessionData.
-	// See its definition in Session for details.
-	ApplicationName string
 	// TxnState is a string representation of the current transactional state.
 	TxnState string
 	// TxnReadOnly specifies if the current transaction is read-only.

--- a/pkg/sql/session.go
+++ b/pkg/sql/session.go
@@ -673,18 +673,17 @@ func (s *Session) extendedEvalCtx(
 
 	return extendedEvalContext{
 		EvalContext: tree.EvalContext{
-			Txn:             txn,
-			SessionData:     &s.data,
-			ApplicationName: s.dataMutator.ApplicationName(),
-			TxnState:        getTransactionState(&s.TxnState),
-			TxnReadOnly:     s.TxnState.readOnly,
-			TxnImplicit:     s.TxnState.implicitTxn,
-			Settings:        st,
-			CtxProvider:     s,
-			Mon:             &s.TxnState.mon,
-			TestingKnobs:    evalContextTestingKnobs,
-			StmtTimestamp:   stmtTimestamp,
-			TxnTimestamp:    txnTimestamp,
+			Txn:           txn,
+			SessionData:   &s.data,
+			TxnState:      getTransactionState(&s.TxnState),
+			TxnReadOnly:   s.TxnState.readOnly,
+			TxnImplicit:   s.TxnState.implicitTxn,
+			Settings:      st,
+			CtxProvider:   s,
+			Mon:           &s.TxnState.mon,
+			TestingKnobs:  evalContextTestingKnobs,
+			StmtTimestamp: stmtTimestamp,
+			TxnTimestamp:  txnTimestamp,
 		},
 		SessionMutator:  &s.dataMutator,
 		VirtualSchemas:  s.execCfg.VirtualSchemas,
@@ -887,7 +886,7 @@ func (s *Session) serialize() serverpb.Session {
 	return serverpb.Session{
 		Username:        s.data.User,
 		ClientAddress:   s.ClientAddr,
-		ApplicationName: s.data.ApplicationName(),
+		ApplicationName: s.data.ApplicationName,
 		Start:           s.phaseTimes[sessionInit].UTC(),
 		ActiveQueries:   activeQueries,
 		KvTxnID:         kvTxnID,
@@ -1901,18 +1900,10 @@ type sessionDataMutator struct {
 
 // SetApplicationName sets the application name.
 func (m *sessionDataMutator) SetApplicationName(appName string) {
-	m.data.SetApplicationName(appName)
+	m.data.ApplicationName = appName
 	if m.applicationNameChanged != nil {
 		m.applicationNameChanged(appName)
 	}
-}
-
-// ApplicationName returns the session's "application_name" variable. This is
-// not a setter method, but the method is here nevertheless because
-// ApplicationName is not part of SessionData because accessing it needs
-// locking.
-func (m *sessionDataMutator) ApplicationName() string {
-	return m.data.ApplicationName()
 }
 
 func (m *sessionDataMutator) SetDatabase(dbName string) {

--- a/pkg/sql/sessiondata/sequence_state.go
+++ b/pkg/sql/sessiondata/sequence_state.go
@@ -43,6 +43,18 @@ func NewSequenceState() *SequenceState {
 	return &ss
 }
 
+// copy performs a deep copy of SequenceState.
+func (ss *SequenceState) copy() *SequenceState {
+	cp := NewSequenceState()
+	ss.mu.Lock()
+	defer ss.mu.Unlock()
+	for k, v := range ss.mu.latestValues {
+		cp.mu.latestValues[k] = v
+	}
+	cp.mu.lastSequenceIncremented = ss.mu.lastSequenceIncremented
+	return ss
+}
+
 // NextVal ever called returns true if a sequence has ever been incremented on
 // this session.
 func (ss *SequenceState) nextValEverCalledLocked() bool {

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -91,7 +91,7 @@ var varGen = map[string]sessionVar{
 			return nil
 		},
 		Get: func(evalCtx *extendedEvalContext) string {
-			return evalCtx.ApplicationName
+			return evalCtx.SessionData.ApplicationName
 		},
 		Reset: func(m *sessionDataMutator) error {
 			m.SetApplicationName(m.defaults.applicationName)


### PR DESCRIPTION
Make the SessionData struct copiable. This will be used to copy state
from a session to internal statements that need to be run in the same
context (particularly, with the same user and database).

This patch removes a mutex protecting sessionData.AppName. It used to be
that the field was accessed concurrently by connEx.Serialize() - a
method used by the "session registry". This patch creates an atomic that
parallels sessionData.AppName for that purpose.

Release note: None