### PR TITLE
all: move some errgroup to ctxgroup

### DIFF
--- a/pkg/ccl/importccl/read_import_csv.go
+++ b/pkg/ccl/importccl/read_import_csv.go
@@ -14,11 +14,10 @@ import (
 	"io"
 	"runtime"
 
-	"golang.org/x/sync/errgroup"
-
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/pkg/errors"
 )
@@ -48,13 +47,13 @@ func newCSVInputReader(
 	}
 }
 
-func (c *csvInputReader) start(ctx context.Context, group *errgroup.Group) {
-	group.Go(func() error {
-		sCtx, span := tracing.ChildSpan(ctx, "convertcsv")
+func (c *csvInputReader) start(group ctxgroup.Group) {
+	group.GoCtx(func(ctx context.Context) error {
+		ctx, span := tracing.ChildSpan(ctx, "convertcsv")
 		defer tracing.FinishSpan(span)
 
 		defer close(c.kvCh)
-		return groupWorkers(sCtx, runtime.NumCPU(), func(ctx context.Context) error {
+		return ctxgroup.GroupWorkers(ctx, runtime.NumCPU(), func(ctx context.Context) error {
 			return c.convertRecord(ctx)
 		})
 	})

--- a/pkg/util/ctxgroup/ctxgroup.go
+++ b/pkg/util/ctxgroup/ctxgroup.go
@@ -1,0 +1,200 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+/*
+Package ctxgroup wraps golang.org/x/sync/errgroup with a context func.
+
+This package extends and modifies the errgroup API slightly to
+make context variables more explicit. WithContext no longer returns
+a context. Instead, the GoCtx method explicitly passes one to the
+invoked func. The goal is to make misuse of context vars with errgroups
+more difficult.
+
+Problems with errgroup
+
+The bugs this package attempts to prevent are: misuse of shadowed
+ctx variables after errgroup closure and confusion in the face of
+multiple ctx variables when trying to prevent shadowing. The following
+are all example bugs that Cockroach has had during its use of errgroup:
+
+	ctx := context.Background()
+	g, ctx := errgroup.WithContext(ctx)
+	ch := make(chan bool)
+	g.Go(func() error {
+		defer close(ch)
+		for _, val := range []bool{true, false} {
+			select {
+			case ch <- val:
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+		}
+		return nil
+	})
+	g.Go(func() error {
+		for val := range ch {
+			if err := api.Call(ctx, val); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+	if err := g.Wait(); err != nil {
+		return err
+	}
+	api.Call(ctx, "done")
+
+The ctx used by the final api.Call is already closed because the
+errgroup has returned. This happened because of the desire to not
+create another ctx variable, and so we shadowed the original ctx var,
+but then incorrectly continued to use it after the errgroup had closed
+its context. So we make a modification and create new gCtx variable
+that doesn't shadow the original ctx:
+
+	ctx := context.Background()
+	g, gCtx := errgroup.WithContext(ctx)
+	ch := make(chan bool)
+	g.Go(func() error {
+		defer close(ch)
+		for _, val := range []bool{true, false} {
+			select {
+			case ch <- val:
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+		}
+		return nil
+	})
+	g.Go(func() error {
+		for val := range ch {
+			if err := api.Call(ctx, val); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+	if err := g.Wait(); err != nil {
+		return err
+	}
+	api.Call(ctx, "done")
+
+Now the final api.Call is correct. But the other api.Call is incorrect
+and the ctx.Done receive is incorrect because they are using the wrong
+context and thus won't correctly exit early if the errgroup needs to
+exit early. Contrast with using this package:
+
+	ctx := context.Background()
+	g := ctxgroup.WithContext(ctx)
+	ch := make(chan bool)
+	g.GoCtx(func(ctx context.Context) error {
+		defer close(ch)
+		for _, val := range []bool{true, false} {
+			select {
+			case ch <- val:
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+		}
+		return nil
+	})
+	g.GoCtx(func(ctx context.Context) error {
+		for val := range ch {
+			if err := api.Call(ctx, val); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+	if err := g.Wait(); err != nil {
+		return err
+	}
+	api.Call(ctx, "done")
+
+Here it is always correct to use ctx as the context variable. The
+above example can be further improved in its Done call to:
+
+	ctx := context.Background()
+	g := ctxgroup.WithContext(ctx)
+	ch := make(chan bool)
+	g.GoCtx(func(ctx context.Context) error {
+		defer close(ch)
+		for _, val := range []bool{true, false} {
+			select {
+			case ch <- val:
+			case <-g.Done
+				return g.Err()
+			}
+		}
+		return nil
+	})
+	g.GoCtx(func(ctx context.Context) error {
+		for val := range ch {
+			if err := api.Call(ctx, val); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+	if err := g.Wait(); err != nil {
+		return err
+	}
+	api.Call(ctx, "done")
+
+*/
+package ctxgroup
+
+import (
+	"context"
+
+	"golang.org/x/sync/errgroup"
+)
+
+// Group wraps errgroup.
+type Group struct {
+	*errgroup.Group
+	// Done is set to ctx.Done().
+	Done <-chan struct{}
+	ctx  context.Context
+}
+
+// WithContext returns a new Group and an associated Context derived from ctx.
+func WithContext(ctx context.Context) Group {
+	grp, ctx := errgroup.WithContext(ctx)
+	return Group{
+		Group: grp,
+		Done:  ctx.Done(),
+		ctx:   ctx,
+	}
+}
+
+// GoCtx calls the given function in a new goroutine.
+func (g Group) GoCtx(f func(ctx context.Context) error) {
+	g.Group.Go(func() error {
+		return f(g.ctx)
+	})
+}
+
+// Err returns the Group's ctx.Err().
+func (g Group) Err() error {
+	return g.ctx.Err()
+}
+
+// GroupWorkers runs num worker go routines in an errgroup.
+func GroupWorkers(ctx context.Context, num int, f func(context.Context) error) error {
+	group := WithContext(ctx)
+	for i := 0; i < num; i++ {
+		group.GoCtx(f)
+	}
+	return group.Wait()
+}


### PR DESCRIPTION
The backup/restore/import code all uses errgroup for pipelining
work. We have historically had difficulties making sure the correct
ctx variable is used. Between the passed ctx, the span ctx, and the
errgroup ctx, occasionally we make an error and choose the wrong
variable.

Some examples. Before this change, backup.go was receiving from an
incorrect ctx.Done chan, resulting in a significant amount of wasted
work in case of an error (but no incorrectness). Second, in the CSV
refactor from yesterday an afternoon was spent by two of us figuring
out a race condition that turned out to be using an incorrect ctx
variable.

The goal here is to design an errgroup API that is harder to
misuse. This API works with two changes from base errgroup. First,
WithContext does not return a context. Second, a new GoCtx method
is added that explicitly passes the group's ctx to the invoked
func. These two changes make it much harder to use an incorrect
ctx. Now the easiest (and correct) thing is to just always use `ctx`
instead of having to worry about using the group's ctx vs the calling
parent func's ctx.

See https://godoc.org/github.com/oklog/run for an alternative API. That
API is nice in that it doesn't mention context at all. However we
already require contexts pretty much everywhere, so we might as well
embrace an API that does that in a helpful way for us.

Release note: None