### PR TITLE
cherry-pick 2.0: fix flaky select_index test

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/select_index
+++ b/pkg/sql/logictest/testdata/logic_test/select_index
@@ -1115,7 +1115,7 @@ query B
 SELECT * FROM bool2 WHERE a IS NULL
 ----
 
-query B
+query B rowsort
 SELECT * FROM bool2 WHERE a IS NOT NULL
 ----
 false


### PR DESCRIPTION
This is a fixup to #25339, I missed a `rowsort`.

Release note: None