### PR TITLE
storage: reject time_until_store_dead if smaller than gossip interval

### DIFF
--- a/pkg/acceptance/decommission_test.go
+++ b/pkg/acceptance/decommission_test.go
@@ -346,7 +346,7 @@ func testDecommissionInner(
 	// waste too much time waiting for the node to be recognized as dead. Note that
 	// we don't want to set this number too low or everything will seem dead to the
 	// allocator at all times, so nothing will ever happen.
-	withDB(1, "SET CLUSTER SETTING server.time_until_store_dead = '15s'")
+	withDB(1, "SET CLUSTER SETTING server.time_until_store_dead = '1m15s'")
 
 	log.Info(ctx, "intentionally killing first node")
 	if err := c.Kill(ctx, 0); err != nil {

--- a/pkg/server/updates_test.go
+++ b/pkg/server/updates_test.go
@@ -139,7 +139,7 @@ func TestReportUsage(t *testing.T) {
 	if _, err := db.Exec(fmt.Sprintf(`CREATE DATABASE %s`, elemName)); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := db.Exec(`SET CLUSTER SETTING server.time_until_store_dead = '20s'`); err != nil {
+	if _, err := db.Exec(`SET CLUSTER SETTING server.time_until_store_dead = '90s'`); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := db.Exec(`SET CLUSTER SETTING diagnostics.reporting.send_crash_reports = false`); err != nil {
@@ -417,7 +417,7 @@ func TestReportUsage(t *testing.T) {
 		"cluster.organization":                     "<redacted>",
 		"diagnostics.reporting.enabled":            "true",
 		"diagnostics.reporting.send_crash_reports": "false",
-		"server.time_until_store_dead":             "20s",
+		"server.time_until_store_dead":             "1m30s",
 		"trace.debug.enable":                       "false",
 		"version":                                  "2.0-3",
 		"cluster.secret":                           "<redacted>",

--- a/pkg/storage/store_pool.go
+++ b/pkg/storage/store_pool.go
@@ -31,6 +31,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/shuffle"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+	"github.com/pkg/errors"
 )
 
 const (
@@ -57,11 +58,25 @@ var failedReservationsTimeout = settings.RegisterNonNegativeDurationSetting(
 	5*time.Second,
 )
 
+const timeUntilStoreDeadSettingName = "server.time_until_store_dead"
+
 // TimeUntilStoreDead wraps "server.time_until_store_dead".
-var TimeUntilStoreDead = settings.RegisterNonNegativeDurationSetting(
-	"server.time_until_store_dead",
+var TimeUntilStoreDead = settings.RegisterValidatedDurationSetting(
+	timeUntilStoreDeadSettingName,
 	"the time after which if there is no new gossiped information about a store, it is considered dead",
 	5*time.Minute,
+	func(v time.Duration) error {
+		// Setting this to less than the interval for gossiping stores is a big
+		// no-no, since this value is compared to the age of the most recent gossip
+		// from each store to determine whether that store is live. Put a buffer of
+		// 15 seconds on top to allow time for gossip to propagate.
+		const minTimeUntilStoreDead = gossip.StoresInterval + 15*time.Second
+		if v < minTimeUntilStoreDead {
+			return errors.Errorf("cannot set %s to less than %v: %v",
+				timeUntilStoreDeadSettingName, minTimeUntilStoreDead, v)
+		}
+		return nil
+	},
 )
 
 // A NodeLivenessFunc accepts a node ID, current time and threshold before


### PR DESCRIPTION
Fixes #25391

Release note (sql change): The server.time_until_store_dead cluster
setting can no longer be set to less than 1m15s. Setting it to lower
values was previously allowed but not safe, since it can cause very bad
rebalancing behavior.

I think this is good enough for now, so I'm closing the issue, but if you think it's important to allow smaller values then let me know and we can find time later to change how the `StorePool` determines liveness.