### PR TITLE
roachtest: don't parse stderr in cluster.pgURL

### DIFF
--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -770,7 +770,7 @@ func (c *cluster) pgURL(ctx context.Context, node nodeListOption, external bool)
 	}
 	args = append(args, c.makeNodes(node))
 	cmd := exec.CommandContext(ctx, roachprod, args...)
-	output, err := cmd.CombinedOutput()
+	output, err := cmd.Output()
 	if err != nil {
 		fmt.Println(strings.Join(cmd.Args, ` `))
 		c.t.Fatal(err)


### PR DESCRIPTION
The function was trying to parse the following log and was failing as a
result:

```
skipping encrypted SSH key "/Users/nathan/.ssh/id_rsa"; if necessary, add the key to your SSH agent
```

It no longer attempts to parse stderr.

Release note: None