### PR TITLE
distsql: annotate visual query plans with execution stats

### DIFF
--- a/docs/generated/sql/bnf/explain_stmt.bnf
+++ b/docs/generated/sql/bnf/explain_stmt.bnf
@@ -1,3 +1,4 @@
 explain_stmt ::=
 	'EXPLAIN' explainable_stmt
 	| 'EXPLAIN' '(' ( | 'EXPRS' | 'METADATA' | 'QUALIFY' | 'VERBOSE' | 'TYPES' ) ( ( ',' ( | 'EXPRS' | 'METADATA' | 'QUALIFY' | 'VERBOSE' | 'TYPES' ) ) )* ')' explainable_stmt
+	| 'EXPLAIN' 'ANALYZE' '(' ( | 'EXPRS' | 'METADATA' | 'QUALIFY' | 'VERBOSE' | 'TYPES' ) ( ( ',' ( | 'EXPRS' | 'METADATA' | 'QUALIFY' | 'VERBOSE' | 'TYPES' ) ) )* ')' explainable_stmt

--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -83,6 +83,7 @@ execute_stmt ::=
 explain_stmt ::=
 	'EXPLAIN' explainable_stmt
 	| 'EXPLAIN' '(' explain_option_list ')' explainable_stmt
+	| 'EXPLAIN' 'ANALYZE' '(' explain_option_list ')' explainable_stmt
 
 export_stmt ::=
 	'EXPORT' 'INTO' import_data_format string_or_placeholder opt_with_options 'FROM' select_stmt

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -595,7 +595,7 @@ CREATE TABLE crdb_internal.session_trace (
 );
 `,
 	populate: func(ctx context.Context, p *planner, _ *DatabaseDescriptor, addRow func(...tree.Datum) error) error {
-		rows, err := p.ExtendedEvalContext().Tracing.getRecording()
+		rows, err := p.ExtendedEvalContext().Tracing.getSessionTrace()
 		if err != nil {
 			return err
 		}

--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -129,7 +129,7 @@ func (dsp *DistSQLPlanner) Run(
 
 	if logPlanDiagram {
 		log.VEvent(ctx, 1, "creating plan diagram")
-		json, url, err := distsqlrun.GeneratePlanDiagramWithURL(flows)
+		json, url, err := distsqlrun.GeneratePlanDiagramURL(flows)
 		if err != nil {
 			log.Infof(ctx, "Error generating diagram: %s", err)
 		} else {

--- a/pkg/sql/distsqlrun/flow_diagram_test.go
+++ b/pkg/sql/distsqlrun/flow_diagram_test.go
@@ -139,7 +139,7 @@ func TestPlanDiagramIndexJoin(t *testing.T) {
 		},
 	}
 
-	json, url, err := GeneratePlanDiagramWithURL(flows)
+	json, url, err := GeneratePlanDiagramURL(flows)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -362,7 +362,7 @@ func TestPlanDiagramJoin(t *testing.T) {
 	}
 
 	var buf bytes.Buffer
-	if err := GeneratePlanDiagram(flows, &buf); err != nil {
+	if err := GeneratePlanDiagram(flows, nil /* spans */, &buf); err != nil {
 		t.Fatal(err)
 	}
 

--- a/pkg/sql/distsqlrun/processors.go
+++ b/pkg/sql/distsqlrun/processors.go
@@ -31,6 +31,9 @@ import (
 	"github.com/pkg/errors"
 )
 
+// processorIDTagKey is the key used for processor id tags in tracing spans.
+const processorIDTagKey = tracing.TagPrefix + "processorid"
+
 // Processor is a common interface implemented by all processors, used by the
 // higher-level flow orchestration code.
 type Processor interface {

--- a/pkg/sql/distsqlrun/stats.go
+++ b/pkg/sql/distsqlrun/stats.go
@@ -16,7 +16,15 @@ package distsqlrun
 
 import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 )
+
+// DistSQLSpanStats is a tracing.SpanStats that returns a list of stats to
+// output on a query plan.
+type DistSQLSpanStats interface {
+	tracing.SpanStats
+	StatsForQueryPlan() []string
+}
 
 // InputStatCollector wraps a RowSource and collects stats from it.
 type InputStatCollector struct {

--- a/pkg/sql/distsqlrun/tablereader.go
+++ b/pkg/sql/distsqlrun/tablereader.go
@@ -274,6 +274,11 @@ func (trs *TableReaderStats) Stats() map[string]string {
 	}
 }
 
+// StatsForQueryPlan implements the DistSQLSpanStats interface.
+func (trs *TableReaderStats) StatsForQueryPlan() []string {
+	return []string{fmt.Sprintf("rows read: %d", trs.InputStats.NumRows)}
+}
+
 // outputStatsToTrace outputs the collected tableReader stats to the trace. Will
 // fail silently if the tableReader is not collecting stats.
 func (tr *tableReader) outputStatsToTrace() {

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -973,21 +973,24 @@ type SessionTracing struct {
 	lastRecording []traceRow
 }
 
-// getRecording returns the session trace. If we're not currently tracing, this
-// will be the last recorded trace. If we are currently tracing, we'll return
-// whatever was recorded so far.
-func (st *SessionTracing) getRecording() ([]traceRow, error) {
+// getSessionTrace returns the session trace. If we're not currently tracing,
+// this will be the last recorded trace. If we are currently tracing, we'll
+// return whatever was recorded so far.
+func (st *SessionTracing) getSessionTrace() ([]traceRow, error) {
 	if !st.enabled {
 		return st.lastRecording, nil
 	}
 
+	return generateSessionTraceVTable(st.getRecording())
+}
+
+// getRecording returns the recorded spans of the current trace.
+func (st *SessionTracing) getRecording() []tracing.RecordedSpan {
 	var spans []tracing.RecordedSpan
 	if st.firstTxnSpan != nil {
 		spans = append(spans, tracing.GetRecording(st.firstTxnSpan)...)
 	}
-	spans = append(spans, tracing.GetRecording(st.connSpan)...)
-
-	return generateSessionTraceVTable(spans)
+	return append(spans, tracing.GetRecording(st.connSpan)...)
 }
 
 // StartTracing starts "session tracing". From this moment on, everything

--- a/pkg/sql/explain_distsql.go
+++ b/pkg/sql/explain_distsql.go
@@ -19,6 +19,8 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/sql/distsqlrun"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 )
 
 // explainDistSQLNode is a planNode that wraps a plan and returns
@@ -27,6 +29,14 @@ type explainDistSQLNode struct {
 	optColumnsSlot
 
 	plan planNode
+
+	// If analyze is set, plan will be executed with tracing enabled and a url
+	// pointing to a visual query plan with statistics will be in the row
+	// returned by the node.
+	analyze bool
+	// stmtType is the StatementType of the plan. It is needed by the
+	// distSQLWrapper when analyzing a statement.
+	stmtType tree.StatementType
 
 	run explainDistSQLRun
 }
@@ -60,8 +70,48 @@ func (n *explainDistSQLNode) startExec(params runParams) error {
 		return err
 	}
 	distSQLPlanner.FinalizePlan(&planCtx, &plan)
+
+	var spans []tracing.RecordedSpan
+	if n.analyze {
+		// If tracing is already enabled, don't call StopTracing at the end.
+		shouldStopTracing := !params.extendedEvalCtx.Tracing.Enabled()
+
+		// Start tracing. KV tracing is not enabled because we are only interested
+		// in stats present on the spans. Noop if tracing is already enabled.
+		if err := params.extendedEvalCtx.Tracing.StartTracing(
+			tracing.SnowballRecording, false, /* kvTracingEnabled */
+		); err != nil {
+			return err
+		}
+
+		// Discard rows that are returned.
+		rw := newCallbackResultWriter(func(ctx context.Context, row tree.Datums) error {
+			return nil
+		})
+		execCfg := params.p.ExecCfg()
+		recv := makeDistSQLReceiver(
+			params.ctx,
+			rw,
+			n.stmtType,
+			execCfg.RangeDescriptorCache,
+			execCfg.LeaseHolderCache,
+			params.p.txn,
+			func(ts hlc.Timestamp) {
+				_ = execCfg.Clock.Update(ts)
+			},
+		)
+		distSQLPlanner.Run(&planCtx, params.p.txn, &plan, recv, params.p.ExtendedEvalContext())
+
+		spans = params.extendedEvalCtx.Tracing.getRecording()
+		if shouldStopTracing {
+			if err := params.extendedEvalCtx.Tracing.StopTracing(); err != nil {
+				return err
+			}
+		}
+	}
+
 	flows := plan.GenerateFlowSpecs(params.extendedEvalCtx.NodeID)
-	planJSON, planURL, err := distsqlrun.GeneratePlanDiagramWithURL(flows)
+	planJSON, planURL, err := distsqlrun.GeneratePlanDiagramURLWithSpans(flows, spans)
 	if err != nil {
 		return err
 	}
@@ -82,5 +132,11 @@ func (n *explainDistSQLNode) Next(runParams) (bool, error) {
 	return true, nil
 }
 
-func (n *explainDistSQLNode) Values() tree.Datums       { return n.run.values }
-func (n *explainDistSQLNode) Close(ctx context.Context) { n.plan.Close(ctx) }
+func (n *explainDistSQLNode) Values() tree.Datums { return n.run.values }
+func (n *explainDistSQLNode) Close(ctx context.Context) {
+	// If we analyzed the statement, we relinquished ownership of the plan to a
+	// distSQLWrapper.
+	if !n.analyze {
+		n.plan.Close(ctx)
+	}
+}

--- a/pkg/sql/logictest/testdata/planner_test/distsql_auto_mode
+++ b/pkg/sql/logictest/testdata/planner_test/distsql_auto_mode
@@ -124,3 +124,10 @@ EXPLAIN (DISTSQL) SELECT t1.a FROM abc t1 INNER JOIN abc t2 on t1.a::REGCLASS = 
 # Query with OID expression - don't distribute (#24423).
 statement error pq: OID expressions are not supported by distsql
 EXPLAIN (DISTSQL) SELECT 246::REGTYPE FROM abc
+
+# Verify that EXPLAIN ANALYZE (DISTSQL) annotates plans with collected
+# statistics.
+query T
+SELECT "URL" FROM [EXPLAIN ANALYZE (DISTSQL) SELECT * FROM kv]
+----
+https://cockroachdb.github.io/distsqlplan/decode.html?eJyMj71qxDAQhPs8xTH1QuxWVdprknCkCyoUazhMfF6zK-eHQ-8ebBUhReDKmZG-j71i1szHdKEjvKJHFCymA93Vtqo9OOYvhE4wzstatjoKBjUiXFHGMhEBL-lt4okp0-47CDJLGqcdu9h4Sfb98P4BgemnH4wph0OHWAW6ll-ql3QmQl_ldvOJvujs_CP9j9zVKGA-s13nutrAZ9Nh17T4tP_bi0wvbe1bOM5tqrHe_QQAAP__udhpqQ==

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -2111,7 +2111,7 @@ table_name_list:
 // %Text:
 // EXPLAIN <statement>
 // EXPLAIN ([PLAN ,] <planoptions...> ) <statement>
-// EXPLAIN (DISTSQL) <statement>
+// EXPLAIN [ANALYZE] (DISTSQL) <statement>
 //
 // Explainable statements:
 //     SELECT, CREATE, DROP, ALTER, INSERT, UPSERT, UPDATE, DELETE,
@@ -2130,6 +2130,10 @@ explain_stmt:
 | EXPLAIN '(' explain_option_list ')' explainable_stmt
   {
     $$.val = &tree.Explain{Options: $3.strs(), Statement: $5.stmt()}
+  }
+| EXPLAIN ANALYZE '(' explain_option_list ')' explainable_stmt
+  {
+    $$.val = &tree.Explain{Options: append($4.strs(), $2), Statement: $6.stmt()}
   }
 // This second error rule is necessary, because otherwise
 // explainable_stmt also provides "selectclause := '(' error ..." and

--- a/pkg/sql/sem/tree/explain.go
+++ b/pkg/sql/sem/tree/explain.go
@@ -81,6 +81,7 @@ const (
 	ExplainFlagNoExpand
 	ExplainFlagNoNormalize
 	ExplainFlagNoOptimize
+	ExplainFlagAnalyze
 )
 
 var explainFlagStrings = map[string]int{
@@ -90,6 +91,7 @@ var explainFlagStrings = map[string]int{
 	"noexpand":    ExplainFlagNoExpand,
 	"nonormalize": ExplainFlagNoNormalize,
 	"nooptimize":  ExplainFlagNoOptimize,
+	"analyze":     ExplainFlagAnalyze,
 }
 
 // ParseOptions parses the options for an EXPLAIN statement.

--- a/pkg/sql/show_trace.go
+++ b/pkg/sql/show_trace.go
@@ -151,7 +151,7 @@ func (n *showTraceNode) Next(params runParams) (bool, error) {
 			n.run.stopTracing = nil
 		}
 
-		traceRows, err := params.extendedEvalCtx.Tracing.getRecording()
+		traceRows, err := params.extendedEvalCtx.Tracing.getSessionTrace()
 		if err != nil {
 			return false, err
 		}


### PR DESCRIPTION
This is done through the EXPLAIN (DISTSQL, ANALYZE) statement. The
provided statement is executed with tracing enabled and the resulting
statistics found in the trace spans are added to the plan.

Addresses #19476

Release note (sql change): Add EXPLAIN (DISTSQL, ANALYZE). This
annotates distsql execution plans with collected execution statistics.

Note that since we only collect the number of rows read from the tableReader for now, there aren't that many stats on the plan yet.

Result:
<img width="742" alt="screen shot 2018-05-23 at 10 06 32 am" src="https://user-images.githubusercontent.com/10560359/40431613-c530d67a-5e75-11e8-9a16-a6486f837692.png">
