### PR TITLE
cli: ignore flags when determining command name

### DIFF
--- a/pkg/cli/interactive_tests/test_flags.tcl
+++ b/pkg/cli/interactive_tests/test_flags.tcl
@@ -27,6 +27,21 @@ interrupt
 eexpect ":/# "
 end_test
 
+start_test {Check that the "failed running SUBCOMMAND" message does not consider a flag the subcommand}
+send "$argv --verbosity 2 start --garbage\r"
+eexpect {Failed running "start"}
+end_test
+
+start_test {Check that the "failed running SUBCOMMAND" message handles nested subcommands}
+send "$argv --verbosity 2 debug zip --garbage\r"
+eexpect {Failed running "debug zip"}
+end_test
+
+start_test {Check that the "failed running SUBCOMMAND" message handles missing subcommands}
+send "$argv --verbosity 2 --garbage\r"
+eexpect {Failed running "cockroach"}
+end_test
+
 send "exit 0\r"
 eexpect eof
 


### PR DESCRIPTION
Our CLI attempts to determine a command name early at boot (e.g, "start" or
"quit"), which it uses to initialize error reporting and to print a "Failed
running COMMAND" message if an error occurs.

The previous computation of the command name was flawed, as it blindly used
at the first command-line argument. In the case of a command like

   $ cockroach --verbosity 2 start

the command name would be incorrectly computed as "--verbosity".

Adjust the name computation to ask Cobra what it thinks so that flags and their
arguments are properly ignored.

Fix #23350.

Release note (cli change): Messages that refer to the invoked command (e.g.,
"Failed running start") are no longer confused by the presence of flags before
the first argument (e.g., "cockroach --no-color start").