### PR TITLE
cmd/roachtest: add testSpec.MinVersion

### DIFF
--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -53,6 +53,7 @@ var (
 	cockroach   string
 	workload    string
 	roachprod   string
+	buildTag    string
 	clusterName string
 	clusterID   string
 	clusterWipe bool

--- a/pkg/cmd/roachtest/main.go
+++ b/pkg/cmd/roachtest/main.go
@@ -63,6 +63,13 @@ Use 'roachtest run -n' to see a list of all tests.
 				return fmt.Errorf("--count (%d) must by greater than 0", count)
 			}
 			r := newRegistry()
+			if buildTag != "" {
+				if err := r.setBuildVersion(buildTag); err != nil {
+					return err
+				}
+			} else {
+				r.loadBuildVersion()
+			}
 			registerTests(r)
 			os.Exit(r.Run(args))
 			return nil
@@ -81,6 +88,8 @@ Use 'roachtest run -n' to see a list of all tests.
 		&parallelism, "parallelism", "p", parallelism, "number of tests to run in parallel")
 	runCmd.Flags().StringVar(
 		&artifacts, "artifacts", "artifacts", "path to artifacts directory")
+	runCmd.Flags().StringVar(
+		&buildTag, "build-tag", "", "build tag (auto-detect if empty)")
 	runCmd.Flags().StringVar(
 		&clusterID, "cluster-id", "", "an identifier to use in the test cluster's name")
 	runCmd.Flags().BoolVar(

--- a/pkg/cmd/roachtest/upgrade.go
+++ b/pkg/cmd/roachtest/upgrade.go
@@ -248,8 +248,9 @@ func registerUpgrade(r *registry) {
 	const oldVersion = "v2.0.0"
 	for _, n := range []int{5} {
 		r.Add(testSpec{
-			Name:  fmt.Sprintf("upgrade/oldVersion=%s/nodes=%d", oldVersion, n),
-			Nodes: nodes(n),
+			Name:       fmt.Sprintf("upgrade/oldVersion=%s/nodes=%d", oldVersion, n),
+			MinVersion: "v2.1.0",
+			Nodes:      nodes(n),
 			Run: func(ctx context.Context, t *test, c *cluster) {
 				runUpgrade(ctx, t, c, oldVersion)
 			},

--- a/pkg/cmd/roachtest/version.go
+++ b/pkg/cmd/roachtest/version.go
@@ -236,9 +236,10 @@ func registerVersion(r *registry) {
 	const version = "v2.0.0"
 	for _, n := range []int{3, 5} {
 		r.Add(testSpec{
-			Name:   fmt.Sprintf("version/mixedWith=%s/nodes=%d", version, n),
-			Nodes:  nodes(n + 1),
-			Stable: true, // DO NOT COPY to new tests
+			Name:       fmt.Sprintf("version/mixedWith=%s/nodes=%d", version, n),
+			MinVersion: "v2.1.0",
+			Nodes:      nodes(n + 1),
+			Stable:     true, // DO NOT COPY to new tests
 			Run: func(ctx context.Context, t *test, c *cluster) {
 				runVersion(ctx, t, c, version)
 			},


### PR DESCRIPTION
Allow tests to specify the minimum cockroach version they require to
run. If the build version (auto-detected using git) is less than the min
version specified for the test, the test is skipped. For example, if
`upgrade/oldVersion=v2.0.0` (which has a min version of `v2.1.0`) is run
on the `release-2.0` branch we see:

    === RUN   upgrade/oldVersion=v2.0.0/nodes=5 [unstable,skip]
    --- SKIP: upgrade/oldVersion=v2.0.0/nodes=5 (0.00s)
        build-version (2.0.2) < min-version (2.1.0-0)

Fixes #25740

Release note: None