### PR TITLE
CONTRIBUTING.md: avoid recommendation to use 'go get'

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,7 +50,7 @@ new engineers.
 2. Get the CockroachDB code:
 
    ```shell
-   go get -d github.com/cockroachdb/cockroach
+   git clone https://github.com/cockroachdb/cockroach $(go env GOPATH)/src/github.com/cockroachdb/cockroach
    cd $(go env GOPATH)/src/github.com/cockroachdb/cockroach
    ```
 


### PR DESCRIPTION
Since #25325 landed, 'go get' no longer works. Adjust our contributing
guidelines appropriately.

Release note: None

/cc @rendaw (thanks for the report!)