### PR TITLE
sql: fix panic with UNION ALL

### DIFF
--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -2120,6 +2120,9 @@ func (dsp *DistSQLPlanner) createPlanForNode(
 	}
 
 	if dsp.shouldPlanTestMetadata() {
+		if err := plan.CheckLastStagePost(); err != nil {
+			log.Fatal(planCtx.ctx, err)
+		}
 		plan.AddNoGroupingStageWithCoreFunc(
 			func(_ int, _ *distsqlplan.Processor) distsqlrun.ProcessorCoreUnion {
 				return distsqlrun.ProcessorCoreUnion{
@@ -2478,6 +2481,19 @@ func (dsp *DistSQLPlanner) createPlanForSetOp(
 			}
 			p.AddSingleGroupStage(
 				dsp.nodeDesc.NodeID, distinctSpec, distsqlrun.PostProcessSpec{}, p.ResultTypes)
+		} else {
+			// UNION ALL is special: it doesn't have any required downstream
+			// processor, so its two inputs might have different post-processing
+			// which would violate an assumption later down the line. Check for this
+			// condition and add a no-op stage if it exists.
+			if err := p.CheckLastStagePost(); err != nil {
+				p.AddSingleGroupStage(
+					dsp.nodeDesc.NodeID,
+					distsqlrun.ProcessorCoreUnion{Noop: &distsqlrun.NoopCoreSpec{}},
+					distsqlrun.PostProcessSpec{},
+					p.ResultTypes,
+				)
+			}
 		}
 	} else {
 		// We plan INTERSECT and EXCEPT queries with joiners. Get the appropriate

--- a/pkg/sql/logictest/testdata/logic_test/union
+++ b/pkg/sql/logictest/testdata/logic_test/union
@@ -248,3 +248,14 @@ CREATE TABLE b (a INTEGER PRIMARY KEY)
 
 query I
 SELECT * FROM a UNION ALL SELECT * FROM b
+
+
+# Make sure that UNION ALL doesn't crash when its two children have different
+# post-processing stages.
+
+statement ok
+CREATE TABLE c (a INT PRIMARY KEY, b INT)
+
+query I
+SELECT a FROM a WHERE a > 2 UNION ALL (SELECT a FROM c WHERE b > 2) LIMIT 1;
+----


### PR DESCRIPTION
Previously, UNION ALL distsql plans could panic the server if the two
sub plans had different post processing. Now, this condition is
detected, and a no-op stage is inserted after the plans if necessary.

Fixes #25611.

Release note (bug fix): fix a server crash when trying to plan
certain UNION ALL queries.