### PR TITLE
opt: set required ordering in scanNode

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/limit
+++ b/pkg/sql/opt/exec/execbuilder/testdata/limit
@@ -6,7 +6,7 @@ INSERT INTO t VALUES (1, 1, 1), (2, -4, 8), (3, 9, 27), (4, -16, 94), (5, 25, 12
 exec hide-colnames
 EXPLAIN (VERBOSE) SELECT k, v FROM t ORDER BY k LIMIT 5
 ----
-scan  ·      ·          (k, v)  ·
+scan  ·      ·          (k, v)  +k
 ·     table  t@primary  ·       ·
 ·     spans  ALL        ·       ·
 ·     limit  5          ·       ·
@@ -24,9 +24,9 @@ k:int  v:int
 exec hide-colnames
 EXPLAIN (VERBOSE) SELECT k, v FROM t ORDER BY k OFFSET 5
 ----
-limit      ·       ·          (k, v)  ·
+limit      ·       ·          (k, v)  +k
  │         offset  5          ·       ·
- └── scan  ·       ·          (k, v)  ·
+ └── scan  ·       ·          (k, v)  +k
 ·          table   t@primary  ·       ·
 ·          spans   ALL        ·       ·
 
@@ -39,10 +39,10 @@ k:int  v:int
 exec hide-colnames
 EXPLAIN (VERBOSE) SELECT k, v FROM t ORDER BY v LIMIT (1+4) OFFSET 1
 ----
-limit      ·       ·          (k, v)  ·
+limit      ·       ·          (k, v)  +v
  │         count   5          ·       ·
  │         offset  1          ·       ·
- └── scan  ·       ·          (k, v)  ·
+ └── scan  ·       ·          (k, v)  +v
 ·          table   t@t_v_idx  ·       ·
 ·          spans   ALL        ·       ·
 

--- a/pkg/sql/opt/exec/execbuilder/testdata/orderby
+++ b/pkg/sql/opt/exec/execbuilder/testdata/orderby
@@ -145,7 +145,7 @@ EXPLAIN (VERBOSE) SELECT b FROM t ORDER BY a LIMIT 1
 ----
 render     ·         ·          (b)     ·
  │         render 0  b          ·       ·
- └── scan  ·         ·          (a, b)  ·
+ └── scan  ·         ·          (a, b)  +a
 ·          table     t@primary  ·       ·
 ·          spans     ALL        ·       ·
 ·          limit     1          ·       ·
@@ -423,7 +423,7 @@ two
 exec hide-colnames
 EXPLAIN (VERBOSE) SELECT * FROM abc ORDER BY a
 ----
-scan  ·      ·            (a, b, c, d)  ·
+scan  ·      ·            (a, b, c, d)  +a
 ·     table  abc@primary  ·             ·
 ·     spans  ALL          ·             ·
 
@@ -467,7 +467,7 @@ a:int  b:int  c:int  d:string
 exec hide-colnames
 EXPLAIN (VERBOSE) SELECT a, b FROM abc ORDER BY b, a
 ----
-scan  ·      ·       (a, b)  ·
+scan  ·      ·       (a, b)  +b,+a
 ·     table  abc@ba  ·       ·
 ·     spans  ALL     ·       ·
 
@@ -490,7 +490,7 @@ a:int  b:int
 exec hide-colnames
 EXPLAIN (VERBOSE) SELECT a, b, c FROM abc ORDER BY b, a, c
 ----
-scan  ·      ·       (a, b, c)  ·
+scan  ·      ·       (a, b, c)  +b,+a,+c
 ·     table  abc@ba  ·          ·
 ·     spans  ALL     ·          ·
 
@@ -563,7 +563,7 @@ EXPLAIN (VERBOSE) SELECT a, b FROM abc ORDER BY b, c
 render     ·         ·       (a, b)     ·
  │         render 0  a       ·          ·
  │         render 1  b       ·          ·
- └── scan  ·         ·       (a, b, c)  ·
+ └── scan  ·         ·       (a, b, c)  +b,+c
 ·          table     abc@bc  ·          ·
 ·          spans     ALL     ·          ·
 
@@ -613,7 +613,7 @@ EXPLAIN (VERBOSE) SELECT a, b FROM abc ORDER BY b, c, a
 render     ·         ·       (a, b)     ·
  │         render 0  a       ·          ·
  │         render 1  b       ·          ·
- └── scan  ·         ·       (a, b, c)  ·
+ └── scan  ·         ·       (a, b, c)  +b,+c,+a
 ·          table     abc@bc  ·          ·
 ·          spans     ALL     ·          ·
 

--- a/pkg/sql/opt/exec/factory.go
+++ b/pkg/sql/opt/exec/factory.go
@@ -53,12 +53,18 @@ type Factory interface {
 	//     in the constraint.
 	//   - If hardLimit > 0, then only up to hardLimit rows can be returned from
 	//     the scan.
+	//
+	// The required ordering (reqOrder) is necessary for distributed execution:
+	// this annotation indicates how results from multiple nodes are merged. It
+	// refers to the scanned columns by ordinal: specifically, ColIdx=0 is the
+	// first column in the needed set, ColIdx=1 is the second column, etc.
 	ConstructScan(
 		table opt.Table,
 		index opt.Index,
 		needed ColumnOrdinalSet,
 		indexConstraint *constraint.Constraint,
 		hardLimit int64,
+		reqOrder sqlbase.ColumnOrdering,
 	) (Node, error)
 
 	// ConstructFilter returns a node that applies a filter on the results of

--- a/pkg/sql/opt_exec_engine.go
+++ b/pkg/sql/opt_exec_engine.go
@@ -127,6 +127,7 @@ func (ee *execEngine) ConstructScan(
 	cols exec.ColumnOrdinalSet,
 	indexConstraint *constraint.Constraint,
 	hardLimit int64,
+	reqOrder sqlbase.ColumnOrdering,
 ) (exec.Node, error) {
 	tabDesc := table.(*optTable).desc
 	indexDesc := index.(*optIndex).desc
@@ -149,6 +150,12 @@ func (ee *execEngine) ConstructScan(
 	if err != nil {
 		return nil, err
 	}
+	for i := range reqOrder {
+		if reqOrder[i].ColIdx >= len(colCfg.wantedColumns) {
+			return nil, errors.Errorf("invalid reqOrder: %v", reqOrder)
+		}
+	}
+	scan.props.ordering = reqOrder
 	return scan, nil
 }
 


### PR DESCRIPTION
Set the ordering property of the scanNode. This is inconsequential for
local execution, but it is a necessary hint to the distsql planner: it
will make sure to maintain this order when results are merged from
different nodes.

Release note: None