### PR TITLE
sql: fix gossip alert key parsing

### DIFF
--- a/pkg/gossip/gossip.go
+++ b/pkg/gossip/gossip.go
@@ -670,7 +670,7 @@ func (g *Gossip) updateNodeAddress(key string, content roachpb.Value) {
 	// We can't directly compare the node against the empty descriptor because
 	// the proto has a repeated field and thus isn't comparable.
 	if desc.NodeID == 0 && desc.Address.IsEmpty() {
-		nodeID, err := NodeIDFromKey(key)
+		nodeID, err := NodeIDFromKey(key, KeyNodeIDPrefix)
 		if err != nil {
 			log.Errorf(ctx, "unable to update node address for removed node: %s", err)
 			return

--- a/pkg/gossip/keys.go
+++ b/pkg/gossip/keys.go
@@ -116,11 +116,11 @@ func IsNodeIDKey(key string) bool {
 	return strings.HasPrefix(key, KeyNodeIDPrefix+separator)
 }
 
-// NodeIDFromKey attempts to extract a NodeID from the provided key. The key
-// should have been constructed by MakeNodeIDKey or MakeNodeHealthAlertKey.
-// Returns an error if the key is not of the correct type or is not parsable.
-func NodeIDFromKey(key string) (roachpb.NodeID, error) {
-	trimmedKey, err := removePrefixFromKey(key, KeyNodeIDPrefix)
+// NodeIDFromKey attempts to extract a NodeID from the provided key after
+// stripping the provided prefix. Returns an error if the key is not of the
+// correct type or is not parsable.
+func NodeIDFromKey(key string, prefix string) (roachpb.NodeID, error) {
+	trimmedKey, err := removePrefixFromKey(key, prefix)
 	if err != nil {
 		return 0, err
 	}

--- a/pkg/gossip/keys_test.go
+++ b/pkg/gossip/keys_test.go
@@ -46,7 +46,7 @@ func TestNodeIDFromKey(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.key, func(t *testing.T) {
-			nodeID, err := NodeIDFromKey(tc.key)
+			nodeID, err := NodeIDFromKey(tc.key, KeyNodeIDPrefix)
 			if err != nil {
 				if tc.success {
 					t.Errorf("expected success, got error: %s", err)

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -1841,7 +1841,7 @@ CREATE TABLE crdb_internal.gossip_alerts (
 			if err := protoutil.Unmarshal(bytes, &d); err != nil {
 				return errors.Wrapf(err, "failed to parse value for key %q", key)
 			}
-			nodeID, err := gossip.NodeIDFromKey(key)
+			nodeID, err := gossip.NodeIDFromKey(key, gossip.KeyNodeHealthAlertPrefix)
 			if err != nil {
 				return errors.Wrapf(err, "failed to parse node ID from key %q", key)
 			}

--- a/pkg/sql/crdb_internal_test.go
+++ b/pkg/sql/crdb_internal_test.go
@@ -1,0 +1,65 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package sql_test
+
+import (
+	"context"
+	"testing"
+
+	"time"
+
+	"fmt"
+
+	"github.com/cockroachdb/cockroach/pkg/gossip"
+	"github.com/cockroachdb/cockroach/pkg/server/status"
+	"github.com/cockroachdb/cockroach/pkg/sql"
+	"github.com/cockroachdb/cockroach/pkg/sql/tests"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+)
+
+func TestGossipAlertsTable(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	params, _ := tests.CreateTestServerParams()
+	s, _, _ := serverutils.StartServer(t, params)
+	defer s.Stopper().Stop(context.TODO())
+	ctx := context.TODO()
+
+	if err := s.Gossip().AddInfoProto(gossip.MakeNodeHealthAlertKey(456), &status.HealthCheckResult{
+		Alerts: []status.HealthAlert{{
+			StoreID:     123,
+			Category:    status.HealthAlert_METRICS,
+			Description: "foo",
+			Value:       100.0,
+		}},
+	}, time.Hour); err != nil {
+		t.Fatal(err)
+	}
+
+	ie := s.InternalExecutor().(*sql.InternalExecutor)
+	row, err := ie.QueryRow(ctx, "test", nil /* txn */, "SELECT * FROM crdb_internal.gossip_alerts")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if a, e := len(row), 5; a != e {
+		t.Fatalf("got %d rows, wanted %d", a, e)
+	}
+	a := fmt.Sprintf("%v %v %v %v %v", row[0], row[1], row[2], row[3], row[4])
+	e := "456 123 'metrics' 'foo' 100.0"
+	if a != e {
+		t.Fatalf("got:\n%s\nexpected:\n%s", a, e)
+	}
+}


### PR DESCRIPTION
Queries to `crdb_internal.gossip_alerts` would fail whenever the table
was nonempty due to calling an incorrect parsing function.

Release note: None