### PR TITLE
opt: push filter into scanNode when execbuilding

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/join
+++ b/pkg/sql/opt/exec/execbuilder/testdata/join
@@ -46,16 +46,15 @@ SELECT "Tree", "Field", "Description" FROM [
 EXPLAIN (VERBOSE) SELECT * FROM twocolumn AS a JOIN twocolumn AS b ON a.x = 44
 ]
 ----
-join            ·       ·
- │              type    cross
- ├── filter     ·       ·
- │    │         filter  x = 44
- │    └── scan  ·       ·
- │              table   twocolumn@primary
- │              spans   ALL
- └── scan       ·       ·
-·               table   twocolumn@primary
-·               spans   ALL
+join       ·       ·
+ │         type    cross
+ ├── scan  ·       ·
+ │         table   twocolumn@primary
+ │         spans   ALL
+ │         filter  x = 44
+ └── scan  ·       ·
+·          table   twocolumn@primary
+·          spans   ALL
 
 query TTT
 SELECT "Tree", "Field", "Description" FROM [
@@ -458,20 +457,19 @@ SELECT *
  WHERE b > 1 AND (n IS NULL OR n > 1) AND (n IS NULL OR a  < sq)
 ]
 ----
-filter               ·         ·
- │                   filter    ((n IS NULL) OR (n > 1)) AND ((n IS NULL) OR (a < sq))
- └── join            ·         ·
-      │              type      left outer
-      │              equality  (b) = (sq)
-      │              pred      a > 1
-      ├── filter     ·         ·
-      │    │         filter    b > 1
-      │    └── scan  ·         ·
-      │              table     pairs@primary
-      │              spans     ALL
-      └── scan       ·         ·
-·                    table     square@primary
-·                    spans     -/5/#
+filter          ·         ·
+ │              filter    ((n IS NULL) OR (n > 1)) AND ((n IS NULL) OR (a < sq))
+ └── join       ·         ·
+      │         type      left outer
+      │         equality  (b) = (sq)
+      │         pred      a > 1
+      ├── scan  ·         ·
+      │         table     pairs@primary
+      │         spans     ALL
+      │         filter    b > 1
+      └── scan  ·         ·
+·               table     square@primary
+·               spans     -/5/#
 
 query TTT
 SELECT "Tree", "Field", "Description" FROM [
@@ -481,20 +479,19 @@ SELECT *
  WHERE (a IS NULL OR a > 2) AND n > 1 AND (a IS NULL OR a < sq)
 ]
 ----
-filter               ·         ·
- │                   filter    ((a IS NULL) OR (a > 2)) AND ((a IS NULL) OR (a < sq))
- └── join            ·         ·
-      │              type      right outer
-      │              equality  (b) = (sq)
-      │              pred      n < 6
-      ├── filter     ·         ·
-      │    │         filter    a > 1
-      │    └── scan  ·         ·
-      │              table     pairs@primary
-      │              spans     ALL
-      └── scan       ·         ·
-·                    table     square@primary
-·                    spans     /2-
+filter          ·         ·
+ │              filter    ((a IS NULL) OR (a > 2)) AND ((a IS NULL) OR (a < sq))
+ └── join       ·         ·
+      │         type      right outer
+      │         equality  (b) = (sq)
+      │         pred      n < 6
+      ├── scan  ·         ·
+      │         table     pairs@primary
+      │         spans     ALL
+      │         filter    a > 1
+      └── scan  ·         ·
+·               table     square@primary
+·               spans     /2-
 
 # The simpler plan for an inner join, to compare.
 query TTT
@@ -505,18 +502,17 @@ SELECT *
  WHERE (a IS NULL OR a > 2) AND n > 1 AND (a IS NULL OR a < sq)
 ]
 ----
-join            ·         ·
- │              type      inner
- │              equality  (b) = (sq)
- │              pred      (a IS NULL) OR (a < sq)
- ├── filter     ·         ·
- │    │         filter    (a > 1) AND ((a IS NULL) OR (a > 2))
- │    └── scan  ·         ·
- │              table     pairs@primary
- │              spans     ALL
- └── scan       ·         ·
-·               table     square@primary
-·               spans     /2-/5/#
+join       ·         ·
+ │         type      inner
+ │         equality  (b) = (sq)
+ │         pred      (a IS NULL) OR (a < sq)
+ ├── scan  ·         ·
+ │         table     pairs@primary
+ │         spans     ALL
+ │         filter    (a > 1) AND ((a IS NULL) OR (a > 2))
+ └── scan  ·         ·
+·          table     square@primary
+·          spans     /2-/5/#
 
 
 statement ok
@@ -1038,17 +1034,16 @@ CREATE TABLE abg (
 query TTT
 EXPLAIN SELECT * FROM abcdef join (select * from abg) USING (a,b) WHERE ((a,b)>(1,2) OR ((a,b)=(1,2) AND c < 6) OR ((a,b,c)=(1,2,6) AND d > 8))
 ----
-render               ·         ·
- └── join            ·         ·
-      │              type      inner
-      │              equality  (a, b) = (a, b)
-      ├── filter     ·         ·
-      │    └── scan  ·         ·
-      │              table     abcdef@primary
-      │              spans     /1/2/6/9-
-      └── scan       ·         ·
-·                    table     abg@primary
-·                    spans     ALL
+render          ·         ·
+ └── join       ·         ·
+      │         type      inner
+      │         equality  (a, b) = (a, b)
+      ├── scan  ·         ·
+      │         table     abcdef@primary
+      │         spans     /1/2/6/9-
+      └── scan  ·         ·
+·               table     abg@primary
+·               spans     ALL
 
 # Regression tests for mixed-type equality columns (#22514).
 statement ok

--- a/pkg/sql/opt/exec/execbuilder/testdata/orderby
+++ b/pkg/sql/opt/exec/execbuilder/testdata/orderby
@@ -239,13 +239,22 @@ scan  ·      ·
 query TTT
 EXPLAIN SELECT a, b, c FROM abc WHERE b > 10 ORDER BY b, a, d
 ----
-render               ·      ·
- └── sort            ·      ·
-      │              order  +b,+a,+d
-      └── filter     ·      ·
-           └── scan  ·      ·
-·                    table  abc@primary
-·                    spans  ALL
+render          ·      ·
+ └── sort       ·      ·
+      │         order  +b,+a,+d
+      └── scan  ·      ·
+·               table  abc@primary
+·               spans  ALL
+
+query III
+SELECT a, b, c FROM abc WHERE b > 4 ORDER BY b, a, d
+----
+4  5  6
+
+query III
+SELECT a, b, c FROM abc WHERE b > 4 ORDER BY b, a, d
+----
+4  5  6
 
 # We cannot have rows with identical values for a,b,c so we don't need to
 # sort for d.
@@ -253,13 +262,12 @@ render               ·      ·
 query TTTTT
 EXPLAIN (VERBOSE) SELECT a, b, c, d FROM abc WHERE b > 10 ORDER BY b, a, c, d
 ----
-sort            ·       ·            (a, b, c, d)  +b,+a,+c,+d
- │              order   +b,+a,+c,+d  ·             ·
- └── filter     ·       ·            (a, b, c, d)  ·
-      │         filter  b > 10       ·             ·
-      └── scan  ·       ·            (a, b, c, d)  ·
-·               table   abc@primary  ·             ·
-·               spans   ALL          ·             ·
+sort       ·       ·            (a, b, c, d)  +b,+a,+c,+d
+ │         order   +b,+a,+c,+d  ·             ·
+ └── scan  ·       ·            (a, b, c, d)  ·
+·          table   abc@primary  ·             ·
+·          spans   ALL          ·             ·
+·          filter  b > 10       ·             ·
 
 query TTT
 EXPLAIN SELECT a, b FROM abc ORDER BY b, c

--- a/pkg/sql/opt/exec/execbuilder/testdata/project
+++ b/pkg/sql/opt/exec/execbuilder/testdata/project
@@ -22,11 +22,10 @@ SELECT * FROM a WHERE x > 1
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM a WHERE y > 1
 ----
-filter     ·       ·          (x, y)  ·
- │         filter  y > 1      ·       ·
- └── scan  ·       ·          (x, y)  ·
-·          table   a@primary  ·       ·
-·          spans   ALL        ·       ·
+scan  ·       ·          (x, y)  ·
+·     table   a@primary  ·       ·
+·     spans   ALL        ·       ·
+·     filter  y > 1      ·       ·
 
 query II
 SELECT * FROM a WHERE y > 1
@@ -124,14 +123,13 @@ SELECT x, x, y, x FROM a
 query TTTTT
 EXPLAIN (VERBOSE) SELECT x + 1, x + y FROM a WHERE x + y > 20
 ----
-render          ·         ·             ("x + 1", "x + y")  ·
- │              render 0  x + 1         ·                   ·
- │              render 1  x + y         ·                   ·
- └── filter     ·         ·             (x, y)              ·
-      │         filter    (x + y) > 20  ·                   ·
-      └── scan  ·         ·             (x, y)              ·
-·               table     a@primary     ·                   ·
-·               spans     ALL           ·                   ·
+render     ·         ·             ("x + 1", "x + y")  ·
+ │         render 0  x + 1         ·                   ·
+ │         render 1  x + y         ·                   ·
+ └── scan  ·         ·             (x, y)              ·
+·          table     a@primary     ·                   ·
+·          spans     ALL           ·                   ·
+·          filter    (x + y) > 20  ·                   ·
 
 query II
 SELECT x + 1, x + y FROM a WHERE x + y > 20

--- a/pkg/sql/opt/exec/execbuilder/testdata/scalar
+++ b/pkg/sql/opt/exec/execbuilder/testdata/scalar
@@ -480,24 +480,22 @@ NULL
 query TTTTT
 EXPLAIN (VERBOSE) SELECT a FROM t WHERE a BETWEEN b AND d
 ----
-render          ·         ·                      (a)        ·
- │              render 0  a                      ·          ·
- └── filter     ·         ·                      (a, b, d)  ·
-      │         filter    (a >= b) AND (a <= d)  ·          ·
-      └── scan  ·         ·                      (a, b, d)  ·
-·               table     t@primary              ·          ·
-·               spans     ALL                    ·          ·
+render     ·         ·                      (a)        ·
+ │         render 0  a                      ·          ·
+ └── scan  ·         ·                      (a, b, d)  ·
+·          table     t@primary              ·          ·
+·          spans     ALL                    ·          ·
+·          filter    (a >= b) AND (a <= d)  ·          ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT a FROM t WHERE a NOT BETWEEN b AND d
 ----
-render          ·         ·                   (a)        ·
- │              render 0  a                   ·          ·
- └── filter     ·         ·                   (a, b, d)  ·
-      │         filter    (a < b) OR (a > d)  ·          ·
-      └── scan  ·         ·                   (a, b, d)  ·
-·               table     t@primary           ·          ·
-·               spans     ALL                 ·          ·
+render     ·         ·                   (a)        ·
+ │         render 0  a                   ·          ·
+ └── scan  ·         ·                   (a, b, d)  ·
+·          table     t@primary           ·          ·
+·          spans     ALL                 ·          ·
+·          filter    (a < b) OR (a > d)  ·          ·
 
 query TTTTT
 EXPLAIN (VERBOSE) SELECT a BETWEEN SYMMETRIC b AND d FROM t

--- a/pkg/sql/opt/exec/execbuilder/testdata/select
+++ b/pkg/sql/opt/exec/execbuilder/testdata/select
@@ -20,11 +20,10 @@ SELECT * FROM a WHERE x > 1
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM a WHERE y > 10
 ----
-filter     ·       ·          (x, y)  ·
- │         filter  y > 10     ·       ·
- └── scan  ·       ·          (x, y)  ·
-·          table   a@primary  ·       ·
-·          spans   ALL        ·       ·
+scan  ·       ·          (x, y)  ·
+·     table   a@primary  ·       ·
+·     spans   ALL        ·       ·
+·     filter  y > 10     ·       ·
 
 query II rowsort
 SELECT * FROM a WHERE y > 10
@@ -47,11 +46,10 @@ SELECT * FROM a WHERE x > 1 AND x < 3
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM a WHERE x > 1 AND y < 30
 ----
-filter     ·       ·          (x, y)  ·
- │         filter  y < 30     ·       ·
- └── scan  ·       ·          (x, y)  ·
-·          table   a@primary  ·       ·
-·          spans   /2-        ·       ·
+scan  ·       ·          (x, y)  ·
+·     table   a@primary  ·       ·
+·     spans   /2-        ·       ·
+·     filter  y < 30     ·       ·
 
 query II
 SELECT * FROM a WHERE x > 1 AND y < 30
@@ -239,11 +237,10 @@ scan  ·      ·                (d decimal)  ·
 query TTTTT
 EXPLAIN (TYPES) SELECT * FROM dec2 WHERE isnan(d)
 ----
-filter     ·       ·                            (d decimal)  ·
- │         filter  (isnan((d)[decimal]))[bool]  ·            ·
- └── scan  ·       ·                            (d decimal)  ·
-·          table   dec2@primary                 ·            ·
-·          spans   ALL                          ·            ·
+scan  ·       ·                            (d decimal)  ·
+·     table   dec2@primary                 ·            ·
+·     spans   ALL                          ·            ·
+·     filter  (isnan((d)[decimal]))[bool]  ·            ·
 
 # ------------------------------------------------------------------------------
 # Verify that lookups for Float NaN use indices when possible:
@@ -271,11 +268,10 @@ scan  ·      ·                    (f float)  ·
 query TTTTT
 EXPLAIN (TYPES) SELECT * FROM flt WHERE isnan(f)
 ----
-filter     ·       ·                          (f float)  ·
- │         filter  (isnan((f)[float]))[bool]  ·          ·
- └── scan  ·       ·                          (f float)  ·
-·          table   flt@primary                ·          ·
-·          spans   ALL                        ·          ·
+scan  ·       ·                          (f float)  ·
+·     table   flt@primary                ·          ·
+·     spans   ALL                        ·          ·
+·     filter  (isnan((f)[float]))[bool]  ·          ·
 
 # ------------------------------------------------------------------------------
 # ANY, ALL tests.

--- a/pkg/sql/opt/exec/execbuilder/testdata/stats
+++ b/pkg/sql/opt/exec/execbuilder/testdata/stats
@@ -20,8 +20,7 @@ CREATE STATISTICS v ON v FROM b
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM b WHERE u = 1 AND v = 1
 ----
-filter     ·       ·          (u, v)  ·
- │         filter  u = 1      ·       ·
- └── scan  ·       ·          (u, v)  ·
-·          table   b@b_v_idx  ·       ·
-·          spans   /1-/2      ·       ·
+scan  ·       ·          (u, v)  ·
+·     table   b@b_v_idx  ·       ·
+·     spans   /1-/2      ·       ·
+·     filter  u = 1      ·       ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/subquery
+++ b/pkg/sql/opt/exec/execbuilder/testdata/subquery
@@ -7,19 +7,18 @@ INSERT INTO t VALUES (1, 1, 1), (2, 4, 8), (3, 9, 27), (4, 16, 64)
 query TTTTT
 EXPLAIN (VERBOSE) SELECT EXISTS(SELECT * FROM t WHERE u = k*k)
 ----
-root                 ·          ·                 ("EXISTS (SELECT * FROM t WHERE u = (k * k))")  ·
- ├── render          ·          ·                 ("EXISTS (SELECT * FROM t WHERE u = (k * k))")  ·
- │    │              render 0   @S1               ·                                               ·
- │    └── emptyrow   ·          ·                 ()                                              ·
- └── subquery        ·          ·                 ("EXISTS (SELECT * FROM t WHERE u = (k * k))")  ·
-      │              id         @S1               ·                                               ·
-      │              sql        EXISTS <unknown>  ·                                               ·
-      │              exec mode  exists            ·                                               ·
-      └── filter     ·          ·                 (k, u, v)                                       ·
-           │         filter     u = (k * k)       ·                                               ·
-           └── scan  ·          ·                 (k, u, v)                                       ·
-·                    table      t@primary         ·                                               ·
-·                    spans      ALL               ·                                               ·
+root                ·          ·                 ("EXISTS (SELECT * FROM t WHERE u = (k * k))")  ·
+ ├── render         ·          ·                 ("EXISTS (SELECT * FROM t WHERE u = (k * k))")  ·
+ │    │             render 0   @S1               ·                                               ·
+ │    └── emptyrow  ·          ·                 ()                                              ·
+ └── subquery       ·          ·                 ("EXISTS (SELECT * FROM t WHERE u = (k * k))")  ·
+      │             id         @S1               ·                                               ·
+      │             sql        EXISTS <unknown>  ·                                               ·
+      │             exec mode  exists            ·                                               ·
+      └── scan      ·          ·                 (k, u, v)                                       ·
+·                   table      t@primary         ·                                               ·
+·                   spans      ALL               ·                                               ·
+·                   filter     u = (k * k)       ·                                               ·
 
 query B
 SELECT EXISTS(SELECT * FROM t WHERE u = k*k)
@@ -35,11 +34,10 @@ query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM t WHERE u = (SELECT MAX(u) FROM t)
 ----
 root                 ·            ·          (k, u, v)  ·
- ├── filter          ·            ·          (k, u, v)  ·
- │    │              filter       u = @S1    ·          ·
- │    └── scan       ·            ·          (k, u, v)  ·
+ ├── scan            ·            ·          (k, u, v)  ·
  │                   table        t@primary  ·          ·
  │                   spans        ALL        ·          ·
+ │                   filter       u = @S1    ·          ·
  └── subquery        ·            ·          (k, u, v)  ·
       │              id           @S1        ·          ·
       │              sql          <unknown>  ·          ·
@@ -58,32 +56,29 @@ SELECT * FROM t WHERE u = (SELECT MAX(u) FROM t)
 query TTTTT
 EXPLAIN (VERBOSE) SELECT * FROM t WHERE u = (SELECT MAX(u) FROM t WHERE EXISTS(SELECT * FROM t WHERE u=k*k))
 ----
-root                      ·            ·                 (k, u, v)  ·
- ├── filter               ·            ·                 (k, u, v)  ·
- │    │                   filter       u = @S2           ·          ·
- │    └── scan            ·            ·                 (k, u, v)  ·
- │                        table        t@primary         ·          ·
- │                        spans        ALL               ·          ·
- ├── subquery             ·            ·                 (k, u, v)  ·
- │    │                   id           @S1               ·          ·
- │    │                   sql          EXISTS <unknown>  ·          ·
- │    │                   exec mode    exists            ·          ·
- │    └── filter          ·            ·                 (k, u, v)  ·
- │         │              filter       u = (k * k)       ·          ·
- │         └── scan       ·            ·                 (k, u, v)  ·
- │                        table        t@primary         ·          ·
- │                        spans        ALL               ·          ·
- └── subquery             ·            ·                 (k, u, v)  ·
-      │                   id           @S2               ·          ·
-      │                   sql          <unknown>         ·          ·
-      │                   exec mode    one row           ·          ·
-      └── group           ·            ·                 (agg0)     ·
-           │              aggregate 0  max(u)            ·          ·
-           └── filter     ·            ·                 (u)        ·
-                │         filter       @S1               ·          ·
-                └── scan  ·            ·                 (u)        ·
-·                         table        t@primary         ·          ·
-·                         spans        ALL               ·          ·
+root                 ·            ·                 (k, u, v)  ·
+ ├── scan            ·            ·                 (k, u, v)  ·
+ │                   table        t@primary         ·          ·
+ │                   spans        ALL               ·          ·
+ │                   filter       u = @S2           ·          ·
+ ├── subquery        ·            ·                 (k, u, v)  ·
+ │    │              id           @S1               ·          ·
+ │    │              sql          EXISTS <unknown>  ·          ·
+ │    │              exec mode    exists            ·          ·
+ │    └── scan       ·            ·                 (k, u, v)  ·
+ │                   table        t@primary         ·          ·
+ │                   spans        ALL               ·          ·
+ │                   filter       u = (k * k)       ·          ·
+ └── subquery        ·            ·                 (k, u, v)  ·
+      │              id           @S2               ·          ·
+      │              sql          <unknown>         ·          ·
+      │              exec mode    one row           ·          ·
+      └── group      ·            ·                 (agg0)     ·
+           │         aggregate 0  max(u)            ·          ·
+           └── scan  ·            ·                 (u)        ·
+·                    table        t@primary         ·          ·
+·                    spans        ALL               ·          ·
+·                    filter       @S1               ·          ·
 
 query III
 SELECT * FROM t WHERE u = (SELECT MAX(u) FROM t WHERE EXISTS(SELECT * FROM t WHERE u=k*k))

--- a/pkg/sql/opt_exec_factory.go
+++ b/pkg/sql/opt_exec_factory.go
@@ -106,6 +106,12 @@ func asDataSource(n exec.Node) planDataSource {
 
 // ConstructFilter is part of the exec.Factory interface.
 func (ef *execFactory) ConstructFilter(n exec.Node, filter tree.TypedExpr) (exec.Node, error) {
+	if s, ok := n.(*scanNode); ok && s.filter == nil {
+		// Push the filter into the scanNode.
+		s.filter = s.filterVars.Rebind(filter, true /* alsoReset */, false /* normalizeToNonNil */)
+		return s, nil
+	}
+	// Create a filterNode.
 	src := asDataSource(n)
 	f := &filterNode{
 		source: src,


### PR DESCRIPTION
We try to put the filter in the `scanNode` when possible. This makes
the plans shorter and closer to those of the heuristic planner; but
the main reason is that a DistSQL "should distribute" heuristic checks
if scanNodes have filters.

Release note: None