### PR TITLE
importccl: check node health and compatibility during IMPORT planning

### DIFF
--- a/pkg/ccl/importccl/csv.go
+++ b/pkg/ccl/importccl/csv.go
@@ -30,7 +30,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
-	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/distsqlrun"
@@ -924,23 +923,6 @@ func doDistributedCSVTransform(
 ) error {
 	evalCtx := p.ExtendedEvalContext()
 
-	// TODO(dan): Filter out unhealthy nodes.
-	resp, err := p.ExecCfg().StatusServer.Nodes(ctx, &serverpb.NodesRequest{})
-	if err != nil {
-		return err
-	}
-	var nodes []roachpb.NodeDescriptor
-	for _, node := range resp.Nodes {
-		nodes = append(nodes, node.Desc)
-	}
-	// Shuffle node order so that multiple IMPORTs done in parallel will not
-	// identically schedule CSV reading. For example, if there are 3 nodes and 4
-	// files, the first node will get 2 files while the other nodes will each get 1
-	// file. Shuffling will make that first node random instead of always the same.
-	rand.Shuffle(len(nodes), func(i, j int) {
-		nodes[i], nodes[j] = nodes[j], nodes[i]
-	})
-
 	ci := sqlbase.ColTypeInfoFromColTypes([]sqlbase.ColumnType{
 		{SemanticType: sqlbase.ColumnType_STRING},
 		{SemanticType: sqlbase.ColumnType_INT},
@@ -957,12 +939,8 @@ func doDistributedCSVTransform(
 
 	if err := sql.LoadCSV(
 		ctx,
-		p.DistSQLPlanner(),
+		p,
 		job,
-		p.ExecCfg().DB,
-		evalCtx,
-		p.ExecCfg().NodeID.Get(),
-		nodes,
 		sql.NewRowResultWriter(rows),
 		tableDesc,
 		files,

--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -890,21 +890,31 @@ func (dsp *DistSQLPlanner) getNodeIDForScan(
 	if err != nil {
 		return 0, err
 	}
-	nodeID := replInfo.NodeID
 
-	// Check node health and compatibility.
-	addr := replInfo.NodeDesc.Address.String()
-	if err := dsp.checkNodeHealth(planCtx.ctx, nodeID, addr); err != nil {
-		log.Eventf(planCtx.ctx, "not planning on node %d. unhealthy", nodeID)
-		return dsp.nodeDesc.NodeID, nil
+	nodeID := replInfo.NodeDesc.NodeID
+	if err := dsp.checkNodeHealthAndVersion(planCtx, replInfo.NodeDesc); err != nil {
+		log.Eventf(planCtx.ctx, "not planning on node %d. %v", nodeID, err)
 	}
-	if !dsp.nodeVersionIsCompatible(nodeID, dsp.planVersion) {
-		log.Eventf(planCtx.ctx, "not planning on node %d. incompatible version", nodeID)
-		return dsp.nodeDesc.NodeID, nil
-	}
-
-	planCtx.nodeAddresses[nodeID] = addr
 	return nodeID, nil
+}
+
+// checkNodeHealthAndVersion adds the node to planCtx if it is healthy and
+// has a compatible version. An error is returned otherwise.
+func (dsp *DistSQLPlanner) checkNodeHealthAndVersion(
+	planCtx *planningCtx, desc *roachpb.NodeDescriptor,
+) error {
+	nodeID := desc.NodeID
+	addr := desc.Address.String()
+	var err error
+
+	if err = dsp.checkNodeHealth(planCtx.ctx, nodeID, addr); err != nil {
+		err = errors.New("unhealthy")
+	} else if !dsp.nodeVersionIsCompatible(nodeID, dsp.planVersion) {
+		err = errors.New("incompatible version")
+	} else {
+		planCtx.nodeAddresses[nodeID] = addr
+	}
+	return err
 }
 
 // createTableReaders generates a plan consisting of table reader processors,


### PR DESCRIPTION
Simplify the LoadCSV signature by taking just a PlanHookState for any
argument that can be fetched from it. Determine the node list using
this new health check function. We can remove the rand.Shuffle call
because the map iteration should produce some level of randomness.

Fixes #12876

Release note (bug fix): Fix problems with imports sometimes failing
after node decommissioning.