### PR TITLE
release-2.0: libroach: fix excessive compactions performed by DBCompactRange

### DIFF
--- a/c-deps/libroach/db.h
+++ b/c-deps/libroach/db.h
@@ -17,7 +17,9 @@
 #include <libroach.h>
 #include <memory>
 #include <rocksdb/comparator.h>
+#include <rocksdb/db.h>
 #include <rocksdb/iterator.h>
+#include <rocksdb/metadata.h>
 #include <rocksdb/status.h>
 #include <rocksdb/write_batch.h>
 
@@ -70,5 +72,14 @@ std::string EncodeKey(DBKey k);
 // Stats are only computed for keys between the given range.
 MVCCStatsResult MVCCComputeStatsInternal(::rocksdb::Iterator* const iter_rep, DBKey start,
                                          DBKey end, int64_t now_nanos);
+
+// BatchSStables batches the supplied sstable metadata into chunks of
+// sstables that are target_size. An empty start or end key indicates
+// that the a compaction from the beginning (or end) of the key space
+// should be provided. The sstable metadata must already be sorted by
+// smallest key.
+void BatchSSTablesForCompaction(const std::vector<rocksdb::SstFileMetaData> &sst,
+                                rocksdb::Slice start_key, rocksdb::Slice end_key,
+                                uint64_t target_size, std::vector<rocksdb::Range> *ranges);
 
 }  // namespace cockroach

--- a/c-deps/libroach/db_test.cc
+++ b/c-deps/libroach/db_test.cc
@@ -30,3 +30,71 @@ TEST(Libroach, DBOpenHook) {
   EXPECT_ERR(DBOpenHook("", db_opts),
              "DBOptions has extra_options, but OSS code cannot handle them");
 }
+
+TEST(Libroach, BatchSSTablesForCompaction) {
+  auto toString = [](const std::vector<rocksdb::Range>& ranges) -> std::string {
+    std::string res;
+    for (auto r : ranges) {
+      if (!res.empty()) {
+        res.append(",");
+      }
+      res.append(r.start.data(), r.start.size());
+      res.append("-");
+      res.append(r.limit.data(), r.limit.size());
+    }
+    return res;
+  };
+
+  auto sst = [](const std::string& smallest, const std::string& largest,
+                uint64_t size) -> rocksdb::SstFileMetaData {
+    return rocksdb::SstFileMetaData("", "", size, 0, 0, smallest, largest, 0, 0);
+  };
+
+  struct TestCase {
+    TestCase(const std::vector<rocksdb::SstFileMetaData>& s,
+             const std::string& start, const std::string& end,
+             uint64_t target, const std::string& expected)
+        : sst(s),
+          start_key(start),
+          end_key(end),
+          target_size(target),
+          expected_ranges(expected) {
+    }
+    std::vector<rocksdb::SstFileMetaData> sst;
+    std::string start_key;
+    std::string end_key;
+    uint64_t target_size;
+    std::string expected_ranges;
+  };
+
+  std::vector<TestCase> testCases = {
+    TestCase({ sst("a", "b", 10) },
+             "", "", 10, "-"),
+    TestCase({ sst("a", "b", 10) },
+             "a", "", 10, "a-"),
+    TestCase({ sst("a", "b", 10) },
+             "", "b", 10, "-b"),
+    TestCase({ sst("a", "b", 10) },
+             "a", "b", 10, "a-b"),
+    TestCase({ sst("c", "d", 10) },
+             "a", "b", 10, "a-b"),
+    TestCase({ sst("a", "b", 10), sst("b", "c", 10) },
+             "a", "c", 10, "a-b,b-c"),
+    TestCase({ sst("a", "b", 10), sst("b", "c", 10) },
+             "a", "c", 100, "a-c"),
+    TestCase({ sst("a", "b", 10), sst("b", "c", 10) },
+             "", "c", 10, "-b,b-c"),
+    TestCase({ sst("a", "b", 10), sst("b", "c", 10) },
+             "a", "", 10, "a-b,b-"),
+    TestCase({ sst("a", "b", 10), sst("b", "c", 10), sst("c", "d", 10) },
+             "a", "d", 10, "a-b,b-c,c-d"),
+    TestCase({ sst("a", "b", 10), sst("b", "c", 10), sst("c", "d", 10) },
+             "a", "d", 20, "a-c,c-d"),
+  };
+  for (auto c : testCases) {
+    std::vector<rocksdb::Range> ranges;
+    BatchSSTablesForCompaction(c.sst, c.start_key, c.end_key, c.target_size, &ranges);
+    auto result = toString(ranges);
+    EXPECT_EQ(c.expected_ranges, result);
+  }
+}


### PR DESCRIPTION
Backport 1/1 commits from #26355.

/cc @cockroachdb/release

---

Fix excessive compactions from `DBCompactRange` due to mishandling of
the first and last ranges to compact. When a non-empty start or end key
is specified, DBCompactRange was previously calling
`rocksdb::DB::CompactRange` with a `null` start/end key resulting in
compacting from the beginning (or to the end) of the entire key space.

See #24029
