### PR TITLE
opt: error out on unsupported DISTINCT or FILTER aggregate

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/aggregate
+++ b/pkg/sql/opt/exec/execbuilder/testdata/aggregate
@@ -576,17 +576,19 @@ SELECT COUNT((k, v)) FROM kv
 column6:int
 6
 
-exec
-SELECT COUNT(DISTINCT (k, v)) FROM kv
-----
-column6:int
-6
 
-exec
-SELECT COUNT(DISTINCT (k, (v))) FROM kv
-----
-column6:int
-6
+# TODO(radu): DISTINCT not supported yet.
+#exec
+#SELECT COUNT(DISTINCT (k, v)) FROM kv
+#----
+#column6:int
+#6
+
+#exec
+#SELECT COUNT(DISTINCT (k, (v))) FROM kv
+#----
+#column6:int
+#6
 
 exec
 SELECT COUNT((k, v)) FROM kv LIMIT 1

--- a/pkg/sql/opt/optbuilder/groupby.go
+++ b/pkg/sql/opt/optbuilder/groupby.go
@@ -330,6 +330,18 @@ func (b *Builder) buildAggregateFunction(
 			pgerror.UnimplementedWithIssueError(10495, "aggregate functions with multiple arguments are not supported yet"),
 		})
 	}
+	if f.Type == tree.DistinctFuncType {
+		panic(builderError{pgerror.Unimplemented(
+			"aggregate with DISTINCT",
+			"aggregates with DISTINCT are not supported yet",
+		)})
+	}
+	if f.Filter != nil {
+		panic(builderError{pgerror.Unimplemented(
+			"aggregate with FILTER",
+			"aggregates with FILTER are not supported yet",
+		)})
+	}
 
 	aggInScope, aggOutScope := inScope.startAggFunc()
 

--- a/pkg/sql/opt/optbuilder/testdata/aggregate
+++ b/pkg/sql/opt/optbuilder/testdata/aggregate
@@ -2688,3 +2688,13 @@ project
  │              └── variable: abc.d [type=decimal]
  └── projections
       └── variable: column9 [type=decimal]
+
+build
+SELECT SUM(DISTINCT abc.d) FROM abc
+----
+error: aggregates with DISTINCT are not supported yet
+
+build
+SELECT SUM(abc.d) FILTER (WHERE abc.d > 0) FROM abc
+----
+error: aggregates with FILTER are not supported yet


### PR DESCRIPTION
We currently silently ignore DISTINCT or FILTER for aggregates;
return an error instead.

Release note: None