### PR TITLE
encryption: rename "switching env" format version to "file registry".

### DIFF
--- a/c-deps/libroach/ccl/db.cc
+++ b/c-deps/libroach/ccl/db.cc
@@ -37,9 +37,9 @@ rocksdb::Status DBOpenHook(const std::string& db_dir, const DBOptions db_opts,
     return rocksdb::Status::OK();
   }
 
-  // The Go code sets the "switching_env" storage version if we specified encryption flags,
+  // The Go code sets the "file_registry" storage version if we specified encryption flags,
   // but let's double check anyway.
-  if (!db_opts.use_switching_env) {
+  if (!db_opts.use_file_registry) {
     return rocksdb::Status::InvalidArgument(
         "on-disk version does not support encryption, but we found encryption flags");
   }

--- a/c-deps/libroach/ccl/db_test.cc
+++ b/c-deps/libroach/ccl/db_test.cc
@@ -13,20 +13,20 @@ using namespace cockroach;
 
 TEST(LibroachCCL, DBOpenHook) {
   DBOptions db_opts;
-  db_opts.use_switching_env = false;
+  db_opts.use_file_registry = false;
 
   // Try an empty extra_options.
   db_opts.extra_options = ToDBSlice("");
   EXPECT_OK(DBOpenHook("", db_opts, nullptr));
 
-  // Try without switching env enabled and bogus options. We should fail
-  // because encryption options without switching env is not allowed.
+  // Try without file registry enabled and bogus options. We should fail
+  // because encryption options without file registry is not allowed.
   db_opts.extra_options = ToDBSlice("blah");
   EXPECT_ERR(DBOpenHook("", db_opts, nullptr),
              "on-disk version does not support encryption, but we found encryption flags");
 
-  db_opts.use_switching_env = true;
-  // Try with switching env but bogus encryption flags.
+  db_opts.use_file_registry = true;
+  // Try with file registry but bogus encryption flags.
   db_opts.extra_options = ToDBSlice("blah");
   EXPECT_ERR(DBOpenHook("", db_opts, nullptr), "failed to parse extra options");
 }

--- a/c-deps/libroach/db.cc
+++ b/c-deps/libroach/db.cc
@@ -138,8 +138,8 @@ DBStatus DBOpen(DBEngine** db, DBSlice dir, DBOptions db_opts) {
   // Create the file registry. It uses the base_env to access the registry file.
   auto file_registry = std::unique_ptr<FileRegistry>(new FileRegistry(env_ctx->base_env, db_dir));
 
-  if (db_opts.use_switching_env) {
-    // We're using the switching env.
+  if (db_opts.use_file_registry) {
+    // We're using the file registry.
     auto status = file_registry->Load();
     if (!status.ok()) {
       return ToDBStatus(status);
@@ -148,7 +148,7 @@ DBStatus DBOpen(DBEngine** db, DBSlice dir, DBOptions db_opts) {
     // EnvManager takes ownership of the file registry.
     env_ctx->file_registry.swap(file_registry);
   } else {
-    // Switching env format not enabled: check whether we have a registry file (we shouldn't).
+    // File registry format not enabled: check whether we have a registry file (we shouldn't).
     // The file_registry is not passed to anyone, it is deleted when it goes out of scope.
     auto status = file_registry->CheckNoRegistryFile();
     if (!status.ok()) {

--- a/c-deps/libroach/include/libroach.h
+++ b/c-deps/libroach/include/libroach.h
@@ -68,7 +68,7 @@ typedef struct {
   bool logging_enabled;
   int num_cpu;
   int max_open_files;
-  bool use_switching_env;
+  bool use_file_registry;
   bool must_exist;
   bool read_only;
   DBSlice rocksdb_options;

--- a/pkg/base/store_spec.go
+++ b/pkg/base/store_spec.go
@@ -67,9 +67,9 @@ type StoreSpec struct {
 	SizePercent float64
 	InMemory    bool
 	Attributes  roachpb.Attributes
-	// UseSwitchingEnv is true if the "switching env" store version is desired.
+	// UseFileRegistry is true if the "file registry" store version is desired.
 	// This is set by CCL code when encryption-at-rest is in use.
-	UseSwitchingEnv bool
+	UseFileRegistry bool
 	// RocksDBOptions contains RocksDB specific options using a semicolon
 	// separated key-value syntax ("key1=value1; key2=value2").
 	RocksDBOptions string

--- a/pkg/ccl/baseccl/encryption_spec.go
+++ b/pkg/ccl/baseccl/encryption_spec.go
@@ -199,14 +199,13 @@ func PopulateStoreSpecWithEncryption(
 			}
 
 			// Found a matching path.
-			if storeSpecs.Specs[i].UseSwitchingEnv {
+			if storeSpecs.Specs[i].UseFileRegistry {
 				return fmt.Errorf("store with path %s already has an encryption setting",
 					storeSpecs.Specs[i].Path)
 			}
 
-			// TODO(mberhault): figure out how to pass encryption settings through to C++-CCL.
-			// Tell the store we absolutely need the switching env.
-			storeSpecs.Specs[i].UseSwitchingEnv = true
+			// Tell the store we absolutely need the file registry.
+			storeSpecs.Specs[i].UseFileRegistry = true
 			opts, err := es.toEncryptionOptions()
 			if err != nil {
 				return err

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -530,7 +530,7 @@ func (cfg *Config) CreateEngines(ctx context.Context) (Engines, error) {
 				MaxOpenFiles:            openFileLimitPerStore,
 				WarnLargeBatchThreshold: 500 * time.Millisecond,
 				Settings:                cfg.Settings,
-				UseSwitchingEnv:         spec.UseSwitchingEnv,
+				UseFileRegistry:         spec.UseFileRegistry,
 				RocksDBOptions:          spec.RocksDBOptions,
 				ExtraOptions:            spec.ExtraOptions,
 			}

--- a/pkg/storage/engine/rocksdb.go
+++ b/pkg/storage/engine/rocksdb.go
@@ -451,9 +451,9 @@ type RocksDBConfig struct {
 	WarnLargeBatchThreshold time.Duration
 	// Settings instance for cluster-wide knobs.
 	Settings *cluster.Settings
-	// UseSwitchingEnv is true if the switching env is needed (eg: encryption-at-rest).
-	// This may force the store version to versionSwitchingEnv if currently lower.
-	UseSwitchingEnv bool
+	// UseFileRegistry is true if the file registry is needed (eg: encryption-at-rest).
+	// This may force the store version to versionFileRegistry if currently lower.
+	UseFileRegistry bool
 	// RocksDBOptions contains RocksDB specific options using a semicolon
 	// separated key-value syntax ("key1=value1; key2=value2").
 	RocksDBOptions string
@@ -577,15 +577,15 @@ func (r *RocksDB) open() error {
 
 		newVersion = existingVersion
 		if newVersion == versionNoFile {
-			// We currently set the default store version one before the switching env
+			// We currently set the default store version one before the file registry
 			// to allow downgrades to older binaries as long as encryption is not in use.
-			// TODO(mberhault): once enough releases supporting versionSwitchingEnv have passed, we can upgrade
+			// TODO(mberhault): once enough releases supporting versionFileRegistry have passed, we can upgrade
 			// to it without worry.
 			newVersion = versionBeta20160331
 		}
 
-		// Using the switching environment forces the latest version. We can't downgrade!
-		if r.cfg.UseSwitchingEnv {
+		// Using the file registry forces the latest version. We can't downgrade!
+		if r.cfg.UseFileRegistry {
 			newVersion = versionCurrent
 		}
 	} else {
@@ -608,7 +608,7 @@ func (r *RocksDB) open() error {
 			logging_enabled:   C.bool(log.V(3)),
 			num_cpu:           C.int(rocksdbConcurrency),
 			max_open_files:    C.int(maxOpenFiles),
-			use_switching_env: C.bool(newVersion == versionCurrent),
+			use_file_registry: C.bool(newVersion == versionCurrent),
 			must_exist:        C.bool(r.cfg.MustExist),
 			read_only:         C.bool(r.cfg.ReadOnly),
 			rocksdb_options:   goToCSlice([]byte(r.cfg.RocksDBOptions)),

--- a/pkg/storage/engine/version.go
+++ b/pkg/storage/engine/version.go
@@ -27,14 +27,14 @@ type storageVersion int
 const (
 	versionNoFile storageVersion = iota
 	versionBeta20160331
-	versionSwitchingEnv
+	versionFileRegistry
 )
 
 const (
 	versionFilename     = "COCKROACHDB_VERSION"
 	versionFilenameTemp = "COCKROACHDB_VERSION_TEMP"
 	versionMinimum      = versionNoFile
-	versionCurrent      = versionSwitchingEnv
+	versionCurrent      = versionFileRegistry
 )
 
 // Version stores all the version information for all stores and is used as


### PR DESCRIPTION
Cleanup following #21580, the switching env went away.

This is a rename only, the only thing persisted was the format version iota, and that has not changed.
 
Release note: None