### PR TITLE
remove time selector when onboarding

### DIFF
--- a/pkg/ui/ccl/src/views/clusterviz/containers/map/index.tsx
+++ b/pkg/ui/ccl/src/views/clusterviz/containers/map/index.tsx
@@ -74,8 +74,8 @@ class ClusterVisualization extends React.Component<ClusterVisualizationProps & R
               onChange={this.handleMapTableToggle}
             />
           </div>
-          <div style={{ float: "right" }}><TimeScaleDropdown /></div>
-          <div style={{ textAlign: "center", paddingTop: 4 }}><Breadcrumbs tiers={tiers} /></div>
+          <div style={{ float: "right", display: showingLicensePage ? "none" : null }}><TimeScaleDropdown /></div>
+          <div style={{ textAlign: "center", paddingTop: 4, display: showingLicensePage ? "none" : null }}><Breadcrumbs tiers={tiers} /></div>
         </div>
         <Loading
           loading={!this.props.licenseDataExists}


### PR DESCRIPTION
Release note: None

Removes time selector and tier label when user is onboarding, since those are both no-ops. 

I did want to point out that I copied the syntax from line 54, and the null and "100%" might be flipped, since that format didn't work for me.

With enterprise license:

![image](https://user-images.githubusercontent.com/5768024/39582636-5caad768-4ebc-11e8-9fe5-2337aa6978df.png)

Without enterprise license:

![image](https://user-images.githubusercontent.com/5768024/39582669-719890d4-4ebc-11e8-9e9e-0f1d3bb5ddbc.png)

Fixes #25097