### PR TITLE
backport-2.0: server: fix the fix for spurious gzip errors

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1756,7 +1756,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			//      -v http://localhost:8080/favicon.ico > /dev/null
 			//
 			// which results in a 304 Not Modified.
-			if err := gzw.Close(); err != http.ErrBodyNotAllowed {
+			if err := gzw.Close(); err != nil && err != http.ErrBodyNotAllowed {
 				ctx := s.AnnotateCtx(r.Context())
 				log.Warningf(ctx, "error closing gzip response writer: %v", err)
 			}


### PR DESCRIPTION
Backport 1/1 commits from #25106.

/cc @cockroachdb/release

---

Release note (general change): stopped spamming the server logs with
"error closing gzip response writer" messages.

https://github.com/cockroachdb/cockroach/pull/24367 just made things worse. It's a little embarrassing that three of us looked at that code without noticing.