### PR TITLE
opt: execbuild lookup joins

### DIFF
--- a/pkg/sql/index_join.go
+++ b/pkg/sql/index_join.go
@@ -88,7 +88,42 @@ type indexJoinNode struct {
 	// uses more columns than the PK.
 	primaryKeyColumns []bool
 
+	// The columns returned by this node. While these are not ever different from
+	// the table scanNode in the heuristic planner, the optimizer plans them to
+	// be different in some cases.
+	cols []sqlbase.ColumnDescriptor
+	// There is a 1-1 correspondence between cols and resultColumns.
+	resultColumns sqlbase.ResultColumns
+
 	run indexJoinRun
+}
+
+// processIndexJoinColumns returns
+// * a slice denoting the columns being returned which are members of the primary key and
+// * a map from column IDs to their index in the output.
+func processIndexJoinColumns(
+	table *scanNode, indexScan *scanNode,
+) (primaryKeyColumns []bool, colIDtoRowIndex map[sqlbase.ColumnID]int) {
+	colIDtoRowIndex = map[sqlbase.ColumnID]int{}
+
+	// primaryKeyColumns defined here will serve both as the primaryKeyColumns
+	// field in the indexJoinNode, and to determine which columns are
+	// provided by this index for the purpose of splitting the WHERE
+	// filter into an index-specific part and a "rest" part.
+	// TODO(justin): make this a FastIntSet.
+	primaryKeyColumns = make([]bool, len(indexScan.cols))
+	for _, colID := range table.desc.PrimaryIndex.ColumnIDs {
+		// All the PK columns from the table scanNode must
+		// be fetched in the index scanNode.
+		idx, ok := indexScan.colIdxMap[colID]
+		if !ok {
+			panic(fmt.Sprintf("Unknown column %d in PrimaryIndex!", colID))
+		}
+		primaryKeyColumns[idx] = true
+		colIDtoRowIndex[colID] = idx
+	}
+
+	return primaryKeyColumns, colIDtoRowIndex
 }
 
 // makeIndexJoin build an index join node.
@@ -114,23 +149,7 @@ func (p *planner) makeIndexJoin(
 	table.initOrdering(0 /* exactPrefix */, p.EvalContext())
 	table.disableBatchLimit()
 
-	colIDtoRowIndex := map[sqlbase.ColumnID]int{}
-
-	// primaryKeyColumns defined here will serve both as the primaryKeyColumns
-	// field in the indexJoinNode, and to determine which columns are
-	// provided by this index for the purpose of splitting the WHERE
-	// filter into an index-specific part and a "rest" part.
-	primaryKeyColumns := make([]bool, len(origScan.cols))
-	for _, colID := range table.desc.PrimaryIndex.ColumnIDs {
-		// All the PK columns from the table scanNode must
-		// be fetched in the index scanNode.
-		idx, ok := indexScan.colIdxMap[colID]
-		if !ok {
-			panic(fmt.Sprintf("Unknown column %d in PrimaryIndex!", colID))
-		}
-		primaryKeyColumns[idx] = true
-		colIDtoRowIndex[colID] = idx
-	}
+	primaryKeyColumns, colIDtoRowIndex := processIndexJoinColumns(table, indexScan)
 
 	// To split the WHERE filter into an index-specific part and a
 	// "rest" part below the splitFilter() code must know which columns
@@ -152,7 +171,6 @@ func (p *planner) makeIndexJoin(
 			valProvidedIndex[idx] = true
 			colIDtoRowIndex[colID] = idx
 		}
-
 	}
 
 	if origScan.filter != nil {
@@ -179,14 +197,14 @@ func (p *planner) makeIndexJoin(
 	// Ensure that the remaining indexed vars are transferred to the
 	// table scanNode fully.
 	table.filter = table.filterVars.Rebind(table.filter, true /* alsoReset */, false /* normalizeToNonNil */)
-
 	indexScan.initOrdering(exactPrefix, p.EvalContext())
 
 	primaryKeyPrefix := roachpb.Key(sqlbase.MakeIndexKeyPrefix(table.desc, table.index.ID))
-
 	node := &indexJoinNode{
 		index:             indexScan,
 		table:             table,
+		cols:              table.cols,
+		resultColumns:     table.resultColumns,
 		primaryKeyColumns: primaryKeyColumns,
 		run: indexJoinRun{
 			primaryKeyPrefix: primaryKeyPrefix,

--- a/pkg/sql/logictest/testdata/logic_test/select_index
+++ b/pkg/sql/logictest/testdata/logic_test/select_index
@@ -1,4 +1,4 @@
-# LogicTest: default opt parallel-stmts distsql distsql-opt distsql-metadata
+# LogicTest: default opt parallel-stmts distsql distsql-metadata
 
 statement ok
 CREATE TABLE t (
@@ -293,11 +293,10 @@ SELECT * FROM xy WHERE x IN (NULL, 1, 2)
 1  NULL
 1  1
 
-# TODO(justinj): re-enable once lookup join can be executed
-#query II
-#SELECT * FROM xy WHERE (x, y) IN ((NULL, NULL), (1, NULL), (NULL, 1), (1, 1), (1, 2))
-#----
-#1  1
+query II
+SELECT * FROM xy WHERE (x, y) IN ((NULL, NULL), (1, NULL), (NULL, 1), (1, 1), (1, 2))
+----
+1  1
 
 # Test index constraints for IS (NOT) TRUE/FALSE.
 statement ok
@@ -417,16 +416,15 @@ CREATE TABLE noncover (
 statement ok
 INSERT INTO noncover VALUES (1, 2, 3, 4), (5, 6, 7, 8)
 
-# TODO(justinj): re-enable once lookup join execution support is merged
-#query IIII
-#SELECT * FROM noncover WHERE b = 2
-#----
-#1 2 3 4
+query IIII
+SELECT * FROM noncover WHERE b = 2
+----
+1 2 3 4
 
-#query IIII
-#SELECT * FROM noncover WHERE c = 7
-#----
-#5 6 7 8
+query IIII
+SELECT * FROM noncover WHERE c = 7
+----
+5 6 7 8
 
 query IIII
 SELECT * FROM noncover WHERE c > 0 ORDER BY c DESC

--- a/pkg/sql/opt/exec/execbuilder/testdata/select_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/select_index
@@ -814,32 +814,25 @@ scan  ·       ·                     (k, v)  ·
 statement ok
 CREATE TABLE xy (x INT, y INT, INDEX (y))
 
-# TODO(justinj): re-enable once exec support for lookup join is done
-#query TTTTT
-#EXPLAIN (VERBOSE) SELECT * FROM xy WHERE y IS NOT DISTINCT FROM NULL
-#----
-#render           ·         ·                 (x, y)                                   y=CONST
-# │               render 0  test.public.xy.x  ·                                        ·
-# │               render 1  test.public.xy.y  ·                                        ·
-# └── index-join  ·         ·                 (x, y, rowid[hidden,omitted])            y=CONST; rowid!=NULL; key(rowid)
-#      ├── scan   ·         ·                 (x[omitted], y[omitted], rowid[hidden])  y=CONST; rowid!=NULL; key(rowid)
-#      │          table     xy@xy_y_idx       ·                                        ·
-#      │          spans     /NULL-/!NULL      ·                                        ·
-#      └── scan   ·         ·                 (x, y, rowid[hidden,omitted])            ·
-#·                table     xy@primary        ·                                        ·
-#
-#query TTTTT
-#EXPLAIN (VERBOSE) SELECT * FROM xy WHERE y IS NOT DISTINCT FROM 4
-#----
-#render           ·         ·                 (x, y)                                   y=CONST
-# │               render 0  test.public.xy.x  ·                                        ·
-# │               render 1  test.public.xy.y  ·                                        ·
-# └── index-join  ·         ·                 (x, y, rowid[hidden,omitted])            y=CONST; rowid!=NULL; key(rowid)
-#      ├── scan   ·         ·                 (x[omitted], y[omitted], rowid[hidden])  y=CONST; rowid!=NULL; key(rowid)
-#      │          table     xy@xy_y_idx       ·                                        ·
-#      │          spans     /4-/5             ·                                        ·
-#      └── scan   ·         ·                 (x, y, rowid[hidden,omitted])            ·
-#·                table     xy@primary        ·                                        ·
+query TTTTT
+EXPLAIN (VERBOSE) SELECT * FROM xy WHERE y IS NOT DISTINCT FROM NULL
+----
+index-join  ·      ·             (x, y)              ·
+ ├── scan   ·      ·             (y, rowid[hidden])  ·
+ │          table  xy@xy_y_idx   ·                   ·
+ │          spans  /NULL-/!NULL  ·                   ·
+ └── scan   ·      ·             (x, y)              ·
+·           table  xy@primary    ·                   ·
+
+query TTTTT
+EXPLAIN (VERBOSE) SELECT * FROM xy WHERE y IS NOT DISTINCT FROM 4
+----
+index-join  ·      ·            (x, y)              ·
+ ├── scan   ·      ·            (y, rowid[hidden])  ·
+ │          table  xy@xy_y_idx  ·                   ·
+ │          spans  /4-/5        ·                   ·
+ └── scan   ·      ·            (x, y)              ·
+·           table  xy@primary   ·                   ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM xy WHERE y IS DISTINCT FROM NULL
@@ -871,16 +864,17 @@ scan  ·      ·          (x, y)  ·
 ·     table  xy@xy_idx  ·       ·
 ·     spans  /1-/3      ·       ·
 
-# TODO(justinj): re-enable once exec support for lookup join is done
-#query TTTTT
-#EXPLAIN (VERBOSE) SELECT * FROM xy WHERE (x, y) IN ((NULL, NULL), (1, NULL), (NULL, 1), (1, 1), (1, 2))
-#----
-#render     ·         ·                 (x, y)                         x=CONST; y!=NULL
-# │         render 0  test.public.xy.x  ·                              ·
-# │         render 1  test.public.xy.y  ·                              ·
-# └── scan  ·         ·                 (x, y, rowid[hidden,omitted])  x=CONST; y!=NULL; rowid!=NULL; key(y,rowid)
-#·          table     xy@xy_idx         ·                              ·
-#·          spans     /1/1-/1/3         ·                              ·
+query TTTTT
+EXPLAIN (VERBOSE) SELECT * FROM xy WHERE (x, y) IN ((NULL, NULL), (1, NULL), (NULL, 1), (1, 1), (1, 2))
+----
+filter           ·       ·                                                               (x, y)              ·
+ │               filter  (x, y) IN ((NULL, NULL), (1, NULL), (NULL, 1), (1, 1), (1, 2))  ·                   ·
+ └── index-join  ·       ·                                                               (x, y)              ·
+      ├── scan   ·       ·                                                               (y, rowid[hidden])  ·
+      │          table   xy@xy_y_idx                                                     ·                   ·
+      │          spans   /1-/3                                                           ·                   ·
+      └── scan   ·       ·                                                               (x, y)              ·
+·                table   xy@primary                                                      ·                   ·
 
 # ------------------------------------------------------------------------------
 # Non-covering index
@@ -902,48 +896,47 @@ CREATE TABLE noncover (
 statement ok
 INSERT INTO noncover VALUES (1, 2, 3, 4), (5, 6, 7, 8)
 
-# TODO(justinj): re-enable once exec support for lookup join is done
-#query TTT
-#EXPLAIN SELECT * FROM noncover WHERE b = 2
-#----
-#index-join  ·      ·
-# ├── scan   ·      ·
-# │          table  noncover@b
-# │          spans  /2-/3
-# └── scan   ·      ·
-#·           table  noncover@primary
-#
-#query T
-#SELECT message FROM [SHOW KV TRACE FOR SELECT * FROM noncover WHERE b = 2]
-# WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
-#----
-#fetched: /noncover/b/2/1 -> NULL
-#fetched: /noncover/primary/1 -> NULL
-#fetched: /noncover/primary/1/b -> 2
-#fetched: /noncover/primary/1/c -> 3
-#fetched: /noncover/primary/1/d -> 4
-#output row: [1 2 3 4]
-#
-#query TTT
-#EXPLAIN SELECT * FROM noncover WHERE c = 6
-#----
-#index-join  ·      ·
-# ├── scan   ·      ·
-# │          table  noncover@c
-# │          spans  /6-/7
-# └── scan   ·      ·
-#·           table  noncover@primary
-#
-#query T
-#SELECT message FROM [SHOW KV TRACE FOR SELECT * FROM noncover WHERE c = 7]
-# WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
-#----
-#fetched: /noncover/c/7 -> /5
-#fetched: /noncover/primary/5 -> NULL
-#fetched: /noncover/primary/5/b -> 6
-#fetched: /noncover/primary/5/c -> 7
-#fetched: /noncover/primary/5/d -> 8
-#output row: [5 6 7 8]
+query TTT
+EXPLAIN SELECT * FROM noncover WHERE b = 2
+----
+index-join  ·      ·
+ ├── scan   ·      ·
+ │          table  noncover@b
+ │          spans  /2-/3
+ └── scan   ·      ·
+·           table  noncover@primary
+
+query T
+SELECT message FROM [SHOW KV TRACE FOR SELECT * FROM noncover WHERE b = 2]
+ WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
+----
+fetched: /noncover/b/2/1 -> NULL
+fetched: /noncover/primary/1 -> NULL
+fetched: /noncover/primary/1/b -> 2
+fetched: /noncover/primary/1/c -> 3
+fetched: /noncover/primary/1/d -> 4
+output row: [1 2 3 4]
+
+query TTT
+EXPLAIN SELECT * FROM noncover WHERE c = 6
+----
+index-join  ·      ·
+ ├── scan   ·      ·
+ │          table  noncover@c
+ │          spans  /6-/7
+ └── scan   ·      ·
+·           table  noncover@primary
+
+query T
+SELECT message FROM [SHOW KV TRACE FOR SELECT * FROM noncover WHERE c = 7]
+ WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
+----
+fetched: /noncover/c/7 -> /5
+fetched: /noncover/primary/5 -> NULL
+fetched: /noncover/primary/5/b -> 6
+fetched: /noncover/primary/5/c -> 7
+fetched: /noncover/primary/5/d -> 8
+output row: [5 6 7 8]
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM noncover WHERE c > 0 ORDER BY c DESC
@@ -1067,121 +1060,160 @@ INSERT INTO t2 VALUES
   (8, 3, 2, '32'),
   (9, 3, 3, '33')
 
-# TODO(justinj): re-enable once exec support for lookup join is done
-#query TTT
-#SELECT "Tree", "Field", "Description" FROM [
-#EXPLAIN (VERBOSE) SELECT * FROM t2 WHERE b = 2 AND c % 2 = 0
-#]
-#----
-#index-join  ·       ·
-# ├── scan   ·       ·
-# │          table   t2@bc
-# │          spans   /2-/3
-# │          filter  (c % 2) = 0
-# └── scan   ·       ·
-#·           table   t2@primary
-#
-## We do NOT look up the table row for '21' and '23'.
-#query T
-#SELECT message FROM [SHOW KV TRACE FOR SELECT * FROM t2 WHERE b = 2 AND c % 2 = 0]
-# WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
-#----
-#fetched: /t2/bc/2/1/4 -> NULL
-#fetched: /t2/bc/2/2/5 -> NULL
-#fetched: /t2/bc/2/3/6 -> NULL
-#fetched: /t2/primary/5 -> NULL
-#fetched: /t2/primary/5/b -> 2
-#fetched: /t2/primary/5/c -> 2
-#fetched: /t2/primary/5/s -> '22'
-#output row: [5 2 2 '22']
-#
-#query TTT
-#SELECT "Tree", "Field", "Description" FROM [
-#EXPLAIN (VERBOSE) SELECT * FROM t2 WHERE b = 2 AND c != b
-#]
-#----
-#index-join  ·       ·
-# ├── scan   ·       ·
-# │          table   t2@bc
-# │          spans   /2/!NULL-/3
-# │          filter  c != b
-# └── scan   ·       ·
-#·           table   t2@primary
-#
-## We do NOT look up the table row for '22'.
-#query T
-#SELECT message FROM [SHOW KV TRACE FOR SELECT * FROM t2 WHERE b = 2 AND c != b]
-# WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
-#----
-#fetched: /t2/bc/2/1/4 -> NULL
-#fetched: /t2/bc/2/2/5 -> NULL
-#fetched: /t2/bc/2/3/6 -> NULL
-#fetched: /t2/primary/4 -> NULL
-#fetched: /t2/primary/4/b -> 2
-#fetched: /t2/primary/4/c -> 1
-#fetched: /t2/primary/4/s -> '21'
-#output row: [4 2 1 '21']
-#fetched: /t2/primary/6 -> NULL
-#fetched: /t2/primary/6/b -> 2
-#fetched: /t2/primary/6/c -> 3
-#fetched: /t2/primary/6/s -> '23'
-#output row: [6 2 3 '23']
-#
-## We do NOT look up the table row for '22'.
-#query T
-#SELECT message FROM [SHOW KV TRACE FOR SELECT * FROM t2 WHERE b = 2 AND c != b AND s <> '21']
-# WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
-#----
-#fetched: /t2/bc/2/1/4 -> NULL
-#fetched: /t2/bc/2/2/5 -> NULL
-#fetched: /t2/bc/2/3/6 -> NULL
-#fetched: /t2/primary/4 -> NULL
-#fetched: /t2/primary/4/b -> 2
-#fetched: /t2/primary/4/c -> 1
-#fetched: /t2/primary/4/s -> '21'
-#fetched: /t2/primary/6 -> NULL
-#fetched: /t2/primary/6/b -> 2
-#fetched: /t2/primary/6/c -> 3
-#fetched: /t2/primary/6/s -> '23'
-#output row: [6 2 3 '23']
-#
-## We only look up the table rows where c = b+1 or a > b+4: '23', '32', '33'.
-#query T
-#SELECT message FROM [SHOW KV TRACE FOR SELECT * FROM t2 WHERE b > 1 AND ((c = b+1 AND s != '23') OR (a > b+4 AND s != '32'))]
-# WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
-#----
-#fetched: /t2/bc/2/1/4 -> NULL
-#fetched: /t2/bc/2/2/5 -> NULL
-#fetched: /t2/bc/2/3/6 -> NULL
-#fetched: /t2/bc/3/1/7 -> NULL
-#fetched: /t2/bc/3/2/8 -> NULL
-#fetched: /t2/bc/3/3/9 -> NULL
-#fetched: /t2/primary/6 -> NULL
-#fetched: /t2/primary/6/b -> 2
-#fetched: /t2/primary/6/c -> 3
-#fetched: /t2/primary/6/s -> '23'
-#fetched: /t2/primary/8 -> NULL
-#fetched: /t2/primary/8/b -> 3
-#fetched: /t2/primary/8/c -> 2
-#fetched: /t2/primary/8/s -> '32'
-#fetched: /t2/primary/9 -> NULL
-#fetched: /t2/primary/9/b -> 3
-#fetched: /t2/primary/9/c -> 3
-#fetched: /t2/primary/9/s -> '33'
-#output row: [9 3 3 '33']
-#
-## Check that splitting of the expression filter does not mistakenly
-## bring non-indexed columns (s) under the index scanNode. (#12582)
-## To test this we need an expression containing non-indexed
-## columns that disappears during range simplification.
-#query TTTTT
-#EXPLAIN (VERBOSE) SELECT a FROM t2 WHERE b = 2 OR ((b BETWEEN 2 AND 1) AND ((s != 'a') OR (s = 'a')))
-#----
-#render           ·         ·                (a)                                      a!=NULL
-# │               render 0  test.public.t2.a ·                                        ·
-# └── index-join  ·         ·                (a, b[omitted], c[omitted], s[omitted])  b=CONST; a!=NULL; weak-key(a,c)
-#      ├── scan   ·         ·                (a, b[omitted], c[omitted], s[omitted])  b=CONST; a!=NULL; weak-key(a,c)
-#      │          table     t2@bc            ·                                        ·
-#      │          spans     /2-/3            ·                                        ·
-#      └── scan   ·         ·                (a, b[omitted], c[omitted], s[omitted])  ·
-#·                table     t2@primary       ·                                        ·
+query TTT
+SELECT "Tree", "Field", "Description" FROM [
+EXPLAIN (VERBOSE) SELECT * FROM t2 WHERE b = 2 AND c % 2 = 0
+]
+----
+filter           ·       ·
+ │               filter  (c % 2) = 0
+ └── index-join  ·       ·
+      ├── scan   ·       ·
+      │          table   t2@bc
+      │          spans   /2-/3
+      └── scan   ·       ·
+·                table   t2@primary
+
+# We do NOT look up the table row for '21' and '23'.
+# TODO(justin): we need to push the c % 2 into the index scan.
+query T
+SELECT message FROM [SHOW KV TRACE FOR SELECT * FROM t2 WHERE b = 2 AND c % 2 = 0]
+ WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
+----
+fetched: /t2/bc/2/1/4 -> NULL
+fetched: /t2/bc/2/2/5 -> NULL
+fetched: /t2/bc/2/3/6 -> NULL
+fetched: /t2/primary/4 -> NULL
+fetched: /t2/primary/4/b -> 2
+fetched: /t2/primary/4/c -> 1
+fetched: /t2/primary/4/s -> '21'
+fetched: /t2/primary/5 -> NULL
+fetched: /t2/primary/5/b -> 2
+fetched: /t2/primary/5/c -> 2
+fetched: /t2/primary/5/s -> '22'
+output row: [5 2 2 '22']
+fetched: /t2/primary/6 -> NULL
+fetched: /t2/primary/6/b -> 2
+fetched: /t2/primary/6/c -> 3
+fetched: /t2/primary/6/s -> '23'
+
+query TTT
+SELECT "Tree", "Field", "Description" FROM [
+EXPLAIN (VERBOSE) SELECT * FROM t2 WHERE b = 2 AND c != b
+]
+----
+filter           ·       ·
+ │               filter  c != b
+ └── index-join  ·       ·
+      ├── scan   ·       ·
+      │          table   t2@bc
+      │          spans   /2/!NULL-/3
+      └── scan   ·       ·
+·                table   t2@primary
+
+# We do NOT look up the table row for '22'.
+# TODO(justin): we need to push the filter into the index scan.
+query T
+SELECT message FROM [SHOW KV TRACE FOR SELECT * FROM t2 WHERE b = 2 AND c != b]
+ WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
+----
+fetched: /t2/bc/2/1/4 -> NULL
+fetched: /t2/bc/2/2/5 -> NULL
+fetched: /t2/bc/2/3/6 -> NULL
+fetched: /t2/primary/4 -> NULL
+fetched: /t2/primary/4/b -> 2
+fetched: /t2/primary/4/c -> 1
+fetched: /t2/primary/4/s -> '21'
+output row: [4 2 1 '21']
+fetched: /t2/primary/5 -> NULL
+fetched: /t2/primary/5/b -> 2
+fetched: /t2/primary/5/c -> 2
+fetched: /t2/primary/5/s -> '22'
+fetched: /t2/primary/6 -> NULL
+fetched: /t2/primary/6/b -> 2
+fetched: /t2/primary/6/c -> 3
+fetched: /t2/primary/6/s -> '23'
+output row: [6 2 3 '23']
+
+# We do NOT look up the table row for '22'.
+# TODO(justin): we need to push the filter into the index scan.
+query T
+SELECT message FROM [SHOW KV TRACE FOR SELECT * FROM t2 WHERE b = 2 AND c != b AND s <> '21']
+ WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
+----
+fetched: /t2/bc/2/1/4 -> NULL
+fetched: /t2/bc/2/2/5 -> NULL
+fetched: /t2/bc/2/3/6 -> NULL
+fetched: /t2/primary/4 -> NULL
+fetched: /t2/primary/4/b -> 2
+fetched: /t2/primary/4/c -> 1
+fetched: /t2/primary/4/s -> '21'
+fetched: /t2/primary/5 -> NULL
+fetched: /t2/primary/5/b -> 2
+fetched: /t2/primary/5/c -> 2
+fetched: /t2/primary/5/s -> '22'
+fetched: /t2/primary/6 -> NULL
+fetched: /t2/primary/6/b -> 2
+fetched: /t2/primary/6/c -> 3
+fetched: /t2/primary/6/s -> '23'
+output row: [6 2 3 '23']
+
+# We only look up the table rows where c = b+1 or a > b+4: '23', '32', '33'.
+# TODO(justin): we need to push the filter into the index scan.
+query T
+SELECT message FROM [SHOW KV TRACE FOR SELECT * FROM t2 WHERE b > 1 AND ((c = b+1 AND s != '23') OR (a > b+4 AND s != '32'))]
+ WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
+----
+fetched: /t2/primary/1 -> NULL
+fetched: /t2/primary/1/b -> 1
+fetched: /t2/primary/1/c -> 1
+fetched: /t2/primary/1/s -> '11'
+fetched: /t2/primary/2 -> NULL
+fetched: /t2/primary/2/b -> 1
+fetched: /t2/primary/2/c -> 2
+fetched: /t2/primary/2/s -> '12'
+fetched: /t2/primary/3 -> NULL
+fetched: /t2/primary/3/b -> 1
+fetched: /t2/primary/3/c -> 3
+fetched: /t2/primary/3/s -> '13'
+fetched: /t2/primary/4 -> NULL
+fetched: /t2/primary/4/b -> 2
+fetched: /t2/primary/4/c -> 1
+fetched: /t2/primary/4/s -> '21'
+fetched: /t2/primary/5 -> NULL
+fetched: /t2/primary/5/b -> 2
+fetched: /t2/primary/5/c -> 2
+fetched: /t2/primary/5/s -> '22'
+fetched: /t2/primary/6 -> NULL
+fetched: /t2/primary/6/b -> 2
+fetched: /t2/primary/6/c -> 3
+fetched: /t2/primary/6/s -> '23'
+fetched: /t2/primary/7 -> NULL
+fetched: /t2/primary/7/b -> 3
+fetched: /t2/primary/7/c -> 1
+fetched: /t2/primary/7/s -> '31'
+fetched: /t2/primary/8 -> NULL
+fetched: /t2/primary/8/b -> 3
+fetched: /t2/primary/8/c -> 2
+fetched: /t2/primary/8/s -> '32'
+fetched: /t2/primary/9 -> NULL
+fetched: /t2/primary/9/b -> 3
+fetched: /t2/primary/9/c -> 3
+fetched: /t2/primary/9/s -> '33'
+output row: [9 3 3 '33']
+
+# Check that splitting of the expression filter does not mistakenly
+# bring non-indexed columns (s) under the index scanNode. (#12582)
+# To test this we need an expression containing non-indexed
+# columns that disappears during range simplification.
+query TTTTT
+EXPLAIN (VERBOSE) SELECT a FROM t2 WHERE b = 2 OR ((b BETWEEN 2 AND 1) AND ((s != 'a') OR (s = 'a')))
+----
+render           ·         ·           (a)        ·
+ │               render 0  a           ·          ·
+ └── index-join  ·         ·           (a, b, s)  ·
+      ├── scan   ·         ·           (a, b)     ·
+      │          table     t2@bc       ·          ·
+      │          spans     /2-/3       ·          ·
+      └── scan   ·         ·           (a, b, s)  ·
+·                table     t2@primary  ·          ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/select_index_hints
+++ b/pkg/sql/opt/exec/execbuilder/testdata/select_index_hints
@@ -127,17 +127,15 @@ index-join  ·      ·
  └── scan   ·      ·
 ·           table  abcd@primary
 
-# TODO(justinj): re-enable once exec support for lookup join is done
-#query TTT
-#EXPLAIN SELECT b, c, d FROM abcd WHERE c = 10
-#----
-#render           ·      ·
-# └── index-join  ·      ·
-#      ├── scan   ·      ·
-#      │          table  abcd@cd
-#      │          spans  /10-/11
-#      └── scan   ·      ·
-#·                table  abcd@primary
+query TTT
+EXPLAIN SELECT b, c, d FROM abcd WHERE c = 10
+----
+index-join  ·      ·
+ ├── scan   ·      ·
+ │          table  abcd@cd
+ │          spans  /10-/11
+ └── scan   ·      ·
+·           table  abcd@primary
 
 query TTT
 EXPLAIN SELECT b, c, d FROM abcd@{NO_INDEX_JOIN} WHERE c = 10

--- a/pkg/sql/opt/exec/factory.go
+++ b/pkg/sql/opt/exec/factory.go
@@ -106,6 +106,9 @@ type Factory interface {
 	// each row in the input node.
 	ConstructOrdinality(input Node, colName string) (Node, error)
 
+	// ConstructLookupJoin returns a node that performs a lookup join.
+	ConstructLookupJoin(input Node, table opt.Table, cols ColumnOrdinalSet) (Node, error)
+
 	// ConstructLimit returns a node that implements LIMIT and/or OFFSET on the
 	// results of the given node. If one or the other is not needed, then it is
 	// set to nil.

--- a/pkg/sql/opt/xform/testdata/rules/scan
+++ b/pkg/sql/opt/xform/testdata/rules/scan
@@ -154,6 +154,36 @@ memo (optimized)
  ├── G6: (function G7 lower)
  └── G7: (variable abc.d)
 
+memo
+SELECT j FROM a WHERE s = 'foo'
+----
+memo (optimized)
+ ├── G1: (project G2 G3)
+ │    └── "[presentation: j:5]"
+ │         ├── best: (project G2 G3)
+ │         └── cost: 1.00
+ ├── G2: (select G4 G5) (scan a@si_idx,cols=(4,5),constrained) (lookup-join G6 a,cols=(4,5))
+ │    └── ""
+ │         ├── best: (scan a@si_idx,cols=(4,5),constrained)
+ │         └── cost: 1.00
+ ├── G3: (projections a.j)
+ ├── G4: (scan a,cols=(4,5)) (lookup-join G7 a,cols=(4,5)) (scan a@si_idx,cols=(4,5))
+ │    └── ""
+ │         ├── best: (scan a,cols=(4,5))
+ │         └── cost: 1000.00
+ ├── G5: (filters G8)
+ ├── G6: (scan a@s_idx,cols=(1,4),constrained)
+ │    └── ""
+ │         ├── best: (scan a@s_idx,cols=(1,4),constrained)
+ │         └── cost: 1.00
+ ├── G7: (scan a@s_idx,cols=(1,4))
+ │    └── ""
+ │         ├── best: (scan a@s_idx,cols=(1,4))
+ │         └── cost: 1000.00
+ ├── G8: (eq G9 G10)
+ ├── G9: (variable a.s)
+ └── G10: (const 'foo')
+
 # Scan of primary index is lowest cost.
 opt
 SELECT s, i, f FROM a ORDER BY k, i, s

--- a/pkg/sql/plan_columns.go
+++ b/pkg/sql/plan_columns.go
@@ -87,6 +87,8 @@ func getPlanColumns(plan planNode, mut bool) sqlbase.ResultColumns {
 		return n.columns
 	case *upsertNode:
 		return n.columns
+	case *indexJoinNode:
+		return n.resultColumns
 
 	// Nodes with a fixed schema.
 	case *scrubNode:
@@ -116,8 +118,6 @@ func getPlanColumns(plan planNode, mut bool) sqlbase.ResultColumns {
 		return getPlanColumns(n.plan, mut)
 	case *filterNode:
 		return getPlanColumns(n.source.plan, mut)
-	case *indexJoinNode:
-		return getPlanColumns(n.table, mut)
 	case *limitNode:
 		return getPlanColumns(n.plan, mut)
 	case *spoolNode:


### PR DESCRIPTION
This commit allows executing index joins planned by the optimizer.

Still remaining is to push filters down into the scan. This is blocking
a lot of tests from being added. At the moment I'm not entirely
confident I'm initializing the indexJoinNode sufficiently, but once
more tests are added I will be more confident.

Release note: None.