### PR TITLE
css: fix big font (forced min font size)

### DIFF
--- a/pkg/ui/styl/layout/navigation-bar.styl
+++ b/pkg/ui/styl/layout/navigation-bar.styl
@@ -56,6 +56,7 @@ $subnav-underline-height = 3px
     color $body-color
     list-style-type none
     line-height 18px
+    word-break break-all
 
     &.normal
       polyline, rect, path, ellipse


### PR DESCRIPTION
small css style patch for nav bar, fix big font out (user forced min font size)

just for example i prefer set minimum font size 14 in FF browser (i hope smbdy do same ) https://gist.github.com/hyphop/0cecb27ee2fc1d50e2d79193efbbe3ee#file-5_ff_pref_big_fonts-png-255-png

check next example pics

PS: i think css word-break its not bad solution

some additional info there about this 
https://gist.github.com/hyphop/0cecb27ee2fc1d50e2d79193efbbe3ee