### PR TITLE
sqlbase: Fix comment referencing function that has since moved

### DIFF
--- a/pkg/sql/sqlbase/structured.pb.go
+++ b/pkg/sql/sqlbase/structured.pb.go
@@ -959,8 +959,8 @@ func _DescriptorMutation_OneofSizer(msg proto.Message) (n int) {
 // structured metadata key. The TableDescriptor has a globally-unique ID,
 // while its member {Column,Index}Descriptors have locally-unique IDs.
 type TableDescriptor struct {
-	// The table name. It should be normalized using sqlbase.NormalizeName()
-	// before comparing it.
+	// The table name. It should be normalized using NormalizeName() before
+	// comparing it.
 	Name string `protobuf:"bytes,1,opt,name=name" json:"name"`
 	ID   ID     `protobuf:"varint,3,opt,name=id,casttype=ID" json:"id"`
 	// ID of the parent database.

--- a/pkg/sql/sqlbase/structured.proto
+++ b/pkg/sql/sqlbase/structured.proto
@@ -448,8 +448,8 @@ message TableDescriptor {
   // Needed for the descriptorProto interface.
   option (gogoproto.goproto_getters) = true;
 
-  // The table name. It should be normalized using sqlbase.NormalizeName()
-  // before comparing it.
+  // The table name. It should be normalized using NormalizeName() before
+  // comparing it.
   optional string name = 1 [(gogoproto.nullable) = false];
   optional uint32 id = 3 [(gogoproto.nullable) = false,
       (gogoproto.customname) = "ID", (gogoproto.casttype) = "ID"];


### PR DESCRIPTION
NormalizeName has since moved to the "lex" package, and this confused me
about whether it was the same function being referred to here. Just
get rid of the package prefix to avoid this confusion in the future.

Release note: None