### PR TITLE
roachtest: fix store generation

### DIFF
--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -223,7 +223,7 @@ func execCmdWithBuffer(ctx context.Context, l *logger, args ...string) ([]byte, 
 
 	out, err := cmd.CombinedOutput()
 	if err != nil {
-		return nil, errors.Wrapf(err, `%s`, strings.Join(args, ` `))
+		return out, errors.Wrapf(err, `%s`, strings.Join(args, ` `))
 	}
 	return out, nil
 }

--- a/pkg/cmd/roachtest/main.go
+++ b/pkg/cmd/roachtest/main.go
@@ -147,6 +147,7 @@ Cockroach cluster with existing data.
 		RunE: func(_ *cobra.Command, args []string) error {
 			r := newRegistry()
 			registerStoreGen(r, args)
+			clusterWipe = true
 			// We've only registered one store generation "test" that does its own
 			// argument processing, so no need to provide any arguments to r.Run.
 			os.Exit(r.Run(nil /* filter */))

--- a/pkg/cmd/roachtest/store_gen.go
+++ b/pkg/cmd/roachtest/store_gen.go
@@ -31,11 +31,12 @@ func storeDirURL(fixtureURL string, stores int, binVersion string) string {
 }
 
 func storeDumpExists(ctx context.Context, c *cluster, storeDirPath string) (bool, error) {
-	err := c.RunE(ctx, c.Node(1), fmt.Sprintf("gsutil -m -q ls %s &> /dev/null", storeDirPath))
+	output, err := c.RunWithBuffer(ctx, c.l, c.Node(1),
+		fmt.Sprintf("gsutil -m -q ls %s", storeDirPath))
 	if err == nil {
 		return true, nil
 	}
-	if strings.Contains(err.Error(), "matched no objects") {
+	if strings.Contains(string(output), "matched no objects") {
 		return false, nil
 	}
 	return false, err

--- a/pkg/cmd/roachtest/tpcc.go
+++ b/pkg/cmd/roachtest/tpcc.go
@@ -379,8 +379,9 @@ func registerTPCCBench(r *registry) {
 			CPUs:  16,
 			Chaos: true,
 
-			LoadWarehouses: 5000,
-			EstimatedMax:   500,
+			LoadWarehouses:  5000,
+			EstimatedMax:    500,
+			StoreDirVersion: "2.0-5",
 		},
 		// objective 3, key result 2.
 		{


### PR DESCRIPTION
This change fixes store generation's detection of existing stores. It
also changes store-gen to wipe the cluster after it has completed.