### PR TITLE
opt: add cluster setting for experimental_opt

### DIFF
--- a/docs/generated/settings/settings.html
+++ b/docs/generated/settings/settings.html
@@ -44,6 +44,7 @@
 <tr><td><code>server.time_until_store_dead</code></td><td>duration</td><td><code>5m0s</code></td><td>the time after which if there is no new gossiped information about a store, it is considered dead</td></tr>
 <tr><td><code>server.web_session_timeout</code></td><td>duration</td><td><code>168h0m0s</code></td><td>the duration that a newly created web session will be valid</td></tr>
 <tr><td><code>sql.defaults.distsql</code></td><td>enumeration</td><td><code>1</code></td><td>Default distributed SQL execution mode [off = 0, auto = 1, on = 2]</td></tr>
+<tr><td><code>sql.defaults.optimizer</code></td><td>enumeration</td><td><code>0</code></td><td>Default cost-based optimizer mode [off = 0, on = 1, local = 2, always = 3]</td></tr>
 <tr><td><code>sql.distsql.distribute_index_joins</code></td><td>boolean</td><td><code>true</code></td><td>if set, for index joins we instantiate a join reader on every node that has a stream; if not set, we use a single join reader</td></tr>
 <tr><td><code>sql.distsql.interleaved_joins.enabled</code></td><td>boolean</td><td><code>true</code></td><td>if set we plan interleaved table joins instead of merge joins when possible</td></tr>
 <tr><td><code>sql.distsql.merge_joins.enabled</code></td><td>boolean</td><td><code>true</code></td><td>if set, we plan merge joins when possible</td></tr>

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -441,6 +441,7 @@ func (sp sessionParams) sessionData(
 		ApplicationName: sp.args.ApplicationName,
 		Database:        curDb,
 		DistSQLMode:     sessiondata.DistSQLExecMode(DistSQLClusterExecMode.Get(&settings.SV)),
+		OptimizerMode:   sessiondata.OptimizerMode(OptimizerClusterMode.Get(&settings.SV)),
 		SearchPath:      sqlbase.DefaultSearchPath,
 		Location:        time.UTC,
 		User:            sp.args.User,

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -101,6 +101,19 @@ var traceSessionEventLogEnabled = settings.RegisterBoolSetting(
 	"set to true to enable session tracing", false,
 )
 
+// OptimizerClusterMode controls the cluster default for when the cost-based optimizer is used.
+var OptimizerClusterMode = settings.RegisterEnumSetting(
+	"sql.defaults.optimizer",
+	"Default cost-based optimizer mode",
+	"Off",
+	map[int64]string{
+		int64(sessiondata.OptimizerAlways): "Always",
+		int64(sessiondata.OptimizerLocal):  "Local",
+		int64(sessiondata.OptimizerOff):    "Off",
+		int64(sessiondata.OptimizerOn):     "On",
+	},
+)
+
 // DistSQLClusterExecMode controls the cluster default for when DistSQL is used.
 var DistSQLClusterExecMode = settings.RegisterEnumSetting(
 	"sql.defaults.distsql",

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -1199,8 +1199,10 @@ query             STRING                    true  NULL     {}
 statement ok
 SET DATABASE = test
 
+# We filter here because experimental_opt will be different depending on which
+# configuration this logic test is running in.
 query TTTTTT colnames
-SELECT name, setting, category, short_desc, extra_desc, vartype FROM pg_catalog.pg_settings
+SELECT name, setting, category, short_desc, extra_desc, vartype FROM pg_catalog.pg_settings WHERE name != 'experimental_opt'
 ----
 name                            setting       category  short_desc  extra_desc  vartype
 application_name                ·             NULL      NULL        NULL        string
@@ -1214,7 +1216,6 @@ default_transaction_read_only   off           NULL      NULL        NULL        
 distsql                         off           NULL      NULL        NULL        string
 experimental_force_lookup_join  off           NULL      NULL        NULL        string
 experimental_force_zigzag_join  off           NULL      NULL        NULL        string
-experimental_opt                off           NULL      NULL        NULL        string
 extra_float_digits              ·             NULL      NULL        NULL        string
 intervalstyle                   postgres      NULL      NULL        NULL        string
 max_index_keys                  32            NULL      NULL        NULL        string
@@ -1234,7 +1235,7 @@ transaction_read_only           off           NULL      NULL        NULL        
 transaction_status              NoTxn         NULL      NULL        NULL        string
 
 query TTTTTTT colnames
-SELECT name, setting, unit, context, enumvals, boot_val, reset_val FROM pg_catalog.pg_settings
+SELECT name, setting, unit, context, enumvals, boot_val, reset_val FROM pg_catalog.pg_settings WHERE name != 'experimental_opt'
 ----
 name                            setting       unit  context  enumvals  boot_val      reset_val
 application_name                ·             NULL  user     NULL      ·             ·
@@ -1248,7 +1249,6 @@ default_transaction_read_only   off           NULL  user     NULL      off      
 distsql                         off           NULL  user     NULL      off           off
 experimental_force_lookup_join  off           NULL  user     NULL      off           off
 experimental_force_zigzag_join  off           NULL  user     NULL      off           off
-experimental_opt                off           NULL  user     NULL      off           off
 extra_float_digits              ·             NULL  user     NULL      ·             ·
 intervalstyle                   postgres      NULL  user     NULL      postgres      postgres
 max_index_keys                  32            NULL  user     NULL      32            32

--- a/pkg/sql/logictest/testdata/logic_test/set
+++ b/pkg/sql/logictest/testdata/logic_test/set
@@ -79,39 +79,6 @@ SHOW application_name
 application_name
 helloworld
 
-query TT
-SHOW ALL
-----
-application_name                helloworld
-bytea_output                    hex
-client_encoding                 UTF8
-client_min_messages             ·
-database                        foo
-datestyle                       ISO
-default_transaction_isolation   serializable
-default_transaction_read_only   off
-distsql                         off
-experimental_force_lookup_join  off
-experimental_force_zigzag_join  off
-experimental_opt                off
-extra_float_digits              ·
-intervalstyle                   postgres
-max_index_keys                  32
-node_id                         1
-search_path                     public
-server_version                  9.5.0
-server_version_num              90500
-session_user                    root
-sql_safe_updates                false
-standard_conforming_strings     on
-statement_timeout               0s
-timezone                        UTC
-tracing                         off
-transaction_isolation           serializable
-transaction_priority            normal
-transaction_read_only           off
-transaction_status              NoTxn
-
 # SESSION_USER is a special keyword, check that SHOW knows about it.
 query T
 SHOW session_user

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -18,8 +18,10 @@ SELECT * FROM [SHOW client_encoding] WITH ORDINALITY
 client_encoding     ordinality
 UTF8                1
 
+# We filter here because experimental_opt will be different depending on which
+# configuration this logic test is running in.
 query TT colnames
-SELECT * FROM [SHOW ALL]
+SELECT * FROM [SHOW ALL] WHERE variable != 'experimental_opt'
 ----
 variable                        value
 application_name                ·
@@ -33,7 +35,6 @@ default_transaction_read_only   off
 distsql                         off
 experimental_force_lookup_join  off
 experimental_force_zigzag_join  off
-experimental_opt                off
 extra_float_digits              ·
 intervalstyle                   postgres
 max_index_keys                  32

--- a/pkg/sql/stats/stats_cache.go
+++ b/pkg/sql/stats/stats_cache.go
@@ -149,6 +149,12 @@ func (sc *TableStatisticsCache) lookupTableStats(
 func (sc *TableStatisticsCache) refreshTableStats(
 	ctx context.Context, tableID sqlbase.ID,
 ) ([]*TableStatistic, error) {
+	if sqlbase.IsReservedID(tableID) {
+		// Don't try to get statistics for system tables (most importantly,
+		// for table_statistics itself).
+		return nil, nil
+	}
+
 	tableStatistics, err := sc.getTableStatsFromDB(ctx, tableID)
 	if err != nil {
 		return nil, err

--- a/pkg/sql/stats/stats_cache_test.go
+++ b/pkg/sql/stats/stats_cache_test.go
@@ -118,7 +118,7 @@ func initTestData(
 	// later be compared with the returned stats using reflect.DeepEqual.
 	expStatsList := []TableStatistic{
 		{
-			TableID:       sqlbase.ID(0),
+			TableID:       sqlbase.ID(100),
 			StatisticID:   0,
 			Name:          "table0",
 			ColumnIDs:     []sqlbase.ColumnID{1},
@@ -131,7 +131,7 @@ func initTestData(
 			},
 		},
 		{
-			TableID:       sqlbase.ID(0),
+			TableID:       sqlbase.ID(100),
 			StatisticID:   1,
 			ColumnIDs:     []sqlbase.ColumnID{2, 3},
 			CreatedAt:     time.Date(2010, 11, 20, 11, 35, 23, 0, time.UTC),
@@ -140,7 +140,7 @@ func initTestData(
 			NullCount:     5,
 		},
 		{
-			TableID:       sqlbase.ID(1),
+			TableID:       sqlbase.ID(101),
 			StatisticID:   0,
 			ColumnIDs:     []sqlbase.ColumnID{0},
 			CreatedAt:     time.Date(2017, 11, 20, 11, 35, 23, 0, time.UTC),
@@ -149,7 +149,7 @@ func initTestData(
 			NullCount:     100,
 		},
 		{
-			TableID:       sqlbase.ID(2),
+			TableID:       sqlbase.ID(102),
 			StatisticID:   34,
 			Name:          "table2",
 			ColumnIDs:     []sqlbase.ColumnID{1, 2, 3},
@@ -174,7 +174,7 @@ func initTestData(
 	}
 
 	// Add another TableID for which we don't have stats.
-	expectedStats[sqlbase.ID(3)] = nil
+	expectedStats[sqlbase.ID(103)] = nil
 
 	return expectedStats, nil
 }
@@ -211,7 +211,7 @@ func TestTableStatisticsCache(t *testing.T) {
 	}
 
 	// Table IDs 0 and 1 should have been evicted since the cache size is 2.
-	tableIDs = []sqlbase.ID{sqlbase.ID(0), sqlbase.ID(1)}
+	tableIDs = []sqlbase.ID{sqlbase.ID(100), sqlbase.ID(101)}
 	for _, tableID := range tableIDs {
 		if statsList, ok := sc.lookupTableStats(ctx, tableID); ok {
 			t.Fatalf("lookup of evicted key %d returned: %s", tableID, statsList)
@@ -219,7 +219,7 @@ func TestTableStatisticsCache(t *testing.T) {
 	}
 
 	// Table IDs 2 and 3 should still be in the cache.
-	tableIDs = []sqlbase.ID{sqlbase.ID(2), sqlbase.ID(3)}
+	tableIDs = []sqlbase.ID{sqlbase.ID(102), sqlbase.ID(103)}
 	for _, tableID := range tableIDs {
 		if _, ok := sc.lookupTableStats(ctx, tableID); !ok {
 			t.Fatalf("for lookup of key %d, expected stats %s", tableID, expectedStats[tableID])
@@ -227,7 +227,7 @@ func TestTableStatisticsCache(t *testing.T) {
 	}
 
 	// After invalidation Table ID 2 should be gone.
-	tableID := sqlbase.ID(2)
+	tableID := sqlbase.ID(102)
 	sc.InvalidateTableStats(ctx, tableID)
 	if statsList, ok := sc.lookupTableStats(ctx, tableID); ok {
 		t.Fatalf("lookup of invalidated key %d returned: %s", tableID, statsList)

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -363,11 +363,11 @@ var varGen = map[string]sessionVar{
 			return nil
 		},
 		Get: func(evalCtx *extendedEvalContext) string {
-			return evalCtx.SessionData.DistSQLMode.String()
+			return evalCtx.SessionData.OptimizerMode.String()
 		},
 		Reset: func(m *sessionDataMutator) error {
-			m.SetDistSQLMode(sessiondata.DistSQLExecMode(
-				DistSQLClusterExecMode.Get(&m.settings.SV)))
+			m.SetOptimizerMode(sessiondata.OptimizerMode(
+				OptimizerClusterMode.Get(&m.settings.SV)))
 			return nil
 		},
 	},


### PR DESCRIPTION
This commit adds the `sql.defaults.optimizer` cluster setting, which
sets the default value of the `experimental_opt` session variable. It
also fixes a bug in which the value of `experimental_opt` would be
incorrectly reported as the value of the DistSQL cluster setting and
fixes some related tests.

This cluster setting will make benchmarking the cost-based optimizer
much simpler, as a single cluster can easily be used to benchmark both
with and without the optimizer.

Not sure if there's a nice way to test a cluster setting like this, so I just tested it manually for the time being.

Release note (sql change): Added a cluster setting to enable the
experimental cost-based optimizer.