### PR TITLE
libroach: Obey read-only option in FileRegistry and DataKeyManager.

### DIFF
--- a/c-deps/libroach/ccl/encrypted_env_test.cc
+++ b/c-deps/libroach/ccl/encrypted_env_test.cc
@@ -24,7 +24,8 @@ TEST(EncryptedEnv, ConcurrentAccess) {
   auto key_manager = new MemKeyManager(MakeAES128Key(env.get()));
   auto stream = new CTRCipherStreamCreator(key_manager, enginepb::Data);
 
-  auto file_registry = std::unique_ptr<FileRegistry>(new FileRegistry(env.get(), "/"));
+  auto file_registry =
+      std::unique_ptr<FileRegistry>(new FileRegistry(env.get(), "/", false /* read-only */));
   EXPECT_OK(file_registry->Load());
 
   std::unique_ptr<rocksdb::Env> encrypted_env(
@@ -138,7 +139,8 @@ TEST(EncryptedEnv, FileOps) {
   auto tmpdir = std::unique_ptr<TempDirHandler>(new TempDirHandler());
   ASSERT_TRUE(tmpdir->Init());
 
-  auto file_registry = std::unique_ptr<FileRegistry>(new FileRegistry(env, tmpdir->Path("")));
+  auto file_registry =
+      std::unique_ptr<FileRegistry>(new FileRegistry(env, tmpdir->Path(""), false /* read-only */));
   EXPECT_OK(file_registry->Load());
 
   std::unique_ptr<rocksdb::Env> encrypted_env(

--- a/c-deps/libroach/ccl/key_manager.h
+++ b/c-deps/libroach/ccl/key_manager.h
@@ -111,7 +111,10 @@ class DataKeyManager : public KeyManager {
  public:
   // `env` is owned by the caller and should be an encrypted Env.
   // `db_dir` is the rocksdb directory.
-  explicit DataKeyManager(rocksdb::Env* env, const std::string& db_dir, int64_t rotation_period);
+  // If read-only is true, the DataKeyManager can be used to lookup keys but cannot
+  // change any keys (eg: SetActiveStoreKey will fail).
+  explicit DataKeyManager(rocksdb::Env* env, const std::string& db_dir, int64_t rotation_period,
+                          bool read_only);
 
   virtual ~DataKeyManager();
 
@@ -137,6 +140,7 @@ class DataKeyManager : public KeyManager {
   rocksdb::Env* env_;
   std::string registry_path_;
   int64_t rotation_period_;
+  bool read_only_;
 
   // The registry is read-only and can only be swapped for another one, it cannot be mutated in
   // place. mu_ must be held for any registry access.

--- a/c-deps/libroach/ccl/testutils.cc
+++ b/c-deps/libroach/ccl/testutils.cc
@@ -8,9 +8,20 @@
 
 #include "testutils.h"
 #include <gtest/gtest.h>
+#include "ccl/baseccl/encryption_options.pb.h"
 #include "crypto_utils.h"
 
 namespace testutils {
+
+std::string MakePlaintextExtraOptions() {
+  cockroach::ccl::baseccl::EncryptionOptions opts;
+  opts.mutable_key_files()->set_current_key("plain");
+  opts.mutable_key_files()->set_old_key("plain");
+
+  std::string ret;
+  opts.SerializeToString(&ret);
+  return ret;
+}
 
 enginepbccl::SecretKey* MakeAES128Key(rocksdb::Env* env) {
   int64_t now;

--- a/c-deps/libroach/ccl/testutils.h
+++ b/c-deps/libroach/ccl/testutils.h
@@ -17,6 +17,9 @@ namespace enginepbccl = cockroach::ccl::storageccl::engineccl::enginepbccl;
 
 namespace testutils {
 
+// Generate the DBOptions.extra_options string for plaintext keys.
+std::string MakePlaintextExtraOptions();
+
 // MakeAES<size>Key creates a SecretKeyObject with a key of the specified size.
 // It needs an Env for the current time.
 enginepbccl::SecretKey* MakeAES128Key(rocksdb::Env* env);

--- a/c-deps/libroach/db.cc
+++ b/c-deps/libroach/db.cc
@@ -78,10 +78,10 @@ ScopedStats::~ScopedStats() {
   }
 }
 
-void BatchSSTablesForCompaction(const std::vector<rocksdb::SstFileMetaData> &sst,
+void BatchSSTablesForCompaction(const std::vector<rocksdb::SstFileMetaData>& sst,
                                 rocksdb::Slice start_key, rocksdb::Slice end_key,
-                                uint64_t target_size, std::vector<rocksdb::Range> *ranges) {
-  int prev = -1; // index of the last compacted sst
+                                uint64_t target_size, std::vector<rocksdb::Range>* ranges) {
+  int prev = -1;  // index of the last compacted sst
   uint64_t size = 0;
   for (int i = 0; i < sst.size(); ++i) {
     size += sst[i].size;
@@ -179,7 +179,8 @@ DBStatus DBOpen(DBEngine** db, DBSlice dir, DBOptions db_opts) {
   }
 
   // Create the file registry. It uses the base_env to access the registry file.
-  auto file_registry = std::unique_ptr<FileRegistry>(new FileRegistry(env_ctx->base_env, db_dir));
+  auto file_registry =
+      std::unique_ptr<FileRegistry>(new FileRegistry(env_ctx->base_env, db_dir, db_opts.read_only));
 
   if (db_opts.use_file_registry) {
     // We're using the file registry.
@@ -382,10 +383,8 @@ DBStatus DBCompactRange(DBEngine* db, DBSlice start, DBSlice end, bool force_bot
   BatchSSTablesForCompaction(sst, start_key, end_key, target_size, &ranges);
 
   for (auto r : ranges) {
-    rocksdb::Status status = db->rep->CompactRange(
-        options,
-        r.start.empty() ? nullptr : &r.start,
-        r.limit.empty() ? nullptr : &r.limit);
+    rocksdb::Status status = db->rep->CompactRange(options, r.start.empty() ? nullptr : &r.start,
+                                                   r.limit.empty() ? nullptr : &r.limit);
     if (!status.ok()) {
       return ToDBStatus(status);
     }

--- a/c-deps/libroach/file_registry.h
+++ b/c-deps/libroach/file_registry.h
@@ -34,9 +34,10 @@ static const std::string kFileRegistryFilename = "COCKROACHDB_REGISTRY";
 // All paths given to FileRegistry should be absolute paths. It converts
 // paths within `db_dir` to relative paths internally.
 // Paths outside `db_dir` remain absolute.
+// If read-only is set, the registry can be used for a read-only DB, but cannot be modified.
 class FileRegistry {
  public:
-  FileRegistry(rocksdb::Env* env, const std::string& db_dir);
+  FileRegistry(rocksdb::Env* env, const std::string& db_dir, bool read_only);
   ~FileRegistry() {}
 
   // Returns OK if the registry file does not exist.
@@ -77,6 +78,7 @@ class FileRegistry {
  private:
   rocksdb::Env* env_;
   std::string db_dir_;
+  bool read_only_;
   std::string registry_path_;
 
   // Write 'reg' to the registry file, and swap with registry_ if successful. mu_ is held.

--- a/c-deps/libroach/file_registry_test.cc
+++ b/c-deps/libroach/file_registry_test.cc
@@ -13,9 +13,9 @@
 // permissions and limitations under the License.
 
 #include <vector>
-#include "../fmt.h"
-#include "../testutils.h"
 #include "file_registry.h"
+#include "fmt.h"
+#include "testutils.h"
 
 using namespace cockroach;
 
@@ -44,8 +44,50 @@ TEST(FileRegistry, TransformPath) {
   for (auto t : test_cases) {
     SCOPED_TRACE(fmt::StringPrintf("Testing #%d", test_num++));
 
-    FileRegistry reg(nullptr, t.db_dir);
+    FileRegistry reg(nullptr, t.db_dir, false /* read-only */);
     auto out = reg.TransformPath(t.input);
     EXPECT_EQ(t.output, out);
   }
+}
+
+TEST(FileRegistry, FileOps) {
+  std::unique_ptr<rocksdb::Env> env(rocksdb::NewMemEnv(rocksdb::Env::Default()));
+
+  FileRegistry rw_reg(env.get(), "/", false /* read-only */);
+  ASSERT_OK(rw_reg.CheckNoRegistryFile());
+  ASSERT_OK(rw_reg.Load());
+
+  EXPECT_EQ(nullptr, rw_reg.GetFileEntry("/foo"));
+  auto entry = std::unique_ptr<enginepb::FileEntry>(new enginepb::FileEntry());
+  EXPECT_OK(rw_reg.SetFileEntry("/foo", std::move(entry)));
+  EXPECT_NE(nullptr, rw_reg.GetFileEntry("/foo"));
+
+  EXPECT_OK(rw_reg.MaybeLinkEntry("/foo", "/bar"));
+  EXPECT_NE(nullptr, rw_reg.GetFileEntry("/foo"));
+  EXPECT_NE(nullptr, rw_reg.GetFileEntry("/bar"));
+
+  EXPECT_OK(rw_reg.MaybeRenameEntry("/bar", "/baz"));
+  EXPECT_NE(nullptr, rw_reg.GetFileEntry("/foo"));
+  EXPECT_EQ(nullptr, rw_reg.GetFileEntry("/bar"));
+  EXPECT_NE(nullptr, rw_reg.GetFileEntry("/baz"));
+
+  EXPECT_OK(rw_reg.MaybeDeleteEntry("/baz"));
+  EXPECT_NE(nullptr, rw_reg.GetFileEntry("/foo"));
+  EXPECT_EQ(nullptr, rw_reg.GetFileEntry("/bar"));
+  EXPECT_EQ(nullptr, rw_reg.GetFileEntry("/baz"));
+
+  // Now try with a read-only registry.
+  FileRegistry ro_reg(env.get(), "/", true /* read-only */);
+  // We have a registry file.
+  EXPECT_ERR(ro_reg.CheckNoRegistryFile(), "registry file .* exists");
+  ASSERT_OK(ro_reg.Load());
+
+  EXPECT_NE(nullptr, ro_reg.GetFileEntry("/foo"));
+  EXPECT_EQ(nullptr, ro_reg.GetFileEntry("/bar"));
+  EXPECT_EQ(nullptr, ro_reg.GetFileEntry("/baz"));
+
+  // All mutable operations fail.
+  EXPECT_ERR(ro_reg.MaybeLinkEntry("/foo", "/bar"), "file registry is read-only .*");
+  EXPECT_ERR(ro_reg.MaybeRenameEntry("/foo", "/baz"), "file registry is read-only .*");
+  EXPECT_ERR(ro_reg.MaybeDeleteEntry("/foo"), "file registry is read-only .*");
 }


### PR DESCRIPTION
These two classes handle the File and Key registries persisted to local
disk. When the read-only option is set on the DB, it's important we not
modify on-disk state or we risk corrupting data for a running node.

Release Note: none