### PR TITLE
storage/engine: don't try to slice potentially invalid pointers

### DIFF
--- a/pkg/storage/engine/slice_test.go
+++ b/pkg/storage/engine/slice_test.go
@@ -14,28 +14,15 @@
 
 package engine
 
-import "C"
-
 import (
-	"unsafe"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 )
 
-func nonZeroingMakeByteSlice(len int) []byte {
-	ptr := mallocgc(uintptr(len), nil, false)
-	return (*[maxArrayLen]byte)(ptr)[:len:len]
-}
-
-// Replacement for C.GoBytes which does not zero initialize the returned slice
-// before overwriting it.
-//
-// TODO(peter): Remove when go1.11 is released which has a similar change to
-// C.GoBytes.
-func gobytes(ptr unsafe.Pointer, len int) []byte {
-	if len == 0 {
-		return make([]byte, 0)
-	}
-	x := nonZeroingMakeByteSlice(len)
-	src := (*[maxArrayLen]byte)(ptr)[:len:len]
-	copy(x, src)
-	return x
+// Regression test for #25289: calling gobytes() on an invalid pointer is fine
+// as long as we're asking for 0 bytes.
+func TestGoBytesNil(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	_ = gobytes(nil, 0)
 }


### PR DESCRIPTION
Don't try to slice an invalid pointer (such as nil) because the Go
compiler generates code which accesses the first element.

Fixes #25289

Release note (bug fix): Fix a rare segfault that occurred when reading
from an invalid memory location returned from C++.