### PR TITLE
backport-2.0: backupccl: skip flaky TestBackupRestoreControlJob

### DIFF
--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -816,6 +816,7 @@ func getLowWaterMark(jobID int64, sqlDB *gosql.DB) (roachpb.Key, error) {
 // work as intended on backup and restore jobs.
 func TestBackupRestoreControlJob(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	t.Skip("#24637")
 
 	defer func(oldInterval time.Duration) {
 		jobs.DefaultAdoptInterval = oldInterval


### PR DESCRIPTION
Backport 1/1 commits from #24638.

/cc @cockroachdb/release

---

Release note: None

Touches https://github.com/cockroachdb/cockroach/issues/24693
