### PR TITLE
opt: minor cleanup around formatPrivate

### DIFF
--- a/pkg/sql/opt/memo/expr_view.go
+++ b/pkg/sql/opt/memo/expr_view.go
@@ -254,7 +254,7 @@ func (ev ExprView) formatRelational(f *opt.ExprFmtCtx, tp treeprinter.Node) {
 	switch ev.Operator() {
 	case opt.ScanOp:
 		formatter := ev.mem.makeExprFormatter(&buf)
-		formatter.formatScanPrivate(ev.Private().(*ScanOpDef), true /* short */)
+		formatter.formatPrivate(ev.Private(), formatNormal)
 	}
 
 	var physProps *props.Physical

--- a/pkg/sql/opt/memo/testdata/memo
+++ b/pkg/sql/opt/memo/testdata/memo
@@ -131,12 +131,12 @@ memo (optimized)
  │    └── ""
  │         ├── best: (project G2 G3)
  │         └── cost: 2026.65
- ├── G2: (limit G4 G5 +2)
+ ├── G2: (limit G4 G5 ordering=+2)
  │    ├── ""
- │    │    ├── best: (limit G4="[ordering: +2]" G5 +2)
+ │    │    ├── best: (limit G4="[ordering: +2]" G5 ordering=+2)
  │    │    └── cost: 2026.65
  │    └── "[ordering: +2]"
- │         ├── best: (limit G4="[ordering: +2]" G5 +2)
+ │         ├── best: (limit G4="[ordering: +2]" G5 ordering=+2)
  │         └── cost: 2026.65
  ├── G3: (projections G6 a.y b.x)
  ├── G4: (inner-join G7 G8 G9)
@@ -266,3 +266,30 @@ memo (optimized)
       └── ""
            ├── best: (scan a,constrained)
            └── cost: 1.00
+
+memo 
+SELECT x, y FROM a UNION SELECT x+1, y+1 FROM a
+----
+memo (optimized)
+ ├── G1: (union G2 G3)
+ │    └── "[presentation: x:7,y:8]"
+ │         ├── best: (union G2 G3)
+ │         └── cost: 2000.00
+ ├── G2: (scan a)
+ │    └── ""
+ │         ├── best: (scan a)
+ │         └── cost: 1000.00
+ ├── G3: (project G4 G5)
+ │    └── ""
+ │         ├── best: (project G4 G5)
+ │         └── cost: 1000.00
+ ├── G4: (scan a)
+ │    └── ""
+ │         ├── best: (scan a)
+ │         └── cost: 1000.00
+ ├── G5: (projections G6 G7)
+ ├── G6: (plus G8 G10)
+ ├── G7: (plus G9 G10)
+ ├── G8: (variable a.x)
+ ├── G9: (variable a.y)
+ └── G10: (const 1)

--- a/pkg/sql/opt/ops/enforcer.opt
+++ b/pkg/sql/opt/ops/enforcer.opt
@@ -14,7 +14,6 @@
 # be sorted by one or more of the input columns, each of which can be sorted in
 # either ascending or descending order. See the Ordering field in the
 # PhysicalProps struct.
-# TODO(andyk): Add the Ordering field.
 [Enforcer]
 define Sort {
     Input Expr

--- a/pkg/sql/opt/xform/testdata/rules/limit
+++ b/pkg/sql/opt/xform/testdata/rules/limit
@@ -111,9 +111,9 @@ memo
 SELECT s FROM a WHERE s='foo' LIMIT 1
 ----
 memo (optimized)
- ├── G1: (limit G2 G3 ) (scan a@s_idx,cols=(4),constrained,lim=1) (scan a@si_idx,cols=(4),constrained,lim=1)
+ ├── G1: (limit G2 G3) (scan a@s_idx,cols=(4),constrained,lim=1) (scan a@si_idx,cols=(4),constrained,lim=1)
  │    └── "[presentation: s:4]"
- │         ├── best: (limit G2 G3 )
+ │         ├── best: (limit G2 G3)
  │         └── cost: 1.00
  ├── G2: (select G4 G5) (scan a@s_idx,cols=(4),constrained) (scan a@si_idx,cols=(4),constrained)
  │    └── ""


### PR DESCRIPTION
 - move the `formatScanPrivate` code to `formatPrivate`

 - print out an `Ordering` private properly (relevant when formatting
   memo with Limit/Offset)

 - don't print out `SetOpColMap` private

Release note: None