### PR TITLE
sql: fix crash for 'begin; release savepoint'

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/txn
+++ b/pkg/sql/logictest/testdata/logic_test/txn
@@ -770,7 +770,7 @@ ROLLBACK
 statement ok
 BEGIN
 
-statement error SAVEPOINT COCKROACH_RESTART has not been used
+statement error pgcode 3B000 savepoint COCKROACH_RESTART has not been used
 ROLLBACK TO SAVEPOINT cockroach_restart
 
 statement ok
@@ -784,7 +784,7 @@ BEGIN
 statement error pq: relation "bogus_name" does not exist
 SELECT * from bogus_name
 
-statement error SAVEPOINT COCKROACH_RESTART has not been used
+statement error pgcode 3B000 savepoint COCKROACH_RESTART has not been used
 ROLLBACK TO SAVEPOINT cockroach_restart
 
 statement ok
@@ -978,6 +978,14 @@ BEGIN; SELECT 1
 
 query error pgcode 40001 restart transaction: HandledRetryableTxnError: forced by crdb_internal.force_retry()
 SELECT CRDB_INTERNAL.FORCE_RETRY('1s':::INTERVAL)
+
+statement ok
+ROLLBACK
+
+# Check that we don't crash when doing a release that wasn't preceded by a
+# savepoint.
+statement error pgcode 3B000 savepoint COCKROACH_RESTART has not been used
+BEGIN; RELEASE SAVEPOINT cockroach_restart
 
 statement ok
 ROLLBACK


### PR DESCRIPTION
Release is not accepted if savepoint hasn't been previously used. This
patch turns the crash into an error.
Also sticks a pg error code to similar errors.

Release note(bug fix): 'begin; release savepoint' no longer crashes, but
returns an error.

Fixes #24433