### PR TITLE
sql, distsql, opt: fixing serialization of empty array

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/array
+++ b/pkg/sql/logictest/testdata/logic_test/array
@@ -1,4 +1,4 @@
-# LogicTest: default opt distsql distsql-metadata
+# LogicTest: default opt distsql distsql-metadata distsql-opt
 
 # array construction
 

--- a/pkg/sql/opt/exec/execbuilder/scalar_builder.go
+++ b/pkg/sql/opt/exec/execbuilder/scalar_builder.go
@@ -110,11 +110,7 @@ func (b *Builder) indexedVar(
 
 func (b *Builder) buildTuple(ctx *buildScalarCtx, ev memo.ExprView) (tree.TypedExpr, error) {
 	if memo.MatchesTupleOfConstants(ev) {
-		datums := make(tree.Datums, ev.ChildCount())
-		for i := range datums {
-			datums[i] = memo.ExtractConstDatum(ev.Child(i))
-		}
-		return tree.NewDTuple(datums...), nil
+		return memo.ExtractConstDatum(ev), nil
 	}
 
 	typedExprs := make([]tree.TypedExpr, ev.ChildCount())
@@ -290,6 +286,9 @@ func (b *Builder) buildCoalesce(ctx *buildScalarCtx, ev memo.ExprView) (tree.Typ
 }
 
 func (b *Builder) buildArray(ctx *buildScalarCtx, ev memo.ExprView) (tree.TypedExpr, error) {
+	if memo.HasOnlyConstChildren(ev) {
+		return memo.ExtractConstDatum(ev), nil
+	}
 	exprs := make(tree.TypedExprs, ev.ChildCount())
 	var err error
 	for i := range exprs {

--- a/pkg/sql/opt/exec/execbuilder/testdata/scalar
+++ b/pkg/sql/opt/exec/execbuilder/testdata/scalar
@@ -356,20 +356,20 @@ render     ·         ·          ("j ? 'a'")  ·
 query TTTTT
 EXPLAIN (VERBOSE) SELECT j ?| ARRAY['a', 'b', 'c'] FROM t
 ----
-render     ·         ·                          ("j ?| ARRAY['a', 'b', 'c']")  ·
- │         render 0  j ?| ARRAY['a', 'b', 'c']  ·                              ·
- └── scan  ·         ·                          (j)                            ·
-·          table     t@primary                  ·                              ·
-·          spans     ALL                        ·                              ·
+render     ·         ·                        ("j ?| ARRAY['a', 'b', 'c']")  ·
+ │         render 0  j ?| ARRAY['a','b','c']  ·                              ·
+ └── scan  ·         ·                        (j)                            ·
+·          table     t@primary                ·                              ·
+·          spans     ALL                      ·                              ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT j ?& ARRAY['a', 'b', 'c'] FROM t
 ----
-render     ·         ·                          ("j ?& ARRAY['a', 'b', 'c']")  ·
- │         render 0  j ?& ARRAY['a', 'b', 'c']  ·                              ·
- └── scan  ·         ·                          (j)                            ·
-·          table     t@primary                  ·                              ·
-·          spans     ALL                        ·                              ·
+render     ·         ·                        ("j ?& ARRAY['a', 'b', 'c']")  ·
+ │         render 0  j ?& ARRAY['a','b','c']  ·                              ·
+ └── scan  ·         ·                        (j)                            ·
+·          table     t@primary                ·                              ·
+·          spans     ALL                      ·                              ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT j#>ARRAY['a'] FROM t
@@ -516,6 +516,24 @@ render     ·         ·                                              ("a NOT BE
  └── scan  ·         ·                                              (a, b, d)                            ·
 ·          table     t@primary                                      ·                                    ·
 ·          spans     ALL                                            ·                                    ·
+
+query TTTTT
+EXPLAIN (VERBOSE) SELECT ARRAY[]:::int[] FROM t
+----
+render     ·         ·          ("ARRAY[]:::INT[]")  ·
+ │         render 0  ARRAY[]    ·                    ·
+ └── scan  ·         ·          ()                   ·
+·          table     t@primary  ·                    ·
+·          spans     ALL        ·                    ·
+
+query TTTTT
+EXPLAIN (VERBOSE) SELECT ARRAY[1, 2, 3] FROM t
+----
+render     ·         ·             ("ARRAY[1, 2, 3]")  ·
+ │         render 0  ARRAY[1,2,3]  ·                   ·
+ └── scan  ·         ·             ()                  ·
+·          table     t@primary     ·                   ·
+·          spans     ALL           ·                   ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT ARRAY[a + 1, 2, 3] FROM t

--- a/pkg/sql/opt/memo/constraint_builder.go
+++ b/pkg/sql/opt/memo/constraint_builder.go
@@ -74,7 +74,7 @@ func (cb *constraintsBuilder) buildSingleColumnConstraint(
 		return constraint.SingleConstraint(&c), true
 	}
 
-	if val.IsConstValue() {
+	if val.IsConstValue() || MatchesTupleOfConstants(val) {
 		return cb.buildSingleColumnConstraintConst(col, op, ExtractConstDatum(val))
 	}
 

--- a/pkg/sql/opt/memo/extract.go
+++ b/pkg/sql/opt/memo/extract.go
@@ -19,21 +19,45 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
 )
 
 // This file contains various helper functions that extract an op-specific
 // field from an expression.
 
 // ExtractConstDatum returns the Datum that represents the value of an operator
-// having the ConstValue tag.
+// with a constant value. An operator with a constant value is:
+//  - one that has a ConstValue tag, or
+//  - a tuple or array where all children are constant values.
 func ExtractConstDatum(ev ExprView) tree.Datum {
 	switch ev.Operator() {
 	case opt.NullOp:
 		return tree.DNull
+
 	case opt.TrueOp:
 		return tree.DBoolTrue
+
 	case opt.FalseOp:
 		return tree.DBoolFalse
+
+	case opt.TupleOp:
+		datums := make(tree.Datums, ev.ChildCount())
+		for i := range datums {
+			datums[i] = ExtractConstDatum(ev.Child(i))
+		}
+		return tree.NewDTuple(datums...)
+
+	case opt.ArrayOp:
+		elementType := ev.Logical().Scalar.Type.(types.TArray).Typ
+		a := tree.NewDArray(elementType)
+		a.Array = make(tree.Datums, ev.ChildCount())
+		for i := range a.Array {
+			a.Array[i] = ExtractConstDatum(ev.Child(i))
+			if a.Array[i] == tree.DNull {
+				a.HasNulls = true
+			}
+		}
+		return a
 	}
 	if !ev.IsConstValue() {
 		panic(fmt.Sprintf("non-const expression: %+v", ev))

--- a/pkg/sql/opt/memo/testdata/logprops/constraints
+++ b/pkg/sql/opt/memo/testdata/logprops/constraints
@@ -606,3 +606,26 @@ select
       └── is-not [type=bool, outer=(3), constraints=(/3: [ - /'foo') [/e'foo\x00' - ]; tight)]
            ├── variable: abc.c [type=string, outer=(3)]
            └── const: 'foo' [type=string]
+
+opt
+SELECT * FROM (SELECT (x, y) AS col FROM a) WHERE col > (1, 2)
+----
+select
+ ├── columns: col:4(tuple{int, int}!null)
+ ├── stats: [rows=333]
+ ├── project
+ │    ├── columns: col:4(tuple{int, int})
+ │    ├── stats: [rows=1000]
+ │    ├── scan a
+ │    │    ├── columns: x:1(int) y:2(int)
+ │    │    └── stats: [rows=1000]
+ │    └── projections [outer=(1,2)]
+ │         └── tuple [type=tuple{int, int}, outer=(1,2)]
+ │              ├── variable: a.x [type=int, outer=(1)]
+ │              └── variable: a.y [type=int, outer=(2)]
+ └── filters [type=bool, outer=(4), constraints=(/4: [/(1, 3) - ]; tight)]
+      └── gt [type=bool, outer=(4), constraints=(/4: [/(1, 3) - ]; tight)]
+           ├── variable: col [type=tuple{int, int}, outer=(4)]
+           └── tuple [type=tuple{int, int}]
+                ├── const: 1 [type=int]
+                └── const: 2 [type=int]

--- a/pkg/sql/opt/norm/testdata/rules/scalar
+++ b/pkg/sql/opt/norm/testdata/rules/scalar
@@ -176,8 +176,8 @@ project
       ├── a.s::JSON [type=jsonb, outer=(4)]
       ├── a.s::VARCHAR(2) [type=string, outer=(4)]
       ├── a.i::SMALLINT [type=int, outer=(2)]
-      ├── ARRAY[1, 2]::OIDVECTOR [type=oid[]]
-      └── ARRAY[1, 2]::INT2VECTOR [type=int[]]
+      ├── ARRAY[1,2]::OIDVECTOR [type=oid[]]
+      └── ARRAY[1,2]::INT2VECTOR [type=int[]]
 
 # --------------------------------------------------
 # FoldNullCast

--- a/pkg/sql/sem/tree/datum.go
+++ b/pkg/sql/sem/tree/datum.go
@@ -2878,7 +2878,11 @@ func (d *DArray) IsMin(_ *EvalContext) bool {
 }
 
 // AmbiguousFormat implements the Datum interface.
-func (*DArray) AmbiguousFormat() bool { return false }
+func (d *DArray) AmbiguousFormat() bool {
+	// The type of the array is ambiguous if it is empty; when serializing we need
+	// to annotate it with the type.
+	return len(d.Array) == 0
+}
 
 // Format implements the NodeFormatter interface.
 func (d *DArray) Format(ctx *FmtCtx) {


### PR DESCRIPTION
`DArray.AmbiguousFormat` now returns true if the array is empty. This
fixes a serialization issue.

The optimizer code now creates a `DArray` instead of an `Array`
whenever possible (most importantly, for empty arrays).

Fixes #26087.

Release note (bug fix): Fixed an error caused by empty arrays in some
cases.