### PR TITLE
roachtest: fix roachmart tests

### DIFF
--- a/pkg/cmd/roachtest/roachmart.go
+++ b/pkg/cmd/roachtest/roachmart.go
@@ -31,7 +31,7 @@ func registerRoachmart(r *registry) {
 			i    int
 			zone string
 		}{
-			{1, "us-central1-b"},
+			{1, "us-east1-b"},
 			{4, "us-west1-b"},
 			{7, "europe-west2-b"},
 		}


### PR DESCRIPTION
Roachprod geo clusters are no longer using the us-central1-b zone, so
don't reference it in the roachtest. This reverts #25530.

Fixes #25689

Release note: None