### PR TITLE
storage: Disable campaign-on-wake when receiving raft messages

### DIFF
--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -716,6 +716,10 @@ func (c *cluster) Start(ctx context.Context, opts ...option) {
 	if encrypt && !argExists(args, "--encrypt") {
 		args = append(args, "--encrypt")
 	}
+	if local {
+		// This avoids annoying firewall prompts on macos
+		args = append(args, "--args", "--host=127.0.0.1")
+	}
 	if err := execCmd(ctx, c.l, args...); err != nil {
 		c.t.Fatal(err)
 	}

--- a/pkg/cmd/roachtest/election.go
+++ b/pkg/cmd/roachtest/election.go
@@ -1,0 +1,73 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License. See the AUTHORS file
+// for names of contributors.
+
+package main
+
+import (
+	"context"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+)
+
+func registerElectionAfterRestart(r *registry) {
+	r.Add(testSpec{
+		Name:   "election-after-restart",
+		Nodes:  nodes(3),
+		Stable: false, // Introduced 2018-06-06
+		Run: func(ctx context.Context, t *test, c *cluster) {
+			t.Status("starting up")
+			c.Put(ctx, cockroach, "./cockroach")
+			c.Start(ctx)
+
+			t.Status("creating table and splits")
+			c.Run(ctx, c.Node(1), `./cockroach sql --insecure -e "
+        CREATE TABLE kv (k INT PRIMARY KEY, v INT);
+        ALTER TABLE kv SPLIT AT SELECT generate_series(0, 10000, 100)"`)
+
+			start := timeutil.Now()
+			c.Run(ctx, c.Node(1), `./cockroach sql --insecure -e "
+        SELECT * FROM kv"`)
+			duration := timeutil.Since(start)
+			c.l.printf("pre-restart, query took %s\n", duration)
+
+			t.Status("restarting")
+			c.Stop(ctx)
+			c.Start(ctx)
+
+			// Each of the 100 ranges in this table must elect a leader for
+			// this query to complete. In naive raft, each of these
+			// elections would require waiting for a 3-second timeout, one
+			// at a time. This test verifies that our mechanisms to speed
+			// this up are working (we trigger elections eagerly, but not so
+			// eagerly that multiple elections conflict with each other).
+			start = timeutil.Now()
+			c.Run(ctx, c.Node(1), `./cockroach sql --insecure -e "
+        SELECT * FROM kv"`)
+			duration = timeutil.Since(start)
+			c.l.printf("post-restart, query took %s\n", duration)
+			if expected := 15 * time.Second; duration > expected {
+				// In the happy case, this query runs in around 250ms. Prior
+				// to the introduction of this test, a bug caused most
+				// elections to fail and the query would take over 100
+				// seconds. There are still issues that can cause a few
+				// elections to fail (the biggest one as I write this is
+				// #26448), so we must use a generous timeout here. We may be
+				// able to tighten the bounds as we make more improvements.
+				t.Fatalf("expected query to succeed in less than %s, took %s", expected, duration)
+			}
+		},
+	})
+}

--- a/pkg/cmd/roachtest/registry.go
+++ b/pkg/cmd/roachtest/registry.go
@@ -30,6 +30,7 @@ func registerTests(r *registry) {
 	registerDecommission(r)
 	registerDiskUsage(r)
 	registerDrop(r)
+	registerElectionAfterRestart(r)
 	registerHotSpotSplits(r)
 	registerImportTPCC(r)
 	registerImportTPCH(r)

--- a/pkg/storage/replica.go
+++ b/pkg/storage/replica.go
@@ -525,7 +525,7 @@ var _ KeyRange = &Replica{}
 //
 // Requires that both Replica.mu and Replica.raftMu are held.
 func (r *Replica) withRaftGroupLocked(
-	f func(r *raft.RawNode) (unquiesceAndWakeLeader bool, _ error),
+	mayCampaignOnWake bool, f func(r *raft.RawNode) (unquiesceAndWakeLeader bool, _ error),
 ) error {
 	if r.mu.destroyStatus.RemovedOrCorrupt() {
 		// Silently ignore all operations on destroyed replicas. We can't return an
@@ -554,7 +554,9 @@ func (r *Replica) withRaftGroupLocked(
 		}
 		r.mu.internalRaftGroup = raftGroup
 
-		r.maybeCampaignOnWakeLocked(ctx)
+		if mayCampaignOnWake {
+			r.maybeCampaignOnWakeLocked(ctx)
+		}
 	}
 
 	unquiesce, err := f(r.mu.internalRaftGroup)
@@ -568,13 +570,21 @@ func (r *Replica) withRaftGroupLocked(
 // Raft group. It acquires and releases the Replica lock, so r.mu must not be
 // held (or acquired by the supplied function).
 //
+// If mayCampaignOnWake is true, the replica may initiate a raft
+// election if it was previously in a dormant state. Most callers
+// should set this to true, because the prevote feature minimizes the
+// disruption from unnecessary elections. The exception is that we
+// should not initiate an election while handling incoming raft
+// messages (which may include MsgVotes from an election in progress,
+// and this election would be disrupted if we started our own).
+//
 // Requires that Replica.raftMu is held.
 func (r *Replica) withRaftGroup(
-	f func(r *raft.RawNode) (unquiesceAndWakeLeader bool, _ error),
+	mayCampaignOnWake bool, f func(r *raft.RawNode) (unquiesceAndWakeLeader bool, _ error),
 ) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	return r.withRaftGroupLocked(f)
+	return r.withRaftGroupLocked(mayCampaignOnWake, f)
 }
 
 func shouldCampaignOnWake(
@@ -1825,7 +1835,7 @@ func (r *Replica) maybeInitializeRaftGroup(ctx context.Context) {
 	defer r.raftMu.Unlock()
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	if err := r.withRaftGroupLocked(func(raftGroup *raft.RawNode) (bool, error) {
+	if err := r.withRaftGroupLocked(true, func(raftGroup *raft.RawNode) (bool, error) {
 		return true, nil
 	}); err != nil {
 		log.VErrEventf(ctx, 1, "unable to initialize raft group: %s", err)
@@ -3340,7 +3350,7 @@ func defaultSubmitProposalLocked(r *Replica, p *ProposalData) error {
 			return err
 		}
 
-		return r.withRaftGroupLocked(func(raftGroup *raft.RawNode) (bool, error) {
+		return r.withRaftGroupLocked(true, func(raftGroup *raft.RawNode) (bool, error) {
 			// We're proposing a command here so there is no need to wake the
 			// leader if we were quiesced.
 			r.unquiesceLocked()
@@ -3353,7 +3363,7 @@ func defaultSubmitProposalLocked(r *Replica, p *ProposalData) error {
 		})
 	}
 
-	return r.withRaftGroupLocked(func(raftGroup *raft.RawNode) (bool, error) {
+	return r.withRaftGroupLocked(true, func(raftGroup *raft.RawNode) (bool, error) {
 		encode := encodeRaftCommandV1
 		if p.command.ReplicatedEvalResult.AddSSTable != nil {
 			if p.command.ReplicatedEvalResult.AddSSTable.Data == nil {
@@ -3438,7 +3448,10 @@ func (r *Replica) unquiesceAndWakeLeaderLocked() {
 // message. Before doing so, it assures that the replica is unquiesced and ready
 // to handle the request.
 func (r *Replica) stepRaftGroup(req *RaftMessageRequest) error {
-	return r.withRaftGroup(func(raftGroup *raft.RawNode) (bool, error) {
+	// We're processing an incoming raft message (from a batch that may
+	// include MsgVotes), so don't campaign if we wake up our raft
+	// group.
+	return r.withRaftGroup(false, func(raftGroup *raft.RawNode) (bool, error) {
 		// We're processing a message from another replica which means that the
 		// other replica is not quiesced, so we don't need to wake the leader.
 		r.unquiesceLocked()
@@ -3518,7 +3531,7 @@ func (r *Replica) handleRaftReadyRaftMuLocked(
 	//     handleRaftReadyRaftMuLocked, the next write will get blocked.
 	defer r.updateProposalQuotaRaftMuLocked(ctx, lastLeaderID)
 
-	err := r.withRaftGroupLocked(func(raftGroup *raft.RawNode) (bool, error) {
+	err := r.withRaftGroupLocked(true, func(raftGroup *raft.RawNode) (bool, error) {
 		if hasReady = raftGroup.HasReady(); hasReady {
 			rd = raftGroup.Ready()
 		}
@@ -3827,7 +3840,7 @@ func (r *Replica) handleRaftReadyRaftMuLocked(
 			}
 			r.mu.Unlock()
 
-			if err := r.withRaftGroup(func(raftGroup *raft.RawNode) (bool, error) {
+			if err := r.withRaftGroup(true, func(raftGroup *raft.RawNode) (bool, error) {
 				raftGroup.ApplyConfChange(cc)
 				return true, nil
 			}); err != nil {
@@ -3848,7 +3861,7 @@ func (r *Replica) handleRaftReadyRaftMuLocked(
 	// has changed. Or do we need more locking to guarantee that replica
 	// ID cannot change during handleRaftReady?
 	const expl = "during advance"
-	if err := r.withRaftGroup(func(raftGroup *raft.RawNode) (bool, error) {
+	if err := r.withRaftGroup(true, func(raftGroup *raft.RawNode) (bool, error) {
 		raftGroup.Advance(rd)
 		return true, nil
 	}); err != nil {
@@ -4440,7 +4453,7 @@ func (r *Replica) sendRaftMessage(ctx context.Context, msg raftpb.Message) {
 		FromReplica: fromReplica,
 		Message:     msg,
 	}) {
-		if err := r.withRaftGroup(func(raftGroup *raft.RawNode) (bool, error) {
+		if err := r.withRaftGroup(true, func(raftGroup *raft.RawNode) (bool, error) {
 			r.mu.droppedMessages++
 			raftGroup.ReportUnreachable(msg.To)
 			return true, nil
@@ -4485,7 +4498,7 @@ func (r *Replica) reportSnapshotStatus(ctx context.Context, to roachpb.ReplicaID
 		snapStatus = raft.SnapshotFailure
 	}
 
-	if err := r.withRaftGroup(func(raftGroup *raft.RawNode) (bool, error) {
+	if err := r.withRaftGroup(true, func(raftGroup *raft.RawNode) (bool, error) {
 		raftGroup.ReportSnapshot(uint64(to), snapStatus)
 		return true, nil
 	}); err != nil {

--- a/pkg/storage/replica_proposal.go
+++ b/pkg/storage/replica_proposal.go
@@ -437,7 +437,7 @@ func addSSTablePreApply(
 //
 // TODO(tschottdorf): there's also maybeTransferRaftLeader. Only one should exist.
 func (r *Replica) maybeTransferRaftLeadership(ctx context.Context, target roachpb.ReplicaID) {
-	err := r.withRaftGroup(func(raftGroup *raft.RawNode) (bool, error) {
+	err := r.withRaftGroup(true, func(raftGroup *raft.RawNode) (bool, error) {
 		// Only the raft leader can attempt a leadership transfer.
 		if status := raftGroup.Status(); status.RaftState == raft.StateLeader {
 			// Only attempt this if the target has all the log entries. Although

--- a/pkg/storage/store_test.go
+++ b/pkg/storage/store_test.go
@@ -688,7 +688,7 @@ func TestStoreRemoveReplicaDestroy(t *testing.T) {
 
 	// Verify that removal of a replica marks it as destroyed so that future raft
 	// commands on the Replica will silently be dropped.
-	if err := repl1.withRaftGroup(func(r *raft.RawNode) (bool, error) {
+	if err := repl1.withRaftGroup(true, func(r *raft.RawNode) (bool, error) {
 		return true, errors.Errorf("unexpectedly created a raft group")
 	}); err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
When the incoming message is a MsgVote (which is likely the case for
the first message received by a quiesced follower), immediate
campaigning will cause the election to fail.

This is similar to reverting commit 44e3977, but only disables
campaigning in one location.

Fixes #26391

Release note: None