### PR TITLE
opt/idxconstraint: fix IS NOT handling of NULLs

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/select_index
+++ b/pkg/sql/logictest/testdata/logic_test/select_index
@@ -1023,7 +1023,7 @@ render           ·         ·                 (x, y)                           
  └── index-join  ·         ·                 (x, y, rowid[hidden,omitted])            y!=NULL; rowid!=NULL; key(y,rowid)
       ├── scan   ·         ·                 (x[omitted], y[omitted], rowid[hidden])  y!=NULL; rowid!=NULL; key(y,rowid)
       │          table     xy@xy_y_idx       ·                                        ·
-      │          spans     /!NULL-/4 /5-     ·                                        ·
+      │          spans     -/4 /5-           ·                                        ·
       └── scan   ·         ·                 (x, y, rowid[hidden,omitted])            ·
 ·                table     xy@primary        ·                                        ·
 
@@ -1064,3 +1064,101 @@ query II
 SELECT * FROM xy WHERE (x, y) IN ((NULL, NULL), (1, NULL), (NULL, 1), (1, 1), (1, 2))
 ----
 1  1
+
+# Test index constraints for IS (NOT) TRUE/FALSE.
+statement ok
+CREATE TABLE bool1 (
+  a BOOL,
+  INDEX (a)
+);
+INSERT INTO bool1 VALUES (NULL), (TRUE), (FALSE)
+
+query B
+SELECT * FROM bool1 WHERE a IS NULL
+----
+NULL
+
+query B rowsort
+SELECT * FROM bool1 WHERE a IS NOT NULL
+----
+false
+true
+
+query B
+SELECT * FROM bool1 WHERE a IS TRUE
+----
+true
+
+query B rowsort
+SELECT * FROM bool1 WHERE a IS NOT TRUE
+----
+NULL
+false
+
+query B
+SELECT * FROM bool1 WHERE a IS FALSE
+----
+false
+
+query B rowsort
+SELECT * FROM bool1 WHERE a IS NOT FALSE
+----
+NULL
+true
+
+statement ok
+CREATE TABLE bool2 (
+  a BOOL NOT NULL,
+  INDEX (a)
+);
+INSERT INTO bool2 VALUES (TRUE), (FALSE)
+
+query B
+SELECT * FROM bool2 WHERE a IS NULL
+----
+
+query B rowsort
+SELECT * FROM bool2 WHERE a IS NOT NULL
+----
+false
+true
+
+query B
+SELECT * FROM bool2 WHERE a IS TRUE
+----
+true
+
+query B
+SELECT * FROM bool2 WHERE a IS NOT TRUE
+----
+false
+
+query B
+SELECT * FROM bool2 WHERE a IS FALSE
+----
+false
+
+query B
+SELECT * FROM bool2 WHERE a IS NOT FALSE
+----
+true
+
+# Test index constraints for IS (NOT) DISTINCT FROM on an integer column.
+statement ok
+CREATE TABLE int (
+  a INT,
+  INDEX (a)
+);
+INSERT INTO int VALUES (NULL), (0), (1), (2)
+
+query I
+SELECT * FROM int WHERE a IS NOT DISTINCT FROM 2
+----
+2
+
+query I rowsort
+SELECT * FROM int WHERE a IS DISTINCT FROM 2
+----
+NULL
+0
+1

--- a/pkg/sql/opt/idxconstraint/index_constraints.go
+++ b/pkg/sql/opt/idxconstraint/index_constraints.go
@@ -253,9 +253,12 @@ func (c *indexConstraintCtx) makeSpansForSingleColumnDatum(
 
 	case opt.NeOp, opt.IsNotOp:
 		// Build constraint that doesn't contain the key:
-		//   if nullable    : [ - key) (key - ]
-		//   if not nullable: (/NULL - key) (key - ]
-		startKey, startBoundary := c.notNullStartKey(offset)
+		//   if nullable or IsNotOp   : [ - key) (key - ]
+		//   if not nullable and NeOp : (/NULL - key) (key - ]
+		startKey, startBoundary := emptyKey, includeBoundary
+		if op == opt.NeOp {
+			startKey, startBoundary = c.notNullStartKey(offset)
+		}
 		key := constraint.MakeKey(datum)
 		descending := c.columns[offset].Descending()
 		c.singleSpan(offset, startKey, startBoundary, key, excludeBoundary, descending, out)

--- a/pkg/sql/opt/idxconstraint/testdata/single-column
+++ b/pkg/sql/opt/idxconstraint/testdata/single-column
@@ -149,3 +149,36 @@ index-constraints vars=(bool) index=(@1)
 NOT @1
 ----
 [/false - /false]
+
+index-constraints vars=(bool) index=(@1)
+@1 IS TRUE
+----
+[/true - /true]
+
+index-constraints vars=(bool) index=(@1)
+@1 IS FALSE
+----
+[/false - /false]
+
+index-constraints vars=(bool) index=(@1)
+@1 IS NOT TRUE
+----
+[ - /false]
+(/true - ]
+
+index-constraints vars=(bool) index=(@1)
+@1 IS NOT FALSE
+----
+[ - /false)
+[/true - ]
+
+index-constraints vars=(int) index=(@1)
+@1 IS NOT DISTINCT FROM 5
+----
+[/5 - /5]
+
+index-constraints vars=(int) index=(@1)
+@1 IS DISTINCT FROM 5
+----
+[ - /4]
+[/6 - ]


### PR DESCRIPTION
`IS DISTINCT FROM` (IsNotOp) treats NULL as any other value: `NULL IS
DISTINCT FROM 5` is true. The index constraints code incorrectly
treats it as `NeOp` and generates a not-null constraint.  Fixing and
adding some testcases.

Release note (bug fix): fixed a bug with `IS DISTINCT FROM` not
returning NULL values that pass the condition in some cases.

I plan to cherry-pick to 2.0.x