### PR TITLE
acceptance: use fixed ports

### DIFF
--- a/pkg/acceptance/util.go
+++ b/pkg/acceptance/util.go
@@ -31,5 +31,6 @@ func makePGClient(t *testing.T, dest string) *gosql.DB {
 	if err != nil {
 		t.Fatal(err)
 	}
+	db.SetMaxIdleConns(0)
 	return db
 }

--- a/pkg/acceptance/util_cluster.go
+++ b/pkg/acceptance/util_cluster.go
@@ -120,11 +120,11 @@ func StartCluster(ctx context.Context, t *testing.T, cfg cluster.TestConfig) (c 
 			logDir = filepath.Join(logDir, filepath.Clean(t.Name()))
 		}
 
-		perNodeCfg := map[int]localcluster.NodeConfig{}
+		perNodeCfg := localcluster.MakePerNodeFixedPortsCfg(len(cfg.Nodes))
 		for i := 0; i < len(cfg.Nodes); i++ {
 			// TODO(tschottdorf): handle Nodes[i].Stores properly.
 			if cfg.Nodes[i].Version != "" {
-				var nCfg localcluster.NodeConfig
+				nCfg := perNodeCfg[i]
 				nCfg.Binary = GetBinary(ctx, t, cfg.Nodes[i].Version)
 				perNodeCfg[i] = nCfg
 			}

--- a/pkg/acceptance/version_upgrade_test.go
+++ b/pkg/acceptance/version_upgrade_test.go
@@ -62,8 +62,6 @@ const sourceVersion = "source"
 func (bv binaryVersionUpgrade) name() string { return fmt.Sprintf("binary=%s", bv.newVersion) }
 
 func (bv binaryVersionUpgrade) run(ctx context.Context, t *testing.T, c cluster.Cluster) {
-	t.Helper()
-
 	var newBin string
 	if bv.newVersion == sourceVersion {
 		newBin = localcluster.SourceBinary()
@@ -110,7 +108,6 @@ func (bv binaryVersionUpgrade) run(ctx context.Context, t *testing.T, c cluster.
 }
 
 func (bv binaryVersionUpgrade) checkAll(ctx context.Context, t *testing.T, c cluster.Cluster) {
-	t.Helper()
 	for i := 0; i < c.NumNodes(); i++ {
 		bv.checkNode(ctx, t, c, i)
 	}
@@ -119,7 +116,6 @@ func (bv binaryVersionUpgrade) checkAll(ctx context.Context, t *testing.T, c clu
 func (bv binaryVersionUpgrade) checkNode(
 	ctx context.Context, t *testing.T, c cluster.Cluster, nodeIdx int,
 ) {
-	t.Helper()
 	db := makePGClient(t, c.PGUrl(ctx, nodeIdx))
 	defer db.Close()
 
@@ -177,8 +173,6 @@ type clusterVersionUpgrade struct {
 func (cv clusterVersionUpgrade) name() string { return fmt.Sprintf("cluster=%s", cv.newVersion) }
 
 func (cv clusterVersionUpgrade) run(ctx context.Context, t *testing.T, c cluster.Cluster) {
-	t.Helper()
-
 	// hasShowSettingBug is true when we're working around
 	// https://github.com/cockroachdb/cockroach/issues/22796.
 	//

--- a/pkg/acceptance/version_upgrade_test.go
+++ b/pkg/acceptance/version_upgrade_test.go
@@ -94,7 +94,7 @@ func (bv binaryVersionUpgrade) run(ctx context.Context, t *testing.T, c cluster.
 			}
 			log.Infof(ctx, "wiping node %d's data directory", nodeIdx)
 		}
-		log.Infof(ctx, "upgrading node %d's binary to %s", nodeIdx, bv.newVersion)
+		log.Infof(ctx, "upgrading node at index %d's binary to %s", nodeIdx, bv.newVersion)
 		lc.ReplaceBinary(nodeIdx, newBin)
 		if err := lc.Restart(ctx, nodeIdx); err != nil {
 			t.Fatal(err)

--- a/pkg/acceptance/version_upgrade_test.go
+++ b/pkg/acceptance/version_upgrade_test.go
@@ -315,6 +315,7 @@ func testVersionUpgrade(ctx context.Context, t *testing.T, cfg cluster.TestConfi
 	// the cluster, and we had a bug about migrations on large numbers of tables:
 	// #22370.
 	db := makePGClient(t, c.PGUrl(ctx, 0 /* nodeId */))
+	defer db.Close()
 	if _, err := db.Exec(fmt.Sprintf("create database lotsatables")); err != nil {
 		t.Fatal(err)
 	}
@@ -324,7 +325,6 @@ func testVersionUpgrade(ctx context.Context, t *testing.T, cfg cluster.TestConfi
 			t.Fatal(err)
 		}
 	}
-	defer db.Close()
 
 	startingBinVersion.checkAll(ctx, t, c)
 	for _, step := range steps {


### PR DESCRIPTION
The use of randomized ports in acceptance testing has done a good job at
highlighting how difficult it is to productionize these deployments, at the
considerable expense of diffcult-to-fix Gossip connectivity snags such as
\#25385.

To avoid this class of problems in acceptance testing today, switch to
fixed ports (where gossip persistence can iron out most kinks).  This
prevents us from running multiple test instances in parallel, but we don't
plan on doing that anyway.

Some discussion of this can be found in #18056 (which ironically suggests
removing gossip persistence).

I've run around a hundred runs of TestVersionUpgrade with code (close to)
this PR without a timeout (I was able to reproduce them in dozens of runs
before).

Fixes #25385. Fixes #25444. Fixes #25802 (optimistically).

Release note: None