### PR TITLE
ts: Properly read columnar format

### DIFF
--- a/pkg/roachpb/internal.go
+++ b/pkg/roachpb/internal.go
@@ -14,37 +14,29 @@
 
 package roachpb
 
-// Summation returns the sum value for this sample.
-func (samp InternalTimeSeriesSample) Summation() float64 {
-	return samp.Sum
+// IsColumnar returns true if this InternalTimeSeriesData stores its samples
+// in columnar format.
+func (data *InternalTimeSeriesData) IsColumnar() bool {
+	return len(data.Offset) > 0
 }
 
-// Average returns the average value for this sample.
-func (samp InternalTimeSeriesSample) Average() float64 {
-	if samp.Count == 0 {
-		return 0
-	}
-	return samp.Sum / float64(samp.Count)
+// IsRollup returns true if this InternalTimeSeriesData is both in columnar
+// format and contains "rollup" data.
+func (data *InternalTimeSeriesData) IsRollup() bool {
+	return len(data.Count) > 0
 }
 
-// Maximum returns the maximum value encountered by this sample.
-func (samp InternalTimeSeriesSample) Maximum() float64 {
-	if samp.Count < 2 {
-		return samp.Sum
+// SampleCount returns the number of samples contained in this
+// InternalTimeSeriesData.
+func (data *InternalTimeSeriesData) SampleCount() int {
+	if data.IsColumnar() {
+		return len(data.Offset)
 	}
-	if samp.Max != nil {
-		return *samp.Max
-	}
-	return 0
+	return len(data.Samples)
 }
 
-// Minimum returns the minimum value encountered by this sample.
-func (samp InternalTimeSeriesSample) Minimum() float64 {
-	if samp.Count < 2 {
-		return samp.Sum
-	}
-	if samp.Min != nil {
-		return *samp.Min
-	}
-	return 0
+// OffsetForTimestamp returns the offset within this collection that would
+// represent the provided timestamp.
+func (data *InternalTimeSeriesData) OffsetForTimestamp(timestampNanos int64) int32 {
+	return int32((timestampNanos - data.StartTimestampNanos) / data.SampleDurationNanos)
 }

--- a/pkg/ts/db_test.go
+++ b/pkg/ts/db_test.go
@@ -379,13 +379,6 @@ func (mq *modelQuery) assertSuccess(expectedDatapointCount, expectedSourceCount 
 	if err != nil {
 		mq.modelRunner.t.Fatal(err)
 	}
-	if a, e := len(actualDatapoints), expectedDatapointCount; a != e {
-		mq.modelRunner.t.Logf("actual datapoints: %v", actualDatapoints)
-		mq.modelRunner.t.Fatal(errors.Errorf("query got %d datapoints, wanted %d", a, e))
-	}
-	if a, e := len(actualSources), expectedSourceCount; a != e {
-		mq.modelRunner.t.Fatal(errors.Errorf("query got %d sources, wanted %d", a, e))
-	}
 
 	// Query the model.
 	modelDatapoints := mq.modelRunner.model.Query(
@@ -405,6 +398,15 @@ func (mq *modelQuery) assertSuccess(expectedDatapointCount, expectedSourceCount 
 		for _, diff := range pretty.Diff(a, e) {
 			mq.modelRunner.t.Error(diff)
 		}
+	}
+	if a, e := len(actualDatapoints), expectedDatapointCount; a != e {
+		mq.modelRunner.t.Logf("actual datapoints: %v", actualDatapoints)
+		mq.modelRunner.t.Logf("model datapoints: %v", modelDatapoints)
+		mq.modelRunner.t.Fatal(errors.Errorf("query got %d datapoints, wanted %d", a, e))
+	}
+	if a, e := len(actualSources), expectedSourceCount; a != e {
+		mq.modelRunner.t.Logf("actual sources: %v", actualSources)
+		mq.modelRunner.t.Fatal(errors.Errorf("query got %d sources, wanted %d", a, e))
 	}
 }
 


### PR DESCRIPTION
This commit allows the time series query system to properly handle
on-disk data stored in the columnar format. It does so in a way that is
completely backwards compatible with the row-based format; a queried
time span can actually handle a mixture of row-and-column formatted data
blocks and produce a correct response.

This does not yet include the actual writing of columnar data to disk -
all data being written is currently still in row format. As such, tests
have not yet been added verifying the columnar format through the entire
pipeline. However, unit tests for the downsampling logic have been
greatly expanded, as this was the portion of the code most greatly
affected by this change.

Release note: none.