### PR TITLE
sql: allow BYTES -> JSON casts

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/json
+++ b/pkg/sql/logictest/testdata/logic_test/json
@@ -601,3 +601,11 @@ SELECT '{"a": []}'::JSONB #- ARRAY['a', '0']
 
 statement error pgcode 22P02 a path element is not an integer: foo
 SELECT '{"a": {"b": ["foo"]}}'::JSONB #- ARRAY['a', 'b', 'foo']
+
+query TT
+SELECT b'1'::JSONB, b'2'::JSON
+----
+1 2
+
+statement error could not parse JSON
+SELECT b'\x00'::JSON

--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -3198,6 +3198,8 @@ func PerformCast(ctx *EvalContext, d Datum, t coltypes.CastTargetType) (Datum, e
 		}
 	case *coltypes.TJSON:
 		switch v := d.(type) {
+		case *DBytes:
+			return ParseDJSON(string(*v))
 		case *DString:
 			return ParseDJSON(string(*v))
 		case *DJSON:

--- a/pkg/sql/sem/tree/expr.go
+++ b/pkg/sql/sem/tree/expr.go
@@ -1361,7 +1361,7 @@ var (
 	uuidCastTypes      = []types.T{types.Unknown, types.String, types.FamCollatedString, types.Bytes, types.UUID}
 	inetCastTypes      = []types.T{types.Unknown, types.String, types.FamCollatedString, types.INet}
 	arrayCastTypes     = []types.T{types.Unknown, types.String}
-	jsonCastTypes      = []types.T{types.Unknown, types.String, types.JSON}
+	jsonCastTypes      = []types.T{types.Unknown, types.String, types.JSON, types.Bytes}
 )
 
 // validCastTypes returns a set of types that can be cast into the provided type.


### PR DESCRIPTION
Needed because BYTES -> TEXT casts encode the byte string so things
like '{}'::BYTES::JSON would fail.

Release note (sql change): allow casts from BYTES to JSON.