### PR TITLE
roachtest: introduce chaos, use in scaledata test

### DIFF
--- a/pkg/cmd/roachtest/chaos.go
+++ b/pkg/cmd/roachtest/chaos.go
@@ -1,0 +1,84 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package main
+
+import (
+	"context"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+)
+
+// ChaosTimer configures a chaos schedule.
+type ChaosTimer interface {
+	Timing() (time.Duration, time.Duration)
+}
+
+// Periodic is a chaos timing using fixed durations.
+type Periodic struct {
+	Down, Up time.Duration
+}
+
+// Timing implements ChaosTimer.
+func (p Periodic) Timing() (time.Duration, time.Duration) {
+	return p.Down, p.Up
+}
+
+// Chaos stops and restarts nodes in a cluster.
+type Chaos struct {
+	// Timing is consulted before each chaos event. It provides the duration of
+	// the downtime and the subsequent chaos-free duration.
+	Timer ChaosTimer
+	// Target is consulted before each chaos event to determine the node(s) which
+	// should be killed.
+	Target func() nodeListOption
+	// Duration is the duration after which the chaos agent will terminate cleanly.
+	Duration time.Duration
+}
+
+// Runner returns a closure that runs chaos against the given cluster without
+// setting off the monitor. The process returns without an error after the chaos
+// duration.
+func (ch *Chaos) Runner(c *cluster, m *monitor) func(context.Context) error {
+	return func(ctx context.Context) error {
+		l, err := c.l.childLogger("CHAOS")
+		if err != nil {
+			return err
+		}
+		for tBegin := timeutil.Now(); timeutil.Since(tBegin) < ch.Duration; {
+			before, between := ch.Timer.Timing()
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-time.After(before):
+			}
+
+			target := ch.Target()
+			l.printf("killing %v (slept %s)\n", target, before)
+			m.ExpectDeath()
+			c.Stop(ctx, target)
+
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-time.After(between):
+			}
+
+			c.l.printf("restarting %v after %s of downtime\n", target, between)
+			c.Start(ctx, target)
+		}
+		return nil
+	}
+}

--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -22,6 +22,7 @@ import (
 	gosql "database/sql"
 	"fmt"
 	"io"
+	"math/rand"
 	"net"
 	"net/url"
 	"os"
@@ -41,6 +42,7 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	// "postgres" gosql driver
+
 	_ "github.com/lib/pq"
 )
 
@@ -280,6 +282,10 @@ func (n nodeListOption) merge(o nodeListOption) nodeListOption {
 		}
 	}
 	return r
+}
+
+func (n nodeListOption) randNode() nodeListOption {
+	return nodeListOption{n[rand.Intn(len(n))]}
 }
 
 func (n nodeListOption) String() string {
@@ -852,12 +858,13 @@ func (c *cluster) isLocal() bool {
 }
 
 type monitor struct {
-	t      testI
-	l      *logger
-	nodes  string
-	ctx    context.Context
-	cancel func()
-	g      *errgroup.Group
+	t         testI
+	l         *logger
+	nodes     string
+	ctx       context.Context
+	cancel    func()
+	g         *errgroup.Group
+	expDeaths int32 // atomically
 }
 
 func newMonitor(ctx context.Context, c *cluster, opts ...option) *monitor {
@@ -869,6 +876,12 @@ func newMonitor(ctx context.Context, c *cluster, opts ...option) *monitor {
 	m.ctx, m.cancel = context.WithCancel(ctx)
 	m.g, m.ctx = errgroup.WithContext(m.ctx)
 	return m
+}
+
+// ExpectDeath lets the monitor know that a node is about to be killed, and that
+// this should be ignored.
+func (m *monitor) ExpectDeath() {
+	atomic.AddInt32(&m.expDeaths, 1)
 }
 
 func (m *monitor) Go(fn func(context.Context) error) {
@@ -986,7 +999,7 @@ func (m *monitor) wait(args ...string) error {
 			var id int
 			var s string
 			if n, _ := fmt.Sscanf(msg, "%d: %s", &id, &s); n == 2 {
-				if strings.Contains(s, "dead") {
+				if strings.Contains(s, "dead") && atomic.AddInt32(&m.expDeaths, -1) < 0 {
 					setErr(fmt.Errorf("unexpected node event: %s", msg))
 					return
 				}


### PR DESCRIPTION
I was tempted to go on an extended refactoring streak (pull out test and
log into their own packages, untangle dependencies, avoid relying on
roachprod monitor, ...) but I decided to approach this in a
goal-oriented manner.

Instead, code like this can now be introduced into existing tests
(assuming the workloads tolerate errors):

```sql
m.Go(randomKillChaos(
    c, m, chaosTimer(ctxWithTimeout, time.Minute, 30*time.Second), roachNodes))
```

Fixes #24279.

Release note: None