### PR TITLE
acceptance: fix flakiness in TestDockerCLI/test_log_config_msg.tcl

### DIFF
--- a/pkg/cli/interactive_tests/test_log_config_msg.tcl
+++ b/pkg/cli/interactive_tests/test_log_config_msg.tcl
@@ -2,19 +2,29 @@
 
 source [file join [file dirname $argv0] common.tcl]
 
+# We stop the server before each test to ensure the log file is
+# flushed and not in the middle of a rotation.
+
 start_server $argv
+stop_server $argv
 
 start_test "Check that the cluster ID is reported at the start of the first log file."
-system "grep '\\\[config\\\] clusterID:' logs/db/logs/cockroach.log"
+system "grep -qF '\[config\] clusterID:' logs/db/logs/cockroach.log"
 end_test
 
-stop_server $argv
 
 # Make a server with a tiny log buffer so as to force frequent log rotation.
 system "mkfifo pid_fifo || true; $argv start --insecure --pid-file=pid_fifo --background -s=path=logs/db --log-file-max-size=2k >>logs/expect-cmd.log 2>&1 & cat pid_fifo > server_pid"
+stop_server $argv
 
 start_test "Check that the cluster ID is reported at the start of new log files."
-system "grep '\\\[config\\\] clusterID:' logs/db/logs/cockroach.log"
+# Verify that the string "restarted pre-existing node" can be found
+# somewhere. This ensures that if this string ever changes, the test
+# below won't report a false negative.
+system "grep -q 'restarted pre-existing node' logs/db/logs/*.log"
+# Verify that "cockroach.log" is not the file where the server reports
+# it just started.
+system "if grep -q 'restarted pre-existing node' logs/db/logs/cockroach.log; then false; fi"
+# Verify that the last log file does contain the cluster ID.
+system "grep -qF '\[config\] clusterID:' logs/db/logs/cockroach.log"
 end_test
-
-stop_server $argv


### PR DESCRIPTION
Fixes #25334.

The test was susceptible to a race with the log file rotation (observe
an empty file that's just been created). This patch fixes the
flakiness by ensuring the observed log file is flushed, closed and in
a consistent state before observing it.

Release note: None

cc @tschottdorf 