### PR TITLE
changefeedccl: respect schema change table leases

### DIFF
--- a/pkg/ccl/changefeedccl/buffer.go
+++ b/pkg/ccl/changefeedccl/buffer.go
@@ -1,0 +1,43 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package changefeedccl
+
+import "github.com/cockroachdb/cockroach/pkg/util/syncutil"
+
+// TODO(dan): Monitor memory usage and spill to disk when necessary.
+type changefeedBuffer struct {
+	syncutil.Mutex
+	buf []changedKVs
+	idx int
+}
+
+// append adds new kvs to the buffer.
+func (b *changefeedBuffer) append(kvs changedKVs) {
+	b.Lock()
+	if b.idx >= len(b.buf) {
+		// Attempt to minimize allocations by reusing the buffer.
+		b.buf = b.buf[:0]
+		b.idx = 0
+	}
+	b.buf = append(b.buf, kvs)
+	b.Unlock()
+}
+
+// get returns the next kvs or false if the buffer is empty.
+func (b *changefeedBuffer) get() (changedKVs, bool) {
+	var ret changedKVs
+	var ok bool
+	b.Lock()
+	if b.idx < len(b.buf) {
+		ret, ok = b.buf[b.idx], true
+		b.idx++
+	}
+	b.Unlock()
+	return ret, ok
+}

--- a/pkg/ccl/changefeedccl/hooks.go
+++ b/pkg/ccl/changefeedccl/hooks.go
@@ -1,0 +1,195 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package changefeedccl
+
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/ccl/backupccl"
+	"github.com/cockroachdb/cockroach/pkg/internal/client"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/sql"
+	"github.com/cockroachdb/cockroach/pkg/sql/jobs"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/tracing"
+	"github.com/pkg/errors"
+)
+
+func init() {
+	sql.AddPlanHook(changefeedPlanHook)
+	jobs.AddResumeHook(changefeedResumeHook)
+}
+
+type envelopeType string
+
+const (
+	optEnvelope = `envelope`
+
+	optEnvelopeKeyOnly envelopeType = `key_only`
+	optEnvelopeRow     envelopeType = `row`
+
+	sinkSchemeKafka      = `kafka`
+	sinkParamTopicPrefix = `topic_prefix`
+)
+
+var changefeedOptionExpectValues = map[string]bool{
+	optEnvelope: true,
+}
+
+// changefeedPlanHook implements sql.PlanHookFn.
+func changefeedPlanHook(
+	_ context.Context, stmt tree.Statement, p sql.PlanHookState,
+) (sql.PlanHookRowFn, sqlbase.ResultColumns, []sql.PlanNode, error) {
+	changefeedStmt, ok := stmt.(*tree.CreateChangefeed)
+	if !ok {
+		return nil, nil, nil, nil
+	}
+
+	sinkURIFn, err := p.TypeAsString(changefeedStmt.SinkURI, `CREATE CHANGEFEED`)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	optsFn, err := p.TypeAsStringOpts(changefeedStmt.Options, changefeedOptionExpectValues)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	header := sqlbase.ResultColumns{
+		{Name: "job_id", Typ: types.Int},
+	}
+	fn := func(ctx context.Context, _ []sql.PlanNode, resultsCh chan<- tree.Datums) error {
+		ctx, span := tracing.ChildSpan(ctx, stmt.StatementTag())
+		defer tracing.FinishSpan(span)
+
+		sinkURI, err := sinkURIFn()
+		if err != nil {
+			return err
+		}
+
+		opts, err := optsFn()
+		if err != nil {
+			return err
+		}
+
+		now := p.ExecCfg().Clock.Now()
+		var highwater hlc.Timestamp
+		if changefeedStmt.AsOf.Expr != nil {
+			var err error
+			if highwater, err = sql.EvalAsOfTimestamp(nil, changefeedStmt.AsOf, now); err != nil {
+				return err
+			}
+		}
+
+		// TODO(dan): This grabs table descriptors once, but uses them to
+		// interpret kvs written later. This both doesn't handle any schema
+		// changes and breaks the table leasing.
+		descriptorTime := now
+		if highwater != (hlc.Timestamp{}) {
+			descriptorTime = highwater
+		}
+		targetDescs, _, err := backupccl.ResolveTargetsToDescriptors(
+			ctx, p, descriptorTime, changefeedStmt.Targets)
+		if err != nil {
+			return err
+		}
+		var tableDescs []sqlbase.TableDescriptor
+		for _, desc := range targetDescs {
+			if tableDesc := desc.GetTable(); tableDesc != nil {
+				tableDescs = append(tableDescs, *tableDesc)
+			}
+		}
+
+		details := jobs.ChangefeedDetails{
+			TableDescs: tableDescs,
+			Opts:       opts,
+			SinkURI:    sinkURI,
+		}
+		// The resumed job validates, but also validate early so the `CREATE
+		// CHANGEFEED` returns an error if any of the options are wrong,
+		// otherwise it would only show up as a failed job.
+		if details, err = validateChangefeed(details); err != nil {
+			return err
+		}
+
+		job, _, err := p.ExecCfg().JobRegistry.StartJob(ctx, resultsCh, jobs.Record{
+			Description: changefeedJobDescription(changefeedStmt),
+			Username:    p.User(),
+			DescriptorIDs: func() (sqlDescIDs []sqlbase.ID) {
+				for _, desc := range targetDescs {
+					sqlDescIDs = append(sqlDescIDs, desc.GetID())
+				}
+				return sqlDescIDs
+			}(),
+			Details: details,
+			Progress: jobs.ChangefeedProgress{
+				Highwater: highwater,
+			},
+		})
+		if err != nil {
+			return err
+		}
+		resultsCh <- tree.Datums{
+			tree.NewDInt(tree.DInt(*job.ID())),
+		}
+		return nil
+	}
+	return fn, header, nil, nil
+}
+
+func changefeedJobDescription(changefeed *tree.CreateChangefeed) string {
+	return tree.AsStringWithFlags(changefeed, tree.FmtAlwaysQualifyTableNames)
+}
+
+func validateChangefeed(details jobs.ChangefeedDetails) (jobs.ChangefeedDetails, error) {
+	switch envelopeType(details.Opts[optEnvelope]) {
+	case ``, optEnvelopeRow:
+		details.Opts[optEnvelope] = string(optEnvelopeRow)
+	case optEnvelopeKeyOnly:
+		details.Opts[optEnvelope] = string(optEnvelopeKeyOnly)
+	default:
+		return jobs.ChangefeedDetails{}, errors.Errorf(
+			`unknown %s: %s`, optEnvelope, details.Opts[optEnvelope])
+	}
+
+	for _, tableDesc := range details.TableDescs {
+		if len(tableDesc.Families) != 1 {
+			return jobs.ChangefeedDetails{}, errors.Errorf(
+				`only tables with 1 column family are currently supported: %s has %d`,
+				tableDesc.Name, len(tableDesc.Families))
+		}
+	}
+
+	return details, nil
+}
+
+type changefeedResumer struct{}
+
+func (b *changefeedResumer) Resume(
+	ctx context.Context, job *jobs.Job, planHookState interface{}, _ chan<- tree.Datums,
+) error {
+	execCfg := planHookState.(sql.PlanHookState).ExecCfg()
+	return runChangefeedFlow(ctx, execCfg, job)
+}
+func (b *changefeedResumer) OnFailOrCancel(context.Context, *client.Txn, *jobs.Job) error { return nil }
+func (b *changefeedResumer) OnSuccess(context.Context, *client.Txn, *jobs.Job) error      { return nil }
+func (b *changefeedResumer) OnTerminal(
+	context.Context, *jobs.Job, jobs.Status, chan<- tree.Datums,
+) {
+}
+
+func changefeedResumeHook(typ jobs.Type, _ *cluster.Settings) jobs.Resumer {
+	if typ != jobs.TypeChangefeed {
+		return nil
+	}
+	return &changefeedResumer{}
+}

--- a/pkg/ccl/changefeedccl/rowfetcher_cache.go
+++ b/pkg/ccl/changefeedccl/rowfetcher_cache.go
@@ -1,0 +1,81 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package changefeedccl
+
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/sql"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/pkg/storage/engine"
+	"github.com/cockroachdb/cockroach/pkg/util"
+)
+
+// rowFetcherCache maintains a cache of single table RowFetchers. Given a key
+// with an mvcc timestamp, it retrieves the correct TableDescriptor for that key
+// and returns a RowFetcher initialized with that table. This RowFetcher's
+// StartScanFrom can be used to turn that key (or all the keys making up the
+// column families of one row) into a row.
+//
+// TODO(dan): Actually cache things.
+type rowFetcherCache struct {
+	leaseMgr *sql.LeaseManager
+
+	a sqlbase.DatumAlloc
+}
+
+func newRowFetcherCache(leaseMgr *sql.LeaseManager) *rowFetcherCache {
+	return &rowFetcherCache{leaseMgr: leaseMgr}
+}
+
+func (c *rowFetcherCache) RowFetcherForKey(
+	ctx context.Context, key engine.MVCCKey,
+) (*sqlbase.RowFetcher, error) {
+	// TODO(dan): Handle interleaved tables.
+	_, tableID, _, err := sqlbase.DecodeTableIDIndexID(key.Key)
+	if err != nil {
+		return nil, err
+	}
+
+	// TODO(dan): We don't really need a lease, this is just a convenient way to
+	// get the right descriptor for a timestamp, so release it immediately after
+	// we acquire it. Avoid the lease entirely.
+	tableDesc, _, err := c.leaseMgr.Acquire(ctx, key.Timestamp, tableID)
+	if err != nil {
+		return nil, err
+	}
+	if err := c.leaseMgr.Release(tableDesc); err != nil {
+		return nil, err
+	}
+
+	// TODO(dan): Allow for decoding a subset of the columns.
+	colIdxMap := make(map[sqlbase.ColumnID]int)
+	var valNeededForCol util.FastIntSet
+	for colIdx, col := range tableDesc.Columns {
+		colIdxMap[col.ID] = colIdx
+		valNeededForCol.Add(colIdx)
+	}
+
+	var rf sqlbase.RowFetcher
+	if err := rf.Init(
+		false /* reverse */, false /* returnRangeInfo */, false /* isCheck */, &c.a,
+		sqlbase.RowFetcherTableArgs{
+			Spans:            tableDesc.AllIndexSpans(),
+			Desc:             tableDesc,
+			Index:            &tableDesc.PrimaryIndex,
+			ColIdxMap:        colIdxMap,
+			IsSecondaryIndex: false,
+			Cols:             tableDesc.Columns,
+			ValNeededForCol:  valNeededForCol,
+		},
+	); err != nil {
+		return nil, err
+	}
+	return &rf, nil
+}


### PR DESCRIPTION
Our schema changes work via a state machine and table descriptor leases.
This means that as a changefeed advances through time, it will need to
use different versions of descriptor if schema changes are being run on
the table. This commit reuses some existing machinery to do this in a
very slow but correct way. Performance work will be done in a followup.
NB: schema changes with backfills are also TBD since the user semantics
are still being worked through.

This also cleans up the existing code for upcoming work and decomposes
it a bit. The new hooks.go file is just code movement.

Release note: None