### PR TITLE
cherrypick-2.0: sql: fix crash when propagating filters through groupNode

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/aggregate
+++ b/pkg/sql/logictest/testdata/logic_test/aggregate
@@ -1488,3 +1488,30 @@ render                    ·            ·
 # Regression test for #23798 until #10495 is fixed.
 statement error function reserved for internal use
 SELECT final_variance(1.2, 1.2, 123) FROM kv
+
+# Regression test for #25533 (crash when propagating filter through GROUP BY).
+query TTTTT
+EXPLAIN (VERBOSE) SELECT 1 FROM kv GROUP BY v, w::DECIMAL HAVING w::DECIMAL > 1;
+----
+render                    ·            ·                          ("1")                           "1"=CONST
+ │                        render 0     1                          ·                               ·
+ └── group                ·            ·                          ("w::DECIMAL")                  ·
+      │                   aggregate 0  test.public.kv.w::DECIMAL  ·                               ·
+      │                   group by     @1-@2                      ·                               ·
+      └── filter          ·            ·                          (v, "w::DECIMAL")               "w::DECIMAL"!=NULL
+           │              filter       "w::DECIMAL" > 1           ·                               ·
+           └── render     ·            ·                          (v, "w::DECIMAL")               ·
+                │         render 0     test.public.kv.v           ·                               ·
+                │         render 1     test.public.kv.w::DECIMAL  ·                               ·
+                └── scan  ·            ·                          (k[omitted], v, w, s[omitted])  k!=NULL; key(k)
+·                         table        kv@primary                 ·                               ·
+·                         spans        ALL                        ·                               ·
+
+query I
+SELECT 1 FROM kv GROUP BY v, w::DECIMAL HAVING w::DECIMAL > 1
+----
+1
+1
+1
+1
+1

--- a/pkg/sql/opt_filters.go
+++ b/pkg/sql/opt_filters.go
@@ -436,8 +436,7 @@ func (p *planner) addGroupFilter(
 	}
 
 	// Propagate the inner filter.
-	newPlan, err := p.propagateOrWrapFilters(
-		ctx, g.plan, info, innerFilter)
+	newPlan, err := p.propagateOrWrapFilters(ctx, g.plan, nil /* info */, innerFilter)
 	if err != nil {
 		return g, extraFilter, err
 	}


### PR DESCRIPTION
We were incorrectly passing the `info` for the `groupNode` as the
`info` for the input. This causes a crash, but only in fairly specific
circumstances: when we have a filter that we need to put in a
`filterNode` around the input, and the input has fewer columns than the
`groupNode`.

Fixes #25533.

Release note (bug fix): Fixed a crash in some cases when using a GROUP
BY with HAVING.