### PR TITLE
workload: fix fixture generation completion status

### DIFF
--- a/pkg/ccl/workloadccl/fixture.go
+++ b/pkg/ccl/workloadccl/fixture.go
@@ -210,7 +210,7 @@ func (c *groupCSVWriter) groupWriteCSVs(
 			throughput := float64(newBytesWritten) / (d.Seconds() * float64(1<<20) /* 1MiB */)
 			log.Infof(ctx, `wrote csv %s [%d,%d] of %d row batches (%.2f%% (%s) in %s: %.1f MB/s)`,
 				table.Name, rowStart, rowIdx, table.InitialRows.NumBatches,
-				float64(100*table.InitialRows.NumBatches)/float64(rowIdx),
+				float64(100*rowIdx)/float64(table.InitialRows.NumBatches),
 				humanizeutil.IBytes(newBytesWritten), d, throughput)
 
 			return nil


### PR DESCRIPTION
This change fixes lines like:
```
wrote csv stock [20968051,21165657] of 200000000 row batches (10.58% (9.8 GiB) in 1m12.758125494s: 138.5 MB/s)
```

They now contain a correct representation of the completion percentage.

Release note: None