### PR TITLE
opt/optbuilder: Fix type checking for HAVING, WHERE, and ON

### DIFF
--- a/pkg/sql/opt/optbuilder/groupby.go
+++ b/pkg/sql/opt/optbuilder/groupby.go
@@ -284,7 +284,7 @@ func (b *Builder) buildAggregation(
 // The return value corresponds to the top-level memo group ID for this
 // HAVING clause.
 func (b *Builder) buildHaving(having tree.Expr, inScope *scope) memo.GroupID {
-	out := b.buildScalar(inScope.resolveType(having, types.Bool), inScope)
+	out := b.buildScalar(inScope.resolveAndRequireType(having, types.Bool, "HAVING"), inScope)
 	if len(inScope.groupby.varsUsed) > 0 {
 		i := inScope.groupby.varsUsed[0]
 		col := b.colMap[i]

--- a/pkg/sql/opt/optbuilder/join.go
+++ b/pkg/sql/opt/optbuilder/join.go
@@ -63,7 +63,7 @@ func (b *Builder) buildJoin(join *tree.JoinTableExpr, inScope *scope) (outScope 
 
 		var filter memo.GroupID
 		if on, ok := cond.(*tree.OnJoinCond); ok {
-			filter = b.buildScalar(outScope.resolveType(on.Expr, types.Bool), outScope)
+			filter = b.buildScalar(outScope.resolveAndRequireType(on.Expr, types.Bool, "ON"), outScope)
 		} else {
 			filter = b.factory.ConstructTrue()
 		}

--- a/pkg/sql/opt/optbuilder/select.go
+++ b/pkg/sql/opt/optbuilder/select.go
@@ -309,7 +309,7 @@ func (b *Builder) buildFrom(from *tree.From, where *tree.Where, inScope *scope) 
 
 	if where != nil {
 		// All "from" columns are visible to the filter expression.
-		texpr := outScope.resolveType(where.Expr, types.Bool)
+		texpr := outScope.resolveAndRequireType(where.Expr, types.Bool, "WHERE")
 
 		// Make sure there are no aggregation/window functions in the filter
 		// (after subqueries have been expanded).

--- a/pkg/sql/opt/optbuilder/testdata/having
+++ b/pkg/sql/opt/optbuilder/testdata/having
@@ -103,7 +103,7 @@ error: aggregate functions are not allowed in the argument of max()
 build
 SELECT MAX(k), MIN(v) FROM kv HAVING k
 ----
-error: column "kv.k" must appear in the GROUP BY clause or be used in an aggregate function
+error: argument of HAVING must be type bool, not type int
 
 # Expressions listed in the HAVING clause must conform to same validation as the SELECT clause (grouped or aggregated).
 build

--- a/pkg/sql/opt/optbuilder/testdata/join
+++ b/pkg/sql/opt/optbuilder/testdata/join
@@ -3024,3 +3024,9 @@ project
       └── plus [type=int]
            ├── variable: column1 [type=int]
            └── const: 1 [type=int]
+
+# ON clause must be type bool.
+build
+SELECT * FROM foo JOIN bar ON foo.c
+----
+error: argument of ON must be type bool, not type float

--- a/pkg/sql/opt/optbuilder/testdata/where
+++ b/pkg/sql/opt/optbuilder/testdata/where
@@ -258,3 +258,9 @@ project
                 └── tuple [type=tuple{unknown, int}]
                      ├── null [type=unknown]
                      └── const: 50 [type=int]
+
+# Where clause must be type bool.
+build
+SELECT * FROM ab WHERE a
+----
+error: argument of WHERE must be type bool, not type int


### PR DESCRIPTION
The `HAVING`, `WHERE`, and `ON` clauses must all be type bool. This commit
causes an error to be thrown if another type is used instead.

The error message is the same as the error thrown by the existing
CockroachDB planner.

Release note: None