### PR TITLE
distsqlrun: make txn mem mon own local flow's

### DIFF
--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -206,7 +206,7 @@ func (dsp *DistSQLPlanner) Run(
 		Flow:        flows[thisNodeID],
 		EvalContext: evalCtxProto,
 	}
-	ctx, flow, err := dsp.distSQLSrv.SetupSyncFlow(ctx, &localReq, recv)
+	ctx, flow, err := dsp.distSQLSrv.SetupSyncFlow(ctx, evalCtx.Mon, &localReq, recv)
 	if err != nil {
 		recv.SetError(err)
 		return

--- a/pkg/sql/distsqlplan/aggregator_funcs_test.go
+++ b/pkg/sql/distsqlplan/aggregator_funcs_test.go
@@ -68,7 +68,7 @@ func runTestFlow(
 
 	var rowBuf distsqlrun.RowBuffer
 
-	ctx, flow, err := distSQLSrv.SetupSyncFlow(context.TODO(), &req, &rowBuf)
+	ctx, flow, err := distSQLSrv.SetupSyncFlow(context.TODO(), distSQLSrv.ParentMemoryMonitor, &req, &rowBuf)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/sql/distsqlrun/flow_registry_test.go
+++ b/pkg/sql/distsqlrun/flow_registry_test.go
@@ -541,7 +541,7 @@ func TestSyncFlowAfterDrain(t *testing.T) {
 
 	types := make([]sqlbase.ColumnType, 0)
 	rb := NewRowBuffer(types, nil /* rows */, RowBufferArgs{})
-	ctx, flow, err := distSQLSrv.SetupSyncFlow(ctx, &req, rb)
+	ctx, flow, err := distSQLSrv.SetupSyncFlow(ctx, &distSQLSrv.memMonitor, &req, rb)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Previously, DistSQL flows that were local to the coordinator node used a
memory monitor that was owned by a generic distsql memory monitor. This
was misleading, as it prevented memory used by distsql local to a node
from showing up in the query's used memory.

Now, a query's transaction memory monitor is passed to the local distsql
flow created for it. The remote distsql flows still are monitored by the
generic distsql one, but this is a start at bettering the situation.

Closes #25879.

Release note: None