### PR TITLE
opt: support selecting from EXPLAIN

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/explain
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain
@@ -62,3 +62,23 @@ join         ·              ·                   (x, y, u, v)        ·
 ·            row 0, expr 1  2                   ·                   ·
 ·            row 1, expr 0  3                   ·                   ·
 ·            row 1, expr 1  4                   ·                   ·
+
+exec
+SELECT "Tree", "Columns" FROM [ EXPLAIN (VERBOSE) SELECT * FROM xy ORDER BY y ]
+----
+Tree:string  Columns:string
+sort         (x, y)
+ │           ·
+ └── scan    (x, y)
+·            ·
+·            ·
+
+exec
+SELECT "Level", "Type" FROM [ EXPLAIN (VERBOSE) SELECT * FROM xy ORDER BY y ]
+----
+Level:int  Type:string
+0          sort
+0          ·
+1          scan
+1          ·
+1          ·

--- a/pkg/sql/opt/optbuilder/select.go
+++ b/pkg/sql/opt/optbuilder/select.go
@@ -64,6 +64,10 @@ func (b *Builder) buildTable(texpr tree.TableExpr, inScope *scope) (outScope *sc
 		outScope.removeHiddenCols()
 		return outScope
 
+	case *tree.StatementSource:
+		outScope = b.buildStmt(source.Statement, inScope)
+		return outScope
+
 	default:
 		panic(errorf("not yet implemented: table expr: %T", texpr))
 	}

--- a/pkg/sql/opt/optbuilder/testdata/explain
+++ b/pkg/sql/opt/optbuilder/testdata/explain
@@ -47,3 +47,35 @@ explain
       └── eq [type=bool]
            ├── variable: xy.x [type=int]
            └── variable: column1 [type=int]
+
+build
+SELECT "Tree" FROM [ EXPLAIN (VERBOSE) SELECT * FROM xy ]
+----
+project
+ ├── columns: Tree:3(string)
+ ├── explain
+ │    ├── columns: Tree:3(string) Level:4(int) Type:5(string) Field:6(string) Description:7(string) Columns:8(string) Ordering:9(string)
+ │    └── scan xy
+ │         └── columns: x:1(int!null) y:2(int)
+ └── projections
+      └── variable: Tree [type=string]
+
+build
+SELECT "Tree" FROM [ EXPLAIN (VERBOSE) SELECT x, x, y FROM xy ORDER BY y ]
+----
+project
+ ├── columns: Tree:3(string)
+ ├── explain
+ │    ├── columns: Tree:3(string) Level:4(int) Type:5(string) Field:6(string) Description:7(string) Columns:8(string) Ordering:9(string)
+ │    └── sort
+ │         ├── columns: x:1(int!null) x:1(int!null) y:2(int)
+ │         ├── ordering: +2
+ │         └── project
+ │              ├── columns: xy.x:1(int!null) xy.y:2(int)
+ │              ├── scan xy
+ │              │    └── columns: xy.x:1(int!null) xy.y:2(int)
+ │              └── projections
+ │                   ├── variable: xy.x [type=int]
+ │                   └── variable: xy.y [type=int]
+ └── projections
+      └── variable: Tree [type=string]

--- a/pkg/sql/opt/xform/physical_props_builder.go
+++ b/pkg/sql/opt/xform/physical_props_builder.go
@@ -135,7 +135,7 @@ func (b physicalPropsBuilder) buildChildProps(
 
 	if required == memo.MinPhysPropsID {
 		switch mexpr.Operator() {
-		case opt.LimitOp, opt.OffsetOp:
+		case opt.LimitOp, opt.OffsetOp, opt.ExplainOp:
 		default:
 			// Fast path taken in common case when no properties are required of
 			// parent and the operator itself does not require any properties.


### PR DESCRIPTION
Implementing a missing code path for allowing statements like EXPLAIN
to be data sources. This allows us to SELECT columns from EXPLAIN,
which will be useful for `EXPLAIN (DISTSQL)`.

Fixing a bug in the physicalPropsBuilder where we were incorrectly
handling ExplainOp.

Release note: None