### PR TITLE
batcheval: fix error check in Get when READ_UNCOMMITTED

### DIFF
--- a/pkg/storage/batcheval/cmd_get.go
+++ b/pkg/storage/batcheval/cmd_get.go
@@ -37,6 +37,9 @@ func Get(
 
 	val, intents, err := engine.MVCCGet(ctx, batch, args.Key, h.Timestamp,
 		h.ReadConsistency == roachpb.CONSISTENT, h.Txn)
+	if err != nil {
+		return result.Result{}, err
+	}
 
 	reply.Value = val
 	if h.ReadConsistency == roachpb.READ_UNCOMMITTED {


### PR DESCRIPTION
Before this change, it was possible for a `READ_UNCOMMITTED`
`Get` to miss an error because the method overwrote its
`err` value before performing an error check. This change
fixes this.

Luckily, we never perform `READ_UNCOMMITTED` `Gets` at the moment,
we only perform `READ_UNCOMMITTED` `Scans` and `ReverseScans`.
Still, we'll need to be aware of this if we find a need for
`READ_UNCOMMITED` `Gets` in the 2.1 release cycle, because 2.0
clusters will have this bug.

Release note: None