### PR TITLE
util: explicitly enumerate encoding types

### DIFF
--- a/pkg/util/encoding/encoding.go
+++ b/pkg/util/encoding/encoding.go
@@ -1038,27 +1038,30 @@ type Type int
 
 // Type values.
 // TODO(dan, arjun): Make this into a proto enum.
+// The 'Type' annotations are necessary for producing stringer-generated values.
 const (
-	Unknown Type = iota
-	Null
-	NotNull
-	Int
-	Float
-	Decimal
-	Bytes
-	BytesDesc // Bytes encoded descendingly
-	Time
-	Duration
-	True
-	False
-	UUID
-	Array
-	IPAddr
-	// Do not change SentinelType from 15. This value is specifically used for bit
-	// manipulation in EncodeValueTag.
-	SentinelType Type = 15 // Used in the Value encoding.
-	JSON         Type = iota
-	Tuple
+	Unknown   Type = 0
+	Null      Type = 1
+	NotNull   Type = 2
+	Int       Type = 3
+	Float     Type = 4
+	Decimal   Type = 5
+	Bytes     Type = 6
+	BytesDesc Type = 7 // Bytes encoded descendingly
+	Time      Type = 8
+	Duration  Type = 9
+	True      Type = 10
+	False     Type = 11
+	UUID      Type = 12
+	Array     Type = 13
+	IPAddr    Type = 14
+	// SentinelType is used for bit manipulation to check if the encoded type
+	// value requires more than 4 bits, and thus will be encoded in two bytes. It
+	// is not used as a type value, and thus intentionally overlaps with the
+	// subsequent type value. The 'Type' annotation is intentionally omitted here.
+	SentinelType      = 15
+	JSON         Type = 15
+	Tuple        Type = 16
 )
 
 // PeekType peeks at the type of the value encoded at the start of b.

--- a/pkg/util/encoding/type_string.go
+++ b/pkg/util/encoding/type_string.go
@@ -4,9 +4,9 @@ package encoding
 
 import "strconv"
 
-const _Type_name = "UnknownNullNotNullIntFloatDecimalBytesBytesDescTimeDurationTrueFalseUUIDArrayIPAddrSentinelTypeJSONTuple"
+const _Type_name = "UnknownNullNotNullIntFloatDecimalBytesBytesDescTimeDurationTrueFalseUUIDArrayIPAddrJSONTuple"
 
-var _Type_index = [...]uint8{0, 7, 11, 18, 21, 26, 33, 38, 47, 51, 59, 63, 68, 72, 77, 83, 95, 99, 104}
+var _Type_index = [...]uint8{0, 7, 11, 18, 21, 26, 33, 38, 47, 51, 59, 63, 68, 72, 77, 83, 87, 92}
 
 func (i Type) String() string {
 	if i < 0 || i >= Type(len(_Type_index)-1) {


### PR DESCRIPTION
The existence of the SentinelType, which overlaps in value with other
values in the enum confuses readers. Also improve the comment on SentinelType.

Fixes #25759.
