### PR TITLE
storage: ensure non-expired context before each liveness update attempt

### DIFF
--- a/pkg/storage/node_liveness.go
+++ b/pkg/storage/node_liveness.go
@@ -748,6 +748,10 @@ func (nl *NodeLiveness) updateLiveness(
 	handleCondFailed func(actual Liveness) error,
 ) error {
 	for {
+		// Before each attempt, ensure that the context has not expired.
+		if err := ctx.Err(); err != nil {
+			return err
+		}
 		for _, eng := range nl.engines {
 			// Synchronously writing to all disks before updating node liveness because
 			// we don't want any excessively slow disks to prevent the lease from


### PR DESCRIPTION
Fixes #25430.

Before this change, a liveness update could get stuck in an infinite
loop if its context expired. This is because it would continue to retry
and continue to get `errRetryLiveness` errors due to
`AmbiguousResultErrors` created by `DistSender`.

Release note: None