### PR TITLE
sql: stop using a txn for getting the index backfill timestamp

### DIFF
--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -550,19 +550,14 @@ func (sc *SchemaChanger) backfillIndexes(
 ) error {
 	// Pick a read timestamp for our index backfill, or reuse the previously
 	// stored one.
-	if err := sc.db.Txn(ctx, func(ctx context.Context, txn *client.Txn) error {
-		details := *sc.job.WithTxn(txn).Payload().Details.(*jobs.Payload_SchemaChange).SchemaChange
-		if details.ReadAsOf == (hlc.Timestamp{}) {
-			details.ReadAsOf = txn.CommitTimestamp()
-			if err := sc.job.WithTxn(txn).SetDetails(ctx, details); err != nil {
-				return errors.Wrapf(err, "failed to store readAsOf on job %d", *sc.job.ID())
-			}
+	details := *sc.job.Payload().Details.(*jobs.Payload_SchemaChange).SchemaChange
+	if details.ReadAsOf == (hlc.Timestamp{}) {
+		details.ReadAsOf = sc.clock.Now()
+		if err := sc.job.SetDetails(ctx, details); err != nil {
+			return errors.Wrapf(err, "failed to store readAsOf on job %d", *sc.job.ID())
 		}
-		sc.readAsOf = details.ReadAsOf
-		return nil
-	}); err != nil {
-		return err
 	}
+	sc.readAsOf = details.ReadAsOf
 
 	if fn := sc.testingKnobs.RunBeforeIndexBackfill; fn != nil {
 		fn()


### PR DESCRIPTION
Index backfills use AOST so that their reads are less intrusive.
Before this patch, the timestamp for them reads was chosen in a bizarre
way (unless I'm missing something) - we were creating a txn for the soul
purpose of getting its timestamp. That txn was used to save the job
details with the timestamp in them, but I don't think using a txn for
that is necessary.
This patch gets a timestamp directly from the node's clock.

Besides seeming bizarre, the old code had a bug - it was incorrectly
using the job.WithTxn() API. The code was:

       if err := sc.db.Txn(ctx, func(ctx context.Context, txn *client.Txn) error {
               details := *sc.job.WithTxn(txn).Payload().Details.(*jobs.Payload_SchemaChange).SchemaChange
               if details.ReadAsOf == (hlc.Timestamp{}) {
                       details.ReadAsOf = txn.CommitTimestamp()
                       if err := sc.job.WithTxn(txn).SetDetails(ctx, details); err != nil {
                               return errors.Wrapf(err, "failed to store readAsOf on job %d", *sc.job.ID())
                       }
               }
               sc.readAsOf = details.ReadAsOf
               return nil
       }); err != nil {
               return err
       }

The first WithTxn() call is just bad - it mutates the job and persists
the txn in it, for no reason. If the second WithTxn() call runs, then
the effects of the first one will be negated - the SetDetails() call
will indirectly wipe the txn. However, if the 2nd call didn't run (which
happens, for example, when the txn gets restarted), then the job ends up
holding on to a committed transaction, which will cause it to fail when
it tries to do some further operations.

Fixes #25680

Release note(bug fix): Fixed a bug causing index creation to fail under
rare circustances.