### PR TITLE
backport-2.0: compactor: configure via cluster settings

### DIFF
--- a/pkg/settings/float.go
+++ b/pkg/settings/float.go
@@ -45,6 +45,14 @@ func (*FloatSetting) Typ() string {
 	return "f"
 }
 
+// Override changes the setting, panicking when validation fails.
+// For testing usage only.
+func (f *FloatSetting) Override(sv *Values, v float64) {
+	if err := f.set(sv, v); err != nil {
+		panic(err)
+	}
+}
+
 // Validate that a value conforms with the validation function.
 func (f *FloatSetting) Validate(v float64) error {
 	if f.validateFn != nil {

--- a/pkg/settings/float.go
+++ b/pkg/settings/float.go
@@ -69,6 +69,11 @@ func (f *FloatSetting) setToDefault(sv *Values) {
 	}
 }
 
+// Default returns the default value.
+func (f *FloatSetting) Default() float64 {
+	return f.defaultValue
+}
+
 // RegisterFloatSetting defines a new setting with type float.
 func RegisterFloatSetting(key, desc string, defaultValue float64) *FloatSetting {
 	return RegisterValidatedFloatSetting(key, desc, defaultValue, nil)

--- a/pkg/settings/int.go
+++ b/pkg/settings/int.go
@@ -73,6 +73,11 @@ func (i *IntSetting) setToDefault(sv *Values) {
 	}
 }
 
+// Default returns the default value.
+func (i *IntSetting) Default() int64 {
+	return i.defaultValue
+}
+
 // RegisterIntSetting defines a new setting with type int.
 func RegisterIntSetting(key, desc string, defaultValue int64) *IntSetting {
 	return RegisterValidatedIntSetting(key, desc, defaultValue, nil)

--- a/pkg/storage/compactor/compactor.go
+++ b/pkg/storage/compactor/compactor.go
@@ -284,13 +284,24 @@ func (c *Compactor) processCompaction(
 	capacity roachpb.StoreCapacity,
 	delBatch engine.Batch,
 ) (int64, error) {
-	shouldProcess := c.enabled() && (aggr.Bytes >= c.thresholdBytes() ||
-		aggr.Bytes >= int64(float64(capacity.LogicalBytes)*c.thresholdBytesUsedFraction()) ||
-		aggr.Bytes >= int64(float64(capacity.Available)*c.thresholdBytesAvailableFraction()))
+	aboveSizeThresh := aggr.Bytes >= c.thresholdBytes()
+	aboveUsedFracThresh := func() bool {
+		thresh := c.thresholdBytesUsedFraction()
+		return thresh > 0 && aggr.Bytes >= int64(float64(capacity.LogicalBytes)*thresh)
+	}()
+	aboveAvailFracThresh := func() bool {
+		thresh := c.thresholdBytesAvailableFraction()
+		return thresh > 0 && aggr.Bytes >= int64(float64(capacity.Available)*thresh)
+	}()
 
+	shouldProcess := c.enabled() && (aboveSizeThresh || aboveUsedFracThresh || aboveAvailFracThresh)
 	if shouldProcess {
 		startTime := timeutil.Now()
-		log.Infof(ctx, "processing compaction %s", aggr)
+		log.Infof(ctx,
+			"processing compaction %s (reasons: size=%t used=%t avail=%t)",
+			aggr, aboveSizeThresh, aboveUsedFracThresh, aboveAvailFracThresh,
+		)
+
 		if err := c.eng.CompactRange(aggr.StartKey, aggr.EndKey, false /* forceBottommost */); err != nil {
 			c.Metrics.CompactionFailures.Inc(1)
 			return 0, errors.Wrapf(err, "unable to compact range %+v", aggr)
@@ -316,7 +327,7 @@ func (c *Compactor) processCompaction(
 			continue
 		}
 		if tooOld {
-			c.Metrics.BytesSkipped.Inc(aggr.Bytes)
+			c.Metrics.BytesSkipped.Inc(sc.Bytes)
 		}
 		key := keys.StoreSuggestedCompactionKey(sc.StartKey, sc.EndKey)
 		if err := delBatch.Clear(engine.MVCCKey{Key: key}); err != nil {

--- a/pkg/storage/compactor/settings.go
+++ b/pkg/storage/compactor/settings.go
@@ -1,0 +1,106 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package compactor
+
+import (
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/settings"
+	"github.com/pkg/errors"
+)
+
+func init() {
+	// Hide the advanced knobs (defined below), leaving only `enabled`
+	// user-visible.
+	minInterval.Hide()
+	thresholdBytes.Hide()
+	thresholdBytesUsedFraction.Hide()
+	thresholdBytesAvailableFraction.Hide()
+	maxSuggestedCompactionRecordAge.Hide()
+}
+
+func validateFraction(v float64) error {
+	if v >= 0 && v <= 1 { // handles +-Inf, Nan
+		return nil
+	}
+	return errors.Errorf("value %v not between zero and one", v)
+}
+
+var enabled = settings.RegisterBoolSetting(
+	"compactor.enabled",
+	"when false, the system will reclaim space occupied by deleted data less aggressively",
+	true,
+)
+
+// minInterval indicates the minimum period of
+// time to wait before any compaction activity is considered, after
+// suggestions are made. The intent is to allow sufficient time for
+// all ranges to be cleared when a big table is dropped, so the
+// compactor can determine contiguous stretches and efficient delete
+// sstable files.
+var minInterval = settings.RegisterDurationSetting(
+	"compactor.min_interval",
+	"minimum time interval to wait before compacting",
+	2*time.Minute,
+)
+
+// thresholdBytes is the threshold in bytes of suggested
+// reclamation, after which the compactor will begin processing
+// (taking compactor min interval into account). Note that we want
+// to target roughly the target size of an L6 SSTable (128MB) but
+// these are logical bytes (as in, from MVCCStats) which can't be
+// translated into SSTable-bytes. As a result, we conservatively set
+// a higher threshold.
+var thresholdBytes = settings.RegisterByteSizeSetting(
+	"compactor.threshold_bytes",
+	"minimum expected logical space reclamation required before considering an aggregated suggestion",
+	256<<20, // more than 256MiB will trigger
+)
+
+// ThresholdBytesUsedFraction is the fraction of total logical
+// bytes used which are up for suggested reclamation, after which
+// the compactor will begin processing (taking compactor min
+// interval into account). Note that this threshold handles the case
+// where a table is dropped which is a significant fraction of the
+// total space in the database, but does not exceed the absolute
+// defaultThresholdBytes threshold.
+var thresholdBytesUsedFraction = settings.RegisterValidatedFloatSetting(
+	"compactor.threshold_used_fraction",
+	"Consider suggestions for at least the given percentage of the used logical space",
+	0.10, // more than 10% of space will trigger
+	validateFraction,
+)
+
+// thresholdBytesAvailableFraction is the fraction of remaining
+// available space on a disk, which, if exceeded by the size of a suggested
+// compaction, should trigger the processing of said compaction. This
+// threshold is meant to make compaction more aggressive when a store is
+// nearly full, since reclaiming space is much more important in such
+// scenarios.	ThresholdBytesAvailableFraction() float64
+var thresholdBytesAvailableFraction = settings.RegisterValidatedFloatSetting(
+	"compactor.threshold_available_fraction",
+	"Consider suggestions for at least the given percentage of the available logical space",
+	0.10, // more than 10% of space will trigger
+	validateFraction,
+)
+
+// maxSuggestedCompactionRecordAge is the maximum age of a
+// suggested compaction record. If not processed within this time
+// interval since the compaction was suggested, it will be deleted.
+var maxSuggestedCompactionRecordAge = settings.RegisterNonNegativeDurationSetting(
+	"compactor.max_record_age",
+	"discard suggestions not processed within this duration",
+	24*time.Hour,
+)

--- a/pkg/storage/compactor/settings.go
+++ b/pkg/storage/compactor/settings.go
@@ -78,7 +78,7 @@ var thresholdBytes = settings.RegisterByteSizeSetting(
 // defaultThresholdBytes threshold.
 var thresholdBytesUsedFraction = settings.RegisterValidatedFloatSetting(
 	"compactor.threshold_used_fraction",
-	"Consider suggestions for at least the given percentage of the used logical space",
+	"Consider suggestions for at least the given percentage of the used logical space (zero to disable)",
 	0.10, // more than 10% of space will trigger
 	validateFraction,
 )
@@ -91,7 +91,7 @@ var thresholdBytesUsedFraction = settings.RegisterValidatedFloatSetting(
 // scenarios.	ThresholdBytesAvailableFraction() float64
 var thresholdBytesAvailableFraction = settings.RegisterValidatedFloatSetting(
 	"compactor.threshold_available_fraction",
-	"Consider suggestions for at least the given percentage of the available logical space",
+	"Consider suggestions for at least the given percentage of the available logical space (zero to disable)",
 	0.10, // more than 10% of space will trigger
 	validateFraction,
 )

--- a/pkg/storage/store.go
+++ b/pkg/storage/store.go
@@ -876,6 +876,7 @@ func NewStore(cfg StoreConfig, eng engine.Engine, nodeDesc *roachpb.NodeDescript
 	s.metrics.registry.AddMetricStruct(tsCacheMetrics)
 
 	s.compactor = compactor.NewCompactor(
+		s.cfg.Settings,
 		s.engine.(engine.WithSSTables),
 		s.Capacity,
 		func(ctx context.Context) { s.asyncGossipStore(ctx, "compactor-initiated rocksdb compaction") },


### PR DESCRIPTION
Backport 1/1 commits from #25397.

/cc @cockroachdb/release

---

The compactor can cause instability or degrade performance, and it does
so in an intransparent way, partially because its compactions are
low-priority and are thus regularly pending for upwards of ten minutes,
without being able to tell at which point work is being done. It's
important to be able to change its behavior, and in particular to
disable it, whether that's because of a known problem or a suspected
one. This wasn't possible at all previously. Now it can be achieved by
setting `compactor.threshold_bytes` and `max_record_age` to a very high
and low value, respectively.

Release note (general change): Introduced cluster settings to configure
the compactor.
