### PR TITLE
sql: Add the generate_subscripts builtin function

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -867,6 +867,13 @@ Compatible elements: hour, minute, second, millisecond, microsecond.</p>
 </span></td></tr>
 <tr><td><code>generate_series(start: <a href="timestamp.html">timestamp</a>, end: <a href="timestamp.html">timestamp</a>, step: <a href="interval.html">interval</a>) &rarr; setof tuple{timestamp}</code></td><td><span class="funcdesc"><p>Produces a virtual table containing the timestamp values from <code>start</code> to <code>end</code>, inclusive, by increment of <code>step</code>.</p>
 </span></td></tr>
+<tr><td><code>generate_subscripts(array: anyelement[]) &rarr; setof tuple{int}</code></td><td><span class="funcdesc"><p>Returns a series comprising the given array’s subscripts.</p>
+</span></td></tr>
+<tr><td><code>generate_subscripts(array: anyelement[], dim: <a href="int.html">int</a>) &rarr; setof tuple{int}</code></td><td><span class="funcdesc"><p>Returns a series comprising the given array’s subscripts.</p>
+</span></td></tr>
+<tr><td><code>generate_subscripts(array: anyelement[], dim: <a href="int.html">int</a>, reverse: <a href="bool.html">bool</a>) &rarr; setof tuple{int}</code></td><td><span class="funcdesc"><p>Returns a series comprising the given array’s subscripts.</p>
+<p>When reverse is true, the series is returned in reverse order.</p>
+</span></td></tr>
 <tr><td><code>has_any_column_privilege(table: <a href="string.html">string</a>, privilege: <a href="string.html">string</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Returns whether or not the current user has privileges for any column of table.</p>
 </span></td></tr>
 <tr><td><code>has_any_column_privilege(table: oid, privilege: <a href="string.html">string</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Returns whether or not the current user has privileges for any column of table.</p>

--- a/pkg/sql/logictest/testdata/logic_test/generators
+++ b/pkg/sql/logictest/testdata/logic_test/generators
@@ -561,3 +561,165 @@ subtest 24866
 # 3
 # 2
 # 1
+
+subtest generate_subscripts
+
+# Basic use cases
+
+query I colnames
+SELECT * FROM generate_subscripts(ARRAY[3,2,1])
+----
+generate_subscripts
+1
+2
+3
+
+query I colnames
+SELECT * FROM generate_subscripts(ARRAY[3,2,1], 1)
+----
+generate_subscripts
+1
+2
+3
+
+query I colnames
+SELECT * FROM generate_subscripts(ARRAY[3,2,1], 1, false)
+----
+generate_subscripts
+1
+2
+3
+
+query I colnames
+SELECT * FROM generate_subscripts(ARRAY[3,2,1], 1, true)
+----
+generate_subscripts
+3
+2
+1
+
+query I colnames
+SELECT generate_subscripts('{NULL,1,NULL,2}'::int[], 1) AS s
+----
+s
+1
+2
+3
+4
+
+query I colnames
+SELECT generate_subscripts('{NULL,1,NULL,2}'::int[], 1, true) AS s
+----
+s
+4
+3
+2
+1
+
+# With a non-valid dimension (only 1 should return any rows)
+
+query I colnames
+SELECT * FROM generate_subscripts(ARRAY[3,2,1], 2)
+----
+generate_subscripts
+
+query I colnames
+SELECT * FROM generate_subscripts(ARRAY[3,2,1], 2, false)
+----
+generate_subscripts
+
+query I colnames
+SELECT * FROM generate_subscripts(ARRAY[3,2,1], 2, true)
+----
+generate_subscripts
+
+query I colnames
+SELECT * FROM generate_subscripts(ARRAY[3,2,1], 0)
+----
+generate_subscripts
+
+query I colnames
+SELECT * FROM generate_subscripts(ARRAY[3,2,1], 0, false)
+----
+generate_subscripts
+
+query I colnames
+SELECT * FROM generate_subscripts(ARRAY[3,2,1], 0, true)
+----
+generate_subscripts
+
+query I colnames
+SELECT * FROM generate_subscripts(ARRAY[3,2,1], -1)
+----
+generate_subscripts
+
+query I colnames
+SELECT * FROM generate_subscripts(ARRAY[3,2,1], -1, false)
+----
+generate_subscripts
+
+query I colnames
+SELECT * FROM generate_subscripts(ARRAY[3,2,1], -1, true)
+----
+generate_subscripts
+
+# With an empty array
+query I colnames
+SELECT * FROM generate_subscripts(ARRAY[]:::int[])
+----
+generate_subscripts
+
+query I colnames
+SELECT * FROM generate_subscripts(ARRAY[]:::int[], 1)
+----
+generate_subscripts
+
+query I colnames
+SELECT * FROM generate_subscripts(ARRAY[]:::string[], 1, false)
+----
+generate_subscripts
+
+query I colnames
+SELECT * FROM generate_subscripts(ARRAY[]:::bool[], 1, true)
+----
+generate_subscripts
+
+query I colnames
+SELECT * FROM generate_subscripts(ARRAY[]:::int[], 0)
+----
+generate_subscripts
+
+query I colnames
+SELECT * FROM generate_subscripts(ARRAY[]:::string[], -1, false)
+----
+generate_subscripts
+
+query I colnames
+SELECT * FROM generate_subscripts(ARRAY[]:::bool[], 2, true)
+----
+generate_subscripts
+
+# With an array with only one value
+query I colnames
+SELECT * FROM generate_subscripts(ARRAY[100])
+----
+generate_subscripts
+1
+
+query I colnames
+SELECT * FROM generate_subscripts(ARRAY[100], 1)
+----
+generate_subscripts
+1
+
+query I colnames
+SELECT * FROM generate_subscripts(ARRAY['b'], 1, false)
+----
+generate_subscripts
+1
+
+query I colnames
+SELECT * FROM generate_subscripts(ARRAY[true], 1, true)
+----
+generate_subscripts
+1

--- a/pkg/sql/sem/builtins/generator_builtins.go
+++ b/pkg/sql/sem/builtins/generator_builtins.go
@@ -56,6 +56,7 @@ func initGeneratorBuiltins() {
 // generators.
 var Generators = map[string][]tree.Builtin{
 	"generate_series": {
+		// See https://www.postgresql.org/docs/current/static/functions-srf.html#FUNCTIONS-SRF-SERIES
 		makeGeneratorBuiltin(
 			tree.ArgTypes{{"start", types.Int}, {"end", types.Int}},
 			seriesValueGeneratorType,
@@ -76,6 +77,7 @@ var Generators = map[string][]tree.Builtin{
 		),
 	},
 	"pg_get_keywords": {
+		// See https://www.postgresql.org/docs/10/static/functions-info.html#FUNCTIONS-INFO-CATALOG-TABLE
 		makeGeneratorBuiltin(
 			tree.ArgTypes{},
 			keywordsValueGeneratorType,
@@ -84,6 +86,7 @@ var Generators = map[string][]tree.Builtin{
 		),
 	},
 	"unnest": {
+		// See https://www.postgresql.org/docs/current/static/functions-array.html
 		makeGeneratorBuiltinWithReturnType(
 			tree.ArgTypes{{"input", types.AnyArray}},
 			func(args []tree.TypedExpr) types.T {
@@ -124,6 +127,28 @@ var Generators = map[string][]tree.Builtin{
 			makeUnaryGenerator,
 			"Produces a virtual table containing a single row with no values.\n\n"+
 				"This function is used only by CockroachDB's developers for testing purposes.",
+		),
+	},
+	"generate_subscripts": {
+		// See https://www.postgresql.org/docs/current/static/functions-srf.html#FUNCTIONS-SRF-SUBSCRIPTS
+		makeGeneratorBuiltin(
+			tree.ArgTypes{{"array", types.AnyArray}},
+			subscriptsValueGeneratorType,
+			makeGenerateSubscriptsGenerator,
+			"Returns a series comprising the given array's subscripts.",
+		),
+		makeGeneratorBuiltin(
+			tree.ArgTypes{{"array", types.AnyArray}, {"dim", types.Int}},
+			subscriptsValueGeneratorType,
+			makeGenerateSubscriptsGenerator,
+			"Returns a series comprising the given array's subscripts.",
+		),
+		makeGeneratorBuiltin(
+			tree.ArgTypes{{"array", types.AnyArray}, {"dim", types.Int}, {"reverse", types.Bool}},
+			subscriptsValueGeneratorType,
+			makeGenerateSubscriptsGenerator,
+			"Returns a series comprising the given array's subscripts.\n\n"+
+				"When reverse is true, the series is returned in reverse order.",
 		),
 	},
 	"json_array_elements":       {jsonArrayElementsImpl},
@@ -191,10 +216,7 @@ func (k *keywordsValueGenerator) Start() error {
 }
 func (k *keywordsValueGenerator) Next() (bool, error) {
 	k.curKeyword++
-	if k.curKeyword >= len(keywordNames) {
-		return false, nil
-	}
-	return true, nil
+	return k.curKeyword < len(keywordNames), nil
 }
 
 // Values implements the tree.ValueGenerator interface.
@@ -438,10 +460,7 @@ func (s *expandArrayValueGenerator) Close() {}
 // Next implements the tree.ValueGenerator interface.
 func (s *expandArrayValueGenerator) Next() (bool, error) {
 	s.avg.nextIndex++
-	if s.avg.nextIndex >= s.avg.array.Len() {
-		return false, nil
-	}
-	return true, nil
+	return s.avg.nextIndex < s.avg.array.Len(), nil
 }
 
 // Values implements the tree.ValueGenerator interface.
@@ -451,6 +470,78 @@ func (s *expandArrayValueGenerator) Values() tree.Datums {
 		s.avg.array.Array[s.avg.nextIndex],
 		tree.NewDInt(tree.DInt(s.avg.nextIndex + 1)),
 	}
+}
+
+func makeGenerateSubscriptsGenerator(
+	evalCtx *tree.EvalContext, args tree.Datums,
+) (tree.ValueGenerator, error) {
+	var arr *tree.DArray
+	dim := 1
+	if len(args) > 1 {
+		dim = int(tree.MustBeDInt(args[1]))
+	}
+	// We sadly only support 1D arrays right now.
+	if dim == 1 {
+		arr = tree.MustBeDArray(args[0])
+	} else {
+		arr = &tree.DArray{}
+	}
+	var reverse bool
+	if len(args) == 3 {
+		reverse = bool(tree.MustBeDBool(args[2]))
+	}
+	return &subscriptsValueGenerator{
+		avg:     arrayValueGenerator{array: arr},
+		reverse: reverse,
+	}, nil
+}
+
+// subscriptsValueGenerator is a value generator that returns a series
+// comprising the given array's subscripts.
+type subscriptsValueGenerator struct {
+	avg     arrayValueGenerator
+	reverse bool
+}
+
+var subscriptsValueGeneratorLabels = []string{"generate_subscripts"}
+
+var subscriptsValueGeneratorType = types.TTable{
+	Cols:   types.TTuple{types.Int},
+	Labels: subscriptsValueGeneratorLabels,
+}
+
+// ResolvedType implements the tree.ValueGenerator interface.
+func (s *subscriptsValueGenerator) ResolvedType() types.TTable {
+	return subscriptsValueGeneratorType
+}
+
+// Start implements the tree.ValueGenerator interface.
+func (s *subscriptsValueGenerator) Start() error {
+	if s.reverse {
+		s.avg.nextIndex = s.avg.array.Len()
+	} else {
+		s.avg.nextIndex = -1
+	}
+	return nil
+}
+
+// Close implements the tree.ValueGenerator interface.
+func (s *subscriptsValueGenerator) Close() {}
+
+// Next implements the tree.ValueGenerator interface.
+func (s *subscriptsValueGenerator) Next() (bool, error) {
+	if s.reverse {
+		s.avg.nextIndex--
+		return s.avg.nextIndex >= 0, nil
+	}
+	s.avg.nextIndex++
+	return s.avg.nextIndex < s.avg.array.Len(), nil
+}
+
+// Values implements the tree.ValueGenerator interface.
+func (s *subscriptsValueGenerator) Values() tree.Datums {
+	// Generate Subscript's indexes are 1 based.
+	return tree.Datums{tree.NewDInt(tree.DInt(s.avg.nextIndex + 1))}
 }
 
 // EmptyDTable returns a new, empty tree.DTable.


### PR DESCRIPTION
This builtin returns a series that matches the array's specified dimension's
length.

As we only support 1D arrays, this function only returns valid values for that
dimension.

Closes #13098

Release note(sql change): Added support for the genearte_subscripts builtin
function.