### PR TITLE
ui: fix typo in node map onboarding screen

### DIFF
--- a/pkg/ui/ccl/src/views/clusterviz/containers/map/needEnterpriseLicense.tsx
+++ b/pkg/ui/ccl/src/views/clusterviz/containers/map/needEnterpriseLicense.tsx
@@ -37,7 +37,8 @@ export default class NeedEnterpriseLicense extends React.Component<NodeCanvasCon
             Activate the trial license with two simple SQL commands.
           </Step>
           <Step num={3} img={step3Img}>
-            Refer this <a href={docsURL.enableNodeMap}>configuration guide</a> to configure the Node Map.
+            Follow <a href={docsURL.enableNodeMap}>this guide</a> to configure localities
+            and locations.
           </Step>
         </div>
       </section>


### PR DESCRIPTION
Fixes #25096

Before;
![image](https://user-images.githubusercontent.com/7341/39328525-9e1b070c-4969-11e8-9a94-c8da59cd0069.png)

After:
![image](https://user-images.githubusercontent.com/7341/39328511-94bb181e-4969-11e8-99ea-2d7b74dd0670.png)

Release note (admin ui change): fix typo in node map onboarding screen