### PR TITLE
backupccl: support SHOW BACKUP [RANGES|FILES]

### DIFF
--- a/docs/generated/sql/bnf/show_backup.bnf
+++ b/docs/generated/sql/bnf/show_backup.bnf
@@ -1,2 +1,4 @@
 show_backup_stmt ::=
 	'SHOW' 'BACKUP' location
+	| 'SHOW' 'BACKUP' 'RANGES' location
+	| 'SHOW' 'BACKUP' 'FILES' location

--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -440,6 +440,8 @@ use_stmt ::=
 
 show_backup_stmt ::=
 	'SHOW' 'BACKUP' string_or_placeholder
+	| 'SHOW' 'BACKUP' 'RANGES' string_or_placeholder
+	| 'SHOW' 'BACKUP' 'FILES' string_or_placeholder
 
 show_columns_stmt ::=
 	'SHOW' 'COLUMNS' 'FROM' table_name
@@ -680,6 +682,7 @@ unreserved_keyword ::=
 	| 'EXPERIMENTAL_REPLICA'
 	| 'EXPLAIN'
 	| 'EXPORT'
+	| 'FILES'
 	| 'FILTER'
 	| 'FIRST'
 	| 'FLOAT4'
@@ -756,6 +759,7 @@ unreserved_keyword ::=
 	| 'QUERIES'
 	| 'QUERY'
 	| 'RANGE'
+	| 'RANGES'
 	| 'READ'
 	| 'RECURSIVE'
 	| 'REF'

--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -1770,7 +1770,7 @@ alter_table_cmd ::=
 	| 'ALTER' opt_column column_name 'DROP' 'STORED'
 	| 'DROP' opt_column 'IF' 'EXISTS' column_name opt_drop_behavior
 	| 'DROP' opt_column column_name opt_drop_behavior
-	| 'ALTER' opt_column column_name opt_set_data 'TYPE' typename opt_alter_column_collate opt_alter_column_using
+	| 'ALTER' opt_column column_name opt_set_data 'TYPE' typename opt_collate opt_alter_column_using
 	| 'ADD' table_constraint opt_validate_behavior
 	| 'VALIDATE' 'CONSTRAINT' constraint_name
 	| 'DROP' 'CONSTRAINT' 'IF' 'EXISTS' constraint_name opt_drop_behavior
@@ -1972,7 +1972,7 @@ opt_set_data ::=
 	'SET' 'DATA'
 	| 
 
-opt_alter_column_collate ::=
+opt_collate ::=
 	'COLLATE' collation_name
 	| 
 

--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -12,7 +12,6 @@ import (
 	"bytes"
 	"context"
 	gosql "database/sql"
-	"database/sql/driver"
 	"fmt"
 	"hash/crc32"
 	"io"
@@ -2446,69 +2445,6 @@ func TestRestoreDatabaseVersusTable(t *testing.T) {
 			t.Fatal(err)
 		}
 	})
-}
-
-func TestShowBackup(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-
-	const numAccounts = 11
-	_, _, sqlDB, _, cleanupFn := backupRestoreTestSetup(t, singleNode, numAccounts, initNone)
-	defer cleanupFn()
-
-	full, inc := localFoo+"/full", localFoo+"/inc"
-
-	beforeFull := timeutil.Now()
-	sqlDB.Exec(t, `BACKUP data.bank TO $1`, full)
-
-	var unused driver.Value
-	var start, end *time.Time
-	var dataSize, rows uint64
-	sqlDB.QueryRow(t, `SELECT * FROM [SHOW BACKUP $1] WHERE "table" = 'bank'`, full).Scan(
-		&unused, &unused, &start, &end, &dataSize, &rows,
-	)
-	if start != nil {
-		t.Errorf("expected null start time on full backup, got %v", *start)
-	}
-	if !(*end).After(beforeFull) {
-		t.Errorf("expected now (%s) to be in (%s, %s)", beforeFull, start, end)
-	}
-	if dataSize <= 0 {
-		t.Errorf("expected dataSize to be >0 got : %d", dataSize)
-	}
-	if rows != numAccounts {
-		t.Errorf("expected %d got: %d", numAccounts, rows)
-	}
-
-	// Mess with half the rows.
-	affectedRows, err := sqlDB.Exec(t,
-		`UPDATE data.bank SET id = -1 * id WHERE id > $1`, numAccounts/2,
-	).RowsAffected()
-	if err != nil {
-		t.Fatal(err)
-	} else if affectedRows != numAccounts/2 {
-		t.Fatalf("expected to update %d rows, got %d", numAccounts/2, affectedRows)
-	}
-
-	beforeInc := timeutil.Now()
-	sqlDB.Exec(t, `BACKUP data.bank TO $1 INCREMENTAL FROM $2`, inc, full)
-
-	sqlDB.QueryRow(t, `SELECT * FROM [SHOW BACKUP $1] WHERE "table" = 'bank'`, inc).Scan(
-		&unused, &unused, &start, &end, &dataSize, &rows,
-	)
-	if start == nil {
-		t.Errorf("expected start time on inc backup, got %v", *start)
-	}
-	if !(*end).After(beforeInc) {
-		t.Errorf("expected now (%s) to be in (%s, %s)", beforeInc, start, end)
-	}
-	if dataSize <= 0 {
-		t.Errorf("expected dataSize to be >0 got : %d", dataSize)
-	}
-	// We added affectedRows and removed affectedRows, so there should be 2*
-	// affectedRows in the backup.
-	if expected := affectedRows * 2; rows != uint64(expected) {
-		t.Errorf("expected %d got: %d", expected, rows)
-	}
 }
 
 func TestBackupAzureAccountName(t *testing.T) {

--- a/pkg/ccl/backupccl/show.go
+++ b/pkg/ccl/backupccl/show.go
@@ -1,0 +1,117 @@
+// Copyright 2016 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package backupccl
+
+import (
+	"context"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/ccl/utilccl"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/sql"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/types"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+	"github.com/cockroachdb/cockroach/pkg/util/encoding"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/cockroachdb/cockroach/pkg/util/tracing"
+)
+
+// showBackupPlanHook implements PlanHookFn.
+func showBackupPlanHook(
+	ctx context.Context, stmt tree.Statement, p sql.PlanHookState,
+) (sql.PlanHookRowFn, sqlbase.ResultColumns, []sql.PlanNode, error) {
+	backup, ok := stmt.(*tree.ShowBackup)
+	if !ok {
+		return nil, nil, nil, nil
+	}
+
+	if err := utilccl.CheckEnterpriseEnabled(
+		p.ExecCfg().Settings, p.ExecCfg().ClusterID(), p.ExecCfg().Organization(), "SHOW BACKUP",
+	); err != nil {
+		return nil, nil, nil, err
+	}
+
+	if err := p.RequireSuperUser(ctx, "SHOW BACKUP"); err != nil {
+		return nil, nil, nil, err
+	}
+
+	toFn, err := p.TypeAsString(backup.Path, "SHOW BACKUP")
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	header := sqlbase.ResultColumns{
+		{Name: "database", Typ: types.String},
+		{Name: "table", Typ: types.String},
+		{Name: "start_time", Typ: types.Timestamp},
+		{Name: "end_time", Typ: types.Timestamp},
+		{Name: "size_bytes", Typ: types.Int},
+		{Name: "rows", Typ: types.Int},
+	}
+	fn := func(ctx context.Context, _ []sql.PlanNode, resultsCh chan<- tree.Datums) error {
+		// TODO(dan): Move this span into sql.
+		ctx, span := tracing.ChildSpan(ctx, stmt.StatementTag())
+		defer tracing.FinishSpan(span)
+
+		str, err := toFn()
+		if err != nil {
+			return err
+		}
+		desc, err := ReadBackupDescriptorFromURI(ctx, str, p.ExecCfg().Settings)
+		if err != nil {
+			return err
+		}
+		descs := make(map[sqlbase.ID]string)
+		for _, descriptor := range desc.Descriptors {
+			if database := descriptor.GetDatabase(); database != nil {
+				if _, ok := descs[database.ID]; !ok {
+					descs[database.ID] = database.Name
+				}
+			}
+		}
+		descSizes := make(map[sqlbase.ID]roachpb.BulkOpSummary)
+		for _, file := range desc.Files {
+			// TODO(dan): This assumes each file in the backup only contains
+			// data from a single table, which is usually but not always
+			// correct. It does not account for interleaved tables or if a
+			// BACKUP happened to catch a newly created table that hadn't yet
+			// been split into its own range.
+			_, tableID, err := encoding.DecodeUvarintAscending(file.Span.Key)
+			if err != nil {
+				continue
+			}
+			s := descSizes[sqlbase.ID(tableID)]
+			s.Add(file.EntryCounts)
+			descSizes[sqlbase.ID(tableID)] = s
+		}
+		start := tree.DNull
+		if desc.StartTime.WallTime != 0 {
+			start = tree.MakeDTimestamp(timeutil.Unix(0, desc.StartTime.WallTime), time.Nanosecond)
+		}
+		for _, descriptor := range desc.Descriptors {
+			if table := descriptor.GetTable(); table != nil {
+				dbName := descs[table.ParentID]
+				resultsCh <- tree.Datums{
+					tree.NewDString(dbName),
+					tree.NewDString(table.Name),
+					start,
+					tree.MakeDTimestamp(timeutil.Unix(0, desc.EndTime.WallTime), time.Nanosecond),
+					tree.NewDInt(tree.DInt(descSizes[table.ID].DataSize)),
+					tree.NewDInt(tree.DInt(descSizes[table.ID].Rows)),
+				}
+			}
+		}
+		return nil
+	}
+	return fn, header, nil, nil
+}
+
+func init() {
+	sql.AddPlanHook(showBackupPlanHook)
+}

--- a/pkg/ccl/backupccl/show_test.go
+++ b/pkg/ccl/backupccl/show_test.go
@@ -10,9 +10,13 @@ package backupccl_test
 
 import (
 	"database/sql/driver"
+	"fmt"
+	"regexp"
 	"testing"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 )
@@ -21,10 +25,10 @@ func TestShowBackup(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	const numAccounts = 11
-	_, _, sqlDB, _, cleanupFn := backupRestoreTestSetup(t, singleNode, numAccounts, initNone)
+	_, tc, sqlDB, _, cleanupFn := backupRestoreTestSetup(t, singleNode, numAccounts, initNone)
 	defer cleanupFn()
 
-	full, inc := localFoo+"/full", localFoo+"/inc"
+	full, inc, details := localFoo+"/full", localFoo+"/inc", localFoo+"/details"
 
 	beforeFull := timeutil.Now()
 	sqlDB.Exec(t, `BACKUP data.bank TO $1`, full)
@@ -77,5 +81,39 @@ func TestShowBackup(t *testing.T) {
 	// affectedRows in the backup.
 	if expected := affectedRows * 2; rows != uint64(expected) {
 		t.Errorf("expected %d got: %d", expected, rows)
+	}
+
+	sqlDB.Exec(t, `CREATE TABLE data.details1 (c INT PRIMARY KEY)`)
+	sqlDB.Exec(t, `INSERT INTO data.details1 (SELECT generate_series(1, 100))`)
+	sqlDB.Exec(t, `ALTER TABLE data.details1 SPLIT AT VALUES (1), (42)`)
+	sqlDB.Exec(t, `CREATE TABLE data.details2()`)
+	sqlDB.Exec(t, `BACKUP data.details1, data.details2 TO $1;`, details)
+
+	details1Desc := sqlbase.GetTableDescriptor(tc.Server(0).DB(), "data", "details1")
+	details2Desc := sqlbase.GetTableDescriptor(tc.Server(0).DB(), "data", "details2")
+	details1Key := roachpb.Key(sqlbase.MakeIndexKeyPrefix(details1Desc, details1Desc.PrimaryIndex.ID))
+	details2Key := roachpb.Key(sqlbase.MakeIndexKeyPrefix(details2Desc, details2Desc.PrimaryIndex.ID))
+
+	sqlDB.CheckQueryResults(t, fmt.Sprintf(`SHOW BACKUP RANGES '%s'`, details), [][]string{
+		{"/Table/54/1", "/Table/54/2", string(details1Key), string(details1Key.PrefixEnd())},
+		{"/Table/55/1", "/Table/55/2", string(details2Key), string(details2Key.PrefixEnd())},
+	})
+
+	var showFiles = fmt.Sprintf(`SELECT start_pretty, end_pretty, size_bytes, rows
+		FROM [SHOW BACKUP FILES '%s']`, details)
+	sqlDB.CheckQueryResults(t, showFiles, [][]string{
+		{"/Table/54/1/1", "/Table/54/1/42", "369", "41"},
+		{"/Table/54/1/42", "/Table/54/2", "531", "59"},
+	})
+	sstMatcher := regexp.MustCompile(`\d+\.sst`)
+	pathRows := sqlDB.QueryStr(t, `SELECT path FROM [SHOW BACKUP FILES $1]`, details)
+	for _, row := range pathRows {
+		path := row[0]
+		if matched := sstMatcher.MatchString(path); !matched {
+			t.Errorf("malformatted path in SHOW BACKUP FILES: %s", path)
+		}
+	}
+	if len(pathRows) != 2 {
+		t.Fatalf("expected 2 files, but got %d", len(pathRows))
 	}
 }

--- a/pkg/ccl/backupccl/show_test.go
+++ b/pkg/ccl/backupccl/show_test.go
@@ -1,0 +1,81 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package backupccl_test
+
+import (
+	"database/sql/driver"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+)
+
+func TestShowBackup(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	const numAccounts = 11
+	_, _, sqlDB, _, cleanupFn := backupRestoreTestSetup(t, singleNode, numAccounts, initNone)
+	defer cleanupFn()
+
+	full, inc := localFoo+"/full", localFoo+"/inc"
+
+	beforeFull := timeutil.Now()
+	sqlDB.Exec(t, `BACKUP data.bank TO $1`, full)
+
+	var unused driver.Value
+	var start, end *time.Time
+	var dataSize, rows uint64
+	sqlDB.QueryRow(t, `SELECT * FROM [SHOW BACKUP $1] WHERE "table" = 'bank'`, full).Scan(
+		&unused, &unused, &start, &end, &dataSize, &rows,
+	)
+	if start != nil {
+		t.Errorf("expected null start time on full backup, got %v", *start)
+	}
+	if !(*end).After(beforeFull) {
+		t.Errorf("expected now (%s) to be in (%s, %s)", beforeFull, start, end)
+	}
+	if dataSize <= 0 {
+		t.Errorf("expected dataSize to be >0 got : %d", dataSize)
+	}
+	if rows != numAccounts {
+		t.Errorf("expected %d got: %d", numAccounts, rows)
+	}
+
+	// Mess with half the rows.
+	affectedRows, err := sqlDB.Exec(t,
+		`UPDATE data.bank SET id = -1 * id WHERE id > $1`, numAccounts/2,
+	).RowsAffected()
+	if err != nil {
+		t.Fatal(err)
+	} else if affectedRows != numAccounts/2 {
+		t.Fatalf("expected to update %d rows, got %d", numAccounts/2, affectedRows)
+	}
+
+	beforeInc := timeutil.Now()
+	sqlDB.Exec(t, `BACKUP data.bank TO $1 INCREMENTAL FROM $2`, inc, full)
+
+	sqlDB.QueryRow(t, `SELECT * FROM [SHOW BACKUP $1] WHERE "table" = 'bank'`, inc).Scan(
+		&unused, &unused, &start, &end, &dataSize, &rows,
+	)
+	if start == nil {
+		t.Errorf("expected start time on inc backup, got %v", *start)
+	}
+	if !(*end).After(beforeInc) {
+		t.Errorf("expected now (%s) to be in (%s, %s)", beforeInc, start, end)
+	}
+	if dataSize <= 0 {
+		t.Errorf("expected dataSize to be >0 got : %d", dataSize)
+	}
+	// We added affectedRows and removed affectedRows, so there should be 2*
+	// affectedRows in the backup.
+	if expected := affectedRows * 2; rows != uint64(expected) {
+		t.Errorf("expected %d got: %d", expected, rows)
+	}
+}

--- a/pkg/cmd/docgen/diagrams.go
+++ b/pkg/cmd/docgen/diagrams.go
@@ -344,7 +344,7 @@ var specs = []stmtSpec{
 	{
 		name:   "alter_column",
 		stmt:   "alter_onetable_stmt",
-		inline: []string{"alter_table_cmds", "alter_table_cmd", "opt_column", "alter_column_default", "opt_set_data", "opt_alter_column_collate", "opt_alter_column_using"},
+		inline: []string{"alter_table_cmds", "alter_table_cmd", "opt_column", "alter_column_default", "opt_set_data", "opt_collate", "opt_alter_column_using"},
 		regreplace: map[string]string{
 			regList: "",
 		},
@@ -369,7 +369,7 @@ var specs = []stmtSpec{
 	{
 		name:   "alter_table",
 		stmt:   "alter_onetable_stmt",
-		inline: []string{"alter_table_cmds", "alter_table_cmd", "column_def", "opt_drop_behavior", "alter_column_default", "opt_column", "opt_set_data", "table_constraint", "opt_alter_column_collate", "opt_alter_column_using"},
+		inline: []string{"alter_table_cmds", "alter_table_cmd", "column_def", "opt_drop_behavior", "alter_column_default", "opt_column", "opt_set_data", "table_constraint", "opt_collate", "opt_alter_column_using"},
 		replace: map[string]string{
 			"'VALIDATE' 'CONSTRAINT' name": "",
 			"opt_validate_behavior":        "",

--- a/pkg/sql/parser/parse_test.go
+++ b/pkg/sql/parser/parse_test.go
@@ -958,6 +958,8 @@ func TestParse(t *testing.T) {
 		{`BACKUP TABLE foo TO 'bar'`},
 		{`BACKUP TABLE foo.foo, baz.baz TO 'bar'`},
 		{`SHOW BACKUP 'bar'`},
+		{`SHOW BACKUP RANGES 'bar'`},
+		{`SHOW BACKUP FILES 'bar'`},
 		{`BACKUP TABLE foo TO 'bar' AS OF SYSTEM TIME '1' INCREMENTAL FROM 'baz'`},
 		{`BACKUP TABLE foo TO $1 INCREMENTAL FROM 'bar', $2, 'baz'`},
 		{`BACKUP DATABASE foo TO 'bar'`},

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -475,7 +475,8 @@ func newNameFromStr(s string) *tree.Name {
 %token <str> EXPERIMENTAL_AUDIT
 %token <str> EXPLAIN EXPORT EXTRACT EXTRACT_DURATION
 
-%token <str> FALSE FAMILY FETCH FETCHVAL FETCHTEXT FETCHVAL_PATH FETCHTEXT_PATH FILTER
+%token <str> FALSE FAMILY FETCH FETCHVAL FETCHTEXT FETCHVAL_PATH FETCHTEXT_PATH
+%token <str> FILES FILTER
 %token <str> FIRST FLOAT FLOAT4 FLOAT8 FLOORDIV FOLLOWING FOR FORCE_INDEX FOREIGN FROM FULL
 
 %token <str> GIN GRANT GRANTS GREATEST GROUP GROUPING
@@ -511,7 +512,7 @@ func newNameFromStr(s string) *tree.Name {
 
 %token <str> QUERIES QUERY
 
-%token <str> RANGE READ REAL RECURSIVE REF REFERENCES
+%token <str> RANGE RANGES READ REAL RECURSIVE REF REFERENCES
 %token <str> REGCLASS REGPROC REGPROCEDURE REGNAMESPACE REGTYPE
 %token <str> REMOVE_PATH RENAME REPEATABLE
 %token <str> RELEASE RESET RESTORE RESTRICT RESUME RETURNING REVOKE RIGHT
@@ -2839,12 +2840,29 @@ show_histogram_stmt:
 
 // %Help: SHOW BACKUP - list backup contents
 // %Category: CCL
-// %Text: SHOW BACKUP <location>
+// %Text: SHOW BACKUP [FILES|RANGES] <location>
 // %SeeAlso: WEBDOCS/show-backup.html
 show_backup_stmt:
   SHOW BACKUP string_or_placeholder
   {
-    $$.val = &tree.ShowBackup{Path: $3.expr()}
+    $$.val = &tree.ShowBackup{
+      Details: tree.BackupDefaultDetails,
+      Path:    $3.expr(),
+    }
+  }
+| SHOW BACKUP RANGES string_or_placeholder
+  {
+    $$.val = &tree.ShowBackup{
+      Details: tree.BackupRangeDetails,
+      Path:    $4.expr(),
+    }
+  }
+| SHOW BACKUP FILES string_or_placeholder
+  {
+    $$.val = &tree.ShowBackup{
+      Details: tree.BackupFileDetails,
+      Path:    $4.expr(),
+    }
   }
 | SHOW BACKUP error // SHOW HELP: SHOW BACKUP
 
@@ -7921,6 +7939,7 @@ unreserved_keyword:
 | EXPERIMENTAL_REPLICA
 | EXPLAIN
 | EXPORT
+| FILES
 | FILTER
 | FIRST
 | FLOAT4
@@ -7997,6 +8016,7 @@ unreserved_keyword:
 | QUERIES
 | QUERY
 | RANGE
+| RANGES
 | READ
 | RECURSIVE
 | REF

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -734,8 +734,6 @@ func newNameFromStr(s string) *tree.Name {
 %type <tree.AlterIndexCmd> alter_index_cmd
 %type <tree.AlterIndexCmds> alter_index_cmds
 
-%type <empty> opt_collate_clause
-
 %type <tree.DropBehavior> opt_drop_behavior
 %type <tree.DropBehavior> opt_interleave_drop_behavior
 
@@ -753,7 +751,8 @@ func newNameFromStr(s string) *tree.Name {
 
 %type <tree.Operator> subquery_op
 %type <*tree.UnresolvedName> func_name
-%type <empty> opt_collate
+%type <str> opt_collate
+%type <empty> opt_collate_unimpl
 
 %type <str> database_name index_name opt_index_name column_name insert_column_item statistics_name window_name
 %type <str> family_name opt_family_name table_alias_name constraint_name target_name zone_name partition_name collation_name
@@ -938,7 +937,6 @@ func newNameFromStr(s string) *tree.Name {
 
 %type <str> relocate_kw ranges_kw
 
-%type <str> opt_alter_column_collate
 %type <tree.Expr> opt_alter_column_using
 
 // Precedence: lowest to highest
@@ -1404,7 +1402,7 @@ alter_table_cmd:
   //     [SET DATA] TYPE <typename>
   //     [ COLLATE collation ]
   //     [ USING <expression> ]
-| ALTER opt_column column_name opt_set_data TYPE typename opt_alter_column_collate opt_alter_column_using
+| ALTER opt_column column_name opt_set_data TYPE typename opt_collate opt_alter_column_using
   {
     $$.val = &tree.AlterTableAlterColumnType{
       ColumnKeyword: $2.bool(),
@@ -1502,12 +1500,6 @@ alter_column_default:
     $$.val = nil
   }
 
-// The opt_collate and opt_collate_clause rules are currently used to
-// block on various issues.
-opt_alter_column_collate:
-  COLLATE collation_name { $$ = $2 }
-| /* EMPTY */ { $$ = "" }
-
 opt_alter_column_using:
   USING a_expr { $$ = $2 }
 | /* EMPTY */ {}
@@ -1536,10 +1528,6 @@ opt_validate_behavior:
   {
     $$.val = tree.ValidationDefault
   }
-
-opt_collate_clause:
-  COLLATE collation_name { return unimplementedWithIssue(sqllex, 9851) }
-| /* EMPTY */ {}
 
 // %Help: BACKUP - back up data to external storage
 // %Category: CCL
@@ -4248,14 +4236,18 @@ index_params:
 // expressions in parens. For backwards-compatibility reasons, we allow an
 // expression that's just a function call to be written without parens.
 index_elem:
-  column_name opt_collate opt_asc_desc
+  column_name opt_collate_unimpl opt_asc_desc
   {
     $$.val = tree.IndexElem{Column: tree.Name($1), Direction: $3.dir()}
   }
-| func_expr_windowless opt_collate opt_asc_desc { return unimplemented(sqllex, "index_elem func expr (computed indexes)") }
-| '(' a_expr ')' opt_collate opt_asc_desc { return unimplemented(sqllex, "index_elem a_expr (computed indexes)") }
+| func_expr_windowless opt_collate_unimpl opt_asc_desc { return unimplemented(sqllex, "index_elem func expr (computed indexes)") }
+| '(' a_expr ')' opt_collate_unimpl opt_asc_desc { return unimplemented(sqllex, "index_elem a_expr (computed indexes)") }
 
 opt_collate:
+  COLLATE collation_name { $$ = $2 }
+| /* EMPTY */ { $$ = "" }
+
+opt_collate_unimpl:
   COLLATE collation_name { return unimplementedWithIssue(sqllex, 16619) }
 | /* EMPTY */ {}
 

--- a/pkg/sql/sem/tree/show.go
+++ b/pkg/sql/sem/tree/show.go
@@ -49,14 +49,33 @@ func (node *ShowClusterSetting) Format(ctx *FmtCtx) {
 	ctx.WriteString(node.Name)
 }
 
+// BackupDetails represents the type of details to display for a SHOW BACKUP
+// statement.
+type BackupDetails int
+
+const (
+	// BackupDefaultDetails identifies a bare SHOW BACKUP statement.
+	BackupDefaultDetails BackupDetails = iota
+	// BackupRangeDetails identifies a SHOW BACKUP RANGES statement.
+	BackupRangeDetails
+	// BackupFileDetails identifies a SHOW BACKUP FILES statement.
+	BackupFileDetails
+)
+
 // ShowBackup represents a SHOW BACKUP statement.
 type ShowBackup struct {
-	Path Expr
+	Path    Expr
+	Details BackupDetails
 }
 
 // Format implements the NodeFormatter interface.
 func (node *ShowBackup) Format(ctx *FmtCtx) {
 	ctx.WriteString("SHOW BACKUP ")
+	if node.Details == BackupRangeDetails {
+		ctx.WriteString("RANGES ")
+	} else if node.Details == BackupFileDetails {
+		ctx.WriteString("FILES ")
+	}
 	ctx.FormatNode(node.Path)
 }
 


### PR DESCRIPTION
This makes debugging a broken backup substantially easier.

Release note (enterprise change): Introduce SHOW BACKUP RANGES and SHOW
BACKUP FILES, which show details about the ranges and files,
respectively, which comprise a backup.