### PR TITLE
Makefile: don't set MACOS_DEPLOYMENT_TARGET if not on macOS

### DIFF
--- a/build/variables.mk
+++ b/build/variables.mk
@@ -163,6 +163,7 @@ define VALID_VARS
   langgen-package
   logictest-package
   logictestccl-package
+  macos-version
   optgen-defs
   optgen-norm-rules
   optgen-package


### PR DESCRIPTION
In speeding up the build system boot time (#26187) I accidentally made
it such that the MACOS_DEPLOYMENT_TARGET env var was getting exported on
non-macOS platforms. This was breaking our release pipeline.

Also suppress an annoying warning when sw_vers does not exist. It is not
expected to exist on non-macOS platforms.

Fix #26351.

Release note: None