### PR TITLE
sql: remove allowAdding resolver option

### DIFF
--- a/pkg/sql/alter_sequence.go
+++ b/pkg/sql/alter_sequence.go
@@ -37,7 +37,7 @@ func (p *planner) AlterSequence(ctx context.Context, n *tree.AlterSequence) (pla
 	var seqDesc *TableDescriptor
 	// DDL statements avoid the cache to avoid leases, and can view non-public descriptors.
 	// TODO(vivek): check if the cache can be used.
-	p.runWithOptions(resolveFlags{allowAdding: true, skipCache: true}, func() {
+	p.runWithOptions(resolveFlags{skipCache: true}, func() {
 		seqDesc, err = ResolveExistingObject(ctx, p, tn, !n.IfExists, requireSequenceDesc)
 	})
 	if err != nil {

--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -54,7 +54,7 @@ func (p *planner) AlterTable(ctx context.Context, n *tree.AlterTable) (planNode,
 	var tableDesc *TableDescriptor
 	// DDL statements avoid the cache to avoid leases, and can view non-public descriptors.
 	// TODO(vivek): check if the cache can be used.
-	p.runWithOptions(resolveFlags{allowAdding: true, skipCache: true}, func() {
+	p.runWithOptions(resolveFlags{skipCache: true}, func() {
 		tableDesc, err = ResolveExistingObject(ctx, p, tn, !n.IfExists, requireTableDesc)
 	})
 	if err != nil {
@@ -122,7 +122,7 @@ func (n *alterTableNode) startExec(params runParams) error {
 				var changedSeqDescs []*TableDescriptor
 				// DDL statements use uncached descriptors, and can view newly added things.
 				// TODO(vivek): check if the cache can be used.
-				params.p.runWithOptions(resolveFlags{allowAdding: true, skipCache: true}, func() {
+				params.p.runWithOptions(resolveFlags{skipCache: true}, func() {
 					changedSeqDescs, err = maybeAddSequenceDependencies(params.p, n.tableDesc, col, expr, params.EvalContext())
 				})
 				if err != nil {
@@ -248,7 +248,7 @@ func (n *alterTableNode) startExec(params runParams) error {
 				// on tables that were just added. See the comment at the start of
 				// the global-scope resolveFK().
 				// TODO(vivek): check if the cache can be used.
-				params.p.runWithOptions(resolveFlags{allowAdding: true, skipCache: true}, func() {
+				params.p.runWithOptions(resolveFlags{skipCache: true}, func() {
 					err = params.p.resolveFK(params.ctx, n.tableDesc, d, affected, sqlbase.ConstraintValidity_Unvalidated)
 				})
 				if err != nil {
@@ -694,7 +694,7 @@ func applyColumnMutation(
 			// DDL statements avoid the cache to avoid leases, and can view non-public descriptors.
 			// TODO(vivek): check if the cache can be used.
 			var changedSeqDescs []*TableDescriptor
-			params.p.runWithOptions(resolveFlags{allowAdding: true, skipCache: true}, func() {
+			params.p.runWithOptions(resolveFlags{skipCache: true}, func() {
 				changedSeqDescs, err = maybeAddSequenceDependencies(params.p, tableDesc, col, expr, params.EvalContext())
 			})
 			if err != nil {

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -1783,7 +1783,6 @@ func (ex *connExecutor) resetPlanner(
 	p.isPreparing = false
 	p.asOfSystemTime = false
 	p.avoidCachedDescriptors = false
-	p.revealNewDescriptors = false
 }
 
 // txnStateTransitionsApplyWrapper is a wrapper on top of Machine built with the

--- a/pkg/sql/create_index.go
+++ b/pkg/sql/create_index.go
@@ -42,7 +42,7 @@ func (p *planner) CreateIndex(ctx context.Context, n *tree.CreateIndex) (planNod
 	var tableDesc *TableDescriptor
 	// DDL statements avoid the cache to avoid leases, and can view non-public descriptors.
 	// TODO(vivek): check if the cache can be used.
-	p.runWithOptions(resolveFlags{skipCache: true, allowAdding: true}, func() {
+	p.runWithOptions(resolveFlags{skipCache: true}, func() {
 		tableDesc, err = ResolveExistingObject(ctx, p, tn, true /*required*/, requireTableDesc)
 	})
 	if err != nil {

--- a/pkg/sql/create_sequence.go
+++ b/pkg/sql/create_sequence.go
@@ -36,7 +36,7 @@ func (p *planner) CreateSequence(ctx context.Context, n *tree.CreateSequence) (p
 	}
 
 	var dbDesc *DatabaseDescriptor
-	p.runWithOptions(resolveFlags{skipCache: true, allowAdding: true}, func() {
+	p.runWithOptions(resolveFlags{skipCache: true}, func() {
 		dbDesc, err = ResolveTargetObject(ctx, p, name)
 	})
 	if err != nil {

--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -55,7 +55,7 @@ func (p *planner) CreateTable(ctx context.Context, n *tree.CreateTable) (planNod
 	}
 
 	var dbDesc *DatabaseDescriptor
-	p.runWithOptions(resolveFlags{skipCache: true, allowAdding: true}, func() {
+	p.runWithOptions(resolveFlags{skipCache: true}, func() {
 		dbDesc, err = ResolveTargetObject(ctx, p, tn)
 	})
 	if err != nil {
@@ -1269,7 +1269,7 @@ func (p *planner) makeTableDesc(
 	// it needs to pull in descriptors from FK depended-on tables
 	// and interleaved parents using their current state in KV.
 	// See the comment at the start of MakeTableDesc() and resolveFK().
-	p.runWithOptions(resolveFlags{allowAdding: true, skipCache: true}, func() {
+	p.runWithOptions(resolveFlags{skipCache: true}, func() {
 		ret, err = MakeTableDesc(
 			ctx,
 			p.txn,

--- a/pkg/sql/create_view.go
+++ b/pkg/sql/create_view.go
@@ -49,7 +49,7 @@ func (p *planner) CreateView(ctx context.Context, n *tree.CreateView) (planNode,
 	}
 
 	var dbDesc *DatabaseDescriptor
-	p.runWithOptions(resolveFlags{skipCache: true, allowAdding: true}, func() {
+	p.runWithOptions(resolveFlags{skipCache: true}, func() {
 		dbDesc, err = ResolveTargetObject(ctx, p, name)
 	})
 	if err != nil {

--- a/pkg/sql/drop_index.go
+++ b/pkg/sql/drop_index.go
@@ -44,7 +44,7 @@ func (p *planner) DropIndex(ctx context.Context, n *tree.DropIndex) (planNode, e
 		var err error
 		// DDL statements avoid the cache to avoid leases, and can view non-public descriptors.
 		// TODO(vivek): check if the cache can be used.
-		p.runWithOptions(resolveFlags{allowAdding: true, skipCache: true}, func() {
+		p.runWithOptions(resolveFlags{skipCache: true}, func() {
 			tn, tableDesc, err = expandIndexName(ctx, p, index, !n.IfExists /* requireTable */)
 		})
 		if err != nil {
@@ -74,7 +74,7 @@ func (n *dropIndexNode) startExec(params runParams) error {
 		// drop need to be visible to the second drop.
 		var tableDesc *TableDescriptor
 		var err error
-		params.p.runWithOptions(resolveFlags{allowAdding: true, skipCache: true}, func() {
+		params.p.runWithOptions(resolveFlags{skipCache: true}, func() {
 			tableDesc, err = ResolveExistingObject(
 				ctx, params.p, index.tn, true /*required*/, requireTableDesc)
 		})

--- a/pkg/sql/drop_table.go
+++ b/pkg/sql/drop_table.go
@@ -154,7 +154,7 @@ func (p *planner) prepareDrop(
 ) (tableDesc *sqlbase.TableDescriptor, err error) {
 	// DDL statements avoid the cache to avoid leases, and can view non-public descriptors.
 	// TODO(vivek): check if the cache can be used.
-	p.runWithOptions(resolveFlags{allowAdding: true, skipCache: true}, func() {
+	p.runWithOptions(resolveFlags{skipCache: true}, func() {
 		tableDesc, err = ResolveExistingObject(ctx, p, name, required, requiredType)
 	})
 	if err != nil {

--- a/pkg/sql/grant_revoke.go
+++ b/pkg/sql/grant_revoke.go
@@ -78,7 +78,7 @@ func (p *planner) changePrivileges(
 	var descriptors []sqlbase.DescriptorProto
 	// DDL statements avoid the cache to avoid leases, and can view non-public descriptors.
 	// TODO(vivek): check if the cache can be used.
-	p.runWithOptions(resolveFlags{skipCache: true, allowAdding: true}, func() {
+	p.runWithOptions(resolveFlags{skipCache: true}, func() {
 		descriptors, err = getDescriptorsFromTargetList(ctx, p, targets)
 	})
 	if err != nil {

--- a/pkg/sql/physical_schema_accessors.go
+++ b/pkg/sql/physical_schema_accessors.go
@@ -137,7 +137,7 @@ func (a UncachedPhysicalAccessor) GetObjectDesc(
 		// We have a descriptor. Is it in the right state?
 		if err := filterTableState(desc); err != nil {
 			// No: let's see the flag.
-			if flags.allowAdding && err == errTableAdding {
+			if err == errTableAdding {
 				// We'll keep that despite the ADD state.
 				return desc, dbDesc, nil
 			}
@@ -197,8 +197,7 @@ func (a *CachedPhysicalAccessor) GetObjectDesc(
 ) (*ObjectDescriptor, *DatabaseDescriptor, error) {
 	// Can we use the table cache?
 	// - avoidCached -> the caller said no.
-	// - allowAdding -> no, the table cache only wants to handle public descriptors.
-	if !flags.avoidCached && !flags.allowAdding {
+	if !flags.avoidCached {
 		return a.tc.getTableVersion(flags.ctx, name, flags)
 	}
 

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -132,11 +132,6 @@ type planner struct {
 	// if it is SNAPSHOT.
 	avoidCachedDescriptors bool
 
-	// revealNewDescriptors, when true, instructs the name resolution
-	// code to also use descriptors in state ADD.
-	// Used by e.g. multiple DDL inside transactions.
-	revealNewDescriptors bool
-
 	// If set, the planner should skip checking for the SELECT privilege when
 	// initializing plans to read from a table. This should be used with care.
 	skipSelectPrivilegeChecks bool

--- a/pkg/sql/rename_column.go
+++ b/pkg/sql/rename_column.go
@@ -40,7 +40,7 @@ func (p *planner) RenameColumn(ctx context.Context, n *tree.RenameColumn) (planN
 	var tableDesc *TableDescriptor
 	// DDL statements avoid the cache to avoid leases, and can view non-public descriptors.
 	// TODO(vivek): check if the cache can be used.
-	p.runWithOptions(resolveFlags{allowAdding: true, skipCache: true}, func() {
+	p.runWithOptions(resolveFlags{skipCache: true}, func() {
 		tableDesc, err = ResolveExistingObject(ctx, p, tn, !n.IfExists, requireTableDesc)
 	})
 	if err != nil {

--- a/pkg/sql/rename_database.go
+++ b/pkg/sql/rename_database.go
@@ -79,7 +79,7 @@ func (p *planner) RenameDatabase(ctx context.Context, n *tree.RenameDatabase) (p
 	lookupFlags.required = false
 	for i := range tbNames {
 		tbDesc, _, err := phyAccessor.GetObjectDesc(&tbNames[i],
-			ObjectLookupFlags{CommonLookupFlags: lookupFlags, allowAdding: true})
+			ObjectLookupFlags{CommonLookupFlags: lookupFlags})
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/sql/rename_index.go
+++ b/pkg/sql/rename_index.go
@@ -35,7 +35,7 @@ func (p *planner) RenameIndex(ctx context.Context, n *tree.RenameIndex) (planNod
 	var err error
 	// DDL statements avoid the cache to avoid leases, and can view non-public descriptors.
 	// TODO(vivek): check if the cache can be used.
-	p.runWithOptions(resolveFlags{allowAdding: true, skipCache: true}, func() {
+	p.runWithOptions(resolveFlags{skipCache: true}, func() {
 		_, tableDesc, err = expandIndexName(ctx, p, n.Index, true /* requireTable */)
 	})
 	if err != nil {

--- a/pkg/sql/rename_table.go
+++ b/pkg/sql/rename_table.go
@@ -51,7 +51,7 @@ func (p *planner) RenameTable(ctx context.Context, n *tree.RenameTable) (planNod
 	var tableDesc *TableDescriptor
 	// DDL statements avoid the cache to avoid leases, and can view non-public descriptors.
 	// TODO(vivek): check if the cache can be used.
-	p.runWithOptions(resolveFlags{skipCache: true, allowAdding: true}, func() {
+	p.runWithOptions(resolveFlags{skipCache: true}, func() {
 		tableDesc, err = ResolveExistingObject(ctx, p, oldTn, !n.IfExists, toRequire)
 	})
 	if err != nil {
@@ -90,7 +90,7 @@ func (p *planner) RenameTable(ctx context.Context, n *tree.RenameTable) (planNod
 	// Check if target database exists.
 	// We also look at uncached descriptors here.
 	var targetDbDesc *DatabaseDescriptor
-	p.runWithOptions(resolveFlags{skipCache: true, allowAdding: true}, func() {
+	p.runWithOptions(resolveFlags{skipCache: true}, func() {
 		targetDbDesc, err = ResolveTargetObject(ctx, p, newTn)
 	})
 	if err != nil {

--- a/pkg/sql/resolver.go
+++ b/pkg/sql/resolver.go
@@ -122,10 +122,6 @@ func ResolveExistingObject(
 // use(someVar)
 func (p *planner) runWithOptions(flags resolveFlags, fn func()) {
 	if flags.skipCache {
-		defer func(prev bool) { p.revealNewDescriptors = prev }(p.revealNewDescriptors)
-		// Descriptors in the ADDING state are visible to requests
-		// that skip the cache.
-		p.revealNewDescriptors = true
 		defer func(prev bool) { p.avoidCachedDescriptors = prev }(p.avoidCachedDescriptors)
 		p.avoidCachedDescriptors = true
 	}
@@ -215,7 +211,6 @@ func (p *planner) CommonLookupFlags(ctx context.Context, required bool) CommonLo
 func (p *planner) ObjectLookupFlags(ctx context.Context, required bool) ObjectLookupFlags {
 	return ObjectLookupFlags{
 		CommonLookupFlags: p.CommonLookupFlags(ctx, required),
-		allowAdding:       p.revealNewDescriptors,
 	}
 }
 

--- a/pkg/sql/resolver.go
+++ b/pkg/sql/resolver.go
@@ -115,17 +115,17 @@ func ResolveExistingObject(
 //
 // var someVar T
 // var err error
-// p.runWithOptions(resolveFlags{allowAdding: true}, func() {
+// p.runWithOptions(resolveFlags{skipCache: true}, func() {
 //    someVar, err = ResolveExistingObject(ctx, p, ...)
 // })
 // if err != nil { ... }
 // use(someVar)
 func (p *planner) runWithOptions(flags resolveFlags, fn func()) {
-	if flags.allowAdding {
-		defer func(prev bool) { p.revealNewDescriptors = prev }(p.revealNewDescriptors)
-		p.revealNewDescriptors = true
-	}
 	if flags.skipCache {
+		defer func(prev bool) { p.revealNewDescriptors = prev }(p.revealNewDescriptors)
+		// Descriptors in the ADDING state are visible to requests
+		// that skip the cache.
+		p.revealNewDescriptors = true
 		defer func(prev bool) { p.avoidCachedDescriptors = prev }(p.avoidCachedDescriptors)
 		p.avoidCachedDescriptors = true
 	}
@@ -133,8 +133,7 @@ func (p *planner) runWithOptions(flags resolveFlags, fn func()) {
 }
 
 type resolveFlags struct {
-	allowAdding bool
-	skipCache   bool
+	skipCache bool
 }
 
 // ResolveTargetObject determines a valid target path for an object
@@ -429,7 +428,7 @@ func (p *planner) getTableAndIndex(
 
 	// DDL statements avoid the cache to avoid leases, and can view non-public descriptors.
 	// TODO(vivek): check if the cache can be used.
-	p.runWithOptions(resolveFlags{allowAdding: true, skipCache: true}, func() {
+	p.runWithOptions(resolveFlags{skipCache: true}, func() {
 		if tableWithIndex == nil {
 			// Variant: ALTER TABLE
 			tn, err = table.Normalize()

--- a/pkg/sql/schema_accessors.go
+++ b/pkg/sql/schema_accessors.go
@@ -80,8 +80,6 @@ type SchemaAccessor interface {
 	// found and flags.required is true, an error is returned, otherwise
 	// a nil reference is returned.
 	//
-	// flag.allowAdding controls inclusion of non-public descriptors.
-	//
 	// The 2nd return value (DatabaseDescriptor) is only returned if the
 	// lookup function otherwise needed to load the database descriptor.
 	// It is not guaranteed to be non-nil even if the first return value
@@ -114,7 +112,4 @@ type DatabaseListFlags struct {
 // ObjectLookupFlags is the flag struct suitable for GetObjectDesc().
 type ObjectLookupFlags struct {
 	CommonLookupFlags
-	// if allowAdding is set, descriptors in the ADD state will be
-	// included in the results as well.
-	allowAdding bool
 }

--- a/pkg/sql/sequence.go
+++ b/pkg/sql/sequence.go
@@ -126,7 +126,7 @@ func (p *planner) SetSequenceValue(
 	// However tests break if it does.
 	var descriptor *TableDescriptor
 	var err error
-	p.runWithOptions(resolveFlags{allowAdding: true, skipCache: true}, func() {
+	p.runWithOptions(resolveFlags{skipCache: true}, func() {
 		descriptor, err = ResolveExistingObject(ctx, p, seqName, true /*required*/, requireSequenceDesc)
 	})
 	if err != nil {

--- a/pkg/sql/set_zone_config.go
+++ b/pkg/sql/set_zone_config.go
@@ -77,7 +77,7 @@ func (n *setZoneConfigNode) startExec(params runParams) error {
 	var table *TableDescriptor
 	// DDL statements avoid the cache to avoid leases, and can view non-public descriptors.
 	// TODO(vivek): check if the cache can be used.
-	params.p.runWithOptions(resolveFlags{allowAdding: true, skipCache: true}, func() {
+	params.p.runWithOptions(resolveFlags{skipCache: true}, func() {
 		table, err = params.p.resolveTableForZone(params.ctx, &n.zoneSpecifier)
 	})
 	if err != nil {

--- a/pkg/sql/show_constraints.go
+++ b/pkg/sql/show_constraints.go
@@ -36,12 +36,10 @@ func (p *planner) ShowConstraints(ctx context.Context, n *tree.ShowConstraints) 
 
 	var desc *TableDescriptor
 	// We avoid the cache so that we can observe the constraints without
-	// taking a lease, like other SHOW commands. We also use
-	// allowAdding=true so we can look at the constraints of a table
-	// added in the same transaction.
+	// taking a lease, like other SHOW commands.
 	//
 	// TODO(vivek): check if the cache can be used.
-	p.runWithOptions(resolveFlags{allowAdding: true, skipCache: true}, func() {
+	p.runWithOptions(resolveFlags{skipCache: true}, func() {
 		desc, err = ResolveExistingObject(ctx, p, tn, true /*required*/, requireTableDesc)
 	})
 	if err != nil {

--- a/pkg/sql/show_fingerprints.go
+++ b/pkg/sql/show_fingerprints.go
@@ -61,12 +61,10 @@ func (p *planner) ShowFingerprints(
 
 	var tableDesc *TableDescriptor
 	// We avoid the cache so that we can observe the fingerprints without
-	// taking a lease, like other SHOW commands. We also use
-	// allowAdding=true so we can look at the fingerprints of a table
-	// added in the same transaction.
+	// taking a lease, like other SHOW commands.
 	//
 	// TODO(vivek): check if the cache can be used.
-	p.runWithOptions(resolveFlags{allowAdding: true, skipCache: true}, func() {
+	p.runWithOptions(resolveFlags{skipCache: true}, func() {
 		tableDesc, err = ResolveExistingObject(ctx, p, tn, true /*required*/, requireTableDesc)
 	})
 	if err != nil {

--- a/pkg/sql/show_grants.go
+++ b/pkg/sql/show_grants.go
@@ -84,12 +84,10 @@ func (p *planner) ShowGrants(ctx context.Context, n *tree.ShowGrants) (planNode,
 				}
 				var tables tree.TableNames
 				// We avoid the cache so that we can observe the grants taking
-				// a lease, like other SHOW commands. We also use
-				// allowAdding=true so we can look at the grants of a table
-				// added in the same transaction.
+				// a lease, like other SHOW commands.
 				//
 				// TODO(vivek): check if the cache can be used.
-				p.runWithOptions(resolveFlags{allowAdding: true, skipCache: true}, func() {
+				p.runWithOptions(resolveFlags{skipCache: true}, func() {
 					tables, err = expandTableGlob(ctx, p, tableGlob)
 				})
 				if err != nil {

--- a/pkg/sql/show_stats.go
+++ b/pkg/sql/show_stats.go
@@ -50,12 +50,10 @@ func (p *planner) ShowTableStats(ctx context.Context, n *tree.ShowTableStats) (p
 
 	var desc *TableDescriptor
 	// We avoid the cache so that we can observe the stats without
-	// taking a lease, like other SHOW commands. We also use
-	// allowAdding=true so we can look at the stats of a table
-	// added in the same transaction.
+	// taking a lease, like other SHOW commands.
 	//
 	// TODO(vivek): check if the cache can be used.
-	p.runWithOptions(resolveFlags{allowAdding: true, skipCache: true}, func() {
+	p.runWithOptions(resolveFlags{skipCache: true}, func() {
 		desc, err = ResolveExistingObject(ctx, p, tn, true /*required*/, requireTableDesc)
 	})
 	if err != nil {

--- a/pkg/sql/show_table.go
+++ b/pkg/sql/show_table.go
@@ -40,12 +40,10 @@ func (p *planner) showTableDetails(
 
 	var desc *TableDescriptor
 	// We avoid the cache so that we can observe the details without
-	// taking a lease, like other SHOW commands. We also use
-	// allowAdding=true so we can look at the details of a table
-	// added in the same transaction.
+	// taking a lease, like other SHOW commands.
 	//
 	// TODO(vivek): check if the cache can be used.
-	p.runWithOptions(resolveFlags{allowAdding: true, skipCache: true}, func() {
+	p.runWithOptions(resolveFlags{skipCache: true}, func() {
 		desc, err = ResolveExistingObject(ctx, p, tn, true /*required*/, anyDescType)
 	})
 	if err != nil {

--- a/pkg/sql/show_zone_config.go
+++ b/pkg/sql/show_zone_config.go
@@ -77,12 +77,10 @@ func (n *showZoneConfigNode) startExec(params runParams) error {
 	var tblDesc *TableDescriptor
 	var err error
 	// We avoid the cache so that we can observe the zone configuration
-	// without taking a lease, like other SHOW commands.  We also use
-	// allowAdding=true so we can look at the configuration of a table
-	// added in the same transaction.
+	// without taking a lease, like other SHOW commands.
 	//
 	// TODO(vivek): check if the cache can be used.
-	params.p.runWithOptions(resolveFlags{allowAdding: true, skipCache: true}, func() {
+	params.p.runWithOptions(resolveFlags{skipCache: true}, func() {
 		tblDesc, err = params.p.resolveTableForZone(params.ctx, &n.zoneSpecifier)
 	})
 	if err != nil {

--- a/pkg/sql/table.go
+++ b/pkg/sql/table.go
@@ -210,11 +210,6 @@ func (tc *TableCollection) getTableVersion(
 		log.Infof(ctx, "planner acquiring lease on table '%s'", tn)
 	}
 
-	if flags.allowAdding {
-		return nil, nil, pgerror.NewErrorf(pgerror.CodeInternalError,
-			"programming error: unsupported flags passed to getTableVersion: %+v", flags)
-	}
-
 	if tn.SchemaName != tree.PublicSchemaName {
 		if flags.required {
 			return nil, nil, sqlbase.NewUnsupportedSchemaUsageError(tree.ErrString(tn))

--- a/pkg/sql/truncate.go
+++ b/pkg/sql/truncate.go
@@ -50,7 +50,7 @@ func (p *planner) Truncate(ctx context.Context, n *tree.Truncate) (planNode, err
 		var tableDesc *TableDescriptor
 		// DDL statements avoid the cache to avoid leases, and can view non-public descriptors.
 		// TODO(vivek): check if the cache can be used.
-		p.runWithOptions(resolveFlags{skipCache: true, allowAdding: true}, func() {
+		p.runWithOptions(resolveFlags{skipCache: true}, func() {
 			tableDesc, err = ResolveExistingObject(ctx, p, tn, true /*required*/, requireTableDesc)
 		})
 		if err != nil {


### PR DESCRIPTION
allowAdding is always set to the same value
as skipCache. If such a policy is needed to
be enforced it can be enforced at a higher level.

Release note: None