### PR TITLE
sql: add default case for type switch in ShowClusterSetting

### DIFF
--- a/pkg/sql/show_cluster_setting.go
+++ b/pkg/sql/show_cluster_setting.go
@@ -133,7 +133,7 @@ func (p *planner) ShowClusterSetting(
 		name:    "SHOW CLUSTER SETTING " + name,
 		columns: columns,
 		constructor: func(ctx context.Context, p *planner) (planNode, error) {
-			d := tree.DNull
+			var d tree.Datum
 			switch s := val.(type) {
 			case *settings.IntSetting:
 				d = tree.NewDInt(tree.DInt(s.Get(&st.SV)))
@@ -155,6 +155,8 @@ func (p *planner) ShowClusterSetting(
 				d = tree.NewDInt(tree.DInt(s.Get(&st.SV)))
 			case *settings.ByteSizeSetting:
 				d = tree.NewDString(s.String(&st.SV))
+			default:
+				return nil, errors.Errorf("unknown setting type for %s: %s", name, val.Typ())
 			}
 
 			v := p.newContainerValuesNode(columns, 0)


### PR DESCRIPTION
Noticed while looking at #25600, but this doesn't appear to be the issue
given that the segfault is within DString, not DNull. It still seems
like a bad practice not to catch this, though.

Release note: None

Sorry for bugging you if we actually do want such errors to fall through, or are happy with trusting the switch statement above.