### PR TITLE
storage: avoid querying pusher where transaction record can't exist

### DIFF
--- a/pkg/storage/txnwait/queue.go
+++ b/pkg/storage/txnwait/queue.go
@@ -433,7 +433,7 @@ func (q *Queue) MaybeWaitForPush(
 	var queryPusherCh <-chan *roachpb.Transaction // accepts updates to the pusher txn
 	var queryPusherErrCh <-chan *roachpb.Error    // accepts errors querying the pusher txn
 	var readyCh chan struct{}                     // signaled when pusher txn should be queried
-	if req.PusherTxn.ID != (uuid.UUID{}) {
+	if req.PusherTxn.ID != uuid.Nil && req.PusherTxn.Key != nil {
 		// Create a context which will be canceled once this call completes.
 		// This ensures that the goroutine created to query the pusher txn
 		// is properly cleaned up.


### PR DESCRIPTION
This change checks whether a txn has a non-nil key before querying it
if it's waiting on an extant transaction which owns a conflicting intent.
Previously, the code would query the pusher's txn, even if the key was
nil, which would just send a spurious `QueryTxn` request to the first
range in the keyspace.

See #26059

Release note: None