### PR TITLE
sql: fix panics from mismatched comp. col types

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/computed
+++ b/pkg/sql/logictest/testdata/logic_test/computed
@@ -739,3 +739,12 @@ UPSERT INTO error_check VALUES (1, 'foo')
 # Upsert -> insert
 statement error computed column i:
 UPSERT INTO error_check VALUES (3, 'foo')
+
+statement ok
+CREATE TABLE x (
+  a INT PRIMARY KEY,
+  b INT AS (a+1) STORED
+)
+
+query error value type decimal doesn't match type INT of column "a"
+INSERT INTO x VALUES(1.4)

--- a/pkg/sql/plan.go
+++ b/pkg/sql/plan.go
@@ -833,6 +833,8 @@ func (p *planner) newPlan(
 		return p.Update(ctx, n, desiredTypes)
 	case *tree.ValuesClause:
 		return p.Values(ctx, n, desiredTypes)
+	case *tree.ValuesClauseWithNames:
+		return p.Values(ctx, n, desiredTypes)
 	default:
 		return nil, errors.Errorf("unknown statement type: %T", stmt)
 	}

--- a/pkg/sql/sem/tree/values.go
+++ b/pkg/sql/sem/tree/values.go
@@ -40,3 +40,15 @@ func (node *ValuesClause) Format(ctx *FmtCtx) {
 		comma = ", "
 	}
 }
+
+// ValuesClauseWithNames is a VALUES clause that has been annotated with column
+// names. This is only produced at plan time, never by the parser. It's used to
+// pass column names to the VALUES planNode, so it can produce intelligible
+// error messages during value type checking.
+type ValuesClauseWithNames struct {
+	ValuesClause
+
+	// Names is a list of the column names that each tuple in the ValuesClause
+	// corresponds to.
+	Names NameList
+}

--- a/pkg/sql/sqlbase/column_type_encoding.go
+++ b/pkg/sql/sqlbase/column_type_encoding.go
@@ -668,21 +668,9 @@ func MarshalColumnValue(col ColumnDescriptor, val tree.Datum) (roachpb.Value, er
 		}
 	case ColumnType_ARRAY:
 		if v, ok := val.(*tree.DArray); ok {
-			semanticType, err := datumTypeToColumnSemanticType(v.ParamTyp)
-			if err != nil {
+			if err := checkElementType(v.ParamTyp, col.Type); err != nil {
 				return r, err
 			}
-			if semanticType != *col.Type.ArrayContents {
-				return r, errors.Errorf("type of array contents %s doesn't match column type %s",
-					v.ParamTyp, col.Type.ArrayContents)
-			}
-			if cs, ok := v.ParamTyp.(types.TCollatedString); ok {
-				if cs.Locale != *col.Type.Locale {
-					return r, errors.Errorf("locale of collated string array being inserted (%s) doesn't match locale of column type (%s)",
-						cs.Locale, *col.Type.Locale)
-				}
-			}
-
 			b, err := encodeArray(v, nil)
 			if err != nil {
 				return r, err
@@ -1089,6 +1077,24 @@ func datumTypeToArrayElementEncodingType(t types.T) (encoding.Type, error) {
 		}
 		return 0, errors.Errorf("Don't know encoding type for %s", t)
 	}
+}
+
+func checkElementType(paramType types.T, columnType ColumnType) error {
+	semanticType, err := datumTypeToColumnSemanticType(paramType)
+	if err != nil {
+		return err
+	}
+	if semanticType != *columnType.ArrayContents {
+		return errors.Errorf("type of array contents %s doesn't match column type %s",
+			paramType, columnType.ArrayContents)
+	}
+	if cs, ok := paramType.(types.TCollatedString); ok {
+		if cs.Locale != *columnType.Locale {
+			return errors.Errorf("locale of collated string array being inserted (%s) doesn't match locale of column type (%s)",
+				cs.Locale, *columnType.Locale)
+		}
+	}
+	return nil
 }
 
 // encodeArrayElement appends the encoded form of one array element to


### PR DESCRIPTION
The first commit is #25682.

Fixes #25721.

Previously, inserting a value of the wrong type into a column depended
on by a computed column would panic the server. That's because we used
to defer enforcing type checking of insert values until marshalling
time.

This commit fixes the bug by correcting that long-standing problem: we
now enforce insert-value type checks at plan time instead of run time.

To do so, while preserving the nice error messages of the previous
approach that include the names of the columns that had mismatched
types, this commit introduces a new fake AST node called
ValuesClauseWithNames that is a values clause that includes column name
information. This is populated by insert nodes, so that the values
clause can type check itself at plan time and produce error messages
with column names.

Release note (bug fix): fix panic caused by inserting values of the
wrong type into columns depended on by computed columns.