### PR TITLE
cherrypick-2.0: cli: `debug zip` with timeout, added dump for crdb_internal.gossip_*

### DIFF
--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -2093,6 +2093,8 @@ writing ` + os.DevNull + `
   debug/events
   debug/liveness
   debug/settings
+  debug/gossip/liveness
+  debug/gossip/nodes
   debug/nodes/1/status
   debug/nodes/1/gossip
   debug/nodes/1/stacks

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -303,6 +303,7 @@ func init() {
 	timeoutCmds := []*cobra.Command{
 		statusNodeCmd,
 		lsNodesCmd,
+		debugZipCmd,
 		// If you add something here, make sure the actual implementation
 		// of the command uses `cmdTimeoutContext(.)` or it will ignore
 		// the timeout.


### PR DESCRIPTION
Now made command `debug zip` continue past errors with a timeout
(based on peter's timeout commit).

Also dumped information in crdb_internal.gossip_nodes and gossip_liveness
to the output file.

Fixes #23954.
cc @cockroachdb/release 
Release note: None