### PR TITLE
sql: Implement minus for JSON and text array

### DIFF
--- a/docs/generated/sql/operators.md
+++ b/docs/generated/sql/operators.md
@@ -97,6 +97,7 @@
 <tr><td><a href="interval.html">interval</a> <code>-</code> <a href="interval.html">interval</a></td><td><a href="interval.html">interval</a></td></tr>
 <tr><td>jsonb <code>-</code> <a href="int.html">int</a></td><td>jsonb</td></tr>
 <tr><td>jsonb <code>-</code> <a href="string.html">string</a></td><td>jsonb</td></tr>
+<tr><td>jsonb <code>-</code> <a href="string.html">string[]</a></td><td>jsonb</td></tr>
 <tr><td><a href="time.html">time</a> <code>-</code> <a href="interval.html">interval</a></td><td><a href="time.html">time</a></td></tr>
 <tr><td><a href="time.html">time</a> <code>-</code> <a href="time.html">time</a></td><td><a href="interval.html">interval</a></td></tr>
 <tr><td><a href="timestamp.html">timestamp</a> <code>-</code> <a href="interval.html">interval</a></td><td><a href="timestamp.html">timestamp</a></td></tr>

--- a/pkg/sql/logictest/testdata/logic_test/json
+++ b/pkg/sql/logictest/testdata/logic_test/json
@@ -599,5 +599,30 @@ SELECT '{"a": []}'::JSONB #- ARRAY['a', '0']
 ----
 {"a": []}
 
+query T
+SELECT '{"a":123,"b":456,"c":567}'::JSONB - array[]:::text[];
+----
+{"a": 123, "b": 456, "c": 567}
+
+query T
+SELECT '{"a":123,"b":456,"c":567}'::JSONB - array['a','c'];
+----
+{"b": 456}
+
+query T
+SELECT '{"a":123,"c":"asdf"}'::JSONB - array['a','c'];
+----
+{}
+
+query T
+SELECT '{}'::JSONB - array['a','c'];
+----
+{}
+
+query T
+SELECT '{"b": [], "c": {"a": "b"}}'::JSONB - array['a'];
+----
+{"b": [], "c": {"a": "b"}}
+
 statement error pgcode 22P02 a path element is not an integer: foo
 SELECT '{"a": {"b": ["foo"]}}'::JSONB #- ARRAY['a', 'b', 'foo']

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -903,6 +903,24 @@ var BinOps = map[BinaryOperator]binOpOverload{
 			},
 		},
 		BinOp{
+			LeftType:   types.JSON,
+			RightType:  types.TArray{Typ: types.String},
+			ReturnType: types.JSON,
+			fn: func(_ *EvalContext, left Datum, right Datum) (Datum, error) {
+				j := left.(*DJSON).JSON
+				arr := *MustBeDArray(right)
+
+				for _, str := range arr.Array {
+					var err error
+					j, _, err = j.RemoveString(string(MustBeDString(str)))
+					if err != nil {
+						return nil, err
+					}
+				}
+				return &DJSON{j}, nil
+			},
+		},
+		BinOp{
 			LeftType:   types.INet,
 			RightType:  types.INet,
 			ReturnType: types.Int,


### PR DESCRIPTION
* Added another case for the `Minus` operation to take a JSON Object on the left and a text array on the right
* Added JSON logic tests for this new functionality 

Release note: Implemented the minus operation between a JSON Object and a text array.

closes #23293 
