### PR TITLE
sql: miscellaneous INSERT, UPSERT and UPDATE correctness fixes

### DIFF
--- a/pkg/ccl/importccl/load.go
+++ b/pkg/ccl/importccl/load.go
@@ -333,6 +333,10 @@ func (i inserter) CPut(key, value, expValue interface{}) {
 	panic("unimplemented")
 }
 
+func (i inserter) Del(key ...interface{}) {
+	panic("unimplemented")
+}
+
 func (i inserter) Put(key, value interface{}) {
 	i(roachpb.KeyValue{
 		Key:   *key.(*roachpb.Key),

--- a/pkg/sql/logictest/testdata/logic_test/update
+++ b/pkg/sql/logictest/testdata/logic_test/update
@@ -514,3 +514,33 @@ SELECT * FROM kv
 1  1
 2  3
 3  4
+
+# Check that updates on tables with multiple column families behave as
+# they should.
+
+statement ok
+CREATE TABLE tu (a INT PRIMARY KEY, b INT, c INT, d INT, FAMILY (a), FAMILY (b), FAMILY (c,d));
+  INSERT INTO tu VALUES (1, 2, 3, 4)
+
+query T
+SELECT message FROM [SHOW KV TRACE FOR UPDATE tu SET b = NULL, c = NULL, d = NULL]
+----
+Scan /Table/63/{1-2}
+querying next range at /Table/63/1
+r1: sending batch 1 Scan to (n1,s1):1
+fetched: /tu/primary/1 -> NULL
+fetched: /tu/primary/1/b -> 2
+fetched: /tu/primary/1/c/d -> /3/4
+Del /Table/63/1/1/1/1
+Del /Table/63/1/1/2/1
+querying next range at /Table/63/1/1/1/1
+r1: sending batch 2 Del, 1 BeginTxn to (n1,s1):1
+fast path - rows affected: 1
+
+statement ok
+UPDATE tu SET b = NULL, c = NULL, d = NULL
+
+query IIII rowsort
+SELECT * FROM tu
+----
+1 NULL NULL NULL

--- a/pkg/sql/logictest/testdata/logic_test/upsert
+++ b/pkg/sql/logictest/testdata/logic_test/upsert
@@ -415,3 +415,33 @@ count                ·      ·
            └── scan  ·      ·
 ·                    table  kv@primary
 ·                    spans  ALL
+
+# Regression test for #25726.
+# UPSERT over tables with column families, on the fast path, use the
+# INSERT logic. This has special casing for column families of 1
+# column, and another special casing for column families of 2+
+# columns. The special casing is only for families that do not include
+# the primary key. So we need a table with 3 families: 1 for the PK, 1
+# with just 1 col, and 1 with 2+ cols.
+statement ok
+CREATE TABLE tu (a INT PRIMARY KEY, b INT, c INT, d INT, FAMILY (a), FAMILY (b), FAMILY (c,d));
+  INSERT INTO tu VALUES (1, 2, 3, 4)
+
+
+query T
+SELECT message FROM [SHOW KV TRACE FOR UPSERT INTO tu VALUES (1, NULL, NULL, NULL)]
+----
+Put /Table/63/1/1/0 -> /TUPLE/
+Del /Table/63/1/1/1/1
+Del /Table/63/1/1/2/1
+querying next range at /Table/63/1/1/0
+r1: sending batch 1 Put, 2 Del, 1 BeginTxn to (n1,s1):1
+fast path - rows affected: 1
+
+statement ok
+UPSERT INTO tu VALUES (1, NULL, NULL, NULL)
+
+query IIII rowsort
+SELECT * FROM tu
+----
+1 NULL NULL NULL

--- a/pkg/sql/sqlbase/rowwriter.go
+++ b/pkg/sql/sqlbase/rowwriter.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/internal/client"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -164,7 +165,6 @@ type RowInserter struct {
 	marshaled []roachpb.Value
 	key       roachpb.Key
 	valueBuf  []byte
-	scratch   []byte
 	value     roachpb.Value
 }
 
@@ -236,6 +236,14 @@ func insertPutFn(
 	b.Put(key, value)
 }
 
+// insertDelFn is used by insertRow to delete existing rows.
+func insertDelFn(ctx context.Context, b putter, key *roachpb.Key, traceKV bool) {
+	if traceKV {
+		log.VEventfDepth(ctx, 1, 2, "Del %s", *key)
+	}
+	b.Del(key)
+}
+
 // insertPutFn is used by insertRow when conflicts should be ignored.
 func insertInvertedPutFn(
 	ctx context.Context, b putter, key *roachpb.Key, value *roachpb.Value, traceKV bool,
@@ -295,94 +303,13 @@ func (ri *RowInserter) InsertRow(
 	}
 
 	// Add the new values.
-	// TODO(dan): This has gotten very similar to the loop in UpdateRow, see if
-	// they can be DRY'd. Ideally, this would also work for
-	// truncateAndBackfillColumnsChunk, which is currently abusing rowUpdater.
-	for i, family := range ri.Helper.TableDesc.Families {
-		if i > 0 {
-			// HACK: MakeFamilyKey appends to its argument, so on every loop iteration
-			// after the first, trim primaryIndexKey so nothing gets overwritten.
-			// TODO(dan): Instead of this, use something like engine.ChunkAllocator.
-			primaryIndexKey = primaryIndexKey[:len(primaryIndexKey):len(primaryIndexKey)]
-		}
-
-		ri.key = keys.MakeFamilyKey(primaryIndexKey, uint32(family.ID))
-		if len(family.ColumnIDs) == 1 && family.ColumnIDs[0] == family.DefaultColumnID {
-			// Storage optimization to store DefaultColumnID directly as a value. Also
-			// backwards compatible with the original BaseFormatVersion.
-
-			idx, ok := ri.InsertColIDtoRowIndex[family.DefaultColumnID]
-			if !ok {
-				continue
-			}
-
-			if ri.marshaled[idx].RawBytes == nil {
-				if overwrite {
-					// If the new family contains a NULL value, then we must
-					// delete any pre-existing row.
-					if traceKV {
-						log.VEventf(ctx, 2, "Del %s", ri.key)
-					}
-					b.Del(&ri.key)
-				}
-			} else {
-				// We only output non-NULL values. Non-existent column keys are
-				// considered NULL during scanning and the row sentinel ensures we know
-				// the row exists.
-				putFn(ctx, b, &ri.key, &ri.marshaled[idx], traceKV)
-			}
-
-			continue
-		}
-
-		ri.valueBuf = ri.valueBuf[:0]
-
-		var lastColID ColumnID
-		familySortedColumnIDs, ok := ri.Helper.sortedColumnFamily(family.ID)
-		if !ok {
-			panic("invalid family sorted column id map")
-		}
-		for _, colID := range familySortedColumnIDs {
-			idx, ok := ri.InsertColIDtoRowIndex[colID]
-			if !ok || values[idx] == tree.DNull {
-				// Column not being inserted.
-				continue
-			}
-
-			if skip, err := ri.Helper.skipColumnInPK(colID, family.ID, values[idx]); err != nil {
-				return err
-			} else if skip {
-				continue
-			}
-
-			col := ri.InsertCols[idx]
-
-			if lastColID > col.ID {
-				panic(fmt.Errorf("cannot write column id %d after %d", col.ID, lastColID))
-			}
-			colIDDiff := col.ID - lastColID
-			lastColID = col.ID
-			ri.valueBuf, err = EncodeTableValue(ri.valueBuf, colIDDiff, values[idx], ri.scratch)
-			if err != nil {
-				return err
-			}
-		}
-
-		if family.ID != 0 && len(ri.valueBuf) == 0 {
-			if overwrite {
-				// The family might have already existed but every column in it is being
-				// set to NULL, so delete it.
-				if traceKV {
-					log.VEventf(ctx, 2, "Del %s", ri.key)
-				}
-				b.Del(&ri.key)
-			}
-		} else {
-			ri.value.SetTuple(ri.valueBuf)
-			putFn(ctx, b, &ri.key, &ri.value, traceKV)
-		}
-
-		ri.key = nil
+	ri.valueBuf, err = prepareInsertOrUpdateBatch(ctx, b,
+		&ri.Helper, primaryIndexKey, ri.InsertCols,
+		values, ri.InsertColIDtoRowIndex,
+		ri.marshaled, ri.InsertColIDtoRowIndex,
+		&ri.key, &ri.value, ri.valueBuf, putFn, overwrite, traceKV)
+	if err != nil {
+		return err
 	}
 
 	putFn = insertInvertedPutFn
@@ -392,6 +319,143 @@ func (ri *RowInserter) InsertRow(
 	}
 
 	return nil
+}
+
+// prepareInsertOrUpdateBatch constructs a KV batch that inserts or
+// updates a row in KV.
+// - batch is the KV batch where commands should be appended.
+// - putFn is the functions that can append Put/CPut commands to the batch.
+//   (must be adapted depending on whether 'overwrite' is set)
+// - helper is the rowHelper that knows about the table being modified.
+// - primaryIndexKey is the PK prefix for the current row.
+// - updatedCols is the list of schema columns being updated.
+// - values is the SQL-level row values that are being written.
+// - marshaledValues contains the pre-encoded KV-level row values.
+//   marshaledValues is only used when writing single column families.
+//   Regardless of whether there are single column families,
+//   pre-encoding must occur prior to calling this function to check whether
+//   the encoding is _possible_ (i.e. values fit in the column types, etc).
+// - valColIDMapping/marshaledColIDMapping is the mapping from column
+//   IDs into positions of the slices values or marshaledValues.
+// - kvKey and kvValues must be heap-allocated scratch buffers to write
+//   roachpb.Key and roachpb.Value values.
+// - rawValueBuf must be a scratch byte array. This must be reinitialized
+//   to an empty slice on each call but can be preserved at its current
+//   capacity to avoid allocations. The function returns the slice.
+// - overwrite must be set to true for UPDATE and UPSERT.
+// - traceKV is to be set to log the KV operations added to the batch.
+func prepareInsertOrUpdateBatch(
+	ctx context.Context,
+	batch putter,
+	helper *rowHelper,
+	primaryIndexKey []byte,
+	updatedCols []ColumnDescriptor,
+	values []tree.Datum,
+	valColIDMapping map[ColumnID]int,
+	marshaledValues []roachpb.Value,
+	marshaledColIDMapping map[ColumnID]int,
+	kvKey *roachpb.Key,
+	kvValue *roachpb.Value,
+	rawValueBuf []byte,
+	putFn func(ctx context.Context, b putter, key *roachpb.Key, value *roachpb.Value, traceKV bool),
+	overwrite, traceKV bool,
+) ([]byte, error) {
+	for i, family := range helper.TableDesc.Families {
+		update := false
+		for _, colID := range family.ColumnIDs {
+			if _, ok := marshaledColIDMapping[colID]; ok {
+				update = true
+				break
+			}
+		}
+		if !update {
+			continue
+		}
+
+		if i > 0 {
+			// HACK: MakeFamilyKey appends to its argument, so on every loop iteration
+			// after the first, trim primaryIndexKey so nothing gets overwritten.
+			// TODO(dan): Instead of this, use something like engine.ChunkAllocator.
+			primaryIndexKey = primaryIndexKey[:len(primaryIndexKey):len(primaryIndexKey)]
+		}
+
+		*kvKey = keys.MakeFamilyKey(primaryIndexKey, uint32(family.ID))
+		if len(family.ColumnIDs) == 1 && family.ColumnIDs[0] == family.DefaultColumnID {
+			// Storage optimization to store DefaultColumnID directly as a value. Also
+			// backwards compatible with the original BaseFormatVersion.
+
+			idx, ok := marshaledColIDMapping[family.DefaultColumnID]
+			if !ok {
+				continue
+			}
+
+			if marshaledValues[idx].RawBytes == nil {
+				if overwrite {
+					// If the new family contains a NULL value, then we must
+					// delete any pre-existing row.
+					insertDelFn(ctx, batch, kvKey, traceKV)
+				}
+			} else {
+				// We only output non-NULL values. Non-existent column keys are
+				// considered NULL during scanning and the row sentinel ensures we know
+				// the row exists.
+				putFn(ctx, batch, kvKey, &marshaledValues[idx], traceKV)
+			}
+
+			continue
+		}
+
+		rawValueBuf = rawValueBuf[:0]
+
+		var lastColID ColumnID
+		familySortedColumnIDs, ok := helper.sortedColumnFamily(family.ID)
+		if !ok {
+			return nil, pgerror.NewErrorf(pgerror.CodeInternalError,
+				"programming error: invalid family sorted column id map")
+		}
+		for _, colID := range familySortedColumnIDs {
+			idx, ok := valColIDMapping[colID]
+			if !ok || values[idx] == tree.DNull {
+				// Column not being updated or inserted.
+				continue
+			}
+
+			if skip, err := helper.skipColumnInPK(colID, family.ID, values[idx]); err != nil {
+				return nil, err
+			} else if skip {
+				continue
+			}
+
+			col := updatedCols[idx]
+
+			if lastColID > col.ID {
+				return nil, pgerror.NewErrorf(pgerror.CodeInternalError,
+					"programming error: cannot write column id %d after %d", col.ID, lastColID)
+			}
+			colIDDiff := col.ID - lastColID
+			lastColID = col.ID
+			var err error
+			rawValueBuf, err = EncodeTableValue(rawValueBuf, colIDDiff, values[idx], nil)
+			if err != nil {
+				return nil, err
+			}
+		}
+
+		if family.ID != 0 && len(rawValueBuf) == 0 {
+			if overwrite {
+				// The family might have already existed but every column in it is being
+				// set to NULL, so delete it.
+				insertDelFn(ctx, batch, kvKey, traceKV)
+			}
+		} else {
+			kvValue.SetTuple(rawValueBuf)
+			putFn(ctx, batch, kvKey, kvValue, traceKV)
+		}
+
+		*kvKey = nil
+	}
+
+	return rawValueBuf, nil
 }
 
 // EncodeIndexesForRow encodes the provided values into their primary and
@@ -428,7 +492,6 @@ type RowUpdater struct {
 	key             roachpb.Key
 	indexEntriesBuf []IndexEntry
 	valueBuf        []byte
-	scratch         []byte
 	value           roachpb.Value
 }
 
@@ -761,109 +824,13 @@ func (ru *RowUpdater) UpdateRow(
 	}
 
 	// Add the new values.
-	// TODO(dan): This has gotten very similar to the loop in insertRow, see if
-	// they can be DRY'd. Ideally, this would also work for
-	// truncateAndBackfillColumnsChunk, which is currently abusing rowUpdater.
-	for i, family := range ru.Helper.TableDesc.Families {
-		update := false
-		for _, colID := range family.ColumnIDs {
-			if _, ok := ru.updateColIDtoRowIndex[colID]; ok {
-				update = true
-				break
-			}
-		}
-		if !update {
-			continue
-		}
-
-		if i > 0 {
-			// HACK: MakeFamilyKey appends to its argument, so on every loop iteration
-			// after the first, trim primaryIndexKey so nothing gets overwritten.
-			// TODO(dan): Instead of this, use something like engine.ChunkAllocator.
-			primaryIndexKey = primaryIndexKey[:len(primaryIndexKey):len(primaryIndexKey)]
-		}
-
-		if len(family.ColumnIDs) == 1 && family.ColumnIDs[0] == family.DefaultColumnID {
-			// Storage optimization to store DefaultColumnID directly as a value. Also
-			// backwards compatible with the original BaseFormatVersion.
-
-			idx, ok := ru.updateColIDtoRowIndex[family.DefaultColumnID]
-			if !ok {
-				continue
-			}
-
-			ru.key = keys.MakeFamilyKey(primaryIndexKey, uint32(family.ID))
-			if ru.marshaled[idx].RawBytes == nil {
-				// If the new family contains a NULL value, then we must delete
-				// any pre-existing row.
-				if traceKV {
-					log.VEventf(ctx, 2, "Del %s", ru.key)
-				}
-				batch.Del(&ru.key)
-			} else {
-				if traceKV {
-					log.VEventf(ctx, 2, "Put %s -> %v", keys.PrettyPrint(ru.Helper.primIndexValDirs, ru.key), ru.marshaled[idx].PrettyPrint())
-				}
-				batch.Put(&ru.key, &ru.marshaled[idx])
-			}
-			ru.key = nil
-
-			continue
-		}
-
-		ru.key = keys.MakeFamilyKey(primaryIndexKey, uint32(family.ID))
-		ru.valueBuf = ru.valueBuf[:0]
-
-		var lastColID ColumnID
-		familySortedColumnIDs, ok := ru.Helper.sortedColumnFamily(family.ID)
-		if !ok {
-			panic("invalid family sorted column id map")
-		}
-		for _, colID := range familySortedColumnIDs {
-			idx, ok := ru.FetchColIDtoRowIndex[colID]
-			if !ok {
-				return nil, errors.Errorf("column %d was expected to be fetched, but wasn't", colID)
-			}
-			if ru.newValues[idx] == tree.DNull {
-				continue
-			}
-
-			if skip, err := ru.Helper.skipColumnInPK(colID, family.ID, ru.newValues[idx]); err != nil {
-				return nil, err
-			} else if skip {
-				continue
-			}
-
-			col := ru.FetchCols[idx]
-
-			if lastColID > col.ID {
-				panic(fmt.Errorf("cannot write column id %d after %d", col.ID, lastColID))
-			}
-			colIDDiff := col.ID - lastColID
-			lastColID = col.ID
-			ru.valueBuf, err = EncodeTableValue(ru.valueBuf, colIDDiff, ru.newValues[idx], ru.scratch)
-			if err != nil {
-				return nil, err
-			}
-		}
-
-		if family.ID != 0 && len(ru.valueBuf) == 0 {
-			// The family might have already existed but every column in it is being
-			// set to NULL, so delete it.
-			if traceKV {
-				log.VEventf(ctx, 2, "Del %s", keys.PrettyPrint(ru.Helper.primIndexValDirs, ru.key))
-			}
-
-			batch.Del(&ru.key)
-		} else {
-			ru.value.SetTuple(ru.valueBuf)
-			if traceKV {
-				log.VEventf(ctx, 2, "Put %s -> %v", keys.PrettyPrint(ru.Helper.primIndexValDirs, ru.key), ru.value.PrettyPrint())
-			}
-			batch.Put(&ru.key, &ru.value)
-		}
-
-		ru.key = nil
+	ru.valueBuf, err = prepareInsertOrUpdateBatch(ctx, b,
+		&ru.Helper, primaryIndexKey, ru.FetchCols,
+		ru.newValues, ru.FetchColIDtoRowIndex,
+		ru.marshaled, ru.updateColIDtoRowIndex,
+		&ru.key, &ru.value, ru.valueBuf, insertPutFn, true /* overwrite */, traceKV)
+	if err != nil {
+		return ru.newValues, nil
 	}
 
 	// Update secondary indexes.


### PR DESCRIPTION
Fixes #25726.
Performs a long-awaited cleanup requested by @danhhz.

This code is ripe for rewriting (there's a bunch of common tests that should really be performed once for the entire table, instead of anew every row) but we'll do this later.