### PR TITLE
sql: allow DML statements after a TRUNCATE in the same transaction

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/schema_change_in_txn
+++ b/pkg/sql/logictest/testdata/logic_test/schema_change_in_txn
@@ -446,3 +446,56 @@ a b 23
 
 statement ok
 COMMIT
+
+subtest truncate_and_insert
+
+statement ok
+BEGIN
+
+statement ok
+TRUNCATE want
+
+statement ok
+INSERT INTO want (k,v) VALUES ('a', 'b')
+
+statement ok
+CREATE INDEX foo on want (v)
+
+query TT
+SELECT * FROM want@foo
+----
+a b
+
+statement ok
+COMMIT
+
+query TT
+SELECT * FROM want
+----
+a b
+
+statement ok
+BEGIN
+
+statement ok
+TRUNCATE orders
+
+# table orders is not visible to the transaction #17949
+statement error pgcode 42P01 relation "orders" does not exist
+INSERT INTO orders (k,v) VALUES ('a', 'b')
+
+statement ok
+COMMIT;
+
+statement ok
+BEGIN
+
+statement ok
+TRUNCATE customers CASCADE
+
+# table customers is not visible to the transaction #17949
+statement error pgcode 42P01 relation "customers" does not exist
+INSERT INTO customers (k) VALUES ('b')
+
+statement ok
+COMMIT;

--- a/pkg/sql/schema_changer_test.go
+++ b/pkg/sql/schema_changer_test.go
@@ -2600,7 +2600,7 @@ CREATE TABLE t.test (k INT PRIMARY KEY, v INT, pi DECIMAL DEFAULT (DECIMAL '3.14
 	}
 
 	newTableDesc := sqlbase.GetTableDescriptor(kvDB, "t", "test")
-	if !newTableDesc.Adding() {
+	if newTableDesc.Adding() {
 		t.Fatalf("bad state = %s", newTableDesc.State)
 	}
 	if err := zoneExists(sqlDB, &cfg, newTableDesc.ID); err != nil {


### PR DESCRIPTION
this change still suffers from the same problem as #17949
where DML statements fail after a TRUNCATE to a table with
external FK or INTERLEAVE references.

fixes #25794

Release note (sql fix): allow DML statements after a TRUNCATE in
the same transaction