### PR TITLE
roachtest: deflake clockjump/tc=small_forward_enabled

### DIFF
--- a/pkg/cmd/roachtest/clock_jump_crash.go
+++ b/pkg/cmd/roachtest/clock_jump_crash.go
@@ -88,7 +88,7 @@ func registerClockJump(r *registry) {
 		},
 		{
 			name:             "small_forward_enabled",
-			offset:           150 * time.Millisecond,
+			offset:           100 * time.Millisecond,
 			jumpCheckEnabled: true,
 			aliveAfterOffset: true,
 		},


### PR DESCRIPTION
After enabling the flag to panic on forward clock jumps,
small forward jumps should not crash cockroach, only
large forward jumps should.

With the default MAX_OFFSET of 500ms, any forward jump
greater than 250ms causes a panic in the node. PhysicalNow()
is called every 125ms to refresh last physical time and
if two successive readings of physical time differ by
more than 250ms, cockroach panics.

So in general two successive readings of physical time would differ
by at most 125ms. The test case to not crash on forward jump
should at most introduce a skew of at most 125ms in order to not be
flaky.

This commit changes the introduced skew to 100ms.

Fixes #25449.

Release note: None