### PR TITLE
sql: Check for and reject typos in zone config constraints

### DIFF
--- a/pkg/cli/testdata/zone_attrs.yaml
+++ b/pkg/cli/testdata/zone_attrs.yaml
@@ -1,2 +1,2 @@
 num_replicas: 1
-constraints: [+us-east-1a,+ssd]
+constraints: [+zone=us-east-1a,+ssd]

--- a/pkg/cli/testdata/zone_attrs_advanced.yaml
+++ b/pkg/cli/testdata/zone_attrs_advanced.yaml
@@ -1,3 +1,3 @@
 num_replicas: 3
-constraints: {"+us-east-1a,+ssd": 1, "+us-east-1b": 1}
-experimental_lease_preferences: [[+us-east1b], [+us-east-1a]]
+constraints: {"+zone=us-east-1a,+ssd": 1, "+region=us-east-1": 1}
+experimental_lease_preferences: [[+region=us-east-1], [+zone=us-east-1a]]

--- a/pkg/server/updates_test.go
+++ b/pkg/server/updates_test.go
@@ -103,6 +103,7 @@ func TestCheckVersion(t *testing.T) {
 func TestReportUsage(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
+	const elemName = "somestring"
 	ctx := context.TODO()
 
 	r := makeMockRecorder(t)
@@ -111,15 +112,18 @@ func TestReportUsage(t *testing.T) {
 
 	st := cluster.MakeTestingClusterSettings()
 
+	storeSpec := base.DefaultTestStoreSpec
+	storeSpec.Attributes = roachpb.Attributes{Attrs: []string{elemName}}
 	params := base.TestServerArgs{
 		StoreSpecs: []base.StoreSpec{
-			base.DefaultTestStoreSpec,
+			storeSpec,
 			base.DefaultTestStoreSpec,
 		},
 		Settings: st,
 		Locality: roachpb.Locality{
 			Tiers: []roachpb.Tier{
 				{Key: "region", Value: "east"},
+				{Key: "zone", Value: elemName},
 				{Key: "state", Value: "ny"},
 				{Key: "city", Value: "nyc"},
 			},
@@ -132,7 +136,6 @@ func TestReportUsage(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	const elemName = "somestring"
 	if _, err := db.Exec(fmt.Sprintf(`CREATE DATABASE %s`, elemName)); err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/sql/set_zone_config_test.go
+++ b/pkg/sql/set_zone_config_test.go
@@ -1,0 +1,126 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package sql
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
+	"github.com/cockroachdb/cockroach/pkg/server/status"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+)
+
+func TestValidateZoneAttrsAndLocalities(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	stores := []struct {
+		nodeAttrs     []string
+		storeAttrs    []string
+		storeLocality []roachpb.Tier
+	}{
+		{
+			nodeAttrs:  []string{"highcpu", "highmem"},
+			storeAttrs: []string{"ssd"},
+			storeLocality: []roachpb.Tier{
+				{Key: "geo", Value: "us"},
+				{Key: "region", Value: "us-east1"},
+				{Key: "zone", Value: "us-east1-b"},
+			},
+		},
+		{
+			nodeAttrs:  []string{"lowcpu", "lowmem"},
+			storeAttrs: []string{"hdd"},
+			storeLocality: []roachpb.Tier{
+				{Key: "geo", Value: "eu"},
+				{Key: "region", Value: "eu-west1"},
+				{Key: "zone", Value: "eu-west1-b"},
+				{Key: "rack", Value: "17"},
+			},
+		},
+	}
+
+	nodes := &serverpb.NodesResponse{}
+	for _, store := range stores {
+		nodes.Nodes = append(nodes.Nodes, status.NodeStatus{
+			StoreStatuses: []status.StoreStatus{
+				{
+					Desc: roachpb.StoreDescriptor{
+						Attrs: roachpb.Attributes{
+							Attrs: store.storeAttrs,
+						},
+						Node: roachpb.NodeDescriptor{
+							Attrs: roachpb.Attributes{
+								Attrs: store.nodeAttrs,
+							},
+							Locality: roachpb.Locality{
+								Tiers: store.storeLocality,
+							},
+						},
+					},
+				},
+			},
+		})
+	}
+
+	getNodes := func(_ context.Context, _ *serverpb.NodesRequest) (*serverpb.NodesResponse, error) {
+		return nodes, nil
+	}
+
+	const expectSuccess = false
+	const expectErr = true
+	for i, tc := range []struct {
+		cfg       string
+		expectErr bool
+	}{
+		{`nonsense`, expectErr},
+		{`range_max_bytes: 100`, expectSuccess},
+		{`range_max_byte: 100`, expectErr},
+		{`constraints: ["+region=us-east1"]`, expectSuccess},
+		{`constraints: {"+region=us-east1": 2, "+region=eu-west1": 1}`, expectSuccess},
+		{`constraints: ["+region=us-eas1"]`, expectErr},
+		{`constraints: {"+region=us-eas1": 2, "+region=eu-west1": 1}`, expectErr},
+		{`constraints: {"+region=us-east1": 2, "+region=eu-wes1": 1}`, expectErr},
+		{`constraints: ["+regio=us-east1"]`, expectErr},
+		{`constraints: ["+rack=17"]`, expectSuccess},
+		{`constraints: ["+rack=18"]`, expectErr},
+		{`constraints: ["+rach=17"]`, expectErr},
+		{`constraints: ["+highcpu"]`, expectSuccess},
+		{`constraints: ["+lowmem"]`, expectSuccess},
+		{`constraints: ["+ssd"]`, expectSuccess},
+		{`constraints: ["+highcp"]`, expectErr},
+		{`constraints: ["+owmem"]`, expectErr},
+		{`constraints: ["+sssd"]`, expectErr},
+		{`experimental_lease_preferences: [["+region=us-east1", "+ssd"], ["+geo=us", "+highcpu"]]`, expectSuccess},
+		{`experimental_lease_preferences: [["+region=us-eat1", "+ssd"], ["+geo=us", "+highcpu"]]`, expectErr},
+		{`experimental_lease_preferences: [["+region=us-east1", "+foo"], ["+geo=us", "+highcpu"]]`, expectErr},
+		{`experimental_lease_preferences: [["+region=us-east1", "+ssd"], ["+geo=us", "+bar"]]`, expectErr},
+		{`constraints: ["-region=us-east1"]`, expectSuccess},
+		{`constraints: ["-regio=us-eas1"]`, expectSuccess},
+		{`constraints: {"-region=us-eas1": 2, "-region=eu-wes1": 1}`, expectSuccess},
+		{`constraints: ["-foo=bar"]`, expectSuccess},
+		{`constraints: ["-highcpu"]`, expectSuccess},
+		{`constraints: ["-ssd"]`, expectSuccess},
+		{`constraints: ["-fake"]`, expectSuccess},
+	} {
+		err := validateZoneAttrsAndLocalities(context.Background(), getNodes, tc.cfg)
+		if err != nil && !tc.expectErr {
+			t.Errorf("#%d: expected success for %q; got %v", i, tc.cfg, err)
+		} else if err == nil && tc.expectErr {
+			t.Errorf("#%d: expected err for %q; got success", i, tc.cfg)
+		}
+	}
+}


### PR DESCRIPTION
This makes sure that each individual constraint specified in zone config
`constraints` and `experimental_lease_preferences` match at least one
node in the cluster. This helps prevent the confusion caused by typos,
which can otherwise be hard to detect (particularly in
`experimental_lease_preferences`).

Fixes #24021

Release note (cli change): Typos in zone config constraints are now
validated. At the time that they're set, required attributes and
localities must match at least one node in the cluster.