### PR TITLE
Makefile: remove gotestdashi target

### DIFF
--- a/build/teamcity-test.sh
+++ b/build/teamcity-test.sh
@@ -11,9 +11,9 @@ run build/builder.sh go install ./pkg/cmd/github-pull-request-make
 run build/builder.sh env BUILD_VCS_NUMBER="$BUILD_VCS_NUMBER" TARGET=stress github-pull-request-make
 tc_end_block "Maybe stress pull request"
 
-tc_start_block "Compile"
-run build/builder.sh make -Otarget gotestdashi
-tc_end_block "Compile"
+tc_start_block "Compile C dependencies"
+run build/builder.sh make -Otarget c-deps
+tc_end_block "Compile C dependencies"
 
 tc_start_block "Run Go tests"
 run build/builder.sh env TZ=America/New_York make test TESTFLAGS='-v' 2>&1 \

--- a/build/variables.mk
+++ b/build/variables.mk
@@ -153,6 +153,8 @@ define VALID_VARS
   bindir
   bins
   cyan
+  go-targets
+  go-targets-ccl
   go-version-check
   langgen-package
   optgen-defs


### PR DESCRIPTION
The gotestdashi target no longer serves any purpose, since Go 1.10 no
longer requires 'go test -i' to be run before any 'go test' invocation
for sane caching behavior. Removing it requires some refactoring of the
Makefile to avoid duplicating the list of test targets everywhere.

Fix #23770.

Release note: None