### PR TITLE
github: map pkg/server to new server-prs list, not admin-ui

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -13,7 +13,7 @@
 /pkg/kv/                     @cockroachdb/core-prs
 /pkg/roachpb/                @cockroachdb/core-prs
 /pkg/rpc/                    @cockroachdb/core-prs
-/pkg/server/                 @cockroachdb/core-prs @cockroachdb/admin-ui-prs
+/pkg/server/                 @cockroachdb/core-prs @cockroachdb/server-prs
 /pkg/storage/                @cockroachdb/core-prs
 /pkg/migration/              @cockroachdb/core-prs
 /pkg/sqlmigrations           @cockroachdb/core-prs @cockroachdb/sql-wiring-prs


### PR DESCRIPTION
@couchand mapped /pkg/server to admin-ui-prs in an attempt to get it
more attention and love, but it ended up spamming others who just want
to be aware of UI changes, like Amruta. Splitting it out allows more
control over what you are subscribed to.

Not sure if I also have to create this in the github UI somewhere.

Release note: None