### PR TITLE
sql: add the array_to_string builtin

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -228,6 +228,10 @@
 </span></td></tr>
 <tr><td><code>array_replace(array: timetz[], toreplace: timetz, replacewith: timetz) &rarr; timetz[]</code></td><td><span class="funcdesc"><p>Replace all occurrences of <code>toreplace</code> in <code>array</code> with <code>replacewith</code>.</p>
 </span></td></tr>
+<tr><td><code>array_to_string(input: anyelement[], delim: <a href="string.html">string</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Join an array into a string with a delimiter.</p>
+</span></td></tr>
+<tr><td><code>array_to_string(input: anyelement[], delimiter: <a href="string.html">string</a>, null: <a href="string.html">string</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Join an array into a string with a delimiter, replacing NULLs with a null string.</p>
+</span></td></tr>
 <tr><td><code>array_upper(input: anyelement[], array_dimension: <a href="int.html">int</a>) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Calculates the maximum value of <code>input</code> on the provided <code>array_dimension</code>. However, because CockroachDB doesn’t yet support multi-dimensional arrays, the only supported <code>array_dimension</code> is <strong>1</strong>.</p>
 </span></td></tr>
 <tr><td><code>string_to_array(str: <a href="string.html">string</a>, delimiter: <a href="string.html">string</a>) &rarr; <a href="string.html">string</a>[]</code></td><td><span class="funcdesc"><p>Split a string into components on a delimiter.</p>

--- a/pkg/sql/logictest/testdata/logic_test/builtin_function
+++ b/pkg/sql/logictest/testdata/logic_test/builtin_function
@@ -1723,3 +1723,13 @@ SELECT lpad('abc', 100000000000000)
 
 query error memory budget exceeded
 SELECT rpad('abc', 100000000000000)
+
+query TT
+SELECT array_to_string(ARRAY['a', 'b,', NULL, 'c'], ','), array_to_string(ARRAY['a', 'b,', NULL, 'c'], ',', NULL)
+----
+a,b,,c  a,b,,c
+
+query TT
+SELECT array_to_string(ARRAY['a', 'b,', 'c'], NULL), array_to_string(ARRAY['a', 'b,', NULL, 'c'], 'foo', 'zerp')
+----
+NULL  afoob,foozerpfooc

--- a/pkg/sql/sem/builtins/builtins_test.go
+++ b/pkg/sql/sem/builtins/builtins_test.go
@@ -59,7 +59,7 @@ func TestGenerateUniqueIDOrder(t *testing.T) {
 	}
 }
 
-func TestStringToArray(t *testing.T) {
+func TestStringToArrayAndBack(t *testing.T) {
 	// s allows us to have a string pointer literal.
 	s := func(x string) *string { return &x }
 	cases := []struct {
@@ -108,7 +108,22 @@ func TestStringToArray(t *testing.T) {
 
 			evalContext := tree.NewTestingEvalContext(cluster.MakeTestingClusterSettings())
 			if result.Compare(evalContext, expectedArray) != 0 {
-				t.Fatalf("expected %v, got %v", tc.expected, result)
+				t.Errorf("expected %v, got %v", tc.expected, result)
+			}
+
+			s, err := arrayToString(result.(*tree.DArray), tc.sep, tc.nullStr)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if tc.sep == nil {
+				if s != tree.DNull {
+					t.Errorf("expected null, found %s", s)
+				}
+				return
+			}
+			fmt.Println(s)
+			if string(*s.(*tree.DString)) != tc.input {
+				t.Errorf("original %s, roundtripped %s", tc.input, s)
 			}
 		})
 	}


### PR DESCRIPTION
This is used to join values in an array with a delimiter into a string,
with an optional null replacement string.

Fixes #23774.

Release note (sql change): add the array_to_string builtin function.