### PR TITLE
kv: make transport.SendNext synchronous

### DIFF
--- a/pkg/kv/local_test_cluster_util.go
+++ b/pkg/kv/local_test_cluster_util.go
@@ -39,11 +39,11 @@ type localTestClusterTransport struct {
 	latency time.Duration
 }
 
-func (l *localTestClusterTransport) SendNext(ctx context.Context, done chan<- BatchCall) {
+func (l *localTestClusterTransport) SendNext(ctx context.Context) (*roachpb.BatchResponse, error) {
 	if l.latency > 0 {
 		time.Sleep(l.latency)
 	}
-	l.Transport.SendNext(ctx, done)
+	return l.Transport.SendNext(ctx)
 }
 
 // InitFactoryForLocalTestCluster initializes a TxnCoordSenderFactory

--- a/pkg/kv/send_test.go
+++ b/pkg/kv/send_test.go
@@ -94,15 +94,13 @@ func (f *firstNErrorTransport) GetPending() []roachpb.ReplicaDescriptor {
 	return nil
 }
 
-func (f *firstNErrorTransport) SendNext(_ context.Context, done chan<- BatchCall) {
-	call := BatchCall{
-		Reply: &roachpb.BatchResponse{},
-	}
+func (f *firstNErrorTransport) SendNext(_ context.Context) (*roachpb.BatchResponse, error) {
+	var err error
 	if f.numSent < f.numErrors {
-		call.Err = roachpb.NewSendError("test")
+		err = roachpb.NewSendError("test")
 	}
 	f.numSent++
-	done <- call
+	return &roachpb.BatchResponse{}, err
 }
 
 func (f *firstNErrorTransport) NextReplica() roachpb.ReplicaDescriptor {

--- a/pkg/server/status/health_check.go
+++ b/pkg/server/status/health_check.go
@@ -50,7 +50,6 @@ var trackedMetrics = map[string]threshold{
 	"ranges.underreplicated":      gaugeZero,
 	"requests.backpressure.split": gaugeZero,
 	"requests.slow.commandqueue":  gaugeZero,
-	"requests.slow.distsender":    gaugeZero,
 	"requests.slow.lease":         gaugeZero,
 	"requests.slow.raft":          gaugeZero,
 	"sys.goroutines":              {gauge: true, min: 5000},

--- a/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/requests.tsx
+++ b/pkg/ui/src/views/cluster/containers/nodeGraphs/dashboards/requests.tsx
@@ -6,15 +6,9 @@ import { Metric, Axis } from "src/views/shared/components/metricQuery";
 import { GraphDashboardProps } from "./dashboardUtils";
 
 export default function (props: GraphDashboardProps) {
-  const { storeSources, nodeSources } = props;
+  const { storeSources } = props;
 
   return [
-    <LineGraph title="Slow Distsender Requests" sources={nodeSources}>
-      <Axis label="requests">
-        <Metric name="cr.node.requests.slow.distsender" title="Slow Distsender Requests" nonNegativeRate />
-      </Axis>
-    </LineGraph>,
-
     <LineGraph title="Slow Raft Proposals" sources={storeSources}>
       <Axis label="proposals">
         <Metric name="cr.store.requests.slow.raft" title="Slow Raft Proposals" nonNegativeRate />


### PR DESCRIPTION
Previously, transport.SendNext was asynchronous. It would return its
results on a channel that was passed in, and immediately return instead
of blocking.

To do this, the primary implementation (grpcTransport.SendNext()) would
spin up a new goroutine every time it was called with more than one
target replica.

This was expensive and showed up in profiles. It was a relic of when the
transport used to send to multiple replicas in parallel. Now that it
doesn't do this, keeping the extra goroutine is pointless overhead.

As a side-effect, we temporarily lose the ability to track in-flight
"slow distsender" requests as a a metric, or log them once they exceed
the slow request threshold. This ability could be resurrected if
necessary by adding a DistSender nanny goroutine that periodically polls
a request registry, but it's not clear whether anybody cares about this
functionality, so this commit just removes the metric and log.

Release note: None