### PR TITLE
build: unbreak testrace build by avoiding gotestdashi

### DIFF
--- a/build/teamcity-testrace.sh
+++ b/build/teamcity-testrace.sh
@@ -25,9 +25,9 @@ else
 fi
 tc_end_block "Determine changed packages"
 
-tc_start_block "Compile"
-run build/builder.sh make -Otarget gotestdashi GOFLAGS=-race
-tc_end_block "Compile"
+tc_start_block "Compile C dependencies"
+run build/builder.sh make -Otarget c-deps GOFLAGS=-race
+tc_end_block "Compile C dependencies"
 
 tc_start_block "Run Go tests under race detector"
 run build/builder.sh env \


### PR DESCRIPTION
`make gotestdashi` was removed in 0e9f62108, but unfortunately it is
still used by teamcity-testrace.sh. Adjust teamcity-testrace.sh to use
`make c-deps` instead. (This fix was applied to teamcity-test.sh in the
original commit, but since that commit didn't actually modify any Go
packages it did not trigger the broken codepath in
teamcity-testrace.sh.)

Release note: None