### PR TITLE
sql: allow CANCEL JOB on schema changes

### DIFF
--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -472,7 +472,7 @@ func (sc *SchemaChanger) distBackfill(
 				fractionRangesFinished := float32(origNRanges-nRanges) / float32(origNRanges)
 				fractionCompleted := origFractionCompleted + fractionLeft*fractionRangesFinished
 				if err := sc.job.Progressed(ctx, jobs.FractionUpdater(fractionCompleted)); err != nil {
-					log.Infof(ctx, "Ignoring error reporting progress %f for job %d: %v", fractionCompleted, *sc.job.ID(), err)
+					return jobs.SimplifyInvalidStatusError(err)
 				}
 			}
 

--- a/pkg/sql/distsql_physical_planner_test.go
+++ b/pkg/sql/distsql_physical_planner_test.go
@@ -78,7 +78,7 @@ func SplitTable(
 
 	rightRangeStartKey := rightRange.StartKey.AsRawKey()
 	rightRange, err = tc.AddReplicas(rightRangeStartKey, tc.Target(targetNodeIdx))
-	if err != nil {
+	if err != nil && !testutils.IsError(err, "is already present") {
 		t.Fatal(err)
 	}
 

--- a/pkg/sql/jobs/jobs.go
+++ b/pkg/sql/jobs/jobs.go
@@ -109,6 +109,16 @@ func (e *InvalidStatusError) Error() string {
 	return fmt.Sprintf("cannot %s %s job (id %d)", e.op, e.status, e.id)
 }
 
+// SimplifyInvalidStatusError unwraps an *InvalidStatusError into an error
+// message suitable for users. Other errors are returned as passed.
+func SimplifyInvalidStatusError(err error) error {
+	ierr, ok := err.(*InvalidStatusError)
+	if !ok {
+		return err
+	}
+	return errors.Errorf("job %s", ierr.status)
+}
+
 // ID returns the ID of the job that this Job is currently tracking. This will
 // be nil if Created has not yet been called.
 func (j *Job) ID() *int64 {

--- a/pkg/sql/jobs/jobs_test.go
+++ b/pkg/sql/jobs/jobs_test.go
@@ -1026,17 +1026,17 @@ func TestJobLifecycle(t *testing.T) {
 		}
 	})
 
-	t.Run("cannot pause or cancel uncontrollable jobs", func(t *testing.T) {
+	t.Run("cannot pause or resume schema changes", func(t *testing.T) {
 		job, _ := createJob(jobs.Record{
 			Details: jobs.SchemaChangeDetails{},
 		})
 		if err := registry.Pause(ctx, nil, *job.ID()); !testutils.IsError(err, "is not controllable") {
 			t.Fatalf("unexpected %v", err)
 		}
-		if err := registry.Cancel(ctx, nil, *job.ID()); !testutils.IsError(err, "is not controllable") {
+		if err := registry.Resume(ctx, nil, *job.ID()); !testutils.IsError(err, "is not controllable") {
 			t.Fatalf("unexpected %v", err)
 		}
-		if err := registry.Resume(ctx, nil, *job.ID()); !testutils.IsError(err, "is not controllable") {
+		if err := registry.Cancel(ctx, nil, *job.ID()); err != nil {
 			t.Fatalf("unexpected %v", err)
 		}
 	})

--- a/pkg/sql/logictest/testdata/logic_test/alter_table
+++ b/pkg/sql/logictest/testdata/logic_test/alter_table
@@ -89,7 +89,7 @@ ORDER BY created DESC
 LIMIT 2
 ----
 SCHEMA CHANGE  ROLL BACK ALTER TABLE test.public.t ADD CONSTRAINT bar UNIQUE (c)  root  succeeded  1.00  ·
-SCHEMA CHANGE  ALTER TABLE test.public.t ADD CONSTRAINT bar UNIQUE (c)            root  failed     0.10  duplicate key value (c)=(1) violates unique constraint "bar"
+SCHEMA CHANGE  ALTER TABLE test.public.t ADD CONSTRAINT bar UNIQUE (c)            root  failed     0.00  duplicate key value (c)=(1) violates unique constraint "bar"
 
 query IIII colnames,rowsort
 SELECT * FROM t

--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -783,11 +783,6 @@ func (sc *SchemaChanger) runStateMachineAndBackfill(
 		return err
 	}
 
-	if err := sc.job.Progressed(ctx, jobs.FractionUpdater(.1)); err != nil {
-		log.Warningf(ctx, "failed to log progress on job %v after completing state machine: %v",
-			*sc.job.ID(), err)
-	}
-
 	// Run backfill(s).
 	if err := sc.runBackfill(ctx, lease, evalCtx); err != nil {
 		return err


### PR DESCRIPTION
Also remove an inaccurate setting of jobs.Progress to an initial
10%. Each chunk already sets a better progress amount.

Release note (sql change): allow CANCEL JOB to be executed on
long-running schema change jobs, causing them to terminate early and
roll back.

See #16018