### PR TITLE
cmd/workload: add -stats flag to run command

### DIFF
--- a/pkg/cmd/roachtest/kv.go
+++ b/pkg/cmd/roachtest/kv.go
@@ -33,7 +33,7 @@ func registerKV(r *registry) {
 			concurrency := ifLocal("", " --concurrency="+fmt.Sprint(nodes*64))
 			duration := " --duration=" + ifLocal("10s", "10m")
 			cmd := fmt.Sprintf(
-				"./workload run kv --init --read-percent=%d --splits=1000"+
+				"./workload run kv --init --read-percent=%d --splits=1000 --histograms=logs/stats.json"+
 					concurrency+duration+
 					" {pgurl:1-%d}",
 				percent, nodes)

--- a/pkg/workload/histogram.go
+++ b/pkg/workload/histogram.go
@@ -203,3 +203,24 @@ type HistogramTick struct {
 	// [Now-Elapsed,Now).
 	Now time.Time
 }
+
+// Snapshot creates a SnapshotTick from the receiver.
+func (t HistogramTick) Snapshot() SnapshotTick {
+	return SnapshotTick{
+		Name:    t.Name,
+		Elapsed: t.Elapsed,
+		Now:     t.Now,
+		Hist:    t.Hist.Export(),
+	}
+}
+
+// SnapshotTick parallels HistogramTick but replace the histogram with a
+// snapshot that is suitable for serialization. Additionally, it only contains
+// the per-tick histogram, not the cumulative histogram. (The cumulative
+// histogram can be computed by aggregating all of the per-tick histograms).
+type SnapshotTick struct {
+	Name    string
+	Hist    *hdrhistogram.Snapshot
+	Elapsed time.Duration
+	Now     time.Time
+}


### PR DESCRIPTION
The `-stats` flag causes the `run` command to output per-op histograms
to the specified file every tick (i.e. every second). The histograms are
encoded via `json.Encoder`. Each histogram encodes to ~730 bytes. An
hours worth of data will consume 2.5 MB, though this data compresses
quite well (8:1 with gzip). We only output the per-tick histograms as
the cumulative histogram can be computed via aggregation. The raw
histogram data is output so that histograms from multiple `workload`
generators can be combined (e.g. a geo-distributed tpcc run where
multiple `workload` workers are pointed at the same cluster).

Release note: None