### PR TITLE
distsqlrun: delete MultiplexedRowChannel

### DIFF
--- a/pkg/sql/distsqlrun/base_test.go
+++ b/pkg/sql/distsqlrun/base_test.go
@@ -34,7 +34,7 @@ func TestRunDrain(t *testing.T) {
 
 	// A source with no rows and 2 ProducerMetadata messages.
 	src := &RowChannel{}
-	src.InitWithBufSize(nil, 10)
+	src.initWithBufSizeAndNumSenders(nil, 10, 1)
 	src.Push(nil /* row */, &ProducerMetadata{Err: fmt.Errorf("test")})
 	src.Push(nil /* row */, nil /* meta */)
 	src.Start(ctx)
@@ -62,7 +62,7 @@ func BenchmarkRowChannelPipeline(b *testing.B) {
 			wg.Add(len(rc))
 
 			for i := range rc {
-				rc[i].Init(oneIntCol)
+				rc[i].InitWithNumSenders(oneIntCol, 1)
 
 				go func(i int) {
 					defer wg.Done()
@@ -108,8 +108,8 @@ func BenchmarkMultiplexedRowChannel(b *testing.B) {
 			for i := 0; i < b.N; i++ {
 				var wg sync.WaitGroup
 				wg.Add(senders + 1)
-				mrc := &MultiplexedRowChannel{}
-				mrc.Init(senders, oneIntCol)
+				mrc := &RowChannel{}
+				mrc.InitWithNumSenders(oneIntCol, senders)
 				go func() {
 					for {
 						if r, _ := mrc.Next(); r == nil {

--- a/pkg/sql/distsqlrun/flow.go
+++ b/pkg/sql/distsqlrun/flow.go
@@ -338,29 +338,20 @@ func (f *Flow) setup(ctx context.Context, spec *FlowSpec) error {
 			var sync RowSource
 			switch is.Type {
 			case InputSyncSpec_UNORDERED:
-				if len(is.Streams) == 1 {
-					rowChan := &RowChannel{}
-					rowChan.Init(is.ColumnTypes)
-					if err := f.setupInboundStream(ctx, is.Streams[0], rowChan); err != nil {
+				mrc := &RowChannel{}
+				mrc.InitWithNumSenders(is.ColumnTypes, len(is.Streams))
+				for _, s := range is.Streams {
+					if err := f.setupInboundStream(ctx, s, mrc); err != nil {
 						return err
 					}
-					sync = rowChan
-				} else {
-					mrc := &MultiplexedRowChannel{}
-					mrc.Init(len(is.Streams), is.ColumnTypes)
-					for _, s := range is.Streams {
-						if err := f.setupInboundStream(ctx, s, mrc); err != nil {
-							return err
-						}
-					}
-					sync = mrc
 				}
+				sync = mrc
 			case InputSyncSpec_ORDERED:
 				// Ordered synchronizer: create a RowChannel for each input.
 				streams := make([]RowSource, len(is.Streams))
 				for i, s := range is.Streams {
 					rowChan := &RowChannel{}
-					rowChan.Init(is.ColumnTypes)
+					rowChan.InitWithNumSenders(is.ColumnTypes, 1)
 					if err := f.setupInboundStream(ctx, s, rowChan); err != nil {
 						return err
 					}
@@ -422,7 +413,7 @@ func (f *Flow) setup(ctx context.Context, spec *FlowSpec) error {
 				for inIdx, in := range ps.Input {
 					// Look for "simple" inputs: an unordered input (which, by definition,
 					// doesn't require an ordered synchronizer), with a single input stream
-					// (which doesn't require a MultiplexedRowChannel).
+					// (which doesn't require a multiplexed RowChannel).
 					if in.Type != InputSyncSpec_UNORDERED {
 						continue
 					}

--- a/pkg/sql/distsqlrun/input_sync_test.go
+++ b/pkg/sql/distsqlrun/input_sync_test.go
@@ -144,8 +144,8 @@ func TestUnorderedSync(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	columnTypeInt := sqlbase.ColumnType{SemanticType: sqlbase.ColumnType_INT}
-	mrc := &MultiplexedRowChannel{}
-	mrc.Init(5, []sqlbase.ColumnType{columnTypeInt})
+	mrc := &RowChannel{}
+	mrc.InitWithNumSenders([]sqlbase.ColumnType{columnTypeInt}, 5)
 	producerErr := make(chan error, 100)
 	for i := 1; i <= 5; i++ {
 		go func(i int) {
@@ -193,8 +193,8 @@ func TestUnorderedSync(t *testing.T) {
 	}
 
 	// Test case when one source closes with an error.
-	mrc = &MultiplexedRowChannel{}
-	mrc.Init(5, []sqlbase.ColumnType{columnTypeInt})
+	mrc = &RowChannel{}
+	mrc.InitWithNumSenders([]sqlbase.ColumnType{columnTypeInt}, 5)
 	for i := 1; i <= 5; i++ {
 		go func(i int) {
 			for j := 1; j <= 100; j++ {

--- a/pkg/sql/distsqlrun/outbox.go
+++ b/pkg/sql/distsqlrun/outbox.go
@@ -91,7 +91,7 @@ func (m *outbox) init(types []sqlbase.ColumnType) {
 		// rows.
 		types = make([]sqlbase.ColumnType, 0)
 	}
-	m.RowChannel.Init(types)
+	m.RowChannel.InitWithNumSenders(types, 1)
 	m.encoder.init(types)
 }
 

--- a/pkg/sql/distsqlrun/routers_test.go
+++ b/pkg/sql/distsqlrun/routers_test.go
@@ -448,7 +448,7 @@ func TestMetadataIsForwarded(t *testing.T) {
 			chans := make([]RowChannel, 2)
 			recvs := make([]RowReceiver, 2)
 			for i := 0; i < 2; i++ {
-				chans[i].InitWithBufSize(nil /* no column types */, 1)
+				chans[i].initWithBufSizeAndNumSenders(nil /* no column types */, 1, 1)
 				recvs[i] = &chans[i]
 			}
 			router, wg := setupRouter(t, evalCtx, tc.spec, nil /* no columns */, recvs)
@@ -565,7 +565,7 @@ func TestRouterBlocks(t *testing.T) {
 			chans := make([]RowChannel, 2)
 			recvs := make([]RowReceiver, 2)
 			for i := 0; i < 2; i++ {
-				chans[i].InitWithBufSize(colTypes, 1)
+				chans[i].initWithBufSizeAndNumSenders(colTypes, 1, 1)
 				recvs[i] = &chans[i]
 			}
 			router, err := makeRouter(&tc.spec, recvs)
@@ -687,7 +687,7 @@ func TestRangeRouterInit(t *testing.T) {
 			chans := make([]RowChannel, 2)
 			recvs := make([]RowReceiver, 2)
 			for i := 0; i < 2; i++ {
-				chans[i].InitWithBufSize(colTypes, 1)
+				chans[i].initWithBufSizeAndNumSenders(colTypes, 1, 1)
 				recvs[i] = &chans[i]
 			}
 			_, err := makeRouter(&spec, recvs)
@@ -734,7 +734,7 @@ func BenchmarkRouter(b *testing.B) {
 					for i := 0; i < b.N; i++ {
 						input.Reset()
 						for i := 0; i < nOutputs; i++ {
-							chans[i].InitWithBufSize(colTypes, rowChannelBufSize)
+							chans[i].InitWithNumSenders(colTypes, 1)
 							recvs[i] = &chans[i]
 						}
 						r, wg := setupRouter(b, evalCtx, spec, colTypes, recvs)


### PR DESCRIPTION
It was almost identical to RowChannel. RowChannel can do the extra work
of MultiplexedRowChannel with no overhead, because all of the extra work
lives solely in the various Closed methods.

Release note: None