### PR TITLE
storage: put an Aborted txn inside a TxnAbortedError

### DIFF
--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -5198,6 +5198,7 @@ func checkIfTxnAborted(
 		if entry.Priority > newTxn.Priority {
 			newTxn.Priority = entry.Priority
 		}
+		newTxn.Status = roachpb.ABORTED
 		return roachpb.NewErrorWithTxn(roachpb.NewTransactionAbortedError(), &newTxn)
 	}
 	return nil

--- a/pkg/storage/replica_test.go
+++ b/pkg/storage/replica_test.go
@@ -5170,6 +5170,7 @@ func TestAbortSpanError(t *testing.T) {
 		expected := txn.Clone()
 		expected.Timestamp = txn.Timestamp
 		expected.Priority = priority
+		expected.Status = roachpb.ABORTED
 		if pErr.GetTxn() == nil || !reflect.DeepEqual(pErr.GetTxn(), &expected) {
 			t.Errorf("txn does not match: %s vs. %s", pErr.GetTxn(), expected)
 		}


### PR DESCRIPTION
TxnAbortedErrors have an updated transaction it them. It makes sense for
that transaction to be marked as Aborted, instead of Pending.