### PR TITLE
sql/logictest: Turn off the consistency checker during logic tests

### DIFF
--- a/pkg/sql/logictest/logic.go
+++ b/pkg/sql/logictest/logic.go
@@ -904,6 +904,13 @@ func (t *logicTest) setup(cfg testClusterConfig) {
 		t.cluster.Server(t.nodeIdx).SetDistSQLSpanResolver(fakeResolver)
 	}
 
+	// Turn off the consistency checker as it is a little spammy and won't impact these tests.
+	if _, err := t.cluster.ServerConn(0).Exec(
+		"SET CLUSTER SETTING server.consistency_check.interval = '0ms'",
+	); err != nil {
+		t.Fatal(err)
+	}
+
 	if cfg.overrideDistSQLMode != "" {
 		if _, err := t.cluster.ServerConn(0).Exec(
 			"SET CLUSTER SETTING sql.defaults.distsql = $1::string", cfg.overrideDistSQLMode,

--- a/pkg/sql/logictest/testdata/logic_test/event_log
+++ b/pkg/sql/logictest/testdata/logic_test/event_log
@@ -327,6 +327,7 @@ ORDER BY "timestamp"
 0  1  {"SettingName":"diagnostics.reporting.enabled","Value":"true","User":"node"}
 0  1  {"SettingName":"trace.debug.enable","Value":"false","User":"node"}
 0  1  {"SettingName":"cluster.secret","Value":"gen_random_uuid()::STRING","User":"node"}
+0  1  {"SettingName":"server.consistency_check.interval","Value":"0s","User":"root"}
 0  1  {"SettingName":"kv.allocator.load_based_lease_rebalancing.enabled","Value":"false","User":"root"}
 0  1  {"SettingName":"kv.allocator.load_based_lease_rebalancing.enabled","Value":"DEFAULT","User":"root"}
 

--- a/pkg/sql/logictest/testdata/logic_test/system
+++ b/pkg/sql/logictest/testdata/logic_test/system
@@ -458,6 +458,7 @@ ORDER BY name
 ----
 cluster.secret
 diagnostics.reporting.enabled
+server.consistency_check.interval
 trace.debug.enable
 version
 
@@ -470,9 +471,10 @@ FROM system.settings
 WHERE name NOT IN ('version', 'sql.defaults.distsql', 'cluster.secret')
 ORDER BY name
 ----
-diagnostics.reporting.enabled  true
-somesetting                    somevalue
-trace.debug.enable             false
+diagnostics.reporting.enabled     true
+server.consistency_check.interval 0s
+somesetting                       somevalue
+trace.debug.enable                false
 
 user testuser
 

--- a/pkg/storage/consistency_queue.go
+++ b/pkg/storage/consistency_queue.go
@@ -105,7 +105,7 @@ func (q *consistencyQueue) process(
 	req := roachpb.CheckConsistencyRequest{}
 	if _, pErr := repl.CheckConsistency(ctx, req); pErr != nil {
 		_, shouldQuiesce := <-repl.store.Stopper().ShouldQuiesce()
-		if !shouldQuiesce || !grpcutil.IsClosedConnection(pErr.GoError()) {
+		if !shouldQuiesce && !grpcutil.IsClosedConnection(pErr.GoError()) {
 			// Suppress noisy errors about closed GRPC connections when the
 			// server is quiescing.
 			log.Error(ctx, pErr.GoError())


### PR DESCRIPTION
Quite often, a version of the following error message will appear in logic test
output.

`E180502 20:08:23.403784 2381 storage/consistency_queue.go:111  [replica consistency checker,n1,s1,r1/1:/M{in-ax}] computing own checksum: rpc error: code = Unavailable desc = transport is closing`

This turns off the consistency checker, which should not be run for these tests
in the first place.

Release note: None