### PR TITLE
sql: fix DIPAddr serialization issue

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/inet
+++ b/pkg/sql/logictest/testdata/logic_test/inet
@@ -1,4 +1,4 @@
-# LogicTest: default parallel-stmts distsql distsql-metadata
+# LogicTest: default opt parallel-stmts distsql distsql-metadata distsql-opt
 
 # Basic IPv4 tests
 
@@ -868,3 +868,9 @@ query T
 SELECT text('::ffff:192.168.0.1/24'::INET)
 ----
 ::ffff:192.168.0.1/24
+
+# Verify the inet datum gets serialized correctly for distsql.
+query T
+SELECT host(MAX('192.168.0.2/24'::INET)) FROM (VALUES (1)) AS t(x)
+----
+192.168.0.2

--- a/pkg/sql/sem/tree/datum.go
+++ b/pkg/sql/sem/tree/datum.go
@@ -1408,7 +1408,7 @@ func (*DIPAddr) Max(_ *EvalContext) (Datum, bool) {
 
 // AmbiguousFormat implements the Datum interface.
 func (*DIPAddr) AmbiguousFormat() bool {
-	return false
+	return true
 }
 
 // Format implements the NodeFormatter interface.


### PR DESCRIPTION
Correcting `DIPAddr.AmbiguousFormat` to be true, i.e. that type
annotations are necessary when serializing the datum (e.g. for
DistSQL). Without it, the value is parsed as a string.

Release note (bug fix): Fixed an error caused by INET constants in
some rare cases.