### PR TITLE
sql: fix union of cols w/ mismatched type aliases

### DIFF
--- a/pkg/sql/distsqlplan/physical_plan.go
+++ b/pkg/sql/distsqlplan/physical_plan.go
@@ -800,7 +800,7 @@ func MergeResultTypes(left, right []sqlbase.ColumnType) ([]sqlbase.ColumnType, e
 			merged[i] = leftType
 		} else if leftType.SemanticType == sqlbase.ColumnType_NULL {
 			merged[i] = rightType
-		} else if leftType.Equal(rightType) {
+		} else if leftType.Equivalent(rightType) {
 			merged[i] = leftType
 		} else {
 			return nil, errors.Errorf("conflicting ColumnTypes: %v and %v", leftType, rightType)

--- a/pkg/sql/logictest/testdata/logic_test/union
+++ b/pkg/sql/logictest/testdata/logic_test/union
@@ -237,3 +237,14 @@ union             ·     ·
  └── render       ·     ·
       └── values  ·     ·
 ·                 size  3 columns, 6 rows
+
+# Check that UNION permits columns of different visible types
+
+statement ok
+CREATE TABLE a (a INT PRIMARY KEY)
+
+statement ok
+CREATE TABLE b (a INTEGER PRIMARY KEY)
+
+query I
+SELECT * FROM a UNION ALL SELECT * FROM b

--- a/pkg/sql/sqlbase/structured.go
+++ b/pkg/sql/sqlbase/structured.go
@@ -2134,6 +2134,13 @@ func (c *ColumnType) elementColumnType() *ColumnType {
 	return &result
 }
 
+// Equivalent checks whether a column type is equivalent to another, excluding
+// its VisibleType type alias, which doesn't effect equality.
+func (c *ColumnType) Equivalent(other ColumnType) bool {
+	other.VisibleType = c.VisibleType
+	return c.Equal(other)
+}
+
 // SQLString returns the SQL string corresponding to the type.
 func (c *ColumnType) SQLString() string {
 	switch c.SemanticType {


### PR DESCRIPTION
Previously, the ColumnType.Equals method provided by protobuf generated
code was used to compare column types for equality when determining
whether two DistSQL streams were mergeable. This was incorrect because
column types can have type aliases known as VisibleTypes, which might
not match despite the underlying column types being equal. An example is
the column types INT and INTEGER. We preserve the difference between
those two, so that SHOW CREATE TABLE produces the same output as the
original CREATE TABLE.

To fix this, a new ColumnType.Equivalent method is introduced that
ignores the VisibleType field on ColumnTypes.

Fixes #25674.

Release note: None