### PR TITLE
sql: simply return err variable whatever it’s value

### DIFF
--- a/pkg/sql/sequence.go
+++ b/pkg/sql/sequence.go
@@ -374,8 +374,5 @@ func getUsedSequenceNames(defaultExpr tree.TypedExpr) ([]string, error) {
 			return nil, true, expr
 		},
 	)
-	if err != nil {
-		return nil, err
-	}
-	return names, nil
+	return names, err
 }


### PR DESCRIPTION
This err != nil check seems unnecessary since you can simply return the names slice, which will be nil if not appended to, and err can be returned directly and will be checked by the caller anyway.