### PR TITLE
storage: discard RocksDB logs on Go side

### DIFF
--- a/c-deps/libroach/include/libroach.h
+++ b/c-deps/libroach/include/libroach.h
@@ -65,7 +65,6 @@ typedef struct DBIterator DBIterator;
 // DBOptions contains local database options.
 typedef struct {
   DBCache* cache;
-  bool logging_enabled;
   int num_cpu;
   int max_open_files;
   bool use_file_registry;

--- a/c-deps/libroach/options.cc
+++ b/c-deps/libroach/options.cc
@@ -44,14 +44,8 @@ class DBPrefixExtractor : public rocksdb::SliceTransform {
 
 class DBLogger : public rocksdb::Logger {
  public:
-  DBLogger(bool enabled) : enabled_(enabled) {}
+  DBLogger() {}
   virtual void Logv(const char* format, va_list ap) {
-    // TODO(pmattis): Benchmark calling Go exported methods from C++
-    // to determine if this is too slow.
-    if (!enabled_) {
-      return;
-    }
-
     // First try with a small fixed size buffer.
     char space[1024];
 
@@ -94,9 +88,6 @@ class DBLogger : public rocksdb::Logger {
       delete[] buf;
     }
   }
-
- private:
-  const bool enabled_;
 };
 
 class TimeBoundTblPropCollector : public rocksdb::TablePropertiesCollector {
@@ -162,7 +153,7 @@ rocksdb::Options DBMakeOptions(DBOptions db_opts) {
   options.max_subcompactions = std::max(db_opts.num_cpu / 2, 1);
   options.comparator = &kComparator;
   options.create_if_missing = !db_opts.must_exist;
-  options.info_log.reset(new DBLogger(db_opts.logging_enabled));
+  options.info_log.reset(new DBLogger());
   options.merge_operator.reset(NewMergeOperator());
   options.prefix_extractor.reset(new DBPrefixExtractor);
   options.statistics = rocksdb::CreateDBStatistics();

--- a/pkg/storage/engine/rocksdb.go
+++ b/pkg/storage/engine/rocksdb.go
@@ -87,9 +87,10 @@ const debugIteratorLeak = false
 
 //export rocksDBLog
 func rocksDBLog(s *C.char, n C.int) {
-	// Note that rocksdb logging is only enabled if log.V(3) is true
-	// when RocksDB.Open() is called.
-	log.Info(context.TODO(), C.GoStringN(s, n))
+	if log.V(3) {
+		ctx := log.WithLogTagStr(context.Background(), "rocksdb", "")
+		log.Info(ctx, C.GoStringN(s, n))
+	}
 }
 
 //export prettyPrintKey
@@ -605,7 +606,6 @@ func (r *RocksDB) open() error {
 	status := C.DBOpen(&r.rdb, goToCSlice([]byte(r.cfg.Dir)),
 		C.DBOptions{
 			cache:             r.cache.cache,
-			logging_enabled:   C.bool(log.V(3)),
 			num_cpu:           C.int(rocksdbConcurrency),
 			max_open_files:    C.int(maxOpenFiles),
 			use_file_registry: C.bool(newVersion == versionCurrent),


### PR DESCRIPTION
This allows this log stream to be intercepted via the log spy. RocksDB
does not log at high frequency (usually during compaction events), so
performance is not a concern here.

Release note: None