### PR TITLE
ui: Test metrics saga with redux-test-saga-plan

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1098,6 +1098,10 @@ ui-test: $(UI_CCL_DLLS) $(UI_CCL_MANIFESTS)
 ui-test-watch: $(UI_CCL_DLLS) $(UI_CCL_MANIFESTS)
 	$(NODE_RUN) -C pkg/ui $(KARMA) start --no-single-run --auto-watch
 
+.PHONY: ui-test-debug
+ui-test-debug: $(UI_DLLS) $(UI_MANIFESTS)
+	$(NODE_RUN) -C $(UI_ROOT) $(KARMA) start --browsers Chrome --no-single-run --debug --auto-watch
+
 pkg/ui/distccl/bindata.go: $(UI_CCL_DLLS) $(UI_CCL_MANIFESTS) $(UI_JS_CCL) $(shell find pkg/ui/ccl -type f)
 pkg/ui/distoss/bindata.go: $(UI_OSS_DLLS) $(UI_OSS_MANIFESTS) $(UI_JS_OSS)
 pkg/ui/dist%/bindata.go: pkg/ui/webpack.app.js $(shell find pkg/ui/src pkg/ui/styl -type f)

--- a/pkg/ui/package.json
+++ b/pkg/ui/package.json
@@ -93,6 +93,7 @@
     "nib": "^1.1.2",
     "prop-types": "^15.5.10",
     "protobufjs": "^6.7.3",
+    "redux-saga-test-plan": "^3.6.0",
     "rimraf": "^2.6.1",
     "sinon": "2.1.0",
     "source-map-loader": "^0.2.0",

--- a/pkg/ui/src/redux/metrics.spec.ts
+++ b/pkg/ui/src/redux/metrics.spec.ts
@@ -1,10 +1,12 @@
 import { assert } from "chai";
 import _ from "lodash";
 import Long from "long";
+import { expectSaga, testSaga } from "redux-saga-test-plan";
+import * as matchers from "redux-saga-test-plan/matchers";
 
 import { delay } from "redux-saga";
-import { AllEffect, call, ForkEffect, put, take } from "redux-saga/effects";
-import { queryTimeSeries } from "src/util/api";
+import { call, put } from "redux-saga/effects";
+import { queryTimeSeries, TimeSeriesQueryRequestMessage } from "src/util/api";
 import * as protos from "src/js/protos";
 
 import * as metrics from "./metrics";
@@ -166,61 +168,85 @@ describe("metrics reducer", function() {
       });
     }
 
-    function createResponse(queries: protos.cockroach.ts.tspb.IQuery[]) {
+    function createResponse(
+      queries: protos.cockroach.ts.tspb.IQuery[],
+      datapoints: protos.cockroach.ts.tspb.TimeSeriesDatapoint[]  = [],
+    ) {
       return new protos.cockroach.ts.tspb.TimeSeriesQueryResponse({
-        results: queries.map(q => {
+        results: queries.map(query => {
           return {
-            query: q,
-            datapoints: [],
+            query,
+            datapoints,
           };
         }),
       });
     }
 
-    describe("queryMetricsSaga", function() {
+    function createDatapoints(val: number) {
+      const result: protos.cockroach.ts.tspb.TimeSeriesDatapoint[] = [];
+      for (let i = 0; i < val; i++) {
+        result.push(new protos.cockroach.ts.tspb.TimeSeriesDatapoint({
+          timestamp_nanos: new Long(val),
+          value: val,
+        }));
+      }
+      return result;
+    }
+
+    describe("queryMetricsSaga plan", function() {
       it("initially waits for incoming request objects", function () {
-        const saga = metrics.queryMetricsSaga();
-        assert.deepEqual(saga.next().value, take(metrics.REQUEST));
+        testSaga(metrics.queryMetricsSaga)
+          .next()
+          .take(metrics.REQUEST);
       });
 
       it("correctly accumulates batches", function () {
         const requestAction = metrics.requestMetrics("id", createRequest(shortTimespan, "short.1"));
-        const saga = metrics.queryMetricsSaga();
-        saga.next();
+        const beginAction = metrics.beginMetrics(requestAction.payload.id, requestAction.payload.data);
 
-        // Pass in a request, the generator should put the request to the
-        // redux store, fork "sendBatches" process, then await another request.
-        assert.deepEqual(saga.next(requestAction).value, put(requestAction));
-        const sendBatchesFork = saga.next().value as ForkEffect;
-        assert.isDefined(sendBatchesFork.FORK);
-        assert.deepEqual(saga.next().value, take(metrics.REQUEST));
-
-        // Pass in two additional requests, the generator should not yield another
-        // fork.
-        for (let i = 0; i < 2; i++) {
-          assert.deepEqual(saga.next(requestAction).value, put(requestAction));
-          assert.deepEqual(saga.next().value, take(metrics.REQUEST));
-        }
-
-        // Run the fork function. It should initially call delay (to defer to the
-        // event queue), then call sendRequestBatches with the currently
-        // accumulated batches, then complete.
-        const accumulateBatch = sendBatchesFork.FORK.fn() as IterableIterator<any>;
-        assert.deepEqual(accumulateBatch.next().value, call(delay, 0));
-        assert.deepEqual(
-          accumulateBatch.next().value,
-          call(
-            metrics.batchAndSendRequests,
-            [requestAction.payload, requestAction.payload, requestAction.payload],
-          ),
-        );
-        assert.isTrue(accumulateBatch.next().done);
-
-        // Pass in a request, the generator should again yield a "fork" followed
-        // by another take for request objects.
-        assert.deepEqual(saga.next(requestAction).value, put(requestAction));
-        assert.isDefined((saga.next().value as ForkEffect).FORK);
-        assert.deepEqual(saga.next().value, take(metrics.REQUEST));
+        return expectSaga(metrics.queryMetricsSaga)
+          // Stub out calls to batchAndSendRequests.
+          .provide([
+            [matchers.call.fn(metrics.batchAndSendRequests), null],
+          ])
+          // Dispatch six requests, with delays inserted in order to trigger
+          // batch sends.
+          .dispatch(requestAction)
+          .dispatch(requestAction)
+          .dispatch(requestAction)
+          .delay(0)
+          .dispatch(requestAction)
+          .delay(0)
+          .dispatch(requestAction)
+          .dispatch(requestAction)
+          .run()
+          .then((result) => {
+            const { effects } = result;
+            // Verify the order of call dispatches.
+            assert.deepEqual(
+              effects.call,
+              [
+                call(delay, 0),
+                call(metrics.batchAndSendRequests, [requestAction.payload, requestAction.payload, requestAction.payload]),
+                call(delay, 0),
+                call(metrics.batchAndSendRequests, [requestAction.payload]),
+                call(delay, 0),
+                call(metrics.batchAndSendRequests, [requestAction.payload, requestAction.payload]),
+              ],
+            );
+            // Verify that all beginAction puts were dispatched.
+            assert.deepEqual(
+              effects.put,
+              [
+                put(beginAction),
+                put(beginAction),
+                put(beginAction),
+                put(beginAction),
+                put(beginAction),
+                put(beginAction),
+              ],
+            );
+          });
       });
     });
 
@@ -239,25 +265,25 @@ describe("metrics reducer", function() {
 
         // Mix the requests together and send the combined request set.
         const mixedRequests = _.flatMap(shortRequests, (short, i) => [short, longRequests[i]]);
-        const sendBatches = metrics.batchAndSendRequests(mixedRequests);
 
-        // sendBatches next puts a "fetchMetrics" action into the store.
-        assert.deepEqual(sendBatches.next().value, put(metrics.fetchMetrics()));
-
-        // Next, sendBatches dispatches a "all" effect with a "call" for each
-        // batch; there should be two batches in total, one containing the
-        // short requests and one containing the long requests. The order
-        // of requests in each batch is maintained.
-        const allEffect = sendBatches.next().value as AllEffect;
-        assert.isArray(allEffect.ALL);
-        assert.deepEqual(allEffect.ALL, [
-          call(metrics.sendRequestBatch, shortRequests),
-          call(metrics.sendRequestBatch, longRequests),
-        ]);
-
-        // After completion, puts "fetchMetricsComplete" to store.
-        assert.deepEqual(sendBatches.next().value, put(metrics.fetchMetricsComplete()));
-        assert.isTrue(sendBatches.next().done);
+        testSaga(metrics.batchAndSendRequests, mixedRequests)
+          // sendBatches next puts a "fetchMetrics" action into the store.
+          .next()
+          .put(metrics.fetchMetrics())
+          .next()
+          // Next, sendBatches dispatches a "all" effect with a "call" for each
+          // batch; there should be two batches in total, one containing the
+          // short requests and one containing the long requests. The order of
+          // requests in each batch is maintained.
+          .all([
+            call(metrics.sendRequestBatch, shortRequests),
+            call(metrics.sendRequestBatch, longRequests),
+          ])
+          // After completion, puts "fetchMetricsComplete" to store.
+          .next()
+          .put(metrics.fetchMetricsComplete())
+          .next()
+          .isDone();
       });
     });
 
@@ -269,47 +295,210 @@ describe("metrics reducer", function() {
       ];
 
       it("correctly sends batch as single request, correctly handles valid response", function() {
-        const sendBatch = metrics.sendRequestBatch(requests);
+        // The expected request that will be generated by sendRequestBatch.
         const expectedRequest = createRequest(shortTimespan, "short.1", "short.2", "short.3", "short.4");
-        assert.deepEqual(sendBatch.next().value, call(queryTimeSeries, expectedRequest));
-
         // Return a valid response.
         const response = createResponse(expectedRequest.queries);
+        // Generate the expected put effects to be generated after receiving the response.
+        const expectedEffects = _.map(requests, req => metrics.receiveMetrics(
+          req.id, req.data, createResponse(req.data.queries),
+        ));
 
-        // Expect three puts to the underlying store.
-        const actualEffects = [
-          sendBatch.next(response).value,
-          sendBatch.next().value,
-          sendBatch.next().value,
-        ];
-        const expectedEffects = requests.map(req => put(metrics.receiveMetrics(
-          req.id,
-          req.data,
-          createResponse(req.data.queries),
-        )));
-        assert.deepEqual(actualEffects, expectedEffects);
-        assert.isTrue(sendBatch.next().done);
+        testSaga(metrics.sendRequestBatch, requests)
+          .next()
+          .call(queryTimeSeries, expectedRequest)
+          .next(response)
+          .put(expectedEffects[0])
+          .next()
+          .put(expectedEffects[1])
+          .next()
+          .put(expectedEffects[2])
+          .next()
+          .isDone();
       });
 
       it("correctly handles error response", function() {
-        const sendBatch = metrics.sendRequestBatch(requests);
+        // The expected request that will be generated by sendRequestBatch.
         const expectedRequest = createRequest(shortTimespan, "short.1", "short.2", "short.3", "short.4");
-        assert.deepEqual(sendBatch.next().value, call(queryTimeSeries, expectedRequest));
-
-        // Throw an exception, a network error.  Expect three puts, which are
-        // are error responses.
+        // Return an error response.
         const err = new Error("network error");
-        const actualEffects = [
-          sendBatch.throw(err).value,
-          sendBatch.next().value,
-          sendBatch.next().value,
-        ];
-        const expectedEffects = requests.map(req => put(metrics.errorMetrics(
-          req.id,
-          err,
-        )));
-        assert.deepEqual(actualEffects, expectedEffects);
-        assert.isTrue(sendBatch.next().done);
+        // Generate the expected put effects to be generated after receiving the response.
+        const expectedEffects = _.map(requests, req => metrics.errorMetrics(
+          req.id, err,
+        ));
+
+        testSaga(metrics.sendRequestBatch, requests)
+          .next()
+          .call(queryTimeSeries, expectedRequest)
+          .throw(err)
+          .put(expectedEffects[0])
+          .next()
+          .put(expectedEffects[1])
+          .next()
+          .put(expectedEffects[2])
+          .next()
+          .isDone();
+      });
+    });
+
+    describe("integration test", function() {
+      const shortRequests = [
+        metrics.requestMetrics("id.0", createRequest(shortTimespan, "short.1")),
+        metrics.requestMetrics("id.2", createRequest(shortTimespan, "short.2", "short.3")),
+        metrics.requestMetrics("id.4", createRequest(shortTimespan, "short.4")),
+      ];
+      const longRequests = [
+        metrics.requestMetrics("id.1", createRequest(longTimespan, "long.1")),
+        metrics.requestMetrics("id.3", createRequest(longTimespan, "long.2", "long.3")),
+        metrics.requestMetrics("id.5", createRequest(longTimespan, "long.4", "long.5")),
+      ];
+
+      const createMetricsState = (
+        id: string, ts: timespan, metricNames: string[], datapointCount: number,
+      ): metrics.MetricsQuery => {
+        const request = createRequest(ts, ...metricNames);
+        const state = new metrics.MetricsQuery(id);
+        state.request = request;
+        state.nextRequest = request;
+        state.data = createResponse(request.queries, createDatapoints(datapointCount));
+        state.error = undefined;
+        return state;
+      };
+
+      const createMetricsErrorState = (
+        id: string, ts: timespan, metricNames: string[], err: Error,
+      ): metrics.MetricsQuery => {
+        const request = createRequest(ts, ...metricNames);
+        const state = new metrics.MetricsQuery(id);
+        state.nextRequest = request;
+        state.error = err;
+        return state;
+      };
+
+      const createMetricsInFlightState = (
+        id: string, ts: timespan, metricNames: string[],
+      ): metrics.MetricsQuery => {
+        const request = createRequest(ts, ...metricNames);
+        const state = new metrics.MetricsQuery(id);
+        state.nextRequest = request;
+        return state;
+      };
+
+      it("handles success correctly", function() {
+        const expectedState = new metrics.MetricsState();
+        expectedState.inFlight = 0;
+        expectedState.queries = {
+          "id.0": createMetricsState("id.0", shortTimespan, ["short.1"], 3),
+          "id.1": createMetricsState("id.1", longTimespan, ["long.1"], 3),
+          "id.2": createMetricsState("id.2", shortTimespan, ["short.2", "short.3"], 3),
+          "id.3": createMetricsState("id.3", longTimespan, ["long.2", "long.3"], 3),
+          "id.4": createMetricsState("id.4", shortTimespan, ["short.4"], 3),
+          "id.5": createMetricsState("id.5", longTimespan, ["long.4", "long.5"], 3),
+        };
+
+        return expectSaga(metrics.queryMetricsSaga)
+          .withReducer(metrics.metricsReducer)
+          .hasFinalState(expectedState)
+          .provide({
+            call(effect, next) {
+              if (effect.fn === queryTimeSeries) {
+                return new Promise((resolve) => {
+                  setTimeout(
+                    () => resolve(createResponse((effect.args[0] as TimeSeriesQueryRequestMessage).queries, createDatapoints(3))),
+                    10,
+                  );
+                });
+              }
+              return next();
+            },
+          })
+          .dispatch(shortRequests[0])
+          .dispatch(longRequests[0])
+          .dispatch(shortRequests[1])
+          .delay(0)
+          .dispatch(longRequests[1])
+          .dispatch(shortRequests[2])
+          .dispatch(longRequests[2])
+          .run();
+      });
+
+      it("handles errors correctly", function() {
+        const fakeError = new Error("connection error");
+
+        const expectedState = new metrics.MetricsState();
+        expectedState.inFlight = 0;
+        expectedState.queries = {
+          "id.0": createMetricsState("id.0", shortTimespan, ["short.1"], 3),
+          "id.1": createMetricsState("id.1", longTimespan, ["long.1"], 3),
+          "id.2": createMetricsState("id.2", shortTimespan, ["short.2", "short.3"], 3),
+          "id.3": createMetricsErrorState("id.3", longTimespan, ["long.2", "long.3"], fakeError),
+          "id.4": createMetricsErrorState("id.4", shortTimespan, ["short.4"], fakeError),
+          "id.5": createMetricsErrorState("id.5", longTimespan, ["long.4", "long.5"], fakeError),
+        };
+
+        let callCounter = 0;
+        return expectSaga(metrics.queryMetricsSaga)
+          .withReducer(metrics.metricsReducer)
+          .hasFinalState(expectedState)
+          .provide({
+            call(effect, next) {
+              if (effect.fn === queryTimeSeries) {
+                callCounter++;
+                if (callCounter > 2) {
+                  throw fakeError;
+                }
+                return createResponse((effect.args[0] as TimeSeriesQueryRequestMessage).queries, createDatapoints(3));
+              }
+              return next();
+            },
+          })
+          .dispatch(shortRequests[0])
+          .dispatch(longRequests[0])
+          .dispatch(shortRequests[1])
+          .delay(0)
+          .dispatch(longRequests[1])
+          .dispatch(shortRequests[2])
+          .dispatch(longRequests[2])
+          .run();
+      });
+
+      it("handles inflight counter correctly", function() {
+        const expectedState = new metrics.MetricsState();
+        expectedState.inFlight = 1;
+        expectedState.queries = {
+          "id.0": createMetricsState("id.0", shortTimespan, ["short.1"], 3),
+          "id.1": createMetricsState("id.1", longTimespan, ["long.1"], 3),
+          "id.2": createMetricsState("id.2", shortTimespan, ["short.2", "short.3"], 3),
+          "id.3": createMetricsInFlightState("id.3", longTimespan, ["long.2", "long.3"]),
+          "id.4": createMetricsInFlightState("id.4", shortTimespan, ["short.4"]),
+          "id.5": createMetricsInFlightState("id.5", longTimespan, ["long.4", "long.5"]),
+        };
+
+        let callCounter = 0;
+        return expectSaga(metrics.queryMetricsSaga)
+          .withReducer(metrics.metricsReducer)
+          .hasFinalState(expectedState)
+          .provide({
+            call(effect, next) {
+              if (effect.fn === queryTimeSeries) {
+                callCounter++;
+                if (callCounter > 2) {
+                  // return a promise that never resolves.
+                  return new Promise((_resolve) => {});
+                }
+                return createResponse((effect.args[0] as TimeSeriesQueryRequestMessage).queries, createDatapoints(3));
+              }
+              return next();
+            },
+          })
+          .dispatch(shortRequests[0])
+          .dispatch(longRequests[0])
+          .dispatch(shortRequests[1])
+          .delay(0)
+          .dispatch(longRequests[1])
+          .dispatch(shortRequests[2])
+          .dispatch(longRequests[2])
+          .run();
       });
     });
   });

--- a/pkg/ui/src/redux/metrics.ts
+++ b/pkg/ui/src/redux/metrics.ts
@@ -18,6 +18,7 @@ type TSRequest = protos.cockroach.ts.tspb.TimeSeriesQueryRequest;
 type TSResponse = protos.cockroach.ts.tspb.TimeSeriesQueryResponse;
 
 export const REQUEST = "cockroachui/metrics/REQUEST";
+export const BEGIN = "cockroachui/metrics/BEGIN";
 export const RECEIVE = "cockroachui/metrics/RECEIVE";
 export const ERROR = "cockroachui/metrics/ERROR";
 export const FETCH = "cockroachui/metrics/FETCH";
@@ -183,6 +184,20 @@ export function requestMetrics(id: string, request: TSRequest): PayloadAction<Wi
 }
 
 /**
+ * beginMetrics is dispatched by the processing saga to indicate that it has
+ * begun the process of dispatching a request.
+ */
+export function beginMetrics(id: string, request: TSRequest): PayloadAction<WithID<TSRequest>> {
+  return {
+    type: BEGIN,
+    payload: {
+      id: id,
+      data: request,
+    },
+  };
+}
+
+/**
  * receiveMetrics indicates that a previous request from this component has been
  * fulfilled by the server.
  */
@@ -253,7 +268,7 @@ export function* queryMetricsSaga() {
     const requestAction: PayloadAction<WithID<TSRequest>> = yield take((REQUEST));
 
     // Dispatch action to underlying store.
-    yield put(requestAction);
+    yield put(beginMetrics(requestAction.payload.id, requestAction.payload.data));
     requests.push(requestAction.payload);
 
     // If no other requests are queued, fork a process which will send the

--- a/pkg/ui/yarn.lock
+++ b/pkg/ui/yarn.lock
@@ -429,6 +429,14 @@ array-includes@^3.0.3:
     define-properties "^1.1.2"
     es-abstract "^1.7.0"
 
+array-map@0.0.0:
+  version "0.0.0"
+  resolved "https://registry.yarnpkg.com/array-map/-/array-map-0.0.0.tgz#88a2bab73d1cf7bcd5c1b118a003f66f665fa662"
+
+array-reduce@0.0.0:
+  version "0.0.0"
+  resolved "https://registry.yarnpkg.com/array-reduce/-/array-reduce-0.0.0.tgz#173899d3ffd1c7d9383e4479525dbe278cab5f2b"
+
 array-slice@^0.2.3:
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/array-slice/-/array-slice-0.2.3.tgz#dd3cfb80ed7973a75117cdac69b0b99ec86186f5"
@@ -1865,6 +1873,10 @@ core-js@^2.2.0, core-js@^2.4.0:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.4.1.tgz#4de911e667b0eae9124e34254b53aea6fc618d3e"
 
+core-js@^2.4.1:
+  version "2.5.5"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.5.5.tgz#b14dde936c640c0579a6b50cabcc132dd6127e3b"
+
 core-js@^2.5.0:
   version "2.5.7"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.5.7.tgz#f972608ff0cead68b841a16a932d0b183791814e"
@@ -2969,6 +2981,10 @@ for-own@^0.1.4:
   dependencies:
     for-in "^1.0.1"
 
+foreach@2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/foreach/-/foreach-2.0.4.tgz#cc5d0d8ae1d46cc9a555c2682f910977859935df"
+
 foreach@^2.0.5:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/foreach/-/foreach-2.0.5.tgz#0bee005018aeb260d0a3af3ae658dd0136ec1b99"
@@ -3074,6 +3090,10 @@ fsevents@^1.1.2:
   dependencies:
     nan "^2.9.2"
     node-pre-gyp "^0.10.0"
+
+fsm-iterator@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/fsm-iterator/-/fsm-iterator-1.1.0.tgz#337de45de19eb205788cf02e3a955ec206760dec"
 
 fstream-ignore@^1.0.5:
   version "1.0.5"
@@ -3952,6 +3972,10 @@ json-stringify-safe@~5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
 
+json3@3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/json3/-/json3-3.3.0.tgz#0e9e7f6c5d270b758929af4d6fefdc84bd66e259"
+
 json3@3.3.2, json3@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/json3/-/json3-3.3.2.tgz#3c0434743df93e2f5c42aee7b19bcb483575f4e1"
@@ -4209,9 +4233,17 @@ lodash.isarray@^3.0.0:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/lodash.isarray/-/lodash.isarray-3.0.4.tgz#79e4eb88c36a8122af86f844aa9bcd851b5fbb55"
 
+lodash.isequal@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.isequal/-/lodash.isequal-4.5.0.tgz#415c4478f2bcc30120c22ce10ed3226f7d3e18e0"
+
 lodash.isfunction@^3.0.8:
   version "3.0.8"
   resolved "https://registry.yarnpkg.com/lodash.isfunction/-/lodash.isfunction-3.0.8.tgz#4db709fc81bc4a8fd7127a458a5346c5cdce2c6b"
+
+lodash.ismatch@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/lodash.ismatch/-/lodash.ismatch-4.4.0.tgz#756cb5150ca3ba6f11085a78849645f188f85f37"
 
 lodash.isstring@^4.0.1:
   version "4.0.1"
@@ -4848,6 +4880,10 @@ object-inspect@^1.5.0:
 object-is@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/object-is/-/object-is-1.0.1.tgz#0aa60ec9989a0b3ed795cf4d06f62cf1ad6539b6"
+
+object-keys@0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-0.5.0.tgz#09e211f3e00318afc4f592e36e7cdc10d9ad7293"
 
 object-keys@^1.0.11, object-keys@^1.0.8:
   version "1.0.11"
@@ -5893,6 +5929,17 @@ reduce-function-call@^1.0.1:
   resolved "https://registry.yarnpkg.com/reduce-function-call/-/reduce-function-call-1.0.2.tgz#5a200bf92e0e37751752fe45b0ab330fd4b6be99"
   dependencies:
     balanced-match "^0.4.2"
+
+redux-saga-test-plan@^3.6.0:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/redux-saga-test-plan/-/redux-saga-test-plan-3.6.0.tgz#ca316ce212efbddf4ffa532bb0e673bba8114b1d"
+  dependencies:
+    core-js "^2.4.1"
+    fsm-iterator "^1.1.0"
+    lodash.isequal "^4.5.0"
+    lodash.ismatch "^4.4.0"
+    object-assign "^4.1.0"
+    util-inspect "^0.1.8"
 
 redux-saga@^0.15.6:
   version "0.15.6"
@@ -7104,6 +7151,18 @@ useragent@^2.1.12:
 util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
+
+util-inspect@^0.1.8:
+  version "0.1.8"
+  resolved "https://registry.yarnpkg.com/util-inspect/-/util-inspect-0.1.8.tgz#2b39dbcd2d921f2d8430923caff40f4b5cea5db1"
+  dependencies:
+    array-map "0.0.0"
+    array-reduce "0.0.0"
+    foreach "2.0.4"
+    indexof "0.0.1"
+    isarray "0.0.1"
+    json3 "3.3.0"
+    object-keys "0.5.0"
 
 util@0.10.3, util@^0.10.3:
   version "0.10.3"


### PR DESCRIPTION
Rewrite tests of the existing metrics query system, which uses
redux-saga, to use the third-party testing tool redux-test-saga-plan.
This is a powerful tool which makes tightly-coupled saga tests much more
succinct, but also allows for loosely-coupled integration tests with
powerful mocking and expectation options.

+ Rewrites most existing tests for the metrics saga to use "testSaga()"
primative, which is still tightly coupled to saga output, but is much
more succinct than the previous code.
+ Rewrites one test to use "expectSaga()" primitive, which actually runs
a saga in the background and allows result expectations to be divided
more clearly from the underlying saga.
+ Adds three new integration-level tests using "expectSaga()".

Also adds a useful "ui-test-debug" make target, which is similar to the
existing "ui-test-watch" target but opens up a Chrome browser for
interactive debugging with Karma. I believe this is now acceptable,
since the UI tests depend on a chrome installation.

Release note: none