### PR TITLE
opt: distsql planner fix for index-join

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/select_index
+++ b/pkg/sql/logictest/testdata/logic_test/select_index
@@ -1,4 +1,4 @@
-# LogicTest: default opt parallel-stmts distsql distsql-metadata
+# LogicTest: default opt parallel-stmts distsql distsql-opt distsql-metadata
 
 statement ok
 CREATE TABLE t (


### PR DESCRIPTION
In the heuristic planner, scanNodes always output all columns of the
table (even if some values are missing). This means that an index join
node and both child scanNodes all have the same schema.

With the optimizer, the scanNodes only output the columns that are
needed. The index join node now has its own set of output columns
(added in PR #25292).

This change makes the distsql planner work in both cases; it is
similar to the fix that was necessary for scan nodes.

Also reenabling `distsql-opt` config on the `select_index` logictest.

Release note: None