### PR TITLE
sql: fix flaky ShowSessions and disable TestColumnConversions/TIME-TIMETZ

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/alter_column_type
+++ b/pkg/sql/logictest/testdata/logic_test/alter_column_type
@@ -9,8 +9,9 @@ CREATE TABLE t (s STRING, sl STRING(5), t TIME, ts TIMESTAMP)
 statement ok
 INSERT INTO t VALUES ('some string', 'short', TIME '20:16:27', '2018-05-23 20:16:27.658082')
 
+# Not using TIMETZ until #26074 and #25224 are resolved.
 statement ok
-ALTER TABLE t ALTER s TYPE BYTES, ALTER sl TYPE STRING(6), ALTER t TYPE TIMETZ, ALTER ts TYPE TIMESTAMPTZ
+ALTER TABLE t ALTER s TYPE BYTES, ALTER sl TYPE STRING(6), ALTER ts TYPE TIMESTAMPTZ
 
 query TTBTT colnames
 SHOW COLUMNS FROM t
@@ -18,7 +19,7 @@ SHOW COLUMNS FROM t
 Field  Type                      Null  Default  Indices
 s      BYTES                     true  NULL     {}
 sl     STRING(6)                 true  NULL     {}
-t      TIMETZ                    true  NULL     {}
+t      TIME                      true  NULL     {}
 ts     TIMESTAMP WITH TIME ZONE  true  NULL     {}
 
 query TTTT

--- a/pkg/sql/schemachange/alter_column_type.go
+++ b/pkg/sql/schemachange/alter_column_type.go
@@ -122,12 +122,13 @@ var classifiers = map[sqlbase.ColumnType_SemanticType]map[sqlbase.ColumnType_Sem
 		},
 		sqlbase.ColumnType_STRING: classifierWidth,
 	},
-	sqlbase.ColumnType_TIME: {
-		sqlbase.ColumnType_TIMETZ: ColumnConversionTrivial.classifier(),
-	},
-	sqlbase.ColumnType_TIMETZ: {
-		sqlbase.ColumnType_TIME: ColumnConversionTrivial.classifier(),
-	},
+	// #26078
+	// sqlbase.ColumnType_TIME: {
+	// sqlbase.ColumnType_TIMETZ: ColumnConversionTrivial.classifier(),
+	// },
+	// sqlbase.ColumnType_TIMETZ: {
+	// sqlbase.ColumnType_TIME: ColumnConversionTrivial.classifier(),
+	// },
 	sqlbase.ColumnType_TIMESTAMP: {
 		sqlbase.ColumnType_TIMESTAMPTZ: ColumnConversionTrivial.classifier(),
 	},

--- a/pkg/sql/schemachange/alter_column_type_test.go
+++ b/pkg/sql/schemachange/alter_column_type_test.go
@@ -126,12 +126,13 @@ func TestColumnConversions(t *testing.T) {
 			{SemanticType: sqlbase.ColumnType_BYTES, Width: 20}: ColumnConversionTrivial,
 		},
 
-		{SemanticType: sqlbase.ColumnType_TIME}: {
-			{SemanticType: sqlbase.ColumnType_TIMETZ}: ColumnConversionTrivial,
-		},
-		{SemanticType: sqlbase.ColumnType_TIMETZ}: {
-			{SemanticType: sqlbase.ColumnType_TIME}: ColumnConversionTrivial,
-		},
+		// Disabled until #26078 is resolved
+		// {SemanticType: sqlbase.ColumnType_TIME}: {
+		// {SemanticType: sqlbase.ColumnType_TIMETZ}: ColumnConversionTrivial,
+		// },
+		// {SemanticType: sqlbase.ColumnType_TIMETZ}: {
+		// {SemanticType: sqlbase.ColumnType_TIME}: ColumnConversionTrivial,
+		// },
 
 		{SemanticType: sqlbase.ColumnType_TIMESTAMP}: {
 			{SemanticType: sqlbase.ColumnType_TIMESTAMPTZ}: ColumnConversionTrivial,


### PR DESCRIPTION
-  Disables TIME/TIMETZ conversions until #26074 #26076 #26077 #26078 are addressed.

- For TestShowSessions: Needed to disable a couple of features (event logging, migrations,
  automatic upgrades) that cause automatic internal queries to be executed
  that get in the way of the expected output to show sessions.

Fixes #25331.
Fixes #25733.
