### PR TITLE
libroach: fix concurrent access to same file when using encryption

### DIFF
--- a/c-deps/libroach/CMakeLists.txt
+++ b/c-deps/libroach/CMakeLists.txt
@@ -120,17 +120,10 @@ foreach(tsrc ${tests})
     set(tname ${dirname}_${filename})
   endif()
 
-  # Add a new executable and set includes/libraries/properties.
-  add_executable(${tname} ${tsrc} testutils.cc)
-  target_include_directories(${tname}
-    PRIVATE ../googletest/googletest/include
-    PRIVATE ../protobuf/src
-    PRIVATE ../rocksdb/include
-    PRIVATE protos
-  )
-
-  # Link `ccl/` tests against roachccl and CryptoPP.
   if(${tsrc} MATCHES "^ccl/")
+    # Link `ccl/` tests against roachccl and CryptoPP.
+		# Use ccl/testutils.
+    add_executable(${tname} ${tsrc} testutils.cc ccl/testutils.cc)
     target_link_libraries(${tname}
       roachccl
       ${CRYPTOPP_LIB}
@@ -139,7 +132,18 @@ foreach(tsrc ${tests})
       PRIVATE .. # CryptoPP headers are directly in the directory. Include .. to be able to include <cryptopp/....h>
       PRIVATE protosccl
     )
+  else()
+		# Use testutils.
+    add_executable(${tname} ${tsrc} testutils.cc)
   endif()
+
+	# Set includes/libraries/properties.
+  target_include_directories(${tname}
+    PRIVATE ../googletest/googletest/include
+    PRIVATE ../protobuf/src
+    PRIVATE ../rocksdb/include
+    PRIVATE protos
+  )
 
   # Add all other libraries.
   target_link_libraries(${tname}

--- a/c-deps/libroach/ccl/db.cc
+++ b/c-deps/libroach/ccl/db.cc
@@ -71,8 +71,8 @@ class CCLEnvStatsHandler : public EnvStatsHandler {
 
 // DBOpenHook parses the extra_options field of DBOptions and initializes encryption objects if
 // needed.
-rocksdb::Status DBOpenHook(const std::string& db_dir, const DBOptions db_opts,
-                           EnvManager* env_mgr) {
+rocksdb::Status DBOpenHook(std::shared_ptr<rocksdb::Logger> info_log, const std::string& db_dir,
+                           const DBOptions db_opts, EnvManager* env_mgr) {
   DBSlice options = db_opts.extra_options;
   if (options.len == 0) {
     return rocksdb::Status::OK();

--- a/c-deps/libroach/ccl/testutils.cc
+++ b/c-deps/libroach/ccl/testutils.cc
@@ -1,0 +1,40 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+#include "testutils.h"
+#include "crypto_utils.h"
+
+enginepbccl::SecretKey* MakeAES128Key(rocksdb::Env* env) {
+  int64_t now;
+  env->GetCurrentTime(&now);
+
+  auto key = new enginepbccl::SecretKey();
+  // Random key.
+  key->set_key(RandomBytes(16));
+
+  auto info = key->mutable_info();
+  info->set_encryption_type(enginepbccl::AES128_CTR);
+  info->set_creation_time(now);
+  // Random key ID.
+  info->set_key_id(HexString(RandomBytes(kKeyIDLength)));
+
+  return key;
+}
+
+MemKeyManager::~MemKeyManager() {}
+
+std::unique_ptr<enginepbccl::SecretKey> MemKeyManager::CurrentKey() {
+  return std::unique_ptr<enginepbccl::SecretKey>(new enginepbccl::SecretKey(*key_.get()));
+}
+
+std::unique_ptr<enginepbccl::SecretKey> MemKeyManager::GetKey(const std::string& id) {
+  if (key_ != nullptr && key_->info().key_id() == id) {
+    return std::unique_ptr<enginepbccl::SecretKey>(new enginepbccl::SecretKey(*key_.get()));
+  }
+  return nullptr;
+}

--- a/c-deps/libroach/ccl/testutils.h
+++ b/c-deps/libroach/ccl/testutils.h
@@ -1,0 +1,34 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+#pragma once
+
+#include <rocksdb/env.h>
+#include <string>
+#include "ccl/storageccl/engineccl/enginepbccl/key_registry.pb.h"
+#include "key_manager.h"
+
+namespace enginepbccl = cockroach::ccl::storageccl::engineccl::enginepbccl;
+
+// MakeAES<size>Key creates a SecretKeyObject with a key of the specified size.
+// It needs an Env for the current time.
+enginepbccl::SecretKey* MakeAES128Key(rocksdb::Env* env);
+
+// MemKeyManager is a simple key manager useful for tests.
+// It holds a single key. ie: there is only an active key, no old keys.
+class MemKeyManager : public KeyManager {
+ public:
+  explicit MemKeyManager(enginepbccl::SecretKey* key) : key_(key) {}
+  virtual ~MemKeyManager();
+
+  virtual std::unique_ptr<enginepbccl::SecretKey> CurrentKey() override;
+  virtual std::unique_ptr<enginepbccl::SecretKey> GetKey(const std::string& id) override;
+
+ private:
+  std::unique_ptr<enginepbccl::SecretKey> key_;
+};

--- a/c-deps/libroach/db.h
+++ b/c-deps/libroach/db.h
@@ -18,6 +18,7 @@
 #include <memory>
 #include <rocksdb/comparator.h>
 #include <rocksdb/db.h>
+#include <rocksdb/env.h>
 #include <rocksdb/iterator.h>
 #include <rocksdb/metadata.h>
 #include <rocksdb/status.h>
@@ -28,7 +29,8 @@ namespace cockroach {
 struct EnvManager;
 
 // DBOpenHook is called at the beginning of DBOpen. It can be implemented in CCL code.
-rocksdb::Status DBOpenHook(const std::string& db_dir, const DBOptions opts, EnvManager* env_ctx);
+rocksdb::Status DBOpenHook(std::shared_ptr<rocksdb::Logger> info_log, const std::string& db_dir,
+                           const DBOptions opts, EnvManager* env_ctx);
 
 // ToDBSlice returns a DBSlice from a rocksdb::Slice
 inline DBSlice ToDBSlice(const rocksdb::Slice& s) {
@@ -88,8 +90,8 @@ class ScopedStats {
 // that the a compaction from the beginning (or end) of the key space
 // should be provided. The sstable metadata must already be sorted by
 // smallest key.
-void BatchSSTablesForCompaction(const std::vector<rocksdb::SstFileMetaData> &sst,
+void BatchSSTablesForCompaction(const std::vector<rocksdb::SstFileMetaData>& sst,
                                 rocksdb::Slice start_key, rocksdb::Slice end_key,
-                                uint64_t target_size, std::vector<rocksdb::Range> *ranges);
+                                uint64_t target_size, std::vector<rocksdb::Range>* ranges);
 
 }  // namespace cockroach

--- a/c-deps/libroach/db_test.cc
+++ b/c-deps/libroach/db_test.cc
@@ -24,11 +24,11 @@ TEST(Libroach, DBOpenHook) {
 
   // Try an empty extra_options.
   db_opts.extra_options = ToDBSlice("");
-  EXPECT_OK(DBOpenHook("", db_opts, nullptr));
+  EXPECT_OK(DBOpenHook(nullptr, "", db_opts, nullptr));
 
   // Try extra_options with anything at all.
   db_opts.extra_options = ToDBSlice("blah");
-  EXPECT_ERR(DBOpenHook("", db_opts, nullptr),
+  EXPECT_ERR(DBOpenHook(nullptr, "", db_opts, nullptr),
              "DBOptions has extra_options, but OSS code cannot handle them");
 }
 

--- a/c-deps/libroach/plaintext_stream.h
+++ b/c-deps/libroach/plaintext_stream.h
@@ -24,21 +24,26 @@ class PlaintextStream final : public rocksdb_utils::BlockAccessCipherStream {
   PlaintextStream() {}
   virtual ~PlaintextStream() {}
 
-  virtual size_t BlockSize() override { return 0; }
-  virtual rocksdb::Status Encrypt(uint64_t fileOffset, char* data, size_t dataSize) override {
+  virtual rocksdb::Status Encrypt(uint64_t fileOffset, char* data, size_t dataSize) const override {
     return rocksdb::Status::OK();
   }
-  virtual rocksdb::Status Decrypt(uint64_t fileOffset, char* data, size_t dataSize) override {
+  virtual rocksdb::Status Decrypt(uint64_t fileOffset, char* data, size_t dataSize) const override {
     return rocksdb::Status::OK();
   }
 
  protected:
-  virtual void AllocateScratch(std::string&) override{};
-  virtual rocksdb::Status EncryptBlock(uint64_t blockIndex, char* data, char* scratch) override {
-    return rocksdb::Status::OK();
+  virtual rocksdb::Status
+  InitCipher(std::unique_ptr<rocksdb_utils::BlockCipher>* cipher) const override {
+    return rocksdb::Status::InvalidArgument("InitCipher cannot be called on a PlaintextStream");
   }
-  virtual rocksdb::Status DecryptBlock(uint64_t blockIndex, char* data, char* scratch) override {
-    return rocksdb::Status::OK();
+
+  virtual rocksdb::Status EncryptBlock(rocksdb_utils::BlockCipher* cipher, uint64_t blockIndex,
+                                       char* data, char* scratch) const override {
+    return rocksdb::Status::InvalidArgument("EncryptBlock cannot be called on a PlaintextStream");
+  }
+  virtual rocksdb::Status DecryptBlock(rocksdb_utils::BlockCipher* cipher, uint64_t blockIndex,
+                                       char* data, char* scratch) const override {
+    return rocksdb::Status::InvalidArgument("DecryptBlock cannot be called on a PlaintextStream");
   }
 };
 

--- a/c-deps/libroach/rocksdbutils/env_encryption.h
+++ b/c-deps/libroach/rocksdbutils/env_encryption.h
@@ -41,37 +41,6 @@ class CipherStreamCreator;
 rocksdb::Env* NewEncryptedEnv(rocksdb::Env* base_env, cockroach::FileRegistry* file_registry,
                               CipherStreamCreator* creator);
 
-// BlockAccessCipherStream is the base class for any cipher stream that
-// supports random access at block level (without requiring data from other blocks).
-// E.g. CTR (Counter operation mode) supports this requirement.
-class BlockAccessCipherStream {
- public:
-  virtual ~BlockAccessCipherStream() {}
-
-  // BlockSize returns the size of each block supported by this cipher stream.
-  virtual size_t BlockSize() = 0;
-
-  // Encrypt one or more (partial) blocks of data at the file offset.
-  // Length of data is given in dataSize.
-  virtual rocksdb::Status Encrypt(uint64_t fileOffset, char* data, size_t dataSize);
-
-  // Decrypt one or more (partial) blocks of data at the file offset.
-  // Length of data is given in dataSize.
-  virtual rocksdb::Status Decrypt(uint64_t fileOffset, char* data, size_t dataSize);
-
- protected:
-  // Allocate scratch space which is passed to EncryptBlock/DecryptBlock.
-  virtual void AllocateScratch(std::string&) = 0;
-
-  // Encrypt a block of data at the given block index.
-  // Length of data is equal to BlockSize();
-  virtual rocksdb::Status EncryptBlock(uint64_t blockIndex, char* data, char* scratch) = 0;
-
-  // Decrypt a block of data at the given block index.
-  // Length of data is equal to BlockSize();
-  virtual rocksdb::Status DecryptBlock(uint64_t blockIndex, char* data, char* scratch) = 0;
-};
-
 // BlockCipher
 class BlockCipher {
  public:
@@ -87,6 +56,37 @@ class BlockCipher {
   // Decrypt a block of data.
   // Length of data is equal to BlockSize().
   virtual rocksdb::Status Decrypt(char* data) = 0;
+};
+
+// BlockAccessCipherStream is the base class for any cipher stream that
+// supports random access at block level (without requiring data from other blocks).
+// E.g. CTR (Counter operation mode) supports this requirement.
+class BlockAccessCipherStream {
+ public:
+  virtual ~BlockAccessCipherStream() {}
+
+  // Encrypt one or more (partial) blocks of data at the file offset.
+  // Length of data is given in dataSize.
+  virtual rocksdb::Status Encrypt(uint64_t fileOffset, char* data, size_t dataSize) const;
+
+  // Decrypt one or more (partial) blocks of data at the file offset.
+  // Length of data is given in dataSize.
+  virtual rocksdb::Status Decrypt(uint64_t fileOffset, char* data, size_t dataSize) const;
+
+ protected:
+  // Initialize a new cipher object. A Cipher is not thread-safe but can be used for any
+  // number of EncryptBlock/DecryptBlock calls.
+  virtual rocksdb::Status InitCipher(std::unique_ptr<rocksdb_utils::BlockCipher>* cipher) const = 0;
+
+  // Encrypt a block of data at the given block index.
+  // Length of data is equal to cipher.BlockSize();
+  virtual rocksdb::Status EncryptBlock(rocksdb_utils::BlockCipher* cipher, uint64_t blockIndex,
+                                       char* data, char* scratch) const = 0;
+
+  // Decrypt a block of data at the given block index.
+  // Length of data is equal to cipher.BlockSize();
+  virtual rocksdb::Status DecryptBlock(rocksdb_utils::BlockCipher* cipher, uint64_t blockIndex,
+                                       char* data, char* scratch) const = 0;
 };
 
 // CipherStreamCreator is the abstract class used by EncryptedEnv.


### PR DESCRIPTION
Fixes #26261.

The various `Env::***File` objects are used concurrently by rocksdb (eg: in the compaction code).
If multiple reads occur on the same encrypted file handle and CryptoPP is using the software AES implementation, some working state in the cipher gets corrupted by the other calls. This results in broken decryption bubbling up as checksum failures on rocksdb.

Fix this by passing the key to the `CTRCipherStream` and initializing a new `Cipher` object for each block of data (the `RandomAccessFile::Read` block. This will still use one `Cipher` for multiple AES blocks).

Release note (bug fix): fix concurrent access to same file when using encryption