### PR TITLE
scripts: EternalShell support for gceworker

### DIFF
--- a/build/bootstrap/bootstrap-debian.sh
+++ b/build/bootstrap/bootstrap-debian.sh
@@ -28,7 +28,7 @@ sudo adduser "${USER}" docker
 
 # Configure environment variables
 echo 'export PATH="/usr/lib/ccache:${PATH}"' >> ~/.bashrc_bootstrap
-echo 'export COCKROACH_BUILDER_CCACHE=1"' >> ~/.bashrc_bootstrap
+echo 'export COCKROACH_BUILDER_CCACHE=1' >> ~/.bashrc_bootstrap
 # NB: GOPATH defaults to ${HOME}/go (but maybe having it set for the remainder
 # of the script is enough reason to keep it here).
 echo 'export GOPATH=${HOME}/go' >> ~/.bashrc_bootstrap

--- a/scripts/gceworker.sh
+++ b/scripts/gceworker.sh
@@ -30,12 +30,16 @@ case "${cmd}" in
            --boot-disk-device-name "${NAME}" \
            --scopes "default,cloud-platform"
     gcloud compute firewall-rules create "${NAME}-mosh" --allow udp:60000-61000
+    gcloud compute firewall-rules create "${NAME}-et" --allow tcp:2022
 
     # Retry while vm and sshd to start up.
     retry gcloud compute ssh "${NAME}" --command=true
 
     gcloud compute copy-files "build/bootstrap" "${NAME}:bootstrap"
     gcloud compute ssh "${NAME}" --ssh-flag="-A" --command="./bootstrap/bootstrap-debian.sh"
+    # This was not put in bootstrap-debian.sh because it's for Ubuntu (the Debian version of it
+    # was broken).
+    gcloud compute ssh "${NAME}" --ssh-flag="-A" --command="sudo add-apt-repository ppa:jgmath2000/et && sudo apt-get update && sudo apt-get install -y --no-install-recommends et"
 
     if [[ -n "${cr_dev_license}" ]]; then
         $0 ssh "echo COCKROACH_DEV_LICENSE=${cr_dev_license} >> ~/.bashrc_bootstrap"
@@ -55,11 +59,17 @@ case "${cmd}" in
     delete|destroy)
     status=0
     gcloud compute firewall-rules delete "${NAME}-mosh" || status=$((status+1))
+    gcloud compute firewall-rules delete "${NAME}-et" || status=$((status+1))
     gcloud compute instances delete "${NAME}" || status=$((status+1))
     exit ${status}
     ;;
     ssh)
     retry gcloud compute ssh "${NAME}" --ssh-flag="-A" "$@"
+    ;;
+    et)
+    read -r -a arr <<< "$(gcloud compute ssh "${NAME}" --dry-run)"
+    host="${arr[-1]}"
+    et "${host}"
     ;;
     mosh)
     # An alternative solution would be to run gcloud compute config-ssh after


### PR DESCRIPTION
`mosh` is nice, but it messes with the scrollback capabilities of the
terminal, which is unfortunate when the shell is used for long-running
commands whose output matters.

Baking in workarounds for mosh into gceworker seemed more complex than also
offering EternalShell (et), which works in more predictable ways.
`et` does not offer "typing prediction" and thus feels a little less
snappy, but our gceworkers are typically not high-latency.

Also fixes a typo in the .bashrc_bootstrap file. Not sure how this worked
in the past.

Release note: None