### PR TITLE
roachtest: bump import job leniency default

### DIFF
--- a/pkg/cmd/roachtest/import.go
+++ b/pkg/cmd/roachtest/import.go
@@ -66,7 +66,10 @@ func registerImportTPCH(r *registry) {
 				c.Put(ctx, cockroach, "./cockroach")
 				c.Start(ctx)
 				conn := c.Conn(ctx, 1)
-				if _, err := conn.Exec(`create database csv`); err != nil {
+				if _, err := conn.Exec(`
+					CREATE DATABASE csv;
+					SET CLUSTER SETTING jobs.registry.leniency = '5m';
+				`); err != nil {
 					t.Fatal(err)
 				}
 				t.Status(`running import`)


### PR DESCRIPTION
It is curious that the 1m default isn't enough to allow the liveness
to correct itself. Maybe something isn't working like we think it is
in the job registry or maybe the GCE nodes get really bogged down. Try
increasing the time to 5m to see if it fixes the problem.

Fixes #25734

Release note: None