### PR TITLE
sql: provde a new function `random_int64()`

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -570,6 +570,8 @@ has no relationship with the commit order of concurrent transactions.</p>
 </span></td></tr>
 <tr><td><code>random() &rarr; <a href="float.html">float</a></code></td><td><span class="funcdesc"><p>Returns a random float between 0 and 1.</p>
 </span></td></tr>
+<tr><td><code>random_int64() &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Returns a random 64-bit integer.</p>
+</span></td></tr>
 <tr><td><code>round(input: <a href="decimal.html">decimal</a>, decimal_accuracy: <a href="int.html">int</a>) &rarr; <a href="decimal.html">decimal</a></code></td><td><span class="funcdesc"><p>Keeps <code>decimal_accuracy</code> number of figures to the right of the zero position in <code>input</code> using half away from zero rounding. If <code>decimal_accuracy</code> is not in the range -2^31…(2^31-1), the results are undefined.</p>
 </span></td></tr>
 <tr><td><code>round(input: <a href="float.html">float</a>, decimal_accuracy: <a href="int.html">int</a>) &rarr; <a href="float.html">float</a></code></td><td><span class="funcdesc"><p>Keeps <code>decimal_accuracy</code> number of figures to the right of the zero position  in <code>input</code> using half to even (banker’s) rounding.</p>

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -1025,6 +1025,19 @@ CockroachDB supports the following flags:
 		},
 	},
 
+	"random_int64": {
+		tree.Builtin{
+			Types:                   tree.ArgTypes{},
+			ReturnType:              tree.FixedReturnType(types.Int),
+			Impure:                  true,
+			NeedsRepeatedEvaluation: true,
+			Fn: func(_ *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
+				return tree.NewDInt(tree.DInt(int64(rand.Uint64()))), nil
+			},
+			Info: "Returns a random 64-bit integer.",
+		},
+	},
+
 	"unique_rowid": {
 		tree.Builtin{
 			Types:      tree.ArgTypes{},

--- a/pkg/sql/sem/tree/normalize_test.go
+++ b/pkg/sql/sem/tree/normalize_test.go
@@ -144,6 +144,7 @@ func TestNormalizeExpr(t *testing.T) {
 		{`s=lower('FOO')`, `s = 'foo'`},
 		{`lower(s)='foo'`, `lower(s) = 'foo'`},
 		{`random()`, `random()`},
+		{`random_int64()`, `random_int64()`},
 		{`a=count('FOO') OVER ()`, `a = count('FOO') OVER ()`},
 		{`9223372036854775808`, `9223372036854775808`},
 		{`-9223372036854775808`, `-9223372036854775808`},


### PR DESCRIPTION
Fixes #7186.

Release note (sql change): A new function `random_int64()` is
provided, intended for use on INTEGER index keys when there is no
application demand for time ordering. It has less data locality than
`unique_rowid()` and thus will reduce hotspots and may increase
insert/access performance.