### PR TITLE
build: pass through env vars to roachtest

### DIFF
--- a/build/teamcity-local-roachtest.sh
+++ b/build/teamcity-local-roachtest.sh
@@ -25,10 +25,17 @@ tc_start_block "Run local roachtests"
 # TODO(dan): Run kv/splits as a proof of concept of running roachtest on every
 # PR. After we're sure this is stable, curate a suite of the tests that work
 # locally.
-run build/builder.sh ./bin/roachtest run kv/splits \
-  --local \
-  --cockroach "cockroach" \
-  --workload "bin/workload" \
-  --artifacts artifacts \
-  --teamcity
+run build/builder.sh \
+  env \
+    GITHUB_API_TOKEN="$GITHUB_API_TOKEN" \
+    BUILD_VCS_NUMBER="$BUILD_VCS_NUMBER" \
+    TC_BUILD_ID="$TC_BUILD_ID" \
+    TC_SERVER_URL="$TC_SERVER_URL" \
+    PKG="${PKG:-}" GOFLAGS="${GOFLAGS:-}" TAGS="${TAGS:-}" \
+  ./bin/roachtest run kv/splits \
+    --local \
+    --cockroach "cockroach" \
+    --workload "bin/workload" \
+    --artifacts artifacts \
+    --teamcity
 tc_end_block "Run local roachtests"

--- a/pkg/cmd/roachtest/kv.go
+++ b/pkg/cmd/roachtest/kv.go
@@ -64,6 +64,8 @@ func registerKVSplits(r *registry) {
 		Nodes:  nodes(4),
 		Stable: true, // DO NOT COPY to new tests
 		Run: func(ctx context.Context, t *test, c *cluster) {
+			t.Fatal("TODO(peter): testing, remove before merging")
+
 			nodes := c.nodes - 1
 			c.Put(ctx, cockroach, "./cockroach", c.Range(1, nodes))
 			c.Put(ctx, workload, "./workload", c.Node(nodes+1))


### PR DESCRIPTION
Pass through various env vars to roachtest so that roachtest can post
github issues.

Release note: None