### PR TITLE
workload: add partition affinity to TPCC workload

### DIFF
--- a/pkg/workload/tpcc/partition.go
+++ b/pkg/workload/tpcc/partition.go
@@ -337,3 +337,16 @@ func partitionTables(db *gosql.DB, warehouses, partitions int) {
 	partitionHistory(db, wIDs, partitions)
 	partitionItem(db, partitions)
 }
+
+func isTableAlreadyPartitioned(db *gosql.DB) (bool, error) {
+	var count int
+	if err := db.QueryRow(
+		// Check for the existence of a partition named p0, which indicates that the
+		// table has been paritioned already.
+		`SELECT count(*) FROM crdb_internal.partitions where name = 'p0'`,
+	).Scan(&count); err != nil {
+		return false, err
+	}
+
+	return count > 0, nil
+}


### PR DESCRIPTION
Before there was no good way to run multiple TPCC workloads against one
cluster because we couldn't peg the load generator to a specific range
of warehouses.

Now TPCC has a flag to set parition affinity for paritioned tables, so
that it will only run against warehouses in one partition while knowing
that it's a subset of the total warehouses. This will keep the total
cluster TPMC within the correct bounds.

Closes #25087

Release note: None