### PR TITLE
cmd/internal/issues: avoid segfault on nil-Author

### DIFF
--- a/pkg/cmd/internal/issues/issues.go
+++ b/pkg/cmd/internal/issues/issues.go
@@ -111,6 +111,9 @@ func getAssignee(
 	listCommits func(ctx context.Context, owner string, repo string,
 		opts *github.CommitsListOptions) ([]*github.RepositoryCommit, *github.Response, error),
 ) (string, error) {
+	if authorEmail == "" {
+		return "", nil
+	}
 	commits, _, err := listCommits(ctx, githubUser, githubRepo, &github.CommitsListOptions{
 		Author: authorEmail,
 		ListOptions: github.ListOptions{
@@ -124,6 +127,9 @@ func getAssignee(
 		return "", errors.Errorf("couldn't find GitHub commits for user email %s", authorEmail)
 	}
 
+	if commits[0].Author == nil {
+		return "", nil
+	}
 	assignee := *commits[0].Author.Login
 
 	if newAssignee, ok := oldFriendsMap[assignee]; ok {

--- a/pkg/cmd/internal/issues/issues_test.go
+++ b/pkg/cmd/internal/issues/issues_test.go
@@ -255,3 +255,13 @@ Failed test: %s`,
 		}
 	}
 }
+
+func TestGetAssignee(t *testing.T) {
+	listCommits := func(_ context.Context, owner string, repo string,
+		opts *github.CommitsListOptions) ([]*github.RepositoryCommit, *github.Response, error) {
+		return []*github.RepositoryCommit{
+			{},
+		}, nil, nil
+	}
+	_, _ = getAssignee(context.Background(), "", listCommits)
+}


### PR DESCRIPTION
Avoid a nil-pointer dereference if we find a commit with a nil-Author
field. Seen on a nightly roachtest build.

Release note: None