### PR TITLE
sql: fix create user

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/user
+++ b/pkg/sql/logictest/testdata/logic_test/user
@@ -18,19 +18,19 @@ root
 testuser
 user1
 
-statement error a role named admin already exists
+statement error pgcode 42710 a role named admin already exists
 CREATE USER admin
 
-statement error a role named admin already exists
+statement error pgcode 42710 a role named admin already exists
 CREATE USER IF NOT EXISTS admin
 
-statement error a user named user1 already exists
+statement error pgcode 42710 a user named user1 already exists
 CREATE USER user1
 
 statement ok
 CREATE USER IF NOT EXISTS user1
 
-statement error a user named user1 already exists
+statement error pgcode 42710 a user named user1 already exists
 CREATE USER UsEr1
 
 statement ok

--- a/pkg/sql/user.go
+++ b/pkg/sql/user.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 )
@@ -65,28 +64,6 @@ func (p *planner) GetAllUsersAndRoles(ctx context.Context) (map[string]bool, err
 		users[string(username)] = bool(*isRole)
 	}
 	return users, nil
-}
-
-// Returns true is the requested username is a role, false if it is a user.
-// Returns error if it does not exist.
-func existingUserIsRole(
-	ctx context.Context, ie *InternalExecutor, txn *client.Txn, username string,
-) (bool, error) {
-	values, err := ie.QueryRow(
-		ctx,
-		"is-role",
-		txn,
-		`SELECT "isRole" FROM system.users WHERE username=$1`,
-		username)
-	if err != nil {
-		return false, errors.Wrapf(err, "error looking up user %s", username)
-	}
-	if len(values) == 0 {
-		return false, errors.Errorf("no user or role named %s", username)
-	}
-
-	isRole := bool(*(values[0]).(*tree.DBool))
-	return isRole, nil
 }
 
 var roleMembersTableName = tree.MakeTableName("system", "role_members")


### PR DESCRIPTION
The "create user" statement was swallowing a (KV) error and continuing
with the transaction, which is not valid. This patch rewrites it to do a
read for detecting the conflict it was previously detecting via the
error.
Also adds an error code to some failures.

Release note: None