### PR TITLE
sql: report unimplemented error on ORDER BY in function arguments

### DIFF
--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -1810,9 +1810,9 @@ column_path ::=
 
 func_application ::=
 	func_name '(' ')'
-	| func_name '(' expr_list opt_sort_clause ')'
-	| func_name '(' 'ALL' expr_list opt_sort_clause ')'
-	| func_name '(' 'DISTINCT' expr_list opt_sort_clause ')'
+	| func_name '(' expr_list ')'
+	| func_name '(' 'ALL' expr_list ')'
+	| func_name '(' 'DISTINCT' expr_list ')'
 	| func_name '(' '*' ')'
 
 filter_clause ::=

--- a/pkg/sql/logictest/testdata/logic_test/orms
+++ b/pkg/sql/logictest/testdata/logic_test/orms
@@ -21,15 +21,16 @@ id   bigint  NULL  false  20  -1
 name text    NULL  false  25  -1
 
 
-## 12115
-query TT
-SELECT t.typname enum_name, array_agg(e.enumlabel ORDER BY enumsortorder) enum_value
-    FROM pg_type t
-    JOIN pg_enum e ON t.oid = e.enumtypid
-    JOIN pg_catalog.pg_namespace n ON n.oid = t.typnamespace
-    WHERE n.nspname = 'public'
-    GROUP BY 1
-----
+# #12115
+# Skipped until #25148 is solved
+#query TT
+#SELECT t.typname enum_name, array_agg(e.enumlabel ORDER BY enumsortorder) enum_value
+#    FROM pg_type t
+#    JOIN pg_enum e ON t.oid = e.enumtypid
+#    JOIN pg_catalog.pg_namespace n ON n.oid = t.typnamespace
+#    WHERE n.nspname = 'public'
+#    GROUP BY 1
+#----
 
 
 ## 12207

--- a/pkg/sql/parser/parse_test.go
+++ b/pkg/sql/parser/parse_test.go
@@ -1917,6 +1917,13 @@ RESTORE ROLE foo, bar FROM 'baz'
              ^
 HINT: try \h RESTORE`,
 		},
+		{
+			`SELECT max(a ORDER BY b) FROM ab`,
+			`unimplemented at or near ")"
+SELECT max(a ORDER BY b) FROM ab
+                       ^
+HINT: See: https://github.com/cockroachdb/cockroach/issues/23620`,
+		},
 	}
 	for _, d := range testData {
 		_, err := Parse(d.sql)

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -5021,6 +5021,10 @@ opt_all_clause:
   ALL {}
 | /* EMPTY */ {}
 
+opt_sort_clause_err:
+  sort_clause { return unimplementedWithIssue(sqllex, 23620) }
+| /* EMPTY */ {}
+
 opt_sort_clause:
   sort_clause
   {
@@ -6652,17 +6656,17 @@ func_application:
   {
     $$.val = &tree.FuncExpr{Func: $1.resolvableFuncRefFromName()}
   }
-| func_name '(' expr_list opt_sort_clause ')'
+| func_name '(' expr_list opt_sort_clause_err ')'
   {
     $$.val = &tree.FuncExpr{Func: $1.resolvableFuncRefFromName(), Exprs: $3.exprs()}
   }
-| func_name '(' VARIADIC a_expr opt_sort_clause ')' { return unimplemented(sqllex, "variadic") }
-| func_name '(' expr_list ',' VARIADIC a_expr opt_sort_clause ')' { return unimplemented(sqllex, "variadic") }
-| func_name '(' ALL expr_list opt_sort_clause ')'
+| func_name '(' VARIADIC a_expr opt_sort_clause_err ')' { return unimplemented(sqllex, "variadic") }
+| func_name '(' expr_list ',' VARIADIC a_expr opt_sort_clause_err ')' { return unimplemented(sqllex, "variadic") }
+| func_name '(' ALL expr_list opt_sort_clause_err ')'
   {
     $$.val = &tree.FuncExpr{Func: $1.resolvableFuncRefFromName(), Type: tree.AllFuncType, Exprs: $4.exprs()}
   }
-| func_name '(' DISTINCT expr_list opt_sort_clause ')'
+| func_name '(' DISTINCT expr_list opt_sort_clause_err ')'
   {
     $$.val = &tree.FuncExpr{Func: $1.resolvableFuncRefFromName(), Type: tree.DistinctFuncType, Exprs: $4.exprs()}
   }
@@ -7422,7 +7426,7 @@ a_expr_const:
   {
     $$.val = tree.NewBytesStrVal($1)
   }
-| func_name '(' expr_list opt_sort_clause ')' SCONST { return unimplemented(sqllex, "func const") }
+| func_name '(' expr_list opt_sort_clause_err ')' SCONST { return unimplemented(sqllex, "func const") }
 | const_typename SCONST
   {
     $$.val = &tree.CastExpr{Expr: tree.NewStrVal($2), Type: $1.colType(), SyntaxMode: tree.CastPrepend}


### PR DESCRIPTION
Informs #23620.

CockroachDB currently does not support specifying the order of
aggregations (#23620) but accepts the syntax silently. This is not
useful, because it creates the wrong expectations with users and
prevents CRL from learning about user demand for the feature.

This patch ensures that the syntax reports an unimplemented error.

Release note (sql change): CockroachDB now properly reports an error
when a query attempts to use ORDER BY within a function argument list,
which is an unsupported feature.