### PR TITLE
sql: Split aggregate logic test so that it can be reused

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -837,7 +837,7 @@ testlogic: pkg/sql/logictest/logictest.test
 testccllogic: ## Run SQL CCL Logic Tests.
 testccllogic: pkg/ccl/logictestccl/logictestccl.test
 
-testlogic testccllogic: TESTS := Test(CCL)?Logic//$(if $(FILES),^$(subst $(space),$$|^,$(FILES))$$)/$(SUBTESTS)
+testlogic testccllogic: TESTS := Test\w*Logic//$(if $(FILES),^$(subst $(space),$$|^,$(FILES))$$)/$(SUBTESTS)
 testlogic testccllogic: TESTFLAGS := -test.v $(if $(FILES),-show-sql)
 testlogic testccllogic:
 	cd $(<D) && ./$(<F) -test.run "$(TESTS)" -test.timeout $(TESTTIMEOUT) $(TESTFLAGS)

--- a/pkg/sql/logictest/logic.go
+++ b/pkg/sql/logictest/logic.go
@@ -394,7 +394,7 @@ var logicTestConfigs = []testClusterConfig{
 		serverVersion:  &roachpb.Version{Major: 1, Minor: 1},
 		disableUpgrade: 1,
 	},
-	{name: "opt", numNodes: 1, overrideOptimizerMode: "On"},
+	{name: "opt", numNodes: 1, overrideDistSQLMode: "Off", overrideOptimizerMode: "On"},
 	{name: "parallel-stmts", numNodes: 1, parallelStmts: true, overrideDistSQLMode: "Off"},
 	{name: "distsql", numNodes: 3, useFakeSpanResolver: true, overrideDistSQLMode: "On"},
 	{name: "distsql-opt", numNodes: 3, useFakeSpanResolver: true, overrideDistSQLMode: "On", overrideOptimizerMode: "On"},

--- a/pkg/sql/logictest/logic_test.go
+++ b/pkg/sql/logictest/logic_test.go
@@ -25,12 +25,27 @@ import (
 
 // TestLogic runs logic tests that were written by hand to test various
 // CockroachDB features. The tests use a similar methodology to the SQLLite
-// Sqllogictests.
+// Sqllogictests. All of these tests should only verify correctness of output,
+// and not how that output was derived. Therefore, these tests can be run
+// using the heuristic planner, the cost-based optimizer, or even run against
+// Postgres to verify it returns the same logical results.
 //
 // See the comments in logic.go for more details.
 func TestLogic(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	RunLogicTest(t, "testdata/logic_test/[^.]*")
+}
+
+// TestPlannerLogic tests the heuristic planner by running EXPLAIN and SHOW
+// TRACE queries that show the plan that was produced. These tests are split
+// off from the TestLogic tests because the expected output is specific to how
+// the planner works. The cost-based optimizer will often return different
+// results for the same EXPLAIN statement, as it often chooses different ways
+// to execute the same logical query. Note that the cost-based optimizer tests
+// are housed in the various sql/opt packages.
+func TestPlannerLogic(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	RunLogicTest(t, "testdata/planner_test/[^.]*")
 }
 
 // TestSqlLiteLogic runs all logic tests from CockroachDB's fork of

--- a/pkg/sql/logictest/testdata/logic_test/aggregate
+++ b/pkg/sql/logictest/testdata/logic_test/aggregate
@@ -1,4 +1,4 @@
-# LogicTest: default parallel-stmts distsql distsql-metadata
+# LogicTest: default opt parallel-stmts distsql distsql-metadata
 
 statement ok
 CREATE TABLE kv (
@@ -325,19 +325,6 @@ query error column "s" must appear in the GROUP BY clause or be used in an aggre
 SELECT COUNT(*), s FROM kv GROUP BY UPPER(s)
 
 # Selecting and grouping on a more complex expression works.
-query TTTTT
-EXPLAIN (VERBOSE) SELECT COUNT(*), k+v FROM kv GROUP BY k+v
-----
-group           ·            ·                                    (count, "k + v")                weak-key("k + v")
- │              aggregate 0  count_rows()                         ·                               ·
- │              aggregate 1  k + v                                ·                               ·
- │              group by     @1                                   ·                               ·
- └── render     ·            ·                                    ("k + v")                       ·
-      │         render 0     test.public.kv.k + test.public.kv.v  ·                               ·
-      └── scan  ·            ·                                    (k, v, w[omitted], s[omitted])  k!=NULL; key(k)
-·               table        kv@primary                           ·                               ·
-·               spans        ALL                                  ·                               ·
-
 query II rowsort
 SELECT COUNT(*), k+v FROM kv GROUP BY k+v
 ----
@@ -350,24 +337,6 @@ SELECT COUNT(*), k+v FROM kv GROUP BY k+v
 
 
 # Selecting a more complex expression, made up of things which are each grouped, works.
-query TTTTT
-EXPLAIN (VERBOSE) SELECT COUNT(*), k+v FROM kv GROUP BY k, v
-----
-render               ·            ·                 (count, "k + v")                ·
- │                   render 0     agg0              ·                               ·
- │                   render 1     agg1 + agg2       ·                               ·
- └── group           ·            ·                 (agg0, agg1, agg2)              agg1!=NULL; key(agg1)
-      │              aggregate 0  count_rows()      ·                               ·
-      │              aggregate 1  k                 ·                               ·
-      │              aggregate 2  v                 ·                               ·
-      │              group by     @1-@2             ·                               ·
-      └── render     ·            ·                 (k, v)                          k!=NULL; key(k); +k
-           │         render 0     test.public.kv.k  ·                               ·
-           │         render 1     test.public.kv.v  ·                               ·
-           └── scan  ·            ·                 (k, v, w[omitted], s[omitted])  k!=NULL; key(k); +k
-·                    table        kv@primary        ·                               ·
-·                    spans        ALL               ·                               ·
-
 query II rowsort
 SELECT COUNT(*), k+v FROM kv GROUP BY k, v
 ----
@@ -618,34 +587,6 @@ SELECT AVG(k) * 2.0 + MAX(v)::DECIMAL FROM kv WHERE w*2 = k
 ----
 14.0
 
-query TTT
-SELECT "Tree", "Field", "Description" FROM [
-EXPLAIN (VERBOSE) SELECT COUNT(k) FROM kv
-]
-----
-group           ·            ·
- │              aggregate 0  count(k)
- └── render     ·            ·
-      │         render 0     test.public.kv.k
-      └── scan  ·            ·
-·               table        kv@primary
-·               spans        ALL
-
-query TTT
-SELECT "Tree", "Field", "Description" FROM [
-EXPLAIN (VERBOSE) SELECT COUNT(k), SUM(k), MAX(k) FROM kv
-]
-----
-group           ·            ·
- │              aggregate 0  count(k)
- │              aggregate 1  sum(k)
- │              aggregate 2  max(k)
- └── render     ·            ·
-      │         render 0     test.public.kv.k
-      └── scan  ·            ·
-·               table        kv@primary
-·               spans        ALL
-
 statement ok
 CREATE TABLE abc (
   a CHAR PRIMARY KEY,
@@ -656,20 +597,6 @@ CREATE TABLE abc (
 
 statement ok
 INSERT INTO abc VALUES ('one', 1.5, true, 5::decimal), ('two', 2.0, false, 1.1::decimal)
-
-query TTT
-SELECT "Tree", "Field", "Description" FROM [
-EXPLAIN (VERBOSE) SELECT MIN(a) FROM abc
-]
-----
-group           ·            ·
- │              aggregate 0  min(a)
- └── render     ·            ·
-      │         render 0     test.public.abc.a
-      └── scan  ·            ·
-·               table        abc@primary
-·               spans        ALL
-·               limit        1
 
 query TRBR
 SELECT MIN(a), MIN(b), MIN(c), MIN(d) FROM abc
@@ -739,178 +666,45 @@ SELECT MIN(x) FROM xyz
 ----
 1
 
-query TTT
-SELECT "Tree", "Field", "Description" FROM [
-EXPLAIN (VERBOSE) SELECT MIN(x) FROM xyz
-]
-----
-group           ·            ·
- │              aggregate 0  min(x)
- └── render     ·            ·
-      │         render 0     test.public.xyz.x
-      └── scan  ·            ·
-·               table        xyz@xy
-·               spans        ALL
-·               limit        1
-
 query I
 SELECT MIN(x) FROM xyz WHERE x in (0, 4, 7)
 ----
 4
-
-query TTT
-SELECT "Tree", "Field", "Description" FROM [
-EXPLAIN (VERBOSE) SELECT MIN(x) FROM xyz WHERE x in (0, 4, 7)
-]
-----
-group           ·            ·
- │              aggregate 0  min(x)
- └── render     ·            ·
-      │         render 0     test.public.xyz.x
-      └── scan  ·            ·
-·               table        xyz@xy
-·               spans        /0-/1 /4-/5 /7-/8
-·               limit        1
 
 query I
 SELECT MAX(x) FROM xyz
 ----
 7
 
-query TTT
-SELECT "Tree", "Field", "Description" FROM [
-EXPLAIN (VERBOSE) SELECT MAX(x) FROM xyz
-]
-----
-group              ·            ·
- │                 aggregate 0  max(x)
- └── render        ·            ·
-      │            render 0     test.public.xyz.x
-      └── revscan  ·            ·
-·                  table        xyz@xy
-·                  spans        ALL
-·                  limit        1
-
 query I
 SELECT MIN(y) FROM xyz WHERE x = 1
 ----
 2
-
-query TTT
-SELECT "Tree", "Field", "Description" FROM [
-EXPLAIN (VERBOSE) SELECT MIN(y) FROM xyz WHERE x = 1
-]
-----
-group           ·            ·
- │              aggregate 0  min(y)
- └── render     ·            ·
-      │         render 0     test.public.xyz.y
-      └── scan  ·            ·
-·               table        xyz@xy
-·               spans        /1/!NULL-/2
-·               limit        1
 
 query I
 SELECT MAX(y) FROM xyz WHERE x = 1
 ----
 2
 
-query TTT
-SELECT "Tree", "Field", "Description" FROM [
-EXPLAIN (VERBOSE) SELECT MAX(y) FROM xyz WHERE x = 1
-]
-----
-group              ·            ·
- │                 aggregate 0  max(y)
- └── render        ·            ·
-      │            render 0     test.public.xyz.y
-      └── revscan  ·            ·
-·                  table        xyz@xy
-·                  spans        /1/!NULL-/2
-·                  limit        1
-
 query I
 SELECT MIN(y) FROM xyz WHERE x = 7
 ----
 NULL
-
-query TTT
-SELECT "Tree", "Field", "Description" FROM [
-EXPLAIN (VERBOSE) SELECT MIN(y) FROM xyz WHERE x = 7
-]
-----
-group           ·            ·
- │              aggregate 0  min(y)
- └── render     ·            ·
-      │         render 0     test.public.xyz.y
-      └── scan  ·            ·
-·               table        xyz@xy
-·               spans        /7/!NULL-/8
-·               limit        1
 
 query I
 SELECT MAX(y) FROM xyz WHERE x = 7
 ----
 NULL
 
-query TTT
-SELECT "Tree", "Field", "Description" FROM [
-EXPLAIN (VERBOSE) SELECT MAX(y) FROM xyz WHERE x = 7
-]
-----
-group              ·            ·
- │                 aggregate 0  max(y)
- └── render        ·            ·
-      │            render 0     test.public.xyz.y
-      └── revscan  ·            ·
-·                  table        xyz@xy
-·                  spans        /7/!NULL-/8
-·                  limit        1
-
 query I
 SELECT MIN(x) FROM xyz WHERE (y, z) = (2, 3.0)
 ----
 1
 
-query TTT
-SELECT "Tree", "Field", "Description" FROM [
-EXPLAIN (VERBOSE) SELECT MIN(x) FROM xyz WHERE (y, z) = (2, 3.0)
-]
-----
-group           ·            ·
- │              aggregate 0  min(x)
- └── render     ·            ·
-      │         render 0     test.public.xyz.x
-      └── scan  ·            ·
-·               table        xyz@zyx
-·               spans        /3/2-/3/3
-·               limit        1
-
-query T
-SELECT message FROM [SHOW KV TRACE FOR SELECT MIN(x) FROM xyz WHERE (y, z) = (2, 3.0)]
- WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
-----
-fetched: /xyz/zyx/3.0/2/1 -> NULL
-output row: [1]
-
 query I
 SELECT MAX(x) FROM xyz WHERE (z, y) = (3.0, 2)
 ----
 1
-
-query TTT
-SELECT "Tree", "Field", "Description" FROM [
-EXPLAIN (VERBOSE) SELECT MAX(x) FROM xyz WHERE (z, y) = (3.0, 2)
-]
-----
-group              ·            ·
- │                 aggregate 0  max(x)
- └── render        ·            ·
-      │            render 0     test.public.xyz.x
-      └── revscan  ·            ·
-·                  table        xyz@zyx
-·                  spans        /3/2-/3/3
-·                  limit        1
 
 # VARIANCE/STDDEV
 
@@ -918,20 +712,6 @@ query RRR
 SELECT VARIANCE(x), VARIANCE(y::decimal), round(VARIANCE(z), 14) FROM xyz
 ----
 9 4.5 6.33333333333333
-
-query T
-SELECT message FROM [SHOW KV TRACE FOR SELECT VARIANCE(x), VARIANCE(y::decimal), round(VARIANCE(z), 14) FROM xyz]
- WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
-----
-fetched: /xyz/primary/1 -> NULL
-fetched: /xyz/primary/1/y -> 2
-fetched: /xyz/primary/1/z -> 3.0
-fetched: /xyz/primary/4 -> NULL
-fetched: /xyz/primary/4/y -> 5
-fetched: /xyz/primary/4/z -> 6.0
-fetched: /xyz/primary/7 -> NULL
-fetched: /xyz/primary/7/z -> 8.0
-output row: [9 4.5 6.33333333333333]
 
 query R
 SELECT VARIANCE(x) FROM xyz WHERE x = 10
@@ -942,19 +722,6 @@ query R
 SELECT VARIANCE(x) FROM xyz WHERE x = 1
 ----
 NULL
-
-query TTT
-SELECT "Tree", "Field", "Description" FROM [
-EXPLAIN (VERBOSE) SELECT VARIANCE(x) FROM xyz WHERE x = 1
-]
-----
-group           ·            ·
- │              aggregate 0  variance(x)
- └── render     ·            ·
-      │         render 0     test.public.xyz.x
-      └── scan  ·            ·
-·               table        xyz@xy
-·               spans        /1-/2
 
 query RRR
 SELECT STDDEV(x), STDDEV(y::decimal), round(STDDEV(z), 14) FROM xyz
@@ -996,14 +763,6 @@ query RRR
 SELECT round(STDDEV(n), 2), round(STDDEV(n), 2), round(STDDEV(p)) FROM mnop
 ----
 0.29 0.29 3
-
-# Verify we only look at one row for MIN when we have an index on that column.
-query T
-SELECT message FROM [SHOW KV TRACE FOR SELECT MIN(z) FROM xyz]
- WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
-----
-fetched: /xyz/zyx/3.0/2/1 -> NULL
-output row: [3.0]
 
 query RRR
 SELECT AVG(1::int)::float, AVG(2::float)::float, AVG(3::decimal)::float
@@ -1083,140 +842,6 @@ SELECT JSONB_AGG(s) FROM (SELECT s FROM kv ORDER BY k)
 ----
 ["a", "a", null, "b", "b", "A"]
 
-# Tests for the single-row optimization.
-statement OK
-CREATE TABLE ab (
-  a INT PRIMARY KEY,
-  b INT,
-  FAMILY (a),
-  FAMILY (b)
-)
-
-statement OK
-INSERT INTO ab VALUES
-  (1, 10),
-  (2, 20),
-  (3, 30),
-  (4, 40),
-  (5, 50)
-
-query TTT
-SELECT "Tree", "Field", "Description" FROM [
-EXPLAIN (VERBOSE) SELECT MIN(a) FROM abc
-]
-----
-group           ·            ·
- │              aggregate 0  min(a)
- └── render     ·            ·
-      │         render 0     test.public.abc.a
-      └── scan  ·            ·
-·               table        abc@primary
-·               spans        ALL
-·               limit        1
-
-# Verify we only buffer one row.
-query T
-SELECT message FROM [SHOW KV TRACE FOR SELECT MIN(a) FROM ab]
- WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
-----
-fetched: /ab/primary/1 -> NULL
-fetched: /ab/primary/1/b -> 10
-output row: [1]
-
-query TTT
-SELECT "Tree", "Field", "Description" FROM [
-EXPLAIN (VERBOSE) SELECT MAX(a) FROM abc
-]
-----
-group              ·            ·
- │                 aggregate 0  max(a)
- └── render        ·            ·
-      │            render 0     test.public.abc.a
-      └── revscan  ·            ·
-·                  table        abc@primary
-·                  spans        ALL
-·                  limit        1
-
-# Verify we only buffer one row.
-query T
-SELECT message FROM [SHOW KV TRACE FOR SELECT MAX(a) FROM ab]
- WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
-----
-fetched: /ab/primary/5/b -> 50
-fetched: /ab/primary/5 -> NULL
-output row: [5]
-
-query TTT
-SELECT "Tree", "Field", "Description" FROM [
-EXPLAIN (VERBOSE) SELECT v, COUNT(k) FROM kv GROUP BY v ORDER BY COUNT(k)
-]
-----
-sort                 ·            ·
- │                   order        +count
- └── group           ·            ·
-      │              aggregate 0  v
-      │              aggregate 1  count(k)
-      │              group by     @1
-      └── render     ·            ·
-           │         render 0     test.public.kv.v
-           │         render 1     test.public.kv.k
-           └── scan  ·            ·
-·                    table        kv@primary
-·                    spans        ALL
-
-query TTT
-SELECT "Tree", "Field", "Description" FROM [
-EXPLAIN (VERBOSE) SELECT v, COUNT(*) FROM kv GROUP BY v ORDER BY COUNT(*)
-]
-----
-sort                 ·            ·
- │                   order        +count
- └── group           ·            ·
-      │              aggregate 0  v
-      │              aggregate 1  count_rows()
-      │              group by     @1
-      └── render     ·            ·
-           │         render 0     test.public.kv.v
-           └── scan  ·            ·
-·                    table        kv@primary
-·                    spans        ALL
-
-query TTT
-SELECT "Tree", "Field", "Description" FROM [
-EXPLAIN (VERBOSE) SELECT v, COUNT(1) FROM kv GROUP BY v ORDER BY COUNT(1)
-]
-----
-sort                 ·            ·
- │                   order        +count
- └── group           ·            ·
-      │              aggregate 0  v
-      │              aggregate 1  count(1)
-      │              group by     @1
-      └── render     ·            ·
-           │         render 0     test.public.kv.v
-           │         render 1     1
-           └── scan  ·            ·
-·                    table        kv@primary
-·                    spans        ALL
-
-# Check that filters propagate through no-op aggregation.
-query TTT
-SELECT "Tree", "Field", "Description" FROM [
-EXPLAIN (VERBOSE) SELECT * FROM (SELECT v, COUNT(1) FROM kv GROUP BY v) WHERE v > 10
-]
-----
-group           ·            ·
- │              aggregate 0  v
- │              aggregate 1  count(1)
- │              group by     @1
- └── render     ·            ·
-      │         render 0     test.public.kv.v
-      │         render 1     1
-      └── scan  ·            ·
-·               table        kv@primary
-·               spans        ALL
-·               filter       v > 10
-
 # Verify that FILTER works.
 
 statement ok
@@ -1262,50 +887,7 @@ SELECT k FILTER (WHERE k=1) FROM kv GROUP BY k
 query error aggregate functions are not allowed in FILTER
 SELECT v, COUNT(*) FILTER (WHERE COUNT(*) > 5) FROM filter_test GROUP BY v
 
-# Check that filter expressions are only rendered once.
-query TTT
-SELECT "Tree", "Field", "Description" FROM [
-EXPLAIN (VERBOSE) SELECT COUNT(*) FILTER (WHERE k>5), MAX(k>5) FILTER(WHERE k>5) FROM filter_test GROUP BY v
-]
-----
-group           ·            ·
- │              aggregate 0  count_rows() FILTER (WHERE k > 5)
- │              aggregate 1  max(k > 5) FILTER (WHERE k > 5)
- │              group by     @1
- └── render     ·            ·
-      │         render 0     test.public.filter_test.v
-      │         render 1     test.public.filter_test.k > 5
-      └── scan  ·            ·
-·               table        filter_test@primary
-·               spans        ALL
-
-query TTTTT
-EXPLAIN (TYPES) SELECT COUNT(*) FILTER (WHERE k > 5) FROM filter_test GROUP BY v
-----
-group           ·            ·                                  (count int)                                                    ·
- │              aggregate 0  count_rows() FILTER (WHERE k > 5)  ·                                                              ·
- │              group by     @1                                 ·                                                              ·
- └── render     ·            ·                                  (v int, "k > 5" bool)                                          ·
-      │         render 0     (v)[int]                           ·                                                              ·
-      │         render 1     ((k)[int] > (5)[int])[bool]        ·                                                              ·
-      └── scan  ·            ·                                  (k int, v int, mark[omitted] bool, rowid[hidden,omitted] int)  rowid!=NULL; key(rowid)
-·               table        filter_test@primary                ·                                                              ·
-·               spans        ALL                                ·                                                              ·
-
 # Tests with * inside GROUP BY.
-query TTT
-SELECT "Tree", "Field", "Description" FROM [
-EXPLAIN (VERBOSE) SELECT 1 FROM kv GROUP BY kv.*
-]
-----
-render          ·         ·
- │              render 0  1
- └── group      ·         ·
-      │         group by  @1-@4
-      └── scan  ·         ·
-·               table     kv@primary
-·               spans     ALL
-
 query I
 SELECT 1 FROM kv GROUP BY kv.*
 ----
@@ -1315,30 +897,6 @@ SELECT 1 FROM kv GROUP BY kv.*
 1
 1
 1
-
-query TTT
-SELECT "Tree", "Field", "Description" FROM [
-EXPLAIN (VERBOSE) SELECT SUM(abc.d) FROM kv JOIN abc ON kv.k >= abc.d GROUP BY kv.*
-]
-----
-group                ·            ·
- │                   aggregate 0  sum(d)
- │                   group by     @1-@4
- └── render          ·            ·
-      │              render 0     test.public.kv.k
-      │              render 1     test.public.kv.v
-      │              render 2     test.public.kv.w
-      │              render 3     test.public.kv.s
-      │              render 4     test.public.abc.d
-      └── join       ·            ·
-           │         type         inner
-           │         pred         test.public.kv.k >= test.public.abc.d
-           ├── scan  ·            ·
-           │         table        kv@primary
-           │         spans        ALL
-           └── scan  ·            ·
-·                    table        abc@primary
-·                    spans        ALL
 
 query R rowsort
 SELECT SUM(abc.d) FROM kv JOIN abc ON kv.k >= abc.d GROUP BY kv.*
@@ -1357,18 +915,6 @@ statement ok
 INSERT INTO opt_test VALUES (1, NULL), (2, 10), (3, NULL), (4, 5)
 
 # Verify that we correctly add the v IS NOT NULL constraint (which restricts the span).
-query TTTTT
-EXPLAIN (VERBOSE) SELECT MIN(v) FROM opt_test
-----
-group           ·            ·                       (min)            ·
- │              aggregate 0  min(v)                  ·                ·
- └── render     ·            ·                       (v)              v!=NULL; +v
-      │         render 0     test.public.opt_test.v  ·                ·
-      └── scan  ·            ·                       (k[omitted], v)  k!=NULL; v!=NULL; key(k,v); +v
-·               table        opt_test@v              ·                ·
-·               spans        /!NULL-                 ·                ·
-·               limit        1                       ·                ·
-
 # Without the "v IS NOT NULL" constraint, this result would incorrectly be NULL.
 query I
 SELECT MIN(v) FROM opt_test
@@ -1382,49 +928,12 @@ SELECT MIN(v) FROM opt_test@primary
 5
 
 # Repeat test when there is an existing filter.
-query TTTTT
-EXPLAIN (VERBOSE) SELECT MIN(v) FROM opt_test WHERE k <> 4
-----
-group           ·            ·                       (min)   ·
- │              aggregate 0  min(v)                  ·       ·
- └── render     ·            ·                       (v)     v!=NULL; +v
-      │         render 0     test.public.opt_test.v  ·       ·
-      └── scan  ·            ·                       (k, v)  k!=NULL; v!=NULL; key(k,v); +v
-·               table        opt_test@v              ·       ·
-·               spans        /!NULL-                 ·       ·
-·               filter       k != 4                  ·       ·
-
 query I
 SELECT MIN(v) FROM opt_test WHERE k <> 4
 ----
 10
 
-# Check the optimization when the argument is non-trivial. The renderNode can't
-# present an ordering on v+1 so the optimization is not applied, but the IS NOT
-# NULL filter should be added.
-query TTTTT
-EXPLAIN (VERBOSE) SELECT MIN(v+1) FROM opt_test WHERE k <> 4
-----
-group           ·            ·                           (min)            ·
- │              aggregate 0  min(v + 1)                  ·                ·
- └── render     ·            ·                           ("v + 1")        ·
-      │         render 0     test.public.opt_test.v + 1  ·                ·
-      └── scan  ·            ·                           (k[omitted], v)  k!=NULL; v!=NULL; key(k)
-·               table        opt_test@primary            ·                ·
-·               spans        -/3/# /5-                   ·                ·
-·               filter       (v + 1) IS NOT NULL         ·                ·
-
 # Verify that we don't use the optimization if there is a GROUP BY.
-query TTTTT
-EXPLAIN (VERBOSE) SELECT MIN(v) FROM opt_test GROUP BY k
-----
-group      ·            ·                 (min)   ·
- │         aggregate 0  min(v)            ·       ·
- │         group by     @1                ·       ·
- └── scan  ·            ·                 (k, v)  k!=NULL; key(k)
-·          table        opt_test@primary  ·       ·
-·          spans        ALL               ·       ·
-
 query I rowsort
 SELECT MIN(v) FROM opt_test GROUP BY k
 ----
@@ -1472,8 +981,17 @@ SELECT MAX(true), MIN(true)
 true
 true
 
+# Grouping and rendering tuples.
+statement OK
+CREATE TABLE ab (
+  a INT PRIMARY KEY,
+  b INT,
+  FAMILY (a),
+  FAMILY (b)
+)
+
 statement ok
-DELETE FROM ab; INSERT INTO ab(a,b) VALUES (1,2), (3,4);
+INSERT INTO ab(a,b) VALUES (1,2), (3,4);
   CREATE TABLE xy(x STRING, y STRING);
   INSERT INTO xy(x, y) VALUES ('a', 'b'), ('c', 'd')
 
@@ -1484,24 +1002,6 @@ SELECT (b, a) FROM ab GROUP BY (b, a)
 (2,1)
 (4,3)
 
-query TTT
-SELECT "Tree", "Field", "Description" FROM [
-EXPLAIN (VERBOSE) SELECT (b, a) FROM ab GROUP BY (b, a)
-]
-----
-render               ·            ·
- │                   render 0     (agg0, agg1)
- └── group           ·            ·
-      │              aggregate 0  b
-      │              aggregate 1  a
-      │              group by     @1-@2
-      └── render     ·            ·
-           │         render 0     test.public.ab.b
-           │         render 1     test.public.ab.a
-           └── scan  ·            ·
-·                    table        ab@primary
-·                    spans        ALL
-
 query TT rowsort
 SELECT MIN(y), (b, a)
  FROM ab, xy GROUP BY (x, (a, b))
@@ -1510,35 +1010,6 @@ b  (2,1)
 d  (2,1)
 b  (4,3)
 d  (4,3)
-
-query TTT
-SELECT "Tree", "Field", "Description" FROM [
-EXPLAIN (VERBOSE)
-   SELECT MIN(y), (b, a)
-     FROM ab, xy GROUP BY (x, (a, b))
-]
-----
-render                    ·            ·
- │                        render 0     agg0
- │                        render 1     (agg1, agg2)
- └── group                ·            ·
-      │                   aggregate 0  min(y)
-      │                   aggregate 1  b
-      │                   aggregate 2  a
-      │                   group by     @1-@3
-      └── render          ·            ·
-           │              render 0     test.public.xy.x
-           │              render 1     test.public.ab.a
-           │              render 2     test.public.ab.b
-           │              render 3     test.public.xy.y
-           └── join       ·            ·
-                │         type         cross
-                ├── scan  ·            ·
-                │         table        ab@primary
-                │         spans        ALL
-                └── scan  ·            ·
-·                         table        xy@primary
-·                         spans        ALL
 
 # Test that ordering on GROUP BY columns is maintained.
 statement ok
@@ -1570,20 +1041,6 @@ SELECT x, max(y) FROM group_ord GROUP BY x
 7  2
 8  4
 
-query TTTTT
-EXPLAIN (VERBOSE) SELECT x, max(y) FROM group_ord GROUP BY x
-----
-group           ·            ·                        (x, max)            x!=NULL; key(x)
- │              aggregate 0  x                        ·                   ·
- │              aggregate 1  max(y)                   ·                   ·
- │              group by     @1                       ·                   ·
- └── render     ·            ·                        (x, y)              x!=NULL; key(x); +x
-      │         render 0     test.public.group_ord.x  ·                   ·
-      │         render 1     test.public.group_ord.y  ·                   ·
-      └── scan  ·            ·                        (x, y, z[omitted])  x!=NULL; key(x); +x
-·               table        group_ord@primary        ·                   ·
-·               spans        ALL                      ·                   ·
-
 # The ordering is on all the GROUP BY columns, and is preserved after the
 # aggregation.
 query II
@@ -1595,20 +1052,6 @@ SELECT x, max(y) FROM group_ord GROUP BY x ORDER BY x
 6  2
 7  2
 8  4
-
-query TTTTT
-EXPLAIN (VERBOSE) SELECT x, max(y) FROM group_ord GROUP BY x ORDER BY x
-----
-group           ·            ·                        (x, max)            x!=NULL; key(x); +x
- │              aggregate 0  x                        ·                   ·
- │              aggregate 1  max(y)                   ·                   ·
- │              group by     @1                       ·                   ·
- └── render     ·            ·                        (x, y)              x!=NULL; key(x); +x
-      │         render 0     test.public.group_ord.x  ·                   ·
-      │         render 1     test.public.group_ord.y  ·                   ·
-      └── scan  ·            ·                        (x, y, z[omitted])  x!=NULL; key(x); +x
-·               table        group_ord@primary        ·                   ·
-·               spans        ALL                      ·                   ·
 
 # The ordering is on some of the GROUP BY columns, and isn't preserved after
 # the aggregation.
@@ -1622,22 +1065,6 @@ SELECT z, x, max(y) FROM group_ord GROUP BY x, z
 2  7  2
 2  8  4
 
-query TTTTT
-EXPLAIN (VERBOSE) SELECT z, x, max(y) FROM group_ord GROUP BY x, z
-----
-group           ·            ·                        (z, x, max)  x!=NULL; key(x)
- │              aggregate 0  z                        ·            ·
- │              aggregate 1  x                        ·            ·
- │              aggregate 2  max(y)                   ·            ·
- │              group by     @1-@2                    ·            ·
- └── render     ·            ·                        (x, z, y)    x!=NULL; key(x); +x
-      │         render 0     test.public.group_ord.x  ·            ·
-      │         render 1     test.public.group_ord.z  ·            ·
-      │         render 2     test.public.group_ord.y  ·            ·
-      └── scan  ·            ·                        (x, y, z)    x!=NULL; key(x); +x
-·               table        group_ord@primary        ·            ·
-·               spans        ALL                      ·            ·
-
 # The ordering is on some of the GROUP BY columns, and is preserved after
 # the aggregation.
 query III
@@ -1650,22 +1077,6 @@ SELECT z, x, max(y) FROM group_ord GROUP BY x, z ORDER BY x
 2  7  2
 2  8  4
 
-query TTTTT
-EXPLAIN (VERBOSE) SELECT z, x, max(y) FROM group_ord GROUP BY x, z ORDER BY x
-----
-group           ·            ·                        (z, x, max)  x!=NULL; key(x); +x
- │              aggregate 0  z                        ·            ·
- │              aggregate 1  x                        ·            ·
- │              aggregate 2  max(y)                   ·            ·
- │              group by     @1-@2                    ·            ·
- └── render     ·            ·                        (x, z, y)    x!=NULL; key(x); +x
-      │         render 0     test.public.group_ord.x  ·            ·
-      │         render 1     test.public.group_ord.z  ·            ·
-      │         render 2     test.public.group_ord.y  ·            ·
-      └── scan  ·            ·                        (x, y, z)    x!=NULL; key(x); +x
-·               table        group_ord@primary        ·            ·
-·               spans        ALL                      ·            ·
-
 # If the underlying ordering isn't from the primary index, it needs to be hinted
 # for now.
 query II rowsort
@@ -1674,23 +1085,6 @@ SELECT z, max(y) FROM group_ord@foo GROUP BY z
 5  4
 2  4
 3  2
-
-query TTTTT
-EXPLAIN (VERBOSE) SELECT z, max(y) FROM group_ord@foo GROUP BY z
-----
-group                 ·            ·                        (z, max)                     weak-key(z)
- │                    aggregate 0  z                        ·                            ·
- │                    aggregate 1  max(y)                   ·                            ·
- │                    group by     @1                       ·                            ·
- └── render           ·            ·                        (z, y)                       +z
-      │               render 0     test.public.group_ord.z  ·                            ·
-      │               render 1     test.public.group_ord.y  ·                            ·
-      └── index-join  ·            ·                        (x[omitted], y, z)           x!=NULL; weak-key(x,z); +z
-           ├── scan   ·            ·                        (x, y[omitted], z[omitted])  x!=NULL; weak-key(x,z); +z
-           │          table        group_ord@foo            ·                            ·
-           │          spans        ALL                      ·                            ·
-           └── scan   ·            ·                        (x[omitted], y, z)           ·
-·                     table        group_ord@primary        ·                            ·
 
 # Test that a merge join is used on two aggregate subqueries with orderings on
 # the GROUP BY columns. Note that an ORDER BY is not necessary on the
@@ -1701,59 +1095,11 @@ SELECT * FROM (SELECT x, max(y) FROM group_ord GROUP BY x) JOIN (SELECT z, min(y
 5  NULL  5  4
 3  4     3  2
 
-query TTTTT
-EXPLAIN (VERBOSE) SELECT * FROM (SELECT x, max(y) FROM group_ord GROUP BY x) JOIN (SELECT z, min(y) FROM group_ord@foo GROUP BY z) ON x = z
-----
-join                       ·               ·                        (x, max, z, min)             x=z; x!=NULL
- │                         type            inner                    ·                            ·
- │                         equality        (x) = (z)                ·                            ·
- │                         mergeJoinOrder  +"(x=z)"                 ·                            ·
- ├── group                 ·               ·                        (x, max)                     x!=NULL; key(x); +x
- │    │                    aggregate 0     x                        ·                            ·
- │    │                    aggregate 1     max(y)                   ·                            ·
- │    │                    group by        @1                       ·                            ·
- │    └── render           ·               ·                        (x, y)                       x!=NULL; key(x); +x
- │         │               render 0        test.public.group_ord.x  ·                            ·
- │         │               render 1        test.public.group_ord.y  ·                            ·
- │         └── scan        ·               ·                        (x, y, z[omitted])           x!=NULL; key(x); +x
- │                         table           group_ord@primary        ·                            ·
- │                         spans           ALL                      ·                            ·
- └── group                 ·               ·                        (z, min)                     weak-key(z); +z
-      │                    aggregate 0     z                        ·                            ·
-      │                    aggregate 1     min(y)                   ·                            ·
-      │                    group by        @1                       ·                            ·
-      └── render           ·               ·                        (z, y)                       +z
-           │               render 0        test.public.group_ord.z  ·                            ·
-           │               render 1        test.public.group_ord.y  ·                            ·
-           └── index-join  ·               ·                        (x[omitted], y, z)           x!=NULL; weak-key(x,z); +z
-                ├── scan   ·               ·                        (x, y[omitted], z[omitted])  x!=NULL; weak-key(x,z); +z
-                │          table           group_ord@foo            ·                            ·
-                │          spans           ALL                      ·                            ·
-                └── scan   ·               ·                        (x[omitted], y, z)           ·
-·                          table           group_ord@primary        ·                            ·
-
 # Regression test for #23798 until #10495 is fixed.
 statement error function reserved for internal use
 SELECT final_variance(1.2, 1.2, 123) FROM kv
 
 # Regression test for #25533 (crash when propagating filter through GROUP BY).
-query TTTTT
-EXPLAIN (VERBOSE) SELECT 1 FROM kv GROUP BY v, w::DECIMAL HAVING w::DECIMAL > 1;
-----
-render                    ·            ·                          ("1")                           "1"=CONST           
- │                        render 0     1                          ·                               ·                   
- └── group                ·            ·                          (agg0)                          weak-key(agg0)      
-      │                   aggregate 0  w::DECIMAL                 ·                               ·                   
-      │                   group by     @1-@2                      ·                               ·                   
-      └── filter          ·            ·                          (v, "w::DECIMAL")               "w::DECIMAL"!=NULL  
-           │              filter       "w::DECIMAL" > 1           ·                               ·                   
-           └── render     ·            ·                          (v, "w::DECIMAL")               ·                   
-                │         render 0     test.public.kv.v           ·                               ·                   
-                │         render 1     test.public.kv.w::DECIMAL  ·                               ·                   
-                └── scan  ·            ·                          (k[omitted], v, w, s[omitted])  k!=NULL; key(k)     
-·                         table        kv@primary                 ·                               ·                   
-·                         spans        ALL                        ·                               ·                   
-
 query I
 SELECT 1 FROM kv GROUP BY v, w::DECIMAL HAVING w::DECIMAL > 1
 ----

--- a/pkg/sql/logictest/testdata/planner_test/aggregate
+++ b/pkg/sql/logictest/testdata/planner_test/aggregate
@@ -1,0 +1,748 @@
+# LogicTest: default
+
+statement ok
+CREATE TABLE kv (
+  k INT PRIMARY KEY,
+  v INT,
+  w INT,
+  s STRING
+)
+
+# Selecting and grouping on a more complex expression works.
+query TTTTT
+EXPLAIN (VERBOSE) SELECT COUNT(*), k+v FROM kv GROUP BY k+v
+----
+group           ·            ·                                    (count, "k + v")                weak-key("k + v")
+ │              aggregate 0  count_rows()                         ·                               ·
+ │              aggregate 1  k + v                                ·                               ·
+ │              group by     @1                                   ·                               ·
+ └── render     ·            ·                                    ("k + v")                       ·
+      │         render 0     test.public.kv.k + test.public.kv.v  ·                               ·
+      └── scan  ·            ·                                    (k, v, w[omitted], s[omitted])  k!=NULL; key(k)
+·               table        kv@primary                           ·                               ·
+·               spans        ALL                                  ·                               ·
+
+# Selecting a more complex expression, made up of things which are each grouped, works.
+query TTTTT
+EXPLAIN (VERBOSE) SELECT COUNT(*), k+v FROM kv GROUP BY k, v
+----
+render               ·            ·                 (count, "k + v")                ·
+ │                   render 0     agg0              ·                               ·
+ │                   render 1     agg1 + agg2       ·                               ·
+ └── group           ·            ·                 (agg0, agg1, agg2)              agg1!=NULL; key(agg1)
+      │              aggregate 0  count_rows()      ·                               ·
+      │              aggregate 1  k                 ·                               ·
+      │              aggregate 2  v                 ·                               ·
+      │              group by     @1-@2             ·                               ·
+      └── render     ·            ·                 (k, v)                          k!=NULL; key(k); +k
+           │         render 0     test.public.kv.k  ·                               ·
+           │         render 1     test.public.kv.v  ·                               ·
+           └── scan  ·            ·                 (k, v, w[omitted], s[omitted])  k!=NULL; key(k); +k
+·                    table        kv@primary        ·                               ·
+·                    spans        ALL               ·                               ·
+
+query TTT
+SELECT "Tree", "Field", "Description" FROM [
+EXPLAIN (VERBOSE) SELECT COUNT(k) FROM kv
+]
+----
+group           ·            ·
+ │              aggregate 0  count(k)
+ └── render     ·            ·
+      │         render 0     test.public.kv.k
+      └── scan  ·            ·
+·               table        kv@primary
+·               spans        ALL
+
+query TTT
+SELECT "Tree", "Field", "Description" FROM [
+EXPLAIN (VERBOSE) SELECT COUNT(k), SUM(k), MAX(k) FROM kv
+]
+----
+group           ·            ·
+ │              aggregate 0  count(k)
+ │              aggregate 1  sum(k)
+ │              aggregate 2  max(k)
+ └── render     ·            ·
+      │         render 0     test.public.kv.k
+      └── scan  ·            ·
+·               table        kv@primary
+·               spans        ALL
+
+statement ok
+CREATE TABLE abc (
+  a CHAR PRIMARY KEY,
+  b FLOAT,
+  c BOOLEAN,
+  d DECIMAL
+)
+
+query TTT
+SELECT "Tree", "Field", "Description" FROM [
+EXPLAIN (VERBOSE) SELECT MIN(a) FROM abc
+]
+----
+group           ·            ·
+ │              aggregate 0  min(a)
+ └── render     ·            ·
+      │         render 0     test.public.abc.a
+      └── scan  ·            ·
+·               table        abc@primary
+·               spans        ALL
+·               limit        1
+
+# Verify summing of intervals
+statement ok
+CREATE TABLE intervals (
+  a INTERVAL PRIMARY KEY
+)
+
+statement ok
+CREATE TABLE xyz (
+  x INT PRIMARY KEY,
+  y INT,
+  z FLOAT,
+  INDEX xy (x, y),
+  INDEX zyx (z, y, x),
+  FAMILY (x),
+  FAMILY (y),
+  FAMILY (z)
+)
+
+query TTT
+SELECT "Tree", "Field", "Description" FROM [
+EXPLAIN (VERBOSE) SELECT MIN(x) FROM xyz
+]
+----
+group           ·            ·
+ │              aggregate 0  min(x)
+ └── render     ·            ·
+      │         render 0     test.public.xyz.x
+      └── scan  ·            ·
+·               table        xyz@xy
+·               spans        ALL
+·               limit        1
+
+query TTT
+SELECT "Tree", "Field", "Description" FROM [
+EXPLAIN (VERBOSE) SELECT MIN(x) FROM xyz WHERE x in (0, 4, 7)
+]
+----
+group           ·            ·
+ │              aggregate 0  min(x)
+ └── render     ·            ·
+      │         render 0     test.public.xyz.x
+      └── scan  ·            ·
+·               table        xyz@xy
+·               spans        /0-/1 /4-/5 /7-/8
+·               limit        1
+
+query TTT
+SELECT "Tree", "Field", "Description" FROM [
+EXPLAIN (VERBOSE) SELECT MAX(x) FROM xyz
+]
+----
+group              ·            ·
+ │                 aggregate 0  max(x)
+ └── render        ·            ·
+      │            render 0     test.public.xyz.x
+      └── revscan  ·            ·
+·                  table        xyz@xy
+·                  spans        ALL
+·                  limit        1
+
+query TTT
+SELECT "Tree", "Field", "Description" FROM [
+EXPLAIN (VERBOSE) SELECT MIN(y) FROM xyz WHERE x = 1
+]
+----
+group           ·            ·
+ │              aggregate 0  min(y)
+ └── render     ·            ·
+      │         render 0     test.public.xyz.y
+      └── scan  ·            ·
+·               table        xyz@xy
+·               spans        /1/!NULL-/2
+·               limit        1
+
+query TTT
+SELECT "Tree", "Field", "Description" FROM [
+EXPLAIN (VERBOSE) SELECT MAX(y) FROM xyz WHERE x = 1
+]
+----
+group              ·            ·
+ │                 aggregate 0  max(y)
+ └── render        ·            ·
+      │            render 0     test.public.xyz.y
+      └── revscan  ·            ·
+·                  table        xyz@xy
+·                  spans        /1/!NULL-/2
+·                  limit        1
+
+query TTT
+SELECT "Tree", "Field", "Description" FROM [
+EXPLAIN (VERBOSE) SELECT MIN(y) FROM xyz WHERE x = 7
+]
+----
+group           ·            ·
+ │              aggregate 0  min(y)
+ └── render     ·            ·
+      │         render 0     test.public.xyz.y
+      └── scan  ·            ·
+·               table        xyz@xy
+·               spans        /7/!NULL-/8
+·               limit        1
+
+query TTT
+SELECT "Tree", "Field", "Description" FROM [
+EXPLAIN (VERBOSE) SELECT MAX(y) FROM xyz WHERE x = 7
+]
+----
+group              ·            ·
+ │                 aggregate 0  max(y)
+ └── render        ·            ·
+      │            render 0     test.public.xyz.y
+      └── revscan  ·            ·
+·                  table        xyz@xy
+·                  spans        /7/!NULL-/8
+·                  limit        1
+
+query TTT
+SELECT "Tree", "Field", "Description" FROM [
+EXPLAIN (VERBOSE) SELECT MIN(x) FROM xyz WHERE (y, z) = (2, 3.0)
+]
+----
+group           ·            ·
+ │              aggregate 0  min(x)
+ └── render     ·            ·
+      │         render 0     test.public.xyz.x
+      └── scan  ·            ·
+·               table        xyz@zyx
+·               spans        /3/2-/3/3
+·               limit        1
+
+statement okSE
+INSERT INTO xyz VALUES (1, 2, 3.0), (4, 5, 6.0), (7, NULL, 8.0)
+
+query T
+SELECT message FROM [SHOW KV TRACE FOR SELECT MIN(x) FROM xyz WHERE (y, z) = (2, 3.0)]
+ WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
+----
+fetched: /xyz/zyx/3.0/2/1 -> NULL
+output row: [1]
+
+query TTT
+SELECT "Tree", "Field", "Description" FROM [
+EXPLAIN (VERBOSE) SELECT MAX(x) FROM xyz WHERE (z, y) = (3.0, 2)
+]
+----
+group              ·            ·
+ │                 aggregate 0  max(x)
+ └── render        ·            ·
+      │            render 0     test.public.xyz.x
+      └── revscan  ·            ·
+·                  table        xyz@zyx
+·                  spans        /3/2-/3/3
+·                  limit        1
+
+# VARIANCE/STDDEV
+
+query T
+SELECT message FROM [SHOW KV TRACE FOR SELECT VARIANCE(x), VARIANCE(y::decimal), round(VARIANCE(z), 14) FROM xyz]
+ WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
+----
+fetched: /xyz/primary/1 -> NULL
+fetched: /xyz/primary/1/y -> 2
+fetched: /xyz/primary/1/z -> 3.0
+fetched: /xyz/primary/4 -> NULL
+fetched: /xyz/primary/4/y -> 5
+fetched: /xyz/primary/4/z -> 6.0
+fetched: /xyz/primary/7 -> NULL
+fetched: /xyz/primary/7/z -> 8.0
+output row: [9 4.5 6.33333333333333]
+
+query TTT
+SELECT "Tree", "Field", "Description" FROM [
+EXPLAIN (VERBOSE) SELECT VARIANCE(x) FROM xyz WHERE x = 1
+]
+----
+group           ·            ·
+ │              aggregate 0  variance(x)
+ └── render     ·            ·
+      │         render 0     test.public.xyz.x
+      └── scan  ·            ·
+·               table        xyz@xy
+·               spans        /1-/2
+
+# Verify we only look at one row for MIN when we have an index on that column.
+query T
+SELECT message FROM [SHOW KV TRACE FOR SELECT MIN(z) FROM xyz]
+ WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
+----
+fetched: /xyz/zyx/3.0/2/1 -> NULL
+output row: [3.0]
+
+# Tests for the single-row optimization.
+statement OK
+CREATE TABLE ab (
+  a INT PRIMARY KEY,
+  b INT,
+  FAMILY (a),
+  FAMILY (b)
+)
+
+query TTT
+SELECT "Tree", "Field", "Description" FROM [
+EXPLAIN (VERBOSE) SELECT MIN(a) FROM abc
+]
+----
+group           ·            ·
+ │              aggregate 0  min(a)
+ └── render     ·            ·
+      │         render 0     test.public.abc.a
+      └── scan  ·            ·
+·               table        abc@primary
+·               spans        ALL
+·               limit        1
+
+statement OK
+INSERT INTO ab VALUES
+  (1, 10),
+  (2, 20),
+  (3, 30),
+  (4, 40),
+  (5, 50)
+
+# Verify we only buffer one row.
+query T
+SELECT message FROM [SHOW KV TRACE FOR SELECT MIN(a) FROM ab]
+ WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
+----
+fetched: /ab/primary/1 -> NULL
+fetched: /ab/primary/1/b -> 10
+output row: [1]
+
+query TTT
+SELECT "Tree", "Field", "Description" FROM [
+EXPLAIN (VERBOSE) SELECT MAX(a) FROM abc
+]
+----
+group              ·            ·
+ │                 aggregate 0  max(a)
+ └── render        ·            ·
+      │            render 0     test.public.abc.a
+      └── revscan  ·            ·
+·                  table        abc@primary
+·                  spans        ALL
+·                  limit        1
+
+# Verify we only buffer one row.
+query T
+SELECT message FROM [SHOW KV TRACE FOR SELECT MAX(a) FROM ab]
+ WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
+----
+fetched: /ab/primary/5/b -> 50
+fetched: /ab/primary/5 -> NULL
+output row: [5]
+
+query TTT
+SELECT "Tree", "Field", "Description" FROM [
+EXPLAIN (VERBOSE) SELECT v, COUNT(k) FROM kv GROUP BY v ORDER BY COUNT(k)
+]
+----
+sort                 ·            ·
+ │                   order        +count
+ └── group           ·            ·
+      │              aggregate 0  v
+      │              aggregate 1  count(k)
+      │              group by     @1
+      └── render     ·            ·
+           │         render 0     test.public.kv.v
+           │         render 1     test.public.kv.k
+           └── scan  ·            ·
+·                    table        kv@primary
+·                    spans        ALL
+
+query TTT
+SELECT "Tree", "Field", "Description" FROM [
+EXPLAIN (VERBOSE) SELECT v, COUNT(*) FROM kv GROUP BY v ORDER BY COUNT(*)
+]
+----
+sort                 ·            ·
+ │                   order        +count
+ └── group           ·            ·
+      │              aggregate 0  v
+      │              aggregate 1  count_rows()
+      │              group by     @1
+      └── render     ·            ·
+           │         render 0     test.public.kv.v
+           └── scan  ·            ·
+·                    table        kv@primary
+·                    spans        ALL
+
+query TTT
+SELECT "Tree", "Field", "Description" FROM [
+EXPLAIN (VERBOSE) SELECT v, COUNT(1) FROM kv GROUP BY v ORDER BY COUNT(1)
+]
+----
+sort                 ·            ·
+ │                   order        +count
+ └── group           ·            ·
+      │              aggregate 0  v
+      │              aggregate 1  count(1)
+      │              group by     @1
+      └── render     ·            ·
+           │         render 0     test.public.kv.v
+           │         render 1     1
+           └── scan  ·            ·
+·                    table        kv@primary
+·                    spans        ALL
+
+# Check that filters propagate through no-op aggregation.
+query TTT
+SELECT "Tree", "Field", "Description" FROM [
+EXPLAIN (VERBOSE) SELECT * FROM (SELECT v, COUNT(1) FROM kv GROUP BY v) WHERE v > 10
+]
+----
+group           ·            ·
+ │              aggregate 0  v
+ │              aggregate 1  count(1)
+ │              group by     @1
+ └── render     ·            ·
+      │         render 0     test.public.kv.v
+      │         render 1     1
+      └── scan  ·            ·
+·               table        kv@primary
+·               spans        ALL
+·               filter       v > 10
+
+# Verify that FILTER works.
+
+statement ok
+CREATE TABLE filter_test (
+  k INT,
+  v INT,
+  mark BOOL
+)
+
+# Check that filter expressions are only rendered once.
+query TTT
+SELECT "Tree", "Field", "Description" FROM [
+EXPLAIN (VERBOSE) SELECT COUNT(*) FILTER (WHERE k>5), MAX(k>5) FILTER(WHERE k>5) FROM filter_test GROUP BY v
+]
+----
+group           ·            ·
+ │              aggregate 0  count_rows() FILTER (WHERE k > 5)
+ │              aggregate 1  max(k > 5) FILTER (WHERE k > 5)
+ │              group by     @1
+ └── render     ·            ·
+      │         render 0     test.public.filter_test.v
+      │         render 1     test.public.filter_test.k > 5
+      └── scan  ·            ·
+·               table        filter_test@primary
+·               spans        ALL
+
+query TTTTT
+EXPLAIN (TYPES) SELECT COUNT(*) FILTER (WHERE k > 5) FROM filter_test GROUP BY v
+----
+group           ·            ·                                  (count int)                                                    ·
+ │              aggregate 0  count_rows() FILTER (WHERE k > 5)  ·                                                              ·
+ │              group by     @1                                 ·                                                              ·
+ └── render     ·            ·                                  (v int, "k > 5" bool)                                          ·
+      │         render 0     (v)[int]                           ·                                                              ·
+      │         render 1     ((k)[int] > (5)[int])[bool]        ·                                                              ·
+      └── scan  ·            ·                                  (k int, v int, mark[omitted] bool, rowid[hidden,omitted] int)  rowid!=NULL; key(rowid)
+·               table        filter_test@primary                ·                                                              ·
+·               spans        ALL                                ·                                                              ·
+
+# Tests with * inside GROUP BY.
+query TTT
+SELECT "Tree", "Field", "Description" FROM [
+EXPLAIN (VERBOSE) SELECT 1 FROM kv GROUP BY kv.*
+]
+----
+render          ·         ·
+ │              render 0  1
+ └── group      ·         ·
+      │         group by  @1-@4
+      └── scan  ·         ·
+·               table     kv@primary
+·               spans     ALL
+
+query TTT
+SELECT "Tree", "Field", "Description" FROM [
+EXPLAIN (VERBOSE) SELECT SUM(abc.d) FROM kv JOIN abc ON kv.k >= abc.d GROUP BY kv.*
+]
+----
+group                ·            ·
+ │                   aggregate 0  sum(d)
+ │                   group by     @1-@4
+ └── render          ·            ·
+      │              render 0     test.public.kv.k
+      │              render 1     test.public.kv.v
+      │              render 2     test.public.kv.w
+      │              render 3     test.public.kv.s
+      │              render 4     test.public.abc.d
+      └── join       ·            ·
+           │         type         inner
+           │         pred         test.public.kv.k >= test.public.abc.d
+           ├── scan  ·            ·
+           │         table        kv@primary
+           │         spans        ALL
+           └── scan  ·            ·
+·                    table        abc@primary
+·                    spans        ALL
+
+# opt_test is used for tests around the single-row optimization for MIN/MAX.
+statement ok
+CREATE TABLE opt_test (k INT PRIMARY KEY, v INT, INDEX v(v))
+
+# Verify that we correctly add the v IS NOT NULL constraint (which restricts the span).
+query TTTTT
+EXPLAIN (VERBOSE) SELECT MIN(v) FROM opt_test
+----
+group           ·            ·                       (min)            ·
+ │              aggregate 0  min(v)                  ·                ·
+ └── render     ·            ·                       (v)              v!=NULL; +v
+      │         render 0     test.public.opt_test.v  ·                ·
+      └── scan  ·            ·                       (k[omitted], v)  k!=NULL; v!=NULL; key(k,v); +v
+·               table        opt_test@v              ·                ·
+·               spans        /!NULL-                 ·                ·
+·               limit        1                       ·                ·
+
+# Repeat test when there is an existing filter.
+query TTTTT
+EXPLAIN (VERBOSE) SELECT MIN(v) FROM opt_test WHERE k <> 4
+----
+group           ·            ·                       (min)   ·
+ │              aggregate 0  min(v)                  ·       ·
+ └── render     ·            ·                       (v)     v!=NULL; +v
+      │         render 0     test.public.opt_test.v  ·       ·
+      └── scan  ·            ·                       (k, v)  k!=NULL; v!=NULL; key(k,v); +v
+·               table        opt_test@v              ·       ·
+·               spans        /!NULL-                 ·       ·
+·               filter       k != 4                  ·       ·
+
+# Check the optimization when the argument is non-trivial. The renderNode can't
+# present an ordering on v+1 so the optimization is not applied, but the IS NOT
+# NULL filter should be added.
+query TTTTT
+EXPLAIN (VERBOSE) SELECT MIN(v+1) FROM opt_test WHERE k <> 4
+----
+group           ·            ·                           (min)            ·
+ │              aggregate 0  min(v + 1)                  ·                ·
+ └── render     ·            ·                           ("v + 1")        ·
+      │         render 0     test.public.opt_test.v + 1  ·                ·
+      └── scan  ·            ·                           (k[omitted], v)  k!=NULL; v!=NULL; key(k)
+·               table        opt_test@primary            ·                ·
+·               spans        -/3/# /5-                   ·                ·
+·               filter       (v + 1) IS NOT NULL         ·                ·
+
+# Verify that we don't use the optimization if there is a GROUP BY.
+query TTTTT
+EXPLAIN (VERBOSE) SELECT MIN(v) FROM opt_test GROUP BY k
+----
+group      ·            ·                 (min)   ·
+ │         aggregate 0  min(v)            ·       ·
+ │         group by     @1                ·       ·
+ └── scan  ·            ·                 (k, v)  k!=NULL; key(k)
+·          table        opt_test@primary  ·       ·
+·          spans        ALL               ·       ·
+
+query TTT
+SELECT "Tree", "Field", "Description" FROM [
+EXPLAIN (VERBOSE) SELECT (b, a) FROM ab GROUP BY (b, a)
+]
+----
+render               ·            ·
+ │                   render 0     (agg0, agg1)
+ └── group           ·            ·
+      │              aggregate 0  b
+      │              aggregate 1  a
+      │              group by     @1-@2
+      └── render     ·            ·
+           │         render 0     test.public.ab.b
+           │         render 1     test.public.ab.a
+           └── scan  ·            ·
+·                    table        ab@primary
+·                    spans        ALL
+
+statement ok
+CREATE TABLE xy(x STRING, y STRING);
+
+query TTT
+SELECT "Tree", "Field", "Description" FROM [
+EXPLAIN (VERBOSE)
+   SELECT MIN(y), (b, a)
+     FROM ab, xy GROUP BY (x, (a, b))
+]
+----
+render                    ·            ·
+ │                        render 0     agg0
+ │                        render 1     (agg1, agg2)
+ └── group                ·            ·
+      │                   aggregate 0  min(y)
+      │                   aggregate 1  b
+      │                   aggregate 2  a
+      │                   group by     @1-@3
+      └── render          ·            ·
+           │              render 0     test.public.xy.x
+           │              render 1     test.public.ab.a
+           │              render 2     test.public.ab.b
+           │              render 3     test.public.xy.y
+           └── join       ·            ·
+                │         type         cross
+                ├── scan  ·            ·
+                │         table        ab@primary
+                │         spans        ALL
+                └── scan  ·            ·
+·                         table        xy@primary
+·                         spans        ALL
+
+# Test that ordering on GROUP BY columns is maintained.
+statement ok
+CREATE TABLE group_ord (
+  x INT PRIMARY KEY,
+  y INT,
+  z INT,
+  INDEX foo(z)
+)
+
+# The ordering is on all the GROUP BY columns, and isn't preserved after the
+# aggregation.
+query TTTTT
+EXPLAIN (VERBOSE) SELECT x, max(y) FROM group_ord GROUP BY x
+----
+group           ·            ·                        (x, max)            x!=NULL; key(x)
+ │              aggregate 0  x                        ·                   ·
+ │              aggregate 1  max(y)                   ·                   ·
+ │              group by     @1                       ·                   ·
+ └── render     ·            ·                        (x, y)              x!=NULL; key(x); +x
+      │         render 0     test.public.group_ord.x  ·                   ·
+      │         render 1     test.public.group_ord.y  ·                   ·
+      └── scan  ·            ·                        (x, y, z[omitted])  x!=NULL; key(x); +x
+·               table        group_ord@primary        ·                   ·
+·               spans        ALL                      ·                   ·
+
+# The ordering is on all the GROUP BY columns, and is preserved after the
+# aggregation.
+query TTTTT
+EXPLAIN (VERBOSE) SELECT x, max(y) FROM group_ord GROUP BY x ORDER BY x
+----
+group           ·            ·                        (x, max)            x!=NULL; key(x); +x
+ │              aggregate 0  x                        ·                   ·
+ │              aggregate 1  max(y)                   ·                   ·
+ │              group by     @1                       ·                   ·
+ └── render     ·            ·                        (x, y)              x!=NULL; key(x); +x
+      │         render 0     test.public.group_ord.x  ·                   ·
+      │         render 1     test.public.group_ord.y  ·                   ·
+      └── scan  ·            ·                        (x, y, z[omitted])  x!=NULL; key(x); +x
+·               table        group_ord@primary        ·                   ·
+·               spans        ALL                      ·                   ·
+
+# The ordering is on some of the GROUP BY columns, and isn't preserved after
+# the aggregation.
+query TTTTT
+EXPLAIN (VERBOSE) SELECT z, x, max(y) FROM group_ord GROUP BY x, z
+----
+group           ·            ·                        (z, x, max)  x!=NULL; key(x)
+ │              aggregate 0  z                        ·            ·
+ │              aggregate 1  x                        ·            ·
+ │              aggregate 2  max(y)                   ·            ·
+ │              group by     @1-@2                    ·            ·
+ └── render     ·            ·                        (x, z, y)    x!=NULL; key(x); +x
+      │         render 0     test.public.group_ord.x  ·            ·
+      │         render 1     test.public.group_ord.z  ·            ·
+      │         render 2     test.public.group_ord.y  ·            ·
+      └── scan  ·            ·                        (x, y, z)    x!=NULL; key(x); +x
+·               table        group_ord@primary        ·            ·
+·               spans        ALL                      ·            ·
+
+# The ordering is on some of the GROUP BY columns, and is preserved after
+# the aggregation.
+query TTTTT
+EXPLAIN (VERBOSE) SELECT z, x, max(y) FROM group_ord GROUP BY x, z ORDER BY x
+----
+group           ·            ·                        (z, x, max)  x!=NULL; key(x); +x
+ │              aggregate 0  z                        ·            ·
+ │              aggregate 1  x                        ·            ·
+ │              aggregate 2  max(y)                   ·            ·
+ │              group by     @1-@2                    ·            ·
+ └── render     ·            ·                        (x, z, y)    x!=NULL; key(x); +x
+      │         render 0     test.public.group_ord.x  ·            ·
+      │         render 1     test.public.group_ord.z  ·            ·
+      │         render 2     test.public.group_ord.y  ·            ·
+      └── scan  ·            ·                        (x, y, z)    x!=NULL; key(x); +x
+·               table        group_ord@primary        ·            ·
+·               spans        ALL                      ·            ·
+
+# If the underlying ordering isn't from the primary index, it needs to be hinted
+# for now.
+query TTTTT
+EXPLAIN (VERBOSE) SELECT z, max(y) FROM group_ord@foo GROUP BY z
+----
+group                 ·            ·                        (z, max)                     weak-key(z)
+ │                    aggregate 0  z                        ·                            ·
+ │                    aggregate 1  max(y)                   ·                            ·
+ │                    group by     @1                       ·                            ·
+ └── render           ·            ·                        (z, y)                       +z
+      │               render 0     test.public.group_ord.z  ·                            ·
+      │               render 1     test.public.group_ord.y  ·                            ·
+      └── index-join  ·            ·                        (x[omitted], y, z)           x!=NULL; weak-key(x,z); +z
+           ├── scan   ·            ·                        (x, y[omitted], z[omitted])  x!=NULL; weak-key(x,z); +z
+           │          table        group_ord@foo            ·                            ·
+           │          spans        ALL                      ·                            ·
+           └── scan   ·            ·                        (x[omitted], y, z)           ·
+·                     table        group_ord@primary        ·                            ·
+
+# Test that a merge join is used on two aggregate subqueries with orderings on
+# the GROUP BY columns. Note that an ORDER BY is not necessary on the
+# subqueries.
+query TTTTT
+EXPLAIN (VERBOSE) SELECT * FROM (SELECT x, max(y) FROM group_ord GROUP BY x) JOIN (SELECT z, min(y) FROM group_ord@foo GROUP BY z) ON x = z
+----
+join                       ·               ·                        (x, max, z, min)             x=z; x!=NULL
+ │                         type            inner                    ·                            ·
+ │                         equality        (x) = (z)                ·                            ·
+ │                         mergeJoinOrder  +"(x=z)"                 ·                            ·
+ ├── group                 ·               ·                        (x, max)                     x!=NULL; key(x); +x
+ │    │                    aggregate 0     x                        ·                            ·
+ │    │                    aggregate 1     max(y)                   ·                            ·
+ │    │                    group by        @1                       ·                            ·
+ │    └── render           ·               ·                        (x, y)                       x!=NULL; key(x); +x
+ │         │               render 0        test.public.group_ord.x  ·                            ·
+ │         │               render 1        test.public.group_ord.y  ·                            ·
+ │         └── scan        ·               ·                        (x, y, z[omitted])           x!=NULL; key(x); +x
+ │                         table           group_ord@primary        ·                            ·
+ │                         spans           ALL                      ·                            ·
+ └── group                 ·               ·                        (z, min)                     weak-key(z); +z
+      │                    aggregate 0     z                        ·                            ·
+      │                    aggregate 1     min(y)                   ·                            ·
+      │                    group by        @1                       ·                            ·
+      └── render           ·               ·                        (z, y)                       +z
+           │               render 0        test.public.group_ord.z  ·                            ·
+           │               render 1        test.public.group_ord.y  ·                            ·
+           └── index-join  ·               ·                        (x[omitted], y, z)           x!=NULL; weak-key(x,z); +z
+                ├── scan   ·               ·                        (x, y[omitted], z[omitted])  x!=NULL; weak-key(x,z); +z
+                │          table           group_ord@foo            ·                            ·
+                │          spans           ALL                      ·                            ·
+                └── scan   ·               ·                        (x[omitted], y, z)           ·
+·                          table           group_ord@primary        ·                            ·
+
+# Regression test for #25533 (crash when propagating filter through GROUP BY).
+query TTTTT
+EXPLAIN (VERBOSE) SELECT 1 FROM kv GROUP BY v, w::DECIMAL HAVING w::DECIMAL > 1;
+----
+render                    ·            ·                          ("1")                           "1"=CONST
+ │                        render 0     1                          ·                               ·
+ └── group                ·            ·                          (agg0)                          weak-key(agg0)
+      │                   aggregate 0  w::DECIMAL                 ·                               ·
+      │                   group by     @1-@2                      ·                               ·
+      └── filter          ·            ·                          (v, "w::DECIMAL")               "w::DECIMAL"!=NULL
+           │              filter       "w::DECIMAL" > 1           ·                               ·
+           └── render     ·            ·                          (v, "w::DECIMAL")               ·
+                │         render 0     test.public.kv.v           ·                               ·
+                │         render 1     test.public.kv.w::DECIMAL  ·                               ·
+                └── scan  ·            ·                          (k[omitted], v, w, s[omitted])  k!=NULL; key(k)
+·                         table        kv@primary                 ·                               ·
+·                         spans        ALL                        ·                               ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/aggregate
+++ b/pkg/sql/opt/exec/execbuilder/testdata/aggregate
@@ -10,699 +10,165 @@ CREATE TABLE kv (
 ----
 
 exec hide-colnames nodist
-EXPLAIN (VERBOSE) SELECT MIN(1), MAX(1), COUNT(1), SUM_INT(1), AVG(1), SUM(1), STDDEV(1), VARIANCE(1), BOOL_AND(true), BOOL_OR(false), XOR_AGG(b'\x01') FROM kv
+EXPLAIN (TYPES) SELECT MIN(1), MAX(1), COUNT(1), SUM_INT(1), AVG(1), SUM(1), STDDEV(1), VARIANCE(1), BOOL_AND(true), BOOL_OR(false), XOR_AGG(b'\x01') FROM kv
 ----
-group           ·             ·                   (min, max, count, sum_int, avg, sum, stddev, variance, bool_and, bool_or, xor_agg)  ·
- │              aggregate 0   min(column5)        ·                                                                                   ·
- │              aggregate 1   max(column5)        ·                                                                                   ·
- │              aggregate 2   count(column5)      ·                                                                                   ·
- │              aggregate 3   sum_int(column5)    ·                                                                                   ·
- │              aggregate 4   avg(column5)        ·                                                                                   ·
- │              aggregate 5   sum(column5)        ·                                                                                   ·
- │              aggregate 6   stddev(column5)     ·                                                                                   ·
- │              aggregate 7   variance(column5)   ·                                                                                   ·
- │              aggregate 8   bool_and(column14)  ·                                                                                   ·
- │              aggregate 9   bool_or(column16)   ·                                                                                   ·
- │              aggregate 10  xor_agg(column18)   ·                                                                                   ·
- └── render     ·             ·                   (column5, column14, column16, column18)                                             ·
-      │         render 0      1                   ·                                                                                   ·
-      │         render 1      true                ·                                                                                   ·
-      │         render 2      false               ·                                                                                   ·
-      │         render 3      '\x01'              ·                                                                                   ·
-      └── scan  ·             ·                   ()                                                                                  ·
-·               table         kv@primary          ·                                                                                   ·
-·               spans         ALL                 ·                                                                                   ·
-
-exec
-SELECT MIN(1), MAX(1), COUNT(1), SUM_INT(1), AVG(1), SUM(1), STDDEV(1), VARIANCE(1), BOOL_AND(true), BOOL_OR(false), XOR_AGG(b'\x01') FROM kv
-----
-min:int  max:int  count:int  sum_int:int  avg:decimal  sum:decimal  stddev:decimal  variance:decimal  bool_and:bool  bool_or:bool  xor_agg:bytes
-NULL     NULL     0          NULL         NULL         NULL         NULL            NULL              NULL           NULL          NULL
-
-# Aggregate functions return NULL if there are no rows.
-exec
-SELECT ARRAY_AGG(1) FROM kv
-----
-array_agg:int[]
-NULL
-
-exec
-SELECT JSON_AGG(1) FROM kv
-----
-json_agg:jsonb
-NULL
-
-exec
-SELECT JSONB_AGG(1) FROM kv
-----
-jsonb_agg:jsonb
-NULL
+group           ·             ·                   (min int, max int, count int, sum_int int, avg decimal, sum decimal, stddev decimal, variance decimal, bool_and bool, bool_or bool, xor_agg bytes)  ·
+ │              aggregate 0   min(column5)        ·                                                                                                                                                   ·
+ │              aggregate 1   max(column5)        ·                                                                                                                                                   ·
+ │              aggregate 2   count(column5)      ·                                                                                                                                                   ·
+ │              aggregate 3   sum_int(column5)    ·                                                                                                                                                   ·
+ │              aggregate 4   avg(column5)        ·                                                                                                                                                   ·
+ │              aggregate 5   sum(column5)        ·                                                                                                                                                   ·
+ │              aggregate 6   stddev(column5)     ·                                                                                                                                                   ·
+ │              aggregate 7   variance(column5)   ·                                                                                                                                                   ·
+ │              aggregate 8   bool_and(column14)  ·                                                                                                                                                   ·
+ │              aggregate 9   bool_or(column16)   ·                                                                                                                                                   ·
+ │              aggregate 10  xor_agg(column18)   ·                                                                                                                                                   ·
+ └── render     ·             ·                   (column5 int, column14 bool, column16 bool, column18 bytes)                                                                                         ·
+      │         render 0      (1)[int]            ·                                                                                                                                                   ·
+      │         render 1      (true)[bool]        ·                                                                                                                                                   ·
+      │         render 2      (false)[bool]       ·                                                                                                                                                   ·
+      │         render 3      ('\x01')[bytes]     ·                                                                                                                                                   ·
+      └── scan  ·             ·                   ()                                                                                                                                                  ·
+·               table         kv@primary          ·                                                                                                                                                   ·
+·               spans         ALL                 ·                                                                                                                                                   ·
 
 exec hide-colnames nodist
-EXPLAIN (VERBOSE) SELECT MIN(v), MAX(v), COUNT(v), SUM_INT(1), AVG(v), SUM(v), STDDEV(v), VARIANCE(v), BOOL_AND(v = 1), BOOL_AND(v = 1), XOR_AGG(s::bytes) FROM kv
+EXPLAIN (TYPES) SELECT MIN(v), MAX(v), COUNT(v), SUM_INT(1), AVG(v), SUM(v), STDDEV(v), VARIANCE(v), BOOL_AND(v = 1), BOOL_AND(v = 1), XOR_AGG(s::bytes) FROM kv
 ----
-render               ·            ·                   (min, max, count, sum_int, avg, sum, stddev, variance, bool_and, bool_and, xor_agg)  ·
- │                   render 0     agg0                ·                                                                                    ·
- │                   render 1     agg1                ·                                                                                    ·
- │                   render 2     agg2                ·                                                                                    ·
- │                   render 3     agg3                ·                                                                                    ·
- │                   render 4     agg4                ·                                                                                    ·
- │                   render 5     agg5                ·                                                                                    ·
- │                   render 6     agg6                ·                                                                                    ·
- │                   render 7     agg7                ·                                                                                    ·
- │                   render 8     agg8                ·                                                                                    ·
- │                   render 9     agg8                ·                                                                                    ·
- │                   render 10    agg9                ·                                                                                    ·
- └── group           ·            ·                   (agg0, agg1, agg2, agg3, agg4, agg5, agg6, agg7, agg8, agg9)                         ·
-      │              aggregate 0  min(kv.v)           ·                                                                                    ·
-      │              aggregate 1  max(kv.v)           ·                                                                                    ·
-      │              aggregate 2  count(kv.v)         ·                                                                                    ·
-      │              aggregate 3  sum_int(column8)    ·                                                                                    ·
-      │              aggregate 4  avg(kv.v)           ·                                                                                    ·
-      │              aggregate 5  sum(kv.v)           ·                                                                                    ·
-      │              aggregate 6  stddev(kv.v)        ·                                                                                    ·
-      │              aggregate 7  variance(kv.v)      ·                                                                                    ·
-      │              aggregate 8  bool_and(column14)  ·                                                                                    ·
-      │              aggregate 9  xor_agg(column16)   ·                                                                                    ·
-      └── render     ·            ·                   (column8, column14, column16, "kv.v")                                                ·
-           │         render 0     1                   ·                                                                                    ·
-           │         render 1     v = 1               ·                                                                                    ·
-           │         render 2     s::BYTES            ·                                                                                    ·
-           │         render 3     v                   ·                                                                                    ·
-           └── scan  ·            ·                   (v, s)                                                                               ·
-·                    table        kv@primary          ·                                                                                    ·
-·                    spans        ALL                 ·                                                                                    ·
-
-exec
-SELECT MIN(v), MAX(v), COUNT(v), SUM_INT(1), AVG(v), SUM(v), STDDEV(v), VARIANCE(v), BOOL_AND(v = 1), BOOL_AND(v = 1), XOR_AGG(s::bytes) FROM kv
-----
-min:int  max:int  count:int  sum_int:int  avg:decimal  sum:decimal  stddev:decimal  variance:decimal  bool_and:bool  bool_and:bool  xor_agg:bytes
-NULL     NULL     0          NULL         NULL         NULL         NULL            NULL              NULL           NULL           NULL
-
-exec
-SELECT ARRAY_AGG(v) FROM kv
-----
-array_agg:int[]
-NULL
-
-exec
-SELECT JSON_AGG(v) FROM kv
-----
-json_agg:jsonb
-NULL
-
-exec
-SELECT JSONB_AGG(v) FROM kv
-----
-jsonb_agg:jsonb
-NULL
+render               ·            ·                            (min int, max int, count int, sum_int int, avg decimal, sum decimal, stddev decimal, variance decimal, bool_and bool, bool_and bool, xor_agg bytes)  ·
+ │                   render 0     (agg0)[int]                  ·                                                                                                                                                    ·
+ │                   render 1     (agg1)[int]                  ·                                                                                                                                                    ·
+ │                   render 2     (agg2)[int]                  ·                                                                                                                                                    ·
+ │                   render 3     (agg3)[int]                  ·                                                                                                                                                    ·
+ │                   render 4     (agg4)[decimal]              ·                                                                                                                                                    ·
+ │                   render 5     (agg5)[decimal]              ·                                                                                                                                                    ·
+ │                   render 6     (agg6)[decimal]              ·                                                                                                                                                    ·
+ │                   render 7     (agg7)[decimal]              ·                                                                                                                                                    ·
+ │                   render 8     (agg8)[bool]                 ·                                                                                                                                                    ·
+ │                   render 9     (agg8)[bool]                 ·                                                                                                                                                    ·
+ │                   render 10    (agg9)[bytes]                ·                                                                                                                                                    ·
+ └── group           ·            ·                            (agg0 int, agg1 int, agg2 int, agg3 int, agg4 decimal, agg5 decimal, agg6 decimal, agg7 decimal, agg8 bool, agg9 bytes)                              ·
+      │              aggregate 0  min(kv.v)                    ·                                                                                                                                                    ·
+      │              aggregate 1  max(kv.v)                    ·                                                                                                                                                    ·
+      │              aggregate 2  count(kv.v)                  ·                                                                                                                                                    ·
+      │              aggregate 3  sum_int(column8)             ·                                                                                                                                                    ·
+      │              aggregate 4  avg(kv.v)                    ·                                                                                                                                                    ·
+      │              aggregate 5  sum(kv.v)                    ·                                                                                                                                                    ·
+      │              aggregate 6  stddev(kv.v)                 ·                                                                                                                                                    ·
+      │              aggregate 7  variance(kv.v)               ·                                                                                                                                                    ·
+      │              aggregate 8  bool_and(column14)           ·                                                                                                                                                    ·
+      │              aggregate 9  xor_agg(column16)            ·                                                                                                                                                    ·
+      └── render     ·            ·                            (column8 int, column14 bool, column16 bytes, "kv.v" int)                                                                                             ·
+           │         render 0     (1)[int]                     ·                                                                                                                                                    ·
+           │         render 1     ((v)[int] = (1)[int])[bool]  ·                                                                                                                                                    ·
+           │         render 2     ((s)[string]::BYTES)[bytes]  ·                                                                                                                                                    ·
+           │         render 3     (v)[int]                     ·                                                                                                                                                    ·
+           └── scan  ·            ·                            (v int, s string)                                                                                                                                    ·
+·                    table        kv@primary                   ·                                                                                                                                                    ·
+·                    spans        ALL                          ·                                                                                                                                                    ·
 
 # Aggregate functions trigger aggregation and computation when there is no source.
 exec hide-colnames nodist
-EXPLAIN (VERBOSE) SELECT MIN(1), COUNT(1), MAX(1), SUM_INT(1), AVG(1)::float, SUM(1), STDDEV(1), VARIANCE(1), BOOL_AND(true), BOOL_OR(true), TO_HEX(XOR_AGG(b'\x01'))
+EXPLAIN (TYPES) SELECT MIN(1), COUNT(1), MAX(1), SUM_INT(1), AVG(1)::float, SUM(1), STDDEV(1), VARIANCE(1), BOOL_AND(true), BOOL_OR(true), TO_HEX(XOR_AGG(b'\x01'))
 ----
-render                 ·             ·                   (min, count, max, sum_int, "avg(1)::FLOAT", sum, stddev, variance, bool_and, bool_or, to_hex)  ·
- │                     render 0      agg0                ·                                                                                              ·
- │                     render 1      agg1                ·                                                                                              ·
- │                     render 2      agg2                ·                                                                                              ·
- │                     render 3      agg3                ·                                                                                              ·
- │                     render 4      agg4::FLOAT         ·                                                                                              ·
- │                     render 5      agg5                ·                                                                                              ·
- │                     render 6      agg6                ·                                                                                              ·
- │                     render 7      agg7                ·                                                                                              ·
- │                     render 8      agg8                ·                                                                                              ·
- │                     render 9      agg9                ·                                                                                              ·
- │                     render 10     to_hex(agg10)       ·                                                                                              ·
- └── group             ·             ·                   (agg0, agg1, agg2, agg3, agg4, agg5, agg6, agg7, agg8, agg9, agg10)                            ·
-      │                aggregate 0   min(column1)        ·                                                                                              ·
-      │                aggregate 1   count(column1)      ·                                                                                              ·
-      │                aggregate 2   max(column1)        ·                                                                                              ·
-      │                aggregate 3   sum_int(column1)    ·                                                                                              ·
-      │                aggregate 4   avg(column1)        ·                                                                                              ·
-      │                aggregate 5   sum(column1)        ·                                                                                              ·
-      │                aggregate 6   stddev(column1)     ·                                                                                              ·
-      │                aggregate 7   variance(column1)   ·                                                                                              ·
-      │                aggregate 8   bool_and(column11)  ·                                                                                              ·
-      │                aggregate 9   bool_or(column11)   ·                                                                                              ·
-      │                aggregate 10  xor_agg(column14)   ·                                                                                              ·
-      └── render       ·             ·                   (column1, column11, column14)                                                                  ·
-           │           render 0      1                   ·                                                                                              ·
-           │           render 1      true                ·                                                                                              ·
-           │           render 2      '\x01'              ·                                                                                              ·
-           └── values  ·             ·                   ()                                                                                             ·
-·                      size          0 columns, 1 row    ·                                                                                              ·
-
-exec
-SELECT MIN(1), COUNT(1), MAX(1), SUM_INT(1), AVG(1)::float, SUM(1), STDDEV(1), VARIANCE(1), BOOL_AND(true), BOOL_OR(true), TO_HEX(XOR_AGG(b'\x01'))
-----
-min:int  count:int  max:int  sum_int:int  avg(1)::FLOAT:float  sum:decimal  stddev:decimal  variance:decimal  bool_and:bool  bool_or:bool  to_hex:string
-1        1          1        1            1.0                  1            NULL            NULL              true           true          01
-
-# Aggregate functions triggers aggregation and computation when there is no source.
-exec
-SELECT MIN(1), COUNT(1), MAX(1), SUM_INT(1), AVG(1)::float, SUM(1), STDDEV(1), VARIANCE(1), BOOL_AND(true), BOOL_OR(true), TO_HEX(XOR_AGG(b'\x01'))
-----
-min:int  count:int  max:int  sum_int:int  avg(1)::FLOAT:float  sum:decimal  stddev:decimal  variance:decimal  bool_and:bool  bool_or:bool  to_hex:string
-1        1          1        1            1.0                  1            NULL            NULL              true           true          01
-
-# Aggregate functions triggers aggregation and computation when there is no source.
-exec
-SELECT ARRAY_AGG(1)
-----
-array_agg:int[]
-ARRAY[1]
-
-exec
-SELECT JSON_AGG(1)
-----
-json_agg:jsonb
-'[1]'
-
-exec
-SELECT JSONB_AGG(1)
-----
-jsonb_agg:jsonb
-'[1]'
-
-# Some aggregate functions are not normalized to NULL when given a NULL
-# argument.
-exec
-SELECT COUNT(NULL)
-----
-count:int
-0
-
-exec
-SELECT JSON_AGG(NULL)
-----
-json_agg:jsonb
-'[null]'
-
-exec
-SELECT JSONB_AGG(NULL)
-----
-jsonb_agg:jsonb
-'[null]'
-
-exec
-SELECT ARRAY_AGG(NULL::TEXT)
-----
-array_agg:string[]
-ARRAY[NULL]
-
-# TODO(radu): Selecting from series not supported yet.
-## Check that COALESCE using aggregate results over an empty table
-## work properly.
-#exec
-#SELECT COALESCE(MAX(1), 0) FROM generate_series(1,0)
-#----
-#0
-#
-#exec
-#SELECT COUNT_ROWS() FROM generate_series(1,100)
-#----
-#100
-#
-## Same, using arithmetic on COUNT.
-#exec
-#SELECT 1 + COUNT(*) FROM generate_series(1,0)
-#----
-#1
-
-# Same, using an empty table.
-# The following test *must* occur before the first INSERT to the tables,
-# so that it can observe an empty table.
-exec
-SELECT COUNT(*), COALESCE(MAX(k), 1) FROM kv
-----
-count:int  COALESCE(max(k), 1):int
-0          1
-
-# TODO(radu): Subqueries not implemented yet.
-## Same, using a subquery. (#12705)
-#exec
-#SELECT (SELECT COALESCE(MAX(1), 0) FROM generate_series(1,0))
-#----
-#0
-
-exec-raw
-INSERT INTO kv VALUES
-(1, 2, 3, 'a'),
-(3, 4, 5, 'a'),
-(5, NULL, 5, NULL),
-(6, 2, 3, 'b'),
-(7, 2, 2, 'b'),
-(8, 4, 2, 'A')
-----
-
-# Aggregate functions triggers aggregation and computation for every row even when applied to a constant.
-# NB: The XOR result is 00 because \x01 is XOR'd an even number of times.
-exec
-SELECT MIN(1), COUNT(1), MAX(1), SUM_INT(1), AVG(1)::float, SUM(1), STDDEV(1), VARIANCE(1)::float, BOOL_AND(true), BOOL_OR(true), TO_HEX(XOR_AGG(b'\x01')) FROM kv
-----
-min:int  count:int  max:int  sum_int:int  avg(1)::FLOAT:float  sum:decimal  stddev:decimal  variance(1)::FLOAT:float  bool_and:bool  bool_or:bool  to_hex:string
-1        6          1        6            1.0                  6            0               0.0                       true           true          00
-
-# Aggregate functions triggers aggregation and computation for every row even when applied to a constant.
-exec
-SELECT ARRAY_AGG(1) FROM kv
-----
-array_agg:int[]
-ARRAY[1,1,1,1,1,1]
-
-exec
-SELECT JSON_AGG(1) FROM kv
-----
-json_agg:jsonb
-'[1, 1, 1, 1, 1, 1]'
-
-exec
-SELECT JSONB_AGG(1) FROM kv
-----
-jsonb_agg:jsonb
-'[1, 1, 1, 1, 1, 1]'
-
-# Even with no aggregate functions, grouping occurs in the presence of GROUP BY.
-exec rowsort
-SELECT 1 FROM kv GROUP BY v
-----
-1:int
-1
-1
-1
-
-# Presence of HAVING triggers aggregation, reducing results to one row (even without GROUP BY).
-exec
-SELECT 3 FROM kv HAVING TRUE
-----
-3:int
-3
-
-exec rowsort
-SELECT COUNT(*), k FROM kv GROUP BY k
-----
-count:int  k:int
-1          1
-1          3
-1          5
-1          6
-1          7
-1          8
+render                 ·             ·                                 (min int, count int, max int, sum_int int, "avg(1)::FLOAT" float, sum decimal, stddev decimal, variance decimal, bool_and bool, bool_or bool, to_hex string)  ·
+ │                     render 0      (agg0)[int]                       ·                                                                                                                                                             ·
+ │                     render 1      (agg1)[int]                       ·                                                                                                                                                             ·
+ │                     render 2      (agg2)[int]                       ·                                                                                                                                                             ·
+ │                     render 3      (agg3)[int]                       ·                                                                                                                                                             ·
+ │                     render 4      ((agg4)[decimal]::FLOAT)[float]   ·                                                                                                                                                             ·
+ │                     render 5      (agg5)[decimal]                   ·                                                                                                                                                             ·
+ │                     render 6      (agg6)[decimal]                   ·                                                                                                                                                             ·
+ │                     render 7      (agg7)[decimal]                   ·                                                                                                                                                             ·
+ │                     render 8      (agg8)[bool]                      ·                                                                                                                                                             ·
+ │                     render 9      (agg9)[bool]                      ·                                                                                                                                                             ·
+ │                     render 10     (to_hex((agg10)[bytes]))[string]  ·                                                                                                                                                             ·
+ └── group             ·             ·                                 (agg0 int, agg1 int, agg2 int, agg3 int, agg4 decimal, agg5 decimal, agg6 decimal, agg7 decimal, agg8 bool, agg9 bool, agg10 bytes)                           ·
+      │                aggregate 0   min(column1)                      ·                                                                                                                                                             ·
+      │                aggregate 1   count(column1)                    ·                                                                                                                                                             ·
+      │                aggregate 2   max(column1)                      ·                                                                                                                                                             ·
+      │                aggregate 3   sum_int(column1)                  ·                                                                                                                                                             ·
+      │                aggregate 4   avg(column1)                      ·                                                                                                                                                             ·
+      │                aggregate 5   sum(column1)                      ·                                                                                                                                                             ·
+      │                aggregate 6   stddev(column1)                   ·                                                                                                                                                             ·
+      │                aggregate 7   variance(column1)                 ·                                                                                                                                                             ·
+      │                aggregate 8   bool_and(column11)                ·                                                                                                                                                             ·
+      │                aggregate 9   bool_or(column11)                 ·                                                                                                                                                             ·
+      │                aggregate 10  xor_agg(column14)                 ·                                                                                                                                                             ·
+      └── render       ·             ·                                 (column1 int, column11 bool, column14 bytes)                                                                                                                  ·
+           │           render 0      (1)[int]                          ·                                                                                                                                                             ·
+           │           render 1      (true)[bool]                      ·                                                                                                                                                             ·
+           │           render 2      ('\x01')[bytes]                   ·                                                                                                                                                             ·
+           └── values  ·             ·                                 ()                                                                                                                                                            ·
+·                      size          0 columns, 1 row                  ·                                                                                                                                                             ·
 
 exec hide-colnames nodist
-EXPLAIN (VERBOSE) SELECT COUNT(*), k FROM kv GROUP BY 2
+EXPLAIN (TYPES) SELECT COUNT(*), k FROM kv GROUP BY 2
 ----
-render          ·            ·             (count, k)  ·
- │              render 0     agg0          ·           ·
- │              render 1     k             ·           ·
- └── group      ·            ·             (k, agg0)   ·
-      │         aggregate 0  k             ·           ·
-      │         aggregate 1  count_rows()  ·           ·
-      │         group by     @1            ·           ·
-      └── scan  ·            ·             (k)         ·
-·               table        kv@primary    ·           ·
-·               spans        ALL           ·           ·
-
-# GROUP BY specified using column index works.
-exec rowsort
-SELECT COUNT(*), k FROM kv GROUP BY 2
-----
-count:int  k:int
-1          1
-1          3
-1          5
-1          6
-1          7
-1          8
-
-# Grouping by more than one column works.
-exec rowsort
-SELECT v, COUNT(*), w FROM kv GROUP BY v, w
-----
-v:int  count:int  w:int
-NULL   1          5
-2      1          2
-2      2          3
-4      1          2
-4      1          5
-
-# Grouping by more than one column using column numbers works.
-exec rowsort
-SELECT v, COUNT(*), w FROM kv GROUP BY 1, 3
-----
-v:int  count:int  w:int
-NULL   1          5
-2      1          2
-2      2          3
-4      1          2
-4      1          5
-
-# Selecting and grouping on a function expression works.
-exec rowsort
-SELECT COUNT(*), UPPER(s) FROM kv GROUP BY UPPER(s)
-----
-count:int  upper:string
-1          NULL
-2          B
-3          A
-
-# Selecting and grouping on a constant works.
-exec
-SELECT COUNT(*) FROM kv GROUP BY 1+2
-----
-count:int
-6
-
-exec
-SELECT COUNT(*) FROM kv GROUP BY length('abc')
-----
-count:int
-6
-
-# Selecting a function of something which is grouped works.
-exec rowsort
-SELECT COUNT(*), UPPER(s) FROM kv GROUP BY s
-----
-count:int  upper:string
-1          NULL
-1          A
-2          A
-2          B
+render          ·            ·             (count int, k int)  ·
+ │              render 0     (agg0)[int]   ·                   ·
+ │              render 1     (k)[int]      ·                   ·
+ └── group      ·            ·             (k int, agg0 int)   ·
+      │         aggregate 0  k             ·                   ·
+      │         aggregate 1  count_rows()  ·                   ·
+      │         group by     @1            ·                   ·
+      └── scan  ·            ·             (k int)             ·
+·               table        kv@primary    ·                   ·
+·               spans        ALL           ·                   ·
 
 # Selecting and grouping on a more complex expression works.
 exec hide-colnames nodist
-EXPLAIN (VERBOSE) SELECT COUNT(*), k+v FROM kv GROUP BY k+v
+EXPLAIN (TYPES) SELECT COUNT(*), k+v FROM kv GROUP BY k+v
 ----
-render               ·            ·             (count, "k + v")  ·
- │                   render 0     agg0          ·                 ·
- │                   render 1     column5       ·                 ·
- └── group           ·            ·             (column5, agg0)   ·
-      │              aggregate 0  column5       ·                 ·
-      │              aggregate 1  count_rows()  ·                 ·
-      │              group by     @1            ·                 ·
-      └── render     ·            ·             (column5)         ·
-           │         render 0     k + v         ·                 ·
-           └── scan  ·            ·             (k, v)            ·
-·                    table        kv@primary    ·                 ·
-·                    spans        ALL           ·                 ·
-
-exec rowsort
-SELECT COUNT(*), k+v FROM kv GROUP BY k+v
-----
-count:int  k + v:int
-1          NULL
-1          3
-1          7
-1          8
-1          9
-1          12
+render               ·            ·                           (count int, "k + v" int)  ·
+ │                   render 0     (agg0)[int]                 ·                         ·
+ │                   render 1     (column5)[int]              ·                         ·
+ └── group           ·            ·                           (column5 int, agg0 int)   ·
+      │              aggregate 0  column5                     ·                         ·
+      │              aggregate 1  count_rows()                ·                         ·
+      │              group by     @1                          ·                         ·
+      └── render     ·            ·                           (column5 int)             ·
+           │         render 0     ((k)[int] + (v)[int])[int]  ·                         ·
+           └── scan  ·            ·                           (k int, v int)            ·
+·                    table        kv@primary                  ·                         ·
+·                    spans        ALL                         ·                         ·
 
 # Selecting a more complex expression, made up of things which are each grouped, works.
 exec hide-colnames nodist
-EXPLAIN (VERBOSE) SELECT COUNT(*), k+v FROM kv GROUP BY k, v
+EXPLAIN (TYPES) SELECT COUNT(*), k+v FROM kv GROUP BY k, v
 ----
-render          ·            ·             (count, "k + v")  ·
- │              render 0     agg0          ·                 ·
- │              render 1     k + v         ·                 ·
- └── group      ·            ·             (k, v, agg0)      ·
-      │         aggregate 0  k             ·                 ·
-      │         aggregate 1  v             ·                 ·
-      │         aggregate 2  count_rows()  ·                 ·
-      │         group by     @1-@2         ·                 ·
-      └── scan  ·            ·             (k, v)            ·
-·               table        kv@primary    ·                 ·
-·               spans        ALL           ·                 ·
-
-exec rowsort
-SELECT COUNT(*), k+v FROM kv GROUP BY k, v
-----
-count:int  k + v:int
-1          NULL
-1          3
-1          7
-1          8
-1          9
-1          12
-
-# Test case from #2761.
-exec rowsort
-SELECT count(kv.k) AS count_1, kv.v + kv.w AS lx FROM kv GROUP BY kv.v + kv.w
-----
-count_1:int  lx:int
-1            NULL
-1            4
-1            6
-1            9
-2            5
-
-exec rowsort
-SELECT s, COUNT(*) FROM kv GROUP BY s HAVING COUNT(*) > 1
-----
-s:string  count:int
-a         2
-b         2
-
-#TODO(radu): DISTINCT not supported yet.
-#exec rowsort
-#SELECT UPPER(s), COUNT(DISTINCT s), COUNT(DISTINCT UPPER(s)) FROM kv GROUP BY UPPER(s) HAVING COUNT(DISTINCT s) > 1
-#----
-#column5:string  column6:int  column8:int
-#A               3            3
-#B               2            2
-
-exec rowsort
-SELECT MAX(k), MIN(v) FROM kv HAVING MIN(v) > 2
-----
-max:int  min:int
-
-exec rowsort
-SELECT MAX(k), MIN(v) FROM kv HAVING MAX(v) > 2
-----
-max:int  min:int
-8        2
-
-exec
-SELECT COUNT(*)
-----
-count:int
-1
-
-exec
-SELECT COUNT(k) FROM kv
-----
-count:int
-6
-
-exec
-SELECT COUNT(1)
-----
-count:int
-1
-
-exec
-SELECT COUNT(1) FROM kv
-----
-count:int
-6
-
-# TODO(radu): ORDER BY not implemented yet.
-#exec
-#SELECT v, COUNT(k) FROM kv GROUP BY v ORDER BY v
-#----
-#NULL 1
-#2 3
-#4 2
-#
-#exec
-#SELECT v, COUNT(k) FROM kv GROUP BY v ORDER BY v DESC
-#----
-#4 2
-#2 3
-#NULL 1
-#
-#exec
-#SELECT v, COUNT(k) FROM kv GROUP BY v ORDER BY COUNT(k) DESC
-#----
-#2 3
-#4 2
-#NULL 1
-#
-#exec
-#SELECT v, COUNT(k) FROM kv GROUP BY v ORDER BY v-COUNT(k)
-#----
-#NULL 1
-#2 3
-#4 2
-#
-#exec
-#SELECT v, COUNT(k) FROM kv GROUP BY v ORDER BY 1 DESC
-#----
-#4 2
-#2 3
-#NULL 1
-
-# TODO(radu): column names should be "count".
-exec
-SELECT COUNT(*), COUNT(k), COUNT(kv.v) FROM kv
-----
-count:int  count:int  count:int
-6          6          5
-
-# TODO(radu): this requires tuples but they are not yet supported in
-# distsql (#15938).
-exec nodist
-SELECT COUNT(kv.*) FROM kv
-----
-count:int
-6
-
-# TODO(radu): DISTINCT not supported yet.
-#exec
-#SELECT COUNT(DISTINCT k), COUNT(DISTINCT v), COUNT(DISTINCT (v)) FROM kv
-#----
-#6 2 2
-#
-#exec rowsort
-#SELECT UPPER(s), COUNT(DISTINCT k), COUNT(DISTINCT v), COUNT(DISTINCT (v)) FROM kv GROUP BY UPPER(s)
-#----
-#A    3 2 2
-#B    2 1 1
-#NULL 1 0 0
-#
-#
-
-# TODO(radu): these queries require tuples but they are not yet supported in
-# distsql (#15938).
-exec nodist
-SELECT COUNT((k, v)) FROM kv
-----
-count:int
-6
-
-# TODO(radu): DISTINCT not supported yet.
-#exec nodist
-#SELECT COUNT(DISTINCT (k, v)) FROM kv
-#----
-#column6:int
-#6
-
-#exec nodist
-#SELECT COUNT(DISTINCT (k, (v))) FROM kv
-#----
-#column6:int
-#6
-
-exec nodist
-SELECT COUNT((k, v)) FROM kv LIMIT 1
-----
-count:int
-6
-
-exec nodist
-SELECT COUNT((k, v)) FROM kv OFFSET 1
-----
-count:int
-
-exec
-SELECT COUNT(k)+COUNT(kv.v) FROM kv
-----
-count(k) + count(kv.v):int
-11
-
-exec nodist
-SELECT COUNT(NULL::int), COUNT((NULL, NULL))
-----
-count:int  count:int
-0          1
-
-exec
-SELECT MIN(k), MAX(k), MIN(v), MAX(v) FROM kv
-----
-min:int  max:int  min:int  max:int
-1        8        2        4
-
-# Even if no input rows match, we expect a row (of nulls).
-exec
-SELECT MIN(k), MAX(k), MIN(v), MAX(v) FROM kv WHERE k > 8
-----
-min:int  max:int  min:int  max:int
-NULL     NULL     NULL     NULL
-
-# TODO(justin): we don't yet respect the inner ORDER BY
-#exec
-#SELECT ARRAY_AGG(k), ARRAY_AGG(s) FROM (SELECT k, s FROM kv ORDER BY k)
-#----
-#column5:int[]       column6:string[]
-#ARRAY[1,3,5,6,7,8]  ARRAY['a','a',NULL,'b','b','A']
-
-exec
-SELECT array_agg(s) FROM kv WHERE s IS NULL
-----
-array_agg:string[]
-ARRAY[NULL]
-
-exec
-SELECT JSON_AGG(s) FROM kv WHERE s IS NULL
-----
-json_agg:jsonb
-'[null]'
-
-exec
-SELECT JSONB_AGG(s) FROM kv WHERE s IS NULL
-----
-jsonb_agg:jsonb
-'[null]'
-
-exec
-SELECT AVG(k), AVG(v), SUM(k), SUM(v) FROM kv
-----
-avg:decimal  avg:decimal  sum:decimal  sum:decimal
-5            2.8          30           14
-
-exec
-SELECT AVG(k::decimal), AVG(v::decimal), SUM(k::decimal), SUM(v::decimal) FROM kv
-----
-avg:decimal  avg:decimal  sum:decimal  sum:decimal
-5            2.8          30           14
-
-#exec
-#SELECT AVG(DISTINCT k), AVG(DISTINCT v), SUM(DISTINCT k), SUM(DISTINCT v) FROM kv
-#----
-#5 3 30 6
-
-exec
-SELECT AVG(k) * 2.0 + MAX(v)::DECIMAL FROM kv
-----
-(avg(k) * 2.0) + max(v)::DECIMAL:decimal
-14.0
-
-# Verify things work with distsql when some of the nodes emit no results in the
-# local stage.
-exec
-SELECT AVG(k) * 2.0 + MAX(v)::DECIMAL FROM kv WHERE w*2 = k
-----
-(avg(k) * 2.0) + max(v)::DECIMAL:decimal
-14.0
+render          ·            ·                           (count int, "k + v" int)  ·
+ │              render 0     (agg0)[int]                 ·                         ·
+ │              render 1     ((k)[int] + (v)[int])[int]  ·                         ·
+ └── group      ·            ·                           (k int, v int, agg0 int)  ·
+      │         aggregate 0  k                           ·                         ·
+      │         aggregate 1  v                           ·                         ·
+      │         aggregate 2  count_rows()                ·                         ·
+      │         group by     @1-@2                       ·                         ·
+      └── scan  ·            ·                           (k int, v int)            ·
+·               table        kv@primary                  ·                         ·
+·               spans        ALL                         ·                         ·
 
 exec hide-colnames nodist
-EXPLAIN (VERBOSE) SELECT COUNT(k) FROM kv
+EXPLAIN (TYPES) SELECT COUNT(k) FROM kv
 ----
-group      ·            ·           (count)  ·
- │         aggregate 0  count(k)    ·        ·
- └── scan  ·            ·           (k)      ·
-·          table        kv@primary  ·        ·
-·          spans        ALL         ·        ·
+group      ·            ·           (count int)  ·
+ │         aggregate 0  count(k)    ·            ·
+ └── scan  ·            ·           (k int)      ·
+·          table        kv@primary  ·            ·
+·          spans        ALL         ·            ·
 
 exec hide-colnames nodist
-EXPLAIN (VERBOSE) SELECT COUNT(k), SUM(k), MAX(k) FROM kv
+EXPLAIN (TYPES) SELECT COUNT(k), SUM(k), MAX(k) FROM kv
 ----
-group      ·            ·           (count, sum, max)  ·
- │         aggregate 0  count(k)    ·                  ·
- │         aggregate 1  sum(k)      ·                  ·
- │         aggregate 2  max(k)      ·                  ·
- └── scan  ·            ·           (k)                ·
-·          table        kv@primary  ·                  ·
-·          spans        ALL         ·                  ·
+group      ·            ·           (count int, sum decimal, max int)  ·
+ │         aggregate 0  count(k)    ·                                  ·
+ │         aggregate 1  sum(k)      ·                                  ·
+ │         aggregate 2  max(k)      ·                                  ·
+ └── scan  ·            ·           (k int)                            ·
+·          table        kv@primary  ·                                  ·
+·          spans        ALL         ·                                  ·
 
 exec-raw
 CREATE TABLE abc (
@@ -713,53 +179,14 @@ CREATE TABLE abc (
 )
 ----
 
-exec-raw
-INSERT INTO abc VALUES ('one', 1.5, true, 5::decimal), ('two', 2.0, false, 1.1::decimal)
-----
-
 exec hide-colnames nodist
-EXPLAIN (VERBOSE) SELECT MIN(a) FROM abc
+EXPLAIN (TYPES) SELECT MIN(a) FROM abc
 ----
-group      ·            ·            (min)  ·
- │         aggregate 0  min(a)       ·      ·
- └── scan  ·            ·            (a)    ·
-·          table        abc@primary  ·      ·
-·          spans        ALL          ·      ·
-
-exec
-SELECT MIN(a), MIN(b), MIN(c), MIN(d) FROM abc
-----
-min:string  min:float  min:bool  min:decimal
-one         1.5        false     1.1
-
-exec
-SELECT MAX(a), MAX(b), MAX(c), MAX(d) FROM abc
-----
-max:string  max:float  max:bool  max:decimal
-two         2.0        true      5
-
-exec
-SELECT AVG(b), SUM(b), AVG(d), SUM(d) FROM abc
-----
-avg:float  sum:float  avg:decimal  sum:decimal
-1.75       3.5        3.05         6.1
-
-# Verify summing of intervals
-exec-raw
-CREATE TABLE intervals (
-  a INTERVAL PRIMARY KEY
-)
-----
-
-exec-raw
-INSERT INTO intervals VALUES (INTERVAL '1 year 2 months 3 days 4 seconds'), (INTERVAL '2 year 3 months 4 days 5 seconds'), (INTERVAL '10000ms')
-----
-
-exec
-SELECT SUM(a) FROM intervals
-----
-sum:interval
-'3y5mon7d19s'
+group      ·            ·            (min string)  ·
+ │         aggregate 0  min(a)       ·             ·
+ └── scan  ·            ·            (a string)    ·
+·          table        abc@primary  ·             ·
+·          spans        ALL          ·             ·
 
 exec-raw
 CREATE TABLE xyz (
@@ -778,279 +205,122 @@ exec-raw
 INSERT INTO xyz VALUES (1, 2, 3.0), (4, 5, 6.0), (7, NULL, 8.0)
 ----
 
-exec
-SELECT MIN(x) FROM xyz
-----
-min:int
-1
-
 exec hide-colnames nodist
-EXPLAIN (VERBOSE) SELECT MIN(x) FROM xyz
+EXPLAIN (TYPES) SELECT MIN(x) FROM xyz
 ----
-group      ·            ·            (min)  ·
- │         aggregate 0  min(x)       ·      ·
- └── scan  ·            ·            (x)    ·
-·          table        xyz@primary  ·      ·
-·          spans        ALL          ·      ·
-
-exec
-SELECT MIN(x) FROM xyz WHERE x in (0, 4, 7)
-----
-min:int
-4
+group      ·            ·            (min int)  ·
+ │         aggregate 0  min(x)       ·          ·
+ └── scan  ·            ·            (x int)    ·
+·          table        xyz@primary  ·          ·
+·          spans        ALL          ·          ·
 
 # TODO(radu): we don't yet optimize this by scanning one entry from the xy index.
 exec hide-colnames nodist
-EXPLAIN (VERBOSE) SELECT MIN(x) FROM xyz WHERE x in (0, 4, 7)
+EXPLAIN (TYPES) SELECT MIN(x) FROM xyz WHERE x in (0, 4, 7)
 ----
-group      ·            ·                        (min)  ·
- │         aggregate 0  min(x)                   ·      ·
- └── scan  ·            ·                        (x)    ·
-·          table        xyz@primary              ·      ·
-·          spans        /0-/0/# /4-/4/# /7-/7/#  ·      ·
-
-exec
-SELECT MAX(x) FROM xyz
-----
-max:int
-7
+group      ·            ·                        (min int)  ·
+ │         aggregate 0  min(x)                   ·          ·
+ └── scan  ·            ·                        (x int)    ·
+·          table        xyz@primary              ·          ·
+·          spans        /0-/0/# /4-/4/# /7-/7/#  ·          ·
 
 # TODO(radu): we don't yet optimize MIN/MAX by scanning one entry from the xy index.
 exec hide-colnames nodist
-EXPLAIN (VERBOSE) SELECT MAX(x) FROM xyz
+EXPLAIN (TYPES) SELECT MAX(x) FROM xyz
 ----
-group      ·            ·            (max)  ·
- │         aggregate 0  max(x)       ·      ·
- └── scan  ·            ·            (x)    ·
-·          table        xyz@primary  ·      ·
-·          spans        ALL          ·      ·
-
-exec
-SELECT MIN(y) FROM xyz WHERE x = 1
-----
-min:int
-2
+group      ·            ·            (max int)  ·
+ │         aggregate 0  max(x)       ·          ·
+ └── scan  ·            ·            (x int)    ·
+·          table        xyz@primary  ·          ·
+·          spans        ALL          ·          ·
 
 exec hide-colnames nodist
-EXPLAIN (VERBOSE) SELECT MIN(y) FROM xyz WHERE x = 1
+EXPLAIN (TYPES) SELECT MIN(y) FROM xyz WHERE x = 1
 ----
-group      ·            ·            (min)   ·
- │         aggregate 0  min(y)       ·       ·
- └── scan  ·            ·            (x, y)  ·
-·          table        xyz@primary  ·       ·
-·          spans        /1-/1/#      ·       ·
-
-exec
-SELECT MAX(y) FROM xyz WHERE x = 1
-----
-max:int
-2
+group      ·            ·            (min int)       ·
+ │         aggregate 0  min(y)       ·               ·
+ └── scan  ·            ·            (x int, y int)  ·
+·          table        xyz@primary  ·               ·
+·          spans        /1-/1/#      ·               ·
 
 exec hide-colnames nodist
-EXPLAIN (VERBOSE) SELECT MAX(y) FROM xyz WHERE x = 1
+EXPLAIN (TYPES) SELECT MAX(y) FROM xyz WHERE x = 1
 ----
-group      ·            ·            (max)   ·
- │         aggregate 0  max(y)       ·       ·
- └── scan  ·            ·            (x, y)  ·
-·          table        xyz@primary  ·       ·
-·          spans        /1-/1/#      ·       ·
-
-exec
-SELECT MIN(y) FROM xyz WHERE x = 7
-----
-min:int
-NULL
+group      ·            ·            (max int)       ·
+ │         aggregate 0  max(y)       ·               ·
+ └── scan  ·            ·            (x int, y int)  ·
+·          table        xyz@primary  ·               ·
+·          spans        /1-/1/#      ·               ·
 
 exec hide-colnames nodist
-EXPLAIN (VERBOSE) SELECT MIN(y) FROM xyz WHERE x = 7
+EXPLAIN (TYPES) SELECT MIN(y) FROM xyz WHERE x = 7
 ----
-group      ·            ·            (min)   ·
- │         aggregate 0  min(y)       ·       ·
- └── scan  ·            ·            (x, y)  ·
-·          table        xyz@primary  ·       ·
-·          spans        /7-/7/#      ·       ·
-
-exec
-SELECT MAX(y) FROM xyz WHERE x = 7
-----
-max:int
-NULL
+group      ·            ·            (min int)       ·
+ │         aggregate 0  min(y)       ·               ·
+ └── scan  ·            ·            (x int, y int)  ·
+·          table        xyz@primary  ·               ·
+·          spans        /7-/7/#      ·               ·
 
 exec hide-colnames nodist
-EXPLAIN (VERBOSE) SELECT MAX(y) FROM xyz WHERE x = 7
+EXPLAIN (TYPES) SELECT MAX(y) FROM xyz WHERE x = 7
 ----
-group      ·            ·            (max)   ·
- │         aggregate 0  max(y)       ·       ·
- └── scan  ·            ·            (x, y)  ·
-·          table        xyz@primary  ·       ·
-·          spans        /7-/7/#      ·       ·
-
-exec
-SELECT MIN(x) FROM xyz WHERE (y, z) = (2, 3.0)
-----
-min:int
-1
+group      ·            ·            (max int)       ·
+ │         aggregate 0  max(y)       ·               ·
+ └── scan  ·            ·            (x int, y int)  ·
+·          table        xyz@primary  ·               ·
+·          spans        /7-/7/#      ·               ·
 
 exec hide-colnames nodist
-EXPLAIN (VERBOSE) SELECT MIN(x) FROM xyz WHERE (y, z) = (2, 3.0)
+EXPLAIN (TYPES) SELECT MIN(x) FROM xyz WHERE (y, z) = (2, 3.0)
 ----
-group      ·            ·          (min)      ·
- │         aggregate 0  min(x)     ·          ·
- └── scan  ·            ·          (x, y, z)  ·
-·          table        xyz@zyx    ·          ·
-·          spans        /3/2-/3/3  ·          ·
+group      ·            ·          (min int)                ·
+ │         aggregate 0  min(x)     ·                        ·
+ └── scan  ·            ·          (x int, y int, z float)  ·
+·          table        xyz@zyx    ·                        ·
+·          spans        /3/2-/3/3  ·                        ·
 
-exec
-SELECT MAX(x) FROM xyz WHERE (z, y) = (3.0, 2)
-----
-max:int
-1
+# TODO(radu): enable once we have SHOW TRACE support
+#query T
+#SELECT message FROM [SHOW KV TRACE FOR SELECT MIN(x) FROM xyz WHERE (y, z) = (2, 3.0)]
+# WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
+#----
+#fetched: /xyz/zyx/3.0/2/1 -> NULL
+#output row: [1]
 
 exec hide-colnames nodist
-EXPLAIN (VERBOSE) SELECT MAX(x) FROM xyz WHERE (z, y) = (3.0, 2)
+EXPLAIN (TYPES) SELECT MAX(x) FROM xyz WHERE (z, y) = (3.0, 2)
 ----
-group      ·            ·          (max)      ·
- │         aggregate 0  max(x)     ·          ·
- └── scan  ·            ·          (x, y, z)  ·
-·          table        xyz@zyx    ·          ·
-·          spans        /3/2-/3/3  ·          ·
+group      ·            ·          (max int)                ·
+ │         aggregate 0  max(x)     ·                        ·
+ └── scan  ·            ·          (x int, y int, z float)  ·
+·          table        xyz@zyx    ·                        ·
+·          spans        /3/2-/3/3  ·                        ·
 
 # VARIANCE/STDDEV
 
-exec
-SELECT VARIANCE(x), VARIANCE(y::decimal), round(VARIANCE(z), 14) FROM xyz
-----
-variance:decimal  variance:decimal  round:float
-9                 4.5               6.33333333333333
-
-exec
-SELECT VARIANCE(x) FROM xyz WHERE x = 10
-----
-variance:decimal
-NULL
-
-exec
-SELECT VARIANCE(x) FROM xyz WHERE x = 1
-----
-variance:decimal
-NULL
+# TODO(radu): enable once we have SHOW TRACE support
+#query T
+#SELECT message FROM [SHOW KV TRACE FOR SELECT VARIANCE(x), VARIANCE(y::decimal), round(VARIANCE(z), 14) FROM xyz]
+# WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
+#----
+#fetched: /xyz/primary/1 -> NULL
+#fetched: /xyz/primary/1/y -> 2
+#fetched: /xyz/primary/1/z -> 3.0
+#fetched: /xyz/primary/4 -> NULL
+#fetched: /xyz/primary/4/y -> 5
+#fetched: /xyz/primary/4/z -> 6.0
+#fetched: /xyz/primary/7 -> NULL
+#fetched: /xyz/primary/7/z -> 8.0
+#output row: [9 4.5 6.33333333333333]
 
 exec hide-colnames nodist
-EXPLAIN (VERBOSE) SELECT VARIANCE(x) FROM xyz WHERE x = 1
+EXPLAIN (TYPES) SELECT VARIANCE(x) FROM xyz WHERE x = 1
 ----
-group      ·            ·            (variance)  ·
- │         aggregate 0  variance(x)  ·           ·
- └── scan  ·            ·            (x)         ·
-·          table        xyz@primary  ·           ·
-·          spans        /1-/1/#      ·           ·
-
-exec
-SELECT STDDEV(x), STDDEV(y::decimal), round(STDDEV(z), 14) FROM xyz
-----
-stddev:decimal  stddev:decimal         round:float
-3               2.1213203435596425732  2.51661147842358
-
-exec
-SELECT STDDEV(x) FROM xyz WHERE x = 1
-----
-stddev:decimal
-NULL
-
-exec
-SELECT AVG(1::int)::float, AVG(2::float)::float, AVG(3::decimal)::float
-----
-avg(1::INT)::FLOAT:float  avg(2::FLOAT)::FLOAT:float  avg(3::DECIMAL)::FLOAT:float
-1.0                       2.0                         3.0
-
-exec
-SELECT COUNT(2::int), COUNT(3::float), COUNT(4::decimal)
-----
-count:int  count:int  count:int
-1          1          1
-
-exec
-SELECT SUM(1::int), SUM(2::float), SUM(3::decimal)
-----
-sum:decimal  sum:float  sum:decimal
-1            2.0        3
-
-exec
-SELECT VARIANCE(1::int), VARIANCE(1::float), VARIANCE(1::decimal)
-----
-variance:decimal  variance:float  variance:decimal
-NULL              NULL            NULL
-
-exec
-SELECT STDDEV(1::int), STDDEV(1::float), STDDEV(1::decimal)
-----
-stddev:decimal  stddev:float  stddev:decimal
-NULL            NULL          NULL
-
-# TODO(radu): subqueries not supported yet.
-## Ensure subqueries don't trigger aggregation.
-#exec
-#SELECT x > (SELECT avg(0)) FROM xyz LIMIT 1
-#----
-#true
-
-exec-raw
-CREATE TABLE bools (b BOOL)
-----
-
-exec
-SELECT BOOL_AND(b), BOOL_OR(b) FROM bools
-----
-bool_and:bool  bool_or:bool
-NULL           NULL
-
-exec-raw
-INSERT INTO bools VALUES (true), (true), (true)
-----
-
-exec
-SELECT BOOL_AND(b), BOOL_OR(b) FROM bools
-----
-bool_and:bool  bool_or:bool
-true           true
-
-exec-raw
-INSERT INTO bools VALUES (false), (false)
-----
-
-exec
-SELECT BOOL_AND(b), BOOL_OR(b) FROM bools
-----
-bool_and:bool  bool_or:bool
-false          true
-
-exec-raw
-DELETE FROM bools WHERE b
-----
-
-exec
-SELECT BOOL_AND(b), BOOL_OR(b) FROM bools
-----
-bool_and:bool  bool_or:bool
-false          false
-
-# TODO(justin): we don't yet respect the inner ORDER BY
-#exec
-#SELECT CONCAT_AGG(s) FROM (SELECT s FROM kv ORDER BY k)
-#----
-#column5:string
-#aabbA
-#
-#exec
-#SELECT JSON_AGG(s) FROM (SELECT s FROM kv ORDER BY k)
-#----
-#column5:jsonb
-#'["a", "a", null, "b", "b", "A"]'
-#
-#exec
-#SELECT JSONB_AGG(s) FROM (SELECT s FROM kv ORDER BY k)
-#----
-#column5:jsonb
-#'["a", "a", null, "b", "b", "A"]'
+group      ·            ·            (variance decimal)  ·
+ │         aggregate 0  variance(x)  ·                   ·
+ └── scan  ·            ·            (x int)             ·
+·          table        xyz@primary  ·                   ·
+·          spans        /1-/1/#      ·                   ·
 
 ## Tests for the single-row optimization.
 exec-raw
@@ -1114,53 +384,47 @@ INSERT INTO ab VALUES
 #fetched: /ab/primary/5 -> NULL
 #output row: [5]
 
-# TODO(radu): ORDER BY not supported yet.
-#exec hide-colnames nodist
-#EXPLAIN (VERBOSE) SELECT v, COUNT(k) FROM kv GROUP BY v ORDER BY COUNT(k)
-#----
-#sort                 ·            ·
-# │                   order        +count
-# └── group           ·            ·
-#      │              aggregate 0  v
-#      │              aggregate 1  count(k)
-#      │              group by     @1
-#      └── render     ·            ·
-#           │         render 0     v
-#           │         render 1     k
-#           └── scan  ·            ·
-#·                    table        kv@primary
-#·                    spans        ALL
-#
-#exec hide-colnames nodist
-#EXPLAIN (VERBOSE) #SELECT v, COUNT(*) FROM kv GROUP BY v ORDER BY COUNT(*)
-#----
-#sort                 ·            ·
-# │                   order        +count
-# └── group           ·            ·
-#      │              aggregate 0  v
-#      │              aggregate 1  count_rows()
-#      │              group by     @1
-#      └── render     ·            ·
-#           │         render 0     v
-#           └── scan  ·            ·
-#·                    table        kv@primary
-#·                    spans        ALL
-#
-#exec hide-colnames nodist
-#EXPLAIN (VERBOSE) SELECT v, COUNT(1) FROM kv GROUP BY v ORDER BY COUNT(1)
-#----
-#sort                 ·            ·
-# │                   order        +count
-# └── group           ·            ·
-#      │              aggregate 0  v
-#      │              aggregate 1  count(1)
-#      │              group by     @1
-#      └── render     ·            ·
-#           │         render 0     v
-#           │         render 1     1
-#           └── scan  ·            ·
-#·                    table        kv@primary
-#·                    spans        ALL
+exec hide-colnames nodist
+EXPLAIN (TYPES) SELECT v, COUNT(k) FROM kv GROUP BY v ORDER BY COUNT(k)
+----
+sort            ·            ·           (v int, count int)  +count
+ │              order        +count      ·                   ·
+ └── group      ·            ·           (v int, count int)  ·
+      │         aggregate 0  v           ·                   ·
+      │         aggregate 1  count(k)    ·                   ·
+      │         group by     @2          ·                   ·
+      └── scan  ·            ·           (k int, v int)      ·
+·               table        kv@primary  ·                   ·
+·               spans        ALL         ·                   ·
+
+exec hide-colnames nodist
+EXPLAIN (TYPES) SELECT v, COUNT(*) FROM kv GROUP BY v ORDER BY COUNT(*)
+----
+sort            ·            ·             (v int, count int)  +count
+ │              order        +count        ·                   ·
+ └── group      ·            ·             (v int, count int)  ·
+      │         aggregate 0  v             ·                   ·
+      │         aggregate 1  count_rows()  ·                   ·
+      │         group by     @1            ·                   ·
+      └── scan  ·            ·             (v int)             ·
+·               table        kv@primary    ·                   ·
+·               spans        ALL           ·                   ·
+
+exec hide-colnames nodist
+EXPLAIN (TYPES) SELECT v, COUNT(1) FROM kv GROUP BY v ORDER BY COUNT(1)
+----
+sort                 ·            ·               (v int, count int)         +count
+ │                   order        +count          ·                          ·
+ └── group           ·            ·               (v int, count int)         ·
+      │              aggregate 0  kv.v            ·                          ·
+      │              aggregate 1  count(column5)  ·                          ·
+      │              group by     @2              ·                          ·
+      └── render     ·            ·               (column5 int, "kv.v" int)  ·
+           │         render 0     (1)[int]        ·                          ·
+           │         render 1     (v)[int]        ·                          ·
+           └── scan  ·            ·               (v int)                    ·
+·                    table        kv@primary      ·                          ·
+·                    spans        ALL             ·                          ·
 
 # TODO(radu): we don't propagate filters yet.
 ## Check that filters propagate through no-op aggregation.
@@ -1189,34 +453,6 @@ INSERT INTO ab VALUES
 #  mark BOOL
 #)
 #----
-#
-#exec-raw
-#INSERT INTO filter_test VALUES
-#(1, 2, false),
-#(3, 4, true),
-#(5, NULL, true),
-#(6, 2, true),
-#(7, 2, true),
-#(8, 4, true),
-#(NULL, 4, true)
-#----
-#
-## FILTER should eliminate some results.
-#exec rowsort
-#SELECT v, COUNT(*) FILTER (WHERE k > 5) FROM filter_test GROUP BY v
-#----
-#2 2
-#4 1
-#NULL 0
-#
-## Test multiple filters
-#exec rowsort
-#SELECT v, mark, COUNT(*) FILTER (WHERE k > 5), COUNT(*), MAX(k) FILTER (WHERE k < 8) FROM filter_test GROUP BY v, mark
-#----
-#2 false 0 1 1
-#2 true 2 2 7
-#4 true 1 3 3
-#NULL true 0 1 5
 #
 ## Check that filter expressions are only rendered once.
 #exec nodist
@@ -1248,56 +484,35 @@ INSERT INTO ab VALUES
 
 # Tests with * inside GROUP BY.
 exec hide-colnames nodist
-EXPLAIN (VERBOSE) SELECT 1 FROM kv GROUP BY kv.*;
+EXPLAIN (TYPES) SELECT 1 FROM kv GROUP BY kv.*;
 ----
-render     ·         ·           ("1")  ·
- │         render 0  1           ·      ·
- └── scan  ·         ·           ()     ·
-·          table     kv@primary  ·      ·
-·          spans     ALL         ·      ·
-
-exec
-SELECT 1 FROM kv GROUP BY kv.*;
-----
-1:int
-1
-1
-1
-1
-1
-1
+render     ·         ·           ("1" int)  ·
+ │         render 0  (1)[int]    ·          ·
+ └── scan  ·         ·           ()         ·
+·          table     kv@primary  ·          ·
+·          spans     ALL         ·          ·
 
 exec hide-colnames nodist
-EXPLAIN (VERBOSE) SELECT SUM(abc.d) FROM kv JOIN abc ON kv.k >= abc.d GROUP BY kv.*;
+EXPLAIN (TYPES) SELECT SUM(abc.d) FROM kv JOIN abc ON kv.k >= abc.d GROUP BY kv.*;
 ----
-render               ·            ·            (sum)               ·
- │                   render 0     agg0         ·                   ·
- └── group           ·            ·            (k, v, w, s, agg0)  ·
-      │              aggregate 0  k            ·                   ·
-      │              aggregate 1  v            ·                   ·
-      │              aggregate 2  w            ·                   ·
-      │              aggregate 3  s            ·                   ·
-      │              aggregate 4  sum(d)       ·                   ·
-      │              group by     @1-@4        ·                   ·
-      └── join       ·            ·            (k, v, w, s, d)     ·
-           │         type         inner        ·                   ·
-           │         pred         k >= d       ·                   ·
-           ├── scan  ·            ·            (k, v, w, s)        ·
-           │         table        kv@primary   ·                   ·
-           │         spans        ALL          ·                   ·
-           └── scan  ·            ·            (d)                 ·
-·                    table        abc@primary  ·                   ·
-·                    spans        ALL          ·                   ·
-
-exec rowsort
-SELECT SUM(abc.d) FROM kv JOIN abc ON kv.k >= abc.d GROUP BY kv.*;
-----
-sum:decimal
-1.1
-6.1
-6.1
-6.1
-6.1
+render               ·            ·                                 (sum decimal)                                  ·
+ │                   render 0     (agg0)[decimal]                   ·                                              ·
+ └── group           ·            ·                                 (k int, v int, w int, s string, agg0 decimal)  ·
+      │              aggregate 0  k                                 ·                                              ·
+      │              aggregate 1  v                                 ·                                              ·
+      │              aggregate 2  w                                 ·                                              ·
+      │              aggregate 3  s                                 ·                                              ·
+      │              aggregate 4  sum(d)                            ·                                              ·
+      │              group by     @1-@4                             ·                                              ·
+      └── join       ·            ·                                 (k int, v int, w int, s string, d decimal)     ·
+           │         type         inner                             ·                                              ·
+           │         pred         ((k)[int] >= (d)[decimal])[bool]  ·                                              ·
+           ├── scan  ·            ·                                 (k int, v int, w int, s string)                ·
+           │         table        kv@primary                        ·                                              ·
+           │         spans        ALL                               ·                                              ·
+           └── scan  ·            ·                                 (d decimal)                                    ·
+·                    table        abc@primary                       ·                                              ·
+·                    spans        ALL                               ·                                              ·
 
 # TODO(radu): single-row optimization not yet supported.
 ## opt_test is used for tests around the single-row optimization for MIN/MAX.
@@ -1305,13 +520,9 @@ sum:decimal
 #CREATE TABLE opt_test (k INT PRIMARY KEY, v INT, INDEX v(v))
 #----
 #
-#exec-raw
-#INSERT INTO opt_test VALUES (1, NULL), (2, 10), (3, NULL), (4, 5)
-#----
-#
 ## Verify that we correctly add the v IS NOT NULL constraint (which restricts the span).
 #exec hide-colnames nodist
-#EXPLAIN (VERBOSE) SELECT MIN(v) FROM opt_test
+#EXPLAIN (TYPES) SELECT MIN(v) FROM opt_test
 #----
 #group           0  group   ·            ·                       (min)            ·
 # │              0  ·       aggregate 0  min(v)                  ·                ·
@@ -1322,21 +533,9 @@ sum:decimal
 #·               2  ·       spans        /!NULL-                 ·                ·
 #·               2  ·       limit        1                       ·                ·
 #
-## Without the "v IS NOT NULL" constraint, this result would incorrectly be NULL.
-#exec
-#SELECT MIN(v) FROM opt_test
-#----
-#5
-#
-## Cross-check against a query without this optimization.
-#exec
-#SELECT MIN(v) FROM opt_test@primary
-#----
-#5
-#
 ## Repeat test when there is an existing filter.
 #exec hide-colnames nodist
-#EXPLAIN (VERBOSE) SELECT MIN(v) FROM opt_test WHERE k <> 4
+#EXPLAIN (TYPES) SELECT MIN(v) FROM opt_test WHERE k <> 4
 #----
 #group           0  group   ·            ·                       (min)   ·
 # │              0  ·       aggregate 0  min(v)                  ·       ·
@@ -1347,16 +546,11 @@ sum:decimal
 #·               2  ·       spans        /!NULL-                 ·       ·
 #·               2  ·       filter       k != 4                  ·       ·
 #
-#exec
-#SELECT MIN(v) FROM opt_test WHERE k <> 4
-#----
-#10
-#
 ## Check the optimization when the argument is non-trivial. The renderNode can't
 ## present an ordering on v+1 so the optimization is not applied, but the IS NOT
 ## NULL filter should be added.
 #exec hide-colnames nodist
-#EXPLAIN (VERBOSE) SELECT MIN(v+1) FROM opt_test WHERE k <> 4
+#EXPLAIN (TYPES) SELECT MIN(v+1) FROM opt_test WHERE k <> 4
 #----
 #group           0  group   ·            ·                           (min)            ·
 # │              0  ·       aggregate 0  min(v + 1)                  ·                ·
@@ -1369,7 +563,7 @@ sum:decimal
 #
 ## Verify that we don't use the optimization if there is a GROUP BY.
 #exec hide-colnames nodist
-#EXPLAIN (VERBOSE) SELECT MIN(v) FROM opt_test GROUP BY k
+#EXPLAIN (TYPES) SELECT MIN(v) FROM opt_test GROUP BY k
 #----
 #group      0  group  ·            ·                 (min)   ·
 # │         0  ·      aggregate 0  min(v)            ·       ·
@@ -1377,109 +571,172 @@ sum:decimal
 # └── scan  1  scan   ·            ·                 (k, v)  k!=NULL; key(k)
 #·          1  ·      table        opt_test@primary  ·       ·
 #·          1  ·      spans        ALL               ·       ·
-#
-#exec rowsort
-#SELECT MIN(v) FROM opt_test GROUP BY k
-#----
-#NULL
-#NULL
-#5
-#10
-#
-#exec rowsort
-#SELECT MAX(v) FROM opt_test GROUP BY k
-#----
-#NULL
-#NULL
-#5
-#10
 
 exec-raw
-CREATE TABLE xor_bytes (a bytes, b int, c int)
-----
-
-exec-raw
-INSERT INTO xor_bytes VALUES
-  (b'\x01\x01', 1, 3),
-  (b'\x02\x01', 1, 1),
-  (b'\x04\x01', 2, -5),
-  (b'\x08\x01', 2, -1),
-  (b'\x10\x01', 2, 0)
-----
-
-exec
-SELECT TO_HEX(XOR_AGG(a)), XOR_AGG(c) FROM xor_bytes
-----
-to_hex:string  xor_agg:int
-1f01           6
-
-# TODO(radu): ORDER BY not supported.
-#exec
-#SELECT TO_HEX(XOR_AGG(a)), b, XOR_AGG(c) FROM xor_bytes GROUP BY b ORDER BY b
-#----
-#0300  1   2
-#1c01  2   4
-
-exec
-SELECT MAX(true), MIN(true)
-----
-max:bool  min:bool
-true      true
-
-exec-raw
-DELETE FROM ab;
-INSERT INTO ab(a,b) VALUES (1,2), (3,4);
 CREATE TABLE xy(x STRING, y STRING);
-INSERT INTO xy(x, y) VALUES ('a', 'b'), ('c', 'd')
 ----
-
-# Grouping and rendering tuples.
-exec rowsort nodist
-SELECT (b, a) FROM ab GROUP BY (b, a)
-----
-(b, a):tuple{int, int}
-(2, 1)
-(4, 3)
 
 # TODO(radu): this requires tuples but they are not yet supported in
 # distsql (#15938).
 exec hide-colnames nodist
-EXPLAIN (VERBOSE) SELECT (b, a) FROM ab GROUP BY (b, a)
+EXPLAIN (TYPES) SELECT (b, a) FROM ab GROUP BY (b, a)
 ----
-render     ·         ·           ("(b, a)")  ·
- │         render 0  (b, a)      ·           ·
- └── scan  ·         ·           (a, b)      ·
-·          table     ab@primary  ·           ·
-·          spans     ALL         ·           ·
-
-# TODO(radu): this requires tuples but they are not yet supported in
-# distsql (#15938).
-exec rowsort nodist
-SELECT MIN(y), (b, a) FROM ab, xy GROUP BY (x, (a, b))
-----
-min:string  (b, a):tuple{int, int}
-b           (2, 1)
-b           (4, 3)
-d           (2, 1)
-d           (4, 3)
+render     ·         ·                                        ("(b, a)" tuple{int, int})  ·
+ │         render 0  (((b)[int], (a)[int]))[tuple{int, int}]  ·                           ·
+ └── scan  ·         ·                                        (a int, b int)              ·
+·          table     ab@primary                               ·                           ·
+·          spans     ALL                                      ·                           ·
 
 exec hide-colnames nodist
-EXPLAIN (VERBOSE) SELECT MIN(y), (b, a) FROM ab, xy GROUP BY (x, (a, b))
+EXPLAIN (TYPES) SELECT MIN(y), (b, a) FROM ab, xy GROUP BY (x, (a, b))
 ----
-render               ·            ·           (min, "(b, a)")  ·
- │                   render 0     agg0        ·                ·
- │                   render 1     (b, a)      ·                ·
- └── group           ·            ·           (a, b, x, agg0)  ·
-      │              aggregate 0  a           ·                ·
-      │              aggregate 1  b           ·                ·
-      │              aggregate 2  x           ·                ·
-      │              aggregate 3  min(y)      ·                ·
-      │              group by     @1-@3       ·                ·
-      └── join       ·            ·           (a, b, x, y)     ·
-           │         type         cross       ·                ·
-           ├── scan  ·            ·           (a, b)           ·
-           │         table        ab@primary  ·                ·
-           │         spans        ALL         ·                ·
-           └── scan  ·            ·           (x, y)           ·
-·                    table        xy@primary  ·                ·
-·                    spans        ALL         ·                ·
+render               ·            ·                                        (min string, "(b, a)" tuple{int, int})  ·
+ │                   render 0     (agg0)[string]                           ·                                       ·
+ │                   render 1     (((b)[int], (a)[int]))[tuple{int, int}]  ·                                       ·
+ └── group           ·            ·                                        (a int, b int, x string, agg0 string)   ·
+      │              aggregate 0  a                                        ·                                       ·
+      │              aggregate 1  b                                        ·                                       ·
+      │              aggregate 2  x                                        ·                                       ·
+      │              aggregate 3  min(y)                                   ·                                       ·
+      │              group by     @1-@3                                    ·                                       ·
+      └── join       ·            ·                                        (a int, b int, x string, y string)      ·
+           │         type         cross                                    ·                                       ·
+           ├── scan  ·            ·                                        (a int, b int)                          ·
+           │         table        ab@primary                               ·                                       ·
+           │         spans        ALL                                      ·                                       ·
+           └── scan  ·            ·                                        (x string, y string)                    ·
+·                    table        xy@primary                               ·                                       ·
+·                    spans        ALL                                      ·                                       ·
+
+# Test that ordering on GROUP BY columns is maintained.
+# TODO(radu): Derive GROUP BY ordering in physicalPropsBuilder.
+#exec-raw
+#CREATE TABLE group_ord (
+#  x INT PRIMARY KEY,
+#  y INT,
+#  z INT,
+#  INDEX foo(z)
+#)
+#----
+#
+## The ordering is on all the GROUP BY columns, and isn't preserved after the
+## aggregation.
+#exec hide-colnames nodist
+#EXPLAIN (TYPES) SELECT x, max(y) FROM group_ord GROUP BY x
+#----
+#group      ·            ·                  (x, max)  ·
+# │         aggregate 0  x                  ·         ·
+# │         aggregate 1  max(y)             ·         ·
+# │         group by     @1                 ·         ·
+# └── scan  ·            ·                  (x, y)    ·
+#·          table        group_ord@primary  ·         ·
+#·          spans        ALL                ·         ·
+#
+## The ordering is on all the GROUP BY columns, and is preserved after the
+## aggregation.
+#exec hide-colnames nodist
+#EXPLAIN (TYPES) SELECT x, max(y) FROM group_ord GROUP BY x ORDER BY x
+#----
+#sort            ·            ·                  (x, max)  +x
+# │              order        +x                 ·         ·
+# └── group      ·            ·                  (x, max)  ·
+#      │         aggregate 0  x                  ·         ·
+#      │         aggregate 1  max(y)             ·         ·
+#      │         group by     @1                 ·         ·
+#      └── scan  ·            ·                  (x, y)    ·
+#·               table        group_ord@primary  ·         ·
+#·               spans        ALL                ·         ·
+#
+## The ordering is on some of the GROUP BY columns, and isn't preserved after
+## the aggregation.
+#exec hide-colnames nodist
+#EXPLAIN (TYPES) SELECT z, x, max(y) FROM group_ord GROUP BY x, z
+#----
+#render          ·            ·                  (z, x, max)   ·
+# │              render 0     z                  ·             ·
+# │              render 1     x                  ·             ·
+# │              render 2     agg0               ·             ·
+# └── group      ·            ·                  (x, z, agg0)  ·
+#      │         aggregate 0  x                  ·             ·
+#      │         aggregate 1  z                  ·             ·
+#      │         aggregate 2  max(y)             ·             ·
+#      │         group by     @1,@3              ·             ·
+#      └── scan  ·            ·                  (x, y, z)     ·
+#·               table        group_ord@primary  ·             ·
+#·               spans        ALL                ·             ·
+#
+## The ordering is on some of the GROUP BY columns, and is preserved after
+## the aggregation.
+#exec hide-colnames nodist
+#EXPLAIN (TYPES) SELECT z, x, max(y) FROM group_ord GROUP BY x, z ORDER BY x
+#----
+#render               ·            ·                  (z, x, max)   ·
+# │                   render 0     z                  ·             ·
+# │                   render 1     x                  ·             ·
+# │                   render 2     agg0               ·             ·
+# └── sort            ·            ·                  (x, z, agg0)  +x
+#      │              order        +x                 ·             ·
+#      └── group      ·            ·                  (x, z, agg0)  ·
+#           │         aggregate 0  x                  ·             ·
+#           │         aggregate 1  z                  ·             ·
+#           │         aggregate 2  max(y)             ·             ·
+#           │         group by     @1,@3              ·             ·
+#           └── scan  ·            ·                  (x, y, z)     ·
+#·                    table        group_ord@primary  ·             ·
+#·                    spans        ALL                ·             ·
+#
+## If the underlying ordering isn't from the primary index, it needs to be hinted
+## for now.
+#exec hide-colnames nodist
+#EXPLAIN (TYPES) SELECT z, max(y) FROM group_ord@foo GROUP BY z
+#----
+#group      ·            ·                  (z, max)  ·
+# │         aggregate 0  z                  ·         ·
+# │         aggregate 1  max(y)             ·         ·
+# │         group by     @2                 ·         ·
+# └── scan  ·            ·                  (y, z)    ·
+#·          table        group_ord@primary  ·         ·
+#·          spans        ALL                ·         ·
+#
+## Test that a merge join is used on two aggregate subqueries with orderings on
+## the GROUP BY columns. Note that an ORDER BY is not necessary on the
+## subqueries.
+#exec hide-colnames nodist
+#EXPLAIN (TYPES) SELECT * FROM (SELECT x, max(y) FROM group_ord GROUP BY x) JOIN (SELECT z, min(y) FROM group_ord@foo GROUP BY z) ON x = z
+#----
+#join            ·            ·                  (x, max, z, min)  ·
+# │              type         inner              ·                 ·
+# │              equality     (x) = (z)          ·                 ·
+# ├── group      ·            ·                  (x, agg0)         ·
+# │    │         aggregate 0  x                  ·                 ·
+# │    │         aggregate 1  max(y)             ·                 ·
+# │    │         group by     @1                 ·                 ·
+# │    └── scan  ·            ·                  (x, y)            ·
+# │              table        group_ord@primary  ·                 ·
+# │              spans        ALL                ·                 ·
+# └── group      ·            ·                  (z, agg0)         ·
+#      │         aggregate 0  z                  ·                 ·
+#      │         aggregate 1  min(y)             ·                 ·
+#      │         group by     @2                 ·                 ·
+#      └── scan  ·            ·                  (y, z)            ·
+#·               table        group_ord@primary  ·                 ·
+#·               spans        ALL                ·                 ·
+
+# Regression test for #25533 (crash when propagating filter through GROUP BY).
+exec hide-colnames nodist
+EXPLAIN (TYPES) SELECT 1 FROM kv GROUP BY v, w::DECIMAL HAVING w::DECIMAL > 1;
+----
+render                    ·            ·                                          ("1" int)                      ·
+ │                        render 0     (1)[int]                                   ·                              ·
+ └── group                ·            ·                                          ("kv.v" int, column5 decimal)  ·
+      │                   aggregate 0  kv.v                                       ·                              ·
+      │                   aggregate 1  column5                                    ·                              ·
+      │                   group by     @2,@1                                      ·                              ·
+      └── filter          ·            ·                                          (column5 decimal, "kv.v" int)  ·
+           │              filter       ((column5)[decimal] > (1)[decimal])[bool]  ·                              ·
+           └── render     ·            ·                                          (column5 decimal, "kv.v" int)  ·
+                │         render 0     ((w)[int]::DECIMAL)[decimal]               ·                              ·
+                │         render 1     (v)[int]                                   ·                              ·
+                └── scan  ·            ·                                          (v int, w int)                 ·
+·                         table        kv@primary                                 ·                              ·
+·                         spans        ALL                                        ·                              ·

--- a/pkg/sql/opt/optbuilder/scalar.go
+++ b/pkg/sql/opt/optbuilder/scalar.go
@@ -126,7 +126,7 @@ func (b *Builder) buildScalarHelper(
 			// groupStrs checking code above.
 			panic(errorf(
 				"column \"%s\" must appear in the GROUP BY clause or be used in an aggregate function",
-				t.String(),
+				tree.ErrString(&t.name),
 			))
 		}
 		return b.finishBuildScalarRef(t, label, inScope, outScope)

--- a/pkg/sql/opt/optbuilder/select.go
+++ b/pkg/sql/opt/optbuilder/select.go
@@ -15,8 +15,11 @@
 package optbuilder
 
 import (
+	"fmt"
+
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
 )
@@ -74,7 +77,10 @@ func (b *Builder) buildTable(texpr tree.TableExpr, inScope *scope) (outScope *sc
 		return outScope
 
 	default:
-		panic(errorf("not yet implemented: table expr: %T", texpr))
+		panic(builderError{pgerror.Unimplemented(
+			"table expr",
+			fmt.Sprintf("not yet implemented: table expr: %T", texpr),
+		)})
 	}
 }
 

--- a/pkg/sql/opt/optbuilder/testdata/aggregate
+++ b/pkg/sql/opt/optbuilder/testdata/aggregate
@@ -273,7 +273,7 @@ project
 build
 SELECT COUNT(*), k FROM kv
 ----
-error: column "kv.k" must appear in the GROUP BY clause or be used in an aggregate function
+error: column "k" must appear in the GROUP BY clause or be used in an aggregate function
 
 build
 SELECT COUNT(*) FROM kv GROUP BY s < 5
@@ -522,7 +522,7 @@ project
 build
 SELECT COUNT(*), s FROM kv GROUP BY UPPER(s)
 ----
-error: column "kv.s" must appear in the GROUP BY clause or be used in an aggregate function
+error: column "s" must appear in the GROUP BY clause or be used in an aggregate function
 
 # Selecting and grouping on a more complex expression works.
 build
@@ -570,17 +570,17 @@ project
 build
 SELECT COUNT(*), k+v FROM kv GROUP BY k
 ----
-error: column "kv.v" must appear in the GROUP BY clause or be used in an aggregate function
+error: column "v" must appear in the GROUP BY clause or be used in an aggregate function
 
 build
 SELECT COUNT(*), k+v FROM kv GROUP BY v
 ----
-error: column "kv.k" must appear in the GROUP BY clause or be used in an aggregate function
+error: column "k" must appear in the GROUP BY clause or be used in an aggregate function
 
 build
 SELECT COUNT(*), v/(k+v) FROM kv GROUP BY k+v
 ----
-error: column "kv.v" must appear in the GROUP BY clause or be used in an aggregate function
+error: column "v" must appear in the GROUP BY clause or be used in an aggregate function
 
 build
 SELECT k FROM kv WHERE AVG(k) > 1
@@ -2022,7 +2022,7 @@ project
 build
 SELECT b1.b AND abc.c AND abc.c FROM bools b1, bools b2, abc GROUP BY b1.b AND abc.c, b2.b
 ----
-error: column "abc.c" must appear in the GROUP BY clause or be used in an aggregate function
+error: column "c" must appear in the GROUP BY clause or be used in an aggregate function
 
 build
 SELECT b1.b OR abc.c OR b2.b FROM bools b1, bools b2, abc GROUP BY b1.b OR abc.c, b2.b
@@ -2058,7 +2058,7 @@ project
 build
 SELECT b1.b OR abc.c OR abc.c FROM bools b1, bools b2, abc GROUP BY b1.b OR abc.c, b2.b
 ----
-error: column "abc.c" must appear in the GROUP BY clause or be used in an aggregate function
+error: column "c" must appear in the GROUP BY clause or be used in an aggregate function
 
 build
 SELECT k % w % v FROM kv GROUP BY k % w, v
@@ -2110,7 +2110,7 @@ project
 build
 SELECT CONCAT(CONCAT(s, a), s) FROM kv, abc GROUP BY CONCAT(s, a), a
 ----
-error: column "kv.s" must appear in the GROUP BY clause or be used in an aggregate function
+error: column "s" must appear in the GROUP BY clause or be used in an aggregate function
 
 build
 SELECT k < w AND v != 5 FROM kv GROUP BY k < w, v
@@ -2138,7 +2138,7 @@ project
 build
 SELECT k < w AND k < v FROM kv GROUP BY k < w, v
 ----
-error: column "kv.k" must appear in the GROUP BY clause or be used in an aggregate function
+error: column "k" must appear in the GROUP BY clause or be used in an aggregate function
 
 exec-ddl
 CREATE TABLE foo (bar JSON, baz JSON)
@@ -2181,7 +2181,7 @@ project
 build
 SELECT a.bar @> b.baz AND b.baz @> b.baz FROM foo AS a, foo AS b GROUP BY b.baz <@ a.bar, b.baz
 ----
-error: column "a.bar" must appear in the GROUP BY clause or be used in an aggregate function
+error: column "bar" must appear in the GROUP BY clause or be used in an aggregate function
 
 build
 SELECT b.baz <@ a.bar AND b.baz <@ b.baz FROM foo AS a, foo AS b GROUP BY b.baz <@ a.bar, b.baz
@@ -2253,7 +2253,7 @@ build
 SELECT date_trunc('second', a.t) - date_trunc('second', b.t) FROM times a, times b
   GROUP BY date_trunc('second', a.t), date_trunc('minute', b.t)
 ----
-error: column "b.t" must appear in the GROUP BY clause or be used in an aggregate function
+error: column "t" must appear in the GROUP BY clause or be used in an aggregate function
 
 build
 SELECT NOT b FROM bools GROUP BY NOT b
@@ -2272,7 +2272,7 @@ group-by
 build
 SELECT b FROM bools GROUP BY NOT b
 ----
-error: column "bools.b" must appear in the GROUP BY clause or be used in an aggregate function
+error: column "b" must appear in the GROUP BY clause or be used in an aggregate function
 
 build
 SELECT NOT b FROM bools GROUP BY b
@@ -2314,7 +2314,7 @@ project
 build
 SELECT k * (-w) FROM kv GROUP BY +k, -w
 ----
-error: column "kv.k" must appear in the GROUP BY clause or be used in an aggregate function
+error: column "k" must appear in the GROUP BY clause or be used in an aggregate function
 
 build
 SELECT +k * (-w) FROM kv GROUP BY k, w

--- a/pkg/sql/opt/optbuilder/testdata/having
+++ b/pkg/sql/opt/optbuilder/testdata/having
@@ -113,19 +113,19 @@ error (42804): argument of HAVING must be type bool, not type int
 build
 SELECT 3 FROM kv GROUP BY v HAVING k > 5
 ----
-error: column "kv.k" must appear in the GROUP BY clause or be used in an aggregate function
+error: column "k" must appear in the GROUP BY clause or be used in an aggregate function
 
 # pg has a special case for grouping on primary key, which would allow this, but we do not.
 # See http://www.postgresql.org/docs/current/static/sql-select.html#SQL-GROUPBY
 build
 SELECT 3 FROM kv GROUP BY k HAVING v > 2
 ----
-error: column "kv.v" must appear in the GROUP BY clause or be used in an aggregate function
+error: column "v" must appear in the GROUP BY clause or be used in an aggregate function
 
 build
 SELECT k FROM kv HAVING k > 7
 ----
-error: column "kv.k" must appear in the GROUP BY clause or be used in an aggregate function
+error: column "k" must appear in the GROUP BY clause or be used in an aggregate function
 
 build
 SELECT count(*), k+w FROM kv GROUP BY k+w HAVING (k+w) > 5
@@ -155,7 +155,7 @@ project
 build
 SELECT count(*), k+w FROM kv GROUP BY k+w HAVING (k+v) > 5
 ----
-error: column "kv.k" must appear in the GROUP BY clause or be used in an aggregate function
+error: column "k" must appear in the GROUP BY clause or be used in an aggregate function
 
 # Check that everything still works with differently qualified names
 build
@@ -259,7 +259,7 @@ project
 build fully-qualify-names
 SELECT t.kv.v FROM t.kv GROUP BY v, kv.k * w HAVING w > 5
 ----
-error: column "t.public.kv.w" must appear in the GROUP BY clause or be used in an aggregate function
+error: column "w" must appear in the GROUP BY clause or be used in an aggregate function
 
 build fully-qualify-names
 SELECT UPPER(s), COUNT(s), COUNT(UPPER(s)) FROM t.kv GROUP BY UPPER(s) HAVING COUNT(s) > 1

--- a/pkg/sql/opt/optbuilder/testdata/orderby
+++ b/pkg/sql/opt/optbuilder/testdata/orderby
@@ -402,37 +402,37 @@ error (42P01): no data source matches prefix: a
 build
 SELECT GENERATE_SERIES FROM GENERATE_SERIES(1, 100) ORDER BY ARRAY[GENERATE_SERIES]
 ----
-error: not yet implemented: table expr: *tree.FuncExpr
+error (0A000): not yet implemented: table expr: *tree.FuncExpr
 
 build
 SELECT ARRAY[GENERATE_SERIES] FROM GENERATE_SERIES(1, 100) ORDER BY ARRAY[GENERATE_SERIES]
 ----
-error: not yet implemented: table expr: *tree.FuncExpr
+error (0A000): not yet implemented: table expr: *tree.FuncExpr
 
 build
 SELECT ARRAY[GENERATE_SERIES] FROM GENERATE_SERIES(1, 100) ORDER BY 1
 ----
-error: not yet implemented: table expr: *tree.FuncExpr
+error (0A000): not yet implemented: table expr: *tree.FuncExpr
 
 build
 SELECT ARRAY[GENERATE_SERIES] AS a FROM GENERATE_SERIES(1, 100) ORDER BY a
 ----
-error: not yet implemented: table expr: *tree.FuncExpr
+error (0A000): not yet implemented: table expr: *tree.FuncExpr
 
 build
 SELECT GENERATE_SERIES, ARRAY[GENERATE_SERIES] FROM GENERATE_SERIES(1, 1) ORDER BY 1
 ----
-error: not yet implemented: table expr: *tree.FuncExpr
+error (0A000): not yet implemented: table expr: *tree.FuncExpr
 
 build
 SELECT GENERATE_SERIES, ARRAY[GENERATE_SERIES] FROM GENERATE_SERIES(1, 1) ORDER BY GENERATE_SERIES
 ----
-error: not yet implemented: table expr: *tree.FuncExpr
+error (0A000): not yet implemented: table expr: *tree.FuncExpr
 
 build
 SELECT GENERATE_SERIES, ARRAY[GENERATE_SERIES] FROM GENERATE_SERIES(1, 1) ORDER BY -GENERATE_SERIES
 ----
-error: not yet implemented: table expr: *tree.FuncExpr
+error (0A000): not yet implemented: table expr: *tree.FuncExpr
 
 
 # Sort should be skipped if the ORDER BY clause is constant.


### PR DESCRIPTION
This commit splits the aggregate logic test into multiple parts:

  logic_test/aggregate
    This part excludes EXPLAIN and SHOW TRACE queries, since their output
    only applies to the heuristic planner. These queries often fail with the
    cost-based optimizer, which often uses a different execution plan. With
    the EXPLAIN and SHOW TRACE queries removed, this test can now be
    successfully run using the cost-based optimizer ("opt" config).

  planner_test/aggregate
    This part includes all the EXPLAIN and SHOW TRACE queries that were
    removed from the original logic_test. The expected output is the same
    as it originally was; namely the plans that the heuristic planner
    derives.

  opt/exec/execbuilder
    This part is analogous to the planner_test part, except that the EXPLAIN
    and SHOW TRACE queries run with the cost-based optimizer. Most of these
    tests had already been copied to the `opt` packages, so this commit just
    copies a few additional tests that never made it over, as well as delete
    redundant tests that are already part of the logic_test suite.

There are still 150+ other tests to split. This commit serves as the template
for how that will be done. Once the larger team is happy with the methodology,
we'll begin the work of migrating the other tests.

With this change, while we do lose the convenience of having execution output
paired with EXPLAIN/TRACE output, we gain the ability to run the same set of
logic tests against a wider variety of configurations. By doing so, we stick
more closely to the spirit of the original SQLite sqllogictest methodology.

Release note: None