### PR TITLE
acceptance: de-flake decommissioning test

### DIFF
--- a/pkg/acceptance/decommission_test.go
+++ b/pkg/acceptance/decommission_test.go
@@ -227,7 +227,8 @@ func testDecommissionInner(
 
 		exp := [][]string{
 			decommissionHeader,
-			{strconv.Itoa(int(target)), "true", "0", "true", "true"},
+			// Note that the process may return before the node is known as draining.
+			{strconv.Itoa(int(target)), "true", "0", "true", "false|true"},
 			decommissionFooter,
 		}
 		if err := matchCSV(o, exp); err != nil {
@@ -284,7 +285,8 @@ func testDecommissionInner(
 
 		exp := [][]string{
 			decommissionHeader,
-			{strconv.Itoa(int(target)), "true", "0", "true", "true"},
+			// Note that the process may return before the node is known as draining.
+			{strconv.Itoa(int(target)), "true", "0", "true", "false|true"},
 			decommissionFooter,
 		}
 		if err := matchCSV(o, exp); err != nil {
@@ -331,7 +333,8 @@ func testDecommissionInner(
 
 		exp := [][]string{
 			decommissionHeader,
-			{strconv.Itoa(int(target)), "true", "0", "true", "true"},
+			// Note that the process may return before the node is known as draining.
+			{strconv.Itoa(int(target)), "true", "0", "true", "false|true"},
 			decommissionFooter,
 		}
 		if err := matchCSV(o, exp); err != nil {


### PR DESCRIPTION
When letting the server handle the waiting portion, it will generally
return based on the replica count and won't care whether the node is
already draining. The tests were making that assumption in a few
remaining places and as a result, failed every once in a blue moon.

Fixes #21888.

Release note: None