### PR TITLE
sql: Add empty pg_stat_activity virtual table

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/grant_table
+++ b/pkg/sql/logictest/testdata/logic_test/grant_table
@@ -112,6 +112,7 @@ test      pg_catalog          pg_rewrite                         public  SELECT
 test      pg_catalog          pg_roles                           public  SELECT
 test      pg_catalog          pg_sequence                        public  SELECT
 test      pg_catalog          pg_settings                        public  SELECT
+test      pg_catalog          pg_stat_activity                   public  SELECT
 test      pg_catalog          pg_tables                          public  SELECT
 test      pg_catalog          pg_tablespace                      public  SELECT
 test      pg_catalog          pg_trigger                         public  SELECT

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -282,6 +282,7 @@ pg_catalog          pg_rewrite
 pg_catalog          pg_roles
 pg_catalog          pg_sequence
 pg_catalog          pg_settings
+pg_catalog          pg_stat_activity
 pg_catalog          pg_tables
 pg_catalog          pg_tablespace
 pg_catalog          pg_trigger
@@ -399,6 +400,7 @@ pg_rewrite
 pg_roles
 pg_sequence
 pg_settings
+pg_stat_activity
 pg_tables
 pg_tablespace
 pg_trigger
@@ -523,6 +525,7 @@ system         pg_catalog          pg_rewrite                         SYSTEM VIE
 system         pg_catalog          pg_roles                           SYSTEM VIEW  NO                  1
 system         pg_catalog          pg_sequence                        SYSTEM VIEW  NO                  1
 system         pg_catalog          pg_settings                        SYSTEM VIEW  NO                  1
+system         pg_catalog          pg_stat_activity                   SYSTEM VIEW  NO                  1
 system         pg_catalog          pg_tables                          SYSTEM VIEW  NO                  1
 system         pg_catalog          pg_tablespace                      SYSTEM VIEW  NO                  1
 system         pg_catalog          pg_trigger                         SYSTEM VIEW  NO                  1
@@ -954,7 +957,7 @@ testuser  other_db       public              SELECT          NULL
 
 # root can see everything
 query TTTTTTTT colnames
-SELECT * FROM system.information_schema.table_privileges ORDER BY table_name
+SELECT * FROM system.information_schema.table_privileges ORDER BY table_name, grantee, privilege_type
 ----
 grantor  grantee  table_catalog  table_schema        table_name                         privilege_type  is_grantable  with_hierarchy
 NULL     public   system         information_schema  administrable_role_authorizations  SELECT          NULL          NULL
@@ -969,64 +972,64 @@ NULL     public   system         information_schema  columns                    
 NULL     public   system         information_schema  constraint_column_usage            SELECT          NULL          NULL
 NULL     public   system         crdb_internal       create_statements                  SELECT          NULL          NULL
 NULL     admin    system         public              descriptor                         GRANT           NULL          NULL
-NULL     root     system         public              descriptor                         SELECT          NULL          NULL
 NULL     admin    system         public              descriptor                         SELECT          NULL          NULL
 NULL     root     system         public              descriptor                         GRANT           NULL          NULL
+NULL     root     system         public              descriptor                         SELECT          NULL          NULL
 NULL     public   system         information_schema  enabled_roles                      SELECT          NULL          NULL
 NULL     admin    system         public              eventlog                           DELETE          NULL          NULL
 NULL     admin    system         public              eventlog                           GRANT           NULL          NULL
+NULL     admin    system         public              eventlog                           INSERT          NULL          NULL
+NULL     admin    system         public              eventlog                           SELECT          NULL          NULL
+NULL     admin    system         public              eventlog                           UPDATE          NULL          NULL
 NULL     root     system         public              eventlog                           DELETE          NULL          NULL
 NULL     root     system         public              eventlog                           GRANT           NULL          NULL
 NULL     root     system         public              eventlog                           INSERT          NULL          NULL
 NULL     root     system         public              eventlog                           SELECT          NULL          NULL
-NULL     admin    system         public              eventlog                           UPDATE          NULL          NULL
 NULL     root     system         public              eventlog                           UPDATE          NULL          NULL
-NULL     admin    system         public              eventlog                           SELECT          NULL          NULL
-NULL     admin    system         public              eventlog                           INSERT          NULL          NULL
 NULL     public   system         crdb_internal       forward_dependencies               SELECT          NULL          NULL
 NULL     public   system         crdb_internal       gossip_alerts                      SELECT          NULL          NULL
 NULL     public   system         crdb_internal       gossip_liveness                    SELECT          NULL          NULL
 NULL     public   system         crdb_internal       gossip_nodes                       SELECT          NULL          NULL
 NULL     public   system         crdb_internal       index_columns                      SELECT          NULL          NULL
-NULL     admin    system         public              jobs                               GRANT           NULL          NULL
 NULL     admin    system         public              jobs                               DELETE          NULL          NULL
+NULL     admin    system         public              jobs                               GRANT           NULL          NULL
+NULL     admin    system         public              jobs                               INSERT          NULL          NULL
+NULL     admin    system         public              jobs                               SELECT          NULL          NULL
+NULL     admin    system         public              jobs                               UPDATE          NULL          NULL
+NULL     public   system         crdb_internal       jobs                               SELECT          NULL          NULL
+NULL     root     system         public              jobs                               DELETE          NULL          NULL
 NULL     root     system         public              jobs                               GRANT           NULL          NULL
 NULL     root     system         public              jobs                               INSERT          NULL          NULL
-NULL     public   system         crdb_internal       jobs                               SELECT          NULL          NULL
 NULL     root     system         public              jobs                               SELECT          NULL          NULL
-NULL     admin    system         public              jobs                               INSERT          NULL          NULL
-NULL     root     system         public              jobs                               DELETE          NULL          NULL
-NULL     admin    system         public              jobs                               UPDATE          NULL          NULL
 NULL     root     system         public              jobs                               UPDATE          NULL          NULL
-NULL     admin    system         public              jobs                               SELECT          NULL          NULL
 NULL     public   system         information_schema  key_column_usage                   SELECT          NULL          NULL
 NULL     public   system         crdb_internal       kv_node_status                     SELECT          NULL          NULL
 NULL     public   system         crdb_internal       kv_store_status                    SELECT          NULL          NULL
-NULL     root     system         public              lease                              SELECT          NULL          NULL
-NULL     admin    system         public              lease                              GRANT           NULL          NULL
 NULL     admin    system         public              lease                              DELETE          NULL          NULL
+NULL     admin    system         public              lease                              GRANT           NULL          NULL
 NULL     admin    system         public              lease                              INSERT          NULL          NULL
 NULL     admin    system         public              lease                              SELECT          NULL          NULL
 NULL     admin    system         public              lease                              UPDATE          NULL          NULL
 NULL     root     system         public              lease                              DELETE          NULL          NULL
 NULL     root     system         public              lease                              GRANT           NULL          NULL
-NULL     root     system         public              lease                              UPDATE          NULL          NULL
 NULL     root     system         public              lease                              INSERT          NULL          NULL
+NULL     root     system         public              lease                              SELECT          NULL          NULL
+NULL     root     system         public              lease                              UPDATE          NULL          NULL
 NULL     public   system         crdb_internal       leases                             SELECT          NULL          NULL
-NULL     root     system         public              locations                          GRANT           NULL          NULL
-NULL     admin    system         public              locations                          UPDATE          NULL          NULL
-NULL     admin    system         public              locations                          SELECT          NULL          NULL
 NULL     admin    system         public              locations                          DELETE          NULL          NULL
-NULL     admin    system         public              locations                          INSERT          NULL          NULL
 NULL     admin    system         public              locations                          GRANT           NULL          NULL
-NULL     root     system         public              locations                          UPDATE          NULL          NULL
-NULL     root     system         public              locations                          SELECT          NULL          NULL
-NULL     root     system         public              locations                          INSERT          NULL          NULL
+NULL     admin    system         public              locations                          INSERT          NULL          NULL
+NULL     admin    system         public              locations                          SELECT          NULL          NULL
+NULL     admin    system         public              locations                          UPDATE          NULL          NULL
 NULL     root     system         public              locations                          DELETE          NULL          NULL
-NULL     root     system         public              namespace                          SELECT          NULL          NULL
-NULL     root     system         public              namespace                          GRANT           NULL          NULL
+NULL     root     system         public              locations                          GRANT           NULL          NULL
+NULL     root     system         public              locations                          INSERT          NULL          NULL
+NULL     root     system         public              locations                          SELECT          NULL          NULL
+NULL     root     system         public              locations                          UPDATE          NULL          NULL
 NULL     admin    system         public              namespace                          GRANT           NULL          NULL
 NULL     admin    system         public              namespace                          SELECT          NULL          NULL
+NULL     root     system         public              namespace                          GRANT           NULL          NULL
+NULL     root     system         public              namespace                          SELECT          NULL          NULL
 NULL     public   system         crdb_internal       node_build_info                    SELECT          NULL          NULL
 NULL     public   system         crdb_internal       node_metrics                       SELECT          NULL          NULL
 NULL     public   system         crdb_internal       node_queries                       SELECT          NULL          NULL
@@ -1061,6 +1064,7 @@ NULL     public   system         pg_catalog          pg_rewrite                 
 NULL     public   system         pg_catalog          pg_roles                           SELECT          NULL          NULL
 NULL     public   system         pg_catalog          pg_sequence                        SELECT          NULL          NULL
 NULL     public   system         pg_catalog          pg_settings                        SELECT          NULL          NULL
+NULL     public   system         pg_catalog          pg_stat_activity                   SELECT          NULL          NULL
 NULL     public   system         pg_catalog          pg_tables                          SELECT          NULL          NULL
 NULL     public   system         pg_catalog          pg_tablespace                      SELECT          NULL          NULL
 NULL     public   system         pg_catalog          pg_trigger                         SELECT          NULL          NULL
@@ -1068,28 +1072,28 @@ NULL     public   system         pg_catalog          pg_type                    
 NULL     public   system         pg_catalog          pg_user                            SELECT          NULL          NULL
 NULL     public   system         pg_catalog          pg_user_mapping                    SELECT          NULL          NULL
 NULL     public   system         pg_catalog          pg_views                           SELECT          NULL          NULL
-NULL     root     system         public              rangelog                           INSERT          NULL          NULL
-NULL     root     system         public              rangelog                           DELETE          NULL          NULL
-NULL     admin    system         public              rangelog                           UPDATE          NULL          NULL
-NULL     admin    system         public              rangelog                           SELECT          NULL          NULL
-NULL     admin    system         public              rangelog                           GRANT           NULL          NULL
 NULL     admin    system         public              rangelog                           DELETE          NULL          NULL
-NULL     root     system         public              rangelog                           GRANT           NULL          NULL
+NULL     admin    system         public              rangelog                           GRANT           NULL          NULL
 NULL     admin    system         public              rangelog                           INSERT          NULL          NULL
-NULL     root     system         public              rangelog                           UPDATE          NULL          NULL
+NULL     admin    system         public              rangelog                           SELECT          NULL          NULL
+NULL     admin    system         public              rangelog                           UPDATE          NULL          NULL
+NULL     root     system         public              rangelog                           DELETE          NULL          NULL
+NULL     root     system         public              rangelog                           GRANT           NULL          NULL
+NULL     root     system         public              rangelog                           INSERT          NULL          NULL
 NULL     root     system         public              rangelog                           SELECT          NULL          NULL
+NULL     root     system         public              rangelog                           UPDATE          NULL          NULL
 NULL     public   system         crdb_internal       ranges                             SELECT          NULL          NULL
 NULL     public   system         information_schema  referential_constraints            SELECT          NULL          NULL
-NULL     root     system         public              role_members                       GRANT           NULL          NULL
-NULL     admin    system         public              role_members                       UPDATE          NULL          NULL
-NULL     root     system         public              role_members                       UPDATE          NULL          NULL
-NULL     admin    system         public              role_members                       INSERT          NULL          NULL
-NULL     admin    system         public              role_members                       GRANT           NULL          NULL
 NULL     admin    system         public              role_members                       DELETE          NULL          NULL
-NULL     root     system         public              role_members                       INSERT          NULL          NULL
+NULL     admin    system         public              role_members                       GRANT           NULL          NULL
+NULL     admin    system         public              role_members                       INSERT          NULL          NULL
 NULL     admin    system         public              role_members                       SELECT          NULL          NULL
+NULL     admin    system         public              role_members                       UPDATE          NULL          NULL
 NULL     root     system         public              role_members                       DELETE          NULL          NULL
+NULL     root     system         public              role_members                       GRANT           NULL          NULL
+NULL     root     system         public              role_members                       INSERT          NULL          NULL
 NULL     root     system         public              role_members                       SELECT          NULL          NULL
+NULL     root     system         public              role_members                       UPDATE          NULL          NULL
 NULL     public   system         information_schema  role_table_grants                  SELECT          NULL          NULL
 NULL     public   system         crdb_internal       schema_changes                     SELECT          NULL          NULL
 NULL     public   system         information_schema  schema_privileges                  SELECT          NULL          NULL
@@ -1097,76 +1101,76 @@ NULL     public   system         information_schema  schemata                   
 NULL     public   system         information_schema  sequences                          SELECT          NULL          NULL
 NULL     public   system         crdb_internal       session_trace                      SELECT          NULL          NULL
 NULL     public   system         crdb_internal       session_variables                  SELECT          NULL          NULL
-NULL     root     system         public              settings                           GRANT           NULL          NULL
-NULL     root     system         public              settings                           SELECT          NULL          NULL
-NULL     root     system         public              settings                           INSERT          NULL          NULL
-NULL     admin    system         public              settings                           UPDATE          NULL          NULL
-NULL     admin    system         public              settings                           SELECT          NULL          NULL
-NULL     admin    system         public              settings                           INSERT          NULL          NULL
-NULL     admin    system         public              settings                           GRANT           NULL          NULL
 NULL     admin    system         public              settings                           DELETE          NULL          NULL
-NULL     root     system         public              settings                           UPDATE          NULL          NULL
+NULL     admin    system         public              settings                           GRANT           NULL          NULL
+NULL     admin    system         public              settings                           INSERT          NULL          NULL
+NULL     admin    system         public              settings                           SELECT          NULL          NULL
+NULL     admin    system         public              settings                           UPDATE          NULL          NULL
 NULL     root     system         public              settings                           DELETE          NULL          NULL
+NULL     root     system         public              settings                           GRANT           NULL          NULL
+NULL     root     system         public              settings                           INSERT          NULL          NULL
+NULL     root     system         public              settings                           SELECT          NULL          NULL
+NULL     root     system         public              settings                           UPDATE          NULL          NULL
 NULL     public   system         information_schema  statistics                         SELECT          NULL          NULL
 NULL     public   system         crdb_internal       table_columns                      SELECT          NULL          NULL
 NULL     public   system         information_schema  table_constraints                  SELECT          NULL          NULL
 NULL     public   system         crdb_internal       table_indexes                      SELECT          NULL          NULL
 NULL     public   system         information_schema  table_privileges                   SELECT          NULL          NULL
 NULL     admin    system         public              table_statistics                   DELETE          NULL          NULL
-NULL     root     system         public              table_statistics                   UPDATE          NULL          NULL
-NULL     root     system         public              table_statistics                   GRANT           NULL          NULL
-NULL     root     system         public              table_statistics                   DELETE          NULL          NULL
+NULL     admin    system         public              table_statistics                   GRANT           NULL          NULL
+NULL     admin    system         public              table_statistics                   INSERT          NULL          NULL
 NULL     admin    system         public              table_statistics                   SELECT          NULL          NULL
 NULL     admin    system         public              table_statistics                   UPDATE          NULL          NULL
+NULL     root     system         public              table_statistics                   DELETE          NULL          NULL
+NULL     root     system         public              table_statistics                   GRANT           NULL          NULL
 NULL     root     system         public              table_statistics                   INSERT          NULL          NULL
 NULL     root     system         public              table_statistics                   SELECT          NULL          NULL
-NULL     admin    system         public              table_statistics                   INSERT          NULL          NULL
-NULL     admin    system         public              table_statistics                   GRANT           NULL          NULL
+NULL     root     system         public              table_statistics                   UPDATE          NULL          NULL
 NULL     public   system         information_schema  tables                             SELECT          NULL          NULL
 NULL     public   system         crdb_internal       tables                             SELECT          NULL          NULL
-NULL     root     system         public              ui                                 SELECT          NULL          NULL
-NULL     root     system         public              ui                                 INSERT          NULL          NULL
-NULL     root     system         public              ui                                 GRANT           NULL          NULL
-NULL     admin    system         public              ui                                 UPDATE          NULL          NULL
-NULL     admin    system         public              ui                                 SELECT          NULL          NULL
-NULL     admin    system         public              ui                                 INSERT          NULL          NULL
-NULL     admin    system         public              ui                                 GRANT           NULL          NULL
 NULL     admin    system         public              ui                                 DELETE          NULL          NULL
+NULL     admin    system         public              ui                                 GRANT           NULL          NULL
+NULL     admin    system         public              ui                                 INSERT          NULL          NULL
+NULL     admin    system         public              ui                                 SELECT          NULL          NULL
+NULL     admin    system         public              ui                                 UPDATE          NULL          NULL
 NULL     root     system         public              ui                                 DELETE          NULL          NULL
+NULL     root     system         public              ui                                 GRANT           NULL          NULL
+NULL     root     system         public              ui                                 INSERT          NULL          NULL
+NULL     root     system         public              ui                                 SELECT          NULL          NULL
 NULL     root     system         public              ui                                 UPDATE          NULL          NULL
 NULL     public   system         information_schema  user_privileges                    SELECT          NULL          NULL
-NULL     root     system         public              users                              UPDATE          NULL          NULL
-NULL     root     system         public              users                              GRANT           NULL          NULL
-NULL     root     system         public              users                              DELETE          NULL          NULL
-NULL     admin    system         public              users                              UPDATE          NULL          NULL
-NULL     admin    system         public              users                              SELECT          NULL          NULL
-NULL     admin    system         public              users                              INSERT          NULL          NULL
-NULL     admin    system         public              users                              GRANT           NULL          NULL
 NULL     admin    system         public              users                              DELETE          NULL          NULL
-NULL     root     system         public              users                              SELECT          NULL          NULL
+NULL     admin    system         public              users                              GRANT           NULL          NULL
+NULL     admin    system         public              users                              INSERT          NULL          NULL
+NULL     admin    system         public              users                              SELECT          NULL          NULL
+NULL     admin    system         public              users                              UPDATE          NULL          NULL
+NULL     root     system         public              users                              DELETE          NULL          NULL
+NULL     root     system         public              users                              GRANT           NULL          NULL
 NULL     root     system         public              users                              INSERT          NULL          NULL
+NULL     root     system         public              users                              SELECT          NULL          NULL
+NULL     root     system         public              users                              UPDATE          NULL          NULL
 NULL     public   system         information_schema  views                              SELECT          NULL          NULL
 NULL     admin    system         public              web_sessions                       DELETE          NULL          NULL
 NULL     admin    system         public              web_sessions                       GRANT           NULL          NULL
 NULL     admin    system         public              web_sessions                       INSERT          NULL          NULL
 NULL     admin    system         public              web_sessions                       SELECT          NULL          NULL
-NULL     root     system         public              web_sessions                       INSERT          NULL          NULL
+NULL     admin    system         public              web_sessions                       UPDATE          NULL          NULL
 NULL     root     system         public              web_sessions                       DELETE          NULL          NULL
 NULL     root     system         public              web_sessions                       GRANT           NULL          NULL
-NULL     root     system         public              web_sessions                       UPDATE          NULL          NULL
+NULL     root     system         public              web_sessions                       INSERT          NULL          NULL
 NULL     root     system         public              web_sessions                       SELECT          NULL          NULL
-NULL     admin    system         public              web_sessions                       UPDATE          NULL          NULL
-NULL     public   system         crdb_internal       zones                              SELECT          NULL          NULL
-NULL     root     system         public              zones                              DELETE          NULL          NULL
+NULL     root     system         public              web_sessions                       UPDATE          NULL          NULL
 NULL     admin    system         public              zones                              DELETE          NULL          NULL
 NULL     admin    system         public              zones                              GRANT           NULL          NULL
 NULL     admin    system         public              zones                              INSERT          NULL          NULL
 NULL     admin    system         public              zones                              SELECT          NULL          NULL
 NULL     admin    system         public              zones                              UPDATE          NULL          NULL
+NULL     public   system         crdb_internal       zones                              SELECT          NULL          NULL
+NULL     root     system         public              zones                              DELETE          NULL          NULL
 NULL     root     system         public              zones                              GRANT           NULL          NULL
-NULL     root     system         public              zones                              UPDATE          NULL          NULL
-NULL     root     system         public              zones                              SELECT          NULL          NULL
 NULL     root     system         public              zones                              INSERT          NULL          NULL
+NULL     root     system         public              zones                              SELECT          NULL          NULL
+NULL     root     system         public              zones                              UPDATE          NULL          NULL
 
 query TTTTTTTT colnames
 SELECT * FROM system.information_schema.role_table_grants
@@ -1247,6 +1251,7 @@ NULL     public   system         pg_catalog          pg_rewrite                 
 NULL     public   system         pg_catalog          pg_roles                           SELECT          NULL          NULL
 NULL     public   system         pg_catalog          pg_sequence                        SELECT          NULL          NULL
 NULL     public   system         pg_catalog          pg_settings                        SELECT          NULL          NULL
+NULL     public   system         pg_catalog          pg_stat_activity                   SELECT          NULL          NULL
 NULL     public   system         pg_catalog          pg_tables                          SELECT          NULL          NULL
 NULL     public   system         pg_catalog          pg_tablespace                      SELECT          NULL          NULL
 NULL     public   system         pg_catalog          pg_trigger                         SELECT          NULL          NULL

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -41,6 +41,7 @@ pg_rewrite
 pg_roles
 pg_sequence
 pg_settings
+pg_stat_activity
 pg_tables
 pg_tablespace
 pg_trigger
@@ -101,6 +102,7 @@ pg_rewrite
 pg_roles
 pg_sequence
 pg_settings
+pg_stat_activity
 pg_tables
 pg_tablespace
 pg_trigger
@@ -1146,6 +1148,38 @@ query TOOBTTT colnames
 SELECT * FROM pg_catalog.pg_extension
 ----
 extname  extowner  extnamespace  extrelocatable  extversion  extconfig  extcondition
+
+## pg_catalog.pg_stat_activity
+
+query OTIOTTTTITTTTTTTIIT colnames
+SELECT * FROM pg_catalog.pg_stat_activity
+----
+datid  datname  pid  usesysid  username  application_name  client_addr  client_hostname  client_port  backend_start  xact_start  query_start  state_change  wait_event_type  wait_event  state  backend_xid  backend_xmin  query
+
+query TTBTT colnames
+SHOW COLUMNS FROM pg_catalog.pg_stat_activity
+----
+Field             Type                      Null  Default  Indices
+datid             OID                       true  NULL     {}
+datname           NAME                      true  NULL     {}
+pid               INTEGER                   true  NULL     {}
+usesysid          OID                       true  NULL     {}
+username          NAME                      true  NULL     {}
+application_name  STRING                    true  NULL     {}
+client_addr       INET                      true  NULL     {}
+client_hostname   STRING                    true  NULL     {}
+client_port       INTEGER                   true  NULL     {}
+backend_start     TIMESTAMP WITH TIME ZONE  true  NULL     {}
+xact_start        TIMESTAMP WITH TIME ZONE  true  NULL     {}
+query_start       TIMESTAMP WITH TIME ZONE  true  NULL     {}
+state_change      TIMESTAMP WITH TIME ZONE  true  NULL     {}
+wait_event_type   STRING                    true  NULL     {}
+wait_event        STRING                    true  NULL     {}
+state             STRING                    true  NULL     {}
+backend_xid       INTEGER                   true  NULL     {}
+backend_xmin      INTEGER                   true  NULL     {}
+query             STRING                    true  NULL     {}
+
 
 ## pg_catalog.pg_settings
 

--- a/pkg/sql/logictest/testdata/planner_test/explain
+++ b/pkg/sql/logictest/testdata/planner_test/explain
@@ -156,7 +156,7 @@ sort                   ·      ·
  └── render            ·      ·
       └── filter       ·      ·
            └── values  ·      ·
-·                      size   6 columns, 83 rows
+·                      size   6 columns, 84 rows
 
 query TTT
 EXPLAIN SHOW DATABASE
@@ -219,7 +219,7 @@ sort                                       ·            ·
                      ├── render            ·            ·
                      │    └── filter       ·            ·
                      │         └── values  ·            ·
-                     │                     size         17 columns, 752 rows
+                     │                     size         17 columns, 771 rows
                      └── render            ·            ·
                           └── filter       ·            ·
                                └── values  ·            ·
@@ -233,7 +233,7 @@ sort                   ·      ·
  └── render            ·      ·
       └── filter       ·      ·
            └── values  ·      ·
-·                      size   8 columns, 540 rows
+·                      size   8 columns, 545 rows
 
 
 query TTT

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain
@@ -157,7 +157,7 @@ sort                   ·      ·
  └── render            ·      ·
       └── filter       ·      ·
            └── values  ·      ·
-·                      size   6 columns, 83 rows
+·                      size   6 columns, 84 rows
 
 query TTT
 EXPLAIN SHOW DATABASE
@@ -220,7 +220,7 @@ sort                                       ·            ·
                      ├── render            ·            ·
                      │    └── filter       ·            ·
                      │         └── values  ·            ·
-                     │                     size         17 columns, 752 rows
+                     │                     size         17 columns, 771 rows
                      └── render            ·            ·
                           └── filter       ·            ·
                                └── values  ·            ·
@@ -234,7 +234,7 @@ sort                   ·      ·
  └── render            ·      ·
       └── filter       ·      ·
            └── values  ·      ·
-·                      size   8 columns, 540 rows
+·                      size   8 columns, 545 rows
 
 
 query TTT

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -90,6 +90,7 @@ var pgCatalog = virtualSchema{
 		pgCatalogTriggerTable,
 		pgCatalogTypeTable,
 		pgCatalogViewsTable,
+		pgCatalogStatActivityTable,
 	},
 	// Postgres's catalogs are ill-defined when there is no current
 	// database set. Simply reject any attempts to use them in that
@@ -1887,6 +1888,36 @@ CREATE TABLE pg_catalog.pg_user_mapping (
 	populate: func(ctx context.Context, p *planner, _ *DatabaseDescriptor, addRow func(...tree.Datum) error) error {
 		// This table stores the mapping to foreign server users.
 		// Foreign servers are not supported.
+		return nil
+	},
+}
+
+// See: https://www.postgresql.org/docs/9.6/static/monitoring-stats.html#PG-STAT-ACTIVITY-VIEW
+var pgCatalogStatActivityTable = virtualSchemaTable{
+	schema: `
+CREATE TABLE pg_catalog.pg_stat_activity (
+	datid OID,
+	datname NAME,
+	pid INTEGER,
+	usesysid OID,
+	username NAME,
+	application_name TEXT,
+	client_addr INET,
+	client_hostname TEXT,
+	client_port INTEGER,
+	backend_start TIMESTAMPTZ,
+	xact_start TIMESTAMPTZ,
+	query_start TIMESTAMPTZ,
+	state_change TIMESTAMPTZ,
+	wait_event_type TEXT,
+	wait_event TEXT,
+	state TEXT,
+	backend_xid INTEGER,
+	backend_xmin INTEGER,
+	query TEXT
+)
+`,
+	populate: func(ctx context.Context, p *planner, _ *DatabaseDescriptor, addRow func(...tree.Datum) error) error {
 		return nil
 	},
 }


### PR DESCRIPTION
Release note: Add an empty pg_stat_activity virtual table for
compatibility

closes #24745 

tested DBeaver and the client no longer errors out when trying to access Administer > Sessions