### PR TITLE
distsql: add NewFinalIterator to the rowIterator interface

### DIFF
--- a/pkg/sql/distsqlrun/disk_row_container.go
+++ b/pkg/sql/distsqlrun/disk_row_container.go
@@ -212,6 +212,11 @@ func (d *diskRowContainer) NewIterator(ctx context.Context) rowIterator {
 	return diskRowIterator{rowContainer: d, SortedDiskMapIterator: d.diskMap.NewIterator()}
 }
 
+// NewFinalIterator is equivalent to NewIterator.
+func (d *diskRowContainer) NewFinalIterator(ctx context.Context) rowIterator {
+	return d.NewIterator(ctx)
+}
+
 // Row returns the current row. The returned sqlbase.EncDatumRow is only valid
 // until the next call to Row().
 func (r diskRowIterator) Row() (sqlbase.EncDatumRow, error) {

--- a/pkg/sql/distsqlrun/hashjoiner.go
+++ b/pkg/sql/distsqlrun/hashjoiner.go
@@ -469,7 +469,7 @@ func (h *hashJoiner) buildPhase(
 	}
 
 	// Transfer rows from memory.
-	i := h.rows[h.storedSide].NewIterator(ctx)
+	i := h.rows[h.storedSide].NewFinalIterator(ctx)
 	defer i.Close()
 	for i.Rewind(); ; i.Next() {
 		if err := h.cancelChecker.Check(); err != nil {
@@ -636,7 +636,7 @@ func (h *hashJoiner) probePhase(
 		src = h.rightSource
 	}
 	// First process the rows that were already buffered.
-	probeIterator := h.rows[side].NewIterator(ctx)
+	probeIterator := h.rows[side].NewFinalIterator(ctx)
 	defer probeIterator.Close()
 	for probeIterator.Rewind(); ; probeIterator.Next() {
 		if ok, err := probeIterator.Valid(); err != nil {

--- a/pkg/sql/distsqlrun/sorter.go
+++ b/pkg/sql/distsqlrun/sorter.go
@@ -251,7 +251,7 @@ func (s *sortAllProcessor) fill() (ok bool, _ error) {
 	s.diskContainer = &diskContainer
 
 	// Transfer the rows from memory to disk. This frees up the memory taken up by s.rows.
-	i := s.rows.NewIterator(ctx)
+	i := s.rows.NewFinalIterator(ctx)
 	for i.Rewind(); ; i.Next() {
 		if ok, err := i.Valid(); err != nil {
 			return false, err
@@ -312,7 +312,7 @@ func (s *sortAllProcessor) fillWithContainer(
 	}
 	r.Sort(ctx)
 
-	s.i = r.NewIterator(ctx)
+	s.i = r.NewFinalIterator(ctx)
 	s.i.Rewind()
 
 	return true, nil, nil


### PR DESCRIPTION
Some implementations of the rowIterator interface would destroy rows as
they were iterated over to free memory eagerly. NewFinalIterator is
introduced in this change to provide non-reusable behavior and
NewIterator is explicitly described as reusable.

A reusable iterator has been added to the memRowContainer to satisfy
these new interface semantics.

Release note: None