### PR TITLE
importccl: make spans overlap during IMPORT with transform

### DIFF
--- a/pkg/ccl/importccl/import_stmt_test.go
+++ b/pkg/ccl/importccl/import_stmt_test.go
@@ -656,6 +656,15 @@ func TestImportCSVStmt(t *testing.T) {
 					t.Fatal("expected > 1 SST files")
 				}
 			}
+
+			// Verify spans don't have trailing '/0'.
+			ranges := sqlDB.QueryStr(t, `SHOW testing_ranges FROM TABLE t`)
+			for _, r := range ranges {
+				const end = `/0`
+				if strings.HasSuffix(r[0], end) || strings.HasSuffix(r[1], end) {
+					t.Errorf("bad span: %s - %s", r[0], r[1])
+				}
+			}
 		})
 	}
 

--- a/pkg/ccl/importccl/sst_writer_proc.go
+++ b/pkg/ccl/importccl/sst_writer_proc.go
@@ -167,12 +167,12 @@ func (sp *sstWriter) Run(ctx context.Context, wg *sync.WaitGroup) {
 					if chunk > 0 {
 						name = fmt.Sprintf("%d-%s", chunk, name)
 					}
+					end := span.End
+					if sst.more {
+						end = sst.span.EndKey
+					}
 
 					if sp.spec.Destination == "" {
-						end := span.End
-						if sst.more {
-							end = sst.span.EndKey
-						}
 						if err := sp.db.AdminSplit(ctx, end, end); err != nil {
 							return err
 						}
@@ -231,7 +231,7 @@ func (sp *sstWriter) Run(ctx context.Context, wg *sync.WaitGroup) {
 						),
 						sqlbase.DatumToEncDatum(
 							sqlbase.ColumnType{SemanticType: sqlbase.ColumnType_BYTES},
-							tree.NewDBytes(tree.DBytes(sst.span.EndKey)),
+							tree.NewDBytes(tree.DBytes(end)),
 						),
 					}
 					cs, err := sp.out.EmitRow(ctx, row)


### PR DESCRIPTION
Force the backup descriptor spans to overlap correctly. This prevents
various extra ranges from being created during RESTORE of data created
with IMPORT with transform. The IMPORT commands will need to be re-run
to generate correct spans in the descriptors.

Fixes #26375

Release note: None