### PR TITLE
util: add IsMakeTest flag

### DIFF
--- a/pkg/sql/opt/norm/factory.go
+++ b/pkg/sql/opt/norm/factory.go
@@ -162,10 +162,8 @@ func (f *Factory) InternList(items []memo.GroupID) memo.ListID {
 // onConstruct is called as a final step by each factory construction method,
 // so that any custom manual pattern matching/replacement code can be run.
 func (f *Factory) onConstruct(e memo.Expr) memo.GroupID {
-	// RaceEnabled ensures that checks are run on every change (as part of make
-	// testrace) while keeping the check code out of non-test builds.
-	// TODO(radu): replace this with a flag that is true for all tests.
-	if util.RaceEnabled {
+	// Run extra checks, but only for test builds.
+	if util.IsMakeTest {
 		f.checkExpr(e)
 	}
 	group := f.mem.MemoizeNormExpr(f.evalCtx, e)

--- a/pkg/util/test_off.go
+++ b/pkg/util/test_off.go
@@ -1,0 +1,23 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+
+// +build !maketest
+
+package util
+
+// IsMakeTest is true if we are part of a `go test` built initiated through the
+// Makefile. It can be used for expensive assertions that we want to keep out of
+// non-test builds.
+const IsMakeTest = false

--- a/pkg/util/test_on.go
+++ b/pkg/util/test_on.go
@@ -1,0 +1,23 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+
+// +build maketest
+
+package util
+
+// IsMakeTest is true if we are part of a `go test` built initiated through the
+// Makefile. It can be used for expensive assertions that we want to keep out of
+// non-test builds.
+const IsMakeTest = true


### PR DESCRIPTION
We have been putting various assertions that we want to keep out of
non-test builds behind the `TestRace` flag. This makes the assertions
run only in testrace builds. This is good because testrace is run
on every PR, but not ideal since developers mostly run `make test`.

This change adds an `IsMakeTest` flag which is true if this is a build
for tests run via the makefile (`make test`, `make stress` etc).

One check in the optimizer now uses the new flag.

Release note: None