### PR TITLE
storage: Fix a discrepancy between quiescent flag and unquiesced map

### DIFF
--- a/pkg/server/status.go
+++ b/pkg/server/status.go
@@ -1099,7 +1099,7 @@ func (s *statusServer) Ranges(
 				NoRaftLeader:           !storage.HasRaftLeader(raftStatus) && !metrics.Quiescent,
 				Underreplicated:        metrics.Underreplicated,
 				NoLease:                metrics.Leader && !metrics.LeaseValid && !metrics.Quiescent,
-				QuiescentEqualsTicking: metrics.Quiescent == metrics.Ticking,
+				QuiescentEqualsTicking: raftStatus != nil && metrics.Quiescent == metrics.Ticking,
 			},
 			CmdQLocal:   serverpb.CommandQueueMetrics(metrics.CmdQMetricsLocal),
 			CmdQGlobal:  serverpb.CommandQueueMetrics(metrics.CmdQMetricsGlobal),

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -3425,6 +3425,9 @@ func (r *Replica) unquiesceAndWakeLeaderLocked() {
 			log.Infof(ctx, "unquiescing: waking leader")
 		}
 		r.mu.quiescent = false
+		r.store.unquiescedReplicas.Lock()
+		r.store.unquiescedReplicas.m[r.RangeID] = struct{}{}
+		r.store.unquiescedReplicas.Unlock()
 		r.maybeCampaignOnWakeLocked(ctx)
 		// Propose an empty command which will wake the leader.
 		_ = r.mu.internalRaftGroup.Propose(encodeRaftCommandV1(makeIDKey(), nil))


### PR DESCRIPTION
There are two paths by which a replica can become unquiesced, and only
one of them updated the unquiesced map.

Updates #26257

This is probably the underlying issue there, although I'm still
looking for potential synchronization problems coming from the use of
two different locks.

Release note: None