### PR TITLE
sql: add pg_builtin `pg_is_in_recovery()`

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/builtin_function
+++ b/pkg/sql/logictest/testdata/logic_test/builtin_function
@@ -1770,3 +1770,11 @@ query TT
 SELECT array_to_string(NULL, ','), array_to_string(NULL, 'foo', 'zerp')
 ----
 NULL  NULL
+
+subtest pg_is_in_recovery
+
+query B colnames
+SELECT pg_is_in_recovery()
+----
+pg_is_in_recovery
+false

--- a/pkg/sql/sem/builtins/pg_builtins.go
+++ b/pkg/sql/sem/builtins/pg_builtins.go
@@ -779,6 +779,20 @@ var pgBuiltins = map[string]builtinDefinition{
 		},
 	),
 
+	// pg_is_in_recovery returns true if the Postgres database is currently in
+	// recovery.  This is not applicable so this can always return false.
+	// https://www.postgresql.org/docs/current/static/functions-admin.html#FUNCTIONS-RECOVERY-INFO-TABLE
+	"pg_is_in_recovery": makeBuiltin(defProps(),
+		tree.Overload{
+			Types:      tree.ArgTypes{},
+			ReturnType: tree.FixedReturnType(types.Bool),
+			Fn: func(*tree.EvalContext, tree.Datums) (tree.Datum, error) {
+				return tree.DBoolFalse, nil
+			},
+			Info: notUsableInfo,
+		},
+	),
+
 	// Access Privilege Inquiry Functions allow users to query object access
 	// privileges programmatically. Each function has a number of variants,
 	// which differ based on their function signatures. These signatures have


### PR DESCRIPTION
This function is required for compatibility for PGAdmin.

Fixes #26374.

Release note (sql change): Added `pg_is_in_recovery()` for compatibilty with postgres tools.