### PR TITLE
sql, opt: move EXPLAIN option parsing to sem/tree; support EXPLAIN flags in opt

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/relational_builder.go
+++ b/pkg/sql/opt/exec/execbuilder/relational_builder.go
@@ -549,14 +549,14 @@ func (b *Builder) buildExplain(ev memo.ExprView) (execPlan, error) {
 	if err != nil {
 		return execPlan{}, err
 	}
-	node, err := b.factory.ConstructExplain(plan)
+	def := ev.Private().(*memo.ExplainOpDef)
+	node, err := b.factory.ConstructExplain(&def.Options, plan)
 	if err != nil {
 		return execPlan{}, err
 	}
 	ep := execPlan{root: node}
-	colList := ev.Private().(*memo.ExplainOpDef).ColList
-	for i := range colList {
-		ep.outputCols.Set(int(colList[i]), i)
+	for i := range def.ColList {
+		ep.outputCols.Set(int(def.ColList[i]), i)
 	}
 	// The subqueries are now owned by the explain node; remove them so they don't
 	// also show up in the final plan.

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain
@@ -3,6 +3,22 @@ CREATE TABLE xy (x INT PRIMARY KEY, y INT)
 ----
 
 exec
+EXPLAIN SELECT * FROM xy
+----
+Tree:string  Field:string  Description:string
+scan         ·             ·
+·            table         xy@primary
+·            spans         ALL
+
+exec
+EXPLAIN (TYPES) SELECT * FROM xy
+----
+Tree:string  Field:string  Description:string  Columns:string  Ordering:string
+scan         ·             ·                   (x int, y int)  ·
+·            table         xy@primary          ·               ·
+·            spans         ALL                 ·               ·
+
+exec
 EXPLAIN (VERBOSE) SELECT * FROM xy
 ----
 Tree:string  Field:string  Description:string  Columns:string  Ordering:string

--- a/pkg/sql/opt/exec/factory.go
+++ b/pkg/sql/opt/exec/factory.go
@@ -110,9 +110,7 @@ type Factory interface {
 
 	// ConstructExplain returns a node that implements EXPLAIN, showing
 	// information about the given plan.
-	//
-	// TODO(radu): add flags, for now we assume VERBOSE.
-	ConstructExplain(plan Plan) (Node, error)
+	ConstructExplain(options *tree.ExplainOptions, plan Plan) (Node, error)
 }
 
 // Subquery encapsulates information about a subquery that is part of a plan.

--- a/pkg/sql/opt/memo/private_defs.go
+++ b/pkg/sql/opt/memo/private_defs.go
@@ -110,7 +110,7 @@ func (s *ScanOpDef) CanProvideOrdering(md *opt.Metadata, required Ordering) bool
 
 // ExplainOpDef defines the value of the Def private field of the Explain operator.
 type ExplainOpDef struct {
-	// TODO(radu): flags
+	Options tree.ExplainOptions
 
 	// ColList stores the column IDs for the explain columns.
 	ColList opt.ColList

--- a/pkg/sql/opt/memo/private_storage.go
+++ b/pkg/sql/opt/memo/private_storage.go
@@ -209,6 +209,9 @@ func (ps *privateStorage) internLookupJoinDef(def *LookupJoinDef) PrivateID {
 // returns the same private id that was returned from the previous call.
 func (ps *privateStorage) internExplainOpDef(def *ExplainOpDef) PrivateID {
 	ps.keyBuf.Reset()
+	ps.keyBuf.writeUvarint(uint64(def.Options.Mode))
+	// This isn't a column set, but writing it out works just the same.
+	ps.keyBuf.writeColSet(def.Options.Flags)
 	ps.keyBuf.writeColList(def.ColList)
 	ps.keyBuf.WriteString(def.Props.Fingerprint())
 	typ := (*ExplainOpDef)(nil)

--- a/pkg/sql/opt/optbuilder/testdata/explain
+++ b/pkg/sql/opt/optbuilder/testdata/explain
@@ -8,6 +8,30 @@ TABLE xy
       └── x int not null
 
 build
+EXPLAIN SELECT * FROM xy
+----
+explain
+ ├── columns: Tree:3(string) Field:4(string) Description:5(string)
+ └── scan xy
+      └── columns: x:1(int!null) y:2(int)
+
+build
+EXPLAIN (PLAN,SYMVARS) SELECT * FROM xy
+----
+explain
+ ├── columns: Tree:3(string) Field:4(string) Description:5(string)
+ └── scan xy
+      └── columns: x:1(int!null) y:2(int)
+
+build
+EXPLAIN (TYPES) SELECT * FROM xy
+----
+explain
+ ├── columns: Tree:3(string) Field:6(string) Description:7(string) Columns:8(string) Ordering:9(string)
+ └── scan xy
+      └── columns: x:1(int!null) y:2(int)
+
+build
 EXPLAIN (VERBOSE) SELECT * FROM xy
 ----
 explain


### PR DESCRIPTION
#### sql: move EXPLAIN option parsing to sem/tree

Move the EXPLAIN option parsing code so that it can be used by the
optimizer as well.

Release note: None

#### opt: support EXPLAIN flags

Release note: None