### PR TITLE
sql: don't truncate interleave parents w/o cascade

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/interleaved
+++ b/pkg/sql/logictest/testdata/logic_test/interleaved
@@ -168,8 +168,11 @@ SELECT * FROM p1_0
 2  2  2.01  2
 7  5  7.01  7.0
 
-statement ok
+statement error "p2" is interleaved by table "p1_0"
 TRUNCATE TABLE p2
+
+statement ok
+TRUNCATE TABLE p2 CASCADE
 
 statement error unimplemented
 DROP TABLE p2
@@ -312,7 +315,7 @@ EXPLAIN SELECT * FROM orders WHERE customer = 1 AND id = 1000
 ----
 scan  ·      ·
 ·     table  orders@primary
-·     spans  /1/#/66/1/1000-/1/#/66/1/1000/#
+·     spans  /1/#/68/1/1000-/1/#/68/1/1000/#
 
 # Check that interleaving can occur across databases
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/truncate
+++ b/pkg/sql/logictest/testdata/logic_test/truncate
@@ -65,3 +65,70 @@ INSERT INTO selfref VALUES (1, NULL);
 
 statement ok
 DROP TABLE selfref
+
+subtest truncate_interleave
+
+statement ok
+CREATE TABLE a (a INT PRIMARY KEY)
+
+statement ok
+CREATE TABLE b (a INT, b INT, PRIMARY KEY (a, b), UNIQUE INDEX(b)) INTERLEAVE IN PARENT a(a)
+
+statement error "a" is interleaved by table "b"
+TRUNCATE a
+
+statement ok
+TRUNCATE a CASCADE
+
+statement ok
+TRUNCATE b
+
+statement ok
+TRUNCATE b CASCADE
+
+statement ok
+CREATE TABLE c (c INT PRIMARY KEY, d INT REFERENCES b(b))
+
+statement error "b" is referenced by foreign key from table "c"
+TRUNCATE a, b
+
+statement ok
+INSERT INTO b VALUES(1, 2)
+
+statement ok
+INSERT INTO c VALUES(1, 2)
+
+statement ok
+TRUNCATE a CASCADE
+
+query II
+SELECT * FROM c
+----
+
+statement ok
+CREATE TABLE d (c INT PRIMARY KEY) INTERLEAVE IN PARENT c(c);
+
+statement ok
+TRUNCATE a, b, c, d
+
+statement error "c" is interleaved by table "d"
+TRUNCATE a, b, c
+
+statement error "c" is interleaved by table "d"
+TRUNCATE a, b, c
+
+statement ok
+INSERT INTO b VALUES(1, 2)
+
+statement ok
+INSERT INTO c VALUES(1, 2)
+
+statement ok
+INSERT INTO d VALUES (1)
+
+statement ok
+TRUNCATE a CASCADE
+
+query I
+SELECT * FROM d
+----


### PR DESCRIPTION
Previously, running `TRUNCATE` on the parent of two interleaved tables
would silently truncate the child interleaved table as well. This is
dangerous and likely unexpected, and could lead to some nasty surprises
to users.

Now, the `CASCADE` option must be specified to `TRUNCATE` a table that
has interleaved children. If it is, both tables will be truncated. If it
isn't, an error will be returned indicating the interleaved chid.

Note that this also ties into foreign keys - there can be a long chain
of foreign key and interleave children, all of which will prevent the
`TRUNCATE` from going through without `CASCADE`, no matter how deep the
chain.

Fixes #19584.

Release note (sql change): running `TRUNCATE` without `CASCADE` on a
table that has interleaved table children will return an error instead
of proceeding to delete both tables.