### PR TITLE
opt: add WITH ORDINALITY via a RowNumber operator

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/ordinality
+++ b/pkg/sql/opt/exec/execbuilder/testdata/ordinality
@@ -1,0 +1,67 @@
+# tests adapted from logictest -- ordinality
+
+exec
+SELECT ordinality FROM (VALUES ('a'), ('b')) WITH ORDINALITY
+----
+ordinality:int
+1
+2
+
+exec-raw
+CREATE TABLE foo (x CHAR PRIMARY KEY); INSERT INTO foo(x) VALUES ('a'), ('b')
+----
+
+exec
+SELECT * FROM foo WITH ORDINALITY
+----
+x:string  ordinality:int
+a         1
+b         2
+
+exec
+SELECT * FROM foo WITH ORDINALITY LIMIT 1
+----
+x:string  ordinality:int
+a         1
+
+exec hide-colnames
+EXPLAIN (VERBOSE) SELECT MAX(ordinality) FROM foo WITH ORDINALITY
+----
+group                 ·            ·                (column3)          ·
+ │                    aggregate 0  max(ordinality)  ·                  ·
+ └── render           ·            ·                ("ordinality")     ·
+      │               render 0     "ordinality"     ·                  ·
+      └── ordinality  ·            ·                (x, "ordinality")  ·
+           └── scan   ·            ·                (x)                ·
+·                     table        foo@primary      ·                  ·
+·                     spans        ALL              ·                  ·
+
+exec hide-colnames
+SELECT * FROM foo WITH ORDINALITY AS a, foo WITH ORDINALITY AS b
+----
+a  1  a  1
+a  1  b  2
+b  2  a  1
+b  2  b  2
+
+exec hide-colnames
+EXPLAIN (VERBOSE) SELECT * FROM foo WITH ORDINALITY WHERE ordinality > 1 ORDER BY ordinality
+----
+filter           ·       ·                 (x, "ordinality")  ·
+ │               filter  "ordinality" > 1  ·                  ·
+ └── ordinality  ·       ·                 (x, "ordinality")  ·
+      └── scan   ·       ·                 (x)                ·
+·                table   foo@primary       ·                  ·
+·                spans   ALL               ·                  ·
+
+exec hide-colnames
+EXPLAIN (VERBOSE) SELECT * FROM foo WITH ORDINALITY WHERE ordinality > 1 ORDER BY ordinality DESC
+----
+sort                  ·       ·                 (x, "ordinality")  -"ordinality"
+ │                    order   -"ordinality"     ·                  ·
+ └── filter           ·       ·                 (x, "ordinality")  ·
+      │               filter  "ordinality" > 1  ·                  ·
+      └── ordinality  ·       ·                 (x, "ordinality")  ·
+           └── scan   ·       ·                 (x)                ·
+·                     table   foo@primary       ·                  ·
+·                     spans   ALL               ·                  ·

--- a/pkg/sql/opt/exec/factory.go
+++ b/pkg/sql/opt/exec/factory.go
@@ -102,6 +102,10 @@ type Factory interface {
 	// by the input node.
 	ConstructSort(input Node, ordering sqlbase.ColumnOrdering) (Node, error)
 
+	// ConstructOrdinality returns a node that appends an ordinality column to
+	// each row in the input node.
+	ConstructOrdinality(input Node, colName string) (Node, error)
+
 	// ConstructLimit returns a node that implements LIMIT and/or OFFSET on the
 	// results of the given node. If only an offset is desired, limit should be
 	// math.MaxInt64.

--- a/pkg/sql/opt/memo/memo_format.go
+++ b/pkg/sql/opt/memo/memo_format.go
@@ -260,6 +260,11 @@ func (f exprFormatter) formatPrivate(private interface{}) {
 		case *ScanOpDef:
 			f.formatScanPrivate(t, false /* short */)
 
+		case *RowNumberDef:
+			if t.Ordering.Defined() {
+				fmt.Fprintf(f.buf, " ordering=%s", t.Ordering)
+			}
+
 		case opt.ColumnID:
 			fmt.Fprintf(f.buf, " %s", f.mem.metadata.ColumnLabel(t))
 

--- a/pkg/sql/opt/memo/private_storage.go
+++ b/pkg/sql/opt/memo/private_storage.go
@@ -221,6 +221,26 @@ func (ps *privateStorage) internExplainOpDef(def *ExplainOpDef) PrivateID {
 	return ps.addValue(privateKey{iface: typ, str: ps.keyBuf.String()}, def)
 }
 
+// internRowNumberDef adds the given value to storage and returns an id that can
+// later be used to retrieve the value by calling the lookup method. If the
+// value has been previously added to storage, then internRowNumberDef always
+// returns the same private id that was returned from the previous call.
+func (ps *privateStorage) internRowNumberDef(def *RowNumberDef) PrivateID {
+	// The below code is carefully constructed to not allocate in the case where
+	// the value is already in the map. Be careful when modifying.
+	ps.keyBuf.Reset()
+	for _, col := range def.Ordering {
+		ps.keyBuf.writeVarint(int64(col))
+	}
+	ps.keyBuf.writeUvarint(uint64(def.ColID))
+
+	typ := (*RowNumberDef)(nil)
+	if id, ok := ps.privatesMap[privateKey{iface: typ, str: ps.keyBuf.String()}]; ok {
+		return id
+	}
+	return ps.addValue(privateKey{iface: typ, str: ps.keyBuf.String()}, def)
+}
+
 // internSetOpColMap adds the given value to storage and returns an id that can
 // later be used to retrieve the value by calling the lookup method. If the
 // value has been previously added to storage, then internSetOpColMap always

--- a/pkg/sql/opt/memo/testdata/logprops/ordinality
+++ b/pkg/sql/opt/memo/testdata/logprops/ordinality
@@ -1,0 +1,20 @@
+exec-ddl
+CREATE TABLE xy (x INT PRIMARY KEY, y INT)
+----
+TABLE xy
+ ├── x int not null
+ ├── y int
+ └── INDEX primary
+      └── x int not null
+
+build
+SELECT * FROM xy WITH ORDINALITY
+----
+row-number
+ ├── columns: x:1(int!null) y:2(int) ordinality:3(int!null)
+ ├── stats: [rows=1000]
+ ├── keys: (1) (3)
+ └── scan xy
+      ├── columns: xy.x:1(int!null) xy.y:2(int)
+      ├── stats: [rows=1000]
+      └── keys: (1)

--- a/pkg/sql/opt/memo/testdata/logprops/select
+++ b/pkg/sql/opt/memo/testdata/logprops/select
@@ -114,3 +114,15 @@ select
  └── eq [type=bool, outer=(3), constraints=(/3: [/5 - /5]; tight)]
       ├── variable: column3 [type=int, outer=(3)]
       └── const: 5 [type=int]
+
+build
+SELECT * FROM xy WITH ORDINALITY
+----
+row-number
+ ├── columns: x:1(int!null) y:2(int) ordinality:3(int!null)
+ ├── stats: [rows=1000]
+ ├── keys: (1) (3)
+ └── scan xy
+      ├── columns: xy.x:1(int!null) xy.y:2(int)
+      ├── stats: [rows=1000]
+      └── keys: (1)

--- a/pkg/sql/opt/memo/testdata/stats/ordinality
+++ b/pkg/sql/opt/memo/testdata/stats/ordinality
@@ -1,0 +1,161 @@
+exec-ddl
+CREATE TABLE a (x INT PRIMARY KEY, y INT)
+----
+TABLE a
+ ├── x int not null
+ ├── y int
+ └── INDEX primary
+      └── x int not null
+
+exec-ddl
+ALTER TABLE a INJECT STATISTICS '[
+  {
+    "columns": ["x"],
+    "created_at": "2018-01-01 1:00:00.00000+00:00",
+    "row_count": 5000,
+    "distinct_count": 5000
+  },
+  {
+    "columns": ["y"],
+    "created_at": "2018-01-01 1:30:00.00000+00:00",
+    "row_count": 4000,
+    "distinct_count": 400
+  }
+]'
+----
+
+build
+SELECT * FROM (SELECT * FROM a WITH ORDINALITY) WHERE ordinality > 0 AND ordinality <= 10
+----
+select
+ ├── columns: x:1(int!null) y:2(int) ordinality:3(int!null)
+ ├── stats: [rows=10, distinct(3)=10]
+ ├── keys: (1) (3)
+ ├── row-number
+ │    ├── columns: a.x:1(int!null) a.y:2(int) ordinality:3(int!null)
+ │    ├── stats: [rows=4000, distinct(3)=4000]
+ │    ├── keys: (1) (3)
+ │    └── scan a
+ │         ├── columns: a.x:1(int!null) a.y:2(int)
+ │         ├── stats: [rows=4000]
+ │         └── keys: (1)
+ └── and [type=bool, outer=(3), constraints=(/3: [/1 - /10]; tight)]
+      ├── gt [type=bool, outer=(3), constraints=(/3: [/1 - ]; tight)]
+      │    ├── variable: ordinality [type=int, outer=(3)]
+      │    └── const: 0 [type=int]
+      └── le [type=bool, outer=(3), constraints=(/3: (/NULL - /10]; tight)]
+           ├── variable: ordinality [type=int, outer=(3)]
+           └── const: 10 [type=int]
+
+build
+SELECT * FROM (SELECT * FROM a WITH ORDINALITY) WHERE y > 0 AND y <= 10
+----
+select
+ ├── columns: x:1(int!null) y:2(int) ordinality:3(int!null)
+ ├── stats: [rows=100, distinct(2)=10]
+ ├── keys: (1) (3)
+ ├── row-number
+ │    ├── columns: a.x:1(int!null) a.y:2(int) ordinality:3(int!null)
+ │    ├── stats: [rows=4000, distinct(2)=400]
+ │    ├── keys: (1) (3)
+ │    └── scan a
+ │         ├── columns: a.x:1(int!null) a.y:2(int)
+ │         ├── stats: [rows=4000, distinct(2)=400]
+ │         └── keys: (1)
+ └── and [type=bool, outer=(2), constraints=(/2: [/1 - /10]; tight)]
+      ├── gt [type=bool, outer=(2), constraints=(/2: [/1 - ]; tight)]
+      │    ├── variable: a.y [type=int, outer=(2)]
+      │    └── const: 0 [type=int]
+      └── le [type=bool, outer=(2), constraints=(/2: (/NULL - /10]; tight)]
+           ├── variable: a.y [type=int, outer=(2)]
+           └── const: 10 [type=int]
+
+build
+SELECT 1 FROM a WITH ORDINALITY
+----
+project
+ ├── columns: column4:4(int)
+ ├── stats: [rows=4000]
+ ├── row-number
+ │    ├── columns: a.x:1(int!null) a.y:2(int) ordinality:3(int!null)
+ │    ├── stats: [rows=4000]
+ │    ├── keys: (1) (3)
+ │    └── scan a
+ │         ├── columns: a.x:1(int!null) a.y:2(int)
+ │         ├── stats: [rows=4000]
+ │         └── keys: (1)
+ └── projections
+      └── const: 1 [type=int]
+
+build
+SELECT x FROM (SELECT * FROM a WITH ORDINALITY) WHERE ordinality > 0 AND ordinality <= 10
+----
+project
+ ├── columns: x:1(int!null)
+ ├── stats: [rows=10]
+ ├── keys: (1)
+ ├── select
+ │    ├── columns: a.x:1(int!null) a.y:2(int) ordinality:3(int!null)
+ │    ├── stats: [rows=10, distinct(3)=10]
+ │    ├── keys: (1) (3)
+ │    ├── row-number
+ │    │    ├── columns: a.x:1(int!null) a.y:2(int) ordinality:3(int!null)
+ │    │    ├── stats: [rows=4000, distinct(3)=4000]
+ │    │    ├── keys: (1) (3)
+ │    │    └── scan a
+ │    │         ├── columns: a.x:1(int!null) a.y:2(int)
+ │    │         ├── stats: [rows=4000]
+ │    │         └── keys: (1)
+ │    └── and [type=bool, outer=(3), constraints=(/3: [/1 - /10]; tight)]
+ │         ├── gt [type=bool, outer=(3), constraints=(/3: [/1 - ]; tight)]
+ │         │    ├── variable: ordinality [type=int, outer=(3)]
+ │         │    └── const: 0 [type=int]
+ │         └── le [type=bool, outer=(3), constraints=(/3: (/NULL - /10]; tight)]
+ │              ├── variable: ordinality [type=int, outer=(3)]
+ │              └── const: 10 [type=int]
+ └── projections [outer=(1)]
+      └── variable: a.x [type=int, outer=(1)]
+
+
+build
+SELECT * FROM (SELECT * FROM a WITH ORDINALITY) WHERE ordinality = 2
+----
+select
+ ├── columns: x:1(int!null) y:2(int) ordinality:3(int!null)
+ ├── stats: [rows=1, distinct(3)=1]
+ ├── keys: (1) (3)
+ ├── row-number
+ │    ├── columns: a.x:1(int!null) a.y:2(int) ordinality:3(int!null)
+ │    ├── stats: [rows=4000, distinct(3)=4000]
+ │    ├── keys: (1) (3)
+ │    └── scan a
+ │         ├── columns: a.x:1(int!null) a.y:2(int)
+ │         ├── stats: [rows=4000]
+ │         └── keys: (1)
+ └── eq [type=bool, outer=(3), constraints=(/3: [/2 - /2]; tight)]
+      ├── variable: ordinality [type=int, outer=(3)]
+      └── const: 2 [type=int]
+
+build
+SELECT DISTINCT ordinality FROM (SELECT * FROM a WITH ORDINALITY)
+----
+group-by
+ ├── columns: ordinality:3(int!null)
+ ├── grouping columns: ordinality:3(int!null)
+ ├── stats: [rows=4000, distinct(3)=4000]
+ ├── keys: (3)
+ ├── project
+ │    ├── columns: ordinality:3(int!null)
+ │    ├── stats: [rows=4000, distinct(3)=4000]
+ │    ├── keys: (3)
+ │    ├── row-number
+ │    │    ├── columns: a.x:1(int!null) a.y:2(int) ordinality:3(int!null)
+ │    │    ├── stats: [rows=4000, distinct(3)=4000]
+ │    │    ├── keys: (1) (3)
+ │    │    └── scan a
+ │    │         ├── columns: a.x:1(int!null) a.y:2(int)
+ │    │         ├── stats: [rows=4000]
+ │    │         └── keys: (1)
+ │    └── projections [outer=(3)]
+ │         └── variable: ordinality [type=int, outer=(3)]
+ └── aggregations

--- a/pkg/sql/opt/metadata_column.go
+++ b/pkg/sql/opt/metadata_column.go
@@ -133,3 +133,10 @@ func (wk *WeakKeys) Add(new ColSet) {
 	}
 	*wk = append((*wk)[:insert], new)
 }
+
+// Copy returns a copy of the list of weak keys.
+func (wk *WeakKeys) Copy() WeakKeys {
+	res := make(WeakKeys, len(*wk))
+	copy(res, *wk)
+	return res
+}

--- a/pkg/sql/opt/ops/relational.opt
+++ b/pkg/sql/opt/ops/relational.opt
@@ -323,3 +323,11 @@ define Explain {
     Input Expr
     Def   ExplainOpDef
 }
+
+# RowNumber adds a column to each row in its input containing a unique,
+# increasing number.
+[Relational]
+define RowNumber {
+    Input    Expr
+    Def      RowNumberDef
+}

--- a/pkg/sql/opt/optbuilder/testdata/ordinality
+++ b/pkg/sql/opt/optbuilder/testdata/ordinality
@@ -1,0 +1,110 @@
+exec-ddl
+CREATE TABLE abcd (
+  a INT PRIMARY KEY,
+  b INT,
+  c INT,
+  d INT,
+  INDEX abc (a, b, c)
+)
+----
+TABLE abcd
+ ├── a int not null
+ ├── b int
+ ├── c int
+ ├── d int
+ ├── INDEX primary
+ │    └── a int not null
+ └── INDEX abc
+      ├── a int not null
+      ├── b int
+      └── c int
+
+build
+SELECT a, ordinality FROM abcd WITH ORDINALITY
+----
+project
+ ├── columns: a:1(int!null) ordinality:5(int!null)
+ ├── row-number
+ │    ├── columns: abcd.a:1(int!null) abcd.b:2(int) abcd.c:3(int) abcd.d:4(int) ordinality:5(int!null)
+ │    └── scan abcd
+ │         └── columns: abcd.a:1(int!null) abcd.b:2(int) abcd.c:3(int) abcd.d:4(int)
+ └── projections
+      ├── variable: abcd.a [type=int]
+      └── variable: ordinality [type=int]
+
+build
+SELECT a, ordinality FROM (SELECT * FROM abcd ORDER BY a) WITH ORDINALITY
+----
+project
+ ├── columns: a:1(int!null) ordinality:5(int!null)
+ ├── row-number
+ │    ├── columns: abcd.a:1(int!null) abcd.b:2(int) abcd.c:3(int) abcd.d:4(int) ordinality:5(int!null)
+ │    └── scan abcd
+ │         ├── columns: abcd.a:1(int!null) abcd.b:2(int) abcd.c:3(int) abcd.d:4(int)
+ │         └── ordering: +1
+ └── projections
+      ├── variable: abcd.a [type=int]
+      └── variable: ordinality [type=int]
+
+build
+SELECT a, ordinality FROM (SELECT * FROM abcd ORDER BY a) WITH ORDINALITY ORDER BY ordinality
+----
+project
+ ├── columns: a:1(int!null) ordinality:5(int!null)
+ ├── ordering: +5
+ ├── row-number
+ │    ├── columns: abcd.a:1(int!null) abcd.b:2(int) abcd.c:3(int) abcd.d:4(int) ordinality:5(int!null)
+ │    ├── ordering: +5
+ │    └── scan abcd
+ │         ├── columns: abcd.a:1(int!null) abcd.b:2(int) abcd.c:3(int) abcd.d:4(int)
+ │         └── ordering: +1
+ └── projections
+      ├── variable: abcd.a [type=int]
+      └── variable: ordinality [type=int]
+
+build
+SELECT a, ordinality FROM (SELECT * FROM abcd ORDER BY a) WITH ORDINALITY ORDER BY ordinality
+----
+project
+ ├── columns: a:1(int!null) ordinality:5(int!null)
+ ├── ordering: +5
+ ├── row-number
+ │    ├── columns: abcd.a:1(int!null) abcd.b:2(int) abcd.c:3(int) abcd.d:4(int) ordinality:5(int!null)
+ │    ├── ordering: +5
+ │    └── scan abcd
+ │         ├── columns: abcd.a:1(int!null) abcd.b:2(int) abcd.c:3(int) abcd.d:4(int)
+ │         └── ordering: +1
+ └── projections
+      ├── variable: abcd.a [type=int]
+      └── variable: ordinality [type=int]
+
+build
+SELECT a FROM abcd WITH ORDINALITY ORDER BY ordinality
+----
+project
+ ├── columns: a:1(int!null)
+ ├── ordering: +5
+ ├── row-number
+ │    ├── columns: abcd.a:1(int!null) abcd.b:2(int) abcd.c:3(int) abcd.d:4(int) ordinality:5(int!null)
+ │    ├── ordering: +5
+ │    └── scan abcd
+ │         └── columns: abcd.a:1(int!null) abcd.b:2(int) abcd.c:3(int) abcd.d:4(int)
+ └── projections
+      ├── variable: abcd.a [type=int]
+      └── variable: ordinality [type=int]
+
+build
+SELECT ordinality FROM abcd WITH ORDINALITY ORDER BY a
+----
+sort
+ ├── columns: ordinality:5(int!null)
+ ├── ordering: +1
+ └── project
+      ├── columns: ordinality:5(int!null) abcd.a:1(int!null)
+      ├── row-number
+      │    ├── columns: abcd.a:1(int!null) abcd.b:2(int) abcd.c:3(int) abcd.d:4(int) ordinality:5(int!null)
+      │    └── scan abcd
+      │         └── columns: abcd.a:1(int!null) abcd.b:2(int) abcd.c:3(int) abcd.d:4(int)
+      └── projections
+           ├── variable: ordinality [type=int]
+           └── variable: abcd.a [type=int]

--- a/pkg/sql/opt/optgen/cmd/optgen/utils.go
+++ b/pkg/sql/opt/optgen/cmd/optgen/utils.go
@@ -58,6 +58,8 @@ func mapPrivateType(typ string) string {
 		return "*memo.ScanOpDef"
 	case "LookupJoinDef":
 		return "*memo.LookupJoinDef"
+	case "RowNumberDef":
+		return "*memo.RowNumberDef"
 	case "SetOpColMap":
 		return "*memo.SetOpColMap"
 	case "ExplainOpDef":

--- a/pkg/sql/opt/xform/testdata/physprops/ordering
+++ b/pkg/sql/opt/xform/testdata/physprops/ordering
@@ -298,3 +298,168 @@ memo (optimized)
       └── "[presentation: x:1,y:2,z:3,s:4] [ordering: +2]"
            ├── best: (sort G2)
            └── cost: 1250.00
+
+# --------------------------------------------------
+# With Ordinality
+# --------------------------------------------------
+
+memo
+SELECT y FROM a WITH ORDINALITY ORDER BY ordinality
+----
+memo (optimized)
+ ├── G1: (project G2 G3)
+ │    ├── "[presentation: y:2] [ordering: +5]"
+ │    │    ├── best: (project G2="[ordering: +5]" G3)
+ │    │    └── cost: 1000.00
+ │    └── ""
+ │         ├── best: (project G2 G3)
+ │         └── cost: 1000.00
+ ├── G2: (row-number G4)
+ │    ├── ""
+ │    │    ├── best: (row-number G4)
+ │    │    └── cost: 1000.00
+ │    └── "[ordering: +5]"
+ │         ├── best: (row-number G4)
+ │         └── cost: 1000.00
+ ├── G3: (projections G5 G6)
+ ├── G4: (scan a)
+ │    └── ""
+ │         ├── best: (scan a)
+ │         └── cost: 1000.00
+ ├── G5: (variable a.y)
+ └── G6: (variable ordinality)
+
+memo
+SELECT y FROM a WITH ORDINALITY ORDER BY -ordinality
+----
+memo (optimized)
+ ├── G1: (project G2 G3)
+ │    ├── "[presentation: y:2] [ordering: +6]"
+ │    │    ├── best: (sort G1)
+ │    │    └── cost: 1250.00
+ │    └── ""
+ │         ├── best: (project G2 G3)
+ │         └── cost: 1000.00
+ ├── G2: (row-number G4)
+ │    └── ""
+ │         ├── best: (row-number G4)
+ │         └── cost: 1000.00
+ ├── G3: (projections G5 G6)
+ ├── G4: (scan a)
+ │    └── ""
+ │         ├── best: (scan a)
+ │         └── cost: 1000.00
+ ├── G5: (variable a.y)
+ ├── G6: (unary-minus G7)
+ └── G7: (variable ordinality)
+
+memo
+SELECT y FROM a WITH ORDINALITY ORDER BY ordinality, x
+----
+memo (optimized)
+ ├── G1: (project G2 G3)
+ │    ├── "[presentation: y:2] [ordering: +5,+1]"
+ │    │    ├── best: (project G2="[ordering: +5,+1]" G3)
+ │    │    └── cost: 1000.00
+ │    └── ""
+ │         ├── best: (project G2 G3)
+ │         └── cost: 1000.00
+ ├── G2: (row-number G4)
+ │    ├── ""
+ │    │    ├── best: (row-number G4)
+ │    │    └── cost: 1000.00
+ │    └── "[ordering: +5,+1]"
+ │         ├── best: (row-number G4)
+ │         └── cost: 1000.00
+ ├── G3: (projections G5 G6 G7)
+ ├── G4: (scan a)
+ │    └── ""
+ │         ├── best: (scan a)
+ │         └── cost: 1000.00
+ ├── G5: (variable a.y)
+ ├── G6: (variable ordinality)
+ └── G7: (variable a.x)
+
+memo
+SELECT y FROM (SELECT * FROM a ORDER BY y) WITH ORDINALITY ORDER BY y, ordinality
+----
+memo (optimized)
+ ├── G1: (project G2 G3)
+ │    ├── "[presentation: y:2] [ordering: +2,+5]"
+ │    │    ├── best: (project G2="[ordering: +2,+5]" G3)
+ │    │    └── cost: 1250.00
+ │    └── ""
+ │         ├── best: (project G2 G3)
+ │         └── cost: 1250.00
+ ├── G2: (row-number G4 ordering=+2)
+ │    ├── ""
+ │    │    ├── best: (row-number G4="[ordering: +2]" ordering=+2)
+ │    │    └── cost: 1250.00
+ │    └── "[ordering: +2,+5]"
+ │         ├── best: (row-number G4="[ordering: +2]" ordering=+2)
+ │         └── cost: 1250.00
+ ├── G3: (projections G5 G6)
+ ├── G4: (scan a)
+ │    ├── ""
+ │    │    ├── best: (scan a)
+ │    │    └── cost: 1000.00
+ │    └── "[ordering: +2]"
+ │         ├── best: (sort G4)
+ │         └── cost: 1250.00
+ ├── G5: (variable a.y)
+ └── G6: (variable ordinality)
+
+memo
+SELECT y FROM (SELECT * FROM a ORDER BY y) WITH ORDINALITY ORDER BY ordinality, y
+----
+memo (optimized)
+ ├── G1: (project G2 G3)
+ │    ├── "[presentation: y:2] [ordering: +5,+2]"
+ │    │    ├── best: (project G2="[ordering: +5,+2]" G3)
+ │    │    └── cost: 1250.00
+ │    └── ""
+ │         ├── best: (project G2 G3)
+ │         └── cost: 1250.00
+ ├── G2: (row-number G4 ordering=+2)
+ │    ├── ""
+ │    │    ├── best: (row-number G4="[ordering: +2]" ordering=+2)
+ │    │    └── cost: 1250.00
+ │    └── "[ordering: +5,+2]"
+ │         ├── best: (row-number G4="[ordering: +2]" ordering=+2)
+ │         └── cost: 1250.00
+ ├── G3: (projections G5 G6)
+ ├── G4: (scan a)
+ │    ├── ""
+ │    │    ├── best: (scan a)
+ │    │    └── cost: 1000.00
+ │    └── "[ordering: +2]"
+ │         ├── best: (sort G4)
+ │         └── cost: 1250.00
+ ├── G5: (variable a.y)
+ └── G6: (variable ordinality)
+
+memo
+SELECT y FROM a WITH ORDINALITY ORDER BY ordinality DESC
+----
+memo (optimized)
+ ├── G1: (project G2 G3)
+ │    ├── "[presentation: y:2] [ordering: -5]"
+ │    │    ├── best: (sort G1)
+ │    │    └── cost: 1250.00
+ │    └── ""
+ │         ├── best: (project G2 G3)
+ │         └── cost: 1000.00
+ ├── G2: (row-number G4)
+ │    ├── ""
+ │    │    ├── best: (row-number G4)
+ │    │    └── cost: 1000.00
+ │    └── "[ordering: -5]"
+ │         ├── best: (sort G2)
+ │         └── cost: 1250.00
+ ├── G3: (projections G5 G6)
+ ├── G4: (scan a)
+ │    └── ""
+ │         ├── best: (scan a)
+ │         └── cost: 1000.00
+ ├── G5: (variable a.y)
+ └── G6: (variable ordinality)

--- a/pkg/sql/opt_exec_engine.go
+++ b/pkg/sql/opt_exec_engine.go
@@ -355,6 +355,26 @@ func (ee *execEngine) ConstructSort(
 	}, nil
 }
 
+// ConstructOrdinality is part of the exec.Factory interface.
+func (ee *execEngine) ConstructOrdinality(input exec.Node, colName string) (exec.Node, error) {
+	plan := input.(planNode)
+	inputColumns := planColumns(plan)
+	cols := make(sqlbase.ResultColumns, len(inputColumns)+1)
+	copy(cols, inputColumns)
+	cols[len(cols)-1] = sqlbase.ResultColumn{
+		Name: colName,
+		Typ:  types.Int,
+	}
+	return &ordinalityNode{
+		source:  plan,
+		columns: cols,
+		run: ordinalityRun{
+			row:    make(tree.Datums, len(cols)),
+			curCnt: 1,
+		},
+	}, nil
+}
+
 // ConstructLimit is part of the exec.Factory interface.
 func (ee *execEngine) ConstructLimit(
 	input exec.Node, limit int64, offset int64,


### PR DESCRIPTION
WITH ORDINALITY is has the behaviour of a special case of the window
function RANK with the empty set of partitioning columns. This commit
leaves most of window functions unimplemented, only implementing enough
to do WITH ORDINALITY.

WITH ORDINALITY introduces a new column `ordinality` to the input set,
whose value corresponds to a given row's position in that input set.
The semantics of the ordering are briefly discussed at
https://www.cockroachlabs.com/docs/stable/query-order.html#order-preservation.

This commit introduces window functions in a very limited form - only as
required for WITH ORDINALITY, so no partitioning or window functions
besides ROW_NUMBER() are supported. In addition, a given window function
can only have a single windowing operator.

Release note: None