### PR TITLE
sql: cluster settings: outbox flush timer+bufsize

### DIFF
--- a/docs/generated/settings/settings.html
+++ b/docs/generated/settings/settings.html
@@ -45,6 +45,8 @@
 <tr><td><code>sql.distsql.distribute_index_joins</code></td><td>boolean</td><td><code>true</code></td><td>if set, for index joins we instantiate a join reader on every node that has a stream; if not set, we use a single join reader</td></tr>
 <tr><td><code>sql.distsql.interleaved_joins.enabled</code></td><td>boolean</td><td><code>true</code></td><td>if set we plan interleaved table joins instead of merge joins when possible</td></tr>
 <tr><td><code>sql.distsql.merge_joins.enabled</code></td><td>boolean</td><td><code>true</code></td><td>if set, we plan merge joins when possible</td></tr>
+<tr><td><code>sql.distsql.outbox_buf_rows</code></td><td>integer</td><td><code>16</code></td><td>amount of rows to buffer in the outbox</td></tr>
+<tr><td><code>sql.distsql.outbox_flush_period</code></td><td>duration</td><td><code>100µs</code></td><td>duration to wait before flushing an idle outbox</td></tr>
 <tr><td><code>sql.distsql.temp_storage.joins</code></td><td>boolean</td><td><code>true</code></td><td>set to true to enable use of disk for distributed sql joins</td></tr>
 <tr><td><code>sql.distsql.temp_storage.sorts</code></td><td>boolean</td><td><code>true</code></td><td>set to true to enable use of disk for distributed sql sorts</td></tr>
 <tr><td><code>sql.distsql.temp_storage.workmem</code></td><td>byte size</td><td><code>64 MiB</code></td><td>maximum amount of memory in bytes a processor can use before falling back to temp storage</td></tr>


### PR DESCRIPTION
Two new cluster settings permit modification of the outbox flush timer
and buffer size, which is helpful for tuning large queries.

Release note: None