### PR TITLE
sql: Add information_schema routines and parameters tables

### DIFF
--- a/pkg/sql/information_schema.go
+++ b/pkg/sql/information_schema.go
@@ -43,8 +43,10 @@ var informationSchema = virtualSchema{
 		informationSchemaConstraintColumnUsageTable,
 		informationSchemaEnabledRoles,
 		informationSchemaKeyColumnUsageTable,
+		informationSchemaParametersTable,
 		informationSchemaReferentialConstraintsTable,
 		informationSchemaRoleTableGrants,
+		informationSchemaRoutineTable,
 		informationSchemaSchemataTable,
 		informationSchemaSchemataTablePrivileges,
 		informationSchemaSequences,
@@ -466,6 +468,53 @@ CREATE TABLE information_schema.key_column_usage (
 	},
 }
 
+// Postgres: https://www.postgresql.org/docs/9.6/static/infoschema-parameters.html
+// MySQL:    https://dev.mysql.com/doc/refman/5.7/en/parameters-table.html
+var informationSchemaParametersTable = virtualSchemaTable{
+	schema: `
+CREATE TABLE information_schema.parameters (
+	SPECIFIC_CATALOG STRING,
+	SPECIFIC_SCHEMA STRING,
+	SPECIFIC_NAME STRING,
+	ORDINAL_POSITION INT,
+	PARAMETER_MODE STRING,
+	IS_RESULT STRING,
+	AS_LOCATOR STRING,
+	PARAMETER_NAME STRING,
+	DATA_TYPE STRING,
+	CHARACTER_MAXIMUM_LENGTH INT,
+	CHARACTER_OCTET_LENGTH INT,
+	CHARACTER_SET_CATALOG STRING,
+	CHARACTER_SET_SCHEMA STRING,
+	CHARACTER_SET_NAME STRING,
+	COLLATION_CATALOG STRING,
+	COLLATION_SCHEMA STRING,
+	COLLATION_NAME STRING,
+	NUMERIC_PRECISION INT,
+	NUMERIC_PRECISION_RADIX INT,
+	NUMERIC_SCALE INT,
+	DATETIME_PRECISION INT,
+	INTERVAL_TYPE STRING,
+	INTERVAL_PRECISION INT,
+	UDT_CATALOG STRING,
+	UDT_SCHEMA STRING,
+	UDT_NAME STRING,
+	SCOPE_CATALOG STRING,
+	SCOPE_SCHEMA STRING,
+	SCOPE_NAME STRING,
+	MAXIMUM_CARDINALITY INT,
+	DTD_IDENTIFIER STRING,
+	PARAMETER_DEFAULT STRING
+);
+`,
+	// This is the same as information_schema.table_privileges. In postgres, this virtual table does
+	// not show tables with grants provided through PUBLIC, but table_privileges does.
+	// Since we don't have the PUBLIC concept, the two virtual tables are identical.
+	populate: func(ctx context.Context, p *planner, dbContext *DatabaseDescriptor, addRow func(...tree.Datum) error) error {
+		return nil
+	},
+}
+
 var (
 	matchOptionFull    = tree.NewDString("FULL")
 	matchOptionPartial = tree.NewDString("PARTIAL")
@@ -577,6 +626,98 @@ CREATE TABLE information_schema.role_table_grants (
 	// not show tables with grants provided through PUBLIC, but table_privileges does.
 	// Since we don't have the PUBLIC concept, the two virtual tables are identical.
 	populate: populateTablePrivileges,
+}
+
+// Postgres: https://www.postgresql.org/docs/9.6/static/infoschema-routines.html
+// MySQL:    https://dev.mysql.com/doc/mysql-infoschema-excerpt/5.7/en/routines-table.html
+var informationSchemaRoutineTable = virtualSchemaTable{
+	schema: `
+CREATE TABLE information_schema.routines (
+	SPECIFIC_CATALOG STRING,
+	SPECIFIC_SCHEMA STRING,
+	SPECIFIC_NAME STRING,
+	ROUTINE_CATALOG STRING,
+	ROUTINE_SCHEMA STRING,
+	ROUTINE_NAME STRING,
+	ROUTINE_TYPE STRING,
+	MODULE_CATALOG STRING,
+	MODULE_SCHEMA STRING,
+	MODULE_NAME STRING,
+	UDT_CATALOG STRING,
+	UDT_SCHEMA STRING,
+	UDT_NAME STRING,
+	DATA_TYPE STRING,
+	CHARACTER_MAXIMUM_LENGTH INT,
+	CHARACTER_OCTET_LENGTH INT,
+	CHARACTER_SET_CATALOG STRING,
+	CHARACTER_SET_SCHEMA STRING,
+	CHARACTER_SET_NAME STRING,
+	COLLATION_CATALOG STRING,
+	COLLATION_SCHEMA STRING,
+	COLLATION_NAME STRING,
+	NUMERIC_PRECISION INT,
+	NUMERIC_PRECISION_RADIX INT,
+	NUMERIC_SCALE INT,
+	DATETIME_PRECISION INT,
+	INTERVAL_TYPE STRING,
+	INTERVAL_PRECISION STRING,
+	TYPE_UDT_CATALOG STRING,
+	TYPE_UDT_SCHEMA STRING,
+	TYPE_UDT_NAME STRING,
+	SCOPE_CATALOG STRING,
+	SCOPE_NAME STRING,
+	MAXIMUM_CARDINALITY INT,
+	DTD_IDENTIFIER STRING,
+	ROUTINE_BODY STRING,
+	ROUTINE_DEFINITION STRING,
+	EXTERNAL_NAME STRING,
+	EXTERNAL_LANGUAGE STRING,
+	PARAMETER_STYLE STRING,
+	IS_DETERMINSTIC STRING,
+	SQL_DATA_ACCESS STRING,
+	IS_NULL_CALL STRING,
+	SQL_PATH STRING,
+	SCHEMA_LEVEL_ROUTINE STRING,
+	MAX_DYNAMIC_RESULT_SETS INT,
+	IS_USER_DEFINED_CAST STRING,
+	IS_IMPLICITLY_INVOCABLE STRING,
+	SECURITY_TYPE STRING,
+	TO_SQL_SPECIFIC_CATALOG STRING,
+	TO_SQL_SPECIFIC_SCHEMA STRING,
+	TO_SQL_SPECIFIC_NAME STRING,
+	AS_LOCATOR STRING,
+	CREATED  TIMESTAMPTZ,
+	LAST_ALTERED TIMESTAMPTZ,
+	NEW_SAVEPOINT_LEVEL  STRING,
+	IS_UDT_DEPENDENT STRING,
+	RESULT_CAST_FROM_DATA_TYPE STRING,
+	RESULT_CAST_AS_LOCATOR STRING,
+	RESULT_CAST_CHAR_MAX_LENGTH  INT,
+	RESULT_CAST_CHAR_OCTET_LENGTH STRING,
+	RESULT_CAST_CHAR_SET_CATALOG STRING,
+	RESULT_CAST_CHAR_SET_SCHEMA  STRING,
+	RESULT_CAST_CHAR_SET_NAME STRING,
+	RESULT_CAST_COLLATION_CATALOG STRING,
+	RESULT_CAST_COLLATION_SCHEMA STRING,
+	RESULT_CAST_COLLATION_NAME STRING,
+	RESULT_CAST_NUMERIC_PRECISION INT,
+	RESULT_CAST_NUMERIC_PRECISION_RADIX INT,
+	RESULT_CAST_NUMERIC_SCALE INT,
+	RESULT_CAST_DATETIME_PRECISION STRING,
+	RESULT_CAST_INTERVAL_TYPE STRING,
+	RESULT_CAST_INTERVAL_PRECISION INT,
+	RESULT_CAST_TYPE_UDT_CATALOG STRING,
+	RESULT_CAST_TYPE_UDT_SCHEMA  STRING,
+	RESULT_CAST_TYPE_UDT_NAME STRING,
+	RESULT_CAST_SCOPE_CATALOG STRING,
+	RESULT_CAST_SCOPE_SCHEMA STRING,
+	RESULT_CAST_SCOPE_NAME STRING,
+	RESULT_CAST_MAXIMUM_CARDINALITY INT,
+	RESULT_CAST_DTD_IDENTIFIER STRING
+); `,
+	populate: func(ctx context.Context, p *planner, dbContext *DatabaseDescriptor, addRow func(...tree.Datum) error) error {
+		return nil
+	},
 }
 
 // Postgres: https://www.postgresql.org/docs/9.6/static/infoschema-schemata.html

--- a/pkg/sql/logictest/testdata/logic_test/grant_table
+++ b/pkg/sql/logictest/testdata/logic_test/grant_table
@@ -72,8 +72,10 @@ test      information_schema  columns                            public  SELECT
 test      information_schema  constraint_column_usage            public  SELECT
 test      information_schema  enabled_roles                      public  SELECT
 test      information_schema  key_column_usage                   public  SELECT
+test      information_schema  parameters                         public  SELECT
 test      information_schema  referential_constraints            public  SELECT
 test      information_schema  role_table_grants                  public  SELECT
+test      information_schema  routines                           public  SELECT
 test      information_schema  schema_privileges                  public  SELECT
 test      information_schema  schemata                           public  SELECT
 test      information_schema  sequences                          public  SELECT

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -21,8 +21,10 @@ columns
 constraint_column_usage
 enabled_roles
 key_column_usage
+parameters
 referential_constraints
 role_table_grants
+routines
 schema_privileges
 schemata
 sequences
@@ -125,8 +127,10 @@ columns
 constraint_column_usage
 enabled_roles
 key_column_usage
+parameters
 referential_constraints
 role_table_grants
+routines
 schema_privileges
 schemata
 sequences
@@ -244,8 +248,10 @@ information_schema  columns
 information_schema  constraint_column_usage
 information_schema  enabled_roles
 information_schema  key_column_usage
+information_schema  parameters
 information_schema  referential_constraints
 information_schema  role_table_grants
+information_schema  routines
 information_schema  schema_privileges
 information_schema  schemata
 information_schema  sequences
@@ -362,8 +368,10 @@ columns
 constraint_column_usage
 enabled_roles
 key_column_usage
+parameters
 referential_constraints
 role_table_grants
+routines
 schema_privileges
 schemata
 sequences
@@ -487,8 +495,10 @@ system         information_schema  columns                            SYSTEM VIE
 system         information_schema  constraint_column_usage            SYSTEM VIEW  NO                  1
 system         information_schema  enabled_roles                      SYSTEM VIEW  NO                  1
 system         information_schema  key_column_usage                   SYSTEM VIEW  NO                  1
+system         information_schema  parameters                         SYSTEM VIEW  NO                  1
 system         information_schema  referential_constraints            SYSTEM VIEW  NO                  1
 system         information_schema  role_table_grants                  SYSTEM VIEW  NO                  1
+system         information_schema  routines                           SYSTEM VIEW  NO                  1
 system         information_schema  schema_privileges                  SYSTEM VIEW  NO                  1
 system         information_schema  schemata                           SYSTEM VIEW  NO                  1
 system         information_schema  sequences                          SYSTEM VIEW  NO                  1
@@ -1037,6 +1047,7 @@ NULL     public   system         crdb_internal       node_queries               
 NULL     public   system         crdb_internal       node_runtime_info                  SELECT          NULL          NULL
 NULL     public   system         crdb_internal       node_sessions                      SELECT          NULL          NULL
 NULL     public   system         crdb_internal       node_statement_statistics          SELECT          NULL          NULL
+NULL     public   system         information_schema  parameters                         SELECT          NULL          NULL
 NULL     public   system         crdb_internal       partitions                         SELECT          NULL          NULL
 NULL     public   system         pg_catalog          pg_am                              SELECT          NULL          NULL
 NULL     public   system         pg_catalog          pg_attrdef                         SELECT          NULL          NULL
@@ -1096,6 +1107,7 @@ NULL     root     system         public              role_members               
 NULL     root     system         public              role_members                       SELECT          NULL          NULL
 NULL     root     system         public              role_members                       UPDATE          NULL          NULL
 NULL     public   system         information_schema  role_table_grants                  SELECT          NULL          NULL
+NULL     public   system         information_schema  routines                           SELECT          NULL          NULL
 NULL     public   system         crdb_internal       schema_changes                     SELECT          NULL          NULL
 NULL     public   system         information_schema  schema_privileges                  SELECT          NULL          NULL
 NULL     public   system         information_schema  schemata                           SELECT          NULL          NULL
@@ -1127,8 +1139,8 @@ NULL     root     system         public              table_statistics           
 NULL     root     system         public              table_statistics                   INSERT          NULL          NULL
 NULL     root     system         public              table_statistics                   SELECT          NULL          NULL
 NULL     root     system         public              table_statistics                   UPDATE          NULL          NULL
-NULL     public   system         information_schema  tables                             SELECT          NULL          NULL
 NULL     public   system         crdb_internal       tables                             SELECT          NULL          NULL
+NULL     public   system         information_schema  tables                             SELECT          NULL          NULL
 NULL     admin    system         public              ui                                 DELETE          NULL          NULL
 NULL     admin    system         public              ui                                 GRANT           NULL          NULL
 NULL     admin    system         public              ui                                 INSERT          NULL          NULL
@@ -1214,8 +1226,10 @@ NULL     public   system         information_schema  columns                    
 NULL     public   system         information_schema  constraint_column_usage            SELECT          NULL          NULL
 NULL     public   system         information_schema  enabled_roles                      SELECT          NULL          NULL
 NULL     public   system         information_schema  key_column_usage                   SELECT          NULL          NULL
+NULL     public   system         information_schema  parameters                         SELECT          NULL          NULL
 NULL     public   system         information_schema  referential_constraints            SELECT          NULL          NULL
 NULL     public   system         information_schema  role_table_grants                  SELECT          NULL          NULL
+NULL     public   system         information_schema  routines                           SELECT          NULL          NULL
 NULL     public   system         information_schema  schema_privileges                  SELECT          NULL          NULL
 NULL     public   system         information_schema  schemata                           SELECT          NULL          NULL
 NULL     public   system         information_schema  sequences                          SELECT          NULL          NULL
@@ -1599,6 +1613,141 @@ column_name     STRING  false  NULL     {}
 privilege_type  STRING  false  NULL     {}
 is_grantable    STRING  true   NULL     {}
 
+
+# test information_schema.routines
+query TTBTT colnames
+SHOW COLUMNS FROM information_schema.routines
+----
+Field                                Type                      Null  Default  Indices
+specific_catalog                     STRING                    true  NULL     {}
+specific_schema                      STRING                    true  NULL     {}
+specific_name                        STRING                    true  NULL     {}
+routine_catalog                      STRING                    true  NULL     {}
+routine_schema                       STRING                    true  NULL     {}
+routine_name                         STRING                    true  NULL     {}
+routine_type                         STRING                    true  NULL     {}
+module_catalog                       STRING                    true  NULL     {}
+module_schema                        STRING                    true  NULL     {}
+module_name                          STRING                    true  NULL     {}
+udt_catalog                          STRING                    true  NULL     {}
+udt_schema                           STRING                    true  NULL     {}
+udt_name                             STRING                    true  NULL     {}
+data_type                            STRING                    true  NULL     {}
+character_maximum_length             INT                       true  NULL     {}
+character_octet_length               INT                       true  NULL     {}
+character_set_catalog                STRING                    true  NULL     {}
+character_set_schema                 STRING                    true  NULL     {}
+character_set_name                   STRING                    true  NULL     {}
+collation_catalog                    STRING                    true  NULL     {}
+collation_schema                     STRING                    true  NULL     {}
+collation_name                       STRING                    true  NULL     {}
+numeric_precision                    INT                       true  NULL     {}
+numeric_precision_radix              INT                       true  NULL     {}
+numeric_scale                        INT                       true  NULL     {}
+datetime_precision                   INT                       true  NULL     {}
+interval_type                        STRING                    true  NULL     {}
+interval_precision                   STRING                    true  NULL     {}
+type_udt_catalog                     STRING                    true  NULL     {}
+type_udt_schema                      STRING                    true  NULL     {}
+type_udt_name                        STRING                    true  NULL     {}
+scope_catalog                        STRING                    true  NULL     {}
+scope_name                           STRING                    true  NULL     {}
+maximum_cardinality                  INT                       true  NULL     {}
+dtd_identifier                       STRING                    true  NULL     {}
+routine_body                         STRING                    true  NULL     {}
+routine_definition                   STRING                    true  NULL     {}
+external_name                        STRING                    true  NULL     {}
+external_language                    STRING                    true  NULL     {}
+parameter_style                      STRING                    true  NULL     {}
+is_determinstic                      STRING                    true  NULL     {}
+sql_data_access                      STRING                    true  NULL     {}
+is_null_call                         STRING                    true  NULL     {}
+sql_path                             STRING                    true  NULL     {}
+schema_level_routine                 STRING                    true  NULL     {}
+max_dynamic_result_sets              INT                       true  NULL     {}
+is_user_defined_cast                 STRING                    true  NULL     {}
+is_implicitly_invocable              STRING                    true  NULL     {}
+security_type                        STRING                    true  NULL     {}
+to_sql_specific_catalog              STRING                    true  NULL     {}
+to_sql_specific_schema               STRING                    true  NULL     {}
+to_sql_specific_name                 STRING                    true  NULL     {}
+as_locator                           STRING                    true  NULL     {}
+created                              TIMESTAMP WITH TIME ZONE  true  NULL     {}
+last_altered                         TIMESTAMP WITH TIME ZONE  true  NULL     {}
+new_savepoint_level                  STRING                    true  NULL     {}
+is_udt_dependent                     STRING                    true  NULL     {}
+result_cast_from_data_type           STRING                    true  NULL     {}
+result_cast_as_locator               STRING                    true  NULL     {}
+result_cast_char_max_length          INT                       true  NULL     {}
+result_cast_char_octet_length        STRING                    true  NULL     {}
+result_cast_char_set_catalog         STRING                    true  NULL     {}
+result_cast_char_set_schema          STRING                    true  NULL     {}
+result_cast_char_set_name            STRING                    true  NULL     {}
+result_cast_collation_catalog        STRING                    true  NULL     {}
+result_cast_collation_schema         STRING                    true  NULL     {}
+result_cast_collation_name           STRING                    true  NULL     {}
+result_cast_numeric_precision        INT                       true  NULL     {}
+result_cast_numeric_precision_radix  INT                       true  NULL     {}
+result_cast_numeric_scale            INT                       true  NULL     {}
+result_cast_datetime_precision       STRING                    true  NULL     {}
+result_cast_interval_type            STRING                    true  NULL     {}
+result_cast_interval_precision       INT                       true  NULL     {}
+result_cast_type_udt_catalog         STRING                    true  NULL     {}
+result_cast_type_udt_schema          STRING                    true  NULL     {}
+result_cast_type_udt_name            STRING                    true  NULL     {}
+result_cast_scope_catalog            STRING                    true  NULL     {}
+result_cast_scope_schema             STRING                    true  NULL     {}
+result_cast_scope_name               STRING                    true  NULL     {}
+result_cast_maximum_cardinality      INT                       true  NULL     {}
+result_cast_dtd_identifier           STRING                    true  NULL     {}
+
+query TTTTTTTTTTTTTTIITTTTTTIIIITTTTTTTITTTTTTTTTTTITTTTTTTTTTTTTITTTTTTTIIITTITTTTTTIT colnames
+SELECT * FROM information_schema.routines
+----
+specific_catalog  specific_schema  specific_name  routine_catalog  routine_schema  routine_name  routine_type  module_catalog  module_schema  module_name  udt_catalog  udt_schema  udt_name  data_type  character_maximum_length  character_octet_length  character_set_catalog  character_set_schema  character_set_name  collation_catalog  collation_schema  collation_name  numeric_precision  numeric_precision_radix  numeric_scale  datetime_precision  interval_type  interval_precision  type_udt_catalog  type_udt_schema  type_udt_name  scope_catalog  scope_name  maximum_cardinality  dtd_identifier  routine_body  routine_definition  external_name  external_language  parameter_style  is_determinstic  sql_data_access  is_null_call  sql_path  schema_level_routine  max_dynamic_result_sets  is_user_defined_cast  is_implicitly_invocable  security_type  to_sql_specific_catalog  to_sql_specific_schema  to_sql_specific_name  as_locator  created  last_altered  new_savepoint_level  is_udt_dependent  result_cast_from_data_type  result_cast_as_locator  result_cast_char_max_length  result_cast_char_octet_length  result_cast_char_set_catalog  result_cast_char_set_schema  result_cast_char_set_name  result_cast_collation_catalog  result_cast_collation_schema  result_cast_collation_name  result_cast_numeric_precision  result_cast_numeric_precision_radix  result_cast_numeric_scale  result_cast_datetime_precision  result_cast_interval_type  result_cast_interval_precision  result_cast_type_udt_catalog  result_cast_type_udt_schema  result_cast_type_udt_name  result_cast_scope_catalog  result_cast_scope_schema  result_cast_scope_name  result_cast_maximum_cardinality  result_cast_dtd_identifier
+
+# test information_schema.parameters
+query TTBTT colnames
+SHOW COLUMNS FROM information_schema.parameters
+----
+Field                     Type    Null  Default  Indices
+specific_catalog          STRING  true  NULL     {}
+specific_schema           STRING  true  NULL     {}
+specific_name             STRING  true  NULL     {}
+ordinal_position          INT     true  NULL     {}
+parameter_mode            STRING  true  NULL     {}
+is_result                 STRING  true  NULL     {}
+as_locator                STRING  true  NULL     {}
+parameter_name            STRING  true  NULL     {}
+data_type                 STRING  true  NULL     {}
+character_maximum_length  INT     true  NULL     {}
+character_octet_length    INT     true  NULL     {}
+character_set_catalog     STRING  true  NULL     {}
+character_set_schema      STRING  true  NULL     {}
+character_set_name        STRING  true  NULL     {}
+collation_catalog         STRING  true  NULL     {}
+collation_schema          STRING  true  NULL     {}
+collation_name            STRING  true  NULL     {}
+numeric_precision         INT     true  NULL     {}
+numeric_precision_radix   INT     true  NULL     {}
+numeric_scale             INT     true  NULL     {}
+datetime_precision        INT     true  NULL     {}
+interval_type             STRING  true  NULL     {}
+interval_precision        INT     true  NULL     {}
+udt_catalog               STRING  true  NULL     {}
+udt_schema                STRING  true  NULL     {}
+udt_name                  STRING  true  NULL     {}
+scope_catalog             STRING  true  NULL     {}
+scope_schema              STRING  true  NULL     {}
+scope_name                STRING  true  NULL     {}
+maximum_cardinality       INT     true  NULL     {}
+dtd_identifier            STRING  true  NULL     {}
+parameter_default         STRING  true  NULL     {}
+
+query TTTITTTTTIITTTTTTIIIITITTTTTTITT colnames
+SELECT * FROM information_schema.parameters
+----
+specific_catalog  specific_schema  specific_name  ordinal_position  parameter_mode  is_result  as_locator  parameter_name  data_type  character_maximum_length  character_octet_length  character_set_catalog  character_set_schema  character_set_name  collation_catalog  collation_schema  collation_name  numeric_precision  numeric_precision_radix  numeric_scale  datetime_precision  interval_type  interval_precision  udt_catalog  udt_schema  udt_name  scope_catalog  scope_schema  scope_name  maximum_cardinality  dtd_identifier  parameter_default
 
 query TTTTTTTT colnames
 SELECT * FROM system.information_schema.column_privileges WHERE table_name = 'eventlog'

--- a/pkg/sql/logictest/testdata/planner_test/explain
+++ b/pkg/sql/logictest/testdata/planner_test/explain
@@ -156,7 +156,7 @@ sort                   ·      ·
  └── render            ·      ·
       └── filter       ·      ·
            └── values  ·      ·
-·                      size   6 columns, 84 rows
+·                      size   6 columns, 86 rows
 
 query TTT
 EXPLAIN SHOW DATABASE
@@ -219,7 +219,7 @@ sort                                       ·            ·
                      ├── render            ·            ·
                      │    └── filter       ·            ·
                      │         └── values  ·            ·
-                     │                     size         17 columns, 775 rows
+                     │                     size         17 columns, 888 rows
                      └── render            ·            ·
                           └── filter       ·            ·
                                └── values  ·            ·
@@ -233,7 +233,7 @@ sort                   ·      ·
  └── render            ·      ·
       └── filter       ·      ·
            └── values  ·      ·
-·                      size   8 columns, 545 rows
+·                      size   8 columns, 555 rows
 
 
 query TTT

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain
@@ -157,7 +157,7 @@ sort                   ·      ·
  └── render            ·      ·
       └── filter       ·      ·
            └── values  ·      ·
-·                      size   6 columns, 84 rows
+·                      size   6 columns, 86 rows
 
 query TTT
 EXPLAIN SHOW DATABASE
@@ -220,7 +220,7 @@ sort                                       ·            ·
                      ├── render            ·            ·
                      │    └── filter       ·            ·
                      │         └── values  ·            ·
-                     │                     size         17 columns, 775 rows
+                     │                     size         17 columns, 888 rows
                      └── render            ·            ·
                           └── filter       ·            ·
                                └── values  ·            ·
@@ -234,7 +234,7 @@ sort                   ·      ·
  └── render            ·      ·
       └── filter       ·      ·
            └── values  ·      ·
-·                      size   8 columns, 545 rows
+·                      size   8 columns, 555 rows
 
 
 query TTT


### PR DESCRIPTION
Release note (sql change): Added placeholder information_schema.routines and
information_schema.parameters for compatibility with Navicat, PGAdmin
and other clients that require them.

closes #24759 