### PR TITLE
sql: cleanup reference to ExecCfg

### DIFF
--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -731,6 +731,11 @@ func (ts *TestServer) GetRangeLease(
 
 }
 
+// ExecutorConfig is part of the TestServerInterface.
+func (ts *TestServer) ExecutorConfig() interface{} {
+	return *ts.execCfg
+}
+
 type testServerFactoryImpl struct{}
 
 // TestServerFactory can be passed to serverutils.InitTestServerFactory

--- a/pkg/sql/join_test.go
+++ b/pkg/sql/join_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
+	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
@@ -256,9 +257,9 @@ func TestSemiAntiJoin(t *testing.T) {
 					return err
 				}
 
+				execCfg := s.ExecutorConfig().(ExecutorConfig)
 				p, cleanup := newInternalPlanner(
-					"", txn, "root", &MemoryMetrics{},
-					s.InternalExecutor().(*InternalExecutor).ExecCfg,
+					"TestSemiAntiJoin", txn, security.RootUser, &MemoryMetrics{}, &execCfg,
 				)
 				defer cleanup()
 				leftSrc := planDataSource{

--- a/pkg/sql/opt_exec_engine.go
+++ b/pkg/sql/opt_exec_engine.go
@@ -22,6 +22,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
+	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/constraint"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/exec"
@@ -36,7 +37,7 @@ var _ exec.TestEngineFactory = &Executor{}
 // NewTestEngine is part of the exec.TestEngineFactory interface.
 func (e *Executor) NewTestEngine(defaultDatabase string) exec.TestEngine {
 	txn := client.NewTxn(e.cfg.DB, e.cfg.NodeID.Get(), client.RootTxn)
-	p, cleanup := newInternalPlanner("opt", txn, "root", &MemoryMetrics{}, &e.cfg)
+	p, cleanup := newInternalPlanner("opt", txn, security.RootUser, &MemoryMetrics{}, &e.cfg)
 	// TODO(radu): Setting this directly is a hack.
 	p.extendedEvalCtx.SessionData.Database = defaultDatabase
 	return newExecEngine(p, cleanup)

--- a/pkg/testutils/serverutils/test_server_shim.go
+++ b/pkg/testutils/serverutils/test_server_shim.go
@@ -76,6 +76,10 @@ type TestServerInterface interface {
 	// InternalExecutor returns a *sqlutil.InternalExecutor as an interface{}.
 	InternalExecutor() interface{}
 
+	// ExecutorConfig returns a copy of the server's ExecutorConfig.
+	// The real return type is sql.ExecutorConfig.
+	ExecutorConfig() interface{}
+
 	// Gossip returns the gossip used by the TestServer.
 	Gossip() *gossip.Gossip
 


### PR DESCRIPTION
A test was using an InternalExecutor to get an ExecutorConfig, but
there's a better way. Also the old way is about to break.

Release note: None