### PR TITLE
sql/ui: Create eventlog events for zone config changes

### DIFF
--- a/pkg/sql/event_log.go
+++ b/pkg/sql/event_log.go
@@ -86,6 +86,11 @@ const (
 
 	// EventLogSetClusterSetting is recorded when a cluster setting is changed.
 	EventLogSetClusterSetting EventLogType = "set_cluster_setting"
+
+	// EventLogSetZoneConfig is recorded when a zone config is changed.
+	EventLogSetZoneConfig EventLogType = "set_zone_config"
+	// EventLogRemoveZoneConfig is recorded when a zone config is removed.
+	EventLogRemoveZoneConfig EventLogType = "remove_zone_config"
 )
 
 // EventLogSetClusterSettingDetail is the json details for a settings change.

--- a/pkg/sql/logictest/testdata/logic_test/event_log
+++ b/pkg/sql/logictest/testdata/logic_test/event_log
@@ -330,6 +330,47 @@ ORDER BY "timestamp"
 0  1  {"SettingName":"kv.allocator.load_based_lease_rebalancing.enabled","Value":"false","User":"root"}
 0  1  {"SettingName":"kv.allocator.load_based_lease_rebalancing.enabled","Value":"DEFAULT","User":"root"}
 
+# Set and unset zone configs
+##################
+
+statement ok
+CREATE TABLE a (id INT PRIMARY KEY)
+
+statement ok
+ALTER TABLE a EXPERIMENTAL CONFIGURE ZONE 'range_max_bytes: 67108865'
+
+statement ok
+ALTER TABLE a EXPERIMENTAL CONFIGURE ZONE NULL
+
+statement ok
+ALTER RANGE liveness EXPERIMENTAL CONFIGURE ZONE 'range_min_bytes: 1048577'
+
+statement ok
+ALTER RANGE liveness EXPERIMENTAL CONFIGURE ZONE NULL
+
+# verify zone config changes are logged
+##################
+query IIT
+SELECT "targetID", "reportingID", "info"
+FROM system.eventlog
+WHERE "eventType" = 'set_zone_config'
+ORDER BY "timestamp"
+----
+57  1  {"Target":"test.a","Config":"range_max_bytes: 67108865","User":"root"}
+22  1  {"Target":".liveness","Config":"range_min_bytes: 1048577","User":"root"}
+
+query IIT
+SELECT "targetID", "reportingID", "info"
+FROM system.eventlog
+WHERE "eventType" = 'remove_zone_config'
+ORDER BY "timestamp"
+----
+57  1  {"Target":"test.a","User":"root"}
+22  1  {"Target":".liveness","User":"root"}
+
+statement ok
+DROP TABLE a
+
 # Sequences
 
 statement ok
@@ -346,9 +387,9 @@ SELECT "eventType", "targetID", "reportingID", info::JSONB->>'SequenceName'
   FROM system.eventlog
  WHERE "eventType" in ('create_sequence', 'alter_sequence', 'drop_sequence')
 ----
-create_sequence  57  1  test.public.s
-alter_sequence   57  1  test.public.s
-drop_sequence    57  1  test.public.s
+create_sequence  58  1  test.public.s
+alter_sequence   58  1  test.public.s
+drop_sequence    58  1  test.public.s
 
 # Views
 
@@ -363,5 +404,5 @@ SELECT "eventType", "targetID", "reportingID", info::JSONB->>'ViewName'
   FROM system.eventlog
  WHERE "eventType" in ('create_view', 'drop_view')
 ----
-drop_view    58  1  test.public.v
-create_view  58  1  test.public.v
+drop_view    59  1  test.public.v
+create_view  59  1  test.public.v

--- a/pkg/sql/set_zone_config.go
+++ b/pkg/sql/set_zone_config.go
@@ -157,7 +157,33 @@ func (n *setZoneConfigNode) startExec(params runParams) error {
 	hasNewSubzones := yamlConfig != nil && index != nil
 	n.run.numAffected, err = writeZoneConfig(params.ctx, params.p.txn,
 		targetID, table, zone, params.extendedEvalCtx.ExecCfg, hasNewSubzones)
-	return err
+	if err != nil {
+		return err
+	}
+
+	var eventLogType EventLogType
+	info := struct {
+		Target string
+		Config string `json:",omitempty"`
+		User   string
+	}{
+		Target: config.CLIZoneSpecifier(&n.zoneSpecifier),
+		User:   params.SessionData().User,
+	}
+	if yamlConfig == nil {
+		eventLogType = EventLogRemoveZoneConfig
+	} else {
+		eventLogType = EventLogSetZoneConfig
+		info.Config = *yamlConfig
+	}
+	return MakeEventLogger(params.extendedEvalCtx.ExecCfg).InsertEventRecord(
+		params.ctx,
+		params.p.txn,
+		eventLogType,
+		int32(targetID),
+		int32(params.extendedEvalCtx.NodeID),
+		info,
+	)
 }
 
 func (n *setZoneConfigNode) Next(runParams) (bool, error) { return false, nil }

--- a/pkg/ui/src/util/eventTypes.ts
+++ b/pkg/ui/src/util/eventTypes.ts
@@ -49,6 +49,10 @@ export const NODE_DECOMMISSIONED = "node_decommissioned";
 export const NODE_RECOMMISSIONED = "node_recommissioned";
 // Recorded when a cluster setting is changed.
 export const SET_CLUSTER_SETTING = "set_cluster_setting";
+// Recorded when a zone config is changed.
+export const SET_ZONE_CONFIG = "set_zone_config";
+// Recorded when a zone config is removed.
+export const REMOVE_ZONE_CONFIG = "remove_zone_config";
 
 // Node Event Types
 export const nodeEvents = [NODE_JOIN, NODE_RESTART, NODE_DECOMMISSIONED, NODE_RECOMMISSIONED];
@@ -58,7 +62,7 @@ export const tableEvents = [
   DROP_INDEX, CREATE_VIEW, DROP_VIEW, REVERSE_SCHEMA_CHANGE, FINISH_SCHEMA_CHANGE,
   FINISH_SCHEMA_CHANGE_ROLLBACK,
 ];
-export const settingsEvents = [SET_CLUSTER_SETTING];
+export const settingsEvents = [SET_CLUSTER_SETTING, SET_ZONE_CONFIG, REMOVE_ZONE_CONFIG];
 export const allEvents = [...nodeEvents, ...databaseEvents, ...tableEvents, ...settingsEvents];
 
 const nodeEventSet = _.invert(nodeEvents);

--- a/pkg/ui/src/util/events.ts
+++ b/pkg/ui/src/util/events.ts
@@ -59,6 +59,10 @@ export function getEventDescription(e: Event$Properties): string {
         return `Cluster Setting Changed: User ${info.User} set ${info.SettingName} to ${info.Value}`;
       }
       return `Cluster Setting Changed: User ${info.User} changed ${info.SettingName}`;
+    case eventTypes.SET_ZONE_CONFIG:
+    return `Zone Config Changed: User ${info.User} set the zone config for ${info.Target} to ${info.Config}`;
+    case eventTypes.REMOVE_ZONE_CONFIG:
+      return `Zone Config Removed: User ${info.User} removed the zone config for ${info.Target}`;
     default:
       return `Unknown Event Type: ${e.event_type}, content: ${JSON.stringify(info, null, 2)}`;
   }
@@ -76,6 +80,8 @@ export interface EventInfo {
   SequenceName?: string;
   SettingName?: string;
   Value?: string;
+  Target?: string;
+  Config?: string;
   // The following are three names for the same key (it was renamed twice).
   // All ar included for backwards compatibility.
   DroppedTables?: string[];


### PR DESCRIPTION
Fixes #23444

Release note (cli change): Changing or removing a replication zone
config now causes events to be written to the system event log.

-------------------------

The best way to print the names of the modified zones isn't totally clear to me.

1. `config.CLIZoneSpecifier(&n.zoneSpecifier)` (as I've included here) gives statements in the UI Like `Zone Config Changed: User root set the zone config for foo.bar to num_replicas: 7` or `Zone Config Changed: User root set the zone config for demo.users.w to constraints: {"+region=us-west1": 2}`
2. `&n.zoneSpecifier.String()` is a no-go because it doesn't qualify names at all, so you get, e.g. `bar` instead of `foo.bar`
3. `tree.AsStringWithFlags(&n.zoneSpecifier, tree.FmtAlwaysQualifyTableNames)` gives statements like `Zone Config Changed: User root set the zone config for TABLE foo.public.bar to num_replicas: 7` or `Zone Config Changed: User root set the zone config for PARTITION w OF INDEX users@primary to constraints: {"+region=us-west1": 2}`. I don't love the caps-lock or the inclusion of the `public` schema, but this would also be perfectly reasonable.

Option 1 matches the CLI syntax for setting zones. Option 3 matches the SQL syntax. What do you think, @benesch?