### PR TITLE
client, kv: make createNonCancelableDB sane

### DIFF
--- a/pkg/kv/txn_coord_sender_test.go
+++ b/pkg/kv/txn_coord_sender_test.go
@@ -1468,28 +1468,17 @@ func TestTxnOnePhaseCommit(t *testing.T) {
 	checkTxnMetrics(t, metrics, "commit 1PC txn", 1, 1 /* 1PC */, 0, 0, 0)
 }
 
-// createNonCancelableDB returns a client DB and a sender. The sender
-// will be used for every transaction sent through the DB, so use with
-// care. The point is that every invocation of TxnCoordSender.Send will
-// be supplied a context with Done()==nil.
-func createNonCancelableDB(
-	db *client.DB, hbInterval time.Duration, clientTimeout time.Duration,
+// createTimeoutDB returns a DB whose txns are considered abandoned by the
+// TxnCoordSender after a given timeout.
+func createTimeoutDB(
+	db *client.DB, dbCtx client.DBContext, hbInterval time.Duration, clientTimeout time.Duration,
 ) *client.DB {
-	// Create the single txn coord for this test.
-	tc := db.GetFactory().New(client.RootTxn).(*TxnCoordSender)
-	tc.heartbeatInterval = hbInterval
-	tc.clientTimeout = clientTimeout
-
-	// client.Txn supplies a non-cancelable context, which makes the
-	// transaction coordinator ignore timeout-based abandonment and use the
-	// context's lifetime instead. In this test, we are testing timeout-based
-	// abandonment, so we need to supply a non-cancelable context.
-	var factory client.TxnSenderFactoryFunc = func(_ client.TxnType) client.TxnSender {
-		return client.TxnSenderFunc(func(_ context.Context, ba roachpb.BatchRequest) (*roachpb.BatchResponse, *roachpb.Error) {
-			return tc.Send(context.Background(), ba)
-		})
-	}
-	return client.NewDB(factory, tc.TxnCoordSenderFactory.clock)
+	origFactory := db.GetFactory().(*TxnCoordSenderFactory)
+	factory := *origFactory
+	factory.heartbeatInterval = hbInterval
+	factory.clientTimeout = clientTimeout
+	dbCtx.UseTimeoutTxnAbandonment = true
+	return client.NewDBWithContext(&factory, factory.clock, dbCtx)
 }
 
 func TestTxnAbandonCount(t *testing.T) {
@@ -1506,7 +1495,7 @@ func TestTxnAbandonCount(t *testing.T) {
 
 	hbInterval := 2 * time.Millisecond
 	clientTimeout := 1 * time.Millisecond
-	db := createNonCancelableDB(s.DB, hbInterval, clientTimeout)
+	db := createTimeoutDB(s.DB, *s.DBContext, hbInterval, clientTimeout)
 
 	if err := db.Txn(ctx, func(ctx context.Context, txn *client.Txn) error {
 		count++
@@ -1564,7 +1553,7 @@ func TestTxnReadAfterAbandon(t *testing.T) {
 
 	hbInterval := s.DB.GetFactory().(*TxnCoordSenderFactory).heartbeatInterval
 	clientTimeout := s.DB.GetFactory().(*TxnCoordSenderFactory).clientTimeout
-	db := createNonCancelableDB(s.DB, hbInterval, clientTimeout)
+	db := createTimeoutDB(s.DB, *s.DBContext, hbInterval, clientTimeout)
 
 	err := db.Txn(context.Background(), func(ctx context.Context, txn *client.Txn) error {
 		count++


### PR DESCRIPTION
More improvements to createNonCancelableDB - it now returns a legit DB
versus the monstrosity it was returning before.
We no longer create a TxnCoordSender before the transaction that's going
to use it - a practice which is about to become a problem with other
changes that are going on.

Release note: None