### PR TITLE
opt: Fix grouping column reference bug

### DIFF
--- a/pkg/sql/opt/optbuilder/scope.go
+++ b/pkg/sql/opt/optbuilder/scope.go
@@ -49,10 +49,12 @@ type scope struct {
 	columns int
 }
 
-// groupByStrSet is a set of stringified GROUP BY expressions.
-type groupByStrSet map[string]struct{}
+// groupByStrSet is a set of stringified GROUP BY expressions that map to the
+// grouping column in an aggOutScope scope that projects that expression.
+type groupByStrSet map[string]*scopeColumn
 
-// exists is the 0-byte value of each element in groupByStrSet.
+// exists is a 0-byte dummy value used in a map that's being used to track
+// whether keys exist (i.e. where only the key matters).
 var exists = struct{}{}
 
 // inGroupingContext returns true when the aggInScope is not nil. This is the
@@ -260,21 +262,6 @@ func (s *scope) findAggregate(agg aggregateInfo) *scopeColumn {
 				// existing column that computes it.
 				return &s.getAggregateCols()[i]
 			}
-		}
-	}
-
-	return nil
-}
-
-// findGrouping finds the given grouping expression among the bound variables
-// in the groupingsScope. Returns nil if the grouping is not found.
-func (s *scope) findGrouping(grouping memo.GroupID) *scopeColumn {
-	for i, g := range s.groupby.groupings {
-		if g == grouping {
-			// Grouping already exists, so return information about the
-			// existing column that computes it. The first columns in aggInScope
-			// are always listed in the same order as s.groupby.groupings.
-			return &s.groupby.aggInScope.cols[i]
 		}
 	}
 

--- a/pkg/sql/opt/optbuilder/testdata/aggregate
+++ b/pkg/sql/opt/optbuilder/testdata/aggregate
@@ -1937,12 +1937,8 @@ project
  │                   └── variable: kv.w [type=int]
  └── projections
       └── div [type=decimal]
-           ├── plus [type=int]
-           │    ├── variable: kv.k [type=int]
-           │    └── variable: kv.v [type=int]
-           └── plus [type=int]
-                ├── variable: kv.v [type=int]
-                └── variable: kv.w [type=int]
+           ├── variable: column5 [type=int]
+           └── variable: column6 [type=int]
 
 # Check that everything still works with differently qualified names
 build fully-qualify-names
@@ -1989,9 +1985,7 @@ project
  └── projections
       └── plus [type=int]
            ├── variable: t.public.kv.v [type=int]
-           └── mult [type=int]
-                ├── variable: t.public.kv.k [type=int]
-                └── variable: t.public.kv.w [type=int]
+           └── variable: column6 [type=int]
 
 # Check all the different types of scalar expressions as group by columns
 build
@@ -2022,9 +2016,7 @@ project
  │                   └── variable: abc.c [type=bool]
  └── projections
       └── and [type=bool]
-           ├── and [type=bool]
-           │    ├── variable: bools.b [type=bool]
-           │    └── variable: abc.c [type=bool]
+           ├── variable: column9 [type=bool]
            └── variable: bools.b [type=bool]
 
 build
@@ -2060,9 +2052,7 @@ project
  │                   └── variable: abc.c [type=bool]
  └── projections
       └── or [type=bool]
-           ├── or [type=bool]
-           │    ├── variable: bools.b [type=bool]
-           │    └── variable: abc.c [type=bool]
+           ├── variable: column9 [type=bool]
            └── variable: bools.b [type=bool]
 
 build
@@ -2088,9 +2078,7 @@ project
  │                   └── variable: kv.w [type=int]
  └── projections
       └── mod [type=int]
-           ├── mod [type=int]
-           │    ├── variable: kv.k [type=int]
-           │    └── variable: kv.w [type=int]
+           ├── variable: column5 [type=int]
            └── variable: kv.v [type=int]
 
 build
@@ -2116,9 +2104,7 @@ project
  │                   └── variable: abc.a [type=string]
  └── projections
       └── function: concat [type=string]
-           ├── function: concat [type=string]
-           │    ├── variable: kv.s [type=string]
-           │    └── variable: abc.a [type=string]
+           ├── variable: column9 [type=string]
            └── variable: abc.a [type=string]
 
 build
@@ -2144,9 +2130,7 @@ project
  │                   └── variable: kv.w [type=int]
  └── projections
       └── and [type=bool]
-           ├── lt [type=bool]
-           │    ├── variable: kv.k [type=int]
-           │    └── variable: kv.w [type=int]
+           ├── variable: column5 [type=bool]
            └── ne [type=bool]
                 ├── variable: kv.v [type=int]
                 └── const: 5 [type=int]
@@ -2189,9 +2173,7 @@ project
  │                   └── variable: foo.baz [type=jsonb]
  └── projections
       └── and [type=bool]
-           ├── contains [type=bool]
-           │    ├── variable: foo.bar [type=jsonb]
-           │    └── variable: foo.baz [type=jsonb]
+           ├── variable: column7 [type=bool]
            └── contains [type=bool]
                 ├── variable: foo.baz [type=jsonb]
                 └── variable: foo.baz [type=jsonb]
@@ -2199,7 +2181,7 @@ project
 build
 SELECT a.bar @> b.baz AND b.baz @> b.baz FROM foo AS a, foo AS b GROUP BY b.baz <@ a.bar, b.baz
 ----
-error: column "foo.bar" must appear in the GROUP BY clause or be used in an aggregate function
+error: column "a.bar" must appear in the GROUP BY clause or be used in an aggregate function
 
 build
 SELECT b.baz <@ a.bar AND b.baz <@ b.baz FROM foo AS a, foo AS b GROUP BY b.baz <@ a.bar, b.baz
@@ -2224,9 +2206,7 @@ project
  │                   └── variable: foo.baz [type=jsonb]
  └── projections
       └── and [type=bool]
-           ├── contains [type=bool]
-           │    ├── variable: foo.bar [type=jsonb]
-           │    └── variable: foo.baz [type=jsonb]
+           ├── variable: column7 [type=bool]
            └── contains [type=bool]
                 ├── variable: foo.baz [type=jsonb]
                 └── variable: foo.baz [type=jsonb]
@@ -2266,18 +2246,14 @@ project
  │                   └── variable: times.t [type=time]
  └── projections
       └── minus [type=interval]
-           ├── function: date_trunc [type=interval]
-           │    ├── const: 'second' [type=string]
-           │    └── variable: times.t [type=time]
-           └── function: date_trunc [type=interval]
-                ├── const: 'minute' [type=string]
-                └── variable: times.t [type=time]
+           ├── variable: column3 [type=interval]
+           └── variable: column4 [type=interval]
 
 build
 SELECT date_trunc('second', a.t) - date_trunc('second', b.t) FROM times a, times b
   GROUP BY date_trunc('second', a.t), date_trunc('minute', b.t)
 ----
-error: column "times.t" must appear in the GROUP BY clause or be used in an aggregate function
+error: column "b.t" must appear in the GROUP BY clause or be used in an aggregate function
 
 build
 SELECT NOT b FROM bools GROUP BY NOT b
@@ -2332,9 +2308,8 @@ project
  │                   └── variable: kv.w [type=int]
  └── projections
       └── mult [type=int]
-           ├── variable: kv.k [type=int]
-           └── unary-minus [type=int]
-                └── variable: kv.w [type=int]
+           ├── variable: column5 [type=int]
+           └── variable: column6 [type=int]
 
 build
 SELECT k * (-w) FROM kv GROUP BY +k, -w

--- a/pkg/sql/opt/optbuilder/testdata/having
+++ b/pkg/sql/opt/optbuilder/testdata/having
@@ -131,9 +131,9 @@ build
 SELECT count(*), k+w FROM kv GROUP BY k+w HAVING (k+w) > 5
 ----
 project
- ├── columns: count:6(int) "k + w":5(int)
+ ├── columns: count:6(int) "k + w":5(int!null)
  └── select
-      ├── columns: column5:5(int) count:6(int)
+      ├── columns: column5:5(int!null) count:6(int)
       ├── group-by
       │    ├── columns: column5:5(int) count:6(int)
       │    ├── grouping columns: column5:5(int)
@@ -149,9 +149,7 @@ project
       │         └── count-rows [type=int]
       └── filters [type=bool]
            └── gt [type=bool]
-                ├── plus [type=int]
-                │    ├── variable: kv.k [type=int]
-                │    └── variable: kv.w [type=int]
+                ├── variable: column5 [type=int]
                 └── const: 5 [type=int]
 
 build
@@ -204,8 +202,7 @@ project
       │              └── variable: kv.w [type=int]
       └── filters [type=bool]
            └── like [type=bool]
-                ├── function: lower [type=string]
-                │    └── variable: kv.s [type=string]
+                ├── variable: column5 [type=string]
                 └── const: 'test%' [type=string]
 
 build
@@ -242,7 +239,7 @@ SELECT t.kv.v FROM t.kv GROUP BY v, kv.k * w HAVING k * kv.w > 5
 project
  ├── columns: v:2(int)
  └── select
-      ├── columns: t.public.kv.v:2(int) column5:5(int)
+      ├── columns: t.public.kv.v:2(int) column5:5(int!null)
       ├── group-by
       │    ├── columns: t.public.kv.v:2(int) column5:5(int)
       │    ├── grouping columns: t.public.kv.v:2(int) column5:5(int)
@@ -256,9 +253,7 @@ project
       │                   └── variable: t.public.kv.w [type=int]
       └── filters [type=bool]
            └── gt [type=bool]
-                ├── mult [type=int]
-                │    ├── variable: t.public.kv.k [type=int]
-                │    └── variable: t.public.kv.w [type=int]
+                ├── variable: column5 [type=int]
                 └── const: 5 [type=int]
 
 build fully-qualify-names


### PR DESCRIPTION
Queries like this are not working correctly:

  SELECT (k+w)+1 FROM kv GROUP BY k+w

The problem is that the (k+w) expression is not being replaced by a
reference to the grouping column. This causes the Project expression
to have dangling outer references, because it's trying to reference
the "k" and "w" columns, which are no longer available. We already
had tests that detected this problem, but the expected output was
incorrect.

This commit fixes the issue by refactoring how grouping column refs
are handled. By detecting grouping column refs *before* a scalar
expression is built, rather than after, there is no longer any need
for varsUsed. Non-grouping column refs can be immediately flagged.

In addition, this commit regularizes various scalar build methods so
that they take an outScope. If that is non-nil, then the build method
is expected to project the expression as a new column. Otherwise, it
returns an expression that will be nested in a larger expression.
This change simplifies the logic and makes it more regular.

Release note: None