### PR TITLE
sql: support max_identifier_length variable

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -1549,6 +1549,7 @@ integer_datetimes                    on                  NULL      NULL        N
 intervalstyle                        postgres            NULL      NULL        NULL        string
 locality                             region=test,dc=dc1  NULL      NULL        NULL        string
 lock_timeout                         0                   NULL      NULL        NULL        string
+max_identifier_length                128                 NULL      NULL        NULL        string
 max_index_keys                       32                  NULL      NULL        NULL        string
 node_id                              1                   NULL      NULL        NULL        string
 reorder_joins_limit                  4                   NULL      NULL        NULL        string
@@ -1603,6 +1604,7 @@ integer_datetimes                    on                  NULL  user     NULL    
 intervalstyle                        postgres            NULL  user     NULL      postgres            postgres
 locality                             region=test,dc=dc1  NULL  user     NULL      region=test,dc=dc1  region=test,dc=dc1
 lock_timeout                         0                   NULL  user     NULL      0                   0
+max_identifier_length                128                 NULL  user     NULL      128                 128
 max_index_keys                       32                  NULL  user     NULL      32                  32
 node_id                              1                   NULL  user     NULL      1                   1
 reorder_joins_limit                  4                   NULL  user     NULL      4                   4
@@ -1653,6 +1655,7 @@ integer_datetimes                    NULL    NULL     NULL     NULL        NULL
 intervalstyle                        NULL    NULL     NULL     NULL        NULL
 locality                             NULL    NULL     NULL     NULL        NULL
 lock_timeout                         NULL    NULL     NULL     NULL        NULL
+max_identifier_length                NULL    NULL     NULL     NULL        NULL
 max_index_keys                       NULL    NULL     NULL     NULL        NULL
 node_id                              NULL    NULL     NULL     NULL        NULL
 optimizer                            NULL    NULL     NULL     NULL        NULL

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -48,6 +48,7 @@ integer_datetimes                    on
 intervalstyle                        postgres
 locality                             region=test,dc=dc1
 lock_timeout                         0
+max_identifier_length                128
 max_index_keys                       32
 node_id                              1
 reorder_joins_limit                  4

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -545,6 +545,12 @@ var varGen = map[string]sessionVar{
 	// See also issue #5924.
 	`idle_in_transaction_session_timeout`: makeCompatIntVar(`idle_in_transaction_session_timeout`, 0),
 
+	// Supported for PG compatibility only.
+	// See https://www.postgresql.org/docs/10/static/sql-syntax-lexical.html#SQL-SYNTAX-IDENTIFIERS
+	`max_identifier_length`: {
+		Get: func(evalCtx *extendedEvalContext) string { return "128" },
+	},
+
 	// See https://www.postgresql.org/docs/10/static/runtime-config-preset.html#GUC-MAX-INDEX-KEYS
 	`max_index_keys`: makeReadOnlyVar("32"),
 


### PR DESCRIPTION
See https://www.postgresql.org/docs/10/static/sql-syntax-lexical.html#SQL-SYNTAX-IDENTIFIERS

Postgres always returns 63 for this variable and doesn't allow it to be
set. This is needed for recent versions of ActiveRecord. It is currently
blocking cockroachdb/examples-orms#49.

This commit sets it to 128 to match SQL Server and Oracle, but doesn't
attempt to validate any incoming schema definitions. We may reserve the
right to do that in the future.

Release note (sql change): support the max_identifier_length variable, which is immutably set to 128. CockroachDB does not attempt to validate that identifiers are less than this length currently; we reserve the right to begin doing so in the future in a backward-compatible way.
Release justification: Low-risk compatibility improvement