### PR TITLE
roachtest,workload: support generating store dumps

### DIFF
--- a/pkg/ccl/workloadccl/fixture.go
+++ b/pkg/ccl/workloadccl/fixture.go
@@ -107,6 +107,11 @@ func generatorToGCSFolder(config FixtureConfig, gen workload.Generator) string {
 	)
 }
 
+// FixtureURL returns the URL for pre-computed Generator data stored on GCS.
+func FixtureURL(config FixtureConfig, gen workload.Generator) string {
+	return fmt.Sprintf("gs://%s/%s", config.GCSBucket, generatorToGCSFolder(config, gen))
+}
+
 // GetFixture returns a handle for pre-computed Generator data stored on GCS. It
 // is expected that the generator will have had Configure called on it.
 func GetFixture(

--- a/pkg/cmd/roachtest/store_gen.go
+++ b/pkg/cmd/roachtest/store_gen.go
@@ -1,0 +1,87 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"strings"
+
+	"golang.org/x/sync/errgroup"
+)
+
+var stores = 3
+
+// registerStoreGen registers a store generation "test" that powers the
+// 'roachtest store-gen' subcommand.
+func registerStoreGen(r *registry, args []string) {
+	workloadArgs := strings.Join(args, " ")
+
+	r.Add(testSpec{
+		Name:  "store-gen",
+		Nodes: nodes(stores),
+		Run: func(ctx context.Context, t *test, c *cluster) {
+			c.Put(ctx, cockroach, "./cockroach")
+			c.Put(ctx, workload, "./workload")
+			c.Start(ctx)
+
+			m := newMonitor(ctx, c)
+			m.Go(func(ctx context.Context) error {
+				t.Status("restoring fixture")
+				c.Run(ctx, c.Node(1), fmt.Sprintf("./workload fixtures load %s", workloadArgs))
+
+				urlBase, err := c.RunWithBuffer(ctx, c.l, c.Node(1),
+					fmt.Sprintf(`./workload fixtures url %s`, workloadArgs))
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				db := c.Conn(ctx, 1)
+				defer db.Close()
+				var binVersion string
+				err = db.QueryRow("SELECT crdb_internal.node_executable_version()").Scan(&binVersion)
+				if err != nil {
+					return err
+				}
+
+				fixturesURL := fmt.Sprintf("%s/stores=%d,bin-version=%s",
+					bytes.TrimSpace(urlBase), stores, binVersion)
+
+				// gsutil rm fails if no objects exist, even with -f, so check if any
+				// old store directories exist before attempting to remove them.
+				err = c.RunE(ctx, c.Node(1), fmt.Sprintf("gsutil -m -q ls %s &> /dev/null", fixturesURL))
+				if err == nil {
+					t.Status("deleting old store dumps")
+					c.Run(ctx, c.Node(1), fmt.Sprintf("gsutil -m -q rm -r %s", fixturesURL))
+				}
+
+				t.Status("uploading store dumps")
+				var g errgroup.Group
+				for store := 1; store <= stores; store++ {
+					store := store
+					g.Go(func() error {
+						c.Run(ctx, c.Node(store), fmt.Sprintf("gsutil -m -q cp -r {store-dir}/* %s/%d/",
+							fixturesURL, store))
+						return nil
+					})
+				}
+				return g.Wait()
+			})
+			m.Wait()
+		},
+	})
+}

--- a/pkg/cmd/workload/check.go
+++ b/pkg/cmd/workload/check.go
@@ -27,10 +27,10 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/workload"
 )
 
-var checkCmd = &cobra.Command{
+var checkCmd = setCmdDefaults(&cobra.Command{
 	Use:   `check`,
 	Short: `Check a running cluster's data for consistency`,
-}
+})
 
 func init() {
 	for _, meta := range workload.Registered() {
@@ -53,10 +53,10 @@ func init() {
 			}
 		}
 
-		genCheckCmd := &cobra.Command{
+		genCheckCmd := setCmdDefaults(&cobra.Command{
 			Use:  meta.Name + ` [CRDB URI]`,
 			Args: cobra.RangeArgs(0, 1),
-		}
+		})
 		genCheckCmd.Flags().AddFlagSet(genFlags)
 		genCheckCmd.Run = cmdHelper(gen, check)
 		checkCmd.AddCommand(genCheckCmd)

--- a/pkg/cmd/workload/csv_server.go
+++ b/pkg/cmd/workload/csv_server.go
@@ -25,12 +25,12 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/workload"
 )
 
-var csvServerCmd = &cobra.Command{
+var csvServerCmd = setCmdDefaults(&cobra.Command{
 	Use:   `csv-server`,
 	Short: `Serves csv table data through an HTTP interface`,
 	Args:  cobra.NoArgs,
 	RunE:  runCSVServer,
-}
+})
 
 var port *int
 

--- a/pkg/cmd/workload/fixtures.go
+++ b/pkg/cmd/workload/fixtures.go
@@ -51,20 +51,22 @@ func config() workloadccl.FixtureConfig {
 	return config
 }
 
-var fixturesCmd = &cobra.Command{Use: `fixtures`}
-var fixturesListCmd = &cobra.Command{
+var fixturesCmd = setCmdDefaults(&cobra.Command{
+	Use: `fixtures`,
+})
+var fixturesListCmd = setCmdDefaults(&cobra.Command{
 	Use:   `list`,
 	Short: `List all fixtures stored on GCS`,
 	Run:   handleErrs(fixturesList),
-}
-var fixturesMakeCmd = &cobra.Command{
+})
+var fixturesMakeCmd = setCmdDefaults(&cobra.Command{
 	Use:   `make`,
 	Short: `Regenerate and store a fixture on GCS`,
-}
-var fixturesLoadCmd = &cobra.Command{
+})
+var fixturesLoadCmd = setCmdDefaults(&cobra.Command{
 	Use:   `load`,
 	Short: `Load a fixture into a running cluster. An enterprise license is required.`,
-}
+})
 
 var fixturesMakeCSVServerURL = fixturesMakeCmd.PersistentFlags().String(
 	`csv-server`, ``,
@@ -118,18 +120,18 @@ func init() {
 			}
 		}
 
-		genMakeCmd := &cobra.Command{
+		genMakeCmd := setCmdDefaults(&cobra.Command{
 			Use:  meta.Name + ` [CRDB URI]`,
 			Args: cobra.RangeArgs(0, 1),
-		}
+		})
 		genMakeCmd.Flags().AddFlagSet(genFlags)
 		genMakeCmd.Run = cmdHelper(gen, fixturesMake)
 		fixturesMakeCmd.AddCommand(genMakeCmd)
 
-		genLoadCmd := &cobra.Command{
+		genLoadCmd := setCmdDefaults(&cobra.Command{
 			Use:  meta.Name + ` [CRDB URI]`,
 			Args: cobra.RangeArgs(0, 1),
-		}
+		})
 		genLoadCmd.Flags().AddFlagSet(genFlags)
 		genLoadCmd.Run = cmdHelper(gen, fixturesLoad)
 		fixturesLoadCmd.AddCommand(genLoadCmd)

--- a/pkg/cmd/workload/main.go
+++ b/pkg/cmd/workload/main.go
@@ -23,9 +23,9 @@ import (
 	_ "github.com/cockroachdb/cockroach/pkg/ccl/workloadccl/allccl"
 )
 
-var rootCmd = &cobra.Command{
+var rootCmd = setCmdDefaults(&cobra.Command{
 	Use: `workload`,
-}
+})
 
 func main() {
 	if err := rootCmd.Execute(); err != nil {


### PR DESCRIPTION
Support generating store dumps like those used by the backup2tb test. Store dumps can bootstrap a CockroachDB cluster with data more quickly than RESTORE can, but they must be regenerated for every desired number of stores.

The core performance team plans to use these store dumps to quickly bootstrap performance tests.

For example, here's how I'm regenerating the backup2tb stores (to fix #24337):

```
./roachtest store-gen --stores=10 bank --payload-bytes=10240 --ranges=0 --rows=65104166
```

Fix #25085.