### PR TITLE
storage: add unsplittable ranges to split queue purgatory

### DIFF
--- a/pkg/storage/consistency_queue.go
+++ b/pkg/storage/consistency_queue.go
@@ -133,6 +133,6 @@ func (q *consistencyQueue) timer(duration time.Duration) time.Duration {
 }
 
 // purgatoryChan returns nil.
-func (*consistencyQueue) purgatoryChan() <-chan struct{} {
+func (*consistencyQueue) purgatoryChan() <-chan time.Time {
 	return nil
 }

--- a/pkg/storage/gc_queue.go
+++ b/pkg/storage/gc_queue.go
@@ -906,6 +906,6 @@ func (*gcQueue) timer(_ time.Duration) time.Duration {
 }
 
 // purgatoryChan returns nil.
-func (*gcQueue) purgatoryChan() <-chan struct{} {
+func (*gcQueue) purgatoryChan() <-chan time.Time {
 	return nil
 }

--- a/pkg/storage/helpers_test.go
+++ b/pkg/storage/helpers_test.go
@@ -152,6 +152,12 @@ func (s *Store) ReplicateQueuePurgatoryLength() int {
 	return s.replicateQueue.PurgatoryLength()
 }
 
+// SplitQueuePurgatoryLength returns the number of replicas in split
+// queue purgatory.
+func (s *Store) SplitQueuePurgatoryLength() int {
+	return s.splitQueue.PurgatoryLength()
+}
+
 // SetRaftLogQueueActive enables or disables the raft log queue.
 func (s *Store) SetRaftLogQueueActive(active bool) {
 	s.setRaftLogQueueActive(active)

--- a/pkg/storage/metrics.go
+++ b/pkg/storage/metrics.go
@@ -400,6 +400,9 @@ var (
 	metaSplitQueueProcessingNanos = metric.Metadata{
 		Name: "queue.split.processingnanos",
 		Help: "Nanoseconds spent processing replicas in the split queue"}
+	metaSplitQueuePurgatory = metric.Metadata{
+		Name: "queue.split.purgatory",
+		Help: "Number of replicas in the split queue's purgatory, waiting to become splittable"}
 	metaTimeSeriesMaintenanceQueueSuccesses = metric.Metadata{
 		Name: "queue.tsmaintenance.process.success",
 		Help: "Number of replicas successfully processed by the time series maintenance queue"}
@@ -637,6 +640,7 @@ type StoreMetrics struct {
 	SplitQueueFailures                        *metric.Counter
 	SplitQueuePending                         *metric.Gauge
 	SplitQueueProcessingNanos                 *metric.Counter
+	SplitQueuePurgatory                       *metric.Gauge
 	TimeSeriesMaintenanceQueueSuccesses       *metric.Counter
 	TimeSeriesMaintenanceQueueFailures        *metric.Counter
 	TimeSeriesMaintenanceQueuePending         *metric.Gauge
@@ -824,6 +828,7 @@ func newStoreMetrics(histogramWindow time.Duration) *StoreMetrics {
 		SplitQueueFailures:                        metric.NewCounter(metaSplitQueueFailures),
 		SplitQueuePending:                         metric.NewGauge(metaSplitQueuePending),
 		SplitQueueProcessingNanos:                 metric.NewCounter(metaSplitQueueProcessingNanos),
+		SplitQueuePurgatory:                       metric.NewGauge(metaSplitQueuePurgatory),
 		TimeSeriesMaintenanceQueueSuccesses:       metric.NewCounter(metaTimeSeriesMaintenanceQueueFailures),
 		TimeSeriesMaintenanceQueueFailures:        metric.NewCounter(metaTimeSeriesMaintenanceQueueSuccesses),
 		TimeSeriesMaintenanceQueuePending:         metric.NewGauge(metaTimeSeriesMaintenanceQueuePending),

--- a/pkg/storage/queue.go
+++ b/pkg/storage/queue.go
@@ -177,11 +177,11 @@ type queueImpl interface {
 	// yet, this can be 0.
 	timer(time.Duration) time.Duration
 
-	// purgatoryChan returns a channel that is signaled when it's time
-	// to retry replicas which have been relegated to purgatory due to
-	// failures. If purgatoryChan returns nil, failing replicas are not
-	// sent to purgatory.
-	purgatoryChan() <-chan struct{}
+	// purgatoryChan returns a channel that is signaled with the current
+	// time when it's time to retry replicas which have been relegated to
+	// purgatory due to failures. If purgatoryChan returns nil, failing
+	// replicas are not sent to purgatory.
+	purgatoryChan() <-chan time.Time
 }
 
 type queueConfig struct {

--- a/pkg/storage/queue.go
+++ b/pkg/storage/queue.go
@@ -312,6 +312,11 @@ func (bq *baseQueue) Length() int {
 
 // PurgatoryLength returns the current size of purgatory.
 func (bq *baseQueue) PurgatoryLength() int {
+	// Lock processing while measuring the purgatory length. This ensures that
+	// no purgatory replicas are concurrently being processed, during which time
+	// they are removed from bq.mu.purgatory even though they may be re-added.
+	defer bq.lockProcessing()()
+
 	bq.mu.Lock()
 	defer bq.mu.Unlock()
 	return len(bq.mu.purgatory)

--- a/pkg/storage/raft_log_queue.go
+++ b/pkg/storage/raft_log_queue.go
@@ -279,7 +279,7 @@ func (*raftLogQueue) timer(_ time.Duration) time.Duration {
 }
 
 // purgatoryChan returns nil.
-func (*raftLogQueue) purgatoryChan() <-chan struct{} {
+func (*raftLogQueue) purgatoryChan() <-chan time.Time {
 	return nil
 }
 

--- a/pkg/storage/raft_snapshot_queue.go
+++ b/pkg/storage/raft_snapshot_queue.go
@@ -121,6 +121,6 @@ func (*raftSnapshotQueue) timer(_ time.Duration) time.Duration {
 	return raftSnapshotQueueTimerDuration
 }
 
-func (rq *raftSnapshotQueue) purgatoryChan() <-chan struct{} {
+func (rq *raftSnapshotQueue) purgatoryChan() <-chan time.Time {
 	return nil
 }

--- a/pkg/storage/replica_gc_queue.go
+++ b/pkg/storage/replica_gc_queue.go
@@ -254,6 +254,6 @@ func (*replicaGCQueue) timer(_ time.Duration) time.Duration {
 }
 
 // purgatoryChan returns nil.
-func (*replicaGCQueue) purgatoryChan() <-chan struct{} {
+func (*replicaGCQueue) purgatoryChan() <-chan time.Time {
 	return nil
 }

--- a/pkg/storage/split_queue.go
+++ b/pkg/storage/split_queue.go
@@ -165,6 +165,6 @@ func (*splitQueue) timer(_ time.Duration) time.Duration {
 }
 
 // purgatoryChan returns nil.
-func (*splitQueue) purgatoryChan() <-chan struct{} {
+func (*splitQueue) purgatoryChan() <-chan time.Time {
 	return nil
 }

--- a/pkg/storage/split_queue.go
+++ b/pkg/storage/split_queue.go
@@ -32,6 +32,13 @@ const (
 	// splitQueueTimerDuration is the duration between splits of queued ranges.
 	splitQueueTimerDuration = 0 // zero duration to process splits greedily.
 
+	// splitQueuePurgatoryCheckInterval is the interval at which replicas in
+	// purgatory make split attempts. Purgatory is used by the splitQueue to
+	// store ranges that are large enough to require a split but are
+	// unsplittable because they do not contain a suitable split key. Purgatory
+	// prevents them from repeatedly attempting to split at an unbounded rate.
+	splitQueuePurgatoryCheckInterval = 1 * time.Minute
+
 	// splits should be relatively isolated, other than requiring expensive
 	// RocksDB scans over part of the splitting range to recompute stats. We
 	// allow a limitted number of splits to be processed at once.
@@ -42,13 +49,23 @@ const (
 // or along intersecting zone config boundaries.
 type splitQueue struct {
 	*baseQueue
-	db *client.DB
+	db       *client.DB
+	purgChan <-chan time.Time
 }
 
 // newSplitQueue returns a new instance of splitQueue.
 func newSplitQueue(store *Store, db *client.DB, gossip *gossip.Gossip) *splitQueue {
+	var purgChan <-chan time.Time
+	if c := store.TestingKnobs().SplitQueuePurgatoryChan; c != nil {
+		purgChan = c
+	} else {
+		purgTicker := time.NewTicker(splitQueuePurgatoryCheckInterval)
+		purgChan = purgTicker.C
+	}
+
 	sq := &splitQueue{
-		db: db,
+		db:       db,
+		purgChan: purgChan,
 	}
 	sq.baseQueue = newBaseQueue(
 		"split", sq, store, gossip,
@@ -62,6 +79,7 @@ func newSplitQueue(store *Store, db *client.DB, gossip *gossip.Gossip) *splitQue
 			failures:             store.metrics.SplitQueueFailures,
 			pending:              store.metrics.SplitQueuePending,
 			processingNanos:      store.metrics.SplitQueueProcessingNanos,
+			purgatory:            store.metrics.SplitQueuePurgatory,
 		},
 	)
 	return sq
@@ -89,6 +107,15 @@ func (sq *splitQueue) shouldQueue(
 	return
 }
 
+// unsplittableRangeError indicates that a split attempt failed because a no
+// suitable split key could be found.
+type unsplittableRangeError struct{}
+
+func (unsplittableRangeError) Error() string         { return "could not find valid split key" }
+func (unsplittableRangeError) purgatoryErrorMarker() {}
+
+var _ purgatoryError = unsplittableRangeError{}
+
 // process synchronously invokes admin split for each proposed split key.
 func (sq *splitQueue) process(ctx context.Context, r *Replica, sysCfg config.SystemConfig) error {
 	err := sq.processAttempt(ctx, r, sysCfg)
@@ -113,7 +140,7 @@ func (sq *splitQueue) processAttempt(
 	// First handle case of splitting due to zone config maps.
 	desc := r.Desc()
 	if splitKey := sysCfg.ComputeSplitKey(desc.StartKey, desc.EndKey); splitKey != nil {
-		if _, _, pErr := r.adminSplitWithDescriptor(
+		if _, err := r.adminSplitWithDescriptor(
 			ctx,
 			roachpb.AdminSplitRequest{
 				Span: roachpb.Span{
@@ -122,8 +149,8 @@ func (sq *splitQueue) processAttempt(
 				SplitKey: splitKey.AsRawKey(),
 			},
 			desc,
-		); pErr != nil {
-			return errors.Wrapf(pErr.GoError(), "unable to split %s at key %q", r, splitKey)
+		); err != nil {
+			return errors.Wrapf(err, "unable to split %s at key %q", r, splitKey)
 		}
 		return nil
 	}
@@ -134,27 +161,12 @@ func (sq *splitQueue) processAttempt(
 	size := r.GetMVCCStats().Total()
 	maxBytes := r.GetMaxBytes()
 	if maxBytes > 0 && float64(size)/float64(maxBytes) > 1 {
-		if _, validSplitKey, pErr := r.adminSplitWithDescriptor(
+		_, err := r.adminSplitWithDescriptor(
 			ctx,
 			roachpb.AdminSplitRequest{},
 			desc,
-		); pErr != nil {
-			return pErr.GoError()
-		} else if !validSplitKey {
-			// If we couldn't find a split key, set the max-bytes for the range to
-			// double its current size to prevent future attempts to split the range
-			// until it grows again.
-			newMaxBytes := size * 2
-			r.SetMaxBytes(newMaxBytes)
-			log.VEventf(ctx, 2, "couldn't find valid split key, growing max bytes to %d", newMaxBytes)
-		} else {
-			// We successfully split the range, reset max-bytes to the zone setting.
-			zone, err := sysCfg.GetZoneConfigForKey(desc.StartKey)
-			if err != nil {
-				return err
-			}
-			r.SetMaxBytes(zone.RangeMaxBytes)
-		}
+		)
+		return err
 	}
 	return nil
 }
@@ -164,7 +176,7 @@ func (*splitQueue) timer(_ time.Duration) time.Duration {
 	return splitQueueTimerDuration
 }
 
-// purgatoryChan returns nil.
-func (*splitQueue) purgatoryChan() <-chan time.Time {
-	return nil
+// purgatoryChan returns the split queue's purgatory channel.
+func (sq *splitQueue) purgatoryChan() <-chan time.Time {
+	return sq.purgChan
 }

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -744,6 +744,9 @@ type StoreTestingKnobs struct {
 	// process ranges that need to be split, for use in tests that use
 	// the replication queue but disable the split queue.
 	ReplicateQueueAcceptsUnsplit bool
+	// SplitQueuePurgatoryChan allows a test to control the channel used to
+	// trigger split queue purgatory processing.
+	SplitQueuePurgatoryChan <-chan time.Time
 	// SkipMinSizeCheck, if set, makes the store creation process skip the check
 	// for a minimum size.
 	SkipMinSizeCheck bool

--- a/pkg/storage/ts_maintenance_queue.go
+++ b/pkg/storage/ts_maintenance_queue.go
@@ -154,6 +154,6 @@ func (q *timeSeriesMaintenanceQueue) timer(duration time.Duration) time.Duration
 	return replInterval - duration
 }
 
-func (*timeSeriesMaintenanceQueue) purgatoryChan() <-chan struct{} {
+func (*timeSeriesMaintenanceQueue) purgatoryChan() <-chan time.Time {
 	return nil
 }


### PR DESCRIPTION
Fixes #25191.

This makes the fix for #24215 trivial.

In #14654 we added a mechanism to double the max range size whenever a
split attempt found a range that was unsplittable. This prevented a
tight loop of split attempts. However, it didn't actually do anything to
help us find a split point to reduce the size of the range in the
future. This size doubling worked in practice, but it was a blunt
instrument that had strange effects (see #24215).

This change rips out this range size doubling and replaces it with a
split queue purgatory. This purgatory is used to house replicas that
are unsplittable, preventing them from getting into a tight loop.

Release note: None