### PR TITLE
sql: introduce sqlbase.ExtendedTableDescriptor

### DIFF
--- a/pkg/sql/alter_sequence.go
+++ b/pkg/sql/alter_sequence.go
@@ -34,12 +34,7 @@ func (p *planner) AlterSequence(ctx context.Context, n *tree.AlterSequence) (pla
 		return nil, err
 	}
 
-	var seqDesc *TableDescriptor
-	// DDL statements avoid the cache to avoid leases, and can view non-public descriptors.
-	// TODO(vivek): check if the cache can be used.
-	p.runWithOptions(resolveFlags{skipCache: true}, func() {
-		seqDesc, err = ResolveExistingObject(ctx, p, tn, !n.IfExists, requireSequenceDesc)
-	})
+	seqDesc, err := ResolveExistingTableFromStore(ctx, p, tn, !n.IfExists, requireSequenceDesc)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -54,12 +54,7 @@ func (p *planner) AlterTable(ctx context.Context, n *tree.AlterTable) (planNode,
 		return nil, err
 	}
 
-	var tableDesc *TableDescriptor
-	// DDL statements avoid the cache to avoid leases, and can view non-public descriptors.
-	// TODO(vivek): check if the cache can be used.
-	p.runWithOptions(resolveFlags{skipCache: true}, func() {
-		tableDesc, err = ResolveExistingObject(ctx, p, tn, !n.IfExists, requireTableDesc)
-	})
+	tableDesc, err := ResolveExistingTableFromStore(ctx, p, tn, !n.IfExists, requireTableDesc)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/copy.go
+++ b/pkg/sql/copy.go
@@ -113,7 +113,7 @@ func newCopyMachine(
 	if err := c.p.CheckPrivilege(ctx, tableDesc, privilege.INSERT); err != nil {
 		return nil, err
 	}
-	cols, err := c.p.processColumns(tableDesc, n.Columns,
+	cols, err := c.p.processColumns(&tableDesc.TableDescriptor, n.Columns,
 		true /* ensureColumns */, false /* allowMutations */)
 	if err != nil {
 		return nil, err

--- a/pkg/sql/create_index.go
+++ b/pkg/sql/create_index.go
@@ -39,12 +39,7 @@ func (p *planner) CreateIndex(ctx context.Context, n *tree.CreateIndex) (planNod
 		return nil, err
 	}
 
-	var tableDesc *TableDescriptor
-	// DDL statements avoid the cache to avoid leases, and can view non-public descriptors.
-	// TODO(vivek): check if the cache can be used.
-	p.runWithOptions(resolveFlags{skipCache: true}, func() {
-		tableDesc, err = ResolveExistingObject(ctx, p, tn, true /*required*/, requireTableDesc)
-	})
+	tableDesc, err := ResolveExistingTableFromStore(ctx, p, tn, true /*required*/, requireTableDesc)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/create_stats.go
+++ b/pkg/sql/create_stats.go
@@ -66,7 +66,7 @@ func (p *planner) CreateStatistics(ctx context.Context, n *tree.CreateStats) (pl
 
 	return &createStatsNode{
 		CreateStats: *n,
-		tableDesc:   tableDesc,
+		tableDesc:   &tableDesc.TableDescriptor,
 		columns:     columnIDs,
 	}, nil
 }

--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -449,10 +449,11 @@ func resolveFK(
 ) error {
 	targetTable := d.Table.TableName()
 
-	target, err := ResolveExistingObject(ctx, sc, targetTable, true /*required*/, requireTableDesc)
+	obj, err := ResolveExistingObject(ctx, sc, targetTable, true /*required*/, requireTableDesc)
 	if err != nil {
 		return err
 	}
+	target := &obj.TableDescriptor
 	if target.ID == tbl.ID {
 		// When adding a self-ref FK to an _existing_ table, we want to make sure
 		// we edit the same copy.
@@ -1224,9 +1225,10 @@ func MakeTableDesc(
 
 	// We use a fkSelfResolver so that name resolution can find the newly created
 	// table.
+	obj := sqlbase.NewExtendedTableDescriptor(desc)
 	fkResolver := &fkSelfResolver{
 		SchemaResolver: vt,
-		newTableDesc:   &desc,
+		newTableDesc:   &obj,
 		newTableName:   n.Table.TableName(),
 	}
 

--- a/pkg/sql/data_source.go
+++ b/pkg/sql/data_source.go
@@ -125,7 +125,7 @@ func (p *planner) getDataSource(
 		}
 
 		colCfg := scanColumnsConfig{visibility: scanVisibility}
-		return p.getPlanForDesc(ctx, desc, tn, hints, colCfg)
+		return p.getPlanForDesc(ctx, &desc.TableDescriptor, tn, hints, colCfg)
 
 	case *tree.FuncExpr:
 		return p.getGeneratorPlan(ctx, t, sqlbase.AnonymousTable)
@@ -210,11 +210,11 @@ func (p *planner) QualifyWithDatabase(
 
 func (p *planner) getTableDescByID(
 	ctx context.Context, tableID sqlbase.ID,
-) (*sqlbase.TableDescriptor, error) {
+) (*ObjectDescriptor, error) {
 	// TODO(knz): replace this by an API on SchemaAccessor/SchemaResolver.
 	descFunc := p.Tables().getTableVersionByID
 	if p.avoidCachedDescriptors {
-		descFunc = sqlbase.GetTableDescFromID
+		descFunc = sqlbase.GetExtendedTableDescFromID
 	}
 	return descFunc(ctx, p.txn, tableID)
 }
@@ -242,7 +242,7 @@ func (p *planner) getTableScanByRef(
 		addUnwantedAsHidden: true,
 		visibility:          scanVisibility,
 	}
-	src, err := p.getPlanForDesc(ctx, desc, &tn, hints, colCfg)
+	src, err := p.getPlanForDesc(ctx, &desc.TableDescriptor, &tn, hints, colCfg)
 	if err != nil {
 		return src, err
 	}

--- a/pkg/sql/delete.go
+++ b/pkg/sql/delete.go
@@ -90,7 +90,7 @@ func (p *planner) Delete(
 	// Determine what are the foreign key tables that are involved in the deletion.
 	fkTables, err := sqlbase.TablesNeededForFKs(
 		ctx,
-		*desc,
+		desc.TableDescriptor,
 		sqlbase.CheckDeletes,
 		p.lookupFKTable,
 		p.CheckPrivilege,
@@ -120,7 +120,7 @@ func (p *planner) Delete(
 
 	// Create the table deleter, which does the bulk of the work.
 	rd, err := sqlbase.MakeRowDeleter(
-		p.txn, desc, fkTables, requestedCols, sqlbase.CheckFKs, p.EvalContext(), &p.alloc,
+		p.txn, &desc.TableDescriptor, fkTables, requestedCols, sqlbase.CheckFKs, p.EvalContext(), &p.alloc,
 	)
 	if err != nil {
 		return nil, err

--- a/pkg/sql/drop_index.go
+++ b/pkg/sql/drop_index.go
@@ -72,12 +72,8 @@ func (n *dropIndexNode) startExec(params runParams) error {
 		// the list: when two or more index names refer to the same table,
 		// the mutation list and new version number created by the first
 		// drop need to be visible to the second drop.
-		var tableDesc *TableDescriptor
-		var err error
-		params.p.runWithOptions(resolveFlags{skipCache: true}, func() {
-			tableDesc, err = ResolveExistingObject(
-				ctx, params.p, index.tn, true /*required*/, requireTableDesc)
-		})
+		tableDesc, err := ResolveExistingTableFromStore(
+			ctx, params.p, index.tn, true /*required*/, requireTableDesc)
 		if err != nil {
 			// Somehow the descriptor we had during newPlan() is not there
 			// any more.

--- a/pkg/sql/drop_table.go
+++ b/pkg/sql/drop_table.go
@@ -153,10 +153,7 @@ func (p *planner) prepareDrop(
 	ctx context.Context, name *tree.TableName, required bool, requiredType requiredType,
 ) (tableDesc *sqlbase.TableDescriptor, err error) {
 	// DDL statements avoid the cache to avoid leases, and can view non-public descriptors.
-	// TODO(vivek): check if the cache can be used.
-	p.runWithOptions(resolveFlags{skipCache: true}, func() {
-		tableDesc, err = ResolveExistingObject(ctx, p, name, required, requiredType)
-	})
+	tableDesc, err = ResolveExistingTableFromStore(ctx, p, name, required, requiredType)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/helpers_test.go
+++ b/pkg/sql/helpers_test.go
@@ -56,7 +56,7 @@ func NewLeaseRemovalTracker() *LeaseRemovalTracker {
 // TrackRemoval starts monitoring lease removals for a particular lease.
 // This should be called before triggering the operation that (asynchronously)
 // removes the lease.
-func (w *LeaseRemovalTracker) TrackRemoval(table *sqlbase.TableDescriptor) RemovalTracker {
+func (w *LeaseRemovalTracker) TrackRemoval(table *ObjectDescriptor) RemovalTracker {
 	id := tableVersionID{
 		id:      table.ID,
 		version: table.Version,
@@ -80,7 +80,7 @@ func (t RemovalTracker) WaitForRemoval() error {
 // LeaseRemovedNotification has to be called after a lease is removed from the
 // store. This should be hooked up as a callback to
 // LeaseStoreTestingKnobs.LeaseReleasedEvent.
-func (w *LeaseRemovalTracker) LeaseRemovedNotification(table sqlbase.TableDescriptor, err error) {
+func (w *LeaseRemovalTracker) LeaseRemovedNotification(table ObjectDescriptor, err error) {
 	w.mu.Lock()
 	defer w.mu.Unlock()
 
@@ -114,7 +114,7 @@ func (m *LeaseManager) AcquireAndAssertMinVersion(
 	timestamp hlc.Timestamp,
 	tableID sqlbase.ID,
 	minVersion sqlbase.DescriptorVersion,
-) (*sqlbase.TableDescriptor, hlc.Timestamp, error) {
+) (*ObjectDescriptor, hlc.Timestamp, error) {
 	t := m.findTableState(tableID, true)
 	if err := t.ensureVersion(ctx, minVersion, m); err != nil {
 		return nil, hlc.Timestamp{}, err
@@ -123,5 +123,5 @@ func (m *LeaseManager) AcquireAndAssertMinVersion(
 	if err != nil {
 		return nil, hlc.Timestamp{}, err
 	}
-	return &table.TableDescriptor, table.expiration, nil
+	return &table.ObjectDescriptor, table.expiration, nil
 }

--- a/pkg/sql/lease_internal_test.go
+++ b/pkg/sql/lease_internal_test.go
@@ -153,7 +153,7 @@ CREATE TABLE t.test (k CHAR PRIMARY KEY, v CHAR);
 
 	tableDesc := sqlbase.GetTableDescriptor(kvDB, "t", "test")
 
-	var tables []sqlbase.TableDescriptor
+	var tables []ObjectDescriptor
 	var expiration hlc.Timestamp
 	getLeases := func() {
 		for i := 0; i < 3; i++ {
@@ -220,8 +220,8 @@ CREATE TABLE t.test (k CHAR PRIMARY KEY, v CHAR);
 	// without a lease.
 	ts.mu.Lock()
 	tableVersion := &tableVersionState{
-		TableDescriptor: tables[0],
-		expiration:      tables[5].ModificationTime,
+		ObjectDescriptor: tables[0],
+		expiration:       tables[5].ModificationTime,
 	}
 	ts.mu.active.insert(tableVersion)
 	ts.mu.Unlock()
@@ -276,7 +276,7 @@ CREATE TABLE t.test (k CHAR PRIMARY KEY, v CHAR);
 	if lease.ID != tableDesc.ID {
 		t.Fatalf("new name has wrong ID: %d (expected: %d)", lease.ID, tableDesc.ID)
 	}
-	if err := leaseManager.Release(&lease.TableDescriptor); err != nil {
+	if err := leaseManager.Release(&lease.ObjectDescriptor); err != nil {
 		t.Fatal(err)
 	}
 
@@ -303,7 +303,7 @@ CREATE TABLE t.test (k CHAR PRIMARY KEY, v CHAR);
 	if lease.ID != tableDesc.ID {
 		t.Fatalf("new name has wrong ID: %d (expected: %d)", lease.ID, tableDesc.ID)
 	}
-	if err := leaseManager.Release(&lease.TableDescriptor); err != nil {
+	if err := leaseManager.Release(&lease.ObjectDescriptor); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -336,7 +336,7 @@ CREATE TABLE t.%s (k CHAR PRIMARY KEY, v CHAR);
 	if lease := leaseManager.tableNames.get(tableDesc.ParentID, tableName, s.Clock().Now()); lease == nil {
 		t.Fatalf("name cache has no unexpired entry for (%d, %s)", tableDesc.ParentID, tableName)
 	} else {
-		if err := leaseManager.Release(&lease.TableDescriptor); err != nil {
+		if err := leaseManager.Release(&lease.ObjectDescriptor); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -421,7 +421,7 @@ CREATE TABLE t.test (k CHAR PRIMARY KEY, v CHAR);
 	// Release.
 	// tableChan acts as a barrier, synchronizing the two routines at every
 	// iteration.
-	tableChan := make(chan *sqlbase.TableDescriptor)
+	tableChan := make(chan *ObjectDescriptor)
 	errChan := make(chan error)
 	go func() {
 		for table := range tableChan {
@@ -603,7 +603,7 @@ func TestLeaseAcquireAndReleaseConcurrently(t *testing.T) {
 
 	// Result is a struct for moving results to the main result routine.
 	type Result struct {
-		table *sqlbase.TableDescriptor
+		table *ObjectDescriptor
 		exp   hlc.Timestamp
 		err   error
 	}
@@ -686,7 +686,7 @@ func TestLeaseAcquireAndReleaseConcurrently(t *testing.T) {
 								}
 							}
 						},
-						LeaseAcquiredEvent: func(_ sqlbase.TableDescriptor, _ error) {
+						LeaseAcquiredEvent: func(_ ObjectDescriptor, _ error) {
 							atomic.AddInt32(&leasesAcquiredCount, 1)
 							<-acquisitionBlock
 						},

--- a/pkg/sql/logical_schema_accessors.go
+++ b/pkg/sql/logical_schema_accessors.go
@@ -67,7 +67,7 @@ func (l *LogicalSchemaAccessor) GetObjectDesc(
 ) (*ObjectDescriptor, *DatabaseDescriptor, error) {
 	if scEntry, ok := l.vt.getVirtualSchemaEntry(name.Schema()); ok {
 		if t, ok := scEntry.tables[name.Table()]; ok {
-			return t.desc, nil, nil
+			return &sqlbase.ExtendedTableDescriptor{TableDescriptor: *t.desc}, nil, nil
 		}
 		if flags.required {
 			return nil, nil, sqlbase.NewUndefinedRelationError(name)

--- a/pkg/sql/opt_catalog.go
+++ b/pkg/sql/opt_catalog.go
@@ -58,10 +58,10 @@ func (oc *optCatalog) FindTable(ctx context.Context, name *tree.TableName) (opt.
 	if oc.wrappers == nil {
 		oc.wrappers = make(map[*sqlbase.TableDescriptor]*optTable)
 	}
-	wrapper, ok := oc.wrappers[desc]
+	wrapper, ok := oc.wrappers[&desc.TableDescriptor]
 	if !ok {
-		wrapper = newOptTable(oc.statsCache, desc)
-		oc.wrappers[desc] = wrapper
+		wrapper = newOptTable(oc.statsCache, &desc.TableDescriptor)
+		oc.wrappers[&desc.TableDescriptor] = wrapper
 	}
 	return wrapper, nil
 }

--- a/pkg/sql/physical_schema_accessors.go
+++ b/pkg/sql/physical_schema_accessors.go
@@ -139,17 +139,22 @@ func (a UncachedPhysicalAccessor) GetObjectDesc(
 			// No: let's see the flag.
 			if err == errTableAdding {
 				// We'll keep that despite the ADD state.
-				return desc, dbDesc, nil
+				obj := sqlbase.NewExtendedTableDescriptor(*desc)
+				return &obj, dbDesc, nil
 			}
 			// Bad state: the descriptor is essentially invisible.
 			desc = nil
 		}
 	}
 
-	if desc == nil && flags.required {
-		return nil, nil, sqlbase.NewUndefinedRelationError(name)
+	if desc == nil {
+		if flags.required {
+			return nil, nil, sqlbase.NewUndefinedRelationError(name)
+		}
+		return nil, dbDesc, nil
 	}
-	return desc, dbDesc, nil
+	obj := sqlbase.NewExtendedTableDescriptor(*desc)
+	return &obj, dbDesc, nil
 }
 
 // CachedPhysicalAccessor adds a cache on top of any SchemaAccessor.

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -401,7 +401,7 @@ func (p *planner) lookupFKTable(
 		}
 		return sqlbase.TableLookup{}, err
 	}
-	return sqlbase.TableLookup{Table: table}, nil
+	return sqlbase.TableLookup{Table: &table.TableDescriptor}, nil
 }
 
 // TypeAsString enforces (not hints) that the given expression typechecks as a

--- a/pkg/sql/rename_column.go
+++ b/pkg/sql/rename_column.go
@@ -37,12 +37,9 @@ func (p *planner) RenameColumn(ctx context.Context, n *tree.RenameColumn) (planN
 	if err != nil {
 		return nil, err
 	}
-	var tableDesc *TableDescriptor
+
 	// DDL statements avoid the cache to avoid leases, and can view non-public descriptors.
-	// TODO(vivek): check if the cache can be used.
-	p.runWithOptions(resolveFlags{skipCache: true}, func() {
-		tableDesc, err = ResolveExistingObject(ctx, p, tn, !n.IfExists, requireTableDesc)
-	})
+	tableDesc, err := ResolveExistingTableFromStore(ctx, p, tn, !n.IfExists, requireTableDesc)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/rename_table.go
+++ b/pkg/sql/rename_table.go
@@ -48,12 +48,8 @@ func (p *planner) RenameTable(ctx context.Context, n *tree.RenameTable) (planNod
 		toRequire = requireSequenceDesc
 	}
 
-	var tableDesc *TableDescriptor
 	// DDL statements avoid the cache to avoid leases, and can view non-public descriptors.
-	// TODO(vivek): check if the cache can be used.
-	p.runWithOptions(resolveFlags{skipCache: true}, func() {
-		tableDesc, err = ResolveExistingObject(ctx, p, oldTn, !n.IfExists, toRequire)
-	})
+	tableDesc, err := ResolveExistingTableFromStore(ctx, p, oldTn, !n.IfExists, toRequire)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/schema_accessors.go
+++ b/pkg/sql/schema_accessors.go
@@ -44,7 +44,7 @@ type (
 	DatabaseDescriptor = sqlbase.DatabaseDescriptor
 	// ObjectDescriptor is provided for convenience and to make the
 	// interface definitions below more intuitive.
-	ObjectDescriptor = sqlbase.TableDescriptor
+	ObjectDescriptor = sqlbase.ExtendedTableDescriptor
 	// TableDescriptor is provided for convenience and to make the
 	// interface definitions below more intuitive.
 	TableDescriptor = sqlbase.TableDescriptor

--- a/pkg/sql/scrub.go
+++ b/pkg/sql/scrub.go
@@ -112,7 +112,7 @@ func (n *scrubNode) startExec(params runParams) error {
 		if err != nil {
 			return err
 		}
-		if err := n.startScrubTable(params.ctx, params.p, tableDesc, tableName); err != nil {
+		if err := n.startScrubTable(params.ctx, params.p, &tableDesc.TableDescriptor, tableName); err != nil {
 			return err
 		}
 	case tree.ScrubDatabase:
@@ -191,7 +191,7 @@ func (n *scrubNode) startScrubDatabase(ctx context.Context, p *planner, name *tr
 		if !tableDesc.IsTable() {
 			continue
 		}
-		if err := n.startScrubTable(ctx, p, tableDesc, tableName); err != nil {
+		if err := n.startScrubTable(ctx, p, &tableDesc.TableDescriptor, tableName); err != nil {
 			return err
 		}
 	}

--- a/pkg/sql/sequence.go
+++ b/pkg/sql/sequence.go
@@ -37,11 +37,7 @@ func (p *planner) IncrementSequence(ctx context.Context, seqName *tree.TableName
 
 	// TODO(vivek,knz): this lookup should really use the cached descriptor.
 	// However tests break if it does.
-	var descriptor *TableDescriptor
-	var err error
-	p.runWithOptions(resolveFlags{skipCache: true}, func() {
-		descriptor, err = ResolveExistingObject(ctx, p, seqName, true /*required*/, requireSequenceDesc)
-	})
+	descriptor, err := ResolveExistingTableFromStore(ctx, p, seqName, true /*required*/, requireSequenceDesc)
 	if err != nil {
 		return 0, err
 	}
@@ -95,11 +91,7 @@ func (p *planner) GetLatestValueInSessionForSequence(
 ) (int64, error) {
 	// TODO(vivek,knz): this lookup should really use the cached descriptor.
 	// However tests break if it does.
-	var descriptor *TableDescriptor
-	var err error
-	p.runWithOptions(resolveFlags{skipCache: true}, func() {
-		descriptor, err = ResolveExistingObject(ctx, p, seqName, true /*required*/, requireSequenceDesc)
-	})
+	descriptor, err := ResolveExistingTableFromStore(ctx, p, seqName, true /*required*/, requireSequenceDesc)
 	if err != nil {
 		return 0, err
 	}
@@ -124,11 +116,7 @@ func (p *planner) SetSequenceValue(
 
 	// TODO(vivek,knz): this lookup should really use the cached descriptor.
 	// However tests break if it does.
-	var descriptor *TableDescriptor
-	var err error
-	p.runWithOptions(resolveFlags{skipCache: true}, func() {
-		descriptor, err = ResolveExistingObject(ctx, p, seqName, true /*required*/, requireSequenceDesc)
-	})
+	descriptor, err := ResolveExistingTableFromStore(ctx, p, seqName, true /*required*/, requireSequenceDesc)
 	if err != nil {
 		return err
 	}
@@ -306,7 +294,7 @@ func maybeAddSequenceDependencies(
 			ID:        tableDesc.ID,
 			ColumnIDs: []sqlbase.ColumnID{col.ID},
 		})
-		seqDescs = append(seqDescs, seqDesc)
+		seqDescs = append(seqDescs, &seqDesc.TableDescriptor)
 	}
 	return seqDescs, nil
 }

--- a/pkg/sql/show_constraints.go
+++ b/pkg/sql/show_constraints.go
@@ -34,14 +34,11 @@ func (p *planner) ShowConstraints(ctx context.Context, n *tree.ShowConstraints) 
 		return nil, err
 	}
 
-	var desc *TableDescriptor
 	// We avoid the cache so that we can observe the constraints without
 	// taking a lease, like other SHOW commands.
 	//
 	// TODO(vivek): check if the cache can be used.
-	p.runWithOptions(resolveFlags{skipCache: true}, func() {
-		desc, err = ResolveExistingObject(ctx, p, tn, true /*required*/, requireTableDesc)
-	})
+	desc, err := ResolveExistingTableFromStore(ctx, p, tn, true /*required*/, requireTableDesc)
 	if err != nil {
 		return nil, sqlbase.NewUndefinedRelationError(tn)
 	}

--- a/pkg/sql/show_fingerprints.go
+++ b/pkg/sql/show_fingerprints.go
@@ -59,14 +59,11 @@ func (p *planner) ShowFingerprints(
 		return nil, err
 	}
 
-	var tableDesc *TableDescriptor
 	// We avoid the cache so that we can observe the fingerprints without
 	// taking a lease, like other SHOW commands.
 	//
 	// TODO(vivek): check if the cache can be used.
-	p.runWithOptions(resolveFlags{skipCache: true}, func() {
-		tableDesc, err = ResolveExistingObject(ctx, p, tn, true /*required*/, requireTableDesc)
-	})
+	tableDesc, err := ResolveExistingTableFromStore(ctx, p, tn, true /*required*/, requireTableDesc)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/show_stats.go
+++ b/pkg/sql/show_stats.go
@@ -48,14 +48,9 @@ func (p *planner) ShowTableStats(ctx context.Context, n *tree.ShowTableStats) (p
 		return nil, err
 	}
 
-	var desc *TableDescriptor
 	// We avoid the cache so that we can observe the stats without
 	// taking a lease, like other SHOW commands.
-	//
-	// TODO(vivek): check if the cache can be used.
-	p.runWithOptions(resolveFlags{skipCache: true}, func() {
-		desc, err = ResolveExistingObject(ctx, p, tn, true /*required*/, requireTableDesc)
-	})
+	desc, err := ResolveExistingTableFromStore(ctx, p, tn, true /*required*/, requireTableDesc)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/show_table.go
+++ b/pkg/sql/show_table.go
@@ -43,9 +43,7 @@ func (p *planner) showTableDetails(
 	// taking a lease, like other SHOW commands.
 	//
 	// TODO(vivek): check if the cache can be used.
-	p.runWithOptions(resolveFlags{skipCache: true}, func() {
-		desc, err = ResolveExistingObject(ctx, p, tn, true /*required*/, anyDescType)
-	})
+	desc, err = ResolveExistingTableFromStore(ctx, p, tn, true /*required*/, anyDescType)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/sqlbase/column_resolver.go
+++ b/pkg/sql/sqlbase/column_resolver.go
@@ -262,8 +262,8 @@ func newAmbiguousSourceError(tn *tree.TableName) error {
 		tree.ErrString(&tn.TableName), tree.ErrString(&tn.CatalogName))
 }
 
-// NameResolutionResult implements the tree.NameResolutionResult interface.
-func (*TableDescriptor) NameResolutionResult() {}
+// ExtendedTableDescriptor implements the tree.NameResolutionResult interface.
+func (*ExtendedTableDescriptor) NameResolutionResult() {}
 
 // SchemaMeta implements the tree.SchemaMeta interface.
 func (*DatabaseDescriptor) SchemaMeta() {}

--- a/pkg/sql/sqlbase/structured.go
+++ b/pkg/sql/sqlbase/structured.go
@@ -175,6 +175,20 @@ func GetTableDescFromID(ctx context.Context, txn *client.Txn, id ID) (*TableDesc
 	return table, nil
 }
 
+// GetExtendedTableDescFromID retrieves the table descriptor for
+// the table ID passed in using an existing txn. Returns an error if the
+// descriptor doesn't exist or if it exists and is not a table.
+func GetExtendedTableDescFromID(
+	ctx context.Context, txn *client.Txn, id ID,
+) (*ExtendedTableDescriptor, error) {
+	table, err := GetTableDescFromID(ctx, txn, id)
+	if err != nil {
+		return nil, err
+	}
+	obj := NewExtendedTableDescriptor(*table)
+	return &obj, nil
+}
+
 // RunOverAllColumns applies its argument fn to each of the column IDs in desc.
 // If there is an error, that error is returned immediately.
 func (desc *IndexDescriptor) RunOverAllColumns(fn func(id ColumnID) error) error {
@@ -2744,4 +2758,15 @@ func (desc *TableDescriptor) FindAllReferences() (map[ID]struct{}, error) {
 		refs[c.ID] = struct{}{}
 	}
 	return refs, nil
+}
+
+// ExtendedTableDescriptor is a TableDescriptor along with some
+// precomputed values. It is meant to be const.
+type ExtendedTableDescriptor struct {
+	TableDescriptor
+}
+
+// NewExtendedTableDescriptor returns a fully constructed ExtendedTableDescriptor.
+func NewExtendedTableDescriptor(table TableDescriptor) ExtendedTableDescriptor {
+	return ExtendedTableDescriptor{TableDescriptor: table}
 }

--- a/pkg/sql/truncate.go
+++ b/pkg/sql/truncate.go
@@ -47,12 +47,7 @@ func (p *planner) Truncate(ctx context.Context, n *tree.Truncate) (planNode, err
 		if err != nil {
 			return nil, err
 		}
-		var tableDesc *TableDescriptor
-		// DDL statements avoid the cache to avoid leases, and can view non-public descriptors.
-		// TODO(vivek): check if the cache can be used.
-		p.runWithOptions(resolveFlags{skipCache: true}, func() {
-			tableDesc, err = ResolveExistingObject(ctx, p, tn, true /*required*/, requireTableDesc)
-		})
+		tableDesc, err := ResolveExistingTableFromStore(ctx, p, tn, true /*required*/, requireTableDesc)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/sql/update.go
+++ b/pkg/sql/update.go
@@ -91,7 +91,7 @@ func (p *planner) Update(
 	// Determine what are the foreign key tables that are involved in the update.
 	fkTables, err := sqlbase.TablesNeededForFKs(
 		ctx,
-		*desc,
+		desc.TableDescriptor,
 		sqlbase.CheckUpdates,
 		p.lookupFKTable,
 		p.CheckPrivilege,
@@ -148,7 +148,7 @@ func (p *planner) Update(
 	// Extract the column descriptors for the column names listed
 	// in the LHS operands of SET expressions. This also checks
 	// that each column is assigned at most once.
-	updateCols, err := p.processColumns(desc, names,
+	updateCols, err := p.processColumns(&desc.TableDescriptor, names,
 		true /* ensureColumns */, false /* allowMutations */)
 	if err != nil {
 		return nil, err
@@ -177,7 +177,7 @@ func (p *planner) Update(
 	// all the computed columns. The computedCols result is an alias for the suffix
 	// of updateCols that corresponds to computed columns.
 	updateCols, computedCols, computeExprs, err :=
-		sqlbase.ProcessComputedColumns(ctx, updateCols, tn, desc, &p.txCtx, p.EvalContext())
+		sqlbase.ProcessComputedColumns(ctx, updateCols, tn, &desc.TableDescriptor, &p.txCtx, p.EvalContext())
 	if err != nil {
 		return nil, err
 	}
@@ -201,7 +201,7 @@ func (p *planner) Update(
 	// process of being added.
 	ru, err := sqlbase.MakeRowUpdater(
 		p.txn,
-		desc,
+		&desc.TableDescriptor,
 		fkTables,
 		updateCols,
 		requestedCols,

--- a/pkg/sql/zone_config.go
+++ b/pkg/sql/zone_config.go
@@ -180,10 +180,11 @@ func (p *planner) resolveTableForZone(
 		if err != nil {
 			return nil, err
 		}
-		res, err = ResolveExistingObject(ctx, p, tn, true /*required*/, anyDescType)
+		obj, err := ResolveExistingObject(ctx, p, tn, true /*required*/, anyDescType)
 		if err != nil {
 			return nil, err
 		}
+		res = &obj.TableDescriptor
 	}
 	return res, err
 }


### PR DESCRIPTION
This change introduces sqlbase.ExtendedTableDescriptor
and makes sql.ObjectDescriptor the same type. The long
term plan is to have the non-schema change sql code use
ExtendedTableDescriptor which is a const type, and the
schema change code that is capable of modifying a table
descriptor to use TableDescriptor directly. The longer
term plan is to also allow ExtendedTableDescriptor hold
const precomputed values that are used across statements.

Introduce ResolveExistingTableFromStore and use it in
some parts of the schema change code.

related to #22275

Release note: None