### PR TITLE
Makefile: don't cache GOPATH

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -207,7 +207,8 @@ XGO     ?= xgo
 TAR     ?= tar
 
 # Ensure we have an unambiguous GOPATH.
-ifdef have-defs
+GOPATH := $(shell $(GO) env GOPATH)
+
 ifneq "$(or $(findstring :,$(GOPATH)),$(findstring ;,$(GOPATH)))" ""
 $(error GOPATHs with multiple entries are not supported)
 endif
@@ -226,7 +227,6 @@ $(error GOPATH=/ is not supported)
 endif
 
 $(info GOPATH set to $(GOPATH))
-endif
 
 # We install our vendored tools to a directory within this repository to avoid
 # overwriting any user-installed binaries of the same name in the default GOBIN.
@@ -718,7 +718,6 @@ ifndef IGNORE_GOVERS
 	@build/go-version-check.sh $(GO) || { echo "Disable this check with IGNORE_GOVERS=1." >&2; exit 1; }
 endif
 	@echo "macos-version = $$(sw_vers -productVersion 2>/dev/null | grep -oE '[0-9]+\.[0-9]+')" > $@
-	@echo "export GOPATH ?= $$($(GO) env GOPATH)" >> $@
 	@echo "GOEXE = $$($(XGO) env GOEXE)" >> $@
 	@echo "NCPUS = $$({ getconf _NPROCESSORS_ONLN || sysctl -n hw.ncpu || nproc; } 2>/dev/null)" >> $@
 	@echo "UNAME = $$(uname)" >> $@


### PR DESCRIPTION
Caching the output of GOPATH, as introduced in #26187, turns out to
interact poorly with our GOPATH validation. Because the builder and the
host share build/defs.mk, it's possible to end up in a state where Make
sees an invalid but stale GOPATH and aborts the build, instead of
rebuilding build/defs.mk to get a up-to-date and valid GOPATH.

Just don't cache GOPATH to avoid the problem.

Release note: None