### PR TITLE
server: push metrics to Graphite

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -176,6 +176,12 @@
 
 [[projects]]
   branch = "master"
+  name = "github.com/beorn7/perks"
+  packages = ["quantile"]
+  revision = "3a771d992973f24aa725d07868b467d1ddfceafb"
+
+[[projects]]
+  branch = "master"
   name = "github.com/biogo/store"
   packages = ["llrb"]
   revision = "913427a1d5e89604e50ea1db0f28f34966d61602"
@@ -924,6 +930,15 @@
   version = "v1.0.0"
 
 [[projects]]
+  name = "github.com/prometheus/client_golang"
+  packages = [
+    "prometheus",
+    "prometheus/graphite",
+  ]
+  revision = "967789050ba94deca04a5e84cce8ad472ce313c1"
+  version = "v0.9.0-pre1"
+
+[[projects]]
   branch = "master"
   name = "github.com/prometheus/client_model"
   packages = ["go"]
@@ -938,6 +953,17 @@
     "model",
   ]
   revision = "1bab55dd05dbff384524a6a1c99006d9eb5f139b"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/prometheus/procfs"
+  packages = [
+    ".",
+    "internal/util",
+    "nfs",
+    "xfs",
+  ]
+  revision = "8b1c2da0d56deffdbb9e48d4414b4e674bd8083e"
 
 [[projects]]
   branch = "master"
@@ -1271,6 +1297,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "dfafad574198c5257aec577e320265e79b968c26e5dfad96ed753e933c9a1590"
+  inputs-digest = "bea31ac3645efde6e281cd477725432516f4a1c98bc0600d50f4a4daed069fb0"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/docs/generated/settings/settings.html
+++ b/docs/generated/settings/settings.html
@@ -12,6 +12,8 @@
 <tr><td><code>diagnostics.reporting.enabled</code></td><td>boolean</td><td><code>true</code></td><td>enable reporting diagnostic metrics to cockroach labs</td></tr>
 <tr><td><code>diagnostics.reporting.interval</code></td><td>duration</td><td><code>1h0m0s</code></td><td>interval at which diagnostics data should be reported (should be shorter than diagnostics.forced_stat_reset.interval)</td></tr>
 <tr><td><code>diagnostics.reporting.send_crash_reports</code></td><td>boolean</td><td><code>true</code></td><td>send crash and panic reports</td></tr>
+<tr><td><code>external.graphite.endpoint</code></td><td>string</td><td><code></code></td><td>if nonempty, push server metrics to the Graphite or Carbon server at the specified host:port</td></tr>
+<tr><td><code>external.graphite.interval</code></td><td>duration</td><td><code>10s</code></td><td>the interval at which metrics are pushed to Graphite (if enabled)</td></tr>
 <tr><td><code>jobs.registry.leniency</code></td><td>duration</td><td><code>1m0s</code></td><td>the amount of time to defer any attempts to reschedule a job</td></tr>
 <tr><td><code>kv.allocator.lease_rebalancing_aggressiveness</code></td><td>float</td><td><code>1E+00</code></td><td>set greater than 1.0 to rebalance leases toward load more aggressively, or between 0 and 1.0 to be more conservative about rebalancing leases</td></tr>
 <tr><td><code>kv.allocator.load_based_lease_rebalancing.enabled</code></td><td>boolean</td><td><code>true</code></td><td>set to enable rebalancing of range leases based on load and latency</td></tr>

--- a/pkg/server/graphite_test.go
+++ b/pkg/server/graphite_test.go
@@ -1,0 +1,72 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package server
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+)
+
+// TestGraphite tests that a server pushes metrics data to Graphite endpoint,
+// if configured. In addition, it verifies that things don't fall apart when
+// the endpoint goes away.
+func TestGraphite(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	s, rawDB, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	defer s.Stopper().Stop(context.TODO())
+	ctx := context.Background()
+
+	const setQ = `SET CLUSTER SETTING "%s" = "%s"`
+	const interval = 3 * time.Millisecond
+	db := sqlutils.MakeSQLRunner(rawDB)
+	db.Exec(t, fmt.Sprintf(setQ, graphiteIntervalKey, interval))
+
+	listen := func() {
+		lis, err := net.Listen("tcp", "127.0.0.1:0")
+		if err != nil {
+			t.Fatal("failed to open port", err)
+		}
+		p := lis.Addr().String()
+		log.Infof(ctx, "Open port %s and listening", p)
+
+		defer func() {
+			log.Infof(ctx, "Close port %s", p)
+			if err := lis.Close(); err != nil {
+				t.Fatal("failed to close port", err)
+			}
+		}()
+
+		db.Exec(t, fmt.Sprintf(setQ, "external.graphite.endpoint", p))
+		if _, e := lis.Accept(); e != nil {
+			t.Fatal("failed to receive connection", e)
+		} else {
+			log.Info(ctx, "received connection")
+		}
+	}
+
+	listen()
+	log.Info(ctx, "Make sure things don't fall apart when endpoint goes away.")
+	time.Sleep(5 * interval)
+	listen()
+}

--- a/pkg/server/node.go
+++ b/pkg/server/node.go
@@ -35,6 +35,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/server/status"
+	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
@@ -57,7 +58,9 @@ const (
 	gossipStatusInterval = 1 * time.Minute
 
 	// FirstNodeID is the node ID of the first node in a new cluster.
-	FirstNodeID = 1
+	FirstNodeID         = 1
+	graphiteIntervalKey = "external.graphite.interval"
+	maxGraphiteInterval = 15 * time.Minute
 )
 
 // Metric names.
@@ -71,6 +74,30 @@ var (
 	metaExecError = metric.Metadata{
 		Name: "exec.error",
 		Help: "Number of batch KV requests that failed to execute on this node"}
+)
+
+// Cluster settings.
+var (
+	// graphiteEndpoint is host:port, if any, of Graphite metrics server.
+	graphiteEndpoint = settings.RegisterStringSetting(
+		"external.graphite.endpoint",
+		"if nonempty, push server metrics to the Graphite or Carbon server at the specified host:port",
+		"",
+	)
+	// graphiteInterval is how often metrics are pushed to Graphite, if enabled.
+	graphiteInterval = settings.RegisterValidatedDurationSetting(
+		graphiteIntervalKey,
+		"the interval at which metrics are pushed to Graphite (if enabled)",
+		10*time.Second,
+		func(v time.Duration) error {
+			if v < 0 {
+				return errors.Errorf("cannot set %s to a negative duration: %s", graphiteIntervalKey, v)
+			} else if v > maxGraphiteInterval {
+				return errors.Errorf("cannot set %s to more than %v: %s", graphiteIntervalKey, maxGraphiteInterval, v)
+			}
+			return nil
+		},
+	)
 )
 
 type nodeMetrics struct {
@@ -755,6 +782,31 @@ func (n *Node) computePeriodicMetrics(ctx context.Context, tick int) error {
 			log.Warningf(ctx, "%s: unable to compute metrics: %s", store, err)
 		}
 		return nil
+	})
+}
+
+func (n *Node) startGraphiteStatsExporter(st *cluster.Settings) {
+	ctx := log.WithLogTag(n.AnnotateCtx(context.Background()), "graphite stats exporter", nil)
+	pm := metric.MakePrometheusExporter()
+
+	n.stopper.RunWorker(ctx, func(ctx context.Context) {
+		var timer timeutil.Timer
+		defer timer.Stop()
+		for {
+			timer.Reset(graphiteInterval.Get(&st.SV))
+			select {
+			case <-n.stopper.ShouldStop():
+				return
+			case <-timer.C:
+				timer.Read = true
+				endpoint := graphiteEndpoint.Get(&st.SV)
+				if endpoint != "" {
+					if err := n.recorder.ExportToGraphite(ctx, endpoint, &pm); err != nil {
+						log.Infof(ctx, "error pushing metrics to graphite: %s\n", err)
+					}
+				}
+			}
+		}
 	})
 }
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1452,6 +1452,15 @@ If problems persist, please see ` + base.DocsURL("cluster-setup-troubleshooting.
 	// Begin recording status summaries.
 	s.node.startWriteNodeStatus(DefaultMetricsSampleInterval)
 
+	var graphiteOnce sync.Once
+	graphiteEndpoint.SetOnChange(&s.st.SV, func() {
+		if graphiteEndpoint.Get(&s.st.SV) != "" {
+			graphiteOnce.Do(func() {
+				s.node.startGraphiteStatsExporter(s.st)
+			})
+		}
+	})
+
 	// Create and start the schema change manager only after a NodeID
 	// has been assigned.
 	var testingKnobs *sql.SchemaChangerTestingKnobs

--- a/pkg/util/log/log.go
+++ b/pkg/util/log/log.go
@@ -81,6 +81,15 @@ func Info(ctx context.Context, args ...interface{}) {
 	logDepth(ctx, 1, Severity_INFO, "", args)
 }
 
+// InfoDepth logs to the INFO log, offsetting the caller's stack frame by
+// 'depth'.
+// It extracts log tags from the context and logs them along with the given
+// message. Arguments are handled in the manner of fmt.Print; a newline is
+// appended.
+func InfoDepth(ctx context.Context, depth int, args ...interface{}) {
+	logDepth(ctx, depth+1, Severity_INFO, "", args)
+}
+
 // InfofDepth logs to the INFO log, offsetting the caller's stack frame by
 // 'depth'.
 // It extracts log tags from the context and logs them along with the given

--- a/pkg/util/metric/graphite_exporter.go
+++ b/pkg/util/metric/graphite_exporter.go
@@ -1,0 +1,73 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package metric
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/pkg/errors"
+	"github.com/prometheus/client_golang/prometheus/graphite"
+)
+
+var errNoEndpoint = errors.New("external.graphite.endpoint is not set")
+
+// GraphiteExporter scrapes PrometheusExporter for metrics and pushes
+// them to a Graphite or Carbon server.
+type GraphiteExporter struct {
+	pm *PrometheusExporter
+}
+
+// MakeGraphiteExporter returns an initialized graphite exporter.
+func MakeGraphiteExporter(pm *PrometheusExporter) GraphiteExporter {
+	return GraphiteExporter{pm: pm}
+}
+
+type loggerFunc func(...interface{})
+
+// Println implements graphite.Logger.
+func (lf loggerFunc) Println(v ...interface{}) {
+	lf(v...)
+}
+
+// Push metrics scraped from registry to Graphite or Carbon server.
+// It converts the same metrics that are pulled by Prometheus into Graphite-format.
+func (ge *GraphiteExporter) Push(ctx context.Context, endpoint string) error {
+	if endpoint == "" {
+		return errNoEndpoint
+	}
+	h, err := os.Hostname()
+	if err != nil {
+		return err
+	}
+	// Make the bridge.
+	var b *graphite.Bridge
+	if b, err = graphite.NewBridge(&graphite.Config{
+		URL:           endpoint,
+		Gatherer:      ge.pm,
+		Prefix:        fmt.Sprintf("%s.cockroach", h),
+		Timeout:       10 * time.Second,
+		ErrorHandling: graphite.AbortOnError,
+		Logger: loggerFunc(func(args ...interface{}) {
+			log.InfoDepth(ctx, 1, args...)
+		}),
+	}); err != nil {
+		return err
+	}
+	return b.Push()
+}

--- a/pkg/util/metric/prometheus_exporter.go
+++ b/pkg/util/metric/prometheus_exporter.go
@@ -18,6 +18,7 @@ import (
 	"io"
 
 	"github.com/gogo/protobuf/proto"
+	"github.com/prometheus/client_golang/prometheus"
 	prometheusgo "github.com/prometheus/client_model/go"
 	"github.com/prometheus/common/expfmt"
 )
@@ -92,4 +93,18 @@ func (pm *PrometheusExporter) PrintAsText(w io.Writer) error {
 		family.Metric = []*prometheusgo.Metric{}
 	}
 	return nil
+}
+
+// Verify GraphiteExporter implements Gatherer interface.
+var _ prometheus.Gatherer = (*PrometheusExporter)(nil)
+
+// Gather implements prometheus.Gatherer
+func (pm *PrometheusExporter) Gather() ([]*prometheusgo.MetricFamily, error) {
+	v := make([]*prometheusgo.MetricFamily, len(pm.families))
+	i := 0
+	for _, family := range pm.families {
+		v[i] = family
+		i++
+	}
+	return v, nil
 }


### PR DESCRIPTION
See issue #25198 for more context on the motivation. For clusters which use the Graphite stack instead of Prometheus for monitoring, we need a way to export metrics. Prometheus has a library that performs the conversion.

To do / discuss:
- update dependencies in vendor directory
- how to feature toggle this on/off
- how to pass in config values (URL for graphite server, polling interval), e.g. cmd-line args
- there might be a couple of other questions I've asked in my code

This PR isn't polished as I want some feedback before choosing e.g. to use cmd-line args for config.