### PR TITLE
ui: proxy segment analytics through the reg cluster

### DIFF
--- a/pkg/ui/package.json
+++ b/pkg/ui/package.json
@@ -33,7 +33,7 @@
     "whatwg-fetch": "^2.0.3"
   },
   "devDependencies": {
-    "@types/analytics-node": "^0.0.30",
+    "@types/analytics-node": "^0.0.32",
     "@types/bytebuffer": "^5.0.33",
     "@types/chai": "^4.1.0",
     "@types/classnames": "^0.0.32",

--- a/pkg/ui/src/redux/analytics.ts
+++ b/pkg/ui/src/redux/analytics.ts
@@ -6,6 +6,7 @@ import { Store } from "redux";
 import * as protos from "src/js/protos";
 import { versionsSelector } from "src/redux/alerts";
 import { store, history, AdminUIState } from "src/redux/state";
+import { COCKROACHLABS_ADDR } from "src/util/cockroachlabsAPI";
 
 type ClusterResponse = protos.cockroach.server.serverpb.IClusterResponse;
 
@@ -243,7 +244,10 @@ export class AnalyticsSync {
 // Create a global instance of AnalyticsSync which can be used from various
 // packages. If enabled, this instance will push to segment using the following
 // analytics key.
-const analyticsInstance = new Analytics("5Vbp8WMYDmZTfCwE0uiUqEdAcTiZWFDb");
+const analyticsOpts = {
+  host: COCKROACHLABS_ADDR + "/api/segment",
+};
+const analyticsInstance = new Analytics("5Vbp8WMYDmZTfCwE0uiUqEdAcTiZWFDb", analyticsOpts);
 export const analytics = new AnalyticsSync(analyticsInstance, store, defaultRedactions);
 
 // Attach a listener to the history object which will track a 'page' event

--- a/pkg/ui/yarn.lock
+++ b/pkg/ui/yarn.lock
@@ -52,9 +52,9 @@
     component-type "^1.2.1"
     join-component "^1.1.0"
 
-"@types/analytics-node@^0.0.30":
-  version "0.0.30"
-  resolved "https://registry.yarnpkg.com/@types/analytics-node/-/analytics-node-0.0.30.tgz#8d9dfc7f7c2fe2344e825d2acc5061c442067229"
+"@types/analytics-node@^0.0.32":
+  version "0.0.32"
+  resolved "https://registry.yarnpkg.com/@types/analytics-node/-/analytics-node-0.0.32.tgz#4bd500d2b63f519d9e180e4d3c02d187b55bab6d"
 
 "@types/bytebuffer@^5.0.33":
   version "5.0.34"


### PR DESCRIPTION
This addresses a few concerns with our analytics.  Previously, we would send reports directly to segment, this changes that to proxy through the registration cluster, to protect our user's IPs as well as future-proof in case we wanted to switch to another provider.