### PR TITLE
pgwire: increase connection read deadline

### DIFF
--- a/pkg/sql/pgwire/conn.go
+++ b/pkg/sql/pgwire/conn.go
@@ -1344,7 +1344,7 @@ func (c *readTimeoutConn) Read(b []byte) (int, error) {
 	// read before checking for exit conditions. The tradeoff is between the
 	// time it takes to react to session context cancellation and the overhead
 	// of waking up and checking for exit conditions.
-	const readTimeout = 150 * time.Millisecond
+	const readTimeout = 1 * time.Second
 
 	// Remove the read deadline when returning from this function to avoid
 	// unexpected behavior.

--- a/pkg/sql/pgwire/pgwire_test.go
+++ b/pkg/sql/pgwire/pgwire_test.go
@@ -373,7 +373,7 @@ func TestPGWireDrainOngoingTxns(t *testing.T) {
 		// The expected behavior is for the pgServer to immediately cancel any
 		// ongoing sessions and wait for 1s for the cancellation to take effect.
 		if err := pgServer.DrainImpl(
-			0 /* drainWait */, 1*time.Second, /* cancelWait */
+			0 /* drainWait */, 2*time.Second, /* cancelWait */
 		); err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
The investigation in #24695 found that an idle single node
still has a decent amount of activity. `strace` demonstrated
that this activity included repeated `read()` calls on network
sockets. The investigation also noted that the number of these
calls scaled linearly with the number of SQL connections open.
@jordanlewis noticed that the `read` calls went away completely
without any SQL connections open to the idle node, effectively
isolating their source.

We spent some time tracking down where in the network stack we
were performing this polling until Jordan noticed that it was
coming from `readTimeoutConn`'s use of `Conn.SetReadDeadline`.
This deadline was being set to 150ms, meaning that each SQL
connection was polling `read()` about 7 times per second. This
seems excessive.

This change reduces the number of system calls required by idle
open SQL connections by roughly an order of 7 by increasing its
read deadline to 1 second. This comes at the expense of a small
amount of responsiveness when a SQL connection drops - we'll now
take a little longer to cancel any ongoing queries and clean up
its state.

Release note: None