### PR TITLE
lint: Fix a file descriptor leak

### DIFF
--- a/pkg/testutils/lint/lint_test.go
+++ b/pkg/testutils/lint/lint_test.go
@@ -870,6 +870,7 @@ func TestLint(t *testing.T) {
 				t.Error(err)
 				return
 			}
+			defer file.Close()
 			firstLine, err := bufio.NewReader(file).ReadString('\n')
 			if err != nil {
 				t.Errorf("reading first line of %s: %s", filename, err)


### PR DESCRIPTION
This leak is enough to cause `make lintshort` fail when run under the
default file descriptor limit on macos (256).

Release note: None