### PR TITLE
sql: fix CANCEL/PAUSE/RESUME QUERIES/JOBS/SESSIONS with non-canonical types

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/run_control
+++ b/pkg/sql/logictest/testdata/logic_test/run_control
@@ -12,6 +12,9 @@ CANCEL JOBS SELECT 'foo'
 query error CANCEL JOBS expects a single column source, got 2 columns
 CANCEL JOBS VALUES (1,2)
 
+query error CANCEL JOBS requires int values, not type oid
+CANCEL JOB 1::OID
+
 statement ok count 0
 PAUSE JOB (SELECT id FROM system.jobs LIMIT 0)
 
@@ -83,3 +86,10 @@ CANCEL SESSION (SELECT 'a' LIMIT 0)
 
 statement ok count 0
 CANCEL SESSIONS SELECT 'a' LIMIT 0
+
+# Regression test for #25842
+query error odd length hex string
+CANCEL SESSION 'aaa'::NAME
+
+query error odd length hex string
+CANCEL QUERY 'aaa'::NAME


### PR DESCRIPTION
Fixes #25842

Prior to this patch, the various control statement were announcing via
their type checking rules that they accepted non-canonical value
types (i.e. wrapped via DOidWrapper to give them a different postgres
type OID), however their execution code did not support non-canonical
types and would panic if presented with such a value.

This patch fixes the behavior by properly unwrapping the values.

Release note (bug fix): CockroachDB no longer crashes if the control
statements (`CANCEL`/`PAUSE`/`RESUME`) are given values using special
PostgresSQL types (e.g. `NAME`).