### PR TITLE
Makefile: unbreak the macOS release build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -479,7 +479,7 @@ CONFIGURE_FLAGS += --host=$(XHOST_TRIPLE) CC=$(CC_PATH) CXX=$(CXX_PATH)
 # Use XCMAKE_FLAGS when invoking CMake on libraries/binaries for the target
 # platform (i.e., the cross-compiled platform, if specified); use plain
 # CMAKE_FLAGS when invoking CMake on libraries/binaries for the host platform.
-XCMAKE_FLAGS += -DCMAKE_C_COMPILER=$(CC_PATH) -DCMAKE_CXX_COMPILER=$(CXX_PATH) -DCMAKE_SYSTEM_NAME=$(CMAKE_SYSTEM_NAME)
+XCMAKE_FLAGS += -DCMAKE_C_COMPILER=$(CC_PATH) -DCMAKE_CXX_COMPILER=$(CXX_PATH) -DCMAKE_SYSTEM_NAME=$(CMAKE_SYSTEM_NAME) -DCMAKE_INSTALL_NAME_TOOL=$(XHOST_TRIPLE)-install_name_tool
 
 TARGET_TRIPLE := $(XHOST_TRIPLE)
 else


### PR DESCRIPTION
RocksDB v5.12 (which we upgraded to in c9ceee596) enables CMake's support for
assembly language. This causes CMake to go looking for a binary called
"install_name_tool", which exists when compiling natively on macOS, but does
not exist when cross-compiling from Linux. In our builder, the binary is called
"x86_64-apple-darwin13-install_name_tool"; pipe that through to CMake to
unbreak the build.

Release note: None