### PR TITLE
kv: skip TestTxnCoordSenderRetries

### DIFF
--- a/pkg/kv/dist_sender_server_test.go
+++ b/pkg/kv/dist_sender_server_test.go
@@ -1871,6 +1871,7 @@ func TestTxnCoordSenderHeartbeatFailurePostSplit(t *testing.T) {
 // but still fail in others, depending on different conditions.
 func TestTxnCoordSenderRetries(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	t.Skip("26434")
 
 	var filterFn atomic.Value
 	var storeKnobs storage.StoreTestingKnobs


### PR DESCRIPTION
TestTxnCoordSenderRetries is flaky, presumably as a consequence of
merging #25541.
A subtest is sometimes failing because a CommandFilter that it's using
is inadvertently injecting a failure into a lingering request from a
previous subtest. Don't know why that PR changed any behavior yet, but
it seems more likely that this is a test issue than issue warranting a
rollback, so skipping while I figure it out.

Touches #26434

Release note: None