### PR TITLE
roachtest: fix the scaledata tests

### DIFF
--- a/pkg/cmd/roachtest/drop.go
+++ b/pkg/cmd/roachtest/drop.go
@@ -166,9 +166,8 @@ gc:
 	initDiskSpace := int(1E9)
 
 	r.Add(testSpec{
-		Name:   fmt.Sprintf("drop/tpcc/w=%d,nodes=%d", warehouses, numNodes),
-		Nodes:  nodes(numNodes),
-		Stable: true, // DO NOT COPY to new tests
+		Name:  fmt.Sprintf("drop/tpcc/w=%d,nodes=%d", warehouses, numNodes),
+		Nodes: nodes(numNodes),
 		Run: func(ctx context.Context, t *test, c *cluster) {
 			// NB: this is likely not going to work out in `-local` mode. Edit the
 			// numbers during iteration.

--- a/pkg/cmd/roachtest/scaledata.go
+++ b/pkg/cmd/roachtest/scaledata.go
@@ -83,7 +83,7 @@ func runSqlapp(ctx context.Context, t *test, c *cluster, app, flags string, dur 
 
 	// Sqlapps each take a `--cockroach_ip_addresses_csv` flag, which is a
 	// comma-separated list of node IP addresses with optional port specifiers.
-	addrStr := strings.Join(c.InternalAddr(ctx, c.All()), ",")
+	addrStr := strings.Join(c.InternalAddr(ctx, c.Range(1, roachNodeCount)), ",")
 
 	m := newMonitor(ctx, c, roachNodes)
 	m.Go(func(ctx context.Context) error {


### PR DESCRIPTION
A previous PR had accidentally caused the worker node to be specified as a
cockroach node.

Release note: None