### PR TITLE
sql: permit tuple-typed placeholders

### DIFF
--- a/pkg/sql/coltypes/conv.go
+++ b/pkg/sql/coltypes/conv.go
@@ -118,6 +118,16 @@ func DatumTypeToColumnType(t types.T) (T, error) {
 			return nil, err
 		}
 		return ArrayOf(elemTyp, nil)
+	case types.TTuple:
+		colTyp := make(TTuple, len(typ))
+		for i := range typ {
+			elemTyp, err := DatumTypeToColumnType(typ[i])
+			if err != nil {
+				return nil, err
+			}
+			colTyp[i] = elemTyp
+		}
+		return colTyp, nil
 	case types.TOidWrapper:
 		return DatumTypeToColumnType(typ.T)
 	}
@@ -175,6 +185,12 @@ func CastTargetToDatumType(t CastTargetType) types.T {
 		default:
 			panic(fmt.Sprintf("unexpected CastTarget %T[%T]", t, ct.ParamType))
 		}
+	case TTuple:
+		ret := make(types.TTuple, len(ct))
+		for i := range ct {
+			ret[i] = CastTargetToDatumType(ct[i])
+		}
+		return ret
 	case *TOid:
 		return TOidToType(ct)
 	default:

--- a/pkg/sql/coltypes/interface.go
+++ b/pkg/sql/coltypes/interface.go
@@ -66,6 +66,7 @@ func (*TBytes) columnType()          {}
 func (*TCollatedString) columnType() {}
 func (*TArray) columnType()          {}
 func (*TVector) columnType()         {}
+func (TTuple) columnType()           {}
 func (*TOid) columnType()            {}
 
 // All Ts also implement CastTargetType.
@@ -88,6 +89,7 @@ func (*TBytes) castTargetType()          {}
 func (*TCollatedString) castTargetType() {}
 func (*TArray) castTargetType()          {}
 func (*TVector) castTargetType()         {}
+func (TTuple) castTargetType()           {}
 func (*TOid) castTargetType()            {}
 
 func (node *TBool) String() string           { return ColTypeAsString(node) }
@@ -109,4 +111,5 @@ func (node *TBytes) String() string          { return ColTypeAsString(node) }
 func (node *TCollatedString) String() string { return ColTypeAsString(node) }
 func (node *TArray) String() string          { return ColTypeAsString(node) }
 func (node *TVector) String() string         { return ColTypeAsString(node) }
+func (node TTuple) String() string           { return ColTypeAsString(node) }
 func (node *TOid) String() string            { return ColTypeAsString(node) }

--- a/pkg/sql/coltypes/tuples.go
+++ b/pkg/sql/coltypes/tuples.go
@@ -12,13 +12,26 @@
 // implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
-package sql
+package coltypes
 
 import (
-	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"bytes"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/lex"
 )
 
-// SetTransaction sets a transaction's isolation level, priority and ro/rw state
-func (p *planner) SetTransaction(n *tree.SetTransaction) (planNode, error) {
-	return newZeroNode(nil /* columns */), p.extendedEvalCtx.TxnModesSetter.setTransactionModes(n.Modes)
+// TTuple represents tuple column types. Tuples aren't writable to disk, but
+// all types still need ColType representations.
+type TTuple []T
+
+// Format implements the ColTypeFormatter interface.
+func (node TTuple) Format(buf *bytes.Buffer, flags lex.EncodeFlags) {
+	buf.WriteString("(")
+	for i := range node {
+		if i != 0 {
+			buf.WriteString(", ")
+		}
+		node[i].Format(buf, flags)
+	}
+	buf.WriteString(")")
 }

--- a/pkg/sql/logictest/testdata/logic_test/create_as
+++ b/pkg/sql/logictest/testdata/logic_test/create_as
@@ -83,7 +83,7 @@ CREATE TABLE foo (x, y, z) AS SELECT catalog_name, schema_name, sql_path FROM in
 statement error pq: relation "foo" already exists
 CREATE TABLE foo (x, y, z) AS SELECT catalog_name, schema_name, sql_path FROM information_schema.schemata
 
-statement error pq: value type tuple{} cannot be used for table columns
+statement error pq: unsupported result type: tuple{}
 CREATE TABLE foo2 (x) AS (VALUES(ROW()))
 
 statement error pq: value type setof tuple{int} cannot be used for table columns

--- a/pkg/sql/logictest/testdata/logic_test/tuple
+++ b/pkg/sql/logictest/testdata/logic_test/tuple
@@ -664,3 +664,24 @@ render     ·         ·                      (a, b, c)                         
 ·          table     abc@abc_a_b_c_idx      ·                                 ·
 ·          spans     /1-                    ·                                 ·
 ·          filter    (a, b, c) > (1, 2, 3)  ·                                 ·
+
+subtest tuple_placeholders
+
+statement ok
+PREPARE x AS SELECT $1 = (1,2)
+
+statement ok
+PREPARE y AS SELECT (1,2) = $1
+
+query B
+EXECUTE x((1,2))
+----
+true
+
+query B
+EXECUTE y((1,2))
+----
+true
+
+query error expected EXECUTE parameter expression to have type tuple\{int, int\}, but '\(1, 2, 3\)' has type tuple\{int, int, int\}
+EXECUTE x((1,2,3))

--- a/pkg/sql/sem/types/types.go
+++ b/pkg/sql/sem/types/types.go
@@ -345,7 +345,16 @@ func (t TTuple) Equivalent(other T) bool {
 		return true
 	}
 	u, ok := UnwrapType(other).(TTuple)
-	if !ok || len(t) != len(u) {
+	if !ok {
+		return false
+	}
+	if len(t) == 0 || len(u) == 0 {
+		// Tuples that aren't fully specified (have a nil subtype list) are always
+		// equivalent to other tuples, to allow overloads to specify that they take
+		// an arbitrary tuple type.
+		return true
+	}
+	if len(t) != len(u) {
 		return false
 	}
 	for i, typ := range t {
@@ -375,7 +384,7 @@ func (t TTuple) IsAmbiguous() bool {
 			return true
 		}
 	}
-	return false
+	return len(t) == 0
 }
 
 // TPlaceholder is the type of a placeholder.
@@ -389,6 +398,9 @@ func (t TPlaceholder) String() string { return fmt.Sprintf("placeholder{%s}", t.
 // Equivalent implements the T interface.
 func (t TPlaceholder) Equivalent(other T) bool {
 	if other == Any {
+		return true
+	}
+	if other.IsAmbiguous() {
 		return true
 	}
 	u, ok := UnwrapType(other).(TPlaceholder)


### PR DESCRIPTION
Previously, using a placeholder in a tuple context would cause a panic
in the server.

Now, they're correctly typed.

Fixes #25254.

Release note (bug fix): prevent crash with queries that use placeholders
for tuple types.