### PR TITLE
ccl/importccl: fix nil pointer dereference when importing date values

### DIFF
--- a/pkg/ccl/importccl/read_import_csv.go
+++ b/pkg/ccl/importccl/read_import_csv.go
@@ -138,6 +138,9 @@ func (c *csvInputReader) convertRecord(ctx context.Context, kvCh chan<- kvBatch)
 	if err != nil {
 		return err
 	}
+	if conv.evalCtx.SessionData == nil {
+		panic("uninitialized session data")
+	}
 
 	for batch := range c.recordCh {
 		for batchIdx, record := range batch.r {


### PR DESCRIPTION
Properly initialize `rowConverter.evalCtx` to contain a non-nil
`SessionData`.

Fixes #25648
Fixes #25647

Release note (bug fix): Fix a nil pointer dereference when importing
data containing date values.