### PR TITLE
distsql: fix a tablereader planning bug

### DIFF
--- a/pkg/sql/distsqlrun/input_sync.go
+++ b/pkg/sql/distsqlrun/input_sync.go
@@ -241,7 +241,8 @@ func (s *orderedSynchronizer) advanceRoot() error {
 			return err
 		} else if cmp > 0 {
 			return errors.Errorf(
-				"incorrectly ordered stream %s after %s", src.row.String(s.types), oldRow.String(s.types),
+				"incorrectly ordered stream %s after %s (ordering: %v)",
+				src.row.String(s.types), oldRow.String(s.types), s.ordering,
 			)
 		}
 	}

--- a/pkg/sql/logictest/testdata/logic_test/collatedstring_nullinindex
+++ b/pkg/sql/logictest/testdata/logic_test/collatedstring_nullinindex
@@ -1,4 +1,4 @@
-# LogicTest: default opt parallel-stmts distsql distsql-metadata distsql-disk
+# LogicTest: default opt parallel-stmts distsql distsql-opt distsql-metadata distsql-disk
 
 statement ok
 CREATE TABLE t (

--- a/pkg/sql/logictest/testdata/logic_test/computed
+++ b/pkg/sql/logictest/testdata/logic_test/computed
@@ -1,4 +1,4 @@
-# LogicTest: default opt parallel-stmts distsql distsql-metadata
+# LogicTest: default opt parallel-stmts distsql distsql-opt distsql-metadata
 
 statement ok
 CREATE TABLE with_no_column_refs (


### PR DESCRIPTION
Fixing a planning bug related to scanNodes created by the optimizer;
we weren't using the new map in one place.

Enabling the `distsql-opt` config for `collatedstring_nullinindex` and `computed`.

Release note: None