### PR TITLE
json: properly report capacity of encoded jsons

### DIFF
--- a/pkg/util/json/encoded.go
+++ b/pkg/util/json/encoded.go
@@ -80,7 +80,11 @@ func newEncodedFromRoot(v []byte) (*jsonEncoded, error) {
 	return &jsonEncoded{
 		typ:          typ,
 		containerLen: containerLen,
-		value:        v,
+		// Manually set the capacity of the new slice to its length, so we properly
+		// report the memory size of this encoded json object. The original slice
+		// capacity is very large, since it probably points to the backing byte
+		// slice of a kv batch.
+		value: v[:len(v):len(v)],
 	}, nil
 }
 


### PR DESCRIPTION
Previously, jsonEncoded structs reported their memory size as including
the underlying capacity of their encoded byte slices. This was
incorrect, as usually that underlying slice is an entire kv batch. This
problem led to significant overcounting of the memory used by queries
that read JSON data from disk, which resulted in spurious
BudgetExceededErrors.

Release note (bug fix): prevent spurious BudgetExceededErrors for some
queries that read a lot of JSON data from disk.