### PR TITLE
sql: remove need to use ADD state with interleaved tables

### DIFF
--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -820,8 +820,6 @@ func addInterleave(
 		intl.SharedPrefixLen -= ancestor.SharedPrefixLen
 	}
 	index.Interleave = sqlbase.InterleaveDescriptor{Ancestors: append(ancestorPrefix, intl)}
-
-	desc.State = sqlbase.TableDescriptor_ADD
 	return nil
 }
 
@@ -853,19 +851,7 @@ func (p *planner) finalizeInterleave(
 	ancestorIndex.InterleavedBy = append(ancestorIndex.InterleavedBy,
 		sqlbase.ForeignKeyReference{Table: desc.ID, Index: index.ID})
 
-	if err := p.saveNonmutationAndNotify(ctx, ancestorTable); err != nil {
-		return err
-	}
-
-	if desc.State == sqlbase.TableDescriptor_ADD {
-		desc.State = sqlbase.TableDescriptor_PUBLIC
-
-		if err := p.saveNonmutationAndNotify(ctx, desc); err != nil {
-			return err
-		}
-	}
-
-	return nil
+	return p.saveNonmutationAndNotify(ctx, ancestorTable)
 }
 
 // CreatePartitioning constructs the partitioning descriptor for an index that

--- a/pkg/sql/logictest/testdata/logic_test/interleaved
+++ b/pkg/sql/logictest/testdata/logic_test/interleaved
@@ -380,3 +380,59 @@ END
 
 statement error duplicate key value \(p_id,c_id\)=\(1,1\) violates unique constraint "primary"
 INSERT INTO c20067 VALUES (1, 1, 'John Doe')
+
+
+subtest create_interleaved_external_reference
+
+statement ok
+CREATE TABLE referee (a INT PRIMARY KEY);
+
+statement ok
+BEGIN TRANSACTION
+
+statement ok
+CREATE TABLE refers (
+  a INT PRIMARY KEY,
+  b INT,
+  INDEX b_idx (b)
+) INTERLEAVE IN PARENT referee (a)
+
+# Add some schema changes within the same transaction.
+statement ok
+CREATE INDEX foo ON refers (a)
+
+statement ok
+ALTER INDEX refers@b_idx RENAME TO another_idx
+
+query TT
+SHOW CREATE TABLE refers
+----
+refers CREATE TABLE refers (
+  a INT NOT NULL,
+  b INT NULL,
+  CONSTRAINT "primary" PRIMARY KEY (a ASC),
+  INDEX another_idx (b ASC),
+  INDEX foo (a ASC),
+  FAMILY "primary" (a, b)
+) INTERLEAVE IN PARENT referee (a)
+
+statement ok
+DROP INDEX refers@another_idx
+
+# refers is PUBLIC.
+query T
+SHOW TABLES FROM test
+----
+all_interleaves
+c20067
+customers
+interdb
+orders
+p1_0
+p1_1
+p20067
+referee
+refers
+
+statement ok
+COMMIT


### PR DESCRIPTION
We were incorrectly setting an interleaved child to the ADD
state and then reverting it to the PUBLIC state in the transaction
that creates such a table.

Note: the test added in this change worked prior to this change.

The INTERLEAVE relationship between tables is not a constraint
but a layout. Moreover unlike an FK relationship, an INTERLEAVE
relationship is a one way relationship, in that, a child row
needs to be placed with a parent row, but a child row need not
have a parent row. Therefore a parent table need not know whether
it is interleaved in supporting DML statements. In other words
DML operations can run on a parent table using a cached descriptor
that doesn't specify the INTERLEAVE relationship. For DDL statements
affecting the INTERLEAVE relationship, the descriptors are read
from the store and will run consistently. For example DROP TABLE
will see the INTERLEAVE relationship.

Release note: None