### PR TITLE
storage: proactively renew expiration-based leases

### DIFF
--- a/pkg/storage/replica_proposal.go
+++ b/pkg/storage/replica_proposal.go
@@ -258,17 +258,28 @@ func (r *Replica) leasePostApply(ctx context.Context, newLease roachpb.Lease) {
 	// by the previous lease holder.
 	r.mu.Lock()
 	r.mu.state.Lease = &newLease
+	expirationBasedLease := r.requiresExpiringLeaseRLocked()
 	r.mu.Unlock()
 
+	// Gossip the first range whenever its lease is acquired. We check to make
+	// sure the lease is active so that a trailing replica won't process an old
+	// lease request and attempt to gossip the first range.
 	if leaseChangingHands && iAmTheLeaseHolder && r.IsFirstRange() && r.IsLeaseValid(newLease, r.store.Clock().Now()) {
-		// Gossip the first range whenever its lease is acquired. We check to
-		// make sure the lease is active so that a trailing replica won't process
-		// an old lease request and attempt to gossip the first range.
 		r.gossipFirstRange(ctx)
+	}
 
-		// Notify the lease renewer worker that we want it to renew the first
-		// range's expiration-based lease.
-		r.store.expirationBasedLeaseChan <- r
+	// Whenever we first acquire an expiration-based lease, notify the lease
+	// renewer worker that we want it to keep proactively renewing the lease
+	// before it expires.
+	if leaseChangingHands && iAmTheLeaseHolder && expirationBasedLease && r.IsLeaseValid(newLease, r.store.Clock().Now()) {
+		// It's not worth blocking on a full channel here since the worst that can
+		// happen is the lease times out and has to be reacquired when needed, but
+		// log an error since it's pretty unexpected.
+		select {
+		case r.store.expirationBasedLeaseChan <- r:
+		default:
+			log.Warningf(ctx, "unable to kick off proactive lease renewal; channel full")
+		}
 	}
 
 	if leaseChangingHands && !iAmTheLeaseHolder {

--- a/pkg/storage/replica_proposal.go
+++ b/pkg/storage/replica_proposal.go
@@ -260,11 +260,15 @@ func (r *Replica) leasePostApply(ctx context.Context, newLease roachpb.Lease) {
 	r.mu.state.Lease = &newLease
 	r.mu.Unlock()
 
-	// Gossip the first range whenever its lease is acquired. We check to
-	// make sure the lease is active so that a trailing replica won't process
-	// an old lease request and attempt to gossip the first range.
 	if leaseChangingHands && iAmTheLeaseHolder && r.IsFirstRange() && r.IsLeaseValid(newLease, r.store.Clock().Now()) {
+		// Gossip the first range whenever its lease is acquired. We check to
+		// make sure the lease is active so that a trailing replica won't process
+		// an old lease request and attempt to gossip the first range.
 		r.gossipFirstRange(ctx)
+
+		// Notify the lease renewer worker that we want it to renew the first
+		// range's expiration-based lease.
+		r.store.expirationBasedLeaseChan <- r
 	}
 
 	if leaseChangingHands && !iAmTheLeaseHolder {

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -883,7 +883,11 @@ func NewStore(cfg StoreConfig, eng engine.Engine, nodeDesc *roachpb.NodeDescript
 	s.metrics.registry.AddMetricStruct(s.compactor.Metrics)
 
 	s.snapshotApplySem = make(chan struct{}, cfg.concurrentSnapshotApplyLimit)
-	s.expirationBasedLeaseChan = make(chan *Replica, 1)
+
+	// The channel size here is arbitrary. We don't want it to fill up, but it
+	// isn't a disaster if it does and it shouldn't unless a huge number of meta2
+	// range leases are acquired at once.
+	s.expirationBasedLeaseChan = make(chan *Replica, 64)
 
 	s.limiters.BulkIOWriteRate = rate.NewLimiter(rate.Limit(bulkIOWriteLimit.Get(&cfg.Settings.SV)), bulkIOWriteBurst)
 	bulkIOWriteLimit.SetOnChange(&cfg.Settings.SV, func() {
@@ -1556,10 +1560,6 @@ func (s *Store) startGossip() {
 // This reduces user-visible latency when range lookups are needed to serve a
 // request and reduces ping-ponging of r1's lease to different replicas as
 // maybeGossipFirstRange is called on each (e.g.  #24753).
-//
-// NOTE: Currently the only lease that we proactively renew is r1, but this
-// could easily be expanded to renew all the meta2 ranges as well. If we do so,
-// the length of expirationBasedLeaseChan should be increased.
 func (s *Store) startLeaseRenewer(ctx context.Context) {
 	// Start a goroutine that watches and proactively renews certain
 	// expiration-based leases.
@@ -1595,6 +1595,18 @@ func (s *Store) startLeaseRenewer(ctx context.Context) {
 			select {
 			case repl := <-s.expirationBasedLeaseChan:
 				repls[repl] = struct{}{}
+				// If we got one entry off the channel, there may be more (e.g. a node
+				// holding a bunch of meta2 ranges just failed), so keep pulling until
+				// we can't get any more.
+			continuepulling:
+				for {
+					select {
+					case repl := <-s.expirationBasedLeaseChan:
+						repls[repl] = struct{}{}
+					default:
+						break continuepulling
+					}
+				}
 			case <-timer.C:
 				timer.Read = true
 			case <-s.stopper.ShouldStop():

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -401,6 +401,10 @@ type Store struct {
 	// data destruction.
 	snapshotApplySem chan struct{}
 
+	// Channel of newly-acquired expiration-based leases that we want to
+	// proactively renew.
+	expirationBasedLeaseChan chan *Replica
+
 	// draining holds a bool which indicates whether this store is draining. See
 	// SetDraining() for a more detailed explanation of behavior changes.
 	//
@@ -879,6 +883,7 @@ func NewStore(cfg StoreConfig, eng engine.Engine, nodeDesc *roachpb.NodeDescript
 	s.metrics.registry.AddMetricStruct(s.compactor.Metrics)
 
 	s.snapshotApplySem = make(chan struct{}, cfg.concurrentSnapshotApplyLimit)
+	s.expirationBasedLeaseChan = make(chan *Replica, 1)
 
 	s.limiters.BulkIOWriteRate = rate.NewLimiter(rate.Limit(bulkIOWriteLimit.Get(&cfg.Settings.SV)), bulkIOWriteBurst)
 	bulkIOWriteLimit.SetOnChange(&cfg.Settings.SV, func() {
@@ -1433,6 +1438,8 @@ func (s *Store) Start(ctx context.Context, stopper *stop.Stopper) error {
 		log.Event(ctx, "computed initial metrics")
 	}
 
+	s.startLeaseRenewer(ctx)
+
 	// Start the storage engine compactor.
 	if envutil.EnvOrDefaultBool("COCKROACH_ENABLE_COMPACTOR", true) {
 		s.compactor.Start(s.AnnotateCtx(context.Background()), s.Tracer(), s.stopper)
@@ -1540,6 +1547,61 @@ func (s *Store) startGossip() {
 			}
 		})
 	}
+}
+
+// startLeaseRenewer runs an infinite loop in a goroutine which regularly
+// checks whether the store has any expiration-based leases that should be
+// proactively renewed and attempts to continue renewing them.
+//
+// This reduces user-visible latency when range lookups are needed to serve a
+// request and reduces ping-ponging of r1's lease to different replicas as
+// maybeGossipFirstRange is called on each (e.g.  #24753).
+//
+// NOTE: Currently the only lease that we proactively renew is r1, but this
+// could easily be expanded to renew all the meta2 ranges as well. If we do so,
+// the length of expirationBasedLeaseChan should be increased.
+func (s *Store) startLeaseRenewer(ctx context.Context) {
+	// Start a goroutine that watches and proactively renews certain
+	// expiration-based leases.
+	s.stopper.RunWorker(ctx, func(context.Context) {
+		repls := make(map[*Replica]struct{})
+		timer := timeutil.NewTimer()
+		defer timer.Stop()
+
+		// Determine how frequently to attempt to ensure that we have each lease.
+		// The divisor used here is somewhat arbitrary, but needs to be large
+		// enough to ensure we'll attempt to renew the lease reasonably early
+		// within the RangeLeaseRenewalDuration time window. This means we'll wake
+		// up more often that strictly necessary, but it's more maintainable than
+		// attempting to accurately determine exactly when each iteration of a
+		// lease expires and when we should attempt to renew it as a result.
+		renewalDuration := s.cfg.RangeLeaseActiveDuration() / 5
+		for {
+			for repl := range repls {
+				annotatedCtx := repl.AnnotateCtx(ctx)
+				_, pErr := repl.redirectOnOrAcquireLease(annotatedCtx)
+				if pErr != nil {
+					if _, ok := pErr.GetDetail().(*roachpb.NotLeaseHolderError); !ok {
+						log.Warningf(annotatedCtx, "failed to proactively renew lease: %s", pErr)
+					}
+					delete(repls, repl)
+					continue
+				}
+			}
+
+			if len(repls) > 0 {
+				timer.Reset(renewalDuration)
+			}
+			select {
+			case repl := <-s.expirationBasedLeaseChan:
+				repls[repl] = struct{}{}
+			case <-timer.C:
+				timer.Read = true
+			case <-s.stopper.ShouldStop():
+				return
+			}
+		}
+	})
 }
 
 // systemGossipUpdate is a callback for gossip updates to


### PR DESCRIPTION
This mechanism won't scale incredibly well to proactively renewing all
expiration-based leases since it'd require a goroutine per lease. It
should be fine if we only auto-renew r1's lease, though.

Fixes #24753

Release note: None

----------------

@bdarnell, do you have any suggestions for testing this? I've verified it manually, but it's hard to properly isolate this code in a realistic way. We could ratchet the lease durations way down and wait until the lease's expiration bumps, but that creates a timing-based test that is either flaky if we use a really short lease duration or slow if we use a long one.