### PR TITLE
sql: fail gracefully on unsupported multi-arg aggregations

### DIFF
--- a/docs/generated/sql/aggregates.md
+++ b/docs/generated/sql/aggregates.md
@@ -49,14 +49,6 @@
 </span></td></tr>
 <tr><td><code>count_rows() &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Calculates the number of rows.</p>
 </span></td></tr>
-<tr><td><code>final_stddev(arg1: <a href="decimal.html">decimal</a>, arg2: <a href="decimal.html">decimal</a>, arg3: <a href="int.html">int</a>) &rarr; <a href="decimal.html">decimal</a></code></td><td><span class="funcdesc"><p>Calculates the standard deviation from the selected locally-computed squared difference values.</p>
-</span></td></tr>
-<tr><td><code>final_stddev(arg1: <a href="float.html">float</a>, arg2: <a href="float.html">float</a>, arg3: <a href="int.html">int</a>) &rarr; <a href="float.html">float</a></code></td><td><span class="funcdesc"><p>Calculates the standard deviation from the selected locally-computed squared difference values.</p>
-</span></td></tr>
-<tr><td><code>final_variance(arg1: <a href="decimal.html">decimal</a>, arg2: <a href="decimal.html">decimal</a>, arg3: <a href="int.html">int</a>) &rarr; <a href="decimal.html">decimal</a></code></td><td><span class="funcdesc"><p>Calculates the variance from the selected locally-computed squared difference values.</p>
-</span></td></tr>
-<tr><td><code>final_variance(arg1: <a href="float.html">float</a>, arg2: <a href="float.html">float</a>, arg3: <a href="int.html">int</a>) &rarr; <a href="float.html">float</a></code></td><td><span class="funcdesc"><p>Calculates the variance from the selected locally-computed squared difference values.</p>
-</span></td></tr>
 <tr><td><code>json_agg(arg1: anyelement) &rarr; jsonb</code></td><td><span class="funcdesc"><p>aggregates values as a JSON or JSONB array</p>
 </span></td></tr>
 <tr><td><code>jsonb_agg(arg1: anyelement) &rarr; jsonb</code></td><td><span class="funcdesc"><p>aggregates values as a JSON or JSONB array</p>

--- a/pkg/cmd/docgen/funcs.go
+++ b/pkg/cmd/docgen/funcs.go
@@ -182,6 +182,9 @@ func generateFunctions(from map[string][]tree.Builtin, categorize bool) []byte {
 		}
 		seen[name] = struct{}{}
 		for _, fn := range fns {
+			if fn.Private {
+				continue
+			}
 			if fn.Info == notUsableInfo {
 				continue
 			}

--- a/pkg/sql/logictest/testdata/logic_test/aggregate
+++ b/pkg/sql/logictest/testdata/logic_test/aggregate
@@ -1724,3 +1724,7 @@ join                       ·               ·                        (x, max, z
                 │          spans           ALL                      ·                            ·
                 └── scan   ·               ·                        (x[omitted], y, z)           ·
 ·                          table           group_ord@primary        ·                            ·
+
+# Regression test for #23798 until #10495 is fixed.
+statement error function reserved for internal use
+SELECT final_variance(1.2, 1.2, 123) FROM kv

--- a/pkg/sql/logictest/testdata/logic_test/window
+++ b/pkg/sql/logictest/testdata/logic_test/window
@@ -1683,3 +1683,7 @@ query R
 SELECT MAX(i) * (1/j) * (ROW_NUMBER() OVER (ORDER BY MAX(i))) FROM (SELECT 1 AS i, 2 AS j) GROUP BY j
 ----
 0.5
+
+# regression test for #23798 until #10495 is fixed.
+statement error function reserved for internal use
+SELECT final_variance(1.2, 1.2, 123) OVER (PARTITION BY k) FROM kv

--- a/pkg/sql/sem/builtins/all_builtins.go
+++ b/pkg/sql/sem/builtins/all_builtins.go
@@ -36,6 +36,10 @@ func init() {
 	tree.FunDefs = make(map[string]*tree.FunctionDefinition)
 	for name, def := range Builtins {
 		tree.FunDefs[name] = tree.NewFunctionDefinition(name, def)
+		if tree.FunDefs[name].Private {
+			// Avoid listing help for private functions.
+			continue
+		}
 		AllBuiltinNames = append(AllBuiltinNames, name)
 	}
 

--- a/pkg/sql/sem/tree/builtin.go
+++ b/pkg/sql/sem/tree/builtin.go
@@ -102,6 +102,11 @@ type Builtin struct {
 	// might be more appropriate.
 	Info string
 
+	// Private, when set to true, indicates the built-in function is not
+	// available for use by user queries. This is currently used by some
+	// aggregates due to issue #10495.
+	Private bool
+
 	AggregateFunc func([]types.T, *EvalContext) AggregateFunc
 	WindowFunc    func([]types.T, *EvalContext) WindowFunc
 	Fn            func(*EvalContext, Datums) (Datum, error)

--- a/pkg/sql/sem/tree/function_definition.go
+++ b/pkg/sql/sem/tree/function_definition.go
@@ -25,23 +25,28 @@ type FunctionDefinition struct {
 	HasOverloadsNeedingRepeatedEvaluation bool
 	// Definition is the set of overloads for this function name.
 	Definition []overloadImpl
+	// Private is set if any of the overloads has Private set.
+	Private bool
 }
 
 // NewFunctionDefinition allocates a function definition corresponding
 // to the given built-in definition.
 func NewFunctionDefinition(name string, def []Builtin) *FunctionDefinition {
 	hasRowDependentOverloads := false
+	private := false
 	overloads := make([]overloadImpl, len(def))
 	for i := range def {
 		overloads[i] = &def[i]
 		if def[i].NeedsRepeatedEvaluation {
 			hasRowDependentOverloads = true
 		}
+		private = private || def[i].Private
 	}
 	return &FunctionDefinition{
 		Name: name,
 		HasOverloadsNeedingRepeatedEvaluation: hasRowDependentOverloads,
 		Definition:                            overloads,
+		Private:                               private,
 	}
 }
 

--- a/pkg/sql/window.go
+++ b/pkg/sql/window.go
@@ -855,6 +855,7 @@ func (v *extractWindowFuncsVisitor) VisitPre(expr tree.Expr) (recurse bool, newE
 			v.windowFnCount++
 			v.n.funcs = append(v.n.funcs, f)
 			return false, f
+
 		case t.GetAggregateConstructor() != nil:
 			// If we see an aggregation that is not used in a window function, we save it
 			// in the visitor's seen aggregate set. The aggregate function will remain in


### PR DESCRIPTION
Fixes #23798.

CockroachDB does not yet support running aggregation functions with
more than one argument (#10495).

Prior to this patch, an error was properly generated for the situation
where an aggregate function is applied to multiple arguments in
"simple" contexts; however the check was absent when used in a window
frame, and attempting to use multiple arguments in that context would
cause a panic.

Intuitively, this code path should not have been reachable because
issue #10495 would otherwise suggest that no aggregate function
accepting more than one argument should even be defined.

Unfortunately, a previous change meant to experiment with distributed
execution of multi-argument aggregates introduced the definitions of
two such aggregates: `final_variance()` and `final_stddev()`.
This in turns enabled the code path leading to a crash.

To remove access to this code path required removing access to these
particular built-in functions from the SQL dialect. This patch
achieves this by introducing a boolean flag `Private` on built-in
functions, set to true for these two, which prevent both use by SQL
queries and auto-generation of docs.

Release note (bug fix): CockroachDB now properly reports an error when
using the internal-only functions `final_variance()` and
`final_stddev()` instead of causing a crash.