### PR TITLE
sql, opt: Add pg error codes, tests for error messages

### DIFF
--- a/pkg/sql/data_source.go
+++ b/pkg/sql/data_source.go
@@ -288,7 +288,8 @@ func renameSource(
 		for colIdx, aliasIdx := 0, 0; aliasIdx < len(colAlias); colIdx++ {
 			if colIdx >= len(src.info.SourceColumns) {
 				srcName := tree.ErrString(&tableAlias)
-				return planDataSource{}, errors.Errorf(
+				return planDataSource{}, pgerror.NewErrorf(
+					pgerror.CodeInvalidColumnReferenceError,
 					"source %q has %d columns available but %d columns specified",
 					srcName, aliasIdx, len(colAlias))
 			}

--- a/pkg/sql/group.go
+++ b/pkg/sql/group.go
@@ -27,7 +27,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
-	"github.com/pkg/errors"
 )
 
 // A groupNode implements the planNode interface and handles the grouping logic.
@@ -738,7 +737,7 @@ func (v *extractAggregatesVisitor) VisitPre(expr tree.Expr) (recurse bool, newEx
 		}
 
 	case *tree.IndexedVar:
-		v.err = errors.Errorf(
+		v.err = pgerror.NewErrorf(pgerror.CodeGroupingError,
 			"column \"%s\" must appear in the GROUP BY clause or be used in an aggregate function",
 			t)
 		return false, expr

--- a/pkg/sql/join.go
+++ b/pkg/sql/join.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"unsafe"
 
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
@@ -167,8 +168,11 @@ func (p *planner) makeJoin(
 				// ambiguity later.
 				continue
 			}
-			return planDataSource{}, fmt.Errorf(
-				"cannot join columns from the same source name %q (missing AS clause)", t)
+			return planDataSource{}, pgerror.NewErrorf(
+				pgerror.CodeDuplicateAliasError,
+				"source name %q specified more than once (missing AS clause)",
+				t,
+			)
 		}
 	}
 

--- a/pkg/sql/logictest/testdata/logic_test/aggregate
+++ b/pkg/sql/logictest/testdata/logic_test/aggregate
@@ -185,7 +185,7 @@ SELECT 3 FROM kv HAVING TRUE
 ----
 3
 
-query error column "k" must appear in the GROUP BY clause or be used in an aggregate function
+query error pgcode 42803 column "k" must appear in the GROUP BY clause or be used in an aggregate function
 SELECT COUNT(*), k FROM kv
 
 query error unsupported comparison operator: <string> < <int>
@@ -230,13 +230,13 @@ SELECT SUM(v) FROM kv GROUP BY k LIMIT 1 OFFSET SUM(v)
 query error aggregate functions are not allowed in VALUES
 INSERT INTO kv (k, v) VALUES (99, COUNT(1))
 
-query error GROUP BY position 5 is not in select list
+query error pgcode 42P10 GROUP BY position 5 is not in select list
 SELECT COUNT(*), k FROM kv GROUP BY 5
 
-query error GROUP BY position 0 is not in select list
+query error pgcode 42P10 GROUP BY position 0 is not in select list
 SELECT COUNT(*), k FROM kv GROUP BY 0
 
-query error non-integer constant in GROUP BY
+query error pgcode 42601 non-integer constant in GROUP BY
 SELECT 1 GROUP BY 'a'
 
 # Qualifying a name in the SELECT, the GROUP BY, both or neither should not affect validation.

--- a/pkg/sql/logictest/testdata/logic_test/join
+++ b/pkg/sql/logictest/testdata/logic_test/join
@@ -454,10 +454,10 @@ CREATE TABLE othertype (x TEXT)
 query error pgcode 42804 JOIN/USING types.*cannot be matched
 SELECT * FROM (onecolumn AS a JOIN othertype AS b USING(x))
 
-query error cannot join columns from the same source name "onecolumn"
+query error pgcode 42712 source name "onecolumn" specified more than once \(missing AS clause\)
 SELECT * FROM (onecolumn JOIN onecolumn USING(x))
 
-query error cannot join columns from the same source name "onecolumn"
+query error pgcode 42712 source name "onecolumn" specified more than once \(missing AS clause\)
 SELECT * FROM (onecolumn JOIN twocolumn USING(x) JOIN onecolumn USING(x))
 
 # Check that star expansion works across anonymous sources.

--- a/pkg/sql/logictest/testdata/logic_test/order_by
+++ b/pkg/sql/logictest/testdata/logic_test/order_by
@@ -165,22 +165,22 @@ query I
 3
 2
 
-query error multiple ORDER BY clauses not allowed
+query error pgcode 42601 multiple ORDER BY clauses not allowed
 ((SELECT a FROM t ORDER BY a)) ORDER BY a
 
 query error expected c to be of type int, found type bool
 SELECT CASE a WHEN 1 THEN b ELSE c END as val FROM t ORDER BY val
 
-query error ORDER BY position 0 is not in select list
+query error pgcode 42P10 ORDER BY position 0 is not in select list
 SELECT * FROM t ORDER BY 0
 
-query error non-integer constant in ORDER BY: true
+query error pgcode 42601 non-integer constant in ORDER BY: true
 SELECT * FROM t ORDER BY true
 
-query error non-integer constant in ORDER BY: 'a'
+query error pgcode 42601 non-integer constant in ORDER BY: 'a'
 SELECT * FROM t ORDER BY 'a'
 
-query error non-integer constant in ORDER BY: 2\.5
+query error pgcode 42601 non-integer constant in ORDER BY: 2\.5
 SELECT * FROM t ORDER BY 2.5
 
 query error column "foo" does not exist

--- a/pkg/sql/logictest/testdata/logic_test/select
+++ b/pkg/sql/logictest/testdata/logic_test/select
@@ -276,7 +276,7 @@ query IIII
 SELECT * FROM xyzw LIMIT (RANDOM() * 0.0)::int OFFSET (RANDOM() * 0.0)::int
 ----
 
-query error multiple LIMIT clauses not allowed
+query error pgcode 42601 multiple LIMIT clauses not allowed
 ((SELECT a FROM t LIMIT 1)) LIMIT 1
 
 query IIII

--- a/pkg/sql/logictest/testdata/logic_test/select_table_alias
+++ b/pkg/sql/logictest/testdata/logic_test/select_table_alias
@@ -89,7 +89,7 @@ SELECT foo.a FROM abc AS foo (foo1)
 
 # Verify error for too many column aliases.
 
-query error source "foo" has 3 columns available but 4 columns specified
+query error pgcode 42P10 source "foo" has 3 columns available but 4 columns specified
 SELECT * FROM abc AS foo (foo1, foo2, foo3, foo4)
 
 

--- a/pkg/sql/logictest/testdata/logic_test/subquery
+++ b/pkg/sql/logictest/testdata/logic_test/subquery
@@ -142,7 +142,7 @@ SELECT (1, 2) = ALL(SELECT 1, 2)
 ----
 true
 
-query error subquery must return only one column, found 2
+query error pgcode 42601 subquery must return only one column, found 2
 SELECT (SELECT 1, 2)
 
 query error unsupported comparison operator: <int> IN <tuple{tuple{int, int}}>
@@ -233,7 +233,7 @@ SELECT * FROM xyz
 statement error value type tuple{int, int} doesn't match type INT of column "z"
 UPDATE xyz SET z = (SELECT (10, 11)) WHERE x = 7
 
-statement error subquery must return 2 columns, found 1
+statement error pgcode 42601 subquery must return 2 columns, found 1
 UPDATE xyz SET (y, z) = (SELECT (11, 12)) WHERE x = 7
 
 #regression, see #6852

--- a/pkg/sql/logictest/testdata/logic_test/union
+++ b/pkg/sql/logictest/testdata/logic_test/union
@@ -171,22 +171,22 @@ SELECT * FROM (VALUES (1)) a LEFT JOIN (VALUES (1) UNION VALUES (2)) b on a.colu
 ----
 1 1
 
-query error each UNION query must have the same number of columns: 2 vs 1
+query error pgcode 42601 each UNION query must have the same number of columns: 2 vs 1
 SELECT 1, 2 UNION SELECT 3
 
-query error each INTERSECT query must have the same number of columns: 2 vs 1
+query error pgcode 42601 each INTERSECT query must have the same number of columns: 2 vs 1
 SELECT 1, 2 INTERSECT SELECT 3
 
-query error each EXCEPT query must have the same number of columns: 2 vs 1
+query error pgcode 42601 each EXCEPT query must have the same number of columns: 2 vs 1
 SELECT 1, 2 EXCEPT SELECT 3
 
-query error UNION types int and string cannot be matched
+query error pgcode 42804 UNION types int and string cannot be matched
 SELECT 1 UNION SELECT '3'
 
-query error INTERSECT types int and string cannot be matched
+query error pgcode 42804 INTERSECT types int and string cannot be matched
 SELECT 1 INTERSECT SELECT '3'
 
-query error EXCEPT types int and string cannot be matched
+query error pgcode 42804 EXCEPT types int and string cannot be matched
 SELECT 1 EXCEPT SELECT '3'
 
 query error pgcode 42703 column \"z\" does not exist

--- a/pkg/sql/logictest/testdata/logic_test/values
+++ b/pkg/sql/logictest/testdata/logic_test/values
@@ -33,7 +33,7 @@ SELECT a + b FROM (VALUES (1, 2), (3, 4), (5, 6)) AS v(a, b)
 7
 11
 
-query error VALUES lists must all be the same length, expected 1 columns, found 2
+query error pgcode 42601 VALUES lists must all be the same length, expected 1 columns, found 2
 VALUES (1), (2, 3)
 
 query I
@@ -52,3 +52,6 @@ VALUES ((SELECT 1)), ((SELECT 2))
 ----
 1
 2
+
+query error pgcode 42804 VALUES types string and int cannot be matched
+VALUES (NULL, 1), (2, NULL), (NULL, 'a')

--- a/pkg/sql/opt/optbuilder/builder.go
+++ b/pkg/sql/opt/optbuilder/builder.go
@@ -16,7 +16,6 @@ package optbuilder
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
@@ -138,13 +137,6 @@ func (b *Builder) Build() (root memo.GroupID, required *props.Physical, err erro
 // back to errors inside Builder.Build.
 type builderError struct {
 	error
-}
-
-// errorf formats according to a format specifier and returns the string as a
-// builderError.
-func errorf(format string, a ...interface{}) builderError {
-	err := fmt.Errorf(format, a...)
-	return builderError{err}
 }
 
 // unimplementedf formats according to a format specifier and returns a Postgres

--- a/pkg/sql/opt/optbuilder/distinct.go
+++ b/pkg/sql/opt/optbuilder/distinct.go
@@ -16,6 +16,7 @@ package optbuilder
 
 import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 )
 
@@ -56,7 +57,10 @@ func (b *Builder) buildDistinct(
 	// CockroachDB, so we may need to support it eventually.
 	for _, col := range outScope.physicalProps.Ordering {
 		if !outScope.hasColumn(col.ID()) {
-			panic(errorf("for SELECT DISTINCT, ORDER BY expressions must appear in select list"))
+			panic(builderError{pgerror.NewErrorf(
+				pgerror.CodeInvalidColumnReferenceError,
+				"for SELECT DISTINCT, ORDER BY expressions must appear in select list",
+			)})
 		}
 	}
 

--- a/pkg/sql/opt/optbuilder/explain.go
+++ b/pkg/sql/opt/optbuilder/explain.go
@@ -15,6 +15,8 @@
 package optbuilder
 
 import (
+	"fmt"
+
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
@@ -47,7 +49,7 @@ func (b *Builder) buildExplain(explain *tree.Explain, inScope *scope) (outScope 
 		cols = sqlbase.ExplainDistSQLColumns
 
 	default:
-		panic(errorf("unsupported EXPLAIN mode"))
+		panic(fmt.Errorf("unsupported EXPLAIN mode: %d", opts.Mode))
 	}
 	b.synthesizeResultColumns(outScope, cols)
 

--- a/pkg/sql/opt/optbuilder/join.go
+++ b/pkg/sql/opt/optbuilder/join.go
@@ -93,10 +93,11 @@ func (b *Builder) validateJoinTableNames(leftTables map[string]struct{}, rightSc
 			continue
 		}
 		if _, ok := leftTables[t.FQString()]; ok {
-			panic(errorf(
-				"cannot join columns from the same source name %q (missing AS clause)",
+			panic(builderError{pgerror.NewErrorf(
+				pgerror.CodeDuplicateAliasError,
+				"source name %q specified more than once (missing AS clause)",
 				tree.ErrString(&t.TableName),
-			))
+			)})
 		}
 	}
 }

--- a/pkg/sql/opt/optbuilder/scope.go
+++ b/pkg/sql/opt/optbuilder/scope.go
@@ -296,7 +296,7 @@ func (s *scope) startAggFunc() (aggInScope *scope, aggOutScope *scope) {
 		}
 	}
 
-	panic(errorf("aggregate function is not allowed in this context"))
+	panic(fmt.Errorf("aggregate function is not allowed in this context"))
 }
 
 // endAggFunc is called when the builder finishes building an aggregate
@@ -306,7 +306,7 @@ func (s *scope) startAggFunc() (aggInScope *scope, aggOutScope *scope) {
 // added.
 func (s *scope) endAggFunc() {
 	if !s.groupby.inAgg {
-		panic(errorf("mismatched calls to start/end aggFunc"))
+		panic(fmt.Errorf("mismatched calls to start/end aggFunc"))
 	}
 	s.groupby.inAgg = false
 }
@@ -647,9 +647,11 @@ func (s *scope) replaceSubquery(sub *tree.Subquery, multiRow bool, desiredColumn
 		n := len(outScope.cols)
 		switch desiredColumns {
 		case 1:
-			panic(errorf("subquery must return only one column, found %d", n))
+			panic(builderError{pgerror.NewErrorf(pgerror.CodeSyntaxError,
+				"subquery must return only one column, found %d", n)})
 		default:
-			panic(errorf("subquery must return %d columns, found %d", desiredColumns, n))
+			panic(builderError{pgerror.NewErrorf(pgerror.CodeSyntaxError,
+				"subquery must return %d columns, found %d", desiredColumns, n)})
 		}
 	}
 

--- a/pkg/sql/opt/optbuilder/show_trace.go
+++ b/pkg/sql/opt/optbuilder/show_trace.go
@@ -15,6 +15,8 @@
 package optbuilder
 
 import (
+	"fmt"
+
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/props"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -49,7 +51,7 @@ func (b *Builder) buildShowTrace(showTrace *tree.ShowTrace, inScope *scope) (out
 		b.synthesizeResultColumns(outScope, sqlbase.ShowReplicaTraceColumns)
 
 	default:
-		panic(errorf("SHOW %s not supported", showTrace.TraceType))
+		panic(fmt.Errorf("SHOW %s not supported", showTrace.TraceType))
 	}
 
 	def := memo.ShowTraceOpDef{

--- a/pkg/sql/opt/optbuilder/subquery.go
+++ b/pkg/sql/opt/optbuilder/subquery.go
@@ -265,7 +265,9 @@ func (b *Builder) buildMultiRowSubquery(
 		}
 
 	default:
-		panic(fmt.Errorf("transformSubquery called with operator %v", c.Operator))
+		panic(fmt.Errorf(
+			"buildMultiRowSubquery called with operator %v", c.Operator,
+		))
 	}
 
 	// Construct the outer Any(...) operator.

--- a/pkg/sql/opt/optbuilder/testdata/aggregate
+++ b/pkg/sql/opt/optbuilder/testdata/aggregate
@@ -273,7 +273,7 @@ project
 build
 SELECT COUNT(*), k FROM kv
 ----
-error: column "k" must appear in the GROUP BY clause or be used in an aggregate function
+error (42803): column "k" must appear in the GROUP BY clause or be used in an aggregate function
 
 build
 SELECT COUNT(*) FROM kv GROUP BY s < 5
@@ -339,17 +339,17 @@ error (42803): aggregate functions are not allowed in VALUES
 build
 SELECT COUNT(*), k FROM kv GROUP BY 5
 ----
-error: GROUP BY position 5 is not in select list
+error (42P10): GROUP BY position 5 is not in select list
 
 build
 SELECT COUNT(*), k FROM kv GROUP BY 0
 ----
-error: GROUP BY position 0 is not in select list
+error (42P10): GROUP BY position 0 is not in select list
 
 build
 SELECT 1 GROUP BY 'a'
 ----
-error: non-integer constant in GROUP BY: 'a'
+error (42601): non-integer constant in GROUP BY: 'a'
 
 # Qualifying a name in the SELECT, the GROUP BY, both or neither should not affect validation.
 build
@@ -522,7 +522,7 @@ project
 build
 SELECT COUNT(*), s FROM kv GROUP BY UPPER(s)
 ----
-error: column "s" must appear in the GROUP BY clause or be used in an aggregate function
+error (42803): column "s" must appear in the GROUP BY clause or be used in an aggregate function
 
 # Selecting and grouping on a more complex expression works.
 build
@@ -570,17 +570,17 @@ project
 build
 SELECT COUNT(*), k+v FROM kv GROUP BY k
 ----
-error: column "v" must appear in the GROUP BY clause or be used in an aggregate function
+error (42803): column "v" must appear in the GROUP BY clause or be used in an aggregate function
 
 build
 SELECT COUNT(*), k+v FROM kv GROUP BY v
 ----
-error: column "k" must appear in the GROUP BY clause or be used in an aggregate function
+error (42803): column "k" must appear in the GROUP BY clause or be used in an aggregate function
 
 build
 SELECT COUNT(*), v/(k+v) FROM kv GROUP BY k+v
 ----
-error: column "v" must appear in the GROUP BY clause or be used in an aggregate function
+error (42803): column "v" must appear in the GROUP BY clause or be used in an aggregate function
 
 build
 SELECT k FROM kv WHERE AVG(k) > 1
@@ -2022,7 +2022,7 @@ project
 build
 SELECT b1.b AND abc.c AND abc.c FROM bools b1, bools b2, abc GROUP BY b1.b AND abc.c, b2.b
 ----
-error: column "c" must appear in the GROUP BY clause or be used in an aggregate function
+error (42803): column "c" must appear in the GROUP BY clause or be used in an aggregate function
 
 build
 SELECT b1.b OR abc.c OR b2.b FROM bools b1, bools b2, abc GROUP BY b1.b OR abc.c, b2.b
@@ -2058,7 +2058,7 @@ project
 build
 SELECT b1.b OR abc.c OR abc.c FROM bools b1, bools b2, abc GROUP BY b1.b OR abc.c, b2.b
 ----
-error: column "c" must appear in the GROUP BY clause or be used in an aggregate function
+error (42803): column "c" must appear in the GROUP BY clause or be used in an aggregate function
 
 build
 SELECT k % w % v FROM kv GROUP BY k % w, v
@@ -2110,7 +2110,7 @@ project
 build
 SELECT CONCAT(CONCAT(s, a), s) FROM kv, abc GROUP BY CONCAT(s, a), a
 ----
-error: column "s" must appear in the GROUP BY clause or be used in an aggregate function
+error (42803): column "s" must appear in the GROUP BY clause or be used in an aggregate function
 
 build
 SELECT k < w AND v != 5 FROM kv GROUP BY k < w, v
@@ -2138,7 +2138,7 @@ project
 build
 SELECT k < w AND k < v FROM kv GROUP BY k < w, v
 ----
-error: column "k" must appear in the GROUP BY clause or be used in an aggregate function
+error (42803): column "k" must appear in the GROUP BY clause or be used in an aggregate function
 
 exec-ddl
 CREATE TABLE foo (bar JSON, baz JSON)
@@ -2181,7 +2181,7 @@ project
 build
 SELECT a.bar @> b.baz AND b.baz @> b.baz FROM foo AS a, foo AS b GROUP BY b.baz <@ a.bar, b.baz
 ----
-error: column "bar" must appear in the GROUP BY clause or be used in an aggregate function
+error (42803): column "bar" must appear in the GROUP BY clause or be used in an aggregate function
 
 build
 SELECT b.baz <@ a.bar AND b.baz <@ b.baz FROM foo AS a, foo AS b GROUP BY b.baz <@ a.bar, b.baz
@@ -2253,7 +2253,7 @@ build
 SELECT date_trunc('second', a.t) - date_trunc('second', b.t) FROM times a, times b
   GROUP BY date_trunc('second', a.t), date_trunc('minute', b.t)
 ----
-error: column "t" must appear in the GROUP BY clause or be used in an aggregate function
+error (42803): column "t" must appear in the GROUP BY clause or be used in an aggregate function
 
 build
 SELECT NOT b FROM bools GROUP BY NOT b
@@ -2272,7 +2272,7 @@ group-by
 build
 SELECT b FROM bools GROUP BY NOT b
 ----
-error: column "b" must appear in the GROUP BY clause or be used in an aggregate function
+error (42803): column "b" must appear in the GROUP BY clause or be used in an aggregate function
 
 build
 SELECT NOT b FROM bools GROUP BY b
@@ -2314,7 +2314,7 @@ project
 build
 SELECT k * (-w) FROM kv GROUP BY +k, -w
 ----
-error: column "k" must appear in the GROUP BY clause or be used in an aggregate function
+error (42803): column "k" must appear in the GROUP BY clause or be used in an aggregate function
 
 build
 SELECT +k * (-w) FROM kv GROUP BY k, w

--- a/pkg/sql/opt/optbuilder/testdata/distinct
+++ b/pkg/sql/opt/optbuilder/testdata/distinct
@@ -148,7 +148,7 @@ error (22023): unsupported binary operator: <int> + <float>
 build
 SELECT DISTINCT y AS w FROM xyz ORDER by z
 ----
-error: for SELECT DISTINCT, ORDER BY expressions must appear in select list
+error (42P10): for SELECT DISTINCT, ORDER BY expressions must appear in select list
 
 build
 SELECT DISTINCT y AS w FROM xyz ORDER by y

--- a/pkg/sql/opt/optbuilder/testdata/having
+++ b/pkg/sql/opt/optbuilder/testdata/having
@@ -113,19 +113,19 @@ error (42804): argument of HAVING must be type bool, not type int
 build
 SELECT 3 FROM kv GROUP BY v HAVING k > 5
 ----
-error: column "k" must appear in the GROUP BY clause or be used in an aggregate function
+error (42803): column "k" must appear in the GROUP BY clause or be used in an aggregate function
 
 # pg has a special case for grouping on primary key, which would allow this, but we do not.
 # See http://www.postgresql.org/docs/current/static/sql-select.html#SQL-GROUPBY
 build
 SELECT 3 FROM kv GROUP BY k HAVING v > 2
 ----
-error: column "v" must appear in the GROUP BY clause or be used in an aggregate function
+error (42803): column "v" must appear in the GROUP BY clause or be used in an aggregate function
 
 build
 SELECT k FROM kv HAVING k > 7
 ----
-error: column "k" must appear in the GROUP BY clause or be used in an aggregate function
+error (42803): column "k" must appear in the GROUP BY clause or be used in an aggregate function
 
 build
 SELECT count(*), k+w FROM kv GROUP BY k+w HAVING (k+w) > 5
@@ -155,7 +155,7 @@ project
 build
 SELECT count(*), k+w FROM kv GROUP BY k+w HAVING (k+v) > 5
 ----
-error: column "k" must appear in the GROUP BY clause or be used in an aggregate function
+error (42803): column "k" must appear in the GROUP BY clause or be used in an aggregate function
 
 # Check that everything still works with differently qualified names
 build
@@ -259,7 +259,7 @@ project
 build fully-qualify-names
 SELECT t.kv.v FROM t.kv GROUP BY v, kv.k * w HAVING w > 5
 ----
-error: column "w" must appear in the GROUP BY clause or be used in an aggregate function
+error (42803): column "w" must appear in the GROUP BY clause or be used in an aggregate function
 
 build fully-qualify-names
 SELECT UPPER(s), COUNT(s), COUNT(UPPER(s)) FROM t.kv GROUP BY UPPER(s) HAVING COUNT(s) > 1

--- a/pkg/sql/opt/optbuilder/testdata/inner-join
+++ b/pkg/sql/opt/optbuilder/testdata/inner-join
@@ -131,12 +131,12 @@ inner-join
 build fully-qualify-names
 SELECT * FROM a, a
 ----
-error: cannot join columns from the same source name "a" (missing AS clause)
+error (42712): source name "a" specified more than once (missing AS clause)
 
 build fully-qualify-names
 SELECT * FROM t.a, a
 ----
-error: cannot join columns from the same source name "a" (missing AS clause)
+error (42712): source name "a" specified more than once (missing AS clause)
 
 build fully-qualify-names
 SELECT * FROM t.a, a AS a

--- a/pkg/sql/opt/optbuilder/testdata/join
+++ b/pkg/sql/opt/optbuilder/testdata/join
@@ -1194,12 +1194,12 @@ error (42804): JOIN/USING types int for left and string for right cannot be matc
 build
 SELECT * FROM (onecolumn JOIN onecolumn USING(x))
 ----
-error: cannot join columns from the same source name "onecolumn" (missing AS clause)
+error (42712): source name "onecolumn" specified more than once (missing AS clause)
 
 build
 SELECT * FROM (onecolumn JOIN twocolumn USING(x) JOIN onecolumn USING(x))
 ----
-error: cannot join columns from the same source name "onecolumn" (missing AS clause)
+error (42712): source name "onecolumn" specified more than once (missing AS clause)
 
 # Check that star expansion works across anonymous sources.
 build

--- a/pkg/sql/opt/optbuilder/testdata/orderby
+++ b/pkg/sql/opt/optbuilder/testdata/orderby
@@ -91,7 +91,7 @@ sort
 build
 SELECT DISTINCT c FROM t ORDER BY b DESC
 ----
-error: for SELECT DISTINCT, ORDER BY expressions must appear in select list
+error (42P10): for SELECT DISTINCT, ORDER BY expressions must appear in select list
 
 build
 SELECT a AS foo, b FROM t ORDER BY foo DESC
@@ -362,7 +362,7 @@ limit
 build
 ((SELECT a FROM t ORDER BY a)) ORDER BY a
 ----
-error: multiple ORDER BY clauses not allowed
+error (42601): multiple ORDER BY clauses not allowed
 
 build
 SELECT CASE a WHEN 1 THEN b ELSE c END as val FROM t ORDER BY val
@@ -372,22 +372,22 @@ error: incompatible value type: expected c to be of type int, found type bool
 build
 SELECT * FROM t ORDER BY 0
 ----
-error: ORDER BY position 0 is not in select list
+error (42P10): ORDER BY position 0 is not in select list
 
 build
 SELECT * FROM t ORDER BY true
 ----
-error: non-integer constant in ORDER BY: true
+error (42601): non-integer constant in ORDER BY: true
 
 build
 SELECT * FROM t ORDER BY 'a'
 ----
-error: non-integer constant in ORDER BY: 'a'
+error (42601): non-integer constant in ORDER BY: 'a'
 
 build
 SELECT * FROM t ORDER BY 2.5
 ----
-error: non-integer constant in ORDER BY: 2.5
+error (42601): non-integer constant in ORDER BY: 2.5
 
 build
 SELECT * FROM t ORDER BY foo
@@ -908,3 +908,8 @@ project
  └── scan abcd
       ├── columns: a:1(int!null) b:2(int) c:3(int) d:4(int)
       └── ordering: +1,+2,+3
+
+build
+SELECT ARRAY[a] FROM abcd ORDER BY 1
+----
+error (0A000): can't order by column type int[]

--- a/pkg/sql/opt/optbuilder/testdata/select
+++ b/pkg/sql/opt/optbuilder/testdata/select
@@ -509,7 +509,7 @@ limit
 build
 ((SELECT x FROM xyzw LIMIT 1)) LIMIT 1
 ----
-error: multiple LIMIT clauses not allowed
+error (42601): multiple LIMIT clauses not allowed
 
 build
 SELECT * FROM (SELECT * FROM xyzw LIMIT 5) OFFSET 5
@@ -1062,4 +1062,4 @@ error (0A000): AS OF clause not supported
 build
 SELECT * FROM a AS t(a, b, c)
 ----
-error: source "t" has 2 columns available but 3 columns specified
+error (42P10): source "t" has 2 columns available but 3 columns specified

--- a/pkg/sql/opt/optbuilder/testdata/subquery
+++ b/pkg/sql/opt/optbuilder/testdata/subquery
@@ -616,7 +616,7 @@ project
 build
 SELECT (SELECT 1, 2)
 ----
-error: subquery must return only one column, found 2
+error (42601): subquery must return only one column, found 2
 
 build
 SELECT 1 IN (SELECT 1, 2)
@@ -696,7 +696,7 @@ project
 build
 SELECT (SELECT * FROM abc)
 ----
-error: subquery must return only one column, found 3
+error (42601): subquery must return only one column, found 3
 
 build
 SELECT (SELECT a FROM abc)

--- a/pkg/sql/opt/optbuilder/testdata/union
+++ b/pkg/sql/opt/optbuilder/testdata/union
@@ -704,32 +704,32 @@ left-join
 build
 SELECT 1, 2 UNION SELECT 3
 ----
-error: each UNION query must have the same number of columns: 2 vs 1
+error (42601): each UNION query must have the same number of columns: 2 vs 1
 
 build
 SELECT 1, 2 INTERSECT SELECT 3
 ----
-error: each INTERSECT query must have the same number of columns: 2 vs 1
+error (42601): each INTERSECT query must have the same number of columns: 2 vs 1
 
 build
 SELECT 1, 2 EXCEPT SELECT 3
 ----
-error: each EXCEPT query must have the same number of columns: 2 vs 1
+error (42601): each EXCEPT query must have the same number of columns: 2 vs 1
 
 build
 SELECT 1 UNION SELECT '3'
 ----
-error: UNION types int and string cannot be matched
+error (42804): UNION types int and string cannot be matched
 
 build
 SELECT 1 INTERSECT SELECT '3'
 ----
-error: INTERSECT types int and string cannot be matched
+error (42804): INTERSECT types int and string cannot be matched
 
 build
 SELECT 1 EXCEPT SELECT '3'
 ----
-error: EXCEPT types int and string cannot be matched
+error (42804): EXCEPT types int and string cannot be matched
 
 # TODO(rytaft): Error message should be `pgcode 42703 column "z" does not exist`
 build
@@ -740,7 +740,7 @@ error (42703): column "z" does not exist
 build
 SELECT ARRAY[1] UNION ALL SELECT ARRAY['foo']
 ----
-error: UNION types int[] and string[] cannot be matched
+error (42804): UNION types int[] and string[] cannot be matched
 
 exec-ddl
 CREATE TABLE t.xy (x STRING NOT NULL, y STRING NOT NULL)

--- a/pkg/sql/opt/optbuilder/testdata/values
+++ b/pkg/sql/opt/optbuilder/testdata/values
@@ -25,7 +25,7 @@ values
 build
 VALUES (1), (2, 3)
 ----
-error: VALUES lists must all be the same length, expected 1 columns, found 2
+error (42601): VALUES lists must all be the same length, expected 1 columns, found 2
 
 build
 VALUES (1), (1), (2), (3) ORDER BY 1 DESC LIMIT 3
@@ -57,7 +57,7 @@ error (42703): column "z" does not exist
 build
 VALUES ('this', 'is', 'a', 'test'), (1, 2, 3, 4)
 ----
-error: VALUES list type mismatch, int for string
+error (42804): VALUES types int and string cannot be matched
 
 build
 VALUES ('one', 1, 1.0), ('two', 2, 2.0)
@@ -129,7 +129,7 @@ values
 build
 VALUES (NULL, 1), (2, NULL), (NULL, 'a')
 ----
-error: VALUES list type mismatch, string for int
+error (42804): VALUES types string and int cannot be matched
 
 build
 SELECT COALESCE(a, b) FROM (VALUES (1, 2), (3, NULL), (NULL, 4), (NULL, NULL)) AS v(a, b)

--- a/pkg/sql/opt/optbuilder/testdata/window
+++ b/pkg/sql/opt/optbuilder/testdata/window
@@ -1,0 +1,30 @@
+exec-ddl
+CREATE TABLE kv (
+  k INT PRIMARY KEY,
+  v INT,
+  w INT,
+  s STRING
+)
+----
+TABLE kv
+ ├── k int not null
+ ├── v int
+ ├── w int
+ ├── s string
+ └── INDEX primary
+      └── k int not null
+
+build
+SELECT avg(k) OVER (PARTITION BY v) FROM kv ORDER BY 1
+----
+error (0A000): window functions are not supported
+
+build
+SELECT avg(avg(k) OVER ()) FROM kv ORDER BY 1
+----
+error (42803): aggregate function calls cannot contain window function calls
+
+build
+SELECT * FROM kv GROUP BY v, COUNT(w) OVER ()
+----
+error (42P20): window functions are not allowed in GROUP BY

--- a/pkg/sql/opt/optbuilder/testdata/with
+++ b/pkg/sql/opt/optbuilder/testdata/with
@@ -1,0 +1,23 @@
+exec-ddl
+CREATE TABLE x(a INT)
+----
+TABLE x
+ ├── a int
+ ├── rowid int not null (hidden)
+ └── INDEX primary
+      └── rowid int not null (hidden)
+
+exec-ddl
+CREATE TABLE y(a INT)
+----
+TABLE y
+ ├── a int
+ ├── rowid int not null (hidden)
+ └── INDEX primary
+      └── rowid int not null (hidden)
+
+build
+WITH t AS (SELECT a FROM y WHERE a < 3)
+  SELECT * FROM x NATURAL JOIN t
+----
+error (0A000): with clause not supported

--- a/pkg/sql/opt/optbuilder/util.go
+++ b/pkg/sql/opt/optbuilder/util.go
@@ -147,20 +147,30 @@ func colIndex(numOriginalCols int, expr tree.Expr, context string) int {
 			}
 			ord = val
 		} else {
-			panic(errorf("non-integer constant in %s: %s", context, expr))
+			panic(builderError{pgerror.NewErrorf(
+				pgerror.CodeSyntaxError,
+				"non-integer constant in %s: %s", context, expr,
+			)})
 		}
 	case *tree.DInt:
 		if *i >= 0 {
 			ord = int64(*i)
 		}
 	case *tree.StrVal:
-		panic(errorf("non-integer constant in %s: %s", context, expr))
+		panic(builderError{pgerror.NewErrorf(
+			pgerror.CodeSyntaxError, "non-integer constant in %s: %s", context, expr,
+		)})
 	case tree.Datum:
-		panic(errorf("non-integer constant in %s: %s", context, expr))
+		panic(builderError{pgerror.NewErrorf(
+			pgerror.CodeSyntaxError, "non-integer constant in %s: %s", context, expr,
+		)})
 	}
 	if ord != -1 {
 		if ord < 1 || ord > int64(numOriginalCols) {
-			panic(errorf("%s position %s is not in select list", context, expr))
+			panic(builderError{pgerror.NewErrorf(
+				pgerror.CodeInvalidColumnReferenceError,
+				"%s position %s is not in select list", context, expr,
+			)})
 		}
 		ord--
 	}

--- a/pkg/sql/render.go
+++ b/pkg/sql/render.go
@@ -101,13 +101,17 @@ func (p *planner) Select(
 		wrapped = s.Select.Select
 		if s.Select.OrderBy != nil {
 			if orderBy != nil {
-				return nil, fmt.Errorf("multiple ORDER BY clauses not allowed")
+				return nil, pgerror.NewErrorf(
+					pgerror.CodeSyntaxError, "multiple ORDER BY clauses not allowed",
+				)
 			}
 			orderBy = s.Select.OrderBy
 		}
 		if s.Select.Limit != nil {
 			if limit != nil {
-				return nil, fmt.Errorf("multiple LIMIT clauses not allowed")
+				return nil, pgerror.NewErrorf(
+					pgerror.CodeSyntaxError, "multiple LIMIT clauses not allowed",
+				)
 			}
 			limit = s.Select.Limit
 		}

--- a/pkg/sql/sort.go
+++ b/pkg/sql/sort.go
@@ -461,20 +461,30 @@ func (p *planner) colIndex(numOriginalCols int, expr tree.Expr, context string) 
 			}
 			ord = val
 		} else {
-			return -1, errors.Errorf("non-integer constant in %s: %s", context, expr)
+			return -1, pgerror.NewErrorf(
+				pgerror.CodeSyntaxError,
+				"non-integer constant in %s: %s", context, expr,
+			)
 		}
 	case *tree.DInt:
 		if *i >= 0 {
 			ord = int64(*i)
 		}
 	case *tree.StrVal:
-		return -1, errors.Errorf("non-integer constant in %s: %s", context, expr)
+		return -1, pgerror.NewErrorf(
+			pgerror.CodeSyntaxError, "non-integer constant in %s: %s", context, expr,
+		)
 	case tree.Datum:
-		return -1, errors.Errorf("non-integer constant in %s: %s", context, expr)
+		return -1, pgerror.NewErrorf(
+			pgerror.CodeSyntaxError, "non-integer constant in %s: %s", context, expr,
+		)
 	}
 	if ord != -1 {
 		if ord < 1 || ord > int64(numOriginalCols) {
-			return -1, errors.Errorf("%s position %s is not in select list", context, expr)
+			return -1, pgerror.NewErrorf(
+				pgerror.CodeInvalidColumnReferenceError,
+				"%s position %s is not in select list", context, expr,
+			)
 		}
 		ord--
 	}

--- a/pkg/sql/subquery.go
+++ b/pkg/sql/subquery.go
@@ -365,10 +365,12 @@ func (v *subqueryVisitor) extractSubquery(
 		switch desiredColumns {
 		case 1:
 			plan.Close(v.ctx)
-			return nil, fmt.Errorf("subquery must return only one column, found %d", len(cols))
+			return nil, pgerror.NewErrorf(pgerror.CodeSyntaxError,
+				"subquery must return only one column, found %d", len(cols))
 		default:
 			plan.Close(v.ctx)
-			return nil, fmt.Errorf("subquery must return %d columns, found %d", desiredColumns, len(cols))
+			return nil, pgerror.NewErrorf(pgerror.CodeSyntaxError,
+				"subquery must return %d columns, found %d", desiredColumns, len(cols))
 		}
 	}
 


### PR DESCRIPTION
This commit ensures that all errors in the optbuilder have a pg
errorcode. In order to keep the optimizer in sync with the heuristic
planner, this commit also updates some of the heuristic planner error
messages to match the Postgres error messages and include pgcodes.

Other errors in the optbuilder which should never be thrown (e.g., in
the default case of a switch statement that covers all cases) have been
converted into panics.

Release note (sql change): Fixed some error messages to more closely
match the Postgres error messages, including the corresponding Postgres
error codes.