### PR TITLE
build: make 'go get github.com/cockroachdb/cockroach' fail

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,7 @@ TAGS         :=
 ARCHIVE      := cockroach.src.tgz
 STARTFLAGS   := -s type=mem,size=1GiB --logtostderr
 BUILDMODE    := install
-BUILDTARGET  := .
+BUILDTARGET  := ./pkg/cmd/cockroach
 SUFFIX       :=
 INSTALL      := install
 prefix       := /usr/local

--- a/pkg/acceptance/cluster/dockercluster.go
+++ b/pkg/acceptance/cluster/dockercluster.go
@@ -75,7 +75,7 @@ var maxRangeBytes = config.DefaultZoneConfig().RangeMaxBytes
 
 // CockroachBinary is the path to the host-side binary to use.
 var CockroachBinary = flag.String("b", func() string {
-	rootPkg, err := build.Import("github.com/cockroachdb/cockroach", "", 0)
+	rootPkg, err := build.Import("github.com/cockroachdb/cockroach", "", build.FindOnly)
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/cli/flags_test.go
+++ b/pkg/cli/flags_test.go
@@ -46,7 +46,7 @@ func TestNoLinkForbidden(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	// Verify that the cockroach binary doesn't depend on certain packages.
 	buildutil.VerifyNoImports(t,
-		"github.com/cockroachdb/cockroach", true,
+		"github.com/cockroachdb/cockroach/pkg/cmd/cockroach", true,
 		[]string{
 			"testing",  // defines flags
 			"go/build", // probably not something we want in the main binary

--- a/pkg/cmd/cockroach/main.go
+++ b/pkg/cmd/cockroach/main.go
@@ -12,11 +12,13 @@
 // implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
-package main
-
+// This is the default entry point for a CockroachDB binary.
+//
 // The ccl hook import below means building this will produce CCL'ed binaries.
 // This file itself remains Apache2 to preserve the organization of ccl code
 // under the /pkg/ccl subtree, but is unused for pure FLOSS builds.
+package main
+
 import (
 	_ "github.com/cockroachdb/cockroach/pkg/ccl" // ccl init hooks
 	"github.com/cockroachdb/cockroach/pkg/cli"


### PR DESCRIPTION
The root package, github.com/cockroachdb/cockroach, previously served as
the main entry point for the default CCL binary. This meant that naively
running

    $ go get github.com/cockroachdb/cockroach

would fail with cryptic errors about missing "reserved keywords", as our
build requires generating some Go code via Make. Our documentation
suggests that users instead run

    $ go get -d github.com/cockroachdb/cockroach
    $ make

but many users, somewhat understandably, fail to read that
documentation.

Move the main entry point to ./pkg/cmd/cockroach. Running 'go get
github.com/cockroachdb/cockroach' will now produce a less confusing
error that reads:

    can't load package: package github.com/cockroachdb/cockroach: no Go
    files in GOPATH/src/github.com/cockroachdb/cockroach

Hopefully this spurs users to read the build instructions.

(Running 'go get github.com/cockroachdb/cockroach/pkg/cmd/cockroach'
still produces the same cryptic error messages as before, but users are
far less likely to construct that 'go get' invocation.)

Fix #23583.
Fix #23992.

Release note: None