### PR TITLE
sql: set an "application name" for queries run using the InternalExecutor

### DIFF
--- a/pkg/sql/internal.go
+++ b/pkg/sql/internal.go
@@ -385,6 +385,9 @@ func (ie *internalExecutorImpl) execInternal(
 	stmt string,
 	qargs ...interface{},
 ) (retRes result, retErr error) {
+	if sargs != nil && sargs.ApplicationName == "" {
+		sargs.ApplicationName = "internal-" + opName
+	}
 
 	defer func() {
 		// We wrap errors with the opName, but not if they're retriable - in that

--- a/pkg/sql/show_test.go
+++ b/pkg/sql/show_test.go
@@ -27,11 +27,9 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
-	"github.com/cockroachdb/cockroach/pkg/server"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/jobs"
 	"github.com/cockroachdb/cockroach/pkg/sql/tests"
-	"github.com/cockroachdb/cockroach/pkg/sqlmigrations"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -580,16 +578,9 @@ func TestShowSessions(t *testing.T) {
 		base.TestClusterArgs{
 			ReplicationMode: base.ReplicationManual,
 			ServerArgs: base.TestServerArgs{
-				DisableEventLog: true,
-				UseDatabase:     "test",
+				UseDatabase: "test",
 				Knobs: base.TestingKnobs{
 					SQLExecutor: execKnobs,
-					SQLMigrationManager: &sqlmigrations.MigrationManagerTestingKnobs{
-						DisableMigrations: true,
-					},
-					Upgrade: &server.UpgradeTestingKnobs{
-						DisableUpgrade: 1,
-					},
 				},
 			},
 		})
@@ -598,7 +589,7 @@ func TestShowSessions(t *testing.T) {
 	conn = tc.ServerConn(0)
 	sqlutils.CreateTable(t, conn, "t", "num INT", 0, nil)
 
-	const showSessions = "SELECT active_queries, node_id, (now() - session_start)::FLOAT FROM [SHOW CLUSTER SESSIONS]"
+	const showSessions = "SELECT node_id, (now() - session_start)::FLOAT FROM [SHOW CLUSTER SESSIONS]"
 
 	rows, err := conn.Query(showSessions)
 	if err != nil {
@@ -607,17 +598,14 @@ func TestShowSessions(t *testing.T) {
 	defer rows.Close()
 
 	count := 0
-	var q string
 	for rows.Next() {
 		count++
 
 		var nodeID int
 		var delta float64
-		var queries string
-		if err := rows.Scan(&queries, &nodeID, &delta); err != nil {
+		if err := rows.Scan(&nodeID, &delta); err != nil {
 			t.Fatal(err)
 		}
-		q = q + queries
 		if nodeID < 1 || nodeID > 2 {
 			t.Fatalf("invalid node ID: %d", nodeID)
 		}
@@ -634,7 +622,7 @@ func TestShowSessions(t *testing.T) {
 	}
 
 	if expectedCount := 1; count != expectedCount {
-		t.Fatalf("unexpected number of running sessions: %d, expected %d, %s", count, expectedCount, q)
+		t.Fatalf("unexpected number of running sessions: %d, expected %d", count, expectedCount)
 	}
 }
 


### PR DESCRIPTION
Seems like a good idea in general, and it allows tests for `show
sessions` to filter them out.
TestShowSessions was flaky because it was running into unexpected
sessions created by various internal queries that run in the background.

Fixes #25331

Release note: None