### PR TITLE
backport-2.0: sql: properly mark current_date as impure

### DIFF
--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -1268,6 +1268,7 @@ CockroachDB supports the following flags:
 
 	"current_date": {
 		tree.Builtin{
+			Impure:     true,
 			Types:      tree.ArgTypes{},
 			ReturnType: tree.FixedReturnType(types.Date),
 			Fn: func(ctx *tree.EvalContext, args tree.Datums) (tree.Datum, error) {

--- a/pkg/sql/sem/tree/normalize_test.go
+++ b/pkg/sql/sem/tree/normalize_test.go
@@ -144,6 +144,7 @@ func TestNormalizeExpr(t *testing.T) {
 		{`s=lower('FOO')`, `s = 'foo'`},
 		{`lower(s)='foo'`, `lower(s) = 'foo'`},
 		{`random()`, `random()`},
+		{`current_date()`, `current_date()`},
 		{`a=count('FOO') OVER ()`, `a = count('FOO') OVER ()`},
 		{`9223372036854775808`, `9223372036854775808`},
 		{`-9223372036854775808`, `-9223372036854775808`},


### PR DESCRIPTION
Back-port of a small fix contained in #26370 for #26354.

cc @cockroachdb/release 
