### PR TITLE
ui: sort system database last on databases page

### DIFF
--- a/pkg/ui/src/views/databases/containers/databases/index.spec.ts
+++ b/pkg/ui/src/views/databases/containers/databases/index.spec.ts
@@ -1,0 +1,39 @@
+import { assert } from "chai";
+
+import * as protos from "src/js/protos";
+import { selectDatabasesByType } from "./";
+
+describe("selectDatabasesByType", function() {
+  it("returns empty arrays if database data is missing", function() {
+    const state = {
+      cachedData: {
+        databases: {
+          inFlight: false,
+          valid: false,
+        },
+      },
+    };
+
+    assert.deepEqual(selectDatabasesByType(state), { user: [], system: [] });
+  });
+
+  it("separates out the system databases", function() {
+    const userDatabases = ["foo", "bar", "baz"];
+    const systemDatabases = ["defaultdb", "postgres", "system"];
+    const state = {
+      cachedData: {
+        databases: {
+          inFlight: false,
+          valid: true,
+          data: protos.cockroach.server.serverpb.DatabasesResponse.fromObject({
+            databases: systemDatabases.concat(userDatabases),
+          }),
+        },
+      },
+    };
+
+    const dbs = selectDatabasesByType(state);
+
+    assert.deepEqual(dbs, { user: userDatabases, system: systemDatabases });
+  });
+});

--- a/pkg/ui/src/views/databases/containers/databases/index.tsx
+++ b/pkg/ui/src/views/databases/containers/databases/index.tsx
@@ -20,6 +20,13 @@ const databasePages = [
   { value: "grants", label: "Grants" },
 ];
 
+// The system databases should sort after user databases.
+const systemDatabases = [
+  "defaultdb",
+  "postgres",
+  "system",
+];
+
 // DatabaseListNav displays the database page navigation bar.
 class DatabaseListNav extends React.Component<{selected: string}, {}> {
   // Magic to add react router to the context.
@@ -65,6 +72,8 @@ class DatabaseTablesList extends React.Component<DatabaseListProps, {}> {
   }
 
   render() {
+    const dbs = _.partition(this.props.databaseNames, (db) => systemDatabases.indexOf(db) === -1);
+
     return <div>
       <Helmet>
         <title>Tables | Databases</title>
@@ -72,9 +81,13 @@ class DatabaseTablesList extends React.Component<DatabaseListProps, {}> {
       <section className="section"><h1>Databases</h1></section>
       <DatabaseListNav selected="tables"/>
       <div className="section databases">
-        { _.map(this.props.databaseNames, (n) => {
-          return <DatabaseSummaryTables name={n} key={n} />;
-        }) }
+        {
+          dbs[0].map(n => <DatabaseSummaryTables name={n} key={n} />)
+        }
+        <hr />
+        {
+          dbs[1].map(n => <DatabaseSummaryTables name={n} key={n} />)
+        }
         <NonTableSummary />
       </div>
     </div>;
@@ -88,6 +101,8 @@ class DatabaseGrantsList extends React.Component<DatabaseListProps, {}> {
   }
 
   render() {
+    const dbs = _.partition(this.props.databaseNames, (db) => systemDatabases.indexOf(db) === -1);
+
     return <div>
       <Helmet>
         <title>Grants | Databases</title>
@@ -95,49 +110,22 @@ class DatabaseGrantsList extends React.Component<DatabaseListProps, {}> {
       <section className="section"><h1>Databases</h1></section>
       <DatabaseListNav selected="grants"/>
       <div className="section databases">
-        { _.map(this.props.databaseNames, (n) => {
-          return <DatabaseSummaryGrants name={n} key={n} />;
-        }) }
+        {
+          dbs[0].map(n => <DatabaseSummaryGrants name={n} key={n} />)
+        }
+        <hr />
+        {
+          dbs[1].map(n => <DatabaseSummaryGrants name={n} key={n} />)
+        }
       </div>
     </div>;
   }
 }
 
-const systemDatabases = [
-  "defaultdb",
-  "postgres",
-  "system",
-];
-
-function cmp(a: string, b: string) {
-  if (a === b) {
-      return 0;
-  }
-  if (a < b) {
-      return -1;
-  }
-  return 1;
-}
-
-function systemLast(a: string, b: string) {
-  const aIsSys = systemDatabases.indexOf(a) !== -1;
-  const bIsSys = systemDatabases.indexOf(b) !== -1;
-  if (aIsSys && bIsSys) {
-    return cmp(a, b);
-  }
-  if (aIsSys) {
-      return 1;
-  }
-  if (bIsSys) {
-      return -1;
-  }
-  return cmp(a, b);
-}
-
 // Base selectors to extract data from redux state.
 function databaseNames(state: AdminUIState): string[] {
   if (state.cachedData.databases.data && state.cachedData.databases.data.databases) {
-    return state.cachedData.databases.data.databases.sort(systemLast);
+    return state.cachedData.databases.data.databases;
   }
   return [];
 }

--- a/pkg/ui/src/views/databases/containers/databases/index.tsx
+++ b/pkg/ui/src/views/databases/containers/databases/index.tsx
@@ -119,8 +119,44 @@ class DatabaseGrantsList extends React.Component<DatabaseListProps, {}> {
   }
 }
 
+const systemDatabases = [
+  "defaultdb",
+  "postgres",
+  "system",
+];
+
+function cmp(a: string, b: string) {
+  if (a === b) {
+      return 0;
+  }
+  if (a < b) {
+      return -1;
+  }
+  return 1;
+}
+
+function systemLast(a: string, b: string) {
+  const aIsSys = systemDatabases.indexOf(a) !== -1;
+  const bIsSys = systemDatabases.indexOf(b) !== -1;
+  if (aIsSys && bIsSys) {
+    return cmp(a, b);
+  }
+  if (aIsSys) {
+      return 1;
+  }
+  if (bIsSys) {
+      return -1;
+  }
+  return cmp(a, b);
+}
+
 // Base selectors to extract data from redux state.
-const databaseNames = (state: AdminUIState): string[] => state.cachedData.databases.data && state.cachedData.databases.data.databases;
+function databaseNames(state: AdminUIState): string[] {
+  if (state.cachedData.databases.data && state.cachedData.databases.data.databases) {
+    return state.cachedData.databases.data.databases.sort(systemLast);
+  }
+  return [];
+}
 
 // Connect the DatabaseTablesList class with our redux store.
 const databaseTablesListConnected = connect(

--- a/pkg/ui/src/views/databases/containers/databases/index.tsx
+++ b/pkg/ui/src/views/databases/containers/databases/index.tsx
@@ -15,16 +15,6 @@ import DatabaseSummaryTables from "src/views/databases/containers/databaseTables
 import DatabaseSummaryGrants from "src/views/databases/containers/databaseGrants";
 import NonTableSummary from "./nonTableSummary";
 
-// excludedTableList is a list of virtual databases that should be excluded
-// from database lists; they are not physical databases, and thus cause issues
-// with our backend methods.
-// TODO(mrtracy): This exclusion should occur on the backend methods, which
-// should handle virtual tables correctly. Github #9689.
-const excludedTableList = {
-  "information_schema": true,
-  "pg_catalog": true,
-};
-
 const databasePages = [
   { value: "tables", label: "Tables" },
   { value: "grants", label: "Grants" },
@@ -83,9 +73,6 @@ class DatabaseTablesList extends React.Component<DatabaseListProps, {}> {
       <DatabaseListNav selected="tables"/>
       <div className="section databases">
         { _.map(this.props.databaseNames, (n) => {
-          if (excludedTableList.hasOwnProperty(n)) {
-            return null;
-          }
           return <DatabaseSummaryTables name={n} key={n} />;
         }) }
         <NonTableSummary />
@@ -109,9 +96,6 @@ class DatabaseGrantsList extends React.Component<DatabaseListProps, {}> {
       <DatabaseListNav selected="grants"/>
       <div className="section databases">
         { _.map(this.props.databaseNames, (n) => {
-          if (excludedTableList.hasOwnProperty(n)) {
-            return null;
-          }
           return <DatabaseSummaryGrants name={n} key={n} />;
         }) }
       </div>

--- a/pkg/ui/styl/pages/databases.styl
+++ b/pkg/ui/styl/pages/databases.styl
@@ -3,3 +3,12 @@
 
 .database-summary-title
   text-align left
+
+hr
+  border-left none
+  border-right none
+  border-bottom none
+  border-top 1px solid $tooltip-color
+
+  margin-top 20px
+  margin-bottom 20px


### PR DESCRIPTION
This sorts the system databases last, so that user databases are together
and the system tables are next to the non-table system data on this page.
Specifically `system`, `defaultdb`, and `postgres` sort to the end.

<img width="1166" alt="screen shot 2018-05-23 at 2 17 07 pm" src="https://user-images.githubusercontent.com/793969/40443436-534d3a98-5e94-11e8-80f6-a933f73a55e5.png">
(notice `test` above `defaultdb` here with the horizontal rule between)

Fixes #25453
Release note (admin ui change): List the system databases after all user
databases on the Databases page, instead of mixed in with them.