### PR TITLE
distsql: blacklist CURRENT_SCHEMA

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/builtin_function
+++ b/pkg/sql/logictest/testdata/logic_test/builtin_function
@@ -1203,6 +1203,14 @@ SELECT CURRENT_SCHEMAS(false)
 ----
 {"public"}
 
+# Force the function to be evaluated at execution time and verify it doesn't
+# break when distsql is on.
+query T
+SELECT CURRENT_SCHEMAS(x) FROM (VALUES (true), (false)) AS t(x);
+----
+{"pg_catalog","public"}
+{"public"}
+
 statement ok
 SET SEARCH_PATH=test,pg_catalog
 

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -2305,9 +2305,10 @@ may increase either contention or retry errors, or both.`,
 	// SQL client against a pg server.
 	"current_schema": {
 		tree.Builtin{
-			Types:      tree.ArgTypes{},
-			ReturnType: tree.FixedReturnType(types.String),
-			Category:   categorySystemInfo,
+			Types:            tree.ArgTypes{},
+			ReturnType:       tree.FixedReturnType(types.String),
+			Category:         categorySystemInfo,
+			DistsqlBlacklist: true,
 			Fn: func(evalCtx *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
 				ctx := evalCtx.Ctx()
 				curDb := evalCtx.SessionData.Database
@@ -2336,9 +2337,10 @@ may increase either contention or retry errors, or both.`,
 	// server.
 	"current_schemas": {
 		tree.Builtin{
-			Types:      tree.ArgTypes{{"include_pg_catalog", types.Bool}},
-			ReturnType: tree.FixedReturnType(types.TArray{Typ: types.String}),
-			Category:   categorySystemInfo,
+			Types:            tree.ArgTypes{{"include_pg_catalog", types.Bool}},
+			ReturnType:       tree.FixedReturnType(types.TArray{Typ: types.String}),
+			Category:         categorySystemInfo,
+			DistsqlBlacklist: true,
 			Fn: func(evalCtx *tree.EvalContext, args tree.Datums) (tree.Datum, error) {
 				ctx := evalCtx.Ctx()
 				curDb := evalCtx.SessionData.Database


### PR DESCRIPTION
Blacklist builtins that use `EvalContext.Planner`.

Release note: None