### PR TITLE
cmd/roachtest: hardcode list of roachmart zones to use

### DIFF
--- a/pkg/ccl/workloadccl/roachmartccl/roachmart.go
+++ b/pkg/ccl/workloadccl/roachmartccl/roachmart.go
@@ -28,7 +28,7 @@ import (
 // to roachprod.
 //
 // TODO(benesch): avoid hardcoding these.
-var zones = []string{"us-east1-b", "us-west1-b", "europe-west2-b"}
+var zones = []string{"us-central1-b", "us-west1-b", "europe-west2-b"}
 
 var usersSchema = func() string {
 	var buf bytes.Buffer

--- a/pkg/cmd/roachtest/main.go
+++ b/pkg/cmd/roachtest/main.go
@@ -126,7 +126,7 @@ Use 'roachtest bench -n' to see a list of all benchmarks.
 			&clusterWipe, "wipe", cmd == runCmd, // default depends on test vs. bench
 			"wipe existing cluster before starting test (for use with --cluster)")
 		cmd.Flags().StringVar(
-			&zones, "zones", "", "Zones for the cluster (use roachprod defaults if empty)")
+			&zonesF, "zones", "", "Zones for the cluster (use roachprod defaults if empty)")
 	}
 
 	var storeGenCmd = &cobra.Command{

--- a/pkg/cmd/roachtest/roachmart.go
+++ b/pkg/cmd/roachtest/roachmart.go
@@ -31,7 +31,7 @@ func registerRoachmart(r *registry) {
 			i    int
 			zone string
 		}{
-			{1, "us-east1-b"},
+			{1, "us-central1-b"},
 			{4, "us-west1-b"},
 			{7, "europe-west2-b"},
 		}
@@ -75,7 +75,7 @@ func registerRoachmart(r *registry) {
 		v := v
 		r.Add(testSpec{
 			Name:   fmt.Sprintf("roachmart/partition=%v", v),
-			Nodes:  nodes(9, geo()),
+			Nodes:  nodes(9, geo(), zones("us-central1-b,us-west1-b,europe-west2-b")),
 			Stable: true, // DO NOT COPY to new tests
 			Run: func(ctx context.Context, t *test, c *cluster) {
 				runRoachmart(ctx, t, c, v)


### PR DESCRIPTION
Roachmart requires that the list of zones in the roachtest match the
list of zones in workload/roachmart which matches the list of zones used
to create the cluster. Make sure these are all explicitly configured
now. No functional change except roachmart now uses us-central1-b
instead of us-east1-b. The us-central1-b zone is where we run nightly
tests, while us-east1-b is used for manually created roachprod clusters.

Release note: None