### PR TITLE
timeutil: retain monotonic timestamp in Now()

### DIFF
--- a/pkg/util/timeutil/now_test.go
+++ b/pkg/util/timeutil/now_test.go
@@ -16,7 +16,16 @@ package timeutil
 
 import (
 	"testing"
+	"time"
 )
+
+// TestNowUTC asserts that Now()'s timezone is UTC.
+func TestNowUTC(t *testing.T) {
+	n := Now()
+	if l := n.Location(); l != time.UTC {
+		t.Fatalf("expected UTC, got %v", l)
+	}
+}
 
 func BenchmarkNow(b *testing.B) {
 	for i := 0; i < b.N; i++ {

--- a/pkg/util/timeutil/now_unix.go
+++ b/pkg/util/timeutil/now_unix.go
@@ -20,7 +20,17 @@ import (
 	"time"
 )
 
+func init() {
+	// While our datastore uses the HLC clock to protect against backward time
+	// jumps, there are various user-facing timestamps that do not. Go 1.9 added
+	// monotonic timestamps, but our forcing of all timezones to UTC using the
+	// time.UTC() method strips the monotonic clock out of the struct. In order
+	// to get both the benefits of the monotonic timestamps and force all times
+	// to be in UTC we must unfortunately set this global variable.
+	time.Local = time.UTC
+}
+
 // Now returns the current UTC time.
 func Now() time.Time {
-	return time.Now().UTC()
+	return time.Now()
 }

--- a/pkg/util/timeutil/now_windows.go
+++ b/pkg/util/timeutil/now_windows.go
@@ -33,13 +33,10 @@ func init() {
 // This has a higher precision than time.Now in go1.8, but is much slower
 // (~2000x) and requires Windows 8+.
 //
-// TODO(tamird): consider removing this in go1.9. go1.9 is expected to add
-// monotonic clock support to values retured from time.Now, which this
-// implementation will not support. The monotonic clock support may also
-// obviate the need for this, since we only need the higher precision when
-// subtracting `time.Time`s.
+// Even on Go 1.10 with Windows 10 the time resolution of time.Now() is
+// about 500µs. The method below can do <1µs.
 func Now() time.Time {
 	var ft windows.Filetime
 	windows.GetSystemTimePreciseAsFileTime(&ft)
-	return time.Unix(0, ft.Nanoseconds()).UTC()
+	return time.Unix(0, ft.Nanoseconds())
 }


### PR DESCRIPTION
Fixes #19781

Release note: None