### PR TITLE
sql: permit null arguments to array_to_str

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/builtin_function
+++ b/pkg/sql/logictest/testdata/logic_test/builtin_function
@@ -1733,3 +1733,8 @@ query TT
 SELECT array_to_string(ARRAY['a', 'b,', 'c'], NULL), array_to_string(ARRAY['a', 'b,', NULL, 'c'], 'foo', 'zerp')
 ----
 NULL  afoob,foozerpfooc
+
+query TT
+SELECT array_to_string(NULL, ','), array_to_string(NULL, 'foo', 'zerp')
+----
+NULL  NULL

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -2053,10 +2053,9 @@ may increase either contention or retry errors, or both.`,
 
 	"array_to_string": {
 		tree.Builtin{
-			Types:        tree.ArgTypes{{"input", types.AnyArray}, {"delim", types.String}},
-			ReturnType:   tree.FixedReturnType(types.String),
-			Category:     categoryArray,
-			NullableArgs: true,
+			Types:      tree.ArgTypes{{"input", types.AnyArray}, {"delim", types.String}},
+			ReturnType: tree.FixedReturnType(types.String),
+			Category:   categoryArray,
 			Fn: func(_ *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
 				arr := tree.MustBeDArray(args[0])
 				delimOrNil := stringOrNil(args[1])
@@ -2070,6 +2069,9 @@ may increase either contention or retry errors, or both.`,
 			Category:     categoryArray,
 			NullableArgs: true,
 			Fn: func(_ *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
+				if args[0] == tree.DNull {
+					return tree.DNull, nil
+				}
 				arr := tree.MustBeDArray(args[0])
 				delimOrNil := stringOrNil(args[1])
 				nullStr := stringOrNil(args[2])


### PR DESCRIPTION
Since array_to_str takes nullable arguments, the array argument must be
explicitly checked for nullability. The other arguments already were
checked.

Thanks, @mjibson and RSG!

Fixes #25750.

Release note: None