### PR TITLE
sql: Wait for node statuses in test that sets zone config on node attr

### DIFF
--- a/pkg/ccl/partitionccl/partition_test.go
+++ b/pkg/ccl/partitionccl/partition_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/config"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
-	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
@@ -1121,28 +1120,7 @@ func setupPartitioningTestCluster(ctx context.Context, t testing.TB) (*sqlutils.
 
 	// Make sure all stores are present in the NodeStatus endpoint or else zone
 	// config changes may flake (#25488).
-	testutils.SucceedsSoon(t, func() error {
-		url := tc.Server(0).ServingAddr()
-		conn, err := tc.Server(0).RPCContext().GRPCDial(url).Connect(context.Background())
-		if err != nil {
-			return err
-		}
-		client := serverpb.NewStatusClient(conn)
-		response, err := client.Nodes(context.Background(), &serverpb.NodesRequest{})
-		if err != nil {
-			return err
-		}
-
-		if len(response.Nodes) != 3 {
-			return fmt.Errorf("not enough nodes registered: %+v", response)
-		}
-		for _, node := range response.Nodes {
-			if len(node.StoreStatuses) != 1 {
-				return fmt.Errorf("expected 1 StoreStatus in NodeStatus, got %+v", node)
-			}
-		}
-		return nil
-	})
+	tc.WaitForNodeStatuses(t)
 
 	return sqlDB, func() {
 		tc.Stopper().Stop(context.Background())

--- a/pkg/sql/show_trace_replica_test.go
+++ b/pkg/sql/show_trace_replica_test.go
@@ -53,8 +53,12 @@ func TestShowTraceReplica(t *testing.T) {
 	}}
 	tc := testcluster.StartTestCluster(t, numNodes, tcArgs)
 	defer tc.Stopper().Stop(ctx)
-	sqlDB := sqlutils.MakeSQLRunner(tc.Conns[0])
 
+	// Make sure all stores are present in the NodeStatus endpoint or else zone
+	// config changes may flake (#25488).
+	tc.WaitForNodeStatuses(t)
+
+	sqlDB := sqlutils.MakeSQLRunner(tc.Conns[0])
 	sqlDB.Exec(t, `CREATE DATABASE d`)
 	sqlDB.Exec(t, `CREATE TABLE d.t1 (a INT PRIMARY KEY)`)
 	sqlDB.Exec(t, `CREATE TABLE d.t2 (a INT PRIMARY KEY)`)


### PR DESCRIPTION
Reusing the code I added recently to fix the same problem in
partitioning tests.

There are no other tests I can find that set zone configs on attributes
like "+n3" or "+s3", so hopefully this is the last of them. I should
have checked that after the partitioning flakes.

Fixes #25649

Release note: None