### PR TITLE
backport-2.0: ui: add compaction/flushes to storage graphs

### DIFF
--- a/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/storage.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/storage.tsx
@@ -112,6 +112,19 @@ export default function (props: GraphDashboardProps) {
     </LineGraph>,
 
     <LineGraph
+      title="RocksDB Compactions/Flushes"
+      sources={storeSources}
+      tooltip={
+        `The number of RocksDB compactions and memtable flushes, per second ${tooltipSelection}.`
+      }
+    >
+      <Axis label="count">
+        <Metric name="cr.store.rocksdb.compactions" title="Compactions" nonNegativeRate />
+        <Metric name="cr.store.rocksdb.flushes" title="Flushes" nonNegativeRate />
+      </Axis>
+    </LineGraph>,
+
+    <LineGraph
       title="Time Series Writes"
       sources={nodeSources}
       tooltip={


### PR DESCRIPTION
Backport 1/1 commits from #25428.

/cc @cockroachdb/release

---

Knowing whether compactions are going on is helpful when diagnosing I/O
performance problems.

Release note (admin ui change): Add RocksDB compactions/flushes to
storage graphs.
