### PR TITLE
kv: detect canceled contexts in db.Txn() retry loop

### DIFF
--- a/pkg/internal/client/txn.go
+++ b/pkg/internal/client/txn.go
@@ -798,6 +798,9 @@ func (txn *Txn) Exec(
 	}
 
 	for {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
 		err = fn(ctx, txn, &opt)
 
 		if err == nil && opt.AutoCommit {


### PR DESCRIPTION
This patch makes it so that the retry loop is interrupted if the context
is found to be canceled.
This generally seems like a good idea, as it is with all retry loops.
But in particular it helps with a current funky behavior: when a "txn's
context" is canceled, the heartbeat loop is interrupted and the
TxnCoordSender will synthesize TransactionAbortedErrors on subsequent
txn.Send() calls. This error will trigger a txn retry - and I guess the
next Send() after that will error out somewhere.

Release note: None