### PR TITLE
ui: fix action names broken by #25823

### DIFF
--- a/pkg/ui/src/views/devtools/containers/raftMessages/index.tsx
+++ b/pkg/ui/src/views/devtools/containers/raftMessages/index.tsx
@@ -176,7 +176,7 @@ function mapStateToProps(state: AdminUIState) {
 const actions = {
   refreshNodes,
   refreshLiveness,
-  hoverOnAction,
-  hoverOffAction,
+  hoverOn: hoverOnAction,
+  hoverOff: hoverOffAction,
 };
 export default connect(mapStateToProps, actions)(NodeGraphs);

--- a/pkg/ui/src/views/shared/containers/metricDataProvider/index.tsx
+++ b/pkg/ui/src/views/shared/containers/metricDataProvider/index.tsx
@@ -223,7 +223,7 @@ const metricsDataProviderConnected = connect(
     };
   },
   {
-    requestMetricsAction,
+    requestMetrics: requestMetricsAction,
   },
 )(MetricsDataProvider);
 


### PR DESCRIPTION
In that PR, I mechanically replaced identifiers when there were new
warnings about shadowing, but in two places I accidentally changed
semantics due to the shorthand form of object literals.  :man_facepalming:

Release note: None