### PR TITLE
distsql: add stats collection to hashJoiner

### DIFF
--- a/pkg/sql/distsqlrun/api.pb.go
+++ b/pkg/sql/distsqlrun/api.pb.go
@@ -60,6 +60,7 @@
 		InterleavedReaderJoinerSpec
 		InputStats
 		TableReaderStats
+		HashJoinerStats
 */
 package distsqlrun
 

--- a/pkg/sql/distsqlrun/joinerbase.go
+++ b/pkg/sql/distsqlrun/joinerbase.go
@@ -124,6 +124,13 @@ func otherSide(s joinSide) joinSide {
 	return joinSide(1 - uint8(s))
 }
 
+func (j joinSide) String() string {
+	if j == leftSide {
+		return "left"
+	}
+	return "right"
+}
+
 // renderUnmatchedRow creates a result row given an unmatched row on either
 // side. Only used for outer joins.
 func (jb *joinerBase) renderUnmatchedRow(

--- a/pkg/sql/distsqlrun/stats.pb.go
+++ b/pkg/sql/distsqlrun/stats.pb.go
@@ -35,9 +35,24 @@ func (m *TableReaderStats) String() string            { return proto.CompactText
 func (*TableReaderStats) ProtoMessage()               {}
 func (*TableReaderStats) Descriptor() ([]byte, []int) { return fileDescriptorStats, []int{1} }
 
+// HashJoinerStats are the stats collected during a hashJoiner run.
+type HashJoinerStats struct {
+	LeftInputStats   InputStats `protobuf:"bytes,1,opt,name=left_input_stats,json=leftInputStats" json:"left_input_stats"`
+	RightInputStats  InputStats `protobuf:"bytes,2,opt,name=right_input_stats,json=rightInputStats" json:"right_input_stats"`
+	StoredSide       string     `protobuf:"bytes,3,opt,name=stored_side,json=storedSide,proto3" json:"stored_side,omitempty"`
+	MaxAllocatedMem  int64      `protobuf:"varint,4,opt,name=max_allocated_mem,json=maxAllocatedMem,proto3" json:"max_allocated_mem,omitempty"`
+	MaxAllocatedDisk int64      `protobuf:"varint,5,opt,name=max_allocated_disk,json=maxAllocatedDisk,proto3" json:"max_allocated_disk,omitempty"`
+}
+
+func (m *HashJoinerStats) Reset()                    { *m = HashJoinerStats{} }
+func (m *HashJoinerStats) String() string            { return proto.CompactTextString(m) }
+func (*HashJoinerStats) ProtoMessage()               {}
+func (*HashJoinerStats) Descriptor() ([]byte, []int) { return fileDescriptorStats, []int{2} }
+
 func init() {
 	proto.RegisterType((*InputStats)(nil), "cockroach.sql.distsqlrun.InputStats")
 	proto.RegisterType((*TableReaderStats)(nil), "cockroach.sql.distsqlrun.TableReaderStats")
+	proto.RegisterType((*HashJoinerStats)(nil), "cockroach.sql.distsqlrun.HashJoinerStats")
 }
 func (m *InputStats) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
@@ -88,6 +103,56 @@ func (m *TableReaderStats) MarshalTo(dAtA []byte) (int, error) {
 	return i, nil
 }
 
+func (m *HashJoinerStats) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalTo(dAtA)
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *HashJoinerStats) MarshalTo(dAtA []byte) (int, error) {
+	var i int
+	_ = i
+	var l int
+	_ = l
+	dAtA[i] = 0xa
+	i++
+	i = encodeVarintStats(dAtA, i, uint64(m.LeftInputStats.Size()))
+	n2, err := m.LeftInputStats.MarshalTo(dAtA[i:])
+	if err != nil {
+		return 0, err
+	}
+	i += n2
+	dAtA[i] = 0x12
+	i++
+	i = encodeVarintStats(dAtA, i, uint64(m.RightInputStats.Size()))
+	n3, err := m.RightInputStats.MarshalTo(dAtA[i:])
+	if err != nil {
+		return 0, err
+	}
+	i += n3
+	if len(m.StoredSide) > 0 {
+		dAtA[i] = 0x1a
+		i++
+		i = encodeVarintStats(dAtA, i, uint64(len(m.StoredSide)))
+		i += copy(dAtA[i:], m.StoredSide)
+	}
+	if m.MaxAllocatedMem != 0 {
+		dAtA[i] = 0x20
+		i++
+		i = encodeVarintStats(dAtA, i, uint64(m.MaxAllocatedMem))
+	}
+	if m.MaxAllocatedDisk != 0 {
+		dAtA[i] = 0x28
+		i++
+		i = encodeVarintStats(dAtA, i, uint64(m.MaxAllocatedDisk))
+	}
+	return i, nil
+}
+
 func encodeVarintStats(dAtA []byte, offset int, v uint64) int {
 	for v >= 1<<7 {
 		dAtA[offset] = uint8(v&0x7f | 0x80)
@@ -111,6 +176,26 @@ func (m *TableReaderStats) Size() (n int) {
 	_ = l
 	l = m.InputStats.Size()
 	n += 1 + l + sovStats(uint64(l))
+	return n
+}
+
+func (m *HashJoinerStats) Size() (n int) {
+	var l int
+	_ = l
+	l = m.LeftInputStats.Size()
+	n += 1 + l + sovStats(uint64(l))
+	l = m.RightInputStats.Size()
+	n += 1 + l + sovStats(uint64(l))
+	l = len(m.StoredSide)
+	if l > 0 {
+		n += 1 + l + sovStats(uint64(l))
+	}
+	if m.MaxAllocatedMem != 0 {
+		n += 1 + sovStats(uint64(m.MaxAllocatedMem))
+	}
+	if m.MaxAllocatedDisk != 0 {
+		n += 1 + sovStats(uint64(m.MaxAllocatedDisk))
+	}
 	return n
 }
 
@@ -276,6 +361,183 @@ func (m *TableReaderStats) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+func (m *HashJoinerStats) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowStats
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= (uint64(b) & 0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: HashJoinerStats: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: HashJoinerStats: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field LeftInputStats", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowStats
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= (int(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthStats
+			}
+			postIndex := iNdEx + msglen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if err := m.LeftInputStats.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field RightInputStats", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowStats
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= (int(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthStats
+			}
+			postIndex := iNdEx + msglen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if err := m.RightInputStats.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field StoredSide", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowStats
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= (uint64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthStats
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.StoredSide = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 4:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field MaxAllocatedMem", wireType)
+			}
+			m.MaxAllocatedMem = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowStats
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.MaxAllocatedMem |= (int64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 5:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field MaxAllocatedDisk", wireType)
+			}
+			m.MaxAllocatedDisk = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowStats
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.MaxAllocatedDisk |= (int64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		default:
+			iNdEx = preIndex
+			skippy, err := skipStats(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if skippy < 0 {
+				return ErrInvalidLengthStats
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
 func skipStats(dAtA []byte) (n int, err error) {
 	l := len(dAtA)
 	iNdEx := 0
@@ -384,18 +646,26 @@ var (
 func init() { proto.RegisterFile("sql/distsqlrun/stats.proto", fileDescriptorStats) }
 
 var fileDescriptorStats = []byte{
-	// 207 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xe2, 0x92, 0x2a, 0x2e, 0xcc, 0xd1,
-	0x4f, 0xc9, 0x2c, 0x2e, 0x29, 0x2e, 0xcc, 0x29, 0x2a, 0xcd, 0xd3, 0x2f, 0x2e, 0x49, 0x2c, 0x29,
-	0xd6, 0x2b, 0x28, 0xca, 0x2f, 0xc9, 0x17, 0x92, 0x48, 0xce, 0x4f, 0xce, 0x2e, 0xca, 0x4f, 0x4c,
-	0xce, 0xd0, 0x2b, 0x2e, 0xcc, 0xd1, 0x43, 0xa8, 0x92, 0x12, 0x49, 0xcf, 0x4f, 0xcf, 0x07, 0x2b,
-	0xd2, 0x07, 0xb1, 0x20, 0xea, 0x95, 0xd4, 0xb9, 0xb8, 0x3c, 0xf3, 0x0a, 0x4a, 0x4b, 0x82, 0x41,
-	0x66, 0x08, 0x49, 0x72, 0x71, 0xe4, 0x95, 0xe6, 0xc6, 0x17, 0xe5, 0x97, 0x17, 0x4b, 0x30, 0x2a,
-	0x30, 0x6a, 0x30, 0x07, 0xb1, 0xe7, 0x95, 0xe6, 0x06, 0xe5, 0x97, 0x17, 0x2b, 0xc5, 0x73, 0x09,
-	0x84, 0x24, 0x26, 0xe5, 0xa4, 0x06, 0xa5, 0x26, 0xa6, 0xa4, 0x16, 0x41, 0x94, 0x7b, 0x73, 0x71,
-	0x67, 0x82, 0x34, 0xc7, 0x83, 0x5d, 0x00, 0xd6, 0xc1, 0x6d, 0xa4, 0xa2, 0x87, 0xcb, 0x09, 0x7a,
-	0x08, 0x9b, 0x9c, 0x58, 0x4e, 0xdc, 0x93, 0x67, 0x08, 0xe2, 0xca, 0x44, 0x88, 0xa8, 0x9c, 0x78,
-	0x28, 0xc7, 0x70, 0xe2, 0x91, 0x1c, 0xe3, 0x85, 0x47, 0x72, 0x8c, 0x37, 0x1e, 0xc9, 0x31, 0x3e,
-	0x78, 0x24, 0xc7, 0x38, 0xe1, 0xb1, 0x1c, 0x43, 0x14, 0x17, 0xc2, 0x88, 0x24, 0x36, 0xb0, 0xb3,
-	0x8d, 0x01, 0x01, 0x00, 0x00, 0xff, 0xff, 0xbe, 0xaf, 0x46, 0x87, 0x04, 0x01, 0x00, 0x00,
+	// 336 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xa4, 0x91, 0xcb, 0x4e, 0xc2, 0x40,
+	0x14, 0x86, 0x29, 0xe0, 0xed, 0x90, 0x08, 0x34, 0x2e, 0x2a, 0x8b, 0x42, 0x08, 0x89, 0xc4, 0x98,
+	0x92, 0xe8, 0x13, 0x48, 0x5c, 0x78, 0x89, 0x9b, 0x42, 0x5c, 0xb8, 0x99, 0x0c, 0x9d, 0x11, 0x26,
+	0xcc, 0x74, 0x60, 0x66, 0x1a, 0x78, 0x0c, 0x9f, 0xc7, 0x27, 0x60, 0xe9, 0xd2, 0x95, 0xd1, 0xfa,
+	0x22, 0xa6, 0x43, 0x10, 0x58, 0xb8, 0x30, 0xee, 0x9a, 0x3f, 0xdf, 0xf9, 0xfe, 0x73, 0x3a, 0x50,
+	0xd3, 0x53, 0xde, 0x21, 0x4c, 0x1b, 0x3d, 0xe5, 0x2a, 0x89, 0x3b, 0xda, 0x60, 0xa3, 0x83, 0x89,
+	0x92, 0x46, 0xba, 0x5e, 0x24, 0xa3, 0xb1, 0x92, 0x38, 0x1a, 0x05, 0x7a, 0xca, 0x83, 0x35, 0x55,
+	0x3b, 0x1a, 0xca, 0xa1, 0xb4, 0x50, 0x27, 0xfb, 0x5a, 0xf2, 0xcd, 0x13, 0x80, 0x9b, 0x78, 0x92,
+	0x98, 0x5e, 0xe6, 0x70, 0x8f, 0x61, 0x3f, 0x4e, 0x04, 0x52, 0x72, 0xa6, 0x3d, 0xa7, 0xe1, 0xb4,
+	0x0b, 0xe1, 0x5e, 0x9c, 0x88, 0x50, 0xce, 0x74, 0x13, 0x41, 0xa5, 0x8f, 0x07, 0x9c, 0x86, 0x14,
+	0x13, 0xaa, 0x96, 0xf8, 0x1d, 0x94, 0x58, 0x36, 0x8c, 0xec, 0x06, 0x76, 0xa2, 0x74, 0xde, 0x0a,
+	0x7e, 0x5b, 0x21, 0x58, 0x37, 0x75, 0x8b, 0x8b, 0xf7, 0x7a, 0x2e, 0x04, 0xf6, 0x93, 0x34, 0x5f,
+	0xf2, 0x50, 0xbe, 0xc6, 0x7a, 0x74, 0x2b, 0x59, 0xbc, 0x2a, 0xe8, 0x43, 0x85, 0xd3, 0x27, 0x83,
+	0xfe, 0xd7, 0x72, 0x98, 0x39, 0x36, 0xae, 0x7c, 0x80, 0xaa, 0x62, 0xc3, 0xd1, 0xb6, 0x36, 0xff,
+	0x67, 0x6d, 0xd9, 0x4a, 0x36, 0xbc, 0x75, 0x28, 0x69, 0x23, 0x15, 0x25, 0x48, 0x33, 0x42, 0xbd,
+	0x42, 0xc3, 0x69, 0x1f, 0x84, 0xb0, 0x8c, 0x7a, 0x8c, 0x50, 0xf7, 0x14, 0xaa, 0x02, 0xcf, 0x11,
+	0xe6, 0x5c, 0x46, 0xd8, 0x50, 0x82, 0x04, 0x15, 0x5e, 0xd1, 0xfe, 0xe7, 0xb2, 0xc0, 0xf3, 0xcb,
+	0x55, 0x7e, 0x4f, 0x85, 0x7b, 0x06, 0xee, 0x36, 0x4b, 0x98, 0x1e, 0x7b, 0x3b, 0x16, 0xae, 0x6c,
+	0xc2, 0x57, 0x4c, 0x8f, 0xbb, 0xad, 0xc5, 0xa7, 0x9f, 0x5b, 0xa4, 0xbe, 0xf3, 0x9a, 0xfa, 0xce,
+	0x5b, 0xea, 0x3b, 0x1f, 0xa9, 0xef, 0x3c, 0x7f, 0xf9, 0xb9, 0x47, 0x58, 0x9f, 0x30, 0xd8, 0xb5,
+	0x6f, 0x7e, 0xf1, 0x1d, 0x00, 0x00, 0xff, 0xff, 0x3f, 0x8b, 0x16, 0xfa, 0x41, 0x02, 0x00, 0x00,
 }

--- a/pkg/sql/distsqlrun/stats.proto
+++ b/pkg/sql/distsqlrun/stats.proto
@@ -28,3 +28,12 @@ message InputStats {
 message TableReaderStats {
   InputStats input_stats = 1 [(gogoproto.nullable) = false];
 }
+
+// HashJoinerStats are the stats collected during a hashJoiner run.
+message HashJoinerStats {
+  InputStats left_input_stats = 1 [(gogoproto.nullable) = false];
+  InputStats right_input_stats = 2 [(gogoproto.nullable) = false];
+  string stored_side = 3;
+  int64 max_allocated_mem = 4;
+  int64 max_allocated_disk = 5;
+}

--- a/pkg/sql/distsqlrun/tablereader.go
+++ b/pkg/sql/distsqlrun/tablereader.go
@@ -265,7 +265,7 @@ func (tr *tableReader) ConsumerClosed() {
 	tr.internalClose()
 }
 
-var _ tracing.SpanStats = &TableReaderStats{}
+var _ DistSQLSpanStats = &TableReaderStats{}
 
 // Stats implements the SpanStats interface.
 func (trs *TableReaderStats) Stats() map[string]string {

--- a/pkg/sql/logictest/testdata/planner_test/distsql_auto_mode
+++ b/pkg/sql/logictest/testdata/planner_test/distsql_auto_mode
@@ -128,6 +128,6 @@ EXPLAIN (DISTSQL) SELECT 246::REGTYPE FROM abc
 # Verify that EXPLAIN ANALYZE (DISTSQL) annotates plans with collected
 # statistics.
 query T
-SELECT "URL" FROM [EXPLAIN ANALYZE (DISTSQL) SELECT * FROM kv]
+SELECT "URL" FROM [EXPLAIN ANALYZE (DISTSQL) SELECT * FROM kv JOIN kw ON kv.k=kw.w];
 ----
-https://cockroachdb.github.io/distsqlplan/decode.html?eJyMj71qxDAQhPs8xTH1QuxWVdprknCkCyoUazhMfF6zK-eHQ-8ebBUhReDKmZG-j71i1szHdKEjvKJHFCymA93Vtqo9OOYvhE4wzstatjoKBjUiXFHGMhEBL-lt4okp0-47CDJLGqcdu9h4Sfb98P4BgemnH4wph0OHWAW6ll-ql3QmQl_ldvOJvujs_CP9j9zVKGA-s13nutrAZ9Nh17T4tP_bi0wvbe1bOM5tqrHe_QQAAP__udhpqQ==
+https://cockroachdb.github.io/distsqlplan/decode.html?eJyckkFr4zAQhe_7K8ScEhDEdvYkWBB7anpoSuit-KBa00TEtsyM3CQE__diuZA6JG3To968N994xkeovcUHUyGDeoYUcgkN-QKZPfXSYFjYPahEgqubNvRyLqHwhKCOEFwoERQ8mZcSV2gs0iwBCRaDcWVs25CrDB309g0kkN-xIDRWiQTyToJvw6krB7NGUGknf0dOr5B3PyVnV8knYFt7skhoR7C8T35nuTD-neHNvXc10iwbT1_ia5jodPqP3HoTJjqbgoyiGH2KhFg_Fzl4QivYWVQiOkBCZfaiwsrTQbSMvVP8_5Ct4-1IXLZBCZ1KnUk9l_rv1Z3Nb7nWCrnxNeP57i52TvqFoV3jcAD2LRX4SL6ImOG5jLkoWOQwVLPhsahjKf5On8PpDeHsPJx9GZ6PwkmXd3_eAwAA___kgB3h


### PR DESCRIPTION
Release note: None

Simple screenshot:
<img width="455" alt="screen shot 2018-06-04 at 11 03 10 am" src="https://user-images.githubusercontent.com/10560359/40927067-d2bee208-67eb-11e8-9be5-15d7fee489d5.png">

You can also see the filtering on the above screenshot. 

More complicated screenshot:
<img width="711" alt="screen shot 2018-06-04 at 11 08 48 am" src="https://user-images.githubusercontent.com/10560359/40927071-d8d894b8-67eb-11e8-8ffb-2c63afac4d98.png">

Weird thing above is that we somehow decided to store the left side although I thought the default if no short stream is found is to store the right side. I'll look into this. The memory used is accurate, but it's kind of weird that the disk usage was also 64MB, I want to verify this.
