### PR TITLE
gossip: Increase node descriptor TTL and centralize intervals/TTLs

### DIFF
--- a/pkg/server/node.go
+++ b/pkg/server/node.go
@@ -55,11 +55,6 @@ import (
 const (
 	// gossipStatusInterval is the interval for logging gossip status.
 	gossipStatusInterval = 1 * time.Minute
-	// gossipNodeDescriptorInterval is the interval for gossiping the node descriptor.
-	// Note that increasing this duration may increase the likelihood of gossip
-	// thrashing, since node descriptors are used to determine the number of gossip
-	// hops between nodes (see #9819 for context).
-	gossipNodeDescriptorInterval = 1 * time.Hour
 
 	// FirstNodeID is the node ID of the first node in a new cluster.
 	FirstNodeID = 1
@@ -697,8 +692,8 @@ func (n *Node) startGossip(ctx context.Context, stopper *stop.Stopper) {
 		}
 
 		statusTicker := time.NewTicker(gossipStatusInterval)
-		storesTicker := time.NewTicker(gossip.GossipStoresInterval)
-		nodeTicker := time.NewTicker(gossipNodeDescriptorInterval)
+		storesTicker := time.NewTicker(gossip.StoresInterval)
+		nodeTicker := time.NewTicker(gossip.NodeDescriptorInterval)
 		defer storesTicker.Stop()
 		defer nodeTicker.Stop()
 		n.gossipStores(ctx) // one-off run before going to sleep

--- a/pkg/storage/replicate_queue_test.go
+++ b/pkg/storage/replicate_queue_test.go
@@ -21,12 +21,10 @@ import (
 	"math"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/pkg/errors"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
-	"github.com/cockroachdb/cockroach/pkg/gossip"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/server"
@@ -43,13 +41,6 @@ func TestReplicateQueueRebalance(t *testing.T) {
 	if testing.Short() {
 		t.Skip("short flag")
 	}
-
-	// Set the gossip stores interval lower to speed up rebalancing. With the
-	// default of 5s we have to wait ~5s for the rebalancing to start.
-	defer func(v time.Duration) {
-		gossip.GossipStoresInterval = v
-	}(gossip.GossipStoresInterval)
-	gossip.GossipStoresInterval = 100 * time.Millisecond
 
 	const numNodes = 5
 	tc := testcluster.StartTestCluster(t, numNodes,

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -73,8 +73,6 @@ const (
 	// rangeIDAllocCount is the number of Range IDs to allocate per allocation.
 	rangeIDAllocCount             = 10
 	defaultHeartbeatIntervalTicks = 5
-	// ttlStoreGossip is time-to-live for store-related info.
-	ttlStoreGossip = 2 * time.Minute
 
 	// defaultRaftEntryCacheSize is the default size in bytes for a
 	// store's Raft log entry cache.
@@ -1553,7 +1551,7 @@ func (s *Store) GossipStore(ctx context.Context) error {
 	// Unique gossip key per store.
 	gossipStoreKey := gossip.MakeStoreKey(storeDesc.StoreID)
 	// Gossip store descriptor.
-	if err := s.cfg.Gossip.AddInfoProto(gossipStoreKey, storeDesc, ttlStoreGossip); err != nil {
+	if err := s.cfg.Gossip.AddInfoProto(gossipStoreKey, storeDesc, gossip.StoreTTL); err != nil {
 		return err
 	}
 	// Once we have gossiped the store descriptor the first time, other nodes
@@ -1643,7 +1641,7 @@ func (s *Store) GossipDeadReplicas(ctx context.Context) error {
 	// Unique gossip key per store.
 	key := gossip.MakeDeadReplicasKey(s.StoreID())
 	// Gossip dead replicas.
-	return s.cfg.Gossip.AddInfoProto(key, &deadReplicas, ttlStoreGossip)
+	return s.cfg.Gossip.AddInfoProto(key, &deadReplicas, gossip.StoreTTL)
 }
 
 // Bootstrap writes a new store ident to the underlying engine. To


### PR DESCRIPTION
In the process, remove the old COCKROACH_GOSSIP_STORES_INTERVAL
environment variable. I can't find any mentions of people using it, and
setting it to larger than the 2 minute TTL for store gossip would be
dangerous.

Addresses part of #24753 by making it much less likely that nodes on
opposite sides of a gossip partition would just forget about each other.

Release note: None