### PR TITLE
sql: permited collated strings as index constraints

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/collatedstring
+++ b/pkg/sql/logictest/testdata/logic_test/collatedstring
@@ -240,6 +240,11 @@ x
 ü
 
 query T
+SELECT a FROM t WHERE a = 'A' COLLATE en;
+----
+A
+
+query T
 SELECT 'a' COLLATE en::STRING || 'b'
 ----
 ab
@@ -299,3 +304,18 @@ query T
 SELECT a FROM foo
 ----
 NULL
+
+# Regression test for #24449
+
+statement ok
+INSERT INTO foo VALUES ('aBcD' COLLATE en_u_ks_level2)
+
+query T
+SELECT * FROM foo WHERE a = 'aBcD' COLLATE en_u_ks_level2
+----
+aBcD
+
+query T
+SELECT * FROM foo WHERE a = 'abcd' COLLATE en_u_ks_level2
+----
+aBcD

--- a/pkg/sql/sqlbase/table.go
+++ b/pkg/sql/sqlbase/table.go
@@ -1362,13 +1362,13 @@ func DecodeTableKey(
 		}
 		return a.NewDOid(tree.MakeDOid(tree.DInt(i))), rkey, err
 	default:
-		if _, ok := valType.(types.TCollatedString); ok {
+		if t, ok := valType.(types.TCollatedString); ok {
 			var r string
-			_, r, err = encoding.DecodeUnsafeStringAscending(key, nil)
+			rkey, r, err = encoding.DecodeUnsafeStringAscending(key, nil)
 			if err != nil {
 				return nil, nil, err
 			}
-			return nil, nil, errors.Errorf("TODO(eisen): cannot decode collation key: %q", r)
+			return tree.NewDCollatedString(r, t.Locale, &a.env), rkey, err
 		}
 		return nil, nil, errors.Errorf("TODO(pmattis): decoded index key: %s", valType)
 	}


### PR DESCRIPTION
Previously, there was an accidental miss - you couldn't use a collated
string as a value in a WHERE clause that got converted into an index
constraint. This was purely an oversight.

Fixes #24449.

Release note (sql change): permit use of collated strings in WHERE
clauses on indexed columns.