### PR TITLE
roachtest: retain clusters upon ctrl-c when --debug specified

### DIFF
--- a/pkg/cmd/roachtest/test.go
+++ b/pkg/cmd/roachtest/test.go
@@ -325,7 +325,9 @@ func (r *registry) Run(filter []string) int {
 			r.status.Unlock()
 
 		case <-sig:
-			destroyAllClusters()
+			if !debug {
+				destroyAllClusters()
+			}
 		}
 	}
 }


### PR DESCRIPTION
Don't destroy clusters when an interrupt signal is received and
`--debug` is specified.

Fixes #25440

Release note: None