### PR TITLE
Makefile: learn that gogo.proto lives in a submodule

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1022,6 +1022,8 @@ CPP_SOURCES_CCL := $(subst $(PKG_ROOT),$(CPP_PROTO_CCL_ROOT),$(CPP_PROTOS_CCL:%.
 
 UI_PROTOS := $(UI_JS) $(UI_TS)
 
+$(GOGOPROTO_PROTO): $(SUBMODULES_TARGET)
+
 $(GO_PROTOS_TARGET): $(PROTOC) $(GO_PROTOS) $(GOGOPROTO_PROTO) $(BOOTSTRAP_TARGET) bin/protoc-gen-gogoroach
 	$(FIND_RELEVANT) -type f -name '*.pb.go' -exec rm {} +
 	set -e; for dir in $(sort $(dir $(GO_PROTOS))); do \


### PR DESCRIPTION
@tschottdorf or @knz can one of you shepard this? I'll be on vacation starting approximately now.

---

Without waiting for submodules to be initialized, gogo.proto won't
exist and the build will fail.

Fix #25337.

Release note: None