### PR TITLE
Makefile: use 8m timeout for Go tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ FILES :=
 SUBTESTS :=
 
 ## Test timeout to use for regular tests.
-TESTTIMEOUT := 4m
+TESTTIMEOUT := 8m
 
 ## Test timeout to use for race tests.
 RACETIMEOUT := 25m


### PR DESCRIPTION
The logic tests were bumping up against the 4m threshold, causing
regular flakes.

Perhaps we want to be more selective about increasing the timeout,
but my preference would be to not block this PR on it but to file
an issue instead.

Fixes #25582.
Fixes #25482.

Release note: None