### PR TITLE
sysutil: un-break non-linux build

### DIFF
--- a/pkg/cli/debug.go
+++ b/pkg/cli/debug.go
@@ -174,8 +174,12 @@ func runDebugBallast(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return errors.Wrapf(err, "failed to stat the directory %s", dataDirectory)
 	}
-	total := int64(fs.Blocks) * fs.Bsize
-	free := int64(fs.Bavail) * fs.Bsize
+	// This int casting may look awkward, but serves to avoid TestLint/TestMegaCheck/misccheck/uncovert
+	// which likes to fire since the struct fields of `fs` have different types on
+	// different systems.
+	total := int64(int(fs.Blocks) * int(fs.Bsize))
+	free := int64(int(fs.Bavail) * int(fs.Bsize))
+
 	used := total - free
 	var targetUsage int64
 	p := debugCtx.ballastSize.Percent

--- a/pkg/util/sysutil/large_file_naive.go
+++ b/pkg/util/sysutil/large_file_naive.go
@@ -12,11 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package sysutil is a cross-platform compatibility layer on top of package
-// syscall. It exposes APIs for common operations that require package syscall
-// and re-exports several symbols from package syscall that are known to be
-// safe. Using package syscall directly from other packages is forbidden.
-
 // +build !linux
 
 package sysutil


### PR DESCRIPTION
The sysutil package had a recent addition that didn't compile properly
on non-linux systems. The main issue was that Go apparently treats the
file suffix `_linux.go` as an implicit build tag. In effect, that file
was never built, so only linux builds worked.

Also fixed another compile error caused by a different-width integer
type used on OSX.

Release note: None