### PR TITLE
release-2.0: cli: don't prompt for a password when a cert is provided

### DIFF
--- a/pkg/acceptance/cluster/dockercluster.go
+++ b/pkg/acceptance/cluster/dockercluster.go
@@ -672,6 +672,9 @@ func (l *DockerCluster) Start(ctx context.Context) {
 	maybePanic(security.CreateClientPair(
 		l.CertsDir, filepath.Join(l.CertsDir, security.EmbeddedCAKey),
 		512, 48*time.Hour, false, security.RootUser))
+	maybePanic(security.CreateClientPair(
+		l.CertsDir, filepath.Join(l.CertsDir, security.EmbeddedCAKey),
+		512, 48*time.Hour, false, "testuser"))
 
 	l.monitorCtx, l.monitorCtxCancelFunc = context.WithCancel(context.Background())
 	go l.monitor(ctx)

--- a/pkg/cli/interactive_tests/test_secure.tcl
+++ b/pkg/cli/interactive_tests/test_secure.tcl
@@ -69,6 +69,18 @@ send "\\q\r"
 eexpect $prompt
 end_test
 
+start_test "Can create users without passwords."
+send "$argv user set testuser --certs-dir=$certs_dir\r"
+eexpect $prompt
+end_test
+
+start_test "Passwords are not requested when a certificate for the user exists"
+send "$argv sql --user=testuser --certs-dir=$certs_dir\r"
+eexpect "testuser@"
+send "\\q\r"
+eexpect $prompt
+end_test
+
 start_test "Check that root cannot use password."
 # Run as root but with a non-existent certs directory.
 send "$argv sql --url='postgresql://root@localhost:26257?sslmode=verify-full'\r"

--- a/pkg/cli/sql_util.go
+++ b/pkg/cli/sql_util.go
@@ -559,9 +559,9 @@ func makeSQLClient(appName string) (*sqlConn, error) {
 			}
 			// If we can go on (we have a certificate spec), clear the password.
 			baseURL.User = url.User(security.RootUser)
-		} else {
-			// If there's no password in the URL yet, ask for it and populate
-			// it in the URL.
+		} else if options.Get("sslcert") == "" || options.Get("sslkey") == "" {
+			// If there's no password in the URL yet and we don't have a client
+			// certificate, ask for it and populate it in the URL.
 			if _, pwdSet := baseURL.User.Password(); !pwdSet {
 				pwd, err := security.PromptForPassword()
 				if err != nil {


### PR DESCRIPTION
Backport 1/1 commits from #25252.

/cc @cockroachdb/release

Fix #26180.

---

This was broken by a refactor (14fdc28). Add a test so it doesn't break again.

Fix #25165.

Release note (cli change): The CLI no longer prompts for a password when a
certificate is provided.
