### PR TITLE
sql: trim EXPLAIN flags

### DIFF
--- a/pkg/sql/explain.go
+++ b/pkg/sql/explain.go
@@ -50,7 +50,6 @@ func (p *planner) Explain(ctx context.Context, n *tree.Explain) (planNode, error
 	normalizeExprs := true
 	flags := explainFlags{
 		showMetadata: false,
-		showExprs:    false,
 		showTypes:    false,
 	}
 
@@ -68,30 +67,14 @@ func (p *planner) Explain(ctx context.Context, n *tree.Explain) (planNode, error
 			switch optLower {
 			case "types":
 				newMode = explainPlan
-				flags.showExprs = true
 				flags.showTypes = true
-				// TYPES implies METADATA.
 				flags.showMetadata = true
 
 			case "symvars":
 				flags.symbolicVars = true
-
-			case "metadata":
-				flags.showMetadata = true
-
-			case "qualify":
-				flags.qualifyNames = true
-
 			case "verbose":
-				// VERBOSE implies EXPRS.
-				flags.showExprs = true
-				// VERBOSE implies QUALIFY.
 				flags.qualifyNames = true
-				// VERBOSE implies METADATA.
 				flags.showMetadata = true
-
-			case "exprs":
-				flags.showExprs = true
 
 			case "noexpand":
 				expanded = false

--- a/pkg/sql/explain_plan.go
+++ b/pkg/sql/explain_plan.go
@@ -186,12 +186,8 @@ type explainEntry struct {
 type explainFlags struct {
 	// showMetadata indicates whether the output has separate columns for the
 	// schema signature and ordering information of the intermediate
-	// nodes.
+	// nodes (also, whether the plan prints expressions embedded inside the node).
 	showMetadata bool
-
-	// showExprs indicates whether the plan prints expressions
-	// embedded inside the node.
-	showExprs bool
 
 	// qualifyNames determines whether column names in expressions
 	// should be fully qualified during pretty-printing.
@@ -323,7 +319,6 @@ func planToString(ctx context.Context, plan planNode, subqueryPlans []subquery) 
 	e := explainer{
 		explainFlags: explainFlags{
 			showMetadata: true,
-			showExprs:    true,
 			showTypes:    true,
 		},
 		fmtFlags: tree.FmtExpr(tree.FmtSymbolicSubqueries, true, true, true),
@@ -360,7 +355,7 @@ func (e *explainer) observer() planObserver {
 
 // expr implements the planObserver interface.
 func (e *explainer) expr(nodeName, fieldName string, n int, expr tree.Expr) {
-	if e.showExprs && expr != nil {
+	if e.showMetadata && expr != nil {
 		if nodeName == "join" {
 			qualifySave := e.fmtFlags
 			e.fmtFlags.SetFlags(tree.FmtShowTableAliases)

--- a/pkg/sql/logictest/testdata/logic_test/aggregate
+++ b/pkg/sql/logictest/testdata/logic_test/aggregate
@@ -612,25 +612,29 @@ SELECT AVG(k) * 2.0 + MAX(v)::DECIMAL FROM kv WHERE w*2 = k
 14.0
 
 query TTT
-EXPLAIN (EXPRS) SELECT COUNT(k) FROM kv
+SELECT "Tree", "Field", "Description" FROM [
+EXPLAIN (VERBOSE) SELECT COUNT(k) FROM kv
+]
 ----
 group           ·            ·
  │              aggregate 0  count(k)
  └── render     ·            ·
-      │         render 0     k
+      │         render 0     test.public.kv.k
       └── scan  ·            ·
 ·               table        kv@primary
 ·               spans        ALL
 
 query TTT
-EXPLAIN (EXPRS) SELECT COUNT(k), SUM(k), MAX(k) FROM kv
+SELECT "Tree", "Field", "Description" FROM [
+EXPLAIN (VERBOSE) SELECT COUNT(k), SUM(k), MAX(k) FROM kv
+]
 ----
 group           ·            ·
  │              aggregate 0  count(k)
  │              aggregate 1  sum(k)
  │              aggregate 2  max(k)
  └── render     ·            ·
-      │         render 0     k
+      │         render 0     test.public.kv.k
       └── scan  ·            ·
 ·               table        kv@primary
 ·               spans        ALL
@@ -647,12 +651,14 @@ statement ok
 INSERT INTO abc VALUES ('one', 1.5, true, 5::decimal), ('two', 2.0, false, 1.1::decimal)
 
 query TTT
-EXPLAIN (EXPRS) SELECT MIN(a) FROM abc
+SELECT "Tree", "Field", "Description" FROM [
+EXPLAIN (VERBOSE) SELECT MIN(a) FROM abc
+]
 ----
 group           ·            ·
  │              aggregate 0  min(a)
  └── render     ·            ·
-      │         render 0     a
+      │         render 0     test.public.abc.a
       └── scan  ·            ·
 ·               table        abc@primary
 ·               spans        ALL
@@ -727,12 +733,14 @@ SELECT MIN(x) FROM xyz
 1
 
 query TTT
-EXPLAIN (EXPRS) SELECT MIN(x) FROM xyz
+SELECT "Tree", "Field", "Description" FROM [
+EXPLAIN (VERBOSE) SELECT MIN(x) FROM xyz
+]
 ----
 group           ·            ·
  │              aggregate 0  min(x)
  └── render     ·            ·
-      │         render 0     x
+      │         render 0     test.public.xyz.x
       └── scan  ·            ·
 ·               table        xyz@xy
 ·               spans        ALL
@@ -744,12 +752,14 @@ SELECT MIN(x) FROM xyz WHERE x in (0, 4, 7)
 4
 
 query TTT
-EXPLAIN (EXPRS) SELECT MIN(x) FROM xyz WHERE x in (0, 4, 7)
+SELECT "Tree", "Field", "Description" FROM [
+EXPLAIN (VERBOSE) SELECT MIN(x) FROM xyz WHERE x in (0, 4, 7)
+]
 ----
 group           ·            ·
  │              aggregate 0  min(x)
  └── render     ·            ·
-      │         render 0     x
+      │         render 0     test.public.xyz.x
       └── scan  ·            ·
 ·               table        xyz@xy
 ·               spans        /0-/1 /4-/5 /7-/8
@@ -761,12 +771,14 @@ SELECT MAX(x) FROM xyz
 7
 
 query TTT
-EXPLAIN (EXPRS) SELECT MAX(x) FROM xyz
+SELECT "Tree", "Field", "Description" FROM [
+EXPLAIN (VERBOSE) SELECT MAX(x) FROM xyz
+]
 ----
 group              ·            ·
  │                 aggregate 0  max(x)
  └── render        ·            ·
-      │            render 0     x
+      │            render 0     test.public.xyz.x
       └── revscan  ·            ·
 ·                  table        xyz@xy
 ·                  spans        ALL
@@ -778,12 +790,14 @@ SELECT MIN(y) FROM xyz WHERE x = 1
 2
 
 query TTT
-EXPLAIN (EXPRS) SELECT MIN(y) FROM xyz WHERE x = 1
+SELECT "Tree", "Field", "Description" FROM [
+EXPLAIN (VERBOSE) SELECT MIN(y) FROM xyz WHERE x = 1
+]
 ----
 group           ·            ·
  │              aggregate 0  min(y)
  └── render     ·            ·
-      │         render 0     y
+      │         render 0     test.public.xyz.y
       └── scan  ·            ·
 ·               table        xyz@xy
 ·               spans        /1/!NULL-/2
@@ -795,12 +809,14 @@ SELECT MAX(y) FROM xyz WHERE x = 1
 2
 
 query TTT
-EXPLAIN (EXPRS) SELECT MAX(y) FROM xyz WHERE x = 1
+SELECT "Tree", "Field", "Description" FROM [
+EXPLAIN (VERBOSE) SELECT MAX(y) FROM xyz WHERE x = 1
+]
 ----
 group              ·            ·
  │                 aggregate 0  max(y)
  └── render        ·            ·
-      │            render 0     y
+      │            render 0     test.public.xyz.y
       └── revscan  ·            ·
 ·                  table        xyz@xy
 ·                  spans        /1/!NULL-/2
@@ -812,12 +828,14 @@ SELECT MIN(y) FROM xyz WHERE x = 7
 NULL
 
 query TTT
-EXPLAIN (EXPRS) SELECT MIN(y) FROM xyz WHERE x = 7
+SELECT "Tree", "Field", "Description" FROM [
+EXPLAIN (VERBOSE) SELECT MIN(y) FROM xyz WHERE x = 7
+]
 ----
 group           ·            ·
  │              aggregate 0  min(y)
  └── render     ·            ·
-      │         render 0     y
+      │         render 0     test.public.xyz.y
       └── scan  ·            ·
 ·               table        xyz@xy
 ·               spans        /7/!NULL-/8
@@ -829,12 +847,14 @@ SELECT MAX(y) FROM xyz WHERE x = 7
 NULL
 
 query TTT
-EXPLAIN (EXPRS) SELECT MAX(y) FROM xyz WHERE x = 7
+SELECT "Tree", "Field", "Description" FROM [
+EXPLAIN (VERBOSE) SELECT MAX(y) FROM xyz WHERE x = 7
+]
 ----
 group              ·            ·
  │                 aggregate 0  max(y)
  └── render        ·            ·
-      │            render 0     y
+      │            render 0     test.public.xyz.y
       └── revscan  ·            ·
 ·                  table        xyz@xy
 ·                  spans        /7/!NULL-/8
@@ -846,12 +866,14 @@ SELECT MIN(x) FROM xyz WHERE (y, z) = (2, 3.0)
 1
 
 query TTT
-EXPLAIN (EXPRS) SELECT MIN(x) FROM xyz WHERE (y, z) = (2, 3.0)
+SELECT "Tree", "Field", "Description" FROM [
+EXPLAIN (VERBOSE) SELECT MIN(x) FROM xyz WHERE (y, z) = (2, 3.0)
+]
 ----
 group           ·            ·
  │              aggregate 0  min(x)
  └── render     ·            ·
-      │         render 0     x
+      │         render 0     test.public.xyz.x
       └── scan  ·            ·
 ·               table        xyz@zyx
 ·               spans        /3/2-/3/3
@@ -870,12 +892,14 @@ SELECT MAX(x) FROM xyz WHERE (z, y) = (3.0, 2)
 1
 
 query TTT
-EXPLAIN (EXPRS) SELECT MAX(x) FROM xyz WHERE (z, y) = (3.0, 2)
+SELECT "Tree", "Field", "Description" FROM [
+EXPLAIN (VERBOSE) SELECT MAX(x) FROM xyz WHERE (z, y) = (3.0, 2)
+]
 ----
 group              ·            ·
  │                 aggregate 0  max(x)
  └── render        ·            ·
-      │            render 0     x
+      │            render 0     test.public.xyz.x
       └── revscan  ·            ·
 ·                  table        xyz@zyx
 ·                  spans        /3/2-/3/3
@@ -913,12 +937,14 @@ SELECT VARIANCE(x) FROM xyz WHERE x = 1
 NULL
 
 query TTT
-EXPLAIN (EXPRS) SELECT VARIANCE(x) FROM xyz WHERE x = 1
+SELECT "Tree", "Field", "Description" FROM [
+EXPLAIN (VERBOSE) SELECT VARIANCE(x) FROM xyz WHERE x = 1
+]
 ----
 group           ·            ·
  │              aggregate 0  variance(x)
  └── render     ·            ·
-      │         render 0     x
+      │         render 0     test.public.xyz.x
       └── scan  ·            ·
 ·               table        xyz@xy
 ·               spans        /1-/2
@@ -1068,12 +1094,14 @@ INSERT INTO ab VALUES
   (5, 50)
 
 query TTT
-EXPLAIN (EXPRS) SELECT MIN(a) FROM abc
+SELECT "Tree", "Field", "Description" FROM [
+EXPLAIN (VERBOSE) SELECT MIN(a) FROM abc
+]
 ----
 group           ·            ·
  │              aggregate 0  min(a)
  └── render     ·            ·
-      │         render 0     a
+      │         render 0     test.public.abc.a
       └── scan  ·            ·
 ·               table        abc@primary
 ·               spans        ALL
@@ -1089,12 +1117,14 @@ fetched: /ab/primary/1/b -> 10
 output row: [1]
 
 query TTT
-EXPLAIN (EXPRS) SELECT MAX(a) FROM abc
+SELECT "Tree", "Field", "Description" FROM [
+EXPLAIN (VERBOSE) SELECT MAX(a) FROM abc
+]
 ----
 group              ·            ·
  │                 aggregate 0  max(a)
  └── render        ·            ·
-      │            render 0     a
+      │            render 0     test.public.abc.a
       └── revscan  ·            ·
 ·                  table        abc@primary
 ·                  spans        ALL
@@ -1110,7 +1140,9 @@ fetched: /ab/primary/5 -> NULL
 output row: [5]
 
 query TTT
-EXPLAIN (EXPRS) SELECT v, COUNT(k) FROM kv GROUP BY v ORDER BY COUNT(k)
+SELECT "Tree", "Field", "Description" FROM [
+EXPLAIN (VERBOSE) SELECT v, COUNT(k) FROM kv GROUP BY v ORDER BY COUNT(k)
+]
 ----
 sort                 ·            ·
  │                   order        +count
@@ -1119,14 +1151,16 @@ sort                 ·            ·
       │              aggregate 1  count(k)
       │              group by     @1
       └── render     ·            ·
-           │         render 0     v
-           │         render 1     k
+           │         render 0     test.public.kv.v
+           │         render 1     test.public.kv.k
            └── scan  ·            ·
 ·                    table        kv@primary
 ·                    spans        ALL
 
 query TTT
-EXPLAIN (EXPRS) SELECT v, COUNT(*) FROM kv GROUP BY v ORDER BY COUNT(*)
+SELECT "Tree", "Field", "Description" FROM [
+EXPLAIN (VERBOSE) SELECT v, COUNT(*) FROM kv GROUP BY v ORDER BY COUNT(*)
+]
 ----
 sort                 ·            ·
  │                   order        +count
@@ -1135,13 +1169,15 @@ sort                 ·            ·
       │              aggregate 1  count_rows()
       │              group by     @1
       └── render     ·            ·
-           │         render 0     v
+           │         render 0     test.public.kv.v
            └── scan  ·            ·
 ·                    table        kv@primary
 ·                    spans        ALL
 
 query TTT
-EXPLAIN (EXPRS) SELECT v, COUNT(1) FROM kv GROUP BY v ORDER BY COUNT(1)
+SELECT "Tree", "Field", "Description" FROM [
+EXPLAIN (VERBOSE) SELECT v, COUNT(1) FROM kv GROUP BY v ORDER BY COUNT(1)
+]
 ----
 sort                 ·            ·
  │                   order        +count
@@ -1150,7 +1186,7 @@ sort                 ·            ·
       │              aggregate 1  count(1)
       │              group by     @1
       └── render     ·            ·
-           │         render 0     v
+           │         render 0     test.public.kv.v
            │         render 1     1
            └── scan  ·            ·
 ·                    table        kv@primary
@@ -1158,14 +1194,16 @@ sort                 ·            ·
 
 # Check that filters propagate through no-op aggregation.
 query TTT
-EXPLAIN(EXPRS) SELECT * FROM (SELECT v, COUNT(1) FROM kv GROUP BY v) WHERE v > 10
+SELECT "Tree", "Field", "Description" FROM [
+EXPLAIN (VERBOSE) SELECT * FROM (SELECT v, COUNT(1) FROM kv GROUP BY v) WHERE v > 10
+]
 ----
 group           ·            ·
  │              aggregate 0  v
  │              aggregate 1  count(1)
  │              group by     @1
  └── render     ·            ·
-      │         render 0     v
+      │         render 0     test.public.kv.v
       │         render 1     1
       └── scan  ·            ·
 ·               table        kv@primary
@@ -1219,15 +1257,17 @@ SELECT v, COUNT(*) FILTER (WHERE COUNT(*) > 5) FROM filter_test GROUP BY v
 
 # Check that filter expressions are only rendered once.
 query TTT
-EXPLAIN (EXPRS) SELECT COUNT(*) FILTER (WHERE k>5), MAX(k>5) FILTER(WHERE k>5) FROM filter_test GROUP BY v
+SELECT "Tree", "Field", "Description" FROM [
+EXPLAIN (VERBOSE) SELECT COUNT(*) FILTER (WHERE k>5), MAX(k>5) FILTER(WHERE k>5) FROM filter_test GROUP BY v
+]
 ----
 group           ·            ·
  │              aggregate 0  count_rows() FILTER (WHERE k > 5)
  │              aggregate 1  max(k > 5) FILTER (WHERE k > 5)
  │              group by     @1
  └── render     ·            ·
-      │         render 0     v
-      │         render 1     k > 5
+      │         render 0     test.public.filter_test.v
+      │         render 1     test.public.filter_test.k > 5
       └── scan  ·            ·
 ·               table        filter_test@primary
 ·               spans        ALL
@@ -1247,7 +1287,9 @@ group           0  group   ·            ·                                  (co
 
 # Tests with * inside GROUP BY.
 query TTT
-EXPLAIN (EXPRS) SELECT 1 FROM kv GROUP BY kv.*;
+SELECT "Tree", "Field", "Description" FROM [
+EXPLAIN (VERBOSE) SELECT 1 FROM kv GROUP BY kv.*
+]
 ----
 render          ·         ·
  │              render 0  1
@@ -1258,7 +1300,7 @@ render          ·         ·
 ·               spans     ALL
 
 query I
-SELECT 1 FROM kv GROUP BY kv.*;
+SELECT 1 FROM kv GROUP BY kv.*
 ----
 1
 1
@@ -1268,17 +1310,19 @@ SELECT 1 FROM kv GROUP BY kv.*;
 1
 
 query TTT
-EXPLAIN (EXPRS) SELECT SUM(abc.d) FROM kv JOIN abc ON kv.k >= abc.d GROUP BY kv.*;
+SELECT "Tree", "Field", "Description" FROM [
+EXPLAIN (VERBOSE) SELECT SUM(abc.d) FROM kv JOIN abc ON kv.k >= abc.d GROUP BY kv.*
+]
 ----
 group                ·            ·
  │                   aggregate 0  sum(d)
  │                   group by     @1-@4
  └── render          ·            ·
-      │              render 0     k
-      │              render 1     v
-      │              render 2     w
-      │              render 3     s
-      │              render 4     d
+      │              render 0     test.public.kv.k
+      │              render 1     test.public.kv.v
+      │              render 2     test.public.kv.w
+      │              render 3     test.public.kv.s
+      │              render 4     test.public.abc.d
       └── join       ·            ·
            │         type         inner
            │         pred         test.public.kv.k >= test.public.abc.d
@@ -1290,7 +1334,7 @@ group                ·            ·
 ·                    spans        ALL
 
 query R rowsort
-SELECT SUM(abc.d) FROM kv JOIN abc ON kv.k >= abc.d GROUP BY kv.*;
+SELECT SUM(abc.d) FROM kv JOIN abc ON kv.k >= abc.d GROUP BY kv.*
 ----
 1.1
 6.1
@@ -1434,7 +1478,9 @@ SELECT (b, a) FROM ab GROUP BY (b, a)
 (4,3)
 
 query TTT
-EXPLAIN(EXPRS) SELECT (b, a) FROM ab GROUP BY (b, a)
+SELECT "Tree", "Field", "Description" FROM [
+EXPLAIN (VERBOSE) SELECT (b, a) FROM ab GROUP BY (b, a)
+]
 ----
 render               ·            ·
  │                   render 0     (agg0, agg1)
@@ -1443,8 +1489,8 @@ render               ·            ·
       │              aggregate 1  a
       │              group by     @1-@2
       └── render     ·            ·
-           │         render 0     b
-           │         render 1     a
+           │         render 0     test.public.ab.b
+           │         render 1     test.public.ab.a
            └── scan  ·            ·
 ·                    table        ab@primary
 ·                    spans        ALL
@@ -1459,9 +1505,11 @@ b  (4,3)
 d  (4,3)
 
 query TTT
-EXPLAIN(EXPRS)
+SELECT "Tree", "Field", "Description" FROM [
+EXPLAIN (VERBOSE)
    SELECT MIN(y), (b, a)
      FROM ab, xy GROUP BY (x, (a, b))
+]
 ----
 render                    ·            ·
  │                        render 0     agg0
@@ -1472,10 +1520,10 @@ render                    ·            ·
       │                   aggregate 2  a
       │                   group by     @1-@3
       └── render          ·            ·
-           │              render 0     x
-           │              render 1     a
-           │              render 2     b
-           │              render 3     y
+           │              render 0     test.public.xy.x
+           │              render 1     test.public.ab.a
+           │              render 2     test.public.ab.b
+           │              render 3     test.public.xy.y
            └── join       ·            ·
                 │         type         cross
                 ├── scan  ·            ·

--- a/pkg/sql/logictest/testdata/logic_test/alter_table
+++ b/pkg/sql/logictest/testdata/logic_test/alter_table
@@ -655,16 +655,19 @@ CREATE TABLE s (k1 INT, k2 INT, v INT, PRIMARY KEY (k1,k2))
 
 # Verify limits and orderings are propagated correctly to the select.
 query TITTTTT colnames
-EXPLAIN (METADATA) ALTER TABLE s SPLIT AT SELECT k1,k2 FROM s ORDER BY k1 LIMIT 3
+EXPLAIN (VERBOSE) ALTER TABLE s SPLIT AT SELECT k1,k2 FROM s ORDER BY k1 LIMIT 3
 ----
-Tree                 Level  Type    Field  Description  Columns               Ordering
-split                0      split   ·      ·            (key, pretty)         ·
- └── limit           1      limit   ·      ·            (k1, k2)              k1!=NULL; k2!=NULL; key(k1,k2); +k1
-      └── render     2      render  ·      ·            (k1, k2)              k1!=NULL; k2!=NULL; key(k1,k2); +k1
-           └── scan  3      scan    ·      ·            (k1, k2, v[omitted])  k1!=NULL; k2!=NULL; key(k1,k2); +k1
-·                    3      ·       table  s@primary    ·                     ·
-·                    3      ·       spans  ALL          ·                     ·
-·                    3      ·       limit  3            ·                     ·
+Tree                 Level  Type    Field     Description       Columns               Ordering
+split                0      split   ·         ·                 (key, pretty)         ·
+ └── limit           1      limit   ·         ·                 (k1, k2)              k1!=NULL; k2!=NULL; key(k1,k2); +k1
+      │              1      ·       count     3                 ·                     ·
+      └── render     2      render  ·         ·                 (k1, k2)              k1!=NULL; k2!=NULL; key(k1,k2); +k1
+           │         2      ·       render 0  test.public.s.k1  ·                     ·
+           │         2      ·       render 1  test.public.s.k2  ·                     ·
+           └── scan  3      scan    ·         ·                 (k1, k2, v[omitted])  k1!=NULL; k2!=NULL; key(k1,k2); +k1
+·                    3      ·       table     s@primary         ·                     ·
+·                    3      ·       spans     ALL               ·                     ·
+·                    3      ·       limit     3                 ·                     ·
 
 # Verify that impure defaults are evaluated separately on each row
 # (#14352)

--- a/pkg/sql/logictest/testdata/logic_test/distinct
+++ b/pkg/sql/logictest/testdata/logic_test/distinct
@@ -205,15 +205,16 @@ SELECT COUNT(*) FROM (SELECT DISTINCT y FROM xyz)
 
 
 query TITTTTT
-EXPLAIN (METADATA) SELECT DISTINCT x FROM xyz
+EXPLAIN (VERBOSE) SELECT DISTINCT x FROM xyz
 ----
-render     0  render  ·      ·            (x)                          x!=NULL; key(x)
- └── scan  1  scan    ·      ·            (x, y[omitted], z[omitted])  x!=NULL; key(x)
-·          1  ·       table  xyz@primary  ·                            ·
-·          1  ·       spans  ALL          ·                            ·
+render     0  render  ·         ·                  (x)                          x!=NULL; key(x)
+ │         0  ·       render 0  test.public.xyz.x  ·                            ·
+ └── scan  1  scan    ·         ·                  (x, y[omitted], z[omitted])  x!=NULL; key(x)
+·          1  ·       table     xyz@primary        ·                            ·
+·          1  ·       spans     ALL                ·                            ·
 
 query TITTTTT
-EXPLAIN (METADATA) SELECT DISTINCT x, y, z FROM xyz
+EXPLAIN (VERBOSE) SELECT DISTINCT x, y, z FROM xyz
 ----
 scan  0  scan  ·      ·            (x, y, z)  x!=NULL; key(x)
 ·     0  ·     table  xyz@primary  ·          ·
@@ -230,33 +231,41 @@ CREATE TABLE abcd (
 )
 
 query TITTTTT
-EXPLAIN (METADATA) SELECT DISTINCT 1, d, b FROM abcd ORDER BY d, b
+EXPLAIN (VERBOSE) SELECT DISTINCT 1, d, b FROM abcd ORDER BY d, b
 ----
-render     0  render  ·      ·                  ("1", d, b)                     "1"=CONST; d!=NULL; b!=NULL; key(d,b); +d,+b
- └── scan  1  scan    ·      ·                  (a[omitted], b, c[omitted], d)  b!=NULL; d!=NULL; key(b,d); +d,+b
-·          1  ·       table  abcd@abcd_d_b_key  ·                               ·
-·          1  ·       spans  ALL                ·                               ·
+render     0  render  ·         ·                   ("1", d, b)                     "1"=CONST; d!=NULL; b!=NULL; key(d,b); +d,+b
+ │         0  ·       render 0  1                   ·                               ·
+ │         0  ·       render 1  test.public.abcd.d  ·                               ·
+ │         0  ·       render 2  test.public.abcd.b  ·                               ·
+ └── scan  1  scan    ·         ·                   (a[omitted], b, c[omitted], d)  b!=NULL; d!=NULL; key(b,d); +d,+b
+·          1  ·       table     abcd@abcd_d_b_key   ·                               ·
+·          1  ·       spans     ALL                 ·                               ·
 
 query TITTTTT
-EXPLAIN (METADATA) SELECT DISTINCT a, b FROM abcd
+EXPLAIN (VERBOSE) SELECT DISTINCT a, b FROM abcd
 ----
-distinct        0  distinct  ·          ·             (a, b)                          a!=NULL; b!=NULL; key(a,b); +a,+b
- │              0  ·         order key  a, b          ·                               ·
- └── render     1  render    ·          ·             (a, b)                          a!=NULL; b!=NULL; +a,+b
-      └── scan  2  scan      ·          ·             (a, b, c[omitted], d[omitted])  a!=NULL; b!=NULL; c!=NULL; key(a,b,c); +a,+b
-·               2  ·         table      abcd@primary  ·                               ·
-·               2  ·         spans      ALL           ·                               ·
+distinct        0  distinct  ·          ·                   (a, b)                          a!=NULL; b!=NULL; key(a,b); +a,+b
+ │              0  ·         order key  a, b                ·                               ·
+ └── render     1  render    ·          ·                   (a, b)                          a!=NULL; b!=NULL; +a,+b
+      │         1  ·         render 0   test.public.abcd.a  ·                               ·
+      │         1  ·         render 1   test.public.abcd.b  ·                               ·
+      └── scan  2  scan      ·          ·                   (a, b, c[omitted], d[omitted])  a!=NULL; b!=NULL; c!=NULL; key(a,b,c); +a,+b
+·               2  ·         table      abcd@primary        ·                               ·
+·               2  ·         spans      ALL                 ·                               ·
 
 query TITTTTT
-EXPLAIN (METADATA) SELECT DISTINCT a, b, c FROM abcd
+EXPLAIN (VERBOSE) SELECT DISTINCT a, b, c FROM abcd
 ----
-render     0  render  ·      ·             (a, b, c)              a!=NULL; b!=NULL; c!=NULL; key(a,b,c)
- └── scan  1  scan    ·      ·             (a, b, c, d[omitted])  a!=NULL; b!=NULL; c!=NULL; key(a,b,c)
-·          1  ·       table  abcd@primary  ·                      ·
-·          1  ·       spans  ALL           ·                      ·
+render     0  render  ·         ·                   (a, b, c)              a!=NULL; b!=NULL; c!=NULL; key(a,b,c)
+ │         0  ·       render 0  test.public.abcd.a  ·                      ·
+ │         0  ·       render 1  test.public.abcd.b  ·                      ·
+ │         0  ·       render 2  test.public.abcd.c  ·                      ·
+ └── scan  1  scan    ·         ·                   (a, b, c, d[omitted])  a!=NULL; b!=NULL; c!=NULL; key(a,b,c)
+·          1  ·       table     abcd@primary        ·                      ·
+·          1  ·       spans     ALL                 ·                      ·
 
 query TITTTTT
-EXPLAIN (METADATA) SELECT DISTINCT a, b, c, d FROM abcd
+EXPLAIN (VERBOSE) SELECT DISTINCT a, b, c, d FROM abcd
 ----
 scan  0  scan  ·      ·             (a, b, c, d)  a!=NULL; b!=NULL; c!=NULL; key(a,b,c)
 ·     0  ·     table  abcd@primary  ·             ·

--- a/pkg/sql/logictest/testdata/logic_test/explain
+++ b/pkg/sql/logictest/testdata/logic_test/explain
@@ -24,18 +24,20 @@ render     ·      ·
 ·          spans  ALL
 
 query TITTTTT colnames
-EXPLAIN (PLAN, METADATA) SELECT 1
+EXPLAIN (PLAN, VERBOSE) SELECT 1
 ----
-Tree           Level  Type      Field  Description  Columns  Ordering
-render         0      render    ·      ·            ("1")    "1"=CONST
- └── emptyrow  1      emptyrow  ·      ·            ()       ·
+Tree           Level  Type      Field     Description  Columns  Ordering
+render         0      render    ·         ·            ("1")    "1"=CONST
+ │             0      ·         render 0  1            ·        ·
+ └── emptyrow  1      emptyrow  ·         ·            ()       ·
 
 query TITTTTT colnames
-EXPLAIN (METADATA,PLAN) SELECT 1
+EXPLAIN (VERBOSE,PLAN) SELECT 1
 ----
-Tree           Level  Type      Field  Description  Columns  Ordering
-render         0      render    ·      ·            ("1")    "1"=CONST
- └── emptyrow  1      emptyrow  ·      ·            ()       ·
+Tree           Level  Type      Field     Description  Columns  Ordering
+render         0      render    ·         ·            ("1")    "1"=CONST
+ │             0      ·         render 0  1            ·        ·
+ └── emptyrow  1      emptyrow  ·         ·            ()       ·
 
 query T
 SELECT message FROM [SHOW KV TRACE FOR SELECT 1]
@@ -73,17 +75,36 @@ render         0      render    ·         ·                         ("$1::INT"
 
 # Ensure that tracing results are sorted after gathering
 query TITTTTT
-EXPLAIN (METADATA) SHOW TRACE FOR SELECT 1
+EXPLAIN (VERBOSE) SHOW TRACE FOR SELECT 1
 ----
-sort                                         0  sort            ·      ·             ("timestamp", age, message, tag, loc, operation, span)                        +"timestamp"
- │                                           0  ·               order  +"timestamp"  ·                                                                             ·
- └── window                                  1  window          ·      ·             ("timestamp", age, message, tag, loc, operation, span)                        ·
-      └── render                             2  render          ·      ·             ("timestamp", """timestamp""", message, tag, loc, operation, span)            "timestamp"="""timestamp"""
-           └── window                        3  window          ·      ·             ("timestamp", message, tag, loc, operation, span)                             ·
-                └── render                   4  render          ·      ·             ("timestamp", message, tag, loc, operation, span, message_idx)                ·
-                     └── show trace for      5  show trace for  ·      ·             (span_idx, message_idx, "timestamp", duration, operation, loc, tag, message)  ·
-                          └── render         6  render          ·      ·             ("1")                                                                         "1"=CONST
-                               └── emptyrow  7  emptyrow        ·      ·             ()                                                                            ·
+sort                                         0  sort            ·         ·                                                                                                                                                                            ("timestamp", age, message, tag, loc, operation, span)                        +"timestamp"
+ │                                           0  ·               order     +"timestamp"                                                                                                                                                                 ·                                                                             ·
+ └── window                                  1  window          ·         ·                                                                                                                                                                            ("timestamp", age, message, tag, loc, operation, span)                        ·
+      │                                      1  ·               window 0  first_value("timestamp") OVER (ORDER BY "timestamp")                                                                                                                         ·                                                                             ·
+      │                                      1  ·               render 1  "timestamp" - first_value("timestamp") OVER (ORDER BY "timestamp")                                                                                                           ·                                                                             ·
+      └── render                             2  render          ·         ·                                                                                                                                                                            ("timestamp", """timestamp""", message, tag, loc, operation, span)            "timestamp"="""timestamp"""
+           │                                 2  ·               render 0  "timestamp"                                                                                                                                                                  ·                                                                             ·
+           │                                 2  ·               render 1  "timestamp"                                                                                                                                                                  ·                                                                             ·
+           │                                 2  ·               render 2  message                                                                                                                                                                      ·                                                                             ·
+           │                                 2  ·               render 3  tag                                                                                                                                                                          ·                                                                             ·
+           │                                 2  ·               render 4  loc                                                                                                                                                                          ·                                                                             ·
+           │                                 2  ·               render 5  operation                                                                                                                                                                    ·                                                                             ·
+           │                                 2  ·               render 6  span                                                                                                                                                                         ·                                                                             ·
+           └── window                        3  window          ·         ·                                                                                                                                                                            ("timestamp", message, tag, loc, operation, span)                             ·
+                │                            3  ·               window 0  first_value(test.crdb_internal.session_trace.operation) OVER (PARTITION BY test.crdb_internal.session_trace.span_idx ORDER BY test.crdb_internal.session_trace.message_idx)  ·                                                                             ·
+                │                            3  ·               render 4  first_value(test.crdb_internal.session_trace.operation) OVER (PARTITION BY test.crdb_internal.session_trace.span_idx ORDER BY test.crdb_internal.session_trace.message_idx)  ·                                                                             ·
+                └── render                   4  render          ·         ·                                                                                                                                                                            ("timestamp", message, tag, loc, operation, span, message_idx)                ·
+                     │                       4  ·               render 0  test.crdb_internal.session_trace."timestamp"                                                                                                                                 ·                                                                             ·
+                     │                       4  ·               render 1  test.crdb_internal.session_trace.message                                                                                                                                     ·                                                                             ·
+                     │                       4  ·               render 2  test.crdb_internal.session_trace.tag                                                                                                                                         ·                                                                             ·
+                     │                       4  ·               render 3  test.crdb_internal.session_trace.loc                                                                                                                                         ·                                                                             ·
+                     │                       4  ·               render 4  test.crdb_internal.session_trace.operation                                                                                                                                   ·                                                                             ·
+                     │                       4  ·               render 5  test.crdb_internal.session_trace.span_idx                                                                                                                                    ·                                                                             ·
+                     │                       4  ·               render 6  test.crdb_internal.session_trace.message_idx                                                                                                                                 ·                                                                             ·
+                     └── show trace for      5  show trace for  ·         ·                                                                                                                                                                            (span_idx, message_idx, "timestamp", duration, operation, loc, tag, message)  ·
+                          └── render         6  render          ·         ·                                                                                                                                                                            ("1")                                                                         "1"=CONST
+                               │             6  ·               render 0  1                                                                                                                                                                            ·                                                                             ·
+                               └── emptyrow  7  emptyrow        ·         ·                                                                                                                                                                            ()                                                                            ·
 
 # Ensure that all relevant statement types can be explained
 query TTT
@@ -136,7 +157,7 @@ EXPLAIN ALTER TABLE foo ADD COLUMN y INT
 alter table  ·  ·
 
 query TTT
-EXPLAIN (EXPRS) ALTER TABLE foo SPLIT AT VALUES (42)
+SELECT "Tree", "Field", "Description" FROM [EXPLAIN (VERBOSE) ALTER TABLE foo SPLIT AT VALUES (42)]
 ----
 split        ·              ·
  └── values  ·              ·

--- a/pkg/sql/logictest/testdata/logic_test/explain_plan
+++ b/pkg/sql/logictest/testdata/logic_test/explain_plan
@@ -31,7 +31,7 @@ scan  ·      ·
 ·     spans  ALL
 
 query TITTTTT
-EXPLAIN (METADATA) SELECT * FROM t
+EXPLAIN (VERBOSE) SELECT * FROM t
 ----
 scan  0  scan  ·      ·          (k, v)  k!=NULL; key(k)
 ·     0  ·     table  t@primary  ·       ·
@@ -65,7 +65,7 @@ values  ·     ·
 ·       size  1 column, 1 row
 
 query TTT
-EXPLAIN (EXPRS) SELECT * FROM t WITH ORDINALITY LIMIT 1 OFFSET 1
+SELECT "Tree", "Field", "Description" FROM [EXPLAIN (VERBOSE) SELECT * FROM t WITH ORDINALITY LIMIT 1 OFFSET 1]
 ----
 limit            ·       ·
  │               count   1
@@ -86,14 +86,14 @@ distinct        ·      ·
 ·               spans  ALL
 
 query TTT
-EXPLAIN (EXPRS) SELECT DISTINCT v FROM t LIMIT 1 OFFSET 1
+SELECT "Tree", "Field", "Description" FROM [EXPLAIN (VERBOSE) SELECT DISTINCT v FROM t LIMIT 1 OFFSET 1]
 ----
 limit                ·         ·
  │                   count     1
  │                   offset    1
  └── distinct        ·         ·
       └── render     ·         ·
-           │         render 0  v
+           │         render 0  test.public.t.v
            └── scan  ·         ·
 ·                    table     t@primary
 ·                    spans     ALL
@@ -104,25 +104,27 @@ statement ok
 PREPARE x AS SELECT DISTINCT v from t LIMIT $1
 
 query TTT
-EXPLAIN (EXPRS) EXECUTE x(3)
+SELECT "Tree", "Field", "Description" FROM [EXPLAIN (VERBOSE) EXECUTE x(3)]
 ----
 limit                ·         ·
  │                   count     3
  └── distinct        ·         ·
       └── render     ·         ·
-           │         render 0  v
+           │         render 0  test.public.t.v
            └── scan  ·         ·
 ·                    table     t@primary
 ·                    spans     ALL
 
 query TTT
-EXPLAIN (EXPRS) SELECT * FROM [EXECUTE x(3)]
+SELECT "Tree", "Field", "Description" FROM [
+EXPLAIN (VERBOSE) SELECT * FROM [EXECUTE x(3)]
+]
 ----
 limit                ·         ·
  │                   count     3
  └── distinct        ·         ·
       └── render     ·         ·
-           │         render 0  v
+           │         render 0  test.public.t.v
            └── scan  ·         ·
 ·                    table     t@primary
 ·                    spans     ALL
@@ -131,14 +133,16 @@ statement ok
 CREATE TABLE tc (a INT, b INT, INDEX c(a))
 
 query TITTTTT
-EXPLAIN (METADATA) SELECT * FROM tc WHERE a = 10 ORDER BY b
+EXPLAIN (VERBOSE) SELECT * FROM tc WHERE a = 10 ORDER BY b
 ----
-sort                  0  sort        ·      ·           (a, b)                                   a=CONST; +b
- │                    0  ·           order  +b          ·                                        ·
- └── render           1  render      ·      ·           (a, b)                                   a=CONST
-      └── index-join  2  index-join  ·      ·           (a, b, rowid[hidden,omitted])            a=CONST; rowid!=NULL; key(rowid)
-           ├── scan   3  scan        ·      ·           (a[omitted], b[omitted], rowid[hidden])  a=CONST; rowid!=NULL; key(rowid)
-           │          3  ·           table  tc@c        ·                                        ·
-           │          3  ·           spans  /10-/11     ·                                        ·
-           └── scan   3  scan        ·      ·           (a, b, rowid[hidden,omitted])            ·
-·                     3  ·           table  tc@primary  ·                                        ·
+sort                  0  sort        ·         ·                 (a, b)                                   a=CONST; +b
+ │                    0  ·           order     +b                ·                                        ·
+ └── render           1  render      ·         ·                 (a, b)                                   a=CONST
+      │               1  ·           render 0  test.public.tc.a  ·                                        ·
+      │               1  ·           render 1  test.public.tc.b  ·                                        ·
+      └── index-join  2  index-join  ·         ·                 (a, b, rowid[hidden,omitted])            a=CONST; rowid!=NULL; key(rowid)
+           ├── scan   3  scan        ·         ·                 (a[omitted], b[omitted], rowid[hidden])  a=CONST; rowid!=NULL; key(rowid)
+           │          3  ·           table     tc@c              ·                                        ·
+           │          3  ·           spans     /10-/11           ·                                        ·
+           └── scan   3  scan        ·         ·                 (a, b, rowid[hidden,omitted])            ·
+·                     3  ·           table     tc@primary        ·                                        ·

--- a/pkg/sql/logictest/testdata/logic_test/explain_types
+++ b/pkg/sql/logictest/testdata/logic_test/explain_types
@@ -45,7 +45,7 @@ render     0  render  ·         ·          (k int)                  k!=NULL; k
 ·          1  ·       spans     ALL        ·                        ·
 
 query TITTTTT
-EXPLAIN (TYPES,QUALIFY) SELECT k FROM t
+EXPLAIN (TYPES,VERBOSE) SELECT k FROM t
 ----
 render     0  render  ·         ·                       (k int)                  k!=NULL; key(k)
  │         0  ·       render 0  (test.public.t.k)[int]  ·                        ·

--- a/pkg/sql/logictest/testdata/logic_test/generators
+++ b/pkg/sql/logictest/testdata/logic_test/generators
@@ -187,7 +187,7 @@ SELECT t.*, u.*, generate_series(1,2), generate_series(3, 4) FROM t, u
 #·                         expr      generate_series(3, 4)
 
 query error pq: unimplemented: cannot use multiple set-returning functions in a single SELECT clause: "generate_series\(3, 4\)"
-EXPLAIN(EXPRS) SELECT t.*, u.*, generate_series(1,2), generate_series(3, 4) FROM t, u
+EXPLAIN (VERBOSE) SELECT t.*, u.*, generate_series(1,2), generate_series(3, 4) FROM t, u
 
 query TTII colnames
 SELECT t.*, u.*, a.*, b.* FROM t, u, generate_series(1, 2) AS a, generate_series(3, 4) AS b

--- a/pkg/sql/logictest/testdata/logic_test/insert
+++ b/pkg/sql/logictest/testdata/logic_test/insert
@@ -603,7 +603,9 @@ INSERT INTO select_t VALUES (1, 9), (8, 2), (3, 7), (6, 4)
 # Check that INSERT supports ORDER BY (MySQL extension)
 
 query TTT
-EXPLAIN (PLAN,EXPRS) INSERT INTO insert_t TABLE select_t ORDER BY v DESC
+SELECT "Tree", "Field", "Description" FROM [
+EXPLAIN (VERBOSE) INSERT INTO insert_t TABLE select_t ORDER BY v DESC
+]
 ----
 count                     ·          ·
  └── insert               ·          ·
@@ -614,8 +616,8 @@ count                     ·          ·
       └── sort            ·          ·
            │              order      -v
            └── render     ·          ·
-                │         render 0   x
-                │         render 1   v
+                │         render 0   test.public.select_t.x
+                │         render 1   test.public.select_t.v
                 └── scan  ·          ·
 ·                         table      select_t@primary
 ·                         spans      ALL
@@ -634,7 +636,9 @@ statement ok
 TRUNCATE TABLE insert_t
 
 query TTT
-EXPLAIN (PLAN,EXPRS) INSERT INTO insert_t SELECT * FROM select_t LIMIT 1
+SELECT "Tree", "Field", "Description" FROM [
+EXPLAIN (VERBOSE) INSERT INTO insert_t SELECT * FROM select_t LIMIT 1
+]
 ----
 count                     ·          ·
  └── insert               ·          ·
@@ -645,8 +649,8 @@ count                     ·          ·
       └── limit           ·          ·
            │              count      1
            └── render     ·          ·
-                │         render 0   x
-                │         render 1   v
+                │         render 0   test.public.select_t.x
+                │         render 1   test.public.select_t.v
                 └── scan  ·          ·
 ·                         table      select_t@primary
 ·                         spans      ALL

--- a/pkg/sql/logictest/testdata/logic_test/join
+++ b/pkg/sql/logictest/testdata/logic_test/join
@@ -400,11 +400,13 @@ x  x  y  b  d  e
 
 # Check EXPLAIN.
 query TTT
-EXPLAIN (EXPRS) SELECT * FROM onecolumn JOIN twocolumn USING(x)
+SELECT "Tree", "Field", "Description" FROM [
+EXPLAIN (VERBOSE) SELECT * FROM onecolumn JOIN twocolumn USING(x)
+]
 ----
 render          ·         ·
- │              render 0  x
- │              render 1  y
+ │              render 0  test.public.onecolumn.x
+ │              render 1  test.public.twocolumn.y
  └── join       ·         ·
       │         type      inner
       │         equality  (x) = (x)
@@ -417,13 +419,15 @@ render          ·         ·
 
 # Check EXPLAIN.
 query TTT
-EXPLAIN (EXPRS) SELECT * FROM twocolumn AS a JOIN twocolumn AS b ON a.x = b.y
+SELECT "Tree", "Field", "Description" FROM [
+EXPLAIN (VERBOSE) SELECT * FROM twocolumn AS a JOIN twocolumn AS b ON a.x = b.y
+]
 ----
 render          ·         ·
- │              render 0  x
- │              render 1  y
- │              render 2  x
- │              render 3  y
+ │              render 0  a.x
+ │              render 1  a.y
+ │              render 2  b.x
+ │              render 3  b.y
  └── join       ·         ·
       │         type      inner
       │         equality  (x) = (y)
@@ -436,13 +440,15 @@ render          ·         ·
 
 # Check EXPLAIN.
 query TTT
-EXPLAIN (EXPRS) SELECT * FROM twocolumn AS a JOIN twocolumn AS b ON a.x = 44
+SELECT "Tree", "Field", "Description" FROM [
+EXPLAIN (VERBOSE) SELECT * FROM twocolumn AS a JOIN twocolumn AS b ON a.x = 44
+]
 ----
 render          ·         ·
- │              render 0  x
- │              render 1  y
- │              render 2  x
- │              render 3  y
+ │              render 0  a.x
+ │              render 1  a.y
+ │              render 2  b.x
+ │              render 3  b.y
  └── join       ·         ·
       │         type      cross
       ├── scan  ·         ·
@@ -455,12 +461,14 @@ render          ·         ·
 
 # Check EXPLAIN.
 query TTT
-EXPLAIN (EXPRS) SELECT * FROM onecolumn AS a JOIN twocolumn AS b ON ((a.x)) = ((b.y))
+SELECT "Tree", "Field", "Description" FROM [
+EXPLAIN (VERBOSE) SELECT * FROM onecolumn AS a JOIN twocolumn AS b ON ((a.x)) = ((b.y))
+]
 ----
 render          ·         ·
- │              render 0  x
- │              render 1  x
- │              render 2  y
+ │              render 0  a.x
+ │              render 1  b.x
+ │              render 2  b.y
  └── join       ·         ·
       │         type      inner
       │         equality  (x) = (y)
@@ -473,12 +481,14 @@ render          ·         ·
 
 # Check EXPLAIN.
 query TTT
-EXPLAIN (EXPRS) SELECT * FROM onecolumn JOIN twocolumn ON onecolumn.x = twocolumn.y
+SELECT "Tree", "Field", "Description" FROM [
+EXPLAIN (VERBOSE) SELECT * FROM onecolumn JOIN twocolumn ON onecolumn.x = twocolumn.y
+]
 ----
 render          ·         ·
- │              render 0  x
- │              render 1  x
- │              render 2  y
+ │              render 0  test.public.onecolumn.x
+ │              render 1  test.public.twocolumn.x
+ │              render 2  test.public.twocolumn.y
  └── join       ·         ·
       │         type      inner
       │         equality  (x) = (y)
@@ -491,17 +501,19 @@ render          ·         ·
 
 
 query TTT
-EXPLAIN (EXPRS) SELECT * FROM (onecolumn CROSS JOIN twocolumn JOIN onecolumn AS a(b) ON a.b=twocolumn.x JOIN twocolumn AS c(d,e) ON a.b=c.d AND c.d=onecolumn.x) LIMIT 1
+SELECT "Tree", "Field", "Description" FROM [
+EXPLAIN (VERBOSE) SELECT * FROM (onecolumn CROSS JOIN twocolumn JOIN onecolumn AS a(b) ON a.b=twocolumn.x JOIN twocolumn AS c(d,e) ON a.b=c.d AND c.d=onecolumn.x) LIMIT 1
+]
 ----
 limit                          ·         ·
  │                             count     1
  └── render                    ·         ·
-      │                        render 0  x
-      │                        render 1  x
-      │                        render 2  y
-      │                        render 3  b
-      │                        render 4  d
-      │                        render 5  e
+      │                        render 0  test.public.onecolumn.x
+      │                        render 1  test.public.twocolumn.x
+      │                        render 2  test.public.twocolumn.y
+      │                        render 3  a.b
+      │                        render 4  c.d
+      │                        render 5  c.e
       └── join                 ·         ·
            │                   type      inner
            │                   equality  (b, x) = (d, d)
@@ -611,22 +623,25 @@ CREATE TABLE s(x INT); INSERT INTO s(x) VALUES (1),(2),(3),(4),(5),(6),(7),(8),(
 
 # THe following queries verify that only the necessary columns are scanned.
 query TITTTTT
-EXPLAIN (METADATA) SELECT a.x, b.y FROM twocolumn AS a, twocolumn AS b
+EXPLAIN (VERBOSE) SELECT a.x, b.y FROM twocolumn AS a, twocolumn AS b
 ----
-render          0  render  ·      ·                  (x, y)                                                                        ·
- └── join       1  join    ·      ·                  (x, y[omitted], rowid[hidden,omitted], x[omitted], y, rowid[hidden,omitted])  ·
-      │         1  ·       type   cross              ·                                                                             ·
-      ├── scan  2  scan    ·      ·                  (x, y[omitted], rowid[hidden,omitted])                                        rowid!=NULL; key(rowid)
-      │         2  ·       table  twocolumn@primary  ·                                                                             ·
-      │         2  ·       spans  ALL                ·                                                                             ·
-      └── scan  2  scan    ·      ·                  (x[omitted], y, rowid[hidden,omitted])                                        rowid!=NULL; key(rowid)
-·               2  ·       table  twocolumn@primary  ·                                                                             ·
-·               2  ·       spans  ALL                ·                                                                             ·
+render          0  render  ·         ·                  (x, y)                                                                        ·
+ │              0  ·       render 0  a.x                ·                                                                             ·
+ │              0  ·       render 1  b.y                ·                                                                             ·
+ └── join       1  join    ·         ·                  (x, y[omitted], rowid[hidden,omitted], x[omitted], y, rowid[hidden,omitted])  ·
+      │         1  ·       type      cross              ·                                                                             ·
+      ├── scan  2  scan    ·         ·                  (x, y[omitted], rowid[hidden,omitted])                                        rowid!=NULL; key(rowid)
+      │         2  ·       table     twocolumn@primary  ·                                                                             ·
+      │         2  ·       spans     ALL                ·                                                                             ·
+      └── scan  2  scan    ·         ·                  (x[omitted], y, rowid[hidden,omitted])                                        rowid!=NULL; key(rowid)
+·               2  ·       table     twocolumn@primary  ·                                                                             ·
+·               2  ·       spans     ALL                ·                                                                             ·
 
 query TITTTTT
-EXPLAIN (METADATA) SELECT b.y FROM (twocolumn AS a JOIN twocolumn AS b USING(x))
+EXPLAIN (VERBOSE) SELECT b.y FROM (twocolumn AS a JOIN twocolumn AS b USING(x))
 ----
 render          0  render  ·         ·                  (y)                                                                                    ·
+ │              0  ·       render 0  b.y                ·                                                                                      ·
  └── join       1  join    ·         ·                  (x[omitted], y[omitted], rowid[hidden,omitted], x[omitted], y, rowid[hidden,omitted])  ·
       │         1  ·       type      inner              ·                                                                                      ·
       │         1  ·       equality  (x) = (x)          ·                                                                                      ·
@@ -638,9 +653,10 @@ render          0  render  ·         ·                  (y)                   
 ·               2  ·       spans     ALL                ·                                                                                      ·
 
 query TITTTTT
-EXPLAIN (METADATA) SELECT b.y FROM (twocolumn AS a JOIN twocolumn AS b ON a.x = b.x)
+EXPLAIN (VERBOSE) SELECT b.y FROM (twocolumn AS a JOIN twocolumn AS b ON a.x = b.x)
 ----
 render          0  render  ·         ·                  (y)                                                                                    ·
+ │              0  ·       render 0  b.y                ·                                                                                      ·
  └── join       1  join    ·         ·                  (x[omitted], y[omitted], rowid[hidden,omitted], x[omitted], y, rowid[hidden,omitted])  ·
       │         1  ·       type      inner              ·                                                                                      ·
       │         1  ·       equality  (x) = (x)          ·                                                                                      ·
@@ -652,36 +668,53 @@ render          0  render  ·         ·                  (y)                   
 ·               2  ·       spans     ALL                ·                                                                                      ·
 
 query TITTTTT
-EXPLAIN (METADATA) SELECT a.x FROM (twocolumn AS a JOIN twocolumn AS b ON a.x < b.y)
+EXPLAIN (VERBOSE) SELECT a.x FROM (twocolumn AS a JOIN twocolumn AS b ON a.x < b.y)
 ----
-render          0  render  ·      ·                  (x)                                                                                    ·
- └── join       1  join    ·      ·                  (x, y[omitted], rowid[hidden,omitted], x[omitted], y[omitted], rowid[hidden,omitted])  ·
-      │         1  ·       type   inner              ·                                                                                      ·
-      ├── scan  2  scan    ·      ·                  (x, y[omitted], rowid[hidden,omitted])                                                 rowid!=NULL; key(rowid)
-      │         2  ·       table  twocolumn@primary  ·                                                                                      ·
-      │         2  ·       spans  ALL                ·                                                                                      ·
-      └── scan  2  scan    ·      ·                  (x[omitted], y, rowid[hidden,omitted])                                                 rowid!=NULL; key(rowid)
-·               2  ·       table  twocolumn@primary  ·                                                                                      ·
-·               2  ·       spans  ALL                ·                                                                                      ·
+render          0  render  ·         ·                  (x)                                                                                    ·
+ │              0  ·       render 0  a.x                ·                                                                                      ·
+ └── join       1  join    ·         ·                  (x, y[omitted], rowid[hidden,omitted], x[omitted], y[omitted], rowid[hidden,omitted])  ·
+      │         1  ·       type      inner              ·                                                                                      ·
+      │         1  ·       pred      a.x < b.y          ·                                                                                      ·
+      ├── scan  2  scan    ·         ·                  (x, y[omitted], rowid[hidden,omitted])                                                 rowid!=NULL; key(rowid)
+      │         2  ·       table     twocolumn@primary  ·                                                                                      ·
+      │         2  ·       spans     ALL                ·                                                                                      ·
+      └── scan  2  scan    ·         ·                  (x[omitted], y, rowid[hidden,omitted])                                                 rowid!=NULL; key(rowid)
+·               2  ·       table     twocolumn@primary  ·                                                                                      ·
+·               2  ·       spans     ALL                ·                                                                                      ·
 
 # Ensure that the ordering information for the result of joins is sane. (#12037)
 query TITTTTT
-EXPLAIN (METADATA) SELECT * FROM (SELECT * FROM (VALUES (9, 1), (8, 2)) AS a (u, k) ORDER BY k)
-                INNER JOIN (VALUES (1, 1), (2, 2)) AS b (k, w) USING (k) ORDER BY u
+EXPLAIN (VERBOSE) SELECT * FROM (SELECT * FROM (VALUES (9, 1), (8, 2)) AS a (u, k) ORDER BY k)
+                  INNER JOIN (VALUES (1, 1), (2, 2)) AS b (k, w) USING (k) ORDER BY u
 ----
-sort                             0  sort    ·         ·                  (k, u, w)                     +u
- │                               0  ·       order     +u                 ·                             ·
- └── render                      1  render  ·         ·                  (k, u, w)                     ·
-      └── render                 2  render  ·         ·                  (k, u, k[hidden,omitted], w)  ·
-           └── join              3  join    ·         ·                  (u, k, k[omitted], w)         ·
-                │                3  ·       type      inner              ·                             ·
-                │                3  ·       equality  (k) = (k)          ·                             ·
-                ├── sort         4  sort    ·         ·                  (u, k)                        +k
-                │    │           4  ·       order     +k                 ·                             ·
-                │    └── values  5  values  ·         ·                  (u, k)                        ·
-                │                5  ·       size      2 columns, 2 rows  ·                             ·
-                └── values       4  values  ·         ·                  (column1, column2)            ·
-·                                4  ·       size      2 columns, 2 rows  ·                             ·
+sort                             0  sort    ·              ·                  (k, u, w)                     +u
+ │                               0  ·       order          +u                 ·                             ·
+ └── render                      1  render  ·              ·                  (k, u, w)                     ·
+      │                          1  ·       render 0       k                  ·                             ·
+      │                          1  ·       render 1       u                  ·                             ·
+      │                          1  ·       render 2       b.w                ·                             ·
+      └── render                 2  render  ·              ·                  (k, u, k[hidden,omitted], w)  ·
+           │                     2  ·       render 0       k                  ·                             ·
+           │                     2  ·       render 1       u                  ·                             ·
+           │                     2  ·       render 2       NULL               ·                             ·
+           │                     2  ·       render 3       b.w                ·                             ·
+           └── join              3  join    ·              ·                  (u, k, k[omitted], w)         ·
+                │                3  ·       type           inner              ·                             ·
+                │                3  ·       equality       (k) = (k)          ·                             ·
+                ├── sort         4  sort    ·              ·                  (u, k)                        +k
+                │    │           4  ·       order          +k                 ·                             ·
+                │    └── values  5  values  ·              ·                  (u, k)                        ·
+                │                5  ·       size           2 columns, 2 rows  ·                             ·
+                │                5  ·       row 0, expr 0  9                  ·                             ·
+                │                5  ·       row 0, expr 1  1                  ·                             ·
+                │                5  ·       row 1, expr 0  8                  ·                             ·
+                │                5  ·       row 1, expr 1  2                  ·                             ·
+                └── values       4  values  ·              ·                  (column1, column2)            ·
+·                                4  ·       size           2 columns, 2 rows  ·                             ·
+·                                4  ·       row 0, expr 0  1                  ·                             ·
+·                                4  ·       row 0, expr 1  1                  ·                             ·
+·                                4  ·       row 1, expr 0  2                  ·                             ·
+·                                4  ·       row 1, expr 1  2                  ·                             ·
 
 # Ensure that large cross-joins are optimized somehow (#10633)
 statement ok
@@ -1078,18 +1111,20 @@ SELECT *
 4  6  NULL  NULL
 
 query TTT
-EXPLAIN(EXPRS)
+SELECT "Tree", "Field", "Description" FROM [
+EXPLAIN (VERBOSE)
 SELECT *
   FROM (SELECT * FROM pairs LEFT JOIN square ON b = sq AND a > 1 AND n < 6)
  WHERE b > 1 AND (n IS NULL OR n > 1) AND (n IS NULL OR a  < sq)
+]
 ----
 render               ·         ·
- │                   render 0  a
- │                   render 1  b
- │                   render 2  n
- │                   render 3  sq
+ │                   render 0  test.public.pairs.a
+ │                   render 1  test.public.pairs.b
+ │                   render 2  test.public.square.n
+ │                   render 3  test.public.square.sq
  └── filter          ·         ·
-      │              filter    ((n IS NULL) OR (n > 1)) AND ((n IS NULL) OR (a < sq))
+      │              filter    ((test.public.square.n IS NULL) OR (test.public.square.n > 1)) AND ((test.public.square.n IS NULL) OR (test.public.pairs.a < test.public.square.sq))
       └── join       ·         ·
            │         type      left outer
            │         equality  (b) = (sq)
@@ -1115,18 +1150,20 @@ NULL  NULL  5  25
 NULL  NULL  6  36
 
 query TTT
-EXPLAIN(EXPRS)
+SELECT "Tree", "Field", "Description" FROM [
+EXPLAIN (VERBOSE)
 SELECT *
   FROM (SELECT * FROM pairs RIGHT JOIN square ON b = sq AND a > 1 AND n < 6)
  WHERE (a IS NULL OR a > 2) AND n > 1 AND (a IS NULL OR a < sq)
+]
 ----
 render               ·         ·
- │                   render 0  a
- │                   render 1  b
- │                   render 2  n
- │                   render 3  sq
+ │                   render 0  test.public.pairs.a
+ │                   render 1  test.public.pairs.b
+ │                   render 2  test.public.square.n
+ │                   render 3  test.public.square.sq
  └── filter          ·         ·
-      │              filter    ((a IS NULL) OR (a > 2)) AND ((a IS NULL) OR (a < sq))
+      │              filter    ((test.public.pairs.a IS NULL) OR (test.public.pairs.a > 2)) AND ((test.public.pairs.a IS NULL) OR (test.public.pairs.a < test.public.square.sq))
       └── join       ·         ·
            │         type      right outer
            │         equality  (b) = (sq)
@@ -1141,16 +1178,18 @@ render               ·         ·
 
 # The simpler plan for an inner join, to compare.
 query TTT
-EXPLAIN(EXPRS)
+SELECT "Tree", "Field", "Description" FROM [
+EXPLAIN (VERBOSE)
 SELECT *
   FROM (SELECT * FROM pairs JOIN square ON b = sq AND a > 1 AND n < 6)
  WHERE (a IS NULL OR a > 2) AND n > 1 AND (a IS NULL OR a < sq)
+]
 ----
 render          ·         ·
- │              render 0  a
- │              render 1  b
- │              render 2  n
- │              render 3  sq
+ │              render 0  test.public.pairs.a
+ │              render 1  test.public.pairs.b
+ │              render 2  test.public.square.n
+ │              render 3  test.public.square.sq
  └── join       ·         ·
       │         type      inner
       │         equality  (b) = (sq)
@@ -2065,13 +2104,15 @@ INSERT INTO bar VALUES
 
 # Only a and c can be equality columns.
 query TTT
-EXPLAIN (EXPRS) SELECT * FROM foo NATURAL JOIN bar
+SELECT "Tree", "Field", "Description" FROM [
+EXPLAIN (VERBOSE) SELECT * FROM foo NATURAL JOIN bar
+]
 ----
 render          ·         ·
- │              render 0  a
- │              render 1  b
- │              render 2  c
- │              render 3  d
+ │              render 0  test.public.foo.a
+ │              render 1  test.public.foo.b
+ │              render 2  test.public.foo.c
+ │              render 3  test.public.foo.d
  └── join       ·         ·
       │         type      inner
       │         equality  (a, c) = (a, c)
@@ -2092,26 +2133,28 @@ SELECT * FROM foo NATURAL JOIN bar
 
 # b can't be an equality column.
 query TTT
-EXPLAIN (EXPRS) SELECT * FROM foo JOIN bar USING (b)
+SELECT "Tree", "Field", "Description" FROM [
+EXPLAIN (VERBOSE) SELECT * FROM foo JOIN bar USING (b)
+]
 ----
 render               ·         ·
- │                   render 0  b
- │                   render 1  a
- │                   render 2  c
- │                   render 3  d
- │                   render 4  a
- │                   render 5  c
- │                   render 6  d
+ │                   render 0  test.public.foo.b
+ │                   render 1  test.public.foo.a
+ │                   render 2  test.public.foo.c
+ │                   render 3  test.public.foo.d
+ │                   render 4  test.public.bar.a
+ │                   render 5  test.public.bar.c
+ │                   render 6  test.public.bar.d
  └── render          ·         ·
-      │              render 0  b
-      │              render 1  a
-      │              render 2  c
-      │              render 3  d
+      │              render 0  test.public.foo.b
+      │              render 1  test.public.foo.a
+      │              render 2  test.public.foo.c
+      │              render 3  test.public.foo.d
       │              render 4  NULL
-      │              render 5  a
+      │              render 5  test.public.bar.a
       │              render 6  NULL
-      │              render 7  c
-      │              render 8  d
+      │              render 7  test.public.bar.c
+      │              render 8  test.public.bar.d
       │              render 9  NULL
       └── join       ·         ·
            │         type      inner
@@ -2132,15 +2175,17 @@ SELECT * FROM foo JOIN bar USING (b)
 
 # Only a can be an equality column.
 query TTT
-EXPLAIN (EXPRS) SELECT * FROM foo JOIN bar USING (a, b)
+SELECT "Tree", "Field", "Description" FROM [
+EXPLAIN (VERBOSE) SELECT * FROM foo JOIN bar USING (a, b)
+]
 ----
 render          ·         ·
- │              render 0  a
- │              render 1  b
- │              render 2  c
- │              render 3  d
- │              render 4  c
- │              render 5  d
+ │              render 0  test.public.foo.a
+ │              render 1  test.public.foo.b
+ │              render 2  test.public.foo.c
+ │              render 3  test.public.foo.d
+ │              render 4  test.public.bar.c
+ │              render 5  test.public.bar.d
  └── join       ·         ·
       │         type      inner
       │         equality  (a) = (a)
@@ -2161,14 +2206,16 @@ SELECT * FROM foo JOIN bar USING (a, b)
 
 # Only a and c can be equality columns.
 query TTT
-EXPLAIN (EXPRS) SELECT * FROM foo JOIN bar USING (a, b, c)
+SELECT "Tree", "Field", "Description" FROM [
+EXPLAIN (VERBOSE) SELECT * FROM foo JOIN bar USING (a, b, c)
+]
 ----
 render          ·         ·
- │              render 0  a
- │              render 1  b
- │              render 2  c
- │              render 3  d
- │              render 4  d
+ │              render 0  test.public.foo.a
+ │              render 1  test.public.foo.b
+ │              render 2  test.public.foo.c
+ │              render 3  test.public.foo.d
+ │              render 4  test.public.bar.d
  └── join       ·         ·
       │         type      inner
       │         equality  (a, c) = (a, c)
@@ -2189,17 +2236,19 @@ SELECT * FROM foo JOIN bar USING (a, b, c)
 
 # b can't be an equality column.
 query TTT
-EXPLAIN (EXPRS) SELECT * FROM foo JOIN bar ON foo.b = bar.b
+SELECT "Tree", "Field", "Description" FROM [
+EXPLAIN (VERBOSE) SELECT * FROM foo JOIN bar ON foo.b = bar.b
+]
 ----
 render          ·         ·
- │              render 0  a
- │              render 1  b
- │              render 2  c
- │              render 3  d
- │              render 4  a
- │              render 5  b
- │              render 6  c
- │              render 7  d
+ │              render 0  test.public.foo.a
+ │              render 1  test.public.foo.b
+ │              render 2  test.public.foo.c
+ │              render 3  test.public.foo.d
+ │              render 4  test.public.bar.a
+ │              render 5  test.public.bar.b
+ │              render 6  test.public.bar.c
+ │              render 7  test.public.bar.d
  └── join       ·         ·
       │         type      inner
       │         pred      test.public.foo.b = test.public.bar.b
@@ -2219,17 +2268,19 @@ SELECT * FROM foo JOIN bar ON foo.b = bar.b
 
 # Only a can be an equality column.
 query TTT
-EXPLAIN (EXPRS) SELECT * FROM foo JOIN bar ON foo.a = bar.a AND foo.b = bar.b
+SELECT "Tree", "Field", "Description" FROM [
+EXPLAIN (VERBOSE) SELECT * FROM foo JOIN bar ON foo.a = bar.a AND foo.b = bar.b
+]
 ----
 render          ·         ·
- │              render 0  a
- │              render 1  b
- │              render 2  c
- │              render 3  d
- │              render 4  a
- │              render 5  b
- │              render 6  c
- │              render 7  d
+ │              render 0  test.public.foo.a
+ │              render 1  test.public.foo.b
+ │              render 2  test.public.foo.c
+ │              render 3  test.public.foo.d
+ │              render 4  test.public.bar.a
+ │              render 5  test.public.bar.b
+ │              render 6  test.public.bar.c
+ │              render 7  test.public.bar.d
  └── join       ·         ·
       │         type      inner
       │         equality  (a) = (a)
@@ -2249,17 +2300,19 @@ SELECT * FROM foo JOIN bar ON foo.a = bar.a AND foo.b = bar.b
 3  3  3  3  3  3  3  3
 
 query TTT
-EXPLAIN (EXPRS) SELECT * FROM foo, bar WHERE foo.b = bar.b
+SELECT "Tree", "Field", "Description" FROM [
+EXPLAIN (VERBOSE) SELECT * FROM foo, bar WHERE foo.b = bar.b
+]
 ----
 render          ·         ·
- │              render 0  a
- │              render 1  b
- │              render 2  c
- │              render 3  d
- │              render 4  a
- │              render 5  b
- │              render 6  c
- │              render 7  d
+ │              render 0  test.public.foo.a
+ │              render 1  test.public.foo.b
+ │              render 2  test.public.foo.c
+ │              render 3  test.public.foo.d
+ │              render 4  test.public.bar.a
+ │              render 5  test.public.bar.b
+ │              render 6  test.public.bar.c
+ │              render 7  test.public.bar.d
  └── join       ·         ·
       │         type      inner
       │         pred      test.public.foo.b = test.public.bar.b
@@ -2279,17 +2332,19 @@ SELECT * FROM foo, bar WHERE foo.b = bar.b
 
 # Only a can be an equality column.
 query TTT
-EXPLAIN (EXPRS) SELECT * FROM foo, bar WHERE foo.a = bar.a AND foo.b = bar.b
+SELECT "Tree", "Field", "Description" FROM [
+EXPLAIN (VERBOSE) SELECT * FROM foo, bar WHERE foo.a = bar.a AND foo.b = bar.b
+]
 ----
 render          ·         ·
- │              render 0  a
- │              render 1  b
- │              render 2  c
- │              render 3  d
- │              render 4  a
- │              render 5  b
- │              render 6  c
- │              render 7  d
+ │              render 0  test.public.foo.a
+ │              render 1  test.public.foo.b
+ │              render 2  test.public.foo.c
+ │              render 3  test.public.foo.d
+ │              render 4  test.public.bar.a
+ │              render 5  test.public.bar.b
+ │              render 6  test.public.bar.c
+ │              render 7  test.public.bar.d
  └── join       ·         ·
       │         type      inner
       │         equality  (a) = (a)
@@ -2310,15 +2365,17 @@ SELECT * FROM foo, bar WHERE foo.a = bar.a AND foo.b = bar.b
 
 # Only a and c can be equality columns.
 query TTT
-EXPLAIN (EXPRS) SELECT * FROM foo JOIN bar USING (a,b) WHERE foo.c = bar.c AND foo.d = bar.d
+SELECT "Tree", "Field", "Description" FROM [
+EXPLAIN (VERBOSE) SELECT * FROM foo JOIN bar USING (a,b) WHERE foo.c = bar.c AND foo.d = bar.d
+]
 ----
 render          ·         ·
- │              render 0  a
- │              render 1  b
- │              render 2  c
- │              render 3  d
- │              render 4  c
- │              render 5  d
+ │              render 0  test.public.foo.a
+ │              render 1  test.public.foo.b
+ │              render 2  test.public.foo.c
+ │              render 3  test.public.foo.d
+ │              render 4  test.public.bar.c
+ │              render 5  test.public.bar.d
  └── join       ·         ·
       │         type      inner
       │         equality  (a, c) = (a, c)

--- a/pkg/sql/logictest/testdata/logic_test/lookup_join
+++ b/pkg/sql/logictest/testdata/logic_test/lookup_join
@@ -186,31 +186,6 @@ SELECT "URL" FROM [EXPLAIN (DISTSQL) SELECT DISTINCT(authors.name) FROM authors,
 https://cockroachdb.github.io/distsqlplan/decode.html?eJysks-L6jAQx-_vr5A5KeSBaa2HwoMe3uH5WHSRvS0eYjOrWWum5AfsIv7vS9qDtmyjwh6bzGc-35nmBJokLsURLeSvwIFBBhsGtaESrSUTjtuihfyAfMpA6dq7cLxhUJJByE_glKsQcljSb6qBgUQnVNUUnRmQdxfEOrFDyOdndtWWx9u-iG2FaxQSTac51EYdhfkshHf7kJXByrt8VHBWJDCk5j-q3hIdOuJ0UJw8Iv5PSt_jfSI6-Hr0TkqPSIcIlzCDSdLBJJcAXpORaFD2_-ftkm_G-SfsPozUH6fCNzcukskfo3Z7Ny745I74s0cW-VdZp3Tput5I96zT_caLX6OtSVu869FPw2ZQ7rDdtCVvSnw2VDaa9nPVcM2BROva23n7sdDtVQh4DfMoPOvAvA8nUTiNm9MHzEkfnkXhLG7OovC0B2_Ov74CAAD__1i6oG0=
 
 
-query TTT
-EXPLAIN (EXPRS) SELECT DISTINCT(authors.name) FROM authors, books AS b1, books AS b2 WHERE b1.title = b2.title AND authors.book = b1.title AND b1.shelf <> b2.shelf
-----
-distinct                  ·               ·
- └── render               ·               ·
-      │                   render 0        name
-      └── join            ·               ·
-           │              type            inner
-           │              equality        (book) = (title)
-           ├── scan       ·               ·
-           │              table           authors@primary
-           │              spans           ALL
-           └── join       ·               ·
-                │         type            inner
-                │         equality        (title) = (title)
-                │         mergeJoinOrder  +"(title=title)"
-                │         pred            b1.shelf != b2.shelf
-                ├── scan  ·               ·
-                │         table           books@primary
-                │         spans           ALL
-                └── scan  ·               ·
-·                         table           books@primary
-·                         spans           ALL
-
-
 query TITTTTT colnames
 EXPLAIN (VERBOSE) SELECT DISTINCT(authors.name) FROM authors, books AS b1, books AS b2 WHERE b1.title = b2.title AND authors.book = b1.title AND b1.shelf <> b2.shelf
 ----

--- a/pkg/sql/logictest/testdata/logic_test/needed_columns
+++ b/pkg/sql/logictest/testdata/logic_test/needed_columns
@@ -1,108 +1,140 @@
 # LogicTest: default distsql distsql-metadata
 
 query TITTTTT
-EXPLAIN (METADATA,NOOPTIMIZE) SELECT 1 FROM (SELECT 2 AS s)
+EXPLAIN (VERBOSE,NOOPTIMIZE) SELECT 1 FROM (SELECT 2 AS s)
 ----
-render              0  render    ·  ·  ("1")  "1"=CONST
- └── render         1  render    ·  ·  (s)    s=CONST
-      └── emptyrow  2  emptyrow  ·  ·  ()     ·
+render              0  render    ·         ·  ("1")  "1"=CONST
+ │                  0  ·         render 0  1  ·      ·
+ └── render         1  render    ·         ·  (s)    s=CONST
+      │             1  ·         render 0  2  ·      ·
+      └── emptyrow  2  emptyrow  ·         ·  ()     ·
 
 # Propagation to data sources.
 query TITTTTT
-EXPLAIN (METADATA) SELECT 1 FROM (SELECT 2 AS s)
+EXPLAIN (VERBOSE) SELECT 1 FROM (SELECT 2 AS s)
 ----
-render              0  render    ·  ·  ("1")         "1"=CONST
- └── render         1  render    ·  ·  (s[omitted])  ·
-      └── emptyrow  2  emptyrow  ·  ·  ()            ·
+render              0  render    ·         ·     ("1")         "1"=CONST
+ │                  0  ·         render 0  1     ·             ·
+ └── render         1  render    ·         ·     (s[omitted])  ·
+      │             1  ·         render 0  NULL  ·             ·
+      └── emptyrow  2  emptyrow  ·         ·     ()            ·
 
 # Propagation through CREATE TABLE.
 query TITTTTT
-EXPLAIN (METADATA) CREATE TABLE t AS SELECT 1 FROM (SELECT 2 AS s)
+EXPLAIN (VERBOSE) CREATE TABLE t AS SELECT 1 FROM (SELECT 2 AS s)
 ----
-create table             0  create table  ·  ·  ()            ·
- └── render              1  render        ·  ·  ("1")         "1"=CONST
-      └── render         2  render        ·  ·  (s[omitted])  ·
-           └── emptyrow  3  emptyrow      ·  ·  ()            ·
+create table             0  create table  ·         ·     ()            ·
+ └── render              1  render        ·         ·     ("1")         "1"=CONST
+      │                  1  ·             render 0  1     ·             ·
+      └── render         2  render        ·         ·     (s[omitted])  ·
+           │             2  ·             render 0  NULL  ·             ·
+           └── emptyrow  3  emptyrow      ·         ·     ()            ·
 
 # Propagation through LIMIT.
 query TITTTTT
-EXPLAIN (METADATA) SELECT 1 FROM (SELECT 2 AS s) LIMIT 1
+EXPLAIN (VERBOSE) SELECT 1 FROM (SELECT 2 AS s) LIMIT 1
 ----
-limit                    0  limit     ·  ·  ("1")         "1"=CONST
- └── render              1  render    ·  ·  ("1")         "1"=CONST
-      └── render         2  render    ·  ·  (s[omitted])  ·
-           └── emptyrow  3  emptyrow  ·  ·  ()            ·
+limit                    0  limit     ·         ·     ("1")         "1"=CONST
+ │                       0  ·         count     1     ·             ·
+ └── render              1  render    ·         ·     ("1")         "1"=CONST
+      │                  1  ·         render 0  1     ·             ·
+      └── render         2  render    ·         ·     (s[omitted])  ·
+           │             2  ·         render 0  NULL  ·             ·
+           └── emptyrow  3  emptyrow  ·         ·     ()            ·
 
 query TITTTTT
-EXPLAIN (METADATA) SELECT 1 FROM (SELECT 2 AS s LIMIT 1)
+EXPLAIN (VERBOSE) SELECT 1 FROM (SELECT 2 AS s LIMIT 1)
 ----
-render                   0  render    ·  ·  ("1")         "1"=CONST
- └── limit               1  limit     ·  ·  (s[omitted])  ·
-      └── render         2  render    ·  ·  (s[omitted])  ·
-           └── emptyrow  3  emptyrow  ·  ·  ()            ·
+render                   0  render    ·         ·     ("1")         "1"=CONST
+ │                       0  ·         render 0  1     ·             ·
+ └── limit               1  limit     ·         ·     (s[omitted])  ·
+      │                  1  ·         count     1     ·             ·
+      └── render         2  render    ·         ·     (s[omitted])  ·
+           │             2  ·         render 0  NULL  ·             ·
+           └── emptyrow  3  emptyrow  ·         ·     ()            ·
 
 # Propagation through UNION.
 query TITTTTT
-EXPLAIN (METADATA) SELECT 1 FROM (SELECT 1 AS s UNION SELECT 2 AS s)
+EXPLAIN (VERBOSE) SELECT 1 FROM (SELECT 1 AS s UNION SELECT 2 AS s)
 ----
-render                   0  render    ·  ·  ("1")  "1"=CONST
- └── union               1  union     ·  ·  (s)    ·
-      ├── render         2  render    ·  ·  (s)    s=CONST
-      │    └── emptyrow  3  emptyrow  ·  ·  ()     ·
-      └── render         2  render    ·  ·  (s)    s=CONST
-           └── emptyrow  3  emptyrow  ·  ·  ()     ·
+render                   0  render    ·         ·  ("1")  "1"=CONST
+ │                       0  ·         render 0  1  ·      ·
+ └── union               1  union     ·         ·  (s)    ·
+      ├── render         2  render    ·         ·  (s)    s=CONST
+      │    │             2  ·         render 0  2  ·      ·
+      │    └── emptyrow  3  emptyrow  ·         ·  ()     ·
+      └── render         2  render    ·         ·  (s)    s=CONST
+           │             2  ·         render 0  1  ·      ·
+           └── emptyrow  3  emptyrow  ·         ·  ()     ·
 
 query TITTTTT
-EXPLAIN (METADATA) SELECT 1 FROM (SELECT 1 AS s UNION ALL SELECT 2 AS s)
+EXPLAIN (VERBOSE) SELECT 1 FROM (SELECT 1 AS s UNION ALL SELECT 2 AS s)
 ----
-render                   0  render    ·  ·  ("1")         "1"=CONST
- └── append              1  append    ·  ·  (s[omitted])  ·
-      ├── render         2  render    ·  ·  (s[omitted])  ·
-      │    └── emptyrow  3  emptyrow  ·  ·  ()            ·
-      └── render         2  render    ·  ·  (s[omitted])  ·
-           └── emptyrow  3  emptyrow  ·  ·  ()            ·
+render                   0  render    ·         ·     ("1")         "1"=CONST
+ │                       0  ·         render 0  1     ·             ·
+ └── append              1  append    ·         ·     (s[omitted])  ·
+      ├── render         2  render    ·         ·     (s[omitted])  ·
+      │    │             2  ·         render 0  NULL  ·             ·
+      │    └── emptyrow  3  emptyrow  ·         ·     ()            ·
+      └── render         2  render    ·         ·     (s[omitted])  ·
+           │             2  ·         render 0  NULL  ·             ·
+           └── emptyrow  3  emptyrow  ·         ·     ()            ·
 
 # Propagation through WITH ORDINALITY.
 query TITTTTT
-EXPLAIN (METADATA) SELECT 1 FROM (SELECT 1 AS s) WITH ORDINALITY
+EXPLAIN (VERBOSE) SELECT 1 FROM (SELECT 1 AS s) WITH ORDINALITY
 ----
-render                   0  render      ·  ·  ("1")                       "1"=CONST
- └── ordinality          1  ordinality  ·  ·  (s[omitted], "ordinality")  weak-key("ordinality")
-      └── render         2  render      ·  ·  (s[omitted])                ·
-           └── emptyrow  3  emptyrow    ·  ·  ()                          ·
+render                   0  render      ·         ·     ("1")                       "1"=CONST
+ │                       0  ·           render 0  1     ·                           ·
+ └── ordinality          1  ordinality  ·         ·     (s[omitted], "ordinality")  weak-key("ordinality")
+      └── render         2  render      ·         ·     (s[omitted])                ·
+           │             2  ·           render 0  NULL  ·                           ·
+           └── emptyrow  3  emptyrow    ·         ·     ()                          ·
 
 # Propagation through sort, when the sorting column is in the results.
 query TITTTTT
-EXPLAIN (METADATA) SELECT x FROM (SELECT 1 AS x, 2 AS y) ORDER BY x
+EXPLAIN (VERBOSE) SELECT x FROM (SELECT 1 AS x, 2 AS y) ORDER BY x
 ----
-render              0  render    ·  ·  (x)              x=CONST
- └── render         1  render    ·  ·  (x, y[omitted])  x=CONST
-      └── emptyrow  2  emptyrow  ·  ·  ()               ·
+render              0  render    ·         ·     (x)              x=CONST
+ │                  0  ·         render 0  x     ·                ·
+ └── render         1  render    ·         ·     (x, y[omitted])  x=CONST
+      │             1  ·         render 0  1     ·                ·
+      │             1  ·         render 1  NULL  ·                ·
+      └── emptyrow  2  emptyrow  ·         ·     ()               ·
 
 # Propagation through sort, when the sorting column is not in the results.
 query TITTTTT
-EXPLAIN (METADATA) SELECT x FROM (SELECT 1 AS x, 2 AS y, 3 AS z) ORDER BY y
+EXPLAIN (VERBOSE) SELECT x FROM (SELECT 1 AS x, 2 AS y, 3 AS z) ORDER BY y
 ----
-nosort                   0  nosort    ·      ·   (x)                 x=CONST
- │                       0  ·         order  +y  ·                   ·
- └── render              1  render    ·      ·   (x, y)              x=CONST; y=CONST
-      └── render         2  render    ·      ·   (x, y, z[omitted])  x=CONST; y=CONST
-           └── emptyrow  3  emptyrow  ·      ·   ()                  ·
+nosort                   0  nosort    ·         ·     (x)                 x=CONST
+ │                       0  ·         order     +y    ·                   ·
+ └── render              1  render    ·         ·     (x, y)              x=CONST; y=CONST
+      │                  1  ·         render 0  x     ·                   ·
+      │                  1  ·         render 1  y     ·                   ·
+      └── render         2  render    ·         ·     (x, y, z[omitted])  x=CONST; y=CONST
+           │             2  ·         render 0  1     ·                   ·
+           │             2  ·         render 1  2     ·                   ·
+           │             2  ·         render 2  NULL  ·                   ·
+           └── emptyrow  3  emptyrow  ·         ·     ()                  ·
 
 # Propagation to sub-queries.
 query TITTTTT
-EXPLAIN (METADATA) SELECT 1 = (SELECT 2 AS x FROM (SELECT 3 AS s)) AS y
+EXPLAIN (VERBOSE) SELECT 1 = (SELECT 2 AS x FROM (SELECT 3 AS s)) AS y
 ----
 root                               0  root      ·          ·                                     (y)           y=CONST
  ├── render                        1  render    ·          ·                                     (y)           y=CONST
+ │    │                            1  ·         render 0   @S1 = 1                               ·             ·
  │    └── emptyrow                 2  emptyrow  ·          ·                                     ()            ·
  └── subquery                      1  subquery  ·          ·                                     (y)           y=CONST
       │                            1  ·         id         @S1                                   ·             ·
       │                            1  ·         sql        (SELECT 2 AS x FROM (SELECT 3 AS s))  ·             ·
       │                            1  ·         exec mode  one row                               ·             ·
       └── limit                    2  limit     ·          ·                                     (x)           x=CONST
+           │                       2  ·         count      2                                     ·             ·
            └── render              3  render    ·          ·                                     (x)           x=CONST
+                │                  3  ·         render 0   2                                     ·             ·
                 └── render         4  render    ·          ·                                     (s[omitted])  ·
+                     │             4  ·         render 0   NULL                                  ·             ·
                      └── emptyrow  5  emptyrow  ·          ·                                     ()            ·
 
 # Propagation through table scans.
@@ -110,45 +142,52 @@ statement ok
 CREATE TABLE kv(k INT PRIMARY KEY, v INT)
 
 query TITTTTT
-EXPLAIN (METADATA) SELECT 1 FROM kv
+EXPLAIN (VERBOSE) SELECT 1 FROM kv
 ----
-render     0  render  ·      ·           ("1")                     "1"=CONST
- └── scan  1  scan    ·      ·           (k[omitted], v[omitted])  k!=NULL; key(k)
-·          1  ·       table  kv@primary  ·                         ·
-·          1  ·       spans  ALL         ·                         ·
+render     0  render  ·         ·           ("1")                     "1"=CONST
+ │         0  ·       render 0  1           ·                         ·
+ └── scan  1  scan    ·         ·           (k[omitted], v[omitted])  k!=NULL; key(k)
+·          1  ·       table     kv@primary  ·                         ·
+·          1  ·       spans     ALL         ·                         ·
 
 # Propagation through DISTINCT.
 query TITTTTT
-EXPLAIN (METADATA) SELECT DISTINCT v FROM kv
+EXPLAIN (VERBOSE) SELECT DISTINCT v FROM kv
 ----
-distinct        0  distinct  ·      ·           (v)              weak-key(v)
- └── render     1  render    ·      ·           (v)              ·
-      └── scan  2  scan      ·      ·           (k[omitted], v)  k!=NULL; key(k)
-·               2  ·         table  kv@primary  ·                ·
-·               2  ·         spans  ALL         ·                ·
+distinct        0  distinct  ·         ·                 (v)              weak-key(v)
+ └── render     1  render    ·         ·                 (v)              ·
+      │         1  ·         render 0  test.public.kv.v  ·                ·
+      └── scan  2  scan      ·         ·                 (k[omitted], v)  k!=NULL; key(k)
+·               2  ·         table     kv@primary        ·                ·
+·               2  ·         spans     ALL               ·                ·
 
 # Propagation through INSERT.
 query TITTTTT
-EXPLAIN (METADATA) INSERT INTO kv(k, v) SELECT 1, 2 FROM (SELECT 3 AS x, 4 AS y)
+EXPLAIN (VERBOSE) INSERT INTO kv(k, v) SELECT 1, 2 FROM (SELECT 3 AS x, 4 AS y)
 ----
-count                         0  count     ·     ·         ()                        ·
- └── insert                   1  insert    ·     ·         ()                        ·
-      │                       1  ·         into  kv(k, v)  ·                         ·
-      └── render              2  render    ·     ·         ("1", "2")                "1"=CONST; "2"=CONST
-           └── render         3  render    ·     ·         (x[omitted], y[omitted])  ·
-                └── emptyrow  4  emptyrow  ·     ·         ()                        ·
+count                         0  count     ·         ·         ()                        ·
+ └── insert                   1  insert    ·         ·         ()                        ·
+      │                       1  ·         into      kv(k, v)  ·                         ·
+      └── render              2  render    ·         ·         ("1", "2")                "1"=CONST; "2"=CONST
+           │                  2  ·         render 0  1         ·                         ·
+           │                  2  ·         render 1  2         ·                         ·
+           └── render         3  render    ·         ·         (x[omitted], y[omitted])  ·
+                │             3  ·         render 0  NULL      ·                         ·
+                │             3  ·         render 1  NULL      ·                         ·
+                └── emptyrow  4  emptyrow  ·         ·         ()                        ·
 
 # Propagation through DELETE.
 query TITTTTT
-EXPLAIN (METADATA) DELETE FROM kv WHERE k = 3
+EXPLAIN (VERBOSE) DELETE FROM kv WHERE k = 3
 ----
-count                0  count   ·      ·           ()               ·
- └── delete          1  delete  ·      ·           ()               ·
-      │              1  ·       from   kv          ·                ·
-      └── render     2  render  ·      ·           (k)              k=CONST; key()
-           └── scan  3  scan    ·      ·           (k, v[omitted])  k=CONST; key()
-·                    3  ·       table  kv@primary  ·                ·
-·                    3  ·       spans  /3-/3/#     ·                ·
+count                0  count   ·         ·                 ()               ·
+ └── delete          1  delete  ·         ·                 ()               ·
+      │              1  ·       from      kv                ·                ·
+      └── render     2  render  ·         ·                 (k)              k=CONST; key()
+           │         2  ·       render 0  test.public.kv.k  ·                ·
+           └── scan  3  scan    ·         ·                 (k, v[omitted])  k=CONST; key()
+·                    3  ·       table     kv@primary        ·                ·
+·                    3  ·       spans     /3-/3/#           ·                ·
 
 # Ensure that propagations through a render node removes the renders
 # and properly propagates the remaining needed columns.

--- a/pkg/sql/logictest/testdata/logic_test/order_by
+++ b/pkg/sql/logictest/testdata/logic_test/order_by
@@ -197,7 +197,7 @@ nosort             ·      ·
 ·                  spans  ALL
 
 query TITTTTT
-EXPLAIN(METADATA) SELECT * FROM t ORDER BY (b, t.*)
+EXPLAIN (VERBOSE) SELECT * FROM t ORDER BY (b, t.*)
 ----
 sort       0  sort  ·      ·          (a, b, c)  a!=NULL; key(a); +b,+a
  │         0  ·     order  +b,+a,+c   ·          ·
@@ -206,7 +206,7 @@ sort       0  sort  ·      ·          (a, b, c)  a!=NULL; key(a); +b,+a
 ·          1  ·     spans  ALL        ·          ·
 
 query TITTTTT
-EXPLAIN(METADATA) SELECT * FROM t ORDER BY (b, a), c
+EXPLAIN (VERBOSE) SELECT * FROM t ORDER BY (b, a), c
 ----
 sort       0  sort  ·      ·          (a, b, c)  a!=NULL; key(a); +b,+a
  │         0  ·     order  +b,+a,+c   ·          ·
@@ -215,7 +215,7 @@ sort       0  sort  ·      ·          (a, b, c)  a!=NULL; key(a); +b,+a
 ·          1  ·     spans  ALL        ·          ·
 
 query TITTTTT
-EXPLAIN(METADATA) SELECT * FROM t ORDER BY b, (a, c)
+EXPLAIN (VERBOSE) SELECT * FROM t ORDER BY b, (a, c)
 ----
 sort       0  sort  ·      ·          (a, b, c)  a!=NULL; key(a); +b,+a
  │         0  ·     order  +b,+a,+c   ·          ·
@@ -224,7 +224,7 @@ sort       0  sort  ·      ·          (a, b, c)  a!=NULL; key(a); +b,+a
 ·          1  ·     spans  ALL        ·          ·
 
 query TITTTTT
-EXPLAIN(METADATA) SELECT * FROM t ORDER BY (b, (a, c))
+EXPLAIN (VERBOSE) SELECT * FROM t ORDER BY (b, (a, c))
 ----
 sort       0  sort  ·      ·          (a, b, c)  a!=NULL; key(a); +b,+a
  │         0  ·     order  +b,+a,+c   ·          ·
@@ -375,36 +375,39 @@ nosort          ·      ·
 
 # Check that the sort key reuses the existing render.
 query TITTTTT
-EXPLAIN (METADATA) SELECT b+2 FROM t ORDER BY b+2
+EXPLAIN (VERBOSE) SELECT b+2 FROM t ORDER BY b+2
 ----
-sort            0  sort    ·      ·          ("b + 2")                    +"b + 2"
- │              0  ·       order  +"b + 2"   ·                            ·
- └── render     1  render  ·      ·          ("b + 2")                    ·
-      └── scan  2  scan    ·      ·          (a[omitted], b, c[omitted])  a!=NULL; key(a)
-·               2  ·       table  t@primary  ·                            ·
-·               2  ·       spans  ALL        ·                            ·
+sort            0  sort    ·         ·                    ("b + 2")                    +"b + 2"
+ │              0  ·       order     +"b + 2"             ·                            ·
+ └── render     1  render  ·         ·                    ("b + 2")                    ·
+      │         1  ·       render 0  test.public.t.b + 2  ·                            ·
+      └── scan  2  scan    ·         ·                    (a[omitted], b, c[omitted])  a!=NULL; key(a)
+·               2  ·       table     t@primary            ·                            ·
+·               2  ·       spans     ALL                  ·                            ·
 
 # Check that the sort picks up a renamed render properly.
 query TITTTTT
-EXPLAIN (METADATA) SELECT b+2 AS y FROM t ORDER BY y
+EXPLAIN (VERBOSE) SELECT b+2 AS y FROM t ORDER BY y
 ----
-sort            0  sort    ·      ·          (y)                          +y
- │              0  ·       order  +y         ·                            ·
- └── render     1  render  ·      ·          (y)                          ·
-      └── scan  2  scan    ·      ·          (a[omitted], b, c[omitted])  a!=NULL; key(a)
-·               2  ·       table  t@primary  ·                            ·
-·               2  ·       spans  ALL        ·                            ·
+sort            0  sort    ·         ·                    (y)                          +y
+ │              0  ·       order     +y                   ·                            ·
+ └── render     1  render  ·         ·                    (y)                          ·
+      │         1  ·       render 0  test.public.t.b + 2  ·                            ·
+      └── scan  2  scan    ·         ·                    (a[omitted], b, c[omitted])  a!=NULL; key(a)
+·               2  ·       table     t@primary            ·                            ·
+·               2  ·       spans     ALL                  ·                            ·
 
 # Check that the sort reuses a render behind a rename properly.
 query TITTTTT
-EXPLAIN (METADATA) SELECT b+2 AS y FROM t ORDER BY b+2
+EXPLAIN (VERBOSE) SELECT b+2 AS y FROM t ORDER BY b+2
 ----
-sort            0  sort    ·      ·          (y)                          +y
- │              0  ·       order  +y         ·                            ·
- └── render     1  render  ·      ·          (y)                          ·
-      └── scan  2  scan    ·      ·          (a[omitted], b, c[omitted])  a!=NULL; key(a)
-·               2  ·       table  t@primary  ·                            ·
-·               2  ·       spans  ALL        ·                            ·
+sort            0  sort    ·         ·                    (y)                          +y
+ │              0  ·       order     +y                   ·                            ·
+ └── render     1  render  ·         ·                    (y)                          ·
+      │         1  ·       render 0  test.public.t.b + 2  ·                            ·
+      └── scan  2  scan    ·         ·                    (a[omitted], b, c[omitted])  a!=NULL; key(a)
+·               2  ·       table     t@primary            ·                            ·
+·               2  ·       spans     ALL                  ·                            ·
 
 statement ok
 CREATE TABLE abc (
@@ -612,14 +615,17 @@ render        ·      ·
 
 # Verify that the ordering of the primary index is still used for the outer sort.
 query TITTTTT
-EXPLAIN (METADATA) SELECT * FROM (SELECT b, c FROM abc WHERE a=1 ORDER BY a,b) ORDER BY b,c
+EXPLAIN (VERBOSE) SELECT * FROM (SELECT b, c FROM abc WHERE a=1 ORDER BY a,b) ORDER BY b,c
 ----
-nosort          0  nosort  ·      ·            (b, c)                          b!=NULL; c!=NULL; key(b,c); +b,+c
- │              0  ·       order  +b,+c        ·                               ·
- └── render     1  render  ·      ·            (b, c, a[omitted])              a=CONST; b!=NULL; c!=NULL; key(b,c); +b,+c
-      └── scan  2  scan    ·      ·            (a[omitted], b, c, d[omitted])  a=CONST; b!=NULL; c!=NULL; key(b,c); +b,+c
-·               2  ·       table  abc@primary  ·                               ·
-·               2  ·       spans  /1-/2        ·                               ·
+nosort          0  nosort  ·         ·                  (b, c)                          b!=NULL; c!=NULL; key(b,c); +b,+c
+ │              0  ·       order     +b,+c              ·                               ·
+ └── render     1  render  ·         ·                  (b, c, a[omitted])              a=CONST; b!=NULL; c!=NULL; key(b,c); +b,+c
+      │         1  ·       render 0  test.public.abc.b  ·                               ·
+      │         1  ·       render 1  test.public.abc.c  ·                               ·
+      │         1  ·       render 2  NULL               ·                               ·
+      └── scan  2  scan    ·         ·                  (a[omitted], b, c, d[omitted])  a=CONST; b!=NULL; c!=NULL; key(b,c); +b,+c
+·               2  ·       table     abc@primary        ·                               ·
+·               2  ·       spans     /1-/2              ·                               ·
 
 statement ok
 CREATE TABLE bar (id INT PRIMARY KEY, baz STRING, UNIQUE INDEX i_bar (baz))
@@ -628,7 +634,7 @@ statement ok
 INSERT INTO bar VALUES (0, NULL), (1, NULL)
 
 query TITTTTT
-EXPLAIN (METADATA) SELECT * FROM bar ORDER BY baz, id
+EXPLAIN (VERBOSE) SELECT * FROM bar ORDER BY baz, id
 ----
 sort       0  sort  ·      ·          (id, baz)  weak-key(baz); +baz,+id
  │         0  ·     order  +baz,+id   ·          ·
@@ -727,12 +733,15 @@ NaN
 1
 
 query TITTTTT
-EXPLAIN (METADATA) SELECT * FROM (SELECT * FROM (VALUES ('a'), ('b'), ('c')) AS c(x) ORDER BY x)
+EXPLAIN (VERBOSE) SELECT * FROM (SELECT * FROM (VALUES ('a'), ('b'), ('c')) AS c(x) ORDER BY x)
 ----
-sort         0  sort    ·      ·                 (x)  +x
- │           0  ·       order  +x                ·    ·
- └── values  1  values  ·      ·                 (x)  ·
-·            1  ·       size   1 column, 3 rows  ·    ·
+sort         0  sort    ·              ·                 (x)  +x
+ │           0  ·       order          +x                ·    ·
+ └── values  1  values  ·              ·                 (x)  ·
+·            1  ·       size           1 column, 3 rows  ·    ·
+·            1  ·       row 0, expr 0  'a'               ·    ·
+·            1  ·       row 1, expr 0  'b'               ·    ·
+·            1  ·       row 2, expr 0  'c'               ·    ·
 
 query TTT
 EXPLAIN SELECT * FROM (VALUES ('a'), ('b'), ('c')) WITH ORDINALITY ORDER BY ordinality ASC
@@ -751,55 +760,70 @@ sort              ·      ·
 ·                 size   1 column, 3 rows
 
 query TITTTTT
-EXPLAIN (METADATA) SELECT * FROM (SELECT * FROM (VALUES ('a'), ('b'), ('c')) AS c(x)) WITH ORDINALITY
+EXPLAIN (VERBOSE) SELECT * FROM (SELECT * FROM (VALUES ('a'), ('b'), ('c')) AS c(x)) WITH ORDINALITY
 ----
-ordinality   0  ordinality  ·     ·                 (x, "ordinality")  weak-key("ordinality")
- └── values  1  values      ·     ·                 (x)                ·
-·            1  ·           size  1 column, 3 rows  ·                  ·
+ordinality   0  ordinality  ·              ·                 (x, "ordinality")  weak-key("ordinality")
+ └── values  1  values      ·              ·                 (x)                ·
+·            1  ·           size           1 column, 3 rows  ·                  ·
+·            1  ·           row 0, expr 0  'a'               ·                  ·
+·            1  ·           row 1, expr 0  'b'               ·                  ·
+·            1  ·           row 2, expr 0  'c'               ·                  ·
 
 query TITTTTT
-EXPLAIN (METADATA) SELECT * FROM (SELECT * FROM (VALUES ('a'), ('b'), ('c')) AS c(x) ORDER BY x) WITH ORDINALITY
+EXPLAIN (VERBOSE) SELECT * FROM (SELECT * FROM (VALUES ('a'), ('b'), ('c')) AS c(x) ORDER BY x) WITH ORDINALITY
 ----
-ordinality        0  ordinality  ·      ·                 (x, "ordinality")  weak-key("ordinality")
- └── sort         1  sort        ·      ·                 (x)                +x
-      │           1  ·           order  +x                ·                  ·
-      └── values  2  values      ·      ·                 (x)                ·
-·                 2  ·           size   1 column, 3 rows  ·                  ·
+ordinality        0  ordinality  ·              ·                 (x, "ordinality")  weak-key("ordinality")
+ └── sort         1  sort        ·              ·                 (x)                +x
+      │           1  ·           order          +x                ·                  ·
+      └── values  2  values      ·              ·                 (x)                ·
+·                 2  ·           size           1 column, 3 rows  ·                  ·
+·                 2  ·           row 0, expr 0  'a'               ·                  ·
+·                 2  ·           row 1, expr 0  'b'               ·                  ·
+·                 2  ·           row 2, expr 0  'c'               ·                  ·
 
 # Check that the ordering of the source does not propagate blindly to RETURNING.
 query TITTTTT
-EXPLAIN (METADATA) INSERT INTO t(a, b) SELECT * FROM (SELECT 1 AS x, 2 AS y) ORDER BY x RETURNING b
+EXPLAIN (VERBOSE) INSERT INTO t(a, b) SELECT * FROM (SELECT 1 AS x, 2 AS y) ORDER BY x RETURNING b
 ----
-render                        0  render    ·     ·        (b)        ·
- └── run                      1  run       ·     ·        (a, b, c)  ·
-      └── insert              2  insert    ·     ·        (a, b, c)  ·
-           │                  2  ·         into  t(a, b)  ·          ·
-           └── render         3  render    ·     ·        (x, y)     x=CONST; y=CONST
-                └── emptyrow  4  emptyrow  ·     ·        ()         ·
+render                        0  render    ·         ·                (b)        ·
+ │                            0  ·         render 0  test.public.t.b  ·          ·
+ └── run                      1  run       ·         ·                (a, b, c)  ·
+      └── insert              2  insert    ·         ·                (a, b, c)  ·
+           │                  2  ·         into      t(a, b)          ·          ·
+           └── render         3  render    ·         ·                (x, y)     x=CONST; y=CONST
+                │             3  ·         render 0  1                ·          ·
+                │             3  ·         render 1  2                ·          ·
+                └── emptyrow  4  emptyrow  ·         ·                ()         ·
 
 query TITTTTT
-EXPLAIN (METADATA) DELETE FROM t WHERE a = 3 RETURNING b
+EXPLAIN (VERBOSE) DELETE FROM t WHERE a = 3 RETURNING b
 ----
-render               0  render  ·      ·          (b)        key()
- └── run             1  run     ·      ·          (a, b, c)  a=CONST; key()
-      └── delete     2  delete  ·      ·          (a, b, c)  a=CONST; key()
-           │         2  ·       from   t          ·          ·
-           └── scan  3  scan    ·      ·          (a, b, c)  a=CONST; key()
-·                    3  ·       table  t@primary  ·          ·
-·                    3  ·       spans  /3-/3/#    ·          ·
+render               0  render  ·         ·                (b)        key()
+ │                   0  ·       render 0  test.public.t.b  ·          ·
+ └── run             1  run     ·         ·                (a, b, c)  a=CONST; key()
+      └── delete     2  delete  ·         ·                (a, b, c)  a=CONST; key()
+           │         2  ·       from      t                ·          ·
+           └── scan  3  scan    ·         ·                (a, b, c)  a=CONST; key()
+·                    3  ·       table     t@primary        ·          ·
+·                    3  ·       spans     /3-/3/#          ·          ·
 
 query TITTTTT
-EXPLAIN (METADATA) UPDATE t SET c = TRUE RETURNING b
+EXPLAIN (VERBOSE) UPDATE t SET c = TRUE RETURNING b
 ----
-render                    0  render  ·      ·          (b)                ·
- └── run                  1  run     ·      ·          (a, b, c)          ·
-      └── update          2  update  ·      ·          (a, b, c)          ·
-           │              2  ·       table  t          ·                  ·
-           │              2  ·       set    c          ·                  ·
-           └── render     3  render  ·      ·          (a, b, c, "true")  "true"=CONST; a!=NULL; key(a)
-                └── scan  4  scan    ·      ·          (a, b, c)          a!=NULL; key(a)
-·                         4  ·       table  t@primary  ·                  ·
-·                         4  ·       spans  ALL        ·                  ·
+render                    0  render  ·         ·                (b)                ·
+ │                        0  ·       render 0  test.public.t.b  ·                  ·
+ └── run                  1  run     ·         ·                (a, b, c)          ·
+      └── update          2  update  ·         ·                (a, b, c)          ·
+           │              2  ·       table     t                ·                  ·
+           │              2  ·       set       c                ·                  ·
+           └── render     3  render  ·         ·                (a, b, c, "true")  "true"=CONST; a!=NULL; key(a)
+                │         3  ·       render 0  test.public.t.a  ·                  ·
+                │         3  ·       render 1  test.public.t.b  ·                  ·
+                │         3  ·       render 2  test.public.t.c  ·                  ·
+                │         3  ·       render 3  true             ·                  ·
+                └── scan  4  scan    ·         ·                (a, b, c)          a!=NULL; key(a)
+·                         4  ·       table     t@primary        ·                  ·
+·                         4  ·       spans     ALL              ·                  ·
 
 statement ok
 CREATE TABLE uvwxyz (
@@ -816,12 +840,15 @@ CREATE TABLE uvwxyz (
 # Verify that the outer ordering is propagated to index selection and we choose
 # the index that avoids any sorting.
 query TITTTTT
-EXPLAIN (METADATA) SELECT * FROM (SELECT y, w, x FROM uvwxyz WHERE y = 1 ORDER BY w) ORDER BY w, x
+EXPLAIN (VERBOSE) SELECT * FROM (SELECT y, w, x FROM uvwxyz WHERE y = 1 ORDER BY w) ORDER BY w, x
 ----
-render     0  render  ·      ·            (y, w, x)                                                             y=CONST; +w,+x
- └── scan  1  scan    ·      ·            (u[omitted], v[omitted], w, x, y, z[omitted], rowid[hidden,omitted])  y=CONST; rowid!=NULL; weak-key(u,v,w,x,z,rowid); +w,+x
-·          1  ·       table  uvwxyz@ywxz  ·                                                                     ·
-·          1  ·       spans  /1-/2        ·                                                                     ·
+render     0  render  ·         ·                     (y, w, x)                                                             y=CONST; +w,+x
+ │         0  ·       render 0  test.public.uvwxyz.y  ·                                                                     ·
+ │         0  ·       render 1  test.public.uvwxyz.w  ·                                                                     ·
+ │         0  ·       render 2  test.public.uvwxyz.x  ·                                                                     ·
+ └── scan  1  scan    ·         ·                     (u[omitted], v[omitted], w, x, y, z[omitted], rowid[hidden,omitted])  y=CONST; rowid!=NULL; weak-key(u,v,w,x,z,rowid); +w,+x
+·          1  ·       table     uvwxyz@ywxz           ·                                                                     ·
+·          1  ·       spans     /1-/2                 ·                                                                     ·
 
 
 statement ok
@@ -836,11 +863,16 @@ CREATE TABLE blocks (
 # Test that ordering goes "through" a renderNode that has a duplicate render of
 # an order-by column (#13696).
 query TITTTTT
-EXPLAIN (METADATA) SELECT block_id,writer_id,block_num,block_id FROM blocks ORDER BY block_id, writer_id, block_num LIMIT 1
+EXPLAIN (VERBOSE) SELECT block_id,writer_id,block_num,block_id FROM blocks ORDER BY block_id, writer_id, block_num LIMIT 1
 ----
-limit           0  limit   ·      ·               (block_id, writer_id, block_num, block_id)            block_id=block_id; block_id!=NULL; writer_id!=NULL; block_num!=NULL; key(block_id,writer_id,block_num); +block_id,+writer_id,+block_num
- └── render     1  render  ·      ·               (block_id, writer_id, block_num, block_id)            block_id=block_id; block_id!=NULL; writer_id!=NULL; block_num!=NULL; key(block_id,writer_id,block_num); +block_id,+writer_id,+block_num
-      └── scan  2  scan    ·      ·               (block_id, writer_id, block_num, raw_bytes[omitted])  block_id!=NULL; writer_id!=NULL; block_num!=NULL; key(block_id,writer_id,block_num); +block_id,+writer_id,+block_num
-·               2  ·       table  blocks@primary  ·                                                     ·
-·               2  ·       spans  ALL             ·                                                     ·
-·               2  ·       limit  1               ·                                                     ·
+limit           0  limit   ·         ·                             (block_id, writer_id, block_num, block_id)            block_id=block_id; block_id!=NULL; writer_id!=NULL; block_num!=NULL; key(block_id,writer_id,block_num); +block_id,+writer_id,+block_num
+ │              0  ·       count     1                             ·                                                     ·
+ └── render     1  render  ·         ·                             (block_id, writer_id, block_num, block_id)            block_id=block_id; block_id!=NULL; writer_id!=NULL; block_num!=NULL; key(block_id,writer_id,block_num); +block_id,+writer_id,+block_num
+      │         1  ·       render 0  test.public.blocks.block_id   ·                                                     ·
+      │         1  ·       render 1  test.public.blocks.writer_id  ·                                                     ·
+      │         1  ·       render 2  test.public.blocks.block_num  ·                                                     ·
+      │         1  ·       render 3  test.public.blocks.block_id   ·                                                     ·
+      └── scan  2  scan    ·         ·                             (block_id, writer_id, block_num, raw_bytes[omitted])  block_id!=NULL; writer_id!=NULL; block_num!=NULL; key(block_id,writer_id,block_num); +block_id,+writer_id,+block_num
+·               2  ·       table     blocks@primary                ·                                                     ·
+·               2  ·       spans     ALL                           ·                                                     ·
+·               2  ·       limit     1                             ·                                                     ·

--- a/pkg/sql/logictest/testdata/logic_test/order_by_index
+++ b/pkg/sql/logictest/testdata/logic_test/order_by_index
@@ -4,47 +4,56 @@ statement ok
 CREATE TABLE kv(k INT PRIMARY KEY, v INT); CREATE INDEX foo ON kv(v DESC)
 
 query TITTTTT
-EXPLAIN (METADATA) SELECT v FROM kv ORDER BY PRIMARY KEY kv
+EXPLAIN (VERBOSE) SELECT v FROM kv ORDER BY PRIMARY KEY kv
 ----
-nosort          0  nosort  ·      ·           (v)     ·
- │              0  ·       order  +k          ·       ·
- └── render     1  render  ·      ·           (v, k)  k!=NULL; key(k); +k
-      └── scan  2  scan    ·      ·           (k, v)  k!=NULL; key(k); +k
-·               2  ·       table  kv@primary  ·       ·
-·               2  ·       spans  ALL         ·       ·
+nosort          0  nosort  ·         ·                 (v)     ·
+ │              0  ·       order     +k                ·       ·
+ └── render     1  render  ·         ·                 (v, k)  k!=NULL; key(k); +k
+      │         1  ·       render 0  test.public.kv.v  ·       ·
+      │         1  ·       render 1  test.public.kv.k  ·       ·
+      └── scan  2  scan    ·         ·                 (k, v)  k!=NULL; key(k); +k
+·               2  ·       table     kv@primary        ·       ·
+·               2  ·       spans     ALL               ·       ·
 
 query TITTTTT
-EXPLAIN (METADATA) SELECT v FROM kv ORDER BY PRIMARY KEY kv ASC
+EXPLAIN (VERBOSE) SELECT v FROM kv ORDER BY PRIMARY KEY kv ASC
 ----
-nosort          0  nosort  ·      ·           (v)     ·
- │              0  ·       order  +k          ·       ·
- └── render     1  render  ·      ·           (v, k)  k!=NULL; key(k); +k
-      └── scan  2  scan    ·      ·           (k, v)  k!=NULL; key(k); +k
-·               2  ·       table  kv@primary  ·       ·
-·               2  ·       spans  ALL         ·       ·
+nosort          0  nosort  ·         ·                 (v)     ·
+ │              0  ·       order     +k                ·       ·
+ └── render     1  render  ·         ·                 (v, k)  k!=NULL; key(k); +k
+      │         1  ·       render 0  test.public.kv.v  ·       ·
+      │         1  ·       render 1  test.public.kv.k  ·       ·
+      └── scan  2  scan    ·         ·                 (k, v)  k!=NULL; key(k); +k
+·               2  ·       table     kv@primary        ·       ·
+·               2  ·       spans     ALL               ·       ·
 
 query TITTTTT
-EXPLAIN (METADATA) SELECT v FROM kv ORDER BY PRIMARY KEY kv DESC
+EXPLAIN (VERBOSE) SELECT v FROM kv ORDER BY PRIMARY KEY kv DESC
 ----
-nosort             0  nosort   ·      ·           (v)     ·
- │                 0  ·        order  -k          ·       ·
- └── render        1  render   ·      ·           (v, k)  k!=NULL; key(k); -k
-      └── revscan  2  revscan  ·      ·           (k, v)  k!=NULL; key(k); -k
-·                  2  ·        table  kv@primary  ·       ·
-·                  2  ·        spans  ALL         ·       ·
+nosort             0  nosort   ·         ·                 (v)     ·
+ │                 0  ·        order     -k                ·       ·
+ └── render        1  render   ·         ·                 (v, k)  k!=NULL; key(k); -k
+      │            1  ·        render 0  test.public.kv.v  ·       ·
+      │            1  ·        render 1  test.public.kv.k  ·       ·
+      └── revscan  2  revscan  ·         ·                 (k, v)  k!=NULL; key(k); -k
+·                  2  ·        table     kv@primary        ·       ·
+·                  2  ·        spans     ALL               ·       ·
 
 query TITTTTT
-EXPLAIN (METADATA) SELECT k FROM kv ORDER BY v, PRIMARY KEY kv, v-2
+EXPLAIN (VERBOSE) SELECT k FROM kv ORDER BY v, PRIMARY KEY kv, v-2
 ----
-sort               0  sort     ·      ·               (k)              k!=NULL
- │                 0  ·        order  +v,+k,+"v - 2"  ·                ·
- └── render        1  render   ·      ·               (k, v, "v - 2")  k!=NULL; weak-key(k,v); +v
-      └── revscan  2  revscan  ·      ·               (k, v)           k!=NULL; weak-key(k,v); +v
-·                  2  ·        table  kv@foo          ·                ·
-·                  2  ·        spans  ALL             ·                ·
+sort               0  sort     ·         ·                     (k)              k!=NULL
+ │                 0  ·        order     +v,+k,+"v - 2"        ·                ·
+ └── render        1  render   ·         ·                     (k, v, "v - 2")  k!=NULL; weak-key(k,v); +v
+      │            1  ·        render 0  test.public.kv.k      ·                ·
+      │            1  ·        render 1  test.public.kv.v      ·                ·
+      │            1  ·        render 2  test.public.kv.v - 2  ·                ·
+      └── revscan  2  revscan  ·         ·                     (k, v)           k!=NULL; weak-key(k,v); +v
+·                  2  ·        table     kv@foo                ·                ·
+·                  2  ·        spans     ALL                   ·                ·
 
 query TITTTTT
-EXPLAIN (METADATA) SELECT k FROM kv ORDER BY INDEX kv@foo
+EXPLAIN (VERBOSE) SELECT k FROM kv ORDER BY INDEX kv@foo
 ----
 nosort     0  nosort  ·      ·       (k)     k!=NULL
  │         0  ·       order  -v      ·       ·
@@ -53,7 +62,7 @@ nosort     0  nosort  ·      ·       (k)     k!=NULL
 ·          1  ·       spans  ALL     ·       ·
 
 query TITTTTT
-EXPLAIN (METADATA) SELECT k FROM kv ORDER BY INDEX kv@foo ASC
+EXPLAIN (VERBOSE) SELECT k FROM kv ORDER BY INDEX kv@foo ASC
 ----
 nosort     0  nosort  ·      ·       (k)     k!=NULL
  │         0  ·       order  -v      ·       ·
@@ -62,7 +71,7 @@ nosort     0  nosort  ·      ·       (k)     k!=NULL
 ·          1  ·       spans  ALL     ·       ·
 
 query TITTTTT
-EXPLAIN (METADATA) SELECT k FROM kv ORDER BY INDEX kv@foo DESC
+EXPLAIN (VERBOSE) SELECT k FROM kv ORDER BY INDEX kv@foo DESC
 ----
 nosort        0  nosort   ·      ·       (k)     k!=NULL
  │            0  ·        order  +v      ·       ·
@@ -71,7 +80,7 @@ nosort        0  nosort   ·      ·       (k)     k!=NULL
 ·             1  ·        spans  ALL     ·       ·
 
 query TITTTTT
-EXPLAIN (METADATA) SELECT k FROM kv ORDER BY INDEX kv@foo, k
+EXPLAIN (VERBOSE) SELECT k FROM kv ORDER BY INDEX kv@foo, k
 ----
 nosort     0  nosort  ·      ·       (k)     k!=NULL
  │         0  ·       order  -v,+k   ·       ·
@@ -86,44 +95,51 @@ nosort     0  nosort  ·      ·       (k)     k!=NULL
 #
 
 query TITTTTT
-EXPLAIN(METADATA) SELECT k FROM kv JOIN (VALUES (1,2)) AS z(a,b) ON kv.k = z.a ORDER BY INDEX kv@foo
+EXPLAIN (VERBOSE) SELECT k FROM kv JOIN (VALUES (1,2)) AS z(a,b) ON kv.k = z.a ORDER BY INDEX kv@foo
 ----
-sort                   0  sort    ·         ·                 (k)                             ·
- │                     0  ·       order     -v                ·                               ·
- └── render            1  render  ·         ·                 (k, v)                          ·
-      └── join         2  join    ·         ·                 (k, v, a[omitted], b[omitted])  ·
-           │           2  ·       type      inner             ·                               ·
-           │           2  ·       equality  (k) = (a)         ·                               ·
-           ├── scan    3  scan    ·         ·                 (k, v)                          k!=NULL; key(k)
-           │           3  ·       table     kv@primary        ·                               ·
-           │           3  ·       spans     ALL               ·                               ·
-           └── values  3  values  ·         ·                 (column1, column2[omitted])     ·
-·                      3  ·       size      2 columns, 1 row  ·                               ·
+sort                   0  sort    ·              ·                 (k)                             ·
+ │                     0  ·       order          -v                ·                               ·
+ └── render            1  render  ·              ·                 (k, v)                          ·
+      │                1  ·       render 0       test.public.kv.k  ·                               ·
+      │                1  ·       render 1       test.public.kv.v  ·                               ·
+      └── join         2  join    ·              ·                 (k, v, a[omitted], b[omitted])  ·
+           │           2  ·       type           inner             ·                               ·
+           │           2  ·       equality       (k) = (a)         ·                               ·
+           ├── scan    3  scan    ·              ·                 (k, v)                          k!=NULL; key(k)
+           │           3  ·       table          kv@primary        ·                               ·
+           │           3  ·       spans          ALL               ·                               ·
+           └── values  3  values  ·              ·                 (column1, column2[omitted])     ·
+·                      3  ·       size           2 columns, 1 row  ·                               ·
+·                      3  ·       row 0, expr 0  1                 ·                               ·
 
 query TITTTTT
-EXPLAIN(METADATA) SELECT k FROM kv a NATURAL JOIN kv ORDER BY INDEX kv@foo
+EXPLAIN (VERBOSE) SELECT k FROM kv a NATURAL JOIN kv ORDER BY INDEX kv@foo
 ----
-sort                 0  sort    ·               ·                (k)                             k!=NULL; key(k)
- │                   0  ·       order           -v               ·                               ·
- └── render          1  render  ·               ·                (k, v)                          k!=NULL; v!=NULL; key(k)
-      └── join       2  join    ·               ·                (k, v[omitted], k[omitted], v)  k=k; v=v; k!=NULL; v!=NULL; key(k)
-           │         2  ·       type            inner            ·                               ·
-           │         2  ·       equality        (k, v) = (k, v)  ·                               ·
-           │         2  ·       mergeJoinOrder  +"(k=k)"         ·                               ·
-           ├── scan  3  scan    ·               ·                (k, v)                          k!=NULL; key(k); +k
-           │         3  ·       table           kv@primary       ·                               ·
-           │         3  ·       spans           ALL              ·                               ·
-           └── scan  3  scan    ·               ·                (k, v)                          k!=NULL; key(k); +k
-·                    3  ·       table           kv@primary       ·                               ·
-·                    3  ·       spans           ALL              ·                               ·
+sort                 0  sort    ·               ·                 (k)                             k!=NULL; key(k)
+ │                   0  ·       order           -v                ·                               ·
+ └── render          1  render  ·               ·                 (k, v)                          k!=NULL; v!=NULL; key(k)
+      │              1  ·       render 0        a.k               ·                               ·
+      │              1  ·       render 1        test.public.kv.v  ·                               ·
+      └── join       2  join    ·               ·                 (k, v[omitted], k[omitted], v)  k=k; v=v; k!=NULL; v!=NULL; key(k)
+           │         2  ·       type            inner             ·                               ·
+           │         2  ·       equality        (k, v) = (k, v)   ·                               ·
+           │         2  ·       mergeJoinOrder  +"(k=k)"          ·                               ·
+           ├── scan  3  scan    ·               ·                 (k, v)                          k!=NULL; key(k); +k
+           │         3  ·       table           kv@primary        ·                               ·
+           │         3  ·       spans           ALL               ·                               ·
+           └── scan  3  scan    ·               ·                 (k, v)                          k!=NULL; key(k); +k
+·                    3  ·       table           kv@primary        ·                               ·
+·                    3  ·       spans           ALL               ·                               ·
 
 # The underlying index can be forced manually, of course.
 query TITTTTT
-EXPLAIN(METADATA) SELECT k FROM kv@foo a NATURAL JOIN kv@foo ORDER BY INDEX kv@foo
+EXPLAIN (VERBOSE) SELECT k FROM kv@foo a NATURAL JOIN kv@foo ORDER BY INDEX kv@foo
 ----
 nosort               0  nosort  ·               ·                  (k)                             k!=NULL
  │                   0  ·       order           -v                 ·                               ·
  └── render          1  render  ·               ·                  (k, v)                          k!=NULL; v!=NULL; -v
+      │              1  ·       render 0        a.k                ·                               ·
+      │              1  ·       render 1        test.public.kv.v   ·                               ·
       └── join       2  join    ·               ·                  (k, v[omitted], k[omitted], v)  k=k; v=v; k!=NULL; v!=NULL; -v
            │         2  ·       type            inner              ·                               ·
            │         2  ·       equality        (k, v) = (k, v)    ·                               ·

--- a/pkg/sql/logictest/testdata/logic_test/ordinality
+++ b/pkg/sql/logictest/testdata/logic_test/ordinality
@@ -83,7 +83,7 @@ true
 
 # Show that the primary key is used under ordinalityNode.
 query TITTTTT
-EXPLAIN (METADATA) SELECT * FROM (SELECT * FROM foo WHERE x > 'a') WITH ORDINALITY
+EXPLAIN (VERBOSE) SELECT * FROM (SELECT * FROM foo WHERE x > 'a') WITH ORDINALITY
 ----
 ordinality  0  ordinality  ·      ·            (x, "ordinality")  x!=NULL; key(x); weak-key("ordinality")
  └── scan   1  scan        ·      ·            (x)                x!=NULL; key(x)
@@ -93,10 +93,11 @@ ordinality  0  ordinality  ·      ·            (x, "ordinality")  x!=NULL; key
 # Show that the primary key cannot be used with a PK predicate
 # outside of ordinalityNode.
 query TITTTTT
-EXPLAIN (METADATA) SELECT * FROM foo WITH ORDINALITY WHERE x > 'a'
+EXPLAIN (VERBOSE) SELECT * FROM foo WITH ORDINALITY WHERE x > 'a'
 ----
-filter           0  filter      ·      ·            (x, "ordinality")  x!=NULL; key(x); weak-key("ordinality")
- └── ordinality  1  ordinality  ·      ·            (x, "ordinality")  x!=NULL; key(x); weak-key("ordinality")
-      └── scan   2  scan        ·      ·            (x)                x!=NULL; key(x)
-·                2  ·           table  foo@primary  ·                  ·
-·                2  ·           spans  ALL          ·                  ·
+filter           0  filter      ·       ·                        (x, "ordinality")  x!=NULL; key(x); weak-key("ordinality")
+ │               0  ·           filter  test.public.foo.x > 'a'  ·                  ·
+ └── ordinality  1  ordinality  ·       ·                        (x, "ordinality")  x!=NULL; key(x); weak-key("ordinality")
+      └── scan   2  scan        ·       ·                        (x)                x!=NULL; key(x)
+·                2  ·           table   foo@primary              ·                  ·
+·                2  ·           spans   ALL                      ·                  ·

--- a/pkg/sql/logictest/testdata/logic_test/ranges
+++ b/pkg/sql/logictest/testdata/logic_test/ranges
@@ -110,16 +110,19 @@ NULL       /8       {1}       1
 
 # Verify limits and orderings are propagated correctly to the select.
 query TITTTTT colnames
-EXPLAIN (METADATA) ALTER TABLE t SPLIT AT SELECT k1,k2 FROM t ORDER BY k1 LIMIT 3
+EXPLAIN (VERBOSE) ALTER TABLE t SPLIT AT SELECT k1,k2 FROM t ORDER BY k1 LIMIT 3
 ----
-Tree                 Level  Type    Field  Description  Columns                           Ordering
-split                0      split   ·      ·            (key, pretty)                     ·
- └── limit           1      limit   ·      ·            (k1, k2)                          k1!=NULL; k2!=NULL; key(k1,k2); +k1
-      └── render     2      render  ·      ·            (k1, k2)                          k1!=NULL; k2!=NULL; key(k1,k2); +k1
-           └── scan  3      scan    ·      ·            (k1, k2, v[omitted], w[omitted])  k1!=NULL; k2!=NULL; key(k1,k2); +k1
-·                    3      ·       table  t@primary    ·                                 ·
-·                    3      ·       spans  ALL          ·                                 ·
-·                    3      ·       limit  3            ·                                 ·
+Tree                 Level  Type    Field     Description       Columns                           Ordering
+split                0      split   ·         ·                 (key, pretty)                     ·
+ └── limit           1      limit   ·         ·                 (k1, k2)                          k1!=NULL; k2!=NULL; key(k1,k2); +k1
+      │              1      ·       count     3                 ·                                 ·
+      └── render     2      render  ·         ·                 (k1, k2)                          k1!=NULL; k2!=NULL; key(k1,k2); +k1
+           │         2      ·       render 0  test.public.t.k1  ·                                 ·
+           │         2      ·       render 1  test.public.t.k2  ·                                 ·
+           └── scan  3      scan    ·         ·                 (k1, k2, v[omitted], w[omitted])  k1!=NULL; k2!=NULL; key(k1,k2); +k1
+·                    3      ·       table     t@primary         ·                                 ·
+·                    3      ·       spans     ALL               ·                                 ·
+·                    3      ·       limit     3                 ·                                 ·
 
 # -- Tests with interleaved tables --
 

--- a/pkg/sql/logictest/testdata/logic_test/select_non_covering_index
+++ b/pkg/sql/logictest/testdata/logic_test/select_non_covering_index
@@ -70,7 +70,7 @@ SELECT * FROM t WHERE c = 7
 5 6 7 8
 
 query TITTTTT
-EXPLAIN (METADATA) SELECT * FROM t WHERE c > 0 ORDER BY c DESC
+EXPLAIN (VERBOSE) SELECT * FROM t WHERE c > 0 ORDER BY c DESC
 ----
 index-join    0  index-join  ·      ·          (a, b, c, d)                             c!=NULL; key(c); -c
  ├── revscan  1  revscan     ·      ·          (a, b[omitted], c[omitted], d[omitted])  c!=NULL; key(c); -c
@@ -135,7 +135,9 @@ limit            ·      ·
 ·                table  t@primary
 
 query TTT
-EXPLAIN (EXPRS) SELECT * FROM t ORDER BY c OFFSET 5
+SELECT "Tree", "Field", "Description" FROM [
+EXPLAIN (VERBOSE) SELECT * FROM t ORDER BY c OFFSET 5
+]
 ----
 limit           ·       ·
  │              offset  5
@@ -146,7 +148,9 @@ limit           ·       ·
 ·               spans   ALL
 
 query TTT
-EXPLAIN (EXPRS) SELECT * FROM t ORDER BY c LIMIT 5 OFFSET 5
+SELECT "Tree", "Field", "Description" FROM [
+EXPLAIN (VERBOSE) SELECT * FROM t ORDER BY c LIMIT 5 OFFSET 5
+]
 ----
 limit            ·       ·
  │               count   5
@@ -160,7 +164,9 @@ limit            ·       ·
 ·                table   t@primary
 
 query TTT
-EXPLAIN (EXPRS) SELECT * FROM t ORDER BY c LIMIT 1000000
+SELECT "Tree", "Field", "Description" FROM [
+EXPLAIN (VERBOSE) SELECT * FROM t ORDER BY c LIMIT 1000000
+]
 ----
 limit           ·         ·
  │              count     1000000

--- a/pkg/sql/logictest/testdata/logic_test/select_non_covering_index_filtering
+++ b/pkg/sql/logictest/testdata/logic_test/select_non_covering_index_filtering
@@ -30,7 +30,9 @@ INSERT INTO t VALUES
   (9, 3, 3, '33')
 
 query TTT
-EXPLAIN (EXPRS) SELECT * FROM t WHERE b = 2 AND c % 2 = 0
+SELECT "Tree", "Field", "Description" FROM [
+EXPLAIN (VERBOSE) SELECT * FROM t WHERE b = 2 AND c % 2 = 0
+]
 ----
 index-join  ·       ·
  ├── scan   ·       ·
@@ -55,7 +57,9 @@ fetched: /t/primary/5/s -> '22'
 output row: [5 2 2 '22']
 
 query TTT
-EXPLAIN (EXPRS) SELECT * FROM t WHERE b = 2 AND c != b
+SELECT "Tree", "Field", "Description" FROM [
+EXPLAIN (VERBOSE) SELECT * FROM t WHERE b = 2 AND c != b
+]
 ----
 index-join  ·       ·
  ├── scan   ·       ·

--- a/pkg/sql/logictest/testdata/logic_test/sequences
+++ b/pkg/sql/logictest/testdata/logic_test/sequences
@@ -181,7 +181,7 @@ statement error pq: column name "foo" not found
 SELECT foo from select_test
 
 query TITTTTT colnames
-EXPLAIN (PLAN, METADATA) SELECT * FROM select_test
+EXPLAIN (VERBOSE) SELECT * FROM select_test
 ----
 Tree             Level  Type             Field  Description  Columns                           Ordering
 sequence select  0      sequence select  ·      ·            (last_value, log_cnt, is_called)  ·

--- a/pkg/sql/logictest/testdata/logic_test/stars_in_subexpressions
+++ b/pkg/sql/logictest/testdata/logic_test/stars_in_subexpressions
@@ -26,7 +26,7 @@ SELECT COUNT(DISTINCT x.*) FROM a x, a y
 2
 
 query TITTTTT
-EXPLAIN(VERBOSE) SELECT COUNT(DISTINCT x.*) FROM a x, a y
+EXPLAIN (VERBOSE) SELECT COUNT(DISTINCT x.*) FROM a x, a y
 ----
 group                0  group   ·            ·                       (count)                                                                       ·
  │                   0  ·       aggregate 0  count(DISTINCT (x, y))  ·                                                                             ·
@@ -42,39 +42,45 @@ group                0  group   ·            ·                       (count)  
 ·                    3  ·       spans        ALL                     ·                                                                             ·
 
 query TTT
-EXPLAIN(EXPRS) SELECT * FROM a ORDER BY a.*
+SELECT "Tree", "Field", "Description" FROM [
+EXPLAIN (VERBOSE) SELECT * FROM a ORDER BY a.*
+]
 ----
 sort            ·         ·
  │              order     +x,+y
  └── render     ·         ·
-      │         render 0  x
-      │         render 1  y
+      │         render 0  test.public.a.x
+      │         render 1  test.public.a.y
       └── scan  ·         ·
 ·               table     a@primary
 ·               spans     ALL
 
 query TTT
-EXPLAIN(EXPRS) SELECT * FROM a ORDER BY (a.*)
+SELECT "Tree", "Field", "Description" FROM [
+EXPLAIN (VERBOSE) SELECT * FROM a ORDER BY (a.*)
+]
 ----
 sort            ·         ·
  │              order     +x,+y
  └── render     ·         ·
-      │         render 0  x
-      │         render 1  y
+      │         render 0  test.public.a.x
+      │         render 1  test.public.a.y
       └── scan  ·         ·
 ·               table     a@primary
 ·               spans     ALL
 
 query TTT
-EXPLAIN(EXPRS) SELECT MIN(y.x) FROM a x, a y GROUP BY x.*
+SELECT "Tree", "Field", "Description" FROM [
+EXPLAIN (VERBOSE) SELECT MIN(y.x) FROM a x, a y GROUP BY x.*
+]
 ----
 group                ·            ·
  │                   aggregate 0  min(x)
  │                   group by     @1-@2
  └── render          ·            ·
-      │              render 0     x
-      │              render 1     y
-      │              render 2     x
+      │              render 0     x.x
+      │              render 1     x.y
+      │              render 2     y.x
       └── join       ·            ·
            │         type         cross
            ├── scan  ·            ·
@@ -85,16 +91,18 @@ group                ·            ·
 ·                    spans        ALL
 
 query TTT
-EXPLAIN(EXPRS) SELECT MIN(y.x) FROM a x, a y GROUP BY (1, (x.*))
+SELECT "Tree", "Field", "Description" FROM [
+EXPLAIN (VERBOSE) SELECT MIN(y.x) FROM a x, a y GROUP BY (1, (x.*))
+]
 ----
 group                ·            ·
  │                   aggregate 0  min(x)
  │                   group by     @1-@3
  └── render          ·            ·
       │              render 0     1
-      │              render 1     x
-      │              render 2     y
-      │              render 3     x
+      │              render 1     x.x
+      │              render 2     x.y
+      │              render 3     y.x
       └── join       ·            ·
            │         type         cross
            ├── scan  ·            ·
@@ -106,15 +114,17 @@ group                ·            ·
 
 # A useful optimization: naked tuple expansion in GROUP BY clause.
 query TTT
-EXPLAIN(EXPRS) SELECT MIN(y.x) FROM a x, a y GROUP BY (x.*)
+SELECT "Tree", "Field", "Description" FROM [
+EXPLAIN (VERBOSE) SELECT MIN(y.x) FROM a x, a y GROUP BY (x.*)
+]
 ----
 group                ·            ·
  │                   aggregate 0  min(x)
  │                   group by     @1-@2
  └── render          ·            ·
-      │              render 0     x
-      │              render 1     y
-      │              render 2     x
+      │              render 0     x.x
+      │              render 1     x.y
+      │              render 2     y.x
       └── join       ·            ·
            │         type         cross
            ├── scan  ·            ·
@@ -126,14 +136,16 @@ group                ·            ·
 
 # Show reuse of renders expression inside an expansion.
 query TTT
-EXPLAIN(EXPRS) SELECT x.y FROM a x, a y GROUP BY x.*
+SELECT "Tree", "Field", "Description" FROM [
+EXPLAIN (VERBOSE) SELECT x.y FROM a x, a y GROUP BY x.*
+]
 ----
 group                ·            ·
  │                   aggregate 0  y
  │                   group by     @1-@2
  └── render          ·            ·
-      │              render 0     x
-      │              render 1     y
+      │              render 0     x.x
+      │              render 1     x.y
       └── join       ·            ·
            │         type         cross
            ├── scan  ·            ·

--- a/pkg/sql/logictest/testdata/logic_test/subquery
+++ b/pkg/sql/logictest/testdata/logic_test/subquery
@@ -464,18 +464,21 @@ true
 
 # check that residual filters are not expanded twice
 query TITTTTT
-EXPLAIN (METADATA) SELECT x FROM xyz WHERE x IN (SELECT x FROM xyz)
+EXPLAIN (VERBOSE) SELECT x FROM xyz WHERE x IN (SELECT x FROM xyz)
 ----
 root                 0  root      ·          ·                    (x)                          x!=NULL; key(x)
  ├── render          1  render    ·          ·                    (x)                          x!=NULL; key(x)
+ │    │              1  ·         render 0   test.public.xyz.x    ·                            ·
  │    └── scan       2  scan      ·          ·                    (x, y[omitted], z[omitted])  x!=NULL; key(x)
  │                   2  ·         table      xyz@primary          ·                            ·
  │                   2  ·         spans      ALL                  ·                            ·
+ │                   2  ·         filter     x IN @S1             ·                            ·
  └── subquery        1  subquery  ·          ·                    (x)                          x!=NULL; key(x)
       │              1  ·         id         @S1                  ·                            ·
       │              1  ·         sql        (SELECT x FROM xyz)  ·                            ·
       │              1  ·         exec mode  all rows normalized  ·                            ·
       └── render     2  render    ·          ·                    (x)                          x!=NULL; key(x)
+           │         2  ·         render 0   test.public.xyz.x    ·                            ·
            └── scan  3  scan      ·          ·                    (x, y[omitted], z[omitted])  x!=NULL; key(x)
 ·                    3  ·         table      xyz@primary          ·                            ·
 ·                    3  ·         spans      ALL                  ·                            ·

--- a/pkg/sql/logictest/testdata/logic_test/update
+++ b/pkg/sql/logictest/testdata/logic_test/update
@@ -345,19 +345,24 @@ count           ·      ·
 ·               spans  ALL
 
 query TITTTTT
-EXPLAIN (METADATA) UPDATE xyz SET (x, y) = (1, 2)
+EXPLAIN (VERBOSE) UPDATE xyz SET (x, y) = (1, 2)
 ----
-count                0  count   ·      ·            ()                   ·
- └── update          1  update  ·      ·            ()                   ·
-      │              1  ·       table  xyz          ·                    ·
-      │              1  ·       set    x, y         ·                    ·
-      └── render     2  render  ·      ·            (x, y, z, "1", "2")  "1"=CONST; "2"=CONST; x!=NULL; key(x)
-           └── scan  3  scan    ·      ·            (x, y, z)            x!=NULL; key(x)
-·                    3  ·       table  xyz@primary  ·                    ·
-·                    3  ·       spans  ALL          ·                    ·
+count                0  count   ·         ·                  ()                   ·
+ └── update          1  update  ·         ·                  ()                   ·
+      │              1  ·       table     xyz                ·                    ·
+      │              1  ·       set       x, y               ·                    ·
+      └── render     2  render  ·         ·                  (x, y, z, "1", "2")  "1"=CONST; "2"=CONST; x!=NULL; key(x)
+           │         2  ·       render 0  test.public.xyz.x  ·                    ·
+           │         2  ·       render 1  test.public.xyz.y  ·                    ·
+           │         2  ·       render 2  test.public.xyz.z  ·                    ·
+           │         2  ·       render 3  1                  ·                    ·
+           │         2  ·       render 4  2                  ·                    ·
+           └── scan  3  scan    ·         ·                  (x, y, z)            x!=NULL; key(x)
+·                    3  ·       table     xyz@primary        ·                    ·
+·                    3  ·       spans     ALL                ·                    ·
 
 query TITTTTT
-EXPLAIN (METADATA) UPDATE xyz SET (x, y) = (y, x)
+EXPLAIN (VERBOSE) UPDATE xyz SET (x, y) = (y, x)
 ----
 count           0  count   ·      ·            ()         ·
  └── update     1  update  ·      ·            ()         ·
@@ -368,16 +373,20 @@ count           0  count   ·      ·            ()         ·
 ·               2  ·       spans  ALL          ·          ·
 
 query TITTTTT
-EXPLAIN (METADATA) UPDATE xyz SET (x, y) = (2, 2)
+EXPLAIN (VERBOSE) UPDATE xyz SET (x, y) = (2, 2)
 ----
-count                0  count   ·      ·            ()              ·
- └── update          1  update  ·      ·            ()              ·
-      │              1  ·       table  xyz          ·               ·
-      │              1  ·       set    x, y         ·               ·
-      └── render     2  render  ·      ·            (x, y, z, "2")  "2"=CONST; x!=NULL; key(x)
-           └── scan  3  scan    ·      ·            (x, y, z)       x!=NULL; key(x)
-·                    3  ·       table  xyz@primary  ·               ·
-·                    3  ·       spans  ALL          ·               ·
+count                0  count   ·         ·                  ()              ·
+ └── update          1  update  ·         ·                  ()              ·
+      │              1  ·       table     xyz                ·               ·
+      │              1  ·       set       x, y               ·               ·
+      └── render     2  render  ·         ·                  (x, y, z, "2")  "2"=CONST; x!=NULL; key(x)
+           │         2  ·       render 0  test.public.xyz.x  ·               ·
+           │         2  ·       render 1  test.public.xyz.y  ·               ·
+           │         2  ·       render 2  test.public.xyz.z  ·               ·
+           │         2  ·       render 3  2                  ·               ·
+           └── scan  3  scan    ·         ·                  (x, y, z)       x!=NULL; key(x)
+·                    3  ·       table     xyz@primary        ·               ·
+·                    3  ·       spans     ALL                ·               ·
 
 statement ok
 CREATE TABLE lots (

--- a/pkg/sql/logictest/testdata/logic_test/upsert
+++ b/pkg/sql/logictest/testdata/logic_test/upsert
@@ -403,7 +403,9 @@ SELECT * FROM issue_17339 ORDER BY a;
 2 1
 
 query TTT
-EXPLAIN (PLAN,EXPRS) UPSERT INTO kv TABLE kv ORDER BY v DESC
+SELECT "Tree", "Field", "Description" FROM [
+EXPLAIN (VERBOSE) UPSERT INTO kv TABLE kv ORDER BY v DESC
+]
 ----
 count                ·      ·
  └── upsert          ·      ·

--- a/pkg/sql/opt_exec_engine.go
+++ b/pkg/sql/opt_exec_engine.go
@@ -105,7 +105,6 @@ func (ee *execEngine) Explain(p exec.Plan) ([]tree.Datums, error) {
 	// Add an explain node to the plan and run that.
 	flags := explainFlags{
 		showMetadata: true,
-		showExprs:    true,
 		qualifyNames: true,
 	}
 	explainNode, err := ee.planner.makeExplainPlanNodeWithPlan(

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -2013,14 +2013,15 @@ table_name_list:
 // %Category: Misc
 // %Text:
 // EXPLAIN <statement>
-// EXPLAIN [( [PLAN ,] <planoptions...> )] <statement>
+// EXPLAIN ([PLAN ,] <planoptions...> ) <statement>
+// EXPLAIN (DISTSQL) <statement>
 //
 // Explainable statements:
 //     SELECT, CREATE, DROP, ALTER, INSERT, UPSERT, UPDATE, DELETE,
 //     SHOW, EXPLAIN, EXECUTE
 //
 // Plan options:
-//     TYPES, EXPRS, METADATA, QUALIFY, INDENT, VERBOSE, DIST_SQL
+//     TYPES, VERBOSE
 //
 // %SeeAlso: WEBDOCS/explain.html
 explain_stmt:

--- a/pkg/sql/sem/tree/explain.go
+++ b/pkg/sql/sem/tree/explain.go
@@ -20,8 +20,8 @@ import (
 
 // Explain represents an EXPLAIN statement.
 type Explain struct {
-	// Options defines how EXPLAIN should operate (VERBOSE, METADATA,
-	// etc.) Which options are valid depends on the explain mode. See
+	// Options defines how EXPLAIN should operate (e.g. VERBOSE).
+	// Which options are valid depends on the explain mode. See
 	// sql/explain.go for details.
 	Options []string
 

--- a/pkg/sql/table_ref_test.go
+++ b/pkg/sql/table_ref_test.go
@@ -104,7 +104,7 @@ ALTER TABLE test.t DROP COLUMN xx;
 
 	for i, d := range testData {
 		t.Run(d.tableExpr, func(t *testing.T) {
-			sql := `SELECT "Columns" FROM [EXPLAIN(METADATA) SELECT * FROM ` + d.tableExpr + "]"
+			sql := `SELECT "Columns" FROM [EXPLAIN(VERBOSE) SELECT * FROM ` + d.tableExpr + "]"
 			var columns string
 			if err := db.QueryRow(sql).Scan(&columns); err != nil {
 				if d.expectedError != "" {


### PR DESCRIPTION
EXPLAIN has too many flags with overlapping functionality.
Removing the METADATA, QUALIFY, and EXPRS flags. The information
returned by these is contained in the VERBOSE output.

Release note (sql change): Removed the METADATA, QUALIFY and EXPRS
flags for EXPLAIN.