### PR TITLE
opt: support SHOW TRACE

### DIFF
--- a/pkg/sql/explain_plan.go
+++ b/pkg/sql/explain_plan.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
-	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/util/treeprinter"
 )
@@ -46,34 +45,6 @@ type explainPlanNode struct {
 	optimizeSubqueries bool
 
 	run explainPlanRun
-}
-
-var explainPlanColumns = sqlbase.ResultColumns{
-	// Tree shows the node type with the tree structure.
-	{Name: "Tree", Typ: types.String},
-	// Field is the part of the node that a row of output pertains to.
-	{Name: "Field", Typ: types.String},
-	// Description contains details about the field.
-	{Name: "Description", Typ: types.String},
-}
-
-var explainPlanVerboseColumns = sqlbase.ResultColumns{
-	// Tree shows the node type with the tree structure.
-	{Name: "Tree", Typ: types.String},
-	// Level is the depth of the node in the tree. Hidden by default; can be
-	// retrieved using:
-	//   SELECT "Level" FROM [ EXPLAIN (VERBOSE) ... ].
-	{Name: "Level", Typ: types.Int, Hidden: true},
-	// Type is the node type. Hidden by default.
-	{Name: "Type", Typ: types.String, Hidden: true},
-	// Field is the part of the node that a row of output pertains to.
-	{Name: "Field", Typ: types.String},
-	// Description contains details about the field.
-	{Name: "Description", Typ: types.String},
-	// Columns is the type signature of the data source.
-	{Name: "Columns", Typ: types.String},
-	// Ordering indicates the known ordering of the data from this source.
-	{Name: "Ordering", Typ: types.String},
 }
 
 // newExplainPlanNode instantiates a planNode that runs an EXPLAIN query.
@@ -116,9 +87,9 @@ func (p *planner) makeExplainPlanNodeWithPlan(
 		flags.showTypes = true
 	}
 
-	columns := explainPlanColumns
+	columns := sqlbase.ExplainPlanColumns
 	if flags.showMetadata {
-		columns = explainPlanVerboseColumns
+		columns = sqlbase.ExplainPlanVerboseColumns
 	}
 
 	e := explainer{explainFlags: flags}

--- a/pkg/sql/logictest/testdata/logic_test/alter_table
+++ b/pkg/sql/logictest/testdata/logic_test/alter_table
@@ -1,4 +1,4 @@
-# LogicTest: default opt parallel-stmts distsql distsql-metadata distsql-opt
+# LogicTest: default parallel-stmts distsql distsql-metadata
 
 statement ok
 CREATE TABLE other (b INT PRIMARY KEY)

--- a/pkg/sql/opt/exec/execbuilder/testdata/show_trace
+++ b/pkg/sql/opt/exec/execbuilder/testdata/show_trace
@@ -1,0 +1,43 @@
+exec-raw
+CREATE TABLE xy (x INT PRIMARY KEY, y INT)
+----
+
+exec nodist
+EXPLAIN (VERBOSE) SHOW TRACE FOR SELECT x FROM xy ORDER BY y
+----
+Tree:string          Field:string  Description:string  Columns:string                                          Ordering:string
+show trace for       ·             ·                   ("timestamp", age, message, tag, loc, operation, span)  ·
+ └── render          ·             ·                   (x)                                                     ·
+      │              render 0      x                   ·                                                       ·
+      └── sort       ·             ·                   (x, y)                                                  +y
+           │         order         +y                  ·                                                       ·
+           └── scan  ·             ·                   (x, y)                                                  ·
+·                    table         xy@primary          ·                                                       ·
+·                    spans         ALL                 ·                                                       ·
+
+exec nodist
+EXPLAIN (VERBOSE) SHOW COMPACT KV TRACE FOR SELECT x FROM xy ORDER BY y
+----
+Tree:string          Field:string  Description:string  Columns:string                  Ordering:string
+show trace for       ·             ·                   (age, message, tag, operation)  ·
+ └── render          ·             ·                   (x)                             ·
+      │              render 0      x                   ·                               ·
+      └── sort       ·             ·                   (x, y)                          +y
+           │         order         +y                  ·                               ·
+           └── scan  ·             ·                   (x, y)                          ·
+·                    table         xy@primary          ·                               ·
+·                    spans         ALL                 ·                               ·
+
+exec nodist
+EXPLAIN (VERBOSE) SHOW EXPERIMENTAL_REPLICA TRACE FOR SELECT x FROM xy ORDER BY y
+----
+Tree:string               Field:string  Description:string  Columns:string                                          Ordering:string
+replica trace             ·             ·                   ("timestamp", node_id, store_id, replica_id)            ·
+ └── show trace for       ·             ·                   ("timestamp", age, message, tag, loc, operation, span)  ·
+      └── render          ·             ·                   (x)                                                     ·
+           │              render 0      x                   ·                                                       ·
+           └── sort       ·             ·                   (x, y)                                                  +y
+                │         order         +y                  ·                                                       ·
+                └── scan  ·             ·                   (x, y)                                                  ·
+·                         table         xy@primary          ·                                                       ·
+·                         spans         ALL                 ·                                                       ·

--- a/pkg/sql/opt/exec/factory.go
+++ b/pkg/sql/opt/exec/factory.go
@@ -121,6 +121,10 @@ type Factory interface {
 	// ConstructExplain returns a node that implements EXPLAIN, showing
 	// information about the given plan.
 	ConstructExplain(options *tree.ExplainOptions, plan Plan) (Node, error)
+
+	// ConstructShowTrace returns a node that implements a SHOW TRACE statement.
+	// If the input is nil, it creates a node for SHOW TRACE FOR SESSION.
+	ConstructShowTrace(typ tree.ShowTraceType, compact bool, input Node) (Node, error)
 }
 
 // Subquery encapsulates information about a subquery that is part of a plan.

--- a/pkg/sql/opt/memo/expr_view.go
+++ b/pkg/sql/opt/memo/expr_view.go
@@ -252,7 +252,7 @@ func (ev ExprView) formatRelational(f *opt.ExprFmtCtx, tp treeprinter.Node) {
 	fmt.Fprintf(&buf, "%v", ev.op)
 
 	switch ev.Operator() {
-	case opt.ScanOp:
+	case opt.ScanOp, opt.ShowTraceOp, opt.ShowTraceForSessionOp:
 		formatter := ev.mem.makeExprFormatter(&buf)
 		formatter.formatPrivate(ev.Private(), formatNormal)
 	}

--- a/pkg/sql/opt/memo/logical_props_builder.go
+++ b/pkg/sql/opt/memo/logical_props_builder.go
@@ -87,6 +87,9 @@ func (b *logicalPropsBuilder) buildRelationalProps(ev ExprView) props.Logical {
 	case opt.ExplainOp:
 		return b.buildExplainProps(ev)
 
+	case opt.ShowTraceOp, opt.ShowTraceForSessionOp:
+		return b.buildShowTraceProps(ev)
+
 	case opt.RowNumberOp:
 		return b.buildRowNumberProps(ev)
 	}
@@ -435,6 +438,18 @@ func (b *logicalPropsBuilder) buildExplainProps(ev ExprView) props.Logical {
 	logical.Relational.Cardinality = props.AnyCardinality
 
 	// Zero value for Stats is ok for Explain.
+
+	return logical
+}
+
+func (b *logicalPropsBuilder) buildShowTraceProps(ev ExprView) props.Logical {
+	logical := props.Logical{Relational: &props.Relational{}}
+
+	def := ev.Private().(*ShowTraceOpDef)
+	logical.Relational.OutputCols = opt.ColListToSet(def.ColList)
+	logical.Relational.Cardinality = props.AnyCardinality
+
+	// Zero value for Stats is ok for ShowTrace.
 
 	return logical
 }

--- a/pkg/sql/opt/memo/memo_format.go
+++ b/pkg/sql/opt/memo/memo_format.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/props"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/util/treeprinter"
 )
 
@@ -302,6 +303,24 @@ func (f exprFormatter) formatPrivate(private interface{}, mode formatMode) {
 		fmt.Fprintf(f.buf, " %s,cols=%s", f.mem.metadata.Table(t.Table).TabName(), t.Cols)
 
 	case *ExplainOpDef:
+		if mode == formatMemo {
+			propsStr := t.Props.String()
+			if propsStr != "" {
+				fmt.Fprintf(f.buf, " %s", propsStr)
+			}
+		}
+
+	case *ShowTraceOpDef:
+		if t.Compact {
+			f.buf.WriteString(" compact")
+		}
+		switch t.Type {
+		case tree.ShowTraceKV:
+			f.buf.WriteString(" kv")
+		case tree.ShowTraceReplica:
+			f.buf.WriteString(" replica")
+		}
+
 		if mode == formatMemo {
 			propsStr := t.Props.String()
 			if propsStr != "" {

--- a/pkg/sql/opt/memo/private_defs.go
+++ b/pkg/sql/opt/memo/private_defs.go
@@ -147,6 +147,21 @@ type ExplainOpDef struct {
 	Props props.Physical
 }
 
+// ShowTraceOpDef defines the value of the Def private field of the Explain operator.
+type ShowTraceOpDef struct {
+	Type tree.ShowTraceType
+
+	// Compact indicates that we output a smaller set of columns; set
+	// when SHOW COMPACT [KV] TRACE is used.
+	Compact bool
+
+	// ColList stores the column IDs for the SHOW TRACE columns.
+	ColList opt.ColList
+
+	// Props stores the required physical properties for the enclosed expression.
+	Props props.Physical
+}
+
 // RowNumberDef defines the value of the Def private field of the RowNumber
 // operator.
 type RowNumberDef struct {

--- a/pkg/sql/opt/memo/private_storage.go
+++ b/pkg/sql/opt/memo/private_storage.go
@@ -245,7 +245,7 @@ func (ps *privateStorage) internLookupJoinDef(def *LookupJoinDef) PrivateID {
 
 // internExplainOpDef adds the given value to storage and returns an id that can
 // later be used to retrieve the value by calling the lookup method. If the
-// value has been previously added to storage, then internLookupJoinDef always
+// value has been previously added to storage, then internExplainOpDef always
 // returns the same private id that was returned from the previous call.
 func (ps *privateStorage) internExplainOpDef(def *ExplainOpDef) PrivateID {
 	ps.keyBuf.Reset()
@@ -255,6 +255,27 @@ func (ps *privateStorage) internExplainOpDef(def *ExplainOpDef) PrivateID {
 	ps.keyBuf.writeColList(def.ColList)
 	ps.keyBuf.WriteString(def.Props.Fingerprint())
 	typ := (*ExplainOpDef)(nil)
+	if id, ok := ps.privatesMap[privateKey{iface: typ, str: ps.keyBuf.String()}]; ok {
+		return id
+	}
+	return ps.addValue(privateKey{iface: typ, str: ps.keyBuf.String()}, def)
+}
+
+// internShowTraceOpDef adds the given value to storage and returns an id that can
+// later be used to retrieve the value by calling the lookup method. If the
+// value has been previously added to storage, then internShowTraceOpDef always
+// returns the same private id that was returned from the previous call.
+func (ps *privateStorage) internShowTraceOpDef(def *ShowTraceOpDef) PrivateID {
+	ps.keyBuf.Reset()
+	ps.keyBuf.WriteString(string(def.Type))
+	if def.Compact {
+		ps.keyBuf.WriteByte(1)
+	} else {
+		ps.keyBuf.WriteByte(0)
+	}
+	ps.keyBuf.writeColList(def.ColList)
+	ps.keyBuf.WriteString(def.Props.Fingerprint())
+	typ := (*ShowTraceOpDef)(nil)
 	if id, ok := ps.privatesMap[privateKey{iface: typ, str: ps.keyBuf.String()}]; ok {
 		return id
 	}

--- a/pkg/sql/opt/norm/rule_props_builder.go
+++ b/pkg/sql/opt/norm/rule_props_builder.go
@@ -84,11 +84,13 @@ func (b *rulePropsBuilder) buildProps(ev memo.ExprView) {
 	case opt.Max1RowOp:
 		b.buildMax1RowProps(ev)
 
-	case opt.ExplainOp:
-		b.buildExplainProps(ev)
-
 	case opt.RowNumberOp:
 		b.buildRowNumberProps(ev)
+
+	case opt.ExplainOp, opt.ShowTraceOp, opt.ShowTraceForSessionOp:
+		// Don't allow any columns to be pruned, since that would trigger the
+		// creation of a wrapper Project around the Explain (it's not capable
+		// of pruning columns or of passing through Project operators).
 
 	default:
 		panic(fmt.Sprintf("unrecognized relational expression type: %v", ev.Operator()))
@@ -175,12 +177,6 @@ func (b *rulePropsBuilder) buildValuesProps(ev memo.ExprView) {
 
 	// All columns can potentially be pruned from the Values operator.
 	relational.Rule.PruneCols = ev.Logical().Relational.OutputCols
-}
-
-func (b *rulePropsBuilder) buildExplainProps(ev memo.ExprView) {
-	// Don't allow any columns to be pruned, since that would trigger the
-	// creation of a wrapper Project around the Explain, since it's not capable
-	// of pruning columns or of passing through Project operators.
 }
 
 func (b *rulePropsBuilder) buildLimitProps(ev memo.ExprView) {

--- a/pkg/sql/opt/ops/relational.opt
+++ b/pkg/sql/opt/ops/relational.opt
@@ -311,18 +311,34 @@ define Offset {
     Ordering Ordering
 }
 
-# Max1Row is an operator which enforces that its input must return at most one
-# row. It is used as input to the Subquery operator. See the comment above
-# Subquery for more details.
+# Max1Row enforces that its input must return at most one row. It is used as
+# input to the Subquery operator. See the comment above Subquery for more
+# details.
 [Relational]
 define Max1Row {
     Input Expr
 }
 
+# Explain returns information about the execution plan of the "input"
+# expression.
 [Relational]
 define Explain {
     Input Expr
     Def   ExplainOpDef
+}
+
+# ShowTrace runs the "input" expressions in a special tracing mode and returns
+# trace results.
+[Relational]
+define ShowTrace {
+    Input Expr
+    Def   ShowTraceOpDef
+}
+
+# ShowTraceForSession returns the current session traces.
+[Relational]
+define ShowTraceForSession {
+    Def   ShowTraceOpDef
 }
 
 # RowNumber adds a column to each row in its input containing a unique,

--- a/pkg/sql/opt/optbuilder/builder.go
+++ b/pkg/sql/opt/optbuilder/builder.go
@@ -182,6 +182,9 @@ func (b *Builder) buildStmt(stmt tree.Statement, inScope *scope) (outScope *scop
 	case *tree.Explain:
 		return b.buildExplain(stmt, inScope)
 
+	case *tree.ShowTrace:
+		return b.buildShowTrace(stmt, inScope)
+
 	default:
 		panic(unimplementedf("unsupported statement: %T", stmt))
 	}

--- a/pkg/sql/opt/optbuilder/show_trace.go
+++ b/pkg/sql/opt/optbuilder/show_trace.go
@@ -1,0 +1,70 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package optbuilder
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/props"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+)
+
+func (b *Builder) buildShowTrace(showTrace *tree.ShowTrace, inScope *scope) (outScope *scope) {
+	var stmtGroup memo.GroupID
+	var stmtProps props.Physical
+
+	if showTrace.Statement != nil {
+		// We don't allow the statement under ShowTrace to reference outer columns, so we
+		// pass a "blank" scope rather than inScope.
+		stmtScope := b.buildStmt(showTrace.Statement, &scope{builder: b})
+		// Calculate the presentation, since we will store it in the ShowTrace op.
+		stmtScope.setPresentation()
+		stmtGroup = stmtScope.group
+		stmtProps = stmtScope.physicalProps
+	}
+
+	outScope = inScope.push()
+
+	switch showTrace.TraceType {
+	case tree.ShowTraceRaw, tree.ShowTraceKV:
+		if showTrace.Compact {
+			b.synthesizeResultColumns(outScope, sqlbase.ShowCompactTraceColumns)
+		} else {
+			b.synthesizeResultColumns(outScope, sqlbase.ShowTraceColumns)
+		}
+
+	case tree.ShowTraceReplica:
+		b.synthesizeResultColumns(outScope, sqlbase.ShowReplicaTraceColumns)
+
+	default:
+		panic(errorf("SHOW %s not supported", showTrace.TraceType))
+	}
+
+	def := memo.ShowTraceOpDef{
+		Type:    showTrace.TraceType,
+		Compact: showTrace.Compact,
+		ColList: colsToColList(outScope.cols),
+		Props:   stmtProps,
+	}
+	for i := range outScope.cols {
+		def.ColList[i] = outScope.cols[i].id
+	}
+	if showTrace.Statement != nil {
+		outScope.group = b.factory.ConstructShowTrace(stmtGroup, b.factory.InternShowTraceOpDef(&def))
+	} else {
+		outScope.group = b.factory.ConstructShowTraceForSession(b.factory.InternShowTraceOpDef(&def))
+	}
+	return outScope
+}

--- a/pkg/sql/opt/optbuilder/testdata/show_trace
+++ b/pkg/sql/opt/optbuilder/testdata/show_trace
@@ -1,0 +1,87 @@
+build
+SHOW TRACE FOR SESSION
+----
+show-trace-for-session
+ └── columns: timestamp:1(timestamptz) age:2(interval) message:3(string) tag:4(string) loc:5(string) operation:6(string) span:7(int)
+
+build
+SHOW COMPACT TRACE FOR SESSION
+----
+show-trace-for-session compact
+ └── columns: age:1(interval) message:2(string) tag:3(string) operation:4(string)
+
+build
+SHOW KV TRACE FOR SESSION
+----
+show-trace-for-session kv
+ └── columns: timestamp:1(timestamptz) age:2(interval) message:3(string) tag:4(string) loc:5(string) operation:6(string) span:7(int)
+
+build
+SHOW COMPACT KV TRACE FOR SESSION
+----
+show-trace-for-session compact kv
+ └── columns: age:1(interval) message:2(string) tag:3(string) operation:4(string)
+
+exec-ddl
+CREATE TABLE xy (x INT PRIMARY KEY, y INT)
+----
+TABLE xy
+ ├── x int not null
+ ├── y int
+ └── INDEX primary
+      └── x int not null
+
+build
+SHOW TRACE FOR SELECT x FROM xy ORDER BY y
+----
+show-trace
+ ├── columns: timestamp:3(timestamptz) age:4(interval) message:5(string) tag:6(string) loc:7(string) operation:8(string) span:9(int)
+ └── sort
+      ├── columns: x:1(int!null)
+      ├── ordering: +2
+      └── scan xy
+           └── columns: x:1(int!null) y:2(int)
+
+build
+SHOW COMPACT TRACE FOR SELECT x FROM xy ORDER BY y
+----
+show-trace compact
+ ├── columns: age:3(interval) message:4(string) tag:5(string) operation:6(string)
+ └── sort
+      ├── columns: x:1(int!null)
+      ├── ordering: +2
+      └── scan xy
+           └── columns: x:1(int!null) y:2(int)
+
+build
+SHOW KV TRACE FOR SELECT x FROM xy ORDER BY y
+----
+show-trace kv
+ ├── columns: timestamp:3(timestamptz) age:4(interval) message:5(string) tag:6(string) loc:7(string) operation:8(string) span:9(int)
+ └── sort
+      ├── columns: x:1(int!null)
+      ├── ordering: +2
+      └── scan xy
+           └── columns: x:1(int!null) y:2(int)
+
+build
+SHOW COMPACT KV TRACE FOR SELECT x FROM xy ORDER BY y
+----
+show-trace compact kv
+ ├── columns: age:3(interval) message:4(string) tag:5(string) operation:6(string)
+ └── sort
+      ├── columns: x:1(int!null)
+      ├── ordering: +2
+      └── scan xy
+           └── columns: x:1(int!null) y:2(int)
+
+build
+SHOW EXPERIMENTAL_REPLICA TRACE FOR SELECT x FROM xy ORDER BY y
+----
+show-trace replica
+ ├── columns: timestamp:3(timestamptz) node_id:4(int) store_id:5(int) replica_id:6(int)
+ └── sort
+      ├── columns: x:1(int!null)
+      ├── ordering: +2
+      └── scan xy
+           └── columns: x:1(int!null) y:2(int)

--- a/pkg/sql/opt/optbuilder/util.go
+++ b/pkg/sql/opt/optbuilder/util.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/transform"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 )
 
 // expandStar expands expr into a list of columns if expr
@@ -118,6 +119,15 @@ func (b *Builder) synthesizeColumn(
 	b.colMap = append(b.colMap, col)
 	scope.cols = append(scope.cols, col)
 	return &scope.cols[len(scope.cols)-1]
+}
+
+func (b *Builder) synthesizeResultColumns(scope *scope, cols sqlbase.ResultColumns) {
+	for i := range cols {
+		c := b.synthesizeColumn(scope, cols[i].Name, cols[i].Typ, nil /* expr */, 0 /* group */)
+		if cols[i].Hidden {
+			c.hidden = true
+		}
+	}
 }
 
 // colIndex takes an expression that refers to a column using an integer,

--- a/pkg/sql/opt/optgen/cmd/optgen/utils.go
+++ b/pkg/sql/opt/optgen/cmd/optgen/utils.go
@@ -68,6 +68,8 @@ func mapPrivateType(typ string) string {
 		return "*memo.SetOpColMap"
 	case "ExplainOpDef":
 		return "*memo.ExplainOpDef"
+	case "ShowTraceOpDef":
+		return "*memo.ShowTraceOpDef"
 	case "Datum":
 		return "tree.Datum"
 	case "Type":

--- a/pkg/sql/opt/xform/physical_props_builder.go
+++ b/pkg/sql/opt/xform/physical_props_builder.go
@@ -142,7 +142,7 @@ func (b physicalPropsBuilder) buildChildProps(
 
 	if required == memo.MinPhysPropsID {
 		switch mexpr.Operator() {
-		case opt.LimitOp, opt.OffsetOp, opt.ExplainOp, opt.RowNumberOp:
+		case opt.LimitOp, opt.OffsetOp, opt.ExplainOp, opt.ShowTraceOp, opt.RowNumberOp:
 		default:
 			// Fast path taken in common case when no properties are required of
 			// parent and the operator itself does not require any properties.
@@ -184,6 +184,11 @@ func (b physicalPropsBuilder) buildChildProps(
 	case opt.ExplainOp:
 		if nth == 0 {
 			childProps = b.mem.LookupPrivate(mexpr.AsExplain().Def()).(*memo.ExplainOpDef).Props
+		}
+
+	case opt.ShowTraceOp:
+		if nth == 0 {
+			childProps = b.mem.LookupPrivate(mexpr.AsShowTrace().Def()).(*memo.ShowTraceOpDef).Props
 		}
 	}
 

--- a/pkg/sql/opt_exec_engine.go
+++ b/pkg/sql/opt_exec_engine.go
@@ -524,6 +524,26 @@ func (ee *execEngine) ConstructExplain(
 	)
 }
 
+// ConstructShowTrace is part of the exec.Factory interface.
+func (ee *execEngine) ConstructShowTrace(
+	typ tree.ShowTraceType, compact bool, input exec.Node,
+) (exec.Node, error) {
+	var inputPlan planNode
+	if input != nil {
+		inputPlan = input.(planNode)
+	}
+
+	// TODO(radu): we hardcode tree.Rows because the optimizer doesn't yet support
+	// statements with other types.
+	node := ee.planner.makeShowTraceNode(inputPlan, tree.Rows, compact, typ == tree.ShowTraceKV)
+
+	if typ == tree.ShowTraceReplica {
+		// Wrap the showTraceNode in a showTraceReplicaNode.
+		return ee.planner.makeShowTraceReplicaNode(node), nil
+	}
+	return node, nil
+}
+
 // execEngineRowWriter is used when executing via DistSQL as a container for the
 // results.
 type execEngineRowWriter struct {

--- a/pkg/sql/plan_columns.go
+++ b/pkg/sql/plan_columns.go
@@ -106,7 +106,7 @@ func getPlanColumns(plan planNode, mut bool) sqlbase.ResultColumns {
 	case *splitNode:
 		return n.getColumns(mut, splitNodeColumns)
 	case *showTraceReplicaNode:
-		return n.getColumns(mut, showTraceReplicaColumns)
+		return n.getColumns(mut, sqlbase.ShowReplicaTraceColumns)
 	case *sequenceSelectNode:
 		return n.getColumns(mut, sequenceSelectColumns)
 

--- a/pkg/sql/show_trace.go
+++ b/pkg/sql/show_trace.go
@@ -23,7 +23,6 @@ import (
 	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
-	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/util/duration"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -100,9 +99,9 @@ func (p *planner) makeShowTraceNode(
 	}
 	if compact {
 		// We make a copy here because n.columns can be mutated to rename columns.
-		n.columns = append(n.columns, showCompactTraceColumns...)
+		n.columns = append(n.columns, sqlbase.ShowCompactTraceColumns...)
 	} else {
-		n.columns = append(n.columns, showTraceColumns...)
+		n.columns = append(n.columns, sqlbase.ShowTraceColumns...)
 	}
 	return n
 }
@@ -333,20 +332,3 @@ var kvMsgRegexp = regexp.MustCompile(
 		"^starting plan$",
 	}, "|"),
 )
-
-var showTraceColumns = sqlbase.ResultColumns{
-	{Name: "timestamp", Typ: types.TimestampTZ},
-	{Name: "age", Typ: types.Interval},
-	{Name: "message", Typ: types.String},
-	{Name: "tag", Typ: types.String},
-	{Name: "loc", Typ: types.String},
-	{Name: "operation", Typ: types.String},
-	{Name: "span", Typ: types.Int},
-}
-
-var showCompactTraceColumns = sqlbase.ResultColumns{
-	{Name: "age", Typ: types.Interval},
-	{Name: "message", Typ: types.String},
-	{Name: "tag", Typ: types.String},
-	{Name: "operation", Typ: types.String},
-}

--- a/pkg/sql/show_trace_replica.go
+++ b/pkg/sql/show_trace_replica.go
@@ -21,8 +21,6 @@ import (
 	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
-	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
-	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/pkg/errors"
 )
 
@@ -66,7 +64,7 @@ func (n *showTraceReplicaNode) Next(params runParams) (bool, error) {
 			return ok, err
 		}
 		values := n.plan.Values()
-		// The rows are received from showTraceNode; see showTraceColumns.
+		// The rows are received from showTraceNode; see ShowTraceColumns.
 		const (
 			tsCol  = 0
 			msgCol = 2
@@ -112,13 +110,6 @@ func (n *showTraceReplicaNode) Values() tree.Datums {
 
 func (n *showTraceReplicaNode) Close(ctx context.Context) {
 	n.plan.Close(ctx)
-}
-
-var showTraceReplicaColumns = sqlbase.ResultColumns{
-	{Name: "timestamp", Typ: types.TimestampTZ},
-	{Name: "node_id", Typ: types.Int},
-	{Name: "store_id", Typ: types.Int},
-	{Name: "replica_id", Typ: types.Int},
 }
 
 var nodeStoreRangeRE = regexp.MustCompile(`^\[n(\d+),s(\d+),r(\d+)/`)

--- a/pkg/sql/sqlbase/result_columns.go
+++ b/pkg/sql/sqlbase/result_columns.go
@@ -71,3 +71,36 @@ func (r ResultColumns) TypesEqual(other ResultColumns) bool {
 	}
 	return true
 }
+
+// ExplainPlanColumns are the result columns of an EXPLAIN (PLAN) ...
+// statement.
+var ExplainPlanColumns = ResultColumns{
+	// Tree shows the node type with the tree structure.
+	{Name: "Tree", Typ: types.String},
+	// Field is the part of the node that a row of output pertains to.
+	{Name: "Field", Typ: types.String},
+	// Description contains details about the field.
+	{Name: "Description", Typ: types.String},
+}
+
+// ExplainPlanVerboseColumns are the result columns of an
+// EXPLAIN (PLAN, ...) ...
+// statement when a flag like VERBOSE or TYPES is passed.
+var ExplainPlanVerboseColumns = ResultColumns{
+	// Tree shows the node type with the tree structure.
+	{Name: "Tree", Typ: types.String},
+	// Level is the depth of the node in the tree. Hidden by default; can be
+	// retrieved using:
+	//   SELECT "Level" FROM [ EXPLAIN (VERBOSE) ... ].
+	{Name: "Level", Typ: types.Int, Hidden: true},
+	// Type is the node type. Hidden by default.
+	{Name: "Type", Typ: types.String, Hidden: true},
+	// Field is the part of the node that a row of output pertains to.
+	{Name: "Field", Typ: types.String},
+	// Description contains details about the field.
+	{Name: "Description", Typ: types.String},
+	// Columns is the type signature of the data source.
+	{Name: "Columns", Typ: types.String},
+	// Ordering indicates the known ordering of the data from this source.
+	{Name: "Ordering", Typ: types.String},
+}

--- a/pkg/sql/sqlbase/result_columns.go
+++ b/pkg/sql/sqlbase/result_columns.go
@@ -104,3 +104,32 @@ var ExplainPlanVerboseColumns = ResultColumns{
 	// Ordering indicates the known ordering of the data from this source.
 	{Name: "Ordering", Typ: types.String},
 }
+
+// ShowTraceColumns are the result columns of a SHOW [KV] TRACE statement.
+var ShowTraceColumns = ResultColumns{
+	{Name: "timestamp", Typ: types.TimestampTZ},
+	{Name: "age", Typ: types.Interval},
+	{Name: "message", Typ: types.String},
+	{Name: "tag", Typ: types.String},
+	{Name: "loc", Typ: types.String},
+	{Name: "operation", Typ: types.String},
+	{Name: "span", Typ: types.Int},
+}
+
+// ShowCompactTraceColumns are the result columns of a
+// SHOW COMPACT [KV] TRACE statement.
+var ShowCompactTraceColumns = ResultColumns{
+	{Name: "age", Typ: types.Interval},
+	{Name: "message", Typ: types.String},
+	{Name: "tag", Typ: types.String},
+	{Name: "operation", Typ: types.String},
+}
+
+// ShowReplicaTraceColumns are the result columns of a
+// SHOW EXPERIMENTAL_REPLICA TRACE statement.
+var ShowReplicaTraceColumns = ResultColumns{
+	{Name: "timestamp", Typ: types.TimestampTZ},
+	{Name: "node_id", Typ: types.Int},
+	{Name: "store_id", Typ: types.Int},
+	{Name: "replica_id", Typ: types.Int},
+}

--- a/pkg/sql/walk.go
+++ b/pkg/sql/walk.go
@@ -586,7 +586,7 @@ var planNodeNames = map[reflect.Type]string{
 	reflect.TypeOf(&explainDistSQLNode{}):       "explain distsql",
 	reflect.TypeOf(&explainPlanNode{}):          "explain plan",
 	reflect.TypeOf(&showTraceNode{}):            "show trace for",
-	reflect.TypeOf(&showTraceReplicaNode{}):     "show trace for",
+	reflect.TypeOf(&showTraceReplicaNode{}):     "replica trace",
 	reflect.TypeOf(&filterNode{}):               "filter",
 	reflect.TypeOf(&groupNode{}):                "group",
 	reflect.TypeOf(&unaryNode{}):                "emptyrow",


### PR DESCRIPTION
#### sql: move explain ResultColumns to sqlbase

We are duplicating the information about the result columns returned
by EXPLAIN statements (in sql and in opt/optbuilder). This change
moves the definitions to sqlbase and uses them in both cases.

Release note: None

#### opt: support SHOW TRACE

Adding optimizer support for SHOW TRACE statements.

We use two operators, one for `SHOW TRACE FOR <query>` and one for
`SHOW TRACE FOR SESSION`. They both use the same `ShowTraceOpDef` for
the private.

We don't add non-explain execbuilder tests because statement tracing
doesn't work with the TestEngine implementation. This will be
addressed in a subsequent PR.

Release note: None
