### PR TITLE
opt: Wrap projected outer columns in a variable expression

### DIFF
--- a/pkg/sql/opt/memo/testdata/logprops/groupby
+++ b/pkg/sql/opt/memo/testdata/logprops/groupby
@@ -162,42 +162,46 @@ select
  ├── stats: [rows=333]
  ├── keys: (1) weak(3,4)
  ├── scan xyzs
- │    ├── columns: x:1(int!null) y:2(int) z:3(float!null) s:4(string)
+ │    ├── columns: xyzs.x:1(int!null) xyzs.y:2(int) z:3(float!null) s:4(string)
  │    ├── stats: [rows=1000]
  │    └── keys: (1) weak(3,4)
  └── filters [type=bool, outer=(1,2)]
       └── gt [type=bool, outer=(1,2)]
            ├── subquery [type=decimal, outer=(1,2)]
            │    └── max1-row
-           │         ├── columns: sum:8(decimal)
+           │         ├── columns: sum:10(decimal)
            │         ├── outer: (1,2)
            │         ├── cardinality: [0 - 1]
            │         ├── stats: [rows=1]
            │         └── project
-           │              ├── columns: sum:8(decimal)
+           │              ├── columns: sum:10(decimal)
            │              ├── outer: (1,2)
            │              ├── stats: [rows=700]
            │              └── group-by
-           │                   ├── columns: u:6(float) sum:8(decimal)
+           │                   ├── columns: u:6(float) sum:10(decimal)
            │                   ├── grouping columns: u:6(float)
            │                   ├── outer: (1,2)
            │                   ├── stats: [rows=700, distinct(6)=700]
            │                   ├── keys: weak(6)
            │                   ├── project
-           │                   │    ├── columns: x:1(int) u:6(float)
+           │                   │    ├── columns: x:9(int) u:6(float)
            │                   │    ├── outer: (1,2)
            │                   │    ├── stats: [rows=1000, distinct(6)=700]
-           │                   │    └── project
-           │                   │         ├── columns: y:2(int) u:6(float)
-           │                   │         ├── outer: (2)
-           │                   │         ├── stats: [rows=1000, distinct(6)=700]
-           │                   │         └── scan kuv
-           │                   │              ├── columns: k:5(int!null) u:6(float) v:7(string)
-           │                   │              ├── stats: [rows=1000, distinct(6)=700]
-           │                   │              └── keys: (5)
-           │                   └── aggregations [outer=(1)]
-           │                        └── sum [type=decimal, outer=(1)]
-           │                             └── variable: xyzs.x [type=int, outer=(1)]
+           │                   │    ├── project
+           │                   │    │    ├── columns: y:8(int) u:6(float)
+           │                   │    │    ├── outer: (2)
+           │                   │    │    ├── stats: [rows=1000, distinct(6)=700]
+           │                   │    │    ├── scan kuv
+           │                   │    │    │    ├── columns: k:5(int!null) u:6(float) v:7(string)
+           │                   │    │    │    ├── stats: [rows=1000, distinct(6)=700]
+           │                   │    │    │    └── keys: (5)
+           │                   │    │    └── projections [outer=(2,6)]
+           │                   │    │         └── variable: xyzs.y [type=int, outer=(2)]
+           │                   │    └── projections [outer=(1,6)]
+           │                   │         └── variable: xyzs.x [type=int, outer=(1)]
+           │                   └── aggregations [outer=(9)]
+           │                        └── sum [type=decimal, outer=(9)]
+           │                             └── variable: x [type=int, outer=(9)]
            └── const: 100 [type=decimal]
 
 # Calculate groupby cardinality.

--- a/pkg/sql/opt/memo/testdata/logprops/join
+++ b/pkg/sql/opt/memo/testdata/logprops/join
@@ -426,38 +426,42 @@ select
  ├── stats: [rows=333]
  ├── keys: (1) weak(3,4)
  ├── scan xysd
- │    ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null)
+ │    ├── columns: xysd.x:1(int!null) xysd.y:2(int) s:3(string) d:4(decimal!null)
  │    ├── stats: [rows=1000]
  │    └── keys: (1) weak(3,4)
  └── filters [type=bool, outer=(1-3)]
       └── exists [type=bool, outer=(1-3)]
            └── inner-join
-                ├── columns: x:1(int) y:2(int)
+                ├── columns: x:5(int) y:6(int)
                 ├── outer: (1-3)
                 ├── cardinality: [0 - 1]
                 ├── stats: [rows=0]
                 ├── project
-                │    ├── columns: x:1(int)
+                │    ├── columns: x:5(int)
                 │    ├── outer: (1)
                 │    ├── cardinality: [1 - 1]
                 │    ├── stats: [rows=1]
-                │    └── values
-                │         ├── cardinality: [1 - 1]
-                │         ├── stats: [rows=1]
-                │         └── tuple [type=tuple{}]
+                │    ├── values
+                │    │    ├── cardinality: [1 - 1]
+                │    │    ├── stats: [rows=1]
+                │    │    └── tuple [type=tuple{}]
+                │    └── projections [outer=(1)]
+                │         └── variable: xysd.x [type=int, outer=(1)]
                 ├── project
-                │    ├── columns: y:2(int)
+                │    ├── columns: y:6(int)
                 │    ├── outer: (2)
                 │    ├── cardinality: [1 - 1]
                 │    ├── stats: [rows=1]
-                │    └── values
-                │         ├── cardinality: [1 - 1]
-                │         ├── stats: [rows=1]
-                │         └── tuple [type=tuple{}]
-                └── filters [type=bool, outer=(1,3)]
-                     └── eq [type=bool, outer=(1,3)]
-                          ├── cast: STRING [type=string, outer=(1)]
-                          │    └── variable: xysd.x [type=int, outer=(1)]
+                │    ├── values
+                │    │    ├── cardinality: [1 - 1]
+                │    │    ├── stats: [rows=1]
+                │    │    └── tuple [type=tuple{}]
+                │    └── projections [outer=(2)]
+                │         └── variable: xysd.y [type=int, outer=(2)]
+                └── filters [type=bool, outer=(3,5)]
+                     └── eq [type=bool, outer=(3,5)]
+                          ├── cast: STRING [type=string, outer=(5)]
+                          │    └── variable: x [type=int, outer=(5)]
                           └── variable: xysd.s [type=string, outer=(3)]
 
 # Calculate semi-join cardinality when left side has non-zero cardinality.

--- a/pkg/sql/opt/memo/testdata/logprops/limit
+++ b/pkg/sql/opt/memo/testdata/logprops/limit
@@ -104,31 +104,33 @@ build
 SELECT (SELECT x FROM kuv LIMIT y) FROM xyzs
 ----
 project
- ├── columns: "(SELECT x FROM kuv LIMIT y)":8(int)
+ ├── columns: "(SELECT x FROM kuv LIMIT y)":9(int)
  ├── stats: [rows=1000]
  ├── scan xyzs
- │    ├── columns: x:1(int!null) y:2(int) z:3(float!null) s:4(string)
+ │    ├── columns: xyzs.x:1(int!null) y:2(int) z:3(float!null) s:4(string)
  │    ├── stats: [rows=1000]
  │    └── keys: (1) weak(3,4)
  └── projections [outer=(1,2)]
       └── subquery [type=int, outer=(1,2)]
            └── max1-row
-                ├── columns: x:1(int)
+                ├── columns: x:8(int)
                 ├── outer: (1,2)
                 ├── cardinality: [0 - 1]
                 ├── stats: [rows=1]
                 └── limit
-                     ├── columns: x:1(int)
+                     ├── columns: x:8(int)
                      ├── outer: (1,2)
                      ├── stats: [rows=1000]
                      ├── project
-                     │    ├── columns: x:1(int)
+                     │    ├── columns: x:8(int)
                      │    ├── outer: (1)
                      │    ├── stats: [rows=1000]
-                     │    └── scan kuv
-                     │         ├── columns: k:5(int!null) u:6(float) v:7(string)
-                     │         ├── stats: [rows=1000]
-                     │         └── keys: (5)
+                     │    ├── scan kuv
+                     │    │    ├── columns: k:5(int!null) u:6(float) v:7(string)
+                     │    │    ├── stats: [rows=1000]
+                     │    │    └── keys: (5)
+                     │    └── projections [outer=(1)]
+                     │         └── variable: xyzs.x [type=int, outer=(1)]
                      └── variable: xyzs.y [type=int, outer=(2)]
 
 # Test very high limit (> max uint32).

--- a/pkg/sql/opt/memo/testdata/logprops/offset
+++ b/pkg/sql/opt/memo/testdata/logprops/offset
@@ -81,31 +81,33 @@ build
 SELECT (SELECT x FROM kuv OFFSET y) FROM xyzs
 ----
 project
- ├── columns: "(SELECT x FROM kuv OFFSET y)":8(int)
+ ├── columns: "(SELECT x FROM kuv OFFSET y)":9(int)
  ├── stats: [rows=1000]
  ├── scan xyzs
- │    ├── columns: x:1(int!null) y:2(int) z:3(float!null) s:4(string)
+ │    ├── columns: xyzs.x:1(int!null) y:2(int) z:3(float!null) s:4(string)
  │    ├── stats: [rows=1000]
  │    └── keys: (1) weak(3,4)
  └── projections [outer=(1,2)]
       └── subquery [type=int, outer=(1,2)]
            └── max1-row
-                ├── columns: x:1(int)
+                ├── columns: x:8(int)
                 ├── outer: (1,2)
                 ├── cardinality: [0 - 1]
                 ├── stats: [rows=1]
                 └── offset
-                     ├── columns: x:1(int)
+                     ├── columns: x:8(int)
                      ├── outer: (1,2)
                      ├── stats: [rows=1000]
                      ├── project
-                     │    ├── columns: x:1(int)
+                     │    ├── columns: x:8(int)
                      │    ├── outer: (1)
                      │    ├── stats: [rows=1000]
-                     │    └── scan kuv
-                     │         ├── columns: k:5(int!null) u:6(float) v:7(string)
-                     │         ├── stats: [rows=1000]
-                     │         └── keys: (5)
+                     │    ├── scan kuv
+                     │    │    ├── columns: k:5(int!null) u:6(float) v:7(string)
+                     │    │    ├── stats: [rows=1000]
+                     │    │    └── keys: (5)
+                     │    └── projections [outer=(1)]
+                     │         └── variable: xyzs.x [type=int, outer=(1)]
                      └── variable: xyzs.y [type=int, outer=(2)]
 
 # Reduce cardinality of input set.

--- a/pkg/sql/opt/memo/testdata/logprops/project
+++ b/pkg/sql/opt/memo/testdata/logprops/project
@@ -60,19 +60,19 @@ select
  ├── stats: [rows=333]
  ├── keys: (1) weak(3,4)
  ├── scan xysd
- │    ├── columns: x:1(int!null) y:2(int) s:3(string) d:4(decimal!null)
+ │    ├── columns: x:1(int!null) xysd.y:2(int) s:3(string) d:4(decimal!null)
  │    ├── stats: [rows=1000]
  │    └── keys: (1) weak(3,4)
  └── filters [type=bool, outer=(1,2)]
       └── gt [type=bool, outer=(1,2)]
            ├── subquery [type=int, outer=(1,2)]
            │    └── max1-row
-           │         ├── columns: "(SELECT y)":8(int)
+           │         ├── columns: "(SELECT y)":9(int)
            │         ├── outer: (1,2)
            │         ├── cardinality: [0 - 1]
            │         ├── stats: [rows=1]
            │         └── project
-           │              ├── columns: "(SELECT y)":8(int)
+           │              ├── columns: "(SELECT y)":9(int)
            │              ├── outer: (1,2)
            │              ├── stats: [rows=111]
            │              ├── select
@@ -91,19 +91,21 @@ select
            │              └── projections [outer=(2)]
            │                   └── subquery [type=int, outer=(2)]
            │                        └── max1-row
-           │                             ├── columns: y:2(int)
+           │                             ├── columns: y:8(int)
            │                             ├── outer: (2)
            │                             ├── cardinality: [1 - 1]
            │                             ├── stats: [rows=1]
            │                             └── project
-           │                                  ├── columns: y:2(int)
+           │                                  ├── columns: y:8(int)
            │                                  ├── outer: (2)
            │                                  ├── cardinality: [1 - 1]
            │                                  ├── stats: [rows=1]
-           │                                  └── values
-           │                                       ├── cardinality: [1 - 1]
-           │                                       ├── stats: [rows=1]
-           │                                       └── tuple [type=tuple{}]
+           │                                  ├── values
+           │                                  │    ├── cardinality: [1 - 1]
+           │                                  │    ├── stats: [rows=1]
+           │                                  │    └── tuple [type=tuple{}]
+           │                                  └── projections [outer=(2)]
+           │                                       └── variable: xysd.y [type=int, outer=(2)]
            └── const: 5 [type=int]
 
 # Pass through cardinality.

--- a/pkg/sql/opt/memo/testdata/logprops/set
+++ b/pkg/sql/opt/memo/testdata/logprops/set
@@ -114,47 +114,51 @@ select
  ├── stats: [rows=333]
  ├── keys: (1)
  ├── scan xy
- │    ├── columns: xy.x:1(int!null) y:2(int)
+ │    ├── columns: xy.x:1(int!null) xy.y:2(int)
  │    ├── stats: [rows=1000]
  │    └── keys: (1)
  └── filters [type=bool, outer=(1,2)]
       └── eq [type=bool, outer=(1,2)]
            ├── subquery [type=tuple{int, int}, outer=(1,2)]
            │    └── max1-row
-           │         ├── columns: column11:11(tuple{int, int})
+           │         ├── columns: column13:13(tuple{int, int})
            │         ├── outer: (1,2)
            │         ├── cardinality: [0 - 1]
            │         ├── stats: [rows=1]
            │         └── project
-           │              ├── columns: column11:11(tuple{int, int})
+           │              ├── columns: column13:13(tuple{int, int})
            │              ├── outer: (1,2)
            │              ├── stats: [rows=1400]
            │              ├── union
-           │              │    ├── columns: x:9(int) u:10(int)
-           │              │    ├── left columns: xy.x:1(int) uv.u:3(int)
-           │              │    ├── right columns: y:2(int) uv.v:7(int)
+           │              │    ├── columns: x:11(int) u:12(int)
+           │              │    ├── left columns: x:6(int) uv.u:3(int)
+           │              │    ├── right columns: y:10(int) uv.v:8(int)
            │              │    ├── outer: (1,2)
-           │              │    ├── stats: [rows=1400, distinct(9,10)=1400]
+           │              │    ├── stats: [rows=1400, distinct(11,12)=1400]
            │              │    ├── project
-           │              │    │    ├── columns: xy.x:1(int) uv.u:3(int)
+           │              │    │    ├── columns: x:6(int) uv.u:3(int)
            │              │    │    ├── outer: (1)
-           │              │    │    ├── stats: [rows=1000, distinct(1,3)=700]
-           │              │    │    └── scan uv
-           │              │    │         ├── columns: uv.u:3(int) uv.v:4(int!null) uv.rowid:5(int!null)
-           │              │    │         ├── stats: [rows=1000, distinct(3)=700]
-           │              │    │         └── keys: (5)
+           │              │    │    ├── stats: [rows=1000, distinct(3,6)=700]
+           │              │    │    ├── scan uv
+           │              │    │    │    ├── columns: uv.u:3(int) uv.v:4(int!null) uv.rowid:5(int!null)
+           │              │    │    │    ├── stats: [rows=1000, distinct(3)=700]
+           │              │    │    │    └── keys: (5)
+           │              │    │    └── projections [outer=(1,3)]
+           │              │    │         └── variable: xy.x [type=int, outer=(1)]
            │              │    └── project
-           │              │         ├── columns: y:2(int) uv.v:7(int!null)
+           │              │         ├── columns: y:10(int) uv.v:8(int!null)
            │              │         ├── outer: (2)
-           │              │         ├── stats: [rows=1000, distinct(2,7)=700]
-           │              │         └── scan uv
-           │              │              ├── columns: uv.u:6(int) uv.v:7(int!null) uv.rowid:8(int!null)
-           │              │              ├── stats: [rows=1000, distinct(7)=700]
-           │              │              └── keys: (8)
-           │              └── projections [outer=(9,10)]
-           │                   └── tuple [type=tuple{int, int}, outer=(9,10)]
-           │                        ├── variable: x [type=int, outer=(9)]
-           │                        └── variable: u [type=int, outer=(10)]
+           │              │         ├── stats: [rows=1000, distinct(8,10)=700]
+           │              │         ├── scan uv
+           │              │         │    ├── columns: uv.u:7(int) uv.v:8(int!null) uv.rowid:9(int!null)
+           │              │         │    ├── stats: [rows=1000, distinct(8)=700]
+           │              │         │    └── keys: (9)
+           │              │         └── projections [outer=(2,8)]
+           │              │              └── variable: xy.y [type=int, outer=(2)]
+           │              └── projections [outer=(11,12)]
+           │                   └── tuple [type=tuple{int, int}, outer=(11,12)]
+           │                        ├── variable: x [type=int, outer=(11)]
+           │                        └── variable: u [type=int, outer=(12)]
            └── tuple [type=tuple{int, int}]
                 ├── const: 1 [type=int]
                 └── const: 2 [type=int]

--- a/pkg/sql/opt/optbuilder/scalar.go
+++ b/pkg/sql/opt/optbuilder/scalar.go
@@ -116,7 +116,13 @@ func (b *Builder) buildScalarHelper(
 		// Change this to generate the string once for the top-level expression and
 		// check the relevant slice for this subexpression.
 		if col, ok := inScope.groupby.groupStrs[symbolicExprStr(scalar)]; ok {
-			return b.finishBuildScalarRef(col, label, inScope, outScope)
+			// We pass aggOutScope as the input scope because it contains all of
+			// the aggregates and grouping columns that are available for projection.
+			// finishBuildScalarRef wraps projected columns in a variable expression
+			// with a new column ID if they are not contained in the input scope, so
+			// passing in aggOutScope ensures we don't create new column IDs when not
+			// necessary.
+			return b.finishBuildScalarRef(col, label, inScope.groupby.aggOutScope, outScope)
 		}
 	}
 

--- a/pkg/sql/opt/optbuilder/scope.go
+++ b/pkg/sql/opt/optbuilder/scope.go
@@ -176,6 +176,19 @@ func (s *scope) resolveAndRequireType(
 	return texpr
 }
 
+// isOuterColumn returns true if the given column is not present in the current
+// scope (it may or may not be present in an ancestor scope).
+func (s *scope) isOuterColumn(id opt.ColumnID) bool {
+	for i := range s.cols {
+		col := &s.cols[i]
+		if col.id == id {
+			return false
+		}
+	}
+
+	return true
+}
+
 // hasColumn returns true if the given column id is found within this scope.
 func (s *scope) hasColumn(id opt.ColumnID) bool {
 	// We only allow hidden columns in the current scope. Hidden columns

--- a/pkg/sql/opt/optbuilder/testdata/subquery
+++ b/pkg/sql/opt/optbuilder/testdata/subquery
@@ -1441,17 +1441,19 @@ build
 SELECT (SELECT akv.k) FROM kv akv
 ----
 project
- ├── columns: "(SELECT akv.k)":3(int)
+ ├── columns: "(SELECT akv.k)":4(int)
  ├── scan kv
- │    └── columns: k:1(int!null) v:2(string)
+ │    └── columns: kv.k:1(int!null) v:2(string)
  └── projections
       └── subquery [type=int]
            └── max1-row
-                ├── columns: k:1(int)
+                ├── columns: k:3(int)
                 └── project
-                     ├── columns: k:1(int)
-                     └── values
-                          └── tuple [type=tuple{}]
+                     ├── columns: k:3(int)
+                     ├── values
+                     │    └── tuple [type=tuple{}]
+                     └── projections
+                          └── variable: kv.k [type=int]
 
 exec-ddl
 CREATE TABLE db1.kv (k INT PRIMARY KEY, v INT)
@@ -1466,7 +1468,7 @@ build fully-qualify-names
 SELECT (SELECT t.kv.k) FROM db1.kv, kv
 ----
 project
- ├── columns: "(SELECT t.kv.k)":5(int)
+ ├── columns: "(SELECT t.kv.k)":6(int)
  ├── inner-join
  │    ├── columns: db1.public.kv.k:1(int!null) db1.public.kv.v:2(int) t.public.kv.k:3(int!null) t.public.kv.v:4(string)
  │    ├── scan kv
@@ -1477,11 +1479,13 @@ project
  └── projections
       └── subquery [type=int]
            └── max1-row
-                ├── columns: t.public.kv.k:3(int)
+                ├── columns: k:5(int)
                 └── project
-                     ├── columns: t.public.kv.k:3(int)
-                     └── values
-                          └── tuple [type=tuple{}]
+                     ├── columns: k:5(int)
+                     ├── values
+                     │    └── tuple [type=tuple{}]
+                     └── projections
+                          └── variable: t.public.kv.k [type=int]
 
 # Ambiguity in parent scope.
 build fully-qualify-names
@@ -1499,7 +1503,7 @@ build fully-qualify-names
 SELECT (SELECT kv1.k) FROM db1.kv AS kv1, kv
 ----
 project
- ├── columns: "(SELECT kv1.k)":5(int)
+ ├── columns: "(SELECT kv1.k)":6(int)
  ├── inner-join
  │    ├── columns: db1.public.kv.k:1(int!null) db1.public.kv.v:2(int) t.public.kv.k:3(int!null) t.public.kv.v:4(string)
  │    ├── scan kv
@@ -1510,11 +1514,13 @@ project
  └── projections
       └── subquery [type=int]
            └── max1-row
-                ├── columns: db1.public.kv.k:1(int)
+                ├── columns: k:5(int)
                 └── project
-                     ├── columns: db1.public.kv.k:1(int)
-                     └── values
-                          └── tuple [type=tuple{}]
+                     ├── columns: k:5(int)
+                     ├── values
+                     │    └── tuple [type=tuple{}]
+                     └── projections
+                          └── variable: db1.public.kv.k [type=int]
 
 # Check that the inner kv is chosen when there are matching names in both
 # scopes.
@@ -1562,3 +1568,273 @@ project
                                               └── plus [type=int]
                                                    ├── variable: t.public.kv.k [type=int]
                                                    └── variable: db1.public.kv.k [type=int]
+
+exec-ddl
+CREATE TABLE t1 (a INT)
+----
+TABLE t1
+ ├── a int
+ ├── rowid int not null (hidden)
+ └── INDEX primary
+      └── rowid int not null (hidden)
+
+exec-ddl
+CREATE TABLE t2 (a INT)
+----
+TABLE t2
+ ├── a int
+ ├── rowid int not null (hidden)
+ └── INDEX primary
+      └── rowid int not null (hidden)
+
+exec-ddl
+CREATE TABLE t3 (a INT)
+----
+TABLE t3
+ ├── a int
+ ├── rowid int not null (hidden)
+ └── INDEX primary
+      └── rowid int not null (hidden)
+
+build
+SELECT (SELECT (SELECT MAX(t3.a) FROM t1) FROM t2) FROM t3
+----
+project
+ ├── columns: "(SELECT (SELECT max(t3.a) FROM t1) FROM t2)":10(int)
+ ├── scan t3
+ │    └── columns: t3.a:1(int) t3.rowid:2(int!null)
+ └── projections
+      └── subquery [type=int]
+           └── max1-row
+                ├── columns: "(SELECT max(t3.a) FROM t1)":9(int)
+                └── project
+                     ├── columns: "(SELECT max(t3.a) FROM t1)":9(int)
+                     ├── scan t2
+                     │    └── columns: t2.a:3(int) t2.rowid:4(int!null)
+                     └── projections
+                          └── subquery [type=int]
+                               └── max1-row
+                                    ├── columns: max:8(int)
+                                    └── group-by
+                                         ├── columns: max:8(int)
+                                         ├── project
+                                         │    ├── columns: a:7(int)
+                                         │    ├── scan t1
+                                         │    │    └── columns: t1.a:5(int) t1.rowid:6(int!null)
+                                         │    └── projections
+                                         │         └── variable: t3.a [type=int]
+                                         └── aggregations
+                                              └── max [type=int]
+                                                   └── variable: a [type=int]
+
+build
+SELECT (SELECT (SELECT DISTINCT t3.a FROM t1) FROM t2) FROM t3
+----
+project
+ ├── columns: "(SELECT (SELECT DISTINCT t3.a FROM t1) FROM t2)":9(int)
+ ├── scan t3
+ │    └── columns: t3.a:1(int) t3.rowid:2(int!null)
+ └── projections
+      └── subquery [type=int]
+           └── max1-row
+                ├── columns: "(SELECT DISTINCT t3.a FROM t1)":8(int)
+                └── project
+                     ├── columns: "(SELECT DISTINCT t3.a FROM t1)":8(int)
+                     ├── scan t2
+                     │    └── columns: t2.a:3(int) t2.rowid:4(int!null)
+                     └── projections
+                          └── subquery [type=int]
+                               └── max1-row
+                                    ├── columns: a:7(int)
+                                    └── group-by
+                                         ├── columns: a:7(int)
+                                         ├── grouping columns: a:7(int)
+                                         └── project
+                                              ├── columns: a:7(int)
+                                              ├── scan t1
+                                              │    └── columns: t1.a:5(int) t1.rowid:6(int!null)
+                                              └── projections
+                                                   └── variable: t3.a [type=int]
+
+build
+SELECT (SELECT (SELECT COUNT(*) FROM t1 GROUP BY t3.a) FROM t2) FROM t3
+----
+project
+ ├── columns: "(SELECT (SELECT count(*) FROM t1 GROUP BY t3.a) FROM t2)":10(int)
+ ├── scan t3
+ │    └── columns: t3.a:1(int) t3.rowid:2(int!null)
+ └── projections
+      └── subquery [type=int]
+           └── max1-row
+                ├── columns: "(SELECT count(*) FROM t1 GROUP BY t3.a)":9(int)
+                └── project
+                     ├── columns: "(SELECT count(*) FROM t1 GROUP BY t3.a)":9(int)
+                     ├── scan t2
+                     │    └── columns: t2.a:3(int) t2.rowid:4(int!null)
+                     └── projections
+                          └── subquery [type=int]
+                               └── max1-row
+                                    ├── columns: count:8(int)
+                                    └── project
+                                         ├── columns: count:8(int)
+                                         └── group-by
+                                              ├── columns: a:7(int) count:8(int)
+                                              ├── grouping columns: a:7(int)
+                                              ├── project
+                                              │    ├── columns: a:7(int)
+                                              │    ├── scan t1
+                                              │    │    └── columns: t1.a:5(int) t1.rowid:6(int!null)
+                                              │    └── projections
+                                              │         └── variable: t3.a [type=int]
+                                              └── aggregations
+                                                   └── count-rows [type=int]
+
+build
+SELECT (SELECT (SELECT t2.a + t3.a FROM t1 GROUP BY t2.a + t3.a) FROM t2) FROM t3
+----
+project
+ ├── columns: "(SELECT (SELECT t2.a + t3.a FROM t1 GROUP BY t2.a + t3.a) FROM t2)":9(int)
+ ├── scan t3
+ │    └── columns: t3.a:1(int) t3.rowid:2(int!null)
+ └── projections
+      └── subquery [type=int]
+           └── max1-row
+                ├── columns: "(SELECT t2.a + t3.a FROM t1 GROUP BY t2.a + t3.a)":8(int)
+                └── project
+                     ├── columns: "(SELECT t2.a + t3.a FROM t1 GROUP BY t2.a + t3.a)":8(int)
+                     ├── scan t2
+                     │    └── columns: t2.a:3(int) t2.rowid:4(int!null)
+                     └── projections
+                          └── subquery [type=int]
+                               └── max1-row
+                                    ├── columns: column7:7(int)
+                                    └── group-by
+                                         ├── columns: column7:7(int)
+                                         ├── grouping columns: column7:7(int)
+                                         └── project
+                                              ├── columns: column7:7(int)
+                                              ├── scan t1
+                                              │    └── columns: t1.a:5(int) t1.rowid:6(int!null)
+                                              └── projections
+                                                   └── plus [type=int]
+                                                        ├── variable: t2.a [type=int]
+                                                        └── variable: t3.a [type=int]
+
+build
+SELECT (SELECT (SELECT t2.a + t3.a FROM t1 GROUP BY t2.a, t3.a HAVING t2.a > t3.a) FROM t2) FROM t3
+----
+project
+ ├── columns: "(SELECT (SELECT t2.a + t3.a FROM t1 GROUP BY t2.a, t3.a HAVING t2.a > t3.a) FROM t2)":11(int)
+ ├── scan t3
+ │    └── columns: t3.a:1(int) t3.rowid:2(int!null)
+ └── projections
+      └── subquery [type=int]
+           └── max1-row
+                ├── columns: "(SELECT t2.a + t3.a FROM t1 GROUP BY t2.a, t3.a HAVING t2.a > t3.a)":10(int)
+                └── project
+                     ├── columns: "(SELECT t2.a + t3.a FROM t1 GROUP BY t2.a, t3.a HAVING t2.a > t3.a)":10(int)
+                     ├── scan t2
+                     │    └── columns: t2.a:3(int) t2.rowid:4(int!null)
+                     └── projections
+                          └── subquery [type=int]
+                               └── max1-row
+                                    ├── columns: "t2.a + t3.a":9(int)
+                                    └── project
+                                         ├── columns: "t2.a + t3.a":9(int)
+                                         ├── select
+                                         │    ├── columns: a:7(int!null) a:8(int!null)
+                                         │    ├── group-by
+                                         │    │    ├── columns: a:7(int) a:8(int)
+                                         │    │    ├── grouping columns: a:7(int) a:8(int)
+                                         │    │    └── project
+                                         │    │         ├── columns: a:7(int) a:8(int)
+                                         │    │         ├── scan t1
+                                         │    │         │    └── columns: t1.a:5(int) t1.rowid:6(int!null)
+                                         │    │         └── projections
+                                         │    │              ├── variable: t2.a [type=int]
+                                         │    │              └── variable: t3.a [type=int]
+                                         │    └── filters [type=bool]
+                                         │         └── gt [type=bool]
+                                         │              ├── variable: a [type=int]
+                                         │              └── variable: a [type=int]
+                                         └── projections
+                                              └── plus [type=int]
+                                                   ├── variable: a [type=int]
+                                                   └── variable: a [type=int]
+
+build
+SELECT (SELECT ARRAY[COUNT(*), t1.a, t2.a] FROM t1 GROUP BY t1.a, t2.a HAVING t2.a > 5) FROM t2
+----
+project
+ ├── columns: "(SELECT ARRAY[count(*), t1.a, t2.a] FROM t1 GROUP BY t1.a, t2.a HAVING t2.a > 5)":8(int[])
+ ├── scan t2
+ │    └── columns: t2.a:1(int) t2.rowid:2(int!null)
+ └── projections
+      └── subquery [type=int[]]
+           └── max1-row
+                ├── columns: "ARRAY[count(*), t1.a, t2.a]":7(int[])
+                └── project
+                     ├── columns: "ARRAY[count(*), t1.a, t2.a]":7(int[])
+                     ├── select
+                     │    ├── columns: t1.a:3(int) a:5(int!null) column6:6(int)
+                     │    ├── group-by
+                     │    │    ├── columns: t1.a:3(int) a:5(int) column6:6(int)
+                     │    │    ├── grouping columns: t1.a:3(int) a:5(int)
+                     │    │    ├── project
+                     │    │    │    ├── columns: a:5(int) t1.a:3(int)
+                     │    │    │    ├── scan t1
+                     │    │    │    │    └── columns: t1.a:3(int) t1.rowid:4(int!null)
+                     │    │    │    └── projections
+                     │    │    │         └── variable: t2.a [type=int]
+                     │    │    └── aggregations
+                     │    │         └── count-rows [type=int]
+                     │    └── filters [type=bool]
+                     │         └── gt [type=bool]
+                     │              ├── variable: a [type=int]
+                     │              └── const: 5 [type=int]
+                     └── projections
+                          └── array: int[] [type=int[]]
+                               ├── variable: column6 [type=int]
+                               ├── variable: t1.a [type=int]
+                               └── variable: a [type=int]
+
+build
+SELECT (SELECT (SELECT MAX(t3.a) / MIN(t3.a) FROM t1 GROUP BY t2.a) FROM t2) FROM t3
+----
+project
+ ├── columns: "(SELECT (SELECT max(t3.a) / min(t3.a) FROM t1 GROUP BY t2.a) FROM t2)":13(decimal)
+ ├── scan t3
+ │    └── columns: t3.a:1(int) t3.rowid:2(int!null)
+ └── projections
+      └── subquery [type=decimal]
+           └── max1-row
+                ├── columns: "(SELECT max(t3.a) / min(t3.a) FROM t1 GROUP BY t2.a)":12(decimal)
+                └── project
+                     ├── columns: "(SELECT max(t3.a) / min(t3.a) FROM t1 GROUP BY t2.a)":12(decimal)
+                     ├── scan t2
+                     │    └── columns: t2.a:3(int) t2.rowid:4(int!null)
+                     └── projections
+                          └── subquery [type=decimal]
+                               └── max1-row
+                                    ├── columns: "max(t3.a) / min(t3.a)":11(decimal)
+                                    └── project
+                                         ├── columns: "max(t3.a) / min(t3.a)":11(decimal)
+                                         ├── group-by
+                                         │    ├── columns: a:7(int) column9:9(int) column10:10(int)
+                                         │    ├── grouping columns: a:7(int)
+                                         │    ├── project
+                                         │    │    ├── columns: a:7(int) a:8(int)
+                                         │    │    ├── scan t1
+                                         │    │    │    └── columns: t1.a:5(int) t1.rowid:6(int!null)
+                                         │    │    └── projections
+                                         │    │         ├── variable: t2.a [type=int]
+                                         │    │         └── variable: t3.a [type=int]
+                                         │    └── aggregations
+                                         │         ├── max [type=int]
+                                         │         │    └── variable: a [type=int]
+                                         │         └── min [type=int]
+                                         │              └── variable: a [type=int]
+                                         └── projections
+                                              └── div [type=decimal]
+                                                   ├── variable: column9 [type=int]
+                                                   └── variable: column10 [type=int]


### PR DESCRIPTION
This commit fixes an issue in which outer columns were being
treated as "passthrough columns" during projection. Now, outer
columns are wrapped in a variable expression and assigned a new
column ID.

For example, consider this query on table `xy`, which has two columns
(`x` and `y`):

`SELECT (SELECT x) FROM xy;`

Previously, the projected column `x` would have been assigned the same
column ID as the scanned column `x` (e.g., ID 1). Now, it's assigned a
new column ID (e.g., ID 3). This change will be important for correct
subquery decorrelation for more complex queries.

Release note: None