### PR TITLE
roachtest: create TPC-C benchmarking tool

### DIFF
--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -750,6 +750,14 @@ func (c *cluster) RunWithBuffer(
 		append([]string{roachprod, "run", c.makeNodes(node), "--"}, args...)...)
 }
 
+// RemountNoBarrier remounts the cluster's local SSDs with the nobarrier option.
+func (c *cluster) RemountNoBarrier(ctx context.Context) {
+	c.Run(ctx, c.All(),
+		"sudo", "umount", "/mnt/data1", ";",
+		"sudo", "mount", "-o", "discard,defaults,nobarrier",
+		"/dev/disk/by-id/google-local-ssd-0", "/mnt/data1")
+}
+
 // pgURL returns the Postgres endpoint for the specified node. It accepts a flag
 // specifying whether the URL should include the node's internal or external IP
 // address. In general, inter-cluster communication and should use internal IPs

--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -552,15 +552,17 @@ func (c *cluster) Destroy(ctx context.Context) {
 func (c *cluster) destroy(ctx context.Context) {
 	defer close(c.destroyed)
 
-	if c.name != clusterName {
-		c.status("destroying cluster")
-		if err := execCmd(ctx, c.l, roachprod, "destroy", c.name); err != nil {
-			c.l.errorf("%s", err)
-		}
-	} else if clusterWipe {
-		c.status("wiping cluster")
-		if err := execCmd(ctx, c.l, roachprod, "wipe", c.name); err != nil {
-			c.l.errorf("%s", err)
+	if clusterWipe {
+		if c.name != clusterName {
+			c.status("destroying cluster")
+			if err := execCmd(ctx, c.l, roachprod, "destroy", c.name); err != nil {
+				c.l.errorf("%s", err)
+			}
+		} else {
+			c.status("wiping cluster")
+			if err := execCmd(ctx, c.l, roachprod, "wipe", c.name); err != nil {
+				c.l.errorf("%s", err)
+			}
 		}
 	} else {
 		c.l.printf("skipping cluster wipe\n")

--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -913,7 +913,13 @@ func newMonitor(ctx context.Context, c *cluster, opts ...option) *monitor {
 // ExpectDeath lets the monitor know that a node is about to be killed, and that
 // this should be ignored.
 func (m *monitor) ExpectDeath() {
-	atomic.AddInt32(&m.expDeaths, 1)
+	m.ExpectDeaths(1)
+}
+
+// ExpectDeaths lets the monitor know that a specific number of nodes are about
+// to be killed, and that they should be ignored.
+func (m *monitor) ExpectDeaths(count int32) {
+	atomic.AddInt32(&m.expDeaths, count)
 }
 
 func (m *monitor) Go(fn func(context.Context) error) {

--- a/pkg/cmd/roachtest/kv.go
+++ b/pkg/cmd/roachtest/kv.go
@@ -23,11 +23,7 @@ import (
 func registerKV(r *registry) {
 	runKV := func(ctx context.Context, t *test, c *cluster, percent int) {
 		if !c.isLocal() {
-			// TODO(peter): remountNoBarrier when Nathan's PR merges.
-			c.Run(ctx, c.All(),
-				"sudo", "umount", "/mnt/data1", ";",
-				"sudo", "mount", "-o", "discard,defaults,nobarrier",
-				"/dev/disk/by-id/google-local-ssd-0", "/mnt/data1")
+			c.RemountNoBarrier(ctx)
 		}
 
 		nodes := c.nodes - 1
@@ -100,10 +96,7 @@ func registerKVScalability(r *registry) {
 		nodes := c.nodes - 1
 
 		if !c.isLocal() {
-			c.Run(ctx, c.All(),
-				"sudo", "umount", "/mnt/data1", ";",
-				"sudo", "mount", "-o", "discard,defaults,nobarrier",
-				"/dev/disk/by-id/google-local-ssd-0", "/mnt/data1")
+			c.RemountNoBarrier(ctx)
 		}
 
 		c.Put(ctx, cockroach, "./cockroach", c.Range(1, nodes))

--- a/pkg/cmd/roachtest/registry.go
+++ b/pkg/cmd/roachtest/registry.go
@@ -18,7 +18,7 @@ package main
 func registerTests(r *registry) {
 	// Helpful shell pipeline to generate the list below:
 	//
-	// grep -h -E 'func register[^(]+\(.*registry\) {' *.go | grep -E -o 'register[^(]+' | grep -v '^registerTests$' | sort | awk '{printf "\t%s(r)\n", $0}'
+	// grep -h -E 'func register[^(]+\(.*registry\) {' *.go | grep -E -o 'register[^(]+' | grep -v '^registerTests$' | grep -v '^\w*Bench$' | sort | awk '{printf "\t%s(r)\n", $0}'
 
 	registerAllocator(r)
 	registerBackup(r)
@@ -44,4 +44,12 @@ func registerTests(r *registry) {
 	registerTPCC(r)
 	registerUpgrade(r)
 	registerVersion(r)
+}
+
+func registerBenchmarks(r *registry) {
+	// Helpful shell pipeline to generate the list below:
+	//
+	// grep -h -E 'func register[^(]+\(.*registry\) {' *.go | grep -E -o 'register[^(]+' | grep -v '^registerTests$' | grep '^\w*Bench$' | sort | awk '{printf "\t%s(r)\n", $0}'
+
+	registerTPCCBench(r)
 }

--- a/pkg/cmd/roachtest/scaledata.go
+++ b/pkg/cmd/roachtest/scaledata.go
@@ -90,9 +90,9 @@ func runSqlapp(ctx context.Context, t *test, c *cluster, app, flags string, dur 
 		// Kill one node at a time, with a minute of healthy cluster and thirty
 		// seconds of down node.
 		ch := Chaos{
-			Timer:    Periodic{Down: 30 * time.Second, Up: time.Minute},
-			Target:   roachNodes.randNode,
-			Duration: dur,
+			Timer:   Periodic{Down: 30 * time.Second, Up: 1 * time.Minute},
+			Target:  roachNodes.randNode,
+			Stopper: time.After(dur),
 		}
 		m.Go(ch.Runner(c, m))
 	}

--- a/pkg/cmd/roachtest/tpcc.go
+++ b/pkg/cmd/roachtest/tpcc.go
@@ -209,10 +209,7 @@ func runTPCCBench(ctx context.Context, t *test, c *cluster, b tpccBenchSpec) {
 
 	// Disable write barrier on mounted SSDs.
 	if !c.isLocal() {
-		c.Run(ctx, c.All(),
-			"sudo", "umount", "/mnt/data1", ";",
-			"sudo", "mount", "-o", "discard,defaults,nobarrier",
-			"/dev/disk/by-id/google-local-ssd-0", "/mnt/data1")
+		c.RemountNoBarrier(ctx)
 	}
 
 	c.Put(ctx, cockroach, "./cockroach", roachNodes)

--- a/pkg/cmd/roachtest/tpcc.go
+++ b/pkg/cmd/roachtest/tpcc.go
@@ -18,6 +18,14 @@ package main
 import (
 	"context"
 	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/util/color"
+	"github.com/cockroachdb/cockroach/pkg/util/search"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/pkg/errors"
 )
 
 func registerTPCC(r *registry) {
@@ -58,4 +66,323 @@ func registerTPCC(r *registry) {
 			runTPCC(ctx, t, c, 1, "")
 		},
 	})
+
+	// Run a single tpccbench spec in CI.
+	registerTPCCBenchSpec(r, tpccBenchSpec{
+		Nodes: 3,
+		CPUs:  4,
+		// TODO(m-schneider): enable when geo-distributed benchmarking is supported.
+		// Chaos: true,
+		// Geo: true,
+
+		LoadWarehouses: 1000,
+		EstimatedMax:   300,
+	})
+}
+
+type tpccBenchSpec struct {
+	Nodes int
+	CPUs  int
+	Chaos bool
+	Geo   bool
+
+	// The number of warehouses to load into the cluster before beginning
+	// benchmarking. Should be larger than EstimatedMax and should be a
+	// value that is unlikely to be achievable.
+	LoadWarehouses int
+	// An estimate of the maximum number of warehouses achievable in the
+	// cluster config. The closer this is to the actual max achievable
+	// warehouse count, the faster the benchmark will be in producing a
+	// result. This can be adjusted over time as performance characteristics
+	// change (i.e. CockroachDB gets faster!).
+	EstimatedMax int
+}
+
+func registerTPCCBenchSpec(r *registry, b tpccBenchSpec) {
+	nameParts := []string{
+		"tpccbench",
+		fmt.Sprintf("nodes=%d", b.Nodes),
+		fmt.Sprintf("cpu=%d", b.CPUs),
+	}
+	if b.Chaos {
+		nameParts = append(nameParts, "chaos")
+	}
+	if b.Geo {
+		nameParts = append(nameParts, "geo")
+	}
+	name := strings.Join(nameParts, "/")
+
+	opts := []createOption{cpu(b.CPUs)}
+	if b.Geo {
+		opts = append(opts, geo())
+	}
+	nodes := nodes(b.Nodes+1, opts...)
+
+	r.Add(testSpec{
+		Name:  name,
+		Nodes: nodes,
+		Run: func(ctx context.Context, t *test, c *cluster) {
+			runTPCCBench(ctx, t, c, b)
+		},
+	})
+}
+
+// loadTPCCBench loads a TPCC dataset for the specific benchmark spec. The
+// function is idempotent and first checks whether a compatible dataset exists,
+// performing an expensive dataset restore only if it doesn't.
+func loadTPCCBench(
+	ctx context.Context, c *cluster, roachNodes, loadNode nodeListOption, warehouses int,
+) error {
+	db := c.Conn(ctx, 1)
+	defer db.Close()
+
+	// Check if the dataset already exists and is already large enough to
+	// accommodate this benchmarking. If so, we can skip the fixture RESTORE.
+	var tableExists bool
+	if err := db.QueryRowContext(ctx, `
+		SELECT COUNT(*) > 0
+		FROM INFORMATION_SCHEMA.TABLES
+		WHERE TABLE_CATALOG = 'tpcc' AND TABLE_NAME = 'warehouse'`,
+	).Scan(&tableExists); err != nil {
+		return err
+	}
+	if tableExists {
+		var curWarehouses int
+		if err := db.QueryRowContext(ctx,
+			`SELECT COUNT(*) FROM tpcc.warehouse`,
+		).Scan(&curWarehouses); err != nil {
+			return err
+		}
+		if curWarehouses >= warehouses {
+			// The cluster has enough warehouses. Nothing to do.
+			return nil
+		}
+
+		// If the dataset exists but is not large enough, wipe the cluster
+		// before restoring.
+		c.Wipe(ctx, roachNodes)
+		c.Start(ctx, roachNodes)
+	}
+
+	// Load the corresponding fixture.
+	cmd := fmt.Sprintf(
+		"./workload fixtures load tpcc --checks=false --warehouses=%d {pgurl:1}", warehouses)
+	if err := c.RunE(ctx, loadNode, cmd); err != nil {
+		return err
+	}
+
+	// Split and scatter the tables. Set duration to 1ms so that the load
+	// generation doesn't actually run.
+	cmd = fmt.Sprintf(
+		"./workload run tpcc --warehouses=%d --split --scatter "+
+			"--duration=1ms {pgurl:1}", warehouses)
+	return c.RunE(ctx, loadNode, cmd)
+}
+
+// tpccbench is a suite of benchmarking tools that run TPC-C against CockroachDB
+// clusters in different configurations. The tools search for the maximum number
+// of warehouses that a load generator can run TPC-C against while still
+// maintaining a minimum acceptable throughput. This maximum warehouse value is
+// directly comparable to other runs of the tool in the same cluster config, and
+// expresses how well CockroachDB performance scales.
+//
+// In order to run a benchmark spec, the tool must first load a TPC-C dataset
+// large enough to accommodate it. This can take a while, so it is recommended
+// to use a combination of `--cluster=<cluster>` and `--wipe=false` flags to
+// limit the loading phase to the first run of the tool. Subsequent runs will be
+// able to avoid the dataset restore as long as they are not wiped. This allows
+// for quick iteration on experimental changes.
+//
+// It can also be useful to omit the `--cluster` flag during the first run of
+// the tool to allow roachtest to create the correct set of VMs required by the
+// test. The `--wipe` flag will prevent this cluster from being destroyed, so it
+// can then be used during future runs.
+func runTPCCBench(ctx context.Context, t *test, c *cluster, b tpccBenchSpec) {
+	if b.Geo {
+		// TODO(m-schneider): add support for geo-distributed benchmarking.
+		t.Fatal("geo-distributed benchmarking not supported")
+	}
+
+	roachNodeCount := c.nodes - 1
+	roachNodes := c.Range(1, roachNodeCount)
+	loadNode := c.Node(c.nodes)
+
+	// Disable write barrier on mounted SSDs.
+	if !c.isLocal() {
+		c.Run(ctx, c.All(),
+			"sudo", "umount", "/mnt/data1", ";",
+			"sudo", "mount", "-o", "discard,defaults,nobarrier",
+			"/dev/disk/by-id/google-local-ssd-0", "/mnt/data1")
+	}
+
+	c.Put(ctx, cockroach, "./cockroach", roachNodes)
+	c.Put(ctx, workload, "./workload", loadNode)
+	c.Start(ctx, roachNodes)
+
+	m := newMonitor(ctx, c, roachNodes)
+	m.Go(func(ctx context.Context) error {
+		t.Status("setting up dataset")
+		err := loadTPCCBench(ctx, c, roachNodes, loadNode, b.LoadWarehouses)
+		if err != nil {
+			return err
+		}
+
+		// Search between 1 and b.LoadWarehouses for the largest number of
+		// warehouses that can be operated on while sustaining a throughput
+		// threshold, set to a fraction of max tpmC.
+		precision := b.LoadWarehouses / 200
+		initStepSize := precision
+		s := search.NewLineSearcher(1, b.LoadWarehouses, b.EstimatedMax, initStepSize, precision)
+		res, err := s.Search(func(warehouses int) (bool, error) {
+			// Restart the cluster before each iteration to help eliminate
+			// inter-trial interactions.
+			m.ExpectDeaths(int32(roachNodeCount))
+			c.Stop(ctx, roachNodes)
+			c.Start(ctx, roachNodes)
+			time.Sleep(10 * time.Second)
+
+			// Set up the load geneartion configuration.
+			loadDur := 3 * time.Minute
+			loadDone := make(chan time.Time, 1)
+			extraFlags := ""
+
+			// If we're running chaos in this configuration, modify this config.
+			if b.Chaos {
+				// Increase the load generation duration.
+				loadDur = 5 * time.Minute
+				extraFlags = " --tolerate-errors"
+
+				// Kill one node at a time.
+				ch := Chaos{
+					Timer:   Periodic{Down: 1 * time.Second, Up: 90 * time.Second},
+					Target:  roachNodes.randNode,
+					Stopper: loadDone,
+				}
+				m.Go(ch.Runner(c, m))
+			}
+
+			t.Status(fmt.Sprintf("running benchmark, warehouses=%d", warehouses))
+			cmd := fmt.Sprintf("ulimit -n 32768; "+
+				"./workload run tpcc --warehouses=%d --ramp=30s --duration=%s%s {pgurl:1-%d}",
+				warehouses, loadDur, extraFlags, roachNodeCount)
+			out, err := c.RunWithBuffer(ctx, c.l, loadNode, cmd)
+			loadDone <- timeutil.Now()
+			if err != nil {
+				return false, err
+			}
+
+			// Parse the stats header and stats lines from the output.
+			str := string(out)
+			lines := strings.Split(str, "\n")
+			for i, line := range lines {
+				if strings.Contains(line, "tpmC") {
+					lines = lines[i:]
+				}
+				if i == len(lines)-1 {
+					return false, errors.Errorf("tpmC not found in output:\n\n%s\n", out)
+				}
+			}
+			headerLine, statsLine := lines[0], lines[1]
+			c.l.printf("%s\n%s\n", headerLine, statsLine)
+
+			// Parse tpmC value from stats line.
+			fields := strings.Fields(statsLine)
+			tpmC, err := strconv.ParseFloat(fields[1], 64)
+			if err != nil {
+				return false, err
+			}
+
+			// Determine the fraction of the maximum possible tpmC realized.
+			maxTpmC := 12.8 * float64(warehouses)
+			tpmCRatio := tpmC / maxTpmC
+
+			// Determine whether this means the test passed or not. We use a
+			// threshold of 85% of max tpmC as the "passing" criteria for a
+			// given number of warehouses. This does not take response latencies
+			// for different op types into account directly as required by the
+			// formal TPC-C spec, but in practice it results in stable results.
+			passRatio := 0.85
+			pass := tpmCRatio > passRatio
+
+			// Print the result.
+			color.Stdout(color.Green)
+			passStr := "PASS"
+			if !pass {
+				color.Stdout(color.Red)
+				passStr = "FAIL"
+			}
+			c.l.printf("--- %s: tpcc %d resulted in %.1f tpmC (%.1f%% of max tpmC)\n\n",
+				passStr, warehouses, tpmC, tpmCRatio*100)
+			color.Stdout(color.Reset)
+
+			return pass, nil
+		})
+		if err != nil {
+			return err
+		}
+
+		color.Stdout(color.Green)
+		c.l.printf("------\nMAX WAREHOUSES = %d\n------\n\n", res)
+		color.Stdout(color.Reset)
+		return nil
+	})
+	m.Wait()
+	c.Stop(ctx, c.All())
+}
+
+func registerTPCCBench(r *registry) {
+	specs := []tpccBenchSpec{
+		{
+			Nodes: 3,
+			CPUs:  4,
+
+			LoadWarehouses: 1000,
+			EstimatedMax:   325,
+		},
+		{
+			Nodes: 3,
+			CPUs:  16,
+
+			LoadWarehouses: 2000,
+			EstimatedMax:   1300,
+		},
+		// objective 1, key result 1 & 2.
+		{
+			Nodes: 18,
+			CPUs:  16,
+
+			LoadWarehouses: 10000,
+			EstimatedMax:   5300,
+		},
+		// objective 2, key result 1.
+		{
+			Nodes: 7,
+			CPUs:  16,
+			Chaos: true,
+
+			LoadWarehouses: 5000,
+			EstimatedMax:   500,
+		},
+		// objective 3, key result 2.
+		{
+			Nodes: 9,
+			CPUs:  16,
+			Geo:   true,
+
+			LoadWarehouses: 5000,
+			EstimatedMax:   2000,
+		},
+		// objective 4, key result 2.
+		{
+			Nodes: 64,
+			CPUs:  16,
+
+			LoadWarehouses: 50000,
+			EstimatedMax:   40000,
+		},
+	}
+
+	for _, b := range specs {
+		registerTPCCBenchSpec(r, b)
+	}
 }

--- a/pkg/util/color/color.go
+++ b/pkg/util/color/color.go
@@ -57,9 +57,14 @@ type Code int
 
 // Color codes.
 const (
-	Red Code = iota
+	Black Code = iota
+	Red
+	Green
 	Yellow
+	Blue
+	Magenta
 	Cyan
+	White
 	Gray
 	Reset
 )
@@ -71,21 +76,31 @@ type Profile map[Code][]byte
 // For terminals with 8-color support.
 var profile8 = Profile{
 	// Keep these in the same order as the color codes above.
-	Red:    []byte("\033[0;31;49m"),
-	Yellow: []byte("\033[0;33;49m"),
-	Cyan:   []byte("\033[0;36;49m"),
-	Gray:   []byte("\033[2;37;49m"),
-	Reset:  []byte("\033[0m"),
+	Black:   []byte("\033[0;30;49m"),
+	Red:     []byte("\033[0;31;49m"),
+	Green:   []byte("\033[0;32;49m"),
+	Yellow:  []byte("\033[0;33;49m"),
+	Blue:    []byte("\033[0;34;49m"),
+	Magenta: []byte("\033[0;35;49m"),
+	Cyan:    []byte("\033[0;36;49m"),
+	White:   []byte("\033[0;37;49m"),
+	Gray:    []byte("\033[2;37;49m"),
+	Reset:   []byte("\033[0m"),
 }
 
 // For terminals with 256-color support.
 var profile256 = Profile{
 	// Keep these in the same order as the color codes above.
-	Red:    []byte("\033[38;5;160m"),
-	Yellow: []byte("\033[38;5;214m"),
-	Cyan:   []byte("\033[38;5;33m"),
-	Gray:   []byte("\033[38;5;246m"),
-	Reset:  []byte("\033[0m"),
+	Black:   []byte("\033[38;5;0m"),
+	Red:     []byte("\033[38;5;160m"),
+	Green:   []byte("\033[38;5;2m"),
+	Yellow:  []byte("\033[38;5;214m"),
+	Blue:    []byte("\033[38;5;4m"),
+	Magenta: []byte("\033[38;5;5m"),
+	Cyan:    []byte("\033[38;5;33m"),
+	White:   []byte("\033[38;5;315"),
+	Gray:    []byte("\033[38;5;246m"),
+	Reset:   []byte("\033[0m"),
 }
 
 // Stdout sets the color for future output to os.Stdout.

--- a/pkg/util/search/search.go
+++ b/pkg/util/search/search.go
@@ -1,0 +1,236 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package search
+
+import "github.com/pkg/errors"
+
+// A Predicate is a funcation that returns whether a given search value "passes"
+// or not. It assumes that that within the search domain of [min, max) provided
+// to a Searcher, f(i) == true implies f(i-1) == true and f(i) == false implies
+// f(i+1) == false. A Predicate can be called multiple times, so it should be
+// a pure function.
+type Predicate func(int) (bool, error)
+
+// A Searcher searches to find the largest value that passes a given predicate
+// function.
+type Searcher interface {
+	// Search runs the predicate function multiple times while searching for the
+	// largest value that passes the provided predicate function. It is only
+	// valid to call Search once for a given Searcher instance.
+	Search(pred Predicate) (res int, err error)
+
+	// The following two methods are un-exported and are used by
+	// searchWithSearcher to provide a default implementation of Search.
+
+	// current returns the current value of the Searcher.
+	current() int
+
+	// step updates the Searcher with the results of a single search step.
+	step(pass bool) (found bool)
+}
+
+// Used to provide a default implementation of Searcher.Search.
+func searchWithSearcher(s Searcher, pred Predicate) (int, error) {
+	for {
+		pass, err := pred(s.current())
+		if err != nil {
+			return 0, err
+		}
+		found := s.step(pass)
+		if found {
+			return s.current(), nil
+		}
+	}
+}
+
+type searchSpace struct {
+	min int // max known passing
+	max int // min known failing
+}
+
+func (ss *searchSpace) bound(pass bool, cur, prec int) (bool, int) {
+	if prec < 1 {
+		panic(errors.Errorf("precision must be >= 1; found %d", prec))
+	}
+	if pass {
+		if cur >= ss.max {
+			panic(errors.Errorf("passed at index above max; max=%v, cur=%v", ss.max, cur))
+		}
+		ss.min = cur
+	} else {
+		if cur <= ss.min {
+			panic(errors.Errorf("failed at index below min; min=%v, cur=%v", ss.min, cur))
+		}
+		ss.max = cur
+	}
+	if ss.max-ss.min <= prec {
+		return true, mid(ss.min, ss.max)
+	}
+	return false, 0
+}
+
+type binarySearcher struct {
+	ss   searchSpace
+	cur  int
+	prec int
+}
+
+// NewBinarySearcher returns a Searcher implementing a binary search strategy.
+// Running the search predicate at min is assumed to pass and running the
+// predicate at max is assumed to fail.
+//
+// While searching, it will result in a worst case and average case of O(log n)
+// calls to the predicate function.
+func NewBinarySearcher(min, max, prec int) Searcher {
+	if min >= max {
+		panic(errors.Errorf("min must be less than max; min=%v, max=%v", min, max))
+	}
+	if prec < 1 {
+		panic(errors.Errorf("precision must be >= 1; prec=%v", prec))
+	}
+	return &binarySearcher{
+		ss: searchSpace{
+			min: min,
+			max: max,
+		},
+		cur:  mid(min, max),
+		prec: prec,
+	}
+}
+
+func (bs *binarySearcher) Search(pred Predicate) (int, error) {
+	return searchWithSearcher(bs, pred)
+}
+
+func (bs *binarySearcher) current() int { return bs.cur }
+
+func (bs *binarySearcher) step(pass bool) (found bool) {
+	found, val := bs.ss.bound(pass, bs.cur, bs.prec)
+	if found {
+		bs.cur = val
+		return true
+	}
+
+	bs.cur = mid(bs.ss.min, bs.ss.max)
+	return false
+}
+
+type lineSearcher struct {
+	ss        searchSpace
+	cur       int
+	stepSize  int
+	firstStep bool
+	overshot  bool
+	prec      int
+}
+
+// NewLineSearcher returns a Searcher implementing a line search strategy with
+// an adaptive step size. Running the search predicate at min is assumed to pass
+// and running the predicate at max is assumed to fail. The strategy will begin
+// searching at the provided start index and with the specified step size.
+//
+// While searching, it will result in a worst case of O(log n) calls to the
+// predicate function. However, the average efficiency is dependent on the
+// distance between the starting value and the desired value. If the initial
+// guess is fairly accurate, the search strategy is expected to perform better
+// (i.e. result in fewer steps) than performing a binary search with no a priori
+// knowledge.
+func NewLineSearcher(min, max, start, stepSize, prec int) Searcher {
+	if min >= max {
+		panic(errors.Errorf("min must be less than max; min=%v, max=%v", min, max))
+	}
+	if start < min || start > max {
+		panic(errors.Errorf("start must be between (min, max); start=%v, min=%v, max=%v",
+			start, min, max))
+	}
+	if stepSize < 1 {
+		panic(errors.Errorf("stepSize must be >= 1; stepSize=%v", stepSize))
+	}
+	if prec < 1 {
+		panic(errors.Errorf("precision must be >= 1; prec=%v", prec))
+	}
+	return &lineSearcher{
+		ss: searchSpace{
+			min: min,
+			max: max,
+		},
+		cur:       start,
+		stepSize:  stepSize,
+		firstStep: true,
+		prec:      prec,
+	}
+}
+
+func (ls *lineSearcher) Search(pred Predicate) (int, error) {
+	return searchWithSearcher(ls, pred)
+}
+
+func (ls *lineSearcher) current() int { return ls.cur }
+
+func (ls *lineSearcher) step(pass bool) (found bool) {
+	found, val := ls.ss.bound(pass, ls.cur, ls.prec)
+	if found {
+		ls.cur = val
+		return true
+	}
+
+	neg := 1
+	if !pass {
+		neg = -1
+	}
+	if ls.firstStep {
+		// First step. Determine initial direction.
+		ls.firstStep = false
+		ls.stepSize = neg * ls.stepSize
+	} else if neg*ls.stepSize < 0 {
+		// Overshot. Reverse and decrease step size.
+		ls.overshot = true
+		ls.stepSize = -ls.stepSize / 2
+	} else {
+		// Undershot.
+		if ls.overshot {
+			// Already overshot. Continue decreasing step size.
+			ls.stepSize /= 2
+		} else {
+			// Haven't yet overshot. Increase step size.
+			ls.stepSize *= 2
+		}
+	}
+
+	// Don't exceed bounds.
+	minStep := ls.ss.min - ls.cur + 1
+	maxStep := ls.ss.max - ls.cur - 1
+	ls.stepSize = max(min(ls.stepSize, maxStep), minStep)
+	ls.cur = ls.cur + ls.stepSize
+	return false
+}
+
+func mid(a, b int) int {
+	return (a + b) / 2
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func max(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}

--- a/pkg/util/search/search_test.go
+++ b/pkg/util/search/search_test.go
@@ -1,0 +1,354 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package search
+
+import (
+	"math/rand"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/stretchr/testify/require"
+)
+
+const pass = true
+const fail = false
+
+func TestSearchSpace(t *testing.T) {
+	t.Run("fromBelow", func(t *testing.T) {
+		ss := searchSpace{min: 0, max: 10}
+
+		found, _ := ss.bound(fail, 8, 3)
+		require.False(t, found)
+		require.Equal(t, ss.min, 0)
+		require.Equal(t, ss.max, 8)
+
+		found, _ = ss.bound(pass, 4, 3)
+		require.False(t, found)
+		require.Equal(t, ss.min, 4)
+		require.Equal(t, ss.max, 8)
+
+		found, val := ss.bound(pass, 5, 3)
+		require.True(t, found)
+		require.Equal(t, val, 6)
+		require.Equal(t, ss.min, 5)
+		require.Equal(t, ss.max, 8)
+
+		found, val = ss.bound(pass, 6, 3)
+		require.True(t, found)
+		require.Equal(t, val, 7)
+		require.Equal(t, ss.min, 6)
+		require.Equal(t, ss.max, 8)
+	})
+
+	t.Run("fromAbove", func(t *testing.T) {
+		ss := searchSpace{min: 0, max: 10}
+
+		found, _ := ss.bound(pass, 4, 3)
+		require.False(t, found)
+		require.Equal(t, ss.min, 4)
+		require.Equal(t, ss.max, 10)
+
+		found, _ = ss.bound(fail, 8, 3)
+		require.False(t, found)
+		require.Equal(t, ss.min, 4)
+		require.Equal(t, ss.max, 8)
+
+		found, val := ss.bound(fail, 7, 3)
+		require.True(t, found)
+		require.Equal(t, val, 5)
+		require.Equal(t, ss.min, 4)
+		require.Equal(t, ss.max, 7)
+
+		found, val = ss.bound(pass, 6, 3)
+		require.True(t, found)
+		require.Equal(t, val, 6)
+		require.Equal(t, ss.min, 6)
+		require.Equal(t, ss.max, 7)
+	})
+
+	t.Run("lowPrec", func(t *testing.T) {
+		ss := searchSpace{min: 0, max: 10}
+
+		found, _ := ss.bound(fail, 8, 1)
+		require.False(t, found)
+		require.Equal(t, ss.min, 0)
+		require.Equal(t, ss.max, 8)
+
+		found, _ = ss.bound(fail, 3, 1)
+		require.False(t, found)
+		require.Equal(t, ss.min, 0)
+		require.Equal(t, ss.max, 3)
+
+		found, _ = ss.bound(pass, 1, 1)
+		require.False(t, found)
+		require.Equal(t, ss.min, 1)
+		require.Equal(t, ss.max, 3)
+
+		found, val := ss.bound(pass, 2, 1)
+		require.True(t, found)
+		require.Equal(t, val, 2)
+		require.Equal(t, ss.min, 2)
+		require.Equal(t, ss.max, 3)
+	})
+
+	t.Run("minimum", func(t *testing.T) {
+		ss := searchSpace{min: 0, max: 10}
+
+		found, _ := ss.bound(fail, 8, 3)
+		require.False(t, found)
+		require.Equal(t, ss.min, 0)
+		require.Equal(t, ss.max, 8)
+
+		found, val := ss.bound(fail, 3, 3)
+		require.True(t, found)
+		require.Equal(t, val, 1)
+		require.Equal(t, ss.min, 0)
+		require.Equal(t, ss.max, 3)
+	})
+
+	t.Run("minimumLowPrec", func(t *testing.T) {
+		ss := searchSpace{min: 0, max: 10}
+
+		found, _ := ss.bound(fail, 8, 1)
+		require.False(t, found)
+		require.Equal(t, ss.min, 0)
+		require.Equal(t, ss.max, 8)
+
+		found, _ = ss.bound(fail, 3, 1)
+		require.False(t, found)
+		require.Equal(t, ss.min, 0)
+		require.Equal(t, ss.max, 3)
+
+		found, val := ss.bound(fail, 1, 1)
+		require.True(t, found)
+		require.Equal(t, val, 0)
+		require.Equal(t, ss.min, 0)
+		require.Equal(t, ss.max, 1)
+	})
+
+	t.Run("maximum", func(t *testing.T) {
+		ss := searchSpace{min: 0, max: 10}
+
+		found, _ := ss.bound(pass, 4, 3)
+		require.False(t, found)
+		require.Equal(t, ss.min, 4)
+		require.Equal(t, ss.max, 10)
+
+		found, val := ss.bound(pass, 8, 3)
+		require.True(t, found)
+		require.Equal(t, val, 9)
+		require.Equal(t, ss.min, 8)
+		require.Equal(t, ss.max, 10)
+	})
+
+	t.Run("maximumLowPrec", func(t *testing.T) {
+		ss := searchSpace{min: 0, max: 10}
+
+		found, _ := ss.bound(pass, 4, 1)
+		require.False(t, found)
+		require.Equal(t, ss.min, 4)
+		require.Equal(t, ss.max, 10)
+
+		found, _ = ss.bound(pass, 8, 1)
+		require.False(t, found)
+		require.Equal(t, ss.min, 8)
+		require.Equal(t, ss.max, 10)
+
+		found, val := ss.bound(pass, 9, 1)
+		require.True(t, found)
+		require.Equal(t, val, 9)
+		require.Equal(t, ss.min, 9)
+		require.Equal(t, ss.max, 10)
+	})
+
+	// Error cases.
+	t.Run("errors", func(t *testing.T) {
+		ss := searchSpace{min: 0, max: 10}
+
+		found, _ := ss.bound(pass, 4, 1)
+		require.False(t, found)
+
+		found, _ = ss.bound(fail, 8, 1)
+		require.False(t, found)
+
+		require.Panics(t, func() { ss.bound(pass, 5, 0) })  // non-positive prec
+		require.Panics(t, func() { ss.bound(fail, 1, 1) })  // below bound failure
+		require.Panics(t, func() { ss.bound(pass, 10, 1) }) // above bound success
+	})
+}
+
+func TestBinarySearcher(t *testing.T) {
+	// Looking for 66.
+	bs := NewBinarySearcher(0, 100, 1)
+	require.Equal(t, bs.current(), 50)
+
+	require.Equal(t, bs.step(pass), false)
+	require.Equal(t, bs.current(), 75)
+
+	require.Equal(t, bs.step(fail), false)
+	require.Equal(t, bs.current(), 62)
+
+	require.Equal(t, bs.step(pass), false)
+	require.Equal(t, bs.current(), 68)
+
+	require.Equal(t, bs.step(fail), false)
+	require.Equal(t, bs.current(), 65)
+
+	require.Equal(t, bs.step(pass), false)
+	require.Equal(t, bs.current(), 66)
+
+	require.Equal(t, bs.step(pass), false)
+	require.Equal(t, bs.current(), 67)
+
+	require.Equal(t, bs.step(fail), true)
+	require.Equal(t, bs.current(), 66)
+
+	// Looking for 25. Should result in 26 because of precision.
+	bs = NewBinarySearcher(0, 100, 3)
+	res, err := bs.Search(func(i int) (bool, error) {
+		return i <= 25, nil
+	})
+	require.Nil(t, err)
+	require.Equal(t, res, 26)
+
+	// Looking for 25. Should result in 25 because of precision.
+	bs = NewBinarySearcher(0, 100, 1)
+	res, err = bs.Search(func(i int) (bool, error) {
+		return i <= 25, nil
+	})
+	require.Nil(t, err)
+	require.Equal(t, res, 25)
+}
+
+func TestLineSearcher(t *testing.T) {
+	// Looking for 66.
+	ls := NewLineSearcher(0, 100, 20 /* start */, 2 /* stepSize */, 1)
+	require.Equal(t, ls.current(), 20)
+
+	require.Equal(t, ls.step(pass), false)
+	require.Equal(t, ls.current(), 22)
+
+	require.Equal(t, ls.step(pass), false)
+	require.Equal(t, ls.current(), 26)
+
+	require.Equal(t, ls.step(pass), false)
+	require.Equal(t, ls.current(), 34)
+
+	require.Equal(t, ls.step(pass), false)
+	require.Equal(t, ls.current(), 50)
+
+	require.Equal(t, ls.step(pass), false)
+	require.Equal(t, ls.current(), 82)
+
+	require.Equal(t, ls.step(fail), false)
+	require.Equal(t, ls.current(), 66)
+
+	require.Equal(t, ls.step(pass), false)
+	require.Equal(t, ls.current(), 74)
+
+	require.Equal(t, ls.step(fail), false)
+	require.Equal(t, ls.current(), 70)
+
+	require.Equal(t, ls.step(fail), false)
+	require.Equal(t, ls.current(), 68)
+
+	require.Equal(t, ls.step(fail), false)
+	require.Equal(t, ls.current(), 67)
+
+	require.Equal(t, ls.step(fail), true)
+	require.Equal(t, ls.current(), 66)
+
+	// Looking for 9.
+	ls = NewLineSearcher(0, 100, 71 /* start */, 4 /* stepSize */, 2)
+	require.Equal(t, ls.current(), 71)
+
+	require.Equal(t, ls.step(fail), false)
+	require.Equal(t, ls.current(), 67)
+
+	require.Equal(t, ls.step(fail), false)
+	require.Equal(t, ls.current(), 59)
+
+	require.Equal(t, ls.step(fail), false)
+	require.Equal(t, ls.current(), 43)
+
+	require.Equal(t, ls.step(fail), false)
+	require.Equal(t, ls.current(), 11)
+
+	require.Equal(t, ls.step(fail), false)
+	require.Equal(t, ls.current(), 1)
+
+	require.Equal(t, ls.step(pass), false)
+	require.Equal(t, ls.current(), 6)
+
+	require.Equal(t, ls.step(pass), false)
+	require.Equal(t, ls.current(), 8)
+
+	require.Equal(t, ls.step(pass), false)
+	require.Equal(t, ls.current(), 9)
+
+	require.Equal(t, ls.step(pass), true)
+	require.Equal(t, ls.current(), 10)
+
+	// Looking for 25. Should result in 26 because of precision.
+	ls = NewLineSearcher(0, 100, 67 /* start */, 2 /* stepSize */, 3)
+	res, err := ls.Search(func(i int) (bool, error) {
+		return i <= 25, nil
+	})
+	require.Nil(t, err)
+	require.Equal(t, res, 26)
+
+	// Looking for 25. Should result in 25 because of precision.
+	ls = NewLineSearcher(0, 100, 92 /* start */, 2 /* stepSize */, 1)
+	res, err = ls.Search(func(i int) (bool, error) {
+		return i <= 25, nil
+	})
+	require.Nil(t, err)
+	require.Equal(t, res, 25)
+}
+
+func TestIdenticalSearchers(t *testing.T) {
+	const prec = 1
+	rng := rand.New(rand.NewSource(timeutil.Now().UnixNano()))
+
+	searcherFns := []func(min, max int) Searcher{
+		func(min, max int) Searcher { return NewBinarySearcher(min, max, prec) },
+		func(min, max int) Searcher { return NewLineSearcher(min, max, mid(min, max), 4, prec) },
+	}
+
+	const trials = 100
+	for tr := 0; tr < trials; tr++ {
+		min := int(rng.Int31())
+		max := int(rng.Int31())
+		if min == max {
+			continue
+		}
+		if min > max {
+			min, max = max, min
+		}
+
+		toFind := rng.Intn(max-min) + min
+		pred := func(i int) (bool, error) {
+			return i <= toFind, nil
+		}
+
+		for _, fn := range searcherFns {
+			s := fn(min, max)
+			val, err := s.Search(pred)
+			require.Nil(t, err)
+			require.Equal(t, val, toFind, "searching with %T in range [%d,%d)", s, min, max)
+		}
+
+	}
+}


### PR DESCRIPTION
Closes #25084.

This change creates a new `tpccbench` roachtest specifically for
the purpose of benchmarking TPC-C. The test spins up a cluster (if
not provided a `--cluster` flag), restores a TPC-C dataset (if not
run on an existing cluster with `--wipe=false` specified), and
benchmarks the cluster's ability to scale under an increasing number
of TPC-C warehouses. Specifically, it uses a line search algorithm
to efficiently search for the maximum number of warehouses that can
be operated on while sustaining a throughput threshold, which is set
to a fraction of max tpmC for that warehouse count.

@a-robinson I pushed this WIP change so that you and others can
play around with it and give feedback on its approach and ergonomics.

cc. @jordanlewis I'd love to hear your thoughts on the early draft of this
tool and if you have any suggestions for how it can be improved or made
more useful.

Release note: None