### PR TITLE
opt: Fallback to 2.0 planner on 2.1 optimizer unsupported feature

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/optimizer
+++ b/pkg/sql/logictest/testdata/logic_test/optimizer
@@ -7,6 +7,12 @@ statement ok
 INSERT INTO t VALUES (1, 10), (2, 20), (3, 30)
 
 statement ok
+CREATE TABLE xy (x INT PRIMARY KEY, y INT)
+
+statement ok
+INSERT INTO xy VALUES (2, 200), (3, 300), (4, 400)
+
+statement ok
 SET EXPERIMENTAL_OPT = ON
 
 # ParenSelect
@@ -41,6 +47,13 @@ SELECT * FROM test.t UNION SELECT * FROM test.t
 2  20
 3  30
 
+# Correlated subquery (only supported by cost-based optimizer)
+query II rowsort
+SELECT * FROM t WHERE EXISTS(SELECT * FROM xy WHERE x=t.k)
+----
+2  20
+3  30
+
 # Insert
 statement ok
 INSERT INTO t VALUES (4, 40)
@@ -56,11 +69,22 @@ SELECT * FROM test.t WHERE 2*v > (SELECT MAX(v) FROM test.t)
 3  30
 4  40
 
+# Fall back to heuristic planner when feature is not support in cost-based
+# optimizer.
+query I rowsort
+SELECT COUNT(*) FILTER (WHERE v>10) FROM t
+----
+3
+
 statement ok
 SET EXPERIMENTAL_OPT = ALWAYS
 
 query error pq: unexpected statement: \*tree.Insert
 INSERT INTO test (k, v) VALUES (5, 50)
+
+# Don't fall back to heuristic planner in ALWAYS mode.
+query error pq: aggregates with FILTER are not supported yet
+SELECT COUNT(*) FILTER (WHERE v>10) FROM t
 
 statement ok
 SET EXPERIMENTAL_OPT = LOCAL

--- a/pkg/sql/opt/optbuilder/builder.go
+++ b/pkg/sql/opt/optbuilder/builder.go
@@ -113,7 +113,7 @@ func (b *Builder) Build() (root memo.GroupID, required *props.Physical, err erro
 			// only possible because the code does not update shared state and does
 			// not manipulate locks.
 			if bldErr, ok := r.(builderError); ok {
-				err = bldErr
+				err = bldErr.error
 			} else {
 				panic(r)
 			}

--- a/pkg/sql/opt/optbuilder/testdata/aggregate
+++ b/pkg/sql/opt/optbuilder/testdata/aggregate
@@ -207,7 +207,7 @@ project
 build
 SELECT ARRAY_AGG(NULL)
 ----
-error: ambiguous call: array_agg(unknown), candidates are:
+error (42725): ambiguous call: array_agg(unknown), candidates are:
 array_agg(int) -> int[]
 array_agg(float) -> float[]
 array_agg(decimal) -> decimal[]
@@ -278,7 +278,7 @@ error: column "kv.k" must appear in the GROUP BY clause or be used in an aggrega
 build
 SELECT COUNT(*) FROM kv GROUP BY s < 5
 ----
-error: unsupported comparison operator: <string> < <int>
+error (22023): unsupported comparison operator: <string> < <int>
 
 build
 SELECT COUNT(*), k FROM kv GROUP BY k
@@ -314,27 +314,27 @@ project
 build
 SELECT * FROM kv GROUP BY v, COUNT(w)
 ----
-error: aggregate functions are not allowed in GROUP BY
+error (42803): aggregate functions are not allowed in GROUP BY
 
 build
 SELECT COUNT(w) FROM kv GROUP BY 1
 ----
-error: aggregate functions are not allowed in GROUP BY
+error (42803): aggregate functions are not allowed in GROUP BY
 
 build
 SELECT SUM(v) FROM kv GROUP BY k LIMIT SUM(v)
 ----
-error: aggregate functions are not allowed in LIMIT
+error (42803): aggregate functions are not allowed in LIMIT
 
 build
 SELECT SUM(v) FROM kv GROUP BY k LIMIT 1 OFFSET SUM(v)
 ----
-error: aggregate functions are not allowed in OFFSET
+error (42803): aggregate functions are not allowed in OFFSET
 
 build
 VALUES (99, COUNT(1))
 ----
-error: aggregate functions are not allowed in VALUES
+error (42803): aggregate functions are not allowed in VALUES
 
 build
 SELECT COUNT(*), k FROM kv GROUP BY 5
@@ -585,12 +585,12 @@ error: column "kv.v" must appear in the GROUP BY clause or be used in an aggrega
 build
 SELECT k FROM kv WHERE AVG(k) > 1
 ----
-error: aggregate functions are not allowed in WHERE
+error (42803): aggregate functions are not allowed in WHERE
 
 build
 SELECT MAX(AVG(k)) FROM kv
 ----
-error: aggregate functions are not allowed in the argument of max()
+error (42803): aggregate functions are not allowed in the argument of max()
 
 # Test case from #2761.
 build
@@ -669,7 +669,7 @@ group-by
 build
 SELECT COUNT(k, v) FROM kv
 ----
-error: unknown signature: count(int, int)
+error (42883): unknown signature: count(int, int)
 
 build
 SELECT v, COUNT(k) FROM kv GROUP BY v ORDER BY v
@@ -1167,32 +1167,32 @@ group-by
 build
 SELECT AVG(a) FROM abc
 ----
-error: unknown signature: avg(string)
+error (42883): unknown signature: avg(string)
 
 build
 SELECT AVG(c) FROM abc
 ----
-error: unknown signature: avg(bool)
+error (42883): unknown signature: avg(bool)
 
 build
 SELECT AVG((a,c)) FROM abc
 ----
-error: unknown signature: avg(tuple{string, bool})
+error (42883): unknown signature: avg(tuple{string, bool})
 
 build
 SELECT SUM(a) FROM abc
 ----
-error: unknown signature: sum(string)
+error (42883): unknown signature: sum(string)
 
 build
 SELECT SUM(c) FROM abc
 ----
-error: unknown signature: sum(bool)
+error (42883): unknown signature: sum(bool)
 
 build
 SELECT SUM((a,c)) FROM abc
 ----
-error: unknown signature: sum(tuple{string, bool})
+error (42883): unknown signature: sum(tuple{string, bool})
 
 exec-ddl
 CREATE TABLE xyz (
@@ -2447,12 +2447,12 @@ project
 build
 SELECT SUM(DISTINCT abc.d) FROM abc
 ----
-error: aggregates with DISTINCT are not supported yet
+error (0A000): aggregates with DISTINCT are not supported yet
 
 build
 SELECT SUM(abc.d) FILTER (WHERE abc.d > 0) FROM abc
 ----
-error: aggregates with FILTER are not supported yet
+error (0A000): aggregates with FILTER are not supported yet
 
 # Check that ordering by an alias of an aggregate works.
 build

--- a/pkg/sql/opt/optbuilder/testdata/distinct
+++ b/pkg/sql/opt/optbuilder/testdata/distinct
@@ -139,7 +139,7 @@ sort
 build
 SELECT DISTINCT y + z FROM xyz ORDER BY y + z
 ----
-error: unsupported binary operator: <int> + <float>
+error (22023): unsupported binary operator: <int> + <float>
 
 # TODO(rytaft): This query causes an error in Postgres, but it is supported by
 # CockroachDB with the semantics:

--- a/pkg/sql/opt/optbuilder/testdata/having
+++ b/pkg/sql/opt/optbuilder/testdata/having
@@ -102,12 +102,12 @@ project
 build
 SELECT MAX(k), MIN(v) FROM kv HAVING MAX(MIN(v)) > 2
 ----
-error: aggregate functions are not allowed in the argument of max()
+error (42803): aggregate functions are not allowed in the argument of max()
 
 build
 SELECT MAX(k), MIN(v) FROM kv HAVING k
 ----
-error: argument of HAVING must be type bool, not type int
+error (42804): argument of HAVING must be type bool, not type int
 
 # Expressions listed in the HAVING clause must conform to same validation as the SELECT clause (grouped or aggregated).
 build

--- a/pkg/sql/opt/optbuilder/testdata/inner-join
+++ b/pkg/sql/opt/optbuilder/testdata/inner-join
@@ -110,12 +110,12 @@ TABLE a
 build fully-qualify-names
 SELECT a.x FROM db1.a, db2.a
 ----
-error: ambiguous source name: "a"
+error (42P09): ambiguous source name: "a"
 
 build fully-qualify-names
 SELECT x FROM a, b
 ----
-error: column reference "x" is ambiguous (candidates: a.x, b.x)
+error (42702): column reference "x" is ambiguous (candidates: a.x, b.x)
 
 build fully-qualify-names
 SELECT * FROM db1.a, db2.a
@@ -152,4 +152,4 @@ inner-join
 build fully-qualify-names
 SELECT a.* FROM t.a, a AS a
 ----
-error: ambiguous source name: "a"
+error (42P09): ambiguous source name: "a"

--- a/pkg/sql/opt/optbuilder/testdata/join
+++ b/pkg/sql/opt/optbuilder/testdata/join
@@ -27,7 +27,7 @@ project
 build
 SELECT x FROM onecolumn AS a, onecolumn AS b
 ----
-error: column reference "x" is ambiguous (candidates: a.x, b.x)
+error (42702): column reference "x" is ambiguous (candidates: a.x, b.x)
 
 # Check that name resolution does not choke on ambiguity if an
 # unqualified column name is requested and there is an anonymous
@@ -879,12 +879,12 @@ project
 build
 SELECT x, a.x, b.y FROM (SELECT * FROM onecolumn AS a NATURAL JOIN twocolumn AS b) AS q
 ----
-error: no data source matches prefix: a
+error (42P01): no data source matches prefix: a
 
 build
 SELECT x, a.x, b.y FROM (SELECT * FROM onecolumn AS a NATURAL JOIN twocolumn AS b)
 ----
-error: no data source matches prefix: a
+error (42P01): no data source matches prefix: a
 
 
 ## Simple test cases for inner, left, right, and outer joins
@@ -1265,17 +1265,17 @@ project
 build
 SELECT x FROM (SELECT * FROM onecolumn), (SELECT * FROM onecolumn)
 ----
-error: column reference "x" is ambiguous (candidates: <anonymous>.x, <anonymous>.x)
+error (42702): column reference "x" is ambiguous (candidates: <anonymous>.x, <anonymous>.x)
 
 build
 SELECT * FROM (onecolumn AS a JOIN onecolumn AS b ON x > 32)
 ----
-error: column reference "x" is ambiguous (candidates: a.x, b.x)
+error (42702): column reference "x" is ambiguous (candidates: a.x, b.x)
 
 build
 SELECT * FROM (onecolumn AS a JOIN onecolumn AS b ON a.y > y)
 ----
-error: column name "a.y" not found
+error (42703): column name "a.y" not found
 
 # THe following queries verify that only the necessary columns are scanned.
 build
@@ -3206,4 +3206,4 @@ project
 build
 SELECT * FROM foo JOIN bar ON foo.c
 ----
-error: argument of ON must be type bool, not type float
+error (42804): argument of ON must be type bool, not type float

--- a/pkg/sql/opt/optbuilder/testdata/limit
+++ b/pkg/sql/opt/optbuilder/testdata/limit
@@ -116,12 +116,12 @@ limit
 build
 SELECT k FROM T LIMIT k
 ----
-error: column name "k" not found
+error (42703): column name "k" not found
 
 build
 SELECT k FROM T LIMIT v
 ----
-error: column name "v" not found
+error (42703): column name "v" not found
 
 build
 SELECT SUM(w) FROM t GROUP BY k, v ORDER BY v DESC LIMIT 10

--- a/pkg/sql/opt/optbuilder/testdata/orderby
+++ b/pkg/sql/opt/optbuilder/testdata/orderby
@@ -108,7 +108,7 @@ sort
 build
 SELECT a AS foo, b AS foo FROM t ORDER BY foo
 ----
-error: ORDER BY "foo" is ambiguous
+error (42P09): ORDER BY "foo" is ambiguous
 
 # Check that no ambiguity is reported if the ORDER BY name refers
 # to two or more equivalent renders (special case in SQL92).
@@ -392,12 +392,12 @@ error: non-integer constant in ORDER BY: 2.5
 build
 SELECT * FROM t ORDER BY foo
 ----
-error: column name "foo" not found
+error (42703): column name "foo" not found
 
 build
 SELECT a FROM t ORDER BY a.b
 ----
-error: no data source matches prefix: a
+error (42P01): no data source matches prefix: a
 
 build
 SELECT GENERATE_SERIES FROM GENERATE_SERIES(1, 100) ORDER BY ARRAY[GENERATE_SERIES]

--- a/pkg/sql/opt/optbuilder/testdata/project
+++ b/pkg/sql/opt/optbuilder/testdata/project
@@ -139,7 +139,7 @@ project
 build
 SELECT rowid FROM (SELECT * FROM b)
 ----
-error: column name "rowid" not found
+error (42703): column name "rowid" not found
 
 build
 SELECT rowid FROM (SELECT rowid FROM b)
@@ -178,7 +178,7 @@ TABLE c
 build
 SELECT rowid FROM b, c
 ----
-error: column reference "rowid" is ambiguous (candidates: b.rowid, c.rowid)
+error (42702): column reference "rowid" is ambiguous (candidates: b.rowid, c.rowid)
 
 build
 SELECT x, y, rowid FROM c WHERE rowid > 0
@@ -214,12 +214,12 @@ project
 build
 SELECT (x, y)::timestamp FROM b
 ----
-error: invalid cast: tuple{int, float} -> TIMESTAMP
+error (42846): invalid cast: tuple{int, float} -> TIMESTAMP
 
 build
 SELECT CAST(x AS int[]) FROM b
 ----
-error: invalid cast: int -> INT[]
+error (42846): invalid cast: int -> INT[]
 
 exec-ddl
 CREATE TABLE abc (a INT PRIMARY KEY, b INT, c INT)
@@ -234,22 +234,22 @@ TABLE abc
 build
 SELECT c FROM (SELECT a FROM abc)
 ----
-error: column name "c" not found
+error (42703): column name "c" not found
 
 build
 SELECT c FROM (SELECT a FROM abc ORDER BY c)
 ----
-error: column name "c" not found
+error (42703): column name "c" not found
 
 build
 SELECT c FROM (SELECT a, b FROM abc ORDER BY c)
 ----
-error: column name "c" not found
+error (42703): column name "c" not found
 
 build fully-qualify-names
 SELECT t.kv.k FROM abc AS kv
 ----
-error: no data source matches prefix: t.kv
+error (42P01): no data source matches prefix: t.kv
 
 exec-ddl
 CREATE TABLE kv (k INT PRIMARY KEY, v INT)

--- a/pkg/sql/opt/optbuilder/testdata/select
+++ b/pkg/sql/opt/optbuilder/testdata/select
@@ -48,7 +48,7 @@ TABLE abc
 build
 SELECT * FROM abc WHERE 'hello'
 ----
-error: could not parse "hello" as type bool: invalid bool value
+error (22P02): could not parse "hello" as type bool: invalid bool value
 
 build
 SELECT * FROM abc
@@ -236,33 +236,33 @@ project
 build
 SELECT foo.* FROM kv
 ----
-error: no data source matches pattern: foo.*
+error (42P01): no data source matches pattern: foo.*
 
 build
 SELECT *
 ----
-error: cannot use "*" without a FROM clause
+error (42602): cannot use "*" without a FROM clause
 
 build
 SELECT kv.* AS foo FROM kv
 ----
-error: "kv.*" cannot be aliased
+error (42601): "kv.*" cannot be aliased
 
 build
 SELECT bar.kv.* FROM kv
 ----
-error: no data source matches pattern: bar.kv.*
+error (42P01): no data source matches pattern: bar.kv.*
 
 # Don't panic with invalid names (#8024)
 build
 SELECT kv.*[1] FROM kv
 ----
-error: cannot subscript type tuple{string, string} because it is not an array
+error (42804): cannot subscript type tuple{string, string} because it is not an array
 
 build
 SELECT ARRAY[]
 ----
-error: cannot determine type of empty array. Consider annotating with the desired type, for example ARRAY[]:::int[]
+error (42P18): cannot determine type of empty array. Consider annotating with the desired type, for example ARRAY[]:::int[]
 
 build
 SELECT FOO.k FROM kv AS foo WHERE foo.k = 'a'
@@ -334,19 +334,19 @@ TABLE xyzw
 build
 SELECT * FROM xyzw LIMIT x
 ----
-error: column name "x" not found
+error (42703): column name "x" not found
 
 # TODO(rytaft): Fix error message:
 # error: name "y" is not defined
 build
 SELECT * FROM xyzw OFFSET 1 + y
 ----
-error: column name "y" not found
+error (42703): column name "y" not found
 
 build
 SELECT * FROM xyzw LIMIT 3.3
 ----
-error: argument of LIMIT must be type int, not type decimal
+error (42804): argument of LIMIT must be type int, not type decimal
 
 build
 SELECT * FROM xyzw ORDER BY 1 LIMIT '1'
@@ -362,7 +362,7 @@ limit
 build
 SELECT * FROM xyzw OFFSET 1.5
 ----
-error: argument of OFFSET must be type int, not type decimal
+error (42804): argument of OFFSET must be type int, not type decimal
 
 # At execution time, this will cause the error: negative value for LIMIT
 build
@@ -1019,7 +1019,7 @@ select
 build
 SELECT * FROM a WHERE (x > 10)::INT[]
 ----
-error: invalid cast: bool -> INT[]
+error (42846): invalid cast: bool -> INT[]
 
 build
 SELECT * FROM a WHERE x = $1

--- a/pkg/sql/opt/optbuilder/testdata/subquery
+++ b/pkg/sql/opt/optbuilder/testdata/subquery
@@ -82,7 +82,7 @@ project
 build
 SELECT 1 + (SELECT 1, 2)
 ----
-error: unsupported binary operator: <int> + <tuple{int, int}>
+error (22023): unsupported binary operator: <int> + <tuple{int, int}>
 
 build
 SELECT (1, 2, 3) IN (SELECT 1, 2, 3)
@@ -621,12 +621,12 @@ error: subquery must return only one column, found 2
 build
 SELECT 1 IN (SELECT 1, 2)
 ----
-error: unsupported comparison operator: <int> IN <tuple{tuple{int, int}}>
+error (22023): unsupported comparison operator: <int> IN <tuple{tuple{int, int}}>
 
 build
 SELECT (1, 2) IN (SELECT 1)
 ----
-error: unsupported comparison operator: <tuple{int, int}> IN <tuple{int}>
+error (22023): unsupported comparison operator: <tuple{int, int}> IN <tuple{int}>
 
 exec-ddl
 CREATE TABLE abc (a INT PRIMARY KEY, b INT, c INT)
@@ -641,7 +641,7 @@ TABLE abc
 build
 SELECT (1, 2) IN (SELECT * FROM abc)
 ----
-error: unsupported comparison operator: <tuple{int, int}> IN <tuple{tuple{int, int, int}}>
+error (22023): unsupported comparison operator: <tuple{int, int}> IN <tuple{tuple{int, int, int}}>
 
 build
 SELECT (1, 2) IN (SELECT a, b FROM abc)
@@ -760,7 +760,7 @@ TABLE kv
 build
 SELECT (SELECT abc.k FROM abc) FROM kv AS abc
 ----
-error: column name "abc.k" not found
+error (42703): column name "abc.k" not found
 
 build
 VALUES (1, (SELECT (2)))
@@ -1487,13 +1487,13 @@ project
 build fully-qualify-names
 SELECT (SELECT kv.k) FROM db1.kv, kv
 ----
-error: ambiguous source name: "kv"
+error (42P09): ambiguous source name: "kv"
 
 # Name not found after searching multiple scopes.
 build fully-qualify-names
 SELECT (SELECT kv1.k) FROM db1.kv, kv
 ----
-error: no data source matches prefix: kv1
+error (42P01): no data source matches prefix: kv1
 
 build fully-qualify-names
 SELECT (SELECT kv1.k) FROM db1.kv AS kv1, kv

--- a/pkg/sql/opt/optbuilder/testdata/union
+++ b/pkg/sql/opt/optbuilder/testdata/union
@@ -735,7 +735,7 @@ error: EXCEPT types int and string cannot be matched
 build
 SELECT 1 UNION SELECT 3 ORDER BY z
 ----
-error: column name "z" not found
+error (42703): column name "z" not found
 
 build
 SELECT ARRAY[1] UNION ALL SELECT ARRAY['foo']

--- a/pkg/sql/opt/optbuilder/testdata/values
+++ b/pkg/sql/opt/optbuilder/testdata/values
@@ -52,7 +52,7 @@ limit
 build
 VALUES (1), (1), (2), (3) ORDER BY z
 ----
-error: column name "z" not found
+error (42703): column name "z" not found
 
 build
 VALUES ('this', 'is', 'a', 'test'), (1, 2, 3, 4)

--- a/pkg/sql/opt/optbuilder/testdata/where
+++ b/pkg/sql/opt/optbuilder/testdata/where
@@ -90,7 +90,7 @@ select
 build
 SELECT * FROM kv WHERE nonexistent = 1
 ----
-error: column name "nonexistent" not found
+error (42703): column name "nonexistent" not found
 
 build
 SELECT 'hello' LIKE v FROM kvString WHERE k LIKE 'like%' ORDER BY k
@@ -275,4 +275,4 @@ project
 build
 SELECT * FROM ab WHERE a
 ----
-error: argument of WHERE must be type bool, not type int
+error (42804): argument of WHERE must be type bool, not type int


### PR DESCRIPTION
If the 2.1 optimizer does not support a SQL feature, it will now
fallback to use the 2.0 planner instead. We detect an unsupported
feature by looking for pgerror.CodeFeatureNotSupportedError, which
optbuilder will return.