### PR TITLE
distsql: support lookup join on secondary index

### DIFF
--- a/docs/generated/settings/settings.html
+++ b/docs/generated/settings/settings.html
@@ -59,6 +59,6 @@
 <tr><td><code>trace.debug.enable</code></td><td>boolean</td><td><code>false</code></td><td>if set, traces for recent requests can be seen in the /debug page</td></tr>
 <tr><td><code>trace.lightstep.token</code></td><td>string</td><td><code></code></td><td>if set, traces go to Lightstep using this token</td></tr>
 <tr><td><code>trace.zipkin.collector</code></td><td>string</td><td><code></code></td><td>if set, traces go to the given Zipkin instance (example: '127.0.0.1:9411'); ignored if trace.lightstep.token is set.</td></tr>
-<tr><td><code>version</code></td><td>custom validation</td><td><code>2.0-4</code></td><td>set the active cluster version in the format '<major>.<minor>'.</td></tr>
+<tr><td><code>version</code></td><td>custom validation</td><td><code>2.0-5</code></td><td>set the active cluster version in the format '<major>.<minor>'.</td></tr>
 </tbody>
 </table>

--- a/pkg/server/updates_test.go
+++ b/pkg/server/updates_test.go
@@ -419,7 +419,7 @@ func TestReportUsage(t *testing.T) {
 		"diagnostics.reporting.send_crash_reports": "false",
 		"server.time_until_store_dead":             "1m30s",
 		"trace.debug.enable":                       "false",
-		"version":                                  "2.0-4",
+		"version":                                  "2.0-5",
 		"cluster.secret":                           "<redacted>",
 	} {
 		if got, ok := r.last.AlteredSettings[key]; !ok {

--- a/pkg/settings/cluster/cockroach_versions.go
+++ b/pkg/settings/cluster/cockroach_versions.go
@@ -52,6 +52,7 @@ const (
 	VersionProposedTSLeaseRequest
 	VersionRangeAppliedStateKey
 	VersionImportFormats
+	VersionSecondaryLookupJoins
 
 	// Add new versions here (step one of two).
 
@@ -211,6 +212,11 @@ var versionsSingleton = keyedVersions([]keyedVersion{
 		// VersionImportFormats is https://github.com/cockroachdb/cockroach/pull/25615.
 		Key:     VersionImportFormats,
 		Version: roachpb.Version{Major: 2, Minor: 0, Unstable: 4},
+	},
+	{
+		// VersionSecondaryLookupJoins is https://github.com/cockroachdb/cockroach/pull/25628.
+		Key:     VersionSecondaryLookupJoins,
+		Version: roachpb.Version{Major: 2, Minor: 0, Unstable: 5},
 	},
 
 	// Add new versions here (step two of two).

--- a/pkg/sql/backfill/backfill.go
+++ b/pkg/sql/backfill/backfill.go
@@ -115,15 +115,10 @@ func (cb *ColumnBackfiller) Init(evalCtx *tree.EvalContext, desc sqlbase.TableDe
 	var valNeededForCol util.FastIntSet
 	valNeededForCol.AddRange(0, len(desc.Columns)-1)
 
-	colIdxMap := make(map[sqlbase.ColumnID]int, len(desc.Columns))
-	for i, c := range desc.Columns {
-		colIdxMap[c.ID] = i
-	}
-
 	tableArgs := sqlbase.RowFetcherTableArgs{
 		Desc:            &desc,
 		Index:           &desc.PrimaryIndex,
-		ColIdxMap:       colIdxMap,
+		ColIdxMap:       desc.ColumnIdxMap(),
 		Cols:            desc.Columns,
 		ValNeededForCol: valNeededForCol,
 	}

--- a/pkg/sql/distsqlrun/interleaved_reader_joiner.go
+++ b/pkg/sql/distsqlrun/interleaved_reader_joiner.go
@@ -200,10 +200,7 @@ func (irj *interleavedReaderJoiner) initRowFetcher(
 		// since we do not expect any projections or rendering
 		// on a scan before a join.
 		args[i].ValNeededForCol.AddRange(0, len(desc.Columns)-1)
-		args[i].ColIdxMap = make(map[sqlbase.ColumnID]int, len(desc.Columns))
-		for j, c := range desc.Columns {
-			args[i].ColIdxMap[c.ID] = j
-		}
+		args[i].ColIdxMap = desc.ColumnIdxMap()
 		args[i].Desc = &desc
 		args[i].Cols = desc.Columns
 		args[i].Spans = make(roachpb.Spans, len(table.Spans))

--- a/pkg/sql/distsqlrun/tablereader.go
+++ b/pkg/sql/distsqlrun/tablereader.go
@@ -98,7 +98,7 @@ func newTableReader(
 	neededColumns := tr.out.neededColumns()
 
 	if _, _, err := initRowFetcher(
-		&tr.fetcher, &tr.tableDesc, int(spec.IndexIdx), spec.Reverse,
+		&tr.fetcher, &tr.tableDesc, int(spec.IndexIdx), tr.tableDesc.ColumnIdxMap(), spec.Reverse,
 		neededColumns, spec.IsCheck, &tr.alloc,
 	); err != nil {
 		return nil, err
@@ -145,6 +145,7 @@ func initRowFetcher(
 	fetcher *sqlbase.RowFetcher,
 	desc *sqlbase.TableDescriptor,
 	indexIdx int,
+	colIdxMap map[sqlbase.ColumnID]int,
 	reverseScan bool,
 	valNeededForCol util.FastIntSet,
 	isCheck bool,
@@ -153,11 +154,6 @@ func initRowFetcher(
 	index, isSecondaryIndex, err = desc.FindIndexByIndexIdx(indexIdx)
 	if err != nil {
 		return nil, false, err
-	}
-
-	colIdxMap := make(map[sqlbase.ColumnID]int, len(desc.Columns))
-	for i, c := range desc.Columns {
-		colIdxMap[c.ID] = i
 	}
 
 	tableArgs := sqlbase.RowFetcherTableArgs{

--- a/pkg/sql/distsqlrun/zigzagjoiner.go
+++ b/pkg/sql/distsqlrun/zigzagjoiner.go
@@ -407,6 +407,7 @@ func (z *zigzagJoiner) setupInfo(spec *ZigzagJoinerSpec, side int, colOffset int
 		&(info.fetcher),
 		info.table,
 		int(info.index.ID)-1,
+		info.table.ColumnIdxMap(),
 		false, /* reverse */
 		neededCols,
 		false, /* check */

--- a/pkg/sql/logictest/testdata/logic_test/crdb_internal
+++ b/pkg/sql/logictest/testdata/logic_test/crdb_internal
@@ -244,7 +244,7 @@ select crdb_internal.set_vmodule('')
 query T
 select crdb_internal.node_executable_version()
 ----
-2.0-4
+2.0-5
 
 query ITTT colnames
 select node_id, component, field, regexp_replace(regexp_replace(value, '^\d+$', '<port>'), e':\\d+', ':<port>') as value from crdb_internal.node_runtime_info
@@ -332,4 +332,4 @@ select * from crdb_internal.gossip_alerts
 query T
 select crdb_internal.node_executable_version()
 ----
-2.0-4
+2.0-5

--- a/pkg/sql/logictest/testdata/logic_test/lookup_join
+++ b/pkg/sql/logictest/testdata/logic_test/lookup_join
@@ -270,3 +270,95 @@ query T
 SELECT "URL" FROM [EXPLAIN (DISTSQL) SELECT * FROM foo JOIN bar USING(a)]
 ----
 https://cockroachdb.github.io/distsqlplan/decode.html?eJycksFqwzAMhu97iqHTBh6Nk-5iGOS47tCOstvowY3V1pBaQXZgo-TdR-JDm9Ck2262pE__L6ETODK41Ef0oD5BgoBn2AiomAr0nrgNx6KF-QKVCLCuqkMb3ggoiBHUCYINJYKCJT1RNctAgMGgbdmVNQKoDmfIB71HUPNGXDSW040_9LbENWqDPEt67aFie9T8ne-IQMCqDuo-lyJPYUxY_ldYXhfeah7VSke1zhK1IzbIaIZru11yxfCr9oc3sg55lvb9lrgLD7l8fGG7P3Sv3r5EPh8dI-uNceMI1ugrch5_dQVJOwOaPcadeKq5wHemopOJ31XHdQGDPsTsPH4WLqZag5ewnISzHiyHcPoHOB3C2SScDGxvmrufAAAA__9feSho
+
+
+####################################
+#  LOOKUP JOIN ON SECONDARY INDEX  #
+####################################
+statement ok
+SET experimental_force_lookup_join = true
+
+# Create a table with a secondary index which stores another column.
+statement ok
+CREATE TABLE multiples (a INT, b INT, c INT, d INT, PRIMARY KEY (a, b), INDEX bc (b) STORING (c))
+
+# Split into ten parts.
+statement ok
+ALTER TABLE multiples SPLIT AT SELECT i FROM GENERATE_SERIES(1, 9) AS g(i)
+
+# Relocate the ten parts to the five nodes.
+statement ok
+ALTER TABLE multiples TESTING_RELOCATE
+  SELECT ARRAY[i%5+1], i FROM GENERATE_SERIES(0, 9) AS g(i)
+
+# Generate 10 rows.
+statement ok
+INSERT INTO multiples SELECT x, 2*x, 3*x, 4*x FROM
+  GENERATE_SERIES(1, 10) AS A(x)
+
+# Lookup join on covering secondary index
+query TTT colnames
+EXPLAIN SELECT t1.a, t2.c FROM multiples t1 JOIN multiples@bc t2 ON t1.a = t2.b
+----
+Tree            Field           Description
+render          ·               ·
+ └── join       ·               ·
+      │         type            inner
+      │         equality        (a) = (b)
+      │         mergeJoinOrder  +"(a=b)"
+      ├── scan  ·               ·
+      │         table           multiples@primary
+      │         spans           ALL
+      └── scan  ·               ·
+·               table           multiples@bc
+·               spans           ALL
+
+query T
+SELECT "URL" FROM [EXPLAIN (DISTSQL) SELECT t1.a, t2.c FROM multiples t1 JOIN multiples@bc t2 ON t1.a = t2.b]
+----
+https://cockroachdb.github.io/distsqlplan/decode.html?eJy8lM1qg0AUhfd9inDXU-Ko-XOVbUpJSuiuuDDOJdiauTIzQkvw3YtaGg3JKERczs-Z73DOcM8gSeA2OqGG4AM4MHCBgQcMfGAwg5BBpihGrUmVV2rBRnxD4DBIZJabcjtkEJNCCM5gEpMiBPAeHVLcYyRQTR1gINBESVphMpWcIvWzPuWpSbIUNTDY5SaYrDmEBQPKzeVdbaIjQsAL1p_9Qon8Q8_a6EPcor4SfeXZ5JMSOSFZGfi3wtb-XTfuXTcXE7kkJVChaDkIixt-t_RM2ZQ7Vzdvs70Wm_dvgQ_dQge70cJ8hBbc_km4QyfRwW4ksRghCa9_Et7QSXSwG0ksR0jC75-EP3QSHexGEquRZ9QNN3vUGUmNvSaQU84wFEesB56mXMX4piiuMPVyV-mqDYHa1Ke8XmxkfVQabIq5Vey2xPxa7NrJHWjPqvbtYv8R3zOreG4nzx8hL6zipZ28fIS8snfldHwT-ye7ZofF028AAAD__2gv7bk=
+
+query II rowsort
+SELECT t1.a, t2.c FROM multiples t1 JOIN multiples@bc t2 ON t1.a = t2.b
+----
+2   3
+4   6
+6   9
+8   12
+10  15
+
+# Lookup join on non-covering secondary index
+# The index join should be subsumed by joinreader, which takes care of the
+# primary index lookups.
+query TTT colnames
+EXPLAIN SELECT t1.a, t2.d FROM multiples t1 JOIN multiples@bc t2 ON t1.a = t2.b
+----
+Tree                  Field           Description
+render                ·               ·
+ └── join             ·               ·
+      │               type            inner
+      │               equality        (a) = (b)
+      │               mergeJoinOrder  +"(a=b)"
+      ├── scan        ·               ·
+      │               table           multiples@primary
+      │               spans           ALL
+      └── index-join  ·               ·
+           ├── scan   ·               ·
+           │          table           multiples@bc
+           │          spans           ALL
+           └── scan   ·               ·
+·                     table           multiples@primary
+
+query T
+SELECT "URL" FROM [EXPLAIN (DISTSQL) SELECT t1.a, t2.d FROM multiples t1 JOIN multiples@bc t2 ON t1.a = t2.b]
+----
+https://cockroachdb.github.io/distsqlplan/decode.html?eJy8lM2LqzAUxffvryh3nUeNH_1w1W0fj3YosxtcWHMpzthcSSLMUPzfB3WYammjUHGZj5Pf4ZxwLyBJ4C4-o4bwDTgwcIGBBwx8YBBAxCBXlKDWpKorjWArPiF0GKQyL0y1HTFISCGEFzCpyRBCeI2PGR4wFqjmDjAQaOI0qzG5Ss-x-tqci8ykeYYaGOwLE842HKKSARXm-q428Qkh5CUbzv5HqfxBB130MelQ_xN9FPnsnVI5I1kb-LXCNsFDN-5DN1cThSQlUKHoOIjKO3539JfyOXdubt5nex02H94CH7uFHnarhcUELbjDk3DHTqKH3UpiOUES3vAkvLGT6GG3klhNkIQ_PAl_7CR62K0k1hPPqDtuDqhzkhoHTSCnmmEoTtgMPE2FSvBFUVJjmuW-1tUbArVpTnmz2MrmqDLYFnOr2O2I-a3YtZN70J5V7dvF_jO-A6t4YScvniEvreKVnbx6hry2d-X0fBP7J7tlR-Wf7wAAAP__gsjtvg==
+
+query II rowsort
+SELECT t1.a, t2.d FROM multiples t1 JOIN multiples@bc t2 ON t1.a = t2.b
+----
+2   4
+4   8
+6   12
+8   16
+10  20

--- a/pkg/sql/sqlbase/fk.go
+++ b/pkg/sql/sqlbase/fk.go
@@ -649,7 +649,7 @@ func makeBaseFKHelper(
 	tableArgs := RowFetcherTableArgs{
 		Desc:             b.searchTable,
 		Index:            b.searchIdx,
-		ColIdxMap:        ColIDtoRowIndexFromCols(b.searchTable.Columns),
+		ColIdxMap:        b.searchTable.ColumnIdxMap(),
 		IsSecondaryIndex: b.searchIdx.ID != b.searchTable.PrimaryIndex.ID,
 		Cols:             b.searchTable.Columns,
 	}

--- a/pkg/sql/sqlbase/rowfetcher_test.go
+++ b/pkg/sql/sqlbase/rowfetcher_test.go
@@ -55,16 +55,11 @@ func initFetcher(
 			index = &entry.tableDesc.PrimaryIndex
 		}
 
-		colIdxMap := make(map[ColumnID]int)
-		for i, c := range entry.tableDesc.Columns {
-			colIdxMap[c.ID] = i
-		}
-
 		fetcherArgs[i] = RowFetcherTableArgs{
 			Spans:            entry.spans,
 			Desc:             entry.tableDesc,
 			Index:            index,
-			ColIdxMap:        colIdxMap,
+			ColIdxMap:        entry.tableDesc.ColumnIdxMap(),
 			IsSecondaryIndex: isSecondaryIndex,
 			Cols:             entry.tableDesc.Columns,
 			ValNeededForCol:  entry.valNeededForCol,

--- a/pkg/sql/sqlbase/structured.go
+++ b/pkg/sql/sqlbase/structured.go
@@ -1809,6 +1809,16 @@ func (desc *TableDescriptor) FindColumnByName(name tree.Name) (ColumnDescriptor,
 	return ColumnDescriptor{}, false, NewUndefinedColumnError(string(name))
 }
 
+// ColumnIdxMap returns a map from Column ID to the ordinal position of that
+// column.
+func (desc *TableDescriptor) ColumnIdxMap() map[ColumnID]int {
+	colIdxMap := make(map[ColumnID]int, len(desc.Columns))
+	for i, c := range desc.Columns {
+		colIdxMap[c.ID] = i
+	}
+	return colIdxMap
+}
+
 // UpdateColumnDescriptor updates an existing column descriptor.
 func (desc *TableDescriptor) UpdateColumnDescriptor(column ColumnDescriptor) {
 	for i := range desc.Columns {


### PR DESCRIPTION
joinReader now supports lookup joins on secondary indexes. This was a
trivial change for queries where all the output columns are included in
the secondary index. I just modified the physical planner to specify the
secondary index in the JoinReaderSpec and removed checks which prevented
secondary indexes from being used.

The more complicated situation is when we want to do a lookup join
against a non-covering index. In this case, the logical planner plans an
index join before the inner join, but we want to perform the lookup join
first. We now handle this by only planning the lookup join during
physical planning, not the index join. During execution, the joinReader
detects that there are output columns not covered by the secondary
index, and it performs primary index lookups as necessary to retrieve
the additional columns.

Fixes #25431