### PR TITLE
distsql: fix hashAggregator close bug

### DIFF
--- a/pkg/sql/distsqlrun/aggregator.go
+++ b/pkg/sql/distsqlrun/aggregator.go
@@ -347,8 +347,17 @@ func (ag *hashAggregator) close() {
 	if ag.internalClose() {
 		log.VEventf(ag.ctx, 2, "exiting aggregator")
 		ag.bucketsAcc.Close(ag.ctx)
-		for _, bucket := range ag.buckets {
-			bucket.close(ag.ctx)
+		// If we have started emitting rows, bucketsIter will represent which
+		// buckets are still open, since buckets are closed once their results are
+		// emitted.
+		if ag.bucketsIter == nil {
+			for _, bucket := range ag.buckets {
+				bucket.close(ag.ctx)
+			}
+		} else {
+			for _, bucket := range ag.bucketsIter {
+				ag.buckets[bucket].close(ag.ctx)
+			}
 		}
 	}
 }

--- a/pkg/sql/logictest/testdata/logic_test/aggregate
+++ b/pkg/sql/logictest/testdata/logic_test/aggregate
@@ -1108,3 +1108,11 @@ SELECT 1 FROM kv GROUP BY v, w::DECIMAL HAVING w::DECIMAL > 1
 1
 1
 1
+
+# Regression test for distsql aggregator crash when using hash aggregation.
+query IT rowsort
+SELECT v, ARRAY_AGG('a') FROM kv GROUP BY v
+----
+2     {"a","a","a"}
+4     {"a","a"}
+NULL  {"a"}


### PR DESCRIPTION
Aggregator buckets are closed when getting the results and emitting
rows, but the hashAggregator would miss that fact and close all of its
buckets, reulting in potential double closes.

Release note (bug fix): Fix a panic when using unordered aggregations.