### PR TITLE
cmd/roachtest: add test.IsBuildVersion

### DIFF
--- a/pkg/cmd/roachtest/debug.go
+++ b/pkg/cmd/roachtest/debug.go
@@ -53,8 +53,10 @@ func registerDebug(r *registry) {
 				return err
 			}
 
-			if err := c.RunE(ctx, c.Node(node), "grep -F 'liveness.heartbeatlatency-p99' ./debug/metrics"); err != nil {
-				return err
+			if t.IsBuildVersion("v2.1.0") {
+				if err := c.RunE(ctx, c.Node(node), "grep -F 'liveness.heartbeatlatency-p99' ./debug/metrics"); err != nil {
+					return err
+				}
 			}
 			if err := c.RunE(ctx, c.Node(node), "rm -rf debug"); err != nil {
 				return err


### PR DESCRIPTION
Added a facility so that tests can perform checks that are conditioned
on the cockroach build version.

Fixes #25729

Release note: None