### PR TITLE
sql, opt: split two logic tests and enable for opt

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/distsql_interleaved_join
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_interleaved_join
@@ -1,4 +1,4 @@
-# LogicTest: 5node-distsql 5node-distsql-metadata
+# LogicTest: 5node-distsql 5node-distsql-opt 5node-distsql-metadata
 
 # The following tables form the interleaved hierarchy:
 #   name:             primary key:                # rows:   'a' = id mod X :
@@ -291,11 +291,6 @@ pid1  pa1  cid1  ca1
 5     5    85    19
 5     5    125   59
 
-query T
-SELECT "URL" FROM [EXPLAIN (DISTSQL) SELECT * FROM parent1 JOIN child1 USING(pid1) WHERE pid1 >= 3 AND pid1 <= 5]
-----
-https://cockroachdb.github.io/distsqlplan/decode.html?eJzMkkFr6zAQhO_vVzzm9B7dEstpL4aCryklKbkWH4S1SQSOZFZyaSn570VWoU5oQ9tTb5ZmZscf2hc4b3ip9xxQPUCBUIIwR0PoxbccgpckZePCPKEqCNb1Q8zX0caOUWFwXgwLGxAMR227pDeHhtB6YVTv1qW_9P2sPDES_BDfxjaEEPWWUZUHmlSrSfUHgxcusnSsH3nN2rDceutYZsVRE-54E5Hw7F7Lc91rYRcT-dpud1Ol3dnOJCHPAaHjTfxXq4v_N5K84ycIqyFWf2tFdUn1FdXX-IxGHdGUP6JRv5SmOE-z5tB7F_hLr16ktWGz5bxjwQ_S8r34dqzJx9WYGy8Mh5jVeT4sXJbSD07D6my4OAqr03D5rXBz-PMaAAD__y7yGHk=
-
 # Swap parent1 and child1 tables.
 
 query IIII rowsort,colnames
@@ -314,11 +309,6 @@ pid1  cid1  ca1  pa1
 5     45    45   5
 5     85    19   5
 5     125   59   5
-
-query T
-SELECT "URL" FROM [EXPLAIN (DISTSQL) SELECT * FROM child1 JOIN parent1 USING(pid1) WHERE pid1 >= 3 AND pid1 <= 5]
-----
-https://cockroachdb.github.io/distsqlplan/decode.html?eJzMklFL-zAUxd__n-LPeVK8sqbDl4LQ14lsslfpQ2jutkCXlJtUFNl3lzSC3dChPvnW5JxzT3_kvsJ5w0u954DqEQqEEoQ5GkIvvuUQvCQpGxfmGVVBsK4fYr6ONnaMCoPzYljYgGA4atslvTk0hNYLo_qwLv2172fliZHgh_g-tiGEqLeMqjzQpFpNqj8ZvHCRpWP9xGvWhuXOW8cyK46acM-biIRn91pe6nZnO5PA13a7mwq9FnYxKXkOCB1v4kWtri5vJZnHTxBWQ6z-14rqkuo51Tf4ikYd0ZS_olF_lKY4T7Pm0HsX-FuvXqS1YbPlvGPBD9Lyg_h2rMnH1ZgbLwyHmNV5PixcltIPTsPqbLg4CqvTcPmjcHP49xYAAP__IiwYdw==
 
 # Select over two ranges for parent/child with split at grandchild key.
 # Also, rows with pid1 <= 30 should have 4 rows whereas pid1 > 30 should
@@ -342,11 +332,6 @@ pid1 pa1 pid1 cid1 ca1
 31    7    31    71    5
 31    7    31    111   45
 
-query T
-SELECT "URL" FROM [EXPLAIN (DISTSQL) SELECT * FROM parent1 JOIN child1 ON parent1.pid1 = child1.pid1 WHERE parent1.pid1 >= 29 AND parent1.pid1 <= 31 ORDER BY parent1.pid1]
-----
-https://cockroachdb.github.io/distsqlplan/decode.html?eJzUUcFq6zAQvL-veOypJSqxnOZiKOiaUpKSa_FBWBtH4EhmtS4twf9eJB0Sl6S0vfVm7czs7IyP4LzBtT5ggOoFJAhYQi2gJ99gCJ7iOJNW5g2qQoB1_cBxXAtoPCFUR2DLHUIFK8dIHepX3KI2SI_eOqR5XGuQte2SyxPuGKKHPWh6V70mdBw5W9vuz5FmbzsTgbwHBHS44xslZ7cPFLnpEwRsBq7-KylUKdRCqHuhllCPAvzAp2MD6xahkqO4EuiUw5NBQjM9W8kZ1OOF1Gt_5_t5OWFfcy8n7vJXdRZ_o84LgbYYeu8CfquqInaNpsX8b4IfqMFn8k2yyc9N0qWBwcAZlfmxcglKB56L5ZfixURcfBaXP3Kux38fAQAA__8x_hkU
-
 # parent-child where pid1 <= 15 have one joined row and pid1 > 15 have no
 # joined rows (since child2 only has 15 rows up to pid1 = 15).
 # Returns:
@@ -363,16 +348,6 @@ pid1 pa1 cid2 cid3 ca2
 16  0  16  2   2
 20  4  20  6   6
 
-# Note this spans all 5 nodes, which makes sense since we want to read all
-# parent rows even if child rows are non-existent (so we can support OUTER
-# joins).
-# TODO(richardwu): we can remove nodes reading from just one table for INNER
-# joins or LEFT/RIGHT joins.
-query T
-SELECT "URL" FROM [EXPLAIN (DISTSQL) SELECT * FROM parent1 JOIN child2 USING(pid1) WHERE pid1 >= 12 ORDER BY pid1]
-----
-https://cockroachdb.github.io/distsqlplan/decode.html?eJzMlD1rwzAQhvf-ivJOLbkSyx8ZDAWtKSUpWYsHY10Sg2MZSS4twf-92B4Sl6YfzuLN0t3j9x6BdESpFa_SA1vErxAg-CAEIIQgREgIldEZW6tN29IDS_WO2CPkZVW7djshZNow4iNc7gpGjGXp2BScvvGGU8XmSeclm7kHgmKX5kWX-MxbhzYjP6TmQ1ap4dK1Y2zy3f68ku3zQrWz9f8BoeCtu5Nidv9o2t7uE4R17eJbKUj6JEOSEckFkoaga3ca1rp0x4hFQxeETh7aKDashmNLMUPSfGO90g-6mkeD7kvp_iBdjDpOMd3j9EcJ-dMVCkYJBdMVCkcJhdMV-uVJ2rCtdGn5T7fTa683qx33z4HVtcn4xeisi-mX647rNhRb11dFv1iWXakb8BwWP8KLAex9hf1rkoNr4PAaOPoXnDQ3nwEAAP__9wcgdA==
-
 # Single gateway node query (node 1).
 # Returns:
 #   pid1    pa1           cid2      cid3              ca2
@@ -384,12 +359,6 @@ SELECT * FROM parent1 JOIN child2 USING(pid1) WHERE pid1 IN (1, 11, 21, 31)
 pid1  pa1  cid2  cid3  ca2
 1     1    1     1     1
 11    3    11    11    4
-
-# These rows are all on the same node 1 (gateway).
-query T
-SELECT "URL" FROM [EXPLAIN (DISTSQL) SELECT * FROM parent1 JOIN child2 USING(pid1) WHERE pid1 IN (1, 11, 21, 31) ORDER BY pid1]
-----
-https://cockroachdb.github.io/distsqlplan/decode.html?eJyMUE1LxDAUvPsrZE6KD9ws6iEg5LoirvQqPYTmbTfQTcrLqyhL_7u0OagHwVvmIzOZnJFy4Bd_4gL7BoOWMEruuJQsC1UNu_ABuyHENE660C2hy8KwZ2jUgWGxS8oysH_nhn1gecoxsdxuQAisPg5rwzMfFEtHPHn5dKMXTmpAaGJ__Kl0xziELQg1B4SBD3rlzM31oyze9QjCflJ76Qy5Lbk7cvfkHtDOhDzp92OL-p5hzUz_H9RwGXMq_GvAX8mbuSVw6Ll-WsmTdPwquVtrKtyv91YicNGqmgp2qUpzO198BQAA___Vk4P-
 
 # Parent-grandchild.
 # Returns:
@@ -417,34 +386,6 @@ pid1  pa1  cid2  cid3  gcid2  gca2
 32    0    2     2     32     6
 33    1    3     3     33     7
 
-query T
-SELECT "URL" FROM [EXPLAIN (DISTSQL)
-  SELECT * FROM parent1 JOIN grandchild2 USING(pid1) WHERE
-    pid1 >= 11 AND pid1 <= 13
-    OR pid1 >= 19 AND pid1 <= 21
-    OR pid1 >= 31 AND pid1 <= 33
-]
-----
-https://cockroachdb.github.io/distsqlplan/decode.html?eJzslE9r3DAQxe_9FGJOu3RKLDlpqWBBhVJwKd5iemt9ENbEETiSkeTSEvzdi-0u8Yb0Xwohh71ZevPjDX6juQHnDZX6miLIz8ABQQDCBdQIffANxejDJC2FhfkGMkOwrh_SdF0jND4QyBtINnUEEgqXKHSkv1JF2lB4762jcJYBgqGkbTc7faDLBJOHvdbhu-p1IJcm-0lg72yXKEi22SjOvgxZljc7xnMpZVF-2rJ9tVJox_jrg_KmfMvWjOA_le1CraD8IAFCZdurdTtt0M40V7Yz4qA-ek_LfwOEji7TRvHn212YGpk_AWE_JMkURyVQnaO6QPUS1SuoRwQ_pNt8YtItgeQj_iLD2-gG54OhQOYoq3q8J-XSv_D9WX6n8H5rcWTNHzQ-_DQ-T2h8xIMyFKcMn1CGf1jjFcXeu0h_9cKzaUWQaWnZJ9EPoaGPwTezzXLcz9x8YSimReXLoXCzNDe4hvlv4fMjOLsLi_9xzv8JrsdnPwIAAP__gf0kvQ==
-
-query TTT
-EXPLAIN SELECT * FROM parent1 JOIN grandchild2 USING(pid1) WHERE
-  pid1 >= 11 AND pid1 <= 13
-  OR pid1 >= 19 AND pid1 <= 21
-  OR pid1 >= 31 AND pid1 <= 33
-----
-render          ·               ·
- └── join       ·               ·
-      │         type            inner
-      │         equality        (pid1) = (pid1)
-      │         mergeJoinOrder  +"(pid1=pid1)"
-      ├── scan  ·               ·
-      │         table           parent1@primary
-      │         spans           /11-/13/# /19-/21/# /31-/33/#
-      └── scan  ·               ·
-·               table           grandchild2@primary
-·               spans           /11/#/56/1-/13/#/56/2 /19/#/56/1-/21/#/56/2 /31/#/56/1-/33/#/56/2
-
 # Swap parent1 and grandchild2 positions.
 query IIIIII rowsort,colnames
 SELECT * FROM grandchild2 JOIN parent1 USING(pid1) WHERE
@@ -463,34 +404,6 @@ pid1  cid2  cid3  gcid2  gca2 pa1
 31    1     1     31     5    7
 32    2     2     32     6    0
 33    3     3     33     7    1
-
-query T
-SELECT "URL" FROM [EXPLAIN (DISTSQL)
-  SELECT * FROM grandchild2 JOIN parent1 USING(pid1) WHERE
-    pid1 >= 11 AND pid1 <= 13
-    OR pid1 >= 19 AND pid1 <= 21
-    OR pid1 >= 31 AND pid1 <= 33
-]
-----
-https://cockroachdb.github.io/distsqlplan/decode.html?eJzslE-L2zAQxe_9FGJOCZ2ylr1LqSCgQim4FKeY3lofhDXrFXglI8mlZfF3L7Yb4oT0Xwolh9wsvfnxBr_RPIF1mgr1SAHEJ-CAkALCHVQInXc1heD8KM2Fuf4KIkEwtuvjeF0h1M4TiCeIJrYEAnIbybekvlBJSpN_54wlf5MAgqaoTDs5vaf7CKOHeVT-m2y8srp-MK0e7UeRvTVtJC_YaiU5-9wnSVZvGM-EEHnxcc225UKhDeOvdsrr4g1bMin_oaxnagFlOwkQStM8LFvqlCcb-U757_3M_w0QWrqPK8mfrzd-bGT6BIRtHwWTHGWKMkN5i_IO5UuoBgTXx30-IaqGQPABf5LhPrreOq_Jkz7IqhpOpFy4F667yY4KT1unB9b8rPHh1_G5oPFJz8owvWZ4QRn-Zo2XFDpnA_3RC0_GFUG6oXmfBNf7mj54V08283E7cdOFphBnlc-H3E7S1OAS5r-Ebw_g5BhO_8U5-yu4Gp59DwAA__8zXSS0
-
-query TTT
-EXPLAIN SELECT * FROM grandchild2 JOIN parent1 USING(pid1) WHERE
-  pid1 >= 11 AND pid1 <= 13
-  OR pid1 >= 19 AND pid1 <= 21
-  OR pid1 >= 31 AND pid1 <= 33
-----
-render          ·               ·
- └── join       ·               ·
-      │         type            inner
-      │         equality        (pid1) = (pid1)
-      │         mergeJoinOrder  +"(pid1=pid1)"
-      ├── scan  ·               ·
-      │         table           grandchild2@primary
-      │         spans           /11/#/56/1-/13/#/56/2 /19/#/56/1-/21/#/56/2 /31/#/56/1-/33/#/56/2
-      └── scan  ·               ·
-·               table           parent1@primary
-·               spans           /11-/13/# /19-/21/# /31-/33/#
 
 # Join on multiple interleaved columns with an overarching ancestor (parent1).
 # Returns:
@@ -514,44 +427,6 @@ pid1  cid2  cid3  ca2  pid1  cid2  cid3  gcid2  gca2
 13    13    13    6    13    13    13    13     0
 14    14    0     0    14    14    0     14     1
 
-# Note there are 5 nodes because the filter cid2 >= 12 AND cid2 <= 14
-# creates a giant parent span which requires reading from all rows.
-query T
-SELECT "URL" FROM [EXPLAIN (DISTSQL)
-  SELECT * FROM child2 JOIN grandchild2 ON
-    child2.pid1=grandchild2.pid1
-    AND child2.cid2=grandchild2.cid2
-    AND child2.cid3=grandchild2.cid3
-  WHERE
-    child2.pid1 >= 5 AND child2.pid1 <= 7
-    OR child2.cid2 >= 12 AND child2.cid2 <= 14
-    OR gcid2 >= 49 AND gcid2 <= 51
-]
-----
-https://cockroachdb.github.io/distsqlplan/decode.html?eJzslUFr2zAUx-_7FOKdHPJGLVluV0FAgzHIGMkIu20-GOs1NbhWkOSxUfLdh-3FrUs21gRy8tH668df8k_wHqG2hlb5A3lQ34ADggCEBBAkIKSQIeycLch769otPbA0P0HFCGW9a0K7nCEU1hGoRwhlqAgULOtArqL8B20oN-Q-2bImdxUDgqGQl1XX-JnuArQd5UPufunivqxMe4JNub1_HmxdXptxyj6WVSCnWBRFmrPvTRwntGCpUmq5-jpj71cf2BAUC3bzJ5ix9YZFkRYDwsWYEQPD5QE6UHKg5O2YkgOV8gMFCP29AaGiuxBpPkct5qiT-Wzh2muMlgBh3QTFNEctUCeoJeoU9TXqG9TvUN9CtkewTXj68T7kWwLF9_gXOU9Omto6Q47MSEK2P6JvZd_a3VX6YuPxajGq5ie9Cz69i0u8C3GSHDHJuYSc5CQ5ySTnEnLkSXLkJOfS4-6InA35na09_dc0i9txSGZL_ez0tnEFfXG26Gr6z3XHdQuGfOhT3n8s6y7qDvgc5v-Er0dw_BIW5zQn58DyHDh9FZzt3_wOAAD__-mfE2o=
-
-query TTT
-EXPLAIN
-  SELECT * FROM child2 JOIN grandchild2 ON
-    child2.pid1=grandchild2.pid1
-    AND child2.cid2=grandchild2.cid2
-    AND child2.cid3=grandchild2.cid3
-  WHERE
-    child2.pid1 >= 5 AND child2.pid1 <= 7
-    OR child2.cid2 >= 12 AND child2.cid2 <= 14
-    OR gcid2 >= 49 AND gcid2 <= 51
-----
-join       ·               ·
- │         type            inner
- │         equality        (pid1, cid2, cid3) = (pid1, cid2, cid3)
- │         mergeJoinOrder  +"(pid1=pid1)",+"(cid2=cid2)",+"(cid3=cid3)"
- ├── scan  ·               ·
- │         table           child2@primary
- │         spans           ALL
- └── scan  ·               ·
-·          table           grandchild2@primary
-·          spans           ALL
-
 # Aggregation over parent and child keys.
 # There are 4 rows for each 10 <= pid1 <= 30 and 3 rows for each 30 < pid1 <=
 # 39.
@@ -572,14 +447,6 @@ SELECT SUM(parent1.pid1), SUM(child1.cid1) FROM parent1 JOIN child1 USING(pid1) 
   pid1 >= 10 AND pid1 <= 39
 ----
 2625 8745
-
-query T
-SELECT "URL" FROM [EXPLAIN (DISTSQL)
-  SELECT SUM(parent1.pid1), SUM(child1.cid1) FROM parent1 JOIN child1 USING(pid1) WHERE
-    pid1 >= 10 AND pid1 <= 39
-]
-----
-https://cockroachdb.github.io/distsqlplan/decode.html?eJzUlVGrmzAUx9_3KS7n6V4WuEZtbysM3GPHto6OPQ0fgjm1gk0kiWOj-N1HlLVa2jisL74lOefv75z_CeYEQnL8yo6oIfoJFAj4QCAAAiEQWEBCoFQyRa2lsimtYMN_Q-QRyEVZGXucEEilQohOYHJTIESwEQZVgewX7pBxVJ9kLlC9WgRHw_KiIX7GvQHLyI9M_YlLplAYm2MDT9vKRE-x3e7y7NBNTA95wc-Bf4kkttW3JCBQ4N48x_T9ywdls5olEDgnB5DUBGRlLl1owzKEiNbk_zv9mGUKM2akel32u_v-48tzTC2zWfkvd4H-XeCFUwmpOCrkPUhSu0ui3tiagl5NdNS4_RmOe6DTjrdv04zbH2VtMENrBzrtWLuaxtpglLXhDK0d6LRj7Xoaa8NR1noztHag0461i-n__zeAO9SlFBqv3oHbX_bs-4A8w_Yx0bJSKX5TMm0w7Xbb6JoDjtq0UdpuNqIN2QK7YuoU-z0xvRb7bvIAOnCqQ7c4fKTuhVO8dJOXj5DfnOKVm7x6hLx2z8obuCbuS3bNTup3fwMAAP__hy1jzg==
 
 ###############
 # Outer joins #
@@ -659,11 +526,6 @@ NULL       /0       20        {5}       5
 
 ### Begin OUTER queries
 
-query T
-SELECT "URL" FROM [EXPLAIN (DISTSQL) SELECT * FROM outer_p1 FULL OUTER JOIN outer_c1 USING (pid1)]
-----
-https://cockroachdb.github.io/distsqlplan/decode.html?eJzclE2L2zAQhu_9FWJOu3TK-nMPhoIuDTgYp5jkVEwx1iQ1OJKR5NIQ_N-L7EOaNP1Y5-abpdEzr585zBmkEpRXRzKQfAEfEAJACAEhAoQYSoROq5qMUdo9mYBU_IDEQ2hk11t3XSLUShMkZ7CNbQkSSKUl3VL1nQqqBOm1aiTpFxchyFZNOyZmtLfgMppjpU9c9Zb01849KprDt99LtStNrQBhe-ooYatdlrHNbvupYOtNmgNCS3v7xP33zx-16zJ-upYkBemEpat8l2VP3EcePiPjATIeIeMxMv4K5YCgensxM7Y6ECT-gH-wv0j3UmlBmsSVZTncmU-uPqjuJb55eD86uIr2Zw0-WMjgg1n24ULsw1n20ULso1n23kLs_7FwCzKdkob-a6N4biWRONC0v4zqdU2ftarHmOm4GbnxQpCxU9WfDqkcS-MP_gr7f4Vfr2DvFg4eSQ4fgaNH4PhNcDm8-xkAAP__5oReVw==
-
 query IIIII rowsort,colnames
 SELECT * FROM outer_p1 FULL OUTER JOIN outer_c1 USING (pid1)
 ----
@@ -695,11 +557,6 @@ pid1  pa1  cid1  cid2  ca1
 26    NULL  26    26    226
 28    NULL  28    28    228
 
-query T
-SELECT "URL" FROM [EXPLAIN (DISTSQL) SELECT * FROM outer_gc1 FULL OUTER JOIN outer_c1 USING (pid1, cid1, cid2)]
-----
-https://cockroachdb.github.io/distsqlplan/decode.html?eJzklU2LnEAQhu_5FVKnHabC-rlJhEBfsuAiTpCdU5Agdq0R3G7pbkOWwf8eWiEzTiYf6xw9Vlc9_crTUB5ASE5Z-Uwa4i_gAYIPCAEghIAQQYHQKVmR1lLZkQlI-A-IXYRGdL2xxwVCJRVBfADTmJYghkQYUi2V3ymnkpN6kI0gdWsjOJmyacfElJ4M2IzmuVQvTPaG1Ne6slN5U3_7vTe2prsA4fGlo9i536eps9s_fsqdh12SAUJLT-aGeVtk_hZZsN18VPa22ZGNIMFJxU5yn-3T9IZ5yO42-Kv0kb07KQNk7zfosBAdFqHDPkAxIMjeHCVoU9YEsTfgH0Qd_fRCKk6K-ExIMVxQmcm3sruNzgYvR_uzaG_RG_nreyN_kahgfaKCRaLC9YkKF4ly1yfqH_-RnHQnhab_2n6uXZ_Ea5p2rZa9quizktUYM5W7kRsPOGkzdb2pSMTYGj_wFPb-Ct_NYPcc9q9JDq6Bw2vg6FVwMbz5GQAA__8alY8h
-
 query IIIIII rowsort,colnames
 SELECT * FROM outer_gc1 FULL OUTER JOIN outer_c1 USING (pid1, cid1, cid2)
 ----
@@ -724,11 +581,6 @@ pid1  cid1  cid2  gcid1  gca1  ca1
 32    32    32    32     332   NULL
 36    36    36    36     336   NULL
 
-query T
-SELECT "URL" FROM [EXPLAIN (DISTSQL) SELECT * FROM outer_c1 LEFT OUTER JOIN outer_p1 USING (pid1) WHERE pid1 >= 0 AND pid1 < 40]
-----
-https://cockroachdb.github.io/distsqlplan/decode.html?eJzUlE-Lo0AQxe_7KeSddtlaYqu7B2HBSwYMIQ6SOQ0yiF3JCMaW7naYEPzug3rIJJP5l5xys_v1q1e_gnKHWkle5Bs2CO8hQPBA8EEIkBEarQo2RuleHh_H8hmhSyjrprX9dUYolGaEO9jSVowQcW1ZV5w_ccq5ZD1TZc164oIg2eZlNaTNeWXRZ5SbXG8j1VrWD0XfQ1quH99KTS-NpUBYbhsOnfn0Zukkd8tp6sySeAFCxSv7MxK_f_3XfZXhE4SktaETCYo8inyKAor-IesIqrV7DmPzNSMUHb3Dukdsa6Ula5YHTFl3YhoL9Uc1k-Do4elo7yBanDVmcZVj9s5i9a6S1T-L1b9K1k9-FSmbRtWGv7Qdbr9eLNc87qJRrS74VqtiiBmPyeAbLiQbO6piPMT1IA0NvjaLD81_D8zusdm7JNm_xBx8y5x1P14CAAD___ca6HA=
-
 query IIIII rowsort,colnames
 SELECT * FROM outer_c1 LEFT OUTER JOIN outer_p1 USING (pid1) WHERE pid1 >= 0 AND pid1 < 40
 ----
@@ -749,11 +601,6 @@ pid1  cid1  cid2  ca1  pa1
 26    26    26    226  NULL
 28    28    28    228  NULL
 
-query T
-SELECT "URL" FROM [EXPLAIN (DISTSQL) SELECT * FROM outer_p1 RIGHT OUTER JOIN outer_gc1 USING (pid1) WHERE pid1 >= 1 AND pid1 <= 20]
-----
-https://cockroachdb.github.io/distsqlplan/decode.html?eJzUlE9r20AQxe_9FOKdWjrF-ucWBIW9lFamWEW4pyCC0I4VgawVu6sQY_Tdg6SDY8f5Z5980-7bN29-A6MdGiV5mW_YILqBB4IPQgBCiIzQalWwMUoP8vQ4lg-IXELVtJ0drjNCoTQj2sFWtmZEiBvLuub8nlPOJeuFqhrWMxcEyTav6jHtL68thoxqk-utUJ1lfdsOPaRVefdcKotBm2qBsNq2HDlp_PvPykn-r36lziKJlyDUvLafhff1y0891Bk_QUg6GzkiIOGTCEnMSXwn8QNZT1Cd3cMYm5eMyOvpBeA9Z9coLVmzPADL-hMjWapvqp2FRw9PR_sH0d5Zs_aud9b-WcD-9QIHZwEH1wv8xu8jZdOqxvC7lsUdto1lydNqGtXpgv9pVYwx0zEZfeOFZGMn1ZsOcTNKY4NPzd6r5vmB2T02-5ckB5eYww-Zs_7TYwAAAP__Vjbt9A==
-
 query IIIIII rowsort,colnames
 SELECT * FROM outer_p1 RIGHT OUTER JOIN outer_gc1 USING (pid1) WHERE pid1 >= 1 AND pid1 <= 20
 ----
@@ -763,86 +610,6 @@ pid1  pa1  cid1  cid2  gcid1  gca1
 12    112  12    12    12     312
 16    116  16    16    16     316
 20    120  20    20    20     320
-
-########################
-# Non-interleaved joins #
-########################
-
-# Join on siblings uses merge joiner.
-# TODO(richardwu): Update this once sibling joins are implemented.
-query T
-SELECT "URL" FROM [EXPLAIN (DISTSQL) SELECT * FROM child1 JOIN child2 USING(pid1)]
-----
-https://cockroachdb.github.io/distsqlplan/decode.html?eJzElsFq20AQhu99ijCnlmyxdyXZsaCgawpNSuit-KBYU1vgaM1Kgobgdy-yCq5ldUabwfLNsvbbnZ35QP8bFDbDh_QFS4h_ggYFBhQEoCAEBREsFeycXWFZWtcsaYH77DfEUwV5saur5u-lgpV1CPEbVHm1RYjhR_q8xSdMM3STKSjIsErz7eGYnctfUvearDb5NtOw3CuwdfV3q-MOz683m7TcnLJJs36poKzSNUKs9-p9JUVESUZUkvlvScd9rMvQYdbd57Y5eNCqntt9Q7fGrzYv0E10p-Nb_FV9TPTtpy8uX2_an6Dgsa7im0SrxKgkUEmkkplK5p3bH28WDLhZXfRV3Vvwg_1sdxMddVb2nx2enK2HD1qP5J5HSbOR3NPXcU9f3j0zvNlmpPl7lDQfaf7mOvM3l59_MLzZwUjz9yjpbqT5B9eZf3D5-YfDmx2ONH-PkhYjzT-8zvzDcbNHTzlPWO5sUeKgZDFtLoTZGts2lbZ2K_zu7OpwTPv4eOAOX9QMy6p9a9qH-6J91RQ4HJ5J4IUE1qK6dUTT2qNlxg-eSeCFBNaiujstO6NNl57-Swd0vwMS1qc9m3bpUCI4DTOC0zAjOA1zgjM0I3gkEZyGGcFpmBGchjnBGZoRfCYRfC5RlIYZRWmYUZSGOUUZmlH0TqIoDTOK0jCjKA1zijI0o-hCoqgW5QSGZiRlaMZShuY05XAuK8jCgiwtyOKCMC_IAoMWJQZ9Fhm8bKVpzlaa5myladZWBuds9QlL5zPzSUu-NGerV17yxjlbz8IDaety_-FPAAAA__-7ahyi
-
-# Join on non-interleaved tables (with key) uses merge joiner.
-query T
-SELECT "URL" FROM [EXPLAIN (DISTSQL) SELECT * FROM parent1 JOIN parent2 ON pid1=pid2]
-----
-https://cockroachdb.github.io/distsqlplan/decode.html?eJy8lVFr2zAQx9_3Kco9bVQjluykqWHg1w7WjrK34Qc1uiWG1DKSDCsl333YLmQxic5GRG9xrJ_u_r8D3zvUWuGjfEUL-W_gwEAAgxQYZMBgCSWDxugNWqtNd2QAHtRfyBMGVd20rvu7ZLDRBiF_B1e5PUIOv-TLHp9RKjSLBBgodLLa92UaU71K81Y00mDtOJQHBrp1H3cdr3h5u9lJuzuFi-58ycA6uUXI-YFd6Ol4jzYKDarxPbdd4eOptj53rq81zvYDzRa_66pGs1idXrvHP-5zwW-_fDPVdjf8BAZPrctvCs4KwYqUFdko8zFPOiHPjE4f9VfdLDgfnTxfOzupzafPl8eaL48_37trzldMdyxiORbxHa-v6Tid7jiN5TiN7_j-mo6z6Y6zWI5n9LT09SSCehIXe4o0d57EWlBnGnlG2-ja4qT1k3RRUG1xsGN1azb40-hNX2Z4fOq5fhEotG54-_HwUA-vuganw1kIvAqB1yEwJ0LzMZ38Tws_LLwwP6WTMZ2GDMsPE8Pyw8Sw_DAxLCIzEToLGdYyRLcfJnT7YUK3HyZ0E5mJ0KsQ3Xchuv0wodsPE7r9MKGbyEyEXofovg_R7YcJ3X6Y0O2HCd1EZurLP2dZipl0FkSvguh1EM2p4PM2Znn49C8AAP__9ASy7Q==
-
-# Join on non-interleaved column uses hash joiner.
-query T
-SELECT "URL" FROM [EXPLAIN (DISTSQL) SELECT * FROM parent1 JOIN child1 ON pa1 = ca1]
-----
-https://cockroachdb.github.io/distsqlplan/decode.html?eJy8llFr2zwUhu-_X1HOVQv6SCTZaWMY-HLdRTvK7oYv3PgsMaSWkRVYKfnvI_Egi-PpWDtEl2nySK_OeaDvBzSmwqfyDTvIvoMEAQoEaBCQgIAUCgGtNSvsOmMPP-mBx-onZHMBddPu3OHPhYCVsQjZB7jabREy-Fa-bvEFywrtbA4CKnRlvT1e09r6rbTveVtabJyEYi_A7Nzvs05HvL7fbMpucw7nCop9IaBz5Rohk3vxb5nS8UyrTb2tQiPps0jqr5FO5-waYyu0WJ2dVBxI6icj7_pcdpsvpm7QzuRg1lv84W5zdffJ1uuNu831HQh43rnsJpciVyLXIk9Eng5efHqNZrxmJOqT-d-0M5kO3z16d3J2t5y-XBlLuIBMi0jCycjCyasKp6YPWMVaekCm-0hLV5GXrq66dD19wDrW0gMyPURauo68dH3VpSfTB5zEWnpApmWkpSeRl55E6xMjQV6wa03T4aS2MD88Bas19qPpzM6u8Ks1q-M1_cfnI3f8J1lh5_pvVf_hsem_OgScDi848JIDS1ZumfppGTAyFQYvOPCSA0tW7sHILmg1pOd_0to_b-2F5fnM5kM64QjuhwnB_TAhuB-mBCdoQvCUI7gfJgT3w4TgfpgSnKAJwRccwe85ivphQlE_TCjqhylFCZpQ9IGjqB8mFPXDhKJ-mFKUoAlFlxxFJasnEDQhKUETlhI0pSmFU12BVxZ4bYFXF5h9gVcYJKsxyIvKEGSrn6Zs9dOUrX6atJXAKVtDytLlzkLaUihN2RrUl4JxytaL8uC1tdj_9ysAAP__U3kYdA==
-
-# Prefix join on interleaved columns uses merge joiner.
-query T
-SELECT "URL" FROM [EXPLAIN (DISTSQL) SELECT * FROM child2 JOIN grandchild2 USING(pid1, cid2)]
-----
-https://cockroachdb.github.io/distsqlplan/decode.html?eJzEll1r2zAUhu_3K8q52qhGItn5Mgx828HaUXY3cuFGZ47BtYxsw0rJfx-2C1kcT8eainzp2I_06uiBvK9QKIn3yTNWEP0EDgwEMAiAQQgMVrBnUGp1wKpSuv2kB-7kb4iWDLKibOr25z2Dg9II0SvUWZ0jRPAjecrxEROJerEEBhLrJMu7bUqdPSf6JT4cs1wK2J8YqKZ-W-q8wtPLzTGpjpdszFncInsGVZ2kCBE_sf9LtRpPleqkkO8TTfwz2nkppSVqlMOlblksbtv9J385ctpvqFP8qrIC9YIPLiHHX_XHN_rTF52lx_MjMHho6uimOxGLAxaHLN6weMvi3WAm58MGEw7bFGOHGM1-rz6rcsFXgy_H9w4v9ubTHeD-zLRItfZsJp_XTO7VTDH9HoQ_OyxSbTzbIea1Q3i1I5h-D4E_OyxSbT3bEcxrR-DVjnD6PYT-7LBItfNsRzivHeFsnWck2SNWpSoqnNRolu3ZUKbYT65SjT7gd60O3Tb940PHdX_fEqu6fyv6h7uif9UGnA6vXeCdC8ydcvOVmeYWIxN28NoF3rnA3Cn3YGRXtBjSy7_pwDzvwAjzy5kth3ToIrgZJgQ3w4TgZpgSnKAJwVcugpthQnAzTAhuhinBCZoQfO0i-MZFUTNMKGqGCUXNMKUoQROKbl0UNcOEomaYUNQMU4oSNKHozkVR7tQTCJqQlKAJSwma0pTCqa7gVhbc2oJbXXDsC26FgTs1Bn5VGaxsNdOUrWaastVMk7YSOGWrTVm6vjObtmRLU7Za9SVrnLL1qjwYbd2fPvwJAAD__4eyQAE=
-
-# Subset join on interleaved columns uses hash joiner.
-query T
-SELECT "URL" FROM [EXPLAIN (DISTSQL) SELECT * FROM child2 JOIN grandchild2 USING(pid1, cid3)]
-----
-https://cockroachdb.github.io/distsqlplan/decode.html?eJzElsGK2zAQhu99imVOLagkkp1sYij42O1htyy9FR-80TQxZK0gOdBlybsX2y1pHFdjdYp6VOxP-jX-IP8r1EbjffmMDrKvIEGAAgEJCEhBwAIKAQdrNuicse0rPXCnv0M2F1DVh2PT_lwI2BiLkL1CUzV7hAy-lE97fMRSo53NQYDGpqz23TEHWz2X9iXf7Kq9VlCcBJhj83Or8w5PLze70u0u2VyKPIHiVAhwTblFyORJ_F2qxXiqrS1r_W-iqT9GO291rI3VaFFfbFa0JPXKyP0-lm73yVQ12pkcTH2P35q3XcZ3H2y13f1agICHY5PddCuRK5GnIl-KfCXy9WAA55sljJuNxL43781hJhfDGYyenV6cLad_cBlPw4BUy8gaysgaymgaqulDV_FUCEh1G1kFFVkFFU2FZPrQk3gqBKRaRVYhiaxCEk2FdPrQ03gqBKRaR1YhjaxC-l96ykioR3QHUzuc1ELm7bVQb7EfkzNHu8HP1my6Y_rlQ8d1f7kaXdM_Vf3iru4ftQGnw0sOvObAkpVbLvy0DBiZCoOXHHjNgSUr92BkV7Qa0vPf6cQ_78QLy8uZzYd0yhHcDxOC-2FCcD9MCU7QhOALjuB-mBDcDxOC-2FKcIImBF9yBL_lKOqHCUX9MKGoH6YUJWhC0RVHUT9MKOqHCUX9MKUoQROKrjmKSlZPIGhCUoImLCVoSlMKp7oCryzw2gKvLjD7Aq8wSFZjkFeVIchWP03Z6qcpW_00aSuBU7aGlKXrbxbSlkJpytagvhSMU7ZelQevrcXpzY8AAAD__5b5Mtw=
-
-# Sort node in between join and child nodes produces hash joiner.
-query T
-SELECT "URL" FROM [EXPLAIN (DISTSQL) SELECT * FROM parent1 JOIN (SELECT * FROM child1 ORDER BY cid1) USING(pid1)]
-----
-https://cockroachdb.github.io/distsqlplan/decode.html?eJy8lk9vm0wQxu_vp4jm9FbdKuyC_yFV4tj0kFRpbxUHYrYxksOiBUuNonz3ClMrApx9mGK41bV_zOzsb_LwQrlJ9W3ypEsKf5IkQYoE-SQoIEELigUV1mx1WRpb_6QBbtLfFHqCsrw4VPV_x4K2xmoKX6jKqr2mkH4kD3t9r5NU22uPBKW6SrL9sUxhs6fEPkdFYnVeSYpfBZlD9fdZb494eL7aJeWuDUf172NBZZU8agrlq_i3nhbne9rusn3abemtnOKU-25spe217Bw_Uh9HHdl_t4e35xxyY1Ntddp6UlyT6CdnDvIlKXdfTZbXh-nMba9_Vf9H8sNnmz3ujv8iQXeHKryKpIiUiAIRLd4dZzDiKGf6vDWfTHGtvO6hz9ZetGrL4ebIuWxm9LS8gM2g3MlmOaXNcmabl9PZrIbfnprLKEZPqwsYBcqdjFJTGqVmNmo1nVH-8Nvz5zKK0dP6AkaBciej_CmN8mc2aj2dUcHw2wvmMorR0-YCRoFyJ6OCKY0KZjZqM8873Jku7nVZmLzUg97QvPocOn3UzVxKc7Bb_c2a7bFM8_HuyB1fHFJdVs23fvPhJm--qhscDq_HwFKNopdjaOW5admlvRbdgr0urBgDVzx4PQbuDJxLL8fQnYH3aN858MB9W4H7tqT7uhZj9sMNg_1ww2g_AA32w02j_Vg6J75yD3w1Zj_cMNgPN4z2A9BgP9w02o_1mP3YjDHcDQPD3TAyHNDAcDcNE6AXIK2JS_BHRfYShCM5oIHlgEaaIxx4DnAkuuzlCMd02csRjuqABq4DGsmOcGA7wKHu7gyVC6A7J0T7d85JUS4NdWflKBeHuruTFOnOiVIujXRnhSkbR7qz4rSPu_NUboDunETt3zknUrk01J0Vqlwc6a7cqdrVPX79708AAAD__3t4GdI=
-
-query TTT
-EXPLAIN SELECT * FROM parent1 JOIN (SELECT * FROM child1 ORDER BY cid1) USING (pid1)
-----
-render               ·         ·
- └── join            ·         ·
-      │              type      inner
-      │              equality  (pid1) = (pid1)
-      ├── scan       ·         ·
-      │              table     parent1@primary
-      │              spans     ALL
-      └── sort       ·         ·
-           │         order     +cid1
-           └── scan  ·         ·
-·                    table     child1@primary
-·                    spans     ALL
-
-# Multi-table staggered join uses interleaved joiner on the bottom join
-# and a merge joiner.
-query T
-SELECT "URL" FROM[EXPLAIN (DISTSQL)
-  SELECT * FROM grandchild1
-  JOIN child1 USING (pid1, cid1)
-  JOIN parent1 USING (pid1)
-ORDER BY pid1
-]
-----
-https://cockroachdb.github.io/distsqlplan/decode.html?eJzcls9u2kAQh-99imhOrbIV7NpAsFTJV6o2qVBvlQ8OnoAlx4vWS9Uo4t0rYxLMn-xgRhiJo7377c7OfIffK-Q6wfv4GQsI_oAEAQoEeCDABwE9iATMjZ5gUWhTbqmAUfIPgq6ANJ8vbPk7EjDRBiF4BZvaDCGAUW7RZBj_xTHGCZrvOs3RdLogIEEbp9nqxh_4ZKG8I32OzUs4NXGeTGZplpSljNPprL76vlCdBQIyfLKfQ3krQnX75Zsp979_goCHhQ1uQilCJUJPhL4IBxAtBeiFXRe-qffx5WYWF7Pt8kIJ0TISUNh4ihDIpTi-Ab_jx2z99k5v-9i3B81jg7mVrJrUhzVtztEmQYPJ7jm35cVH7TrwvJ9oprgeqtyZ6ttYaiM5PI7e_kQ2L_N4LztQ873-qucduT2Nj673t66XJ9kur8d2ogF12_tt2S4vY7s8v-3qJN3U9ehGNKCu26At3dRldFPn1807STfvenQjGlDX7a4t3bzL6OadXzf_JN3869GNaEBdt2FbuvmX0c1vNzoeKGeMxVznBR6VCrvlgzCZYtWmQi_MBH8ZPVldU30-rLhVPEmwsNWqqj5GebVUFng83OfAQw4sWXXLnpuWDVqmmsF9DjzkwJJV907L9mi1S3frtOfut-eE5XbPuru0zxHcDROCu2FCcDdMCU7QhOA9juBumBDcDROCu2FKcIImBO9zBB9wFHXDhKJumFDUDVOKEjSh6B1HUTdMKOqGCUXdMKUoQROKDjmKSlZOIGhCUoImLCVoSlMKp7ICLyzw0gIvLjDzAi8wSFZikHuRoZGtbpqy1U1Ttrpp0lYCp2xtEpb2Z9YkLTWlKVsb5aXGOGXrXnhw2hotP_0PAAD__9pnwiY=
-
-# Multi-table join with parent1 and child1 at the bottom uses interleaved
-# joiner but induces a hash joiner on the higher join.
-query T
-SELECT "URL" FROM [EXPLAIN (DISTSQL)
-  SELECT * FROM parent1
-  JOIN child1 USING (pid1)
-  JOIN grandchild1 USING (pid1, cid1)
-]
-----
-https://cockroachdb.github.io/distsqlplan/decode.html?eJzUls-K2zAQh-99imVOLVXZSLbzx1DwsSllt4Teig_aeDYxeK0gK6XLkncvjrPEdlJNHIEgtzjSJ81ovsPvDUqV4YN8wQri38CBgQAGATAIgUEEKYONVkusKqXrLQ0wz_5CPGKQl5utqf9OGSyVRojfwOSmQIhhXhrUBco_uECZof6u8hL1_QgYZGhkXuxv_IHPBuo78hepX5ON1FiauoxFvlq3V5brvMjqheYcYFDgs_mY8M-fvup67_4nMHjcmvgu4SwRLAlZEkG6Y6C25lDpscCn17u1rNbdemowgHSXMqiMXCHEfMcub_qXfCoO_d5H3ZPfG1lpWWaHbgaXJjqlif-WdjxqWyqdocasc1hak9SWM_19k9X6MEjem-RhHCwJjgNhieiMJHifyoQl0173x7YCh7bO1PygvqjNPY_6D3D27rBzN79KcX7bihNNtxUfe1ace1ac-1FcXKWZuG3NiKbbmk08ayY8ayb8aBZcpVlw25oRTbc1m3rWLPCsWeBHs_AqzcLb1oxouq3ZzLNmoWfNQv-58ExFC6w2qqzwotQ3qnvCbIXNG1Vqq5f4U6vl_prm83HP7TNIhpVpVkXzMS-bpbrAy-GxCzxzgblT3Tyy03zAk4lh8NgFnrnA3Knu3pOd0KJPj9p0YH_vwArz7puN-nToIrgdJgS3w4TgdpgSnKAJwSMXwe0wIbgdJgS3w5TgBE0IPnYRfOKiqB0mFLXDhKJ2mFKUoAlFpy6K2mFCUTtMKGqHKUUJmlB05qIod8oJBE1IStCEpQRNaUrhVFZwCwtuacEtLjjmBbfAwJ0SAz-JDINstdOUrXaastVOk7YSOGXrkLB0OrMhaWkoTdk6KC8NxilbT8KD1dZ09-FfAAAA___T9r_v
 
 # Regression test for #22655.
 

--- a/pkg/sql/logictest/testdata/logic_test/distsql_tighten_spans
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_tighten_spans
@@ -1,0 +1,324 @@
+# LogicTest: 5node-distsql 5node-distsql-opt 5node-distsql-metadata
+
+# This test verifies that we correctly tighten spans during index selection as
+# well as after partitioning spans in distsql.
+
+################
+# Schema setup #
+################
+
+statement ok
+CREATE TABLE p1 (
+  a INT,
+  b INT,
+  PRIMARY KEY (a, b),
+  INDEX b (b)
+)
+
+statement ok
+CREATE TABLE c1 (
+  a INT,
+  b INT,
+  PRIMARY KEY (a,b)
+) INTERLEAVE IN PARENT p1 (a, b)
+
+statement ok
+CREATE TABLE p2 (
+  i INT PRIMARY KEY,
+  d INT
+)
+
+statement ok
+CREATE INDEX p2_id ON p2 (i, d) INTERLEAVE IN PARENT p2 (i)
+
+statement ok
+CREATE TABLE bytes_t (a BYTES PRIMARY KEY)
+
+statement ok
+CREATE TABLE decimal_t (a DECIMAL PRIMARY KEY)
+
+#######################
+# Insert dummy values #
+#######################
+
+statement ok
+INSERT INTO p1 VALUES
+  (1,10),
+  (2,1),
+  (2,2),
+  (2,8),
+  (3,5),
+  (3,10),
+  (4,1),
+  (4,2),
+  (4,4)
+
+statement ok
+INSERT INTO c1 VALUES
+  (1,10),
+  (2,1),
+  (2,4),
+  (2,8),
+  (2,10),
+  (4,2)
+
+statement ok
+INSERT INTO p2 VALUES
+  (1, NULL),
+  (2, 2),
+  (3, 1),
+  (4, NULL),
+  (5, NULL),
+  (6, 10),
+  (7, 2),
+  (8, 3)
+
+statement ok
+INSERT INTO bytes_t VALUES
+  ('a'),
+  ('aa'),
+  ('b'),
+  ('c'),
+  ('ca')
+
+statement ok
+INSERT INTO decimal_t VALUES
+  (1),
+  (1.000001),
+  (1.5),
+  (2),
+  (2.001)
+
+############################
+# Split ranges for distsql #
+############################
+
+# Perform some splits to exercise distsql partitioning as well.
+
+# Create split points at X = 2.
+# Also split at the beginning of each index (0 for ASC, 100 for DESC) to
+# prevent interfering with previous indexes/tables.
+
+# p1 table (interleaved index)
+statement ok
+ALTER TABLE p1 SPLIT AT VALUES(2)
+
+# Create a split at /2/#
+statement ok
+ALTER TABLE c1 SPLIT AT VALUES(2,1)
+
+# Split index
+statement ok
+ALTER INDEX b SPLIT AT VALUES(0)
+
+statement ok
+ALTER INDEX b SPLIT AT VALUES(2)
+
+# p2 table (interleaved index)
+statement ok
+ALTER TABLE p2 SPLIT AT VALUES(0)
+
+statement ok
+ALTER TABLE p2 SPLIT AT VALUES(2)
+
+# Create a split at /2/#
+statement ok
+ALTER INDEX p2_id SPLIT AT VALUES(2)
+
+#####################
+# Distribute ranges #
+#####################
+
+# Distribute our ranges across the first 3 (for primary index) and last 2
+# (for seconary indexes) nodes.
+
+statement ok
+ALTER TABLE p1 TESTING_RELOCATE SELECT ARRAY[i], i FROM generate_series(1,3) AS g(i)
+
+statement ok
+ALTER INDEX b TESTING_RELOCATE SELECT ARRAY[i+3], i FROM generate_series(1,2) AS g(i)
+
+# Interleaved index table
+statement ok
+ALTER TABLE p2 TESTING_RELOCATE SELECT ARRAY[i], i FROM generate_series(1,3) as g(i)
+
+#############################
+# Verify range distribution #
+#############################
+
+# p1 table (interleaved table)
+
+query TTITI colnames
+SHOW TESTING_RANGES FROM TABLE p1
+----
+Start Key    End Key      Range ID  Replicas  Lease Holder
+NULL         /2           1         {1}       1
+/2           /2/1/#/54/1  2         {2}       2
+/2/1/#/54/1  NULL         3         {3}       3
+
+# Indexes
+
+query TTITI colnames
+SHOW TESTING_RANGES FROM INDEX b
+----
+Start Key  End Key  Range ID  Replicas  Lease Holder
+NULL       /0       3         {3}       3
+/0         /2       4         {4}       4
+/2         NULL     5         {5}       5
+
+# p2 table (interleaved index)
+
+query TTITI colnames
+SHOW TESTING_RANGES FROM TABLE p2
+----
+Start Key  End Key    Range ID  Replicas  Lease Holder
+NULL       /0         5         {5}       5
+/0         /2         6         {1}       1
+/2         /2/#/55/2  7         {2}       2
+/2/#/55/2  NULL       8         {3}       3
+
+###############
+# Query tests #
+###############
+
+# p1 table
+
+# Secondary index should not be tightened.
+query II rowsort
+SELECT * FROM p1 WHERE b <= 3
+----
+2 1
+2 2
+4 1
+4 2
+
+# Partial predicate on primary key should not be tightened.
+query II rowsort
+SELECT * FROM p1 WHERE a <= 3
+----
+1 10
+2 1
+2 2
+2 8
+3 5
+3 10
+
+# Tighten end key if span contains full primary key.
+query II rowsort
+SELECT * FROM p1 WHERE a <= 3 AND b <= 3
+----
+2 1
+2 2
+
+# Mixed bounds.
+query II rowsort
+SELECT * FROM p1 WHERE a >= 2 AND b <= 3
+----
+2 1
+2 2
+4 1
+4 2
+
+query II rowsort
+SELECT * FROM c1 WHERE a <= 3
+----
+1 10
+2 1
+2 4
+2 8
+2 10
+
+# Tighten span on fully primary key.
+query II rowsort
+SELECT * FROM c1 WHERE a <= 3 AND b <= 3
+----
+2 1
+
+# Table p2 with interleaved index.
+
+# From the primary index.
+
+# Lower bound (i >= 2)
+query II rowsort
+SELECT * FROM p2 WHERE i>= 2
+----
+2 2
+3 1
+4 NULL
+5 NULL
+6 10
+7 2
+8 3
+
+# Upper bound (i <= 5)
+
+query II rowsort
+SELECT * FROM p2 WHERE i <= 5
+----
+1 NULL
+2 2
+3 1
+4 NULL
+5 NULL
+
+# From the interleaved index: no tightening at all.
+
+# Lower bound (i >= 1 AND d >= 2)
+query II rowsort
+SELECT * FROM p2@p2_id WHERE i>= 1 AND d >= 2
+----
+2 2
+6 10
+7 2
+8 3
+
+# Upper bound (i <= 6 AND d <= 5)
+query II rowsort
+SELECT * FROM p2@p2_id WHERE i <= 6 AND d <= 5
+----
+2 2
+3 1
+
+# IS NULL
+query II rowsort
+SELECT * FROM p2@p2_id WHERE i>= 1 AND d IS NULL
+----
+1 NULL
+4 NULL
+5 NULL
+
+# IS NOT NULL
+query II rowsort
+SELECT * FROM p2@p2_id WHERE i>= 1 AND d IS NOT NULL
+----
+2 2
+3 1
+6 10
+7 2
+8 3
+
+# String table
+query T
+SELECT * FROM bytes_t WHERE a = 'a'
+----
+a
+
+# No tightening.
+query T
+SELECT * FROM bytes_t WHERE a < 'aa'
+----
+a
+
+query R
+SELECT * FROM decimal_t WHERE a = 1.00
+----
+1
+
+# No tightening.
+
+query R rowsort
+SELECT * FROM decimal_t WHERE a < 2
+----
+1
+1.000001
+1.5

--- a/pkg/sql/logictest/testdata/planner_test/distsql_interleaved_join
+++ b/pkg/sql/logictest/testdata/planner_test/distsql_interleaved_join
@@ -1,0 +1,477 @@
+# LogicTest: 5node-distsql
+
+# The following tables form the interleaved hierarchy:
+#   name:             primary key:                # rows:   'a' = id mod X :
+#   parent1           (pid1)                      40        8
+#     child1          (pid1, cid1)                150       66
+#       grandchild1   (pid1, cid1, gcid1)         410       201
+#     child2          (pid1, cid2, cid3)          15        7
+#       grandchild2   (pid1, cid2, cid3, gcid2)   51        13
+#   parent2           (pid2)                      5         2
+# Additional rows in child1, child2, and grandchild1 with no corresponding
+# parent row are also inserted.
+#
+# All IDs belonging to a table (pid1 --> parent1, cid1 --> child1, cid2,cid3
+# --> child2, etc.) start from 1 up to (# rows).
+# Foreign keys are modded by their ancestor's (# rows). For example, for child1
+# row with cid1=500, we take ((cid1-1) % 200 + 1) = 100 as pid1.
+# One exception is cid3, which is taken as cid2 % 15.
+# There's a column 'a' that's modded by a factor.
+#
+# This allows us to test the following edge cases (in order of tests):
+#   - one-to-many (parent1 - child1)
+#   - one-to-one and one-to-none (parent1 - child2)
+#   - parent-grandchild (parent1 - grandchild1)
+#   - multiple interleaved columns (child2 - grandchild2)
+#   - additional ancestor above (child2 - grandchild2)
+#   - no interleaved relationship (parent1 - parent2, parent2 - child1)
+#   - TODO(richardwu): sibling-sibling (child1 - child2)
+
+#################
+# Create tables #
+#################
+
+statement ok
+CREATE TABLE parent1 (pid1 INT PRIMARY KEY, pa1 INT)
+
+statement ok
+CREATE TABLE parent2 (pid2 INT PRIMARY KEY, pa2 INT)
+
+statement ok
+CREATE TABLE child1 (
+  pid1 INT,
+  cid1 INT,
+  ca1 INT,
+  PRIMARY KEY(pid1, cid1)
+)
+INTERLEAVE IN PARENT parent1 (pid1)
+
+statement ok
+CREATE TABLE child2 (
+  pid1 INT,
+  cid2 INT,
+  cid3 INT,
+  ca2 INT,
+  PRIMARY KEY(pid1, cid2, cid3)
+)
+INTERLEAVE IN PARENT parent1 (pid1)
+
+statement ok
+CREATE TABLE grandchild1 (
+  pid1 INT,
+  cid1 INT,
+  gcid1 INT,
+  gca1 INT,
+  PRIMARY KEY(pid1, cid1, gcid1)
+)
+INTERLEAVE IN PARENT child1 (pid1, cid1)
+
+# No foreign key since we are permitting the rows to overflow out of child2
+# for pid1 > 15.
+statement ok
+CREATE TABLE grandchild2 (
+  pid1 INT,
+  cid2 INT,
+  cid3 INT,
+  gcid2 INT,
+  gca2 INT,
+  PRIMARY KEY(pid1, cid2, cid3, gcid2)
+)
+INTERLEAVE IN PARENT child2 (pid1, cid2, cid3)
+
+####################
+# Split our ranges #
+####################
+
+# Split at parent1 key into five parts.
+statement ok
+ALTER TABLE parent1 SPLIT AT SELECT i FROM GENERATE_SERIES(8, 32, 8) AS g(i)
+
+# Split at child1 keys in between parent1 parts (total 10 parts).
+statement ok
+ALTER TABLE child1 SPLIT AT SELECT pid1, pid1 + 40 FROM
+GENERATE_SERIES(4, 36, 8) AS g(pid1)
+
+# Split at grandchild2 keys in between the 10 parts (total 20 parts).
+statement ok
+ALTER TABLE grandchild2 SPLIT AT SELECT pid1, pid1 + 40, pid1, pid1 FROM
+GENERATE_SERIES(2, 38, 4) AS g(pid1)
+
+# Relocate the twenty parts to the five nodes.
+statement ok
+ALTER TABLE grandchild2 TESTING_RELOCATE
+  SELECT ARRAY[((i-1)/2)::INT%5+1], i, i+20, i, i FROM GENERATE_SERIES(1, 39, 2) AS g(i)
+
+# Verify data placement.
+query TTITI colnames
+SHOW TESTING_RANGES FROM TABLE parent1
+----
+Start Key                   End Key                     Range ID  Replicas  Lease Holder
+NULL                        /2/#/56/1/42/2/#/58/1/2     1         {1}       1
+/2/#/56/1/42/2/#/58/1/2     /4/#/55/1/44                11        {2}       2
+/4/#/55/1/44                /6/#/56/1/46/6/#/58/1/6     6         {3}       3
+/6/#/56/1/46/6/#/58/1/6     /8                          12        {4}       4
+/8                          /10/#/56/1/50/10/#/58/1/10  2         {5}       5
+/10/#/56/1/50/10/#/58/1/10  /12/#/55/1/52               13        {1}       1
+/12/#/55/1/52               /14/#/56/1/54/14/#/58/1/14  7         {2}       2
+/14/#/56/1/54/14/#/58/1/14  /16                         14        {3}       3
+/16                         /18/#/56/1/58/18/#/58/1/18  3         {4}       4
+/18/#/56/1/58/18/#/58/1/18  /20/#/55/1/60               15        {5}       5
+/20/#/55/1/60               /22/#/56/1/62/22/#/58/1/22  8         {1}       1
+/22/#/56/1/62/22/#/58/1/22  /24                         16        {2}       2
+/24                         /26/#/56/1/66/26/#/58/1/26  4         {3}       3
+/26/#/56/1/66/26/#/58/1/26  /28/#/55/1/68               17        {4}       4
+/28/#/55/1/68               /30/#/56/1/70/30/#/58/1/30  9         {5}       5
+/30/#/56/1/70/30/#/58/1/30  /32                         18        {1}       1
+/32                         /34/#/56/1/74/34/#/58/1/34  5         {2}       2
+/34/#/56/1/74/34/#/58/1/34  /36/#/55/1/76               19        {3}       3
+/36/#/55/1/76               /38/#/56/1/78/38/#/58/1/38  10        {4}       4
+/38/#/56/1/78/38/#/58/1/38  NULL                        20        {5}       5
+
+query TTITI colnames
+SHOW TESTING_RANGES FROM TABLE child1
+----
+Start Key                   End Key                     Range ID  Replicas  Lease Holder
+NULL                        /2/#/56/1/42/2/#/58/1/2     1         {1}       1
+/2/#/56/1/42/2/#/58/1/2     /4/#/55/1/44                11        {2}       2
+/4/#/55/1/44                /6/#/56/1/46/6/#/58/1/6     6         {3}       3
+/6/#/56/1/46/6/#/58/1/6     /8                          12        {4}       4
+/8                          /10/#/56/1/50/10/#/58/1/10  2         {5}       5
+/10/#/56/1/50/10/#/58/1/10  /12/#/55/1/52               13        {1}       1
+/12/#/55/1/52               /14/#/56/1/54/14/#/58/1/14  7         {2}       2
+/14/#/56/1/54/14/#/58/1/14  /16                         14        {3}       3
+/16                         /18/#/56/1/58/18/#/58/1/18  3         {4}       4
+/18/#/56/1/58/18/#/58/1/18  /20/#/55/1/60               15        {5}       5
+/20/#/55/1/60               /22/#/56/1/62/22/#/58/1/22  8         {1}       1
+/22/#/56/1/62/22/#/58/1/22  /24                         16        {2}       2
+/24                         /26/#/56/1/66/26/#/58/1/26  4         {3}       3
+/26/#/56/1/66/26/#/58/1/26  /28/#/55/1/68               17        {4}       4
+/28/#/55/1/68               /30/#/56/1/70/30/#/58/1/30  9         {5}       5
+/30/#/56/1/70/30/#/58/1/30  /32                         18        {1}       1
+/32                         /34/#/56/1/74/34/#/58/1/34  5         {2}       2
+/34/#/56/1/74/34/#/58/1/34  /36/#/55/1/76               19        {3}       3
+/36/#/55/1/76               /38/#/56/1/78/38/#/58/1/38  10        {4}       4
+/38/#/56/1/78/38/#/58/1/38  NULL                        20        {5}       5
+
+query TTITI colnames
+SHOW TESTING_RANGES FROM TABLE grandchild1
+----
+Start Key                   End Key                     Range ID  Replicas  Lease Holder
+NULL                        /2/#/56/1/42/2/#/58/1/2     1         {1}       1
+/2/#/56/1/42/2/#/58/1/2     /4/#/55/1/44                11        {2}       2
+/4/#/55/1/44                /6/#/56/1/46/6/#/58/1/6     6         {3}       3
+/6/#/56/1/46/6/#/58/1/6     /8                          12        {4}       4
+/8                          /10/#/56/1/50/10/#/58/1/10  2         {5}       5
+/10/#/56/1/50/10/#/58/1/10  /12/#/55/1/52               13        {1}       1
+/12/#/55/1/52               /14/#/56/1/54/14/#/58/1/14  7         {2}       2
+/14/#/56/1/54/14/#/58/1/14  /16                         14        {3}       3
+/16                         /18/#/56/1/58/18/#/58/1/18  3         {4}       4
+/18/#/56/1/58/18/#/58/1/18  /20/#/55/1/60               15        {5}       5
+/20/#/55/1/60               /22/#/56/1/62/22/#/58/1/22  8         {1}       1
+/22/#/56/1/62/22/#/58/1/22  /24                         16        {2}       2
+/24                         /26/#/56/1/66/26/#/58/1/26  4         {3}       3
+/26/#/56/1/66/26/#/58/1/26  /28/#/55/1/68               17        {4}       4
+/28/#/55/1/68               /30/#/56/1/70/30/#/58/1/30  9         {5}       5
+/30/#/56/1/70/30/#/58/1/30  /32                         18        {1}       1
+/32                         /34/#/56/1/74/34/#/58/1/34  5         {2}       2
+/34/#/56/1/74/34/#/58/1/34  /36/#/55/1/76               19        {3}       3
+/36/#/55/1/76               /38/#/56/1/78/38/#/58/1/38  10        {4}       4
+/38/#/56/1/78/38/#/58/1/38  NULL                        20        {5}       5
+
+statement ok
+SET CLUSTER SETTING sql.distsql.interleaved_joins.enabled = true;
+
+#####################
+# Interleaved joins #
+#####################
+
+# Select over two ranges for parent/child with split at children key.
+query T
+SELECT "URL" FROM [EXPLAIN (DISTSQL) SELECT * FROM parent1 JOIN child1 USING(pid1) WHERE pid1 >= 3 AND pid1 <= 5]
+----
+https://cockroachdb.github.io/distsqlplan/decode.html?eJzMkkFr6zAQhO_vVzzm9B7dEstpL4aCryklKbkWH4S1SQSOZFZyaSn570VWoU5oQ9tTb5ZmZscf2hc4b3ip9xxQPUCBUIIwR0PoxbccgpckZePCPKEqCNb1Q8zX0caOUWFwXgwLGxAMR227pDeHhtB6YVTv1qW_9P2sPDES_BDfxjaEEPWWUZUHmlSrSfUHgxcusnSsH3nN2rDceutYZsVRE-54E5Hw7F7Lc91rYRcT-dpud1Ol3dnOJCHPAaHjTfxXq4v_N5K84ycIqyFWf2tFdUn1FdXX-IxGHdGUP6JRv5SmOE-z5tB7F_hLr16ktWGz5bxjwQ_S8r34dqzJx9WYGy8Mh5jVeT4sXJbSD07D6my4OAqr03D5rXBz-PMaAAD__y7yGHk=
+
+# Swap parent1 and child1 tables.
+query T
+SELECT "URL" FROM [EXPLAIN (DISTSQL) SELECT * FROM child1 JOIN parent1 USING(pid1) WHERE pid1 >= 3 AND pid1 <= 5]
+----
+https://cockroachdb.github.io/distsqlplan/decode.html?eJzMklFL-zAUxd__n-LPeVK8sqbDl4LQ14lsslfpQ2jutkCXlJtUFNl3lzSC3dChPvnW5JxzT3_kvsJ5w0u954DqEQqEEoQ5GkIvvuUQvCQpGxfmGVVBsK4fYr6ONnaMCoPzYljYgGA4atslvTk0hNYLo_qwLv2172fliZHgh_g-tiGEqLeMqjzQpFpNqj8ZvHCRpWP9xGvWhuXOW8cyK46acM-biIRn91pe6nZnO5PA13a7mwq9FnYxKXkOCB1v4kWtri5vJZnHTxBWQ6z-14rqkuo51Tf4ikYd0ZS_olF_lKY4T7Pm0HsX-FuvXqS1YbPlvGPBD9Lyg_h2rMnH1ZgbLwyHmNV5PixcltIPTsPqbLg4CqvTcPmjcHP49xYAAP__IiwYdw==
+
+# Select over two ranges for parent/child with split at grandchild key.
+# Also, rows with pid1 <= 30 should have 4 rows whereas pid1 > 30 should
+# have 3 rows.
+query T
+SELECT "URL" FROM [EXPLAIN (DISTSQL) SELECT * FROM parent1 JOIN child1 ON parent1.pid1 = child1.pid1 WHERE parent1.pid1 >= 29 AND parent1.pid1 <= 31 ORDER BY parent1.pid1]
+----
+https://cockroachdb.github.io/distsqlplan/decode.html?eJzUUcFq6zAQvL-veOypJSqxnOZiKOiaUpKSa_FBWBtH4EhmtS4twf9eJB0Sl6S0vfVm7czs7IyP4LzBtT5ggOoFJAhYQi2gJ99gCJ7iOJNW5g2qQoB1_cBxXAtoPCFUR2DLHUIFK8dIHepX3KI2SI_eOqR5XGuQte2SyxPuGKKHPWh6V70mdBw5W9vuz5FmbzsTgbwHBHS44xslZ7cPFLnpEwRsBq7-KylUKdRCqHuhllCPAvzAp2MD6xahkqO4EuiUw5NBQjM9W8kZ1OOF1Gt_5_t5OWFfcy8n7vJXdRZ_o84LgbYYeu8CfquqInaNpsX8b4IfqMFn8k2yyc9N0qWBwcAZlfmxcglKB56L5ZfixURcfBaXP3Kux38fAQAA__8x_hkU
+
+# Parent-child where pid1 <= 15 have one joined row and pid1 > 15 have no
+# joined rows (since child2 only has 15 rows up to pid1 = 15).
+# Note this spans all 5 nodes, which makes sense since we want to read all
+# parent rows even if child rows are non-existent (so we can support OUTER
+# joins).
+# TODO(richardwu): we can remove nodes reading from just one table for INNER
+# joins or LEFT/RIGHT joins.
+query T
+SELECT "URL" FROM [EXPLAIN (DISTSQL) SELECT * FROM parent1 JOIN child2 USING(pid1) WHERE pid1 >= 12 ORDER BY pid1]
+----
+https://cockroachdb.github.io/distsqlplan/decode.html?eJzMlD1rwzAQhvf-ivJOLbkSyx8ZDAWtKSUpWYsHY10Sg2MZSS4twf-92B4Sl6YfzuLN0t3j9x6BdESpFa_SA1vErxAg-CAEIIQgREgIldEZW6tN29IDS_WO2CPkZVW7djshZNow4iNc7gpGjGXp2BScvvGGU8XmSeclm7kHgmKX5kWX-MxbhzYjP6TmQ1ap4dK1Y2zy3f68ku3zQrWz9f8BoeCtu5Nidv9o2t7uE4R17eJbKUj6JEOSEckFkoaga3ca1rp0x4hFQxeETh7aKDashmNLMUPSfGO90g-6mkeD7kvp_iBdjDpOMd3j9EcJ-dMVCkYJBdMVCkcJhdMV-uVJ2rCtdGn5T7fTa683qx33z4HVtcn4xeisi-mX647rNhRb11dFv1iWXakb8BwWP8KLAex9hf1rkoNr4PAaOPoXnDQ3nwEAAP__9wcgdA==
+
+# These rows are all on the same node 1 (gateway).
+query T
+SELECT "URL" FROM [EXPLAIN (DISTSQL) SELECT * FROM parent1 JOIN child2 USING(pid1) WHERE pid1 IN (1, 11, 21, 31) ORDER BY pid1]
+----
+https://cockroachdb.github.io/distsqlplan/decode.html?eJyMUE1LxDAUvPsrZE6KD9ws6iEg5LoirvQqPYTmbTfQTcrLqyhL_7u0OagHwVvmIzOZnJFy4Bd_4gL7BoOWMEruuJQsC1UNu_ABuyHENE660C2hy8KwZ2jUgWGxS8oysH_nhn1gecoxsdxuQAisPg5rwzMfFEtHPHn5dKMXTmpAaGJ__Kl0xziELQg1B4SBD3rlzM31oyze9QjCflJ76Qy5Lbk7cvfkHtDOhDzp92OL-p5hzUz_H9RwGXMq_GvAX8mbuSVw6Ll-WsmTdPwquVtrKtyv91YicNGqmgp2qUpzO198BQAA___Vk4P-
+
+# Parent-grandchild.
+query T
+SELECT "URL" FROM [EXPLAIN (DISTSQL)
+  SELECT * FROM parent1 JOIN grandchild2 USING(pid1) WHERE
+    pid1 >= 11 AND pid1 <= 13
+    OR pid1 >= 19 AND pid1 <= 21
+    OR pid1 >= 31 AND pid1 <= 33
+]
+----
+https://cockroachdb.github.io/distsqlplan/decode.html?eJzslE9r3DAQxe_9FGJOu3RKLDlpqWBBhVJwKd5iemt9ENbEETiSkeTSEvzdi-0u8Yb0Xwohh71ZevPjDX6juQHnDZX6miLIz8ABQQDCBdQIffANxejDJC2FhfkGMkOwrh_SdF0jND4QyBtINnUEEgqXKHSkv1JF2lB4762jcJYBgqGkbTc7faDLBJOHvdbhu-p1IJcm-0lg72yXKEi22SjOvgxZljc7xnMpZVF-2rJ9tVJox_jrg_KmfMvWjOA_le1CraD8IAFCZdurdTtt0M40V7Yz4qA-ek_LfwOEji7TRvHn212YGpk_AWE_JMkURyVQnaO6QPUS1SuoRwQ_pNt8YtItgeQj_iLD2-gG54OhQOYoq3q8J-XSv_D9WX6n8H5rcWTNHzQ-_DQ-T2h8xIMyFKcMn1CGf1jjFcXeu0h_9cKzaUWQaWnZJ9EPoaGPwTezzXLcz9x8YSimReXLoXCzNDe4hvlv4fMjOLsLi_9xzv8JrsdnPwIAAP__gf0kvQ==
+
+query T
+SELECT "URL" FROM [EXPLAIN (DISTSQL)
+  SELECT * FROM grandchild2 JOIN parent1 USING(pid1) WHERE
+    pid1 >= 11 AND pid1 <= 13
+    OR pid1 >= 19 AND pid1 <= 21
+    OR pid1 >= 31 AND pid1 <= 33
+]
+----
+https://cockroachdb.github.io/distsqlplan/decode.html?eJzslE-L2zAQxe_9FGJOCZ2ylr1LqSCgQim4FKeY3lofhDXrFXglI8mlZfF3L7Yb4oT0Xwolh9wsvfnxBr_RPIF1mgr1SAHEJ-CAkALCHVQInXc1heD8KM2Fuf4KIkEwtuvjeF0h1M4TiCeIJrYEAnIbybekvlBJSpN_54wlf5MAgqaoTDs5vaf7CKOHeVT-m2y8srp-MK0e7UeRvTVtJC_YaiU5-9wnSVZvGM-EEHnxcc225UKhDeOvdsrr4g1bMin_oaxnagFlOwkQStM8LFvqlCcb-U757_3M_w0QWrqPK8mfrzd-bGT6BIRtHwWTHGWKMkN5i_IO5UuoBgTXx30-IaqGQPABf5LhPrreOq_Jkz7IqhpOpFy4F667yY4KT1unB9b8rPHh1_G5oPFJz8owvWZ4QRn-Zo2XFDpnA_3RC0_GFUG6oXmfBNf7mj54V08283E7cdOFphBnlc-H3E7S1OAS5r-Ebw_g5BhO_8U5-yu4Gp59DwAA__8zXSS0
+
+query TTT
+EXPLAIN SELECT * FROM grandchild2 JOIN parent1 USING(pid1) WHERE
+  pid1 >= 11 AND pid1 <= 13
+  OR pid1 >= 19 AND pid1 <= 21
+  OR pid1 >= 31 AND pid1 <= 33
+----
+render          ·               ·
+ └── join       ·               ·
+      │         type            inner
+      │         equality        (pid1) = (pid1)
+      │         mergeJoinOrder  +"(pid1=pid1)"
+      ├── scan  ·               ·
+      │         table           grandchild2@primary
+      │         spans           /11/#/56/1-/13/#/56/2 /19/#/56/1-/21/#/56/2 /31/#/56/1-/33/#/56/2
+      └── scan  ·               ·
+·               table           parent1@primary
+·               spans           /11-/13/# /19-/21/# /31-/33/#
+
+# Join on multiple interleaved columns with an overarching ancestor (parent1).
+# Note there are 5 nodes because the filter cid2 >= 12 AND cid2 <= 14
+# creates a giant parent span which requires reading from all rows.
+query T
+SELECT "URL" FROM [EXPLAIN (DISTSQL)
+  SELECT * FROM child2 JOIN grandchild2 ON
+    child2.pid1=grandchild2.pid1
+    AND child2.cid2=grandchild2.cid2
+    AND child2.cid3=grandchild2.cid3
+  WHERE
+    child2.pid1 >= 5 AND child2.pid1 <= 7
+    OR child2.cid2 >= 12 AND child2.cid2 <= 14
+    OR gcid2 >= 49 AND gcid2 <= 51
+]
+----
+https://cockroachdb.github.io/distsqlplan/decode.html?eJzslUFr2zAUx-_7FOKdHPJGLVluV0FAgzHIGMkIu20-GOs1NbhWkOSxUfLdh-3FrUs21gRy8tH668df8k_wHqG2hlb5A3lQ34ADggCEBBAkIKSQIeycLch769otPbA0P0HFCGW9a0K7nCEU1hGoRwhlqAgULOtArqL8B20oN-Q-2bImdxUDgqGQl1XX-JnuArQd5UPufunivqxMe4JNub1_HmxdXptxyj6WVSCnWBRFmrPvTRwntGCpUmq5-jpj71cf2BAUC3bzJ5ix9YZFkRYDwsWYEQPD5QE6UHKg5O2YkgOV8gMFCP29AaGiuxBpPkct5qiT-Wzh2muMlgBh3QTFNEctUCeoJeoU9TXqG9TvUN9CtkewTXj68T7kWwLF9_gXOU9Omto6Q47MSEK2P6JvZd_a3VX6YuPxajGq5ie9Cz69i0u8C3GSHDHJuYSc5CQ5ySTnEnLkSXLkJOfS4-6InA35na09_dc0i9txSGZL_ez0tnEFfXG26Gr6z3XHdQuGfOhT3n8s6y7qDvgc5v-Er0dw_BIW5zQn58DyHDh9FZzt3_wOAAD__-mfE2o=
+
+query TTT
+EXPLAIN
+  SELECT * FROM child2 JOIN grandchild2 ON
+    child2.pid1=grandchild2.pid1
+    AND child2.cid2=grandchild2.cid2
+    AND child2.cid3=grandchild2.cid3
+  WHERE
+    child2.pid1 >= 5 AND child2.pid1 <= 7
+    OR child2.cid2 >= 12 AND child2.cid2 <= 14
+    OR gcid2 >= 49 AND gcid2 <= 51
+----
+join       ·               ·
+ │         type            inner
+ │         equality        (pid1, cid2, cid3) = (pid1, cid2, cid3)
+ │         mergeJoinOrder  +"(pid1=pid1)",+"(cid2=cid2)",+"(cid3=cid3)"
+ ├── scan  ·               ·
+ │         table           child2@primary
+ │         spans           ALL
+ └── scan  ·               ·
+·          table           grandchild2@primary
+·          spans           ALL
+
+# Aggregation over parent and child keys.
+query T
+SELECT "URL" FROM [EXPLAIN (DISTSQL)
+  SELECT SUM(parent1.pid1), SUM(child1.cid1) FROM parent1 JOIN child1 USING(pid1) WHERE
+    pid1 >= 10 AND pid1 <= 39
+]
+----
+https://cockroachdb.github.io/distsqlplan/decode.html?eJzUlVGrmzAUx9_3KS7n6V4WuEZtbysM3GPHto6OPQ0fgjm1gk0kiWOj-N1HlLVa2jisL74lOefv75z_CeYEQnL8yo6oIfoJFAj4QCAAAiEQWEBCoFQyRa2lsimtYMN_Q-QRyEVZGXucEEilQohOYHJTIESwEQZVgewX7pBxVJ9kLlC9WgRHw_KiIX7GvQHLyI9M_YlLplAYm2MDT9vKRE-x3e7y7NBNTA95wc-Bf4kkttW3JCBQ4N48x_T9ywdls5olEDgnB5DUBGRlLl1owzKEiNbk_zv9mGUKM2akel32u_v-48tzTC2zWfkvd4H-XeCFUwmpOCrkPUhSu0ui3tiagl5NdNS4_RmOe6DTjrdv04zbH2VtMENrBzrtWLuaxtpglLXhDK0d6LRj7Xoaa8NR1noztHag0461i-n__zeAO9SlFBqv3oHbX_bs-4A8w_Yx0bJSKX5TMm0w7Xbb6JoDjtq0UdpuNqIN2QK7YuoU-z0xvRb7bvIAOnCqQ7c4fKTuhVO8dJOXj5DfnOKVm7x6hLx2z8obuCbuS3bNTup3fwMAAP__hy1jzg==
+
+###############
+# Outer joins #
+###############
+
+# The schema/values for each table are as follows:
+# Table:        pkey:                     pkey values (same):   values:
+# outer_p1      (pid1)                    {1, 2, 3, ... 20}     100 + pkey
+# outer_c1      (pid1, cid1, cid2)        {2, 4, 6, ... 28}     200 + pkey
+# outer_gc1     (pid1, cid1, cid2, gcid1) {4, 8, 12, ... 36}    300 + pkey
+
+# Split between 4 nodes based on pkey value (p):
+# node 1:       p - 1 mod 20 ∈ [1...5)
+# node 2:       p - 1 mod 20 ∈ [5...10)
+# node 3:       p - 1 mod 20 ∈ [10...15)
+# node 4:       p - 1 mod 20 ∈ [15...20)
+
+statement ok
+CREATE TABLE outer_p1 (
+  pid1 INT PRIMARY KEY,
+  pa1 INT
+)
+
+statement ok
+CREATE TABLE outer_c1 (
+  pid1 INT,
+  cid1 INT,
+  cid2 INT,
+  ca1 INT,
+  PRIMARY KEY (pid1, cid1, cid2)
+) INTERLEAVE IN PARENT outer_p1 (pid1)
+
+statement ok
+CREATE TABLE outer_gc1 (
+  pid1 INT,
+  cid1 INT,
+  cid2 INT,
+  gcid1 INT,
+  gca1 INT,
+  PRIMARY KEY (pid1, cid1, cid2, gcid1)
+) INTERLEAVE IN PARENT outer_c1 (pid1, cid1, cid2)
+
+statement ok
+ALTER TABLE outer_p1 SPLIT AT
+  SELECT i FROM generate_series(0, 40, 5) AS g(i)
+
+statement ok
+ALTER TABLE outer_p1 TESTING_RELOCATE
+  SELECT ARRAY[(((i-3)/5)%4)::INT + 1], i FROM generate_series(3, 40, 5) AS g(i)
+
+query TTITI colnames
+SHOW TESTING_RANGES FROM TABLE outer_p1
+----
+Start Key  End Key  Range ID  Replicas  Lease Holder
+NULL       /0       20        {5}       5
+/0         /5       31        {1}       1
+/5         /10      32        {2}       2
+/10        /15      33        {3}       3
+/15        /20      34        {4}       4
+/20        /25      35        {1}       1
+/25        /30      36        {2}       2
+/30        /35      37        {3}       3
+/35        /40      38        {4}       4
+/40        NULL     39        {5}       5
+
+### Begin OUTER queries
+
+query T
+SELECT "URL" FROM [EXPLAIN (DISTSQL) SELECT * FROM outer_p1 FULL OUTER JOIN outer_c1 USING (pid1)]
+----
+https://cockroachdb.github.io/distsqlplan/decode.html?eJzclE2L2zAQhu_9FWJOu3TK-nMPhoIuDTgYp5jkVEwx1iQ1OJKR5NIQ_N-L7EOaNP1Y5-abpdEzr585zBmkEpRXRzKQfAEfEAJACAEhAoQYSoROq5qMUdo9mYBU_IDEQ2hk11t3XSLUShMkZ7CNbQkSSKUl3VL1nQqqBOm1aiTpFxchyFZNOyZmtLfgMppjpU9c9Zb01849KprDt99LtStNrQBhe-ooYatdlrHNbvupYOtNmgNCS3v7xP33zx-16zJ-upYkBemEpat8l2VP3EcePiPjATIeIeMxMv4K5YCgensxM7Y6ECT-gH-wv0j3UmlBmsSVZTncmU-uPqjuJb55eD86uIr2Zw0-WMjgg1n24ULsw1n20ULso1n23kLs_7FwCzKdkob-a6N4biWRONC0v4zqdU2ftarHmOm4GbnxQpCxU9WfDqkcS-MP_gr7f4Vfr2DvFg4eSQ4fgaNH4PhNcDm8-xkAAP__5oReVw==
+
+query T
+SELECT "URL" FROM [EXPLAIN (DISTSQL) SELECT * FROM outer_gc1 FULL OUTER JOIN outer_c1 USING (pid1, cid1, cid2)]
+----
+https://cockroachdb.github.io/distsqlplan/decode.html?eJzklU2LnEAQhu_5FVKnHabC-rlJhEBfsuAiTpCdU5Agdq0R3G7pbkOWwf8eWiEzTiYf6xw9Vlc9_crTUB5ASE5Z-Uwa4i_gAYIPCAEghIAQQYHQKVmR1lLZkQlI-A-IXYRGdL2xxwVCJRVBfADTmJYghkQYUi2V3ymnkpN6kI0gdWsjOJmyacfElJ4M2IzmuVQvTPaG1Ne6slN5U3_7vTe2prsA4fGlo9i536eps9s_fsqdh12SAUJLT-aGeVtk_hZZsN18VPa22ZGNIMFJxU5yn-3T9IZ5yO42-Kv0kb07KQNk7zfosBAdFqHDPkAxIMjeHCVoU9YEsTfgH0Qd_fRCKk6K-ExIMVxQmcm3sruNzgYvR_uzaG_RG_nreyN_kahgfaKCRaLC9YkKF4ly1yfqH_-RnHQnhab_2n6uXZ_Ea5p2rZa9quizktUYM5W7kRsPOGkzdb2pSMTYGj_wFPb-Ct_NYPcc9q9JDq6Bw2vg6FVwMbz5GQAA__8alY8h
+
+query T
+SELECT "URL" FROM [EXPLAIN (DISTSQL) SELECT * FROM outer_c1 LEFT OUTER JOIN outer_p1 USING (pid1) WHERE pid1 >= 0 AND pid1 < 40]
+----
+https://cockroachdb.github.io/distsqlplan/decode.html?eJzUlE-Lo0AQxe_7KeSddtlaYqu7B2HBSwYMIQ6SOQ0yiF3JCMaW7naYEPzug3rIJJP5l5xys_v1q1e_gnKHWkle5Bs2CO8hQPBA8EEIkBEarQo2RuleHh_H8hmhSyjrprX9dUYolGaEO9jSVowQcW1ZV5w_ccq5ZD1TZc164oIg2eZlNaTNeWXRZ5SbXG8j1VrWD0XfQ1quH99KTS-NpUBYbhsOnfn0Zukkd8tp6sySeAFCxSv7MxK_f_3XfZXhE4SktaETCYo8inyKAor-IesIqrV7DmPzNSMUHb3Dukdsa6Ula5YHTFl3YhoL9Uc1k-Do4elo7yBanDVmcZVj9s5i9a6S1T-L1b9K1k9-FSmbRtWGv7Qdbr9eLNc87qJRrS74VqtiiBmPyeAbLiQbO6piPMT1IA0NvjaLD81_D8zusdm7JNm_xBx8y5x1P14CAAD___ca6HA=
+
+query T
+SELECT "URL" FROM [EXPLAIN (DISTSQL) SELECT * FROM outer_p1 RIGHT OUTER JOIN outer_gc1 USING (pid1) WHERE pid1 >= 1 AND pid1 <= 20]
+----
+https://cockroachdb.github.io/distsqlplan/decode.html?eJzUlE9r20AQxe_9FOKdWjrF-ucWBIW9lFamWEW4pyCC0I4VgawVu6sQY_Tdg6SDY8f5Z5980-7bN29-A6MdGiV5mW_YILqBB4IPQgBCiIzQalWwMUoP8vQ4lg-IXELVtJ0drjNCoTQj2sFWtmZEiBvLuub8nlPOJeuFqhrWMxcEyTav6jHtL68thoxqk-utUJ1lfdsOPaRVefdcKotBm2qBsNq2HDlp_PvPykn-r36lziKJlyDUvLafhff1y0891Bk_QUg6GzkiIOGTCEnMSXwn8QNZT1Cd3cMYm5eMyOvpBeA9Z9coLVmzPADL-hMjWapvqp2FRw9PR_sH0d5Zs_aud9b-WcD-9QIHZwEH1wv8xu8jZdOqxvC7lsUdto1lydNqGtXpgv9pVYwx0zEZfeOFZGMn1ZsOcTNKY4NPzd6r5vmB2T02-5ckB5eYww-Zs_7TYwAAAP__Vjbt9A==
+
+########################
+# Non-interleaved joins #
+########################
+
+# Join on siblings uses merge joiner.
+# TODO(richardwu): Update this once sibling joins are implemented.
+query T
+SELECT "URL" FROM [EXPLAIN (DISTSQL) SELECT * FROM child1 JOIN child2 USING(pid1)]
+----
+https://cockroachdb.github.io/distsqlplan/decode.html?eJzElsFq20AQhu99ijCnlmyxdyXZsaCgawpNSuit-KBYU1vgaM1Kgobgdy-yCq5ldUabwfLNsvbbnZ35QP8bFDbDh_QFS4h_ggYFBhQEoCAEBREsFeycXWFZWtcsaYH77DfEUwV5saur5u-lgpV1CPEbVHm1RYjhR_q8xSdMM3STKSjIsErz7eGYnctfUvearDb5NtOw3CuwdfV3q-MOz683m7TcnLJJs36poKzSNUKs9-p9JUVESUZUkvlvScd9rMvQYdbd57Y5eNCqntt9Q7fGrzYv0E10p-Nb_FV9TPTtpy8uX2_an6Dgsa7im0SrxKgkUEmkkplK5p3bH28WDLhZXfRV3Vvwg_1sdxMddVb2nx2enK2HD1qP5J5HSbOR3NPXcU9f3j0zvNlmpPl7lDQfaf7mOvM3l59_MLzZwUjz9yjpbqT5B9eZf3D5-YfDmx2ONH-PkhYjzT-8zvzDcbNHTzlPWO5sUeKgZDFtLoTZGts2lbZ2K_zu7OpwTPv4eOAOX9QMy6p9a9qH-6J91RQ4HJ5J4IUE1qK6dUTT2qNlxg-eSeCFBNaiujstO6NNl57-Swd0vwMS1qc9m3bpUCI4DTOC0zAjOA1zgjM0I3gkEZyGGcFpmBGchjnBGZoRfCYRfC5RlIYZRWmYUZSGOUUZmlH0TqIoDTOK0jCjKA1zijI0o-hCoqgW5QSGZiRlaMZShuY05XAuK8jCgiwtyOKCMC_IAoMWJQZ9Fhm8bKVpzlaa5myladZWBuds9QlL5zPzSUu-NGerV17yxjlbz8IDaety_-FPAAAA__-7ahyi
+
+# Join on non-interleaved tables (with key) uses merge joiner.
+query T
+SELECT "URL" FROM [EXPLAIN (DISTSQL) SELECT * FROM parent1 JOIN parent2 ON pid1=pid2]
+----
+https://cockroachdb.github.io/distsqlplan/decode.html?eJy8lVFr2zAQx9_3Kco9bVQjluykqWHg1w7WjrK34Qc1uiWG1DKSDCsl333YLmQxic5GRG9xrJ_u_r8D3zvUWuGjfEUL-W_gwEAAgxQYZMBgCSWDxugNWqtNd2QAHtRfyBMGVd20rvu7ZLDRBiF_B1e5PUIOv-TLHp9RKjSLBBgodLLa92UaU71K81Y00mDtOJQHBrp1H3cdr3h5u9lJuzuFi-58ycA6uUXI-YFd6Ol4jzYKDarxPbdd4eOptj53rq81zvYDzRa_66pGs1idXrvHP-5zwW-_fDPVdjf8BAZPrctvCs4KwYqUFdko8zFPOiHPjE4f9VfdLDgfnTxfOzupzafPl8eaL48_37trzldMdyxiORbxHa-v6Tid7jiN5TiN7_j-mo6z6Y6zWI5n9LT09SSCehIXe4o0d57EWlBnGnlG2-ja4qT1k3RRUG1xsGN1azb40-hNX2Z4fOq5fhEotG54-_HwUA-vuganw1kIvAqB1yEwJ0LzMZ38Tws_LLwwP6WTMZ2GDMsPE8Pyw8Sw_DAxLCIzEToLGdYyRLcfJnT7YUK3HyZ0E5mJ0KsQ3Xchuv0wodsPE7r9MKGbyEyEXofovg_R7YcJ3X6Y0O2HCd1EZurLP2dZipl0FkSvguh1EM2p4PM2Znn49C8AAP__9ASy7Q==
+
+# Join on non-interleaved column uses hash joiner.
+query T
+SELECT "URL" FROM [EXPLAIN (DISTSQL) SELECT * FROM parent1 JOIN child1 ON pa1 = ca1]
+----
+https://cockroachdb.github.io/distsqlplan/decode.html?eJy8llFr2zwUhu-_X1HOVQv6SCTZaWMY-HLdRTvK7oYv3PgsMaSWkRVYKfnvI_Egi-PpWDtEl2nySK_OeaDvBzSmwqfyDTvIvoMEAQoEaBCQgIAUCgGtNSvsOmMPP-mBx-onZHMBddPu3OHPhYCVsQjZB7jabREy-Fa-bvEFywrtbA4CKnRlvT1e09r6rbTveVtabJyEYi_A7Nzvs05HvL7fbMpucw7nCop9IaBz5Rohk3vxb5nS8UyrTb2tQiPps0jqr5FO5-waYyu0WJ2dVBxI6icj7_pcdpsvpm7QzuRg1lv84W5zdffJ1uuNu831HQh43rnsJpciVyLXIk9Eng5efHqNZrxmJOqT-d-0M5kO3z16d3J2t5y-XBlLuIBMi0jCycjCyasKp6YPWMVaekCm-0hLV5GXrq66dD19wDrW0gMyPURauo68dH3VpSfTB5zEWnpApmWkpSeRl55E6xMjQV6wa03T4aS2MD88Bas19qPpzM6u8Ks1q-M1_cfnI3f8J1lh5_pvVf_hsem_OgScDi848JIDS1ZumfppGTAyFQYvOPCSA0tW7sHILmg1pOd_0to_b-2F5fnM5kM64QjuhwnB_TAhuB-mBCdoQvCUI7gfJgT3w4TgfpgSnKAJwRccwe85ivphQlE_TCjqhylFCZpQ9IGjqB8mFPXDhKJ-mFKUoAlFlxxFJasnEDQhKUETlhI0pSmFU12BVxZ4bYFXF5h9gVcYJKsxyIvKEGSrn6Zs9dOUrX6atJXAKVtDytLlzkLaUihN2RrUl4JxytaL8uC1tdj_9ysAAP__U3kYdA==
+
+# Prefix join on interleaved columns uses merge joiner.
+query T
+SELECT "URL" FROM [EXPLAIN (DISTSQL) SELECT * FROM child2 JOIN grandchild2 USING(pid1, cid2)]
+----
+https://cockroachdb.github.io/distsqlplan/decode.html?eJzEll1r2zAUhu_3K8q52qhGItn5Mgx828HaUXY3cuFGZ47BtYxsw0rJfx-2C1kcT8eainzp2I_06uiBvK9QKIn3yTNWEP0EDgwEMAiAQQgMVrBnUGp1wKpSuv2kB-7kb4iWDLKibOr25z2Dg9II0SvUWZ0jRPAjecrxEROJerEEBhLrJMu7bUqdPSf6JT4cs1wK2J8YqKZ-W-q8wtPLzTGpjpdszFncInsGVZ2kCBE_sf9LtRpPleqkkO8TTfwz2nkppSVqlMOlblksbtv9J385ctpvqFP8qrIC9YIPLiHHX_XHN_rTF52lx_MjMHho6uimOxGLAxaHLN6weMvi3WAm58MGEw7bFGOHGM1-rz6rcsFXgy_H9w4v9ubTHeD-zLRItfZsJp_XTO7VTDH9HoQ_OyxSbTzbIea1Q3i1I5h-D4E_OyxSbT3bEcxrR-DVjnD6PYT-7LBItfNsRzivHeFsnWck2SNWpSoqnNRolu3ZUKbYT65SjT7gd60O3Tb940PHdX_fEqu6fyv6h7uif9UGnA6vXeCdC8ydcvOVmeYWIxN28NoF3rnA3Cn3YGRXtBjSy7_pwDzvwAjzy5kth3ToIrgZJgQ3w4TgZpgSnKAJwVcugpthQnAzTAhuhinBCZoQfO0i-MZFUTNMKGqGCUXNMKUoQROKbl0UNcOEomaYUNQMU4oSNKHozkVR7tQTCJqQlKAJSwma0pTCqa7gVhbc2oJbXXDsC26FgTs1Bn5VGaxsNdOUrWaastVMk7YSOGWrTVm6vjObtmRLU7Za9SVrnLL1qjwYbd2fPvwJAAD__4eyQAE=
+
+# Subset join on interleaved columns uses hash joiner.
+query T
+SELECT "URL" FROM [EXPLAIN (DISTSQL) SELECT * FROM child2 JOIN grandchild2 USING(pid1, cid3)]
+----
+https://cockroachdb.github.io/distsqlplan/decode.html?eJzElsGK2zAQhu99imVOLagkkp1sYij42O1htyy9FR-80TQxZK0gOdBlybsX2y1pHFdjdYp6VOxP-jX-IP8r1EbjffmMDrKvIEGAAgEJCEhBwAIKAQdrNuicse0rPXCnv0M2F1DVh2PT_lwI2BiLkL1CUzV7hAy-lE97fMRSo53NQYDGpqz23TEHWz2X9iXf7Kq9VlCcBJhj83Or8w5PLze70u0u2VyKPIHiVAhwTblFyORJ_F2qxXiqrS1r_W-iqT9GO291rI3VaFFfbFa0JPXKyP0-lm73yVQ12pkcTH2P35q3XcZ3H2y13f1agICHY5PddCuRK5GnIl-KfCXy9WAA55sljJuNxL43781hJhfDGYyenV6cLad_cBlPw4BUy8gaysgaymgaqulDV_FUCEh1G1kFFVkFFU2FZPrQk3gqBKRaRVYhiaxCEk2FdPrQ03gqBKRaR1YhjaxC-l96ykioR3QHUzuc1ELm7bVQb7EfkzNHu8HP1my6Y_rlQ8d1f7kaXdM_Vf3iru4ftQGnw0sOvObAkpVbLvy0DBiZCoOXHHjNgSUr92BkV7Qa0vPf6cQ_78QLy8uZzYd0yhHcDxOC-2FCcD9MCU7QhOALjuB-mBDcDxOC-2FKcIImBF9yBL_lKOqHCUX9MKGoH6YUJWhC0RVHUT9MKOqHCUX9MKUoQROKrjmKSlZPIGhCUoImLCVoSlMKp7oCryzw2gKvLjD7Aq8wSFZjkFeVIchWP03Z6qcpW_00aSuBU7aGlKXrbxbSlkJpytagvhSMU7ZelQevrcXpzY8AAAD__5b5Mtw=
+
+# Sort node in between join and child nodes produces hash joiner.
+query T
+SELECT "URL" FROM [EXPLAIN (DISTSQL) SELECT * FROM parent1 JOIN (SELECT * FROM child1 ORDER BY cid1) USING(pid1)]
+----
+https://cockroachdb.github.io/distsqlplan/decode.html?eJy8lk9vm0wQxu_vp4jm9FbdKuyC_yFV4tj0kFRpbxUHYrYxksOiBUuNonz3ClMrApx9mGK41bV_zOzsb_LwQrlJ9W3ypEsKf5IkQYoE-SQoIEELigUV1mx1WRpb_6QBbtLfFHqCsrw4VPV_x4K2xmoKX6jKqr2mkH4kD3t9r5NU22uPBKW6SrL9sUxhs6fEPkdFYnVeSYpfBZlD9fdZb494eL7aJeWuDUf172NBZZU8agrlq_i3nhbne9rusn3abemtnOKU-25spe217Bw_Uh9HHdl_t4e35xxyY1Ntddp6UlyT6CdnDvIlKXdfTZbXh-nMba9_Vf9H8sNnmz3ujv8iQXeHKryKpIiUiAIRLd4dZzDiKGf6vDWfTHGtvO6hz9ZetGrL4ebIuWxm9LS8gM2g3MlmOaXNcmabl9PZrIbfnprLKEZPqwsYBcqdjFJTGqVmNmo1nVH-8Nvz5zKK0dP6AkaBciej_CmN8mc2aj2dUcHw2wvmMorR0-YCRoFyJ6OCKY0KZjZqM8873Jku7nVZmLzUg97QvPocOn3UzVxKc7Bb_c2a7bFM8_HuyB1fHFJdVs23fvPhJm--qhscDq_HwFKNopdjaOW5admlvRbdgr0urBgDVzx4PQbuDJxLL8fQnYH3aN858MB9W4H7tqT7uhZj9sMNg_1ww2g_AA32w02j_Vg6J75yD3w1Zj_cMNgPN4z2A9BgP9w02o_1mP3YjDHcDQPD3TAyHNDAcDcNE6AXIK2JS_BHRfYShCM5oIHlgEaaIxx4DnAkuuzlCMd02csRjuqABq4DGsmOcGA7wKHu7gyVC6A7J0T7d85JUS4NdWflKBeHuruTFOnOiVIujXRnhSkbR7qz4rSPu_NUboDunETt3zknUrk01J0Vqlwc6a7cqdrVPX79708AAAD__3t4GdI=
+
+query TTT
+EXPLAIN SELECT * FROM parent1 JOIN (SELECT * FROM child1 ORDER BY cid1) USING (pid1)
+----
+render               ·         ·
+ └── join            ·         ·
+      │              type      inner
+      │              equality  (pid1) = (pid1)
+      ├── scan       ·         ·
+      │              table     parent1@primary
+      │              spans     ALL
+      └── sort       ·         ·
+           │         order     +cid1
+           └── scan  ·         ·
+·                    table     child1@primary
+·                    spans     ALL
+
+# Multi-table staggered join uses interleaved joiner on the bottom join
+# and a merge joiner.
+query T
+SELECT "URL" FROM[EXPLAIN (DISTSQL)
+  SELECT * FROM grandchild1
+  JOIN child1 USING (pid1, cid1)
+  JOIN parent1 USING (pid1)
+ORDER BY pid1
+]
+----
+https://cockroachdb.github.io/distsqlplan/decode.html?eJzcls9u2kAQh-99imhOrbIV7NpAsFTJV6o2qVBvlQ8OnoAlx4vWS9Uo4t0rYxLMn-xgRhiJo7377c7OfIffK-Q6wfv4GQsI_oAEAQoEeCDABwE9iATMjZ5gUWhTbqmAUfIPgq6ANJ8vbPk7EjDRBiF4BZvaDCGAUW7RZBj_xTHGCZrvOs3RdLogIEEbp9nqxh_4ZKG8I32OzUs4NXGeTGZplpSljNPprL76vlCdBQIyfLKfQ3krQnX75Zsp979_goCHhQ1uQilCJUJPhL4IBxAtBeiFXRe-qffx5WYWF7Pt8kIJ0TISUNh4ihDIpTi-Ab_jx2z99k5v-9i3B81jg7mVrJrUhzVtztEmQYPJ7jm35cVH7TrwvJ9oprgeqtyZ6ttYaiM5PI7e_kQ2L_N4LztQ873-qucduT2Nj673t66XJ9kur8d2ogF12_tt2S4vY7s8v-3qJN3U9ehGNKCu26At3dRldFPn1807STfvenQjGlDX7a4t3bzL6OadXzf_JN3869GNaEBdt2FbuvmX0c1vNzoeKGeMxVznBR6VCrvlgzCZYtWmQi_MBH8ZPVldU30-rLhVPEmwsNWqqj5GebVUFng83OfAQw4sWXXLnpuWDVqmmsF9DjzkwJJV907L9mi1S3frtOfut-eE5XbPuru0zxHcDROCu2FCcDdMCU7QhOA9juBumBDcDROCu2FKcIImBO9zBB9wFHXDhKJumFDUDVOKEjSh6B1HUTdMKOqGCUXdMKUoQROKDjmKSlZOIGhCUoImLCVoSlMKp7ICLyzw0gIvLjDzAi8wSFZikHuRoZGtbpqy1U1Ttrpp0lYCp2xtEpb2Z9YkLTWlKVsb5aXGOGXrXnhw2hotP_0PAAD__9pnwiY=
+
+# Multi-table join with parent1 and child1 at the bottom uses interleaved
+# joiner but induces a hash joiner on the higher join.
+query T
+SELECT "URL" FROM [EXPLAIN (DISTSQL)
+  SELECT * FROM parent1
+  JOIN child1 USING (pid1)
+  JOIN grandchild1 USING (pid1, cid1)
+]
+----
+https://cockroachdb.github.io/distsqlplan/decode.html?eJzUls-K2zAQh-99imVOLVXZSLbzx1DwsSllt4Teig_aeDYxeK0gK6XLkncvjrPEdlJNHIEgtzjSJ81ovsPvDUqV4YN8wQri38CBgQAGATAIgUEEKYONVkusKqXrLQ0wz_5CPGKQl5utqf9OGSyVRojfwOSmQIhhXhrUBco_uECZof6u8hL1_QgYZGhkXuxv_IHPBuo78hepX5ON1FiauoxFvlq3V5brvMjqheYcYFDgs_mY8M-fvup67_4nMHjcmvgu4SwRLAlZEkG6Y6C25lDpscCn17u1rNbdemowgHSXMqiMXCHEfMcub_qXfCoO_d5H3ZPfG1lpWWaHbgaXJjqlif-WdjxqWyqdocasc1hak9SWM_19k9X6MEjem-RhHCwJjgNhieiMJHifyoQl0173x7YCh7bO1PygvqjNPY_6D3D27rBzN79KcX7bihNNtxUfe1ace1ac-1FcXKWZuG3NiKbbmk08ayY8ayb8aBZcpVlw25oRTbc1m3rWLPCsWeBHs_AqzcLb1oxouq3ZzLNmoWfNQv-58ExFC6w2qqzwotQ3qnvCbIXNG1Vqq5f4U6vl_prm83HP7TNIhpVpVkXzMS-bpbrAy-GxCzxzgblT3Tyy03zAk4lh8NgFnrnA3Knu3pOd0KJPj9p0YH_vwArz7puN-nToIrgdJgS3w4TgdpgSnKAJwSMXwe0wIbgdJgS3w5TgBE0IPnYRfOKiqB0mFLXDhKJ2mFKUoAlFpy6K2mFCUTtMKGqHKUUJmlB05qIod8oJBE1IStCEpQRNaUrhVFZwCwtuacEtLjjmBbfAwJ0SAz-JDINstdOUrXaastVOk7YSOGXrkLB0OrMhaWkoTdk6KC8NxilbT8KD1dZ09-FfAAAA___T9r_v

--- a/pkg/sql/logictest/testdata/planner_test/distsql_tighten_spans
+++ b/pkg/sql/logictest/testdata/planner_test/distsql_tighten_spans
@@ -1,4 +1,4 @@
-# LogicTest: 5node-distsql 5node-distsql-metadata
+# LogicTest: 5node-distsql
 
 # This test verifies that we correctly tighten spans during index selection as
 # well as after partitioning spans in distsql.
@@ -36,58 +36,6 @@ CREATE TABLE bytes_t (a BYTES PRIMARY KEY)
 
 statement ok
 CREATE TABLE decimal_t (a DECIMAL PRIMARY KEY)
-
-#######################
-# Insert dummy values #
-#######################
-
-statement ok
-INSERT INTO p1 VALUES
-  (1,10),
-  (2,1),
-  (2,2),
-  (2,8),
-  (3,5),
-  (3,10),
-  (4,1),
-  (4,2),
-  (4,4)
-
-statement ok
-INSERT INTO c1 VALUES
-  (1,10),
-  (2,1),
-  (2,4),
-  (2,8),
-  (2,10),
-  (4,2)
-
-statement ok
-INSERT INTO p2 VALUES
-  (1, NULL),
-  (2, 2),
-  (3, 1),
-  (4, NULL),
-  (5, NULL),
-  (6, 10),
-  (7, 2),
-  (8, 3)
-
-statement ok
-INSERT INTO bytes_t VALUES
-  ('a'),
-  ('aa'),
-  ('b'),
-  ('c'),
-  ('ca')
-
-statement ok
-INSERT INTO decimal_t VALUES
-  (1),
-  (1.000001),
-  (1.5),
-  (2),
-  (2.001)
 
 ############################
 # Split ranges for distsql #
@@ -191,14 +139,6 @@ scan  ·      ·
 ·     table  p1@b
 ·     spans  -/4
 
-query II rowsort
-SELECT * FROM p1 WHERE b <= 3
-----
-2 1
-2 2
-4 1
-4 2
-
 # Partial predicate on primary key should not be tightened.
 query TTT
 EXPLAIN SELECT * FROM p1 WHERE a <= 3
@@ -206,16 +146,6 @@ EXPLAIN SELECT * FROM p1 WHERE a <= 3
 scan  ·      ·
 ·     table  p1@primary
 ·     spans  -/4
-
-query II rowsort
-SELECT * FROM p1 WHERE a <= 3
-----
-1 10
-2 1
-2 2
-2 8
-3 5
-3 10
 
 # Tighten end key if span contains full primary key.
 query TTT
@@ -232,12 +162,6 @@ scan  ·      ·
 ·     table  p1@primary
 ·     spans  -/3/3/#
 
-query II rowsort
-SELECT * FROM p1 WHERE a <= 3 AND b <= 3
-----
-2 1
-2 2
-
 # Mixed bounds.
 query TTT
 EXPLAIN SELECT * FROM p1 WHERE a >= 2 AND b <= 3
@@ -245,14 +169,6 @@ EXPLAIN SELECT * FROM p1 WHERE a >= 2 AND b <= 3
 scan  ·      ·
 ·     table  p1@primary
 ·     spans  /2-
-
-query II rowsort
-SELECT * FROM p1 WHERE a >= 2 AND b <= 3
-----
-2 1
-2 2
-4 1
-4 2
 
 # Edge cases.
 
@@ -295,15 +211,6 @@ scan  ·      ·
 ·     table  c1@primary
 ·     spans  -/4
 
-query II rowsort
-SELECT * FROM c1 WHERE a <= 3
-----
-1 10
-2 1
-2 4
-2 8
-2 10
-
 # Tighten span on fully primary key.
 query TTT
 EXPLAIN SELECT * FROM c1 WHERE a <= 3 AND b <= 3
@@ -311,11 +218,6 @@ EXPLAIN SELECT * FROM c1 WHERE a <= 3 AND b <= 3
 scan  ·      ·
 ·     table  c1@primary
 ·     spans  -/3/3/#/54/1/#
-
-query II rowsort
-SELECT * FROM c1 WHERE a <= 3 AND b <= 3
-----
-2 1
 
 # Table p2 with interleaved index.
 
@@ -329,17 +231,6 @@ scan  ·      ·
 ·     table  p2@primary
 ·     spans  /2-
 
-query II rowsort
-SELECT * FROM p2 WHERE i>= 2
-----
-2 2
-3 1
-4 NULL
-5 NULL
-6 10
-7 2
-8 3
-
 # Upper bound (i <= 5)
 
 query TTT
@@ -348,15 +239,6 @@ EXPLAIN SELECT * FROM p2 WHERE i <= 5
 scan  ·      ·
 ·     table  p2@primary
 ·     spans  -/5/#
-
-query II rowsort
-SELECT * FROM p2 WHERE i <= 5
-----
-1 NULL
-2 2
-3 1
-4 NULL
-5 NULL
 
 # From the interleaved index: no tightening at all.
 
@@ -370,14 +252,6 @@ scan  ·      ·
 ·     table  p2@p2_id
 ·     spans  /1/#/55/2/2-
 
-query II rowsort
-SELECT * FROM p2@p2_id WHERE i>= 1 AND d >= 2
-----
-2 2
-6 10
-7 2
-8 3
-
 # Upper bound (i <= 6 AND d <= 5)
 
 query TTT
@@ -386,12 +260,6 @@ EXPLAIN SELECT * FROM p2@p2_id WHERE i <= 6 AND d <= 5
 scan  ·      ·
 ·     table  p2@p2_id
 ·     spans  -/6/#/55/2/6
-
-query II rowsort
-SELECT * FROM p2@p2_id WHERE i <= 6 AND d <= 5
-----
-2 2
-3 1
 
 # IS NULL
 
@@ -402,13 +270,6 @@ scan  ·      ·
 ·     table  p2@p2_id
 ·     spans  /1/#/55/2/NULL-
 
-query II rowsort
-SELECT * FROM p2@p2_id WHERE i>= 1 AND d IS NULL
-----
-1 NULL
-4 NULL
-5 NULL
-
 # IS NOT NULL
 
 query TTT
@@ -417,15 +278,6 @@ EXPLAIN SELECT * FROM p2@p2_id WHERE i >= 1 AND d IS NOT NULL
 scan  ·      ·
 ·     table  p2@p2_id
 ·     spans  /1/#/55/2/!NULL-
-
-query II rowsort
-SELECT * FROM p2@p2_id WHERE i>= 1 AND d IS NOT NULL
-----
-2 2
-3 1
-6 10
-7 2
-8 3
 
 # String table
 
@@ -437,11 +289,6 @@ scan  ·      ·
 ·     table  bytes_t@primary
 ·     spans  /"a"-/"a"/#
 
-query T
-SELECT * FROM bytes_t WHERE a = 'a'
-----
-a
-
 # No tightening.
 
 query TTT colnames
@@ -452,11 +299,6 @@ scan  ·      ·
 ·     table  bytes_t@primary
 ·     spans  -/"aa"
 
-query T
-SELECT * FROM bytes_t WHERE a < 'aa'
-----
-a
-
 query TTT colnames
 EXPLAIN SELECT * FROM decimal_t WHERE a = 1.00
 ----
@@ -464,11 +306,6 @@ Tree  Field  Description
 scan  ·      ·
 ·     table  decimal_t@primary
 ·     spans  /1-/1/#
-
-query R
-SELECT * FROM decimal_t WHERE a = 1.00
-----
-1
 
 # No tightening.
 
@@ -479,10 +316,3 @@ Tree  Field  Description
 scan  ·      ·
 ·     table  decimal_t@primary
 ·     spans  -/2
-
-query R rowsort
-SELECT * FROM decimal_t WHERE a < 2
-----
-1
-1.000001
-1.5

--- a/pkg/sql/opt/exec/execbuilder/testdata/distsql_interleaved_join
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distsql_interleaved_join
@@ -1,0 +1,478 @@
+# LogicTest: 5node-distsql-opt
+
+# The following tables form the interleaved hierarchy:
+#   name:             primary key:                # rows:   'a' = id mod X :
+#   parent1           (pid1)                      40        8
+#     child1          (pid1, cid1)                150       66
+#       grandchild1   (pid1, cid1, gcid1)         410       201
+#     child2          (pid1, cid2, cid3)          15        7
+#       grandchild2   (pid1, cid2, cid3, gcid2)   51        13
+#   parent2           (pid2)                      5         2
+# Additional rows in child1, child2, and grandchild1 with no corresponding
+# parent row are also inserted.
+#
+# All IDs belonging to a table (pid1 --> parent1, cid1 --> child1, cid2,cid3
+# --> child2, etc.) start from 1 up to (# rows).
+# Foreign keys are modded by their ancestor's (# rows). For example, for child1
+# row with cid1=500, we take ((cid1-1) % 200 + 1) = 100 as pid1.
+# One exception is cid3, which is taken as cid2 % 15.
+# There's a column 'a' that's modded by a factor.
+#
+# This allows us to test the following edge cases (in order of tests):
+#   - one-to-many (parent1 - child1)
+#   - one-to-one and one-to-none (parent1 - child2)
+#   - parent-grandchild (parent1 - grandchild1)
+#   - multiple interleaved columns (child2 - grandchild2)
+#   - additional ancestor above (child2 - grandchild2)
+#   - no interleaved relationship (parent1 - parent2, parent2 - child1)
+#   - TODO(richardwu): sibling-sibling (child1 - child2)
+
+#################
+# Create tables #
+#################
+
+statement ok
+CREATE TABLE parent1 (pid1 INT PRIMARY KEY, pa1 INT)
+
+statement ok
+CREATE TABLE parent2 (pid2 INT PRIMARY KEY, pa2 INT)
+
+statement ok
+CREATE TABLE child1 (
+  pid1 INT,
+  cid1 INT,
+  ca1 INT,
+  PRIMARY KEY(pid1, cid1)
+)
+INTERLEAVE IN PARENT parent1 (pid1)
+
+statement ok
+CREATE TABLE child2 (
+  pid1 INT,
+  cid2 INT,
+  cid3 INT,
+  ca2 INT,
+  PRIMARY KEY(pid1, cid2, cid3)
+)
+INTERLEAVE IN PARENT parent1 (pid1)
+
+statement ok
+CREATE TABLE grandchild1 (
+  pid1 INT,
+  cid1 INT,
+  gcid1 INT,
+  gca1 INT,
+  PRIMARY KEY(pid1, cid1, gcid1)
+)
+INTERLEAVE IN PARENT child1 (pid1, cid1)
+
+# No foreign key since we are permitting the rows to overflow out of child2
+# for pid1 > 15.
+statement ok
+CREATE TABLE grandchild2 (
+  pid1 INT,
+  cid2 INT,
+  cid3 INT,
+  gcid2 INT,
+  gca2 INT,
+  PRIMARY KEY(pid1, cid2, cid3, gcid2)
+)
+INTERLEAVE IN PARENT child2 (pid1, cid2, cid3)
+
+####################
+# Split our ranges #
+####################
+
+# Split at parent1 key into five parts.
+statement ok
+ALTER TABLE parent1 SPLIT AT SELECT i FROM GENERATE_SERIES(8, 32, 8) AS g(i)
+
+# Split at child1 keys in between parent1 parts (total 10 parts).
+statement ok
+ALTER TABLE child1 SPLIT AT SELECT pid1, pid1 + 40 FROM
+GENERATE_SERIES(4, 36, 8) AS g(pid1)
+
+# Split at grandchild2 keys in between the 10 parts (total 20 parts).
+statement ok
+ALTER TABLE grandchild2 SPLIT AT SELECT pid1, pid1 + 40, pid1, pid1 FROM
+GENERATE_SERIES(2, 38, 4) AS g(pid1)
+
+# Relocate the twenty parts to the five nodes.
+statement ok
+ALTER TABLE grandchild2 TESTING_RELOCATE
+  SELECT ARRAY[((i-1)/2)::INT%5+1], i, i+20, i, i FROM GENERATE_SERIES(1, 39, 2) AS g(i)
+
+# Verify data placement.
+query TTITI colnames
+SHOW TESTING_RANGES FROM TABLE parent1
+----
+Start Key                   End Key                     Range ID  Replicas  Lease Holder
+NULL                        /2/#/56/1/42/2/#/58/1/2     1         {1}       1
+/2/#/56/1/42/2/#/58/1/2     /4/#/55/1/44                11        {2}       2
+/4/#/55/1/44                /6/#/56/1/46/6/#/58/1/6     6         {3}       3
+/6/#/56/1/46/6/#/58/1/6     /8                          12        {4}       4
+/8                          /10/#/56/1/50/10/#/58/1/10  2         {5}       5
+/10/#/56/1/50/10/#/58/1/10  /12/#/55/1/52               13        {1}       1
+/12/#/55/1/52               /14/#/56/1/54/14/#/58/1/14  7         {2}       2
+/14/#/56/1/54/14/#/58/1/14  /16                         14        {3}       3
+/16                         /18/#/56/1/58/18/#/58/1/18  3         {4}       4
+/18/#/56/1/58/18/#/58/1/18  /20/#/55/1/60               15        {5}       5
+/20/#/55/1/60               /22/#/56/1/62/22/#/58/1/22  8         {1}       1
+/22/#/56/1/62/22/#/58/1/22  /24                         16        {2}       2
+/24                         /26/#/56/1/66/26/#/58/1/26  4         {3}       3
+/26/#/56/1/66/26/#/58/1/26  /28/#/55/1/68               17        {4}       4
+/28/#/55/1/68               /30/#/56/1/70/30/#/58/1/30  9         {5}       5
+/30/#/56/1/70/30/#/58/1/30  /32                         18        {1}       1
+/32                         /34/#/56/1/74/34/#/58/1/34  5         {2}       2
+/34/#/56/1/74/34/#/58/1/34  /36/#/55/1/76               19        {3}       3
+/36/#/55/1/76               /38/#/56/1/78/38/#/58/1/38  10        {4}       4
+/38/#/56/1/78/38/#/58/1/38  NULL                        20        {5}       5
+
+query TTITI colnames
+SHOW TESTING_RANGES FROM TABLE child1
+----
+Start Key                   End Key                     Range ID  Replicas  Lease Holder
+NULL                        /2/#/56/1/42/2/#/58/1/2     1         {1}       1
+/2/#/56/1/42/2/#/58/1/2     /4/#/55/1/44                11        {2}       2
+/4/#/55/1/44                /6/#/56/1/46/6/#/58/1/6     6         {3}       3
+/6/#/56/1/46/6/#/58/1/6     /8                          12        {4}       4
+/8                          /10/#/56/1/50/10/#/58/1/10  2         {5}       5
+/10/#/56/1/50/10/#/58/1/10  /12/#/55/1/52               13        {1}       1
+/12/#/55/1/52               /14/#/56/1/54/14/#/58/1/14  7         {2}       2
+/14/#/56/1/54/14/#/58/1/14  /16                         14        {3}       3
+/16                         /18/#/56/1/58/18/#/58/1/18  3         {4}       4
+/18/#/56/1/58/18/#/58/1/18  /20/#/55/1/60               15        {5}       5
+/20/#/55/1/60               /22/#/56/1/62/22/#/58/1/22  8         {1}       1
+/22/#/56/1/62/22/#/58/1/22  /24                         16        {2}       2
+/24                         /26/#/56/1/66/26/#/58/1/26  4         {3}       3
+/26/#/56/1/66/26/#/58/1/26  /28/#/55/1/68               17        {4}       4
+/28/#/55/1/68               /30/#/56/1/70/30/#/58/1/30  9         {5}       5
+/30/#/56/1/70/30/#/58/1/30  /32                         18        {1}       1
+/32                         /34/#/56/1/74/34/#/58/1/34  5         {2}       2
+/34/#/56/1/74/34/#/58/1/34  /36/#/55/1/76               19        {3}       3
+/36/#/55/1/76               /38/#/56/1/78/38/#/58/1/38  10        {4}       4
+/38/#/56/1/78/38/#/58/1/38  NULL                        20        {5}       5
+
+query TTITI colnames
+SHOW TESTING_RANGES FROM TABLE grandchild1
+----
+Start Key                   End Key                     Range ID  Replicas  Lease Holder
+NULL                        /2/#/56/1/42/2/#/58/1/2     1         {1}       1
+/2/#/56/1/42/2/#/58/1/2     /4/#/55/1/44                11        {2}       2
+/4/#/55/1/44                /6/#/56/1/46/6/#/58/1/6     6         {3}       3
+/6/#/56/1/46/6/#/58/1/6     /8                          12        {4}       4
+/8                          /10/#/56/1/50/10/#/58/1/10  2         {5}       5
+/10/#/56/1/50/10/#/58/1/10  /12/#/55/1/52               13        {1}       1
+/12/#/55/1/52               /14/#/56/1/54/14/#/58/1/14  7         {2}       2
+/14/#/56/1/54/14/#/58/1/14  /16                         14        {3}       3
+/16                         /18/#/56/1/58/18/#/58/1/18  3         {4}       4
+/18/#/56/1/58/18/#/58/1/18  /20/#/55/1/60               15        {5}       5
+/20/#/55/1/60               /22/#/56/1/62/22/#/58/1/22  8         {1}       1
+/22/#/56/1/62/22/#/58/1/22  /24                         16        {2}       2
+/24                         /26/#/56/1/66/26/#/58/1/26  4         {3}       3
+/26/#/56/1/66/26/#/58/1/26  /28/#/55/1/68               17        {4}       4
+/28/#/55/1/68               /30/#/56/1/70/30/#/58/1/30  9         {5}       5
+/30/#/56/1/70/30/#/58/1/30  /32                         18        {1}       1
+/32                         /34/#/56/1/74/34/#/58/1/34  5         {2}       2
+/34/#/56/1/74/34/#/58/1/34  /36/#/55/1/76               19        {3}       3
+/36/#/55/1/76               /38/#/56/1/78/38/#/58/1/38  10        {4}       4
+/38/#/56/1/78/38/#/58/1/38  NULL                        20        {5}       5
+
+# TODO(radu): enable these tests when we plan merge joins.
+# statement ok
+# SET CLUSTER SETTING sql.distsql.interleaved_joins.enabled = true;
+# 
+# #####################
+# # Interleaved joins #
+# #####################
+# 
+# # Select over two ranges for parent/child with split at children key.
+# query T
+# SELECT "URL" FROM [EXPLAIN (DISTSQL) SELECT * FROM parent1 JOIN child1 USING(pid1) WHERE pid1 >= 3 AND pid1 <= 5]
+# ----
+# https://cockroachdb.github.io/distsqlplan/decode.html?eJzMkkFr6zAQhO_vVzzm9B7dEstpL4aCryklKbkWH4S1SQSOZFZyaSn570VWoU5oQ9tTb5ZmZscf2hc4b3ip9xxQPUCBUIIwR0PoxbccgpckZePCPKEqCNb1Q8zX0caOUWFwXgwLGxAMR227pDeHhtB6YVTv1qW_9P2sPDES_BDfxjaEEPWWUZUHmlSrSfUHgxcusnSsH3nN2rDceutYZsVRE-54E5Hw7F7Lc91rYRcT-dpud1Ol3dnOJCHPAaHjTfxXq4v_N5K84ycIqyFWf2tFdUn1FdXX-IxGHdGUP6JRv5SmOE-z5tB7F_hLr16ktWGz5bxjwQ_S8r34dqzJx9WYGy8Mh5jVeT4sXJbSD07D6my4OAqr03D5rXBz-PMaAAD__y7yGHk=
+# 
+# # Swap parent1 and child1 tables.
+# query T
+# SELECT "URL" FROM [EXPLAIN (DISTSQL) SELECT * FROM child1 JOIN parent1 USING(pid1) WHERE pid1 >= 3 AND pid1 <= 5]
+# ----
+# https://cockroachdb.github.io/distsqlplan/decode.html?eJzMklFL-zAUxd__n-LPeVK8sqbDl4LQ14lsslfpQ2jutkCXlJtUFNl3lzSC3dChPvnW5JxzT3_kvsJ5w0u954DqEQqEEoQ5GkIvvuUQvCQpGxfmGVVBsK4fYr6ONnaMCoPzYljYgGA4atslvTk0hNYLo_qwLv2172fliZHgh_g-tiGEqLeMqjzQpFpNqj8ZvHCRpWP9xGvWhuXOW8cyK46acM-biIRn91pe6nZnO5PA13a7mwq9FnYxKXkOCB1v4kWtri5vJZnHTxBWQ6z-14rqkuo51Tf4ikYd0ZS_olF_lKY4T7Pm0HsX-FuvXqS1YbPlvGPBD9Lyg_h2rMnH1ZgbLwyHmNV5PixcltIPTsPqbLg4CqvTcPmjcHP49xYAAP__IiwYdw==
+# 
+# # Select over two ranges for parent/child with split at grandchild key.
+# # Also, rows with pid1 <= 30 should have 4 rows whereas pid1 > 30 should
+# # have 3 rows.
+# query T
+# SELECT "URL" FROM [EXPLAIN (DISTSQL) SELECT * FROM parent1 JOIN child1 ON parent1.pid1 = child1.pid1 WHERE parent1.pid1 >= 29 AND parent1.pid1 <= 31 ORDER BY parent1.pid1]
+# ----
+# https://cockroachdb.github.io/distsqlplan/decode.html?eJzUUcFq6zAQvL-veOypJSqxnOZiKOiaUpKSa_FBWBtH4EhmtS4twf9eJB0Sl6S0vfVm7czs7IyP4LzBtT5ggOoFJAhYQi2gJ99gCJ7iOJNW5g2qQoB1_cBxXAtoPCFUR2DLHUIFK8dIHepX3KI2SI_eOqR5XGuQte2SyxPuGKKHPWh6V70mdBw5W9vuz5FmbzsTgbwHBHS44xslZ7cPFLnpEwRsBq7-KylUKdRCqHuhllCPAvzAp2MD6xahkqO4EuiUw5NBQjM9W8kZ1OOF1Gt_5_t5OWFfcy8n7vJXdRZ_o84LgbYYeu8CfquqInaNpsX8b4IfqMFn8k2yyc9N0qWBwcAZlfmxcglKB56L5ZfixURcfBaXP3Kux38fAQAA__8x_hkU
+# 
+# # Parent-child where pid1 <= 15 have one joined row and pid1 > 15 have no
+# # joined rows (since child2 only has 15 rows up to pid1 = 15).
+# # Note this spans all 5 nodes, which makes sense since we want to read all
+# # parent rows even if child rows are non-existent (so we can support OUTER
+# # joins).
+# # TODO(richardwu): we can remove nodes reading from just one table for INNER
+# # joins or LEFT/RIGHT joins.
+# query T
+# SELECT "URL" FROM [EXPLAIN (DISTSQL) SELECT * FROM parent1 JOIN child2 USING(pid1) WHERE pid1 >= 12 ORDER BY pid1]
+# ----
+# https://cockroachdb.github.io/distsqlplan/decode.html?eJzMlD1rwzAQhvf-ivJOLbkSyx8ZDAWtKSUpWYsHY10Sg2MZSS4twf-92B4Sl6YfzuLN0t3j9x6BdESpFa_SA1vErxAg-CAEIIQgREgIldEZW6tN29IDS_WO2CPkZVW7djshZNow4iNc7gpGjGXp2BScvvGGU8XmSeclm7kHgmKX5kWX-MxbhzYjP6TmQ1ap4dK1Y2zy3f68ku3zQrWz9f8BoeCtu5Nidv9o2t7uE4R17eJbKUj6JEOSEckFkoaga3ca1rp0x4hFQxeETh7aKDashmNLMUPSfGO90g-6mkeD7kvp_iBdjDpOMd3j9EcJ-dMVCkYJBdMVCkcJhdMV-uVJ2rCtdGn5T7fTa683qx33z4HVtcn4xeisi-mX647rNhRb11dFv1iWXakb8BwWP8KLAex9hf1rkoNr4PAaOPoXnDQ3nwEAAP__9wcgdA==
+# 
+# # These rows are all on the same node 1 (gateway).
+# query T
+# SELECT "URL" FROM [EXPLAIN (DISTSQL) SELECT * FROM parent1 JOIN child2 USING(pid1) WHERE pid1 IN (1, 11, 21, 31) ORDER BY pid1]
+# ----
+# https://cockroachdb.github.io/distsqlplan/decode.html?eJyMUE1LxDAUvPsrZE6KD9ws6iEg5LoirvQqPYTmbTfQTcrLqyhL_7u0OagHwVvmIzOZnJFy4Bd_4gL7BoOWMEruuJQsC1UNu_ABuyHENE660C2hy8KwZ2jUgWGxS8oysH_nhn1gecoxsdxuQAisPg5rwzMfFEtHPHn5dKMXTmpAaGJ__Kl0xziELQg1B4SBD3rlzM31oyze9QjCflJ76Qy5Lbk7cvfkHtDOhDzp92OL-p5hzUz_H9RwGXMq_GvAX8mbuSVw6Ll-WsmTdPwquVtrKtyv91YicNGqmgp2qUpzO198BQAA___Vk4P-
+# 
+# # Parent-grandchild.
+# query T
+# SELECT "URL" FROM [EXPLAIN (DISTSQL)
+#   SELECT * FROM parent1 JOIN grandchild2 USING(pid1) WHERE
+#     pid1 >= 11 AND pid1 <= 13
+#     OR pid1 >= 19 AND pid1 <= 21
+#     OR pid1 >= 31 AND pid1 <= 33
+# ]
+# ----
+# https://cockroachdb.github.io/distsqlplan/decode.html?eJzslE9r3DAQxe_9FGJOu3RKLDlpqWBBhVJwKd5iemt9ENbEETiSkeTSEvzdi-0u8Yb0Xwohh71ZevPjDX6juQHnDZX6miLIz8ABQQDCBdQIffANxejDJC2FhfkGMkOwrh_SdF0jND4QyBtINnUEEgqXKHSkv1JF2lB4762jcJYBgqGkbTc7faDLBJOHvdbhu-p1IJcm-0lg72yXKEi22SjOvgxZljc7xnMpZVF-2rJ9tVJox_jrg_KmfMvWjOA_le1CraD8IAFCZdurdTtt0M40V7Yz4qA-ek_LfwOEji7TRvHn212YGpk_AWE_JMkURyVQnaO6QPUS1SuoRwQ_pNt8YtItgeQj_iLD2-gG54OhQOYoq3q8J-XSv_D9WX6n8H5rcWTNHzQ-_DQ-T2h8xIMyFKcMn1CGf1jjFcXeu0h_9cKzaUWQaWnZJ9EPoaGPwTezzXLcz9x8YSimReXLoXCzNDe4hvlv4fMjOLsLi_9xzv8JrsdnPwIAAP__gf0kvQ==
+# 
+# query T
+# SELECT "URL" FROM [EXPLAIN (DISTSQL)
+#   SELECT * FROM grandchild2 JOIN parent1 USING(pid1) WHERE
+#     pid1 >= 11 AND pid1 <= 13
+#     OR pid1 >= 19 AND pid1 <= 21
+#     OR pid1 >= 31 AND pid1 <= 33
+# ]
+# ----
+# https://cockroachdb.github.io/distsqlplan/decode.html?eJzslE-L2zAQxe_9FGJOCZ2ylr1LqSCgQim4FKeY3lofhDXrFXglI8mlZfF3L7Yb4oT0Xwolh9wsvfnxBr_RPIF1mgr1SAHEJ-CAkALCHVQInXc1heD8KM2Fuf4KIkEwtuvjeF0h1M4TiCeIJrYEAnIbybekvlBJSpN_54wlf5MAgqaoTDs5vaf7CKOHeVT-m2y8srp-MK0e7UeRvTVtJC_YaiU5-9wnSVZvGM-EEHnxcc225UKhDeOvdsrr4g1bMin_oaxnagFlOwkQStM8LFvqlCcb-U757_3M_w0QWrqPK8mfrzd-bGT6BIRtHwWTHGWKMkN5i_IO5UuoBgTXx30-IaqGQPABf5LhPrreOq_Jkz7IqhpOpFy4F667yY4KT1unB9b8rPHh1_G5oPFJz8owvWZ4QRn-Zo2XFDpnA_3RC0_GFUG6oXmfBNf7mj54V08283E7cdOFphBnlc-H3E7S1OAS5r-Ebw_g5BhO_8U5-yu4Gp59DwAA__8zXSS0
+# 
+# query TTT
+# EXPLAIN SELECT * FROM grandchild2 JOIN parent1 USING(pid1) WHERE
+#   pid1 >= 11 AND pid1 <= 13
+#   OR pid1 >= 19 AND pid1 <= 21
+#   OR pid1 >= 31 AND pid1 <= 33
+# ----
+# render          ·               ·
+#  └── join       ·               ·
+#       │         type            inner
+#       │         equality        (pid1) = (pid1)
+#       │         mergeJoinOrder  +"(pid1=pid1)"
+#       ├── scan  ·               ·
+#       │         table           grandchild2@primary
+#       │         spans           /11/#/56/1-/13/#/56/2 /19/#/56/1-/21/#/56/2 /31/#/56/1-/33/#/56/2
+#       └── scan  ·               ·
+# ·               table           parent1@primary
+# ·               spans           /11-/13/# /19-/21/# /31-/33/#
+# 
+# # Join on multiple interleaved columns with an overarching ancestor (parent1).
+# # Note there are 5 nodes because the filter cid2 >= 12 AND cid2 <= 14
+# # creates a giant parent span which requires reading from all rows.
+# query T
+# SELECT "URL" FROM [EXPLAIN (DISTSQL)
+#   SELECT * FROM child2 JOIN grandchild2 ON
+#     child2.pid1=grandchild2.pid1
+#     AND child2.cid2=grandchild2.cid2
+#     AND child2.cid3=grandchild2.cid3
+#   WHERE
+#     child2.pid1 >= 5 AND child2.pid1 <= 7
+#     OR child2.cid2 >= 12 AND child2.cid2 <= 14
+#     OR gcid2 >= 49 AND gcid2 <= 51
+# ]
+# ----
+# https://cockroachdb.github.io/distsqlplan/decode.html?eJzslUFr2zAUx-_7FOKdHPJGLVluV0FAgzHIGMkIu20-GOs1NbhWkOSxUfLdh-3FrUs21gRy8tH668df8k_wHqG2hlb5A3lQ34ADggCEBBAkIKSQIeycLch769otPbA0P0HFCGW9a0K7nCEU1hGoRwhlqAgULOtArqL8B20oN-Q-2bImdxUDgqGQl1XX-JnuArQd5UPufunivqxMe4JNub1_HmxdXptxyj6WVSCnWBRFmrPvTRwntGCpUmq5-jpj71cf2BAUC3bzJ5ix9YZFkRYDwsWYEQPD5QE6UHKg5O2YkgOV8gMFCP29AaGiuxBpPkct5qiT-Wzh2muMlgBh3QTFNEctUCeoJeoU9TXqG9TvUN9CtkewTXj68T7kWwLF9_gXOU9Omto6Q47MSEK2P6JvZd_a3VX6YuPxajGq5ie9Cz69i0u8C3GSHDHJuYSc5CQ5ySTnEnLkSXLkJOfS4-6InA35na09_dc0i9txSGZL_ez0tnEFfXG26Gr6z3XHdQuGfOhT3n8s6y7qDvgc5v-Er0dw_BIW5zQn58DyHDh9FZzt3_wOAAD__-mfE2o=
+# 
+# query TTT
+# EXPLAIN
+#   SELECT * FROM child2 JOIN grandchild2 ON
+#     child2.pid1=grandchild2.pid1
+#     AND child2.cid2=grandchild2.cid2
+#     AND child2.cid3=grandchild2.cid3
+#   WHERE
+#     child2.pid1 >= 5 AND child2.pid1 <= 7
+#     OR child2.cid2 >= 12 AND child2.cid2 <= 14
+#     OR gcid2 >= 49 AND gcid2 <= 51
+# ----
+# join       ·               ·
+#  │         type            inner
+#  │         equality        (pid1, cid2, cid3) = (pid1, cid2, cid3)
+#  │         mergeJoinOrder  +"(pid1=pid1)",+"(cid2=cid2)",+"(cid3=cid3)"
+#  ├── scan  ·               ·
+#  │         table           child2@primary
+#  │         spans           ALL
+#  └── scan  ·               ·
+# ·          table           grandchild2@primary
+# ·          spans           ALL
+# 
+# # Aggregation over parent and child keys.
+# query T
+# SELECT "URL" FROM [EXPLAIN (DISTSQL)
+#   SELECT SUM(parent1.pid1), SUM(child1.cid1) FROM parent1 JOIN child1 USING(pid1) WHERE
+#     pid1 >= 10 AND pid1 <= 39
+# ]
+# ----
+# https://cockroachdb.github.io/distsqlplan/decode.html?eJzUlVGrmzAUx9_3KS7n6V4WuEZtbysM3GPHto6OPQ0fgjm1gk0kiWOj-N1HlLVa2jisL74lOefv75z_CeYEQnL8yo6oIfoJFAj4QCAAAiEQWEBCoFQyRa2lsimtYMN_Q-QRyEVZGXucEEilQohOYHJTIESwEQZVgewX7pBxVJ9kLlC9WgRHw_KiIX7GvQHLyI9M_YlLplAYm2MDT9vKRE-x3e7y7NBNTA95wc-Bf4kkttW3JCBQ4N48x_T9ywdls5olEDgnB5DUBGRlLl1owzKEiNbk_zv9mGUKM2akel32u_v-48tzTC2zWfkvd4H-XeCFUwmpOCrkPUhSu0ui3tiagl5NdNS4_RmOe6DTjrdv04zbH2VtMENrBzrtWLuaxtpglLXhDK0d6LRj7Xoaa8NR1noztHag0461i-n__zeAO9SlFBqv3oHbX_bs-4A8w_Yx0bJSKX5TMm0w7Xbb6JoDjtq0UdpuNqIN2QK7YuoU-z0xvRb7bvIAOnCqQ7c4fKTuhVO8dJOXj5DfnOKVm7x6hLx2z8obuCbuS3bNTup3fwMAAP__hy1jzg==
+# 
+# ###############
+# # Outer joins #
+# ###############
+# 
+# # The schema/values for each table are as follows:
+# # Table:        pkey:                     pkey values (same):   values:
+# # outer_p1      (pid1)                    {1, 2, 3, ... 20}     100 + pkey
+# # outer_c1      (pid1, cid1, cid2)        {2, 4, 6, ... 28}     200 + pkey
+# # outer_gc1     (pid1, cid1, cid2, gcid1) {4, 8, 12, ... 36}    300 + pkey
+# 
+# # Split between 4 nodes based on pkey value (p):
+# # node 1:       p - 1 mod 20 ∈ [1...5)
+# # node 2:       p - 1 mod 20 ∈ [5...10)
+# # node 3:       p - 1 mod 20 ∈ [10...15)
+# # node 4:       p - 1 mod 20 ∈ [15...20)
+# 
+# statement ok
+# CREATE TABLE outer_p1 (
+#   pid1 INT PRIMARY KEY,
+#   pa1 INT
+# )
+# 
+# statement ok
+# CREATE TABLE outer_c1 (
+#   pid1 INT,
+#   cid1 INT,
+#   cid2 INT,
+#   ca1 INT,
+#   PRIMARY KEY (pid1, cid1, cid2)
+# ) INTERLEAVE IN PARENT outer_p1 (pid1)
+# 
+# statement ok
+# CREATE TABLE outer_gc1 (
+#   pid1 INT,
+#   cid1 INT,
+#   cid2 INT,
+#   gcid1 INT,
+#   gca1 INT,
+#   PRIMARY KEY (pid1, cid1, cid2, gcid1)
+# ) INTERLEAVE IN PARENT outer_c1 (pid1, cid1, cid2)
+# 
+# statement ok
+# ALTER TABLE outer_p1 SPLIT AT
+#   SELECT i FROM generate_series(0, 40, 5) AS g(i)
+# 
+# statement ok
+# ALTER TABLE outer_p1 TESTING_RELOCATE
+#   SELECT ARRAY[(((i-3)/5)%4)::INT + 1], i FROM generate_series(3, 40, 5) AS g(i)
+# 
+# query TTITI colnames
+# SHOW TESTING_RANGES FROM TABLE outer_p1
+# ----
+# Start Key  End Key  Range ID  Replicas  Lease Holder
+# NULL       /0       20        {5}       5
+# /0         /5       31        {1}       1
+# /5         /10      32        {2}       2
+# /10        /15      33        {3}       3
+# /15        /20      34        {4}       4
+# /20        /25      35        {1}       1
+# /25        /30      36        {2}       2
+# /30        /35      37        {3}       3
+# /35        /40      38        {4}       4
+# /40        NULL     39        {5}       5
+# 
+# ### Begin OUTER queries
+# 
+# query T
+# SELECT "URL" FROM [EXPLAIN (DISTSQL) SELECT * FROM outer_p1 FULL OUTER JOIN outer_c1 USING (pid1)]
+# ----
+# https://cockroachdb.github.io/distsqlplan/decode.html?eJzclE2L2zAQhu_9FWJOu3TK-nMPhoIuDTgYp5jkVEwx1iQ1OJKR5NIQ_N-L7EOaNP1Y5-abpdEzr585zBmkEpRXRzKQfAEfEAJACAEhAoQYSoROq5qMUdo9mYBU_IDEQ2hk11t3XSLUShMkZ7CNbQkSSKUl3VL1nQqqBOm1aiTpFxchyFZNOyZmtLfgMppjpU9c9Zb01849KprDt99LtStNrQBhe-ooYatdlrHNbvupYOtNmgNCS3v7xP33zx-16zJ-upYkBemEpat8l2VP3EcePiPjATIeIeMxMv4K5YCgensxM7Y6ECT-gH-wv0j3UmlBmsSVZTncmU-uPqjuJb55eD86uIr2Zw0-WMjgg1n24ULsw1n20ULso1n23kLs_7FwCzKdkob-a6N4biWRONC0v4zqdU2ftarHmOm4GbnxQpCxU9WfDqkcS-MP_gr7f4Vfr2DvFg4eSQ4fgaNH4PhNcDm8-xkAAP__5oReVw==
+# 
+# query T
+# SELECT "URL" FROM [EXPLAIN (DISTSQL) SELECT * FROM outer_gc1 FULL OUTER JOIN outer_c1 USING (pid1, cid1, cid2)]
+# ----
+# https://cockroachdb.github.io/distsqlplan/decode.html?eJzklU2LnEAQhu_5FVKnHabC-rlJhEBfsuAiTpCdU5Agdq0R3G7pbkOWwf8eWiEzTiYf6xw9Vlc9_crTUB5ASE5Z-Uwa4i_gAYIPCAEghIAQQYHQKVmR1lLZkQlI-A-IXYRGdL2xxwVCJRVBfADTmJYghkQYUi2V3ymnkpN6kI0gdWsjOJmyacfElJ4M2IzmuVQvTPaG1Ne6slN5U3_7vTe2prsA4fGlo9i536eps9s_fsqdh12SAUJLT-aGeVtk_hZZsN18VPa22ZGNIMFJxU5yn-3T9IZ5yO42-Kv0kb07KQNk7zfosBAdFqHDPkAxIMjeHCVoU9YEsTfgH0Qd_fRCKk6K-ExIMVxQmcm3sruNzgYvR_uzaG_RG_nreyN_kahgfaKCRaLC9YkKF4ly1yfqH_-RnHQnhab_2n6uXZ_Ea5p2rZa9quizktUYM5W7kRsPOGkzdb2pSMTYGj_wFPb-Ct_NYPcc9q9JDq6Bw2vg6FVwMbz5GQAA__8alY8h
+# 
+# query T
+# SELECT "URL" FROM [EXPLAIN (DISTSQL) SELECT * FROM outer_c1 LEFT OUTER JOIN outer_p1 USING (pid1) WHERE pid1 >= 0 AND pid1 < 40]
+# ----
+# https://cockroachdb.github.io/distsqlplan/decode.html?eJzUlE-Lo0AQxe_7KeSddtlaYqu7B2HBSwYMIQ6SOQ0yiF3JCMaW7naYEPzug3rIJJP5l5xys_v1q1e_gnKHWkle5Bs2CO8hQPBA8EEIkBEarQo2RuleHh_H8hmhSyjrprX9dUYolGaEO9jSVowQcW1ZV5w_ccq5ZD1TZc164oIg2eZlNaTNeWXRZ5SbXG8j1VrWD0XfQ1quH99KTS-NpUBYbhsOnfn0Zukkd8tp6sySeAFCxSv7MxK_f_3XfZXhE4SktaETCYo8inyKAor-IesIqrV7DmPzNSMUHb3Dukdsa6Ula5YHTFl3YhoL9Uc1k-Do4elo7yBanDVmcZVj9s5i9a6S1T-L1b9K1k9-FSmbRtWGv7Qdbr9eLNc87qJRrS74VqtiiBmPyeAbLiQbO6piPMT1IA0NvjaLD81_D8zusdm7JNm_xBx8y5x1P14CAAD___ca6HA=
+# 
+# query T
+# SELECT "URL" FROM [EXPLAIN (DISTSQL) SELECT * FROM outer_p1 RIGHT OUTER JOIN outer_gc1 USING (pid1) WHERE pid1 >= 1 AND pid1 <= 20]
+# ----
+# https://cockroachdb.github.io/distsqlplan/decode.html?eJzUlE9r20AQxe_9FOKdWjrF-ucWBIW9lFamWEW4pyCC0I4VgawVu6sQY_Tdg6SDY8f5Z5980-7bN29-A6MdGiV5mW_YILqBB4IPQgBCiIzQalWwMUoP8vQ4lg-IXELVtJ0drjNCoTQj2sFWtmZEiBvLuub8nlPOJeuFqhrWMxcEyTav6jHtL68thoxqk-utUJ1lfdsOPaRVefdcKotBm2qBsNq2HDlp_PvPykn-r36lziKJlyDUvLafhff1y0891Bk_QUg6GzkiIOGTCEnMSXwn8QNZT1Cd3cMYm5eMyOvpBeA9Z9coLVmzPADL-hMjWapvqp2FRw9PR_sH0d5Zs_aud9b-WcD-9QIHZwEH1wv8xu8jZdOqxvC7lsUdto1lydNqGtXpgv9pVYwx0zEZfeOFZGMn1ZsOcTNKY4NPzd6r5vmB2T02-5ckB5eYww-Zs_7TYwAAAP__Vjbt9A==
+# 
+# ########################
+# # Non-interleaved joins #
+# ########################
+# 
+# # Join on siblings uses merge joiner.
+# # TODO(richardwu): Update this once sibling joins are implemented.
+# query T
+# SELECT "URL" FROM [EXPLAIN (DISTSQL) SELECT * FROM child1 JOIN child2 USING(pid1)]
+# ----
+# https://cockroachdb.github.io/distsqlplan/decode.html?eJzElsFq20AQhu99ijCnlmyxdyXZsaCgawpNSuit-KBYU1vgaM1Kgobgdy-yCq5ldUabwfLNsvbbnZ35QP8bFDbDh_QFS4h_ggYFBhQEoCAEBREsFeycXWFZWtcsaYH77DfEUwV5saur5u-lgpV1CPEbVHm1RYjhR_q8xSdMM3STKSjIsErz7eGYnctfUvearDb5NtOw3CuwdfV3q-MOz683m7TcnLJJs36poKzSNUKs9-p9JUVESUZUkvlvScd9rMvQYdbd57Y5eNCqntt9Q7fGrzYv0E10p-Nb_FV9TPTtpy8uX2_an6Dgsa7im0SrxKgkUEmkkplK5p3bH28WDLhZXfRV3Vvwg_1sdxMddVb2nx2enK2HD1qP5J5HSbOR3NPXcU9f3j0zvNlmpPl7lDQfaf7mOvM3l59_MLzZwUjz9yjpbqT5B9eZf3D5-YfDmx2ONH-PkhYjzT-8zvzDcbNHTzlPWO5sUeKgZDFtLoTZGts2lbZ2K_zu7OpwTPv4eOAOX9QMy6p9a9qH-6J91RQ4HJ5J4IUE1qK6dUTT2qNlxg-eSeCFBNaiujstO6NNl57-Swd0vwMS1qc9m3bpUCI4DTOC0zAjOA1zgjM0I3gkEZyGGcFpmBGchjnBGZoRfCYRfC5RlIYZRWmYUZSGOUUZmlH0TqIoDTOK0jCjKA1zijI0o-hCoqgW5QSGZiRlaMZShuY05XAuK8jCgiwtyOKCMC_IAoMWJQZ9Fhm8bKVpzlaa5myladZWBuds9QlL5zPzSUu-NGerV17yxjlbz8IDaety_-FPAAAA__-7ahyi
+# 
+# # Join on non-interleaved tables (with key) uses merge joiner.
+# query T
+# SELECT "URL" FROM [EXPLAIN (DISTSQL) SELECT * FROM parent1 JOIN parent2 ON pid1=pid2]
+# ----
+# https://cockroachdb.github.io/distsqlplan/decode.html?eJy8lVFr2zAQx9_3Kco9bVQjluykqWHg1w7WjrK34Qc1uiWG1DKSDCsl333YLmQxic5GRG9xrJ_u_r8D3zvUWuGjfEUL-W_gwEAAgxQYZMBgCSWDxugNWqtNd2QAHtRfyBMGVd20rvu7ZLDRBiF_B1e5PUIOv-TLHp9RKjSLBBgodLLa92UaU71K81Y00mDtOJQHBrp1H3cdr3h5u9lJuzuFi-58ycA6uUXI-YFd6Ol4jzYKDarxPbdd4eOptj53rq81zvYDzRa_66pGs1idXrvHP-5zwW-_fDPVdjf8BAZPrctvCs4KwYqUFdko8zFPOiHPjE4f9VfdLDgfnTxfOzupzafPl8eaL48_37trzldMdyxiORbxHa-v6Tid7jiN5TiN7_j-mo6z6Y6zWI5n9LT09SSCehIXe4o0d57EWlBnGnlG2-ja4qT1k3RRUG1xsGN1azb40-hNX2Z4fOq5fhEotG54-_HwUA-vuganw1kIvAqB1yEwJ0LzMZ38Tws_LLwwP6WTMZ2GDMsPE8Pyw8Sw_DAxLCIzEToLGdYyRLcfJnT7YUK3HyZ0E5mJ0KsQ3Xchuv0wodsPE7r9MKGbyEyEXofovg_R7YcJ3X6Y0O2HCd1EZurLP2dZipl0FkSvguh1EM2p4PM2Znn49C8AAP__9ASy7Q==
+# 
+# # Join on non-interleaved column uses hash joiner.
+# query T
+# SELECT "URL" FROM [EXPLAIN (DISTSQL) SELECT * FROM parent1 JOIN child1 ON pa1 = ca1]
+# ----
+# https://cockroachdb.github.io/distsqlplan/decode.html?eJy8llFr2zwUhu-_X1HOVQv6SCTZaWMY-HLdRTvK7oYv3PgsMaSWkRVYKfnvI_Egi-PpWDtEl2nySK_OeaDvBzSmwqfyDTvIvoMEAQoEaBCQgIAUCgGtNSvsOmMPP-mBx-onZHMBddPu3OHPhYCVsQjZB7jabREy-Fa-bvEFywrtbA4CKnRlvT1e09r6rbTveVtabJyEYi_A7Nzvs05HvL7fbMpucw7nCop9IaBz5Rohk3vxb5nS8UyrTb2tQiPps0jqr5FO5-waYyu0WJ2dVBxI6icj7_pcdpsvpm7QzuRg1lv84W5zdffJ1uuNu831HQh43rnsJpciVyLXIk9Eng5efHqNZrxmJOqT-d-0M5kO3z16d3J2t5y-XBlLuIBMi0jCycjCyasKp6YPWMVaekCm-0hLV5GXrq66dD19wDrW0gMyPURauo68dH3VpSfTB5zEWnpApmWkpSeRl55E6xMjQV6wa03T4aS2MD88Bas19qPpzM6u8Ks1q-M1_cfnI3f8J1lh5_pvVf_hsem_OgScDi848JIDS1ZumfppGTAyFQYvOPCSA0tW7sHILmg1pOd_0to_b-2F5fnM5kM64QjuhwnB_TAhuB-mBCdoQvCUI7gfJgT3w4TgfpgSnKAJwRccwe85ivphQlE_TCjqhylFCZpQ9IGjqB8mFPXDhKJ-mFKUoAlFlxxFJasnEDQhKUETlhI0pSmFU12BVxZ4bYFXF5h9gVcYJKsxyIvKEGSrn6Zs9dOUrX6atJXAKVtDytLlzkLaUihN2RrUl4JxytaL8uC1tdj_9ysAAP__U3kYdA==
+# 
+# # Prefix join on interleaved columns uses merge joiner.
+# query T
+# SELECT "URL" FROM [EXPLAIN (DISTSQL) SELECT * FROM child2 JOIN grandchild2 USING(pid1, cid2)]
+# ----
+# https://cockroachdb.github.io/distsqlplan/decode.html?eJzEll1r2zAUhu_3K8q52qhGItn5Mgx828HaUXY3cuFGZ47BtYxsw0rJfx-2C1kcT8eainzp2I_06uiBvK9QKIn3yTNWEP0EDgwEMAiAQQgMVrBnUGp1wKpSuv2kB-7kb4iWDLKibOr25z2Dg9II0SvUWZ0jRPAjecrxEROJerEEBhLrJMu7bUqdPSf6JT4cs1wK2J8YqKZ-W-q8wtPLzTGpjpdszFncInsGVZ2kCBE_sf9LtRpPleqkkO8TTfwz2nkppSVqlMOlblksbtv9J385ctpvqFP8qrIC9YIPLiHHX_XHN_rTF52lx_MjMHho6uimOxGLAxaHLN6weMvi3WAm58MGEw7bFGOHGM1-rz6rcsFXgy_H9w4v9ubTHeD-zLRItfZsJp_XTO7VTDH9HoQ_OyxSbTzbIea1Q3i1I5h-D4E_OyxSbT3bEcxrR-DVjnD6PYT-7LBItfNsRzivHeFsnWck2SNWpSoqnNRolu3ZUKbYT65SjT7gd60O3Tb940PHdX_fEqu6fyv6h7uif9UGnA6vXeCdC8ydcvOVmeYWIxN28NoF3rnA3Cn3YGRXtBjSy7_pwDzvwAjzy5kth3ToIrgZJgQ3w4TgZpgSnKAJwVcugpthQnAzTAhuhinBCZoQfO0i-MZFUTNMKGqGCUXNMKUoQROKbl0UNcOEomaYUNQMU4oSNKHozkVR7tQTCJqQlKAJSwma0pTCqa7gVhbc2oJbXXDsC26FgTs1Bn5VGaxsNdOUrWaastVMk7YSOGWrTVm6vjObtmRLU7Za9SVrnLL1qjwYbd2fPvwJAAD__4eyQAE=
+# 
+# # Subset join on interleaved columns uses hash joiner.
+# query T
+# SELECT "URL" FROM [EXPLAIN (DISTSQL) SELECT * FROM child2 JOIN grandchild2 USING(pid1, cid3)]
+# ----
+# https://cockroachdb.github.io/distsqlplan/decode.html?eJzElsGK2zAQhu99imVOLagkkp1sYij42O1htyy9FR-80TQxZK0gOdBlybsX2y1pHFdjdYp6VOxP-jX-IP8r1EbjffmMDrKvIEGAAgEJCEhBwAIKAQdrNuicse0rPXCnv0M2F1DVh2PT_lwI2BiLkL1CUzV7hAy-lE97fMRSo53NQYDGpqz23TEHWz2X9iXf7Kq9VlCcBJhj83Or8w5PLze70u0u2VyKPIHiVAhwTblFyORJ_F2qxXiqrS1r_W-iqT9GO291rI3VaFFfbFa0JPXKyP0-lm73yVQ12pkcTH2P35q3XcZ3H2y13f1agICHY5PddCuRK5GnIl-KfCXy9WAA55sljJuNxL43781hJhfDGYyenV6cLad_cBlPw4BUy8gaysgaymgaqulDV_FUCEh1G1kFFVkFFU2FZPrQk3gqBKRaRVYhiaxCEk2FdPrQ03gqBKRaR1YhjaxC-l96ykioR3QHUzuc1ELm7bVQb7EfkzNHu8HP1my6Y_rlQ8d1f7kaXdM_Vf3iru4ftQGnw0sOvObAkpVbLvy0DBiZCoOXHHjNgSUr92BkV7Qa0vPf6cQ_78QLy8uZzYd0yhHcDxOC-2FCcD9MCU7QhOALjuB-mBDcDxOC-2FKcIImBF9yBL_lKOqHCUX9MKGoH6YUJWhC0RVHUT9MKOqHCUX9MKUoQROKrjmKSlZPIGhCUoImLCVoSlMKp7oCryzw2gKvLjD7Aq8wSFZjkFeVIchWP03Z6qcpW_00aSuBU7aGlKXrbxbSlkJpytagvhSMU7ZelQevrcXpzY8AAAD__5b5Mtw=
+# 
+# # Sort node in between join and child nodes produces hash joiner.
+# query T
+# SELECT "URL" FROM [EXPLAIN (DISTSQL) SELECT * FROM parent1 JOIN (SELECT * FROM child1 ORDER BY cid1) USING(pid1)]
+# ----
+# https://cockroachdb.github.io/distsqlplan/decode.html?eJy8lk9vm0wQxu_vp4jm9FbdKuyC_yFV4tj0kFRpbxUHYrYxksOiBUuNonz3ClMrApx9mGK41bV_zOzsb_LwQrlJ9W3ypEsKf5IkQYoE-SQoIEELigUV1mx1WRpb_6QBbtLfFHqCsrw4VPV_x4K2xmoKX6jKqr2mkH4kD3t9r5NU22uPBKW6SrL9sUxhs6fEPkdFYnVeSYpfBZlD9fdZb494eL7aJeWuDUf172NBZZU8agrlq_i3nhbne9rusn3abemtnOKU-25spe217Bw_Uh9HHdl_t4e35xxyY1Ntddp6UlyT6CdnDvIlKXdfTZbXh-nMba9_Vf9H8sNnmz3ujv8iQXeHKryKpIiUiAIRLd4dZzDiKGf6vDWfTHGtvO6hz9ZetGrL4ebIuWxm9LS8gM2g3MlmOaXNcmabl9PZrIbfnprLKEZPqwsYBcqdjFJTGqVmNmo1nVH-8Nvz5zKK0dP6AkaBciej_CmN8mc2aj2dUcHw2wvmMorR0-YCRoFyJ6OCKY0KZjZqM8873Jku7nVZmLzUg97QvPocOn3UzVxKc7Bb_c2a7bFM8_HuyB1fHFJdVs23fvPhJm--qhscDq_HwFKNopdjaOW5admlvRbdgr0urBgDVzx4PQbuDJxLL8fQnYH3aN858MB9W4H7tqT7uhZj9sMNg_1ww2g_AA32w02j_Vg6J75yD3w1Zj_cMNgPN4z2A9BgP9w02o_1mP3YjDHcDQPD3TAyHNDAcDcNE6AXIK2JS_BHRfYShCM5oIHlgEaaIxx4DnAkuuzlCMd02csRjuqABq4DGsmOcGA7wKHu7gyVC6A7J0T7d85JUS4NdWflKBeHuruTFOnOiVIujXRnhSkbR7qz4rSPu_NUboDunETt3zknUrk01J0Vqlwc6a7cqdrVPX79708AAAD__3t4GdI=
+# 
+# query TTT
+# EXPLAIN SELECT * FROM parent1 JOIN (SELECT * FROM child1 ORDER BY cid1) USING (pid1)
+# ----
+# render               ·         ·
+#  └── join            ·         ·
+#       │              type      inner
+#       │              equality  (pid1) = (pid1)
+#       ├── scan       ·         ·
+#       │              table     parent1@primary
+#       │              spans     ALL
+#       └── sort       ·         ·
+#            │         order     +cid1
+#            └── scan  ·         ·
+# ·                    table     child1@primary
+# ·                    spans     ALL
+# 
+# # Multi-table staggered join uses interleaved joiner on the bottom join
+# # and a merge joiner.
+# query T
+# SELECT "URL" FROM[EXPLAIN (DISTSQL)
+#   SELECT * FROM grandchild1
+#   JOIN child1 USING (pid1, cid1)
+#   JOIN parent1 USING (pid1)
+# ORDER BY pid1
+# ]
+# ----
+# https://cockroachdb.github.io/distsqlplan/decode.html?eJzcls9u2kAQh-99imhOrbIV7NpAsFTJV6o2qVBvlQ8OnoAlx4vWS9Uo4t0rYxLMn-xgRhiJo7377c7OfIffK-Q6wfv4GQsI_oAEAQoEeCDABwE9iATMjZ5gUWhTbqmAUfIPgq6ANJ8vbPk7EjDRBiF4BZvaDCGAUW7RZBj_xTHGCZrvOs3RdLogIEEbp9nqxh_4ZKG8I32OzUs4NXGeTGZplpSljNPprL76vlCdBQIyfLKfQ3krQnX75Zsp979_goCHhQ1uQilCJUJPhL4IBxAtBeiFXRe-qffx5WYWF7Pt8kIJ0TISUNh4ihDIpTi-Ab_jx2z99k5v-9i3B81jg7mVrJrUhzVtztEmQYPJ7jm35cVH7TrwvJ9oprgeqtyZ6ttYaiM5PI7e_kQ2L_N4LztQ873-qucduT2Nj673t66XJ9kur8d2ogF12_tt2S4vY7s8v-3qJN3U9ehGNKCu26At3dRldFPn1807STfvenQjGlDX7a4t3bzL6OadXzf_JN3869GNaEBdt2FbuvmX0c1vNzoeKGeMxVznBR6VCrvlgzCZYtWmQi_MBH8ZPVldU30-rLhVPEmwsNWqqj5GebVUFng83OfAQw4sWXXLnpuWDVqmmsF9DjzkwJJV907L9mi1S3frtOfut-eE5XbPuru0zxHcDROCu2FCcDdMCU7QhOA9juBumBDcDROCu2FKcIImBO9zBB9wFHXDhKJumFDUDVOKEjSh6B1HUTdMKOqGCUXdMKUoQROKDjmKSlZOIGhCUoImLCVoSlMKp7ICLyzw0gIvLjDzAi8wSFZikHuRoZGtbpqy1U1Ttrpp0lYCp2xtEpb2Z9YkLTWlKVsb5aXGOGXrXnhw2hotP_0PAAD__9pnwiY=
+# 
+# # Multi-table join with parent1 and child1 at the bottom uses interleaved
+# # joiner but induces a hash joiner on the higher join.
+# query T
+# SELECT "URL" FROM [EXPLAIN (DISTSQL)
+#   SELECT * FROM parent1
+#   JOIN child1 USING (pid1)
+#   JOIN grandchild1 USING (pid1, cid1)
+# ]
+# ----
+# https://cockroachdb.github.io/distsqlplan/decode.html?eJzUls-K2zAQh-99imVOLVXZSLbzx1DwsSllt4Teig_aeDYxeK0gK6XLkncvjrPEdlJNHIEgtzjSJ81ovsPvDUqV4YN8wQri38CBgQAGATAIgUEEKYONVkusKqXrLQ0wz_5CPGKQl5utqf9OGSyVRojfwOSmQIhhXhrUBco_uECZof6u8hL1_QgYZGhkXuxv_IHPBuo78hepX5ON1FiauoxFvlq3V5brvMjqheYcYFDgs_mY8M-fvup67_4nMHjcmvgu4SwRLAlZEkG6Y6C25lDpscCn17u1rNbdemowgHSXMqiMXCHEfMcub_qXfCoO_d5H3ZPfG1lpWWaHbgaXJjqlif-WdjxqWyqdocasc1hak9SWM_19k9X6MEjem-RhHCwJjgNhieiMJHifyoQl0173x7YCh7bO1PygvqjNPY_6D3D27rBzN79KcX7bihNNtxUfe1ace1ac-1FcXKWZuG3NiKbbmk08ayY8ayb8aBZcpVlw25oRTbc1m3rWLPCsWeBHs_AqzcLb1oxouq3ZzLNmoWfNQv-58ExFC6w2qqzwotQ3qnvCbIXNG1Vqq5f4U6vl_prm83HP7TNIhpVpVkXzMS-bpbrAy-GxCzxzgblT3Tyy03zAk4lh8NgFnrnA3Knu3pOd0KJPj9p0YH_vwArz7puN-nToIrgdJgS3w4TgdpgSnKAJwSMXwe0wIbgdJgS3w5TgBE0IPnYRfOKiqB0mFLXDhKJ2mFKUoAlFpy6K2mFCUTtMKGqHKUUJmlB05qIod8oJBE1IStCEpQRNaUrhVFZwCwtuacEtLjjmBbfAwJ0SAz-JDINstdOUrXaastVOk7YSOGXrkLB0OrMhaWkoTdk6KC8NxilbT8KD1dZ09-FfAAAA___T9r_v

--- a/pkg/sql/opt/exec/execbuilder/testdata/distsql_tighten_spans
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distsql_tighten_spans
@@ -1,0 +1,318 @@
+# LogicTest: 5node-distsql-opt
+
+# This test verifies that we correctly tighten spans during index selection as
+# well as after partitioning spans in distsql.
+
+################
+# Schema setup #
+################
+
+statement ok
+CREATE TABLE p1 (
+  a INT,
+  b INT,
+  PRIMARY KEY (a, b),
+  INDEX b (b)
+)
+
+statement ok
+CREATE TABLE c1 (
+  a INT,
+  b INT,
+  PRIMARY KEY (a,b)
+) INTERLEAVE IN PARENT p1 (a, b)
+
+statement ok
+CREATE TABLE p2 (
+  i INT PRIMARY KEY,
+  d INT
+)
+
+statement ok
+CREATE INDEX p2_id ON p2 (i, d) INTERLEAVE IN PARENT p2 (i)
+
+statement ok
+CREATE TABLE bytes_t (a BYTES PRIMARY KEY)
+
+statement ok
+CREATE TABLE decimal_t (a DECIMAL PRIMARY KEY)
+
+############################
+# Split ranges for distsql #
+############################
+
+# Perform some splits to exercise distsql partitioning as well.
+
+# Create split points at X = 2.
+# Also split at the beginning of each index (0 for ASC, 100 for DESC) to
+# prevent interfering with previous indexes/tables.
+
+# p1 table (interleaved index)
+statement ok
+ALTER TABLE p1 SPLIT AT VALUES(2)
+
+# Create a split at /2/#
+statement ok
+ALTER TABLE c1 SPLIT AT VALUES(2,1)
+
+# Split index
+statement ok
+ALTER INDEX b SPLIT AT VALUES(0)
+
+statement ok
+ALTER INDEX b SPLIT AT VALUES(2)
+
+# p2 table (interleaved index)
+statement ok
+ALTER TABLE p2 SPLIT AT VALUES(0)
+
+statement ok
+ALTER TABLE p2 SPLIT AT VALUES(2)
+
+# Create a split at /2/#
+statement ok
+ALTER INDEX p2_id SPLIT AT VALUES(2)
+
+#####################
+# Distribute ranges #
+#####################
+
+# Distribute our ranges across the first 3 (for primary index) and last 2
+# (for seconary indexes) nodes.
+
+statement ok
+ALTER TABLE p1 TESTING_RELOCATE SELECT ARRAY[i], i FROM generate_series(1,3) AS g(i)
+
+statement ok
+ALTER INDEX b TESTING_RELOCATE SELECT ARRAY[i+3], i FROM generate_series(1,2) AS g(i)
+
+# Interleaved index table
+statement ok
+ALTER TABLE p2 TESTING_RELOCATE SELECT ARRAY[i], i FROM generate_series(1,3) as g(i)
+
+#############################
+# Verify range distribution #
+#############################
+
+# p1 table (interleaved table)
+
+query TTITI colnames
+SHOW TESTING_RANGES FROM TABLE p1
+----
+Start Key    End Key      Range ID  Replicas  Lease Holder
+NULL         /2           1         {1}       1
+/2           /2/1/#/54/1  2         {2}       2
+/2/1/#/54/1  NULL         3         {3}       3
+
+# Indexes
+
+query TTITI colnames
+SHOW TESTING_RANGES FROM INDEX b
+----
+Start Key  End Key  Range ID  Replicas  Lease Holder
+NULL       /0       3         {3}       3
+/0         /2       4         {4}       4
+/2         NULL     5         {5}       5
+
+# p2 table (interleaved index)
+
+query TTITI colnames
+SHOW TESTING_RANGES FROM TABLE p2
+----
+Start Key  End Key    Range ID  Replicas  Lease Holder
+NULL       /0         5         {5}       5
+/0         /2         6         {1}       1
+/2         /2/#/55/2  7         {2}       2
+/2/#/55/2  NULL       8         {3}       3
+
+###############
+# Query tests #
+###############
+
+# p1 table
+
+# Secondary index should not be tightened.
+query TTT
+EXPLAIN SELECT * FROM p1 WHERE b <= 3
+----
+scan  ·      ·
+·     table  p1@b
+·     spans  -/4
+
+# Partial predicate on primary key should not be tightened.
+query TTT
+EXPLAIN SELECT * FROM p1 WHERE a <= 3
+----
+scan  ·      ·
+·     table  p1@primary
+·     spans  -/4
+
+# Tighten end key if span contains full primary key.
+query TTT
+EXPLAIN SELECT * FROM p1 WHERE a <= 3 AND b <= 3
+----
+scan  ·      ·
+·     table  p1@primary
+·     spans  -/3/3/#
+
+query TTT
+EXPLAIN SELECT * FROM p1 WHERE a <= 3 AND b < 4
+----
+scan  ·      ·
+·     table  p1@primary
+·     spans  -/3/3/#
+
+# Mixed bounds.
+query TTT
+EXPLAIN SELECT * FROM p1 WHERE a >= 2 AND b <= 3
+----
+scan  ·      ·
+·     table  p1@primary
+·     spans  /2-
+
+# Edge cases.
+
+query TTT
+EXPLAIN SELECT * FROM p1 WHERE a <= 0 AND b <= 0
+----
+scan  ·      ·
+·     table  p1@primary
+·     spans  -/0/0/#
+
+query TTT
+EXPLAIN SELECT * FROM p1 WHERE a <= -1 AND b <= -1
+----
+scan  ·      ·
+·     table  p1@primary
+·     spans  -/-1/-1/#
+
+query TTT
+EXPLAIN SELECT * FROM p1 WHERE a = 1 AND b <= -9223372036854775808
+----
+scan  ·      ·
+·     table  p1@primary
+·     spans  /1-/1/-9223372036854775808/#
+
+query TTT
+EXPLAIN SELECT * FROM p1 WHERE a = 1 AND b <= 9223372036854775807
+----
+scan  ·      ·
+·     table  p1@primary
+·     spans  /1-/1/9223372036854775807/#
+
+# Table c1 (interleaved table)
+
+# Partial primary key does not tighten.
+
+query TTT
+EXPLAIN SELECT * FROM c1 WHERE a <= 3
+----
+scan  ·      ·
+·     table  c1@primary
+·     spans  -/4
+
+# Tighten span on fully primary key.
+query TTT
+EXPLAIN SELECT * FROM c1 WHERE a <= 3 AND b <= 3
+----
+scan  ·      ·
+·     table  c1@primary
+·     spans  -/3/3/#/54/1/#
+
+# Table p2 with interleaved index.
+
+# From the primary index.
+
+# Lower bound (i >= 2)
+query TTT
+EXPLAIN SELECT * FROM p2 WHERE i >= 2
+----
+scan  ·      ·
+·     table  p2@primary
+·     spans  /2-
+
+# Upper bound (i <= 5)
+
+query TTT
+EXPLAIN SELECT * FROM p2 WHERE i <= 5
+----
+scan  ·      ·
+·     table  p2@primary
+·     spans  -/5/#
+
+# From the interleaved index: no tightening at all.
+
+# Lower bound (i >= 1 AND d >= 2)
+
+# Note 53/2 refers to the 2nd index (after primary index) of table p2.
+query TTT
+EXPLAIN SELECT * FROM p2@p2_id WHERE i >= 1 AND d >= 2
+----
+scan  ·      ·
+·     table  p2@p2_id
+·     spans  /1/#/55/2/2-
+
+# Upper bound (i <= 6 AND d <= 5)
+
+query TTT
+EXPLAIN SELECT * FROM p2@p2_id WHERE i <= 6 AND d <= 5
+----
+scan  ·      ·
+·     table  p2@p2_id
+·     spans  -/6/#/55/2/6
+
+# IS NULL
+
+query TTT
+EXPLAIN SELECT * FROM p2@p2_id WHERE i >= 1 AND d IS NULL
+----
+scan  ·      ·
+·     table  p2@p2_id
+·     spans  /1/#/55/2/NULL-
+
+# IS NOT NULL
+
+query TTT
+EXPLAIN SELECT * FROM p2@p2_id WHERE i >= 1 AND d IS NOT NULL
+----
+scan  ·      ·
+·     table  p2@p2_id
+·     spans  /1/#/55/2/!NULL-
+
+# String table
+
+query TTT colnames
+EXPLAIN SELECT * FROM bytes_t WHERE a = 'a'
+----
+Tree  Field  Description
+scan  ·      ·
+·     table  bytes_t@primary
+·     spans  /"a"-/"a"/#
+
+# No tightening.
+
+query TTT colnames
+EXPLAIN SELECT * FROM bytes_t WHERE a < 'aa'
+----
+Tree  Field  Description
+scan  ·      ·
+·     table  bytes_t@primary
+·     spans  -/"aa"
+
+query TTT colnames
+EXPLAIN SELECT * FROM decimal_t WHERE a = 1.00
+----
+Tree  Field  Description
+scan  ·      ·
+·     table  decimal_t@primary
+·     spans  /1-/1/#
+
+# No tightening.
+
+query TTT colnames
+EXPLAIN SELECT * FROM decimal_t WHERE a < 2
+----
+Tree  Field  Description
+scan  ·      ·
+·     table  decimal_t@primary
+·     spans  -/2


### PR DESCRIPTION
 - Rename `interleaved_join` to `distsql_interleaved_join`
 - Rename `select_tighten_spans` to `distsql_tighten_spans`
 - Split both tests into logic and planner, copy to execbuilder. The
   first test is commented out for now; the other had no diff in the
   planner tests.

Release note: None