### PR TITLE
sql: replace bytes.Buffer with strings.Builder where appropriate

### DIFF
--- a/pkg/sql/lex/encode.go
+++ b/pkg/sql/lex/encode.go
@@ -25,6 +25,7 @@ package lex
 
 import (
 	"bytes"
+	"strings"
 	"unicode"
 	"unicode/utf8"
 
@@ -80,7 +81,7 @@ func EscapeSQLString(in string) string {
 
 // HexEncodeString writes a hexadecimal representation of the string
 // to buf.
-func HexEncodeString(buf *bytes.Buffer, in string) {
+func HexEncodeString(buf *strings.Builder, in string) {
 	for i := 0; i < len(in); i++ {
 		buf.Write(stringencoding.RawHexMap[in[i]])
 	}

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -3018,7 +3018,7 @@ func PerformCast(ctx *EvalContext, d Datum, t coltypes.CastTargetType) (Datum, e
 		case *DCollatedString:
 			s = t.Contents
 		case *DBytes:
-			var buf bytes.Buffer
+			var buf strings.Builder
 			buf.WriteString("\\x")
 			lex.HexEncodeString(&buf, string(*t))
 			s = buf.String()


### PR DESCRIPTION
The fixes here don't change any functionality but easily give better efficiency; most instances of bytes.Buffer have already been replaced with strings.Builder in these packages. Note, the changes in regexpEvalFlags can be very significant: avoids an allocation, and avoids fmt.Sprintf for obvious reasons.