### PR TITLE
dnm: distsqlrun: move StreamDecoder below inbound rowchannel

### DIFF
--- a/pkg/sql/distsqlrun/data.go
+++ b/pkg/sql/distsqlrun/data.go
@@ -67,3 +67,16 @@ func ConvertToMappedSpecOrdering(
 	}
 	return specOrdering
 }
+func (msg *ProducerMessage) Copy() *ProducerMessage {
+	new := &ProducerMessage{}
+	if msg.Header != nil {
+		new.Header = &ProducerHeader{}
+		*new.Header = *msg.Header
+	}
+	new.Typing = msg.Typing
+	new.Data.Metadata = msg.Data.Metadata
+	new.Data.NumEmptyRows = msg.Data.NumEmptyRows
+	new.Data.RawBytes = make([]byte, len(msg.Data.RawBytes))
+	copy(new.Data.RawBytes, msg.Data.RawBytes)
+	return new
+}

--- a/pkg/sql/distsqlrun/inbound.go
+++ b/pkg/sql/distsqlrun/inbound.go
@@ -67,7 +67,9 @@ func processInboundStreamHelper(
 	}
 
 	if firstMsg != nil {
-		if res := processProducerMessage(
+		if b, ok := dst.(BatchRowReceiver); ok {
+			b.PushProducerMessage(firstMsg.Header.StreamID, firstMsg)
+		} else if res := processProducerMessage(
 			ctx, stream, dst, &sd, &draining, firstMsg,
 		); res.err != nil || res.consumerClosed {
 			sendErrToConsumer(res.err)
@@ -107,7 +109,9 @@ func processInboundStreamHelper(
 				return
 			}
 
-			if res := processProducerMessage(
+			if b, ok := dst.(BatchRowReceiver); ok {
+				b.PushProducerMessage(firstMsg.Header.StreamID, msg)
+			} else if res := processProducerMessage(
 				ctx, stream, dst, &sd, &draining, msg,
 			); res.err != nil || res.consumerClosed {
 				sendErrToConsumer(res.err)


### PR DESCRIPTION
Previously, the decoding from ProducerMessage into EncDatumRows was done
above the first inbound RowChannel in the system, as soon the network
receiver got messages, by the network receiver thread.

This commit changes the flow a little bit. The network receiver now
pushes the ProducerMessage as is onto a new kind of RowChannel. Nexting
that RowChannel performs the decoding on demand.

This is dnm because it seems to make performance worse.

Closes #25207.

Release note: None