### PR TITLE
storage: make test use a non-transactional sender

### DIFF
--- a/pkg/storage/replica_test.go
+++ b/pkg/storage/replica_test.go
@@ -9002,7 +9002,7 @@ func TestErrorInRaftApplicationClearsIntents(t *testing.T) {
 	ba.Header.Txn = txn
 	ba.Add(&btArgs)
 	assignSeqNumsForReqs(txn, &btArgs)
-	if _, pErr := s.DB().GetSender().Send(context.TODO(), ba); pErr != nil {
+	if _, pErr := s.DB().GetFactory().WrappedSender().Send(context.TODO(), ba); pErr != nil {
 		t.Fatal(pErr.GoError())
 	}
 


### PR DESCRIPTION
A test was using an "unbound" TxnCoordSender to send a transactional
request and we don't like that. This test wants low level access, so go
straight to the DistSender.

Release note: None