### PR TITLE
sql: fix logic test

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -1517,7 +1517,7 @@ DROP DATABASE other_db CASCADE
 
 #Verify  information_schema.user_privileges
 
-query TTTT colnames rowsort
+query TTTT colnames,rowsort
 SELECT * FROM information_schema.user_privileges ORDER BY grantee,privilege_type
 ----
 grantee  table_catalog  privilege_type  is_grantable

--- a/pkg/sql/logictest/testdata/logic_test/tuple
+++ b/pkg/sql/logictest/testdata/logic_test/tuple
@@ -136,7 +136,7 @@ a b c
 2 3 1
 3 1 2
 
-query T colnames rowsort
+query T colnames,rowsort
 SELECT (t.*) FROM t
 ----
 (t.*)


### PR DESCRIPTION
When multiple options are specified in a logic test, the options must be comma separated, not space separated, otherwise only the first option will be picked up.
