### PR TITLE
storage: bump RaftTickInterval in TestReplicaLazyLoad

### DIFF
--- a/pkg/storage/client_raft_test.go
+++ b/pkg/storage/client_raft_test.go
@@ -3094,7 +3094,7 @@ func TestReplicaLazyLoad(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	sc := storage.TestStoreConfig(nil)
-	sc.RaftTickInterval = time.Millisecond // safe because there is only a single node
+	sc.RaftTickInterval = 10 * time.Millisecond // safe because there is only a single node
 	sc.TestingKnobs.DisableScanner = true
 	sc.TestingKnobs.DisablePeriodicGossips = true
 	mtc := &multiTestContext{storeConfig: &sc}


### PR DESCRIPTION
Fixes #25430.

Before this change, the `RaftTickInterval` in the test was so low that
node liveness only had a few milliseconds to perform updates. This
caused the test to be flaky, especially in #25281, which is slowing
down all tests by changing from in-memory stores to on-disk stores. By
bumping up the `RaftTickInterval` by an order of magnitude in the test,
we give node liveness much more time to perform updates.

Release note: None