### PR TITLE
sql: Add implementation for ON CONFLICT DO NOTHING with no specified

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/upsert
+++ b/pkg/sql/logictest/testdata/logic_test/upsert
@@ -1,5 +1,91 @@
 # LogicTest: default opt parallel-stmts distsql distsql-opt distsql-metadata
 
+subtest strict
+
+statement ok
+CREATE TABLE ex(
+  foo INT PRIMARY KEY,
+  bar INT UNIQUE,
+  baz INT
+)
+
+statement count 1
+INSERT INTO ex(foo,bar,baz) VALUES (1,1,1)
+
+statement count 0
+INSERT INTO ex(foo,bar,baz) VALUES (1,1,1) ON CONFLICT DO NOTHING
+
+statement count 0
+INSERT INTO ex(foo,bar,baz) VALUES (2,1,1) ON CONFLICT DO NOTHING
+
+statement count 1
+INSERT INTO ex(foo,bar,baz) VALUES (3,2,2), (3,1,2), (4,2,1) ON CONFLICT DO NOTHING
+
+query III colnames
+SELECT * from ex ORDER BY foo
+----
+foo bar baz
+1   1   1
+3   2   2
+
+query III colnames
+INSERT INTO ex(foo,bar,baz) VALUES (4,3,1), (5,2,1) ON CONFLICT DO NOTHING RETURNING *
+----
+foo  bar  baz
+4    3    1
+
+statement ok
+CREATE TABLE ex2(
+  a INT PRIMARY KEY,
+  b INT UNIQUE,
+  c INT,
+  d INT,
+  e INT,
+  UNIQUE (c,d)
+)
+
+statement count 1
+INSERT INTO ex2(a,b,c,d,e) VALUES (0,0,0,0,0)
+
+statement count 0
+INSERT INTO ex2(a,b,c,d,e) VALUES (1,0,1,1,0), (2,4,0,0,5) ON CONFLICT DO NOTHING
+
+statement count 3
+INSERT INTO ex2(a,b,c,d,e) VALUES (3,4,5,6,7), (8,9,10,11,12), (13,14,15,16,17) ON CONFLICT DO NOTHING
+
+statement count 0
+INSERT INTO ex2(a,b,c,d,e) VALUES (3,4,5,6,7), (8,9,10,11,12) ON CONFLICT DO NOTHING
+
+statement ok
+CREATE TABLE no_unique(
+  a INT,
+  b INT
+)
+
+statement count 1
+INSERT INTO no_unique(a,b) VALUES (1,2)
+
+statement count 1
+INSERT INTO no_unique(a,b) VALUES (1,2) ON CONFLICT DO NOTHING
+
+statement count 3
+INSERT INTO no_unique(a,b) VALUES (1,2), (1,3), (3,2) ON CONFLICT DO NOTHING
+
+query II colnames
+SELECT * from no_unique ORDER BY a, b
+----
+a  b
+1  2
+1  2
+1  2
+1  3
+3  2
+
+statement count 3
+INSERT INTO no_unique(a,b) VALUES (1,2), (1,2), (1,2) ON CONFLICT DO NOTHING
+
+subtest notstrict
+
 statement ok
 CREATE TABLE kv (
   k INT PRIMARY KEY,
@@ -53,9 +139,9 @@ UPSERT INTO kv VALUES (11, 10), (11, 12) RETURNING k, v
 11 12
 
 statement count 1
-INSERT INTO kv VALUES (13, 13), (7, 8) ON CONFLICT (k) DO NOTHING
+INSERT INTO kv VALUES (13, 13), (7, 8) ON CONFLICT (k) DO NOTHING RETURNING *
 
-statement error there is no unique or exclusion constraint matching the ON CONFLICT specification
+statement count 0
 INSERT INTO kv VALUES (13, 13), (7, 8) ON CONFLICT DO NOTHING
 
 statement count 2

--- a/pkg/sql/tablewriter_upsert_fast.go
+++ b/pkg/sql/tablewriter_upsert_fast.go
@@ -33,8 +33,7 @@ import (
 // is the same model as the other `tableFoo`s, which are more simple
 // than upsert.
 type fastTableUpserter struct {
-	tableWriterBase
-	ri sqlbase.RowInserter
+	tableUpserterBase
 }
 
 // init is part of the tableWriter interface.
@@ -69,23 +68,6 @@ func (tu *fastTableUpserter) atBatchEnd(_ context.Context, _ bool) error { retur
 // flushAndStartNewBatch is part of the extendedTableWriter interface.
 func (tu *fastTableUpserter) flushAndStartNewBatch(ctx context.Context) error {
 	return tu.tableWriterBase.flushAndStartNewBatch(ctx, tu.tableDesc())
-}
-
-// finalize is part of the tableWriter interface.
-func (tu *fastTableUpserter) finalize(
-	ctx context.Context, autoCommit autoCommitOpt, traceKV bool,
-) (*sqlbase.RowContainer, error) {
-	return nil, tu.tableWriterBase.finalize(ctx, autoCommit, tu.tableDesc())
-}
-
-// fkSpanCollector is part of the tableWriter interface.
-func (tu *fastTableUpserter) fkSpanCollector() sqlbase.FkSpanCollector {
-	return tu.ri.Fks
-}
-
-// tableDesc is part of the tableWriter interface.
-func (tu *fastTableUpserter) tableDesc() *sqlbase.TableDescriptor {
-	return tu.ri.Helper.TableDesc
 }
 
 // close is part of the tableWriter interface.

--- a/pkg/sql/tablewriter_upsert_strict.go
+++ b/pkg/sql/tablewriter_upsert_strict.go
@@ -1,0 +1,191 @@
+// Copyright 2018 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package sql
+
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/internal/client"
+	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlbase"
+)
+
+// strictTableUpserter implements the conflict-intolerant path for an upsert. See
+// tableUpserter for the general case.
+//
+// strictTableUpserter is used for insert statements with the clause ON CONFLICT DO NOTHING
+// without any specified columns. In this case, whenever a conflict is detected
+// for an insert row on any of the indexes with unique key constraints, the insert is not done.
+type strictTableUpserter struct {
+	tableUpserterBase
+
+	// internal state
+	conflictIndexes []sqlbase.IndexDescriptor
+}
+
+func (tu *strictTableUpserter) init(txn *client.Txn, evalCtx *tree.EvalContext) error {
+	tu.tableWriterBase.init(txn)
+
+	err := tu.tableUpserterBase.init(txn, evalCtx)
+	if err != nil {
+		return err
+	}
+
+	return tu.getUniqueIndexes()
+}
+
+// atBatchEnd is part of the extendedTableWriter interface.
+func (tu *strictTableUpserter) atBatchEnd(ctx context.Context, traceKV bool) error {
+	tableDesc := tu.tableDesc()
+
+	conflictingRows, err := tu.getConflictingRows(ctx, false)
+	if err != nil {
+		return err
+	}
+	for i := 0; i < tu.insertRows.Len(); i++ {
+		insertRow := tu.insertRows.At(i)
+
+		// Has this insert row been marked as conflicting? If so, skip.
+		if _, ok := conflictingRows[i]; ok {
+			continue
+		}
+
+		if err := tu.ri.InsertRow(ctx, tu.b, insertRow, true, sqlbase.CheckFKs, traceKV); err != nil {
+			return err
+		}
+
+		// for ... RETURNING clause
+		resultRow := tu.makeResultFromInsertRow(insertRow, tableDesc.Columns)
+		tu.resultCount++
+
+		if tu.collectRows {
+			_, err = tu.rowsUpserted.AddRow(ctx, resultRow)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	if tu.collectRows {
+		// If we have populate rowsUpserted, the consumer
+		// will want to know exactly how many rows there in there.
+		// Use that as final resultCount. This overrides any
+		// other value computed in the main loop above.
+		tu.resultCount = tu.rowsUpserted.Len()
+	}
+
+	return nil
+}
+
+// Get all unique indexes and store them in tu.ConflictIndexes.
+func (tu *strictTableUpserter) getUniqueIndexes() (err error) {
+	tableDesc := tu.tableDesc()
+	indexes := tableDesc.Indexes
+	for _, index := range indexes {
+		if index.Unique {
+			tu.conflictIndexes = append(tu.conflictIndexes, index)
+		}
+	}
+	return nil
+}
+
+// getConflictingRows returns all of the the rows that are in conflict.
+//
+// The return value is a set of all the rows (by their place in tu.InsertRows)
+// that are in conflict with either an existing row in the table or another insert row.
+func (tu *strictTableUpserter) getConflictingRows(
+	ctx context.Context, _ bool,
+) (conflictingRows map[int]struct{}, err error) {
+	tableDesc := tu.tableDesc()
+
+	conflictingRows = make(map[int]struct{})
+
+	seenKeys := make(map[string]struct{})
+
+	b := tu.txn.NewBatch()
+
+	for i := 0; i < tu.insertRows.Len(); i++ {
+		row := tu.insertRows.At(i)
+
+		// Get the primary key of the insert row.
+		upsertRowPK, _, err := sqlbase.EncodeIndexKey(
+			tableDesc, &tableDesc.PrimaryIndex, tu.ri.InsertColIDtoRowIndex, row, tu.indexKeyPrefix)
+		if err != nil {
+			return nil, err
+		}
+
+		upsertRowPK = keys.MakeFamilyKey(upsertRowPK, 0)
+
+		// If the primary key of the insert row has already been seen among the insert rows,
+		// mark this row as conflicting.
+		if _, ok := seenKeys[string(upsertRowPK)]; ok {
+			conflictingRows[i] = struct{}{}
+		}
+
+		b.Get(roachpb.Key(upsertRowPK))
+		seenKeys[string(upsertRowPK)] = struct{}{}
+
+		// Otherwise, check the primary key against the table.
+
+		// For each secondary index that has a unique constraint, do something similar:
+		// check if the secondary index key has already been seen among the insert rows,
+		// and if not, mark the key to be checked against the table.
+		for _, idx := range tu.conflictIndexes {
+			entries, err := sqlbase.EncodeSecondaryIndex(
+				tableDesc, &idx, tu.ri.InsertColIDtoRowIndex, row)
+			if err != nil {
+				return nil, err
+			}
+
+			for _, entry := range entries {
+				if _, ok := seenKeys[string(entry.Key)]; ok {
+					conflictingRows[i] = struct{}{}
+				}
+				b.Get(entry.Key)
+				seenKeys[string(entry.Key)] = struct{}{}
+			}
+		}
+	}
+
+	// Run a transaction to see if any of the rows conflict with any existing rows in the table or with other insert rows.
+	if err := tu.txn.Run(ctx, b); err != nil {
+		return nil, err
+	}
+
+	numIndexes := 1 + len(tu.conflictIndexes)
+	for i, result := range b.Results {
+		// There are (1 + len(tu.conflictIndexes)) * len(tu.InsertRows) results.
+		// All the results that correspond to a particular insertRow are next to each other.
+		// By this logic, the division computes the insertRow that is being queried for.
+		insertRowIndex := i / numIndexes
+
+		for _, row := range result.Rows {
+			// If any of the result values are not nil, then that means that the insert row is in conflict and should be marked as such.
+			if row.Value != nil {
+				conflictingRows[insertRowIndex] = struct{}{}
+			}
+		}
+	}
+
+	return conflictingRows, nil
+}
+
+// walkExprs is part of the tableWriter interface.
+func (tu *strictTableUpserter) walkExprs(walk func(desc string, index int, expr tree.TypedExpr)) {}
+
+var _ batchedTableWriter = (*strictTableUpserter)(nil)
+var _ tableWriter = (*strictTableUpserter)(nil)

--- a/pkg/sql/upsert.go
+++ b/pkg/sql/upsert.go
@@ -96,14 +96,23 @@ func (p *planner) newUpsertNode(
 	}()
 
 	if n.OnConflict.DoNothing {
-		// TODO(dan): Postgres allows ON CONFLICT DO NOTHING without specifying a
-		// conflict index, which means do nothing on any conflict. Support this if
-		// someone needs it.
-		un.run.tw = &tableUpserter{
-			ri:            ri,
-			conflictIndex: *conflictIndex,
-			collectRows:   needRows,
-			alloc:         &p.alloc,
+		if conflictIndex == nil {
+			un.run.tw = &strictTableUpserter{
+				tableUpserterBase: tableUpserterBase{
+					ri:          ri,
+					collectRows: needRows,
+					alloc:       &p.alloc,
+				},
+			}
+		} else {
+			un.run.tw = &tableUpserter{
+				conflictIndex: *conflictIndex,
+				tableUpserterBase: tableUpserterBase{
+					ri:          ri,
+					collectRows: needRows,
+					alloc:       &p.alloc,
+				},
+			}
 		}
 	} else {
 		// We're going to work on allocating an upsertHelper here, even
@@ -179,18 +188,22 @@ func (p *planner) newUpsertNode(
 			// We then use the super-simple, super-fast writer. There's not
 			// much else to prepare.
 			un.run.tw = &fastTableUpserter{
-				ri: ri,
+				tableUpserterBase: tableUpserterBase{
+					ri: ri,
+				},
 			}
 		} else {
 			// General/slow path.
 			un.run.tw = &tableUpserter{
-				ri:            ri,
-				alloc:         &p.alloc,
+				tableUpserterBase: tableUpserterBase{
+					ri:          ri,
+					alloc:       &p.alloc,
+					collectRows: needRows,
+				},
 				anyComputed:   len(computeExprs) >= 0,
 				fkTables:      fkTables,
 				updateCols:    updateCols,
 				conflictIndex: *conflictIndex,
-				collectRows:   needRows,
 				evaler:        helper,
 			}
 		}
@@ -745,6 +758,10 @@ func upsertExprsAndIndex(
 			updateExprs = append(updateExprs, &tree.UpdateExpr{Names: tree.NameList{n}, Expr: expr})
 		}
 		return updateExprs, conflictIndex, nil
+	}
+
+	if onConflict.DoNothing && len(onConflict.Columns) == 0 {
+		return onConflict.Exprs, nil, nil
 	}
 
 	// General case: INSERT with an ON CONFLICT clause.


### PR DESCRIPTION
columns.

* Added a new upserter, strictTableUpserter, that checks for conflicts
on all indexes and skips a row's insertion if any conflicts exist.

Release note (sql change): Support was added for the syntax INSERT ...
ON CONFLICT DO NOTHING without any specified columns; on a conflict with
any UNIQUE column the insert will not continue.

closes #6639 