### PR TITLE
ui: don't show login indicator unless login is enabled

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1923,7 +1923,8 @@ func serveUIAssets(fileServer http.Handler, cfg Config) http.Handler {
 
 		// Construct arguments for template.
 		tmplArgs := ui.IndexHTMLArgs{
-			LoginEnabled: cfg.RequireWebSession(),
+			LoginEnabled:         cfg.RequireWebSession(),
+			ExperimentalUseLogin: cfg.EnableWebSessionAuthentication,
 		}
 		loggedInUser, ok := request.Context().Value(loggedInUserKey{}).(string)
 		if ok && loggedInUser != "" {

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -963,6 +963,10 @@ func TestServeIndexHTML(t *testing.T) {
 	t.Run("Insecure mode", func(t *testing.T) {
 		s, _, _ := serverutils.StartServer(t, base.TestServerArgs{
 			Insecure: true,
+			// This test server argument has the same effect as setting the environment variable
+			// `COCKROACH_EXPERIMENTAL_REQUIRE_WEB_SESSION` to false, or not setting it.
+			// In test servers, web sessions are required by default.
+			DisableWebSessionAuthentication: true,
 		})
 		defer s.Stopper().Stop(context.TODO())
 		tsrv := s.(*TestServer)
@@ -984,7 +988,7 @@ func TestServeIndexHTML(t *testing.T) {
 			t.Fatal(err)
 		}
 		respString := string(respBytes)
-		expected := fmt.Sprintf(htmlTemplate, `{"LoginEnabled":false,"LoggedInUser":null}`)
+		expected := fmt.Sprintf(htmlTemplate, `{"ExperimentalUseLogin":false,"LoginEnabled":false,"LoggedInUser":null}`)
 		if respString != expected {
 			t.Fatalf("expected %s; got %s", expected, respString)
 		}
@@ -1008,8 +1012,8 @@ func TestServeIndexHTML(t *testing.T) {
 			client http.Client
 			json   string
 		}{
-			{loggedInClient, `{"LoginEnabled":true,"LoggedInUser":"authentic_user"}`},
-			{loggedOutClient, `{"LoginEnabled":true,"LoggedInUser":null}`},
+			{loggedInClient, `{"ExperimentalUseLogin":true,"LoginEnabled":true,"LoggedInUser":"authentic_user"}`},
+			{loggedOutClient, `{"ExperimentalUseLogin":true,"LoginEnabled":true,"LoggedInUser":null}`},
 		}
 
 		for _, testCase := range cases {

--- a/pkg/ui/src/views/app/components/layoutSidebar/index.tsx
+++ b/pkg/ui/src/views/app/components/layoutSidebar/index.tsx
@@ -59,6 +59,10 @@ class IconLink extends React.Component<IconLinkProps, {}> {
 }
 
 function LoginIndicator({ loginState }: { loginState: LoginState }) {
+  if (!loginState.useLogin()) {
+    return null;
+  }
+
   if (!loginState.loginEnabled()) {
     return (<div className="login-indicator">Insecure mode</div>);
   }

--- a/pkg/ui/ui.go
+++ b/pkg/ui/ui.go
@@ -76,8 +76,9 @@ var IndexHTMLTemplate *template.Template
 
 // IndexHTMLArgs are the arguments to IndexHTMLTemplate.
 type IndexHTMLArgs struct {
-	LoginEnabled bool
-	LoggedInUser *string
+	ExperimentalUseLogin bool
+	LoginEnabled         bool
+	LoggedInUser         *string
 }
 
 func init() {


### PR DESCRIPTION
In #25005 I accidentally let the login indicator leak even if the environment
variable wasn't set.  This corrects that issue.

Release note: None
Fixes: #25843