### PR TITLE
libroach: format C++ code.

### DIFF
--- a/c-deps/libroach/batch.cc
+++ b/c-deps/libroach/batch.cc
@@ -521,9 +521,7 @@ DBStatus DBBatch::EnvOpenFile(DBSlice path, rocksdb::WritableFile** file) {
   return FmtStatus("unsupported");
 }
 
-DBStatus DBBatch::EnvReadFile(DBSlice path, DBSlice* contents) {
-  return FmtStatus("unsupported");
-}
+DBStatus DBBatch::EnvReadFile(DBSlice path, DBSlice* contents) { return FmtStatus("unsupported"); }
 
 DBStatus DBBatch::EnvCloseFile(rocksdb::WritableFile* file) { return FmtStatus("unsupported"); }
 
@@ -533,13 +531,9 @@ DBStatus DBBatch::EnvAppendFile(rocksdb::WritableFile* file, DBSlice contents) {
   return FmtStatus("unsupported");
 }
 
-DBStatus DBBatch::EnvDeleteFile(DBSlice path) {
-  return FmtStatus("unsupported");
-}
+DBStatus DBBatch::EnvDeleteFile(DBSlice path) { return FmtStatus("unsupported"); }
 
-DBStatus DBBatch::EnvDeleteDirAndFiles(DBSlice dir) {
-  return FmtStatus("unsupported");
-}
+DBStatus DBBatch::EnvDeleteDirAndFiles(DBSlice dir) { return FmtStatus("unsupported"); }
 
 DBWriteOnlyBatch::DBWriteOnlyBatch(DBEngine* db) : DBEngine(db->rep, db->iters), updates(0) {}
 
@@ -630,13 +624,9 @@ DBStatus DBWriteOnlyBatch::EnvAppendFile(rocksdb::WritableFile* file, DBSlice co
   return FmtStatus("unsupported");
 }
 
-DBStatus DBWriteOnlyBatch::EnvDeleteFile(DBSlice path) {
-  return FmtStatus("unsupported");
-}
+DBStatus DBWriteOnlyBatch::EnvDeleteFile(DBSlice path) { return FmtStatus("unsupported"); }
 
-DBStatus DBWriteOnlyBatch::EnvDeleteDirAndFiles(DBSlice dir) {
-  return FmtStatus("unsupported");
-}
+DBStatus DBWriteOnlyBatch::EnvDeleteDirAndFiles(DBSlice dir) { return FmtStatus("unsupported"); }
 
 rocksdb::WriteBatch::Handler* GetDBBatchInserter(::rocksdb::WriteBatchBase* batch) {
   return new DBBatchInserter(batch);

--- a/c-deps/libroach/db.cc
+++ b/c-deps/libroach/db.cc
@@ -475,9 +475,7 @@ DBStatus DBEnvAppendFile(DBEngine* db, DBWritableFile file, DBSlice contents) {
 
 DBStatus DBEnvDeleteFile(DBEngine* db, DBSlice path) { return db->EnvDeleteFile(path); }
 
-DBStatus DBEnvDeleteDirAndFiles(DBEngine* db, DBSlice dir) {
-  return db->EnvDeleteDirAndFiles(dir);
-}
+DBStatus DBEnvDeleteDirAndFiles(DBEngine* db, DBSlice dir) { return db->EnvDeleteDirAndFiles(dir); }
 
 DBIterator* DBNewIter(DBEngine* db, bool prefix, bool stats) {
   rocksdb::ReadOptions opts;

--- a/c-deps/libroach/engine.cc
+++ b/c-deps/libroach/engine.cc
@@ -259,7 +259,7 @@ DBStatus DBImpl::EnvOpenFile(DBSlice path, rocksdb::WritableFile** file) {
 // EnvReadFile reads the content of the given filename.
 DBStatus DBImpl::EnvReadFile(DBSlice path, DBSlice* contents) {
   rocksdb::Status status;
-  std::string data;  
+  std::string data;
 
   status = ReadFileToString(this->rep->GetEnv(), ToString(path), &data);
   if (!status.ok()) {

--- a/c-deps/libroach/merge_test.cc
+++ b/c-deps/libroach/merge_test.cc
@@ -12,17 +12,15 @@
 // implied.  See the License for the specific language governing
 // permissions and limitations under the License.
 
-#include <vector>
-#include <utility>
 #include <gtest/gtest.h>
-#include "protos/roachpb/internal.pb.h"
+#include <utility>
+#include <vector>
 #include "merge.h"
+#include "protos/roachpb/internal.pb.h"
 
 using namespace cockroach;
 
-void testAddColumns(
-  roachpb::InternalTimeSeriesData* data, int offset, int value
-) {
+void testAddColumns(roachpb::InternalTimeSeriesData* data, int offset, int value) {
   data->add_offset(offset);
   data->add_count(value + 1);
   data->add_last(value + 2);
@@ -33,16 +31,12 @@ void testAddColumns(
   data->add_variance(value + 7);
 }
 
-void testAddColumnsNoRollup(
-  roachpb::InternalTimeSeriesData* data, int offset, int value
-) {
+void testAddColumnsNoRollup(roachpb::InternalTimeSeriesData* data, int offset, int value) {
   data->add_offset(offset);
   data->add_last(value);
 }
 
-void testAddRows(
-  roachpb::InternalTimeSeriesData* data, int offset, int value
-) {
+void testAddRows(roachpb::InternalTimeSeriesData* data, int offset, int value) {
   auto row = data->add_samples();
   row->set_offset(offset);
   row->set_sum(value);
@@ -57,166 +51,157 @@ TEST(TimeSeriesMerge, SortAndDeduplicate) {
     rowData originalRows;
     int firstUnsorted;
     rowData expectedRows;
-    TestCase(rowData orig, int first, rowData expected): 
-      originalRows(orig), firstUnsorted(first), expectedRows(expected) {};
+    TestCase(rowData orig, int first, rowData expected)
+        : originalRows(orig), firstUnsorted(first), expectedRows(expected){};
   };
 
   std::vector<TestCase> testCases = {
-    // Basic sorting and deduplication.
-    TestCase(
-      {
-        {10, 999},
-        {8, 1},
-        {9, 2},
-        {10, 0},
-        {4, 0},
-        {10, 3},
-      },
-      0,
-      {
-        {4, 0},
-        {8, 1},
-        {9, 2},
-        {10, 3},
-      }
-    ),
-    // Partial sorting and deduplication. The first index is intentionally out
-    // of order in order strongly demonstrate that only a suffix of the array
-    // is being sorted, anything before firstUnsorted is not modified.
-    TestCase(
-      {
-        {10, 999},
-        {8, 1},
-        {9, 2},
-        {10, 0},
-        {4, 0},
-        {10, 3},
-      },
-      3,
-      {
-        {10, 999},
-        {8, 1},
-        {9, 2},
-        {4, 0},
-        {10, 3},
-      }
-    ),
-    // Sort only last sample (common case).
-    TestCase(
-      {
-        {1, 1},
-        {2, 2},
-        {3, 3},
-        {4, 4},
-        {5, 5},
-      },
-      4,
-      {
-        {1, 1},
-        {2, 2},
-        {3, 3},
-        {4, 4},
-        {5, 5},
-      }
-    ),
-    // Already sorted.
-    TestCase(
-      {
-        {1, 1},
-        {2, 2},
-        {3, 3},
-        {4, 4},
-        {5, 5},
-      },
-      0,
-      {
-        {1, 1},
-        {2, 2},
-        {3, 3},
-        {4, 4},
-        {5, 5},
-      }
-    ),
-    // Single element shifted forward.
-    TestCase(
-      {
-        {5, 5},
-        {1, 1},
-        {2, 2},
-        {3, 3},
-        {4, 4},
-      },
-      0,
-      {
-        {1, 1},
-        {2, 2},
-        {3, 3},
-        {4, 4},
-        {5, 5},
-      }
-    ),
-    // Reversed.
-    TestCase(
-      {
-        {5, 5},
-        {4, 4},
-        {3, 3},
-        {2, 2},
-        {1, 1},
-      },
-      0,
-      {
-        {1, 1},
-        {2, 2},
-        {3, 3},
-        {4, 4},
-        {5, 5},
-      }
-    ),
-    // Element shift with duplicate.
-    TestCase(
-      {
-        {5, 999},
-        {1, 1},
-        {2, 2},
-        {5, 5},
-        {3, 3},
-        {4, 4},
-      },
-      0,
-      {
-        {1, 1},
-        {2, 2},
-        {3, 3},
-        {4, 4},
-        {5, 5},
-      }
-    ),
-    // Shift with firstUnsorted.
-    TestCase(
-      {
-        {99, 999},
-        {88, 888},
-        {77, 777},
-        {5, 5},
-        {1, 1},
-        {2, 2},
-        {3, 3},
-        {4, 4},
-      },
-      3,
-      {
-        {99, 999},
-        {88, 888},
-        {77, 777},
-        {1, 1},
-        {2, 2},
-        {3, 3},
-        {4, 4},
-        {5, 5},
-      }
-    )
-  };
+      // Basic sorting and deduplication.
+      TestCase(
+          {
+              {10, 999},
+              {8, 1},
+              {9, 2},
+              {10, 0},
+              {4, 0},
+              {10, 3},
+          },
+          0,
+          {
+              {4, 0},
+              {8, 1},
+              {9, 2},
+              {10, 3},
+          }),
+      // Partial sorting and deduplication. The first index is intentionally out
+      // of order in order strongly demonstrate that only a suffix of the array
+      // is being sorted, anything before firstUnsorted is not modified.
+      TestCase(
+          {
+              {10, 999},
+              {8, 1},
+              {9, 2},
+              {10, 0},
+              {4, 0},
+              {10, 3},
+          },
+          3,
+          {
+              {10, 999},
+              {8, 1},
+              {9, 2},
+              {4, 0},
+              {10, 3},
+          }),
+      // Sort only last sample (common case).
+      TestCase(
+          {
+              {1, 1},
+              {2, 2},
+              {3, 3},
+              {4, 4},
+              {5, 5},
+          },
+          4,
+          {
+              {1, 1},
+              {2, 2},
+              {3, 3},
+              {4, 4},
+              {5, 5},
+          }),
+      // Already sorted.
+      TestCase(
+          {
+              {1, 1},
+              {2, 2},
+              {3, 3},
+              {4, 4},
+              {5, 5},
+          },
+          0,
+          {
+              {1, 1},
+              {2, 2},
+              {3, 3},
+              {4, 4},
+              {5, 5},
+          }),
+      // Single element shifted forward.
+      TestCase(
+          {
+              {5, 5},
+              {1, 1},
+              {2, 2},
+              {3, 3},
+              {4, 4},
+          },
+          0,
+          {
+              {1, 1},
+              {2, 2},
+              {3, 3},
+              {4, 4},
+              {5, 5},
+          }),
+      // Reversed.
+      TestCase(
+          {
+              {5, 5},
+              {4, 4},
+              {3, 3},
+              {2, 2},
+              {1, 1},
+          },
+          0,
+          {
+              {1, 1},
+              {2, 2},
+              {3, 3},
+              {4, 4},
+              {5, 5},
+          }),
+      // Element shift with duplicate.
+      TestCase(
+          {
+              {5, 999},
+              {1, 1},
+              {2, 2},
+              {5, 5},
+              {3, 3},
+              {4, 4},
+          },
+          0,
+          {
+              {1, 1},
+              {2, 2},
+              {3, 3},
+              {4, 4},
+              {5, 5},
+          }),
+      // Shift with firstUnsorted.
+      TestCase(
+          {
+              {99, 999},
+              {88, 888},
+              {77, 777},
+              {5, 5},
+              {1, 1},
+              {2, 2},
+              {3, 3},
+              {4, 4},
+          },
+          3,
+          {
+              {99, 999},
+              {88, 888},
+              {77, 777},
+              {1, 1},
+              {2, 2},
+              {3, 3},
+              {4, 4},
+              {5, 5},
+          })};
   for (auto testCase : testCases) {
     roachpb::InternalTimeSeriesData orig;
     for (auto row : testCase.originalRows) {

--- a/c-deps/libroach/snapshot.cc
+++ b/c-deps/libroach/snapshot.cc
@@ -75,12 +75,8 @@ DBStatus DBSnapshot::EnvAppendFile(rocksdb::WritableFile* file, DBSlice contents
   return FmtStatus("unsupported");
 }
 
-DBStatus DBSnapshot::EnvDeleteFile(DBSlice path) {
-  return FmtStatus("unsupported");
-}
+DBStatus DBSnapshot::EnvDeleteFile(DBSlice path) { return FmtStatus("unsupported"); }
 
-DBStatus DBSnapshot::EnvDeleteDirAndFiles(DBSlice dir) {
-  return FmtStatus("unsupported");
-}
+DBStatus DBSnapshot::EnvDeleteDirAndFiles(DBSlice dir) { return FmtStatus("unsupported"); }
 
 }  // namespace cockroach


### PR DESCRIPTION
This is still not enforced due to clang format versionning (they change
often with format behavior modifications).

I should have done this sooner, some of my previous PRs were polluted with re-formatting.

Release note: None