### PR TITLE
opt: Enable additional logic tests for opt configs

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/as_of
+++ b/pkg/sql/logictest/testdata/logic_test/as_of
@@ -1,4 +1,4 @@
-# LogicTest: default
+# LogicTest: default opt
 
 statement ok
 CREATE TABLE t (i INT)

--- a/pkg/sql/logictest/testdata/logic_test/backup
+++ b/pkg/sql/logictest/testdata/logic_test/backup
@@ -1,4 +1,4 @@
-# LogicTest: default distsql distsql-metadata
+# LogicTest: default opt distsql distsql-opt distsql-metadata
 
 query error unknown statement type
 BACKUP DATABASE foo TO '/bar' INCREMENTAL FROM '/baz'

--- a/pkg/sql/logictest/testdata/logic_test/builtin_function
+++ b/pkg/sql/logictest/testdata/logic_test/builtin_function
@@ -1,5 +1,11 @@
 # LogicTest: default parallel-stmts distsql distsql-metadata
 
+statement ok
+CREATE TABLE foo (a int)
+
+statement ok
+INSERT INTO foo (a) VALUES (1)
+
 query error unknown function: foo.bar
 SELECT foo.bar()
 
@@ -1055,6 +1061,27 @@ SELECT GREATEST(1, 1.2)
 ----
 1.2
 
+# Test homogenous functions that can't be constant folded.
+query I
+SELECT GREATEST(NULL, a, 5, NULL) FROM foo
+----
+5
+
+query I
+SELECT GREATEST(NULL, NULL, NULL, a, -1) FROM foo
+----
+1
+
+query I
+SELECT LEAST(NULL, a, 5, NULL) FROM foo
+----
+1
+
+query I
+SELECT LEAST(NULL, NULL, NULL, a, -1) FROM foo
+----
+-1
+
 # Test float and int comparison.
 
 query BBBB
@@ -1218,9 +1245,6 @@ false
 # SELECT current_schema()
 # ----
 # NULL
-
-statement ok
-CREATE TABLE foo (a int)
 
 query B
 SELECT pg_catalog.pg_table_is_visible('foo'::regclass)

--- a/pkg/sql/logictest/testdata/logic_test/builtin_function
+++ b/pkg/sql/logictest/testdata/logic_test/builtin_function
@@ -1,4 +1,4 @@
-# LogicTest: default parallel-stmts distsql distsql-metadata
+# LogicTest: default opt parallel-stmts distsql distsql-metadata
 
 statement ok
 CREATE TABLE foo (a int)

--- a/pkg/sql/logictest/testdata/logic_test/bytes
+++ b/pkg/sql/logictest/testdata/logic_test/bytes
@@ -1,4 +1,4 @@
-# LogicTest: default
+# LogicTest: default opt
 
 query T
 SELECT 'non-escaped-string':::BYTES::STRING

--- a/pkg/sql/logictest/testdata/logic_test/cascade
+++ b/pkg/sql/logictest/testdata/logic_test/cascade
@@ -1,4 +1,4 @@
-# LogicTest: default parallel-stmts distsql distsql-metadata
+# LogicTest: default opt parallel-stmts distsql distsql-opt distsql-metadata
 
 subtest AllCascadingActions
 ### A test of all cascading actions in their most basic form.

--- a/pkg/sql/logictest/testdata/logic_test/case_sensitive_names
+++ b/pkg/sql/logictest/testdata/logic_test/case_sensitive_names
@@ -1,4 +1,4 @@
-# LogicTest: default distsql distsql-metadata
+# LogicTest: default opt distsql distsql-opt distsql-metadata
 
 # Case sensitivity of database names
 

--- a/pkg/sql/logictest/testdata/logic_test/ccl
+++ b/pkg/sql/logictest/testdata/logic_test/ccl
@@ -1,4 +1,4 @@
-# LogicTest: default
+# LogicTest: default opt
 
 # CCL-only statements error out trying to handle the parsed statements.
 

--- a/pkg/sql/logictest/testdata/logic_test/check_constraints
+++ b/pkg/sql/logictest/testdata/logic_test/check_constraints
@@ -1,4 +1,4 @@
-# LogicTest: default parallel-stmts distsql distsql-metadata
+# LogicTest: default opt parallel-stmts distsql distsql-opt distsql-metadata
 
 #### column CHECK constraints
 

--- a/pkg/sql/logictest/testdata/logic_test/collatedstring
+++ b/pkg/sql/logictest/testdata/logic_test/collatedstring
@@ -1,4 +1,4 @@
-# LogicTest: default parallel-stmts distsql distsql-metadata
+# LogicTest: default opt parallel-stmts distsql distsql-opt distsql-metadata
 
 statement error pq: invalid locale bad_locale: language: subtag "locale" is well-formed but unknown
 SELECT 'a' COLLATE bad_locale

--- a/pkg/sql/logictest/testdata/logic_test/collatedstring_constraint
+++ b/pkg/sql/logictest/testdata/logic_test/collatedstring_constraint
@@ -1,4 +1,4 @@
-# LogicTest: default parallel-stmts distsql distsql-metadata distsql-disk
+# LogicTest: default opt parallel-stmts distsql distsql-opt distsql-metadata distsql-disk
 
 # English collation chart: http://www.unicode.org/cldr/charts/30/collation/en_US_POSIX.html
 

--- a/pkg/sql/logictest/testdata/logic_test/collatedstring_index1
+++ b/pkg/sql/logictest/testdata/logic_test/collatedstring_index1
@@ -1,4 +1,4 @@
-# LogicTest: default parallel-stmts distsql distsql-metadata distsql-disk
+# LogicTest: default opt parallel-stmts distsql distsql-opt distsql-metadata distsql-disk
 
 ##
 # Test a primary key with a collated string in first position (can get a key range).
@@ -71,14 +71,6 @@ SELECT COUNT (a) FROM t WHERE a > ('a' COLLATE da) AND a < ('c' COLLATE da)
 statement ok
 CREATE INDEX ON t (b, a) STORING (c)
 
-query TTT
-EXPLAIN SELECT a, b FROM t ORDER BY a, b
-----
-render     ·      ·
- └── scan  ·      ·
-·          table  t@primary
-·          spans  ALL
-
 query TI
 SELECT a, b FROM t ORDER BY a, b
 ----
@@ -91,14 +83,6 @@ B  3
 x  5
 ü  5
 ü  6
-
-query TTT
-EXPLAIN SELECT b, a FROM t ORDER BY b, a
-----
-render     ·      ·
- └── scan  ·      ·
-·          table  t@t_b_a_idx
-·          spans  ALL
 
 query IT
 SELECT b, a FROM t ORDER BY b, a
@@ -133,14 +117,6 @@ SELECT COUNT (a) FROM t WHERE a > ('a' COLLATE da) AND a < ('c' COLLATE da)
 statement ok
 UPDATE t SET a = (a :: STRING || a :: STRING) COLLATE da
 
-query TTT
-EXPLAIN SELECT a, b FROM t ORDER BY a, b
-----
-render     ·      ·
- └── scan  ·      ·
-·          table  t@primary
-·          spans  ALL
-
 query TI
 SELECT a, b FROM t ORDER BY a, b
 ----
@@ -153,14 +129,6 @@ aa  2
 aa  3
 AA  1
 AA  2
-
-query TTT
-EXPLAIN SELECT b, a FROM t ORDER BY b, a
-----
-render     ·      ·
- └── scan  ·      ·
-·          table  t@t_b_a_idx
-·          spans  ALL
 
 query IT
 SELECT b, a FROM t ORDER BY b, a
@@ -180,14 +148,6 @@ SELECT b, a FROM t ORDER BY b, a
 statement ok
 DELETE FROM t WHERE a > ('a' COLLATE da) AND a < ('c' COLLATE da)
 
-query TTT
-EXPLAIN SELECT a, b FROM t ORDER BY a, b
-----
-render     ·      ·
- └── scan  ·      ·
-·          table  t@primary
-·          spans  ALL
-
 query TI
 SELECT a, b FROM t ORDER BY a, b
 ----
@@ -198,14 +158,6 @@ aa  2
 aa  3
 AA  1
 AA  2
-
-query TTT
-EXPLAIN SELECT b, a FROM t ORDER BY b, a
-----
-render     ·      ·
- └── scan  ·      ·
-·          table  t@t_b_a_idx
-·          spans  ALL
 
 query IT
 SELECT b, a FROM t ORDER BY b, a

--- a/pkg/sql/logictest/testdata/logic_test/collatedstring_index2
+++ b/pkg/sql/logictest/testdata/logic_test/collatedstring_index2
@@ -1,4 +1,4 @@
-# LogicTest: default parallel-stmts distsql distsql-metadata distsql-disk
+# LogicTest: default opt parallel-stmts distsql distsql-opt distsql-metadata distsql-disk
 
 ##
 # Test a primary key with a collated string in second position (cannot get a key range).
@@ -71,14 +71,6 @@ SELECT COUNT (a) FROM t WHERE a > ('a' COLLATE de) AND a < ('c' COLLATE de)
 statement ok
 CREATE INDEX ON t (a, b) STORING (c)
 
-query TTT
-EXPLAIN SELECT a, b FROM t ORDER BY a, b
-----
-render     ·      ·
- └── scan  ·      ·
-·          table  t@t_a_b_idx
-·          spans  ALL
-
 query TI
 SELECT a, b FROM t ORDER BY a, b
 ----
@@ -91,14 +83,6 @@ B  3
 ü  5
 ü  6
 x  5
-
-query TTT
-EXPLAIN SELECT b, a FROM t ORDER BY b, a
-----
-render     ·      ·
- └── scan  ·      ·
-·          table  t@primary
-·          spans  ALL
 
 query IT
 SELECT b, a FROM t ORDER BY b, a
@@ -133,14 +117,6 @@ SELECT COUNT (a) FROM t WHERE a > ('a' COLLATE de) AND a < ('c' COLLATE de)
 statement ok
 UPDATE t SET a = (a :: STRING || a :: STRING) COLLATE de
 
-query TTT
-EXPLAIN SELECT a, b FROM t ORDER BY a, b
-----
-render     ·      ·
- └── scan  ·      ·
-·          table  t@t_a_b_idx
-·          spans  ALL
-
 query TI
 SELECT a, b FROM t ORDER BY a, b
 ----
@@ -153,14 +129,6 @@ BB  3
 üü  5
 üü  6
 xx  5
-
-query TTT
-EXPLAIN SELECT b, a FROM t ORDER BY b, a
-----
-render     ·      ·
- └── scan  ·      ·
-·          table  t@primary
-·          spans  ALL
 
 query IT
 SELECT b, a FROM t ORDER BY b, a
@@ -180,28 +148,12 @@ SELECT b, a FROM t ORDER BY b, a
 statement ok
 DELETE FROM t WHERE a > ('a' COLLATE de) AND a < ('c' COLLATE de)
 
-query TTT
-EXPLAIN SELECT a, b FROM t ORDER BY a, b
-----
-render     ·      ·
- └── scan  ·      ·
-·          table  t@t_a_b_idx
-·          spans  ALL
-
 query TI
 SELECT a, b FROM t ORDER BY a, b
 ----
 üü  5
 üü  6
 xx  5
-
-query TTT
-EXPLAIN SELECT b, a FROM t ORDER BY b, a
-----
-render     ·      ·
- └── scan  ·      ·
-·          table  t@primary
-·          spans  ALL
 
 query IT
 SELECT b, a FROM t ORDER BY b, a

--- a/pkg/sql/logictest/testdata/logic_test/collatedstring_normalization
+++ b/pkg/sql/logictest/testdata/logic_test/collatedstring_normalization
@@ -1,4 +1,4 @@
-# LogicTest: default parallel-stmts distsql distsql-metadata
+# LogicTest: default opt parallel-stmts distsql distsql-opt distsql-metadata
 
 statement ok
 CREATE TABLE t (

--- a/pkg/sql/logictest/testdata/logic_test/collatedstring_nullinindex
+++ b/pkg/sql/logictest/testdata/logic_test/collatedstring_nullinindex
@@ -1,4 +1,4 @@
-# LogicTest: default parallel-stmts distsql distsql-metadata distsql-disk
+# LogicTest: default opt parallel-stmts distsql distsql-metadata distsql-disk
 
 statement ok
 CREATE TABLE t (

--- a/pkg/sql/logictest/testdata/logic_test/collatedstring_uniqueindex1
+++ b/pkg/sql/logictest/testdata/logic_test/collatedstring_uniqueindex1
@@ -1,4 +1,4 @@
-# LogicTest: default parallel-stmts distsql distsql-metadata distsql-disk
+# LogicTest: default opt parallel-stmts distsql distsql-opt distsql-metadata distsql-disk
 
 ##
 # Test a primary key with a collated string in first position (can get a key range).
@@ -28,14 +28,6 @@ INSERT INTO t VALUES
 statement ok
 CREATE UNIQUE INDEX ON t (b, a)
 
-query TTT
-EXPLAIN SELECT a, b FROM t ORDER BY a, b
-----
-render     ·      ·
- └── scan  ·      ·
-·          table  t@primary
-·          spans  ALL
-
 query TI
 SELECT a, b FROM t ORDER BY a, b
 ----
@@ -48,14 +40,6 @@ B  3
 x  5
 ü  5
 ü  6
-
-query TTT
-EXPLAIN SELECT b, a FROM t ORDER BY b, a
-----
-render     ·      ·
- └── scan  ·      ·
-·          table  t@t_b_a_key
-·          spans  ALL
 
 query IT
 SELECT b, a FROM t ORDER BY b, a
@@ -90,14 +74,6 @@ SELECT COUNT (a) FROM t WHERE a > ('a' COLLATE da) AND a < ('c' COLLATE da)
 statement ok
 UPDATE t SET a = (a :: STRING || a :: STRING) COLLATE da
 
-query TTT
-EXPLAIN SELECT a, b FROM t ORDER BY a, b
-----
-render     ·      ·
- └── scan  ·      ·
-·          table  t@primary
-·          spans  ALL
-
 query TI
 SELECT a, b FROM t ORDER BY a, b
 ----
@@ -110,14 +86,6 @@ aa  2
 aa  3
 AA  1
 AA  2
-
-query TTT
-EXPLAIN SELECT b, a FROM t ORDER BY b, a
-----
-render     ·      ·
- └── scan  ·      ·
-·          table  t@t_b_a_key
-·          spans  ALL
 
 query IT
 SELECT b, a FROM t ORDER BY b, a
@@ -137,14 +105,6 @@ SELECT b, a FROM t ORDER BY b, a
 statement ok
 DELETE FROM t WHERE a > ('a' COLLATE da) AND a < ('c' COLLATE da)
 
-query TTT
-EXPLAIN SELECT a, b FROM t ORDER BY a, b
-----
-render     ·      ·
- └── scan  ·      ·
-·          table  t@primary
-·          spans  ALL
-
 query TI
 SELECT a, b FROM t ORDER BY a, b
 ----
@@ -155,14 +115,6 @@ aa  2
 aa  3
 AA  1
 AA  2
-
-query TTT
-EXPLAIN SELECT b, a FROM t ORDER BY b, a
-----
-render     ·      ·
- └── scan  ·      ·
-·          table  t@t_b_a_key
-·          spans  ALL
 
 query IT
 SELECT b, a FROM t ORDER BY b, a

--- a/pkg/sql/logictest/testdata/logic_test/collatedstring_uniqueindex2
+++ b/pkg/sql/logictest/testdata/logic_test/collatedstring_uniqueindex2
@@ -1,4 +1,4 @@
-# LogicTest: default parallel-stmts distsql distsql-metadata distsql-disk
+# LogicTest: default opt parallel-stmts distsql distsql-opt distsql-metadata distsql-disk
 
 ##
 # Test a primary key with a collated string in second position (cannot get a key range).
@@ -28,14 +28,6 @@ INSERT INTO t VALUES
 statement ok
 CREATE UNIQUE INDEX ON t (a, b)
 
-query TTT
-EXPLAIN SELECT a, b FROM t ORDER BY a, b
-----
-render     ·      ·
- └── scan  ·      ·
-·          table  t@t_a_b_key
-·          spans  ALL
-
 query TI
 SELECT a, b FROM t ORDER BY a, b
 ----
@@ -48,14 +40,6 @@ B  3
 ü  5
 ü  6
 x  5
-
-query TTT
-EXPLAIN SELECT b, a FROM t ORDER BY b, a
-----
-render     ·      ·
- └── scan  ·      ·
-·          table  t@primary
-·          spans  ALL
 
 query IT
 SELECT b, a FROM t ORDER BY b, a
@@ -90,14 +74,6 @@ SELECT COUNT (a) FROM t WHERE a > ('a' COLLATE de) AND a < ('c' COLLATE de)
 statement ok
 UPDATE t SET a = (a :: STRING || a :: STRING) COLLATE de
 
-query TTT
-EXPLAIN SELECT a, b FROM t ORDER BY a, b
-----
-render     ·      ·
- └── scan  ·      ·
-·          table  t@t_a_b_key
-·          spans  ALL
-
 query TI
 SELECT a, b FROM t ORDER BY a, b
 ----
@@ -110,14 +86,6 @@ BB  3
 üü  5
 üü  6
 xx  5
-
-query TTT
-EXPLAIN SELECT b, a FROM t ORDER BY b, a
-----
-render     ·      ·
- └── scan  ·      ·
-·          table  t@primary
-·          spans  ALL
 
 query IT
 SELECT b, a FROM t ORDER BY b, a
@@ -137,28 +105,12 @@ SELECT b, a FROM t ORDER BY b, a
 statement ok
 DELETE FROM t WHERE a > ('a' COLLATE de) AND a < ('c' COLLATE de)
 
-query TTT
-EXPLAIN SELECT a, b FROM t ORDER BY a, b
-----
-render     ·      ·
- └── scan  ·      ·
-·          table  t@t_a_b_key
-·          spans  ALL
-
 query TI
 SELECT a, b FROM t ORDER BY a, b
 ----
 üü  5
 üü  6
 xx  5
-
-query TTT
-EXPLAIN SELECT b, a FROM t ORDER BY b, a
-----
-render     ·      ·
- └── scan  ·      ·
-·          table  t@primary
-·          spans  ALL
 
 query IT
 SELECT b, a FROM t ORDER BY b, a

--- a/pkg/sql/logictest/testdata/logic_test/computed
+++ b/pkg/sql/logictest/testdata/logic_test/computed
@@ -1,4 +1,4 @@
-# LogicTest: default parallel-stmts distsql distsql-metadata
+# LogicTest: default opt parallel-stmts distsql distsql-metadata
 
 statement ok
 CREATE TABLE with_no_column_refs (
@@ -425,14 +425,6 @@ CREATE TABLE x (
   b TEXT AS (a->>'q') STORED,
   INDEX (b) STORING (k)
 )
-
-query TTT
-EXPLAIN SELECT b FROM x ORDER BY b
-----
-render     ·      ·
- └── scan  ·      ·
-·          table  x@x_b_idx
-·          spans  ALL
 
 statement error cannot write directly to computed column
 INSERT INTO x (k, a, b) VALUES (1, '{"q":"xyz"}', 'not allowed!'), (2, '{"q":"abc"}', 'also not allowed')

--- a/pkg/sql/logictest/testdata/planner_test/select
+++ b/pkg/sql/logictest/testdata/planner_test/select
@@ -1,0 +1,44 @@
+# LogicTest: default
+
+# Ensure that correct index is used when indexed column has collation.
+statement ok
+CREATE TABLE coll (
+  a STRING COLLATE da,
+  b INT,
+  c BOOL,
+  PRIMARY KEY (a, b),
+  INDEX (b, a) STORING (c)
+)
+
+query TTT
+EXPLAIN SELECT a, b FROM coll ORDER BY a, b
+----
+render     ·      ·
+ └── scan  ·      ·
+·          table  coll@primary
+·          spans  ALL
+
+query TTT
+EXPLAIN SELECT b, a FROM coll ORDER BY b, a
+----
+render     ·      ·
+ └── scan  ·      ·
+·          table  coll@coll_b_a_idx
+·          spans  ALL
+
+# Ensure correct index is used when indexed column is computed.
+statement ok
+CREATE TABLE computed (
+  k INT PRIMARY KEY,
+  a JSON,
+  b TEXT AS (a->>'q') STORED,
+  INDEX (b) STORING (k)
+)
+
+query TTT
+EXPLAIN SELECT b FROM computed ORDER BY b
+----
+render     ·      ·
+ └── scan  ·      ·
+·          table  computed@computed_b_idx
+·          spans  ALL

--- a/pkg/sql/opt/exec/execbuilder/testdata/orderby
+++ b/pkg/sql/opt/exec/execbuilder/testdata/orderby
@@ -803,8 +803,9 @@ b + d:int
 7
 
 # The following tests verify we recognize that sorting is not necessary
+# TODO(andyk): Need to actually recognize that sorting is not necessary.
 exec hide-colnames nodist
-EXPLAIN (VERBOSE) SELECT a, b, c FROM abcd@abc WHERE (a, b) = (1, 4) ORDER BY c
+EXPLAIN (VERBOSE) SELECT a, b, c FROM abcd WHERE (a, b) = (1, 4) ORDER BY c
 ----
 sort       ·      ·          (a, b, c)  +c
  │         order  +c         ·          ·
@@ -813,7 +814,7 @@ sort       ·      ·          (a, b, c)  +c
 ·          spans  /1/4-/1/5  ·          ·
 
 exec hide-colnames nodist
-EXPLAIN (VERBOSE) SELECT a, b, c FROM abcd@abc WHERE (a, b) = (1, 4) ORDER BY c, b, a
+EXPLAIN (VERBOSE) SELECT a, b, c FROM abcd WHERE (a, b) = (1, 4) ORDER BY c, b, a
 ----
 sort       ·      ·          (a, b, c)  +c,+b,+a
  │         order  +c,+b,+a   ·          ·
@@ -822,7 +823,7 @@ sort       ·      ·          (a, b, c)  +c,+b,+a
 ·          spans  /1/4-/1/5  ·          ·
 
 exec hide-colnames nodist
-EXPLAIN (VERBOSE) SELECT a, b, c FROM abcd@abc WHERE (a, b) = (1, 4) ORDER BY b, a, c
+EXPLAIN (VERBOSE) SELECT a, b, c FROM abcd WHERE (a, b) = (1, 4) ORDER BY b, a, c
 ----
 sort       ·      ·          (a, b, c)  +b,+a,+c
  │         order  +b,+a,+c   ·          ·
@@ -831,7 +832,7 @@ sort       ·      ·          (a, b, c)  +b,+a,+c
 ·          spans  /1/4-/1/5  ·          ·
 
 exec hide-colnames nodist
-EXPLAIN (VERBOSE) SELECT a, b, c FROM abcd@abc WHERE (a, b) = (1, 4) ORDER BY b, c, a
+EXPLAIN (VERBOSE) SELECT a, b, c FROM abcd WHERE (a, b) = (1, 4) ORDER BY b, c, a
 ----
 sort       ·      ·          (a, b, c)  +b,+c,+a
  │         order  +b,+c,+a   ·          ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/select
+++ b/pkg/sql/opt/exec/execbuilder/testdata/select
@@ -102,3 +102,48 @@ build
 SELECT * FROM crdb_internal.jobs
 ----
 error (0A000): virtual tables are not supported
+
+# Ensure that index is used when indexed column has collation.
+exec-raw
+CREATE TABLE coll (
+  a STRING COLLATE da,
+  b INT,
+  c BOOL,
+  PRIMARY KEY (a, b),
+  INDEX (b, a) STORING (c)
+)
+----
+
+exec hide-colnames nodist
+EXPLAIN (TYPES) SELECT a, b FROM coll ORDER BY a, b
+----
+scan  ·      ·             (a collatedstring{da}, b int)  +a,+b
+·     table  coll@primary  ·                              ·
+·     spans  ALL           ·                              ·
+
+exec hide-colnames nodist
+EXPLAIN (TYPES) SELECT b, a FROM coll ORDER BY b, a
+----
+render     ·         ·                        (b int, a collatedstring{da})  ·
+ │         render 0  (b)[int]                 ·                              ·
+ │         render 1  (a)[collatedstring{da}]  ·                              ·
+ └── scan  ·         ·                        (a collatedstring{da}, b int)  +b,+a
+·          table     coll@coll_b_a_idx        ·                              ·
+·          spans     ALL                      ·                              ·
+
+# Ensure correct index is used when indexed column is computed.
+exec-raw
+CREATE TABLE computed (
+  k INT PRIMARY KEY,
+  a JSON,
+  b TEXT AS (a->>'q') STORED,
+  INDEX (b) STORING (k)
+)
+----
+
+exec hide-colnames nodist
+EXPLAIN (TYPES) SELECT b FROM computed ORDER BY b
+----
+scan  ·      ·                        (b string)  +b
+·     table  computed@computed_b_idx  ·           ·
+·     spans  ALL                      ·           ·

--- a/pkg/sql/opt/optbuilder/orderby.go
+++ b/pkg/sql/opt/optbuilder/orderby.go
@@ -61,6 +61,10 @@ func (b *Builder) buildOrderBy(orderBy tree.OrderBy, inScope, projectionsScope *
 //
 // The projection columns are added to the orderByScope.
 func (b *Builder) buildOrdering(order *tree.Order, inScope, projectionsScope, orderByScope *scope) {
+	if order.Index != "" {
+		panic(unimplementedf("ORDER BY index not supported"))
+	}
+
 	// Unwrap parenthesized expressions like "((a))" to "a".
 	expr := tree.StripParens(order.Expr)
 

--- a/pkg/sql/opt/optbuilder/select.go
+++ b/pkg/sql/opt/optbuilder/select.go
@@ -35,6 +35,10 @@ func (b *Builder) buildTable(texpr tree.TableExpr, inScope *scope) (outScope *sc
 	// NB: The case statements are sorted lexicographically.
 	switch source := texpr.(type) {
 	case *tree.AliasedTableExpr:
+		if source.Hints != nil {
+			panic(unimplementedf("index hints are not supported"))
+		}
+
 		outScope = b.buildTable(source.Expr, inScope)
 
 		// Overwrite output properties with any alias information.
@@ -272,6 +276,10 @@ func (b *Builder) buildSelectClause(
 // See Builder.buildStmt for a description of the remaining input and
 // return values.
 func (b *Builder) buildFrom(from *tree.From, where *tree.Where, inScope *scope) (outScope *scope) {
+	if from.AsOf.Expr != nil {
+		panic(unimplementedf("AS OF clause not supported"))
+	}
+
 	var joinTables map[string]struct{}
 	colsAdded := 0
 

--- a/pkg/sql/opt/optbuilder/testdata/orderby
+++ b/pkg/sql/opt/optbuilder/testdata/orderby
@@ -703,6 +703,11 @@ sort
                      ├── variable: abc.a [type=int]
                      └── const: 1 [type=int]
 
+build
+SELECT a FROM abc ORDER BY INDEX abc@bc
+----
+error (0A000): ORDER BY index not supported
+
 exec-ddl
 CREATE TABLE bar (id INT PRIMARY KEY, baz STRING, UNIQUE INDEX i_bar (baz))
 ----

--- a/pkg/sql/opt/optbuilder/testdata/select
+++ b/pkg/sql/opt/optbuilder/testdata/select
@@ -523,6 +523,11 @@ offset
  │    └── const: 5 [type=int]
  └── const: 5 [type=int]
 
+build
+SELECT * FROM xyzw@foo
+----
+error (0A000): index hints are not supported
+
 exec-ddl
 CREATE TABLE boolean_table (
   id INTEGER PRIMARY KEY NOT NULL,
@@ -1048,3 +1053,8 @@ select
       └── eq [type=bool]
            ├── variable: a.x [type=int]
            └── placeholder: $1 [type=int]
+
+build
+SELECT * FROM a AS OF SYSTEM TIME '10ns'
+----
+error (0A000): AS OF clause not supported

--- a/pkg/sql/opt/xform/testdata/external/tpcc
+++ b/pkg/sql/opt/xform/testdata/external/tpcc
@@ -1139,7 +1139,7 @@ sort
 opt format=show-all
 (SELECT no_w_id, no_d_id, no_o_id FROM new_order)
 EXCEPT ALL
-(SELECT o_w_id, o_d_id, o_id FROM "order"@primary WHERE o_carrier_id IS NULL)
+(SELECT o_w_id, o_d_id, o_id FROM "order" WHERE o_carrier_id IS NULL)
 ----
 except-all
  ├── columns: no_w_id:3(int!null) no_d_id:2(int!null) no_o_id:1(int!null)
@@ -1177,7 +1177,7 @@ except-all
                      └── null [type=unknown]
 
 opt format=show-all
-(SELECT o_w_id, o_d_id, o_id FROM "order"@primary WHERE o_carrier_id IS NULL)
+(SELECT o_w_id, o_d_id, o_id FROM "order" WHERE o_carrier_id IS NULL)
 EXCEPT ALL
 (SELECT no_w_id, no_d_id, no_o_id FROM new_order)
 ----

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -1163,7 +1163,7 @@ CockroachDB supports the following flags:
 	"greatest": {
 		tree.Builtin{
 			Types:        tree.HomogeneousType{},
-			ReturnType:   tree.IdentityReturnType(0),
+			ReturnType:   tree.FirstNonNullReturnType(),
 			NullableArgs: true,
 			Category:     categoryComparison,
 			Fn: func(ctx *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
@@ -1175,7 +1175,7 @@ CockroachDB supports the following flags:
 	"least": {
 		tree.Builtin{
 			Types:        tree.HomogeneousType{},
-			ReturnType:   tree.IdentityReturnType(0),
+			ReturnType:   tree.FirstNonNullReturnType(),
 			NullableArgs: true,
 			Category:     categoryComparison,
 			Fn: func(ctx *tree.EvalContext, args tree.Datums) (tree.Datum, error) {

--- a/pkg/sql/sem/tree/overload.go
+++ b/pkg/sql/sem/tree/overload.go
@@ -273,6 +273,25 @@ func IdentityReturnType(idx int) ReturnTyper {
 	}
 }
 
+// FirstNonNullReturnType returns the type of the first non-null argument, or
+// types.Unknown if all arguments are null. There must be at least one argument,
+// or else FirstNonNullReturnType returns UnknownReturnType. This method is used
+// with HomogeneousType functions, in which all arguments have been checked to
+// have the same type (or be null).
+func FirstNonNullReturnType() ReturnTyper {
+	return func(args []TypedExpr) types.T {
+		if len(args) == 0 {
+			return UnknownReturnType
+		}
+		for _, arg := range args {
+			if t := arg.ResolvedType(); t != types.Unknown {
+				return t
+			}
+		}
+		return types.Unknown
+	}
+}
+
 func returnTypeToFixedType(s ReturnTyper) types.T {
 	if t := s(nil); t != UnknownReturnType {
 		return t


### PR DESCRIPTION
In addition to enabling more logic tests to run against the cost-based optimizer, this PR fixes a GREATEST/LEAST typing bug (which was causing a logic test failure).