### PR TITLE
sql: avoid recursing into scalar expressions multiple times

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/partitioning
+++ b/pkg/ccl/logictestccl/testdata/logic_test/partitioning
@@ -355,19 +355,19 @@ CREATE TABLE t (a INT, b INT, c INT, PRIMARY KEY (a, b)) PARTITION BY LIST (a) (
     PARTITION p1 VALUES IN (SELECT 1)
 )
 
-statement error PARTITION p1: partition expression '\(SELECT 1\)' may not contain variable sub-expressions
+statement error PARTITION p1: variable sub-expressions are not allowed in partition
 CREATE TABLE t (a INT, b INT, c INT, PRIMARY KEY (a, b)) PARTITION BY LIST (a) (
     PARTITION p1 VALUES IN ((SELECT 1))
 )
 
-statement error PARTITION p1: now\(\): partition values must be constant
+statement error PARTITION p1: impure functions are not allowed in partition
 CREATE TABLE t (a TIMESTAMP PRIMARY KEY) PARTITION BY LIST (a) (
     PARTITION p1 VALUES IN (now())
 )
 
-statement error PARTITION p1: uuid_v4\(\) || 'foo': partition values must be constant
+statement error PARTITION p1: impure functions are not allowed in partition
 CREATE TABLE t (a TIMESTAMP PRIMARY KEY) PARTITION BY LIST (a) (
-    PARTITION p1 VALUES IN (uuid_v4\(\) || 'foo')
+    PARTITION p1 VALUES IN (uuid_v4() || 'foo')
 )
 
 statement ok

--- a/pkg/ccl/partitionccl/partition.go
+++ b/pkg/ccl/partitionccl/partition.go
@@ -82,8 +82,9 @@ func valueEncodePartitionTuple(
 			// Fall-through.
 		}
 
+		var semaCtx tree.SemaContext
 		typedExpr, err := sqlbase.SanitizeVarFreeExpr(expr, cols[i].Type.ToDatumType(), "partition",
-			nil /* semaCtx */, evalCtx)
+			&semaCtx, evalCtx, false /* allowImpure */)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -726,7 +726,7 @@ func applyColumnMutation(
 		} else {
 			colDatumType := col.Type.ToDatumType()
 			expr, err := sqlbase.SanitizeVarFreeExpr(
-				t.Default, colDatumType, "DEFAULT", &params.p.semaCtx, params.EvalContext(),
+				t.Default, colDatumType, "DEFAULT", &params.p.semaCtx, params.EvalContext(), true, /* allowImpure */
 			)
 			if err != nil {
 				return err

--- a/pkg/sql/logictest/testdata/logic_test/aggregate
+++ b/pkg/sql/logictest/testdata/logic_test/aggregate
@@ -1126,3 +1126,9 @@ SELECT v, ARRAY_AGG('a') FROM kv GROUP BY v
 2     {"a","a","a"}
 4     {"a","a"}
 NULL  {"a"}
+
+# Regression test for #26419
+query I
+SELECT 123 FROM kv ORDER BY max(v)
+----
+123

--- a/pkg/sql/logictest/testdata/logic_test/alter_table
+++ b/pkg/sql/logictest/testdata/logic_test/alter_table
@@ -433,13 +433,13 @@ INSERT INTO add_default (a) VALUES (3)
 statement error could not parse "foo" as type int
 ALTER TABLE add_default ALTER COLUMN b SET DEFAULT 'foo'
 
-statement error DEFAULT expression .* may not contain variable sub-expressions
+statement error variable sub-expressions are not allowed in DEFAULT
 ALTER TABLE add_default ALTER COLUMN b SET DEFAULT $1
 
-statement error DEFAULT expression .* may not contain variable sub-expressions
+statement error variable sub-expressions are not allowed in DEFAULT
 ALTER TABLE add_default ALTER COLUMN b SET DEFAULT c
 
-statement error DEFAULT expression .* may not contain variable sub-expressions
+statement error variable sub-expressions are not allowed in DEFAULT
 ALTER TABLE add_default ALTER COLUMN b SET DEFAULT (SELECT 1)
 
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/check_constraints
+++ b/pkg/sql/logictest/testdata/logic_test/check_constraints
@@ -68,11 +68,11 @@ statement error pgcode 23514 pq: failed to satisfy CHECK constraint \(b < a\)
 INSERT INTO t3 (a, b) VALUES (2, 3)
 
 # Verify we don't accept COUNT(*)
-statement error aggregate functions are not allowed in CHECK expressions
+statement error variable sub-expressions are not allowed in CHECK
 CREATE TABLE t4 (a INT, b INT CHECK (COUNT(*) = 1))
 
 # no subqueries either.
-statement error CHECK expression .* may not contain variable sub-expressions
+statement error variable sub-expressions are not allowed in CHECK
 CREATE TABLE t4 (a INT, b INT CHECK (EXISTS (SELECT * FROM t2)))
 
 # non-boolean expressions are errors
@@ -93,11 +93,11 @@ statement error failed to satisfy CHECK
 INSERT INTO calls_func VALUES (-5)
 
 # Aggregate function calls in CHECK are not ok.
-statement error aggregate functions are not allowed in CHECK expressions
+statement error aggregate functions are not allowed in CHECK
 CREATE TABLE bad (a INT CHECK(SUM(a) > 1))
 
 # Window function calls in CHECK are not ok.
-statement error window functions are not allowed in CHECK expressions
+statement error window functions are not allowed in CHECK
 CREATE TABLE bad (a INT CHECK(SUM(a) OVER () > 1))
 
 # fail on bad check types
@@ -195,10 +195,10 @@ SELECT * FROM t5
 1 10  9
 2 11  9
 
-statement error CHECK expression .* may not contain variable sub-expressions
+statement error variable sub-expressions are not allowed in CHECK
 CREATE TABLE t6 (x INT CHECK (x = $1))
 
-statement error CHECK expression .* may not contain variable sub-expressions
+statement error variable sub-expressions are not allowed in CHECK
 CREATE TABLE t6 (x INT CHECK (x = (SELECT 1)))
 
 # Check auto-generated constraint names.

--- a/pkg/sql/logictest/testdata/logic_test/computed
+++ b/pkg/sql/logictest/testdata/logic_test/computed
@@ -278,12 +278,12 @@ CREATE TABLE y (
   b INT AS (a) STORED
 )
 
-statement error computed column "a" contains impure functions: now\(\)
+statement error impure functions are not allowed in computed column
 CREATE TABLE y (
   a TIMESTAMP AS (now()) STORED
 )
 
-statement error computed column "a" contains impure functions: now\(\), uuid_v4\(\)
+statement error impure functions are not allowed in computed column
 CREATE TABLE y (
   a STRING AS (CONCAT(now()::STRING, uuid_v4()::STRING)) STORED
 )
@@ -299,7 +299,7 @@ CREATE TABLE y (
   b INT AS (a) STORED
 )
 
-statement error aggregate functions are not allowed in computed column expressions
+statement error aggregate functions are not allowed in computed column
 CREATE TABLE y (
   b INT AS (COUNT(1)) STORED
 )
@@ -379,7 +379,7 @@ ALTER TABLE y ADD FOREIGN KEY (r) REFERENCES x (a)
 statement ok
 DROP TABLE y
 
-statement error computed column expression '\(SELECT 1\)' may not contain variable sub-expressions
+statement error variable sub-expressions are not allowed in computed column
 CREATE TABLE y (
   r INT AS ((SELECT 1)) STORED
 )

--- a/pkg/sql/logictest/testdata/logic_test/create_as
+++ b/pkg/sql/logictest/testdata/logic_test/create_as
@@ -86,7 +86,7 @@ CREATE TABLE foo (x, y, z) AS SELECT catalog_name, schema_name, sql_path FROM in
 statement error pq: unexpected type coltypes.TTuple
 CREATE TABLE foo2 (x) AS (VALUES(ROW()))
 
-statement error pq: value type setof tuple{int AS generate_series} cannot be used for table columns
+statement error pq: generator functions are not allowed in VALUES
 CREATE TABLE foo2 (x) AS (VALUES(generate_series(1,3)))
 
 statement error pq: value type unknown cannot be used for table columns

--- a/pkg/sql/logictest/testdata/logic_test/default
+++ b/pkg/sql/logictest/testdata/logic_test/default
@@ -3,13 +3,13 @@
 statement error expected DEFAULT expression to have type int, but 'false' has type bool
 CREATE TABLE t (a INT PRIMARY KEY DEFAULT false)
 
-statement error DEFAULT expression .* may not contain variable sub-expressions
+statement error variable sub-expressions are not allowed in DEFAULT
 CREATE TABLE t (a INT PRIMARY KEY DEFAULT $1)
 
-statement error DEFAULT expression .* may not contain variable sub-expressions
+statement error variable sub-expressions are not allowed in DEFAULT
 CREATE TABLE t (a INT PRIMARY KEY DEFAULT (SELECT 1))
 
-statement error DEFAULT expression .* may not contain variable sub-expressions
+statement error variable sub-expressions are not allowed in DEFAULT
 CREATE TABLE t (a INT PRIMARY KEY DEFAULT b)
 
 # Issue #14308: support tables with DEFAULT NULL columns.
@@ -17,11 +17,11 @@ statement ok
 CREATE TABLE null_default (ts TIMESTAMP PRIMARY KEY NULL DEFAULT NULL)
 
 # Aggregate function calls in CHECK are not ok.
-statement error aggregate functions are not allowed in DEFAULT expressions
+statement error aggregate functions are not allowed in DEFAULT
 CREATE TABLE bad (a INT DEFAULT COUNT(1))
 
 # Window function calls in CHECK are not ok.
-statement error window functions are not allowed in DEFAULT expressions
+statement error window functions are not allowed in DEFAULT
 CREATE TABLE bad (a INT DEFAULT COUNT(1) OVER ())
 
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/prepare
+++ b/pkg/sql/logictest/testdata/logic_test/prepare
@@ -83,13 +83,13 @@ EXECUTE a('foo', 1)
 query error expected EXECUTE parameter expression to have type int, but '3.5' has type decimal
 EXECUTE a(3.5, 1)
 
-query error aggregate functions are not allowed in EXECUTE parameters
+query error aggregate functions are not allowed in EXECUTE parameter
 EXECUTE a(max(3), 1)
 
-query error window functions are not allowed in EXECUTE parameters
+query error window functions are not allowed in EXECUTE parameter
 EXECUTE a(rank() over (partition by 3), 1)
 
-query error EXECUTE parameter expression '\(SELECT 3\)' may not contain variable sub-expressions
+query error variable sub-expressions are not allowed in EXECUTE parameter
 EXECUTE a((SELECT 3), 1)
 
 query error wrong number of parameters for prepared statement \"a\": expected 2, got 3

--- a/pkg/sql/logictest/testdata/logic_test/srfs
+++ b/pkg/sql/logictest/testdata/logic_test/srfs
@@ -84,7 +84,7 @@ SELECT * FROM GENERATE_SERIES(1, 1) WITH ORDINALITY AS c(x, y)
 x y
 1 1
 
-query error argument of LIMIT must be type int, not type setof
+query error generator functions are not allowed in LIMIT
 SELECT * FROM (VALUES (1)) LIMIT GENERATE_SERIES(1, 3)
 
 query I colnames

--- a/pkg/sql/logictest/testdata/planner_test/aggregate
+++ b/pkg/sql/logictest/testdata/planner_test/aggregate
@@ -856,3 +856,21 @@ render                    ·            ·                          ("1")       
                 └── scan  ·            ·                          (k[omitted], v, w, s[omitted])  k!=NULL; key(k)
 ·                         table        kv@primary                 ·                               ·
 ·                         spans        ALL                        ·                               ·
+
+# Regression test for #26419
+query TTTTT
+EXPLAIN (VERBOSE) SELECT 123 FROM kv ORDER BY max(v)
+----
+sort                      ·            ·                 ("123")                                  "123"=CONST
+ │                        order        +max              ·                                        ·
+ └── render               ·            ·                 ("123", max)                             "123"=CONST
+      │                   render 0     123               ·                                        ·
+      │                   render 1     agg0              ·                                        ·
+      └── group           ·            ·                 (agg0)                                   ·
+           │              aggregate 0  max(v)            ·                                        ·
+           └── render     ·            ·                 (v)                                      v!=NULL
+                │         render 0     test.public.kv.v  ·                                        ·
+                └── scan  ·            ·                 (k[omitted], v, w[omitted], s[omitted])  k!=NULL; v!=NULL; key(k)
+·                         table        kv@primary        ·                                        ·
+·                         spans        ALL               ·                                        ·
+·                         filter       v IS NOT NULL     ·                                        ·

--- a/pkg/sql/logictest/testdata/planner_test/ordinal_references
+++ b/pkg/sql/logictest/testdata/planner_test/ordinal_references
@@ -21,9 +21,9 @@ query TTTTT
 EXPLAIN (VERBOSE) SELECT min(a) AS m FROM foo GROUP BY @1
 ----
 group           ·            ·                  (m)                                     ·
- │              aggregate 0  min(a)             ·                                       ·
+ │              aggregate 0  min(@1)            ·                                       ·
  │              group by     @1                 ·                                       ·
- └── render     ·            ·                  (a)                                     ·
+ └── render     ·            ·                  ("@1")                                  ·
       │         render 0     test.public.foo.a  ·                                       ·
       └── scan  ·            ·                  (a, b[omitted], rowid[hidden,omitted])  rowid!=NULL; key(rowid)
 ·               table        foo@primary        ·                                       ·
@@ -35,7 +35,7 @@ EXPLAIN (VERBOSE) SELECT min(a) AS m FROM foo GROUP BY @2
 group           ·            ·                  (m)                            ·
  │              aggregate 0  min(a)             ·                              ·
  │              group by     @1                 ·                              ·
- └── render     ·            ·                  (b, a)                         ·
+ └── render     ·            ·                  ("@2", a)                      ·
       │         render 0     test.public.foo.b  ·                              ·
       │         render 1     test.public.foo.a  ·                              ·
       └── scan  ·            ·                  (a, b, rowid[hidden,omitted])  rowid!=NULL; key(rowid)

--- a/pkg/sql/opt/optbuilder/scope.go
+++ b/pkg/sql/opt/optbuilder/scope.go
@@ -319,7 +319,7 @@ func (s *scope) startAggFunc() (aggInScope *scope, aggOutScope *scope) {
 		}
 	}
 
-	panic(fmt.Errorf("aggregate function is not allowed in this context"))
+	panic(unimplementedf("woops the aggregate semantic analysis is incomplete"))
 }
 
 // endAggFunc is called when the builder finishes building an aggregate

--- a/pkg/sql/sem/tree/normalize.go
+++ b/pkg/sql/sem/tree/normalize.go
@@ -841,37 +841,6 @@ func IsConst(evalCtx *EvalContext, expr Expr) bool {
 	return v.run(expr)
 }
 
-type impureFunctionsVisitor struct {
-	fns []*FuncExpr
-}
-
-var _ Visitor = &impureFunctionsVisitor{}
-
-func (v *impureFunctionsVisitor) VisitPre(expr Expr) (recurse bool, newExpr Expr) {
-	switch t := expr.(type) {
-	case *FuncExpr:
-		if t.IsImpure() {
-			v.fns = append(v.fns, t)
-			return true, expr
-		}
-	}
-	return true, expr
-}
-
-func (*impureFunctionsVisitor) VisitPost(expr Expr) Expr { return expr }
-
-func (v *impureFunctionsVisitor) run(expr Expr) []*FuncExpr {
-	WalkExprConst(v, expr)
-	return v.fns
-}
-
-// ImpureFunctions returns the impure functions in an expression. It does not
-// return any column references, which distinguishes it from IsConst.
-func ImpureFunctions(expr Expr) []*FuncExpr {
-	v := impureFunctionsVisitor{}
-	return v.run(expr)
-}
-
 // isVar returns true if the expression's value can vary during plan
 // execution.
 func isVar(evalCtx *EvalContext, expr Expr) bool {

--- a/pkg/sql/split_test.go
+++ b/pkg/sql/split_test.go
@@ -85,7 +85,7 @@ func TestSplitAt(t *testing.T) {
 			error: `index "not_present" does not exist`,
 		},
 		{
-			in:    "ALTER TABLE d.i SPLIT AT VALUES (avg(1))",
+			in:    "ALTER TABLE d.i SPLIT AT VALUES (avg(1::float))",
 			error: "aggregate functions are not allowed in VALUES",
 		},
 		{

--- a/pkg/sql/sqlbase/errors.go
+++ b/pkg/sql/sqlbase/errors.go
@@ -192,11 +192,6 @@ func NewRangeUnavailableError(
 		rangeID, nodeIDs, origErr)
 }
 
-// NewWindowingError creates a windowing error.
-func NewWindowingError(in string) error {
-	return pgerror.NewErrorf(pgerror.CodeWindowingError, "window functions are not allowed in %s", in)
-}
-
 // NewWindowInAggError creates an error for the case when a window function is
 // nested within an aggregate function.
 func NewWindowInAggError() error {

--- a/pkg/sql/window.go
+++ b/pkg/sql/window.go
@@ -97,7 +97,7 @@ func (p *planner) window(
 	// renders to determine this because window functions may be added to the
 	// renderNode by an ORDER BY clause.
 	// For instance: SELECT x FROM y ORDER BY avg(x) OVER ().
-	if containsWindowFn := p.txCtx.WindowFuncInExprs(s.render); !containsWindowFn {
+	if !s.renderProps.SeenWindowApplication {
 		return nil, nil
 	}
 


### PR DESCRIPTION
(Needed to complete  #26223)
Fixes #26420.
Fixes #26419.

Prior to this patch, the planning code would (ab)use recursions into
scalar expression trees to determine various scalar properties like
"is this using impure functions" or "is this using aggregate
functions", etc. Also the code would use separate recursions to
determine each separate properties.

Also the code was incomplete as it didn't check some important
properties, for example SRFs should be rejected from LIMIT clauses.

The multiple recursions are inefficient and adding the missing
necessary checks would make it even more inefficient.

Instead, this code makes the type checking recursion, which needs to
happen in any case, collect the "interesting" scalar properties in a
new field `Properties` of `SemaContext`. This field is then subsequently checked
where needed, without the need for additional recursions.

Release note (sql change): CockroachDB now recognizes aggregates in
ORDER BY clauses even when there is no GROUP BY clause nor aggregation
performed, for compatibility with PostgreSQL.

Release note (bug fix): CockroachDB now produces a clearer message
when special functions (e.g. `generate_series`) are used in an invalid
context (e.g. `LIMIT`).
