### PR TITLE
sql: use distsql for local distinct

### DIFF
--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -1718,7 +1718,7 @@ func (dsp *DistSQLPlanner) createPlanForIndexJoin(
 }
 
 // getTypesForPlanResult returns the types of the elements in the result streams
-// of a plan that corresponds to a given planNode. If planToSreamColMap is nil,
+// of a plan that corresponds to a given planNode. If planToStreamColMap is nil,
 // a 1-1 mapping is assumed.
 func getTypesForPlanResult(node planNode, planToStreamColMap []int) ([]sqlbase.ColumnType, error) {
 	nodeColumns := planColumns(node)
@@ -2220,6 +2220,36 @@ func (dsp *DistSQLPlanner) createPlanForValues(
 	}, nil
 }
 
+func createDistinctSpec(n *distinctNode, cols []int) *distsqlrun.DistinctSpec {
+	var orderedColumns []uint32
+	for i, o := range n.columnsInOrder {
+		if o {
+			orderedColumns = append(orderedColumns, uint32(cols[i]))
+		}
+	}
+
+	var distinctColumns []uint32
+	if !n.distinctOnColIdxs.Empty() {
+		for planCol, streamCol := range cols {
+			if streamCol != -1 && n.distinctOnColIdxs.Contains(planCol) {
+				distinctColumns = append(distinctColumns, uint32(streamCol))
+			}
+		}
+	} else {
+		// If no distinct columns were specified, run distinct on the entire row.
+		for planCol := range planColumns(n) {
+			if streamCol := cols[planCol]; streamCol != -1 {
+				distinctColumns = append(distinctColumns, uint32(streamCol))
+			}
+		}
+	}
+
+	return &distsqlrun.DistinctSpec{
+		OrderedColumns:  orderedColumns,
+		DistinctColumns: distinctColumns,
+	}
+}
+
 func (dsp *DistSQLPlanner) createPlanForDistinct(
 	planCtx *planningCtx, n *distinctNode,
 ) (physicalPlan, error) {
@@ -2228,34 +2258,9 @@ func (dsp *DistSQLPlanner) createPlanForDistinct(
 		return physicalPlan{}, err
 	}
 	currentResultRouters := plan.ResultRouters
-	var orderedColumns []uint32
-	for i, o := range n.columnsInOrder {
-		if o {
-			orderedColumns = append(orderedColumns, uint32(plan.planToStreamColMap[i]))
-		}
-	}
-
-	var distinctColumns []uint32
-	if !n.distinctOnColIdxs.Empty() {
-		for planCol, streamCol := range plan.planToStreamColMap {
-			if streamCol != -1 && n.distinctOnColIdxs.Contains(planCol) {
-				distinctColumns = append(distinctColumns, uint32(streamCol))
-			}
-		}
-	} else {
-		// If no distinct columns were specified, run distinct on the entire row.
-		for planCol := range planColumns(n) {
-			if streamCol := plan.planToStreamColMap[planCol]; streamCol != -1 {
-				distinctColumns = append(distinctColumns, uint32(streamCol))
-			}
-		}
-	}
 
 	distinctSpec := distsqlrun.ProcessorCoreUnion{
-		Distinct: &distsqlrun.DistinctSpec{
-			OrderedColumns:  orderedColumns,
-			DistinctColumns: distinctColumns,
-		},
+		Distinct: createDistinctSpec(n, plan.planToStreamColMap),
 	}
 
 	if len(currentResultRouters) == 1 {

--- a/pkg/sql/distsqlrun/base.go
+++ b/pkg/sql/distsqlrun/base.go
@@ -155,6 +155,12 @@ type RowSource interface {
 	ConsumerClosed()
 }
 
+// RowSourcedProcessor is the union of RowSource and Processor.
+type RowSourcedProcessor interface {
+	RowSource
+	Run(_ context.Context, wg *sync.WaitGroup)
+}
+
 // Run reads records from the source and outputs them to the receiver, properly
 // draining the source of metadata and closing both the source and receiver.
 //

--- a/pkg/sql/distsqlrun/distinct.go
+++ b/pkg/sql/distsqlrun/distinct.go
@@ -25,6 +25,7 @@ import (
 	"github.com/pkg/errors"
 )
 
+// Distinct is the physical processor implementation of the DISTINCT relational operator.
 type Distinct struct {
 	processorBase
 
@@ -57,14 +58,15 @@ var _ RowSource = &SortedDistinct{}
 
 const sortedDistinctProcName = "sorted distinct"
 
-func newDistinct(
+// NewDistinct instantiates a new Distinct processor.
+func NewDistinct(
 	flowCtx *FlowCtx,
 	processorID int32,
 	spec *DistinctSpec,
 	input RowSource,
 	post *PostProcessSpec,
 	output RowReceiver,
-) (Processor, error) {
+) (RowSourcedProcessor, error) {
 	if len(spec.DistinctColumns) == 0 {
 		return nil, errors.New("programming error: 0 distinct columns specified for distinct processor")
 	}

--- a/pkg/sql/distsqlrun/distinct.go
+++ b/pkg/sql/distsqlrun/distinct.go
@@ -25,7 +25,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-type distinct struct {
+type Distinct struct {
 	processorBase
 
 	input            RowSource
@@ -41,19 +41,19 @@ type distinct struct {
 	scratch          []byte
 }
 
-// sortedDistinct is a specialized distinct that can be used when all of the
+// SortedDistinct is a specialized distinct that can be used when all of the
 // distinct columns are also ordered.
-type sortedDistinct struct {
-	distinct
+type SortedDistinct struct {
+	Distinct
 }
 
-var _ Processor = &distinct{}
-var _ RowSource = &distinct{}
+var _ Processor = &Distinct{}
+var _ RowSource = &Distinct{}
 
 const distinctProcName = "distinct"
 
-var _ Processor = &sortedDistinct{}
-var _ RowSource = &sortedDistinct{}
+var _ Processor = &SortedDistinct{}
+var _ RowSource = &SortedDistinct{}
 
 const sortedDistinctProcName = "sorted distinct"
 
@@ -82,7 +82,7 @@ func newDistinct(
 		distinctCols.Add(int(col))
 	}
 
-	d := &distinct{
+	d := &Distinct{
 		input:        input,
 		orderedCols:  spec.OrderedColumns,
 		distinctCols: distinctCols,
@@ -106,8 +106,8 @@ func newDistinct(
 
 	if allSorted {
 		// We can use the faster sortedDistinct processor.
-		return &sortedDistinct{
-			distinct: *d,
+		return &SortedDistinct{
+			Distinct: *d,
 		}, nil
 	}
 
@@ -115,13 +115,13 @@ func newDistinct(
 }
 
 // Start is part of the RowSource interface.
-func (d *distinct) Start(ctx context.Context) context.Context {
+func (d *Distinct) Start(ctx context.Context) context.Context {
 	d.input.Start(ctx)
 	return d.startInternal(ctx, distinctProcName)
 }
 
 // Run is part of the processor interface.
-func (d *distinct) Run(ctx context.Context, wg *sync.WaitGroup) {
+func (d *Distinct) Run(ctx context.Context, wg *sync.WaitGroup) {
 	if d.out.output == nil {
 		panic("distinct output not initialized for emitting rows")
 	}
@@ -133,13 +133,13 @@ func (d *distinct) Run(ctx context.Context, wg *sync.WaitGroup) {
 }
 
 // Start is part of the RowSource interface.
-func (d *sortedDistinct) Start(ctx context.Context) context.Context {
+func (d *SortedDistinct) Start(ctx context.Context) context.Context {
 	d.input.Start(ctx)
 	return d.startInternal(ctx, sortedDistinctProcName)
 }
 
 // Run is part of the processor interface.
-func (d *sortedDistinct) Run(ctx context.Context, wg *sync.WaitGroup) {
+func (d *SortedDistinct) Run(ctx context.Context, wg *sync.WaitGroup) {
 	if d.out.output == nil {
 		panic("distinct output not initialized for emitting rows")
 	}
@@ -150,7 +150,7 @@ func (d *sortedDistinct) Run(ctx context.Context, wg *sync.WaitGroup) {
 	}
 }
 
-func (d *distinct) matchLastGroupKey(row sqlbase.EncDatumRow) (bool, error) {
+func (d *Distinct) matchLastGroupKey(row sqlbase.EncDatumRow) (bool, error) {
 	if !d.haveLastGroupKey {
 		return false, nil
 	}
@@ -167,7 +167,7 @@ func (d *distinct) matchLastGroupKey(row sqlbase.EncDatumRow) (bool, error) {
 
 // encode appends the encoding of non-ordered columns, which we use as a key in
 // our 'seen' set.
-func (d *distinct) encode(appendTo []byte, row sqlbase.EncDatumRow) ([]byte, error) {
+func (d *Distinct) encode(appendTo []byte, row sqlbase.EncDatumRow) ([]byte, error) {
 	var err error
 	for i, datum := range row {
 		// Ignore columns that are not in the distinctCols, as if we are
@@ -192,14 +192,14 @@ func (d *distinct) encode(appendTo []byte, row sqlbase.EncDatumRow) ([]byte, err
 	return appendTo, nil
 }
 
-func (d *distinct) close() {
+func (d *Distinct) close() {
 	// Need to close the mem accounting while the context is still valid.
 	d.memAcc.Close(d.ctx)
 	d.internalClose()
 }
 
 // Next is part of the RowSource interface.
-func (d *distinct) Next() (sqlbase.EncDatumRow, *ProducerMetadata) {
+func (d *Distinct) Next() (sqlbase.EncDatumRow, *ProducerMetadata) {
 	for d.state == stateRunning {
 		row, meta := d.input.Next()
 		if meta != nil {
@@ -266,7 +266,7 @@ func (d *distinct) Next() (sqlbase.EncDatumRow, *ProducerMetadata) {
 //
 // sortedDistinct is simpler than distinct. All it has to do is keep track
 // of the last row it saw, emitting if the new row is different.
-func (d *sortedDistinct) Next() (sqlbase.EncDatumRow, *ProducerMetadata) {
+func (d *SortedDistinct) Next() (sqlbase.EncDatumRow, *ProducerMetadata) {
 	for d.state == stateRunning {
 		row, meta := d.input.Next()
 		if meta != nil {
@@ -296,12 +296,12 @@ func (d *sortedDistinct) Next() (sqlbase.EncDatumRow, *ProducerMetadata) {
 }
 
 // ConsumerDone is part of the RowSource interface.
-func (d *distinct) ConsumerDone() {
+func (d *Distinct) ConsumerDone() {
 	d.input.ConsumerDone()
 }
 
 // ConsumerClosed is part of the RowSource interface.
-func (d *distinct) ConsumerClosed() {
+func (d *Distinct) ConsumerClosed() {
 	// The consumer is done, Next() will not be called again.
 	d.close()
 }

--- a/pkg/sql/distsqlrun/distinct_test.go
+++ b/pkg/sql/distsqlrun/distinct_test.go
@@ -123,7 +123,7 @@ func TestDistinct(t *testing.T) {
 				EvalCtx:  evalCtx,
 			}
 
-			d, err := newDistinct(&flowCtx, 0 /* processorID */, &ds, in, &PostProcessSpec{}, out)
+			d, err := NewDistinct(&flowCtx, 0 /* processorID */, &ds, in, &PostProcessSpec{}, out)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -173,7 +173,7 @@ func benchmarkDistinct(b *testing.B, orderedColumns []uint32) {
 			b.SetBytes(int64(8 * numRows * numCols))
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
-				d, err := newDistinct(flowCtx, 0 /* processorID */, spec, input, post, &RowDisposer{})
+				d, err := NewDistinct(flowCtx, 0 /* processorID */, spec, input, post, &RowDisposer{})
 				if err != nil {
 					b.Fatal(err)
 				}

--- a/pkg/sql/distsqlrun/processors.go
+++ b/pkg/sql/distsqlrun/processors.go
@@ -916,7 +916,7 @@ func newProcessor(
 		if err := checkNumInOut(inputs, outputs, 1, 1); err != nil {
 			return nil, err
 		}
-		return newDistinct(flowCtx, processorID, core.Distinct, inputs[0], post, outputs[0])
+		return NewDistinct(flowCtx, processorID, core.Distinct, inputs[0], post, outputs[0])
 	}
 	if core.Aggregator != nil {
 		if err := checkNumInOut(inputs, outputs, 1, 1); err != nil {

--- a/pkg/sql/plan_node_to_row_source.go
+++ b/pkg/sql/plan_node_to_row_source.go
@@ -1,0 +1,103 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package sql
+
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/distsqlrun"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+)
+
+type planNodeToRowSource struct {
+	running bool
+
+	node        planNode
+	params      runParams
+	outputTypes []sqlbase.ColumnType
+
+	// run time state machine values
+	ctx context.Context
+	row sqlbase.EncDatumRow
+}
+
+func makePlanNodeToRowSource(source planNode, params runParams) (*planNodeToRowSource, error) {
+	nodeColumns := planColumns(source)
+
+	types := make([]sqlbase.ColumnType, len(nodeColumns))
+	for i := range nodeColumns {
+		colTyp, err := sqlbase.DatumTypeToColumnType(nodeColumns[i].Typ)
+		if err != nil {
+			return nil, err
+		}
+		types[i] = colTyp
+	}
+	row := make(sqlbase.EncDatumRow, len(nodeColumns))
+
+	return &planNodeToRowSource{
+		node:        source,
+		params:      params,
+		outputTypes: types,
+		row:         row,
+		running:     true,
+	}, nil
+}
+
+var _ distsqlrun.RowSource = &planNodeToRowSource{}
+
+func (p *planNodeToRowSource) OutputTypes() []sqlbase.ColumnType {
+	return p.outputTypes
+}
+
+func (p *planNodeToRowSource) Start(ctx context.Context) context.Context {
+	p.ctx = ctx
+	return ctx
+}
+
+func (p *planNodeToRowSource) internalClose() {
+	if p.running {
+		p.node.Close(p.ctx)
+		p.running = false
+	}
+}
+
+func (p *planNodeToRowSource) Next() (sqlbase.EncDatumRow, *distsqlrun.ProducerMetadata) {
+	if !p.running {
+		return nil, nil
+	}
+
+	valid, err := p.node.Next(p.params)
+	if err != nil {
+		p.internalClose()
+		return nil, &distsqlrun.ProducerMetadata{Err: err}
+	}
+	if !valid {
+		p.internalClose()
+		return nil, nil
+	}
+
+	for i, datum := range p.node.Values() {
+		p.row[i] = sqlbase.DatumToEncDatum(p.outputTypes[i], datum)
+	}
+	return p.row, nil
+}
+
+func (p *planNodeToRowSource) ConsumerDone() {
+	p.internalClose()
+}
+
+func (p *planNodeToRowSource) ConsumerClosed() {
+	p.internalClose()
+}

--- a/pkg/sql/row_source_to_plan_node.go
+++ b/pkg/sql/row_source_to_plan_node.go
@@ -1,0 +1,86 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package sql
+
+import (
+	"context"
+
+	"fmt"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/distsqlrun"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+)
+
+// rowSourceToPlanNode wraps a RowSource and presents it as a PlanNode. It must
+// be constructed with Create(), after which it is a PlanNode and can be treated
+// as such.
+type rowSourceToPlanNode struct {
+	source distsqlrun.RowSource
+
+	// Temporary variables
+	row      sqlbase.EncDatumRow
+	da       sqlbase.DatumAlloc
+	datumRow tree.Datums
+}
+
+var _ planNode = &rowSourceToPlanNode{}
+
+func makeRowSourceToPlanNode(s distsqlrun.RowSource) *rowSourceToPlanNode {
+	row := make(tree.Datums, len(s.OutputTypes()))
+
+	return &rowSourceToPlanNode{
+		source:   s,
+		datumRow: row,
+	}
+}
+
+func (r *rowSourceToPlanNode) Next(params runParams) (bool, error) {
+	for {
+		var p *distsqlrun.ProducerMetadata
+		r.row, p = r.source.Next()
+
+		if p != nil {
+			if p.Err != nil {
+				return false, p.Err
+			}
+			if p.TraceData != nil {
+				// We drop trace metadata since we have no reasonable way to propagate
+				// it in local SQL execution.
+				continue
+			}
+			return false, fmt.Errorf("unexpected producer metadata: %+v", p)
+		}
+
+		if r.row == nil {
+			return false, nil
+		}
+
+		if err := sqlbase.EncDatumRowToDatums(r.source.OutputTypes(), r.datumRow, r.row, &r.da); err != nil {
+			return false, err
+		}
+		return true, nil
+	}
+}
+
+func (r *rowSourceToPlanNode) Values() tree.Datums {
+	return r.datumRow
+}
+
+func (r *rowSourceToPlanNode) Close(ctx context.Context) {
+	if r.source != nil {
+		r.source.ConsumerClosed()
+	}
+}


### PR DESCRIPTION
Use the distsql distinct processor for processing local sql queries. This is a work-in-progress to demonstrate and begin a discussion around the shims used.

This PR is rebased on top of #25860, so only evaluate the last commit. The main interfaces on which I'd like discussion are RowSourceToPlanNode and PlanNodeToRowSource. The rest of this PR is exporting changes (2nd commit), some planning plumbing, and code removal in local distinct.