### PR TITLE
sql: move schema change backfill logic to sql/backfill

### DIFF
--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/backfill"
 	"github.com/cockroachdb/cockroach/pkg/sql/distsqlrun"
 	"github.com/cockroachdb/cockroach/pkg/sql/jobs"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -331,7 +332,7 @@ func (sc *SchemaChanger) getMutationToBackfill(
 	ctx context.Context,
 	version sqlbase.DescriptorVersion,
 	backfillType backfillType,
-	filter distsqlrun.MutationFilter,
+	filter backfill.MutationFilter,
 ) (*sqlbase.DescriptorMutation, int, error) {
 	var mutation *sqlbase.DescriptorMutation
 	var mutationIdx int
@@ -441,7 +442,7 @@ func (sc *SchemaChanger) distBackfill(
 	version sqlbase.DescriptorVersion,
 	backfillType backfillType,
 	backfillChunkSize int64,
-	filter distsqlrun.MutationFilter,
+	filter backfill.MutationFilter,
 ) error {
 	duration := checkpointInterval
 	if sc.testingKnobs.WriteCheckpointInterval > 0 {
@@ -597,7 +598,7 @@ func (sc *SchemaChanger) backfillIndexes(
 
 	return sc.distBackfill(
 		ctx, evalCtx, lease, version, indexBackfill, indexBackfillChunkSize,
-		distsqlrun.IndexMutationFilter)
+		backfill.IndexMutationFilter)
 }
 
 func (sc *SchemaChanger) truncateAndBackfillColumns(
@@ -609,5 +610,5 @@ func (sc *SchemaChanger) truncateAndBackfillColumns(
 	return sc.distBackfill(
 		ctx, evalCtx,
 		lease, version, columnBackfill, columnTruncateAndBackfillChunkSize,
-		distsqlrun.ColumnMutationFilter)
+		backfill.ColumnMutationFilter)
 }

--- a/pkg/sql/backfill/backfill.go
+++ b/pkg/sql/backfill/backfill.go
@@ -1,0 +1,438 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+// The Column and Index backfill primitives.
+
+package backfill
+
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/internal/client"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/transform"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/pkg/util"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
+	"github.com/pkg/errors"
+)
+
+// MutationFilter is the type of a simple predicate on a mutation.
+type MutationFilter func(sqlbase.DescriptorMutation) bool
+
+// ColumnMutationFilter is a filter that allows mutations that add or drop
+// columns.
+func ColumnMutationFilter(m sqlbase.DescriptorMutation) bool {
+	return m.GetColumn() != nil &&
+		(m.Direction == sqlbase.DescriptorMutation_ADD || m.Direction == sqlbase.DescriptorMutation_DROP)
+}
+
+// IndexMutationFilter is a filter that allows mutations that add indexes.
+func IndexMutationFilter(m sqlbase.DescriptorMutation) bool {
+	return m.GetIndex() != nil && m.Direction == sqlbase.DescriptorMutation_ADD
+}
+
+// backfiller is common to a ColumnBackfiller or an IndexBackfiller.
+type backfiller struct {
+	fetcher sqlbase.RowFetcher
+	alloc   sqlbase.DatumAlloc
+}
+
+// ColumnBackfiller is capable of running a column backfill for all
+// updateCols.
+type ColumnBackfiller struct {
+	backfiller
+
+	added []sqlbase.ColumnDescriptor
+	// updateCols is a slice of all column descriptors that are being modified.
+	updateCols  []sqlbase.ColumnDescriptor
+	updateExprs []tree.TypedExpr
+	evalCtx     *tree.EvalContext
+}
+
+// Init initializes a column backfiller.
+func (cb *ColumnBackfiller) Init(evalCtx *tree.EvalContext, desc sqlbase.TableDescriptor) error {
+	cb.evalCtx = evalCtx
+	var dropped []sqlbase.ColumnDescriptor
+	if len(desc.Mutations) > 0 {
+		for _, m := range desc.Mutations {
+			if ColumnMutationFilter(m) {
+				desc := *m.GetColumn()
+				switch m.Direction {
+				case sqlbase.DescriptorMutation_ADD:
+					cb.added = append(cb.added, desc)
+				case sqlbase.DescriptorMutation_DROP:
+					dropped = append(dropped, desc)
+				}
+			}
+		}
+	}
+	defaultExprs, err := sqlbase.MakeDefaultExprs(
+		cb.added, &transform.ExprTransformContext{}, cb.evalCtx,
+	)
+	if err != nil {
+		return err
+	}
+	var txCtx transform.ExprTransformContext
+	computedExprs, err := sqlbase.MakeComputedExprs(cb.added, &desc,
+		tree.NewUnqualifiedTableName(tree.Name(desc.Name)), &txCtx, cb.evalCtx)
+	if err != nil {
+		return err
+	}
+
+	cb.updateCols = append(cb.added, dropped...)
+	if len(dropped) > 0 || len(defaultExprs) > 0 || len(computedExprs) > 0 {
+		// Populate default or computed values.
+		cb.updateExprs = make([]tree.TypedExpr, len(cb.updateCols))
+		for j, col := range cb.added {
+			if col.IsComputed() {
+				cb.updateExprs[j] = computedExprs[j]
+			} else if defaultExprs == nil || defaultExprs[j] == nil {
+				cb.updateExprs[j] = tree.DNull
+			} else {
+				cb.updateExprs[j] = defaultExprs[j]
+			}
+		}
+		for j := range dropped {
+			cb.updateExprs[j+len(cb.added)] = tree.DNull
+		}
+	}
+
+	// We need all the columns.
+	var valNeededForCol util.FastIntSet
+	valNeededForCol.AddRange(0, len(desc.Columns)-1)
+
+	colIdxMap := make(map[sqlbase.ColumnID]int, len(desc.Columns))
+	for i, c := range desc.Columns {
+		colIdxMap[c.ID] = i
+	}
+
+	tableArgs := sqlbase.RowFetcherTableArgs{
+		Desc:            &desc,
+		Index:           &desc.PrimaryIndex,
+		ColIdxMap:       colIdxMap,
+		Cols:            desc.Columns,
+		ValNeededForCol: valNeededForCol,
+	}
+	return cb.fetcher.Init(
+		false /* reverse */, false /* returnRangeInfo */, false /* isCheck */, &cb.alloc, tableArgs,
+	)
+}
+
+// RunColumnBackfillChunk runs column backfill over a chunk of the table using
+// the span sp provided, for all updateCols.
+func (cb *ColumnBackfiller) RunColumnBackfillChunk(
+	ctx context.Context,
+	txn *client.Txn,
+	tableDesc sqlbase.TableDescriptor,
+	otherTables []sqlbase.TableDescriptor,
+	sp roachpb.Span,
+	chunkSize int64,
+	alsoCommit bool,
+) (roachpb.Key, error) {
+	fkTables, _ := sqlbase.TablesNeededForFKs(
+		ctx,
+		tableDesc,
+		sqlbase.CheckUpdates,
+		sqlbase.NoLookup,
+		sqlbase.NoCheckPrivilege,
+		nil, /* AnalyzeExprFunction */
+	)
+	for _, fkTableDesc := range otherTables {
+		found, ok := fkTables[fkTableDesc.ID]
+		if !ok {
+			// We got passed an extra table for some reason - just ignore it.
+			continue
+		}
+		found.Table = &fkTableDesc
+		fkTables[fkTableDesc.ID] = found
+	}
+	for id, table := range fkTables {
+		if table.Table == nil {
+			// We weren't passed all of the tables that we need by the coordinator.
+			return roachpb.Key{}, errors.Errorf("table %v not sent by coordinator", id)
+		}
+	}
+	// TODO(dan): Tighten up the bound on the requestedCols parameter to
+	// makeRowUpdater.
+	requestedCols := make([]sqlbase.ColumnDescriptor, 0, len(tableDesc.Columns)+len(cb.added))
+	requestedCols = append(requestedCols, tableDesc.Columns...)
+	requestedCols = append(requestedCols, cb.added...)
+	ru, err := sqlbase.MakeRowUpdater(
+		txn,
+		&tableDesc,
+		fkTables,
+		cb.updateCols,
+		requestedCols,
+		sqlbase.RowUpdaterOnlyColumns,
+		cb.evalCtx,
+		&cb.alloc,
+	)
+	if err != nil {
+		return roachpb.Key{}, err
+	}
+
+	// TODO(dan): This check is an unfortunate bleeding of the internals of
+	// rowUpdater. Extract the sql row to k/v mapping logic out into something
+	// usable here.
+	if !ru.IsColumnOnlyUpdate() {
+		panic("only column data should be modified, but the rowUpdater is configured otherwise")
+	}
+
+	// Get the next set of rows.
+	//
+	// Running the scan and applying the changes in many transactions
+	// is fine because the schema change is in the correct state to
+	// handle intermediate OLTP commands which delete and add values
+	// during the scan. Index entries in the new index are being
+	// populated and deleted by the OLTP commands but not otherwise
+	// read or used
+	if err := cb.fetcher.StartScan(
+		ctx, txn, []roachpb.Span{sp}, true /* limitBatches */, chunkSize, false, /* traceKV */
+	); err != nil {
+		log.Errorf(ctx, "scan error: %s", err)
+		return roachpb.Key{}, err
+	}
+
+	oldValues := make(tree.Datums, len(ru.FetchCols))
+	updateValues := make(tree.Datums, len(cb.updateExprs))
+	b := txn.NewBatch()
+	rowLength := 0
+	iv := &sqlbase.RowIndexedVarContainer{
+		Cols:    tableDesc.Columns,
+		Mapping: ru.FetchColIDtoRowIndex,
+	}
+	cb.evalCtx.IVarContainer = iv
+	for i := int64(0); i < chunkSize; i++ {
+		datums, _, _, err := cb.fetcher.NextRowDecoded(ctx)
+		if err != nil {
+			return roachpb.Key{}, err
+		}
+		if datums == nil {
+			break
+		}
+		iv.CurSourceRow = datums
+
+		// Evaluate the new values. This must be done separately for
+		// each row so as to handle impure functions correctly.
+		for j, e := range cb.updateExprs {
+			val, err := e.Eval(cb.evalCtx)
+			if err != nil {
+				return roachpb.Key{}, sqlbase.NewInvalidSchemaDefinitionError(err)
+			}
+			if j < len(cb.added) && !cb.added[j].Nullable && val == tree.DNull {
+				return roachpb.Key{}, sqlbase.NewNonNullViolationError(cb.added[j].Name)
+			}
+			updateValues[j] = val
+		}
+		copy(oldValues, datums)
+		// Update oldValues with NULL values where values weren't found;
+		// only update when necessary.
+		if rowLength != len(datums) {
+			rowLength = len(datums)
+			for j := rowLength; j < len(oldValues); j++ {
+				oldValues[j] = tree.DNull
+			}
+		}
+		if _, err := ru.UpdateRow(
+			ctx, b, oldValues, updateValues, sqlbase.CheckFKs, false, /* traceKV */
+		); err != nil {
+			return roachpb.Key{}, err
+		}
+	}
+	// Write the new row values.
+	writeBatch := txn.Run
+	if alsoCommit {
+		writeBatch = txn.CommitInBatch
+	}
+	if err := writeBatch(ctx, b); err != nil {
+		return roachpb.Key{}, ConvertBackfillError(ctx, &tableDesc, b)
+	}
+	return cb.fetcher.Key(), nil
+}
+
+// ConvertBackfillError returns a cleaner SQL error for a failed Batch.
+func ConvertBackfillError(
+	ctx context.Context, tableDesc *sqlbase.TableDescriptor, b *client.Batch,
+) error {
+	// A backfill on a new schema element has failed and the batch contains
+	// information useful in printing a sensible error. However
+	// ConvertBatchError() will only work correctly if the schema elements
+	// are "live" in the tableDesc.
+	desc := protoutil.Clone(tableDesc).(*sqlbase.TableDescriptor)
+	mutationID := desc.Mutations[0].MutationID
+	for _, mutation := range desc.Mutations {
+		if mutation.MutationID != mutationID {
+			// Mutations are applied in a FIFO order. Only apply the first set
+			// of mutations if they have the mutation ID we're looking for.
+			break
+		}
+		desc.MakeMutationComplete(mutation)
+	}
+	return sqlbase.ConvertBatchError(ctx, desc, b)
+}
+
+// IndexBackfiller is capable of backfilling all the added index.
+type IndexBackfiller struct {
+	backfiller
+
+	added []sqlbase.IndexDescriptor
+	// colIdxMap maps ColumnIDs to indices into desc.Columns and desc.Mutations.
+	colIdxMap map[sqlbase.ColumnID]int
+
+	types   []sqlbase.ColumnType
+	rowVals tree.Datums
+}
+
+// Init initializes an IndexBackfiller.
+func (ib *IndexBackfiller) Init(desc sqlbase.TableDescriptor) error {
+	numCols := len(desc.Columns)
+	cols := desc.Columns
+	if len(desc.Mutations) > 0 {
+		cols = make([]sqlbase.ColumnDescriptor, 0, numCols+len(desc.Mutations))
+		cols = append(cols, desc.Columns...)
+		for _, m := range desc.Mutations {
+			if column := m.GetColumn(); column != nil {
+				cols = append(cols, *column)
+			}
+		}
+	}
+
+	var valNeededForCol util.FastIntSet
+	mutationID := desc.Mutations[0].MutationID
+	for _, m := range desc.Mutations {
+		if m.MutationID != mutationID {
+			break
+		}
+		if IndexMutationFilter(m) {
+			idx := m.GetIndex()
+			ib.added = append(ib.added, *idx)
+			for i, col := range cols {
+				if idx.ContainsColumnID(col.ID) {
+					valNeededForCol.Add(i)
+				}
+			}
+		}
+	}
+
+	ib.types = make([]sqlbase.ColumnType, len(cols))
+	for i := range cols {
+		ib.types[i] = cols[i].Type
+	}
+
+	ib.colIdxMap = make(map[sqlbase.ColumnID]int, len(cols))
+	for i, c := range cols {
+		ib.colIdxMap[c.ID] = i
+	}
+
+	tableArgs := sqlbase.RowFetcherTableArgs{
+		Desc:            &desc,
+		Index:           &desc.PrimaryIndex,
+		ColIdxMap:       ib.colIdxMap,
+		Cols:            cols,
+		ValNeededForCol: valNeededForCol,
+	}
+	return ib.fetcher.Init(
+		false /* reverse */, false /* returnRangeInfo */, false /* isCheck */, &ib.alloc, tableArgs,
+	)
+}
+
+// BuildIndexEntriesChunk reads a chunk of rows from a table using the span sp
+// provided, and builds all the added indexes.
+func (ib *IndexBackfiller) BuildIndexEntriesChunk(
+	ctx context.Context,
+	txn *client.Txn,
+	tableDesc sqlbase.TableDescriptor,
+	sp roachpb.Span,
+	chunkSize int64,
+) ([]sqlbase.IndexEntry, roachpb.Key, error) {
+	entries := make([]sqlbase.IndexEntry, 0, chunkSize*int64(len(ib.added)))
+
+	// Get the next set of rows.
+	//
+	// Running the scan and applying the changes in many transactions
+	// is fine because the schema change is in the correct state to
+	// handle intermediate OLTP commands which delete and add values
+	// during the scan. Index entries in the new index are being
+	// populated and deleted by the OLTP commands but not otherwise
+	// read or used
+	if err := ib.fetcher.StartScan(
+		ctx, txn, []roachpb.Span{sp}, true /* limitBatches */, chunkSize, false, /* traceKV */
+	); err != nil {
+		log.Errorf(ctx, "scan error: %s", err)
+		return nil, nil, err
+	}
+
+	buffer := make([]sqlbase.IndexEntry, len(ib.added))
+	for i := int64(0); i < chunkSize; i++ {
+		encRow, _, _, err := ib.fetcher.NextRow(ctx)
+		if err != nil {
+			return nil, nil, err
+		}
+		if encRow == nil {
+			break
+		}
+		if len(ib.rowVals) == 0 {
+			ib.rowVals = make(tree.Datums, len(encRow))
+		}
+		if err := sqlbase.EncDatumRowToDatums(ib.types, ib.rowVals, encRow, &ib.alloc); err != nil {
+			return nil, nil, err
+		}
+
+		// We're resetting the length of this slice for variable length indexes such as inverted
+		// indexes which can append entries to the end of the slice. If we don't do this, then everything
+		// EncodeSecondaryIndexes appends to secondaryIndexEntries for a row, would stay in the slice for
+		// subsequent rows and we would then have duplicates in entries on output.
+		buffer = buffer[:len(ib.added)]
+		if buffer, err = sqlbase.EncodeSecondaryIndexes(
+			&tableDesc, ib.added, ib.colIdxMap,
+			ib.rowVals, buffer); err != nil {
+			return nil, nil, err
+		}
+		entries = append(entries, buffer...)
+	}
+	return entries, ib.fetcher.Key(), nil
+}
+
+// RunIndexBackfillChunk runs an index backfill over a chunk of the table
+// by tracversing the span sp provided. The backfill is run for the added
+// indexes.
+func (ib *IndexBackfiller) RunIndexBackfillChunk(
+	ctx context.Context,
+	txn *client.Txn,
+	tableDesc sqlbase.TableDescriptor,
+	sp roachpb.Span,
+	chunkSize int64,
+	alsoCommit bool,
+) (roachpb.Key, error) {
+	entries, key, err := ib.BuildIndexEntriesChunk(ctx, txn, tableDesc, sp, chunkSize)
+	if err != nil {
+		return nil, err
+	}
+	batch := txn.NewBatch()
+
+	for _, entry := range entries {
+		batch.InitPut(entry.Key, &entry.Value, false /* failOnTombstones */)
+	}
+	writeBatch := txn.Run
+	if alsoCommit {
+		writeBatch = txn.CommitInBatch
+	}
+	if err := writeBatch(ctx, batch); err != nil {
+		return nil, ConvertBackfillError(ctx, &tableDesc, batch)
+	}
+	return key, nil
+}

--- a/pkg/sql/distsqlrun/columnbackfiller.go
+++ b/pkg/sql/distsqlrun/columnbackfiller.go
@@ -17,39 +17,22 @@ package distsqlrun
 import (
 	"context"
 
-	"github.com/pkg/errors"
-
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
-	"github.com/cockroachdb/cockroach/pkg/sql/sem/transform"
-	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/backfill"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
-	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
-	"github.com/cockroachdb/cockroach/pkg/util/log"
 )
 
 // columnBackfiller is a processor for backfilling columns.
 type columnBackfiller struct {
 	backfiller
 
-	added   []sqlbase.ColumnDescriptor
-	dropped []sqlbase.ColumnDescriptor
-	// updateCols is a slice of all column descriptors that are being modified.
-	updateCols  []sqlbase.ColumnDescriptor
-	updateExprs []tree.TypedExpr
-
-	evalCtx *tree.EvalContext
+	backfill.ColumnBackfiller
 }
 
 var _ Processor = &columnBackfiller{}
 var _ chunkBackfiller = &columnBackfiller{}
-
-// ColumnMutationFilter is a filter that allows mutations that add or drop
-// columns.
-func ColumnMutationFilter(m sqlbase.DescriptorMutation) bool {
-	return m.GetColumn() != nil && (m.Direction == sqlbase.DescriptorMutation_ADD || m.Direction == sqlbase.DescriptorMutation_DROP)
-}
 
 func newColumnBackfiller(
 	flowCtx *FlowCtx, spec BackfillerSpec, post *PostProcessSpec, output RowReceiver,
@@ -57,90 +40,19 @@ func newColumnBackfiller(
 	cb := &columnBackfiller{
 		backfiller: backfiller{
 			name:    "Column",
-			filter:  ColumnMutationFilter,
+			filter:  backfill.ColumnMutationFilter,
 			flowCtx: flowCtx,
 			output:  output,
 			spec:    spec,
 		},
-		evalCtx: flowCtx.NewEvalCtx(),
 	}
 	cb.backfiller.chunkBackfiller = cb
 
-	if err := cb.init(); err != nil {
+	if err := cb.ColumnBackfiller.Init(cb.flowCtx.NewEvalCtx(), cb.spec.Table); err != nil {
 		return nil, err
 	}
 
 	return cb, nil
-}
-
-func (cb *columnBackfiller) init() error {
-	desc := cb.spec.Table
-
-	// colIdxMap maps ColumnIDs to indices into desc.Columns and desc.Mutations.
-	var colIdxMap map[sqlbase.ColumnID]int
-
-	if len(desc.Mutations) > 0 {
-		for _, m := range desc.Mutations {
-			if ColumnMutationFilter(m) {
-				desc := *m.GetColumn()
-				switch m.Direction {
-				case sqlbase.DescriptorMutation_ADD:
-					cb.added = append(cb.added, desc)
-				case sqlbase.DescriptorMutation_DROP:
-					cb.dropped = append(cb.dropped, desc)
-				}
-			}
-		}
-	}
-	defaultExprs, err := sqlbase.MakeDefaultExprs(
-		cb.added, &transform.ExprTransformContext{}, cb.evalCtx,
-	)
-	if err != nil {
-		return err
-	}
-	var txCtx transform.ExprTransformContext
-	computedExprs, err := sqlbase.MakeComputedExprs(cb.added, &desc, tree.NewUnqualifiedTableName(tree.Name(desc.Name)), &txCtx, cb.flowCtx.NewEvalCtx())
-	if err != nil {
-		return err
-	}
-
-	cb.updateCols = append(cb.added, cb.dropped...)
-	if len(cb.dropped) > 0 || len(defaultExprs) > 0 || len(computedExprs) > 0 {
-		// Populate default or computed values.
-		cb.updateExprs = make([]tree.TypedExpr, len(cb.updateCols))
-		for j, col := range cb.added {
-			if col.IsComputed() {
-				cb.updateExprs[j] = computedExprs[j]
-			} else if defaultExprs == nil || defaultExprs[j] == nil {
-				cb.updateExprs[j] = tree.DNull
-			} else {
-				cb.updateExprs[j] = defaultExprs[j]
-			}
-		}
-		for j := range cb.dropped {
-			cb.updateExprs[j+len(cb.added)] = tree.DNull
-		}
-	}
-
-	// We need all the columns.
-	var valNeededForCol util.FastIntSet
-	valNeededForCol.AddRange(0, len(desc.Columns)-1)
-
-	colIdxMap = make(map[sqlbase.ColumnID]int, len(desc.Columns))
-	for i, c := range desc.Columns {
-		colIdxMap[c.ID] = i
-	}
-
-	tableArgs := sqlbase.RowFetcherTableArgs{
-		Desc:            &desc,
-		Index:           &desc.PrimaryIndex,
-		ColIdxMap:       colIdxMap,
-		Cols:            desc.Columns,
-		ValNeededForCol: valNeededForCol,
-	}
-	return cb.fetcher.Init(
-		false /* reverse */, false /* returnRangeInfo */, false /* isCheck */, &cb.alloc, tableArgs,
-	)
 }
 
 // runChunk implements the chunkBackfiller interface.
@@ -152,6 +64,7 @@ func (cb *columnBackfiller) runChunk(
 	readAsOf hlc.Timestamp,
 ) (roachpb.Key, error) {
 	tableDesc := cb.backfiller.spec.Table
+	var key roachpb.Key
 	err := cb.flowCtx.clientDB.Txn(ctx, func(ctx context.Context, txn *client.Txn) error {
 		if cb.flowCtx.testingKnobs.RunBeforeBackfillChunk != nil {
 			if err := cb.flowCtx.testingKnobs.RunBeforeBackfillChunk(sp); err != nil {
@@ -162,121 +75,17 @@ func (cb *columnBackfiller) runChunk(
 			defer cb.flowCtx.testingKnobs.RunAfterBackfillChunk()
 		}
 
-		fkTables, _ := sqlbase.TablesNeededForFKs(
+		var err error
+		key, err = cb.RunColumnBackfillChunk(
 			ctx,
-			tableDesc,
-			sqlbase.CheckUpdates,
-			sqlbase.NoLookup,
-			sqlbase.NoCheckPrivilege,
-			nil, /* AnalyzeExprFunction */
-		)
-		for _, fkTableDesc := range cb.spec.OtherTables {
-			found, ok := fkTables[fkTableDesc.ID]
-			if !ok {
-				// We got passed an extra table for some reason - just ignore it.
-				continue
-			}
-			found.Table = &fkTableDesc
-			fkTables[fkTableDesc.ID] = found
-		}
-		for id, table := range fkTables {
-			if table.Table == nil {
-				// We weren't passed all of the tables that we need by the coordinator.
-				return errors.Errorf("table %v not sent by coordinator", id)
-			}
-		}
-		// TODO(dan): Tighten up the bound on the requestedCols parameter to
-		// makeRowUpdater.
-		requestedCols := make([]sqlbase.ColumnDescriptor, 0, len(tableDesc.Columns)+len(cb.added))
-		requestedCols = append(requestedCols, tableDesc.Columns...)
-		requestedCols = append(requestedCols, cb.added...)
-		ru, err := sqlbase.MakeRowUpdater(
 			txn,
-			&tableDesc,
-			fkTables,
-			cb.updateCols,
-			requestedCols,
-			sqlbase.RowUpdaterOnlyColumns,
-			&cb.flowCtx.EvalCtx,
-			&cb.alloc,
+			tableDesc,
+			cb.backfiller.spec.OtherTables,
+			sp,
+			chunkSize,
+			true, /*alsoCommit*/
 		)
-		if err != nil {
-			return err
-		}
-
-		// TODO(dan): This check is an unfortunate bleeding of the internals of
-		// rowUpdater. Extract the sql row to k/v mapping logic out into something
-		// usable here.
-		if !ru.IsColumnOnlyUpdate() {
-			panic("only column data should be modified, but the rowUpdater is configured otherwise")
-		}
-
-		// Get the next set of rows.
-		//
-		// Running the scan and applying the changes in many transactions
-		// is fine because the schema change is in the correct state to
-		// handle intermediate OLTP commands which delete and add values
-		// during the scan. Index entries in the new index are being
-		// populated and deleted by the OLTP commands but not otherwise
-		// read or used
-		if err := cb.fetcher.StartScan(
-			ctx, txn, []roachpb.Span{sp}, true /* limitBatches */, chunkSize, false, /* traceKV */
-		); err != nil {
-			log.Errorf(ctx, "scan error: %s", err)
-			return err
-		}
-
-		oldValues := make(tree.Datums, len(ru.FetchCols))
-		updateValues := make(tree.Datums, len(cb.updateExprs))
-		b := txn.NewBatch()
-		rowLength := 0
-		iv := &sqlbase.RowIndexedVarContainer{
-			Cols:    tableDesc.Columns,
-			Mapping: ru.FetchColIDtoRowIndex,
-		}
-		cb.evalCtx.IVarContainer = iv
-		for i := int64(0); i < chunkSize; i++ {
-			datums, _, _, err := cb.fetcher.NextRowDecoded(ctx)
-			if err != nil {
-				return err
-			}
-			if datums == nil {
-				break
-			}
-			iv.CurSourceRow = datums
-
-			// Evaluate the new values. This must be done separately for
-			// each row so as to handle impure functions correctly.
-			for j, e := range cb.updateExprs {
-				val, err := e.Eval(cb.evalCtx)
-				if err != nil {
-					return sqlbase.NewInvalidSchemaDefinitionError(err)
-				}
-				if j < len(cb.added) && !cb.added[j].Nullable && val == tree.DNull {
-					return sqlbase.NewNonNullViolationError(cb.added[j].Name)
-				}
-				updateValues[j] = val
-			}
-			copy(oldValues, datums)
-			// Update oldValues with NULL values where values weren't found;
-			// only update when necessary.
-			if rowLength != len(datums) {
-				rowLength = len(datums)
-				for j := rowLength; j < len(oldValues); j++ {
-					oldValues[j] = tree.DNull
-				}
-			}
-			if _, err := ru.UpdateRow(
-				ctx, b, oldValues, updateValues, sqlbase.CheckFKs, false, /* traceKV */
-			); err != nil {
-				return err
-			}
-		}
-		// Write the new row values.
-		if err := txn.CommitInBatch(ctx, b); err != nil {
-			return ConvertBackfillError(ctx, &cb.spec.Table, b)
-		}
-		return nil
+		return err
 	})
-	return cb.fetcher.Key(), err
+	return key, err
 }


### PR DESCRIPTION
The distsql backfill calls the sql/backfill code.

The future plan is to also call backfill within a transaction
that runs schema changes in the same transaction as a
CREATE TABLE. Since the CREATE TABLE in a transaction
is not visible to other transactions until the transaction
commits, the schema change can run the backfill without
incrementing the version of the table descriptor.

related to #24626

Release note: None