### PR TITLE
build: use ccache in nightly stress builds

### DIFF
--- a/build/teamcity-stress.sh
+++ b/build/teamcity-stress.sh
@@ -4,7 +4,7 @@ set -euxo pipefail
 export BUILDER_HIDE_GOPATH_SRC=1
 
 source "$(dirname "${0}")/teamcity-support.sh"
-maybe_ccache
+definitely_ccache
 
 mkdir -p artifacts
 

--- a/build/teamcity-support.sh
+++ b/build/teamcity-support.sh
@@ -11,8 +11,12 @@ maybe_ccache() {
     echo "On release branch ($TC_BUILD_BRANCH), so not enabling ccache."
   else
     echo "Building PR (#$TC_BUILD_BRANCH), so enabling ccache."
-    run export COCKROACH_BUILDER_CCACHE=1
+    definitely_ccache
   fi
+}
+
+definitely_ccache() {
+  run export COCKROACH_BUILDER_CCACHE=1
 }
 
 run() {


### PR DESCRIPTION
The logic to prevent ccache from being used in release builds was
unintentionally turning ccache off for stress builds, too. This speeds
up individual stress builds by about three minutes, on average, which
should prevent nightly stress runs from leaking into working hours.

Release note: None