### PR TITLE
opt: Fix natural join column reference bug

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/join
+++ b/pkg/sql/opt/exec/execbuilder/testdata/join
@@ -302,3 +302,35 @@ SELECT * FROM a WHERE NOT EXISTS(SELECT * FROM c WHERE x-1 = u)
 x:int  y:int
 1      10
 2      20
+
+exec hide-colnames nodist
+EXPLAIN (VERBOSE) SELECT * FROM (SELECT x, x+1 plus1 FROM a) NATURAL FULL JOIN (SELECT x, 2 two FROM b)
+----
+render               ·         ·                       (x, plus1, two)             ·
+ │                   render 0  COALESCE("a.x", "b.x")  ·                           ·
+ │                   render 1  plus1                   ·                           ·
+ │                   render 2  two                     ·                           ·
+ └── join            ·         ·                       (plus1, "a.x", two, "b.x")  ·
+      │              type      full outer              ·                           ·
+      │              equality  ("a.x") = ("b.x")       ·                           ·
+      ├── render     ·         ·                       (plus1, "a.x")              ·
+      │    │         render 0  x + 1                   ·                           ·
+      │    │         render 1  x                       ·                           ·
+      │    └── scan  ·         ·                       (x)                         ·
+      │              table     a@primary               ·                           ·
+      │              spans     ALL                     ·                           ·
+      └── render     ·         ·                       (two, "b.x")                ·
+           │         render 0  2                       ·                           ·
+           │         render 1  x                       ·                           ·
+           └── scan  ·         ·                       (x)                         ·
+·                    table     b@primary               ·                           ·
+·                    spans     ALL                     ·                           ·
+
+exec rowsort
+SELECT * FROM (SELECT x, x+1 plus1 FROM a) NATURAL FULL JOIN (SELECT x, 2 two FROM b)
+----
+x:int  plus1:int  two:int
+1      2          NULL
+2      3          2
+3      4          2
+4      NULL       2

--- a/pkg/sql/opt/optbuilder/join.go
+++ b/pkg/sql/opt/optbuilder/join.go
@@ -144,10 +144,14 @@ func (b *Builder) buildUsingJoin(
 	outScope.group = b.constructJoin(joinType, leftScope.group, rightScope.group, filter)
 
 	if len(mergedCols) > 0 {
-		// Wrap in a projection to include the merged columns.
+		// Wrap in a projection to include the merged columns and ensure that all
+		// remaining columns are passed through unchanged.
 		for i, col := range outScope.cols {
 			if mergedCol, ok := mergedCols[col.id]; ok {
 				outScope.cols[i].group = mergedCol
+			} else {
+				// Mark column as passthrough.
+				outScope.cols[i].group = 0
 			}
 		}
 

--- a/pkg/sql/opt/optbuilder/testdata/join
+++ b/pkg/sql/opt/optbuilder/testdata/join
@@ -1824,6 +1824,39 @@ project
                 ├── variable: t1.y [type=int]
                 └── variable: t2.y [type=int]
 
+# Regression: computed columns are not wrapped with Variable outside join.
+build
+SELECT * FROM (SELECT x, x+1 AS plus1 FROM t1) NATURAL FULL OUTER JOIN (SELECT x, 2 AS two FROM t2)
+----
+project
+ ├── columns: x:13(int) plus1:6(int) two:12(int)
+ └── project
+      ├── columns: x:13(int) t1.x:2(int) plus1:6(int) t2.x:9(int) two:12(int)
+      ├── full-join
+      │    ├── columns: t1.x:2(int) plus1:6(int) t2.x:9(int) two:12(int)
+      │    ├── project
+      │    │    ├── columns: plus1:6(int) t1.x:2(int)
+      │    │    ├── scan t1
+      │    │    │    └── columns: col1:1(int) t1.x:2(int) col2:3(int) t1.y:4(int) t1.rowid:5(int!null)
+      │    │    └── projections
+      │    │         └── plus [type=int]
+      │    │              ├── variable: t1.x [type=int]
+      │    │              └── const: 1 [type=int]
+      │    ├── project
+      │    │    ├── columns: two:12(int!null) t2.x:9(int)
+      │    │    ├── scan t2
+      │    │    │    └── columns: col3:7(int) t2.y:8(int) t2.x:9(int) col4:10(int) t2.rowid:11(int!null)
+      │    │    └── projections
+      │    │         └── const: 2 [type=int]
+      │    └── filters [type=bool]
+      │         └── eq [type=bool]
+      │              ├── variable: t1.x [type=int]
+      │              └── variable: t2.x [type=int]
+      └── projections
+           └── coalesce [type=int]
+                ├── variable: t1.x [type=int]
+                └── variable: t2.x [type=int]
+
 build
 SELECT * FROM t1 FULL OUTER JOIN t2 ON t1.x=t2.x
 ----


### PR DESCRIPTION
A query like this:

  SELECT *
  FROM (SELECT x, 1 FROM t1)
  NATURAL FULL OUTER JOIN (SELECT x, 2 FROM t2)

was incorrectly projecting the constant columns in the wrapper
created by the natural join, like this:

  SELECT COALESCE(t1.x, t2.x), 1, 2
  FROM (SELECT x, 1 FROM t1)
  FULL OUTER JOIN (SELECT x, 2 FROM t2)
  ON t1.x = t2.x

The fix wraps synthesized columns in variable references, so that
the right value gets projected in the case where the left or right
side is padded with nulls due to the full outer join.

Release note: None