### PR TITLE
backport-2.0: storage: ensure non-expired context before each liveness update attempt

### DIFF
--- a/pkg/storage/node_liveness.go
+++ b/pkg/storage/node_liveness.go
@@ -703,6 +703,10 @@ func (nl *NodeLiveness) updateLiveness(
 	handleCondFailed func(actual Liveness) error,
 ) error {
 	for {
+		// Before each attempt, ensure that the context has not expired.
+		if err := ctx.Err(); err != nil {
+			return err
+		}
 		if err := nl.updateLivenessAttempt(ctx, newLiveness, oldLiveness, handleCondFailed); err != nil {
 			// Intentionally don't errors.Cause() the error, or we'd hop past errRetryLiveness.
 			if _, ok := err.(*errRetryLiveness); ok {


### PR DESCRIPTION
Backport 1/1 commits from #25631.

/cc @cockroachdb/release

---

Fixes #25430.

Before this change, a liveness update could get stuck in an infinite
loop if its context expired. This is because it would continue to retry
and continue to get `errRetryLiveness` errors due to
`AmbiguousResultErrors` created by `DistSender`.

Release note: None
