### PR TITLE
sql: check passwords with HaveIBeenPwned

### DIFF
--- a/pkg/sql/alter_user.go
+++ b/pkg/sql/alter_user.go
@@ -63,7 +63,7 @@ type alterUserSetPasswordRun struct {
 }
 
 func (n *alterUserSetPasswordNode) startExec(params runParams) error {
-	normalizedUsername, hashedPassword, err := n.userAuthInfo.resolve()
+	normalizedUsername, hashedPassword, err := n.userAuthInfo.resolve(params.EvalContext().SessionData)
 	if err != nil {
 		return err
 	}

--- a/pkg/sql/create_user.go
+++ b/pkg/sql/create_user.go
@@ -15,12 +15,18 @@
 package sql
 
 import (
+	"bufio"
 	"context"
+	"crypto/sha1"
+	"fmt"
+	"net/http"
 	"regexp"
+	"strconv"
 
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/pkg/errors"
 )
@@ -71,7 +77,7 @@ func (p *planner) CreateUserNode(
 }
 
 func (n *CreateUserNode) startExec(params runParams) error {
-	normalizedUsername, hashedPassword, err := n.userAuthInfo.resolve()
+	normalizedUsername, hashedPassword, err := n.userAuthInfo.resolve(params.EvalContext().SessionData)
 	if err != nil {
 		return err
 	}
@@ -195,8 +201,8 @@ func (p *planner) getUserAuthInfo(nameE, passwordE tree.Expr, ctx string) (userA
 	return userAuthInfo{name: name, password: password}, nil
 }
 
-// resolve returns the actual user name and (hashed) password.
-func (ua *userAuthInfo) resolve() (string, []byte, error) {
+// resolve returns the actual user name and (hashed) password. If checkHaveIBeenPwned is true, an error is returned if
+func (ua *userAuthInfo) resolve(session *sessiondata.SessionData) (string, []byte, error) {
 	name, err := ua.name()
 	if err != nil {
 		return "", nil, err
@@ -219,6 +225,15 @@ func (ua *userAuthInfo) resolve() (string, []byte, error) {
 			return "", nil, security.ErrEmptyPassword
 		}
 
+		if session.SafeUpdates {
+			const haveIBeenPwnedCount = 50
+			if count, err := getHaveIBeenPwnedCount(resolvedPassword); err != nil {
+				return "", nil, errors.Wrap(err, "getHaveIBeenPwnedCount")
+			} else if count > haveIBeenPwnedCount {
+				return "", nil, errors.Errorf("common password: has been reported in breaches over %d times", haveIBeenPwnedCount)
+			}
+		}
+
 		hashedPassword, err = security.HashPassword(resolvedPassword)
 		if err != nil {
 			return "", nil, err
@@ -226,4 +241,27 @@ func (ua *userAuthInfo) resolve() (string, []byte, error) {
 	}
 
 	return normalizedUsername, hashedPassword, nil
+}
+
+func getHaveIBeenPwnedCount(password string) (int, error) {
+	sha := sha1.Sum([]byte(password))
+	text := fmt.Sprintf("%X", sha)
+	const prefixLen = 5
+	const postfixLen = sha1.Size*2 - prefixLen
+
+	resp, err := http.Get(fmt.Sprintf("https://api.pwnedpasswords.com/range/%s", text[:prefixLen]))
+	if err != nil {
+		return 0, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return 0, errors.New(resp.Status)
+	}
+	scan := bufio.NewScanner(resp.Body)
+	for scan.Scan() {
+		if text[prefixLen:] == scan.Text()[:postfixLen] {
+			return strconv.Atoi(scan.Text()[postfixLen+1:])
+		}
+	}
+	return 0, scan.Err()
 }

--- a/pkg/sql/logictest/logic_test.go
+++ b/pkg/sql/logictest/logic_test.go
@@ -15,6 +15,7 @@
 package logictest
 
 import (
+	"net/http"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -22,5 +23,9 @@ import (
 
 func TestLogic(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+
+	// This prevents leaking an http conn goroutine during getHaveIBeenPwnedCount.
+	http.DefaultTransport.(*http.Transport).DisableKeepAlives = true
+
 	RunLogicTest(t)
 }

--- a/pkg/sql/logictest/testdata/logic_test/user
+++ b/pkg/sql/logictest/testdata/logic_test/user
@@ -115,3 +115,14 @@ user root
 
 statement error pq: user root cannot use password authentication
 ALTER USER root WITH PASSWORD 'foo'
+
+subtest HaveIBeenPwned
+
+statement ok
+SET sql_safe_updates = true;
+
+statement error pq: common password: has been reported in breaches over 50 times
+ALTER USER foo WITH PASSWORD 'test'
+
+statement error pq: common password: has been reported in breaches over 50 times
+CREATE USER foo2 WITH PASSWORD 'blah'


### PR DESCRIPTION
Use sql_safe_updates as a flag to check if passwords are too common.

Release note (sql change): If the sql_safe_updates session setting is
true, passwords set with CREATE USER or ALTER USER are securely checked
against https://pwnedpasswords.com and error if they are too common.