### PR TITLE
cmd/roachtest: add "stable" tag to tests

### DIFF
--- a/pkg/cmd/roachtest/allocator.go
+++ b/pkg/cmd/roachtest/allocator.go
@@ -76,15 +76,17 @@ func registerAllocator(r *registry) {
 	}
 
 	r.Add(testSpec{
-		Name:  `upreplicate/1to3`,
-		Nodes: nodes(3),
+		Name:   `upreplicate/1to3`,
+		Nodes:  nodes(3),
+		Stable: true, // DO NOT COPY to new tests
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			runAllocator(ctx, t, c, 1, 10.0)
 		},
 	})
 	r.Add(testSpec{
-		Name:  `rebalance/3to5`,
-		Nodes: nodes(5),
+		Name:   `rebalance/3to5`,
+		Nodes:  nodes(5),
+		Stable: true, // DO NOT COPY to new tests
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			runAllocator(ctx, t, c, 3, 42.0)
 		},

--- a/pkg/cmd/roachtest/cancel.go
+++ b/pkg/cmd/roachtest/cancel.go
@@ -117,16 +117,18 @@ func registerCancel(r *registry) {
 	}
 
 	r.Add(testSpec{
-		Name:  fmt.Sprintf("cancel/tpcc/distsql/w=%d,nodes=%d", warehouses, numNodes),
-		Nodes: nodes(numNodes),
+		Name:   fmt.Sprintf("cancel/tpcc/distsql/w=%d,nodes=%d", warehouses, numNodes),
+		Nodes:  nodes(numNodes),
+		Stable: true, // DO NOT COPY to new tests
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			runCancel(ctx, t, c, queries, warehouses, true /* useDistsql */)
 		},
 	})
 
 	r.Add(testSpec{
-		Name:  fmt.Sprintf("cancel/tpcc/local/w=%d,nodes=%d", warehouses, numNodes),
-		Nodes: nodes(numNodes),
+		Name:   fmt.Sprintf("cancel/tpcc/local/w=%d,nodes=%d", warehouses, numNodes),
+		Nodes:  nodes(numNodes),
+		Stable: true, // DO NOT COPY to new tests
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			runCancel(ctx, t, c, queries, warehouses, false /* useDistsql */)
 		},

--- a/pkg/cmd/roachtest/clock_jump_crash.go
+++ b/pkg/cmd/roachtest/clock_jump_crash.go
@@ -115,8 +115,9 @@ func registerClockJump(r *registry) {
 	for i := range testCases {
 		tc := testCases[i]
 		r.Add(testSpec{
-			Name:  fmt.Sprintf("clockjump/tc=%s", tc.name),
-			Nodes: nodes(numNodes),
+			Name:   fmt.Sprintf("clockjump/tc=%s", tc.name),
+			Nodes:  nodes(numNodes),
+			Stable: true, // DO NOT COPY to new tests
 			Run: func(ctx context.Context, t *test, c *cluster) {
 				runClockJump(t, c, tc)
 			},

--- a/pkg/cmd/roachtest/clock_monotonic.go
+++ b/pkg/cmd/roachtest/clock_monotonic.go
@@ -128,8 +128,9 @@ func registerClockMonotonicity(r *registry) {
 	for i := range testCases {
 		tc := testCases[i]
 		r.Add(testSpec{
-			Name:  fmt.Sprintf("clockmonotonic/tc=%s", tc.name),
-			Nodes: nodes(numNodes),
+			Name:   fmt.Sprintf("clockmonotonic/tc=%s", tc.name),
+			Nodes:  nodes(numNodes),
+			Stable: true, // DO NOT COPY to new tests
 			Run: func(ctx context.Context, t *test, c *cluster) {
 				runClockMonotonicity(t, c, tc)
 			},

--- a/pkg/cmd/roachtest/copy.go
+++ b/pkg/cmd/roachtest/copy.go
@@ -139,8 +139,9 @@ func registerCopy(r *registry) {
 	for _, inTxn := range []bool{true, false} {
 		inTxn := inTxn
 		r.Add(testSpec{
-			Name:  fmt.Sprintf("copy/bank/rows=%d,nodes=%d,txn=%t", rows, numNodes, inTxn),
-			Nodes: nodes(numNodes),
+			Name:   fmt.Sprintf("copy/bank/rows=%d,nodes=%d,txn=%t", rows, numNodes, inTxn),
+			Nodes:  nodes(numNodes),
+			Stable: true, // DO NOT COPY to new tests
 			Run: func(ctx context.Context, t *test, c *cluster) {
 				runCopy(ctx, t, c, rows, inTxn)
 			},

--- a/pkg/cmd/roachtest/debug.go
+++ b/pkg/cmd/roachtest/debug.go
@@ -83,8 +83,9 @@ func registerDebug(r *registry) {
 
 	for _, n := range []int{3} {
 		r.Add(testSpec{
-			Name:  fmt.Sprintf("debug/nodes=%d", n),
-			Nodes: nodes(n),
+			Name:   fmt.Sprintf("debug/nodes=%d", n),
+			Nodes:  nodes(n),
+			Stable: true, // DO NOT COPY to new tests
 			Run: func(ctx context.Context, t *test, c *cluster) {
 				runDebug(ctx, t, c)
 			},

--- a/pkg/cmd/roachtest/decommission.go
+++ b/pkg/cmd/roachtest/decommission.go
@@ -223,8 +223,9 @@ func registerDecommission(r *registry) {
 	duration := time.Hour
 
 	r.Add(testSpec{
-		Name:  fmt.Sprintf("decommission/nodes=%d/duration=%s", numNodes, duration),
-		Nodes: nodes(numNodes),
+		Name:   fmt.Sprintf("decommission/nodes=%d/duration=%s", numNodes, duration),
+		Nodes:  nodes(numNodes),
+		Stable: true, // DO NOT COPY to new tests
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			if local {
 				duration = 3 * time.Minute

--- a/pkg/cmd/roachtest/drop.go
+++ b/pkg/cmd/roachtest/drop.go
@@ -166,8 +166,9 @@ gc:
 	initDiskSpace := int(1E9)
 
 	r.Add(testSpec{
-		Name:  fmt.Sprintf("drop/tpcc/w=%d,nodes=%d", warehouses, numNodes),
-		Nodes: nodes(numNodes),
+		Name:   fmt.Sprintf("drop/tpcc/w=%d,nodes=%d", warehouses, numNodes),
+		Nodes:  nodes(numNodes),
+		Stable: true, // DO NOT COPY to new tests
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			// NB: this is likely not going to work out in `-local` mode. Edit the
 			// numbers during iteration.

--- a/pkg/cmd/roachtest/hotspotsplits.go
+++ b/pkg/cmd/roachtest/hotspotsplits.go
@@ -111,6 +111,7 @@ func registerHotSpotSplits(r *registry) {
 		SkippedBecause: "https://github.com/cockroachdb/cockroach/issues/25036",
 		Name:           fmt.Sprintf("hotspotsplits/nodes=%d", numNodes),
 		Nodes:          nodes(numNodes),
+		Stable:         true, // DO NOT COPY to new tests
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			if local {
 				concurrency = 50

--- a/pkg/cmd/roachtest/import.go
+++ b/pkg/cmd/roachtest/import.go
@@ -59,8 +59,9 @@ func registerImportTPCC(r *registry) {
 func registerImportTPCH(r *registry) {
 	for _, n := range []int{4, 8} {
 		r.Add(testSpec{
-			Name:  fmt.Sprintf(`import/tpch/nodes=%d`, n),
-			Nodes: nodes(n),
+			Name:   fmt.Sprintf(`import/tpch/nodes=%d`, n),
+			Nodes:  nodes(n),
+			Stable: true, // DO NOT COPY to new tests
 			Run: func(ctx context.Context, t *test, c *cluster) {
 				c.Put(ctx, cockroach, "./cockroach")
 				c.Start(ctx)

--- a/pkg/cmd/roachtest/kv.go
+++ b/pkg/cmd/roachtest/kv.go
@@ -47,8 +47,9 @@ func registerKV(r *registry) {
 		p := p
 		for _, n := range []int{1, 3} {
 			r.Add(testSpec{
-				Name:  fmt.Sprintf("kv%d/nodes=%d", p, n),
-				Nodes: nodes(n + 1),
+				Name:   fmt.Sprintf("kv%d/nodes=%d", p, n),
+				Nodes:  nodes(n + 1),
+				Stable: true, // DO NOT COPY to new tests
 				Run: func(ctx context.Context, t *test, c *cluster) {
 					runKV(ctx, t, c, p)
 				},
@@ -59,8 +60,9 @@ func registerKV(r *registry) {
 
 func registerKVSplits(r *registry) {
 	r.Add(testSpec{
-		Name:  "kv/splits/nodes=3",
-		Nodes: nodes(4),
+		Name:   "kv/splits/nodes=3",
+		Nodes:  nodes(4),
+		Stable: true, // DO NOT COPY to new tests
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			nodes := c.nodes - 1
 			c.Put(ctx, cockroach, "./cockroach", c.Range(1, nodes))

--- a/pkg/cmd/roachtest/large_range.go
+++ b/pkg/cmd/roachtest/large_range.go
@@ -38,8 +38,9 @@ func registerLargeRange(r *registry) {
 	const numNodes = 3
 
 	r.Add(testSpec{
-		Name:  fmt.Sprintf("largerange/splits/size=%s,nodes=%d", bytesStr(size), numNodes),
-		Nodes: nodes(numNodes),
+		Name:   fmt.Sprintf("largerange/splits/size=%s,nodes=%d", bytesStr(size), numNodes),
+		Nodes:  nodes(numNodes),
+		Stable: true, // DO NOT COPY to new tests
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			runLargeRangeSplits(ctx, t, c, size)
 		},

--- a/pkg/cmd/roachtest/restore.go
+++ b/pkg/cmd/roachtest/restore.go
@@ -21,8 +21,9 @@ import (
 
 func registerRestore(r *registry) {
 	r.Add(testSpec{
-		Name:  `restore2TB`,
-		Nodes: nodes(10),
+		Name:   `restore2TB`,
+		Nodes:  nodes(10),
+		Stable: true, // DO NOT COPY to new tests
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			c.Put(ctx, cockroach, "./cockroach")
 			c.Start(ctx)

--- a/pkg/cmd/roachtest/roachmart.go
+++ b/pkg/cmd/roachtest/roachmart.go
@@ -74,8 +74,9 @@ func registerRoachmart(r *registry) {
 	for _, v := range []bool{true, false} {
 		v := v
 		r.Add(testSpec{
-			Name:  fmt.Sprintf("roachmart/partition=%v", v),
-			Nodes: nodes(9, geo()),
+			Name:   fmt.Sprintf("roachmart/partition=%v", v),
+			Nodes:  nodes(9, geo()),
+			Stable: true, // DO NOT COPY to new tests
 			Run: func(ctx context.Context, t *test, c *cluster) {
 				runRoachmart(ctx, t, c, v)
 			},

--- a/pkg/cmd/roachtest/scaledata.go
+++ b/pkg/cmd/roachtest/scaledata.go
@@ -47,8 +47,9 @@ func registerScaleData(r *registry) {
 		const duration = 10 * time.Minute
 		for _, n := range []int{3, 6} {
 			r.Add(testSpec{
-				Name:  fmt.Sprintf("scaledata/%s/nodes=%d", app, n),
-				Nodes: nodes(n + 1),
+				Name:   fmt.Sprintf("scaledata/%s/nodes=%d", app, n),
+				Nodes:  nodes(n + 1),
+				Stable: true, // DO NOT COPY to new tests
 				Run: func(ctx context.Context, t *test, c *cluster) {
 					runSqlapp(ctx, t, c, app, flags, duration)
 				},

--- a/pkg/cmd/roachtest/schemachange.go
+++ b/pkg/cmd/roachtest/schemachange.go
@@ -27,8 +27,9 @@ import (
 
 func registerSchemaChange(r *registry) {
 	r.Add(testSpec{
-		Name:  `schemachange`,
-		Nodes: nodes(5),
+		Name:   `schemachange`,
+		Nodes:  nodes(5),
+		Stable: true, // DO NOT COPY to new tests
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			const fixturePath = `gs://cockroach-fixtures/workload/tpch/scalefactor=10/backup`
 

--- a/pkg/cmd/roachtest/test_test.go
+++ b/pkg/cmd/roachtest/test_test.go
@@ -34,12 +34,21 @@ func TestRegistryRun(t *testing.T) {
 	r := newRegistry()
 	r.out = ioutil.Discard
 	r.Add(testSpec{
-		Name: "pass",
+		Name:   "pass",
+		Stable: true,
 		Run: func(ctx context.Context, t *test, c *cluster) {
 		},
 	})
 	r.Add(testSpec{
-		Name: "fail",
+		Name:   "fail",
+		Stable: true,
+		Run: func(ctx context.Context, t *test, c *cluster) {
+			t.Fatal("failed")
+		},
+	})
+	r.Add(testSpec{
+		Name:   "fail-unstable",
+		Stable: false,
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			t.Fatal("failed")
 		},
@@ -52,6 +61,7 @@ func TestRegistryRun(t *testing.T) {
 		{nil, 1},
 		{[]string{"pass"}, 0},
 		{[]string{"fail"}, 1},
+		{[]string{"fail-unstable"}, 0},
 		{[]string{"pass|fail"}, 1},
 		{[]string{"pass", "fail"}, 1},
 	}
@@ -91,7 +101,8 @@ func TestRegistryStatus(t *testing.T) {
 	r.out = &buf
 	r.statusInterval = 20 * time.Millisecond
 	r.Add(testSpec{
-		Name: `status`,
+		Name:   `status`,
+		Stable: true,
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			t.Status("waiting")
 			var wg sync.WaitGroup
@@ -144,7 +155,8 @@ func TestRegistryStatusUnknown(t *testing.T) {
 	r.statusInterval = 20 * time.Millisecond
 
 	r.Add(testSpec{
-		Name: `status`,
+		Name:   `status`,
+		Stable: true,
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			for i := 0; i < 100; i++ {
 				time.Sleep(r.statusInterval)

--- a/pkg/cmd/roachtest/tpcc.go
+++ b/pkg/cmd/roachtest/tpcc.go
@@ -43,15 +43,17 @@ func registerTPCC(r *registry) {
 	}
 
 	r.Add(testSpec{
-		Name:  "tpcc/w=1/nodes=3",
-		Nodes: nodes(4),
+		Name:   "tpcc/w=1/nodes=3",
+		Nodes:  nodes(4),
+		Stable: true, // DO NOT COPY to new tests
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			runTPCC(ctx, t, c, 1, " --wait=false")
 		},
 	})
 	r.Add(testSpec{
-		Name:  "tpmc/w=1/nodes=3",
-		Nodes: nodes(4),
+		Name:   "tpmc/w=1/nodes=3",
+		Nodes:  nodes(4),
+		Stable: true, // DO NOT COPY to new tests
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			runTPCC(ctx, t, c, 1, "")
 		},

--- a/pkg/cmd/roachtest/version.go
+++ b/pkg/cmd/roachtest/version.go
@@ -210,8 +210,9 @@ func registerVersion(r *registry) {
 	const version = "v2.0.0"
 	for _, n := range []int{3, 5} {
 		r.Add(testSpec{
-			Name:  fmt.Sprintf("version/mixedWith=%s/nodes=%d", version, n),
-			Nodes: nodes(n + 1),
+			Name:   fmt.Sprintf("version/mixedWith=%s/nodes=%d", version, n),
+			Nodes:  nodes(n + 1),
+			Stable: true, // DO NOT COPY to new tests
 			Run: func(ctx context.Context, t *test, c *cluster) {
 				runVersion(ctx, t, c, version)
 			},


### PR DESCRIPTION
Add `testSpec.Stable` which indicates if a test is considered stable or
unstable. Unstable tests do not count against the pass/fail status of a
roachtest run and are display differently in the slack status message. The
expectation is that all new tests will start as unstable and only graduate
to being marked as stable after they have repeatedly passed in nightly
testing.

Unstable tests have the string `[unstable]` displayed next to their name in
RUN/PASS/FAIL messages. `roachtest run -n | grep unstable` will show all of
the unstable tests.

Mark all tests except for `backup2TB`,
`import/tpcc/warehouses=1000/nodes=4`, and `jepsen` as stable.

Fixes #25286

Release note: None