### PR TITLE
prereqs: ignore Go files that start with . or _

### DIFF
--- a/pkg/cmd/prereqs/testdata/src/example.com/specialchars/.ignore.go
+++ b/pkg/cmd/prereqs/testdata/src/example.com/specialchars/.ignore.go
@@ -1,0 +1,17 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package a
+
+dfasdg agawega ageawg

--- a/pkg/cmd/prereqs/testdata/src/example.com/specialchars/_ignore.go
+++ b/pkg/cmd/prereqs/testdata/src/example.com/specialchars/_ignore.go
@@ -1,0 +1,17 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package a
+
+dfasdg agawega ageawg


### PR DESCRIPTION
The Go build system ignores Go files that start with . or _, as they're
usually temporary files generated by editors. Teach prereqs to exclude
these files to avoid spurious rebuilds.

See comments within for why we can't rely on go/build to ignore these
files automatically.

Really fix #25201.