### PR TITLE
[dnm,wip] storage: GC aggressively when SysBytes is large

### DIFF
--- a/pkg/roachpb/data.pb.go
+++ b/pkg/roachpb/data.pb.go
@@ -533,6 +533,18 @@ func (*Lease) Descriptor() ([]byte, []int) { return fileDescriptorData, []int{12
 // and must start fresh with an updated priority.
 type AbortSpanEntry struct {
 	// The key of the associated transaction.
+	//
+	// TODO(tschottdorf): when splitting ranges, we currently blindly copy the
+	// abort span of the pre-split range into the RHS of the post-split ranges.
+	// This is a bit silly since the records contain the key that anchors the
+	// transaction, and so in principle we can tell which records to copy (though
+	// that means we have to decode them). The extra copy isn't an issue since the
+	// span is usually small, but we've seen that in practice it can become large
+	// (#25233), at which point splitting either becomes impossible (due to the
+	// raft max command size) or a bad idea (as it duplicates the large span
+	// further). We should generally opt for the safer (albeit somewhat slower)
+	// option of copying only what's needed. In a similar spirit, we could remove
+	// those entries from the LHS.
 	Key Key `protobuf:"bytes,1,opt,name=key,proto3,casttype=Key" json:"key,omitempty"`
 	// The candidate commit timestamp the transaction record held at the time
 	// it was aborted.

--- a/pkg/roachpb/data.proto
+++ b/pkg/roachpb/data.proto
@@ -430,6 +430,18 @@ message AbortSpanEntry {
   option (gogoproto.populate) = true;
 
   // The key of the associated transaction.
+  //
+  // TODO(tschottdorf): when splitting ranges, we currently blindly copy the
+  // abort span of the pre-split range into the RHS of the post-split ranges.
+  // This is a bit silly since the records contain the key that anchors the
+  // transaction, and so in principle we can tell which records to copy (though
+  // that means we have to decode them). The extra copy isn't an issue since the
+  // span is usually small, but we've seen that in practice it can become large
+  // (#25233), at which point splitting either becomes impossible (due to the
+  // raft max command size) or a bad idea (as it duplicates the large span
+  // further). We should generally opt for the safer (albeit somewhat slower)
+  // option of copying only what's needed. In a similar spirit, we could remove
+  // those entries from the LHS.
   bytes key = 1 [(gogoproto.casttype) = "Key"];
   // The candidate commit timestamp the transaction record held at the time
   // it was aborted.

--- a/pkg/storage/gc_queue.go
+++ b/pkg/storage/gc_queue.go
@@ -29,6 +29,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/gossip"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/storage/abortspan"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine"
 	"github.com/cockroachdb/cockroach/pkg/storage/engine/enginepb"
@@ -59,7 +60,8 @@ const (
 	//
 	// TODO(tschottdorf): need to enforce at all times that this is much
 	// larger than the heartbeat interval used by the coordinator.
-	txnCleanupThreshold = time.Hour
+	txnCleanupThreshold           = time.Hour
+	txnCleanupAggressiveThreshold = time.Minute
 
 	// Thresholds used to decide whether to queue for GC based
 	// on keys and intents.
@@ -70,6 +72,10 @@ const (
 	// GCRequests into multiple batches.
 	gcKeyVersionChunkBytes = base.ChunkRaftCommandThresholdBytes
 )
+
+func shouldGCAggressively(st *cluster.Settings, sysBytes int64) bool {
+	return MaxCommandSize.Get(&st.SV)/6 < sysBytes
+}
 
 // gcQueue manages a queue of replicas slated to be scanned in their
 // entirety using the MVCC versions iterator. The gc queue manages the
@@ -134,6 +140,9 @@ type gcQueueScore struct {
 	GCBytes                  int64
 	GCByteAge                int64
 	ExpMinGCByteAgeReduction int64
+
+	// See (GCer).Aggressive.
+	Aggressive bool
 }
 
 func (r gcQueueScore) String() string {
@@ -162,6 +171,23 @@ func (gcq *gcQueue) shouldQueue(
 	ctx context.Context, now hlc.Timestamp, repl *Replica, sysCfg config.SystemConfig,
 ) (bool, float64) {
 	r := makeGCQueueScore(ctx, repl, now, sysCfg)
+	if r.Aggressive {
+		// Always process when being aggressive.
+		r.FinalScore += 1.0
+		r.ShouldQueue = true
+
+		// Send a crash report because we don't want to have to queue replicas
+		// aggressively, let alone in a tight loop.
+		_ = repl.store.stopper.RunAsyncTask(ctx, "report aggressive GC", func(ctx context.Context) {
+			log.SendCrashReport(
+				ctx,
+				&repl.store.cfg.Settings.SV,
+				0, // depth
+				"aggressive GC initiated for range %d: %v",
+				[]interface{}{log.Safe(repl.RangeID), log.Safe(repl.GetMVCCStats())},
+			)
+		})
+	}
 	return r.ShouldQueue, r.FinalScore
 }
 
@@ -521,12 +547,19 @@ func (NoopGCer) SetGCThreshold(context.Context, GCThreshold) error { return nil 
 // GC implements storage.GCer.
 func (NoopGCer) GC(context.Context, []roachpb.GCRequest_GCKey) error { return nil }
 
+// Aggressive implements storage.GCer. It always returns false.
+func (NoopGCer) Aggressive() bool { return false }
+
 type replicaGCer struct {
 	repl  *Replica
 	count int32 // update atomically
 }
 
 var _ GCer = &replicaGCer{}
+
+func (r *replicaGCer) Aggressive() bool {
+	return shouldGCAggressively(r.repl.ClusterSettings(), r.repl.GetMVCCStats().SysBytes)
+}
 
 func (r *replicaGCer) template() roachpb.GCRequest {
 	desc := r.repl.Desc()
@@ -685,6 +718,9 @@ type GCThreshold struct {
 type GCer interface {
 	SetGCThreshold(context.Context, GCThreshold) error
 	GC(context.Context, []roachpb.GCRequest_GCKey) error
+	// When this returns true, run GC aggressively. This is a last resort to clean
+	// up large local key ranges for which no good triggers exist.
+	Aggressive() bool
 }
 
 // RunGC runs garbage collection for the specified descriptor on the
@@ -713,15 +749,17 @@ func RunGC(
 
 	// Compute intent expiration (intent age at which we attempt to resolve).
 	intentExp := now.Add(-intentAgeThreshold.Nanoseconds(), 0)
-	txnExp := now.Add(-txnCleanupThreshold.Nanoseconds(), 0)
 
 	gc := engine.MakeGarbageCollector(now, policy)
 	infoMu.Threshold = gc.Threshold
-	infoMu.TxnSpanGCThreshold = txnExp
+	{
+		txnExp := now.Add(-txnCleanupThreshold.Nanoseconds(), 0)
+		infoMu.TxnSpanGCThreshold = txnExp
+	}
 
 	if err := gcer.SetGCThreshold(ctx, GCThreshold{
 		Key: gc.Threshold,
-		Txn: txnExp,
+		Txn: infoMu.TxnSpanGCThreshold,
 	}); err != nil {
 		return GCInfo{}, errors.Wrap(err, "failed to set GC thresholds")
 	}
@@ -860,10 +898,23 @@ func RunGC(
 		}
 	}
 
-	// From now on, all newly added keys are range-local.
+	infoMu.Lock()
+	localExp := infoMu.TxnSpanGCThreshold
+	infoMu.Unlock()
+
+	if gcer.Aggressive() {
+		localExp = now
+		localExp.Add(-txnCleanupAggressiveThreshold.Nanoseconds(), 0)
+
+		if err := gcer.SetGCThreshold(ctx, GCThreshold{
+			Txn: localExp,
+		}); err != nil {
+			return GCInfo{}, errors.Wrap(err, "failed to set GC thresholds")
+		}
+	}
 
 	// Process local range key entries (txn records, queue last processed times).
-	localRangeKeys, err := processLocalKeyRange(ctx, snap, desc, txnExp, &infoMu, cleanupTxnIntentsAsyncFn)
+	localRangeKeys, err := processLocalKeyRange(ctx, snap, desc, localExp, &infoMu, cleanupTxnIntentsAsyncFn)
 	if err != nil {
 		return GCInfo{}, err
 	}
@@ -874,7 +925,7 @@ func RunGC(
 
 	// Clean up the AbortSpan.
 	log.Event(ctx, "processing AbortSpan")
-	abortSpanKeys := processAbortSpan(ctx, snap, desc.RangeID, txnExp, &infoMu)
+	abortSpanKeys := processAbortSpan(ctx, snap, desc.RangeID, localExp, &infoMu)
 	if err := gcer.GC(ctx, abortSpanKeys); err != nil {
 		return GCInfo{}, err
 	}

--- a/pkg/storage/gc_queue_test.go
+++ b/pkg/storage/gc_queue_test.go
@@ -766,7 +766,11 @@ func TestGCQueueTransactionTable(t *testing.T) {
 				spans = val.([]roachpb.Span)
 			}
 			if !reflect.DeepEqual(spans, expIntents) {
-				return fmt.Errorf("%s: unexpected intent resolutions:\nexpected: %s\nobserved: %s", strKey, expIntents, spans)
+				err := fmt.Errorf("%s: unexpected intent resolutions:\nexpected: %s\nobserved: %s", strKey, expIntents, spans)
+				if len(spans) > len(expIntents) {
+					t.Fatal(err)
+				}
+				return err
 			}
 			entry := &roachpb.AbortSpanEntry{}
 			abortExists, err := tc.repl.abortSpan.Get(context.Background(), tc.store.Engine(), txns[strKey].ID, entry)


### PR DESCRIPTION
This isn't ready for prime time, but I want to test it on a real
dataset.

----

See #25233. The abort span (or transaction span) can become arbitrarily
large, and yet its GC is not driven by a metric. This makes it possible
for a range to become highly GC'able without having it be picked up by
GC.

Even worse, if the abort span is too large we won't be able to split the
range any more; a split *copies* the abort span into the right hand side
(though in theory it could copy only a relevant part and remove these
items from the LHS). This means that such a range can cause stability
problems.

Address this problem in a somewhat inelegant but hopefully workable way:
The SysBytes of the range queues the replica for "aggressive" GC when it
exceeds a set fraction of the max raft command size. In "aggressive"
mode, everything in the local key span older than a minute is cleared
out (in regular operation it's one hour). Doing this *should* interrupt
long-running transactions (though in theory it could let them refresh
their spans) though due to deficiencies in how the TxnGCSpanThreshold is
handled in practice it won't (this needs to be fixed separately).

Release note (bug fix): Prevent formation of large ranges in some workloads
with many aborted transactions.