### PR TITLE
roachtest: Skip clock tests

### DIFF
--- a/pkg/cmd/roachtest/clock_jump_crash.go
+++ b/pkg/cmd/roachtest/clock_jump_crash.go
@@ -81,31 +81,31 @@ func registerClockJump(r *registry) {
 
 	testCases := []clockJumpTestCase{
 		{
-			name:             "large_forward_jump_with_check",
+			name:             "large_forward_enabled",
 			offset:           500 * time.Millisecond,
 			jumpCheckEnabled: true,
 			aliveAfterOffset: false,
 		},
 		{
-			name:             "small_forward_jump_with_check",
+			name:             "small_forward_enabled",
 			offset:           200 * time.Millisecond,
 			jumpCheckEnabled: true,
 			aliveAfterOffset: true,
 		},
 		{
-			name:             "large_backward_jump_with_check",
+			name:             "large_backward_enabled",
 			offset:           -500 * time.Millisecond,
 			jumpCheckEnabled: true,
 			aliveAfterOffset: true,
 		},
 		{
-			name:             "large_forward_jump_without_check",
+			name:             "large_forward_disabled",
 			offset:           500 * time.Millisecond,
 			jumpCheckEnabled: false,
 			aliveAfterOffset: true,
 		},
 		{
-			name:             "large_backward_jump_without_check",
+			name:             "large_backward_disabled",
 			offset:           -500 * time.Millisecond,
 			jumpCheckEnabled: false,
 			aliveAfterOffset: true,
@@ -115,8 +115,9 @@ func registerClockJump(r *registry) {
 	for i := range testCases {
 		tc := testCases[i]
 		r.Add(testSpec{
-			Name:  fmt.Sprintf("clockjump/nodes=%d/tc=%s", numNodes, tc.name),
-			Nodes: nodes(numNodes),
+			SkippedBecause: "https://github.com/cockroachdb/cockroach/issues/25138",
+			Name:           fmt.Sprintf("clockjump/tc=%s", tc.name),
+			Nodes:          nodes(numNodes),
 			Run: func(ctx context.Context, t *test, c *cluster) {
 				runClockJump(t, c, tc)
 			},

--- a/pkg/cmd/roachtest/clock_monotonic.go
+++ b/pkg/cmd/roachtest/clock_monotonic.go
@@ -112,13 +112,13 @@ func registerClockMonotonicity(r *registry) {
 		{
 			// Without enabling the feature to persist wall time, wall time is
 			// currently non monotonic on backward clock jumps when a node is down.
-			name:                     "non_monotonic_without_persisting_walltm",
+			name:                     "non_persistent",
 			offset:                   -60 * time.Second,
 			persistWallTimeInterval:  0,
 			expectIncreasingWallTime: false,
 		},
 		{
-			name:                     "monotonic_with_persisting_walltm",
+			name:                     "persistent",
 			offset:                   -60 * time.Second,
 			persistWallTimeInterval:  500 * time.Millisecond,
 			expectIncreasingWallTime: true,
@@ -128,8 +128,9 @@ func registerClockMonotonicity(r *registry) {
 	for i := range testCases {
 		tc := testCases[i]
 		r.Add(testSpec{
-			Name:  fmt.Sprintf("clockmonotonic/nodes=%d/tc=%s", numNodes, tc.name),
-			Nodes: nodes(numNodes),
+			SkippedBecause: "https://github.com/cockroachdb/cockroach/issues/25138",
+			Name:           fmt.Sprintf("clockmonotonic/tc=%s", tc.name),
+			Nodes:          nodes(numNodes),
 			Run: func(ctx context.Context, t *test, c *cluster) {
 				runClockMonotonicity(t, c, tc)
 			},


### PR DESCRIPTION
Shorten the long names that caused their first failures, but they're
still not working so skip them.

See #25138

Release note: None