### PR TITLE
cmd/roachtest: verify unique nightly cluster names at test registration

### DIFF
--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -209,6 +209,14 @@ func execCmdWithBuffer(ctx context.Context, l *logger, args ...string) ([]byte, 
 	return out, nil
 }
 
+func makeGCEClusterName(testName, id, username string) string {
+	name := fmt.Sprintf("%s-%s-%s", username, id, testName)
+	name = strings.ToLower(name)
+	name = regexp.MustCompile(`[^-a-z0-9]+`).ReplaceAllString(name, "-")
+	name = regexp.MustCompile(`-+`).ReplaceAllString(name, "-")
+	return name
+}
+
 func makeClusterName(t testI) string {
 	if clusterName != "" {
 		return clusterName
@@ -216,7 +224,6 @@ func makeClusterName(t testI) string {
 	if local {
 		return "local"
 	}
-
 	if username == "" {
 		usr, err := user.Current()
 		if err != nil {
@@ -228,11 +235,7 @@ func makeClusterName(t testI) string {
 	if id == "" {
 		id = fmt.Sprintf("%d", timeutil.Now().Unix())
 	}
-	name := fmt.Sprintf("%s-%s-%s", username, id, t.Name())
-	name = strings.ToLower(name)
-	name = regexp.MustCompile(`[^-a-z0-9]+`).ReplaceAllString(name, "-")
-	name = regexp.MustCompile(`-+`).ReplaceAllString(name, "-")
-	return name
+	return makeGCEClusterName(t.Name(), id, username)
 }
 
 type testI interface {


### PR DESCRIPTION
Fixes #25137

Release note: None