### PR TITLE
distsqlrun: use batch row channel in input syncs

### DIFF
--- a/pkg/sql/distsqlrun/base.go
+++ b/pkg/sql/distsqlrun/base.go
@@ -378,21 +378,39 @@ type RowChannel struct {
 
 	// dataChan is the same channel as C.
 	dataChan chan RowChannelMsg
+
+	// numSenders is an atomic counter that keeps track of how many senders have
+	// yet to call ProducerDone().
+	numSenders int32
 }
 
 var _ RowReceiver = &RowChannel{}
 var _ RowSource = &RowChannel{}
 
-// InitWithBufSize initializes the RowChannel with a given buffer size.
+// InitWithBufSize initializes the RowChannel with a given buffer size and 1
+// sender.
 func (rc *RowChannel) InitWithBufSize(types []sqlbase.ColumnType, chanBufSize int) {
+	rc.InitWithBufSizeAndNumSenders(types, chanBufSize, 1)
+}
+
+// Init initializes the RowChannel with the default buffer size and 1 sender.
+func (rc *RowChannel) Init(types []sqlbase.ColumnType) {
+	rc.InitWithBufSizeAndNumSenders(types, rowChannelBufSize, 1)
+}
+
+// InitWithNumSenders initializes the RowChannel with the default buffer size
+// and the given number of senders.
+func (rc *RowChannel) InitWithNumSenders(types []sqlbase.ColumnType, numSenders int) {
+	rc.InitWithBufSizeAndNumSenders(types, rowChannelBufSize, numSenders)
+}
+
+// InitWithBufSizeAndNumSenders initializes the RowChannel with a given buffer
+// size and number of senders.
+func (rc *RowChannel) InitWithBufSizeAndNumSenders(types []sqlbase.ColumnType, chanBufSize int, numSenders int) {
 	rc.types = types
 	rc.dataChan = make(chan RowChannelMsg, chanBufSize)
 	rc.C = rc.dataChan
-}
-
-// Init initializes the RowChannel with the default buffer size.
-func (rc *RowChannel) Init(types []sqlbase.ColumnType) {
-	rc.InitWithBufSize(types, rowChannelBufSize)
+	atomic.StoreInt32(&rc.numSenders, int32(numSenders))
 }
 
 // Push is part of the RowReceiver interface.
@@ -415,7 +433,13 @@ func (rc *RowChannel) Push(row sqlbase.EncDatumRow, meta *ProducerMetadata) Cons
 
 // ProducerDone is part of the RowReceiver interface.
 func (rc *RowChannel) ProducerDone() {
-	close(rc.dataChan)
+	newVal := atomic.AddInt32(&rc.numSenders, -1)
+	if newVal < 0 {
+		panic("too many ProducerDone() calls")
+	}
+	if newVal == 0 {
+		close(rc.dataChan)
+	}
 }
 
 // OutputTypes is part of the RowSource interface.
@@ -444,86 +468,14 @@ func (rc *RowChannel) ConsumerDone() {
 // ConsumerClosed is part of the RowSource interface.
 func (rc *RowChannel) ConsumerClosed() {
 	rc.consumerClosed("RowChannel")
-	// Read (at most) one message in case the producer is blocked trying to emit a
-	// row. Note that, if the producer is done, then it has also closed the
-	// channel this will not block. The producer might be neither blocked nor
-	// closed, though; hence the default case.
-	select {
-	case <-rc.dataChan:
-	default:
-	}
-}
-
-// MultiplexedRowChannel is a RowChannel wrapper which allows multiple row
-// producers to push rows on the same channel.
-type MultiplexedRowChannel struct {
-	rowChan RowChannel
-	// numSenders is an atomic counter that keeps track of how many senders have
-	// yet to call ProducerDone().
-	numSenders int32
-}
-
-var _ RowReceiver = &MultiplexedRowChannel{}
-var _ RowSource = &MultiplexedRowChannel{}
-
-// Init initializes the MultiplexedRowChannel with the default buffer size.
-func (mrc *MultiplexedRowChannel) Init(numSenders int, types []sqlbase.ColumnType) {
-	mrc.rowChan.Init(types)
-	atomic.StoreInt32(&mrc.numSenders, int32(numSenders))
-}
-
-// Push is part of the RowReceiver interface.
-func (mrc *MultiplexedRowChannel) Push(
-	row sqlbase.EncDatumRow, meta *ProducerMetadata,
-) ConsumerStatus {
-	return mrc.rowChan.Push(row, meta)
-}
-
-// ProducerDone is part of the RowReceiver interface.
-func (mrc *MultiplexedRowChannel) ProducerDone() {
-	newVal := atomic.AddInt32(&mrc.numSenders, -1)
-	if newVal < 0 {
-		panic("too many ProducerDone() calls")
-	}
-	if newVal == 0 {
-		mrc.rowChan.ProducerDone()
-	}
-}
-
-// OutputTypes is part of the RowSource interface.
-func (mrc *MultiplexedRowChannel) OutputTypes() []sqlbase.ColumnType {
-	return mrc.rowChan.types
-}
-
-// Start is part of the RowSource interface.
-func (mrc *MultiplexedRowChannel) Start(ctx context.Context) context.Context {
-	mrc.rowChan.Start(ctx)
-	return ctx
-}
-
-// Next is part of the RowSource interface.
-func (mrc *MultiplexedRowChannel) Next() (row sqlbase.EncDatumRow, meta *ProducerMetadata) {
-	return mrc.rowChan.Next()
-}
-
-// ConsumerDone is part of the RowSource interface.
-func (mrc *MultiplexedRowChannel) ConsumerDone() {
-	mrc.rowChan.ConsumerDone()
-}
-
-// ConsumerClosed is part of the RowSource interface.
-func (mrc *MultiplexedRowChannel) ConsumerClosed() {
-	status := ConsumerStatus(atomic.LoadUint32((*uint32)(&mrc.rowChan.consumerStatus)))
-	if status == ConsumerClosed {
-		panic("MultiplexedRowChannel already closed")
-	}
-	atomic.StoreUint32(
-		(*uint32)(&mrc.rowChan.consumerStatus), uint32(ConsumerClosed))
-	numSenders := atomic.LoadInt32(&mrc.numSenders)
+	numSenders := atomic.LoadInt32(&rc.numSenders)
 	// Drain (at most) numSenders messages in case senders are blocked trying to
 	// emit a row.
+	// Note that, if the producer is done, then it has also closed the
+	// channel this will not block. The producer might be neither blocked nor
+	// closed, though; hence the no data case.
 	for i := int32(0); i < numSenders; i++ {
-		if _, ok := <-mrc.rowChan.dataChan; !ok {
+		if _, ok := <-rc.dataChan; !ok {
 			break
 		}
 	}

--- a/pkg/sql/distsqlrun/base.go
+++ b/pkg/sql/distsqlrun/base.go
@@ -84,6 +84,16 @@ type RowReceiver interface {
 	ProducerDone()
 }
 
+// BatchRowReceiver is a RowReceiver that can also accept an entire batch of
+// RowChannelMsgs at once.
+type BatchRowReceiver interface {
+	RowReceiver
+
+	// PushBatch sends many records to the consumer of this RowReceiver. Its
+	// semantics are identical to running Push once per RowChannelMsg.
+	PushBatch(msgs []RowChannelMsg) ConsumerStatus
+}
+
 // RowSource is any component of a flow that produces rows that can be consumed
 // by another component.
 //
@@ -378,10 +388,6 @@ type RowChannel struct {
 
 	// dataChan is the same channel as C.
 	dataChan chan RowChannelMsg
-
-	// numSenders is an atomic counter that keeps track of how many senders have
-	// yet to call ProducerDone().
-	numSenders int32
 }
 
 var _ RowReceiver = &RowChannel{}
@@ -433,11 +439,7 @@ func (rc *RowChannel) Push(row sqlbase.EncDatumRow, meta *ProducerMetadata) Cons
 
 // ProducerDone is part of the RowReceiver interface.
 func (rc *RowChannel) ProducerDone() {
-	newVal := atomic.AddInt32(&rc.numSenders, -1)
-	if newVal < 0 {
-		panic("too many ProducerDone() calls")
-	}
-	if newVal == 0 {
+	if newSenders := rc.producerDone(); newSenders == 0 {
 		close(rc.dataChan)
 	}
 }
@@ -476,6 +478,125 @@ func (rc *RowChannel) ConsumerClosed() {
 	// closed, though; hence the no data case.
 	for i := int32(0); i < numSenders; i++ {
 		if _, ok := <-rc.dataChan; !ok {
+			break
+		}
+	}
+}
+
+// BatchRowChannel is a way of passing a batch of messages between goroutines.
+type BatchRowChannel struct {
+	rowSourceBase
+
+	types []sqlbase.ColumnType
+	buf   []RowChannelMsg
+
+	ch chan []RowChannelMsg
+}
+
+// Push implements the RowReceiver interface.
+func (rc *BatchRowChannel) Push(row sqlbase.EncDatumRow, meta *ProducerMetadata) ConsumerStatus {
+	return rc.PushBatch([]RowChannelMsg{{Row: row, Meta: meta}})
+}
+
+// InitWithBufSize initializes the BatchRowChannel with a given buffer size.
+func (rc *BatchRowChannel) InitWithBufSize(types []sqlbase.ColumnType, chanBufSize int) {
+	rc.InitWithBufSizeAndNumSenders(types, chanBufSize, 1)
+}
+
+// Init initializes the BatchRowChannel with the default buffer size.
+func (rc *BatchRowChannel) Init(types []sqlbase.ColumnType) {
+	rc.InitWithBufSizeAndNumSenders(types, rowChannelBufSize, 1)
+}
+
+// InitWithNumSenders initializes the RowChannel with the default buffer size
+// and the given number of senders.
+func (rc *BatchRowChannel) InitWithNumSenders(types []sqlbase.ColumnType, numSenders int) {
+	rc.InitWithBufSizeAndNumSenders(types, rowChannelBufSize, numSenders)
+}
+
+// InitWithBufSizeAndNumSenders initializes the RowChannel with a given buffer
+// size and number of senders.
+func (rc *BatchRowChannel) InitWithBufSizeAndNumSenders(types []sqlbase.ColumnType, chanBufSize int, numSenders int) {
+	rc.types = types
+	rc.ch = make(chan []RowChannelMsg, chanBufSize)
+	atomic.StoreInt32(&rc.numSenders, int32(numSenders))
+}
+
+// OutputTypes implements the RowSource interface.
+func (rc *BatchRowChannel) OutputTypes() []sqlbase.ColumnType {
+	return rc.types
+}
+
+// Start implements the RowSource interface.
+func (rc *BatchRowChannel) Start(ctx context.Context) context.Context {
+	return ctx
+}
+
+// PushBatch implements the BatchRowReceiver interface.
+func (rc *BatchRowChannel) PushBatch(msgs []RowChannelMsg) ConsumerStatus {
+	consumerStatus := ConsumerStatus(
+		atomic.LoadUint32((*uint32)(&rc.consumerStatus)))
+	switch consumerStatus {
+	case NeedMoreRows:
+		rc.ch <- msgs
+	case DrainRequested:
+		// If we're draining, only forward metadata.
+		idx := 0
+		for i := range msgs {
+			if msgs[i].Meta != nil {
+				msgs[idx] = msgs[i]
+				idx++
+			}
+		}
+		msgs = msgs[:idx]
+		if len(msgs) != 0 {
+			rc.ch <- msgs
+		}
+	case ConsumerClosed:
+		// If the consumer is gone, swallow all the rows.
+	}
+	return consumerStatus
+}
+
+// Next implements the RowSource interface.
+func (rc *BatchRowChannel) Next() (sqlbase.EncDatumRow, *ProducerMetadata) {
+	for len(rc.buf) == 0 {
+		batch, ok := <-rc.ch
+		if !ok {
+			// No more rows.
+			return nil, nil
+		}
+		rc.buf = batch
+	}
+
+	msg := rc.buf[0]
+	rc.buf = rc.buf[1:]
+	return msg.Row, msg.Meta
+}
+
+// ProducerDone implements the RowReceiver interface.
+func (rc *BatchRowChannel) ProducerDone() {
+	if newSenders := rc.producerDone(); newSenders == 0 {
+		close(rc.ch)
+	}
+}
+
+// ConsumerDone implements the RowSource interface.
+func (rc *BatchRowChannel) ConsumerDone() {
+	rc.consumerDone()
+}
+
+// ConsumerClosed implements the RowSource interface.
+func (rc *BatchRowChannel) ConsumerClosed() {
+	rc.consumerClosed("BatchRowChannel")
+	numSenders := atomic.LoadInt32(&rc.numSenders)
+	// Drain (at most) numSenders messages in case senders are blocked trying to
+	// emit a row.
+	// Note that, if the producer is done, then it has also closed the
+	// channel this will not block. The producer might be neither blocked nor
+	// closed, though; hence the no data case.
+	for i := int32(0); i < numSenders; i++ {
+		if _, ok := <-rc.ch; !ok {
 			break
 		}
 	}

--- a/pkg/sql/distsqlrun/base_test.go
+++ b/pkg/sql/distsqlrun/base_test.go
@@ -108,8 +108,8 @@ func BenchmarkMultiplexedRowChannel(b *testing.B) {
 			for i := 0; i < b.N; i++ {
 				var wg sync.WaitGroup
 				wg.Add(senders + 1)
-				mrc := &MultiplexedRowChannel{}
-				mrc.Init(senders, oneIntCol)
+				mrc := &RowChannel{}
+				mrc.InitWithNumSenders(oneIntCol, senders)
 				go func() {
 					for {
 						if r, _ := mrc.Next(); r == nil {

--- a/pkg/sql/distsqlrun/flow.go
+++ b/pkg/sql/distsqlrun/flow.go
@@ -338,7 +338,7 @@ func (f *Flow) setup(ctx context.Context, spec *FlowSpec) error {
 			var sync RowSource
 			switch is.Type {
 			case InputSyncSpec_UNORDERED:
-				mrc := &RowChannel{}
+				mrc := &BatchRowChannel{}
 				mrc.InitWithNumSenders(is.ColumnTypes, len(is.Streams))
 				for _, s := range is.Streams {
 					if err := f.setupInboundStream(ctx, s, mrc); err != nil {
@@ -350,7 +350,7 @@ func (f *Flow) setup(ctx context.Context, spec *FlowSpec) error {
 				// Ordered synchronizer: create a RowChannel for each input.
 				streams := make([]RowSource, len(is.Streams))
 				for i, s := range is.Streams {
-					rowChan := &RowChannel{}
+					rowChan := &BatchRowChannel{}
 					rowChan.Init(is.ColumnTypes)
 					if err := f.setupInboundStream(ctx, s, rowChan); err != nil {
 						return err

--- a/pkg/sql/distsqlrun/input_sync_test.go
+++ b/pkg/sql/distsqlrun/input_sync_test.go
@@ -144,8 +144,8 @@ func TestUnorderedSync(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	columnTypeInt := sqlbase.ColumnType{SemanticType: sqlbase.ColumnType_INT}
-	mrc := &MultiplexedRowChannel{}
-	mrc.Init(5, []sqlbase.ColumnType{columnTypeInt})
+	mrc := &RowChannel{}
+	mrc.InitWithNumSenders([]sqlbase.ColumnType{columnTypeInt}, 5)
 	producerErr := make(chan error, 100)
 	for i := 1; i <= 5; i++ {
 		go func(i int) {
@@ -193,8 +193,8 @@ func TestUnorderedSync(t *testing.T) {
 	}
 
 	// Test case when one source closes with an error.
-	mrc = &MultiplexedRowChannel{}
-	mrc.Init(5, []sqlbase.ColumnType{columnTypeInt})
+	mrc = &RowChannel{}
+	mrc.InitWithNumSenders([]sqlbase.ColumnType{columnTypeInt}, 5)
 	for i := 1; i <= 5; i++ {
 		go func(i int) {
 			for j := 1; j <= 100; j++ {


### PR DESCRIPTION
Previously, the DistSQL input synchronizers used RowChannels to
send incoming messages to the first processor in every flow. Each
incoming message was sent by itself through the row channel. As we know,
sending a message through a Go channel is relatively slow - it's better
to send fewer, large messages through a channel than many, small ones.
Furthermore, incoming messages in DistSQL are already bundled into
batches by the DistSQL network layer, which sends a chunk of rows over
the network at once instead of row by row. The receiver used to get that
batch, just to decompose it into individual rows to send over the row
channel.

This commit introduces a new interface, BatchRowReceiver, along with a
matching BatchRowChannel implementation. It behaves as an ordinary
RowSource, returning a single row at once, but it permits batch Push
access with a new method PushBatch. This is much more efficient.

This change doesn't appear to change overall query performance, but
the microbenchmarks show a large change.

```
BenchmarkRowChannelPipeline/length=1-8          10000000               125 ns/op          63.53 MB/s
BenchmarkBatchRowChannel-8                       3000000               515 ns/op         248.23 MB/s
```

Closes #25207.

Release note: None