### PR TITLE
build: include netcat and lsof in the builder image

### DIFF
--- a/build/builder.sh
+++ b/build/builder.sh
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 image=cockroachdb/builder
-version=20180502-092643
+version=20180504-124046
 
 function init() {
   docker build --tag="${image}" "$(dirname "${0}")/builder"

--- a/build/builder/Dockerfile
+++ b/build/builder/Dockerfile
@@ -172,6 +172,8 @@ RUN curl -fsSL https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key ad
  && apt-get update
 
 # ccache - speed up C and C++ compilation
+# lsof - roachprod monitor
+# netcat - roachprod monitor
 # nodejs - ui
 # openjdk-8-jre - railroad diagram generation
 # google-cloud-sdk - roachprod acceptance tests
@@ -180,6 +182,8 @@ RUN curl -fsSL https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key ad
 RUN apt-get install -y --no-install-recommends \
     ccache \
     google-cloud-sdk \
+    lsof \
+    netcat \
     nodejs \
     openjdk-8-jre \
     openssh-client \


### PR DESCRIPTION
These are needed by roachprod monitor, which is used by roachtests,
which we're about to start running on every PR (with --local inside the
builder image).

Release note: None