### PR TITLE
distsql: add batching for secondary lookup joins

### DIFF
--- a/pkg/sql/distsqlrun/joinreader_test.go
+++ b/pkg/sql/distsqlrun/joinreader_test.go
@@ -228,6 +228,9 @@ func TestJoinReader(t *testing.T) {
 				t.Fatal(err)
 			}
 
+			// Set a lower batch size to force multiple batches.
+			jr.batchSize = 2
+
 			jr.Run(context.Background(), nil /* wg */)
 
 			if !in.Done {
@@ -342,6 +345,10 @@ INSERT INTO test.t VALUES
 			if err != nil {
 				t.Fatal(err)
 			}
+
+			// Set a lower batch size to force multiple batches.
+			jr.batchSize = 2
+
 			jr.Run(context.Background(), nil /* wg */)
 
 			// Check results.

--- a/pkg/sql/distsqlrun/server.go
+++ b/pkg/sql/distsqlrun/server.go
@@ -74,7 +74,7 @@ type DistSQLVersion uint32
 //
 // ATTENTION: When updating these fields, add to version_history.txt explaining
 // what changed.
-const Version DistSQLVersion = 13
+const Version DistSQLVersion = 14
 
 // MinAcceptedVersion is the oldest version that the server is
 // compatible with; see above.

--- a/pkg/sql/distsqlrun/version_history.txt
+++ b/pkg/sql/distsqlrun/version_history.txt
@@ -58,3 +58,7 @@
     - Add NumRows to ValuesSpec (used for zero-column case). The implementation
       tolerates this field being unset in existing planning cases (at lest one
       column).
+- Version: 14 (MinAcceptedVersion: 6)
+    - Enhancements to lookup joins. They now support joining against secondary
+      indexes as well as left outer joins. Left join support required two
+      additional fields on JoinReaderSpec: index_filter_expr and type.


### PR DESCRIPTION
Lookup joins on non-covering secondary indexes were previously making a
separate primary index scan for every secondary index row. Now those
scans are grouped together into batches of up to 100 spans.

Release note: None