### PR TITLE
sql, opt: mark SRFs as unsupported in optimizer

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/optimizer
+++ b/pkg/sql/logictest/testdata/logic_test/optimizer
@@ -91,6 +91,19 @@ query I rowsort
 SELECT id FROM crdb_internal.jobs
 ----
 
+query I rowsort
+SELECT * FROM GENERATE_SERIES(1, 3)
+----
+1
+2
+3
+
+query I rowsort
+SELECT GENERATE_SERIES(1, 2)
+----
+1
+2
+
 statement ok
 SET EXPERIMENTAL_OPT = ALWAYS
 
@@ -106,6 +119,12 @@ SELECT * FROM tview
 
 query error pq: virtual tables are not supported
 SELECT id FROM crdb_internal.jobs
+
+query error pq: not yet implemented: table expr: \*tree\.FuncExpr
+SELECT * FROM GENERATE_SERIES(1, 3)
+
+query error pq: generator functions are not supported
+SELECT GENERATE_SERIES(1, 2)
 
 statement ok
 SET EXPERIMENTAL_OPT = LOCAL

--- a/pkg/sql/logictest/testdata/logic_test/srfs
+++ b/pkg/sql/logictest/testdata/logic_test/srfs
@@ -1,4 +1,4 @@
-# LogicTest: default parallel-stmts distsql distsql-metadata
+# LogicTest: default opt parallel-stmts distsql distsql-metadata distsql-opt
 
 subtest generate_series
 

--- a/pkg/sql/opt/optbuilder/groupby.go
+++ b/pkg/sql/opt/optbuilder/groupby.go
@@ -408,6 +408,11 @@ func isAggregate(def *tree.FunctionDefinition) bool {
 	return ok
 }
 
+func isGenerator(def *tree.FunctionDefinition) bool {
+	_, ok := builtins.Generators[strings.ToLower(def.Name)]
+	return ok
+}
+
 var constructAggLookup = map[string]func(f *norm.Factory, argList []memo.GroupID) memo.GroupID{
 	"array_agg": func(f *norm.Factory, argList []memo.GroupID) memo.GroupID {
 		return f.ConstructArrayAgg(argList[0])

--- a/pkg/sql/opt/optbuilder/scope.go
+++ b/pkg/sql/opt/optbuilder/scope.go
@@ -540,6 +540,10 @@ func (s *scope) VisitPre(expr tree.Expr) (recurse bool, newExpr tree.Expr) {
 		if err != nil {
 			panic(builderError{err})
 		}
+		if isGenerator(def) {
+			panic(unimplementedf("generator functions are not supported"))
+		}
+
 		if len(t.Exprs) != 1 {
 			break
 		}

--- a/pkg/sql/opt/optbuilder/testdata/srfs
+++ b/pkg/sql/opt/optbuilder/testdata/srfs
@@ -1,0 +1,247 @@
+# tests adapted from logictest -- srfs
+
+# generate_series
+
+build
+SELECT * FROM GENERATE_SERIES(1, 3)
+----
+error (0A000): not yet implemented: table expr: *tree.FuncExpr
+
+build
+SELECT * FROM GENERATE_SERIES(1, 2), GENERATE_SERIES(1, 2)
+----
+error (0A000): not yet implemented: table expr: *tree.FuncExpr
+
+build
+SELECT * FROM PG_CATALOG.GENERATE_SERIES(1, 3)
+----
+error (0A000): not yet implemented: table expr: *tree.FuncExpr
+
+build
+SELECT * FROM GENERATE_SERIES(1, 1) AS c(x)
+----
+error (0A000): not yet implemented: table expr: *tree.FuncExpr
+
+build
+SELECT * FROM GENERATE_SERIES(1, 1) WITH ORDINALITY AS c(x, y)
+----
+error (0A000): not yet implemented: table expr: *tree.FuncExpr
+
+build
+SELECT * FROM (VALUES (1)) LIMIT GENERATE_SERIES(1, 3)
+----
+error (0A000): generator functions are not supported
+
+# multiple_SRFs
+
+build
+SELECT GENERATE_SERIES(1, 2), GENERATE_SERIES(3, 4)
+----
+error (0A000): generator functions are not supported
+
+exec-ddl
+CREATE TABLE t (a string)
+----
+TABLE t
+ ├── a string
+ ├── rowid int not null (hidden)
+ └── INDEX primary
+      └── rowid int not null (hidden)
+
+exec-ddl
+CREATE TABLE u (b string)
+----
+TABLE u
+ ├── b string
+ ├── rowid int not null (hidden)
+ └── INDEX primary
+      └── rowid int not null (hidden)
+
+build
+SELECT t.*, u.*, a.*, b.* FROM t, u, generate_series(1, 2) AS a, generate_series(3, 4) AS b
+----
+error (0A000): not yet implemented: table expr: *tree.FuncExpr
+
+build
+SELECT 3 + x FROM generate_series(1,2) AS a(x)
+----
+error (0A000): not yet implemented: table expr: *tree.FuncExpr
+
+build
+SELECT 3 + (3 * generate_series(1,3))
+----
+error (0A000): generator functions are not supported
+
+# unnest
+
+build
+SELECT * from unnest(ARRAY[1,2])
+----
+error (0A000): not yet implemented: table expr: *tree.FuncExpr
+
+build
+SELECT unnest(ARRAY[1,2]), unnest(ARRAY['a', 'b'])
+----
+error (0A000): generator functions are not supported
+
+build
+SELECT unnest(ARRAY[3,4]) - 2
+----
+error (0A000): generator functions are not supported
+
+build
+SELECT 1 + generate_series(0, 1), unnest(ARRAY[2, 4]) - 1
+----
+error (0A000): generator functions are not supported
+
+build
+SELECT ascii(unnest(ARRAY['a', 'b', 'c']));
+----
+error (0A000): generator functions are not supported
+
+# nested_SRF
+# See #20511
+
+build
+SELECT generate_series(generate_series(1, 3), 3)
+----
+error (0A000): generator functions are not supported
+
+build
+SELECT generate_series(1, 3) + generate_series(1, 3)
+----
+error (0A000): generator functions are not supported
+
+build
+SELECT generate_series(1, 3) FROM t WHERE generate_series > 3
+----
+error (42703): column "generate_series" does not exist
+
+# Regressions for #15900: ensure that null parameters to generate_series don't
+# cause issues.
+
+build
+SELECT * from generate_series(1, (select * from generate_series(1, 0)))
+----
+error (0A000): not yet implemented: table expr: *tree.FuncExpr
+
+# The following query is designed to produce a null array argument to unnest
+# in a way that the type system can't detect before evaluation.
+build
+SELECT unnest((SELECT current_schemas((SELECT isnan((SELECT round(3.4, (SELECT generate_series(1, 0)))))))));
+----
+error (0A000): generator functions are not supported
+
+# pg_get_keywords
+
+# pg_get_keywords for compatibility (#10291)
+build
+SELECT * FROM pg_get_keywords() WHERE word IN ('alter', 'and', 'between', 'cross') ORDER BY word
+----
+error (0A000): not yet implemented: table expr: *tree.FuncExpr
+
+# Postgres enables renaming both the source and the column name for
+# single-column generators, but not for multi-column generators.
+build
+SELECT a.*, b.*, c.* FROM generate_series(1,1) a, unnest(ARRAY[1]) b, pg_get_keywords() c LIMIT 0
+----
+error (0A000): not yet implemented: table expr: *tree.FuncExpr
+
+# Beware of multi-valued SRFs in render position (#19149)
+build
+SELECT 'a', pg_get_keywords(), 'c' LIMIT 1
+----
+error (0A000): generator functions are not supported
+
+build
+SELECT 'a', pg_get_keywords() b, 'c' LIMIT 1
+----
+error (0A000): generator functions are not supported
+
+# unary_table
+
+build
+SELECT 'a', crdb_internal.unary_table() b, 'c' LIMIT 1
+----
+error (0A000): generator functions are not supported
+
+# upper
+
+# Regular scalar functions can be used as functions too. #22312
+build
+SELECT * FROM upper('abc')
+----
+error (0A000): not yet implemented: table expr: *tree.FuncExpr
+
+# current_schema
+
+build
+SELECT * FROM current_schema() WITH ORDINALITY AS a(b)
+----
+error (0A000): not yet implemented: table expr: *tree.FuncExpr
+
+# expandArray
+
+build
+SELECT information_schema._pg_expandarray(ARRAY['b', 'a'])
+----
+error (0A000): generator functions are not supported
+
+build
+SELECT * FROM information_schema._pg_expandarray(ARRAY['b', 'a'])
+----
+error (0A000): not yet implemented: table expr: *tree.FuncExpr
+
+# srf_accessor
+
+build
+SELECT (1).*
+----
+error (42804): type int is not composite
+
+build
+SELECT ('a').*
+----
+error (42804): type string is not composite
+
+build
+SELECT (unnest(ARRAY[]:::INT[])).*
+----
+error (0A000): generator functions are not supported
+
+build
+SELECT (information_schema._pg_expandarray(ARRAY['c', 'b', 'a'])).*
+----
+error (0A000): generator functions are not supported
+
+build
+SELECT (information_schema._pg_expandarray(ARRAY['c', 'b', 'a'])).x
+----
+error (0A000): generator functions are not supported
+
+build
+SELECT (information_schema._pg_expandarray(ARRAY['c', 'b', 'a'])).other
+----
+error (0A000): generator functions are not supported
+
+build
+SELECT temp.n from information_schema._pg_expandarray(array['c','b','a']) AS temp;
+----
+error (0A000): not yet implemented: table expr: *tree.FuncExpr
+
+build
+SELECT temp.* from information_schema._pg_expandarray(array['c','b','a']) AS temp;
+----
+error (0A000): not yet implemented: table expr: *tree.FuncExpr
+
+build
+SELECT * from information_schema._pg_expandarray(array['c','b','a']) AS temp;
+----
+error (0A000): not yet implemented: table expr: *tree.FuncExpr
+
+# generate_subscripts
+
+build
+SELECT * FROM generate_subscripts(ARRAY[3,2,1])
+----
+error (0A000): not yet implemented: table expr: *tree.FuncExpr


### PR DESCRIPTION
This commit ensures that any SRF in a query causes the optimizer
to return an unsupported error. This allows us to enable the `srfs`
logic test for `opt` and `distsql-opt`, since these queries will fall
back on the 2.0 planner.

Release note: None