### PR TITLE
server: add MarshalJSON and UnmarshalJSON to UUID

### DIFF
--- a/pkg/util/uuid/uuid.go
+++ b/pkg/util/uuid/uuid.go
@@ -16,6 +16,7 @@ package uuid
 
 import (
 	"encoding/binary"
+	"encoding/json"
 	"fmt"
 
 	"github.com/cockroachdb/cockroach/pkg/util/uint128"
@@ -93,6 +94,22 @@ func (u UUID) MarshalTo(data []byte) (int, error) {
 // Unmarshal unmarshals data to u.
 func (u *UUID) Unmarshal(data []byte) error {
 	return u.UUID.UnmarshalBinary(data)
+}
+
+// MarshalJSON returns the JSON encoding of u.
+func (u UUID) MarshalJSON() ([]byte, error) {
+	return json.Marshal(u.String())
+}
+
+// UnmarshalJSON unmarshals the JSON encoded data into u.
+func (u *UUID) UnmarshalJSON(data []byte) error {
+	var uuidString string
+	if err := json.Unmarshal(data, &uuidString); err != nil {
+		return err
+	}
+	uuid, err := FromString(uuidString)
+	*u = uuid
+	return err
 }
 
 // MakeV4 delegates to "github.com/satori/go.uuid".NewV4 and wraps the result in


### PR DESCRIPTION
Fixes #23842

The gogoproto specification states that certain methods need to be
defined on a customtype:
https://github.com/gogo/protobuf/blob/1ef32a8b9fc3f8ec940126907cedb5998f6318e4/custom_types.md#custom-type-method-signatures

The lack of these JSON marshaling functions resulted in an error when
the kvTxnId was not null when requesting the active txn id through the
status endpoint.

Release note (bug fix): Fix a bug where the sessions endpoint on the
admin UI would return an error when there was an active transaction.