### PR TITLE
sql: Add computed column name to errors

### DIFF
--- a/pkg/sql/insert.go
+++ b/pkg/sql/insert.go
@@ -598,7 +598,8 @@ func GenerateInsertRow(
 			// available.
 			d, err := computeExprs[i].Eval(&evalCtx)
 			if err != nil {
-				return nil, err
+				return nil, errors.Wrapf(err,
+					"computed column %s", tree.ErrString((*tree.Name)(&computedCols[i].Name)))
 			}
 			rowVals[rowContainerForComputedVals.Mapping[computedCols[i].ID]] = d
 		}

--- a/pkg/sql/logictest/testdata/logic_test/computed
+++ b/pkg/sql/logictest/testdata/logic_test/computed
@@ -708,3 +708,24 @@ INSERT INTO x (a) SELECT 1
 
 statement ok
 DROP TABLE x
+
+# Verify errors emitted from computed columns contain the column name
+statement ok
+CREATE TABLE error_check (k INT PRIMARY KEY, s STRING, i INT AS (s::INT) STORED)
+
+statement ok
+INSERT INTO error_check VALUES(1, '1')
+
+statement error computed column i:
+INSERT INTO error_check VALUES(2, 'foo')
+
+statement error computed column i:
+UPDATE error_check SET s = 'foo' WHERE k = 1
+
+# Upsert -> update
+statement error computed column i:
+UPSERT INTO error_check VALUES (1, 'foo')
+
+# Upsert -> insert
+statement error computed column i:
+UPSERT INTO error_check VALUES (3, 'foo')

--- a/pkg/sql/update.go
+++ b/pkg/sql/update.go
@@ -600,7 +600,8 @@ func (u *updateNode) processSourceRow(params runParams, sourceVals tree.Datums) 
 			d, err := u.run.computeExprs[i].Eval(params.EvalContext())
 			if err != nil {
 				params.EvalContext().IVarContainer = nil
-				return err
+				return errors.Wrapf(err,
+					"computed column %s", tree.ErrString((*tree.Name)(&u.run.computedCols[i].Name)))
 			}
 			u.run.updateValues[u.run.updateColsIdx[u.run.computedCols[i].ID]] = d
 		}


### PR DESCRIPTION
If a computed column's expression results in an error, the name of the computed
column will be added to the error returned to the user.  This will make it
easier for users to understand why an otherwise valid operation might fail.

Release note: None