### PR TITLE
[DO NOT MERGE] tombstonemap: proof of concept

### DIFF
--- a/pkg/util/tombstonemap/testdata/get
+++ b/pkg/util/tombstonemap/testdata/get
@@ -1,0 +1,1031 @@
+# 3: a-----------m
+# 2:      f------------s
+# 1:          j---------------z
+
+init
+a-m#3,f-s#2,j-z#1
+----
+a-m#3
+f-m#3
+f-m#2
+j-m#3
+j-m#2
+j-m#1
+m-s#2
+m-s#1
+s-z#1
+
+init
+a-a#1
+----
+
+# 3:  b-d
+# 1: a---e
+
+init
+a-e#1,b-d#3
+----
+a-e#1
+b-d#3
+b-e#1
+d-e#1
+
+init
+b-d#3,a-e#1
+----
+a-b#1
+b-d#3
+b-d#1
+d-e#1
+
+get t=3
+a#3 a#2 a#1 a#0
+----
+alive alive deleted deleted
+
+get t=2
+a#2 a#1 a#0
+----
+alive deleted deleted
+
+get t=1
+a#1 a#0
+----
+deleted deleted
+
+get t=3
+b#3 b#2 b#1 b#0
+----
+deleted deleted deleted deleted
+
+get t=2
+b#2 b#1 b#0
+----
+alive deleted deleted
+
+get t=1
+b#1 b#0
+----
+deleted deleted
+
+get t=3
+c#3 c#2 c#1 c#0
+----
+deleted deleted deleted deleted
+
+get t=2
+c#2 c#1 c#0
+----
+alive deleted deleted
+
+get t=1
+c#1 c#0
+----
+deleted deleted
+
+get t=3
+d#3 d#2 d#1 d#0
+----
+alive alive deleted deleted
+
+get t=2
+d#2 d#1 d#0
+----
+alive deleted deleted
+
+get t=1
+d#1 d#0
+----
+deleted deleted
+
+
+# 3: a---e
+# 1:  b-d
+
+init
+b-d#1,a-e#3
+----
+a-b#3
+b-d#3
+b-d#1
+d-e#3
+
+init
+a-e#3,b-d#1
+----
+a-e#3
+b-e#3
+b-d#1
+d-e#3
+
+get t=3
+a#3 a#2 a#1 a#0
+----
+deleted deleted deleted deleted
+
+get t=2
+a#2 a#1 a#0
+----
+alive alive alive
+
+get t=1
+a#1 a#0
+----
+alive alive
+
+get t=3
+b#3 b#2 b#1 b#0
+----
+deleted deleted deleted deleted
+
+get t=2
+b#2 b#1 b#0
+----
+alive deleted deleted
+
+get t=1
+b#1 b#0
+----
+deleted deleted
+
+get t=3
+c#3 c#2 c#1 c#0
+----
+deleted deleted deleted deleted
+
+get t=2
+c#2 c#1 c#0
+----
+alive deleted deleted
+
+get t=1
+c#1 c#0
+----
+deleted deleted
+
+get t=3
+d#3 d#2 d#1 d#0
+----
+deleted deleted deleted deleted
+
+get t=2
+d#2 d#1 d#0
+----
+alive alive alive
+
+get t=1
+d#1 d#0
+----
+alive alive
+
+
+# 3: a--d
+# 1:  b--e
+
+init
+b-e#1,a-d#3
+----
+a-b#3
+b-d#3
+b-e#1
+d-e#1
+
+init
+a-d#3,b-e#1
+----
+a-d#3
+b-d#3
+b-d#1
+d-e#1
+
+get t=3
+a#3 a#2 a#1 a#0
+----
+deleted deleted deleted deleted
+
+get t=2
+a#2 a#1 a#0
+----
+alive alive alive
+
+get t=1
+a#1 a#0
+----
+alive alive
+
+get t=3
+b#3 b#2 b#1 b#0
+----
+deleted deleted deleted deleted
+
+get t=2
+b#2 b#1 b#0
+----
+alive deleted deleted
+
+get t=1
+b#1 b#0
+----
+deleted deleted
+
+get t=3
+c#3 c#2 c#1 c#0
+----
+deleted deleted deleted deleted
+
+get t=2
+c#2 c#1 c#0
+----
+alive deleted deleted
+
+get t=1
+c#1 c#0
+----
+deleted deleted
+
+get t=3
+d#3 d#2 d#1 d#0
+----
+alive alive deleted deleted
+
+get t=2
+d#2 d#1 d#0
+----
+alive deleted deleted
+
+get t=1
+d#1 d#0
+----
+deleted deleted
+
+
+# 3:  b--e
+# 1: a--d
+
+init
+a-d#1,b-e#3
+----
+a-d#1
+b-d#3
+b-d#1
+d-e#3
+
+init
+b-e#3,a-d#1
+----
+a-b#1
+b-e#3
+b-d#1
+d-e#3
+
+get t=3
+a#3 a#2 a#1 a#0
+----
+alive alive deleted deleted
+
+get t=2
+a#2 a#1 a#0
+----
+alive deleted deleted
+
+get t=1
+a#1 a#0
+----
+deleted deleted
+
+get t=3
+b#3 b#2 b#1 b#0
+----
+deleted deleted deleted deleted
+
+get t=2
+b#2 b#1 b#0
+----
+alive deleted deleted
+
+get t=1
+b#1 b#0
+----
+deleted deleted
+
+get t=3
+c#3 c#2 c#1 c#0
+----
+deleted deleted deleted deleted
+
+get t=2
+c#2 c#1 c#0
+----
+alive deleted deleted
+
+get t=1
+c#1 c#0
+----
+deleted deleted
+
+get t=3
+d#3 d#2 d#1 d#0
+----
+deleted deleted deleted deleted
+
+get t=2
+d#2 d#1 d#0
+----
+alive alive alive
+
+get t=1
+d#1 d#0
+----
+alive alive
+
+
+# 3: a--d
+# 1: a---e
+
+init
+a-e#1,a-d#3
+----
+a-d#3
+a-e#1
+d-e#1
+
+init
+a-d#3,a-e#1
+----
+a-d#3
+a-d#1
+d-e#1
+
+get t=3
+a#3 a#2 a#1 a#0
+----
+deleted deleted deleted deleted
+
+get t=2
+a#2 a#1 a#0
+----
+alive deleted deleted
+
+get t=1
+a#1 a#0
+----
+deleted deleted
+
+get t=3
+b#3 b#2 b#1 b#0
+----
+deleted deleted deleted deleted
+
+get t=2
+b#2 b#1 b#0
+----
+alive deleted deleted
+
+get t=1
+b#1 b#0
+----
+deleted deleted
+
+get t=3
+c#3 c#2 c#1 c#0
+----
+deleted deleted deleted deleted
+
+get t=2
+c#2 c#1 c#0
+----
+alive deleted deleted
+
+get t=1
+c#1 c#0
+----
+deleted deleted
+
+get t=3
+d#3 d#2 d#1 d#0
+----
+alive alive deleted deleted
+
+get t=2
+d#2 d#1 d#0
+----
+alive deleted deleted
+
+get t=1
+d#1 d#0
+----
+deleted deleted
+
+
+# 3: a---e
+# 1: a--d
+
+init
+a-d#1,a-e#3
+----
+a-d#3
+a-d#1
+d-e#3
+
+init
+a-e#3,a-d#1
+----
+a-e#3
+a-d#1
+d-e#3
+
+get t=3
+a#3 a#2 a#1 a#0
+----
+deleted deleted deleted deleted
+
+get t=2
+a#2 a#1 a#0
+----
+alive deleted deleted
+
+get t=1
+a#1 a#0
+----
+deleted deleted
+
+get t=3
+b#3 b#2 b#1 b#0
+----
+deleted deleted deleted deleted
+
+get t=2
+b#2 b#1 b#0
+----
+alive deleted deleted
+
+get t=1
+b#1 b#0
+----
+deleted deleted
+
+get t=3
+c#3 c#2 c#1 c#0
+----
+deleted deleted deleted deleted
+
+get t=2
+c#2 c#1 c#0
+----
+alive deleted deleted
+
+get t=1
+c#1 c#0
+----
+deleted deleted
+
+get t=3
+d#3 d#2 d#1 d#0
+----
+deleted deleted deleted deleted
+
+get t=2
+d#2 d#1 d#0
+----
+alive alive alive
+
+get t=1
+d#1 d#0
+----
+alive alive
+
+
+# 3:  b--e
+# 1: a---e
+
+init
+a-e#1,b-e#3
+----
+a-e#1
+b-e#3
+b-e#1
+
+init
+b-e#3,a-e#1
+----
+a-b#1
+b-e#3
+b-e#1
+
+get t=3
+a#3 a#2 a#1 a#0
+----
+alive alive deleted deleted
+
+get t=2
+a#2 a#1 a#0
+----
+alive deleted deleted
+
+get t=1
+a#1 a#0
+----
+deleted deleted
+
+get t=3
+b#3 b#2 b#1 b#0
+----
+deleted deleted deleted deleted
+
+get t=2
+b#2 b#1 b#0
+----
+alive deleted deleted
+
+get t=1
+b#1 b#0
+----
+deleted deleted
+
+get t=3
+c#3 c#2 c#1 c#0
+----
+deleted deleted deleted deleted
+
+get t=2
+c#2 c#1 c#0
+----
+alive deleted deleted
+
+get t=1
+c#1 c#0
+----
+deleted deleted
+
+get t=3
+d#3 d#2 d#1 d#0
+----
+deleted deleted deleted deleted
+
+get t=2
+d#2 d#1 d#0
+----
+alive deleted deleted
+
+get t=1
+d#1 d#0
+----
+deleted deleted
+
+
+# 3: a---e
+# 1:  b--e
+
+init
+b-e#1,a-e#3
+----
+a-b#3
+b-e#3
+b-e#1
+
+init
+a-e#3,b-e#1
+----
+a-e#3
+b-e#3
+b-e#1
+
+get t=3
+a#3 a#2 a#1 a#0
+----
+deleted deleted deleted deleted
+
+get t=2
+a#2 a#1 a#0
+----
+alive alive alive
+
+get t=1
+a#1 a#0
+----
+alive alive
+
+get t=3
+b#3 b#2 b#1 b#0
+----
+deleted deleted deleted deleted
+
+get t=2
+b#2 b#1 b#0
+----
+alive deleted deleted
+
+get t=1
+b#1 b#0
+----
+deleted deleted
+
+get t=3
+c#3 c#2 c#1 c#0
+----
+deleted deleted deleted deleted
+
+get t=2
+c#2 c#1 c#0
+----
+alive deleted deleted
+
+get t=1
+c#1 c#0
+----
+deleted deleted
+
+get t=3
+d#3 d#2 d#1 d#0
+----
+deleted deleted deleted deleted
+
+get t=2
+d#2 d#1 d#0
+----
+alive deleted deleted
+
+get t=1
+d#1 d#0
+----
+deleted deleted
+
+
+# 3: a---e
+# 1: a---e
+
+init
+a-e#1,a-e#3
+----
+a-e#3
+a-e#1
+
+init
+a-e#3,a-e#1
+----
+a-e#3
+a-e#1
+
+get t=3
+a#3 a#2 a#1 a#0
+----
+deleted deleted deleted deleted
+
+get t=2
+a#2 a#1 a#0
+----
+alive deleted deleted
+
+get t=1
+a#1 a#0
+----
+deleted deleted
+
+get t=3
+b#3 b#2 b#1 b#0
+----
+deleted deleted deleted deleted
+
+get t=2
+b#2 b#1 b#0
+----
+alive deleted deleted
+
+get t=1
+b#1 b#0
+----
+deleted deleted
+
+get t=3
+c#3 c#2 c#1 c#0
+----
+deleted deleted deleted deleted
+
+get t=2
+c#2 c#1 c#0
+----
+alive deleted deleted
+
+get t=1
+c#1 c#0
+----
+deleted deleted
+
+get t=3
+d#3 d#2 d#1 d#0
+----
+deleted deleted deleted deleted
+
+get t=2
+d#2 d#1 d#0
+----
+alive deleted deleted
+
+get t=1
+d#1 d#0
+----
+deleted deleted
+
+
+# 3:   c-e
+# 1: a-c
+
+init
+a-c#1,c-e#3
+----
+a-c#1
+c-e#3
+
+init
+c-e#3,a-c#1
+----
+a-c#1
+c-e#3
+
+get t=3
+a#3 a#2 a#1 a#0
+----
+alive alive deleted deleted
+
+get t=2
+a#2 a#1 a#0
+----
+alive deleted deleted
+
+get t=1
+a#1 a#0
+----
+deleted deleted
+
+get t=3
+b#3 b#2 b#1 b#0
+----
+alive alive deleted deleted
+
+get t=2
+b#2 b#1 b#0
+----
+alive deleted deleted
+
+get t=1
+b#1 b#0
+----
+deleted deleted
+
+get t=3
+c#3 c#2 c#1 c#0
+----
+deleted deleted deleted deleted
+
+get t=2
+c#2 c#1 c#0
+----
+alive alive alive
+
+get t=1
+c#1 c#0
+----
+alive alive
+
+get t=3
+d#3 d#2 d#1 d#0
+----
+deleted deleted deleted deleted
+
+get t=2
+d#2 d#1 d#0
+----
+alive alive alive
+
+get t=1
+d#1 d#0
+----
+alive alive
+
+
+# 3: a-c
+# 1:   c-e
+
+init
+c-e#1,a-c#3
+----
+a-c#3
+c-e#1
+
+init
+a-c#3,c-e#1
+----
+a-c#3
+c-e#1
+
+get t=3
+a#3 a#2 a#1 a#0
+----
+deleted deleted deleted deleted
+
+get t=2
+a#2 a#1 a#0
+----
+alive alive alive
+
+get t=1
+a#1 a#0
+----
+alive alive
+
+get t=3
+b#3 b#2 b#1 b#0
+----
+deleted deleted deleted deleted
+
+get t=2
+b#2 b#1 b#0
+----
+alive alive alive
+
+get t=1
+b#1 b#0
+----
+alive alive
+
+get t=3
+c#3 c#2 c#1 c#0
+----
+alive alive deleted deleted
+
+get t=2
+c#2 c#1 c#0
+----
+alive deleted deleted
+
+get t=1
+c#1 c#0
+----
+deleted deleted
+
+get t=3
+d#3 d#2 d#1 d#0
+----
+alive alive deleted deleted
+
+get t=2
+d#2 d#1 d#0
+----
+alive deleted deleted
+
+get t=1
+d#1 d#0
+----
+deleted deleted
+
+
+# 3:    de
+# 1: a-c
+
+init
+a-c#1,d-e#3
+----
+a-c#1
+d-e#3
+
+init
+d-e#3,a-c#1
+----
+a-c#1
+d-e#3
+
+get t=3
+a#3 a#2 a#1 a#0
+----
+alive alive deleted deleted
+
+get t=2
+a#2 a#1 a#0
+----
+alive deleted deleted
+
+get t=1
+a#1 a#0
+----
+deleted deleted
+
+get t=3
+b#3 b#2 b#1 b#0
+----
+alive alive deleted deleted
+
+get t=2
+b#2 b#1 b#0
+----
+alive deleted deleted
+
+get t=1
+b#1 b#0
+----
+deleted deleted
+
+get t=3
+c#3 c#2 c#1 c#0
+----
+alive alive alive alive
+
+get t=2
+c#2 c#1 c#0
+----
+alive alive alive
+
+get t=1
+c#1 c#0
+----
+alive alive
+
+get t=3
+d#3 d#2 d#1 d#0
+----
+deleted deleted deleted deleted
+
+get t=2
+d#2 d#1 d#0
+----
+alive alive alive
+
+get t=1
+d#1 d#0
+----
+alive alive
+
+
+# 3: a-c
+# 1:    de
+
+init
+d-e#1,a-c#3
+----
+a-c#3
+d-e#1
+
+init
+a-c#3,d-e#1
+----
+a-c#3
+d-e#1
+
+get t=3
+a#3 a#2 a#1 a#0
+----
+deleted deleted deleted deleted
+
+get t=2
+a#2 a#1 a#0
+----
+alive alive alive
+
+get t=1
+a#1 a#0
+----
+alive alive
+
+get t=3
+b#3 b#2 b#1 b#0
+----
+deleted deleted deleted deleted
+
+get t=2
+b#2 b#1 b#0
+----
+alive alive alive
+
+get t=1
+b#1 b#0
+----
+alive alive
+
+get t=3
+c#3 c#2 c#1 c#0
+----
+alive alive alive alive
+
+get t=2
+c#2 c#1 c#0
+----
+alive alive alive
+
+get t=1
+c#1 c#0
+----
+alive alive
+
+get t=3
+d#3 d#2 d#1 d#0
+----
+alive alive deleted deleted
+
+get t=2
+d#2 d#1 d#0
+----
+alive deleted deleted
+
+get t=1
+d#1 d#0
+----
+deleted deleted

--- a/pkg/util/tombstonemap/tombstone_map.go
+++ b/pkg/util/tombstonemap/tombstone_map.go
@@ -1,0 +1,260 @@
+package tombstonemap
+
+import (
+	"bytes"
+	"fmt"
+	"sort"
+)
+
+type entry struct {
+	begin string
+	end   string
+	seq   int
+}
+
+func (e entry) String() string {
+	return fmt.Sprintf("%s-%s#%d", e.begin, e.end, e.seq)
+}
+
+type entries []*entry
+
+func (e entries) Len() int {
+	return len(e)
+}
+
+func (e entries) Less(i, j int) bool {
+	if e[i].begin < e[j].begin {
+		return true
+	}
+	if e[i].begin > e[j].begin {
+		return false
+	}
+	return e[i].seq > e[j].seq
+}
+
+func (e entries) Swap(i, j int) {
+	e[i], e[j] = e[j], e[i]
+}
+
+// M maintains a map of versioned tombstones and provides O(logn + k)
+// operations for adding a tombstone and determining whether a key is deleted
+// at a particular version (sequence number).
+//
+// The natural representation for this tombstone map would be an interval tree,
+// yet we need to work within the confines of the RocksDB iterator API. The
+// difficulty with this restriction is avoiding having to examine all of the
+// entries in the map. Consider the following scenario:
+//
+//   3: a-----------m
+//   2:      f------------s
+//   1:          j---------------z
+//
+// Imagine we index the tombstones by their start key. What happens if we query
+// for the key "t". We search in the tree and find the tombstone j-z#1. Great,
+// but how do we know this is the only tombstone that covers this key? We
+// don't. We have to look at the previous tombstone and the one before that,
+// etc, all the way to the tombstone with the smallest begin key because we
+// don't know how far each of these tombstones extend.
+//
+// In order to avoid this O(n) scanning operation, this maintains the invariant
+// that any tombstone start key will be the start key for the start key or end
+// key for any other overlapping tombstone. Tombstones are split upon being
+// added to the map and we "split" existing tombstones in the map based on the
+// new tombstone's begin key. In the example above, we create a structure that
+// looks like:
+//
+//   3: a----f---j--m
+//   2:      f---j--------s
+//   1:          j--------s------z
+//
+// This expands the number of tombstones, but allows query operations to know
+// at which point there are no interesting tombstones to the left of a key. In
+// order to fit within the restrictions of the RocksDB MemTable, existing
+// entries are not actually split. Instead, an overlapping tombstone at the
+// same sequence number is added. For example, j-z#1 is "split" by adding an
+// additional tombstone s-z#1.
+//
+// Note that overlapping tombstones do create pathological behavior here
+// (quadratic number of tombstones can be generated), yet overlapping
+// tombstones are rare in practice. If tombstones do not overlap, not
+// additional tombstones are created. The above structure can be encoded and
+// queried directly in the RocksDB memtable and sstables.
+//
+// The approach here is reminiscent of the CockroachDB timestamp cache, though
+// the timestamp cache is mildly simpler in that it only needs to maintain a
+// single value (the max timestamp) for overlapping ranges.
+type M struct {
+	// Tombstone map entries are contained in a single sorted slice. A real
+	// implementation would use a tree.
+	entries entries
+}
+
+// New constructs a new tombstone map.
+func New() *M {
+	return &M{}
+}
+
+func (m *M) String() string {
+	var buf bytes.Buffer
+	for _, e := range m.entries {
+		fmt.Fprintf(&buf, "%s\n", e)
+	}
+	return buf.String()
+}
+
+// index returns the index of the first entry in the map the potentially
+// overlaps the specified key. It is up to the caller to determine if an
+// overlap actually exists. This method is O(logn + k) where n is the total
+// number of tombstones and k is the number of overlapping tombstones anchored
+// at the same begin key.
+func (m *M) index(key string) int {
+	if len(m.entries) == 0 {
+		return -1
+	}
+
+	i := sort.Search(len(m.entries), func(i int) bool {
+		return m.entries[i].begin >= key
+	})
+
+	// i is currently positioned at the first entry which is greater than or
+	// equal to key. Entries are sorted by key and then by descending sequence
+	// number. Consider what happens if we have multiple entries beginning on a
+	// particular key, such as [a-c#3, a-c#2, a-c#1]. If we're searching for the
+	// key "b", we'll be positioned after that last entry. We need to back up
+	// until we reach the first entry.
+	if i == 0 || (i < len(m.entries) && m.entries[i].begin == key) {
+		// We're either at the first entry in the map, or we landed precisely on
+		// the start key for a tombstone.
+		return i
+	}
+
+	// Back up until we find the first version for the set of overlapping
+	// tombstones (we found the last version).
+	for i--; i > 0; i-- {
+		if m.entries[i-1].begin != m.entries[i].begin {
+			break
+		}
+	}
+
+	return i
+}
+
+// Add adds a tombstone from begin (inclusive) to end (exclusive) at the
+// specified sequence number.
+func (m *M) Add(begin, end string, seq int) {
+	i := m.index(begin)
+	n := len(m.entries)
+	if i >= 0 {
+		// Split both existing entries and the new entry at overlap points. This
+		// forces the invariant that if a range tombstone overlaps an existing
+		// tombstone they will share exactly the same start and end keys.
+		//
+		//        a----f---j--m
+		//             f---j--m-----s
+		//                 j--m-----s------z
+		for j := 0; i < n; i = j {
+			e := m.entries[i]
+			if begin >= e.end || end <= e.begin {
+				// If the new range is before past the current range we're done due to
+				// the way we've aligned the start and end points for overlapping
+				// ranges.
+				break
+			}
+
+			// Find the next set of overlapping existing entries. These entries all
+			// have the same start key and, by definition, will have the same end
+			// key. We grab the entire set because we might have to split them
+			// en-masse.
+			for j = i + 1; j < n; j++ {
+				if e.begin != m.entries[j].begin {
+					break
+				}
+			}
+
+			if begin < e.begin {
+				// new:      a------------------
+				// existing:       g-------------------
+				m.entries = append(m.entries, &entry{begin, e.begin, seq})
+				begin = e.begin
+			} else if begin > e.begin {
+				// new:            g-------------------
+				// existing: a------------------
+				for k := i; k < j; k++ {
+					t := m.entries[k]
+					// TODO(peter): the following modifies an existing entry.
+					// m.entries = append(m.entries, &entry{t.begin, begin, t.seq})
+					m.entries = append(m.entries, &entry{t.begin, t.end, t.seq})
+					m.entries[k].begin = begin
+				}
+			}
+			// invariant: begin == e.begin
+
+			if end > e.end {
+				// new:      -------------------------z
+				// existing: ------------m
+				m.entries = append(m.entries, &entry{begin, e.end, seq})
+				begin = e.end
+				continue
+			}
+			if end < e.end {
+				// new:      ------------m
+				// existing: -------------------------z
+				for k := i; k < j; k++ {
+					t := m.entries[k]
+					// TODO(peter): the following modifies an existing entry.
+					// m.entries = append(m.entries, &entry{t.begin, end, t.seq})
+					m.entries = append(m.entries, &entry{t.begin, t.end, t.seq})
+					m.entries[k].begin = end
+				}
+			}
+			// invariant: end <= e.end
+			break
+		}
+	}
+
+	if begin != end {
+		m.entries = append(m.entries, &entry{begin, end, seq})
+	}
+	sort.Sort(m.entries)
+}
+
+// Get returns true if the specified <key,seq> pair is deleted at the specified
+// read sequence number. Get ignores tombstones newer than the read sequence
+// number. This method is O(logn + k) where n is the total number of tombstones
+// and k is the number of overlapping tombstones anchored at the same begin
+// key.
+func (m *M) Get(key string, seq, readSeq int) bool {
+	// TODO(peter): Rather than use index(), we could use search sort. If the
+	// tombstone we land on contains our key we walk backward through the
+	// tombstones until we find one that is visible and that is newer than our
+	// key's sequence number.
+	i := m.index(key)
+	if i < 0 || i >= len(m.entries) {
+		return false
+	}
+	e := m.entries[i]
+	if key >= e.end {
+		// The key lies past the tombstone. Due to the way tombstones are split
+		// during insertion, this means the key does not reside within any
+		// tombstone.
+		return false
+	}
+
+	for ; i < len(m.entries); i++ {
+		e := m.entries[i]
+		if key < e.begin {
+			// The key lies before the tombstone.
+			break
+		}
+		if e.seq > readSeq {
+			// Ignore tombstones newer than our read sequence.
+			continue
+		}
+		if e.seq >= seq {
+			// The key lies within the tombstone and the tombstone is newer than the
+			// key.
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/util/tombstonemap/tombstone_map_test.go
+++ b/pkg/util/tombstonemap/tombstone_map_test.go
@@ -1,0 +1,91 @@
+package tombstonemap
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/testutils/datadriven"
+)
+
+var entryRe = regexp.MustCompile(`(\w+)-(\w+)#(\d+)`)
+
+func parseEntry(t *testing.T, s string) entry {
+	m := entryRe.FindStringSubmatch(s)
+	if len(m) != 4 {
+		t.Fatalf("expected 4 components, but found %d", len(m))
+	}
+	seq, err := strconv.Atoi(m[3])
+	if err != nil {
+		t.Fatal(err)
+	}
+	return entry{
+		begin: m[1],
+		end:   m[2],
+		seq:   seq,
+	}
+}
+
+func parseM(t *testing.T, s string) *M {
+	m := New()
+	for _, p := range strings.Split(s, ",") {
+		e := parseEntry(t, p)
+		m.Add(e.begin, e.end, e.seq)
+	}
+	return m
+}
+
+var getRe = regexp.MustCompile(`(\w+)#(\d+)`)
+
+func parseGet(t *testing.T, s string) (string, int) {
+	m := getRe.FindStringSubmatch(s)
+	if len(m) != 3 {
+		t.Fatalf("expected 3 components, but found %d", len(m))
+	}
+	seq, err := strconv.Atoi(m[2])
+	if err != nil {
+		t.Fatal(err)
+	}
+	return m[1], seq
+}
+
+func TestGet(t *testing.T) {
+	datadriven.Walk(t, "testdata", func(t *testing.T, path string) {
+		var m *M
+		datadriven.RunTest(t, path, func(d *datadriven.TestData) string {
+			switch d.Cmd {
+			case "get":
+				if len(d.CmdArgs) != 1 {
+					t.Fatalf("expected 1 argument, but found %s", d.CmdArgs)
+				}
+				if d.CmdArgs[0].Key != "t" {
+					t.Fatalf("expected timestamp argument, but found %s", d.CmdArgs[0])
+				}
+				readSeq, err := strconv.Atoi(d.CmdArgs[0].Vals[0])
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				var results []string
+				for _, p := range strings.Split(d.Input, " ") {
+					key, seq := parseGet(t, p)
+					if m.Get(key, seq, readSeq) {
+						results = append(results, "deleted")
+					} else {
+						results = append(results, "alive")
+					}
+				}
+				return strings.Join(results, " ") + "\n"
+
+			case "init":
+				m = parseM(t, d.Input)
+				return m.String()
+
+			default:
+				return fmt.Sprintf("unknown command: %s", d.Cmd)
+			}
+		})
+	})
+}


### PR DESCRIPTION
This is a proof of concept for how to represent versioned tombstones in
a sorted map while supporting efficient queries for whether a versioned
key is alive or deleted at a specific point in time.

This is not intended to be merged, but used as a reference for
implementation directly inside RocksDB.

See #24029.

See [RocksDB DeleteRange](https://docs.google.com/document/d/12iAMGqiXotAlbN6Ryh1P9Mp2xoLONaxUy39fjZ5MyK4/edit?usp=sharing) for a description of RocksDB range tombstones and the problems with the RangeDelAggregator approach.

We might be able to mitigate some of the problems with
RangeDelAggregator, but I wanted to explore how I would have tackled the
range tombstone implementation vs trying to patch the existing
implementation. This approach would allow us to query the range
tombstone data directly as it is stored in memtables and sstables
without converting it to another form suitable for querying.

A question that a diligent reader will bring up is how we will deal with
differing formats for the range-del-block in sstables. We'd have to add
some marker to the sstable footer to indicate a different format for the
range-del-block, and then I think we can convert the old format to the
new format when the range-del-block is loaded.

A remaining open question is how exactly this would be integrated with
RocksDB iterators. Ideally I'd like to keep a heap of active tombstones
for the current iteration location. I haven't worked out the details of
how this would be done.