### PR TITLE
sqlbase: comp. cols work with missing insert cols

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/computed
+++ b/pkg/sql/logictest/testdata/logic_test/computed
@@ -107,6 +107,28 @@ DELETE FROM x
 statement ok
 DROP TABLE x
 
+statement ok
+CREATE TABLE x (
+  a INT NOT NULL,
+  b INT,
+  c INT AS (a) STORED,
+  d INT AS (a + b) STORED
+)
+
+statement ok
+INSERT INTO x (a) VALUES (1)
+
+statement error null value in column "a" violates not-null constraint
+INSERT INTO x (b) VALUES (1)
+
+query II
+SELECT c, d FROM x
+----
+1  NULL
+
+statement ok
+DROP TABLE x
+
 # Check with upserts
 statement ok
 CREATE TABLE x (

--- a/pkg/sql/sqlbase/computed_exprs.go
+++ b/pkg/sql/sqlbase/computed_exprs.go
@@ -41,7 +41,11 @@ var _ tree.IndexedVarContainer = &RowIndexedVarContainer{}
 func (r *RowIndexedVarContainer) IndexedVarEval(
 	idx int, ctx *tree.EvalContext,
 ) (tree.Datum, error) {
-	return r.CurSourceRow[r.Mapping[r.Cols[idx].ID]], nil
+	rowIdx, ok := r.Mapping[r.Cols[idx].ID]
+	if !ok {
+		return tree.DNull, nil
+	}
+	return r.CurSourceRow[rowIdx], nil
 }
 
 // IndexedVarResolvedType implements tree.IndexedVarContainer.


### PR DESCRIPTION
Previously, specifying only a partial set of columns to insert into a
table with computed columns could lead to incorrect results.

Fixes #25627.
Fixes #25670.

Release note (bug fix): fix a crash caused by inserting data into a
table with computed columns that reference other columns that weren't
present in the insert statement.