### PR TITLE
build: ensure TeamCity captures scoped logs in test[race]

### DIFF
--- a/build/teamcity-test.sh
+++ b/build/teamcity-test.sh
@@ -6,6 +6,9 @@ source "$(dirname "${0}")/teamcity-support.sh"
 
 tc_prepare
 
+export TMPDIR=$PWD/artifacts/test
+mkdir -p "$TMPDIR"
+
 tc_start_block "Maybe stress pull request"
 run build/builder.sh go install ./pkg/cmd/github-pull-request-make
 run build/builder.sh env BUILD_VCS_NUMBER="$BUILD_VCS_NUMBER" TARGET=stress github-pull-request-make

--- a/build/teamcity-testrace.sh
+++ b/build/teamcity-testrace.sh
@@ -6,6 +6,9 @@ source "$(dirname "${0}")/teamcity-support.sh"
 
 tc_prepare
 
+export TMPDIR=$PWD/artifacts/testrace
+mkdir -p "$TMPDIR"
+
 tc_start_block "Maybe stressrace pull request"
 build/builder.sh go install ./pkg/cmd/github-pull-request-make
 build/builder.sh env BUILD_VCS_NUMBER="$BUILD_VCS_NUMBER" TARGET=stressrace github-pull-request-make


### PR DESCRIPTION
log.Scope puts logs in a temporary directory, but we want those logs to
be available in TeamCity. Set TMPDIR to "artifacts", which TeamCity is
configured to look in. (This is how the acceptance tests currently
work.)

Fix #20245.

Release note: None