### PR TITLE
roachtest: update hardcoded list of zones in roachmart

### DIFF
--- a/pkg/cmd/roachtest/roachmart.go
+++ b/pkg/cmd/roachtest/roachmart.go
@@ -31,7 +31,7 @@ func registerRoachmart(r *registry) {
 			i    int
 			zone string
 		}{
-			{1, "us-east1-b"},
+			{1, "us-central1-b"},
 			{4, "us-west1-b"},
 			{7, "europe-west2-b"},
 		}


### PR DESCRIPTION
We have a very unfortunate hardcoded list of the zones that we expect
roachprod to make for a geo-distributed cluster. We should remove the
list at some point, but for now, update the list to unbreak the test.

Caught by #25421.

Release note: None