### PR TITLE
sql: Add logictest configs for 2.1 cost-based optimizer

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/postgres_jsonb
+++ b/pkg/sql/logictest/testdata/logic_test/postgres_jsonb
@@ -1,4 +1,4 @@
-# LogicTest: default parallel-stmts distsql distsql-metadata
+# LogicTest: default opt parallel-stmts distsql distsql-opt distsql-metadata
 
 # This file is an incomplete porting of
 # https://github.com/postgres/postgres/blob/11e264517dff7a911d9e6494de86049cab42cde3/src/test/regress/sql/jsonb.sql

--- a/pkg/sql/logictest/testdata/logic_test/postgresjoin
+++ b/pkg/sql/logictest/testdata/logic_test/postgresjoin
@@ -1,4 +1,4 @@
-# LogicTest: default parallel-stmts distsql distsql-metadata distsql-disk
+# LogicTest: default opt parallel-stmts distsql distsql-opt distsql-metadata distsql-disk
 
 # These are postgres regress sql join test suite
 # https://github.com/postgres/postgres/blob/master/src/test/regress/sql/join.sql


### PR DESCRIPTION
Add two new configs to run the SQL logic tests with the 2.1 cost-based
optimizer. Enable the new configs for two of the logic tests.

Release note: None