### PR TITLE
cli: show encryption flag.

### DIFF
--- a/pkg/ccl/cliccl/cliflagsccl/flags.go
+++ b/pkg/ccl/cliccl/cliflagsccl/flags.go
@@ -15,15 +15,35 @@ var (
 	EnterpriseEncryption = cliflags.FlagInfo{
 		Name: "enterprise-encryption",
 		Description: `
+<PRE>
 *** Valid enterprise licenses only ***
 
-TODO(mberhault): fill this.
+WARNING: encryption at rest is an experimental feature.
 
+Enable encryption at rest for a store.
+
+TODO(mberhault): fill in description.
+
+</PRE>
+Key files must be of size 32 bytes + AES key size, such as:
+<PRE>
+AES-128: 48 bytes
+AES-192: 56 bytes
+AES-256: 64 bytes
+
+</PRE>
 Valid fields:
-* path: must match the path of one of the stores
-* key: path to the current key file
-* old-key: path to the previous key file
-* rotation-period: amount of time after which data keys should be rotated
+<PRE>
+* path    (required): must match the path of one of the stores
+* key     (required): path to the current key file, or "plain"
+* old-key (required): path to the previous key file, or "plain"
+* rotation-period   : amount of time after which data keys should be rotated
+
+</PRE>
+example:
+<PRE>
+  --enterprise-encryption=path=cockroach-data,key=/keys/aes-128.key,old-key=plain
+</PRE>
 `,
 	}
 )

--- a/pkg/ccl/cliccl/start.go
+++ b/pkg/ccl/cliccl/start.go
@@ -27,10 +27,6 @@ func init() {
 	cli.AddPersistentPreRunE(cli.StartCmd, func(cmd *cobra.Command, _ []string) error {
 		return populateStoreSpecsEncryption()
 	})
-
-	// The flag is kept hidden for now.
-	// TODO(mberhault): make visible once encryption is fully implemented.
-	_ = cli.StartCmd.Flags().MarkHidden(cliflagsccl.EnterpriseEncryption.Name)
 }
 
 // populateStoreSpecsEncryption is a PreRun hook that matches store encryption specs with the


### PR DESCRIPTION
Stop hidding the encryption flag, and improve the description slightly.

Release note (CLI change): Show --enterprise-encryption flag on start command