### PR TITLE
sql: rename logic test directive

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/case_sensitive_names
+++ b/pkg/ccl/logictestccl/testdata/logic_test/case_sensitive_names
@@ -1,4 +1,4 @@
-# LogicTest: default
+# TestConfigs: default
 
 statement ok
 CREATE TABLE p (a INT PRIMARY KEY) PARTITION BY LIST (a) (

--- a/pkg/ccl/logictestccl/testdata/logic_test/crdb_internal
+++ b/pkg/ccl/logictestccl/testdata/logic_test/crdb_internal
@@ -1,4 +1,4 @@
-# LogicTest: default
+# TestConfigs: default
 
 query IITTI colnames
 SELECT * FROM crdb_internal.partitions

--- a/pkg/ccl/logictestccl/testdata/logic_test/partitioning
+++ b/pkg/ccl/logictestccl/testdata/logic_test/partitioning
@@ -1,4 +1,4 @@
-# LogicTest: default
+# TestConfigs: default
 
 statement error syntax
 CREATE TABLE t (a INT, b INT, c INT, PRIMARY KEY (a, b)) PARTITION BY LIST ()

--- a/pkg/ccl/logictestccl/testdata/logic_test/partitioning_index
+++ b/pkg/ccl/logictestccl/testdata/logic_test/partitioning_index
@@ -1,4 +1,4 @@
-# LogicTest: default
+# TestConfigs: default
 
 statement ok
 CREATE TABLE ok1 (

--- a/pkg/ccl/logictestccl/testdata/logic_test/restore
+++ b/pkg/ccl/logictestccl/testdata/logic_test/restore
@@ -1,4 +1,4 @@
-# LogicTest: default
+# TestConfigs: default
 
 # Check that we get through parsing and license check.
 statement error pq: failed to read backup descriptor: unsupported storage scheme: ""

--- a/pkg/ccl/logictestccl/testdata/logic_test/role
+++ b/pkg/ccl/logictestccl/testdata/logic_test/role
@@ -1,4 +1,4 @@
-# LogicTest: default
+# TestConfigs: default
 
 query T colnames
 SHOW ROLES

--- a/pkg/sql/logictest/logic.go
+++ b/pkg/sql/logictest/logic.go
@@ -99,7 +99,7 @@ import (
 //
 // Logic tests can start with a directive as follows:
 //
-//   # LogicTest: default parallel-stmts distsql
+//   # TestConfigs: default parallel-stmts distsql
 //
 // This directive lists configurations; the test is run once in each
 // configuration (in separate subtests). The configurations are defined by
@@ -251,7 +251,7 @@ import (
 // Configuration:
 //
 // -config name   customizes the test cluster configuration for test
-//                files that lack LogicTest directives; must be one
+//                files that lack TestConfigs directives; must be one
 //                of `logicTestConfigs`.
 //                Example:
 //                  -config distsql
@@ -317,7 +317,7 @@ var (
 	bigtest       = flag.Bool("bigtest", false, "enable the long-running SqlLiteLogic test")
 	defaultConfig = flag.String(
 		"config", "default",
-		"customizes the default test cluster configuration for files that lack LogicTest directives",
+		"customizes the default test cluster configuration for files that lack TestConfigs directives",
 	)
 
 	// Testing mode
@@ -380,7 +380,7 @@ type testClusterConfig struct {
 
 // logicTestConfigs contains all possible cluster configs. A test file can
 // specify a list of configs they run on in a file-level comment like:
-//   # LogicTest: default distsql
+//   # TestConfigs: default distsql
 // The test is run once on each configuration (in different subtests).
 // If no configs are indicated, the default one is used (unless overridden
 // via -config).
@@ -969,13 +969,13 @@ CREATE DATABASE test;
 	t.unsupported = 0
 }
 
-// readTestFileConfigs reads any LogicTest directive at the beginning of a
-// test file. A line that starts with "# LogicTest:" specifies a list of
+// readTestFileConfigs reads any TestConfigs directive at the beginning of a
+// test file. A line that starts with "# TestConfigs:" specifies a list of
 // configuration names. The test file is run against each of those
 // configurations.
 //
 // Example:
-//   # LogicTest: default distsql
+//   # TestConfigs: default distsql
 //
 // If the file doesn't contain a directive, the default config is returned.
 func readTestFileConfigs(t *testing.T, path string) []logicTestConfigIdx {
@@ -997,10 +997,10 @@ func readTestFileConfigs(t *testing.T, path string) []logicTestConfigIdx {
 			break
 		}
 		// Directive lines are of the form:
-		// # LogicTest: opt1=val1 opt2=val3 boolopt1
-		if len(fields) > 1 && cmd == "#" && fields[1] == "LogicTest:" {
+		// # TestConfigs: cfg1 cfg2 ...
+		if len(fields) > 1 && cmd == "#" && fields[1] == "TestConfigs:" {
 			if len(fields) == 2 {
-				t.Fatalf("%s: empty LogicTest directive", path)
+				t.Fatalf("%s: empty TestConfigs directive", path)
 			}
 			var configs []logicTestConfigIdx
 			for _, configName := range fields[2:] {

--- a/pkg/sql/logictest/testdata/logic_test/aggregate
+++ b/pkg/sql/logictest/testdata/logic_test/aggregate
@@ -1,4 +1,4 @@
-# LogicTest: default opt parallel-stmts distsql distsql-metadata
+# TestConfigs: default opt parallel-stmts distsql distsql-metadata
 
 statement ok
 CREATE TABLE kv (

--- a/pkg/sql/logictest/testdata/logic_test/alias_types
+++ b/pkg/sql/logictest/testdata/logic_test/alias_types
@@ -1,4 +1,4 @@
-# LogicTest: default opt distsql distsql-metadata distsql-opt
+# TestConfigs: default opt distsql distsql-metadata distsql-opt
 
 statement ok
 CREATE TABLE aliases (

--- a/pkg/sql/logictest/testdata/logic_test/alter_sequence
+++ b/pkg/sql/logictest/testdata/logic_test/alter_sequence
@@ -1,4 +1,4 @@
-# LogicTest: default opt parallel-stmts distsql distsql-metadata distsql-opt
+# TestConfigs: default opt parallel-stmts distsql distsql-metadata distsql-opt
 
 # see also file `sequences`
 

--- a/pkg/sql/logictest/testdata/logic_test/alter_table
+++ b/pkg/sql/logictest/testdata/logic_test/alter_table
@@ -1,4 +1,4 @@
-# LogicTest: default parallel-stmts distsql distsql-metadata
+# TestConfigs: default parallel-stmts distsql distsql-metadata
 
 statement ok
 CREATE TABLE other (b INT PRIMARY KEY)

--- a/pkg/sql/logictest/testdata/logic_test/array
+++ b/pkg/sql/logictest/testdata/logic_test/array
@@ -1,4 +1,4 @@
-# LogicTest: default opt distsql distsql-metadata
+# TestConfigs: default opt distsql distsql-metadata
 
 # array construction
 

--- a/pkg/sql/logictest/testdata/logic_test/as_of
+++ b/pkg/sql/logictest/testdata/logic_test/as_of
@@ -1,4 +1,4 @@
-# LogicTest: default
+# TestConfigs: default
 
 statement ok
 CREATE TABLE t (i INT)

--- a/pkg/sql/logictest/testdata/logic_test/backup
+++ b/pkg/sql/logictest/testdata/logic_test/backup
@@ -1,4 +1,4 @@
-# LogicTest: default distsql distsql-metadata
+# TestConfigs: default distsql distsql-metadata
 
 query error unknown statement type
 BACKUP DATABASE foo TO '/bar' INCREMENTAL FROM '/baz'

--- a/pkg/sql/logictest/testdata/logic_test/builtin_function
+++ b/pkg/sql/logictest/testdata/logic_test/builtin_function
@@ -1,4 +1,4 @@
-# LogicTest: default parallel-stmts distsql distsql-metadata
+# TestConfigs: default parallel-stmts distsql distsql-metadata
 
 query error unknown function: foo.bar
 SELECT foo.bar()

--- a/pkg/sql/logictest/testdata/logic_test/bytes
+++ b/pkg/sql/logictest/testdata/logic_test/bytes
@@ -1,4 +1,4 @@
-# LogicTest: default
+# TestConfigs: default
 
 query T
 SELECT 'non-escaped-string':::BYTES::STRING

--- a/pkg/sql/logictest/testdata/logic_test/cascade
+++ b/pkg/sql/logictest/testdata/logic_test/cascade
@@ -1,4 +1,4 @@
-# LogicTest: default parallel-stmts distsql distsql-metadata
+# TestConfigs: default parallel-stmts distsql distsql-metadata
 
 subtest AllCascadingActions
 ### A test of all cascading actions in their most basic form.

--- a/pkg/sql/logictest/testdata/logic_test/case_sensitive_names
+++ b/pkg/sql/logictest/testdata/logic_test/case_sensitive_names
@@ -1,4 +1,4 @@
-# LogicTest: default distsql distsql-metadata
+# TestConfigs: default distsql distsql-metadata
 
 # Case sensitivity of database names
 

--- a/pkg/sql/logictest/testdata/logic_test/ccl
+++ b/pkg/sql/logictest/testdata/logic_test/ccl
@@ -1,4 +1,4 @@
-# LogicTest: default
+# TestConfigs: default
 
 # CCL-only statements error out trying to handle the parsed statements.
 

--- a/pkg/sql/logictest/testdata/logic_test/check_constraints
+++ b/pkg/sql/logictest/testdata/logic_test/check_constraints
@@ -1,4 +1,4 @@
-# LogicTest: default parallel-stmts distsql distsql-metadata
+# TestConfigs: default parallel-stmts distsql distsql-metadata
 
 #### column CHECK constraints
 

--- a/pkg/sql/logictest/testdata/logic_test/cluster_version
+++ b/pkg/sql/logictest/testdata/logic_test/cluster_version
@@ -1,4 +1,4 @@
-# LogicTest: default-v1.1@v1.0-noupgrade
+# TestConfigs: default-v1.1@v1.0-noupgrade
 
 query T
 SHOW CLUSTER SETTING version

--- a/pkg/sql/logictest/testdata/logic_test/collatedstring
+++ b/pkg/sql/logictest/testdata/logic_test/collatedstring
@@ -1,4 +1,4 @@
-# LogicTest: default parallel-stmts distsql distsql-metadata
+# TestConfigs: default parallel-stmts distsql distsql-metadata
 
 statement error pq: invalid locale bad_locale: language: subtag "locale" is well-formed but unknown
 SELECT 'a' COLLATE bad_locale

--- a/pkg/sql/logictest/testdata/logic_test/collatedstring_constraint
+++ b/pkg/sql/logictest/testdata/logic_test/collatedstring_constraint
@@ -1,4 +1,4 @@
-# LogicTest: default parallel-stmts distsql distsql-metadata distsql-disk
+# TestConfigs: default parallel-stmts distsql distsql-metadata distsql-disk
 
 # English collation chart: http://www.unicode.org/cldr/charts/30/collation/en_US_POSIX.html
 

--- a/pkg/sql/logictest/testdata/logic_test/collatedstring_index1
+++ b/pkg/sql/logictest/testdata/logic_test/collatedstring_index1
@@ -1,4 +1,4 @@
-# LogicTest: default parallel-stmts distsql distsql-metadata distsql-disk
+# TestConfigs: default parallel-stmts distsql distsql-metadata distsql-disk
 
 ##
 # Test a primary key with a collated string in first position (can get a key range).

--- a/pkg/sql/logictest/testdata/logic_test/collatedstring_index2
+++ b/pkg/sql/logictest/testdata/logic_test/collatedstring_index2
@@ -1,4 +1,4 @@
-# LogicTest: default parallel-stmts distsql distsql-metadata distsql-disk
+# TestConfigs: default parallel-stmts distsql distsql-metadata distsql-disk
 
 ##
 # Test a primary key with a collated string in second position (cannot get a key range).

--- a/pkg/sql/logictest/testdata/logic_test/collatedstring_normalization
+++ b/pkg/sql/logictest/testdata/logic_test/collatedstring_normalization
@@ -1,4 +1,4 @@
-# LogicTest: default parallel-stmts distsql distsql-metadata
+# TestConfigs: default parallel-stmts distsql distsql-metadata
 
 statement ok
 CREATE TABLE t (

--- a/pkg/sql/logictest/testdata/logic_test/collatedstring_nullinindex
+++ b/pkg/sql/logictest/testdata/logic_test/collatedstring_nullinindex
@@ -1,4 +1,4 @@
-# LogicTest: default parallel-stmts distsql distsql-metadata distsql-disk
+# TestConfigs: default parallel-stmts distsql distsql-metadata distsql-disk
 
 statement ok
 CREATE TABLE t (

--- a/pkg/sql/logictest/testdata/logic_test/collatedstring_uniqueindex1
+++ b/pkg/sql/logictest/testdata/logic_test/collatedstring_uniqueindex1
@@ -1,4 +1,4 @@
-# LogicTest: default parallel-stmts distsql distsql-metadata distsql-disk
+# TestConfigs: default parallel-stmts distsql distsql-metadata distsql-disk
 
 ##
 # Test a primary key with a collated string in first position (can get a key range).

--- a/pkg/sql/logictest/testdata/logic_test/collatedstring_uniqueindex2
+++ b/pkg/sql/logictest/testdata/logic_test/collatedstring_uniqueindex2
@@ -1,4 +1,4 @@
-# LogicTest: default parallel-stmts distsql distsql-metadata distsql-disk
+# TestConfigs: default parallel-stmts distsql distsql-metadata distsql-disk
 
 ##
 # Test a primary key with a collated string in second position (cannot get a key range).

--- a/pkg/sql/logictest/testdata/logic_test/computed
+++ b/pkg/sql/logictest/testdata/logic_test/computed
@@ -1,4 +1,4 @@
-# LogicTest: default parallel-stmts distsql distsql-metadata
+# TestConfigs: default parallel-stmts distsql distsql-metadata
 
 statement ok
 CREATE TABLE with_no_column_refs (

--- a/pkg/sql/logictest/testdata/logic_test/crdb_internal
+++ b/pkg/sql/logictest/testdata/logic_test/crdb_internal
@@ -1,4 +1,4 @@
-# LogicTest: default distsql distsql-metadata
+# TestConfigs: default distsql distsql-metadata
 
 query error database "crdb_internal" does not exist
 ALTER DATABASE crdb_internal RENAME TO not_crdb_internal

--- a/pkg/sql/logictest/testdata/logic_test/create_as
+++ b/pkg/sql/logictest/testdata/logic_test/create_as
@@ -1,4 +1,4 @@
-# LogicTest: default
+# TestConfigs: default
 
 statement count 3
 CREATE TABLE stock (item, quantity) AS VALUES ('cups', 10), ('plates', 15), ('forks', 30)

--- a/pkg/sql/logictest/testdata/logic_test/create_index
+++ b/pkg/sql/logictest/testdata/logic_test/create_index
@@ -1,4 +1,4 @@
-# LogicTest: default parallel-stmts distsql distsql-metadata
+# TestConfigs: default parallel-stmts distsql distsql-metadata
 
 statement ok
 CREATE TABLE t (

--- a/pkg/sql/logictest/testdata/logic_test/create_statements
+++ b/pkg/sql/logictest/testdata/logic_test/create_statements
@@ -1,4 +1,4 @@
-# LogicTest: default parallel-stmts distsql distsql-metadata
+# TestConfigs: default parallel-stmts distsql distsql-metadata
 
 statement ok
 CREATE TABLE t (a INT REFERENCES t)

--- a/pkg/sql/logictest/testdata/logic_test/dangerous_statements
+++ b/pkg/sql/logictest/testdata/logic_test/dangerous_statements
@@ -1,4 +1,4 @@
-# LogicTest: default distsql distsql-metadata
+# TestConfigs: default distsql distsql-metadata
 
 statement ok
 CREATE TABLE foo(x INT)

--- a/pkg/sql/logictest/testdata/logic_test/database
+++ b/pkg/sql/logictest/testdata/logic_test/database
@@ -1,4 +1,4 @@
-# LogicTest: default
+# TestConfigs: default
 
 statement ok
 CREATE DATABASE a

--- a/pkg/sql/logictest/testdata/logic_test/datetime
+++ b/pkg/sql/logictest/testdata/logic_test/datetime
@@ -1,4 +1,4 @@
-# LogicTest: default parallel-stmts distsql distsql-metadata distsql-disk
+# TestConfigs: default parallel-stmts distsql distsql-metadata distsql-disk
 
 statement ok
 CREATE TABLE t (

--- a/pkg/sql/logictest/testdata/logic_test/decimal
+++ b/pkg/sql/logictest/testdata/logic_test/decimal
@@ -1,4 +1,4 @@
-# LogicTest: default parallel-stmts distsql distsql-metadata distsql-disk
+# TestConfigs: default parallel-stmts distsql distsql-metadata distsql-disk
 
 # The following tests have results equivalent to Postgres (differences
 # in string representation and number of decimals returned, but otherwise

--- a/pkg/sql/logictest/testdata/logic_test/deep_interleaving
+++ b/pkg/sql/logictest/testdata/logic_test/deep_interleaving
@@ -1,4 +1,4 @@
-# LogicTest: default distsql distsql-metadata
+# TestConfigs: default distsql distsql-metadata
 
 # Test index selection for deeply interleaved tables.
 # These tests are in their own file because table IDs appear in the EXPLAIN output.

--- a/pkg/sql/logictest/testdata/logic_test/default
+++ b/pkg/sql/logictest/testdata/logic_test/default
@@ -1,4 +1,4 @@
-# LogicTest: default parallel-stmts distsql distsql-metadata
+# TestConfigs: default parallel-stmts distsql distsql-metadata
 
 statement error expected DEFAULT expression to have type int, but 'false' has type bool
 CREATE TABLE t (a INT PRIMARY KEY DEFAULT false)

--- a/pkg/sql/logictest/testdata/logic_test/delete
+++ b/pkg/sql/logictest/testdata/logic_test/delete
@@ -1,4 +1,4 @@
-# LogicTest: default parallel-stmts
+# TestConfigs: default parallel-stmts
 
 statement ok
 CREATE TABLE kv (

--- a/pkg/sql/logictest/testdata/logic_test/dependencies
+++ b/pkg/sql/logictest/testdata/logic_test/dependencies
@@ -1,4 +1,4 @@
-# LogicTest: default distsql distsql-metadata
+# TestConfigs: default distsql distsql-metadata
 
 statement ok
 CREATE TABLE test_kv(k INT PRIMARY KEY, v INT, w DECIMAL);

--- a/pkg/sql/logictest/testdata/logic_test/discard
+++ b/pkg/sql/logictest/testdata/logic_test/discard
@@ -1,4 +1,4 @@
-# LogicTest: default distsql distsql-metadata
+# TestConfigs: default distsql distsql-metadata
 
 statement ok
 SET SEARCH_PATH = foo

--- a/pkg/sql/logictest/testdata/logic_test/distinct
+++ b/pkg/sql/logictest/testdata/logic_test/distinct
@@ -1,4 +1,4 @@
-# LogicTest: default parallel-stmts distsql distsql-metadata distsql-disk
+# TestConfigs: default parallel-stmts distsql distsql-metadata distsql-disk
 
 statement ok
 CREATE TABLE xyz (

--- a/pkg/sql/logictest/testdata/logic_test/distinct_on
+++ b/pkg/sql/logictest/testdata/logic_test/distinct_on
@@ -1,4 +1,4 @@
-# LogicTest: default parallel-stmts distsql distsql-metadata distsql-disk
+# TestConfigs: default parallel-stmts distsql distsql-metadata distsql-disk
 
 statement ok
 CREATE TABLE xyz (

--- a/pkg/sql/logictest/testdata/logic_test/distsql_agg
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_agg
@@ -1,4 +1,4 @@
-# LogicTest: 5node-distsql 5node-distsql-metadata 5node-distsql-disk
+# TestConfigs: 5node-distsql 5node-distsql-metadata 5node-distsql-disk
 
 statement ok
 CREATE TABLE data (a INT, b INT, c FLOAT, d DECIMAL, PRIMARY KEY (a, b, c, d))

--- a/pkg/sql/logictest/testdata/logic_test/distsql_distinct_on
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_distinct_on
@@ -1,4 +1,4 @@
-# LogicTest: 5node-distsql 5node-distsql-metadata 5node-distsql-disk
+# TestConfigs: 5node-distsql 5node-distsql-metadata 5node-distsql-disk
 
 statement ok
 CREATE TABLE xyz (

--- a/pkg/sql/logictest/testdata/logic_test/distsql_expr
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_expr
@@ -1,4 +1,4 @@
-# LogicTest: default distsql distsql-metadata
+# TestConfigs: default distsql distsql-metadata
 
 statement ok
 CREATE TABLE t (c int PRIMARY KEY)

--- a/pkg/sql/logictest/testdata/logic_test/distsql_indexjoin
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_indexjoin
@@ -1,4 +1,4 @@
-# LogicTest: 5node-distsql 5node-distsql-metadata
+# TestConfigs: 5node-distsql 5node-distsql-metadata
 
 statement ok
 CREATE TABLE t (k INT PRIMARY KEY, v INT, w INT, INDEX v(v))

--- a/pkg/sql/logictest/testdata/logic_test/distsql_join
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_join
@@ -1,4 +1,4 @@
-# LogicTest: 5node-distsql 5node-distsql-metadata
+# TestConfigs: 5node-distsql 5node-distsql-metadata
 
 statement ok
 CREATE TABLE data (a INT, b INT, c INT, d INT, PRIMARY KEY (a, b, c, d))

--- a/pkg/sql/logictest/testdata/logic_test/distsql_numtables
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_numtables
@@ -1,4 +1,4 @@
-# LogicTest: 5node-distsql 5node-distsql-metadata 5node-distsql-disk
+# TestConfigs: 5node-distsql 5node-distsql-metadata 5node-distsql-disk
 
 # First, we set up two data tables:
 #   - NumToSquare maps integers from 1 to 100 to their squares

--- a/pkg/sql/logictest/testdata/logic_test/distsql_scrub
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_scrub
@@ -1,4 +1,4 @@
-# LogicTest: 5node-distsql 5node-distsql-metadata 5node-distsql-disk
+# TestConfigs: 5node-distsql 5node-distsql-metadata 5node-distsql-disk
 
 # Verify the index check execution plan uses a merge join.
 

--- a/pkg/sql/logictest/testdata/logic_test/distsql_stats
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_stats
@@ -1,4 +1,4 @@
-# LogicTest: 5node-distsql 5node-distsql-metadata
+# TestConfigs: 5node-distsql 5node-distsql-metadata
 
 statement ok
 CREATE TABLE data (a INT, b INT, c FLOAT, d DECIMAL, PRIMARY KEY (a, b, c, d))

--- a/pkg/sql/logictest/testdata/logic_test/distsql_union
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_union
@@ -1,4 +1,4 @@
-# LogicTest: 5node-distsql 5node-distsql-metadata 5node-distsql-disk
+# TestConfigs: 5node-distsql 5node-distsql-metadata 5node-distsql-disk
 
 statement ok
 CREATE TABLE xyz (

--- a/pkg/sql/logictest/testdata/logic_test/drop_database
+++ b/pkg/sql/logictest/testdata/logic_test/drop_database
@@ -1,4 +1,4 @@
-# LogicTest: default
+# TestConfigs: default
 
 statement ok
 CREATE DATABASE "foo-bar"

--- a/pkg/sql/logictest/testdata/logic_test/drop_index
+++ b/pkg/sql/logictest/testdata/logic_test/drop_index
@@ -1,4 +1,4 @@
-# LogicTest: default
+# TestConfigs: default
 
 statement ok
 CREATE TABLE users (

--- a/pkg/sql/logictest/testdata/logic_test/drop_sequence
+++ b/pkg/sql/logictest/testdata/logic_test/drop_sequence
@@ -1,4 +1,4 @@
-# LogicTest: default parallel-stmts distsql distsql-metadata
+# TestConfigs: default parallel-stmts distsql distsql-metadata
 
 # see also file `sequences`
 

--- a/pkg/sql/logictest/testdata/logic_test/drop_table
+++ b/pkg/sql/logictest/testdata/logic_test/drop_table
@@ -1,4 +1,4 @@
-# LogicTest: default
+# TestConfigs: default
 
 statement ok
 CREATE TABLE a (id INT PRIMARY KEY)

--- a/pkg/sql/logictest/testdata/logic_test/drop_user
+++ b/pkg/sql/logictest/testdata/logic_test/drop_user
@@ -1,4 +1,4 @@
-# LogicTest: default
+# TestConfigs: default
 
 statement ok
 CREATE USER user1

--- a/pkg/sql/logictest/testdata/logic_test/drop_view
+++ b/pkg/sql/logictest/testdata/logic_test/drop_view
@@ -1,4 +1,4 @@
-# LogicTest: default
+# TestConfigs: default
 
 statement ok
 CREATE TABLE a (k STRING PRIMARY KEY, v STRING)

--- a/pkg/sql/logictest/testdata/logic_test/errors
+++ b/pkg/sql/logictest/testdata/logic_test/errors
@@ -1,4 +1,4 @@
-# LogicTest: default distsql distsql-metadata
+# TestConfigs: default distsql distsql-metadata
 
 statement error pgcode 42P01 relation "fake1" does not exist
 ALTER TABLE fake1 DROP COLUMN a

--- a/pkg/sql/logictest/testdata/logic_test/event_log
+++ b/pkg/sql/logictest/testdata/logic_test/event_log
@@ -1,4 +1,4 @@
-# LogicTest: default distsql distsql-metadata
+# TestConfigs: default distsql distsql-metadata
 
 ##################
 # TABLE DDL

--- a/pkg/sql/logictest/testdata/logic_test/explain
+++ b/pkg/sql/logictest/testdata/logic_test/explain
@@ -1,4 +1,4 @@
-# LogicTest: default distsql distsql-metadata
+# TestConfigs: default distsql distsql-metadata
 
 query TTT colnames
 EXPLAIN (PLAN) SELECT 1 FROM system.jobs WHERE FALSE

--- a/pkg/sql/logictest/testdata/logic_test/explain_distsql
+++ b/pkg/sql/logictest/testdata/logic_test/explain_distsql
@@ -1,4 +1,4 @@
-# LogicTest: default
+# TestConfigs: default
 
 #
 # Tests that verify DistSQL support and auto mode determination.

--- a/pkg/sql/logictest/testdata/logic_test/explain_plan
+++ b/pkg/sql/logictest/testdata/logic_test/explain_plan
@@ -1,4 +1,4 @@
-# LogicTest: default distsql distsql-metadata
+# TestConfigs: default distsql distsql-metadata
 
 statement ok
 CREATE TABLE t (

--- a/pkg/sql/logictest/testdata/logic_test/explain_types
+++ b/pkg/sql/logictest/testdata/logic_test/explain_types
@@ -1,4 +1,4 @@
-# LogicTest: default distsql distsql-metadata
+# TestConfigs: default distsql distsql-metadata
 
 statement ok
 CREATE TABLE t (

--- a/pkg/sql/logictest/testdata/logic_test/family
+++ b/pkg/sql/logictest/testdata/logic_test/family
@@ -1,4 +1,4 @@
-# LogicTest: default parallel-stmts distsql distsql-metadata
+# TestConfigs: default parallel-stmts distsql distsql-metadata
 
 # a is the primary key so b gets optimized into a one column value. The c, d
 # family has two columns, so it's encoded as a tuple

--- a/pkg/sql/logictest/testdata/logic_test/fk
+++ b/pkg/sql/logictest/testdata/logic_test/fk
@@ -1,4 +1,4 @@
-# LogicTest: default parallel-stmts distsql distsql-metadata
+# TestConfigs: default parallel-stmts distsql distsql-metadata
 
 statement ok
 CREATE TABLE customers (id INT PRIMARY KEY, email STRING UNIQUE)

--- a/pkg/sql/logictest/testdata/logic_test/float
+++ b/pkg/sql/logictest/testdata/logic_test/float
@@ -1,4 +1,4 @@
-# LogicTest: default parallel-stmts distsql distsql-metadata
+# TestConfigs: default parallel-stmts distsql distsql-metadata
 
 # -0 and 0 should not be possible in a unique index.
 

--- a/pkg/sql/logictest/testdata/logic_test/function_lookup
+++ b/pkg/sql/logictest/testdata/logic_test/function_lookup
@@ -1,4 +1,4 @@
-# LogicTest: default distsql distsql-metadata
+# TestConfigs: default distsql distsql-metadata
 
 statement ok
 CREATE TABLE foo(x INT DEFAULT LENGTH(PG_TYPEOF(1234))-1)

--- a/pkg/sql/logictest/testdata/logic_test/generators
+++ b/pkg/sql/logictest/testdata/logic_test/generators
@@ -1,4 +1,4 @@
-# LogicTest: default parallel-stmts distsql distsql-metadata
+# TestConfigs: default parallel-stmts distsql distsql-metadata
 
 subtest generate_series
 

--- a/pkg/sql/logictest/testdata/logic_test/grant_database
+++ b/pkg/sql/logictest/testdata/logic_test/grant_database
@@ -1,4 +1,4 @@
-# LogicTest: default
+# TestConfigs: default
 
 statement ok
 CREATE DATABASE a

--- a/pkg/sql/logictest/testdata/logic_test/grant_table
+++ b/pkg/sql/logictest/testdata/logic_test/grant_table
@@ -1,4 +1,4 @@
-# LogicTest: default
+# TestConfigs: default
 
 statement ok
 CREATE DATABASE a

--- a/pkg/sql/logictest/testdata/logic_test/inet
+++ b/pkg/sql/logictest/testdata/logic_test/inet
@@ -1,4 +1,4 @@
-# LogicTest: default parallel-stmts distsql distsql-metadata
+# TestConfigs: default parallel-stmts distsql distsql-metadata
 
 # Basic IPv4 tests
 

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -1,4 +1,4 @@
-# LogicTest: default
+# TestConfigs: default
 
 # Verify information_schema database handles mutation statements correctly.
 

--- a/pkg/sql/logictest/testdata/logic_test/insert
+++ b/pkg/sql/logictest/testdata/logic_test/insert
@@ -1,4 +1,4 @@
-# LogicTest: default parallel-stmts
+# TestConfigs: default parallel-stmts
 
 statement error pgcode 42P01 relation "kv" does not exist
 INSERT INTO kv VALUES ('a', 'b')

--- a/pkg/sql/logictest/testdata/logic_test/interleaved
+++ b/pkg/sql/logictest/testdata/logic_test/interleaved
@@ -1,4 +1,4 @@
-# LogicTest: default parallel-stmts distsql distsql-metadata
+# TestConfigs: default parallel-stmts distsql distsql-metadata
 
 # Grandparent table
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/interleaved_join
+++ b/pkg/sql/logictest/testdata/logic_test/interleaved_join
@@ -1,4 +1,4 @@
-# LogicTest: 5node-distsql 5node-distsql-metadata
+# TestConfigs: 5node-distsql 5node-distsql-metadata
 
 # The following tables form the interleaved hierarchy:
 #   name:             primary key:                # rows:   'a' = id mod X :

--- a/pkg/sql/logictest/testdata/logic_test/inverted_index
+++ b/pkg/sql/logictest/testdata/logic_test/inverted_index
@@ -1,4 +1,4 @@
-# LogicTest: default distsql distsql-metadata parallel-stmts
+# TestConfigs: default distsql distsql-metadata parallel-stmts
 
 statement ok
 CREATE TABLE t (

--- a/pkg/sql/logictest/testdata/logic_test/join
+++ b/pkg/sql/logictest/testdata/logic_test/join
@@ -1,4 +1,4 @@
-# LogicTest: default parallel-stmts distsql distsql-metadata distsql-disk
+# TestConfigs: default parallel-stmts distsql distsql-metadata distsql-disk
 
 # The join condition logic is tricky to get right with NULL
 # values. Simple implementations can deal well with NULLs on the first

--- a/pkg/sql/logictest/testdata/logic_test/json
+++ b/pkg/sql/logictest/testdata/logic_test/json
@@ -1,4 +1,4 @@
-# LogicTest: default distsql distsql-metadata parallel-stmts
+# TestConfigs: default distsql distsql-metadata parallel-stmts
 
 ## Basic creation
 

--- a/pkg/sql/logictest/testdata/logic_test/json_builtins
+++ b/pkg/sql/logictest/testdata/logic_test/json_builtins
@@ -1,4 +1,4 @@
-# LogicTest: default distsql distsql-metadata parallel-stmts
+# TestConfigs: default distsql distsql-metadata parallel-stmts
 
 ## json_typeof and jsonb_typeof
 

--- a/pkg/sql/logictest/testdata/logic_test/limit
+++ b/pkg/sql/logictest/testdata/logic_test/limit
@@ -1,4 +1,4 @@
-# LogicTest: default distsql distsql-metadata
+# TestConfigs: default distsql distsql-metadata
 
 query I
 SELECT generate_series FROM GENERATE_SERIES(1, 100) ORDER BY generate_series LIMIT 5;

--- a/pkg/sql/logictest/testdata/logic_test/lookup_join
+++ b/pkg/sql/logictest/testdata/logic_test/lookup_join
@@ -1,4 +1,4 @@
-# LogicTest: 5node-distsql 5node-distsql-metadata
+# TestConfigs: 5node-distsql 5node-distsql-metadata
 
 ########################
 #  LOOKUP JOIN FORCED  #

--- a/pkg/sql/logictest/testdata/logic_test/manual_retry
+++ b/pkg/sql/logictest/testdata/logic_test/manual_retry
@@ -1,4 +1,4 @@
-# LogicTest: default parallel-stmts distsql distsql-metadata
+# TestConfigs: default parallel-stmts distsql distsql-metadata
 
 subtest automatic_retry
 

--- a/pkg/sql/logictest/testdata/logic_test/multi_statement
+++ b/pkg/sql/logictest/testdata/logic_test/multi_statement
@@ -1,4 +1,4 @@
-# LogicTest: default parallel-stmts distsql distsql-metadata
+# TestConfigs: default parallel-stmts distsql distsql-metadata
 
 statement ok
 CREATE TABLE kv (

--- a/pkg/sql/logictest/testdata/logic_test/name_escapes
+++ b/pkg/sql/logictest/testdata/logic_test/name_escapes
@@ -1,4 +1,4 @@
-# LogicTest: default distsql distsql-metadata
+# TestConfigs: default distsql distsql-metadata
 
 # Check that the various things in a table definition are properly escaped when
 # printed out.

--- a/pkg/sql/logictest/testdata/logic_test/namespace
+++ b/pkg/sql/logictest/testdata/logic_test/namespace
@@ -1,4 +1,4 @@
-# LogicTest: default distsql distsql-metadata
+# TestConfigs: default distsql distsql-metadata
 
 statement ok
 CREATE TABLE a(a INT)

--- a/pkg/sql/logictest/testdata/logic_test/needed_columns
+++ b/pkg/sql/logictest/testdata/logic_test/needed_columns
@@ -1,4 +1,4 @@
-# LogicTest: default distsql distsql-metadata
+# TestConfigs: default distsql distsql-metadata
 
 query TTTTT
 EXPLAIN (VERBOSE,NOOPTIMIZE) SELECT 1 FROM (SELECT 2 AS s)

--- a/pkg/sql/logictest/testdata/logic_test/no_primary_key
+++ b/pkg/sql/logictest/testdata/logic_test/no_primary_key
@@ -1,4 +1,4 @@
-# LogicTest: default parallel-stmts distsql distsql-metadata
+# TestConfigs: default parallel-stmts distsql distsql-metadata
 
 query error duplicate column name: "rowid"
 CREATE TABLE t (

--- a/pkg/sql/logictest/testdata/logic_test/optimizer
+++ b/pkg/sql/logictest/testdata/logic_test/optimizer
@@ -1,4 +1,4 @@
-# LogicTest: default distsql
+# TestConfigs: default distsql
 
 statement ok
 CREATE TABLE t (k INT PRIMARY KEY, v INT)

--- a/pkg/sql/logictest/testdata/logic_test/order_by
+++ b/pkg/sql/logictest/testdata/logic_test/order_by
@@ -1,4 +1,4 @@
-# LogicTest: default parallel-stmts distsql distsql-metadata distsql-disk
+# TestConfigs: default parallel-stmts distsql distsql-metadata distsql-disk
 
 statement ok
 CREATE TABLE t (

--- a/pkg/sql/logictest/testdata/logic_test/order_by_index
+++ b/pkg/sql/logictest/testdata/logic_test/order_by_index
@@ -1,4 +1,4 @@
-# LogicTest: default distsql distsql-metadata
+# TestConfigs: default distsql distsql-metadata
 
 statement ok
 CREATE TABLE kv(k INT PRIMARY KEY, v INT); CREATE INDEX foo ON kv(v DESC)

--- a/pkg/sql/logictest/testdata/logic_test/ordinal_references
+++ b/pkg/sql/logictest/testdata/logic_test/ordinal_references
@@ -1,4 +1,4 @@
-# LogicTest: default parallel-stmts distsql distsql-metadata
+# TestConfigs: default parallel-stmts distsql distsql-metadata
 
 statement ok
 CREATE TABLE foo(a INT, b CHAR)

--- a/pkg/sql/logictest/testdata/logic_test/ordinality
+++ b/pkg/sql/logictest/testdata/logic_test/ordinality
@@ -1,4 +1,4 @@
-# LogicTest: default parallel-stmts distsql distsql-metadata
+# TestConfigs: default parallel-stmts distsql distsql-metadata
 
 query TI colnames
 SELECT * FROM (VALUES ('a'), ('b')) WITH ORDINALITY AS X(name, i)

--- a/pkg/sql/logictest/testdata/logic_test/orms
+++ b/pkg/sql/logictest/testdata/logic_test/orms
@@ -1,4 +1,4 @@
-# LogicTest: default parallel-stmts distsql distsql-metadata
+# TestConfigs: default parallel-stmts distsql distsql-metadata
 
 ## This test file contains various complex queries that ORMs issue during
 ## startup or general use.

--- a/pkg/sql/logictest/testdata/logic_test/parallel_stmts
+++ b/pkg/sql/logictest/testdata/logic_test/parallel_stmts
@@ -1,4 +1,4 @@
-# LogicTest: default parallel-stmts distsql distsql-metadata
+# TestConfigs: default parallel-stmts distsql distsql-metadata
 
 statement ok
 CREATE TABLE kv (

--- a/pkg/sql/logictest/testdata/logic_test/partitioning
+++ b/pkg/sql/logictest/testdata/logic_test/partitioning
@@ -1,4 +1,4 @@
-# LogicTest: default
+# TestConfigs: default
 
 statement error creating or manipulating partitions requires a CCL binary
 CREATE TABLE t (a INT, b INT, c INT, PRIMARY KEY (a, b)) PARTITION BY LIST (a) (

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -1,4 +1,4 @@
-# LogicTest: default parallel-stmts
+# TestConfigs: default parallel-stmts
 
 # Verify pg_catalog database handles mutation statements correctly.
 

--- a/pkg/sql/logictest/testdata/logic_test/pgoidtype
+++ b/pkg/sql/logictest/testdata/logic_test/pgoidtype
@@ -1,4 +1,4 @@
-# LogicTest: default distsql distsql-metadata
+# TestConfigs: default distsql distsql-metadata
 
 query OO
 SELECT 3::OID, '3'::OID

--- a/pkg/sql/logictest/testdata/logic_test/physical_props
+++ b/pkg/sql/logictest/testdata/logic_test/physical_props
@@ -1,4 +1,4 @@
-# LogicTest: default
+# TestConfigs: default
 
 statement ok
 CREATE TABLE abcd (a INT PRIMARY KEY, b INT, c INT, d INT)

--- a/pkg/sql/logictest/testdata/logic_test/planhook
+++ b/pkg/sql/logictest/testdata/logic_test/planhook
@@ -1,4 +1,4 @@
-# LogicTest: default distsql distsql-metadata
+# TestConfigs: default distsql distsql-metadata
 
 # The placeholder returns one row with one value: the string 'planhook'.
 query T

--- a/pkg/sql/logictest/testdata/logic_test/planning_errors
+++ b/pkg/sql/logictest/testdata/logic_test/planning_errors
@@ -1,4 +1,4 @@
-# LogicTest: default
+# TestConfigs: default
 
 # Check that plans that fail during expansion/optimization do not cause
 # memory leaks. #17274

--- a/pkg/sql/logictest/testdata/logic_test/poison_after_push
+++ b/pkg/sql/logictest/testdata/logic_test/poison_after_push
@@ -1,4 +1,4 @@
-# LogicTest: default parallel-stmts distsql distsql-metadata
+# TestConfigs: default parallel-stmts distsql distsql-metadata
 
 # This example session documents that a SERIALIZABLE transaction is
 # not immediately poisoned when it revisits a Range on which one of

--- a/pkg/sql/logictest/testdata/logic_test/postgres_jsonb
+++ b/pkg/sql/logictest/testdata/logic_test/postgres_jsonb
@@ -1,4 +1,4 @@
-# LogicTest: default opt parallel-stmts distsql distsql-opt distsql-metadata
+# TestConfigs: default opt parallel-stmts distsql distsql-opt distsql-metadata
 
 # This file is an incomplete porting of
 # https://github.com/postgres/postgres/blob/11e264517dff7a911d9e6494de86049cab42cde3/src/test/regress/sql/jsonb.sql

--- a/pkg/sql/logictest/testdata/logic_test/postgresjoin
+++ b/pkg/sql/logictest/testdata/logic_test/postgresjoin
@@ -1,4 +1,4 @@
-# LogicTest: default opt parallel-stmts distsql distsql-opt distsql-metadata distsql-disk
+# TestConfigs: default opt parallel-stmts distsql distsql-opt distsql-metadata distsql-disk
 
 # These are postgres regress sql join test suite
 # https://github.com/postgres/postgres/blob/master/src/test/regress/sql/join.sql

--- a/pkg/sql/logictest/testdata/logic_test/prepare
+++ b/pkg/sql/logictest/testdata/logic_test/prepare
@@ -1,4 +1,4 @@
-# LogicTest: default
+# TestConfigs: default
 
 ## Tests for ensuring that prepared statements can't get overwritten and for
 ## deallocate and deallocate all.

--- a/pkg/sql/logictest/testdata/logic_test/privilege_builtins
+++ b/pkg/sql/logictest/testdata/logic_test/privilege_builtins
@@ -1,4 +1,4 @@
-# LogicTest: default distsql distsql-metadata
+# TestConfigs: default distsql distsql-metadata
 
 statement ok
 CREATE USER bar

--- a/pkg/sql/logictest/testdata/logic_test/privileges_database
+++ b/pkg/sql/logictest/testdata/logic_test/privileges_database
@@ -1,4 +1,4 @@
-# LogicTest: default distsql distsql-metadata
+# TestConfigs: default distsql distsql-metadata
 
 # Test default database-level permissions.
 # Default user is root.

--- a/pkg/sql/logictest/testdata/logic_test/privileges_table
+++ b/pkg/sql/logictest/testdata/logic_test/privileges_table
@@ -1,4 +1,4 @@
-# LogicTest: default parallel-stmts distsql distsql-metadata
+# TestConfigs: default parallel-stmts distsql distsql-metadata
 
 # Test default table-level permissions.
 # Default user is root.

--- a/pkg/sql/logictest/testdata/logic_test/ranges
+++ b/pkg/sql/logictest/testdata/logic_test/ranges
@@ -1,4 +1,4 @@
-# LogicTest: 5node
+# TestConfigs: 5node
 
 statement ok
 CREATE TABLE t (k1 INT, k2 INT, v INT, w INT, PRIMARY KEY (k1, k2))

--- a/pkg/sql/logictest/testdata/logic_test/rename_column
+++ b/pkg/sql/logictest/testdata/logic_test/rename_column
@@ -1,4 +1,4 @@
-# LogicTest: default parallel-stmts distsql distsql-metadata
+# TestConfigs: default parallel-stmts distsql distsql-metadata
 
 statement ok
 CREATE TABLE users (

--- a/pkg/sql/logictest/testdata/logic_test/rename_database
+++ b/pkg/sql/logictest/testdata/logic_test/rename_database
@@ -1,4 +1,4 @@
-# LogicTest: default parallel-stmts distsql distsql-metadata
+# TestConfigs: default parallel-stmts distsql distsql-metadata
 
 query T
 SHOW DATABASES

--- a/pkg/sql/logictest/testdata/logic_test/rename_index
+++ b/pkg/sql/logictest/testdata/logic_test/rename_index
@@ -1,4 +1,4 @@
-# LogicTest: default parallel-stmts distsql distsql-metadata
+# TestConfigs: default parallel-stmts distsql distsql-metadata
 
 statement ok
 CREATE TABLE users (

--- a/pkg/sql/logictest/testdata/logic_test/rename_sequence
+++ b/pkg/sql/logictest/testdata/logic_test/rename_sequence
@@ -1,4 +1,4 @@
-# LogicTest: default distsql distsql-metadata parallel-stmts
+# TestConfigs: default distsql distsql-metadata parallel-stmts
 
 # see also file `sequences`
 

--- a/pkg/sql/logictest/testdata/logic_test/rename_table
+++ b/pkg/sql/logictest/testdata/logic_test/rename_table
@@ -1,4 +1,4 @@
-# LogicTest: default parallel-stmts distsql distsql-metadata
+# TestConfigs: default parallel-stmts distsql distsql-metadata
 
 statement error pgcode 42P01 relation "foo" does not exist
 ALTER TABLE foo RENAME TO bar

--- a/pkg/sql/logictest/testdata/logic_test/rename_view
+++ b/pkg/sql/logictest/testdata/logic_test/rename_view
@@ -1,4 +1,4 @@
-# LogicTest: default parallel-stmts distsql distsql-metadata
+# TestConfigs: default parallel-stmts distsql distsql-metadata
 
 statement error pgcode 42P01 relation "foo" does not exist
 ALTER VIEW foo RENAME TO bar

--- a/pkg/sql/logictest/testdata/logic_test/reset
+++ b/pkg/sql/logictest/testdata/logic_test/reset
@@ -1,4 +1,4 @@
-# LogicTest: default
+# TestConfigs: default
 
 statement error unknown variable: "foo"
 RESET FOO

--- a/pkg/sql/logictest/testdata/logic_test/returning
+++ b/pkg/sql/logictest/testdata/logic_test/returning
@@ -1,4 +1,4 @@
-# LogicTest: default parallel-stmts
+# TestConfigs: default parallel-stmts
 
 statement ok
 CREATE TABLE a (a int, b int)

--- a/pkg/sql/logictest/testdata/logic_test/role
+++ b/pkg/sql/logictest/testdata/logic_test/role
@@ -1,4 +1,4 @@
-# LogicTest: default
+# TestConfigs: default
 
 query T colnames
 SHOW ROLES

--- a/pkg/sql/logictest/testdata/logic_test/run_control
+++ b/pkg/sql/logictest/testdata/logic_test/run_control
@@ -1,4 +1,4 @@
-# LogicTest: default parallel-stmts distsql distsql-metadata
+# TestConfigs: default parallel-stmts distsql distsql-metadata
 
 query error job with ID 1 does not exist
 PAUSE JOB 1

--- a/pkg/sql/logictest/testdata/logic_test/scale
+++ b/pkg/sql/logictest/testdata/logic_test/scale
@@ -1,4 +1,4 @@
-# LogicTest: default parallel-stmts distsql distsql-metadata
+# TestConfigs: default parallel-stmts distsql distsql-metadata
 
 statement ok
 CREATE TABLE test (

--- a/pkg/sql/logictest/testdata/logic_test/scatter
+++ b/pkg/sql/logictest/testdata/logic_test/scatter
@@ -1,4 +1,4 @@
-# LogicTest: default
+# TestConfigs: default
 
 statement ok
 CREATE TABLE t (a INT PRIMARY KEY)

--- a/pkg/sql/logictest/testdata/logic_test/schema_change_in_txn
+++ b/pkg/sql/logictest/testdata/logic_test/schema_change_in_txn
@@ -1,4 +1,4 @@
-# LogicTest: default parallel-stmts distsql distsql-metadata
+# TestConfigs: default parallel-stmts distsql distsql-metadata
 
 subtest create_with_other_commands_in_txn
 

--- a/pkg/sql/logictest/testdata/logic_test/schema_change_retry
+++ b/pkg/sql/logictest/testdata/logic_test/schema_change_retry
@@ -1,4 +1,4 @@
-# LogicTest: default parallel-stmts distsql distsql-metadata
+# TestConfigs: default parallel-stmts distsql distsql-metadata
 
 # This test reproduces https://github.com/cockroachdb/cockroach/issues/23979
 

--- a/pkg/sql/logictest/testdata/logic_test/scrub
+++ b/pkg/sql/logictest/testdata/logic_test/scrub
@@ -1,4 +1,4 @@
-# LogicTest: default parallel-stmts distsql distsql-metadata
+# TestConfigs: default parallel-stmts distsql distsql-metadata
 
 statement error pgcode 42P01 relation "t" does not exist
 EXPERIMENTAL SCRUB TABLE t

--- a/pkg/sql/logictest/testdata/logic_test/select
+++ b/pkg/sql/logictest/testdata/logic_test/select
@@ -1,4 +1,4 @@
-# LogicTest: default parallel-stmts distsql distsql-metadata
+# TestConfigs: default parallel-stmts distsql distsql-metadata
 
 # SELECT with no table.
 

--- a/pkg/sql/logictest/testdata/logic_test/select_index
+++ b/pkg/sql/logictest/testdata/logic_test/select_index
@@ -1,4 +1,4 @@
-# LogicTest: default parallel-stmts distsql distsql-metadata
+# TestConfigs: default parallel-stmts distsql distsql-metadata
 
 statement ok
 CREATE TABLE t (

--- a/pkg/sql/logictest/testdata/logic_test/select_index_hints
+++ b/pkg/sql/logictest/testdata/logic_test/select_index_hints
@@ -1,4 +1,4 @@
-# LogicTest: default parallel-stmts distsql distsql-metadata
+# TestConfigs: default parallel-stmts distsql distsql-metadata
 
 statement ok
 CREATE TABLE abcd (

--- a/pkg/sql/logictest/testdata/logic_test/select_index_span_ranges
+++ b/pkg/sql/logictest/testdata/logic_test/select_index_span_ranges
@@ -1,4 +1,4 @@
-# LogicTest: default parallel-stmts distsql distsql-metadata
+# TestConfigs: default parallel-stmts distsql distsql-metadata
 
 # This test verifies that we correctly perform an index join when the KV
 # batches span ranges. This is testing that SQL disables batch limits for index

--- a/pkg/sql/logictest/testdata/logic_test/select_non_covering_index
+++ b/pkg/sql/logictest/testdata/logic_test/select_non_covering_index
@@ -1,4 +1,4 @@
-# LogicTest: default parallel-stmts distsql distsql-metadata
+# TestConfigs: default parallel-stmts distsql distsql-metadata
 
 statement ok
 CREATE TABLE t (

--- a/pkg/sql/logictest/testdata/logic_test/select_non_covering_index_filtering
+++ b/pkg/sql/logictest/testdata/logic_test/select_non_covering_index_filtering
@@ -1,4 +1,4 @@
-# LogicTest: default parallel-stmts distsql distsql-metadata
+# TestConfigs: default parallel-stmts distsql distsql-metadata
 
 # These tests verify that while we are joining an index with the table, we
 # evaluate what parts of the filter we can using the columns in the index

--- a/pkg/sql/logictest/testdata/logic_test/select_search_path
+++ b/pkg/sql/logictest/testdata/logic_test/select_search_path
@@ -1,4 +1,4 @@
-# LogicTest: default distsql distsql-metadata
+# TestConfigs: default distsql distsql-metadata
 
 # Test that pg_catalog tables are accessible without qualifying table/view
 # names.

--- a/pkg/sql/logictest/testdata/logic_test/select_table_alias
+++ b/pkg/sql/logictest/testdata/logic_test/select_table_alias
@@ -1,4 +1,4 @@
-# LogicTest: default distsql distsql-metadata
+# TestConfigs: default distsql distsql-metadata
 
 # Tests for SELECT with table aliasing.
 

--- a/pkg/sql/logictest/testdata/logic_test/select_tighten_spans
+++ b/pkg/sql/logictest/testdata/logic_test/select_tighten_spans
@@ -1,4 +1,4 @@
-# LogicTest: 5node-distsql 5node-distsql-metadata
+# TestConfigs: 5node-distsql 5node-distsql-metadata
 
 # This test verifies that we correctly tighten spans during index selection as
 # well as after partitioning spans in distsql.

--- a/pkg/sql/logictest/testdata/logic_test/sequences
+++ b/pkg/sql/logictest/testdata/logic_test/sequences
@@ -1,4 +1,4 @@
-# LogicTest: default distsql distsql-metadata parallel-stmts
+# TestConfigs: default distsql distsql-metadata parallel-stmts
 
 # see also files `drop_sequence`, `alter_sequence`, `rename_sequence`
 

--- a/pkg/sql/logictest/testdata/logic_test/sequences_distsql
+++ b/pkg/sql/logictest/testdata/logic_test/sequences_distsql
@@ -1,4 +1,4 @@
-# LogicTest: distsql distsql-metadata
+# TestConfigs: distsql distsql-metadata
 
 
 # Test that sequence functions work in DistSQL queries.

--- a/pkg/sql/logictest/testdata/logic_test/serial
+++ b/pkg/sql/logictest/testdata/logic_test/serial
@@ -1,4 +1,4 @@
-# LogicTest: default parallel-stmts distsql distsql-metadata
+# TestConfigs: default parallel-stmts distsql distsql-metadata
 
 statement ok
 CREATE TABLE serial (

--- a/pkg/sql/logictest/testdata/logic_test/serializable_eager_restart
+++ b/pkg/sql/logictest/testdata/logic_test/serializable_eager_restart
@@ -1,4 +1,4 @@
-# LogicTest: default parallel-stmts distsql distsql-metadata
+# TestConfigs: default parallel-stmts distsql distsql-metadata
 
 # Demonstrates late restarting of a serializable transaction when its
 # commit timestamp has moved forward.

--- a/pkg/sql/logictest/testdata/logic_test/set
+++ b/pkg/sql/logictest/testdata/logic_test/set
@@ -1,4 +1,4 @@
-# LogicTest: default
+# TestConfigs: default
 
 statement error unknown variable: "foo"
 SET foo = bar

--- a/pkg/sql/logictest/testdata/logic_test/show_fingerprints
+++ b/pkg/sql/logictest/testdata/logic_test/show_fingerprints
@@ -1,4 +1,4 @@
-# LogicTest: default parallel-stmts distsql distsql-metadata
+# TestConfigs: default parallel-stmts distsql distsql-metadata
 
 statement ok
 CREATE TABLE t (a INT PRIMARY KEY, b INT, c INT, d INT, INDEX (b) STORING (d))

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -1,4 +1,4 @@
-# LogicTest: default
+# TestConfigs: default
 
 query T colnames
 SELECT * FROM [SHOW client_encoding]

--- a/pkg/sql/logictest/testdata/logic_test/show_trace
+++ b/pkg/sql/logictest/testdata/logic_test/show_trace
@@ -1,4 +1,4 @@
-# LogicTest: default
+# TestConfigs: default
 
 # Prepare a trace to be inspected below.
 

--- a/pkg/sql/logictest/testdata/logic_test/show_trace_replica
+++ b/pkg/sql/logictest/testdata/logic_test/show_trace_replica
@@ -1,4 +1,4 @@
-# LogicTest: default
+# TestConfigs: default
 
 statement ok
 CREATE TABLE t (a INT PRIMARY KEY)

--- a/pkg/sql/logictest/testdata/logic_test/snapshot_certain_read
+++ b/pkg/sql/logictest/testdata/logic_test/snapshot_certain_read
@@ -1,4 +1,4 @@
-# LogicTest: default parallel-stmts distsql distsql-metadata
+# TestConfigs: default parallel-stmts distsql distsql-metadata
 
 # This test verifies that when a SNAPSHOT transaction reads without
 # uncertainty, it actually does that. We had a performance bug which caused the

--- a/pkg/sql/logictest/testdata/logic_test/snapshot_issue2861
+++ b/pkg/sql/logictest/testdata/logic_test/snapshot_issue2861
@@ -1,4 +1,4 @@
-# LogicTest: default parallel-stmts distsql distsql-metadata
+# TestConfigs: default parallel-stmts distsql distsql-metadata
 
 # Run a simple shell session in which a reader conflicts with an open txn in
 # SNAPSHOT isolation by means of a read, which is resolved by a Push. Prevents

--- a/pkg/sql/logictest/testdata/logic_test/snapshot_timestamp_drift
+++ b/pkg/sql/logictest/testdata/logic_test/snapshot_timestamp_drift
@@ -1,4 +1,4 @@
-# LogicTest: default parallel-stmts distsql distsql-metadata
+# TestConfigs: default parallel-stmts distsql distsql-metadata
 
 # Prevents regression of #4293: We used the commit timestamp candidate instead
 # of the original timestamp for reads, which means that transactions were

--- a/pkg/sql/logictest/testdata/logic_test/snapshot_unrelated_update
+++ b/pkg/sql/logictest/testdata/logic_test/snapshot_unrelated_update
@@ -1,4 +1,4 @@
-# LogicTest: default parallel-stmts distsql distsql-metadata
+# TestConfigs: default parallel-stmts distsql distsql-metadata
 
 statement ok
 CREATE TABLE t (id INT PRIMARY KEY, v string)

--- a/pkg/sql/logictest/testdata/logic_test/spool
+++ b/pkg/sql/logictest/testdata/logic_test/spool
@@ -1,4 +1,4 @@
-# LogicTest: default
+# TestConfigs: default
 
 statement ok
 CREATE TABLE t(x INT PRIMARY KEY); INSERT INTO t VALUES(1);

--- a/pkg/sql/logictest/testdata/logic_test/stars_in_subexpressions
+++ b/pkg/sql/logictest/testdata/logic_test/stars_in_subexpressions
@@ -1,4 +1,4 @@
-# LogicTest: default
+# TestConfigs: default
 
 statement ok
 CREATE TABLE a(x, y) AS VALUES (1, 1), (2, 2)

--- a/pkg/sql/logictest/testdata/logic_test/statement_source
+++ b/pkg/sql/logictest/testdata/logic_test/statement_source
@@ -1,4 +1,4 @@
-# LogicTest: default parallel-stmts
+# TestConfigs: default parallel-stmts
 
 statement ok
 CREATE TABLE a (a INT PRIMARY KEY, b INT)

--- a/pkg/sql/logictest/testdata/logic_test/statement_statistics
+++ b/pkg/sql/logictest/testdata/logic_test/statement_statistics
@@ -1,4 +1,4 @@
-# LogicTest: default
+# TestConfigs: default
 
 # Check that node_statement_statistics report per application
 

--- a/pkg/sql/logictest/testdata/logic_test/storing
+++ b/pkg/sql/logictest/testdata/logic_test/storing
@@ -1,4 +1,4 @@
-# LogicTest: default parallel-stmts distsql distsql-metadata
+# TestConfigs: default parallel-stmts distsql distsql-metadata
 
 statement ok
 CREATE TABLE t (

--- a/pkg/sql/logictest/testdata/logic_test/suboperators
+++ b/pkg/sql/logictest/testdata/logic_test/suboperators
@@ -1,4 +1,4 @@
-# LogicTest: default parallel-stmts distsql distsql-metadata
+# TestConfigs: default parallel-stmts distsql distsql-metadata
 
 statement ok
 CREATE TABLE abc (a INT, b INT, C INT)

--- a/pkg/sql/logictest/testdata/logic_test/subquery
+++ b/pkg/sql/logictest/testdata/logic_test/subquery
@@ -1,4 +1,4 @@
-# LogicTest: default parallel-stmts distsql distsql-metadata
+# TestConfigs: default parallel-stmts distsql distsql-metadata
 
 # Tests for subqueries (SELECT statements which are part of a bigger statement).
 

--- a/pkg/sql/logictest/testdata/logic_test/system
+++ b/pkg/sql/logictest/testdata/logic_test/system
@@ -1,4 +1,4 @@
-# LogicTest: default parallel-stmts distsql distsql-metadata
+# TestConfigs: default parallel-stmts distsql distsql-metadata
 
 query T
 SHOW DATABASES

--- a/pkg/sql/logictest/testdata/logic_test/table
+++ b/pkg/sql/logictest/testdata/logic_test/table
@@ -1,4 +1,4 @@
-# LogicTest: default parallel-stmts distsql distsql-metadata
+# TestConfigs: default parallel-stmts distsql distsql-metadata
 
 statement ok
 SET DATABASE = ""

--- a/pkg/sql/logictest/testdata/logic_test/time
+++ b/pkg/sql/logictest/testdata/logic_test/time
@@ -1,4 +1,4 @@
-# LogicTest: default parallel-stmts distsql distsql-metadata
+# TestConfigs: default parallel-stmts distsql distsql-metadata
 
 # Note that the odd '0000-01-01 hh:mi:ss +0000 UTC' result format is an
 # artifact of how pq displays TIMEs.

--- a/pkg/sql/logictest/testdata/logic_test/timetz
+++ b/pkg/sql/logictest/testdata/logic_test/timetz
@@ -1,4 +1,4 @@
-# LogicTest: default parallel-stmts distsql distsql-metadata
+# TestConfigs: default parallel-stmts distsql distsql-metadata
 
 # Note that the odd '0000-01-01 hh:mi:ss +0000 UTC' result format is an
 # artifact of how pq displays TIMETZs.

--- a/pkg/sql/logictest/testdata/logic_test/truncate
+++ b/pkg/sql/logictest/testdata/logic_test/truncate
@@ -1,4 +1,4 @@
-# LogicTest: default parallel-stmts distsql distsql-metadata
+# TestConfigs: default parallel-stmts distsql distsql-metadata
 
 statement ok
 CREATE TABLE kv (

--- a/pkg/sql/logictest/testdata/logic_test/tuple
+++ b/pkg/sql/logictest/testdata/logic_test/tuple
@@ -1,4 +1,4 @@
-# LogicTest: default parallel-stmts distsql distsql-metadata distsql-disk
+# TestConfigs: default parallel-stmts distsql distsql-metadata distsql-disk
 
 subtest unlabeled_tuple
 

--- a/pkg/sql/logictest/testdata/logic_test/txn
+++ b/pkg/sql/logictest/testdata/logic_test/txn
@@ -1,4 +1,4 @@
-# LogicTest: default parallel-stmts distsql distsql-metadata
+# TestConfigs: default parallel-stmts distsql distsql-metadata
 
 # Transaction involving schema changes.
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/txn_retry
+++ b/pkg/sql/logictest/testdata/logic_test/txn_retry
@@ -1,4 +1,4 @@
-# LogicTest: default
+# TestConfigs: default
 
 # Check that we auto-retry pushed transactions which can't be refreshed - if
 # they're pushed while we can still auto-retry them.

--- a/pkg/sql/logictest/testdata/logic_test/typing
+++ b/pkg/sql/logictest/testdata/logic_test/typing
@@ -1,4 +1,4 @@
-# LogicTest: default
+# TestConfigs: default
 
 statement ok
 CREATE TABLE f (x FLOAT)

--- a/pkg/sql/logictest/testdata/logic_test/unimplemented
+++ b/pkg/sql/logictest/testdata/logic_test/unimplemented
@@ -1,4 +1,4 @@
-# LogicTest: default
+# TestConfigs: default
 
 statement error pq: unimplemented
 ALTER TABLE foo RENAME CONSTRAINT x TO y

--- a/pkg/sql/logictest/testdata/logic_test/union
+++ b/pkg/sql/logictest/testdata/logic_test/union
@@ -1,4 +1,4 @@
-# LogicTest: default distsql distsql-metadata
+# TestConfigs: default distsql distsql-metadata
 
 query I rowsort
 VALUES (1), (1), (1), (2), (2) UNION VALUES (1), (3), (1)

--- a/pkg/sql/logictest/testdata/logic_test/update
+++ b/pkg/sql/logictest/testdata/logic_test/update
@@ -1,4 +1,4 @@
-# LogicTest: default parallel-stmts
+# TestConfigs: default parallel-stmts
 
 statement ok
 CREATE TABLE kv (

--- a/pkg/sql/logictest/testdata/logic_test/upsert
+++ b/pkg/sql/logictest/testdata/logic_test/upsert
@@ -1,4 +1,4 @@
-# LogicTest: default parallel-stmts distsql distsql-metadata
+# TestConfigs: default parallel-stmts distsql distsql-metadata
 
 statement ok
 CREATE TABLE kv (

--- a/pkg/sql/logictest/testdata/logic_test/user
+++ b/pkg/sql/logictest/testdata/logic_test/user
@@ -1,4 +1,4 @@
-# LogicTest: default
+# TestConfigs: default
 
 query T colnames
 SHOW USERS

--- a/pkg/sql/logictest/testdata/logic_test/uuid
+++ b/pkg/sql/logictest/testdata/logic_test/uuid
@@ -1,4 +1,4 @@
-# LogicTest: default parallel-stmts distsql distsql-metadata
+# TestConfigs: default parallel-stmts distsql distsql-metadata
 
 statement ok
 CREATE TABLE u (token uuid PRIMARY KEY,

--- a/pkg/sql/logictest/testdata/logic_test/values
+++ b/pkg/sql/logictest/testdata/logic_test/values
@@ -1,4 +1,4 @@
-# LogicTest: default distsql distsql-metadata
+# TestConfigs: default distsql distsql-metadata
 
 query III colnames
 VALUES (1, 2, 3), (4, 5, 6)

--- a/pkg/sql/logictest/testdata/logic_test/views
+++ b/pkg/sql/logictest/testdata/logic_test/views
@@ -1,4 +1,4 @@
-# LogicTest: default parallel-stmts distsql distsql-metadata
+# TestConfigs: default parallel-stmts distsql distsql-metadata
 
 statement ok
 CREATE TABLE t (a INT PRIMARY KEY, b INT)

--- a/pkg/sql/logictest/testdata/logic_test/where
+++ b/pkg/sql/logictest/testdata/logic_test/where
@@ -1,4 +1,4 @@
-# LogicTest: default parallel-stmts distsql distsql-metadata
+# TestConfigs: default parallel-stmts distsql distsql-metadata
 
 statement ok
 CREATE TABLE kv (

--- a/pkg/sql/logictest/testdata/logic_test/window
+++ b/pkg/sql/logictest/testdata/logic_test/window
@@ -1,4 +1,4 @@
-# LogicTest: default parallel-stmts distsql distsql-metadata
+# TestConfigs: default parallel-stmts distsql distsql-metadata
 
 statement ok
 CREATE TABLE kv (

--- a/pkg/sql/logictest/testdata/logic_test/with
+++ b/pkg/sql/logictest/testdata/logic_test/with
@@ -1,4 +1,4 @@
-# LogicTest: default parallel-stmts distsql distsql-metadata
+# TestConfigs: default parallel-stmts distsql distsql-metadata
 
 query error unsupported multiple use of CTE clause "a"
 WITH a AS (SELECT 1) SELECT * FROM a CROSS JOIN a

--- a/pkg/sql/logictest/testdata/planner_test/aggregate
+++ b/pkg/sql/logictest/testdata/planner_test/aggregate
@@ -1,4 +1,4 @@
-# LogicTest: default
+# TestConfigs: default
 
 statement ok
 CREATE TABLE kv (

--- a/pkg/testutils/lint/lint_test.go
+++ b/pkg/testutils/lint/lint_test.go
@@ -872,8 +872,8 @@ func TestLint(t *testing.T) {
 				t.Errorf("reading first line of %s: %s", filename, err)
 				return
 			}
-			if !strings.HasPrefix(firstLine, "# LogicTest:") {
-				t.Errorf("%s must start with a directive, e.g. `# LogicTest: default`", filename)
+			if !strings.HasPrefix(firstLine, "# TestConfigs:") {
+				t.Errorf("%s must start with a directive, e.g. `# TestConfigs: default`", filename)
 			}
 		}); err != nil {
 			t.Error(err)


### PR DESCRIPTION
We now use the multiple configurations directive in other tests (the
planner tests). Renaming the `LogicTest:` directive to `TestConfigs:`,
which is more informative anyway.

Release note: None