### PR TITLE
sql: support json - text

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/json
+++ b/pkg/sql/logictest/testdata/logic_test/json
@@ -502,6 +502,31 @@ SELECT '{"foo": {"bar": 1}}'::JSONB #- ARRAY['foo', 'bar']
 {"foo": {}}
 
 query T
+SELECT '{"foo": {"bar": 1}}'::JSONB #- ARRAY['foo']
+----
+{}
+
+query T
+SELECT '{"foo": {"bar": 1}}'::JSONB #- ARRAY['bar']
+----
+{"foo": {"bar": 1}}
+
+query T
+SELECT '{"foo": {"bar": 1}, "one": 1, "two": 2}'::JSONB #- ARRAY['one']
+----
+{"foo": {"bar": 1}, "two": 2}
+
+query T
+SELECT '{}'::JSONB #- ARRAY['foo']
+----
+{}
+
+query T
+SELECT '{"foo": {"bar": 1}}'::JSONB #- ARRAY['']
+----
+{"foo": {"bar": 1}}
+
+query T
 SELECT '{"a": "b"}'::JSONB::STRING
 ----
 {"a": "b"}
@@ -510,3 +535,69 @@ query T
 SELECT CAST('{"a": "b"}'::JSONB AS STRING)
 ----
 {"a": "b"}
+
+query T
+SELECT '["1", "2", "3"]'::JSONB - '1'
+----
+["2", "3"]
+
+query T
+SELECT '["1", "2", "1", "2", "3"]'::JSONB - '2'
+----
+["1", "1", "3"]
+
+query T
+SELECT '["1", "2", "3"]'::JSONB - '4'
+----
+["1", "2", "3"]
+
+query T
+SELECT '[]'::JSONB - '1'
+----
+[]
+
+query T
+SELECT '["1", "2", "3"]'::JSONB - ''
+----
+["1", "2", "3"]
+
+query T
+SELECT '[1, "1", 1.0]'::JSONB - '1'
+----
+[1, 1.0]
+
+query T
+SELECT '[1, 2, 3]'::JSONB #- ARRAY['0']
+----
+[2, 3]
+
+query T
+SELECT '[1, 2, 3]'::JSONB #- ARRAY['3']
+----
+[1, 2, 3]
+
+query T
+SELECT '[]'::JSONB #- ARRAY['0']
+----
+[]
+
+statement error pgcode 22P02 a path element is not an integer: foo
+SELECT '["foo"]'::JSONB #- ARRAY['foo']
+
+query T
+SELECT '{"a": ["foo"]}'::JSONB #- ARRAY['a', '0']
+----
+{"a": []}
+
+query T
+SELECT '{"a": ["foo", "bar"]}'::JSONB #- ARRAY['a', '1']
+----
+{"a": ["foo"]}
+
+query T
+SELECT '{"a": []}'::JSONB #- ARRAY['a', '0']
+----
+{"a": []}
+
+statement error pgcode 22P02 a path element is not an integer: foo
+SELECT '{"a": {"b": ["foo"]}}'::JSONB #- ARRAY['a', 'b', 'foo']

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -883,7 +883,7 @@ var BinOps = map[BinaryOperator]binOpOverload{
 			RightType:  types.String,
 			ReturnType: types.JSON,
 			fn: func(_ *EvalContext, left Datum, right Datum) (Datum, error) {
-				j, _, err := left.(*DJSON).JSON.RemoveKey(string(MustBeDString(right)))
+				j, _, err := left.(*DJSON).JSON.RemoveString(string(MustBeDString(right)))
 				if err != nil {
 					return nil, err
 				}

--- a/pkg/util/json/encoded.go
+++ b/pkg/util/json/encoded.go
@@ -648,13 +648,13 @@ func (j *jsonEncoded) Concat(other JSON) (JSON, error) {
 	return decoded.Concat(other)
 }
 
-// RemoveKey implements the JSON interface.
-func (j *jsonEncoded) RemoveKey(key string) (JSON, bool, error) {
+// RemoveString implements the JSON interface.
+func (j *jsonEncoded) RemoveString(s string) (JSON, bool, error) {
 	decoded, err := j.shallowDecode()
 	if err != nil {
 		return nil, false, err
 	}
-	return decoded.RemoveKey(key)
+	return decoded.RemoveString(s)
 }
 
 func (j *jsonEncoded) RemovePath(path []string) (JSON, bool, error) {

--- a/pkg/util/json/json_test.go
+++ b/pkg/util/json/json_test.go
@@ -1020,7 +1020,7 @@ func TestJSONDeepSet(t *testing.T) {
 	}
 }
 
-func TestJSONRemoveKey(t *testing.T) {
+func TestJSONRemoveString(t *testing.T) {
 	json := jsonTestShorthand
 	cases := map[string][]struct {
 		key      string
@@ -1061,7 +1061,7 @@ func TestJSONRemoveKey(t *testing.T) {
 
 		for _, tc := range tests {
 			runDecodedAndEncoded(t, k+`-`+tc.key, left, func(t *testing.T, j JSON) {
-				result, ok, err := j.RemoveKey(tc.key)
+				result, ok, err := j.RemoveString(tc.key)
 				if tc.errMsg != "" {
 					if err == nil {
 						t.Fatal("expected error")
@@ -1902,7 +1902,7 @@ func TestJSONRemovePath(t *testing.T) {
 			{path: []string{}, ok: false, expected: `{"foo": 1}`},
 			{path: []string{"bar"}, ok: false, expected: `{"foo": 1}`},
 		},
-		`{"foo": {"bar": 1, "baz": 2}}}`: {
+		`{"foo": {"bar": 1, "baz": 2}}`: {
 			{path: []string{}, ok: false, expected: `{"foo": {"bar": 1, "baz": 2}}`},
 			{path: []string{"foo"}, ok: true, expected: `{}`},
 			{path: []string{"foo", "bar"}, ok: true, expected: `{"foo": {"baz": 2}}`},
@@ -1932,8 +1932,8 @@ func TestJSONRemovePath(t *testing.T) {
 			{path: []string{"0", "0"}, ok: true, expected: `[[]]`},
 		},
 		`[1]`: {
-			{path: []string{"foo"}, ok: false, expected: `[1]`},
-			{path: []string{""}, ok: false, expected: `[1]`},
+			{path: []string{"foo"}, ok: false, expected: "", errMsg: "a path element is not an integer: foo"},
+			{path: []string{""}, ok: false, expected: "", errMsg: "a path element is not an integer: "},
 			{path: []string{"0"}, ok: true, expected: `[]`},
 			{path: []string{"0", "0"}, ok: false, expected: `[1]`},
 		},


### PR DESCRIPTION
Added support for JSONArray minus string. The code used to quietly
do nothing on the operation; now, instead, it loops over all elements
of the array, converts it to string and compares to the key to be removed.

Resolves: #25665.

Release note: None