### PR TITLE
release-2.0: sql: fix crash for 'begin; release savepoint'

### DIFF
--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -32,6 +32,10 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/uint128"
 )
 
+var errSavepointNotUsed = pgerror.NewErrorf(
+	pgerror.CodeSavepointExceptionError,
+	"savepoint %s has not been used", tree.RestartSavepointName)
+
 // execStmt executes one statement by dispatching according to the current
 // state. Returns an Event to be passed to the state machine, or nil if no
 // transition is needed. If nil is returned, then the cursor is supposed to
@@ -191,6 +195,10 @@ func (ex *connExecutor) execStmtInOpenState(
 		if err := tree.ValidateRestartCheckpoint(s.Savepoint); err != nil {
 			return makeErrEvent(err)
 		}
+		if !ex.machine.CurState().(stateOpen).RetryIntent.Get() {
+			return makeErrEvent(errSavepointNotUsed)
+		}
+
 		// ReleaseSavepoint is executed fully here; there's no plan for it.
 		ev, payload := ex.commitSQLTransaction(ctx, stmt.AST)
 		res.ResetStmtType((*tree.CommitTransaction)(nil))
@@ -222,8 +230,7 @@ func (ex *connExecutor) execStmtInOpenState(
 			return makeErrEvent(err)
 		}
 		if !os.RetryIntent.Get() {
-			err := fmt.Errorf("SAVEPOINT %s has not been used", tree.RestartSavepointName)
-			return makeErrEvent(err)
+			return makeErrEvent(errSavepointNotUsed)
 		}
 
 		res.ResetStmtType((*tree.Savepoint)(nil))
@@ -784,10 +791,9 @@ func (ex *connExecutor) execStmtInAbortedState(
 		}
 
 		if !(inRestartWait || ex.machine.CurState().(stateAborted).RetryIntent.Get()) {
-			err := fmt.Errorf("SAVEPOINT %s has not been used", tree.RestartSavepointName)
 			ev := eventNonRetriableErr{IsCommit: fsm.False}
 			payload := eventNonRetriableErrPayload{
-				err: err,
+				err: errSavepointNotUsed,
 			}
 			return ev, payload
 		}

--- a/pkg/sql/logictest/testdata/logic_test/txn
+++ b/pkg/sql/logictest/testdata/logic_test/txn
@@ -770,7 +770,7 @@ ROLLBACK
 statement ok
 BEGIN
 
-statement error SAVEPOINT COCKROACH_RESTART has not been used
+statement error pgcode 3B000 savepoint COCKROACH_RESTART has not been used
 ROLLBACK TO SAVEPOINT cockroach_restart
 
 statement ok
@@ -784,7 +784,7 @@ BEGIN
 statement error pq: relation "bogus_name" does not exist
 SELECT * from bogus_name
 
-statement error SAVEPOINT COCKROACH_RESTART has not been used
+statement error pgcode 3B000 savepoint COCKROACH_RESTART has not been used
 ROLLBACK TO SAVEPOINT cockroach_restart
 
 statement ok
@@ -978,6 +978,14 @@ BEGIN; SELECT 1
 
 query error pgcode 40001 restart transaction: HandledRetryableTxnError: forced by crdb_internal.force_retry()
 SELECT CRDB_INTERNAL.FORCE_RETRY('1s':::INTERVAL)
+
+statement ok
+ROLLBACK
+
+# Check that we don't crash when doing a release that wasn't preceded by a
+# savepoint.
+statement error pgcode 3B000 savepoint COCKROACH_RESTART has not been used
+BEGIN; RELEASE SAVEPOINT cockroach_restart
 
 statement ok
 ROLLBACK


### PR DESCRIPTION
Cherry-pick of #25247

Release is not accepted if savepoint hasn't been previously used. This
patch turns the crash into an error.
Also sticks a pg error code to similar errors.

Release note(bug fix): 'begin; release savepoint' no longer crashes, but
returns an error.

Fixes #24433

cc @cockroachdb/release 