### PR TITLE
workload/bank: improve splits UX

### DIFF
--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -102,7 +102,7 @@ func backupRestoreTestSetupWithParams(
 	if _, err := workload.Setup(ctx, sqlDB.DB, bankData, insertBatchSize, concurrency); err != nil {
 		t.Fatalf("%+v", err)
 	}
-	if err := bank.Split(sqlDB.DB, bankData); err != nil {
+	if err := workload.Split(ctx, sqlDB.DB, bankData.Tables()[0], 1 /* concurrency */); err != nil {
 		// This occasionally flakes, so ignore errors.
 		t.Logf("failed to split: %+v", err)
 	}

--- a/pkg/ccl/importccl/exportcsv_test.go
+++ b/pkg/ccl/importccl/exportcsv_test.go
@@ -50,7 +50,7 @@ func setupExportableBank(t *testing.T, nodes, rows int) (*sqlutils.SQLRunner, st
 	}
 	last := uint32(v.ValueInt())
 	config.TestingSetZoneConfig(last+1, config.ZoneConfig{RangeMaxBytes: 5000})
-	if err := bank.Split(db.DB, wk); err != nil {
+	if err := workload.Split(ctx, db.DB, wk.Tables()[0], 1 /* concurrency */); err != nil {
 		t.Fatal(err)
 	}
 	db.Exec(t, "ALTER TABLE bank SCATTER")

--- a/pkg/workload/bank/bank_test.go
+++ b/pkg/workload/bank/bank_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/workload"
 )
 
 func TestBank(t *testing.T) {
@@ -54,7 +55,7 @@ func TestBank(t *testing.T) {
 			bankTable := bank.Tables()[0]
 			sqlDB.Exec(t, fmt.Sprintf(`CREATE TABLE %s %s`, bankTable.Name, bankTable.Schema))
 
-			if err := Split(sqlDB.DB, bank); err != nil {
+			if err := workload.Split(ctx, sqlDB.DB, bankTable, 1 /* concurrency */); err != nil {
 				t.Fatalf("%+v", err)
 			}
 


### PR DESCRIPTION
Previously, bank would silently ignore any value of --splits greater
than --rows. Now this is checked in a validate hook and errors.

Also remove a duplicate implementation of workload.Splits in the bank
package.

Release note: None

Closes #26456.