### PR TITLE
release-2.0: distsqlrun: fix panic with offsets and topk sort

### DIFF
--- a/pkg/sql/distsqlrun/sorter.go
+++ b/pkg/sql/distsqlrun/sorter.go
@@ -425,11 +425,11 @@ func (s *sortTopKProcessor) Next() (sqlbase.EncDatumRow, *ProducerMetadata) {
 		s.rows.Sort(ctx)
 	}
 
-	if s.closed || s.rows.Len() == 0 {
-		return nil, s.producerMeta(nil /* err */)
-	}
-
 	for {
+		if s.closed || s.rows.Len() == 0 {
+			return nil, s.producerMeta(nil /* err */)
+		}
+
 		row := s.rows.EncRow(0)
 		s.rows.PopFirst()
 

--- a/pkg/sql/logictest/testdata/logic_test/order_by
+++ b/pkg/sql/logictest/testdata/logic_test/order_by
@@ -838,3 +838,16 @@ limit           ·      ·               (block_id, writer_id, block_num, block_
 ·               table  blocks@primary  ·                                                     ·
 ·               spans  ALL             ·                                                     ·
 ·               limit  1               ·                                                     ·
+
+# Regression test for #25197: make sure that order by with an offset works in
+# the top-k sorter.
+
+statement ok
+CREATE TABLE t25197 (id BIGSERIAL PRIMARY KEY, d TEXT)
+
+statement ok
+INSERT INTO t25197 (d) VALUES ('test1')
+
+query TT
+SELECT * FROM t25197 ORDER BY d ASC OFFSET 1 LIMIT 10
+----


### PR DESCRIPTION
Fixes #25197.

Release note (bug fix): fix a panic in the top k sorter that occurred
with offsets.