### PR TITLE
schemachange: Fix TIMETZ tests.

### DIFF
--- a/pkg/sql/schemachange/alter_column_type.go
+++ b/pkg/sql/schemachange/alter_column_type.go
@@ -122,13 +122,18 @@ var classifiers = map[sqlbase.ColumnType_SemanticType]map[sqlbase.ColumnType_Sem
 		},
 		sqlbase.ColumnType_STRING: classifierWidth,
 	},
-	// #26078
-	// sqlbase.ColumnType_TIME: {
-	// sqlbase.ColumnType_TIMETZ: ColumnConversionTrivial.classifier(),
-	// },
-	// sqlbase.ColumnType_TIMETZ: {
-	// sqlbase.ColumnType_TIME: ColumnConversionTrivial.classifier(),
-	// },
+	// TODO(bob): It looks like TIMETZ is currently in flux and the
+	// implementation, encoding, and semantics may be changing.
+	// We'll disable this change for the moment until these
+	// issues settle:
+	// https://github.com/cockroachdb/cockroach/issues/25224
+	// https://github.com/cockroachdb/cockroach/issues/26097
+	sqlbase.ColumnType_TIME: {
+		sqlbase.ColumnType_TIMETZ: ColumnConversionDangerous.classifier(),
+	},
+	sqlbase.ColumnType_TIMETZ: {
+		sqlbase.ColumnType_TIME: ColumnConversionDangerous.classifier(),
+	},
 	sqlbase.ColumnType_TIMESTAMP: {
 		sqlbase.ColumnType_TIMESTAMPTZ: ColumnConversionTrivial.classifier(),
 	},


### PR DESCRIPTION
The code was originally using the current time for tests, but this caused
flakiness if the value would roll over a date boundary when it was converted
from the test's local timezone to UTC time.  This has been solved by fixing the
time to one that is guaranteed not to roll over.

Additionally, per referenced issues, TIMETZ conversions have been disabled
until some of its implementation details get worked out.

Resolves #26077
Resolves #26076
Resolves #26078
Resolves #26074

Release note: None