### PR TITLE
opt: allow distribution of optimizer plans

### DIFF
--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -398,7 +398,7 @@ func shouldUseOptimizer(optMode sessiondata.OptimizerMode, stmt Statement) bool 
 			return true
 		}
 
-	case sessiondata.OptimizerOn:
+	case sessiondata.OptimizerOn, sessiondata.OptimizerLocal:
 		// Only handle a subset of the statement types (currently read-only queries).
 		switch stmt.AST.(type) {
 		case *tree.ParenSelect, *tree.Select, *tree.SelectClause,

--- a/pkg/sql/logictest/testdata/logic_test/optimizer
+++ b/pkg/sql/logictest/testdata/logic_test/optimizer
@@ -1,4 +1,4 @@
-# LogicTest: default
+# LogicTest: default distsql
 
 statement ok
 CREATE TABLE t (k INT PRIMARY KEY, v INT)
@@ -10,7 +10,7 @@ statement ok
 SET EXPERIMENTAL_OPT = ON
 
 # ParenSelect
-query II
+query II rowsort
 (SELECT * FROM test.t)
 ----
 1  10
@@ -18,7 +18,7 @@ query II
 3  30
 
 # Select
-query II
+query II rowsort
 SELECT * FROM test.t ORDER BY 1-t.k
 ----
 3  30
@@ -26,7 +26,7 @@ SELECT * FROM test.t ORDER BY 1-t.k
 1  10
 
 # SelectClause
-query II
+query II rowsort
 SELECT * FROM test.t
 ----
 1  10
@@ -34,7 +34,7 @@ SELECT * FROM test.t
 3  30
 
 # UnionClause
-query II
+query II rowsort
 SELECT * FROM test.t UNION SELECT * FROM test.t
 ----
 1  10
@@ -50,7 +50,7 @@ SELECT EXISTS(SELECT * FROM t WHERE k > 2)
 ----
 true
 
-query II
+query II rowsort
 SELECT * FROM test.t WHERE 2*v > (SELECT MAX(v) FROM test.t)
 ----
 3  30
@@ -61,3 +61,15 @@ SET EXPERIMENTAL_OPT = ALWAYS
 
 query error pq: unexpected statement: \*tree.Insert
 INSERT INTO test (k, v) VALUES (5, 50)
+
+statement ok
+SET EXPERIMENTAL_OPT = LOCAL
+
+# In local mode, we should always get the results in order (no rowsort).
+query II
+SELECT * FROM test.t
+----
+1  10
+2  20
+3  30
+4  40

--- a/pkg/sql/logictest/testdata/logic_test/set
+++ b/pkg/sql/logictest/testdata/logic_test/set
@@ -194,6 +194,9 @@ statement ok
 SET EXPERIMENTAL_OPT = ON
 
 statement ok
+SET EXPERIMENTAL_OPT = LOCAL
+
+statement ok
 SET EXPERIMENTAL_OPT = OFF
 
 statement error not supported

--- a/pkg/sql/sessiondata/session_data.go
+++ b/pkg/sql/sessiondata/session_data.go
@@ -134,6 +134,9 @@ const (
 	OptimizerOff = iota
 	// OptimizerOn means that we use the optimizer for all supported statements.
 	OptimizerOn
+	// OptimizerLocal means that we use the optimizer for all supported
+	// statements, but we don't try to distribute the resulting plan.
+	OptimizerLocal
 	// OptimizerAlways means that we attempt to use the optimizer always, even
 	// for unsupported statements which result in errors. This mode is useful
 	// for testing.
@@ -146,6 +149,8 @@ func (m OptimizerMode) String() string {
 		return "off"
 	case OptimizerOn:
 		return "on"
+	case OptimizerLocal:
+		return "local"
 	case OptimizerAlways:
 		return "always"
 	default:
@@ -160,6 +165,8 @@ func OptimizerModeFromString(val string) (_ OptimizerMode, ok bool) {
 		return OptimizerOff, true
 	case "ON":
 		return OptimizerOn, true
+	case "LOCAL":
+		return OptimizerLocal, true
 	case "ALWAYS":
 		return OptimizerAlways, true
 	default:


### PR DESCRIPTION
Flip the switch to allow plans generated through the optimizer to be
executed by distsql. Add a `LOCAL` option for the `EXPERIMENTAL_OPT`
variable to revert to the old behavior.

Release note: None