### PR TITLE
sql: Log event for TRUNCATE TABLE

### DIFF
--- a/pkg/sql/event_log.go
+++ b/pkg/sql/event_log.go
@@ -40,6 +40,8 @@ const (
 	EventLogCreateTable EventLogType = "create_table"
 	// EventLogDropTable is recorded when a table is dropped.
 	EventLogDropTable EventLogType = "drop_table"
+	// EventLogTruncateTable is recorded when a table is truncated.
+	EventLogTruncateTable EventLogType = "truncate_table"
 	// EventLogAlterTable is recorded when a table is altered.
 	EventLogAlterTable EventLogType = "alter_table"
 

--- a/pkg/sql/logictest/testdata/logic_test/event_log
+++ b/pkg/sql/logictest/testdata/logic_test/event_log
@@ -174,6 +174,19 @@ WHERE "eventType" = 'finish_schema_change'
 53  1
 53  1
 
+# Truncate a table
+##################
+
+statement ok
+TRUNCATE TABLE a
+
+query IIT rowsort
+SELECT "targetID", "reportingID", info::JSONB->>'TableName'
+FROM system.eventlog
+WHERE "eventType" = 'truncate_table'
+----
+53  1  test.public.a
+
 # Drop both tables + superfluous "IF EXISTS"
 ##################
 
@@ -196,7 +209,7 @@ SELECT "targetID", "reportingID", info::JSONB->>'TableName'
 FROM system.eventlog
 WHERE "eventType" = 'drop_table'
 ----
-53  1  test.public.a
+55  1  test.public.a
 54  1  test.public.b
 
 # Verify the contents of the 'info' field of each event.
@@ -208,7 +221,7 @@ FROM system.eventlog
 WHERE "eventType" = 'drop_table'
   AND info::JSONB->>'Statement' LIKE 'DROP TABLE a%'
 ----
-53  1  test.public.a
+55  1  test.public.a
 
 query IIT
 SELECT "targetID", "reportingID", info::JSONB->>'TableName'
@@ -245,7 +258,7 @@ FROM system.eventlog
 WHERE "eventType" = 'create_database'
   AND info::JSONB->>'Statement' LIKE 'CREATE DATABASE eventlogtest%'
 ----
-55  1
+56  1
 
 query II
 SELECT "targetID", "reportingID"
@@ -253,7 +266,7 @@ FROM system.eventlog
 WHERE "eventType" = 'create_database'
   AND info::JSONB->>'Statement' LIKE 'CREATE DATABASE IF NOT EXISTS othereventlogtest%'
 ----
-56  1
+57  1
 
 # Add some tables to eventlogtest.
 ##################
@@ -290,7 +303,7 @@ FROM system.eventlog
 WHERE "eventType" = 'drop_database'
   AND info::JSONB->>'Statement' LIKE 'DROP DATABASE eventlogtest%'
 ----
-55  1  ["eventlogtest.public.anothertesttable", "eventlogtest.public.testtable"]
+56  1  ["eventlogtest.public.anothertesttable", "eventlogtest.public.testtable"]
 
 query IIT
 SELECT "targetID", "reportingID", info::JSONB->>'DroppedSchemaObjects'
@@ -298,7 +311,7 @@ FROM system.eventlog
 WHERE "eventType" = 'drop_database'
   AND info::JSONB->>'Statement' LIKE 'DROP DATABASE IF EXISTS othereventlogtest%'
 ----
-56  1  []
+57  1  []
 
 statement ok
 SET DATABASE = test
@@ -356,7 +369,7 @@ FROM system.eventlog
 WHERE "eventType" = 'set_zone_config'
 ORDER BY "timestamp"
 ----
-59  1  {"Target":"test.a","Config":"range_max_bytes: 67108865","User":"root"}
+60  1  {"Target":"test.a","Config":"range_max_bytes: 67108865","User":"root"}
 22  1  {"Target":".liveness","Config":"range_min_bytes: 1048577","User":"root"}
 
 query IIT
@@ -365,7 +378,7 @@ FROM system.eventlog
 WHERE "eventType" = 'remove_zone_config'
 ORDER BY "timestamp"
 ----
-59  1  {"Target":"test.a","User":"root"}
+60  1  {"Target":"test.a","User":"root"}
 22  1  {"Target":".liveness","User":"root"}
 
 statement ok
@@ -387,9 +400,9 @@ SELECT "eventType", "targetID", "reportingID", info::JSONB->>'SequenceName'
   FROM system.eventlog
  WHERE "eventType" in ('create_sequence', 'alter_sequence', 'drop_sequence')
 ----
-create_sequence  60  1  test.public.s
-alter_sequence   60  1  test.public.s
-drop_sequence    60  1  test.public.s
+create_sequence  61  1  test.public.s
+alter_sequence   61  1  test.public.s
+drop_sequence    61  1  test.public.s
 
 # Views
 
@@ -404,5 +417,5 @@ SELECT "eventType", "targetID", "reportingID", info::JSONB->>'ViewName'
   FROM system.eventlog
  WHERE "eventType" in ('create_view', 'drop_view')
 ----
-create_view  61  1  test.public.v
-drop_view    61  1  test.public.v
+create_view  62  1  test.public.v
+drop_view    62  1  test.public.v

--- a/pkg/ui/src/util/eventTypes.ts
+++ b/pkg/ui/src/util/eventTypes.ts
@@ -14,6 +14,8 @@ export const DROP_DATABASE = "drop_database";
 export const CREATE_TABLE = "create_table";
 // Recorded when a table is dropped.
 export const DROP_TABLE = "drop_table";
+// Recorded when a table is truncated.
+export const TRUNCATE_TABLE = "truncate_table";
 // Recorded when a table is altered.
 export const ALTER_TABLE = "alter_table";
 // Recorded when an index is created.
@@ -58,9 +60,9 @@ export const REMOVE_ZONE_CONFIG = "remove_zone_config";
 export const nodeEvents = [NODE_JOIN, NODE_RESTART, NODE_DECOMMISSIONED, NODE_RECOMMISSIONED];
 export const databaseEvents = [CREATE_DATABASE, DROP_DATABASE];
 export const tableEvents = [
-  CREATE_TABLE, DROP_TABLE, ALTER_TABLE, CREATE_INDEX, ALTER_INDEX,
-  DROP_INDEX, CREATE_VIEW, DROP_VIEW, REVERSE_SCHEMA_CHANGE, FINISH_SCHEMA_CHANGE,
-  FINISH_SCHEMA_CHANGE_ROLLBACK,
+  CREATE_TABLE, DROP_TABLE, TRUNCATE_TABLE, ALTER_TABLE, CREATE_INDEX,
+  ALTER_INDEX, DROP_INDEX, CREATE_VIEW, DROP_VIEW, REVERSE_SCHEMA_CHANGE,
+  FINISH_SCHEMA_CHANGE, FINISH_SCHEMA_CHANGE_ROLLBACK,
 ];
 export const settingsEvents = [SET_CLUSTER_SETTING, SET_ZONE_CONFIG, REMOVE_ZONE_CONFIG];
 export const allEvents = [...nodeEvents, ...databaseEvents, ...tableEvents, ...settingsEvents];

--- a/pkg/ui/src/util/events.ts
+++ b/pkg/ui/src/util/events.ts
@@ -22,6 +22,8 @@ export function getEventDescription(e: Event$Properties): string {
       return `Table Created: User ${info.User} created table ${info.TableName}`;
     case eventTypes.DROP_TABLE:
       return `Table Dropped: User ${info.User} dropped table ${info.TableName}`;
+    case eventTypes.TRUNCATE_TABLE:
+      return `Table Truncated: User ${info.User} truncated table ${info.TableName}`;
     case eventTypes.ALTER_TABLE:
       return `Schema Change: User ${info.User} began a schema change to alter table ${info.TableName} with ID ${info.MutationID}`;
     case eventTypes.CREATE_INDEX:


### PR DESCRIPTION
Fixes #25867

Release note (sql change): TRUNCATE TABLE commands are now logged in the
event log.