### PR TITLE
tpccbench: use pre-generated store directories when possible

### DIFF
--- a/pkg/cmd/roachtest/backup.go
+++ b/pkg/cmd/roachtest/backup.go
@@ -17,24 +17,7 @@ package main
 
 import (
 	"context"
-	"fmt"
-
-	"golang.org/x/sync/errgroup"
 )
-
-func downloadStoreDumps(
-	ctx context.Context, c *cluster, location string, binVersion string, nodeCount int,
-) error {
-	var g errgroup.Group
-	for node := 1; node <= nodeCount; node++ {
-		node := node
-		g.Go(func() error {
-			path := location + fmt.Sprintf(`/stores=%d,bin-version=%s/%d/*`, nodeCount, binVersion, node)
-			return c.RunE(ctx, c.Node(node), `mkdir -p {store-dir} && gsutil -m -q cp -r `+path+` {store-dir}`)
-		})
-	}
-	return g.Wait()
-}
 
 func registerBackup(r *registry) {
 	r.Add(testSpec{
@@ -49,7 +32,8 @@ func registerBackup(r *registry) {
 			// roachtest --cockroach cockroach-v2.0.1 store-gen --stores=10 bank \
 			//           --payload-bytes=10240 --ranges=0 --rows=65104166
 			location := `gs://cockroach-fixtures/workload/bank/version=1.0.0,payload-bytes=10240,ranges=0,rows=65104166,seed=1`
-			if err := downloadStoreDumps(ctx, c, location, "2.0", nodes); err != nil {
+			storeDirsPath := storeDirURL(location, nodes, "2.0")
+			if err := downloadStoreDumps(ctx, c, storeDirsPath, nodes); err != nil {
 				t.Fatal(err)
 			}
 


### PR DESCRIPTION
Fixes #25085.

This change allows tpccbench to optionally use pre-generated store
directories for dataset ingestion. This results in about a 4x
speedup in startup time (TPCC 1K drops from ~20 minutes to ~5m).

Release note: None