### PR TITLE
roachtest: Make --store configurable in roachtest

### DIFF
--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -47,6 +47,7 @@ var (
 	local       bool
 	artifacts   string
 	cockroach   string
+	store       string
 	workload    string
 	clusterName string
 	clusterID   string
@@ -606,6 +607,9 @@ func (c *cluster) Start(ctx context.Context, opts ...option) {
 	args := []string{
 		"roachprod",
 		"start",
+	}
+	if store != "" {
+		args = append(args, "-a", "--store="+store)
 	}
 	args = append(args, roachprodArgs(opts)...)
 	args = append(args, c.makeNodes(opts...))

--- a/pkg/cmd/roachtest/main.go
+++ b/pkg/cmd/roachtest/main.go
@@ -74,6 +74,8 @@ Use 'roachtest run -n' to see a list of all tests.
 		"wipe existing cluster before starting test (for use with --cluster)")
 	runCmd.Flags().StringVar(
 		&cockroach, "cockroach", "", "path to cockroach binary to use")
+	runCmd.Flags().StringVar(
+		&store, "store", "", "path to cockroach store")
 	runCmd.Flags().StringVarP(
 		&username, "user", "u", username, "username to run under, detect if blank")
 	runCmd.Flags().StringVar(


### PR DESCRIPTION
When roachtest is run on Bodega cluster, it encounters permission error when trying to
create dir for cockroach's store. By making --store configurable in roachtest, we can
set store dir to a writable directory and avoid permission issues.

Release note: None.