### PR TITLE
ts: Implement new on-disk format for time series

### DIFF
--- a/c-deps/libroach/CMakeLists.txt
+++ b/c-deps/libroach/CMakeLists.txt
@@ -91,6 +91,7 @@ set(tests
   db_test.cc
   encoding_test.cc
   file_registry_test.cc
+  merge_test.cc
   ccl/db_test.cc
   ccl/key_manager_test.cc
 )

--- a/c-deps/libroach/merge.h
+++ b/c-deps/libroach/merge.h
@@ -17,6 +17,7 @@
 #include <libroach.h>
 #include <rocksdb/merge_operator.h>
 #include "defines.h"
+#include "protos/roachpb/internal.pb.h"
 #include "protos/storage/engine/enginepb/mvcc.pb.h"
 
 namespace cockroach {
@@ -26,5 +27,7 @@ WARN_UNUSED_RESULT bool MergeValues(cockroach::storage::engine::enginepb::MVCCMe
                                     bool full_merge, rocksdb::Logger* logger);
 DBStatus MergeResult(cockroach::storage::engine::enginepb::MVCCMetadata* meta, DBString* result);
 rocksdb::MergeOperator* NewMergeOperator();
+void sortAndDeduplicateColumns(roachpb::InternalTimeSeriesData* data, int first_unsorted);
+void convertToColumnar(roachpb::InternalTimeSeriesData* data);
 
 }  // namespace cockroach

--- a/c-deps/libroach/merge_test.cc
+++ b/c-deps/libroach/merge_test.cc
@@ -1,0 +1,249 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied.  See the License for the specific language governing
+// permissions and limitations under the License.
+
+#include <vector>
+#include <utility>
+#include <gtest/gtest.h>
+#include "protos/roachpb/internal.pb.h"
+#include "merge.h"
+
+using namespace cockroach;
+
+void testAddColumns(
+  roachpb::InternalTimeSeriesData* data, int offset, int value
+) {
+  data->add_offset(offset);
+  data->add_count(value + 1);
+  data->add_last(value + 2);
+  data->add_first(value + 3);
+  data->add_min(value + 4);
+  data->add_max(value + 5);
+  data->add_sum(value + 6);
+  data->add_variance(value + 7);
+}
+
+void testAddColumnsNoRollup(
+  roachpb::InternalTimeSeriesData* data, int offset, int value
+) {
+  data->add_offset(offset);
+  data->add_last(value);
+}
+
+void testAddRows(
+  roachpb::InternalTimeSeriesData* data, int offset, int value
+) {
+  auto row = data->add_samples();
+  row->set_offset(offset);
+  row->set_sum(value);
+  row->set_count(1);
+  row->set_max(value + 1);
+  row->set_min(value + 2);
+}
+
+TEST(TimeSeriesMerge, SortAndDeduplicate) {
+  struct TestCase {
+    using rowData = std::vector<std::pair<int, int>>;
+    rowData originalRows;
+    int firstUnsorted;
+    rowData expectedRows;
+    TestCase(rowData orig, int first, rowData expected): 
+      originalRows(orig), firstUnsorted(first), expectedRows(expected) {};
+  };
+
+  std::vector<TestCase> testCases = {
+    // Basic sorting and deduplication.
+    TestCase(
+      {
+        {10, 999},
+        {8, 1},
+        {9, 2},
+        {10, 0},
+        {4, 0},
+        {10, 3},
+      },
+      0,
+      {
+        {4, 0},
+        {8, 1},
+        {9, 2},
+        {10, 3},
+      }
+    ),
+    // Partial sorting and deduplication. The first index is intentionally out
+    // of order in order strongly demonstrate that only a suffix of the array
+    // is being sorted, anything before firstUnsorted is not modified.
+    TestCase(
+      {
+        {10, 999},
+        {8, 1},
+        {9, 2},
+        {10, 0},
+        {4, 0},
+        {10, 3},
+      },
+      3,
+      {
+        {10, 999},
+        {8, 1},
+        {9, 2},
+        {4, 0},
+        {10, 3},
+      }
+    ),
+    // Sort only last sample (common case).
+    TestCase(
+      {
+        {1, 1},
+        {2, 2},
+        {3, 3},
+        {4, 4},
+        {5, 5},
+      },
+      4,
+      {
+        {1, 1},
+        {2, 2},
+        {3, 3},
+        {4, 4},
+        {5, 5},
+      }
+    ),
+    // Already sorted.
+    TestCase(
+      {
+        {1, 1},
+        {2, 2},
+        {3, 3},
+        {4, 4},
+        {5, 5},
+      },
+      0,
+      {
+        {1, 1},
+        {2, 2},
+        {3, 3},
+        {4, 4},
+        {5, 5},
+      }
+    ),
+    // Single element shifted forward.
+    TestCase(
+      {
+        {5, 5},
+        {1, 1},
+        {2, 2},
+        {3, 3},
+        {4, 4},
+      },
+      0,
+      {
+        {1, 1},
+        {2, 2},
+        {3, 3},
+        {4, 4},
+        {5, 5},
+      }
+    ),
+    // Reversed.
+    TestCase(
+      {
+        {5, 5},
+        {4, 4},
+        {3, 3},
+        {2, 2},
+        {1, 1},
+      },
+      0,
+      {
+        {1, 1},
+        {2, 2},
+        {3, 3},
+        {4, 4},
+        {5, 5},
+      }
+    ),
+    // Element shift with duplicate.
+    TestCase(
+      {
+        {5, 999},
+        {1, 1},
+        {2, 2},
+        {5, 5},
+        {3, 3},
+        {4, 4},
+      },
+      0,
+      {
+        {1, 1},
+        {2, 2},
+        {3, 3},
+        {4, 4},
+        {5, 5},
+      }
+    ),
+    // Shift with firstUnsorted.
+    TestCase(
+      {
+        {99, 999},
+        {88, 888},
+        {77, 777},
+        {5, 5},
+        {1, 1},
+        {2, 2},
+        {3, 3},
+        {4, 4},
+      },
+      3,
+      {
+        {99, 999},
+        {88, 888},
+        {77, 777},
+        {1, 1},
+        {2, 2},
+        {3, 3},
+        {4, 4},
+        {5, 5},
+      }
+    )
+  };
+  for (auto testCase : testCases) {
+    roachpb::InternalTimeSeriesData orig;
+    for (auto row : testCase.originalRows) {
+      testAddColumns(&orig, row.first, row.second);
+    }
+    roachpb::InternalTimeSeriesData expected;
+    for (auto row : testCase.expectedRows) {
+      testAddColumns(&expected, row.first, row.second);
+    }
+
+    sortAndDeduplicateColumns(&orig, testCase.firstUnsorted);
+    EXPECT_EQ(orig.SerializeAsString(), expected.SerializeAsString());
+  }
+}
+
+TEST(TimeSeriesMerge, ConvertToColumnar) {
+  roachpb::InternalTimeSeriesData orig;
+  testAddRows(&orig, 1, 2);
+  testAddRows(&orig, 2, 4);
+  testAddRows(&orig, 3, 4);
+
+  roachpb::InternalTimeSeriesData expected;
+  testAddColumnsNoRollup(&expected, 1, 2);
+  testAddColumnsNoRollup(&expected, 2, 4);
+  testAddColumnsNoRollup(&expected, 3, 4);
+
+  EXPECT_NE(orig.SerializeAsString(), expected.SerializeAsString());
+  convertToColumnar(&orig);
+  EXPECT_EQ(orig.SerializeAsString(), expected.SerializeAsString());
+}

--- a/c-deps/libroach/protos/roachpb/internal.pb.cc
+++ b/c-deps/libroach/protos/roachpb/internal.pb.cc
@@ -86,6 +86,14 @@ void InternalTimeSeriesData::InitAsDefaultInstance() {
 const int InternalTimeSeriesData::kStartTimestampNanosFieldNumber;
 const int InternalTimeSeriesData::kSampleDurationNanosFieldNumber;
 const int InternalTimeSeriesData::kSamplesFieldNumber;
+const int InternalTimeSeriesData::kOffsetFieldNumber;
+const int InternalTimeSeriesData::kLastFieldNumber;
+const int InternalTimeSeriesData::kCountFieldNumber;
+const int InternalTimeSeriesData::kSumFieldNumber;
+const int InternalTimeSeriesData::kMaxFieldNumber;
+const int InternalTimeSeriesData::kMinFieldNumber;
+const int InternalTimeSeriesData::kFirstFieldNumber;
+const int InternalTimeSeriesData::kVarianceFieldNumber;
 #endif  // !defined(_MSC_VER) || _MSC_VER >= 1900
 
 InternalTimeSeriesData::InternalTimeSeriesData()
@@ -101,7 +109,15 @@ InternalTimeSeriesData::InternalTimeSeriesData(const InternalTimeSeriesData& fro
       _internal_metadata_(NULL),
       _has_bits_(from._has_bits_),
       _cached_size_(0),
-      samples_(from.samples_) {
+      samples_(from.samples_),
+      offset_(from.offset_),
+      last_(from.last_),
+      count_(from.count_),
+      sum_(from.sum_),
+      max_(from.max_),
+      min_(from.min_),
+      first_(from.first_),
+      variance_(from.variance_) {
   _internal_metadata_.MergeFrom(from._internal_metadata_);
   ::memcpy(&start_timestamp_nanos_, &from.start_timestamp_nanos_,
     static_cast<size_t>(reinterpret_cast<char*>(&sample_duration_nanos_) -
@@ -149,6 +165,14 @@ void InternalTimeSeriesData::Clear() {
   (void) cached_has_bits;
 
   samples_.Clear();
+  offset_.Clear();
+  last_.Clear();
+  count_.Clear();
+  sum_.Clear();
+  max_.Clear();
+  min_.Clear();
+  first_.Clear();
+  variance_.Clear();
   cached_has_bits = _has_bits_[0];
   if (cached_has_bits & 3u) {
     ::memset(&start_timestamp_nanos_, 0, static_cast<size_t>(
@@ -211,6 +235,158 @@ bool InternalTimeSeriesData::MergePartialFromCodedStream(
         break;
       }
 
+      // repeated int32 offset = 4 [packed = true];
+      case 4: {
+        if (static_cast< ::google::protobuf::uint8>(tag) ==
+            static_cast< ::google::protobuf::uint8>(34u /* 34 & 0xFF */)) {
+          DO_((::google::protobuf::internal::WireFormatLite::ReadPackedPrimitive<
+                   ::google::protobuf::int32, ::google::protobuf::internal::WireFormatLite::TYPE_INT32>(
+                 input, this->mutable_offset())));
+        } else if (
+            static_cast< ::google::protobuf::uint8>(tag) ==
+            static_cast< ::google::protobuf::uint8>(32u /* 32 & 0xFF */)) {
+          DO_((::google::protobuf::internal::WireFormatLite::ReadRepeatedPrimitiveNoInline<
+                   ::google::protobuf::int32, ::google::protobuf::internal::WireFormatLite::TYPE_INT32>(
+                 1, 34u, input, this->mutable_offset())));
+        } else {
+          goto handle_unusual;
+        }
+        break;
+      }
+
+      // repeated double last = 5 [packed = true];
+      case 5: {
+        if (static_cast< ::google::protobuf::uint8>(tag) ==
+            static_cast< ::google::protobuf::uint8>(42u /* 42 & 0xFF */)) {
+          DO_((::google::protobuf::internal::WireFormatLite::ReadPackedPrimitive<
+                   double, ::google::protobuf::internal::WireFormatLite::TYPE_DOUBLE>(
+                 input, this->mutable_last())));
+        } else if (
+            static_cast< ::google::protobuf::uint8>(tag) ==
+            static_cast< ::google::protobuf::uint8>(41u /* 41 & 0xFF */)) {
+          DO_((::google::protobuf::internal::WireFormatLite::ReadRepeatedPrimitiveNoInline<
+                   double, ::google::protobuf::internal::WireFormatLite::TYPE_DOUBLE>(
+                 1, 42u, input, this->mutable_last())));
+        } else {
+          goto handle_unusual;
+        }
+        break;
+      }
+
+      // repeated uint32 count = 6 [packed = true];
+      case 6: {
+        if (static_cast< ::google::protobuf::uint8>(tag) ==
+            static_cast< ::google::protobuf::uint8>(50u /* 50 & 0xFF */)) {
+          DO_((::google::protobuf::internal::WireFormatLite::ReadPackedPrimitive<
+                   ::google::protobuf::uint32, ::google::protobuf::internal::WireFormatLite::TYPE_UINT32>(
+                 input, this->mutable_count())));
+        } else if (
+            static_cast< ::google::protobuf::uint8>(tag) ==
+            static_cast< ::google::protobuf::uint8>(48u /* 48 & 0xFF */)) {
+          DO_((::google::protobuf::internal::WireFormatLite::ReadRepeatedPrimitiveNoInline<
+                   ::google::protobuf::uint32, ::google::protobuf::internal::WireFormatLite::TYPE_UINT32>(
+                 1, 50u, input, this->mutable_count())));
+        } else {
+          goto handle_unusual;
+        }
+        break;
+      }
+
+      // repeated double sum = 7 [packed = true];
+      case 7: {
+        if (static_cast< ::google::protobuf::uint8>(tag) ==
+            static_cast< ::google::protobuf::uint8>(58u /* 58 & 0xFF */)) {
+          DO_((::google::protobuf::internal::WireFormatLite::ReadPackedPrimitive<
+                   double, ::google::protobuf::internal::WireFormatLite::TYPE_DOUBLE>(
+                 input, this->mutable_sum())));
+        } else if (
+            static_cast< ::google::protobuf::uint8>(tag) ==
+            static_cast< ::google::protobuf::uint8>(57u /* 57 & 0xFF */)) {
+          DO_((::google::protobuf::internal::WireFormatLite::ReadRepeatedPrimitiveNoInline<
+                   double, ::google::protobuf::internal::WireFormatLite::TYPE_DOUBLE>(
+                 1, 58u, input, this->mutable_sum())));
+        } else {
+          goto handle_unusual;
+        }
+        break;
+      }
+
+      // repeated double max = 8 [packed = true];
+      case 8: {
+        if (static_cast< ::google::protobuf::uint8>(tag) ==
+            static_cast< ::google::protobuf::uint8>(66u /* 66 & 0xFF */)) {
+          DO_((::google::protobuf::internal::WireFormatLite::ReadPackedPrimitive<
+                   double, ::google::protobuf::internal::WireFormatLite::TYPE_DOUBLE>(
+                 input, this->mutable_max())));
+        } else if (
+            static_cast< ::google::protobuf::uint8>(tag) ==
+            static_cast< ::google::protobuf::uint8>(65u /* 65 & 0xFF */)) {
+          DO_((::google::protobuf::internal::WireFormatLite::ReadRepeatedPrimitiveNoInline<
+                   double, ::google::protobuf::internal::WireFormatLite::TYPE_DOUBLE>(
+                 1, 66u, input, this->mutable_max())));
+        } else {
+          goto handle_unusual;
+        }
+        break;
+      }
+
+      // repeated double min = 9 [packed = true];
+      case 9: {
+        if (static_cast< ::google::protobuf::uint8>(tag) ==
+            static_cast< ::google::protobuf::uint8>(74u /* 74 & 0xFF */)) {
+          DO_((::google::protobuf::internal::WireFormatLite::ReadPackedPrimitive<
+                   double, ::google::protobuf::internal::WireFormatLite::TYPE_DOUBLE>(
+                 input, this->mutable_min())));
+        } else if (
+            static_cast< ::google::protobuf::uint8>(tag) ==
+            static_cast< ::google::protobuf::uint8>(73u /* 73 & 0xFF */)) {
+          DO_((::google::protobuf::internal::WireFormatLite::ReadRepeatedPrimitiveNoInline<
+                   double, ::google::protobuf::internal::WireFormatLite::TYPE_DOUBLE>(
+                 1, 74u, input, this->mutable_min())));
+        } else {
+          goto handle_unusual;
+        }
+        break;
+      }
+
+      // repeated double first = 10 [packed = true];
+      case 10: {
+        if (static_cast< ::google::protobuf::uint8>(tag) ==
+            static_cast< ::google::protobuf::uint8>(82u /* 82 & 0xFF */)) {
+          DO_((::google::protobuf::internal::WireFormatLite::ReadPackedPrimitive<
+                   double, ::google::protobuf::internal::WireFormatLite::TYPE_DOUBLE>(
+                 input, this->mutable_first())));
+        } else if (
+            static_cast< ::google::protobuf::uint8>(tag) ==
+            static_cast< ::google::protobuf::uint8>(81u /* 81 & 0xFF */)) {
+          DO_((::google::protobuf::internal::WireFormatLite::ReadRepeatedPrimitiveNoInline<
+                   double, ::google::protobuf::internal::WireFormatLite::TYPE_DOUBLE>(
+                 1, 82u, input, this->mutable_first())));
+        } else {
+          goto handle_unusual;
+        }
+        break;
+      }
+
+      // repeated double variance = 11 [packed = true];
+      case 11: {
+        if (static_cast< ::google::protobuf::uint8>(tag) ==
+            static_cast< ::google::protobuf::uint8>(90u /* 90 & 0xFF */)) {
+          DO_((::google::protobuf::internal::WireFormatLite::ReadPackedPrimitive<
+                   double, ::google::protobuf::internal::WireFormatLite::TYPE_DOUBLE>(
+                 input, this->mutable_variance())));
+        } else if (
+            static_cast< ::google::protobuf::uint8>(tag) ==
+            static_cast< ::google::protobuf::uint8>(89u /* 89 & 0xFF */)) {
+          DO_((::google::protobuf::internal::WireFormatLite::ReadRepeatedPrimitiveNoInline<
+                   double, ::google::protobuf::internal::WireFormatLite::TYPE_DOUBLE>(
+                 1, 90u, input, this->mutable_variance())));
+        } else {
+          goto handle_unusual;
+        }
+        break;
+      }
+
       default: {
       handle_unusual:
         if (tag == 0) {
@@ -252,6 +428,82 @@ void InternalTimeSeriesData::SerializeWithCachedSizes(
       3, this->samples(static_cast<int>(i)), output);
   }
 
+  // repeated int32 offset = 4 [packed = true];
+  if (this->offset_size() > 0) {
+    ::google::protobuf::internal::WireFormatLite::WriteTag(4, ::google::protobuf::internal::WireFormatLite::WIRETYPE_LENGTH_DELIMITED, output);
+    output->WriteVarint32(static_cast< ::google::protobuf::uint32>(
+        _offset_cached_byte_size_));
+  }
+  for (int i = 0, n = this->offset_size(); i < n; i++) {
+    ::google::protobuf::internal::WireFormatLite::WriteInt32NoTag(
+      this->offset(i), output);
+  }
+
+  // repeated double last = 5 [packed = true];
+  if (this->last_size() > 0) {
+    ::google::protobuf::internal::WireFormatLite::WriteTag(5, ::google::protobuf::internal::WireFormatLite::WIRETYPE_LENGTH_DELIMITED, output);
+    output->WriteVarint32(static_cast< ::google::protobuf::uint32>(
+        _last_cached_byte_size_));
+    ::google::protobuf::internal::WireFormatLite::WriteDoubleArray(
+      this->last().data(), this->last_size(), output);
+  }
+
+  // repeated uint32 count = 6 [packed = true];
+  if (this->count_size() > 0) {
+    ::google::protobuf::internal::WireFormatLite::WriteTag(6, ::google::protobuf::internal::WireFormatLite::WIRETYPE_LENGTH_DELIMITED, output);
+    output->WriteVarint32(static_cast< ::google::protobuf::uint32>(
+        _count_cached_byte_size_));
+  }
+  for (int i = 0, n = this->count_size(); i < n; i++) {
+    ::google::protobuf::internal::WireFormatLite::WriteUInt32NoTag(
+      this->count(i), output);
+  }
+
+  // repeated double sum = 7 [packed = true];
+  if (this->sum_size() > 0) {
+    ::google::protobuf::internal::WireFormatLite::WriteTag(7, ::google::protobuf::internal::WireFormatLite::WIRETYPE_LENGTH_DELIMITED, output);
+    output->WriteVarint32(static_cast< ::google::protobuf::uint32>(
+        _sum_cached_byte_size_));
+    ::google::protobuf::internal::WireFormatLite::WriteDoubleArray(
+      this->sum().data(), this->sum_size(), output);
+  }
+
+  // repeated double max = 8 [packed = true];
+  if (this->max_size() > 0) {
+    ::google::protobuf::internal::WireFormatLite::WriteTag(8, ::google::protobuf::internal::WireFormatLite::WIRETYPE_LENGTH_DELIMITED, output);
+    output->WriteVarint32(static_cast< ::google::protobuf::uint32>(
+        _max_cached_byte_size_));
+    ::google::protobuf::internal::WireFormatLite::WriteDoubleArray(
+      this->max().data(), this->max_size(), output);
+  }
+
+  // repeated double min = 9 [packed = true];
+  if (this->min_size() > 0) {
+    ::google::protobuf::internal::WireFormatLite::WriteTag(9, ::google::protobuf::internal::WireFormatLite::WIRETYPE_LENGTH_DELIMITED, output);
+    output->WriteVarint32(static_cast< ::google::protobuf::uint32>(
+        _min_cached_byte_size_));
+    ::google::protobuf::internal::WireFormatLite::WriteDoubleArray(
+      this->min().data(), this->min_size(), output);
+  }
+
+  // repeated double first = 10 [packed = true];
+  if (this->first_size() > 0) {
+    ::google::protobuf::internal::WireFormatLite::WriteTag(10, ::google::protobuf::internal::WireFormatLite::WIRETYPE_LENGTH_DELIMITED, output);
+    output->WriteVarint32(static_cast< ::google::protobuf::uint32>(
+        _first_cached_byte_size_));
+    ::google::protobuf::internal::WireFormatLite::WriteDoubleArray(
+      this->first().data(), this->first_size(), output);
+  }
+
+  // repeated double variance = 11 [packed = true];
+  if (this->variance_size() > 0) {
+    ::google::protobuf::internal::WireFormatLite::WriteTag(11, ::google::protobuf::internal::WireFormatLite::WIRETYPE_LENGTH_DELIMITED, output);
+    output->WriteVarint32(static_cast< ::google::protobuf::uint32>(
+        _variance_cached_byte_size_));
+    ::google::protobuf::internal::WireFormatLite::WriteDoubleArray(
+      this->variance().data(), this->variance_size(), output);
+  }
+
   output->WriteRaw(_internal_metadata_.unknown_fields().data(),
                    static_cast<int>(_internal_metadata_.unknown_fields().size()));
   // @@protoc_insertion_point(serialize_end:cockroach.roachpb.InternalTimeSeriesData)
@@ -271,6 +523,134 @@ size_t InternalTimeSeriesData::ByteSizeLong() const {
         ::google::protobuf::internal::WireFormatLite::MessageSize(
           this->samples(static_cast<int>(i)));
     }
+  }
+
+  // repeated int32 offset = 4 [packed = true];
+  {
+    size_t data_size = ::google::protobuf::internal::WireFormatLite::
+      Int32Size(this->offset_);
+    if (data_size > 0) {
+      total_size += 1 +
+        ::google::protobuf::internal::WireFormatLite::Int32Size(
+            static_cast< ::google::protobuf::int32>(data_size));
+    }
+    int cached_size = ::google::protobuf::internal::ToCachedSize(data_size);
+    GOOGLE_SAFE_CONCURRENT_WRITES_BEGIN();
+    _offset_cached_byte_size_ = cached_size;
+    GOOGLE_SAFE_CONCURRENT_WRITES_END();
+    total_size += data_size;
+  }
+
+  // repeated double last = 5 [packed = true];
+  {
+    unsigned int count = static_cast<unsigned int>(this->last_size());
+    size_t data_size = 8UL * count;
+    if (data_size > 0) {
+      total_size += 1 +
+        ::google::protobuf::internal::WireFormatLite::Int32Size(
+            static_cast< ::google::protobuf::int32>(data_size));
+    }
+    int cached_size = ::google::protobuf::internal::ToCachedSize(data_size);
+    GOOGLE_SAFE_CONCURRENT_WRITES_BEGIN();
+    _last_cached_byte_size_ = cached_size;
+    GOOGLE_SAFE_CONCURRENT_WRITES_END();
+    total_size += data_size;
+  }
+
+  // repeated uint32 count = 6 [packed = true];
+  {
+    size_t data_size = ::google::protobuf::internal::WireFormatLite::
+      UInt32Size(this->count_);
+    if (data_size > 0) {
+      total_size += 1 +
+        ::google::protobuf::internal::WireFormatLite::Int32Size(
+            static_cast< ::google::protobuf::int32>(data_size));
+    }
+    int cached_size = ::google::protobuf::internal::ToCachedSize(data_size);
+    GOOGLE_SAFE_CONCURRENT_WRITES_BEGIN();
+    _count_cached_byte_size_ = cached_size;
+    GOOGLE_SAFE_CONCURRENT_WRITES_END();
+    total_size += data_size;
+  }
+
+  // repeated double sum = 7 [packed = true];
+  {
+    unsigned int count = static_cast<unsigned int>(this->sum_size());
+    size_t data_size = 8UL * count;
+    if (data_size > 0) {
+      total_size += 1 +
+        ::google::protobuf::internal::WireFormatLite::Int32Size(
+            static_cast< ::google::protobuf::int32>(data_size));
+    }
+    int cached_size = ::google::protobuf::internal::ToCachedSize(data_size);
+    GOOGLE_SAFE_CONCURRENT_WRITES_BEGIN();
+    _sum_cached_byte_size_ = cached_size;
+    GOOGLE_SAFE_CONCURRENT_WRITES_END();
+    total_size += data_size;
+  }
+
+  // repeated double max = 8 [packed = true];
+  {
+    unsigned int count = static_cast<unsigned int>(this->max_size());
+    size_t data_size = 8UL * count;
+    if (data_size > 0) {
+      total_size += 1 +
+        ::google::protobuf::internal::WireFormatLite::Int32Size(
+            static_cast< ::google::protobuf::int32>(data_size));
+    }
+    int cached_size = ::google::protobuf::internal::ToCachedSize(data_size);
+    GOOGLE_SAFE_CONCURRENT_WRITES_BEGIN();
+    _max_cached_byte_size_ = cached_size;
+    GOOGLE_SAFE_CONCURRENT_WRITES_END();
+    total_size += data_size;
+  }
+
+  // repeated double min = 9 [packed = true];
+  {
+    unsigned int count = static_cast<unsigned int>(this->min_size());
+    size_t data_size = 8UL * count;
+    if (data_size > 0) {
+      total_size += 1 +
+        ::google::protobuf::internal::WireFormatLite::Int32Size(
+            static_cast< ::google::protobuf::int32>(data_size));
+    }
+    int cached_size = ::google::protobuf::internal::ToCachedSize(data_size);
+    GOOGLE_SAFE_CONCURRENT_WRITES_BEGIN();
+    _min_cached_byte_size_ = cached_size;
+    GOOGLE_SAFE_CONCURRENT_WRITES_END();
+    total_size += data_size;
+  }
+
+  // repeated double first = 10 [packed = true];
+  {
+    unsigned int count = static_cast<unsigned int>(this->first_size());
+    size_t data_size = 8UL * count;
+    if (data_size > 0) {
+      total_size += 1 +
+        ::google::protobuf::internal::WireFormatLite::Int32Size(
+            static_cast< ::google::protobuf::int32>(data_size));
+    }
+    int cached_size = ::google::protobuf::internal::ToCachedSize(data_size);
+    GOOGLE_SAFE_CONCURRENT_WRITES_BEGIN();
+    _first_cached_byte_size_ = cached_size;
+    GOOGLE_SAFE_CONCURRENT_WRITES_END();
+    total_size += data_size;
+  }
+
+  // repeated double variance = 11 [packed = true];
+  {
+    unsigned int count = static_cast<unsigned int>(this->variance_size());
+    size_t data_size = 8UL * count;
+    if (data_size > 0) {
+      total_size += 1 +
+        ::google::protobuf::internal::WireFormatLite::Int32Size(
+            static_cast< ::google::protobuf::int32>(data_size));
+    }
+    int cached_size = ::google::protobuf::internal::ToCachedSize(data_size);
+    GOOGLE_SAFE_CONCURRENT_WRITES_BEGIN();
+    _variance_cached_byte_size_ = cached_size;
+    GOOGLE_SAFE_CONCURRENT_WRITES_END();
+    total_size += data_size;
   }
 
   if (_has_bits_[0 / 32] & 3u) {
@@ -307,6 +687,14 @@ void InternalTimeSeriesData::MergeFrom(const InternalTimeSeriesData& from) {
   (void) cached_has_bits;
 
   samples_.MergeFrom(from.samples_);
+  offset_.MergeFrom(from.offset_);
+  last_.MergeFrom(from.last_);
+  count_.MergeFrom(from.count_);
+  sum_.MergeFrom(from.sum_);
+  max_.MergeFrom(from.max_);
+  min_.MergeFrom(from.min_);
+  first_.MergeFrom(from.first_);
+  variance_.MergeFrom(from.variance_);
   cached_has_bits = from._has_bits_[0];
   if (cached_has_bits & 3u) {
     if (cached_has_bits & 0x00000001u) {
@@ -337,6 +725,14 @@ void InternalTimeSeriesData::Swap(InternalTimeSeriesData* other) {
 void InternalTimeSeriesData::InternalSwap(InternalTimeSeriesData* other) {
   using std::swap;
   samples_.InternalSwap(&other->samples_);
+  offset_.InternalSwap(&other->offset_);
+  last_.InternalSwap(&other->last_);
+  count_.InternalSwap(&other->count_);
+  sum_.InternalSwap(&other->sum_);
+  max_.InternalSwap(&other->max_);
+  min_.InternalSwap(&other->min_);
+  first_.InternalSwap(&other->first_);
+  variance_.InternalSwap(&other->variance_);
   swap(start_timestamp_nanos_, other->start_timestamp_nanos_);
   swap(sample_duration_nanos_, other->sample_duration_nanos_);
   swap(_has_bits_[0], other->_has_bits_[0]);

--- a/c-deps/libroach/protos/roachpb/internal.pb.h
+++ b/c-deps/libroach/protos/roachpb/internal.pb.h
@@ -151,16 +151,112 @@ class InternalTimeSeriesData : public ::google::protobuf::MessageLite /* @@proto
 
   // accessors -------------------------------------------------------
 
-  int samples_size() const;
-  void clear_samples();
-  static const int kSamplesFieldNumber = 3;
-  const ::cockroach::roachpb::InternalTimeSeriesSample& samples(int index) const;
-  ::cockroach::roachpb::InternalTimeSeriesSample* mutable_samples(int index);
-  ::cockroach::roachpb::InternalTimeSeriesSample* add_samples();
-  ::google::protobuf::RepeatedPtrField< ::cockroach::roachpb::InternalTimeSeriesSample >*
+  GOOGLE_PROTOBUF_DEPRECATED_ATTR int samples_size() const;
+  GOOGLE_PROTOBUF_DEPRECATED_ATTR void clear_samples();
+  GOOGLE_PROTOBUF_DEPRECATED_ATTR static const int kSamplesFieldNumber = 3;
+  GOOGLE_PROTOBUF_DEPRECATED_ATTR const ::cockroach::roachpb::InternalTimeSeriesSample& samples(int index) const;
+  GOOGLE_PROTOBUF_DEPRECATED_ATTR ::cockroach::roachpb::InternalTimeSeriesSample* mutable_samples(int index);
+  GOOGLE_PROTOBUF_DEPRECATED_ATTR ::cockroach::roachpb::InternalTimeSeriesSample* add_samples();
+  GOOGLE_PROTOBUF_DEPRECATED_ATTR ::google::protobuf::RepeatedPtrField< ::cockroach::roachpb::InternalTimeSeriesSample >*
       mutable_samples();
-  const ::google::protobuf::RepeatedPtrField< ::cockroach::roachpb::InternalTimeSeriesSample >&
+  GOOGLE_PROTOBUF_DEPRECATED_ATTR const ::google::protobuf::RepeatedPtrField< ::cockroach::roachpb::InternalTimeSeriesSample >&
       samples() const;
+
+  // repeated int32 offset = 4 [packed = true];
+  int offset_size() const;
+  void clear_offset();
+  static const int kOffsetFieldNumber = 4;
+  ::google::protobuf::int32 offset(int index) const;
+  void set_offset(int index, ::google::protobuf::int32 value);
+  void add_offset(::google::protobuf::int32 value);
+  const ::google::protobuf::RepeatedField< ::google::protobuf::int32 >&
+      offset() const;
+  ::google::protobuf::RepeatedField< ::google::protobuf::int32 >*
+      mutable_offset();
+
+  // repeated double last = 5 [packed = true];
+  int last_size() const;
+  void clear_last();
+  static const int kLastFieldNumber = 5;
+  double last(int index) const;
+  void set_last(int index, double value);
+  void add_last(double value);
+  const ::google::protobuf::RepeatedField< double >&
+      last() const;
+  ::google::protobuf::RepeatedField< double >*
+      mutable_last();
+
+  // repeated uint32 count = 6 [packed = true];
+  int count_size() const;
+  void clear_count();
+  static const int kCountFieldNumber = 6;
+  ::google::protobuf::uint32 count(int index) const;
+  void set_count(int index, ::google::protobuf::uint32 value);
+  void add_count(::google::protobuf::uint32 value);
+  const ::google::protobuf::RepeatedField< ::google::protobuf::uint32 >&
+      count() const;
+  ::google::protobuf::RepeatedField< ::google::protobuf::uint32 >*
+      mutable_count();
+
+  // repeated double sum = 7 [packed = true];
+  int sum_size() const;
+  void clear_sum();
+  static const int kSumFieldNumber = 7;
+  double sum(int index) const;
+  void set_sum(int index, double value);
+  void add_sum(double value);
+  const ::google::protobuf::RepeatedField< double >&
+      sum() const;
+  ::google::protobuf::RepeatedField< double >*
+      mutable_sum();
+
+  // repeated double max = 8 [packed = true];
+  int max_size() const;
+  void clear_max();
+  static const int kMaxFieldNumber = 8;
+  double max(int index) const;
+  void set_max(int index, double value);
+  void add_max(double value);
+  const ::google::protobuf::RepeatedField< double >&
+      max() const;
+  ::google::protobuf::RepeatedField< double >*
+      mutable_max();
+
+  // repeated double min = 9 [packed = true];
+  int min_size() const;
+  void clear_min();
+  static const int kMinFieldNumber = 9;
+  double min(int index) const;
+  void set_min(int index, double value);
+  void add_min(double value);
+  const ::google::protobuf::RepeatedField< double >&
+      min() const;
+  ::google::protobuf::RepeatedField< double >*
+      mutable_min();
+
+  // repeated double first = 10 [packed = true];
+  int first_size() const;
+  void clear_first();
+  static const int kFirstFieldNumber = 10;
+  double first(int index) const;
+  void set_first(int index, double value);
+  void add_first(double value);
+  const ::google::protobuf::RepeatedField< double >&
+      first() const;
+  ::google::protobuf::RepeatedField< double >*
+      mutable_first();
+
+  // repeated double variance = 11 [packed = true];
+  int variance_size() const;
+  void clear_variance();
+  static const int kVarianceFieldNumber = 11;
+  double variance(int index) const;
+  void set_variance(int index, double value);
+  void add_variance(double value);
+  const ::google::protobuf::RepeatedField< double >&
+      variance() const;
+  ::google::protobuf::RepeatedField< double >*
+      mutable_variance();
 
   bool has_start_timestamp_nanos() const;
   void clear_start_timestamp_nanos();
@@ -185,6 +281,22 @@ class InternalTimeSeriesData : public ::google::protobuf::MessageLite /* @@proto
   ::google::protobuf::internal::HasBits<1> _has_bits_;
   mutable int _cached_size_;
   ::google::protobuf::RepeatedPtrField< ::cockroach::roachpb::InternalTimeSeriesSample > samples_;
+  ::google::protobuf::RepeatedField< ::google::protobuf::int32 > offset_;
+  mutable int _offset_cached_byte_size_;
+  ::google::protobuf::RepeatedField< double > last_;
+  mutable int _last_cached_byte_size_;
+  ::google::protobuf::RepeatedField< ::google::protobuf::uint32 > count_;
+  mutable int _count_cached_byte_size_;
+  ::google::protobuf::RepeatedField< double > sum_;
+  mutable int _sum_cached_byte_size_;
+  ::google::protobuf::RepeatedField< double > max_;
+  mutable int _max_cached_byte_size_;
+  ::google::protobuf::RepeatedField< double > min_;
+  mutable int _min_cached_byte_size_;
+  ::google::protobuf::RepeatedField< double > first_;
+  mutable int _first_cached_byte_size_;
+  ::google::protobuf::RepeatedField< double > variance_;
+  mutable int _variance_cached_byte_size_;
   ::google::protobuf::int64 start_timestamp_nanos_;
   ::google::protobuf::int64 sample_duration_nanos_;
   friend struct ::protobuf_roachpb_2finternal_2eproto::TableStruct;
@@ -419,6 +531,246 @@ inline const ::google::protobuf::RepeatedPtrField< ::cockroach::roachpb::Interna
 InternalTimeSeriesData::samples() const {
   // @@protoc_insertion_point(field_list:cockroach.roachpb.InternalTimeSeriesData.samples)
   return samples_;
+}
+
+// repeated int32 offset = 4 [packed = true];
+inline int InternalTimeSeriesData::offset_size() const {
+  return offset_.size();
+}
+inline void InternalTimeSeriesData::clear_offset() {
+  offset_.Clear();
+}
+inline ::google::protobuf::int32 InternalTimeSeriesData::offset(int index) const {
+  // @@protoc_insertion_point(field_get:cockroach.roachpb.InternalTimeSeriesData.offset)
+  return offset_.Get(index);
+}
+inline void InternalTimeSeriesData::set_offset(int index, ::google::protobuf::int32 value) {
+  offset_.Set(index, value);
+  // @@protoc_insertion_point(field_set:cockroach.roachpb.InternalTimeSeriesData.offset)
+}
+inline void InternalTimeSeriesData::add_offset(::google::protobuf::int32 value) {
+  offset_.Add(value);
+  // @@protoc_insertion_point(field_add:cockroach.roachpb.InternalTimeSeriesData.offset)
+}
+inline const ::google::protobuf::RepeatedField< ::google::protobuf::int32 >&
+InternalTimeSeriesData::offset() const {
+  // @@protoc_insertion_point(field_list:cockroach.roachpb.InternalTimeSeriesData.offset)
+  return offset_;
+}
+inline ::google::protobuf::RepeatedField< ::google::protobuf::int32 >*
+InternalTimeSeriesData::mutable_offset() {
+  // @@protoc_insertion_point(field_mutable_list:cockroach.roachpb.InternalTimeSeriesData.offset)
+  return &offset_;
+}
+
+// repeated double last = 5 [packed = true];
+inline int InternalTimeSeriesData::last_size() const {
+  return last_.size();
+}
+inline void InternalTimeSeriesData::clear_last() {
+  last_.Clear();
+}
+inline double InternalTimeSeriesData::last(int index) const {
+  // @@protoc_insertion_point(field_get:cockroach.roachpb.InternalTimeSeriesData.last)
+  return last_.Get(index);
+}
+inline void InternalTimeSeriesData::set_last(int index, double value) {
+  last_.Set(index, value);
+  // @@protoc_insertion_point(field_set:cockroach.roachpb.InternalTimeSeriesData.last)
+}
+inline void InternalTimeSeriesData::add_last(double value) {
+  last_.Add(value);
+  // @@protoc_insertion_point(field_add:cockroach.roachpb.InternalTimeSeriesData.last)
+}
+inline const ::google::protobuf::RepeatedField< double >&
+InternalTimeSeriesData::last() const {
+  // @@protoc_insertion_point(field_list:cockroach.roachpb.InternalTimeSeriesData.last)
+  return last_;
+}
+inline ::google::protobuf::RepeatedField< double >*
+InternalTimeSeriesData::mutable_last() {
+  // @@protoc_insertion_point(field_mutable_list:cockroach.roachpb.InternalTimeSeriesData.last)
+  return &last_;
+}
+
+// repeated uint32 count = 6 [packed = true];
+inline int InternalTimeSeriesData::count_size() const {
+  return count_.size();
+}
+inline void InternalTimeSeriesData::clear_count() {
+  count_.Clear();
+}
+inline ::google::protobuf::uint32 InternalTimeSeriesData::count(int index) const {
+  // @@protoc_insertion_point(field_get:cockroach.roachpb.InternalTimeSeriesData.count)
+  return count_.Get(index);
+}
+inline void InternalTimeSeriesData::set_count(int index, ::google::protobuf::uint32 value) {
+  count_.Set(index, value);
+  // @@protoc_insertion_point(field_set:cockroach.roachpb.InternalTimeSeriesData.count)
+}
+inline void InternalTimeSeriesData::add_count(::google::protobuf::uint32 value) {
+  count_.Add(value);
+  // @@protoc_insertion_point(field_add:cockroach.roachpb.InternalTimeSeriesData.count)
+}
+inline const ::google::protobuf::RepeatedField< ::google::protobuf::uint32 >&
+InternalTimeSeriesData::count() const {
+  // @@protoc_insertion_point(field_list:cockroach.roachpb.InternalTimeSeriesData.count)
+  return count_;
+}
+inline ::google::protobuf::RepeatedField< ::google::protobuf::uint32 >*
+InternalTimeSeriesData::mutable_count() {
+  // @@protoc_insertion_point(field_mutable_list:cockroach.roachpb.InternalTimeSeriesData.count)
+  return &count_;
+}
+
+// repeated double sum = 7 [packed = true];
+inline int InternalTimeSeriesData::sum_size() const {
+  return sum_.size();
+}
+inline void InternalTimeSeriesData::clear_sum() {
+  sum_.Clear();
+}
+inline double InternalTimeSeriesData::sum(int index) const {
+  // @@protoc_insertion_point(field_get:cockroach.roachpb.InternalTimeSeriesData.sum)
+  return sum_.Get(index);
+}
+inline void InternalTimeSeriesData::set_sum(int index, double value) {
+  sum_.Set(index, value);
+  // @@protoc_insertion_point(field_set:cockroach.roachpb.InternalTimeSeriesData.sum)
+}
+inline void InternalTimeSeriesData::add_sum(double value) {
+  sum_.Add(value);
+  // @@protoc_insertion_point(field_add:cockroach.roachpb.InternalTimeSeriesData.sum)
+}
+inline const ::google::protobuf::RepeatedField< double >&
+InternalTimeSeriesData::sum() const {
+  // @@protoc_insertion_point(field_list:cockroach.roachpb.InternalTimeSeriesData.sum)
+  return sum_;
+}
+inline ::google::protobuf::RepeatedField< double >*
+InternalTimeSeriesData::mutable_sum() {
+  // @@protoc_insertion_point(field_mutable_list:cockroach.roachpb.InternalTimeSeriesData.sum)
+  return &sum_;
+}
+
+// repeated double max = 8 [packed = true];
+inline int InternalTimeSeriesData::max_size() const {
+  return max_.size();
+}
+inline void InternalTimeSeriesData::clear_max() {
+  max_.Clear();
+}
+inline double InternalTimeSeriesData::max(int index) const {
+  // @@protoc_insertion_point(field_get:cockroach.roachpb.InternalTimeSeriesData.max)
+  return max_.Get(index);
+}
+inline void InternalTimeSeriesData::set_max(int index, double value) {
+  max_.Set(index, value);
+  // @@protoc_insertion_point(field_set:cockroach.roachpb.InternalTimeSeriesData.max)
+}
+inline void InternalTimeSeriesData::add_max(double value) {
+  max_.Add(value);
+  // @@protoc_insertion_point(field_add:cockroach.roachpb.InternalTimeSeriesData.max)
+}
+inline const ::google::protobuf::RepeatedField< double >&
+InternalTimeSeriesData::max() const {
+  // @@protoc_insertion_point(field_list:cockroach.roachpb.InternalTimeSeriesData.max)
+  return max_;
+}
+inline ::google::protobuf::RepeatedField< double >*
+InternalTimeSeriesData::mutable_max() {
+  // @@protoc_insertion_point(field_mutable_list:cockroach.roachpb.InternalTimeSeriesData.max)
+  return &max_;
+}
+
+// repeated double min = 9 [packed = true];
+inline int InternalTimeSeriesData::min_size() const {
+  return min_.size();
+}
+inline void InternalTimeSeriesData::clear_min() {
+  min_.Clear();
+}
+inline double InternalTimeSeriesData::min(int index) const {
+  // @@protoc_insertion_point(field_get:cockroach.roachpb.InternalTimeSeriesData.min)
+  return min_.Get(index);
+}
+inline void InternalTimeSeriesData::set_min(int index, double value) {
+  min_.Set(index, value);
+  // @@protoc_insertion_point(field_set:cockroach.roachpb.InternalTimeSeriesData.min)
+}
+inline void InternalTimeSeriesData::add_min(double value) {
+  min_.Add(value);
+  // @@protoc_insertion_point(field_add:cockroach.roachpb.InternalTimeSeriesData.min)
+}
+inline const ::google::protobuf::RepeatedField< double >&
+InternalTimeSeriesData::min() const {
+  // @@protoc_insertion_point(field_list:cockroach.roachpb.InternalTimeSeriesData.min)
+  return min_;
+}
+inline ::google::protobuf::RepeatedField< double >*
+InternalTimeSeriesData::mutable_min() {
+  // @@protoc_insertion_point(field_mutable_list:cockroach.roachpb.InternalTimeSeriesData.min)
+  return &min_;
+}
+
+// repeated double first = 10 [packed = true];
+inline int InternalTimeSeriesData::first_size() const {
+  return first_.size();
+}
+inline void InternalTimeSeriesData::clear_first() {
+  first_.Clear();
+}
+inline double InternalTimeSeriesData::first(int index) const {
+  // @@protoc_insertion_point(field_get:cockroach.roachpb.InternalTimeSeriesData.first)
+  return first_.Get(index);
+}
+inline void InternalTimeSeriesData::set_first(int index, double value) {
+  first_.Set(index, value);
+  // @@protoc_insertion_point(field_set:cockroach.roachpb.InternalTimeSeriesData.first)
+}
+inline void InternalTimeSeriesData::add_first(double value) {
+  first_.Add(value);
+  // @@protoc_insertion_point(field_add:cockroach.roachpb.InternalTimeSeriesData.first)
+}
+inline const ::google::protobuf::RepeatedField< double >&
+InternalTimeSeriesData::first() const {
+  // @@protoc_insertion_point(field_list:cockroach.roachpb.InternalTimeSeriesData.first)
+  return first_;
+}
+inline ::google::protobuf::RepeatedField< double >*
+InternalTimeSeriesData::mutable_first() {
+  // @@protoc_insertion_point(field_mutable_list:cockroach.roachpb.InternalTimeSeriesData.first)
+  return &first_;
+}
+
+// repeated double variance = 11 [packed = true];
+inline int InternalTimeSeriesData::variance_size() const {
+  return variance_.size();
+}
+inline void InternalTimeSeriesData::clear_variance() {
+  variance_.Clear();
+}
+inline double InternalTimeSeriesData::variance(int index) const {
+  // @@protoc_insertion_point(field_get:cockroach.roachpb.InternalTimeSeriesData.variance)
+  return variance_.Get(index);
+}
+inline void InternalTimeSeriesData::set_variance(int index, double value) {
+  variance_.Set(index, value);
+  // @@protoc_insertion_point(field_set:cockroach.roachpb.InternalTimeSeriesData.variance)
+}
+inline void InternalTimeSeriesData::add_variance(double value) {
+  variance_.Add(value);
+  // @@protoc_insertion_point(field_add:cockroach.roachpb.InternalTimeSeriesData.variance)
+}
+inline const ::google::protobuf::RepeatedField< double >&
+InternalTimeSeriesData::variance() const {
+  // @@protoc_insertion_point(field_list:cockroach.roachpb.InternalTimeSeriesData.variance)
+  return variance_;
+}
+inline ::google::protobuf::RepeatedField< double >*
+InternalTimeSeriesData::mutable_variance() {
+  // @@protoc_insertion_point(field_mutable_list:cockroach.roachpb.InternalTimeSeriesData.variance)
+  return &variance_;
 }
 
 // -------------------------------------------------------------------

--- a/pkg/roachpb/internal.proto
+++ b/pkg/roachpb/internal.proto
@@ -37,6 +37,24 @@ import "gogoproto/gogo.proto";
 // mind, this message does not identify the variable which is actually being
 // measured; that information is expected be encoded in the key where this
 // message is stored.
+//
+// The actual samples can be stored in one of two formats: a Row-based format in
+// the "samples" repeated field, or a columnar format spread across several
+// different repeated columns. The row-based format will eventually be
+// deprecated, but is maintained for backwards compatibility. There is no flag
+// that indicates whether the data is stored as rows or columns; columnar data
+// is indicated by the presence of a non-zero-length "offset" collection, while
+// row data is indicated by a non-zero-length "samples" collection. Each data
+// message must have all of its data either row format or column format.
+//
+// One feature of the columnar layout is that it is "sparse", and columns
+// without useful information are elided. Specifically, the "offset" and "last"
+// columns will always be populated, but the other columns are only populated
+// for resolutions which contain detailed "rollup" information about long sample
+// periods. In the case of non-rollup data there is only one measurement per
+// sample period, and the value of all optional columns can be directly inferred
+// from the "last" column. Eliding those columns represents a significant memory
+// and on-disk savings for our highest resolution data.
 message InternalTimeSeriesData {
   // Holds a wall time, expressed as a unix epoch time in nanoseconds. This
   // represents the earliest possible timestamp for a sample within the
@@ -44,8 +62,40 @@ message InternalTimeSeriesData {
   optional int64 start_timestamp_nanos = 1 [(gogoproto.nullable) = false];
   // The duration of each sample interval, expressed in nanoseconds.
   optional int64 sample_duration_nanos = 2 [(gogoproto.nullable) = false];
-  // The actual data samples for this metric.
-  repeated InternalTimeSeriesSample samples = 3 [(gogoproto.nullable) = false];
+  // The data samples for this metric if this data was written in the old
+  // row format.
+  repeated InternalTimeSeriesSample samples = 3 [(gogoproto.nullable) = false, deprecated=true];
+  // Columnar array containing the ordered offsets of the samples in this
+  // data set.
+  repeated int32 offset = 4 [packed=true];
+  // Columnar array containing the last value of the samples in this data set;
+  // the "last" value is the most recent individual measurement during a sample
+  // period.
+  repeated double last = 5 [packed=true];
+  // Columnar array containing the total number of measurements that were taken
+  // during this sample period.
+  repeated uint32 count = 6 [packed=true];
+  // Columnar array containing the sum of measurements that were taken during
+  // this sample period. If this column is elided, its value for all samples is
+  // 1.
+  repeated double sum = 7 [packed=true];
+  // Columnar array containing the maximum value of any single measurement taken
+  // during this sample period. If this column is elided, its value for all
+  // samples is equal to "last".
+  repeated double max = 8 [packed=true];
+  // Columnar array containing the minimum value of any single measurements
+  // taken during this sample period. If this column is elided, its value for
+  // all samples is equal to "last".
+  repeated double min = 9 [packed=true];
+  // Columnar array containing the first value of the samples in this data set;
+  // the "first" value is the earliest individual measurement during a sample
+  // period. If this column is elided, its value for all samples is equal to
+  // "last".
+  repeated double first = 10 [packed=true];
+  // Columnar array containing the variance of measurements that were taken
+  // during this sample period. If this column is elided, its value for all
+  // samples is zero.
+  repeated double variance = 11 [packed=true];
 }
 
 // A InternalTimeSeriesSample represents data gathered from multiple

--- a/pkg/storage/engine/engine_test.go
+++ b/pkg/storage/engine/engine_test.go
@@ -421,22 +421,22 @@ func TestEngineMerge(t *testing.T) {
 			{
 				mvccKey("timeseriesmerged"),
 				[][]byte{
-					timeSeries(testtime, 1000, []tsSample{
+					timeSeriesRow(testtime, 1000, []tsSample{
 						{1, 1, 5, 5, 5},
 					}...),
-					timeSeries(testtime, 1000, []tsSample{
+					timeSeriesRow(testtime, 1000, []tsSample{
 						{2, 1, 5, 5, 5},
 						{1, 2, 10, 7, 3},
 					}...),
-					timeSeries(testtime, 1000, []tsSample{
+					timeSeriesRow(testtime, 1000, []tsSample{
 						{10, 1, 5, 5, 5},
 					}...),
-					timeSeries(testtime, 1000, []tsSample{
+					timeSeriesRow(testtime, 1000, []tsSample{
 						{5, 1, 5, 5, 5},
 						{3, 1, 5, 5, 5},
 					}...),
 				},
-				timeSeries(testtime, 1000, []tsSample{
+				timeSeriesRow(testtime, 1000, []tsSample{
 					{1, 2, 10, 7, 3},
 					{2, 1, 5, 5, 5},
 					{3, 1, 5, 5, 5},

--- a/pkg/storage/engine/mvcc_test.go
+++ b/pkg/storage/engine/mvcc_test.go
@@ -70,10 +70,10 @@ var (
 	value4       = roachpb.MakeValueFromString("testValue4")
 	value5       = roachpb.MakeValueFromString("testValue5")
 	value6       = roachpb.MakeValueFromString("testValue6")
-	tsvalue1     = timeSeriesAsValue(testtime, 1000, []tsSample{
+	tsvalue1     = timeSeriesRowAsValue(testtime, 1000, []tsSample{
 		{1, 1, 5, 5, 5},
 	}...)
-	tsvalue2 = timeSeriesAsValue(testtime, 1000, []tsSample{
+	tsvalue2 = timeSeriesRowAsValue(testtime, 1000, []tsSample{
 		{1, 1, 15, 15, 15},
 	}...)
 	valueEmpty = roachpb.MakeValueFromString("")

--- a/pkg/ts/memory_test.go
+++ b/pkg/ts/memory_test.go
@@ -37,7 +37,7 @@ func TestGetMaxTimespan(t *testing.T) {
 		{
 			Resolution10s,
 			QueryMemoryOptions{
-				BudgetBytes:             2 * (sizeOfTimeSeriesData + sizeOfTimeSeriesData*360),
+				BudgetBytes:             2 * (sizeOfTimeSeriesData + sizeOfSample*360),
 				EstimatedSources:        1,
 				InterpolationLimitNanos: 0,
 			},
@@ -48,7 +48,7 @@ func TestGetMaxTimespan(t *testing.T) {
 		{
 			Resolution10s,
 			QueryMemoryOptions{
-				BudgetBytes:             sizeOfTimeSeriesData + sizeOfTimeSeriesData*360,
+				BudgetBytes:             sizeOfTimeSeriesData + sizeOfSample*360,
 				EstimatedSources:        1,
 				InterpolationLimitNanos: 0,
 			},
@@ -59,7 +59,7 @@ func TestGetMaxTimespan(t *testing.T) {
 		{
 			Resolution10s,
 			QueryMemoryOptions{
-				BudgetBytes:             2 * (sizeOfTimeSeriesData + sizeOfTimeSeriesData*360),
+				BudgetBytes:             2 * (sizeOfTimeSeriesData + sizeOfSample*360),
 				EstimatedSources:        2,
 				InterpolationLimitNanos: 0,
 			},
@@ -70,7 +70,7 @@ func TestGetMaxTimespan(t *testing.T) {
 		{
 			Resolution10s,
 			QueryMemoryOptions{
-				BudgetBytes:             12 * (sizeOfTimeSeriesData + sizeOfTimeSeriesData*360),
+				BudgetBytes:             12 * (sizeOfTimeSeriesData + sizeOfSample*360),
 				EstimatedSources:        6,
 				InterpolationLimitNanos: 0,
 			},
@@ -81,7 +81,7 @@ func TestGetMaxTimespan(t *testing.T) {
 		{
 			Resolution10s,
 			QueryMemoryOptions{
-				BudgetBytes:             18 * (sizeOfTimeSeriesData + sizeOfTimeSeriesData*360),
+				BudgetBytes:             18 * (sizeOfTimeSeriesData + sizeOfSample*360),
 				EstimatedSources:        6,
 				InterpolationLimitNanos: 0,
 			},
@@ -92,7 +92,7 @@ func TestGetMaxTimespan(t *testing.T) {
 		{
 			Resolution10s,
 			QueryMemoryOptions{
-				BudgetBytes:             12 * (sizeOfTimeSeriesData + sizeOfTimeSeriesData*360),
+				BudgetBytes:             12 * (sizeOfTimeSeriesData + sizeOfSample*360),
 				EstimatedSources:        6,
 				InterpolationLimitNanos: 1,
 			},
@@ -103,7 +103,7 @@ func TestGetMaxTimespan(t *testing.T) {
 		{
 			Resolution10s,
 			QueryMemoryOptions{
-				BudgetBytes:             18 * (sizeOfTimeSeriesData + sizeOfTimeSeriesData*360),
+				BudgetBytes:             18 * (sizeOfTimeSeriesData + sizeOfSample*360),
 				EstimatedSources:        6,
 				InterpolationLimitNanos: 1,
 			},
@@ -114,7 +114,7 @@ func TestGetMaxTimespan(t *testing.T) {
 		{
 			Resolution10s,
 			QueryMemoryOptions{
-				BudgetBytes:             18 * (sizeOfTimeSeriesData + sizeOfTimeSeriesData*360),
+				BudgetBytes:             18 * (sizeOfTimeSeriesData + sizeOfSample*360),
 				EstimatedSources:        6,
 				InterpolationLimitNanos: int64(float64(Resolution10s.SlabDuration()) * 0.75),
 			},
@@ -125,7 +125,7 @@ func TestGetMaxTimespan(t *testing.T) {
 		{
 			Resolution10s,
 			QueryMemoryOptions{
-				BudgetBytes:             24 * (sizeOfTimeSeriesData + sizeOfTimeSeriesData*360),
+				BudgetBytes:             24 * (sizeOfTimeSeriesData + sizeOfSample*360),
 				EstimatedSources:        6,
 				InterpolationLimitNanos: int64(float64(Resolution10s.SlabDuration()) * 0.75),
 			},
@@ -136,7 +136,7 @@ func TestGetMaxTimespan(t *testing.T) {
 		{
 			resolution1ns,
 			QueryMemoryOptions{
-				BudgetBytes:             3 * (sizeOfTimeSeriesData + sizeOfTimeSeriesData*10),
+				BudgetBytes:             3 * (sizeOfTimeSeriesData + sizeOfSample*10),
 				EstimatedSources:        1,
 				InterpolationLimitNanos: 1,
 			},


### PR DESCRIPTION
The first commit is #25587 and can be ignored for this PR.


Implement a new *columnar* on-disk format for time series samples,
replacing the previous row-like format.

Previously, each slab of time series data contained a collection of
"samples", where each sample was a message containing a number of
fields; the timestamp (offset), and a number of value fields intended to
contain "rolled-up" data for long-term, low resolution storage.

The new format is columnar; the top-level slab contains multiple
parallel arrays, with each array containing the ordered values for the
individual samples.

This gives us the following advantages:

This has a columnar layout, made up of parallel arrays. This gives us
all of the advantages we were missing in the previous layout:

+ High-resolution data can leave the aggregate fields completely empty;
only the "last" aggregate fields. This will reduce the in-memory size of
each sample from the full Sample structure down to a int32 and a
float64. This also means we can add several more aggregates without
inflating the size of each sample.
+ The columnar format takes advantage of protobuffer repeated field
packing, which should save considerable space for the encoded on-disk
format.
+ When querying, we can iterate directly over the data fields we need,
which may improve data locality (and thus cache-miss performance) or
allow us to more aggressively release memory for data that is not
needed.

This commit does the following:

+ Define new columnar fields in roachpb/internal.proto.
+ Write new C++ merge logic for the columnar fields. This does not
replace the existing row logic; it lives alongside it.
+ Create an upgrade path in the merge logic for row-formatted slabs;
this occurs whenever columnar data is merged into an existing key with
row-formatted data. This ensures than any individual slab of data will
contain only row-formatted samples or column-formatted samples, but
never both.

Release note: none.