### PR TITLE
roachtest: separate fetching logs from cluster destruction

### DIFF
--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -540,11 +540,7 @@ func (c *cluster) Node(i int) nodeListOption {
 	return c.Range(i, i)
 }
 
-func (c *cluster) Destroy(ctx context.Context) {
-	if c == nil {
-		return
-	}
-
+func (c *cluster) FetchLogs(ctx context.Context) {
 	// Don't hang forever if we can't fetch the logs.
 	execCtx, cancel := context.WithTimeout(ctx, 2*time.Minute)
 	defer cancel()
@@ -552,6 +548,12 @@ func (c *cluster) Destroy(ctx context.Context) {
 	c.status("retrieving logs")
 	_ = execCmd(execCtx, c.l, roachprod, "get", c.name, "logs",
 		filepath.Join(artifacts, teamCityNameEscape(c.t.Name()), "logs"))
+}
+
+func (c *cluster) Destroy(ctx context.Context) {
+	if c == nil {
+		return
+	}
 
 	// Only destroy the cluster if it exists in the cluster registry. The cluster
 	// may not exist if the test was interrupted and the teardown machinery is

--- a/pkg/cmd/roachtest/test.go
+++ b/pkg/cmd/roachtest/test.go
@@ -715,6 +715,11 @@ func (r *registry) run(spec *testSpec, filter *regexp.Regexp, c *cluster, done f
 
 		if t.spec.Run != nil {
 			if !dryrun {
+				if c != nil {
+					defer func() {
+						c.FetchLogs(ctx)
+					}()
+				}
 				t.spec.Run(ctx, t, c)
 			}
 		} else {


### PR DESCRIPTION
Fetch logs for each test (or subtest) with a non-nil `Run`
function. This is a change from the previous behavior which fetched logs
when a cluster was being destroyed. That behavior either grouped logs
from multiple subtests in the same directory, or only grabbed logs from
the last subtest run.

Fixes #26155

Release note: None