### PR TITLE
scripts: Remove "default" scope from gceworker

### DIFF
--- a/scripts/gceworker.sh
+++ b/scripts/gceworker.sh
@@ -28,7 +28,7 @@ case "${cmd}" in
            --boot-disk-size "100" \
            --boot-disk-type "pd-ssd" \
            --boot-disk-device-name "${NAME}" \
-           --scopes "default,cloud-platform"
+           --scopes "cloud-platform"
     gcloud compute firewall-rules create "${NAME}-mosh" --allow udp:60000-61000
 
     # Retry while vm and sshd to start up.


### PR DESCRIPTION
I don't know what the default scope is/was, but it's no longer being
accepted. The "cloud-platform" scope is enough to give full permissions
on the project.

Release note: None