### PR TITLE
backport-2.0: sql: remove unneeded row definitions in the grammar

### DIFF
--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -1274,8 +1274,7 @@ d_expr ::=
 	| select_with_parens
 	| 'ARRAY' select_with_parens
 	| 'ARRAY' array_expr
-	| explicit_row
-	| implicit_row
+	| row
 
 array_subscripts ::=
 	( array_subscript ) ( ( array_subscript ) )*
@@ -1582,11 +1581,9 @@ array_expr ::=
 	'[' opt_expr_list ']'
 	| '[' array_expr_list ']'
 
-explicit_row ::=
+row ::=
 	'ROW' '(' opt_expr_list ')'
-
-implicit_row ::=
-	'(' expr_list ',' a_expr ')'
+	| '(' expr_list ',' a_expr ')'
 
 array_subscript ::=
 	'[' a_expr ']'

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -847,7 +847,7 @@ func newNameFromStr(s string) *tree.Name {
 %type <tree.Expr>  interval
 %type <[]coltypes.T> type_list prep_type_clause
 %type <tree.Exprs> array_expr_list
-%type <tree.Expr>  row explicit_row implicit_row
+%type <tree.Expr>  row
 %type <tree.Expr>  case_expr case_arg case_default
 %type <*tree.When>  when_clause
 %type <[]*tree.When> when_clause_list
@@ -5080,13 +5080,8 @@ first_or_next:
 // We handle this by using the a_expr production for what the spec calls
 // <ordinary grouping set>, which in the spec represents either one column
 // reference or a parenthesized list of column references. Then, we check the
-// top node of the a_expr to see if it's an implicit RowExpr, and if so, just
-// grab and use the list, discarding the node. (this is done in parse analysis,
-// not here)
-//
-// (we abuse the row_format field of RowExpr to distinguish implicit and
-// explicit row constructors; it's debatable if anyone sanely wants to use them
-// in a group clause, but if they have a reason to, we make it possible.)
+// top node of the a_expr to see if it's an RowExpr, and if so, just grab and
+// use the list, discarding the node. (this is done in parse analysis, not here)
 //
 // Each item in the group_clause list is either an expression tree or a
 // GroupingSet node of some type.
@@ -6539,11 +6534,7 @@ d_expr:
   {
     $$.val = $2.expr()
   }
-| explicit_row
-  {
-    $$.val = $1.expr()
-  }
-| implicit_row
+| row
   {
     $$.val = $1.expr()
   }
@@ -6873,18 +6864,6 @@ row:
     $$.val = &tree.Tuple{Exprs: $3.exprs(), Row: true}
   }
 | '(' expr_list ',' a_expr ')'
-  {
-    $$.val = &tree.Tuple{Exprs: append($2.exprs(), $4.expr())}
-  }
-
-explicit_row:
-  ROW '(' opt_expr_list ')'
-  {
-    $$.val = &tree.Tuple{Exprs: $3.exprs(), Row: true}
-  }
-
-implicit_row:
-  '(' expr_list ',' a_expr ')'
   {
     $$.val = &tree.Tuple{Exprs: append($2.exprs(), $4.expr())}
   }


### PR DESCRIPTION
Backport 1/1 commits from #25170.

/cc @cockroachdb/release

I'm backporting both #25170 and #25216 so that any changes to the sql.y grammar will be easier to backport in the future.  They both do not have any effect on the system.

---

There is no difference between a row, implicit row or explisit row in our
grammar.  This just removes the extra labels.

Release note: None
