### PR TITLE
opt: Fix output column names

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/aggregate
+++ b/pkg/sql/opt/exec/execbuilder/testdata/aggregate
@@ -12,176 +12,176 @@ CREATE TABLE kv (
 exec hide-colnames nodist
 EXPLAIN (VERBOSE) SELECT MIN(1), MAX(1), COUNT(1), SUM_INT(1), AVG(1), SUM(1), STDDEV(1), VARIANCE(1), BOOL_AND(true), BOOL_OR(false), XOR_AGG(b'\x01') FROM kv
 ----
-group           ·             ·                   (column6, column7, column8, column9, column10, column11, column12, column13, column15, column17, column19)  ·
- │              aggregate 0   min(column5)        ·                                                                                                           ·
- │              aggregate 1   max(column5)        ·                                                                                                           ·
- │              aggregate 2   count(column5)      ·                                                                                                           ·
- │              aggregate 3   sum_int(column5)    ·                                                                                                           ·
- │              aggregate 4   avg(column5)        ·                                                                                                           ·
- │              aggregate 5   sum(column5)        ·                                                                                                           ·
- │              aggregate 6   stddev(column5)     ·                                                                                                           ·
- │              aggregate 7   variance(column5)   ·                                                                                                           ·
- │              aggregate 8   bool_and(column14)  ·                                                                                                           ·
- │              aggregate 9   bool_or(column16)   ·                                                                                                           ·
- │              aggregate 10  xor_agg(column18)   ·                                                                                                           ·
- └── render     ·             ·                   (column5, column14, column16, column18)                                                                     ·
-      │         render 0      1                   ·                                                                                                           ·
-      │         render 1      true                ·                                                                                                           ·
-      │         render 2      false               ·                                                                                                           ·
-      │         render 3      '\x01'              ·                                                                                                           ·
-      └── scan  ·             ·                   ()                                                                                                          ·
-·               table         kv@primary          ·                                                                                                           ·
-·               spans         ALL                 ·                                                                                                           ·
+group           ·             ·                   (min, max, count, sum_int, avg, sum, stddev, variance, bool_and, bool_or, xor_agg)  ·
+ │              aggregate 0   min(column5)        ·                                                                                   ·
+ │              aggregate 1   max(column5)        ·                                                                                   ·
+ │              aggregate 2   count(column5)      ·                                                                                   ·
+ │              aggregate 3   sum_int(column5)    ·                                                                                   ·
+ │              aggregate 4   avg(column5)        ·                                                                                   ·
+ │              aggregate 5   sum(column5)        ·                                                                                   ·
+ │              aggregate 6   stddev(column5)     ·                                                                                   ·
+ │              aggregate 7   variance(column5)   ·                                                                                   ·
+ │              aggregate 8   bool_and(column14)  ·                                                                                   ·
+ │              aggregate 9   bool_or(column16)   ·                                                                                   ·
+ │              aggregate 10  xor_agg(column18)   ·                                                                                   ·
+ └── render     ·             ·                   (column5, column14, column16, column18)                                             ·
+      │         render 0      1                   ·                                                                                   ·
+      │         render 1      true                ·                                                                                   ·
+      │         render 2      false               ·                                                                                   ·
+      │         render 3      '\x01'              ·                                                                                   ·
+      └── scan  ·             ·                   ()                                                                                  ·
+·               table         kv@primary          ·                                                                                   ·
+·               spans         ALL                 ·                                                                                   ·
 
 exec
 SELECT MIN(1), MAX(1), COUNT(1), SUM_INT(1), AVG(1), SUM(1), STDDEV(1), VARIANCE(1), BOOL_AND(true), BOOL_OR(false), XOR_AGG(b'\x01') FROM kv
 ----
-column6:int  column7:int  column8:int  column9:int  column10:decimal  column11:decimal  column12:decimal  column13:decimal  column15:bool  column17:bool  column19:bytes
-NULL         NULL         0            NULL         NULL              NULL              NULL              NULL              NULL           NULL           NULL
+min:int  max:int  count:int  sum_int:int  avg:decimal  sum:decimal  stddev:decimal  variance:decimal  bool_and:bool  bool_or:bool  xor_agg:bytes
+NULL     NULL     0          NULL         NULL         NULL         NULL            NULL              NULL           NULL          NULL
 
 # Aggregate functions return NULL if there are no rows.
 exec
 SELECT ARRAY_AGG(1) FROM kv
 ----
-column6:int[]
+array_agg:int[]
 NULL
 
 exec
 SELECT JSON_AGG(1) FROM kv
 ----
-column6:jsonb
+json_agg:jsonb
 NULL
 
 exec
 SELECT JSONB_AGG(1) FROM kv
 ----
-column6:jsonb
+jsonb_agg:jsonb
 NULL
 
 exec hide-colnames nodist
 EXPLAIN (VERBOSE) SELECT MIN(v), MAX(v), COUNT(v), SUM_INT(1), AVG(v), SUM(v), STDDEV(v), VARIANCE(v), BOOL_AND(v = 1), BOOL_AND(v = 1), XOR_AGG(s::bytes) FROM kv
 ----
-render               ·            ·                   (column5, column6, column7, column9, column10, column11, column12, column13, column15, column15, column17)  ·
- │                   render 0     agg0                ·                                                                                                           ·
- │                   render 1     agg1                ·                                                                                                           ·
- │                   render 2     agg2                ·                                                                                                           ·
- │                   render 3     agg3                ·                                                                                                           ·
- │                   render 4     agg4                ·                                                                                                           ·
- │                   render 5     agg5                ·                                                                                                           ·
- │                   render 6     agg6                ·                                                                                                           ·
- │                   render 7     agg7                ·                                                                                                           ·
- │                   render 8     agg8                ·                                                                                                           ·
- │                   render 9     agg8                ·                                                                                                           ·
- │                   render 10    agg9                ·                                                                                                           ·
- └── group           ·            ·                   (agg0, agg1, agg2, agg3, agg4, agg5, agg6, agg7, agg8, agg9)                                                ·
-      │              aggregate 0  min(kv.v)           ·                                                                                                           ·
-      │              aggregate 1  max(kv.v)           ·                                                                                                           ·
-      │              aggregate 2  count(kv.v)         ·                                                                                                           ·
-      │              aggregate 3  sum_int(column8)    ·                                                                                                           ·
-      │              aggregate 4  avg(kv.v)           ·                                                                                                           ·
-      │              aggregate 5  sum(kv.v)           ·                                                                                                           ·
-      │              aggregate 6  stddev(kv.v)        ·                                                                                                           ·
-      │              aggregate 7  variance(kv.v)      ·                                                                                                           ·
-      │              aggregate 8  bool_and(column14)  ·                                                                                                           ·
-      │              aggregate 9  xor_agg(column16)   ·                                                                                                           ·
-      └── render     ·            ·                   (column8, column14, column16, "kv.v")                                                                       ·
-           │         render 0     1                   ·                                                                                                           ·
-           │         render 1     v = 1               ·                                                                                                           ·
-           │         render 2     s::BYTES            ·                                                                                                           ·
-           │         render 3     v                   ·                                                                                                           ·
-           └── scan  ·            ·                   (v, s)                                                                                                      ·
-·                    table        kv@primary          ·                                                                                                           ·
-·                    spans        ALL                 ·                                                                                                           ·
+render               ·            ·                   (min, max, count, sum_int, avg, sum, stddev, variance, bool_and, bool_and, xor_agg)  ·
+ │                   render 0     agg0                ·                                                                                    ·
+ │                   render 1     agg1                ·                                                                                    ·
+ │                   render 2     agg2                ·                                                                                    ·
+ │                   render 3     agg3                ·                                                                                    ·
+ │                   render 4     agg4                ·                                                                                    ·
+ │                   render 5     agg5                ·                                                                                    ·
+ │                   render 6     agg6                ·                                                                                    ·
+ │                   render 7     agg7                ·                                                                                    ·
+ │                   render 8     agg8                ·                                                                                    ·
+ │                   render 9     agg8                ·                                                                                    ·
+ │                   render 10    agg9                ·                                                                                    ·
+ └── group           ·            ·                   (agg0, agg1, agg2, agg3, agg4, agg5, agg6, agg7, agg8, agg9)                         ·
+      │              aggregate 0  min(kv.v)           ·                                                                                    ·
+      │              aggregate 1  max(kv.v)           ·                                                                                    ·
+      │              aggregate 2  count(kv.v)         ·                                                                                    ·
+      │              aggregate 3  sum_int(column8)    ·                                                                                    ·
+      │              aggregate 4  avg(kv.v)           ·                                                                                    ·
+      │              aggregate 5  sum(kv.v)           ·                                                                                    ·
+      │              aggregate 6  stddev(kv.v)        ·                                                                                    ·
+      │              aggregate 7  variance(kv.v)      ·                                                                                    ·
+      │              aggregate 8  bool_and(column14)  ·                                                                                    ·
+      │              aggregate 9  xor_agg(column16)   ·                                                                                    ·
+      └── render     ·            ·                   (column8, column14, column16, "kv.v")                                                ·
+           │         render 0     1                   ·                                                                                    ·
+           │         render 1     v = 1               ·                                                                                    ·
+           │         render 2     s::BYTES            ·                                                                                    ·
+           │         render 3     v                   ·                                                                                    ·
+           └── scan  ·            ·                   (v, s)                                                                               ·
+·                    table        kv@primary          ·                                                                                    ·
+·                    spans        ALL                 ·                                                                                    ·
 
 exec
 SELECT MIN(v), MAX(v), COUNT(v), SUM_INT(1), AVG(v), SUM(v), STDDEV(v), VARIANCE(v), BOOL_AND(v = 1), BOOL_AND(v = 1), XOR_AGG(s::bytes) FROM kv
 ----
-column5:int  column6:int  column7:int  column9:int  column10:decimal  column11:decimal  column12:decimal  column13:decimal  column15:bool  column15:bool  column17:bytes
-NULL         NULL         0            NULL         NULL              NULL              NULL              NULL              NULL           NULL           NULL
+min:int  max:int  count:int  sum_int:int  avg:decimal  sum:decimal  stddev:decimal  variance:decimal  bool_and:bool  bool_and:bool  xor_agg:bytes
+NULL     NULL     0          NULL         NULL         NULL         NULL            NULL              NULL           NULL           NULL
 
 exec
 SELECT ARRAY_AGG(v) FROM kv
 ----
-column5:int[]
+array_agg:int[]
 NULL
 
 exec
 SELECT JSON_AGG(v) FROM kv
 ----
-column5:jsonb
+json_agg:jsonb
 NULL
 
 exec
 SELECT JSONB_AGG(v) FROM kv
 ----
-column5:jsonb
+jsonb_agg:jsonb
 NULL
 
 # Aggregate functions trigger aggregation and computation when there is no source.
 exec hide-colnames nodist
 EXPLAIN (VERBOSE) SELECT MIN(1), COUNT(1), MAX(1), SUM_INT(1), AVG(1)::float, SUM(1), STDDEV(1), VARIANCE(1), BOOL_AND(true), BOOL_OR(true), TO_HEX(XOR_AGG(b'\x01'))
 ----
-render                 ·             ·                   (column2, column3, column4, column5, column7, column8, column9, column10, column12, column13, column16)  ·
- │                     render 0      agg0                ·                                                                                                        ·
- │                     render 1      agg1                ·                                                                                                        ·
- │                     render 2      agg2                ·                                                                                                        ·
- │                     render 3      agg3                ·                                                                                                        ·
- │                     render 4      agg4::FLOAT         ·                                                                                                        ·
- │                     render 5      agg5                ·                                                                                                        ·
- │                     render 6      agg6                ·                                                                                                        ·
- │                     render 7      agg7                ·                                                                                                        ·
- │                     render 8      agg8                ·                                                                                                        ·
- │                     render 9      agg9                ·                                                                                                        ·
- │                     render 10     to_hex(agg10)       ·                                                                                                        ·
- └── group             ·             ·                   (agg0, agg1, agg2, agg3, agg4, agg5, agg6, agg7, agg8, agg9, agg10)                                      ·
-      │                aggregate 0   min(column1)        ·                                                                                                        ·
-      │                aggregate 1   count(column1)      ·                                                                                                        ·
-      │                aggregate 2   max(column1)        ·                                                                                                        ·
-      │                aggregate 3   sum_int(column1)    ·                                                                                                        ·
-      │                aggregate 4   avg(column1)        ·                                                                                                        ·
-      │                aggregate 5   sum(column1)        ·                                                                                                        ·
-      │                aggregate 6   stddev(column1)     ·                                                                                                        ·
-      │                aggregate 7   variance(column1)   ·                                                                                                        ·
-      │                aggregate 8   bool_and(column11)  ·                                                                                                        ·
-      │                aggregate 9   bool_or(column11)   ·                                                                                                        ·
-      │                aggregate 10  xor_agg(column14)   ·                                                                                                        ·
-      └── render       ·             ·                   (column1, column11, column14)                                                                            ·
-           │           render 0      1                   ·                                                                                                        ·
-           │           render 1      true                ·                                                                                                        ·
-           │           render 2      '\x01'              ·                                                                                                        ·
-           └── values  ·             ·                   ()                                                                                                       ·
-·                      size          0 columns, 1 row    ·                                                                                                        ·
+render                 ·             ·                   (min, count, max, sum_int, "avg(1)::FLOAT", sum, stddev, variance, bool_and, bool_or, to_hex)  ·
+ │                     render 0      agg0                ·                                                                                              ·
+ │                     render 1      agg1                ·                                                                                              ·
+ │                     render 2      agg2                ·                                                                                              ·
+ │                     render 3      agg3                ·                                                                                              ·
+ │                     render 4      agg4::FLOAT         ·                                                                                              ·
+ │                     render 5      agg5                ·                                                                                              ·
+ │                     render 6      agg6                ·                                                                                              ·
+ │                     render 7      agg7                ·                                                                                              ·
+ │                     render 8      agg8                ·                                                                                              ·
+ │                     render 9      agg9                ·                                                                                              ·
+ │                     render 10     to_hex(agg10)       ·                                                                                              ·
+ └── group             ·             ·                   (agg0, agg1, agg2, agg3, agg4, agg5, agg6, agg7, agg8, agg9, agg10)                            ·
+      │                aggregate 0   min(column1)        ·                                                                                              ·
+      │                aggregate 1   count(column1)      ·                                                                                              ·
+      │                aggregate 2   max(column1)        ·                                                                                              ·
+      │                aggregate 3   sum_int(column1)    ·                                                                                              ·
+      │                aggregate 4   avg(column1)        ·                                                                                              ·
+      │                aggregate 5   sum(column1)        ·                                                                                              ·
+      │                aggregate 6   stddev(column1)     ·                                                                                              ·
+      │                aggregate 7   variance(column1)   ·                                                                                              ·
+      │                aggregate 8   bool_and(column11)  ·                                                                                              ·
+      │                aggregate 9   bool_or(column11)   ·                                                                                              ·
+      │                aggregate 10  xor_agg(column14)   ·                                                                                              ·
+      └── render       ·             ·                   (column1, column11, column14)                                                                  ·
+           │           render 0      1                   ·                                                                                              ·
+           │           render 1      true                ·                                                                                              ·
+           │           render 2      '\x01'              ·                                                                                              ·
+           └── values  ·             ·                   ()                                                                                             ·
+·                      size          0 columns, 1 row    ·                                                                                              ·
 
 exec
 SELECT MIN(1), COUNT(1), MAX(1), SUM_INT(1), AVG(1)::float, SUM(1), STDDEV(1), VARIANCE(1), BOOL_AND(true), BOOL_OR(true), TO_HEX(XOR_AGG(b'\x01'))
 ----
-column2:int  column3:int  column4:int  column5:int  column7:float  column8:decimal  column9:decimal  column10:decimal  column12:bool  column13:bool  column16:string
-1            1            1            1            1.0            1                NULL             NULL              true           true           01
+min:int  count:int  max:int  sum_int:int  avg(1)::FLOAT:float  sum:decimal  stddev:decimal  variance:decimal  bool_and:bool  bool_or:bool  to_hex:string
+1        1          1        1            1.0                  1            NULL            NULL              true           true          01
 
 # Aggregate functions triggers aggregation and computation when there is no source.
 exec
 SELECT MIN(1), COUNT(1), MAX(1), SUM_INT(1), AVG(1)::float, SUM(1), STDDEV(1), VARIANCE(1), BOOL_AND(true), BOOL_OR(true), TO_HEX(XOR_AGG(b'\x01'))
 ----
-column2:int  column3:int  column4:int  column5:int  column7:float  column8:decimal  column9:decimal  column10:decimal  column12:bool  column13:bool  column16:string
-1            1            1            1            1.0            1                NULL             NULL              true           true           01
+min:int  count:int  max:int  sum_int:int  avg(1)::FLOAT:float  sum:decimal  stddev:decimal  variance:decimal  bool_and:bool  bool_or:bool  to_hex:string
+1        1          1        1            1.0                  1            NULL            NULL              true           true          01
 
 # Aggregate functions triggers aggregation and computation when there is no source.
 exec
 SELECT ARRAY_AGG(1)
 ----
-column2:int[]
+array_agg:int[]
 ARRAY[1]
 
 exec
 SELECT JSON_AGG(1)
 ----
-column2:jsonb
+json_agg:jsonb
 '[1]'
 
 exec
 SELECT JSONB_AGG(1)
 ----
-column2:jsonb
+jsonb_agg:jsonb
 '[1]'
 
 # Some aggregate functions are not normalized to NULL when given a NULL
@@ -189,19 +189,19 @@ column2:jsonb
 exec
 SELECT COUNT(NULL)
 ----
-column2:int
+count:int
 0
 
 exec
 SELECT JSON_AGG(NULL)
 ----
-column2:jsonb
+json_agg:jsonb
 '[null]'
 
 exec
 SELECT JSONB_AGG(NULL)
 ----
-column2:jsonb
+jsonb_agg:jsonb
 '[null]'
 
 # With an explicit cast, this works as expected.
@@ -209,7 +209,7 @@ column2:jsonb
 exec nodist
 SELECT ARRAY_AGG(NULL::TEXT)
 ----
-column2:string[]
+array_agg:string[]
 ARRAY[NULL]
 
 # TODO(radu): Selecting from series not supported yet.
@@ -237,8 +237,8 @@ ARRAY[NULL]
 exec
 SELECT COUNT(*), COALESCE(MAX(k), 1) FROM kv
 ----
-column5:int  column7:int
-0            1
+count:int  COALESCE(max(k), 1):int
+0          1
 
 # TODO(radu): Subqueries not implemented yet.
 ## Same, using a subquery. (#12705)
@@ -262,33 +262,33 @@ INSERT INTO kv VALUES
 exec
 SELECT MIN(1), COUNT(1), MAX(1), SUM_INT(1), AVG(1)::float, SUM(1), STDDEV(1), VARIANCE(1)::float, BOOL_AND(true), BOOL_OR(true), TO_HEX(XOR_AGG(b'\x01')) FROM kv
 ----
-column6:int  column7:int  column8:int  column9:int  column11:float  column12:decimal  column13:decimal  column15:float  column17:bool  column18:bool  column21:string
-1            6            1            6            1.0             6                 0                 0.0             true           true           00
+min:int  count:int  max:int  sum_int:int  avg(1)::FLOAT:float  sum:decimal  stddev:decimal  variance(1)::FLOAT:float  bool_and:bool  bool_or:bool  to_hex:string
+1        6          1        6            1.0                  6            0               0.0                       true           true          00
 
 # Aggregate functions triggers aggregation and computation for every row even when applied to a constant.
 exec
 SELECT ARRAY_AGG(1) FROM kv
 ----
-column6:int[]
+array_agg:int[]
 ARRAY[1,1,1,1,1,1]
 
 exec
 SELECT JSON_AGG(1) FROM kv
 ----
-column6:jsonb
+json_agg:jsonb
 '[1, 1, 1, 1, 1, 1]'
 
 exec
 SELECT JSONB_AGG(1) FROM kv
 ----
-column6:jsonb
+jsonb_agg:jsonb
 '[1, 1, 1, 1, 1, 1]'
 
 # Even with no aggregate functions, grouping occurs in the presence of GROUP BY.
 exec rowsort
 SELECT 1 FROM kv GROUP BY v
 ----
-column5:int
+1:int
 1
 1
 1
@@ -297,154 +297,154 @@ column5:int
 exec
 SELECT 3 FROM kv HAVING TRUE
 ----
-column5:int
+3:int
 3
 
 exec rowsort
 SELECT COUNT(*), k FROM kv GROUP BY k
 ----
-column5:int  k:int
-1            1
-1            3
-1            5
-1            6
-1            7
-1            8
+count:int  k:int
+1          1
+1          3
+1          5
+1          6
+1          7
+1          8
 
 exec hide-colnames nodist
 EXPLAIN (VERBOSE) SELECT COUNT(*), k FROM kv GROUP BY 2
 ----
-render          ·            ·             (column5, k)  ·
- │              render 0     agg0          ·             ·
- │              render 1     k             ·             ·
- └── group      ·            ·             (k, agg0)     ·
-      │         aggregate 0  k             ·             ·
-      │         aggregate 1  count_rows()  ·             ·
-      │         group by     @1            ·             ·
-      └── scan  ·            ·             (k)           ·
-·               table        kv@primary    ·             ·
-·               spans        ALL           ·             ·
+render          ·            ·             (count, k)  ·
+ │              render 0     agg0          ·           ·
+ │              render 1     k             ·           ·
+ └── group      ·            ·             (k, agg0)   ·
+      │         aggregate 0  k             ·           ·
+      │         aggregate 1  count_rows()  ·           ·
+      │         group by     @1            ·           ·
+      └── scan  ·            ·             (k)         ·
+·               table        kv@primary    ·           ·
+·               spans        ALL           ·           ·
 
 # GROUP BY specified using column index works.
 exec rowsort
 SELECT COUNT(*), k FROM kv GROUP BY 2
 ----
-column5:int  k:int
-1            1
-1            3
-1            5
-1            6
-1            7
-1            8
+count:int  k:int
+1          1
+1          3
+1          5
+1          6
+1          7
+1          8
 
 # Grouping by more than one column works.
 exec rowsort
 SELECT v, COUNT(*), w FROM kv GROUP BY v, w
 ----
-v:int  column5:int  w:int
-NULL   1            5
-2      1            2
-2      2            3
-4      1            2
-4      1            5
+v:int  count:int  w:int
+NULL   1          5
+2      1          2
+2      2          3
+4      1          2
+4      1          5
 
 # Grouping by more than one column using column numbers works.
 exec rowsort
 SELECT v, COUNT(*), w FROM kv GROUP BY 1, 3
 ----
-v:int  column5:int  w:int
-NULL   1            5
-2      1            2
-2      2            3
-4      1            2
-4      1            5
+v:int  count:int  w:int
+NULL   1          5
+2      1          2
+2      2          3
+4      1          2
+4      1          5
 
 # Selecting and grouping on a function expression works.
 exec rowsort
 SELECT COUNT(*), UPPER(s) FROM kv GROUP BY UPPER(s)
 ----
-column6:int  column5:string
-1            NULL
-2            B
-3            A
+count:int  upper:string
+1          NULL
+2          B
+3          A
 
 # Selecting and grouping on a constant works.
 exec
 SELECT COUNT(*) FROM kv GROUP BY 1+2
 ----
-column6:int
+count:int
 6
 
 exec
 SELECT COUNT(*) FROM kv GROUP BY length('abc')
 ----
-column6:int
+count:int
 6
 
 # Selecting a function of something which is grouped works.
 exec rowsort
 SELECT COUNT(*), UPPER(s) FROM kv GROUP BY s
 ----
-column5:int  column6:string
-1            NULL
-1            A
-2            A
-2            B
+count:int  upper:string
+1          NULL
+1          A
+2          A
+2          B
 
 # Selecting and grouping on a more complex expression works.
 exec hide-colnames nodist
 EXPLAIN (VERBOSE) SELECT COUNT(*), k+v FROM kv GROUP BY k+v
 ----
-render               ·            ·             (column6, column5)  ·
- │                   render 0     agg0          ·                   ·
- │                   render 1     column5       ·                   ·
- └── group           ·            ·             (column5, agg0)     ·
-      │              aggregate 0  column5       ·                   ·
-      │              aggregate 1  count_rows()  ·                   ·
-      │              group by     @1            ·                   ·
-      └── render     ·            ·             (column5)           ·
-           │         render 0     k + v         ·                   ·
-           └── scan  ·            ·             (k, v)              ·
-·                    table        kv@primary    ·                   ·
-·                    spans        ALL           ·                   ·
+render               ·            ·             (count, "k + v")  ·
+ │                   render 0     agg0          ·                 ·
+ │                   render 1     column5       ·                 ·
+ └── group           ·            ·             (column5, agg0)   ·
+      │              aggregate 0  column5       ·                 ·
+      │              aggregate 1  count_rows()  ·                 ·
+      │              group by     @1            ·                 ·
+      └── render     ·            ·             (column5)         ·
+           │         render 0     k + v         ·                 ·
+           └── scan  ·            ·             (k, v)            ·
+·                    table        kv@primary    ·                 ·
+·                    spans        ALL           ·                 ·
 
 exec rowsort
 SELECT COUNT(*), k+v FROM kv GROUP BY k+v
 ----
-column6:int  column5:int
-1            NULL
-1            3
-1            7
-1            8
-1            9
-1            12
+count:int  k + v:int
+1          NULL
+1          3
+1          7
+1          8
+1          9
+1          12
 
 # Selecting a more complex expression, made up of things which are each grouped, works.
 exec hide-colnames nodist
 EXPLAIN (VERBOSE) SELECT COUNT(*), k+v FROM kv GROUP BY k, v
 ----
-render          ·            ·             (column5, column6)  ·
- │              render 0     agg0          ·                   ·
- │              render 1     k + v         ·                   ·
- └── group      ·            ·             (k, v, agg0)        ·
-      │         aggregate 0  k             ·                   ·
-      │         aggregate 1  v             ·                   ·
-      │         aggregate 2  count_rows()  ·                   ·
-      │         group by     @1-@2         ·                   ·
-      └── scan  ·            ·             (k, v)              ·
-·               table        kv@primary    ·                   ·
-·               spans        ALL           ·                   ·
+render          ·            ·             (count, "k + v")  ·
+ │              render 0     agg0          ·                 ·
+ │              render 1     k + v         ·                 ·
+ └── group      ·            ·             (k, v, agg0)      ·
+      │         aggregate 0  k             ·                 ·
+      │         aggregate 1  v             ·                 ·
+      │         aggregate 2  count_rows()  ·                 ·
+      │         group by     @1-@2         ·                 ·
+      └── scan  ·            ·             (k, v)            ·
+·               table        kv@primary    ·                 ·
+·               spans        ALL           ·                 ·
 
 exec rowsort
 SELECT COUNT(*), k+v FROM kv GROUP BY k, v
 ----
-column5:int  column6:int
-1            NULL
-1            3
-1            7
-1            8
-1            9
-1            12
+count:int  k + v:int
+1          NULL
+1          3
+1          7
+1          8
+1          9
+1          12
 
 # Test case from #2761.
 exec rowsort
@@ -460,7 +460,7 @@ count_1:int  lx:int
 exec rowsort
 SELECT s, COUNT(*) FROM kv GROUP BY s HAVING COUNT(*) > 1
 ----
-s:string  column5:int
+s:string  count:int
 a         2
 b         2
 
@@ -475,36 +475,36 @@ b         2
 exec rowsort
 SELECT MAX(k), MIN(v) FROM kv HAVING MIN(v) > 2
 ----
-column6:int  column5:int
+max:int  min:int
 
 exec rowsort
 SELECT MAX(k), MIN(v) FROM kv HAVING MAX(v) > 2
 ----
-column6:int  column7:int
-8            2
+max:int  min:int
+8        2
 
 exec
 SELECT COUNT(*)
 ----
-column1:int
+count:int
 1
 
 exec
 SELECT COUNT(k) FROM kv
 ----
-column5:int
+count:int
 6
 
 exec
 SELECT COUNT(1)
 ----
-column2:int
+count:int
 1
 
 exec
 SELECT COUNT(1) FROM kv
 ----
-column6:int
+count:int
 6
 
 # TODO(radu): ORDER BY not implemented yet.
@@ -547,15 +547,15 @@ column6:int
 exec
 SELECT COUNT(*), COUNT(k), COUNT(kv.v) FROM kv
 ----
-column5:int  column6:int  column7:int
-6            6            5
+count:int  count:int  count:int
+6          6          5
 
 # TODO(radu): this requires tuples but they are not yet supported in
 # distsql (#15938).
 exec nodist
 SELECT COUNT(kv.*) FROM kv
 ----
-column6:int
+count:int
 6
 
 # TODO(radu): DISTINCT not supported yet.
@@ -578,7 +578,7 @@ column6:int
 exec nodist
 SELECT COUNT((k, v)) FROM kv
 ----
-column6:int
+count:int
 6
 
 # TODO(radu): DISTINCT not supported yet.
@@ -597,38 +597,38 @@ column6:int
 exec nodist
 SELECT COUNT((k, v)) FROM kv LIMIT 1
 ----
-column6:int
+count:int
 6
 
 exec nodist
 SELECT COUNT((k, v)) FROM kv OFFSET 1
 ----
-column6:int
+count:int
 
 exec
 SELECT COUNT(k)+COUNT(kv.v) FROM kv
 ----
-column7:int
+count(k) + count(kv.v):int
 11
 
 exec nodist
 SELECT COUNT(NULL::int), COUNT((NULL, NULL))
 ----
-column2:int  column4:int
-0            1
+count:int  count:int
+0          1
 
 exec
 SELECT MIN(k), MAX(k), MIN(v), MAX(v) FROM kv
 ----
-column5:int  column6:int  column7:int  column8:int
-1            8            2            4
+min:int  max:int  min:int  max:int
+1        8        2        4
 
 # Even if no input rows match, we expect a row (of nulls).
 exec
 SELECT MIN(k), MAX(k), MIN(v), MAX(v) FROM kv WHERE k > 8
 ----
-column5:int  column6:int  column7:int  column8:int
-NULL         NULL         NULL         NULL
+min:int  max:int  min:int  max:int
+NULL     NULL     NULL     NULL
 
 # TODO(justin): we don't yet respect the inner ORDER BY
 #exec
@@ -640,32 +640,32 @@ NULL         NULL         NULL         NULL
 exec
 SELECT array_agg(s) FROM kv WHERE s IS NULL
 ----
-column5:string[]
+array_agg:string[]
 ARRAY[NULL]
 
 exec
 SELECT JSON_AGG(s) FROM kv WHERE s IS NULL
 ----
-column5:jsonb
+json_agg:jsonb
 '[null]'
 
 exec
 SELECT JSONB_AGG(s) FROM kv WHERE s IS NULL
 ----
-column5:jsonb
+jsonb_agg:jsonb
 '[null]'
 
 exec
 SELECT AVG(k), AVG(v), SUM(k), SUM(v) FROM kv
 ----
-column5:decimal  column6:decimal  column7:decimal  column8:decimal
-5                2.8              30               14
+avg:decimal  avg:decimal  sum:decimal  sum:decimal
+5            2.8          30           14
 
 exec
 SELECT AVG(k::decimal), AVG(v::decimal), SUM(k::decimal), SUM(v::decimal) FROM kv
 ----
-column6:decimal  column8:decimal  column9:decimal  column10:decimal
-5                2.8              30               14
+avg:decimal  avg:decimal  sum:decimal  sum:decimal
+5            2.8          30           14
 
 #exec
 #SELECT AVG(DISTINCT k), AVG(DISTINCT v), SUM(DISTINCT k), SUM(DISTINCT v) FROM kv
@@ -675,7 +675,7 @@ column6:decimal  column8:decimal  column9:decimal  column10:decimal
 exec
 SELECT AVG(k) * 2.0 + MAX(v)::DECIMAL FROM kv
 ----
-column7:decimal
+(avg(k) * 2.0) + max(v)::DECIMAL:decimal
 14.0
 
 # Verify things work with distsql when some of the nodes emit no results in the
@@ -683,28 +683,28 @@ column7:decimal
 exec
 SELECT AVG(k) * 2.0 + MAX(v)::DECIMAL FROM kv WHERE w*2 = k
 ----
-column7:decimal
+(avg(k) * 2.0) + max(v)::DECIMAL:decimal
 14.0
 
 exec hide-colnames nodist
 EXPLAIN (VERBOSE) SELECT COUNT(k) FROM kv
 ----
-group      ·            ·           (column5)  ·
- │         aggregate 0  count(k)    ·          ·
- └── scan  ·            ·           (k)        ·
-·          table        kv@primary  ·          ·
-·          spans        ALL         ·          ·
+group      ·            ·           (count)  ·
+ │         aggregate 0  count(k)    ·        ·
+ └── scan  ·            ·           (k)      ·
+·          table        kv@primary  ·        ·
+·          spans        ALL         ·        ·
 
 exec hide-colnames nodist
 EXPLAIN (VERBOSE) SELECT COUNT(k), SUM(k), MAX(k) FROM kv
 ----
-group      ·            ·           (column5, column6, column7)  ·
- │         aggregate 0  count(k)    ·                            ·
- │         aggregate 1  sum(k)      ·                            ·
- │         aggregate 2  max(k)      ·                            ·
- └── scan  ·            ·           (k)                          ·
-·          table        kv@primary  ·                            ·
-·          spans        ALL         ·                            ·
+group      ·            ·           (count, sum, max)  ·
+ │         aggregate 0  count(k)    ·                  ·
+ │         aggregate 1  sum(k)      ·                  ·
+ │         aggregate 2  max(k)      ·                  ·
+ └── scan  ·            ·           (k)                ·
+·          table        kv@primary  ·                  ·
+·          spans        ALL         ·                  ·
 
 exec-raw
 CREATE TABLE abc (
@@ -722,29 +722,29 @@ INSERT INTO abc VALUES ('one', 1.5, true, 5::decimal), ('two', 2.0, false, 1.1::
 exec hide-colnames nodist
 EXPLAIN (VERBOSE) SELECT MIN(a) FROM abc
 ----
-group      ·            ·            (column5)  ·
- │         aggregate 0  min(a)       ·          ·
- └── scan  ·            ·            (a)        ·
-·          table        abc@primary  ·          ·
-·          spans        ALL          ·          ·
+group      ·            ·            (min)  ·
+ │         aggregate 0  min(a)       ·      ·
+ └── scan  ·            ·            (a)    ·
+·          table        abc@primary  ·      ·
+·          spans        ALL          ·      ·
 
 exec
 SELECT MIN(a), MIN(b), MIN(c), MIN(d) FROM abc
 ----
-column5:string  column6:float  column7:bool  column8:decimal
-one             1.5            false         1.1
+min:string  min:float  min:bool  min:decimal
+one         1.5        false     1.1
 
 exec
 SELECT MAX(a), MAX(b), MAX(c), MAX(d) FROM abc
 ----
-column5:string  column6:float  column7:bool  column8:decimal
-two             2.0            true          5
+max:string  max:float  max:bool  max:decimal
+two         2.0        true      5
 
 exec
 SELECT AVG(b), SUM(b), AVG(d), SUM(d) FROM abc
 ----
-column5:float  column6:float  column7:decimal  column8:decimal
-1.75           3.5            3.05             6.1
+avg:float  sum:float  avg:decimal  sum:decimal
+1.75       3.5        3.05         6.1
 
 # Verify summing of intervals
 exec-raw
@@ -760,7 +760,7 @@ INSERT INTO intervals VALUES (INTERVAL '1 year 2 months 3 days 4 seconds'), (INT
 exec
 SELECT SUM(a) FROM intervals
 ----
-column2:interval
+sum:interval
 '3y5mon7d19s'
 
 exec-raw
@@ -783,120 +783,120 @@ INSERT INTO xyz VALUES (1, 2, 3.0), (4, 5, 6.0), (7, NULL, 8.0)
 exec
 SELECT MIN(x) FROM xyz
 ----
-column4:int
+min:int
 1
 
 exec hide-colnames nodist
 EXPLAIN (VERBOSE) SELECT MIN(x) FROM xyz
 ----
-group      ·            ·            (column4)  ·
- │         aggregate 0  min(x)       ·          ·
- └── scan  ·            ·            (x)        ·
-·          table        xyz@primary  ·          ·
-·          spans        ALL          ·          ·
+group      ·            ·            (min)  ·
+ │         aggregate 0  min(x)       ·      ·
+ └── scan  ·            ·            (x)    ·
+·          table        xyz@primary  ·      ·
+·          spans        ALL          ·      ·
 
 exec
 SELECT MIN(x) FROM xyz WHERE x in (0, 4, 7)
 ----
-column4:int
+min:int
 4
 
 # TODO(radu): we don't yet optimize this by scanning one entry from the xy index.
 exec hide-colnames nodist
 EXPLAIN (VERBOSE) SELECT MIN(x) FROM xyz WHERE x in (0, 4, 7)
 ----
-group      ·            ·                        (column4)  ·
- │         aggregate 0  min(x)                   ·          ·
- └── scan  ·            ·                        (x)        ·
-·          table        xyz@primary              ·          ·
-·          spans        /0-/0/# /4-/4/# /7-/7/#  ·          ·
+group      ·            ·                        (min)  ·
+ │         aggregate 0  min(x)                   ·      ·
+ └── scan  ·            ·                        (x)    ·
+·          table        xyz@primary              ·      ·
+·          spans        /0-/0/# /4-/4/# /7-/7/#  ·      ·
 
 exec
 SELECT MAX(x) FROM xyz
 ----
-column4:int
+max:int
 7
 
 # TODO(radu): we don't yet optimize MIN/MAX by scanning one entry from the xy index.
 exec hide-colnames nodist
 EXPLAIN (VERBOSE) SELECT MAX(x) FROM xyz
 ----
-group      ·            ·            (column4)  ·
- │         aggregate 0  max(x)       ·          ·
- └── scan  ·            ·            (x)        ·
-·          table        xyz@primary  ·          ·
-·          spans        ALL          ·          ·
+group      ·            ·            (max)  ·
+ │         aggregate 0  max(x)       ·      ·
+ └── scan  ·            ·            (x)    ·
+·          table        xyz@primary  ·      ·
+·          spans        ALL          ·      ·
 
 exec
 SELECT MIN(y) FROM xyz WHERE x = 1
 ----
-column4:int
+min:int
 2
 
 exec hide-colnames nodist
 EXPLAIN (VERBOSE) SELECT MIN(y) FROM xyz WHERE x = 1
 ----
-group      ·            ·            (column4)  ·
- │         aggregate 0  min(y)       ·          ·
- └── scan  ·            ·            (x, y)     ·
-·          table        xyz@primary  ·          ·
-·          spans        /1-/1/#      ·          ·
+group      ·            ·            (min)   ·
+ │         aggregate 0  min(y)       ·       ·
+ └── scan  ·            ·            (x, y)  ·
+·          table        xyz@primary  ·       ·
+·          spans        /1-/1/#      ·       ·
 
 exec
 SELECT MAX(y) FROM xyz WHERE x = 1
 ----
-column4:int
+max:int
 2
 
 exec hide-colnames nodist
 EXPLAIN (VERBOSE) SELECT MAX(y) FROM xyz WHERE x = 1
 ----
-group      ·            ·            (column4)  ·
- │         aggregate 0  max(y)       ·          ·
- └── scan  ·            ·            (x, y)     ·
-·          table        xyz@primary  ·          ·
-·          spans        /1-/1/#      ·          ·
+group      ·            ·            (max)   ·
+ │         aggregate 0  max(y)       ·       ·
+ └── scan  ·            ·            (x, y)  ·
+·          table        xyz@primary  ·       ·
+·          spans        /1-/1/#      ·       ·
 
 exec
 SELECT MIN(y) FROM xyz WHERE x = 7
 ----
-column4:int
+min:int
 NULL
 
 exec hide-colnames nodist
 EXPLAIN (VERBOSE) SELECT MIN(y) FROM xyz WHERE x = 7
 ----
-group      ·            ·            (column4)  ·
- │         aggregate 0  min(y)       ·          ·
- └── scan  ·            ·            (x, y)     ·
-·          table        xyz@primary  ·          ·
-·          spans        /7-/7/#      ·          ·
+group      ·            ·            (min)   ·
+ │         aggregate 0  min(y)       ·       ·
+ └── scan  ·            ·            (x, y)  ·
+·          table        xyz@primary  ·       ·
+·          spans        /7-/7/#      ·       ·
 
 exec
 SELECT MAX(y) FROM xyz WHERE x = 7
 ----
-column4:int
+max:int
 NULL
 
 exec hide-colnames nodist
 EXPLAIN (VERBOSE) SELECT MAX(y) FROM xyz WHERE x = 7
 ----
-group      ·            ·            (column4)  ·
- │         aggregate 0  max(y)       ·          ·
- └── scan  ·            ·            (x, y)     ·
-·          table        xyz@primary  ·          ·
-·          spans        /7-/7/#      ·          ·
+group      ·            ·            (max)   ·
+ │         aggregate 0  max(y)       ·       ·
+ └── scan  ·            ·            (x, y)  ·
+·          table        xyz@primary  ·       ·
+·          spans        /7-/7/#      ·       ·
 
 exec
 SELECT MIN(x) FROM xyz WHERE (y, z) = (2, 3.0)
 ----
-column4:int
+min:int
 1
 
 exec hide-colnames nodist
 EXPLAIN (VERBOSE) SELECT MIN(x) FROM xyz WHERE (y, z) = (2, 3.0)
 ----
-group      ·            ·          (column4)  ·
+group      ·            ·          (min)      ·
  │         aggregate 0  min(x)     ·          ·
  └── scan  ·            ·          (x, y, z)  ·
 ·          table        xyz@zyx    ·          ·
@@ -905,13 +905,13 @@ group      ·            ·          (column4)  ·
 exec
 SELECT MAX(x) FROM xyz WHERE (z, y) = (3.0, 2)
 ----
-column4:int
+max:int
 1
 
 exec hide-colnames nodist
 EXPLAIN (VERBOSE) SELECT MAX(x) FROM xyz WHERE (z, y) = (3.0, 2)
 ----
-group      ·            ·          (column4)  ·
+group      ·            ·          (max)      ·
  │         aggregate 0  max(x)     ·          ·
  └── scan  ·            ·          (x, y, z)  ·
 ·          table        xyz@zyx    ·          ·
@@ -922,71 +922,71 @@ group      ·            ·          (column4)  ·
 exec
 SELECT VARIANCE(x), VARIANCE(y::decimal), round(VARIANCE(z), 14) FROM xyz
 ----
-column4:decimal  column6:decimal  column8:float
-9                4.5              6.33333333333333
+variance:decimal  variance:decimal  round:float
+9                 4.5               6.33333333333333
 
 exec
 SELECT VARIANCE(x) FROM xyz WHERE x = 10
 ----
-column4:decimal
+variance:decimal
 NULL
 
 exec
 SELECT VARIANCE(x) FROM xyz WHERE x = 1
 ----
-column4:decimal
+variance:decimal
 NULL
 
 exec hide-colnames nodist
 EXPLAIN (VERBOSE) SELECT VARIANCE(x) FROM xyz WHERE x = 1
 ----
-group      ·            ·            (column4)  ·
- │         aggregate 0  variance(x)  ·          ·
- └── scan  ·            ·            (x)        ·
-·          table        xyz@primary  ·          ·
-·          spans        /1-/1/#      ·          ·
+group      ·            ·            (variance)  ·
+ │         aggregate 0  variance(x)  ·           ·
+ └── scan  ·            ·            (x)         ·
+·          table        xyz@primary  ·           ·
+·          spans        /1-/1/#      ·           ·
 
 exec
 SELECT STDDEV(x), STDDEV(y::decimal), round(STDDEV(z), 14) FROM xyz
 ----
-column4:decimal  column6:decimal        column8:float
-3                2.1213203435596425732  2.51661147842358
+stddev:decimal  stddev:decimal         round:float
+3               2.1213203435596425732  2.51661147842358
 
 exec
 SELECT STDDEV(x) FROM xyz WHERE x = 1
 ----
-column4:decimal
+stddev:decimal
 NULL
 
 exec
 SELECT AVG(1::int)::float, AVG(2::float)::float, AVG(3::decimal)::float
 ----
-column3:float  column6:float  column9:float
-1.0            2.0            3.0
+avg(1::INT)::FLOAT:float  avg(2::FLOAT)::FLOAT:float  avg(3::DECIMAL)::FLOAT:float
+1.0                       2.0                         3.0
 
 exec
 SELECT COUNT(2::int), COUNT(3::float), COUNT(4::decimal)
 ----
-column2:int  column4:int  column6:int
-1            1            1
+count:int  count:int  count:int
+1          1          1
 
 exec
 SELECT SUM(1::int), SUM(2::float), SUM(3::decimal)
 ----
-column2:decimal  column4:float  column6:decimal
-1                2.0            3
+sum:decimal  sum:float  sum:decimal
+1            2.0        3
 
 exec
 SELECT VARIANCE(1::int), VARIANCE(1::float), VARIANCE(1::decimal)
 ----
-column2:decimal  column4:float  column6:decimal
-NULL             NULL           NULL
+variance:decimal  variance:float  variance:decimal
+NULL              NULL            NULL
 
 exec
 SELECT STDDEV(1::int), STDDEV(1::float), STDDEV(1::decimal)
 ----
-column2:decimal  column4:float  column6:decimal
-NULL             NULL           NULL
+stddev:decimal  stddev:float  stddev:decimal
+NULL            NULL          NULL
 
 # TODO(radu): subqueries not supported yet.
 ## Ensure subqueries don't trigger aggregation.
@@ -1002,8 +1002,8 @@ CREATE TABLE bools (b BOOL)
 exec
 SELECT BOOL_AND(b), BOOL_OR(b) FROM bools
 ----
-column3:bool  column4:bool
-NULL          NULL
+bool_and:bool  bool_or:bool
+NULL           NULL
 
 exec-raw
 INSERT INTO bools VALUES (true), (true), (true)
@@ -1012,8 +1012,8 @@ INSERT INTO bools VALUES (true), (true), (true)
 exec
 SELECT BOOL_AND(b), BOOL_OR(b) FROM bools
 ----
-column3:bool  column4:bool
-true          true
+bool_and:bool  bool_or:bool
+true           true
 
 exec-raw
 INSERT INTO bools VALUES (false), (false)
@@ -1022,8 +1022,8 @@ INSERT INTO bools VALUES (false), (false)
 exec
 SELECT BOOL_AND(b), BOOL_OR(b) FROM bools
 ----
-column3:bool  column4:bool
-false         true
+bool_and:bool  bool_or:bool
+false          true
 
 exec-raw
 DELETE FROM bools WHERE b
@@ -1032,8 +1032,8 @@ DELETE FROM bools WHERE b
 exec
 SELECT BOOL_AND(b), BOOL_OR(b) FROM bools
 ----
-column3:bool  column4:bool
-false         false
+bool_and:bool  bool_or:bool
+false          false
 
 # TODO(justin): we don't yet respect the inner ORDER BY
 #exec
@@ -1252,16 +1252,16 @@ INSERT INTO ab VALUES
 exec hide-colnames nodist
 EXPLAIN (VERBOSE) SELECT 1 FROM kv GROUP BY kv.*;
 ----
-render     ·         ·           (column5)  ·
- │         render 0  1           ·          ·
- └── scan  ·         ·           ()         ·
-·          table     kv@primary  ·          ·
-·          spans     ALL         ·          ·
+render     ·         ·           ("1")  ·
+ │         render 0  1           ·      ·
+ └── scan  ·         ·           ()     ·
+·          table     kv@primary  ·      ·
+·          spans     ALL         ·      ·
 
 exec
 SELECT 1 FROM kv GROUP BY kv.*;
 ----
-column5:int
+1:int
 1
 1
 1
@@ -1272,7 +1272,7 @@ column5:int
 exec hide-colnames nodist
 EXPLAIN (VERBOSE) SELECT SUM(abc.d) FROM kv JOIN abc ON kv.k >= abc.d GROUP BY kv.*;
 ----
-render               ·            ·            (column9)           ·
+render               ·            ·            (sum)               ·
  │                   render 0     agg0         ·                   ·
  └── group           ·            ·            (k, v, w, s, agg0)  ·
       │              aggregate 0  k            ·                   ·
@@ -1294,7 +1294,7 @@ render               ·            ·            (column9)           ·
 exec rowsort
 SELECT SUM(abc.d) FROM kv JOIN abc ON kv.k >= abc.d GROUP BY kv.*;
 ----
-column9:decimal
+sum:decimal
 1.1
 6.1
 6.1
@@ -1412,8 +1412,8 @@ INSERT INTO xor_bytes VALUES
 exec
 SELECT TO_HEX(XOR_AGG(a)), XOR_AGG(c) FROM xor_bytes
 ----
-column6:string  column7:int
-1f01            6
+to_hex:string  xor_agg:int
+1f01           6
 
 # TODO(radu): ORDER BY not supported.
 #exec
@@ -1425,8 +1425,8 @@ column6:string  column7:int
 exec
 SELECT MAX(true), MIN(true)
 ----
-column2:bool  column3:bool
-true          true
+max:bool  min:bool
+true      true
 
 exec-raw
 DELETE FROM ab;
@@ -1439,7 +1439,7 @@ INSERT INTO xy(x, y) VALUES ('a', 'b'), ('c', 'd')
 exec rowsort nodist
 SELECT (b, a) FROM ab GROUP BY (b, a)
 ----
-column3:tuple{int, int}
+(b, a):tuple{int, int}
 (2, 1)
 (4, 3)
 
@@ -1448,40 +1448,40 @@ column3:tuple{int, int}
 exec hide-colnames nodist
 EXPLAIN (VERBOSE) SELECT (b, a) FROM ab GROUP BY (b, a)
 ----
-render     ·         ·           (column3)  ·
- │         render 0  (b, a)      ·          ·
- └── scan  ·         ·           (a, b)     ·
-·          table     ab@primary  ·          ·
-·          spans     ALL         ·          ·
+render     ·         ·           ("(b, a)")  ·
+ │         render 0  (b, a)      ·           ·
+ └── scan  ·         ·           (a, b)      ·
+·          table     ab@primary  ·           ·
+·          spans     ALL         ·           ·
 
 # TODO(radu): this requires tuples but they are not yet supported in
 # distsql (#15938).
 exec rowsort nodist
 SELECT MIN(y), (b, a) FROM ab, xy GROUP BY (x, (a, b))
 ----
-column6:string  column7:tuple{int, int}
-b               (2, 1)
-b               (4, 3)
-d               (2, 1)
-d               (4, 3)
+min:string  (b, a):tuple{int, int}
+b           (2, 1)
+b           (4, 3)
+d           (2, 1)
+d           (4, 3)
 
 exec hide-colnames nodist
 EXPLAIN (VERBOSE) SELECT MIN(y), (b, a) FROM ab, xy GROUP BY (x, (a, b))
 ----
-render               ·            ·           (column6, column7)  ·
- │                   render 0     agg0        ·                   ·
- │                   render 1     (b, a)      ·                   ·
- └── group           ·            ·           (a, b, x, agg0)     ·
-      │              aggregate 0  a           ·                   ·
-      │              aggregate 1  b           ·                   ·
-      │              aggregate 2  x           ·                   ·
-      │              aggregate 3  min(y)      ·                   ·
-      │              group by     @1-@3       ·                   ·
-      └── join       ·            ·           (a, b, x, y)        ·
-           │         type         cross       ·                   ·
-           ├── scan  ·            ·           (a, b)              ·
-           │         table        ab@primary  ·                   ·
-           │         spans        ALL         ·                   ·
-           └── scan  ·            ·           (x, y)              ·
-·                    table        xy@primary  ·                   ·
-·                    spans        ALL         ·                   ·
+render               ·            ·           (min, "(b, a)")  ·
+ │                   render 0     agg0        ·                ·
+ │                   render 1     (b, a)      ·                ·
+ └── group           ·            ·           (a, b, x, agg0)  ·
+      │              aggregate 0  a           ·                ·
+      │              aggregate 1  b           ·                ·
+      │              aggregate 2  x           ·                ·
+      │              aggregate 3  min(y)      ·                ·
+      │              group by     @1-@3       ·                ·
+      └── join       ·            ·           (a, b, x, y)     ·
+           │         type         cross       ·                ·
+           ├── scan  ·            ·           (a, b)           ·
+           │         table        ab@primary  ·                ·
+           │         spans        ALL         ·                ·
+           └── scan  ·            ·           (x, y)           ·
+·                    table        xy@primary  ·                ·
+·                    spans        ALL         ·                ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/limit
+++ b/pkg/sql/opt/exec/execbuilder/testdata/limit
@@ -81,7 +81,7 @@ k:int  v:int
 exec hide-colnames nodist
 EXPLAIN (VERBOSE) SELECT SUM(w) FROM t GROUP BY k, v ORDER BY v DESC LIMIT 10
 ----
-render                    ·            ·          (column4)     ·
+render                    ·            ·          (sum)         ·
  │                        render 0     agg0       ·             ·
  └── limit                ·            ·          (k, v, agg0)  -v
       │                   count        10         ·             ·
@@ -99,7 +99,7 @@ render                    ·            ·          (column4)     ·
 exec
 SELECT SUM(w) FROM t GROUP BY k, v ORDER BY v DESC LIMIT 10
 ----
-column4:decimal
+sum:decimal
 125
 27
 1

--- a/pkg/sql/opt/exec/execbuilder/testdata/orderby
+++ b/pkg/sql/opt/exec/execbuilder/testdata/orderby
@@ -319,16 +319,16 @@ render               ·         ·          (a, b, c)                       ·
 exec hide-colnames nodist
 EXPLAIN (VERBOSE) SELECT 1, * FROM t ORDER BY 1
 ----
-sort            ·         ·          (column4, a, b, c)  +column4
- │              order     +column4   ·                   ·
- └── render     ·         ·          (column4, a, b, c)  ·
-      │         render 0  1          ·                   ·
-      │         render 1  a          ·                   ·
-      │         render 2  b          ·                   ·
-      │         render 3  c          ·                   ·
-      └── scan  ·         ·          (a, b, c)           ·
-·               table     t@primary  ·                   ·
-·               spans     ALL        ·                   ·
+sort            ·         ·          ("1", a, b, c)  +"1"
+ │              order     +"1"       ·               ·
+ └── render     ·         ·          ("1", a, b, c)  ·
+      │         render 0  1          ·               ·
+      │         render 1  a          ·               ·
+      │         render 2  b          ·               ·
+      │         render 3  c          ·               ·
+      └── scan  ·         ·          (a, b, c)       ·
+·               table     t@primary  ·               ·
+·               spans     ALL        ·               ·
 
 exec hide-colnames nodist
 EXPLAIN (VERBOSE) SELECT * FROM t ORDER BY length('abc')
@@ -352,9 +352,9 @@ render               ·         ·              (a, b, c)                       
 exec hide-colnames nodist
 EXPLAIN (VERBOSE) SELECT b+2 FROM t ORDER BY b+2
 ----
-sort            ·         ·          (column4)  +column4
- │              order     +column4   ·          ·
- └── render     ·         ·          (column4)  ·
+sort            ·         ·          ("b + 2")  +"b + 2"
+ │              order     +"b + 2"   ·          ·
+ └── render     ·         ·          ("b + 2")  ·
       │         render 0  b + 2      ·          ·
       └── scan  ·         ·          (b)        ·
 ·               table     t@primary  ·          ·
@@ -787,7 +787,7 @@ INSERT INTO abcd VALUES (1, 4, 2, 3), (2, 3, 4, 1), (3, 2, 1, 2), (4, 4, 1, 1)
 exec rowsort
 SELECT a+b FROM (SELECT * FROM abcd ORDER BY d)
 ----
-column5:int
+a + b:int
 5
 5
 5
@@ -796,7 +796,7 @@ column5:int
 exec rowsort
 SELECT b+d FROM (SELECT * FROM abcd ORDER BY a,d)
 ----
-column5:int
+b + d:int
 4
 4
 5

--- a/pkg/sql/opt/exec/execbuilder/testdata/ordinality
+++ b/pkg/sql/opt/exec/execbuilder/testdata/ordinality
@@ -29,7 +29,7 @@ a         1
 exec hide-colnames nodist
 EXPLAIN (VERBOSE) SELECT MAX(ordinality) FROM foo WITH ORDINALITY
 ----
-group            ·            ·                (column3)       ·
+group            ·            ·                (max)           ·
  │               aggregate 0  max(ordinality)  ·               ·
  └── ordinality  ·            ·                ("ordinality")  ·
       └── scan   ·            ·                ()              ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/project
+++ b/pkg/sql/opt/exec/execbuilder/testdata/project
@@ -57,7 +57,7 @@ x:int  y:int
 exec hide-colnames nodist
 EXPLAIN (VERBOSE) SELECT x + 1 FROM a
 ----
-render     ·         ·          (column3)  ·
+render     ·         ·          ("x + 1")  ·
  │         render 0  x + 1      ·          ·
  └── scan  ·         ·          (x)        ·
 ·          table     a@primary  ·          ·
@@ -66,7 +66,7 @@ render     ·         ·          (column3)  ·
 exec rowsort
 SELECT x + 1 FROM a
 ----
-column3:int
+x + 1:int
 2
 3
 4
@@ -74,7 +74,7 @@ column3:int
 exec hide-colnames nodist
 EXPLAIN (VERBOSE) SELECT x, x + 1, y, y + 1, x + y FROM a
 ----
-render     ·         ·          (x, column3, y, column4, column5)  ·
+render     ·         ·          (x, "x + 1", y, "y + 1", "x + y")  ·
  │         render 0  x          ·                                  ·
  │         render 1  x + 1      ·                                  ·
  │         render 2  y          ·                                  ·
@@ -87,27 +87,27 @@ render     ·         ·          (x, column3, y, column4, column5)  ·
 exec rowsort
 SELECT x, x + 1, y, y + 1, x + y FROM a
 ----
-x:int  column3:int  y:int  column4:int  column5:int
-1      2            10     11           11
-2      3            20     21           22
-3      4            30     31           33
+x:int  x + 1:int  y:int  y + 1:int  x + y:int
+1      2          10     11         11
+2      3          20     21         22
+3      4          30     31         33
 
 exec hide-colnames nodist
 EXPLAIN (VERBOSE) SELECT u * v + v FROM (SELECT x + 3, y + 10 FROM a) AS foo(u, v)
 ----
-render          ·         ·                              (column5)           ·
- │              render 0  column4 + (column3 * column4)  ·                   ·
- └── render     ·         ·                              (column3, column4)  ·
-      │         render 0  x + 3                          ·                   ·
-      │         render 1  y + 10                         ·                   ·
-      └── scan  ·         ·                              (x, y)              ·
-·               table     a@primary                      ·                   ·
-·               spans     ALL                            ·                   ·
+render          ·         ·                                ("(u * v) + v")      ·
+ │              render 0  "y + 10" + ("x + 3" * "y + 10")  ·                    ·
+ └── render     ·         ·                                ("x + 3", "y + 10")  ·
+      │         render 0  x + 3                            ·                    ·
+      │         render 1  y + 10                           ·                    ·
+      └── scan  ·         ·                                (x, y)               ·
+·               table     a@primary                        ·                    ·
+·               spans     ALL                              ·                    ·
 
 exec rowsort
 SELECT u + v FROM (SELECT x + 3, y + 10 FROM a) AS foo(u, v)
 ----
-column5:int
+u + v:int
 24
 35
 46
@@ -135,7 +135,7 @@ x:int  x:int  y:int  x:int
 exec hide-colnames nodist
 EXPLAIN (VERBOSE) SELECT x + 1, x + y FROM a WHERE x + y > 20
 ----
-render          ·         ·             (column3, column4)  ·
+render          ·         ·             ("x + 1", "x + y")  ·
  │              render 0  x + 1         ·                   ·
  │              render 1  x + y         ·                   ·
  └── filter     ·         ·             (x, y)              ·
@@ -147,9 +147,9 @@ render          ·         ·             (column3, column4)  ·
 exec rowsort
 SELECT x + 1, x + y FROM a WHERE x + y > 20
 ----
-column3:int  column4:int
-3            22
-4            33
+x + 1:int  x + y:int
+3          22
+4          33
 
 exec-raw
 CREATE TABLE b (x INT, y INT);
@@ -205,13 +205,13 @@ TABLE nocols
 exec hide-colnames nodist
 EXPLAIN (VERBOSE) SELECT 1, * FROM t.nocols
 ----
-render     ·         ·               (column2)  ·
- │         render 0  1               ·          ·
- └── scan  ·         ·               ()         ·
-·          table     nocols@primary  ·          ·
-·          spans     ALL             ·          ·
+render     ·         ·               ("1")  ·
+ │         render 0  1               ·      ·
+ └── scan  ·         ·               ()     ·
+·          table     nocols@primary  ·      ·
+·          spans     ALL             ·      ·
 
 exec
 SELECT 1, * FROM t.nocols
 ----
-column2:int
+1:int

--- a/pkg/sql/opt/exec/execbuilder/testdata/scalar
+++ b/pkg/sql/opt/exec/execbuilder/testdata/scalar
@@ -9,7 +9,7 @@ CREATE TABLE t (a INT, b INT, c INT, d INT, j JSONB, s STRING)
 exec hide-colnames nodist
 EXPLAIN (VERBOSE) SELECT 1 + 2
 ----
-render       ·         ·                 (column1)  ·
+render       ·         ·                 ("1 + 2")  ·
  │           render 0  3                 ·          ·
  └── values  ·         ·                 ()         ·
 ·            size      0 columns, 1 row  ·          ·
@@ -17,15 +17,15 @@ render       ·         ·                 (column1)  ·
 exec hide-colnames nodist
 EXPLAIN (VERBOSE) SELECT true
 ----
-render       ·         ·                 (column1)  ·
- │           render 0  true              ·          ·
- └── values  ·         ·                 ()         ·
-·            size      0 columns, 1 row  ·          ·
+render       ·         ·                 ("true")  ·
+ │           render 0  true              ·         ·
+ └── values  ·         ·                 ()        ·
+·            size      0 columns, 1 row  ·         ·
 
 exec hide-colnames nodist
 EXPLAIN (VERBOSE) SELECT false
 ----
-render       ·         ·                 (column1)  ·
+render       ·         ·                 ("false")  ·
  │           render 0  false             ·          ·
  └── values  ·         ·                 ()         ·
 ·            size      0 columns, 1 row  ·          ·
@@ -33,23 +33,23 @@ render       ·         ·                 (column1)  ·
 exec hide-colnames nodist
 EXPLAIN (VERBOSE) SELECT (1, 2)
 ----
-render       ·         ·                 (column1)  ·
- │           render 0  (1, 2)            ·          ·
- └── values  ·         ·                 ()         ·
-·            size      0 columns, 1 row  ·          ·
+render       ·         ·                 ("(1, 2)")  ·
+ │           render 0  (1, 2)            ·           ·
+ └── values  ·         ·                 ()          ·
+·            size      0 columns, 1 row  ·           ·
 
 exec hide-colnames nodist
 EXPLAIN (VERBOSE) SELECT (true, false)
 ----
-render       ·         ·                 (column1)  ·
- │           render 0  (true, false)     ·          ·
- └── values  ·         ·                 ()         ·
-·            size      0 columns, 1 row  ·          ·
+render       ·         ·                 ("(true, false)")  ·
+ │           render 0  (true, false)     ·                  ·
+ └── values  ·         ·                 ()                 ·
+·            size      0 columns, 1 row  ·                  ·
 
 exec hide-colnames nodist
 EXPLAIN (VERBOSE) SELECT 1 + 2 FROM t
 ----
-render     ·         ·          (column8)  ·
+render     ·         ·          ("1 + 2")  ·
  │         render 0  3          ·          ·
  └── scan  ·         ·          ()         ·
 ·          table     t@primary  ·          ·
@@ -58,7 +58,7 @@ render     ·         ·          (column8)  ·
 exec hide-colnames nodist
 EXPLAIN (VERBOSE) SELECT a + 2 FROM t
 ----
-render     ·         ·          (column8)  ·
+render     ·         ·          ("a + 2")  ·
  │         render 0  a + 2      ·          ·
  └── scan  ·         ·          (a)        ·
 ·          table     t@primary  ·          ·
@@ -67,219 +67,219 @@ render     ·         ·          (column8)  ·
 exec hide-colnames nodist
 EXPLAIN (VERBOSE) SELECT a >= 5 AND b <= 10 AND c < 4 FROM t
 ----
-render     ·         ·                                     (column8)  ·
- │         render 0  ((a >= 5) AND (b <= 10)) AND (c < 4)  ·          ·
- └── scan  ·         ·                                     (a, b, c)  ·
-·          table     t@primary                             ·          ·
-·          spans     ALL                                   ·          ·
+render     ·         ·                                     ("((a >= 5) AND (b <= 10)) AND (c < 4)")  ·
+ │         render 0  ((a >= 5) AND (b <= 10)) AND (c < 4)  ·                                         ·
+ └── scan  ·         ·                                     (a, b, c)                                 ·
+·          table     t@primary                             ·                                         ·
+·          spans     ALL                                   ·                                         ·
 
 exec hide-colnames nodist
 EXPLAIN (VERBOSE) SELECT a >= 5 OR b <= 10 OR c < 4  FROM t
 ----
-render     ·         ·                                   (column8)  ·
- │         render 0  ((a >= 5) OR (b <= 10)) OR (c < 4)  ·          ·
- └── scan  ·         ·                                   (a, b, c)  ·
-·          table     t@primary                           ·          ·
-·          spans     ALL                                 ·          ·
+render     ·         ·                                   ("((a >= 5) OR (b <= 10)) OR (c < 4)")  ·
+ │         render 0  ((a >= 5) OR (b <= 10)) OR (c < 4)  ·                                       ·
+ └── scan  ·         ·                                   (a, b, c)                               ·
+·          table     t@primary                           ·                                       ·
+·          spans     ALL                                 ·                                       ·
 
 exec hide-colnames nodist
 EXPLAIN (VERBOSE) SELECT NOT (a = 5) FROM t
 ----
-render     ·         ·          (column8)  ·
- │         render 0  a != 5     ·          ·
- └── scan  ·         ·          (a)        ·
-·          table     t@primary  ·          ·
-·          spans     ALL        ·          ·
+render     ·         ·          ("NOT (a = 5)")  ·
+ │         render 0  a != 5     ·                ·
+ └── scan  ·         ·          (a)              ·
+·          table     t@primary  ·                ·
+·          spans     ALL        ·                ·
 
 exec hide-colnames nodist
 EXPLAIN (VERBOSE) SELECT NOT (a > 5 AND b >= 10) FROM t
 ----
-render     ·         ·                     (column8)  ·
- │         render 0  (a <= 5) OR (b < 10)  ·          ·
- └── scan  ·         ·                     (a, b)     ·
-·          table     t@primary             ·          ·
-·          spans     ALL                   ·          ·
+render     ·         ·                     ("NOT ((a > 5) AND (b >= 10))")  ·
+ │         render 0  (a <= 5) OR (b < 10)  ·                                ·
+ └── scan  ·         ·                     (a, b)                           ·
+·          table     t@primary             ·                                ·
+·          spans     ALL                   ·                                ·
 
 exec hide-colnames nodist
 EXPLAIN (VERBOSE) SELECT (a >= 5 AND b <= 10) OR (a <= 10 AND c > 5) FROM t
 ----
-render     ·         ·                                                    (column8)  ·
- │         render 0  ((a >= 5) AND (b <= 10)) OR ((a <= 10) AND (c > 5))  ·          ·
- └── scan  ·         ·                                                    (a, b, c)  ·
-·          table     t@primary                                            ·          ·
-·          spans     ALL                                                  ·          ·
+render     ·         ·                                                    ("((a >= 5) AND (b <= 10)) OR ((a <= 10) AND (c > 5))")  ·
+ │         render 0  ((a >= 5) AND (b <= 10)) OR ((a <= 10) AND (c > 5))  ·                                                        ·
+ └── scan  ·         ·                                                    (a, b, c)                                                ·
+·          table     t@primary                                            ·                                                        ·
+·          spans     ALL                                                  ·                                                        ·
 
 exec hide-colnames nodist
 EXPLAIN (VERBOSE) SELECT NOT (a >= 5 OR b <= 10) AND NOT (c >= 10) FROM t
 ----
-render     ·         ·                                    (column8)  ·
- │         render 0  ((a < 5) AND (b > 10)) AND (c < 10)  ·          ·
- └── scan  ·         ·                                    (a, b, c)  ·
-·          table     t@primary                            ·          ·
-·          spans     ALL                                  ·          ·
+render     ·         ·                                    ("(NOT ((a >= 5) OR (b <= 10))) AND (NOT (c >= 10))")  ·
+ │         render 0  ((a < 5) AND (b > 10)) AND (c < 10)  ·                                                      ·
+ └── scan  ·         ·                                    (a, b, c)                                              ·
+·          table     t@primary                            ·                                                      ·
+·          spans     ALL                                  ·                                                      ·
 
 exec hide-colnames nodist
 EXPLAIN (VERBOSE) SELECT (a, b) = (1, 2)  FROM t
 ----
-render     ·         ·                    (column8)  ·
- │         render 0  (a = 1) AND (b = 2)  ·          ·
- └── scan  ·         ·                    (a, b)     ·
-·          table     t@primary            ·          ·
-·          spans     ALL                  ·          ·
+render     ·         ·                    ("(a, b) = (1, 2)")  ·
+ │         render 0  (a = 1) AND (b = 2)  ·                    ·
+ └── scan  ·         ·                    (a, b)               ·
+·          table     t@primary            ·                    ·
+·          spans     ALL                  ·                    ·
 
 exec hide-colnames nodist
 EXPLAIN (VERBOSE) SELECT a IN (1, 2) FROM t
 ----
-render     ·         ·            (column8)  ·
- │         render 0  a IN (1, 2)  ·          ·
- └── scan  ·         ·            (a)        ·
-·          table     t@primary    ·          ·
-·          spans     ALL          ·          ·
+render     ·         ·            ("a IN (1, 2)")  ·
+ │         render 0  a IN (1, 2)  ·                ·
+ └── scan  ·         ·            (a)              ·
+·          table     t@primary    ·                ·
+·          spans     ALL          ·                ·
 
 exec hide-colnames nodist
 EXPLAIN (VERBOSE) SELECT (a, b) IN ((1, 2), (3, 4)) FROM t
 ----
-render     ·         ·                           (column8)  ·
- │         render 0  (a, b) IN ((1, 2), (3, 4))  ·          ·
- └── scan  ·         ·                           (a, b)     ·
-·          table     t@primary                   ·          ·
-·          spans     ALL                         ·          ·
+render     ·         ·                           ("(a, b) IN ((1, 2), (3, 4))")  ·
+ │         render 0  (a, b) IN ((1, 2), (3, 4))  ·                               ·
+ └── scan  ·         ·                           (a, b)                          ·
+·          table     t@primary                   ·                               ·
+·          spans     ALL                         ·                               ·
 
 exec hide-colnames nodist
 EXPLAIN (VERBOSE) SELECT (a, b + c, 5 + d * 2) = (b+c, 8, a - c)  FROM t
 ----
-render     ·         ·                                                                (column8)     ·
- │         render 0  ((a = (b + c)) AND ((b + c) = 8)) AND (((d * 2) + 5) = (a - c))  ·             ·
- └── scan  ·         ·                                                                (a, b, c, d)  ·
-·          table     t@primary                                                        ·             ·
-·          spans     ALL                                                              ·             ·
+render     ·         ·                                                                ("(a, b + c, 5 + (d * 2)) = (b + c, 8, a - c)")  ·
+ │         render 0  ((a = (b + c)) AND ((b + c) = 8)) AND (((d * 2) + 5) = (a - c))  ·                                                ·
+ └── scan  ·         ·                                                                (a, b, c, d)                                     ·
+·          table     t@primary                                                        ·                                                ·
+·          spans     ALL                                                              ·                                                ·
 
 exec hide-colnames nodist
 EXPLAIN (VERBOSE) SELECT ((a, b), (c, d)) = ((1, 2), (3, 4))  FROM t
 ----
-render     ·         ·                                                (column8)     ·
- │         render 0  (((a = 1) AND (b = 2)) AND (c = 3)) AND (d = 4)  ·             ·
- └── scan  ·         ·                                                (a, b, c, d)  ·
-·          table     t@primary                                        ·             ·
-·          spans     ALL                                              ·             ·
+render     ·         ·                                                ("((a, b), (c, d)) = ((1, 2), (3, 4))")  ·
+ │         render 0  (((a = 1) AND (b = 2)) AND (c = 3)) AND (d = 4)  ·                                        ·
+ └── scan  ·         ·                                                (a, b, c, d)                             ·
+·          table     t@primary                                        ·                                        ·
+·          spans     ALL                                              ·                                        ·
 
 exec hide-colnames nodist
 EXPLAIN (VERBOSE) SELECT (a, (b, 'a'), (c, 'b', 5)) = (9, (a+c, s), (5, s, a)) FROM t
 ----
-render     ·         ·                                                                                      (column8)     ·
- │         render 0  (((((a = 9) AND (b = (a + c))) AND (s = 'a')) AND (c = 5)) AND (s = 'b')) AND (a = 5)  ·             ·
- └── scan  ·         ·                                                                                      (a, b, c, s)  ·
-·          table     t@primary                                                                              ·             ·
-·          spans     ALL                                                                                    ·             ·
+render     ·         ·                                                                                      ("(a, (b, 'a'), (c, 'b', 5)) = (9, (a + c, s), (5, s, a))")  ·
+ │         render 0  (((((a = 9) AND (b = (a + c))) AND (s = 'a')) AND (c = 5)) AND (s = 'b')) AND (a = 5)  ·                                                            ·
+ └── scan  ·         ·                                                                                      (a, b, c, s)                                                 ·
+·          table     t@primary                                                                              ·                                                            ·
+·          spans     ALL                                                                                    ·                                                            ·
 
 exec hide-colnames nodist
 EXPLAIN (VERBOSE) SELECT a IS NULL FROM t
 ----
-render     ·         ·          (column8)  ·
- │         render 0  a IS NULL  ·          ·
- └── scan  ·         ·          (a)        ·
-·          table     t@primary  ·          ·
-·          spans     ALL        ·          ·
+render     ·         ·          ("a IS NULL")  ·
+ │         render 0  a IS NULL  ·              ·
+ └── scan  ·         ·          (a)            ·
+·          table     t@primary  ·              ·
+·          spans     ALL        ·              ·
 
 exec hide-colnames nodist
 EXPLAIN (VERBOSE) SELECT a IS NOT DISTINCT FROM NULL FROM t
 ----
-render     ·         ·          (column8)  ·
- │         render 0  a IS NULL  ·          ·
- └── scan  ·         ·          (a)        ·
-·          table     t@primary  ·          ·
-·          spans     ALL        ·          ·
+render     ·         ·          ("a IS NULL")  ·
+ │         render 0  a IS NULL  ·              ·
+ └── scan  ·         ·          (a)            ·
+·          table     t@primary  ·              ·
+·          spans     ALL        ·              ·
 
 exec hide-colnames nodist
 EXPLAIN (VERBOSE) SELECT a IS NOT DISTINCT FROM b FROM t
 ----
-render     ·         ·                         (column8)  ·
- │         render 0  a IS NOT DISTINCT FROM b  ·          ·
- └── scan  ·         ·                         (a, b)     ·
-·          table     t@primary                 ·          ·
-·          spans     ALL                       ·          ·
+render     ·         ·                         ("a IS NOT DISTINCT FROM b")  ·
+ │         render 0  a IS NOT DISTINCT FROM b  ·                             ·
+ └── scan  ·         ·                         (a, b)                        ·
+·          table     t@primary                 ·                             ·
+·          spans     ALL                       ·                             ·
 
 exec hide-colnames nodist
 EXPLAIN (VERBOSE) SELECT a IS NOT NULL FROM t
 ----
-render     ·         ·              (column8)  ·
- │         render 0  a IS NOT NULL  ·          ·
- └── scan  ·         ·              (a)        ·
-·          table     t@primary      ·          ·
-·          spans     ALL            ·          ·
+render     ·         ·              ("a IS NOT NULL")  ·
+ │         render 0  a IS NOT NULL  ·                  ·
+ └── scan  ·         ·              (a)                ·
+·          table     t@primary      ·                  ·
+·          spans     ALL            ·                  ·
 
 exec hide-colnames nodist
 EXPLAIN (VERBOSE) SELECT a IS DISTINCT FROM NULL FROM t
 ----
-render     ·         ·              (column8)  ·
- │         render 0  a IS NOT NULL  ·          ·
- └── scan  ·         ·              (a)        ·
-·          table     t@primary      ·          ·
-·          spans     ALL            ·          ·
+render     ·         ·              ("a IS NOT NULL")  ·
+ │         render 0  a IS NOT NULL  ·                  ·
+ └── scan  ·         ·              (a)                ·
+·          table     t@primary      ·                  ·
+·          spans     ALL            ·                  ·
 
 exec hide-colnames nodist
 EXPLAIN (VERBOSE) SELECT a IS DISTINCT FROM b FROM t
 ----
-render     ·         ·                     (column8)  ·
- │         render 0  a IS DISTINCT FROM b  ·          ·
- └── scan  ·         ·                     (a, b)     ·
-·          table     t@primary             ·          ·
-·          spans     ALL                   ·          ·
+render     ·         ·                     ("a IS DISTINCT FROM b")  ·
+ │         render 0  a IS DISTINCT FROM b  ·                         ·
+ └── scan  ·         ·                     (a, b)                    ·
+·          table     t@primary             ·                         ·
+·          spans     ALL                   ·                         ·
 
 exec hide-colnames nodist
 EXPLAIN (VERBOSE) SELECT +a + (-b) FROM t
 ----
-render     ·         ·          (column8)  ·
- │         render 0  a + (-b)   ·          ·
- └── scan  ·         ·          (a, b)     ·
-·          table     t@primary  ·          ·
-·          spans     ALL        ·          ·
+render     ·         ·          ("(+a) + (-b)")  ·
+ │         render 0  a + (-b)   ·                ·
+ └── scan  ·         ·          (a, b)           ·
+·          table     t@primary  ·                ·
+·          spans     ALL        ·                ·
 
 exec hide-colnames nodist
 EXPLAIN (VERBOSE) SELECT CASE a WHEN 1 THEN 2 WHEN 2 THEN 3 ELSE 4 END FROM t
 ----
-render     ·         ·                                              (column8)  ·
- │         render 0  CASE a WHEN 1 THEN 2 WHEN 2 THEN 3 ELSE 4 END  ·          ·
- └── scan  ·         ·                                              (a)        ·
-·          table     t@primary                                      ·          ·
-·          spans     ALL                                            ·          ·
+render     ·         ·                                              ("CASE a WHEN 1 THEN 2 WHEN 2 THEN 3 ELSE 4 END")  ·
+ │         render 0  CASE a WHEN 1 THEN 2 WHEN 2 THEN 3 ELSE 4 END  ·                                                  ·
+ └── scan  ·         ·                                              (a)                                                ·
+·          table     t@primary                                      ·                                                  ·
+·          spans     ALL                                            ·                                                  ·
 
 exec hide-colnames nodist
 EXPLAIN (VERBOSE) SELECT CASE WHEN a = 2 THEN 1 ELSE 2 END FROM t
 ----
-render     ·         ·                                  (column8)  ·
- │         render 0  CASE WHEN a = 2 THEN 1 ELSE 2 END  ·          ·
- └── scan  ·         ·                                  (a)        ·
-·          table     t@primary                          ·          ·
-·          spans     ALL                                ·          ·
+render     ·         ·                                  ("CASE WHEN a = 2 THEN 1 ELSE 2 END")  ·
+ │         render 0  CASE WHEN a = 2 THEN 1 ELSE 2 END  ·                                      ·
+ └── scan  ·         ·                                  (a)                                    ·
+·          table     t@primary                          ·                                      ·
+·          spans     ALL                                ·                                      ·
 
 exec hide-colnames nodist
 EXPLAIN (VERBOSE) SELECT CASE a + 3 WHEN 5 * b THEN 1 % b WHEN 6 THEN 2 ELSE -1 END FROM t
 ----
-render     ·         ·                                                           (column8)  ·
- │         render 0  CASE a + 3 WHEN b * 5 THEN 1 % b WHEN 6 THEN 2 ELSE -1 END  ·          ·
- └── scan  ·         ·                                                           (a, b)     ·
-·          table     t@primary                                                   ·          ·
-·          spans     ALL                                                         ·          ·
+render     ·         ·                                                           ("CASE a + 3 WHEN 5 * b THEN 1 % b WHEN 6 THEN 2 ELSE -1 END")  ·
+ │         render 0  CASE a + 3 WHEN b * 5 THEN 1 % b WHEN 6 THEN 2 ELSE -1 END  ·                                                               ·
+ └── scan  ·         ·                                                           (a, b)                                                          ·
+·          table     t@primary                                                   ·                                                               ·
+·          spans     ALL                                                         ·                                                               ·
 
 # Tests for CASE with no ELSE statement
 exec hide-colnames nodist
 EXPLAIN (VERBOSE) SELECT CASE WHEN a = 2 THEN 1 END FROM t
 ----
-render     ·         ·                           (column8)  ·
- │         render 0  CASE WHEN a = 2 THEN 1 END  ·          ·
- └── scan  ·         ·                           (a)        ·
-·          table     t@primary                   ·          ·
-·          spans     ALL                         ·          ·
+render     ·         ·                           ("CASE WHEN a = 2 THEN 1 END")  ·
+ │         render 0  CASE WHEN a = 2 THEN 1 END  ·                               ·
+ └── scan  ·         ·                           (a)                             ·
+·          table     t@primary                   ·                               ·
+·          spans     ALL                         ·                               ·
 
 exec hide-colnames nodist
 EXPLAIN (VERBOSE) SELECT CASE a WHEN 2 THEN 1 END FROM t
 ----
-render     ·         ·                         (column8)  ·
- │         render 0  CASE a WHEN 2 THEN 1 END  ·          ·
- └── scan  ·         ·                         (a)        ·
-·          table     t@primary                 ·          ·
-·          spans     ALL                       ·          ·
+render     ·         ·                         ("CASE a WHEN 2 THEN 1 END")  ·
+ │         render 0  CASE a WHEN 2 THEN 1 END  ·                             ·
+ └── scan  ·         ·                         (a)                           ·
+·          table     t@primary                 ·                             ·
+·          spans     ALL                       ·                             ·
 
 exec allow-unsupported hide-colnames nodist
 EXPLAIN (VERBOSE) SELECT a FROM t WHERE a IS OF (INT)
@@ -293,11 +293,11 @@ filter     ·       ·                (a)  ·
 exec hide-colnames nodist
 EXPLAIN (VERBOSE) SELECT LENGTH(s) FROM t
 ----
-render     ·         ·          (column8)  ·
- │         render 0  length(s)  ·          ·
- └── scan  ·         ·          (s)        ·
-·          table     t@primary  ·          ·
-·          spans     ALL        ·          ·
+render     ·         ·          (length)  ·
+ │         render 0  length(s)  ·         ·
+ └── scan  ·         ·          (s)       ·
+·          table     t@primary  ·         ·
+·          spans     ALL        ·         ·
 
 # Verify that the built function can be executed.
 exec-raw
@@ -308,7 +308,7 @@ INSERT INTO str VALUES ('a'), ('ab'), ('abc')
 exec rowsort
 SELECT LENGTH(s) FROM str
 ----
-column3:int
+length:int
 1
 2
 3
@@ -316,116 +316,116 @@ column3:int
 exec hide-colnames nodist
 EXPLAIN (VERBOSE) SELECT j @> '{"a": 1}' FROM t
 ----
-render     ·         ·                (column8)  ·
- │         render 0  j @> '{"a": 1}'  ·          ·
- └── scan  ·         ·                (j)        ·
-·          table     t@primary        ·          ·
-·          spans     ALL              ·          ·
+render     ·         ·                ("j @> '{""a"": 1}'")  ·
+ │         render 0  j @> '{"a": 1}'  ·                      ·
+ └── scan  ·         ·                (j)                    ·
+·          table     t@primary        ·                      ·
+·          spans     ALL              ·                      ·
 
 exec hide-colnames nodist
 EXPLAIN (VERBOSE) SELECT '{"a": 1}' <@ j FROM t
 ----
-render     ·         ·                (column8)  ·
- │         render 0  j @> '{"a": 1}'  ·          ·
- └── scan  ·         ·                (j)        ·
-·          table     t@primary        ·          ·
-·          spans     ALL              ·          ·
+render     ·         ·                ("'{""a"": 1}' <@ j")  ·
+ │         render 0  j @> '{"a": 1}'  ·                      ·
+ └── scan  ·         ·                (j)                    ·
+·          table     t@primary        ·                      ·
+·          spans     ALL              ·                      ·
 
 exec hide-colnames nodist
 EXPLAIN (VERBOSE) SELECT j->>'a' FROM t
 ----
-render     ·         ·          (column8)  ·
- │         render 0  j->>'a'    ·          ·
- └── scan  ·         ·          (j)        ·
-·          table     t@primary  ·          ·
-·          spans     ALL        ·          ·
+render     ·         ·          ("j->>'a'")  ·
+ │         render 0  j->>'a'    ·            ·
+ └── scan  ·         ·          (j)          ·
+·          table     t@primary  ·            ·
+·          spans     ALL        ·            ·
 
 exec hide-colnames nodist
 EXPLAIN (VERBOSE) SELECT j->'a' FROM t
 ----
-render     ·         ·          (column8)  ·
- │         render 0  j->'a'     ·          ·
- └── scan  ·         ·          (j)        ·
-·          table     t@primary  ·          ·
-·          spans     ALL        ·          ·
+render     ·         ·          ("j->'a'")  ·
+ │         render 0  j->'a'     ·           ·
+ └── scan  ·         ·          (j)         ·
+·          table     t@primary  ·           ·
+·          spans     ALL        ·           ·
 
 exec hide-colnames nodist
 EXPLAIN (VERBOSE) SELECT j ? 'a' FROM t
 ----
-render     ·         ·          (column8)  ·
- │         render 0  j ? 'a'    ·          ·
- └── scan  ·         ·          (j)        ·
-·          table     t@primary  ·          ·
-·          spans     ALL        ·          ·
+render     ·         ·          ("j ? 'a'")  ·
+ │         render 0  j ? 'a'    ·            ·
+ └── scan  ·         ·          (j)          ·
+·          table     t@primary  ·            ·
+·          spans     ALL        ·            ·
 
 exec hide-colnames nodist
 EXPLAIN (VERBOSE) SELECT j ?| ARRAY['a', 'b', 'c'] FROM t
 ----
-render     ·         ·                          (column8)  ·
- │         render 0  j ?| ARRAY['a', 'b', 'c']  ·          ·
- └── scan  ·         ·                          (j)        ·
-·          table     t@primary                  ·          ·
-·          spans     ALL                        ·          ·
+render     ·         ·                          ("j ?| ARRAY['a', 'b', 'c']")  ·
+ │         render 0  j ?| ARRAY['a', 'b', 'c']  ·                              ·
+ └── scan  ·         ·                          (j)                            ·
+·          table     t@primary                  ·                              ·
+·          spans     ALL                        ·                              ·
 
 exec hide-colnames nodist
 EXPLAIN (VERBOSE) SELECT j ?& ARRAY['a', 'b', 'c'] FROM t
 ----
-render     ·         ·                          (column8)  ·
- │         render 0  j ?& ARRAY['a', 'b', 'c']  ·          ·
- └── scan  ·         ·                          (j)        ·
-·          table     t@primary                  ·          ·
-·          spans     ALL                        ·          ·
+render     ·         ·                          ("j ?& ARRAY['a', 'b', 'c']")  ·
+ │         render 0  j ?& ARRAY['a', 'b', 'c']  ·                              ·
+ └── scan  ·         ·                          (j)                            ·
+·          table     t@primary                  ·                              ·
+·          spans     ALL                        ·                              ·
 
 exec hide-colnames nodist
 EXPLAIN (VERBOSE) SELECT j#>ARRAY['a'] FROM t
 ----
-render     ·         ·              (column8)  ·
- │         render 0  j#>ARRAY['a']  ·          ·
- └── scan  ·         ·              (j)        ·
-·          table     t@primary      ·          ·
-·          spans     ALL            ·          ·
+render     ·         ·              ("j#>ARRAY['a']")  ·
+ │         render 0  j#>ARRAY['a']  ·                  ·
+ └── scan  ·         ·              (j)                ·
+·          table     t@primary      ·                  ·
+·          spans     ALL            ·                  ·
 
 exec hide-colnames nodist
 EXPLAIN (VERBOSE) SELECT j#>>ARRAY['a'] FROM t
 ----
-render     ·         ·               (column8)  ·
- │         render 0  j#>>ARRAY['a']  ·          ·
- └── scan  ·         ·               (j)        ·
-·          table     t@primary       ·          ·
-·          spans     ALL             ·          ·
+render     ·         ·               ("j#>>ARRAY['a']")  ·
+ │         render 0  j#>>ARRAY['a']  ·                   ·
+ └── scan  ·         ·               (j)                 ·
+·          table     t@primary       ·                   ·
+·          spans     ALL             ·                   ·
 
 
 exec hide-colnames nodist
 EXPLAIN (VERBOSE) SELECT CAST(a AS string), b::float FROM t
 ----
-render     ·         ·          (column8, column9)  ·
- │         render 0  a::STRING  ·                   ·
- │         render 1  b::FLOAT   ·                   ·
- └── scan  ·         ·          (a, b)              ·
-·          table     t@primary  ·                   ·
-·          spans     ALL        ·                   ·
+render     ·         ·          ("CAST(a AS STRING)", "b::FLOAT")  ·
+ │         render 0  a::STRING  ·                                  ·
+ │         render 1  b::FLOAT   ·                                  ·
+ └── scan  ·         ·          (a, b)                             ·
+·          table     t@primary  ·                                  ·
+·          spans     ALL        ·                                  ·
 
 exec hide-colnames nodist
 EXPLAIN (VERBOSE) SELECT CAST(a + b + c AS string) FROM t
 ----
-render     ·         ·                      (column8)  ·
- │         render 0  (c + (a + b))::STRING  ·          ·
- └── scan  ·         ·                      (a, b, c)  ·
-·          table     t@primary              ·          ·
-·          spans     ALL                    ·          ·
+render     ·         ·                      ("CAST((a + b) + c AS STRING)")  ·
+ │         render 0  (c + (a + b))::STRING  ·                                ·
+ └── scan  ·         ·                      (a, b, c)                        ·
+·          table     t@primary              ·                                ·
+·          spans     ALL                    ·                                ·
 
 exec rowsort
 SELECT LENGTH(s)::float, s FROM str
 ----
-column3:float  s:string
-1.0            a
-2.0            ab
-3.0            abc
+length(s)::FLOAT:float  s:string
+1.0                     a
+2.0                     ab
+3.0                     abc
 
 exec hide-colnames nodist
 EXPLAIN (VERBOSE) SELECT COALESCE(a, b) FROM (VALUES (1, 2), (3, NULL), (NULL, 4), (NULL, NULL)) AS v(a, b)
 ----
-render       ·              ·                           (column3)           ·
+render       ·              ·                           ("COALESCE(a, b)")  ·
  │           render 0       COALESCE(column1, column2)  ·                   ·
  └── values  ·              ·                           (column1, column2)  ·
 ·            size           2 columns, 4 rows           ·                   ·
@@ -441,7 +441,7 @@ render       ·              ·                           (column3)           ·
 exec rowsort
 SELECT COALESCE(a, b) FROM (VALUES (1, 2), (3, NULL), (NULL, 4), (NULL, NULL)) AS v(a, b)
 ----
-column3:int
+COALESCE(a, b):int
 NULL
 1
 3
@@ -450,7 +450,7 @@ NULL
 exec hide-colnames nodist
 EXPLAIN (VERBOSE) SELECT COALESCE(a, b, c) FROM (VALUES (1, 2, 3), (NULL, 4, 5), (NULL, NULL, 6), (NULL, NULL, NULL)) AS v(a, b, c)
 ----
-render       ·              ·                                    (column4)                    ·
+render       ·              ·                                    ("COALESCE(a, b, c)")        ·
  │           render 0       COALESCE(column1, column2, column3)  ·                            ·
  └── values  ·              ·                                    (column1, column2, column3)  ·
 ·            size           3 columns, 4 rows                    ·                            ·
@@ -470,7 +470,7 @@ render       ·              ·                                    (column4)    
 exec rowsort
 SELECT COALESCE(a, b, c) FROM (VALUES (1, 2, 3), (NULL, 4, 5), (NULL, NULL, 6), (NULL, NULL, NULL)) AS v(a, b, c)
 ----
-column4:int
+COALESCE(a, b, c):int
 NULL
 1
 4
@@ -501,26 +501,26 @@ render          ·         ·                   (a)        ·
 exec hide-colnames nodist
 EXPLAIN (VERBOSE) SELECT a BETWEEN SYMMETRIC b AND d FROM t
 ----
-render     ·         ·                                                   (column8)  ·
- │         render 0  ((a >= b) AND (a <= d)) OR ((a >= d) AND (a <= b))  ·          ·
- └── scan  ·         ·                                                   (a, b, d)  ·
-·          table     t@primary                                           ·          ·
-·          spans     ALL                                                 ·          ·
+render     ·         ·                                                   ("a BETWEEN SYMMETRIC b AND d")  ·
+ │         render 0  ((a >= b) AND (a <= d)) OR ((a >= d) AND (a <= b))  ·                                ·
+ └── scan  ·         ·                                                   (a, b, d)                        ·
+·          table     t@primary                                           ·                                ·
+·          spans     ALL                                                 ·                                ·
 
 exec hide-colnames nodist
 EXPLAIN (VERBOSE) SELECT a NOT BETWEEN SYMMETRIC b AND d FROM t
 ----
-render     ·         ·                                              (column8)  ·
- │         render 0  ((a < b) OR (a > d)) AND ((a < d) OR (a > b))  ·          ·
- └── scan  ·         ·                                              (a, b, d)  ·
-·          table     t@primary                                      ·          ·
-·          spans     ALL                                            ·          ·
+render     ·         ·                                              ("a NOT BETWEEN SYMMETRIC b AND d")  ·
+ │         render 0  ((a < b) OR (a > d)) AND ((a < d) OR (a > b))  ·                                    ·
+ └── scan  ·         ·                                              (a, b, d)                            ·
+·          table     t@primary                                      ·                                    ·
+·          spans     ALL                                            ·                                    ·
 
 exec hide-colnames nodist
 EXPLAIN (VERBOSE) SELECT ARRAY[a + 1, 2, 3] FROM t
 ----
-render     ·         ·                   (column8)  ·
- │         render 0  ARRAY[a + 1, 2, 3]  ·          ·
- └── scan  ·         ·                   (a)        ·
-·          table     t@primary           ·          ·
-·          spans     ALL                 ·          ·
+render     ·         ·                   ("ARRAY[a + 1, 2, 3]")  ·
+ │         render 0  ARRAY[a + 1, 2, 3]  ·                       ·
+ └── scan  ·         ·                   (a)                     ·
+·          table     t@primary           ·                       ·
+·          spans     ALL                 ·                       ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/subquery
+++ b/pkg/sql/opt/exec/execbuilder/testdata/subquery
@@ -7,7 +7,7 @@ opt
 SELECT EXISTS(SELECT * FROM t WHERE u = k*k)
 ----
 project
- ├── columns: column4:4(bool)
+ ├── columns: "EXISTS (SELECT * FROM t WHERE u = (k * k))":4(bool)
  ├── cardinality: [1 - 1]
  ├── stats: [rows=1]
  ├── cost: 1010.01
@@ -38,31 +38,31 @@ project
 exec hide-colnames nodist
 EXPLAIN (VERBOSE) SELECT EXISTS(SELECT * FROM t WHERE u = k*k)
 ----
-root                 ·          ·                 (column4)  ·
- ├── render          ·          ·                 (column4)  ·
- │    │              render 0   @S1               ·          ·
- │    └── values     ·          ·                 ()         ·
- │                   size       0 columns, 1 row  ·          ·
- └── subquery        ·          ·                 (column4)  ·
-      │              id         @S1               ·          ·
-      │              sql        EXISTS <unknown>  ·          ·
-      │              exec mode  exists            ·          ·
-      └── filter     ·          ·                 (k, u, v)  ·
-           │         filter     u = (k * k)       ·          ·
-           └── scan  ·          ·                 (k, u, v)  ·
-·                    table      t@primary         ·          ·
-·                    spans      ALL               ·          ·
+root                 ·          ·                 ("EXISTS (SELECT * FROM t WHERE u = (k * k))")  ·
+ ├── render          ·          ·                 ("EXISTS (SELECT * FROM t WHERE u = (k * k))")  ·
+ │    │              render 0   @S1               ·                                               ·
+ │    └── values     ·          ·                 ()                                              ·
+ │                   size       0 columns, 1 row  ·                                               ·
+ └── subquery        ·          ·                 ("EXISTS (SELECT * FROM t WHERE u = (k * k))")  ·
+      │              id         @S1               ·                                               ·
+      │              sql        EXISTS <unknown>  ·                                               ·
+      │              exec mode  exists            ·                                               ·
+      └── filter     ·          ·                 (k, u, v)                                       ·
+           │         filter     u = (k * k)       ·                                               ·
+           └── scan  ·          ·                 (k, u, v)                                       ·
+·                    table      t@primary         ·                                               ·
+·                    spans      ALL               ·                                               ·
 
 exec nodist
 SELECT EXISTS(SELECT * FROM t WHERE u = k*k)
 ----
-column4:bool
+EXISTS (SELECT * FROM t WHERE u = (k * k)):bool
 true
 
 exec nodist
 SELECT EXISTS(SELECT * FROM t WHERE u != k*k)
 ----
-column4:bool
+EXISTS (SELECT * FROM t WHERE u != (k * k)):bool
 false
 
 exec hide-colnames nodist

--- a/pkg/sql/opt/exec/execbuilder/testdata/union
+++ b/pkg/sql/opt/exec/execbuilder/testdata/union
@@ -141,14 +141,14 @@ NULL
 exec rowsort
 SELECT x, pg_typeof(y) FROM (SELECT 1, NULL UNION ALL SELECT 2, 4) AS t(x, y)
 ----
-x:int  column7:string
+x:int  pg_typeof:string
 1      unknown
 2      int
 
 exec rowsort
 SELECT x, pg_typeof(y) FROM (SELECT 1, 3 UNION ALL SELECT 2, NULL) AS t(x, y)
 ----
-x:int  column7:string
+x:int  pg_typeof:string
 1      int
 2      unknown
 

--- a/pkg/sql/opt/exec/execbuilder/testdata/values
+++ b/pkg/sql/opt/exec/execbuilder/testdata/values
@@ -2,21 +2,21 @@
 exec hide-colnames nodist
 EXPLAIN (VERBOSE) SELECT 1
 ----
-render       ·         ·                 (column1)  ·
- │           render 0  1                 ·          ·
- └── values  ·         ·                 ()         ·
-·            size      0 columns, 1 row  ·          ·
+render       ·         ·                 ("1")  ·
+ │           render 0  1                 ·      ·
+ └── values  ·         ·                 ()     ·
+·            size      0 columns, 1 row  ·      ·
 
 exec
 SELECT 1
 ----
-column1:int
+1:int
 1
 
 exec hide-colnames nodist
 EXPLAIN (VERBOSE) SELECT 1 + 2
 ----
-render       ·         ·                 (column1)  ·
+render       ·         ·                 ("1 + 2")  ·
  │           render 0  3                 ·          ·
  └── values  ·         ·                 ()         ·
 ·            size      0 columns, 1 row  ·          ·
@@ -24,7 +24,7 @@ render       ·         ·                 (column1)  ·
 exec
 SELECT 1 + 2
 ----
-column1:int
+1 + 2:int
 3
 
 exec hide-colnames nodist
@@ -68,7 +68,7 @@ column1:int
 exec hide-colnames nodist
 EXPLAIN (VERBOSE) SELECT a + b FROM (VALUES (1, 2), (3, 4), (5, 6)) AS v(a, b)
 ----
-render       ·              ·                  (column3)           ·
+render       ·              ·                  ("a + b")           ·
  │           render 0       column1 + column2  ·                   ·
  └── values  ·              ·                  (column1, column2)  ·
 ·            size           2 columns, 3 rows  ·                   ·
@@ -82,7 +82,7 @@ render       ·              ·                  (column3)           ·
 exec
 SELECT a + b FROM (VALUES (1, 2), (3, 4), (5, 6)) AS v(a, b)
 ----
-column3:int
+a + b:int
 3
 7
 11

--- a/pkg/sql/opt/memo/testdata/logprops/groupby
+++ b/pkg/sql/opt/memo/testdata/logprops/groupby
@@ -27,11 +27,11 @@ build
 SELECT y, SUM(z), x, False FROM xyzs GROUP BY x, y
 ----
 project
- ├── columns: y:2(int) column5:5(float) x:1(int!null) column6:6(bool!null)
+ ├── columns: y:2(int) sum:5(float) x:1(int!null) false:6(bool!null)
  ├── stats: [rows=1000]
  ├── keys: (1)
  ├── group-by
- │    ├── columns: x:1(int!null) y:2(int) column5:5(float)
+ │    ├── columns: x:1(int!null) y:2(int) sum:5(float)
  │    ├── grouping columns: x:1(int!null) y:2(int)
  │    ├── stats: [rows=1000, distinct(1,2)=1000]
  │    ├── keys: (1)
@@ -54,7 +54,7 @@ build
 SELECT SUM(x), MAX(y) FROM xyzs
 ----
 group-by
- ├── columns: column5:5(decimal) column6:6(int)
+ ├── columns: sum:5(decimal) max:6(int)
  ├── cardinality: [1 - 1]
  ├── stats: [rows=1]
  ├── project
@@ -97,10 +97,10 @@ build
 SELECT y, SUM(z) FROM xyzs GROUP BY z, y
 ----
 project
- ├── columns: y:2(int) column5:5(float)
+ ├── columns: y:2(int) sum:5(float)
  ├── stats: [rows=1000]
  └── group-by
-      ├── columns: y:2(int) z:3(float!null) column5:5(float)
+      ├── columns: y:2(int) z:3(float!null) sum:5(float)
       ├── grouping columns: y:2(int) z:3(float!null)
       ├── stats: [rows=1000, distinct(2,3)=1000]
       ├── keys: weak(2,3)
@@ -120,7 +120,7 @@ build
 SELECT z, MAX(s) FROM xyzs GROUP BY z
 ----
 group-by
- ├── columns: z:3(float!null) column5:5(string)
+ ├── columns: z:3(float!null) max:5(string)
  ├── grouping columns: z:3(float!null)
  ├── stats: [rows=700, distinct(3)=700]
  ├── keys: (3)
@@ -168,16 +168,16 @@ select
  └── gt [type=bool, outer=(1,2)]
       ├── subquery [type=decimal, outer=(1,2)]
       │    └── max1-row
-      │         ├── columns: column8:8(decimal)
+      │         ├── columns: sum:8(decimal)
       │         ├── outer: (1,2)
       │         ├── cardinality: [0 - 1]
       │         ├── stats: [rows=1]
       │         └── project
-      │              ├── columns: column8:8(decimal)
+      │              ├── columns: sum:8(decimal)
       │              ├── outer: (1,2)
       │              ├── stats: [rows=700]
       │              └── group-by
-      │                   ├── columns: u:6(float) column8:8(decimal)
+      │                   ├── columns: u:6(float) sum:8(decimal)
       │                   ├── grouping columns: u:6(float)
       │                   ├── outer: (1,2)
       │                   ├── stats: [rows=700, distinct(6)=700]

--- a/pkg/sql/opt/memo/testdata/logprops/join
+++ b/pkg/sql/opt/memo/testdata/logprops/join
@@ -47,7 +47,7 @@ opt
 SELECT (SELECT (VALUES (x), (y))) FROM xysd
 ----
 project
- ├── columns: column7:7(int)
+ ├── columns: "(SELECT (VALUES (x), (y)))":7(int)
  ├── stats: [rows=1000]
  ├── inner-join-apply
  │    ├── columns: x:1(int!null) y:2(int) column1:5(int)

--- a/pkg/sql/opt/memo/testdata/logprops/limit
+++ b/pkg/sql/opt/memo/testdata/logprops/limit
@@ -41,11 +41,11 @@ build
 SELECT COUNT(*) FROM xyzs LIMIT 10
 ----
 limit
- ├── columns: column5:5(int)
+ ├── columns: count:5(int)
  ├── cardinality: [1 - 1]
  ├── stats: [rows=1]
  ├── group-by
- │    ├── columns: column5:5(int)
+ │    ├── columns: count:5(int)
  │    ├── cardinality: [1 - 1]
  │    ├── stats: [rows=1]
  │    ├── project
@@ -71,11 +71,11 @@ limit
  │    └── keys: (1) weak(3,4)
  └── subquery [type=int]
       └── max1-row
-           ├── columns: column5:5(int!null)
+           ├── columns: "1":5(int!null)
            ├── cardinality: [1 - 1]
            ├── stats: [rows=1]
            └── project
-                ├── columns: column5:5(int!null)
+                ├── columns: "1":5(int!null)
                 ├── cardinality: [1 - 1]
                 ├── stats: [rows=1]
                 ├── values
@@ -104,7 +104,7 @@ build
 SELECT (SELECT x FROM kuv LIMIT y) FROM xyzs
 ----
 project
- ├── columns: column8:8(int)
+ ├── columns: "(SELECT x FROM kuv LIMIT y)":8(int)
  ├── stats: [rows=1000]
  ├── scan xyzs
  │    ├── columns: x:1(int!null) y:2(int) z:3(float!null) s:4(string)

--- a/pkg/sql/opt/memo/testdata/logprops/offset
+++ b/pkg/sql/opt/memo/testdata/logprops/offset
@@ -49,11 +49,11 @@ offset
  │    └── keys: (1) weak(3,4)
  └── subquery [type=int]
       └── max1-row
-           ├── columns: column5:5(int!null)
+           ├── columns: "1":5(int!null)
            ├── cardinality: [1 - 1]
            ├── stats: [rows=1]
            └── project
-                ├── columns: column5:5(int!null)
+                ├── columns: "1":5(int!null)
                 ├── cardinality: [1 - 1]
                 ├── stats: [rows=1]
                 ├── values
@@ -81,7 +81,7 @@ build
 SELECT (SELECT x FROM kuv OFFSET y) FROM xyzs
 ----
 project
- ├── columns: column8:8(int)
+ ├── columns: "(SELECT x FROM kuv OFFSET y)":8(int)
  ├── stats: [rows=1000]
  ├── scan xyzs
  │    ├── columns: x:1(int!null) y:2(int) z:3(float!null) s:4(string)

--- a/pkg/sql/opt/memo/testdata/logprops/project
+++ b/pkg/sql/opt/memo/testdata/logprops/project
@@ -27,7 +27,7 @@ build
 SELECT y, x+1, 1, x FROM xysd
 ----
 project
- ├── columns: y:2(int) column5:5(int) column6:6(int!null) x:1(int!null)
+ ├── columns: y:2(int) "x + 1":5(int) "1":6(int!null) x:1(int!null)
  ├── stats: [rows=1000]
  ├── keys: (1)
  ├── scan xysd
@@ -66,12 +66,12 @@ select
  └── gt [type=bool, outer=(1,2)]
       ├── subquery [type=int, outer=(1,2)]
       │    └── max1-row
-      │         ├── columns: column8:8(int)
+      │         ├── columns: "(SELECT y)":8(int)
       │         ├── outer: (1,2)
       │         ├── cardinality: [0 - 1]
       │         ├── stats: [rows=1]
       │         └── project
-      │              ├── columns: column8:8(int)
+      │              ├── columns: "(SELECT y)":8(int)
       │              ├── outer: (1,2)
       │              ├── stats: [rows=111]
       │              ├── select
@@ -129,7 +129,7 @@ build
 SELECT 1, 'foo', null, 1::decimal + null, null::string FROM xysd
 ----
 project
- ├── columns: column5:5(int!null) column6:6(string!null) column7:7(unknown) column7:7(unknown) column8:8(string)
+ ├── columns: "1":5(int!null) "'foo'":6(string!null) NULL:7(unknown) "1::DECIMAL + NULL":7(unknown) "NULL::STRING":8(string)
  ├── stats: [rows=1000]
  ├── scan xysd
  │    ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null)

--- a/pkg/sql/opt/memo/testdata/logprops/scalar
+++ b/pkg/sql/opt/memo/testdata/logprops/scalar
@@ -36,13 +36,13 @@ build
 SELECT xy.x + 1 = length('foo') + xy.y, uv.rowid * xy.x FROM xy, uv
 ----
 project
- ├── columns: column6:6(bool) column7:7(int)
+ ├── columns: "(xy.x + 1) = (length('foo') + xy.y)":6(bool) "uv.rowid * xy.x":7(int)
  ├── stats: [rows=1000000]
  ├── inner-join
- │    ├── columns: x:1(int!null) y:2(int) u:3(int) v:4(int!null) rowid:5(int!null)
+ │    ├── columns: xy.x:1(int!null) y:2(int) u:3(int) v:4(int!null) rowid:5(int!null)
  │    ├── stats: [rows=1000000]
  │    ├── scan xy
- │    │    ├── columns: x:1(int!null) y:2(int)
+ │    │    ├── columns: xy.x:1(int!null) y:2(int)
  │    │    ├── stats: [rows=1000]
  │    │    └── keys: (1)
  │    ├── scan uv

--- a/pkg/sql/opt/memo/testdata/logprops/select
+++ b/pkg/sql/opt/memo/testdata/logprops/select
@@ -93,7 +93,7 @@ build
 SELECT COUNT(*) FROM xy HAVING COUNT(*) = 5
 ----
 select
- ├── columns: column3:3(int!null)
+ ├── columns: count:3(int!null)
  ├── cardinality: [0 - 1]
  ├── stats: [rows=1, distinct(3)=1]
  ├── group-by

--- a/pkg/sql/opt/memo/testdata/logprops/values
+++ b/pkg/sql/opt/memo/testdata/logprops/values
@@ -29,7 +29,7 @@ build
 SELECT (VALUES (x), (y+1)) FROM xy
 ----
 project
- ├── columns: column4:4(int)
+ ├── columns: "(VALUES (x), (y + 1))":4(int)
  ├── stats: [rows=1000]
  ├── scan xy
  │    ├── columns: x:1(int!null) y:2(int)

--- a/pkg/sql/opt/memo/testdata/memo
+++ b/pkg/sql/opt/memo/testdata/memo
@@ -24,16 +24,16 @@ ORDER BY y
 LIMIT 10
 ----
 limit
- ├── columns: y:2(int!null) x:3(string!null) column5:5(int)
+ ├── columns: y:2(int!null) x:3(string!null) "y + 1":5(int)
  ├── cardinality: [0 - 10]
  ├── stats: [rows=10]
  ├── ordering: +2
  ├── sort
- │    ├── columns: y:2(int!null) b.x:3(string!null) column5:5(int)
+ │    ├── columns: y:2(int!null) b.x:3(string!null) "y + 1":5(int)
  │    ├── stats: [rows=476]
  │    ├── ordering: +2
  │    └── project
- │         ├── columns: column5:5(int) y:2(int!null) b.x:3(string!null)
+ │         ├── columns: "y + 1":5(int) y:2(int!null) b.x:3(string!null)
  │         ├── stats: [rows=476]
  │         ├── select
  │         │    ├── columns: a.x:1(int!null) y:2(int!null) b.x:3(string!null) z:4(decimal!null)
@@ -72,7 +72,7 @@ ORDER BY y
 LIMIT 10
 ----
 project
- ├── columns: y:2(int!null) x:3(string!null) column5:5(int)
+ ├── columns: y:2(int!null) x:3(string!null) "y + 1":5(int)
  ├── cardinality: [0 - 10]
  ├── stats: [rows=10]
  ├── ordering: +2
@@ -124,7 +124,7 @@ LIMIT 10
 ----
 memo (optimized)
  ├── G1: (project G2 G3)
- │    ├── "[presentation: y:2,x:3,column5:5] [ordering: +2]"
+ │    ├── "[presentation: y:2,x:3,y + 1:5] [ordering: +2]"
  │    │    ├── best: (project G2="[ordering: +2]" G3)
  │    │    └── cost: 2026.65
  │    └── ""
@@ -177,7 +177,7 @@ WHERE z=1 AND concat(x, 'foo', x)=concat(x, 'foo', x)
 ----
 memo (optimized)
  ├── G1: (project G2 G3)
- │    └── "[presentation: column3:3,column4:4,column5:5,column6:6]"
+ │    └── "[presentation: 1:3,1 + z:4,now()::TIMESTAMP:5,now()::TIMESTAMP WITH TIME ZONE:6]"
  │         ├── best: (project G2 G3)
  │         └── cost: 1010.00
  ├── G2: (select G4 G5)

--- a/pkg/sql/opt/memo/testdata/stats/groupby
+++ b/pkg/sql/opt/memo/testdata/stats/groupby
@@ -69,10 +69,10 @@ build
 SELECT max(y) FROM a GROUP BY x
 ----
 project
- ├── columns: column5:5(int)
+ ├── columns: max:5(int)
  ├── stats: [rows=2000]
  └── group-by
-      ├── columns: x:1(int!null) column5:5(int)
+      ├── columns: x:1(int!null) max:5(int)
       ├── grouping columns: x:1(int!null)
       ├── stats: [rows=2000, distinct(1)=2000]
       ├── keys: (1)
@@ -93,7 +93,7 @@ build
 SELECT y, sum(z) FROM a GROUP BY y
 ----
 group-by
- ├── columns: y:2(int) column5:5(float)
+ ├── columns: y:2(int) sum:5(float)
  ├── grouping columns: y:2(int)
  ├── stats: [rows=400, distinct(2)=400]
  ├── keys: weak(2)
@@ -112,10 +112,10 @@ build
 SELECT max(x) FROM a GROUP BY y, z, s
 ----
 project
- ├── columns: column5:5(int)
+ ├── columns: max:5(int)
  ├── stats: [rows=600]
  └── group-by
-      ├── columns: y:2(int) z:3(float!null) s:4(string) column5:5(int)
+      ├── columns: y:2(int) z:3(float!null) s:4(string) max:5(int)
       ├── grouping columns: y:2(int) z:3(float!null) s:4(string)
       ├── stats: [rows=600, distinct(2-4)=600]
       ├── keys: weak(3,4)
@@ -135,10 +135,10 @@ build
 SELECT min(x) FROM a GROUP BY y, z
 ----
 project
- ├── columns: column5:5(int)
+ ├── columns: min:5(int)
  ├── stats: [rows=2000]
  └── group-by
-      ├── columns: y:2(int) z:3(float!null) column5:5(int)
+      ├── columns: y:2(int) z:3(float!null) min:5(int)
       ├── grouping columns: y:2(int) z:3(float!null)
       ├── stats: [rows=2000, distinct(2,3)=2000]
       ├── keys: weak(2,3)
@@ -158,14 +158,14 @@ build
 SELECT max(x) FROM a GROUP BY y, z, s HAVING s IN ('a', 'b')
 ----
 project
- ├── columns: column5:5(int)
+ ├── columns: max:5(int)
  ├── stats: [rows=120]
  └── select
-      ├── columns: y:2(int) z:3(float!null) s:4(string!null) column5:5(int)
+      ├── columns: y:2(int) z:3(float!null) s:4(string!null) max:5(int)
       ├── stats: [rows=120, distinct(4)=2]
       ├── keys: (3,4)
       ├── group-by
-      │    ├── columns: y:2(int) z:3(float!null) s:4(string) column5:5(int)
+      │    ├── columns: y:2(int) z:3(float!null) s:4(string) max:5(int)
       │    ├── grouping columns: y:2(int) z:3(float!null) s:4(string)
       │    ├── stats: [rows=600, distinct(4)=10, distinct(2-4)=600]
       │    ├── keys: weak(3,4)
@@ -191,7 +191,7 @@ build
 SELECT sum(x), s FROM a GROUP BY s HAVING sum(x) = 5
 ----
 project
- ├── columns: column5:5(decimal!null) s:4(string)
+ ├── columns: sum:5(decimal!null) s:4(string)
  ├── stats: [rows=1]
  ├── keys: weak(4)
  └── select

--- a/pkg/sql/opt/memo/testdata/stats/join
+++ b/pkg/sql/opt/memo/testdata/stats/join
@@ -201,11 +201,11 @@ build
 SELECT sum(b.z), a.x, b.z FROM a, b GROUP BY a.x, b.z
 ----
 project
- ├── columns: column8:8(decimal) x:1(int!null) z:6(int!null)
+ ├── columns: sum:8(decimal) x:1(int!null) z:6(int!null)
  ├── stats: [rows=500000]
  ├── keys: (1,6)
  └── group-by
-      ├── columns: a.x:1(int!null) z:6(int!null) column8:8(decimal)
+      ├── columns: a.x:1(int!null) z:6(int!null) sum:8(decimal)
       ├── grouping columns: a.x:1(int!null) z:6(int!null)
       ├── stats: [rows=500000, distinct(1,6)=500000]
       ├── keys: (1,6)

--- a/pkg/sql/opt/memo/testdata/stats/limit
+++ b/pkg/sql/opt/memo/testdata/stats/limit
@@ -83,11 +83,11 @@ limit
  │         └── const: 'foo' [type=string]
  └── subquery [type=int]
       └── max1-row
-           ├── columns: column5:5(int!null)
+           ├── columns: "5":5(int!null)
            ├── cardinality: [1 - 1]
            ├── stats: [rows=1]
            └── project
-                ├── columns: column5:5(int!null)
+                ├── columns: "5":5(int!null)
                 ├── cardinality: [1 - 1]
                 ├── stats: [rows=1]
                 ├── values

--- a/pkg/sql/opt/memo/testdata/stats/lookup-join
+++ b/pkg/sql/opt/memo/testdata/stats/lookup-join
@@ -49,10 +49,10 @@ opt
 SELECT count(*) FROM (SELECT * FROM a WHERE s = 'foo' AND x + y = 10) GROUP BY s, y
 ----
 project
- ├── columns: column5:5(int)
+ ├── columns: count:5(int)
  ├── stats: [rows=65]
  └── group-by
-      ├── columns: y:2(int) s:3(string!null) column5:5(int)
+      ├── columns: y:2(int) s:3(string!null) count:5(int)
       ├── grouping columns: y:2(int) s:3(string!null)
       ├── stats: [rows=65, distinct(2,3)=65]
       ├── keys: weak(2,3)

--- a/pkg/sql/opt/memo/testdata/stats/ordinality
+++ b/pkg/sql/opt/memo/testdata/stats/ordinality
@@ -74,7 +74,7 @@ build
 SELECT 1 FROM a WITH ORDINALITY
 ----
 project
- ├── columns: column4:4(int!null)
+ ├── columns: "1":4(int!null)
  ├── stats: [rows=4000]
  ├── row-number
  │    ├── columns: x:1(int!null) y:2(int) ordinality:3(int!null)

--- a/pkg/sql/opt/memo/testdata/stats/project
+++ b/pkg/sql/opt/memo/testdata/stats/project
@@ -69,10 +69,10 @@ build
 SELECT count(*) FROM (SELECT x, y FROM a) GROUP BY x, y
 ----
 project
- ├── columns: column5:5(int)
+ ├── columns: count:5(int)
  ├── stats: [rows=2000]
  └── group-by
-      ├── columns: x:1(int!null) y:2(int) column5:5(int)
+      ├── columns: x:1(int!null) y:2(int) count:5(int)
       ├── grouping columns: x:1(int!null) y:2(int)
       ├── stats: [rows=2000, distinct(1,2)=2000]
       ├── keys: (1)
@@ -95,7 +95,7 @@ select
  ├── columns: v:5(string!null)
  ├── stats: [rows=20, distinct(5)=1]
  ├── project
- │    ├── columns: column5:5(string)
+ │    ├── columns: concat:5(string)
  │    ├── stats: [rows=2000, distinct(5)=100]
  │    ├── scan a
  │    │    ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null)
@@ -107,7 +107,7 @@ select
  │              └── cast: string [type=string, outer=(2)]
  │                   └── variable: a.y [type=int, outer=(2)]
  └── eq [type=bool, outer=(5), constraints=(/5: [/'foo' - /'foo']; tight)]
-      ├── variable: column5 [type=string, outer=(5)]
+      ├── variable: concat [type=string, outer=(5)]
       └── const: 'foo' [type=string]
 
 # Test that stats for synthesized and non-synthesized columns are combined.
@@ -116,11 +116,11 @@ SELECT * FROM (SELECT CONCAT(s, y::string), x FROM a) AS q(v, x) GROUP BY v, x
 ----
 group-by
  ├── columns: v:5(string) x:1(int!null)
- ├── grouping columns: x:1(int!null) column5:5(string)
+ ├── grouping columns: x:1(int!null) concat:5(string)
  ├── stats: [rows=2000, distinct(1,5)=2000]
  ├── keys: (1)
  └── project
-      ├── columns: column5:5(string) x:1(int!null)
+      ├── columns: concat:5(string) x:1(int!null)
       ├── stats: [rows=2000, distinct(1,5)=2000]
       ├── keys: (1)
       ├── scan a
@@ -141,7 +141,7 @@ select
  ├── columns: v:5(int!null)
  ├── stats: [rows=142, distinct(5)=100]
  ├── project
- │    ├── columns: column5:5(int)
+ │    ├── columns: "y + 3":5(int)
  │    ├── stats: [rows=2000, distinct(5)=1400]
  │    ├── scan a
  │    │    ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null)
@@ -153,10 +153,10 @@ select
  │              └── const: 3 [type=int]
  └── and [type=bool, outer=(5), constraints=(/5: [/1 - /100]; tight)]
       ├── ge [type=bool, outer=(5), constraints=(/5: [/1 - ]; tight)]
-      │    ├── variable: column5 [type=int, outer=(5)]
+      │    ├── variable: y + 3 [type=int, outer=(5)]
       │    └── const: 1 [type=int]
       └── le [type=bool, outer=(5), constraints=(/5: (/NULL - /100]; tight)]
-           ├── variable: column5 [type=int, outer=(5)]
+           ├── variable: y + 3 [type=int, outer=(5)]
            └── const: 100 [type=int]
 
 exec-ddl

--- a/pkg/sql/opt/memo/testdata/stats/scan
+++ b/pkg/sql/opt/memo/testdata/stats/scan
@@ -100,7 +100,7 @@ opt
 SELECT count(*), y, x FROM a WHERE x > 0 AND x <= 100 GROUP BY x, y
 ----
 group-by
- ├── columns: column5:5(int) y:2(int) x:1(int!null)
+ ├── columns: count:5(int) y:2(int) x:1(int!null)
  ├── grouping columns: x:1(int!null) y:2(int)
  ├── stats: [rows=148, distinct(1,2)=148]
  ├── keys: (1)

--- a/pkg/sql/opt/memo/testdata/stats/select
+++ b/pkg/sql/opt/memo/testdata/stats/select
@@ -152,10 +152,10 @@ build
 SELECT sum(x) FROM b WHERE x > 1000 AND x <= 2000 GROUP BY z
 ----
 project
- ├── columns: column4:4(decimal)
+ ├── columns: sum:4(decimal)
  ├── stats: [rows=99]
  └── group-by
-      ├── columns: z:2(int!null) column4:4(decimal)
+      ├── columns: z:2(int!null) sum:4(decimal)
       ├── grouping columns: z:2(int!null)
       ├── stats: [rows=99, distinct(2)=99]
       ├── keys: (2)

--- a/pkg/sql/opt/memo/testdata/typing
+++ b/pkg/sql/opt/memo/testdata/typing
@@ -39,7 +39,7 @@ build
 SELECT 1, TRUE, FALSE, NULL
 ----
 project
- ├── columns: column1:1(int!null) column2:2(bool!null) column3:3(bool!null) column4:4(unknown)
+ ├── columns: "1":1(int!null) true:2(bool!null) false:3(bool!null) NULL:4(unknown)
  ├── values
  │    └── tuple [type=tuple{}]
  └── projections
@@ -65,7 +65,7 @@ build
 SELECT (a.x, 1.5), a.y FROM a
 ----
 project
- ├── columns: column3:3(tuple{int, decimal}) y:2(int)
+ ├── columns: "(a.x, 1.5)":3(tuple{int, decimal}) y:2(int)
  ├── scan a
  │    └── columns: x:1(int!null) y:2(int)
  └── projections
@@ -231,9 +231,9 @@ build
 SELECT a.x & a.y, a.x | a.y, a.x # a.y FROM a
 ----
 project
- ├── columns: column3:3(int) column4:4(int) column5:5(int)
+ ├── columns: "a.x & a.y":3(int) "a.x | a.y":4(int) "a.x # a.y":5(int)
  ├── scan a
- │    └── columns: x:1(int!null) y:2(int)
+ │    └── columns: x:1(int!null) a.y:2(int)
  └── projections
       ├── bitand [type=int]
       │    ├── variable: a.x [type=int]
@@ -250,9 +250,9 @@ build
 SELECT a.x + 1.5, DATE '2000-01-01' - 15, 10.10 * a.x, 1 / a.y, a.x // 1.5 FROM a
 ----
 project
- ├── columns: column3:3(decimal) column4:4(date) column5:5(decimal) column6:6(decimal) column7:7(decimal)
+ ├── columns: "a.x + 1.5":3(decimal) "DATE '2000-01-01' - 15":4(date) "10.10 * a.x":5(decimal) "1 / a.y":6(decimal) "a.x // 1.5":7(decimal)
  ├── scan a
- │    └── columns: x:1(int!null) y:2(int)
+ │    └── columns: a.x:1(int!null) a.y:2(int)
  └── projections
       ├── plus [type=decimal]
       │    ├── variable: a.x [type=int]
@@ -275,9 +275,9 @@ build
 SELECT 100.1 % a.x, a.x ^ 2.5, a.x << 3, a.y >> 2 FROM a
 ----
 project
- ├── columns: column3:3(decimal) column4:4(decimal) column5:5(int) column6:6(int)
+ ├── columns: "100.1 % a.x":3(decimal) "a.x ^ 2.5":4(decimal) "a.x << 3":5(int) "a.y >> 2":6(int)
  ├── scan a
- │    └── columns: x:1(int!null) y:2(int)
+ │    └── columns: a.x:1(int!null) y:2(int)
  └── projections
       ├── mod [type=decimal]
       │    ├── const: 100.1 [type=decimal]
@@ -297,7 +297,7 @@ build
 SELECT '[1, 2]'->1, '[1, 2]'->>1, '{"a": 5}'#>ARRAY['a'], '{"a": 5}'#>>ARRAY['a'] FROM a
 ----
 project
- ├── columns: column3:3(jsonb) column4:4(string) column5:5(jsonb) column6:6(string)
+ ├── columns: "'[1, 2]'->1":3(jsonb) "'[1, 2]'->>1":4(string) "'{"a": 5}'#>ARRAY['a']":5(jsonb) "'{"a": 5}'#>>ARRAY['a']":6(string)
  ├── scan a
  │    └── columns: x:1(int!null) y:2(int)
  └── projections
@@ -321,7 +321,7 @@ build
 SELECT b.x || 'more' FROM b
 ----
 project
- ├── columns: column3:3(string)
+ ├── columns: "b.x || 'more'":3(string)
  ├── scan b
  │    └── columns: x:1(string!null) z:2(decimal!null)
  └── projections
@@ -334,9 +334,9 @@ build
 SELECT -a.y, ~a.x FROM a
 ----
 project
- ├── columns: column3:3(int) column4:4(int)
+ ├── columns: "-a.y":3(int) "~a.x":4(int)
  ├── scan a
- │    └── columns: x:1(int!null) y:2(int)
+ │    └── columns: a.x:1(int!null) a.y:2(int)
  └── projections
       ├── unary-minus [type=int]
       │    └── variable: a.y [type=int]
@@ -348,7 +348,7 @@ build
 SELECT arr || arr, arr || NULL, NULL || arr FROM unusual
 ----
 project
- ├── columns: column3:3(int[]) column4:4(int[]) column5:5(int[])
+ ├── columns: "arr || arr":3(int[]) "arr || NULL":4(int[]) "NULL || arr":5(int[])
  ├── scan unusual
  │    └── columns: x:1(int!null) arr:2(int[])
  └── projections
@@ -367,7 +367,7 @@ build
 SELECT x || arr, arr || x, x || NULL, NULL || x FROM unusual
 ----
 project
- ├── columns: column3:3(int[]) column4:4(int[]) column5:5(int[]) column6:6(int[])
+ ├── columns: "x || arr":3(int[]) "arr || x":4(int[]) "x || NULL":5(int[]) "NULL || x":6(int[])
  ├── scan unusual
  │    └── columns: x:1(int!null) arr:2(int[])
  └── projections
@@ -389,7 +389,7 @@ build
 SELECT length('text')
 ----
 project
- ├── columns: column1:1(int)
+ ├── columns: length:1(int)
  ├── values
  │    └── tuple [type=tuple{}]
  └── projections
@@ -401,7 +401,7 @@ build
 SELECT div(1.0, 2.0)
 ----
 project
- ├── columns: column1:1(decimal)
+ ├── columns: div:1(decimal)
  ├── values
  │    └── tuple [type=tuple{}]
  └── projections
@@ -414,7 +414,7 @@ build
 SELECT NOW()
 ----
 project
- ├── columns: column1:1(timestamptz)
+ ├── columns: now:1(timestamptz)
  ├── values
  │    └── tuple [type=tuple{}]
  └── projections
@@ -425,7 +425,7 @@ build
 SELECT GREATEST(1, 2, 3, 4)
 ----
 project
- ├── columns: column1:1(int)
+ ├── columns: greatest:1(int)
  ├── values
  │    └── tuple [type=tuple{}]
  └── projections
@@ -444,7 +444,7 @@ SELECT
 FROM b
 ----
 group-by
- ├── columns: column3:3(decimal[]) column4:4(decimal) column6:6(bool) column7:7(bool) column8:8(string) column9:9(int) column10:10(int) column11:11(string) column12:12(decimal) column14:14(int) column15:15(decimal) column16:16(decimal) column17:17(decimal) column18:18(decimal) column19:19(int) column21:21(jsonb) column23:23(jsonb)
+ ├── columns: array_agg:3(decimal[]) avg:4(decimal) bool_and:6(bool) bool_or:7(bool) concat_agg:8(string) count:9(int) count:10(int) max:11(string) max:12(decimal) sum_int:14(int) sum:15(decimal) sqrdiff:16(decimal) variance:17(decimal) stddev:18(decimal) xor_agg:19(int) json_agg:21(jsonb) jsonb_agg:23(jsonb)
  ├── project
  │    ├── columns: column5:5(bool) column13:13(int) column20:20(jsonb) column22:22(jsonb) x:1(string!null) z:2(decimal!null)
  │    ├── scan b
@@ -499,16 +499,16 @@ opt
 SELECT * FROM (SELECT x, x::string, y FROM a) WHERE (SELECT MAX(x) FROM b WHERE y=z::int) > 'foo'
 ----
 project
- ├── columns: x:1(int!null) column3:3(string) y:2(int)
+ ├── columns: x:1(int!null) "x::STRING":3(string) y:2(int)
  └── select
-      ├── columns: a.x:1(int!null) y:2(int) column3:3(string) column6:6(string!null)
+      ├── columns: a.x:1(int!null) y:2(int) "x::STRING":3(string) max:6(string!null)
       ├── group-by
-      │    ├── columns: a.x:1(int!null) y:2(int) column3:3(string) column6:6(string)
+      │    ├── columns: a.x:1(int!null) y:2(int) "x::STRING":3(string) max:6(string)
       │    ├── grouping columns: a.x:1(int!null)
       │    ├── left-join
-      │    │    ├── columns: a.x:1(int!null) y:2(int) column3:3(string) b.x:4(string) z:5(decimal)
+      │    │    ├── columns: a.x:1(int!null) y:2(int) "x::STRING":3(string) b.x:4(string) z:5(decimal)
       │    │    ├── project
-      │    │    │    ├── columns: column3:3(string) a.x:1(int!null) y:2(int)
+      │    │    │    ├── columns: "x::STRING":3(string) a.x:1(int!null) y:2(int)
       │    │    │    ├── scan a
       │    │    │    │    └── columns: a.x:1(int!null) y:2(int)
       │    │    │    └── projections
@@ -527,8 +527,8 @@ project
       │         ├── any-not-null [type=int]
       │         │    └── variable: a.y [type=int]
       │         └── any-not-null [type=string]
-      │              └── variable: column3 [type=string]
+      │              └── variable: x::STRING [type=string]
       └── filters [type=bool]
            └── gt [type=bool]
-                ├── variable: column6 [type=string]
+                ├── variable: max [type=string]
                 └── const: 'foo' [type=string]

--- a/pkg/sql/opt/norm/testdata/props/prune_cols
+++ b/pkg/sql/opt/norm/testdata/props/prune_cols
@@ -70,7 +70,7 @@ build
 SELECT i, s, k+1 FROM a
 ----
 project
- ├── columns: i:2(int) s:4(string) column5:5(int)
+ ├── columns: i:2(int) s:4(string) "k + 1":5(int)
  ├── prune: (2,4,5)
  ├── scan a
  │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string)
@@ -128,11 +128,11 @@ project
  ├── keys: (1)
  ├── prune: (1-4)
  └── select
-      ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) column7:7(int!null)
+      ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) "k + 1":7(int!null)
       ├── keys: (1)
       ├── prune: (2-4)
       ├── left-join-apply
-      │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) column7:7(int)
+      │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) "k + 1":7(int)
       │    ├── keys: (1)
       │    ├── prune: (2-4,7)
       │    ├── scan a
@@ -140,12 +140,12 @@ project
       │    │    ├── keys: (1)
       │    │    └── prune: (1-4)
       │    ├── max1-row
-      │    │    ├── columns: column7:7(int)
+      │    │    ├── columns: "k + 1":7(int)
       │    │    ├── outer: (1)
       │    │    ├── cardinality: [0 - 1]
       │    │    ├── prune: (7)
       │    │    └── project
-      │    │         ├── columns: column7:7(int)
+      │    │         ├── columns: "k + 1":7(int)
       │    │         ├── outer: (1)
       │    │         ├── prune: (7)
       │    │         ├── select
@@ -167,7 +167,7 @@ project
       │    └── true [type=bool]
       └── filters [type=bool, outer=(7), constraints=(/7: [/1 - /1]; tight)]
            └── eq [type=bool, outer=(7), constraints=(/7: [/1 - /1]; tight)]
-                ├── variable: column7 [type=int, outer=(7)]
+                ├── variable: k + 1 [type=int, outer=(7)]
                 └── const: 1 [type=int]
 
 # SemiJoin operator.
@@ -255,10 +255,10 @@ opt
 SELECT COUNT(*), SUM(i) FROM a GROUP BY s, f
 ----
 project
- ├── columns: column5:5(int) column6:6(decimal)
+ ├── columns: count:5(int) sum:6(decimal)
  ├── prune: (5,6)
  └── group-by
-      ├── columns: f:3(float) s:4(string) column5:5(int) column6:6(decimal)
+      ├── columns: f:3(float) s:4(string) count:5(int) sum:6(decimal)
       ├── grouping columns: f:3(float) s:4(string)
       ├── keys: weak(3,4)
       ├── prune: (5,6)
@@ -275,7 +275,7 @@ opt
 SELECT COUNT(*), SUM(i) FROM a
 ----
 group-by
- ├── columns: column5:5(int) column6:6(decimal)
+ ├── columns: count:5(int) sum:6(decimal)
  ├── cardinality: [1 - 1]
  ├── prune: (5,6)
  ├── scan a
@@ -429,7 +429,7 @@ build
 SELECT (SELECT 1 FROM a)
 ----
 project
- ├── columns: column6:6(int)
+ ├── columns: "(SELECT 1 FROM a)":6(int)
  ├── cardinality: [1 - 1]
  ├── prune: (6)
  ├── values
@@ -438,11 +438,11 @@ project
  └── projections
       └── subquery [type=int]
            └── max1-row
-                ├── columns: column5:5(int!null)
+                ├── columns: "1":5(int!null)
                 ├── cardinality: [0 - 1]
                 ├── prune: (5)
                 └── project
-                     ├── columns: column5:5(int!null)
+                     ├── columns: "1":5(int!null)
                      ├── prune: (5)
                      ├── scan a
                      │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string)

--- a/pkg/sql/opt/norm/testdata/rules/bool
+++ b/pkg/sql/opt/norm/testdata/rules/bool
@@ -36,7 +36,7 @@ opt
 SELECT False OR False
 ----
 project
- ├── columns: column1:1(bool!null)
+ ├── columns: "false OR false":1(bool!null)
  ├── cardinality: [1 - 1]
  ├── values
  │    ├── cardinality: [1 - 1]
@@ -51,7 +51,7 @@ opt
 SELECT (i=5 OR False) AND (s<'foo' AND True) FROM a
 ----
 project
- ├── columns: column6:6(bool)
+ ├── columns: "((i = 5) OR false) AND ((s < 'foo') AND true)":6(bool)
  ├── scan a
  │    └── columns: i:2(int) s:4(string)
  └── projections [outer=(2,4)]
@@ -72,7 +72,7 @@ opt
 SELECT k=1 AND False AND f=3.5 FROM a
 ----
 project
- ├── columns: column6:6(bool!null)
+ ├── columns: "((k = 1) AND false) AND (f = 3.5)":6(bool!null)
  ├── scan a
  └── projections
       └── false [type=bool]
@@ -81,7 +81,7 @@ opt
 SELECT False AND s='foo' FROM a
 ----
 project
- ├── columns: column6:6(bool!null)
+ ├── columns: "false AND (s = 'foo')":6(bool!null)
  ├── scan a
  └── projections
       └── false [type=bool]
@@ -91,7 +91,7 @@ opt
 SELECT true AND k=1 FROM a
 ----
 project
- ├── columns: column6:6(bool)
+ ├── columns: "true AND (k = 1)":6(bool)
  ├── scan a
  │    ├── columns: k:1(int!null)
  │    └── keys: (1)
@@ -104,7 +104,7 @@ opt
 SELECT k=1 AND i=2 AND true FROM a
 ----
 project
- ├── columns: column6:6(bool)
+ ├── columns: "((k = 1) AND (i = 2)) AND true":6(bool)
  ├── scan a
  │    ├── columns: k:1(int!null) i:2(int)
  │    └── keys: (1)
@@ -130,7 +130,7 @@ opt
 SELECT (k>1 AND k<5) AND (f=3.5 AND s='foo') FROM a
 ----
 project
- ├── columns: column6:6(bool)
+ ├── columns: "((k > 1) AND (k < 5)) AND ((f = 3.5) AND (s = 'foo'))":6(bool)
  ├── scan a
  │    ├── columns: k:1(int!null) f:3(float) s:4(string)
  │    └── keys: (1)
@@ -158,7 +158,7 @@ opt
 SELECT k=1 OR (i=2 OR True) FROM a
 ----
 project
- ├── columns: column6:6(bool!null)
+ ├── columns: "(k = 1) OR ((i = 2) OR true)":6(bool!null)
  ├── scan a
  └── projections
       └── true [type=bool]
@@ -167,7 +167,7 @@ opt
 SELECT k=1 OR True OR f=3.5 FROM a
 ----
 project
- ├── columns: column6:6(bool!null)
+ ├── columns: "((k = 1) OR true) OR (f = 3.5)":6(bool!null)
  ├── scan a
  └── projections
       └── true [type=bool]
@@ -177,7 +177,7 @@ opt
 SELECT false OR k=1 FROM a
 ----
 project
- ├── columns: column6:6(bool)
+ ├── columns: "false OR (k = 1)":6(bool)
  ├── scan a
  │    ├── columns: k:1(int!null)
  │    └── keys: (1)
@@ -245,7 +245,7 @@ opt
 SELECT (k=1 OR false) AND (false OR k=2 OR false) AND true FROM a
 ----
 project
- ├── columns: column6:6(bool)
+ ├── columns: "(((k = 1) OR false) AND ((false OR (k = 2)) OR false)) AND true":6(bool)
  ├── scan a
  │    ├── columns: k:1(int!null)
  │    └── keys: (1)
@@ -263,7 +263,7 @@ opt
 SELECT (k=1 OR (i=2 OR f=3.5)) AND (s='foo' AND s<>'bar') FROM a
 ----
 project
- ├── columns: column6:6(bool)
+ ├── columns: "((k = 1) OR ((i = 2) OR (f = 3.5))) AND ((s = 'foo') AND (s != 'bar'))":6(bool)
  ├── scan a
  │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string)
  │    └── keys: (1)
@@ -325,7 +325,7 @@ opt
 SELECT null and null FROM a
 ----
 project
- ├── columns: column6:6(bool)
+ ├── columns: "NULL AND NULL":6(bool)
  ├── scan a
  └── projections
       └── null [type=bool, constraints=(contradiction; tight)]
@@ -334,7 +334,7 @@ opt
 SELECT null or null FROM a
 ----
 project
- ├── columns: column6:6(bool)
+ ├── columns: "NULL OR NULL":6(bool)
  ├── scan a
  └── projections
       └── null [type=bool, constraints=(contradiction; tight)]
@@ -343,7 +343,7 @@ opt
 SELECT null or (null and null and null) or null FROM a
 ----
 project
- ├── columns: column6:6(bool)
+ ├── columns: "(NULL OR ((NULL AND NULL) AND NULL)) OR NULL":6(bool)
  ├── scan a
  └── projections
       └── null [type=bool, constraints=(contradiction; tight)]
@@ -353,7 +353,7 @@ opt
 SELECT null or (null and k=1) FROM a
 ----
 project
- ├── columns: column6:6(bool)
+ ├── columns: "NULL OR (NULL AND (k = 1))":6(bool)
  ├── scan a
  │    ├── columns: k:1(int!null)
  │    └── keys: (1)

--- a/pkg/sql/opt/norm/testdata/rules/combo
+++ b/pkg/sql/opt/norm/testdata/rules/combo
@@ -801,7 +801,7 @@ Initial expression
   Cost: 2000.00
 ================================================================================
   project
-   ├── columns: column8:8(bool)
+   ├── columns: "x = ANY (SELECT k FROM a)":8(bool)
    ├── scan xy
    │    ├── columns: x:1(int!null) y:2(int)
    │    └── keys: (1)
@@ -819,7 +819,7 @@ PruneScanCols
   Cost: 2000.00
 ================================================================================
    project
-    ├── columns: column8:8(bool)
+    ├── columns: "x = ANY (SELECT k FROM a)":8(bool)
     ├── scan xy
     │    ├── columns: x:1(int!null) y:2(int)
     │    └── keys: (1)
@@ -839,7 +839,7 @@ EliminateProject
   Cost: 2000.00
 ================================================================================
    project
-    ├── columns: column8:8(bool)
+    ├── columns: "x = ANY (SELECT k FROM a)":8(bool)
     ├── scan xy
     │    ├── columns: x:1(int!null) y:2(int)
     │    └── keys: (1)
@@ -859,7 +859,7 @@ HoistProjectSubquery
   Cost: 2020.01
 ================================================================================
    project
-    ├── columns: column8:8(bool)
+    ├── columns: "x = ANY (SELECT k FROM a)":8(bool)
   - ├── scan xy
   - │    ├── columns: x:1(int!null) y:2(int)
   - │    └── keys: (1)
@@ -929,7 +929,7 @@ EnsureSelectFilters
   Cost: 2020.01
 ================================================================================
    project
-    ├── columns: column8:8(bool)
+    ├── columns: "x = ANY (SELECT k FROM a)":8(bool)
     ├── inner-join-apply
     │    ├── columns: x:1(int!null) y:2(int) case:11(bool)
     │    ├── keys: (1)
@@ -996,7 +996,7 @@ TryDecorrelateProject
   Cost: 2030.01
 ================================================================================
    project
-    ├── columns: column8:8(bool)
+    ├── columns: "x = ANY (SELECT k FROM a)":8(bool)
   - ├── inner-join-apply
   + ├── select
     │    ├── columns: x:1(int!null) y:2(int) case:11(bool)
@@ -1093,7 +1093,7 @@ TryDecorrelateScalarGroupBy
   Cost: 2036.66
 ================================================================================
    project
-    ├── columns: column8:8(bool)
+    ├── columns: "x = ANY (SELECT k FROM a)":8(bool)
     ├── select
     │    ├── columns: x:1(int!null) y:2(int) case:11(bool)
     │    ├── keys: (1)
@@ -1191,7 +1191,7 @@ TryDecorrelateProjectSelect
   Cost: 2033.33
 ================================================================================
    project
-    ├── columns: column8:8(bool)
+    ├── columns: "x = ANY (SELECT k FROM a)":8(bool)
     ├── select
     │    ├── columns: x:1(int!null) y:2(int) case:11(bool)
     │    ├── keys: (1)
@@ -1283,7 +1283,7 @@ DecorrelateJoin
   Cost: 2033.33
 ================================================================================
    project
-    ├── columns: column8:8(bool)
+    ├── columns: "x = ANY (SELECT k FROM a)":8(bool)
     ├── select
     │    ├── columns: x:1(int!null) y:2(int) case:11(bool)
     │    ├── keys: (1)
@@ -1351,7 +1351,7 @@ EliminateGroupByProject
   Cost: 2033.33
 ================================================================================
    project
-    ├── columns: column8:8(bool)
+    ├── columns: "x = ANY (SELECT k FROM a)":8(bool)
     ├── select
     │    ├── columns: x:1(int!null) y:2(int) case:11(bool)
     │    ├── keys: (1)
@@ -1439,7 +1439,7 @@ EliminateSelect
   Cost: 2030.00
 ================================================================================
    project
-    ├── columns: column8:8(bool)
+    ├── columns: "x = ANY (SELECT k FROM a)":8(bool)
     ├── select
     │    ├── columns: x:1(int!null) y:2(int) case:11(bool)
     │    ├── keys: (1)
@@ -1532,7 +1532,7 @@ EliminateSelect
   Cost: 2020.00
 ================================================================================
    project
-    ├── columns: column8:8(bool)
+    ├── columns: "x = ANY (SELECT k FROM a)":8(bool)
   - ├── select
   - │    ├── columns: x:1(int!null) y:2(int) case:11(bool)
   + ├── project
@@ -1640,7 +1640,7 @@ PruneProjectCols
   Cost: 2020.00
 ================================================================================
    project
-    ├── columns: column8:8(bool)
+    ├── columns: "x = ANY (SELECT k FROM a)":8(bool)
     ├── project
   - │    ├── columns: case:11(bool) x:1(int!null) y:2(int)
   - │    ├── keys: (1)
@@ -1699,7 +1699,7 @@ PruneAggCols
   Cost: 2020.00
 ================================================================================
    project
-    ├── columns: column8:8(bool)
+    ├── columns: "x = ANY (SELECT k FROM a)":8(bool)
     ├── project
     │    ├── columns: case:11(bool)
     │    ├── group-by
@@ -1759,7 +1759,7 @@ PruneGroupByCols
   Cost: 2020.00
 ================================================================================
    project
-    ├── columns: column8:8(bool)
+    ├── columns: "x = ANY (SELECT k FROM a)":8(bool)
     ├── project
     │    ├── columns: case:11(bool)
     │    ├── group-by
@@ -1836,7 +1836,7 @@ PruneJoinLeftCols
   Cost: 2020.00
 ================================================================================
    project
-    ├── columns: column8:8(bool)
+    ├── columns: "x = ANY (SELECT k FROM a)":8(bool)
     ├── project
     │    ├── columns: case:11(bool)
     │    ├── group-by
@@ -1894,7 +1894,7 @@ EliminateProject
   Cost: 2020.00
 ================================================================================
    project
-    ├── columns: column8:8(bool)
+    ├── columns: "x = ANY (SELECT k FROM a)":8(bool)
     ├── project
     │    ├── columns: case:11(bool)
     │    ├── group-by
@@ -1970,7 +1970,7 @@ InlineProjectInProject
   Cost: 2020.00
 ================================================================================
    project
-    ├── columns: column8:8(bool)
+    ├── columns: "x = ANY (SELECT k FROM a)":8(bool)
   - ├── project
   - │    ├── columns: case:11(bool)
   - │    ├── group-by
@@ -2070,7 +2070,7 @@ GenerateIndexScans (no changes)
 GenerateIndexScans (higher cost)
 --------------------------------------------------------------------------------
    project
-    ├── columns: column8:8(bool)
+    ├── columns: "x = ANY (SELECT k FROM a)":8(bool)
     ├── group-by
     │    ├── columns: x:1(int!null) bool_or:10(bool)
     │    ├── grouping columns: x:1(int!null)
@@ -2121,7 +2121,7 @@ Final best expression
   Cost: 2020.00
 ================================================================================
   project
-   ├── columns: column8:8(bool)
+   ├── columns: "x = ANY (SELECT k FROM a)":8(bool)
    ├── group-by
    │    ├── columns: x:1(int!null) bool_or:10(bool)
    │    ├── grouping columns: x:1(int!null)

--- a/pkg/sql/opt/norm/testdata/rules/comp
+++ b/pkg/sql/opt/norm/testdata/rules/comp
@@ -382,7 +382,7 @@ opt
 SELECT NULL IS NULL
 ----
 project
- ├── columns: column1:1(bool!null)
+ ├── columns: "NULL IS NULL":1(bool!null)
  ├── cardinality: [1 - 1]
  ├── values
  │    ├── cardinality: [1 - 1]
@@ -397,7 +397,7 @@ opt
 SELECT 1 IS NULL
 ----
 project
- ├── columns: column1:1(bool!null)
+ ├── columns: "1 IS NULL":1(bool!null)
  ├── cardinality: [1 - 1]
  ├── values
  │    ├── cardinality: [1 - 1]
@@ -412,7 +412,7 @@ opt
 SELECT NULL IS NOT NULL, NULL IS NOT TRUE
 ----
 project
- ├── columns: column1:1(bool!null) column2:2(bool!null)
+ ├── columns: "NULL IS NOT NULL":1(bool!null) "NULL IS NOT true":2(bool!null)
  ├── cardinality: [1 - 1]
  ├── values
  │    ├── cardinality: [1 - 1]
@@ -431,7 +431,7 @@ opt
 SELECT 1 IS NOT NULL, k IS NOT NULL, i IS NOT NULL from a
 ----
 project
- ├── columns: column6:6(bool!null) column7:7(bool) column8:8(bool)
+ ├── columns: "1 IS NOT NULL":6(bool!null) "k IS NOT NULL":7(bool) "i IS NOT NULL":8(bool)
  ├── scan a
  │    ├── columns: k:1(int!null) i:2(int)
  │    └── keys: (1)
@@ -451,7 +451,7 @@ opt
 SELECT NULL IS NOT TRUE, NULL IS TRUE
 ----
 project
- ├── columns: column1:1(bool!null) column2:2(bool!null)
+ ├── columns: "NULL IS NOT true":1(bool!null) "NULL IS true":2(bool!null)
  ├── cardinality: [1 - 1]
  ├── values
  │    ├── cardinality: [1 - 1]

--- a/pkg/sql/opt/norm/testdata/rules/decorrelate
+++ b/pkg/sql/opt/norm/testdata/rules/decorrelate
@@ -265,7 +265,7 @@ opt
 SELECT 5=ANY(SELECT y FROM xy WHERE x=k) FROM a
 ----
 project
- ├── columns: column8:8(bool)
+ ├── columns: "5 = ANY (SELECT y FROM xy WHERE x = k)":8(bool)
  ├── group-by
  │    ├── columns: k:1(int!null) bool_or:10(bool)
  │    ├── grouping columns: k:1(int!null)
@@ -322,16 +322,16 @@ project
  ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
  ├── keys: (1)
  └── select
-      ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb) x:6(int) column8:8(int!null)
+      ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb) x:6(int) "y + 1":8(int!null)
       ├── keys: (1)
       ├── left-join
-      │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb) x:6(int) column8:8(int)
+      │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb) x:6(int) "y + 1":8(int)
       │    ├── keys: (1)
       │    ├── scan a
       │    │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
       │    │    └── keys: (1)
       │    ├── project
-      │    │    ├── columns: column8:8(int) x:6(int!null)
+      │    │    ├── columns: "y + 1":8(int) x:6(int!null)
       │    │    ├── cardinality: [0 - 1]
       │    │    ├── keys: (6)
       │    │    ├── scan xy
@@ -348,7 +348,7 @@ project
       │              └── variable: a.k [type=int, outer=(1)]
       └── filters [type=bool, outer=(8), constraints=(/8: [/11 - ]; tight)]
            └── gt [type=bool, outer=(8), constraints=(/8: [/11 - ]; tight)]
-                ├── variable: column8 [type=int, outer=(8)]
+                ├── variable: y + 1 [type=int, outer=(8)]
                 └── const: 10 [type=int]
 
 # Any clause with constant.
@@ -356,7 +356,7 @@ opt
 SELECT 5=ANY(SELECT y FROM xy WHERE x=k) FROM a
 ----
 project
- ├── columns: column8:8(bool)
+ ├── columns: "5 = ANY (SELECT y FROM xy WHERE x = k)":8(bool)
  ├── group-by
  │    ├── columns: k:1(int!null) bool_or:10(bool)
  │    ├── grouping columns: k:1(int!null)
@@ -410,7 +410,7 @@ opt
 SELECT i=ANY(SELECT y FROM xy WHERE x=k) FROM a
 ----
 project
- ├── columns: column8:8(bool)
+ ├── columns: "i = ANY (SELECT y FROM xy WHERE x = k)":8(bool)
  ├── group-by
  │    ├── columns: k:1(int!null) i:2(int) bool_or:10(bool)
  │    ├── grouping columns: k:1(int!null)
@@ -466,7 +466,7 @@ opt
 SELECT i*i/5=ANY(SELECT y FROM xy WHERE x=k) FROM a
 ----
 project
- ├── columns: column8:8(bool)
+ ├── columns: "((i * i) / 5) = ANY (SELECT y FROM xy WHERE x = k)":8(bool)
  ├── group-by
  │    ├── columns: k:1(int!null) scalar:9(decimal) bool_or:11(bool)
  │    ├── grouping columns: k:1(int!null)
@@ -640,11 +640,11 @@ semi-join-apply
  │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
  │    └── keys: (1)
  ├── select
- │    ├── columns: x:6(int!null) y:7(int) column10:10(decimal) cnt:11(int!null)
+ │    ├── columns: x:6(int!null) y:7(int) sum:10(decimal) cnt:11(int!null)
  │    ├── outer: (2)
  │    ├── keys: (6)
  │    ├── group-by
- │    │    ├── columns: x:6(int!null) y:7(int) column10:10(decimal) cnt:11(int)
+ │    │    ├── columns: x:6(int!null) y:7(int) sum:10(decimal) cnt:11(int)
  │    │    ├── grouping columns: x:6(int!null)
  │    │    ├── outer: (2)
  │    │    ├── keys: (6)
@@ -678,21 +678,21 @@ opt
 SELECT * FROM (SELECT i, 'foo' FROM a) WHERE 5=(SELECT MAX(y) FROM xy WHERE x=i)
 ----
 project
- ├── columns: i:2(int) column6:6(string)
+ ├── columns: i:2(int) "'foo'":6(string)
  └── select
-      ├── columns: i:2(int) column6:6(string) column9:9(int!null) rownum:10(int!null)
+      ├── columns: i:2(int) "'foo'":6(string) max:9(int!null) rownum:10(int!null)
       ├── keys: (10)
       ├── group-by
-      │    ├── columns: i:2(int) column6:6(string) column9:9(int) rownum:10(int!null)
+      │    ├── columns: i:2(int) "'foo'":6(string) max:9(int) rownum:10(int!null)
       │    ├── grouping columns: rownum:10(int!null)
       │    ├── keys: (10)
       │    ├── left-join
-      │    │    ├── columns: i:2(int) column6:6(string!null) x:7(int) y:8(int) rownum:10(int!null)
+      │    │    ├── columns: i:2(int) "'foo'":6(string!null) x:7(int) y:8(int) rownum:10(int!null)
       │    │    ├── row-number
-      │    │    │    ├── columns: i:2(int) column6:6(string!null) rownum:10(int!null)
+      │    │    │    ├── columns: i:2(int) "'foo'":6(string!null) rownum:10(int!null)
       │    │    │    ├── keys: (10)
       │    │    │    └── project
-      │    │    │         ├── columns: column6:6(string!null) i:2(int)
+      │    │    │         ├── columns: "'foo'":6(string!null) i:2(int)
       │    │    │         ├── scan a
       │    │    │         │    └── columns: i:2(int)
       │    │    │         └── projections [outer=(2)]
@@ -710,10 +710,10 @@ project
       │         ├── any-not-null [type=int, outer=(2)]
       │         │    └── variable: a.i [type=int, outer=(2)]
       │         └── any-not-null [type=string, outer=(6)]
-      │              └── variable: column6 [type=string, outer=(6)]
+      │              └── variable: 'foo' [type=string, outer=(6)]
       └── filters [type=bool, outer=(9), constraints=(/9: [/5 - /5]; tight)]
            └── eq [type=bool, outer=(9), constraints=(/9: [/5 - /5]; tight)]
-                ├── variable: column9 [type=int, outer=(9)]
+                ├── variable: max [type=int, outer=(9)]
                 └── const: 5 [type=int]
 
 # Don't decorrelate when agg function that doesn't ignore nulls is used.
@@ -724,17 +724,17 @@ project
  ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
  ├── keys: (1)
  └── inner-join-apply
-      ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb) column9:9(string!null)
+      ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb) concat_agg:9(string!null)
       ├── keys: (1)
       ├── scan a
       │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
       │    └── keys: (1)
       ├── select
-      │    ├── columns: column9:9(string!null)
+      │    ├── columns: concat_agg:9(string!null)
       │    ├── outer: (1)
       │    ├── cardinality: [0 - 1]
       │    ├── group-by
-      │    │    ├── columns: column9:9(string)
+      │    │    ├── columns: concat_agg:9(string)
       │    │    ├── outer: (1)
       │    │    ├── cardinality: [1 - 1]
       │    │    ├── project
@@ -759,7 +759,7 @@ project
       │    │              └── variable: column8 [type=string, outer=(8)]
       │    └── filters [type=bool, outer=(9), constraints=(/9: [/'foo' - /'foo']; tight)]
       │         └── eq [type=bool, outer=(9), constraints=(/9: [/'foo' - /'foo']; tight)]
-      │              ├── variable: column9 [type=string, outer=(9)]
+      │              ├── variable: concat_agg [type=string, outer=(9)]
       │              └── const: 'foo' [type=string]
       └── true [type=bool]
 
@@ -1105,16 +1105,16 @@ project
  ├── columns: k:1(int!null) i:2(int!null) f:3(float) s:4(string) j:5(jsonb)
  ├── keys: (1)
  └── select
-      ├── columns: k:1(int!null) i:2(int!null) f:3(float) s:4(string) j:5(jsonb) column8:8(int!null) xy.y:10(int!null)
+      ├── columns: k:1(int!null) i:2(int!null) f:3(float) s:4(string) j:5(jsonb) count:8(int!null) xy.y:10(int!null)
       ├── keys: (1)
       ├── left-join-apply
-      │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb) column8:8(int!null) xy.y:10(int)
+      │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb) count:8(int!null) xy.y:10(int)
       │    ├── keys: (1)
       │    ├── select
-      │    │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb) column8:8(int!null)
+      │    │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb) count:8(int!null)
       │    │    ├── keys: (1)
       │    │    ├── group-by
-      │    │    │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb) column8:8(int)
+      │    │    │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb) count:8(int)
       │    │    │    ├── grouping columns: k:1(int!null)
       │    │    │    ├── keys: (1)
       │    │    │    ├── left-join
@@ -1141,7 +1141,7 @@ project
       │    │    │              └── variable: a.j [type=jsonb, outer=(5)]
       │    │    └── filters [type=bool, outer=(8), constraints=(/8: [/1 - ]; tight)]
       │    │         └── gt [type=bool, outer=(8), constraints=(/8: [/1 - ]; tight)]
-      │    │              ├── variable: column8 [type=int, outer=(8)]
+      │    │              ├── variable: count [type=int, outer=(8)]
       │    │              └── const: 0 [type=int]
       │    ├── limit
       │    │    ├── columns: xy.y:10(int!null)
@@ -1172,10 +1172,10 @@ project
  ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
  ├── keys: (1)
  └── select
-      ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb) column8:8(int)
+      ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb) count:8(int)
       ├── keys: (1)
       ├── group-by
-      │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb) column8:8(int)
+      │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb) count:8(int)
       │    ├── grouping columns: k:1(int!null)
       │    ├── keys: (1)
       │    ├── left-join
@@ -1208,7 +1208,7 @@ project
                 │    │    ├── const: 0 [type=int]
                 │    │    └── function: length [type=int, outer=(8)]
                 │    │         └── cast: string [type=string, outer=(8)]
-                │    │              └── variable: column8 [type=int, outer=(8)]
+                │    │              └── variable: count [type=int, outer=(8)]
                 │    └── tuple [type=tuple{int, int}]
                 │         ├── const: 0 [type=int]
                 │         └── const: 1 [type=int]
@@ -1336,7 +1336,7 @@ opt
 SELECT i*i/100 < ALL(SELECT y FROM xy), s FROM a
 ----
 project
- ├── columns: column8:8(bool) s:4(string)
+ ├── columns: "((i * i) / 100) < ALL (SELECT y FROM xy)":8(bool) s:4(string)
  ├── group-by
  │    ├── columns: k:1(int!null) s:4(string) scalar:9(decimal) bool_or:11(bool)
  │    ├── grouping columns: k:1(int!null)
@@ -1401,7 +1401,7 @@ opt
 SELECT (SELECT x FROM xy WHERE x=k) FROM a
 ----
 project
- ├── columns: column8:8(int)
+ ├── columns: "(SELECT x FROM xy WHERE x = k)":8(int)
  ├── left-join-apply
  │    ├── columns: k:1(int!null) x:6(int)
  │    ├── keys: (1)
@@ -1440,9 +1440,9 @@ SELECT
 FROM a
 ----
 project
- ├── columns: column6:6(int!null) column9:9(int) column12:12(int) column15:15(bool) column18:18(bool) column22:22(int)
+ ├── columns: "5":6(int!null) "(SELECT x FROM xy WHERE x = k)":9(int) "(SELECT y FROM xy LIMIT 1)":12(int) "5 IN (SELECT y FROM xy)":15(bool) "EXISTS (SELECT * FROM xy)":18(bool) "(SELECT count(*) FROM xy WHERE y = k)":22(int)
  ├── group-by
- │    ├── columns: k:1(int!null) xy.x:7(int) column21:21(int)
+ │    ├── columns: k:1(int!null) xy.x:7(int) count:21(int)
  │    ├── grouping columns: k:1(int!null)
  │    ├── keys: (1)
  │    ├── left-join
@@ -1496,14 +1496,14 @@ project
       │    └── scan xy
       │         ├── columns: xy.x:16(int!null) xy.y:17(int)
       │         └── keys: (16)
-      └── variable: column21 [type=int, outer=(21)]
+      └── variable: count [type=int, outer=(21)]
 
 # Subquery in GroupBy aggregate (optbuilder creates correlated Project).
 opt
 SELECT MAX((SELECT y FROM xy WHERE y=i)) FROM a
 ----
 group-by
- ├── columns: column9:9(int)
+ ├── columns: max:9(int)
  ├── cardinality: [1 - 1]
  ├── project
  │    ├── columns: column8:8(int)
@@ -1536,7 +1536,7 @@ opt
 SELECT EXISTS(SELECT * FROM xy WHERE y=i) FROM a
 ----
 project
- ├── columns: column8:8(bool)
+ ├── columns: "EXISTS (SELECT * FROM xy WHERE y = i)":8(bool)
  ├── group-by
  │    ├── columns: k:1(int!null) exists_agg:10(bool)
  │    ├── grouping columns: k:1(int!null)
@@ -1567,7 +1567,7 @@ opt
 SELECT 5 < ANY(SELECT y FROM xy WHERE y=i) FROM a
 ----
 project
- ├── columns: column8:8(bool)
+ ├── columns: "5 < ANY (SELECT y FROM xy WHERE y = i)":8(bool)
  ├── group-by
  │    ├── columns: k:1(int!null) bool_or:10(bool)
  │    ├── grouping columns: k:1(int!null)
@@ -1787,7 +1787,7 @@ opt
 SELECT (VALUES ((SELECT i+1)), (10), ((SELECT k+1))) FROM a
 ----
 project
- ├── columns: column9:9(int)
+ ├── columns: "(VALUES ((SELECT i + 1)), (10), ((SELECT k + 1)))":9(int)
  ├── inner-join-apply
  │    ├── columns: k:1(int!null) i:2(int) column1:8(int)
  │    ├── keys: (1)
@@ -1803,11 +1803,11 @@ project
  │    │         ├── outer: (1,2)
  │    │         ├── cardinality: [3 - 3]
  │    │         └── inner-join-apply
- │    │              ├── columns: column6:6(int) column7:7(int) column1:8(int)
+ │    │              ├── columns: "i + 1":6(int) "k + 1":7(int) column1:8(int)
  │    │              ├── outer: (1,2)
  │    │              ├── cardinality: [3 - 3]
  │    │              ├── project
- │    │              │    ├── columns: column7:7(int) column6:6(int)
+ │    │              │    ├── columns: "k + 1":7(int) "i + 1":6(int)
  │    │              │    ├── outer: (1,2)
  │    │              │    ├── cardinality: [1 - 1]
  │    │              │    ├── values
@@ -1825,11 +1825,11 @@ project
  │    │              │    ├── outer: (6,7)
  │    │              │    ├── cardinality: [3 - 3]
  │    │              │    ├── tuple [type=tuple{int}, outer=(6)]
- │    │              │    │    └── variable: column6 [type=int, outer=(6)]
+ │    │              │    │    └── variable: i + 1 [type=int, outer=(6)]
  │    │              │    ├── tuple [type=tuple{int}]
  │    │              │    │    └── const: 10 [type=int]
  │    │              │    └── tuple [type=tuple{int}, outer=(7)]
- │    │              │         └── variable: column7 [type=int, outer=(7)]
+ │    │              │         └── variable: k + 1 [type=int, outer=(7)]
  │    │              └── true [type=bool]
  │    └── true [type=bool]
  └── projections [outer=(8)]
@@ -1840,7 +1840,7 @@ opt
 SELECT (VALUES (EXISTS(SELECT * FROM xy WHERE x=k))) FROM a
 ----
 project
- ├── columns: column9:12(bool)
+ ├── columns: "(VALUES (EXISTS (SELECT * FROM xy WHERE x = k)))":12(bool)
  ├── left-join-apply
  │    ├── columns: k:1(int!null) column1:8(bool)
  │    ├── keys: (1)
@@ -1905,7 +1905,7 @@ opt
 SELECT (VALUES (5 IN (SELECT y FROM xy WHERE x=k))) FROM a
 ----
 project
- ├── columns: column9:13(bool)
+ ├── columns: "(VALUES (5 IN (SELECT y FROM xy WHERE x = k)))":13(bool)
  ├── left-join-apply
  │    ├── columns: k:1(int!null) column1:8(bool)
  │    ├── keys: (1)
@@ -2054,7 +2054,7 @@ semi-join
  │              ├── variable: a.i [type=int, outer=(2)]
  │              └── variable: xy.y [type=int, outer=(7)]
  ├── project
- │    ├── columns: column10:10(string)
+ │    ├── columns: "y::STRING":10(string)
  │    ├── scan xy
  │    │    └── columns: xy.y:9(int)
  │    └── projections [outer=(9)]
@@ -2063,7 +2063,7 @@ semi-join
  └── filters [type=bool, outer=(4,10), constraints=(/4: (/NULL - ]; /10: (/NULL - ])]
       └── eq [type=bool, outer=(4,10), constraints=(/4: (/NULL - ]; /10: (/NULL - ])]
            ├── variable: a.s [type=string, outer=(4)]
-           └── variable: column10 [type=string, outer=(10)]
+           └── variable: y::STRING [type=string, outer=(10)]
 
 # Don't hoist uncorrelated ANY (but rewrite it to EXISTS).
 opt
@@ -2198,7 +2198,7 @@ anti-join
  │              │    └── variable: xy.y [type=int, outer=(7)]
  │              └── false [type=bool]
  ├── project
- │    ├── columns: column10:10(string)
+ │    ├── columns: "y::STRING":10(string)
  │    ├── scan xy
  │    │    └── columns: xy.y:9(int)
  │    └── projections [outer=(9)]
@@ -2208,7 +2208,7 @@ anti-join
       └── is-not [type=bool, outer=(4,10)]
            ├── eq [type=bool, outer=(4,10), constraints=(/4: (/NULL - ]; /10: (/NULL - ])]
            │    ├── variable: a.s [type=string, outer=(4)]
-           │    └── variable: column10 [type=string, outer=(10)]
+           │    └── variable: y::STRING [type=string, outer=(10)]
            └── false [type=bool]
 
 # Don't hoist uncorrelated NOT ANY (but rewrite it to NOT EXISTS).
@@ -2308,7 +2308,7 @@ anti-join
  │              ├── variable: a.i [type=int, outer=(2)]
  │              └── variable: xy.y [type=int, outer=(7)]
  ├── project
- │    ├── columns: column10:10(string)
+ │    ├── columns: "y::STRING":10(string)
  │    ├── scan xy
  │    │    └── columns: xy.y:9(int)
  │    └── projections [outer=(9)]
@@ -2318,5 +2318,5 @@ anti-join
       └── is-not [type=bool, outer=(4,10)]
            ├── eq [type=bool, outer=(4,10), constraints=(/4: (/NULL - ]; /10: (/NULL - ])]
            │    ├── variable: a.s [type=string, outer=(4)]
-           │    └── variable: column10 [type=string, outer=(10)]
+           │    └── variable: y::STRING [type=string, outer=(10)]
            └── false [type=bool]

--- a/pkg/sql/opt/norm/testdata/rules/groupby
+++ b/pkg/sql/opt/norm/testdata/rules/groupby
@@ -91,7 +91,7 @@ opt
 SELECT s, i, SUM(i) FROM a GROUP BY s, i
 ----
 group-by
- ├── columns: s:4(string!null) i:2(int!null) column6:6(decimal)
+ ├── columns: s:4(string!null) i:2(int!null) sum:6(decimal)
  ├── grouping columns: i:2(int!null) s:4(string!null)
  ├── keys: (2,4)
  ├── scan a
@@ -108,9 +108,9 @@ opt
 SELECT MIN(s) FROM (SELECT i, s FROM (SELECT * FROM a UNION SELECT * FROM a)) GROUP BY i
 ----
 project
- ├── columns: column16:16(string)
+ ├── columns: min:16(string)
  └── group-by
-      ├── columns: i:12(int!null) column16:16(string)
+      ├── columns: i:12(int!null) min:16(string)
       ├── grouping columns: i:12(int!null)
       ├── keys: (12)
       ├── union
@@ -132,9 +132,9 @@ opt
 SELECT MIN(s) FROM (SELECT i+1 AS i2, s FROM a) GROUP BY i2
 ----
 project
- ├── columns: column7:7(string)
+ ├── columns: min:7(string)
  └── group-by
-      ├── columns: i2:6(int) column7:7(string)
+      ├── columns: i2:6(int) min:7(string)
       ├── grouping columns: i2:6(int)
       ├── keys: weak(6)
       ├── project

--- a/pkg/sql/opt/norm/testdata/rules/inline
+++ b/pkg/sql/opt/norm/testdata/rules/inline
@@ -171,7 +171,7 @@ opt
 SELECT expr, i+1 FROM (SELECT k=1 AS expr, i FROM a)
 ----
 project
- ├── columns: expr:6(bool) column7:7(int)
+ ├── columns: expr:6(bool) "i + 1":7(int)
  ├── scan a
  │    ├── columns: k:1(int!null) i:2(int)
  │    └── keys: (1)
@@ -188,7 +188,7 @@ opt
 SELECT expr+1, i, expr2 || 'bar' FROM (SELECT k+1 AS expr, s || 'foo' AS expr2, i FROM a)
 ----
 project
- ├── columns: column8:8(int) i:2(int) column9:9(string)
+ ├── columns: "expr + 1":8(int) i:2(int) "expr2 || 'bar'":9(string)
  ├── scan a
  │    ├── columns: k:1(int!null) i:2(int) s:4(string)
  │    └── keys: (1)
@@ -209,7 +209,7 @@ opt
 SELECT expr, expr*2 FROM (SELECT k+1 AS expr FROM a)
 ----
 project
- ├── columns: expr:6(int) column7:7(int)
+ ├── columns: expr:6(int) "expr * 2":7(int)
  ├── project
  │    ├── columns: expr:6(int)
  │    ├── scan a
@@ -229,7 +229,7 @@ opt
 SELECT EXISTS(SELECT * FROM xy WHERE x=1 OR x=2), expr*2 FROM (SELECT k+1 AS expr FROM a)
 ----
 project
- ├── columns: column9:9(bool) column10:10(int)
+ ├── columns: "EXISTS (SELECT * FROM xy WHERE (x = 1) OR (x = 2))":9(bool) "expr * 2":10(int)
  ├── scan a
  │    ├── columns: k:1(int!null)
  │    └── keys: (1)
@@ -250,7 +250,7 @@ opt
 SELECT EXISTS(SELECT * FROM xy WHERE expr<0) FROM (SELECT k+1 AS expr FROM a)
 ----
 project
- ├── columns: column9:9(bool)
+ ├── columns: "EXISTS (SELECT * FROM xy WHERE expr < 0)":9(bool)
  ├── group-by
  │    ├── columns: exists_agg:11(bool) rownum:12(int!null)
  │    ├── grouping columns: rownum:12(int!null)

--- a/pkg/sql/opt/norm/testdata/rules/join
+++ b/pkg/sql/opt/norm/testdata/rules/join
@@ -445,13 +445,13 @@ opt
 SELECT * FROM a LEFT JOIN (SELECT COUNT(*) FROM b) ON True
 ----
 inner-join
- ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb) column8:8(int)
+ ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb) count:8(int)
  ├── keys: (1)
  ├── scan a
  │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
  │    └── keys: (1)
  ├── group-by
- │    ├── columns: column8:8(int)
+ │    ├── columns: count:8(int)
  │    ├── cardinality: [1 - 1]
  │    ├── scan b
  │    └── aggregations
@@ -463,14 +463,14 @@ opt
 SELECT * FROM a FULL JOIN (SELECT COUNT(*) FROM b) ON True
 ----
 right-join
- ├── columns: k:1(int) i:2(int) f:3(float) s:4(string) j:5(jsonb) column8:8(int)
+ ├── columns: k:1(int) i:2(int) f:3(float) s:4(string) j:5(jsonb) count:8(int)
  ├── cardinality: [1 - ]
  ├── keys: weak(1)
  ├── scan a
  │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
  │    └── keys: (1)
  ├── group-by
- │    ├── columns: column8:8(int)
+ │    ├── columns: count:8(int)
  │    ├── cardinality: [1 - 1]
  │    ├── scan b
  │    └── aggregations
@@ -485,10 +485,10 @@ project
  ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
  ├── keys: (1)
  └── select
-      ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb) column7:7(decimal!null)
+      ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb) sum:7(decimal!null)
       ├── keys: (1)
       ├── group-by
-      │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb) column7:7(decimal)
+      │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb) sum:7(decimal)
       │    ├── grouping columns: k:1(int!null)
       │    ├── keys: (1)
       │    ├── inner-join-apply
@@ -518,7 +518,7 @@ project
       │              └── variable: a.j [type=jsonb, outer=(5)]
       └── filters [type=bool, outer=(7), constraints=(/7: [/1 - /1]; tight)]
            └── eq [type=bool, outer=(7), constraints=(/7: [/1 - /1]; tight)]
-                ├── variable: column7 [type=decimal, outer=(7)]
+                ├── variable: sum [type=decimal, outer=(7)]
                 └── const: 1 [type=decimal]
 
 # Don't simplify right join
@@ -526,14 +526,14 @@ opt
 SELECT * FROM a RIGHT JOIN (SELECT COUNT(*) FROM b) ON True
 ----
 right-join
- ├── columns: k:1(int) i:2(int) f:3(float) s:4(string) j:5(jsonb) column8:8(int)
+ ├── columns: k:1(int) i:2(int) f:3(float) s:4(string) j:5(jsonb) count:8(int)
  ├── cardinality: [1 - ]
  ├── keys: weak(1)
  ├── scan a
  │    ├── columns: k:1(int!null) i:2(int) f:3(float) s:4(string) j:5(jsonb)
  │    └── keys: (1)
  ├── group-by
- │    ├── columns: column8:8(int)
+ │    ├── columns: count:8(int)
  │    ├── cardinality: [1 - 1]
  │    ├── scan b
  │    └── aggregations
@@ -547,10 +547,10 @@ opt
 SELECT * FROM (SELECT COUNT(*) FROM b) RIGHT JOIN a ON True
 ----
 inner-join
- ├── columns: column3:3(int) k:4(int!null) i:5(int) f:6(float) s:7(string) j:8(jsonb)
+ ├── columns: count:3(int) k:4(int!null) i:5(int) f:6(float) s:7(string) j:8(jsonb)
  ├── keys: (4)
  ├── group-by
- │    ├── columns: column3:3(int)
+ │    ├── columns: count:3(int)
  │    ├── cardinality: [1 - 1]
  │    ├── scan b
  │    └── aggregations
@@ -565,11 +565,11 @@ opt
 SELECT * FROM (SELECT COUNT(*) FROM b) FULL JOIN a ON True
 ----
 left-join
- ├── columns: column3:3(int) k:4(int) i:5(int) f:6(float) s:7(string) j:8(jsonb)
+ ├── columns: count:3(int) k:4(int) i:5(int) f:6(float) s:7(string) j:8(jsonb)
  ├── cardinality: [1 - ]
  ├── keys: weak(4)
  ├── group-by
- │    ├── columns: column3:3(int)
+ │    ├── columns: count:3(int)
  │    ├── cardinality: [1 - 1]
  │    ├── scan b
  │    └── aggregations
@@ -584,11 +584,11 @@ opt
 SELECT * FROM (SELECT COUNT(*) FROM b) LEFT JOIN a ON True
 ----
 left-join
- ├── columns: column3:3(int) k:4(int) i:5(int) f:6(float) s:7(string) j:8(jsonb)
+ ├── columns: count:3(int) k:4(int) i:5(int) f:6(float) s:7(string) j:8(jsonb)
  ├── cardinality: [1 - ]
  ├── keys: weak(4)
  ├── group-by
- │    ├── columns: column3:3(int)
+ │    ├── columns: count:3(int)
  │    ├── cardinality: [1 - 1]
  │    ├── scan b
  │    └── aggregations

--- a/pkg/sql/opt/norm/testdata/rules/limit
+++ b/pkg/sql/opt/norm/testdata/rules/limit
@@ -93,7 +93,7 @@ opt
 SELECT k, f*2.0 FROM a LIMIT 5
 ----
 project
- ├── columns: k:1(int!null) column6:6(float)
+ ├── columns: k:1(int!null) "f * 2.0":6(float)
  ├── cardinality: [0 - 5]
  ├── keys: (1)
  ├── scan a
@@ -110,7 +110,7 @@ opt
 SELECT f, f+1.1 FROM (SELECT f, i FROM a GROUP BY f, i) a ORDER BY f LIMIT 5
 ----
 project
- ├── columns: f:3(float) column6:6(float)
+ ├── columns: f:3(float) "f + 1.1":6(float)
  ├── cardinality: [0 - 5]
  ├── ordering: +3
  ├── limit
@@ -167,7 +167,7 @@ opt
 SELECT k, f*2.0 FROM a OFFSET 5
 ----
 project
- ├── columns: k:1(int!null) column6:6(float)
+ ├── columns: k:1(int!null) "f * 2.0":6(float)
  ├── keys: (1)
  ├── offset
  │    ├── columns: k:1(int!null) f:3(float)
@@ -186,7 +186,7 @@ opt
 SELECT f, f+1.1 FROM (SELECT f, i FROM a GROUP BY f, i) a ORDER BY f OFFSET 5
 ----
 project
- ├── columns: f:3(float) column6:6(float)
+ ├── columns: f:3(float) "f + 1.1":6(float)
  ├── ordering: +3
  ├── offset
  │    ├── columns: i:2(int) f:3(float)
@@ -215,7 +215,7 @@ opt
 SELECT k, f*2.0 FROM a OFFSET 5 LIMIT 10
 ----
 project
- ├── columns: k:1(int!null) column6:6(float)
+ ├── columns: k:1(int!null) "f * 2.0":6(float)
  ├── cardinality: [0 - 10]
  ├── keys: (1)
  ├── limit
@@ -239,7 +239,7 @@ opt
 SELECT f, f+1.1 FROM (SELECT f, i FROM a GROUP BY f, i) a ORDER BY f OFFSET 5 LIMIT 10
 ----
 project
- ├── columns: f:3(float) column6:6(float)
+ ├── columns: f:3(float) "f + 1.1":6(float)
  ├── cardinality: [0 - 10]
  ├── ordering: +3
  ├── limit

--- a/pkg/sql/opt/norm/testdata/rules/max1row
+++ b/pkg/sql/opt/norm/testdata/rules/max1row
@@ -26,7 +26,7 @@ opt
 SELECT (SELECT i FROM a LIMIT 1) > 5
 ----
 project
- ├── columns: column6:6(bool)
+ ├── columns: "(SELECT i FROM a LIMIT 1) > 5":6(bool)
  ├── cardinality: [1 - 1]
  ├── values
  │    ├── cardinality: [1 - 1]
@@ -43,7 +43,7 @@ opt
 SELECT (SELECT COUNT(*) FROM a) > 100
 ----
 project
- ├── columns: column7:7(bool)
+ ├── columns: "(SELECT count(*) FROM a) > 100":7(bool)
  ├── cardinality: [1 - 1]
  ├── values
  │    ├── cardinality: [1 - 1]
@@ -52,7 +52,7 @@ project
       └── gt [type=bool]
            ├── subquery [type=int]
            │    └── group-by
-           │         ├── columns: column6:6(int)
+           │         ├── columns: count:6(int)
            │         ├── cardinality: [1 - 1]
            │         ├── scan a
            │         └── aggregations
@@ -63,7 +63,7 @@ opt
 SELECT (SELECT i FROM a LIMIT 0) > 5
 ----
 project
- ├── columns: column6:6(bool)
+ ├── columns: "(SELECT i FROM a LIMIT 0) > 5":6(bool)
  ├── cardinality: [1 - 1]
  ├── values
  │    ├── cardinality: [1 - 1]
@@ -84,7 +84,7 @@ opt
 SELECT (SELECT i FROM a) > 5
 ----
 project
- ├── columns: column6:6(bool)
+ ├── columns: "(SELECT i FROM a) > 5":6(bool)
  ├── cardinality: [1 - 1]
  ├── values
  │    ├── cardinality: [1 - 1]

--- a/pkg/sql/opt/norm/testdata/rules/numeric
+++ b/pkg/sql/opt/norm/testdata/rules/numeric
@@ -23,7 +23,7 @@ SELECT
 FROM a
 ----
 project
- ├── columns: column6:6(int) column7:7(int) column8:8(float) column9:9(float) column10:10(decimal) column11:11(decimal)
+ ├── columns: "(a.i + a.i) + 0":6(int) "0 + (a.i + a.i)":7(int) "(a.f + a.f) + 0":8(float) "0 + (a.f + a.f)":9(float) "(a.d + a.d) + 0":10(decimal) "0 + (a.d + a.d)":11(decimal)
  ├── scan a
  │    └── columns: i:2(int) f:3(float) d:4(decimal)
  └── projections [outer=(2-4)]
@@ -59,7 +59,7 @@ SELECT
 FROM a
 ----
 project
- ├── columns: column6:6(int) column7:7(float) column8:8(decimal)
+ ├── columns: "(a.i + a.i) - 0":6(int) "(a.f + a.f) - 0":7(float) "(a.d + a.d) - 0":8(decimal)
  ├── scan a
  │    └── columns: i:2(int) f:3(float) d:4(decimal)
  └── projections [outer=(2-4)]
@@ -86,7 +86,7 @@ SELECT
 FROM a
 ----
 project
- ├── columns: column6:6(int) column7:7(int) column8:8(float) column9:9(float) column10:10(decimal) column11:11(decimal)
+ ├── columns: "(a.i + a.i) * 1":6(int) "1 * (a.i + a.i)":7(int) "(a.f + a.f) * 1":8(float) "1 * (a.f + a.f)":9(float) "(a.d + a.d) * 1":10(decimal) "1 * (a.d + a.d)":11(decimal)
  ├── scan a
  │    └── columns: i:2(int) f:3(float) d:4(decimal)
  └── projections [outer=(2-4)]
@@ -121,7 +121,7 @@ SELECT
 FROM a
 ----
 project
- ├── columns: column6:6(decimal) column7:7(float) column8:8(decimal)
+ ├── columns: "a.i / 1":6(decimal) "a.f / 1":7(float) "a.d / 1":8(decimal)
  ├── scan a
  │    └── columns: i:2(int) f:3(float) d:4(decimal)
  └── projections [outer=(2-4)]
@@ -140,7 +140,7 @@ SELECT
 FROM a
 ----
 project
- ├── columns: column6:6(float) column7:7(decimal) column8:8(interval)
+ ├── columns: "-(a.f - a.f)":6(float) "-(a.d - a.i)":7(decimal) "-(a.t - a.t)":8(interval)
  ├── scan a
  │    └── columns: i:2(int) f:3(float) d:4(decimal) t:5(time)
  └── projections [outer=(2-5)]
@@ -161,7 +161,7 @@ opt
 SELECT -(-a.i::int) FROM a
 ----
 project
- ├── columns: column6:6(int)
+ ├── columns: "-(-a.i::INT)":6(int)
  ├── scan a
  │    └── columns: i:2(int)
  └── projections [outer=(2)]

--- a/pkg/sql/opt/norm/testdata/rules/project
+++ b/pkg/sql/opt/norm/testdata/rules/project
@@ -51,7 +51,7 @@ opt
 SELECT *, 1 FROM a
 ----
 project
- ├── columns: x:1(int!null) y:2(int) f:3(float) s:4(string) column5:5(int!null)
+ ├── columns: x:1(int!null) y:2(int) f:3(float) s:4(string) "1":5(int!null)
  ├── keys: (1)
  ├── scan a
  │    ├── columns: x:1(int!null) y:2(int) f:3(float) s:4(string)
@@ -67,7 +67,7 @@ opt
 SELECT y+1 FROM (SELECT a.y FROM a, b WHERE a.x=b.x) a
 ----
 project
- ├── columns: column7:7(int)
+ ├── columns: "y + 1":7(int)
  ├── inner-join
  │    ├── columns: a.x:1(int!null) y:2(int) b.x:5(int!null)
  │    ├── scan a

--- a/pkg/sql/opt/norm/testdata/rules/prune_cols
+++ b/pkg/sql/opt/norm/testdata/rules/prune_cols
@@ -35,7 +35,7 @@ opt
 SELECT 1 FROM (SELECT i+1, k FROM a) a
 ----
 project
- ├── columns: column6:6(int!null)
+ ├── columns: "1":6(int!null)
  ├── scan a
  └── projections
       └── const: 1 [type=int]
@@ -45,7 +45,7 @@ opt
 SELECT k+i FROM (SELECT i, k, s || 'foo' FROM a) a
 ----
 project
- ├── columns: column6:6(int)
+ ├── columns: "k + i":6(int)
  ├── scan a
  │    ├── columns: k:1(int!null) i:2(int)
  │    └── keys: (1)
@@ -73,7 +73,7 @@ opt
 SELECT l*l, k FROM (SELECT k, length(s) l, i FROM a) a
 ----
 project
- ├── columns: column6:6(int) k:1(int!null)
+ ├── columns: "l * l":6(int) k:1(int!null)
  ├── keys: (1)
  ├── project
  │    ├── columns: l:5(int) k:1(int!null)
@@ -106,7 +106,7 @@ opt
 SELECT k, k+1, i+1 FROM a
 ----
 project
- ├── columns: k:1(int!null) column5:5(int) column6:6(int)
+ ├── columns: k:1(int!null) "k + 1":5(int) "i + 1":6(int)
  ├── keys: (1)
  ├── scan a
  │    ├── columns: k:1(int!null) i:2(int)
@@ -124,7 +124,7 @@ opt
 SELECT k+i FROM a
 ----
 project
- ├── columns: column5:5(int)
+ ├── columns: "k + i":5(int)
  ├── scan a
  │    ├── columns: k:1(int!null) i:2(int)
  │    └── keys: (1)
@@ -138,7 +138,7 @@ opt
 SELECT 1 FROM a
 ----
 project
- ├── columns: column5:5(int!null)
+ ├── columns: "1":5(int!null)
  ├── scan a
  └── projections
       └── const: 1 [type=int]
@@ -186,7 +186,7 @@ opt
 SELECT 1 FROM a WHERE now()<'2000-01-01T02:00:00'::timestamp
 ----
 project
- ├── columns: column5:5(int!null)
+ ├── columns: "1":5(int!null)
  ├── select
  │    ├── scan a
  │    └── filters [type=bool]
@@ -201,7 +201,7 @@ opt
 SELECT i-1, k*k FROM a WHERE k+1<5 AND s||'o'='foo'
 ----
 project
- ├── columns: column5:5(int) column6:6(int)
+ ├── columns: "i - 1":5(int) "k * k":6(int)
  ├── select
  │    ├── columns: k:1(int!null) i:2(int) s:4(string)
  │    ├── keys: (1)
@@ -256,7 +256,7 @@ opt
 SELECT f, f+1.1 FROM (SELECT f, k FROM a GROUP BY f, k HAVING SUM(k)=100) a
 ----
 project
- ├── columns: f:3(float) column6:6(float)
+ ├── columns: f:3(float) "f + 1.1":6(float)
  ├── select
  │    ├── columns: k:1(int!null) f:3(float) column5:5(decimal!null)
  │    ├── keys: (1)
@@ -335,7 +335,7 @@ opt
 SELECT f, f*2.0 FROM (SELECT f, s FROM a GROUP BY f, s LIMIT 5) a
 ----
 project
- ├── columns: f:3(float) column5:5(float)
+ ├── columns: f:3(float) "f * 2.0":5(float)
  ├── cardinality: [0 - 5]
  ├── limit
  │    ├── columns: f:3(float) s:4(string)
@@ -511,7 +511,7 @@ opt
 SELECT f, f*2.0 FROM (SELECT f, s FROM a GROUP BY f, s OFFSET 5 LIMIT 5) a
 ----
 project
- ├── columns: f:3(float) column5:5(float)
+ ├── columns: f:3(float) "f * 2.0":5(float)
  ├── cardinality: [0 - 5]
  ├── limit
  │    ├── columns: f:3(float) s:4(string)
@@ -600,7 +600,7 @@ opt
 SELECT a.k+1, xy.* FROM a FULL JOIN xy ON True
 ----
 project
- ├── columns: column7:7(int) x:5(int) y:6(int)
+ ├── columns: "a.k + 1":7(int) x:5(int) y:6(int)
  ├── full-join
  │    ├── columns: k:1(int) x:5(int) y:6(int)
  │    ├── scan a
@@ -632,7 +632,7 @@ opt
 SELECT a.k+1, a.i/2, xy.* FROM a INNER JOIN xy ON a.k*a.k=xy.x AND a.s||'o'='foo'
 ----
 project
- ├── columns: column7:7(int) column8:8(decimal) x:5(int!null) y:6(int)
+ ├── columns: "a.k + 1":7(int) "a.i / 2":8(decimal) x:5(int!null) y:6(int)
  ├── inner-join
  │    ├── columns: k:1(int!null) i:2(int) s:4(string) x:5(int!null) y:6(int)
  │    ├── select
@@ -765,7 +765,7 @@ opt
 SELECT xy.*, a.k+1 FROM xy FULL JOIN a ON True
 ----
 project
- ├── columns: x:1(int) y:2(int) column7:7(int)
+ ├── columns: x:1(int) y:2(int) "a.k + 1":7(int)
  ├── full-join
  │    ├── columns: x:1(int) y:2(int) k:3(int)
  │    ├── scan xy
@@ -797,7 +797,7 @@ opt
 SELECT xy.*, a.k+1, a.i/2 FROM xy INNER JOIN a ON xy.x=a.k*a.k AND a.s||'o'='foo'
 ----
 project
- ├── columns: x:1(int!null) y:2(int) column7:7(int) column8:8(decimal)
+ ├── columns: x:1(int!null) y:2(int) "a.k + 1":7(int) "a.i / 2":8(decimal)
  ├── inner-join
  │    ├── columns: x:1(int!null) y:2(int) k:3(int!null) i:4(int) s:6(string)
  │    ├── scan xy
@@ -872,7 +872,7 @@ opt
 SELECT 1 FROM a,xy
 ----
 project
- ├── columns: column7:7(int!null)
+ ├── columns: "1":7(int!null)
  ├── inner-join
  │    ├── scan a
  │    ├── scan xy
@@ -885,14 +885,14 @@ opt
 SELECT a.k, xy.x, a.k+xy.x FROM a LEFT JOIN xy ON a.k=xy.x
 ----
 project
- ├── columns: k:1(int!null) x:5(int) column7:7(int)
+ ├── columns: k:1(int!null) x:5(int) "a.k + xy.x":7(int)
  ├── left-join
- │    ├── columns: k:1(int!null) x:5(int)
+ │    ├── columns: k:1(int!null) xy.x:5(int)
  │    ├── scan a
  │    │    ├── columns: k:1(int!null)
  │    │    └── keys: (1)
  │    ├── scan xy
- │    │    ├── columns: x:5(int!null)
+ │    │    ├── columns: xy.x:5(int!null)
  │    │    └── keys: (5)
  │    └── filters [type=bool, outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ])]
  │         └── eq [type=bool, outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ])]
@@ -937,7 +937,7 @@ opt
 SELECT 1 FROM (SELECT s FROM a GROUP BY s) a
 ----
 project
- ├── columns: column5:5(int!null)
+ ├── columns: "1":5(int!null)
  ├── group-by
  │    ├── columns: s:4(string)
  │    ├── grouping columns: s:4(string)
@@ -956,7 +956,7 @@ opt
 SELECT s, SUM(i) FROM a GROUP BY s
 ----
 group-by
- ├── columns: s:4(string) column5:5(decimal)
+ ├── columns: s:4(string) sum:5(decimal)
  ├── grouping columns: s:4(string)
  ├── keys: weak(4)
  ├── scan a
@@ -970,7 +970,7 @@ opt
 SELECT AVG(s::int+i), s, i FROM a GROUP BY s, i
 ----
 group-by
- ├── columns: column6:6(decimal) s:4(string) i:2(int)
+ ├── columns: avg:6(decimal) s:4(string) i:2(int)
  ├── grouping columns: i:2(int) s:4(string)
  ├── keys: weak(2,4)
  ├── project
@@ -991,7 +991,7 @@ opt
 SELECT MIN(i), MAX(k), MAX(k) FROM a
 ----
 group-by
- ├── columns: column5:5(int) column6:6(int) column6:6(int)
+ ├── columns: min:5(int) max:6(int) max:6(int)
  ├── cardinality: [1 - 1]
  ├── scan a
  │    ├── columns: k:1(int!null) i:2(int)
@@ -1007,7 +1007,7 @@ opt
 SELECT s, i+1 FROM a GROUP BY i, s
 ----
 project
- ├── columns: s:4(string) column5:5(int)
+ ├── columns: s:4(string) "i + 1":5(int)
  ├── group-by
  │    ├── columns: i:2(int) s:4(string)
  │    ├── grouping columns: i:2(int) s:4(string)
@@ -1024,7 +1024,7 @@ opt
 SELECT MIN(sm), i FROM (SELECT s, i, SUM(k) sm, AVG(k) av FROM a GROUP BY i, s) a GROUP BY i
 ----
 group-by
- ├── columns: column7:7(decimal) i:2(int)
+ ├── columns: min:7(decimal) i:2(int)
  ├── grouping columns: i:2(int)
  ├── keys: weak(2)
  ├── group-by
@@ -1086,7 +1086,7 @@ opt
 SELECT 1 FROM (VALUES ('foo', 'bar', 'baz'), ('apple', 'banana', 'cherry')) a
 ----
 project
- ├── columns: column4:4(int!null)
+ ├── columns: "1":4(int!null)
  ├── cardinality: [2 - 2]
  ├── values
  │    ├── cardinality: [2 - 2]

--- a/pkg/sql/opt/norm/testdata/rules/scalar
+++ b/pkg/sql/opt/norm/testdata/rules/scalar
@@ -32,7 +32,7 @@ SELECT
 FROM a
 ----
 project
- ├── columns: column7:7(bool) column8:8(bool) column9:9(bool) column10:10(bool) column11:11(int) column12:12(int) column13:13(int) column14:14(int) column15:15(int)
+ ├── columns: "(1 + i) = k":7(bool) "(2 - k) != i":8(bool) "(i + 1) IS NOT DISTINCT FROM k":9(bool) "(i - 1) IS DISTINCT FROM k":10(bool) "(i * 2) + k":11(int) "(i + 2) * k":12(int) "(i ^ 2) & k":13(int) "(i ^ 2) | k":14(int) "(i * i) # k":15(int)
  ├── scan a
  │    ├── columns: k:1(int!null) i:2(int)
  │    └── keys: (1)
@@ -101,7 +101,7 @@ SELECT
 FROM a
 ----
 project
- ├── columns: column7:7(bool) column8:8(bool) column9:9(bool) column10:10(bool) column11:11(float) column12:12(int) column13:13(int) column14:14(int) column15:15(int)
+ ├── columns: "(length('foo') + 1) = (i + k)":7(bool) "length('bar') != (i * 2)":8(bool) "5 IS NOT DISTINCT FROM (1 - k)":9(bool) "(10::DECIMAL + 1::INT) IS DISTINCT FROM k":10(bool) "1 + f":11(float) "(5 * length('foo')) * (i * i)":12(int) "(100 ^ 2) & (i + i)":13(int) "(length('foo') + 1) | (i + i)":14(int) "(1 - length('foo')) # (k ^ 2)":15(int)
  ├── scan a
  │    ├── columns: k:1(int!null) i:2(int) f:3(float)
  │    └── keys: (1)
@@ -172,7 +172,7 @@ opt
 SELECT COALESCE(i) FROM a
 ----
 project
- ├── columns: column7:7(int)
+ ├── columns: "COALESCE(i)":7(int)
  ├── scan a
  │    └── columns: i:2(int)
  └── projections [outer=(2)]
@@ -185,7 +185,7 @@ opt
 SELECT COALESCE(NULL) FROM a
 ----
 project
- ├── columns: column7:7(unknown)
+ ├── columns: "COALESCE(NULL)":7(unknown)
  ├── scan a
  └── projections
       └── null [type=unknown]
@@ -194,7 +194,7 @@ opt
 SELECT COALESCE(NULL, 'foo', s) FROM a
 ----
 project
- ├── columns: column7:7(string!null)
+ ├── columns: "COALESCE(NULL, 'foo', s)":7(string!null)
  ├── scan a
  └── projections
       └── const: 'foo' [type=string]
@@ -203,7 +203,7 @@ opt
 SELECT COALESCE(NULL, NULL, s, s || 'foo') FROM a
 ----
 project
- ├── columns: column7:7(string)
+ ├── columns: "COALESCE(NULL, NULL, s, s || 'foo')":7(string)
  ├── scan a
  │    └── columns: s:4(string)
  └── projections [outer=(4)]
@@ -218,7 +218,7 @@ opt
 SELECT COALESCE(i, NULL, NULL) FROM a
 ----
 project
- ├── columns: column7:7(int)
+ ├── columns: "COALESCE(i, NULL, NULL)":7(int)
  ├── scan a
  │    └── columns: i:2(int)
  └── projections [outer=(2)]
@@ -234,7 +234,7 @@ opt
 SELECT i::int, arr::int[], '[1, 2]'::json::json, null::string::int FROM a
 ----
 project
- ├── columns: column7:7(int) column8:8(int[]) column9:9(jsonb!null) column10:10(int)
+ ├── columns: "i::INT":7(int) "arr::INT[]":8(int[]) "'[1, 2]'::JSON::JSON":9(jsonb!null) "NULL::STRING::INT":10(int)
  ├── scan a
  │    └── columns: i:2(int) arr:6(int[])
  └── projections [outer=(2,6)]
@@ -248,7 +248,7 @@ opt
 SELECT i::float, arr::decimal[], s::json::json FROM a
 ----
 project
- ├── columns: column7:7(float) column8:8(decimal[]) column9:9(jsonb)
+ ├── columns: "i::FLOAT":7(float) "arr::DECIMAL[]":8(decimal[]) "s::JSON::JSON":9(jsonb)
  ├── scan a
  │    └── columns: i:2(int) s:4(string) arr:6(int[])
  └── projections [outer=(2,4,6)]
@@ -266,7 +266,7 @@ opt
 SELECT null::int, null::timestamptz
 ----
 project
- ├── columns: column1:1(int) column2:2(timestamptz)
+ ├── columns: "NULL::INT":1(int) "NULL::TIMESTAMP WITH TIME ZONE":2(timestamptz)
  ├── cardinality: [1 - 1]
  ├── values
  │    ├── cardinality: [1 - 1]
@@ -282,7 +282,7 @@ opt
 SELECT +null::int, -null::int, ~null::int FROM a
 ----
 project
- ├── columns: column7:7(int) column8:8(int) column9:9(int)
+ ├── columns: "+NULL::INT":7(int) "-NULL::INT":8(int) "~NULL::INT":9(int)
  ├── scan a
  └── projections
       ├── null [type=int]
@@ -308,7 +308,7 @@ SELECT
 FROM a
 ----
 project
- ├── columns: column7:7(int) column8:8(int) column9:9(decimal) column10:10(decimal) column11:11(float) column12:12(float) column13:13(int) column14:14(int) column15:15(decimal[]) column16:16(string[]) column17:17(decimal[]) column18:18(float[])
+ ├── columns: "NULL::INT & 1":7(int) "1 & NULL::INT":8(int) "NULL::DECIMAL + 1":9(decimal) "1 + NULL::DECIMAL":10(decimal) "NULL::FLOAT % 1":11(float) "1 % NULL::FLOAT":12(float) "NULL::INT << 4":13(int) "4 << NULL::INT":14(int) "arr::DECIMAL[] || NULL":15(decimal[]) "NULL || arr::STRING[]":16(string[]) "i::DECIMAL || NULL":17(decimal[]) "NULL || i::FLOAT":18(float[])
  ├── scan a
  │    └── columns: i:2(int) arr:6(int[])
  └── projections [outer=(2,6)]
@@ -348,7 +348,7 @@ SELECT
 FROM a
 ----
 project
- ├── columns: column7:7(jsonb) column8:8(jsonb) column9:9(jsonb) column10:10(jsonb) column11:11(string) column12:12(string) column11:11(string) column12:12(string) column13:13(jsonb) column14:14(unknown) column15:15(string) column14:14(unknown)
+ ├── columns: "NULL::JSON || '[1, 2]'":7(jsonb) "'[1, 2]' || NULL::JSON":8(jsonb) "NULL::JSON->'foo'":9(jsonb) "'{}'::JSONB->NULL::STRING":10(jsonb) "NULL::JSON->>'foo'":11(string) "'{}'::JSONB->>NULL::STRING":12(string) "NULL::JSON->>'foo'":11(string) "'{}'::JSONB->>NULL::STRING":12(string) "NULL::JSON#>ARRAY['foo']":13(jsonb) "'{}'::JSONB#>NULL":14(unknown) "NULL::JSON#>>ARRAY['foo']":15(string) "'{}'::JSONB#>>NULL":14(unknown)
  ├── scan a
  └── projections
       ├── null [type=jsonb]
@@ -368,7 +368,7 @@ opt
 SELECT null IN (i), null NOT IN (s) FROM a
 ----
 project
- ├── columns: column7:7(bool) column8:8(bool)
+ ├── columns: "NULL IN (i)":7(bool) "NULL NOT IN (s)":8(bool)
  ├── scan a
  └── projections
       ├── null [type=bool, constraints=(contradiction; tight)]
@@ -381,7 +381,7 @@ opt
 SELECT i IN (null, null), k NOT IN (1 * null, null::int, 1 < null) FROM a
 ----
 project
- ├── columns: column7:7(bool) column8:8(bool)
+ ├── columns: "i IN (NULL, NULL)":7(bool) "k NOT IN (1 * NULL, NULL::INT, 1 < NULL)":8(bool)
  ├── scan a
  └── projections
       ├── null [type=bool, constraints=(contradiction; tight)]
@@ -394,7 +394,7 @@ opt
 SELECT i IN (2, 1, 1, null, 3, null, 2, 3.0) FROM a
 ----
 project
- ├── columns: column7:7(bool)
+ ├── columns: "i IN (2, 1, 1, NULL, 3, NULL, 2, 3.0)":7(bool)
  ├── scan a
  │    └── columns: i:2(int)
  └── projections [outer=(2)]
@@ -410,7 +410,7 @@ opt
 SELECT s NOT IN ('foo', s || 'foo', 'bar', length(s)::string, NULL) FROM a
 ----
 project
- ├── columns: column7:7(bool)
+ ├── columns: "s NOT IN ('foo', s || 'foo', 'bar', length(s)::STRING, NULL)":7(bool)
  ├── scan a
  │    └── columns: s:4(string)
  └── projections [outer=(4)]
@@ -462,7 +462,7 @@ select
  └── filters [type=bool]
       └── exists [type=bool]
            └── group-by
-                ├── columns: column13:13(string)
+                ├── columns: max:13(string)
                 ├── cardinality: [1 - 1]
                 ├── scan a
                 │    ├── columns: a.s:10(string)

--- a/pkg/sql/opt/norm/testdata/rules/select
+++ b/pkg/sql/opt/norm/testdata/rules/select
@@ -184,7 +184,7 @@ opt
 SELECT * FROM (SELECT i, i+1, f FROM a) a WHERE f=10.0
 ----
 project
- ├── columns: i:2(int) column6:6(int) f:3(float!null)
+ ├── columns: i:2(int) "i + 1":6(int) f:3(float!null)
  ├── select
  │    ├── columns: i:2(int) f:3(float!null)
  │    ├── scan a
@@ -250,7 +250,7 @@ opt
 SELECT f, f+1.1 FROM (SELECT f, i FROM a GROUP BY f, i HAVING SUM(f)=10.0) a
 ----
 project
- ├── columns: f:3(float) column7:7(float)
+ ├── columns: f:3(float) "f + 1.1":7(float)
  ├── select
  │    ├── columns: i:2(int) f:3(float) column6:6(float!null)
  │    ├── keys: weak(2,3)
@@ -758,7 +758,7 @@ opt
 SELECT * FROM (SELECT i, COUNT(*) FROM a GROUP BY i) a WHERE i=1
 ----
 group-by
- ├── columns: i:2(int!null) column6:6(int)
+ ├── columns: i:2(int!null) count:6(int)
  ├── grouping columns: i:2(int!null)
  ├── keys: (2)
  ├── select

--- a/pkg/sql/opt/optbuilder/testdata/aggregate
+++ b/pkg/sql/opt/optbuilder/testdata/aggregate
@@ -21,7 +21,7 @@ SELECT MIN(1), MAX(1), COUNT(1), SUM_INT(1), AVG(1), SUM(1), STDDEV(1),
   VARIANCE(1), BOOL_AND(true), BOOL_OR(false), XOR_AGG(b'\x01') FROM kv
 ----
 group-by
- ├── columns: column6:6(int) column7:7(int) column8:8(int) column9:9(int) column10:10(decimal) column11:11(decimal) column12:12(decimal) column13:13(decimal) column15:15(bool) column17:17(bool) column19:19(bytes)
+ ├── columns: min:6(int) max:7(int) count:8(int) sum_int:9(int) avg:10(decimal) sum:11(decimal) stddev:12(decimal) variance:13(decimal) bool_and:15(bool) bool_or:17(bool) xor_agg:19(bytes)
  ├── project
  │    ├── columns: column5:5(int!null) column14:14(bool!null) column16:16(bool!null) column18:18(bytes!null)
  │    ├── scan kv
@@ -60,9 +60,9 @@ SELECT MIN(v), MAX(v), COUNT(v), SUM_INT(1), AVG(v), SUM(v), STDDEV(v),
   VARIANCE(v), BOOL_AND(v = 1), BOOL_AND(v = 1), XOR_AGG(s::bytes) FROM kv
 ----
 project
- ├── columns: column5:5(int) column6:6(int) column7:7(int) column9:9(int) column10:10(decimal) column11:11(decimal) column12:12(decimal) column13:13(decimal) column15:15(bool) column15:15(bool) column17:17(bytes)
+ ├── columns: min:5(int) max:6(int) count:7(int) sum_int:9(int) avg:10(decimal) sum:11(decimal) stddev:12(decimal) variance:13(decimal) bool_and:15(bool) bool_and:15(bool) xor_agg:17(bytes)
  └── group-by
-      ├── columns: column5:5(int) column6:6(int) column7:7(int) column9:9(int) column10:10(decimal) column11:11(decimal) column12:12(decimal) column13:13(decimal) column15:15(bool) column17:17(bytes)
+      ├── columns: min:5(int) max:6(int) count:7(int) sum_int:9(int) avg:10(decimal) sum:11(decimal) stddev:12(decimal) variance:13(decimal) bool_and:15(bool) xor_agg:17(bytes)
       ├── project
       │    ├── columns: column8:8(int!null) column14:14(bool) column16:16(bytes) v:2(int)
       │    ├── scan kv
@@ -101,9 +101,9 @@ SELECT MIN(1), COUNT(1), MAX(1), SUM_INT(1), AVG(1)::float, SUM(1), STDDEV(1),
   VARIANCE(1)::float, BOOL_AND(true), BOOL_OR(true), TO_HEX(XOR_AGG(b'\x01'))
 ----
 project
- ├── columns: column2:2(int) column3:3(int) column4:4(int) column5:5(int) column7:7(float) column8:8(decimal) column9:9(decimal) column11:11(float) column13:13(bool) column14:14(bool) column17:17(string)
+ ├── columns: min:2(int) count:3(int) max:4(int) sum_int:5(int) "avg(1)::FLOAT":7(float) sum:8(decimal) stddev:9(decimal) "variance(1)::FLOAT":11(float) bool_and:13(bool) bool_or:14(bool) to_hex:17(string)
  ├── group-by
- │    ├── columns: column2:2(int) column3:3(int) column4:4(int) column5:5(int) column6:6(decimal) column8:8(decimal) column9:9(decimal) column10:10(decimal) column13:13(bool) column14:14(bool) column16:16(bytes)
+ │    ├── columns: min:2(int) count:3(int) max:4(int) sum_int:5(int) column6:6(decimal) sum:8(decimal) stddev:9(decimal) column10:10(decimal) bool_and:13(bool) bool_or:14(bool) column16:16(bytes)
  │    ├── project
  │    │    ├── columns: column1:1(int!null) column12:12(bool!null) column15:15(bytes!null)
  │    │    ├── values
@@ -147,7 +147,7 @@ build
 SELECT ARRAY_AGG(1) FROM kv
 ----
 group-by
- ├── columns: column6:6(int[])
+ ├── columns: array_agg:6(int[])
  ├── project
  │    ├── columns: column5:5(int!null)
  │    ├── scan kv
@@ -162,7 +162,7 @@ build
 SELECT JSON_AGG(v) FROM kv
 ----
 group-by
- ├── columns: column5:5(jsonb)
+ ├── columns: json_agg:5(jsonb)
  ├── project
  │    ├── columns: v:2(int)
  │    └── scan kv
@@ -175,7 +175,7 @@ build
 SELECT JSONB_AGG(1)
 ----
 group-by
- ├── columns: column2:2(jsonb)
+ ├── columns: jsonb_agg:2(jsonb)
  ├── project
  │    ├── columns: column1:1(int!null)
  │    ├── values
@@ -191,7 +191,7 @@ build
 SELECT 1 FROM kv GROUP BY v
 ----
 project
- ├── columns: column5:5(int!null)
+ ├── columns: "1":5(int!null)
  ├── group-by
  │    ├── columns: v:2(int)
  │    ├── grouping columns: v:2(int)
@@ -229,7 +229,7 @@ build
 SELECT ARRAY_AGG(NULL::TEXT)
 ----
 group-by
- ├── columns: column2:2(string[])
+ ├── columns: array_agg:2(string[])
  ├── project
  │    ├── columns: column1:1(string)
  │    ├── values
@@ -245,15 +245,15 @@ build
 SELECT (SELECT COALESCE(MAX(1), 0) FROM kv)
 ----
 project
- ├── columns: column8:8(int)
+ ├── columns: "(SELECT COALESCE(max(1), 0) FROM kv)":8(int)
  ├── values
  │    └── tuple [type=tuple{}]
  └── projections
       └── subquery [type=int]
            └── max1-row
-                ├── columns: column7:7(int)
+                ├── columns: "COALESCE(max(1), 0)":7(int)
                 └── project
-                     ├── columns: column7:7(int)
+                     ├── columns: "COALESCE(max(1), 0)":7(int)
                      ├── group-by
                      │    ├── columns: column6:6(int)
                      │    ├── project
@@ -284,9 +284,9 @@ build
 SELECT COUNT(*), k FROM kv GROUP BY k
 ----
 project
- ├── columns: column5:5(int) k:1(int!null)
+ ├── columns: count:5(int) k:1(int!null)
  └── group-by
-      ├── columns: k:1(int!null) column5:5(int)
+      ├── columns: k:1(int!null) count:5(int)
       ├── grouping columns: k:1(int!null)
       ├── project
       │    ├── columns: k:1(int!null)
@@ -300,9 +300,9 @@ build
 SELECT COUNT(*), k FROM kv GROUP BY 2
 ----
 project
- ├── columns: column5:5(int) k:1(int!null)
+ ├── columns: count:5(int) k:1(int!null)
  └── group-by
-      ├── columns: k:1(int!null) column5:5(int)
+      ├── columns: k:1(int!null) count:5(int)
       ├── grouping columns: k:1(int!null)
       ├── project
       │    ├── columns: k:1(int!null)
@@ -356,9 +356,9 @@ build
 SELECT COUNT(*), kv.s FROM kv GROUP BY s
 ----
 project
- ├── columns: column5:5(int) s:4(string)
+ ├── columns: count:5(int) s:4(string)
  └── group-by
-      ├── columns: s:4(string) column5:5(int)
+      ├── columns: s:4(string) count:5(int)
       ├── grouping columns: s:4(string)
       ├── project
       │    ├── columns: s:4(string)
@@ -371,9 +371,9 @@ build
 SELECT COUNT(*), s FROM kv GROUP BY kv.s
 ----
 project
- ├── columns: column5:5(int) s:4(string)
+ ├── columns: count:5(int) s:4(string)
  └── group-by
-      ├── columns: s:4(string) column5:5(int)
+      ├── columns: s:4(string) count:5(int)
       ├── grouping columns: s:4(string)
       ├── project
       │    ├── columns: s:4(string)
@@ -386,9 +386,9 @@ build
 SELECT COUNT(*), kv.s FROM kv GROUP BY kv.s
 ----
 project
- ├── columns: column5:5(int) s:4(string)
+ ├── columns: count:5(int) s:4(string)
  └── group-by
-      ├── columns: s:4(string) column5:5(int)
+      ├── columns: s:4(string) count:5(int)
       ├── grouping columns: s:4(string)
       ├── project
       │    ├── columns: s:4(string)
@@ -401,9 +401,9 @@ build
 SELECT COUNT(*), s FROM kv GROUP BY s
 ----
 project
- ├── columns: column5:5(int) s:4(string)
+ ├── columns: count:5(int) s:4(string)
  └── group-by
-      ├── columns: s:4(string) column5:5(int)
+      ├── columns: s:4(string) count:5(int)
       ├── grouping columns: s:4(string)
       ├── project
       │    ├── columns: s:4(string)
@@ -417,9 +417,9 @@ build
 SELECT v, COUNT(*), w FROM kv GROUP BY v, w
 ----
 project
- ├── columns: v:2(int) column5:5(int) w:3(int)
+ ├── columns: v:2(int) count:5(int) w:3(int)
  └── group-by
-      ├── columns: v:2(int) w:3(int) column5:5(int)
+      ├── columns: v:2(int) w:3(int) count:5(int)
       ├── grouping columns: v:2(int) w:3(int)
       ├── project
       │    ├── columns: v:2(int) w:3(int)
@@ -433,9 +433,9 @@ build
 SELECT v, COUNT(*), w FROM kv GROUP BY 1, 3
 ----
 project
- ├── columns: v:2(int) column5:5(int) w:3(int)
+ ├── columns: v:2(int) count:5(int) w:3(int)
  └── group-by
-      ├── columns: v:2(int) w:3(int) column5:5(int)
+      ├── columns: v:2(int) w:3(int) count:5(int)
       ├── grouping columns: v:2(int) w:3(int)
       ├── project
       │    ├── columns: v:2(int) w:3(int)
@@ -449,9 +449,9 @@ build
 SELECT COUNT(*), UPPER(s) FROM kv GROUP BY UPPER(s)
 ----
 project
- ├── columns: column6:6(int) column5:5(string)
+ ├── columns: count:6(int) upper:5(string)
  └── group-by
-      ├── columns: column5:5(string) column6:6(int)
+      ├── columns: column5:5(string) count:6(int)
       ├── grouping columns: column5:5(string)
       ├── project
       │    ├── columns: column5:5(string)
@@ -468,9 +468,9 @@ build
 SELECT COUNT(*) FROM kv GROUP BY 1+2
 ----
 project
- ├── columns: column6:6(int)
+ ├── columns: count:6(int)
  └── group-by
-      ├── columns: column5:5(int!null) column6:6(int)
+      ├── columns: column5:5(int!null) count:6(int)
       ├── grouping columns: column5:5(int!null)
       ├── project
       │    ├── columns: column5:5(int!null)
@@ -485,9 +485,9 @@ build
 SELECT COUNT(*) FROM kv GROUP BY length('abc')
 ----
 project
- ├── columns: column6:6(int)
+ ├── columns: count:6(int)
  └── group-by
-      ├── columns: column5:5(int) column6:6(int)
+      ├── columns: column5:5(int) count:6(int)
       ├── grouping columns: column5:5(int)
       ├── project
       │    ├── columns: column5:5(int)
@@ -504,9 +504,9 @@ build
 SELECT COUNT(*), UPPER(s) FROM kv GROUP BY s
 ----
 project
- ├── columns: column5:5(int) column6:6(string)
+ ├── columns: count:5(int) upper:6(string)
  ├── group-by
- │    ├── columns: s:4(string) column5:5(int)
+ │    ├── columns: s:4(string) count:5(int)
  │    ├── grouping columns: s:4(string)
  │    ├── project
  │    │    ├── columns: s:4(string)
@@ -529,9 +529,9 @@ build
 SELECT COUNT(*), k+v FROM kv GROUP BY k+v
 ----
 project
- ├── columns: column6:6(int) column5:5(int)
+ ├── columns: count:6(int) "k + v":5(int)
  └── group-by
-      ├── columns: column5:5(int) column6:6(int)
+      ├── columns: column5:5(int) count:6(int)
       ├── grouping columns: column5:5(int)
       ├── project
       │    ├── columns: column5:5(int)
@@ -550,9 +550,9 @@ build
 SELECT COUNT(*), k+v FROM kv GROUP BY k, v
 ----
 project
- ├── columns: column5:5(int) column6:6(int)
+ ├── columns: count:5(int) "k + v":6(int)
  ├── group-by
- │    ├── columns: k:1(int!null) v:2(int) column5:5(int)
+ │    ├── columns: k:1(int!null) v:2(int) count:5(int)
  │    ├── grouping columns: k:1(int!null) v:2(int)
  │    ├── project
  │    │    ├── columns: k:1(int!null) v:2(int)
@@ -617,7 +617,7 @@ build
 SELECT COUNT(*)
 ----
 group-by
- ├── columns: column1:1(int)
+ ├── columns: count:1(int)
  ├── values
  │    └── tuple [type=tuple{}]
  └── aggregations
@@ -627,7 +627,7 @@ build
 SELECT COUNT(k) from kv
 ----
 group-by
- ├── columns: column5:5(int)
+ ├── columns: count:5(int)
  ├── project
  │    ├── columns: k:1(int!null)
  │    └── scan kv
@@ -640,7 +640,7 @@ build
 SELECT COUNT(1)
 ----
 group-by
- ├── columns: column2:2(int)
+ ├── columns: count:2(int)
  ├── project
  │    ├── columns: column1:1(int!null)
  │    ├── values
@@ -655,7 +655,7 @@ build
 SELECT COUNT(1) from kv
 ----
 group-by
- ├── columns: column6:6(int)
+ ├── columns: count:6(int)
  ├── project
  │    ├── columns: column5:5(int!null)
  │    ├── scan kv
@@ -675,10 +675,10 @@ build
 SELECT v, COUNT(k) FROM kv GROUP BY v ORDER BY v
 ----
 sort
- ├── columns: v:2(int) column5:5(int)
+ ├── columns: v:2(int) count:5(int)
  ├── ordering: +2
  └── group-by
-      ├── columns: v:2(int) column5:5(int)
+      ├── columns: v:2(int) count:5(int)
       ├── grouping columns: v:2(int)
       ├── project
       │    ├── columns: k:1(int!null) v:2(int)
@@ -692,10 +692,10 @@ build
 SELECT v, COUNT(k) FROM kv GROUP BY v ORDER BY v DESC
 ----
 sort
- ├── columns: v:2(int) column5:5(int)
+ ├── columns: v:2(int) count:5(int)
  ├── ordering: -2
  └── group-by
-      ├── columns: v:2(int) column5:5(int)
+      ├── columns: v:2(int) count:5(int)
       ├── grouping columns: v:2(int)
       ├── project
       │    ├── columns: k:1(int!null) v:2(int)
@@ -709,10 +709,10 @@ build
 SELECT v, COUNT(k) FROM kv GROUP BY v ORDER BY COUNT(k) DESC
 ----
 sort
- ├── columns: v:2(int) column5:5(int)
+ ├── columns: v:2(int) count:5(int)
  ├── ordering: -5
  └── group-by
-      ├── columns: v:2(int) column5:5(int)
+      ├── columns: v:2(int) count:5(int)
       ├── grouping columns: v:2(int)
       ├── project
       │    ├── columns: k:1(int!null) v:2(int)
@@ -726,12 +726,12 @@ build
 SELECT v, COUNT(k) FROM kv GROUP BY v ORDER BY v-COUNT(k)
 ----
 sort
- ├── columns: v:2(int) column5:5(int)
+ ├── columns: v:2(int) count:5(int)
  ├── ordering: +6
  └── project
-      ├── columns: column6:6(int) v:2(int) column5:5(int)
+      ├── columns: column6:6(int) v:2(int) count:5(int)
       ├── group-by
-      │    ├── columns: v:2(int) column5:5(int)
+      │    ├── columns: v:2(int) count:5(int)
       │    ├── grouping columns: v:2(int)
       │    ├── project
       │    │    ├── columns: k:1(int!null) v:2(int)
@@ -743,7 +743,7 @@ sort
       └── projections
            └── minus [type=int]
                 ├── variable: kv.v [type=int]
-                └── variable: column5 [type=int]
+                └── variable: count [type=int]
 
 build
 SELECT v FROM kv GROUP BY v ORDER BY SUM(k)
@@ -766,10 +766,10 @@ build
 SELECT v, COUNT(k) FROM kv GROUP BY v ORDER BY 1 DESC
 ----
 sort
- ├── columns: v:2(int) column5:5(int)
+ ├── columns: v:2(int) count:5(int)
  ├── ordering: -2
  └── group-by
-      ├── columns: v:2(int) column5:5(int)
+      ├── columns: v:2(int) count:5(int)
       ├── grouping columns: v:2(int)
       ├── project
       │    ├── columns: k:1(int!null) v:2(int)
@@ -783,7 +783,7 @@ build
 SELECT COUNT(*), COUNT(k), COUNT(kv.v) FROM kv
 ----
 group-by
- ├── columns: column5:5(int) column6:6(int) column7:7(int)
+ ├── columns: count:5(int) count:6(int) count:7(int)
  ├── project
  │    ├── columns: k:1(int!null) v:2(int)
  │    └── scan kv
@@ -799,7 +799,7 @@ build
 SELECT COUNT(kv.*) FROM kv
 ----
 group-by
- ├── columns: column6:6(int)
+ ├── columns: count:6(int)
  ├── project
  │    ├── columns: column5:5(tuple{int, int, int, string})
  │    ├── scan kv
@@ -818,9 +818,9 @@ build
 SELECT COUNT((k, v)) FROM kv LIMIT 1
 ----
 limit
- ├── columns: column6:6(int)
+ ├── columns: count:6(int)
  ├── group-by
- │    ├── columns: column6:6(int)
+ │    ├── columns: count:6(int)
  │    ├── project
  │    │    ├── columns: column5:5(tuple{int, int})
  │    │    ├── scan kv
@@ -838,9 +838,9 @@ build
 SELECT COUNT((k, v)) FROM kv OFFSET 1
 ----
 offset
- ├── columns: column6:6(int)
+ ├── columns: count:6(int)
  ├── group-by
- │    ├── columns: column6:6(int)
+ │    ├── columns: count:6(int)
  │    ├── project
  │    │    ├── columns: column5:5(tuple{int, int})
  │    │    ├── scan kv
@@ -858,7 +858,7 @@ build
 SELECT COUNT(k)+COUNT(kv.v) FROM kv
 ----
 project
- ├── columns: column7:7(int)
+ ├── columns: "count(k) + count(kv.v)":7(int)
  ├── group-by
  │    ├── columns: column5:5(int) column6:6(int)
  │    ├── project
@@ -879,7 +879,7 @@ build
 SELECT COUNT(NULL::int), COUNT((NULL, NULL))
 ----
 group-by
- ├── columns: column2:2(int) column4:4(int)
+ ├── columns: count:2(int) count:4(int)
  ├── project
  │    ├── columns: column1:1(int) column3:3(tuple{unknown, unknown})
  │    ├── values
@@ -900,7 +900,7 @@ build
 SELECT MIN(k), MAX(k), MIN(v), MAX(v) FROM kv
 ----
 group-by
- ├── columns: column5:5(int) column6:6(int) column7:7(int) column8:8(int)
+ ├── columns: min:5(int) max:6(int) min:7(int) max:8(int)
  ├── project
  │    ├── columns: k:1(int!null) v:2(int)
  │    └── scan kv
@@ -919,7 +919,7 @@ build
 SELECT MIN(k), MAX(k), MIN(v), MAX(v) FROM kv WHERE k > 8
 ----
 group-by
- ├── columns: column5:5(int) column6:6(int) column7:7(int) column8:8(int)
+ ├── columns: min:5(int) max:6(int) min:7(int) max:8(int)
  ├── project
  │    ├── columns: k:1(int!null) v:2(int)
  │    └── select
@@ -943,7 +943,7 @@ build
 SELECT ARRAY_AGG(k), ARRAY_AGG(s) FROM (SELECT k, s FROM kv ORDER BY k)
 ----
 group-by
- ├── columns: column5:5(int[]) column6:6(string[])
+ ├── columns: array_agg:5(int[]) array_agg:6(string[])
  ├── project
  │    ├── columns: k:1(int!null) s:4(string)
  │    └── scan kv
@@ -958,7 +958,7 @@ build
 SELECT array_agg(s) FROM kv WHERE s IS NULL
 ----
 group-by
- ├── columns: column5:5(string[])
+ ├── columns: array_agg:5(string[])
  ├── project
  │    ├── columns: s:4(string)
  │    └── select
@@ -976,7 +976,7 @@ build
 SELECT AVG(k), AVG(v), SUM(k), SUM(v) FROM kv
 ----
 group-by
- ├── columns: column5:5(decimal) column6:6(decimal) column7:7(decimal) column8:8(decimal)
+ ├── columns: avg:5(decimal) avg:6(decimal) sum:7(decimal) sum:8(decimal)
  ├── project
  │    ├── columns: k:1(int!null) v:2(int)
  │    └── scan kv
@@ -995,7 +995,7 @@ build
 SELECT AVG(k::decimal), AVG(v::decimal), SUM(k::decimal), SUM(v::decimal) FROM kv
 ----
 group-by
- ├── columns: column6:6(decimal) column8:8(decimal) column9:9(decimal) column10:10(decimal)
+ ├── columns: avg:6(decimal) avg:8(decimal) sum:9(decimal) sum:10(decimal)
  ├── project
  │    ├── columns: column5:5(decimal) column7:7(decimal)
  │    ├── scan kv
@@ -1019,7 +1019,7 @@ build
 SELECT AVG(k) * 2.0 + MAX(v)::DECIMAL FROM kv
 ----
 project
- ├── columns: column7:7(decimal)
+ ├── columns: "(avg(k) * 2.0) + max(v)::DECIMAL":7(decimal)
  ├── group-by
  │    ├── columns: column5:5(decimal) column6:6(int)
  │    ├── project
@@ -1043,7 +1043,7 @@ build
 SELECT AVG(k) * 2.0 + MAX(v)::DECIMAL FROM kv WHERE w*2 = k
 ----
 project
- ├── columns: column7:7(decimal)
+ ├── columns: "(avg(k) * 2.0) + max(v)::DECIMAL":7(decimal)
  ├── group-by
  │    ├── columns: column5:5(decimal) column6:6(int)
  │    ├── project
@@ -1090,7 +1090,7 @@ build
 SELECT MIN(a), MIN(b), MIN(c), MIN(d) FROM abc
 ----
 group-by
- ├── columns: column5:5(string) column6:6(float) column7:7(bool) column8:8(decimal)
+ ├── columns: min:5(string) min:6(float) min:7(bool) min:8(decimal)
  ├── scan abc
  │    └── columns: a:1(string!null) b:2(float) c:3(bool) d:4(decimal)
  └── aggregations
@@ -1107,7 +1107,7 @@ build
 SELECT MAX(a), MAX(b), MAX(c), MAX(d) FROM abc
 ----
 group-by
- ├── columns: column5:5(string) column6:6(float) column7:7(bool) column8:8(decimal)
+ ├── columns: max:5(string) max:6(float) max:7(bool) max:8(decimal)
  ├── scan abc
  │    └── columns: a:1(string!null) b:2(float) c:3(bool) d:4(decimal)
  └── aggregations
@@ -1124,7 +1124,7 @@ build
 SELECT AVG(b), SUM(b), AVG(d), SUM(d) FROM abc
 ----
 group-by
- ├── columns: column5:5(float) column6:6(float) column7:7(decimal) column8:8(decimal)
+ ├── columns: avg:5(float) sum:6(float) avg:7(decimal) sum:8(decimal)
  ├── project
  │    ├── columns: b:2(float) d:4(decimal)
  │    └── scan abc
@@ -1154,7 +1154,7 @@ build
 SELECT SUM(a) FROM intervals
 ----
 group-by
- ├── columns: column2:2(interval)
+ ├── columns: sum:2(interval)
  ├── scan intervals
  │    └── columns: a:1(interval!null)
  └── aggregations
@@ -1221,7 +1221,7 @@ build
 SELECT MIN(x) FROM xyz
 ----
 group-by
- ├── columns: column4:4(int)
+ ├── columns: min:4(int)
  ├── project
  │    ├── columns: x:1(int!null)
  │    └── scan xyz
@@ -1234,7 +1234,7 @@ build
 SELECT MIN(x) FROM xyz WHERE x in (0, 4, 7)
 ----
 group-by
- ├── columns: column4:4(int)
+ ├── columns: min:4(int)
  ├── project
  │    ├── columns: x:1(int!null)
  │    └── select
@@ -1255,7 +1255,7 @@ build
 SELECT MAX(x) FROM xyz
 ----
 group-by
- ├── columns: column4:4(int)
+ ├── columns: max:4(int)
  ├── project
  │    ├── columns: x:1(int!null)
  │    └── scan xyz
@@ -1268,7 +1268,7 @@ build
 SELECT MAX(y) FROM xyz WHERE x = 1
 ----
 group-by
- ├── columns: column4:4(int)
+ ├── columns: max:4(int)
  ├── project
  │    ├── columns: y:2(int)
  │    └── select
@@ -1286,7 +1286,7 @@ build
 SELECT MIN(y) FROM xyz WHERE x = 7
 ----
 group-by
- ├── columns: column4:4(int)
+ ├── columns: min:4(int)
  ├── project
  │    ├── columns: y:2(int)
  │    └── select
@@ -1304,7 +1304,7 @@ build
 SELECT MIN(x) FROM xyz WHERE (y, z) = (2, 3.0)
 ----
 group-by
- ├── columns: column4:4(int)
+ ├── columns: min:4(int)
  ├── project
  │    ├── columns: x:1(int!null)
  │    └── select
@@ -1326,7 +1326,7 @@ build
 SELECT MAX(x) FROM xyz WHERE (z, y) = (3.0, 2)
 ----
 group-by
- ├── columns: column4:4(int)
+ ├── columns: max:4(int)
  ├── project
  │    ├── columns: x:1(int!null)
  │    └── select
@@ -1351,9 +1351,9 @@ build
 SELECT VARIANCE(x), VARIANCE(y::decimal), round(VARIANCE(z), 14) FROM xyz
 ----
 project
- ├── columns: column4:4(decimal) column6:6(decimal) column8:8(float)
+ ├── columns: variance:4(decimal) variance:6(decimal) round:8(float)
  ├── group-by
- │    ├── columns: column4:4(decimal) column6:6(decimal) column7:7(float)
+ │    ├── columns: variance:4(decimal) variance:6(decimal) column7:7(float)
  │    ├── project
  │    │    ├── columns: column5:5(decimal) x:1(int!null) z:3(float)
  │    │    ├── scan xyz
@@ -1377,7 +1377,7 @@ build
 SELECT VARIANCE(x) FROM xyz WHERE x = 10
 ----
 group-by
- ├── columns: column4:4(decimal)
+ ├── columns: variance:4(decimal)
  ├── project
  │    ├── columns: x:1(int!null)
  │    └── select
@@ -1395,9 +1395,9 @@ build
 SELECT STDDEV(x), STDDEV(y::decimal), round(STDDEV(z), 14) FROM xyz
 ----
 project
- ├── columns: column4:4(decimal) column6:6(decimal) column8:8(float)
+ ├── columns: stddev:4(decimal) stddev:6(decimal) round:8(float)
  ├── group-by
- │    ├── columns: column4:4(decimal) column6:6(decimal) column7:7(float)
+ │    ├── columns: stddev:4(decimal) stddev:6(decimal) column7:7(float)
  │    ├── project
  │    │    ├── columns: column5:5(decimal) x:1(int!null) z:3(float)
  │    │    ├── scan xyz
@@ -1421,7 +1421,7 @@ build
 SELECT STDDEV(x) FROM xyz WHERE x = 1
 ----
 group-by
- ├── columns: column4:4(decimal)
+ ├── columns: stddev:4(decimal)
  ├── project
  │    ├── columns: x:1(int!null)
  │    └── select
@@ -1439,7 +1439,7 @@ build
 SELECT AVG(1::int)::float, AVG(2::float)::float, AVG(3::decimal)::float
 ----
 project
- ├── columns: column3:3(float) column6:6(float) column9:9(float)
+ ├── columns: "avg(1::INT)::FLOAT":3(float) "avg(2::FLOAT)::FLOAT":6(float) "avg(3::DECIMAL)::FLOAT":9(float)
  ├── group-by
  │    ├── columns: column2:2(decimal) column5:5(float) column8:8(decimal)
  │    ├── project
@@ -1472,7 +1472,7 @@ build
 SELECT COUNT(2::int), COUNT(3::float), COUNT(4::decimal)
 ----
 group-by
- ├── columns: column2:2(int) column4:4(int) column6:6(int)
+ ├── columns: count:2(int) count:4(int) count:6(int)
  ├── project
  │    ├── columns: column1:1(int) column3:3(float) column5:5(decimal)
  │    ├── values
@@ -1496,7 +1496,7 @@ build
 SELECT SUM(1::int), SUM(2::float), SUM(3::decimal)
 ----
 group-by
- ├── columns: column2:2(decimal) column4:4(float) column6:6(decimal)
+ ├── columns: sum:2(decimal) sum:4(float) sum:6(decimal)
  ├── project
  │    ├── columns: column1:1(int) column3:3(float) column5:5(decimal)
  │    ├── values
@@ -1520,7 +1520,7 @@ build
 SELECT VARIANCE(1::int), VARIANCE(1::float), VARIANCE(1::decimal)
 ----
 group-by
- ├── columns: column2:2(decimal) column4:4(float) column6:6(decimal)
+ ├── columns: variance:2(decimal) variance:4(float) variance:6(decimal)
  ├── project
  │    ├── columns: column1:1(int) column3:3(float) column5:5(decimal)
  │    ├── values
@@ -1544,7 +1544,7 @@ build
 SELECT STDDEV(1::int), STDDEV(1::float), STDDEV(1::decimal)
 ----
 group-by
- ├── columns: column2:2(decimal) column4:4(float) column6:6(decimal)
+ ├── columns: stddev:2(decimal) stddev:4(float) stddev:6(decimal)
  ├── project
  │    ├── columns: column1:1(int) column3:3(float) column5:5(decimal)
  │    ├── values
@@ -1569,9 +1569,9 @@ build
 SELECT x > (SELECT avg(0)) FROM xyz LIMIT 1
 ----
 limit
- ├── columns: column6:6(bool)
+ ├── columns: "x > (SELECT avg(0))":6(bool)
  ├── project
- │    ├── columns: column6:6(bool)
+ │    ├── columns: "x > (SELECT avg(0))":6(bool)
  │    ├── scan xyz
  │    │    └── columns: x:1(int!null) y:2(int) z:3(float)
  │    └── projections
@@ -1579,9 +1579,9 @@ limit
  │              ├── variable: xyz.x [type=int]
  │              └── subquery [type=decimal]
  │                   └── max1-row
- │                        ├── columns: column5:5(decimal)
+ │                        ├── columns: avg:5(decimal)
  │                        └── group-by
- │                             ├── columns: column5:5(decimal)
+ │                             ├── columns: avg:5(decimal)
  │                             ├── project
  │                             │    ├── columns: column4:4(int!null)
  │                             │    ├── values
@@ -1597,9 +1597,9 @@ build
 SELECT x > (SELECT avg(y) FROM xyz) FROM xyz LIMIT 1
 ----
 limit
- ├── columns: column8:8(bool)
+ ├── columns: "x > (SELECT avg(y) FROM xyz)":8(bool)
  ├── project
- │    ├── columns: column8:8(bool)
+ │    ├── columns: "x > (SELECT avg(y) FROM xyz)":8(bool)
  │    ├── scan xyz
  │    │    └── columns: xyz.x:1(int!null) xyz.y:2(int) xyz.z:3(float)
  │    └── projections
@@ -1607,9 +1607,9 @@ limit
  │              ├── variable: xyz.x [type=int]
  │              └── subquery [type=decimal]
  │                   └── max1-row
- │                        ├── columns: column7:7(decimal)
+ │                        ├── columns: avg:7(decimal)
  │                        └── group-by
- │                             ├── columns: column7:7(decimal)
+ │                             ├── columns: avg:7(decimal)
  │                             ├── project
  │                             │    ├── columns: xyz.y:5(int)
  │                             │    └── scan xyz
@@ -1632,7 +1632,7 @@ build
 SELECT BOOL_AND(b), BOOL_OR(b) FROM bools
 ----
 group-by
- ├── columns: column3:3(bool) column4:4(bool)
+ ├── columns: bool_and:3(bool) bool_or:4(bool)
  ├── project
  │    ├── columns: b:1(bool)
  │    └── scan bools
@@ -1649,7 +1649,7 @@ build
 SELECT 1 FROM kv GROUP BY kv.*;
 ----
 project
- ├── columns: column5:5(int!null)
+ ├── columns: "1":5(int!null)
  ├── group-by
  │    ├── columns: k:1(int!null) v:2(int) w:3(int) s:4(string)
  │    ├── grouping columns: k:1(int!null) v:2(int) w:3(int) s:4(string)
@@ -1673,9 +1673,9 @@ build
 SELECT TO_HEX(XOR_AGG(a)), XOR_AGG(c) FROM xor_bytes
 ----
 project
- ├── columns: column6:6(string) column7:7(int)
+ ├── columns: to_hex:6(string) xor_agg:7(int)
  ├── group-by
- │    ├── columns: column5:5(bytes) column7:7(int)
+ │    ├── columns: column5:5(bytes) xor_agg:7(int)
  │    ├── project
  │    │    ├── columns: a:1(bytes) c:3(int)
  │    │    └── scan xor_bytes
@@ -1693,12 +1693,12 @@ build
 SELECT TO_HEX(XOR_AGG(a)), b, XOR_AGG(c) FROM xor_bytes GROUP BY b ORDER BY b
 ----
 sort
- ├── columns: column6:6(string) b:2(int) column7:7(int)
+ ├── columns: to_hex:6(string) b:2(int) xor_agg:7(int)
  ├── ordering: +2
  └── project
-      ├── columns: column6:6(string) b:2(int) column7:7(int)
+      ├── columns: to_hex:6(string) b:2(int) xor_agg:7(int)
       ├── group-by
-      │    ├── columns: b:2(int) column5:5(bytes) column7:7(int)
+      │    ├── columns: b:2(int) column5:5(bytes) xor_agg:7(int)
       │    ├── grouping columns: b:2(int)
       │    ├── project
       │    │    ├── columns: a:1(bytes) b:2(int) c:3(int)
@@ -1719,7 +1719,7 @@ build
 SELECT XOR_AGG(i) FROM (VALUES (b'\x01'), (b'\x01\x01')) AS a(i)
 ----
 group-by
- ├── columns: column2:2(bytes)
+ ├── columns: xor_agg:2(bytes)
  ├── values
  │    ├── columns: column1:1(bytes)
  │    ├── tuple [type=tuple{bytes}]
@@ -1734,7 +1734,7 @@ build
 SELECT MAX(true), MIN(true)
 ----
 group-by
- ├── columns: column2:2(bool) column3:3(bool)
+ ├── columns: max:2(bool) min:3(bool)
  ├── project
  │    ├── columns: column1:1(bool!null)
  │    ├── values
@@ -1751,7 +1751,7 @@ build
 SELECT CONCAT_AGG(s) FROM (SELECT s FROM kv ORDER BY k)
 ----
 group-by
- ├── columns: column5:5(string)
+ ├── columns: concat_agg:5(string)
  ├── project
  │    ├── columns: k:1(int!null) s:4(string)
  │    └── scan kv
@@ -1764,7 +1764,7 @@ build
 SELECT JSON_AGG(s) FROM (SELECT s FROM kv ORDER BY k)
 ----
 group-by
- ├── columns: column5:5(jsonb)
+ ├── columns: json_agg:5(jsonb)
  ├── project
  │    ├── columns: k:1(int!null) s:4(string)
  │    └── scan kv
@@ -1777,7 +1777,7 @@ build
 SELECT JSONB_AGG(s) FROM (SELECT s FROM kv ORDER BY k)
 ----
 group-by
- ├── columns: column5:5(jsonb)
+ ├── columns: jsonb_agg:5(jsonb)
  ├── project
  │    ├── columns: k:1(int!null) s:4(string)
  │    └── scan kv
@@ -1815,7 +1815,7 @@ build
 SELECT (b, a) FROM ab GROUP BY (b, a)
 ----
 project
- ├── columns: column3:3(tuple{int, int})
+ ├── columns: "(b, a)":3(tuple{int, int})
  ├── group-by
  │    ├── columns: a:1(int!null) b:2(int)
  │    ├── grouping columns: a:1(int!null) b:2(int)
@@ -1833,9 +1833,9 @@ SELECT MIN(y), (b, a)
  FROM ab, xy GROUP BY (x, (a, b))
 ----
 project
- ├── columns: column6:6(string) column7:7(tuple{int, int})
+ ├── columns: min:6(string) "(b, a)":7(tuple{int, int})
  ├── group-by
- │    ├── columns: a:1(int!null) b:2(int) x:3(string) column6:6(string)
+ │    ├── columns: a:1(int!null) b:2(int) x:3(string) min:6(string)
  │    ├── grouping columns: a:1(int!null) b:2(int) x:3(string)
  │    ├── project
  │    │    ├── columns: a:1(int!null) b:2(int) x:3(string) y:4(string)
@@ -1858,10 +1858,10 @@ build
 SELECT v, COUNT(k) FROM kv GROUP BY v ORDER BY COUNT(k)
 ----
 sort
- ├── columns: v:2(int) column5:5(int)
+ ├── columns: v:2(int) count:5(int)
  ├── ordering: +5
  └── group-by
-      ├── columns: v:2(int) column5:5(int)
+      ├── columns: v:2(int) count:5(int)
       ├── grouping columns: v:2(int)
       ├── project
       │    ├── columns: k:1(int!null) v:2(int)
@@ -1875,10 +1875,10 @@ build
 SELECT v, COUNT(*) FROM kv GROUP BY v ORDER BY COUNT(*)
 ----
 sort
- ├── columns: v:2(int) column5:5(int)
+ ├── columns: v:2(int) count:5(int)
  ├── ordering: +5
  └── group-by
-      ├── columns: v:2(int) column5:5(int)
+      ├── columns: v:2(int) count:5(int)
       ├── grouping columns: v:2(int)
       ├── project
       │    ├── columns: v:2(int)
@@ -1891,10 +1891,10 @@ build
 SELECT v, COUNT(1) FROM kv GROUP BY v ORDER BY COUNT(1)
 ----
 sort
- ├── columns: v:2(int) column6:6(int)
+ ├── columns: v:2(int) count:6(int)
  ├── ordering: +6
  └── group-by
-      ├── columns: v:2(int) column6:6(int)
+      ├── columns: v:2(int) count:6(int)
       ├── grouping columns: v:2(int)
       ├── project
       │    ├── columns: column5:5(int!null) v:2(int)
@@ -1910,7 +1910,7 @@ build
 SELECT (k+v)/(v+w) FROM kv GROUP BY k+v, v+w;
 ----
 project
- ├── columns: column7:7(decimal)
+ ├── columns: "(k + v) / (v + w)":7(decimal)
  ├── group-by
  │    ├── columns: column5:5(int) column6:6(int)
  │    ├── grouping columns: column5:5(int) column6:6(int)
@@ -1939,9 +1939,9 @@ build fully-qualify-names
 SELECT SUM(t.kv.w), t.kv.v FROM t.kv GROUP BY v, kv.k * w
 ----
 project
- ├── columns: column6:6(decimal) v:2(int)
+ ├── columns: sum:6(decimal) v:2(int)
  └── group-by
-      ├── columns: t.public.kv.v:2(int) column5:5(int) column6:6(decimal)
+      ├── columns: t.public.kv.v:2(int) column5:5(int) sum:6(decimal)
       ├── grouping columns: t.public.kv.v:2(int) column5:5(int)
       ├── project
       │    ├── columns: column5:5(int) t.public.kv.v:2(int) t.public.kv.w:3(int)
@@ -1959,9 +1959,9 @@ build fully-qualify-names
 SELECT SUM(t.kv.w), LOWER(s), t.kv.v + k * t.kv.w, t.kv.v FROM t.kv GROUP BY v, LOWER(kv.s), kv.k * w
 ----
 project
- ├── columns: column7:7(decimal) column5:5(string) column8:8(int) v:2(int)
+ ├── columns: sum:7(decimal) lower:5(string) "t.kv.v + (k * t.kv.w)":8(int) v:2(int)
  ├── group-by
- │    ├── columns: t.public.kv.v:2(int) column5:5(string) column6:6(int) column7:7(decimal)
+ │    ├── columns: t.public.kv.v:2(int) column5:5(string) column6:6(int) sum:7(decimal)
  │    ├── grouping columns: t.public.kv.v:2(int) column5:5(string) column6:6(int)
  │    ├── project
  │    │    ├── columns: column5:5(string) column6:6(int) t.public.kv.v:2(int) t.public.kv.w:3(int)
@@ -1988,7 +1988,7 @@ build
 SELECT b1.b AND abc.c AND b2.b FROM bools b1, bools b2, abc GROUP BY b1.b AND abc.c, b2.b
 ----
 project
- ├── columns: column10:10(bool)
+ ├── columns: "(b1.b AND abc.c) AND b2.b":10(bool)
  ├── group-by
  │    ├── columns: bools.b:3(bool) column9:9(bool)
  │    ├── grouping columns: bools.b:3(bool) column9:9(bool)
@@ -2026,7 +2026,7 @@ build
 SELECT b1.b OR abc.c OR b2.b FROM bools b1, bools b2, abc GROUP BY b1.b OR abc.c, b2.b
 ----
 project
- ├── columns: column10:10(bool)
+ ├── columns: "(b1.b OR abc.c) OR b2.b":10(bool)
  ├── group-by
  │    ├── columns: bools.b:3(bool) column9:9(bool)
  │    ├── grouping columns: bools.b:3(bool) column9:9(bool)
@@ -2064,7 +2064,7 @@ build
 SELECT k % w % v FROM kv GROUP BY k % w, v
 ----
 project
- ├── columns: column6:6(int)
+ ├── columns: "(k % w) % v":6(int)
  ├── group-by
  │    ├── columns: v:2(int) column5:5(int)
  │    ├── grouping columns: v:2(int) column5:5(int)
@@ -2087,7 +2087,7 @@ build
 SELECT CONCAT(CONCAT(s, a), a) FROM kv, abc GROUP BY CONCAT(s, a), a
 ----
 project
- ├── columns: column10:10(string)
+ ├── columns: concat:10(string)
  ├── group-by
  │    ├── columns: a:5(string!null) column9:9(string)
  │    ├── grouping columns: a:5(string!null) column9:9(string)
@@ -2120,7 +2120,7 @@ build
 SELECT k < w AND v != 5 FROM kv GROUP BY k < w, v
 ----
 project
- ├── columns: column6:6(bool)
+ ├── columns: "(k < w) AND (v != 5)":6(bool)
  ├── group-by
  │    ├── columns: v:2(int) column5:5(bool)
  │    ├── grouping columns: v:2(int) column5:5(bool)
@@ -2160,7 +2160,7 @@ build
 SELECT a.bar @> b.baz AND b.baz @> b.baz FROM foo AS a, foo AS b GROUP BY a.bar @> b.baz, b.baz
 ----
 project
- ├── columns: column8:8(bool)
+ ├── columns: "(a.bar @> b.baz) AND (b.baz @> b.baz)":8(bool)
  ├── group-by
  │    ├── columns: foo.baz:5(jsonb) column7:7(bool)
  │    ├── grouping columns: foo.baz:5(jsonb) column7:7(bool)
@@ -2195,7 +2195,7 @@ build
 SELECT b.baz <@ a.bar AND b.baz <@ b.baz FROM foo AS a, foo AS b GROUP BY b.baz <@ a.bar, b.baz
 ----
 project
- ├── columns: column8:8(bool)
+ ├── columns: "(b.baz <@ a.bar) AND (b.baz <@ b.baz)":8(bool)
  ├── group-by
  │    ├── columns: foo.baz:5(jsonb) column7:7(bool)
  │    ├── grouping columns: foo.baz:5(jsonb) column7:7(bool)
@@ -2234,7 +2234,7 @@ SELECT date_trunc('second', a.t) - date_trunc('minute', b.t) FROM times a, times
   GROUP BY date_trunc('second', a.t), date_trunc('minute', b.t)
 ----
 project
- ├── columns: column5:5(interval)
+ ├── columns: "date_trunc('second', a.t) - date_trunc('minute', b.t)":5(interval)
  ├── group-by
  │    ├── columns: column3:3(interval) column4:4(interval)
  │    ├── grouping columns: column3:3(interval) column4:4(interval)
@@ -2273,7 +2273,7 @@ build
 SELECT NOT b FROM bools GROUP BY NOT b
 ----
 group-by
- ├── columns: column3:3(bool)
+ ├── columns: "NOT b":3(bool)
  ├── grouping columns: column3:3(bool)
  └── project
       ├── columns: column3:3(bool)
@@ -2292,7 +2292,7 @@ build
 SELECT NOT b FROM bools GROUP BY b
 ----
 project
- ├── columns: column3:3(bool)
+ ├── columns: "NOT b":3(bool)
  ├── group-by
  │    ├── columns: b:1(bool)
  │    ├── grouping columns: b:1(bool)
@@ -2308,7 +2308,7 @@ build
 SELECT +k * (-w) FROM kv GROUP BY +k, -w
 ----
 project
- ├── columns: column7:7(int)
+ ├── columns: "(+k) * (-w)":7(int)
  ├── group-by
  │    ├── columns: column5:5(int) column6:6(int)
  │    ├── grouping columns: column5:5(int) column6:6(int)
@@ -2335,7 +2335,7 @@ build
 SELECT +k * (-w) FROM kv GROUP BY k, w
 ----
 project
- ├── columns: column5:5(int)
+ ├── columns: "(+k) * (-w)":5(int)
  ├── group-by
  │    ├── columns: k:1(int!null) w:3(int)
  │    ├── grouping columns: k:1(int!null) w:3(int)
@@ -2353,7 +2353,7 @@ build
 SELECT 1 + MIN(v*2) FROM kv GROUP BY k+3
 ----
 project
- ├── columns: column8:8(int)
+ ├── columns: "1 + min(v * 2)":8(int)
  ├── group-by
  │    ├── columns: column5:5(int) column7:7(int)
  │    ├── grouping columns: column5:5(int)
@@ -2380,9 +2380,9 @@ build
 SELECT count(*) FROM kv GROUP BY k, k
 ----
 project
- ├── columns: column5:5(int)
+ ├── columns: count:5(int)
  └── group-by
-      ├── columns: k:1(int!null) column5:5(int)
+      ├── columns: k:1(int!null) count:5(int)
       ├── grouping columns: k:1(int!null)
       ├── project
       │    ├── columns: k:1(int!null)
@@ -2395,9 +2395,9 @@ build
 SELECT COUNT(UPPER(s)) FROM kv GROUP BY UPPER(s)
 ----
 project
- ├── columns: column6:6(int)
+ ├── columns: count:6(int)
  └── group-by
-      ├── columns: column5:5(string) column6:6(int)
+      ├── columns: column5:5(string) count:6(int)
       ├── grouping columns: column5:5(string)
       ├── project
       │    ├── columns: column5:5(string)
@@ -2414,9 +2414,9 @@ build
 SELECT SUM(abc.d) FROM kv JOIN abc ON kv.k >= abc.d GROUP BY kv.*
 ----
 project
- ├── columns: column9:9(decimal)
+ ├── columns: sum:9(decimal)
  └── group-by
-      ├── columns: k:1(int!null) v:2(int) w:3(int) s:4(string) column9:9(decimal)
+      ├── columns: k:1(int!null) v:2(int) w:3(int) s:4(string) sum:9(decimal)
       ├── grouping columns: k:1(int!null) v:2(int) w:3(int) s:4(string)
       ├── project
       │    ├── columns: k:1(int!null) v:2(int) w:3(int) s:4(string) d:8(decimal)

--- a/pkg/sql/opt/optbuilder/testdata/distinct
+++ b/pkg/sql/opt/optbuilder/testdata/distinct
@@ -104,13 +104,13 @@ build
 SELECT DISTINCT y + x FROM xyz ORDER by (y + x)
 ----
 sort
- ├── columns: column4:4(int)
+ ├── columns: "y + x":4(int)
  ├── ordering: +4
  └── group-by
-      ├── columns: column4:4(int)
-      ├── grouping columns: column4:4(int)
+      ├── columns: "y + x":4(int)
+      ├── grouping columns: "y + x":4(int)
       └── project
-           ├── columns: column4:4(int)
+           ├── columns: "y + x":4(int)
            ├── scan xyz
            │    └── columns: x:1(int!null) y:2(int) z:3(float)
            └── projections
@@ -122,13 +122,13 @@ build
 SELECT DISTINCT y + x FROM xyz ORDER BY y + x
 ----
 sort
- ├── columns: column4:4(int)
+ ├── columns: "y + x":4(int)
  ├── ordering: +4
  └── group-by
-      ├── columns: column4:4(int)
-      ├── grouping columns: column4:4(int)
+      ├── columns: "y + x":4(int)
+      ├── grouping columns: "y + x":4(int)
       └── project
-           ├── columns: column4:4(int)
+           ├── columns: "y + x":4(int)
            ├── scan xyz
            │    └── columns: x:1(int!null) y:2(int) z:3(float)
            └── projections
@@ -168,10 +168,10 @@ build
 SELECT DISTINCT (y,z) FROM xyz
 ----
 group-by
- ├── columns: column4:4(tuple{int, float})
- ├── grouping columns: column4:4(tuple{int, float})
+ ├── columns: "(y, z)":4(tuple{int, float})
+ ├── grouping columns: "(y, z)":4(tuple{int, float})
  └── project
-      ├── columns: column4:4(tuple{int, float})
+      ├── columns: "(y, z)":4(tuple{int, float})
       ├── scan xyz
       │    └── columns: x:1(int!null) y:2(int) z:3(float)
       └── projections
@@ -183,7 +183,7 @@ build
 SELECT COUNT(*) FROM (SELECT DISTINCT y FROM xyz)
 ----
 group-by
- ├── columns: column4:4(int)
+ ├── columns: count:4(int)
  ├── project
  │    └── group-by
  │         ├── columns: y:2(int)
@@ -231,12 +231,12 @@ build
 SELECT DISTINCT MAX(x) FROM xyz GROUP BY x
 ----
 group-by
- ├── columns: column4:4(int)
- ├── grouping columns: column4:4(int)
+ ├── columns: max:4(int)
+ ├── grouping columns: max:4(int)
  └── project
-      ├── columns: column4:4(int)
+      ├── columns: max:4(int)
       └── group-by
-           ├── columns: x:1(int!null) column4:4(int)
+           ├── columns: x:1(int!null) max:4(int)
            ├── grouping columns: x:1(int!null)
            ├── project
            │    ├── columns: x:1(int!null)
@@ -250,10 +250,10 @@ build
 SELECT DISTINCT x+y FROM xyz
 ----
 group-by
- ├── columns: column4:4(int)
- ├── grouping columns: column4:4(int)
+ ├── columns: "x + y":4(int)
+ ├── grouping columns: "x + y":4(int)
  └── project
-      ├── columns: column4:4(int)
+      ├── columns: "x + y":4(int)
       ├── scan xyz
       │    └── columns: x:1(int!null) y:2(int) z:3(float)
       └── projections
@@ -265,10 +265,10 @@ build
 SELECT DISTINCT 3 FROM xyz
 ----
 group-by
- ├── columns: column4:4(int!null)
- ├── grouping columns: column4:4(int!null)
+ ├── columns: "3":4(int!null)
+ ├── grouping columns: "3":4(int!null)
  └── project
-      ├── columns: column4:4(int!null)
+      ├── columns: "3":4(int!null)
       ├── scan xyz
       │    └── columns: x:1(int!null) y:2(int) z:3(float)
       └── projections
@@ -278,10 +278,10 @@ build
 SELECT DISTINCT 3
 ----
 group-by
- ├── columns: column1:1(int!null)
- ├── grouping columns: column1:1(int!null)
+ ├── columns: "3":1(int!null)
+ ├── grouping columns: "3":1(int!null)
  └── project
-      ├── columns: column1:1(int!null)
+      ├── columns: "3":1(int!null)
       ├── values
       │    └── tuple [type=tuple{}]
       └── projections
@@ -291,14 +291,14 @@ build
 SELECT DISTINCT MAX(z), x+y, 3 FROM xyz GROUP BY x, y HAVING y > 4
 ----
 group-by
- ├── columns: column4:4(float) column5:5(int) column6:6(int!null)
- ├── grouping columns: column4:4(float) column5:5(int) column6:6(int!null)
+ ├── columns: max:4(float) "x + y":5(int) "3":6(int!null)
+ ├── grouping columns: max:4(float) "x + y":5(int) "3":6(int!null)
  └── project
-      ├── columns: column5:5(int) column6:6(int!null) column4:4(float)
+      ├── columns: "x + y":5(int) "3":6(int!null) max:4(float)
       ├── select
-      │    ├── columns: x:1(int!null) y:2(int!null) column4:4(float)
+      │    ├── columns: x:1(int!null) y:2(int!null) max:4(float)
       │    ├── group-by
-      │    │    ├── columns: x:1(int!null) y:2(int) column4:4(float)
+      │    │    ├── columns: x:1(int!null) y:2(int) max:4(float)
       │    │    ├── grouping columns: x:1(int!null) y:2(int)
       │    │    ├── scan xyz
       │    │    │    └── columns: x:1(int!null) y:2(int) z:3(float)
@@ -343,13 +343,13 @@ build
 SELECT DISTINCT 1, d, b FROM abcd ORDER BY d, b
 ----
 sort
- ├── columns: column5:5(int!null) d:4(int!null) b:2(int!null)
+ ├── columns: "1":5(int!null) d:4(int!null) b:2(int!null)
  ├── ordering: +4,+2
  └── group-by
-      ├── columns: b:2(int!null) d:4(int!null) column5:5(int!null)
-      ├── grouping columns: b:2(int!null) d:4(int!null) column5:5(int!null)
+      ├── columns: b:2(int!null) d:4(int!null) "1":5(int!null)
+      ├── grouping columns: b:2(int!null) d:4(int!null) "1":5(int!null)
       └── project
-           ├── columns: column5:5(int!null) b:2(int!null) d:4(int!null)
+           ├── columns: "1":5(int!null) b:2(int!null) d:4(int!null)
            ├── scan abcd
            │    └── columns: a:1(int!null) b:2(int!null) c:3(int!null) d:4(int!null)
            └── projections

--- a/pkg/sql/opt/optbuilder/testdata/having
+++ b/pkg/sql/opt/optbuilder/testdata/having
@@ -21,7 +21,7 @@ build
 SELECT 3 FROM kv HAVING TRUE
 ----
 project
- ├── columns: column5:5(int!null)
+ ├── columns: "3":5(int!null)
  ├── select
  │    ├── group-by
  │    │    └── project
@@ -35,7 +35,7 @@ build
 SELECT s, COUNT(*) FROM kv GROUP BY s HAVING COUNT(*) > 1
 ----
 select
- ├── columns: s:4(string) column5:5(int!null)
+ ├── columns: s:4(string) count:5(int!null)
  ├── group-by
  │    ├── columns: s:4(string) column5:5(int)
  │    ├── grouping columns: s:4(string)
@@ -53,11 +53,11 @@ build
 SELECT MAX(k), MIN(v) FROM kv HAVING MIN(v) > 2
 ----
 project
- ├── columns: column6:6(int) column5:5(int!null)
+ ├── columns: max:6(int) min:5(int!null)
  └── select
-      ├── columns: column5:5(int!null) column6:6(int)
+      ├── columns: column5:5(int!null) max:6(int)
       ├── group-by
-      │    ├── columns: column5:5(int) column6:6(int)
+      │    ├── columns: column5:5(int) max:6(int)
       │    ├── project
       │    │    ├── columns: k:1(int!null) v:2(int)
       │    │    └── scan kv
@@ -75,11 +75,11 @@ build
 SELECT MAX(k), MIN(v) FROM kv HAVING MAX(v) > 2
 ----
 project
- ├── columns: column6:6(int) column7:7(int)
+ ├── columns: max:6(int) min:7(int)
  └── select
-      ├── columns: column5:5(int!null) column6:6(int) column7:7(int)
+      ├── columns: column5:5(int!null) max:6(int) min:7(int)
       ├── group-by
-      │    ├── columns: column5:5(int) column6:6(int) column7:7(int)
+      │    ├── columns: column5:5(int) max:6(int) min:7(int)
       │    ├── project
       │    │    ├── columns: k:1(int!null) v:2(int)
       │    │    └── scan kv
@@ -127,11 +127,11 @@ build
 SELECT count(*), k+w FROM kv GROUP BY k+w HAVING (k+w) > 5
 ----
 project
- ├── columns: column6:6(int) column5:5(int)
+ ├── columns: count:6(int) "k + w":5(int)
  └── select
-      ├── columns: column5:5(int) column6:6(int)
+      ├── columns: column5:5(int) count:6(int)
       ├── group-by
-      │    ├── columns: column5:5(int) column6:6(int)
+      │    ├── columns: column5:5(int) count:6(int)
       │    ├── grouping columns: column5:5(int)
       │    ├── project
       │    │    ├── columns: column5:5(int)
@@ -159,11 +159,11 @@ build
 SELECT MAX(kv.v) FROM kv GROUP BY v HAVING kv.v > 5
 ----
 project
- ├── columns: column5:5(int)
+ ├── columns: max:5(int)
  └── select
-      ├── columns: v:2(int!null) column5:5(int)
+      ├── columns: v:2(int!null) max:5(int)
       ├── group-by
-      │    ├── columns: v:2(int) column5:5(int)
+      │    ├── columns: v:2(int) max:5(int)
       │    ├── grouping columns: v:2(int)
       │    ├── project
       │    │    ├── columns: v:2(int)
@@ -180,11 +180,11 @@ build
 SELECT SUM(kv.w) FROM kv GROUP BY LOWER(s) HAVING LOWER(kv.s) LIKE 'test%'
 ----
 project
- ├── columns: column6:6(decimal)
+ ├── columns: sum:6(decimal)
  └── select
-      ├── columns: column5:5(string) column6:6(decimal)
+      ├── columns: column5:5(string) sum:6(decimal)
       ├── group-by
-      │    ├── columns: column5:5(string) column6:6(decimal)
+      │    ├── columns: column5:5(string) sum:6(decimal)
       │    ├── grouping columns: column5:5(string)
       │    ├── project
       │    │    ├── columns: column5:5(string) w:3(int)
@@ -205,7 +205,7 @@ build
 SELECT SUM(kv.w) FROM kv GROUP BY LOWER(s) HAVING SUM(w) IN (4, 5, 6)
 ----
 project
- ├── columns: column6:6(decimal!null)
+ ├── columns: sum:6(decimal!null)
  └── select
       ├── columns: column5:5(string) column6:6(decimal!null)
       ├── group-by
@@ -261,9 +261,9 @@ build fully-qualify-names
 SELECT UPPER(s), COUNT(s), COUNT(UPPER(s)) FROM t.kv GROUP BY UPPER(s) HAVING COUNT(s) > 1
 ----
 select
- ├── columns: column5:5(string) column6:6(int!null) column7:7(int)
+ ├── columns: upper:5(string) count:6(int!null) count:7(int)
  ├── group-by
- │    ├── columns: column5:5(string) column6:6(int) column7:7(int)
+ │    ├── columns: column5:5(string) column6:6(int) count:7(int)
  │    ├── grouping columns: column5:5(string)
  │    ├── project
  │    │    ├── columns: column5:5(string) t.public.kv.s:4(string)

--- a/pkg/sql/opt/optbuilder/testdata/join
+++ b/pkg/sql/opt/optbuilder/testdata/join
@@ -2989,7 +2989,7 @@ FROM
     (VALUES (1, 1)) AS u)
 ----
 project
- ├── columns: column1:5(int) column7:7(int)
+ ├── columns: column1:5(int) "column1 + 1":7(int)
  ├── project
  │    ├── columns: column1:5(int) column2:6(int)
  │    └── project

--- a/pkg/sql/opt/optbuilder/testdata/limit
+++ b/pkg/sql/opt/optbuilder/testdata/limit
@@ -127,15 +127,15 @@ build
 SELECT SUM(w) FROM t GROUP BY k, v ORDER BY v DESC LIMIT 10
 ----
 limit
- ├── columns: column4:4(decimal)
+ ├── columns: sum:4(decimal)
  ├── ordering: -2
  ├── sort
- │    ├── columns: v:2(int) column4:4(decimal)
+ │    ├── columns: v:2(int) sum:4(decimal)
  │    ├── ordering: -2
  │    └── project
- │         ├── columns: v:2(int) column4:4(decimal)
+ │         ├── columns: v:2(int) sum:4(decimal)
  │         └── group-by
- │              ├── columns: k:1(int!null) v:2(int) column4:4(decimal)
+ │              ├── columns: k:1(int!null) v:2(int) sum:4(decimal)
  │              ├── grouping columns: k:1(int!null) v:2(int)
  │              ├── scan t
  │              │    └── columns: k:1(int!null) v:2(int) w:3(int)

--- a/pkg/sql/opt/optbuilder/testdata/orderby
+++ b/pkg/sql/opt/optbuilder/testdata/orderby
@@ -142,7 +142,7 @@ build
 SELECT a AS "foo.bar", b FROM t ORDER BY "foo.bar" DESC
 ----
 sort
- ├── columns: foo.bar:1(int!null) b:2(int)
+ ├── columns: bar:1(int!null) b:2(int)
  ├── ordering: -1
  └── project
       ├── columns: a:1(int!null) b:2(int)
@@ -453,10 +453,10 @@ build
 SELECT 1, * FROM t ORDER BY 1
 ----
 sort
- ├── columns: column4:4(int!null) a:1(int!null) b:2(int) c:3(bool)
+ ├── columns: "1":4(int!null) a:1(int!null) b:2(int) c:3(bool)
  ├── ordering: +4
  └── project
-      ├── columns: column4:4(int!null) a:1(int!null) b:2(int) c:3(bool)
+      ├── columns: "1":4(int!null) a:1(int!null) b:2(int) c:3(bool)
       ├── scan t
       │    └── columns: a:1(int!null) b:2(int) c:3(bool)
       └── projections
@@ -480,10 +480,10 @@ build
 SELECT b+2 FROM t ORDER BY b+2
 ----
 sort
- ├── columns: column4:4(int)
+ ├── columns: "b + 2":4(int)
  ├── ordering: +4
  └── project
-      ├── columns: column4:4(int)
+      ├── columns: "b + 2":4(int)
       ├── scan t
       │    └── columns: a:1(int!null) b:2(int) c:3(bool)
       └── projections
@@ -747,7 +747,7 @@ build
 SELECT a+b FROM (SELECT * FROM abcd ORDER BY d)
 ----
 project
- ├── columns: column5:5(int)
+ ├── columns: "a + b":5(int)
  ├── scan abcd
  │    └── columns: a:1(int!null) b:2(int) c:3(int) d:4(int)
  └── projections
@@ -759,7 +759,7 @@ build
 SELECT b+d FROM (SELECT * FROM abcd ORDER BY a,d)
 ----
 project
- ├── columns: column5:5(int)
+ ├── columns: "b + d":5(int)
  ├── scan abcd
  │    └── columns: a:1(int!null) b:2(int) c:3(int) d:4(int)
  └── projections

--- a/pkg/sql/opt/optbuilder/testdata/project
+++ b/pkg/sql/opt/optbuilder/testdata/project
@@ -21,7 +21,7 @@ build
 SELECT 5
 ----
 project
- ├── columns: column1:1(int!null)
+ ├── columns: "5":1(int!null)
  ├── values
  │    └── tuple [type=tuple{}]
  └── projections
@@ -82,7 +82,7 @@ build
 SELECT *, ((x < y) OR x > 1000) FROM a
 ----
 project
- ├── columns: x:1(int!null) y:2(float) column3:3(bool)
+ ├── columns: x:1(int!null) y:2(float) "((x < y) OR (x > 1000))":3(bool)
  ├── scan a
  │    └── columns: x:1(int!null) y:2(float)
  └── projections
@@ -98,7 +98,7 @@ build
 SELECT a.*, true FROM a
 ----
 project
- ├── columns: x:1(int!null) y:2(float) column3:3(bool!null)
+ ├── columns: x:1(int!null) y:2(float) true:3(bool!null)
  ├── scan a
  │    └── columns: x:1(int!null) y:2(float)
  └── projections
@@ -108,9 +108,9 @@ build
 SELECT u + 1, v + 1 FROM (SELECT a.x + 3, a.y + 1.0 FROM a) AS foo(u, v)
 ----
 project
- ├── columns: column5:5(int) column6:6(float)
+ ├── columns: "u + 1":5(int) "v + 1":6(float)
  ├── project
- │    ├── columns: column3:3(int) column4:4(float)
+ │    ├── columns: "a.x + 3":3(int) "a.y + 1.0":4(float)
  │    ├── scan a
  │    │    └── columns: x:1(int!null) y:2(float)
  │    └── projections
@@ -122,10 +122,10 @@ project
  │              └── const: 1.0 [type=float]
  └── projections
       ├── plus [type=int]
-      │    ├── variable: column3 [type=int]
+      │    ├── variable: a.x + 3 [type=int]
       │    └── const: 1 [type=int]
       └── plus [type=float]
-           ├── variable: column4 [type=float]
+           ├── variable: a.y + 1.0 [type=float]
            └── const: 1.0 [type=float]
 
 build
@@ -203,7 +203,7 @@ build
 SELECT rowid::string FROM b
 ----
 project
- ├── columns: column4:4(string)
+ ├── columns: "rowid::STRING":4(string)
  ├── scan b
  │    └── columns: x:1(int) y:2(float) rowid:3(int!null)
  └── projections

--- a/pkg/sql/opt/optbuilder/testdata/select
+++ b/pkg/sql/opt/optbuilder/testdata/select
@@ -6,7 +6,7 @@ build
 SELECT 1
 ----
 project
- ├── columns: column1:1(int!null)
+ ├── columns: "1":1(int!null)
  ├── values
  │    └── tuple [type=tuple{}]
  └── projections
@@ -16,7 +16,7 @@ build
 SELECT NULL
 ----
 project
- ├── columns: column1:1(unknown)
+ ├── columns: NULL:1(unknown)
  ├── values
  │    └── tuple [type=tuple{}]
  └── projections
@@ -60,7 +60,7 @@ build
 SELECT NULL, * FROM abc
 ----
 project
- ├── columns: column4:4(unknown) a:1(int!null) b:2(int) c:3(int)
+ ├── columns: NULL:4(unknown) a:1(int!null) b:2(int) c:3(int)
  ├── scan abc
  │    └── columns: a:1(int!null) b:2(int) c:3(int)
  └── projections
@@ -179,7 +179,7 @@ build
 SELECT v||'foo' FROM kv
 ----
 project
- ├── columns: column3:3(string)
+ ├── columns: "v || 'foo'":3(string)
  ├── scan kv
  │    └── columns: k:1(string!null) v:2(string)
  └── projections
@@ -191,7 +191,7 @@ build
 SELECT LOWER(v) FROM kv
 ----
 project
- ├── columns: column3:3(string)
+ ├── columns: lower:3(string)
  ├── scan kv
  │    └── columns: k:1(string!null) v:2(string)
  └── projections
@@ -222,7 +222,7 @@ build
 SELECT (kv.*) FROM kv
 ----
 project
- ├── columns: column3:3(tuple{string, string})
+ ├── columns: "(kv.*)":3(tuple{string, string})
  ├── scan kv
  │    └── columns: k:1(string!null) v:2(string)
  └── projections
@@ -394,7 +394,7 @@ build
 SELECT (x,y) FROM xyzw
 ----
 project
- ├── columns: column5:5(tuple{int, int})
+ ├── columns: "(x, y)":5(tuple{int, int})
  ├── scan xyzw
  │    └── columns: x:1(int!null) y:2(int) z:3(int) w:4(int)
  └── projections
@@ -526,7 +526,7 @@ build allow-unsupported
 SELECT CASE WHEN NULL THEN 1 ELSE 2 END
 ----
 project
- ├── columns: column1:1(int)
+ ├── columns: "CASE WHEN NULL THEN 1 ELSE 2 END":1(int)
  ├── values
  │    └── tuple [type=tuple{}]
  └── projections
@@ -541,7 +541,7 @@ build
 SELECT 0 * b, b % 1, 0 % b from abc
 ----
 project
- ├── columns: column4:4(int) column5:5(int) column6:6(int)
+ ├── columns: "0 * b":4(int) "b % 1":5(int) "0 % b":6(int)
  ├── scan abc
  │    └── columns: a:1(int!null) b:2(int) c:3(int)
  └── projections
@@ -560,7 +560,7 @@ build
 SELECT 1 IN (1, 2)
 ----
 project
- ├── columns: column1:1(bool)
+ ├── columns: "1 IN (1, 2)":1(bool)
  ├── values
  │    └── tuple [type=tuple{}]
  └── projections
@@ -574,7 +574,7 @@ build
 SELECT NULL IN (1, 2)
 ----
 project
- ├── columns: column1:1(bool)
+ ├── columns: "NULL IN (1, 2)":1(bool)
  ├── values
  │    └── tuple [type=tuple{}]
  └── projections
@@ -588,7 +588,7 @@ build
 SELECT 1 IN (NULL, 2)
 ----
 project
- ├── columns: column1:1(bool)
+ ├── columns: "1 IN (NULL, 2)":1(bool)
  ├── values
  │    └── tuple [type=tuple{}]
  └── projections
@@ -602,7 +602,7 @@ build
 SELECT (1, NULL) IN ((1, 1))
 ----
 project
- ├── columns: column1:1(bool)
+ ├── columns: "(1, NULL) IN ((1, 1))":1(bool)
  ├── values
  │    └── tuple [type=tuple{}]
  └── projections
@@ -620,7 +620,7 @@ build
  SELECT NULL::int IN (SELECT * FROM (VALUES (1)) AS t(a))
 ----
 project
- ├── columns: column2:2(bool)
+ ├── columns: "NULL::INT IN (SELECT * FROM (VALUES (1)) AS t (a))":2(bool)
  ├── values
  │    └── tuple [type=tuple{}]
  └── projections
@@ -636,7 +636,7 @@ build
 SELECT (1, NULL::int) IN (SELECT * FROM (VALUES (1, 1)) AS t(a, b))
 ----
 project
- ├── columns: column4:4(bool)
+ ├── columns: "(1, NULL::INT) IN (SELECT * FROM (VALUES (1, 1)) AS t (a, b))":4(bool)
  ├── values
  │    └── tuple [type=tuple{}]
  └── projections
@@ -661,7 +661,7 @@ build
 SELECT NULL::int NOT IN (SELECT * FROM (VALUES (1)) AS t(a))
 ----
 project
- ├── columns: column2:2(bool)
+ ├── columns: "NULL::INT NOT IN (SELECT * FROM (VALUES (1)) AS t (a))":2(bool)
  ├── values
  │    └── tuple [type=tuple{}]
  └── projections
@@ -678,7 +678,7 @@ build
 SELECT (1, NULL::int) NOT IN (SELECT * FROM (VALUES (1, 1)) AS t(a, b))
 ----
 project
- ├── columns: column4:4(bool)
+ ├── columns: "(1, NULL::INT) NOT IN (SELECT * FROM (VALUES (1, 1)) AS t (a, b))":4(bool)
  ├── values
  │    └── tuple [type=tuple{}]
  └── projections
@@ -705,7 +705,7 @@ build
 SELECT NULL::int IN (SELECT * FROM (VALUES (1)) AS t(a) WHERE a > 1)
 ----
 project
- ├── columns: column2:2(bool)
+ ├── columns: "NULL::INT IN (SELECT * FROM (VALUES (1)) AS t (a) WHERE a > 1)":2(bool)
  ├── values
  │    └── tuple [type=tuple{}]
  └── projections
@@ -726,7 +726,7 @@ build
 SELECT (1, NULL::int) IN (SELECT * FROM (VALUES (1, 1)) AS t(a, b) WHERE a > 1)
 ----
 project
- ├── columns: column4:4(bool)
+ ├── columns: "(1, NULL::INT) IN (SELECT * FROM (VALUES (1, 1)) AS t (a, b) WHERE a > 1)":4(bool)
  ├── values
  │    └── tuple [type=tuple{}]
  └── projections
@@ -756,7 +756,7 @@ build
 SELECT NULL::int NOT IN (SELECT * FROM (VALUES (1)) AS t(a) WHERE a > 1)
 ----
 project
- ├── columns: column2:2(bool)
+ ├── columns: "NULL::INT NOT IN (SELECT * FROM (VALUES (1)) AS t (a) WHERE a > 1)":2(bool)
  ├── values
  │    └── tuple [type=tuple{}]
  └── projections
@@ -778,7 +778,7 @@ build
 SELECT (1, NULL::int) NOT IN (SELECT * FROM (VALUES (1, 1)) AS t(a, b) WHERE a > 1)
 ----
 project
- ├── columns: column4:4(bool)
+ ├── columns: "(1, NULL::INT) NOT IN (SELECT * FROM (VALUES (1, 1)) AS t (a, b) WHERE a > 1)":4(bool)
  ├── values
  │    └── tuple [type=tuple{}]
  └── projections
@@ -809,7 +809,7 @@ build
 SELECT NULL::int NOT IN (SELECT * FROM (VALUES (1)) AS t(a) WHERE a > 1)
 ----
 project
- ├── columns: column2:2(bool)
+ ├── columns: "NULL::INT NOT IN (SELECT * FROM (VALUES (1)) AS t (a) WHERE a > 1)":2(bool)
  ├── values
  │    └── tuple [type=tuple{}]
  └── projections
@@ -831,7 +831,7 @@ build
 SELECT (1, NULL::int) NOT IN (SELECT * FROM (VALUES (1, 1)) AS t(a, b) WHERE a > 1)
 ----
 project
- ├── columns: column4:4(bool)
+ ├── columns: "(1, NULL::INT) NOT IN (SELECT * FROM (VALUES (1, 1)) AS t (a, b) WHERE a > 1)":4(bool)
  ├── values
  │    └── tuple [type=tuple{}]
  └── projections
@@ -862,7 +862,7 @@ build
 SELECT NULL::int NOT IN (SELECT * FROM (VALUES (1)) AS t(a) WHERE a > 1)
 ----
 project
- ├── columns: column2:2(bool)
+ ├── columns: "NULL::INT NOT IN (SELECT * FROM (VALUES (1)) AS t (a) WHERE a > 1)":2(bool)
  ├── values
  │    └── tuple [type=tuple{}]
  └── projections
@@ -884,7 +884,7 @@ build
 SELECT (1, NULL::int) NOT IN (SELECT * FROM (VALUES (1, 1)) AS t(a, b) WHERE a > 1)
 ----
 project
- ├── columns: column4:4(bool)
+ ├── columns: "(1, NULL::INT) NOT IN (SELECT * FROM (VALUES (1, 1)) AS t (a, b) WHERE a > 1)":4(bool)
  ├── values
  │    └── tuple [type=tuple{}]
  └── projections
@@ -980,7 +980,7 @@ build
 SELECT @1, @2 FROM a
 ----
 project
- ├── columns: column3:3(int) column4:4(float)
+ ├── columns: "@1":3(int) "@2":4(float)
  ├── scan a
  │    └── columns: x:1(int!null) y:2(float)
  └── projections

--- a/pkg/sql/opt/optbuilder/testdata/subquery
+++ b/pkg/sql/opt/optbuilder/testdata/subquery
@@ -6,15 +6,15 @@ build
 SELECT (SELECT 1)
 ----
 project
- ├── columns: column2:2(int)
+ ├── columns: "(SELECT 1)":2(int)
  ├── values
  │    └── tuple [type=tuple{}]
  └── projections
       └── subquery [type=int]
            └── max1-row
-                ├── columns: column1:1(int!null)
+                ├── columns: "1":1(int!null)
                 └── project
-                     ├── columns: column1:1(int!null)
+                     ├── columns: "1":1(int!null)
                      ├── values
                      │    └── tuple [type=tuple{}]
                      └── projections
@@ -24,13 +24,13 @@ build
 SELECT 1 IN (SELECT 1)
 ----
 project
- ├── columns: column2:2(bool)
+ ├── columns: "1 IN (SELECT 1)":2(bool)
  ├── values
  │    └── tuple [type=tuple{}]
  └── projections
       └── any: eq [type=bool]
            ├── project
-           │    ├── columns: column1:1(int!null)
+           │    ├── columns: "1":1(int!null)
            │    ├── values
            │    │    └── tuple [type=tuple{}]
            │    └── projections
@@ -41,13 +41,13 @@ build
 SELECT 1 IN ((((SELECT 1))))
 ----
 project
- ├── columns: column2:2(bool)
+ ├── columns: "1 IN ((((SELECT 1))))":2(bool)
  ├── values
  │    └── tuple [type=tuple{}]
  └── projections
       └── any: eq [type=bool]
            ├── project
-           │    ├── columns: column1:1(int!null)
+           │    ├── columns: "1":1(int!null)
            │    ├── values
            │    │    └── tuple [type=tuple{}]
            │    └── projections
@@ -63,7 +63,7 @@ build
 SELECT 1 + (SELECT 1)
 ----
 project
- ├── columns: column2:2(int)
+ ├── columns: "1 + (SELECT 1)":2(int)
  ├── values
  │    └── tuple [type=tuple{}]
  └── projections
@@ -71,9 +71,9 @@ project
            ├── const: 1 [type=int]
            └── subquery [type=int]
                 └── max1-row
-                     ├── columns: column1:1(int!null)
+                     ├── columns: "1":1(int!null)
                      └── project
-                          ├── columns: column1:1(int!null)
+                          ├── columns: "1":1(int!null)
                           ├── values
                           │    └── tuple [type=tuple{}]
                           └── projections
@@ -88,7 +88,7 @@ build
 SELECT (1, 2, 3) IN (SELECT 1, 2, 3)
 ----
 project
- ├── columns: column5:5(bool)
+ ├── columns: "(1, 2, 3) IN (SELECT 1, 2, 3)":5(bool)
  ├── values
  │    └── tuple [type=tuple{}]
  └── projections
@@ -96,7 +96,7 @@ project
            ├── project
            │    ├── columns: column4:4(tuple{int, int, int})
            │    ├── project
-           │    │    ├── columns: column1:1(int!null) column2:2(int!null) column3:3(int!null)
+           │    │    ├── columns: "1":1(int!null) "2":2(int!null) "3":3(int!null)
            │    │    ├── values
            │    │    │    └── tuple [type=tuple{}]
            │    │    └── projections
@@ -105,9 +105,9 @@ project
            │    │         └── const: 3 [type=int]
            │    └── projections
            │         └── tuple [type=tuple{int, int, int}]
-           │              ├── variable: column1 [type=int]
-           │              ├── variable: column2 [type=int]
-           │              └── variable: column3 [type=int]
+           │              ├── variable: 1 [type=int]
+           │              ├── variable: 2 [type=int]
+           │              └── variable: 3 [type=int]
            └── tuple [type=tuple{int, int, int}]
                 ├── const: 1 [type=int]
                 ├── const: 2 [type=int]
@@ -117,7 +117,7 @@ build
 SELECT (1, 2, 3) = (SELECT 1, 2, 3)
 ----
 project
- ├── columns: column5:5(bool)
+ ├── columns: "(1, 2, 3) = (SELECT 1, 2, 3)":5(bool)
  ├── values
  │    └── tuple [type=tuple{}]
  └── projections
@@ -132,7 +132,7 @@ project
                      └── project
                           ├── columns: column4:4(tuple{int, int, int})
                           ├── project
-                          │    ├── columns: column1:1(int!null) column2:2(int!null) column3:3(int!null)
+                          │    ├── columns: "1":1(int!null) "2":2(int!null) "3":3(int!null)
                           │    ├── values
                           │    │    └── tuple [type=tuple{}]
                           │    └── projections
@@ -141,15 +141,15 @@ project
                           │         └── const: 3 [type=int]
                           └── projections
                                └── tuple [type=tuple{int, int, int}]
-                                    ├── variable: column1 [type=int]
-                                    ├── variable: column2 [type=int]
-                                    └── variable: column3 [type=int]
+                                    ├── variable: 1 [type=int]
+                                    ├── variable: 2 [type=int]
+                                    └── variable: 3 [type=int]
 
 build
 SELECT (1, 2, 3) != (SELECT 1, 2, 3)
 ----
 project
- ├── columns: column5:5(bool)
+ ├── columns: "(1, 2, 3) != (SELECT 1, 2, 3)":5(bool)
  ├── values
  │    └── tuple [type=tuple{}]
  └── projections
@@ -164,7 +164,7 @@ project
                      └── project
                           ├── columns: column4:4(tuple{int, int, int})
                           ├── project
-                          │    ├── columns: column1:1(int!null) column2:2(int!null) column3:3(int!null)
+                          │    ├── columns: "1":1(int!null) "2":2(int!null) "3":3(int!null)
                           │    ├── values
                           │    │    └── tuple [type=tuple{}]
                           │    └── projections
@@ -173,15 +173,15 @@ project
                           │         └── const: 3 [type=int]
                           └── projections
                                └── tuple [type=tuple{int, int, int}]
-                                    ├── variable: column1 [type=int]
-                                    ├── variable: column2 [type=int]
-                                    └── variable: column3 [type=int]
+                                    ├── variable: 1 [type=int]
+                                    ├── variable: 2 [type=int]
+                                    └── variable: 3 [type=int]
 
 build
 SELECT (SELECT 1, 2, 3) = (SELECT 1, 2, 3)
 ----
 project
- ├── columns: column9:9(bool)
+ ├── columns: "(SELECT 1, 2, 3) = (SELECT 1, 2, 3)":9(bool)
  ├── values
  │    └── tuple [type=tuple{}]
  └── projections
@@ -192,7 +192,7 @@ project
            │         └── project
            │              ├── columns: column7:7(tuple{int, int, int})
            │              ├── project
-           │              │    ├── columns: column1:1(int!null) column2:2(int!null) column3:3(int!null)
+           │              │    ├── columns: "1":1(int!null) "2":2(int!null) "3":3(int!null)
            │              │    ├── values
            │              │    │    └── tuple [type=tuple{}]
            │              │    └── projections
@@ -201,16 +201,16 @@ project
            │              │         └── const: 3 [type=int]
            │              └── projections
            │                   └── tuple [type=tuple{int, int, int}]
-           │                        ├── variable: column1 [type=int]
-           │                        ├── variable: column2 [type=int]
-           │                        └── variable: column3 [type=int]
+           │                        ├── variable: 1 [type=int]
+           │                        ├── variable: 2 [type=int]
+           │                        └── variable: 3 [type=int]
            └── subquery [type=tuple{int, int, int}]
                 └── max1-row
                      ├── columns: column8:8(tuple{int, int, int})
                      └── project
                           ├── columns: column8:8(tuple{int, int, int})
                           ├── project
-                          │    ├── columns: column4:4(int!null) column5:5(int!null) column6:6(int!null)
+                          │    ├── columns: "1":4(int!null) "2":5(int!null) "3":6(int!null)
                           │    ├── values
                           │    │    └── tuple [type=tuple{}]
                           │    └── projections
@@ -219,30 +219,30 @@ project
                           │         └── const: 3 [type=int]
                           └── projections
                                └── tuple [type=tuple{int, int, int}]
-                                    ├── variable: column4 [type=int]
-                                    ├── variable: column5 [type=int]
-                                    └── variable: column6 [type=int]
+                                    ├── variable: 1 [type=int]
+                                    ├── variable: 2 [type=int]
+                                    └── variable: 3 [type=int]
 
 build
 SELECT (SELECT 1) IN (SELECT 1)
 ----
 project
- ├── columns: column3:3(bool)
+ ├── columns: "(SELECT 1) IN (SELECT 1)":3(bool)
  ├── values
  │    └── tuple [type=tuple{}]
  └── projections
       └── any: eq [type=bool]
            ├── project
-           │    ├── columns: column1:1(int!null)
+           │    ├── columns: "1":1(int!null)
            │    ├── values
            │    │    └── tuple [type=tuple{}]
            │    └── projections
            │         └── const: 1 [type=int]
            └── subquery [type=int]
                 └── max1-row
-                     ├── columns: column2:2(int!null)
+                     ├── columns: "1":2(int!null)
                      └── project
-                          ├── columns: column2:2(int!null)
+                          ├── columns: "1":2(int!null)
                           ├── values
                           │    └── tuple [type=tuple{}]
                           └── projections
@@ -252,16 +252,16 @@ build
 SELECT (SELECT 1) IN (1)
 ----
 project
- ├── columns: column2:2(bool)
+ ├── columns: "(SELECT 1) IN (1)":2(bool)
  ├── values
  │    └── tuple [type=tuple{}]
  └── projections
       └── in [type=bool]
            ├── subquery [type=int]
            │    └── max1-row
-           │         ├── columns: column1:1(int!null)
+           │         ├── columns: "1":1(int!null)
            │         └── project
-           │              ├── columns: column1:1(int!null)
+           │              ├── columns: "1":1(int!null)
            │              ├── values
            │              │    └── tuple [type=tuple{}]
            │              └── projections
@@ -283,7 +283,7 @@ build
 SELECT (SELECT 1, 2) IN (SELECT 1, 2)
 ----
 project
- ├── columns: column7:7(bool)
+ ├── columns: "(SELECT 1, 2) IN (SELECT 1, 2)":7(bool)
  ├── values
  │    └── tuple [type=tuple{}]
  └── projections
@@ -291,7 +291,7 @@ project
            ├── project
            │    ├── columns: column5:5(tuple{int, int})
            │    ├── project
-           │    │    ├── columns: column1:1(int!null) column2:2(int!null)
+           │    │    ├── columns: "1":1(int!null) "2":2(int!null)
            │    │    ├── values
            │    │    │    └── tuple [type=tuple{}]
            │    │    └── projections
@@ -299,15 +299,15 @@ project
            │    │         └── const: 2 [type=int]
            │    └── projections
            │         └── tuple [type=tuple{int, int}]
-           │              ├── variable: column1 [type=int]
-           │              └── variable: column2 [type=int]
+           │              ├── variable: 1 [type=int]
+           │              └── variable: 2 [type=int]
            └── subquery [type=tuple{int, int}]
                 └── max1-row
                      ├── columns: column6:6(tuple{int, int})
                      └── project
                           ├── columns: column6:6(tuple{int, int})
                           ├── project
-                          │    ├── columns: column3:3(int!null) column4:4(int!null)
+                          │    ├── columns: "1":3(int!null) "2":4(int!null)
                           │    ├── values
                           │    │    └── tuple [type=tuple{}]
                           │    └── projections
@@ -315,8 +315,8 @@ project
                           │         └── const: 2 [type=int]
                           └── projections
                                └── tuple [type=tuple{int, int}]
-                                    ├── variable: column3 [type=int]
-                                    └── variable: column4 [type=int]
+                                    ├── variable: 1 [type=int]
+                                    └── variable: 2 [type=int]
 
 # Postgres cannot handle this query, even though it seems sensical:
 #   ERROR:  subquery must return only one column
@@ -326,7 +326,7 @@ build
 SELECT (SELECT 1, 2) IN ((1, 2))
 ----
 project
- ├── columns: column4:4(bool)
+ ├── columns: "(SELECT 1, 2) IN ((1, 2))":4(bool)
  ├── values
  │    └── tuple [type=tuple{}]
  └── projections
@@ -337,7 +337,7 @@ project
            │         └── project
            │              ├── columns: column3:3(tuple{int, int})
            │              ├── project
-           │              │    ├── columns: column1:1(int!null) column2:2(int!null)
+           │              │    ├── columns: "1":1(int!null) "2":2(int!null)
            │              │    ├── values
            │              │    │    └── tuple [type=tuple{}]
            │              │    └── projections
@@ -345,8 +345,8 @@ project
            │              │         └── const: 2 [type=int]
            │              └── projections
            │                   └── tuple [type=tuple{int, int}]
-           │                        ├── variable: column1 [type=int]
-           │                        └── variable: column2 [type=int]
+           │                        ├── variable: 1 [type=int]
+           │                        └── variable: 2 [type=int]
            └── tuple [type=tuple{tuple{int, int}}]
                 └── tuple [type=tuple{int, int}]
                      ├── const: 1 [type=int]
@@ -360,7 +360,7 @@ build
 SELECT (SELECT (1, 2)) IN (SELECT 1, 2)
 ----
 project
- ├── columns: column5:5(bool)
+ ├── columns: "(SELECT (1, 2)) IN (SELECT 1, 2)":5(bool)
  ├── values
  │    └── tuple [type=tuple{}]
  └── projections
@@ -368,7 +368,7 @@ project
            ├── project
            │    ├── columns: column4:4(tuple{int, int})
            │    ├── project
-           │    │    ├── columns: column1:1(int!null) column2:2(int!null)
+           │    │    ├── columns: "1":1(int!null) "2":2(int!null)
            │    │    ├── values
            │    │    │    └── tuple [type=tuple{}]
            │    │    └── projections
@@ -376,13 +376,13 @@ project
            │    │         └── const: 2 [type=int]
            │    └── projections
            │         └── tuple [type=tuple{int, int}]
-           │              ├── variable: column1 [type=int]
-           │              └── variable: column2 [type=int]
+           │              ├── variable: 1 [type=int]
+           │              └── variable: 2 [type=int]
            └── subquery [type=tuple{int, int}]
                 └── max1-row
-                     ├── columns: column3:3(tuple{int, int})
+                     ├── columns: "(1, 2)":3(tuple{int, int})
                      └── project
-                          ├── columns: column3:3(tuple{int, int})
+                          ├── columns: "(1, 2)":3(tuple{int, int})
                           ├── values
                           │    └── tuple [type=tuple{}]
                           └── projections
@@ -394,16 +394,16 @@ build
 SELECT (SELECT (1, 2)) IN ((1, 2))
 ----
 project
- ├── columns: column2:2(bool)
+ ├── columns: "(SELECT (1, 2)) IN ((1, 2))":2(bool)
  ├── values
  │    └── tuple [type=tuple{}]
  └── projections
       └── in [type=bool]
            ├── subquery [type=tuple{int, int}]
            │    └── max1-row
-           │         ├── columns: column1:1(tuple{int, int})
+           │         ├── columns: "(1, 2)":1(tuple{int, int})
            │         └── project
-           │              ├── columns: column1:1(tuple{int, int})
+           │              ├── columns: "(1, 2)":1(tuple{int, int})
            │              ├── values
            │              │    └── tuple [type=tuple{}]
            │              └── projections
@@ -423,13 +423,13 @@ build
 SELECT (SELECT 1, 2) IN (SELECT (1, 2))
 ----
 project
- ├── columns: column5:5(bool)
+ ├── columns: "(SELECT 1, 2) IN (SELECT (1, 2))":5(bool)
  ├── values
  │    └── tuple [type=tuple{}]
  └── projections
       └── any: eq [type=bool]
            ├── project
-           │    ├── columns: column1:1(tuple{int, int})
+           │    ├── columns: "(1, 2)":1(tuple{int, int})
            │    ├── values
            │    │    └── tuple [type=tuple{}]
            │    └── projections
@@ -442,7 +442,7 @@ project
                      └── project
                           ├── columns: column4:4(tuple{int, int})
                           ├── project
-                          │    ├── columns: column2:2(int!null) column3:3(int!null)
+                          │    ├── columns: "1":2(int!null) "2":3(int!null)
                           │    ├── values
                           │    │    └── tuple [type=tuple{}]
                           │    └── projections
@@ -450,20 +450,20 @@ project
                           │         └── const: 2 [type=int]
                           └── projections
                                └── tuple [type=tuple{int, int}]
-                                    ├── variable: column2 [type=int]
-                                    └── variable: column3 [type=int]
+                                    ├── variable: 1 [type=int]
+                                    └── variable: 2 [type=int]
 
 build
 SELECT (SELECT (1, 2)) IN (SELECT (1, 2))
 ----
 project
- ├── columns: column3:3(bool)
+ ├── columns: "(SELECT (1, 2)) IN (SELECT (1, 2))":3(bool)
  ├── values
  │    └── tuple [type=tuple{}]
  └── projections
       └── any: eq [type=bool]
            ├── project
-           │    ├── columns: column1:1(tuple{int, int})
+           │    ├── columns: "(1, 2)":1(tuple{int, int})
            │    ├── values
            │    │    └── tuple [type=tuple{}]
            │    └── projections
@@ -472,9 +472,9 @@ project
            │              └── const: 2 [type=int]
            └── subquery [type=tuple{int, int}]
                 └── max1-row
-                     ├── columns: column2:2(tuple{int, int})
+                     ├── columns: "(1, 2)":2(tuple{int, int})
                      └── project
-                          ├── columns: column2:2(tuple{int, int})
+                          ├── columns: "(1, 2)":2(tuple{int, int})
                           ├── values
                           │    └── tuple [type=tuple{}]
                           └── projections
@@ -486,13 +486,13 @@ build
 SELECT 1 = ANY(SELECT 1)
 ----
 project
- ├── columns: column2:2(bool)
+ ├── columns: "1 = ANY (SELECT 1)":2(bool)
  ├── values
  │    └── tuple [type=tuple{}]
  └── projections
       └── any: eq [type=bool]
            ├── project
-           │    ├── columns: column1:1(int!null)
+           │    ├── columns: "1":1(int!null)
            │    ├── values
            │    │    └── tuple [type=tuple{}]
            │    └── projections
@@ -503,7 +503,7 @@ build
 SELECT (1, 2) = ANY(SELECT 1, 2)
 ----
 project
- ├── columns: column4:4(bool)
+ ├── columns: "(1, 2) = ANY (SELECT 1, 2)":4(bool)
  ├── values
  │    └── tuple [type=tuple{}]
  └── projections
@@ -511,7 +511,7 @@ project
            ├── project
            │    ├── columns: column3:3(tuple{int, int})
            │    ├── project
-           │    │    ├── columns: column1:1(int!null) column2:2(int!null)
+           │    │    ├── columns: "1":1(int!null) "2":2(int!null)
            │    │    ├── values
            │    │    │    └── tuple [type=tuple{}]
            │    │    └── projections
@@ -519,8 +519,8 @@ project
            │    │         └── const: 2 [type=int]
            │    └── projections
            │         └── tuple [type=tuple{int, int}]
-           │              ├── variable: column1 [type=int]
-           │              └── variable: column2 [type=int]
+           │              ├── variable: 1 [type=int]
+           │              └── variable: 2 [type=int]
            └── tuple [type=tuple{int, int}]
                 ├── const: 1 [type=int]
                 └── const: 2 [type=int]
@@ -529,13 +529,13 @@ build
 SELECT 1 = SOME(SELECT 1)
 ----
 project
- ├── columns: column2:2(bool)
+ ├── columns: "1 = SOME (SELECT 1)":2(bool)
  ├── values
  │    └── tuple [type=tuple{}]
  └── projections
       └── any: eq [type=bool]
            ├── project
-           │    ├── columns: column1:1(int!null)
+           │    ├── columns: "1":1(int!null)
            │    ├── values
            │    │    └── tuple [type=tuple{}]
            │    └── projections
@@ -546,7 +546,7 @@ build
 SELECT (1, 2) = SOME(SELECT 1, 2)
 ----
 project
- ├── columns: column4:4(bool)
+ ├── columns: "(1, 2) = SOME (SELECT 1, 2)":4(bool)
  ├── values
  │    └── tuple [type=tuple{}]
  └── projections
@@ -554,7 +554,7 @@ project
            ├── project
            │    ├── columns: column3:3(tuple{int, int})
            │    ├── project
-           │    │    ├── columns: column1:1(int!null) column2:2(int!null)
+           │    │    ├── columns: "1":1(int!null) "2":2(int!null)
            │    │    ├── values
            │    │    │    └── tuple [type=tuple{}]
            │    │    └── projections
@@ -562,8 +562,8 @@ project
            │    │         └── const: 2 [type=int]
            │    └── projections
            │         └── tuple [type=tuple{int, int}]
-           │              ├── variable: column1 [type=int]
-           │              └── variable: column2 [type=int]
+           │              ├── variable: 1 [type=int]
+           │              └── variable: 2 [type=int]
            └── tuple [type=tuple{int, int}]
                 ├── const: 1 [type=int]
                 └── const: 2 [type=int]
@@ -572,14 +572,14 @@ build
 SELECT 1 = ALL(SELECT 1)
 ----
 project
- ├── columns: column2:2(bool)
+ ├── columns: "1 = ALL (SELECT 1)":2(bool)
  ├── values
  │    └── tuple [type=tuple{}]
  └── projections
       └── not [type=bool]
            └── any: ne [type=bool]
                 ├── project
-                │    ├── columns: column1:1(int!null)
+                │    ├── columns: "1":1(int!null)
                 │    ├── values
                 │    │    └── tuple [type=tuple{}]
                 │    └── projections
@@ -590,7 +590,7 @@ build
 SELECT (1, 2) = ALL(SELECT 1, 2)
 ----
 project
- ├── columns: column4:4(bool)
+ ├── columns: "(1, 2) = ALL (SELECT 1, 2)":4(bool)
  ├── values
  │    └── tuple [type=tuple{}]
  └── projections
@@ -599,7 +599,7 @@ project
                 ├── project
                 │    ├── columns: column3:3(tuple{int, int})
                 │    ├── project
-                │    │    ├── columns: column1:1(int!null) column2:2(int!null)
+                │    │    ├── columns: "1":1(int!null) "2":2(int!null)
                 │    │    ├── values
                 │    │    │    └── tuple [type=tuple{}]
                 │    │    └── projections
@@ -607,8 +607,8 @@ project
                 │    │         └── const: 2 [type=int]
                 │    └── projections
                 │         └── tuple [type=tuple{int, int}]
-                │              ├── variable: column1 [type=int]
-                │              └── variable: column2 [type=int]
+                │              ├── variable: 1 [type=int]
+                │              └── variable: 2 [type=int]
                 └── tuple [type=tuple{int, int}]
                      ├── const: 1 [type=int]
                      └── const: 2 [type=int]
@@ -647,7 +647,7 @@ build
 SELECT (1, 2) IN (SELECT a, b FROM abc)
 ----
 project
- ├── columns: column5:5(bool)
+ ├── columns: "(1, 2) IN (SELECT a, b FROM abc)":5(bool)
  ├── values
  │    └── tuple [type=tuple{}]
  └── projections
@@ -670,7 +670,7 @@ build
 SELECT (1, 2) IN (SELECT a, b FROM abc WHERE false)
 ----
 project
- ├── columns: column5:5(bool)
+ ├── columns: "(1, 2) IN (SELECT a, b FROM abc WHERE false)":5(bool)
  ├── values
  │    └── tuple [type=tuple{}]
  └── projections
@@ -701,7 +701,7 @@ build
 SELECT (SELECT a FROM abc)
 ----
 project
- ├── columns: column4:4(int)
+ ├── columns: "(SELECT a FROM abc)":4(int)
  ├── values
  │    └── tuple [type=tuple{}]
  └── projections
@@ -717,7 +717,7 @@ build
 SELECT EXISTS (SELECT a FROM abc)
 ----
 project
- ├── columns: column4:4(bool)
+ ├── columns: "EXISTS (SELECT a FROM abc)":4(bool)
  ├── values
  │    └── tuple [type=tuple{}]
  └── projections
@@ -731,7 +731,7 @@ build
 SELECT (SELECT a FROM abc WHERE false)
 ----
 project
- ├── columns: column4:4(int)
+ ├── columns: "(SELECT a FROM abc WHERE false)":4(int)
  ├── values
  │    └── tuple [type=tuple{}]
  └── projections
@@ -769,9 +769,9 @@ values
       ├── const: 1 [type=int]
       └── subquery [type=int]
            └── max1-row
-                ├── columns: column1:1(int!null)
+                ├── columns: "(2)":1(int!null)
                 └── project
-                     ├── columns: column1:1(int!null)
+                     ├── columns: "(2)":1(int!null)
                      ├── values
                      │    └── tuple [type=tuple{}]
                      └── projections
@@ -808,7 +808,7 @@ build
 SELECT 1 IN (SELECT x FROM xyz ORDER BY x DESC)
 ----
 project
- ├── columns: column4:4(bool)
+ ├── columns: "1 IN (SELECT x FROM xyz ORDER BY x DESC)":4(bool)
  ├── values
  │    └── tuple [type=tuple{}]
  └── projections
@@ -830,9 +830,9 @@ select
       ├── variable: xyz.x [type=int]
       └── subquery [type=int]
            └── max1-row
-                ├── columns: column7:7(int)
+                ├── columns: min:7(int)
                 └── group-by
-                     ├── columns: column7:7(int)
+                     ├── columns: min:7(int)
                      ├── project
                      │    ├── columns: xyz.x:4(int!null)
                      │    └── scan xyz
@@ -852,9 +852,9 @@ select
       ├── variable: xyz.x [type=int]
       └── subquery [type=int]
            └── max1-row
-                ├── columns: column7:7(int)
+                ├── columns: max:7(int)
                 └── group-by
-                     ├── columns: column7:7(int)
+                     ├── columns: max:7(int)
                      ├── project
                      │    ├── columns: xyz.x:4(int!null)
                      │    └── scan xyz
@@ -902,13 +902,13 @@ build
 SELECT EXISTS(SELECT 1 FROM kv AS x WHERE x.k = 1)
 ----
 project
- ├── columns: column4:4(bool)
+ ├── columns: "EXISTS (SELECT 1 FROM kv AS x WHERE x.k = 1)":4(bool)
  ├── values
  │    └── tuple [type=tuple{}]
  └── projections
       └── exists [type=bool]
            └── project
-                ├── columns: column3:3(int!null)
+                ├── columns: "1":3(int!null)
                 ├── select
                 │    ├── columns: k:1(int!null) v:2(string)
                 │    ├── scan kv
@@ -923,13 +923,13 @@ build
 SELECT EXISTS(SELECT 1 FROM kv WHERE k = 2)
 ----
 project
- ├── columns: column4:4(bool)
+ ├── columns: "EXISTS (SELECT 1 FROM kv WHERE k = 2)":4(bool)
  ├── values
  │    └── tuple [type=tuple{}]
  └── projections
       └── exists [type=bool]
            └── project
-                ├── columns: column3:3(int!null)
+                ├── columns: "1":3(int!null)
                 ├── select
                 │    ├── columns: k:1(int!null) v:2(string)
                 │    ├── scan kv
@@ -1327,24 +1327,24 @@ build
 SELECT (SELECT 1), (SELECT 2)
 ----
 project
- ├── columns: column2:2(int) column4:4(int)
+ ├── columns: "(SELECT 1)":2(int) "(SELECT 2)":4(int)
  ├── values
  │    └── tuple [type=tuple{}]
  └── projections
       ├── subquery [type=int]
       │    └── max1-row
-      │         ├── columns: column1:1(int!null)
+      │         ├── columns: "1":1(int!null)
       │         └── project
-      │              ├── columns: column1:1(int!null)
+      │              ├── columns: "1":1(int!null)
       │              ├── values
       │              │    └── tuple [type=tuple{}]
       │              └── projections
       │                   └── const: 1 [type=int]
       └── subquery [type=int]
            └── max1-row
-                ├── columns: column3:3(int!null)
+                ├── columns: "2":3(int!null)
                 └── project
-                     ├── columns: column3:3(int!null)
+                     ├── columns: "2":3(int!null)
                      ├── values
                      │    └── tuple [type=tuple{}]
                      └── projections
@@ -1355,15 +1355,15 @@ build
 SELECT (SELECT 1), (SELECT a FROM abc), (SELECT 1), (SELECT a FROM abc)
 ----
 project
- ├── columns: column2:2(int) column6:6(int) column2:2(int) column6:6(int)
+ ├── columns: "(SELECT 1)":2(int) "(SELECT a FROM abc)":6(int) "(SELECT 1)":2(int) "(SELECT a FROM abc)":6(int)
  ├── values
  │    └── tuple [type=tuple{}]
  └── projections
       ├── subquery [type=int]
       │    └── max1-row
-      │         ├── columns: column1:1(int!null)
+      │         ├── columns: "1":1(int!null)
       │         └── project
-      │              ├── columns: column1:1(int!null)
+      │              ├── columns: "1":1(int!null)
       │              ├── values
       │              │    └── tuple [type=tuple{}]
       │              └── projections
@@ -1381,32 +1381,32 @@ build
 SELECT (SELECT (SELECT 1)), (SELECT (SELECT 1)), (SELECT 1)
 ----
 project
- ├── columns: column3:3(int) column3:3(int) column7:7(int)
+ ├── columns: "(SELECT (SELECT 1))":3(int) "(SELECT (SELECT 1))":3(int) "(SELECT 1)":7(int)
  ├── values
  │    └── tuple [type=tuple{}]
  └── projections
       ├── subquery [type=int]
       │    └── max1-row
-      │         ├── columns: column2:2(int)
+      │         ├── columns: "(SELECT 1)":2(int)
       │         └── project
-      │              ├── columns: column2:2(int)
+      │              ├── columns: "(SELECT 1)":2(int)
       │              ├── values
       │              │    └── tuple [type=tuple{}]
       │              └── projections
       │                   └── subquery [type=int]
       │                        └── max1-row
-      │                             ├── columns: column1:1(int!null)
+      │                             ├── columns: "1":1(int!null)
       │                             └── project
-      │                                  ├── columns: column1:1(int!null)
+      │                                  ├── columns: "1":1(int!null)
       │                                  ├── values
       │                                  │    └── tuple [type=tuple{}]
       │                                  └── projections
       │                                       └── const: 1 [type=int]
       └── subquery [type=int]
            └── max1-row
-                ├── columns: column6:6(int!null)
+                ├── columns: "1":6(int!null)
                 └── project
-                     ├── columns: column6:6(int!null)
+                     ├── columns: "1":6(int!null)
                      ├── values
                      │    └── tuple [type=tuple{}]
                      └── projections
@@ -1417,7 +1417,7 @@ build
 SELECT (SELECT akv.k) FROM kv akv
 ----
 project
- ├── columns: column3:3(int)
+ ├── columns: "(SELECT akv.k)":3(int)
  ├── scan kv
  │    └── columns: k:1(int!null) v:2(string)
  └── projections
@@ -1442,7 +1442,7 @@ build fully-qualify-names
 SELECT (SELECT t.kv.k) FROM db1.kv, kv
 ----
 project
- ├── columns: column5:5(int)
+ ├── columns: "(SELECT t.kv.k)":5(int)
  ├── inner-join
  │    ├── columns: db1.public.kv.k:1(int!null) db1.public.kv.v:2(int) t.public.kv.k:3(int!null) t.public.kv.v:4(string)
  │    ├── scan kv
@@ -1475,7 +1475,7 @@ build fully-qualify-names
 SELECT (SELECT kv1.k) FROM db1.kv AS kv1, kv
 ----
 project
- ├── columns: column5:5(int)
+ ├── columns: "(SELECT kv1.k)":5(int)
  ├── inner-join
  │    ├── columns: db1.public.kv.k:1(int!null) db1.public.kv.v:2(int) t.public.kv.k:3(int!null) t.public.kv.v:4(string)
  │    ├── scan kv
@@ -1498,7 +1498,7 @@ build fully-qualify-names
 SELECT (SELECT kv.k FROM db1.kv) FROM kv
 ----
 project
- ├── columns: column5:5(int)
+ ├── columns: "(SELECT kv.k FROM db1.kv)":5(int)
  ├── scan kv
  │    └── columns: t.public.kv.k:1(int!null) t.public.kv.v:2(string)
  └── projections
@@ -1515,23 +1515,23 @@ build fully-qualify-names
 SELECT (SELECT (SELECT t.kv.k + k) FROM db1.kv) FROM kv
 ----
 project
- ├── columns: column7:7(int)
+ ├── columns: "(SELECT (SELECT t.kv.k + k) FROM db1.kv)":7(int)
  ├── scan kv
  │    └── columns: t.public.kv.k:1(int!null) t.public.kv.v:2(string)
  └── projections
       └── subquery [type=int]
            └── max1-row
-                ├── columns: column6:6(int)
+                ├── columns: "(SELECT t.kv.k + k)":6(int)
                 └── project
-                     ├── columns: column6:6(int)
+                     ├── columns: "(SELECT t.kv.k + k)":6(int)
                      ├── scan kv
                      │    └── columns: db1.public.kv.k:3(int!null) db1.public.kv.v:4(int)
                      └── projections
                           └── subquery [type=int]
                                └── max1-row
-                                    ├── columns: column5:5(int)
+                                    ├── columns: "t.kv.k + k":5(int)
                                     └── project
-                                         ├── columns: column5:5(int)
+                                         ├── columns: "t.kv.k + k":5(int)
                                          ├── values
                                          │    └── tuple [type=tuple{}]
                                          └── projections

--- a/pkg/sql/opt/optbuilder/testdata/union
+++ b/pkg/sql/opt/optbuilder/testdata/union
@@ -315,20 +315,20 @@ build
 SELECT x, pg_typeof(y) FROM (SELECT 1, NULL UNION ALL SELECT 2, 4) AS t(x, y)
 ----
 project
- ├── columns: x:5(int!null) column7:7(string)
+ ├── columns: x:5(int!null) pg_typeof:7(string)
  ├── union-all
- │    ├── columns: column1:5(int!null) column2:6(int)
- │    ├── left columns: column1:1(int) column2:2(unknown)
- │    ├── right columns: column3:3(int) column4:4(int)
+ │    ├── columns: "1":5(int!null) NULL:6(int)
+ │    ├── left columns: "1":1(int) NULL:2(unknown)
+ │    ├── right columns: "2":3(int) "4":4(int)
  │    ├── project
- │    │    ├── columns: column1:1(int!null) column2:2(unknown)
+ │    │    ├── columns: "1":1(int!null) NULL:2(unknown)
  │    │    ├── values
  │    │    │    └── tuple [type=tuple{}]
  │    │    └── projections
  │    │         ├── const: 1 [type=int]
  │    │         └── null [type=unknown]
  │    └── project
- │         ├── columns: column3:3(int!null) column4:4(int!null)
+ │         ├── columns: "2":3(int!null) "4":4(int!null)
  │         ├── values
  │         │    └── tuple [type=tuple{}]
  │         └── projections
@@ -336,26 +336,26 @@ project
  │              └── const: 4 [type=int]
  └── projections
       └── function: pg_typeof [type=string]
-           └── variable: column2 [type=int]
+           └── variable: NULL [type=int]
 
 build
 SELECT x, pg_typeof(y) FROM (SELECT 1, 3 UNION ALL SELECT 2, NULL) AS t(x, y)
 ----
 project
- ├── columns: x:5(int!null) column7:7(string)
+ ├── columns: x:5(int!null) pg_typeof:7(string)
  ├── union-all
- │    ├── columns: column1:5(int!null) column2:6(int)
- │    ├── left columns: column1:1(int) column2:2(int)
- │    ├── right columns: column3:3(int) column4:4(unknown)
+ │    ├── columns: "1":5(int!null) "3":6(int)
+ │    ├── left columns: "1":1(int) "3":2(int)
+ │    ├── right columns: "2":3(int) NULL:4(unknown)
  │    ├── project
- │    │    ├── columns: column1:1(int!null) column2:2(int!null)
+ │    │    ├── columns: "1":1(int!null) "3":2(int!null)
  │    │    ├── values
  │    │    │    └── tuple [type=tuple{}]
  │    │    └── projections
  │    │         ├── const: 1 [type=int]
  │    │         └── const: 3 [type=int]
  │    └── project
- │         ├── columns: column3:3(int!null) column4:4(unknown)
+ │         ├── columns: "2":3(int!null) NULL:4(unknown)
  │         ├── values
  │         │    └── tuple [type=tuple{}]
  │         └── projections
@@ -363,7 +363,7 @@ project
  │              └── null [type=unknown]
  └── projections
       └── function: pg_typeof [type=string]
-           └── variable: column2 [type=int]
+           └── variable: 3 [type=int]
 
 exec-ddl
 CREATE TABLE uniontest (

--- a/pkg/sql/opt/optbuilder/testdata/values
+++ b/pkg/sql/opt/optbuilder/testdata/values
@@ -135,7 +135,7 @@ build
 SELECT COALESCE(a, b) FROM (VALUES (1, 2), (3, NULL), (NULL, 4), (NULL, NULL)) AS v(a, b)
 ----
 project
- ├── columns: column3:3(int)
+ ├── columns: "COALESCE(a, b)":3(int)
  ├── values
  │    ├── columns: column1:1(int) column2:2(int)
  │    ├── tuple [type=tuple{int, int}]
@@ -164,9 +164,9 @@ values
  ├── tuple [type=tuple{int}]
  │    └── subquery [type=int]
  │         └── max1-row
- │              ├── columns: column1:1(int!null)
+ │              ├── columns: "1":1(int!null)
  │              └── project
- │                   ├── columns: column1:1(int!null)
+ │                   ├── columns: "1":1(int!null)
  │                   ├── values
  │                   │    └── tuple [type=tuple{}]
  │                   └── projections
@@ -174,9 +174,9 @@ values
  └── tuple [type=tuple{int}]
       └── subquery [type=int]
            └── max1-row
-                ├── columns: column2:2(int!null)
+                ├── columns: "2":2(int!null)
                 └── project
-                     ├── columns: column2:2(int!null)
+                     ├── columns: "2":2(int!null)
                      ├── values
                      │    └── tuple [type=tuple{}]
                      └── projections
@@ -192,9 +192,9 @@ values
  └── tuple [type=tuple{int}]
       └── subquery [type=int]
            └── max1-row
-                ├── columns: column1:1(int!null)
+                ├── columns: "2":1(int!null)
                 └── project
-                     ├── columns: column1:1(int!null)
+                     ├── columns: "2":1(int!null)
                      ├── values
                      │    └── tuple [type=tuple{}]
                      └── projections

--- a/pkg/sql/opt/optbuilder/testdata/where
+++ b/pkg/sql/opt/optbuilder/testdata/where
@@ -92,7 +92,7 @@ build
 SELECT 'hello' LIKE v FROM kvString WHERE k LIKE 'like%' ORDER BY k
 ----
 project
- ├── columns: column3:3(bool)
+ ├── columns: "'hello' LIKE v":3(bool)
  ├── ordering: +1
  ├── select
  │    ├── columns: k:1(string!null) v:2(string)
@@ -112,7 +112,7 @@ build
 SELECT 'hello' SIMILAR TO v FROM kvString WHERE k SIMILAR TO 'like[1-2]' ORDER BY k
 ----
 project
- ├── columns: column3:3(bool)
+ ├── columns: "'hello' SIMILAR TO v":3(bool)
  ├── ordering: +1
  ├── select
  │    ├── columns: k:1(string!null) v:2(string)
@@ -132,7 +132,7 @@ build
 SELECT 'hello' ~ replace(v, '%', '.*') FROM kvString WHERE k ~ 'like[1-2]' ORDER BY k
 ----
 project
- ├── columns: column3:3(bool)
+ ├── columns: "'hello' ~ replace(v, '%', '.*')":3(bool)
  ├── ordering: +1
  ├── select
  │    ├── columns: k:1(string!null) v:2(string)

--- a/pkg/sql/opt/xform/testdata/external/liquibase
+++ b/pkg/sql/opt/xform/testdata/external/liquibase
@@ -279,7 +279,7 @@ WHERE ((c.relkind = 'r'::CHAR) OR (c.relkind = 'f'::CHAR)) AND (n.nspname = 'pub
 project
  ├── columns: oid:1(oid) schemaname:29(string) tablename:2(string) relacl:26(string[]) tableowner:129(string) description:130(string) relkind:17(string) cluster:92(string) hasoids:20(bool) hasindexes:13(bool) hasrules:22(bool) tablespace:33(string) param:27(string[]) hastriggers:23(bool) unlogged:15(string) ftoptions:120(string[]) srvname:122(string) reltuples:10(float) inhtable:135(bool) inhschemaname:69(string) inhtablename:42(string)
  ├── group-by
- │    ├── columns: pg_class.oid:1(oid) pg_class.relname:2(string) pg_class.relowner:5(oid) pg_class.reltuples:10(float) pg_class.relhasindex:13(bool) pg_class.relpersistence:15(string) pg_class.relkind:17(string) pg_class.relhasoids:20(bool) pg_class.relhasrules:22(bool) pg_class.relhastriggers:23(bool) pg_class.relacl:26(string[]) pg_class.reloptions:27(string[]) pg_namespace.nspname:29(string) spcname:33(string) pg_class.relname:42(string) pg_namespace.nspname:69(string) pg_class.relname:92(string) ftoptions:120(string[]) srvname:122(string) column134:134(int) rownum:136(int!null)
+ │    ├── columns: pg_class.oid:1(oid) pg_class.relname:2(string) pg_class.relowner:5(oid) pg_class.reltuples:10(float) pg_class.relhasindex:13(bool) pg_class.relpersistence:15(string) pg_class.relkind:17(string) pg_class.relhasoids:20(bool) pg_class.relhasrules:22(bool) pg_class.relhastriggers:23(bool) pg_class.relacl:26(string[]) pg_class.reloptions:27(string[]) pg_namespace.nspname:29(string) spcname:33(string) pg_class.relname:42(string) pg_namespace.nspname:69(string) pg_class.relname:92(string) ftoptions:120(string[]) srvname:122(string) count:134(int) rownum:136(int!null)
  │    ├── grouping columns: rownum:136(int!null)
  │    ├── keys: (136)
  │    ├── left-join
@@ -447,5 +447,5 @@ project
       ├── function: obj_description [type=string, outer=(1)]
       │    └── variable: pg_class.oid [type=oid, outer=(1)]
       └── gt [type=bool, outer=(134), constraints=(/134: [/1 - ]; tight)]
-           ├── variable: column134 [type=int, outer=(134)]
+           ├── variable: count [type=int, outer=(134)]
            └── const: 0 [type=int]

--- a/pkg/sql/opt/xform/testdata/external/navicat
+++ b/pkg/sql/opt/xform/testdata/external/navicat
@@ -281,7 +281,7 @@ sort
  └── project
       ├── columns: tableowner:129(string) description:130(string) inhtable:135(bool) pg_class.oid:1(oid) pg_class.relname:2(string) pg_class.reltuples:10(float) pg_class.relhasindex:13(bool) pg_class.relpersistence:15(string) pg_class.relkind:17(string) pg_class.relhasoids:20(bool) pg_class.relhasrules:22(bool) pg_class.relhastriggers:23(bool) pg_class.relacl:26(string[]) pg_class.reloptions:27(string[]) pg_namespace.nspname:29(string) spcname:33(string) pg_class.relname:42(string) pg_namespace.nspname:69(string) pg_class.relname:92(string) ftoptions:120(string[]) srvname:122(string)
       ├── group-by
-      │    ├── columns: pg_class.oid:1(oid) pg_class.relname:2(string) pg_class.relowner:5(oid) pg_class.reltuples:10(float) pg_class.relhasindex:13(bool) pg_class.relpersistence:15(string) pg_class.relkind:17(string) pg_class.relhasoids:20(bool) pg_class.relhasrules:22(bool) pg_class.relhastriggers:23(bool) pg_class.relacl:26(string[]) pg_class.reloptions:27(string[]) pg_namespace.nspname:29(string) spcname:33(string) pg_class.relname:42(string) pg_namespace.nspname:69(string) pg_class.relname:92(string) ftoptions:120(string[]) srvname:122(string) column134:134(int) rownum:136(int!null)
+      │    ├── columns: pg_class.oid:1(oid) pg_class.relname:2(string) pg_class.relowner:5(oid) pg_class.reltuples:10(float) pg_class.relhasindex:13(bool) pg_class.relpersistence:15(string) pg_class.relkind:17(string) pg_class.relhasoids:20(bool) pg_class.relhasrules:22(bool) pg_class.relhastriggers:23(bool) pg_class.relacl:26(string[]) pg_class.reloptions:27(string[]) pg_namespace.nspname:29(string) spcname:33(string) pg_class.relname:42(string) pg_namespace.nspname:69(string) pg_class.relname:92(string) ftoptions:120(string[]) srvname:122(string) count:134(int) rownum:136(int!null)
       │    ├── grouping columns: rownum:136(int!null)
       │    ├── keys: (136)
       │    ├── left-join
@@ -449,5 +449,5 @@ sort
            ├── function: obj_description [type=string, outer=(1)]
            │    └── variable: pg_class.oid [type=oid, outer=(1)]
            └── gt [type=bool, outer=(134), constraints=(/134: [/1 - ]; tight)]
-                ├── variable: column134 [type=int, outer=(134)]
+                ├── variable: count [type=int, outer=(134)]
                 └── const: 0 [type=int]

--- a/pkg/sql/opt/xform/testdata/external/tpcc
+++ b/pkg/sql/opt/xform/testdata/external/tpcc
@@ -837,7 +837,7 @@ FROM order_line
 WHERE ol_w_id = 10 AND ol_d_id = 100 AND ol_o_id = 1000
 ----
 group-by
- ├── columns: column11:11(decimal)
+ ├── columns: sum:11(decimal)
  ├── cardinality: [1 - 1]
  ├── stats: [rows=1]
  ├── cost: 1.00
@@ -909,7 +909,7 @@ ON (w_id = d_w_id)
 WHERE w_ytd != sum_d_ytd
 ----
 group-by
- ├── columns: column22:22(int)
+ ├── columns: count:22(int)
  ├── cardinality: [1 - 1]
  ├── stats: [rows=1]
  ├── cost: 1178.00
@@ -975,14 +975,14 @@ GROUP BY no_d_id, no_w_id
 ORDER BY no_w_id, no_d_id
 ----
 sort
- ├── columns: column4:4(int)
+ ├── columns: max:4(int)
  ├── stats: [rows=100, distinct(2,3)=100]
  ├── cost: 90006.64
  ├── keys: (2,3)
  ├── ordering: +3,+2
  ├── prune: (4)
  └── group-by
-      ├── columns: new_order.no_d_id:2(int!null) new_order.no_w_id:3(int!null) column4:4(int)
+      ├── columns: new_order.no_d_id:2(int!null) new_order.no_w_id:3(int!null) max:4(int)
       ├── grouping columns: new_order.no_d_id:2(int!null) new_order.no_w_id:3(int!null)
       ├── stats: [rows=100, distinct(2,3)=100]
       ├── cost: 90000.00
@@ -1005,14 +1005,14 @@ GROUP BY o_d_id, o_w_id
 ORDER BY o_w_id, o_d_id
 ----
 sort
- ├── columns: column9:9(int)
+ ├── columns: max:9(int)
  ├── stats: [rows=100, distinct(2,3)=100]
  ├── cost: 300006.64
  ├── keys: (2,3)
  ├── ordering: +3,+2
  ├── prune: (9)
  └── group-by
-      ├── columns: "order".o_d_id:2(int!null) "order".o_w_id:3(int!null) column9:9(int)
+      ├── columns: "order".o_d_id:2(int!null) "order".o_w_id:3(int!null) max:9(int)
       ├── grouping columns: "order".o_d_id:2(int!null) "order".o_w_id:3(int!null)
       ├── stats: [rows=100, distinct(2,3)=100]
       ├── cost: 300000.00
@@ -1039,7 +1039,7 @@ FROM
 WHERE nod != -1
 ----
 group-by
- ├── columns: column8:8(int)
+ ├── columns: count:8(int)
  ├── cardinality: [1 - 1]
  ├── stats: [rows=1]
  ├── cost: 90001.00
@@ -1086,14 +1086,14 @@ GROUP BY o_w_id, o_d_id
 ORDER BY o_w_id, o_d_id
 ----
 sort
- ├── columns: column9:9(decimal)
+ ├── columns: sum:9(decimal)
  ├── stats: [rows=100, distinct(2,3)=100]
  ├── cost: 300006.64
  ├── keys: (2,3)
  ├── ordering: +3,+2
  ├── prune: (9)
  └── group-by
-      ├── columns: "order".o_d_id:2(int!null) "order".o_w_id:3(int!null) column9:9(decimal)
+      ├── columns: "order".o_d_id:2(int!null) "order".o_w_id:3(int!null) sum:9(decimal)
       ├── grouping columns: "order".o_d_id:2(int!null) "order".o_w_id:3(int!null)
       ├── stats: [rows=100, distinct(2,3)=100]
       ├── cost: 300000.00
@@ -1115,14 +1115,14 @@ GROUP BY ol_w_id, ol_d_id
 ORDER BY ol_w_id, ol_d_id
 ----
 sort
- ├── columns: column11:11(int)
+ ├── columns: count:11(int)
  ├── stats: [rows=100, distinct(2,3)=100]
  ├── cost: 1000006.64
  ├── keys: (2,3)
  ├── ordering: +3,+2
  ├── prune: (11)
  └── group-by
-      ├── columns: order_line.ol_d_id:2(int!null) order_line.ol_w_id:3(int!null) column11:11(int)
+      ├── columns: order_line.ol_d_id:2(int!null) order_line.ol_w_id:3(int!null) count:11(int)
       ├── grouping columns: order_line.ol_d_id:2(int!null) order_line.ol_w_id:3(int!null)
       ├── stats: [rows=100, distinct(2,3)=100]
       ├── cost: 1000000.00
@@ -1238,7 +1238,7 @@ sort
  └── except-all
       ├── columns: "order".o_w_id:3(int!null) "order".o_d_id:2(int!null) "order".o_id:1(int!null) "order".o_ol_cnt:7(int)
       ├── left columns: "order".o_w_id:3(int!null) "order".o_d_id:2(int!null) "order".o_id:1(int!null) "order".o_ol_cnt:7(int)
-      ├── right columns: order_line.ol_w_id:11(int) order_line.ol_d_id:10(int) order_line.ol_o_id:9(int) column19:19(int)
+      ├── right columns: order_line.ol_w_id:11(int) order_line.ol_d_id:10(int) order_line.ol_o_id:9(int) count:19(int)
       ├── stats: [rows=300000]
       ├── cost: 1300000.00
       ├── scan order
@@ -1248,7 +1248,7 @@ sort
       │    ├── keys: (1-3)
       │    └── prune: (1-3,7)
       └── group-by
-           ├── columns: order_line.ol_o_id:9(int!null) order_line.ol_d_id:10(int!null) order_line.ol_w_id:11(int!null) column19:19(int)
+           ├── columns: order_line.ol_o_id:9(int!null) order_line.ol_d_id:10(int!null) order_line.ol_w_id:11(int!null) count:19(int)
            ├── grouping columns: order_line.ol_o_id:9(int!null) order_line.ol_d_id:10(int!null) order_line.ol_w_id:11(int!null)
            ├── stats: [rows=100000, distinct(9-11)=100000]
            ├── cost: 1000000.00
@@ -1277,18 +1277,18 @@ EXCEPT ALL
 )
 ----
 sort
- ├── columns: ol_w_id:3(int!null) ol_d_id:2(int!null) ol_o_id:1(int!null) column11:11(int)
+ ├── columns: ol_w_id:3(int!null) ol_d_id:2(int!null) ol_o_id:1(int!null) count:11(int)
  ├── stats: [rows=100000]
  ├── cost: 1316609.64
  ├── ordering: +3,+2,-1
  └── except-all
-      ├── columns: order_line.ol_w_id:3(int!null) order_line.ol_d_id:2(int!null) order_line.ol_o_id:1(int!null) column11:11(int)
-      ├── left columns: order_line.ol_w_id:3(int!null) order_line.ol_d_id:2(int!null) order_line.ol_o_id:1(int!null) column11:11(int)
+      ├── columns: order_line.ol_w_id:3(int!null) order_line.ol_d_id:2(int!null) order_line.ol_o_id:1(int!null) count:11(int)
+      ├── left columns: order_line.ol_w_id:3(int!null) order_line.ol_d_id:2(int!null) order_line.ol_o_id:1(int!null) count:11(int)
       ├── right columns: "order".o_w_id:14(int) "order".o_d_id:13(int) "order".o_id:12(int) "order".o_ol_cnt:18(int)
       ├── stats: [rows=100000]
       ├── cost: 1300000.00
       ├── group-by
-      │    ├── columns: order_line.ol_o_id:1(int!null) order_line.ol_d_id:2(int!null) order_line.ol_w_id:3(int!null) column11:11(int)
+      │    ├── columns: order_line.ol_o_id:1(int!null) order_line.ol_d_id:2(int!null) order_line.ol_w_id:3(int!null) count:11(int)
       │    ├── grouping columns: order_line.ol_o_id:1(int!null) order_line.ol_d_id:2(int!null) order_line.ol_w_id:3(int!null)
       │    ├── stats: [rows=100000, distinct(1-3)=100000]
       │    ├── cost: 1000000.00
@@ -1326,7 +1326,7 @@ ON (ol_w_id = o_w_id AND ol_d_id = o_d_id AND ol_o_id = o_id)
 WHERE ol_o_id IS NULL OR o_id IS NULL
 ----
 group-by
- ├── columns: column19:19(int)
+ ├── columns: count:19(int)
  ├── cardinality: [1 - 1]
  ├── stats: [rows=1]
  ├── cost: 1313000.02

--- a/pkg/sql/opt/xform/testdata/external/tpch
+++ b/pkg/sql/opt/xform/testdata/external/tpch
@@ -365,19 +365,19 @@ project
  ├── cardinality: [0 - 100]
  ├── ordering: -15,+23,+11,+1
  └── limit
-      ├── columns: p_partkey:1(int) p_mfgr:3(string) supplier.s_name:11(string) supplier.s_address:12(string) supplier.s_phone:14(string) supplier.s_acctbal:15(float) supplier.s_comment:16(string) partsupp.ps_supplycost:20(float!null) nation.n_name:23(string) column48:48(float!null) rownum:49(int!null)
+      ├── columns: p_partkey:1(int) p_mfgr:3(string) supplier.s_name:11(string) supplier.s_address:12(string) supplier.s_phone:14(string) supplier.s_acctbal:15(float) supplier.s_comment:16(string) partsupp.ps_supplycost:20(float!null) nation.n_name:23(string) min:48(float!null) rownum:49(int!null)
       ├── cardinality: [0 - 100]
       ├── keys: (49)
       ├── ordering: -15,+23,+11,+1
       ├── sort
-      │    ├── columns: p_partkey:1(int) p_mfgr:3(string) supplier.s_name:11(string) supplier.s_address:12(string) supplier.s_phone:14(string) supplier.s_acctbal:15(float) supplier.s_comment:16(string) partsupp.ps_supplycost:20(float!null) nation.n_name:23(string) column48:48(float!null) rownum:49(int!null)
+      │    ├── columns: p_partkey:1(int) p_mfgr:3(string) supplier.s_name:11(string) supplier.s_address:12(string) supplier.s_phone:14(string) supplier.s_acctbal:15(float) supplier.s_comment:16(string) partsupp.ps_supplycost:20(float!null) nation.n_name:23(string) min:48(float!null) rownum:49(int!null)
       │    ├── keys: (49)
       │    ├── ordering: -15,+23,+11,+1
       │    └── select
-      │         ├── columns: p_partkey:1(int) p_mfgr:3(string) supplier.s_name:11(string) supplier.s_address:12(string) supplier.s_phone:14(string) supplier.s_acctbal:15(float) supplier.s_comment:16(string) partsupp.ps_supplycost:20(float!null) nation.n_name:23(string) column48:48(float!null) rownum:49(int!null)
+      │         ├── columns: p_partkey:1(int) p_mfgr:3(string) supplier.s_name:11(string) supplier.s_address:12(string) supplier.s_phone:14(string) supplier.s_acctbal:15(float) supplier.s_comment:16(string) partsupp.ps_supplycost:20(float!null) nation.n_name:23(string) min:48(float!null) rownum:49(int!null)
       │         ├── keys: (49)
       │         ├── group-by
-      │         │    ├── columns: p_partkey:1(int) p_mfgr:3(string) supplier.s_name:11(string) supplier.s_address:12(string) supplier.s_phone:14(string) supplier.s_acctbal:15(float) supplier.s_comment:16(string) partsupp.ps_supplycost:20(float) nation.n_name:23(string) column48:48(float) rownum:49(int!null)
+      │         │    ├── columns: p_partkey:1(int) p_mfgr:3(string) supplier.s_name:11(string) supplier.s_address:12(string) supplier.s_phone:14(string) supplier.s_acctbal:15(float) supplier.s_comment:16(string) partsupp.ps_supplycost:20(float) nation.n_name:23(string) min:48(float) rownum:49(int!null)
       │         │    ├── grouping columns: rownum:49(int!null)
       │         │    ├── keys: (49)
       │         │    ├── left-join-apply
@@ -503,7 +503,7 @@ project
       │         └── filters [type=bool, outer=(20,48), constraints=(/20: (/NULL - ]; /48: (/NULL - ])]
       │              └── eq [type=bool, outer=(20,48), constraints=(/20: (/NULL - ]; /48: (/NULL - ])]
       │                   ├── variable: partsupp.ps_supplycost [type=float, outer=(20)]
-      │                   └── variable: column48 [type=float, outer=(48)]
+      │                   └── variable: min [type=float, outer=(48)]
       └── const: 100 [type=int]
 
 # --------------------------------------------------
@@ -1569,7 +1569,7 @@ sort
                 ├── variable: column37 [type=float, outer=(37)]
                 └── subquery [type=float]
                      └── project
-                          ├── columns: column35:35(float)
+                          ├── columns: "sum(ps_supplycost * ps_availqty::FLOAT) * 0.0001":35(float)
                           ├── cardinality: [1 - 1]
                           ├── group-by
                           │    ├── columns: column34:34(float)
@@ -1771,11 +1771,11 @@ sort
  ├── keys: weak(18)
  ├── ordering: -19,-18
  └── group-by
-      ├── columns: column18:18(int) custdist:19(int)
-      ├── grouping columns: column18:18(int)
+      ├── columns: count:18(int) custdist:19(int)
+      ├── grouping columns: count:18(int)
       ├── keys: weak(18)
       ├── group-by
-      │    ├── columns: c_custkey:1(int!null) column18:18(int)
+      │    ├── columns: c_custkey:1(int!null) count:18(int)
       │    ├── grouping columns: c_custkey:1(int!null)
       │    ├── keys: (1)
       │    ├── left-join
@@ -2141,16 +2141,16 @@ ORDER BY
 LIMIT 100;
 ----
 limit
- ├── columns: c_name:2(string) c_custkey:1(int!null) o_orderkey:9(int!null) o_orderdate:13(date) o_totalprice:12(float) column51:51(float)
+ ├── columns: c_name:2(string) c_custkey:1(int!null) o_orderkey:9(int!null) o_orderdate:13(date) o_totalprice:12(float) sum:51(float)
  ├── cardinality: [0 - 100]
  ├── keys: weak(1,2,9,12,13)
  ├── ordering: -12,+13
  ├── sort
- │    ├── columns: c_custkey:1(int!null) c_name:2(string) o_orderkey:9(int!null) o_totalprice:12(float) o_orderdate:13(date) column51:51(float)
+ │    ├── columns: c_custkey:1(int!null) c_name:2(string) o_orderkey:9(int!null) o_totalprice:12(float) o_orderdate:13(date) sum:51(float)
  │    ├── keys: weak(1,2,9,12,13)
  │    ├── ordering: -12,+13
  │    └── group-by
- │         ├── columns: c_custkey:1(int!null) c_name:2(string) o_orderkey:9(int!null) o_totalprice:12(float) o_orderdate:13(date) column51:51(float)
+ │         ├── columns: c_custkey:1(int!null) c_name:2(string) o_orderkey:9(int!null) o_totalprice:12(float) o_orderdate:13(date) sum:51(float)
  │         ├── grouping columns: c_custkey:1(int!null) c_name:2(string) o_orderkey:9(int!null) o_totalprice:12(float) o_orderdate:13(date)
  │         ├── keys: weak(1,2,9,12,13)
  │         ├── semi-join
@@ -2755,7 +2755,7 @@ sort
       │    │    │              ├── variable: customer.c_acctbal [type=float, outer=(6)]
       │    │    │              └── subquery [type=float]
       │    │    │                   └── group-by
-      │    │    │                        ├── columns: column17:17(float)
+      │    │    │                        ├── columns: avg:17(float)
       │    │    │                        ├── cardinality: [1 - 1]
       │    │    │                        ├── select
       │    │    │                        │    ├── columns: customer.c_phone:13(string) customer.c_acctbal:14(float!null)

--- a/pkg/sql/opt/xform/testdata/physprops/ordering
+++ b/pkg/sql/opt/xform/testdata/physprops/ordering
@@ -109,7 +109,7 @@ opt
 SELECT x+1, y FROM a ORDER BY x, y DESC
 ----
 project
- ├── columns: column5:5(int) y:2(float!null)
+ ├── columns: "x + 1":5(int) y:2(float!null)
  ├── ordering: +1,-2
  ├── scan a
  │    ├── columns: x:1(int!null) y:2(float!null)
@@ -124,10 +124,10 @@ opt
 SELECT y, x, z+1 FROM a ORDER BY x, y
 ----
 sort
- ├── columns: y:2(float!null) x:1(int!null) column5:5(decimal)
+ ├── columns: y:2(float!null) x:1(int!null) "z + 1":5(decimal)
  ├── ordering: +1,+2
  └── project
-      ├── columns: column5:5(decimal) x:1(int!null) y:2(float!null)
+      ├── columns: "z + 1":5(decimal) x:1(int!null) y:2(float!null)
       ├── scan a
       │    └── columns: x:1(int!null) y:2(float!null) z:3(decimal)
       └── projections
@@ -158,7 +158,7 @@ opt
 SELECT y, x-1 FROM a WHERE x>y ORDER BY x, y DESC
 ----
 project
- ├── columns: y:2(float!null) column5:5(int)
+ ├── columns: y:2(float!null) "x - 1":5(int)
  ├── ordering: +1,-2
  ├── select
  │    ├── columns: x:1(int!null) y:2(float!null)
@@ -180,7 +180,7 @@ SELECT y, x-1 FROM a WHERE x>y ORDER BY x, y DESC
 ----
 memo (optimized)
  ├── G1: (project G2 G3)
- │    ├── "[presentation: y:2,column5:5] [ordering: +1,-2]"
+ │    ├── "[presentation: y:2,x - 1:5] [ordering: +1,-2]"
  │    │    ├── best: (project G2="[ordering: +1,-2]" G3)
  │    │    └── cost: 1010.00
  │    └── ""

--- a/pkg/sql/opt/xform/testdata/physprops/presentation
+++ b/pkg/sql/opt/xform/testdata/physprops/presentation
@@ -67,7 +67,7 @@ opt
 SELECT MAX(y), y, y, x FROM a GROUP BY a.x, a.y
 ----
 group-by
- ├── columns: column3:3(int) y:2(int) y:2(int) x:1(int!null)
+ ├── columns: max:3(int) y:2(int) y:2(int) x:1(int!null)
  ├── grouping columns: x:1(int!null) y:2(int)
  ├── scan a
  │    └── columns: x:1(int!null) y:2(int)


### PR DESCRIPTION
This PR is broken into two commits for ease of review: the first contains the
updates to the go code, and the second contains all the updated test cases.

This PR fixes the output column names for projections with no alias
that are not bare table columns. Previously, any synthesized column was
given a name such as column1, column2, etc. Now the name matches the name
given by the existing CockroachDB planner, which is more evocative of
what the column contains.

For example: aggregate columns such as `MAX(x)` are given the name of
the aggregate builtin (e.g., "max"). Other scalar expressions are given
the name of the full expression. For example, `x + y` is given the name
"x + y".