### PR TITLE
cherrypick-2.0: opt/idxconstraint: fix IS NOT handling of NULLs

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/select_index
+++ b/pkg/sql/logictest/testdata/logic_test/select_index
@@ -1021,7 +1021,7 @@ render           ·         ·                 (x, y)                           
  └── index-join  ·         ·                 (x, y, rowid[hidden,omitted])            y!=NULL; rowid!=NULL; key(y,rowid)
       ├── scan   ·         ·                 (x[omitted], y[omitted], rowid[hidden])  y!=NULL; rowid!=NULL; key(y,rowid)
       │          table     xy@xy_y_idx       ·                                        ·
-      │          spans     /!NULL-/4 /5-     ·                                        ·
+      │          spans     -/4 /5-           ·                                        ·
       └── scan   ·         ·                 (x, y, rowid[hidden,omitted])            ·
 ·                table     xy@primary        ·                                        ·
 
@@ -1062,3 +1062,101 @@ query II
 SELECT * FROM xy WHERE (x, y) IN ((NULL, NULL), (1, NULL), (NULL, 1), (1, 1), (1, 2))
 ----
 1  1
+
+# Test index constraints for IS (NOT) TRUE/FALSE.
+statement ok
+CREATE TABLE bool1 (
+  a BOOL,
+  INDEX (a)
+);
+INSERT INTO bool1 VALUES (NULL), (TRUE), (FALSE)
+
+query B
+SELECT * FROM bool1 WHERE a IS NULL
+----
+NULL
+
+query B rowsort
+SELECT * FROM bool1 WHERE a IS NOT NULL
+----
+false
+true
+
+query B
+SELECT * FROM bool1 WHERE a IS TRUE
+----
+true
+
+query B rowsort
+SELECT * FROM bool1 WHERE a IS NOT TRUE
+----
+NULL
+false
+
+query B
+SELECT * FROM bool1 WHERE a IS FALSE
+----
+false
+
+query B rowsort
+SELECT * FROM bool1 WHERE a IS NOT FALSE
+----
+NULL
+true
+
+statement ok
+CREATE TABLE bool2 (
+  a BOOL NOT NULL,
+  INDEX (a)
+);
+INSERT INTO bool2 VALUES (TRUE), (FALSE)
+
+query B
+SELECT * FROM bool2 WHERE a IS NULL
+----
+
+query B
+SELECT * FROM bool2 WHERE a IS NOT NULL
+----
+false
+true
+
+query B
+SELECT * FROM bool2 WHERE a IS TRUE
+----
+true
+
+query B
+SELECT * FROM bool2 WHERE a IS NOT TRUE
+----
+false
+
+query B
+SELECT * FROM bool2 WHERE a IS FALSE
+----
+false
+
+query B
+SELECT * FROM bool2 WHERE a IS NOT FALSE
+----
+true
+
+# Test index constraints for IS (NOT) DISTINCT FROM on an integer column.
+statement ok
+CREATE TABLE int (
+  a INT,
+  INDEX (a)
+);
+INSERT INTO int VALUES (NULL), (0), (1), (2)
+
+query I
+SELECT * FROM int WHERE a IS NOT DISTINCT FROM 2
+----
+2
+
+query I rowsort
+SELECT * FROM int WHERE a IS DISTINCT FROM 2
+----
+NULL
+0
+1

--- a/pkg/sql/opt/index_constraints.go
+++ b/pkg/sql/opt/index_constraints.go
@@ -176,7 +176,11 @@ func (c *indexConstraintCtx) makeSpansForSingleColumn(
 		return LogicalSpans{sp}, true, true
 
 	case neOp, isNotOp:
-		spans := LogicalSpans{c.makeNotNullSpan(offset), c.makeNotNullSpan(offset)}
+		spans := LogicalSpans{MakeFullSpan(), MakeFullSpan()}
+		if op == neOp {
+			spans[0] = c.makeNotNullSpan(offset)
+			spans[1] = c.makeNotNullSpan(offset)
+		}
 		spans[0].End = LogicalKey{Vals: tree.Datums{datum}, Inclusive: false}
 		spans[1].Start = LogicalKey{Vals: tree.Datums{datum}, Inclusive: false}
 		c.preferInclusive(offset, &spans[0])

--- a/pkg/sql/opt/testdata/index-constraints
+++ b/pkg/sql/opt/testdata/index-constraints
@@ -1223,3 +1223,36 @@ build-scalar,normalize,index-constraints vars=(string) index=(@1)
 ----
 [/'ABC' - /'ABD')
 Remaining filter: @1 SIMILAR TO '(ABC|ABCDEF)%'
+
+build-scalar,normalize,index-constraints vars=(bool) index=(@1)
+@1 IS TRUE
+----
+[/true - /true]
+
+build-scalar,normalize,index-constraints vars=(bool) index=(@1)
+@1 IS FALSE
+----
+[/false - /false]
+
+build-scalar,normalize,index-constraints vars=(bool) index=(@1)
+@1 IS NOT TRUE
+----
+[ - /false]
+(/true - ]
+
+build-scalar,normalize,index-constraints vars=(bool) index=(@1)
+@1 IS NOT FALSE
+----
+[ - /false)
+[/true - ]
+
+build-scalar,normalize,index-constraints vars=(int) index=(@1)
+@1 IS NOT DISTINCT FROM 5
+----
+[/5 - /5]
+
+build-scalar,normalize,index-constraints vars=(int) index=(@1)
+@1 IS DISTINCT FROM 5
+----
+[ - /4]
+[/6 - ]


### PR DESCRIPTION
`IS DISTINCT FROM` (IsNotOp) treats NULL as any other value:
`NULL IS DISTINCT FROM 5` is true. The index constraints code
incorrectly treats it as `NeOp` and generates a not-null constraint.
Fixing and adding some testcases.

Release note (bug fix): fixed a bug with `IS DISTINCT FROM` not
returning NULL values that pass the condition in some cases.

This is a backport of #25336. CC @cockroachdb/release 