### PR TITLE
importccl: re-enable TestImportCSVStmt

### DIFF
--- a/pkg/ccl/importccl/import_stmt_test.go
+++ b/pkg/ccl/importccl/import_stmt_test.go
@@ -283,7 +283,6 @@ func makeCSVData(
 
 func TestImportCSVStmt(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	t.Skip("#26036")
 
 	const (
 		nodes       = 3


### PR DESCRIPTION
The underlying bug appears to have been fixed in #26259.

Release note: None