### PR TITLE
importccl: plumb flowctx's EvalContext

### DIFF
--- a/pkg/ccl/importccl/import_stmt_test.go
+++ b/pkg/ccl/importccl/import_stmt_test.go
@@ -744,7 +744,7 @@ func BenchmarkConvertRecord(b *testing.B) {
 	// start up workers.
 	for i := 0; i < runtime.NumCPU(); i++ {
 		group.Go(func() error {
-			return c.convertRecord(ctx)
+			return c.convertRecordWorker(ctx)
 		})
 	}
 	const batchSize = 500

--- a/pkg/ccl/importccl/read_import_mysqlout.go
+++ b/pkg/ccl/importccl/read_import_mysqlout.go
@@ -15,6 +15,7 @@ import (
 	"unicode"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 )
 
@@ -29,7 +30,7 @@ func newMysqloutfileReader(
 	kvCh chan kvBatch,
 	opts roachpb.MySQLOutfileOptions,
 	tableDesc *sqlbase.TableDescriptor,
-	expectedCols int,
+	evalCtx *tree.EvalContext,
 ) *mysqloutfileReader {
 	null := "NULL"
 	if opts.HasEscape {
@@ -37,7 +38,7 @@ func newMysqloutfileReader(
 	}
 	csvOpts := roachpb.CSVOptions{NullEncoding: &null}
 	return &mysqloutfileReader{
-		csvInputReader: *newCSVInputReader(kvCh, csvOpts, tableDesc, expectedCols),
+		csvInputReader: *newCSVInputReader(kvCh, csvOpts, tableDesc, evalCtx),
 		opts:           opts,
 	}
 }

--- a/pkg/ccl/importccl/read_import_mysqlout_test.go
+++ b/pkg/ccl/importccl/read_import_mysqlout_test.go
@@ -23,6 +23,8 @@ import (
 	"testing"
 	"unicode/utf8"
 
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	_ "github.com/go-sql-driver/mysql"
@@ -217,8 +219,8 @@ func TestMysqlOutfileReader(t *testing.T) {
 	ctx := context.TODO()
 	for _, config := range configs {
 		t.Run(config.name, func(t *testing.T) {
-			const testdataRowWidth = 3
-			converter := newMysqloutfileReader(nil, config.opts, nil, testdataRowWidth)
+			converter := newMysqloutfileReader(nil, config.opts, &sqlbase.TableDescriptor{}, nil)
+			converter.expectedCols = 3
 			// unblock batch chan sends
 			converter.csvInputReader.recordCh = make(chan csvRecord, 4)
 			converter.csvInputReader.batchSize = 10


### PR DESCRIPTION
This replaces the mocked EvalContext that was used in CSV decoding with a real one.

Release note: none.