### PR TITLE
opt: support for EXPLAIN

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/builder_test.go
+++ b/pkg/sql/opt/exec/execbuilder/builder_test.go
@@ -31,7 +31,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/exec"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/testutils"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
-	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/testutils/datadriven"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -64,10 +63,8 @@ import (
 //        columns (1-indexed). Used for queries which guarantee a partial order.
 //        See partialSort() for more information.
 //
-//  - exec-explain
-//
-//    Builds a memo structure from a SQL statement, then builds an
-//    execution plan and outputs the details of that plan.
+//      - hide-colnames: if specified, the column names and types won't be
+//        shown (as the first row of results).
 //
 //  - catalog
 //
@@ -96,6 +93,7 @@ func TestExecBuild(t *testing.T) {
 
 			var rowSort bool
 			var partialSortColumns []int
+			var hideColNames bool
 
 			for _, arg := range d.CmdArgs {
 				switch arg.Key {
@@ -115,6 +113,9 @@ func TestExecBuild(t *testing.T) {
 						partialSortColumns[i] = val - 1
 					}
 
+				case "hide-colnames":
+					hideColNames = true
+
 				default:
 					if err := tester.Flags.Set(arg); err != nil {
 						d.Fatalf(t, "%s", err)
@@ -130,17 +131,11 @@ func TestExecBuild(t *testing.T) {
 				}
 				return ""
 
-			case "exec", "exec-explain":
+			case "exec":
 				eng := s.Executor().(exec.TestEngineFactory).NewTestEngine("test")
 				defer eng.Close()
 
-				var columns sqlbase.ResultColumns
-				var results []tree.Datums
-				if d.Cmd == "exec-explain" {
-					results, err = tester.Explain(eng)
-				} else {
-					columns, results, err = tester.Exec(eng)
-				}
+				columns, results, err := tester.Exec(eng)
 				if err != nil {
 					d.Fatalf(t, "%v", err)
 				}
@@ -161,7 +156,7 @@ func TestExecBuild(t *testing.T) {
 					' ', /* padchar */
 					0,   /* flags */
 				)
-				if columns != nil {
+				if columns != nil && !hideColNames {
 					for i := range columns {
 						if i > 0 {
 							fmt.Fprintf(tw, "\t")

--- a/pkg/sql/opt/exec/execbuilder/testdata/aggregate
+++ b/pkg/sql/opt/exec/execbuilder/testdata/aggregate
@@ -9,8 +9,8 @@ CREATE TABLE kv (
 )
 ----
 
-exec-explain
-SELECT MIN(1), MAX(1), COUNT(1), SUM_INT(1), AVG(1), SUM(1), STDDEV(1), VARIANCE(1), BOOL_AND(true), BOOL_OR(false), XOR_AGG(b'\x01') FROM kv
+exec hide-colnames
+EXPLAIN (VERBOSE) SELECT MIN(1), MAX(1), COUNT(1), SUM_INT(1), AVG(1), SUM(1), STDDEV(1), VARIANCE(1), BOOL_AND(true), BOOL_OR(false), XOR_AGG(b'\x01') FROM kv
 ----
 group           0  group   ·             ·                   (column6, column7, column8, column9, column10, column11, column12, column13, column15, column17, column19)  ·
  │              0  ·       aggregate 0   min(column5)        ·                                                                                                           ·
@@ -58,8 +58,8 @@ SELECT JSONB_AGG(1) FROM kv
 column6:jsonb
 NULL
 
-exec-explain
-SELECT MIN(v), MAX(v), COUNT(v), SUM_INT(1), AVG(v), SUM(v), STDDEV(v), VARIANCE(v), BOOL_AND(v = 1), BOOL_AND(v = 1), XOR_AGG(s::bytes) FROM kv
+exec hide-colnames
+EXPLAIN (VERBOSE) SELECT MIN(v), MAX(v), COUNT(v), SUM_INT(1), AVG(v), SUM(v), STDDEV(v), VARIANCE(v), BOOL_AND(v = 1), BOOL_AND(v = 1), XOR_AGG(s::bytes) FROM kv
 ----
 render               0  render  ·            ·                   (column5, column6, column7, column9, column10, column11, column12, column13, column15, column15, column17)  ·
  │                   0  ·       render 0     agg0                ·                                                                                                           ·
@@ -118,8 +118,8 @@ column5:jsonb
 NULL
 
 # Aggregate functions trigger aggregation and computation when there is no source.
-exec-explain
-SELECT MIN(1), COUNT(1), MAX(1), SUM_INT(1), AVG(1)::float, SUM(1), STDDEV(1), VARIANCE(1), BOOL_AND(true), BOOL_OR(true), TO_HEX(XOR_AGG(b'\x01'))
+exec hide-colnames
+EXPLAIN (VERBOSE) SELECT MIN(1), COUNT(1), MAX(1), SUM_INT(1), AVG(1)::float, SUM(1), STDDEV(1), VARIANCE(1), BOOL_AND(true), BOOL_OR(true), TO_HEX(XOR_AGG(b'\x01'))
 ----
 render                 0  render  ·             ·                   (column2, column3, column4, column5, column7, column8, column9, column10, column12, column13, column16)  ·
  │                     0  ·       render 0      agg0                ·                                                                                                        ·
@@ -310,8 +310,8 @@ column5:int  k:int
 1            7
 1            8
 
-exec-explain
-SELECT COUNT(*), k FROM kv GROUP BY 2
+exec hide-colnames
+EXPLAIN (VERBOSE) SELECT COUNT(*), k FROM kv GROUP BY 2
 ----
 render          0  render  ·            ·             (column5, k)  ·
  │              0  ·       render 0     agg0          ·             ·
@@ -391,8 +391,8 @@ column5:int  column6:string
 2            B
 
 # Selecting and grouping on a more complex expression works.
-exec-explain
-SELECT COUNT(*), k+v FROM kv GROUP BY k+v
+exec hide-colnames
+EXPLAIN (VERBOSE) SELECT COUNT(*), k+v FROM kv GROUP BY k+v
 ----
 render               0  render  ·            ·             (column6, column5)  ·
  │                   0  ·       render 0     agg0          ·                   ·
@@ -419,8 +419,8 @@ column6:int  column5:int
 1            12
 
 # Selecting a more complex expression, made up of things which are each grouped, works.
-exec-explain
-SELECT COUNT(*), k+v FROM kv GROUP BY k, v
+exec hide-colnames
+EXPLAIN (VERBOSE) SELECT COUNT(*), k+v FROM kv GROUP BY k, v
 ----
 render          0  render  ·            ·             (column5, column6)  ·
  │              0  ·       render 0     agg0          ·                   ·
@@ -679,8 +679,8 @@ SELECT AVG(k) * 2.0 + MAX(v)::DECIMAL FROM kv WHERE w*2 = k
 column7:decimal
 14.0
 
-exec-explain
-SELECT COUNT(k) FROM kv
+exec hide-colnames
+EXPLAIN (VERBOSE) SELECT COUNT(k) FROM kv
 ----
 group      0  group  ·            ·           (column5)  ·
  │         0  ·      aggregate 0  count(k)    ·          ·
@@ -688,8 +688,8 @@ group      0  group  ·            ·           (column5)  ·
 ·          1  ·      table        kv@primary  ·          ·
 ·          1  ·      spans        ALL         ·          ·
 
-exec-explain
-SELECT COUNT(k), SUM(k), MAX(k) FROM kv
+exec hide-colnames
+EXPLAIN (VERBOSE) SELECT COUNT(k), SUM(k), MAX(k) FROM kv
 ----
 group      0  group  ·            ·           (column5, column6, column7)  ·
  │         0  ·      aggregate 0  count(k)    ·                            ·
@@ -712,8 +712,8 @@ exec-raw
 INSERT INTO abc VALUES ('one', 1.5, true, 5::decimal), ('two', 2.0, false, 1.1::decimal)
 ----
 
-exec-explain
-SELECT MIN(a) FROM abc
+exec hide-colnames
+EXPLAIN (VERBOSE) SELECT MIN(a) FROM abc
 ----
 group      0  group  ·            ·            (column5)  ·
  │         0  ·      aggregate 0  min(a)       ·          ·
@@ -779,8 +779,8 @@ SELECT MIN(x) FROM xyz
 column4:int
 1
 
-exec-explain
-SELECT MIN(x) FROM xyz
+exec hide-colnames
+EXPLAIN (VERBOSE) SELECT MIN(x) FROM xyz
 ----
 group      0  group  ·            ·            (column4)  ·
  │         0  ·      aggregate 0  min(x)       ·          ·
@@ -795,8 +795,8 @@ column4:int
 4
 
 # TODO(radu): we don't yet optimize this by scanning one entry from the xy index.
-exec-explain
-SELECT MIN(x) FROM xyz WHERE x in (0, 4, 7)
+exec hide-colnames
+EXPLAIN (VERBOSE) SELECT MIN(x) FROM xyz WHERE x in (0, 4, 7)
 ----
 group      0  group  ·            ·                        (column4)  ·
  │         0  ·      aggregate 0  min(x)                   ·          ·
@@ -811,8 +811,8 @@ column4:int
 7
 
 # TODO(radu): we don't yet optimize MIN/MAX by scanning one entry from the xy index.
-exec-explain
-SELECT MAX(x) FROM xyz
+exec hide-colnames
+EXPLAIN (VERBOSE) SELECT MAX(x) FROM xyz
 ----
 group      0  group  ·            ·            (column4)  ·
  │         0  ·      aggregate 0  max(x)       ·          ·
@@ -826,8 +826,8 @@ SELECT MIN(y) FROM xyz WHERE x = 1
 column4:int
 2
 
-exec-explain
-SELECT MIN(y) FROM xyz WHERE x = 1
+exec hide-colnames
+EXPLAIN (VERBOSE) SELECT MIN(y) FROM xyz WHERE x = 1
 ----
 group           0  group   ·            ·            (column4)  ·
  │              0  ·       aggregate 0  min(xyz.y)   ·          ·
@@ -843,8 +843,8 @@ SELECT MAX(y) FROM xyz WHERE x = 1
 column4:int
 2
 
-exec-explain
-SELECT MAX(y) FROM xyz WHERE x = 1
+exec hide-colnames
+EXPLAIN (VERBOSE) SELECT MAX(y) FROM xyz WHERE x = 1
 ----
 group           0  group   ·            ·            (column4)  ·
  │              0  ·       aggregate 0  max(xyz.y)   ·          ·
@@ -860,8 +860,8 @@ SELECT MIN(y) FROM xyz WHERE x = 7
 column4:int
 NULL
 
-exec-explain
-SELECT MIN(y) FROM xyz WHERE x = 7
+exec hide-colnames
+EXPLAIN (VERBOSE) SELECT MIN(y) FROM xyz WHERE x = 7
 ----
 group           0  group   ·            ·            (column4)  ·
  │              0  ·       aggregate 0  min(xyz.y)   ·          ·
@@ -877,8 +877,8 @@ SELECT MAX(y) FROM xyz WHERE x = 7
 column4:int
 NULL
 
-exec-explain
-SELECT MAX(y) FROM xyz WHERE x = 7
+exec hide-colnames
+EXPLAIN (VERBOSE) SELECT MAX(y) FROM xyz WHERE x = 7
 ----
 group           0  group   ·            ·            (column4)  ·
  │              0  ·       aggregate 0  max(xyz.y)   ·          ·
@@ -894,8 +894,8 @@ SELECT MIN(x) FROM xyz WHERE (y, z) = (2, 3.0)
 column4:int
 1
 
-exec-explain
-SELECT MIN(x) FROM xyz WHERE (y, z) = (2, 3.0)
+exec hide-colnames
+EXPLAIN (VERBOSE) SELECT MIN(x) FROM xyz WHERE (y, z) = (2, 3.0)
 ----
 group           0  group   ·            ·           (column4)  ·
  │              0  ·       aggregate 0  min(xyz.x)  ·          ·
@@ -911,8 +911,8 @@ SELECT MAX(x) FROM xyz WHERE (z, y) = (3.0, 2)
 column4:int
 1
 
-exec-explain
-SELECT MAX(x) FROM xyz WHERE (z, y) = (3.0, 2)
+exec hide-colnames
+EXPLAIN (VERBOSE) SELECT MAX(x) FROM xyz WHERE (z, y) = (3.0, 2)
 ----
 group           0  group   ·            ·           (column4)  ·
  │              0  ·       aggregate 0  max(xyz.x)  ·          ·
@@ -942,8 +942,8 @@ SELECT VARIANCE(x) FROM xyz WHERE x = 1
 column4:decimal
 NULL
 
-exec-explain
-SELECT VARIANCE(x) FROM xyz WHERE x = 1
+exec hide-colnames
+EXPLAIN (VERBOSE) SELECT VARIANCE(x) FROM xyz WHERE x = 1
 ----
 group      0  group  ·            ·            (column4)  ·
  │         0  ·      aggregate 0  variance(x)  ·          ·
@@ -1121,8 +1121,8 @@ INSERT INTO ab VALUES
 #output row: [5]
 
 # TODO(radu): ORDER BY not supported yet.
-#exec-explain
-#SELECT v, COUNT(k) FROM kv GROUP BY v ORDER BY COUNT(k)
+#exec hide-colnames
+#EXPLAIN (VERBOSE) SELECT v, COUNT(k) FROM kv GROUP BY v ORDER BY COUNT(k)
 #----
 #sort                 ·            ·
 # │                   order        +count
@@ -1137,8 +1137,8 @@ INSERT INTO ab VALUES
 #·                    table        kv@primary
 #·                    spans        ALL
 #
-#exec-explain
-#SELECT v, COUNT(*) FROM kv GROUP BY v ORDER BY COUNT(*)
+#exec hide-colnames
+#EXPLAIN (VERBOSE) #SELECT v, COUNT(*) FROM kv GROUP BY v ORDER BY COUNT(*)
 #----
 #sort                 ·            ·
 # │                   order        +count
@@ -1152,8 +1152,8 @@ INSERT INTO ab VALUES
 #·                    table        kv@primary
 #·                    spans        ALL
 #
-#exec-explain
-#SELECT v, COUNT(1) FROM kv GROUP BY v ORDER BY COUNT(1)
+#exec hide-colnames
+#EXPLAIN (VERBOSE) SELECT v, COUNT(1) FROM kv GROUP BY v ORDER BY COUNT(1)
 #----
 #sort                 ·            ·
 # │                   order        +count
@@ -1253,8 +1253,8 @@ INSERT INTO ab VALUES
 #·               2  ·       spans        ALL                                ·                                                              ·
 
 # Tests with * inside GROUP BY.
-exec-explain
-SELECT 1 FROM kv GROUP BY kv.*;
+exec hide-colnames
+EXPLAIN (VERBOSE) SELECT 1 FROM kv GROUP BY kv.*;
 ----
 render     0  render  ·         ·           (column5)  ·
  │         0  ·       render 0  1           ·          ·
@@ -1273,8 +1273,8 @@ column5:int
 1
 1
 
-exec-explain
-SELECT SUM(abc.d) FROM kv JOIN abc ON kv.k >= abc.d GROUP BY kv.*;
+exec hide-colnames
+EXPLAIN (VERBOSE) SELECT SUM(abc.d) FROM kv JOIN abc ON kv.k >= abc.d GROUP BY kv.*;
 ----
 render               0  render  ·            ·            (column9)           ·
  │                   0  ·       render 0     agg0         ·                   ·
@@ -1316,7 +1316,7 @@ column9:decimal
 #----
 #
 ## Verify that we correctly add the v IS NOT NULL constraint (which restricts the span).
-#exec
+#exec hide-colnames
 #EXPLAIN (VERBOSE) SELECT MIN(v) FROM opt_test
 #----
 #group           0  group   ·            ·                       (min)            ·
@@ -1341,7 +1341,7 @@ column9:decimal
 #5
 #
 ## Repeat test when there is an existing filter.
-#exec
+#exec hide-colnames
 #EXPLAIN (VERBOSE) SELECT MIN(v) FROM opt_test WHERE k <> 4
 #----
 #group           0  group   ·            ·                       (min)   ·
@@ -1361,7 +1361,7 @@ column9:decimal
 ## Check the optimization when the argument is non-trivial. The renderNode can't
 ## present an ordering on v+1 so the optimization is not applied, but the IS NOT
 ## NULL filter should be added.
-#exec
+#exec hide-colnames
 #EXPLAIN (VERBOSE) SELECT MIN(v+1) FROM opt_test WHERE k <> 4
 #----
 #group           0  group   ·            ·                           (min)            ·
@@ -1374,7 +1374,7 @@ column9:decimal
 #·               2  ·       filter       (v + 1) IS NOT NULL         ·                ·
 #
 ## Verify that we don't use the optimization if there is a GROUP BY.
-#exec
+#exec hide-colnames
 #EXPLAIN (VERBOSE) SELECT MIN(v) FROM opt_test GROUP BY k
 #----
 #group      0  group  ·            ·                 (min)   ·
@@ -1447,8 +1447,8 @@ column3:tuple{int, int}
 (2, 1)
 (4, 3)
 
-exec-explain
-SELECT (b, a) FROM ab GROUP BY (b, a)
+exec hide-colnames
+EXPLAIN (VERBOSE) SELECT (b, a) FROM ab GROUP BY (b, a)
 ----
 render     0  render  ·         ·           (column3)  ·
  │         0  ·       render 0  (b, a)      ·          ·
@@ -1465,8 +1465,8 @@ b               (4, 3)
 d               (2, 1)
 d               (4, 3)
 
-exec-explain
-SELECT MIN(y), (b, a) FROM ab, xy GROUP BY (x, (a, b))
+exec hide-colnames
+EXPLAIN (VERBOSE) SELECT MIN(y), (b, a) FROM ab, xy GROUP BY (x, (a, b))
 ----
 render               0  render  ·            ·           (column6, column7)  ·
  │                   0  ·       render 0     agg0        ·                   ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain
@@ -1,0 +1,64 @@
+exec-raw
+CREATE TABLE xy (x INT PRIMARY KEY, y INT)
+----
+
+exec
+EXPLAIN (VERBOSE) SELECT * FROM xy
+----
+Tree:string  Level:int  Type:string  Field:string  Description:string  Columns:string  Ordering:string
+scan         0          scan         ·             ·                   (x, y)          ·
+·            0          ·            table         xy@primary          ·               ·
+·            0          ·            spans         ALL                 ·               ·
+
+exec
+EXPLAIN (VERBOSE) SELECT x, x, y FROM xy
+----
+Tree:string  Level:int  Type:string  Field:string  Description:string  Columns:string  Ordering:string
+render       0          render       ·             ·                   (x, x, y)       ·
+ │           0          ·            render 0      x                   ·               ·
+ │           0          ·            render 1      x                   ·               ·
+ │           0          ·            render 2      y                   ·               ·
+ └── scan    1          scan         ·             ·                   (x, y)          ·
+·            1          ·            table         xy@primary          ·               ·
+·            1          ·            spans         ALL                 ·               ·
+
+exec
+EXPLAIN (VERBOSE) SELECT * FROM xy ORDER BY y
+----
+Tree:string  Level:int  Type:string  Field:string  Description:string  Columns:string  Ordering:string
+sort         0          sort         ·             ·                   (x, y)          +y
+ │           0          ·            order         +y                  ·               ·
+ └── scan    1          scan         ·             ·                   (x, y)          ·
+·            1          ·            table         xy@primary          ·               ·
+·            1          ·            spans         ALL                 ·               ·
+
+exec
+EXPLAIN (VERBOSE) SELECT x, x, y FROM xy ORDER BY y
+----
+Tree:string     Level:int  Type:string  Field:string  Description:string  Columns:string  Ordering:string
+render          0          render       ·             ·                   (x, x, y)       ·
+ │              0          ·            render 0      x                   ·               ·
+ │              0          ·            render 1      x                   ·               ·
+ │              0          ·            render 2      y                   ·               ·
+ └── sort       1          sort         ·             ·                   (x, y)          +y
+      │         1          ·            order         +y                  ·               ·
+      └── scan  2          scan         ·             ·                   (x, y)          ·
+·               2          ·            table         xy@primary          ·               ·
+·               2          ·            spans         ALL                 ·               ·
+
+exec
+EXPLAIN (VERBOSE) SELECT * FROM xy INNER JOIN (VALUES (1, 2), (3, 4)) AS t(u,v) ON x=u
+----
+Tree:string  Level:int  Type:string  Field:string   Description:string  Columns:string      Ordering:string
+join         0          join         ·              ·                   (x, y, u, v)        ·
+ │           0          ·            type           inner               ·                   ·
+ │           0          ·            equality       (x) = (column1)     ·                   ·
+ ├── scan    1          scan         ·              ·                   (x, y)              ·
+ │           1          ·            table          xy@primary          ·                   ·
+ │           1          ·            spans          ALL                 ·                   ·
+ └── values  1          values       ·              ·                   (column1, column2)  ·
+·            1          ·            size           2 columns, 2 rows   ·                   ·
+·            1          ·            row 0, expr 0  1                   ·                   ·
+·            1          ·            row 0, expr 1  2                   ·                   ·
+·            1          ·            row 1, expr 0  3                   ·                   ·
+·            1          ·            row 1, expr 1  4                   ·                   ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/join
+++ b/pkg/sql/opt/exec/execbuilder/testdata/join
@@ -5,8 +5,8 @@ INSERT INTO a VALUES (1, 10), (2, 20), (3, 30);
 INSERT INTO b VALUES (2, 200), (3, 300), (4, 400)
 ----
 
-exec-explain
-SELECT * FROM a, b
+exec hide-colnames
+EXPLAIN (VERBOSE) SELECT * FROM a, b
 ----
 join       0  join  ·      ·          (x, y, x, z)  ·
  │         0  ·     type   cross      ·             ·
@@ -31,8 +31,8 @@ x:int  y:int  x:int  z:int
 3      30     3      300
 3      30     4      400
 
-exec-explain
-SELECT * FROM a, b WHERE a.x = b.x
+exec hide-colnames
+EXPLAIN (VERBOSE) SELECT * FROM a, b WHERE a.x = b.x
 ----
 join       0  join  ·         ·          (x, y, x, z)  ·
  │         0  ·     type      inner      ·             ·
@@ -51,8 +51,8 @@ x:int  y:int  x:int  z:int
 2      20     2      200
 3      30     3      300
 
-exec-explain
-SELECT * FROM a INNER JOIN b ON a.x = b.x
+exec hide-colnames
+EXPLAIN (VERBOSE) SELECT * FROM a INNER JOIN b ON a.x = b.x
 ----
 join       0  join  ·         ·          (x, y, x, z)  ·
  │         0  ·     type      inner      ·             ·
@@ -71,8 +71,8 @@ x:int  y:int  x:int  z:int
 2      20     2      200
 3      30     3      300
 
-exec-explain
-SELECT * FROM a NATURAL JOIN b
+exec hide-colnames
+EXPLAIN (VERBOSE) SELECT * FROM a NATURAL JOIN b
 ----
 render          0  render  ·         ·          (x, y, z)     ·
  │              0  ·       render 0  x          ·             ·
@@ -95,8 +95,8 @@ x:int  y:int  z:int
 2      20     200
 3      30     300
 
-exec-explain
-SELECT * FROM a LEFT OUTER JOIN b ON a.x = b.x
+exec hide-colnames
+EXPLAIN (VERBOSE) SELECT * FROM a LEFT OUTER JOIN b ON a.x = b.x
 ----
 join       0  join  ·         ·           (x, y, x, z)  ·
  │         0  ·     type      left outer  ·             ·
@@ -116,8 +116,8 @@ x:int  y:int  x:int  z:int
 2      20     2      200
 3      30     3      300
 
-exec-explain
-SELECT * FROM a NATURAL RIGHT OUTER JOIN b
+exec hide-colnames
+EXPLAIN (VERBOSE) SELECT * FROM a NATURAL RIGHT OUTER JOIN b
 ----
 render          0  render  ·         ·            (x, y, z)     ·
  │              0  ·       render 0  x            ·             ·
@@ -141,8 +141,8 @@ x:int  y:int  z:int
 3      30     300
 4      NULL   400
 
-exec-explain
-SELECT * FROM a FULL OUTER JOIN b USING(x)
+exec hide-colnames
+EXPLAIN (VERBOSE) SELECT * FROM a FULL OUTER JOIN b USING(x)
 ----
 render          0  render  ·         ·               (x, y, z)     ·
  │              0  ·       render 0  COALESCE(x, x)  ·             ·
@@ -168,8 +168,8 @@ x:int  y:int  z:int
 4      NULL   400
 
 # Select filters are pushed through join, down to scans.
-exec-explain
-SELECT * FROM a, b WHERE y > 10 AND z < 400
+exec hide-colnames
+EXPLAIN (VERBOSE) SELECT * FROM a, b WHERE y > 10 AND z < 400
 ----
 join            0  join    ·       ·          (x, y, x, z)  ·
  │              0  ·       type    cross      ·             ·
@@ -194,8 +194,8 @@ x:int  y:int  x:int  z:int
 3      30     3      300
 
 # Join filter is pushed through join, down to scan.
-exec-explain
-SELECT * FROM a LEFT JOIN b ON a.x=b.x AND z < 300
+exec hide-colnames
+EXPLAIN (VERBOSE) SELECT * FROM a LEFT JOIN b ON a.x=b.x AND z < 300
 ----
 join            0  join    ·         ·           (x, y, x, z)  ·
  │              0  ·       type      left outer  ·             ·
@@ -225,8 +225,8 @@ CREATE TABLE c (u INT PRIMARY KEY, v INT);
 INSERT INTO c VALUES (2, 200), (3, 300), (4, 400)
 ----
 
-exec-explain
-SELECT * FROM a WHERE EXISTS(SELECT * FROM c WHERE x = u)
+exec hide-colnames
+EXPLAIN (VERBOSE) SELECT * FROM a WHERE EXISTS(SELECT * FROM c WHERE x = u)
 ----
 join       0  join  ·         ·          (x, y)  ·
  │         0  ·     type      semi       ·       ·
@@ -245,8 +245,8 @@ x:int  y:int
 2      20
 3      30
 
-exec-explain
-SELECT * FROM a WHERE EXISTS(SELECT * FROM c WHERE x-1 = u)
+exec hide-colnames
+EXPLAIN (VERBOSE) SELECT * FROM a WHERE EXISTS(SELECT * FROM c WHERE x-1 = u)
 ----
 join       0  join  ·      ·            (x, y)  ·
  │         0  ·     type   semi         ·       ·
@@ -264,8 +264,8 @@ SELECT * FROM a WHERE EXISTS(SELECT * FROM c WHERE x-1 = u)
 x:int  y:int
 3      30
 
-exec-explain
-SELECT * FROM a WHERE NOT EXISTS(SELECT * FROM c WHERE x = u)
+exec hide-colnames
+EXPLAIN (VERBOSE) SELECT * FROM a WHERE NOT EXISTS(SELECT * FROM c WHERE x = u)
 ----
 join       0  join  ·         ·          (x, y)  ·
  │         0  ·     type      anti       ·       ·
@@ -283,8 +283,8 @@ SELECT * FROM a WHERE NOT EXISTS(SELECT * FROM c WHERE x = u)
 x:int  y:int
 1      10
 
-exec-explain
-SELECT * FROM a WHERE NOT EXISTS(SELECT * FROM c WHERE x-1 = u)
+exec hide-colnames
+EXPLAIN (VERBOSE) SELECT * FROM a WHERE NOT EXISTS(SELECT * FROM c WHERE x-1 = u)
 ----
 join       0  join  ·      ·            (x, y)  ·
  │         0  ·     type   anti         ·       ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/limit
+++ b/pkg/sql/opt/exec/execbuilder/testdata/limit
@@ -3,8 +3,8 @@ CREATE TABLE t (k INT PRIMARY KEY, v INT, w INT, INDEX(v));
 INSERT INTO t VALUES (1, 1, 1), (2, -4, 8), (3, 9, 27), (4, -16, 94), (5, 25, 125), (6, -36, 216)
 ----
 
-exec-explain
-SELECT k, v FROM t ORDER BY k LIMIT 5
+exec hide-colnames
+EXPLAIN (VERBOSE) SELECT k, v FROM t ORDER BY k LIMIT 5
 ----
 scan  0  scan  ·      ·          (k, v)  ·
 ·     0  ·     table  t@primary  ·       ·
@@ -21,8 +21,8 @@ k:int  v:int
 4      -16
 5      25
 
-exec-explain
-SELECT k, v FROM t ORDER BY k OFFSET 5
+exec hide-colnames
+EXPLAIN (VERBOSE) SELECT k, v FROM t ORDER BY k OFFSET 5
 ----
 limit      0  limit  ·       ·          (k, v)  ·
  │         0  ·      offset  5          ·       ·
@@ -36,8 +36,8 @@ SELECT k, v FROM t ORDER BY k OFFSET 5
 k:int  v:int
 6      -36
 
-exec-explain
-SELECT k, v FROM t ORDER BY v LIMIT (1+4) OFFSET 1
+exec hide-colnames
+EXPLAIN (VERBOSE) SELECT k, v FROM t ORDER BY v LIMIT (1+4) OFFSET 1
 ----
 limit      0  limit  ·       ·          (k, v)  ·
  │         0  ·      count   5          ·       ·
@@ -56,8 +56,8 @@ k:int  v:int
 3      9
 5      25
 
-exec-explain
-SELECT k, v FROM t ORDER BY v DESC LIMIT (1+4) OFFSET 1
+exec hide-colnames
+EXPLAIN (VERBOSE) SELECT k, v FROM t ORDER BY v DESC LIMIT (1+4) OFFSET 1
 ----
 limit           0  limit  ·       ·          (k, v)  -v
  │              0  ·      count   5          ·       ·
@@ -78,8 +78,8 @@ k:int  v:int
 4      -16
 6      -36
 
-exec-explain
-SELECT SUM(w) FROM t GROUP BY k, v ORDER BY v DESC LIMIT 10
+exec hide-colnames
+EXPLAIN (VERBOSE) SELECT SUM(w) FROM t GROUP BY k, v ORDER BY v DESC LIMIT 10
 ----
 render                         0  render  ·            ·          (column4)         ·
  │                             0  ·       render 0     column4    ·                 ·
@@ -110,8 +110,8 @@ column4:decimal
 94
 216
 
-exec-explain
-SELECT k FROM (SELECT k, v FROM t ORDER BY v LIMIT 4)
+exec hide-colnames
+EXPLAIN (VERBOSE) SELECT k FROM (SELECT k, v FROM t ORDER BY v LIMIT 4)
 ----
 render     0  render  ·         ·          (k)     ·
  │         0  ·       render 0  k          ·       ·
@@ -129,8 +129,8 @@ k:int
 2
 1
 
-exec-explain
-SELECT k FROM (SELECT k, v, w FROM t ORDER BY v LIMIT 4)
+exec hide-colnames
+EXPLAIN (VERBOSE) SELECT k FROM (SELECT k, v, w FROM t ORDER BY v LIMIT 4)
 ----
 render     0  render  ·         ·          (k)     ·
  │         0  ·       render 0  k          ·       ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/orderby
+++ b/pkg/sql/opt/exec/execbuilder/testdata/orderby
@@ -20,8 +20,8 @@ NULL
 false
 true
 
-exec-explain
-SELECT c FROM t ORDER BY c
+exec hide-colnames
+EXPLAIN (VERBOSE) SELECT c FROM t ORDER BY c
 ----
 sort       0  sort  ·      ·          (c)  +c
  │         0  ·     order  +c         ·    ·
@@ -45,8 +45,8 @@ a:int  b:int
 2      8
 1      9
 
-exec-explain
-SELECT a, b FROM t ORDER BY b
+exec hide-colnames
+EXPLAIN (VERBOSE) SELECT a, b FROM t ORDER BY b
 ----
 sort       0  sort  ·      ·          (a, b)  +b
  │         0  ·     order  +b         ·       ·
@@ -62,8 +62,8 @@ a:int  b:int
 2      8
 3      7
 
-exec-explain
-SELECT a, b FROM t ORDER BY b DESC
+exec hide-colnames
+EXPLAIN (VERBOSE) SELECT a, b FROM t ORDER BY b DESC
 ----
 sort       0  sort  ·      ·          (a, b)  -b
  │         0  ·     order  -b         ·       ·
@@ -80,8 +80,8 @@ a:int
 2
 1
 
-exec-explain
-SELECT a, b FROM t ORDER BY b LIMIT 2
+exec hide-colnames
+EXPLAIN (VERBOSE) SELECT a, b FROM t ORDER BY b LIMIT 2
 ----
 limit           0  limit  ·      ·          (a, b)  +b
  │              0  ·      count  2          ·       ·
@@ -99,8 +99,8 @@ a:int  b:int
 2      8
 
 # TODO(radu): this does not work. Unclear if we want to support it or not.
-#exec-explain
-#SELECT DISTINCT c FROM t ORDER BY b LIMIT 2
+#exec hide-colnames
+#EXPLAIN (VERBOSE) #SELECT DISTINCT c FROM t ORDER BY b LIMIT 2
 #----
 #limit                     0  limit     ·         ·                (c)                 weak-key(c)
 # │                        0  ·         count     2                ·                   ·
@@ -129,8 +129,8 @@ b:int
 8
 9
 
-exec-explain
-SELECT b FROM t ORDER BY a DESC
+exec hide-colnames
+EXPLAIN (VERBOSE) SELECT b FROM t ORDER BY a DESC
 ----
 render          0  render  ·         ·          (b)     ·
  │              0  ·       render 0  b          ·       ·
@@ -140,8 +140,8 @@ render          0  render  ·         ·          (b)     ·
 ·               2  ·       table     t@primary  ·       ·
 ·               2  ·       spans     ALL        ·       ·
 
-exec-explain
-SELECT b FROM t ORDER BY a LIMIT 1
+exec hide-colnames
+EXPLAIN (VERBOSE) SELECT b FROM t ORDER BY a LIMIT 1
 ----
 render     0  render  ·         ·          (b)     ·
  │         0  ·       render 0  b          ·       ·
@@ -150,8 +150,8 @@ render     0  render  ·         ·          (b)     ·
 ·          1  ·       spans     ALL        ·       ·
 ·          1  ·       limit     1          ·       ·
 
-exec-explain
-SELECT b FROM t ORDER BY a DESC, b ASC
+exec hide-colnames
+EXPLAIN (VERBOSE) SELECT b FROM t ORDER BY a DESC, b ASC
 ----
 render          0  render  ·         ·          (b)     ·
  │              0  ·       render 0  b          ·       ·
@@ -161,8 +161,8 @@ render          0  render  ·         ·          (b)     ·
 ·               2  ·       table     t@primary  ·       ·
 ·               2  ·       spans     ALL        ·       ·
 
-exec-explain
-SELECT b FROM t ORDER BY a DESC, b DESC
+exec hide-colnames
+EXPLAIN (VERBOSE) SELECT b FROM t ORDER BY a DESC, b DESC
 ----
 render          0  render  ·         ·          (b)     ·
  │              0  ·       render 0  b          ·       ·
@@ -172,8 +172,8 @@ render          0  render  ·         ·          (b)     ·
 ·               2  ·       table     t@primary  ·       ·
 ·               2  ·       spans     ALL        ·       ·
 
-exec-explain
-SELECT * FROM t ORDER BY (b, t.*)
+exec hide-colnames
+EXPLAIN (VERBOSE) SELECT * FROM t ORDER BY (b, t.*)
 ----
 sort       0  sort  ·      ·          (a, b, c)  +b,+a,+c
  │         0  ·     order  +b,+a,+c   ·          ·
@@ -181,8 +181,8 @@ sort       0  sort  ·      ·          (a, b, c)  +b,+a,+c
 ·          1  ·     table  t@primary  ·          ·
 ·          1  ·     spans  ALL        ·          ·
 
-exec-explain
-SELECT * FROM t ORDER BY (b, a), c
+exec hide-colnames
+EXPLAIN (VERBOSE) SELECT * FROM t ORDER BY (b, a), c
 ----
 sort       0  sort  ·      ·          (a, b, c)  +b,+a,+c
  │         0  ·     order  +b,+a,+c   ·          ·
@@ -190,8 +190,8 @@ sort       0  sort  ·      ·          (a, b, c)  +b,+a,+c
 ·          1  ·     table  t@primary  ·          ·
 ·          1  ·     spans  ALL        ·          ·
 
-exec-explain
-SELECT * FROM t ORDER BY b, (a, c)
+exec hide-colnames
+EXPLAIN (VERBOSE) SELECT * FROM t ORDER BY b, (a, c)
 ----
 sort       0  sort  ·      ·          (a, b, c)  +b,+a,+c
  │         0  ·     order  +b,+a,+c   ·          ·
@@ -199,8 +199,8 @@ sort       0  sort  ·      ·          (a, b, c)  +b,+a,+c
 ·          1  ·     table  t@primary  ·          ·
 ·          1  ·     spans  ALL        ·          ·
 
-exec-explain
-SELECT * FROM t ORDER BY (b, (a, c))
+exec hide-colnames
+EXPLAIN (VERBOSE) SELECT * FROM t ORDER BY (b, (a, c))
 ----
 sort       0  sort  ·      ·          (a, b, c)  +b,+a,+c
  │         0  ·     order  +b,+a,+c   ·          ·
@@ -298,8 +298,8 @@ a:int
 
 # Check that sort is skipped if the ORDER BY clause is constant.
 # TODO(radu): we don't optimize constant columns yet.
-exec-explain
-SELECT * FROM t ORDER BY 1+2
+exec hide-colnames
+EXPLAIN (VERBOSE) SELECT * FROM t ORDER BY 1+2
 ----
 render               0  render  ·         ·          (a, b, c)                       ·
  │                   0  ·       render 0  "t.a"      ·                               ·
@@ -316,8 +316,8 @@ render               0  render  ·         ·          (a, b, c)                
 ·                    3  ·       table     t@primary  ·                               ·
 ·                    3  ·       spans     ALL        ·                               ·
 
-exec-explain
-SELECT 1, * FROM t ORDER BY 1
+exec hide-colnames
+EXPLAIN (VERBOSE) SELECT 1, * FROM t ORDER BY 1
 ----
 sort            0  sort    ·         ·          (column4, a, b, c)  +column4
  │              0  ·       order     +column4   ·                   ·
@@ -330,8 +330,8 @@ sort            0  sort    ·         ·          (column4, a, b, c)  +column4
 ·               2  ·       table     t@primary  ·                   ·
 ·               2  ·       spans     ALL        ·                   ·
 
-exec-explain
-SELECT * FROM t ORDER BY length('abc')
+exec hide-colnames
+EXPLAIN (VERBOSE) SELECT * FROM t ORDER BY length('abc')
 ----
 render               0  render  ·         ·              (a, b, c)                       ·
  │                   0  ·       render 0  "t.a"          ·                               ·
@@ -349,8 +349,8 @@ render               0  render  ·         ·              (a, b, c)            
 ·                    3  ·       spans     ALL            ·                               ·
 
 # Check that the sort key reuses the existing render.
-exec-explain
-SELECT b+2 FROM t ORDER BY b+2
+exec hide-colnames
+EXPLAIN (VERBOSE) SELECT b+2 FROM t ORDER BY b+2
 ----
 sort            0  sort    ·         ·          (column4)  +column4
  │              0  ·       order     +column4   ·          ·
@@ -361,8 +361,8 @@ sort            0  sort    ·         ·          (column4)  +column4
 ·               2  ·       spans     ALL        ·          ·
 
 # Check that the sort picks up a renamed render properly.
-exec-explain
-SELECT b+2 AS y FROM t ORDER BY y
+exec hide-colnames
+EXPLAIN (VERBOSE) SELECT b+2 AS y FROM t ORDER BY y
 ----
 sort            0  sort    ·         ·          (y)  +y
  │              0  ·       order     +y         ·    ·
@@ -373,8 +373,8 @@ sort            0  sort    ·         ·          (y)  +y
 ·               2  ·       spans     ALL        ·    ·
 
 # Check that the sort reuses a render behind a rename properly.
-exec-explain
-SELECT b+2 AS y FROM t ORDER BY b+2
+exec hide-colnames
+EXPLAIN (VERBOSE) SELECT b+2 AS y FROM t ORDER BY b+2
 ----
 sort            0  sort    ·         ·          (y)  +y
  │              0  ·       order     +y         ·    ·
@@ -420,8 +420,8 @@ six
 three
 two
 
-exec-explain
-SELECT * FROM abc ORDER BY a
+exec hide-colnames
+EXPLAIN (VERBOSE) SELECT * FROM abc ORDER BY a
 ----
 scan  0  scan  ·      ·            (a, b, c, d)  ·
 ·     0  ·     table  abc@primary  ·             ·
@@ -441,8 +441,8 @@ a:int  b:int  c:int  d:string
 3      8      1      eight
 3      9      1      nine
 
-exec-explain
-SELECT * FROM abc ORDER BY a, c
+exec hide-colnames
+EXPLAIN (VERBOSE) SELECT * FROM abc ORDER BY a, c
 ----
 sort       0  sort  ·      ·            (a, b, c, d)  +a,+c
  │         0  ·     order  +a,+c        ·             ·
@@ -464,8 +464,8 @@ a:int  b:int  c:int  d:string
 3      8      1      eight
 3      9      1      nine
 
-exec-explain
-SELECT a, b FROM abc ORDER BY b, a
+exec hide-colnames
+EXPLAIN (VERBOSE) SELECT a, b FROM abc ORDER BY b, a
 ----
 scan  0  scan  ·      ·       (a, b)  ·
 ·     0  ·     table  abc@ba  ·       ·
@@ -487,8 +487,8 @@ a:int  b:int
 
 # The non-unique index ba includes column c (required to make the keys unique)
 # so the results will already be sorted.
-exec-explain
-SELECT a, b, c FROM abc ORDER BY b, a, c
+exec hide-colnames
+EXPLAIN (VERBOSE) SELECT a, b, c FROM abc ORDER BY b, a, c
 ----
 scan  0  scan  ·      ·       (a, b, c)  ·
 ·     0  ·     table  abc@ba  ·          ·
@@ -509,8 +509,8 @@ a:int  b:int  c:int
 3      9      1
 
 # We use the WHERE condition to force the use of index ba.
-exec-explain
-SELECT a, b, c FROM abc WHERE b > 4 ORDER BY b, a, d
+exec hide-colnames
+EXPLAIN (VERBOSE) SELECT a, b, c FROM abc WHERE b > 4 ORDER BY b, a, d
 ----
 render               0  render  ·         ·            (a, b, c)     ·
  │                   0  ·       render 0  a            ·             ·
@@ -536,8 +536,8 @@ a:int  b:int  c:int
 
 # We cannot have rows with identical values for a,b,c so we don't need to
 # sort for d.
-exec-explain
-SELECT a, b, c, d FROM abc WHERE b > 4 ORDER BY b, a, c, d
+exec hide-colnames
+EXPLAIN (VERBOSE) SELECT a, b, c, d FROM abc WHERE b > 4 ORDER BY b, a, c, d
 ----
 sort            0  sort    ·       ·            (a, b, c, d)  +b,+a,+c,+d
  │              0  ·       order   +b,+a,+c,+d  ·             ·
@@ -557,8 +557,8 @@ a:int  b:int  c:int  d:string
 3      8      1      eight
 3      9      1      nine
 
-exec-explain
-SELECT a, b FROM abc ORDER BY b, c
+exec hide-colnames
+EXPLAIN (VERBOSE) SELECT a, b FROM abc ORDER BY b, c
 ----
 render     0  render  ·         ·       (a, b)     ·
  │         0  ·       render 0  a       ·          ·
@@ -581,8 +581,8 @@ a:int  b:int
 3      8
 3      9
 
-exec-explain
-SELECT a, b FROM abc ORDER BY c, b
+exec hide-colnames
+EXPLAIN (VERBOSE) SELECT a, b FROM abc ORDER BY c, b
 ----
 render          0  render  ·         ·            (a, b)     ·
  │              0  ·       render 0  a            ·          ·
@@ -607,8 +607,8 @@ a:int  b:int
 1      2
 1      3
 
-exec-explain
-SELECT a, b FROM abc ORDER BY b, c, a
+exec hide-colnames
+EXPLAIN (VERBOSE) SELECT a, b FROM abc ORDER BY b, c, a
 ----
 render     0  render  ·         ·       (a, b)     ·
  │         0  ·       render 0  a       ·          ·
@@ -631,8 +631,8 @@ a:int  b:int
 3      8
 3      9
 
-exec-explain
-SELECT a, b FROM abc ORDER BY b, c, a DESC
+exec hide-colnames
+EXPLAIN (VERBOSE) SELECT a, b FROM abc ORDER BY b, c, a DESC
 ----
 render          0  render  ·         ·            (a, b)     ·
  │              0  ·       render 0  a            ·          ·
@@ -657,8 +657,8 @@ a:int  b:int
 3      8
 3      9
 
-exec-explain
-SELECT a FROM abc ORDER BY a DESC
+exec hide-colnames
+EXPLAIN (VERBOSE) SELECT a FROM abc ORDER BY a DESC
 ----
 sort       0  sort  ·      ·            (a)  -a
  │         0  ·     order  -a           ·    ·
@@ -699,8 +699,8 @@ a:int
 1
 1
 
-exec-explain
-SELECT c FROM abc WHERE b = 2 ORDER BY c
+exec hide-colnames
+EXPLAIN (VERBOSE) SELECT c FROM abc WHERE b = 2 ORDER BY c
 ----
 sort            0  sort    ·         ·       (c)     +c
  │              0  ·       order     +c      ·       ·
@@ -710,8 +710,8 @@ sort            0  sort    ·         ·       (c)     +c
 ·               2  ·       table     abc@bc  ·       ·
 ·               2  ·       spans     /2-/3   ·       ·
 
-exec-explain
-SELECT c FROM abc WHERE b = 2 ORDER BY c DESC
+exec hide-colnames
+EXPLAIN (VERBOSE) SELECT c FROM abc WHERE b = 2 ORDER BY c DESC
 ----
 sort            0  sort    ·         ·       (c)     -c
  │              0  ·       order     -c      ·       ·
@@ -722,8 +722,8 @@ sort            0  sort    ·         ·       (c)     -c
 ·               2  ·       spans     /2-/3   ·       ·
 
 # Verify that the ordering of the primary index is still used for the outer sort.
-exec-explain
-SELECT * FROM (SELECT b, c FROM abc WHERE a=1 ORDER BY a,b) ORDER BY b,c
+exec hide-colnames
+EXPLAIN (VERBOSE) SELECT * FROM (SELECT b, c FROM abc WHERE a=1 ORDER BY a,b) ORDER BY b,c
 ----
 render          0  render  ·         ·            (b, c)     ·
  │              0  ·       render 0  b            ·          ·
@@ -747,8 +747,8 @@ exec-raw
 INSERT INTO bar VALUES (0, NULL, 10), (1, NULL, 5)
 ----
 
-exec-explain
-SELECT * FROM bar ORDER BY baz, extra
+exec hide-colnames
+EXPLAIN (VERBOSE) SELECT * FROM bar ORDER BY baz, extra
 ----
 sort       0  sort  ·      ·            (id, baz, extra)  +baz,+extra
  │         0  ·     order  +baz,+extra  ·                 ·
@@ -803,8 +803,8 @@ column5:int
 7
 
 # The following tests verify we recognize that sorting is not necessary
-exec-explain
-SELECT a, b, c FROM abcd@abc WHERE (a, b) = (1, 4) ORDER BY c
+exec hide-colnames
+EXPLAIN (VERBOSE) SELECT a, b, c FROM abcd@abc WHERE (a, b) = (1, 4) ORDER BY c
 ----
 sort       0  sort  ·      ·          (a, b, c)  +c
  │         0  ·     order  +c         ·          ·
@@ -812,8 +812,8 @@ sort       0  sort  ·      ·          (a, b, c)  +c
 ·          1  ·     table  abcd@abc   ·          ·
 ·          1  ·     spans  /1/4-/1/5  ·          ·
 
-exec-explain
-SELECT a, b, c FROM abcd@abc WHERE (a, b) = (1, 4) ORDER BY c, b, a
+exec hide-colnames
+EXPLAIN (VERBOSE) SELECT a, b, c FROM abcd@abc WHERE (a, b) = (1, 4) ORDER BY c, b, a
 ----
 sort       0  sort  ·      ·          (a, b, c)  +c,+b,+a
  │         0  ·     order  +c,+b,+a   ·          ·
@@ -821,8 +821,8 @@ sort       0  sort  ·      ·          (a, b, c)  +c,+b,+a
 ·          1  ·     table  abcd@abc   ·          ·
 ·          1  ·     spans  /1/4-/1/5  ·          ·
 
-exec-explain
-SELECT a, b, c FROM abcd@abc WHERE (a, b) = (1, 4) ORDER BY b, a, c
+exec hide-colnames
+EXPLAIN (VERBOSE) SELECT a, b, c FROM abcd@abc WHERE (a, b) = (1, 4) ORDER BY b, a, c
 ----
 sort       0  sort  ·      ·          (a, b, c)  +b,+a,+c
  │         0  ·     order  +b,+a,+c   ·          ·
@@ -830,8 +830,8 @@ sort       0  sort  ·      ·          (a, b, c)  +b,+a,+c
 ·          1  ·     table  abcd@abc   ·          ·
 ·          1  ·     spans  /1/4-/1/5  ·          ·
 
-exec-explain
-SELECT a, b, c FROM abcd@abc WHERE (a, b) = (1, 4) ORDER BY b, c, a
+exec hide-colnames
+EXPLAIN (VERBOSE) SELECT a, b, c FROM abcd@abc WHERE (a, b) = (1, 4) ORDER BY b, c, a
 ----
 sort       0  sort  ·      ·          (a, b, c)  +b,+c,+a
  │         0  ·     order  +b,+c,+a   ·          ·
@@ -856,8 +856,8 @@ NaN
 -1.0
 1.0
 
-exec-explain
-SELECT * FROM (VALUES ('a'), ('b'), ('c')) AS c(x) ORDER BY x
+exec hide-colnames
+EXPLAIN (VERBOSE) SELECT * FROM (VALUES ('a'), ('b'), ('c')) AS c(x) ORDER BY x
 ----
 sort         0  sort    ·              ·                 (x)  +x
  │           0  ·       order          +x                ·    ·
@@ -867,8 +867,8 @@ sort         0  sort    ·              ·                 (x)  +x
 ·            1  ·       row 1, expr 0  'b'               ·    ·
 ·            1  ·       row 2, expr 0  'c'               ·    ·
 
-exec-explain
-SELECT * FROM (SELECT * FROM (VALUES ('a'), ('b'), ('c')) AS c(x) ORDER BY x)
+exec hide-colnames
+EXPLAIN (VERBOSE) SELECT * FROM (SELECT * FROM (VALUES ('a'), ('b'), ('c')) AS c(x) ORDER BY x)
 ----
 values  0  values  ·              ·                 (x)  ·
 ·       0  ·       size           1 column, 3 rows  ·    ·
@@ -877,15 +877,15 @@ values  0  values  ·              ·                 (x)  ·
 ·       0  ·       row 2, expr 0  'c'               ·    ·
 
 # TODO(radu): ordinality not supported
-#exec-explain
-#SELECT * FROM (VALUES ('a'), ('b'), ('c')) WITH ORDINALITY ORDER BY ordinality ASC
+#exec hide-colnames
+#EXPLAIN (VERBOSE) #SELECT * FROM (VALUES ('a'), ('b'), ('c')) WITH ORDINALITY ORDER BY ordinality ASC
 #----
 #ordinality   ·     ·
 # └── values  ·     ·
 #·            size  1 column, 3 rows
 #
-#exec-explain
-#SELECT * FROM (VALUES ('a'), ('b'), ('c')) WITH ORDINALITY ORDER BY ordinality DESC
+#exec hide-colnames
+#EXPLAIN (VERBOSE) SELECT * FROM (VALUES ('a'), ('b'), ('c')) WITH ORDINALITY ORDER BY ordinality DESC
 #----
 #sort              ·      ·
 # │                order  -"ordinality"
@@ -894,8 +894,8 @@ values  0  values  ·              ·                 (x)  ·
 #·                 size   1 column, 3 rows
 #
 # Once ordinality is supported these test cases should have a sort node.
-#exec-explain
-#SELECT * FROM (SELECT * FROM (VALUES ('a'), ('b'), ('c')) AS c(x)) WITH ORDINALITY
+#exec hide-colnames
+#EXPLAIN (VERBOSE) SELECT * FROM (SELECT * FROM (VALUES ('a'), ('b'), ('c')) AS c(x)) WITH ORDINALITY
 #----
 #values  0  values  ·              ·                 (x)  ·
 #·       0  ·       size           1 column, 3 rows  ·    ·
@@ -903,8 +903,8 @@ values  0  values  ·              ·                 (x)  ·
 #·       0  ·       row 1, expr 0  'b'               ·    ·
 #·       0  ·       row 2, expr 0  'c'               ·    ·
 #
-#exec-explain
-#SELECT * FROM (SELECT * FROM (VALUES ('a'), ('b'), ('c')) AS c(x) ORDER BY x) WITH ORDINALITY
+#exec hide-colnames
+#EXPLAIN (VERBOSE) SELECT * FROM (SELECT * FROM (VALUES ('a'), ('b'), ('c')) AS c(x) ORDER BY x) WITH ORDINALITY
 #----
 #values  0  values  ·              ·                 (x)  ·
 #·       0  ·       size           1 column, 3 rows  ·    ·
@@ -914,16 +914,16 @@ values  0  values  ·              ·                 (x)  ·
 
 # TODO(radu): DML statements not supported yet.
 ## Check that the ordering of the source does not propagate blindly to RETURNING.
-#exec-explain
-#INSERT INTO t(a, b) SELECT * FROM (SELECT 1 AS x, 2 AS y) ORDER BY x RETURNING b
+#exec hide-colnames
+#EXPLAIN (VERBOSE) #INSERT INTO t(a, b) SELECT * FROM (SELECT 1 AS x, 2 AS y) ORDER BY x RETURNING b
 #----
 #insert              0  insert    ·     ·        (b)     ·
 # │                  0  ·         into  t(a, b)  ·       ·
 # └── render         1  render    ·     ·        (x, y)  x=CONST; y=CONST
 #      └── emptyrow  2  emptyrow  ·     ·        ()      ·
 #
-#exec-explain
-#DELETE FROM t WHERE a = 3 RETURNING b
+#exec hide-colnames
+#EXPLAIN (VERBOSE) DELETE FROM t WHERE a = 3 RETURNING b
 #----
 #delete     0  delete  ·      ·          (b)        ·
 # │         0  ·       from   t          ·          ·
@@ -931,8 +931,8 @@ values  0  values  ·              ·                 (x)  ·
 #·          1  ·       table  t@primary  ·          ·
 #·          1  ·       spans  /3-/3/#    ·          ·
 #
-#exec-explain
-#UPDATE t SET c = TRUE RETURNING b
+#exec hide-colnames
+#EXPLAIN (VERBOSE) UPDATE t SET c = TRUE RETURNING b
 #----
 #update          0  update  ·      ·          (b)                ·
 # │              0  ·       table  t          ·                  ·
@@ -957,8 +957,8 @@ CREATE TABLE uvwxyz (
 
 # Verify that the outer ordering is propagated to index selection and we choose
 # the index that avoids any sorting.
-exec-explain
-SELECT * FROM (SELECT y, w, x FROM uvwxyz WHERE y = 1 ORDER BY w) ORDER BY w, x
+exec hide-colnames
+EXPLAIN (VERBOSE) SELECT * FROM (SELECT y, w, x FROM uvwxyz WHERE y = 1 ORDER BY w) ORDER BY w, x
 ----
 render          0  render  ·         ·            (y, w, x)  ·
  │              0  ·       render 0  y            ·          ·
@@ -983,8 +983,8 @@ CREATE TABLE blocks (
 # TODO(radu): LIMIT not supported yet.
 ## Test that ordering goes "through" a renderNode that has a duplicate render of
 ## an order-by column (#13696).
-#exec-explain
-#SELECT block_id,writer_id,block_num,block_id FROM blocks ORDER BY block_id, writer_id, block_num LIMIT 1
+#exec hide-colnames
+#EXPLAIN (VERBOSE) #SELECT block_id,writer_id,block_num,block_id FROM blocks ORDER BY block_id, writer_id, block_num LIMIT 1
 #----
 #render          0  render  ·         ·                   (block_id, writer_id, block_num, block_id)                                      ·
 # │              0  ·       render 0  "blocks.block_id"   ·                                                                               ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/project
+++ b/pkg/sql/opt/exec/execbuilder/testdata/project
@@ -10,8 +10,8 @@ exec-raw
 INSERT INTO a VALUES (1, 10), (2, 20), (3, 30)
 ----
 
-exec-explain
-SELECT * FROM a WHERE x > 1
+exec hide-colnames
+EXPLAIN (VERBOSE) SELECT * FROM a WHERE x > 1
 ----
 scan  0  scan  ·      ·          (x, y)  ·
 ·     0  ·     table  a@primary  ·       ·
@@ -24,8 +24,8 @@ x:int  y:int
 2      20
 3      30
 
-exec-explain
-SELECT * FROM a WHERE y > 1
+exec hide-colnames
+EXPLAIN (VERBOSE) SELECT * FROM a WHERE y > 1
 ----
 filter     0  filter  ·       ·          (x, y)  ·
  │         0  ·       filter  y > 1      ·       ·
@@ -41,8 +41,8 @@ x:int  y:int
 2      20
 3      30
 
-exec-explain
-SELECT * FROM a WHERE x > 1 AND x < 3
+exec hide-colnames
+EXPLAIN (VERBOSE) SELECT * FROM a WHERE x > 1 AND x < 3
 ----
 scan  0  scan  ·      ·          (x, y)  ·
 ·     0  ·     table  a@primary  ·       ·
@@ -54,8 +54,8 @@ SELECT * FROM a WHERE x > 1 AND x < 3
 x:int  y:int
 2      20
 
-exec-explain
-SELECT x + 1 FROM a
+exec hide-colnames
+EXPLAIN (VERBOSE) SELECT x + 1 FROM a
 ----
 render     0  render  ·         ·          (column3)  ·
  │         0  ·       render 0  x + 1      ·          ·
@@ -71,8 +71,8 @@ column3:int
 3
 4
 
-exec-explain
-SELECT x, x + 1, y, y + 1, x + y FROM a
+exec hide-colnames
+EXPLAIN (VERBOSE) SELECT x, x + 1, y, y + 1, x + y FROM a
 ----
 render     0  render  ·         ·          (x, column3, y, column4, column5)  ·
  │         0  ·       render 0  x          ·                                  ·
@@ -92,8 +92,8 @@ x:int  column3:int  y:int  column4:int  column5:int
 2      3            20     21           22
 3      4            30     31           33
 
-exec-explain
-SELECT u + v FROM (SELECT x + 3, y + 10 FROM a) AS foo(u, v)
+exec hide-colnames
+EXPLAIN (VERBOSE) SELECT u + v FROM (SELECT x + 3, y + 10 FROM a) AS foo(u, v)
 ----
 render          0  render  ·         ·                  (column5)           ·
  │              0  ·       render 0  column3 + column4  ·                   ·
@@ -112,8 +112,8 @@ column5:int
 35
 46
 
-exec-explain
-SELECT x, x, y, x FROM a
+exec hide-colnames
+EXPLAIN (VERBOSE) SELECT x, x, y, x FROM a
 ----
 render     0  render  ·         ·          (x, x, y, x)  ·
  │         0  ·       render 0  x          ·             ·
@@ -132,8 +132,8 @@ x:int  x:int  y:int  x:int
 2      2      20     2
 3      3      30     3
 
-exec-explain
-SELECT x + 1, x + y FROM a WHERE x + y > 20
+exec hide-colnames
+EXPLAIN (VERBOSE) SELECT x + 1, x + y FROM a WHERE x + y > 20
 ----
 render          0  render  ·         ·             (column3, column4)  ·
  │              0  ·       render 0  x + 1         ·                   ·
@@ -157,8 +157,8 @@ INSERT INTO b VALUES (1, 10), (2, 20), (3, 30)
 ----
 
 # Test with a hidden column.
-exec-explain
-SELECT * FROM b
+exec hide-colnames
+EXPLAIN (VERBOSE) SELECT * FROM b
 ----
 scan  0  scan  ·      ·          (x, y)  ·
 ·     0  ·     table  b@primary  ·       ·
@@ -172,8 +172,8 @@ x:int  y:int
 2      20
 3      30
 
-exec-explain
-SELECT x FROM b WHERE rowid > 0
+exec hide-colnames
+EXPLAIN (VERBOSE) SELECT x FROM b WHERE rowid > 0
 ----
 render     0  render  ·         ·          (x)                 ·
  │         0  ·       render 0  x          ·                   ·
@@ -202,8 +202,8 @@ TABLE nocols
  └── INDEX primary
       └── rowid int not null (hidden)
 
-exec-explain
-SELECT 1, * FROM t.nocols
+exec hide-colnames
+EXPLAIN (VERBOSE) SELECT 1, * FROM t.nocols
 ----
 render     0  render  ·         ·               (column2)  ·
  │         0  ·       render 0  1               ·          ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/scalar
+++ b/pkg/sql/opt/exec/execbuilder/testdata/scalar
@@ -6,48 +6,48 @@ exec-raw
 CREATE TABLE t (a INT, b INT, c INT, d INT, j JSONB, s STRING)
 ----
 
-exec-explain
-SELECT 1 + 2
+exec hide-colnames
+EXPLAIN (VERBOSE) SELECT 1 + 2
 ----
 render       0  render  ·         ·                 (column1)  ·
  │           0  ·       render 0  3                 ·          ·
  └── values  1  values  ·         ·                 ()         ·
 ·            1  ·       size      0 columns, 1 row  ·          ·
 
-exec-explain
-SELECT true
+exec hide-colnames
+EXPLAIN (VERBOSE) SELECT true
 ----
 render       0  render  ·         ·                 (column1)  ·
  │           0  ·       render 0  true              ·          ·
  └── values  1  values  ·         ·                 ()         ·
 ·            1  ·       size      0 columns, 1 row  ·          ·
 
-exec-explain
-SELECT false
+exec hide-colnames
+EXPLAIN (VERBOSE) SELECT false
 ----
 render       0  render  ·         ·                 (column1)  ·
  │           0  ·       render 0  false             ·          ·
  └── values  1  values  ·         ·                 ()         ·
 ·            1  ·       size      0 columns, 1 row  ·          ·
 
-exec-explain
-SELECT (1, 2)
+exec hide-colnames
+EXPLAIN (VERBOSE) SELECT (1, 2)
 ----
 render       0  render  ·         ·                 (column1)  ·
  │           0  ·       render 0  (1, 2)            ·          ·
  └── values  1  values  ·         ·                 ()         ·
 ·            1  ·       size      0 columns, 1 row  ·          ·
 
-exec-explain
-SELECT (true, false)
+exec hide-colnames
+EXPLAIN (VERBOSE) SELECT (true, false)
 ----
 render       0  render  ·         ·                 (column1)  ·
  │           0  ·       render 0  (true, false)     ·          ·
  └── values  1  values  ·         ·                 ()         ·
 ·            1  ·       size      0 columns, 1 row  ·          ·
 
-exec-explain
-SELECT 1 + 2 FROM t
+exec hide-colnames
+EXPLAIN (VERBOSE) SELECT 1 + 2 FROM t
 ----
 render     0  render  ·         ·          (column8)  ·
  │         0  ·       render 0  3          ·          ·
@@ -55,8 +55,8 @@ render     0  render  ·         ·          (column8)  ·
 ·          1  ·       table     t@primary  ·          ·
 ·          1  ·       spans     ALL        ·          ·
 
-exec-explain
-SELECT a + 2 FROM t
+exec hide-colnames
+EXPLAIN (VERBOSE) SELECT a + 2 FROM t
 ----
 render     0  render  ·         ·          (column8)  ·
  │         0  ·       render 0  a + 2      ·          ·
@@ -64,8 +64,8 @@ render     0  render  ·         ·          (column8)  ·
 ·          1  ·       table     t@primary  ·          ·
 ·          1  ·       spans     ALL        ·          ·
 
-exec-explain
-SELECT a >= 5 AND b <= 10 AND c < 4 FROM t
+exec hide-colnames
+EXPLAIN (VERBOSE) SELECT a >= 5 AND b <= 10 AND c < 4 FROM t
 ----
 render     0  render  ·         ·                                     (column8)  ·
  │         0  ·       render 0  ((a >= 5) AND (b <= 10)) AND (c < 4)  ·          ·
@@ -73,8 +73,8 @@ render     0  render  ·         ·                                     (column8
 ·          1  ·       table     t@primary                             ·          ·
 ·          1  ·       spans     ALL                                   ·          ·
 
-exec-explain
-SELECT a >= 5 OR b <= 10 OR c < 4  FROM t
+exec hide-colnames
+EXPLAIN (VERBOSE) SELECT a >= 5 OR b <= 10 OR c < 4  FROM t
 ----
 render     0  render  ·         ·                                   (column8)  ·
  │         0  ·       render 0  ((a >= 5) OR (b <= 10)) OR (c < 4)  ·          ·
@@ -82,8 +82,8 @@ render     0  render  ·         ·                                   (column8) 
 ·          1  ·       table     t@primary                           ·          ·
 ·          1  ·       spans     ALL                                 ·          ·
 
-exec-explain
-SELECT NOT (a = 5) FROM t
+exec hide-colnames
+EXPLAIN (VERBOSE) SELECT NOT (a = 5) FROM t
 ----
 render     0  render  ·         ·          (column8)  ·
  │         0  ·       render 0  a != 5     ·          ·
@@ -91,8 +91,8 @@ render     0  render  ·         ·          (column8)  ·
 ·          1  ·       table     t@primary  ·          ·
 ·          1  ·       spans     ALL        ·          ·
 
-exec-explain
-SELECT NOT (a > 5 AND b >= 10) FROM t
+exec hide-colnames
+EXPLAIN (VERBOSE) SELECT NOT (a > 5 AND b >= 10) FROM t
 ----
 render     0  render  ·         ·                     (column8)  ·
  │         0  ·       render 0  (a <= 5) OR (b < 10)  ·          ·
@@ -100,8 +100,8 @@ render     0  render  ·         ·                     (column8)  ·
 ·          1  ·       table     t@primary             ·          ·
 ·          1  ·       spans     ALL                   ·          ·
 
-exec-explain
-SELECT (a >= 5 AND b <= 10) OR (a <= 10 AND c > 5) FROM t
+exec hide-colnames
+EXPLAIN (VERBOSE) SELECT (a >= 5 AND b <= 10) OR (a <= 10 AND c > 5) FROM t
 ----
 render     0  render  ·         ·                                                    (column8)  ·
  │         0  ·       render 0  ((a >= 5) AND (b <= 10)) OR ((a <= 10) AND (c > 5))  ·          ·
@@ -109,8 +109,8 @@ render     0  render  ·         ·                                             
 ·          1  ·       table     t@primary                                            ·          ·
 ·          1  ·       spans     ALL                                                  ·          ·
 
-exec-explain
-SELECT NOT (a >= 5 OR b <= 10) AND NOT (c >= 10) FROM t
+exec hide-colnames
+EXPLAIN (VERBOSE) SELECT NOT (a >= 5 OR b <= 10) AND NOT (c >= 10) FROM t
 ----
 render     0  render  ·         ·                                    (column8)  ·
  │         0  ·       render 0  ((a < 5) AND (b > 10)) AND (c < 10)  ·          ·
@@ -118,8 +118,8 @@ render     0  render  ·         ·                                    (column8)
 ·          1  ·       table     t@primary                            ·          ·
 ·          1  ·       spans     ALL                                  ·          ·
 
-exec-explain
-SELECT (a, b) = (1, 2)  FROM t
+exec hide-colnames
+EXPLAIN (VERBOSE) SELECT (a, b) = (1, 2)  FROM t
 ----
 render     0  render  ·         ·                    (column8)  ·
  │         0  ·       render 0  (a = 1) AND (b = 2)  ·          ·
@@ -127,8 +127,8 @@ render     0  render  ·         ·                    (column8)  ·
 ·          1  ·       table     t@primary            ·          ·
 ·          1  ·       spans     ALL                  ·          ·
 
-exec-explain
-SELECT a IN (1, 2) FROM t
+exec hide-colnames
+EXPLAIN (VERBOSE) SELECT a IN (1, 2) FROM t
 ----
 render     0  render  ·         ·            (column8)  ·
  │         0  ·       render 0  a IN (1, 2)  ·          ·
@@ -136,8 +136,8 @@ render     0  render  ·         ·            (column8)  ·
 ·          1  ·       table     t@primary    ·          ·
 ·          1  ·       spans     ALL          ·          ·
 
-exec-explain
-SELECT (a, b) IN ((1, 2), (3, 4)) FROM t
+exec hide-colnames
+EXPLAIN (VERBOSE) SELECT (a, b) IN ((1, 2), (3, 4)) FROM t
 ----
 render     0  render  ·         ·                           (column8)  ·
  │         0  ·       render 0  (a, b) IN ((1, 2), (3, 4))  ·          ·
@@ -145,8 +145,8 @@ render     0  render  ·         ·                           (column8)  ·
 ·          1  ·       table     t@primary                   ·          ·
 ·          1  ·       spans     ALL                         ·          ·
 
-exec-explain
-SELECT (a, b + c, 5 + d * 2) = (b+c, 8, a - c)  FROM t
+exec hide-colnames
+EXPLAIN (VERBOSE) SELECT (a, b + c, 5 + d * 2) = (b+c, 8, a - c)  FROM t
 ----
 render     0  render  ·         ·                                                                (column8)     ·
  │         0  ·       render 0  ((a = (b + c)) AND ((b + c) = 8)) AND (((d * 2) + 5) = (a - c))  ·             ·
@@ -154,8 +154,8 @@ render     0  render  ·         ·                                             
 ·          1  ·       table     t@primary                                                        ·             ·
 ·          1  ·       spans     ALL                                                              ·             ·
 
-exec-explain
-SELECT ((a, b), (c, d)) = ((1, 2), (3, 4))  FROM t
+exec hide-colnames
+EXPLAIN (VERBOSE) SELECT ((a, b), (c, d)) = ((1, 2), (3, 4))  FROM t
 ----
 render     0  render  ·         ·                                                (column8)     ·
  │         0  ·       render 0  (((a = 1) AND (b = 2)) AND (c = 3)) AND (d = 4)  ·             ·
@@ -163,8 +163,8 @@ render     0  render  ·         ·                                             
 ·          1  ·       table     t@primary                                        ·             ·
 ·          1  ·       spans     ALL                                              ·             ·
 
-exec-explain
-SELECT (a, (b, 'a'), (c, 'b', 5)) = (9, (a+c, s), (5, s, a)) FROM t
+exec hide-colnames
+EXPLAIN (VERBOSE) SELECT (a, (b, 'a'), (c, 'b', 5)) = (9, (a+c, s), (5, s, a)) FROM t
 ----
 render     0  render  ·         ·                                                                                      (column8)     ·
  │         0  ·       render 0  (((((a = 9) AND (b = (a + c))) AND (s = 'a')) AND (c = 5)) AND (s = 'b')) AND (a = 5)  ·             ·
@@ -172,8 +172,8 @@ render     0  render  ·         ·                                             
 ·          1  ·       table     t@primary                                                                              ·             ·
 ·          1  ·       spans     ALL                                                                                    ·             ·
 
-exec-explain
-SELECT a IS NULL FROM t
+exec hide-colnames
+EXPLAIN (VERBOSE) SELECT a IS NULL FROM t
 ----
 render     0  render  ·         ·          (column8)  ·
  │         0  ·       render 0  a IS NULL  ·          ·
@@ -181,8 +181,8 @@ render     0  render  ·         ·          (column8)  ·
 ·          1  ·       table     t@primary  ·          ·
 ·          1  ·       spans     ALL        ·          ·
 
-exec-explain
-SELECT a IS NOT DISTINCT FROM NULL FROM t
+exec hide-colnames
+EXPLAIN (VERBOSE) SELECT a IS NOT DISTINCT FROM NULL FROM t
 ----
 render     0  render  ·         ·          (column8)  ·
  │         0  ·       render 0  a IS NULL  ·          ·
@@ -190,8 +190,8 @@ render     0  render  ·         ·          (column8)  ·
 ·          1  ·       table     t@primary  ·          ·
 ·          1  ·       spans     ALL        ·          ·
 
-exec-explain
-SELECT a IS NOT DISTINCT FROM b FROM t
+exec hide-colnames
+EXPLAIN (VERBOSE) SELECT a IS NOT DISTINCT FROM b FROM t
 ----
 render     0  render  ·         ·                         (column8)  ·
  │         0  ·       render 0  a IS NOT DISTINCT FROM b  ·          ·
@@ -199,8 +199,8 @@ render     0  render  ·         ·                         (column8)  ·
 ·          1  ·       table     t@primary                 ·          ·
 ·          1  ·       spans     ALL                       ·          ·
 
-exec-explain
-SELECT a IS NOT NULL FROM t
+exec hide-colnames
+EXPLAIN (VERBOSE) SELECT a IS NOT NULL FROM t
 ----
 render     0  render  ·         ·              (column8)  ·
  │         0  ·       render 0  a IS NOT NULL  ·          ·
@@ -208,8 +208,8 @@ render     0  render  ·         ·              (column8)  ·
 ·          1  ·       table     t@primary      ·          ·
 ·          1  ·       spans     ALL            ·          ·
 
-exec-explain
-SELECT a IS DISTINCT FROM NULL FROM t
+exec hide-colnames
+EXPLAIN (VERBOSE) SELECT a IS DISTINCT FROM NULL FROM t
 ----
 render     0  render  ·         ·              (column8)  ·
  │         0  ·       render 0  a IS NOT NULL  ·          ·
@@ -217,8 +217,8 @@ render     0  render  ·         ·              (column8)  ·
 ·          1  ·       table     t@primary      ·          ·
 ·          1  ·       spans     ALL            ·          ·
 
-exec-explain
-SELECT a IS DISTINCT FROM b FROM t
+exec hide-colnames
+EXPLAIN (VERBOSE) SELECT a IS DISTINCT FROM b FROM t
 ----
 render     0  render  ·         ·                     (column8)  ·
  │         0  ·       render 0  a IS DISTINCT FROM b  ·          ·
@@ -226,8 +226,8 @@ render     0  render  ·         ·                     (column8)  ·
 ·          1  ·       table     t@primary             ·          ·
 ·          1  ·       spans     ALL                   ·          ·
 
-exec-explain
-SELECT +a + (-b) FROM t
+exec hide-colnames
+EXPLAIN (VERBOSE) SELECT +a + (-b) FROM t
 ----
 render     0  render  ·         ·          (column8)  ·
  │         0  ·       render 0  a + (-b)   ·          ·
@@ -235,8 +235,8 @@ render     0  render  ·         ·          (column8)  ·
 ·          1  ·       table     t@primary  ·          ·
 ·          1  ·       spans     ALL        ·          ·
 
-exec-explain
-SELECT CASE a WHEN 1 THEN 2 WHEN 2 THEN 3 ELSE 4 END FROM t
+exec hide-colnames
+EXPLAIN (VERBOSE) SELECT CASE a WHEN 1 THEN 2 WHEN 2 THEN 3 ELSE 4 END FROM t
 ----
 render     0  render  ·         ·                                              (column8)  ·
  │         0  ·       render 0  CASE a WHEN 1 THEN 2 WHEN 2 THEN 3 ELSE 4 END  ·          ·
@@ -244,8 +244,8 @@ render     0  render  ·         ·                                             
 ·          1  ·       table     t@primary                                      ·          ·
 ·          1  ·       spans     ALL                                            ·          ·
 
-exec-explain
-SELECT CASE WHEN a = 2 THEN 1 ELSE 2 END FROM t
+exec hide-colnames
+EXPLAIN (VERBOSE) SELECT CASE WHEN a = 2 THEN 1 ELSE 2 END FROM t
 ----
 render     0  render  ·         ·                                  (column8)  ·
  │         0  ·       render 0  CASE WHEN a = 2 THEN 1 ELSE 2 END  ·          ·
@@ -253,8 +253,8 @@ render     0  render  ·         ·                                  (column8)  
 ·          1  ·       table     t@primary                          ·          ·
 ·          1  ·       spans     ALL                                ·          ·
 
-exec-explain
-SELECT CASE a + 3 WHEN 5 * b THEN 1 % b WHEN 6 THEN 2 ELSE -1 END FROM t
+exec hide-colnames
+EXPLAIN (VERBOSE) SELECT CASE a + 3 WHEN 5 * b THEN 1 % b WHEN 6 THEN 2 ELSE -1 END FROM t
 ----
 render     0  render  ·         ·                                                           (column8)  ·
  │         0  ·       render 0  CASE a + 3 WHEN b * 5 THEN 1 % b WHEN 6 THEN 2 ELSE -1 END  ·          ·
@@ -263,8 +263,8 @@ render     0  render  ·         ·                                             
 ·          1  ·       spans     ALL                                                         ·          ·
 
 # Tests for CASE with no ELSE statement
-exec-explain
-SELECT CASE WHEN a = 2 THEN 1 END FROM t
+exec hide-colnames
+EXPLAIN (VERBOSE) SELECT CASE WHEN a = 2 THEN 1 END FROM t
 ----
 render     0  render  ·         ·                           (column8)  ·
  │         0  ·       render 0  CASE WHEN a = 2 THEN 1 END  ·          ·
@@ -272,8 +272,8 @@ render     0  render  ·         ·                           (column8)  ·
 ·          1  ·       table     t@primary                   ·          ·
 ·          1  ·       spans     ALL                         ·          ·
 
-exec-explain
-SELECT CASE a WHEN 2 THEN 1 END FROM t
+exec hide-colnames
+EXPLAIN (VERBOSE) SELECT CASE a WHEN 2 THEN 1 END FROM t
 ----
 render     0  render  ·         ·                         (column8)  ·
  │         0  ·       render 0  CASE a WHEN 2 THEN 1 END  ·          ·
@@ -281,8 +281,8 @@ render     0  render  ·         ·                         (column8)  ·
 ·          1  ·       table     t@primary                 ·          ·
 ·          1  ·       spans     ALL                       ·          ·
 
-exec-explain allow-unsupported
-SELECT a FROM t WHERE a IS OF (INT)
+exec allow-unsupported hide-colnames
+EXPLAIN (VERBOSE) SELECT a FROM t WHERE a IS OF (INT)
 ----
 filter     0  filter  ·       ·                (a)  ·
  │         0  ·       filter  t.a IS OF (INT)  ·    ·
@@ -290,8 +290,8 @@ filter     0  filter  ·       ·                (a)  ·
 ·          1  ·       table   t@primary        ·    ·
 ·          1  ·       spans   ALL              ·    ·
 
-exec-explain
-SELECT LENGTH(s) FROM t
+exec hide-colnames
+EXPLAIN (VERBOSE) SELECT LENGTH(s) FROM t
 ----
 render     0  render  ·         ·          (column8)  ·
  │         0  ·       render 0  length(s)  ·          ·
@@ -313,8 +313,8 @@ column3:int
 2
 3
 
-exec-explain
-SELECT j @> '{"a": 1}' FROM t
+exec hide-colnames
+EXPLAIN (VERBOSE) SELECT j @> '{"a": 1}' FROM t
 ----
 render     0  render  ·         ·                (column8)  ·
  │         0  ·       render 0  j @> '{"a": 1}'  ·          ·
@@ -322,8 +322,8 @@ render     0  render  ·         ·                (column8)  ·
 ·          1  ·       table     t@primary        ·          ·
 ·          1  ·       spans     ALL              ·          ·
 
-exec-explain
-SELECT '{"a": 1}' <@ j FROM t
+exec hide-colnames
+EXPLAIN (VERBOSE) SELECT '{"a": 1}' <@ j FROM t
 ----
 render     0  render  ·         ·                (column8)  ·
  │         0  ·       render 0  j @> '{"a": 1}'  ·          ·
@@ -331,8 +331,8 @@ render     0  render  ·         ·                (column8)  ·
 ·          1  ·       table     t@primary        ·          ·
 ·          1  ·       spans     ALL              ·          ·
 
-exec-explain
-SELECT j->>'a' FROM t
+exec hide-colnames
+EXPLAIN (VERBOSE) SELECT j->>'a' FROM t
 ----
 render     0  render  ·         ·          (column8)  ·
  │         0  ·       render 0  j->>'a'    ·          ·
@@ -340,8 +340,8 @@ render     0  render  ·         ·          (column8)  ·
 ·          1  ·       table     t@primary  ·          ·
 ·          1  ·       spans     ALL        ·          ·
 
-exec-explain
-SELECT j->'a' FROM t
+exec hide-colnames
+EXPLAIN (VERBOSE) SELECT j->'a' FROM t
 ----
 render     0  render  ·         ·          (column8)  ·
  │         0  ·       render 0  j->'a'     ·          ·
@@ -349,8 +349,8 @@ render     0  render  ·         ·          (column8)  ·
 ·          1  ·       table     t@primary  ·          ·
 ·          1  ·       spans     ALL        ·          ·
 
-exec-explain
-SELECT j ? 'a' FROM t
+exec hide-colnames
+EXPLAIN (VERBOSE) SELECT j ? 'a' FROM t
 ----
 render     0  render  ·         ·          (column8)  ·
  │         0  ·       render 0  j ? 'a'    ·          ·
@@ -358,8 +358,8 @@ render     0  render  ·         ·          (column8)  ·
 ·          1  ·       table     t@primary  ·          ·
 ·          1  ·       spans     ALL        ·          ·
 
-exec-explain
-SELECT j ?| ARRAY['a', 'b', 'c'] FROM t
+exec hide-colnames
+EXPLAIN (VERBOSE) SELECT j ?| ARRAY['a', 'b', 'c'] FROM t
 ----
 render     0  render  ·         ·                          (column8)  ·
  │         0  ·       render 0  j ?| ARRAY['a', 'b', 'c']  ·          ·
@@ -367,8 +367,8 @@ render     0  render  ·         ·                          (column8)  ·
 ·          1  ·       table     t@primary                  ·          ·
 ·          1  ·       spans     ALL                        ·          ·
 
-exec-explain
-SELECT j ?& ARRAY['a', 'b', 'c'] FROM t
+exec hide-colnames
+EXPLAIN (VERBOSE) SELECT j ?& ARRAY['a', 'b', 'c'] FROM t
 ----
 render     0  render  ·         ·                          (column8)  ·
  │         0  ·       render 0  j ?& ARRAY['a', 'b', 'c']  ·          ·
@@ -376,8 +376,8 @@ render     0  render  ·         ·                          (column8)  ·
 ·          1  ·       table     t@primary                  ·          ·
 ·          1  ·       spans     ALL                        ·          ·
 
-exec-explain
-SELECT j#>ARRAY['a'] FROM t
+exec hide-colnames
+EXPLAIN (VERBOSE) SELECT j#>ARRAY['a'] FROM t
 ----
 render     0  render  ·         ·              (column8)  ·
  │         0  ·       render 0  j#>ARRAY['a']  ·          ·
@@ -385,8 +385,8 @@ render     0  render  ·         ·              (column8)  ·
 ·          1  ·       table     t@primary      ·          ·
 ·          1  ·       spans     ALL            ·          ·
 
-exec-explain
-SELECT j#>>ARRAY['a'] FROM t
+exec hide-colnames
+EXPLAIN (VERBOSE) SELECT j#>>ARRAY['a'] FROM t
 ----
 render     0  render  ·         ·               (column8)  ·
  │         0  ·       render 0  j#>>ARRAY['a']  ·          ·
@@ -395,8 +395,8 @@ render     0  render  ·         ·               (column8)  ·
 ·          1  ·       spans     ALL             ·          ·
 
 
-exec-explain
-SELECT CAST(a AS string), b::float FROM t
+exec hide-colnames
+EXPLAIN (VERBOSE) SELECT CAST(a AS string), b::float FROM t
 ----
 render     0  render  ·         ·          (column8, column9)  ·
  │         0  ·       render 0  a::STRING  ·                   ·
@@ -405,8 +405,8 @@ render     0  render  ·         ·          (column8, column9)  ·
 ·          1  ·       table     t@primary  ·                   ·
 ·          1  ·       spans     ALL        ·                   ·
 
-exec-explain
-SELECT CAST(a + b + c AS string) FROM t
+exec hide-colnames
+EXPLAIN (VERBOSE) SELECT CAST(a + b + c AS string) FROM t
 ----
 render     0  render  ·         ·                      (column8)  ·
  │         0  ·       render 0  (c + (a + b))::STRING  ·          ·
@@ -422,8 +422,8 @@ column3:float  s:string
 2.0            ab
 3.0            abc
 
-exec-explain
-SELECT COALESCE(a, b) FROM (VALUES (1, 2), (3, NULL), (NULL, 4), (NULL, NULL)) AS v(a, b)
+exec hide-colnames
+EXPLAIN (VERBOSE) SELECT COALESCE(a, b) FROM (VALUES (1, 2), (3, NULL), (NULL, 4), (NULL, NULL)) AS v(a, b)
 ----
 render       0  render  ·              ·                           (column3)           ·
  │           0  ·       render 0       COALESCE(column1, column2)  ·                   ·
@@ -447,8 +447,8 @@ column3:int
 4
 NULL
 
-exec-explain
-SELECT COALESCE(a, b, c) FROM (VALUES (1, 2, 3), (NULL, 4, 5), (NULL, NULL, 6), (NULL, NULL, NULL)) AS v(a, b, c)
+exec hide-colnames
+EXPLAIN (VERBOSE) SELECT COALESCE(a, b, c) FROM (VALUES (1, 2, 3), (NULL, 4, 5), (NULL, NULL, 6), (NULL, NULL, NULL)) AS v(a, b, c)
 ----
 render       0  render  ·              ·                                    (column4)                    ·
  │           0  ·       render 0       COALESCE(column1, column2, column3)  ·                            ·
@@ -476,8 +476,8 @@ column4:int
 6
 NULL
 
-exec-explain
-SELECT a FROM t WHERE a BETWEEN b AND d
+exec hide-colnames
+EXPLAIN (VERBOSE) SELECT a FROM t WHERE a BETWEEN b AND d
 ----
 render          0  render  ·         ·                      (a)        ·
  │              0  ·       render 0  a                      ·          ·
@@ -487,8 +487,8 @@ render          0  render  ·         ·                      (a)        ·
 ·               2  ·       table     t@primary              ·          ·
 ·               2  ·       spans     ALL                    ·          ·
 
-exec-explain
-SELECT a FROM t WHERE a NOT BETWEEN b AND d
+exec hide-colnames
+EXPLAIN (VERBOSE) SELECT a FROM t WHERE a NOT BETWEEN b AND d
 ----
 render          0  render  ·         ·                   (a)        ·
  │              0  ·       render 0  a                   ·          ·
@@ -498,8 +498,8 @@ render          0  render  ·         ·                   (a)        ·
 ·               2  ·       table     t@primary           ·          ·
 ·               2  ·       spans     ALL                 ·          ·
 
-exec-explain
-SELECT a BETWEEN SYMMETRIC b AND d FROM t
+exec hide-colnames
+EXPLAIN (VERBOSE) SELECT a BETWEEN SYMMETRIC b AND d FROM t
 ----
 render     0  render  ·         ·                                                   (column8)  ·
  │         0  ·       render 0  ((a >= b) AND (a <= d)) OR ((a >= d) AND (a <= b))  ·          ·
@@ -507,8 +507,8 @@ render     0  render  ·         ·                                             
 ·          1  ·       table     t@primary                                           ·          ·
 ·          1  ·       spans     ALL                                                 ·          ·
 
-exec-explain
-SELECT a NOT BETWEEN SYMMETRIC b AND d FROM t
+exec hide-colnames
+EXPLAIN (VERBOSE) SELECT a NOT BETWEEN SYMMETRIC b AND d FROM t
 ----
 render     0  render  ·         ·                                              (column8)  ·
  │         0  ·       render 0  ((a < b) OR (a > d)) AND ((a < d) OR (a > b))  ·          ·
@@ -516,8 +516,8 @@ render     0  render  ·         ·                                             
 ·          1  ·       table     t@primary                                      ·          ·
 ·          1  ·       spans     ALL                                            ·          ·
 
-exec-explain
-SELECT ARRAY[a + 1, 2, 3] FROM t
+exec hide-colnames
+EXPLAIN (VERBOSE) SELECT ARRAY[a + 1, 2, 3] FROM t
 ----
 render     0  render  ·         ·                   (column8)  ·
  │         0  ·       render 0  ARRAY[a + 1, 2, 3]  ·          ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/scan
+++ b/pkg/sql/opt/exec/execbuilder/testdata/scan
@@ -12,8 +12,8 @@ scan a
  ├── cost: 1000.00
  └── keys: (1)
 
-exec-explain
-SELECT * FROM a
+exec hide-colnames
+EXPLAIN (VERBOSE) SELECT * FROM a
 ----
 scan  0  scan  ·      ·          (x, y, s)  ·
 ·     0  ·     table  a@primary  ·          ·
@@ -37,8 +37,8 @@ scan a
  ├── cost: 1000.00
  └── keys: (1)
 
-exec-explain
-SELECT s, x FROM a
+exec hide-colnames
+EXPLAIN (VERBOSE) SELECT s, x FROM a
 ----
 render     0  render  ·         ·          (s, x)  ·
  │         0  ·       render 0  s          ·       ·
@@ -77,8 +77,8 @@ apple     1
 banana    2
 cherry    3
 
-exec-explain
-SELECT s, x FROM b
+exec hide-colnames
+EXPLAIN (VERBOSE) SELECT s, x FROM b
 ----
 render     0  render  ·         ·          (s, x)  ·
  │         0  ·       render 0  s          ·       ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/select
+++ b/pkg/sql/opt/exec/execbuilder/testdata/select
@@ -3,8 +3,8 @@ CREATE TABLE a (x INT PRIMARY KEY, y INT);
 INSERT INTO a VALUES (1, 10), (2, 20), (3, 30)
 ----
 
-exec-explain
-SELECT * FROM a WHERE x > 1
+exec hide-colnames
+EXPLAIN (VERBOSE) SELECT * FROM a WHERE x > 1
 ----
 scan  0  scan  ·      ·          (x, y)  ·
 ·     0  ·     table  a@primary  ·       ·
@@ -17,8 +17,8 @@ x:int  y:int
 2      20
 3      30
 
-exec-explain
-SELECT * FROM a WHERE y > 10
+exec hide-colnames
+EXPLAIN (VERBOSE) SELECT * FROM a WHERE y > 10
 ----
 filter     0  filter  ·       ·          (x, y)  ·
  │         0  ·       filter  y > 10     ·       ·
@@ -33,8 +33,8 @@ x:int  y:int
 2      20
 3      30
 
-exec-explain
-SELECT * FROM a WHERE x > 1 AND x < 3
+exec hide-colnames
+EXPLAIN (VERBOSE) SELECT * FROM a WHERE x > 1 AND x < 3
 ----
 scan  0  scan  ·      ·          (x, y)  ·
 ·     0  ·     table  a@primary  ·       ·
@@ -46,8 +46,8 @@ SELECT * FROM a WHERE x > 1 AND x < 3
 x:int  y:int
 2      20
 
-exec-explain
-SELECT * FROM a WHERE x > 1 AND y < 30
+exec hide-colnames
+EXPLAIN (VERBOSE) SELECT * FROM a WHERE x > 1 AND y < 30
 ----
 filter     0  filter  ·       ·          (x, y)  ·
  │         0  ·       filter  y < 30     ·       ·
@@ -66,8 +66,8 @@ CREATE TABLE b (x INT, y INT);
 INSERT INTO b VALUES (1, 10), (2, 20), (3, 30)
 ----
 
-exec-explain
-SELECT x, y, rowid FROM b WHERE rowid > 0
+exec hide-colnames
+EXPLAIN (VERBOSE) SELECT x, y, rowid FROM b WHERE rowid > 0
 ----
 scan  0  scan  ·      ·          (x, y, rowid[hidden])  ·
 ·     0  ·     table  b@primary  ·                      ·
@@ -78,8 +78,8 @@ CREATE TABLE c (n INT PRIMARY KEY, str STRING, INDEX str(str DESC));
 INSERT INTO c SELECT i, to_english(i) FROM GENERATE_SERIES(1, 10) AS g(i)
 ----
 
-exec-explain
-SELECT * FROM c WHERE str >= 'moo'
+exec hide-colnames
+EXPLAIN (VERBOSE) SELECT * FROM c WHERE str >= 'moo'
 ----
 scan  0  scan  ·      ·                  (n, str)  ·
 ·     0  ·     table  c@str              ·         ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/stats
+++ b/pkg/sql/opt/exec/execbuilder/testdata/stats
@@ -66,8 +66,8 @@ select
            ├── variable: b.u [type=int, outer=(1)]
            └── const: 1 [type=int]
 
-exec-explain
-SELECT * FROM b WHERE u = 1 AND v = 1
+exec hide-colnames
+EXPLAIN (VERBOSE) SELECT * FROM b WHERE u = 1 AND v = 1
 ----
 filter     0  filter  ·       ·          (u, v)  ·
  │         0  ·       filter  u = 1      ·       ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/subquery
+++ b/pkg/sql/opt/exec/execbuilder/testdata/subquery
@@ -35,8 +35,8 @@ project
                                ├── variable: t.k [type=int, outer=(1)]
                                └── variable: t.k [type=int, outer=(1)]
 
-exec-explain
-SELECT EXISTS(SELECT * FROM t WHERE u = k*k)
+exec hide-colnames
+EXPLAIN (VERBOSE) SELECT EXISTS(SELECT * FROM t WHERE u = k*k)
 ----
 root                 0  root      ·          ·                 (column4)  ·
  ├── render          1  render    ·          ·                 (column4)  ·
@@ -65,8 +65,8 @@ SELECT EXISTS(SELECT * FROM t WHERE u != k*k)
 column4:bool
 false
 
-exec-explain
-SELECT * FROM t WHERE u = (SELECT MAX(u) FROM t)
+exec hide-colnames
+EXPLAIN (VERBOSE) SELECT * FROM t WHERE u = (SELECT MAX(u) FROM t)
 ----
 root                 0  root      ·            ·          (k, u, v)  ·
  ├── filter          1  filter    ·            ·          (k, u, v)  ·
@@ -90,8 +90,8 @@ SELECT * FROM t WHERE u = (SELECT MAX(u) FROM t)
 k:int  u:int  v:int
 4      16     64
 
-exec-explain
-SELECT * FROM t WHERE u = (SELECT MAX(u) FROM t WHERE EXISTS(SELECT * FROM t WHERE u=k*k))
+exec hide-colnames
+EXPLAIN (VERBOSE) SELECT * FROM t WHERE u = (SELECT MAX(u) FROM t WHERE EXISTS(SELECT * FROM t WHERE u=k*k))
 ----
 root                      0  root      ·            ·                 (k, u, v)  ·
  ├── filter               1  filter    ·            ·                 (k, u, v)  ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/union
+++ b/pkg/sql/opt/exec/execbuilder/testdata/union
@@ -235,8 +235,8 @@ v:int
 3
 2
 
-exec-explain
-SELECT v FROM t.uniontest UNION SELECT k FROM t.uniontest
+exec hide-colnames
+EXPLAIN (VERBOSE) SELECT v FROM t.uniontest UNION SELECT k FROM t.uniontest
 ----
 union      0  union  ·      ·                  (v)  ·
  ├── scan  1  scan   ·      ·                  (k)  ·
@@ -246,8 +246,8 @@ union      0  union  ·      ·                  (v)  ·
 ·          1  ·      table  uniontest@primary  ·    ·
 ·          1  ·      spans  ALL                ·    ·
 
-exec-explain
-SELECT v FROM t.uniontest UNION ALL SELECT k FROM t.uniontest
+exec hide-colnames
+EXPLAIN (VERBOSE) SELECT v FROM t.uniontest UNION ALL SELECT k FROM t.uniontest
 ----
 append     0  append  ·      ·                  (v)  ·
  ├── scan  1  scan    ·      ·                  (k)  ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/values
+++ b/pkg/sql/opt/exec/execbuilder/testdata/values
@@ -1,6 +1,6 @@
 # Tests for the implicit one row, zero column values operator.
-exec-explain
-SELECT 1
+exec hide-colnames
+EXPLAIN (VERBOSE) SELECT 1
 ----
 render       0  render  ·         ·                 (column1)  ·
  │           0  ·       render 0  1                 ·          ·
@@ -13,8 +13,8 @@ SELECT 1
 column1:int
 1
 
-exec-explain
-SELECT 1 + 2
+exec hide-colnames
+EXPLAIN (VERBOSE) SELECT 1 + 2
 ----
 render       0  render  ·         ·                 (column1)  ·
  │           0  ·       render 0  3                 ·          ·
@@ -27,8 +27,8 @@ SELECT 1 + 2
 column1:int
 3
 
-exec-explain
-VALUES (1, 2, 3), (4, 5, 6)
+exec hide-colnames
+EXPLAIN (VERBOSE) VALUES (1, 2, 3), (4, 5, 6)
 ----
 values  0  values  ·              ·                  (column1, column2, column3)  ·
 ·       0  ·       size           3 columns, 2 rows  ·                            ·
@@ -46,8 +46,8 @@ column1:int  column2:int  column3:int
 1            2            3
 4            5            6
 
-exec-explain
-VALUES (LENGTH('a')), (1 + LENGTH('a')), (LENGTH('abc')), (LENGTH('ab') * 2)
+exec hide-colnames
+EXPLAIN (VERBOSE) VALUES (LENGTH('a')), (1 + LENGTH('a')), (LENGTH('abc')), (LENGTH('ab') * 2)
 ----
 values  0  values  ·              ·                 (column1)  ·
 ·       0  ·       size           1 column, 4 rows  ·          ·
@@ -65,8 +65,8 @@ column1:int
 3
 4
 
-exec-explain
-SELECT a + b FROM (VALUES (1, 2), (3, 4), (5, 6)) AS v(a, b)
+exec hide-colnames
+EXPLAIN (VERBOSE) SELECT a + b FROM (VALUES (1, 2), (3, 4), (5, 6)) AS v(a, b)
 ----
 render       0  render  ·              ·                  (column3)           ·
  │           0  ·       render 0       column1 + column2  ·                   ·

--- a/pkg/sql/opt/exec/factory.go
+++ b/pkg/sql/opt/exec/factory.go
@@ -107,6 +107,12 @@ type Factory interface {
 	// ConstructPlan creates a plan enclosing the given plan and (optionally)
 	// subqueries.
 	ConstructPlan(root Node, subqueries []Subquery) (Plan, error)
+
+	// ConstructExplain returns a node that implements EXPLAIN, showing
+	// information about the given plan.
+	//
+	// TODO(radu): add flags, for now we assume VERBOSE.
+	ConstructExplain(plan Plan) (Node, error)
 }
 
 // Subquery encapsulates information about a subquery that is part of a plan.

--- a/pkg/sql/opt/exec/test_engine.go
+++ b/pkg/sql/opt/exec/test_engine.go
@@ -41,10 +41,6 @@ type TestEngine interface {
 	// results as a Datum table.
 	Execute(p Plan) ([]tree.Datums, error)
 
-	// Explain executes EXPLAIN (VERBOSE) on the given plan (created through the
-	// Factory) and returns the results as a Datum table.
-	Explain(n Plan) ([]tree.Datums, error)
-
 	// Close cleans up any state associated with construction or execution of
 	// plans. It must always be called as the last step in using an engine
 	// instance.

--- a/pkg/sql/opt/memo/logical_props_builder.go
+++ b/pkg/sql/opt/memo/logical_props_builder.go
@@ -77,6 +77,9 @@ func (b logicalPropsBuilder) buildRelationalProps(ev ExprView) LogicalProps {
 
 	case opt.Max1RowOp:
 		return b.buildMax1RowProps(ev)
+
+	case opt.ExplainOp:
+		return b.buildExplainProps(ev)
 	}
 
 	panic(fmt.Sprintf("unrecognized relational expression type: %v", ev.op))
@@ -355,6 +358,18 @@ func (b logicalPropsBuilder) buildValuesProps(ev ExprView) LogicalProps {
 	props.Relational.Cardinality = Cardinality{Min: card, Max: card}
 
 	props.Relational.Stats.initValues(ev, &props.Relational.OutputCols)
+
+	return props
+}
+
+func (b logicalPropsBuilder) buildExplainProps(ev ExprView) LogicalProps {
+	props := LogicalProps{Relational: &RelationalProps{}}
+
+	def := ev.Private().(*ExplainOpDef)
+	props.Relational.OutputCols = opt.ColListToSet(def.ColList)
+	props.Relational.Cardinality = AnyCardinality
+
+	// Zero value for Stats is ok for Explain.
 
 	return props
 }

--- a/pkg/sql/opt/memo/memo_format.go
+++ b/pkg/sql/opt/memo/memo_format.go
@@ -267,7 +267,10 @@ func (f exprFormatter) formatPrivate(private interface{}) {
 			fmt.Fprintf(f.buf, " %s,cols=%s", f.mem.metadata.Table(t.Table).TabName(), t.Cols)
 
 		case *ExplainOpDef:
-			fmt.Fprintf(f.buf, " %s", t.Props.String())
+			propsStr := t.Props.String()
+			if propsStr != "" {
+				fmt.Fprintf(f.buf, " %s", propsStr)
+			}
 
 		case opt.ColSet, opt.ColList:
 			// Don't show anything, because it's mostly redundant.

--- a/pkg/sql/opt/memo/memo_format.go
+++ b/pkg/sql/opt/memo/memo_format.go
@@ -266,6 +266,9 @@ func (f exprFormatter) formatPrivate(private interface{}) {
 		case *LookupJoinDef:
 			fmt.Fprintf(f.buf, " %s,cols=%s", f.mem.metadata.Table(t.Table).TabName(), t.Cols)
 
+		case *ExplainOpDef:
+			fmt.Fprintf(f.buf, " %s", t.Props.String())
+
 		case opt.ColSet, opt.ColList:
 			// Don't show anything, because it's mostly redundant.
 

--- a/pkg/sql/opt/memo/private_defs.go
+++ b/pkg/sql/opt/memo/private_defs.go
@@ -108,6 +108,17 @@ func (s *ScanOpDef) CanProvideOrdering(md *opt.Metadata, required Ordering) bool
 	return true
 }
 
+// ExplainOpDef defines the value of the Def private field of the Explain operator.
+type ExplainOpDef struct {
+	// TODO(radu): flags
+
+	// ColList stores the column IDs for the explain columns.
+	ColList opt.ColList
+
+	// Props stores the required physical properties for the enclosed expression.
+	Props PhysicalProps
+}
+
 // SetOpColMap defines the value of the ColMap private field of the set
 // operators: Union, Intersect, Except, UnionAll, IntersectAll and ExceptAll.
 // It matches columns from the left and right inputs of the operator

--- a/pkg/sql/opt/memo/private_storage.go
+++ b/pkg/sql/opt/memo/private_storage.go
@@ -203,6 +203,19 @@ func (ps *privateStorage) internLookupJoinDef(def *LookupJoinDef) PrivateID {
 	return ps.addValue(privateKey{iface: typ, str: ps.keyBuf.String()}, def)
 }
 
+// internExplainOpDef adds the given value to storage and returns an id that
+// later be used to retrieve the value by calling the lookup method.
+func (ps *privateStorage) internExplainOpDef(def *ExplainOpDef) PrivateID {
+	ps.keyBuf.Reset()
+	ps.keyBuf.writeColList(def.ColList)
+	ps.keyBuf.WriteString(def.Props.Fingerprint())
+	typ := (*ExplainOpDef)(nil)
+	if id, ok := ps.privatesMap[privateKey{iface: typ, str: ps.keyBuf.String()}]; ok {
+		return id
+	}
+	return ps.addValue(privateKey{iface: typ, str: ps.keyBuf.String()}, def)
+}
+
 // internSetOpColMap adds the given value to storage and returns an id that can
 // later be used to retrieve the value by calling the lookup method. If the
 // value has been previously added to storage, then internSetOpColMap always

--- a/pkg/sql/opt/memo/private_storage.go
+++ b/pkg/sql/opt/memo/private_storage.go
@@ -203,8 +203,10 @@ func (ps *privateStorage) internLookupJoinDef(def *LookupJoinDef) PrivateID {
 	return ps.addValue(privateKey{iface: typ, str: ps.keyBuf.String()}, def)
 }
 
-// internExplainOpDef adds the given value to storage and returns an id that
-// later be used to retrieve the value by calling the lookup method.
+// internExplainOpDef adds the given value to storage and returns an id that can
+// later be used to retrieve the value by calling the lookup method. If the
+// value has been previously added to storage, then internLookupJoinDef always
+// returns the same private id that was returned from the previous call.
 func (ps *privateStorage) internExplainOpDef(def *ExplainOpDef) PrivateID {
 	ps.keyBuf.Reset()
 	ps.keyBuf.writeColList(def.ColList)

--- a/pkg/sql/opt/ops/relational.opt
+++ b/pkg/sql/opt/ops/relational.opt
@@ -317,3 +317,9 @@ define Offset {
 define Max1Row {
     Input Expr
 }
+
+[Relational]
+define Explain {
+    Input Expr
+    Def   ExplainOpDef
+}

--- a/pkg/sql/opt/optbuilder/explain.go
+++ b/pkg/sql/opt/optbuilder/explain.go
@@ -1,0 +1,64 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package optbuilder
+
+import (
+	"strings"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/opt"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
+)
+
+func (b *Builder) buildExplain(explain *tree.Explain, inScope *scope) (outScope *scope) {
+	// TODO(radu): for now we only support VERBOSE
+	if len(explain.Options) != 1 || strings.ToLower(explain.Options[0]) != "verbose" {
+		panic(errorf("only VERBOSE option supported for now"))
+	}
+
+	// We don't allow the statement under Explain to reference outer columns, so we
+	// pass a "blank" scope rather than inScope.
+	stmtScope := b.buildStmt(explain.Statement, &scope{builder: b})
+	// Calculate the presentation, since we will store it in the Explain op.
+	stmtScope.setPresentation()
+
+	outScope = inScope.push()
+
+	// Tree shows the node type with the tree structure.
+	b.synthesizeColumn(outScope, "Tree", types.String, nil /* expr */, 0 /* group */)
+	// Level is the depth of the node in the tree.
+	b.synthesizeColumn(outScope, "Level", types.Int, nil /* expr */, 0 /* group */)
+	// Type is the node type.
+	b.synthesizeColumn(outScope, "Type", types.String, nil /* expr */, 0 /* group */)
+	// Field is the part of the node that a row of output pertains to.
+	b.synthesizeColumn(outScope, "Field", types.String, nil /* expr */, 0 /* group */)
+	// Description contains details about the field.
+	b.synthesizeColumn(outScope, "Description", types.String, nil /* expr */, 0 /* group */)
+	// Columns is the type signature of the data source.
+	b.synthesizeColumn(outScope, "Columns", types.String, nil /* expr */, 0 /* group */)
+	// Ordering indicates the known ordering of the data from this source.
+	b.synthesizeColumn(outScope, "Ordering", types.String, nil /* expr */, 0 /* group */)
+
+	def := memo.ExplainOpDef{
+		ColList: make(opt.ColList, len(outScope.cols)),
+		Props:   stmtScope.physicalProps,
+	}
+	for i := range outScope.cols {
+		def.ColList[i] = outScope.cols[i].id
+	}
+	outScope.group = b.factory.ConstructExplain(stmtScope.group, b.factory.InternExplainOpDef(&def))
+	return outScope
+}

--- a/pkg/sql/opt/optbuilder/orderby.go
+++ b/pkg/sql/opt/optbuilder/orderby.go
@@ -162,7 +162,7 @@ func (b *Builder) buildOrderByProject(projectionsScope, orderByScope *scope) {
 	}
 
 	projectionsScope.physicalProps.Ordering = orderByScope.physicalProps.Ordering
-	projectionsScope.physicalProps.Presentation = makePresentation(projectionsScope.cols)
+	projectionsScope.setPresentation()
 }
 
 func ensureColumnOrderable(e tree.TypedExpr) {

--- a/pkg/sql/opt/optbuilder/scope.go
+++ b/pkg/sql/opt/optbuilder/scope.go
@@ -90,6 +90,13 @@ func (s *scope) appendColumn(col *scopeColumn, label string) *scopeColumn {
 	return newCol
 }
 
+// setPresentation sets s.physicalProps.Presentation (if not already set).
+func (s *scope) setPresentation() {
+	if s.physicalProps.Presentation == nil {
+		s.physicalProps.Presentation = makePresentation(s.cols)
+	}
+}
+
 // walkExprTree walks the given expression and performs name resolution,
 // replaces unresolved column names with columnProps, and replaces subqueries
 // with typed subquery structs.

--- a/pkg/sql/opt/optbuilder/scope.go
+++ b/pkg/sql/opt/optbuilder/scope.go
@@ -92,9 +92,17 @@ func (s *scope) appendColumn(col *scopeColumn, label string) *scopeColumn {
 
 // setPresentation sets s.physicalProps.Presentation (if not already set).
 func (s *scope) setPresentation() {
-	if s.physicalProps.Presentation == nil {
-		s.physicalProps.Presentation = makePresentation(s.cols)
+	if s.physicalProps.Presentation != nil {
+		return
 	}
+	presentation := make(memo.Presentation, 0, len(s.cols))
+	for i := range s.cols {
+		col := &s.cols[i]
+		if !col.hidden {
+			presentation = append(presentation, opt.LabeledColumn{Label: string(col.name), ID: col.id})
+		}
+	}
+	s.physicalProps.Presentation = presentation
 }
 
 // walkExprTree walks the given expression and performs name resolution,

--- a/pkg/sql/opt/optbuilder/testdata/explain
+++ b/pkg/sql/opt/optbuilder/testdata/explain
@@ -1,0 +1,49 @@
+exec-ddl
+CREATE TABLE xy (x INT PRIMARY KEY, y INT)
+----
+TABLE xy
+ ├── x int not null
+ ├── y int
+ └── INDEX primary
+      └── x int not null
+
+build
+EXPLAIN (VERBOSE) SELECT * FROM xy
+----
+explain
+ ├── columns: Tree:3(string) Level:4(int) Type:5(string) Field:6(string) Description:7(string) Columns:8(string) Ordering:9(string)
+ └── scan xy
+      └── columns: x:1(int!null) y:2(int)
+
+# Verify we preserve the ordering requirement of the explained query.
+build
+EXPLAIN (VERBOSE) SELECT * FROM xy ORDER BY y
+----
+explain
+ ├── columns: Tree:3(string) Level:4(int) Type:5(string) Field:6(string) Description:7(string) Columns:8(string) Ordering:9(string)
+ └── sort
+      ├── columns: x:1(int!null) y:2(int)
+      ├── ordering: +2
+      └── scan xy
+           └── columns: xy.x:1(int!null) xy.y:2(int)
+
+build
+EXPLAIN (VERBOSE) SELECT * FROM xy INNER JOIN (VALUES (1, 2), (3, 4)) AS t(u,v) ON x=u
+----
+explain
+ ├── columns: Tree:5(string) Level:6(int) Type:7(string) Field:8(string) Description:9(string) Columns:10(string) Ordering:11(string)
+ └── inner-join
+      ├── columns: x:1(int!null) y:2(int) u:3(int) v:4(int)
+      ├── scan xy
+      │    └── columns: xy.x:1(int!null) xy.y:2(int)
+      ├── values
+      │    ├── columns: column1:3(int) column2:4(int)
+      │    ├── tuple [type=tuple{int, int}]
+      │    │    ├── const: 1 [type=int]
+      │    │    └── const: 2 [type=int]
+      │    └── tuple [type=tuple{int, int}]
+      │         ├── const: 3 [type=int]
+      │         └── const: 4 [type=int]
+      └── eq [type=bool]
+           ├── variable: xy.x [type=int]
+           └── variable: column1 [type=int]

--- a/pkg/sql/opt/optbuilder/util.go
+++ b/pkg/sql/opt/optbuilder/util.go
@@ -297,17 +297,6 @@ func findColByIndex(cols []scopeColumn, id opt.ColumnID) *scopeColumn {
 	return nil
 }
 
-func makePresentation(cols []scopeColumn) memo.Presentation {
-	presentation := make(memo.Presentation, 0, len(cols))
-	for i := range cols {
-		col := &cols[i]
-		if !col.hidden {
-			presentation = append(presentation, opt.LabeledColumn{Label: string(col.name), ID: col.id})
-		}
-	}
-	return presentation
-}
-
 func (b *Builder) assertNoAggregationOrWindowing(expr tree.Expr, op string) {
 	exprTransformCtx := transform.ExprTransformContext{}
 	if exprTransformCtx.AggregateInExpr(expr, b.semaCtx.SearchPath) {

--- a/pkg/sql/opt/optgen/cmd/optgen/utils.go
+++ b/pkg/sql/opt/optgen/cmd/optgen/utils.go
@@ -60,6 +60,8 @@ func mapPrivateType(typ string) string {
 		return "*memo.LookupJoinDef"
 	case "SetOpColMap":
 		return "*memo.SetOpColMap"
+	case "ExplainOpDef":
+		return "*memo.ExplainOpDef"
 	case "Datum":
 		return "tree.Datum"
 	case "Type":

--- a/pkg/sql/opt/testutils/opt_tester.go
+++ b/pkg/sql/opt/testutils/opt_tester.go
@@ -399,16 +399,6 @@ func (ot *OptTester) ExecBuild(eng exec.TestEngine) (exec.Plan, error) {
 	return execbuilder.New(eng.Factory(), ev).Build()
 }
 
-// Explain builds the exec node tree for the SQL query and then runs the
-// explain command that describes the physical execution plan.
-func (ot *OptTester) Explain(eng exec.TestEngine) ([]tree.Datums, error) {
-	plan, err := ot.ExecBuild(eng)
-	if err != nil {
-		return nil, err
-	}
-	return eng.Explain(plan)
-}
-
 // Exec builds the exec node tree for the SQL query and then executes it.
 func (ot *OptTester) Exec(eng exec.TestEngine) (sqlbase.ResultColumns, []tree.Datums, error) {
 	plan, err := ot.ExecBuild(eng)

--- a/pkg/sql/opt/xform/coster.go
+++ b/pkg/sql/opt/xform/coster.go
@@ -74,6 +74,13 @@ func (c *coster) ComputeCost(candidate *memo.BestExpr, props *memo.LogicalProps)
 		// TODO(justin): remove this once we can execbuild index joins.
 		return 1000000000000
 
+	case opt.ExplainOp:
+		// Technically, the cost of an Explain operation is independent of the cost
+		// of the underlying plan. However, we want to explain the plan we would get
+		// without EXPLAIN, i.e. the lowest cost plan. So we let the default code
+		// below pass through the input plan cost.
+		fallthrough
+
 	default:
 		// By default, cost of parent is sum of child costs.
 		return c.computeChildrenCost(candidate)

--- a/pkg/sql/opt/xform/physical_props_builder.go
+++ b/pkg/sql/opt/xform/physical_props_builder.go
@@ -169,6 +169,11 @@ func (b physicalPropsBuilder) buildChildProps(
 			}
 			childProps.Ordering = b.mem.LookupPrivate(ordering).(memo.Ordering)
 		}
+
+	case opt.ExplainOp:
+		if nth == 0 {
+			childProps = b.mem.LookupPrivate(mexpr.AsExplain().Def()).(*memo.ExplainOpDef).Props
+		}
 	}
 
 	// If properties haven't changed, no need to re-intern them.

--- a/pkg/sql/opt/xform/testdata/physprops/ordering
+++ b/pkg/sql/opt/xform/testdata/physprops/ordering
@@ -268,3 +268,33 @@ memo (optimized)
  ├── G7: (gt G8 G9)
  ├── G8: (variable a.x)
  └── G9: (variable a.y)
+
+# --------------------------------------------------
+# Explain operator.
+# --------------------------------------------------
+opt
+EXPLAIN (VERBOSE) SELECT * FROM a ORDER BY y
+----
+explain
+ ├── columns: Tree:5(string) Level:6(int) Type:7(string) Field:8(string) Description:9(string) Columns:10(string) Ordering:11(string)
+ └── sort
+      ├── columns: x:1(int!null) y:2(float!null) z:3(decimal) s:4(string!null)
+      ├── ordering: +2
+      └── scan a
+           └── columns: a.x:1(int!null) a.y:2(float!null) a.z:3(decimal) a.s:4(string!null)
+
+memo
+EXPLAIN (VERBOSE) SELECT * FROM a ORDER BY y
+----
+memo (optimized)
+ ├── G1: (explain G2 [presentation: x:1,y:2,z:3,s:4] [ordering: +2])
+ │    └── "[presentation: Tree:5,Level:6,Type:7,Field:8,Description:9,Columns:10,Ordering:11]"
+ │         ├── best: (explain G2="[presentation: x:1,y:2,z:3,s:4] [ordering: +2]" [presentation: x:1,y:2,z:3,s:4] [ordering: +2])
+ │         └── cost: 1250.00
+ └── G2: (scan a)
+      ├── ""
+      │    ├── best: (scan a)
+      │    └── cost: 1000.00
+      └── "[presentation: x:1,y:2,z:3,s:4] [ordering: +2]"
+           ├── best: (sort G2)
+           └── cost: 1250.00

--- a/pkg/sql/opt_exec_engine.go
+++ b/pkg/sql/opt_exec_engine.go
@@ -100,30 +100,6 @@ func (ee *execEngine) Execute(p exec.Plan) ([]tree.Datums, error) {
 	return res, nil
 }
 
-// Explain is part of the exec.TestEngine interface.
-func (ee *execEngine) Explain(p exec.Plan) ([]tree.Datums, error) {
-	// Add an explain node to the plan and run that.
-	flags := explainFlags{
-		showMetadata: true,
-		qualifyNames: true,
-	}
-	explainNode, err := ee.planner.makeExplainPlanNodeWithPlan(
-		context.TODO(),
-		flags,
-		false, /* expanded */
-		false, /* optimized */
-		false, /* optimizeSubqueries */
-		p.(*planTop).plan,
-		p.(*planTop).subqueryPlans,
-	)
-	if err != nil {
-		return nil, err
-	}
-
-	// Execute the explain node.
-	return ee.Execute(&planTop{plan: explainNode})
-}
-
 // Close is part of the exec.TestEngine interface.
 func (ee *execEngine) Close() {
 	if ee.cleanup != nil {

--- a/pkg/sql/opt_exec_engine.go
+++ b/pkg/sql/opt_exec_engine.go
@@ -112,6 +112,7 @@ func (ee *execEngine) Explain(p exec.Plan) ([]tree.Datums, error) {
 		flags,
 		false, /* expanded */
 		false, /* optimized */
+		false, /* optimizeSubqueries */
 		p.(*planTop).plan,
 		p.(*planTop).subqueryPlans,
 	)
@@ -422,4 +423,23 @@ func (ee *execEngine) ConstructPlan(root exec.Node, subqueries []exec.Subquery) 
 		}
 	}
 	return res, nil
+}
+
+// ConstructExplain is part of the exec.Factory interface.
+func (ee *execEngine) ConstructExplain(plan exec.Plan) (exec.Node, error) {
+	p := plan.(*planTop)
+	// For now, we assume VERBOSE.
+	flags := explainFlags{
+		showMetadata: true,
+		qualifyNames: true,
+	}
+	return ee.planner.makeExplainPlanNodeWithPlan(
+		context.TODO(),
+		flags,
+		false, /* expanded */
+		false, /* optimized */
+		false, /* optimizeSubqueries */
+		p.plan,
+		p.subqueryPlans,
+	)
 }


### PR DESCRIPTION
#### opt: introduce and build ExplainOp

The ExplainOp must remember the physical props required by the
underlying query.

For now we only support `EXPLAIN (VERBOSE)`.

Release note: None

#### opt: execbuild support for EXPLAIN

Release note: None

#### opt: remove exec-explain

Remove the `exec-explain` directive and convert all the tests to exec
an EXPLAIN statement. Add `hide-columns` option to suppress the header
with the column names and types, for cleaner output (and to avoid a
ton of diffs in this change).

Release note: None
