### PR TITLE
opt: Enable additional logic tests for opt configs

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/crdb_internal
+++ b/pkg/sql/logictest/testdata/logic_test/crdb_internal
@@ -1,4 +1,4 @@
-# LogicTest: default distsql distsql-metadata
+# LogicTest: default opt distsql distsql-opt distsql-metadata
 
 query error database "crdb_internal" does not exist
 ALTER DATABASE crdb_internal RENAME TO not_crdb_internal

--- a/pkg/sql/logictest/testdata/logic_test/create_as
+++ b/pkg/sql/logictest/testdata/logic_test/create_as
@@ -1,4 +1,4 @@
-# LogicTest: default
+# LogicTest: default opt
 
 statement count 3
 CREATE TABLE stock (item, quantity) AS VALUES ('cups', 10), ('plates', 15), ('forks', 30)

--- a/pkg/sql/logictest/testdata/logic_test/create_index
+++ b/pkg/sql/logictest/testdata/logic_test/create_index
@@ -1,4 +1,4 @@
-# LogicTest: default parallel-stmts distsql distsql-metadata
+# LogicTest: default opt parallel-stmts distsql distsql-opt distsql-metadata
 
 statement ok
 CREATE TABLE t (

--- a/pkg/sql/logictest/testdata/logic_test/create_statements
+++ b/pkg/sql/logictest/testdata/logic_test/create_statements
@@ -1,4 +1,4 @@
-# LogicTest: default parallel-stmts distsql distsql-metadata
+# LogicTest: default opt parallel-stmts distsql distsql-opt distsql-metadata
 
 statement ok
 CREATE TABLE t (a INT REFERENCES t)

--- a/pkg/sql/logictest/testdata/logic_test/dangerous_statements
+++ b/pkg/sql/logictest/testdata/logic_test/dangerous_statements
@@ -1,4 +1,4 @@
-# LogicTest: default distsql distsql-metadata
+# LogicTest: default opt distsql distsql-opt distsql-metadata
 
 statement ok
 CREATE TABLE foo(x INT)

--- a/pkg/sql/logictest/testdata/logic_test/database
+++ b/pkg/sql/logictest/testdata/logic_test/database
@@ -1,4 +1,4 @@
-# LogicTest: default
+# LogicTest: default opt
 
 statement ok
 CREATE DATABASE a

--- a/pkg/sql/logictest/testdata/logic_test/datetime
+++ b/pkg/sql/logictest/testdata/logic_test/datetime
@@ -1,4 +1,4 @@
-# LogicTest: default parallel-stmts distsql distsql-metadata distsql-disk
+# LogicTest: default opt parallel-stmts distsql distsql-metadata distsql-disk
 
 statement ok
 CREATE TABLE t (
@@ -22,31 +22,6 @@ query TTT
 SELECT * FROM t WHERE a = '2015-08-25 05:45:45.53453+01:00'::timestamp
 ----
 2015-08-25 04:45:45.53453 +0000 +0000   2015-08-25 00:00:00 +0000 +0000   2h45m2s234ms
-
-query T
-SELECT message FROM [SHOW KV TRACE FOR SELECT * FROM t WHERE a = '2015-08-25 06:45:45.53453+02:00'::timestamp]
- WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
-----
-fetched: /t/primary/'2015-08-25 04:45:45.53453+00:00' -> NULL
-fetched: /t/primary/'2015-08-25 04:45:45.53453+00:00'/b -> '2015-08-25'
-fetched: /t/primary/'2015-08-25 04:45:45.53453+00:00'/c -> '2h45m2s234ms'
-output row: ['2015-08-25 04:45:45.53453+00:00' '2015-08-25' '2h45m2s234ms']
-
-query T
-SELECT message FROM [SHOW KV TRACE FOR SELECT b FROM t WHERE b < '2015-08-29'::date]
- WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
-----
-fetched: /t/t_b_key/'2015-08-25' -> /'2015-08-25 04:45:45.53453+00:00'
-output row: ['2015-08-25']
-
-query T
-SELECT message FROM [SHOW KV TRACE FOR SELECT c FROM t WHERE c < '234h45m2s234ms'::interval]
- WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
-----
-fetched: /t/t_c_key/'2h45m2s234ms' -> /'2015-08-25 04:45:45.53453+00:00'
-output row: ['2h45m2s234ms']
-fetched: /t/t_c_key/'34h2s' -> /'2015-08-30 03:34:45.34567+00:00'
-output row: ['34h2s']
 
 # insert duplicate value with different time zone offset
 statement error duplicate key value \(a\)=\('2015-08-30 03:34:45\.34567\+00:00'\) violates unique constraint "primary"

--- a/pkg/sql/logictest/testdata/logic_test/decimal
+++ b/pkg/sql/logictest/testdata/logic_test/decimal
@@ -1,4 +1,4 @@
-# LogicTest: default parallel-stmts distsql distsql-metadata distsql-disk
+# LogicTest: default opt parallel-stmts distsql distsql-opt distsql-metadata distsql-disk
 
 # The following tests have results equivalent to Postgres (differences
 # in string representation and number of decimals returned, but otherwise
@@ -117,37 +117,15 @@ SELECT 'NaN'::decimal, '-NaN'::decimal, 'sNaN'::decimal, '-sNaN'::decimal
 ----
 NaN NaN NaN NaN
 
-query TTT
-EXPLAIN SELECT * FROM t2 WHERE d IS NaN and v IS NaN
-----
-scan  ·      ·
-·     table  t2@primary
-·     spans  /NaN/NaN-/NaN/NaN/#
-
 query RR
 SELECT * FROM t2 WHERE d IS NaN and v IS NaN
 ----
 NaN NaN
 
-# The NaN suffix is decimalNaNDesc, not decimalNaN(Asc).
-query TTT
-EXPLAIN SELECT * FROM t2 WHERE d = 'Infinity' and v = 'Infinity'
-----
-scan  ·      ·
-·     table  t2@primary
-·     spans  /Infinity/Infinity-/Infinity/Infinity/#
-
 query RR
 SELECT * FROM t2 WHERE d = 'Infinity' and v = 'Infinity'
 ----
 Infinity Infinity
-
-query TTT
-EXPLAIN SELECT * FROM t2 WHERE d = '-Infinity' and v = '-Infinity'
-----
-scan  ·      ·
-·     table  t2@primary
-·     spans  /-Infinity/-Infinity-/-Infinity/-Infinity/#
 
 query RR
 SELECT * FROM t2 WHERE d = '-Infinity' and v = '-Infinity'
@@ -198,35 +176,6 @@ query R
 SELECT * FROM s WHERE d = 'inf'::decimal
 ----
 Infinity
-
-# Verify that lookups for NaN use indices when possible:
-# - `WHERE d IS NaN` should perform a point lookup.
-# - `WHERE d = 'NaN'` should also perform a point lookup.
-# - `WHERE isnan(d)` is a function so it can't perform a point lookup.
-
-query TTT
-EXPLAIN SELECT * FROM s WHERE d IS NaN
-----
-render     ·      ·
- └── scan  ·      ·
-·          table  s@s_d_idx
-·          spans  /NaN-/-Infinity
-
-query TTT
-EXPLAIN SELECT * FROM s WHERE d = 'NaN'
-----
-render     ·      ·
- └── scan  ·      ·
-·          table  s@s_d_idx
-·          spans  /NaN-/-Infinity
-
-query TTT
-EXPLAIN SELECT * FROM s WHERE isnan(d)
-----
-render     ·      ·
- └── scan  ·      ·
-·          table  s@s_d_idx
-·          spans  ALL
 
 query R
 SELECT * FROM s WHERE d = 'NaN'

--- a/pkg/sql/logictest/testdata/logic_test/deep_interleaving
+++ b/pkg/sql/logictest/testdata/logic_test/deep_interleaving
@@ -1,7 +1,6 @@
-# LogicTest: default distsql distsql-metadata
+# LogicTest: default opt distsql distsql-opt distsql-metadata
 
-# Test index selection for deeply interleaved tables.
-# These tests are in their own file because table IDs appear in the EXPLAIN output.
+# Test querying deeply interleaved tables.
 
 statement ok
 CREATE TABLE level1 (
@@ -64,13 +63,6 @@ INSERT INTO level4 VALUES
   (3, 20, 100), (3, 20, 200), (3, 20, 300),
   (3, 30, 100), (3, 30, 200), (3, 30, 300)
 
-query TTT
-EXPLAIN SELECT * FROM level4
-----
-scan  ·      ·
-·     table  level4@primary
-·     spans  ALL
-
 query III rowsort
 SELECT * FROM level4
 ----
@@ -102,17 +94,6 @@ SELECT * FROM level4
 3  30  200
 3  30  300
 
-# The span below ends at the end of the first index of table 53, and is not
-# constraining the value of k2 or k3. This is confusing on first glance because
-# the second interleave in the hierarchy doesn't contain any new primary key
-# columns on top of the first interleave.
-query TTT
-EXPLAIN SELECT * FROM level4 WHERE k1 > 1 AND k1 < 3
-----
-scan  ·      ·
-·     table  level4@primary
-·     spans  /2/#/54/1/#/55/1-/2/#/54/1/#/55/2
-
 query III rowsort
 SELECT * FROM level4 WHERE k1 > 1 AND k1 < 3
 ----
@@ -126,13 +107,6 @@ SELECT * FROM level4 WHERE k1 > 1 AND k1 < 3
 2  30  200
 2  30  300
 
-query TTT
-EXPLAIN SELECT * FROM level4 WHERE k1 = 2 AND k2 > 10 AND k2 < 30
-----
-scan  ·      ·
-·     table  level4@primary
-·     spans  /2/#/54/1/#/55/1/11-/2/#/54/1/#/55/1/30
-
 query III rowsort
 SELECT * FROM level4 WHERE k1 = 2 AND k2 > 10 AND k2 < 30
 ----
@@ -140,24 +114,10 @@ SELECT * FROM level4 WHERE k1 = 2 AND k2 > 10 AND k2 < 30
 2  20  200
 2  20  300
 
-query TTT
-EXPLAIN SELECT * FROM level4 WHERE k1 = 2 AND k2 = 20 AND k3 > 100 AND k3 < 300
-----
-scan  ·      ·
-·     table  level4@primary
-·     spans  /2/#/54/1/#/55/1/20/101/#/56/1-/2/#/54/1/#/55/1/20/299/#/56/1/#
-
 query III
 SELECT * FROM level4 WHERE k1 = 2 AND k2 = 20 AND k3 > 100 AND k3 < 300
 ----
 2  20  200
-
-query TTT
-EXPLAIN SELECT * FROM level4 WHERE k1 = 2 AND k2 = 20 AND k3 = 200
-----
-scan  ·      ·
-·     table  level4@primary
-·     spans  /2/#/54/1/#/55/1/20/200/#/56/1-/2/#/54/1/#/55/1/20/200/#/56/1/#
 
 query III
 SELECT * FROM level4 WHERE k1 = 2 AND k2 = 20 AND k3 = 200

--- a/pkg/sql/logictest/testdata/logic_test/default
+++ b/pkg/sql/logictest/testdata/logic_test/default
@@ -1,4 +1,4 @@
-# LogicTest: default parallel-stmts distsql distsql-metadata
+# LogicTest: default opt parallel-stmts distsql distsql-opt distsql-metadata
 
 statement error expected DEFAULT expression to have type int, but 'false' has type bool
 CREATE TABLE t (a INT PRIMARY KEY DEFAULT false)

--- a/pkg/sql/logictest/testdata/logic_test/delete
+++ b/pkg/sql/logictest/testdata/logic_test/delete
@@ -1,4 +1,4 @@
-# LogicTest: default parallel-stmts
+# LogicTest: default opt parallel-stmts
 
 statement ok
 CREATE TABLE kv (

--- a/pkg/sql/logictest/testdata/logic_test/dependencies
+++ b/pkg/sql/logictest/testdata/logic_test/dependencies
@@ -1,4 +1,4 @@
-# LogicTest: default distsql distsql-metadata
+# LogicTest: default opt distsql distsql-opt distsql-metadata
 
 statement ok
 CREATE TABLE test_kv(k INT PRIMARY KEY, v INT, w DECIMAL);

--- a/pkg/sql/logictest/testdata/logic_test/discard
+++ b/pkg/sql/logictest/testdata/logic_test/discard
@@ -1,4 +1,4 @@
-# LogicTest: default distsql distsql-metadata
+# LogicTest: default opt distsql distsql-opt distsql-metadata
 
 statement ok
 SET SEARCH_PATH = foo

--- a/pkg/sql/logictest/testdata/logic_test/distinct
+++ b/pkg/sql/logictest/testdata/logic_test/distinct
@@ -1,4 +1,4 @@
-# LogicTest: default parallel-stmts distsql distsql-metadata distsql-disk
+# LogicTest: default opt parallel-stmts distsql distsql-opt distsql-metadata distsql-disk
 
 statement ok
 CREATE TABLE xyz (
@@ -47,16 +47,6 @@ SELECT y FROM (SELECT DISTINCT y, z FROM xyz)
 3
 2
 
-# TODO(vivek): Use the secondary index. Use distinct in index selection.
-query TTT
-EXPLAIN SELECT DISTINCT y, z FROM xyz
-----
-distinct        ·      ·
- └── render     ·      ·
-      └── scan  ·      ·
-·               table  xyz@primary
-·               spans  ALL
-
 query II partialsort(2)
 SELECT DISTINCT y, z FROM xyz ORDER BY z
 ----
@@ -65,16 +55,6 @@ SELECT DISTINCT y, z FROM xyz ORDER BY z
 2 6
 5 6
 2 9
-
-query TTT
-EXPLAIN SELECT DISTINCT y, z FROM xyz ORDER BY z
-----
-distinct        ·          ·
- │              order key  y, z
- └── render     ·          ·
-      └── scan  ·          ·
-·               table      xyz@foo
-·               spans      ALL
 
 query II partialsort(1)
 SELECT DISTINCT y, z FROM xyz ORDER BY y
@@ -85,18 +65,6 @@ SELECT DISTINCT y, z FROM xyz ORDER BY y
 3 5
 5 6
 
-query TTT
-EXPLAIN SELECT DISTINCT y, z FROM xyz ORDER BY y
-----
-distinct             ·          ·
- │                   order key  y
- └── sort            ·          ·
-      │              order      +y
-      └── render     ·          ·
-           └── scan  ·          ·
-·                    table      xyz@foo
-·                    spans      ALL
-
 query II
 SELECT DISTINCT y, z FROM xyz ORDER BY y, z
 ----
@@ -106,18 +74,6 @@ SELECT DISTINCT y, z FROM xyz ORDER BY y, z
 3 5
 5 6
 
-query TTT
-EXPLAIN SELECT DISTINCT y, z FROM xyz ORDER BY y, z
-----
-distinct             ·          ·
- │                   order key  y, z
- └── sort            ·          ·
-      │              order      +y,+z
-      └── render     ·          ·
-           └── scan  ·          ·
-·                    table      xyz@foo
-·                    spans      ALL
-
 query I
 SELECT DISTINCT y + z FROM xyz ORDER by (y + z)
 ----
@@ -125,35 +81,14 @@ SELECT DISTINCT y + z FROM xyz ORDER by (y + z)
 8
 11
 
-query TTT
-EXPLAIN SELECT DISTINCT y + z FROM xyz ORDER BY y + z
+query II
+SELECT DISTINCT y AS w, z FROM xyz ORDER by z, w
 ----
-distinct             ·          ·
- │                   order key  y + z
- └── sort            ·          ·
-      │              order      +"y + z"
-      └── render     ·          ·
-           └── scan  ·          ·
-·                    table      xyz@primary
-·                    spans      ALL
-
-query I
-SELECT DISTINCT y AS w FROM xyz ORDER by z
-----
-2
-3
-5
-
-query TTT
-EXPLAIN SELECT DISTINCT y AS w FROM xyz ORDER BY z
-----
-distinct             ·      ·
- └── nosort          ·      ·
-      │              order  +z
-      └── render     ·      ·
-           └── scan  ·      ·
-·                    table  xyz@foo
-·                    spans  ALL
+2  3
+3  5
+2  6
+5  6
+2  9
 
 query I
 SELECT DISTINCT y AS w FROM xyz ORDER by y
@@ -161,18 +96,6 @@ SELECT DISTINCT y AS w FROM xyz ORDER by y
 2
 3
 5
-
-query TTT
-EXPLAIN SELECT DISTINCT y AS w FROM xyz ORDER BY y
-----
-distinct             ·          ·
- │                   order key  w
- └── sort            ·          ·
-      │              order      +w
-      └── render     ·          ·
-           └── scan  ·          ·
-·                    table      xyz@foo
-·                    spans      ALL
 
 # Insert NULL values for z.
 statement ok
@@ -203,90 +126,11 @@ SELECT COUNT(*) FROM (SELECT DISTINCT y FROM xyz)
 ----
 3
 
-
-query TTTTT
-EXPLAIN (VERBOSE) SELECT DISTINCT x FROM xyz
-----
-render     ·         ·                  (x)                          x!=NULL; key(x)
- │         render 0  test.public.xyz.x  ·                            ·
- └── scan  ·         ·                  (x, y[omitted], z[omitted])  x!=NULL; key(x)
-·          table     xyz@primary        ·                            ·
-·          spans     ALL                ·                            ·
-
-query TTTTT
-EXPLAIN (VERBOSE) SELECT DISTINCT x, y, z FROM xyz
-----
-scan  ·      ·            (x, y, z)  x!=NULL; key(x)
-·     table  xyz@primary  ·          ·
-·     spans  ALL          ·          ·
-
-statement ok
-CREATE TABLE abcd (
-  a INT,
-  b INT,
-  c INT,
-  d INT NOT NULL,
-  PRIMARY KEY (a, b, c),
-  UNIQUE INDEX (d, b)
-)
-
-query TTTTT
-EXPLAIN (VERBOSE) SELECT DISTINCT 1, d, b FROM abcd ORDER BY d, b
-----
-render     ·         ·                   ("1", d, b)                     "1"=CONST; d!=NULL; b!=NULL; key(d,b); +d,+b
- │         render 0  1                   ·                               ·
- │         render 1  test.public.abcd.d  ·                               ·
- │         render 2  test.public.abcd.b  ·                               ·
- └── scan  ·         ·                   (a[omitted], b, c[omitted], d)  b!=NULL; d!=NULL; key(b,d); +d,+b
-·          table     abcd@abcd_d_b_key   ·                               ·
-·          spans     ALL                 ·                               ·
-
-query TTTTT
-EXPLAIN (VERBOSE) SELECT DISTINCT a, b FROM abcd
-----
-distinct        ·          ·                   (a, b)                          a!=NULL; b!=NULL; key(a,b); +a,+b
- │              order key  a, b                ·                               ·
- └── render     ·          ·                   (a, b)                          a!=NULL; b!=NULL; +a,+b
-      │         render 0   test.public.abcd.a  ·                               ·
-      │         render 1   test.public.abcd.b  ·                               ·
-      └── scan  ·          ·                   (a, b, c[omitted], d[omitted])  a!=NULL; b!=NULL; c!=NULL; key(a,b,c); +a,+b
-·               table      abcd@primary        ·                               ·
-·               spans      ALL                 ·                               ·
-
-query TTTTT
-EXPLAIN (VERBOSE) SELECT DISTINCT a, b, c FROM abcd
-----
-render     ·         ·                   (a, b, c)              a!=NULL; b!=NULL; c!=NULL; key(a,b,c)
- │         render 0  test.public.abcd.a  ·                      ·
- │         render 1  test.public.abcd.b  ·                      ·
- │         render 2  test.public.abcd.c  ·                      ·
- └── scan  ·         ·                   (a, b, c, d[omitted])  a!=NULL; b!=NULL; c!=NULL; key(a,b,c)
-·          table     abcd@primary        ·                      ·
-·          spans     ALL                 ·                      ·
-
-query TTTTT
-EXPLAIN (VERBOSE) SELECT DISTINCT a, b, c, d FROM abcd
-----
-scan  ·      ·             (a, b, c, d)  a!=NULL; b!=NULL; c!=NULL; key(a,b,c)
-·     table  abcd@primary  ·             ·
-·     spans  ALL           ·             ·
-
 statement ok
 CREATE TABLE kv (k INT PRIMARY KEY, v INT, UNIQUE INDEX idx(v))
 
 statement ok
 INSERT INTO kv VALUES (1, 1), (2, 2), (3, NULL), (4, NULL), (5, 5), (6, NULL)
-
-query TTTTT colnames
-EXPLAIN (VERBOSE) SELECT DISTINCT v FROM kv
-----
-Tree            Field     Description       Columns          Ordering
-distinct        ·         ·                 (v)              weak-key(v)
- └── render     ·         ·                 (v)              ·
-      │         render 0  test.public.kv.v  ·                ·
-      └── scan  ·         ·                 (k[omitted], v)  k!=NULL; key(k)
-·               table     kv@primary        ·                ·
-·               spans     ALL               ·                ·
 
 query I rowsort
 SELECT DISTINCT v FROM kv
@@ -296,19 +140,6 @@ NULL
 2
 5
 
-# Verify we don't incorrectly elide the distinct node when we only have a weak key (#19343).
-query TTTTT colnames
-EXPLAIN (VERBOSE) SELECT DISTINCT v FROM kv@idx
-----
-Tree            Field      Description       Columns          Ordering
-distinct        ·          ·                 (v)              weak-key(v); +v
- │              order key  v                 ·                ·
- └── render     ·          ·                 (v)              weak-key(v); +v
-      │         render 0   test.public.kv.v  ·                ·
-      └── scan  ·          ·                 (k[omitted], v)  weak-key(v); +v
-·               table      kv@idx            ·                ·
-·               spans      ALL               ·                ·
-
 query I rowsort
 SELECT DISTINCT v FROM kv@idx
 ----
@@ -317,34 +148,9 @@ NULL
 2
 5
 
-# Here we can infer that v is not-NULL so eliding the node is correct.
-query TTTTT colnames
-EXPLAIN (VERBOSE) SELECT DISTINCT v FROM kv@idx WHERE v > 0
-----
-Tree       Field     Description       Columns          Ordering
-render     ·         ·                 (v)              v!=NULL; key(v)
- │         render 0  test.public.kv.v  ·                ·
- └── scan  ·         ·                 (k[omitted], v)  v!=NULL; key(v)
-·          table     kv@idx            ·                ·
-·          spans     /1-               ·                ·
-
 query I rowsort
 SELECT DISTINCT v FROM kv@idx WHERE v > 0
 ----
 1
 2
 5
-
-statement ok
-CREATE TABLE kv2 (k INT PRIMARY KEY, v INT NOT NULL, UNIQUE INDEX idx(v))
-
-# In this case it is correct to elide the distinct node.
-query TTTTT colnames
-EXPLAIN (VERBOSE) SELECT DISTINCT v FROM kv2@idx
-----
-Tree       Field     Description        Columns          Ordering
-render     ·         ·                  (v)              v!=NULL; key(v)
- │         render 0  test.public.kv2.v  ·                ·
- └── scan  ·         ·                  (k[omitted], v)  v!=NULL; key(v)
-·          table     kv2@idx            ·                ·
-·          spans     ALL                ·                ·

--- a/pkg/sql/logictest/testdata/logic_test/distinct_on
+++ b/pkg/sql/logictest/testdata/logic_test/distinct_on
@@ -1,4 +1,4 @@
-# LogicTest: default parallel-stmts distsql distsql-metadata distsql-disk
+# LogicTest: default opt parallel-stmts distsql distsql-opt distsql-metadata distsql-disk
 
 statement ok
 CREATE TABLE xyz (
@@ -40,19 +40,6 @@ INSERT INTO abc VALUES
 
 # 3/3 columns
 
-query TTTTT
-EXPLAIN (VERBOSE) SELECT DISTINCT ON (x, y, z) x, y, z FROM xyz
-----
-distinct        ·            ·                  (x, y, z)                              weak-key(x,y,z)
- │              distinct on  x, y, z            ·                                      ·
- └── render     ·            ·                  (x, y, z)                              ·
-      │         render 0     test.public.xyz.x  ·                                      ·
-      │         render 1     test.public.xyz.y  ·                                      ·
-      │         render 2     test.public.xyz.z  ·                                      ·
-      └── scan  ·            ·                  (x, y, z, pk1[omitted], pk2[omitted])  pk1!=NULL; pk2!=NULL; key(pk1,pk2)
-·               table        xyz@primary        ·                                      ·
-·               spans        ALL                ·                                      ·
-
 query III rowsort
 SELECT DISTINCT ON (x, y, z) x, y, z FROM xyz
 ----
@@ -62,21 +49,6 @@ SELECT DISTINCT ON (x, y, z) x, y, z FROM xyz
 2 2 3
 4 5 6
 4 1 6
-
-query TTTTT
-EXPLAIN (VERBOSE) SELECT DISTINCT ON (z, x, y) x FROM xyz
-----
-render               ·            ·                  (x)                                    ·
- │                   render 0     x                  ·                                      ·
- └── distinct        ·            ·                  (x, z, y)                              weak-key(x,z,y)
-      │              distinct on  x, z, y            ·                                      ·
-      └── render     ·            ·                  (x, z, y)                              ·
-           │         render 0     test.public.xyz.x  ·                                      ·
-           │         render 1     test.public.xyz.z  ·                                      ·
-           │         render 2     test.public.xyz.y  ·                                      ·
-           └── scan  ·            ·                  (x, y, z, pk1[omitted], pk2[omitted])  pk1!=NULL; pk2!=NULL; key(pk1,pk2)
-·                    table        xyz@primary        ·                                      ·
-·                    spans        ALL                ·                                      ·
 
 query I rowsort
 SELECT DISTINCT ON (y, x, z) x FROM xyz
@@ -98,17 +70,6 @@ NULL
 6
 6
 
-query TTTTT
-EXPLAIN (VERBOSE) SELECT DISTINCT ON (b, c, a) a, c, b FROM abc
-----
-render     ·         ·                  (a, c, b)  a!=NULL; c!=NULL; b!=NULL; key(a,c,b)
- │         render 0  test.public.abc.a  ·          ·
- │         render 1  test.public.abc.c  ·          ·
- │         render 2  test.public.abc.b  ·          ·
- └── scan  ·         ·                  (a, b, c)  a!=NULL; b!=NULL; c!=NULL; key(a,b,c)
-·          table     abc@primary        ·          ·
-·          spans     ALL                ·          ·
-
 query TTT rowsort
 SELECT DISTINCT ON (b, c, a) a, c, b FROM abc
 ----
@@ -116,41 +77,12 @@ SELECT DISTINCT ON (b, c, a) a, c, b FROM abc
 1 2 1
 1 2 2
 
-# Distinct node should be elided since we have a strong key.
-query TTTTT
-EXPLAIN (VERBOSE) SELECT DISTINCT ON (b, c, a) a FROM abc
-----
-render     ·         ·            (a)        a!=NULL
- │         render 0  a            ·          ·
- └── scan  ·         ·            (a, b, c)  a!=NULL; b!=NULL; c!=NULL; key(a,b,c)
-·          table     abc@primary  ·          ·
-·          spans     ALL          ·          ·
-
-
 query T rowsort
 SELECT DISTINCT ON (b, c, a) a FROM abc
 ----
 1
 1
 1
-
-
-# Distinct node should be elided since we have a strong key.
-query TTTTT
-EXPLAIN (VERBOSE) SELECT DISTINCT ON (c, a, b) b FROM abc ORDER BY b
-----
-render               ·         ·                  (b)                          b!=NULL; +b
- │                   render 0  b                  ·                            ·
- └── sort            ·         ·                  (b, c[omitted], a[omitted])  b!=NULL; c!=NULL; a!=NULL; key(b,c,a); +b
-      │              order     +b                 ·                            ·
-      └── render     ·         ·                  (b, c[omitted], a[omitted])  b!=NULL; c!=NULL; a!=NULL; key(b,c,a)
-           │         render 0  test.public.abc.b  ·                            ·
-           │         render 1  NULL               ·                            ·
-           │         render 2  NULL               ·                            ·
-           └── scan  ·         ·                  (a[omitted], b, c[omitted])  a!=NULL; b!=NULL; c!=NULL; key(a,b,c)
-·                    table     abc@primary        ·                            ·
-·                    spans     ALL                ·                            ·
-
 
 query T rowsort
 SELECT DISTINCT ON (c, a, b) b FROM abc ORDER BY b
@@ -162,18 +94,6 @@ SELECT DISTINCT ON (c, a, b) b FROM abc ORDER BY b
 
 # 2/3 columns
 
-query TTTTT
-EXPLAIN (VERBOSE) SELECT DISTINCT ON (x, y) y, x FROM xyz
-----
-distinct        ·            ·                  (y, x)                                          weak-key(y,x)
- │              distinct on  y, x               ·                                               ·
- └── render     ·            ·                  (y, x)                                          ·
-      │         render 0     test.public.xyz.y  ·                                               ·
-      │         render 1     test.public.xyz.x  ·                                               ·
-      └── scan  ·            ·                  (x, y, z[omitted], pk1[omitted], pk2[omitted])  pk1!=NULL; pk2!=NULL; key(pk1,pk2)
-·               table        xyz@primary        ·                                               ·
-·               spans        ALL                ·                                               ·
-
 query II rowsort
 SELECT DISTINCT ON (x, y) y, x FROM xyz
 ----
@@ -182,20 +102,6 @@ SELECT DISTINCT ON (x, y) y, x FROM xyz
 2 2
 5 4
 1 4
-
-query TTTTT
-EXPLAIN (VERBOSE) SELECT DISTINCT ON (y, x) x FROM xyz
-----
-render               ·            ·                  (x)                                             ·
- │                   render 0     x                  ·                                               ·
- └── distinct        ·            ·                  (x, y)                                          weak-key(x,y)
-      │              distinct on  x, y               ·                                               ·
-      └── render     ·            ·                  (x, y)                                          ·
-           │         render 0     test.public.xyz.x  ·                                               ·
-           │         render 1     test.public.xyz.y  ·                                               ·
-           └── scan  ·            ·                  (x, y, z[omitted], pk1[omitted], pk2[omitted])  pk1!=NULL; pk2!=NULL; key(pk1,pk2)
-·                    table        xyz@primary        ·                                               ·
-·                    spans        ALL                ·                                               ·
 
 query I rowsort
 SELECT DISTINCT ON (y, x) x FROM xyz
@@ -215,63 +121,11 @@ SELECT DISTINCT ON (x, y) y FROM xyz
 5
 1
 
-query TTTTT
-EXPLAIN (VERBOSE) SELECT DISTINCT ON (y, x, x, y, x) x, y FROM xyz
-----
-distinct        ·            ·                  (x, y)                                          weak-key(x,y)
- │              distinct on  x, y               ·                                               ·
- └── render     ·            ·                  (x, y)                                          ·
-      │         render 0     test.public.xyz.x  ·                                               ·
-      │         render 1     test.public.xyz.y  ·                                               ·
-      └── scan  ·            ·                  (x, y, z[omitted], pk1[omitted], pk2[omitted])  pk1!=NULL; pk2!=NULL; key(pk1,pk2)
-·               table        xyz@primary        ·                                               ·
-·               spans        ALL                ·                                               ·
-
-query TTTTT
-EXPLAIN (VERBOSE) SELECT DISTINCT ON(pk1, x) pk1, x FROM xyz ORDER BY pk1
-----
-distinct        ·            ·                    (pk1, x)                                        pk1!=NULL; weak-key(pk1,x); +pk1
- │              distinct on  pk1, x               ·                                               ·
- │              order key    pk1                  ·                                               ·
- └── render     ·            ·                    (pk1, x)                                        pk1!=NULL; +pk1
-      │         render 0     test.public.xyz.pk1  ·                                               ·
-      │         render 1     test.public.xyz.x    ·                                               ·
-      └── scan  ·            ·                    (x, y[omitted], z[omitted], pk1, pk2[omitted])  pk1!=NULL; pk2!=NULL; key(pk1,pk2); +pk1
-·               table        xyz@primary          ·                                               ·
-·               spans        ALL                  ·                                               ·
-
-query TTTTT
-EXPLAIN (VERBOSE) SELECT DISTINCT ON (a, c) a, b FROM abc
-----
-render          ·            ·            (a, b)     a!=NULL; b!=NULL; +a
- │              render 0     a            ·          ·
- │              render 1     b            ·          ·
- └── distinct   ·            ·            (a, b, c)  a!=NULL; b!=NULL; c!=NULL; key(a,c); +a
-      │         distinct on  a, c         ·          ·
-      │         order key    a            ·          ·
-      └── scan  ·            ·            (a, b, c)  a!=NULL; b!=NULL; c!=NULL; key(a,b,c); +a
-·               table        abc@primary  ·          ·
-·               spans        ALL          ·          ·
-
 query TT rowsort
 SELECT DISTINCT ON (a, c) a, b FROM abc ORDER BY a, c, b
 ----
 1 1
 1 1
-
-query TTTTT
-EXPLAIN (VERBOSE) SELECT DISTINCT ON (c, a) b, c, a FROM abc
-----
-distinct        ·            ·                  (b, c, a)  b!=NULL; c!=NULL; a!=NULL; key(c,a); +a
- │              distinct on  c, a               ·          ·
- │              order key    a                  ·          ·
- └── render     ·            ·                  (b, c, a)  b!=NULL; c!=NULL; a!=NULL; key(b,c,a); +a
-      │         render 0     test.public.abc.b  ·          ·
-      │         render 1     test.public.abc.c  ·          ·
-      │         render 2     test.public.abc.a  ·          ·
-      └── scan  ·            ·                  (a, b, c)  a!=NULL; b!=NULL; c!=NULL; key(a,b,c); +a
-·               table        abc@primary        ·          ·
-·               spans        ALL                ·          ·
 
 # We wrap this with an ORDER BY otherwise this would be non-deterministic.
 query TTT rowsort
@@ -290,21 +144,6 @@ SELECT DISTINCT ON (y) y FROM xyz
 2
 5
 
-# Check that distinct propagates the smaller, tighter key (pk1) as opposed to
-# the original key (pk1, pk2).
-query TTTTT
-EXPLAIN (VERBOSE) SELECT DISTINCT ON (pk1) pk1, pk2 FROM xyz
-----
-distinct        ·            ·                    (pk1, pk2)                                      pk1!=NULL; pk2!=NULL; key(pk1); +pk1
- │              distinct on  pk1                  ·                                               ·
- │              order key    pk1                  ·                                               ·
- └── render     ·            ·                    (pk1, pk2)                                      pk1!=NULL; pk2!=NULL; key(pk1,pk2); +pk1
-      │         render 0     test.public.xyz.pk1  ·                                               ·
-      │         render 1     test.public.xyz.pk2  ·                                               ·
-      └── scan  ·            ·                    (x[omitted], y[omitted], z[omitted], pk1, pk2)  pk1!=NULL; pk2!=NULL; key(pk1,pk2); +pk1
-·               table        xyz@primary          ·                                               ·
-·               spans        ALL                  ·                                               ·
-
 query T rowsort
 SELECT DISTINCT ON (c) a FROM abc
 ----
@@ -317,32 +156,11 @@ SELECT DISTINCT ON (b) b FROM abc
 1
 2
 
-
 # We wrap this with an ORDER BY otherwise this would be non-deterministic.
 query TTT rowsort
 SELECT DISTINCT ON (a) a, b, c FROM abc ORDER BY a, b, c
 ----
 1 1 1
-
-# Ensure order simplification on DISTINCT ON columns does not simplifying out
-# an explicit order from ORDER BY.
-# Note that the -c ordering was reduced after the distinct: this is because
-# we have a strong key on 'a' so ordering after '+a' is unnecessary.
-query TTTTT
-EXPLAIN (VERBOSE) SELECT DISTINCT ON (a) a, c FROM abc ORDER BY a, c DESC, b
-----
-distinct             ·            ·                  (a, c)     a!=NULL; c!=NULL; key(a); +a
- │                   distinct on  a                  ·          ·
- │                   order key    a                  ·          ·
- └── sort            ·            ·                  (a, c)     a!=NULL; c!=NULL; +a,-c
-      │              order        +a,-c,+b           ·          ·
-      └── render     ·            ·                  (a, c, b)  a!=NULL; c!=NULL; b!=NULL; key(a,c,b); +a
-           │         render 0     test.public.abc.a  ·          ·
-           │         render 1     test.public.abc.c  ·          ·
-           │         render 2     test.public.abc.b  ·          ·
-           └── scan  ·            ·                  (a, b, c)  a!=NULL; b!=NULL; c!=NULL; key(a,b,c); +a
-·                    table        abc@primary        ·          ·
-·                    spans        ALL                ·          ·
 
 query TT
 SELECT DISTINCT ON (a) a, c FROM abc ORDER BY a, c DESC, b
@@ -362,42 +180,12 @@ SELECT DISTINCT ON (y) x, y, z FROM xyz ORDER BY x, y
 statement error SELECT DISTINCT ON expressions must be a prefix of or include all ORDER BY expressions
 SELECT DISTINCT ON (y, z) x, y, z FROM xyz ORDER BY x
 
-query TTTTT
-EXPLAIN (VERBOSE) SELECT DISTINCT ON (x) x FROM xyz ORDER BY x DESC
-----
-distinct             ·            ·                  (x)                                                      weak-key(x); -x
- │                   distinct on  x                  ·                                                        ·
- │                   order key    x                  ·                                                        ·
- └── sort            ·            ·                  (x)                                                      -x
-      │              order        -x                 ·                                                        ·
-      └── render     ·            ·                  (x)                                                      ·
-           │         render 0     test.public.xyz.x  ·                                                        ·
-           └── scan  ·            ·                  (x, y[omitted], z[omitted], pk1[omitted], pk2[omitted])  pk1!=NULL; pk2!=NULL; key(pk1,pk2)
-·                    table        xyz@primary        ·                                                        ·
-·                    spans        ALL                ·                                                        ·
-
 query I
 SELECT DISTINCT ON (x) x FROM xyz ORDER BY x DESC
 ----
 4
 2
 1
-
-query TTTTT
-EXPLAIN (VERBOSE) SELECT DISTINCT ON (x, z) y, z, x FROM xyz ORDER BY z
-----
-distinct             ·            ·                  (y, z, x)                              weak-key(z,x); +z
- │                   distinct on  z, x               ·                                      ·
- │                   order key    z                  ·                                      ·
- └── sort            ·            ·                  (y, z, x)                              +z
-      │              order        +z                 ·                                      ·
-      └── render     ·            ·                  (y, z, x)                              ·
-           │         render 0     test.public.xyz.y  ·                                      ·
-           │         render 1     test.public.xyz.z  ·                                      ·
-           │         render 2     test.public.xyz.x  ·                                      ·
-           └── scan  ·            ·                  (x, y, z, pk1[omitted], pk2[omitted])  pk1!=NULL; pk2!=NULL; key(pk1,pk2)
-·                    table        xyz@primary        ·                                      ·
-·                    spans        ALL                ·                                      ·
 
 # We add a filter to eliminate one of the rows that may be flakily returned
 # depending on parallel execution of DISTINCT ON.
@@ -409,22 +197,6 @@ SELECT DISTINCT ON (x, z) y, z, x FROM xyz WHERE (x,y,z) != (4, 1, 6) ORDER BY z
 1 2 1
 2 3 2
 5 6 4
-
-query TTTTT
-EXPLAIN (VERBOSE) SELECT DISTINCT ON (x) y, z, x FROM xyz ORDER BY x ASC, z DESC, y DESC
-----
-distinct             ·            ·                  (y, z, x)                              weak-key(x); +x,-z,-y
- │                   distinct on  x                  ·                                      ·
- │                   order key    x                  ·                                      ·
- └── sort            ·            ·                  (y, z, x)                              +x,-z,-y
-      │              order        +x,-z,-y           ·                                      ·
-      └── render     ·            ·                  (y, z, x)                              ·
-           │         render 0     test.public.xyz.y  ·                                      ·
-           │         render 1     test.public.xyz.z  ·                                      ·
-           │         render 2     test.public.xyz.x  ·                                      ·
-           └── scan  ·            ·                  (x, y, z, pk1[omitted], pk2[omitted])  pk1!=NULL; pk2!=NULL; key(pk1,pk2)
-·                    table        xyz@primary        ·                                      ·
-·                    spans        ALL                ·                                      ·
 
 query III
 SELECT DISTINCT ON (x) y, z, x FROM xyz ORDER BY x ASC, z DESC, y DESC
@@ -443,23 +215,6 @@ SELECT DISTINCT ON(MAX(x)) y FROM xyz
 statement error column "z" must appear in the GROUP BY clause or be used in an aggregate function
 SELECT DISTINCT ON(MAX(x), z) MIN(y) FROM xyz
 
-query TTTTT
-EXPLAIN (VERBOSE) SELECT DISTINCT ON (MAX(y)) MAX(x) FROM xyz
-----
-render                    ·            ·                  (max)                                           ·
- │                        render 0     max                ·                                               ·
- └── distinct             ·            ·                  (max, max)                                      weak-key(max)
-      │                   distinct on  max                ·                                               ·
-      └── group           ·            ·                  (max, max)                                      ·
-           │              aggregate 0  max(x)             ·                                               ·
-           │              aggregate 1  max(y)             ·                                               ·
-           └── render     ·            ·                  (x, y)                                          ·
-                │         render 0     test.public.xyz.x  ·                                               ·
-                │         render 1     test.public.xyz.y  ·                                               ·
-                └── scan  ·            ·                  (x, y, z[omitted], pk1[omitted], pk2[omitted])  pk1!=NULL; pk2!=NULL; key(pk1,pk2)
-·                         table        xyz@primary        ·                                               ·
-·                         spans        ALL                ·                                               ·
-
 query I
 SELECT DISTINCT ON (MAX(x)) MIN(y) FROM xyz
 ----
@@ -469,22 +224,6 @@ query I
 SELECT DISTINCT ON (MIN(x)) MAX(y) FROM xyz
 ----
 5
-
-query TTTTT
-EXPLAIN (VERBOSE) SELECT DISTINCT ON(MIN(a), MAX(b), MIN(c)) MAX(a) FROM abc
-----
-render               ·            ·              (max)                 ·
- │                   render 0     max            ·                     ·
- └── distinct        ·            ·              (max, min, max, min)  weak-key(min,max,min)
-      │              distinct on  min, max, min  ·                     ·
-      └── group      ·            ·              (max, min, max, min)  ·
-           │         aggregate 0  max(a)         ·                     ·
-           │         aggregate 1  min(a)         ·                     ·
-           │         aggregate 2  max(b)         ·                     ·
-           │         aggregate 3  min(c)         ·                     ·
-           └── scan  ·            ·              (a, b, c)             a!=NULL; b!=NULL; c!=NULL; key(a,b,c)
-·                    table        abc@primary    ·                     ·
-·                    spans        ALL            ·                     ·
 
 query T
 SELECT DISTINCT ON(MIN(a), MAX(b), MIN(c)) MAX(c) FROM abc
@@ -498,49 +237,12 @@ SELECT DISTINCT ON(MIN(a), MAX(b), MIN(c)) MAX(c) FROM abc
 statement error column "x" must appear in the GROUP BY clause or be used in an aggregate function
 SELECT DISTINCT ON (x) MIN(x) FROM xyz GROUP BY y
 
-# TODO(richardwu): we can elide the DISTINCT ON since its key is equivalent
-# to the group key.
-query TTTTT
-EXPLAIN (VERBOSE) SELECT DISTINCT ON(y) MIN(x) FROM xyz GROUP BY y
-----
-render                    ·            ·                  (min)                                           ·
- │                        render 0     min                ·                                               ·
- └── distinct             ·            ·                  (min, y)                                        weak-key(y)
-      │                   distinct on  y                  ·                                               ·
-      └── group           ·            ·                  (min, y)                                        weak-key(y)
-           │              aggregate 0  min(x)             ·                                               ·
-           │              aggregate 1  y                  ·                                               ·
-           │              group by     @1                 ·                                               ·
-           └── render     ·            ·                  (y, x)                                          ·
-                │         render 0     test.public.xyz.y  ·                                               ·
-                │         render 1     test.public.xyz.x  ·                                               ·
-                └── scan  ·            ·                  (x, y, z[omitted], pk1[omitted], pk2[omitted])  pk1!=NULL; pk2!=NULL; key(pk1,pk2)
-·                         table        xyz@primary        ·                                               ·
-·                         spans        ALL                ·                                               ·
-
 query I rowsort
 SELECT DISTINCT ON(y) MIN(x) FROM xyz GROUP BY y
 ----
 1
 1
 4
-
-query TTTTT
-EXPLAIN (VERBOSE) SELECT DISTINCT ON(MIN(x)) MIN(x) FROM xyz GROUP BY y HAVING MIN(x) = 1
-----
-distinct                  ·            ·                  (min)                                           min=CONST; key()
- │                        distinct on  min                ·                                               ·
- └── filter               ·            ·                  (min)                                           min=CONST
-      │                   filter       agg0 = 1           ·                                               ·
-      └── group           ·            ·                  (min)                                           ·
-           │              aggregate 0  min(x)             ·                                               ·
-           │              group by     @1                 ·                                               ·
-           └── render     ·            ·                  (y, x)                                          ·
-                │         render 0     test.public.xyz.y  ·                                               ·
-                │         render 1     test.public.xyz.x  ·                                               ·
-                └── scan  ·            ·                  (x, y, z[omitted], pk1[omitted], pk2[omitted])  pk1!=NULL; pk2!=NULL; key(pk1,pk2)
-·                         table        xyz@primary        ·                                               ·
-·                         spans        ALL                ·                                               ·
 
 query I
 SELECT DISTINCT ON(MIN(x)) MIN(x) FROM xyz GROUP BY y HAVING MIN(x) = 1
@@ -550,22 +252,6 @@ SELECT DISTINCT ON(MIN(x)) MIN(x) FROM xyz GROUP BY y HAVING MIN(x) = 1
 #########################
 # With window functions #
 #########################
-
-query TTTTT
-EXPLAIN (VERBOSE) SELECT DISTINCT ON(row_number() OVER()) y FROM xyz
-----
-render                    ·            ·                     (y)                                                      ·
- │                        render 0     y                     ·                                                        ·
- └── distinct             ·            ·                     (y, row_number)                                          weak-key(row_number)
-      │                   distinct on  row_number            ·                                                        ·
-      └── window          ·            ·                     (y, row_number)                                          ·
-           │              window 0     row_number() OVER ()  ·                                                        ·
-           │              render 1     row_number() OVER ()  ·                                                        ·
-           └── render     ·            ·                     (y)                                                      ·
-                │         render 0     test.public.xyz.y     ·                                                        ·
-                └── scan  ·            ·                     (x[omitted], y, z[omitted], pk1[omitted], pk2[omitted])  pk1!=NULL; pk2!=NULL; key(pk1,pk2)
-·                         table        xyz@primary           ·                                                        ·
-·                         spans        ALL                   ·                                                        ·
 
 query I rowsort
 SELECT DISTINCT ON(row_number() OVER()) y FROM xyz
@@ -596,33 +282,12 @@ SELECT DISTINCT ON(row_number() OVER()) y FROM xyz ORDER BY row_number() OVER() 
 statement error DISTINCT ON position 2 is not in select list
 SELECT DISTINCT ON (2) x FROM xyz
 
-query TTTTT
-EXPLAIN (VERBOSE) SELECT DISTINCT ON (1) x, y, z FROM xyz
-----
-distinct        ·            ·                  (x, y, z)                              weak-key(x)
- │              distinct on  x                  ·                                      ·
- └── render     ·            ·                  (x, y, z)                              ·
-      │         render 0     test.public.xyz.x  ·                                      ·
-      │         render 1     test.public.xyz.y  ·                                      ·
-      │         render 2     test.public.xyz.z  ·                                      ·
-      └── scan  ·            ·                  (x, y, z, pk1[omitted], pk2[omitted])  pk1!=NULL; pk2!=NULL; key(pk1,pk2)
-·               table        xyz@primary        ·                                      ·
-·               spans        ALL                ·                                      ·
-
 query I rowsort
 SELECT DISTINCT ON (1) x FROM xyz
 ----
 1
 2
 4
-
-# Distinct node elided because of strong key.
-query TTTTT
-EXPLAIN (VERBOSE) SELECT DISTINCT ON (1,2,3) a, b, c FROM abc
-----
-scan  ·      ·            (a, b, c)  a!=NULL; b!=NULL; c!=NULL; key(a,b,c)
-·     table  abc@primary  ·          ·
-·     spans  ALL          ·          ·
 
 query III rowsort
 SELECT DISTINCT ON (1,2,3) x, y, z FROM xyz
@@ -638,19 +303,7 @@ SELECT DISTINCT ON (1,2,3) x, y, z FROM xyz
 # With alias references #
 #########################
 
-# This should priortize alias (use 'x' as the key).
-query TTTTT
-EXPLAIN (VERBOSE) SELECT DISTINCT ON(y) x AS y, y AS x FROM xyz
-----
-distinct        ·            ·                  (y, x)                                          weak-key(y)
- │              distinct on  y                  ·                                               ·
- └── render     ·            ·                  (y, x)                                          ·
-      │         render 0     test.public.xyz.x  ·                                               ·
-      │         render 1     test.public.xyz.y  ·                                               ·
-      └── scan  ·            ·                  (x, y, z[omitted], pk1[omitted], pk2[omitted])  pk1!=NULL; pk2!=NULL; key(pk1,pk2)
-·               table        xyz@primary        ·                                               ·
-·               spans        ALL                ·                                               ·
-
+# This should prioritize alias (use 'x' as the key).
 # This would be non-deterministic if we don't select y (actually x) from the
 # subquery.
 query I rowsort
@@ -661,17 +314,6 @@ SELECT y FROM (SELECT DISTINCT ON(y) x AS y, y AS x FROM xyz)
 4
 
 # Ignores the alias.
-query TTTTT
-EXPLAIN (VERBOSE) SELECT DISTINCT ON(x) x AS y FROM xyz
-----
-distinct        ·            ·                  (y)                                                      weak-key(y)
- │              distinct on  y                  ·                                                        ·
- └── render     ·            ·                  (y)                                                      ·
-      │         render 0     test.public.xyz.x  ·                                                        ·
-      └── scan  ·            ·                  (x, y[omitted], z[omitted], pk1[omitted], pk2[omitted])  pk1!=NULL; pk2!=NULL; key(pk1,pk2)
-·               table        xyz@primary        ·                                                        ·
-·               spans        ALL                ·                                                        ·
-
 query I rowsort
 SELECT DISTINCT ON(x) x AS y FROM xyz
 ----
@@ -682,19 +324,6 @@ SELECT DISTINCT ON(x) x AS y FROM xyz
 ##################################
 # With nested parentheses/tuples #
 ##################################
-
-query TTTTT
-EXPLAIN (VERBOSE) SELECT DISTINCT ON(((x)), (x, y)) x, y FROM xyz
-----
-distinct        ·            ·                  (x, y)                                          weak-key(x,y)
- │              distinct on  x, y               ·                                               ·
- └── render     ·            ·                  (x, y)                                          ·
-      │         render 0     test.public.xyz.x  ·                                               ·
-      │         render 1     test.public.xyz.y  ·                                               ·
-      └── scan  ·            ·                  (x, y, z[omitted], pk1[omitted], pk2[omitted])  pk1!=NULL; pk2!=NULL; key(pk1,pk2)
-·               table        xyz@primary        ·                                               ·
-·               spans        ALL                ·                                               ·
-
 
 query II rowsort
 SELECT DISTINCT ON(((x)), (x, y)) x, y FROM xyz
@@ -708,20 +337,6 @@ SELECT DISTINCT ON(((x)), (x, y)) x, y FROM xyz
 ################################
 # Hybrid PK and non-PK queries #
 ################################
-
-# Distinct elided because of strong key presence.
-query TTTTT
-EXPLAIN (VERBOSE) SELECT DISTINCT ON(pk1, pk2, x, y) x, y, z FROM xyz ORDER BY x, y
-----
-render          ·         ·            (x, y, z)                              +x,+y
- │              render 0  x            ·                                      ·
- │              render 1  y            ·                                      ·
- │              render 2  z            ·                                      ·
- └── sort       ·         ·            (x, y, z, pk1[omitted], pk2[omitted])  pk1!=NULL; pk2!=NULL; key(pk1,pk2); +x,+y
-      │         order     +x,+y        ·                                      ·
-      └── scan  ·         ·            (x, y, z, pk1[omitted], pk2[omitted])  pk1!=NULL; pk2!=NULL; key(pk1,pk2)
-·               table     xyz@primary  ·                                      ·
-·               spans     ALL          ·                                      ·
 
 # We need to rowsort this since the ORDER BY isn't on the entire SELECT columns.
 query III rowsort
@@ -737,25 +352,6 @@ SELECT DISTINCT ON(pk1, pk2, x, y) x, y, z FROM xyz ORDER BY x, y
 
 # Ordering only propagates up until distinctNode.
 # pk1 ordering does not propagate at all since it's not explicitly needed.
-query TTTTT
-EXPLAIN (VERBOSE) SELECT DISTINCT ON (x, y, z) pk1 FROM xyz ORDER BY x
-----
-render                    ·            ·                    (pk1)                         pk1!=NULL
- │                        render 0     pk1                  ·                             ·
- └── distinct             ·            ·                    (pk1, x, y, z)                pk1!=NULL; weak-key(x,y,z); +x
-      │                   distinct on  x, y, z              ·                             ·
-      │                   order key    x                    ·                             ·
-      └── sort            ·            ·                    (pk1, x, y, z)                pk1!=NULL; +x
-           │              order        +x                   ·                             ·
-           └── render     ·            ·                    (pk1, x, y, z)                pk1!=NULL
-                │         render 0     test.public.xyz.pk1  ·                             ·
-                │         render 1     test.public.xyz.x    ·                             ·
-                │         render 2     test.public.xyz.y    ·                             ·
-                │         render 3     test.public.xyz.z    ·                             ·
-                └── scan  ·            ·                    (x, y, z, pk1, pk2[omitted])  pk1!=NULL; pk2!=NULL; key(pk1,pk2)
-·                         table        xyz@primary          ·                             ·
-·                         spans        ALL                  ·                             ·
-
 # We add a filter since there could be multiple valid pk1s otherwise for distinct
 # rows.
 query I rowsort

--- a/pkg/sql/logictest/testdata/logic_test/drop_database
+++ b/pkg/sql/logictest/testdata/logic_test/drop_database
@@ -1,4 +1,4 @@
-# LogicTest: default
+# LogicTest: default opt
 
 statement ok
 CREATE DATABASE "foo-bar"

--- a/pkg/sql/logictest/testdata/logic_test/drop_index
+++ b/pkg/sql/logictest/testdata/logic_test/drop_index
@@ -1,4 +1,4 @@
-# LogicTest: default
+# LogicTest: default opt
 
 statement ok
 CREATE TABLE users (

--- a/pkg/sql/logictest/testdata/logic_test/drop_sequence
+++ b/pkg/sql/logictest/testdata/logic_test/drop_sequence
@@ -1,4 +1,4 @@
-# LogicTest: default parallel-stmts distsql distsql-metadata
+# LogicTest: default opt parallel-stmts distsql distsql-opt distsql-metadata
 
 # see also file `sequences`
 

--- a/pkg/sql/logictest/testdata/logic_test/drop_table
+++ b/pkg/sql/logictest/testdata/logic_test/drop_table
@@ -1,4 +1,4 @@
-# LogicTest: default
+# LogicTest: default opt
 
 statement ok
 CREATE TABLE a (id INT PRIMARY KEY)

--- a/pkg/sql/logictest/testdata/logic_test/drop_user
+++ b/pkg/sql/logictest/testdata/logic_test/drop_user
@@ -1,4 +1,4 @@
-# LogicTest: default
+# LogicTest: default opt
 
 statement ok
 CREATE USER user1

--- a/pkg/sql/logictest/testdata/logic_test/drop_view
+++ b/pkg/sql/logictest/testdata/logic_test/drop_view
@@ -1,4 +1,4 @@
-# LogicTest: default
+# LogicTest: default opt
 
 statement ok
 CREATE TABLE a (k STRING PRIMARY KEY, v STRING)

--- a/pkg/sql/logictest/testdata/logic_test/errors
+++ b/pkg/sql/logictest/testdata/logic_test/errors
@@ -1,4 +1,4 @@
-# LogicTest: default distsql distsql-metadata
+# LogicTest: default opt distsql distsql-opt distsql-metadata
 
 statement error pgcode 42P01 relation "fake1" does not exist
 ALTER TABLE fake1 DROP COLUMN a

--- a/pkg/sql/logictest/testdata/logic_test/event_log
+++ b/pkg/sql/logictest/testdata/logic_test/event_log
@@ -1,4 +1,4 @@
-# LogicTest: default distsql distsql-metadata
+# LogicTest: default opt distsql distsql-opt distsql-metadata
 
 ##################
 # TABLE DDL

--- a/pkg/sql/logictest/testdata/logic_test/family
+++ b/pkg/sql/logictest/testdata/logic_test/family
@@ -1,4 +1,4 @@
-# LogicTest: default parallel-stmts distsql distsql-metadata
+# LogicTest: default opt parallel-stmts distsql distsql-opt distsql-metadata
 
 # a is the primary key so b gets optimized into a one column value. The c, d
 # family has two columns, so it's encoded as a tuple

--- a/pkg/sql/logictest/testdata/logic_test/fk
+++ b/pkg/sql/logictest/testdata/logic_test/fk
@@ -1,4 +1,4 @@
-# LogicTest: default parallel-stmts distsql distsql-metadata
+# LogicTest: default opt parallel-stmts distsql distsql-opt distsql-metadata
 
 statement ok
 CREATE TABLE customers (id INT PRIMARY KEY, email STRING UNIQUE)

--- a/pkg/sql/logictest/testdata/logic_test/float
+++ b/pkg/sql/logictest/testdata/logic_test/float
@@ -1,4 +1,4 @@
-# LogicTest: default parallel-stmts distsql distsql-metadata
+# LogicTest: default opt parallel-stmts distsql distsql-opt distsql-metadata
 
 # -0 and 0 should not be possible in a unique index.
 
@@ -12,35 +12,6 @@ INSERT INTO p VALUES (NULL), ('NaN'::float), ('Inf'::float), ('-Inf'::float), ('
 
 statement error duplicate key value
 INSERT INTO p VALUES ('-0'::float)
-
-# Verify that lookups for NaN use indices when possible:
-# - `WHERE f IS NaN` should perform a point lookup.
-# - `WHERE f = 'NaN'` should also perform a point lookup.
-# - `WHERE isnan(f)` is a function so it can't perform a point lookup.
-
-query TTT
-EXPLAIN SELECT * FROM p WHERE f IS NaN
-----
-render     ·      ·
- └── scan  ·      ·
-·          table  p@p_f_key
-·          spans  /NaN-/NaN/PrefixEnd
-
-query TTT
-EXPLAIN SELECT * FROM p WHERE f = 'NaN'
-----
-render     ·      ·
- └── scan  ·      ·
-·          table  p@p_f_key
-·          spans  /NaN-/NaN/PrefixEnd
-
-query TTT
-EXPLAIN SELECT * FROM p WHERE isnan(f)
-----
-render     ·      ·
- └── scan  ·      ·
-·          table  p@p_f_key
-·          spans  ALL
 
 query R
 SELECT * FROM p WHERE f = 'NaN'

--- a/pkg/sql/logictest/testdata/logic_test/function_lookup
+++ b/pkg/sql/logictest/testdata/logic_test/function_lookup
@@ -1,4 +1,4 @@
-# LogicTest: default distsql distsql-metadata
+# LogicTest: default opt distsql distsql-opt distsql-metadata
 
 statement ok
 CREATE TABLE foo(x INT DEFAULT LENGTH(PG_TYPEOF(1234))-1)

--- a/pkg/sql/logictest/testdata/logic_test/grant_database
+++ b/pkg/sql/logictest/testdata/logic_test/grant_database
@@ -1,4 +1,4 @@
-# LogicTest: default
+# LogicTest: default opt
 
 statement ok
 CREATE DATABASE a

--- a/pkg/sql/logictest/testdata/logic_test/grant_table
+++ b/pkg/sql/logictest/testdata/logic_test/grant_table
@@ -1,4 +1,4 @@
-# LogicTest: default
+# LogicTest: default opt
 
 statement ok
 CREATE DATABASE a

--- a/pkg/sql/logictest/testdata/logic_test/inet
+++ b/pkg/sql/logictest/testdata/logic_test/inet
@@ -1,4 +1,4 @@
-# LogicTest: default opt parallel-stmts distsql distsql-metadata distsql-opt
+# LogicTest: default opt parallel-stmts distsql distsql-opt distsql-metadata
 
 # Basic IPv4 tests
 

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -1,4 +1,4 @@
-# LogicTest: default
+# LogicTest: default opt
 
 # Verify information_schema database handles mutation statements correctly.
 

--- a/pkg/sql/logictest/testdata/logic_test/insert
+++ b/pkg/sql/logictest/testdata/logic_test/insert
@@ -1,4 +1,4 @@
-# LogicTest: default parallel-stmts
+# LogicTest: default opt parallel-stmts
 
 statement error pgcode 42P01 relation "kv" does not exist
 INSERT INTO kv VALUES ('a', 'b')

--- a/pkg/sql/logictest/testdata/logic_test/interleaved
+++ b/pkg/sql/logictest/testdata/logic_test/interleaved
@@ -1,4 +1,4 @@
-# LogicTest: default parallel-stmts distsql distsql-metadata
+# LogicTest: default opt parallel-stmts distsql distsql-opt distsql-metadata
 
 # Grandparent table
 statement ok
@@ -309,13 +309,6 @@ query IIR
 SELECT * FROM orders WHERE customer = 1 AND id = 1000
 ----
 1 1000 100.00000
-
-query TTT
-EXPLAIN SELECT * FROM orders WHERE customer = 1 AND id = 1000
-----
-scan  ·      ·
-·     table  orders@primary
-·     spans  /1/#/70/1/1000-/1/#/70/1/1000/#
 
 # Check that interleaving can occur across databases
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/inverted_index
+++ b/pkg/sql/logictest/testdata/logic_test/inverted_index
@@ -1,4 +1,4 @@
-# LogicTest: default distsql distsql-metadata parallel-stmts
+# LogicTest: default opt distsql distsql-opt distsql-metadata parallel-stmts
 
 statement ok
 CREATE TABLE t (
@@ -153,16 +153,6 @@ INSERT INTO d VALUES (30,  '{"a": []}')
 statement ok
 INSERT INTO d VALUES (31,  '{"a": {"b": "c", "d": "e"}, "f": "g"}')
 
-query TTTTT
-EXPLAIN (VERBOSE) SELECT * from d where b @>'{"a": "b"}'
-----
-index-join  ·      ·                            (a, b)           b=CONST; a!=NULL; key(a)
- ├── scan   ·      ·                            (a, b[omitted])  b=CONST; a!=NULL; key(a)
- │          table  d@foo_inv                    ·                ·
- │          spans  /"a"/"b"-/"a"/"b"/PrefixEnd  ·                ·
- └── scan   ·      ·                            (a, b)           ·
-·           table  d@primary                    ·                ·
-
 query IT
 SELECT * from d where b @> NULL ORDER BY a;
 ----
@@ -177,48 +167,17 @@ SELECT * from d where b @>'{"a": "b"}' ORDER BY a;
 1  {"a": "b"}
 7  {"a": "b", "c": "d"}
 
-
-query TTTTT
-EXPLAIN (VERBOSE) SELECT * from d where b @>'{"a": {"b": [1]}}'
-----
-index-join  ·      ·                                        (a, b)           b=CONST; a!=NULL; key(a)
- ├── scan   ·      ·                                        (a, b[omitted])  b=CONST; a!=NULL; key(a)
- │          table  d@foo_inv                                ·                ·
- │          spans  /"a"/"b"/Arr/1-/"a"/"b"/Arr/1/PrefixEnd  ·                ·
- └── scan   ·      ·                                        (a, b)           ·
-·           table  d@primary                                ·                ·
-
 query IT
 SELECT * from d where b @> '{"a": {"b": [1]}}' ORDER BY a;
 ----
 4  {"a": {"b": [1]}}
 5  {"a": {"b": [1, [2]]}}
 
-query TTTTT
-EXPLAIN (VERBOSE) SELECT * from d where b @> '{"a": {"b": [[2]]}}';
-----
-index-join  ·      ·                                                (a, b)           b=CONST; a!=NULL; key(a)
- ├── scan   ·      ·                                                (a, b[omitted])  b=CONST; a!=NULL; key(a)
- │          table  d@foo_inv                                        ·                ·
- │          spans  /"a"/"b"/Arr/Arr/2-/"a"/"b"/Arr/Arr/2/PrefixEnd  ·                ·
- └── scan   ·      ·                                                (a, b)           ·
-·           table  d@primary                                        ·                ·
-
 query IT
 SELECT * from d where b @> '{"a": {"b": [[2]]}}' ORDER BY a;
 ----
 5  {"a": {"b": [1, [2]]}}
 6  {"a": {"b": [[2]]}}
-
-query TTTTT
-EXPLAIN (VERBOSE) SELECT * from d where b @> '{"a": {"b":true}}';
-----
-index-join  ·      ·                             (a, b)           b=CONST; a!=NULL; key(a)
- ├── scan   ·      ·                             (a, b[omitted])  b=CONST; a!=NULL; key(a)
- │          table  d@foo_inv                     ·                ·
- │          spans  /"a"/"b"/True-/"a"/"b"/False  ·                ·
- └── scan   ·      ·                             (a, b)           ·
-·           table  d@primary                     ·                ·
 
 query IT
 SELECT * from d where b @> '{"a": {"b": true}}' ORDER BY a;
@@ -231,30 +190,10 @@ SELECT * from d where b @> '{"a": {"b": [[2]]}}' ORDER BY a;
 5  {"a": {"b": [1, [2]]}}
 6  {"a": {"b": [[2]]}}
 
-query TTTTT
-EXPLAIN (VERBOSE) SELECT * from d where b @>'[1]'
-----
-index-join  ·      ·                        (a, b)           b=CONST; a!=NULL; key(a)
- ├── scan   ·      ·                        (a, b[omitted])  b=CONST; a!=NULL; key(a)
- │          table  d@foo_inv                ·                ·
- │          spans  /Arr/1-/Arr/1/PrefixEnd  ·                ·
- └── scan   ·      ·                        (a, b)           ·
-·           table  d@primary                ·                ·
-
 query IT
 SELECT * from d where b @>'[1]' ORDER BY a;
 ----
 2  [1, 2, 3, 4, "foo"]
-
-query TTTTT
-EXPLAIN (VERBOSE) SELECT * from d where b @>'[{"a": {"b": [1]}}]'
-----
-index-join  ·      ·                                                (a, b)           b=CONST; a!=NULL; key(a)
- ├── scan   ·      ·                                                (a, b[omitted])  b=CONST; a!=NULL; key(a)
- │          table  d@foo_inv                                        ·                ·
- │          spans  /Arr/"a"/"b"/Arr/1-/Arr/"a"/"b"/Arr/1/PrefixEnd  ·                ·
- └── scan   ·      ·                                                (a, b)           ·
-·           table  d@primary                                        ·                ·
 
 query IT
 SELECT * from d where b @>'[{"a": {"b": [1]}}]' ORDER BY a;
@@ -316,24 +255,6 @@ SELECT * from d where b @> '1.23' ORDER BY a;
 ----
 15  1.23
 
-query TTTTT
-EXPLAIN (VERBOSE) SELECT * from d where b @> '[]';
-----
-scan  ·       ·          (a, b)  a!=NULL; b!=NULL; key(a)
-·     table   d@primary  ·       ·
-·     spans   ALL        ·       ·
-·     filter  b @> '[]'  ·       ·
-
-
-query TTTTT
-EXPLAIN (VERBOSE) SELECT * from d where b @> '{}';
-----
-scan  ·       ·          (a, b)  a!=NULL; b!=NULL; key(a)
-·     table   d@primary  ·       ·
-·     spans   ALL        ·       ·
-·     filter  b @> '{}'  ·       ·
-
-
 query IT
 SELECT * from d where b @> '{}' ORDER BY a;
 ----
@@ -390,26 +311,6 @@ query IT
 SELECT * from d where b->'a' = '"b"'
 ----
 7  {"a": "b", "c": "d"}
-
-query TTTTT
-EXPLAIN (VERBOSE) SELECT * from d where b->'a' = '"b"'
-----
-index-join  ·      ·                            (a, b)           b=CONST; a!=NULL; key(a)
- ├── scan   ·      ·                            (a, b[omitted])  b=CONST; a!=NULL; key(a)
- │          table  d@foo_inv                    ·                ·
- │          spans  /"a"/"b"-/"a"/"b"/PrefixEnd  ·                ·
- └── scan   ·      ·                            (a, b)           ·
-·           table  d@primary                    ·                ·
-
-query TTTTT
-EXPLAIN (VERBOSE) SELECT * from d where '"b"' = b->'a'
-----
-index-join  ·      ·                            (a, b)           b=CONST; a!=NULL; key(a)
- ├── scan   ·      ·                            (a, b[omitted])  b=CONST; a!=NULL; key(a)
- │          table  d@foo_inv                    ·                ·
- │          spans  /"a"/"b"-/"a"/"b"/PrefixEnd  ·                ·
- └── scan   ·      ·                            (a, b)           ·
-·           table  d@primary                    ·                ·
 
 statement ok
 INSERT INTO d VALUES (23,  '{"a": 123.123}')
@@ -497,14 +398,6 @@ query IT
 SELECT * from d where b = NULL;
 ----
 
-query TTTTT
-EXPLAIN (VERBOSE) SELECT * from d where b IS NULL
-----
-scan  ·       ·          (a, b)  a!=NULL; key(a)
-·     table   d@primary  ·       ·
-·     spans   ALL        ·       ·
-·     filter  b IS NULL  ·       ·
-
 query IT
 SELECT * from d where b @> NULL;
 ----
@@ -531,20 +424,6 @@ SELECT * from d where b @> '{"a": []}' ORDER BY a;
 25  {"a": [{}]}
 30  {"a": []}
 
-query TTT
-EXPLAIN SELECT * from d where b @> '{"a": []}' ORDER BY a;
-----
-scan  ·      ·
-·     table  d@primary
-·     spans  ALL
-
-query TTT
-EXPLAIN SELECT * from d where b @> '{"a": {}}' ORDER BY a;
-----
-scan  ·      ·
-·     table  d@primary
-·     spans  ALL
-
 ## Multi-path contains queries
 
 query IT
@@ -556,28 +435,6 @@ query IT
 SELECT * from d where b @> '{"a": {"b": "c", "d": "e"}, "f": "g"}'
 ----
 31  {"a": {"b": "c", "d": "e"}, "f": "g"}
-
-query TTTTT
-EXPLAIN (VERBOSE) SELECT * from d where b @> '{"a": {"b": "c"}, "f": "g"}'
-----
-index-join  ·       ·                                    (a, b)           b=CONST; a!=NULL; key(a)
- ├── scan   ·       ·                                    (a, b[omitted])  b=CONST; a!=NULL; key(a)
- │          table   d@foo_inv                            ·                ·
- │          spans   /"a"/"b"/"c"-/"a"/"b"/"c"/PrefixEnd  ·                ·
- └── scan   ·       ·                                    (a, b)           ·
-·           table   d@primary                            ·                ·
-·           filter  b @> '{"a": {"b": "c"}, "f": "g"}'   ·                ·
-
-query TTTTT
-EXPLAIN (VERBOSE) SELECT * from d where b @> '{"a": {"b": "c", "d": "e"}, "f": "g"}'
-----
-index-join  ·       ·                                             (a, b)           b=CONST; a!=NULL; key(a)
- ├── scan   ·       ·                                             (a, b[omitted])  b=CONST; a!=NULL; key(a)
- │          table   d@foo_inv                                     ·                ·
- │          spans   /"a"/"b"/"c"-/"a"/"b"/"c"/PrefixEnd           ·                ·
- └── scan   ·       ·                                             (a, b)           ·
-·           table   d@primary                                     ·                ·
-·           filter  b @> '{"a": {"b": "c", "d": "e"}, "f": "g"}'  ·                ·
 
 query IT
 SELECT * from d where b @> '{"c": "d", "a": "b"}'
@@ -610,36 +467,6 @@ query IT
 SELECT * from d where b @> '[{"a": {"b": [[2]]}}, "d"]'
 ----
 16  [{"a": {"b": [1, [2]]}}, "d"]
-
-query TTTTT
-EXPLAIN (VERBOSE) SELECT * from d where b @> '[{"a": {"b": [[2]]}}, "d"]'
-----
-index-join  ·       ·                                                        (a, b)           b=CONST; a!=NULL; key(a)
- ├── scan   ·       ·                                                        (a, b[omitted])  b=CONST; a!=NULL; key(a)
- │          table   d@foo_inv                                                ·                ·
- │          spans   /Arr/"a"/"b"/Arr/Arr/2-/Arr/"a"/"b"/Arr/Arr/2/PrefixEnd  ·                ·
- └── scan   ·       ·                                                        (a, b)           ·
-·           table   d@primary                                                ·                ·
-·           filter  b @> '[{"a": {"b": [[2]]}}, "d"]'                        ·                ·
-
-query TTTTT
-EXPLAIN (VERBOSE) SELECT * from d where b @> '{"a": {}, "b": 2}'
-----
-index-join  ·       ·                         (a, b)           b=CONST; a!=NULL; key(a)
- ├── scan   ·       ·                         (a, b[omitted])  b=CONST; a!=NULL; key(a)
- │          table   d@foo_inv                 ·                ·
- │          spans   /"b"/2-/"b"/2/PrefixEnd   ·                ·
- └── scan   ·       ·                         (a, b)           ·
-·           table   d@primary                 ·                ·
-·           filter  b @> '{"a": {}, "b": 2}'  ·                ·
-
-query TTTTT
-EXPLAIN (VERBOSE) SELECT * from d where b @> '{"a": {}, "b": {}}'
-----
-scan  ·       ·                          (a, b)  a!=NULL; b!=NULL; key(a)
-·     table   d@primary                  ·       ·
-·     spans   ALL                        ·       ·
-·     filter  b @> '{"a": {}, "b": {}}'  ·       ·
 
 
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/optimizer
+++ b/pkg/sql/logictest/testdata/logic_test/optimizer
@@ -1,4 +1,4 @@
-# LogicTest: default distsql
+# LogicTest: default opt distsql distsql-opt
 
 statement ok
 CREATE TABLE t (k INT PRIMARY KEY, v INT)
@@ -79,6 +79,18 @@ SELECT COUNT(*) FILTER (WHERE v>10) FROM t
 ----
 3
 
+query II rowsort
+SELECT * FROM tview
+----
+1  10
+2  20
+3  30
+4  40
+
+query I rowsort
+SELECT id FROM crdb_internal.jobs
+----
+
 statement ok
 SET EXPERIMENTAL_OPT = ALWAYS
 
@@ -91,6 +103,9 @@ SELECT COUNT(*) FILTER (WHERE v>10) FROM t
 
 query error pq: views and sequences are not supported
 SELECT * FROM tview
+
+query error pq: virtual tables are not supported
+SELECT id FROM crdb_internal.jobs
 
 statement ok
 SET EXPERIMENTAL_OPT = LOCAL

--- a/pkg/sql/logictest/testdata/logic_test/optimizer
+++ b/pkg/sql/logictest/testdata/logic_test/optimizer
@@ -4,6 +4,9 @@ statement ok
 CREATE TABLE t (k INT PRIMARY KEY, v INT)
 
 statement ok
+CREATE VIEW tview AS SELECT k, v FROM t
+
+statement ok
 INSERT INTO t VALUES (1, 10), (2, 20), (3, 30)
 
 statement ok
@@ -85,6 +88,9 @@ INSERT INTO test (k, v) VALUES (5, 50)
 # Don't fall back to heuristic planner in ALWAYS mode.
 query error pq: aggregates with FILTER are not supported yet
 SELECT COUNT(*) FILTER (WHERE v>10) FROM t
+
+query error pq: views and sequences are not supported
+SELECT * FROM tview
 
 statement ok
 SET EXPERIMENTAL_OPT = LOCAL

--- a/pkg/sql/logictest/testdata/logic_test/srfs
+++ b/pkg/sql/logictest/testdata/logic_test/srfs
@@ -33,11 +33,6 @@ SELECT * FROM GENERATE_SERIES('2017-11-11 00:00:00'::TIMESTAMP, '2017-11-11 03:0
 ----
 generate_series
 
-query TTT
-EXPLAIN SELECT * FROM GENERATE_SERIES(1, 3)
-----
-generator  ·  ·
-
 query II colnames
 SELECT * FROM GENERATE_SERIES(1, 2), GENERATE_SERIES(1, 2)
 ----
@@ -46,14 +41,6 @@ generate_series  generate_series
 1                2
 2                1
 2                2
-
-query TTT
-EXPLAIN SELECT * FROM GENERATE_SERIES(1, 2), GENERATE_SERIES(1, 2)
-----
-join            ·     ·
- │              type  cross
- ├── generator  ·     ·
- └── generator  ·     ·
 
 query I colnames
 SELECT * FROM GENERATE_SERIES(3, 1, -1)
@@ -107,11 +94,6 @@ generate_series
 1
 2
 
-query TTT
-EXPLAIN SELECT GENERATE_SERIES(1, 3)
-----
-generator  ·  ·
-
 subtest multiple_SRFs
 # See #20511
 
@@ -124,17 +106,6 @@ subtest multiple_SRFs
 
 query error pq: unimplemented: cannot use multiple set-returning functions in a single SELECT clause: "generate_series\(3, 4\)"
 SELECT GENERATE_SERIES(1, 2), GENERATE_SERIES(3, 4)
-
-# query TTT
-# EXPLAIN SELECT GENERATE_SERIES(1, 2), GENERATE_SERIES(1, 2)
-# ----
-# join            ·     ·
-# │              type  cross
-# ├── generator  ·     ·
-# └── generator  ·     ·
-
-query error pq: unimplemented: cannot use multiple set-returning functions in a single SELECT clause: "generate_series\(1, 2\)"
-EXPLAIN SELECT GENERATE_SERIES(1, 2), GENERATE_SERIES(1, 2)
 
 statement ok
 CREATE TABLE t (a string)
@@ -160,34 +131,6 @@ INSERT INTO u VALUES ('bird')
 
 query error pq: unimplemented: cannot use multiple set-returning functions in a single SELECT clause: "generate_series\(3, 4\)"
 SELECT t.*, u.*, generate_series(1,2), generate_series(3, 4) FROM t, u
-
-# query TTT
-# EXPLAIN(EXPRS) SELECT t.*, u.*, generate_series(1,2), generate_series(3, 4) FROM t, u
-# ----
-# render                    ·         ·
-# │                        render 0  a
-# │                        render 1  b
-# │                        render 2  generate_series
-# │                        render 3  generate_series
-# └── join                 ·         ·
-#      │                   type      cross
-#      ├── join            ·         ·
-#      │    │              type      cross
-#      │    ├── join       ·         ·
-#      │    │    │         type      cross
-#      │    │    ├── scan  ·         ·
-#      │    │    │         table     t@primary
-#      │    │    │         spans     ALL
-#      │    │    └── scan  ·         ·
-#      │    │              table     u@primary
-#      │    │              spans     ALL
-#      │    └── generator  ·         ·
-#      │                   expr      generate_series(1, 2)
-#      └── generator       ·         ·
-#·                         expr      generate_series(3, 4)
-
-query error pq: unimplemented: cannot use multiple set-returning functions in a single SELECT clause: "generate_series\(3, 4\)"
-EXPLAIN (VERBOSE) SELECT t.*, u.*, generate_series(1,2), generate_series(3, 4) FROM t, u
 
 query TTII colnames
 SELECT t.*, u.*, a.*, b.* FROM t, u, generate_series(1, 2) AS a, generate_series(3, 4) AS b

--- a/pkg/sql/logictest/testdata/logic_test/where
+++ b/pkg/sql/logictest/testdata/logic_test/where
@@ -1,4 +1,4 @@
-# LogicTest: default parallel-stmts distsql distsql-metadata
+# LogicTest: default opt parallel-stmts distsql distsql-opt distsql-metadata
 
 statement ok
 CREATE TABLE kv (
@@ -17,6 +17,18 @@ CREATE TABLE kvString (
 
 statement ok
 INSERT INTO kvString VALUES ('like1', 'hell%'), ('like2', 'worl%')
+
+query II rowsort
+SELECT * FROM kv WHERE True
+----
+1 2
+3 4
+5 6
+7 8
+
+query II
+SELECT * FROM kv WHERE False
+----
 
 query II rowsort
 SELECT * FROM kv WHERE k IN (1, 3)

--- a/pkg/sql/logictest/testdata/planner_test/distinct
+++ b/pkg/sql/logictest/testdata/planner_test/distinct
@@ -1,0 +1,207 @@
+# LogicTest: default
+
+statement ok
+CREATE TABLE xyz (
+  x INT PRIMARY KEY,
+  y INT,
+  z INT,
+  INDEX foo (z, y)
+)
+
+# TODO(vivek): Use the secondary index. Use distinct in index selection.
+query TTT
+EXPLAIN SELECT DISTINCT y, z FROM xyz
+----
+distinct        ·      ·
+ └── render     ·      ·
+      └── scan  ·      ·
+·               table  xyz@primary
+·               spans  ALL
+
+query TTT
+EXPLAIN SELECT DISTINCT y, z FROM xyz ORDER BY z
+----
+distinct        ·          ·
+ │              order key  y, z
+ └── render     ·          ·
+      └── scan  ·          ·
+·               table      xyz@foo
+·               spans      ALL
+
+query TTT
+EXPLAIN SELECT DISTINCT y, z FROM xyz ORDER BY y
+----
+distinct             ·          ·
+ │                   order key  y
+ └── sort            ·          ·
+      │              order      +y
+      └── render     ·          ·
+           └── scan  ·          ·
+·                    table      xyz@foo
+·                    spans      ALL
+
+query TTT
+EXPLAIN SELECT DISTINCT y, z FROM xyz ORDER BY y, z
+----
+distinct             ·          ·
+ │                   order key  y, z
+ └── sort            ·          ·
+      │              order      +y,+z
+      └── render     ·          ·
+           └── scan  ·          ·
+·                    table      xyz@foo
+·                    spans      ALL
+
+query TTT
+EXPLAIN SELECT DISTINCT y + z FROM xyz ORDER BY y + z
+----
+distinct             ·          ·
+ │                   order key  y + z
+ └── sort            ·          ·
+      │              order      +"y + z"
+      └── render     ·          ·
+           └── scan  ·          ·
+·                    table      xyz@primary
+·                    spans      ALL
+
+query TTT
+EXPLAIN SELECT DISTINCT y AS w FROM xyz ORDER BY z
+----
+distinct             ·      ·
+ └── nosort          ·      ·
+      │              order  +z
+      └── render     ·      ·
+           └── scan  ·      ·
+·                    table  xyz@foo
+·                    spans  ALL
+
+query TTT
+EXPLAIN SELECT DISTINCT y AS w FROM xyz ORDER BY y
+----
+distinct             ·          ·
+ │                   order key  w
+ └── sort            ·          ·
+      │              order      +w
+      └── render     ·          ·
+           └── scan  ·          ·
+·                    table      xyz@foo
+·                    spans      ALL
+
+query TTTTT
+EXPLAIN (VERBOSE) SELECT DISTINCT x FROM xyz
+----
+render     ·         ·                  (x)                          x!=NULL; key(x)
+ │         render 0  test.public.xyz.x  ·                            ·
+ └── scan  ·         ·                  (x, y[omitted], z[omitted])  x!=NULL; key(x)
+·          table     xyz@primary        ·                            ·
+·          spans     ALL                ·                            ·
+
+query TTTTT
+EXPLAIN (VERBOSE) SELECT DISTINCT x, y, z FROM xyz
+----
+scan  ·      ·            (x, y, z)  x!=NULL; key(x)
+·     table  xyz@primary  ·          ·
+·     spans  ALL          ·          ·
+
+statement ok
+CREATE TABLE abcd (
+  a INT,
+  b INT,
+  c INT,
+  d INT NOT NULL,
+  PRIMARY KEY (a, b, c),
+  UNIQUE INDEX (d, b)
+)
+
+query TTTTT
+EXPLAIN (VERBOSE) SELECT DISTINCT 1, d, b FROM abcd ORDER BY d, b
+----
+render     ·         ·                   ("1", d, b)                     "1"=CONST; d!=NULL; b!=NULL; key(d,b); +d,+b
+ │         render 0  1                   ·                               ·
+ │         render 1  test.public.abcd.d  ·                               ·
+ │         render 2  test.public.abcd.b  ·                               ·
+ └── scan  ·         ·                   (a[omitted], b, c[omitted], d)  b!=NULL; d!=NULL; key(b,d); +d,+b
+·          table     abcd@abcd_d_b_key   ·                               ·
+·          spans     ALL                 ·                               ·
+
+query TTTTT
+EXPLAIN (VERBOSE) SELECT DISTINCT a, b FROM abcd
+----
+distinct        ·          ·                   (a, b)                          a!=NULL; b!=NULL; key(a,b); +a,+b
+ │              order key  a, b                ·                               ·
+ └── render     ·          ·                   (a, b)                          a!=NULL; b!=NULL; +a,+b
+      │         render 0   test.public.abcd.a  ·                               ·
+      │         render 1   test.public.abcd.b  ·                               ·
+      └── scan  ·          ·                   (a, b, c[omitted], d[omitted])  a!=NULL; b!=NULL; c!=NULL; key(a,b,c); +a,+b
+·               table      abcd@primary        ·                               ·
+·               spans      ALL                 ·                               ·
+
+query TTTTT
+EXPLAIN (VERBOSE) SELECT DISTINCT a, b, c FROM abcd
+----
+render     ·         ·                   (a, b, c)              a!=NULL; b!=NULL; c!=NULL; key(a,b,c)
+ │         render 0  test.public.abcd.a  ·                      ·
+ │         render 1  test.public.abcd.b  ·                      ·
+ │         render 2  test.public.abcd.c  ·                      ·
+ └── scan  ·         ·                   (a, b, c, d[omitted])  a!=NULL; b!=NULL; c!=NULL; key(a,b,c)
+·          table     abcd@primary        ·                      ·
+·          spans     ALL                 ·                      ·
+
+query TTTTT
+EXPLAIN (VERBOSE) SELECT DISTINCT a, b, c, d FROM abcd
+----
+scan  ·      ·             (a, b, c, d)  a!=NULL; b!=NULL; c!=NULL; key(a,b,c)
+·     table  abcd@primary  ·             ·
+·     spans  ALL           ·             ·
+
+statement ok
+CREATE TABLE kv (k INT PRIMARY KEY, v INT, UNIQUE INDEX idx(v))
+
+query TTTTT colnames
+EXPLAIN (VERBOSE) SELECT DISTINCT v FROM kv
+----
+Tree            Field     Description       Columns          Ordering
+distinct        ·         ·                 (v)              weak-key(v)
+ └── render     ·         ·                 (v)              ·
+      │         render 0  test.public.kv.v  ·                ·
+      └── scan  ·         ·                 (k[omitted], v)  k!=NULL; key(k)
+·               table     kv@primary        ·                ·
+·               spans     ALL               ·                ·
+
+# Verify we don't incorrectly elide the distinct node when we only have a weak key (#19343).
+query TTTTT colnames
+EXPLAIN (VERBOSE) SELECT DISTINCT v FROM kv@idx
+----
+Tree            Field      Description       Columns          Ordering
+distinct        ·          ·                 (v)              weak-key(v); +v
+ │              order key  v                 ·                ·
+ └── render     ·          ·                 (v)              weak-key(v); +v
+      │         render 0   test.public.kv.v  ·                ·
+      └── scan  ·          ·                 (k[omitted], v)  weak-key(v); +v
+·               table      kv@idx            ·                ·
+·               spans      ALL               ·                ·
+
+# Here we can infer that v is not-NULL so eliding the node is correct.
+query TTTTT colnames
+EXPLAIN (VERBOSE) SELECT DISTINCT v FROM kv@idx WHERE v > 0
+----
+Tree       Field     Description       Columns          Ordering
+render     ·         ·                 (v)              v!=NULL; key(v)
+ │         render 0  test.public.kv.v  ·                ·
+ └── scan  ·         ·                 (k[omitted], v)  v!=NULL; key(v)
+·          table     kv@idx            ·                ·
+·          spans     /1-               ·                ·
+
+statement ok
+CREATE TABLE kv2 (k INT PRIMARY KEY, v INT NOT NULL, UNIQUE INDEX idx(v))
+
+# In this case it is correct to elide the distinct node.
+query TTTTT colnames
+EXPLAIN (VERBOSE) SELECT DISTINCT v FROM kv2@idx
+----
+Tree       Field     Description        Columns          Ordering
+render     ·         ·                  (v)              v!=NULL; key(v)
+ │         render 0  test.public.kv2.v  ·                ·
+ └── scan  ·         ·                  (k[omitted], v)  v!=NULL; key(v)
+·          table     kv2@idx            ·                ·
+·          spans     ALL                ·                ·

--- a/pkg/sql/logictest/testdata/planner_test/distinct_on
+++ b/pkg/sql/logictest/testdata/planner_test/distinct_on
@@ -1,0 +1,466 @@
+# LogicTest: default
+
+statement ok
+CREATE TABLE xyz (
+  x INT,
+  y INT,
+  z INT,
+  pk1 INT,
+  pk2 INT,
+  PRIMARY KEY (pk1, pk2)
+)
+
+statement ok
+CREATE TABLE abc (
+  a STRING,
+  b STRING,
+  c STRING,
+  PRIMARY KEY (a, b, c)
+)
+
+##################
+# Simple queries #
+##################
+
+# 3/3 columns
+
+query TTTTT
+EXPLAIN (VERBOSE) SELECT DISTINCT ON (x, y, z) x, y, z FROM xyz
+----
+distinct        ·            ·                  (x, y, z)                              weak-key(x,y,z)
+ │              distinct on  x, y, z            ·                                      ·
+ └── render     ·            ·                  (x, y, z)                              ·
+      │         render 0     test.public.xyz.x  ·                                      ·
+      │         render 1     test.public.xyz.y  ·                                      ·
+      │         render 2     test.public.xyz.z  ·                                      ·
+      └── scan  ·            ·                  (x, y, z, pk1[omitted], pk2[omitted])  pk1!=NULL; pk2!=NULL; key(pk1,pk2)
+·               table        xyz@primary        ·                                      ·
+·               spans        ALL                ·                                      ·
+
+query TTTTT
+EXPLAIN (VERBOSE) SELECT DISTINCT ON (z, x, y) x FROM xyz
+----
+render               ·            ·                  (x)                                    ·
+ │                   render 0     x                  ·                                      ·
+ └── distinct        ·            ·                  (x, z, y)                              weak-key(x,z,y)
+      │              distinct on  x, z, y            ·                                      ·
+      └── render     ·            ·                  (x, z, y)                              ·
+           │         render 0     test.public.xyz.x  ·                                      ·
+           │         render 1     test.public.xyz.z  ·                                      ·
+           │         render 2     test.public.xyz.y  ·                                      ·
+           └── scan  ·            ·                  (x, y, z, pk1[omitted], pk2[omitted])  pk1!=NULL; pk2!=NULL; key(pk1,pk2)
+·                    table        xyz@primary        ·                                      ·
+·                    spans        ALL                ·                                      ·
+
+query TTTTT
+EXPLAIN (VERBOSE) SELECT DISTINCT ON (b, c, a) a, c, b FROM abc
+----
+render     ·         ·                  (a, c, b)  a!=NULL; c!=NULL; b!=NULL; key(a,c,b)
+ │         render 0  test.public.abc.a  ·          ·
+ │         render 1  test.public.abc.c  ·          ·
+ │         render 2  test.public.abc.b  ·          ·
+ └── scan  ·         ·                  (a, b, c)  a!=NULL; b!=NULL; c!=NULL; key(a,b,c)
+·          table     abc@primary        ·          ·
+·          spans     ALL                ·          ·
+
+# Distinct node should be elided since we have a strong key.
+query TTTTT
+EXPLAIN (VERBOSE) SELECT DISTINCT ON (b, c, a) a FROM abc
+----
+render     ·         ·            (a)        a!=NULL
+ │         render 0  a            ·          ·
+ └── scan  ·         ·            (a, b, c)  a!=NULL; b!=NULL; c!=NULL; key(a,b,c)
+·          table     abc@primary  ·          ·
+·          spans     ALL          ·          ·
+
+# Distinct node should be elided since we have a strong key.
+query TTTTT
+EXPLAIN (VERBOSE) SELECT DISTINCT ON (c, a, b) b FROM abc ORDER BY b
+----
+render               ·         ·                  (b)                          b!=NULL; +b
+ │                   render 0  b                  ·                            ·
+ └── sort            ·         ·                  (b, c[omitted], a[omitted])  b!=NULL; c!=NULL; a!=NULL; key(b,c,a); +b
+      │              order     +b                 ·                            ·
+      └── render     ·         ·                  (b, c[omitted], a[omitted])  b!=NULL; c!=NULL; a!=NULL; key(b,c,a)
+           │         render 0  test.public.abc.b  ·                            ·
+           │         render 1  NULL               ·                            ·
+           │         render 2  NULL               ·                            ·
+           └── scan  ·         ·                  (a[omitted], b, c[omitted])  a!=NULL; b!=NULL; c!=NULL; key(a,b,c)
+·                    table     abc@primary        ·                            ·
+·                    spans     ALL                ·                            ·
+
+
+# 2/3 columns
+
+query TTTTT
+EXPLAIN (VERBOSE) SELECT DISTINCT ON (x, y) y, x FROM xyz
+----
+distinct        ·            ·                  (y, x)                                          weak-key(y,x)
+ │              distinct on  y, x               ·                                               ·
+ └── render     ·            ·                  (y, x)                                          ·
+      │         render 0     test.public.xyz.y  ·                                               ·
+      │         render 1     test.public.xyz.x  ·                                               ·
+      └── scan  ·            ·                  (x, y, z[omitted], pk1[omitted], pk2[omitted])  pk1!=NULL; pk2!=NULL; key(pk1,pk2)
+·               table        xyz@primary        ·                                               ·
+·               spans        ALL                ·                                               ·
+
+query TTTTT
+EXPLAIN (VERBOSE) SELECT DISTINCT ON (y, x) x FROM xyz
+----
+render               ·            ·                  (x)                                             ·
+ │                   render 0     x                  ·                                               ·
+ └── distinct        ·            ·                  (x, y)                                          weak-key(x,y)
+      │              distinct on  x, y               ·                                               ·
+      └── render     ·            ·                  (x, y)                                          ·
+           │         render 0     test.public.xyz.x  ·                                               ·
+           │         render 1     test.public.xyz.y  ·                                               ·
+           └── scan  ·            ·                  (x, y, z[omitted], pk1[omitted], pk2[omitted])  pk1!=NULL; pk2!=NULL; key(pk1,pk2)
+·                    table        xyz@primary        ·                                               ·
+·                    spans        ALL                ·                                               ·
+
+query TTTTT
+EXPLAIN (VERBOSE) SELECT DISTINCT ON (y, x, x, y, x) x, y FROM xyz
+----
+distinct        ·            ·                  (x, y)                                          weak-key(x,y)
+ │              distinct on  x, y               ·                                               ·
+ └── render     ·            ·                  (x, y)                                          ·
+      │         render 0     test.public.xyz.x  ·                                               ·
+      │         render 1     test.public.xyz.y  ·                                               ·
+      └── scan  ·            ·                  (x, y, z[omitted], pk1[omitted], pk2[omitted])  pk1!=NULL; pk2!=NULL; key(pk1,pk2)
+·               table        xyz@primary        ·                                               ·
+·               spans        ALL                ·                                               ·
+
+query TTTTT
+EXPLAIN (VERBOSE) SELECT DISTINCT ON(pk1, x) pk1, x FROM xyz ORDER BY pk1
+----
+distinct        ·            ·                    (pk1, x)                                        pk1!=NULL; weak-key(pk1,x); +pk1
+ │              distinct on  pk1, x               ·                                               ·
+ │              order key    pk1                  ·                                               ·
+ └── render     ·            ·                    (pk1, x)                                        pk1!=NULL; +pk1
+      │         render 0     test.public.xyz.pk1  ·                                               ·
+      │         render 1     test.public.xyz.x    ·                                               ·
+      └── scan  ·            ·                    (x, y[omitted], z[omitted], pk1, pk2[omitted])  pk1!=NULL; pk2!=NULL; key(pk1,pk2); +pk1
+·               table        xyz@primary          ·                                               ·
+·               spans        ALL                  ·                                               ·
+
+query TTTTT
+EXPLAIN (VERBOSE) SELECT DISTINCT ON (a, c) a, b FROM abc
+----
+render          ·            ·            (a, b)     a!=NULL; b!=NULL; +a
+ │              render 0     a            ·          ·
+ │              render 1     b            ·          ·
+ └── distinct   ·            ·            (a, b, c)  a!=NULL; b!=NULL; c!=NULL; key(a,c); +a
+      │         distinct on  a, c         ·          ·
+      │         order key    a            ·          ·
+      └── scan  ·            ·            (a, b, c)  a!=NULL; b!=NULL; c!=NULL; key(a,b,c); +a
+·               table        abc@primary  ·          ·
+·               spans        ALL          ·          ·
+
+query TTTTT
+EXPLAIN (VERBOSE) SELECT DISTINCT ON (c, a) b, c, a FROM abc
+----
+distinct        ·            ·                  (b, c, a)  b!=NULL; c!=NULL; a!=NULL; key(c,a); +a
+ │              distinct on  c, a               ·          ·
+ │              order key    a                  ·          ·
+ └── render     ·            ·                  (b, c, a)  b!=NULL; c!=NULL; a!=NULL; key(b,c,a); +a
+      │         render 0     test.public.abc.b  ·          ·
+      │         render 1     test.public.abc.c  ·          ·
+      │         render 2     test.public.abc.a  ·          ·
+      └── scan  ·            ·                  (a, b, c)  a!=NULL; b!=NULL; c!=NULL; key(a,b,c); +a
+·               table        abc@primary        ·          ·
+·               spans        ALL                ·          ·
+
+
+# 1/3 columns
+
+# Check that distinct propagates the smaller, tighter key (pk1) as opposed to
+# the original key (pk1, pk2).
+query TTTTT
+EXPLAIN (VERBOSE) SELECT DISTINCT ON (pk1) pk1, pk2 FROM xyz
+----
+distinct        ·            ·                    (pk1, pk2)                                      pk1!=NULL; pk2!=NULL; key(pk1); +pk1
+ │              distinct on  pk1                  ·                                               ·
+ │              order key    pk1                  ·                                               ·
+ └── render     ·            ·                    (pk1, pk2)                                      pk1!=NULL; pk2!=NULL; key(pk1,pk2); +pk1
+      │         render 0     test.public.xyz.pk1  ·                                               ·
+      │         render 1     test.public.xyz.pk2  ·                                               ·
+      └── scan  ·            ·                    (x[omitted], y[omitted], z[omitted], pk1, pk2)  pk1!=NULL; pk2!=NULL; key(pk1,pk2); +pk1
+·               table        xyz@primary          ·                                               ·
+·               spans        ALL                  ·                                               ·
+
+# Ensure order simplification on DISTINCT ON columns does not simplifying out
+# an explicit order from ORDER BY.
+# Note that the -c ordering was reduced after the distinct: this is because
+# we have a strong key on 'a' so ordering after '+a' is unnecessary.
+query TTTTT
+EXPLAIN (VERBOSE) SELECT DISTINCT ON (a) a, c FROM abc ORDER BY a, c DESC, b
+----
+distinct             ·            ·                  (a, c)     a!=NULL; c!=NULL; key(a); +a
+ │                   distinct on  a                  ·          ·
+ │                   order key    a                  ·          ·
+ └── sort            ·            ·                  (a, c)     a!=NULL; c!=NULL; +a,-c
+      │              order        +a,-c,+b           ·          ·
+      └── render     ·            ·                  (a, c, b)  a!=NULL; c!=NULL; b!=NULL; key(a,c,b); +a
+           │         render 0     test.public.abc.a  ·          ·
+           │         render 1     test.public.abc.c  ·          ·
+           │         render 2     test.public.abc.b  ·          ·
+           └── scan  ·            ·                  (a, b, c)  a!=NULL; b!=NULL; c!=NULL; key(a,b,c); +a
+·                    table        abc@primary        ·          ·
+·                    spans        ALL                ·          ·
+
+#################
+# With ORDER BY #
+#################
+
+query TTTTT
+EXPLAIN (VERBOSE) SELECT DISTINCT ON (x) x FROM xyz ORDER BY x DESC
+----
+distinct             ·            ·                  (x)                                                      weak-key(x); -x
+ │                   distinct on  x                  ·                                                        ·
+ │                   order key    x                  ·                                                        ·
+ └── sort            ·            ·                  (x)                                                      -x
+      │              order        -x                 ·                                                        ·
+      └── render     ·            ·                  (x)                                                      ·
+           │         render 0     test.public.xyz.x  ·                                                        ·
+           └── scan  ·            ·                  (x, y[omitted], z[omitted], pk1[omitted], pk2[omitted])  pk1!=NULL; pk2!=NULL; key(pk1,pk2)
+·                    table        xyz@primary        ·                                                        ·
+·                    spans        ALL                ·                                                        ·
+
+query TTTTT
+EXPLAIN (VERBOSE) SELECT DISTINCT ON (x, z) y, z, x FROM xyz ORDER BY z
+----
+distinct             ·            ·                  (y, z, x)                              weak-key(z,x); +z
+ │                   distinct on  z, x               ·                                      ·
+ │                   order key    z                  ·                                      ·
+ └── sort            ·            ·                  (y, z, x)                              +z
+      │              order        +z                 ·                                      ·
+      └── render     ·            ·                  (y, z, x)                              ·
+           │         render 0     test.public.xyz.y  ·                                      ·
+           │         render 1     test.public.xyz.z  ·                                      ·
+           │         render 2     test.public.xyz.x  ·                                      ·
+           └── scan  ·            ·                  (x, y, z, pk1[omitted], pk2[omitted])  pk1!=NULL; pk2!=NULL; key(pk1,pk2)
+·                    table        xyz@primary        ·                                      ·
+·                    spans        ALL                ·                                      ·
+
+query TTTTT
+EXPLAIN (VERBOSE) SELECT DISTINCT ON (x) y, z, x FROM xyz ORDER BY x ASC, z DESC, y DESC
+----
+distinct             ·            ·                  (y, z, x)                              weak-key(x); +x,-z,-y
+ │                   distinct on  x                  ·                                      ·
+ │                   order key    x                  ·                                      ·
+ └── sort            ·            ·                  (y, z, x)                              +x,-z,-y
+      │              order        +x,-z,-y           ·                                      ·
+      └── render     ·            ·                  (y, z, x)                              ·
+           │         render 0     test.public.xyz.y  ·                                      ·
+           │         render 1     test.public.xyz.z  ·                                      ·
+           │         render 2     test.public.xyz.x  ·                                      ·
+           └── scan  ·            ·                  (x, y, z, pk1[omitted], pk2[omitted])  pk1!=NULL; pk2!=NULL; key(pk1,pk2)
+·                    table        xyz@primary        ·                                      ·
+·                    spans        ALL                ·                                      ·
+
+#####################
+# With aggregations #
+#####################
+
+query TTTTT
+EXPLAIN (VERBOSE) SELECT DISTINCT ON (MAX(y)) MAX(x) FROM xyz
+----
+render                    ·            ·                  (max)                                           ·
+ │                        render 0     max                ·                                               ·
+ └── distinct             ·            ·                  (max, max)                                      weak-key(max)
+      │                   distinct on  max                ·                                               ·
+      └── group           ·            ·                  (max, max)                                      ·
+           │              aggregate 0  max(x)             ·                                               ·
+           │              aggregate 1  max(y)             ·                                               ·
+           └── render     ·            ·                  (x, y)                                          ·
+                │         render 0     test.public.xyz.x  ·                                               ·
+                │         render 1     test.public.xyz.y  ·                                               ·
+                └── scan  ·            ·                  (x, y, z[omitted], pk1[omitted], pk2[omitted])  pk1!=NULL; pk2!=NULL; key(pk1,pk2)
+·                         table        xyz@primary        ·                                               ·
+·                         spans        ALL                ·                                               ·
+
+query TTTTT
+EXPLAIN (VERBOSE) SELECT DISTINCT ON(MIN(a), MAX(b), MIN(c)) MAX(a) FROM abc
+----
+render               ·            ·              (max)                 ·
+ │                   render 0     max            ·                     ·
+ └── distinct        ·            ·              (max, min, max, min)  weak-key(min,max,min)
+      │              distinct on  min, max, min  ·                     ·
+      └── group      ·            ·              (max, min, max, min)  ·
+           │         aggregate 0  max(a)         ·                     ·
+           │         aggregate 1  min(a)         ·                     ·
+           │         aggregate 2  max(b)         ·                     ·
+           │         aggregate 3  min(c)         ·                     ·
+           └── scan  ·            ·              (a, b, c)             a!=NULL; b!=NULL; c!=NULL; key(a,b,c)
+·                    table        abc@primary    ·                     ·
+·                    spans        ALL            ·                     ·
+
+#################
+# With GROUP BY #
+#################
+
+# TODO(richardwu): we can elide the DISTINCT ON since its key is equivalent
+# to the group key.
+query TTTTT
+EXPLAIN (VERBOSE) SELECT DISTINCT ON(y) MIN(x) FROM xyz GROUP BY y
+----
+render                    ·            ·                  (min)                                           ·
+ │                        render 0     min                ·                                               ·
+ └── distinct             ·            ·                  (min, y)                                        weak-key(y)
+      │                   distinct on  y                  ·                                               ·
+      └── group           ·            ·                  (min, y)                                        weak-key(y)
+           │              aggregate 0  min(x)             ·                                               ·
+           │              aggregate 1  y                  ·                                               ·
+           │              group by     @1                 ·                                               ·
+           └── render     ·            ·                  (y, x)                                          ·
+                │         render 0     test.public.xyz.y  ·                                               ·
+                │         render 1     test.public.xyz.x  ·                                               ·
+                └── scan  ·            ·                  (x, y, z[omitted], pk1[omitted], pk2[omitted])  pk1!=NULL; pk2!=NULL; key(pk1,pk2)
+·                         table        xyz@primary        ·                                               ·
+·                         spans        ALL                ·                                               ·
+
+query TTTTT
+EXPLAIN (VERBOSE) SELECT DISTINCT ON(MIN(x)) MIN(x) FROM xyz GROUP BY y HAVING MIN(x) = 1
+----
+distinct                  ·            ·                  (min)                                           min=CONST; key()
+ │                        distinct on  min                ·                                               ·
+ └── filter               ·            ·                  (min)                                           min=CONST
+      │                   filter       agg0 = 1           ·                                               ·
+      └── group           ·            ·                  (min)                                           ·
+           │              aggregate 0  min(x)             ·                                               ·
+           │              group by     @1                 ·                                               ·
+           └── render     ·            ·                  (y, x)                                          ·
+                │         render 0     test.public.xyz.y  ·                                               ·
+                │         render 1     test.public.xyz.x  ·                                               ·
+                └── scan  ·            ·                  (x, y, z[omitted], pk1[omitted], pk2[omitted])  pk1!=NULL; pk2!=NULL; key(pk1,pk2)
+·                         table        xyz@primary        ·                                               ·
+·                         spans        ALL                ·                                               ·
+
+#########################
+# With window functions #
+#########################
+
+query TTTTT
+EXPLAIN (VERBOSE) SELECT DISTINCT ON(row_number() OVER()) y FROM xyz
+----
+render                    ·            ·                     (y)                                                      ·
+ │                        render 0     y                     ·                                                        ·
+ └── distinct             ·            ·                     (y, row_number)                                          weak-key(row_number)
+      │                   distinct on  row_number            ·                                                        ·
+      └── window          ·            ·                     (y, row_number)                                          ·
+           │              window 0     row_number() OVER ()  ·                                                        ·
+           │              render 1     row_number() OVER ()  ·                                                        ·
+           └── render     ·            ·                     (y)                                                      ·
+                │         render 0     test.public.xyz.y     ·                                                        ·
+                └── scan  ·            ·                     (x[omitted], y, z[omitted], pk1[omitted], pk2[omitted])  pk1!=NULL; pk2!=NULL; key(pk1,pk2)
+·                         table        xyz@primary           ·                                                        ·
+·                         spans        ALL                   ·                                                        ·
+
+###########################
+# With ordinal references #
+###########################
+
+query TTTTT
+EXPLAIN (VERBOSE) SELECT DISTINCT ON (1) x, y, z FROM xyz
+----
+distinct        ·            ·                  (x, y, z)                              weak-key(x)
+ │              distinct on  x                  ·                                      ·
+ └── render     ·            ·                  (x, y, z)                              ·
+      │         render 0     test.public.xyz.x  ·                                      ·
+      │         render 1     test.public.xyz.y  ·                                      ·
+      │         render 2     test.public.xyz.z  ·                                      ·
+      └── scan  ·            ·                  (x, y, z, pk1[omitted], pk2[omitted])  pk1!=NULL; pk2!=NULL; key(pk1,pk2)
+·               table        xyz@primary        ·                                      ·
+·               spans        ALL                ·                                      ·
+
+# Distinct node elided because of strong key.
+query TTTTT
+EXPLAIN (VERBOSE) SELECT DISTINCT ON (1,2,3) a, b, c FROM abc
+----
+scan  ·      ·            (a, b, c)  a!=NULL; b!=NULL; c!=NULL; key(a,b,c)
+·     table  abc@primary  ·          ·
+·     spans  ALL          ·          ·
+
+#########################
+# With alias references #
+#########################
+
+# This should priortize alias (use 'x' as the key).
+query TTTTT
+EXPLAIN (VERBOSE) SELECT DISTINCT ON(y) x AS y, y AS x FROM xyz
+----
+distinct        ·            ·                  (y, x)                                          weak-key(y)
+ │              distinct on  y                  ·                                               ·
+ └── render     ·            ·                  (y, x)                                          ·
+      │         render 0     test.public.xyz.x  ·                                               ·
+      │         render 1     test.public.xyz.y  ·                                               ·
+      └── scan  ·            ·                  (x, y, z[omitted], pk1[omitted], pk2[omitted])  pk1!=NULL; pk2!=NULL; key(pk1,pk2)
+·               table        xyz@primary        ·                                               ·
+·               spans        ALL                ·                                               ·
+
+# Ignores the alias.
+query TTTTT
+EXPLAIN (VERBOSE) SELECT DISTINCT ON(x) x AS y FROM xyz
+----
+distinct        ·            ·                  (y)                                                      weak-key(y)
+ │              distinct on  y                  ·                                                        ·
+ └── render     ·            ·                  (y)                                                      ·
+      │         render 0     test.public.xyz.x  ·                                                        ·
+      └── scan  ·            ·                  (x, y[omitted], z[omitted], pk1[omitted], pk2[omitted])  pk1!=NULL; pk2!=NULL; key(pk1,pk2)
+·               table        xyz@primary        ·                                                        ·
+·               spans        ALL                ·                                                        ·
+
+##################################
+# With nested parentheses/tuples #
+##################################
+
+query TTTTT
+EXPLAIN (VERBOSE) SELECT DISTINCT ON(((x)), (x, y)) x, y FROM xyz
+----
+distinct        ·            ·                  (x, y)                                          weak-key(x,y)
+ │              distinct on  x, y               ·                                               ·
+ └── render     ·            ·                  (x, y)                                          ·
+      │         render 0     test.public.xyz.x  ·                                               ·
+      │         render 1     test.public.xyz.y  ·                                               ·
+      └── scan  ·            ·                  (x, y, z[omitted], pk1[omitted], pk2[omitted])  pk1!=NULL; pk2!=NULL; key(pk1,pk2)
+·               table        xyz@primary        ·                                               ·
+·               spans        ALL                ·                                               ·
+
+################################
+# Hybrid PK and non-PK queries #
+################################
+
+# Distinct elided because of strong key presence.
+query TTTTT
+EXPLAIN (VERBOSE) SELECT DISTINCT ON(pk1, pk2, x, y) x, y, z FROM xyz ORDER BY x, y
+----
+render          ·         ·            (x, y, z)                              +x,+y
+ │              render 0  x            ·                                      ·
+ │              render 1  y            ·                                      ·
+ │              render 2  z            ·                                      ·
+ └── sort       ·         ·            (x, y, z, pk1[omitted], pk2[omitted])  pk1!=NULL; pk2!=NULL; key(pk1,pk2); +x,+y
+      │         order     +x,+y        ·                                      ·
+      └── scan  ·         ·            (x, y, z, pk1[omitted], pk2[omitted])  pk1!=NULL; pk2!=NULL; key(pk1,pk2)
+·               table     xyz@primary  ·                                      ·
+·               spans     ALL          ·                                      ·
+
+# Ordering only propagates up until distinctNode.
+# pk1 ordering does not propagate at all since it's not explicitly needed.
+query TTTTT
+EXPLAIN (VERBOSE) SELECT DISTINCT ON (x, y, z) pk1 FROM xyz ORDER BY x
+----
+render                    ·            ·                    (pk1)                         pk1!=NULL
+ │                        render 0     pk1                  ·                             ·
+ └── distinct             ·            ·                    (pk1, x, y, z)                pk1!=NULL; weak-key(x,y,z); +x
+      │                   distinct on  x, y, z              ·                             ·
+      │                   order key    x                    ·                             ·
+      └── sort            ·            ·                    (pk1, x, y, z)                pk1!=NULL; +x
+           │              order        +x                   ·                             ·
+           └── render     ·            ·                    (pk1, x, y, z)                pk1!=NULL
+                │         render 0     test.public.xyz.pk1  ·                             ·
+                │         render 1     test.public.xyz.x    ·                             ·
+                │         render 2     test.public.xyz.y    ·                             ·
+                │         render 3     test.public.xyz.z    ·                             ·
+                └── scan  ·            ·                    (x, y, z, pk1, pk2[omitted])  pk1!=NULL; pk2!=NULL; key(pk1,pk2)
+·                         table        xyz@primary          ·                             ·
+·                         spans        ALL                  ·                             ·

--- a/pkg/sql/logictest/testdata/planner_test/interleaved
+++ b/pkg/sql/logictest/testdata/planner_test/interleaved
@@ -1,0 +1,137 @@
+# LogicTest: default
+
+# ------------------------------------------------------------------------------
+# Test index selection for deeply interleaved tables.
+# These tests are in their own file because table IDs appear in EXPLAIN output.
+# ------------------------------------------------------------------------------
+statement ok
+CREATE TABLE level1 (
+  k1 INT,
+  PRIMARY KEY (k1)
+)
+
+statement ok
+CREATE TABLE level2 (
+  k1 INT,
+  PRIMARY KEY (k1),
+  CONSTRAINT fk1 FOREIGN KEY (k1) REFERENCES level1
+) INTERLEAVE IN PARENT level1 (k1)
+
+statement ok
+CREATE TABLE level3 (
+  k1 INT,
+  k2 INT,
+  k3 INT,
+  PRIMARY KEY (k1, k2, k3),
+  CONSTRAINT fk2 FOREIGN KEY (k1) REFERENCES level2
+) INTERLEAVE IN PARENT level2 (k1)
+
+statement ok
+CREATE TABLE level4 (
+  k1 INT,
+  k2 INT,
+  k3 INT,
+  PRIMARY KEY (k1, k2, k3),
+  CONSTRAINT fk3 FOREIGN KEY (k1, k2, k3) REFERENCES level3
+) INTERLEAVE IN PARENT level3 (k1, k2, k3)
+
+query TTT
+EXPLAIN SELECT * FROM level4
+----
+scan  ·      ·
+·     table  level4@primary
+·     spans  ALL
+
+# The span below ends at the end of the first index of table 53, and is not
+# constraining the value of k2 or k3. This is confusing on first glance because
+# the second interleave in the hierarchy doesn't contain any new primary key
+# columns on top of the first interleave.
+query TTT
+EXPLAIN SELECT * FROM level4 WHERE k1 > 1 AND k1 < 3
+----
+scan  ·      ·
+·     table  level4@primary
+·     spans  /2/#/54/1/#/55/1-/2/#/54/1/#/55/2
+
+query TTT
+EXPLAIN SELECT * FROM level4 WHERE k1 = 2 AND k2 > 10 AND k2 < 30
+----
+scan  ·      ·
+·     table  level4@primary
+·     spans  /2/#/54/1/#/55/1/11-/2/#/54/1/#/55/1/30
+
+query TTT
+EXPLAIN SELECT * FROM level4 WHERE k1 = 2 AND k2 = 20 AND k3 > 100 AND k3 < 300
+----
+scan  ·      ·
+·     table  level4@primary
+·     spans  /2/#/54/1/#/55/1/20/101/#/56/1-/2/#/54/1/#/55/1/20/299/#/56/1/#
+
+query TTT
+EXPLAIN SELECT * FROM level4 WHERE k1 = 2 AND k2 = 20 AND k3 = 200
+----
+scan  ·      ·
+·     table  level4@primary
+·     spans  /2/#/54/1/#/55/1/20/200/#/56/1-/2/#/54/1/#/55/1/20/200/#/56/1/#
+
+# ------------------------------------------------------------------------------
+# Trace of interleaved fetches from interesting interleaved hierarchy.
+# ------------------------------------------------------------------------------
+# Grandparent table
+statement ok
+CREATE TABLE p2 (i INT PRIMARY KEY, s STRING)
+
+# Two tables interleaved at the same level
+statement ok
+CREATE TABLE p1_0 (
+  i INT,
+  s1 STRING,
+  s2 STRING,
+  d DECIMAL,
+  PRIMARY KEY (i, s1),
+  FAMILY (i, s1, s2),
+  FAMILY (d)
+) INTERLEAVE IN PARENT p2 (i)
+
+statement ok
+CREATE TABLE p1_1 (
+  i INT PRIMARY KEY,
+  s1 STRING,
+  s2 STRING,
+  d DECIMAL
+) INTERLEAVE IN PARENT p2 (i)
+
+# Two level deep interleave
+statement ok
+CREATE TABLE p0 (
+  i INT,
+  s1 STRING,
+  s2 STRING,
+  d DECIMAL,
+  PRIMARY KEY (i, s1, s2)
+) INTERLEAVE IN PARENT p1_0 (i, s1)
+
+statement ok
+INSERT INTO p2 VALUES (2, '2'), (3, '3'), (5, '5'), (7, '7')
+
+statement ok
+INSERT INTO p1_0 VALUES (2, '2', '2.01', 2), (3, '3', '3.01', 3), (5, '5', NULL, NULL)
+
+statement ok
+INSERT INTO p1_1 VALUES (2, '2', '2.11', 2), (3, '3', '3.11', 3)
+
+statement ok
+INSERT INTO p0 VALUES (2, '2', '2.0', 2), (3, '3', '3.0', 3), (5, '5', '5.0', 5)
+
+query T
+SELECT message FROM [SHOW KV TRACE FOR SELECT * FROM p1_0]
+ WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
+----
+fetched: /p1_0/primary/2/'2'/s2 -> /'2.01'
+fetched: /p1_0/primary/2/'2'/d -> 2
+output row: [2 '2' '2.01' 2]
+fetched: /p1_0/primary/3/'3'/s2 -> /'3.01'
+fetched: /p1_0/primary/3/'3'/d -> 3
+output row: [3 '3' '3.01' 3]
+fetched: /p1_0/primary/5/'5' -> NULL
+output row: [5 '5' NULL NULL]

--- a/pkg/sql/logictest/testdata/planner_test/inverted_index
+++ b/pkg/sql/logictest/testdata/planner_test/inverted_index
@@ -1,0 +1,183 @@
+# LogicTest: default
+
+statement ok
+CREATE TABLE d (
+  a INT PRIMARY KEY,
+  b JSONB
+)
+
+statement ok
+CREATE INVERTED INDEX foo_inv ON d(b)
+
+query TTTTT
+EXPLAIN (VERBOSE) SELECT * from d where b @>'{"a": "b"}'
+----
+index-join  ·      ·                            (a, b)           b=CONST; a!=NULL; key(a)
+ ├── scan   ·      ·                            (a, b[omitted])  b=CONST; a!=NULL; key(a)
+ │          table  d@foo_inv                    ·                ·
+ │          spans  /"a"/"b"-/"a"/"b"/PrefixEnd  ·                ·
+ └── scan   ·      ·                            (a, b)           ·
+·           table  d@primary                    ·                ·
+
+query TTTTT
+EXPLAIN (VERBOSE) SELECT * from d where b @>'{"a": {"b": [1]}}'
+----
+index-join  ·      ·                                        (a, b)           b=CONST; a!=NULL; key(a)
+ ├── scan   ·      ·                                        (a, b[omitted])  b=CONST; a!=NULL; key(a)
+ │          table  d@foo_inv                                ·                ·
+ │          spans  /"a"/"b"/Arr/1-/"a"/"b"/Arr/1/PrefixEnd  ·                ·
+ └── scan   ·      ·                                        (a, b)           ·
+·           table  d@primary                                ·                ·
+
+query TTTTT
+EXPLAIN (VERBOSE) SELECT * from d where b @> '{"a": {"b": [[2]]}}';
+----
+index-join  ·      ·                                                (a, b)           b=CONST; a!=NULL; key(a)
+ ├── scan   ·      ·                                                (a, b[omitted])  b=CONST; a!=NULL; key(a)
+ │          table  d@foo_inv                                        ·                ·
+ │          spans  /"a"/"b"/Arr/Arr/2-/"a"/"b"/Arr/Arr/2/PrefixEnd  ·                ·
+ └── scan   ·      ·                                                (a, b)           ·
+·           table  d@primary                                        ·                ·
+
+query TTTTT
+EXPLAIN (VERBOSE) SELECT * from d where b @> '{"a": {"b":true}}';
+----
+index-join  ·      ·                             (a, b)           b=CONST; a!=NULL; key(a)
+ ├── scan   ·      ·                             (a, b[omitted])  b=CONST; a!=NULL; key(a)
+ │          table  d@foo_inv                     ·                ·
+ │          spans  /"a"/"b"/True-/"a"/"b"/False  ·                ·
+ └── scan   ·      ·                             (a, b)           ·
+·           table  d@primary                     ·                ·
+
+query TTTTT
+EXPLAIN (VERBOSE) SELECT * from d where b @>'[1]'
+----
+index-join  ·      ·                        (a, b)           b=CONST; a!=NULL; key(a)
+ ├── scan   ·      ·                        (a, b[omitted])  b=CONST; a!=NULL; key(a)
+ │          table  d@foo_inv                ·                ·
+ │          spans  /Arr/1-/Arr/1/PrefixEnd  ·                ·
+ └── scan   ·      ·                        (a, b)           ·
+·           table  d@primary                ·                ·
+
+query TTTTT
+EXPLAIN (VERBOSE) SELECT * from d where b @>'[{"a": {"b": [1]}}]'
+----
+index-join  ·      ·                                                (a, b)           b=CONST; a!=NULL; key(a)
+ ├── scan   ·      ·                                                (a, b[omitted])  b=CONST; a!=NULL; key(a)
+ │          table  d@foo_inv                                        ·                ·
+ │          spans  /Arr/"a"/"b"/Arr/1-/Arr/"a"/"b"/Arr/1/PrefixEnd  ·                ·
+ └── scan   ·      ·                                                (a, b)           ·
+·           table  d@primary                                        ·                ·
+
+query TTTTT
+EXPLAIN (VERBOSE) SELECT * from d where b @> '[]';
+----
+scan  ·       ·          (a, b)  a!=NULL; b!=NULL; key(a)
+·     table   d@primary  ·       ·
+·     spans   ALL        ·       ·
+·     filter  b @> '[]'  ·       ·
+
+
+query TTTTT
+EXPLAIN (VERBOSE) SELECT * from d where b @> '{}';
+----
+scan  ·       ·          (a, b)  a!=NULL; b!=NULL; key(a)
+·     table   d@primary  ·       ·
+·     spans   ALL        ·       ·
+·     filter  b @> '{}'  ·       ·
+
+query TTTTT
+EXPLAIN (VERBOSE) SELECT * from d where b->'a' = '"b"'
+----
+index-join  ·      ·                            (a, b)           b=CONST; a!=NULL; key(a)
+ ├── scan   ·      ·                            (a, b[omitted])  b=CONST; a!=NULL; key(a)
+ │          table  d@foo_inv                    ·                ·
+ │          spans  /"a"/"b"-/"a"/"b"/PrefixEnd  ·                ·
+ └── scan   ·      ·                            (a, b)           ·
+·           table  d@primary                    ·                ·
+
+query TTTTT
+EXPLAIN (VERBOSE) SELECT * from d where '"b"' = b->'a'
+----
+index-join  ·      ·                            (a, b)           b=CONST; a!=NULL; key(a)
+ ├── scan   ·      ·                            (a, b[omitted])  b=CONST; a!=NULL; key(a)
+ │          table  d@foo_inv                    ·                ·
+ │          spans  /"a"/"b"-/"a"/"b"/PrefixEnd  ·                ·
+ └── scan   ·      ·                            (a, b)           ·
+·           table  d@primary                    ·                ·
+
+query TTTTT
+EXPLAIN (VERBOSE) SELECT * from d where b IS NULL
+----
+scan  ·       ·          (a, b)  a!=NULL; key(a)
+·     table   d@primary  ·       ·
+·     spans   ALL        ·       ·
+·     filter  b IS NULL  ·       ·
+
+query TTT
+EXPLAIN SELECT * from d where b @> '{"a": []}' ORDER BY a;
+----
+scan  ·      ·
+·     table  d@primary
+·     spans  ALL
+
+query TTT
+EXPLAIN SELECT * from d where b @> '{"a": {}}' ORDER BY a;
+----
+scan  ·      ·
+·     table  d@primary
+·     spans  ALL
+
+## Multi-path contains queries
+
+query TTTTT
+EXPLAIN (VERBOSE) SELECT * from d where b @> '{"a": {"b": "c"}, "f": "g"}'
+----
+index-join  ·       ·                                    (a, b)           b=CONST; a!=NULL; key(a)
+ ├── scan   ·       ·                                    (a, b[omitted])  b=CONST; a!=NULL; key(a)
+ │          table   d@foo_inv                            ·                ·
+ │          spans   /"a"/"b"/"c"-/"a"/"b"/"c"/PrefixEnd  ·                ·
+ └── scan   ·       ·                                    (a, b)           ·
+·           table   d@primary                            ·                ·
+·           filter  b @> '{"a": {"b": "c"}, "f": "g"}'   ·                ·
+
+query TTTTT
+EXPLAIN (VERBOSE) SELECT * from d where b @> '{"a": {"b": "c", "d": "e"}, "f": "g"}'
+----
+index-join  ·       ·                                             (a, b)           b=CONST; a!=NULL; key(a)
+ ├── scan   ·       ·                                             (a, b[omitted])  b=CONST; a!=NULL; key(a)
+ │          table   d@foo_inv                                     ·                ·
+ │          spans   /"a"/"b"/"c"-/"a"/"b"/"c"/PrefixEnd           ·                ·
+ └── scan   ·       ·                                             (a, b)           ·
+·           table   d@primary                                     ·                ·
+·           filter  b @> '{"a": {"b": "c", "d": "e"}, "f": "g"}'  ·                ·
+
+query TTTTT
+EXPLAIN (VERBOSE) SELECT * from d where b @> '[{"a": {"b": [[2]]}}, "d"]'
+----
+index-join  ·       ·                                                        (a, b)           b=CONST; a!=NULL; key(a)
+ ├── scan   ·       ·                                                        (a, b[omitted])  b=CONST; a!=NULL; key(a)
+ │          table   d@foo_inv                                                ·                ·
+ │          spans   /Arr/"a"/"b"/Arr/Arr/2-/Arr/"a"/"b"/Arr/Arr/2/PrefixEnd  ·                ·
+ └── scan   ·       ·                                                        (a, b)           ·
+·           table   d@primary                                                ·                ·
+·           filter  b @> '[{"a": {"b": [[2]]}}, "d"]'                        ·                ·
+
+query TTTTT
+EXPLAIN (VERBOSE) SELECT * from d where b @> '{"a": {}, "b": 2}'
+----
+index-join  ·       ·                         (a, b)           b=CONST; a!=NULL; key(a)
+ ├── scan   ·       ·                         (a, b[omitted])  b=CONST; a!=NULL; key(a)
+ │          table   d@foo_inv                 ·                ·
+ │          spans   /"b"/2-/"b"/2/PrefixEnd   ·                ·
+ └── scan   ·       ·                         (a, b)           ·
+·           table   d@primary                 ·                ·
+·           filter  b @> '{"a": {}, "b": 2}'  ·                ·
+
+query TTTTT
+EXPLAIN (VERBOSE) SELECT * from d where b @> '{"a": {}, "b": {}}'
+----
+scan  ·       ·                          (a, b)  a!=NULL; b!=NULL; key(a)
+·     table   d@primary                  ·       ·
+·     spans   ALL                        ·       ·
+·     filter  b @> '{"a": {}, "b": {}}'  ·       ·

--- a/pkg/sql/logictest/testdata/planner_test/select
+++ b/pkg/sql/logictest/testdata/planner_test/select
@@ -1,6 +1,8 @@
 # LogicTest: default
 
+# ------------------------------------------------------------------------------
 # Ensure that correct index is used when indexed column has collation.
+# ------------------------------------------------------------------------------
 statement ok
 CREATE TABLE coll (
   a STRING COLLATE da,
@@ -26,7 +28,9 @@ render     ·      ·
 ·          table  coll@coll_b_a_idx
 ·          spans  ALL
 
+# ------------------------------------------------------------------------------
 # Ensure correct index is used when indexed column is computed.
+# ------------------------------------------------------------------------------
 statement ok
 CREATE TABLE computed (
   k INT PRIMARY KEY,
@@ -41,4 +45,145 @@ EXPLAIN SELECT b FROM computed ORDER BY b
 render     ·      ·
  └── scan  ·      ·
 ·          table  computed@computed_b_idx
+·          spans  ALL
+
+# ------------------------------------------------------------------------------
+# Ensure that Select filter probes expected date/time key/values that are in
+# different column families.
+# ------------------------------------------------------------------------------
+statement ok
+CREATE TABLE dt (
+  a TIMESTAMP PRIMARY KEY,
+  b DATE,
+  c INTERVAL,
+  UNIQUE (b),
+  UNIQUE (c),
+  FAMILY (a),
+  FAMILY (b),
+  FAMILY (c)
+)
+
+statement ok
+INSERT INTO dt VALUES
+  ('2015-08-30 03:34:45.34567', '2015-08-30', '34h2s'),
+  ('2015-08-25 04:45:45.53453', '2015-08-25', '2h45m2s234ms'),
+  ('2015-08-29 23:10:09.98763', '2015-08-29', '234h45m2s234ms')
+
+query T
+SELECT message FROM [SHOW KV TRACE FOR SELECT * FROM dt WHERE a = '2015-08-25 06:45:45.53453+02:00'::timestamp]
+ WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
+----
+fetched: /dt/primary/'2015-08-25 04:45:45.53453+00:00' -> NULL
+fetched: /dt/primary/'2015-08-25 04:45:45.53453+00:00'/b -> '2015-08-25'
+fetched: /dt/primary/'2015-08-25 04:45:45.53453+00:00'/c -> '2h45m2s234ms'
+output row: ['2015-08-25 04:45:45.53453+00:00' '2015-08-25' '2h45m2s234ms']
+
+query T
+SELECT message FROM [SHOW KV TRACE FOR SELECT b FROM dt WHERE b < '2015-08-29'::date]
+ WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
+----
+fetched: /dt/dt_b_key/'2015-08-25' -> /'2015-08-25 04:45:45.53453+00:00'
+output row: ['2015-08-25']
+
+query T
+SELECT message FROM [SHOW KV TRACE FOR SELECT c FROM dt WHERE c < '234h45m2s234ms'::interval]
+ WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
+----
+fetched: /dt/dt_c_key/'2h45m2s234ms' -> /'2015-08-25 04:45:45.53453+00:00'
+output row: ['2h45m2s234ms']
+fetched: /dt/dt_c_key/'34h2s' -> /'2015-08-30 03:34:45.34567+00:00'
+output row: ['34h2s']
+
+# ------------------------------------------------------------------------------
+# Ensure that special decimal values result in correct scan spans.
+# ------------------------------------------------------------------------------
+statement ok
+CREATE TABLE dec (d decimal, v decimal(3, 1), primary key (d, v))
+
+query TTT
+EXPLAIN SELECT * FROM dec WHERE d IS NaN and v IS NaN
+----
+scan  ·      ·
+·     table  dec@primary
+·     spans  /NaN/NaN-/NaN/NaN/#
+
+# The NaN suffix is decimalNaNDesc, not decimalNaN(Asc).
+query TTT
+EXPLAIN SELECT * FROM dec WHERE d = 'Infinity' and v = 'Infinity'
+----
+scan  ·      ·
+·     table  dec@primary
+·     spans  /Infinity/Infinity-/Infinity/Infinity/#
+
+query TTT
+EXPLAIN SELECT * FROM dec WHERE d = '-Infinity' and v = '-Infinity'
+----
+scan  ·      ·
+·     table  dec@primary
+·     spans  /-Infinity/-Infinity-/-Infinity/-Infinity/#
+
+# ------------------------------------------------------------------------------
+# Verify that lookups for Decimal NaN use indices when possible:
+# - `WHERE d IS NaN` should perform a point lookup.
+# - `WHERE d = 'NaN'` should also perform a point lookup.
+# - `WHERE isnan(d)` is a function so it can't perform a point lookup.
+# ------------------------------------------------------------------------------
+statement ok
+CREATE TABLE dec2 (d decimal null, index (d))
+
+query TTT
+EXPLAIN SELECT * FROM dec2 WHERE d IS NaN
+----
+render     ·      ·
+ └── scan  ·      ·
+·          table  dec2@dec2_d_idx
+·          spans  /NaN-/-Infinity
+
+query TTT
+EXPLAIN SELECT * FROM dec2 WHERE d = 'NaN'
+----
+render     ·      ·
+ └── scan  ·      ·
+·          table  dec2@dec2_d_idx
+·          spans  /NaN-/-Infinity
+
+query TTT
+EXPLAIN SELECT * FROM dec2 WHERE isnan(d)
+----
+render     ·      ·
+ └── scan  ·      ·
+·          table  dec2@dec2_d_idx
+·          spans  ALL
+
+# ------------------------------------------------------------------------------
+# Verify that lookups for Float NaN use indices when possible:
+# - `WHERE f IS NaN` should perform a point lookup.
+# - `WHERE f = 'NaN'` should also perform a point lookup.
+# - `WHERE isnan(f)` is a function so it can't perform a point lookup.
+# ------------------------------------------------------------------------------
+statement ok
+CREATE TABLE flt (f float null, unique index (f))
+
+query TTT
+EXPLAIN SELECT * FROM flt WHERE f IS NaN
+----
+render     ·      ·
+ └── scan  ·      ·
+·          table  flt@flt_f_key
+·          spans  /NaN-/NaN/PrefixEnd
+
+query TTT
+EXPLAIN SELECT * FROM flt WHERE f = 'NaN'
+----
+render     ·      ·
+ └── scan  ·      ·
+·          table  flt@flt_f_key
+·          spans  /NaN-/NaN/PrefixEnd
+
+query TTT
+EXPLAIN SELECT * FROM flt WHERE isnan(f)
+----
+render     ·      ·
+ └── scan  ·      ·
+·          table  flt@flt_f_key
 ·          spans  ALL

--- a/pkg/sql/logictest/testdata/planner_test/srfs
+++ b/pkg/sql/logictest/testdata/planner_test/srfs
@@ -1,0 +1,63 @@
+# LogicTest: default
+
+subtest generate_series
+
+query TTT
+EXPLAIN SELECT * FROM GENERATE_SERIES(1, 3)
+----
+generator  ·  ·
+
+query TTT
+EXPLAIN SELECT * FROM GENERATE_SERIES(1, 2), GENERATE_SERIES(1, 2)
+----
+join            ·     ·
+ │              type  cross
+ ├── generator  ·     ·
+ └── generator  ·     ·
+
+query TTT
+EXPLAIN SELECT GENERATE_SERIES(1, 3)
+----
+generator  ·  ·
+
+subtest multiple_SRFs
+# See #20511
+
+# query TTT
+# EXPLAIN SELECT GENERATE_SERIES(1, 2), GENERATE_SERIES(1, 2)
+# ----
+# join            ·     ·
+# │              type  cross
+# ├── generator  ·     ·
+# └── generator  ·     ·
+
+statement ok
+CREATE TABLE t (a string)
+
+statement ok
+CREATE TABLE u (b string)
+
+# query TTT
+# EXPLAIN(EXPRS) SELECT t.*, u.*, generate_series(1,2), generate_series(3, 4) FROM t, u
+# ----
+# render                    ·         ·
+# │                        render 0  a
+# │                        render 1  b
+# │                        render 2  generate_series
+# │                        render 3  generate_series
+# └── join                 ·         ·
+#      │                   type      cross
+#      ├── join            ·         ·
+#      │    │              type      cross
+#      │    ├── join       ·         ·
+#      │    │    │         type      cross
+#      │    │    ├── scan  ·         ·
+#      │    │    │         table     t@primary
+#      │    │    │         spans     ALL
+#      │    │    └── scan  ·         ·
+#      │    │              table     u@primary
+#      │    │              spans     ALL
+#      │    └── generator  ·         ·
+#      │                   expr      generate_series(1, 2)
+#      └── generator       ·         ·
+#·                         expr      generate_series(3, 4)

--- a/pkg/sql/opt/exec/execbuilder/relational_builder.go
+++ b/pkg/sql/opt/exec/execbuilder/relational_builder.go
@@ -16,7 +16,6 @@ package execbuilder
 
 import (
 	"fmt"
-	"math"
 
 	"github.com/pkg/errors"
 
@@ -471,22 +470,18 @@ func (b *Builder) buildLimitOffset(ev memo.ExprView) (execPlan, error) {
 	if err != nil {
 		return execPlan{}, err
 	}
-	valueExpr := ev.Child(1)
-	if valueExpr.Operator() != opt.ConstOp {
-		return execPlan{}, errors.Errorf("only constant LIMIT/OFFSET supported")
+	// LIMIT/OFFSET expression should never need buildScalarContext, because it
+	// can't refer to input expression.
+	expr, err := b.buildScalar(nil, ev.Child(1))
+	if err != nil {
+		return execPlan{}, err
 	}
-	datum := valueExpr.Private().(tree.Datum)
-	value, ok := datum.(*tree.DInt)
-	if !ok {
-		return execPlan{}, errors.Errorf("non-integer LIMIT/OFFSET")
-	}
-	var limit, offset int64
+	var node exec.Node
 	if ev.Operator() == opt.LimitOp {
-		limit, offset = int64(*value), 0
+		node, err = b.factory.ConstructLimit(input.root, expr, nil)
 	} else {
-		limit, offset = math.MaxInt64, int64(*value)
+		node, err = b.factory.ConstructLimit(input.root, nil, expr)
 	}
-	node, err := b.factory.ConstructLimit(input.root, limit, offset)
 	if err != nil {
 		return execPlan{}, err
 	}

--- a/pkg/sql/opt/exec/execbuilder/relational_builder.go
+++ b/pkg/sql/opt/exec/execbuilder/relational_builder.go
@@ -471,7 +471,7 @@ func (b *Builder) buildLimitOffset(ev memo.ExprView) (execPlan, error) {
 		return execPlan{}, err
 	}
 	// LIMIT/OFFSET expression should never need buildScalarContext, because it
-	// can't refer to input expression.
+	// can't refer to the input expression.
 	expr, err := b.buildScalar(nil, ev.Child(1))
 	if err != nil {
 		return execPlan{}, err

--- a/pkg/sql/opt/exec/execbuilder/testdata/distinct
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distinct
@@ -1,0 +1,210 @@
+# LogicTest: opt
+
+statement ok
+CREATE TABLE xyz (
+  x INT PRIMARY KEY,
+  y INT,
+  z INT,
+  INDEX foo (z, y)
+)
+
+# TODO(vivek): Use the secondary index. Use distinct in index selection.
+query TTT
+EXPLAIN SELECT DISTINCT y, z FROM xyz
+----
+group      ·            ·
+ │         aggregate 0  y
+ │         aggregate 1  z
+ │         group by     @1-@2
+ └── scan  ·            ·
+·          table        xyz@primary
+·          spans        ALL
+
+query TTT
+EXPLAIN SELECT DISTINCT y, z FROM xyz ORDER BY z
+----
+sort            ·            ·
+ │              order        +z
+ └── group      ·            ·
+      │         aggregate 0  y
+      │         aggregate 1  z
+      │         group by     @1-@2
+      └── scan  ·            ·
+·               table        xyz@primary
+·               spans        ALL
+
+query TTT
+EXPLAIN SELECT DISTINCT y, z FROM xyz ORDER BY y
+----
+sort            ·            ·
+ │              order        +y
+ └── group      ·            ·
+      │         aggregate 0  y
+      │         aggregate 1  z
+      │         group by     @1-@2
+      └── scan  ·            ·
+·               table        xyz@primary
+·               spans        ALL
+
+query TTT
+EXPLAIN SELECT DISTINCT y, z FROM xyz ORDER BY y, z
+----
+sort            ·            ·
+ │              order        +y,+z
+ └── group      ·            ·
+      │         aggregate 0  y
+      │         aggregate 1  z
+      │         group by     @1-@2
+      └── scan  ·            ·
+·               table        xyz@primary
+·               spans        ALL
+
+query TTT
+EXPLAIN SELECT DISTINCT y + z FROM xyz ORDER BY y + z
+----
+sort                 ·            ·
+ │                   order        +"y + z"
+ └── group           ·            ·
+      │              aggregate 0  y + z
+      │              group by     @1
+      └── render     ·            ·
+           └── scan  ·            ·
+·                    table        xyz@primary
+·                    spans        ALL
+
+query TTT
+EXPLAIN SELECT DISTINCT y AS w, z FROM xyz ORDER BY z
+----
+sort            ·            ·
+ │              order        +z
+ └── group      ·            ·
+      │         aggregate 0  y
+      │         aggregate 1  z
+      │         group by     @1-@2
+      └── scan  ·            ·
+·               table        xyz@primary
+·               spans        ALL
+
+query TTT
+EXPLAIN SELECT DISTINCT y AS w FROM xyz ORDER BY y
+----
+sort            ·            ·
+ │              order        +w
+ └── group      ·            ·
+      │         aggregate 0  y
+      │         group by     @1
+      └── scan  ·            ·
+·               table        xyz@primary
+·               spans        ALL
+
+query TTTTT
+EXPLAIN (VERBOSE) SELECT DISTINCT x FROM xyz
+----
+scan  ·      ·            (x)  ·
+·     table  xyz@primary  ·    ·
+·     spans  ALL          ·    ·
+
+query TTTTT
+EXPLAIN (VERBOSE) SELECT DISTINCT x, y, z FROM xyz
+----
+scan  ·      ·            (x, y, z)  ·
+·     table  xyz@primary  ·          ·
+·     spans  ALL          ·          ·
+
+statement ok
+CREATE TABLE abcd (
+  a INT,
+  b INT,
+  c INT,
+  d INT NOT NULL,
+  PRIMARY KEY (a, b, c),
+  UNIQUE INDEX (d, b)
+)
+
+query TTTTT
+EXPLAIN (VERBOSE) SELECT DISTINCT 1, d, b FROM abcd ORDER BY d, b
+----
+render     ·         ·                  ("1", d, b)  ·
+ │         render 0  1                  ·            ·
+ │         render 1  d                  ·            ·
+ │         render 2  b                  ·            ·
+ └── scan  ·         ·                  (b, d)       +d,+b
+·          table     abcd@abcd_d_b_key  ·            ·
+·          spans     ALL                ·            ·
+
+query TTTTT
+EXPLAIN (VERBOSE) SELECT DISTINCT a, b FROM abcd
+----
+group      ·            ·             (a, b)  ·
+ │         aggregate 0  a             ·       ·
+ │         aggregate 1  b             ·       ·
+ │         group by     @1-@2         ·       ·
+ └── scan  ·            ·             (a, b)  ·
+·          table        abcd@primary  ·       ·
+·          spans        ALL           ·       ·
+
+query TTTTT
+EXPLAIN (VERBOSE) SELECT DISTINCT a, b, c FROM abcd
+----
+scan  ·      ·             (a, b, c)  ·
+·     table  abcd@primary  ·          ·
+·     spans  ALL           ·          ·
+
+query TTTTT
+EXPLAIN (VERBOSE) SELECT DISTINCT a, b, c, d FROM abcd
+----
+scan  ·      ·             (a, b, c, d)  ·
+·     table  abcd@primary  ·             ·
+·     spans  ALL           ·             ·
+
+statement ok
+CREATE TABLE kv (k INT PRIMARY KEY, v INT, UNIQUE INDEX idx(v))
+
+query TTTTT
+EXPLAIN (VERBOSE) SELECT DISTINCT v FROM kv
+----
+group      ·            ·           (v)  ·
+ │         aggregate 0  v           ·    ·
+ │         group by     @1          ·    ·
+ └── scan  ·            ·           (v)  ·
+·          table        kv@primary  ·    ·
+·          spans        ALL         ·    ·
+
+# Verify we don't incorrectly elide the distinct node when we only have a weak key (#19343).
+# TODO(radu) re-enable once we support index hints
+#query TTTTT
+#EXPLAIN (VERBOSE) SELECT DISTINCT v FROM kv@idx
+#----
+#Tree            Field      Description       Columns          Ordering
+#distinct        ·          ·                 (v)              weak-key(v); +v
+# │              order key  v                 ·                ·
+# └── render     ·          ·                 (v)              weak-key(v); +v
+#      │         render 0   test.public.kv.v  ·                ·
+#      └── scan  ·          ·                 (k[omitted], v)  weak-key(v); +v
+#·               table      kv@idx            ·                ·
+#·               spans      ALL               ·                ·
+#
+## Here we can infer that v is not-NULL so eliding the node is correct.
+#query TTTTT
+#EXPLAIN (VERBOSE) SELECT DISTINCT v FROM kv@idx WHERE v > 0
+#----
+#Tree       Field     Description       Columns          Ordering
+#render     ·         ·                 (v)              v!=NULL; key(v)
+# │         render 0  test.public.kv.v  ·                ·
+# └── scan  ·         ·                 (k[omitted], v)  v!=NULL; key(v)
+#·          table     kv@idx            ·                ·
+#·          spans     /1-               ·                ·
+#
+#statement ok
+#CREATE TABLE kv2 (k INT PRIMARY KEY, v INT NOT NULL, UNIQUE INDEX idx(v))
+#
+## In this case it is correct to elide the distinct node.
+#query TTTTT
+#EXPLAIN (VERBOSE) SELECT DISTINCT v FROM kv2@idx
+#----
+#Tree       Field     Description        Columns          Ordering
+#render     ·         ·                  (v)              v!=NULL; key(v)
+# │         render 0  test.public.kv2.v  ·                ·
+# └── scan  ·         ·                  (k[omitted], v)  v!=NULL; key(v)
+#·          table     kv2@idx            ·                ·
+#·          spans     ALL                ·                ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/distinct_on
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distinct_on
@@ -1,0 +1,467 @@
+# LogicTest: opt
+
+# TODO(radu): Enable tests once we support DISTINCT ON.
+#statement ok
+#CREATE TABLE xyz (
+#  x INT,
+#  y INT,
+#  z INT,
+#  pk1 INT,
+#  pk2 INT,
+#  PRIMARY KEY (pk1, pk2)
+#)
+#
+#statement ok
+#CREATE TABLE abc (
+#  a STRING,
+#  b STRING,
+#  c STRING,
+#  PRIMARY KEY (a, b, c)
+#)
+#
+###################
+## Simple queries #
+###################
+#
+## 3/3 columns
+#
+#query TTTTT
+#EXPLAIN (VERBOSE) SELECT DISTINCT ON (x, y, z) x, y, z FROM xyz
+#----
+#distinct        ·            ·                  (x, y, z)                              weak-key(x,y,z)
+# │              distinct on  x, y, z            ·                                      ·
+# └── render     ·            ·                  (x, y, z)                              ·
+#      │         render 0     test.public.xyz.x  ·                                      ·
+#      │         render 1     test.public.xyz.y  ·                                      ·
+#      │         render 2     test.public.xyz.z  ·                                      ·
+#      └── scan  ·            ·                  (x, y, z, pk1[omitted], pk2[omitted])  pk1!=NULL; pk2!=NULL; key(pk1,pk2)
+#·               table        xyz@primary        ·                                      ·
+#·               spans        ALL                ·                                      ·
+#
+#query TTTTT
+#EXPLAIN (VERBOSE) SELECT DISTINCT ON (z, x, y) x FROM xyz
+#----
+#render               ·            ·                  (x)                                    ·
+# │                   render 0     x                  ·                                      ·
+# └── distinct        ·            ·                  (x, z, y)                              weak-key(x,z,y)
+#      │              distinct on  x, z, y            ·                                      ·
+#      └── render     ·            ·                  (x, z, y)                              ·
+#           │         render 0     test.public.xyz.x  ·                                      ·
+#           │         render 1     test.public.xyz.z  ·                                      ·
+#           │         render 2     test.public.xyz.y  ·                                      ·
+#           └── scan  ·            ·                  (x, y, z, pk1[omitted], pk2[omitted])  pk1!=NULL; pk2!=NULL; key(pk1,pk2)
+#·                    table        xyz@primary        ·                                      ·
+#·                    spans        ALL                ·                                      ·
+#
+#query TTTTT
+#EXPLAIN (VERBOSE) SELECT DISTINCT ON (b, c, a) a, c, b FROM abc
+#----
+#render     ·         ·                  (a, c, b)  a!=NULL; c!=NULL; b!=NULL; key(a,c,b)
+# │         render 0  test.public.abc.a  ·          ·
+# │         render 1  test.public.abc.c  ·          ·
+# │         render 2  test.public.abc.b  ·          ·
+# └── scan  ·         ·                  (a, b, c)  a!=NULL; b!=NULL; c!=NULL; key(a,b,c)
+#·          table     abc@primary        ·          ·
+#·          spans     ALL                ·          ·
+#
+## Distinct node should be elided since we have a strong key.
+#query TTTTT
+#EXPLAIN (VERBOSE) SELECT DISTINCT ON (b, c, a) a FROM abc
+#----
+#render     ·         ·            (a)        a!=NULL
+# │         render 0  a            ·          ·
+# └── scan  ·         ·            (a, b, c)  a!=NULL; b!=NULL; c!=NULL; key(a,b,c)
+#·          table     abc@primary  ·          ·
+#·          spans     ALL          ·          ·
+#
+## Distinct node should be elided since we have a strong key.
+#query TTTTT
+#EXPLAIN (VERBOSE) SELECT DISTINCT ON (c, a, b) b FROM abc ORDER BY b
+#----
+#render               ·         ·                  (b)                          b!=NULL; +b
+# │                   render 0  b                  ·                            ·
+# └── sort            ·         ·                  (b, c[omitted], a[omitted])  b!=NULL; c!=NULL; a!=NULL; key(b,c,a); +b
+#      │              order     +b                 ·                            ·
+#      └── render     ·         ·                  (b, c[omitted], a[omitted])  b!=NULL; c!=NULL; a!=NULL; key(b,c,a)
+#           │         render 0  test.public.abc.b  ·                            ·
+#           │         render 1  NULL               ·                            ·
+#           │         render 2  NULL               ·                            ·
+#           └── scan  ·         ·                  (a[omitted], b, c[omitted])  a!=NULL; b!=NULL; c!=NULL; key(a,b,c)
+#·                    table     abc@primary        ·                            ·
+#·                    spans     ALL                ·                            ·
+#
+#
+## 2/3 columns
+#
+#query TTTTT
+#EXPLAIN (VERBOSE) SELECT DISTINCT ON (x, y) y, x FROM xyz
+#----
+#distinct        ·            ·                  (y, x)                                          weak-key(y,x)
+# │              distinct on  y, x               ·                                               ·
+# └── render     ·            ·                  (y, x)                                          ·
+#      │         render 0     test.public.xyz.y  ·                                               ·
+#      │         render 1     test.public.xyz.x  ·                                               ·
+#      └── scan  ·            ·                  (x, y, z[omitted], pk1[omitted], pk2[omitted])  pk1!=NULL; pk2!=NULL; key(pk1,pk2)
+#·               table        xyz@primary        ·                                               ·
+#·               spans        ALL                ·                                               ·
+#
+#query TTTTT
+#EXPLAIN (VERBOSE) SELECT DISTINCT ON (y, x) x FROM xyz
+#----
+#render               ·            ·                  (x)                                             ·
+# │                   render 0     x                  ·                                               ·
+# └── distinct        ·            ·                  (x, y)                                          weak-key(x,y)
+#      │              distinct on  x, y               ·                                               ·
+#      └── render     ·            ·                  (x, y)                                          ·
+#           │         render 0     test.public.xyz.x  ·                                               ·
+#           │         render 1     test.public.xyz.y  ·                                               ·
+#           └── scan  ·            ·                  (x, y, z[omitted], pk1[omitted], pk2[omitted])  pk1!=NULL; pk2!=NULL; key(pk1,pk2)
+#·                    table        xyz@primary        ·                                               ·
+#·                    spans        ALL                ·                                               ·
+#
+#query TTTTT
+#EXPLAIN (VERBOSE) SELECT DISTINCT ON (y, x, x, y, x) x, y FROM xyz
+#----
+#distinct        ·            ·                  (x, y)                                          weak-key(x,y)
+# │              distinct on  x, y               ·                                               ·
+# └── render     ·            ·                  (x, y)                                          ·
+#      │         render 0     test.public.xyz.x  ·                                               ·
+#      │         render 1     test.public.xyz.y  ·                                               ·
+#      └── scan  ·            ·                  (x, y, z[omitted], pk1[omitted], pk2[omitted])  pk1!=NULL; pk2!=NULL; key(pk1,pk2)
+#·               table        xyz@primary        ·                                               ·
+#·               spans        ALL                ·                                               ·
+#
+#query TTTTT
+#EXPLAIN (VERBOSE) SELECT DISTINCT ON(pk1, x) pk1, x FROM xyz ORDER BY pk1
+#----
+#distinct        ·            ·                    (pk1, x)                                        pk1!=NULL; weak-key(pk1,x); +pk1
+# │              distinct on  pk1, x               ·                                               ·
+# │              order key    pk1                  ·                                               ·
+# └── render     ·            ·                    (pk1, x)                                        pk1!=NULL; +pk1
+#      │         render 0     test.public.xyz.pk1  ·                                               ·
+#      │         render 1     test.public.xyz.x    ·                                               ·
+#      └── scan  ·            ·                    (x, y[omitted], z[omitted], pk1, pk2[omitted])  pk1!=NULL; pk2!=NULL; key(pk1,pk2); +pk1
+#·               table        xyz@primary          ·                                               ·
+#·               spans        ALL                  ·                                               ·
+#
+#query TTTTT
+#EXPLAIN (VERBOSE) SELECT DISTINCT ON (a, c) a, b FROM abc
+#----
+#render          ·            ·            (a, b)     a!=NULL; b!=NULL; +a
+# │              render 0     a            ·          ·
+# │              render 1     b            ·          ·
+# └── distinct   ·            ·            (a, b, c)  a!=NULL; b!=NULL; c!=NULL; key(a,c); +a
+#      │         distinct on  a, c         ·          ·
+#      │         order key    a            ·          ·
+#      └── scan  ·            ·            (a, b, c)  a!=NULL; b!=NULL; c!=NULL; key(a,b,c); +a
+#·               table        abc@primary  ·          ·
+#·               spans        ALL          ·          ·
+#
+#query TTTTT
+#EXPLAIN (VERBOSE) SELECT DISTINCT ON (c, a) b, c, a FROM abc
+#----
+#distinct        ·            ·                  (b, c, a)  b!=NULL; c!=NULL; a!=NULL; key(c,a); +a
+# │              distinct on  c, a               ·          ·
+# │              order key    a                  ·          ·
+# └── render     ·            ·                  (b, c, a)  b!=NULL; c!=NULL; a!=NULL; key(b,c,a); +a
+#      │         render 0     test.public.abc.b  ·          ·
+#      │         render 1     test.public.abc.c  ·          ·
+#      │         render 2     test.public.abc.a  ·          ·
+#      └── scan  ·            ·                  (a, b, c)  a!=NULL; b!=NULL; c!=NULL; key(a,b,c); +a
+#·               table        abc@primary        ·          ·
+#·               spans        ALL                ·          ·
+#
+#
+## 1/3 columns
+#
+## Check that distinct propagates the smaller, tighter key (pk1) as opposed to
+## the original key (pk1, pk2).
+#query TTTTT
+#EXPLAIN (VERBOSE) SELECT DISTINCT ON (pk1) pk1, pk2 FROM xyz
+#----
+#distinct        ·            ·                    (pk1, pk2)                                      pk1!=NULL; pk2!=NULL; key(pk1); +pk1
+# │              distinct on  pk1                  ·                                               ·
+# │              order key    pk1                  ·                                               ·
+# └── render     ·            ·                    (pk1, pk2)                                      pk1!=NULL; pk2!=NULL; key(pk1,pk2); +pk1
+#      │         render 0     test.public.xyz.pk1  ·                                               ·
+#      │         render 1     test.public.xyz.pk2  ·                                               ·
+#      └── scan  ·            ·                    (x[omitted], y[omitted], z[omitted], pk1, pk2)  pk1!=NULL; pk2!=NULL; key(pk1,pk2); +pk1
+#·               table        xyz@primary          ·                                               ·
+#·               spans        ALL                  ·                                               ·
+#
+## Ensure order simplification on DISTINCT ON columns does not simplifying out
+## an explicit order from ORDER BY.
+## Note that the -c ordering was reduced after the distinct: this is because
+## we have a strong key on 'a' so ordering after '+a' is unnecessary.
+#query TTTTT
+#EXPLAIN (VERBOSE) SELECT DISTINCT ON (a) a, c FROM abc ORDER BY a, c DESC, b
+#----
+#distinct             ·            ·                  (a, c)     a!=NULL; c!=NULL; key(a); +a
+# │                   distinct on  a                  ·          ·
+# │                   order key    a                  ·          ·
+# └── sort            ·            ·                  (a, c)     a!=NULL; c!=NULL; +a,-c
+#      │              order        +a,-c,+b           ·          ·
+#      └── render     ·            ·                  (a, c, b)  a!=NULL; c!=NULL; b!=NULL; key(a,c,b); +a
+#           │         render 0     test.public.abc.a  ·          ·
+#           │         render 1     test.public.abc.c  ·          ·
+#           │         render 2     test.public.abc.b  ·          ·
+#           └── scan  ·            ·                  (a, b, c)  a!=NULL; b!=NULL; c!=NULL; key(a,b,c); +a
+#·                    table        abc@primary        ·          ·
+#·                    spans        ALL                ·          ·
+#
+##################
+## With ORDER BY #
+##################
+#
+#query TTTTT
+#EXPLAIN (VERBOSE) SELECT DISTINCT ON (x) x FROM xyz ORDER BY x DESC
+#----
+#distinct             ·            ·                  (x)                                                      weak-key(x); -x
+# │                   distinct on  x                  ·                                                        ·
+# │                   order key    x                  ·                                                        ·
+# └── sort            ·            ·                  (x)                                                      -x
+#      │              order        -x                 ·                                                        ·
+#      └── render     ·            ·                  (x)                                                      ·
+#           │         render 0     test.public.xyz.x  ·                                                        ·
+#           └── scan  ·            ·                  (x, y[omitted], z[omitted], pk1[omitted], pk2[omitted])  pk1!=NULL; pk2!=NULL; key(pk1,pk2)
+#·                    table        xyz@primary        ·                                                        ·
+#·                    spans        ALL                ·                                                        ·
+#
+#query TTTTT
+#EXPLAIN (VERBOSE) SELECT DISTINCT ON (x, z) y, z, x FROM xyz ORDER BY z
+#----
+#distinct             ·            ·                  (y, z, x)                              weak-key(z,x); +z
+# │                   distinct on  z, x               ·                                      ·
+# │                   order key    z                  ·                                      ·
+# └── sort            ·            ·                  (y, z, x)                              +z
+#      │              order        +z                 ·                                      ·
+#      └── render     ·            ·                  (y, z, x)                              ·
+#           │         render 0     test.public.xyz.y  ·                                      ·
+#           │         render 1     test.public.xyz.z  ·                                      ·
+#           │         render 2     test.public.xyz.x  ·                                      ·
+#           └── scan  ·            ·                  (x, y, z, pk1[omitted], pk2[omitted])  pk1!=NULL; pk2!=NULL; key(pk1,pk2)
+#·                    table        xyz@primary        ·                                      ·
+#·                    spans        ALL                ·                                      ·
+#
+#query TTTTT
+#EXPLAIN (VERBOSE) SELECT DISTINCT ON (x) y, z, x FROM xyz ORDER BY x ASC, z DESC, y DESC
+#----
+#distinct             ·            ·                  (y, z, x)                              weak-key(x); +x,-z,-y
+# │                   distinct on  x                  ·                                      ·
+# │                   order key    x                  ·                                      ·
+# └── sort            ·            ·                  (y, z, x)                              +x,-z,-y
+#      │              order        +x,-z,-y           ·                                      ·
+#      └── render     ·            ·                  (y, z, x)                              ·
+#           │         render 0     test.public.xyz.y  ·                                      ·
+#           │         render 1     test.public.xyz.z  ·                                      ·
+#           │         render 2     test.public.xyz.x  ·                                      ·
+#           └── scan  ·            ·                  (x, y, z, pk1[omitted], pk2[omitted])  pk1!=NULL; pk2!=NULL; key(pk1,pk2)
+#·                    table        xyz@primary        ·                                      ·
+#·                    spans        ALL                ·                                      ·
+#
+######################
+## With aggregations #
+######################
+#
+#query TTTTT
+#EXPLAIN (VERBOSE) SELECT DISTINCT ON (MAX(y)) MAX(x) FROM xyz
+#----
+#render                    ·            ·                  (max)                                           ·
+# │                        render 0     max                ·                                               ·
+# └── distinct             ·            ·                  (max, max)                                      weak-key(max)
+#      │                   distinct on  max                ·                                               ·
+#      └── group           ·            ·                  (max, max)                                      ·
+#           │              aggregate 0  max(x)             ·                                               ·
+#           │              aggregate 1  max(y)             ·                                               ·
+#           └── render     ·            ·                  (x, y)                                          ·
+#                │         render 0     test.public.xyz.x  ·                                               ·
+#                │         render 1     test.public.xyz.y  ·                                               ·
+#                └── scan  ·            ·                  (x, y, z[omitted], pk1[omitted], pk2[omitted])  pk1!=NULL; pk2!=NULL; key(pk1,pk2)
+#·                         table        xyz@primary        ·                                               ·
+#·                         spans        ALL                ·                                               ·
+#
+#query TTTTT
+#EXPLAIN (VERBOSE) SELECT DISTINCT ON(MIN(a), MAX(b), MIN(c)) MAX(a) FROM abc
+#----
+#render               ·            ·              (max)                 ·
+# │                   render 0     max            ·                     ·
+# └── distinct        ·            ·              (max, min, max, min)  weak-key(min,max,min)
+#      │              distinct on  min, max, min  ·                     ·
+#      └── group      ·            ·              (max, min, max, min)  ·
+#           │         aggregate 0  max(a)         ·                     ·
+#           │         aggregate 1  min(a)         ·                     ·
+#           │         aggregate 2  max(b)         ·                     ·
+#           │         aggregate 3  min(c)         ·                     ·
+#           └── scan  ·            ·              (a, b, c)             a!=NULL; b!=NULL; c!=NULL; key(a,b,c)
+#·                    table        abc@primary    ·                     ·
+#·                    spans        ALL            ·                     ·
+#
+##################
+## With GROUP BY #
+##################
+#
+## TODO(richardwu): we can elide the DISTINCT ON since its key is equivalent
+## to the group key.
+#query TTTTT
+#EXPLAIN (VERBOSE) SELECT DISTINCT ON(y) MIN(x) FROM xyz GROUP BY y
+#----
+#render                    ·            ·                  (min)                                           ·
+# │                        render 0     min                ·                                               ·
+# └── distinct             ·            ·                  (min, y)                                        weak-key(y)
+#      │                   distinct on  y                  ·                                               ·
+#      └── group           ·            ·                  (min, y)                                        weak-key(y)
+#           │              aggregate 0  min(x)             ·                                               ·
+#           │              aggregate 1  y                  ·                                               ·
+#           │              group by     @1                 ·                                               ·
+#           └── render     ·            ·                  (y, x)                                          ·
+#                │         render 0     test.public.xyz.y  ·                                               ·
+#                │         render 1     test.public.xyz.x  ·                                               ·
+#                └── scan  ·            ·                  (x, y, z[omitted], pk1[omitted], pk2[omitted])  pk1!=NULL; pk2!=NULL; key(pk1,pk2)
+#·                         table        xyz@primary        ·                                               ·
+#·                         spans        ALL                ·                                               ·
+#
+#query TTTTT
+#EXPLAIN (VERBOSE) SELECT DISTINCT ON(MIN(x)) MIN(x) FROM xyz GROUP BY y HAVING MIN(x) = 1
+#----
+#distinct                  ·            ·                  (min)                                           min=CONST; key()
+# │                        distinct on  min                ·                                               ·
+# └── filter               ·            ·                  (min)                                           min=CONST
+#      │                   filter       agg0 = 1           ·                                               ·
+#      └── group           ·            ·                  (min)                                           ·
+#           │              aggregate 0  min(x)             ·                                               ·
+#           │              group by     @1                 ·                                               ·
+#           └── render     ·            ·                  (y, x)                                          ·
+#                │         render 0     test.public.xyz.y  ·                                               ·
+#                │         render 1     test.public.xyz.x  ·                                               ·
+#                └── scan  ·            ·                  (x, y, z[omitted], pk1[omitted], pk2[omitted])  pk1!=NULL; pk2!=NULL; key(pk1,pk2)
+#·                         table        xyz@primary        ·                                               ·
+#·                         spans        ALL                ·                                               ·
+#
+##########################
+## With window functions #
+##########################
+#
+#query TTTTT
+#EXPLAIN (VERBOSE) SELECT DISTINCT ON(row_number() OVER()) y FROM xyz
+#----
+#render                    ·            ·                     (y)                                                      ·
+# │                        render 0     y                     ·                                                        ·
+# └── distinct             ·            ·                     (y, row_number)                                          weak-key(row_number)
+#      │                   distinct on  row_number            ·                                                        ·
+#      └── window          ·            ·                     (y, row_number)                                          ·
+#           │              window 0     row_number() OVER ()  ·                                                        ·
+#           │              render 1     row_number() OVER ()  ·                                                        ·
+#           └── render     ·            ·                     (y)                                                      ·
+#                │         render 0     test.public.xyz.y     ·                                                        ·
+#                └── scan  ·            ·                     (x[omitted], y, z[omitted], pk1[omitted], pk2[omitted])  pk1!=NULL; pk2!=NULL; key(pk1,pk2)
+#·                         table        xyz@primary           ·                                                        ·
+#·                         spans        ALL                   ·                                                        ·
+#
+############################
+## With ordinal references #
+############################
+#
+#query TTTTT
+#EXPLAIN (VERBOSE) SELECT DISTINCT ON (1) x, y, z FROM xyz
+#----
+#distinct        ·            ·                  (x, y, z)                              weak-key(x)
+# │              distinct on  x                  ·                                      ·
+# └── render     ·            ·                  (x, y, z)                              ·
+#      │         render 0     test.public.xyz.x  ·                                      ·
+#      │         render 1     test.public.xyz.y  ·                                      ·
+#      │         render 2     test.public.xyz.z  ·                                      ·
+#      └── scan  ·            ·                  (x, y, z, pk1[omitted], pk2[omitted])  pk1!=NULL; pk2!=NULL; key(pk1,pk2)
+#·               table        xyz@primary        ·                                      ·
+#·               spans        ALL                ·                                      ·
+#
+## Distinct node elided because of strong key.
+#query TTTTT
+#EXPLAIN (VERBOSE) SELECT DISTINCT ON (1,2,3) a, b, c FROM abc
+#----
+#scan  ·      ·            (a, b, c)  a!=NULL; b!=NULL; c!=NULL; key(a,b,c)
+#·     table  abc@primary  ·          ·
+#·     spans  ALL          ·          ·
+#
+##########################
+## With alias references #
+##########################
+#
+## This should priortize alias (use 'x' as the key).
+#query TTTTT
+#EXPLAIN (VERBOSE) SELECT DISTINCT ON(y) x AS y, y AS x FROM xyz
+#----
+#distinct        ·            ·                  (y, x)                                          weak-key(y)
+# │              distinct on  y                  ·                                               ·
+# └── render     ·            ·                  (y, x)                                          ·
+#      │         render 0     test.public.xyz.x  ·                                               ·
+#      │         render 1     test.public.xyz.y  ·                                               ·
+#      └── scan  ·            ·                  (x, y, z[omitted], pk1[omitted], pk2[omitted])  pk1!=NULL; pk2!=NULL; key(pk1,pk2)
+#·               table        xyz@primary        ·                                               ·
+#·               spans        ALL                ·                                               ·
+#
+## Ignores the alias.
+#query TTTTT
+#EXPLAIN (VERBOSE) SELECT DISTINCT ON(x) x AS y FROM xyz
+#----
+#distinct        ·            ·                  (y)                                                      weak-key(y)
+# │              distinct on  y                  ·                                                        ·
+# └── render     ·            ·                  (y)                                                      ·
+#      │         render 0     test.public.xyz.x  ·                                                        ·
+#      └── scan  ·            ·                  (x, y[omitted], z[omitted], pk1[omitted], pk2[omitted])  pk1!=NULL; pk2!=NULL; key(pk1,pk2)
+#·               table        xyz@primary        ·                                                        ·
+#·               spans        ALL                ·                                                        ·
+#
+###################################
+## With nested parentheses/tuples #
+###################################
+#
+#query TTTTT
+#EXPLAIN (VERBOSE) SELECT DISTINCT ON(((x)), (x, y)) x, y FROM xyz
+#----
+#distinct        ·            ·                  (x, y)                                          weak-key(x,y)
+# │              distinct on  x, y               ·                                               ·
+# └── render     ·            ·                  (x, y)                                          ·
+#      │         render 0     test.public.xyz.x  ·                                               ·
+#      │         render 1     test.public.xyz.y  ·                                               ·
+#      └── scan  ·            ·                  (x, y, z[omitted], pk1[omitted], pk2[omitted])  pk1!=NULL; pk2!=NULL; key(pk1,pk2)
+#·               table        xyz@primary        ·                                               ·
+#·               spans        ALL                ·                                               ·
+#
+#################################
+## Hybrid PK and non-PK queries #
+#################################
+#
+## Distinct elided because of strong key presence.
+#query TTTTT
+#EXPLAIN (VERBOSE) SELECT DISTINCT ON(pk1, pk2, x, y) x, y, z FROM xyz ORDER BY x, y
+#----
+#render          ·         ·            (x, y, z)                              +x,+y
+# │              render 0  x            ·                                      ·
+# │              render 1  y            ·                                      ·
+# │              render 2  z            ·                                      ·
+# └── sort       ·         ·            (x, y, z, pk1[omitted], pk2[omitted])  pk1!=NULL; pk2!=NULL; key(pk1,pk2); +x,+y
+#      │         order     +x,+y        ·                                      ·
+#      └── scan  ·         ·            (x, y, z, pk1[omitted], pk2[omitted])  pk1!=NULL; pk2!=NULL; key(pk1,pk2)
+#·               table     xyz@primary  ·                                      ·
+#·               spans     ALL          ·                                      ·
+#
+## Ordering only propagates up until distinctNode.
+## pk1 ordering does not propagate at all since it's not explicitly needed.
+#query TTTTT
+#EXPLAIN (VERBOSE) SELECT DISTINCT ON (x, y, z) pk1 FROM xyz ORDER BY x
+#----
+#render                    ·            ·                    (pk1)                         pk1!=NULL
+# │                        render 0     pk1                  ·                             ·
+# └── distinct             ·            ·                    (pk1, x, y, z)                pk1!=NULL; weak-key(x,y,z); +x
+#      │                   distinct on  x, y, z              ·                             ·
+#      │                   order key    x                    ·                             ·
+#      └── sort            ·            ·                    (pk1, x, y, z)                pk1!=NULL; +x
+#           │              order        +x                   ·                             ·
+#           └── render     ·            ·                    (pk1, x, y, z)                pk1!=NULL
+#                │         render 0     test.public.xyz.pk1  ·                             ·
+#                │         render 1     test.public.xyz.x    ·                             ·
+#                │         render 2     test.public.xyz.y    ·                             ·
+#                │         render 3     test.public.xyz.z    ·                             ·
+#                └── scan  ·            ·                    (x, y, z, pk1, pk2[omitted])  pk1!=NULL; pk2!=NULL; key(pk1,pk2)
+#·                         table        xyz@primary          ·                             ·
+#·                         spans        ALL                  ·                             ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/interleaved
+++ b/pkg/sql/opt/exec/execbuilder/testdata/interleaved
@@ -1,0 +1,137 @@
+# LogicTest: opt
+
+# ------------------------------------------------------------------------------
+# Test index selection for deeply interleaved tables.
+# These tests are in their own file because table IDs appear in EXPLAIN output.
+# ------------------------------------------------------------------------------
+statement ok
+CREATE TABLE level1 (
+  k1 INT,
+  PRIMARY KEY (k1)
+)
+
+statement ok
+CREATE TABLE level2 (
+  k1 INT,
+  PRIMARY KEY (k1),
+  CONSTRAINT fk1 FOREIGN KEY (k1) REFERENCES level1
+) INTERLEAVE IN PARENT level1 (k1)
+
+statement ok
+CREATE TABLE level3 (
+  k1 INT,
+  k2 INT,
+  k3 INT,
+  PRIMARY KEY (k1, k2, k3),
+  CONSTRAINT fk2 FOREIGN KEY (k1) REFERENCES level2
+) INTERLEAVE IN PARENT level2 (k1)
+
+statement ok
+CREATE TABLE level4 (
+  k1 INT,
+  k2 INT,
+  k3 INT,
+  PRIMARY KEY (k1, k2, k3),
+  CONSTRAINT fk3 FOREIGN KEY (k1, k2, k3) REFERENCES level3
+) INTERLEAVE IN PARENT level3 (k1, k2, k3)
+
+query TTT
+EXPLAIN SELECT * FROM level4
+----
+scan  ·      ·
+·     table  level4@primary
+·     spans  ALL
+
+# The span below ends at the end of the first index of table 53, and is not
+# constraining the value of k2 or k3. This is confusing on first glance because
+# the second interleave in the hierarchy doesn't contain any new primary key
+# columns on top of the first interleave.
+query TTT
+EXPLAIN SELECT * FROM level4 WHERE k1 > 1 AND k1 < 3
+----
+scan  ·      ·
+·     table  level4@primary
+·     spans  /2/#/54/1/#/55/1-/2/#/54/1/#/55/2
+
+query TTT
+EXPLAIN SELECT * FROM level4 WHERE k1 = 2 AND k2 > 10 AND k2 < 30
+----
+scan  ·      ·
+·     table  level4@primary
+·     spans  /2/#/54/1/#/55/1/11-/2/#/54/1/#/55/1/30
+
+query TTT
+EXPLAIN SELECT * FROM level4 WHERE k1 = 2 AND k2 = 20 AND k3 > 100 AND k3 < 300
+----
+scan  ·      ·
+·     table  level4@primary
+·     spans  /2/#/54/1/#/55/1/20/101/#/56/1-/2/#/54/1/#/55/1/20/299/#/56/1/#
+
+query TTT
+EXPLAIN SELECT * FROM level4 WHERE k1 = 2 AND k2 = 20 AND k3 = 200
+----
+scan  ·      ·
+·     table  level4@primary
+·     spans  /2/#/54/1/#/55/1/20/200/#/56/1-/2/#/54/1/#/55/1/20/200/#/56/1/#
+
+# ------------------------------------------------------------------------------
+# Trace of interleaved fetches from interesting interleaved hierarchy.
+# ------------------------------------------------------------------------------
+# Grandparent table
+statement ok
+CREATE TABLE p2 (i INT PRIMARY KEY, s STRING)
+
+# Two tables interleaved at the same level
+statement ok
+CREATE TABLE p1_0 (
+  i INT,
+  s1 STRING,
+  s2 STRING,
+  d DECIMAL,
+  PRIMARY KEY (i, s1),
+  FAMILY (i, s1, s2),
+  FAMILY (d)
+) INTERLEAVE IN PARENT p2 (i)
+
+statement ok
+CREATE TABLE p1_1 (
+  i INT PRIMARY KEY,
+  s1 STRING,
+  s2 STRING,
+  d DECIMAL
+) INTERLEAVE IN PARENT p2 (i)
+
+# Two level deep interleave
+statement ok
+CREATE TABLE p0 (
+  i INT,
+  s1 STRING,
+  s2 STRING,
+  d DECIMAL,
+  PRIMARY KEY (i, s1, s2)
+) INTERLEAVE IN PARENT p1_0 (i, s1)
+
+statement ok
+INSERT INTO p2 VALUES (2, '2'), (3, '3'), (5, '5'), (7, '7')
+
+statement ok
+INSERT INTO p1_0 VALUES (2, '2', '2.01', 2), (3, '3', '3.01', 3), (5, '5', NULL, NULL)
+
+statement ok
+INSERT INTO p1_1 VALUES (2, '2', '2.11', 2), (3, '3', '3.11', 3)
+
+statement ok
+INSERT INTO p0 VALUES (2, '2', '2.0', 2), (3, '3', '3.0', 3), (5, '5', '5.0', 5)
+
+query T
+SELECT message FROM [SHOW KV TRACE FOR SELECT * FROM p1_0]
+ WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
+----
+fetched: /p1_0/primary/2/'2'/s2 -> /'2.01'
+fetched: /p1_0/primary/2/'2'/d -> 2
+output row: [2 '2' '2.01' 2]
+fetched: /p1_0/primary/3/'3'/s2 -> /'3.01'
+fetched: /p1_0/primary/3/'3'/d -> 3
+output row: [3 '3' '3.01' 3]
+fetched: /p1_0/primary/5/'5' -> NULL
+output row: [5 '5' NULL NULL]

--- a/pkg/sql/opt/exec/execbuilder/testdata/inverted_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/inverted_index
@@ -1,0 +1,185 @@
+# LogicTest: opt
+
+# TODO(radu): enable once we support inverted indexes
+#
+#statement ok
+#CREATE TABLE d (
+#  a INT PRIMARY KEY,
+#  b JSONB
+#)
+#
+#statement ok
+#CREATE INVERTED INDEX foo_inv ON d(b)
+#
+#query TTTTT
+#EXPLAIN (VERBOSE) SELECT * from d where b @>'{"a": "b"}'
+#----
+#index-join  ·      ·                            (a, b)           b=CONST; a!=NULL; key(a)
+# ├── scan   ·      ·                            (a, b[omitted])  b=CONST; a!=NULL; key(a)
+# │          table  d@foo_inv                    ·                ·
+# │          spans  /"a"/"b"-/"a"/"b"/PrefixEnd  ·                ·
+# └── scan   ·      ·                            (a, b)           ·
+#·           table  d@primary                    ·                ·
+#
+#query TTTTT
+#EXPLAIN (VERBOSE) SELECT * from d where b @>'{"a": {"b": [1]}}'
+#----
+#index-join  ·      ·                                        (a, b)           b=CONST; a!=NULL; key(a)
+# ├── scan   ·      ·                                        (a, b[omitted])  b=CONST; a!=NULL; key(a)
+# │          table  d@foo_inv                                ·                ·
+# │          spans  /"a"/"b"/Arr/1-/"a"/"b"/Arr/1/PrefixEnd  ·                ·
+# └── scan   ·      ·                                        (a, b)           ·
+#·           table  d@primary                                ·                ·
+#
+#query TTTTT
+#EXPLAIN (VERBOSE) SELECT * from d where b @> '{"a": {"b": [[2]]}}';
+#----
+#index-join  ·      ·                                                (a, b)           b=CONST; a!=NULL; key(a)
+# ├── scan   ·      ·                                                (a, b[omitted])  b=CONST; a!=NULL; key(a)
+# │          table  d@foo_inv                                        ·                ·
+# │          spans  /"a"/"b"/Arr/Arr/2-/"a"/"b"/Arr/Arr/2/PrefixEnd  ·                ·
+# └── scan   ·      ·                                                (a, b)           ·
+#·           table  d@primary                                        ·                ·
+#
+#query TTTTT
+#EXPLAIN (VERBOSE) SELECT * from d where b @> '{"a": {"b":true}}';
+#----
+#index-join  ·      ·                             (a, b)           b=CONST; a!=NULL; key(a)
+# ├── scan   ·      ·                             (a, b[omitted])  b=CONST; a!=NULL; key(a)
+# │          table  d@foo_inv                     ·                ·
+# │          spans  /"a"/"b"/True-/"a"/"b"/False  ·                ·
+# └── scan   ·      ·                             (a, b)           ·
+#·           table  d@primary                     ·                ·
+#
+#query TTTTT
+#EXPLAIN (VERBOSE) SELECT * from d where b @>'[1]'
+#----
+#index-join  ·      ·                        (a, b)           b=CONST; a!=NULL; key(a)
+# ├── scan   ·      ·                        (a, b[omitted])  b=CONST; a!=NULL; key(a)
+# │          table  d@foo_inv                ·                ·
+# │          spans  /Arr/1-/Arr/1/PrefixEnd  ·                ·
+# └── scan   ·      ·                        (a, b)           ·
+#·           table  d@primary                ·                ·
+#
+#query TTTTT
+#EXPLAIN (VERBOSE) SELECT * from d where b @>'[{"a": {"b": [1]}}]'
+#----
+#index-join  ·      ·                                                (a, b)           b=CONST; a!=NULL; key(a)
+# ├── scan   ·      ·                                                (a, b[omitted])  b=CONST; a!=NULL; key(a)
+# │          table  d@foo_inv                                        ·                ·
+# │          spans  /Arr/"a"/"b"/Arr/1-/Arr/"a"/"b"/Arr/1/PrefixEnd  ·                ·
+# └── scan   ·      ·                                                (a, b)           ·
+#·           table  d@primary                                        ·                ·
+#
+#query TTTTT
+#EXPLAIN (VERBOSE) SELECT * from d where b @> '[]';
+#----
+#scan  ·       ·          (a, b)  a!=NULL; b!=NULL; key(a)
+#·     table   d@primary  ·       ·
+#·     spans   ALL        ·       ·
+#·     filter  b @> '[]'  ·       ·
+#
+#
+#query TTTTT
+#EXPLAIN (VERBOSE) SELECT * from d where b @> '{}';
+#----
+#scan  ·       ·          (a, b)  a!=NULL; b!=NULL; key(a)
+#·     table   d@primary  ·       ·
+#·     spans   ALL        ·       ·
+#·     filter  b @> '{}'  ·       ·
+#
+#query TTTTT
+#EXPLAIN (VERBOSE) SELECT * from d where b->'a' = '"b"'
+#----
+#index-join  ·      ·                            (a, b)           b=CONST; a!=NULL; key(a)
+# ├── scan   ·      ·                            (a, b[omitted])  b=CONST; a!=NULL; key(a)
+# │          table  d@foo_inv                    ·                ·
+# │          spans  /"a"/"b"-/"a"/"b"/PrefixEnd  ·                ·
+# └── scan   ·      ·                            (a, b)           ·
+#·           table  d@primary                    ·                ·
+#
+#query TTTTT
+#EXPLAIN (VERBOSE) SELECT * from d where '"b"' = b->'a'
+#----
+#index-join  ·      ·                            (a, b)           b=CONST; a!=NULL; key(a)
+# ├── scan   ·      ·                            (a, b[omitted])  b=CONST; a!=NULL; key(a)
+# │          table  d@foo_inv                    ·                ·
+# │          spans  /"a"/"b"-/"a"/"b"/PrefixEnd  ·                ·
+# └── scan   ·      ·                            (a, b)           ·
+#·           table  d@primary                    ·                ·
+#
+#query TTTTT
+#EXPLAIN (VERBOSE) SELECT * from d where b IS NULL
+#----
+#scan  ·       ·          (a, b)  a!=NULL; key(a)
+#·     table   d@primary  ·       ·
+#·     spans   ALL        ·       ·
+#·     filter  b IS NULL  ·       ·
+#
+#query TTT
+#EXPLAIN SELECT * from d where b @> '{"a": []}' ORDER BY a;
+#----
+#scan  ·      ·
+#·     table  d@primary
+#·     spans  ALL
+#
+#query TTT
+#EXPLAIN SELECT * from d where b @> '{"a": {}}' ORDER BY a;
+#----
+#scan  ·      ·
+#·     table  d@primary
+#·     spans  ALL
+#
+### Multi-path contains queries
+#
+#query TTTTT
+#EXPLAIN (VERBOSE) SELECT * from d where b @> '{"a": {"b": "c"}, "f": "g"}'
+#----
+#index-join  ·       ·                                    (a, b)           b=CONST; a!=NULL; key(a)
+# ├── scan   ·       ·                                    (a, b[omitted])  b=CONST; a!=NULL; key(a)
+# │          table   d@foo_inv                            ·                ·
+# │          spans   /"a"/"b"/"c"-/"a"/"b"/"c"/PrefixEnd  ·                ·
+# └── scan   ·       ·                                    (a, b)           ·
+#·           table   d@primary                            ·                ·
+#·           filter  b @> '{"a": {"b": "c"}, "f": "g"}'   ·                ·
+#
+#query TTTTT
+#EXPLAIN (VERBOSE) SELECT * from d where b @> '{"a": {"b": "c", "d": "e"}, "f": "g"}'
+#----
+#index-join  ·       ·                                             (a, b)           b=CONST; a!=NULL; key(a)
+# ├── scan   ·       ·                                             (a, b[omitted])  b=CONST; a!=NULL; key(a)
+# │          table   d@foo_inv                                     ·                ·
+# │          spans   /"a"/"b"/"c"-/"a"/"b"/"c"/PrefixEnd           ·                ·
+# └── scan   ·       ·                                             (a, b)           ·
+#·           table   d@primary                                     ·                ·
+#·           filter  b @> '{"a": {"b": "c", "d": "e"}, "f": "g"}'  ·                ·
+#
+#query TTTTT
+#EXPLAIN (VERBOSE) SELECT * from d where b @> '[{"a": {"b": [[2]]}}, "d"]'
+#----
+#index-join  ·       ·                                                        (a, b)           b=CONST; a!=NULL; key(a)
+# ├── scan   ·       ·                                                        (a, b[omitted])  b=CONST; a!=NULL; key(a)
+# │          table   d@foo_inv                                                ·                ·
+# │          spans   /Arr/"a"/"b"/Arr/Arr/2-/Arr/"a"/"b"/Arr/Arr/2/PrefixEnd  ·                ·
+# └── scan   ·       ·                                                        (a, b)           ·
+#·           table   d@primary                                                ·                ·
+#·           filter  b @> '[{"a": {"b": [[2]]}}, "d"]'                        ·                ·
+#
+#query TTTTT
+#EXPLAIN (VERBOSE) SELECT * from d where b @> '{"a": {}, "b": 2}'
+#----
+#index-join  ·       ·                         (a, b)           b=CONST; a!=NULL; key(a)
+# ├── scan   ·       ·                         (a, b[omitted])  b=CONST; a!=NULL; key(a)
+# │          table   d@foo_inv                 ·                ·
+# │          spans   /"b"/2-/"b"/2/PrefixEnd   ·                ·
+# └── scan   ·       ·                         (a, b)           ·
+#·           table   d@primary                 ·                ·
+#·           filter  b @> '{"a": {}, "b": 2}'  ·                ·
+#
+#query TTTTT
+#EXPLAIN (VERBOSE) SELECT * from d where b @> '{"a": {}, "b": {}}'
+#----
+#scan  ·       ·                          (a, b)  a!=NULL; b!=NULL; key(a)
+#·     table   d@primary                  ·       ·
+#·     spans   ALL                        ·       ·
+#·     filter  b @> '{"a": {}, "b": {}}'  ·       ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/limit
+++ b/pkg/sql/opt/exec/execbuilder/testdata/limit
@@ -138,3 +138,32 @@ SELECT k FROM (SELECT k, v, w FROM t ORDER BY v LIMIT 4)
 4
 2
 1
+
+# Use expression for LIMIT/OFFSET value.
+query II
+SELECT k, v FROM t ORDER BY k LIMIT LENGTH(PG_TYPEOF(123))
+----
+1  1
+2  -4
+3  9
+
+query II
+SELECT k, v FROM t ORDER BY k LIMIT LENGTH(PG_TYPEOF(123)) OFFSET LENGTH(PG_TYPEOF(123))-2
+----
+2  -4
+3  9
+4  -16
+
+query II
+SELECT k, v FROM t ORDER BY k OFFSET (SELECT COUNT(*)-3 FROM t)
+----
+4  -16
+5  25
+6  -36
+
+query II
+SELECT k, v FROM t ORDER BY k LIMIT (SELECT COUNT(*)-3 FROM t) OFFSET (SELECT COUNT(*)-5 FROM t)
+----
+2  -4
+3  9
+4  -16

--- a/pkg/sql/opt/exec/execbuilder/testdata/select
+++ b/pkg/sql/opt/exec/execbuilder/testdata/select
@@ -91,7 +91,9 @@ SELECT * FROM c WHERE str >= 'moo'
 9   nine
 10  one-zero
 
+# ------------------------------------------------------------------------------
 # Ensure that index is used when indexed column has collation.
+# ------------------------------------------------------------------------------
 statement ok
 CREATE TABLE coll (
   a STRING COLLATE da,
@@ -118,7 +120,9 @@ render     ·         ·                        (b int, a collatedstring{da})  �
 ·          table     coll@coll_b_a_idx        ·                              ·
 ·          spans     ALL                      ·                              ·
 
+# ------------------------------------------------------------------------------
 # Ensure correct index is used when indexed column is computed.
+# ------------------------------------------------------------------------------
 statement ok
 CREATE TABLE computed (
   k INT PRIMARY KEY,
@@ -134,9 +138,141 @@ scan  ·      ·                        (b string)  +b
 ·     table  computed@computed_b_idx  ·           ·
 ·     spans  ALL                      ·           ·
 
-# Virtual tables are currently not supported.
+# ------------------------------------------------------------------------------
+# Ensure that Select filter probes expected date/time key/values that are in
+# different column families.
+# ------------------------------------------------------------------------------
 statement ok
-SET EXPERIMENTAL_OPT = ALWAYS;
+CREATE TABLE dt (
+  a TIMESTAMP PRIMARY KEY,
+  b DATE,
+  c INTERVAL,
+  UNIQUE (b),
+  UNIQUE (c),
+  FAMILY (a),
+  FAMILY (b),
+  FAMILY (c)
+)
 
-statement error virtual tables are not supported
-SELECT * FROM crdb_internal.jobs
+statement ok
+INSERT INTO dt VALUES
+  ('2015-08-30 03:34:45.34567', '2015-08-30', '34h2s'),
+  ('2015-08-25 04:45:45.53453', '2015-08-25', '2h45m2s234ms'),
+  ('2015-08-29 23:10:09.98763', '2015-08-29', '234h45m2s234ms')
+
+query T
+SELECT message FROM [SHOW KV TRACE FOR SELECT * FROM dt WHERE a = '2015-08-25 06:45:45.53453+02:00'::timestamp]
+ WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
+----
+fetched: /dt/primary/'2015-08-25 04:45:45.53453+00:00' -> NULL
+fetched: /dt/primary/'2015-08-25 04:45:45.53453+00:00'/b -> '2015-08-25'
+fetched: /dt/primary/'2015-08-25 04:45:45.53453+00:00'/c -> '2h45m2s234ms'
+output row: ['2015-08-25 04:45:45.53453+00:00' '2015-08-25' '2h45m2s234ms']
+
+query T
+SELECT message FROM [SHOW KV TRACE FOR SELECT b FROM dt WHERE b < '2015-08-29'::date]
+ WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
+----
+fetched: /dt/dt_b_key/'2015-08-25' -> /'2015-08-25 04:45:45.53453+00:00'
+output row: ['2015-08-25']
+
+query T
+SELECT message FROM [SHOW KV TRACE FOR SELECT c FROM dt WHERE c < '234h45m2s234ms'::interval]
+ WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
+----
+fetched: /dt/dt_c_key/'2h45m2s234ms' -> /'2015-08-25 04:45:45.53453+00:00'
+output row: ['2h45m2s234ms']
+fetched: /dt/dt_c_key/'34h2s' -> /'2015-08-30 03:34:45.34567+00:00'
+output row: ['34h2s']
+
+# ------------------------------------------------------------------------------
+# Ensure that special decimal values result in correct scan spans.
+# ------------------------------------------------------------------------------
+statement ok
+CREATE TABLE dec (d decimal, v decimal(3, 1), primary key (d, v))
+
+query TTTTT
+EXPLAIN (TYPES) SELECT * FROM dec WHERE d IS NaN and v IS NaN
+----
+scan  ·      ·                    (d decimal, v decimal)  ·
+·     table  dec@primary          ·                       ·
+·     spans  /NaN/NaN-/NaN/NaN/#  ·                       ·
+
+# The NaN suffix is decimalNaNDesc, not decimalNaN(Asc).
+query TTTTT
+EXPLAIN (TYPES) SELECT * FROM dec WHERE d = 'Infinity' and v = 'Infinity'
+----
+scan  ·      ·                                        (d decimal, v decimal)  ·
+·     table  dec@primary                              ·                       ·
+·     spans  /Infinity/Infinity-/Infinity/Infinity/#  ·                       ·
+
+query TTTTT
+EXPLAIN (TYPES) SELECT * FROM dec WHERE d = '-Infinity' and v = '-Infinity'
+----
+scan  ·      ·                                            (d decimal, v decimal)  ·
+·     table  dec@primary                                  ·                       ·
+·     spans  /-Infinity/-Infinity-/-Infinity/-Infinity/#  ·                       ·
+
+# ------------------------------------------------------------------------------
+# Verify that lookups for Decimal NaN use indices when possible:
+# - `WHERE d IS NaN` should perform a point lookup.
+# - `WHERE d = 'NaN'` should also perform a point lookup.
+# - `WHERE isnan(d)` is a function so it can't perform a point lookup.
+# ------------------------------------------------------------------------------
+statement ok
+CREATE TABLE dec2 (d decimal null, index (d))
+
+query TTTTT
+EXPLAIN (TYPES) SELECT * FROM dec2 WHERE d IS NaN
+----
+scan  ·      ·                (d decimal)  ·
+·     table  dec2@dec2_d_idx  ·            ·
+·     spans  /NaN-/-Infinity  ·            ·
+
+query TTTTT
+EXPLAIN (TYPES) SELECT * FROM dec2 WHERE d = 'NaN'
+----
+scan  ·      ·                (d decimal)  ·
+·     table  dec2@dec2_d_idx  ·            ·
+·     spans  /NaN-/-Infinity  ·            ·
+
+query TTTTT
+EXPLAIN (TYPES) SELECT * FROM dec2 WHERE isnan(d)
+----
+filter     ·       ·                            (d decimal)  ·
+ │         filter  (isnan((d)[decimal]))[bool]  ·            ·
+ └── scan  ·       ·                            (d decimal)  ·
+·          table   dec2@primary                 ·            ·
+·          spans   ALL                          ·            ·
+
+# ------------------------------------------------------------------------------
+# Verify that lookups for Float NaN use indices when possible:
+# - `WHERE f IS NaN` should perform a point lookup.
+# - `WHERE f = 'NaN'` should also perform a point lookup.
+# - `WHERE isnan(f)` is a function so it can't perform a point lookup.
+# ------------------------------------------------------------------------------
+statement ok
+CREATE TABLE flt (f float null, unique index (f))
+
+query TTTTT
+EXPLAIN (TYPES) SELECT * FROM flt WHERE f IS NaN
+----
+scan  ·      ·                    (f float)  ·
+·     table  flt@flt_f_key        ·          ·
+·     spans  /NaN-/NaN/PrefixEnd  ·          ·
+
+query TTTTT
+EXPLAIN (TYPES) SELECT * FROM flt WHERE f = 'NaN'
+----
+scan  ·      ·                    (f float)  ·
+·     table  flt@flt_f_key        ·          ·
+·     spans  /NaN-/NaN/PrefixEnd  ·          ·
+
+query TTTTT
+EXPLAIN (TYPES) SELECT * FROM flt WHERE isnan(f)
+----
+filter     ·       ·                          (f float)  ·
+ │         filter  (isnan((f)[float]))[bool]  ·          ·
+ └── scan  ·       ·                          (f float)  ·
+·          table   flt@primary                ·          ·
+·          spans   ALL                        ·          ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/srfs
+++ b/pkg/sql/opt/exec/execbuilder/testdata/srfs
@@ -1,0 +1,65 @@
+# LogicTest: default
+#
+# TODO(radu): enable once SRF's are supported
+#
+#subtest generate_series
+#
+#query TTT
+#EXPLAIN SELECT * FROM GENERATE_SERIES(1, 3)
+#----
+#generator  ·  ·
+#
+#query TTT
+#EXPLAIN SELECT * FROM GENERATE_SERIES(1, 2), GENERATE_SERIES(1, 2)
+#----
+#join            ·     ·
+# │              type  cross
+# ├── generator  ·     ·
+# └── generator  ·     ·
+#
+#query TTT
+#EXPLAIN SELECT GENERATE_SERIES(1, 3)
+#----
+#generator  ·  ·
+#
+#subtest multiple_SRFs
+## See #20511
+#
+## query TTT
+## EXPLAIN SELECT GENERATE_SERIES(1, 2), GENERATE_SERIES(1, 2)
+## ----
+## join            ·     ·
+## │              type  cross
+## ├── generator  ·     ·
+## └── generator  ·     ·
+#
+#statement ok
+#CREATE TABLE t (a string)
+#
+#statement ok
+#CREATE TABLE u (b string)
+#
+## query TTT
+## EXPLAIN(EXPRS) SELECT t.*, u.*, generate_series(1,2), generate_series(3, 4) FROM t, u
+## ----
+## render                    ·         ·
+## │                        render 0  a
+## │                        render 1  b
+## │                        render 2  generate_series
+## │                        render 3  generate_series
+## └── join                 ·         ·
+##      │                   type      cross
+##      ├── join            ·         ·
+##      │    │              type      cross
+##      │    ├── join       ·         ·
+##      │    │    │         type      cross
+##      │    │    ├── scan  ·         ·
+##      │    │    │         table     t@primary
+##      │    │    │         spans     ALL
+##      │    │    └── scan  ·         ·
+##      │    │              table     u@primary
+##      │    │              spans     ALL
+##      │    └── generator  ·         ·
+##      │                   expr      generate_series(1, 2)
+##      └── generator       ·         ·
+##·                         expr      generate_series(3, 4)

--- a/pkg/sql/opt/exec/factory.go
+++ b/pkg/sql/opt/exec/factory.go
@@ -107,9 +107,9 @@ type Factory interface {
 	ConstructOrdinality(input Node, colName string) (Node, error)
 
 	// ConstructLimit returns a node that implements LIMIT and/or OFFSET on the
-	// results of the given node. If only an offset is desired, limit should be
-	// math.MaxInt64.
-	ConstructLimit(input Node, limit int64, offset int64) (Node, error)
+	// results of the given node. If one or the other is not needed, then it is
+	// set to nil.
+	ConstructLimit(input Node, limit, offset tree.TypedExpr) (Node, error)
 
 	// RenameColumns modifies the column names of a node.
 	RenameColumns(input Node, colNames []string) (Node, error)

--- a/pkg/sql/opt/optbuilder/distinct.go
+++ b/pkg/sql/opt/optbuilder/distinct.go
@@ -16,17 +16,25 @@ package optbuilder
 
 import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 )
 
 // buildDistinct builds a set of memo groups that represent a DISTINCT
 // expression if distinct is true. If distinct is false, we just return
-// `inScope`.
+// `inScope`. If distinctOn is not empty, then this is a DISTINCT ON expression
+// that performs the distinct operation on a subset of columns.
 //
 // See Builder.buildStmt for a description of the remaining input and
 // return values.
-func (b *Builder) buildDistinct(distinct bool, inScope *scope) (outScope *scope) {
+func (b *Builder) buildDistinct(
+	distinct bool, distinctOn tree.DistinctOn, inScope *scope,
+) (outScope *scope) {
 	if !distinct {
 		return inScope
+	}
+
+	if len(distinctOn) > 0 {
+		panic(unimplementedf("DISTINCT ON is not supported"))
 	}
 
 	outScope = inScope.replace()

--- a/pkg/sql/opt/optbuilder/testdata/distinct
+++ b/pkg/sql/opt/optbuilder/testdata/distinct
@@ -357,3 +357,8 @@ sort
            │    └── columns: a:1(int!null) b:2(int!null) c:3(int!null) d:4(int!null)
            └── projections
                 └── const: 1 [type=int]
+
+build
+SELECT DISTINCT ON (b, c) a, b, d FROM abcd ORDER BY b, c
+----
+error (0A000): DISTINCT ON is not supported

--- a/pkg/sql/opt_exec_factory.go
+++ b/pkg/sql/opt_exec_factory.go
@@ -338,7 +338,7 @@ func (ef *execFactory) ConstructOrdinality(input exec.Node, colName string) (exe
 }
 
 // ConstructLimit is part of the exec.Factory interface.
-func (ee *execFactory) ConstructLimit(
+func (ef *execFactory) ConstructLimit(
 	input exec.Node, limit, offset tree.TypedExpr,
 ) (exec.Node, error) {
 	plan := input.(planNode)

--- a/pkg/sql/opt_exec_factory.go
+++ b/pkg/sql/opt_exec_factory.go
@@ -73,6 +73,9 @@ func (ef *execFactory) ConstructScan(
 	if err := scan.initTable(context.TODO(), ef.planner, tabDesc, nil, colCfg); err != nil {
 		return nil, err
 	}
+	if indexConstraint != nil && indexConstraint.IsContradiction() {
+		return newZeroNode(scan.resultColumns), nil
+	}
 	scan.index = indexDesc
 	scan.run.isSecondaryIndex = (indexDesc != &tabDesc.PrimaryIndex)
 	scan.hardLimit = hardLimit

--- a/pkg/sql/opt_exec_factory.go
+++ b/pkg/sql/opt_exec_factory.go
@@ -17,7 +17,6 @@ package sql
 import (
 	"context"
 	"fmt"
-	"math"
 
 	"github.com/pkg/errors"
 
@@ -336,29 +335,22 @@ func (ef *execFactory) ConstructOrdinality(input exec.Node, colName string) (exe
 }
 
 // ConstructLimit is part of the exec.Factory interface.
-func (ef *execFactory) ConstructLimit(
-	input exec.Node, limit int64, offset int64,
+func (ee *execFactory) ConstructLimit(
+	input exec.Node, limit, offset tree.TypedExpr,
 ) (exec.Node, error) {
-	var limitVal, offsetVal tree.Datum
-	if limit != math.MaxInt64 {
-		limitVal = tree.NewDInt(tree.DInt(limit))
-	}
-	if offset != 0 {
-		offsetVal = tree.NewDInt(tree.DInt(offset))
-	}
 	plan := input.(planNode)
 	// If the input plan is also a limitNode that has just an offset, and we are
 	// only applying a limit, update the existing node. This is useful because
 	// Limit and Offset are separate operators which result in separate calls to
 	// this function.
-	if l, ok := plan.(*limitNode); ok && l.countExpr == nil && offsetVal == nil {
-		l.countExpr = limitVal
+	if l, ok := plan.(*limitNode); ok && l.countExpr == nil && offset == nil {
+		l.countExpr = limit
 		return l, nil
 	}
 	return &limitNode{
 		plan:       plan,
-		countExpr:  limitVal,
-		offsetExpr: offsetVal,
+		countExpr:  limit,
+		offsetExpr: offset,
 	}, nil
 }
 


### PR DESCRIPTION
Enable most logic tests from crdb_internal -> inverted_index.

Fix several issues that were preventing these tests from working
with the cost-based optimizer.